### PR TITLE
fix: harden runtime loading and startup scans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ review.md
 
 # Test directories and files
 tests/
+!tests/
+!tests/*.test.ts
 test-files/
 test-lsp-files/
 test-filetime/

--- a/README.md
+++ b/README.md
@@ -289,7 +289,9 @@ See [AST_GREP_RULES.md](AST_GREP_RULES.md) for full guide.
 
 ### At Session Start
 
-When pi starts a new session, pi-lens performs initialization scans to establish baselines and surface existing technical debt:
+When pi starts a new session, pi-lens performs initialization scans to establish baselines and surface existing technical debt.
+
+**Startup safety:** eager cache warmups only run inside a detected project root and are skipped for generic directories (for example `$HOME`) or very large trees. In those cases, pi-lens stays responsive and falls back to on-demand analysis.
 
 **Initialization sequence:**
 1. **Reset session state** — Clear metrics and complexity baselines
@@ -299,7 +301,7 @@ When pi starts a new session, pi-lens performs initialization scans to establish
 5. **Load architect rules** — If `architect.yml` or `.architect.yml` present
 6. **Detect test runner** — Jest, Vitest, Pytest, etc.
 
-**Cached scans** (with 5-min TTL):
+**Cached scans** (with 5-min TTL, only when startup safety allows eager warmup):
 | Scan | Tool | Cached | Purpose |
 |------|------|--------|---------|
 | **TODOs** | Internal | No | Tech debt markers |

--- a/clients/architect-client.ts
+++ b/clients/architect-client.ts
@@ -12,6 +12,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { minimatch } from "minimatch";
+import { resolvePackagePath } from "./package-root.js";
 
 // --- Types ---
 
@@ -88,22 +89,11 @@ export class ArchitectClient {
 
 		// Fall back to built-in default
 		try {
-			// Try multiple possible locations for the default config
 			const possibleDefaultPaths = [
 				path.join(projectRoot, "default-architect.yaml"),
-				path.join(projectRoot, "..", "default-architect.yaml"),
-				path.join(process.cwd(), "default-architect.yaml"),
+				path.join(projectRoot, ".pi-lens", "default-architect.yaml"),
+				resolvePackagePath(import.meta.url, "default-architect.yaml"),
 			];
-
-			// Handle both CommonJS and ESM environments
-			if (typeof __dirname !== "undefined") {
-				possibleDefaultPaths.push(
-					path.join(__dirname, "..", "default-architect.yaml"),
-				);
-				possibleDefaultPaths.push(
-					path.join(__dirname, "..", "..", "default-architect.yaml"),
-				);
-			}
 
 			for (const defaultPath of possibleDefaultPaths) {
 				try {

--- a/clients/ast-grep-client.ts
+++ b/clients/ast-grep-client.ts
@@ -20,6 +20,7 @@ import type {
 	SgMatch,
 } from "./ast-grep-types.js";
 import { SgRunner } from "./sg-runner.js";
+import { resolvePackagePath } from "./package-root.js";
 
 const _getExtensionDir = () => {
 	if (typeof __dirname !== "undefined") {
@@ -38,7 +39,12 @@ export class AstGrepClient {
 	private runner: SgRunner;
 
 	constructor(ruleDir?: string, verbose = false) {
-		this.ruleDir = ruleDir || path.join(process.cwd(), "rules");
+		const projectRuleDir = path.join(process.cwd(), "rules");
+		this.ruleDir =
+			ruleDir ||
+			(fs.existsSync(projectRuleDir)
+				? projectRuleDir
+				: resolvePackagePath(import.meta.url, "rules"));
 		this.log = verbose
 			? (msg: string) => console.error(`[ast-grep] ${msg}`)
 			: () => {};

--- a/clients/dispatch/runners/ast-grep-napi.ts
+++ b/clients/dispatch/runners/ast-grep-napi.ts
@@ -9,6 +9,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { resolvePackagePath } from "../../package-root.js";
 import type {
 	Diagnostic,
 	DispatchContext,
@@ -355,10 +356,12 @@ const astGrepNapiRunner: RunnerDefinition = {
 
 		const diagnostics: Diagnostic[] = [];
 
-		const ruleDirs = [
-			path.join(process.cwd(), "rules/ast-grep-rules/rules"),
-			path.join(process.cwd(), "rules/ast-grep-rules"),
-		];
+		const ruleDirs = [...new Set([
+			path.join(process.cwd(), "rules", "ast-grep-rules", "rules"),
+			path.join(process.cwd(), "rules", "ast-grep-rules"),
+			resolvePackagePath(import.meta.url, "rules", "ast-grep-rules", "rules"),
+			resolvePackagePath(import.meta.url, "rules", "ast-grep-rules"),
+		])];
 
 		for (const ruleDir of ruleDirs) {
 			let rules: YamlRule[];

--- a/clients/dispatch/runners/ast-grep.ts
+++ b/clients/dispatch/runners/ast-grep.ts
@@ -9,6 +9,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { resolvePackagePath } from "../../package-root.js";
 import { safeSpawnAsync } from "../../safe-spawn.js";
 import type {
 	Diagnostic,
@@ -94,15 +95,15 @@ const astGrepRunner: RunnerDefinition = {
 
 function findAstGrepConfig(cwd: string): string | undefined {
 	const candidates = [
-		"rules/ast-grep-rules/.sgconfig.yml",
-		".sgconfig.yml",
-		"sgconfig.yml",
+		path.join(cwd, "rules", "ast-grep-rules", ".sgconfig.yml"),
+		path.join(cwd, ".sgconfig.yml"),
+		path.join(cwd, "sgconfig.yml"),
+		resolvePackagePath(import.meta.url, "rules", "ast-grep-rules", ".sgconfig.yml"),
 	];
 
 	for (const candidate of candidates) {
-		const fullPath = `${cwd}/${candidate}`;
-		if (fs.existsSync(fullPath)) {
-			return fullPath;
+		if (fs.existsSync(candidate)) {
+			return candidate;
 		}
 	}
 
@@ -119,8 +120,8 @@ function parseAstGrepOutput(
 	// Try to parse as JSON
 	// Determine rule directory for fix: extraction
 	const ruleDir = _configPath
-		? path.dirname(_configPath).replace("/.sgconfig.yml", "/rules")
-		: path.join(process.cwd(), "rules", "ast-grep-rules", "rules");
+		? path.join(path.dirname(_configPath), "rules")
+		: resolvePackagePath(import.meta.url, "rules", "ast-grep-rules", "rules");
 
 	try {
 		const parsed = JSON.parse(raw);

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -9,6 +9,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { resolvePackagePath } from "../../../package-root.js";
 import { safeSpawn } from "../../../safe-spawn.js";
 
 // =============================================================================
@@ -119,14 +120,13 @@ export function createConfigFinder(
 			return localPath;
 		}
 
-		// Fall back to extension rules
 		const extensionPaths = [
-			`rules/${ruleDirName}/.sgconfig.yml`,
-			`../rules/${ruleDirName}/.sgconfig.yml`,
+			resolvePackagePath(import.meta.url, "rules", ruleDirName, ".sgconfig.yml"),
+			path.resolve(cwd, `rules/${ruleDirName}/.sgconfig.yml`),
+			path.resolve(cwd, `../rules/${ruleDirName}/.sgconfig.yml`),
 		];
 
-		for (const candidate of extensionPaths) {
-			const fullPath = path.resolve(cwd, candidate);
+		for (const fullPath of extensionPaths) {
 			if (fs.existsSync(fullPath)) {
 				return fullPath;
 			}

--- a/clients/package-root.ts
+++ b/clients/package-root.ts
@@ -1,0 +1,39 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRootCache = new Map<string, string>();
+
+/**
+ * Resolve the installed package root for the current module.
+ * Walks upward from the caller until it finds the nearest package.json.
+ */
+export function getPackageRoot(importMetaUrl: string): string {
+	const cached = packageRootCache.get(importMetaUrl);
+	if (cached) return cached;
+
+	let current = path.dirname(fileURLToPath(importMetaUrl));
+	while (true) {
+		if (fs.existsSync(path.join(current, "package.json"))) {
+			packageRootCache.set(importMetaUrl, current);
+			return current;
+		}
+
+		const parent = path.dirname(current);
+		if (parent === current) {
+			packageRootCache.set(importMetaUrl, current);
+			return current;
+		}
+		current = parent;
+	}
+}
+
+/**
+ * Resolve a path relative to the installed package root.
+ */
+export function resolvePackagePath(
+	importMetaUrl: string,
+	...segments: string[]
+): string {
+	return path.join(getPackageRoot(importMetaUrl), ...segments);
+}

--- a/clients/startup-scan.ts
+++ b/clients/startup-scan.ts
@@ -1,0 +1,130 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { EXCLUDED_DIRS } from "./file-utils.js";
+
+export const PROJECT_ROOT_MARKERS = [
+	".git",
+	"package.json",
+	"pyproject.toml",
+	"Cargo.toml",
+	"go.mod",
+	"composer.json",
+];
+
+export const MAX_STARTUP_SOURCE_FILES = 2000;
+const SOURCE_FILE_PATTERN = /\.(ts|tsx|js|jsx|py|go|rs)$/;
+
+export interface StartupScanContext {
+	cwd: string;
+	scanRoot: string;
+	projectRoot: string | null;
+	canWarmCaches: boolean;
+	reason?: "home-dir" | "no-project-root" | "too-many-source-files";
+	sourceFileCount?: number;
+}
+
+export interface StartupScanOptions {
+	homeDir?: string;
+	maxSourceFiles?: number;
+}
+
+export function findNearestProjectRoot(startDir: string): string | null {
+	let current = path.resolve(startDir);
+
+	while (true) {
+		if (
+			PROJECT_ROOT_MARKERS.some((marker) =>
+				fs.existsSync(path.join(current, marker)),
+			)
+		) {
+			return current;
+		}
+
+		const parent = path.dirname(current);
+		if (parent === current) return null;
+		current = parent;
+	}
+}
+
+export function countSourceFilesWithinLimit(dir: string, limit: number): number {
+	let count = 0;
+	const stack = [path.resolve(dir)];
+
+	while (stack.length > 0) {
+		const current = stack.pop();
+		if (!current) continue;
+
+		let entries: fs.Dirent[] = [];
+		try {
+			entries = fs.readdirSync(current, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const entry of entries) {
+			if (entry.isDirectory()) {
+				if (EXCLUDED_DIRS.includes(entry.name)) continue;
+				stack.push(path.join(current, entry.name));
+				continue;
+			}
+
+			if (entry.isFile() && SOURCE_FILE_PATTERN.test(entry.name)) {
+				count += 1;
+				if (count > limit) return count;
+			}
+		}
+	}
+
+	return count;
+}
+
+export function resolveStartupScanContext(
+	cwd: string,
+	options: StartupScanOptions = {},
+): StartupScanContext {
+	const resolvedCwd = path.resolve(cwd);
+	const homeDir = path.resolve(options.homeDir ?? os.homedir());
+	const maxSourceFiles = options.maxSourceFiles ?? MAX_STARTUP_SOURCE_FILES;
+	const projectRoot = findNearestProjectRoot(resolvedCwd);
+
+	if (!projectRoot) {
+		return {
+			cwd: resolvedCwd,
+			scanRoot: resolvedCwd,
+			projectRoot: null,
+			canWarmCaches: false,
+			reason: resolvedCwd === homeDir ? "home-dir" : "no-project-root",
+		};
+	}
+
+	if (path.resolve(projectRoot) === homeDir) {
+		return {
+			cwd: resolvedCwd,
+			scanRoot: projectRoot,
+			projectRoot,
+			canWarmCaches: false,
+			reason: "home-dir",
+		};
+	}
+
+	const sourceFileCount = countSourceFilesWithinLimit(projectRoot, maxSourceFiles);
+	if (sourceFileCount > maxSourceFiles) {
+		return {
+			cwd: resolvedCwd,
+			scanRoot: projectRoot,
+			projectRoot,
+			canWarmCaches: false,
+			reason: "too-many-source-files",
+			sourceFileCount,
+		};
+	}
+
+	return {
+		cwd: resolvedCwd,
+		scanRoot: projectRoot,
+		projectRoot,
+		canWarmCaches: true,
+		sourceFileCount,
+	};
+}

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -18,6 +18,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { EXCLUDED_DIRS } from "./file-utils.js";
+import { resolvePackagePath } from "./package-root.js";
 import {
 	type TreeSitterQuery,
 	TreeSitterQueryLoader,
@@ -113,31 +114,16 @@ export class TreeSitterClient {
 
 	/** Find tree-sitter grammar directory */
 	private findGrammarsDir(): string {
-		// Check for downloaded grammars in web-tree-sitter/grammars first
+		const packageWebTreeSitterGrammars = resolvePackagePath(
+			import.meta.url,
+			"node_modules",
+			"web-tree-sitter",
+			"grammars",
+		);
 		const downloadedGrammars = [
 			path.join(process.cwd(), "node_modules", "web-tree-sitter", "grammars"),
+			packageWebTreeSitterGrammars,
 		];
-
-		// Add __dirname-based paths if __dirname is available (CommonJS)
-		if (typeof __dirname !== "undefined") {
-			downloadedGrammars.push(
-				path.join(
-					__dirname,
-					"..",
-					"..",
-					"node_modules",
-					"web-tree-sitter",
-					"grammars",
-				),
-				path.join(
-					__dirname,
-					"..",
-					"node_modules",
-					"web-tree-sitter",
-					"grammars",
-				),
-			);
-		}
 
 		for (const dir of downloadedGrammars) {
 			if (
@@ -148,31 +134,16 @@ export class TreeSitterClient {
 			}
 		}
 
-		// Fallback to legacy locations
 		const candidates: string[] = [
 			path.join(process.cwd(), "node_modules", "tree-sitter-wasms", "out"),
+			resolvePackagePath(import.meta.url, "node_modules", "tree-sitter-wasms", "out"),
 		];
-
-		if (typeof __dirname !== "undefined") {
-			candidates.push(
-				path.join(
-					__dirname,
-					"..",
-					"..",
-					"node_modules",
-					"tree-sitter-wasms",
-					"out",
-				),
-				path.join(__dirname, "..", "node_modules", "tree-sitter-wasms", "out"),
-			);
-		}
 
 		for (const dir of candidates) {
 			if (fs.existsSync(dir)) return dir;
 		}
 
-		// Default to web-tree-sitter/grammars (may need manual download)
-		return downloadedGrammars[0];
+		return packageWebTreeSitterGrammars;
 	}
 
 	/** Initialize tree-sitter WASM runtime */
@@ -193,9 +164,8 @@ export class TreeSitterClient {
 			// Store Language loader from module (not from Parser)
 			this.LanguageLoader = mod.Language;
 
-			// Log what we're trying to load
-			const wasmPath = path.join(
-				process.cwd(),
+			const wasmPath = resolvePackagePath(
+				import.meta.url,
 				"node_modules",
 				"web-tree-sitter",
 				"tree-sitter.wasm",
@@ -206,9 +176,8 @@ export class TreeSitterClient {
 
 			await ParserClass.init({
 				locateFile: (scriptName: string) => {
-					// Always return the full path to the WASM file
-					const fullPath = path.join(
-						process.cwd(),
+					const fullPath = resolvePackagePath(
+						import.meta.url,
 						"node_modules",
 						"web-tree-sitter",
 						scriptName,

--- a/clients/tree-sitter-query-loader.ts
+++ b/clients/tree-sitter-query-loader.ts
@@ -7,9 +7,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { resolvePackagePath } from "./package-root.js";
 
 export interface TreeSitterQuery {
 	id: string;
@@ -56,38 +54,42 @@ export class TreeSitterQueryLoader {
 	async loadQueries(): Promise<Map<string, TreeSitterQuery[]>> {
 		if (this.loaded) return this.queries;
 
-		const queriesDir = path.join(process.cwd(), "rules", "tree-sitter-queries");
+		const queryDirs = [...new Set([
+			path.join(process.cwd(), "rules", "tree-sitter-queries"),
+			resolvePackagePath(import.meta.url, "rules", "tree-sitter-queries"),
+		])];
 
-		if (!fs.existsSync(queriesDir)) {
-			this.dbg(`Queries directory not found: ${queriesDir}`);
-			return this.queries;
-		}
-
-		// Load queries from each language subdirectory
-		const languageDirs = fs
-			.readdirSync(queriesDir, { withFileTypes: true })
-			.filter((d) => d.isDirectory())
-			.map((d) => d.name);
-
-		for (const lang of languageDirs) {
-			const langDir = path.join(queriesDir, lang);
-			const queryFiles = fs
-				.readdirSync(langDir)
-				.filter((f) => f.endsWith(".yml"));
-
-			const langQueries: TreeSitterQuery[] = [];
-
-			for (const file of queryFiles) {
-				const filePath = path.join(langDir, file);
-				const query = this.parseQueryFile(filePath, lang);
-				if (query) {
-					langQueries.push(query);
-				}
+		for (const queriesDir of queryDirs) {
+			if (!fs.existsSync(queriesDir)) {
+				this.dbg(`Queries directory not found: ${queriesDir}`);
+				continue;
 			}
 
-			if (langQueries.length > 0) {
-				this.queries.set(lang, langQueries);
-				this.dbg(`Loaded ${langQueries.length} queries for ${lang}`);
+			const languageDirs = fs
+				.readdirSync(queriesDir, { withFileTypes: true })
+				.filter((d) => d.isDirectory())
+				.map((d) => d.name);
+
+			for (const lang of languageDirs) {
+				const langDir = path.join(queriesDir, lang);
+				const queryFiles = fs
+					.readdirSync(langDir)
+					.filter((f) => f.endsWith(".yml"));
+
+				const langQueries = this.queries.get(lang) ?? [];
+
+				for (const file of queryFiles) {
+					const filePath = path.join(langDir, file);
+					const query = this.parseQueryFile(filePath, lang);
+					if (query) {
+						langQueries.push(query);
+					}
+				}
+
+				if (langQueries.length > 0) {
+					this.queries.set(lang, langQueries);
+					this.dbg(`Loaded ${langQueries.length} queries for ${lang}`);
+				}
 			}
 		}
 

--- a/index.ts
+++ b/index.ts
@@ -33,7 +33,9 @@ import { runPipeline } from "./clients/pipeline.js";
 import {
 	buildProjectIndex,
 	findSimilarFunctions,
+	isIndexFresh,
 	loadIndex,
+	saveIndex,
 	type ProjectIndex,
 } from "./clients/project-index.js";
 import { RuffClient } from "./clients/ruff-client.js";
@@ -45,6 +47,7 @@ import {
 import { RustClient } from "./clients/rust-client.js";
 import { getSourceFiles } from "./clients/scan-utils.js";
 import { TestRunnerClient } from "./clients/test-runner-client.js";
+import { resolveStartupScanContext } from "./clients/startup-scan.js";
 import { TodoScanner } from "./clients/todo-scanner.js";
 import { TypeCoverageClient } from "./clients/type-coverage-client.js";
 import { TypeScriptClient } from "./clients/typescript-client.js";
@@ -859,6 +862,7 @@ export default function (pi: ExtensionAPI) {
 			metricsClient.reset();
 			complexityBaselines.clear();
 			resetDispatchBaselines();
+			cachedExports.clear();
 			cachedProjectIndex = null;
 
 			// Reset LSP service so the new session starts with fresh diagnostics.
@@ -869,10 +873,10 @@ export default function (pi: ExtensionAPI) {
 				dbg("session_start: LSP service reset");
 			}
 
-			// Log available tools
+			// Log available tools without triggering startup installs.
 			const tools: string[] = [];
 			tools.push("TypeScript LSP"); // Always available
-			if (await biomeClient.ensureAvailable()) tools.push("Biome");
+			if (biomeClient.isAvailable()) tools.push("Biome");
 			if (astGrepClient.isAvailable()) tools.push("ast-grep");
 			if (ruffClient.isAvailable()) tools.push("Ruff");
 			if (knipClient.isAvailable()) tools.push("Knip");
@@ -919,15 +923,22 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			const cwd = ctx.cwd ?? process.cwd();
-			projectRoot = cwd; // Module-level for architect client
+			const startupScan = resolveStartupScanContext(cwd);
+			const scanRoot = startupScan.projectRoot ?? cwd;
+			projectRoot = scanRoot; // Module-level for architect client
 			dbg(`session_start cwd: ${cwd}`);
+			dbg(
+				`session_start scan root: ${scanRoot} (warmCaches=${startupScan.canWarmCaches}${startupScan.reason ? `, reason=${startupScan.reason}` : ""})`,
+			);
 
 			// Load architect rules if present
-			const hasArchitectRules = architectClient.loadConfig(cwd);
+			const hasArchitectRules = architectClient.loadConfig(scanRoot);
 			if (hasArchitectRules) tools.push("Architect rules");
 
 			// Log test runner if detected
-			const detectedRunner = testRunnerClient.detectRunner(cwd);
+			const detectedRunner = startupScan.projectRoot
+				? testRunnerClient.detectRunner(scanRoot)
+				: null;
 			if (detectedRunner) {
 				tools.push(`Test runner (${detectedRunner.runner})`);
 			}
@@ -952,119 +963,130 @@ export default function (pi: ExtensionAPI) {
 			// Add condensed skill guidance to system message
 			parts.push(condensedGuidance);
 
-			// Scan for project-specific rules (.claude/rules, .agents/rules, CLAUDE.md, etc.)
-			projectRulesScan = scanProjectRules(cwd);
-			if (projectRulesScan.hasCustomRules) {
-				const ruleCount = projectRulesScan.rules.length;
-				const sources = [
-					...new Set(projectRulesScan.rules.map((r) => r.source)),
-				];
-				dbg(
-					`session_start: found ${ruleCount} project rule(s) from ${sources.join(", ")}`,
-				);
-				parts.push(
-					`📋 Project rules found: ${ruleCount} file(s) in ${sources.join(", ")}. These apply alongside pi-lens defaults.`,
-				);
-			} else {
-				dbg("session_start: no project rules found");
-			}
-
-			// TODO/FIXME scan — fast, no deps (cached for on-demand reporting)
-			const todoResult = todoScanner.scanDirectory(cwd);
-			dbg(`session_start TODO scan: ${todoResult.items.length} items`);
-			// Note: TODOs not shown at session start — use /lens-booboo to see them
-
-			// Dead code scan — use cache if fresh, auto-install if needed (cached for on-demand reporting)
-			if (await knipClient.ensureAvailable()) {
-				const cached = cacheManager.readCache<
-					ReturnType<KnipClient["analyze"]>
-				>("knip", cwd);
-				if (cached) {
+			if (startupScan.projectRoot) {
+				// Scan for project-specific rules (.claude/rules, .agents/rules, CLAUDE.md, etc.)
+				projectRulesScan = scanProjectRules(scanRoot);
+				if (projectRulesScan.hasCustomRules) {
+					const ruleCount = projectRulesScan.rules.length;
+					const sources = [
+						...new Set(projectRulesScan.rules.map((r) => r.source)),
+					];
 					dbg(
-						`session_start Knip: cache hit (${Math.round((Date.now() - new Date(cached.meta.timestamp).getTime()) / 1000)}s ago)`,
+						`session_start: found ${ruleCount} project rule(s) from ${sources.join(", ")}`,
+					);
+					parts.push(
+						`📋 Project rules found: ${ruleCount} file(s) in ${sources.join(", ")}. These apply alongside pi-lens defaults.`,
 					);
 				} else {
-					const startMs = Date.now();
-					const knipResult = knipClient.analyze(cwd);
-					cacheManager.writeCache("knip", knipResult, cwd, {
-						scanDurationMs: Date.now() - startMs,
-					});
-					dbg(`session_start Knip scan done`);
+					dbg("session_start: no project rules found");
 				}
 			} else {
-				dbg(`session_start Knip: not available`);
-			}
-			// Note: Knip results not shown at session start — use /lens-booboo to see dead code
-
-			// Duplicate code detection — use cache if fresh, auto-install if needed (cached for on-demand reporting)
-			if (await jscpdClient.ensureAvailable()) {
-				const cached = cacheManager.readCache<ReturnType<JscpdClient["scan"]>>(
-					"jscpd",
-					cwd,
-				);
-				if (cached) {
-					dbg(`session_start jscpd: cache hit`);
-					_cachedJscpdClones = cached.data.clones;
-				} else {
-					const startMs = Date.now();
-					const jscpdResult = jscpdClient.scan(cwd);
-					_cachedJscpdClones = jscpdResult.clones;
-					cacheManager.writeCache("jscpd", jscpdResult, cwd, {
-						scanDurationMs: Date.now() - startMs,
-					});
-					dbg(`session_start jscpd scan done`);
-				}
-			} else {
-				dbg(`session_start jscpd: not available`);
-			}
-			// Note: jscpd results not shown at session start — use /lens-booboo to see duplicates
-
-			// Note: type-coverage runs on-demand via /lens-booboo only (not at session_start)
-
-			// Scan for exported functions (cached for duplicate detection on write)
-			if (await astGrepClient.ensureAvailable()) {
-				const exports = await astGrepClient.scanExports(cwd, "typescript");
-				dbg(`session_start exports scan: ${exports.size} functions found`);
-				for (const [name, file] of exports) {
-					cachedExports.set(name, file);
-				}
+				projectRulesScan = { rules: [], hasCustomRules: false };
 			}
 
-			// Build similarity index for pre-write structural duplicate detection.
-			// Uses the same source files as the exports scan. The index is ~50ms
-			// to query but seconds to build, so we do it once at session start.
-			try {
-				const existing = await loadIndex(cwd);
-				if (existing && existing.entries.size > 0) {
-					cachedProjectIndex = existing;
-					dbg(
-						`session_start: loaded project index from disk (${existing.entries.size} entries)`,
-					);
-				} else {
-					const sourceFiles = getSourceFiles(cwd, true);
-					const tsFiles = sourceFiles.filter(
-						(f) => f.endsWith(".ts") || f.endsWith(".tsx"),
-					);
-					if (tsFiles.length > 0 && tsFiles.length <= 500) {
-						cachedProjectIndex = await buildProjectIndex(cwd, tsFiles);
+			if (startupScan.canWarmCaches) {
+				const todoResult = todoScanner.scanDirectory(scanRoot);
+				dbg(`session_start TODO scan: ${todoResult.items.length} items`);
+
+				if (knipClient.isAvailable()) {
+					const cached = cacheManager.readCache<
+						ReturnType<KnipClient["analyze"]>
+					>("knip", scanRoot);
+					if (cached) {
 						dbg(
-							`session_start: built project index (${cachedProjectIndex.entries.size} entries from ${tsFiles.length} files)`,
+							`session_start Knip: cache hit (${Math.round((Date.now() - new Date(cached.meta.timestamp).getTime()) / 1000)}s ago)`,
 						);
 					} else {
-						dbg(
-							`session_start: skipped project index (${tsFiles.length} files — ${tsFiles.length === 0 ? "none" : "too many"})`,
-						);
+						const startMs = Date.now();
+						const knipResult = knipClient.analyze(scanRoot);
+						cacheManager.writeCache("knip", knipResult, scanRoot, {
+							scanDurationMs: Date.now() - startMs,
+						});
+						dbg(`session_start Knip scan done`);
+					}
+				} else {
+					dbg(`session_start Knip: not available`);
+				}
+
+				if (jscpdClient.isAvailable()) {
+					const cached = cacheManager.readCache<ReturnType<JscpdClient["scan"]>>(
+						"jscpd",
+						scanRoot,
+					);
+					if (cached) {
+						dbg(`session_start jscpd: cache hit`);
+						_cachedJscpdClones = cached.data.clones;
+					} else {
+						const startMs = Date.now();
+						const jscpdResult = jscpdClient.scan(scanRoot);
+						_cachedJscpdClones = jscpdResult.clones;
+						cacheManager.writeCache("jscpd", jscpdResult, scanRoot, {
+							scanDurationMs: Date.now() - startMs,
+						});
+						dbg(`session_start jscpd scan done`);
+					}
+				} else {
+					dbg(`session_start jscpd: not available`);
+				}
+
+				if (astGrepClient.isAvailable()) {
+					const exports = await astGrepClient.scanExports(scanRoot, "typescript");
+					dbg(`session_start exports scan: ${exports.size} functions found`);
+					for (const [name, file] of exports) {
+						cachedExports.set(name, file);
 					}
 				}
-			} catch (err) {
-				dbg(`session_start: project index build failed: ${err}`);
+
+				try {
+					const existing = await loadIndex(scanRoot);
+					if (
+						existing &&
+						existing.entries.size > 0 &&
+						(await isIndexFresh(scanRoot))
+					) {
+						cachedProjectIndex = existing;
+						dbg(
+							`session_start: loaded fresh project index from disk (${existing.entries.size} entries)`,
+						);
+					} else {
+						const sourceFiles = getSourceFiles(scanRoot, true);
+						const tsFiles = sourceFiles.filter(
+							(f) => f.endsWith(".ts") || f.endsWith(".tsx"),
+						);
+						if (tsFiles.length > 0 && tsFiles.length <= 500) {
+							cachedProjectIndex = await buildProjectIndex(scanRoot, tsFiles);
+							await saveIndex(cachedProjectIndex, scanRoot);
+							dbg(
+								`session_start: built project index (${cachedProjectIndex.entries.size} entries from ${tsFiles.length} files)`,
+							);
+						} else {
+							dbg(
+								`session_start: skipped project index (${tsFiles.length} files — ${tsFiles.length === 0 ? "none" : "too many"})`,
+							);
+						}
+					}
+				} catch (err) {
+					dbg(`session_start: project index build failed: ${err}`);
+				}
+			} else {
+				dbg(
+					`session_start: skipped heavy startup scans (${startupScan.reason ?? "unknown"})`,
+				);
+				if (startupScan.reason === "home-dir" || startupScan.reason === "no-project-root") {
+					parts.push(
+						"⚡ Skipping heavy startup scans until pi-lens detects a real project root. On-demand commands still work.",
+					);
+				} else if (startupScan.reason === "too-many-source-files") {
+					parts.push(
+						`⚡ Skipping heavy startup scans for this project because it exceeds the eager startup source-file budget (${startupScan.sourceFileCount ?? "many"} files).`,
+					);
+				}
 			}
 
 			dbg(
 				`session_start: scans complete (${parts.length} part(s)), cached for commands`,
 			);
 
-			// Output the assembled parts to user
 			if (parts.length > 0) {
 				for (const part of parts) {
 					ctx.ui.notify(part, "info");
@@ -1074,20 +1096,24 @@ export default function (pi: ExtensionAPI) {
 			// --- Error debt: check if tests ran since last session ---
 			// If files were modified in previous turn, run tests and check for regression
 			const errorDebtEnabled = pi.getFlag("error-debt");
-			const pendingDebt = cacheManager.readCache<{
-				pendingCheck: boolean;
-				baselineTestsPassed: boolean;
-			}>("errorDebt", cwd);
+			const pendingDebt = startupScan.projectRoot
+				? cacheManager.readCache<{
+					pendingCheck: boolean;
+					baselineTestsPassed: boolean;
+				}>("errorDebt", scanRoot)
+				: null;
 
 			if (
 				errorDebtEnabled &&
+				startupScan.canWarmCaches &&
+				startupScan.projectRoot &&
 				detectedRunner &&
 				pendingDebt?.data?.pendingCheck
 			) {
 				dbg("session_start: running pending error debt check");
 				const testResult = testRunnerClient.runTestFile(
 					".",
-					cwd,
+					scanRoot,
 					detectedRunner.runner,
 					detectedRunner.config,
 				);
@@ -1106,12 +1132,17 @@ export default function (pi: ExtensionAPI) {
 					testsPassed: testsPassed,
 					buildPassed: true,
 				};
-			} else if (errorDebtEnabled && detectedRunner) {
+			} else if (
+				errorDebtEnabled &&
+				startupScan.canWarmCaches &&
+				startupScan.projectRoot &&
+				detectedRunner
+			) {
 				// No pending check - establish fresh baseline
 				dbg("session_start: establishing fresh error debt baseline");
 				const testResult = testRunnerClient.runTestFile(
 					".",
-					cwd,
+					scanRoot,
 					detectedRunner.runner,
 					detectedRunner.config,
 				);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,18 +11,20 @@
 			"dependencies": {
 				"@sinclair/typebox": "^0.34.0",
 				"effect": "^3.21.0",
+				"glob": "^13.0.1",
+				"minimatch": "^10.2.3",
+				"typescript": "^5.0.0",
 				"vscode-jsonrpc": "^8.2.1"
 			},
 			"devDependencies": {
-				"@ast-grep/napi": "^0.42.0",
 				"@biomejs/biome": "^2.4.10",
 				"@types/node": "^22.10.5",
 				"js-yaml": "^4.1.1",
-				"typescript": "^5.0.0",
 				"typescript-language-server": "^5.1.3",
 				"vitest": "^4.1.1"
 			},
 			"optionalDependencies": {
+				"@ast-grep/napi": "^0.42.0",
 				"tree-sitter-wasms": "npm:null@^0.11.0",
 				"web-tree-sitter": "^0.25.10"
 			},
@@ -55,8 +57,8 @@
 			"version": "0.42.0",
 			"resolved": "https://registry.npmjs.org/@ast-grep/napi/-/napi-0.42.0.tgz",
 			"integrity": "sha512-f3DAjeC657EqbWN2In+girgbpvnKMV77bONyhuezXK4XQtvbGCB55u3CnNvQv6EP0caIBTtDHqO5CVyO6qY4LQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">= 10"
 			},
@@ -79,7 +81,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -96,7 +97,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -113,7 +113,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -130,7 +129,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -147,7 +145,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -164,7 +161,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -181,7 +177,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -198,7 +193,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -215,7 +209,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2930,7 +2923,6 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
 			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "18 || 20 || >=22"
 			}
@@ -2988,7 +2980,6 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
 			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
@@ -3639,7 +3630,6 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
 			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"dependencies": {
 				"minimatch": "^10.2.2",
 				"minipass": "^7.1.3",
@@ -4151,7 +4141,6 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
 			"integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"engines": {
 				"node": "20 || >=22"
 			}
@@ -4211,7 +4200,6 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
 			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^5.0.2"
 			},
@@ -4227,7 +4215,6 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
 			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
@@ -4473,7 +4460,6 @@
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
 			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"dependencies": {
 				"lru-cache": "^11.0.0",
 				"minipass": "^7.1.2"
@@ -5037,7 +5023,6 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -48,18 +48,20 @@
 	"dependencies": {
 		"@sinclair/typebox": "^0.34.0",
 		"effect": "^3.21.0",
+		"glob": "^13.0.1",
+		"minimatch": "^10.2.3",
+		"typescript": "^5.0.0",
 		"vscode-jsonrpc": "^8.2.1"
 	},
 	"optionalDependencies": {
+		"@ast-grep/napi": "^0.42.0",
 		"tree-sitter-wasms": "npm:null@^0.11.0",
 		"web-tree-sitter": "^0.25.10"
 	},
 	"devDependencies": {
-		"@ast-grep/napi": "^0.42.0",
 		"@biomejs/biome": "^2.4.10",
 		"@types/node": "^22.10.5",
 		"js-yaml": "^4.1.1",
-		"typescript": "^5.0.0",
 		"typescript-language-server": "^5.1.3",
 		"vitest": "^4.1.1"
 	},

--- a/tests/packaged-assets.test.ts
+++ b/tests/packaged-assets.test.ts
@@ -1,0 +1,59 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ArchitectClient } from "../clients/architect-client.js";
+import { TreeSitterQueryLoader } from "../clients/tree-sitter-query-loader.js";
+
+const originalCwd = process.cwd();
+
+afterEach(() => {
+	process.chdir(originalCwd);
+});
+
+async function withTempDir<T>(run: (dir: string) => Promise<T> | T): Promise<T> {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-assets-"));
+	try {
+		return await run(dir);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+describe("packaged built-in assets", () => {
+	it("loads bundled architect defaults outside the extension repo", async () => {
+		await withTempDir(async (dir) => {
+			process.chdir(dir);
+			const client = new ArchitectClient();
+
+			expect(client.loadConfig(dir)).toBe(true);
+			expect(client.hasConfig()).toBe(true);
+			expect(client.isUserDefined()).toBe(false);
+		});
+	});
+
+	it("loads bundled tree-sitter queries outside the extension repo", async () => {
+		await withTempDir(async (dir) => {
+			process.chdir(dir);
+			const loader = new TreeSitterQueryLoader();
+			const queries = await loader.loadQueries();
+			const totalQueries = [...queries.values()].reduce(
+				(total, entries) => total + entries.length,
+				0,
+			);
+
+			expect(totalQueries).toBeGreaterThan(0);
+		});
+	});
+
+	it("deduplicates packaged tree-sitter queries when cwd already points at the package", async () => {
+		process.chdir(path.resolve(import.meta.dirname, ".."));
+		const loader = new TreeSitterQueryLoader();
+		const queries = await loader.loadQueries();
+		const ids = [...queries.values()].flatMap((entries) =>
+			entries.map((entry) => entry.id),
+		);
+
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});

--- a/tests/runtime-dependencies.test.ts
+++ b/tests/runtime-dependencies.test.ts
@@ -1,0 +1,95 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const RUNTIME_ROOTS = ["clients", "commands"];
+const RUNTIME_FILES = ["index.ts"];
+
+function walkTsFiles(dir: string, files: string[]): void {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === "node_modules" || entry.name === "tests") continue;
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			walkTsFiles(fullPath, files);
+			continue;
+		}
+		if (entry.isFile() && fullPath.endsWith(".ts")) {
+			files.push(fullPath);
+		}
+	}
+}
+
+function getRuntimeFiles(): string[] {
+	const files: string[] = [];
+	for (const root of RUNTIME_ROOTS) {
+		walkTsFiles(path.join(REPO_ROOT, root), files);
+	}
+	for (const file of RUNTIME_FILES) {
+		files.push(path.join(REPO_ROOT, file));
+	}
+	return files;
+}
+
+function getBareImports(filePath: string): string[] {
+	const source = fs.readFileSync(filePath, "utf8");
+	const matches = source.matchAll(
+		/(?:import|export)\s+(?:[^"'`]+?\s+from\s+)?["']([^"']+)["']|import\(["']([^"']+)["']\)/g,
+	);
+	const imports: string[] = [];
+	for (const match of matches) {
+		const specifier = match[1] || match[2];
+		if (!specifier) continue;
+		if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("node:")) {
+			continue;
+		}
+		if (!/^(@[a-z0-9_.-]+\/)?[a-z0-9_.-]+(?:\/[a-z0-9_.-]+)*$/i.test(specifier)) {
+			continue;
+		}
+		imports.push(specifier);
+	}
+	return imports;
+}
+
+function toPackageName(specifier: string): string {
+	if (specifier.startsWith("@")) {
+		return specifier.split("/").slice(0, 2).join("/");
+	}
+	return specifier.split("/")[0];
+}
+
+describe("runtime dependency manifest", () => {
+	it("declares every bare runtime import outside devDependencies", () => {
+		const packageJson = JSON.parse(
+			fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"),
+		) as {
+			dependencies?: Record<string, string>;
+			optionalDependencies?: Record<string, string>;
+			peerDependencies?: Record<string, string>;
+		};
+
+		const declared = new Set<string>([
+			...Object.keys(packageJson.dependencies ?? {}),
+			...Object.keys(packageJson.optionalDependencies ?? {}),
+			...Object.keys(packageJson.peerDependencies ?? {}),
+		]);
+
+		const missing = new Map<string, Set<string>>();
+		for (const filePath of getRuntimeFiles()) {
+			for (const specifier of getBareImports(filePath)) {
+				const pkgName = toPackageName(specifier);
+				if (declared.has(pkgName)) continue;
+				const existing = missing.get(pkgName) ?? new Set<string>();
+				existing.add(path.relative(REPO_ROOT, filePath));
+				missing.set(pkgName, existing);
+			}
+		}
+
+		expect(
+			[...missing.entries()].map(([pkgName, files]) => ({
+				pkgName,
+				files: [...files].sort(),
+			})),
+		).toEqual([]);
+	});
+});

--- a/tests/startup-scan.test.ts
+++ b/tests/startup-scan.test.ts
@@ -1,0 +1,72 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	MAX_STARTUP_SOURCE_FILES,
+	resolveStartupScanContext,
+} from "../clients/startup-scan.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+function makeTempDir(prefix: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempRoots.push(dir);
+	return dir;
+}
+
+describe("startup scan gating", () => {
+	it("skips heavy warmup when cwd is not inside a detected project", () => {
+		const homeDir = makeTempDir("pi-lens-home-");
+		const cwd = path.join(homeDir, "scratch");
+		fs.mkdirSync(cwd, { recursive: true });
+
+		const context = resolveStartupScanContext(cwd, { homeDir });
+
+		expect(context.canWarmCaches).toBe(false);
+		expect(context.projectRoot).toBeNull();
+		expect(context.reason).toBe("no-project-root");
+	});
+
+	it("uses the nearest detected project root for startup scans", () => {
+		const homeDir = makeTempDir("pi-lens-project-home-");
+		const projectRoot = path.join(homeDir, "workspace", "demo");
+		const nestedCwd = path.join(projectRoot, "src", "feature");
+		fs.mkdirSync(nestedCwd, { recursive: true });
+		fs.writeFileSync(path.join(projectRoot, "package.json"), '{"name":"demo"}');
+
+		const context = resolveStartupScanContext(nestedCwd, { homeDir });
+
+		expect(context.canWarmCaches).toBe(true);
+		expect(context.projectRoot).toBe(projectRoot);
+		expect(context.scanRoot).toBe(projectRoot);
+		expect(context.reason).toBeUndefined();
+	});
+
+	it("skips heavy warmup when the detected project exceeds the startup source budget", () => {
+		const homeDir = makeTempDir("pi-lens-large-home-");
+		const projectRoot = path.join(homeDir, "workspace", "huge-project");
+		fs.mkdirSync(projectRoot, { recursive: true });
+		fs.writeFileSync(path.join(projectRoot, "package.json"), '{"name":"huge-project"}');
+
+		for (let i = 0; i <= MAX_STARTUP_SOURCE_FILES; i++) {
+			fs.writeFileSync(
+				path.join(projectRoot, `file-${i}.ts`),
+				`export const value${i} = ${i};\n`,
+			);
+		}
+
+		const context = resolveStartupScanContext(projectRoot, { homeDir });
+
+		expect(context.canWarmCaches).toBe(false);
+		expect(context.projectRoot).toBe(projectRoot);
+		expect(context.reason).toBe("too-many-source-files");
+		expect(context.sourceFileCount).toBeGreaterThan(MAX_STARTUP_SOURCE_FILES);
+	});
+});


### PR DESCRIPTION
## Summary
- fix runtime dependency declarations for published installs
- resolve bundled rules/assets from the installed package root
- skip eager startup warmups outside detected project roots or for oversized trees
- add regression tests for manifest/runtime deps, packaged assets, and startup scan gating

## Testing
- npm run build
- npm test
- npm pack
