### PR TITLE
perf: run startup scans asynchronously in background

### DIFF
--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -6,6 +6,7 @@ import type { BiomeClient } from "./biome-client.js";
 import type { CacheManager } from "./cache-manager.js";
 import type { DependencyChecker } from "./dependency-checker.js";
 import { getDiagnosticTracker } from "./diagnostic-tracker.js";
+import { getKnipIgnorePatterns } from "./file-utils.js";
 import type { GoClient } from "./go-client.js";
 import type { JscpdClient } from "./jscpd-client.js";
 import type { KnipClient } from "./knip-client.js";
@@ -16,11 +17,10 @@ import {
 	loadIndex,
 	saveIndex,
 } from "./project-index.js";
-import { scanProjectRules } from "./rules-scanner.js";
 import type { RuffClient } from "./ruff-client.js";
+import { scanProjectRules } from "./rules-scanner.js";
 import type { RuntimeCoordinator } from "./runtime-coordinator.js";
 import type { RustClient } from "./rust-client.js";
-import { getKnipIgnorePatterns } from "./file-utils.js";
 import { getSourceFiles } from "./scan-utils.js";
 import { resolveStartupScanContext } from "./startup-scan.js";
 import type { TestRunnerClient } from "./test-runner-client.js";
@@ -54,7 +54,9 @@ interface SessionStartDeps {
 	resetLSPService: () => void;
 }
 
-export async function handleSessionStart(deps: SessionStartDeps): Promise<void> {
+export async function handleSessionStart(
+	deps: SessionStartDeps,
+): Promise<void> {
 	const {
 		ctxCwd,
 		getFlag,
@@ -174,9 +176,7 @@ export async function handleSessionStart(deps: SessionStartDeps): Promise<void> 
 						if (p) dbg(`session_start: prettier ready at ${p}`);
 						else dbg("session_start: prettier install failed silently");
 					})
-					.catch((err) =>
-						dbg(`session_start: prettier install error: ${err}`),
-					);
+					.catch((err) => dbg(`session_start: prettier install error: ${err}`));
 			}
 		} catch {
 			// no package.json at cwd root
@@ -203,7 +203,9 @@ export async function handleSessionStart(deps: SessionStartDeps): Promise<void> 
 	runtime.projectRulesScan = scanProjectRules(analysisRoot);
 	if (runtime.projectRulesScan.hasCustomRules) {
 		const ruleCount = runtime.projectRulesScan.rules.length;
-		const sources = [...new Set(runtime.projectRulesScan.rules.map((r) => r.source))];
+		const sources = [
+			...new Set(runtime.projectRulesScan.rules.map((r) => r.source)),
+		];
 		dbg(
 			`session_start: found ${ruleCount} project rule(s) from ${sources.join(", ")}`,
 		);
@@ -214,67 +216,104 @@ export async function handleSessionStart(deps: SessionStartDeps): Promise<void> 
 		dbg("session_start: no project rules found");
 	}
 
-	const todoResult = todoScanner.scanDirectory(analysisRoot);
-	dbg(
-		`session_start TODO scan: ${todoResult.items.length} items (baseline stored)`,
-	);
-	cacheManager.writeCache("todo-baseline", { items: todoResult.items }, analysisRoot);
+	// Fire off all heavy scans as background tasks — don't block session start.
+	// Each consumer already handles the "not ready yet" case gracefully
+	// (cachedExports.size > 0, cachedProjectIndex != null, cache miss paths).
+
+	// TODO scan is lightweight and synchronous — run in background via promise
+	Promise.resolve()
+		.then(() => {
+			const todoResult = todoScanner.scanDirectory(analysisRoot);
+			dbg(
+				`session_start TODO scan: ${todoResult.items.length} items (baseline stored)`,
+			);
+			cacheManager.writeCache(
+				"todo-baseline",
+				{ items: todoResult.items },
+				analysisRoot,
+			);
+		})
+		.catch((err) => dbg(`session_start: TODO scan failed: ${err}`));
 
 	if (!startupScan.canWarmCaches) {
-		dbg(`session_start: skipping heavy scans (${startupScan.reason ?? "unknown"})`);
+		dbg(
+			`session_start: skipping heavy scans (${startupScan.reason ?? "unknown"})`,
+		);
 	} else {
-		if (await knipClient.ensureAvailable()) {
-			const cached = cacheManager.readCache<ReturnType<KnipClient["analyze"]>>(
-				"knip",
-				analysisRoot,
-			);
-			if (cached) {
-				dbg(
-					`session_start Knip: cache hit (${Math.round((Date.now() - new Date(cached.meta.timestamp).getTime()) / 1000)}s ago)`,
-				);
+		dbg(
+			"session_start: launching background scans (knip, jscpd, ast-grep exports, project index)",
+		);
+
+		// Knip — dead code / unused exports
+		(async () => {
+			if (await knipClient.ensureAvailable()) {
+				const cached = cacheManager.readCache<
+					ReturnType<KnipClient["analyze"]>
+				>("knip", analysisRoot);
+				if (cached) {
+					dbg(
+						`session_start Knip: cache hit (${Math.round((Date.now() - new Date(cached.meta.timestamp).getTime()) / 1000)}s ago)`,
+					);
+				} else {
+					const startMs = Date.now();
+					const knipResult = knipClient.analyze(
+						analysisRoot,
+						getKnipIgnorePatterns(),
+					);
+					cacheManager.writeCache("knip", knipResult, analysisRoot, {
+						scanDurationMs: Date.now() - startMs,
+					});
+					dbg(`session_start Knip scan done (${Date.now() - startMs}ms)`);
+				}
 			} else {
-				const startMs = Date.now();
-				const knipResult = knipClient.analyze(
+				dbg("session_start Knip: not available");
+			}
+		})().catch((err) =>
+			dbg(`session_start: Knip background scan failed: ${err}`),
+		);
+
+		// jscpd — duplicate code detection
+		(async () => {
+			if (await jscpdClient.ensureAvailable()) {
+				const cached = cacheManager.readCache<ReturnType<JscpdClient["scan"]>>(
+					"jscpd",
 					analysisRoot,
-					getKnipIgnorePatterns(),
 				);
-				cacheManager.writeCache("knip", knipResult, analysisRoot, {
-					scanDurationMs: Date.now() - startMs,
-				});
-				dbg("session_start Knip scan done");
-			}
-		} else {
-			dbg("session_start Knip: not available");
-		}
-
-		if (await jscpdClient.ensureAvailable()) {
-			const cached = cacheManager.readCache<ReturnType<JscpdClient["scan"]>>(
-				"jscpd",
-				analysisRoot,
-			);
-			if (cached) {
-				dbg("session_start jscpd: cache hit");
+				if (cached) {
+					dbg("session_start jscpd: cache hit");
+				} else {
+					const startMs = Date.now();
+					const jscpdResult = jscpdClient.scan(analysisRoot);
+					cacheManager.writeCache("jscpd", jscpdResult, analysisRoot, {
+						scanDurationMs: Date.now() - startMs,
+					});
+					dbg(`session_start jscpd scan done (${Date.now() - startMs}ms)`);
+				}
 			} else {
-				const startMs = Date.now();
-				const jscpdResult = jscpdClient.scan(analysisRoot);
-				cacheManager.writeCache("jscpd", jscpdResult, analysisRoot, {
-					scanDurationMs: Date.now() - startMs,
-				});
-				dbg("session_start jscpd scan done");
+				dbg("session_start jscpd: not available");
 			}
-		} else {
-			dbg("session_start jscpd: not available");
-		}
+		})().catch((err) =>
+			dbg(`session_start: jscpd background scan failed: ${err}`),
+		);
 
-		if (await astGrepClient.ensureAvailable()) {
-			const exports = await astGrepClient.scanExports(analysisRoot, "typescript");
-			dbg(`session_start exports scan: ${exports.size} functions found`);
-			for (const [name, file] of exports) {
-				runtime.cachedExports.set(name, file);
+		// ast-grep — export scan for duplicate detection
+		(async () => {
+			if (await astGrepClient.ensureAvailable()) {
+				const exports = await astGrepClient.scanExports(
+					analysisRoot,
+					"typescript",
+				);
+				dbg(`session_start exports scan: ${exports.size} functions found`);
+				for (const [name, file] of exports) {
+					runtime.cachedExports.set(name, file);
+				}
 			}
-		}
+		})().catch((err) =>
+			dbg(`session_start: ast-grep exports scan failed: ${err}`),
+		);
 
-		try {
+		// Project index — structural similarity detection
+		(async () => {
 			const existing = await loadIndex(analysisRoot);
 			if (
 				existing &&
@@ -303,13 +342,13 @@ export async function handleSessionStart(deps: SessionStartDeps): Promise<void> 
 					dbg(`session_start: skipped project index (${tsFiles.length} files)`);
 				}
 			}
-		} catch (err) {
-			dbg(`session_start: project index build failed: ${err}`);
-		}
+		})().catch((err) =>
+			dbg(`session_start: project index build failed: ${err}`),
+		);
 	}
 
 	dbg(
-		`session_start: scans complete (${startupNotes.length} startup note(s)), cached for commands`,
+		`session_start: background scans launched (${startupNotes.length} startup note(s))`,
 	);
 
 	const errorDebtEnabled = getFlag("error-debt");


### PR DESCRIPTION
handleSessionStart was running 5 heavy scans sequentially, blocking the session from starting until all of them completed:

 1. TODO scan (walks entire source tree)
 2. Knip analysis (npx knip — dead code detection, 30s timeout)
 3. jscpd scan (npx jscpd — duplicate detection)
 4. ast-grep export scan (spawns sg scan across the project)
 5. Project index build (parses up to 500 TS files with the TypeScript compiler API)

 On a non-trivial project with cold caches, this could easily add 15-20 seconds to startup.

 All five scans now launch as fire-and-forget background promises. session_start returns immediately and the scans populate runtime state as they resolve. This is safe because
 every consumer already handles the "not ready yet" case:

 - cachedExports — guarded by runtime.cachedExports.size > 0
 - cachedProjectIndex — guarded by null + size check
 - Knip/jscpd caches — re-run at turn_end anyway; cache miss is the normal path
 - TODO baseline — only used for delta comparison on later turns

 Each background task has its own .catch() so failures are logged without crashing the session.
