### PR TITLE
fix: harden TODO startup scan for iCloud timeouts

### DIFF
--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -23,8 +23,19 @@ export const EXCLUDED_DIRS = [
 	".gradle",
 	".next",
 	".pi-lens",
-	".pi",              // pi agent directory
-	".ruff_cache",      // Python linter cache
+	".pi", // pi agent directory
+	".ruff_cache", // Python linter cache
+	".worktrees",
+	".claude",
+	".codex",
+	".rescue",
+	".agents",
+	".gstack",
+	".superpowers",
+	".guardrails",
+	".playwright-cli",
+	".playwright-mcp",
+	".vscode",
 	"venv",
 	".venv",
 	"coverage",

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -226,33 +226,33 @@ export async function handleSessionStart(
 			});
 	};
 
-	// Fire off all heavy scans as background tasks — don't block session start.
+	// Fire off heavy scans as background tasks — don't block session start.
 	// Each consumer already handles the "not ready yet" case gracefully
 	// (cachedExports.size > 0, cachedProjectIndex != null, cache miss paths).
-
-	// TODO scan is lightweight and synchronous — run in background via promise
-	runStartupTask("todo", async () => {
-		if (!runtime.isCurrentSession(sessionGeneration)) return;
-		const todoResult = todoScanner.scanDirectory(analysisRoot);
-		if (!runtime.isCurrentSession(sessionGeneration)) return;
-		dbg(
-			`session_start TODO scan: ${todoResult.items.length} items (baseline stored)`,
-		);
-		cacheManager.writeCache(
-			"todo-baseline",
-			{ items: todoResult.items },
-			analysisRoot,
-		);
-	});
 
 	if (!startupScan.canWarmCaches) {
 		dbg(
 			`session_start: skipping heavy scans (${startupScan.reason ?? "unknown"})`,
 		);
+		dbg(`session_start: skipping TODO scan (${startupScan.reason ?? "unknown"})`);
 	} else {
 		dbg(
-			"session_start: launching background scans (knip, jscpd, ast-grep exports, project index)",
+			"session_start: launching background scans (todo, knip, jscpd, ast-grep exports, project index)",
 		);
+
+		runStartupTask("todo", async () => {
+			if (!runtime.isCurrentSession(sessionGeneration)) return;
+			const todoResult = todoScanner.scanDirectory(analysisRoot);
+			if (!runtime.isCurrentSession(sessionGeneration)) return;
+			dbg(
+				`session_start TODO scan: ${todoResult.items.length} items (baseline stored)`,
+			);
+			cacheManager.writeCache(
+				"todo-baseline",
+				{ items: todoResult.items },
+				analysisRoot,
+			);
+		});
 
 		// Knip — dead code / unused exports
 		runStartupTask("knip", async () => {

--- a/clients/todo-scanner.ts
+++ b/clients/todo-scanner.ts
@@ -91,7 +91,12 @@ export class TodoScanner {
 		const absolutePath = path.resolve(filePath);
 		if (!fs.existsSync(absolutePath)) return [];
 
-		const content = fs.readFileSync(absolutePath, "utf-8");
+		let content: string;
+		try {
+			content = fs.readFileSync(absolutePath, "utf-8");
+		} catch {
+			return [];
+		}
 		const lines = content.split("\n");
 		const items: TodoItem[] = [];
 

--- a/tests/clients/file-utils.test.ts
+++ b/tests/clients/file-utils.test.ts
@@ -19,4 +19,11 @@ describe("file-utils exclusion matching", () => {
 		expect(isExcludedDirName("build-cache", ["build-*"])).toBe(true);
 		expect(isExcludedDirName("custom-in", ["custom-out"])).toBe(false);
 	});
+
+	it("excludes common agent/tooling directories", () => {
+		expect(isExcludedDirName(".claude")).toBe(true);
+		expect(isExcludedDirName(".codex")).toBe(true);
+		expect(isExcludedDirName(".worktrees")).toBe(true);
+		expect(isExcludedDirName(".vscode")).toBe(true);
+	});
 });

--- a/tests/clients/runtime-session.test.ts
+++ b/tests/clients/runtime-session.test.ts
@@ -6,6 +6,7 @@ describe("runtime-session notifications", () => {
 	it("emits one compact startup info note and keeps critical warnings separate", async () => {
 		const env = setupTestEnvironment("pi-lens-runtime-session-");
 		const notify = vi.fn();
+		const scanDirectory = vi.fn(() => ({ items: [] }));
 
 		try {
 			await handleSessionStart({
@@ -44,7 +45,7 @@ describe("runtime-session notifications", () => {
 						return null;
 					},
 				},
-				todoScanner: { scanDirectory: () => ({ items: [] }) },
+				todoScanner: { scanDirectory },
 				astGrepClient: {
 					isAvailable: () => false,
 					ensureAvailable: async () => false,
@@ -82,6 +83,7 @@ describe("runtime-session notifications", () => {
 				true,
 			);
 			expect(warningCalls.some(([msg]) => msg.includes("ERROR DEBT"))).toBe(true);
+			expect(scanDirectory).not.toHaveBeenCalled();
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/todo-scanner.test.ts
+++ b/tests/clients/todo-scanner.test.ts
@@ -1,0 +1,23 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { TodoScanner } from "../../clients/todo-scanner.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("todo-scanner", () => {
+	it("returns empty results when a file cannot be read", () => {
+		const scanner = new TodoScanner();
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-todo-"));
+		tempDirs.push(dir);
+
+		expect(scanner.scanFile(dir)).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- wrap TodoScanner.scanFile reads in a safe try/catch so unreadable files (for example iCloud-evicted files) are skipped instead of crashing startup
- gate TODO baseline warmup behind startupScan.canWarmCaches and log when skipped
- expand shared excluded directory list with common agent/tooling folders to avoid inflated source counts and unnecessary startup scan I/O

## Why
Issue #4 reports ETIMEDOUT crashes during session_start on iCloud-synced repos. This patch makes TODO scanning resilient and prevents unnecessary scanning in oversized/tooling-heavy trees.

Closes #4
