### PR TITLE
fix: make Ruff auto-install resilient when pip is missing

### DIFF
--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -7,6 +7,7 @@
 
 import { detectFileKind } from "../file-kinds.js";
 import type { FileKind } from "../file-kinds.js";
+import { LSP_CAPABLE_FILE_KINDS } from "../language-profile.js";
 import {
 	clearLatencyReports,
 	createBaselineStore,
@@ -40,20 +41,7 @@ import "./runners/index.js";
 // store, so baselines.get() always returns undefined and every issue
 // looks "new" every time.
 const sessionBaselines: BaselineStore = createBaselineStore();
-const LSP_CAPABLE_KINDS = new Set<FileKind>([
-	"jsts",
-	"python",
-	"go",
-	"rust",
-	"ruby",
-	"cxx",
-	"cmake",
-	"shell",
-	"json",
-	"markdown",
-	"css",
-	"yaml",
-]);
+const LSP_CAPABLE_KINDS = new Set<FileKind>(LSP_CAPABLE_FILE_KINDS);
 
 function withPrimaryLspGroup(
 	kind: keyof typeof TOOL_PLANS,

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -427,27 +427,121 @@ async function installPipTool(
 	packageName: string,
 ): Promise<string | undefined> {
 	try {
-		const pipCmd = process.platform === "win32" ? "pip" : "pip3";
 		const isWindows = process.platform === "win32";
-		const proc = spawn(pipCmd, ["install", "--user", packageName], {
-			stdio: ["ignore", "pipe", "pipe"],
-			shell: isWindows, // Required for .cmd files on Windows
-		});
+		const pipCandidates = isWindows
+			? [
+					{ command: "pip", args: ["install", "--user", packageName] },
+					{ command: "py", args: ["-m", "pip", "install", "--user", packageName] },
+					{
+						command: "python",
+						args: ["-m", "pip", "install", "--user", packageName],
+					},
+				]
+			: [
+					{ command: "pip3", args: ["install", "--user", packageName] },
+					{ command: "pip", args: ["install", "--user", packageName] },
+					{
+						command: "python3",
+						args: ["-m", "pip", "install", "--user", packageName],
+					},
+					{ command: "python", args: ["-m", "pip", "install", "--user", packageName] },
+				];
 
-		return new Promise((resolve, reject) => {
-			let stderr = "";
-			proc.stderr?.on("data", (data) => (stderr += data));
+		let lastError = "";
+		for (const candidate of pipCandidates) {
+			const outcome = await new Promise<{ ok: boolean; error: string }>((resolve) => {
+				const proc = spawn(candidate.command, candidate.args, {
+					stdio: ["ignore", "pipe", "pipe"],
+					shell: isWindows, // Required for .cmd files on Windows
+				});
 
-			proc.on("exit", (code) => {
-				if (code === 0) {
-					resolve(packageName); // pip installs to PATH
-				} else {
-					reject(new Error(`Failed to install ${packageName}: ${stderr}`));
-				}
+				let stderr = "";
+				proc.stderr?.on("data", (data) => (stderr += data));
+
+				proc.on("exit", (code) => {
+					if (code === 0) {
+						resolve({ ok: true, error: "" });
+					} else {
+						resolve({ ok: false, error: stderr.trim() });
+					}
+				});
+
+				proc.on("error", (err) => {
+					resolve({ ok: false, error: err.message });
+				});
 			});
 
-			proc.on("error", (err) => reject(err));
-		});
+			if (outcome.ok) {
+				// Ensure user-level scripts directory is available in current process PATH.
+				// This helps tools installed via `pip install --user` become immediately callable.
+				const userBaseResult = await new Promise<string>((resolve) => {
+					const probe = spawn(candidate.command, ["-m", "site", "--user-base"], {
+						stdio: ["ignore", "pipe", "pipe"],
+						shell: isWindows,
+					});
+					let stdout = "";
+					probe.stdout?.on("data", (data) => (stdout += data));
+					probe.on("exit", (code) => {
+						if (code === 0) resolve(stdout.trim());
+						else resolve("");
+					});
+					probe.on("error", () => resolve(""));
+				});
+
+				if (userBaseResult) {
+					const candidateScriptDirs: string[] = [
+						path.join(userBaseResult, isWindows ? "Scripts" : "bin"),
+					];
+
+					if (isWindows) {
+						// Some Python setups report USER_BASE as ...\Roaming\Python,
+						// while scripts live in ...\Roaming\Python\PythonXY\Scripts.
+						try {
+							const children = await fs.readdir(userBaseResult, {
+								withFileTypes: true,
+							});
+							for (const entry of children) {
+								if (!entry.isDirectory()) continue;
+								if (!/^python\d+$/i.test(entry.name)) continue;
+								candidateScriptDirs.push(
+									path.join(userBaseResult, entry.name, "Scripts"),
+								);
+							}
+						} catch {
+							// ignore
+						}
+					}
+
+					const currentPath = process.env.PATH || "";
+					const separator = isWindows ? ";" : ":";
+					const normalizedPath = currentPath
+						.toLowerCase()
+						.split(separator)
+						.map((p) => p.trim());
+
+					for (const scriptsDir of candidateScriptDirs) {
+						try {
+							await fs.access(scriptsDir);
+							if (!normalizedPath.includes(scriptsDir.toLowerCase())) {
+								process.env.PATH = `${scriptsDir}${separator}${process.env.PATH || ""}`;
+								debugLog(`Added pip user scripts dir to PATH: ${scriptsDir}`);
+							}
+						} catch {
+							debugLog(`pip user scripts dir not accessible: ${scriptsDir}`);
+						}
+					}
+				}
+
+				return packageName;
+			}
+
+			lastError = `${candidate.command} ${candidate.args.join(" ")}: ${outcome.error}`;
+			debugLog(`[pip-fallback] ${lastError}`);
+		}
+
+		throw new Error(
+			`Failed to install ${packageName}: no usable pip command found (${lastError || "unknown error"})`,
+		);
 	} catch (err) {
 		console.error(
 			`[auto-install] Failed to install ${packageName}: ${(err as Error).message}`,

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -175,6 +175,8 @@ const TOOLS: ToolDefinition[] = [
 	},
 ];
 
+const ensureInFlight = new Map<string, Promise<string | undefined>>();
+
 // --- Check Functions ---
 
 /**
@@ -602,14 +604,26 @@ export async function ensureTool(toolId: string): Promise<string | undefined> {
 		return existingPath;
 	}
 
-	// Try to install
-	const installed = await installTool(toolId);
-	if (!installed) {
-		return undefined;
+	const inFlight = ensureInFlight.get(toolId);
+	if (inFlight) {
+		return inFlight;
 	}
 
-	// Return the path after installation
-	return getToolPath(toolId);
+	const installPromise = (async () => {
+		const installed = await installTool(toolId);
+		if (!installed) {
+			return undefined;
+		}
+
+		return getToolPath(toolId);
+	})();
+
+	ensureInFlight.set(toolId, installPromise);
+	try {
+		return await installPromise;
+	} finally {
+		ensureInFlight.delete(toolId);
+	}
 }
 
 // --- Integration Helpers ---

--- a/clients/language-profile.ts
+++ b/clients/language-profile.ts
@@ -1,0 +1,107 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { detectFileKind, type FileKind } from "./file-kinds.js";
+import { getSourceFiles } from "./scan-utils.js";
+
+export const SUPPORTED_FILE_KINDS: readonly FileKind[] = [
+	"jsts",
+	"python",
+	"go",
+	"rust",
+	"cxx",
+	"cmake",
+	"shell",
+	"json",
+	"markdown",
+	"css",
+	"yaml",
+	"sql",
+	"ruby",
+];
+
+export const LSP_CAPABLE_FILE_KINDS: readonly FileKind[] = [
+	"jsts",
+	"python",
+	"go",
+	"rust",
+	"ruby",
+	"cxx",
+	"cmake",
+	"shell",
+	"json",
+	"markdown",
+	"css",
+	"yaml",
+];
+
+const PROJECT_MARKERS_BY_KIND: Partial<Record<FileKind, readonly string[]>> = {
+	jsts: ["package.json", "tsconfig.json", "jsconfig.json"],
+	python: ["pyproject.toml", "requirements.txt", "setup.py", "setup.cfg"],
+	go: ["go.mod"],
+	rust: ["Cargo.toml"],
+	ruby: ["Gemfile", "Rakefile"],
+};
+
+export interface ProjectLanguageProfile {
+	present: Record<FileKind, boolean>;
+	counts: Partial<Record<FileKind, number>>;
+	detectedKinds: FileKind[];
+}
+
+export function detectProjectLanguageProfile(
+	projectRoot: string,
+	sourceFiles?: string[],
+): ProjectLanguageProfile {
+	const present = Object.fromEntries(
+		SUPPORTED_FILE_KINDS.map((kind) => [kind, false]),
+	) as Record<FileKind, boolean>;
+	const counts: Partial<Record<FileKind, number>> = {};
+
+	for (const [kind, markers] of Object.entries(PROJECT_MARKERS_BY_KIND)) {
+		if (!markers) continue;
+		for (const marker of markers) {
+			if (fs.existsSync(path.join(projectRoot, marker))) {
+				present[kind as FileKind] = true;
+				break;
+			}
+		}
+	}
+
+	let files = sourceFiles;
+	if (!files) {
+		try {
+			files = getSourceFiles(projectRoot, true);
+		} catch {
+			files = [];
+		}
+	}
+
+	for (const file of files) {
+		const kind = detectFileKind(file);
+		if (!kind) continue;
+		present[kind] = true;
+		counts[kind] = (counts[kind] ?? 0) + 1;
+	}
+
+	const detectedKinds = SUPPORTED_FILE_KINDS.filter((kind) => present[kind]);
+
+	return {
+		present,
+		counts,
+		detectedKinds,
+	};
+}
+
+export function hasLanguage(
+	profile: ProjectLanguageProfile,
+	kind: FileKind,
+): boolean {
+	return !!profile.present[kind];
+}
+
+export function hasAnyLanguage(
+	profile: ProjectLanguageProfile,
+	kinds: readonly FileKind[],
+): boolean {
+	return kinds.some((kind) => hasLanguage(profile, kind));
+}

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -266,6 +266,7 @@ export const PythonServer: LSPServerInfo = {
 	name: "Pyright Language Server",
 	extensions: [".py", ".pyi"],
 	root: createRootDetector([
+		".git",
 		"pyproject.toml",
 		"setup.py",
 		"setup.cfg",
@@ -327,7 +328,9 @@ export const PythonServer: LSPServerInfo = {
 				try {
 					await fs.access(candidate);
 					langserverPath = candidate;
-					console.error(`[lsp] Found pyright-langserver: ${candidate}`);
+					if (process.env.PI_LENS_DEBUG === "1") {
+						console.error(`[lsp] Found pyright-langserver: ${candidate}`);
+					}
 					break;
 				} catch {
 					/* not found */

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -55,21 +55,45 @@ interface SessionStartDeps {
 }
 
 const TS_JS_FILE_PATTERN = /\.(?:ts|tsx|cts|mts|js|jsx|cjs|mjs)$/i;
+const PYTHON_FILE_PATTERN = /\.(?:py|pyi)$/i;
 const TS_JS_MARKER_FILES = ["package.json", "tsconfig.json", "jsconfig.json"];
 
-function shouldPreinstallTypeScriptLsp(projectRoot: string): boolean {
+interface ProjectLanguageProfile {
+	hasJsTs: boolean;
+	hasPython: boolean;
+}
+
+function detectProjectLanguageProfile(projectRoot: string): ProjectLanguageProfile {
+	const profile: ProjectLanguageProfile = {
+		hasJsTs: false,
+		hasPython: false,
+	};
+
 	for (const marker of TS_JS_MARKER_FILES) {
 		if (nodeFs.existsSync(path.join(projectRoot, marker))) {
-			return true;
+			profile.hasJsTs = true;
+			break;
 		}
 	}
 
+	let sourceFiles: string[] = [];
 	try {
-		const sourceFiles = getSourceFiles(projectRoot, true);
-		return sourceFiles.some((file) => TS_JS_FILE_PATTERN.test(file));
+		sourceFiles = getSourceFiles(projectRoot, true);
 	} catch {
-		return false;
+		return profile;
 	}
+
+	for (const file of sourceFiles) {
+		if (!profile.hasJsTs && TS_JS_FILE_PATTERN.test(file)) {
+			profile.hasJsTs = true;
+		}
+		if (!profile.hasPython && PYTHON_FILE_PATTERN.test(file)) {
+			profile.hasPython = true;
+		}
+		if (profile.hasJsTs && profile.hasPython) break;
+	}
+
+	return profile;
 }
 
 export async function handleSessionStart(
@@ -151,16 +175,20 @@ export async function handleSessionStart(
 	const scanRoot = startupScan.projectRoot ?? cwd;
 	const analysisRoot = scanRoot;
 	runtime.projectRoot = scanRoot;
+	const languageProfile = detectProjectLanguageProfile(analysisRoot);
 	dbg(`session_start cwd: ${cwd}`);
 	dbg(
 		`session_start scan root: ${scanRoot} (warmCaches=${startupScan.canWarmCaches}${startupScan.reason ? `, reason=${startupScan.reason}` : ""})`,
+	);
+	dbg(
+		`session_start language profile: js_ts=${languageProfile.hasJsTs}, python=${languageProfile.hasPython}`,
 	);
 	if (analysisRoot !== cwd) {
 		dbg(`session_start: monorepo analysis root override -> ${analysisRoot}`);
 	}
 
 	if (getFlag("lens-lsp") && !getFlag("no-lsp")) {
-		if (shouldPreinstallTypeScriptLsp(analysisRoot)) {
+		if (languageProfile.hasJsTs) {
 			dbg("session_start: pre-installing TypeScript LSP...");
 			ensureTool("typescript-language-server")
 				.then((toolPath) => {
@@ -258,8 +286,12 @@ export async function handleSessionStart(
 		);
 		dbg(`session_start: skipping TODO scan (${startupScan.reason ?? "unknown"})`);
 	} else {
+		const scanNames = ["todo"];
+		if (languageProfile.hasJsTs) {
+			scanNames.push("knip", "jscpd", "ast-grep exports", "project index");
+		}
 		dbg(
-			"session_start: launching background scans (todo, knip, jscpd, ast-grep exports, project index)",
+			`session_start: launching background scans (${scanNames.join(", ")})`,
 		);
 
 		runStartupTask("todo", async () => {
@@ -276,113 +308,117 @@ export async function handleSessionStart(
 			);
 		});
 
-		// Knip — dead code / unused exports
-		runStartupTask("knip", async () => {
-			if (await knipClient.ensureAvailable()) {
-				if (!runtime.isCurrentSession(sessionGeneration)) return;
-				const cached = cacheManager.readCache<
-					ReturnType<KnipClient["analyze"]>
-				>("knip", analysisRoot);
-				if (cached) {
+		if (!languageProfile.hasJsTs) {
+			dbg("session_start: skipping JS/TS startup scans (no JS/TS files detected)");
+		} else {
+			// Knip — dead code / unused exports
+			runStartupTask("knip", async () => {
+				if (await knipClient.ensureAvailable()) {
 					if (!runtime.isCurrentSession(sessionGeneration)) return;
-					dbg(
-						`session_start Knip: cache hit (${Math.round((Date.now() - new Date(cached.meta.timestamp).getTime()) / 1000)}s ago)`,
-					);
+					const cached = cacheManager.readCache<
+						ReturnType<KnipClient["analyze"]>
+					>("knip", analysisRoot);
+					if (cached) {
+						if (!runtime.isCurrentSession(sessionGeneration)) return;
+						dbg(
+							`session_start Knip: cache hit (${Math.round((Date.now() - new Date(cached.meta.timestamp).getTime()) / 1000)}s ago)`,
+						);
+					} else {
+						const startMs = Date.now();
+						const knipResult = knipClient.analyze(
+							analysisRoot,
+							getKnipIgnorePatterns(),
+						);
+						if (!runtime.isCurrentSession(sessionGeneration)) return;
+						cacheManager.writeCache("knip", knipResult, analysisRoot, {
+							scanDurationMs: Date.now() - startMs,
+						});
+						dbg(`session_start Knip scan done (${Date.now() - startMs}ms)`);
+					}
 				} else {
-					const startMs = Date.now();
-					const knipResult = knipClient.analyze(
+					if (!runtime.isCurrentSession(sessionGeneration)) return;
+					dbg("session_start Knip: not available");
+				}
+			});
+
+			// jscpd — duplicate code detection
+			runStartupTask("jscpd", async () => {
+				if (await jscpdClient.ensureAvailable()) {
+					if (!runtime.isCurrentSession(sessionGeneration)) return;
+					const cached = cacheManager.readCache<ReturnType<JscpdClient["scan"]>>(
+						"jscpd",
 						analysisRoot,
-						getKnipIgnorePatterns(),
 					);
-					if (!runtime.isCurrentSession(sessionGeneration)) return;
-					cacheManager.writeCache("knip", knipResult, analysisRoot, {
-						scanDurationMs: Date.now() - startMs,
-					});
-					dbg(`session_start Knip scan done (${Date.now() - startMs}ms)`);
-				}
-			} else {
-				if (!runtime.isCurrentSession(sessionGeneration)) return;
-				dbg("session_start Knip: not available");
-			}
-		});
-
-		// jscpd — duplicate code detection
-		runStartupTask("jscpd", async () => {
-			if (await jscpdClient.ensureAvailable()) {
-				if (!runtime.isCurrentSession(sessionGeneration)) return;
-				const cached = cacheManager.readCache<ReturnType<JscpdClient["scan"]>>(
-					"jscpd",
-					analysisRoot,
-				);
-				if (cached) {
-					if (!runtime.isCurrentSession(sessionGeneration)) return;
-					dbg("session_start jscpd: cache hit");
+					if (cached) {
+						if (!runtime.isCurrentSession(sessionGeneration)) return;
+						dbg("session_start jscpd: cache hit");
+					} else {
+						const startMs = Date.now();
+						const jscpdResult = jscpdClient.scan(analysisRoot);
+						if (!runtime.isCurrentSession(sessionGeneration)) return;
+						cacheManager.writeCache("jscpd", jscpdResult, analysisRoot, {
+							scanDurationMs: Date.now() - startMs,
+						});
+						dbg(`session_start jscpd scan done (${Date.now() - startMs}ms)`);
+					}
 				} else {
-					const startMs = Date.now();
-					const jscpdResult = jscpdClient.scan(analysisRoot);
 					if (!runtime.isCurrentSession(sessionGeneration)) return;
-					cacheManager.writeCache("jscpd", jscpdResult, analysisRoot, {
-						scanDurationMs: Date.now() - startMs,
-					});
-					dbg(`session_start jscpd scan done (${Date.now() - startMs}ms)`);
+					dbg("session_start jscpd: not available");
 				}
-			} else {
-				if (!runtime.isCurrentSession(sessionGeneration)) return;
-				dbg("session_start jscpd: not available");
-			}
-		});
+			});
 
-		// ast-grep — export scan for duplicate detection
-		runStartupTask("ast-grep-exports", async () => {
-			if (await astGrepClient.ensureAvailable()) {
-				if (!runtime.isCurrentSession(sessionGeneration)) return;
-				const exports = await astGrepClient.scanExports(
-					analysisRoot,
-					"typescript",
-				);
-				if (!runtime.isCurrentSession(sessionGeneration)) return;
-				dbg(`session_start exports scan: ${exports.size} functions found`);
-				for (const [name, file] of exports) {
-					runtime.cachedExports.set(name, file);
-				}
-			}
-		});
-
-		// Project index — structural similarity detection
-		runStartupTask("project-index", async () => {
-			const existing = await loadIndex(analysisRoot);
-			if (!runtime.isCurrentSession(sessionGeneration)) return;
-			if (
-				existing &&
-				existing.entries.size > 0 &&
-				(await isIndexFresh(analysisRoot))
-			) {
-				if (!runtime.isCurrentSession(sessionGeneration)) return;
-				runtime.cachedProjectIndex = existing;
-				dbg(
-					`session_start: loaded fresh project index (${existing.entries.size} entries)`,
-				);
-			} else {
-				const sourceFiles = getSourceFiles(analysisRoot, true);
-				const tsFiles = sourceFiles.filter(
-					(f) => f.endsWith(".ts") || f.endsWith(".tsx"),
-				);
-				if (tsFiles.length > 0 && tsFiles.length <= 500) {
-					runtime.cachedProjectIndex = await buildProjectIndex(
+			// ast-grep — export scan for duplicate detection
+			runStartupTask("ast-grep-exports", async () => {
+				if (await astGrepClient.ensureAvailable()) {
+					if (!runtime.isCurrentSession(sessionGeneration)) return;
+					const exports = await astGrepClient.scanExports(
 						analysisRoot,
-						tsFiles,
+						"typescript",
 					);
 					if (!runtime.isCurrentSession(sessionGeneration)) return;
-					await saveIndex(runtime.cachedProjectIndex, analysisRoot);
+					dbg(`session_start exports scan: ${exports.size} functions found`);
+					for (const [name, file] of exports) {
+						runtime.cachedExports.set(name, file);
+					}
+				}
+			});
+
+			// Project index — structural similarity detection
+			runStartupTask("project-index", async () => {
+				const existing = await loadIndex(analysisRoot);
+				if (!runtime.isCurrentSession(sessionGeneration)) return;
+				if (
+					existing &&
+					existing.entries.size > 0 &&
+					(await isIndexFresh(analysisRoot))
+				) {
+					if (!runtime.isCurrentSession(sessionGeneration)) return;
+					runtime.cachedProjectIndex = existing;
 					dbg(
-						`session_start: built project index (${runtime.cachedProjectIndex.entries.size} entries from ${tsFiles.length} files)`,
+						`session_start: loaded fresh project index (${existing.entries.size} entries)`,
 					);
 				} else {
-					if (!runtime.isCurrentSession(sessionGeneration)) return;
-					dbg(`session_start: skipped project index (${tsFiles.length} files)`);
+					const sourceFiles = getSourceFiles(analysisRoot, true);
+					const tsFiles = sourceFiles.filter(
+						(f) => f.endsWith(".ts") || f.endsWith(".tsx"),
+					);
+					if (tsFiles.length > 0 && tsFiles.length <= 500) {
+						runtime.cachedProjectIndex = await buildProjectIndex(
+							analysisRoot,
+							tsFiles,
+						);
+						if (!runtime.isCurrentSession(sessionGeneration)) return;
+						await saveIndex(runtime.cachedProjectIndex, analysisRoot);
+						dbg(
+							`session_start: built project index (${runtime.cachedProjectIndex.entries.size} entries from ${tsFiles.length} files)`,
+						);
+					} else {
+						if (!runtime.isCurrentSession(sessionGeneration)) return;
+						dbg(`session_start: skipped project index (${tsFiles.length} files)`);
+					}
 				}
-			}
-		});
+			});
+		}
 	}
 
 	dbg(

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -10,6 +10,10 @@ import { getKnipIgnorePatterns } from "./file-utils.js";
 import type { GoClient } from "./go-client.js";
 import type { JscpdClient } from "./jscpd-client.js";
 import type { KnipClient } from "./knip-client.js";
+import {
+	detectProjectLanguageProfile,
+	hasLanguage,
+} from "./language-profile.js";
 import type { MetricsClient } from "./metrics-client.js";
 import {
 	buildProjectIndex,
@@ -52,48 +56,6 @@ interface SessionStartDeps {
 	cleanStaleTsBuildInfo: (cwd: string) => string[];
 	resetDispatchBaselines: () => void;
 	resetLSPService: () => void;
-}
-
-const TS_JS_FILE_PATTERN = /\.(?:ts|tsx|cts|mts|js|jsx|cjs|mjs)$/i;
-const PYTHON_FILE_PATTERN = /\.(?:py|pyi)$/i;
-const TS_JS_MARKER_FILES = ["package.json", "tsconfig.json", "jsconfig.json"];
-
-interface ProjectLanguageProfile {
-	hasJsTs: boolean;
-	hasPython: boolean;
-}
-
-function detectProjectLanguageProfile(projectRoot: string): ProjectLanguageProfile {
-	const profile: ProjectLanguageProfile = {
-		hasJsTs: false,
-		hasPython: false,
-	};
-
-	for (const marker of TS_JS_MARKER_FILES) {
-		if (nodeFs.existsSync(path.join(projectRoot, marker))) {
-			profile.hasJsTs = true;
-			break;
-		}
-	}
-
-	let sourceFiles: string[] = [];
-	try {
-		sourceFiles = getSourceFiles(projectRoot, true);
-	} catch {
-		return profile;
-	}
-
-	for (const file of sourceFiles) {
-		if (!profile.hasJsTs && TS_JS_FILE_PATTERN.test(file)) {
-			profile.hasJsTs = true;
-		}
-		if (!profile.hasPython && PYTHON_FILE_PATTERN.test(file)) {
-			profile.hasPython = true;
-		}
-		if (profile.hasJsTs && profile.hasPython) break;
-	}
-
-	return profile;
 }
 
 export async function handleSessionStart(
@@ -181,14 +143,14 @@ export async function handleSessionStart(
 		`session_start scan root: ${scanRoot} (warmCaches=${startupScan.canWarmCaches}${startupScan.reason ? `, reason=${startupScan.reason}` : ""})`,
 	);
 	dbg(
-		`session_start language profile: js_ts=${languageProfile.hasJsTs}, python=${languageProfile.hasPython}`,
+		`session_start language profile: ${languageProfile.detectedKinds.join(", ") || "none"}`,
 	);
 	if (analysisRoot !== cwd) {
 		dbg(`session_start: monorepo analysis root override -> ${analysisRoot}`);
 	}
 
 	if (getFlag("lens-lsp") && !getFlag("no-lsp")) {
-		if (languageProfile.hasJsTs) {
+		if (hasLanguage(languageProfile, "jsts")) {
 			dbg("session_start: pre-installing TypeScript LSP...");
 			ensureTool("typescript-language-server")
 				.then((toolPath) => {
@@ -287,7 +249,7 @@ export async function handleSessionStart(
 		dbg(`session_start: skipping TODO scan (${startupScan.reason ?? "unknown"})`);
 	} else {
 		const scanNames = ["todo"];
-		if (languageProfile.hasJsTs) {
+		if (hasLanguage(languageProfile, "jsts")) {
 			scanNames.push("knip", "jscpd", "ast-grep exports", "project index");
 		}
 		dbg(
@@ -308,7 +270,7 @@ export async function handleSessionStart(
 			);
 		});
 
-		if (!languageProfile.hasJsTs) {
+		if (!hasLanguage(languageProfile, "jsts")) {
 			dbg("session_start: skipping JS/TS startup scans (no JS/TS files detected)");
 		} else {
 			// Knip — dead code / unused exports

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -54,6 +54,24 @@ interface SessionStartDeps {
 	resetLSPService: () => void;
 }
 
+const TS_JS_FILE_PATTERN = /\.(?:ts|tsx|cts|mts|js|jsx|cjs|mjs)$/i;
+const TS_JS_MARKER_FILES = ["package.json", "tsconfig.json", "jsconfig.json"];
+
+function shouldPreinstallTypeScriptLsp(projectRoot: string): boolean {
+	for (const marker of TS_JS_MARKER_FILES) {
+		if (nodeFs.existsSync(path.join(projectRoot, marker))) {
+			return true;
+		}
+	}
+
+	try {
+		const sourceFiles = getSourceFiles(projectRoot, true);
+		return sourceFiles.some((file) => TS_JS_FILE_PATTERN.test(file));
+	} catch {
+		return false;
+	}
+}
+
 export async function handleSessionStart(
 	deps: SessionStartDeps,
 ): Promise<void> {
@@ -128,21 +146,6 @@ export async function handleSessionStart(
 		}
 	}
 
-	if (getFlag("lens-lsp") && !getFlag("no-lsp")) {
-		dbg("session_start: pre-installing TypeScript LSP...");
-		ensureTool("typescript-language-server")
-			.then((toolPath) => {
-				if (toolPath) {
-					dbg(`session_start: TypeScript LSP ready at ${toolPath}`);
-				} else {
-					console.error("[lens] TypeScript LSP installation failed");
-				}
-			})
-			.catch((err) => {
-				console.error("[lens] TypeScript LSP pre-install error:", err);
-			});
-	}
-
 	const cwd = ctxCwd ?? process.cwd();
 	const startupScan = resolveStartupScanContext(cwd);
 	const scanRoot = startupScan.projectRoot ?? cwd;
@@ -154,6 +157,25 @@ export async function handleSessionStart(
 	);
 	if (analysisRoot !== cwd) {
 		dbg(`session_start: monorepo analysis root override -> ${analysisRoot}`);
+	}
+
+	if (getFlag("lens-lsp") && !getFlag("no-lsp")) {
+		if (shouldPreinstallTypeScriptLsp(analysisRoot)) {
+			dbg("session_start: pre-installing TypeScript LSP...");
+			ensureTool("typescript-language-server")
+				.then((toolPath) => {
+					if (toolPath) {
+						dbg(`session_start: TypeScript LSP ready at ${toolPath}`);
+					} else {
+						console.error("[lens] TypeScript LSP installation failed");
+					}
+				})
+				.catch((err) => {
+					console.error("[lens] TypeScript LSP pre-install error:", err);
+				});
+		} else {
+			dbg("session_start: skipping TypeScript LSP pre-install (no JS/TS markers)");
+		}
 	}
 
 	{

--- a/tests/clients/runtime-session.test.ts
+++ b/tests/clients/runtime-session.test.ts
@@ -7,6 +7,7 @@ describe("runtime-session notifications", () => {
 		const env = setupTestEnvironment("pi-lens-runtime-session-");
 		const notify = vi.fn();
 		const scanDirectory = vi.fn(() => ({ items: [] }));
+		const ensureTool = vi.fn(async () => null);
 
 		try {
 			await handleSessionStart({
@@ -64,7 +65,7 @@ describe("runtime-session notifications", () => {
 				},
 				goClient: { isGoAvailable: () => false },
 				rustClient: { isAvailable: () => false },
-				ensureTool: async () => null,
+				ensureTool,
 				cleanStaleTsBuildInfo: () => ["tsconfig.tsbuildinfo"],
 				resetDispatchBaselines: () => {},
 				resetLSPService: () => {},
@@ -84,6 +85,7 @@ describe("runtime-session notifications", () => {
 			);
 			expect(warningCalls.some(([msg]) => msg.includes("ERROR DEBT"))).toBe(true);
 			expect(scanDirectory).not.toHaveBeenCalled();
+			expect(ensureTool).not.toHaveBeenCalled();
 		} finally {
 			env.cleanup();
 		}


### PR DESCRIPTION
## Summary
- adds pip installer fallback chain for pip-based tools: tries pip, then py -m pip, then python -m pip on Windows (and equivalent fallbacks on Unix)
- updates installer to add discovered Python user scripts directories to process PATH after successful pip --user install
- handles Windows USER_BASE layouts where scripts are under ...\\Python\\PythonXY\\Scripts

## Why
On some Windows setups pip is not on PATH even when Python is installed (py -m pip works). Ruff auto-install failed in that environment and stayed unavailable for Python projects.
