### PR TITLE
feat: add language-specific no-config startup defaults

### DIFF
--- a/clients/language-profile.ts
+++ b/clients/language-profile.ts
@@ -40,10 +40,13 @@ const PROJECT_MARKERS_BY_KIND: Partial<Record<FileKind, readonly string[]>> = {
 	go: ["go.mod"],
 	rust: ["Cargo.toml"],
 	ruby: ["Gemfile", "Rakefile"],
+	yaml: [".yamllint", "yamllint.yaml", "yamllint.yml", "pyproject.toml"],
+	sql: [".sqlfluff", "pyproject.toml"],
 };
 
 export interface ProjectLanguageProfile {
 	present: Record<FileKind, boolean>;
+	configured: Partial<Record<FileKind, boolean>>;
 	counts: Partial<Record<FileKind, number>>;
 	detectedKinds: FileKind[];
 }
@@ -56,12 +59,14 @@ export function detectProjectLanguageProfile(
 		SUPPORTED_FILE_KINDS.map((kind) => [kind, false]),
 	) as Record<FileKind, boolean>;
 	const counts: Partial<Record<FileKind, number>> = {};
+	const configured: Partial<Record<FileKind, boolean>> = {};
 
 	for (const [kind, markers] of Object.entries(PROJECT_MARKERS_BY_KIND)) {
 		if (!markers) continue;
 		for (const marker of markers) {
 			if (fs.existsSync(path.join(projectRoot, marker))) {
 				present[kind as FileKind] = true;
+				configured[kind as FileKind] = true;
 				break;
 			}
 		}
@@ -87,6 +92,7 @@ export function detectProjectLanguageProfile(
 
 	return {
 		present,
+		configured,
 		counts,
 		detectedKinds,
 	};
@@ -104,4 +110,36 @@ export function hasAnyLanguage(
 	kinds: readonly FileKind[],
 ): boolean {
 	return kinds.some((kind) => hasLanguage(profile, kind));
+}
+
+export function isLanguageConfigured(
+	profile: ProjectLanguageProfile,
+	kind: FileKind,
+): boolean {
+	return !!profile.configured[kind];
+}
+
+export function getDefaultStartupTools(
+	profile: ProjectLanguageProfile,
+): string[] {
+	const tools = new Set<string>();
+
+	if (hasLanguage(profile, "jsts")) {
+		tools.add("typescript-language-server");
+	}
+
+	if (hasLanguage(profile, "python")) {
+		tools.add("pyright");
+		tools.add("ruff");
+	}
+
+	if (hasLanguage(profile, "yaml") && isLanguageConfigured(profile, "yaml")) {
+		tools.add("yamllint");
+	}
+
+	if (hasLanguage(profile, "sql") && isLanguageConfigured(profile, "sql")) {
+		tools.add("sqlfluff");
+	}
+
+	return [...tools];
 }

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -12,7 +12,9 @@ import type { JscpdClient } from "./jscpd-client.js";
 import type { KnipClient } from "./knip-client.js";
 import {
 	detectProjectLanguageProfile,
+	getDefaultStartupTools,
 	hasLanguage,
+	isLanguageConfigured,
 } from "./language-profile.js";
 import type { MetricsClient } from "./metrics-client.js";
 import {
@@ -149,23 +151,37 @@ export async function handleSessionStart(
 		dbg(`session_start: monorepo analysis root override -> ${analysisRoot}`);
 	}
 
-	if (getFlag("lens-lsp") && !getFlag("no-lsp")) {
-		if (hasLanguage(languageProfile, "jsts")) {
-			dbg("session_start: pre-installing TypeScript LSP...");
-			ensureTool("typescript-language-server")
+	const lensLspEnabled = !!getFlag("lens-lsp") && !getFlag("no-lsp");
+	const startupDefaults = getDefaultStartupTools(languageProfile).filter((tool) => {
+		if (
+			(tool === "typescript-language-server" || tool === "pyright") &&
+			!lensLspEnabled
+		) {
+			return false;
+		}
+		if (tool === "ruff" && getFlag("no-autofix-ruff")) {
+			return false;
+		}
+		return true;
+	});
+
+	if (startupDefaults.length > 0) {
+		dbg(`session_start: pre-install defaults -> ${startupDefaults.join(", ")}`);
+		for (const tool of startupDefaults) {
+			ensureTool(tool)
 				.then((toolPath) => {
 					if (toolPath) {
-						dbg(`session_start: TypeScript LSP ready at ${toolPath}`);
+						dbg(`session_start: ${tool} ready at ${toolPath}`);
 					} else {
-						console.error("[lens] TypeScript LSP installation failed");
+						dbg(`session_start: ${tool} installation unavailable`);
 					}
 				})
 				.catch((err) => {
-					console.error("[lens] TypeScript LSP pre-install error:", err);
+					dbg(`session_start: ${tool} pre-install error: ${err}`);
 				});
-		} else {
-			dbg("session_start: skipping TypeScript LSP pre-install (no JS/TS markers)");
 		}
+	} else {
+		dbg("session_start: no language defaults selected for pre-install");
 	}
 
 	{
@@ -248,8 +264,11 @@ export async function handleSessionStart(
 		);
 		dbg(`session_start: skipping TODO scan (${startupScan.reason ?? "unknown"})`);
 	} else {
+		const canRunJsTsHeavyScans =
+			hasLanguage(languageProfile, "jsts") &&
+			isLanguageConfigured(languageProfile, "jsts");
 		const scanNames = ["todo"];
-		if (hasLanguage(languageProfile, "jsts")) {
+		if (canRunJsTsHeavyScans) {
 			scanNames.push("knip", "jscpd", "ast-grep exports", "project index");
 		}
 		dbg(
@@ -270,8 +289,10 @@ export async function handleSessionStart(
 			);
 		});
 
-		if (!hasLanguage(languageProfile, "jsts")) {
-			dbg("session_start: skipping JS/TS startup scans (no JS/TS files detected)");
+		if (!canRunJsTsHeavyScans) {
+			dbg(
+				"session_start: skipping JS/TS startup scans (requires JS/TS language + project config)",
+			);
 		} else {
 			// Knip — dead code / unused exports
 			runStartupTask("knip", async () => {


### PR DESCRIPTION
## Summary
- adds centralized language-profile config signals and default startup tool selection per detected language
- applies language defaults during session_start (for example Python -> pyright/uff, JS/TS -> TypeScript LSP when enabled)
- gates heavy JS/TS startup scans behind both language detection and JS/TS project configuration

## Why
Projects without full config should still get sensible baseline tooling per language, while config-heavy scans remain gated to avoid noisy or expensive startup behavior.
