### PR TITLE
fix(runtime): harden startup and hook integrations

### DIFF
--- a/clients/dispatch/runners/similarity.ts
+++ b/clients/dispatch/runners/similarity.ts
@@ -9,8 +9,8 @@ import * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as ts from "typescript";
-import { EXCLUDED_DIRS } from "../../file-utils.js";
 import { NativeRustCoreClient } from "../../native-rust-client.js";
+import { collectSourceFiles } from "../../source-filter.js";
 import {
 	buildProjectIndex,
 	findSimilarFunctions,
@@ -512,24 +512,21 @@ async function loadOrBuildIndex(
 	}
 
 	// Build new index
-	const { glob } = await import("glob");
-	// Build ignore patterns from centralized EXCLUDED_DIRS
-	const ignorePatterns = [
-		...EXCLUDED_DIRS.map((d) => `**/${d}/**`),
-		"**/*.test.ts",
-		"**/*.spec.ts",
-		"**/*.poc.test.ts",
-	];
-	const files = await glob("**/*.ts", {
-		cwd: projectRoot,
-		ignore: ignorePatterns,
+	const absoluteFiles = collectSourceFiles(projectRoot, {
+		extensions: [".ts"],
+	}).filter((filePath) => {
+		const normalized = filePath.replace(/\\/g, "/");
+		return (
+			!normalized.endsWith(".test.ts") &&
+			!normalized.endsWith(".spec.ts") &&
+			!normalized.endsWith(".poc.test.ts")
+		);
 	});
 
-	if (files.length === 0) {
+	if (absoluteFiles.length === 0) {
 		return null;
 	}
 
-	const absoluteFiles = files.map((f) => path.join(projectRoot, f));
 	const index = await buildProjectIndex(projectRoot, absoluteFiles);
 
 	indexCache.set(projectRoot, index);

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -10,13 +10,13 @@ import { getKnipIgnorePatterns } from "./file-utils.js";
 import type { GoClient } from "./go-client.js";
 import type { JscpdClient } from "./jscpd-client.js";
 import type { KnipClient } from "./knip-client.js";
+import { canRunStartupHeavyScans } from "./language-policy.js";
 import {
 	detectProjectLanguageProfile,
 	getDefaultStartupTools,
 	hasLanguage,
 	isLanguageConfigured,
 } from "./language-profile.js";
-import { canRunStartupHeavyScans } from "./language-policy.js";
 import type { MetricsClient } from "./metrics-client.js";
 import {
 	buildProjectIndex,
@@ -64,7 +64,10 @@ interface SessionStartDeps {
 
 type StartupMode = "full" | "minimal" | "quick";
 
-function isCommandAvailable(command: string, args: string[] = ["--version"]): boolean {
+function isCommandAvailable(
+	command: string,
+	args: string[] = ["--version"],
+): boolean {
 	const result = safeSpawn(command, args, { timeout: 5000 });
 	return !result.error && result.status === 0;
 }
@@ -97,7 +100,9 @@ function getLanguageInstallHints(
 	};
 
 	if (hasStrongSignal("go") && !isCommandAvailable("gopls")) {
-		hints.push("Go detected: install gopls (`go install golang.org/x/tools/gopls@latest`).");
+		hints.push(
+			"Go detected: install gopls (`go install golang.org/x/tools/gopls@latest`).",
+		);
 	}
 	if (hasStrongSignal("rust") && !isCommandAvailable("rust-analyzer")) {
 		hints.push(
@@ -174,6 +179,25 @@ export async function handleSessionStart(
 		delete process.env.PI_LENS_DISABLE_LSP_INSTALL;
 	}
 
+	const hasWorkspaceCwd = typeof ctxCwd === "string" && ctxCwd.length > 0;
+	const cwd = ctxCwd ?? process.cwd();
+	if (quickMode) {
+		runtime.projectRoot = cwd;
+		const quickTools: string[] = [];
+		if (getFlag("lens-lsp") && !getFlag("no-lsp")) {
+			quickTools.push("LSP Service");
+		}
+		log(`Active tools: ${quickTools.join(", ")}`);
+		dbg(
+			`session_start tools: ${quickTools.join(", ") || "deferred (quick mode)"}`,
+		);
+		dbg(
+			"session_start: quick mode active - skipping slow tool probes, language profiling, preinstall, scans, and error debt baseline",
+		);
+		dbg(`session_start total: ${Date.now() - sessionStartMs}ms`);
+		return;
+	}
+
 	const tools: string[] = [];
 	if (getFlag("lens-lsp") && !getFlag("no-lsp")) {
 		tools.push("LSP Service");
@@ -198,17 +222,6 @@ export async function handleSessionStart(
 			);
 			dbg(`session_start: cleaned stale tsbuildinfo: ${cleaned.join(", ")}`);
 		}
-	}
-
-	const hasWorkspaceCwd = typeof ctxCwd === "string" && ctxCwd.length > 0;
-	const cwd = ctxCwd ?? process.cwd();
-	if (quickMode) {
-		runtime.projectRoot = cwd;
-		dbg(
-			"session_start: quick mode active - skipping language profiling, preinstall, scans, and error debt baseline",
-		);
-		dbg(`session_start total: ${Date.now() - sessionStartMs}ms`);
-		return;
 	}
 
 	const startupScan = resolveStartupScanContext(cwd);
@@ -236,18 +249,20 @@ export async function handleSessionStart(
 	}
 
 	const lensLspEnabled = !!getFlag("lens-lsp") && !getFlag("no-lsp");
-	const startupDefaults = getDefaultStartupTools(languageProfile).filter((tool) => {
-		if (
-			(tool === "typescript-language-server" || tool === "pyright") &&
-			!lensLspEnabled
-		) {
-			return false;
-		}
-		if (tool === "ruff" && getFlag("no-autofix-ruff")) {
-			return false;
-		}
-		return true;
-	});
+	const startupDefaults = getDefaultStartupTools(languageProfile).filter(
+		(tool) => {
+			if (
+				(tool === "typescript-language-server" || tool === "pyright") &&
+				!lensLspEnabled
+			) {
+				return false;
+			}
+			if (tool === "ruff" && getFlag("no-autofix-ruff")) {
+				return false;
+			}
+			return true;
+		},
+	);
 
 	if (!allowBootstrapTasks) {
 		dbg("session_start: skipping tool preinstall (startup mode)");
@@ -369,7 +384,9 @@ export async function handleSessionStart(
 		runtime.markStartupScanInFlight(name, sessionGeneration);
 		void task()
 			.then(() => {
-				dbg(`session_start task ${name}: success (${Date.now() - startedAt}ms)`);
+				dbg(
+					`session_start task ${name}: success (${Date.now() - startedAt}ms)`,
+				);
 			})
 			.catch((err) => {
 				dbg(`session_start: ${name} background scan failed: ${err}`);
@@ -391,7 +408,9 @@ export async function handleSessionStart(
 		dbg(
 			`session_start: skipping heavy scans (${startupScan.reason ?? "unknown"})`,
 		);
-		dbg(`session_start: skipping TODO scan (${startupScan.reason ?? "unknown"})`);
+		dbg(
+			`session_start: skipping TODO scan (${startupScan.reason ?? "unknown"})`,
+		);
 	} else {
 		const canRunJsTsHeavyScans = canRunStartupHeavyScans(
 			languageProfile,
@@ -401,9 +420,7 @@ export async function handleSessionStart(
 		if (canRunJsTsHeavyScans) {
 			scanNames.push("knip", "jscpd", "ast-grep exports", "project index");
 		}
-		dbg(
-			`session_start: launching background scans (${scanNames.join(", ")})`,
-		);
+		dbg(`session_start: launching background scans (${scanNames.join(", ")})`);
 
 		runStartupTask("todo", async () => {
 			if (!runtime.isCurrentSession(sessionGeneration)) return;
@@ -458,10 +475,9 @@ export async function handleSessionStart(
 			runStartupTask("jscpd", async () => {
 				if (await jscpdClient.ensureAvailable()) {
 					if (!runtime.isCurrentSession(sessionGeneration)) return;
-					const cached = cacheManager.readCache<ReturnType<JscpdClient["scan"]>>(
-						"jscpd",
-						analysisRoot,
-					);
+					const cached = cacheManager.readCache<
+						ReturnType<JscpdClient["scan"]>
+					>("jscpd", analysisRoot);
 					if (cached) {
 						if (!runtime.isCurrentSession(sessionGeneration)) return;
 						dbg("session_start jscpd: cache hit");
@@ -527,7 +543,9 @@ export async function handleSessionStart(
 						);
 					} else {
 						if (!runtime.isCurrentSession(sessionGeneration)) return;
-						dbg(`session_start: skipped project index (${tsFiles.length} files)`);
+						dbg(
+							`session_start: skipped project index (${tsFiles.length} files)`,
+						);
 					}
 				}
 			});

--- a/commands/booboo.ts
+++ b/commands/booboo.ts
@@ -369,33 +369,13 @@ export async function handleBooboo(
 	// Runner 3: Semantic similarity
 	await tracker.run("semantic similarity (Amain)", async () => {
 		try {
-			const { glob } = await import("glob");
-			const sourceFiles = await glob("**/*.ts", {
-				cwd: targetPath,
-				ignore: [
-					"**/node_modules/**",
-					"**/*.test.ts",
-					"**/*.test.tsx",
-					"**/*.spec.ts",
-					"**/*.spec.tsx",
-					"**/*.poc.test.ts",
-					"**/*.poc.test.tsx",
-					"**/test-utils.ts",
-					"**/test-*.ts",
-					"**/__tests__/**",
-					"**/tests/**",
-					"**/dist/**",
-				],
-			});
+			const absoluteFiles = collectSourceFiles(targetPath, {
+				extensions: [".ts"],
+			}).filter(shouldIncludeFile);
 
-			if (sourceFiles.length === 0) {
+			if (absoluteFiles.length === 0) {
 				return { findings: 0, status: "done" };
 			}
-
-			// Filter out test files using centralized exclusion
-			const absoluteFiles = sourceFiles
-				.map((f) => path.join(targetPath, f))
-				.filter(shouldIncludeFile);
 			const index = await buildProjectIndex(targetPath, absoluteFiles);
 			const topPairs = findTopSimilarPairs(index, 10);
 

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,6 @@ import {
 	getLatencyReports,
 	resetDispatchBaselines,
 } from "./clients/dispatch/integration.js";
-import { extractFunctions } from "./clients/dispatch/runners/similarity.js";
 import { resetFormatService } from "./clients/format-service.js";
 import { evaluateGitGuard, isGitCommitOrPushAttempt } from "./clients/git-guard.js";
 import { ensureTool } from "./clients/installer/index.js";
@@ -506,7 +505,8 @@ pi.on("session_start", async (event, ctx) => {
 			testRunnerClient,
 			goClient,
 			rustClient,
-			ensureTool,
+			ensureTool: async (name: string) =>
+				(await import("./clients/installer/index.js")).ensureTool(name),
 			cleanStaleTsBuildInfo,
 			resetDispatchBaselines,
 			resetLSPService,
@@ -594,6 +594,9 @@ pi.on("tool_call", async (event, ctx) => {
 		const baseline = complexityClient.analyzeFile(filePath);
 		if (baseline) {
 			runtime.complexityBaselines.set(filePath, baseline);
+			const { captureSnapshot } = await import(
+				"./clients/metrics-history.js"
+			);
 			captureSnapshot(filePath, {
 				maintainabilityIndex: baseline.maintainabilityIndex,
 				cognitiveComplexity: baseline.cognitiveComplexity,
@@ -659,6 +662,8 @@ pi.on("tool_call", async (event, ctx) => {
 						ts.ScriptTarget.Latest,
 						true,
 					);
+					const { extractFunctions } = await import("./clients/dispatch/runners/similarity.js");
+					const { findSimilarFunctions } = await import("./clients/project-index.js");
 					const newFunctions = extractFunctions(sourceFile, newContent);
 					const simWarnings: string[] = [];
 					let simHintsTruncated = false;

--- a/tests/clients/runtime-session.test.ts
+++ b/tests/clients/runtime-session.test.ts
@@ -1,87 +1,150 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { handleSessionStart } from "../../clients/runtime-session.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
+function setStartupMode(mode: "full" | "quick"): () => void {
+	const prev = process.env.PI_LENS_STARTUP_MODE;
+	process.env.PI_LENS_STARTUP_MODE = mode;
+	return () => {
+		if (prev === undefined) delete process.env.PI_LENS_STARTUP_MODE;
+		else process.env.PI_LENS_STARTUP_MODE = prev;
+	};
+}
+
+async function runSessionStart(mode: "full" | "quick") {
+	const env = setupTestEnvironment("pi-lens-runtime-session-");
+	const notify = vi.fn();
+	const scanDirectory = vi.fn(() => ({ items: [] }));
+	const ensureTool = vi.fn(async () => null);
+	const restoreStartupMode = setStartupMode(mode);
+
+	try {
+		await handleSessionStart({
+			ctxCwd: env.tmpDir,
+			getFlag: (name: string) => {
+				if (name === "lens-lsp") return true;
+				if (name === "no-lsp") return false;
+				if (name === "error-debt") return true;
+				return false;
+			},
+			notify,
+			dbg: () => {},
+			log: () => {},
+			runtime: {
+				sessionGeneration: 1,
+				isCurrentSession: () => true,
+				markStartupScanInFlight: () => {},
+				clearStartupScanInFlight: () => {},
+				complexityBaselines: new Map(),
+				resetForSession: () => {},
+				projectRoot: "",
+				projectRulesScan: { hasCustomRules: false, rules: [] },
+				cachedExports: new Map(),
+				cachedProjectIndex: null,
+				errorDebtBaseline: { testsPassed: true, buildPassed: true },
+			},
+			metricsClient: { reset: () => {} },
+			cacheManager: {
+				writeCache: () => {},
+				readCache: (key: string) => {
+					if (key === "errorDebt") {
+						return {
+							data: { pendingCheck: true, baselineTestsPassed: true },
+						};
+					}
+					return null;
+				},
+			},
+			todoScanner: { scanDirectory },
+			astGrepClient: {
+				isAvailable: () => false,
+				ensureAvailable: async () => false,
+				scanExports: async () => new Map(),
+			},
+			biomeClient: { isAvailable: () => false },
+			ruffClient: { isAvailable: () => false },
+			knipClient: {
+				isAvailable: () => false,
+				ensureAvailable: async () => false,
+			},
+			jscpdClient: {
+				isAvailable: () => false,
+				ensureAvailable: async () => false,
+			},
+			typeCoverageClient: { isAvailable: () => false },
+			depChecker: { isAvailable: () => false },
+			architectClient: { loadConfig: () => false },
+			testRunnerClient: {
+				detectRunner: () => ({ runner: "vitest", config: null }),
+				runTestFile: () => ({ failed: 1, error: false }),
+			},
+			goClient: { isGoAvailable: () => false },
+			rustClient: { isAvailable: () => false },
+			ensureTool,
+			cleanStaleTsBuildInfo: () => ["tsconfig.tsbuildinfo"],
+			resetDispatchBaselines: () => {},
+			resetLSPService: () => {},
+		} as any);
+
+		return { env, notify, scanDirectory, ensureTool };
+	} catch (error) {
+		env.cleanup();
+		throw error;
+	} finally {
+		restoreStartupMode();
+	}
+}
+
+afterEach(() => {
+	delete process.env.PI_LENS_STARTUP_MODE;
+});
+
 describe("runtime-session notifications", () => {
-	it("emits one compact startup info note and keeps critical warnings separate", async () => {
-		const env = setupTestEnvironment("pi-lens-runtime-session-");
-		const notify = vi.fn();
-		const scanDirectory = vi.fn(() => ({ items: [] }));
-		const ensureTool = vi.fn(async () => null);
+	it("full mode emits build-cache and error-debt warnings while avoiding startup info noise", async () => {
+		const { env, notify, scanDirectory, ensureTool } =
+			await runSessionStart("full");
 
 		try {
-			await handleSessionStart({
-				ctxCwd: env.tmpDir,
-				getFlag: (name: string) => {
-					if (name === "lens-lsp") return true;
-					if (name === "no-lsp") return false;
-					if (name === "error-debt") return true;
-					return false;
-				},
-				notify,
-				dbg: () => {},
-				log: () => {},
-				runtime: {
-					sessionGeneration: 1,
-					isCurrentSession: () => true,
-					markStartupScanInFlight: () => {},
-					clearStartupScanInFlight: () => {},
-					complexityBaselines: new Map(),
-					resetForSession: () => {},
-					projectRoot: "",
-					projectRulesScan: { hasCustomRules: false, rules: [] },
-					cachedExports: new Map(),
-					cachedProjectIndex: null,
-					errorDebtBaseline: { testsPassed: true, buildPassed: true },
-				},
-				metricsClient: { reset: () => {} },
-				cacheManager: {
-					writeCache: () => {},
-					readCache: (key: string) => {
-						if (key === "errorDebt") {
-							return {
-								data: { pendingCheck: true, baselineTestsPassed: true },
-							};
-						}
-						return null;
-					},
-				},
-				todoScanner: { scanDirectory },
-				astGrepClient: {
-					isAvailable: () => false,
-					ensureAvailable: async () => false,
-					scanExports: async () => new Map(),
-				},
-				biomeClient: { isAvailable: () => false },
-				ruffClient: { isAvailable: () => false },
-				knipClient: { isAvailable: () => false, ensureAvailable: async () => false },
-				jscpdClient: { isAvailable: () => false, ensureAvailable: async () => false },
-				typeCoverageClient: { isAvailable: () => false },
-				depChecker: { isAvailable: () => false },
-				architectClient: { loadConfig: () => false },
-				testRunnerClient: {
-					detectRunner: () => ({ runner: "vitest", config: null }),
-					runTestFile: () => ({ failed: 1, error: false }),
-				},
-				goClient: { isGoAvailable: () => false },
-				rustClient: { isAvailable: () => false },
-				ensureTool,
-				cleanStaleTsBuildInfo: () => ["tsconfig.tsbuildinfo"],
-				resetDispatchBaselines: () => {},
-				resetLSPService: () => {},
-			} as any);
-
-			const infoCalls = notify.mock.calls.filter(([, level]) => level === "info");
+			const infoCalls = notify.mock.calls.filter(
+				([, level]) => level === "info",
+			);
 			const warningCalls = notify.mock.calls.filter(
 				([, level]) => level === "warning",
 			);
 
 			expect(infoCalls).toHaveLength(0);
-
-			expect(warningCalls.some(([msg]) => msg.includes("TypeScript build cache"))).toBe(
+			expect(
+				warningCalls.some(([msg]) => msg.includes("TypeScript build cache")),
+			).toBe(true);
+			expect(warningCalls.some(([msg]) => msg.includes("ERROR DEBT"))).toBe(
 				true,
 			);
-			expect(warningCalls.some(([msg]) => msg.includes("ERROR DEBT"))).toBe(true);
+			expect(scanDirectory).not.toHaveBeenCalled();
+			expect(ensureTool).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("quick mode skips build-cache cleanup and error-debt checks", async () => {
+		const { env, notify, scanDirectory, ensureTool } =
+			await runSessionStart("quick");
+
+		try {
+			const infoCalls = notify.mock.calls.filter(
+				([, level]) => level === "info",
+			);
+			const warningCalls = notify.mock.calls.filter(
+				([, level]) => level === "warning",
+			);
+
+			expect(infoCalls).toHaveLength(0);
+			expect(
+				warningCalls.some(([msg]) => msg.includes("TypeScript build cache")),
+			).toBe(false);
+			expect(warningCalls.some(([msg]) => msg.includes("ERROR DEBT"))).toBe(
+				false,
+			);
 			expect(scanDirectory).not.toHaveBeenCalled();
 			expect(ensureTool).not.toHaveBeenCalled();
 		} finally {

--- a/tests/index-integration.test.ts
+++ b/tests/index-integration.test.ts
@@ -1,0 +1,390 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type Handler = (event: any, ctx: any) => unknown;
+
+interface MockPi {
+	registerTool: ReturnType<typeof vi.fn>;
+	registerCommand: ReturnType<typeof vi.fn>;
+	registerFlag: ReturnType<typeof vi.fn>;
+	on: ReturnType<typeof vi.fn>;
+	getFlag: ReturnType<typeof vi.fn>;
+}
+
+function createMockPi(flagOverrides: Record<string, boolean> = {}): {
+	pi: MockPi;
+	handlers: Record<string, Handler[]>;
+	commands: Map<string, { handler?: Handler; description?: string }>;
+} {
+	const handlers: Record<string, Handler[]> = {};
+	const commands = new Map<
+		string,
+		{ handler?: Handler; description?: string }
+	>();
+	const flags = new Map<string, boolean>([
+		["lens-lsp", true],
+		["no-lsp", false],
+		["lens-guard", false],
+		...Object.entries(flagOverrides),
+	]);
+
+	const pi: MockPi = {
+		registerTool: vi.fn(),
+		registerCommand: vi.fn(
+			(name: string, config: { handler?: Handler; description?: string }) => {
+				commands.set(name, config);
+			},
+		),
+		registerFlag: vi.fn((name: string, config: { default?: boolean }) => {
+			if (!flags.has(name) && typeof config?.default === "boolean") {
+				flags.set(name, config.default);
+			}
+		}),
+		on: vi.fn((event: string, handler: Handler) => {
+			(handlers[event] ??= []).push(handler);
+		}),
+		getFlag: vi.fn((name: string) => flags.get(name) ?? false),
+	};
+
+	return { pi, handlers, commands };
+}
+
+describe("index.ts integration", () => {
+	let tmpDir: string;
+	let originalStartupMode: string | undefined;
+
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-index-int-"));
+		originalStartupMode = process.env.PI_LENS_STARTUP_MODE;
+		process.env.PI_LENS_STARTUP_MODE = "quick";
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+		if (originalStartupMode === undefined)
+			delete process.env.PI_LENS_STARTUP_MODE;
+		else process.env.PI_LENS_STARTUP_MODE = originalStartupMode;
+		vi.restoreAllMocks();
+	});
+
+	it("session_start handler passes working ensureTool closure into handleSessionStart", async () => {
+		const ensureToolMock = vi.fn(async (name: string) => `/mock/${name}`);
+		const handleSessionStartMock = vi.fn(
+			async (deps: {
+				ensureTool: (name: string) => Promise<string | undefined>;
+			}) => {
+				await expect(
+					deps.ensureTool("typescript-language-server"),
+				).resolves.toBe("/mock/typescript-language-server");
+			},
+		);
+
+		vi.doMock("../clients/bootstrap.js", () => ({
+			loadBootstrapClients: async () => ({
+				metricsClient: { reset: () => {} },
+				todoScanner: {},
+				biomeClient: { isAvailable: () => false },
+				ruffClient: { isAvailable: () => false },
+				knipClient: { isAvailable: () => false },
+				jscpdClient: { isAvailable: () => false },
+				typeCoverageClient: { isAvailable: () => false },
+				depChecker: { isAvailable: () => false },
+				architectClient: { loadConfig: () => false },
+				testRunnerClient: { detectRunner: () => null },
+				goClient: { isGoAvailable: () => false },
+				rustClient: { isAvailable: () => false },
+				agentBehaviorClient: {
+					recordToolCall: () => {},
+					formatWarnings: () => "",
+				},
+				complexityClient: {
+					isSupportedFile: () => false,
+					analyzeFile: () => null,
+				},
+			}),
+		}));
+		vi.doMock("../clients/runtime-session.js", () => ({
+			handleSessionStart: handleSessionStartMock,
+		}));
+		vi.doMock("../clients/installer/index.js", () => ({
+			ensureTool: ensureToolMock,
+		}));
+
+		const { default: registerExtension } = await import("../index.ts");
+		const { pi, handlers } = createMockPi();
+		registerExtension(pi as any);
+
+		const sessionStart = handlers.session_start?.[0];
+		expect(sessionStart).toBeTypeOf("function");
+
+		await sessionStart?.({}, { cwd: tmpDir, ui: { notify: vi.fn() } });
+
+		expect(handleSessionStartMock).toHaveBeenCalledTimes(1);
+		expect(ensureToolMock).toHaveBeenCalledWith("typescript-language-server");
+	}, 15_000);
+
+	it("tool_call handler executes captureSnapshot and similarity paths without crashing", async () => {
+		const captureSnapshotMock = vi.fn();
+		const touchFileMock = vi.fn().mockResolvedValue(undefined);
+		const sourceFile = path.join(tmpDir, "src", "feature.ts");
+		const similarTarget = path.join(tmpDir, "src", "existing.ts");
+		fs.mkdirSync(path.dirname(sourceFile), { recursive: true });
+		fs.writeFileSync(
+			sourceFile,
+			"export function freshFeature() { return 1; }\n",
+		);
+		fs.writeFileSync(
+			similarTarget,
+			"export function oldFeature() { return 2; }\n",
+		);
+
+		vi.doMock("../clients/bootstrap.js", () => ({
+			loadBootstrapClients: async () => ({
+				metricsClient: { reset: () => {} },
+				todoScanner: {},
+				biomeClient: { isAvailable: () => false },
+				ruffClient: { isAvailable: () => false },
+				knipClient: { isAvailable: () => false },
+				jscpdClient: { isAvailable: () => false },
+				typeCoverageClient: { isAvailable: () => false },
+				depChecker: { isAvailable: () => false },
+				architectClient: { loadConfig: () => false },
+				testRunnerClient: { detectRunner: () => null },
+				goClient: { isGoAvailable: () => false },
+				rustClient: { isAvailable: () => false },
+				agentBehaviorClient: {
+					recordToolCall: () => {},
+					formatWarnings: () => "",
+				},
+				complexityClient: {
+					isSupportedFile: () => true,
+					analyzeFile: () => ({
+						maintainabilityIndex: 88,
+						cognitiveComplexity: 3,
+						maxNestingDepth: 1,
+						linesOfCode: 10,
+						maxCyclomaticComplexity: 2,
+						codeEntropy: 1.2,
+					}),
+				},
+			}),
+		}));
+		vi.doMock("../clients/runtime-session.js", () => ({
+			handleSessionStart: async (deps: any) => {
+				deps.runtime.projectRoot = tmpDir;
+				deps.runtime.cachedExports.set("otherExport", similarTarget);
+				deps.runtime.cachedProjectIndex = {
+					entries: new Map([["existing", { id: "existing" }]]),
+				};
+			},
+		}));
+		vi.doMock("../clients/metrics-history.js", () => ({
+			captureSnapshot: captureSnapshotMock,
+		}));
+		vi.doMock("../clients/lsp/index.js", async () => {
+			const actual = await vi.importActual<
+				typeof import("../clients/lsp/index.js")
+			>("../clients/lsp/index.js");
+			return {
+				...actual,
+				getLSPService: () => ({ touchFile: touchFileMock }),
+			};
+		});
+		vi.doMock("../clients/dispatch/runners/similarity.js", async () => {
+			const actual = await vi.importActual<
+				typeof import("../clients/dispatch/runners/similarity.js")
+			>("../clients/dispatch/runners/similarity.js");
+			const ts = await import("typescript");
+			return {
+				...actual,
+				extractFunctions: () => [
+					{
+						name: "freshFeature",
+						transitionCount: 42,
+						matrix: [[1]],
+						kind: ts.SyntaxKind.FunctionDeclaration,
+					},
+				],
+			};
+		});
+		vi.doMock("../clients/project-index.js", async () => {
+			const actual = await vi.importActual<
+				typeof import("../clients/project-index.js")
+			>("../clients/project-index.js");
+			return {
+				...actual,
+				findSimilarFunctions: () => [
+					{
+						targetId: `src/existing.ts:oldFeature`,
+						targetName: "oldFeature",
+						targetLocation: similarTarget + ":1",
+						similarity: 0.95,
+						signature: "() => number",
+						targetTransitionCount: 42,
+					},
+				],
+			};
+		});
+
+		const { default: registerExtension } = await import("../index.ts");
+		const { pi, handlers } = createMockPi({
+			"lens-lsp": true,
+			"no-lsp": false,
+		});
+		registerExtension(pi as any);
+
+		const notify = vi.fn();
+		await handlers.session_start?.[0]?.({}, { cwd: tmpDir, ui: { notify } });
+
+		const toolCall = handlers.tool_call?.[0];
+		expect(toolCall).toBeTypeOf("function");
+
+		const result = await toolCall?.(
+			{
+				toolName: "write",
+				input: {
+					path: sourceFile,
+					content: "export function freshFeature() { return 1; }\n",
+				},
+			},
+			{ cwd: tmpDir },
+		);
+
+		expect(captureSnapshotMock).toHaveBeenCalledTimes(1);
+		expect(captureSnapshotMock).toHaveBeenCalledWith(
+			sourceFile,
+			expect.objectContaining({
+				maintainabilityIndex: 88,
+				cognitiveComplexity: 3,
+				maxNestingDepth: 1,
+				linesOfCode: 10,
+				maxCyclomatic: 2,
+				entropy: 1.2,
+			}),
+		);
+		expect(touchFileMock).toHaveBeenCalled();
+		expect(result).toEqual(
+			expect.objectContaining({
+				block: false,
+				reason: expect.stringContaining("Potential structural similarity"),
+			}),
+		);
+	}, 15_000);
+
+	it("lens-health command reports crash, latency, diagnostics, and slop telemetry", async () => {
+		vi.doMock("../clients/runtime-coordinator.js", () => ({
+			RuntimeCoordinator: class {
+				projectRoot = tmpDir;
+				getCrashEntries() {
+					return [[path.join(tmpDir, "src", "boom.ts"), 3]];
+				}
+				beginTurn() {}
+				resetForSession() {}
+				complexityBaselines = new Map();
+				projectRulesScan = { hasCustomRules: false, rules: [] };
+				cachedExports = new Map();
+				cachedProjectIndex = null;
+				errorDebtBaseline = null;
+			},
+		}));
+		vi.doMock("../clients/dispatch/integration.js", async () => ({
+			getDispatchSlopScoreLine: () => "Slop score: 12/100",
+			getLatencyReports: () => [
+				{
+					filePath: path.join(tmpDir, "src", "boom.ts"),
+					totalDurationMs: 321,
+					totalDiagnostics: 4,
+					runners: [
+						{ runnerId: "lsp", durationMs: 200, status: "failed" },
+						{ runnerId: "tree-sitter", durationMs: 90, status: "succeeded" },
+						{ runnerId: "eslint", durationMs: 31, status: "succeeded" },
+					],
+				},
+			],
+			resetDispatchBaselines: () => {},
+		}));
+		vi.doMock("../clients/diagnostic-tracker.js", async () => ({
+			getDiagnosticTracker: () => ({
+				reset: () => {},
+				getStats: () => ({
+					totalShown: 8,
+					totalAutoFixed: 2,
+					totalAgentFixed: 1,
+					totalUnresolved: 5,
+					repeatOffenders: [
+						{
+							filePath: path.join(tmpDir, "src", "boom.ts"),
+							line: 7,
+							ruleId: "no-debugger",
+							count: 3,
+						},
+					],
+					topViolations: [
+						{
+							ruleId: "no-console",
+							count: 6,
+							samplePaths: [path.join(tmpDir, "src", "boom.ts")],
+						},
+					],
+				}),
+			}),
+		}));
+		vi.doMock("../clients/bootstrap.js", () => ({
+			loadBootstrapClients: async () => ({
+				metricsClient: { reset: () => {} },
+				todoScanner: {},
+				biomeClient: { isAvailable: () => false },
+				ruffClient: { isAvailable: () => false },
+				knipClient: { isAvailable: () => false },
+				jscpdClient: { isAvailable: () => false },
+				typeCoverageClient: { isAvailable: () => false },
+				depChecker: { isAvailable: () => false },
+				architectClient: { loadConfig: () => false },
+				testRunnerClient: { detectRunner: () => null },
+				goClient: { isGoAvailable: () => false },
+				rustClient: { isAvailable: () => false },
+				agentBehaviorClient: {
+					recordToolCall: () => {},
+					formatWarnings: () => "",
+				},
+				complexityClient: {
+					isSupportedFile: () => false,
+					analyzeFile: () => null,
+				},
+			}),
+		}));
+
+		const { default: registerExtension } = await import("../index.ts");
+		const { pi, commands } = createMockPi();
+		registerExtension(pi as any);
+
+		const notify = vi.fn();
+		const lensHealth = commands.get("lens-health");
+		expect(lensHealth?.handler).toBeTypeOf("function");
+
+		await lensHealth?.handler?.({}, { ui: { notify } });
+
+		expect(notify).toHaveBeenCalledTimes(1);
+		const [message, level] = notify.mock.calls[0];
+		expect(level).toBe("info");
+		expect(message).toContain("🩺 PI-LENS HEALTH");
+		expect(message).toContain("Pipeline crashes (session): 3");
+		expect(message).toContain("Top crash files:");
+		expect(message).toContain("boom.ts: 3");
+		expect(message).toContain("Last dispatch: boom.ts (321ms, 4 diagnostics)");
+		expect(message).toContain("lsp: 200ms (failed)");
+		expect(message).toContain("Diagnostics shown: 8");
+		expect(message).toContain("Auto-fixed: 2");
+		expect(message).toContain("Agent-fixed: 1");
+		expect(message).toContain("Unresolved carryover: 5");
+		expect(message).toContain("Repeat offenders:");
+		expect(message).toContain("boom.ts:7 no-debugger (3x)");
+		expect(message).toContain("Top noisy rules:");
+		expect(message).toContain("no-console: 6 (e.g. src/boom.ts)");
+		expect(message).toContain("Slop score: 12/100");
+	}, 15_000);
+});


### PR DESCRIPTION
## Summary
- preserve lazy startup behavior by deferring `ensureTool`, `captureSnapshot`, and similarity helpers in `index.ts`
- restore quick startup by short-circuiting `runtime-session` before slow tool availability probes
- replace `glob`-based TS source discovery with shared `collectSourceFiles()` in similarity paths
- add regression coverage for full vs quick startup, real `index.ts` session/tool hooks, and `/lens-health` output

## Validation
- npm run build -- --noEmit
- npm test