### PR TITLE
fix(lsp): eliminate stale diagnostics race condition

### DIFF
--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -469,6 +469,9 @@ async function handleNotifyOpen(
 	if (state.openDocuments.has(normalizedPath)) {
 		const version = (state.documentVersions.get(normalizedPath) ?? 0) + 1;
 		state.documentVersions.set(normalizedPath, version);
+		// Clear cached diagnostics so waitForDiagnostics actually waits for
+		// fresh results from the server instead of returning stale ones.
+		state.diagnostics.delete(normalizedPath);
 		await safeSendNotification(state.connection, "textDocument/didChange", {
 			textDocument: { uri, version },
 			contentChanges: [{ text: content }],
@@ -516,6 +519,9 @@ async function handleNotifyChange(
 
 	const version = (state.documentVersions.get(normalizedPath) ?? 0) + 1;
 	state.documentVersions.set(normalizedPath, version);
+	// Clear cached diagnostics so waitForDiagnostics actually waits for
+	// fresh results from the server instead of returning stale ones.
+	state.diagnostics.delete(normalizedPath);
 	await safeSendNotification(state.connection, "textDocument/didChange", {
 		textDocument: { uri, version },
 		contentChanges: [{ text: content }],

--- a/index.ts
+++ b/index.ts
@@ -571,10 +571,13 @@ pi.on("tool_call", async (event, ctx) => {
 	);
 	if (!nodeFs.existsSync(filePath)) return;
 
+	// Only pre-touch LSP for read and lsp_navigation — these need the server
+	// warmed up before the tool executes.  Do NOT pre-touch for write/edit:
+	// the file hasn't been modified yet, so we'd send stale content to the LS
+	// which caches stale diagnostics that the pipeline then returns immediately.
+	// The pipeline's own syncLspFile step handles write/edit with correct content.
 	const shouldAutoTouch =
 		(toolName === "read" ||
-			toolName === "write" ||
-			toolName === "edit" ||
 			toolName === "lsp_navigation") &&
 		!!pi.getFlag("lens-lsp") &&
 		!pi.getFlag("no-lsp");


### PR DESCRIPTION
## Problem

Agents frequently encounter stale LSP diagnostics — errors that don't actually exist anymore. This manifests as internal reasoning like "ahh, that was stale LSP errors..." and wastes turns fixing phantom issues.

## Root Causes

### 1. `didChange` never clears cached diagnostics

`handleNotifyOpen` correctly clears `state.diagnostics` when first opening a file (`didOpen`), but the re-open path (`didChange`, the common case for subsequent edits) does not:

```
Line 480 (didOpen):    state.diagnostics.delete(normalizedPath)   ← ✅ clears
Line 470 (didChange):  [nothing]                                   ← ❌ stale!
```

This means `waitForDiagnostics` checks `state.diagnostics.has(normalizedPath)`, finds the old cached diagnostics, and **returns immediately** without waiting for the server to finish processing the new content.

Same issue exists in `handleNotifyChange`.

### 2. `tool_call` pre-touches LSP with OLD content for write/edit

The `tool_call` handler fires **before** the tool executes:

```typescript
const fileContent = nodeFs.readFileSync(filePath, 'utf-8');  // reads OLD content
void getLSPService().touchFile(filePath, fileContent, ...);   // fire-and-forget
```

For `write`/`edit`, this sends stale content to the LS, which processes it and caches stale diagnostics. The pipeline then finds these cached diagnostics and returns them immediately.

Pre-touching is correct for `read` and `lsp_navigation` (warms the server before navigation), but counterproductive for `write`/`edit` — the pipeline's `syncLspFile` step already handles touching with correct post-write content.

## Fix

1. **`client.ts`**: Clear `state.diagnostics.delete(normalizedPath)` before sending `didChange` in both `handleNotifyOpen` (re-open path) and `handleNotifyChange`. Forces `waitForDiagnostics` to actually wait for fresh `publishDiagnostics` from the server.

2. **`index.ts`**: Remove `write` and `edit` from the `shouldAutoTouch` condition in the `tool_call` handler. Only pre-touch for `read` and `lsp_navigation`.

## Impact

- Eliminates the primary source of stale diagnostics that confuse the agent
- No timeout changes needed — the fix is architectural, not timing-dependent
- May also improve #16 (blocking diagnostics timing-dependent visibility)

## Changes

- `clients/lsp/client.ts`: +3 lines (diagnostics.delete before didChange, two locations)
- `index.ts`: +5/-2 lines (restrict pre-touch to read/lsp_navigation + comment)