### PR TITLE
Escape function names in review-graph regex to prevent pipeline crash

### DIFF
--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -47,6 +47,10 @@ function makeCtx(
 	};
 }
 
+function escapeRegExp(string: string): string {
+	return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function createEmptyGraph(): ReviewGraph {
 	return {
 		version: REVIEW_GRAPH_VERSION,
@@ -220,7 +224,7 @@ function addJsTsFile(
 			symbolName: fn.name,
 			symbolKind: "function",
 			exported: new RegExp(
-				String.raw`export\s+(?:async\s+)?(?:function|const|let|var)\s+${fn.name}\b`,
+				String.raw`export\s+(?:async\s+)?(?:function|const|let|var)\s+${escapeRegExp(fn.name)}\b`,
 			).test(content),
 			metadata: {
 				line: fn.line,


### PR DESCRIPTION
## Problem

When pi-lens analyzes non-JavaScript files (e.g. Markdown with code blocks or embedded iframes), the tree-sitter symbol extractor can emit function names that contain regex metacharacters such as brackets, parentheses, or dollar signs.

These names are interpolated directly into a `new RegExp()` pattern inside `clients/review-graph/builder.ts`:

```ts
new RegExp(
  String.raw`export\s+(?:async\s+)?(?:function|const|let|var)\s+${fn.name}\b`,
).test(content)
```

If `fn.name` contains something like `[(_r=new WeakMap,Da=new WeakMap...]`, the resulting regex is invalid and throws a `SyntaxError`. This crashes the entire pi-lens pipeline, breaking linting / formatting for every subsequent file in the session.

## Fix

Add a small `escapeRegExp` helper (standard character-class escaping) and wrap `fn.name` before inserting it into the pattern.

## Impact

- Prevents pi-lens from crashing on Markdown, JSON, YAML, or any other file kind where extracted symbols may contain special characters.
- No functional change for regular JS/TS identifiers.