### PR TITLE
docs: document PILENS_DATA_DIR env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ pi --no-delta             # Disable delta mode (show all diagnostics, not just n
 pi --lens-guard           # Block git commit/push when unresolved blockers exist (experimental)
 ```
 
+## Environment Variables
+
+- `PILENS_DATA_DIR` — redirect per-project state (scanner caches,
+  turn-state.json) out of the project directory. By default pi-lens writes
+  `<cwd>/.pi-lens/`; if set, it writes to
+  `<PILENS_DATA_DIR>/<sanitized-cwd-slug>/` instead. Useful for keeping repos
+  clean or for mounted/ephemeral setups. Tool binaries always live in
+  `~/.pi-lens/bin/` regardless.
+- `PI_LENS_STARTUP_MODE` — `full` | `minimal` | `quick`. Override the
+  auto-selected startup path. One-shot `pi --print` sessions auto-use `quick`
+  to reduce latency.
+
 ## Key Commands
 
 - `/lens-booboo` — full quality report for current project state


### PR DESCRIPTION
Closes #38.

## What

Adds an **Environment Variables** section to the README, placed between `## Run` and `## Key Commands`, documenting:

- `PILENS_DATA_DIR` — previously only documented in the `getProjectDataDir` docstring in `clients/file-utils.ts`
- `PI_LENS_STARTUP_MODE` — already mentioned inline in the Session Start subsection; duplicated here for discoverability

## Why

Users setting up mounted or ephemeral environments (containers, CI, worktree setups) need to know about `PILENS_DATA_DIR` to keep repos clean. It's a real contract — verified in `clients/file-utils.ts → getProjectDataDir()` — just wasn't surfaced in the README.

## Scope

Purely additive. One file changed (`README.md`), one commit, no code changes.

## Other env vars found (not included in this PR)

While grepping the source, I found several additional `process.env` reads that are not yet documented in the README. Listing them here for awareness — out of scope for this PR:

- `PI_LENS_AUTO_INSTALL`
- `PI_LENS_DEBUG`
- `PI_LENS_DISABLE_LSP_INSTALL`
- `PI_LENS_LOG_RETENTION_DAYS`
- `PI_LENS_LSP_DIAGNOSTICS_AGGREGATE_WAIT_MS`
- `PI_LENS_LSP_DIAGNOSTICS_SEMANTIC_SETTLE_MS`
- `PI_LENS_LSP_DIAGNOSTICS_SEMANTIC_THRESHOLD_MS`
- `PI_LENS_LSP_EARLY_UNBLOCK_GRACE_MS`
- `PI_LENS_LSP_NAV_CLIENT_WAIT_MS`
- `PI_LENS_LSP_TOUCH_DEBOUNCE_MS`
- `PI_LENS_MAX_LOG_SIZE_MB`
- `PI_LENS_TEST_MODE`
- `PI_LENS_TOOLCALL_NAV_TOUCH_MS`
- `PI_LENS_TOOLCALL_TOUCH_MS`

Happy to open a follow-up PR for those if useful.