### PR TITLE
Refactor tsconfig fix type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: TypeScript type-check
-        run: npx tsc --noEmit
-
-      - name: TypeScript dead-code check
-        run: npx tsc --noUnusedLocals --noUnusedParameters --noEmit
+      - name: TypeScript lint
+        run: npm run lint
 
   test:
     name: Unit tests

--- a/clients/dispatch/types.ts
+++ b/clients/dispatch/types.ts
@@ -21,7 +21,9 @@ export type DefectClass =
 	| "correctness"
 	| "safety"
 	| "style"
-	| "unknown";
+	| "unknown"
+	| "unused-value"
+	;
 
 export interface ModifiedRange {
 	start: number;
@@ -68,6 +70,8 @@ export interface Diagnostic {
 	semantic: OutputSemantic;
 	/** Which tool produced this */
 	tool: string;
+	/** A tool-specific code for this diagnostic */
+	code?: string;
 	/** Rule/category */
 	rule?: string;
 	/** Normalized defect class for overlap arbitration */

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -1957,13 +1957,25 @@ export function isKnownToolId(toolId: string): boolean {
 	return TOOLS.some((tool) => tool.id === toolId);
 }
 
+export const GITHUB_TOOLS = [
+	"shellcheck",
+	"shfmt",
+	"rust-analyzer",
+	"golangci-lint",
+	"ktlint",
+	"tflint",
+	"terraform-ls",
+	"zls",
+] as const;
+export type GitHubToolId = (typeof GITHUB_TOOLS)[number];
+
 /**
  * Resolve the GitHub asset filename substring for a tool on a given platform/arch.
  * Returns undefined if the tool has no GitHub spec or no asset for the platform.
  * Exported for testing only.
  */
 export function resolveGitHubAsset(
-	toolId: string,
+	toolId: GitHubToolId,
 	platform: string,
 	arch: string,
 ): string | undefined {
@@ -1972,7 +1984,7 @@ export function resolveGitHubAsset(
 }
 
 export function resolveGitHubInstalledBinaryName(
-	toolId: string,
+	toolId: GitHubToolId,
 	platform: string,
 	assetName: string,
 ): string | undefined {
@@ -1986,7 +1998,7 @@ export function resolveGitHubInstalledBinaryName(
 }
 
 export function resolveGitHubArchiveBinaryCandidates(
-	toolId: string,
+	toolId: GitHubToolId,
 	platform: string,
 	assetName: string,
 ): string[] | undefined {

--- a/clients/lsp/launch.ts
+++ b/clients/lsp/launch.ts
@@ -450,7 +450,9 @@ function _attachErrorHandler(
 export async function launchLSP(
 	command: string,
 	args: string[] = [],
-	options: SpawnOptions = {},
+	options: SpawnOptions & {
+		startupFailureWindowMs?: number,
+	} = {},
 ): Promise<LSPProcess> {
 	const cwd = String(options.cwd ?? process.cwd());
 	const mergedEnv = { ...process.env, ...options.env };
@@ -585,10 +587,6 @@ export async function launchLSP(
 	logSessionStart(
 		`lsp launch: command=${command} resolved=${spawnCommand} args=${JSON.stringify(args)} cwd=${cwd} shell=${needsShell ? "true" : "false"} pid=${proc.pid ?? 0}`,
 	);
-	const startupFailureWindowMs =
-		isWindows && needsShell
-			? WINDOWS_NAV_STARTUP_FAILURE_WINDOW_MS
-			: DEFAULT_STARTUP_FAILURE_WINDOW_MS;
 
 	const formatStartupStderr = (stderr: string): string => {
 		const normalized = compactLogValue(stderr);
@@ -641,6 +639,16 @@ export async function launchLSP(
 				}
 			});
 
+			const startupFailureWindowMs = ((): number => {
+				if (options?.startupFailureWindowMs) {
+					return options.startupFailureWindowMs;
+				} else if (isWindows && needsShell) {
+					return WINDOWS_NAV_STARTUP_FAILURE_WINDOW_MS;
+				} else {
+					return DEFAULT_STARTUP_FAILURE_WINDOW_MS;
+				}
+			})();
+				
 			// Give shell-backed Windows launches a slightly longer window because
 			// npm/cmd shims can fail asynchronously after the initial spawn succeeds.
 			setTimeout(() => {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	"main": "index.ts",
 	"scripts": {
 		"build": "tsc --project tsconfig.build.json",
+		"lint": "tsc --project tsconfig.json",
 		"watch": "tsc --watch",
 		"test": "vitest run",
 		"test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"main": "index.ts",
 	"scripts": {
-		"build": "tsc",
+		"build": "tsc --project tsconfig.build.json",
 		"watch": "tsc --watch",
 		"test": "vitest run",
 		"test:watch": "vitest",

--- a/tests/clients/diagnostic-tracker.test.ts
+++ b/tests/clients/diagnostic-tracker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
 	createDiagnosticTracker,
 	type Diagnostic,

--- a/tests/clients/dispatch/runners/shellcheck.test.ts
+++ b/tests/clients/dispatch/runners/shellcheck.test.ts
@@ -47,7 +47,7 @@ describe("shellcheck runner", () => {
 		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
 
 		vi.mocked(safeSpawnMod.safeSpawn).mockReturnValue({
-			error: null,
+			error: undefined,
 			status: 0,
 			stdout: "",
 			stderr: "",
@@ -75,7 +75,7 @@ describe("shellcheck runner", () => {
 		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
 
 		vi.mocked(safeSpawnMod.safeSpawn).mockReturnValue({
-			error: null,
+			error: undefined,
 			status: 0,
 			stdout: "",
 			stderr: "",
@@ -105,7 +105,7 @@ describe("shellcheck runner", () => {
 		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
 
 		vi.mocked(safeSpawnMod.safeSpawn).mockReturnValue({
-			error: null,
+			error: undefined,
 			status: 1,
 			stdout: JSON.stringify([
 				{

--- a/tests/clients/dispatch/tool-cache-session.test.ts
+++ b/tests/clients/dispatch/tool-cache-session.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { normalizeCacheKey } from "../../../clients/dispatch/dispatcher.js";
 import { FactStore } from "../../../clients/dispatch/fact-store.js";
 

--- a/tests/clients/dispatch/try-catch-facts.test.ts
+++ b/tests/clients/dispatch/try-catch-facts.test.ts
@@ -182,7 +182,7 @@ try {
   doSomething();
 } catch (e) {}
 `;
-    const { facts, ctx } = await runProviderWithContent(code);
+    const { ctx } = await runProviderWithContent(code);
     registerRule(errorSwallowingRule);
     const diagnostics = evaluateRules(ctx);
     expect(diagnostics.length).toBe(1);
@@ -220,7 +220,7 @@ try {
   doFallback();
 }
 `;
-    const { facts, ctx } = await runProviderWithContent(code);
+    const { ctx } = await runProviderWithContent(code);
     registerRule(errorObscuringRule);
     const diagnostics = evaluateRules(ctx);
     expect(diagnostics.length).toBe(1);

--- a/tests/clients/installer/github-release.test.ts
+++ b/tests/clients/installer/github-release.test.ts
@@ -1,21 +1,10 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { GITHUB_TOOLS, GitHubToolId } from "../../../clients/installer/index.ts";
 
 // Ensure the real installer module is used, not any mock registered by other test files
 vi.unmock("../../../clients/installer/index.ts");
-
-const GITHUB_TOOLS = [
-	"shellcheck",
-	"shfmt",
-	"rust-analyzer",
-	"golangci-lint",
-	"ktlint",
-	"tflint",
-	"terraform-ls",
-	"zls",
-] as const;
-type GitHubToolId = (typeof GITHUB_TOOLS)[number];
 
 const SUPPORTED_PLATFORMS = ["linux", "darwin", "win32"] as const;
 const COMMON_ARCHES = ["x64", "arm64"] as const;
@@ -49,7 +38,7 @@ describe("GitHub release asset selection", () => {
 
 	it("returns undefined for unknown tool id", async () => {
 		const { resolveGitHubAsset } = await import("../../../clients/installer/index.ts");
-		expect(resolveGitHubAsset("nonexistent-tool", "linux", "x64")).toBeUndefined();
+		expect(resolveGitHubAsset("nonexistent-tool" as GitHubToolId, "linux", "x64")).toBeUndefined();
 	});
 
 	describe("shellcheck asset patterns", () => {

--- a/tests/clients/lsp/lifecycle.test.ts
+++ b/tests/clients/lsp/lifecycle.test.ts
@@ -40,7 +40,7 @@ describe("LSP Launch", () => {
 		const scriptPath = path.join(os.tmpdir(), `pi-lens-test-${Date.now()}.js`);
 		fs.writeFileSync(scriptPath, "process.exit(1);");
 
-		await expect(launchLSP(process.execPath, [scriptPath])).rejects.toThrow(
+		await expect(launchLSP(process.execPath, [scriptPath], { startupFailureWindowMs: 500 })).rejects.toThrow(
 			/exited immediately/,
 		);
 

--- a/tests/clients/lsp/service-early-unblock.test.ts
+++ b/tests/clients/lsp/service-early-unblock.test.ts
@@ -114,6 +114,8 @@ describe("getDiagnostics early-unblock", () => {
 			getDiagnostics: vi.fn(() => []),
 		};
 
+		void resolveSlowWait;
+
 		createLSPClient
 			.mockResolvedValueOnce(fastClient)
 			.mockResolvedValueOnce(slowClient);

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -8,7 +8,7 @@
  * - Event handlers (session_start, tool_call, tool_result, turn_end)
  */
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("Extension Registration", () => {
 	let registeredTools: string[] = [];

--- a/tests/mocks/runner-factory.ts
+++ b/tests/mocks/runner-factory.ts
@@ -30,7 +30,7 @@ export function createMockRunner(config: MockRunnerConfig): RunnerDefinition {
 		enabledByDefault: config.enabledByDefault ?? true,
 		skipTestFiles: config.skipTestFiles ?? false,
 		when: config.when,
-		async run(ctx: DispatchContext): Promise<RunnerResult> {
+		async run(_ctx: DispatchContext): Promise<RunnerResult> {
 			// Simulate async work (CLI invocation)
 			if (config.runDelay) {
 				await new Promise((resolve) => setTimeout(resolve, config.runDelay));

--- a/tests/source-filter.test.ts
+++ b/tests/source-filter.test.ts
@@ -140,7 +140,6 @@ describe("findSourceSibling", () => {
 		const mjsPath = path.join(dir, "module.mjs");
 		const cjsPath = path.join(dir, "common.cjs");
 		const tsPath = path.join(dir, "module.ts");
-		const ctsPath = path.join(dir, "common.cts");
 
 		expect(findSourceSibling(mjsPath)).toBe(tsPath);
 		// .cts files aren't in precedence list, so .cjs won't be shadowed

--- a/tools/lsp-navigation.ts
+++ b/tools/lsp-navigation.ts
@@ -319,7 +319,11 @@ export function createLspNavigationTool(
 					failureKind: string;
 					resultCount: number;
 				},
-			) => {
+			): typeof payload & {
+				details: typeof payload.details & {
+					failureKind: string;
+				}
+			} => {
 				const normalizedFilePath = meta.filePath.replace(/\\/g, "/");
 				logLatency({
 					type: "phase",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,13 +6,9 @@
 		"strict": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,
-		"allowImportingTsExtensions": true,
-		"noEmit": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
 		"lib": ["ES2022"],
 		"types": ["node"]
 	},
 	"include": ["**/*.ts"],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules", "test-lsp-files", "_trigger-test.ts", "tests"]
 }


### PR DESCRIPTION
This PR adjusts the typescript configuration to allow proper import resolution and type-checking while editing the tests.

For this, I split the `tsconfig.json` into a general purpose one and one specifically for the build with `tsconfig.build.json`.

Then I fixed surfaced type-errors and lints.
