### PR TITLE
Add missing clangd extensions and warmFiles LSP config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Added
 
+- **LSP config warmFiles option** - added "warmFiles" option for LSP config. If defined, expects array of string file paths. pi-lens opens these files at full session startup to seed language servers that index translation units lazily, such as clangd. In a short-lived pinpoint-query context, a clangd `workspaceSymbol` request may return empty results for a symbol in a translation unit clangd has not built an AST for yet. Background indexing may make the query work, but that timing is unreliable in LLVM-scale projects. Specify project entry-point files (those that transitively depend on most of the other files in your project) as warmFiles in the LSP config.
+
+### Added
+
 - **Tab/space indentation mismatch correction in the edit hook** — some models output spaces in `oldText` when the file uses tabs (or vice versa), causing edits to fail with a cryptic "not found" error. The `tool_call` hook now detects this before execution by trying tabs↔2-spaces and tabs↔4-spaces conversions against the actual file. On mismatch it blocks with a `🔄 RETRYABLE` message containing the corrected `oldText` verbatim, so the model retries successfully on the next attempt at zero cost when `oldText` already matches.
 - **Global project-data storage is now the default for new projects** — project-scoped pi-lens artifacts (turn state, worklog, metrics history, index, install choices, runner scratch data) now default to `~/.pi-lens/projects/<project-slug>/` instead of creating `<project>/.pi-lens/`. Existing projects that already have `<project>/.pi-lens/` continue to reuse it unless `PILENS_DATA_DIR` is explicitly set. This closes issue #40 while preserving backward compatibility.
 - **`PILENS_DATA_DIR` and `PI_LENS_STARTUP_MODE` documented in README** — both env vars are now listed under a dedicated _Environment Variables_ section between `## Run` and `## Key Commands`.

--- a/clients/file-kinds.ts
+++ b/clients/file-kinds.ts
@@ -52,20 +52,40 @@ const KIND_EXTENSIONS: Record<FileKind, readonly string[]> = {
 	python: [".py"],
 	go: [".go"],
 	rust: [".rs"],
+	// From llvm-project/clang/lib/Driver/Types.cpp clang::driver::types::lookupTypeForExtension:
 	cxx: [
+		// C
 		".c",
+		".h",
+		// C++
+		".c++",
 		".cc",
+		".cp",
 		".cpp",
 		".cxx",
-		".h",
 		".hh",
 		".hpp",
 		".hxx",
-		".ixx",
-		".ipp",
+		// C++ include files
 		".inl",
+		".ipp",
 		".tpp",
 		".txx",
+		// C++20 module interface files
+		".c++m",
+		".cppm",
+		".cxxm",
+		".ixx",
+		// CUDA
+		".cu",
+		// HIP
+		".hip",
+		// Objective-C
+		".m",
+		".mm",
+		// OpenCL
+		".cl",
+		".clcpp",
 	],
 	cmake: [".cmake"],
 	shell: [".sh", ".bash", ".zsh", ".fish"],

--- a/clients/file-kinds.ts
+++ b/clients/file-kinds.ts
@@ -10,48 +10,63 @@ import { basename, extname } from "node:path";
 // --- Types ---
 
 export type FileKind =
-	| "jsts" // JavaScript/TypeScript/frameworks (js, jsx, ts, tsx, mjs, cjs, vue, svelte)
-	| "python" // Python (.py)
-	| "go" // Go (.go)
-	| "rust" // Rust (.rs)
-	| "cxx" // C/C++ (.c, .cc, .cpp, .h, .hpp, .cxx, etc.)
-	| "cmake" // CMake (.cmake, CMakeLists.txt)
-	| "shell" // Shell (.sh, .bash)
-	| "json" // JSON (.json)
-	| "markdown" // Markdown (.md, .mdx)
-	| "css" // CSS (.css, .scss, .less)
-	| "yaml" // YAML (.yaml, .yml)
-	| "sql" // SQL (.sql)
-	| "ruby" // Ruby (.rb, .rake, .gemspec, .ru)
-	| "html" // HTML (.html, .htm)
+	| "clojure" // Clojure
+	| "cmake" // CMake
+	| "csharp" // C#
+	| "css" // CSS
+	| "cxx" // C/C++
+	| "dart" // Dart
 	| "docker" // Dockerfile
-	| "php" // PHP (.php)
-	| "powershell" // PowerShell (.ps1, .psm1, .psd1)
-	| "prisma" // Prisma schema (.prisma)
-	| "csharp" // C# (.cs)
-	| "fsharp" // F# (.fs, .fsi, .fsx)
-	| "java" // Java (.java)
-	| "kotlin" // Kotlin (.kt, .kts)
-	| "swift" // Swift (.swift)
-	| "dart" // Dart (.dart)
-	| "lua" // Lua (.lua)
-	| "zig" // Zig (.zig, .zon)
-	| "haskell" // Haskell (.hs, .lhs)
-	| "elixir" // Elixir (.ex, .exs)
-	| "gleam" // Gleam (.gleam)
-	| "ocaml" // OCaml (.ml, .mli)
-	| "clojure" // Clojure (.clj, .cljs, .cljc, .edn)
-	| "terraform" // Terraform (.tf, .tfvars)
-	| "nix" // Nix (.nix)
-	| "toml"; // TOML (.toml)
+	| "elixir" // Elixir
+	| "fsharp" // F#
+	| "gleam" // Gleam
+	| "go" // Go
+	| "haskell" // Haskell
+	| "html" // HTML
+	| "java" // Java
+	| "json" // JSON
+	| "jsts" // JavaScript/TypeScript/frameworks
+	| "kotlin" // Kotlin
+	| "lua" // Lua
+	| "markdown" // Markdown
+	| "nix" // Nix
+	| "ocaml" // OCaml
+	| "php" // PHP
+	| "powershell" // PowerShell
+	| "prisma" // Prisma schema
+	| "python" // Python
+	| "ruby" // Ruby
+	| "rust" // Rust
+	| "shell" // Shell
+	| "sql" // SQL
+	| "swift" // Swift
+	| "terraform" // Terraform
+	| "toml" // TOML
+	| "yaml" // YAML
+	| "zig" // Zig
+	;
 
 // --- Extension Maps ---
 
 const KIND_EXTENSIONS: Record<FileKind, readonly string[]> = {
-	jsts: [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".svelte", ".vue"],
-	python: [".py"],
-	go: [".go"],
-	rust: [".rs"],
+	clojure: [
+		".clj",
+		".cljc",
+		".cljs",
+		".edn",
+	],
+	cmake: [
+		".cmake",
+	],
+	csharp: [
+		".cs",
+	],
+	css: [
+		".css",
+		".less",
+		".sass",
+		".scss",
+	],
 	// From llvm-project/clang/lib/Driver/Types.cpp clang::driver::types::lookupTypeForExtension:
 	cxx: [
 		// C
@@ -87,35 +102,121 @@ const KIND_EXTENSIONS: Record<FileKind, readonly string[]> = {
 		".cl",
 		".clcpp",
 	],
-	cmake: [".cmake"],
-	shell: [".sh", ".bash", ".zsh", ".fish"],
-	json: [".json", ".jsonc", ".json5"],
-	markdown: [".md", ".mdx"],
-	css: [".css", ".scss", ".sass", ".less"],
-	yaml: [".yaml", ".yml"],
-	sql: [".sql"],
-	ruby: [".rb", ".rake", ".gemspec", ".ru"],
-	html: [".html", ".htm"],
-	docker: [".dockerfile"],
-	php: [".php"],
-	powershell: [".ps1", ".psm1", ".psd1"],
-	prisma: [".prisma"],
-	csharp: [".cs"],
-	fsharp: [".fs", ".fsi", ".fsx"],
-	java: [".java"],
-	kotlin: [".kt", ".kts"],
-	swift: [".swift"],
-	dart: [".dart"],
-	lua: [".lua"],
-	zig: [".zig", ".zon"],
-	haskell: [".hs", ".lhs"],
-	elixir: [".ex", ".exs"],
-	gleam: [".gleam"],
-	ocaml: [".ml", ".mli"],
-	clojure: [".clj", ".cljs", ".cljc", ".edn"],
-	terraform: [".tf", ".tfvars"],
-	nix: [".nix"],
-	toml: [".toml"],
+	dart: [
+		".dart",
+	],
+	docker: [
+		".dockerfile",
+	],
+	elixir: [
+		".ex",
+		".exs",
+	],
+	fsharp: [
+		".fs",
+		".fsi",
+		".fsx",
+	],
+	gleam: [
+		".gleam",
+	],
+	go: [
+		".go",
+	],
+	haskell: [
+		".hs",
+		".lhs",
+	],
+	html: [
+		".htm",
+		".html",
+	],
+	java: [
+		".java",
+	],
+	json: [
+		".json",
+		".json5",
+		".jsonc",
+	],
+	jsts: [
+		".cjs",
+		".js",
+		".jsx",
+		".mjs",
+		".svelte",
+		".ts",
+		".tsx",
+		".vue",
+	],
+	kotlin: [
+		".kt",
+		".kts",
+	],
+	lua: [
+		".lua",
+	],
+	markdown: [
+		".md",
+		".mdx",
+	],
+	nix: [
+		".nix",
+	],
+	ocaml: [
+		".ml",
+		".mli",
+	],
+	php: [
+		".php",
+	],
+	powershell: [
+		".ps1",
+		".psm1",
+		".psd1",
+	],
+	prisma: [
+		".prisma",
+	],
+	python: [
+		".py",
+	],
+	ruby: [
+		".gemspec",
+		".rake",
+		".rb",
+		".ru",
+	],
+	rust: [
+		".rs",
+	],
+	shell: [
+		".bash",
+		".fish",
+		".sh",
+		".zsh",
+	],
+	sql: [
+		".sql",
+	],
+	swift: [
+		".swift",
+	],
+	terraform: [
+		".tf",
+		".tfvars",
+	],
+	toml: [
+		".toml",
+	],
+	yaml: [
+		".yaml",
+		".yml",
+	],
+	zig: [
+		".zig",
+		".zon",
+	],
 };
 
 // Reverse map: extension → file kind (for fast lookup)

--- a/clients/file-kinds.ts
+++ b/clients/file-kinds.ts
@@ -141,9 +141,11 @@ const KIND_EXTENSIONS: Record<FileKind, readonly string[]> = {
 	],
 	jsts: [
 		".cjs",
+		".cts",
 		".js",
 		".jsx",
 		".mjs",
+		".mts",
 		".svelte",
 		".ts",
 		".tsx",
@@ -180,6 +182,7 @@ const KIND_EXTENSIONS: Record<FileKind, readonly string[]> = {
 	],
 	python: [
 		".py",
+		".pyi",
 	],
 	ruby: [
 		".gemspec",

--- a/clients/file-kinds.ts
+++ b/clients/file-kinds.ts
@@ -48,7 +48,7 @@ export type FileKind =
 
 // --- Extension Maps ---
 
-const KIND_EXTENSIONS: Record<FileKind, readonly string[]> = {
+export const KIND_EXTENSIONS: Record<FileKind, readonly string[]> = {
 	clojure: [
 		".clj",
 		".cljc",

--- a/clients/lsp/config.ts
+++ b/clients/lsp/config.ts
@@ -42,6 +42,8 @@ export interface CustomServerConfig {
 export interface LSPConfig {
 	servers?: Record<string, CustomServerConfig>;
 	disabledServers?: string[];
+	/** Files to open at session start to seed lazy LSP indexing (e.g., clangd). */
+	warmFiles?: string[];
 }
 
 interface RegisteredLSPConfig {

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -12,6 +12,7 @@ import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { access, appendFile, mkdir, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { KIND_EXTENSIONS } from "../file-kinds.js"
 import { ensureTool, getToolEnvironment } from "../installer/index.js";
 import { logLatency } from "../latency-logger.js";
 import { type LSPProcess, launchLSP } from "./launch.js";
@@ -27,7 +28,7 @@ export interface LSPSpawnOptions {
 export interface LSPServerInfo {
 	id: string;
 	name: string;
-	extensions: string[];
+	extensions: readonly string[];
 	root: RootFunction;
 	/**
 	 * Optional per-server initialize timeout.
@@ -392,7 +393,7 @@ type InitializationConfig = Record<string, unknown>;
 interface InteractiveServerSpec {
 	id: string;
 	name: string;
-	extensions: string[];
+	extensions: readonly string[];
 	root: RootFunction;
 	language: string;
 	command: string | ((root: string) => string);
@@ -748,10 +749,14 @@ export async function detectPythonVenv(
 
 // --- Server Definitions ---
 
+const JS_TS_LSP_EXTENSIONS = KIND_EXTENSIONS["jsts"].filter(
+	(ext) => ext !== ".svelte" && ext !== ".vue",
+);
+
 export const TypeScriptServer: LSPServerInfo = {
 	id: "typescript",
 	name: "TypeScript Language Server",
-	extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
+	extensions: JS_TS_LSP_EXTENSIONS,
 	autoPropagateDiagnostics: true,
 	root: DenoExcludeRoot(
 		RootWithFallback(
@@ -850,7 +855,7 @@ export const TypeScriptServer: LSPServerInfo = {
 export const DenoServer: LSPServerInfo = {
 	id: "deno",
 	name: "Deno Language Server",
-	extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
+	extensions: JS_TS_LSP_EXTENSIONS,
 	autoPropagateDiagnostics: true,
 	root: createRootDetector(["deno.json", "deno.jsonc"]),
 	async spawn(root) {
@@ -866,7 +871,7 @@ export const DenoServer: LSPServerInfo = {
 export const PythonServer: LSPServerInfo = {
 	id: "python",
 	name: "Pyright Language Server",
-	extensions: [".py", ".pyi"],
+	extensions: KIND_EXTENSIONS["python"],
 	root: RootWithFallback(
 		createRootDetector([
 			".git",
@@ -932,7 +937,7 @@ export const PythonServer: LSPServerInfo = {
 export const PythonPylspServer: LSPServerInfo = {
 	id: "python-pylsp",
 	name: "Python LSP Server (pylsp)",
-	extensions: [".py", ".pyi"],
+	extensions: KIND_EXTENSIONS["python"],
 	root: RootWithFallback(
 		createRootDetector([
 			".git",
@@ -961,7 +966,7 @@ export const PythonPylspServer: LSPServerInfo = {
 export const GoServer: LSPServerInfo = {
 	id: "go",
 	name: "gopls",
-	extensions: [".go"],
+	extensions: KIND_EXTENSIONS["go"],
 	root: RootWithFallback(
 		WorkspacePriorityRoot([["go.work"], ["go.mod", "go.sum"], [".git"]]),
 	),
@@ -1016,7 +1021,7 @@ function RustWorkspaceRoot(): RootFunction {
 export const RustServer: LSPServerInfo = {
 	id: "rust",
 	name: "rust-analyzer",
-	extensions: [".rs"],
+	extensions: KIND_EXTENSIONS["rust"],
 	root: RootWithFallback(RustWorkspaceRoot()),
 	async spawn(root, options) {
 		// Prefer rustup-installed rust-analyzer; fall back to GitHub-downloaded managed copy
@@ -1044,7 +1049,7 @@ export const RustServer: LSPServerInfo = {
 export const RubyServer: LSPServerInfo = {
 	id: "ruby",
 	name: "Ruby LSP",
-	extensions: [".rb", ".rake", ".gemspec", ".ru"],
+	extensions: KIND_EXTENSIONS["ruby"],
 	root: RootWithFallback(
 		PriorityRoot([["Gemfile", ".ruby-version"], [".git"]]),
 	),
@@ -1096,7 +1101,7 @@ export const RubyServer: LSPServerInfo = {
 export const RubySolargraphServer: LSPServerInfo = {
 	id: "ruby-solargraph",
 	name: "Solargraph",
-	extensions: [".rb", ".rake", ".gemspec", ".ru"],
+	extensions: KIND_EXTENSIONS["ruby"],
 	root: RootWithFallback(
 		PriorityRoot([["Gemfile", ".ruby-version"], [".git"]]),
 	),
@@ -1116,7 +1121,7 @@ export const RubySolargraphServer: LSPServerInfo = {
 export const PHPServer: LSPServerInfo = {
 	id: "php",
 	name: "Intelephense",
-	extensions: [".php"],
+	extensions: KIND_EXTENSIONS["php"],
 	root: RootWithFallback(
 		createRootDetector(["composer.json", "composer.lock"]),
 	),
@@ -1143,7 +1148,7 @@ export const PHPServer: LSPServerInfo = {
 export const CSharpServer: LSPServerInfo = {
 	id: "csharp",
 	name: "csharp-ls",
-	extensions: [".cs"],
+	extensions: KIND_EXTENSIONS["csharp"],
 	root: RootWithFallback(createRootDetector([".sln", ".csproj", ".slnx"])),
 	async spawn(root, options) {
 		const candidates = dotnetToolCandidates("csharp-ls");
@@ -1167,7 +1172,7 @@ export const CSharpServer: LSPServerInfo = {
 export const OmniSharpServer = createInteractiveServer({
 	id: "omnisharp",
 	name: "OmniSharp",
-	extensions: [".cs"],
+	extensions: KIND_EXTENSIONS["csharp"],
 	root: createRootDetector([".sln", ".csproj", ".slnx"]),
 	language: "csharp",
 	command: "OmniSharp",
@@ -1177,7 +1182,7 @@ export const OmniSharpServer = createInteractiveServer({
 export const FSharpServer = createInteractiveServer({
 	id: "fsharp",
 	name: "FSAutocomplete",
-	extensions: [".fs", ".fsi", ".fsx"],
+	extensions: KIND_EXTENSIONS["fsharp"],
 	root: createRootDetector([".sln", ".fsproj"]),
 	language: "fsharp",
 	command: "fsautocomplete",
@@ -1186,7 +1191,7 @@ export const FSharpServer = createInteractiveServer({
 export const JavaServer = createInteractiveServer({
 	id: "java",
 	name: "JDT Language Server",
-	extensions: [".java"],
+	extensions: KIND_EXTENSIONS["java"],
 	root: RootWithFallback(
 		createRootDetector(["pom.xml", "build.gradle", ".classpath"]),
 	),
@@ -1197,7 +1202,7 @@ export const JavaServer = createInteractiveServer({
 export const KotlinServer: LSPServerInfo = {
 	id: "kotlin",
 	name: "Kotlin Language Server",
-	extensions: [".kt", ".kts"],
+	extensions: KIND_EXTENSIONS["kotlin"],
 	root: RootWithFallback(
 		createRootDetector(["build.gradle.kts", "build.gradle", "pom.xml"]),
 	),
@@ -1218,7 +1223,7 @@ export const KotlinServer: LSPServerInfo = {
 export const SwiftServer = createInteractiveServer({
 	id: "swift",
 	name: "SourceKit-LSP",
-	extensions: [".swift"],
+	extensions: KIND_EXTENSIONS["swift"],
 	root: createRootDetector(["Package.swift"]),
 	language: "swift",
 	command: "sourcekit-lsp",
@@ -1227,7 +1232,7 @@ export const SwiftServer = createInteractiveServer({
 export const DartServer = createInteractiveServer({
 	id: "dart",
 	name: "Dart Analysis Server",
-	extensions: [".dart"],
+	extensions: KIND_EXTENSIONS["dart"],
 	root: RootWithFallback(createRootDetector(["pubspec.yaml"])),
 	language: "dart",
 	command: "dart",
@@ -1237,7 +1242,7 @@ export const DartServer = createInteractiveServer({
 export const LuaServer = createInteractiveServer({
 	id: "lua",
 	name: "Lua Language Server",
-	extensions: [".lua"],
+	extensions: KIND_EXTENSIONS["lua"],
 	root: createRootDetector([".luarc.json", ".luacheckrc"]),
 	language: "lua",
 	command: "lua-language-server",
@@ -1246,7 +1251,7 @@ export const LuaServer = createInteractiveServer({
 export const CppServer = createInteractiveServer({
 	id: "cpp",
 	name: "clangd",
-	extensions: [".c", ".cpp", ".cc", ".cxx", ".h", ".hpp"],
+	extensions: KIND_EXTENSIONS["cxx"],
 	root: RootWithFallback(
 		createRootDetector([
 			"compile_commands.json",
@@ -1263,7 +1268,7 @@ export const CppServer = createInteractiveServer({
 export const ZigServer: LSPServerInfo = {
 	id: "zig",
 	name: "ZLS",
-	extensions: [".zig", ".zon"],
+	extensions: KIND_EXTENSIONS["zig"],
 	root: RootWithFallback(createRootDetector(["build.zig"])),
 	spawn(root, options) {
 		return resolveAndLaunch(
@@ -1281,7 +1286,7 @@ export const ZigServer: LSPServerInfo = {
 export const HaskellServer = createInteractiveServer({
 	id: "haskell",
 	name: "Haskell Language Server",
-	extensions: [".hs", ".lhs"],
+	extensions: KIND_EXTENSIONS["haskell"],
 	root: createRootDetector(["stack.yaml", "cabal.project", "*.cabal"]),
 	language: "haskell",
 	command: "haskell-language-server-wrapper",
@@ -1291,7 +1296,7 @@ export const HaskellServer = createInteractiveServer({
 export const ElixirServer = createInteractiveServer({
 	id: "elixir",
 	name: "ElixirLS",
-	extensions: [".ex", ".exs"],
+	extensions: KIND_EXTENSIONS["elixir"],
 	root: RootWithFallback(createRootDetector(["mix.exs"])),
 	language: "elixir",
 	command: "elixir-ls",
@@ -1300,7 +1305,7 @@ export const ElixirServer = createInteractiveServer({
 export const GleamServer = createInteractiveServer({
 	id: "gleam",
 	name: "Gleam LSP",
-	extensions: [".gleam"],
+	extensions: KIND_EXTENSIONS["gleam"],
 	root: RootWithFallback(createRootDetector(["gleam.toml"])),
 	language: "gleam",
 	command: "gleam",
@@ -1310,7 +1315,7 @@ export const GleamServer = createInteractiveServer({
 export const OCamlServer = createInteractiveServer({
 	id: "ocaml",
 	name: "ocamllsp",
-	extensions: [".ml", ".mli"],
+	extensions: KIND_EXTENSIONS["ocaml"],
 	root: createRootDetector(["dune-project", "opam"]),
 	language: "ocaml",
 	command: "ocamllsp",
@@ -1319,7 +1324,7 @@ export const OCamlServer = createInteractiveServer({
 export const ClojureServer = createInteractiveServer({
 	id: "clojure",
 	name: "Clojure LSP",
-	extensions: [".clj", ".cljs", ".cljc", ".edn"],
+	extensions: KIND_EXTENSIONS["clojure"],
 	root: createRootDetector(["deps.edn", "project.clj"]),
 	language: "clojure",
 	command: "clojure-lsp",
@@ -1328,7 +1333,7 @@ export const ClojureServer = createInteractiveServer({
 export const TerraformServer: LSPServerInfo = {
 	id: "terraform",
 	name: "Terraform LSP",
-	extensions: [".tf", ".tfvars"],
+	extensions: KIND_EXTENSIONS["terraform"],
 	root: RootWithFallback(
 		createRootDetector([".terraform.lock.hcl", ".terraform"]),
 	),
@@ -1348,7 +1353,7 @@ export const TerraformServer: LSPServerInfo = {
 export const NixServer = createInteractiveServer({
 	id: "nix",
 	name: "nixd",
-	extensions: [".nix"],
+	extensions: KIND_EXTENSIONS["nix"],
 	root: createRootDetector(["flake.nix"]),
 	language: "nix",
 	command: "nixd",
@@ -1357,7 +1362,11 @@ export const NixServer = createInteractiveServer({
 export const BashServer: LSPServerInfo = {
 	id: "bash",
 	name: "Bash Language Server",
-	extensions: [".sh", ".bash", ".zsh"],
+	extensions: [
+		".bash",
+		".sh",
+		".zsh",
+	],
 	root: FileDirRoot,
 	spawn(root, options) {
 		return resolveAndLaunch(
@@ -1375,7 +1384,10 @@ export const BashServer: LSPServerInfo = {
 export const DockerServer: LSPServerInfo = {
 	id: "docker",
 	name: "Dockerfile Language Server",
-	extensions: [".dockerfile", "Dockerfile"],
+	extensions: [
+		".dockerfile",
+		"Dockerfile",
+	],
 	root: RootWithFallback(
 		PriorityRoot([
 			[
@@ -1403,7 +1415,7 @@ export const DockerServer: LSPServerInfo = {
 export const YamlServer: LSPServerInfo = {
 	id: "yaml",
 	name: "YAML Language Server",
-	extensions: [".yaml", ".yml"],
+	extensions: KIND_EXTENSIONS["yaml"],
 	root: RootWithFallback(
 		PriorityRoot([
 			[".yamllint", "yamllint.yml", "yamllint.yaml", "pyproject.toml"],
@@ -1426,7 +1438,7 @@ export const YamlServer: LSPServerInfo = {
 export const JsonServer: LSPServerInfo = {
 	id: "json",
 	name: "VSCode JSON Language Server",
-	extensions: [".json", ".jsonc"],
+	extensions: KIND_EXTENSIONS["json"],
 	root: RootWithFallback(
 		WorkspacePriorityRoot([
 			["package.json", "tsconfig.json", "jsconfig.json"],
@@ -1449,7 +1461,7 @@ export const JsonServer: LSPServerInfo = {
 export const HtmlServer: LSPServerInfo = {
 	id: "html",
 	name: "VSCode HTML Language Server",
-	extensions: [".html", ".htm"],
+	extensions: KIND_EXTENSIONS["html"],
 	root: RootWithFallback(
 		IgnoreHomeRoot(
 			PriorityRoot([["package.json", "index.html", "vite.config.ts"]]),
@@ -1471,7 +1483,7 @@ export const HtmlServer: LSPServerInfo = {
 export const TomlServer: LSPServerInfo = {
 	id: "toml",
 	name: "Taplo",
-	extensions: [".toml"],
+	extensions: KIND_EXTENSIONS["toml"],
 	root: RootWithFallback(
 		PriorityRoot([["pyproject.toml", "Cargo.toml", "taplo.toml"], [".git"]]),
 	),
@@ -1491,7 +1503,7 @@ export const TomlServer: LSPServerInfo = {
 export const PrismaServer: LSPServerInfo = {
 	id: "prisma",
 	name: "Prisma Language Server",
-	extensions: [".prisma"],
+	extensions: KIND_EXTENSIONS["prisma"],
 	root: RootWithFallback(
 		createRootDetector(["prisma/schema.prisma", "schema.prisma"]),
 	),
@@ -1513,7 +1525,9 @@ export const PrismaServer: LSPServerInfo = {
 export const VueServer: LSPServerInfo = {
 	id: "vue",
 	name: "Vue Language Server",
-	extensions: [".vue"],
+	extensions: [
+		".vue",
+	],
 	root: RootWithFallback(
 		IgnoreHomeRoot(
 			createRootDetector([
@@ -1563,7 +1577,9 @@ export const VueServer: LSPServerInfo = {
 export const SvelteServer: LSPServerInfo = {
 	id: "svelte",
 	name: "Svelte Language Server",
-	extensions: [".svelte"],
+	extensions: [
+		".svelte",
+	],
 	root: RootWithFallback(
 		IgnoreHomeRoot(
 			createRootDetector([
@@ -1604,7 +1620,13 @@ export const SvelteServer: LSPServerInfo = {
 export const ESLintServer: LSPServerInfo = {
 	id: "eslint",
 	name: "ESLint Language Server",
-	extensions: [".js", ".jsx", ".vue", ".svelte"], // Note: .ts/.tsx handled by TypeScript LSP + Biome
+	// Note: .ts/.tsx handled by TypeScript LSP + Biome
+	extensions: [
+		".js",
+		".jsx",
+		".svelte",
+		".vue",
+	],
 	root: IgnoreHomeRoot(
 		createRootDetector([
 			".eslintrc",
@@ -1631,7 +1653,7 @@ export const ESLintServer: LSPServerInfo = {
 export const CssServer: LSPServerInfo = {
 	id: "css",
 	name: "CSS Language Server",
-	extensions: [".css", ".scss", ".sass", ".less"],
+	extensions: KIND_EXTENSIONS["css"],
 	root: RootWithFallback(
 		IgnoreHomeRoot(
 			PriorityRoot([

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -15,6 +15,8 @@ import {
 	getDefaultStartupTools,
 } from "./language-profile.js";
 import { runLogCleanup } from "./log-cleanup.js";
+import { initLSPConfig, loadLSPConfig } from "./lsp/config.js";
+import { getLSPService } from "./lsp/index.js";
 import type { MetricsClient } from "./metrics-client.js";
 import {
 	buildProjectIndex,
@@ -76,6 +78,58 @@ function resolveStartupMode(): StartupMode {
 }
 
 // --- Session-start helpers ---
+
+async function igniteWarmFiles(
+	cwd: string,
+	runtime: RuntimeCoordinator,
+	sessionGeneration: number,
+	dbg: (msg: string) => void,
+): Promise<void> {
+	try {
+		const config = await loadLSPConfig(cwd);
+		const warmFiles = config.warmFiles ?? [];
+		if (warmFiles.length === 0) return;
+
+		dbg(`session_start lsp-warm: ${warmFiles.length} warm file(s) configured`);
+
+		await initLSPConfig(cwd);
+		if (!runtime.isCurrentSession(sessionGeneration)) return;
+
+		const lspService = getLSPService();
+		const total = warmFiles.length;
+		let loaded = 0;
+		let errors = 0;
+
+		for (const relPath of warmFiles) {
+			if (!runtime.isCurrentSession(sessionGeneration)) return;
+			const filePath = path.isAbsolute(relPath)
+				? relPath
+				: path.resolve(cwd, relPath);
+			if (!nodeFs.existsSync(filePath)) {
+				dbg(`session_start lsp-warm: not found: ${relPath}`);
+				errors++;
+				continue;
+			}
+			try {
+				const content = nodeFs.readFileSync(filePath, "utf-8");
+				await lspService.touchFile(filePath, content, {
+					diagnostics: "none",
+					source: "startup-warm",
+					clientScope: "primary",
+					maxClientWaitMs: 2000,
+				});
+				loaded++;
+			} catch (err) {
+				dbg(`session_start lsp-warm: error ${relPath}: ${err}`);
+				errors++;
+			}
+		}
+
+		dbg(`session_start lsp-warm: ${loaded}/${total} opened (${errors} err)`);
+	} catch (err) {
+		dbg(`session_start lsp-warm: config/init error: ${err}`);
+	}
+}
 
 function firePreinstallDefaults(
 	ensureTool: SessionStartDeps["ensureTool"],
@@ -553,6 +607,12 @@ export async function handleSessionStart(
 	}
 
 	dbg("session_start: background scans launched");
+
+	// LSP warm files — open configured files so clangd has AST/index context
+	// before short-lived workspaceSymbol queries that may otherwise return empty.
+	if (!getFlag("no-lsp") && allowBootstrapTasks) {
+		await igniteWarmFiles(cwd, runtime, sessionGeneration, dbg);
+	}
 
 	dbg(`session_start total: ${Date.now() - sessionStartMs}ms`);
 }

--- a/tests/clients/lsp/clangd-lazy-indexing.test.ts
+++ b/tests/clients/lsp/clangd-lazy-indexing.test.ts
@@ -1,0 +1,139 @@
+/**
+ * clangd Lazy TU Integration Tests
+ *
+ * Verifies clangd can return empty workspaceSymbol results before a translation
+ * unit is opened. A later LSP operation on main.cpp gives clangd AST/index
+ * context for api.hpp/api.cpp so apiSymbol can be found.
+ */
+
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createLSPClient } from "../../../clients/lsp/client.js";
+import { launchLSP, stopLSP } from "../../../clients/lsp/launch.js";
+import { setupTestEnvironment } from "../test-utils.js";
+
+// Detect clangd availability at module load time
+const CLANGD: string | null = (() => {
+	try {
+		const bin = process.platform === "win32" ? "where clangd" : "which clangd";
+		return execSync(bin, { encoding: "utf8" }).trim() || null;
+	} catch {
+		return null;
+	}
+})();
+
+function createCompileCommandsJson(projectDir: string, files: string[]): void {
+	const entries = files.map((f) => ({
+		directory: projectDir,
+		command: `c++ -std=c++17 -c ${f} -o ${f}.o`,
+		file: f,
+	}));
+	fs.writeFileSync(
+		path.join(projectDir, "compile_commands.json"),
+		JSON.stringify(entries, null, 2),
+	);
+}
+
+function createProject(projectDir: string): void {
+	const srcDir = path.join(projectDir, "src");
+	fs.mkdirSync(srcDir, { recursive: true });
+
+	fs.writeFileSync(
+		path.join(srcDir, "api.hpp"),
+		"#pragma once\n\nint apiSymbol();\n",
+	);
+	fs.writeFileSync(
+		path.join(srcDir, "api.cpp"),
+		'#include "api.hpp"\n\nint apiSymbol() { return 42; }\n',
+	);
+	fs.writeFileSync(
+		path.join(srcDir, "main.cpp"),
+		'#include "api.hpp"\n\nint main() { return apiSymbol(); }\n',
+	);
+
+	createCompileCommandsJson(projectDir, ["src/main.cpp", "src/api.cpp"]);
+}
+
+async function waitForWorkspaceSymbol(
+	client: Awaited<ReturnType<typeof createLSPClient>>,
+	name: string,
+): Promise<void> {
+	const deadline = Date.now() + 10_000;
+	while (Date.now() < deadline) {
+		const symbols = await client.workspaceSymbol(name);
+		if (symbols.some((s) => s.name === name)) return;
+		await new Promise((r) => setTimeout(r, 200));
+	}
+
+	const symbols = await client.workspaceSymbol(name);
+	expect(symbols.some((s) => s.name === name)).toBe(true);
+}
+
+describe.skipIf(!CLANGD)("clangd lazy TU indexing", () => {
+	let env: ReturnType<typeof setupTestEnvironment>;
+	let proc: Awaited<ReturnType<typeof launchLSP>> | undefined;
+	let client: Awaited<ReturnType<typeof createLSPClient>> | undefined;
+	let projectDir: string;
+	let mainPath: string;
+
+	beforeEach(async () => {
+		env = setupTestEnvironment("pi-lens-clangd-");
+		projectDir = env.tmpDir;
+		createProject(projectDir);
+
+		mainPath = path.join(projectDir, "src", "main.cpp");
+
+		if (CLANGD === null) throw new Error("clangd unavailable");
+
+		// Launch clangd WITHOUT --background-index: only indexes opened TUs
+		proc = await launchLSP(CLANGD, ["--background-index=false"], {
+			cwd: projectDir,
+		});
+
+		client = await createLSPClient({
+			serverId: "clangd",
+			process: proc,
+			root: projectDir,
+		});
+	});
+
+	afterEach(async () => {
+		if (client) {
+			try {
+				await client.shutdown();
+			} catch {
+				// ignore
+			}
+			client = undefined;
+		}
+		if (proc) {
+			try {
+				await stopLSP(proc);
+			} catch {
+				// ignore
+			}
+			proc = undefined;
+		}
+		env.cleanup();
+	});
+
+	it("workspaceSymbol returns results after an LSP operation on main.cpp", async () => {
+		if (client === undefined) throw new Error("LSP client not initialized");
+		const lspClient = client;
+		const beforeOpen = await lspClient.workspaceSymbol("apiSymbol");
+		expect(beforeOpen.filter((s) => s.name === "apiSymbol")).toEqual([]);
+
+		await lspClient.notify.open(
+			mainPath,
+			fs.readFileSync(mainPath, "utf-8"),
+			"cpp",
+		);
+
+		const mainSymbols = await lspClient.documentSymbol(mainPath);
+		expect(mainSymbols.some((s) => s.name === "main")).toBe(true);
+
+		await waitForWorkspaceSymbol(lspClient, "apiSymbol");
+	}, 15_000);
+});

--- a/tests/clients/runtime-session-warm.test.ts
+++ b/tests/clients/runtime-session-warm.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Verifies configured warmFiles are opened during full session startup.
+ * This helps short-lived symbol queries avoid empty clangd results caused by
+ * lazy translation-unit indexing.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleSessionStart } from "../../clients/runtime-session.js";
+import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+
+const mockTouchFile = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../../clients/lsp/config.js", () => ({
+	loadLSPConfig: vi.fn(),
+	initLSPConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../clients/lsp/index.js", () => ({
+	getLSPService: vi.fn(() => ({
+		touchFile: mockTouchFile,
+	})),
+}));
+
+import { initLSPConfig, loadLSPConfig } from "../../clients/lsp/config.js";
+import { getLSPService } from "../../clients/lsp/index.js";
+
+function setStartupMode(mode: "full" | "quick"): () => void {
+	const prev = process.env.PI_LENS_STARTUP_MODE;
+	process.env.PI_LENS_STARTUP_MODE = mode;
+	return () => {
+		if (prev === undefined) delete process.env.PI_LENS_STARTUP_MODE;
+		else process.env.PI_LENS_STARTUP_MODE = prev;
+	};
+}
+
+function makeDefaultRuntime() {
+	return {
+		sessionGeneration: 99,
+		isCurrentSession: () => true,
+		markStartupScanInFlight: () => {},
+		clearStartupScanInFlight: () => {},
+		complexityBaselines: new Map(),
+		resetForSession: () => {},
+		projectRoot: "",
+		projectRulesScan: { hasCustomRules: false, rules: [] },
+		cachedExports: new Map(),
+		cachedProjectIndex: null,
+		errorDebtBaseline: { testsPassed: true, buildPassed: true },
+	};
+}
+
+function makeDeps(
+	overrides: {
+		getFlag?: (name: string) => boolean | string | undefined;
+		dbg?: (msg: string) => void;
+		ctxCwd?: string;
+	} = {},
+) {
+	return {
+		ctxCwd: overrides.ctxCwd ?? process.cwd(),
+		getFlag: overrides.getFlag ?? (() => false),
+		notify: vi.fn(),
+		dbg: overrides.dbg ?? (() => {}),
+		log: () => {},
+		runtime: makeDefaultRuntime(),
+		metricsClient: { reset: () => {} },
+		cacheManager: {
+			writeCache: () => {},
+			readCache: () => null,
+		},
+		todoScanner: { scanDirectory: () => ({ items: [] }) },
+		astGrepClient: {
+			isAvailable: () => false,
+			ensureAvailable: async () => false,
+			scanExports: async () => new Map(),
+		},
+		biomeClient: {
+			isAvailable: () => false,
+			ensureAvailable: async () => false,
+		},
+		ruffClient: {
+			isAvailable: () => false,
+			ensureAvailable: async () => false,
+		},
+		knipClient: {
+			isAvailable: () => false,
+			ensureAvailable: async () => false,
+		},
+		jscpdClient: {
+			isAvailable: () => false,
+			ensureAvailable: async () => false,
+		},
+		typeCoverageClient: { isAvailable: () => false },
+		depChecker: {
+			isAvailable: () => false,
+			ensureAvailable: async () => false,
+		},
+		testRunnerClient: {
+			detectRunner: () => ({ runner: "vitest", config: null }),
+			runTestFile: () => ({ failed: 1, error: false }),
+		},
+		goClient: { isGoAvailable: () => false },
+		rustClient: { isAvailable: () => false },
+		ensureTool: vi.fn(async () => null),
+		cleanStaleTsBuildInfo: () => [],
+		resetDispatchBaselines: () => {},
+		resetLSPService: () => {},
+	} as any;
+}
+
+describe("warmFiles session start", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.mocked(loadLSPConfig).mockResolvedValue({});
+		vi.mocked(getLSPService).mockReturnValue({
+			touchFile: mockTouchFile,
+		} as any);
+	});
+
+	afterEach(() => {
+		delete process.env.PI_LENS_STARTUP_MODE;
+	});
+
+	it("calls touchFile for each warm file in .pi-lens/lsp.json", async () => {
+		const env = setupTestEnvironment("pi-lens-warm-");
+		const restoreStartupMode = setStartupMode("full");
+
+		createTempFile(env.tmpDir, "src/main.cpp", "int main() {}");
+		createTempFile(env.tmpDir, "src/engine.cpp", "void engine() {}");
+
+		vi.mocked(loadLSPConfig).mockResolvedValue({
+			warmFiles: ["src/main.cpp", "src/engine.cpp"],
+		});
+
+		try {
+			await handleSessionStart(makeDeps({ ctxCwd: env.tmpDir }));
+
+			expect(mockTouchFile).toHaveBeenCalledTimes(2);
+
+			const calls = mockTouchFile.mock.calls as Array<
+				[string, string, Record<string, unknown>]
+			>;
+
+			expect(calls[0][0]).toContain("main.cpp");
+			expect(calls[0][1]).toContain("int main()");
+			expect(calls[0][2]).toMatchObject({
+				source: "startup-warm",
+				clientScope: "primary",
+			});
+
+			expect(calls[1][0]).toContain("engine.cpp");
+			expect(calls[1][1]).toContain("void engine()");
+			expect(calls[1][2]).toMatchObject({
+				source: "startup-warm",
+				clientScope: "primary",
+			});
+
+			expect(initLSPConfig).toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+			restoreStartupMode();
+		}
+	}, 15_000);
+
+	it("skips touchFile when warmFiles is empty", async () => {
+		const env = setupTestEnvironment("pi-lens-warm-");
+		const restoreStartupMode = setStartupMode("full");
+
+		vi.mocked(loadLSPConfig).mockResolvedValue({});
+
+		try {
+			await handleSessionStart(makeDeps({ ctxCwd: env.tmpDir }));
+			expect(mockTouchFile).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+			restoreStartupMode();
+		}
+	});
+
+	it("skips touchFile when no-lsp flag is set", async () => {
+		const env = setupTestEnvironment("pi-lens-warm-");
+		const restoreStartupMode = setStartupMode("full");
+
+		vi.mocked(loadLSPConfig).mockResolvedValue({
+			warmFiles: ["src/main.cpp"],
+		});
+		createTempFile(env.tmpDir, "src/main.cpp", "int main() {}");
+
+		try {
+			await handleSessionStart(
+				makeDeps({
+					ctxCwd: env.tmpDir,
+					getFlag: (name: string) => name === "no-lsp",
+				}),
+			);
+			expect(mockTouchFile).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+			restoreStartupMode();
+		}
+	});
+});


### PR DESCRIPTION
This PR adds missing extensions for `clangd`, along with some extension-related cleanup and refactoring.

Added a new "warmFiles" LSP config option: this allows to specify files which should be loaded at session start.

This option provides a solution to the problem of interfacing with language-servers that only perform background or on-demand indexing of translation-units, since they may return incomplete or partial results depending on whether they have encountered the correct TUs already.

For example, with `clangd`, you would specify the entry point to your application or library this way:

```json5
// .pi-lens/lsp.json
{
    warmFiles: ["src/main.cpp", "src/lib.cpp"]
}
```