### PR TITLE
Respect PILENS_DATA_DIR for rule cache

### DIFF
--- a/clients/cache/rule-cache.ts
+++ b/clients/cache/rule-cache.ts
@@ -8,6 +8,7 @@
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { getProjectDataDir } from "../file-utils.js";
 
 const CACHE_VERSION = "v1";
 
@@ -34,7 +35,7 @@ export class RuleCache {
 	private cacheDir: string;
 
 	constructor(language: string, rootDir = process.cwd()) {
-		this.cacheDir = path.join(rootDir, ".pi-lens", "cache");
+		this.cacheDir = path.join(getProjectDataDir(rootDir), "cache");
 		this.cacheFile = path.join(
 			this.cacheDir,
 			`${language}-rules-${CACHE_VERSION}.json`,

--- a/tests/clients/file-utils.test.ts
+++ b/tests/clients/file-utils.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { RuleCache } from "../../clients/cache/rule-cache.js";
 import { getProjectDataDir } from "../../clients/file-utils.js";
 import { appendToWorklog } from "../../clients/fix-worklog.js";
 
@@ -80,6 +81,23 @@ describe("getProjectDataDir", () => {
 		expect(fs.existsSync(path.join(cwd, ".pi-lens"))).toBe(false);
 		expect(
 			fs.existsSync(path.join(getProjectDataDir(cwd), "worklog.jsonl")),
+		).toBe(true);
+	});
+
+	it("stores rule cache under the configured data directory", () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-rule-cache-"));
+		process.env.PILENS_DATA_DIR = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-global-data-"),
+		);
+		const cache = new RuleCache("typescript", cwd);
+
+		cache.set([], []);
+
+		expect(fs.existsSync(path.join(cwd, ".pi-lens"))).toBe(false);
+		expect(
+			fs.existsSync(
+				path.join(getProjectDataDir(cwd), "cache", "typescript-rules-v1.json"),
+			),
 		).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

- Store tree-sitter rule cache files under `getProjectDataDir(rootDir)` instead of `<cwd>/.pi-lens/cache`.
- Add a regression test that confirms `RuleCache` respects `PILENS_DATA_DIR` and does not create a project-local `.pi-lens` directory.

## Tests

- `npm run lint`
- `npm test -- tests/clients/file-utils.test.ts`