### PR TITLE
fix: preserve user prompt after context injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ At `session_start`, pi-lens:
 - applies language-aware startup defaults for tool preinstall
 - warms caches and optional indexes (with overlap/session guardrails)
 - emits missing-tool install hints for detected languages when relevant
-- injects session guidance through internal context (non-user channel) to reduce acknowledgement-only first responses
+- prepends session guidance before the user's prompt so provider bridges keep the real prompt active
 - opens `warmFiles` (if configured in `.pi-lens/lsp.json`) to seed lazy-indexing language servers like clangd before the first symbol query
 
 For one-shot print sessions (for example `pi --print ...`), pi-lens auto-uses a quick startup path that skips heavy bootstrap work to reduce startup latency. Override with `PI_LENS_STARTUP_MODE=full|minimal|quick`.

--- a/index.ts
+++ b/index.ts
@@ -1321,9 +1321,9 @@ export default function (pi: ExtensionAPI) {
 	// --- Inject turn-end findings into next agent turn ---
 	// jscpd, madge, and turn-end delta results are cached at turn_end and consumed here
 	// via the context event, which fires before each provider request.
-	// Important: context handlers must APPEND to the existing message list, not replace it.
-	// Replacing `event.messages` can drop the user's first prompt entirely, which causes
-	// OpenAI Responses requests to fail with: "One of input/previous_response_id/prompt/conversation_id must be provided."
+	// Important: keep the user's prompt as the trailing message. Some provider bridges
+	// treat the final message as the active user action, so pi-lens context must be
+	// prepended instead of appended.
 	// biome-ignore lint/suspicious/noExplicitAny: pi.on("context") overload has TS resolution bug
 	(pi as any).on(
 		"context",
@@ -1348,7 +1348,7 @@ export default function (pi: ExtensionAPI) {
 						?.messages ?? [];
 
 				return {
-					messages: [...existingMessages, ...injectedMessages],
+					messages: [...injectedMessages, ...existingMessages],
 				};
 			} catch (err) {
 				dbg(`context event error: ${err}`);

--- a/tests/index-integration.test.ts
+++ b/tests/index-integration.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CacheManager } from "../clients/cache-manager.js";
 
 // Mock read-guard for integration tests to avoid dynamic require issues
 vi.mock("../clients/read-guard.js", () => ({
@@ -179,6 +180,35 @@ describe("index.ts integration", () => {
 
 		expect(handleSessionStartMock).toHaveBeenCalledTimes(1);
 		expect(ensureToolMock).toHaveBeenCalledWith("typescript-language-server");
+	}, 15_000);
+
+	it("context handler prepends injected guidance before the user prompt", async () => {
+		const { default: registerExtension } = await import("../index.ts");
+		const { pi, handlers } = createMockPi();
+		registerExtension(pi as any);
+
+		const cacheManager = new CacheManager(false);
+		cacheManager.writeCache(
+			"session-start-guidance",
+			{ content: "Use pi-lens tools when useful." },
+			tmpDir,
+		);
+
+		const context = handlers.context?.[0];
+		expect(context).toBeTypeOf("function");
+
+		const userMessage = { role: "user", content: "Fix the bug" };
+		const result = await context?.({ messages: [userMessage] }, { cwd: tmpDir });
+
+		expect(result).toEqual({
+			messages: [
+				expect.objectContaining({
+					role: "user",
+					content: expect.stringContaining("[pi-lens] Session guidance"),
+				}),
+				userMessage,
+			],
+		});
 	}, 15_000);
 
 	it("tool_call handler executes captureSnapshot and similarity paths without crashing", async () => {


### PR DESCRIPTION
## Why

Some provider bridges treat the final context message as the active user action. When pi-lens appends session guidance after the user's prompt, those bridges can receive the guidance as the prompt and demote the real request to earlier context.

## Context

This keeps pi-lens guidance in the provider context but prepends it before the existing messages. The user's submitted prompt stays last, which matches bridge expectations while preserving the guidance.

## Testing

- `npm run lint`
- `npm run build`
- `npm test -- tests/index-integration.test.ts`
- `npm test`
