### PR TITLE
fix: pass readGuard to handleToolResult deps

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1522,6 +1522,7 @@ export default function (pi: ExtensionAPI) {
 			ruffClient,
 			metricsClient,
 			resetLSPService,
+			readGuard: runtime.readGuard,
 			agentBehaviorRecord: (toolName, filePath) =>
 				agentBehaviorClient.recordToolCall(toolName, filePath),
 			formatBehaviorWarnings: (warnings) =>


### PR DESCRIPTION
## Summary

`ToolResultDeps.readGuard` was declared in the interface but never passed from the `tool_result` event handler, making `deps.readGuard` always `undefined`.

## Impact

This silently disabled two `recordWritten()` calls:

1. **Line 148** — `deps.readGuard?.recordWritten(filePath)` at tool_result entry
2. **Line 354** — `deps.readGuard?.recordWritten(changedFile)` post-pipeline

The second one is the most impactful: when autofix or immediate-format modifies a file during the post-write pipeline, the ReadGuard's `FileTime` stamp was not refreshed. This caused the *next* same-turn edit on the same file to trigger a spurious `"File modified since read"` block — even though the agent itself just wrote it.

Only the inline `runtime.readGuard` path (lines 203–208) was working, which happens before the pipeline runs. The post-pipeline refresh for autofix-changed files was completely missed.

## Fix

One-liner: add `readGuard: runtime.readGuard` to the `handleToolResult()` call.