### PR TITLE
fix(knip): async analyze, in-flight guard, and bail when no project root

### DIFF
--- a/clients/knip-client.ts
+++ b/clients/knip-client.ts
@@ -11,7 +11,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { safeSpawn, safeSpawnAsync } from "./safe-spawn.js";
+import { safeSpawnAsync } from "./safe-spawn.js";
 
 // --- Types ---
 
@@ -33,11 +33,37 @@ export interface KnipResult {
 	summary: string;
 }
 
+const EMPTY_RESULT: Omit<KnipResult, "summary"> = {
+	success: false,
+	issues: [],
+	unusedExports: [],
+	unusedFiles: [],
+	unusedDeps: [],
+	unlistedDeps: [],
+};
+
+const ANALYSIS_TIMEOUT_MS = 30_000;
+
 // --- Client ---
 
 export class KnipClient {
 	private knipAvailable: boolean | null = null;
 	private log: (msg: string) => void;
+
+	/**
+	 * De-dupe concurrent `analyze()` calls against the same project root.
+	 *
+	 * Without this guard, two back-to-back turn_end events (or a turn_end
+	 * firing while the session_start scan is still in flight) can each spawn
+	 * a fresh `npx knip` process over the same tree. Two concurrent knip
+	 * runs are CPU-bound and cause the exact pathology we're fixing: load
+	 * averages >5, TUI freezes, and zombie processes reparented to init
+	 * after pi exits mid-scan.
+	 *
+	 * Key: canonicalised project root (not the caller's cwd). Value is the
+	 * in-flight promise; completing clears the slot.
+	 */
+	private inFlight = new Map<string, Promise<KnipResult>>();
 
 	constructor(verbose = false) {
 		this.log = verbose
@@ -45,23 +71,35 @@ export class KnipClient {
 			: () => {};
 	}
 
-	private resolveProjectRoot(startDir: string): string {
+	/**
+	 * Find the nearest directory with a project/knip config marker.
+	 *
+	 * Returns `null` when no marker is found up to the filesystem root.
+	 * Callers MUST treat a null return as "no project here, skip knip" —
+	 * previously this fell back to `startDir`, which on a bare cwd like
+	 * `/home/v` caused knip to recurse through every project and balloon
+	 * memory/CPU.
+	 */
+	private resolveProjectRoot(startDir: string): string | null {
+		const markers = [
+			"package.json",
+			"knip.json",
+			"knip.ts",
+			"knip.config.js",
+			"knip.config.ts",
+		];
 		let current = path.resolve(startDir);
-		while (true) {
-			const markers = [
-				"package.json",
-				"knip.json",
-				"knip.ts",
-				"knip.config.js",
-				"knip.config.ts",
-			];
+		// Safety bound: in practice depths are ~10. This cap just prevents a
+		// pathological symlink loop from hanging the search.
+		for (let depth = 0; depth < 64; depth++) {
 			if (markers.some((m) => fs.existsSync(path.join(current, m)))) {
 				return current;
 			}
 			const parent = path.dirname(current);
-			if (parent === current) return path.resolve(startDir);
+			if (parent === current) return null;
 			current = parent;
 		}
+		return null;
 	}
 
 	/**
@@ -97,95 +135,96 @@ export class KnipClient {
 	}
 
 	/**
-	 * Check if knip CLI is available (legacy sync method)
-	 * Prefer ensureAvailable() for auto-install behavior
+	 * Run knip analysis on the project.
+	 *
+	 * Async (uses `safeSpawnAsync`) so it never blocks the event loop —
+	 * knip scans on large monorepos can take tens of seconds, and the
+	 * previous `spawnSync` implementation froze the TUI for the entire
+	 * duration.
+	 *
+	 * Re-entrancy safe: concurrent calls resolving to the same project
+	 * root share a single knip process via `inFlight`.
 	 */
-	isAvailable(): boolean {
-		if (this.knipAvailable !== null) return this.knipAvailable;
-
-		const result = safeSpawn("npx", ["knip", "--version"], {
-			timeout: 10000,
-		});
-
-		this.knipAvailable = !result.error && result.status === 0;
-		if (this.knipAvailable) {
-			this.log(`Knip available`);
-		}
-
-		return this.knipAvailable;
-	}
-
-	/**
-	 * Run knip analysis on the project
-	 */
-	analyze(cwd?: string, _ignore?: string[]): KnipResult {
-		if (!this.isAvailable()) {
+	async analyze(cwd?: string, _ignore?: string[]): Promise<KnipResult> {
+		if (!(await this.ensureAvailable())) {
 			return {
-				success: false,
-				issues: [],
-				unusedExports: [],
-				unusedFiles: [],
-				unusedDeps: [],
-				unlistedDeps: [],
+				...EMPTY_RESULT,
 				summary: "Knip not available. Install with: npm install -D knip",
 			};
 		}
 
 		const targetDir = this.resolveProjectRoot(cwd || process.cwd());
-
-		try {
-			const args = [
-				"knip",
-				"--reporter=json",
-				"--include",
-				"files,exports,types,dependencies,unlisted",
-			];
-
-			const result = safeSpawn("npx", args, {
-				timeout: 30000,
-				cwd: targetDir,
-			});
-
-			// Knip exits 0 on success (even with issues), 1 on errors
-			const output = result.stdout || "";
-			this.log(`Knip output length: ${output.length}`);
-			if (output.length < 500) {
-				this.log(`Knip output sample: ${output}`);
-			}
-			if (!output.trim()) {
-				return {
-					success: true,
-					issues: [],
-					unusedExports: [],
-					unusedFiles: [],
-					unusedDeps: [],
-					unlistedDeps: [],
-					summary: "No issues found",
-				};
-			}
-
-			return this.parseOutput(output);
-		} catch (err: any) {
-			this.log(`Analysis error: ${err.message}`);
+		if (!targetDir) {
+			// No package.json / knip config anywhere up the tree. Running knip
+			// from an arbitrary cwd (e.g. $HOME) has no defined meaning and in
+			// practice walks huge irrelevant trees — bail early.
+			this.log(
+				`No project root found from ${cwd || process.cwd()}; skipping knip`,
+			);
 			return {
-				success: false,
-				issues: [],
-				unusedExports: [],
-				unusedFiles: [],
-				unusedDeps: [],
-				unlistedDeps: [],
-				summary: `Error: ${err.message}`,
+				...EMPTY_RESULT,
+				success: true,
+				summary: "No project root found; knip skipped",
 			};
 		}
+
+		const key = path.resolve(targetDir);
+		const existing = this.inFlight.get(key);
+		if (existing) {
+			this.log(`Analysis already in flight for ${key}; sharing result`);
+			return existing;
+		}
+
+		const promise = this.runAnalyze(key).finally(() => {
+			this.inFlight.delete(key);
+		});
+		this.inFlight.set(key, promise);
+		return promise;
+	}
+
+	private async runAnalyze(targetDir: string): Promise<KnipResult> {
+		const args = [
+			"knip",
+			"--reporter=json",
+			"--include",
+			"files,exports,types,dependencies,unlisted",
+		];
+
+		const result = await safeSpawnAsync("npx", args, {
+			timeout: ANALYSIS_TIMEOUT_MS,
+			cwd: targetDir,
+		});
+
+		if (result.error) {
+			this.log(`Analysis error: ${result.error.message}`);
+			return {
+				...EMPTY_RESULT,
+				summary: `Error: ${result.error.message}`,
+			};
+		}
+
+		// Knip exits 0 on success (even with issues), 1 on errors
+		const output = result.stdout || "";
+		this.log(`Knip output length: ${output.length}`);
+		if (output.length < 500) {
+			this.log(`Knip output sample: ${output}`);
+		}
+		if (!output.trim()) {
+			return {
+				...EMPTY_RESULT,
+				success: true,
+				summary: "No issues found",
+			};
+		}
+
+		return this.parseOutput(output);
 	}
 
 	/**
 	 * Find unused exports in a specific file
 	 */
-	findUnusedExports(filePath: string): string[] {
-		const result = this.analyze(
-			this.resolveProjectRoot(path.dirname(filePath)),
-		);
+	async findUnusedExports(filePath: string): Promise<string[]> {
+		const result = await this.analyze(path.dirname(filePath));
 		const basename = path.basename(filePath);
 
 		return result.unusedExports
@@ -344,12 +383,7 @@ export class KnipClient {
 			void err;
 			this.log("Failed to parse knip JSON output");
 			return {
-				success: false,
-				issues: [],
-				unusedExports: [],
-				unusedFiles: [],
-				unusedDeps: [],
-				unlistedDeps: [],
+				...EMPTY_RESULT,
 				summary: "Failed to parse output",
 			};
 		}

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -9,7 +9,7 @@ import { clearAllSessions as clearFileTimeSessions } from "./file-time.js";
 import { getKnipIgnorePatterns } from "./file-utils.js";
 import type { GoClient } from "./go-client.js";
 import type { JscpdClient } from "./jscpd-client.js";
-import type { KnipClient } from "./knip-client.js";
+import type { KnipClient, KnipResult } from "./knip-client.js";
 import { canRunStartupHeavyScans } from "./language-policy.js";
 import {
 	detectProjectLanguageProfile,
@@ -258,10 +258,7 @@ function scheduleStartupScans(
 	runTask("knip", async () => {
 		if (await knipClient.ensureAvailable()) {
 			if (!runtime.isCurrentSession(sessionGeneration)) return;
-			const cached = cacheManager.readCache<ReturnType<KnipClient["analyze"]>>(
-				"knip",
-				analysisRoot,
-			);
+			const cached = cacheManager.readCache<KnipResult>("knip", analysisRoot);
 			if (cached) {
 				if (!runtime.isCurrentSession(sessionGeneration)) return;
 				dbg(
@@ -269,7 +266,7 @@ function scheduleStartupScans(
 				);
 			} else {
 				const startMs = Date.now();
-				const knipResult = knipClient.analyze(
+				const knipResult = await knipClient.analyze(
 					analysisRoot,
 					getKnipIgnorePatterns(),
 				);

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -8,7 +8,7 @@ import {
 	toRunnerDisplayPath,
 } from "./dispatch/runner-context.js";
 import { getKnipIgnorePatterns } from "./file-utils.js";
-import type { KnipClient, KnipIssue } from "./knip-client.js";
+import type { KnipClient, KnipIssue, KnipResult } from "./knip-client.js";
 import { logLatency } from "./latency-logger.js";
 import { RUNTIME_CONFIG } from "./runtime-config.js";
 import type { RuntimeCoordinator } from "./runtime-coordinator.js";
@@ -204,11 +204,8 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 		dbg("turn_end: skipping knip (startup scan still in flight)");
 		knipMeta = { skipped: true };
 	} else if (await knipClient.ensureAvailable()) {
-		const knipResult = knipClient.analyze(cwd, getKnipIgnorePatterns());
-		const prevKnip = cacheManager.readCache<ReturnType<KnipClient["analyze"]>>(
-			"knip",
-			cwd,
-		);
+		const knipResult = await knipClient.analyze(cwd, getKnipIgnorePatterns());
+		const prevKnip = cacheManager.readCache<KnipResult>("knip", cwd);
 		cacheManager.writeCache("knip", knipResult, cwd);
 		knipMeta = {
 			success: knipResult.success,

--- a/commands/booboo.ts
+++ b/commands/booboo.ts
@@ -848,7 +848,7 @@ export async function handleBooboo(
 			return { findings: 0, status: "skipped" };
 		}
 
-		const knipResult = clients.knip.analyze(
+		const knipResult = await clients.knip.analyze(
 			targetPath,
 			getKnipIgnorePatterns(),
 		);

--- a/tests/clients/knip-client.test.ts
+++ b/tests/clients/knip-client.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { KnipClient } from "../../clients/knip-client.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
@@ -13,12 +14,162 @@ describe("knip-client", () => {
 			fs.mkdirSync(nested, { recursive: true });
 
 			const client = new KnipClient(false) as unknown as {
-				resolveProjectRoot: (startDir: string) => string;
+				resolveProjectRoot: (startDir: string) => string | null;
 			};
 
 			expect(client.resolveProjectRoot(nested)).toBe(tmpDir);
 		} finally {
 			cleanup();
+		}
+	});
+
+	it("returns null when no project markers exist up the tree", () => {
+		// Regression: previously fell back to startDir, causing knip to scan
+		// arbitrary directories like $HOME when run from a bare cwd.
+		const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-knip-none-"));
+		try {
+			const nested = path.join(tmpRoot, "deep", "nowhere");
+			fs.mkdirSync(nested, { recursive: true });
+
+			const client = new KnipClient(false) as unknown as {
+				resolveProjectRoot: (startDir: string) => string | null;
+			};
+
+			// No package.json anywhere from `nested` up to filesystem root of tmp.
+			// Real filesystem root may have a marker, so we can't assert null on an
+			// unbounded walk — but we CAN assert it doesn't return the startDir
+			// (the old buggy fallback).
+			const resolved = client.resolveProjectRoot(nested);
+			expect(resolved).not.toBe(nested);
+		} finally {
+			fs.rmSync(tmpRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("analyze() short-circuits when no project root is found", async () => {
+		// Regression: previously knip was spawned with cwd=$HOME and recursed
+		// through every sibling project, causing CPU/memory spikes.
+		const tmpRoot = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-knip-skip-"),
+		);
+		try {
+			const client = new KnipClient(false) as unknown as {
+				resolveProjectRoot: (s: string) => string | null;
+				ensureAvailable: () => Promise<boolean>;
+				runAnalyze: (d: string) => Promise<unknown>;
+				analyze: (cwd?: string) => Promise<{
+					success: boolean;
+					issues: unknown[];
+					summary: string;
+				}>;
+			};
+
+			// Pretend knip is installed so we reach the project-root check.
+			vi.spyOn(client, "ensureAvailable").mockResolvedValue(true);
+			// Force project-root resolution to fail.
+			vi.spyOn(client, "resolveProjectRoot").mockReturnValue(null);
+			const runSpy = vi.spyOn(client, "runAnalyze");
+
+			const result = await client.analyze(tmpRoot);
+
+			expect(result.success).toBe(true);
+			expect(result.issues).toHaveLength(0);
+			expect(result.summary).toMatch(/skipped|no project/i);
+			expect(runSpy).not.toHaveBeenCalled();
+		} finally {
+			fs.rmSync(tmpRoot, { recursive: true, force: true });
+			vi.restoreAllMocks();
+		}
+	});
+
+	it("analyze() returns a Promise (non-blocking)", async () => {
+		// Regression: analyze() used to be sync (spawnSync), blocking the event
+		// loop. The TypeScript signature alone doesn't enforce this at runtime,
+		// so we check that the returned value is actually a Promise.
+		const client = new KnipClient(false);
+		const ret = client.analyze("/definitely/not/a/project/path/for/tests");
+		expect(ret).toBeInstanceOf(Promise);
+		// Await so we don't leave a pending spawn behind.
+		await ret;
+	});
+
+	it("de-dupes concurrent analyze() calls for the same project root", async () => {
+		// Regression: back-to-back turn_end events (or turn_end during a
+		// session_start scan) could spawn two `npx knip` processes against
+		// the same tree. Two concurrent knip runs pegged both CPU cores to
+		// 100% and caused the TUI freezes this PR is fixing.
+		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-knip-dedupe-");
+		try {
+			fs.writeFileSync(path.join(tmpDir, "package.json"), '{"name":"demo"}');
+
+			const client = new KnipClient(false) as unknown as {
+				ensureAvailable: () => Promise<boolean>;
+				runAnalyze: (d: string) => Promise<{
+					success: boolean;
+					issues: unknown[];
+					summary: string;
+				}>;
+				analyze: (cwd?: string) => Promise<unknown>;
+			};
+
+			vi.spyOn(client, "ensureAvailable").mockResolvedValue(true);
+
+			type RunResolver = (v: {
+				success: boolean;
+				issues: unknown[];
+				unusedExports: unknown[];
+				unusedFiles: unknown[];
+				unusedDeps: unknown[];
+				unlistedDeps: unknown[];
+				summary: string;
+			}) => void;
+			let resolveRun: RunResolver | null = null;
+			let runCalls = 0;
+			const runSpy = vi.spyOn(client, "runAnalyze").mockImplementation(
+				() =>
+					new Promise((res) => {
+						runCalls++;
+						resolveRun = res as unknown as RunResolver;
+					}),
+			);
+
+			const first = client.analyze(tmpDir);
+			const second = client.analyze(tmpDir);
+
+			// Let microtasks settle so both analyze() calls reach runAnalyze check.
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(runCalls).toBe(1);
+			expect(runSpy).toHaveBeenCalledTimes(1);
+
+			// Resolve the single in-flight run with the same result for both.
+			const payload = {
+				success: true,
+				issues: [],
+				unusedExports: [],
+				unusedFiles: [],
+				unusedDeps: [],
+				unlistedDeps: [],
+				summary: "ok",
+			};
+			(resolveRun as RunResolver | null)?.(payload);
+
+			const [a, b] = await Promise.all([first, second]);
+			expect(a).toBe(b);
+
+			// A subsequent call AFTER the first completes should spawn a new run.
+			resolveRun = null;
+			runCalls = 0;
+			const third = client.analyze(tmpDir);
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(runCalls).toBe(1);
+			(resolveRun as RunResolver | null)?.(payload);
+			await third;
+		} finally {
+			cleanup();
+			vi.restoreAllMocks();
 		}
 	});
 


### PR DESCRIPTION
## Summary

Knip was spawned **synchronously** from `handleTurnEnd` via `safeSpawn` (a `spawnSync` wrapper the file itself flags as deprecated and event-loop-blocking). On top of that, nothing guarded against concurrent runs, and `resolveProjectRoot()` silently fell back to the caller's `cwd` when no project marker was found. Combined, this reliably caused:

- Two concurrent `npx knip --reporter=json --include files,exports,types,dependencies,unlisted` processes each pegging a CPU core to 100%, load avg >5, TUI frozen for the duration of the scan.
- Zombie `knip` processes reparented to `systemd --user` after pi exited mid-scan.
- From a bare `cwd` like `$HOME`, knip recursing through every sibling project under home before timing out at 30s — the original symptom the user reported (`htop` showing two top processes being `node .../.bin/knip`, load 5.14, both CPUs saturated).

Reproducible by running pi from a directory without a `package.json` while pi-lens is enabled: `session_start` spawns a knip background task, then the first `turn_end` fires a second one before the first finishes.

## Root causes (all three fixed)

1. `KnipClient.analyze()` used `safeSpawn` (sync). See [`safe-spawn.ts` itself](./clients/safe-spawn.ts): *"⚠️ DEPRECATED: Use safeSpawnAsync instead. This blocks the entire Node.js event loop until the process exits. If the process hangs, pi will freeze."*
2. `handleTurnEnd` is async and re-entrant. Without an in-flight guard in `KnipClient`, two back-to-back turn_ends, or a turn_end during a session_start scan, spawned two parallel `npx knip` processes over the same tree.
3. `resolveProjectRoot()` returned `startDir` as a fallback when no `package.json` / `knip.*` marker was found, so knip ran from arbitrary directories and walked huge unrelated trees.

## Fix

- Migrate `KnipClient.analyze()` and `findUnusedExports()` to `async` and `safeSpawnAsync`.
- Extract the spawn into `runAnalyze()` and add `inFlight: Map<projectRoot, Promise<KnipResult>>`. Concurrent `analyze()` calls against the same root share a single process; the slot clears when the run settles. A subsequent call after completion spawns fresh as expected.
- Return `null` from `resolveProjectRoot()` when no marker is found, and short-circuit `analyze()` with a `{ success: true, summary: "No project root found; knip skipped" }` result in that case. Added a safety-bound loop cap (64) to guard against symlink loops.
- Remove the unused legacy sync `isAvailable()` method (only caller was `analyze()` itself; `ensureAvailable()` is already the supported async path with auto-install).

## Call-site updates

- `clients/runtime-turn.ts`: `await knipClient.analyze(...)`. Refreshed `cacheManager.readCache<T>()` generic to use `KnipResult` directly (was `ReturnType<KnipClient['analyze']>`, now `Promise<KnipResult>`).
- `clients/runtime-session.ts`: same treatment for the session_start background task.
- `commands/booboo.ts`: `await clients.knip.analyze(...)` in the dead-code runner.

## Tests

`tests/clients/knip-client.test.ts`:

- **Existing** `resolveProjectRoot` test updated for the nullable return type.
- **New** `resolveProjectRoot` returns something other than `startDir` when no markers exist up the tree (catches the old buggy fallback).
- **New** `analyze()` short-circuits with no spawn when no project root is found (regression guard for `$HOME` scans).
- **New** `analyze()` returns a Promise at runtime — the TS signature alone doesn't catch someone regressing to `spawnSync`.
- **New** Concurrent `analyze()` for the same root runs exactly one spawn and both callers receive the same result; a later call after completion spawns fresh.

## Verification

```bash
npx tsc --project tsconfig.json --noEmit   # clean
npx tsc --project tsconfig.build.json       # clean
npx vitest run tests/clients/knip-client.test.ts  # 6/6 pass
npx vitest run tests/clients/session-start-parallelism.test.ts \
               tests/clients/runtime-turn-session.test.ts \
               tests/clients/runtime-session.test.ts  # 22/22 pass
```

Full suite on `master` already had 3 pre-existing failures (`tests/clients/formatters.test.ts` venv-fallback, two `tests/clients/installer/tool-discovery.test.ts` timeouts) — unrelated to this change; confirmed by stashing the diff and re-running on untouched `master`.

## Notes for reviewers

- API is now async: `analyze()` and `findUnusedExports()` return Promises. All callers in this repo are updated.
- The in-flight map is unbounded in theory but keyed by canonical project root (pi-lens analyses at most a handful of roots per session), and entries always clear via `.finally()`.