### PR TITLE
Fix Knip scans escaping non-JS repo roots

### DIFF
--- a/clients/knip-client.ts
+++ b/clients/knip-client.ts
@@ -10,6 +10,7 @@
  */
 
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { safeSpawnAsync } from "./safe-spawn.js";
 
@@ -56,7 +57,7 @@ export class KnipClient {
 	 *
 	 * Without this guard, two back-to-back turn_end events (or a turn_end
 	 * firing while the session_start scan is still in flight) can each spawn
-	 * a fresh `npx knip` process over the same tree. Two concurrent knip
+	 * a fresh `knip` process over the same tree. Two concurrent knip
 	 * runs are CPU-bound and cause the exact pathology we're fixing: load
 	 * averages >5, TUI freezes, and zombie processes reparented to init
 	 * after pi exits mid-scan.
@@ -89,13 +90,32 @@ export class KnipClient {
 			"knip.config.js",
 			"knip.config.ts",
 		];
-		let current = path.resolve(startDir);
+		const boundaries = [".git", ".hg", ".svn"];
+		const homeDir = path.resolve(os.homedir());
+		const initialDir = path.resolve(startDir);
+		let current = initialDir;
 		// Safety bound: in practice depths are ~10. This cap just prevents a
 		// pathological symlink loop from hanging the search.
 		for (let depth = 0; depth < 64; depth++) {
 			if (markers.some((m) => fs.existsSync(path.join(current, m)))) {
 				return current;
 			}
+
+			// Do not escape the current repository just to find an unrelated parent
+			// package.json. Unity/non-JS repos often have no package.json at their
+			// root; walking past their .git boundary can accidentally pick up
+			// ~/package.json and make knip scan the entire home directory.
+			if (boundaries.some((m) => fs.existsSync(path.join(current, m)))) {
+				return null;
+			}
+
+			// Likewise, never treat the user's home-level package.json as the project
+			// for a nested cwd. It is almost always tool/config noise, and scanning
+			// HOME is both slow and crash-prone.
+			if (current === homeDir && initialDir !== homeDir) {
+				return null;
+			}
+
 			const parent = path.dirname(current);
 			if (parent === current) return null;
 			current = parent;
@@ -195,15 +215,15 @@ export class KnipClient {
 
 	private async runAnalyze(targetDir: string): Promise<KnipResult> {
 		const args = [
-			"knip",
 			"--reporter=json",
 			"--include",
 			"files,exports,types,dependencies,unlisted",
 		];
 
-		const result = await safeSpawnAsync("npx", args, {
+		const result = await safeSpawnAsync("knip", args, {
 			timeout: ANALYSIS_TIMEOUT_MS,
 			cwd: targetDir,
+			env: await this.getKnipEnvironment(targetDir),
 		});
 
 		if (result.error) {
@@ -229,6 +249,21 @@ export class KnipClient {
 		}
 
 		return this.parseOutput(output);
+	}
+
+	private async getKnipEnvironment(targetDir: string): Promise<NodeJS.ProcessEnv> {
+		const { getToolEnvironment } = await import("./installer/index.js");
+		const env = await getToolEnvironment();
+		const separator = process.platform === "win32" ? ";" : ":";
+		const currentPath = env.PATH || env.Path || process.env.PATH || "";
+		const localBin = path.join(targetDir, "node_modules", ".bin");
+		const augmentedPath = `${localBin}${separator}${currentPath}`;
+
+		return {
+			...env,
+			PATH: augmentedPath,
+			...(process.platform === "win32" ? { Path: augmentedPath } : {}),
+		};
 	}
 
 	/**

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -256,29 +256,26 @@ function scheduleStartupScans(
 
 	// Knip — dead code / unused exports
 	runTask("knip", async () => {
-		if (await knipClient.ensureAvailable()) {
+		if (!runtime.isCurrentSession(sessionGeneration)) return;
+		const cached = cacheManager.readCache<KnipResult>("knip", analysisRoot);
+		if (cached) {
 			if (!runtime.isCurrentSession(sessionGeneration)) return;
-			const cached = cacheManager.readCache<KnipResult>("knip", analysisRoot);
-			if (cached) {
-				if (!runtime.isCurrentSession(sessionGeneration)) return;
-				dbg(
-					`session_start Knip: cache hit (${Math.round((Date.now() - new Date(cached.meta.timestamp).getTime()) / 1000)}s ago)`,
-				);
-			} else {
-				const startMs = Date.now();
-				const knipResult = await knipClient.analyze(
-					analysisRoot,
-					getKnipIgnorePatterns(),
-				);
-				if (!runtime.isCurrentSession(sessionGeneration)) return;
-				cacheManager.writeCache("knip", knipResult, analysisRoot, {
-					scanDurationMs: Date.now() - startMs,
-				});
-				dbg(`session_start Knip scan done (${Date.now() - startMs}ms)`);
-			}
+			dbg(
+				`session_start Knip: cache hit (${Math.round((Date.now() - new Date(cached.meta.timestamp).getTime()) / 1000)}s ago)`,
+			);
 		} else {
+			// KnipClient skips before probing/installing when analysisRoot is not a real
+			// JS/Knip project. This avoids running knip from Unity/C#/generic repos.
+			const startMs = Date.now();
+			const knipResult = await knipClient.analyze(
+				analysisRoot,
+				getKnipIgnorePatterns(),
+			);
 			if (!runtime.isCurrentSession(sessionGeneration)) return;
-			dbg("session_start Knip: not available");
+			cacheManager.writeCache("knip", knipResult, analysisRoot, {
+				scanDurationMs: Date.now() - startMs,
+			});
+			dbg(`session_start Knip scan done (${Date.now() - startMs}ms)`);
 		}
 	});
 

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -208,67 +208,87 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	if (runtime.isStartupScanInFlight("knip")) {
 		dbg("turn_end: skipping knip (startup scan still in flight)");
 		knipMeta = { skipped: true };
-	} else if (await knipClient.ensureAvailable()) {
-		const knipResult = await knipClient.analyze(cwd, getKnipIgnorePatterns());
+	} else {
+		// Let KnipClient resolve/validate a real JS project root before probing or
+		// auto-installing knip. Non-JS repos (for example Unity projects) should not
+		// run tool checks every turn. Also back off after a timeout/kill so every
+		// agent turn does not spend 30s launching another heavyweight knip process.
 		const prevKnip = cacheManager.readCache<KnipResult>("knip", cwd);
-		cacheManager.writeCache("knip", knipResult, cwd);
-		knipMeta = {
-			success: knipResult.success,
-			totalIssues: knipResult.issues.length,
-			newIssues: 0,
-			blockerIssues: 0,
-			...(!knipResult.success && { reason: knipResult.summary }),
-		};
-
-		if (knipResult.success && knipResult.issues.length > 0) {
-			const issueKey = (i: KnipIssue) =>
-				`${i.type}:${i.file ?? ""}:${i.name}:${i.line ?? 0}:${i.package ?? ""}`;
-			const prevKeys = new Set((prevKnip?.data?.issues ?? []).map(issueKey));
-			const modifiedSet = new Set(files.map((f) => resolveRunnerPath(cwd, f)));
-
-			const newIssues = knipResult.issues.filter((issue) => {
-				if (prevKeys.has(issueKey(issue))) return false;
-				if (!issue.file) return false;
-				const abs = resolveRunnerPath(cwd, issue.file);
-				return modifiedSet.has(abs);
-			});
-			knipMeta.newIssues = newIssues.length;
-
-			const blockerIssues = newIssues.filter(
-				(i) => i.type === "unlisted" || i.type === "bin",
+		const previousFailedHard =
+			prevKnip &&
+			!prevKnip.data.success &&
+			/(timed out|killed|SIGTERM|SIGKILL|SIGABRT)/i.test(
+				prevKnip.data.summary,
 			);
-			knipMeta.blockerIssues = blockerIssues.length;
-			if (blockerIssues.length > 0) {
-				let report =
-					"🔴 New unresolved imports/deps in modified code (Knip):\n";
-				let firstPath: string | null = null;
-				for (const issue of blockerIssues.slice(0, 5)) {
-					const display = issue.file
-						? toRunnerDisplayPath(cwd, issue.file)
-						: "(unknown)";
-					if (!firstPath && display !== "(unknown)") firstPath = display;
-					report += `  ${display}${issue.line ? `:${issue.line}` : ""} — ${issue.type}: ${issue.name}\n`;
-				}
-				if (firstPath) {
-					report += `  First location: ${firstPath}\n`;
-				}
-				blockerParts.push(report);
-			}
 
-			// Newly-unused exports in modified files: symbol was clean before this turn
-			// (not in prevKnip issues) but is now flagged — likely a caller was removed or
-			// an interface changed. Advisory only — the agent may be mid-task.
-			const unusedExportIssues = newIssues.filter((i) => i.type === "export");
-			if (unusedExportIssues.length > 0) {
-				let report =
-					"⚠️ Newly unused exports in modified files — check if callers need updating (Knip):\n";
-				for (const issue of unusedExportIssues.slice(0, 5)) {
-					const display = issue.file
-						? toRunnerDisplayPath(cwd, issue.file)
-						: "(unknown)";
-					report += `  ${display}${issue.line ? `:${issue.line}` : ""} — ${issue.name}\n`;
+		if (previousFailedHard) {
+			dbg(
+				`turn_end: skipping knip after recent failure: ${prevKnip.data.summary}`,
+			);
+			knipMeta = { skipped: true, reason: prevKnip.data.summary };
+		} else {
+			const knipResult = await knipClient.analyze(cwd, getKnipIgnorePatterns());
+			cacheManager.writeCache("knip", knipResult, cwd);
+			knipMeta = {
+				success: knipResult.success,
+				totalIssues: knipResult.issues.length,
+				newIssues: 0,
+				blockerIssues: 0,
+				...(!knipResult.success && { reason: knipResult.summary }),
+			};
+
+			if (knipResult.success && knipResult.issues.length > 0) {
+				const issueKey = (i: KnipIssue) =>
+					`${i.type}:${i.file ?? ""}:${i.name}:${i.line ?? 0}:${i.package ?? ""}`;
+				const prevKeys = new Set((prevKnip?.data?.issues ?? []).map(issueKey));
+				const modifiedSet = new Set(
+					files.map((f) => resolveRunnerPath(cwd, f)),
+				);
+
+				const newIssues = knipResult.issues.filter((issue) => {
+					if (prevKeys.has(issueKey(issue))) return false;
+					if (!issue.file) return false;
+					const abs = resolveRunnerPath(cwd, issue.file);
+					return modifiedSet.has(abs);
+				});
+				knipMeta.newIssues = newIssues.length;
+
+				const blockerIssues = newIssues.filter(
+					(i) => i.type === "unlisted" || i.type === "bin",
+				);
+				knipMeta.blockerIssues = blockerIssues.length;
+				if (blockerIssues.length > 0) {
+					let report =
+						"🔴 New unresolved imports/deps in modified code (Knip):\n";
+					let firstPath: string | null = null;
+					for (const issue of blockerIssues.slice(0, 5)) {
+						const display = issue.file
+							? toRunnerDisplayPath(cwd, issue.file)
+							: "(unknown)";
+						if (!firstPath && display !== "(unknown)") firstPath = display;
+						report += `  ${display}${issue.line ? `:${issue.line}` : ""} — ${issue.type}: ${issue.name}\n`;
+					}
+					if (firstPath) {
+						report += `  First location: ${firstPath}\n`;
+					}
+					blockerParts.push(report);
 				}
-				advisoryParts.push(report);
+
+				// Newly-unused exports in modified files: symbol was clean before this turn
+				// (not in prevKnip issues) but is now flagged — likely a caller was removed or
+				// an interface changed. Advisory only — the agent may be mid-task.
+				const unusedExportIssues = newIssues.filter((i) => i.type === "export");
+				if (unusedExportIssues.length > 0) {
+					let report =
+						"⚠️ Newly unused exports in modified files — check if callers need updating (Knip):\n";
+					for (const issue of unusedExportIssues.slice(0, 5)) {
+						const display = issue.file
+							? toRunnerDisplayPath(cwd, issue.file)
+							: "(unknown)";
+						report += `  ${display}${issue.line ? `:${issue.line}` : ""} — ${issue.name}\n`;
+					}
+					advisoryParts.push(report);
+				}
 			}
 		}
 	}

--- a/tests/clients/cascade-turn-merge.test.ts
+++ b/tests/clients/cascade-turn-merge.test.ts
@@ -9,6 +9,16 @@ import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { handleTurnEnd } from "../../clients/runtime-turn.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
+const EMPTY_KNIP_RESULT = {
+	success: true,
+	issues: [],
+	unusedExports: [],
+	unusedFiles: [],
+	unusedDeps: [],
+	unlistedDeps: [],
+	summary: "skipped",
+};
+
 function diagnostic(filePath: string, message: string, line = 1): Diagnostic {
 	return {
 		id: `lsp:test:${line}`,
@@ -90,7 +100,10 @@ describe("cascade turn-end merge", () => {
 				dbg: () => {},
 				runtime,
 				cacheManager,
-				knipClient: { ensureAvailable: async () => false },
+				knipClient: {
+					ensureAvailable: async () => false,
+					analyze: async () => EMPTY_KNIP_RESULT,
+				},
 				depChecker: { ensureAvailable: async () => false },
 				testRunnerClient: { getTestRunTarget: () => null },
 				resetLSPService: () => {},

--- a/tests/clients/knip-client.test.ts
+++ b/tests/clients/knip-client.test.ts
@@ -23,6 +23,25 @@ describe("knip-client", () => {
 		}
 	});
 
+	it("does not walk past a VCS boundary to a parent package.json", () => {
+		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-knip-boundary-");
+		try {
+			fs.writeFileSync(path.join(tmpDir, "package.json"), '{"name":"parent"}');
+			const repoRoot = path.join(tmpDir, "unity-repo");
+			const nested = path.join(repoRoot, "Assets", "Scripts");
+			fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+			fs.mkdirSync(nested, { recursive: true });
+
+			const client = new KnipClient(false) as unknown as {
+				resolveProjectRoot: (startDir: string) => string | null;
+			};
+
+			expect(client.resolveProjectRoot(nested)).toBeNull();
+		} finally {
+			cleanup();
+		}
+	});
+
 	it("returns null when no project markers exist up the tree", () => {
 		// Regression: previously fell back to startDir, causing knip to scan
 		// arbitrary directories like $HOME when run from a bare cwd.
@@ -82,6 +101,41 @@ describe("knip-client", () => {
 		}
 	});
 
+	it("analyze() skips before probing knip when stopped by repo boundary", async () => {
+		const { tmpDir, cleanup } = setupTestEnvironment(
+			"pi-lens-knip-boundary-skip-",
+		);
+		try {
+			fs.writeFileSync(path.join(tmpDir, "package.json"), '{"name":"parent"}');
+			const repoRoot = path.join(tmpDir, "unity-repo");
+			const nested = path.join(repoRoot, "Assets", "Scripts");
+			fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+			fs.mkdirSync(nested, { recursive: true });
+
+			const client = new KnipClient(false) as unknown as {
+				ensureAvailable: () => Promise<boolean>;
+				runAnalyze: (d: string) => Promise<unknown>;
+				analyze: (cwd?: string) => Promise<{
+					success: boolean;
+					issues: unknown[];
+					summary: string;
+				}>;
+			};
+
+			const ensureSpy = vi.spyOn(client, "ensureAvailable");
+			const runSpy = vi.spyOn(client, "runAnalyze");
+			const result = await client.analyze(nested);
+
+			expect(result.success).toBe(true);
+			expect(result.summary).toMatch(/skipped|no project/i);
+			expect(ensureSpy).not.toHaveBeenCalled();
+			expect(runSpy).not.toHaveBeenCalled();
+		} finally {
+			cleanup();
+			vi.restoreAllMocks();
+		}
+	});
+
 	it("analyze() returns a Promise (non-blocking)", async () => {
 		// Regression: analyze() used to be sync (spawnSync), blocking the event
 		// loop. The TypeScript signature alone doesn't enforce this at runtime,
@@ -95,7 +149,7 @@ describe("knip-client", () => {
 
 	it("de-dupes concurrent analyze() calls for the same project root", async () => {
 		// Regression: back-to-back turn_end events (or turn_end during a
-		// session_start scan) could spawn two `npx knip` processes against
+		// session_start scan) could spawn two `knip` processes against
 		// the same tree. Two concurrent knip runs pegged both CPU cores to
 		// 100% and caused the TUI freezes this PR is fixing.
 		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-knip-dedupe-");

--- a/tests/clients/runtime-event-flow.test.ts
+++ b/tests/clients/runtime-event-flow.test.ts
@@ -9,6 +9,16 @@ import { handleToolResult } from "../../clients/runtime-tool-result.js";
 import { handleTurnEnd } from "../../clients/runtime-turn.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
+const EMPTY_KNIP_RESULT = {
+	success: true,
+	issues: [],
+	unusedExports: [],
+	unusedFiles: [],
+	unusedDeps: [],
+	unlistedDeps: [],
+	summary: "skipped",
+};
+
 vi.mock("../../clients/pipeline.js", () => ({
 	runPipeline: vi.fn(async () => ({
 		output: "no blockers",
@@ -57,6 +67,7 @@ describe("runtime event flow", () => {
 				knipClient: {
 					isAvailable: () => false,
 					ensureAvailable: async () => false,
+					analyze: async () => EMPTY_KNIP_RESULT,
 				},
 				jscpdClient: {
 					isAvailable: () => false,
@@ -112,7 +123,10 @@ describe("runtime event flow", () => {
 				dbg: () => {},
 				runtime,
 				cacheManager,
-				knipClient: { ensureAvailable: async () => false },
+				knipClient: {
+					ensureAvailable: async () => false,
+					analyze: async () => EMPTY_KNIP_RESULT,
+				},
 				depChecker: { ensureAvailable: async () => false },
 				testRunnerClient: { getTestRunTarget: () => null },
 				resetLSPService: () => {},

--- a/tests/clients/runtime-session.test.ts
+++ b/tests/clients/runtime-session.test.ts
@@ -2,6 +2,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { handleSessionStart } from "../../clients/runtime-session.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
+const EMPTY_KNIP_RESULT = {
+	success: true,
+	issues: [],
+	unusedExports: [],
+	unusedFiles: [],
+	unusedDeps: [],
+	unlistedDeps: [],
+	summary: "skipped",
+};
+
 function setStartupMode(mode: "full" | "quick"): () => void {
 	const prev = process.env.PI_LENS_STARTUP_MODE;
 	process.env.PI_LENS_STARTUP_MODE = mode;
@@ -24,6 +34,7 @@ async function runSessionStart(
 	const biomeEnsure = vi.fn(async () => false);
 	const ruffEnsure = vi.fn(async () => false);
 	const knipEnsure = vi.fn(async () => false);
+	const knipAnalyze = vi.fn(async () => EMPTY_KNIP_RESULT);
 	const jscpdEnsure = vi.fn(async () => false);
 	const depEnsure = vi.fn(async () => false);
 	const restoreStartupMode = setStartupMode(mode);
@@ -81,6 +92,7 @@ async function runSessionStart(
 			knipClient: {
 				isAvailable: () => false,
 				ensureAvailable: knipEnsure,
+				analyze: knipAnalyze,
 			},
 			jscpdClient: {
 				isAvailable: () => false,
@@ -112,6 +124,7 @@ async function runSessionStart(
 			biomeEnsure,
 			ruffEnsure,
 			knipEnsure,
+			knipAnalyze,
 			jscpdEnsure,
 			depEnsure,
 		};
@@ -190,6 +203,7 @@ describe("runtime-session notifications", () => {
 			depEnsure,
 			astGrepEnsure,
 			knipEnsure,
+			knipAnalyze,
 			jscpdEnsure,
 		} = await runSessionStart("full", (tmpDir) => {
 			createTempFile(
@@ -208,7 +222,8 @@ describe("runtime-session notifications", () => {
 			expect(biomeEnsure).not.toHaveBeenCalled();
 			expect(ruffEnsure).not.toHaveBeenCalled();
 			expect(astGrepEnsure).toHaveBeenCalledTimes(1);
-			expect(knipEnsure).toHaveBeenCalledTimes(1);
+			expect(knipEnsure).not.toHaveBeenCalled();
+			expect(knipAnalyze).toHaveBeenCalledTimes(1);
 			expect(jscpdEnsure).toHaveBeenCalledTimes(1);
 		} finally {
 			env.cleanup();

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -11,6 +11,16 @@ import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { handleTurnEnd } from "../../clients/runtime-turn.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
+const EMPTY_KNIP_RESULT = {
+	success: true,
+	issues: [],
+	unusedExports: [],
+	unusedFiles: [],
+	unusedDeps: [],
+	unlistedDeps: [],
+	summary: "skipped",
+};
+
 // Minimal turn_end deps — no real tool clients needed for these scenarios.
 function makeTurnEndDeps(
 	runtime: RuntimeCoordinator,
@@ -23,7 +33,10 @@ function makeTurnEndDeps(
 		dbg: () => {},
 		runtime,
 		cacheManager,
-		knipClient: { ensureAvailable: async () => false },
+		knipClient: {
+			ensureAvailable: async () => false,
+			analyze: async () => EMPTY_KNIP_RESULT,
+		},
 		depChecker: { ensureAvailable: async () => false },
 		testRunnerClient: { getTestRunTarget: () => null },
 		resetLSPService: () => {},
@@ -185,6 +198,51 @@ describe("stale turn state eviction", () => {
 		expect(Object.keys(afterState.files)).toHaveLength(0);
 
 		env.cleanup();
+	});
+});
+
+// ── Knip timeout backoff ─────────────────────────────────────────────────────
+
+describe("knip turn-end backoff", () => {
+	it("skips knip after a recent timeout failure", async () => {
+		const env = setupTestEnvironment("pi-lens-knip-backoff-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const cacheManager = new CacheManager(false);
+			const filePath = path.join(env.tmpDir, "src/current.ts");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, "export const x = 1;\n");
+			cacheManager.addModifiedRange(
+				filePath,
+				{ start: 1, end: 1 },
+				false,
+				env.tmpDir,
+			);
+			cacheManager.writeCache(
+				"knip",
+				{
+					...EMPTY_KNIP_RESULT,
+					success: false,
+					summary: "Error: Process timed out after 30000ms (killed with SIGTERM)",
+				},
+				env.tmpDir,
+			);
+			const analyze = vi.fn(async () => EMPTY_KNIP_RESULT);
+
+			await handleTurnEnd(
+				makeTurnEndDeps(runtime, cacheManager, {
+					ctxCwd: env.tmpDir,
+					knipClient: {
+						ensureAvailable: async () => true,
+						analyze,
+					},
+				}),
+			);
+
+			expect(analyze).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+		}
 	});
 });
 


### PR DESCRIPTION
## Summary
- stop Knip project-root discovery at VCS boundaries so nested non-JS repos do not inherit unrelated parent `package.json` files
- skip Knip probing/installing until `KnipClient.analyze()` confirms there is a real Knip/JS project root
- run the resolved `knip` binary directly with local/managed tool paths instead of invoking `npx knip`
- add turn-end backoff after recent Knip timeout/kill failures to avoid repeatedly spending 30s on the same broken scan

## Context
I hit this in a Unity/C# repo with no root `package.json`. The old upward search walked past the repo's `.git`, found a `~/package.json`, and repeatedly launched `npm exec knip ...` from the wrong root. pi-lens logged repeated 30s Knip timeouts, and macOS recorded a Node `SIGABRT` crash for `npm exec knip --reporter=json ...`.

## Tests
- `npm run lint -- --pretty false`
- `npm test -- tests/clients/knip-client.test.ts tests/clients/runtime-session.test.ts tests/clients/runtime-turn-session.test.ts tests/clients/cascade-turn-merge.test.ts tests/clients/runtime-event-flow.test.ts`
- `npm run build && npm test`
