### PR TITLE
tool-policy: stop applying prettier to .md/.mdx without project config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Changed
 
+- **`.md` / `.mdx` no longer auto-format with prettier defaults when the project has no prettier config.** Prettier's defaults reflow lines, normalize emphasis markers (`*` → `_`), and restyle lists, producing noisy diffs on doc-only writes. The smart-default gate still runs prettier when an explicit project config (`.prettierrc`, `prettier` field in `package.json`, etc.) is present — flip is on the no-config path only. To restore prior behaviour, add an empty `.prettierrc` (or any explicit prettier config) to the project root.
 - **README accuracy fixes** — corrected Python LSP label (pyright/basedpyright + jedi), bumped formatter count 26→27→32 (added oxfmt, fish_indent, google-java-format, cljfmt, cmake-format, psscriptanalyzer-format), fixed read-guard markdown exemption text, added `/lens-allow-edit` to key commands, bumped language coverage 35→36+ (added Fish, Svelte, Vue rows), added `tree-sitter` to C/C++ dispatch, added `detekt` to Kotlin dispatch, added formatters to Java/Clojure/CMake/PowerShell rows, added `vale` to Markdown row, added `swiftlint` to Swift row.
 
 - **`.md` read-guard exemption tightened from `allow` to `warn`** — markdown files are no longer silently exempt from the read-before-edit guard. With the new markdown-section expansion providing precise heading-level coverage, edits outside the expanded read range trigger a warning instead of passing unchecked. Plain-text (`.txt`) and log (`.log`) files remain exempt.

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -197,7 +197,9 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 		{
 			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
-			defaultWhenUnconfigured: true,
+			// Prettier's markdown defaults reflow lines, normalize emphasis (* -> _),
+			// and restyle lists. Opt-in via project prettier config; do not run by default.
+			defaultWhenUnconfigured: false,
 			gate: "smart-default",
 		},
 	],
@@ -206,7 +208,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 		{
 			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
-			defaultWhenUnconfigured: true,
+			defaultWhenUnconfigured: false,
 			gate: "smart-default",
 		},
 	],

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -365,7 +365,22 @@ describe("getFormattersForFile — policy selection", () => {
 		expect(formatters.map((f) => f.name)).toEqual(["prettier"]);
 	});
 
-	it("uses prettier as the smart default for unconfigured Markdown files", async () => {
+	it("does not force prettier on unconfigured Markdown files", async () => {
+		// Prettier's markdown defaults reflow lines and normalize emphasis markers,
+		// producing noisy diffs on doc-only writes. Users opt in via project prettier config.
+		const filePath = fileIn(tmpDir, "README.md");
+		const formatters = await getFormattersForFile(filePath, tmpDir);
+		expect(formatters).toEqual([]);
+	});
+
+	it("does not force prettier on unconfigured .mdx files", async () => {
+		const filePath = fileIn(tmpDir, "page.mdx");
+		const formatters = await getFormattersForFile(filePath, tmpDir);
+		expect(formatters).toEqual([]);
+	});
+
+	it("runs prettier on Markdown when project has explicit prettier config", async () => {
+		createTempFile(tmpDir, ".prettierrc", "{}");
 		const filePath = fileIn(tmpDir, "README.md");
 		const formatters = await getFormattersForFile(filePath, tmpDir);
 		expect(formatters.map((f) => f.name)).toEqual(["prettier"]);

--- a/tests/clients/tool-policy.test.ts
+++ b/tests/clients/tool-policy.test.ts
@@ -56,7 +56,6 @@ describe("tool-policy", () => {
 		expect(getSmartDefaultFormatterName("/tmp/file.less")).toBe("prettier");
 		expect(getSmartDefaultFormatterName("/tmp/file.html")).toBe("prettier");
 		expect(getSmartDefaultFormatterName("/tmp/file.yaml")).toBe("prettier");
-		expect(getSmartDefaultFormatterName("/tmp/file.md")).toBe("prettier");
 		expect(getSmartDefaultFormatterName("/tmp/file.kt")).toBe("ktlint");
 		expect(getSmartDefaultFormatterName("/tmp/file.swift")).toBe("swiftformat");
 		expect(getSmartDefaultFormatterName("/tmp/file.fs")).toBe("fantomas");
@@ -81,6 +80,26 @@ describe("tool-policy", () => {
 		expect(getSmartDefaultFormatterName("/tmp/file.php")).toBeUndefined();
 		expect(getSmartDefaultFormatterName("/tmp/file.lua")).toBeUndefined();
 		expect(getSmartDefaultFormatterName("/tmp/file.ml")).toBeUndefined();
+	});
+
+	it("does not auto-apply prettier to markdown without a project prettier config", () => {
+		// Prettier's markdown defaults reflow lines, normalize emphasis markers, and
+		// restyle lists. Users opt in via project `.prettierrc`; the smart-default gate
+		// still honours an explicit config, but no auto-format on empty configuration.
+		expect(getSmartDefaultFormatterName("/tmp/file.md")).toBeUndefined();
+		expect(getSmartDefaultFormatterName("/tmp/file.mdx")).toBeUndefined();
+		expect(getFormatterPolicyForFile("/tmp/file.md")).toMatchObject({
+			formatterNames: ["prettier"],
+			defaultFormatter: "prettier",
+			defaultWhenUnconfigured: false,
+			gate: "smart-default",
+		});
+		expect(getFormatterPolicyForFile("/tmp/file.mdx")).toMatchObject({
+			formatterNames: ["prettier"],
+			defaultFormatter: "prettier",
+			defaultWhenUnconfigured: false,
+			gate: "smart-default",
+		});
 	});
 
 	it("maps managed smart-default formatters to auto-installable tool ids", () => {


### PR DESCRIPTION
Prettier's markdown defaults reflow lines, normalize emphasis markers
(* -> _), and restyle lists. Users without an explicit prettier config
were getting noisy formatter diffs on every doc-only write.

Flip .md and .mdx defaultWhenUnconfigured from true to false on the
smart-default gate. The gate still honours an explicit project prettier
config (.prettierrc, prettier field in package.json, etc.) — the flip
only affects the no-config path.

To restore prior behaviour, add an empty .prettierrc to the project root.

Tests:
- tests/clients/tool-policy.test.ts: move .md out of the smart-default
  assertion; add a focused negative test plus policy-shape assertion
  for .md and .mdx.
- tests/clients/formatters.test.ts: replace
  "uses prettier as the smart default for unconfigured Markdown" with
  a negative case plus a positive case asserting that an explicit
  .prettierrc re-enables prettier (opt-in path).

CHANGELOG.md updated under Unreleased / Changed.
