### PR TITLE
feat(dispatch): configurable runner timeout floor via config file and env

### DIFF
--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -25,7 +25,7 @@ import { getPrimaryDispatchGroup } from "../language-policy.js";
 import { resolveLanguageRootForFile } from "../language-profile.js";
 import { logLatency } from "../latency-logger.js";
 import { normalizeMapKey } from "../path-utils.js";
-import { RUNTIME_CONFIG } from "../runtime-config.js";
+import { RUNTIME_CONFIG, RUNNER_TIMEOUT_FLOOR_MS } from "../runtime-config.js";
 import { safeSpawnAsync } from "../safe-spawn.js";
 import { classifyDiagnostic } from "./diagnostic-taxonomy.js";
 import type { FactStore } from "./fact-store.js";
@@ -906,7 +906,7 @@ async function runRunner(
 	runner: RunnerDefinition,
 	defaultSemantic: OutputSemantic,
 ): Promise<RunnerResult> {
-	const timeoutMs = runner.timeoutMs ?? RUNNER_TIMEOUT_MS;
+	const timeoutMs = Math.max(runner.timeoutMs ?? RUNNER_TIMEOUT_MS, RUNNER_TIMEOUT_FLOOR_MS);
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	try {
 		const result = await Promise.race([

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -25,7 +25,7 @@ import { getPrimaryDispatchGroup } from "../language-policy.js";
 import { resolveLanguageRootForFile } from "../language-profile.js";
 import { logLatency } from "../latency-logger.js";
 import { normalizeMapKey } from "../path-utils.js";
-import { RUNTIME_CONFIG, RUNNER_TIMEOUT_FLOOR_MS } from "../runtime-config.js";
+import { RUNTIME_CONFIG, getRunnerTimeoutFloorMs } from "../runtime-config.js";
 import { safeSpawnAsync } from "../safe-spawn.js";
 import { classifyDiagnostic } from "./diagnostic-taxonomy.js";
 import type { FactStore } from "./fact-store.js";
@@ -906,7 +906,10 @@ async function runRunner(
 	runner: RunnerDefinition,
 	defaultSemantic: OutputSemantic,
 ): Promise<RunnerResult> {
-	const timeoutMs = Math.max(runner.timeoutMs ?? RUNNER_TIMEOUT_MS, RUNNER_TIMEOUT_FLOOR_MS);
+	const timeoutMs = Math.max(
+		runner.timeoutMs ?? RUNNER_TIMEOUT_MS,
+		getRunnerTimeoutFloorMs(),
+	);
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	try {
 		const result = await Promise.race([

--- a/clients/lens-config.ts
+++ b/clients/lens-config.ts
@@ -8,11 +8,11 @@ export interface PiLensGlobalConfig {
 	dispatch?: {
 		/**
 		 * Minimum wall-clock budget (ms) for every dispatch runner.
-		 * Acts as a floor: effective timeout = max(runner.timeoutMs ?? 30_000, runnerTimeoutMs).
+		 * Acts as a floor: effective timeout = max(runner.timeoutMs ?? 30_000, runnerTimeoutFloorMs).
 		 * Useful for large monorepos where slow toolchains (e.g. cargo clippy) exceed
-		 * any runner's declared budget. Also overridable via PI_LENS_RUNNER_TIMEOUT_MS.
+		 * any runner's declared budget. Also overridable via PI_LENS_RUNNER_TIMEOUT_FLOOR_MS.
 		 */
-		runnerTimeoutMs?: number;
+		runnerTimeoutFloorMs?: number;
 	};
 	widget?: {
 		/** Whether the diagnostics widget is visible when a session starts. */
@@ -86,10 +86,11 @@ export function loadPiLensGlobalConfig(
 		return {
 			dispatch: dispatch
 				? {
-						runnerTimeoutMs:
-							typeof dispatch.runnerTimeoutMs === "number" &&
-							dispatch.runnerTimeoutMs > 0
-								? dispatch.runnerTimeoutMs
+						runnerTimeoutFloorMs:
+							typeof dispatch.runnerTimeoutFloorMs === "number" &&
+							Number.isFinite(dispatch.runnerTimeoutFloorMs) &&
+							dispatch.runnerTimeoutFloorMs > 0
+								? dispatch.runnerTimeoutFloorMs
 								: undefined,
 					}
 				: undefined,

--- a/clients/lens-config.ts
+++ b/clients/lens-config.ts
@@ -5,6 +5,15 @@ import * as path from "node:path";
 export type PiLensFormatMode = "deferred" | "immediate";
 
 export interface PiLensGlobalConfig {
+	dispatch?: {
+		/**
+		 * Minimum wall-clock budget (ms) for every dispatch runner.
+		 * Acts as a floor: effective timeout = max(runner.timeoutMs ?? 30_000, runnerTimeoutMs).
+		 * Useful for large monorepos where slow toolchains (e.g. cargo clippy) exceed
+		 * any runner's declared budget. Also overridable via PI_LENS_RUNNER_TIMEOUT_MS.
+		 */
+		runnerTimeoutMs?: number;
+	};
 	widget?: {
 		/** Whether the diagnostics widget is visible when a session starts. */
 		visible?: boolean;
@@ -43,6 +52,11 @@ export function loadPiLensGlobalConfig(
 		if (!parsed || typeof parsed !== "object") return undefined;
 
 		const raw = parsed as Record<string, unknown>;
+		const dispatchRaw = raw.dispatch;
+		const dispatch =
+			dispatchRaw && typeof dispatchRaw === "object"
+				? (dispatchRaw as Record<string, unknown>)
+				: undefined;
 		const widgetRaw = raw.widget;
 		const widget =
 			widgetRaw && typeof widgetRaw === "object"
@@ -70,6 +84,15 @@ export function loadPiLensGlobalConfig(
 				: undefined;
 
 		return {
+			dispatch: dispatch
+				? {
+						runnerTimeoutMs:
+							typeof dispatch.runnerTimeoutMs === "number" &&
+							dispatch.runnerTimeoutMs > 0
+								? dispatch.runnerTimeoutMs
+								: undefined,
+					}
+				: undefined,
 			widget: widget
 				? {
 						visible:

--- a/clients/runtime-config.ts
+++ b/clients/runtime-config.ts
@@ -26,8 +26,7 @@ import { loadPiLensGlobalConfig } from "./lens-config.js";
 const _globalConfig = loadPiLensGlobalConfig();
 const _configFloor = _globalConfig?.dispatch?.runnerTimeoutMs ?? 0;
 const _envFloor = Number(process.env.PI_LENS_RUNNER_TIMEOUT_MS);
-export const RUNNER_TIMEOUT_FLOOR_MS =
-	_configFloor > 0 ? _configFloor : _envFloor > 0 ? _envFloor : 0;
+export const RUNNER_TIMEOUT_FLOOR_MS = Math.max(_configFloor, _envFloor, 0);
 
 export const RUNTIME_CONFIG = {
 	pipeline: {

--- a/clients/runtime-config.ts
+++ b/clients/runtime-config.ts
@@ -3,6 +3,32 @@
  * Keep these values in one place so behavior is consistent and easy to tune.
  */
 
+/**
+ * Minimum wall-clock budget for every dispatch runner. Acts as a floor:
+ * effective timeout = max(runner.timeoutMs ?? 30_000, RUNNER_TIMEOUT_FLOOR_MS).
+ *
+ * Resolution order (highest priority first):
+ *   1. `dispatch.runnerTimeoutMs` in `~/.pi-lens/config.json`
+ *   2. `PI_LENS_RUNNER_TIMEOUT_MS` environment variable
+ *   3. 0 (no floor — runner budgets and the 30 s default apply as-is)
+ *
+ * @example ~/.pi-lens/config.json
+ * ```json
+ * { "dispatch": { "runnerTimeoutMs": 180000 } }
+ * ```
+ *
+ * @example env var
+ * ```bash
+ * PI_LENS_RUNNER_TIMEOUT_MS=180000 pi
+ * ```
+ */
+import { loadPiLensGlobalConfig } from "./lens-config.js";
+const _globalConfig = loadPiLensGlobalConfig();
+const _configFloor = _globalConfig?.dispatch?.runnerTimeoutMs ?? 0;
+const _envFloor = Number(process.env.PI_LENS_RUNNER_TIMEOUT_MS);
+export const RUNNER_TIMEOUT_FLOOR_MS =
+	_configFloor > 0 ? _configFloor : _envFloor > 0 ? _envFloor : 0;
+
 export const RUNTIME_CONFIG = {
 	pipeline: {
 		lspMaxFileBytes: 2 * 1024 * 1024,

--- a/clients/runtime-config.ts
+++ b/clients/runtime-config.ts
@@ -3,30 +3,59 @@
  * Keep these values in one place so behavior is consistent and easy to tune.
  */
 
+import { loadPiLensGlobalConfig } from "./lens-config.js";
+
 /**
- * Minimum wall-clock budget for every dispatch runner. Acts as a floor:
- * effective timeout = max(runner.timeoutMs ?? 30_000, RUNNER_TIMEOUT_FLOOR_MS).
+ * Coerce an arbitrary input to a non-negative finite number, or 0 otherwise.
+ * Used to gate config/env inputs into Math.max — passing NaN through Math.max
+ * poisons the result and produces NaN timeouts downstream, which setTimeout
+ * silently treats as 0 (immediate-abort all dispatch runners).
+ */
+function toPositiveFinite(value: unknown): number {
+	const num = typeof value === "number" ? value : Number(value);
+	return Number.isFinite(num) && num > 0 ? num : 0;
+}
+
+let _runnerTimeoutFloorCache: number | undefined;
+
+/**
+ * Minimum wall-clock budget (ms) for every dispatch runner. Acts as a floor:
+ * effective timeout = max(runner.timeoutMs ?? 30_000, runnerTimeoutFloorMs).
  *
  * Resolution order (highest priority first):
- *   1. `dispatch.runnerTimeoutMs` in `~/.pi-lens/config.json`
- *   2. `PI_LENS_RUNNER_TIMEOUT_MS` environment variable
+ *   1. `dispatch.runnerTimeoutFloorMs` in `~/.pi-lens/config.json`
+ *   2. `PI_LENS_RUNNER_TIMEOUT_FLOOR_MS` environment variable
  *   3. 0 (no floor — runner budgets and the 30 s default apply as-is)
+ *
+ * Lazy + memoized so importing `runtime-config.ts` does not trigger disk IO.
+ * The config file is read at most once per process, on first dispatch.
  *
  * @example ~/.pi-lens/config.json
  * ```json
- * { "dispatch": { "runnerTimeoutMs": 180000 } }
+ * { "dispatch": { "runnerTimeoutFloorMs": 180000 } }
  * ```
  *
  * @example env var
  * ```bash
- * PI_LENS_RUNNER_TIMEOUT_MS=180000 pi
+ * PI_LENS_RUNNER_TIMEOUT_FLOOR_MS=180000 pi
  * ```
  */
-import { loadPiLensGlobalConfig } from "./lens-config.js";
-const _globalConfig = loadPiLensGlobalConfig();
-const _configFloor = _globalConfig?.dispatch?.runnerTimeoutMs ?? 0;
-const _envFloor = Number(process.env.PI_LENS_RUNNER_TIMEOUT_MS);
-export const RUNNER_TIMEOUT_FLOOR_MS = Math.max(_configFloor, _envFloor, 0);
+export function getRunnerTimeoutFloorMs(): number {
+	if (_runnerTimeoutFloorCache !== undefined) return _runnerTimeoutFloorCache;
+	const config = loadPiLensGlobalConfig();
+	const configFloor = toPositiveFinite(config?.dispatch?.runnerTimeoutFloorMs);
+	const envFloor = toPositiveFinite(process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS);
+	_runnerTimeoutFloorCache = Math.max(configFloor, envFloor, 0);
+	return _runnerTimeoutFloorCache;
+}
+
+/**
+ * Test-only: clear the memoized floor so a subsequent call re-reads the
+ * config file and env var. Use after mutating either in a test.
+ */
+export function _resetRunnerTimeoutFloorCacheForTests(): void {
+	_runnerTimeoutFloorCache = undefined;
+}
 
 export const RUNTIME_CONFIG = {
 	pipeline: {

--- a/tests/clients/lens-config.test.ts
+++ b/tests/clients/lens-config.test.ts
@@ -134,6 +134,44 @@ describe("global pi-lens config", () => {
 		);
 	});
 
+	it("parses a positive dispatch.runnerTimeoutFloorMs", () => {
+		const home = makeTempHome();
+		const configPath = writeConfig(
+			home,
+			JSON.stringify({ dispatch: { runnerTimeoutFloorMs: 180000 } }),
+		);
+
+		expect(loadPiLensGlobalConfig(configPath)).toEqual({
+			dispatch: { runnerTimeoutFloorMs: 180000 },
+		});
+	});
+
+	it("rejects a non-positive or non-finite dispatch.runnerTimeoutFloorMs", () => {
+		const home = makeTempHome();
+		const negativePath = writeConfig(
+			home,
+			JSON.stringify({ dispatch: { runnerTimeoutFloorMs: -10 } }),
+		);
+		const zeroPath = writeConfig(
+			home,
+			JSON.stringify({ dispatch: { runnerTimeoutFloorMs: 0 } }),
+		);
+		const stringPath = writeConfig(
+			home,
+			JSON.stringify({ dispatch: { runnerTimeoutFloorMs: "180000" } }),
+		);
+
+		expect(loadPiLensGlobalConfig(negativePath)).toEqual({
+			dispatch: { runnerTimeoutFloorMs: undefined },
+		});
+		expect(loadPiLensGlobalConfig(zeroPath)).toEqual({
+			dispatch: { runnerTimeoutFloorMs: undefined },
+		});
+		expect(loadPiLensGlobalConfig(stringPath)).toEqual({
+			dispatch: { runnerTimeoutFloorMs: undefined },
+		});
+	});
+
 	it("defaults the widget to visible for missing or invalid config", () => {
 		const home = makeTempHome();
 		const missingPath = getPiLensGlobalConfigPath(home);

--- a/tests/clients/runtime-config.test.ts
+++ b/tests/clients/runtime-config.test.ts
@@ -1,0 +1,119 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getPiLensGlobalConfigPath } from "../../clients/lens-config.js";
+import {
+	_resetRunnerTimeoutFloorCacheForTests,
+	getRunnerTimeoutFloorMs,
+} from "../../clients/runtime-config.js";
+
+const tmpDirs: string[] = [];
+let previousConfigPath: string | undefined;
+let previousFloor: string | undefined;
+
+function makeTempHome(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-runtime-config-"));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+function writeConfig(home: string, contents: string): string {
+	const configPath = getPiLensGlobalConfigPath(home);
+	fs.mkdirSync(path.dirname(configPath), { recursive: true });
+	fs.writeFileSync(configPath, contents, "utf-8");
+	return configPath;
+}
+
+beforeEach(() => {
+	previousConfigPath = process.env.PI_LENS_CONFIG_PATH;
+	previousFloor = process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS;
+	delete process.env.PI_LENS_CONFIG_PATH;
+	delete process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS;
+	_resetRunnerTimeoutFloorCacheForTests();
+});
+
+afterEach(() => {
+	if (previousConfigPath === undefined) delete process.env.PI_LENS_CONFIG_PATH;
+	else process.env.PI_LENS_CONFIG_PATH = previousConfigPath;
+	if (previousFloor === undefined)
+		delete process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS;
+	else process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS = previousFloor;
+	_resetRunnerTimeoutFloorCacheForTests();
+	for (const dir of tmpDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("getRunnerTimeoutFloorMs", () => {
+	it("returns 0 when neither config nor env is set", () => {
+		const home = makeTempHome();
+		// No config file written under this home.
+		process.env.PI_LENS_CONFIG_PATH = getPiLensGlobalConfigPath(home);
+		expect(getRunnerTimeoutFloorMs()).toBe(0);
+	});
+
+	it("returns 0 — not NaN — when the env var is unset (regression: NaN poisoning Math.max)", () => {
+		const home = makeTempHome();
+		process.env.PI_LENS_CONFIG_PATH = getPiLensGlobalConfigPath(home);
+		const floor = getRunnerTimeoutFloorMs();
+		expect(Number.isNaN(floor)).toBe(false);
+		expect(floor).toBe(0);
+	});
+
+	it("reads from the env var when set", () => {
+		const home = makeTempHome();
+		process.env.PI_LENS_CONFIG_PATH = getPiLensGlobalConfigPath(home);
+		process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS = "60000";
+		expect(getRunnerTimeoutFloorMs()).toBe(60000);
+	});
+
+	it("rejects a non-numeric env var and returns 0", () => {
+		const home = makeTempHome();
+		process.env.PI_LENS_CONFIG_PATH = getPiLensGlobalConfigPath(home);
+		process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS = "not-a-number";
+		expect(getRunnerTimeoutFloorMs()).toBe(0);
+	});
+
+	it("rejects a negative env var and returns 0", () => {
+		const home = makeTempHome();
+		process.env.PI_LENS_CONFIG_PATH = getPiLensGlobalConfigPath(home);
+		process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS = "-1000";
+		expect(getRunnerTimeoutFloorMs()).toBe(0);
+	});
+
+	it("reads from the config file when set", () => {
+		const home = makeTempHome();
+		writeConfig(
+			home,
+			JSON.stringify({ dispatch: { runnerTimeoutFloorMs: 90000 } }),
+		);
+		process.env.PI_LENS_CONFIG_PATH = getPiLensGlobalConfigPath(home);
+		expect(getRunnerTimeoutFloorMs()).toBe(90000);
+	});
+
+	it("takes the maximum across config and env when both are set", () => {
+		const home = makeTempHome();
+		writeConfig(
+			home,
+			JSON.stringify({ dispatch: { runnerTimeoutFloorMs: 90000 } }),
+		);
+		process.env.PI_LENS_CONFIG_PATH = getPiLensGlobalConfigPath(home);
+		process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS = "180000";
+		expect(getRunnerTimeoutFloorMs()).toBe(180000);
+	});
+
+	it("memoizes — second call does not re-read the env var", () => {
+		const home = makeTempHome();
+		process.env.PI_LENS_CONFIG_PATH = getPiLensGlobalConfigPath(home);
+		process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS = "60000";
+		expect(getRunnerTimeoutFloorMs()).toBe(60000);
+
+		// Mutate after first read; cache should hold the original value until reset.
+		process.env.PI_LENS_RUNNER_TIMEOUT_FLOOR_MS = "120000";
+		expect(getRunnerTimeoutFloorMs()).toBe(60000);
+
+		_resetRunnerTimeoutFloorCacheForTests();
+		expect(getRunnerTimeoutFloorMs()).toBe(120000);
+	});
+});


### PR DESCRIPTION
Runners can already declare their own `timeoutMs` budget; the dispatcher uses `runner.timeoutMs ?? 30_000` as the effective timeout. There was no escape hatch when a project's toolchain exceeds any declared runner budget.

This adds `RUNNER_TIMEOUT_FLOOR_MS` — a floor applied as:
  max(runner.timeoutMs ?? 30_000, floor)

The floor is resolved from (highest priority first):
  1. `dispatch.runnerTimeoutMs` in `~/.pi-lens/config.json`
  2. `PI_LENS_RUNNER_TIMEOUT_MS` environment variable
  3. 0 (no floor — existing behaviour preserved)

Config file example (~/.pi-lens/config.json):
  { "dispatch": { "runnerTimeoutMs": 180000 } }

Env var example:
  PI_LENS_RUNNER_TIMEOUT_MS=180000 pi