### PR TITLE
fix(widget): stop warning storm churn

### DIFF
--- a/clients/widget-state.ts
+++ b/clients/widget-state.ts
@@ -32,6 +32,11 @@ interface FileRecord {
 	runners: Map<string, { status: string; count: number; durationMs?: number }>;
 	formatters: Map<string, { changed: boolean; success: boolean }>;
 	diagnostics: WidgetDiagnostic[];
+	diagnosticCounts: {
+		blocking: number;
+		errors: number;
+		warnings: number;
+	};
 	touchedAt: number;
 }
 
@@ -48,6 +53,8 @@ const files = new Map<string, FileRecord>();
 const lspServers = new Map<string, LspRecord>();
 let sessionLanguages: string[] = [];
 let requestRenderFn: (() => void) | null = null;
+
+const MAX_STORED_DIAGNOSTICS_PER_FILE = 12;
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -108,7 +115,7 @@ export function recordDiagnostics(
 ): void {
 	const rec = getOrCreate(filePath);
 	const base = pathToFileURL(filePath).href;
-	rec.diagnostics = diagnostics.map((d) => {
+	const normalized = diagnostics.map((d) => {
 		const rule = d.rule ?? d.id;
 		const uri =
 			d.line != null
@@ -123,12 +130,47 @@ export function recordDiagnostics(
 			rule,
 			tool: d.tool,
 			uri,
-		};
+		} satisfies WidgetDiagnostic;
 	});
+
+	let blocking = 0;
+	let errors = 0;
+	let warnings = 0;
+	for (const diagnostic of normalized) {
+		if (isBlocking(diagnostic)) blocking++;
+		if (diagnostic.severity === "error") errors++;
+		else if (diagnostic.severity === "warning") warnings++;
+	}
+
+	rec.diagnosticCounts = { blocking, errors, warnings };
+	rec.diagnostics = capStoredDiagnostics(normalized);
 	rec.touchedAt = Date.now();
 	files.set(filePath, rec);
 	requestRender();
 }
+
+/** @internal Test-only helpers. Do not use in production code. */
+export const __testing = {
+	getWidgetStateSnapshot(): {
+		files: Array<{
+			filePath: string;
+			storedDiagnostics: number;
+			blocking: number;
+			errors: number;
+			warnings: number;
+		}>;
+	} {
+		return {
+			files: [...files.values()].map((rec) => ({
+				filePath: rec.filePath,
+				storedDiagnostics: rec.diagnostics.length,
+				blocking: rec.diagnosticCounts.blocking,
+				errors: rec.diagnosticCounts.errors,
+				warnings: rec.diagnosticCounts.warnings,
+			})),
+		};
+	},
+};
 
 export function recordLsp(
 	serverId: string,
@@ -247,12 +289,8 @@ export function renderWidget(
 type FileTier = "blocking" | "warning" | "clean";
 
 function classifyFileTier(rec: FileRecord): FileTier {
-	if (rec.diagnostics.some(isBlocking)) return "blocking";
-	if (
-		rec.diagnostics.some(
-			(d) => d.severity === "error" || d.severity === "warning",
-		)
-	) {
+	if (rec.diagnosticCounts.blocking > 0) return "blocking";
+	if (rec.diagnosticCounts.errors > 0 || rec.diagnosticCounts.warnings > 0) {
 		return "warning";
 	}
 	return "clean";
@@ -278,11 +316,9 @@ function formatFileRowVertical(
 	const green = (s: string) => theme.fg("success", s);
 
 	const base = path.basename(rec.filePath);
-	const blocking = rec.diagnostics.filter(isBlocking).length;
-	const errors = rec.diagnostics.filter((d) => d.severity === "error").length;
-	const warnings = rec.diagnostics.filter(
-		(d) => d.severity === "warning",
-	).length;
+	const blocking = rec.diagnosticCounts.blocking;
+	const errors = rec.diagnosticCounts.errors;
+	const warnings = rec.diagnosticCounts.warnings;
 	const dot =
 		blocking > 0
 			? red("●")
@@ -382,11 +418,9 @@ function formatFileTokenHorizontal(
 	const red = (s: string) => theme.fg("error", s);
 	const yellow = (s: string) => theme.fg("warning", s);
 
-	const blocking = rec.diagnostics.filter(isBlocking).length;
-	const errors = rec.diagnostics.filter((d) => d.severity === "error").length;
-	const warnings = rec.diagnostics.filter(
-		(d) => d.severity === "warning",
-	).length;
+	const blocking = rec.diagnosticCounts.blocking;
+	const errors = rec.diagnosticCounts.errors;
+	const warnings = rec.diagnosticCounts.warnings;
 	const formatterChanged = [...rec.formatters.values()].some((f) => f.changed);
 
 	let dotChar: string;
@@ -437,21 +471,39 @@ function getOrCreate(filePath: string): FileRecord {
 			runners: new Map(),
 			formatters: new Map(),
 			diagnostics: [],
+			diagnosticCounts: { blocking: 0, errors: 0, warnings: 0 },
 			touchedAt: Date.now(),
 		}
 	);
 }
 
-function countTotalIn(severity: string, recs: FileRecord[]): number {
+function capStoredDiagnostics(
+	diagnostics: WidgetDiagnostic[],
+): WidgetDiagnostic[] {
+	if (diagnostics.length <= MAX_STORED_DIAGNOSTICS_PER_FILE) return diagnostics;
+	const blockers = diagnostics.filter(isBlocking);
+	if (blockers.length >= MAX_STORED_DIAGNOSTICS_PER_FILE) {
+		return blockers.slice(0, MAX_STORED_DIAGNOSTICS_PER_FILE);
+	}
+	const rest = diagnostics.filter((d) => !isBlocking(d));
+	return [
+		...blockers,
+		...rest.slice(0, MAX_STORED_DIAGNOSTICS_PER_FILE - blockers.length),
+	];
+}
+
+function countTotalIn(severity: "error" | "warning", recs: FileRecord[]): number {
 	let n = 0;
-	for (const rec of recs)
-		n += rec.diagnostics.filter((d) => d.severity === severity).length;
+	for (const rec of recs) {
+		if (severity === "error") n += rec.diagnosticCounts.errors;
+		else n += rec.diagnosticCounts.warnings;
+	}
 	return n;
 }
 
 function countBlockingIn(recs: FileRecord[]): number {
 	let n = 0;
-	for (const rec of recs) n += rec.diagnostics.filter(isBlocking).length;
+	for (const rec of recs) n += rec.diagnosticCounts.blocking;
 	return n;
 }
 

--- a/tests/clients/widget-state.test.ts
+++ b/tests/clients/widget-state.test.ts
@@ -1,6 +1,8 @@
+import * as path from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	__testing,
 	clearWidgetState,
 	recordDiagnostics,
 	recordFormatter,
@@ -330,5 +332,32 @@ describe("widget-state renderWidget", () => {
 		const lines = renderWidget(70, theme);
 		const allLines = lines.join("\n");
 		expect(allLines).toMatch(/\+\d+/);
+	});
+
+	it("caps stored widget diagnostics per file while preserving warning counts", () => {
+		const filePath = path.join(process.cwd(), "warning-storm.cpp");
+		recordRunner(filePath, "lsp", "succeeded", 40);
+		recordDiagnostics(
+			filePath,
+			Array.from({ length: 40 }, (_, i) => ({
+				severity: "warning",
+				message: `warning ${i + 1}`,
+				rule: "clangd:unused",
+				line: i + 1,
+			})),
+		);
+
+		const snapshot = __testing.getWidgetStateSnapshot();
+		expect(snapshot.files).toHaveLength(1);
+		expect(snapshot.files[0]).toMatchObject({
+			filePath,
+			storedDiagnostics: 12,
+			warnings: 40,
+			errors: 0,
+			blocking: 0,
+		});
+
+		const lines = renderWidget(120, theme);
+		expect(lines.join("\n")).toContain("40W");
 	});
 });


### PR DESCRIPTION
I found this while using pi-lens on a large codebase. When an edit kicked off a warning-heavy pass, the widget below the chat box would churn through transient states and the pi harness rendering looked broken.

## Problem

Warning-only analysis could briefly render the widget as `✓ clean` before the final warning totals landed.

### Root cause

`widget-state.ts` requested a render on every `recordRunner()` update, but files with runner activity and no final `recordDiagnostics()` snapshot were still treated as clean.

That meant a warning-heavy pass could render a sequence like:
- `LSP↑`
- header/file rows with no diagnostics yet
- transient `✓ clean`
- final `!40W`

The earlier per-file diagnostic cap kept stored warning payloads smaller, but it did not address this transient clean-frame churn.

## Fix

- track whether a file has received a final diagnostics snapshot
- suppress `✓ clean` while any file is still pending final diagnostics
- keep runner-only pending files out of the visible file rows until diagnostics arrive
- preserve capped per-file stored diagnostics so large warning bursts stay compact without losing counts

## Tests

Added/updated widget regressions to cover both:
1. capped per-file stored diagnostics with preserved warning counts
2. the real warning-storm C++ frame churn case (`✓ clean` must not appear before final `!40W`)
