### PR TITLE
fix(widget): stop warning storm churn

### DIFF
--- a/clients/widget-state.ts
+++ b/clients/widget-state.ts
@@ -32,6 +32,12 @@ interface FileRecord {
 	runners: Map<string, { status: string; count: number; durationMs?: number }>;
 	formatters: Map<string, { changed: boolean; success: boolean }>;
 	diagnostics: WidgetDiagnostic[];
+	diagnosticCounts: {
+		blocking: number;
+		errors: number;
+		warnings: number;
+	};
+	hasFinalDiagnosticsSnapshot: boolean;
 	touchedAt: number;
 }
 
@@ -49,6 +55,8 @@ const lspServers = new Map<string, LspRecord>();
 let sessionLanguages: string[] = [];
 let requestRenderFn: (() => void) | null = null;
 
+const MAX_STORED_DIAGNOSTICS_PER_FILE = 12;
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 export function setRenderCallback(fn: () => void): void {
@@ -59,6 +67,7 @@ export function clearWidgetState(): void {
 	files.clear();
 	lspServers.clear();
 	sessionLanguages = [];
+	requestRenderFn = null;
 }
 
 export function setSessionLanguages(langs: string[]): void {
@@ -88,6 +97,7 @@ export function recordRunner(
 ): void {
 	const rec = getOrCreate(filePath);
 	rec.runners.set(runnerId, { status, count: diagnosticCount, durationMs });
+	rec.hasFinalDiagnosticsSnapshot = false;
 	rec.touchedAt = Date.now();
 	files.set(filePath, rec);
 	requestRender();
@@ -108,7 +118,7 @@ export function recordDiagnostics(
 ): void {
 	const rec = getOrCreate(filePath);
 	const base = pathToFileURL(filePath).href;
-	rec.diagnostics = diagnostics.map((d) => {
+	const normalized = diagnostics.map((d) => {
 		const rule = d.rule ?? d.id;
 		const uri =
 			d.line != null
@@ -123,12 +133,48 @@ export function recordDiagnostics(
 			rule,
 			tool: d.tool,
 			uri,
-		};
+		} satisfies WidgetDiagnostic;
 	});
+
+	let blocking = 0;
+	let errors = 0;
+	let warnings = 0;
+	for (const diagnostic of normalized) {
+		if (isBlocking(diagnostic)) blocking++;
+		if (diagnostic.severity === "error") errors++;
+		else if (diagnostic.severity === "warning") warnings++;
+	}
+
+	rec.diagnosticCounts = { blocking, errors, warnings };
+	rec.diagnostics = capStoredDiagnostics(normalized);
+	rec.hasFinalDiagnosticsSnapshot = true;
 	rec.touchedAt = Date.now();
 	files.set(filePath, rec);
 	requestRender();
 }
+
+/** @internal Test-only helpers. Do not use in production code. */
+export const __testing = {
+	getWidgetStateSnapshot(): {
+		files: Array<{
+			filePath: string;
+			storedDiagnostics: number;
+			blocking: number;
+			errors: number;
+			warnings: number;
+		}>;
+	} {
+		return {
+			files: [...files.values()].map((rec) => ({
+				filePath: rec.filePath,
+				storedDiagnostics: rec.diagnostics.length,
+				blocking: rec.diagnosticCounts.blocking,
+				errors: rec.diagnosticCounts.errors,
+				warnings: rec.diagnosticCounts.warnings,
+			})),
+		};
+	},
+};
 
 export function recordLsp(
 	serverId: string,
@@ -171,11 +217,12 @@ export function renderWidget(
 
 	// Header — counts from deduplicated files only
 	const deduped = dedupeByBasename([...files.values()]);
-	const recencySorted = deduped.slice(0, 5);
+	const recencySorted = deduped.filter(shouldRenderFile).slice(0, 5);
 	const langStr = sessionLanguages.slice(0, 6).join(" ");
 	const totalBlocking = countBlockingIn(deduped);
 	const totalErrors = countTotalIn("error", deduped);
 	const totalWarnings = countTotalIn("warning", deduped);
+	const hasPendingAnalysis = deduped.some(isPendingAnalysis);
 	const errorChunk =
 		totalErrors > 0
 			? (totalBlocking > 0 ? red : yellow)(`●${totalErrors}E`)
@@ -185,7 +232,7 @@ export function renderWidget(
 		? errorChunk + (warningChunk ? " " + warningChunk : "")
 		: warningChunk
 			? warningChunk
-			: files.size > 0
+			: files.size > 0 && !hasPendingAnalysis
 				? green("✓ clean")
 				: "";
 
@@ -244,22 +291,24 @@ export function renderWidget(
 
 // ── File row layout ──────────────────────────────────────────────────────────
 
-type FileTier = "blocking" | "warning" | "clean";
+type FileTier = "blocking" | "warning" | "pending" | "clean";
 
 function classifyFileTier(rec: FileRecord): FileTier {
-	if (rec.diagnostics.some(isBlocking)) return "blocking";
-	if (
-		rec.diagnostics.some(
-			(d) => d.severity === "error" || d.severity === "warning",
-		)
-	) {
+	if (rec.diagnosticCounts.blocking > 0) return "blocking";
+	if (rec.diagnosticCounts.errors > 0 || rec.diagnosticCounts.warnings > 0) {
 		return "warning";
 	}
+	if (isPendingAnalysis(rec)) return "pending";
 	return "clean";
 }
 
 function sortByTierThenRecency(recs: FileRecord[]): FileRecord[] {
-	const order: Record<FileTier, number> = { blocking: 0, warning: 1, clean: 2 };
+	const order: Record<FileTier, number> = {
+		blocking: 0,
+		warning: 1,
+		pending: 2,
+		clean: 3,
+	};
 	return [...recs].sort((a, b) => {
 		const ta = order[classifyFileTier(a)];
 		const tb = order[classifyFileTier(b)];
@@ -278,17 +327,17 @@ function formatFileRowVertical(
 	const green = (s: string) => theme.fg("success", s);
 
 	const base = path.basename(rec.filePath);
-	const blocking = rec.diagnostics.filter(isBlocking).length;
-	const errors = rec.diagnostics.filter((d) => d.severity === "error").length;
-	const warnings = rec.diagnostics.filter(
-		(d) => d.severity === "warning",
-	).length;
+	const blocking = rec.diagnosticCounts.blocking;
+	const errors = rec.diagnosticCounts.errors;
+	const warnings = rec.diagnosticCounts.warnings;
 	const dot =
 		blocking > 0
 			? red("●")
 			: warnings > 0 || errors > 0
 				? yellow("!")
-				: green("✓");
+				: isPendingAnalysis(rec)
+					? dim("·")
+					: green("✓");
 	const runnerNames = [...rec.runners.entries()]
 		.filter(([, r]) => r.status !== "skipped")
 		.map(([id]) => id)
@@ -300,7 +349,9 @@ function formatFileRowVertical(
 				(warnings > 0 ? " " + yellow(`${warnings}W`) : "")
 			: warnings > 0
 				? " " + yellow(`${warnings}W`)
-				: " " + dim("clean");
+				: isPendingAnalysis(rec)
+					? ""
+					: " " + dim("clean");
 	const changedFormatters = [...rec.formatters.entries()]
 		.filter(([, f]) => f.changed)
 		.map(([name]) => name);
@@ -382,12 +433,10 @@ function formatFileTokenHorizontal(
 	const red = (s: string) => theme.fg("error", s);
 	const yellow = (s: string) => theme.fg("warning", s);
 
-	const blocking = rec.diagnostics.filter(isBlocking).length;
-	const errors = rec.diagnostics.filter((d) => d.severity === "error").length;
-	const warnings = rec.diagnostics.filter(
-		(d) => d.severity === "warning",
-	).length;
-	const formatterChanged = [...rec.formatters.values()].some((f) => f.changed);
+	const blocking = rec.diagnosticCounts.blocking;
+	const errors = rec.diagnosticCounts.errors;
+	const warnings = rec.diagnosticCounts.warnings;
+	const formatterChanged = hasChangedFormatter(rec);
 
 	let dotChar: string;
 	if (blocking > 0) dotChar = red("●");
@@ -437,21 +486,55 @@ function getOrCreate(filePath: string): FileRecord {
 			runners: new Map(),
 			formatters: new Map(),
 			diagnostics: [],
+			diagnosticCounts: { blocking: 0, errors: 0, warnings: 0 },
+			hasFinalDiagnosticsSnapshot: false,
 			touchedAt: Date.now(),
 		}
 	);
 }
 
-function countTotalIn(severity: string, recs: FileRecord[]): number {
+function hasChangedFormatter(rec: FileRecord): boolean {
+	return [...rec.formatters.values()].some((f) => f.changed);
+}
+
+function shouldRenderFile(rec: FileRecord): boolean {
+	return rec.hasFinalDiagnosticsSnapshot || hasChangedFormatter(rec);
+}
+
+function isPendingAnalysis(rec: FileRecord): boolean {
+	return rec.runners.size > 0 && !rec.hasFinalDiagnosticsSnapshot;
+}
+
+function capStoredDiagnostics(
+	diagnostics: WidgetDiagnostic[],
+): WidgetDiagnostic[] {
+	if (diagnostics.length <= MAX_STORED_DIAGNOSTICS_PER_FILE) return diagnostics;
+	const blockers = diagnostics.filter(isBlocking);
+	if (blockers.length >= MAX_STORED_DIAGNOSTICS_PER_FILE) {
+		return blockers.slice(0, MAX_STORED_DIAGNOSTICS_PER_FILE);
+	}
+	const rest = diagnostics.filter((d) => !isBlocking(d));
+	return [
+		...blockers,
+		...rest.slice(0, MAX_STORED_DIAGNOSTICS_PER_FILE - blockers.length),
+	];
+}
+
+function countTotalIn(
+	severity: "error" | "warning",
+	recs: FileRecord[],
+): number {
 	let n = 0;
-	for (const rec of recs)
-		n += rec.diagnostics.filter((d) => d.severity === severity).length;
+	for (const rec of recs) {
+		if (severity === "error") n += rec.diagnosticCounts.errors;
+		else n += rec.diagnosticCounts.warnings;
+	}
 	return n;
 }
 
 function countBlockingIn(recs: FileRecord[]): number {
 	let n = 0;
-	for (const rec of recs) n += rec.diagnostics.filter(isBlocking).length;
+	for (const rec of recs) n += rec.diagnosticCounts.blocking;
 	return n;
 }
 

--- a/clients/widget-state.ts
+++ b/clients/widget-state.ts
@@ -291,14 +291,13 @@ export function renderWidget(
 
 // ── File row layout ──────────────────────────────────────────────────────────
 
-type FileTier = "blocking" | "warning" | "pending" | "clean";
+type FileTier = "blocking" | "warning" | "clean";
 
 function classifyFileTier(rec: FileRecord): FileTier {
 	if (rec.diagnosticCounts.blocking > 0) return "blocking";
 	if (rec.diagnosticCounts.errors > 0 || rec.diagnosticCounts.warnings > 0) {
 		return "warning";
 	}
-	if (isPendingAnalysis(rec)) return "pending";
 	return "clean";
 }
 
@@ -306,8 +305,7 @@ function sortByTierThenRecency(recs: FileRecord[]): FileRecord[] {
 	const order: Record<FileTier, number> = {
 		blocking: 0,
 		warning: 1,
-		pending: 2,
-		clean: 3,
+		clean: 2,
 	};
 	return [...recs].sort((a, b) => {
 		const ta = order[classifyFileTier(a)];
@@ -335,9 +333,7 @@ function formatFileRowVertical(
 			? red("●")
 			: warnings > 0 || errors > 0
 				? yellow("!")
-				: isPendingAnalysis(rec)
-					? dim("·")
-					: green("✓");
+				: green("✓");
 	const runnerNames = [...rec.runners.entries()]
 		.filter(([, r]) => r.status !== "skipped")
 		.map(([id]) => id)
@@ -349,9 +345,7 @@ function formatFileRowVertical(
 				(warnings > 0 ? " " + yellow(`${warnings}W`) : "")
 			: warnings > 0
 				? " " + yellow(`${warnings}W`)
-				: isPendingAnalysis(rec)
-					? ""
-					: " " + dim("clean");
+				: " " + dim("clean");
 	const changedFormatters = [...rec.formatters.entries()]
 		.filter(([, f]) => f.changed)
 		.map(([name]) => name);

--- a/tests/clients/widget-state.test.ts
+++ b/tests/clients/widget-state.test.ts
@@ -1,12 +1,15 @@
+import * as path from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	__testing,
 	clearWidgetState,
 	recordDiagnostics,
 	recordFormatter,
 	recordLsp,
 	recordRunner,
 	renderWidget,
+	setRenderCallback,
 	setSessionLanguages,
 } from "../../clients/widget-state.ts";
 
@@ -262,6 +265,7 @@ describe("widget-state renderWidget", () => {
 			{ severity: "warning", message: "advisory", rule: "Y" },
 		]);
 		recordRunner(c, "tsc", "succeeded", 0);
+		recordDiagnostics(c, []);
 
 		const lines = renderWidget(120, theme);
 		const fileRow = lines.find(
@@ -284,7 +288,9 @@ describe("widget-state renderWidget", () => {
 		const a = `${process.cwd()}/foo.ts`;
 		const b = `${process.cwd()}/bar.ts`;
 		recordRunner(a, "tsc", "succeeded", 0);
+		recordDiagnostics(a, []);
 		recordRunner(b, "tsc", "succeeded", 0);
+		recordDiagnostics(b, []);
 
 		const lines = renderWidget(50, theme);
 		// Vertical: each file on its own line, no packed row contains both.
@@ -298,6 +304,7 @@ describe("widget-state renderWidget", () => {
 	it("truncates basenames preserving the extension", () => {
 		const filePath = `${process.cwd()}/extremely-very-much-too-long-component-name-that-clearly-overflows-the-budget.tsx`;
 		recordRunner(filePath, "tsc", "succeeded", 0);
+		recordDiagnostics(filePath, []);
 
 		const lines = renderWidget(70, theme);
 		const allLines = lines.join("\n");
@@ -325,10 +332,72 @@ describe("widget-state renderWidget", () => {
 		for (let i = 0; i < 5; i++) {
 			const filePath = `${process.cwd()}/this-is-a-fairly-long-name-${i}.ts`;
 			recordRunner(filePath, "tsc", "succeeded", 0);
+			recordDiagnostics(filePath, []);
 		}
 
 		const lines = renderWidget(70, theme);
 		const allLines = lines.join("\n");
 		expect(allLines).toMatch(/\+\d+/);
+	});
+
+	it("caps stored widget diagnostics per file while preserving warning counts", () => {
+		const filePath = path.join(process.cwd(), "warning-storm.cpp");
+		recordRunner(filePath, "lsp", "succeeded", 40);
+		recordDiagnostics(
+			filePath,
+			Array.from({ length: 40 }, (_, i) => ({
+				severity: "warning",
+				message: `warning ${i + 1}`,
+				rule: "clangd:unused",
+				line: i + 1,
+			})),
+		);
+
+		const snapshot = __testing.getWidgetStateSnapshot();
+		expect(snapshot.files).toHaveLength(1);
+		expect(snapshot.files[0]).toMatchObject({
+			filePath,
+			storedDiagnostics: 12,
+			warnings: 40,
+			errors: 0,
+			blocking: 0,
+		});
+
+		const lines = renderWidget(120, theme);
+		expect(lines.join("\n")).toContain("40W");
+	});
+
+	it("does not churn through transient clean frames during warning-only cxx analysis", () => {
+		const frames: string[] = [];
+		setRenderCallback(() => {
+			frames.push(renderWidget(120, theme).join("\n"));
+		});
+
+		setSessionLanguages(["cpp"]);
+		const filePath = path.join(process.cwd(), "warning-storm.cpp");
+
+		recordLsp("cpp", process.cwd(), "spawn_start");
+		recordLsp("cpp", process.cwd(), "spawn_success", 50);
+		recordRunner(filePath, "lsp", "succeeded", 40, 50);
+		recordRunner(filePath, "cpp-check", "succeeded", 40, 80);
+		recordRunner(filePath, "tree-sitter", "succeeded", 0, 10);
+		recordDiagnostics(
+			filePath,
+			Array.from({ length: 40 }, (_, i) => ({
+				severity: "warning",
+				message: `warning ${i + 1}`,
+				rule: "clangd:unused",
+				line: i + 1,
+			})),
+		);
+
+		const nonEmptyFrames = frames.filter((frame) => frame.trim().length > 0);
+		const finalFrame = nonEmptyFrames.at(-1) ?? "";
+		const intermediateFrames = nonEmptyFrames.slice(0, -1);
+
+		expect(finalFrame).toContain("!40W");
+		expect(finalFrame).toContain("warning-storm.cpp");
+		expect(intermediateFrames.join("\n")).not.toContain("✓ clean");
+		expect(new Set(nonEmptyFrames).size).toBeLessThanOrEqual(3);
 	});
 });


### PR DESCRIPTION
I found this while using pi-lens on a large codebase. When an edit kicked off a warning-heavy pass, the widget below the chat box would churn through transient states and the pi harness rendering looked broken.

## Problem

Warning-only analysis could briefly render the widget as `✓ clean` before the final warning totals landed.

### Root cause

`widget-state.ts` requested a render on every `recordRunner()` update, but files with runner activity and no final `recordDiagnostics()` snapshot were still treated as clean.

That meant a warning-heavy pass could render a sequence like:
- `LSP↑`
- header/file rows with no diagnostics yet
- transient `✓ clean`
- final `!40W`

The earlier per-file diagnostic cap kept stored warning payloads smaller, but it did not address this transient clean-frame churn.

## Fix

- track whether a file has received a final diagnostics snapshot
- suppress `✓ clean` while any file is still pending final diagnostics
- keep runner-only pending files out of the visible file rows until diagnostics arrive
- preserve capped per-file stored diagnostics so large warning bursts stay compact without losing counts

## Tests

Added/updated widget regressions to cover both:
1. capped per-file stored diagnostics with preserved warning counts
2. the real warning-storm C++ frame churn case (`✓ clean` must not appear before final `!40W`)
