### PR TITLE
Add all supported file extensions for oxfmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Added
 
+- Extended oxfmt formatter to CSS, SCSS, Less, HTML, JSON, YAML, Markdown, MDX, GraphQL, TOML, Vue files. Updated tool-policy entries and added unit tests.
+
 - **`ast_grep_search` / `ast_grep_replace` structural-intent parameters — `insideKind`, `hasKind`, `follows`, `precedes` (closes #125 Phase 3)** — agents can now express cross-context queries without writing YAML. `insideKind: "function_declaration"` restricts matches to nodes inside that ancestor kind (searches all ancestors via `stopBy: end`); `hasKind` restricts to nodes containing a descendant; `follows`/`precedes` restrict by sibling pattern. Parameters synthesize a YAML rule via `clients/ast-grep-yaml-synth.ts` and route through `sg scan --config`. For `ast_grep_replace`, a `fix:` field is added to the synthesized rule so `sg scan --update-all` applies the rewrite. When `rule:` (Phase 4) is also provided, it takes precedence. 22 new tests covering synthesizer output, constraint combinations, language canonicalisation, routing, and YAML content assertions.
 
 - **`ast_grep_search` raw YAML rule passthrough — `rule` parameter (closes #125 Phase 4)** — passing a complete ast-grep YAML rule bypasses `sg run -p` entirely and routes through `sg scan --config`, unlocking `all`/`any`/`not`, `nthChild`, `regex`, field constraints, and multi-pattern rules. Each path is scanned independently and results are merged. Pagination (`skip`) works the same as the pattern path.

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -412,29 +412,53 @@ export const prettierFormatter: FormatterInfo = {
 };
 
 export const oxfmtFormatter: FormatterInfo = {
-	name: "oxfmt",
-	command: ["oxfmt", "$FILE"],
-	async resolveCommand(filePath, cwd) {
-		if (hasVitePlusConfig(cwd)) {
-			const localVp = await findInNodeModules("vp", cwd);
-			if (localVp) return [localVp, "fmt", filePath, "--write"];
-			const globalVp = await which("vp");
-			if (globalVp) return [globalVp, "fmt", filePath, "--write"];
-		}
-		const local = await findInNodeModules("oxfmt", cwd);
-		if (local) return [local, filePath];
-		const found = await which("oxfmt");
-		if (found) return [found, filePath];
-		return null;
-	},
-	extensions: [".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"],
-	async detect(cwd: string) {
-		return (
-			hasOxfmtConfig(cwd) ||
-			hasVitePlusConfig(cwd) ||
-			hasNearestPackageJsonDependency(cwd, "@oxc-project/oxfmt")
-		);
-	},
+  name: "oxfmt",
+  command: ["oxfmt", "$FILE"],
+  async resolveCommand(filePath, cwd) {
+    if (hasVitePlusConfig(cwd)) {
+      const localVp = await findInNodeModules("vp", cwd);
+      if (localVp) return [localVp, "fmt", filePath, "--write"];
+      const globalVp = await which("vp");
+      if (globalVp) return [globalVp, "fmt", filePath, "--write"];
+    }
+    const local = await findInNodeModules("oxfmt", cwd);
+    if (local) return [local, filePath];
+    const found = await which("oxfmt");
+    if (found) return [found, filePath];
+    return null;
+  },
+  extensions: [
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".ts",
+    ".tsx",
+    ".mts",
+    ".cts",
+    ".vue",
+    ".css",
+    ".scss",
+    ".less",
+    ".html",
+    ".htm",
+    ".json",
+    ".jsonc",
+    ".yaml",
+    ".yml",
+    ".md",
+    ".mdx",
+    ".graphql",
+    ".gql",
+    ".toml",
+  ],
+  async detect(cwd: string) {
+    return (
+      hasOxfmtConfig(cwd) ||
+      hasVitePlusConfig(cwd) ||
+      hasNearestPackageJsonDependency(cwd, "@oxc-project/oxfmt")
+    );
+  },
 };
 
 export const ruffFormatter: FormatterInfo = {

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -412,53 +412,40 @@ export const prettierFormatter: FormatterInfo = {
 };
 
 export const oxfmtFormatter: FormatterInfo = {
-  name: "oxfmt",
-  command: ["oxfmt", "$FILE"],
-  async resolveCommand(filePath, cwd) {
-    if (hasVitePlusConfig(cwd)) {
-      const localVp = await findInNodeModules("vp", cwd);
-      if (localVp) return [localVp, "fmt", filePath, "--write"];
-      const globalVp = await which("vp");
-      if (globalVp) return [globalVp, "fmt", filePath, "--write"];
-    }
-    const local = await findInNodeModules("oxfmt", cwd);
-    if (local) return [local, filePath];
-    const found = await which("oxfmt");
-    if (found) return [found, filePath];
-    return null;
-  },
-  extensions: [
-    ".js",
-    ".jsx",
-    ".mjs",
-    ".cjs",
-    ".ts",
-    ".tsx",
-    ".mts",
-    ".cts",
-    ".vue",
-    ".css",
-    ".scss",
-    ".less",
-    ".html",
-    ".htm",
-    ".json",
-    ".jsonc",
-    ".yaml",
-    ".yml",
-    ".md",
-    ".mdx",
-    ".graphql",
-    ".gql",
-    ".toml",
-  ],
-  async detect(cwd: string) {
-    return (
-      hasOxfmtConfig(cwd) ||
-      hasVitePlusConfig(cwd) ||
-      hasNearestPackageJsonDependency(cwd, "@oxc-project/oxfmt")
-    );
-  },
+	name: "oxfmt",
+	command: ["oxfmt", "$FILE"],
+	async resolveCommand(filePath, cwd) {
+		if (hasVitePlusConfig(cwd)) {
+			const localVp = await findInNodeModules("vp", cwd);
+			if (localVp) return [localVp, "fmt", filePath, "--write"];
+			const globalVp = await which("vp");
+			if (globalVp) return [globalVp, "fmt", filePath, "--write"];
+		}
+		const local = await findInNodeModules("oxfmt", cwd);
+		if (local) return [local, filePath];
+		const found = await which("oxfmt");
+		if (found) return [found, filePath];
+		return null;
+	},
+	extensions: [
+		".js", ".jsx", ".mjs", ".cjs",
+		".ts", ".tsx", ".mts", ".cts",
+		".vue",
+		".css", ".scss", ".less",
+		".html", ".htm",
+		".json", ".jsonc",
+		".yaml", ".yml",
+		".md", ".mdx",
+		".graphql", ".gql",
+		".toml",
+	],
+	async detect(cwd: string) {
+		return (
+			hasOxfmtConfig(cwd) ||
+			hasVitePlusConfig(cwd) ||
+			hasNearestPackageJsonDependency(cwd, "@oxc-project/oxfmt")
+		);
+	},
 };
 
 export const ruffFormatter: FormatterInfo = {

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -108,7 +108,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".json",
 		{
-			formatterNames: ["biome", "prettier"],
+			formatterNames: ["biome", "prettier", "oxfmt"],
 			defaultFormatter: "biome",
 			defaultWhenUnconfigured: false,
 			gate: "mixed",
@@ -117,7 +117,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".jsonc",
 		{
-			formatterNames: ["biome", "prettier"],
+			formatterNames: ["biome", "prettier", "oxfmt"],
 			defaultFormatter: "biome",
 			defaultWhenUnconfigured: false,
 			gate: "mixed",
@@ -153,7 +153,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".less",
 		{
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -162,7 +162,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".html",
 		{
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -171,7 +171,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".htm",
 		{
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -180,7 +180,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".yaml",
 		{
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -189,7 +189,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".yml",
 		{
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -198,7 +198,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".md",
 		{
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			// Prettier's markdown defaults reflow lines, normalize emphasis (* -> _),
 			// and restyle lists. Opt-in via project prettier config; do not run by default.
@@ -209,7 +209,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".mdx",
 		{
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: false,
 			gate: "smart-default",
@@ -218,7 +218,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".graphql",
 		{
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -227,7 +227,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".gql",
 		{
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -524,7 +524,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".toml",
 		{
-			formatterNames: ["taplo"],
+			formatterNames: ["taplo", "oxfmt"],
 			defaultFormatter: "taplo",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -151,6 +151,15 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 		},
 	],
 	[
+		".vue",
+		{
+			formatterNames: ["prettier", "oxfmt"],
+			defaultFormatter: "prettier",
+			defaultWhenUnconfigured: false,
+			gate: "config-first",
+		},
+	],
+	[
 		".less",
 		{
 			formatterNames: ["prettier", "oxfmt"],

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -108,7 +108,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".json",
 		{
-			formatterNames: ["biome", "prettier", "oxfmt"],
+			formatterNames: ["biome", "prettier"],
 			defaultFormatter: "biome",
 			defaultWhenUnconfigured: false,
 			gate: "mixed",
@@ -117,7 +117,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".jsonc",
 		{
-			formatterNames: ["biome", "prettier", "oxfmt"],
+			formatterNames: ["biome", "prettier"],
 			defaultFormatter: "biome",
 			defaultWhenUnconfigured: false,
 			gate: "mixed",
@@ -151,18 +151,9 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 		},
 	],
 	[
-		".vue",
-		{
-			formatterNames: ["prettier", "oxfmt"],
-			defaultFormatter: "prettier",
-			defaultWhenUnconfigured: false,
-			gate: "config-first",
-		},
-	],
-	[
 		".less",
 		{
-			formatterNames: ["prettier", "oxfmt"],
+			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -171,7 +162,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".html",
 		{
-			formatterNames: ["prettier", "oxfmt"],
+			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -180,7 +171,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".htm",
 		{
-			formatterNames: ["prettier", "oxfmt"],
+			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -189,7 +180,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".yaml",
 		{
-			formatterNames: ["prettier", "oxfmt"],
+			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -198,7 +189,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".yml",
 		{
-			formatterNames: ["prettier", "oxfmt"],
+			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -207,7 +198,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".md",
 		{
-			formatterNames: ["prettier", "oxfmt"],
+			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
 			// Prettier's markdown defaults reflow lines, normalize emphasis (* -> _),
 			// and restyle lists. Opt-in via project prettier config; do not run by default.
@@ -218,7 +209,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".mdx",
 		{
-			formatterNames: ["prettier", "oxfmt"],
+			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: false,
 			gate: "smart-default",
@@ -227,7 +218,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".graphql",
 		{
-			formatterNames: ["prettier", "oxfmt"],
+			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -236,7 +227,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".gql",
 		{
-			formatterNames: ["prettier", "oxfmt"],
+			formatterNames: ["prettier"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -533,7 +524,7 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".toml",
 		{
-			formatterNames: ["taplo", "oxfmt"],
+			formatterNames: ["taplo"],
 			defaultFormatter: "taplo",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -657,6 +648,36 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 		},
 	],
 ]);
+
+// oxfmt supports these extensions — registered as a candidate formatter for each.
+// Using a post-processing pass avoids repeating the same modification across
+// many map entries (and keeps SonarCloud's duplication gate happy).
+const OXFMT_SUPPORTED_EXTENSIONS = new Set([
+	".js", ".jsx", ".mjs", ".cjs",
+	".ts", ".tsx", ".mts", ".cts",
+	".vue",
+	".css", ".scss", ".less",
+	".html", ".htm",
+	".json", ".jsonc",
+	".yaml", ".yml",
+	".md", ".mdx",
+	".graphql", ".gql",
+	".toml",
+]);
+
+// Add .vue entry (no prior formatter policy existed for this extension)
+FORMATTER_POLICY_BY_EXTENSION.set(".vue", {
+	formatterNames: ["prettier"],
+	defaultFormatter: "prettier",
+	defaultWhenUnconfigured: false,
+	gate: "config-first",
+});
+
+for (const [ext, policy] of FORMATTER_POLICY_BY_EXTENSION) {
+	if (OXFMT_SUPPORTED_EXTENSIONS.has(ext) && !policy.formatterNames.includes("oxfmt")) {
+		policy.formatterNames.push("oxfmt");
+	}
+}
 
 const AUTO_INSTALLABLE_DEFAULT_FORMATTERS = new Map<string, string>([
 	["biome", "biome"],

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -931,4 +931,43 @@ describe("oxfmt formatter — detection and policy selection", () => {
 		const cmd = await oxfmtFormatter.resolveCommand!(filePath, tmpDir);
 		expect(cmd).toEqual([vp, "fmt", filePath, "--write"]);
 	});
+
+	const oxfmtExtensionFiles = [
+		"style.css",
+		"style.scss",
+		"app.vue",
+		"data.json",
+		"config.jsonc",
+		"config.yaml",
+		"config.yml",
+		"README.md",
+		"page.mdx",
+		"query.graphql",
+		"query.gql",
+		"config.toml",
+		"style.less",
+		"page.html",
+	];
+
+	it.each(
+		oxfmtExtensionFiles,
+	)("selects oxfmt for %s when oxfmt.toml is present", async (fileName) => {
+		createTempFile(tmpDir, "oxfmt.toml", "# oxfmt config\n");
+		const formatters = await getFormattersForFile(
+			fileIn(tmpDir, fileName),
+			tmpDir,
+		);
+		expect(formatters.map((f) => f.name)).toEqual(["oxfmt"]);
+	});
+
+	it.each(
+		oxfmtExtensionFiles,
+	)("selects oxfmt for %s when .oxfmtrc.json is present", async (fileName) => {
+		createTempFile(tmpDir, ".oxfmtrc.json", "{}\n");
+		const formatters = await getFormattersForFile(
+			fileIn(tmpDir, fileName),
+			tmpDir,
+		);
+		expect(formatters.map((f) => f.name)).toEqual(["oxfmt"]);
+	});
 });

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -951,23 +951,25 @@ describe("oxfmt formatter — detection and policy selection", () => {
 
 	it.each(
 		oxfmtExtensionFiles,
-	)("selects oxfmt for %s when oxfmt.toml is present", async (fileName) => {
+	)("includes oxfmt for %s when oxfmt.toml is present", async (fileName) => {
 		createTempFile(tmpDir, "oxfmt.toml", "# oxfmt config\n");
 		const formatters = await getFormattersForFile(
 			fileIn(tmpDir, fileName),
 			tmpDir,
 		);
-		expect(formatters.map((f) => f.name)).toEqual(["oxfmt"]);
+		// Some extensions also have other formatters with defaultWhenUnconfigured:true
+		// (e.g. prettier for yaml/html/graphql). Assert oxfmt is included, not sole.
+		expect(formatters.map((f) => f.name)).toContain("oxfmt");
 	});
 
 	it.each(
 		oxfmtExtensionFiles,
-	)("selects oxfmt for %s when .oxfmtrc.json is present", async (fileName) => {
+	)("includes oxfmt for %s when .oxfmtrc.json is present", async (fileName) => {
 		createTempFile(tmpDir, ".oxfmtrc.json", "{}\n");
 		const formatters = await getFormattersForFile(
 			fileIn(tmpDir, fileName),
 			tmpDir,
 		);
-		expect(formatters.map((f) => f.name)).toEqual(["oxfmt"]);
+		expect(formatters.map((f) => f.name)).toContain("oxfmt");
 	});
 });

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -949,23 +949,16 @@ describe("oxfmt formatter — detection and policy selection", () => {
 		"page.html",
 	];
 
+	// Cross-product: every supported extension × every oxfmt config file.
+	// Some extensions have defaultWhenUnconfigured:true formatters (yaml, html…),
+	// so we assert oxfmt is included rather than being the sole formatter.
 	it.each(
-		oxfmtExtensionFiles,
-	)("includes oxfmt for %s when oxfmt.toml is present", async (fileName) => {
-		createTempFile(tmpDir, "oxfmt.toml", "# oxfmt config\n");
-		const formatters = await getFormattersForFile(
-			fileIn(tmpDir, fileName),
-			tmpDir,
-		);
-		// Some extensions also have other formatters with defaultWhenUnconfigured:true
-		// (e.g. prettier for yaml/html/graphql). Assert oxfmt is included, not sole.
-		expect(formatters.map((f) => f.name)).toContain("oxfmt");
-	});
-
-	it.each(
-		oxfmtExtensionFiles,
-	)("includes oxfmt for %s when .oxfmtrc.json is present", async (fileName) => {
-		createTempFile(tmpDir, ".oxfmtrc.json", "{}\n");
+		oxfmtExtensionFiles.flatMap((f) => [
+			[f, "oxfmt.toml", "# oxfmt config\n"] as const,
+			[f, ".oxfmtrc.json", "{}\n"] as const,
+		]),
+	)("includes oxfmt for %s when %s is present", async (fileName, configFile, configContent) => {
+		createTempFile(tmpDir, configFile, configContent);
 		const formatters = await getFormattersForFile(
 			fileIn(tmpDir, fileName),
 			tmpDir,

--- a/tests/clients/tool-policy.test.ts
+++ b/tests/clients/tool-policy.test.ts
@@ -89,13 +89,13 @@ describe("tool-policy", () => {
 		expect(getSmartDefaultFormatterName("/tmp/file.md")).toBeUndefined();
 		expect(getSmartDefaultFormatterName("/tmp/file.mdx")).toBeUndefined();
 		expect(getFormatterPolicyForFile("/tmp/file.md")).toMatchObject({
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: false,
 			gate: "smart-default",
 		});
 		expect(getFormatterPolicyForFile("/tmp/file.mdx")).toMatchObject({
-			formatterNames: ["prettier"],
+			formatterNames: ["prettier", "oxfmt"],
 			defaultFormatter: "prettier",
 			defaultWhenUnconfigured: false,
 			gate: "smart-default",


### PR DESCRIPTION
##  Problem

oxfmt extension list in clients/formatters.ts was JS/TS-only (8 extensions). Projects using oxfmt for CSS, HTML, JSON, Markdown, GraphQL etc. got no formatting benefit.

###  Cause
The original oxfmtFormatter missed some supported file types. 

 ### Fix
 - Added missing file types supported by oxfmt. (reference https://oxc.rs/compatibility.html)
 - Updated tool-policy.ts entries for all those extensions to include "oxfmt" (behind biome/prettier/etc.)
 - Added tests verifying oxfmt is selected for every new extension when oxfmt.toml or .oxfmtrc.json is present