### PR TITLE
fix(dispatch): go-vet vets the file's package from the module root (closes #263)

### DIFF
--- a/clients/dispatch/runners/go-vet.ts
+++ b/clients/dispatch/runners/go-vet.ts
@@ -4,6 +4,8 @@
  * Runs `go vet` for Go files to catch common mistakes.
  */
 
+import { relative, sep, posix } from "node:path";
+
 import { GoClient } from "../../go-client.js";
 import { safeSpawnAsync } from "../../safe-spawn.js";
 import { stripAnsi } from "../../sanitize.js";
@@ -31,9 +33,23 @@ const goVetRunner: RunnerDefinition = {
 			return { status: "skipped", diagnostics: [], semantic: "none" };
 		}
 
-		// Run go vet on the file
-		const result = await safeSpawnAsync(goExe, ["vet", ctx.filePath], {
+		// Vet the package containing the file from the module root.
+		//
+		// `go vet <one-file.go>` compiles that file in isolation, so same-package
+		// symbols defined in sibling files read as false `undefined: X`, and when
+		// the spawn cwd is outside the module the run also reports
+		// `go.mod file not found` (#263). ctx.cwd is the go.mod module root
+		// (resolveLanguageRootForFile, markers ["go.mod"]), so vet the file's
+		// package from there.
+		const cwd = ctx.cwd || process.cwd();
+		const fileRel = relative(cwd, ctx.filePath).split(sep).join(posix.sep);
+		const pkgPath = fileRel.includes("/")
+			? "./" + fileRel.slice(0, fileRel.lastIndexOf("/"))
+			: ".";
+
+		const result = await safeSpawnAsync(goExe, ["vet", pkgPath], {
 			timeout: 30000,
+			cwd,
 		});
 
 		const raw = stripAnsi(result.stdout + result.stderr);
@@ -42,24 +58,25 @@ const goVetRunner: RunnerDefinition = {
 			return { status: "succeeded", diagnostics: [], semantic: "none" };
 		}
 
-		// Parse output
-		const diagnostics = parseGoVetOutput(raw, ctx.filePath);
+		// createLineParser ignores the output filename and attributes every
+		// diagnostic to ctx.filePath, so keep only this file's lines — package
+		// vetting reports siblings as module-root-relative paths (e.g. `sub/a.go`,
+		// or a bare basename for the module-root package).
+		const relevant = raw
+			.split("\n")
+			.filter((line) => {
+				const m = line.match(/^(.+?):(\d+):(\d+):\s*(.+)/);
+				return m != null && m[1].replace(/\\/g, "/") === fileRel;
+			})
+			.join("\n");
 
-		if (diagnostics.length === 0) {
-			// go vet returned non-zero but no parseable output
-			return {
-				status: "failed",
-				diagnostics: [],
-				semantic: "warning",
-				rawOutput: raw,
-			};
-		}
+		const diagnostics = parseGoVetOutput(relevant, ctx.filePath);
 
-		return {
-			status: "failed",
-			diagnostics,
-			semantic: "warning",
-		};
+		// Edited file clean → succeeded: a sibling-file error no longer flags
+		// the edited file's turn (it surfaces when that file is itself edited).
+		return diagnostics.length > 0
+			? { status: "failed", diagnostics, semantic: "warning" }
+			: { status: "succeeded", diagnostics: [], semantic: "none" };
 	},
 };
 

--- a/clients/dispatch/runners/go-vet.ts
+++ b/clients/dispatch/runners/go-vet.ts
@@ -4,7 +4,7 @@
  * Runs `go vet` for Go files to catch common mistakes.
  */
 
-import { relative, sep, posix } from "node:path";
+import { relative, resolve, sep, posix } from "node:path";
 
 import { GoClient } from "../../go-client.js";
 import { safeSpawnAsync } from "../../safe-spawn.js";
@@ -43,9 +43,14 @@ const goVetRunner: RunnerDefinition = {
 		// package from there.
 		const cwd = ctx.cwd || process.cwd();
 		const fileRel = relative(cwd, ctx.filePath).split(sep).join(posix.sep);
-		const pkgPath = fileRel.includes("/")
-			? "./" + fileRel.slice(0, fileRel.lastIndexOf("/"))
-			: ".";
+		const pkgPath = fileRel.startsWith("../")
+			? // File isn't under ctx.cwd (unexpected — ctx.cwd is the go.mod root).
+				// Vet the root package as a safe fallback rather than emit `./../x`;
+				// the filename filter below still prevents mis-attribution.
+				"."
+			: fileRel.includes("/")
+				? "./" + fileRel.slice(0, fileRel.lastIndexOf("/"))
+				: ".";
 
 		const result = await safeSpawnAsync(goExe, ["vet", pkgPath], {
 			timeout: 30000,
@@ -60,13 +65,16 @@ const goVetRunner: RunnerDefinition = {
 
 		// createLineParser ignores the output filename and attributes every
 		// diagnostic to ctx.filePath, so keep only this file's lines — package
-		// vetting reports siblings as module-root-relative paths (e.g. `sub/a.go`,
-		// or a bare basename for the module-root package).
+		// vetting reports siblings too. Resolve each output path against the vet
+		// cwd before comparing, so go's path FORM (a leading `./` for the
+		// module-root package, an absolute path, `.` segments) can't cause the
+		// edited file's OWN diagnostics to be silently dropped.
+		const absTarget = resolve(ctx.filePath);
 		const relevant = raw
 			.split("\n")
 			.filter((line) => {
 				const m = line.match(/^(.+?):(\d+):(\d+):\s*(.+)/);
-				return m != null && m[1].replace(/\\/g, "/") === fileRel;
+				return m != null && resolve(cwd, m[1].trim()) === absTarget;
 			})
 			.join("\n");
 

--- a/tests/clients/dispatch/runners/go-vet.test.ts
+++ b/tests/clients/dispatch/runners/go-vet.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FactStore } from "../../../../clients/dispatch/fact-store.js";
+
+// vi.hoisted keeps these available when the mock factories run below.
+const { safeSpawnAsync, goExePath } = vi.hoisted(() => ({
+	safeSpawnAsync: vi.fn(),
+	// Mutable so the "go unavailable" case can flip it without re-importing.
+	goExePath: { current: "/usr/local/bin/go" as string | null },
+}));
+
+vi.mock("../../../../clients/go-client.js", () => ({
+	GoClient: class {
+		async findGoPathAsync() {
+			return goExePath.current;
+		}
+	},
+}));
+
+vi.mock("../../../../clients/safe-spawn.js", () => ({ safeSpawnAsync }));
+
+function makeCtx(filePath: string, cwd = process.cwd()) {
+	return {
+		filePath,
+		cwd,
+		kind: "go" as const,
+		fileRole: "source" as const,
+		pi: { getFlag: () => false },
+		autofix: false,
+		deltaMode: true,
+		facts: new FactStore(),
+		hasTool: async () => true,
+		log: () => {},
+	};
+}
+
+function goResult(stdout = "", status = 0, stderr = "") {
+	return { status, stdout, stderr } as Awaited<ReturnType<typeof safeSpawnAsync>>;
+}
+
+describe("go-vet runner", () => {
+	let runner: typeof import("../../../../clients/dispatch/runners/go-vet.js");
+
+	beforeEach(async () => {
+		goExePath.current = "/usr/local/bin/go";
+		safeSpawnAsync.mockReset();
+		runner = await import(
+			"../../../../clients/dispatch/runners/go-vet.js"
+		);
+	});
+
+	it("skips when go is not available", async () => {
+		goExePath.current = null;
+		const res = await runner.default.run(makeCtx("/m/sub/b.go", "/m"));
+		expect(res.status).toBe("skipped");
+		expect(safeSpawnAsync).not.toHaveBeenCalled();
+	});
+
+	it("vets the package containing the file from the module root (not the file in isolation)", async () => {
+		safeSpawnAsync.mockResolvedValue(goResult());
+		const ctx = makeCtx("/m/sub/b.go", "/m");
+		await runner.default.run(ctx);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+		const [exe, args, opts] = safeSpawnAsync.mock.calls[0];
+		expect(exe).toBe("/usr/local/bin/go");
+		expect(args).toEqual(["vet", "./sub"]);
+		expect(opts).toMatchObject({ cwd: "/m", timeout: 30000 });
+	});
+
+	it("vets '.' for a file in the module-root package", async () => {
+		safeSpawnAsync.mockResolvedValue(goResult());
+		await runner.default.run(makeCtx("/m/main.go", "/m"));
+		expect(safeSpawnAsync.mock.calls[0][1]).toEqual(["vet", "."]);
+	});
+
+	it("keeps diagnostics for the edited file but drops sibling-file lines", async () => {
+		// Package vetting reports siblings too; only the edited file must be attributed.
+		safeSpawnAsync.mockResolvedValue(
+			goResult(
+				'sub/a.go:7:2: fmt.Printf format %d has arg "s" of wrong type string\n' +
+					'sub/b.go:4:5: fmt.Printf format %d has arg "s" of wrong type string\n',
+				1,
+			),
+		);
+		const res = await runner.default.run(makeCtx("/m/sub/b.go", "/m"));
+		expect(res.status).toBe("failed");
+		expect(res.diagnostics).toHaveLength(1);
+		expect(res.diagnostics[0].line).toBe(4);
+		expect(res.diagnostics[0].filePath).toBe("/m/sub/b.go");
+	});
+
+	it("returns succeeded when only a sibling file has issues", async () => {
+		safeSpawnAsync.mockResolvedValue(
+			goResult(
+				'sub/a.go:7:2: fmt.Printf format %d has arg "s" of wrong type string\n',
+				1,
+			),
+		);
+		const res = await runner.default.run(makeCtx("/m/sub/b.go", "/m"));
+		expect(res.status).toBe("succeeded");
+		expect(res.diagnostics).toHaveLength(0);
+	});
+
+	it("returns succeeded on a clean package (no output)", async () => {
+		safeSpawnAsync.mockResolvedValue(goResult());
+		const res = await runner.default.run(makeCtx("/m/sub/b.go", "/m"));
+		expect(res.status).toBe("succeeded");
+		expect(res.diagnostics).toHaveLength(0);
+	});
+});

--- a/tests/clients/dispatch/runners/go-vet.test.ts
+++ b/tests/clients/dispatch/runners/go-vet.test.ts
@@ -106,4 +106,34 @@ describe("go-vet runner", () => {
 		expect(res.status).toBe("succeeded");
 		expect(res.diagnostics).toHaveLength(0);
 	});
+
+	// go emits the path in different FORMS depending on the target: a leading
+	// `./` for the module-root package, sometimes an absolute path. A raw-string
+	// match would drop the edited file's own diagnostics; resolving against cwd
+	// keeps them.
+	it("attributes a './'-prefixed module-root path to the edited file", async () => {
+		safeSpawnAsync.mockResolvedValue(
+			goResult(
+				'./main.go:7:2: fmt.Printf format %d has arg "s" of wrong type string\n',
+				1,
+			),
+		);
+		const res = await runner.default.run(makeCtx("/m/main.go", "/m"));
+		expect(res.status).toBe("failed");
+		expect(res.diagnostics).toHaveLength(1);
+		expect(res.diagnostics[0].filePath).toBe("/m/main.go");
+	});
+
+	it("attributes an absolute output path to the edited file", async () => {
+		safeSpawnAsync.mockResolvedValue(
+			goResult(
+				'/m/sub/b.go:4:5: fmt.Printf format %d has arg "s" of wrong type string\n',
+				1,
+			),
+		);
+		const res = await runner.default.run(makeCtx("/m/sub/b.go", "/m"));
+		expect(res.status).toBe("failed");
+		expect(res.diagnostics).toHaveLength(1);
+		expect(res.diagnostics[0].line).toBe(4);
+	});
 });


### PR DESCRIPTION
> Draft pending your review of the scope change below — happy to reshape. Closes #263.

## Problem

The `go-vet` runner spawns `go vet <ctx.filePath>` with **no `cwd`**. In a multi-file Go package this produces:

- **false `undefined: X`** — `go vet <one-file.go>` compiles that file in isolation, so any symbol defined in a sibling file is reported undefined.
- **`go: go.mod file not found`** — when the spawn inherits a cwd with no `go.mod` (e.g. a monorepo root).

…even though `go vet ./...` / `go build ./...` from the module root are clean. Full repro + empirical matrix in #263.

## Fix

Vet the **package** containing the file from the module root — `ctx.cwd` is already the `go.mod` module root via `resolveLanguageRootForFile` (markers `["go.mod"]`):

```ts
const cwd = ctx.cwd || process.cwd();
const fileRel = relative(cwd, ctx.filePath).split(sep).join(posix.sep);
const pkgPath = fileRel.includes("/")
  ? "./" + fileRel.slice(0, fileRel.lastIndexOf("/"))
  : ".";
const result = await safeSpawnAsync(goExe, ["vet", pkgPath], { timeout: 30000, cwd });
```

Because `createLineParser` discards the output filename and attributes every diagnostic to `ctx.filePath`, the parsed output is **filtered to the edited file** so sibling-file diagnostics aren't mis-attributed.

Mirrors the cwd-threading precedent of #121 and the sibling runner `golangci-lint.ts` (`const cwd = ctx.cwd || process.cwd()`). golangci-lint doesn't have this bug because it analyzes the package of a passed file, whereas `go vet <file>` isolates it.

## Scope change to flag

This widens go-vet from single-file to **package** scope (the only correct way to vet multi-file packages), and changes the tail behavior:

- **Before:** non-zero `go vet` with no parseable output → `failed` + `rawOutput`.
- **After:** edited file with 0 own diagnostics → `succeeded`; a sibling-file error no longer flags the edited file's turn (it surfaces when that file is edited).

If you'd prefer to keep emitting `rawOutput` for genuine go-vet failures, or want sibling issues surfaced differently, say so and I'll adjust.

## Verification

- `npm run build` ✅ (in-place `.js`, which is gitignored)
- `npm run lint` (`tsc -p tsconfig.json`, strict CI gate) ✅
- new `tests/clients/dispatch/runners/go-vet.test.ts` — 6/6 ✅ (spawn args `["vet","./sub"]` + `cwd`, `"."` for root pkg, sibling-filtering, clean→succeeded, skip-when-unavailable)
- full dispatch suite — 378/378 ✅ (`tests/clients/dispatch/`)
- existing single-file smoke fixture still resolves to `go vet .` → `bad.go` parseable
