### PR TITLE
feat(project-scan): run ast-grep via bundled napi engine (closes #308)

### DIFF
--- a/clients/dispatch/runners/ast-grep-napi.ts
+++ b/clients/dispatch/runners/ast-grep-napi.ts
@@ -33,7 +33,9 @@ import {
 let sg: typeof import("@ast-grep/napi") | undefined;
 let sgLoadAttempted = false;
 
-async function loadSg(): Promise<typeof import("@ast-grep/napi") | undefined> {
+export async function loadSg(): Promise<
+	typeof import("@ast-grep/napi") | undefined
+> {
 	if (sg) return sg;
 	if (sgLoadAttempted) return undefined; // Don't retry if already failed
 	sgLoadAttempted = true;
@@ -121,11 +123,14 @@ function normalizeRuleId(ruleId: string): string {
 	return ruleId.replace(/-js$/, "");
 }
 
-function canHandle(filePath: string): boolean {
+export function canHandle(filePath: string): boolean {
 	return SUPPORTED_EXTS.includes(path.extname(filePath).toLowerCase());
 }
 
-function getLang(filePath: string, sgModule: typeof import("@ast-grep/napi")) {
+export function getLang(
+	filePath: string,
+	sgModule: typeof import("@ast-grep/napi"),
+) {
 	const ext = path.extname(filePath).toLowerCase();
 	switch (ext) {
 		case ".ts":
@@ -143,6 +148,165 @@ function getLang(filePath: string, sgModule: typeof import("@ast-grep/napi")) {
 		default:
 			return undefined;
 	}
+}
+
+/** Per-edit defaults — tuned to keep inline output bounded on a broken file. */
+export interface AstGrepEvaluateOptions {
+	/** Drop non-error rules and complexity-bounded blocking rules (per-edit blocking pass). */
+	blockingOnly?: boolean;
+	/** Cap matches kept per rule (default {@link MAX_MATCHES_PER_RULE}). */
+	maxMatchesPerRule?: number;
+	/** Cap total diagnostics per file (default {@link MAX_TOTAL_DIAGNOSTICS}). */
+	maxTotalDiagnostics?: number;
+}
+
+/**
+ * Run the shipped ast-grep YAML ruleset against a parsed file via napi's native
+ * engine, applying the same suppression policy (linter/tree-sitter overlap,
+ * overly-broad-pattern guard) as the per-edit runner. Extracted so the
+ * project-wide scanner can reuse the identical engine + rules WITHOUT the
+ * ast-grep binary — closing the no-binary gap (#308) — while the per-edit runner
+ * keeps its tight budgets. Callers pass the already-parsed `rootNode` so they
+ * control parsing/size gating.
+ */
+export function evaluateAstGrepRules(
+	filePath: string,
+	rootNode: { findAll(config: never): unknown[] },
+	cwd: string,
+	kind: string | undefined,
+	options: AstGrepEvaluateOptions = {},
+): Diagnostic[] {
+	const maxMatchesPerRule = options.maxMatchesPerRule ?? MAX_MATCHES_PER_RULE;
+	const maxTotalDiagnostics =
+		options.maxTotalDiagnostics ?? MAX_TOTAL_DIAGNOSTICS;
+	const blockingOnly = options.blockingOnly === true;
+
+	const diagnostics: Diagnostic[] = [];
+	const seenRuleIds = new Set<string>();
+	const suppressLinterOverlap = kind === "jsts" && hasEslintConfig(cwd);
+
+	const ruleDirs = [
+		path.join(process.cwd(), "rules", "ast-grep-rules", "rules"),
+		path.join(process.cwd(), "rules", "ast-grep-rules"),
+		resolvePackagePath(import.meta.url, "rules", "ast-grep-rules", "rules"),
+		resolvePackagePath(import.meta.url, "rules", "ast-grep-rules"),
+	];
+
+	for (const ruleDir of ruleDirs) {
+		let rules: YamlRule[];
+		try {
+			rules = loadYamlRules(ruleDir, blockingOnly ? "error" : undefined);
+		} catch {
+			continue;
+		}
+
+		for (const rule of rules) {
+			// If the same rule id is loaded from multiple directories
+			// (workspace + bundled), prefer the first one to avoid duplicates.
+			if (seenRuleIds.has(rule.id)) continue;
+			seenRuleIds.add(rule.id);
+
+			if (
+				suppressLinterOverlap &&
+				LINTER_OVERLAP.has(normalizeRuleId(rule.id)) &&
+				!NON_SUPPRESSIBLE.has(normalizeRuleId(rule.id))
+			) {
+				continue;
+			}
+
+			// Skip rules already handled by tree-sitter runner (priority 14)
+			if (TREE_SITTER_OVERLAP.has(rule.id)) continue;
+
+			// Skip rules whose top-level pattern is overly broad ($NAME, $X, etc.)
+			// without additional structural constraints to narrow matches.
+			if (
+				rule.rule &&
+				isOverlyBroadPattern(rule.rule.pattern) &&
+				!isStructuredRule(rule)
+			) {
+				continue;
+			}
+
+			const lang = rule.language?.toLowerCase();
+			if (lang && lang !== "typescript" && lang !== "javascript") {
+				continue;
+			}
+
+			if (blockingOnly && rule.rule) {
+				const complexity = calculateRuleComplexity(rule.rule);
+				if (complexity > MAX_BLOCKING_RULE_COMPLEXITY) {
+					continue;
+				}
+			}
+
+			if (!rule.rule) continue;
+
+			try {
+				let matches: unknown[] = [];
+
+				// Delegate matching to napi's native engine, which handles the
+				// full ast-grep rule grammar (pattern, kind, has/inside/follows/
+				// precedes/stopBy/field/nthChild, any/all/not) plus metavariable
+				// `constraints` (#206). A faithful js-yaml parse feeds the rule
+				// object straight through. If napi rejects the rule (a malformed
+				// or invalid-kind rule), skip it — never silently match nothing
+				// through a partial interpreter.
+				const nativeConfig = rule.constraints
+					? { rule: rule.rule, constraints: rule.constraints }
+					: { rule: rule.rule };
+				try {
+					matches = rootNode.findAll(nativeConfig as never);
+				} catch {
+					matches = [];
+				}
+
+				const limitedMatches = matches.slice(0, maxMatchesPerRule);
+
+				for (const match of limitedMatches) {
+					if (diagnostics.length >= maxTotalDiagnostics) break;
+
+					const node = match as {
+						range(): { start: { line: number; column: number } };
+					};
+					const range = node.range();
+					const severity = rule.severity === "error" ? "error" : "warning";
+					const semantic = severity === "error" ? "blocking" : "warning";
+					const defectClass = classifyDefect(
+						rule.id,
+						"ast-grep-napi",
+						rule.message || rule.id,
+					);
+					const ruleFix = explicitRuleFixSuggestion(rule);
+
+					diagnostics.push({
+						id: `ast-grep-napi-${range.start.line}-${rule.id}`,
+						message: `[${rule.metadata?.category || "slop"}] ${rule.message || rule.id}`,
+						filePath,
+						line: range.start.line + 1,
+						column: range.start.column + 1,
+						severity,
+						semantic,
+						tool: "ast-grep-napi",
+						rule: rule.id,
+						defectClass,
+						fixable: !!ruleFix,
+						autoFixAvailable: false,
+						fixKind: ruleFix ? "suggestion" : undefined,
+						fixSuggestion:
+							semantic === "blocking"
+								? (ruleFix ?? defaultFixSuggestion(defectClass, rule.id))
+								: ruleFix,
+					});
+				}
+
+				if (diagnostics.length >= maxTotalDiagnostics) break;
+			} catch {
+				// Rule failed, skip
+			}
+		}
+	}
+
+	return diagnostics;
 }
 
 // --- Runner Definition ---
@@ -224,131 +388,13 @@ const astGrepNapiRunner: RunnerDefinition = {
 			return { status: "skipped", diagnostics: [], semantic: "none" };
 		}
 
-		const diagnostics: Diagnostic[] = [];
-		const seenRuleIds = new Set<string>();
-		const suppressLinterOverlap =
-			ctx.kind === "jsts" && hasEslintConfig(ctx.cwd);
-
-		const ruleDirs = [
-			path.join(process.cwd(), "rules", "ast-grep-rules", "rules"),
-			path.join(process.cwd(), "rules", "ast-grep-rules"),
-			resolvePackagePath(import.meta.url, "rules", "ast-grep-rules", "rules"),
-			resolvePackagePath(import.meta.url, "rules", "ast-grep-rules"),
-		];
-
-		for (const ruleDir of ruleDirs) {
-			let rules: YamlRule[];
-			try {
-				rules = loadYamlRules(ruleDir, ctx.blockingOnly ? "error" : undefined);
-			} catch {
-				continue;
-			}
-
-			for (const rule of rules) {
-				// If the same rule id is loaded from multiple directories
-				// (workspace + bundled), prefer the first one to avoid duplicates.
-				if (seenRuleIds.has(rule.id)) continue;
-				seenRuleIds.add(rule.id);
-
-				if (
-					suppressLinterOverlap &&
-					LINTER_OVERLAP.has(normalizeRuleId(rule.id)) &&
-					!NON_SUPPRESSIBLE.has(normalizeRuleId(rule.id))
-				) {
-					continue;
-				}
-
-				// Skip rules already handled by tree-sitter runner (priority 14)
-				if (TREE_SITTER_OVERLAP.has(rule.id)) continue;
-
-				// Skip rules whose top-level pattern is overly broad ($NAME, $X, etc.)
-				// without additional structural constraints to narrow matches.
-				if (
-					rule.rule &&
-					isOverlyBroadPattern(rule.rule.pattern) &&
-					!isStructuredRule(rule)
-				) {
-					continue;
-				}
-
-				const lang = rule.language?.toLowerCase();
-				if (lang && lang !== "typescript" && lang !== "javascript") {
-					continue;
-				}
-
-				if (ctx.blockingOnly && rule.rule) {
-					const complexity = calculateRuleComplexity(rule.rule);
-					if (complexity > MAX_BLOCKING_RULE_COMPLEXITY) {
-						continue;
-					}
-				}
-
-				if (!rule.rule) continue;
-
-				try {
-					let matches: unknown[] = [];
-
-					// Delegate matching to napi's native engine, which handles the
-					// full ast-grep rule grammar (pattern, kind, has/inside/follows/
-					// precedes/stopBy/field/nthChild, any/all/not) plus metavariable
-					// `constraints` (#206). A faithful js-yaml parse feeds the rule
-					// object straight through. If napi rejects the rule (a malformed
-					// or invalid-kind rule), skip it — never silently match nothing
-					// through a partial interpreter.
-					const nativeConfig = rule.constraints
-						? { rule: rule.rule, constraints: rule.constraints }
-						: { rule: rule.rule };
-					try {
-						matches = rootNode.findAll(nativeConfig as never);
-					} catch {
-						matches = [];
-					}
-
-					const limitedMatches = matches.slice(0, MAX_MATCHES_PER_RULE);
-
-					for (const match of limitedMatches) {
-						if (diagnostics.length >= MAX_TOTAL_DIAGNOSTICS) break;
-
-						const node = match as {
-							range(): { start: { line: number; column: number } };
-						};
-						const range = node.range();
-						const severity = rule.severity === "error" ? "error" : "warning";
-						const semantic = severity === "error" ? "blocking" : "warning";
-						const defectClass = classifyDefect(
-							rule.id,
-							"ast-grep-napi",
-							rule.message || rule.id,
-						);
-						const ruleFix = explicitRuleFixSuggestion(rule);
-
-						diagnostics.push({
-							id: `ast-grep-napi-${range.start.line}-${rule.id}`,
-							message: `[${rule.metadata?.category || "slop"}] ${rule.message || rule.id}`,
-							filePath: ctx.filePath,
-							line: range.start.line + 1,
-							column: range.start.column + 1,
-							severity,
-							semantic,
-							tool: "ast-grep-napi",
-							rule: rule.id,
-							defectClass,
-							fixable: !!ruleFix,
-							autoFixAvailable: false,
-							fixKind: ruleFix ? "suggestion" : undefined,
-							fixSuggestion:
-								semantic === "blocking"
-									? (ruleFix ?? defaultFixSuggestion(defectClass, rule.id))
-									: ruleFix,
-						});
-					}
-
-					if (diagnostics.length >= MAX_TOTAL_DIAGNOSTICS) break;
-				} catch {
-					// Rule failed, skip
-				}
-			}
-		}
+		const diagnostics = evaluateAstGrepRules(
+			ctx.filePath,
+			rootNode,
+			ctx.cwd,
+			ctx.kind,
+			{ blockingOnly: ctx.blockingOnly },
+		);
 
 		const hasBlocking = diagnostics.some((d) => d.semantic === "blocking");
 		let semantic: "blocking" | "warning" | "none" = "none";

--- a/clients/project-diagnostics/cache.ts
+++ b/clients/project-diagnostics/cache.ts
@@ -6,7 +6,9 @@ import type {
 	ProjectDiagnosticsSnapshot,
 } from "./types.js";
 
-export const PROJECT_DIAGNOSTICS_CACHE_VERSION = 1;
+// v2: cheap-tier scan now also runs ast-grep-napi (#308); invalidate older
+// snapshots so a pre-ast-grep cache isn't served as complete via refreshRunners=cached.
+export const PROJECT_DIAGNOSTICS_CACHE_VERSION = 2;
 const SNAPSHOT_CACHE_FILE = "project-diagnostics.json";
 const DELTA_CACHE_FILE = "project-diagnostics-delta.json";
 

--- a/clients/project-diagnostics/scanner.ts
+++ b/clients/project-diagnostics/scanner.ts
@@ -1,8 +1,15 @@
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { createDispatchContext } from "../dispatch/dispatcher.js";
 import { evaluateRules } from "../dispatch/fact-rule-runner.js";
 import { runProviders } from "../dispatch/fact-runner.js";
 import { FactStore } from "../dispatch/fact-store.js";
+import {
+	canHandle as astGrepCanHandle,
+	evaluateAstGrepRules,
+	getLang as astGrepGetLang,
+	loadSg,
+} from "../dispatch/runners/ast-grep-napi.js";
 import type { Diagnostic } from "../dispatch/types.js";
 import { isTestFile } from "../file-utils.js";
 import { collectSourceFilesAsync } from "../source-filter.js";
@@ -21,6 +28,13 @@ import type {
 import "../dispatch/integration.js";
 
 const DEFAULT_MAX_FILES = 500;
+// Skip files this large: matches the per-edit ast-grep runner's guard so a single
+// generated megafile can't dominate a project scan.
+const AST_GREP_MAX_FILE_BYTES = 1024 * 1024;
+// Project-audit budgets — looser than the per-edit runner's 10/50 (which exist to
+// keep inline output bounded), since a project scan is an explicit, expensive call.
+const AST_GREP_SCAN_MAX_MATCHES_PER_RULE = 25;
+const AST_GREP_SCAN_MAX_DIAGNOSTICS_PER_FILE = 100;
 const FACT_RULE_EXTENSIONS = new Set([
 	".ts",
 	".tsx",
@@ -164,6 +178,66 @@ async function scanTreeSitter(
 	return diagnostics;
 }
 
+/**
+ * Project-wide ast-grep pass via the bundled napi engine — no `ast-grep` binary
+ * required (#308). In `lens_diagnostics mode=full` the ast-grep LSP already
+ * covers the project WHEN its binary is present; this closes the no-binary gap
+ * using the same Rust core + shipped ruleset. Findings dedup against the LSP's
+ * (`filePath:line:rule`) in the full-mode merge, so running both never
+ * double-reports. Iterates the SAME `files` list as the other scanners, so it
+ * inherits identical exclusion/ignore/cap behavior automatically.
+ */
+async function scanAstGrepNapi(
+	cwd: string,
+	files: string[],
+): Promise<ProjectDiagnostic[]> {
+	const sgModule = await loadSg();
+	if (!sgModule) return [];
+
+	const diagnostics: ProjectDiagnostic[] = [];
+	for (const filePath of files) {
+		if (isTestFile(filePath) || !astGrepCanHandle(filePath)) continue;
+
+		let stats: fs.Stats;
+		try {
+			stats = fs.statSync(filePath);
+		} catch {
+			continue;
+		}
+		if (stats.size > AST_GREP_MAX_FILE_BYTES) continue;
+
+		const lang = astGrepGetLang(filePath, sgModule);
+		if (!lang) continue;
+
+		let content: string;
+		try {
+			content = fs.readFileSync(filePath, "utf-8");
+		} catch {
+			continue;
+		}
+
+		try {
+			const rootNode = lang.parse(content).root();
+			const fileDiagnostics = evaluateAstGrepRules(
+				filePath,
+				rootNode,
+				cwd,
+				"jsts",
+				{
+					maxMatchesPerRule: AST_GREP_SCAN_MAX_MATCHES_PER_RULE,
+					maxTotalDiagnostics: AST_GREP_SCAN_MAX_DIAGNOSTICS_PER_FILE,
+				},
+			);
+			for (const diagnostic of fileDiagnostics) {
+				diagnostics.push(fromDispatchDiagnostic(diagnostic, "ast-grep-napi"));
+			}
+		} catch {
+			// Project scans are best-effort; one unparsable file must not abort the tool.
+		}
+	}
+	return diagnostics;
+}
+
 export async function scanProjectDiagnostics(
 	options: ProjectDiagnosticsScanOptions,
 ): Promise<ProjectDiagnosticsSnapshot> {
@@ -173,6 +247,7 @@ export async function scanProjectDiagnostics(
 	const diagnostics = [
 		...(await scanTreeSitter(cwd, files)),
 		...(await scanFactRules(cwd, files)),
+		...(await scanAstGrepNapi(cwd, files)),
 	];
 	const snapshot: ProjectDiagnosticsSnapshot = {
 		version: PROJECT_DIAGNOSTICS_CACHE_VERSION,
@@ -181,7 +256,7 @@ export async function scanProjectDiagnostics(
 		scannedAt: new Date().toISOString(),
 		diagnostics,
 		filesScanned: files.length,
-		runners: ["tree-sitter", "fact-rules"],
+		runners: ["tree-sitter", "fact-rules", "ast-grep-napi"],
 	};
 	saveProjectDiagnosticsSnapshot(cwd, snapshot);
 	return snapshot;

--- a/tests/clients/project-diagnostics.test.ts
+++ b/tests/clients/project-diagnostics.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	loadProjectDiagnosticsDeltaReport,
 	loadProjectDiagnosticsSnapshot,
+	PROJECT_DIAGNOSTICS_CACHE_VERSION,
 	reconcileProjectDiagnosticsSnapshot,
 	saveProjectDiagnosticsSnapshot,
 	writeProjectDiagnosticsDeltaReport,
@@ -35,7 +36,7 @@ function snapshot(
 	overrides: Partial<ProjectDiagnosticsSnapshot> = {},
 ): ProjectDiagnosticsSnapshot {
 	return {
-		version: 1,
+		version: PROJECT_DIAGNOSTICS_CACHE_VERSION,
 		cwd: tmp,
 		tier: "cheap",
 		scannedAt: "2026-01-01T00:00:00.000Z",
@@ -50,7 +51,7 @@ function deltaReport(
 	overrides: Partial<ProjectDiagnosticsDeltaReport> = {},
 ): ProjectDiagnosticsDeltaReport {
 	return {
-		version: 1,
+		version: PROJECT_DIAGNOSTICS_CACHE_VERSION,
 		cwd: tmp,
 		generatedAt: "2026-01-01T00:00:00.000Z",
 		sessionId: "session-1",
@@ -89,7 +90,7 @@ describe("project diagnostics cache", () => {
 
 	it("persists delta reports", () => {
 		const report = {
-			version: 1,
+			version: PROJECT_DIAGNOSTICS_CACHE_VERSION,
 			cwd: tmp,
 			generatedAt: "2026-01-01T00:00:00.000Z",
 			sessionId: "session-1",
@@ -275,5 +276,55 @@ describe("scanProjectDiagnostics", () => {
 		expect(loadProjectDiagnosticsSnapshot(tmp)?.diagnostics.length).toBe(
 			result.diagnostics.length,
 		);
+	});
+
+	it("runs ast-grep-napi project-wide without the ast-grep binary (#308)", async () => {
+		const srcDir = path.join(tmp, "src");
+		fs.mkdirSync(srcDir, { recursive: true });
+		// `alert($$$ARGS)` is the shipped `no-alert` rule — a clean, suppression-free
+		// match that exercises the bundled napi engine (no binary involved).
+		fs.writeFileSync(
+			path.join(srcDir, "ui.ts"),
+			'export function notify() { alert("hi"); }\n',
+		);
+
+		const result = await scanProjectDiagnostics({
+			cwd: tmp,
+			tier: "cheap",
+			maxFiles: 10,
+		});
+
+		expect(result.runners).toContain("ast-grep-napi");
+		expect(result.diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					filePath: path.join(srcDir, "ui.ts"),
+					runner: "ast-grep-napi",
+					tool: "ast-grep-napi",
+					rule: "no-alert",
+					source: "project-scan",
+				}),
+			]),
+		);
+	});
+
+	it("excludes ignored/excluded files from the ast-grep scan (#308)", async () => {
+		// node_modules is a canonical excluded dir — its violations must not surface.
+		const vendored = path.join(tmp, "node_modules", "pkg");
+		fs.mkdirSync(vendored, { recursive: true });
+		fs.writeFileSync(
+			path.join(vendored, "index.ts"),
+			'export function n() { alert("vendored"); }\n',
+		);
+
+		const result = await scanProjectDiagnostics({
+			cwd: tmp,
+			tier: "cheap",
+			maxFiles: 50,
+		});
+
+		expect(
+			result.diagnostics.filter((d) => d.filePath.includes("node_modules")),
+		).toHaveLength(0);
 	});
 });

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -477,7 +477,7 @@ describe("lens_diagnostics mode=full", () => {
 			tier: "cheap",
 			scannedAt: "2026-01-01T00:00:00.000Z",
 			filesScanned: 2,
-			runners: ["tree-sitter", "fact-rules"],
+			runners: ["tree-sitter", "fact-rules", "ast-grep-napi"],
 			diagnostics: [
 				{
 					filePath: "/proj/src/project.ts",


### PR DESCRIPTION
Closes #308.

## Problem

`lens_diagnostics mode=full` only ran project-wide ast-grep when the **`ast-grep` binary** was present (via the auxiliary ast-grep LSP, which `runWorkspaceDiagnostics` reaches through `clientScope:"all"`). The cheap-tier `scanProjectDiagnostics` ran only `tree-sitter` + `fact-rules`. So a project **without the binary installed** got **zero** project-wide ast-grep — even though `@ast-grep/napi` is a bundled dependency we already run per-edit.

A CLI pass was rejected: the napi runner, the ast-grep LSP, and the ast-grep CLI are the **same Rust core running the same shipped ruleset** (#239), so a CLI sweep is pure redundancy plus a reintroduced binary dependency. The gap is specifically the no-binary case — which the bundled napi engine closes.

## Change

- Extract the napi matching loop into `evaluateAstGrepRules()` (shared by the per-edit runner and the new scanner; identical suppression policy + native engine).
- Add `scanAstGrepNapi()` to `scanProjectDiagnostics`, alongside `scanTreeSitter` / `scanFactRules`; add `ast-grep-napi` to the snapshot `runners`.
- Iterates the **same `collectSourceFilesAsync` file list** as the other scanners → inherits identical exclusion / `.gitignore` / `.pi-lens.json` / `maxFiles` confinement automatically (no duplicated skip-list). Mirrors per-file content gates (1 MB size cap, `isTestFile` skip, supported extensions).
- **Dedup-safe**: full-mode merge keys on `filePath:line:rule`, so when the binary IS present and both the LSP sweep and the napi scan fire, identical findings collapse — no double-report.
- Scan-mode budget override (25 matches/rule, 100 diags/file) vs the per-edit 10/50 caps, since a project scan is an explicit expensive call.
- Bump `PROJECT_DIAGNOSTICS_CACHE_VERSION` 1→2 so pre-ast-grep snapshots aren't served as complete via `refreshRunners=cached`.

## Tests

- New: ast-grep-napi surfaces a `no-alert` violation project-wide with **no binary** involved.
- New: `node_modules` (excluded dir) produces no ast-grep findings — exclusion inheritance.
- Existing napi-runner tests pass unchanged (extraction preserved behavior); cache-version tests updated to reference the constant.

`build` + `lint` clean; 53/53 targeted tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
