### PR TITLE
fix(lens-diagnostics): dedup napi project scan against ast-grep LSP (refs #308)

### DIFF
--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -609,6 +609,61 @@ describe("lens_diagnostics mode=full", () => {
 		expect(result.details).toMatchObject({ totalBlocking: 1, totalErrors: 1 });
 	});
 
+	it("dedups the napi project scan against ast-grep LSP findings despite the source prefix (#308)", async () => {
+		// The ast-grep LSP keys its findings `ast-grep:<id>`; the napi scan (#308)
+		// uses the bare `<id>`. Same violation, same line — must collapse to ONE in
+		// mode=full, not double-report once the binary is present.
+		mockSummaries.length = 0;
+		mockSummaries.push(
+			sum(
+				"/proj/src/ui.ts",
+				{ warnings: 1 },
+				{
+					diagnostics: [
+						{
+							severity: "warning",
+							message: "Avoid alert()",
+							line: 5,
+							rule: "ast-grep:no-alert",
+							tool: "ast-grep",
+						},
+					],
+				},
+			),
+		);
+		projectDiagnosticsMocks.loadProjectDiagnosticsSnapshot.mockReturnValue({
+			// cache.js is mocked in this file, so the version constant isn't in scope;
+			// the tool path doesn't validate it (loader is mocked, reconcile is identity).
+			version: 2,
+			cwd: "/proj",
+			tier: "cheap",
+			scannedAt: "2026-01-01T00:00:00.000Z",
+			filesScanned: 1,
+			runners: ["tree-sitter", "fact-rules", "ast-grep-napi"],
+			diagnostics: [
+				{
+					filePath: "/proj/src/ui.ts",
+					line: 5,
+					severity: "warning",
+					semantic: "warning",
+					tool: "ast-grep-napi",
+					runner: "ast-grep-napi",
+					rule: "no-alert",
+					message: "Avoid alert()",
+					source: "project-scan",
+				},
+			],
+		});
+		const lspService = { runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]) };
+
+		const result = await run(makeTool({}, lspService), {
+			mode: "full",
+			refreshRunners: "cached",
+		});
+		// One warning, not two — the napi scan finding deduped against the LSP one.
+		expect(result.details).toMatchObject({ totalWarnings: 1 });
+	});
+
 	it("filters ignored cached/widget/project diagnostics when merging full mode (#279)", async () =>
 		withIgnoredFixture(async (cwd) => {
 			const keep = path.join(cwd, "src", "keep.ts");

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -402,11 +402,22 @@ function projectDiagnosticToWidget(
 	};
 }
 
+// The ast-grep LSP keys its diagnostics `rule = "ast-grep:<id>"` (source:code,
+// lsp-diagnostics.ts), while the napi runner — per-edit AND the project scan
+// (#308) — emits the bare `<id>`. Both run the same shipped ruleset, so the same
+// violation must collapse to one finding in mode=full's merge regardless of which
+// engine produced it. Strip the `ast-grep:` source prefix and the `-js` language
+// suffix (the napi runner already treats `<id>` / `<id>-js` as one rule) so the
+// LSP sweep and the napi scan don't double-report the same line.
+function normalizeRuleForDedup(ruleId: string): string {
+	return ruleId.replace(/^ast-grep:/, "").replace(/-js$/, "");
+}
+
 function diagnosticDedupKey(
 	filePath: string,
 	diagnostic: WidgetDiagnostic,
 ): string {
-	const ruleId = diagnostic.rule ?? diagnostic.tool ?? "";
+	const ruleId = normalizeRuleForDedup(diagnostic.rule ?? diagnostic.tool ?? "");
 	return [path.resolve(filePath), diagnostic.line ?? "?", ruleId].join(":");
 }
 


### PR DESCRIPTION
Follow-up to #308 / #309 (already merged).

## Problem

The project-scan ast-grep work (#308, merged in #309) double-reports in `lens_diagnostics mode=full` **when the `ast-grep` binary is present**. The dedup key in `diagnosticDedupKey` compared raw rule ids, but the two engines tag the same rule differently:

- ast-grep **LSP** → `rule = "ast-grep:<id>"` (source:code; `lsp-diagnostics.ts`, source confirmed `"ast-grep"` in `auxiliary-lsp.ts`).
- ast-grep **napi** (per-edit AND the #308 project scan) → bare `<id>`.

`ast-grep:no-alert` ≠ `no-alert`, so the workspace LSP sweep and `scanAstGrepNapi` each surfaced the same violation. (napi-vs-napi already deduped — only the cross-engine case leaked.)

## Fix

Normalize the dedup key: strip the `ast-grep:` source prefix and the `-js` language suffix (the napi runner already treats `<id>` / `<id>-js` as one rule) so LSP and napi findings for the same rule+line collapse to one.

## Test

New: in `mode=full`, a widget ast-grep **LSP** finding (`ast-grep:no-alert`, line 5) + a project-snapshot **napi** finding (`no-alert`, line 5) on the same file dedup to a single warning (`totalWarnings: 1`), not two.

`build` + `lint` clean; lens-diagnostics suite 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
