### PR TITLE
feat(module-report): cold-cache imports (language-uniform) + member nesting (#301)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,13 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   dependents — blast radius), `pilens_module_report` (navigable outline + signatures
   + who-uses-this + ready-to-use `read` args — a token-efficient read substitute;
   the outline is module-level declarations + class members only — function-locals
-  are dropped (#259) — and the `api`/`internal` split is visibility-aware, so a
-  `private`/`protected` member of an exported class sits in `internal` with a
-  `visibility` tag, not the public `api` (#258)) /
+  are dropped (#259). Class/interface members nest under their container by
+  line-range containment (`members[]`, #301); the `api`/`internal` split is over
+  TOP-LEVEL entries only, and a `private`/`protected` member is tagged with a
+  `visibility` field inside its container's members, not promoted to the public
+  `api` (#258). `imports` populate language-uniformly even on a cold cache —
+  resolved to in-project files via the warm graph's resolver, else bucketed
+  internal/external by shape (#301)) /
   `pilens_read_symbol` (one symbol's verbatim body). Wrapped pi tools emit their
   typebox `parameters` as the MCP `inputSchema` (via `schemaWithCwd`) — no
   hand-restated schema to drift.

--- a/clients/module-report.ts
+++ b/clients/module-report.ts
@@ -34,10 +34,14 @@ import * as path from "node:path";
 import { detectFileKind } from "./file-kinds.js";
 import { logLatency } from "./latency-logger.js";
 import { normalizeMapKey } from "./path-utils.js";
+import { resolveImportToFiles } from "./review-graph/import-resolvers.js";
+import type { ReviewGraph, ReviewGraphEdgeKind } from "./review-graph/types.js";
 import type { Symbol as ExtractedSymbol } from "./symbol-types.js";
 import { TreeSitterClient } from "./tree-sitter-client.js";
-import { TreeSitterSymbolExtractor } from "./tree-sitter-symbol-extractor.js";
-import type { ReviewGraph, ReviewGraphEdgeKind } from "./review-graph/types.js";
+import {
+	type ImportRef,
+	TreeSitterSymbolExtractor,
+} from "./tree-sitter-symbol-extractor.js";
 
 // NOTE: live-LSP enrichment is NO LONGER called on this read path (#256). Firing
 // LSP per read — speculatively, on the agent's fan-out path — repeatedly OOM'd
@@ -77,6 +81,12 @@ export interface ModuleSymbolEntry {
 	/** Empty when the symbol has no risk flags; omitted from the wire entirely. */
 	flags?: string[];
 	usedBy?: ModuleSymbolUsedBy[];
+	/** Members nested under their container by line-range containment (#301) —
+	 * a class/interface's methods/fields, an outer class's inner classes. Each
+	 * member is a full entry (read-args, visibility, who-uses-this); omitted when
+	 * the symbol has none. The api/internal split is over TOP-LEVEL entries only;
+	 * members ride along inside their container. */
+	members?: ModuleSymbolEntry[];
 	/** Pre-computed read arguments — the agent's next call sits right here. */
 	read: { path: string; offset: number; limit: number };
 }
@@ -180,21 +190,22 @@ async function getExtractor(
 	return result;
 }
 
-async function extractFileSymbols(
+async function extractFile(
 	absPath: string,
 	languageId: string,
 	content: string,
-): Promise<ExtractedSymbol[]> {
+): Promise<{ symbols: ExtractedSymbol[]; imports: ImportRef[] }> {
 	try {
 		const initialized = await tsClient.init();
-		if (!initialized) return [];
+		if (!initialized) return { symbols: [], imports: [] };
 		const tree = await tsClient.parseFile(absPath, languageId);
-		if (!tree) return [];
+		if (!tree) return { symbols: [], imports: [] };
 		const extractor = await getExtractor(languageId);
-		if (!extractor) return [];
-		return extractor.extract(tree, absPath, content).symbols;
+		if (!extractor) return { symbols: [], imports: [] };
+		const result = extractor.extract(tree, absPath, content);
+		return { symbols: result.symbols, imports: result.imports };
 	} catch {
-		return [];
+		return { symbols: [], imports: [] };
 	}
 }
 
@@ -283,6 +294,63 @@ function collectImports(
 	};
 }
 
+// An import source string "looks internal" when its shape names a same-project
+// target the per-language resolver couldn't pin to a file (a not-yet-created
+// file, or a language we don't resolve to disk). Relative paths and Rust's
+// crate-relative prefixes are unambiguously in-project; everything else
+// (bare specifiers, absolute package paths) is treated as external. This is the
+// floor under `resolveImportToFiles` — it never fabricates a file path, only a
+// best-effort internal/external bucket.
+function looksInternal(source: string): boolean {
+	// A leading "." is relative across every language we extract (JS ./ ../,
+	// Python . .foo ..pkg, Ruby/Dart/bash relative paths) and never begins a bare
+	// or scoped package specifier (react, @scope/pkg, java.util.List, fmt). Rust's
+	// crate-relative prefixes are likewise unambiguously in-project.
+	return (
+		source.startsWith(".") ||
+		source.startsWith("crate::") ||
+		source.startsWith("super::") ||
+		source.startsWith("self::")
+	);
+}
+
+// Cold-cache imports (#301): the warm review graph is the source of truth for
+// imports, but on a cold cache it's absent and `collectImports` returns empty
+// even though the tree-sitter extractor already parsed the import sources. Rebuild
+// the same {external, internal} shape language-uniformly from those sources:
+// resolve each to real in-project files via the warm graph's own resolver
+// (`resolveImportToFiles`) when the language supports it, else fall back to the
+// shape heuristic. Internal entries are cwd-relative display paths (resolved) or
+// the raw source (heuristic), mirroring `collectImports`.
+function coldImports(
+	imports: ImportRef[],
+	languageId: string,
+	absPath: string,
+	projectRoot: string,
+): { external: string[]; internal: string[] } {
+	const external = new Set<string>();
+	const internal = new Set<string>();
+	for (const imp of imports) {
+		const files = resolveImportToFiles(
+			projectRoot,
+			absPath,
+			languageId,
+			imp.source,
+		);
+		if (files.length > 0) {
+			for (const f of files) internal.add(toDisplayPath(f, projectRoot));
+		} else if (looksInternal(imp.source)) {
+			internal.add(imp.source);
+		} else {
+			external.add(imp.source);
+		}
+	}
+	return {
+		external: [...external].sort((a, b) => a.localeCompare(b)),
+		internal: [...internal].sort((a, b) => a.localeCompare(b)),
+	};
+}
+
 function toEntry(
 	sym: ExtractedSymbol,
 	displayPath: string,
@@ -343,6 +411,46 @@ function toEntry(
 		usedBy: usedBy && usedBy.length > 0 ? usedBy : undefined,
 		read: readArgsFor(displayPath, startLine, endLine),
 	};
+}
+
+// Nest members under their container by line-range containment (#301), mirroring
+// ast-grep's outline: a class/interface's methods sit in its `members[]`, not at
+// the top level. Each entry attaches to its NEAREST (smallest) strictly-enclosing
+// entry, so arbitrary depth (a method in an inner class in an outer class) nests
+// correctly. Mutates the entries (sets `members`) and returns the TOP-LEVEL ones
+// (no container) for the api/internal split. The flat list stays usable for
+// ranking so hot nested methods still surface in recommendedReads.
+function nestEntries(entries: ModuleSymbolEntry[]): ModuleSymbolEntry[] {
+	const span = (e: ModuleSymbolEntry) => e.endLine - e.startLine;
+	const containerOf = new Map<
+		ModuleSymbolEntry,
+		ModuleSymbolEntry | undefined
+	>();
+	for (const e of entries) {
+		let best: ModuleSymbolEntry | undefined;
+		for (const c of entries) {
+			if (c === e) continue;
+			// Strict containment: c wraps e AND is strictly larger, so equal-range
+			// pairs (a mis-extracted class+ctor on the same lines) never mutually nest.
+			const contains =
+				c.startLine <= e.startLine &&
+				c.endLine >= e.endLine &&
+				span(c) > span(e);
+			if (!contains) continue;
+			if (!best || span(c) < span(best)) best = c;
+		}
+		containerOf.set(e, best);
+	}
+	for (const e of entries) {
+		const parent = containerOf.get(e);
+		if (!parent) continue;
+		if (!parent.members) parent.members = [];
+		parent.members.push(e);
+	}
+	for (const e of entries) {
+		if (e.members) e.members.sort((a, b) => a.startLine - b.startLine);
+	}
+	return entries.filter((e) => !containerOf.get(e));
 }
 
 function rankRecommendedReads(
@@ -419,9 +527,9 @@ export async function moduleReport(
 	const languageId = tsLangForFile(absPath, kind);
 	const lineCount = content.split(/\r?\n/).length;
 
-	const extracted = languageId
-		? await extractFileSymbols(absPath, languageId, content)
-		: [];
+	const { symbols: extracted, imports: extractedImports } = languageId
+		? await extractFile(absPath, languageId, content)
+		: { symbols: [], imports: [] };
 
 	// READ-ONLY: consume the already-built review graph, never build one here. A
 	// synchronous full build re-runs every fact provider (TS-compiler ASTs for
@@ -439,15 +547,27 @@ export async function moduleReport(
 	// module structure (#259). Presentation-only: the review graph keeps them.
 	const outlineSymbols = extracted.filter((sym) => !sym.local);
 
+	// Flat entries first — ranking and cold-import resolution both read the full
+	// list. `entries` is mutated by nestEntries (members attached); `topLevel` is
+	// the api/internal split surface.
 	const entries = outlineSymbols.map((sym) =>
 		toEntry(sym, absPath, normalizedPath, graph, maxRefs, cwd),
 	);
+	const topLevel = nestEntries(entries);
 
-	const api = entries.filter((entry) => entry.exported);
-	const internal = entries.filter((entry) => !entry.exported);
-	const imports = graph
+	const api = topLevel.filter((entry) => entry.exported);
+	const internal = topLevel.filter((entry) => !entry.exported);
+
+	// Imports: the warm review graph is source-of-truth; on a cold cache (or a
+	// graph without this file's node) fall back to the language-uniform tree-sitter
+	// resolution (#301) so a cold report no longer shows zero imports.
+	const warmImports = graph
 		? collectImports(graph, normalizedPath, cwd)
 		: { external: [], internal: [] };
+	const imports =
+		warmImports.external.length + warmImports.internal.length > 0 || !languageId
+			? warmImports
+			: coldImports(extractedImports, languageId, absPath, cwd);
 
 	const hasGraphNode = graph?.fileNodes.has(normalizedPath) ?? false;
 
@@ -534,7 +654,7 @@ export async function readSymbol(
 		return { found: false, path: absPath, name: symbolName };
 	}
 
-	const symbols = await extractFileSymbols(absPath, languageId, content);
+	const { symbols } = await extractFile(absPath, languageId, content);
 	const sym = symbols.find((candidate) => candidate.name === symbolName);
 	if (!sym) {
 		log(false);

--- a/clients/review-graph/import-resolvers.ts
+++ b/clients/review-graph/import-resolvers.ts
@@ -88,6 +88,33 @@ function resolveDart(cwd: string, filePath: string, source: string): string[] {
 	return resolveRelative(cwd, filePath, source, [".dart"]);
 }
 
+// --- JS/TS -------------------------------------------------------------------
+
+/**
+ * Resolve a relative ESM import (`./x`, `../y`) to an in-project file, trying the
+ * ts/tsx/js/jsx extensions and the `index.*` directory form. Mirrors the warm
+ * graph's `localImportToFile` (builder.ts) — duplicated rather than imported to
+ * avoid a builder→resolvers cycle. Bare specifiers (`react`, `@scope/pkg`) are
+ * package deps → external, so they return []. Used only on the COLD module_report
+ * path: the warm jsts builder resolves imports via the TS compiler and never
+ * reaches this resolver.
+ */
+function resolveJsTs(cwd: string, filePath: string, source: string): string[] {
+	if (!source.startsWith(".")) return [];
+	const base = path.resolve(path.dirname(filePath), source);
+	return firstExistingFile(cwd, [
+		base,
+		`${base}.ts`,
+		`${base}.tsx`,
+		`${base}.js`,
+		`${base}.jsx`,
+		path.join(base, "index.ts"),
+		path.join(base, "index.tsx"),
+		path.join(base, "index.js"),
+		path.join(base, "index.jsx"),
+	]);
+}
+
 // --- Python -----------------------------------------------------------------
 
 /** Candidate source roots for an absolute dotted import. */
@@ -106,7 +133,11 @@ function pythonRoots(cwd: string, fileDir: string): string[] {
 	return [...roots].filter((r) => isDir(r));
 }
 
-function resolvePython(cwd: string, filePath: string, source: string): string[] {
+function resolvePython(
+	cwd: string,
+	filePath: string,
+	source: string,
+): string[] {
 	const fileDir = path.dirname(path.resolve(filePath));
 	if (source.startsWith(".")) {
 		// Relative import: leading dots = how far up, remainder = dotted subpath.
@@ -199,7 +230,9 @@ function resolveJava(cwd: string, filePath: string, source: string): string[] {
 	const parts = source.split(".");
 	for (const root of javaSourceRoots(cwd, filePath)) {
 		// import a.b.Foo  → a/b/Foo.java
-		const asFile = firstExistingFile(cwd, [`${path.join(root, ...parts)}.java`]);
+		const asFile = firstExistingFile(cwd, [
+			`${path.join(root, ...parts)}.java`,
+		]);
 		if (asFile.length) return asFile;
 		// import a.b.*  (captured as a.b) → every .java in the package dir
 		const asPkg = sourceFilesIn(cwd, path.join(root, ...parts), ".java");
@@ -227,6 +260,11 @@ export function resolveImportToFiles(
 	source: string,
 ): string[] {
 	switch (languageId) {
+		case "typescript":
+		case "tsx":
+		case "javascript":
+		case "jsts":
+			return resolveJsTs(cwd, filePath, source);
 		case "ruby":
 			return resolveRelative(cwd, filePath, source, [".rb"]);
 		case "zig":

--- a/clients/tree-sitter-symbol-extractor.ts
+++ b/clients/tree-sitter-symbol-extractor.ts
@@ -460,8 +460,11 @@ SYMBOL_QUERIES.tsx = SYMBOL_QUERIES.typescript;
 // Per-language import-source extraction (#249). Optional and independent of
 // SYMBOL_QUERIES: a language without an entry simply yields no imports (its
 // symbols still extract). Each query captures the import source text as
-// @importSource. jsts/cxx are intentionally absent — their imports are extracted
-// by the review-graph builder's dedicated paths (importFactProvider / #include).
+// @importSource. cxx is intentionally absent — its #include edges are extracted
+// by the review-graph builder's dedicated path. typescript/tsx ARE present (#301)
+// so the COLD module_report path (which runs this extractor directly) sees TS/JS
+// imports; the WARM review graph still sources jsts imports from the TS compiler
+// (importFactProvider) and never reaches this query, so there's no double-count.
 //
 // Call/builtin-based languages (ruby/zig/elixir/bash) express imports as
 // ordinary function/macro calls, so their queries use a `#match?` predicate to
@@ -474,6 +477,18 @@ SYMBOL_QUERIES.tsx = SYMBOL_QUERIES.typescript;
 // lua import query work in the real review-graph client. The validated lua query
 // is recorded on #255 and lands once the parse corruption is fixed.
 const IMPORT_QUERIES: Record<string, string> = {
+	// ESM import + re-export source strings; `source:` is a (string) on both the
+	// typescript and tsx grammars (validated). parseImportMatch strips the quotes.
+	// CJS `require(...)` is intentionally out of scope — the cold path's dominant
+	// case is ESM, and the warm graph already covers require via the TS compiler.
+	typescript: `
+      (import_statement source: (string) @importSource)
+      (export_statement source: (string) @importSource)
+    `,
+	tsx: `
+      (import_statement source: (string) @importSource)
+      (export_statement source: (string) @importSource)
+    `,
 	python: `
       (import_statement name: (dotted_name) @importSource)
       (import_statement name: (aliased_import name: (dotted_name) @importSource))
@@ -573,8 +588,18 @@ export class TreeSitterSymbolExtractor {
 			// and vice versa; the extractor degrades partially, not to nothing.
 			const queries = SYMBOL_QUERIES[this.languageId];
 			if (queries) {
-				this.defQuery = this.compileQuery(Query, language, queries.defs, "defs");
-				this.refQuery = this.compileQuery(Query, language, queries.refs, "refs");
+				this.defQuery = this.compileQuery(
+					Query,
+					language,
+					queries.defs,
+					"defs",
+				);
+				this.refQuery = this.compileQuery(
+					Query,
+					language,
+					queries.refs,
+					"refs",
+				);
 			}
 			const importQuerySrc = IMPORT_QUERIES[this.languageId];
 			if (importQuerySrc) {

--- a/tests/clients/module-report.test.ts
+++ b/tests/clients/module-report.test.ts
@@ -74,9 +74,13 @@ describe("moduleReport — outline + structure", () => {
 		const file = createTempFile(
 			env.tmpDir,
 			"sample.py",
-			["def greet(name):", "    return f'hi {name}'", "", "class Greeter:", "    pass"].join(
-				"\n",
-			),
+			[
+				"def greet(name):",
+				"    return f'hi {name}'",
+				"",
+				"class Greeter:",
+				"    pass",
+			].join("\n"),
 		);
 
 		const report = await moduleReport(file, env.tmpDir);
@@ -264,6 +268,103 @@ describe("moduleReport — review-graph who-uses-this", () => {
 	});
 });
 
+describe("moduleReport — cold-cache imports (#301)", () => {
+	it("TS: resolves a relative import to an in-project file and buckets externals", async () => {
+		const env = makeEnv();
+		createTempFile(env.tmpDir, "dep.ts", "export const x = 1;\n");
+		const file = createTempFile(
+			env.tmpDir,
+			"main.ts",
+			[
+				'import { x } from "./dep";',
+				'import { readFileSync } from "node:fs";',
+				'import express from "express";',
+				"export const y = x;",
+			].join("\n"),
+		);
+		// Cold cache: no warmGraph(). Imports must still populate from tree-sitter
+		// (previously zero), resolving the relative import to the real file.
+		const report = await moduleReport(file, env.tmpDir);
+		expect(report.semantic.source).toBe("none"); // proves cold path
+		expect(report.imports.internal).toContain("dep.ts");
+		// Bare specifiers stay external.
+		expect(report.imports.external).toContain("express");
+		expect(report.imports.external).toContain("node:fs");
+		expect(report.summary.imports).toBe(
+			report.imports.internal.length + report.imports.external.length,
+		);
+	});
+
+	it("TS: an unresolvable relative import falls back to the internal bucket by shape", async () => {
+		const env = makeEnv();
+		const file = createTempFile(
+			env.tmpDir,
+			"a.ts",
+			'import { foo } from "./not-created";\nexport const r = 1;\n',
+		);
+		const report = await moduleReport(file, env.tmpDir);
+		// No file on disk to resolve to, but "./" shape ⇒ internal, never external.
+		expect(report.imports.internal).toContain("./not-created");
+		expect(report.imports.external).toHaveLength(0);
+	});
+
+	it("Python: resolves a dotted intra-package import on a cold cache", async () => {
+		const env = makeEnv();
+		createTempFile(env.tmpDir, "pkg/__init__.py", "");
+		createTempFile(env.tmpDir, "pkg/util.py", "def helper():\n    return 1\n");
+		const file = createTempFile(
+			env.tmpDir,
+			"pkg/main.py",
+			["from pkg.util import helper", "import os", "", "helper()"].join("\n"),
+		);
+		const report = await moduleReport(file, env.tmpDir);
+		expect(report.language).toBe("python");
+		expect(report.imports.internal.some((p) => p.endsWith("util.py"))).toBe(
+			true,
+		);
+		expect(report.imports.external).toContain("os");
+	});
+
+	it("warm graph wins: cold extraction does not override a populated graph", async () => {
+		const env = makeEnv();
+		createTempFile(env.tmpDir, "dep.ts", "export const x = 1;\n");
+		const file = createTempFile(
+			env.tmpDir,
+			"main.ts",
+			'import { x } from "./dep";\nexport const y = x;\n',
+		);
+		await warmGraph(env.tmpDir);
+		const report = await moduleReport(file, env.tmpDir);
+		expect(report.semantic.source).toBe("review-graph"); // warm
+		expect(report.imports.internal).toContain("dep.ts");
+	});
+});
+
+describe("moduleReport — member nesting (#301)", () => {
+	it("ranks a hot nested method into recommendedReads via the flat list", async () => {
+		const env = makeEnv();
+		const file = createTempFile(
+			env.tmpDir,
+			"svc.ts",
+			[
+				"export class Svc {",
+				"  hot(): number { return 1; }",
+				"}",
+				"export function caller(): number { return new Svc().hot(); }",
+			].join("\n"),
+		);
+		await warmGraph(env.tmpDir); // so who-uses-this scores the nested method
+		const report = await moduleReport(file, env.tmpDir);
+		// Svc is top-level with hot nested under it.
+		const svc = report.api.find((e) => e.name === "Svc");
+		expect((svc?.members ?? []).some((e) => e.name === "hot")).toBe(true);
+		// recommendedReads ranks over the FLAT list, so a referenced nested method
+		// can still surface as a recommended read.
+		const reads = report.recommendedReads.map((r) => r.symbol);
+		expect(reads).toContain("hot");
+	});
+});
+
 describe("moduleReport — member visibility (#258) + compact outline (#259)", () => {
 	it("routes private/protected members of an exported class to internal with a visibility tag (#258)", async () => {
 		const env = makeEnv();
@@ -280,22 +381,27 @@ describe("moduleReport — member visibility (#258) + compact outline (#259)", (
 		);
 		const report = await moduleReport(file, env.tmpDir);
 
-		// Public member stays in the api surface.
-		expect(report.api.some((e) => e.name === "run")).toBe(true);
-		// Private/protected members are reachable but not public API → internal.
-		expect(report.api.some((e) => e.name === "secret")).toBe(false);
-		expect(report.api.some((e) => e.name === "guarded")).toBe(false);
+		// The exported class is the top-level api entry; its members nest under it
+		// (#301) rather than appearing flat at top level.
+		const svc = report.api.find((e) => e.name === "Service");
+		expect(svc).toBeDefined();
+		expect(report.api.some((e) => e.name === "run")).toBe(false);
+		const members = svc?.members ?? [];
+		const run = members.find((e) => e.name === "run");
+		const secret = members.find((e) => e.name === "secret");
+		const guarded = members.find((e) => e.name === "guarded");
 
-		const secret = report.internal.find((e) => e.name === "secret");
-		const guarded = report.internal.find((e) => e.name === "guarded");
+		// Public member: exported, no visibility tag.
+		expect(run?.exported).toBe(true);
+		expect(run?.visibility).toBeUndefined();
+		// Private/protected members are reachable but not public API → tagged,
+		// not exported, even though they nest under an exported class.
 		expect(secret?.visibility).toBe("private");
 		expect(guarded?.visibility).toBe("protected");
-		// Not counted as exported for the flag / summary / ranking.
 		expect(secret?.exported).toBe(false);
 		expect(secret?.flags ?? []).not.toContain("exported");
+		// summary.exports counts the top-level api split only.
 		expect(report.summary.exports).toBe(report.api.length);
-		// Public member carries no visibility field.
-		expect(report.api.find((e) => e.name === "run")?.visibility).toBeUndefined();
 	});
 
 	it("keeps class members + module-level symbols while dropping function-locals (#259)", async () => {
@@ -314,11 +420,20 @@ describe("moduleReport — member visibility (#258) + compact outline (#259)", (
 			].join("\n"),
 		);
 		const report = await moduleReport(file, env.tmpDir);
-		const all = [...report.api, ...report.internal].map((e) => e.name);
-		expect(all).toContain("Svc"); // exported class
-		expect(all).toContain("method"); // class member kept
-		expect(all).toContain("top"); // module-level kept
-		expect(all).not.toContain("tmp"); // function-local dropped
+		const topLevel = [...report.api, ...report.internal].map((e) => e.name);
+		expect(topLevel).toContain("Svc"); // exported class — top level
+		expect(topLevel).toContain("top"); // module-level fn — top level
+		expect(topLevel).not.toContain("method"); // class member → nested, not top
+		expect(topLevel).not.toContain("tmp"); // function-local dropped entirely
+
+		// The member lives under its container (#301), and the function-local stays
+		// dropped at every level.
+		const svc = [...report.api, ...report.internal].find(
+			(e) => e.name === "Svc",
+		);
+		const memberNames = (svc?.members ?? []).map((e) => e.name);
+		expect(memberNames).toContain("method");
+		expect(memberNames).not.toContain("tmp");
 	});
 });
 

--- a/tests/clients/tree-sitter-imports.test.ts
+++ b/tests/clients/tree-sitter-imports.test.ts
@@ -25,6 +25,19 @@ interface ImportCase {
 }
 
 const CASES: Record<string, ImportCase> = {
+	// TS/JS imports go through the TS compiler in the WARM review graph; these
+	// IMPORT_QUERIES entries (#301) feed the COLD module_report path. ESM import +
+	// re-export sources extract; CJS require is intentionally out of scope.
+	typescript: {
+		file: "a.ts",
+		src: 'import { a } from "./local";\nimport express from "express";\nexport { b } from "./reexport";\n',
+		expect: ["./local", "express", "./reexport"],
+	},
+	tsx: {
+		file: "a.tsx",
+		src: 'import { a } from "./local";\nimport React from "react";\n',
+		expect: ["./local", "react"],
+	},
 	python: {
 		file: "a.py",
 		src: "import os\nfrom os.path import join\n",
@@ -51,7 +64,11 @@ const CASES: Record<string, ImportCase> = {
 		src: "using System;\nusing System.Collections.Generic;\n",
 		expect: ["System", "System.Collections.Generic"],
 	},
-	swift: { file: "A.swift", src: "import Foundation\n", expect: ["Foundation"] },
+	swift: {
+		file: "A.swift",
+		src: "import Foundation\n",
+		expect: ["Foundation"],
+	},
 	php: { file: "a.php", src: "<?php\nuse App;\n", expect: ["App"] },
 	ocaml: { file: "a.ml", src: "open Core\n", expect: ["Core"] },
 	dart: { file: "a.dart", src: 'import "dart:io";\n', expect: ["dart:io"] },


### PR DESCRIPTION
Closes #301.

Two parity gaps in `module_report`, surfaced against ast-grep's outline.

## 1. Cold-cache imports (language-uniform)
`module_report` sourced imports only from the warm review graph (`collectImports`), so a **cold cache showed zero imports** even though the tree-sitter extractor already parsed them. Now the `{external, internal}` shape is rebuilt language-uniformly from those sources:
- Resolve each to in-project files via the warm graph's own resolver (`resolveImportToFiles`) when the language supports it, else fall back to a shape heuristic (leading `.` or Rust `crate::`/`super::`/`self::` → internal; bare/scoped specifier → external).
- Warm graph still wins when populated; cold extraction only fills the gap.
- Added `typescript`/`tsx` to `IMPORT_QUERIES` (validated against the shipped grammars) so the dominant language's ESM import + re-export sources extract on the cold path. **No double-count:** the warm jsts builder sources imports from the TS compiler and never reaches this query (jsts returns before the tree-sitter path in the builder).
- Added `typescript`/`tsx`/`javascript`/`jsts` cases to `resolveImportToFiles`, reusing a `localImportToFile`-equivalent. **Unreachable from the warm builder** (jsts is handled by `addJsTsFile` and returns early), so warm behavior is provably unchanged.

## 2. Member nesting
Class/interface members now nest under their container by line-range containment (`members[]`), mirroring ast-grep's outline. Each entry attaches to its nearest strictly-enclosing entry, so arbitrary depth nests correctly. The `api`/`internal` split is over **top-level entries only**; members keep full entries (read-args, visibility, who-uses-this). `recommendedReads` still ranks over the flat list, so a hot nested method can still surface.

## Tests
- `tests/clients/module-report.test.ts`: #258/#259 updated to the nested model; new cold-import cases (TS resolve-to-file, unresolvable-shape fallback, Python dotted intra-package, warm-wins); a nested-method ranking case.
- `tests/clients/tree-sitter-imports.test.ts`: `typescript` + `tsx` cases.
- `AGENTS.md` updated for the nested model + cold imports.

Full suite green (2419 passed, 1 skipped); `tsc` lint clean. Touched files were also biome-formatted (the repo has no biome config/CI gate; scoped to this diff only, not a repo-wide reformat).

Follow-ons (separate issues): #302 (cxx `#include` cold imports), #304 (blast-radius section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)