### PR TITLE
feat(module-report): cold-cache imports for cxx (C/C++ #include) (#302)

### DIFF
--- a/clients/module-report.ts
+++ b/clients/module-report.ts
@@ -301,7 +301,14 @@ function collectImports(
 // (bare specifiers, absolute package paths) is treated as external. This is the
 // floor under `resolveImportToFiles` — it never fabricates a file path, only a
 // best-effort internal/external bucket.
-function looksInternal(source: string): boolean {
+function looksInternal(source: string, languageId: string): boolean {
+	// C/C++ (#302): a #include is local-vs-system by syntax, not by a leading dot.
+	// A system header keeps its angle brackets (<stdio.h>) → external; a quoted
+	// local include arrives bare (foo.h, quotes already stripped) → internal, even
+	// when the header file isn't on disk.
+	if (languageId === "c" || languageId === "cpp") {
+		return !source.startsWith("<");
+	}
 	// A leading "." is relative across every language we extract (JS ./ ../,
 	// Python . .foo ..pkg, Ruby/Dart/bash relative paths) and never begins a bare
 	// or scoped package specifier (react, @scope/pkg, java.util.List, fmt). Rust's
@@ -339,7 +346,7 @@ function coldImports(
 		);
 		if (files.length > 0) {
 			for (const f of files) internal.add(toDisplayPath(f, projectRoot));
-		} else if (looksInternal(imp.source)) {
+		} else if (looksInternal(imp.source, languageId)) {
 			internal.add(imp.source);
 		} else {
 			external.add(imp.source);

--- a/clients/review-graph/import-resolvers.ts
+++ b/clients/review-graph/import-resolvers.ts
@@ -115,6 +115,27 @@ function resolveJsTs(cwd: string, filePath: string, source: string): string[] {
 	]);
 }
 
+// --- C / C++ -----------------------------------------------------------------
+
+/**
+ * Resolve a C/C++ `#include` to an in-project header (#302). A system header
+ * (`<stdio.h>`, captured with its angle brackets) is a toolchain/library dep →
+ * external, so it returns []. A quoted local include (`#include "foo.h"` →
+ * `foo.h` after quote-strip) resolves against the same candidate roots the warm
+ * graph's `resolveCxxInclude` uses (the including file's dir, then cwd / include /
+ * src), so cold and warm agree on which file a local include points to.
+ */
+function resolveCxx(cwd: string, filePath: string, source: string): string[] {
+	if (source.startsWith("<")) return [];
+	const dir = path.dirname(path.resolve(filePath));
+	return firstExistingFile(cwd, [
+		path.resolve(dir, source),
+		path.resolve(cwd, source),
+		path.resolve(cwd, "include", source),
+		path.resolve(cwd, "src", source),
+	]);
+}
+
 // --- Python -----------------------------------------------------------------
 
 /** Candidate source roots for an absolute dotted import. */
@@ -265,6 +286,9 @@ export function resolveImportToFiles(
 		case "javascript":
 		case "jsts":
 			return resolveJsTs(cwd, filePath, source);
+		case "c":
+		case "cpp":
+			return resolveCxx(cwd, filePath, source);
 		case "ruby":
 			return resolveRelative(cwd, filePath, source, [".rb"]);
 		case "zig":

--- a/clients/tree-sitter-symbol-extractor.ts
+++ b/clients/tree-sitter-symbol-extractor.ts
@@ -460,11 +460,11 @@ SYMBOL_QUERIES.tsx = SYMBOL_QUERIES.typescript;
 // Per-language import-source extraction (#249). Optional and independent of
 // SYMBOL_QUERIES: a language without an entry simply yields no imports (its
 // symbols still extract). Each query captures the import source text as
-// @importSource. cxx is intentionally absent — its #include edges are extracted
-// by the review-graph builder's dedicated path. typescript/tsx ARE present (#301)
-// so the COLD module_report path (which runs this extractor directly) sees TS/JS
-// imports; the WARM review graph still sources jsts imports from the TS compiler
-// (importFactProvider) and never reaches this query, so there's no double-count.
+// @importSource. typescript/tsx (#301) and c/cpp (#302) ARE present so the COLD
+// module_report path (which runs this extractor directly) sees their imports; the
+// WARM review graph still sources jsts imports from the TS compiler
+// (importFactProvider) and cxx #include edges from its own line-regex path, and
+// neither reaches this query, so there's no double-count.
 //
 // Call/builtin-based languages (ruby/zig/elixir/bash) express imports as
 // ordinary function/macro calls, so their queries use a `#match?` predicate to
@@ -488,6 +488,18 @@ const IMPORT_QUERIES: Record<string, string> = {
 	tsx: `
       (import_statement source: (string) @importSource)
       (export_statement source: (string) @importSource)
+    `,
+	// #include "foo.h" (string_literal) and #include <stdio.h> (system_lib_string)
+	// on both the c and cpp grammars (validated). parseImportMatch strips the quotes
+	// from the local form; the system form keeps its <> so the resolver/bucketer can
+	// tell a system header from a local include.
+	c: `
+      (preproc_include path: (string_literal) @importSource)
+      (preproc_include path: (system_lib_string) @importSource)
+    `,
+	cpp: `
+      (preproc_include path: (string_literal) @importSource)
+      (preproc_include path: (system_lib_string) @importSource)
     `,
 	python: `
       (import_statement name: (dotted_name) @importSource)

--- a/tests/clients/module-report.test.ts
+++ b/tests/clients/module-report.test.ts
@@ -325,6 +325,30 @@ describe("moduleReport — cold-cache imports (#301)", () => {
 		expect(report.imports.external).toContain("os");
 	});
 
+	it("C/C++: resolves a local #include, buckets a system header external (#302)", async () => {
+		const env = makeEnv();
+		createTempFile(env.tmpDir, "foo.h", "int foo(void);\n");
+		const file = createTempFile(
+			env.tmpDir,
+			"main.c",
+			[
+				'#include "foo.h"',
+				"#include <stdio.h>",
+				'#include "missing.h"',
+				"int main(void) { return foo(); }",
+			].join("\n"),
+		);
+		const report = await moduleReport(file, env.tmpDir);
+		expect(report.language).toBe("cxx");
+		expect(report.semantic.source).toBe("none"); // cold path
+		// Local include resolves to the real header.
+		expect(report.imports.internal).toContain("foo.h");
+		// An unresolved local include stays internal by C convention (quoted form).
+		expect(report.imports.internal).toContain("missing.h");
+		// System header keeps its <> and is external.
+		expect(report.imports.external).toContain("<stdio.h>");
+	});
+
 	it("warm graph wins: cold extraction does not override a populated graph", async () => {
 		const env = makeEnv();
 		createTempFile(env.tmpDir, "dep.ts", "export const x = 1;\n");

--- a/tests/clients/tree-sitter-imports.test.ts
+++ b/tests/clients/tree-sitter-imports.test.ts
@@ -38,6 +38,18 @@ const CASES: Record<string, ImportCase> = {
 		src: 'import { a } from "./local";\nimport React from "react";\n',
 		expect: ["./local", "react"],
 	},
+	// C/C++ #include (#302) — local "foo.h" (quotes stripped) + system <stdio.h>
+	// (angle brackets kept so the bucketer can tell local from system).
+	c: {
+		file: "a.c",
+		src: '#include "foo.h"\n#include <stdio.h>\nint main(void) { return 0; }\n',
+		expect: ["foo.h", "<stdio.h>"],
+	},
+	cpp: {
+		file: "a.cpp",
+		src: '#include "bar.hpp"\n#include <vector>\nint main() { return 0; }\n',
+		expect: ["bar.hpp", "<vector>"],
+	},
 	python: {
 		file: "a.py",
 		src: "import os\nfrom os.path import join\n",


### PR DESCRIPTION
Closes #302. **Stacked on #320 (#301)** — base is the #301 branch so the diff is just the cxx delta; retarget to `master` once #320 merges.

Follow-up to #301. #301's cold-import path covered every WASM language with an `IMPORT_QUERIES` entry, but **cxx was still empty on a cold cache**: C/C++ `#include` never went through `IMPORT_QUERIES` (the warm graph extracts includes via its own line-regex path, `addCxxIncludeEdges`), and `resolveImportToFiles` had no `c`/`cpp` case. So a cold `module_report` on a `.c`/`.cpp`/`.h` file showed zero imports.

## Changes
- **`IMPORT_QUERIES`**: added `c`/`cpp` for `preproc_include` — `path:(string_literal)` for `#include "foo.h"` and `path:(system_lib_string)` for `#include <stdio.h>` (validated against the shipped grammars). The local form's quotes are stripped; the system form keeps its `<>` so the resolver/bucketer can tell them apart.
- **`resolveImportToFiles`** (`resolveCxx`): a system header (`<...>`) is external (returns `[]`); a quoted local include resolves against the same candidate roots the warm graph's `resolveCxxInclude` uses (the including file's dir, then `cwd` / `include` / `src`), so cold and warm agree on the target file.
- **`looksInternal`** is now cxx-aware: a `#include` is local-vs-system by syntax, so a system header buckets external while an unresolved quoted local include stays internal by C convention.

## Deliberate divergence (documented)
The warm graph omits system headers entirely (`addCxxIncludeEdges` only edges local includes), so a cold cxx report's `imports.external` (system headers) is **richer** than the warm one's. This is benign — the opposite of the #301 zero-imports bug — and informative for a read substitute. Local-include resolution matches warm exactly.

## Tests
- `tree-sitter-imports.test.ts`: `c` + `cpp` cases.
- `module-report.test.ts`: a cold cxx case (local resolves, unresolved local stays internal, system header external).

Full suite green (2422 passed, 1 skipped); `tsc` lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)