### PR TITLE
feat(module-report): cross-file blast-radius section; remove pilens_impact (#304)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ A pi coding-agent extension that runs automated checks on every file write/edit.
 ```
 index.ts                  Extension entry point (async factory) — the pi host adapter
 mcp/                      Second host adapter: MCP server + hook bin (see "MCP mirror")
-  server.ts               Hand-rolled stdio JSON-RPC MCP server (16 tools) + warm IPC listener
+  server.ts               Hand-rolled stdio JSON-RPC MCP server (15 tools) + warm IPC listener
   worker.ts               fresh-mode child (loads freshly-built code from disk)
   analyze-cli.ts          pi-lens-analyze bin — PostToolUse hook + CLI (warm channel → cold fallback)
 clients/
@@ -24,7 +24,7 @@ clients/
   project-changes.ts      Append-only project/file sequence change log
   reverse-deps.ts         Snapshot-backed reverse dependency index/query helpers
   word-index.ts           Identifier inverted index + BM25 ranking (#162) — built in the session scan, persisted in the snapshot; consumed ONLY by the pilens_symbol_search MCP tool (not yet by pi-lens internals)
-  review-graph/query.ts   Graph queries incl computeImpactCascade (one-hop, used by the cascade) + computeTransitiveImpact (depth-bounded BFS, used ONLY by pilens_impact)
+  review-graph/query.ts   Graph queries incl computeImpactCascade (one-hop, used by the cascade) + computeTransitiveImpact (depth-bounded BFS, used by module_report's blastRadius section #304 + the symbolImpact engine seam)
   installer/index.ts      Auto-install + ensureTool; probe-cache.json for fast restarts. Strategies: npm/pip/gem/github + maven (fat JAR → java -jar launcher) + archive (tree). github API is token-authed (api.github.com only, Authorization dropped on cross-host redirect — unauth=60/hr silently fails CI installs); tar extract is recursive-find (handles FLAT tarballs like gleam, not --strip-components). GITHUB_TOOLS kept in sync with the registry by tool-registry-consistency.test.ts
   lsp/                    38 LSP server IDs (incl. opengrep + ast-grep + zizmor, cross-cutting AUXILIARY diagnostic LSPs — role:"auxiliary", #111/#239/#272), config, lifecycle. clojure-lsp + gleam now auto-install via github (native binary / flat tarball). zizmor (GitHub Actions security, `zizmor --lsp`) attaches to YAML; advisory unless the repo ships zizmor.yml; online audits need a token (env or `gh auth token`) via clients/zizmor-config.ts
   dispatch/               Pipeline dispatcher + 47 registered runners (incl. spotbugs — flag-gated via withSpotbugsGroup, #133). Auxiliary LSPs (opengrep, ast-grep, zizmor, …) are NOT runners — they attach via the lsp runner's with-auxiliary path; see clients/dispatch/auxiliary-lsp.ts
@@ -51,15 +51,13 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   `npm install --omit=dev` does **not** omit `optionalDependencies` (only
   `--omit=optional` does, which pi doesn't pass), so even an "optional" SDK would
   weigh every pi-lens install. ~200 LOC beats a dep for a tools-only server.
-- **16 tools:** `pilens_analyze` (per-edit; `mode: warm|fresh`), `pilens_diagnostics`,
+- **15 tools:** `pilens_analyze` (per-edit; `mode: warm|fresh`), `pilens_diagnostics`,
   `pilens_project_scan`, `pilens_latency`, `pilens_health`, `pilens_rebuild`,
   `pilens_session_start` / `pilens_turn_end` (drive the REAL lifecycle handlers —
   not re-implementations — via `clients/mcp/session.ts`), `pilens_ast_grep_search`
   / `pilens_ast_grep_replace`, `pilens_lsp_navigation` / `pilens_lsp_diagnostics`,
   `pilens_symbol_search` (ranked identifier search over the persisted word index —
-  BM25 + priors + reverse-dep centrality), `pilens_impact` (transitive review-graph
-  dependents — blast radius), `pilens_module_report` (navigable outline + signatures
-  + who-uses-this + ready-to-use `read` args — a token-efficient read substitute;
+  BM25 + priors + reverse-dep centrality), `pilens_module_report` (navigable outline + signatures
   the outline is module-level declarations + class members only — function-locals
   are dropped (#259). Class/interface members nest under their container by
   line-range containment (`members[]`, #301); the `api`/`internal` split is over
@@ -67,7 +65,10 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   `visibility` field inside its container's members, not promoted to the public
   `api` (#258). `imports` populate language-uniformly even on a cold cache —
   resolved to in-project files via the warm graph's resolver, else bucketed
-  internal/external by shape (#301)) /
+  internal/external by shape (#301). Pass `blastRadius: true` for the cross-file
+  **blast radius** (#304): transitive dependents aggregated to ranked file `read`
+  args — read-only over the *cached* graph (omitted when cold), the single
+  successor to the removed `pilens_impact` tool) /
   `pilens_read_symbol` (one symbol's verbatim body). Wrapped pi tools emit their
   typebox `parameters` as the MCP `inputSchema` (via `schemaWithCwd`) — no
   hand-restated schema to drift.
@@ -79,16 +80,16 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   genuine edit-coverage for that symbol's range (a `module_report` outline is NOT —
   shape, not body).
 - **MCP-only vs pi-lens-internal (a real gap to close, not a finished story).**
-  `pilens_symbol_search` and `pilens_impact` are currently **agent-facing queries
-  only**: the word index is built during pi-lens's own session scan (pi pays the
-  cost) but nothing in pi-lens consumes it, and `pilens_impact` uses *transitive*
-  BFS (`computeTransitiveImpact`) while the in-pi **cascade still derives neighbors
-  one-hop** (`computeImpactCascade` in `dispatch/integration.ts`). The higher-value
-  move is to feed the transitive impact (bounded depth/budget) into cascade neighbor
-  derivation — ideally paired with the #202 structural-hash short-circuit so the
-  expansion is *pruned* when a changed file's exported interface is unchanged. When
-  adding a capability via the engine, ask whether pi-lens itself should use it, not
-  just the mirror.
+  `pilens_symbol_search` is currently an **agent-facing query only**: the word index
+  is built during pi-lens's own session scan (pi pays the cost) but nothing in
+  pi-lens consumes it. Likewise `module_report`'s blast-radius (#304) and the
+  `symbolImpact` engine seam use *transitive* BFS (`computeTransitiveImpact`) while
+  the in-pi **cascade still derives neighbors one-hop** (`computeImpactCascade` in
+  `dispatch/integration.ts`). The higher-value move is to feed the transitive impact
+  (bounded depth/budget) into cascade neighbor derivation — ideally paired with the
+  #202 structural-hash short-circuit so the expansion is *pruned* when a changed
+  file's exported interface is unchanged. When adding a capability via the engine,
+  ask whether pi-lens itself should use it, not just the mirror.
 - **warm vs fresh review loop.** The server is long-lived (warm LSP, cached code);
   `fresh` forks a worker that loads freshly-built code from disk → reflects the
   latest commit. `pilens_rebuild` closes it: commit → rebuild → `mode=fresh`.

--- a/README.md
+++ b/README.md
@@ -140,13 +140,17 @@ instead of a flat blob of source. See
 [`docs/module-report-read-symbol.md`](docs/module-report-read-symbol.md)
 for the full design and token-efficiency numbers.
 
-**`module_report(filePath, maxRefsPerSymbol?)`** — returns a structured
-outline: every symbol's name/kind/startLine/endLine/signature, exported vs
-internal split, who-uses-this (`usedBy`), fanout/complexity risk flags,
-and a `recommendedReads` top-3 ranked by usage + complexity. Each symbol
-entry includes a ready-to-use `read` argument (`{path, offset, limit}`)
-so the agent's next call sits right there. Tree-sitter extract + cached
-review-graph lookup; never builds the graph, never calls LSP on this path.
+**`module_report(filePath, maxRefsPerSymbol?, blastRadius?, blastRadiusDepth?)`** —
+returns a structured outline: every symbol's name/kind/startLine/endLine/signature,
+exported vs internal split (with class/interface members nested under their
+container), who-uses-this (`usedBy`), fanout/complexity risk flags, and a
+`recommendedReads` top-3 ranked by usage + complexity. Each symbol entry includes
+a ready-to-use `read` argument (`{path, offset, limit}`) so the agent's next call
+sits right there. Pass `blastRadius: true` to also get the cross-file **blast
+radius** — transitive dependents aggregated to ranked file `read` args ("if you
+change this, verify these files"); read-only over the cached graph, omitted when
+cold (this replaced the standalone `pilens_impact` tool). Tree-sitter extract +
+cached review-graph lookup; never builds the graph, never calls LSP on this path.
 `semantic.source` reports what backed the data (`review-graph` | `none`).
 
 **`read_symbol(filePath, symbol)`** — returns the verbatim body of one
@@ -291,7 +295,7 @@ pi-lens ships an MCP (Model Context Protocol) server so Claude Code — or any M
 | **Per-edit** | `pilens_analyze`, `pilens_lsp_diagnostics`, `pilens_lsp_navigation`, `pilens_ast_grep_search`, `pilens_ast_grep_replace`, `pilens_module_report`, `pilens_read_symbol` | The fast pipeline (format → autofix → LSP diagnostics → parallel runners) plus the structured read-substitute pair. `analyze` accepts `mode: warm \| fresh` — `warm` reuses the server's in-process LSP, `fresh` forks a worker that loads freshly-built code from disk so the result reflects the latest commit. |
 | **Per-turn** | `pilens_turn_end` | Drives the **real** `handleTurnEnd` (knip incremental, jscpd delta, dep-circular, cascade, tests, actionable+code-quality warnings) — not a re-implementation. Caller-supplied edited files are auto-registered into turn-state via `addModifiedRange`. |
 | **Per-session** | `pilens_session_start` | Drives the **real** `handleSessionStart` — full jscpd/knip/type-coverage/dep/govulncheck scans + complexity baselines + LSP warm + the **error-debt baseline** (tests/build pass-state) that powers green→red regression detection. |
-| **Project / observability** | `pilens_project_scan`, `pilens_diagnostics`, `pilens_health`, `pilens_latency`, `pilens_symbol_search`, `pilens_impact` | Cheap project-wide scans, cached diagnostic state, latency telemetry, ranked identifier search (BM25 over the persisted word index), transitive review-graph blast radius. |
+| **Project / observability** | `pilens_project_scan`, `pilens_diagnostics`, `pilens_health`, `pilens_latency`, `pilens_symbol_search` | Cheap project-wide scans, cached diagnostic state, latency telemetry, ranked identifier search (BM25 over the persisted word index). Cross-file blast radius now lives in `pilens_module_report`'s `blastRadius` option. |
 | **Lifecycle / loop** | `pilens_rebuild` | Runs `npm run build:dist` so `pilens_analyze mode=fresh` reflects the latest commit. Makes the review loop self-contained: commit → `pilens_rebuild` → `pilens_analyze mode=fresh` → `pilens_latency`. |
 
 **Honest limits** (live-tested, documented in `docs/mcp.md`):

--- a/clients/lens-engine.ts
+++ b/clients/lens-engine.ts
@@ -165,9 +165,11 @@ export interface SymbolImpactResult {
 
 /**
  * Transitive, depth-bounded impact of a file ("what depends on this") over the
- * review graph's call/reference/import edges (#162). Builds/loads the review
- * graph (3-tier cached, so cheap after the first build) and walks incoming
- * edges. Read-only.
+ * review graph's call/reference/import edges (#162). READ-ONLY (#260): consumes
+ * the already-cached review graph and walks incoming edges — never builds one
+ * (cold cache → available:false). The `module_report` blast-radius section (#304)
+ * is the agent-facing surface for this; this engine helper is kept as a reusable
+ * read-only seam.
  */
 export async function symbolImpact(
 	file: string,

--- a/clients/module-report.ts
+++ b/clients/module-report.ts
@@ -52,6 +52,13 @@ import {
 export interface ModuleReportOptions {
 	/** Cap on who-uses-this entries per symbol. */
 	maxRefsPerSymbol?: number;
+	/** Include the cross-file blast-radius section (#304): the transitive
+	 * dependents of this module, aggregated to ranked file `read` args. Read-only
+	 * over the CACHED graph — omitted entirely on a cold cache (never builds). */
+	blastRadius?: boolean;
+	/** Max hops for the blast-radius walk (default 3). Only meaningful with
+	 * `blastRadius`. */
+	blastRadiusDepth?: number;
 }
 
 export interface ModuleSymbolUsedBy {
@@ -99,6 +106,32 @@ export interface RecommendedRead {
 	limit: number;
 }
 
+/** One file in the blast radius (#304): a transitive dependent of this module,
+ * aggregated from its (possibly several) dependent symbols. */
+export interface BlastRadiusFile {
+	/** cwd-relative display path of the dependent file. */
+	file: string;
+	/** How many dependent symbols/edges in this file reach the module. */
+	dependents: number;
+	/** Closest hop at which this file depends on the module (1 = direct). */
+	minDepth: number;
+	/** Distinct edge kinds by which it depends (calls/references/imports). */
+	relations: ReviewGraphEdgeKind[];
+	/** Ready-to-use read args for the whole dependent file (verify the change). */
+	read: { path: string; offset: number; limit: number };
+}
+
+/** Cross-file blast radius (#304): "if you change this module, read/verify these
+ * files". Present only when requested AND the cached graph is warm. */
+export interface BlastRadius {
+	/** True when the impact walk hit its node cap (the list is a prefix). */
+	truncated: boolean;
+	/** Deepest hop reached (transitivity actually observed). */
+	maxDepth: number;
+	/** Dependent files, ranked closest-and-most-depended-on first. */
+	files: BlastRadiusFile[];
+}
+
 export interface ModuleReport {
 	/** False when the file is unreadable or has no symbols and no graph node. */
 	available: boolean;
@@ -111,6 +144,9 @@ export interface ModuleReport {
 	api: ModuleSymbolEntry[];
 	internal: ModuleSymbolEntry[];
 	recommendedReads: RecommendedRead[];
+	/** Cross-file blast radius (#304) — present only when requested via
+	 * `blastRadius` and the cached graph is warm; omitted otherwise. */
+	blastRadius?: BlastRadius;
 	semantic: {
 		/** Provenance of who-uses-this: AST review graph, future graph-LSP edges
 		 * (#236), or none (cold cache). */
@@ -492,6 +528,90 @@ function rankRecommendedReads(
 		});
 }
 
+// Cap the blast-radius list so a high-fanout module doesn't blow the token
+// budget; the ranking puts the closest/most-depended-on files first. The read
+// limit is the dependent file's own line count when the graph knows it, else a
+// modest default — these are "go verify" pointers, not full dumps.
+const BLAST_RADIUS_FILE_CAP = 12;
+const BLAST_RADIUS_DEFAULT_READ_LIMIT = 400;
+
+function blastReadArgs(
+	graph: ReviewGraph,
+	normalizedFile: string,
+): { path: string; offset: number; limit: number } {
+	const fileNodeId = graph.fileNodes.get(normalizedFile);
+	const lineCount = fileNodeId
+		? graph.nodes.get(fileNodeId)?.metadata?.lineCount
+		: undefined;
+	const limit =
+		typeof lineCount === "number" && lineCount > 0
+			? lineCount
+			: BLAST_RADIUS_DEFAULT_READ_LIMIT;
+	// Machine field keeps the absolute (slash-normalized) path so the host's Read
+	// resolves it unambiguously — same convention as ModuleSymbolEntry.read.
+	return { path: normalizedFile, offset: 1, limit };
+}
+
+// Cross-file blast radius (#304): the transitive dependents of this module,
+// aggregated from symbol-level impact hits to ranked FILE reads — "if you change
+// this module, read/verify these files". Read-only over the CACHED graph the
+// caller already loaded (never builds; the caller gates on a warm graph), so it
+// shares module_report's #256 no-build contract. Returns undefined when nothing
+// depends on the module (no section to show).
+async function computeBlastRadius(
+	graph: ReviewGraph,
+	normalizedPath: string,
+	projectRoot: string,
+	maxDepth: number,
+): Promise<BlastRadius | undefined> {
+	const { computeTransitiveImpact } = await import("./review-graph/query.js");
+	const result = computeTransitiveImpact(graph, normalizedPath, { maxDepth });
+	const byFile = new Map<
+		string,
+		{
+			dependents: number;
+			minDepth: number;
+			relations: Set<ReviewGraphEdgeKind>;
+		}
+	>();
+	for (const hit of result.hits) {
+		if (!hit.file) continue;
+		const key = normalizeMapKey(hit.file);
+		if (key === normalizedPath) continue; // never list the module itself
+		const cur = byFile.get(key) ?? {
+			dependents: 0,
+			minDepth: Number.POSITIVE_INFINITY,
+			relations: new Set<ReviewGraphEdgeKind>(),
+		};
+		cur.dependents += 1;
+		cur.minDepth = Math.min(cur.minDepth, hit.depth);
+		cur.relations.add(hit.relation);
+		byFile.set(key, cur);
+	}
+	if (byFile.size === 0) return undefined;
+	const files: BlastRadiusFile[] = [...byFile.entries()]
+		.map(([key, v]) => ({
+			file: toDisplayPath(key, projectRoot),
+			dependents: v.dependents,
+			minDepth: v.minDepth,
+			relations: [...v.relations].sort((a, b) => a.localeCompare(b)),
+			read: blastReadArgs(graph, key),
+		}))
+		// Closest hop first, then most-depended-on, then stable by path.
+		.sort(
+			(a, b) =>
+				a.minDepth - b.minDepth ||
+				b.dependents - a.dependents ||
+				a.file.localeCompare(b.file),
+		)
+		.slice(0, BLAST_RADIUS_FILE_CAP);
+	return {
+		truncated: result.truncated,
+		maxDepth: result.maxDepthReached,
+		files,
+	};
+}
+
 function unavailableReport(displayPath: string): ModuleReport {
 	return {
 		available: false,
@@ -578,6 +698,20 @@ export async function moduleReport(
 
 	const hasGraphNode = graph?.fileNodes.has(normalizedPath) ?? false;
 
+	// Cross-file blast radius (#304): opt-in, read-only over the CACHED graph. Only
+	// computed when requested AND the file is in a warm graph — a cold cache omits
+	// the section entirely (never builds, same #256 contract as the rest of this
+	// path). Aggregated to file reads; undefined when nothing depends on the module.
+	const blastRadius =
+		options?.blastRadius && graph && hasGraphNode
+			? await computeBlastRadius(
+					graph,
+					normalizedPath,
+					cwd,
+					Math.max(1, options.blastRadiusDepth ?? 3),
+				)
+			: undefined;
+
 	const report: ModuleReport = {
 		available: entries.length > 0 || hasGraphNode,
 		staleness: entries.length === 0 && !hasGraphNode ? "unavailable" : "fresh",
@@ -593,6 +727,7 @@ export async function moduleReport(
 		api,
 		internal,
 		recommendedReads: rankRecommendedReads(entries),
+		...(blastRadius ? { blastRadius } : {}),
 		semantic: {
 			// Provenance of who-uses-this / references. The AST review graph is the
 			// only source on this read path; "graph-lsp" is reserved for #236 (LSP

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -43,7 +43,6 @@ import {
 	runSessionStart,
 	runTurnEnd,
 	summarizeScan,
-	symbolImpact,
 	symbolSearch,
 	type WarmAnalyzeRequest,
 } from "../clients/lens-engine.js";
@@ -374,34 +373,6 @@ const TOOLS = [
 		},
 	},
 	{
-		name: "pilens_impact",
-		description:
-			"Transitive, depth-bounded impact of a file over the review graph: what " +
-			"depends on it (callers, referencers, importers), directly and indirectly. " +
-			"Walks incoming call/reference/import edges breadth-first. Use before a " +
-			"breaking change to see the blast radius. Needs the review graph (built by " +
-			"pilens_session_start, or on first call).",
-		inputSchema: {
-			type: "object",
-			properties: {
-				file: {
-					type: "string",
-					description: "File whose dependents to find (relative to cwd or absolute).",
-				},
-				cwd: { type: "string" },
-				maxDepth: {
-					type: "number",
-					description: "Max hops to traverse (default 3).",
-				},
-				maxHits: {
-					type: "number",
-					description: "Max dependents to return (default 200).",
-				},
-			},
-			required: ["file"],
-		},
-	},
-	{
 		name: "pilens_module_report",
 		description:
 			"Structured, navigable overview of a source module — a token-efficient " +
@@ -412,7 +383,9 @@ const TOOLS = [
 			"tree-sitter outline + review-graph who-uses-this + bounded live-LSP " +
 			"enrichment (exact references/implementations for exported symbols, " +
 			"time-boxed, degrades to graph-only when no LSP server is available). " +
-			"`semantic.source` reports whether LSP data was used. An outline shows " +
+			"`semantic.source` reports whether LSP data was used. Pass " +
+			"`blastRadius: true` for the cross-file blast radius (transitive dependents " +
+			"as ranked file reads, read-only over the cached graph). An outline shows " +
 			"shape, not bodies.",
 		inputSchema: {
 			type: "object",
@@ -425,6 +398,16 @@ const TOOLS = [
 				maxRefsPerSymbol: {
 					type: "number",
 					description: "Cap who-uses-this entries per symbol (default 10).",
+				},
+				blastRadius: {
+					type: "boolean",
+					description:
+						"Include the cross-file blast radius: transitive dependents aggregated to ranked file reads. Read-only over the cached graph (omitted when cold).",
+				},
+				blastRadiusDepth: {
+					type: "number",
+					description:
+						"Max hops for the blast-radius walk (default 3). Only used with blastRadius.",
 				},
 			},
 			required: ["file"],
@@ -679,54 +662,6 @@ async function callTool(
 		});
 	}
 
-	if (name === "pilens_impact") {
-		const file = typeof args.file === "string" ? args.file : "";
-		if (!file.trim()) return toolText("Provide a `file`.");
-		const cwd = typeof args.cwd === "string" ? args.cwd : DEFAULT_CWD;
-		const maxDepth =
-			typeof args.maxDepth === "number" && Number.isFinite(args.maxDepth)
-				? Math.max(1, Math.floor(args.maxDepth))
-				: undefined;
-		const maxHits =
-			typeof args.maxHits === "number" && Number.isFinite(args.maxHits)
-				? Math.max(1, Math.floor(args.maxHits))
-				: undefined;
-		const { available, hits, truncated, maxDepthReached } = await symbolImpact(
-			file,
-			cwd,
-			{ maxDepth, maxHits },
-		);
-		const rel = (f: string) => (f ? path.relative(cwd, f) : "(unknown)");
-		if (!available) {
-			return toolText(
-				"Review graph is empty — run pilens_session_start first.",
-				{ available: false },
-			);
-		}
-		if (hits.length === 0) {
-			return toolText(`Nothing depends on ${rel(path.resolve(cwd, file))}.`, {
-				file,
-				hits: [],
-			});
-		}
-		const byDepth = hits.slice().sort((a, b) => a.depth - b.depth);
-		const lines = [
-			`${hits.length} dependent(s) of ${rel(path.resolve(cwd, file))}` +
-				`${truncated ? " (truncated)" : ""}, max depth ${maxDepthReached}:`,
-			...byDepth
-				.slice(0, 40)
-				.map(
-					(hit) =>
-						`  d${hit.depth} ${hit.relation} ← ${hit.symbol ? `${hit.symbol} ` : ""}${rel(hit.file)}`,
-				),
-		];
-		return toolText(lines.join("\n"), {
-			file,
-			truncated,
-			maxDepthReached,
-			hits: hits.map((hit) => ({ ...hit, file: rel(hit.file) })),
-		});
-	}
 
 	if (name === "pilens_module_report") {
 		const file = typeof args.file === "string" ? args.file : "";
@@ -737,7 +672,17 @@ async function callTool(
 			Number.isFinite(args.maxRefsPerSymbol)
 				? Math.max(1, Math.floor(args.maxRefsPerSymbol))
 				: undefined;
-		const report = await moduleReport(file, cwd, { maxRefsPerSymbol });
+		const blastRadius = args.blastRadius === true;
+		const blastRadiusDepth =
+			typeof args.blastRadiusDepth === "number" &&
+			Number.isFinite(args.blastRadiusDepth)
+				? Math.max(1, Math.floor(args.blastRadiusDepth))
+				: undefined;
+		const report = await moduleReport(file, cwd, {
+			maxRefsPerSymbol,
+			blastRadius,
+			blastRadiusDepth,
+		});
 		if (!report.available) {
 			return {
 				...toolText(

--- a/tests/clients/module-report.test.ts
+++ b/tests/clients/module-report.test.ts
@@ -389,6 +389,83 @@ describe("moduleReport — member nesting (#301)", () => {
 	});
 });
 
+describe("moduleReport — cross-file blast radius (#304)", () => {
+	// dep ← mid ← top, function-wrapped so the review graph captures call edges.
+	function makeChain(env: { tmpDir: string }) {
+		createTempFile(
+			env.tmpDir,
+			"dep.ts",
+			"export function foo(x: number): number {\n  return x + 1;\n}\n",
+		);
+		createTempFile(
+			env.tmpDir,
+			"mid.ts",
+			'import { foo } from "./dep.js";\nexport function bar(): number {\n  return foo(1);\n}\n',
+		);
+		createTempFile(
+			env.tmpDir,
+			"top.ts",
+			'import { bar } from "./mid.js";\nexport function baz(): number {\n  return bar();\n}\n',
+		);
+	}
+
+	it("is omitted unless requested", async () => {
+		const env = makeEnv();
+		makeChain(env);
+		await warmGraph(env.tmpDir);
+		const report = await moduleReport("dep.ts", env.tmpDir);
+		expect(report.blastRadius).toBeUndefined();
+	});
+
+	it("warm + requested: lists transitive dependents as ranked file reads", async () => {
+		const env = makeEnv();
+		makeChain(env);
+		await warmGraph(env.tmpDir);
+		const report = await moduleReport("dep.ts", env.tmpDir, {
+			blastRadius: true,
+		});
+		expect(report.blastRadius).toBeDefined();
+		const files = report.blastRadius?.files ?? [];
+		const names = files.map((f) => f.file);
+		// Direct dependent (mid) at depth 1; transitive dependent (top) deeper.
+		expect(names).toContain("mid.ts");
+		const mid = files.find((f) => f.file === "mid.ts");
+		expect(mid?.minDepth).toBe(1);
+		expect(mid?.dependents).toBeGreaterThanOrEqual(1);
+		expect(mid?.relations.length).toBeGreaterThanOrEqual(1);
+		// Ranked closest-first: the first entry is the shallowest.
+		expect(files[0]?.minDepth).toBeLessThanOrEqual(
+			files[files.length - 1]?.minDepth ?? 99,
+		);
+		// read args point at the dependent file (absolute machine path), offset 1.
+		expect(mid?.read.offset).toBe(1);
+		expect(path.isAbsolute(mid?.read.path ?? "")).toBe(true);
+		// The module itself never appears in its own blast radius.
+		expect(names).not.toContain("dep.ts");
+	});
+
+	it("cold cache + requested: section omitted, no build (read-only #256)", async () => {
+		const env = makeEnv();
+		makeChain(env);
+		// No warmGraph() → cold. Requesting blast radius must NOT build a graph.
+		const report = await moduleReport("dep.ts", env.tmpDir, {
+			blastRadius: true,
+		});
+		expect(report.semantic.source).toBe("none"); // proves cold
+		expect(report.blastRadius).toBeUndefined();
+	});
+
+	it("warm but nothing depends on the file: section omitted", async () => {
+		const env = makeEnv();
+		createTempFile(env.tmpDir, "lonely.ts", "export const solo = 1;\n");
+		await warmGraph(env.tmpDir);
+		const report = await moduleReport("lonely.ts", env.tmpDir, {
+			blastRadius: true,
+		});
+		expect(report.blastRadius).toBeUndefined();
+	});
+});
+
 describe("moduleReport — member visibility (#258) + compact outline (#259)", () => {
 	it("routes private/protected members of an exported class to internal with a visibility tag (#258)", async () => {
 		const env = makeEnv();

--- a/tests/mcp/server.smoke.test.ts
+++ b/tests/mcp/server.smoke.test.ts
@@ -57,7 +57,9 @@ describe("pi-lens MCP server (stdio smoke)", { retry: 2 }, () => {
 		expect(names).toContain("pilens_lsp_navigation");
 		expect(names).toContain("pilens_lsp_diagnostics");
 		expect(names).toContain("pilens_symbol_search");
-		expect(names).toContain("pilens_impact");
+		// pilens_impact was removed (#304) — its blast radius folded into
+		// pilens_module_report's `blastRadius` option.
+		expect(names).not.toContain("pilens_impact");
 		expect(names).toContain("pilens_module_report");
 		expect(names).toContain("pilens_read_symbol");
 		// Each tool advertises an object input schema.

--- a/tools/module-report.ts
+++ b/tools/module-report.ts
@@ -27,6 +27,7 @@ export function createModuleReportTool(getProjectRoot: () => string) {
 		description:
 			"Structured, navigable overview of a source module — a token-efficient substitute for reading the whole file. Returns each symbol's name/kind/signature/line-range with ready-to-use `read` arguments, plus who-uses-this, risk flags, and ranked recommendedReads. Prefer this before a full read; then use read_symbol (or read) for the exact body you need.\n" +
 			"Single mode: tree-sitter outline + review-graph who-uses-this + bounded live-LSP enrichment (exact references/implementations for exported symbols, time-boxed; degrades to graph-only when no LSP server is available). `semantic.source` reports whether LSP data was used.\n" +
+			"Pass `blastRadius: true` to also get the cross-file blast radius — the transitive dependents of this module aggregated to ranked file `read` args (\"if you change this, verify these files\"). Read-only over the cached graph; omitted on a cold cache. Supersedes the standalone impact query.\n" +
 			"Returns JSON. An outline shows shape, not bodies — it does NOT count as having read a symbol's body for editing; use read_symbol for that.",
 		promptSnippet:
 			"Navigable file outline — a cheap substitute for reading a whole file",
@@ -39,10 +40,27 @@ export function createModuleReportTool(getProjectRoot: () => string) {
 					description: "Cap on who-uses-this entries per symbol (default 10).",
 				}),
 			),
+			blastRadius: Type.Optional(
+				Type.Boolean({
+					description:
+						"Include the cross-file blast-radius section: transitive dependents aggregated to ranked file reads. Read-only over the cached graph (omitted when cold).",
+				}),
+			),
+			blastRadiusDepth: Type.Optional(
+				Type.Number({
+					description:
+						"Max hops for the blast-radius walk (default 3). Only used with blastRadius.",
+				}),
+			),
 		}),
 		async execute(
 			_toolCallId: string,
-			params: { path: string; maxRefsPerSymbol?: number },
+			params: {
+				path: string;
+				maxRefsPerSymbol?: number;
+				blastRadius?: boolean;
+				blastRadiusDepth?: number;
+			},
 			_signal: AbortSignal | undefined,
 			_onUpdate: unknown,
 			ctx: { cwd?: string },
@@ -53,6 +71,8 @@ export function createModuleReportTool(getProjectRoot: () => string) {
 			const cwd = getProjectRoot() || ctx.cwd || ".";
 			const report = await moduleReport(absFile, cwd, {
 				maxRefsPerSymbol: params.maxRefsPerSymbol,
+				blastRadius: params.blastRadius,
+				blastRadiusDepth: params.blastRadiusDepth,
 			});
 			return {
 				content: [


### PR DESCRIPTION
Closes #304.

`module_report` had no cross-file blast radius — `usedBy` is 1-hop per symbol, `recommendedReads` points within this file. The transitive view lived only in the standalone `pilens_impact` tool: redundant at the layer agents use and a separate surface to maintain.

## Fold transitive impact into module_report
- New `blastRadius?: boolean` (+ `blastRadiusDepth?`, default 3). When set **and** the file is in a warm cached graph, `computeTransitiveImpact` walks incoming call/reference/import edges; hits are aggregated to **file** granularity (dependents count, closest depth, distinct relations) and emitted as ranked file `read` args — *"if you change this module, read/verify these files"*. Closest-hop-first, then most-depended-on; capped at 12.
- **Strictly read-only** over `getCachedReviewGraph` (the #256 contract): a cold cache **omits the section entirely — never builds**. Also omitted when nothing depends on the module, or when not requested.
- Wired through the pi tool and the MCP mirror (`pilens_module_report`).

## Remove pilens_impact
Deleted the MCP tool def + handler — `module_report.blastRadius` is the single blast-radius surface now (**15 MCP tools, down from 16**). The `symbolImpact` engine seam is kept (read-only) for internal reuse; its stale "builds/loads the graph" doc is corrected to read-only (#260, which it already was).

## Notes / honest edges
- The walk reuses the existing, tested `computeTransitiveImpact` (same one `pilens_impact` used). Transitive reach depends on the review graph's call-edge completeness — e.g. a module-level `const x = f()` initializer isn't always a captured call edge — so depth-2 coverage is "as good as the graph", not new. The aggregation/ranking/omission logic is what's new and tested.
- `symbolImpact` is now used only by its own test; kept deliberately as a read-only engine seam (flagged here in case you'd rather remove it too).

## Tests
`module-report.test.ts`: warm+requested lists ranked transitive dependents; omitted unless requested; **cold cache omits without building**; no-dependents omits. `server.smoke.test.ts`: asserts `pilens_impact` is gone. AGENTS.md (tool count + notes) + README.md updated.

Full suite green (2426 passed, 1 skipped); `tsc` lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)