### PR TITLE
feat(lsp): typos spell-checker auxiliary LSP + worker-exit flake fixes (closes #283)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,9 @@ AGENTS.md is the durable context handed to every agent that works on pi-lens. **
 - **Capture decisions & patterns.** When a commit establishes a non-obvious decision, gotcha, convention, or architectural pattern the next agent would otherwise relearn the hard way, add it here with the *why* and *how-to-apply* (recent examples: the dist/packaging + `pi.skills` resolution gotcha, the event-loop/hot-path discipline, the build-vs-lint gate).
 - **Keep it high-signal.** Prune what's no longer true; prefer concise, load-bearing notes over exhaustive prose.
 
+## Contributing
+For human contributors and issue/PR authors, see `CONTRIBUTING.md` at the repo root. It covers the development workflow, how to add runners, LSP servers, formatters, and rules, and the issue/PR templates. This `AGENTS.md` is the durable agent context; `CONTRIBUTING.md` is the public contributor guide.
+
 ## What it is
 A pi coding-agent extension that runs automated checks on every file write/edit. Dispatches async parallel runners (LSP, biome, ruff, ast-grep, tree-sitter, type coverage, jscpd, knip, Madge, and language-specific linters/build checks) and injects findings as context injections at turn-end and session-start.
 
@@ -26,8 +29,8 @@ clients/
   word-index.ts           Identifier inverted index + BM25 ranking (#162) — built in the session scan, persisted in the snapshot; consumed ONLY by the pilens_symbol_search MCP tool (not yet by pi-lens internals)
   review-graph/query.ts   Graph queries incl computeImpactCascade (one-hop, used by the cascade) + computeTransitiveImpact (depth-bounded BFS, used by module_report's blastRadius section #304)
   installer/index.ts      Auto-install + ensureTool; probe-cache.json for fast restarts. Strategies: npm/pip/gem/github + maven (fat JAR → java -jar launcher) + archive (tree). github API is token-authed (api.github.com only, Authorization dropped on cross-host redirect — unauth=60/hr silently fails CI installs); tar extract is recursive-find (handles FLAT tarballs like gleam, not --strip-components). GITHUB_TOOLS kept in sync with the registry by tool-registry-consistency.test.ts
-  lsp/                    38 LSP server IDs (incl. opengrep + ast-grep + zizmor, cross-cutting AUXILIARY diagnostic LSPs — role:"auxiliary", #111/#239/#272), config, lifecycle. clojure-lsp + gleam now auto-install via github (native binary / flat tarball). zizmor (GitHub Actions security, `zizmor --lsp`) attaches to YAML; advisory unless the repo ships zizmor.yml; online audits need a token (env or `gh auth token`) via clients/zizmor-config.ts
-  dispatch/               Pipeline dispatcher + 47 registered runners (incl. spotbugs — flag-gated via withSpotbugsGroup, #133). Auxiliary LSPs (opengrep, ast-grep, zizmor, …) are NOT runners — they attach via the lsp runner's with-auxiliary path; see clients/dispatch/auxiliary-lsp.ts
+  lsp/                    39 LSP server IDs (incl. opengrep + ast-grep + zizmor + typos, cross-cutting AUXILIARY diagnostic LSPs — role:"auxiliary", #111/#239/#272/#283), config, lifecycle. clojure-lsp + gleam now auto-install via github (native binary / flat tarball). zizmor (GitHub Actions security, `zizmor --lsp`) attaches to YAML; advisory unless the repo ships zizmor.yml; online audits need a token (env or `gh auth token`) via clients/zizmor-config.ts. typos (source-code spell checker, `typos-lsp`, native win-arm64 build) attaches to the code-aux set PLUS markdown (#283 option B); allow-list dictionary (only KNOWN misspellings) so low-FP; advisory (default WARNING) unless the repo ships typos.toml via clients/typos-config.ts
+  dispatch/               Pipeline dispatcher + 47 registered runners (incl. spotbugs — flag-gated via withSpotbugsGroup, #133). Auxiliary LSPs (opengrep, ast-grep, zizmor, typos, …) are NOT runners — they attach via the lsp runner's with-auxiliary path; see clients/dispatch/auxiliary-lsp.ts
   widget-state.ts         Footer widget rendering (@earendil-works/pi-tui)
 tools/                    ast-grep-search, lsp-navigation tool handlers
 tests/                    Vitest test suite (mirrors clients/ structure)

--- a/clients/dispatch/auxiliary-lsp.ts
+++ b/clients/dispatch/auxiliary-lsp.ts
@@ -19,6 +19,7 @@
 
 import type { LSPDiagnostic } from "../lsp/client.js";
 import { findLocalOpengrepConfig } from "../opengrep-config.js";
+import { findLocalTyposConfig } from "../typos-config.js";
 import { findLocalZizmorConfig } from "../zizmor-config.js";
 import { classifyDefect } from "./diagnostic-taxonomy.js";
 import type { DefectClass, OutputSemantic } from "./types.js";
@@ -100,6 +101,27 @@ export const AUXILIARY_LSP_PROFILES: readonly AuxiliaryLspProfile[] = [
 			blockingAllowed && d.severity === 1 ? "blocking" : "warning",
 		defectClass: (d) =>
 			classifyDefect(String(d.code ?? ""), "zizmor", d.message ?? ""),
+	},
+	{
+		serverId: "typos",
+		tool: "typos",
+		// typos-lsp tags its LSP diagnostics `source: "typos"`.
+		sourceMatch: /typos/i,
+		killSwitchFlag: "no-typos",
+		enabledByDefault: true,
+		// typos is allow-list based (only KNOWN misspellings with a known
+		// correction), but as an always-on advisory we only let it BLOCK when the
+		// repo opts in with its own `typos.toml`/`_typos.toml`/`.typos.toml` (the
+		// team's curated dictionary + chosen severity). Advisory otherwise —
+		// findings still surface via lens_diagnostics. Note typos-lsp's default
+		// severity is WARNING, so even with a config it stays advisory unless the
+		// repo raises `diagnostic-severity` to Error.
+		allowBlocking: (cwd) => Boolean(findLocalTyposConfig(cwd)),
+		semantic: (d, { blockingAllowed }) =>
+			blockingAllowed && d.severity === 1 ? "blocking" : "warning",
+		// A misspelling is a documentation/quality defect — not security or
+		// correctness. "style" is the closest taxonomy class.
+		defectClass: () => "style",
 	},
 ];
 

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -800,6 +800,40 @@ export const TOOLS: ToolDefinition[] = [
 		},
 	},
 	{
+		// typos-lsp: source-code spell checker that speaks LSP (#283). cargo-dist
+		// release archives, one per target triple, each holding a single `typos-lsp`
+		// binary (extracted via the recursive binary find). NO token / network — the
+		// dictionary is compiled in. The binary takes no `--version` (it ignores args
+		// and serves the LSP on stdin/stdout); the PATH probe ignores checkArgs and
+		// verifyToolBinary runs with stdin:ignore so the server gets EOF and exits.
+		id: "typos-lsp",
+		name: "typos-lsp",
+		checkCommand: "typos-lsp",
+		checkArgs: ["--version"],
+		installStrategy: "github",
+		binaryName: "typos-lsp",
+		github: {
+			repo: "tekumara/typos-lsp",
+			assetMatch: (platform, arch) => {
+				if (platform === "linux")
+					return arch === "arm64"
+						? "aarch64-unknown-linux-gnu.tar.gz"
+						: "x86_64-unknown-linux-gnu.tar.gz";
+				if (platform === "darwin")
+					return arch === "arm64"
+						? "aarch64-apple-darwin.tar.gz"
+						: "x86_64-apple-darwin.tar.gz";
+				if (platform === "win32")
+					// Native win-arm64 build (one better than zizmor, which emulates).
+					return arch === "arm64"
+						? "aarch64-pc-windows-msvc.zip"
+						: "x86_64-pc-windows-msvc.zip";
+				return undefined;
+			},
+			binaryInArchive: "typos-lsp",
+		},
+	},
+	{
 		id: "tflint",
 		name: "tflint",
 		checkCommand: "tflint",
@@ -3093,6 +3127,7 @@ export const GITHUB_TOOLS = [
 	"ktlint",
 	"actionlint",
 	"zizmor",
+	"typos-lsp",
 	"tflint",
 	"terraform-ls",
 	"zls",

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -517,10 +517,25 @@ export async function killProcessTree(
 	proc: {
 		kill(signal?: NodeJS.Signals | number): boolean;
 		unref?: () => void;
+		exitCode?: number | null;
+		signalCode?: NodeJS.Signals | null;
 	},
 	pid: number,
 	options: LSPShutdownOptions = {},
 ): Promise<void> {
+	// If our child has already exited, its PID is dead and the OS may have
+	// RECYCLED it. The Windows `taskkill /F /T` below force-kills the PID's whole
+	// tree, so on a recycled PID it would kill an unrelated process (in the test
+	// suite this occasionally nuked a vitest worker fork → "Worker exited
+	// unexpectedly" with no fatal dump). There is nothing left for us to kill, and
+	// the handle-based proc.kill() below is moot, so return early.
+	if (
+		(proc.exitCode != null || proc.signalCode != null) &&
+		!options.processExiting
+	) {
+		proc.unref?.();
+		return;
+	}
 	if (process.platform === "win32" && pid > 0) {
 		// Host process is exiting (loop already closing): never spawn a child here —
 		// the spawn's uv_async_send on the closing loop-wakeup handle hard-aborts

--- a/clients/lsp/launch.ts
+++ b/clients/lsp/launch.ts
@@ -883,6 +883,17 @@ export async function stopLSP(handle: LSPProcess): Promise<void> {
 
 		const killWindowsTree = (): boolean => {
 			if (!isWindows || handle.pid <= 0) return false;
+			// If our child has already exited, its PID is dead and the OS may have
+			// RECYCLED it to an unrelated process. `taskkill /F /T` on a recycled PID
+			// force-kills that process AND its whole tree — in the test suite this
+			// occasionally nuked a vitest worker fork ("Worker exited unexpectedly",
+			// no fatal dump, e.g. via the "stopLSP after the process already exited"
+			// path); in production it could kill an unrelated user process. Never
+			// tree-kill a PID we no longer own — fall back to handle.process.kill(),
+			// which on Windows signals via the retained process HANDLE (not the raw
+			// PID), so it's a safe no-op on an already-exited child.
+			if (handle.process.exitCode !== null || handle.process.signalCode !== null)
+				return false;
 			try {
 				// Absolute path avoids PATH-resolution substitution on Windows.
 				const taskkill = `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\taskkill.exe`;

--- a/clients/lsp/server-strategies.ts
+++ b/clients/lsp/server-strategies.ts
@@ -129,6 +129,21 @@ export const SERVER_DIAGNOSTIC_STRATEGIES: Record<string, DiagnosticStrategy> =
 			expectSemanticSecondPush: false,
 			reopenOnResync: false,
 		},
+		// typos (source-code spell checker, auxiliary LSP #283). Push-only (no pull
+		// diagnostics). Its dictionary is compiled in — there's NO rule-load window
+		// like Opengrep — so the FIRST publishDiagnostics after didOpen IS the
+		// complete result: seedFirstPush. It re-scans on didChange (FULL sync), so no
+		// reopen-on-resync. A native single-file spell scan is sub-100ms, so the seed
+		// arrives near-instantly; aggregateWaitMs is a generous ceiling (bounded by
+		// the per-edit caller cap, #242) that the early seed resolves well under.
+		typos: {
+			seedFirstPush: true,
+			pullRetryBudgetMs: 0,
+			debounceMs: 150,
+			aggregateWaitMs: 1500,
+			expectSemanticSecondPush: false,
+			reopenOnResync: false,
+		},
 		// marksman (Markdown LSP, #274). Push-based; native binary so the per-file
 		// parse is fast, but its value is CROSS-file (broken intra-repo links,
 		// missing anchors/heading refs) which needs the workspace index — so the

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -2534,6 +2534,43 @@ export const ZizmorServer: LSPServerInfo = {
 	autoInstall: async () => Boolean(await ensureTool("zizmor")),
 };
 
+// typos — a source-code spell checker that speaks LSP (#283). Cross-cutting,
+// diagnostic-only auxiliary like Opengrep/ast-grep/zizmor: it attaches to many
+// code kinds AND markdown/docs (option B — a spell checker that skips prose
+// misses its highest-value target; typos is ALLOW-LIST based, so it only flags
+// known misspellings with a known correction, keeping the false-positive rate on
+// technical vocab low). Its built-in dictionary is compiled in — NO config needed
+// to run; a repo `typos.toml`/`_typos.toml`/`.typos.toml` only tunes the
+// dictionary/severity (and is the blocking opt-in, see the auxiliary profile).
+// `typos-lsp` takes NO subcommand/flag — it wires stdin/stdout straight into the
+// LSP server. Default severity is WARNING, so findings are advisory by default.
+const TYPOS_EXTENSIONS: readonly string[] = Array.from(
+	new Set([...OPENGREP_EXTENSIONS, ...KIND_EXTENSIONS["markdown"]]),
+);
+
+export const TyposServer: LSPServerInfo = {
+	id: "typos",
+	name: "typos Spell Checker",
+	role: "auxiliary",
+	extensions: TYPOS_EXTENSIONS,
+	// Stable per-repo root so ONE warm server serves the whole project (like the
+	// other auxiliaries) — typos.toml discovery is repo-relative.
+	root: RootWithFallback(NearestRoot([".git"]), async () => process.cwd()),
+	availabilityKey: "typos-lsp",
+	async spawn(root, options) {
+		return resolveAndLaunch(
+			{
+				candidates: ["typos-lsp"],
+				args: [],
+				cwd: root,
+				managedToolId: "typos-lsp",
+			},
+			options?.allowInstall,
+		);
+	},
+	autoInstall: async () => Boolean(await ensureTool("typos-lsp")),
+};
+
 export const LSP_SERVERS: LSPServerInfo[] = [
 	TypeScriptServer,
 	DenoServer,
@@ -2577,6 +2614,7 @@ export const LSP_SERVERS: LSPServerInfo[] = [
 	OpengrepServer,
 	AstGrepServer,
 	ZizmorServer,
+	TyposServer,
 ];
 
 /**

--- a/clients/typos-config.ts
+++ b/clients/typos-config.ts
@@ -1,0 +1,34 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { walkUpDirs } from "./path-utils.js";
+
+/**
+ * typos (source-code spell checker) configuration discovery. typos runs as a
+ * cross-cutting auxiliary LSP (#283); like Opengrep's local-rules gate and
+ * zizmor's `zizmor.yml` gate, the PRESENCE of a repo-local typos config is the
+ * project's deliberate opt-in to let spelling findings BLOCK (it carries the
+ * team's curated allow-list / `extend-words` / severity). Advisory otherwise.
+ *
+ * typos discovers its config as `typos.toml`, `_typos.toml`, or `.typos.toml`
+ * at the project root (see typos' configuration docs). We only need to know if
+ * one EXISTS for the blocking gate — the `typos-lsp` server reads it itself.
+ *
+ * Note: `files.*` ignore globs in the config have NO effect under the LSP
+ * (CLI-only), so a `.typos.toml` does not exclude paths from the LSP scan — it
+ * only tunes the dictionary/severity. The blocking gate keys purely on presence.
+ */
+export const LOCAL_TYPOS_CONFIG_NAMES = [
+	"typos.toml",
+	"_typos.toml",
+	".typos.toml",
+] as const;
+
+export function findLocalTyposConfig(startDir: string): string | undefined {
+	for (const dir of walkUpDirs(startDir || process.cwd())) {
+		for (const name of LOCAL_TYPOS_CONFIG_NAMES) {
+			const candidate = path.join(dir, name);
+			if (fs.existsSync(candidate)) return candidate;
+		}
+	}
+	return undefined;
+}

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -575,6 +575,21 @@ const LSP_FIXTURES = [
 		auxiliarySourceMatch: "zizmor",
 		gitInit: true,
 	},
+	// typos source-code spell checker (auxiliary, #283). The fixture is a markdown
+	// doc with several known misspellings — typos' compiled-in dictionary flags
+	// them with NO config (allow-list based). A markdown fixture deliberately
+	// exercises the option-B prose coverage (the novel scope vs the code-only
+	// auxiliaries). Proves install→spawn→scan→publish on the with-auxiliary path.
+	{
+		lang: "typos",
+		dir: "tests/fixtures/tool-smoke/typos-aux",
+		file: "notes.md",
+		serverHint: "typos (auxiliary)",
+		tools: ["typos-lsp"],
+		auxiliaryServerIds: ["typos"],
+		auxiliarySourceMatch: "typos",
+		gitInit: true,
+	},
 	// ast-grep no-sgconfig BASELINE (#239 Phase 2). NO sgconfig in the fixture, so
 	// the server must attach everywhere and launch with `lsp --config <shipped
 	// baseline>` to run pi-lens's bundled ruleset (`arr.sort()` → the shipped

--- a/tests/clients/dispatch/auxiliary-lsp.test.ts
+++ b/tests/clients/dispatch/auxiliary-lsp.test.ts
@@ -31,6 +31,13 @@ describe("auxiliary LSP enablement", () => {
 			"zizmor",
 		);
 	});
+
+	it("typos is default-on and the no-typos kill switch disables it (#283)", () => {
+		expect(enabledAuxiliaryLspServerIds(() => undefined)).toContain("typos");
+		expect(enabledAuxiliaryLspServerIds((f) => f === "no-typos")).not.toContain(
+			"typos",
+		);
+	});
 });
 
 describe("auxiliary profile source routing", () => {
@@ -41,6 +48,10 @@ describe("auxiliary profile source routing", () => {
 
 	it("routes zizmor's 'zizmor' source to the zizmor profile (#272)", () => {
 		expect(findAuxiliaryProfileForSource("zizmor")?.tool).toBe("zizmor");
+	});
+
+	it("routes typos-lsp's 'typos' source to the typos profile (#283)", () => {
+		expect(findAuxiliaryProfileForSource("typos")?.tool).toBe("typos");
 	});
 
 	it("ignores language-server sources and missing source", () => {
@@ -122,5 +133,34 @@ describe("zizmor semantic policy (#272)", () => {
 			diag({ code: "template-injection", message: "code injection via template" }),
 		);
 		expect(typeof dc === "string" || dc === undefined).toBe(true);
+	});
+});
+
+describe("typos semantic policy (#283)", () => {
+	const typos = AUXILIARY_LSP_PROFILES.find((p) => p.serverId === "typos");
+
+	it("is advisory by default; blocks only ERROR where a repo typos.toml opts in", () => {
+		expect(typos).toBeDefined();
+		// no repo typos config → even an ERROR-severity finding stays advisory
+		// (typos-lsp's own default severity is WARNING anyway).
+		expect(
+			typos?.semantic(diag({ severity: 1 }), { blockingAllowed: false }),
+		).toBe("warning");
+		expect(
+			typos?.semantic(diag({ severity: 2 }), { blockingAllowed: false }),
+		).toBe("warning");
+		// repo opts in with a typos.toml AND raised severity to Error → blocks.
+		expect(
+			typos?.semantic(diag({ severity: 1 }), { blockingAllowed: true }),
+		).toBe("blocking");
+		expect(
+			typos?.semantic(diag({ severity: 2 }), { blockingAllowed: true }),
+		).toBe("warning");
+	});
+
+	it("classifies a misspelling as a style (docs/quality) defect — not security", () => {
+		expect(typos?.defectClass?.(diag({ message: "`recieve` should be `receive`" }))).toBe(
+			"style",
+		);
 	});
 });

--- a/tests/clients/lsp/lifecycle.test.ts
+++ b/tests/clients/lsp/lifecycle.test.ts
@@ -11,14 +11,28 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { launchLSP, stopLSP } from "../../../clients/lsp/launch.js";
 
-describe("LSP Launch", () => {
-	it("throws when binary is not found", async () => {
-		await expect(
-			launchLSP("definitely-not-a-real-binary-12345", ["--stdio"]),
-		).rejects.toThrow();
-	});
+// Every test here spawns a real OS process (launchLSP uses `shell: true` on
+// Windows → cmd.exe). In isolation the whole file runs in <4s, but under the
+// FULL parallel suite the OS starves these spawns and a single one can brush
+// past vitest's 5000ms default per-test timeout (observed: 5021ms on the
+// missing-binary probe whose own startup window is just 50ms — i.e. pure load
+// starvation, not a hang). A generous explicit timeout removes that
+// load-sensitivity without affecting passing runs (the timeout only fires if
+// exceeded).
+const SPAWN_TEST_TIMEOUT_MS = 20_000;
 
-	it("spawns a real Node.js process and returns LSPProcess handle", async () => {
+describe("LSP Launch", () => {
+	it(
+		"throws when binary is not found",
+		{ timeout: SPAWN_TEST_TIMEOUT_MS },
+		async () => {
+			await expect(
+				launchLSP("definitely-not-a-real-binary-12345", ["--stdio"]),
+			).rejects.toThrow();
+		},
+	);
+
+	it("spawns a real Node.js process and returns LSPProcess handle", { timeout: SPAWN_TEST_TIMEOUT_MS }, async () => {
 		// Write a temp script that keeps running (avoids shell escaping issues)
 		const scriptPath = path.join(os.tmpdir(), `pi-lens-test-${Date.now()}.js`);
 		fs.writeFileSync(scriptPath, "setInterval(() => {}, 60000);");
@@ -36,7 +50,7 @@ describe("LSP Launch", () => {
 		fs.unlinkSync(scriptPath);
 	});
 
-	it("detects immediate exit of a bad binary", async () => {
+	it("detects immediate exit of a bad binary", { timeout: SPAWN_TEST_TIMEOUT_MS }, async () => {
 		const scriptPath = path.join(os.tmpdir(), `pi-lens-test-${Date.now()}.js`);
 		fs.writeFileSync(scriptPath, "process.exit(1);");
 
@@ -49,7 +63,7 @@ describe("LSP Launch", () => {
 		fs.unlinkSync(scriptPath);
 	});
 
-	it("stopLSP kills the process", async () => {
+	it("stopLSP kills the process", { timeout: SPAWN_TEST_TIMEOUT_MS }, async () => {
 		const scriptPath = path.join(os.tmpdir(), `pi-lens-test-${Date.now()}.js`);
 		fs.writeFileSync(scriptPath, "setInterval(() => {}, 60000);");
 
@@ -66,7 +80,7 @@ describe("LSP Launch", () => {
 		fs.unlinkSync(scriptPath);
 	});
 
-	it("stopLSP returns when the process already exited", async () => {
+	it("stopLSP returns when the process already exited", { timeout: SPAWN_TEST_TIMEOUT_MS }, async () => {
 		const scriptPath = path.join(os.tmpdir(), `pi-lens-test-${Date.now()}.js`);
 		fs.writeFileSync(scriptPath, "setTimeout(() => process.exit(0), 250);");
 

--- a/tests/clients/typos-config.test.ts
+++ b/tests/clients/typos-config.test.ts
@@ -1,0 +1,43 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	findLocalTyposConfig,
+	LOCAL_TYPOS_CONFIG_NAMES,
+} from "../../clients/typos-config.js";
+
+describe("findLocalTyposConfig (#283)", () => {
+	let root: string;
+	beforeEach(() => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "typos-cfg-"));
+	});
+	afterEach(() => {
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("finds a root-level typos.toml", () => {
+		const cfg = path.join(root, "typos.toml");
+		fs.writeFileSync(cfg, "[default]\n");
+		expect(findLocalTyposConfig(root)).toBe(cfg);
+	});
+
+	it.each([...LOCAL_TYPOS_CONFIG_NAMES])("discovers %s", (name) => {
+		const cfg = path.join(root, name);
+		fs.writeFileSync(cfg, "[default]\n");
+		expect(findLocalTyposConfig(root)).toBe(cfg);
+	});
+
+	it("walks up from a nested start dir", () => {
+		const cfg = path.join(root, "_typos.toml");
+		fs.writeFileSync(cfg, "[default]\n");
+		const nested = path.join(root, "a", "b");
+		fs.mkdirSync(nested, { recursive: true });
+		expect(findLocalTyposConfig(nested)).toBe(cfg);
+	});
+
+	it("returns undefined when no config exists", () => {
+		expect(findLocalTyposConfig(root)).toBeUndefined();
+	});
+});

--- a/tests/fixtures/tool-smoke/typos-aux/notes.md
+++ b/tests/fixtures/tool-smoke/typos-aux/notes.md
@@ -1,0 +1,4 @@
+# Release notes
+
+We recieve the payload and proccess it before the responce is sent.
+This sentance has a known typo so the spell checker has somthing to flag.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,30 @@
 import { defineConfig } from "vitest/config";
 
 // Minimal config — vitest defaults (test discovery, pools, etc.) are preserved.
-// The only addition is a globalSetup that fails fast on a stale in-place build,
-// so tests can't silently run against pre-edit compiled `.js` (#198).
+// Additions:
+//  - globalSetup fails fast on a stale in-place build, so tests can't silently
+//    run against pre-edit compiled `.js` (#198).
+//  - worker heap headroom: the full suite occasionally died with a "Worker
+//    exited unexpectedly" + a `node::GetNodeReport` dump. That report is emitted
+//    by Node's OWN fatal-error handler (V8 heap-limit reached) — an external OS
+//    OOM-kill SIGKILLs with no dump — so the crash is a single long-lived worker
+//    hitting its own V8 heap ceiling, not system memory exhaustion (32-core /
+//    68 GB host). With `isolate: true` vitest resets each worker's module
+//    registry per file, so the native addons (the many tree-sitter grammars +
+//    @ast-grep/napi) are re-loaded file-after-file and their off- and on-heap
+//    buffers accumulate in the reused worker until a heavy worker tips over.
+//    `execArgv` passes --max-old-space-size to every spawned worker, giving that
+//    headroom WITHOUT capping worker count (no CI slowdown); aggregate risk is
+//    negligible (workers never all peak at once, and 4 GB × workers ≪ host RAM).
+//    Tune via PI_LENS_TEST_WORKER_HEAP_MB. NOTE: Vitest 4 flattened the config —
+//    `execArgv` is a direct `test` field (the v3 `poolOptions.forks.execArgv`
+//    nesting no longer exists and is silently ignored).
 export default defineConfig({
 	test: {
 		globalSetup: ["./tests/support/check-build-freshness.ts"],
 		setupFiles: ["./tests/support/vitest-setup.ts"],
+		execArgv: [
+			`--max-old-space-size=${process.env.PI_LENS_TEST_WORKER_HEAP_MB || 4096}`,
+		],
 	},
 });


### PR DESCRIPTION
## Summary

Implements **#283** — adds [`typos-lsp`](https://github.com/tekumara/typos-lsp) (source-code spell checker) as a cross-cutting, diagnostic-only **auxiliary LSP**, following the opengrep/ast-grep/zizmor template (#111/#239/#272). Plus fixes for the full-suite worker-exit flake hit while validating.

### Feature: typos auxiliary LSP (commit 1)
- `clients/typos-config.ts` — `findLocalTyposConfig` (`typos.toml`/`_typos.toml`/`.typos.toml`; presence = blocking opt-in, like the opengrep/zizmor gates).
- `clients/lsp/server.ts` — `TyposServer` (`role:auxiliary`). **Extension scope = option B**: the code-aux set (`OPENGREP_EXTENSIONS`) **plus markdown** — a spell checker that skips prose misses its highest-value target; typos is allow-list based (only *known* misspellings) so it's low-FP on code identifiers.
- `clients/lsp/server-strategies.ts` — push-only, `seedFirstPush`, native sub-100ms scan, 1500ms ceiling (caller-cap bounded, #242).
- `clients/dispatch/auxiliary-lsp.ts` — profile: source `typos`, `no-typos` kill switch, **advisory by default** (typos-lsp default severity is WARNING; blocks only with a repo `typos.toml` *and* raised severity), defect class `style`.
- `clients/installer/index.ts` — `typos-lsp` GitHub-release tool (+`GITHUB_TOOLS`), full six-combo asset matrix incl. **native win-arm64**. Verified the no-arg-parsing binary doesn't hang the install probe (PATH stat ignores args; `verifyToolBinary` runs with `stdin:ignore` → EOF → clean exit).
- Tests: aux profile routing / default-on / kill-switch / semantic + `typos-config` discovery; smoke `LSP_FIXTURES` markdown fixture (covers the new aux via the fixture-coverage guard); AGENTS.md updated.

### Flake fixes (commits 2–4)
The full suite intermittently exited 1 with **all tests passing** ("Worker exited unexpectedly"). Two distinct causes, fixed:

1. **`fix(lsp)` recycled-PID guard (root cause).** Windows teardown ran `taskkill /F /T /PID <pid>` without checking the child was still alive. Once a child exits its PID is dead and the OS may **recycle** it — so the force-tree-kill could land on a vitest worker fork (external SIGKILL, no fatal dump). The `stopLSP`-after-exit test is the trigger. **This is also a latent production hazard** (force-killing an unrelated recycled PID + its tree). Fix: skip the taskkill when the child handle shows it already exited (`exitCode`/`signalCode` set) in both `launch.ts` and `client.ts`; the `proc.kill()` fallback is safe on Windows (signals via the retained process *handle*, not the raw PID).
2. **`test` lifecycle timeouts.** The spawn-based `lifecycle.test.ts` tests use `shell: true` (cmd.exe) and occasionally brushed past vitest's 5000ms default under parallel-load starvation (a 50ms-window probe took 5021ms). Gave them an explicit 20s timeout (only fires if exceeded → no effect on passing runs).
3. **`test` worker heap headroom (defensive, unproven).** Raises worker `--max-old-space-size` to 4 GB via `test.execArgv`. This targets a *separate*, in-process V8-fatal variant (the one run that emitted a `node::GetNodeReport`, which an external kill can't produce). **Honest caveat:** I could not prove this fixes anything — the in-process fatal could be a native-addon abort rather than heap. Kept as harmless headroom; drop it if you'd prefer the PR carry only proven fixes.

## Validation
- `npm run build`, `npm run lint` (tsc) clean.
- Targeted: auxiliary-lsp / typos-config / lsp-fixture-coverage / installer registry-consistency / lifecycle / kill-process-tree all green.
- Full `npm test`: 2434 passed / 1 skipped (the worker-exit was the flake under investigation; the recycled-PID guard addresses its root cause).

## Notes
- Base merge-base is `328806d1`; the only file also touched by master's newer `#319` commit is `AGENTS.md` (different section — expecting a clean 3-way merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)