### PR TITLE
fix(diagnostics): make lens_diagnostics mode=full bounded + cancellable (closes #341)

### DIFF
--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -253,11 +253,12 @@ function getMaxWorkspaceDiagnosticFiles(): number {
 async function collectWorkspaceDiagnosticFiles(
 	root: string,
 	maxFiles: number = getMaxWorkspaceDiagnosticFiles(),
+	signal?: AbortSignal,
 ): Promise<string[]> {
 	const files: string[] = [];
 	const ignoreMatcher = getProjectIgnoreMatcher(root);
 	async function walk(current: string): Promise<void> {
-		if (files.length >= maxFiles) return;
+		if (signal?.aborted || files.length >= maxFiles) return;
 		let entries: nodeFs.Dirent[];
 		try {
 			entries = await nodeFs.promises.readdir(current, {
@@ -267,7 +268,7 @@ async function collectWorkspaceDiagnosticFiles(
 			return;
 		}
 		for (const entry of entries) {
-			if (files.length >= maxFiles) return;
+			if (signal?.aborted || files.length >= maxFiles) return;
 			if (entry.isSymbolicLink()) continue;
 			const full = path.join(current, entry.name);
 			if (entry.isDirectory()) {
@@ -1814,16 +1815,32 @@ export class LSPService {
 	 */
 	async runWorkspaceDiagnostics(
 		cwd: string,
+		options: { maxFiles?: number; signal?: AbortSignal } = {},
 	): Promise<LSPWorkspaceDiagnosticResult[]> {
 		const startedAt = Date.now();
 		const root = path.resolve(cwd);
-		const files = await collectWorkspaceDiagnosticFiles(root);
+		const { signal } = options;
+		// Cap the per-file LSP sweep: a Next.js-scale project can route thousands
+		// of files through the language server at concurrency 8, and without a
+		// caller cap that grinds for tens of minutes (#341). `maxFiles` lets
+		// lens_diagnostics' `maxLspFiles` bound it; falls back to the env/default.
+		const maxFiles =
+			typeof options.maxFiles === "number" &&
+			Number.isFinite(options.maxFiles) &&
+			options.maxFiles > 0
+				? Math.floor(options.maxFiles)
+				: getMaxWorkspaceDiagnosticFiles();
+		const files = await collectWorkspaceDiagnosticFiles(root, maxFiles, signal);
 		const results: LSPWorkspaceDiagnosticResult[] = new Array(files.length);
 		let nextIndex = 0;
 		const workers = Math.min(WORKSPACE_DIAGNOSTICS_CONCURRENCY, files.length);
 		await Promise.all(
 			Array.from({ length: workers }, async () => {
 				while (true) {
+					// Honor cancellation: a long sweep must stop when the agent/user
+					// aborts the turn rather than chew through the remaining files
+					// (#341). Already-collected results are returned as a partial.
+					if (signal?.aborted) return;
 					const index = nextIndex;
 					nextIndex += 1;
 					if (index >= files.length) return;
@@ -1865,6 +1882,8 @@ export class LSPService {
 					0,
 				),
 				concurrency: WORKSPACE_DIAGNOSTICS_CONCURRENCY,
+				maxFiles,
+				aborted: signal?.aborted ?? false,
 			},
 		});
 
@@ -2039,8 +2058,9 @@ export function resetLSPService(options: LSPShutdownOptions = {}): void {
 export function __collectWorkspaceDiagnosticFilesForTest(
 	root: string,
 	maxFiles?: number,
+	signal?: AbortSignal,
 ): Promise<string[]> {
 	return maxFiles === undefined
-		? collectWorkspaceDiagnosticFiles(path.resolve(root))
-		: collectWorkspaceDiagnosticFiles(path.resolve(root), maxFiles);
+		? collectWorkspaceDiagnosticFiles(path.resolve(root), undefined, signal)
+		: collectWorkspaceDiagnosticFiles(path.resolve(root), maxFiles, signal);
 }

--- a/clients/project-diagnostics/scanner.ts
+++ b/clients/project-diagnostics/scanner.ts
@@ -242,13 +242,26 @@ export async function scanProjectDiagnostics(
 	options: ProjectDiagnosticsScanOptions,
 ): Promise<ProjectDiagnosticsSnapshot> {
 	const cwd = path.resolve(options.cwd);
+	const { signal } = options;
 	const maxFiles = Math.max(1, options.maxFiles ?? DEFAULT_MAX_FILES);
 	const files = await collectSourceFilesAsync(cwd, { maxFiles });
-	const diagnostics = [
-		...(await scanTreeSitter(cwd, files)),
-		...(await scanFactRules(cwd, files)),
-		...(await scanAstGrepNapi(cwd, files)),
-	];
+	// Check cancellation at each phase boundary so a full-mode scan stops
+	// promptly when the agent/user aborts (#341). The per-phase runners are
+	// already file-capped, so phase granularity is enough to bound the work.
+	const runners: string[] = [];
+	const diagnostics: ProjectDiagnostic[] = [];
+	if (!signal?.aborted) {
+		diagnostics.push(...(await scanTreeSitter(cwd, files)));
+		runners.push("tree-sitter");
+	}
+	if (!signal?.aborted) {
+		diagnostics.push(...(await scanFactRules(cwd, files)));
+		runners.push("fact-rules");
+	}
+	if (!signal?.aborted) {
+		diagnostics.push(...(await scanAstGrepNapi(cwd, files)));
+		runners.push("ast-grep-napi");
+	}
 	const snapshot: ProjectDiagnosticsSnapshot = {
 		version: PROJECT_DIAGNOSTICS_CACHE_VERSION,
 		cwd,
@@ -256,8 +269,11 @@ export async function scanProjectDiagnostics(
 		scannedAt: new Date().toISOString(),
 		diagnostics,
 		filesScanned: files.length,
-		runners: ["tree-sitter", "fact-rules", "ast-grep-napi"],
+		runners,
 	};
+	// A cancelled scan yields a partial snapshot; don't persist it as the
+	// authoritative cross-session cache — only a complete run is cacheable.
+	if (signal?.aborted) return snapshot;
 	saveProjectDiagnosticsSnapshot(cwd, snapshot);
 	return snapshot;
 }

--- a/clients/project-diagnostics/types.ts
+++ b/clients/project-diagnostics/types.ts
@@ -43,4 +43,10 @@ export interface ProjectDiagnosticsScanOptions {
 	cwd: string;
 	tier: ProjectDiagnosticsTier;
 	maxFiles?: number;
+	/**
+	 * Cancellation for a long full-mode scan (#341). When aborted mid-scan the
+	 * scanner returns a partial snapshot and does NOT persist it, so an
+	 * interrupted run can't poison the cross-session cache.
+	 */
+	signal?: AbortSignal;
 }

--- a/tests/clients/lsp/workspace-diagnostics-exclusion.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-exclusion.test.ts
@@ -127,3 +127,19 @@ describe("LSP workspace-diagnostics cap (#250)", () => {
 		expect(capped.length).toBe(5);
 	});
 });
+
+describe("LSP workspace-diagnostics cancellation (#341)", () => {
+	it("bails the walk immediately when the signal is already aborted", async () => {
+		for (let i = 0; i < 30; i++) write(`src/f${i}.ts`);
+
+		const controller = new AbortController();
+		controller.abort();
+		const files = await __collectWorkspaceDiagnosticFilesForTest(
+			tmpDir,
+			undefined,
+			controller.signal,
+		);
+		// An already-aborted signal short-circuits the walk before it descends.
+		expect(files).toEqual([]);
+	});
+});

--- a/tests/clients/project-diagnostics.test.ts
+++ b/tests/clients/project-diagnostics.test.ts
@@ -241,6 +241,30 @@ describe("scanProjectDiagnostics", () => {
 		expect(result.filesScanned).toBe(2);
 	});
 
+	it("returns a partial snapshot without persisting it when aborted (#341)", async () => {
+		const srcDir = path.join(tmp, "src-abort");
+		fs.mkdirSync(srcDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(srcDir, "ui.ts"),
+			'export function notify() { alert("hi"); }\n',
+		);
+
+		const controller = new AbortController();
+		controller.abort();
+		const result = await scanProjectDiagnostics({
+			cwd: tmp,
+			tier: "cheap",
+			maxFiles: 10,
+			signal: controller.signal,
+		});
+
+		// All phases were skipped (no runners ran) and the partial snapshot was
+		// NOT written to the cross-session cache.
+		expect(result.runners).toEqual([]);
+		expect(result.diagnostics).toEqual([]);
+		expect(loadProjectDiagnosticsSnapshot(tmp)).toBeUndefined();
+	});
+
 	it("runs cheap project scanners and writes a normalized snapshot", async () => {
 		const srcDir = path.join(tmp, "src");
 		fs.mkdirSync(srcDir, { recursive: true });

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -452,7 +452,10 @@ describe("lens_diagnostics mode=full", () => {
 
 		const result = await run(makeTool({}, lspService), { mode: "full" });
 		const text = String(result.content[0].text);
-		expect(lspService.runWorkspaceDiagnostics).toHaveBeenCalledWith("/proj");
+		expect(lspService.runWorkspaceDiagnostics).toHaveBeenCalledWith(
+			"/proj",
+			expect.objectContaining({ signal: expect.anything() }),
+		);
 		expect(text).toContain("edited.ts");
 		expect(text).toContain("cached runner warning");
 		expect(text).toContain("unedited.ts");
@@ -464,6 +467,41 @@ describe("lens_diagnostics mode=full", () => {
 			totalBlocking: 1,
 			totalWarnings: 1,
 		});
+	});
+
+	it("forwards maxLspFiles to the LSP workspace sweep as maxFiles (#341)", async () => {
+		mockSummaries.length = 0;
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]),
+		};
+		await run(makeTool({}, lspService), { mode: "full", maxLspFiles: 200 });
+		expect(lspService.runWorkspaceDiagnostics).toHaveBeenCalledWith(
+			"/proj",
+			expect.objectContaining({ maxFiles: 200 }),
+		);
+	});
+
+	it("threads the abort signal to the LSP sweep and flags partial results (#341)", async () => {
+		mockSummaries.length = 0;
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]),
+		};
+		const controller = new AbortController();
+		controller.abort();
+		const tool = makeTool({}, lspService);
+		const result = await tool.execute(
+			"1",
+			{ mode: "full", maxLspFiles: 50 },
+			controller.signal,
+			null,
+			{ cwd: "/proj" },
+		);
+		const passed = lspService.runWorkspaceDiagnostics.mock.calls[0][1];
+		expect(passed.signal).toBe(controller.signal);
+		expect(passed.signal.aborted).toBe(true);
+		const text = String(result.content[0].text);
+		expect(text).toContain("Scan cancelled before completion");
+		expect(result.details).toMatchObject({ mode: "full", partial: true });
 	});
 
 	it("refreshRunners=cheap scans cheap project runners and merges their cached snapshot", async () => {
@@ -501,11 +539,11 @@ describe("lens_diagnostics mode=full", () => {
 		});
 		const text = String(result.content[0].text);
 		expect(projectDiagnosticsMocks.scanProjectDiagnostics).toHaveBeenCalledWith(
-			{
+			expect.objectContaining({
 				cwd: "/proj",
 				tier: "cheap",
 				maxFiles: 2,
-			},
+			}),
 		);
 		expect(text).toContain("project.ts");
 		expect(text).toContain("project runner warning");

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -43,6 +43,7 @@ const MAX_DIAGNOSTICS_PER_FILE = 50;
 type LSPServiceLike = ReturnType<typeof getLSPService> & {
 	runWorkspaceDiagnostics?: (
 		cwd: string,
+		options?: { maxFiles?: number; signal?: AbortSignal },
 	) => Promise<WorkspaceLspDiagnosticResult[]>;
 };
 
@@ -112,7 +113,13 @@ export function createLensDiagnosticsTool(
 			maxProjectFiles: Type.Optional(
 				Type.Number({
 					description:
-						"mode=full refreshRunners=cheap/all only: cap project files scanned by cheap runners.",
+						"mode=full refreshRunners=cheap/all only: cap project files scanned by the cheap project runners (tree-sitter + fact-rules + ast-grep). Does NOT bound the LSP sweep — use maxLspFiles for that.",
+				}),
+			),
+			maxLspFiles: Type.Optional(
+				Type.Number({
+					description:
+						"mode=full only: cap the number of files routed through the language server for the project-wide LSP sweep. On large projects (e.g. a Next.js app with thousands of source files) the uncapped sweep can take many minutes; set this to bound it. Default is generous (env PI_LENS_LSP_WORKSPACE_MAX_FILES, else 5000).",
 				}),
 			),
 			severity: Type.Optional(
@@ -125,19 +132,19 @@ export function createLensDiagnosticsTool(
 		async execute(
 			_toolCallId: string,
 			params: Record<string, unknown>,
-			_signal: AbortSignal,
+			signal: AbortSignal,
 			_onUpdate: unknown,
 			ctx: { cwd?: string },
 		) {
 			const mode = (params.mode as string | undefined) ?? "delta";
 			const severity = (params.severity as string | undefined) ?? "all";
 			const refreshRunners = params.refreshRunners;
-			const maxProjectFiles =
-				typeof params.maxProjectFiles === "number" &&
-				Number.isFinite(params.maxProjectFiles) &&
-				params.maxProjectFiles > 0
-					? Math.floor(params.maxProjectFiles)
+			const parsePositiveInt = (value: unknown): number | undefined =>
+				typeof value === "number" && Number.isFinite(value) && value > 0
+					? Math.floor(value)
 					: undefined;
+			const maxProjectFiles = parsePositiveInt(params.maxProjectFiles);
+			const maxLspFiles = parsePositiveInt(params.maxLspFiles);
 			const cwd = ctx.cwd ?? getCwd();
 
 			// Reflect the agent's just-made fixes before reporting: flush pending
@@ -154,6 +161,8 @@ export function createLensDiagnosticsTool(
 				return formatFullMode(cwd, severity, getLspService(), {
 					refreshRunners,
 					maxProjectFiles,
+					maxLspFiles,
+					signal,
 				});
 			}
 			return formatDeltaMode(cacheManager, cwd, severity);
@@ -515,13 +524,18 @@ function shouldRefreshProjectDiagnostics(value: unknown): boolean {
 
 async function getProjectDiagnosticsSnapshotForFullMode(
 	cwd: string,
-	options: { refreshRunners?: unknown; maxProjectFiles?: number },
+	options: {
+		refreshRunners?: unknown;
+		maxProjectFiles?: number;
+		signal?: AbortSignal;
+	},
 ): Promise<ProjectDiagnosticsSnapshot | undefined> {
 	if (shouldRefreshProjectDiagnostics(options.refreshRunners)) {
 		return scanProjectDiagnostics({
 			cwd,
 			tier: "cheap",
 			maxFiles: options.maxProjectFiles,
+			signal: options.signal,
 		});
 	}
 	if (shouldUseCachedProjectDiagnostics(options.refreshRunners)) {
@@ -540,7 +554,12 @@ async function formatFullMode(
 	cwd: string,
 	severity: string,
 	lspService: LSPServiceLike,
-	options: { refreshRunners?: unknown; maxProjectFiles?: number } = {},
+	options: {
+		refreshRunners?: unknown;
+		maxProjectFiles?: number;
+		maxLspFiles?: number;
+		signal?: AbortSignal;
+	} = {},
 ): Promise<{ content: [{ type: "text"; text: string }]; details: object }> {
 	const runWorkspaceDiagnostics = lspService.runWorkspaceDiagnostics;
 	if (typeof runWorkspaceDiagnostics !== "function") {
@@ -554,11 +573,16 @@ async function formatFullMode(
 			details: { mode: "full", filesChecked: 0, lspUnavailable: true },
 		};
 	}
+	const { signal } = options;
 	const includeFile = createCurrentIgnoreFilter(cwd);
 	const [rawLspResults, rawProjectSnapshot] = await Promise.all([
-		runWorkspaceDiagnostics.call(lspService, cwd),
+		runWorkspaceDiagnostics.call(lspService, cwd, {
+			maxFiles: options.maxLspFiles,
+			signal,
+		}),
 		getProjectDiagnosticsSnapshotForFullMode(cwd, options),
 	]);
+	const aborted = signal?.aborted ?? false;
 	const lspResults = rawLspResults.filter((result) =>
 		includeFile(result.filePath),
 	);
@@ -578,9 +602,10 @@ async function formatFullMode(
 		projectSnapshot,
 		projectDelta,
 	);
-	return formatAllMode(cwd, severity, summaries, {
+	const result = formatAllMode(cwd, severity, summaries, {
 		mode: "full",
 		lspFilesChecked: rawLspResults.length,
+		partial: aborted,
 		projectDiagnostics:
 			projectSnapshot === undefined
 				? undefined
@@ -599,6 +624,20 @@ async function formatFullMode(
 						turnIndex: projectDelta.turnIndex,
 					},
 	});
+	// Cancelled mid-scan: the results above are whatever completed before the
+	// abort. Tell the agent so it doesn't read a partial sweep as "clean" (#341).
+	if (aborted) {
+		const note =
+			"\n\n⚠ Scan cancelled before completion — results are partial. " +
+			"Re-run with a smaller maxLspFiles to finish within budget.";
+		return {
+			content: [
+				{ type: "text" as const, text: result.content[0].text + note },
+			],
+			details: result.details,
+		};
+	}
+	return result;
 }
 
 function formatAllMode(


### PR DESCRIPTION
## Problem (#341)

`lens_diagnostics mode=full` could grind for ~30 minutes on a large project (the reporter hit it on a Next.js app) and produce no useful result. Two root causes, both confirmed in code:

1. **Uncancellable.** `execute()` received the `AbortSignal` as `_signal` and never passed it into the scan. `formatFullMode` / `runWorkspaceDiagnostics` had no signal, and the worker loop never checked for abort — so a long run could not be interrupted.
2. **The cap didn't bound the LSP sweep.** `maxProjectFiles` flowed only into the cheap project-runner scan (`scanProjectDiagnostics`). The project-wide LSP sweep (`runWorkspaceDiagnostics`) took only `cwd` — its sole bound was the 5000-file safety cap. Up to 5000 files routed through the language server at concurrency 8 with no caller cap is genuinely tens of minutes on a Next.js-scale tree.

The AI analysis on the issue was correct on both points (one nuance: the LSP sweep isn't *unbounded* — it's capped at 5000 — but the reporter had no tool parameter to lower it).

## Fix

- **Thread the `AbortSignal`** from `execute` → `formatFullMode` → `runWorkspaceDiagnostics` (worker loop **and** directory walk) and `scanProjectDiagnostics` (phase boundaries). On abort the already-collected results are returned as a **partial**, and a cancelled cheap scan is **not** persisted to the cross-session cache (so an interrupted run can't poison it).
- **New `maxLspFiles` parameter** that bounds the LSP sweep's file walk, distinct from `maxProjectFiles` (cheap runners). Both parameter descriptions clarified.
- **Partial-result annotation** in full-mode output ("⚠ Scan cancelled before completion — results are partial…") so a truncated sweep isn't mistaken for clean.

This is a **pi-extension-first** fix — the real `AbortSignal` flows through the pi tool path where the hang occurred. The MCP mirror passes a never-aborted signal and picks up the new `maxLspFiles` schema automatically (`schemaWithCwd(lensDiagnosticsTool.parameters)`); no MCP behavior change.

## Tests

- `tests/tools/lens-diagnostics.test.ts` — `maxLspFiles` forwarded to the sweep as `maxFiles`; aborted signal threaded + `partial: true` + cancellation note.
- `tests/clients/lsp/workspace-diagnostics-exclusion.test.ts` — aborted signal short-circuits the file walk.
- `tests/clients/project-diagnostics.test.ts` — aborted scan returns a partial snapshot and does **not** persist it.

Full suite green (266 files, 2528 tests; the one worker-crash on the first run was the known Windows libuv teardown flake in a spawn smoke, green on re-run).

Note: no CHANGELOG entry here — the `[Unreleased]` section is currently dirty with unrelated in-flight work in the shared tree; happy to add one once that settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)