### PR TITLE
feat(read-guard): read_enclosing oversize fallbacks + installer security hardening (refs #345)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ migrate-*.js
 !docs/globalconfig.md
 !docs/language-coverage.md
 !docs/tools.md
+!docs/tools_improvement2.md
 !docs/usage.md
 !docs/lsp-capability-matrix.md
 !docs/lsp-latency-benchmark.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,11 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   `pilens_read_symbol` (one symbol/callback handle's verbatim body). `read_enclosing`
   is the pi agent search/diagnostic → exact-body bridge: given a file+line it
   returns the smallest enclosing symbol/callback body and records read-guard
-  coverage; MCP parity is intentionally deferred until the pi tool surface settles.
+  coverage; if `maxLines` would reject an oversized range, `onOversize:"slice"`
+  returns bounded partial read coverage around the target line while
+  `onOversize:"outline"` returns nested symbol/callback read handles without
+  claiming coverage. MCP parity is intentionally deferred until the pi tool
+  surface settles.
   Wrapped pi tools emit their
   typebox `parameters` as the MCP `inputSchema` (via `schemaWithCwd`) — no
   hand-restated schema to drift.

--- a/clients/lsp/interactive-install.ts
+++ b/clients/lsp/interactive-install.ts
@@ -10,10 +10,10 @@
  * - Only prompts for "common" languages (Go, Rust, YAML, JSON, Bash)
  */
 
-import { spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getProjectDataDir } from "../file-utils.js";
+import { safeSpawnAsync } from "../safe-spawn.js";
 
 function canUseInteractivePrompt(): boolean {
 	return process.stdin.isTTY === true && process.stdout.isTTY === true;
@@ -21,12 +21,11 @@ function canUseInteractivePrompt(): boolean {
 
 async function isToolOnPath(toolId: string): Promise<boolean> {
 	const locator = process.platform === "win32" ? "where" : "which";
-
-	return new Promise((resolve) => {
-		const proc = spawn(locator, [toolId], { stdio: "ignore", shell: false });
-		proc.on("close", (code) => resolve(code === 0));
-		proc.on("error", () => resolve(false));
+	const result = await safeSpawnAsync(locator, [toolId], {
+		timeout: 5000,
+		ignoreAmbientSignal: true,
 	});
+	return result.status === 0;
 }
 
 /**
@@ -306,9 +305,21 @@ function isAutoInstallEnabled(): boolean {
  * Attempt to install a tool using the configured strategy.
  *
  * - "npm":    npm install -g <packageName>
- * - "shell":  run installCommand verbatim via shell (gem, dotnet, brew, etc.)
+ * - "shell":  run the static installCommand as argv (gem, dotnet, brew, etc.)
  * - "manual": can't auto-install — print the command and return false
  */
+export function _parseStaticInstallCommandForTest(
+	command: string,
+): [string, string[]] | undefined {
+	const trimmed = command.trim();
+	// Shell-strategy commands in COMMON_LANGUAGES are deliberately simple static
+	// argv-style commands. Refuse metacharacters instead of routing through
+	// sh/powershell, so this installer path never executes shell text.
+	if (!trimmed || /[;&|<>$`\\\r\n]/.test(trimmed)) return undefined;
+	const [cmd, ...args] = trimmed.split(/\s+/);
+	return cmd ? [cmd, args] : undefined;
+}
+
 async function installTool(config: LanguageConfig): Promise<boolean> {
 	const { installCommand, packageName, installStrategy } = config;
 
@@ -316,28 +327,18 @@ async function installTool(config: LanguageConfig): Promise<boolean> {
 		return false;
 	}
 
-	const [cmd, ...args] =
+	const invocation: [string, string[]] | undefined =
 		installStrategy === "npm" && packageName
-			? ["npm", "install", "-g", packageName]
-			: process.platform === "win32"
-				? ["powershell", "-NoProfile", "-Command", installCommand]
-				: ["sh", "-c", installCommand];
+			? ["npm", ["install", "-g", packageName]]
+			: _parseStaticInstallCommandForTest(installCommand);
+	if (!invocation) return false;
 
-	return new Promise((resolve) => {
-		const proc = spawn(cmd, args, { stdio: "inherit", shell: false });
-
-		proc.on("close", (code) => {
-			if (code === 0) {
-				resolve(true);
-			} else {
-				resolve(false);
-			}
-		});
-
-		proc.on("error", () => {
-			resolve(false);
-		});
+	const [cmd, args] = invocation;
+	const result = await safeSpawnAsync(cmd, args, {
+		timeout: 180000,
+		ignoreAmbientSignal: true,
 	});
+	return result.status === 0;
 }
 
 /**

--- a/clients/module-report.ts
+++ b/clients/module-report.ts
@@ -210,6 +210,16 @@ export interface ReadSymbolResult {
 	source?: string;
 }
 
+export interface ReadEnclosingOutlineItem {
+	name: string;
+	kind: string;
+	startLine: number;
+	endLine: number;
+	signature?: string;
+	parentChain?: string[];
+	read: { path: string; offset: number; limit: number };
+}
+
 export interface ReadEnclosingResult {
 	found: boolean;
 	path: string;
@@ -218,8 +228,17 @@ export interface ReadEnclosingResult {
 	kind?: string;
 	startLine?: number;
 	endLine?: number;
+	enclosingStartLine?: number;
+	enclosingEndLine?: number;
 	signature?: string;
 	parentChain?: string[];
+	partial?: boolean;
+	selection?: {
+		strategy: "range-containment" | "oversize-slice" | "oversize-outline";
+		source: "tree-sitter";
+		confidence: "high" | "medium";
+	};
+	outline?: ReadEnclosingOutlineItem[];
 	error?: string;
 	warnings?: string[];
 	/** The verbatim enclosing body lines — recording this read satisfies the read-guard. */
@@ -229,8 +248,12 @@ export interface ReadEnclosingResult {
 export interface ReadEnclosingOptions {
 	/** Optional semantic kind filter, e.g. function, method, callback, class. */
 	kinds?: string[];
-	/** Optional maximum body size to return. Oversized matches return metadata + error. */
+	/** Optional maximum body size to return. Oversized matches obey onOversize. */
 	maxLines?: number;
+	/** Oversize behavior: error (default), bounded slice, or nested outline. */
+	onOversize?: "error" | "slice" | "outline";
+	/** Maximum lines for onOversize=slice; defaults to maxLines, then 80. */
+	aroundLine?: number;
 }
 
 // kind -> tree-sitter languageId. The languageId keys BOTH the grammar map
@@ -1232,7 +1255,8 @@ const kotlinCallbackRules: CallbackLanguageRules = {
 		const base = classifyGenericCallback(ctx);
 		const call = ancestorOfType(ctx.node, new Set(["call_expression"]), 4);
 		const callee = call?.children?.find(
-			(c) => c.type === "navigation_expression" || c.type === "simple_identifier",
+			(c) =>
+				c.type === "navigation_expression" || c.type === "simple_identifier",
 		);
 		const name = lastCalleeSegment(callee?.text);
 		if (KOTLIN_COROUTINE_BUILDERS.has(name)) {
@@ -1315,8 +1339,7 @@ const csharpCallbackRules: CallbackLanguageRules = {
 		const inv = ancestorOfType(ctx.node, new Set(["invocation_expression"]), 4);
 		if (inv) {
 			const callee = inv.children?.find(
-				(c) =>
-					c.type === "member_access_expression" || c.type === "identifier",
+				(c) => c.type === "member_access_expression" || c.type === "identifier",
 			);
 			const name = lastCalleeSegment(callee?.text);
 			if (/^(?:Run|StartNew|Start)$/.test(name)) {
@@ -1356,7 +1379,9 @@ const CALLBACK_RULES: Record<string, CallbackLanguageRules> = {
 function callbackRulesFor(
 	languageId: string | undefined,
 ): CallbackLanguageRules {
-	return (languageId ? CALLBACK_RULES[languageId] : undefined) ?? jstsCallbackRules;
+	return (
+		(languageId ? CALLBACK_RULES[languageId] : undefined) ?? jstsCallbackRules
+	);
 }
 
 /**
@@ -1725,9 +1750,7 @@ export async function readSymbol(
 			absPath,
 			languageId,
 			callbackWarnings,
-		).find(
-			(candidate) => candidate.name === symbolName,
-		);
+		).find((candidate) => candidate.name === symbolName);
 	} catch (err) {
 		const message = `Callback extraction failed: ${diagnosticMessage(err)}`;
 		logLatency({
@@ -1827,6 +1850,72 @@ function symbolParentChain(
 		)
 		.map((candidate) => candidate.name);
 	return chain.length > 0 ? chain : undefined;
+}
+
+function clampSliceRange(
+	targetLine: number,
+	startLine: number,
+	endLine: number,
+	limit: number,
+): { startLine: number; endLine: number } {
+	const boundedLimit = Math.max(1, Math.min(endLine - startLine + 1, limit));
+	let sliceStart = targetLine - Math.floor(boundedLimit / 2);
+	sliceStart = Math.max(
+		startLine,
+		Math.min(sliceStart, endLine - boundedLimit + 1),
+	);
+	return { startLine: sliceStart, endLine: sliceStart + boundedLimit - 1 };
+}
+
+function enclosingOutline(
+	selected: EnclosingCandidate,
+	symbols: ExtractedSymbol[],
+	callbacks: ModuleCallbackEntry[],
+	filters: Set<string>,
+	filePath: string,
+): ReadEnclosingOutlineItem[] {
+	const items: ReadEnclosingOutlineItem[] = [];
+	for (const sym of symbols) {
+		const startLine = sym.line;
+		const endLine = sym.endLine ?? sym.line;
+		if (startLine === selected.startLine && endLine === selected.endLine)
+			continue;
+		if (startLine < selected.startLine || endLine > selected.endLine) continue;
+		if (!symbolMatchesKind(sym.kind, filters)) continue;
+		items.push({
+			name: sym.name,
+			kind: sym.kind,
+			startLine,
+			endLine,
+			signature: sym.signature,
+			parentChain: symbolParentChain(sym, symbols),
+			read: readArgsFor(filePath, startLine, endLine),
+		});
+	}
+	for (const callback of callbacks) {
+		if (
+			callback.startLine < selected.startLine ||
+			callback.endLine > selected.endLine
+		)
+			continue;
+		if (!callbackMatchesKind(callback.kind, filters)) continue;
+		items.push({
+			name: callback.name,
+			kind: callback.kind,
+			startLine: callback.startLine,
+			endLine: callback.endLine,
+			signature: callback.signature,
+			parentChain: callback.parentChain,
+			read: callback.read,
+		});
+	}
+	return items
+		.sort(
+			(a, b) =>
+				a.startLine - b.startLine ||
+				a.endLine - a.startLine - (b.endLine - b.startLine),
+		)
+		.slice(0, 25);
 }
 
 /**
@@ -1959,9 +2048,8 @@ export async function readEnclosing(
 	const lines = content.split(/\r?\n/);
 	const limit = selected.endLine - selected.startLine + 1;
 	if (options?.maxLines && limit > options.maxLines) {
-		log(false);
-		return {
-			found: false,
+		const oversize = options.onOversize ?? "error";
+		const base = {
 			path: absPath,
 			line: targetLine,
 			name: selected.name,
@@ -1970,8 +2058,62 @@ export async function readEnclosing(
 			endLine: selected.endLine,
 			signature: selected.signature,
 			parentChain: selected.parentChain,
-			error: `Enclosing ${selected.kind} spans ${limit} lines, above maxLines ${options.maxLines}`,
+			enclosingStartLine: selected.startLine,
+			enclosingEndLine: selected.endLine,
 			...(warnings.length > 0 ? { warnings } : {}),
+		};
+		if (oversize === "slice") {
+			const sliceLimit = Math.max(
+				1,
+				Math.floor(options.aroundLine ?? options.maxLines ?? 80),
+			);
+			const slice = clampSliceRange(
+				targetLine,
+				selected.startLine,
+				selected.endLine,
+				sliceLimit,
+			);
+			const source = lines.slice(slice.startLine - 1, slice.endLine).join("\n");
+			log(true);
+			return {
+				...base,
+				found: true,
+				startLine: slice.startLine,
+				endLine: slice.endLine,
+				partial: true,
+				selection: {
+					strategy: "oversize-slice",
+					source: "tree-sitter",
+					confidence: "medium",
+				},
+				source,
+			};
+		}
+		if (oversize === "outline") {
+			log(false);
+			return {
+				...base,
+				found: false,
+				selection: {
+					strategy: "oversize-outline",
+					source: "tree-sitter",
+					confidence: "medium",
+				},
+				outline: enclosingOutline(
+					selected,
+					symbols,
+					callbacks,
+					filters,
+					absPath,
+				),
+				error: `Enclosing ${selected.kind} spans ${limit} lines, above maxLines ${options.maxLines}`,
+			};
+		}
+		log(false);
+		return {
+			...base,
+			found: false,
+			error: `Enclosing ${selected.kind} spans ${limit} lines, above maxLines ${options.maxLines}`,
 		};
 	}
 	const source = lines
@@ -1986,8 +2128,15 @@ export async function readEnclosing(
 		kind: selected.kind,
 		startLine: selected.startLine,
 		endLine: selected.endLine,
+		enclosingStartLine: selected.startLine,
+		enclosingEndLine: selected.endLine,
 		signature: selected.signature,
 		parentChain: selected.parentChain,
+		selection: {
+			strategy: "range-containment",
+			source: "tree-sitter",
+			confidence: "high",
+		},
 		...(warnings.length > 0 ? { warnings } : {}),
 		source,
 	};

--- a/docs/tools_improvement2.md
+++ b/docs/tools_improvement2.md
@@ -1,0 +1,345 @@
+# Tool improvement proposals — round 2
+
+These notes come from dogfooding the current registered tools on the pi-lens codebase. They focus on language-agnostic ergonomics and usefulness, not TypeScript-specific behavior.
+
+## Guiding direction
+
+The tools are most useful as a progressive workflow:
+
+1. Use a compact structural overview to orient.
+2. Return ranked read handles, not huge bodies by default.
+3. Expand only the exact symbol, callback, or block needed.
+4. Make section-level provenance explicit so agents do not over-trust heuristic or cache-backed sections.
+
+## Review calibration
+
+A follow-up review separated genuinely new work from things that are already shipped or redundant:
+
+- Already shipped / do not rebuild: `module_report.focus` ranking, `recommendedReads`, `ast_grep_search` `searchReads` / `matchLocations`, and baseline cold-cache signals via `semantic.source` / `staleness`.
+- Prefer existing robust handles over new ordinal syntax: `foo@line` callback/symbol handles are better than proposed `foo#2` duplicate-name ordinals because line handles do not silently shift meaning by insertion order.
+- Avoid per-flag provenance objects. They would multiply JSON size and conflict with the goal of compact reports. Use section-level provenance instead.
+- Treat automatic AST-pattern suggestion as deferred. `validateOnly` plus better no-match classification is the sound first step.
+
+## `module_report`
+
+### What works well
+
+- Good first-pass map of a module.
+- Top-level API/internal split is useful for understanding the file shape.
+- Imports, who-uses-this, recommended reads, callback handles, and blast radius are valuable in combination.
+- The `recommendedReads` section is the most agent-actionable part of the report.
+
+### Weaknesses observed
+
+- Large modules can produce too much JSON.
+- Complexity/fanout flags are informative but not always directly actionable.
+- Callback and risk flags are heuristic; they need visible provenance/confidence.
+- Cold-cache degradation is easy to miss unless the caller inspects `semantic.source` carefully.
+- A report is shape, not body; agents still need `read_symbol` / `read_enclosing` before editing.
+
+### Proposed improvements
+
+#### Output tiers
+
+Add an explicit `detail` / `view` option:
+
+- `summary`: path, language, imports count, exports, top-level symbols, recommended reads only.
+- `default`: current compact report, capped sections.
+- `deep`: callbacks, usedBy, blast radius, risk flags, full member lists.
+
+Default should optimize for the next action, not exhaustive metadata.
+
+#### Stronger filtering
+
+Add filters that reduce output before serialization:
+
+- `symbols: string[]`
+- `kinds: string[]`
+- `maxItems`
+- `maxCallbacks`
+- `maxUsedBy`
+- `changedOnly` when diff/turn context is available
+
+#### Recommended reads first
+
+Consider returning `recommendedReads` near the top of the JSON and making it the primary default payload. Each recommendation should include a concise reason such as:
+
+- exported entrypoint
+- used by changed file
+- contains callback
+- high fanout
+- matches focus terms
+- blast-radius target
+
+#### Section-level provenance
+
+Separate hard facts from heuristics without inflating every flag. Add compact provenance at the section level, for example:
+
+```json
+{
+  "provenance": {
+    "symbols": "syntax",
+    "usedBy": "cached-review-graph",
+    "callbacks": "heuristic-tree-sitter",
+    "blastRadius": "cached-review-graph"
+  }
+}
+```
+
+This gives most of the honesty benefit at low payload cost.
+
+#### Cold-cache clarity
+
+When graph-backed sections are unavailable, include a short `degraded` note naming what is missing and why. Example:
+
+```json
+{
+  "degraded": ["usedBy omitted: review graph cache is cold"]
+}
+```
+
+#### Fold edit planning into `recommendedReads`
+
+Do not add a parallel `editPlan` mode. It would duplicate `recommendedReads`. Instead, make `recommendedReads` consistently carry the missing edit-plan information: read args, symbol/callback handle, reason, and source/provenance.
+
+## `read_enclosing`
+
+### What works well
+
+- Excellent bridge from diagnostics/search locations to exact source.
+- The `maxLines` guard prevents accidental huge reads.
+- Parent chain and callback support make it better than raw line slicing.
+
+### Weaknesses observed
+
+- If the enclosing symbol is huge, the tool either returns too much or refuses.
+- Line accuracy matters; a stale line can select the wrong scope or no scope.
+- The “smallest useful” enclosing unit can still be a very large factory/function/class.
+- It mostly reasons over named symbols/callbacks; useful block-level structures are not always surfaced.
+
+### Proposed improvements
+
+#### Oversize fallback modes
+
+Add an option:
+
+```text
+onOversize: "error" | "slice" | "outline"
+```
+
+- `error`: current behavior.
+- `slice`: return a bounded region around the target line inside the large enclosing symbol, plus the enclosing signature and parent chain.
+- `outline`: return nested child blocks/callbacks/symbols within the oversized range, with read handles.
+
+#### `aroundLine` mode
+
+Support bounded contextual reads without pretending to read the entire enclosing symbol:
+
+```json
+{
+  "line": 328,
+  "aroundLine": 40,
+  "includeHeader": true
+}
+```
+
+The response should clearly state that it is a partial slice and include the enclosing range.
+
+#### Generic block units
+
+Surface language-uniform structural blocks when no smaller named symbol/callback exists:
+
+- conditional
+- loop
+- try/catch/finally
+- switch/match/case
+- closure/lambda
+- object/dictionary method/property callback
+
+Keep the external schema generic even if internal tree-sitter node kinds differ by language.
+
+#### Sibling navigation hints
+
+When returning an enclosing range, include nearby siblings:
+
+- previous symbol/block
+- next symbol/block
+- nearest child block containing the line
+
+This helps agents decide whether to expand or narrow.
+
+#### Selection provenance
+
+Include why the tool selected that range:
+
+```json
+{
+  "selection": {
+    "strategy": "range-containment",
+    "source": "tree-sitter",
+    "confidence": "high"
+  }
+}
+```
+
+## `read_symbol`
+
+### What works well
+
+- Good exact-body read for a known symbol or callback handle.
+- Pairs well with `module_report`.
+- Read-guard integration makes it operationally useful, not just informational.
+
+### Proposed improvements
+
+- Add fuzzy suggestions when a symbol is not found: nearest names, same prefix, same kind.
+- Add `includeParents: true` to include containing class/object/module headers without full parent bodies.
+- Add `maxLines` and the same `onOversize` options as `read_enclosing`.
+- Do not add ordinal duplicate syntax such as `symbol: "foo#2"`; prefer stable line-based handles such as `foo@120` where disambiguation is needed.
+
+## `ast_grep_search`
+
+### What works well
+
+- Very useful for structural verification and targeted refactors.
+- Raw YAML passthrough and structural-intent options are powerful.
+- `searchReads` / match locations make follow-up edits easier.
+- Good for proving that a specific construct remains or was removed.
+
+### Weaknesses observed
+
+- It is easy to over-specify a pattern and get false “no matches”.
+- “No matches” is hard to interpret unless the pattern is known-good.
+- AST grammar knowledge is still required.
+- Broad patterns can produce large, noisy output.
+- Selector usage can confuse agents because it narrows search roots but does not extract fields.
+
+### Proposed improvements
+
+#### Explain no-match confidence
+
+On zero matches, classify the likely cause:
+
+- valid pattern, searched files, no matches
+- pattern looks too specific
+- possible grammar mismatch
+- selector may be over-narrowing
+- language/path mismatch
+
+Include the exact CLI/search mode used.
+
+#### Defer automatic pattern rewriting
+
+Automatic generation of simpler AST pattern variants is high-risk across languages and grammars. Defer it until `validateOnly` and no-match classification have proven insufficient. Static cookbook hints are safer than generated rewrites.
+
+#### Optional pattern validation mode
+
+Add `validateOnly: true` to parse/compile the pattern or rule without scanning files. This helps distinguish “bad pattern” from “real absence”.
+
+#### Better result caps
+
+Expose:
+
+- `maxMatches`
+- `maxBytes`
+- `groupByFile`
+- `includeCaptures: boolean`
+
+For large results, default to grouped counts plus first few examples.
+
+#### Pattern cookbook hints
+
+When a user provides plain text or an incomplete pattern, return examples tailored to the broad syntactic category:
+
+- import
+- call
+- function/method declaration
+- assignment
+- class/type declaration
+
+These categories are language-agnostic at the tool UX level even if implementation varies by grammar.
+
+## `ast_grep_outline`
+
+### What works well
+
+- Fast syntax-only second opinion.
+- Useful when `module_report` is too semantic or graph-dependent.
+- Good for checking exports/imports without reading entire files.
+
+### Proposed improvements
+
+- Add `maxItems` and `maxDepth` options.
+- Add `includePrivate` / `visibility` normalization where grammars support it.
+- Add a `summary` view that returns counts and top-level names only.
+- Add a `constants: "omit" | "names" | "full"`-style control. Large table/object constants can dominate an otherwise useful outline.
+- Keep `items: "exports"` prominent in the docs; it is much more usable than `items: "all"` on configuration-heavy modules.
+- Include a clear `syntaxOnly: true` and “does not satisfy read guard” note in the main text, not only details.
+
+## `ast_grep_dump` / `ast_dump`
+
+### What works well
+
+- Essential escape hatch when search patterns fail.
+- Helps agents inspect node kinds and nesting.
+
+### Proposed improvements
+
+- Add `focus` / `line` / `range` options so dumping a large snippet can be narrowed.
+- Add `namedOnly` alias for `includeAnonymous: false` for clearer UX.
+- Add “suggested patterns” from selected AST nodes, e.g. turning a node into a simple `$X` pattern.
+
+## `ast_grep_replace`
+
+### What works well
+
+- Dry-run default is the right safety choice.
+- Structural-intent options make complex replacements more approachable.
+
+### Proposed improvements
+
+- Require or strongly warn when `paths` is omitted.
+- Add `maxReplacements` for safety.
+- Add `confirmToken` or preview hash for apply-after-preview workflows, so stale previews are less likely.
+- In dry-run output, include a concise summary by file before full hunks.
+
+## `lsp_navigation`
+
+### What works well
+
+- Excellent for references, hover, symbol search, and capabilities.
+- Structured JSON envelope is useful.
+- `searchReads` integration is valuable.
+
+### Proposed improvements
+
+- Add compact default output for large reference lists and document symbols, with `maxResults` across all location-returning operations.
+- Add symbol-kind filters to `documentSymbol`; unfiltered output can be overwhelmed by local variables and object-property entries.
+- Add `includeContainers` / `topLevelOnly` consistently across symbol-returning operations.
+- Include confidence/provenance when a fallback is used.
+- Make unsupported operations more actionable: “server X does not support Y; try ast_grep_search/module_report instead.”
+- For `references`, distinguish “definition only” / “possibly incomplete” from a confident full reference set. A one-result response is technically correct but easy to over-trust.
+- For `codeAction`, include whether diagnostics were present at the requested range; an empty result is more useful if it says “no diagnostic at range” vs “server has no quickfix.”
+- For rename previews, the current summary is useful; consider adding a `filesTouched` / `editsCount` top-level summary for easier scanning.
+
+## `lsp_diagnostics` and `lens_diagnostics`
+
+### What works well
+
+- `lsp_diagnostics` is good for file-scoped type/error checks before builds.
+- `lens_diagnostics` is valuable because it includes non-LSP runners.
+
+### Proposed improvements
+
+- Make stale/omitted files more prominent.
+- For full scans, include a warning when caps mean the result is partial.
+- Add `paths` to `lens_diagnostics` for focused runner-backed diagnostics, not only session/full modes.
+- Separate “new from this turn” vs “pre-existing” more explicitly.
+
+## Suggested priority
+
+1. `read_enclosing onOversize: "slice" | "outline"` — biggest observed pain; can reuse existing symbol/callback/block outline machinery.
+2. `ast_grep_search validateOnly` — cheap, sound way to distinguish invalid pattern/rule from genuine absence.
+3. `module_report view: "summary"` plus section-level provenance — make the report leaner and more honest in one pass.
+4. Result caps and filters where output is currently high-volume: `ast_grep_search maxMatches/maxBytes/groupByFile` and `lsp_navigation documentSymbol` `maxResults` / kind filters.
+5. `read_enclosing` generic block units and selection provenance — useful, but scope carefully so the tool does not select a nested block when the caller wanted the enclosing method/function.

--- a/tests/clients/lsp/interactive-install.test.ts
+++ b/tests/clients/lsp/interactive-install.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+	_parseStaticInstallCommandForTest,
 	getInstallCommand,
 	getInstallStrategy,
 	supportsInteractiveInstall,
@@ -128,6 +129,26 @@ describe("install strategy", () => {
 // ---------------------------------------------------------------------------
 
 describe("install commands are descriptive", () => {
+	it("parses shell-strategy commands as argv without a shell", () => {
+		expect(
+			_parseStaticInstallCommandForTest(
+				"go install golang.org/x/tools/gopls@latest",
+			),
+		).toEqual(["go", ["install", "golang.org/x/tools/gopls@latest"]]);
+		expect(
+			_parseStaticInstallCommandForTest("nix profile install nixpkgs#nixd"),
+		).toEqual(["nix", ["profile", "install", "nixpkgs#nixd"]]);
+	});
+
+	it("rejects commands that need shell interpretation", () => {
+		expect(
+			_parseStaticInstallCommandForTest(
+				"curl https://example.test/install.sh | sh",
+			),
+		).toBeUndefined();
+		expect(_parseStaticInstallCommandForTest("echo $(whoami)")).toBeUndefined();
+	});
+
 	it("shell-strategy commands are runnable (not URLs or comments)", () => {
 		const shellLangs = ["go", "rust", "ruby", "csharp", "fsharp", "gleam"];
 		for (const lang of shellLangs) {

--- a/tests/clients/module-report.test.ts
+++ b/tests/clients/module-report.test.ts
@@ -255,7 +255,11 @@ describe("moduleReport — outline + structure", () => {
 			"support.go",
 			"package main\nfunc run() {}\n",
 		);
-		const py = createTempFile(env.tmpDir, "support.py", "def run():\n    pass\n");
+		const py = createTempFile(
+			env.tmpDir,
+			"support.py",
+			"def run():\n    pass\n",
+		);
 		const rs = createTempFile(env.tmpDir, "support.rs", "fn run() {}\n");
 		const rb = createTempFile(env.tmpDir, "support.rb", "def run\nend\n");
 
@@ -977,6 +981,67 @@ describe("readEnclosing — search/diagnostic line to exact body", () => {
 		expect(result.found).toBe(false);
 		expect(result.name).toBe("big");
 		expect(result.error).toContain("above maxLines 2");
+		expect(result.source).toBeUndefined();
+	});
+
+	it("can return a bounded slice when the enclosing body is oversized", async () => {
+		const env = makeEnv();
+		const file = createTempFile(
+			env.tmpDir,
+			"big-slice.ts",
+			[
+				"export function big() {",
+				"  const a = 1;",
+				"  const b = 2;",
+				"  const c = 3;",
+				"  return a + b + c;",
+				"}",
+			].join("\n"),
+		);
+
+		const result = await readEnclosing(file, 4, env.tmpDir, {
+			maxLines: 2,
+			onOversize: "slice",
+			aroundLine: 3,
+		});
+
+		expect(result.found).toBe(true);
+		expect(result.partial).toBe(true);
+		expect(result.name).toBe("big");
+		expect(result.startLine).toBe(3);
+		expect(result.endLine).toBe(5);
+		expect(result.enclosingStartLine).toBe(1);
+		expect(result.enclosingEndLine).toBe(6);
+		expect(result.selection?.strategy).toBe("oversize-slice");
+		expect(result.source).toContain("const c = 3");
+		expect(result.source).not.toContain("export function big");
+	});
+
+	it("can return a nested outline when the enclosing body is oversized", async () => {
+		const env = makeEnv();
+		const file = createTempFile(
+			env.tmpDir,
+			"big-outline.ts",
+			[
+				"export function big() {",
+				"  function nested() {",
+				"    return 1;",
+				"  }",
+				"  return nested();",
+				"}",
+			].join("\n"),
+		);
+
+		const result = await readEnclosing(file, 5, env.tmpDir, {
+			maxLines: 2,
+			onOversize: "outline",
+		});
+
+		expect(result.found).toBe(false);
+		expect(result.name).toBe("big");
+		expect(result.selection?.strategy).toBe("oversize-outline");
+		expect(result.outline?.map((item) => item.name)).toContain("nested");
+		expect(result.outline?.[0]?.read).toMatchObject({ offset: 2, limit: 3 });
 		expect(result.source).toBeUndefined();
 	});
 });

--- a/tests/tools/module-report.test.ts
+++ b/tests/tools/module-report.test.ts
@@ -172,6 +172,58 @@ describe("read_enclosing tool", () => {
 			env.cleanup();
 		}
 	});
+
+	it("returns and records a partial slice for oversized enclosing ranges", async () => {
+		const env = setupTestEnvironment("pi-lens-readenc-tool-");
+		try {
+			createTempFile(
+				env.tmpDir,
+				"sample.ts",
+				"export function big() {\n  const a = 1;\n  const b = 2;\n  const c = 3;\n  return a + b + c;\n}\n",
+			);
+			const recorded: Recorded[] = [];
+			const tool = createReadEnclosingTool(
+				() => env.tmpDir,
+				(filePath, symbol) => recorded.push({ filePath, symbol }),
+			);
+
+			const result = await tool.execute(
+				"read-enclosing",
+				{
+					path: "sample.ts",
+					line: 4,
+					maxLines: 2,
+					onOversize: "slice",
+					aroundLine: 3,
+				},
+				undefined,
+				null,
+				{ cwd: env.tmpDir },
+			);
+
+			expect(result.isError).toBeUndefined();
+			expect(String(result.content[0]?.text)).toContain("partial of 1-6");
+			expect(String(result.content[0]?.text)).not.toContain(
+				"export function big",
+			);
+			expect(result.details).toMatchObject({
+				found: true,
+				partial: true,
+				startLine: 3,
+				endLine: 5,
+				enclosingStartLine: 1,
+				enclosingEndLine: 6,
+				readRecorded: true,
+			});
+			expect(recorded[0].symbol).toMatchObject({
+				name: "big",
+				startLine: 3,
+				endLine: 5,
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
 });
 
 describe("read_symbol tool", () => {

--- a/tools/module-report.ts
+++ b/tools/module-report.ts
@@ -293,7 +293,20 @@ export function createReadEnclosingTool(
 			maxLines: Type.Optional(
 				Type.Number({
 					description:
-						"Optional maximum body size to return. Oversized matches return metadata plus an error instead of source.",
+						"Optional maximum body size to return. Oversized matches obey onOversize.",
+				}),
+			),
+			onOversize: Type.Optional(
+				Type.String({
+					enum: ["error", "slice", "outline"],
+					description:
+						"Behavior when the enclosing body exceeds maxLines. error (default) returns metadata only; slice returns a bounded partial read around line; outline returns nested symbols/callbacks with read handles.",
+				}),
+			),
+			aroundLine: Type.Optional(
+				Type.Number({
+					description:
+						"Maximum lines for onOversize=slice; defaults to maxLines, then 80.",
 				}),
 			),
 		}),
@@ -304,6 +317,8 @@ export function createReadEnclosingTool(
 				line: number;
 				kinds?: string[];
 				maxLines?: number;
+				onOversize?: "error" | "slice" | "outline";
+				aroundLine?: number;
 			},
 			_signal: AbortSignal | undefined,
 			_onUpdate: unknown,
@@ -316,6 +331,8 @@ export function createReadEnclosingTool(
 				result = await readEnclosing(absFile, params.line, cwd, {
 					kinds: params.kinds,
 					maxLines: params.maxLines,
+					onOversize: params.onOversize,
+					aroundLine: params.aroundLine,
 				});
 			} catch (err) {
 				return {
@@ -333,8 +350,11 @@ export function createReadEnclosingTool(
 				const warningSuffix = result.warnings?.length
 					? ` Warnings: ${result.warnings.join("; ")}`
 					: "";
+				const outlineSuffix = result.outline?.length
+					? `\n\nNested outline:\n${JSON.stringify(result.outline)}`
+					: "";
 				const text = result.error
-					? `Could not read enclosing range in ${path.basename(absFile)}:${result.line}: ${result.error}${warningSuffix}`
+					? `Could not read enclosing range in ${path.basename(absFile)}:${result.line}: ${result.error}${warningSuffix}${outlineSuffix}`
 					: `No enclosing symbol/callback found in ${path.basename(absFile)}:${result.line}.${warningSuffix}`;
 				return {
 					content: [{ type: "text" as const, text }],
@@ -346,6 +366,14 @@ export function createReadEnclosingTool(
 						...(result.kind ? { kind: result.kind } : {}),
 						...(result.startLine ? { startLine: result.startLine } : {}),
 						...(result.endLine ? { endLine: result.endLine } : {}),
+						...(result.enclosingStartLine
+							? { enclosingStartLine: result.enclosingStartLine }
+							: {}),
+						...(result.enclosingEndLine
+							? { enclosingEndLine: result.enclosingEndLine }
+							: {}),
+						...(result.selection ? { selection: result.selection } : {}),
+						...(result.outline ? { outline: result.outline } : {}),
 						...(result.error ? { error: result.error } : {}),
 						...(result.warnings ? { warnings: result.warnings } : {}),
 					},
@@ -356,7 +384,10 @@ export function createReadEnclosingTool(
 				result,
 				"read_enclosing_guard_error",
 			);
-			const header = `${result.kind} ${result.name}  ${path.basename(result.path)}:${result.startLine}-${result.endLine}`;
+			const range = result.partial
+				? `${result.startLine}-${result.endLine} (partial of ${result.enclosingStartLine}-${result.enclosingEndLine})`
+				: `${result.startLine}-${result.endLine}`;
+			const header = `${result.kind} ${result.name}  ${path.basename(result.path)}:${range}`;
 			const guardWarning = readRecorded
 				? ""
 				: "\n\nWarning: read coverage recording failed; the returned body may not satisfy the edit guard.";
@@ -374,7 +405,11 @@ export function createReadEnclosingTool(
 					line: result.line,
 					startLine: result.startLine,
 					endLine: result.endLine,
+					enclosingStartLine: result.enclosingStartLine,
+					enclosingEndLine: result.enclosingEndLine,
 					parentChain: result.parentChain,
+					partial: result.partial,
+					selection: result.selection,
 					readRecorded,
 					...(result.warnings ? { warnings: result.warnings } : {}),
 				},


### PR DESCRIPTION
First slice of the calibrated round-2 agent-tool ergonomics work (#345), plus an incidental security hardening found along the way. Branches off the just-merged tool-ergonomics work.

## 1. `read_enclosing` oversize fallbacks (priority #1) — `feat(read-guard)`
When an enclosing symbol/callback exceeds `maxLines`, the tool previously returned metadata + an error and nothing readable. Adds `onOversize`:

- **`slice`** — a bounded region centered on the target line (`partial: true`), recording read-guard coverage for exactly the lines returned.
- **`outline`** — nested symbols/callbacks within the oversized range, each with a ready-to-use `read` handle (shape only, no coverage claimed).
- **`error`** — unchanged default.

Also stamps **selection provenance** (`{strategy, source, confidence}`) on every result. Reuses the `module_report` member-nesting + read-arg machinery.

## 2. Installer security hardening — `fix(security)`
The interactive LSP installer ran shell-strategy `installCommand`s verbatim via `sh -c` / `powershell -Command`. Replaced with `safeSpawnAsync` over a static argv parser that **refuses shell metacharacters**; the PATH probe (`which`/`where`) also routes through `safeSpawnAsync`. No installer path executes shell text now. (References #345 per the single-issue directive; can be spun into its own `area:security` issue if independent tracking is wanted.)

## 3. Round-2 plan doc — `docs(tools)`
Tracks `docs/tools_improvement2.md` (gitignore docs-allowlist negation) with the calibrated proposals.

## Validation
- `npm run build` clean, `npm run lint` (tsc) clean
- Full suite: **2557 passed | 1 skipped** (270 files)
- New tests cover slice, outline, the slice read-guard recording path, and the no-shell argv parser (accepts static commands, rejects metacharacters)

Refs #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
