### PR TITLE
fix(lsp): bound pull-diagnostics request so a hung server can't hang the flush

### DIFF
--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -388,6 +388,16 @@ const PULL_DIAGNOSTICS_RETRY_INTERVAL_MS = positiveIntFromEnv(
 	"PI_LENS_LSP_PULL_RETRY_INTERVAL_MS",
 	250,
 );
+// Per-request ceiling for pull diagnostics (textDocument/diagnostic), mirroring
+// NAV_REQUEST_TIMEOUT_MS. safeSendRequest only settles on a reply or a *destroyed*
+// stream, so a pull-mode server that is alive but hung (accepts the request, never
+// replies) would await forever — hanging clientWaitForDiagnostics and, upstream,
+// the diagnostics flush. On timeout the request is treated as `unavailable`, which
+// (per #240) is NOT read as clean and falls through to the bounded push backstop.
+const PULL_REQUEST_TIMEOUT_MS = positiveIntFromEnv(
+	"PI_LENS_LSP_PULL_REQUEST_TIMEOUT_MS",
+	10_000,
+);
 const SHUTDOWN_REQUEST_TIMEOUT_MS = positiveIntFromEnv(
 	"PI_LENS_LSP_SHUTDOWN_TIMEOUT_MS",
 	1000,
@@ -929,15 +939,24 @@ type PullDiagnosticsOutcome =
 async function clientRequestPullDiagnostics(
 	state: LSPClientState,
 	filePath: string,
+	budgetMs: number = PULL_REQUEST_TIMEOUT_MS,
 ): Promise<PullDiagnosticsOutcome> {
 	if (!isClientAlive(state)) return { status: "unavailable" };
 	const uri = pathToFileURL(filePath).href;
 	try {
-		const report = await safeSendRequest<{
-			kind?: string;
-			items?: LSPDiagnostic[];
-			relatedDocuments?: Record<string, { items?: LSPDiagnostic[] }>;
-		}>(state.connection, "textDocument/diagnostic", { textDocument: { uri } });
+		// withTimeout is the backstop against a hung pull-mode server: without it
+		// this await never settles unless the stream is destroyed. Bounded by the
+		// smaller of the absolute ceiling and the caller's remaining wait budget.
+		// On timeout the caught error yields `unavailable` below (never a false
+		// `clean`), so it falls through to the push-wait/timeout backstop.
+		const report = await withTimeout(
+			safeSendRequest<{
+				kind?: string;
+				items?: LSPDiagnostic[];
+				relatedDocuments?: Record<string, { items?: LSPDiagnostic[] }>;
+			}>(state.connection, "textDocument/diagnostic", { textDocument: { uri } }),
+			Math.max(1, Math.min(PULL_REQUEST_TIMEOUT_MS, budgetMs)),
+		);
 
 		if (!report) return { status: "unavailable" };
 
@@ -1010,7 +1029,7 @@ export async function clientWaitForDiagnostics(
 		// `hasFreshDiagnostics()`, which is unconditionally true when there is no
 		// version baseline (`minVersion === undefined`), so a failed pull returned
 		// 0 and was read as a fresh clean.
-		let outcome = await clientRequestPullDiagnostics(state, filePath);
+		let outcome = await clientRequestPullDiagnostics(state, filePath, timeoutMs);
 		if (outcome.status === "found") return;
 		let sawClean = outcome.status === "clean";
 
@@ -1028,7 +1047,11 @@ export async function clientWaitForDiagnostics(
 			await new Promise((resolve) =>
 				setTimeout(resolve, PULL_DIAGNOSTICS_RETRY_INTERVAL_MS),
 			);
-			outcome = await clientRequestPullDiagnostics(state, filePath);
+			outcome = await clientRequestPullDiagnostics(
+				state,
+				filePath,
+				Math.max(0, retryBudgetMs - (Date.now() - startedAt)),
+			);
 			if (outcome.status === "clean") sawClean = true;
 		}
 		if (outcome.status === "found" || sawClean) return;

--- a/tests/clients/lsp/client-internals.test.ts
+++ b/tests/clients/lsp/client-internals.test.ts
@@ -530,6 +530,25 @@ describe("clientWaitForDiagnostics — pull mode (#240)", () => {
 		await clientWaitForDiagnostics(state, TEST_FILE, 120);
 		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
 	});
+
+	it("bounds a hung pull request instead of hanging forever", async () => {
+		const state = pullState();
+		// A pull-mode server that accepts textDocument/diagnostic but NEVER
+		// replies (stream stays alive). safeSendRequest only settles on a reply or
+		// a destroyed stream, so pre-fix this await never resolves and hangs the
+		// whole diagnostics wait (→ pipeline → flush → lens_diagnostics). The
+		// per-request withTimeout must bound it: time out → unavailable → fall
+		// through to the push backstop and resolve within the caller's budget.
+		state.connection.sendRequest = vi.fn(() => new Promise<never>(() => {}));
+
+		const start = Date.now();
+		await clientWaitForDiagnostics(state, TEST_FILE, 120);
+		const elapsed = Date.now() - start;
+		// Went through the timeout→backstop path (not a false early clean)...
+		expect(elapsed).toBeGreaterThanOrEqual(100);
+		// ...and did NOT hang on the never-resolving request.
+		expect(elapsed).toBeLessThan(2000);
+	});
 });
 
 describe("applyDynamicCapabilities", () => {


### PR DESCRIPTION
## Summary

Fixes the **root cause** behind the unbounded `lens_diagnostics` flush that PR #349 works around at the tool boundary.

The pull path in `clientWaitForDiagnostics` awaits `clientRequestPullDiagnostics` → `safeSendRequest("textDocument/diagnostic")` **directly**, and `safeSendRequest` only settles on a reply or a *destroyed* stream (`isStreamError`). A pull-mode server that is **alive but hung** — accepts the request, never replies, stream stays open — makes that `await` never resolve. That hangs the diagnostics wait → the `dispatch_lint` pipeline phase → `flushDebouncedToolResults` → `lens_diagnostics`, forever.

## Why the existing bounds miss it

- Unlike the navigation / init / shutdown callers, this request had **no `withTimeout` ceiling**.
- The `timeoutMs` passed into `clientWaitForDiagnostics` only bounds the *push* backstop and the pull *retry interval* — never the individual pull request. The retry guard `Date.now() - startedAt < retryBudgetMs` is checked *between* awaits, so a single hung request is never interrupted.
- `safeSpawnAsync`'s 30 s cap doesn't apply — this is a pipe request, not a spawn.

This also explains the intermittent repro noted in #349: it only fires for pull-mode servers (rust-analyzer is the classic) when the server stalls mid-analysis.

## Fix

Wrap the pull request in the **existing** `withTimeout` helper, bounded by `min(PULL_REQUEST_TIMEOUT_MS, remaining caller budget)` (new env-configurable constant `PI_LENS_LSP_PULL_REQUEST_TIMEOUT_MS`, default 10 s — mirrors `NAV_REQUEST_TIMEOUT_MS`). On timeout the request is caught as `unavailable`, which per #240 is **not** read as clean and falls through to the already-bounded push backstop.

## Relationship to #349

This is the root fix. #349's tool-level flush valve becomes **defense-in-depth** on top of a properly-bounded LSP request, rather than the primary bound. Once this lands, #349 can be re-scoped down (or kept as a thin belt-and-suspenders layer).

## Follow-ups (not in this PR, to keep it focused)

Three other `safeSendRequest` callers are still unwrapped and share the same latent class: `workspace/symbol`, `textDocument/codeAction` (note: a *sibling* codeAction call already uses `withTimeout`), and `workspace/executeCommand` (needs care — mutating + legitimately long-running).

## Test plan

- New regression test in `client-internals.test.ts` (`clientWaitForDiagnostics — pull mode`): a pull server whose `sendRequest` never resolves now resolves within the caller's budget instead of hanging (pre-fix this test hangs forever).
- `npm run lint` ✅
- Full `tests/clients/lsp/` suite: 320 passed / 2 skipped ✅
- `npm run build:dist` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)