### PR TITLE
refactor(lsp): remove dead launchViaPackageManager (refs #375)

### DIFF
--- a/clients/lsp/launch.ts
+++ b/clients/lsp/launch.ts
@@ -18,11 +18,7 @@ import os from "node:os";
 import path from "node:path";
 import { isTestMode } from "../env-utils.js";
 import { getGlobalPiLensDir } from "../file-utils.js";
-import {
-	allAvailableGlobalBinDirs,
-	execArgs,
-	resolveNodePackageManager,
-} from "../package-manager.js";
+import { allAvailableGlobalBinDirs } from "../package-manager.js";
 
 export interface LSPProcess {
 	process: ChildProcess;
@@ -732,107 +728,6 @@ export async function launchLSP(
 		stderr: proc.stderr,
 		pid: proc.pid ?? 0,
 	};
-}
-
-/**
- * Spawn an LSP server via a package runner (`npx --no`, `bun x`, `pnpm dlx`,
- * `yarn dlx`), resolving the manager from the target dir.
- */
-export async function launchViaPackageManager(
-	packageName: string,
-	args: string[] = [],
-	options: SpawnOptions = {},
-): Promise<LSPProcess> {
-	const isWin = process.platform === "win32";
-	const cwd = String(options.cwd ?? process.cwd());
-	const pm = await resolveNodePackageManager(cwd);
-
-	// Non-npm managers run their binary directly; launchLSP resolves the
-	// platform executable (.cmd/.exe) and handles shell quoting.
-	if (pm !== "npm") {
-		const { command, args: runnerArgs } = execArgs(pm, packageName, args);
-		return launchLSP(command, runnerArgs, options);
-	}
-
-	// npm → npx. On Windows npx is npx.cmd, which needs a shell; probe for an
-	// immediate spawn failure so a missing package surfaces a clear error.
-	if (isWin) {
-		const argsStr = args.map((a) => (a.includes(" ") ? `"${a}"` : a)).join(" ");
-		// --no prevents silent download of uncached packages
-		const shellCommand = `npx --no ${packageName}${argsStr ? ` ${argsStr}` : ""}`;
-
-		const mergedEnv = { ...process.env, ...options.env };
-		const augmentedPath = buildAugmentedPath(resolvePathValue(mergedEnv));
-		const env: NodeJS.ProcessEnv = {
-			...mergedEnv,
-			PATH: augmentedPath,
-			...(isWindows ? { Path: augmentedPath } : {}),
-		};
-
-		const proc = nodeSpawn(shellCommand, [], {
-			cwd,
-			env,
-			stdio: ["pipe", "pipe", "pipe"],
-			detached: false,
-			windowsHide: true,
-			shell: true,
-		});
-
-		if (!proc.stdin || !proc.stdout || !proc.stderr) {
-			throw new Error(`Failed to spawn package manager for: ${packageName}`);
-		}
-
-		// Check for immediate spawn failure on Windows
-		await new Promise<void>((resolve, reject) => {
-			let settled = false;
-
-			proc.on("error", (err: Error & { code?: string }) => {
-				if (!settled && (err.code === "ENOENT" || err.code === "EINVAL")) {
-					settled = true;
-					reject(
-						new Error(
-							`Package manager not found for: ${packageName}. ` +
-								`Install Node.js or check your PATH.`,
-						),
-					);
-				}
-			});
-
-			proc.on("exit", (code: number | null) => {
-				if (!settled && code !== null) {
-					settled = true;
-					reject(
-						new Error(
-							`Package manager exited immediately for: ${packageName} (code: ${code})`,
-						),
-					);
-				}
-			});
-
-			setTimeout(() => {
-				if (!settled) {
-					settled = true;
-					resolve();
-				}
-			}, 50);
-		});
-
-		// Attach permanent error handler
-		_attachErrorHandler(proc, packageName);
-		unrefLspProcessHandles(proc);
-
-		return {
-			process: proc,
-			stdin: proc.stdin,
-			stdout: proc.stdout,
-			stderr: proc.stderr,
-			pid: proc.pid ?? 0,
-		};
-	}
-
-	// --no prevents silent download of uncached packages; user must have
-	// already installed the LSP server via the interactive-install flow.
-	return launchLSP("npx", ["--no", packageName, ...args], options);
 }
 
 /**

--- a/tests/clients/lsp/server-policy.test.ts
+++ b/tests/clients/lsp/server-policy.test.ts
@@ -9,7 +9,6 @@ process.env.PI_LENS_TEST_MODE = "1";
 const ensureTool = vi.fn();
 const getToolEnvironment = vi.fn(async () => ({}));
 const launchLSP = vi.fn();
-const launchViaPackageManager = vi.fn();
 
 vi.mock("../../../clients/installer/index.js", () => ({
 	ensureTool,
@@ -18,7 +17,6 @@ vi.mock("../../../clients/installer/index.js", () => ({
 
 vi.mock("../../../clients/lsp/launch.js", () => ({
 	launchLSP,
-	launchViaPackageManager,
 }));
 
 // Suppress sync disk I/O from logLatency — prevents timeout under full-suite load
@@ -36,7 +34,6 @@ afterEach(() => {
 	delete process.env.PI_LENS_DISABLE_LSP_INSTALL;
 	ensureTool.mockReset();
 	launchLSP.mockReset();
-	launchViaPackageManager.mockReset();
 	vi.resetModules();
 });
 
@@ -554,7 +551,6 @@ describe("lsp server policy", () => {
 
 		const spawned = await SvelteServer.spawn(tmp);
 		expect(spawned?.process).toBeUndefined();
-		expect(launchViaPackageManager).not.toHaveBeenCalled();
 	});
 
 	it("skips package-manager fallback when install is disallowed for file", async () => {
@@ -569,7 +565,6 @@ describe("lsp server policy", () => {
 
 		const spawned = await SvelteServer.spawn(tmp, { allowInstall: false });
 		expect(spawned?.process).toBeUndefined();
-		expect(launchViaPackageManager).not.toHaveBeenCalled();
 	});
 
 	it("keeps custom LSP config scoped per workspace", async () => {


### PR DESCRIPTION
## What

Removes `launchViaPackageManager` from `clients/lsp/launch.ts` — an exported function with **no callers** anywhere in the codebase.

## Why

Verified dead: a repo-wide search finds it only in its own definition (plus stale `.pi-lens/cache/*` snapshots and `dist/`). The live LSP launch path is `launchLSP()`, which resolves an installed server binary across **every** package manager's global bin dir (`_findBinaryInGlobalBin` → `allAvailableGlobalBinDirs`) and spawns it directly — npm/pnpm/yarn/bun installs are all found and run by path, with no npx/dlx round-trip.

`launchViaPackageManager` was also the **only** consumer of `execArgs()` in this file. `execArgs`'s non-npm branch maps to `pnpm dlx` / `yarn dlx` / `bun x`, which **fetch-if-missing** — the one code path that could have silently downloaded an LSP server, contradicting pi-lens's `npx --no` cache-only invariant. Deleting the dead function removes that trap and drops the now-unused `execArgs` / `resolveNodePackageManager` imports.

## Tests

The two `server-policy.test.ts` cases mocked `launchViaPackageManager` and asserted it was *never called* — but `server.js` never imported it, so those assertions were vacuous. Dropped them; the meaningful `spawned?.process` toBeUndefined checks (install-disabled / install-disallowed → no spawn) stay.

- `npm run build` ✓  `npm run lint` ✓
- Full `lsp/` suite: 327 passed ✓
- Full `npm test`: only flake was `tests/mcp/analyze-cli.test.ts` under parallel load (known spawn-smoke flake); passes isolated ✓

No user-facing behavior change (pure dead-code removal), so no CHANGELOG entry.

Refs #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)