### PR TITLE
fix(grammars): keep download-grammars stdout clean so npm pack --silent works (#376)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -74,8 +74,12 @@ jobs:
         run: |
           set -euxo pipefail
           npm ci
-          # prepare script builds dist; pack emits a tarball of the real files[] set
-          TARBALL="$(npm pack --silent)"
+          # prepare script builds dist; pack emits a tarball of the real files[] set.
+          # `npm pack --silent` prints ONLY the tarball name to stdout — but the
+          # `prepare` script (download-grammars) must keep stdout clean for that to
+          # hold. `tail -1` is defense-in-depth against any future prepare-time
+          # stdout chatter leaking into the captured filename (was #376's break).
+          TARBALL="$(npm pack --silent | tail -1)"
           echo "TARBALL=$PWD/$TARBALL" >> "$GITHUB_ENV"
 
       - name: Install via ${{ matrix.pm }} into a clean project

--- a/scripts/download-grammars.js
+++ b/scripts/download-grammars.js
@@ -68,7 +68,9 @@ function findGrammarsDir() {
 async function downloadGrammar(destDir, filename) {
     const dest = join(destDir, filename);
     if (existsSync(dest)) {
-        console.log(`  skip  ${filename} (already exists)`);
+        // Progress goes to stderr — stdout must stay clean so `npm pack --silent`
+        // (which runs this via `prepare`) captures only the tarball name.
+        console.error(`  skip  ${filename} (already exists)`);
         return;
     }
     const url = `${BASE_URL}/${filename}`;
@@ -77,7 +79,7 @@ async function downloadGrammar(destDir, filename) {
         throw new Error(`HTTP ${res.status} fetching ${url}`);
     const buf = await res.arrayBuffer();
     writeFileSync(dest, Buffer.from(buf));
-    console.log(`  ok    ${filename}`);
+    console.error(`  ok    ${filename}`);
 }
 function parseArgs(argv) {
     const out = { core: false };
@@ -100,7 +102,7 @@ async function main() {
     if (!existsSync(grammarsDir)) {
         mkdirSync(grammarsDir, { recursive: true });
     }
-    console.log(`Downloading ${args.core ? "core" : "all"} tree-sitter grammars (${list.length}) → ${grammarsDir}`);
+    console.error(`Downloading ${args.core ? "core" : "all"} tree-sitter grammars (${list.length}) → ${grammarsDir}`);
     const results = await Promise.allSettled(list.map((g) => downloadGrammar(grammarsDir, g)));
     const failed = results.filter((r) => r.status === "rejected");
     if (failed.length > 0) {
@@ -110,7 +112,7 @@ async function main() {
         console.warn(`${failed.length} grammar(s) failed — tree-sitter analysis may be unavailable.`);
     }
     else {
-        console.log("All grammars downloaded successfully.");
+        console.error("All grammars downloaded successfully.");
     }
 }
 main().catch((err) => {

--- a/scripts/download-grammars.ts
+++ b/scripts/download-grammars.ts
@@ -74,7 +74,9 @@ function findGrammarsDir(): string {
 async function downloadGrammar(destDir: string, filename: string): Promise<void> {
 	const dest = join(destDir, filename);
 	if (existsSync(dest)) {
-		console.log(`  skip  ${filename} (already exists)`);
+		// Progress goes to stderr — stdout must stay clean so `npm pack --silent`
+		// (which runs this via `prepare`) captures only the tarball name.
+		console.error(`  skip  ${filename} (already exists)`);
 		return;
 	}
 	const url = `${BASE_URL}/${filename}`;
@@ -82,7 +84,7 @@ async function downloadGrammar(destDir: string, filename: string): Promise<void>
 	if (!res.ok) throw new Error(`HTTP ${res.status} fetching ${url}`);
 	const buf = await res.arrayBuffer();
 	writeFileSync(dest, Buffer.from(buf));
-	console.log(`  ok    ${filename}`);
+	console.error(`  ok    ${filename}`);
 }
 
 function parseArgs(argv: string[]): { core: boolean; dest?: string } {
@@ -107,7 +109,7 @@ async function main(): Promise<void> {
 		mkdirSync(grammarsDir, { recursive: true });
 	}
 
-	console.log(
+	console.error(
 		`Downloading ${args.core ? "core" : "all"} tree-sitter grammars (${list.length}) → ${grammarsDir}`,
 	);
 
@@ -122,7 +124,7 @@ async function main(): Promise<void> {
 		}
 		console.warn(`${failed.length} grammar(s) failed — tree-sitter analysis may be unavailable.`);
 	} else {
-		console.log("All grammars downloaded successfully.");
+		console.error("All grammars downloaded successfully.");
 	}
 }
 

--- a/tests/scripts/download-grammars.test.ts
+++ b/tests/scripts/download-grammars.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for scripts/download-grammars.js — stdout must stay CLEAN.
+ *
+ * The script runs inside the `prepare` lifecycle, so it executes during
+ * `npm pack --silent`, whose stdout is captured as the tarball filename by
+ * install-smoke's `smoke` job. If the script logs progress to stdout (as it did
+ * before this fix — #376's break), that chatter is captured alongside the
+ * filename and the multi-line value blows up `>> $GITHUB_ENV` ("Invalid
+ * format"), turning the whole smoke matrix red. Progress therefore goes to
+ * stderr; stdout must emit nothing.
+ *
+ * Runs the real built script against a pre-populated dest so every grammar hits
+ * the no-network "skip" path — deterministic and offline.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../../scripts/download-grammars.js",
+);
+
+// Mirrors the CORE list in scripts/download-grammars.ts. Pre-creating these
+// forces every entry down the offline "skip (already exists)" branch, so the
+// test never touches the network.
+const CORE_FILES = [
+	"tree-sitter-typescript.wasm",
+	"tree-sitter-tsx.wasm",
+	"tree-sitter-javascript.wasm",
+	"tree-sitter-python.wasm",
+	"tree-sitter-go.wasm",
+	"tree-sitter-rust.wasm",
+	"tree-sitter-json.wasm",
+	"tree-sitter-yaml.wasm",
+	"tree-sitter-bash.wasm",
+	"tree-sitter-html.wasm",
+	"tree-sitter-css.wasm",
+	"tree-sitter-java.wasm",
+];
+
+const dirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of dirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("download-grammars stdout hygiene (#376)", () => {
+	it("writes nothing to stdout when bundling core grammars (all skipped)", () => {
+		const base = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-grammars-"));
+		dirs.push(base);
+		const dest = path.join(base, "grammars");
+		fs.mkdirSync(dest, { recursive: true });
+		// Pre-create every core grammar so the script skips (no network fetch).
+		for (const f of CORE_FILES) fs.writeFileSync(path.join(dest, f), "");
+
+		// dest is resolved relative to cwd (join(process.cwd(), args.dest)), so
+		// run with cwd=base and --dest grammars.
+		const res = spawnSync(
+			process.execPath,
+			[SCRIPT, "--core", "--dest", "grammars"],
+			{ cwd: base, encoding: "utf8" },
+		);
+
+		expect(res.status).toBe(0);
+		// The invariant: stdout is empty so `npm pack --silent` captures only the
+		// tarball name. All progress ("skip …", "Downloading …") must be stderr.
+		expect(res.stdout).toBe("");
+		expect(res.stderr).toContain("skip");
+	});
+});


### PR DESCRIPTION
## The break

The nightly `install-smoke` **`smoke`** matrix (npm/pnpm/bun/yarn × ubuntu/macos) is **fully red on master**. Root cause is #376 fallout, surfaced while dispatching the mise repro run ([logs](https://github.com/apmantza/pi-lens/actions/runs/28682528547)):

```
+ TARBALL='Downloading core tree-sitter grammars (12) → …/grammars
  skip  tree-sitter-typescript.wasm (already exists)
  …
pi-lens-3.8.63.tgz'
##[error]Unable to process file command 'env' successfully.
##[error]Invalid format '  skip  tree-sitter-typescript.wasm (already exists)'
```

The job does `TARBALL="$(npm pack --silent)"`. `npm pack` runs the `prepare` script → `download-grammars`, which logged progress to **stdout**. That chatter got captured with the tarball name; the multi-line value then breaks `>> $GITHUB_ENV`.

## Fix

- **Root cause:** route download-grammars' informational output to **stderr** (`console.error`). `npm pack --silent`'s stdout is now only the tarball filename. Verified locally: `npm pack --silent` → single line `pi-lens-3.8.63.tgz`.
- **Defense-in-depth:** the smoke capture pipes `| tail -1`, so a future prepare-time stdout leak can't reintroduce this.
- **Regression test:** `tests/scripts/download-grammars.test.ts` runs the real script against a pre-populated dest (every grammar hits the offline "skip" path) and asserts stdout is empty.

## Verification

- `npm run build` ✓  `npm run lint` ✓  full `npm test` ✓ (2637 passed, 0 fail)
- Only `$(npm pack …)` capture in the repo is this one (grepped); `ci.yml` uses bare `npm pack` (prints, doesn't capture) so it was unaffected.

CI/build-tooling fix; no user-facing runtime change, so no CHANGELOG entry.

Refs #376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)