### PR TITLE
fix(lens): make lens_diagnostics mode=full cancellable + hang-proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **`lens_diagnostics mode=full` could hang indefinitely and didn't cancel on Escape** — an unattended session was observed wedged for ~8 hours on a small repo. Two root causes, both fixed: **(1) Escape didn't cancel** — the tool honored only the tool-call `signal` positional, not `ctx.signal` (the turn-wired abort Escape fires for a registered extension tool), so the sweep ran on. It now combines both (`combineAbortSignals`, shared in `deadline-utils`) and threads the result through the LSP sweep and project-runner scan. **(2) It could hang forever** — per-file diagnostic waits were bounded, but *client acquisition* in the sweep was not, so a language server hanging on spawn/`initialize` parked a worker permanently. Now (a) each file gets a per-file wall-clock budget (`PI_LENS_LSP_WORKSPACE_PER_FILE_MS`, default 15 s) so a worker always returns to its abort check, and (b) the whole scan has a hard wall-clock ceiling (`PI_LENS_LENS_DIAGNOSTICS_FULL_TIMEOUT_MS`, default 3 min) that aborts it to partial results rather than never returning. The sweep also now emits **start + periodic heartbeat** latency logs (with `completed/total`, `timedOutFiles`) so a future stall is debuggable instead of silent. The same `ctx.signal` cancellation gap is fixed in the sibling tools `lsp_diagnostics` (batch/directory scans) and `ast_grep_search` (which was already abort-aware but checked the wrong signal).
+
 ## [3.8.63] - 2026-07-01
 
 ### Added

--- a/clients/deadline-utils.ts
+++ b/clients/deadline-utils.ts
@@ -11,6 +11,30 @@
  * `withinRemaining` never cleared its timer.
  */
 
+/**
+ * Combine multiple abort signals into one that aborts when ANY of them does.
+ * Returns the single signal unchanged when only one is live, and `undefined`
+ * when none are — so callers can pass it straight through. Used so a tool honors
+ * both its tool-call `signal` positional and the turn-wired `ctx.signal` (Escape),
+ * and to fold in a wall-clock ceiling via `AbortSignal.timeout`.
+ */
+export function combineAbortSignals(
+	...signals: (AbortSignal | undefined)[]
+): AbortSignal | undefined {
+	const live = signals.filter((s): s is AbortSignal => s !== undefined);
+	if (live.length <= 1) return live[0];
+	if (typeof AbortSignal.any === "function") return AbortSignal.any(live);
+	const controller = new AbortController();
+	for (const s of live) {
+		if (s.aborted) {
+			controller.abort((s as AbortSignal & { reason?: unknown }).reason);
+			break;
+		}
+		s.addEventListener("abort", () => controller.abort(s.reason), { once: true });
+	}
+	return controller.signal;
+}
+
 export interface DeadlineOptions {
 	/** Duration budget in ms. Provide this OR `deadlineAt`. */
 	ms?: number;

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -20,6 +20,7 @@ import {
 } from "../file-utils.js";
 import { recordLsp } from "../widget-state.js";
 import { logLatency } from "../latency-logger.js";
+import { withDeadline } from "../deadline-utils.js";
 import { normalizeMapKey, uriToPath } from "../path-utils.js";
 import type {
 	LSPClientInfo,
@@ -1845,8 +1846,30 @@ export class LSPService {
 				? Math.floor(options.maxFiles)
 				: getMaxWorkspaceDiagnosticFiles();
 		const files = await collectWorkspaceDiagnosticFiles(root, maxFiles, signal);
+		// Per-file wall-clock: a language server that hangs during spawn/initialize
+		// would otherwise park a worker on `touchFile` FOREVER (the per-edit
+		// diagnostic wait is bounded, but client acquisition here is not) — the root
+		// of an observed multi-hour hang. Budget each file so the worker always
+		// returns to the loop (and its abort check). Env-tunable.
+		const perFileMs = (() => {
+			const raw = Number(process.env.PI_LENS_LSP_WORKSPACE_PER_FILE_MS);
+			return Number.isFinite(raw) && raw > 0 ? raw : 15_000;
+		})();
 		const results: LSPWorkspaceDiagnosticResult[] = new Array(files.length);
 		let nextIndex = 0;
+		let completed = 0;
+		let timedOutFiles = 0;
+		let lastHeartbeat = Date.now();
+		// Start marker: without this a hang leaves no trace that the sweep even
+		// began (the completion log below never fires). Per-file `lsp_touch_file`
+		// phases + these heartbeats let a hang be bracketed to a file/time.
+		logLatency({
+			type: "phase",
+			phase: "lsp_workspace_diagnostics_start",
+			filePath: root,
+			durationMs: 0,
+			metadata: { fileCount: files.length, maxFiles, perFileMs },
+		});
 		const workers = Math.min(WORKSPACE_DIAGNOSTICS_CONCURRENCY, files.length);
 		await Promise.all(
 			Array.from({ length: workers }, async () => {
@@ -1861,12 +1884,19 @@ export class LSPService {
 					const filePath = files[index];
 					try {
 						const content = await nodeFs.promises.readFile(filePath, "utf-8");
-						const diagnostics = await this.touchFile(filePath, content, {
-							diagnostics: "document",
-							collectDiagnostics: true,
-							clientScope: "all",
-							source: "lens_diagnostics_full",
-						});
+						// onTimeout:"undefined" so a hung file yields no diagnostics and the
+						// worker moves on; a real touchFile rejection still propagates to the
+						// catch below and is recorded as an error.
+						const diagnostics = await withDeadline(
+							this.touchFile(filePath, content, {
+								diagnostics: "document",
+								collectDiagnostics: true,
+								clientScope: "all",
+								source: "lens_diagnostics_full",
+							}),
+							{ ms: perFileMs, onTimeout: "undefined" },
+						);
+						if (diagnostics === undefined) timedOutFiles += 1;
 						results[index] = {
 							filePath,
 							diagnostics: diagnostics ?? [],
@@ -1879,6 +1909,24 @@ export class LSPService {
 							count: 0,
 							error: err instanceof Error ? err.message : String(err),
 						};
+					}
+					completed += 1;
+					// Time-based heartbeat (every ~10s): a hang shows the last heartbeat
+					// then silence, so latency.log pinpoints how far it got.
+					if (Date.now() - lastHeartbeat >= 10_000) {
+						lastHeartbeat = Date.now();
+						logLatency({
+							type: "phase",
+							phase: "lsp_workspace_diagnostics_progress",
+							filePath: root,
+							durationMs: Date.now() - startedAt,
+							metadata: {
+								completed,
+								total: files.length,
+								timedOutFiles,
+								aborted: signal?.aborted ?? false,
+							},
+						});
 					}
 				}
 			}),
@@ -1897,6 +1945,7 @@ export class LSPService {
 				),
 				concurrency: WORKSPACE_DIAGNOSTICS_CONCURRENCY,
 				maxFiles,
+				timedOutFiles,
 				aborted: signal?.aborted ?? false,
 			},
 		});

--- a/tests/clients/deadline-utils.test.ts
+++ b/tests/clients/deadline-utils.test.ts
@@ -9,6 +9,7 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	combineAbortSignals,
 	withBudget,
 	withDeadline,
 	withinRemaining,
@@ -136,5 +137,32 @@ describe("named adapters preserve their exact semantics", () => {
 		await expect(withinRemaining(slow("v", 1000), Date.now() + 10)).resolves.toBeUndefined();
 		await expect(withinRemaining(slowReject("boom", 5), Date.now() + 1000)).resolves.toBeUndefined();
 		await expect(withinRemaining(slow("v", 50), Date.now() - 1)).resolves.toBeUndefined();
+	});
+});
+
+describe("combineAbortSignals", () => {
+	it("returns the single live signal unchanged", () => {
+		const c = new AbortController();
+		expect(combineAbortSignals(undefined, c.signal)).toBe(c.signal);
+	});
+
+	it("returns undefined when no signal is live", () => {
+		expect(combineAbortSignals(undefined, undefined)).toBeUndefined();
+	});
+
+	it("aborts when EITHER source aborts", () => {
+		const a = new AbortController();
+		const b = new AbortController();
+		const combined = combineAbortSignals(a.signal, b.signal);
+		expect(combined?.aborted).toBe(false);
+		b.abort();
+		expect(combined?.aborted).toBe(true);
+	});
+
+	it("is already aborted when a source was pre-aborted", () => {
+		const a = new AbortController();
+		a.abort();
+		const b = new AbortController();
+		expect(combineAbortSignals(a.signal, b.signal)?.aborted).toBe(true);
 	});
 });

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -497,7 +497,8 @@ describe("lens_diagnostics mode=full", () => {
 			{ cwd: "/proj" },
 		);
 		const passed = lspService.runWorkspaceDiagnostics.mock.calls[0][1];
-		expect(passed.signal).toBe(controller.signal);
+		// The sweep receives a COMBINED signal now (tool-call + ctx + wall-clock
+		// ceiling), so assert its aborted state, not object identity.
 		expect(passed.signal.aborted).toBe(true);
 		const text = String(result.content[0].text);
 		expect(text).toContain("Scan cancelled before completion");
@@ -1068,5 +1069,64 @@ describe("lens_diagnostics mode=all", () => {
 		const text = String(result.content[0].text);
 		expect(text).toContain("BOOM error here");
 		expect(text).not.toContain("minor warning here");
+	});
+});
+
+// ── cancellation via ctx.signal (Escape / turn abort) ──────────────────────────
+describe("lens_diagnostics honors the turn abort (ctx.signal)", () => {
+	it("aborts a mode=full scan when ctx.signal (Escape) fires, even if the positional signal is live", async () => {
+		mockSummaries.length = 0;
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]),
+		};
+		// Positional tool-call signal is live (not aborted); the TURN signal is the
+		// one Escape fires. Before the fix the tool only read the positional signal,
+		// so Escape did nothing.
+		const liveCall = new AbortController();
+		const turn = new AbortController();
+		turn.abort();
+		const tool = makeTool({}, lspService);
+		const result = await tool.execute(
+			"1",
+			{ mode: "full", maxLspFiles: 50 },
+			liveCall.signal,
+			null,
+			{ cwd: "/proj", signal: turn.signal },
+		);
+		const passed = lspService.runWorkspaceDiagnostics.mock.calls[0][1];
+		expect(passed.signal.aborted).toBe(true);
+		expect(String(result.content[0].text)).toContain(
+			"Scan cancelled before completion",
+		);
+		expect(result.details).toMatchObject({ mode: "full", partial: true });
+	});
+});
+
+
+describe("lens_diagnostics wall-clock ceiling (never-hang guarantee)", () => {
+	it("stops mode=full and marks timedOut when the wall-clock budget is exceeded", async () => {
+		vi.resetModules();
+		process.env.PI_LENS_LENS_DIAGNOSTICS_FULL_TIMEOUT_MS = "1";
+		const { createLensDiagnosticsTool: freshCreate } = await import(
+			"../../tools/lens-diagnostics.js"
+		);
+		const lspService = {
+			// Outlast the 1ms ceiling so it fires before the sweep returns.
+			runWorkspaceDiagnostics: vi.fn(async () => {
+				await new Promise((r) => setTimeout(r, 30));
+				return [];
+			}),
+		};
+		const tool = freshCreate(
+			makeCacheManager({}) as any,
+			() => "/proj",
+			() => lspService as any,
+		);
+		const result = await tool.execute("1", { mode: "full" }, undefined, null, {
+			cwd: "/proj",
+		});
+		expect(String(result.content[0].text)).toContain("time budget");
+		expect(result.details).toMatchObject({ mode: "full", timedOut: true });
+		delete process.env.PI_LENS_LENS_DIAGNOSTICS_FULL_TIMEOUT_MS;
 	});
 });

--- a/tools/ast-grep-search.ts
+++ b/tools/ast-grep-search.ts
@@ -19,6 +19,7 @@ import {
 } from "../clients/ast-grep-yaml-synth.js";
 import type { SearchReadLocation } from "../clients/search-read-registration.js";
 import { compactRenderResult } from "./render-compact.js";
+import { combineAbortSignals } from "../clients/deadline-utils.js";
 import { LANGUAGES } from "./shared.js";
 
 /**
@@ -409,10 +410,13 @@ export function createAstGrepSearchTool(astGrepClient: AstGrepClient) {
 		async execute(
 			_toolCallId: string,
 			params: Record<string, unknown>,
-			_signal: AbortSignal,
+			_signal: AbortSignal | undefined,
 			_onUpdate: unknown,
-			ctx: { cwd?: string },
+			ctx: { cwd?: string; signal?: AbortSignal },
 		) {
+			// Escape aborts the turn via ctx.signal; the positional signal is the
+			// tool-call one. Honor both so a broad search cancels on Escape.
+			const abortSignal = combineAbortSignals(_signal, ctx.signal);
 			const startedAt = Date.now();
 			const {
 				paths,
@@ -552,7 +556,7 @@ export function createAstGrepSearchTool(astGrepClient: AstGrepClient) {
 					};
 				}
 
-				if (_signal.aborted) return abortError();
+				if (abortSignal?.aborted) return abortError();
 
 				if (!(await astGrepClient.ensureAvailable())) {
 					logOutcome("error", {
@@ -569,7 +573,7 @@ export function createAstGrepSearchTool(astGrepClient: AstGrepClient) {
 						details: {},
 					};
 				}
-				if (_signal.aborted) return abortError();
+				if (abortSignal?.aborted) return abortError();
 
 				if (!hasRawRule && looksLikeRuleYamlOrPlainText(pattern)) {
 					logOutcome("error", {
@@ -670,12 +674,12 @@ export function createAstGrepSearchTool(astGrepClient: AstGrepClient) {
 
 				// Phase 4: raw YAML rule passthrough — routes through sg scan --config
 				if (effectiveRule && effectiveRule.trim().length > 0) {
-					if (_signal.aborted) return abortError();
+					if (abortSignal?.aborted) return abortError();
 					const ruleResult = await astGrepClient.searchWithRule(
 						effectiveRule,
 						searchPaths,
 					);
-					if (_signal.aborted) return abortError();
+					if (abortSignal?.aborted) return abortError();
 					if (ruleResult.error) {
 						logOutcome("error", { errorRaw: ruleResult.error });
 						return {
@@ -726,13 +730,13 @@ export function createAstGrepSearchTool(astGrepClient: AstGrepClient) {
 					};
 				}
 
-				if (_signal.aborted) return abortError();
+				if (abortSignal?.aborted) return abortError();
 				const result = await astGrepClient.search(pattern, lang, searchPaths, {
 					selector,
 					context,
 					strictness,
 				});
-				if (_signal.aborted) return abortError();
+				if (abortSignal?.aborted) return abortError();
 
 				if (result.error) {
 					logOutcome("error", { errorRaw: result.error });

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -12,6 +12,7 @@
 import * as path from "node:path";
 import { Type } from "../clients/deps/typebox.js";
 import { compactRenderResult } from "./render-compact.js";
+import { combineAbortSignals } from "../clients/deadline-utils.js";
 import { getProjectIgnoreMatcher } from "../clients/file-utils.js";
 import { getLSPService } from "../clients/lsp/index.js";
 import type { LSPDiagnostic } from "../clients/lsp/client.js";
@@ -53,6 +54,16 @@ type WorkspaceLspDiagnosticResult = {
 	diagnostics: LSPDiagnostic[];
 	count?: number;
 };
+
+// Wall-clock ceiling for the whole mode=full scan. Even with per-file budgets
+// and abort-signal honoring, a pathological state (a language server hanging on
+// spawn/initialize across many files) could otherwise stall the tool
+// indefinitely — an unattended session was observed hung for ~8h. This hard cap
+// aborts the scan so it always returns (partial) rather than never. Env-tunable.
+const FULL_SCAN_WALL_CLOCK_MS = (() => {
+	const raw = Number(process.env.PI_LENS_LENS_DIAGNOSTICS_FULL_TIMEOUT_MS);
+	return Number.isFinite(raw) && raw > 0 ? raw : 180_000; // 3 min default
+})();
 
 export function createLensDiagnosticsTool(
 	cacheManager: CacheManager,
@@ -165,9 +176,9 @@ export function createLensDiagnosticsTool(
 		async execute(
 			_toolCallId: string,
 			params: Record<string, unknown>,
-			signal: AbortSignal,
+			signal: AbortSignal | undefined,
 			_onUpdate: unknown,
-			ctx: { cwd?: string },
+			ctx: { cwd?: string; signal?: AbortSignal },
 		) {
 			const mode = (params.mode as string | undefined) ?? "delta";
 			const severity = (params.severity as string | undefined) ?? "all";
@@ -180,6 +191,12 @@ export function createLensDiagnosticsTool(
 			const maxLspFiles = parsePositiveInt(params.maxLspFiles);
 			const cwd = ctx.cwd ?? getCwd();
 
+			// Escape aborts the agent *turn*, which fires ctx.signal (the turn-wired
+			// abort); the positional signal is the tool-call signal. A registered
+			// extension tool only reliably sees the turn abort via ctx.signal, so honor
+			// BOTH — else a long mode=full scan ignores Escape (the reported bug).
+			const abortSignal = combineAbortSignals(signal, ctx.signal);
+
 			// Reflect the agent's just-made fixes before reporting: flush pending
 			// per-edit dispatches (re-records fixed files), then drop entries whose
 			// file changed on disk afterwards / was deleted (stale, e.g. external
@@ -191,11 +208,17 @@ export function createLensDiagnosticsTool(
 				return formatAllMode(cwd, severity, undefined, undefined, staleDropped);
 			}
 			if (mode === "full") {
+				// Fold a hard wall-clock ceiling into the abort signal so the scan
+				// always terminates (partial) even if a hung server would otherwise
+				// stall it forever. AbortSignal.timeout aborts with a TimeoutError.
+				const ceiling = AbortSignal.timeout(FULL_SCAN_WALL_CLOCK_MS);
+				const fullSignal = combineAbortSignals(abortSignal, ceiling);
 				return formatFullMode(cwd, severity, getLspService(), {
 					refreshRunners,
 					maxProjectFiles,
 					maxLspFiles,
-					signal,
+					signal: fullSignal,
+					wallClockMs: FULL_SCAN_WALL_CLOCK_MS,
 				});
 			}
 			return formatDeltaMode(cacheManager, cwd, severity);
@@ -592,6 +615,7 @@ async function formatFullMode(
 		maxProjectFiles?: number;
 		maxLspFiles?: number;
 		signal?: AbortSignal;
+		wallClockMs?: number;
 	} = {},
 ): Promise<{ content: [{ type: "text"; text: string }]; details: object }> {
 	const runWorkspaceDiagnostics = lspService.runWorkspaceDiagnostics;
@@ -657,17 +681,23 @@ async function formatFullMode(
 						turnIndex: projectDelta.turnIndex,
 					},
 	});
-	// Cancelled mid-scan: the results above are whatever completed before the
-	// abort. Tell the agent so it doesn't read a partial sweep as "clean" (#341).
+	// Stopped mid-scan: the results above are whatever completed before the abort.
+	// Tell the agent so it doesn't read a partial sweep as "clean" (#341). The
+	// abort is either a user/turn cancel (Escape) or the wall-clock ceiling firing
+	// (AbortSignal.timeout → TimeoutError), which guarantees the scan can't hang
+	// indefinitely — distinguish them so the agent knows whether to just re-run.
 	if (aborted) {
-		const note =
-			"\n\n⚠ Scan cancelled before completion — results are partial. " +
-			"Re-run with a smaller maxLspFiles to finish within budget.";
+		const timedOut =
+			(signal as (AbortSignal & { reason?: { name?: string } }) | undefined)
+				?.reason?.name === "TimeoutError";
+		const note = timedOut
+			? `\n\n⚠ Scan exceeded its ${Math.round((options.wallClockMs ?? 0) / 1000)}s time budget and was stopped — results are partial. ` +
+				"Narrow it with maxLspFiles, or raise PI_LENS_LENS_DIAGNOSTICS_FULL_TIMEOUT_MS."
+			: "\n\n⚠ Scan cancelled before completion — results are partial. " +
+				"Re-run with a smaller maxLspFiles to finish within budget.";
 		return {
-			content: [
-				{ type: "text" as const, text: result.content[0].text + note },
-			],
-			details: result.details,
+			content: [{ type: "text" as const, text: result.content[0].text + note }],
+			details: { ...result.details, timedOut },
 		};
 	}
 	return result;

--- a/tools/lsp-diagnostics.ts
+++ b/tools/lsp-diagnostics.ts
@@ -13,6 +13,7 @@ import {
 	isExcludedDirName,
 } from "../clients/file-utils.js";
 import { getLSPService } from "../clients/lsp/index.js";
+import { combineAbortSignals } from "../clients/deadline-utils.js";
 import type { LSPDiagnostic } from "../clients/lsp/client.js";
 import { baseName, compactRenderResult } from "./render-compact.js";
 
@@ -75,6 +76,7 @@ type LspHealthLike = {
 type BatchOptions = {
 	concurrency: number;
 	waitMs?: number;
+	signal?: AbortSignal;
 };
 
 type FileDiag = {
@@ -130,6 +132,7 @@ async function mapWithConcurrency<T, R>(
 	items: T[],
 	concurrency: number,
 	mapper: (item: T, index: number) => Promise<R>,
+	signal?: AbortSignal,
 ): Promise<R[]> {
 	const results: R[] = [];
 	let nextIndex = 0;
@@ -137,6 +140,9 @@ async function mapWithConcurrency<T, R>(
 	await Promise.all(
 		Array.from({ length: workers }, async () => {
 			while (true) {
+				// Honor cancellation (Escape / turn abort): stop pulling new items
+				// rather than grind the whole batch. Completed entries are returned.
+				if (signal?.aborted) return;
 				const index = nextIndex;
 				nextIndex += 1;
 				if (index >= items.length) return;
@@ -268,10 +274,13 @@ export function createLspDiagnosticsTool() {
 		async execute(
 			_toolCallId: string,
 			params: Record<string, unknown>,
-			_signal: AbortSignal,
+			_signal: AbortSignal | undefined,
 			_onUpdate: unknown,
-			ctx: { cwd?: string },
+			ctx: { cwd?: string; signal?: AbortSignal },
 		) {
+			// Escape aborts the turn via ctx.signal; honor both it and the tool-call
+			// signal so a batch/directory scan cancels rather than grinding on.
+			const signal = combineAbortSignals(_signal, ctx.signal);
 			const typedParams = params as {
 				path?: string;
 				paths?: string[];
@@ -319,6 +328,7 @@ export function createLspDiagnosticsTool() {
 				return runBatchFileDiagnostics(absPaths, severity, lspService, {
 					concurrency,
 					waitMs,
+					signal,
 				});
 			}
 
@@ -356,6 +366,7 @@ export function createLspDiagnosticsTool() {
 				return runDirectoryDiagnostics(absPath, severity, lspService, {
 					concurrency,
 					waitMs,
+					signal,
 				});
 			}
 			return runFileDiagnostics(absPath, severity, lspService, waitMs);
@@ -526,6 +537,7 @@ async function runBatchFileDiagnostics(
 		options.concurrency,
 		(file) =>
 			collectFileDiagnosticResult(file, severity, lspService, options.waitMs),
+		options.signal,
 	);
 	const fileErrors = results.flatMap((result) =>
 		result.error ? [result.error] : [],
@@ -631,6 +643,7 @@ async function runDirectoryDiagnostics(
 		options.concurrency,
 		(file) =>
 			collectFileDiagnosticResult(file, severity, lspService, options.waitMs),
+		options.signal,
 	);
 	const fileErrors = results.flatMap((result) =>
 		result.error ? [result.error] : [],


### PR DESCRIPTION
## The incident

An unattended session had `lens_diagnostics mode=full` **wedged for ~8h on a small repo**, and Escape didn't stop it. Two independent root causes.

## Root cause 1 — Escape didn't cancel
The tool honored only the tool-call `signal` positional, never `ctx.signal` — the **turn-wired abort Escape fires** for a registered extension tool (`ExtensionContext.signal`). The underlying sweep already honored abort between files/phases (#341); it just wasn't receiving the turn signal. Now the tool combines both via a shared `combineAbortSignals` (moved to `clients/deadline-utils`) and threads the result through the LSP sweep + project-runner scan.

## Root cause 2 — it could hang forever
Per-file *diagnostic waits* were bounded (~3s), but **client acquisition wasn't** — a language server hanging on spawn/`initialize` parked a worker permanently, and with all workers parked `Promise.all` never resolved. Fixed with two guards:
- **Per-file wall-clock budget** (`withDeadline`, `PI_LENS_LSP_WORKSPACE_PER_FILE_MS`, default 15s) so a worker always returns to its abort check.
- **Hard overall ceiling** (`AbortSignal.timeout` folded into the combined signal, `PI_LENS_LENS_DIAGNOSTICS_FULL_TIMEOUT_MS`, default 3min) → returns partial results instead of never. The partial note distinguishes user-cancel from budget-timeout (`details.timedOut`).

## Observability (why 8h left no trace)
`runWorkspaceDiagnostics` logged latency only on completion. Added a **start marker + periodic heartbeat** (`completed/total`, `timedOutFiles`) so a future stall is bracketed to a file/time in `latency.log`.

## Sibling tools (same `ctx.signal` gap)
- `lsp_diagnostics` — threads the combined signal into its batch/directory `mapWithConcurrency` (cancels between files).
- `ast_grep_search` — was abort-aware but checked the **wrong** signal; now combines `ctx.signal`.
- `module_report` — single-file/bounded, left as-is.

## Tests
- `ctx.signal` honored for mode=full (Escape path).
- Wall-clock ceiling → `timedOut` partial (env + fresh import).
- `combineAbortSignals` unit tests (in `deadline-utils.test`).
- Existing #341 partial-path test updated for the now-combined signal.
- `npm run build`/`lint` ✓, full `npm test` ✓ (2650 passed).

Fixes the hang + the Escape-cancel gap reported for `lens_diagnostics mode=full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)