### PR TITLE
fix(lsp): abort lsp_diagnostics fan-out + raise full-scan budget to 5min (#343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ All notable changes to pi-lens will be documented in this file.
 ### Changed
 
 - **CLI tool resolution now finds binaries installed by any package manager, not just npm/PATH** (#375) — the shared `resolveLocalFirstAsync` helper (the runner fleet's "local `.bin` → global → `npx --no`" resolver) plus the per-tool resolvers for **biome** (`biome-client.ts`, `dispatch/runners/biome.ts`, `formatters.ts`), **prettier** (`formatters.ts`), **type-coverage**, **jscpd**, **madge** (`dependency-checker.ts`), **ast-grep** (`sg-runner.ts` + the shared `isSgAvailableAsync`), and the **test runners** (`test-runner-client.ts`) now check every installed manager's global bin dir (npm/pnpm/yarn/bun) by direct file lookup before falling back to `npx`. This finds tools installed via `pnpm add -g` / `bun add -g` (whose bin dirs are often off PATH) and survives PATH-cache staleness right after an `install -g`. Each site's existing `npx` fallback is unchanged — the lookup is purely additive, so no user ever gets a surprise `dlx` download. New `findGlobalBinary` / `findNodeToolBinary` helpers in `package-manager.ts`, which also de-duplicate the identical private lookup in `lsp/launch.ts`.
+- **`lens_diagnostics mode=full` wall-clock ceiling raised from 3 min to 5 min** — large monorepos with many cold language servers were hitting the 180s cap and returning partial results before the sweep finished. The default is now 300s (still env-tunable via `PI_LENS_LENS_DIAGNOSTICS_FULL_TIMEOUT_MS`).
 
 ### Fixed
+
+- **`lsp_diagnostics` now stops opening files in the language server once the turn is abandoned** (#343) — the batch and directory scans thread the tool-call + turn (`ctx.signal`) abort signal into their concurrency fan-out, so an Escape/abort mid-scan stops scheduling new files (each in-flight file stays bounded by `waitMs`) and returns partial results, instead of grinding the whole capped batch into the server after the agent has moved on.
 
 ## [3.8.65] - 2026-07-04
 

--- a/tests/tools/lsp-diagnostics.test.ts
+++ b/tests/tools/lsp-diagnostics.test.ts
@@ -69,6 +69,66 @@ describe("lsp_diagnostics tool", () => {
 		}
 	});
 
+	it("short-circuits the batch fan-out when the signal is already aborted (#343)", async () => {
+		const tool = createLspDiagnosticsTool();
+		const controller = new AbortController();
+		controller.abort();
+
+		const result = (await tool.execute(
+			"diag-batch-aborted",
+			{
+				paths: ["/proj/a.ts", "/proj/b.ts", "/proj/c.ts"],
+				severity: "all",
+				concurrency: 2,
+			},
+			controller.signal,
+			null,
+			{ cwd: "." },
+		)) as any;
+
+		// No file was opened in the language server — the worker loop saw the
+		// aborted signal and returned before scheduling any file.
+		expect(
+			(mocked.service as { openFile: ReturnType<typeof vi.fn> }).openFile,
+		).not.toHaveBeenCalled();
+		// Still returns a (partial) batch result, not a throw.
+		expect(result.isError).toBeUndefined();
+		expect(result.details?.mode).toBe("batch");
+		expect(result.details?.filesChecked).toBe(0);
+		expect(result.details?.totalDiagnostics).toBe(0);
+	});
+
+	it("short-circuits the directory fan-out when the signal is already aborted (#343)", async () => {
+		const tool = createLspDiagnosticsTool();
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-lsp-diag-"));
+		fs.writeFileSync(path.join(tmpDir, "a.ts"), "const value = 1;\n");
+		fs.writeFileSync(path.join(tmpDir, "b.ts"), "const value = 2;\n");
+		const controller = new AbortController();
+		controller.abort();
+
+		try {
+			const result = (await tool.execute(
+				"diag-dir-aborted",
+				{ path: tmpDir, severity: "all", concurrency: 2 },
+				controller.signal,
+				null,
+				{ cwd: "." },
+			)) as any;
+
+			// Files were collected by the walk (filesScanned reflects that), but the
+			// abort-aware fan-out opened NONE of them in the language server — the
+			// #343 invariant: no in-flight files after the turn is abandoned.
+			expect(
+				(mocked.service as { openFile: ReturnType<typeof vi.fn> }).openFile,
+			).not.toHaveBeenCalled();
+			expect(result.isError).toBeUndefined();
+			expect(result.details?.mode).toBe("directory");
+			expect(result.details?.totalDiagnostics).toBe(0);
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
 	it("skips canonical excluded dirs during directory scans", async () => {
 		const tool = createLspDiagnosticsTool();
 		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-lsp-diag-"));

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -68,7 +68,7 @@ type WorkspaceLspDiagnosticResult = {
 // aborts the scan so it always returns (partial) rather than never. Env-tunable.
 const FULL_SCAN_WALL_CLOCK_MS = (() => {
 	const raw = Number(process.env.PI_LENS_LENS_DIAGNOSTICS_FULL_TIMEOUT_MS);
-	return Number.isFinite(raw) && raw > 0 ? raw : 180_000; // 3 min default
+	return Number.isFinite(raw) && raw > 0 ? raw : 300_000; // 5 min default
 })();
 
 export function createLensDiagnosticsTool(


### PR DESCRIPTION
Two small, cohesive diagnostics changes.

## 1. `lsp_diagnostics` cancellation hygiene (closes #343)

Follow-up from #341/#342 (which made `lens_diagnostics mode=full` bounded + cancellable). #343 tracked the same gap in `lsp_diagnostics`'s batch/directory fan-out, at lower severity (every path is hard-capped: 1 file / 50 dir / 100 batch — so it's uncancellable-but-bounded, not a hang).

**The code path is already wired:** `execute` combines the tool-call signal (`_signal`) with the turn signal (`ctx.signal`) via `combineAbortSignals` and threads it into `runBatchFileDiagnostics` / `runDirectoryDiagnostics`, and `mapWithConcurrency`'s worker loop returns early on `signal.aborted`. That landed alongside the progress-bar/#341–342 work.

**What was missing was the acceptance test.** This PR adds it:
- Batch mode with an already-aborted signal → `openFile` never called, partial result returned (`filesChecked: 0`).
- Directory mode with an already-aborted signal → the walk still collects files, but the fan-out opens **none** of them in the language server (the #343 invariant: no in-flight files after the turn is abandoned).

In-flight files remain bounded by `waitMs`; only the scheduling of *new* files stops.

## 2. Raise `lens_diagnostics mode=full` budget 3 min → 5 min

Large monorepos with many cold language servers were hitting the 180s wall-clock ceiling and returning partial results before the sweep finished. Default is now 300s, still env-tunable via `PI_LENS_LENS_DIAGNOSTICS_FULL_TIMEOUT_MS`.

## Tests

- Two new `#343` abort tests in `lsp-diagnostics.test.ts`.
- Full suite green (2680 passed).

## Changelog

`[Unreleased]` → Changed (budget) + Fixed (#343).

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)