### PR TITLE
refactor(tree-sitter): share one TreeSitterClient across subsystems (#402 Phase 2 seam)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Unified tree-sitter parsing on a single shared client** (refs #402) — the dispatch tree-sitter runner, project scanner, `module-report`, and review-graph each held their **own** `TreeSitterClient`, so a file written on the hot path was parsed multiple times with no shared tree cache, and each subsystem re-loaded grammars independently. They now share one process-wide client via `clients/tree-sitter-shared.ts` (`getSharedTreeSitterClient` + a single `resolveTreeSitterLanguage` ext→grammar map), so a file parsed by one subsystem is served from the shared tree cache for the others (one parse per write). This also fixes a latent gap: web-tree-sitter's WASM runtime is module-level (one per process), so an Emscripten `abort()` corrupts it for **everyone** — previously only the runner tracked the poison flag while the scanner/module-report/review-graph kept calling the dead runtime; `markTreeSitterWasmAborted()` now makes every consumer skip. Foundation for porting the syntactic TS-AST consumers (fact providers, complexity, rules) off the `typescript` dependency onto tree-sitter.
+
 ### Removed
 
 - **Removed the deprecated built-in TypeScript type-checker fallback** (#402, Phase 1) — the `ts-lsp` dispatch runner and its `TypeScriptClient` (`typescript-client.ts`) are deleted, along with the dead `TypeScriptService` (`ts-service.ts`, which had no consumers). TS type-checking is now **LSP-only** (tsserver via the unified `lsp` runner, which is default-on and was already the primary path — `ts-lsp` merely deferred to it). **Behaviour change:** running with `--no-lsp` no longer provides TS *type* diagnostics; the write-path linters (eslint/oxlint/biome) and structural analysis (tree-sitter, ast-grep, fact-rules) are unaffected. This removes the only `ts.createProgram`/`createLanguageService`/`TypeChecker` usage in the codebase — the first step toward dropping the heavyweight `typescript` dependency entirely (remaining usage is purely syntactic AST parsing, portable to tree-sitter).

--- a/clients/dispatch/runners/tree-sitter.ts
+++ b/clients/dispatch/runners/tree-sitter.ts
@@ -14,7 +14,13 @@ import {
 	computeImpactCascade,
 	recordEntitySnapshotDiff,
 } from "../../review-graph/service.js";
-import { TreeSitterClient } from "../../tree-sitter-client.js";
+import type { TreeSitterClient } from "../../tree-sitter-client.js";
+import {
+	getSharedTreeSitterClient,
+	isTreeSitterWasmAborted,
+	markTreeSitterWasmAborted,
+	resolveTreeSitterLanguage,
+} from "../../tree-sitter-shared.js";
 import { logTreeSitter } from "../../tree-sitter-logger.js";
 import {
 	isDisabledQueryFilePath,
@@ -30,15 +36,6 @@ import type {
 	RunnerResult,
 } from "../types.js";
 
-// Module-level singleton: web-tree-sitter WASM must only be initialized once per process.
-// Creating a new TreeSitterClient() on every write resets TRANSFER_BUFFER (a module-level
-// WASM pointer) — concurrent writes race on _ts_init() and corrupt shared WASM state → crash.
-let _sharedClient: TreeSitterClient | null = null;
-// Once the wasm runtime aborts, the entire module-level wasm heap is corrupted — no
-// recovery is possible within this process. Flag it and skip all further tree-sitter work
-// rather than re-invoking the dead runtime (which prints "Aborted()" on every call and
-// leaks memory on each retry).
-let _wasmAborted = false;
 const blastCooldownByFile = new Map<string, number>();
 const BLAST_COOLDOWN_MS = 5_000;
 
@@ -337,14 +334,6 @@ function isLineInModifiedRanges(
 	return ranges.some((r) => line >= r.start && line <= r.end);
 }
 
-function getSharedClient(): TreeSitterClient | null {
-	if (_wasmAborted) return null;
-	if (!_sharedClient) {
-		_sharedClient = new TreeSitterClient();
-	}
-	return _sharedClient;
-}
-
 /**
  * Calculate total lines changed in modified ranges.
  * Used to skip expensive entity extraction for trivial changes.
@@ -359,47 +348,6 @@ function getTotalLinesChanged(
 /** Threshold: skip entity extraction for changes under 5 lines */
 const ENTITY_EXTRACTION_LINE_THRESHOLD = 5;
 
-function resolveTreeSitterLanguage(filePath: string): string | undefined {
-	const ext = path.extname(filePath).toLowerCase();
-	const EXT_TO_LANG: Record<string, string> = {
-		".ts": "typescript",
-		".mts": "typescript",
-		".cts": "typescript",
-		".tsx": "tsx",
-		".js": "javascript",
-		".mjs": "javascript",
-		".cjs": "javascript",
-		".jsx": "javascript",
-		".py": "python",
-		".go": "go",
-		".rs": "rust",
-		".rb": "ruby",
-		".c": "c",
-		".h": "c",
-		".cc": "cpp",
-		".cpp": "cpp",
-		".cxx": "cpp",
-		".c++": "cpp",
-		".hh": "cpp",
-		".hpp": "cpp",
-		".hxx": "cpp",
-		".inl": "cpp",
-		".ipp": "cpp",
-		".tpp": "cpp",
-		".txx": "cpp",
-		".cu": "cpp",
-		".hip": "cpp",
-		".cs": "csharp",
-		".php": "php",
-		".phtml": "php",
-		".php3": "php",
-		".php4": "php",
-		".php5": "php",
-		".css": "css",
-	};
-	return EXT_TO_LANG[ext];
-}
-
 const treeSitterRunner: RunnerDefinition = {
 	id: "tree-sitter",
 	appliesTo: ["jsts", "python", "go", "rust", "ruby", "cxx", "csharp", "php", "css"],
@@ -409,13 +357,13 @@ const treeSitterRunner: RunnerDefinition = {
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {
 		// Use singleton client — WASM must never be re-initialized after first call
-		const client = getSharedClient();
+		const client = getSharedTreeSitterClient();
 		logTreeSitter({ phase: "runner_start", filePath: ctx.filePath });
 		if (!client || !client.isAvailable()) {
 			logTreeSitter({
 				phase: "runner_skip",
 				filePath: ctx.filePath,
-				reason: _wasmAborted ? "wasm_aborted" : "client_unavailable",
+				reason: isTreeSitterWasmAborted() ? "wasm_aborted" : "client_unavailable",
 				status: "skipped",
 			});
 			return { status: "skipped", diagnostics: [], semantic: "none" };
@@ -652,8 +600,7 @@ const treeSitterRunner: RunnerDefinition = {
 						// Emscripten abort() corrupts the entire module-level wasm heap.
 						// Poison the singleton so no further queries attempt to use the dead runtime.
 						if (msg.includes("Aborted") || msg.includes("abort()")) {
-							_wasmAborted = true;
-							_sharedClient = null;
+							markTreeSitterWasmAborted();
 							logTreeSitter({
 								phase: "query_error",
 								filePath,

--- a/clients/module-report.ts
+++ b/clients/module-report.ts
@@ -39,7 +39,7 @@ import { normalizeMapKey } from "./path-utils.js";
 import { resolveImportToFiles } from "./review-graph/import-resolvers.js";
 import type { ReviewGraph, ReviewGraphEdgeKind } from "./review-graph/types.js";
 import type { Symbol as ExtractedSymbol } from "./symbol-types.js";
-import { TreeSitterClient } from "./tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "./tree-sitter-shared.js";
 import {
 	type ImportRef,
 	TreeSitterSymbolExtractor,
@@ -307,9 +307,9 @@ function tsLangForFile(
 	return kind ? KIND_TO_TS_LANG[kind] : undefined;
 }
 
-// Shared parser + per-language extractor cache. The TreeSitterClient memoizes
-// its own grammar init; extractors are cheap once their queries are compiled.
-const tsClient = new TreeSitterClient();
+// Per-language extractor cache — extractors are cheap once their queries are
+// compiled. The shared TreeSitterClient (which memoizes grammar init) is obtained
+// per call from the process-wide singleton.
 const extractorCache = new Map<
 	string,
 	Promise<TreeSitterSymbolExtractor | null>
@@ -321,7 +321,9 @@ async function getExtractor(
 	let cached = extractorCache.get(languageId);
 	if (!cached) {
 		cached = (async () => {
-			const extractor = new TreeSitterSymbolExtractor(languageId, tsClient);
+			const client = getSharedTreeSitterClient();
+			if (!client) return null;
+			const extractor = new TreeSitterSymbolExtractor(languageId, client);
 			const ok = await extractor.init();
 			return ok ? extractor : null;
 		})().catch((err) => {
@@ -360,6 +362,14 @@ async function extractFile(
 	warnings?: string[];
 }> {
 	try {
+		const tsClient = getSharedTreeSitterClient();
+		if (!tsClient) {
+			return {
+				symbols: [],
+				imports: [],
+				error: "tree-sitter runtime unavailable (wasm aborted)",
+			};
+		}
 		const initialized = await tsClient.init();
 		if (!initialized) {
 			return {

--- a/clients/project-diagnostics/scanner.ts
+++ b/clients/project-diagnostics/scanner.ts
@@ -13,7 +13,7 @@ import {
 import type { Diagnostic } from "../dispatch/types.js";
 import { isTestFile } from "../file-utils.js";
 import { collectSourceFilesAsync } from "../source-filter.js";
-import { TreeSitterClient } from "../tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../tree-sitter-shared.js";
 import { TreeSitterQueryLoader } from "../tree-sitter-query-loader.js";
 import {
 	PROJECT_DIAGNOSTICS_CACHE_VERSION,
@@ -58,11 +58,6 @@ const TREE_SITTER_EXT_TO_LANG: Record<string, string> = {
 	".rb": "ruby",
 };
 
-let sharedTreeSitterClient: TreeSitterClient | undefined;
-function getTreeSitterClient(): TreeSitterClient {
-	sharedTreeSitterClient ??= new TreeSitterClient();
-	return sharedTreeSitterClient;
-}
 
 function normalizeSeverity(
 	severity: string | undefined,
@@ -132,8 +127,8 @@ async function scanTreeSitter(
 	cwd: string,
 	files: string[],
 ): Promise<ProjectDiagnostic[]> {
-	const client = getTreeSitterClient();
-	if (!client.isAvailable()) return [];
+	const client = getSharedTreeSitterClient();
+	if (!client || !client.isAvailable()) return [];
 	if (!(await client.init())) return [];
 
 	const loader = new TreeSitterQueryLoader();

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -15,7 +15,7 @@ import { normalizeMapKey } from "../path-utils.js";
 import { collectProjectSourceFilesAsync } from "../project-scan-policy.js";
 import { resolveImportToFiles } from "./import-resolvers.js";
 import { RUNTIME_CONFIG } from "../runtime-config.js";
-import { TreeSitterClient } from "../tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../tree-sitter-shared.js";
 import {
 	type ExtractedSymbols,
 	TreeSitterSymbolExtractor,
@@ -56,7 +56,6 @@ const MAIN_KIND_EXTENSIONS: string[] = Array.from(MAIN_KINDS).flatMap(
 	(kind) => KIND_EXTENSIONS[kind as keyof typeof KIND_EXTENSIONS] ?? [],
 );
 const CHANGED_SYMBOLS_PREFIX = "session.reviewGraph.changedSymbols:";
-const treeSitterClient = new TreeSitterClient();
 const extractorCache = new Map<string, TreeSitterSymbolExtractor>();
 
 // Per-invocation Promise cache: deduplicates concurrent buildOrUpdateGraph calls
@@ -918,7 +917,9 @@ async function getExtractor(
 	languageId: string,
 ): Promise<TreeSitterSymbolExtractor | null> {
 	if (extractorCache.has(languageId)) return extractorCache.get(languageId)!;
-	const extractor = new TreeSitterSymbolExtractor(languageId, treeSitterClient);
+	const client = getSharedTreeSitterClient();
+	if (!client) return null;
+	const extractor = new TreeSitterSymbolExtractor(languageId, client);
 	const ok = await extractor.init();
 	if (!ok) return null;
 	extractorCache.set(languageId, extractor);
@@ -930,6 +931,8 @@ async function extractTreeSitterSymbols(
 	languageId: string,
 ): Promise<ExtractedSymbols> {
 	const empty: ExtractedSymbols = { symbols: [], refs: [], imports: [] };
+	const treeSitterClient = getSharedTreeSitterClient();
+	if (!treeSitterClient) return empty;
 	const initialized = await treeSitterClient.init();
 	if (!initialized) return empty;
 	const tree = await treeSitterClient.parseFile(filePath, languageId);

--- a/clients/tree-sitter-shared.ts
+++ b/clients/tree-sitter-shared.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared TreeSitterClient singleton + ext→language resolver.
+ *
+ * web-tree-sitter's WASM runtime is module-level — one per process. TRANSFER_BUFFER
+ * and _ts_init are global, so every subsystem MUST share a single TreeSitterClient:
+ * separate clients race on init and corrupt the shared WASM heap. This module is
+ * that single seam — the dispatch tree-sitter runner, project scanner, module-report,
+ * review-graph, and fact providers all obtain their client here, so a file parsed by
+ * one is served from the shared tree cache for the others (one parse per write).
+ *
+ * Once the WASM runtime aborts (Emscripten abort()), the heap is corrupted with no
+ * in-process recovery. markTreeSitterWasmAborted() poisons the singleton so EVERY
+ * consumer skips further tree-sitter work (previously only the runner tracked this,
+ * while the other subsystems kept calling the dead runtime).
+ */
+import * as path from "node:path";
+import { TreeSitterClient } from "./tree-sitter-client.js";
+
+let _shared: TreeSitterClient | null = null;
+let _wasmAborted = false;
+
+/** The process-wide TreeSitterClient, or null once the WASM runtime has aborted. */
+export function getSharedTreeSitterClient(): TreeSitterClient | null {
+	if (_wasmAborted) return null;
+	_shared ??= new TreeSitterClient();
+	return _shared;
+}
+
+export function isTreeSitterWasmAborted(): boolean {
+	return _wasmAborted;
+}
+
+/**
+ * Poison the singleton after an unrecoverable Emscripten abort() — the module-level
+ * WASM heap is corrupted, so no client can be used again this process.
+ */
+export function markTreeSitterWasmAborted(): void {
+	_wasmAborted = true;
+	_shared = null;
+}
+
+/** Test-only: reset the singleton + abort flag. */
+export function _resetSharedTreeSitterClientForTests(): void {
+	_shared = null;
+	_wasmAborted = false;
+}
+
+// Grammar selection by extension. `.tsx` → the tsx grammar (parses JSX); `.jsx` →
+// the javascript grammar. NOTE: the project scanner keeps its OWN ext→lang map
+// because its query lookup is keyed by language id (it maps `.tsx`→typescript to
+// reuse typescript queries) — do not fold that one in without re-keying its queries.
+const EXT_TO_LANG: Record<string, string> = {
+	".ts": "typescript",
+	".mts": "typescript",
+	".cts": "typescript",
+	".tsx": "tsx",
+	".js": "javascript",
+	".mjs": "javascript",
+	".cjs": "javascript",
+	".jsx": "javascript",
+	".py": "python",
+	".go": "go",
+	".rs": "rust",
+	".rb": "ruby",
+	".c": "c",
+	".h": "c",
+	".cc": "cpp",
+	".cpp": "cpp",
+	".cxx": "cpp",
+	".c++": "cpp",
+	".hh": "cpp",
+	".hpp": "cpp",
+	".hxx": "cpp",
+	".inl": "cpp",
+	".ipp": "cpp",
+	".tpp": "cpp",
+	".txx": "cpp",
+	".cu": "cpp",
+	".hip": "cpp",
+	".cs": "csharp",
+	".php": "php",
+	".phtml": "php",
+	".php3": "php",
+	".php4": "php",
+	".php5": "php",
+	".css": "css",
+};
+
+/** Resolve a tree-sitter grammar/language id from a file path's extension. */
+export function resolveTreeSitterLanguage(filePath: string): string | undefined {
+	return EXT_TO_LANG[path.extname(filePath).toLowerCase()];
+}

--- a/tests/clients/tree-sitter-abort-degrade.test.ts
+++ b/tests/clients/tree-sitter-abort-degrade.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { FactStore } from "../../clients/dispatch/fact-store.js";
+import { moduleReport } from "../../clients/module-report.js";
+import { buildOrUpdateGraph } from "../../clients/review-graph/builder.js";
+import {
+	_resetSharedTreeSitterClientForTests,
+	markTreeSitterWasmAborted,
+} from "../../clients/tree-sitter-shared.js";
+import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+
+/**
+ * After an unrecoverable Emscripten abort() the shared TreeSitterClient is
+ * poisoned process-wide (#402 seam). Every consumer that moved onto the shared
+ * client must DEGRADE — return an empty/annotated result — never throw. These
+ * exercise the `if (!client) return <empty>` guards added to the migrated sites,
+ * which the happy-path suite (healthy client) never reaches.
+ *
+ * Isolated in its own file so the module-level poison can't leak into other
+ * test files' tree-sitter usage; reset after each test regardless.
+ */
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length) cleanups.pop()?.();
+	_resetSharedTreeSitterClientForTests(); // un-poison the singleton
+});
+
+describe("tree-sitter wasm-abort degradation (shared client)", () => {
+	it("module_report returns an unavailable report instead of throwing", async () => {
+		const env = setupTestEnvironment("pi-lens-tsabort-mr-");
+		cleanups.push(env.cleanup);
+		const file = createTempFile(env.tmpDir, "m.ts", "export const x = 1;\n");
+
+		markTreeSitterWasmAborted();
+
+		const report = await moduleReport(file, env.tmpDir);
+		expect(report.available).toBe(false);
+		expect(report.error ?? "").toMatch(/aborted|unavailable/i);
+		expect(report.api).toEqual([]);
+	});
+
+	it("review-graph build completes (empty symbols) instead of throwing", async () => {
+		const env = setupTestEnvironment("pi-lens-tsabort-rg-");
+		cleanups.push(env.cleanup);
+		const file = createTempFile(env.tmpDir, "a.ts", "export function f() {}\n");
+
+		markTreeSitterWasmAborted();
+
+		// Poisoned parser ⇒ extractTreeSitterSymbols returns empty; the build must
+		// still resolve without throwing.
+		await expect(
+			buildOrUpdateGraph(env.tmpDir, [file], new FactStore()),
+		).resolves.toBeDefined();
+	});
+});

--- a/tests/clients/tree-sitter-shared.test.ts
+++ b/tests/clients/tree-sitter-shared.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	_resetSharedTreeSitterClientForTests,
+	getSharedTreeSitterClient,
+	isTreeSitterWasmAborted,
+	markTreeSitterWasmAborted,
+	resolveTreeSitterLanguage,
+} from "../../clients/tree-sitter-shared.js";
+
+afterEach(() => {
+	_resetSharedTreeSitterClientForTests();
+});
+
+describe("resolveTreeSitterLanguage", () => {
+	it.each([
+		[".ts", "typescript"],
+		[".mts", "typescript"],
+		[".cts", "typescript"],
+		[".tsx", "tsx"], // JSX-capable grammar (differs from the scanner's query-keyed map)
+		[".js", "javascript"],
+		[".mjs", "javascript"],
+		[".cjs", "javascript"],
+		[".jsx", "javascript"],
+		[".py", "python"],
+		[".go", "go"],
+		[".rs", "rust"],
+		[".rb", "ruby"],
+		[".c", "c"],
+		[".cpp", "cpp"],
+		[".cs", "csharp"],
+		[".php", "php"],
+		[".css", "css"],
+	])("maps %s -> %s", (ext, lang) => {
+		expect(resolveTreeSitterLanguage(`src/file${ext}`)).toBe(lang);
+	});
+
+	it("is case-insensitive on the extension", () => {
+		expect(resolveTreeSitterLanguage("SRC/FILE.TS")).toBe("typescript");
+	});
+
+	it("returns undefined for unsupported extensions", () => {
+		expect(resolveTreeSitterLanguage("file.md")).toBeUndefined();
+		expect(resolveTreeSitterLanguage("file")).toBeUndefined();
+	});
+});
+
+describe("shared TreeSitterClient singleton", () => {
+	it("returns the same instance across calls (one client per process)", () => {
+		const a = getSharedTreeSitterClient();
+		const b = getSharedTreeSitterClient();
+		expect(a).not.toBeNull();
+		expect(a).toBe(b);
+	});
+
+	it("poisons the singleton after a wasm abort (process-wide skip)", () => {
+		expect(isTreeSitterWasmAborted()).toBe(false);
+		expect(getSharedTreeSitterClient()).not.toBeNull();
+
+		markTreeSitterWasmAborted();
+
+		expect(isTreeSitterWasmAborted()).toBe(true);
+		// Every consumer now gets null and must skip tree-sitter work.
+		expect(getSharedTreeSitterClient()).toBeNull();
+	});
+
+	it("test reset restores a fresh, usable singleton", () => {
+		markTreeSitterWasmAborted();
+		expect(getSharedTreeSitterClient()).toBeNull();
+
+		_resetSharedTreeSitterClientForTests();
+
+		expect(isTreeSitterWasmAborted()).toBe(false);
+		expect(getSharedTreeSitterClient()).not.toBeNull();
+	});
+});


### PR DESCRIPTION
The foundation for porting pi-lens's syntactic TS-AST consumers off the `typescript` dependency onto tree-sitter (#402 Phase 2). Consolidation flagged during the import-facts investigation.

## Problem
The dispatch **tree-sitter runner**, **project scanner**, **module-report**, and **review-graph** each did `new TreeSitterClient()`. Consequences:
- A file written on the hot path was parsed **multiple times** (once per subsystem) with **no shared tree cache**, and each subsystem re-loaded grammars independently.
- web-tree-sitter's WASM runtime is **module-level (one per process)** — separate clients race on `_ts_init`/`TRANSFER_BUFFER` (the runner's own comment warns about this).
- Latent bug: on an Emscripten `abort()` the WASM heap is corrupted **process-wide**, but only the runner tracked the poison flag — the scanner/module-report/review-graph kept calling the dead runtime.

## Change
New `clients/tree-sitter-shared.ts` is the single seam:
- **`getSharedTreeSitterClient()`** — one process-wide client → shared tree cache (**one parse per write**) + one grammar init.
- **`resolveTreeSitterLanguage()`** — the ext→grammar map, previously duplicated in the runner. (The scanner keeps its own map because its query lookup is keyed by language id — `.tsx`→typescript there vs `.tsx`→tsx here; noted inline, left for a separate call.)
- **`markTreeSitterWasmAborted()`** — the wasm-abort poison is now process-wide, so **every** consumer skips the dead runtime.

All four sites migrated with null-guards (null client → skip/degrade, matching each site's existing failure path). **Behaviour-preserving** apart from the wasm-abort now correctly poisoning all subsystems (a robustness fix).

## Verification
`build` ✅ · `lint` ✅ · `npm test` ✅ 2709 passed (280 files; the lone worker-teardown assertion is the known Windows spawn-smoke flake). New `tree-sitter-shared.test.ts`: 22 cases (resolver mapping + singleton identity + abort poison + reset).

Refs #402. Next: port `import-facts` (and the other fact/rule/complexity providers) onto this seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)