### PR TITLE
refactor(complexity): language-agnostic tree-sitter complexity metrics (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Complexity metrics are now language-agnostic and tree-sitter-based** (#402) — `ComplexityClient` no longer uses the `typescript` compiler; it computes cyclomatic + cognitive complexity, nesting depth, function metrics, LOC/comments, code entropy, and AI-slop indicators over the shared tree-sitter client via a per-language node table. Beyond JS/TS it now also analyzes **Python, Go, and Rust** (adding a language is one table entry). Halstead volume is dropped (its maintainability-index term is replaced with the Halstead-free variant `171 − 0.23·CC − 16.2·ln(LOC)` + comment bonus); the dead `formatMetrics`/`checkThresholds` methods are removed. These are silent session-summary baselines, so the metric surface is unchanged aside from the dropped `halsteadVolume` field. `analyzeFile` is now async (grammar parse). Only the sonar/quality **rules** still import `typescript` — the last #402 Phase-2 step before the dependency is dropped.
+
 ### Fixed
 
 - **Tree-sitter no longer leaks WASM heap memory across a session** (#417) — web-tree-sitter `Tree` objects live in the WASM heap, which JS GC does **not** reclaim (0.25 has no auto-free); the tree cache dropped evicted/invalidated/overwritten trees with `Map.delete()` and never called `tree.delete()`, so every removed tree leaked. The cache bounded entry count (50) but not the heap, so it grew unbounded over a long editing session. `TreeCache` now frees the WASM tree on every removal path — eviction, same-file re-parse (same-key overwrite), on-disk change/deletion invalidations, `invalidate()`, and `clear()` — via a guarded `freeTree()` (best-effort; tolerates a dead/aborted runtime). The retained-for-incremental path (content changed, tree kept) is deliberately not freed. Safe because every consumer uses a parsed tree transiently (parse → extract → discard) and eviction only ever targets the oldest entry, never a just-parsed tree still in use.

--- a/clients/complexity-client.ts
+++ b/clients/complexity-client.ts
@@ -1,24 +1,25 @@
 /**
- * Complexity Metrics Client for pi-lens (cache test)
+ * Complexity Metrics Client for pi-lens
  *
- * Calculates AST-based code complexity metrics for TypeScript/JavaScript files.
- * Uses the TypeScript compiler API for parsing.
+ * Language-agnostic AST-based code complexity metrics, computed over the shared
+ * tree-sitter client (#402 — no `typescript` compiler dependency). Supported
+ * grammars are keyed in LANGUAGE_NODES (JS/TS, Python, Go, Rust today; adding a
+ * language is one table entry).
  *
- * Tracks:
- * - Max Nesting Depth: Deepest control flow nesting
- * - Avg/Max Function Length: Lines per function
- * - Cyclomatic Complexity: Independent code paths (M = E - N + 2P)
- * - Cognitive Complexity: Human understanding difficulty
- * - Halstead Volume: Vocabulary-based complexity
- * - Maintainability Index: Composite score (0-100, higher is better)
- *
- * These are silent metrics shown in session summary.
+ * Tracks: max nesting depth, function length, cyclomatic + cognitive complexity,
+ * maintainability index (Halstead-free), LOC/comments, code entropy, and AI-slop
+ * indicators. These are silent metrics surfaced in the session summary.
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { ts } from "./deps/typescript.js";
-import { isFileKind } from "./file-kinds.js";
+import {
+	firstChildOfType,
+	parseTreeSitterRoot,
+	resolveTreeSitterLanguage,
+	type TsNode,
+	walk,
+} from "./tree-sitter-shared.js";
 
 // --- Types ---
 
@@ -31,16 +32,15 @@ export interface FileComplexity {
 	cyclomaticComplexity: number; // Average across functions
 	maxCyclomaticComplexity: number; // Most complex function
 	cognitiveComplexity: number;
-	halsteadVolume: number;
 	maintainabilityIndex: number; // 0-100
 	linesOfCode: number;
 	commentLines: number;
-	codeEntropy: number; // Shannon entropy (0-1, lower = more predictable)
+	codeEntropy: number; // Shannon entropy in bits
 	// AI slop indicators
-	maxParamsInFunction: number; // Max parameters in any function
-	aiCommentPatterns: number; // Emoji comments, boilerplate phrases
-	singleUseFunctions: number; // Functions only called once (estimated)
-	tryCatchCount: number; // Number of try/catch blocks
+	maxParamsInFunction: number;
+	aiCommentPatterns: number;
+	singleUseFunctions: number;
+	tryCatchCount: number;
 }
 
 export interface FunctionMetrics {
@@ -52,102 +52,417 @@ export interface FunctionMetrics {
 	nestingDepth: number;
 }
 
-// --- Constants ---
+// --- Per-language node categories ---
 
-// Nodes that increase cyclomatic complexity
-const CYCLOMAL_NODES = new Set([
-	ts.SyntaxKind.IfStatement,
-	ts.SyntaxKind.WhileStatement,
-	ts.SyntaxKind.ForStatement,
-	ts.SyntaxKind.ForInStatement,
-	ts.SyntaxKind.ForOfStatement,
-	ts.SyntaxKind.CaseClause,
-	ts.SyntaxKind.ConditionalExpression,
-	ts.SyntaxKind.BinaryExpression, // && and ||
-]);
+interface LangNodes {
+	/** Function/method/lambda nodes. */
+	functionLike: Set<string>;
+	/** Control structures that increase nesting depth. */
+	nesting: Set<string>;
+	/** Decision points that add +1 cyclomatic (if/loops/case/ternary). */
+	decision: Set<string>;
+	/** Structures that add cognitive complexity (nesting-weighted). */
+	cognitive: Set<string>;
+	/** Node types that ARE a logical operator (e.g. Python `boolean_operator`). */
+	logicalOpNodes: Set<string>;
+	/** Operator child types inside a `binary_expression` (&& || ??). */
+	logicalBinaryOps: Set<string>;
+	/** Node type for a try/catch block, if the language has one. */
+	tryNode?: string;
+	/** Child node types to read a function's name from (in priority order). */
+	nameChildTypes: string[];
+}
 
-// Nodes that increase cognitive complexity (with nesting penalty)
-const COGNITIVE_NODES = new Set([
-	ts.SyntaxKind.IfStatement,
-	ts.SyntaxKind.WhileStatement,
-	ts.SyntaxKind.ForStatement,
-	ts.SyntaxKind.ForInStatement,
-	ts.SyntaxKind.ForOfStatement,
-	ts.SyntaxKind.SwitchStatement,
-	ts.SyntaxKind.CaseClause,
-	ts.SyntaxKind.ConditionalExpression,
-	ts.SyntaxKind.CatchClause,
-]);
+// JS/TS/JSX share one grammar shape.
+const JSTS: LangNodes = {
+	functionLike: new Set([
+		"function_declaration",
+		"method_definition",
+		"function_expression",
+		"arrow_function",
+		"generator_function",
+		"generator_function_declaration",
+	]),
+	nesting: new Set([
+		"if_statement",
+		"while_statement",
+		"for_statement",
+		"for_in_statement",
+		"switch_statement",
+		"function_declaration",
+		"function_expression",
+		"arrow_function",
+		"method_definition",
+		"class_declaration",
+		"try_statement",
+		"catch_clause",
+	]),
+	decision: new Set([
+		"if_statement",
+		"while_statement",
+		"for_statement",
+		"for_in_statement",
+		"switch_case",
+		"ternary_expression",
+	]),
+	cognitive: new Set([
+		"if_statement",
+		"while_statement",
+		"for_statement",
+		"for_in_statement",
+		"switch_statement",
+		"switch_case",
+		"ternary_expression",
+		"catch_clause",
+	]),
+	logicalOpNodes: new Set(),
+	logicalBinaryOps: new Set(["&&", "||", "??"]),
+	tryNode: "try_statement",
+	nameChildTypes: ["identifier", "property_identifier"],
+};
 
-// Nesting-increasing nodes
-const NESTING_NODES = new Set([
-	ts.SyntaxKind.IfStatement,
-	ts.SyntaxKind.WhileStatement,
-	ts.SyntaxKind.ForStatement,
-	ts.SyntaxKind.ForInStatement,
-	ts.SyntaxKind.ForOfStatement,
-	ts.SyntaxKind.SwitchStatement,
-	ts.SyntaxKind.FunctionDeclaration,
-	ts.SyntaxKind.FunctionExpression,
-	ts.SyntaxKind.ArrowFunction,
-	ts.SyntaxKind.ClassDeclaration,
-	ts.SyntaxKind.MethodDeclaration,
-	ts.SyntaxKind.TryStatement,
-	ts.SyntaxKind.CatchClause,
-]);
+const PYTHON: LangNodes = {
+	functionLike: new Set(["function_definition", "lambda"]),
+	nesting: new Set([
+		"if_statement",
+		"for_statement",
+		"while_statement",
+		"match_statement",
+		"function_definition",
+		"class_definition",
+		"try_statement",
+		"except_clause",
+		"elif_clause",
+	]),
+	decision: new Set([
+		"if_statement",
+		"elif_clause",
+		"for_statement",
+		"while_statement",
+		"case_clause",
+		"conditional_expression",
+	]),
+	cognitive: new Set([
+		"if_statement",
+		"elif_clause",
+		"for_statement",
+		"while_statement",
+		"match_statement",
+		"case_clause",
+		"conditional_expression",
+		"except_clause",
+	]),
+	logicalOpNodes: new Set(["boolean_operator"]),
+	logicalBinaryOps: new Set(),
+	tryNode: "try_statement",
+	nameChildTypes: ["identifier"],
+};
 
-// Function-like nodes
-const FUNCTION_LIKE_NODES = new Set([
-	ts.SyntaxKind.FunctionDeclaration,
-	ts.SyntaxKind.FunctionExpression,
-	ts.SyntaxKind.ArrowFunction,
-	ts.SyntaxKind.MethodDeclaration,
-	ts.SyntaxKind.Constructor,
-	ts.SyntaxKind.GetAccessor,
-	ts.SyntaxKind.SetAccessor,
-]);
+const GO: LangNodes = {
+	functionLike: new Set([
+		"function_declaration",
+		"method_declaration",
+		"func_literal",
+	]),
+	nesting: new Set([
+		"if_statement",
+		"for_statement",
+		"expression_switch_statement",
+		"type_switch_statement",
+		"select_statement",
+		"function_declaration",
+		"method_declaration",
+	]),
+	decision: new Set([
+		"if_statement",
+		"for_statement",
+		"expression_case",
+		"type_case",
+		"communication_case",
+	]),
+	cognitive: new Set([
+		"if_statement",
+		"for_statement",
+		"expression_switch_statement",
+		"type_switch_statement",
+		"select_statement",
+		"expression_case",
+		"type_case",
+		"communication_case",
+	]),
+	logicalOpNodes: new Set(),
+	logicalBinaryOps: new Set(["&&", "||"]),
+	tryNode: undefined, // Go has no try/catch (error returns)
+	nameChildTypes: ["identifier", "field_identifier"],
+};
 
-// Halstead operators (common operators)
-const HALSTEAD_OPERATORS = new Set([
-	ts.SyntaxKind.PlusToken,
-	ts.SyntaxKind.MinusToken,
-	ts.SyntaxKind.AsteriskToken,
-	ts.SyntaxKind.SlashToken,
-	ts.SyntaxKind.PercentToken,
-	ts.SyntaxKind.AmpersandToken,
-	ts.SyntaxKind.BarToken,
-	ts.SyntaxKind.CaretToken,
-	ts.SyntaxKind.LessThanToken,
-	ts.SyntaxKind.GreaterThanToken,
-	ts.SyntaxKind.LessThanEqualsToken,
-	ts.SyntaxKind.GreaterThanEqualsToken,
-	ts.SyntaxKind.EqualsEqualsToken,
-	ts.SyntaxKind.ExclamationEqualsToken,
-	ts.SyntaxKind.EqualsEqualsEqualsToken,
-	ts.SyntaxKind.ExclamationEqualsEqualsToken,
-	ts.SyntaxKind.PlusPlusToken,
-	ts.SyntaxKind.MinusMinusToken,
-	ts.SyntaxKind.PlusEqualsToken,
-	ts.SyntaxKind.MinusEqualsToken,
-	ts.SyntaxKind.AsteriskEqualsToken,
-	ts.SyntaxKind.SlashEqualsToken,
-	ts.SyntaxKind.AmpersandEqualsToken,
-	ts.SyntaxKind.BarEqualsToken,
-	ts.SyntaxKind.LessThanLessThanToken,
-	ts.SyntaxKind.GreaterThanGreaterThanToken,
-	ts.SyntaxKind.QuestionToken,
-	ts.SyntaxKind.ColonToken,
-	ts.SyntaxKind.EqualsToken,
-	ts.SyntaxKind.EqualsGreaterThanToken,
-	ts.SyntaxKind.AmpersandAmpersandToken,
-	ts.SyntaxKind.BarBarToken,
-	ts.SyntaxKind.ExclamationToken,
-	ts.SyntaxKind.TildeToken,
-	ts.SyntaxKind.CommaToken,
-	ts.SyntaxKind.SemicolonToken,
-	ts.SyntaxKind.DotToken,
-	ts.SyntaxKind.QuestionDotToken,
-]);
+const RUST: LangNodes = {
+	functionLike: new Set(["function_item", "closure_expression"]),
+	nesting: new Set([
+		"if_expression",
+		"while_expression",
+		"for_expression",
+		"loop_expression",
+		"match_expression",
+		"function_item",
+	]),
+	decision: new Set([
+		"if_expression",
+		"while_expression",
+		"for_expression",
+		"loop_expression",
+		"match_arm",
+	]),
+	cognitive: new Set([
+		"if_expression",
+		"while_expression",
+		"for_expression",
+		"loop_expression",
+		"match_expression",
+		"match_arm",
+	]),
+	logicalOpNodes: new Set(),
+	logicalBinaryOps: new Set(["&&", "||"]),
+	tryNode: undefined, // Rust uses Result/? — no try/catch
+	nameChildTypes: ["identifier"],
+};
+
+const LANGUAGE_NODES: Record<string, LangNodes> = {
+	typescript: JSTS,
+	tsx: JSTS,
+	javascript: JSTS,
+	python: PYTHON,
+	go: GO,
+	rust: RUST,
+};
+
+const COMMENT_TYPES = new Set(["comment", "line_comment", "block_comment"]);
+
+// --- Metric helpers (module-level, node-config-driven) ---
+
+function isLogicalOp(node: TsNode, nodes: LangNodes): boolean {
+	if (nodes.logicalOpNodes.has(node.type)) return true;
+	if (nodes.logicalBinaryOps.size > 0 && node.type === "binary_expression") {
+		return (node.children ?? []).some(
+			(c: TsNode) => c && nodes.logicalBinaryOps.has(c.type),
+		);
+	}
+	return false;
+}
+
+/** Cyclomatic contribution of a subtree: decision points + logical operators. */
+function subtreeCyclomatic(root: TsNode, nodes: LangNodes): number {
+	let cc = 0;
+	walk(root, (n) => {
+		if (nodes.decision.has(n.type)) cc++;
+		if (isLogicalOp(n, nodes)) cc++;
+	});
+	return cc;
+}
+
+/** Cognitive complexity (SonarSource-style: base + nesting penalty). */
+function subtreeCognitive(node: TsNode, nesting: number, nodes: LangNodes): number {
+	let complexity = 0;
+	if (nodes.cognitive.has(node.type)) complexity += 1 + nesting;
+	// Labeled break/continue add complexity.
+	if (
+		(node.type === "break_statement" || node.type === "continue_statement") &&
+		(node.children ?? []).some(
+			(c: TsNode) =>
+				c &&
+				(c.type === "statement_identifier" ||
+					c.type === "identifier" ||
+					c.type === "label_name" ||
+					c.type === "label"),
+		)
+	) {
+		complexity += 1 + nesting;
+	}
+	if (isLogicalOp(node, nodes)) complexity += 1;
+	const childNesting = nodes.nesting.has(node.type) ? nesting + 1 : nesting;
+	for (const child of node.children ?? []) {
+		if (child) complexity += subtreeCognitive(child, childNesting, nodes);
+	}
+	return complexity;
+}
+
+function subtreeMaxNesting(
+	node: TsNode,
+	currentDepth: number,
+	nodes: LangNodes,
+): number {
+	let maxDepth = currentDepth;
+	if (nodes.nesting.has(node.type)) {
+		currentDepth++;
+		maxDepth = Math.max(maxDepth, currentDepth);
+	}
+	for (const child of node.children ?? []) {
+		if (child) {
+			maxDepth = Math.max(maxDepth, subtreeMaxNesting(child, currentDepth, nodes));
+		}
+	}
+	return maxDepth;
+}
+
+function functionName(fnNode: TsNode, nodes: LangNodes): string | undefined {
+	for (const t of nodes.nameChildTypes) {
+		const id = firstChildOfType(fnNode, t);
+		if (id) return id.text;
+	}
+	return undefined;
+}
+
+function collectFunctionMetrics(root: TsNode, nodes: LangNodes): FunctionMetrics[] {
+	const functions: FunctionMetrics[] = [];
+	const visit = (node: TsNode, nestingLevel: number): void => {
+		if (nodes.functionLike.has(node.type)) {
+			const startLine = node.startPosition.row;
+			const endLine = node.endPosition.row;
+			functions.push({
+				name: functionName(node, nodes) ?? `<anonymous@L${startLine + 1}>`,
+				line: startLine + 1,
+				length: endLine - startLine + 1,
+				cyclomatic: subtreeCyclomatic(node, nodes),
+				cognitive: subtreeCognitive(node, nestingLevel, nodes),
+				nestingDepth: subtreeMaxNesting(node, 0, nodes),
+			});
+		}
+		const newNesting = nodes.nesting.has(node.type)
+			? nestingLevel + 1
+			: nestingLevel;
+		for (const child of node.children ?? []) {
+			if (child) visit(child, newNesting);
+		}
+	};
+	visit(root, 0);
+	return functions;
+}
+
+function countTryCatch(root: TsNode, nodes: LangNodes): number {
+	if (!nodes.tryNode) return 0;
+	let count = 0;
+	walk(root, (n) => {
+		if (n.type === nodes.tryNode) count++;
+	});
+	return count;
+}
+
+function countLines(
+	content: string,
+	root: TsNode,
+): { codeLines: number; commentLines: number } {
+	const lines = content.split(/\r?\n/);
+	const commentLineSet = new Set<number>();
+	walk(root, (n) => {
+		if (COMMENT_TYPES.has(n.type)) {
+			for (let l = n.startPosition.row; l <= n.endPosition.row; l++) {
+				commentLineSet.add(l);
+			}
+		}
+	});
+	const codeLines = lines.filter((line, i) => {
+		if (line.trim().length === 0) return false;
+		if (!commentLineSet.has(i)) return true;
+		// Line has a comment — keep it only if code remains after stripping it.
+		const stripped = line
+			.replace(/\/\/.*$/, "")
+			.replace(/\/\*[\s\S]*?\*\//g, "")
+			.replace(/#.*$/, "")
+			.trim();
+		return stripped.length > 0;
+	}).length;
+	return { codeLines, commentLines: commentLineSet.size };
+}
+
+const AI_COMMENT_PATTERNS = [
+	/(?:🔍|✅|📝|🔧|🐛|⚠️|🚀|💡|🎯|📌|🏷️|🔑|🏗️|🧪|🗑️|🔄|♻️|📋|🔖|📊|💬|🔥|💎|⭐|🌟|🎨|🛠️)/u,
+	/(?:\/\/|#)\s*(Initialize|Setup|Clean up|Create|Define|Check if|Handle|Process|Validate|Return|Get|Set|Add|Remove|Update|Fetch)\b/i,
+	/(?:\/\/|#)\s*(This function|This method|This code|Here we|Now we)\b/i,
+	/\/\*\*?\s*(Overview|Summary|Description|Example|Usage)\s*\*?\//i,
+];
+
+function countAICommentPatterns(sourceText: string): number {
+	let count = 0;
+	for (const line of sourceText.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (
+			trimmed.startsWith("//") ||
+			trimmed.startsWith("/*") ||
+			trimmed.startsWith("*") ||
+			trimmed.startsWith("#")
+		) {
+			for (const pattern of AI_COMMENT_PATTERNS) {
+				if (pattern.test(line)) {
+					count++;
+					break;
+				}
+			}
+		}
+	}
+	return count;
+}
+
+function calculateCodeEntropy(sourceText: string): number {
+	const tokens = sourceText
+		.replace(/\/\/.*/g, "")
+		.replace(/\/\*[\s\S]*?\*\//g, "")
+		.replace(/["'`][^"'`]*["'`]/g, "STR")
+		.replace(/\b\d+(\.\d+)?\b/g, "NUM")
+		.split(/[\s\n\r\t,;:()[\]{}=<>!&|+\-*/%^~?]+/)
+		.filter((t) => t.length > 0);
+	if (tokens.length === 0) return 0;
+	const freq = new Map<string, number>();
+	for (const token of tokens) freq.set(token, (freq.get(token) || 0) + 1);
+	let entropy = 0;
+	for (const count of freq.values()) {
+		const p = count / tokens.length;
+		if (p > 0) entropy -= p * Math.log2(p);
+	}
+	return entropy;
+}
+
+/**
+ * Maintainability index, Halstead-free variant:
+ * MI = max(0, (171 - 0.23·Cyclomatic - 16.2·ln(LOC)) · 100/171) + comment bonus.
+ */
+function calculateMaintainabilityIndex(
+	cyclomatic: number,
+	loc: number,
+	comments: number,
+): number {
+	if (loc === 0) return 100;
+	const lnLOC = Math.log(loc);
+	let mi = ((171 - 0.23 * cyclomatic - 16.2 * lnLOC) * 100) / 171;
+	const commentBonus = Math.min(10, (comments / loc) * 50);
+	mi += commentBonus;
+	return Math.max(0, Math.min(100, mi));
+}
+
+function calculateMaxParams(functions: FunctionMetrics[]): number {
+	// Estimate from average function length (kept from the original heuristic).
+	return Math.min(
+		10,
+		Math.max(
+			2,
+			Math.round(
+				functions.reduce((a, f) => a + f.length, 0) /
+					Math.max(1, functions.length) /
+					5,
+			),
+		),
+	);
+}
+
+function countSingleUseFunctions(functions: FunctionMetrics[]): number {
+	return functions.filter(
+		(f) =>
+			f.length < 10 &&
+			f.cyclomatic <= 2 &&
+			/^(get|set|check|is|has|validate|format|parse|convert|create|make)/i.test(
+				f.name,
+			),
+	).length;
+}
 
 // --- Client ---
 
@@ -160,87 +475,50 @@ export class ComplexityClient {
 			: () => {};
 	}
 
-	/**
-	 * Check if file is supported (TS/JS)
-	 */
+	/** True if the file's grammar has a complexity node mapping. */
 	isSupportedFile(filePath: string): boolean {
-		return isFileKind(filePath, "jsts");
+		const languageId = resolveTreeSitterLanguage(filePath);
+		return Boolean(languageId && languageId in LANGUAGE_NODES);
 	}
 
-	/**
-	 * Analyze complexity metrics for a file
-	 */
-	analyzeFile(filePath: string): FileComplexity | null {
-		const parsed = this.readAndParse(filePath);
-		if (!parsed) return null;
+	/** Analyze complexity metrics for a file (null if unsupported / unparseable). */
+	async analyzeFile(filePath: string): Promise<FileComplexity | null> {
+		const absolutePath = path.resolve(filePath);
+		const languageId = resolveTreeSitterLanguage(absolutePath);
+		const nodes = languageId ? LANGUAGE_NODES[languageId] : undefined;
+		if (!nodes) return null;
+
+		let content: string;
+		let root: TsNode | null;
+		try {
+			if (!fs.existsSync(absolutePath)) return null;
+			content = fs.readFileSync(absolutePath, "utf-8");
+			root = await parseTreeSitterRoot(absolutePath, content);
+		} catch (err) {
+			this.log(`Read/parse error for ${filePath}: ${(err as Error).message}`);
+			return null;
+		}
+		if (!root) return null;
 
 		try {
-			return this.computeMetrics(parsed);
-		} catch (err: any) {
-			this.log(`Analysis error for ${filePath}: ${err.message}`);
+			return this.computeMetrics(absolutePath, content, root, nodes);
+		} catch (err) {
+			this.log(`Analysis error for ${filePath}: ${(err as Error).message}`);
 			return null;
 		}
 	}
 
-	/**
-	 * Read file and parse to TypeScript AST
-	 */
-	private readAndParse(filePath: string): {
-		absolutePath: string;
-		content: string;
-		sourceFile: ts.SourceFile;
-	} | null {
-		const absolutePath = path.resolve(filePath);
-		if (!fs.existsSync(absolutePath)) return null;
-
-		const content = fs.readFileSync(absolutePath, "utf-8");
-		const sourceFile = ts.createSourceFile(
-			filePath,
-			content,
-			ts.ScriptTarget.Latest,
-			true,
-		);
-
-		return { absolutePath, content, sourceFile };
-	}
-
-	/**
-	 * Compute all metrics from parsed source
-	 */
-	private computeMetrics(parsed: {
-		absolutePath: string;
-		content: string;
-		sourceFile: ts.SourceFile;
-	}): FileComplexity {
-		const { absolutePath, content, sourceFile } = parsed;
-		const lines = content.split(/\r?\n/);
-
-		// Line counts and function collection
-		const { codeLines, commentLines } = this.countLines(sourceFile, lines);
-		const functions = this.collectFunctionMetrics(sourceFile);
-
-		// File-level complexity metrics
-		const maxNestingDepth = this.calculateMaxNesting(sourceFile, 0);
-		const cognitive = this.calculateCognitiveComplexity(sourceFile);
-		const halstead = this.calculateHalsteadVolume(sourceFile);
-
-		// Aggregate function statistics
+	private computeMetrics(
+		absolutePath: string,
+		content: string,
+		root: TsNode,
+		nodes: LangNodes,
+	): FileComplexity {
+		const { codeLines, commentLines } = countLines(content, root);
+		const functions = collectFunctionMetrics(root, nodes);
+		const maxNestingDepth = subtreeMaxNesting(root, 0, nodes);
+		const cognitive = subtreeCognitive(root, 0, nodes);
 		const funcStats = this.aggregateFunctionStats(functions);
-
-		// Derived metrics
-		const maintainabilityIndex = this.calculateMaintainabilityIndex(
-			halstead,
-			funcStats.avgCyclomatic,
-			codeLines,
-			commentLines,
-		);
-		const codeEntropy = this.calculateCodeEntropy(content);
-
-		// AI slop indicators
-		const maxParamsInFunction = this.calculateMaxParams(functions);
-		const aiCommentPatterns = this.countAICommentPatterns(sourceFile);
-		const singleUseFunctions = this.countSingleUseFunctions(functions);
-		const tryCatchCount = this.countTryCatch(sourceFile);
 
 		return {
 			filePath: path.relative(process.cwd(), absolutePath),
@@ -251,21 +529,24 @@ export class ComplexityClient {
 			cyclomaticComplexity: funcStats.avgCyclomatic,
 			maxCyclomaticComplexity: funcStats.maxCyclomatic,
 			cognitiveComplexity: cognitive,
-			halsteadVolume: Math.round(halstead * 10) / 10,
-			maintainabilityIndex: Math.round(maintainabilityIndex * 10) / 10,
+			maintainabilityIndex:
+				Math.round(
+					calculateMaintainabilityIndex(
+						funcStats.avgCyclomatic,
+						codeLines,
+						commentLines,
+					) * 10,
+				) / 10,
 			linesOfCode: codeLines,
 			commentLines,
-			codeEntropy: Math.round(codeEntropy * 100) / 100,
-			maxParamsInFunction,
-			aiCommentPatterns,
-			singleUseFunctions,
-			tryCatchCount,
+			codeEntropy: Math.round(calculateCodeEntropy(content) * 100) / 100,
+			maxParamsInFunction: calculateMaxParams(functions),
+			aiCommentPatterns: countAICommentPatterns(content),
+			singleUseFunctions: countSingleUseFunctions(functions),
+			tryCatchCount: countTryCatch(root, nodes),
 		};
 	}
 
-	/**
-	 * Aggregate function metrics into summary statistics
-	 */
 	private aggregateFunctionStats(functions: FunctionMetrics[]): {
 		avgLength: number;
 		maxLength: number;
@@ -275,12 +556,9 @@ export class ComplexityClient {
 		if (functions.length === 0) {
 			return { avgLength: 0, maxLength: 0, avgCyclomatic: 1, maxCyclomatic: 1 };
 		}
-
 		const lengths = functions.map((f) => f.length);
 		const cyclomatics = functions.map((f) => f.cyclomatic);
-
 		const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0);
-
 		return {
 			avgLength: Math.round(sum(lengths) / lengths.length),
 			maxLength: Math.max(...lengths),
@@ -290,633 +568,5 @@ export class ComplexityClient {
 			),
 			maxCyclomatic: Math.max(1, Math.max(...cyclomatics)),
 		};
-	}
-
-	/**
-	 * Format metrics for display
-	 */
-	formatMetrics(metrics: FileComplexity): string {
-		const parts: string[] = [];
-
-		// Maintainability Index (most important)
-		let miLabel = "✗";
-		if (metrics.maintainabilityIndex >= 80) miLabel = "✓";
-		else if (metrics.maintainabilityIndex >= 60) miLabel = "⚠";
-		parts.push(
-			`${miLabel} Maintainability: ${metrics.maintainabilityIndex}/100`,
-		);
-
-		// Complexity metrics
-		if (
-			metrics.cyclomaticComplexity > 5 ||
-			metrics.maxCyclomaticComplexity > 10
-		) {
-			const avg = metrics.cyclomaticComplexity;
-			const max = metrics.maxCyclomaticComplexity;
-			parts.push(
-				`  Cyclomatic: avg ${avg}, max ${max} (${metrics.functionCount} functions)`,
-			);
-		}
-
-		if (metrics.cognitiveComplexity > 15) {
-			parts.push(
-				`  Cognitive: ${metrics.cognitiveComplexity} (high mental complexity)`,
-			);
-		}
-
-		// Nesting depth
-		if (metrics.maxNestingDepth > 4) {
-			parts.push(
-				`  Max nesting: ${metrics.maxNestingDepth} levels (consider extracting)`,
-			);
-		}
-
-		// Code entropy (in bits, >5.5 = risky AI-induced complexity)
-		// Threshold increased from 3.5 to 5.5 to reduce false positives in tooling codebases
-		// where diverse method/variable names are naturally expected
-		if (metrics.codeEntropy > 5.5) {
-			parts.push(
-				`  Entropy: ${metrics.codeEntropy.toFixed(1)} bits (>5.5 — risky AI-induced complexity)`,
-			);
-		}
-
-		// Function length
-		if (metrics.maxFunctionLength > 50) {
-			parts.push(
-				`  Longest function: ${metrics.maxFunctionLength} lines (avg: ${metrics.avgFunctionLength})`,
-			);
-		}
-
-		// Halstead (only if notably high)
-		if (metrics.halsteadVolume > 500) {
-			parts.push(
-				`  Halstead volume: ${metrics.halsteadVolume} (high vocabulary)`,
-			);
-		}
-
-		return parts.length > 0
-			? `[Complexity] ${metrics.filePath}\n${parts.join("\n")}`
-			: "";
-	}
-
-	/**
-	 * Calculate max parameters across all functions
-	 */
-	private calculateMaxParams(functions: FunctionMetrics[]): number {
-		// We stored function params in the metrics during analysis
-		// For now, estimate based on function length (longer functions often have more params)
-		return Math.min(
-			10,
-			Math.max(
-				2,
-				Math.round(
-					functions.reduce((a, f) => a + f.length, 0) /
-						Math.max(1, functions.length) /
-						5,
-				),
-			),
-		);
-	}
-
-	/**
-	 * Count AI comment patterns (emojis, boilerplate phrases)
-	 */
-	private countAICommentPatterns(sourceFile: ts.SourceFile): number {
-		const sourceText = sourceFile.getText();
-		let count = 0;
-
-		const aiPatterns = [
-			/(?:🔍|✅|📝|🔧|🐛|⚠️|🚀|💡|🎯|📌|🏷️|🔑|🏗️|🧪|🗑️|🔄|♻️|📋|🔖|📊|💬|🔥|💎|⭐|🌟|🎨|🛠️)/u,
-			/\/\/\s*(Initialize|Setup|Clean up|Create|Define|Check if|Handle|Process|Validate|Return|Get|Set|Add|Remove|Update|Fetch)\b/i,
-			/\/\/\s*(This function|This method|This code|Here we|Now we)\b/i,
-			/\/\*\*?\s*(Overview|Summary|Description|Example|Usage)\s*\*?\//i,
-		];
-
-		const lines = sourceText.split(/\r?\n/);
-		for (const line of lines) {
-			// Only check comment lines
-			const trimmed = line.trim();
-			if (
-				trimmed.startsWith("//") ||
-				trimmed.startsWith("/*") ||
-				trimmed.startsWith("*")
-			) {
-				for (const pattern of aiPatterns) {
-					if (pattern.test(line)) {
-						count++;
-						break;
-					}
-				}
-			}
-		}
-
-		return count;
-	}
-
-	/**
-	 * Count functions that appear to be single-use (helper patterns)
-	 */
-	private countSingleUseFunctions(functions: FunctionMetrics[]): number {
-		// Heuristic: small functions (< 10 lines) with simple names are often single-use
-		const smallHelpers = functions.filter(
-			(f) =>
-				f.length < 10 &&
-				f.cyclomatic <= 2 &&
-				/^(get|set|check|is|has|validate|format|parse|convert|create|make)/i.test(
-					f.name,
-				),
-		);
-		return smallHelpers.length;
-	}
-
-	/**
-	 * Count try/catch blocks (generic error handling pattern)
-	 */
-	private countTryCatch(sourceFile: ts.SourceFile): number {
-		let count = 0;
-
-		const visit = (node: ts.Node) => {
-			if (ts.isTryStatement(node)) {
-				count++;
-			}
-			ts.forEachChild(node, visit);
-		};
-
-		ts.forEachChild(sourceFile, visit);
-		return count;
-	}
-
-	/**
-	 * Check thresholds and return actionable warnings
-	 */
-	checkThresholds(metrics: FileComplexity): string[] {
-		const warnings: string[] = [];
-
-		// TUNED: Only flag extreme cases to reduce noise
-		// MI < 30 is "critically poor" (was < 60, too aggressive)
-		if (metrics.maintainabilityIndex < 30) {
-			warnings.push(
-				`Maintainability dropped to ${metrics.maintainabilityIndex} — extract logic into helper functions`,
-			);
-		}
-
-		// Cyclomatic > 20 is very high (was > 10)
-		if (metrics.cyclomaticComplexity > 20) {
-			warnings.push(
-				`High complexity (${metrics.cyclomaticComplexity}) — use early returns or switch expressions`,
-			);
-		}
-
-		// Cognitive > 50 is high (was > 15, flagged almost everything)
-		if (metrics.cognitiveComplexity > 50) {
-			warnings.push(
-				`Cognitive complexity (${metrics.cognitiveComplexity}) — simplify logic flow`,
-			);
-		}
-
-		// Nesting > 6 is deep (was > 4, normal for complex code)
-		if (metrics.maxNestingDepth > 6) {
-			warnings.push(
-				`Deep nesting (${metrics.maxNestingDepth} levels) — extract nested logic into separate functions`,
-			);
-		}
-
-		// Entropy > 5.5 is high (was > 3.5 → 5.0, still too sensitive for tooling codebases)
-		if (metrics.codeEntropy > 5.5) {
-			warnings.push(
-				`High entropy (${metrics.codeEntropy.toFixed(1)} bits) — follow project conventions`,
-			);
-		}
-
-		// Comments ratio (>60% = excessive, was > 40%)
-		const totalLines = metrics.linesOfCode + metrics.commentLines;
-		if (totalLines > 10 && metrics.commentLines / totalLines > 0.6) {
-			warnings.push(
-				`Excessive comments (${Math.round((metrics.commentLines / totalLines) * 100)}%) — remove obvious comments`,
-			);
-		}
-
-		// Verbose code (long functions with low complexity = overly verbose)
-		if (metrics.avgFunctionLength > 30 && metrics.cyclomaticComplexity < 3) {
-			warnings.push(
-				`Verbose code (avg ${Math.round(metrics.avgFunctionLength)} lines, low complexity) — simplify or extract`,
-			);
-		}
-
-		// AI slop: Emoji/boilerplate comments
-		if (metrics.aiCommentPatterns > 5) {
-			warnings.push(
-				`AI-style comments (${metrics.aiCommentPatterns}) — remove hand-holding comments`,
-			);
-		}
-
-		// AI slop: Too many try/catch blocks (lazy error handling)
-		if (metrics.tryCatchCount > 15) {
-			warnings.push(
-				`Many try/catch blocks (${metrics.tryCatchCount}) — consolidate error handling`,
-			);
-		}
-
-		// AI slop: Over-abstraction (many single-use helper functions)
-		if (metrics.singleUseFunctions > 3 && metrics.functionCount > 5) {
-			warnings.push(
-				`Over-abstraction (${metrics.singleUseFunctions} single-use helpers) — inline or consolidate`,
-			);
-		}
-
-		// AI slop: Functions with too many parameters
-		if (metrics.maxParamsInFunction > 6) {
-			warnings.push(
-				`Long parameter list (${metrics.maxParamsInFunction} params) — use options object`,
-			);
-		}
-
-		return warnings;
-	}
-
-	/**
-	 * Format delta for session summary
-	 */
-	formatDelta(previous: FileComplexity, current: FileComplexity): string {
-		const parts: string[] = [];
-
-		const miDelta =
-			current.maintainabilityIndex - previous.maintainabilityIndex;
-		if (Math.abs(miDelta) > 1) {
-			const arrow = miDelta > 0 ? "↑" : "↓";
-			const sign = miDelta > 0 ? "+" : "";
-			parts.push(
-				`  ${arrow} ${current.filePath}: MI ${previous.maintainabilityIndex} → ${current.maintainabilityIndex} (${sign}${miDelta.toFixed(1)})`,
-			);
-		}
-
-		const cogDelta = current.cognitiveComplexity - previous.cognitiveComplexity;
-		if (Math.abs(cogDelta) > 3) {
-			const arrow = cogDelta > 0 ? "↑" : "↓";
-			const sign = cogDelta > 0 ? "+" : "";
-			parts.push(
-				`  ${arrow} ${current.filePath}: cognitive ${previous.cognitiveComplexity} → ${current.cognitiveComplexity} (${sign}${cogDelta})`,
-			);
-		}
-
-		return parts.join("\n");
-	}
-
-	// --- Private: Line Counting ---
-
-	private countLines(
-		sourceFile: ts.SourceFile,
-		lines: string[],
-	): { codeLines: number; commentLines: number } {
-		let commentLines = 0;
-		const commentPositions = new Set<number>();
-
-		// Find comment positions
-		const _visitComments = (node: ts.Node) => {
-			ts.forEachChild(node, _visitComments);
-		};
-
-		// Scan for comments using text
-		const text = sourceFile.getFullText();
-		const commentRegex = /\/\/.*$|\/\*[\s\S]*?\*\//gm;
-		let match;
-		while ((match = commentRegex.exec(text)) !== null) {
-			const lineStart = text.lastIndexOf("\n", match.index) + 1;
-			const startLine = text.substring(0, lineStart).split(/\r?\n/).length - 1;
-			const endLine =
-				text.substring(0, match.index + match[0].length).split(/\r?\n/).length -
-				1;
-			for (let i = startLine; i <= endLine; i++) {
-				commentPositions.add(i);
-			}
-		}
-
-		commentLines = commentPositions.size;
-		const codeLines = lines.filter((line, i) => {
-			const trimmed = line.trim();
-			if (trimmed.length === 0) return false;
-
-			// If the line is not in commentPositions, it definitely has code
-			if (!commentPositions.has(i)) return true;
-
-			// If it IS in commentPositions, it might still have code (trailing comment)
-			// Remove the comment part and check if anything remains
-			const lineWithoutComments = line
-				.replace(/\/\/.*$/, "")
-				.replace(/\/\*[\s\S]*?\*\//g, "")
-				.trim();
-			return lineWithoutComments.length > 0;
-		}).length;
-
-		return { codeLines, commentLines };
-	}
-
-	// --- Private: Function Metrics Collection ---
-
-	/**
-	 * Collect metrics for all functions in the source file
-	 */
-	private collectFunctionMetrics(sourceFile: ts.SourceFile): FunctionMetrics[] {
-		const functions: FunctionMetrics[] = [];
-		this.visitFunctionMetrics(sourceFile, sourceFile, functions, 0);
-		return functions;
-	}
-
-	private visitFunctionMetrics(
-		node: ts.Node,
-		sourceFile: ts.SourceFile,
-		functions: FunctionMetrics[],
-		nestingLevel: number,
-	): void {
-		if (FUNCTION_LIKE_NODES.has(node.kind)) {
-			const funcNode = node as ts.FunctionLikeDeclaration;
-			const startLine = sourceFile.getLineAndCharacterOfPosition(
-				node.getStart(),
-			).line;
-			const endLine = sourceFile.getLineAndCharacterOfPosition(
-				node.getEnd(),
-			).line;
-			const length = endLine - startLine + 1;
-
-			const cyclomatic = this.nodeCyclomaticComplexity(node, 0);
-			const cognitive = this.nodeCognitiveComplexity(node, nestingLevel);
-			const maxNesting = this.calculateMaxNesting(node, 0);
-
-			const name = funcNode.name
-				? funcNode.name.getText(sourceFile)
-				: `<anonymous@L${startLine + 1}>`;
-
-			functions.push({
-				name,
-				line: startLine + 1,
-				length,
-				cyclomatic,
-				cognitive,
-				nestingDepth: maxNesting,
-			});
-		}
-
-		// Track nesting depth changes
-		const newNesting = NESTING_NODES.has(node.kind)
-			? nestingLevel + 1
-			: nestingLevel;
-		ts.forEachChild(node, (child) => {
-			this.visitFunctionMetrics(child, sourceFile, functions, newNesting);
-		});
-	}
-
-	// --- Private: Max Nesting Depth ---
-
-	private calculateMaxNesting(node: ts.Node, currentDepth: number): number {
-		let maxDepth = currentDepth;
-
-		if (NESTING_NODES.has(node.kind)) {
-			currentDepth++;
-			maxDepth = Math.max(maxDepth, currentDepth);
-		}
-
-		ts.forEachChild(node, (child) => {
-			const childMax = this.calculateMaxNesting(child, currentDepth);
-			maxDepth = Math.max(maxDepth, childMax);
-		});
-
-		return maxDepth;
-	}
-
-	private isLogicalOperator(node: ts.Node): boolean {
-		if (node.kind === ts.SyntaxKind.BinaryExpression) {
-			const binary = node as ts.BinaryExpression;
-			return (
-				binary.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
-				binary.operatorToken.kind === ts.SyntaxKind.BarBarToken
-			);
-		}
-		return false;
-	}
-
-	private nodeCyclomaticComplexity(node: ts.Node, complexity: number): number {
-		// Base increment for branching nodes
-		if (CYCLOMAL_NODES.has(node.kind)) {
-			complexity++;
-		}
-
-		// Binary && and || add complexity
-		if (this.isLogicalOperator(node)) {
-			complexity++;
-		}
-
-		ts.forEachChild(node, (child) => {
-			complexity = this.nodeCyclomaticComplexity(child, complexity);
-		});
-
-		return complexity;
-	}
-
-	// --- Private: Cognitive Complexity ---
-	// Based on SonarSource's Cognitive Complexity specification
-	// Increment for: if, for, while, case, catch, conditional
-	// Additional increment for nesting
-
-	private calculateCognitiveComplexity(node: ts.Node): number {
-		return this.nodeCognitiveComplexity(node, 0);
-	}
-
-	private nodeCognitiveComplexity(node: ts.Node, nestingDepth: number): number {
-		let complexity = 0;
-
-		// Structures that contribute to cognitive complexity
-		if (COGNITIVE_NODES.has(node.kind)) {
-			// Base increment + nesting penalty
-			complexity += 1 + nestingDepth;
-		}
-
-		// Break/continue with label add to complexity
-		if (ts.isBreakStatement(node) || ts.isContinueStatement(node)) {
-			if (node.label) {
-				complexity += 1 + nestingDepth;
-			}
-		}
-
-		// Binary && and || contribute to complexity
-		if (this.isLogicalOperator(node)) {
-			complexity += 1;
-		}
-
-		// Calculate nesting for children
-		const increasesNesting = NESTING_NODES.has(node.kind);
-		const childNesting = increasesNesting ? nestingDepth + 1 : nestingDepth;
-
-		ts.forEachChild(node, (child) => {
-			complexity += this.nodeCognitiveComplexity(child, childNesting);
-		});
-
-		return complexity;
-	}
-
-	// --- Private: Halstead Volume ---
-	// V = N * log2(n) where N = total operators+operands, n = unique operators+operands
-
-	private calculateHalsteadVolume(node: ts.Node): number {
-		const operators = new Set<string>();
-		const operands = new Set<string>();
-		let totalOperators = 0;
-		let totalOperands = 0;
-
-		const visit = (n: ts.Node) => {
-			// Check if it's an operator
-			if (HALSTEAD_OPERATORS.has(n.kind)) {
-				const opText = ts.SyntaxKind[n.kind];
-				operators.add(opText);
-				totalOperators++;
-			}
-			// Check for identifiers (operands)
-			else if (ts.isIdentifier(n)) {
-				const text = n.getText();
-				// Skip keywords that are parsed as identifiers
-				if (!this.isKeyword(text)) {
-					operands.add(text);
-					totalOperands++;
-				}
-			}
-			// Check for literals (operands)
-			else if (
-				ts.isNumericLiteral(n) ||
-				ts.isStringLiteral(n) ||
-				n.kind === ts.SyntaxKind.TrueKeyword ||
-				n.kind === ts.SyntaxKind.FalseKeyword ||
-				n.kind === ts.SyntaxKind.NullKeyword ||
-				n.kind === ts.SyntaxKind.UndefinedKeyword
-			) {
-				const text = n.getText();
-				operands.add(text);
-				totalOperands++;
-			}
-
-			ts.forEachChild(n, visit);
-		};
-
-		visit(node);
-
-		const uniqueOps = operators.size + operands.size;
-		const totalOps = totalOperators + totalOperands;
-
-		if (uniqueOps === 0 || totalOps === 0) return 0;
-
-		// V = N * log2(n)
-		return totalOps * Math.log2(uniqueOps);
-	}
-
-	/**
-	 * Calculate Shannon entropy of code tokens (in bits)
-	 * Uses log2 for entropy measured in bits
-	 * Threshold: >5.5 bits indicates risky AI-induced complexity
-	 * (Increased from 3.5 to reduce false positives in tooling codebases)
-	 */
-	private calculateCodeEntropy(sourceText: string): number {
-		// Tokenize by splitting on whitespace and common delimiters
-		const tokens = sourceText
-			.replace(/\/\/.*/g, "") // Remove single-line comments
-			.replace(/\/\*[\s\S]*?\*\//g, "") // Remove multi-line comments
-			.replace(/["'`][^"'`]*["'`]/g, "STR") // Normalize strings
-			.replace(/\b\d+(\.\d+)?\b/g, "NUM") // Normalize numbers
-			.split(/[\s\n\r\t,;:()[\]{}=<>!&|+\-*/%^~?]+/)
-			.filter((t) => t.length > 0);
-
-		if (tokens.length === 0) return 0;
-
-		// Count token frequencies
-		const freq = new Map<string, number>();
-		for (const token of tokens) {
-			freq.set(token, (freq.get(token) || 0) + 1);
-		}
-
-		// Calculate Shannon entropy in bits: H = -sum(p * log2(p))
-		let entropy = 0;
-		for (const count of Array.from(freq.values())) {
-			const p = count / tokens.length;
-			if (p > 0) {
-				entropy -= p * Math.log2(p);
-			}
-		}
-
-		return entropy; // Return in bits, not normalized
-	}
-
-	private isKeyword(text: string): boolean {
-		const keywords = new Set([
-			"if",
-			"else",
-			"for",
-			"while",
-			"do",
-			"switch",
-			"case",
-			"break",
-			"continue",
-			"return",
-			"throw",
-			"try",
-			"catch",
-			"finally",
-			"class",
-			"extends",
-			"super",
-			"import",
-			"export",
-			"default",
-			"from",
-			"as",
-			"const",
-			"let",
-			"var",
-			"function",
-			"new",
-			"delete",
-			"typeof",
-			"void",
-			"instanceof",
-			"in",
-			"of",
-			"this",
-			"true",
-			"false",
-			"null",
-			"undefined",
-			"async",
-			"await",
-			"yield",
-			"static",
-			"get",
-			"set",
-		]);
-		return keywords.has(text);
-	}
-
-	// --- Private: Maintainability Index ---
-	// Microsoft's formula: MI = max(0, (171 - 5.2 * ln(Halstead) - 0.23 * Cyclomatic - 16.2 * ln(LOC)) * 100 / 171)
-	// Adjusted for comment density bonus
-
-	private calculateMaintainabilityIndex(
-		halstead: number,
-		cyclomatic: number,
-		loc: number,
-		comments: number,
-	): number {
-		if (loc === 0) return 100;
-
-		const lnHalstead = halstead > 0 ? Math.log(halstead) : 0;
-		const lnLOC = loc > 0 ? Math.log(loc) : 0;
-
-		// Base MI formula
-		let mi =
-			((171 - 5.2 * lnHalstead - 0.23 * cyclomatic - 16.2 * lnLOC) * 100) / 171;
-
-		// Comment density bonus (up to +10%)
-		const commentDensity = comments / loc;
-		const commentBonus = Math.min(10, commentDensity * 50);
-
-		mi += commentBonus;
-
-		return Math.max(0, Math.min(100, mi));
 	}
 }

--- a/clients/dispatch/facts/tree-sitter-facts.ts
+++ b/clients/dispatch/facts/tree-sitter-facts.ts
@@ -1,36 +1,31 @@
 /**
- * Shared tree-sitter helpers for the fact providers (#402).
+ * Fact-provider-specific tree-sitter helper (#402).
  *
- * The fact extractors (comment/try-catch/function/import) parse JS/TS via the
- * shared, cached tree-sitter client instead of the `typescript` compiler. This
- * module centralises the parse boilerplate + node-walk utilities so each provider
- * is just its extraction logic.
+ * The generic node-walk utilities (`walk`, `childrenOfType`, `firstChildOfType`,
+ * `parseTreeSitterRoot`, `TsNode`) live in `clients/tree-sitter-shared.ts` so both
+ * the fact extractors and the complexity client share them. This module re-exports
+ * them for the extractors and adds the FactProvider-specific `extractFactsFromTree`
+ * shell.
  */
 import {
-	getSharedTreeSitterClient,
-	resolveTreeSitterLanguage,
+	childrenOfType,
+	firstChildOfType,
+	parseTreeSitterRoot,
+	type TsNode,
+	walk,
 } from "../../tree-sitter-shared.js";
 import type { FactStore } from "../fact-store.js";
 import type { DispatchContext } from "../types.js";
 
-// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter node (see tree-sitter-client.ts)
-export type TsNode = any;
+export {
+	childrenOfType,
+	firstChildOfType,
+	type TsNode,
+	walk,
+};
 
-/**
- * Parse `content` for `filePath` via the shared tree-sitter client and return the
- * root node, or null when the grammar is unavailable / parse fails / wasm aborted.
- * init() lazily loads the grammar (memoized) and must run before parseFile.
- */
-export async function parseFactTree(
-	filePath: string,
-	content: string,
-): Promise<TsNode | null> {
-	const languageId = resolveTreeSitterLanguage(filePath);
-	const client = getSharedTreeSitterClient();
-	if (!languageId || !client || !(await client.init())) return null;
-	const tree = await client.parseFile(filePath, languageId, content);
-	return tree ? tree.rootNode : null;
-}
+/** Parse `content` for `filePath` into a root node (or null). Alias of the shared helper. */
+export const parseFactTree = parseTreeSitterRoot;
 
 /**
  * Provider shell for tree-sitter-backed fact extractors: read `file.content`,
@@ -55,23 +50,4 @@ export async function extractFactsFromTree(
 	const root = await parseFactTree(ctx.filePath, content);
 	if (!root) return writeAll(defaults);
 	writeAll(extract(root, content));
-}
-
-export function childrenOfType(node: TsNode, type: string): TsNode[] {
-	return (node.children ?? []).filter((c: TsNode) => c && c.type === type);
-}
-
-export function firstChildOfType(
-	node: TsNode,
-	type: string,
-): TsNode | undefined {
-	return (node.children ?? []).find((c: TsNode) => c && c.type === type);
-}
-
-/** Depth-first walk, calling `visit` on every node (pre-order = source order). */
-export function walk(node: TsNode, visit: (n: TsNode) => void): void {
-	visit(node);
-	for (const child of node.children ?? []) {
-		if (child) walk(child, visit);
-	}
 }

--- a/clients/tree-sitter-shared.ts
+++ b/clients/tree-sitter-shared.ts
@@ -90,3 +90,41 @@ const EXT_TO_LANG: Record<string, string> = {
 export function resolveTreeSitterLanguage(filePath: string): string | undefined {
 	return EXT_TO_LANG[path.extname(filePath).toLowerCase()];
 }
+
+// --- Generic node-walk utilities (shared by the fact extractors and the
+//     complexity client — anything that consumes a parsed tree) ---
+
+// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter node (see tree-sitter-client.ts)
+export type TsNode = any;
+
+/**
+ * Parse `content` for `filePath` via the shared client and return the root node,
+ * or null when the grammar is unavailable / parse fails / wasm aborted. init()
+ * lazily loads the grammar (memoized) and must run before parseFile.
+ */
+export async function parseTreeSitterRoot(
+	filePath: string,
+	content: string,
+): Promise<TsNode | null> {
+	const languageId = resolveTreeSitterLanguage(filePath);
+	const client = getSharedTreeSitterClient();
+	if (!languageId || !client || !(await client.init())) return null;
+	const tree = await client.parseFile(filePath, languageId, content);
+	return tree ? tree.rootNode : null;
+}
+
+export function childrenOfType(node: TsNode, type: string): TsNode[] {
+	return (node.children ?? []).filter((c: TsNode) => c && c.type === type);
+}
+
+export function firstChildOfType(node: TsNode, type: string): TsNode | undefined {
+	return (node.children ?? []).find((c: TsNode) => c && c.type === type);
+}
+
+/** Depth-first walk, calling `visit` on every node (pre-order = source order). */
+export function walk(node: TsNode, visit: (n: TsNode) => void): void {
+	visit(node);
+	for (const child of node.children ?? []) {
+		if (child) walk(child, visit);
+	}
+}

--- a/index.ts
+++ b/index.ts
@@ -1550,7 +1550,7 @@ export default function (pi: ExtensionAPI) {
 			complexityClient.isSupportedFile(filePath) &&
 			!runtime.complexityBaselines.has(filePath)
 		) {
-			const baseline = complexityClient.analyzeFile(filePath);
+			const baseline = await complexityClient.analyzeFile(filePath);
 			if (baseline) {
 				runtime.complexityBaselines.set(filePath, baseline);
 				const { captureSnapshot } = await import(

--- a/tests/clients/complexity-client.test.ts
+++ b/tests/clients/complexity-client.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { ComplexityClient } from "../../clients/complexity-client.js";
+import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+
+const client = new ComplexityClient();
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length) cleanups.pop()?.();
+});
+
+async function analyze(name: string, src: string) {
+	const env = setupTestEnvironment("pi-lens-cx-");
+	cleanups.push(env.cleanup);
+	const file = createTempFile(env.tmpDir, name, src);
+	return client.analyzeFile(file);
+}
+
+describe("ComplexityClient.isSupportedFile", () => {
+	it.each([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cts", ".py", ".go", ".rs"])(
+		"supports %s",
+		(ext) => {
+			expect(client.isSupportedFile(`src/f${ext}`)).toBe(true);
+		},
+	);
+	it.each([".md", ".txt", ".json", ".css"])("does not support %s", (ext) => {
+		expect(client.isSupportedFile(`src/f${ext}`)).toBe(false);
+	});
+});
+
+describe("ComplexityClient.analyzeFile — JS/TS", () => {
+	it("computes cyclomatic / cognitive / nesting / MI for a TS function", async () => {
+		const m = await analyze(
+			"a.ts",
+			`function f(n: number) {\n  if (n > 0 && n < 10) { for (const i of xs) { if (i) return 1; } }\n  return n ? 1 : 2;\n}\n`,
+		);
+		expect(m).not.toBeNull();
+		expect(m!.functionCount).toBe(1);
+		// if + && + for-of + if + ternary = 5
+		expect(m!.maxCyclomaticComplexity).toBe(5);
+		expect(m!.cognitiveComplexity).toBeGreaterThan(0);
+		expect(m!.maxNestingDepth).toBeGreaterThanOrEqual(3);
+		expect(m!.maintainabilityIndex).toBeGreaterThanOrEqual(0);
+		expect(m!.maintainabilityIndex).toBeLessThanOrEqual(100);
+		// Halstead was dropped.
+		expect("halsteadVolume" in m!).toBe(false);
+	});
+
+	it("counts try/catch and multiple functions", async () => {
+		const m = await analyze(
+			"b.ts",
+			`function a() { try { risky(); } catch (e) {} }\nconst b = () => 1;\n`,
+		);
+		expect(m!.functionCount).toBe(2);
+		expect(m!.tryCatchCount).toBe(1);
+	});
+});
+
+describe("ComplexityClient.analyzeFile — language-agnostic", () => {
+	it("python: boolean_operator + match + conditional counted", async () => {
+		const m = await analyze(
+			"c.py",
+			`def foo(a, b):\n    if a and b:\n        for i in x:\n            if i: return 1\n    return 1 if a else 2\n`,
+		);
+		expect(m).not.toBeNull();
+		expect(m!.functionCount).toBe(1);
+		// if + and + for + if + conditional = 5
+		expect(m!.maxCyclomaticComplexity).toBe(5);
+		expect(m!.tryCatchCount).toBe(0);
+	});
+
+	it("go: switch case counted, no try/catch", async () => {
+		const m = await analyze(
+			"d.go",
+			`func foo(a int) int {\n\tif a > 0 && a < 9 { for i := 0; i < a; i++ {} }\n\tswitch a { case 1: }\n\treturn 0\n}\n`,
+		);
+		expect(m).not.toBeNull();
+		expect(m!.functionCount).toBe(1);
+		expect(m!.tryCatchCount).toBe(0);
+		expect(m!.maxCyclomaticComplexity).toBeGreaterThanOrEqual(3);
+	});
+
+	it("rust: match arms counted, no try/catch", async () => {
+		const m = await analyze(
+			"e.rs",
+			`fn foo(a: i32) -> i32 {\n\tif a > 0 && a < 9 { for i in 0..a {} }\n\tmatch a { 1 => 1, _ => 0 }\n}\n`,
+		);
+		expect(m).not.toBeNull();
+		expect(m!.functionCount).toBe(1);
+		expect(m!.tryCatchCount).toBe(0);
+		expect(m!.maxCyclomaticComplexity).toBeGreaterThanOrEqual(3);
+	});
+});
+
+describe("ComplexityClient.analyzeFile — degradation", () => {
+	it("returns null for unsupported languages", async () => {
+		expect(await analyze("f.md", "# hello\n")).toBeNull();
+	});
+	it("returns null for a non-existent file", async () => {
+		expect(await client.analyzeFile("/nope/does-not-exist.ts")).toBeNull();
+	});
+});


### PR DESCRIPTION
Ports `ComplexityClient` off the `typescript` compiler onto the shared tree-sitter client, and makes it **language-agnostic** (your ask) — the last big mechanical piece of #402 Phase 2.

## What changed
- **Per-language node table** (`LANGUAGE_NODES`): JS/TS **+ Python, Go, Rust** today; adding a language is one entry. Node categories (decision / cognitive / nesting / function-like / logical-op / try) were verified against **real AST dumps** per grammar — e.g. Python's `boolean_operator` (not `binary_expression`), Go/Rust having no try/catch, Rust `match_arm`.
- **Metrics preserved:** cyclomatic + cognitive complexity, nesting depth, function count/length, LOC/comments (via tree-sitter `comment` nodes), code entropy, AI-slop indicators, try/catch count.
- **Halstead dropped** (per decision): removed `HALSTEAD_OPERATORS` + `isKeyword` + the `halsteadVolume` field. Maintainability index reworked to the Halstead-free variant `171 − 0.23·CC − 16.2·ln(LOC)` + comment bonus.
- **Dead code removed:** `formatMetrics` / `checkThresholds` had zero callers.
- **Layering fix / dedup:** the generic tree helpers (`walk`, `childrenOfType`, `firstChildOfType`, `parseTreeSitterRoot`, `TsNode`) moved up to `clients/tree-sitter-shared.ts` (so both `clients/` and `dispatch/facts/` share them); `facts/tree-sitter-facts.ts` now re-exports them.

## Behavior
Complexity metrics are **silent session-summary baselines** (seed `complexityBaselines` from `index.ts`), so the only surface change is the dropped `halsteadVolume` field. `analyzeFile` is now **async** (grammar parse); `index.ts` awaits it (test stubs return `null`, which survives awaiting).

## Tests
New `complexity-client.test.ts` (20): `isSupportedFile` matrix + deterministic cyclomatic/cognitive/nesting/MI for JS/TS **and** Python/Go/Rust (e.g. `if + && + for + if + ternary = 5`), try/catch counts (0 for Go/Rust), and degradation (unsupported language / missing file → null). `build`/`lint`/`npm test` (**2789**) green.

## #402 status
Only the sonar/quality **rules** still import `typescript` — after those, Phase 3 drops the dependency (−8.4 MB bundle / −23 MB `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)