### PR TITLE
ci(grammars): grammar-load health guard + nightly build/test (refs #423)

### DIFF
--- a/.github/workflows/grammar-health.yml
+++ b/.github/workflows/grammar-health.yml
@@ -1,0 +1,74 @@
+name: Grammar health (nightly)
+
+# A bad tree-sitter grammar WASM can crash the whole host runtime instead of
+# failing gracefully (e.g. tree-sitter-swift @ tree-sitter-wasms 0.1.13 triggers a
+# fatal V8 Turboshaft-WASM crash on Node 24 — #423). Such a crash can't be caught
+# in-process and is Node/platform/arch-specific, so this nightly:
+#   1. loads + exercises EVERY grammar in an isolated child process on each OS, so
+#      a crasher is caught here — across platforms — before it reaches a user; and
+#   2. builds the Swift grammar from source with a current tree-sitter-cli and runs
+#      the freshly-built wasm through the same guard, to see whether a rebuilt wasm
+#      dodges the crash (the durable fix — building rather than shipping the bad
+#      prebuilt wasm).
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # 06:00 UTC nightly
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  # 1. Run the guard against the currently-shipped/downloaded grammars on every OS.
+  guard:
+    name: Grammar-load guard (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24" # the version where #423 reproduces
+      - name: Install dependencies (downloads core grammars via prepare)
+        run: npm install --no-audit --no-fund
+      - name: Build
+        run: npm run build
+      - name: Load + exercise every grammar in an isolated child process
+        run: node scripts/check-grammar-load.mjs
+
+  # 2. Build the Swift grammar wasm from source and test whether it still crashes.
+  #    ubuntu has Docker, which `tree-sitter build --wasm` uses for emscripten.
+  build-and-test-swift:
+    name: Build + guard a fresh Swift wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Build
+        run: npm run build
+      - name: Build tree-sitter-swift.wasm from source
+        run: |
+          set -e
+          npm pack tree-sitter-swift@0.7.1
+          mkdir -p swift-src && tar xzf tree-sitter-swift-*.tgz -C swift-src --strip-components=1
+          # tree-sitter build --wasm compiles the grammar's C sources to wasm via
+          # emscripten (Docker on Linux). Pin the CLI to the web-tree-sitter 0.25 ABI.
+          npx --yes tree-sitter-cli@0.25.6 build --wasm \
+            --output "$GITHUB_WORKSPACE/tree-sitter-swift-built.wasm" swift-src
+          ls -la "$GITHUB_WORKSPACE/tree-sitter-swift-built.wasm"
+      - name: Run the freshly-built Swift wasm through the guard
+        run: |
+          cp "$GITHUB_WORKSPACE/tree-sitter-swift-built.wasm" grammars/tree-sitter-swift.wasm
+          node scripts/check-grammar-load.mjs swift

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"selftest:install": "node scripts/install-selftest.mjs",
 		"check:lockfile": "node scripts/check-lockfile-sync.mjs",
 		"check:grammars": "node scripts/check-grammar-provenance.mjs",
+		"check:grammar-load": "node scripts/check-grammar-load.mjs",
 		"audit:tree-sitter": "node scripts/audit-tree-sitter-rules.mjs",
 		"audit:rule-catalog": "node scripts/validate-rule-catalog.mjs",
 		"audit:playground": "node scripts/playground-verify-rule.mjs",

--- a/scripts/check-grammar-load.mjs
+++ b/scripts/check-grammar-load.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Grammar-load health check (#423).
+ *
+ * A bad tree-sitter grammar WASM can crash the whole process — not throw, ABORT
+ * (e.g. `tree-sitter-swift.wasm` @ tree-sitter-wasms 0.1.13 triggers a fatal V8
+ * Turboshaft-WASM crash on Node 24). A crash like that can't be caught in-process,
+ * so this loads + exercises EACH grammar in an isolated CHILD process and reports
+ * which ones crash the runtime (non-zero exit / fatal signal) vs load cleanly.
+ *
+ *   node scripts/check-grammar-load.mjs            # parent: check every grammar
+ *   node scripts/check-grammar-load.mjs <language> # child: load+exercise one grammar
+ *
+ * Requires a built dist (`npm run build`). Exits non-zero if any grammar crashes.
+ */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const HERE = fileURLToPath(import.meta.url);
+
+// A chunk of mixed punctuation/keywords/identifiers — not valid in any one
+// language, but it drives the parser hard across every grammar, which is what
+// heats the WASM enough for the background optimizer to (mis)compile it.
+const STRESS = `
+function foo(a, b) { if (a && b || c) { for (i in x) { return a ? b : c; } } }
+class K extends Base { def method(self): try: pass except E: raise
+fn bar<T>(x: i32) -> i32 { match x { 1 => {}, _ => {} } let y = |z| z + 1; }
+func baz(a int) (int, error) { switch a { case 1: default: } select {} }
+struct S { field: [i32; 4] } impl S { async fn go(&self) { await!(x); } }
+`.repeat(40);
+
+async function exerciseGrammar(languageId) {
+	const { TreeSitterClient } = await import("../clients/tree-sitter-client.js");
+	const client = new TreeSitterClient();
+	if (!(await client.init())) {
+		console.error("tree-sitter runtime unavailable");
+		process.exit(2);
+	}
+	// Parse repeatedly to make the grammar WASM hot → triggers tiered/background
+	// optimization, which is where the bad grammars abort.
+	for (let i = 0; i < 200; i++) {
+		const tree = await client.parseFile(`stress-${i}.src`, languageId, STRESS);
+		if (!tree) {
+			// Grammar couldn't be resolved/loaded (download failure, etc.) — not a
+			// crash, but nothing was exercised. Report as unavailable.
+			console.error(`grammar '${languageId}' did not load`);
+			process.exit(3);
+		}
+	}
+	// Give any background (Turboshaft) compilation time to run and, if it's going
+	// to abort, abort — before we exit cleanly.
+	await new Promise((r) => setTimeout(r, 1500));
+	process.exit(0);
+}
+
+async function main() {
+	const arg = process.argv[2];
+	if (arg) {
+		await exerciseGrammar(arg);
+		return;
+	}
+
+	const { LANGUAGE_TO_GRAMMAR } = await import("../clients/grammar-source.js");
+	const languages = Object.keys(LANGUAGE_TO_GRAMMAR).sort();
+
+	console.error(
+		`[grammar-load-check] Node ${process.version} on ${process.platform}/${process.arch} — checking ${languages.length} grammars\n`,
+	);
+
+	const crashed = [];
+	const unavailable = [];
+	for (const lang of languages) {
+		const r = spawnSync(process.execPath, [HERE, lang], {
+			timeout: 120_000,
+			encoding: "utf8",
+		});
+		const code = r.status;
+		const signal = r.signal;
+		if (code === 0) {
+			console.error(`  ok     ${lang}`);
+		} else if (code === 3) {
+			unavailable.push(lang);
+			console.error(`  skip   ${lang} (grammar did not load — download/env)`);
+		} else {
+			// Non-zero exit / killed by signal / timeout = the runtime went down.
+			const why = signal
+				? `signal ${signal}`
+				: r.error
+					? String(r.error.message)
+					: `exit ${code}`;
+			const tail = (r.stderr || "").trim().split("\n").slice(-3).join(" | ");
+			crashed.push({ lang, why, tail });
+			console.error(`  CRASH  ${lang} (${why})  ${tail}`);
+		}
+	}
+
+	console.error("\n[grammar-load-check] summary:");
+	console.error(`  crashed:     ${crashed.map((c) => c.lang).join(", ") || "none"}`);
+	console.error(`  unavailable: ${unavailable.join(", ") || "none"}`);
+	if (crashed.length > 0) {
+		console.error(
+			`\n✗ ${crashed.length} grammar(s) crash the runtime on this platform — they must be blocklisted (BLOCKED_GRAMMARS).`,
+		);
+		process.exit(1);
+	}
+	console.error("\n✓ all resolvable grammars load + parse without crashing.");
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(2);
+});


### PR DESCRIPTION
Groundwork for #423 (Swift grammar crashes `pi` on Node 24). A bad grammar WASM **crashes the host runtime** rather than failing gracefully — uncatchable in-process, and Node/platform-specific — so ordinary smoke tests can't catch it (a Swift fixture would kill the vitest worker, and only on Node 24).

## What's here
- **`scripts/check-grammar-load.mjs`** (`npm run check:grammar-load`) — loads + *exercises* each grammar in an **isolated child process** (heat-parse to trigger the tiered/background WASM optimizer, which is where the bad grammars abort), and reports which crash the runtime vs load cleanly.
- **`.github/workflows/grammar-health.yml`** (nightly + `workflow_dispatch`):
  1. **`guard`** — runs the health check across **ubuntu / macOS / windows** on **Node 24**, so a crasher is caught per-platform *before* a user hits it.
  2. **`build-and-test-swift`** — builds `tree-sitter-swift.wasm` **from source** with a current `tree-sitter-cli` (emscripten via Docker) and runs the fresh wasm through the guard — testing whether a **rebuilt** wasm dodges the crash (the durable fix: *build* rather than ship the bad prebuilt `tree-sitter-wasms@0.1.13` wasm).

## What the guard already found (local, Node 24 / win32-x64)
`swift` is the **sole crasher** (exit `0x80000003`); the other 24 grammars load + parse cleanly. `yaml`'s wasm is unloadable-but-unused (ABI-incompatible with web-tree-sitter 0.25, `Language.load` fails gracefully — separate cleanup; `@tree-sitter-grammars/tree-sitter-yaml@0.7.1` has a compatible one).

## Not in this PR (deferred, by design)
The **runtime graceful-degrade** for the crash is a separate change still being decided — pure breadcrumb can't reliably attribute an *async/background* crash to one grammar (a Swift session also loads js/ts → over-blocks), so the leading option is a **scoped, cached subprocess probe** for the untested long-tail grammars only. That + a `tracking issue` will follow; this PR is the guard + CI foundation the fix builds on.

Refs #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)