### PR TITLE
fix(diagnostics): mode=full honors inline pi-lens-ignore (#442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **`lens_diagnostics mode=full` now honors inline `# pi-lens-ignore` comments** (#442) — inline suppression (`// pi-lens-ignore: rule` / `# pi-lens-ignore: rule`) was applied only in the per-edit dispatch path (`mode=all`), so a site cleanly suppressed there reappeared as **blocking** in the project-wide `mode=full` sweep — making `mode=full` unusable as a "clean" gate for any project with a legitimate suppression. The suppression filter is now shared (`clients/dispatch/inline-suppressions.ts`) and applied to the merged `mode=full` summaries too: each flagged file is read and its inline ignores honored (fail-safe — a read error never hides a finding), and counts are re-summarized so a fully-suppressed file reports clean. Rule matching also normalizes `ast-grep:<id>` / `<id>-js` forms, so a bare `pi-lens-ignore: <id>` suppresses the finding in both modes. (The reporter's secondary ask — per-rule enable/disable in `.pi-lens.json` — is tracked separately as a follow-up.)
+
 ## [3.8.66] - 2026-07-07
 
 ### Added

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -30,6 +30,7 @@ import { RUNTIME_CONFIG, getRunnerTimeoutFloorMs } from "../runtime-config.js";
 import { safeSpawnAsync } from "../safe-spawn.js";
 import { classifyDiagnostic } from "./diagnostic-taxonomy.js";
 import type { FactStore } from "./fact-store.js";
+import { applyInlineSuppressions } from "./inline-suppressions.js";
 import { getToolPlan } from "./plan.js";
 import { resolveRunnerPath } from "./runner-context.js";
 import { getToolProfile } from "./tool-profile.js";
@@ -241,45 +242,6 @@ function dedupeOverlappingDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
 	return [...byKey.values()];
 }
 
-/**
- * Apply inline suppression comments.
- * Syntax: `// pi-lens-ignore: rule-id` (JS/TS) or `# pi-lens-ignore: rule-id` (Python/Ruby/etc.)
- * Place on the same line as the diagnostic or the line immediately above it.
- */
-function applyInlineSuppressions(
-	diagnostics: Diagnostic[],
-	content: string,
-): Diagnostic[] {
-	if (!content || !diagnostics.length) return diagnostics;
-
-	// Build a set of (line, ruleId) pairs that are suppressed.
-	// Line numbers are 1-based to match diagnostic line numbers.
-	const suppressed = new Set<string>();
-	const lines = content.split("\n");
-	const SUPPRESS_RE = /(?:\/\/|#)\s*pi-lens-ignore:\s*(.+)/;
-	for (let i = 0; i < lines.length; i++) {
-		const m = SUPPRESS_RE.exec(lines[i]);
-		if (!m) continue;
-		const rules = m[1]
-			.split(",")
-			.map((r) => r.trim())
-			.filter(Boolean);
-		const suppressedLine = i + 1; // same line (1-based)
-		const nextLine = i + 2; // next line (1-based)
-		for (const ruleId of rules) {
-			suppressed.add(`${suppressedLine}:${ruleId}`);
-			suppressed.add(`${nextLine}:${ruleId}`);
-		}
-	}
-
-	if (suppressed.size === 0) return diagnostics;
-
-	return diagnostics.filter((d) => {
-		const ruleId = d.rule ?? d.id ?? "";
-		const line = d.line ?? 1;
-		return !suppressed.has(`${line}:${ruleId}`);
-	});
-}
 
 function suppressLintOverlapsWithLsp(diagnostics: Diagnostic[]): Diagnostic[] {
 	const lspBySpanClass = new Set<string>();

--- a/clients/dispatch/inline-suppressions.ts
+++ b/clients/dispatch/inline-suppressions.ts
@@ -1,0 +1,72 @@
+/**
+ * Inline `pi-lens-ignore` suppression — shared between the per-edit dispatch
+ * pipeline (`lens_diagnostics mode=all`) and the project-wide `mode=full` sweep so
+ * BOTH honor the same comments (#442). Previously this lived privately in the
+ * dispatcher, so a site suppressed on the write path reappeared as blocking in the
+ * full scan, making `mode=full` unusable as a clean gate.
+ *
+ * Syntax: `// pi-lens-ignore: rule-id` (JS/TS) or `# pi-lens-ignore: rule-id`
+ * (Python/Ruby/…), comma-separated for multiple rules, on the same line as the
+ * diagnostic or the line immediately above it.
+ */
+
+export interface SuppressibleDiagnostic {
+	line?: number;
+	rule?: string;
+	id?: string;
+}
+
+const SUPPRESS_RE = /(?:\/\/|#)\s*pi-lens-ignore:\s*(.+)/;
+
+/**
+ * Normalize a rule id to the form a user writes in a `pi-lens-ignore` comment.
+ * The napi scan and the ast-grep LSP tag the same rule as `ast-grep:<id>` /
+ * `<id>-js` in some surfaces (see `normalizeRuleForDedup` in lens-diagnostics);
+ * a user's bare `<id>` must still suppress those, so we match the normalized form
+ * as well as the raw one.
+ */
+function normalizeSuppressRule(ruleId: string): string {
+	return ruleId.replace(/^ast-grep:/, "").replace(/-js$/, "");
+}
+
+/**
+ * Drop diagnostics suppressed by an inline `pi-lens-ignore: <rule[,rule2]>`
+ * comment in `content` (the file the diagnostics belong to). A diagnostic is
+ * suppressed when its rule id — raw OR normalized — is listed on its own line or
+ * the line immediately above. Returns the surviving diagnostics (same array if
+ * nothing is suppressed).
+ */
+export function applyInlineSuppressions<T extends SuppressibleDiagnostic>(
+	diagnostics: T[],
+	content: string,
+): T[] {
+	if (!content || !diagnostics.length) return diagnostics;
+
+	// Build the set of (1-based line, rule-id) pairs that are suppressed.
+	const suppressed = new Set<string>();
+	const lines = content.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const m = SUPPRESS_RE.exec(lines[i]);
+		if (!m) continue;
+		const rules = m[1]
+			.split(",")
+			.map((r) => r.trim())
+			.filter(Boolean);
+		const suppressedLine = i + 1; // same line (1-based)
+		const nextLine = i + 2; // next line (1-based)
+		for (const ruleId of rules) {
+			suppressed.add(`${suppressedLine}:${ruleId}`);
+			suppressed.add(`${nextLine}:${ruleId}`);
+		}
+	}
+
+	if (suppressed.size === 0) return diagnostics;
+
+	return diagnostics.filter((d) => {
+		const rawId = d.rule ?? d.id ?? "";
+		const line = d.line ?? 1;
+		if (suppressed.has(`${line}:${rawId}`)) return false;
+		const normId = normalizeSuppressRule(rawId);
+		return normId === rawId || !suppressed.has(`${line}:${normId}`);
+	});
+}

--- a/tests/clients/dispatch/inline-suppressions.test.ts
+++ b/tests/clients/dispatch/inline-suppressions.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+	applyInlineSuppressions,
+	type SuppressibleDiagnostic,
+} from "../../../clients/dispatch/inline-suppressions.js";
+
+type D = SuppressibleDiagnostic & { message?: string };
+
+describe("applyInlineSuppressions (#442 — shared by mode=all + mode=full)", () => {
+	it("suppresses a finding via a same-line `# pi-lens-ignore` comment", () => {
+		const content = "import os\neval(x)  # pi-lens-ignore: no-eval\n";
+		const diags: D[] = [{ line: 2, rule: "no-eval" }];
+		expect(applyInlineSuppressions(diags, content)).toEqual([]);
+	});
+
+	it("suppresses via a comment on the line immediately above", () => {
+		const content = "# pi-lens-ignore: no-eval\neval(x)\n";
+		const diags: D[] = [{ line: 2, rule: "no-eval" }];
+		expect(applyInlineSuppressions(diags, content)).toEqual([]);
+	});
+
+	it("supports the // comment style and multiple comma-separated rules", () => {
+		const content = "eval(x); // pi-lens-ignore: no-eval, no-debugger\n";
+		const diags: D[] = [
+			{ line: 1, rule: "no-eval" },
+			{ line: 1, rule: "no-debugger" },
+			{ line: 1, rule: "other-rule" },
+		];
+		expect(applyInlineSuppressions(diags, content).map((d) => d.rule)).toEqual([
+			"other-rule",
+		]);
+	});
+
+	it("does NOT suppress a different rule or an out-of-range line", () => {
+		// The comment on line 1 covers line 1 + line 2 (next-line semantics), so the
+		// "different line" case uses line 3 to stay out of range.
+		const content = "eval(x)  # pi-lens-ignore: no-eval\nalert(1)\neval(y)\n";
+		const diags: D[] = [
+			{ line: 1, rule: "no-alert" }, // same line, different rule
+			{ line: 3, rule: "no-eval" }, // same rule, out-of-range line
+		];
+		expect(applyInlineSuppressions(diags, content)).toEqual(diags);
+	});
+
+	it("matches by the id field when rule is absent", () => {
+		const content = "x  # pi-lens-ignore: my-check\n";
+		const diags: D[] = [{ line: 1, id: "my-check" }];
+		expect(applyInlineSuppressions(diags, content)).toEqual([]);
+	});
+
+	// The mode=full parity fix: findings surface as `ast-grep:<id>` / `<id>-js`
+	// in some surfaces, but a user writes the bare id — both must suppress (#442).
+	it("suppresses a normalized rule id (ast-grep: prefix / -js suffix)", () => {
+		const content = "eval(x)  # pi-lens-ignore: no-eval\n";
+		expect(
+			applyInlineSuppressions([{ line: 1, rule: "ast-grep:no-eval" }], content),
+		).toEqual([]);
+		expect(
+			applyInlineSuppressions([{ line: 1, rule: "no-eval-js" }], content),
+		).toEqual([]);
+	});
+
+	it("is a no-op when there are no ignore comments", () => {
+		const content = "eval(x)\nalert(1)\n";
+		const diags: D[] = [{ line: 1, rule: "no-eval" }];
+		expect(applyInlineSuppressions(diags, content)).toBe(diags);
+	});
+});

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -470,6 +470,62 @@ describe("lens_diagnostics mode=full", () => {
 		});
 	});
 
+	it("honors inline `# pi-lens-ignore` like mode=all (#442)", async () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-diag-suppress-"));
+		resetProjectLensConfigCache();
+		try {
+			const file = path.join(cwd, "app.py");
+			fs.writeFileSync(
+				file,
+				"value = eval(userInput)  # pi-lens-ignore: no-eval\n",
+			);
+			mockSummaries.length = 0;
+			mockSummaries.push(
+				sum(
+					file,
+					{ blocking: 1 },
+					{
+						diagnostics: [
+							{
+								severity: "error",
+								semantic: "blocking",
+								message: "eval of untrusted input",
+								line: 1,
+								rule: "no-eval",
+								tool: "ast-grep",
+							},
+						],
+					},
+				),
+			);
+			const lspService = {
+				runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]),
+			};
+			const tool = createLensDiagnosticsTool(
+				makeCacheManager({}) as any,
+				() => cwd,
+				() => lspService as any,
+			);
+			const result = await tool.execute(
+				"1",
+				{ mode: "full" },
+				new AbortController().signal,
+				null,
+				{ cwd },
+			);
+			const text = String(result.content[0].text);
+			// The suppressed finding must NOT appear and must NOT count as blocking
+			// (a fully-suppressed run reports clean, so totalBlocking is 0/absent).
+			expect(text).not.toContain("eval of untrusted input");
+			expect(
+				(result.details as { totalBlocking?: number }).totalBlocking ?? 0,
+			).toBe(0);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+			resetProjectLensConfigCache();
+		}
+	});
+
 	it("forwards maxLspFiles to the LSP workspace sweep as maxFiles (#341)", async () => {
 		mockSummaries.length = 0;
 		const lspService = {

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -9,8 +9,10 @@
  *   full            — active project-wide LSP diagnostic scan merged with all.
  */
 
+import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { Type } from "../clients/deps/typebox.js";
+import { applyInlineSuppressions } from "../clients/dispatch/inline-suppressions.js";
 import { compactRenderResult } from "./render-compact.js";
 import { combineAbortSignals } from "../clients/deadline-utils.js";
 import { getProjectIgnoreMatcher } from "../clients/file-utils.js";
@@ -593,6 +595,38 @@ function mergeDiagnosticsWithWidgetSummaries(
 	return [...byFile.values()];
 }
 
+/**
+ * Apply inline `pi-lens-ignore` suppression to the merged mode=full summaries so
+ * the project-wide sweep honors the same comments as the per-edit path (#442) —
+ * without it, a site cleanly suppressed in mode=all reappears as blocking here.
+ * Reads each flagged file once (bounded to files that actually have diagnostics);
+ * a read failure is fail-safe (keep the diagnostics rather than hide a finding on
+ * an I/O error). Re-summarizes so the blocking/error/warning counts reflect the
+ * suppression.
+ */
+async function applyInlineSuppressionsToSummaries(
+	summaries: FileDiagnosticSummary[],
+): Promise<FileDiagnosticSummary[]> {
+	return Promise.all(
+		summaries.map(async (summary) => {
+			if (!summary.diagnostics.length) return summary;
+			let content: string;
+			try {
+				content = await fs.readFile(summary.filePath, "utf8");
+			} catch {
+				return summary; // never hide a finding on a read error
+			}
+			const kept = applyInlineSuppressions(summary.diagnostics, content);
+			if (kept.length === summary.diagnostics.length) return summary;
+			return summarizeDiagnostics(
+				summary.filePath,
+				kept,
+				summary.hasFinalSnapshot,
+			);
+		}),
+	);
+}
+
 function shouldUseCachedProjectDiagnostics(value: unknown): boolean {
 	return value === "cached";
 }
@@ -727,13 +761,15 @@ async function formatFullMode(
 		loadProjectDiagnosticsDeltaReport(cwd),
 		includeFile,
 	);
-	const summaries = mergeDiagnosticsWithWidgetSummaries(
-		getFileDiagnosticSummaries().filter((summary) =>
-			includeFile(summary.filePath),
+	const summaries = await applyInlineSuppressionsToSummaries(
+		mergeDiagnosticsWithWidgetSummaries(
+			getFileDiagnosticSummaries().filter((summary) =>
+				includeFile(summary.filePath),
+			),
+			lspResults,
+			projectSnapshot,
+			projectDelta,
 		),
-		lspResults,
-		projectSnapshot,
-		projectDelta,
 	);
 	const result = formatAllMode(cwd, severity, summaries, {
 		mode: "full",


### PR DESCRIPTION
## What & why

`# pi-lens-ignore` / `// pi-lens-ignore` inline suppression was applied **only in the per-edit dispatch path** (`lens_diagnostics mode=all`) — the filter lived privately in `dispatcher.ts` and was called at exactly one site. The project-wide `mode=full` sweep assembles diagnostics from the LSP workspace scan + `project-diagnostics` extractors + cached runner state and **never ran it**. So a site cleanly suppressed on the write path **reappeared as blocking** in `mode=full`, making it unusable as a "clean" gate for any project with a legitimate suppression (reported by @xificurC).

## Fix

- **Extract** the suppression filter to a shared `clients/dispatch/inline-suppressions.ts` (exported, generic over `{ line, rule, id }`). `dispatcher.ts` now imports it — **zero behavior change** for `mode=all`.
- **Apply it in `mode=full`** (`tools/lens-diagnostics.ts`): the merged summaries are already grouped by file, so each flagged file is read once and its inline ignores honored, then re-summarized so counts reflect the suppression. **Fail-safe:** a read error keeps the diagnostics (never hide a finding on I/O error). Bounded to files that actually have diagnostics.
- **Normalize** `ast-grep:<id>` / `<id>-js` rule forms so a bare `pi-lens-ignore: <id>` suppresses the finding in both modes (the napi scan and ast-grep LSP tag the same rule differently across surfaces).

## Tests

- Shared-filter unit tests: same-line, next-line, `//` + `#` styles, comma-separated multi-rule, `id` fallback, **normalized `ast-grep:`/`-js` forms**, and the no-op case.
- `mode=full` **parity test**: a real temp file with `# pi-lens-ignore: no-eval` + an injected blocking `no-eval` finding → `mode=full` suppresses it and reports **clean**.
- `npm run lint` clean; full `npm test` → 2800 passed, 5 skipped.

## Scope

This restores **inline-suppression parity** (the reported bug). The reporter's *secondary* ask — per-rule enable/disable in `.pi-lens.json` — is a separate, larger config feature and is filed as a follow-up rather than conflated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)