### PR TITLE
perf: write-path micro batch — single-spawn ESLint autofix, parallel codeAction lookups, content reuse (closes #453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to pi-lens will be documented in this file.
 ### Changed
 
 - perf: cascade diagnostics now run concurrently after each edit instead of blocking the write pipeline (~26% median per-edit latency reduction); settled at turn_end with a bounded wait (#450)
+- perf: write-path micro batch — ESLint autofix runs a single `--fix` spawn (was dry-run + fix, double cold-start), LSP quick-fix lookups for blocking diagnostics run in parallel, and the lsp runner reuses its already-read file content for nosemgrep suppression (#453)
 
 ### Fixed
 

--- a/clients/dispatch/runners/lsp.ts
+++ b/clients/dispatch/runners/lsp.ts
@@ -229,25 +229,27 @@ const lspRunner: RunnerDefinition = {
 			.filter(({ d }) => d.severity === 1)
 			.slice(0, MAX_CODE_ACTION_LOOKUPS);
 
-		for (const { d, idx } of blockingDiagIndexes) {
-			try {
-				const start = d.range.start;
-				const end = d.range.end ?? d.range.start;
-				const actions = await lspService.codeAction(
-					ctx.filePath,
-					start.line,
-					start.character,
-					end.line,
-					end.character,
-				);
-				const suggestion = buildCodeActionSuggestion(actions);
-				if (suggestion) {
-					fixSuggestionByIndex.set(idx, suggestion);
+		await Promise.all(
+			blockingDiagIndexes.map(async ({ d, idx }) => {
+				try {
+					const start = d.range.start;
+					const end = d.range.end ?? d.range.start;
+					const actions = await lspService.codeAction(
+						ctx.filePath,
+						start.line,
+						start.character,
+						end.line,
+						end.character,
+					);
+					const suggestion = buildCodeActionSuggestion(actions);
+					if (suggestion) {
+						fixSuggestionByIndex.set(idx, suggestion);
+					}
+				} catch {
+					// Best-effort enrichment only; base diagnostics remain authoritative.
 				}
-			} catch {
-				// Best-effort enrichment only; base diagnostics remain authoritative.
-			}
-		}
+			}),
+		);
 
 		const diagnostics: Diagnostic[] = convertLspDiagnostics(
 			validLspDiags,
@@ -261,24 +263,13 @@ const lspRunner: RunnerDefinition = {
 		// blockingAllowed is per-workspace (e.g. curated repo rules), computed once.
 		const blockingAllowedByProfile = new Map<unknown, boolean>();
 		// Diagnostics dropped by the tool's NATIVE inline suppression (e.g. opengrep
-		// `# nosemgrep`, #441). Read the file content lazily — only once, and only if
-		// some auxiliary profile can suppress.
+		// `# nosemgrep`, #441). Reuses `content` from the sync read above.
 		const suppressedIndices = new Set<number>();
-		let auxFileContent: string | undefined;
-		let auxFileContentRead = false;
-		const getAuxFileContent = (): string | undefined => {
-			if (!auxFileContentRead) {
-				auxFileContent = readFileContent(diagnosticPath);
-				auxFileContentRead = true;
-			}
-			return auxFileContent;
-		};
 		for (let i = 0; i < diagnostics.length; i++) {
 			const profile = findAuxiliaryProfileForSource(validLspDiags[i]?.source);
 			if (!profile) continue;
 			if (profile.isSuppressed) {
-				const content = getAuxFileContent();
-				if (content && profile.isSuppressed(validLspDiags[i], content)) {
+				if (profile.isSuppressed(validLspDiags[i], content)) {
 					suppressedIndices.add(i);
 					continue;
 				}

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -309,8 +309,12 @@ const _eslintCache = new Map<
 >();
 
 /**
- * Run eslint --fix on a file. Returns number of fixable issues resolved,
- * or 0 if ESLint is not configured / not available.
+ * Run eslint --fix on a file. Runs a single spawn and diffs the file before/after,
+ * same idiom as the other autofix helpers below. Exit code 1 (unfixable problems
+ * remain) is allowed because fixes may still have been applied; only exit code 2
+ * (config/fatal error) is treated as failure.
+ * Returns 1 if the file changed, 0 if ESLint is not configured / not available /
+ * made no changes.
  */
 async function tryEslintFix(filePath: string, cwd: string): Promise<number> {
 	const userHasConfig = hasEslintConfig(cwd);
@@ -331,52 +335,14 @@ async function tryEslintFix(filePath: string, cwd: string): Promise<number> {
 	}
 	if (!cached.available || !cached.bin) return 0;
 	const cmd = cached.bin;
-	const configArgs: string[] = [];
-	// --fix-dry-run returns JSON with fixable counts without writing to disk.
-	// Use it to get the real count, then apply with --fix only if needed.
-	const dry = await safeSpawnAsync(
+
+	return detectFileChangedAfterCommand(
+		filePath,
 		cmd,
-		[
-			"--fix-dry-run",
-			"--format",
-			"json",
-			"--no-error-on-unmatched-pattern",
-			...configArgs,
-			filePath,
-		],
-		{ timeout: 30000, cwd },
+		["--fix", "--no-error-on-unmatched-pattern", filePath],
+		cwd,
+		[1],
 	);
-	if (dry.status === 2) return 0;
-	let fixableCount = 0;
-	let anyDryRunOutput = false;
-	try {
-		const results: Array<{
-			fixableErrorCount?: number;
-			fixableWarningCount?: number;
-			output?: string;
-		}> = JSON.parse(dry.stdout);
-		fixableCount = results.reduce(
-			(sum, r) =>
-				sum + (r.fixableErrorCount ?? 0) + (r.fixableWarningCount ?? 0),
-			0,
-		);
-		// `--fix-dry-run` reports the POST-fix state: when every problem is
-		// auto-fixable, `messages`/`fixableErrorCount` are 0 and the fixed source
-		// lands in the `output` field instead. Keying on `fixableErrorCount` alone
-		// therefore misses the common "all fixable" case and never applies fixes.
-		anyDryRunOutput = results.some((r) => typeof r.output === "string");
-	} catch {
-		/* treat as zero fixable on error */
-	}
-	if (fixableCount === 0 && !anyDryRunOutput) return 0;
-	// Apply the fixes
-	const fix = await safeSpawnAsync(
-		cmd,
-		["--fix", "--no-error-on-unmatched-pattern", ...configArgs, filePath],
-		{ timeout: 30000, cwd },
-	);
-	if (fix.status === 2) return 0;
-	return fixableCount > 0 ? fixableCount : anyDryRunOutput ? 1 : 0;
 }
 
 async function tryStylelintFix(filePath: string, cwd: string): Promise<number> {

--- a/tests/clients/dispatch/runners/runner-status-semantics.test.ts
+++ b/tests/clients/dispatch/runners/runner-status-semantics.test.ts
@@ -354,4 +354,57 @@ describe("runner status/semantic edge cases", () => {
 			env.cleanup();
 		}
 	});
+
+	it("lsp runner looks up codeAction for multiple blocking diagnostics in parallel (#453)", async () => {
+		const runner = (await import("../../../../clients/dispatch/runners/lsp.js"))
+			.default;
+		const env = setupTestEnvironment("pi-lens-lsp-parallel-");
+		try {
+			const filePath = path.join(env.tmpDir, "main.ts");
+			fs.writeFileSync(
+				filePath,
+				"const a: string = 1;\nconst b: string = 2;\nconst c: string = 3;\n",
+			);
+
+			hasLSP.mockResolvedValue(true);
+			openFile.mockResolvedValue(undefined);
+			touchFile.mockResolvedValue(
+				[0, 1, 2].map((line) => ({
+					severity: 1,
+					message: "Type 'number' is not assignable to type 'string'.",
+					range: {
+						start: { line, character: 6 },
+						end: { line, character: 7 },
+					},
+					code: "2322",
+				})),
+			);
+			// Assert concurrency by observed overlap (max in-flight lookups), not
+			// wall-clock — elapsed-time bounds flake under parallel vitest load.
+			// Sequential awaits would never have more than 1 lookup in flight.
+			let inFlight = 0;
+			let maxInFlight = 0;
+			codeAction.mockImplementation(
+				() =>
+					new Promise((resolve) => {
+						inFlight += 1;
+						maxInFlight = Math.max(maxInFlight, inFlight);
+						setTimeout(() => {
+							inFlight -= 1;
+							resolve([{ title: "Fix it", kind: "quickfix" }]);
+						}, 20);
+					}),
+			);
+
+			const result = await runner.run(ctx(filePath, env.tmpDir) as never);
+
+			expect(codeAction).toHaveBeenCalledTimes(3);
+			expect(maxInFlight).toBe(3);
+			expect(
+				result.diagnostics.every((d) => d.fixSuggestion?.includes("Fix it")),
+			).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
 });

--- a/tests/clients/pipeline-eslint-autofix.test.ts
+++ b/tests/clients/pipeline-eslint-autofix.test.ts
@@ -3,19 +3,21 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setupTestEnvironment } from "./test-utils.js";
 
-// Mock only the spawn surface — runAutofix's eslint path is pure spawn + JSON
-// parsing on top of the real autofix policy (which reads .eslintrc from disk).
+// Mock only the spawn surface — runAutofix's eslint path is pure spawn +
+// before/after file diffing on top of the real autofix policy (which reads
+// .eslintrc from disk).
 const { safeSpawnAsync } = vi.hoisted(() => ({ safeSpawnAsync: vi.fn() }));
 vi.mock("../../clients/safe-spawn.js", () => ({ safeSpawnAsync }));
 
 import { runAutofix } from "../../clients/pipeline.js";
 
-// Regression guard for #220: ESLint's `--fix-dry-run` reports the POST-fix state,
-// so a fully-autofixable file comes back with fixableErrorCount: 0 and the fixed
-// source in the `output` field. Keying on fixableErrorCount alone made
-// tryEslintFix never apply fixes. The fix also treats a dry-run `output` field as
-// a fix signal.
-describe("runAutofix — eslint --fix-dry-run output-field detection (#220)", () => {
+// Regression guard for #453: eslint autofix used to spawn twice
+// (--fix-dry-run to count fixable issues, then --fix to apply), doubling
+// ESLint's 1-3s cold start. tryEslintFix now runs a single `--fix` spawn and
+// detects the fix via before/after file content, same idiom as
+// tryStylelintFix/tryOxlintFix/etc. Exit code 1 (unfixable problems remain)
+// must still be treated as success when the file changed.
+describe("runAutofix — eslint single-spawn --fix (#453)", () => {
 	let env: ReturnType<typeof setupTestEnvironment>;
 	let filePath: string;
 
@@ -38,28 +40,16 @@ describe("runAutofix — eslint --fix-dry-run output-field detection (#220)", ()
 		};
 	}
 
-	it("applies eslint --fix when the dry-run reports output but fixableErrorCount 0", async () => {
+	it("spawns eslint exactly once and reports a fix when --fix changes the file", async () => {
+		let fixCalls = 0;
 		safeSpawnAsync.mockImplementation(async (_cmd: string, args: string[]) => {
 			if (args.includes("--version")) {
 				return { error: null, status: 0, stdout: "v10.5.0", stderr: "" };
 			}
-			if (args.includes("--fix-dry-run")) {
-				// Post-fix state: no remaining problems, fixed source in `output`.
-				return {
-					error: null,
-					status: 0,
-					stdout: JSON.stringify([
-						{
-							messages: [],
-							fixableErrorCount: 0,
-							fixableWarningCount: 0,
-							output: "const x = 1;\nconsole.log(x);\n",
-						},
-					]),
-					stderr: "",
-				};
-			}
-			// the actual --fix apply
+			// no --fix-dry-run branch: the dry-run spawn must be gone entirely.
+			expect(args).not.toContain("--fix-dry-run");
+			fixCalls++;
+			fs.writeFileSync(filePath, "const x = 1;\nconsole.log(x);\n");
 			return { error: null, status: 0, stdout: "", stderr: "" };
 		});
 
@@ -71,31 +61,18 @@ describe("runAutofix — eslint --fix-dry-run output-field detection (#220)", ()
 			deps() as never,
 		);
 
+		expect(fixCalls).toBe(1);
 		expect(result.attemptedTools).toContain("eslint");
 		expect(result.fixedCount).toBeGreaterThan(0);
 		expect(result.autofixTools.some((t) => t.startsWith("eslint"))).toBe(true);
-		// The apply pass (--fix, not --fix-dry-run) must actually run.
-		const appliedFix = safeSpawnAsync.mock.calls.some(
-			(c) => Array.isArray(c[1]) && c[1].includes("--fix") && !c[1].includes("--fix-dry-run"),
-		);
-		expect(appliedFix).toBe(true);
 	});
 
-	it("does not apply eslint --fix when the dry-run reports no fixes and no output", async () => {
+	it("does not report a fix when eslint --fix leaves the file unchanged", async () => {
 		safeSpawnAsync.mockImplementation(async (_cmd: string, args: string[]) => {
 			if (args.includes("--version")) {
 				return { error: null, status: 0, stdout: "v10.5.0", stderr: "" };
 			}
-			if (args.includes("--fix-dry-run")) {
-				return {
-					error: null,
-					status: 0,
-					stdout: JSON.stringify([
-						{ messages: [], fixableErrorCount: 0, fixableWarningCount: 0 },
-					]),
-					stderr: "",
-				};
-			}
+			// file left untouched
 			return { error: null, status: 0, stdout: "", stderr: "" };
 		});
 
@@ -108,9 +85,25 @@ describe("runAutofix — eslint --fix-dry-run output-field detection (#220)", ()
 		);
 
 		expect(result.fixedCount).toBe(0);
-		const appliedFix = safeSpawnAsync.mock.calls.some(
-			(c) => Array.isArray(c[1]) && c[1].includes("--fix") && !c[1].includes("--fix-dry-run"),
+	});
+
+	it("still counts as fixed when eslint exits 1 (unfixable problems remain) but the file changed", async () => {
+		safeSpawnAsync.mockImplementation(async (_cmd: string, args: string[]) => {
+			if (args.includes("--version")) {
+				return { error: null, status: 0, stdout: "v10.5.0", stderr: "" };
+			}
+			fs.writeFileSync(filePath, "const x = 1;\nconsole.log(x);\n");
+			return { error: null, status: 1, stdout: "", stderr: "" };
+		});
+
+		const result = await runAutofix(
+			filePath,
+			env.tmpDir,
+			() => undefined,
+			() => {},
+			deps() as never,
 		);
-		expect(appliedFix).toBe(false);
+
+		expect(result.fixedCount).toBeGreaterThan(0);
 	});
 });


### PR DESCRIPTION
Follow-up batch from the #450 write-path analysis (dispatch_lint = 59% and autofix = 11% of per-edit wall time remain the hot paths after cascade deferral). Closes #453.

## 1. ESLint autofix: one spawn instead of two (`clients/pipeline.ts`)
`tryEslintFix` ran `--fix-dry-run --format json` (count fixables) then `--fix` (apply) — two full ESLint cold starts (1–3s each) on the config-gated autofix path. Now a single `--fix` + before/after diff via `detectFileChangedAfterCommand`, the exact idiom of every sibling helper in the file. Exit code 1 stays allowed (unfixable problems remaining doesn't mean no fixes were applied). Behavior note: `fixedCount` for eslint is now 0/1 (changed-or-not) instead of the dry-run's fixable tally — consistent with stylelint/oxlint/rubocop, which already report this way. The #220 dry-run-output-field regression guard is retired with the mechanism it guarded.

## 2. Parallel LSP quick-fix lookups (`clients/dispatch/runners/lsp.ts`)
Up to `MAX_CODE_ACTION_LOOKUPS` (6) `codeAction` requests were awaited sequentially — ~6× server round-trip added exactly when blocking diagnostics exist and the agent is waiting. Now `Promise.all` with per-item error isolation (enrichment stays best-effort).

## 3. Content reuse in the lsp runner (same file)
The #441 nosemgrep suppression lazily re-read the file from disk although `run()` already holds the content it synced to the LSP. Reusing it is both cheaper and *more correct* — the suppression check now sees exactly the content the diagnostics were computed against, immune to disk drift in the window.

## Tests
- `pipeline-eslint-autofix.test.ts` rewritten: single-spawn assertion (no `--fix-dry-run` in any call), fix detected via real file diffing, unchanged → 0, exit-1-but-changed → fixed. Mocks only the spawn boundary.
- `runner-status-semantics.test.ts`: new parallelism test asserting **max in-flight overlap = 3** (reviewer hardening: overlap-counting instead of the subagent's wall-clock bound, which would flake under parallel vitest load).
- Full suite **2815 passed, 5 skipped**; lint clean.

## Checklist
- [x] CHANGELOG `[Unreleased]` entry included
- [x] Tests included

🤖 Generated with [Claude Code](https://claude.com/claude-code)