### PR TITLE
refactor: consolidate 8 NDJSON loggers onto one buffered async writer (closes #454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to pi-lens will be documented in this file.
 
 - perf: cascade diagnostics now run concurrently after each edit instead of blocking the write pipeline (~26% median per-edit latency reduction); settled at turn_end with a bounded wait (#450)
 - perf: write-path micro batch — ESLint autofix runs a single `--fix` spawn (was dry-run + fix, double cold-start), LSP quick-fix lookups for blocking diagnostics run in parallel, and the lsp runner reuses its already-read file content for nosemgrep suppression (#453)
+- perf/refactor: the eight NDJSON debug loggers (latency, cascade, read-guard, tree-sitter, dead-code, actionable-warnings, ast-grep-tool, diagnostic) now share one buffered async writer (clients/ndjson-logger.ts) — no more synchronous appendFileSync on the per-edit hot path; best-effort sync flush at process exit (#454)
 
 ### Fixed
 

--- a/clients/actionable-warnings-logger.ts
+++ b/clients/actionable-warnings-logger.ts
@@ -1,7 +1,7 @@
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { isTestMode } from "./env-utils.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
+import { createNdjsonLogger } from "./ndjson-logger.js";
 
 const AW_LOG_DIR = getGlobalPiLensDir();
 const AW_LOG_FILE = path.join(AW_LOG_DIR, "actionable-warnings.log");
@@ -13,14 +13,11 @@ const MAX_LOG_BYTES = Math.max(
 		10,
 	) || 1048576,
 );
-
-try {
-	if (!fs.existsSync(AW_LOG_DIR)) {
-		fs.mkdirSync(AW_LOG_DIR, { recursive: true });
-	}
-} catch (err) {
-	void err;
-}
+const writer = createNdjsonLogger({
+	filePath: AW_LOG_FILE,
+	maxBytes: MAX_LOG_BYTES,
+	backupPath: AW_LOG_BACKUP_FILE,
+});
 
 export interface ActionableWarningsLogEntry {
 	event: string;
@@ -29,37 +26,20 @@ export interface ActionableWarningsLogEntry {
 	metadata?: Record<string, unknown>;
 }
 
-function rotateIfNeeded(): void {
-	try {
-		if (!fs.existsSync(AW_LOG_FILE)) return;
-		const size = fs.statSync(AW_LOG_FILE).size;
-		if (size < MAX_LOG_BYTES) return;
-		try {
-			fs.rmSync(AW_LOG_BACKUP_FILE, { force: true });
-		} catch (err) {
-			void err;
-		}
-		fs.renameSync(AW_LOG_FILE, AW_LOG_BACKUP_FILE);
-	} catch (err) {
-		void err;
-	}
-}
-
 export function logActionableWarningsEvent(
 	entry: ActionableWarningsLogEntry,
 ): void {
 	if (isTestMode()) {
 		return;
 	}
-	const line = `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`;
-	try {
-		rotateIfNeeded();
-		fs.appendFileSync(AW_LOG_FILE, line);
-	} catch (err) {
-		void err;
-	}
+	writer.log({ ts: new Date().toISOString(), ...entry });
 }
 
 export function getActionableWarningsLogPath(): string {
 	return AW_LOG_FILE;
+}
+
+/** Resolve once all enqueued actionable-warnings writes are on disk. */
+export function flushActionableWarningsLog(): Promise<void> {
+	return writer.flush();
 }

--- a/clients/ast-grep-tool-logger.ts
+++ b/clients/ast-grep-tool-logger.ts
@@ -10,10 +10,10 @@
  * Mirrors `actionable-warnings-logger.ts` for shape + rotation behaviour.
  */
 
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { isTestMode } from "./env-utils.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
+import { createNdjsonLogger } from "./ndjson-logger.js";
 
 const AG_LOG_DIR = getGlobalPiLensDir();
 const AG_LOG_FILE = path.join(AG_LOG_DIR, "ast-grep-tools.log");
@@ -25,14 +25,11 @@ const MAX_LOG_BYTES = Math.max(
 		10,
 	) || 1048576,
 );
-
-try {
-	if (!fs.existsSync(AG_LOG_DIR)) {
-		fs.mkdirSync(AG_LOG_DIR, { recursive: true });
-	}
-} catch (err) {
-	void err;
-}
+const writer = createNdjsonLogger({
+	filePath: AG_LOG_FILE,
+	maxBytes: MAX_LOG_BYTES,
+	backupPath: AG_LOG_BACKUP_FILE,
+});
 
 export type AstGrepToolName = "ast_grep_search" | "ast_grep_replace";
 
@@ -151,22 +148,6 @@ export function astGrepRemediationHint(kind: AstGrepErrorKind): string | null {
 	}
 }
 
-function rotateIfNeeded(): void {
-	try {
-		if (!fs.existsSync(AG_LOG_FILE)) return;
-		const size = fs.statSync(AG_LOG_FILE).size;
-		if (size < MAX_LOG_BYTES) return;
-		try {
-			fs.rmSync(AG_LOG_BACKUP_FILE, { force: true });
-		} catch (err) {
-			void err;
-		}
-		fs.renameSync(AG_LOG_FILE, AG_LOG_BACKUP_FILE);
-	} catch (err) {
-		void err;
-	}
-}
-
 export function logAstGrepToolEvent(
 	event: Omit<
 		AstGrepToolEvent,
@@ -186,17 +167,16 @@ export function logAstGrepToolEvent(
 		rewriteLineCount: event.rewriteLineCount,
 		errorRaw: truncate(event.errorRaw, ERROR_TRUNCATE_AT),
 	};
-	const line = `${JSON.stringify({ ts: new Date().toISOString(), ...payload })}\n`;
-	try {
-		rotateIfNeeded();
-		fs.appendFileSync(AG_LOG_FILE, line);
-	} catch (err) {
-		void err;
-	}
+	writer.log({ ts: new Date().toISOString(), ...payload });
 }
 
 export function getAstGrepToolLogPath(): string {
 	return AG_LOG_FILE;
+}
+
+/** Resolve once all enqueued ast-grep-tool writes are on disk. */
+export function flushAstGrepToolLog(): Promise<void> {
+	return writer.flush();
 }
 
 export { countLines as _countLinesForTest };

--- a/clients/cascade-logger.ts
+++ b/clients/cascade-logger.ts
@@ -1,16 +1,12 @@
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { isTestMode } from "./env-utils.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
+import { createNdjsonLogger } from "./ndjson-logger.js";
 
 const CASCADE_LOG_DIR = getGlobalPiLensDir();
 const CASCADE_LOG_FILE = path.join(CASCADE_LOG_DIR, "cascade.log");
 
-try {
-	if (!fs.existsSync(CASCADE_LOG_DIR)) {
-		fs.mkdirSync(CASCADE_LOG_DIR, { recursive: true });
-	}
-} catch {}
+const writer = createNdjsonLogger({ filePath: CASCADE_LOG_FILE });
 
 export interface CascadeLogEntry {
 	ts?: string;
@@ -67,12 +63,14 @@ export function logCascade(entry: CascadeLogEntry): void {
 	if (isTestMode()) {
 		return;
 	}
-	const line = `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`;
-	try {
-		fs.appendFileSync(CASCADE_LOG_FILE, line);
-	} catch {}
+	writer.log({ ts: new Date().toISOString(), ...entry });
 }
 
 export function getCascadeLogPath(): string {
 	return CASCADE_LOG_FILE;
+}
+
+/** Resolve once all enqueued cascade writes are on disk (tests/shutdown). */
+export function flushCascadeLog(): Promise<void> {
+	return writer.flush();
 }

--- a/clients/dead-code-logger.ts
+++ b/clients/dead-code-logger.ts
@@ -6,10 +6,10 @@
  * for shape + size-based rotation.
  */
 
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { isTestMode } from "./env-utils.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
+import { createNdjsonLogger } from "./ndjson-logger.js";
 
 const LOG_DIR = getGlobalPiLensDir();
 const LOG_FILE = path.join(LOG_DIR, "dead-code.log");
@@ -19,6 +19,11 @@ const MAX_LOG_BYTES = Math.max(
 	Number.parseInt(process.env.PI_LENS_DEAD_CODE_LOG_MAX_BYTES ?? "1048576", 10) ||
 		1048576,
 );
+const writer = createNdjsonLogger({
+	filePath: LOG_FILE,
+	maxBytes: MAX_LOG_BYTES,
+	backupPath: LOG_BACKUP_FILE,
+});
 
 export interface DeadCodeScanEvent {
 	language: string;
@@ -33,17 +38,6 @@ export interface DeadCodeScanEvent {
 	reason?: string;
 }
 
-function rotateIfNeeded(): void {
-	try {
-		const stat = fs.statSync(LOG_FILE);
-		if (stat.size >= MAX_LOG_BYTES) {
-			fs.renameSync(LOG_FILE, LOG_BACKUP_FILE);
-		}
-	} catch {
-		// no file yet, or rename raced — nothing to rotate
-	}
-}
-
 /**
  * Append one scan event. Fire-and-forget: telemetry must never break a scan, so
  * every fs error is swallowed. Skipped under test mode to keep the suite from
@@ -51,12 +45,10 @@ function rotateIfNeeded(): void {
  */
 export function logDeadCodeScan(event: DeadCodeScanEvent): void {
 	if (isTestMode()) return;
-	try {
-		if (!fs.existsSync(LOG_DIR)) fs.mkdirSync(LOG_DIR, { recursive: true });
-		rotateIfNeeded();
-		const row = JSON.stringify({ ts: new Date().toISOString(), ...event });
-		fs.appendFileSync(LOG_FILE, row + "\n");
-	} catch {
-		// telemetry is best-effort
-	}
+	writer.log({ ts: new Date().toISOString(), ...event });
+}
+
+/** Resolve once all enqueued dead-code writes are on disk (tests/shutdown). */
+export function flushDeadCodeLog(): Promise<void> {
+	return writer.flush();
 }

--- a/clients/diagnostic-logger.ts
+++ b/clients/diagnostic-logger.ts
@@ -4,10 +4,10 @@
  * Log file: ~/.pi-lens/logs/{date}.jsonl
  */
 
-import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { isTestMode } from "./env-utils.js";
+import { createNdjsonLogger } from "./ndjson-logger.js";
 
 export interface DiagnosticEntry {
 	// When
@@ -66,12 +66,7 @@ export interface LogContext {
 }
 
 function getLogDir(): string {
-	const home = os.homedir();
-	const logDir = path.join(home, ".pi-lens", "logs");
-	if (!fs.existsSync(logDir)) {
-		fs.mkdirSync(logDir, { recursive: true });
-	}
-	return logDir;
+	return path.join(os.homedir(), ".pi-lens", "logs");
 }
 
 function getLogFile(): string {
@@ -90,30 +85,16 @@ export function getDiagnosticLogger(): DiagnosticLogger {
 }
 
 export function createDiagnosticLogger(): DiagnosticLogger {
-	const pending: DiagnosticEntry[] = [];
-	let writing = false;
-
-	const writePending = async () => {
-		if (writing || pending.length === 0) return;
-		writing = true;
-		const toWrite = pending.splice(0, pending.length);
-		const lines = toWrite.map((e) => JSON.stringify(e)).join("\n") + "\n";
-		try {
-			await fs.promises.appendFile(getLogFile(), lines);
-		} catch (err) {
-			// pi-lens-ignore: missing-error-propagation — fire-and-forget log write, must not throw
-			console.error("Failed to write diagnostic log:", err);
-		}
-		writing = false;
-	};
+	// Lazy filePath: the log file is keyed on the current date, resolved per
+	// drain so a long-lived logger rolls over at midnight.
+	const writer = createNdjsonLogger({ filePath: () => getLogFile() });
 
 	return {
 		log(entry: DiagnosticEntry) {
 			if (isTestMode()) {
 				return;
 			}
-			pending.push(entry);
-			writePending(); // async, non-blocking
+			writer.log(entry); // async, non-blocking
 		},
 
 		logCaught(d: Diagnostic, context: LogContext, shownInline = false) {
@@ -141,11 +122,7 @@ export function createDiagnosticLogger(): DiagnosticLogger {
 		},
 
 		async flush() {
-			// Drain any buffered entries, then wait for the write to finish.
-			await writePending();
-			while (writing) {
-				await new Promise((resolve) => setTimeout(resolve, 10));
-			}
+			await writer.flush();
 		},
 	};
 }

--- a/clients/latency-logger.ts
+++ b/clients/latency-logger.ts
@@ -2,15 +2,12 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { isTestMode } from "./env-utils.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
+import { createNdjsonLogger } from "./ndjson-logger.js";
 
 const LATENCY_LOG_DIR = getGlobalPiLensDir();
 const LATENCY_LOG_FILE = path.join(LATENCY_LOG_DIR, "latency.log");
 
-try {
-	if (!fs.existsSync(LATENCY_LOG_DIR)) {
-		fs.mkdirSync(LATENCY_LOG_DIR, { recursive: true });
-	}
-} catch {}
+const writer = createNdjsonLogger({ filePath: LATENCY_LOG_FILE });
 
 export interface LatencyEntry {
 	type: "runner" | "tool_result" | "phase";
@@ -44,14 +41,16 @@ export function logLatency(entry: LatencyEntry): void {
 	if (isTestMode()) {
 		return;
 	}
-	const line = `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`;
-	try {
-		fs.appendFileSync(LATENCY_LOG_FILE, line);
-	} catch {}
+	writer.log({ ts: new Date().toISOString(), ...entry });
 }
 
 export function getLatencyLogPath(): string {
 	return LATENCY_LOG_FILE;
+}
+
+/** Resolve once all enqueued latency writes are on disk (tests/shutdown). */
+export function flushLatencyLog(): Promise<void> {
+	return writer.flush();
 }
 
 export function readLatencyLog(limit = 100): LatencyEntry[] {
@@ -68,7 +67,7 @@ export function readLatencyLog(limit = 100): LatencyEntry[] {
 }
 
 export function clearLatencyLog(): void {
-	try {
-		fs.writeFileSync(LATENCY_LOG_FILE, "");
-	} catch {}
+	// Enqueue the truncate in the same serialized queue so a clear cannot race a
+	// pending drain. Await flushLatencyLog() if you need the file empty on disk.
+	writer.truncate();
 }

--- a/clients/ndjson-logger.ts
+++ b/clients/ndjson-logger.ts
@@ -1,0 +1,182 @@
+/**
+ * Shared write-plumbing for the hand-rolled NDJSON debug loggers in clients/.
+ *
+ * One buffered async writer replaces eight drifting copies of append+rotate.
+ * `log()`/`append()` are synchronous-call, async-write: they enqueue a
+ * serialized line and a single in-flight `fs.promises.appendFile` drains the
+ * queue — no `appendFileSync` on the per-edit hot path (latency-logger alone
+ * fired ~10–20 sync appends per edit, #454/#361/#368).
+ *
+ * Errors are swallowed best-effort, matching every current logger. A
+ * best-effort SYNC flush is registered on `process.on("exit")` (appendFileSync
+ * is fine at exit — not the hot path; no child spawning, #234).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/** A queued write ("line") or an in-band truncate op (latency clear). */
+type QueueItem = { kind: "line"; line: string } | { kind: "truncate" };
+
+export interface NdjsonLoggerOptions {
+	/** Absolute log file path, or a lazy resolver (diagnostic-logger keys on the date). */
+	filePath: string | (() => string);
+	/**
+	 * Rotation threshold in bytes. Absent = never rotate (preserves the loggers
+	 * that don't rotate today). At/above the threshold the file is renamed to
+	 * `<filePath>.1` (previous backup removed first, Windows-safe).
+	 */
+	maxBytes?: number;
+	/** Backup path for rotation. Defaults to `<filePath>.1`. Ignored without maxBytes. */
+	backupPath?: string | (() => string);
+}
+
+export interface NdjsonLogger {
+	/** Serialize `obj` to one NDJSON line and enqueue it (async write). */
+	log(obj: unknown): void;
+	/** Enqueue an already-serialized line (must NOT include the trailing newline). */
+	append(line: string): void;
+	/** Enqueue a truncate op in the same serialized queue (clear-without-racing). */
+	truncate(): void;
+	/** Resolves once everything enqueued so far is on disk. */
+	flush(): Promise<void>;
+	/** Best-effort SYNC flush of any buffered lines — safe to call at process exit. */
+	flushSync(): void;
+}
+
+function resolve(v: string | (() => string)): string {
+	return typeof v === "function" ? v() : v;
+}
+
+// One shared exit handler flushes every logger — avoids an EventEmitter
+// MaxListeners warning once more than ~10 loggers exist (we ship eight, plus
+// diagnostic + test instances). No child spawning at teardown (#234).
+const exitFlushers = new Set<() => void>();
+let exitHandlerRegistered = false;
+
+/** Test-only view of the registered exit flushers (see ndjson-logger.test.ts). */
+export function _exitFlushersForTest(): ReadonlySet<() => void> {
+	return exitFlushers;
+}
+
+function registerExitFlusher(flushSync: () => void): void {
+	exitFlushers.add(flushSync);
+	if (!exitHandlerRegistered) {
+		exitHandlerRegistered = true;
+		process.on("exit", () => {
+			for (const flush of exitFlushers) {
+				try {
+					flush();
+				} catch {}
+			}
+		});
+	}
+}
+
+export function createNdjsonLogger(options: NdjsonLoggerOptions): NdjsonLogger {
+	const queue: QueueItem[] = [];
+	let drainPromise: Promise<void> | null = null;
+	let ensuredDir = false;
+
+	function ensureDir(file: string): void {
+		if (ensuredDir) return;
+		try {
+			fs.mkdirSync(path.dirname(file), { recursive: true });
+			ensuredDir = true;
+		} catch {}
+	}
+
+	function rotateIfNeeded(file: string): void {
+		if (options.maxBytes === undefined) return;
+		try {
+			const size = fs.statSync(file).size;
+			if (size < options.maxBytes) return;
+			const backup = options.backupPath
+				? resolve(options.backupPath)
+				: `${file}.1`;
+			try {
+				fs.rmSync(backup, { force: true });
+			} catch {}
+			fs.renameSync(file, backup);
+		} catch {
+			// no file yet, or rename raced — nothing to rotate
+		}
+	}
+
+	async function drainLoop(): Promise<void> {
+		// Peek, write, then remove — an item stays in the queue until it is on
+		// disk, so a teardown flushSync (which abandons this async loop) never
+		// drops an item this loop had already dequeued but not yet written.
+		while (queue.length > 0) {
+			const item = queue[0];
+			const file = resolve(options.filePath);
+			ensureDir(file);
+			try {
+				if (item.kind === "truncate") {
+					await fs.promises.writeFile(file, "");
+				} else {
+					rotateIfNeeded(file);
+					await fs.promises.appendFile(file, item.line);
+				}
+			} catch {
+				// telemetry is best-effort
+			}
+			queue.shift();
+		}
+	}
+
+	function drain(): Promise<void> {
+		// Serialize: a single in-flight drain owns the queue. flush() awaits this
+		// same promise, so it never resolves before pending writes land. The loop
+		// re-checks queue.length, so items enqueued mid-drain are picked up before
+		// the promise settles — no stranded item, no second concurrent drainer.
+		if (!drainPromise) {
+			drainPromise = drainLoop().finally(() => {
+				drainPromise = null;
+			});
+		}
+		return drainPromise;
+	}
+
+	function enqueue(item: QueueItem): void {
+		queue.push(item);
+		void drain();
+	}
+
+	function flushSync(): void {
+		// Drain the in-memory queue synchronously — safe at process exit.
+		while (queue.length > 0) {
+			const item = queue.shift() as QueueItem;
+			const file = resolve(options.filePath);
+			ensureDir(file);
+			try {
+				if (item.kind === "truncate") {
+					fs.writeFileSync(file, "");
+				} else {
+					rotateIfNeeded(file);
+					fs.appendFileSync(file, item.line);
+				}
+			} catch {}
+		}
+	}
+
+	// Best-effort teardown flush of anything still buffered, via the single
+	// shared exit handler. appendFileSync is fine here — not the hot path.
+	registerExitFlusher(flushSync);
+
+	return {
+		log(obj: unknown): void {
+			enqueue({ kind: "line", line: `${JSON.stringify(obj)}\n` });
+		},
+		append(line: string): void {
+			enqueue({ kind: "line", line: `${line}\n` });
+		},
+		truncate(): void {
+			enqueue({ kind: "truncate" });
+		},
+		async flush(): Promise<void> {
+			await drain();
+		},
+		flushSync,
+	};
+}

--- a/clients/read-guard-logger.ts
+++ b/clients/read-guard-logger.ts
@@ -1,7 +1,7 @@
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { isTestMode } from "./env-utils.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
+import { createNdjsonLogger } from "./ndjson-logger.js";
 
 const READ_GUARD_LOG_DIR = getGlobalPiLensDir();
 const READ_GUARD_LOG_FILE = path.join(READ_GUARD_LOG_DIR, "read-guard.log");
@@ -14,6 +14,11 @@ const MAX_LOG_BYTES = Math.max(
 	Number.parseInt(process.env.PI_LENS_READ_GUARD_MAX_BYTES ?? "1048576", 10) ||
 		1048576,
 );
+const writer = createNdjsonLogger({
+	filePath: READ_GUARD_LOG_FILE,
+	maxBytes: MAX_LOG_BYTES,
+	backupPath: READ_GUARD_LOG_BACKUP_FILE,
+});
 const VERBOSE_READ_GUARD_LOG =
 	process.env.PI_LENS_READ_GUARD_VERBOSE === "1" ||
 	process.env.PI_LENS_READ_GUARD_LOG === "verbose";
@@ -24,14 +29,6 @@ const SNAPSHOT_LOG_SETTING = (
 const LOG_SNAPSHOT_VALIDATION = !["0", "false", "off"].includes(
 	SNAPSHOT_LOG_SETTING,
 );
-
-try {
-	if (!fs.existsSync(READ_GUARD_LOG_DIR)) {
-		fs.mkdirSync(READ_GUARD_LOG_DIR, { recursive: true });
-	}
-} catch (err) {
-	void err;
-}
 
 export interface ReadGuardLogEntry {
 	event: string;
@@ -68,35 +65,18 @@ function shouldLogEvent(event: string): boolean {
 	);
 }
 
-function rotateIfNeeded(): void {
-	try {
-		if (!fs.existsSync(READ_GUARD_LOG_FILE)) return;
-		const size = fs.statSync(READ_GUARD_LOG_FILE).size;
-		if (size < MAX_LOG_BYTES) return;
-		try {
-			fs.rmSync(READ_GUARD_LOG_BACKUP_FILE, { force: true });
-		} catch (err) {
-			void err;
-		}
-		fs.renameSync(READ_GUARD_LOG_FILE, READ_GUARD_LOG_BACKUP_FILE);
-	} catch (err) {
-		void err;
-	}
-}
-
 export function logReadGuardEvent(entry: ReadGuardLogEntry): void {
 	if (isTestMode() || !shouldLogEvent(entry.event)) {
 		return;
 	}
-	const line = `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`;
-	try {
-		rotateIfNeeded();
-		fs.appendFileSync(READ_GUARD_LOG_FILE, line);
-	} catch (err) {
-		void err;
-	}
+	writer.log({ ts: new Date().toISOString(), ...entry });
 }
 
 export function getReadGuardLogPath(): string {
 	return READ_GUARD_LOG_FILE;
+}
+
+/** Resolve once all enqueued read-guard writes are on disk (tests/shutdown). */
+export function flushReadGuardLog(): Promise<void> {
+	return writer.flush();
 }

--- a/clients/tree-sitter-logger.ts
+++ b/clients/tree-sitter-logger.ts
@@ -1,16 +1,12 @@
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { isTestMode } from "./env-utils.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
+import { createNdjsonLogger } from "./ndjson-logger.js";
 
 const TREE_SITTER_LOG_DIR = getGlobalPiLensDir();
 const TREE_SITTER_LOG_FILE = path.join(TREE_SITTER_LOG_DIR, "tree-sitter.log");
 
-try {
-	if (!fs.existsSync(TREE_SITTER_LOG_DIR)) {
-		fs.mkdirSync(TREE_SITTER_LOG_DIR, { recursive: true });
-	}
-} catch {}
+const writer = createNdjsonLogger({ filePath: TREE_SITTER_LOG_FILE });
 
 export interface TreeSitterLogEntry {
 	ts?: string;
@@ -40,12 +36,14 @@ export function logTreeSitter(entry: TreeSitterLogEntry): void {
 	if (isTestMode()) {
 		return;
 	}
-	const line = `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`;
-	try {
-		fs.appendFileSync(TREE_SITTER_LOG_FILE, line);
-	} catch {}
+	writer.log({ ts: new Date().toISOString(), ...entry });
 }
 
 export function getTreeSitterLogPath(): string {
 	return TREE_SITTER_LOG_FILE;
+}
+
+/** Resolve once all enqueued tree-sitter writes are on disk (tests/shutdown). */
+export function flushTreeSitterLog(): Promise<void> {
+	return writer.flush();
 }

--- a/tests/clients/ndjson-logger.test.ts
+++ b/tests/clients/ndjson-logger.test.ts
@@ -1,0 +1,154 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	_exitFlushersForTest,
+	createNdjsonLogger,
+} from "../../clients/ndjson-logger.js";
+
+let tmpDir: string;
+let logFile: string;
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ndjson-logger-"));
+	logFile = path.join(tmpDir, "test.log");
+});
+
+afterEach(() => {
+	try {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	} catch {}
+});
+
+function readLines(file: string): string[] {
+	return fs.readFileSync(file, "utf-8").split("\n").filter(Boolean);
+}
+
+describe("createNdjsonLogger", () => {
+	it("serializes a burst of log() calls in enqueue order", async () => {
+		const logger = createNdjsonLogger({ filePath: logFile });
+		for (let i = 0; i < 50; i++) {
+			logger.log({ i });
+		}
+		await logger.flush();
+
+		const lines = readLines(logFile);
+		expect(lines).toHaveLength(50);
+		lines.forEach((line, idx) => {
+			expect(JSON.parse(line)).toEqual({ i: idx });
+		});
+	});
+
+	it("flush() resolves only once everything enqueued is on disk", async () => {
+		const logger = createNdjsonLogger({ filePath: logFile });
+		logger.log({ a: 1 });
+		logger.log({ b: 2 });
+		await logger.flush();
+		expect(readLines(logFile)).toHaveLength(2);
+
+		// A second batch after a completed flush drains independently.
+		logger.log({ c: 3 });
+		await logger.flush();
+		expect(readLines(logFile)).toHaveLength(3);
+	});
+
+	it("lazily creates the parent directory", async () => {
+		const nested = path.join(tmpDir, "a", "b", "c", "deep.log");
+		const logger = createNdjsonLogger({ filePath: nested });
+		logger.log({ ok: true });
+		await logger.flush();
+		expect(fs.existsSync(nested)).toBe(true);
+	});
+
+	it("rotates to <file>.1 at the byte threshold", async () => {
+		const backup = `${logFile}.1`;
+		// Small threshold so a couple of lines trip it.
+		const logger = createNdjsonLogger({ filePath: logFile, maxBytes: 40 });
+
+		logger.log({ payload: "first-entry-under-threshold" });
+		await logger.flush();
+		// Below threshold on the first write — no rotation yet.
+		expect(fs.existsSync(backup)).toBe(false);
+
+		logger.log({ payload: "second-entry-trips-rotation" });
+		await logger.flush();
+		// The pre-existing file exceeded maxBytes, so it was renamed to .1 and
+		// the new line landed in a fresh primary file.
+		expect(fs.existsSync(backup)).toBe(true);
+		expect(readLines(logFile)).toHaveLength(1);
+	});
+
+	it("never rotates when maxBytes is absent", async () => {
+		const backup = `${logFile}.1`;
+		const logger = createNdjsonLogger({ filePath: logFile });
+		for (let i = 0; i < 100; i++) {
+			logger.log({ padding: "x".repeat(100), i });
+		}
+		await logger.flush();
+		expect(fs.existsSync(backup)).toBe(false);
+		expect(readLines(logFile)).toHaveLength(100);
+	});
+
+	it("a truncate op does not race pending writes (clear is serialized)", async () => {
+		const logger = createNdjsonLogger({ filePath: logFile });
+		logger.log({ before: 1 });
+		logger.log({ before: 2 });
+		logger.truncate();
+		logger.log({ after: 1 });
+		await logger.flush();
+
+		// Enqueue order: two writes, truncate (empties file), one write. The
+		// truncate cannot jump ahead of the earlier writes, so the final file
+		// holds exactly the single post-truncate line.
+		const lines = readLines(logFile);
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0])).toEqual({ after: 1 });
+	});
+
+	it("append() adds the trailing newline itself", async () => {
+		const logger = createNdjsonLogger({ filePath: logFile });
+		logger.append('{"raw":true}');
+		await logger.flush();
+		expect(fs.readFileSync(logFile, "utf-8")).toBe('{"raw":true}\n');
+	});
+
+	it("flushSync drains buffered lines synchronously (exit-handler path)", () => {
+		const logger = createNdjsonLogger({ filePath: logFile });
+		logger.log({ buffered: 1 });
+		logger.log({ buffered: 2 });
+		// Do NOT await drain — call the sync flush directly, as process.on("exit")
+		// would. Everything buffered must land on disk.
+		logger.flushSync();
+		expect(readLines(logFile)).toHaveLength(2);
+	});
+
+	it("registers the logger's flushSync in the shared exit flusher set", () => {
+		const before = _exitFlushersForTest().size;
+		const logger = createNdjsonLogger({ filePath: logFile });
+		// One shared process 'exit' handler flushes all loggers, so we assert the
+		// logger's flushSync is enrolled rather than counting process listeners.
+		expect(_exitFlushersForTest().size).toBe(before + 1);
+		expect(_exitFlushersForTest().has(logger.flushSync)).toBe(true);
+	});
+
+	it("keeps a single shared process 'exit' listener regardless of logger count", () => {
+		const count = process.listenerCount("exit");
+		createNdjsonLogger({ filePath: path.join(tmpDir, "a.log") });
+		createNdjsonLogger({ filePath: path.join(tmpDir, "b.log") });
+		createNdjsonLogger({ filePath: path.join(tmpDir, "c.log") });
+		// No per-logger listener growth — the MaxListeners warning cannot fire.
+		expect(process.listenerCount("exit")).toBe(count);
+	});
+
+	it("swallows write errors (best-effort telemetry)", async () => {
+		// Point at a path whose parent is a file, so mkdir/append fail.
+		const asFile = path.join(tmpDir, "not-a-dir");
+		fs.writeFileSync(asFile, "x");
+		const logger = createNdjsonLogger({
+			filePath: path.join(asFile, "child.log"),
+		});
+		logger.log({ nope: true });
+		await expect(logger.flush()).resolves.toBeUndefined();
+	});
+});

--- a/tests/clients/tree-sitter-logger.test.ts
+++ b/tests/clients/tree-sitter-logger.test.ts
@@ -11,12 +11,14 @@ describe("tree-sitter-logger", () => {
 	});
 
 	it("writes JSON line entries to tree-sitter.log", async () => {
-		const appendFileSync = vi.fn();
+		const appendFile = vi.fn(async (_file: string, _data: string) => {});
 
 		vi.doMock("node:fs", () => ({
-			existsSync: () => true,
 			mkdirSync: vi.fn(),
-			appendFileSync,
+			statSync: () => {
+				throw new Error("ENOENT");
+			},
+			promises: { appendFile },
 		}));
 		vi.doMock("node:os", () => ({
 			homedir: () => "/mock-home",
@@ -31,11 +33,11 @@ describe("tree-sitter-logger", () => {
 			blocking: 1,
 		});
 
-		expect(appendFileSync).toHaveBeenCalledTimes(1);
-		const [filePath, payload] = appendFileSync.mock.calls[0] as [
-			string,
-			string,
-		];
+		// Buffered async write — await the exported flush before asserting.
+		await mod.flushTreeSitterLog();
+
+		expect(appendFile).toHaveBeenCalledTimes(1);
+		const [filePath, payload] = appendFile.mock.calls[0];
 		expect(filePath).toContain("tree-sitter.log");
 		expect(payload).toContain('"phase":"runner_complete"');
 		expect(payload).toContain('"filePath":"src/main.go"');
@@ -44,22 +46,24 @@ describe("tree-sitter-logger", () => {
 	});
 
 	it("swallows append errors", async () => {
-		const appendFileSync = vi.fn(() => {
+		const appendFile = vi.fn(async () => {
 			throw new Error("disk full");
 		});
 
 		vi.doMock("node:fs", () => ({
-			existsSync: () => true,
 			mkdirSync: vi.fn(),
-			appendFileSync,
+			statSync: () => {
+				throw new Error("ENOENT");
+			},
+			promises: { appendFile },
 		}));
 		vi.doMock("node:os", () => ({
 			homedir: () => "/mock-home",
 		}));
 
 		const mod = await import("../../clients/tree-sitter-logger.js");
-		expect(() =>
-			mod.logTreeSitter({ phase: "runner_start", filePath: "src/a.go" }),
-		).not.toThrow();
+		mod.logTreeSitter({ phase: "runner_start", filePath: "src/a.go" });
+		// The swallowed rejection must not surface through flush().
+		await expect(mod.flushTreeSitterLog()).resolves.toBeUndefined();
 	});
 });


### PR DESCRIPTION
Second half of the write-path follow-up batch (after #455). Closes #454.

## Why

Eight hand-rolled copies of "append NDJSON, maybe rotate" (`latency`, `cascade`, `read-guard`, `tree-sitter`, `dead-code`, `actionable-warnings`, `ast-grep-tool`, `diagnostic`), with drifting rotation policies — and `latency-logger` alone fired **~10–20 `fs.appendFileSync` calls per edit** (per runner + per phase + summary), a steady event-loop tax on the hot path (#361/#368 discipline). This is the canonical AGENTS.md consolidation smell.

## What

**New `clients/ndjson-logger.ts`** — `createNdjsonLogger({ filePath | lazy resolver, maxBytes?, backupPath? })`:
- **Sync-call, async-write**: `log()` enqueues; a single serialized drain (`fs.promises.appendFile`) flushes. The drain **peeks-writes-then-shifts**, so the teardown `flushSync` can never drop an item mid-write (worst case at process death is a rare duplicated line — the right tradeoff for telemetry).
- **Rotation preserved per logger** via `maxBytes` (absent = never rotate, matching latency/cascade/tree-sitter/diagnostic today); unified to `rmSync(force)` + `rename` (dead-code previously skipped the rm — a Windows rename-over-existing hazard).
- **Truncate as an in-band queue op** — `clearLatencyLog()` can no longer race a pending drain.
- **`flush(): Promise<void>`** exported per logger (tests/shutdown).
- **One shared `process.on("exit")` handler** (sync flush of buffered lines; deliberate single listener to avoid MaxListeners warnings; no child spawning at teardown — #234).

All eight loggers migrated **plumbing-only**: public APIs (`logLatency`, `logCascade`, …), schemas, and path conventions unchanged; call sites untouched. `diagnostic-logger` keeps its interface/singleton/date-keyed daily file via a lazy path resolver — and loses its old `setTimeout(10)` polling flush.

## Behavior notes (reviewed & accepted)
- `diagnostic-logger` write failures are now silently best-effort like the other seven (was `console.error`) — harmonization, flag if you want the stderr diagnostic back.
- `readLatencyLog`/`clearLatencyLog` have no external callers (verified), so no read-after-write consumer needed fixing; offline readers (`logs:smells`) are unaffected.
- Rotating loggers keep one `statSync` per line inside the drain (size check) — they're low-frequency; the hot latency logger has no rotation and pays zero sync IO.

## Tests
- New `tests/clients/ndjson-logger.test.ts`: serialized ordering under a 50-call burst, flush completeness, rotation at threshold, no-rotation default, truncate-vs-pending-writes, `flushSync`, single shared exit listener, error swallowing.
- `tree-sitter-logger.test.ts` rewritten from sync-append mocking to async-append + `await flush()` (no weakened assertions, no sleeps).
- Rebased on master post-#455; full suite **2826 passed, 5 skipped**; lint clean.

## Checklist
- [x] CHANGELOG `[Unreleased]` entry included
- [x] Tests included

🤖 Generated with [Claude Code](https://claude.com/claude-code)