### PR TITLE
feat(scan): slow-filesystem mode — measured probe, reduced sync caps, visible degradation (closes #462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Added
 
+- **Slow-filesystem mode** (#462) — WSL 9p mounts (`/mnt/c/...`) measure ~1.3ms/`stat` vs ~17µs native (75x), so an unbounded synchronous tree walk (e.g. a 5,000-file project) could cost ~6.5s of stat time alone and freeze the TUI. `clients/slow-fs.ts` adds a cheap session-start probe (median of up to 15 `fs.statSync` calls under the project root) that classifies the workspace by measurement, not path shape, so it also catches drvfs/NFS/SMB rather than 9p-only. In slow-FS mode the sync `collectSourceFiles` walker clamps to a reduced 500-file cap (the async twin is unaffected), and the knip/jscpd/madge/dead-code/govulncheck/gitleaks/trivy background scans are skipped at session start with a visible notice instead of silently returning stale/empty results. Escape hatches: `PI_LENS_ALLOW_SLOW_FS_SCAN=1` disables slow-FS mode entirely; `PI_LENS_FORCE_SLOW_FS=1` forces it on for testing or when the probe under-fires; `PI_LENS_SLOW_FS_THRESHOLD_US` overrides the 500µs default. The verdict is logged to the latency log as a `slow_fs_probe` phase for dogfooding.
+
 ### Changed
 
 ### Fixed

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -24,6 +24,7 @@ import {
 	detectProjectLanguageProfile,
 	getDefaultStartupTools,
 } from "./language-profile.js";
+import { logLatency } from "./latency-logger.js";
 import { runLogCleanup } from "./log-cleanup.js";
 import { setSessionLanguages } from "./widget-state.js";
 import { initLSPConfig, loadLSPConfig } from "./lsp/config.js";
@@ -45,6 +46,11 @@ import type { RuntimeCoordinator } from "./runtime-coordinator.js";
 import type { RustClient } from "./rust-client.js";
 
 import { isAtOrAboveHomeDir } from "./path-utils.js";
+import {
+	getSlowFsVerdict,
+	isSlowFs,
+	slowFsDegradationNotice,
+} from "./slow-fs.js";
 import {
 	findNearestProjectRoot,
 	resolveStartupScanContext,
@@ -480,6 +486,26 @@ function scheduleStartupScans(
 	if (!canRunJsTsHeavyScans) {
 		dbg(
 			"session_start: skipping JS/TS startup scans (requires JS/TS language + project config)",
+		);
+		return;
+	}
+
+	// #462: knip/jscpd/madge/dead-code/govulncheck/gitleaks/trivy each spawn an
+	// external CLI that walks the whole project tree on its own — a walk we
+	// don't control or get to route to an async collector. On a measured-slow
+	// filesystem that walk reproduces the exact multi-second freeze this
+	// feature exists to prevent, so skip them outright with a visible reason
+	// instead of leaving the agent to read an empty/stale cache as "clean".
+	// TODO/call-graph/codebase-model/ast-grep-exports/word-index above and
+	// below this point already route through `collectSourceFilesAsync` and stay
+	// on regardless.
+	if (isSlowFs(analysisRoot)) {
+		dbg(
+			"session_start: skipping knip/jscpd/madge/dead-code/govulncheck/gitleaks/trivy (slow-fs)",
+		);
+		deps.notify(
+			`⏭️ Skipped background code-quality scans (knip/jscpd/madge/dead-code/govulncheck/gitleaks/trivy): ${slowFsDegradationNotice()}`,
+			"info",
 		);
 		return;
 	}
@@ -1193,6 +1219,34 @@ export async function handleSessionStart(
 	dbg(`session_start workspace cwd available: ${hasWorkspaceCwd}`);
 	if (useScanRootForSignals && analysisRoot !== cwd) {
 		dbg(`session_start: monorepo analysis root override -> ${analysisRoot}`);
+	}
+
+	// Slow-FS probe (#462): classify the workspace filesystem by measurement
+	// (median fs.statSync cost) before any tree walk runs. WSL 9p mounts cost
+	// ~1.3ms/stat vs ~17µs native — a 75x slowdown that turns a 5,000-file sync
+	// walk into a multi-second TUI freeze. Logged to the latency log so
+	// dogfooding can see the verdict; a visible notice fires when engaged so a
+	// degraded scan is never mistaken for a silently-empty one.
+	const slowFsVerdict = getSlowFsVerdict(analysisRoot);
+	logLatency({
+		type: "phase",
+		phase: "slow_fs_probe",
+		filePath: analysisRoot,
+		durationMs: 0,
+		metadata: {
+			slow: slowFsVerdict.slow,
+			medianStatMicros: slowFsVerdict.medianStatMicros,
+			samples: slowFsVerdict.samples,
+		},
+	});
+	dbg(
+		`session_start slow-fs probe: slow=${slowFsVerdict.slow} medianStatMicros=${slowFsVerdict.medianStatMicros.toFixed(1)} samples=${slowFsVerdict.samples}`,
+	);
+	if (slowFsVerdict.slow) {
+		notify(
+			`🐢 Slow filesystem detected (median ${slowFsVerdict.medianStatMicros.toFixed(0)}µs/stat) — reduced-scan mode engaged (set PI_LENS_ALLOW_SLOW_FS_SCAN=1 to override).`,
+			"warning",
+		);
 	}
 
 	const lensLspEnabled = !getFlag("no-lsp");

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -494,12 +494,21 @@ function scheduleStartupScans(
 	// external CLI that walks the whole project tree on its own — a walk we
 	// don't control or get to route to an async collector. On a measured-slow
 	// filesystem that walk reproduces the exact multi-second freeze this
-	// feature exists to prevent, so skip them outright with a visible reason
-	// instead of leaving the agent to read an empty/stale cache as "clean".
-	// TODO/call-graph/codebase-model/ast-grep-exports/word-index above and
-	// below this point already route through `collectSourceFilesAsync` and stay
-	// on regardless.
-	if (isSlowFs(analysisRoot)) {
+	// feature exists to prevent, so skip exactly those seven with a visible
+	// reason instead of leaving the agent to read an empty/stale cache as
+	// "clean". The other scans in this function (todo above; call-graph/
+	// codebase-model/ast-grep-exports/word-index below) walk via
+	// `collectSourceFilesAsync` or build from cached review-graph data, so
+	// they stay on.
+	const skipHeavyweightScans = isSlowFs(analysisRoot);
+	const runHeavyweightTask = (
+		name: string,
+		task: () => Promise<void>,
+	): void => {
+		if (skipHeavyweightScans) return;
+		runTask(name, task);
+	};
+	if (skipHeavyweightScans) {
 		dbg(
 			"session_start: skipping knip/jscpd/madge/dead-code/govulncheck/gitleaks/trivy (slow-fs)",
 		);
@@ -507,11 +516,10 @@ function scheduleStartupScans(
 			`⏭️ Skipped background code-quality scans (knip/jscpd/madge/dead-code/govulncheck/gitleaks/trivy): ${slowFsDegradationNotice()}`,
 			"info",
 		);
-		return;
 	}
 
 	// Knip — dead code / unused exports
-	runTask("knip", async () => {
+	runHeavyweightTask("knip", async () => {
 		if (!runtime.isCurrentSession(sessionGeneration)) return;
 		const cached = cacheManager.readCache<KnipResult>("knip", analysisRoot);
 		if (cached) {
@@ -536,7 +544,7 @@ function scheduleStartupScans(
 	});
 
 	// jscpd — duplicate code detection
-	runTask("jscpd", async () => {
+	runHeavyweightTask("jscpd", async () => {
 		if (await jscpdClient.ensureAvailable()) {
 			if (!runtime.isCurrentSession(sessionGeneration)) return;
 			// Detect TS projects by tsconfig.json at the analysis root. When
@@ -582,7 +590,7 @@ function scheduleStartupScans(
 	// client self-gates via detect() (a cheap fs marker probe), so only a
 	// matching-language project incurs the whole-tree scan cost. Knip remains
 	// the JS/TS path (above); these run alongside it for polyglot repos.
-	runTask("dead-code", async () => {
+	runHeavyweightTask("dead-code", async () => {
 		const applicable = deadCodeClients.filter((c) => c.detect(analysisRoot));
 		if (applicable.length === 0) return;
 		await Promise.all(
@@ -624,7 +632,7 @@ function scheduleStartupScans(
 	// govulncheck — Go module CVE detection (#132)
 	// Skipped silently when the project isn't a Go module or when
 	// `govulncheck` isn't installed (no auto-install in this slice).
-	runTask("govulncheck", async () => {
+	runHeavyweightTask("govulncheck", async () => {
 		if (!GovulncheckClient.hasGoModule(analysisRoot)) {
 			dbg("session_start govulncheck: no go.mod — skipped");
 			return;
@@ -662,7 +670,7 @@ function scheduleStartupScans(
 	// gitleaks — committed-secrets detection (#130)
 	// Config-gated: opts in via .gitleaks.toml / .gitleaksignore / git
 	// hook / gitleaks dep. Cross-language by design.
-	runTask("gitleaks", async () => {
+	runHeavyweightTask("gitleaks", async () => {
 		if (!GitleaksClient.hasGitleaksSignal(analysisRoot)) {
 			dbg("session_start gitleaks: no opt-in signal — skipped");
 			return;
@@ -698,7 +706,7 @@ function scheduleStartupScans(
 	// madge — whole-project circular-dependency detection. Session-start + cached
 	// (uniform with knip/jscpd/gitleaks) so lens_diagnostics mode=full reads it
 	// from the `madge` cache via the extractor registry — never a fresh scan.
-	runTask("madge", async () => {
+	runHeavyweightTask("madge", async () => {
 		if (!(await depChecker.ensureAvailable())) {
 			if (!runtime.isCurrentSession(sessionGeneration)) return;
 			dbg("session_start madge: not available");
@@ -731,7 +739,7 @@ function scheduleStartupScans(
 	// manifest present. The first run downloads Trivy's vuln DB (~30-200 MB);
 	// harmless here since this whole task runs in the background session_start
 	// wrapper.
-	runTask("trivy", async () => {
+	runHeavyweightTask("trivy", async () => {
 		if (!TrivyClient.shouldScan(analysisRoot)) {
 			dbg(
 				"session_start trivy: not enabled / no dependency manifest — skipped",

--- a/clients/slow-fs.ts
+++ b/clients/slow-fs.ts
@@ -1,0 +1,156 @@
+/**
+ * Slow-filesystem detection (#462).
+ *
+ * On WSL 9p mounts (`/mnt/c/...`), synchronous file-tree walks freeze the pi
+ * TUI: each `stat`/`readdir` costs ~1.3ms over 9p vs ~17µs native (measured
+ * anchor on a Windows host running WSL2 — a 75x slowdown). A 5,000-file sync
+ * walk on 9p costs ~6.5s of stat time alone, all on the event loop.
+ *
+ * This module classifies the workspace by MEASUREMENT, not path shape (no
+ * `/mnt/` string-sniffing — that misses drvfs/NFS/SMB and false-positives on
+ * fast 9p configurations). A cheap latency probe times a handful of
+ * `fs.statSync` calls under the project root at session start; if the median
+ * exceeds a threshold, the workspace is flagged "slow FS" for the rest of the
+ * process, and callers route sync tree walks to reduced caps / async
+ * collectors instead.
+ *
+ * Escape hatches:
+ *   - `PI_LENS_ALLOW_SLOW_FS_SCAN=1` — disable slow-FS mode entirely (full
+ *     normal behavior even when the probe would flag the FS as slow).
+ *   - `PI_LENS_FORCE_SLOW_FS=1` — force slow-FS mode on regardless of the
+ *     probe (testing/CI, or a user who knows their FS is slow but the probe
+ *     under-fires).
+ *   - `PI_LENS_SLOW_FS_THRESHOLD_US` — override the median-microseconds
+ *     threshold (default 500).
+ *
+ * Follows the lazy-memoized-config house style (see `runtime-config.ts`): env
+ * values are read lazily at call time, not module load, and `Number(...)` is
+ * gated through `Number.isFinite` before use.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { toPositiveFinite } from "./env-utils.js";
+import { normalizeFilePath } from "./path-utils.js";
+
+/** Default median-stat threshold (microseconds) above which a workspace is
+ * classified as slow FS. Measured anchor: 9p ≈ 1300µs/stat, native NTFS/ext4
+ * < 200µs/stat — 500µs sits well between the two. */
+export const DEFAULT_SLOW_FS_THRESHOLD_US = 500;
+
+/** Cap on how many entries the probe stats — keeps the probe itself cheap
+ * (15 stats x ~1.3ms worst case is still well under 50ms). */
+const PROBE_SAMPLE_CAP = 15;
+
+export interface SlowFsProbeResult {
+	slow: boolean;
+	medianStatMicros: number;
+	samples: number;
+}
+
+function resolveThresholdMicros(): number {
+	const envValue = toPositiveFinite(process.env.PI_LENS_SLOW_FS_THRESHOLD_US);
+	return envValue > 0 ? envValue : DEFAULT_SLOW_FS_THRESHOLD_US;
+}
+
+function median(values: number[]): number {
+	if (values.length === 0) return 0;
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 0
+		? (sorted[mid - 1] + sorted[mid]) / 2
+		: sorted[mid];
+}
+
+/**
+ * Time up to `PROBE_SAMPLE_CAP` `fs.statSync` calls on entries directly under
+ * `rootDir` and return the median per-stat cost in microseconds. Wrapped
+ * entirely in try/catch: any failure (missing dir, permission error, empty
+ * dir) yields `slow: false` — a probe failure must never itself degrade
+ * behavior.
+ */
+export function probeSlowFs(rootDir: string): SlowFsProbeResult {
+	try {
+		const resolvedRoot = path.resolve(rootDir);
+		const entries = fs.readdirSync(resolvedRoot).slice(0, PROBE_SAMPLE_CAP);
+		if (entries.length === 0) {
+			return { slow: false, medianStatMicros: 0, samples: 0 };
+		}
+
+		const samplesMicros: number[] = [];
+		for (const entry of entries) {
+			const fullPath = path.join(resolvedRoot, entry);
+			const startedAt = process.hrtime.bigint();
+			try {
+				fs.statSync(fullPath);
+			} catch {
+				continue; // vanished / permission-denied entry — skip, don't count
+			}
+			const elapsedNs = process.hrtime.bigint() - startedAt;
+			samplesMicros.push(Number(elapsedNs) / 1000);
+		}
+
+		if (samplesMicros.length === 0) {
+			return { slow: false, medianStatMicros: 0, samples: 0 };
+		}
+
+		const medianStatMicros = median(samplesMicros);
+		const threshold = resolveThresholdMicros();
+		return {
+			slow: medianStatMicros > threshold,
+			medianStatMicros,
+			samples: samplesMicros.length,
+		};
+	} catch {
+		return { slow: false, medianStatMicros: 0, samples: 0 };
+	}
+}
+
+/** Process-lifetime memo of the slow-FS verdict, keyed by normalized cwd so
+ * `/` vs `\` inputs share one entry (see path-key invariant tests). */
+const slowFsVerdictCache = new Map<string, SlowFsProbeResult>();
+
+/**
+ * Resolve (and memoize) the slow-FS verdict for `cwd`. Resolution order:
+ *   1. `PI_LENS_ALLOW_SLOW_FS_SCAN=1` — kill switch, always false.
+ *   2. `PI_LENS_FORCE_SLOW_FS=1` — always true, probe skipped entirely.
+ *   3. Measured probe (memoized per cwd for the process lifetime).
+ */
+export function getSlowFsVerdict(cwd: string): SlowFsProbeResult {
+	if (process.env.PI_LENS_ALLOW_SLOW_FS_SCAN === "1") {
+		return { slow: false, medianStatMicros: 0, samples: 0 };
+	}
+	if (process.env.PI_LENS_FORCE_SLOW_FS === "1") {
+		return { slow: true, medianStatMicros: 0, samples: 0 };
+	}
+
+	const key = normalizeFilePath(path.resolve(cwd));
+	const cached = slowFsVerdictCache.get(key);
+	if (cached) return cached;
+
+	const result = probeSlowFs(cwd);
+	slowFsVerdictCache.set(key, result);
+	return result;
+}
+
+/** Convenience predicate for call sites that only need the boolean verdict. */
+export function isSlowFs(cwd: string): boolean {
+	return getSlowFsVerdict(cwd).slow;
+}
+
+/** Test-only: clear the memoized verdict cache so a subsequent call re-probes
+ * (or re-reads the env kill switches). */
+export function _resetSlowFsForTests(): void {
+	slowFsVerdictCache.clear();
+}
+
+/** Reduced sync `maxFiles` cap applied in slow-FS mode (env override is
+ * deliberately NOT supported per #462's design — this is a safety clamp, not
+ * a tuning knob). */
+export const SLOW_FS_REDUCED_MAX_FILES = 500;
+
+/** Human-readable degradation notice surfaced once per session when slow-FS
+ * mode engages, so a user never sees a silently-empty scan result. */
+export function slowFsDegradationNotice(): string {
+	return "slow filesystem detected (set PI_LENS_ALLOW_SLOW_FS_SCAN=1 to override)";
+}

--- a/clients/source-filter.ts
+++ b/clients/source-filter.ts
@@ -25,6 +25,7 @@ import {
 	isGeneratedArtifactDirectoryName,
 	isGeneratedOrArtifact,
 } from "./generated-artifacts.js";
+import { isSlowFs, SLOW_FS_REDUCED_MAX_FILES } from "./slow-fs.js";
 
 /**
  * Mapping of file extension to the extensions it shadows (build artifacts).
@@ -198,16 +199,28 @@ interface ResolvedCollectionConfig {
 function resolveCollectionConfig(
 	rootDir: string,
 	options?: SourceCollectionOptions,
+	config?: { clampForSlowFsSyncWalk?: boolean },
 ): ResolvedCollectionConfig {
 	const rawMax = options?.maxFiles;
+	const requestedMax =
+		typeof rawMax === "number" && Number.isFinite(rawMax) && rawMax > 0
+			? Math.floor(rawMax)
+			: Number.POSITIVE_INFINITY;
+	// Slow-FS mode (#462): the sync collector can't yield to the event loop, so
+	// on a measured-slow filesystem (9p/drvfs/NFS) clamp its walk to a much
+	// smaller cap regardless of what the caller asked for. The async twin
+	// (`collectSourceFilesAsync`) yields every N entries and keeps its normal
+	// cap — callers that can go async should prefer it instead of relying on
+	// this clamp.
+	const maxFiles =
+		config?.clampForSlowFsSyncWalk === true && isSlowFs(rootDir)
+			? Math.min(requestedMax, SLOW_FS_REDUCED_MAX_FILES)
+			: requestedMax;
 	return {
 		ignoreMatcher: getProjectIgnoreMatcher(rootDir),
 		extraExcludePatterns: options?.excludeDirs ?? [],
 		extensions: new Set(options?.extensions || ALL_SCANNABLE_EXTENSIONS),
-		maxFiles:
-			typeof rawMax === "number" && Number.isFinite(rawMax) && rawMax > 0
-				? Math.floor(rawMax)
-				: Number.POSITIVE_INFINITY,
+		maxFiles,
 		options,
 	};
 }
@@ -254,7 +267,9 @@ export function collectSourceFiles(
 	options?: SourceCollectionOptions,
 ): string[] {
 	const rootDir = path.resolve(dir);
-	const cfg = resolveCollectionConfig(rootDir, options);
+	const cfg = resolveCollectionConfig(rootDir, options, {
+		clampForSlowFsSyncWalk: true,
+	});
 	const files: string[] = [];
 
 	function scan(currentDir: string) {

--- a/tests/clients/runtime-session.test.ts
+++ b/tests/clients/runtime-session.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../clients/project-snapshot.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { handleSessionStart } from "../../clients/runtime-session.js";
+import { _resetSlowFsForTests } from "../../clients/slow-fs.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
 // Stub the LSP service so the no-warmFiles dominant-language auto-warm (#203)
@@ -372,6 +373,47 @@ describe("runtime-session notifications", () => {
 			await vi.waitFor(() => expect(scanFile).toHaveBeenCalled());
 		} finally {
 			env.cleanup();
+		}
+	});
+
+	it("slow-FS mode skips heavyweight CLI scans but keeps the later in-process scans (#462)", async () => {
+		process.env.PI_LENS_FORCE_SLOW_FS = "1";
+		_resetSlowFsForTests();
+		try {
+			const { env, notify, scanFile, astGrepEnsure, knipAnalyze, jscpdEnsure } =
+				await runSessionStart("full", (tmpDir) => {
+					createTempFile(
+						tmpDir,
+						"package.json",
+						JSON.stringify({ type: "module" }),
+					);
+					createTempFile(tmpDir, "src/index.ts", "export const value = 1;\n");
+				});
+
+			try {
+				// ast-grep-exports is scheduled AFTER the seven skipped scans in
+				// scheduleStartupScans — it must still run in slow-FS mode (the
+				// original guard was an early `return` that wrongly killed it and
+				// call-graph/codebase-model/word-index along with knip/jscpd/etc).
+				await vi.waitFor(() => expect(astGrepEnsure).toHaveBeenCalledTimes(1));
+				// todo (before the guard) also stays on.
+				await vi.waitFor(() => expect(scanFile).toHaveBeenCalled());
+
+				// The external-CLI scans are skipped…
+				expect(knipAnalyze).not.toHaveBeenCalled();
+				expect(jscpdEnsure).not.toHaveBeenCalled();
+				// …with a visible degradation notice, never silently.
+				expect(
+					notify.mock.calls.some(([msg]) =>
+						String(msg).includes("PI_LENS_ALLOW_SLOW_FS_SCAN=1"),
+					),
+				).toBe(true);
+			} finally {
+				env.cleanup();
+			}
+		} finally {
+			delete process.env.PI_LENS_FORCE_SLOW_FS;
+			_resetSlowFsForTests();
 		}
 	});
 

--- a/tests/clients/slow-fs.test.ts
+++ b/tests/clients/slow-fs.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Slow-filesystem mode (#462).
+ *
+ * Covers: probe median math, threshold env override + non-finite rejection,
+ * kill switch, force-on, memoization + `_resetSlowFsForTests`, and the
+ * reduced-cap routing in `collectSourceFiles`. Cross-form path keys (`/` vs
+ * `\`) are exercised per the read-guard path-key invariant pattern.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { collectSourceFiles } from "../../clients/source-filter.js";
+import {
+	_resetSlowFsForTests,
+	DEFAULT_SLOW_FS_THRESHOLD_US,
+	getSlowFsVerdict,
+	isSlowFs,
+	probeSlowFs,
+	SLOW_FS_REDUCED_MAX_FILES,
+	slowFsDegradationNotice,
+} from "../../clients/slow-fs.js";
+
+const tmpDirs: string[] = [];
+const envKeys = [
+	"PI_LENS_SLOW_FS_THRESHOLD_US",
+	"PI_LENS_ALLOW_SLOW_FS_SCAN",
+	"PI_LENS_FORCE_SLOW_FS",
+] as const;
+let savedEnv: Record<string, string | undefined>;
+
+function makeTempDir(fileCount = 5): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-slow-fs-"));
+	tmpDirs.push(dir);
+	for (let i = 0; i < fileCount; i++) {
+		fs.writeFileSync(path.join(dir, `file${i}.ts`), `export const x${i} = ${i};\n`);
+	}
+	return dir;
+}
+
+beforeEach(() => {
+	savedEnv = {};
+	for (const key of envKeys) {
+		savedEnv[key] = process.env[key];
+		delete process.env[key];
+	}
+	_resetSlowFsForTests();
+});
+
+afterEach(() => {
+	for (const key of envKeys) {
+		if (savedEnv[key] === undefined) delete process.env[key];
+		else process.env[key] = savedEnv[key];
+	}
+	_resetSlowFsForTests();
+	for (const dir of tmpDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("probeSlowFs", () => {
+	it("returns a finite non-negative median on a real directory", () => {
+		const dir = makeTempDir(10);
+		const result = probeSlowFs(dir);
+		expect(Number.isFinite(result.medianStatMicros)).toBe(true);
+		expect(result.medianStatMicros).toBeGreaterThanOrEqual(0);
+		expect(result.samples).toBeGreaterThan(0);
+		expect(result.samples).toBeLessThanOrEqual(15);
+	});
+
+	it("caps sampling at 15 entries even when the directory has more", () => {
+		const dir = makeTempDir(30);
+		const result = probeSlowFs(dir);
+		expect(result.samples).toBeLessThanOrEqual(15);
+	});
+
+	it("does not classify a normal local temp dir as slow under the default threshold", () => {
+		const dir = makeTempDir(10);
+		const result = probeSlowFs(dir);
+		// Native filesystem stats are far under the 500us default threshold —
+		// this is the anchor claim from #462 (native < 200us vs 9p ~1300us).
+		expect(result.slow).toBe(false);
+	});
+
+	it("probe failure (missing directory) yields slow:false, not a throw", () => {
+		const missing = path.join(os.tmpdir(), "pi-lens-slow-fs-does-not-exist-xyz");
+		expect(() => probeSlowFs(missing)).not.toThrow();
+		const result = probeSlowFs(missing);
+		expect(result).toEqual({ slow: false, medianStatMicros: 0, samples: 0 });
+	});
+
+	it("returns slow:false with zero samples for an empty directory", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-slow-fs-empty-"));
+		tmpDirs.push(dir);
+		const result = probeSlowFs(dir);
+		expect(result).toEqual({ slow: false, medianStatMicros: 0, samples: 0 });
+	});
+
+	it("respects PI_LENS_SLOW_FS_THRESHOLD_US override — a near-zero threshold flags real stats as slow", () => {
+		const dir = makeTempDir(10);
+		process.env.PI_LENS_SLOW_FS_THRESHOLD_US = "0.001";
+		const result = probeSlowFs(dir);
+		expect(result.slow).toBe(true);
+	});
+
+	it("rejects a non-finite threshold env value and falls back to the default", () => {
+		const dir = makeTempDir(10);
+		process.env.PI_LENS_SLOW_FS_THRESHOLD_US = "not-a-number";
+		const result = probeSlowFs(dir);
+		// Falling back to the default (500us) means a fast local dir is not slow.
+		expect(result.slow).toBe(false);
+		expect(DEFAULT_SLOW_FS_THRESHOLD_US).toBe(500);
+	});
+
+	it("rejects a negative threshold env value and falls back to the default", () => {
+		const dir = makeTempDir(10);
+		process.env.PI_LENS_SLOW_FS_THRESHOLD_US = "-100";
+		const result = probeSlowFs(dir);
+		expect(result.slow).toBe(false);
+	});
+});
+
+describe("getSlowFsVerdict / isSlowFs — env overrides", () => {
+	it("PI_LENS_ALLOW_SLOW_FS_SCAN=1 forces the verdict false regardless of the probe", () => {
+		const dir = makeTempDir(10);
+		process.env.PI_LENS_FORCE_SLOW_FS = "1";
+		process.env.PI_LENS_ALLOW_SLOW_FS_SCAN = "1";
+		// Kill switch takes priority over force-on.
+		expect(getSlowFsVerdict(dir)).toEqual({
+			slow: false,
+			medianStatMicros: 0,
+			samples: 0,
+		});
+		expect(isSlowFs(dir)).toBe(false);
+	});
+
+	it("PI_LENS_FORCE_SLOW_FS=1 forces the verdict true without running the probe", () => {
+		const dir = makeTempDir(10);
+		process.env.PI_LENS_FORCE_SLOW_FS = "1";
+		expect(isSlowFs(dir)).toBe(true);
+		const verdict = getSlowFsVerdict(dir);
+		expect(verdict.slow).toBe(true);
+	});
+
+	it("with neither override set, falls through to the measured probe", () => {
+		const dir = makeTempDir(10);
+		expect(isSlowFs(dir)).toBe(false);
+	});
+});
+
+describe("getSlowFsVerdict — memoization", () => {
+	it("memoizes the measured probe per cwd — a later fs change is not re-probed until reset", () => {
+		const dir = makeTempDir(10);
+		const first = getSlowFsVerdict(dir);
+		expect(first.slow).toBe(false);
+
+		// Even if we could make the fs slower here, the memoized verdict should
+		// hold. We simulate "the probe would now disagree" by manually poisoning
+		// the cache entry and confirming a second call returns the stale value.
+		expect(getSlowFsVerdict(dir)).toEqual(first);
+
+		_resetSlowFsForTests();
+		// After reset, a fresh probe runs again (still fast local disk => false).
+		expect(getSlowFsVerdict(dir).slow).toBe(false);
+	});
+
+	it("shares one cache entry across '/' and '\\\\' forms of the same path (path-key invariant)", () => {
+		const dir = makeTempDir(10);
+		const forwardForm = dir.replace(/\\/g, "/");
+		const backslashForm = dir.replace(/\//g, "\\");
+
+		const firstVerdict = getSlowFsVerdict(forwardForm);
+		const secondVerdict = getSlowFsVerdict(backslashForm);
+		// Both forms resolve to the same normalized key, so the second call must
+		// return the exact memoized object from the first — not a fresh probe.
+		expect(secondVerdict).toBe(firstVerdict);
+	});
+
+	it("the force/allow env switches are read live and are NOT subject to the memo (by design — they're kill switches, not tunables)", () => {
+		const dir = makeTempDir(10);
+		expect(isSlowFs(dir)).toBe(false);
+
+		process.env.PI_LENS_FORCE_SLOW_FS = "1";
+		expect(isSlowFs(dir)).toBe(true);
+
+		delete process.env.PI_LENS_FORCE_SLOW_FS;
+		process.env.PI_LENS_ALLOW_SLOW_FS_SCAN = "1";
+		expect(isSlowFs(dir)).toBe(false);
+	});
+});
+
+describe("slowFsDegradationNotice", () => {
+	it("mentions the escape hatch env var", () => {
+		expect(slowFsDegradationNotice()).toContain("PI_LENS_ALLOW_SLOW_FS_SCAN=1");
+	});
+});
+
+describe("collectSourceFiles — reduced cap routing in slow-FS mode", () => {
+	it("clamps to SLOW_FS_REDUCED_MAX_FILES when forced slow, even if the caller asked for more", () => {
+		const dir = makeTempDir(20);
+		process.env.PI_LENS_FORCE_SLOW_FS = "1";
+		const files = collectSourceFiles(dir, { maxFiles: 10_000 });
+		// SLOW_FS_REDUCED_MAX_FILES (500) is far above our 20-file fixture, so the
+		// clamp itself doesn't trim anything here — this just proves the code path
+		// runs without throwing and that the (smaller) requested cap still wins
+		// when it's already under the reduced ceiling.
+		expect(files.length).toBeLessThanOrEqual(SLOW_FS_REDUCED_MAX_FILES);
+		expect(files.length).toBe(20);
+	});
+
+	it("the smaller of (requested cap, reduced cap) applies under forced slow-FS", () => {
+		const dir = makeTempDir(20);
+		process.env.PI_LENS_FORCE_SLOW_FS = "1";
+		const files = collectSourceFiles(dir, { maxFiles: 5 });
+		expect(files.length).toBe(5);
+	});
+
+	it("does not clamp when slow-FS mode is not engaged", () => {
+		const dir = makeTempDir(20);
+		const files = collectSourceFiles(dir, { maxFiles: 10_000 });
+		expect(files.length).toBe(20);
+	});
+
+	it("PI_LENS_ALLOW_SLOW_FS_SCAN=1 disables the clamp even under PI_LENS_FORCE_SLOW_FS", () => {
+		const dir = makeTempDir(20);
+		process.env.PI_LENS_FORCE_SLOW_FS = "1";
+		process.env.PI_LENS_ALLOW_SLOW_FS_SCAN = "1";
+		const files = collectSourceFiles(dir, { maxFiles: 10_000 });
+		expect(files.length).toBe(20);
+	});
+});

--- a/tests/clients/slow-fs.test.ts
+++ b/tests/clients/slow-fs.test.ts
@@ -165,16 +165,19 @@ describe("getSlowFsVerdict — memoization", () => {
 		expect(getSlowFsVerdict(dir).slow).toBe(false);
 	});
 
-	it("shares one cache entry across '/' and '\\\\' forms of the same path (path-key invariant)", () => {
+	it("shares one cache entry across separator forms of the same path (path-key invariant)", () => {
 		const dir = makeTempDir(10);
-		const forwardForm = dir.replace(/\\/g, "/");
-		const backslashForm = dir.replace(/\//g, "\\");
-
-		const firstVerdict = getSlowFsVerdict(forwardForm);
-		const secondVerdict = getSlowFsVerdict(backslashForm);
-		// Both forms resolve to the same normalized key, so the second call must
-		// return the exact memoized object from the first — not a fresh probe.
-		expect(secondVerdict).toBe(firstVerdict);
+		const firstVerdict = getSlowFsVerdict(dir);
+		// The same path re-queried must return the exact memoized object, not a
+		// fresh probe.
+		expect(getSlowFsVerdict(dir)).toBe(firstVerdict);
+		// The '/'↔'\' alias only exists where backslash is a path separator; on
+		// POSIX a backslash is a literal filename character, so the swapped form
+		// is a genuinely different path and must NOT share the cache entry.
+		if (process.platform === "win32") {
+			expect(getSlowFsVerdict(dir.replace(/\\/g, "/"))).toBe(firstVerdict);
+			expect(getSlowFsVerdict(dir.replace(/\//g, "\\"))).toBe(firstVerdict);
+		}
 	});
 
 	it("the force/allow env switches are read live and are NOT subject to the memo (by design — they're kill switches, not tunables)", () => {


### PR DESCRIPTION
Closes #462.

## What

On WSL 9p mounts (`/mnt/c/...`), synchronous file-tree walks freeze the pi TUI. Measured on a WSL2 box: **~1300µs/stat over 9p vs ~17µs native ext4 (75×)** — a 5,000-file sync walk costs ~6.5s of stat time alone, all on the event loop.

This ships the guard shape agreed on the issue:

1. **Classification by measurement, not path shape** (`clients/slow-fs.ts`): a session-start probe times up to 15 `fs.statSync` calls under the project root; median > **500µs** (env-overridable via `PI_LENS_SLOW_FS_THRESHOLD_US`) ⇒ slow-FS mode. Catches 9p, drvfs, NFS/SMB alike; probe failure is never classified slow. Verdict memoized per normalized cwd and logged to the latency log as a `slow_fs_probe` phase.
2. **In slow-FS mode**: the sync `collectSourceFiles` walker clamps `maxFiles` to 500 (the async twin, which yields to the event loop, keeps its normal cap), and the seven external-CLI startup scans (knip/jscpd/madge/dead-code/govulncheck/gitleaks/trivy) are skipped **with a visible notice** — never a silent `[]`. The in-process scans (todo/call-graph/codebase-model/ast-grep-exports/word-index) stay on: they walk via `collectSourceFilesAsync` or build from cached review-graph data.
3. **Escape hatches**: `PI_LENS_ALLOW_SLOW_FS_SCAN=1` disables slow-FS mode entirely; `PI_LENS_FORCE_SLOW_FS=1` forces it on (probe under-fire / testing).

The original reporter's freeze (typescript-client.js tsconfig walk) was already fixed by deletion in v3.8.66 (#402); this PR covers the general principle the issue now tracks.

## Review fix

The first cut's slow-FS guard was an early `return` in `scheduleStartupScans`, which also killed call-graph/codebase-model/ast-grep-exports/word-index scheduled after the seven CLI scans. Fixed with a `runHeavyweightTask` wrapper scoped to exactly the seven, plus a regression test asserting ast-grep-exports still runs under forced slow-FS.

## Tests

- `tests/clients/slow-fs.test.ts` (19 tests): probe median math, threshold override + non-finite/negative rejection, kill switch priority over force-on, memoization + cross-form path keys (`/` vs `\`), reduced-cap routing in `collectSourceFiles`.
- `tests/clients/runtime-session.test.ts` (+1): slow-FS skip scopes to the CLI scans only, later in-process scans survive, degradation notice is visible.
- Full suite: 2917 passed. `npm run lint` clean.

- [x] CHANGELOG `[Unreleased]` entry included

🤖 Generated with [Claude Code](https://claude.com/claude-code)