### PR TITLE
fix(nightly): servercapabilities merge guard survives schema changes + merges bullet sections (closes #469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **`servercapabilities.md` merge guard survives schema changes and merges bullet sections (#469)** — the #390 nightly merge guard for `scripts/server-capabilities.mjs` required the prior and freshly-generated table headers to be byte-identical before merging, so adding the `ws-pull` column silently disabled the guard and last night's ubuntu-only run dropped the rust and php rows (and their capability-key / executeCommand bullets) entirely. Fixed by reshaping prior rows onto the new header **by column name** (`reshapeRowsByName` in `scripts/lib/md-matrix.mjs` — columns the prior doc lacked are filled with the `·` placeholder, columns dropped from the new schema are simply not carried) and by merging the two bulleted sections ("Raw advertised capability keys", "Advertised executeCommand allowlists") for preserved servers, which the original guard never touched at all (`parseBulletSection`/`mergeBulletSection`). The whole merge is now a pure, unit-tested function (`mergeServerCapabilitiesDoc`) that never spawns an LSP server and fails open (writes the fresh doc, logs to stderr) if either doc's table is unparseable.
+
 ## [3.8.67] - 2026-07-09
 
 ### Added

--- a/scripts/lib/md-matrix.d.mts
+++ b/scripts/lib/md-matrix.d.mts
@@ -28,3 +28,25 @@ export function replaceTable(
   sep: string,
   rows: string[][],
 ): string | null;
+
+export function reshapeRowsByName(
+  priorRows: string[][],
+  priorHeader: string[],
+  newHeader: string[],
+  keyCol: string,
+  placeholder?: string,
+): string[][];
+
+export function parseBulletSection(text: string, heading: string): Map<string, string>;
+
+export function mergeBulletSection(
+  newText: string,
+  heading: string,
+  priorBullets: Map<string, string>,
+  keysToCarry: string[],
+): string;
+
+export function mergeServerCapabilitiesDoc(
+  priorText: string,
+  freshText: string,
+): { text: string; preservedCount: number };

--- a/scripts/lib/md-matrix.mjs
+++ b/scripts/lib/md-matrix.mjs
@@ -134,3 +134,191 @@ export function replaceTable(text, headerMarker, header, sep, rows) {
 	lines.splice(tbl.start, tbl.end - tbl.start, ...rendered);
 	return lines.join("\n");
 }
+
+/**
+ * Merge prior rows into a NEW header shape by column NAME, tolerating a schema
+ * change between the prior doc and this run (#469). Unlike `mergeRows` (which
+ * requires identical headers), this reshapes each prior row that this run did
+ * NOT capture onto `newHeader`: columns present in both are carried by name,
+ * columns the prior row lacked (a column added this run) are filled with
+ * `placeholder`, and columns dropped from the new schema are simply not
+ * carried. Rows this run DID capture are the caller's fresh rows and always
+ * win — pass only the prior rows NOT in `capturedKeys` as `priorRows`.
+ *
+ * @param {string[][]} priorRows     prior rows to reshape (already narrowed to
+ *   the ones this run did not capture), in `priorHeader` column order
+ * @param {string[]} priorHeader     the prior doc's header
+ * @param {string[]} newHeader       this run's header (may differ in columns)
+ * @param {string} keyCol            header name of the unique row key (e.g. "server")
+ * @param {string} [placeholder]     fill value for columns the prior row lacked
+ * @returns {string[][]}             priorRows reshaped onto newHeader
+ */
+export function reshapeRowsByName(
+	priorRows,
+	priorHeader,
+	newHeader,
+	keyCol,
+	placeholder = "·",
+) {
+	const priorIdx = (name) => priorHeader.indexOf(name);
+	return priorRows.map((cells) =>
+		newHeader.map((h) => {
+			const pi = priorIdx(h);
+			if (pi >= 0 && cells[pi] !== undefined) return cells[pi];
+			if (h === keyCol) return cells[priorIdx(keyCol)] ?? "";
+			return placeholder;
+		}),
+	);
+}
+
+/**
+ * Parse a `## heading` bulleted-list section (lines of the form
+ * `- **<key>**: <rest>`) into an ordered Map of key → full bullet line
+ * (without the leading `- `). Stops at the next `## ` heading or EOF. Returns
+ * an empty Map if the section isn't found — callers treat that as "nothing to
+ * carry over", never a crash.
+ *
+ * @param {string} text
+ * @param {string} heading   e.g. "## Raw advertised capability keys"
+ * @returns {Map<string, string>}
+ */
+export function parseBulletSection(text, heading) {
+	const lines = text.split("\n");
+	const map = new Map();
+	let i = lines.findIndex((l) => l.trim() === heading.trim());
+	if (i < 0) return map;
+	i++;
+	// The bold key is followed by either `:` (Raw advertised capability keys)
+	// or ` (N):` (Advertised executeCommand allowlists, N = allowlist size) —
+	// tolerate both so a single parser/merger works for both sections.
+	const bulletRe = /^- \*\*(.+?)\*\*(?:\s*\([^)]*\))?:\s*(.*)$/;
+	for (; i < lines.length; i++) {
+		const line = lines[i];
+		if (/^##\s/.test(line)) break;
+		const m = bulletRe.exec(line);
+		if (m) map.set(m[1], line.replace(/^- /, ""));
+	}
+	return map;
+}
+
+/**
+ * Merge preserved-server bullets into a freshly-generated `## heading` section
+ * of `newText`, carrying over the prior doc's bullet line for each key in
+ * `keysToCarry` that has one (silently skipped if the prior doc had none for
+ * that key). The merged section is re-sorted by key so preserved and freshly-
+ * generated bullets interleave alphabetically, matching the generator's
+ * existing sort. If `heading` isn't found in `newText`, returns `newText`
+ * unchanged (fail-open — never crash the nightly over a missing section).
+ *
+ * @param {string} newText
+ * @param {string} heading
+ * @param {Map<string, string>} priorBullets   from `parseBulletSection` on the prior doc
+ * @param {string[]} keysToCarry               keys (servers) to pull from `priorBullets`
+ * @returns {string}
+ */
+export function mergeBulletSection(newText, heading, priorBullets, keysToCarry) {
+	const lines = newText.split("\n");
+	const headingIdx = lines.findIndex((l) => l.trim() === heading.trim());
+	if (headingIdx < 0) return newText;
+	// The section body starts after the heading, skipping a single blank line
+	// (the generator always emits one), and runs up to the next `## ` heading
+	// or EOF.
+	const bodyStart = lines[headingIdx + 1] === "" ? headingIdx + 2 : headingIdx + 1;
+	let bodyEnd = lines.length;
+	for (let i = bodyStart; i < lines.length; i++) {
+		if (/^##\s/.test(lines[i])) {
+			bodyEnd = i;
+			break;
+		}
+	}
+	// The bold key is followed by either `:` (Raw advertised capability keys)
+	// or ` (N):` (Advertised executeCommand allowlists, N = allowlist size) —
+	// tolerate both so a single parser/merger works for both sections.
+	const bulletRe = /^- \*\*(.+?)\*\*(?:\s*\([^)]*\))?:\s*(.*)$/;
+	const byKey = new Map();
+	// Trailing non-bullet lines within the body (e.g. a blank line at EOF when
+	// this is the last section) — preserved after the sorted bullets rather than
+	// dropped.
+	const trailing = [];
+	for (let i = bodyStart; i < bodyEnd; i++) {
+		const m = bulletRe.exec(lines[i]);
+		if (m) byKey.set(m[1], lines[i]);
+		else trailing.push(lines[i]);
+	}
+	let added = false;
+	for (const k of keysToCarry) {
+		if (byKey.has(k)) continue; // captured this run — always wins
+		const prior = priorBullets.get(k);
+		if (prior === undefined) continue; // prior doc had no bullet — skip silently
+		byKey.set(k, `- ${prior}`);
+		added = true;
+	}
+	if (!added) return newText;
+	const sortedLines = [...byKey.keys()]
+		.sort((a, b) => a.localeCompare(b))
+		.map((k) => byKey.get(k));
+	const before = lines.slice(0, bodyStart);
+	const after = lines.slice(bodyEnd);
+	return [...before, ...sortedLines, ...trailing, ...after].join("\n");
+}
+
+// Deliberately a SHORT, schema-stable marker (not "| server | mode | ws-pull |")
+// — the whole point of #469 is that a prior doc predating the ws-pull column
+// must still be found and parsed, so the marker can't assume a column that
+// might not exist yet.
+const SERVER_CAPS_TABLE_MARKER = "| server | mode |";
+const SERVER_CAPS_RAW_KEYS_HEADING = "## Raw advertised capability keys";
+const SERVER_CAPS_EXEC_CMDS_HEADING = "## Advertised executeCommand allowlists";
+
+/**
+ * Merge a prior `docs/servercapabilities.md` into a freshly-generated one
+ * (#390/#469): servers the fresh run didn't capture keep their prior table
+ * row (reshaped by column NAME onto the fresh header via `reshapeRowsByName`,
+ * so a schema change like the ws-pull column addition no longer disables the
+ * guard — #469) and their bullet lines in both "Raw advertised capability
+ * keys" and "Advertised executeCommand allowlists" (via `mergeBulletSection`,
+ * which the original #390 guard didn't touch at all). Servers captured this
+ * run always win — their fresh row/bullets are never overwritten by a stale
+ * prior value.
+ *
+ * Pure (text in, text in, text out) so it's testable without spawning any LSP
+ * server. Fail-open: if either doc's table is unparseable, returns the fresh
+ * text unchanged (caller logs the skip; the nightly must never crash on this).
+ *
+ * @param {string} priorText   previous docs/servercapabilities.md content
+ * @param {string} freshText   this run's freshly-generated content
+ * @returns {{ text: string, preservedCount: number }}
+ */
+export function mergeServerCapabilitiesDoc(priorText, freshText) {
+	const priorTbl = parseTable(priorText, SERVER_CAPS_TABLE_MARKER);
+	const newTbl = parseTable(freshText, SERVER_CAPS_TABLE_MARKER);
+	if (!priorTbl || !newTbl) {
+		return { text: freshText, preservedCount: 0 };
+	}
+	const keyIdx = newTbl.header.indexOf("server");
+	const priorKeyIdx = priorTbl.header.indexOf("server");
+	if (keyIdx < 0 || priorKeyIdx < 0) {
+		return { text: freshText, preservedCount: 0 };
+	}
+	const capturedKeys = new Set(newTbl.rows.map((c) => c[keyIdx]));
+	const notCapturedPriorRows = priorTbl.rows.filter((c) => !capturedKeys.has(c[priorKeyIdx]));
+	const reshaped = reshapeRowsByName(
+		notCapturedPriorRows,
+		priorTbl.header,
+		newTbl.header,
+		"server",
+	);
+	const mergedRows = [...newTbl.rows, ...reshaped].sort((a, b) =>
+		a[keyIdx].localeCompare(b[keyIdx]),
+	);
+	let text = replaceTable(freshText, SERVER_CAPS_TABLE_MARKER, newTbl.header, newTbl.sep, mergedRows);
+	if (!text) {
+		return { text: freshText, preservedCount: 0 };
+	}
+	const preservedServers = notCapturedPriorRows.map((c) => c[priorKeyIdx]);
+	for (const heading of [SERVER_CAPS_RAW_KEYS_HEADING, SERVER_CAPS_EXEC_CMDS_HEADING]) {
+		const priorBullets = parseBulletSection(priorText, heading);
+		text = mergeBulletSection(text, heading, priorBullets, preservedServers);
+	}
+	return { text, preservedCount: preservedServers.length };
+}

--- a/scripts/server-capabilities.mjs
+++ b/scripts/server-capabilities.mjs
@@ -21,7 +21,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { mergeRows, parseTable, replaceTable } from "./lib/md-matrix.mjs";
+import { mergeServerCapabilitiesDoc } from "./lib/md-matrix.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const argv = process.argv.slice(2);
@@ -197,45 +197,26 @@ if (unavailable.size) {
 lines.push("");
 
 const docPath = path.join(repoRoot, "docs", "servercapabilities.md");
-let output = lines.join("\n");
+const fresh = lines.join("\n");
 
-// #390 partial-doc merge guard: this host (esp. the ubuntu nightly) lacks many
-// toolchains, so servers it couldn't spawn are absent from `rows` and would DROP
-// from the capability table on a naive overwrite. Merge the freshly-measured
-// rows over the PRIOR doc's table so a server we didn't capture this run keeps
-// its last-known row (never regress the server-row count). Only the servers we
-// measured are updated; the rest are preserved verbatim.
+// #390/#469 partial-doc merge guard: this host (esp. the ubuntu nightly) lacks
+// many toolchains, so servers it couldn't spawn are absent from `rows` and
+// would DROP from the doc on a naive overwrite. mergeServerCapabilitiesDoc
+// (pure, tested in tests/scripts/server-capabilities-merge.test.ts) merges the
+// prior doc's rows/bullets for servers this run didn't capture into the fresh
+// doc — schema-tolerant (a column added this run, like ws-pull, no longer
+// silently disables the whole guard — #469) and also carries over the two
+// bullet sections, which the original guard didn't touch at all.
+let output = fresh;
 try {
 	if (fs.existsSync(docPath)) {
 		const prior = fs.readFileSync(docPath, "utf8");
-		const marker = "| server | mode | ws-pull |";
-		const priorTbl = parseTable(prior, marker);
-		const newTbl = parseTable(output, marker);
-		if (priorTbl && newTbl && priorTbl.header.join("|") === newTbl.header.join("|")) {
-			const keyIdx = newTbl.header.indexOf("server");
-			// Treat every freshly-rendered row as an object keyed by header name.
-			const measured = newTbl.rows.map((cells) => {
-				const o = {};
-				newTbl.header.forEach((h, i) => (o[h] = cells[i]));
-				return o;
-			});
-			const merged = mergeRows(
-				priorTbl.rows,
-				priorTbl.header,
-				measured,
-				"server",
-				newTbl.header, // this run is authoritative for every column of a row it measured
+		const { text: merged, preservedCount } = mergeServerCapabilitiesDoc(prior, fresh);
+		output = merged;
+		if (preservedCount > 0) {
+			console.error(
+				`merge guard: preserved ${preservedCount} prior server row(s)/bullet(s) not captured this run.`,
 			);
-			const mergedText = replaceTable(output, marker, newTbl.header, newTbl.sep, merged);
-			if (mergedText) {
-				output = mergedText;
-				const preserved = priorTbl.rows.filter(
-					(c) => !newTbl.rows.some((n) => n[keyIdx] === c[keyIdx]),
-				).length;
-				console.error(
-					`merge guard: preserved ${preserved} prior server row(s) not captured this run.`,
-				);
-			}
 		}
 	}
 } catch (e) {

--- a/tests/scripts/server-capabilities-merge.test.ts
+++ b/tests/scripts/server-capabilities-merge.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for the #469 servercapabilities merge guard fix in
+ * scripts/lib/md-matrix.mjs:
+ *   - reshapeRowsByName  — reshapes prior rows onto a NEW header by column
+ *     NAME (tolerates a schema change, e.g. the ws-pull column addition,
+ *     which previously killed the #390 guard's header-identity precondition).
+ *   - parseBulletSection / mergeBulletSection — carry a preserved server's
+ *     bullet line(s) from the prior doc's "## Raw advertised capability keys"
+ *     / "## Advertised executeCommand allowlists" sections into the fresh
+ *     doc, which the original guard never did at all.
+ *   - mergeServerCapabilitiesDoc — the pure, whole-doc merge function used by
+ *     scripts/server-capabilities.mjs (doc text in, doc text out; no LSP
+ *     server spawn needed to test it).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  mergeBulletSection,
+  mergeServerCapabilitiesDoc,
+  parseBulletSection,
+  parseTable,
+  reshapeRowsByName,
+} from "../../scripts/lib/md-matrix.mjs";
+
+describe("reshapeRowsByName", () => {
+  it("carries prior columns by name and fills a newly-added column with the placeholder", () => {
+    const priorHeader = ["server", "mode", "def", "cmds"];
+    const priorRows = [["rust", "pull", "✓", "0"]];
+    const newHeader = ["server", "mode", "ws-pull", "def", "cmds"];
+    const reshaped = reshapeRowsByName(priorRows, priorHeader, newHeader, "server");
+    expect(reshaped).toEqual([["rust", "pull", "·", "✓", "0"]]);
+  });
+
+  it("drops columns present in the prior schema but absent from the new one", () => {
+    const priorHeader = ["server", "mode", "legacyCol", "def"];
+    const priorRows = [["php", "push-only", "old-value", "✓"]];
+    const newHeader = ["server", "mode", "def"];
+    const reshaped = reshapeRowsByName(priorRows, priorHeader, newHeader, "server");
+    expect(reshaped).toEqual([["php", "push-only", "✓"]]);
+  });
+
+  it("honors a custom placeholder", () => {
+    const priorHeader = ["server", "mode"];
+    const priorRows = [["go", "push-only"]];
+    const newHeader = ["server", "mode", "wSym"];
+    const reshaped = reshapeRowsByName(priorRows, priorHeader, newHeader, "server", "?");
+    expect(reshaped).toEqual([["go", "push-only", "?"]]);
+  });
+});
+
+describe("parseBulletSection / mergeBulletSection", () => {
+  const PRIOR = `# doc
+
+## Raw advertised capability keys
+
+- **php**: completionProvider, definitionProvider
+- **rust**: callHierarchyProvider, definitionProvider
+
+## Advertised executeCommand allowlists
+
+- **rust**: (3): rust-analyzer.runSingle, rust-analyzer.debugSingle, rust-analyzer.showReferences
+
+## Unavailable on the generating host
+
+- clangd
+`;
+
+  it("parses bullets keyed by the bold server name", () => {
+    const map = parseBulletSection(PRIOR, "## Raw advertised capability keys");
+    expect(map.get("php")).toBe(
+      "**php**: completionProvider, definitionProvider",
+    );
+    expect(map.get("rust")).toBe(
+      "**rust**: callHierarchyProvider, definitionProvider",
+    );
+  });
+
+  it("returns an empty map when the heading isn't found", () => {
+    const map = parseBulletSection(PRIOR, "## Nonexistent section");
+    expect(map.size).toBe(0);
+  });
+
+  it("carries over a preserved server's bullet into a fresh section, sorted by key", () => {
+    const fresh = `# doc
+
+## Raw advertised capability keys
+
+- **go**: definitionProvider, hoverProvider
+
+## Unavailable on the generating host
+
+- clangd
+`;
+    const priorBullets = parseBulletSection(PRIOR, "## Raw advertised capability keys");
+    const merged = mergeBulletSection(
+      fresh,
+      "## Raw advertised capability keys",
+      priorBullets,
+      ["php", "rust"],
+    );
+    const lines = merged.split("\n");
+    const bulletLines = lines.filter((l) => l.startsWith("- **"));
+    expect(bulletLines).toEqual([
+      "- **go**: definitionProvider, hoverProvider",
+      "- **php**: completionProvider, definitionProvider",
+      "- **rust**: callHierarchyProvider, definitionProvider",
+    ]);
+    // surrounding structure preserved
+    expect(merged).toContain("## Unavailable on the generating host");
+    expect(merged).toContain("- clangd");
+  });
+
+  it("skips a key silently when the prior doc had no bullet for it", () => {
+    const fresh = `# doc
+
+## Raw advertised capability keys
+
+- **go**: definitionProvider
+`;
+    const priorBullets = parseBulletSection(PRIOR, "## Raw advertised capability keys");
+    const merged = mergeBulletSection(
+      fresh,
+      "## Raw advertised capability keys",
+      priorBullets,
+      ["go", "nonexistent-server"],
+    );
+    expect(merged).toBe(fresh); // "go" already present, "nonexistent-server" has no prior bullet
+  });
+
+  it("returns the text unchanged when the heading is missing (fail-open)", () => {
+    const fresh = "# doc\n\nno sections here\n";
+    const merged = mergeBulletSection(fresh, "## Raw advertised capability keys", new Map(), [
+      "php",
+    ]);
+    expect(merged).toBe(fresh);
+  });
+});
+
+function tableBlock(header: string[], rows: string[][]) {
+  const sep = `|${header.map(() => "---").join("|")}|`;
+  const render = (cells: string[]) => `| ${cells.join(" | ")} |`;
+  return [render(header), sep, ...rows.map(render)].join("\n");
+}
+
+describe("mergeServerCapabilitiesDoc (#469)", () => {
+  const OLD_HEADER = ["server", "mode", "def", "cmds"];
+  const NEW_HEADER = ["server", "mode", "ws-pull", "def", "cmds"];
+
+  function makeDoc(header: string[], rows: string[][], bullets: Record<string, string>) {
+    const lines = [
+      "# LSP server capability inventory",
+      "",
+      "_Last generated: 2026-01-01 on win32; N servers captured, M unavailable._",
+      "",
+      "## Diagnostic mode + navigation/edit operations",
+      "",
+      "Legend line.",
+      "",
+      tableBlock(header, rows),
+      "",
+      "## Raw advertised capability keys",
+      "",
+      "Top-level keys.",
+      "",
+      ...Object.entries(bullets)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([server, keys]) => `- **${server}**: ${keys}`),
+    ];
+    return lines.join("\n") + "\n";
+  }
+
+  it("(a) header-change merge: prior doc without ws-pull + new table with it → prior-only row preserved with placeholder fill", () => {
+    const prior = makeDoc(
+      OLD_HEADER,
+      [
+        ["php", "push-only", "✓", "0"],
+        ["rust", "pull", "✓", "0"],
+      ],
+      { php: "definitionProvider", rust: "definitionProvider, hoverProvider" },
+    );
+    // This run only captured "rust" (php's toolchain absent on this host).
+    const fresh = makeDoc(NEW_HEADER, [["rust", "pull", "✓", "✓", "0"]], {
+      rust: "definitionProvider, hoverProvider",
+    });
+
+    const { text, preservedCount } = mergeServerCapabilitiesDoc(prior, fresh);
+    expect(preservedCount).toBe(1);
+
+    const tbl = parseTable(text, "| server | mode | ws-pull |")!;
+    expect(tbl.header).toEqual(NEW_HEADER);
+    const phpRow = tbl.rows.find((r) => r[0] === "php");
+    expect(phpRow).toEqual(["php", "push-only", "·", "✓", "0"]); // ws-pull filled with placeholder
+    const rustRow = tbl.rows.find((r) => r[0] === "rust");
+    expect(rustRow).toEqual(["rust", "pull", "✓", "✓", "0"]); // captured this run, unchanged
+
+    // bullet carried over too
+    expect(text).toContain("- **php**: definitionProvider");
+  });
+
+  it("(b) same-header merge still works (no schema change)", () => {
+    const prior = makeDoc(
+      OLD_HEADER,
+      [
+        ["go", "push-only", "✓", "46"],
+        ["json", "pull", "·", "0"],
+      ],
+      { go: "definitionProvider", json: "hoverProvider" },
+    );
+    const fresh = makeDoc(OLD_HEADER, [["json", "pull", "·", "0"]], {
+      json: "hoverProvider",
+    });
+
+    const { text, preservedCount } = mergeServerCapabilitiesDoc(prior, fresh);
+    expect(preservedCount).toBe(1);
+    const tbl = parseTable(text, "| server | mode | def |")!;
+    expect(tbl.rows.find((r) => r[0] === "go")).toEqual(["go", "push-only", "✓", "46"]);
+    expect(text).toContain("- **go**: definitionProvider");
+  });
+
+  it("(c) bullet carry-over for a preserved server in both bullet sections", () => {
+    const priorLines = [
+      "# doc",
+      "",
+      tableBlock(OLD_HEADER, [
+        ["rust", "pull", "✓", "3"],
+        ["php", "push-only", "✓", "0"],
+      ]),
+      "",
+      "## Raw advertised capability keys",
+      "",
+      "- **php**: definitionProvider, hoverProvider",
+      "- **rust**: definitionProvider, callHierarchyProvider",
+      "",
+      "## Advertised executeCommand allowlists",
+      "",
+      "- **rust** (3): rust-analyzer.runSingle, rust-analyzer.debugSingle, rust-analyzer.showReferences",
+      "",
+      "## Unavailable on the generating host",
+      "",
+      "- clangd",
+      "",
+    ];
+    const prior = priorLines.join("\n");
+    const freshLines = [
+      "# doc",
+      "",
+      tableBlock(NEW_HEADER, [["ast-grep", "push-only", "·", "·", "1"]]),
+      "",
+      "## Raw advertised capability keys",
+      "",
+      "- **ast-grep**: codeActionProvider",
+      "",
+      "## Advertised executeCommand allowlists",
+      "",
+      "- **ast-grep** (1): ast-grep.applyAllFixes",
+      "",
+      "## Unavailable on the generating host",
+      "",
+      "- rust-analyzer",
+      "- intelephense",
+      "",
+    ];
+    const fresh = freshLines.join("\n");
+
+    const { text, preservedCount } = mergeServerCapabilitiesDoc(prior, fresh);
+    expect(preservedCount).toBe(2); // php + rust rows preserved
+
+    expect(text).toContain("- **php**: definitionProvider, hoverProvider");
+    expect(text).toContain("- **rust**: definitionProvider, callHierarchyProvider");
+    expect(text).toContain(
+      "- **rust** (3): rust-analyzer.runSingle, rust-analyzer.debugSingle, rust-analyzer.showReferences",
+    );
+    // the host-truth "Unavailable" section is untouched (regenerated as-is)
+    expect(text).toContain("- rust-analyzer");
+    expect(text).toContain("- intelephense");
+    expect(text).not.toContain("- clangd");
+  });
+
+  it("(d) captured-this-run servers always win over prior rows", () => {
+    const prior = makeDoc(OLD_HEADER, [["go", "push-only", "·", "0"]], {
+      go: "(none reported)",
+    });
+    // This run DID capture go, with different (fresher) values.
+    const fresh = makeDoc(OLD_HEADER, [["go", "push-only", "✓", "46"]], {
+      go: "definitionProvider, hoverProvider",
+    });
+
+    const { text } = mergeServerCapabilitiesDoc(prior, fresh);
+    const tbl = parseTable(text, "| server | mode | def |")!;
+    expect(tbl.rows.find((r) => r[0] === "go")).toEqual(["go", "push-only", "✓", "46"]);
+    expect(text).toContain("- **go**: definitionProvider, hoverProvider");
+    expect(text).not.toContain("- **go**: (none reported)");
+  });
+
+  it("(e) unparseable prior doc → fresh doc written, no throw", () => {
+    const prior = "not a markdown table at all, just prose.\n";
+    const fresh = makeDoc(NEW_HEADER, [["go", "push-only", "·", "✓", "46"]], {
+      go: "definitionProvider",
+    });
+    let result: ReturnType<typeof mergeServerCapabilitiesDoc> | undefined;
+    expect(() => {
+      result = mergeServerCapabilitiesDoc(prior, fresh);
+    }).not.toThrow();
+    expect(result!.text).toBe(fresh);
+    expect(result!.preservedCount).toBe(0);
+  });
+
+  it("also fails open when the FRESH text's table is unparseable (defensive)", () => {
+    const prior = makeDoc(OLD_HEADER, [["go", "push-only", "✓", "46"]], {
+      go: "definitionProvider",
+    });
+    const fresh = "no table here either\n";
+    const result = mergeServerCapabilitiesDoc(prior, fresh);
+    expect(result.text).toBe(fresh);
+    expect(result.preservedCount).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #469.

## What broke

The 2026-07-09 nightly (first run with the #460 `ws-pull` column) regenerated `docs/servercapabilities.md` on ubuntu and dropped the dev-box-captured rust-analyzer and intelephense rows — table rows AND their bullet entries. Two defects in the #390 merge guard:

1. The guard only merged when prior and fresh table headers were byte-identical, so the ws-pull column addition silently disabled it entirely.
2. The "Raw advertised capability keys" and "Advertised executeCommand allowlists" bullet sections were never merged at all.

No damage reached master — the regressed doc sits only on `bot/lsp-docs-refresh` (its PR-creation step also failed that night; the Actions PR permission has since been enabled).

## Fix

New pure function `mergeServerCapabilitiesDoc(priorText, freshText)` in `scripts/lib/md-matrix.mjs` (testable without spawning any LSP server), replacing the header-identity-gated call site:

- **Schema-tolerant row merge**: prior rows not captured this run are reshaped onto the fresh header by column NAME (`reshapeRowsByName`), filling columns the prior doc lacked with `·`; captured rows always win.
- **Bullet carry-over**: both bullet sections now preserve prior entries for uncaptured servers (`parseBulletSection`/`mergeBulletSection`, tolerating both the `**name**:` and `**name** (N):` bullet forms).
- **Schema-stable table marker**: the parse marker shrank from `| server | mode | ws-pull |` to `| server | mode |` — the old marker itself assumed the new column existed, a second-order instance of the same bug class.
- Fail-open throughout: unparseable prior or fresh doc ⇒ fresh doc written unchanged, nightly never crashes.

The "Unavailable on the generating host" section stays per-host truth and is deliberately not merged.

## Validation

- 14 new tests in `tests/scripts/server-capabilities-merge.test.ts` (header-change merge, same-header merge, bullet carry-over both sections, captured-wins, unparseable prior/fresh, marker regression).
- End-to-end against the real docs: `mergeServerCapabilitiesDoc(master doc, bot-branch regressed doc)` restores the rust + php rows (`·`-filled ws-pull) and both raw-keys bullets, keeps the fresh csharp row, `preservedCount: 2`.
- Full suite 2911 passed; lint clean.

The doc itself regenerates on the next nightly run — no hand-repair in this PR.

- [x] CHANGELOG `[Unreleased]` entry included

🤖 Generated with [Claude Code](https://claude.com/claude-code)