### PR TITLE
fix(subagent-mode): detect avtc-pi-subagent via marker pair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,23 +287,31 @@ Holds: `filePath`, language-root `cwd`, `kind` (`FileKind` — `jsts`, `python`,
 
 ## Subagent-extension compatibility (#476)
 
-pi-lens degrades gracefully — by construction — when it runs alongside the
-two popular subagent extensions (nicobailon/pi-subagents,
-`@tintinweb/pi-subagents`): subagent light mode (#475) skips heavyweight
+pi-lens degrades gracefully — by construction — when it runs alongside
+subagent-spawning extensions: subagent light mode (#475) skips heavyweight
 scans in a spawned child, the instance registry + orphan reaper (#474)
 cleans up LSP processes left behind by a dead parent, and the
 concurrent-session guard (#473, `clients/session-lifecycle.ts`) stops an
-in-process subagent bind from tearing down the parent's live LSP fleet. All
-three were built on reverse-engineered facts about those extensions and the
-pi SDK — nobody has promised us these stay true across releases. `docs/
-subagent-compat.md` records the exact pinned contracts (file + version last
-verified) and is checked nightly by `.github/workflows/compat-smoke.yml`
+in-process subagent bind from tearing down the parent's live LSP fleet.
+`isSubagentSession()` (`clients/subagent-mode.ts`) detects TWO env
+vocabularies: nicobailon/pi-subagents' `PI_SUBAGENT_CHILD=1`, and
+avtc-pi-subagent's `PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` pair
+(both non-empty — requiring the pair, not either var alone, guards against a
+false positive from an unrelated tool; #507). `getSubagentIdentity()` reports
+which vocabulary matched (`marker: "pi-subagents" | "avtc-pi-subagent"`),
+surfaced in the `subagent_light_mode` latency phase. All of this was built on
+reverse-engineered facts about those extensions and the pi SDK — nobody has
+promised us these stay true across releases. `docs/subagent-compat.md`
+records the exact pinned contracts (file + version last verified) and is
+checked nightly by `.github/workflows/compat-smoke.yml`
 (`scripts/compat-contracts.mjs` — pattern-match the installed third-party
 source; `scripts/compat-smoke-behavioral.mjs` — drive a real `pi --mode rpc`
-and assert through the latency log, no LLM turn needed). A nightly failure
+and assert through the latency log, no LLM turn needed; avtc-pi-subagent
+Layer A/B coverage is a deferred follow-up, not yet wired). A nightly failure
 opens/refreshes a single tracking issue — never reds the workflow itself.
 Three env levers govern the behavior: `PI_LENS_SUBAGENT_FULL=1` (force full,
-non-light behavior in a detected subagent child), `PI_LENS_CONCURRENT_SESSION_GUARD=0`
+non-light behavior in a detected subagent child, either vocabulary),
+`PI_LENS_CONCURRENT_SESSION_GUARD=0`
 (disable the #473 guard — every session_start classifies sequential), and
 `PI_LENS_INSTANCE_REGISTRY=0` (disable the #474 registry/reaper).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Subagent light mode now also detects avtc-pi-subagent children** (#507) — `isSubagentSession()` (`clients/subagent-mode.ts`) only recognized `PI_SUBAGENT_CHILD=1`, the marker nicobailon/pi-subagents sets; avtc-pi-subagent (the spawn engine under avtc-pi-feature-flow) is the same real child-process execution model but never sets that var — it sets `PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` instead (grep-verified against avtc-pi-subagent@1.0.3). Consequence: light mode silently never engaged for its children, which run the full heavyweight session-start scan suite, multiplied by feature-flow's parallel-reviewer fan-out (up to ~9 subagents per review round). Detection now also treats the PAIR `PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` (both non-empty) as a subagent signal — requiring the pair rather than either var alone is a deliberate false-positive guard, since a lone var set by some unrelated tool must not trigger light mode. `PI_LENS_SUBAGENT_FULL=1` remains the universal opt-out for both vocabularies. `getSubagentIdentity()` now also reports which vocabulary matched (`marker: "pi-subagents" | "avtc-pi-subagent"`), surfaced in the `subagent_light_mode` latency phase so dogfooding can tell the ecosystems apart. The issue's Layer A pinned-contract + Layer B behavioral compat-smoke additions for avtc-pi-subagent are a deferred M-effort follow-up, not part of this fix.
+
 ### Added
 
 - **Expert LSP for Elixir** (#498) — Expert is now an auto-installed alternate to ElixirLS for `.ex` and `.exs` files. ElixirLS remains the default; add `"elixir"` to `disabledServers` in `.pi-lens/lsp.json` to select Expert. pi-lens launches Expert with its required `--stdio` flag and downloads the official bare GitHub release binary for macOS, Linux, or Windows (Windows arm64 uses the x64 build through emulation).

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -1288,10 +1288,11 @@ export async function handleSessionStart(
 			metadata: {
 				runId: identity?.runId,
 				agentName: identity?.agentName,
+				marker: identity?.marker,
 			},
 		});
 		dbg(
-			`session_start subagent light mode: engaged (runId=${identity?.runId ?? "unknown"} agentName=${identity?.agentName ?? "unknown"})`,
+			`session_start subagent light mode: engaged (marker=${identity?.marker ?? "unknown"} runId=${identity?.runId ?? "unknown"} agentName=${identity?.agentName ?? "unknown"})`,
 		);
 	}
 

--- a/clients/subagent-mode.ts
+++ b/clients/subagent-mode.ts
@@ -1,12 +1,25 @@
 /**
- * Subagent light mode (#449 slice 0).
+ * Subagent light mode (#449 slice 0; broadened #507).
  *
- * The nicobailon/pi-subagents extension spawns each subagent as a child `pi`
- * CLI process and sets `PI_SUBAGENT_CHILD=1` unconditionally in every child's
- * environment (plus `PI_SUBAGENT_RUN_ID` / `PI_SUBAGENT_CHILD_AGENT`). Every
- * child currently loads pi-lens fully by default, so a 4-way fan-out pays 4
- * full LSP pre-warms + 4 sets of heavyweight startup scans in the same cwd —
- * mostly wasted on short-lived task agents.
+ * Two known subagent-spawning ecosystems set different env vocabularies in
+ * every spawned child's environment:
+ *
+ * - nicobailon/pi-subagents sets `PI_SUBAGENT_CHILD=1` unconditionally (plus
+ *   `PI_SUBAGENT_RUN_ID` / `PI_SUBAGENT_CHILD_AGENT` for best-effort identity).
+ * - avtc-pi-subagent (the spawn engine under avtc-pi-feature-flow) is the same
+ *   execution model — real child-process `pi --mode rpc` / `--mode json -p`
+ *   spawns, full env inheritance — but never sets `PI_SUBAGENT_CHILD`. It sets
+ *   `PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` instead (#507,
+ *   grep-verified against avtc-pi-subagent@1.0.3).
+ *
+ * Every child currently loads pi-lens fully by default, so a fan-out of N
+ * subagents pays N full LSP pre-warms + N sets of heavyweight startup scans
+ * in the same cwd — mostly wasted on short-lived task agents.
+ *
+ * Detection requires the avtc PAIR (`PI_SUBAGENT_CHILD_AGENT` AND
+ * `PI_SUBAGENT_PARENT_PID`, both non-empty) rather than either var alone —
+ * deliberate false-positive protection, since a lone var set by some
+ * unrelated tool must not trigger light mode.
  *
  * This module only classifies the session; it does not change any behavior
  * itself. Callers (`runtime-session.ts`) gate the LSP pre-warm and the seven
@@ -14,35 +27,70 @@
  * LSP dispatch is untouched — light mode must not disable diagnostics.
  *
  * Escape hatch: `PI_LENS_SUBAGENT_FULL=1` forces full (non-light) behavior
- * even inside a detected subagent session.
+ * even inside a detected subagent session, for either vocabulary.
  *
  * Follows the lazy-memoized-config house style (see `runtime-config.ts` /
  * `slow-fs.ts`): env values are read lazily at call time, not module load.
  */
 
-/** True iff pi-lens is running inside a nicobailon/pi-subagents child `pi`
- * process, and the caller has not forced full behavior via the escape hatch. */
+/** Which vocabulary matched when classifying the session as a subagent. */
+export type SubagentMarker = "pi-subagents" | "avtc-pi-subagent";
+
+interface SubagentClassification {
+	isSubagent: boolean;
+	marker?: SubagentMarker;
+}
+
+/** Lazily computed once per process (until `_resetSubagentModeForTests`),
+ * matching the memoized-getter house style. */
+let cachedClassification: SubagentClassification | undefined;
+
+function classifySubagentSession(): SubagentClassification {
+	if (cachedClassification !== undefined) return cachedClassification;
+
+	if (process.env.PI_SUBAGENT_CHILD === "1") {
+		cachedClassification = { isSubagent: true, marker: "pi-subagents" };
+		return cachedClassification;
+	}
+
+	const childAgent = process.env.PI_SUBAGENT_CHILD_AGENT || undefined;
+	const parentPid = process.env.PI_SUBAGENT_PARENT_PID || undefined;
+	if (childAgent !== undefined && parentPid !== undefined) {
+		cachedClassification = { isSubagent: true, marker: "avtc-pi-subagent" };
+		return cachedClassification;
+	}
+
+	cachedClassification = { isSubagent: false };
+	return cachedClassification;
+}
+
+/** True iff pi-lens is running inside a detected subagent child `pi` process
+ * (nicobailon/pi-subagents' `PI_SUBAGENT_CHILD=1`, or avtc-pi-subagent's
+ * `PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` pair), and the caller
+ * has not forced full behavior via the escape hatch. */
 export function isSubagentSession(): boolean {
 	if (process.env.PI_LENS_SUBAGENT_FULL === "1") return false;
-	return process.env.PI_SUBAGENT_CHILD === "1";
+	return classifySubagentSession().isSubagent;
 }
 
 export interface SubagentIdentity {
 	runId?: string;
 	agentName?: string;
+	marker?: SubagentMarker;
 }
 
 /**
  * Best-effort identity of the current subagent, read from the env vars the
- * nicobailon/pi-subagents extension sets alongside `PI_SUBAGENT_CHILD=1`.
- * Returns `undefined` when neither identity var is present (e.g. not a
- * subagent session, or a future extension that doesn't set them).
+ * detected extension sets alongside its subagent marker. Returns `undefined`
+ * when neither identity var is present (e.g. not a subagent session, or a
+ * future extension that doesn't set them).
  */
 export function getSubagentIdentity(): SubagentIdentity | undefined {
 	const runId = process.env.PI_SUBAGENT_RUN_ID || undefined;
 	const agentName = process.env.PI_SUBAGENT_CHILD_AGENT || undefined;
 	if (runId === undefined && agentName === undefined) return undefined;
-	return { runId, agentName };
+	const { marker } = classifySubagentSession();
+	return { runId, agentName, marker };
 }
 
 /** Human-readable degradation notice surfaced once per session when subagent
@@ -51,10 +99,9 @@ export function subagentLightModeNotice(): string {
 	return "subagent session — skipped background code-quality scans (set PI_LENS_SUBAGENT_FULL=1 to override)";
 }
 
-/** Test-only: nothing is memoized in this module today (env is read fresh on
- * every call), but this hook exists so callers/tests can reset state uniformly
- * if a memoization layer is added later — matching the `_resetForTests`
- * convention used by `runtime-config.ts` / `slow-fs.ts`. */
+/** Test-only: clears the memoized classification so tests can flip env vars
+ * between cases (matching the `_resetForTests` convention used by
+ * `runtime-config.ts` / `slow-fs.ts`). */
 export function _resetSubagentModeForTests(): void {
-	// no-op: no memoized state yet.
+	cachedClassification = undefined;
 }

--- a/docs/subagent-compat.md
+++ b/docs/subagent-compat.md
@@ -18,6 +18,7 @@ every run.
 | # | Contract | Depended on by | Third-party file (as of the versions below) | Verified against |
 |---|----------|-----------------|-------------------------------------------------|-------------------|
 | 1 | `PI_SUBAGENT_CHILD` is set to the literal string `"1"` in every spawned child's env; `PI_SUBAGENT_RUN_ID` / `PI_SUBAGENT_CHILD_AGENT` are set alongside it for best-effort identity. | `clients/subagent-mode.ts` (`isSubagentSession()`, `getSubagentIdentity()`) | `pi-subagents@0.34.0` — `src/runs/shared/pi-args.ts` (`SUBAGENT_CHILD_ENV`/`SUBAGENT_RUN_ID_ENV`/`SUBAGENT_CHILD_AGENT_ENV` consts + the `env[SUBAGENT_CHILD_ENV] = "1"` assignment) | `checkNicobailonChildEnv` |
+| 1b | avtc-pi-subagent sets `PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` (never `PI_SUBAGENT_CHILD`); `isSubagentSession()` treats the PAIR (both non-empty) as an additional subagent signal (#507). Not yet Layer-A pinned — see the avtc-pi-feature-flow row below. | `clients/subagent-mode.ts` (`isSubagentSession()`, `getSubagentIdentity()`) | `avtc-pi-subagent@1.0.3` (package not yet installed by `compat-contracts.mjs`) | not yet smoke-covered (deferred follow-up) |
 | 2a | The pi SDK's extension loader keeps a **process-global** cache (`extensionCache = new Map()`). This is what makes an in-process `bindExtensions()` reuse pi-lens's own module-scope singletons instead of a fresh isolated instance. | `clients/session-lifecycle.ts` (the whole premise of the concurrent-session guard) | `@earendil-works/pi-coding-agent@0.80.6` — `dist/core/extensions/loader.js` | `checkSdkExtensionCache` |
 | 2b | `AgentSession.bindExtensions()` **unconditionally** emits a `session_start`-typed event (`this._extensionRunner.emit(this._sessionStartEvent)`). | Same as 2a — this is why an in-process subagent bind re-triggers pi-lens's `session_start` handler at all. | `@earendil-works/pi-coding-agent@0.80.6` — `dist/core/agent-session.js` (`bindExtensions()`, ~line 1717) | `checkSdkBindExtensionsEmitsSessionStart` |
 | 2c | `_extensionRunner.invalidate(...)` is called from the sequential session-replacement path (`newSession`/`fork`/`switchSession`/`reload`'s dispose route), never from a concurrent sibling bind. | `clients/session-lifecycle.ts` (`probeCtxActive()` — the asymmetry this whole guard relies on) | `@earendil-works/pi-coding-agent@0.80.6` — `dist/core/agent-session.js` (~line 551) | `checkSdkInvalidateCalled` |
@@ -34,7 +35,7 @@ directory, reads the specific files above, and runs every check.
 
 | Env var | Default | Effect |
 |---------|---------|--------|
-| `PI_LENS_SUBAGENT_FULL` | unset (light mode auto-detects) | Set to `1` to force full (non-light) behavior even inside a detected nicobailon/pi-subagents child session — disables the light-mode heavyweight-scan skip. |
+| `PI_LENS_SUBAGENT_FULL` | unset (light mode auto-detects) | Set to `1` to force full (non-light) behavior even inside a detected subagent child session — nicobailon/pi-subagents (`PI_SUBAGENT_CHILD=1`) or avtc-pi-subagent (`PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` pair, #507) — disables the light-mode heavyweight-scan skip for either vocabulary. |
 | `PI_LENS_CONCURRENT_SESSION_GUARD` | unset (guard enabled) | Set to `0` to disable the #473 concurrent-session guard entirely — every `session_start` classifies as sequential replacement (pre-#473 behavior: a concurrent in-process bind would run the full reset, tearing down the parent's live LSP fleet). |
 | `PI_LENS_INSTANCE_REGISTRY` | unset (registry enabled) | Set to `0` to disable the #474 cross-process instance registry — no orphan-LSP reaping happens at `session_start`, but also no new risk (registry writes are best-effort and already fail open). |
 
@@ -222,10 +223,21 @@ child agents via its bundled `avtc-pi-subagent` engine: **real child-process
 spawns of `pi --mode rpc` / `--mode json -p` — the nicobailon shape — but
 with its OWN env vocabulary**: sets `PI_SUBAGENT_CHILD_AGENT` +
 `PI_SUBAGENT_PARENT_PID`, **never `PI_SUBAGENT_CHILD=1`** (grep-verified).
-Consequence: `subagent-mode.ts` light-mode detection silently never engages
-for its children, which DO run full pi-lens session_start — a real waste gap
-multiplied by feature-flow's parallel-reviewer fan-out. Tracked as #507
-(broaden detection vs document-and-scope); once decided, this package gets a
-Layer A env-vocabulary contract + a Layer B both-directions regression case.
-Its per-feature worktree isolation is the same bystander situation as
-pi-dynamic-workflows' isolated worktrees — no separate row needed for that.
+`subagent-mode.ts` `isSubagentSession()` now detects this vocabulary too
+(#507, fixed 2026-07-10): the pair `PI_SUBAGENT_CHILD_AGENT` +
+`PI_SUBAGENT_PARENT_PID` (both non-empty) is treated as an additional
+subagent signal, alongside nicobailon's `PI_SUBAGENT_CHILD=1`. The pair is
+required rather than either var alone — a lone var set by some unrelated
+tool must not trigger light mode by itself. `PI_LENS_SUBAGENT_FULL=1` remains
+the universal opt-out for both vocabularies. `getSubagentIdentity()` now also
+reports which vocabulary matched (`marker: "pi-subagents" | "avtc-pi-subagent"`),
+surfaced in the `subagent_light_mode` latency phase so dogfooding can tell the
+ecosystems apart. Its per-feature worktree isolation is the same bystander
+situation as pi-dynamic-workflows' isolated worktrees — no separate row
+needed for that.
+
+Still open (deferred, tracked as the remainder of #507): a Layer A pinned
+env-vocabulary contract for avtc-pi-subagent in
+`scripts/lib/compat-contracts.mjs`, and a Layer B behavioral regression case
+asserting light mode engages for an avtc-only-marker child. Both are an
+M-effort follow-up, not part of the detection fix itself.

--- a/tests/clients/subagent-mode.test.ts
+++ b/tests/clients/subagent-mode.test.ts
@@ -1,9 +1,11 @@
 /**
- * Subagent light mode (#449 slice 0).
+ * Subagent light mode (#449 slice 0; broadened #507).
  *
- * Covers: env detection of `PI_SUBAGENT_CHILD=1`, the `PI_LENS_SUBAGENT_FULL=1`
- * override hatch, identity parsing from `PI_SUBAGENT_RUN_ID` /
- * `PI_SUBAGENT_CHILD_AGENT`, and `_resetSubagentModeForTests`.
+ * Covers: env detection of `PI_SUBAGENT_CHILD=1` (nicobailon/pi-subagents)
+ * and the `PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` pair
+ * (avtc-pi-subagent, #507), the `PI_LENS_SUBAGENT_FULL=1` override hatch for
+ * both vocabularies, identity parsing (including the `marker` field), and
+ * `_resetSubagentModeForTests`.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -19,6 +21,7 @@ const envKeys = [
 	"PI_LENS_SUBAGENT_FULL",
 	"PI_SUBAGENT_RUN_ID",
 	"PI_SUBAGENT_CHILD_AGENT",
+	"PI_SUBAGENT_PARENT_PID",
 ] as const;
 let savedEnv: Record<string, string | undefined>;
 
@@ -72,6 +75,29 @@ describe("isSubagentSession", () => {
 		process.env.PI_LENS_SUBAGENT_FULL = "0";
 		expect(isSubagentSession()).toBe(true);
 	});
+
+	it("is true when both PI_SUBAGENT_CHILD_AGENT and PI_SUBAGENT_PARENT_PID are set (avtc-pi-subagent pair)", () => {
+		process.env.PI_SUBAGENT_CHILD_AGENT = "reviewer-1";
+		process.env.PI_SUBAGENT_PARENT_PID = "12345";
+		expect(isSubagentSession()).toBe(true);
+	});
+
+	it("is false when only PI_SUBAGENT_CHILD_AGENT is set (no parent pid) — false-positive guard", () => {
+		process.env.PI_SUBAGENT_CHILD_AGENT = "reviewer-1";
+		expect(isSubagentSession()).toBe(false);
+	});
+
+	it("is false when only PI_SUBAGENT_PARENT_PID is set (no child agent) — false-positive guard", () => {
+		process.env.PI_SUBAGENT_PARENT_PID = "12345";
+		expect(isSubagentSession()).toBe(false);
+	});
+
+	it("PI_LENS_SUBAGENT_FULL=1 overrides the avtc pair back to full behavior", () => {
+		process.env.PI_SUBAGENT_CHILD_AGENT = "reviewer-1";
+		process.env.PI_SUBAGENT_PARENT_PID = "12345";
+		process.env.PI_LENS_SUBAGENT_FULL = "1";
+		expect(isSubagentSession()).toBe(false);
+	});
 });
 
 describe("getSubagentIdentity", () => {
@@ -79,12 +105,13 @@ describe("getSubagentIdentity", () => {
 		expect(getSubagentIdentity()).toBeUndefined();
 	});
 
-	it("parses runId and agentName when both are set", () => {
+	it("parses runId and agentName when both are set (nicobailon, no avtc pair)", () => {
 		process.env.PI_SUBAGENT_RUN_ID = "run-123";
 		process.env.PI_SUBAGENT_CHILD_AGENT = "code-reviewer";
 		expect(getSubagentIdentity()).toEqual({
 			runId: "run-123",
 			agentName: "code-reviewer",
+			marker: undefined,
 		});
 	});
 
@@ -93,6 +120,7 @@ describe("getSubagentIdentity", () => {
 		expect(getSubagentIdentity()).toEqual({
 			runId: "run-456",
 			agentName: undefined,
+			marker: undefined,
 		});
 	});
 
@@ -101,6 +129,7 @@ describe("getSubagentIdentity", () => {
 		expect(getSubagentIdentity()).toEqual({
 			runId: undefined,
 			agentName: "explore",
+			marker: undefined,
 		});
 	});
 
@@ -108,6 +137,28 @@ describe("getSubagentIdentity", () => {
 		process.env.PI_SUBAGENT_RUN_ID = "";
 		process.env.PI_SUBAGENT_CHILD_AGENT = "";
 		expect(getSubagentIdentity()).toBeUndefined();
+	});
+
+	it("carries marker 'pi-subagents' and agentName when PI_SUBAGENT_CHILD=1", () => {
+		process.env.PI_SUBAGENT_CHILD = "1";
+		process.env.PI_SUBAGENT_CHILD_AGENT = "code-reviewer";
+		expect(isSubagentSession()).toBe(true);
+		expect(getSubagentIdentity()).toEqual({
+			runId: undefined,
+			agentName: "code-reviewer",
+			marker: "pi-subagents",
+		});
+	});
+
+	it("carries marker 'avtc-pi-subagent' and agentName when the avtc pair is set", () => {
+		process.env.PI_SUBAGENT_CHILD_AGENT = "reviewer-1";
+		process.env.PI_SUBAGENT_PARENT_PID = "12345";
+		expect(isSubagentSession()).toBe(true);
+		expect(getSubagentIdentity()).toEqual({
+			runId: undefined,
+			agentName: "reviewer-1",
+			marker: "avtc-pi-subagent",
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary
- `isSubagentSession()` only detected nicobailon/pi-subagents' `PI_SUBAGENT_CHILD=1`, so avtc-pi-subagent children (real child-process `pi --mode rpc`/`--mode json -p` spawns under avtc-pi-feature-flow) never engaged light mode — they set `PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` instead, never `PI_SUBAGENT_CHILD` (grep-verified against avtc-pi-subagent@1.0.3). Consequence: full heavyweight session-start scans on every subagent, multiplied by feature-flow's parallel-reviewer fan-out.
- Per the issue's decision (Option 1, broaden detection): `isSubagentSession()` now also treats the PAIR `PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` (both non-empty) as a subagent signal. Requiring the pair rather than either var alone is a deliberate false-positive guard — a lone var set by some unrelated tool must not trigger light mode. `PI_LENS_SUBAGENT_FULL=1` remains the universal opt-out for both vocabularies.
- `getSubagentIdentity()` now reports which vocabulary matched (`marker: "pi-subagents" | "avtc-pi-subagent"`), surfaced in the `subagent_light_mode` latency phase metadata so dogfooding can tell the ecosystems apart.
- Updated `docs/subagent-compat.md` (avtc row, pinned-contracts table, three-env-levers section) and `AGENTS.md`'s subagent-compat summary.

## Deferred (per issue, separate M-effort follow-up)
- Layer A pinned env-vocabulary contract for avtc-pi-subagent in `scripts/lib/compat-contracts.mjs`.
- Layer B behavioral compat-smoke case (child spawned with only avtc markers ⇒ assert light mode engages).
- `subagent-compat.md` row already updated to describe the fix, but the nightly Layer A/B smoke coverage itself is not wired in this PR.

The detection fix itself is complete in this PR.

## Test plan
- [x] `npm run build`
- [x] New/updated tests in `tests/clients/subagent-mode.test.ts`:
  - avtc pair set ⇒ subagent detected, identity carries marker `"avtc-pi-subagent"` + agent name
  - only `PI_SUBAGENT_CHILD_AGENT` set (no parent pid) ⇒ not a subagent (false-positive guard)
  - only `PI_SUBAGENT_PARENT_PID` set ⇒ not a subagent
  - `PI_LENS_SUBAGENT_FULL=1` overrides the avtc pair
  - existing nicobailon cases still pass, now also asserting `marker: "pi-subagents"`
- [x] `npm test` (full suite) — 2 pre-existing unrelated failures confirmed on master too (`tests/index-integration.test.ts` #484 turn-summary timing, `tests/clients/sgconfig.test.ts` #497 cache-invalidation timeout); all subagent-mode/runtime-session tests pass (94/94)
- [x] `npm run lint`
- [x] CHANGELOG.md `[Unreleased]` entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)