### PR TITLE
fix: pin pnpm version in install-smoke.yml to 11.7.0

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -72,7 +72,7 @@ jobs:
         if: matrix.pm == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: latest
+          version: 11.7.0
 
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -152,7 +152,7 @@ jobs:
         if: matrix.pi_install == 'pnpm-global'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: latest
+          version: 11.7.0
 
       - name: Setup bun
         if: matrix.pi_install == 'bun-global'


### PR DESCRIPTION
## Summary
- Nightly `install-smoke` started failing on all `version: latest` pnpm jobs — pnpm `11.12.0`'s self-installer crashes internally (`createFullPkgId`: "Cannot use 'in' operator to search for 'integrity' in undefined"), an upstream bug, not anything in this repo.
- Pins both `Setup pnpm` steps to `11.7.0`, the last confirmed-working version per the failure log.
- Refs #641 (tracking issue to revisit/bump the pin once pnpm ships a fix past 11.12.0) — deliberately not closing it, it's meant to stay open as a future reminder.

## Test plan
- [x] Confirmed the failure is 100% reproducible upstream (identical crash across ubuntu/macos, pnpm/pnpm-global variants), not project-specific.
- [ ] Next scheduled `install-smoke` nightly run (or manual `workflow_dispatch`) should show the pnpm jobs passing again.