### PR TITLE
fix(lsp): shutdown racing an in-flight spawn no longer leaks the server process

### DIFF
--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -1106,6 +1106,22 @@ export class LSPService {
 		recordLsp(server.id, root, "spawn_start");
 		try {
 			const spawned = await server.spawn(root, { allowInstall });
+
+			// Guard 1: service was shut down while we were waiting for the spawn.
+			// Kill the raw process — no LSPClient exists yet — and bail out without
+			// marking the key broken (this is not a server failure).
+			if (this.isDestroyed) {
+				try {
+					spawned?.process?.process?.kill();
+				} catch {
+					// pi-lens-ignore: missing-error-propagation — best-effort kill on aborted spawn
+				}
+				logSessionStart(
+					`lsp spawn ${server.id}: aborted (service shut down mid-spawn)`,
+				);
+				return undefined;
+			}
+
 			if (!spawned) {
 				logSessionStart(
 					`lsp spawn ${server.id}: unavailable (${Date.now() - startedAt}ms)`,
@@ -1155,6 +1171,17 @@ export class LSPService {
 				initializeTimeoutMs: server.initializeTimeoutMs,
 				launchVariant: spawned.launchVariant,
 			});
+
+			// Guard 2: service was shut down while we were completing the initialize
+			// handshake. Shut down the live client best-effort and do not register it.
+			if (this.isDestroyed) {
+				client.shutdown({ fast: true }).catch(() => {});
+				logSessionStart(
+					`lsp spawn ${server.id}: aborted (service shut down mid-initialize)`,
+				);
+				return undefined;
+			}
+
 			const wsDiag =
 				typeof client.getWorkspaceDiagnosticsSupport === "function"
 					? client.getWorkspaceDiagnosticsSupport()
@@ -3034,8 +3061,22 @@ export class LSPService {
 	async shutdown(options: LSPShutdownOptions = {}): Promise<void> {
 		if (this.checkDestroyed()) return;
 		this.isDestroyed = true;
-		// Cancel any in-flight spawns
-		this.state.inFlight.clear();
+
+		// Belt-and-braces: wait for any in-flight spawns so that Guard 1/2 in
+		// spawnClient can observe isDestroyed and clean up. Skip on the
+		// process-exiting path — the event loop is closing and we must not block.
+		if (!options.processExiting && this.state.inFlight.size > 0) {
+			const pending = Array.from(this.state.inFlight.values());
+			this.state.inFlight.clear();
+			const settled = await Promise.allSettled(pending);
+			for (const result of settled) {
+				if (result.status === "fulfilled" && result.value?.client) {
+					result.value.client.shutdown({ fast: true }).catch(() => {});
+				}
+			}
+		} else {
+			this.state.inFlight.clear();
+		}
 
 		for (const [_key, client] of this.state.clients) {
 			try {

--- a/tests/clients/lsp/spawn-shutdown-race.test.ts
+++ b/tests/clients/lsp/spawn-shutdown-race.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression test for #706: shutdown() racing an in-flight spawnClient must
+ * not leave a live server process or a registered client behind.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getServersForFileWithConfig = vi.fn();
+const createLSPClient = vi.fn();
+
+vi.mock("../../../clients/lsp/config.js", () => ({
+	getServersForFileWithConfig,
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../../clients/lsp/client.js", () => ({
+	createLSPClient,
+}));
+
+describe("LSPService spawn-shutdown race (#706)", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("kills a freshly spawned process when shutdown races spawn before createLSPClient", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		// Control the spawn timing so we can inject shutdown mid-spawn
+		let resolveSpawn!: (value: unknown) => void;
+		const spawnGate = new Promise((res) => {
+			resolveSpawn = res;
+		});
+
+		const mockKill = vi.fn();
+		const spawn = vi.fn(async () => {
+			await spawnGate;
+			return {
+				process: {
+					process: { killed: false, kill: mockKill },
+					stdin: {} as any,
+					stdout: {} as any,
+					stderr: {} as any,
+					pid: 999,
+				},
+			};
+		});
+
+		const clientShutdown = vi.fn().mockResolvedValue(undefined);
+		createLSPClient.mockResolvedValue({
+			isAlive: () => true,
+			shutdown: clientShutdown,
+			serverId: "python",
+		});
+
+		getServersForFileWithConfig.mockReturnValue([
+			{
+				id: "python",
+				name: "Python",
+				extensions: [".py"],
+				root: async () => "C:/repo",
+				spawn,
+			},
+		]);
+
+		const file = "C:/repo/main.py";
+
+		// Start the spawn (will hang at spawnGate)
+		const spawnPromise = service.getClientForFile(file);
+
+		// Shut down the service while spawn is still pending
+		const shutdownPromise = service.shutdown();
+
+		// Let the spawn resolve — service is already destroyed at this point
+		resolveSpawn(undefined);
+
+		await shutdownPromise;
+		await spawnPromise;
+
+		// The raw process should have been killed (Guard 1)
+		expect(mockKill).toHaveBeenCalled();
+		// createLSPClient should not have been called at all since guard fires first
+		expect(createLSPClient).not.toHaveBeenCalled();
+		// state.clients must remain empty
+		expect(service.getAliveClientCount()).toBe(0);
+		expect(service.getStatus()).toHaveLength(0);
+	});
+
+	it("shuts down client when shutdown races spawn after createLSPClient", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		// Spawn is gated so we can let it resolve, then call shutdown, then
+		// release createLSPClient — ensuring Guard 2 (post-initialize) fires.
+		let resolveSpawn!: (value: unknown) => void;
+		const spawnGate = new Promise((res) => {
+			resolveSpawn = res;
+		});
+
+		const spawn = vi.fn(async () => {
+			await spawnGate;
+			return {
+				process: {
+					process: { killed: false, kill: vi.fn() },
+					stdin: {} as any,
+					stdout: {} as any,
+					stderr: {} as any,
+					pid: 998,
+				},
+			};
+		});
+
+		let resolveClient!: (value: unknown) => void;
+		const clientGate = new Promise((res) => {
+			resolveClient = res;
+		});
+
+		const clientShutdown = vi.fn().mockResolvedValue(undefined);
+		createLSPClient.mockImplementation(async () => {
+			await clientGate;
+			return {
+				isAlive: () => true,
+				shutdown: clientShutdown,
+				serverId: "python",
+			};
+		});
+
+		getServersForFileWithConfig.mockReturnValue([
+			{
+				id: "python",
+				name: "Python",
+				extensions: [".py"],
+				root: async () => "C:/repo",
+				spawn,
+			},
+		]);
+
+		const file = "C:/repo/main.py";
+
+		// Start the spawn (blocked at spawnGate)
+		const spawnPromise = service.getClientForFile(file);
+
+		// Let spawn resolve while service is still alive — Guard 1 won't fire.
+		// We need createLSPClient to be entered before shutdown() sets isDestroyed.
+		// Use a flag set by the mock to know when that happens.
+		let clientEntered = false;
+		const origImpl = createLSPClient.getMockImplementation()!;
+		createLSPClient.mockImplementation(async (...args: unknown[]) => {
+			clientEntered = true;
+			return origImpl(...args);
+		});
+
+		resolveSpawn(undefined);
+		// Spin until createLSPClient is entered
+		while (!clientEntered) {
+			await Promise.resolve();
+		}
+
+		// Now shut down while createLSPClient is still pending (Guard 2 path)
+		const shutdownPromise = service.shutdown();
+
+		// Release createLSPClient — service is already destroyed
+		resolveClient(undefined);
+
+		await shutdownPromise;
+		await spawnPromise;
+
+		// Guard 2: client.shutdown should have been called best-effort
+		expect(clientShutdown).toHaveBeenCalled();
+		// The leaked client must not be in state.clients
+		expect(service.getAliveClientCount()).toBe(0);
+		expect(service.getStatus()).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

- **Bug**: `LSPService.shutdown()` cleared `state.inFlight` without awaiting or cancelling pending spawn promises. `spawnClient()` never re-checked `this.isDestroyed` after its long-running awaits, so a spawn completing after shutdown would register a live client into the already-destroyed instance — and when `resetLSPService()` nulled the singleton, that client became permanently unreachable, leaking the LSP server process for the host lifetime.
- **Fix**: Added two guards in `spawnClient`: (1) after `await server.spawn()` resolves, if `isDestroyed`, kill the raw process and return `undefined`; (2) after `await createLSPClient()` resolves, if `isDestroyed`, call `client.shutdown({ fast: true })` best-effort and return `undefined`. Also updated `shutdown()` to snapshot and `Promise.allSettled()` the in-flight set before clearing it (belt-and-braces; skipped on the `processExiting` path to avoid blocking a closing event loop).
- **Tests**: Added `tests/clients/lsp/spawn-shutdown-race.test.ts` with two regression scenarios — Guard 1 (process killed before initialize handshake) and Guard 2 (client shut down after initialize but before registration). Both scenarios assert that `state.clients` stays empty and the leaked resource is cleaned up.

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)