### PR TITLE
fix(mcp): MCP host session_start gets full startup mode, not permanent quick-mode

### DIFF
--- a/clients/mcp/session.ts
+++ b/clients/mcp/session.ts
@@ -89,6 +89,14 @@ export async function runSessionStart(
 
 	await handleSessionStart({
 		ctxCwd: cwd,
+		// The MCP server has no TUI keystroke latency to protect, so the
+		// first-call-quick heuristic must not apply. Force "full" mode so
+		// the dominant-language LSP pre-warm, scans, and error-debt baseline
+		// all run on the first (and only) session_start of the process.
+		// An explicit PI_LENS_STARTUP_MODE env var still wins (handled in
+		// handleSessionStart — the override is only checked when the env var
+		// is unset).
+		startupModeOverride: "full",
 		getFlag: host.getFlag,
 		notify: noop,
 		dbg: noop,

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -72,6 +72,18 @@ interface SessionStartDeps {
 	notify: (msg: string, level: "info" | "warning" | "error") => void;
 	dbg: (msg: string) => void;
 	log: (msg: string) => void;
+	/**
+	 * Host-provided startup-mode override. When set, the first-call-quick
+	 * heuristic (TUI cold-start latency mitigation) is skipped and this value
+	 * wins — but only when `PI_LENS_STARTUP_MODE` is NOT explicitly set in the
+	 * environment (an explicit env var still takes highest precedence).
+	 *
+	 * Use case: the MCP server has no TUI keystroke latency to protect and
+	 * should always get "full" mode on its first (and only) session_start so
+	 * the dominant-language LSP pre-warm, scans, and error-debt baseline all
+	 * run. Pass `"full"` from `clients/mcp/session.ts`.
+	 */
+	startupModeOverride?: StartupMode;
 	runtime: RuntimeCoordinator;
 	metricsClient: MetricsClient;
 	cacheManager: CacheManager;
@@ -1075,6 +1087,10 @@ export async function handleSessionStart(
 	//
 	// Opt-out: PI_LENS_COLD_START_QUICK=0 disables this behaviour.
 	// Override: PI_LENS_STARTUP_MODE explicitly set wins (we honour it).
+	//   deps.startupModeOverride lets a host (e.g. the MCP server, which has
+	//   no TUI keystroke latency to protect) skip the quick-mode heuristic
+	//   entirely — but only when PI_LENS_STARTUP_MODE is unset in the env
+	//   (an explicit env var still takes highest precedence).
 	// Tunable: PI_LENS_WARMUP_DELAY_MS adjusts the warmup delay.
 	let startupMode = resolveStartupMode();
 	const processGlobals = globalThis as unknown as {
@@ -1087,7 +1103,9 @@ export async function handleSessionStart(
 		process.env.PI_LENS_COLD_START_QUICK !== "0" &&
 		!process.env.PI_LENS_STARTUP_MODE
 	) {
-		startupMode = "quick";
+		// Apply host-provided override (e.g. MCP server forces "full") before
+		// falling back to the TUI quick-mode heuristic.
+		startupMode = deps.startupModeOverride ?? "quick";
 	}
 	processGlobals.__piLensFirstSessionDone = true;
 

--- a/tests/clients/runtime-session.test.ts
+++ b/tests/clients/runtime-session.test.ts
@@ -513,6 +513,211 @@ describe("runtime-session notifications", () => {
 		}
 	});
 
+	it("startupModeOverride:'full' on first call gets full mode (MCP host path, #546)", async () => {
+		// Simulate the MCP host: first call of the process, no PI_LENS_STARTUP_MODE
+		// set in env, but deps.startupModeOverride = "full". The dbg log line
+		// "startup mode: full" is the cheapest reliable discriminant — it's
+		// emitted synchronously for every startup mode before the quick/full
+		// branch diverges.
+		const env = setupTestEnvironment("pi-lens-mcp-startup-mode-");
+		const globals = globalThis as unknown as {
+			__piLensFirstSessionDone?: boolean;
+			__piLensWarmupScheduled?: boolean;
+		};
+		const prevFirst = globals.__piLensFirstSessionDone;
+		const prevWarmup = globals.__piLensWarmupScheduled;
+		globals.__piLensFirstSessionDone = false;
+		globals.__piLensWarmupScheduled = false;
+		delete process.env.PI_LENS_STARTUP_MODE;
+		const dbg = vi.fn();
+		try {
+			await handleSessionStart({
+				ctxCwd: env.tmpDir,
+				startupModeOverride: "full",
+				getFlag: (name: string) => name === "no-lsp",
+				notify: () => {},
+				dbg,
+				log: () => {},
+				runtime: {
+					sessionGeneration: 1,
+					isCurrentSession: () => true,
+					markStartupScanInFlight: () => {},
+					clearStartupScanInFlight: () => {},
+					complexityBaselines: new Map(),
+					resetForSession: () => {},
+					projectRoot: "",
+					projectRulesScan: { hasCustomRules: false, rules: [] },
+					cachedExports: new Map(),
+					errorDebtBaseline: { testsPassed: true, buildPassed: true },
+				},
+				metricsClient: { reset: () => {} },
+				cacheManager: { writeCache: () => {}, readCache: () => null },
+				todoScanner: { scanDirectory: () => ({ items: [] }), scanFile: () => [] },
+				astGrepClient: { isAvailable: () => false, ensureAvailable: async () => false, scanExports: async () => new Map() },
+				biomeClient: { isAvailable: () => false, ensureAvailable: async () => false },
+				ruffClient: { isAvailable: () => false, ensureAvailable: async () => false },
+				knipClient: { isAvailable: () => false, ensureAvailable: async () => false, analyze: async () => ({ success: true, issues: [], unusedExports: [], unusedFiles: [], unusedDeps: [], unlistedDeps: [], summary: "skipped" }) },
+				jscpdClient: { isAvailable: () => false, ensureAvailable: async () => false },
+				depChecker: { isAvailable: () => false, ensureAvailable: async () => false },
+				testRunnerClient: { detectRunner: () => ({ runner: "vitest", config: null }), runTestFile: () => ({ failed: 1, error: false }) },
+				goClient: { isGoAvailableAsync: async () => false },
+				rustClient: { isAvailableAsync: async () => false },
+				ensureTool: async () => null,
+				cleanStaleTsBuildInfo: () => [],
+				resetDispatchBaselines: () => {},
+				resetLSPService: () => {},
+			} as any);
+			// dbg records the resolved startup mode synchronously
+			expect(
+				dbg.mock.calls.some(([msg]) =>
+					String(msg).includes("startup mode: full"),
+				),
+			).toBe(true);
+			// quick-mode emits a "skipping slow tool probes" dbg line; full does not
+			expect(
+				dbg.mock.calls.some(([msg]) =>
+					String(msg).includes("quick mode active"),
+				),
+			).toBe(false);
+		} finally {
+			globals.__piLensFirstSessionDone = prevFirst;
+			globals.__piLensWarmupScheduled = prevWarmup;
+			env.cleanup();
+		}
+	});
+
+	it("plain/TUI first call (no startupModeOverride) still gets quick mode (#546 non-regression)", async () => {
+		// Ensure the TUI path is unchanged: first call with no override → quick.
+		const env = setupTestEnvironment("pi-lens-tui-startup-mode-");
+		const globals = globalThis as unknown as {
+			__piLensFirstSessionDone?: boolean;
+			__piLensWarmupScheduled?: boolean;
+		};
+		const prevFirst = globals.__piLensFirstSessionDone;
+		const prevWarmup = globals.__piLensWarmupScheduled;
+		globals.__piLensFirstSessionDone = false;
+		globals.__piLensWarmupScheduled = false;
+		delete process.env.PI_LENS_STARTUP_MODE;
+		const dbg = vi.fn();
+		try {
+			await handleSessionStart({
+				ctxCwd: env.tmpDir,
+				// no startupModeOverride → TUI heuristic applies → quick
+				getFlag: (name: string) => name === "no-lsp",
+				notify: () => {},
+				dbg,
+				log: () => {},
+				runtime: {
+					sessionGeneration: 1,
+					isCurrentSession: () => true,
+					markStartupScanInFlight: () => {},
+					clearStartupScanInFlight: () => {},
+					complexityBaselines: new Map(),
+					resetForSession: () => {},
+					projectRoot: "",
+					projectRulesScan: { hasCustomRules: false, rules: [] },
+					cachedExports: new Map(),
+					errorDebtBaseline: { testsPassed: true, buildPassed: true },
+				},
+				metricsClient: { reset: () => {} },
+				cacheManager: { writeCache: () => {}, readCache: () => null },
+				todoScanner: { scanDirectory: () => ({ items: [] }), scanFile: () => [] },
+				astGrepClient: { isAvailable: () => false, ensureAvailable: async () => false, scanExports: async () => new Map() },
+				biomeClient: { isAvailable: () => false, ensureAvailable: async () => false },
+				ruffClient: { isAvailable: () => false, ensureAvailable: async () => false },
+				knipClient: { isAvailable: () => false, ensureAvailable: async () => false, analyze: async () => ({ success: true, issues: [], unusedExports: [], unusedFiles: [], unusedDeps: [], unlistedDeps: [], summary: "skipped" }) },
+				jscpdClient: { isAvailable: () => false, ensureAvailable: async () => false },
+				depChecker: { isAvailable: () => false, ensureAvailable: async () => false },
+				testRunnerClient: { detectRunner: () => ({ runner: "vitest", config: null }), runTestFile: () => ({ failed: 1, error: false }) },
+				goClient: { isGoAvailableAsync: async () => false },
+				rustClient: { isAvailableAsync: async () => false },
+				ensureTool: async () => null,
+				cleanStaleTsBuildInfo: () => [],
+				resetDispatchBaselines: () => {},
+				resetLSPService: () => {},
+			} as any);
+			expect(
+				dbg.mock.calls.some(([msg]) =>
+					String(msg).includes("startup mode: quick"),
+				),
+			).toBe(true);
+			expect(
+				dbg.mock.calls.some(([msg]) =>
+					String(msg).includes("quick mode active"),
+				),
+			).toBe(true);
+		} finally {
+			globals.__piLensFirstSessionDone = prevFirst;
+			globals.__piLensWarmupScheduled = prevWarmup;
+			env.cleanup();
+		}
+	});
+
+	it("explicit PI_LENS_STARTUP_MODE env wins over startupModeOverride (both hosts, #546)", async () => {
+		// Even with startupModeOverride:"full", if PI_LENS_STARTUP_MODE=quick is
+		// set, the env var takes precedence (highest priority rule).
+		const env = setupTestEnvironment("pi-lens-env-override-startup-mode-");
+		const globals = globalThis as unknown as {
+			__piLensFirstSessionDone?: boolean;
+			__piLensWarmupScheduled?: boolean;
+		};
+		const prevFirst = globals.__piLensFirstSessionDone;
+		const prevWarmup = globals.__piLensWarmupScheduled;
+		globals.__piLensFirstSessionDone = false;
+		globals.__piLensWarmupScheduled = false;
+		process.env.PI_LENS_STARTUP_MODE = "quick";
+		const dbg = vi.fn();
+		try {
+			await handleSessionStart({
+				ctxCwd: env.tmpDir,
+				startupModeOverride: "full", // would normally force full for MCP host…
+				getFlag: (name: string) => name === "no-lsp",
+				notify: () => {},
+				dbg,
+				log: () => {},
+				runtime: {
+					sessionGeneration: 1,
+					isCurrentSession: () => true,
+					markStartupScanInFlight: () => {},
+					clearStartupScanInFlight: () => {},
+					complexityBaselines: new Map(),
+					resetForSession: () => {},
+					projectRoot: "",
+					projectRulesScan: { hasCustomRules: false, rules: [] },
+					cachedExports: new Map(),
+					errorDebtBaseline: { testsPassed: true, buildPassed: true },
+				},
+				metricsClient: { reset: () => {} },
+				cacheManager: { writeCache: () => {}, readCache: () => null },
+				todoScanner: { scanDirectory: () => ({ items: [] }), scanFile: () => [] },
+				astGrepClient: { isAvailable: () => false, ensureAvailable: async () => false, scanExports: async () => new Map() },
+				biomeClient: { isAvailable: () => false, ensureAvailable: async () => false },
+				ruffClient: { isAvailable: () => false, ensureAvailable: async () => false },
+				knipClient: { isAvailable: () => false, ensureAvailable: async () => false, analyze: async () => ({ success: true, issues: [], unusedExports: [], unusedFiles: [], unusedDeps: [], unlistedDeps: [], summary: "skipped" }) },
+				jscpdClient: { isAvailable: () => false, ensureAvailable: async () => false },
+				depChecker: { isAvailable: () => false, ensureAvailable: async () => false },
+				testRunnerClient: { detectRunner: () => ({ runner: "vitest", config: null }), runTestFile: () => ({ failed: 1, error: false }) },
+				goClient: { isGoAvailableAsync: async () => false },
+				rustClient: { isAvailableAsync: async () => false },
+				ensureTool: async () => null,
+				cleanStaleTsBuildInfo: () => [],
+				resetDispatchBaselines: () => {},
+				resetLSPService: () => {},
+			} as any);
+			// PI_LENS_STARTUP_MODE=quick wins → resolveStartupMode() returns "quick"
+			// before the heuristic even runs (env var check skips the override branch)
+			expect(
+				dbg.mock.calls.some(([msg]) =>
+					String(msg).includes("startup mode: quick"),
+				),
+			).toBe(true);
+		} finally {
+			globals.__piLensFirstSessionDone = prevFirst;
+			globals.__piLensWarmupScheduled = prevWarmup;
+			env.cleanup();
+		}
+	});
+
 	it("limits deferred availability probes to relevant uncovered tools", async () => {
 		const {
 			env,


### PR DESCRIPTION
## Root cause

`handleSessionStart` (`clients/runtime-session.ts`) force-classifies the **first** `session_start` of any process as `"quick"` mode — a TUI cold-start latency mitigation. The MCP server's `maybeAutoSessionStart()` fires exactly once per process, so it was permanently stuck in quick-mode: no dominant-language LSP pre-warm (`igniteDominantLanguageWarm` is gated on `startupMode === "full"`), no scans, no error-debt baseline, for the process lifetime.

## Fix (Option A — typed override)

Added an optional `startupModeOverride?: StartupMode` field to `SessionStartDeps` (`clients/runtime-session.ts`). When set **and** `PI_LENS_STARTUP_MODE` is unset in the environment, the override wins instead of falling through to the TUI `"quick"` heuristic. Explicit `PI_LENS_STARTUP_MODE` env var retains highest precedence.

`clients/mcp/session.ts` passes `startupModeOverride: "full"` to `handleSessionStart` so the MCP host always gets full mode. The TUI path is completely unchanged (no override provided → `"quick"` as before).

Option A was chosen over the env-mutation Option B because it is explicit, typed, and scoped to the call site — no global mutation, no risk of clobbering a user-set env var.

## Tests

Three new cases added to `tests/clients/runtime-session.test.ts`:
- MCP host first call with `startupModeOverride:"full"` → full mode (verified via `dbg` log line)
- Plain/TUI first call (no override) → quick mode — non-regression guard
- Explicit `PI_LENS_STARTUP_MODE=quick` wins over `startupModeOverride:"full"` — env var precedence preserved

## Files changed

- `clients/runtime-session.ts` — `startupModeOverride` field + updated quick-mode branch
- `clients/mcp/session.ts` — pass `startupModeOverride: "full"` in `runSessionStart`
- `tests/clients/runtime-session.test.ts` — three new test cases

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)