### PR TITLE
perf(lsp): per-edit path races a tsserver sync clean-confirm against the push wait (#707)

### DIFF
--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -163,6 +163,22 @@ function readEnvDiagnosticsWaitMs(): number | undefined {
 	if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
 	return parsed;
 }
+
+/**
+ * #707: grace delay before the racing tsserver sync clean-confirm fires on a
+ * tier-3 silent primary. Short enough to beat the full push-wait budget by a
+ * wide margin (~300ms grace + sync RTT vs ~1000ms budget), long enough to give
+ * a genuinely dirty file's push a head start — a push that arrives within the
+ * grace costs zero extra requests. Read at call time (not memoized) so tests
+ * and users can tune without a rebuild.
+ */
+function readTsserverSyncGraceMs(): number {
+	const raw = process.env.PI_LENS_TSSERVER_SYNC_GRACE_MS;
+	if (raw === undefined) return 300;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) return 300;
+	return parsed;
+}
 const DIAGNOSTICS_SEMANTIC_SETTLE_THRESHOLD_MS = Math.max(
 	0,
 	Number.parseInt(
@@ -1414,6 +1430,15 @@ export class LSPService {
 		}
 
 		let diagnosticsTimedOut = false;
+		// #707: tsserver sync clean-confirm state. `tsserverSyncEligible` is the
+		// full gate (evaluated once, before the wait); `tsserverSyncConfirmed`
+		// holds the sync commands' answer when the racing confirm won the wait
+		// (undefined = the race didn't produce an answer; the end-of-wait
+		// fallback below may still fill it in on a timed-out empty result).
+		let tsserverSyncEligible = false;
+		let tsserverSyncConfirmed:
+			| import("./client.js").LSPDiagnostic[]
+			| undefined = undefined;
 		if (diagnosticsMode !== "none") {
 			// Resolution: env wins so users can tune the cap without rebuilding.
 			// Otherwise, on the single-server hot path (primary scope), use that
@@ -1517,8 +1542,37 @@ export class LSPService {
 				0,
 				...spawned.map((e) => timeoutFor(e.client.serverId)),
 			);
+
+			// #707: evaluate the tsserver sync clean-confirm gate BEFORE the wait
+			// starts. Cheap synchronous gates first (notify succeeded, collecting,
+			// primary scope, strategy marked silentOnClean — only classic
+			// typescript-language-server carries that flag today), then the live
+			// capability-snapshot tier classification (`classifyCascadeWaitTier`,
+			// which also excludes native-ts7 via `launchVariant`). Non-typescript
+			// and pull-capable servers fail the synchronous `silentOnClean` gate and
+			// pay ZERO extra work — not even the snapshot read.
+			if (
+				!notifyWriteTimedOut &&
+				options.collectDiagnostics === true &&
+				clientScope === "primary" &&
+				spawned.length === 1 &&
+				getStrategy(spawned[0].client.serverId).silentOnClean === true
+			) {
+				try {
+					const snapshots = await this.getCapabilitySnapshots(filePath);
+					tsserverSyncEligible =
+						classifyCascadeWaitTier(this, filePath, snapshots) ===
+						"tier3-silent";
+				} catch {
+					// Fail-safe: ineligible — today's full wait, no sync attempt.
+				}
+			}
+
 			const waitStartedAt = Date.now();
-			await Promise.all(
+			// The push wait — same per-server budget composition as before #707;
+			// only the awaiting changed (assigned so it can be raced below).
+			let pushWaitSettled = false;
+			const pushWait = Promise.all(
 				spawned.map((entry) => {
 					const serverTimeout = timeoutFor(entry.client.serverId);
 					const baseline = diagnosticBaselines.get(entry.client);
@@ -1530,12 +1584,105 @@ export class LSPService {
 							: entry.client.waitForDiagnostics(filePath, serverTimeout);
 					return wait.catch(() => undefined);
 				}),
-			);
+			).then(() => {
+				pushWaitSettled = true;
+			});
+
+			if (tsserverSyncEligible) {
+				// #707 racing variant: rather than burning the full push-wait budget
+				// on a silent-on-clean server (which by definition never answers on a
+				// clean file), race the push wait against a grace-delayed sync
+				// confirm. The grace (default 300ms, PI_LENS_TSSERVER_SYNC_GRACE_MS)
+				// gives a genuinely dirty file's push a head start: if diagnostics
+				// arrive before the grace elapses, the sync request never goes out —
+				// zero new latency or requests on the push-answers path.
+				//
+				// Race semantics:
+				//   - sync answers first → that's the confirmed result (clean OR
+				//     dirty — the sync commands return the file's real syntactic +
+				//     semantic state, so a dirty-file win is still correct and its
+				//     findings are surfaced, never discarded).
+				//   - push settles first → push wins; a still-in-flight sync outcome
+				//     is discarded (the racer checks `pushWaitSettled` after the
+				//     call returns and drops its own result).
+				//   - sync unavailable/fails → the racer parks on a never-resolving
+				//     promise so the race is decided by the push wait's own budget,
+				//     exactly today's behavior (the end-of-wait fallback below still
+				//     gets its shot on a timed-out empty result).
+				// The racer never rejects (every failure path is caught), so the
+				// losing promise can never surface as an unhandled rejection.
+				const graceMs = readTsserverSyncGraceMs();
+				const primaryClient = spawned[0].client;
+				// Resolves with the sync commands' diagnostics when the confirm
+				// succeeds; parks on a never-resolving promise on EVERY other path
+				// (push already answered, sync unavailable/failed, push won while
+				// in flight) so the race is then decided by the push wait's own
+				// budget — exactly today's behavior.
+				const syncRacer = (async (): Promise<
+					import("./client.js").LSPDiagnostic[]
+				> => {
+					await new Promise<void>((resolve) => {
+						const timer = setTimeout(resolve, graceMs);
+						timer.unref?.();
+					});
+					// Push already answered (settled, or published diagnostics that
+					// its wait is about to settle on) — nothing to confirm, no sync
+					// request goes out.
+					if (
+						pushWaitSettled ||
+						primaryClient.getDiagnostics(filePath).length > 0
+					) {
+						return new Promise<never>(() => {});
+					}
+					try {
+						const result = await attemptTsserverSyncDiagnostics(
+							filePath,
+							this,
+						);
+						if (result === undefined || pushWaitSettled) {
+							// Sync unavailable/failed, or push won while the sync call
+							// was in flight — drop the sync outcome and let the push
+							// wait decide the race.
+							return new Promise<never>(() => {});
+						}
+						return result;
+					} catch {
+						return new Promise<never>(() => {});
+					}
+				})();
+				const raceOutcome = await Promise.race([
+					pushWait.then((): undefined => undefined),
+					syncRacer,
+				]);
+				if (raceOutcome !== undefined) {
+					tsserverSyncConfirmed = raceOutcome;
+				}
+			} else {
+				await pushWait;
+			}
 			const waitedMs = Date.now() - waitStartedAt;
-			// Within ~20 ms of the configured budget we treat it as a timeout;
-			// the LSP didn't beat the cap. Diagnostics that arrive late still
-			// land in the client's cache and surface on the next edit.
-			if (waitedMs + 20 >= timeoutMs) {
+			if (tsserverSyncConfirmed !== undefined) {
+				// #707: the racing sync confirm won — a definitive answer well under
+				// the push-wait budget. Not a timeout, not inconclusive.
+				logLatency({
+					type: "phase",
+					phase: "lsp_tsserver_sync_confirm",
+					filePath: normalizedPath,
+					durationMs: waitedMs,
+					metadata: {
+						source,
+						clientScope,
+						diagnosticsMode,
+						mode: "race",
+						confirmedDiagnosticCount: tsserverSyncConfirmed.length,
+						budgetMs: timeoutMs,
+						savedVsBudgetMs: Math.max(0, timeoutMs - waitedMs),
+					},
+				});
+			} else if (waitedMs + 20 >= timeoutMs) {
+				// Within ~20 ms of the configured budget we treat it as a timeout;
+				// the LSP didn't beat the cap. Diagnostics that arrive late still
+				// land in the client's cache and surface on the next edit.
 				diagnosticsTimedOut = true;
 				logLatency({
 					type: "phase",
@@ -1552,73 +1699,65 @@ export class LSPService {
 			}
 		}
 
+		// #707: when the racing sync confirm won the wait, its answer IS the
+		// collected result — the file's real syntactic + semantic state straight
+		// from tsserver (clean = [], dirty = real findings that a silentOnClean
+		// server had computed but never published). Otherwise merge the push
+		// diagnostics from the client cache as always.
 		let collected = options.collectDiagnostics
-			? mergeLspDiagnostics(
-					spawned.flatMap((entry) => entry.client.getDiagnostics(filePath)),
-				)
+			? tsserverSyncConfirmed !== undefined
+				? mergeLspDiagnostics(tsserverSyncConfirmed)
+				: mergeLspDiagnostics(
+						spawned.flatMap((entry) => entry.client.getDiagnostics(filePath)),
+					)
 			: undefined;
 
-		// #707: when the diagnostics wait timed out with an empty result on a
-		// primary-scope touch, attempt the tsserver sync clean-confirm escape hatch
-		// (extracted to clients/lsp/tsserver-sync.ts from the #611 tool-side
-		// implementation). This only fires when ALL of the following hold:
-		//   1. the notify write succeeded (the server got the change)
-		//   2. the diagnostics wait timed out (the push never arrived — the silent case)
-		//   3. we're collecting diagnostics on the primary-scope path (one server:
-		//      the dispatch lsp-runner and its equivalents)
-		//   4. nothing arrived via push (collected is empty — if push already surfaced
-		//      diagnostics, there's nothing to confirm via sync)
-		//
-		// If the sync call answers (even with an empty body, which is a confirmed
-		// clean), we use those diagnostics as the confirmed result and clear the
+		// #707 end-of-wait fallback: when the racing confirm did NOT decide the
+		// wait (sync unavailable/failed mid-race, or push resolved as a bare
+		// timeout) and the wait timed out with an empty result on an eligible
+		// touch, give the sync clean-confirm one last shot before reporting
+		// inconclusive. `tsserverSyncEligible` already encodes every gate (notify
+		// succeeded, collecting, primary scope, tier3-silent classic typescript —
+		// native-ts7 excluded by `classifyCascadeWaitTier`). If the sync call
+		// answers (even with an empty body, which is a confirmed clean), we use
+		// those diagnostics as the confirmed result and clear the
 		// `diagnosticsTimedOut` flag so the touch is no longer treated as
-		// inconclusive. Sync diagnostics on a dirty file (silentOnClean server that
-		// had computed-but-unpublished results) are surfaced, not discarded.
-		// If the sync call fails or is unavailable, we fall through to today's
-		// behavior: `inconclusive` = true, `collected` unchanged.
-		//
-		// Seam choice (end-of-wait confirm rather than early-return): the sync call
-		// goes out AFTER the push-wait budget is exhausted. This is the safe "first
-		// cut" — it turns "unconfirmed after ~1000ms" into "confirmed at ~wait+sync-RTT"
-		// without touching the wait scheduling logic. The latency win is correctness
-		// (caller no longer reports "skipped" on a clean TS file) rather than
-		// raw speed; the sync RTT is typically <50ms for a resident tsserver.
+		// inconclusive. Sync diagnostics on a dirty file are surfaced, not
+		// discarded. If the sync call fails or is unavailable, we fall through to
+		// today's behavior: `inconclusive` = true, `collected` unchanged. This
+		// turns "unconfirmed after ~1000ms" into "confirmed at ~wait+sync-RTT"
+		// even when the race path couldn't answer.
 		if (
 			diagnosticsTimedOut &&
-			!notifyWriteTimedOut &&
-			options.collectDiagnostics &&
-			clientScope === "primary" &&
+			tsserverSyncEligible &&
 			collected !== undefined &&
 			collected.length === 0
 		) {
 			try {
-				const snapshots = await this.getCapabilitySnapshots(filePath);
-				const tier = classifyCascadeWaitTier(this, filePath, snapshots);
-				if (tier === "tier3-silent") {
-					const syncResult = await attemptTsserverSyncDiagnostics(
-						filePath,
-						this,
-					);
-					if (syncResult !== undefined) {
-						// Sync answered — confirmed result (clean or with diagnostics).
-						// Clear the timed-out flag so the touch is no longer inconclusive.
-						diagnosticsTimedOut = false;
-						collected = syncResult.length > 0
-							? mergeLspDiagnostics(syncResult)
-							: [];
-						logLatency({
-							type: "phase",
-							phase: "lsp_tsserver_sync_confirm",
-							filePath: normalizedPath,
-							durationMs: Date.now() - startedAt,
-							metadata: {
-								source,
-								clientScope,
-								diagnosticsMode,
-								confirmedDiagnosticCount: collected.length,
-							},
-						});
-					}
+				const syncResult = await attemptTsserverSyncDiagnostics(
+					filePath,
+					this,
+				);
+				if (syncResult !== undefined) {
+					// Sync answered — confirmed result (clean or with diagnostics).
+					// Clear the timed-out flag so the touch is no longer inconclusive.
+					diagnosticsTimedOut = false;
+					collected = syncResult.length > 0
+						? mergeLspDiagnostics(syncResult)
+						: [];
+					logLatency({
+						type: "phase",
+						phase: "lsp_tsserver_sync_confirm",
+						filePath: normalizedPath,
+						durationMs: Date.now() - startedAt,
+						metadata: {
+							source,
+							clientScope,
+							diagnosticsMode,
+							mode: "end-of-wait",
+							confirmedDiagnosticCount: collected.length,
+						},
+					});
 				}
 			} catch {
 				// Any failure here falls through to today's inconclusive behavior.

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -49,6 +49,10 @@ import {
 	buildScopeKey,
 	createWorkspaceDiagnosticsCacheContext,
 } from "./workspace-diagnostics-cache.js";
+import {
+	attemptTsserverSyncDiagnostics,
+} from "./tsserver-sync.js";
+import { classifyCascadeWaitTier } from "./cascade-tier.js";
 
 // --- Init override helpers ---
 
@@ -1548,11 +1552,78 @@ export class LSPService {
 			}
 		}
 
-		const collected = options.collectDiagnostics
+		let collected = options.collectDiagnostics
 			? mergeLspDiagnostics(
 					spawned.flatMap((entry) => entry.client.getDiagnostics(filePath)),
 				)
 			: undefined;
+
+		// #707: when the diagnostics wait timed out with an empty result on a
+		// primary-scope touch, attempt the tsserver sync clean-confirm escape hatch
+		// (extracted to clients/lsp/tsserver-sync.ts from the #611 tool-side
+		// implementation). This only fires when ALL of the following hold:
+		//   1. the notify write succeeded (the server got the change)
+		//   2. the diagnostics wait timed out (the push never arrived — the silent case)
+		//   3. we're collecting diagnostics on the primary-scope path (one server:
+		//      the dispatch lsp-runner and its equivalents)
+		//   4. nothing arrived via push (collected is empty — if push already surfaced
+		//      diagnostics, there's nothing to confirm via sync)
+		//
+		// If the sync call answers (even with an empty body, which is a confirmed
+		// clean), we use those diagnostics as the confirmed result and clear the
+		// `diagnosticsTimedOut` flag so the touch is no longer treated as
+		// inconclusive. Sync diagnostics on a dirty file (silentOnClean server that
+		// had computed-but-unpublished results) are surfaced, not discarded.
+		// If the sync call fails or is unavailable, we fall through to today's
+		// behavior: `inconclusive` = true, `collected` unchanged.
+		//
+		// Seam choice (end-of-wait confirm rather than early-return): the sync call
+		// goes out AFTER the push-wait budget is exhausted. This is the safe "first
+		// cut" — it turns "unconfirmed after ~1000ms" into "confirmed at ~wait+sync-RTT"
+		// without touching the wait scheduling logic. The latency win is correctness
+		// (caller no longer reports "skipped" on a clean TS file) rather than
+		// raw speed; the sync RTT is typically <50ms for a resident tsserver.
+		if (
+			diagnosticsTimedOut &&
+			!notifyWriteTimedOut &&
+			options.collectDiagnostics &&
+			clientScope === "primary" &&
+			collected !== undefined &&
+			collected.length === 0
+		) {
+			try {
+				const snapshots = await this.getCapabilitySnapshots(filePath);
+				const tier = classifyCascadeWaitTier(this, filePath, snapshots);
+				if (tier === "tier3-silent") {
+					const syncResult = await attemptTsserverSyncDiagnostics(
+						filePath,
+						this,
+					);
+					if (syncResult !== undefined) {
+						// Sync answered — confirmed result (clean or with diagnostics).
+						// Clear the timed-out flag so the touch is no longer inconclusive.
+						diagnosticsTimedOut = false;
+						collected = syncResult.length > 0
+							? mergeLspDiagnostics(syncResult)
+							: [];
+						logLatency({
+							type: "phase",
+							phase: "lsp_tsserver_sync_confirm",
+							filePath: normalizedPath,
+							durationMs: Date.now() - startedAt,
+							metadata: {
+								source,
+								clientScope,
+								diagnosticsMode,
+								confirmedDiagnosticCount: collected.length,
+							},
+						});
+					}
+				}
+			} catch {
+				// Any failure here falls through to today's inconclusive behavior.
+			}
+		}
 
 		// A touch is inconclusive when EITHER the notify write or the
 		// diagnostics wait hit their deadline for ANY of the spawned servers

--- a/clients/lsp/tsserver-sync.ts
+++ b/clients/lsp/tsserver-sync.ts
@@ -1,0 +1,192 @@
+/**
+ * #611/#707: classic typescript-language-server tsserver sync diagnostic
+ * commands — shared between the `lsp_diagnostics` tool (where the escape hatch
+ * was first introduced in #611) and the per-edit `touchFile` dispatch path
+ * (wired in #707 to avoid burning the full wait budget on clean TS files).
+ *
+ * These are a genuine synchronous request/response tsserver protocol extension
+ * exposed via `workspace/executeCommand` with command
+ * `typescript.tsserverRequest`. Unlike the push-only LSP surface, calling them
+ * gives a definitive answer: empty array = confirmed clean, non-empty = real
+ * diagnostics the server had computed but never published on the push surface.
+ *
+ * Empirically verified live (2026-07, typescript-language-server 5.9.3, this
+ * repo's own tsconfig.json as the fixture project):
+ *
+ *   workspace/executeCommand {
+ *     command: "typescript.tsserverRequest",
+ *     arguments: [
+ *       "semanticDiagnosticsSync" | "syntacticDiagnosticsSync",
+ *       { file: "<absolute path>", includeLinePosition: true }
+ *     ]
+ *   }
+ *
+ * resolves { executed: true, result: { seq, type: "response", command,
+ * request_seq, success, body: [...] } }, where each body entry is tsserver's
+ * NATIVE protocol diagnostic shape — `message`, `category`
+ * ("error"|"warning"|"suggestion"), `code`, `startLocation`/`endLocation` as
+ * `{ line, offset }` — NOT the LSP `Diagnostic` shape, and both `line`/`offset`
+ * are 1-based (LSP is 0-based).
+ *
+ * All helpers here are pure-function and never throw (every error path returns
+ * `undefined`). The caller must handle `undefined` as "sync path unavailable,
+ * fall back to existing unconfirmed/timed-out behavior".
+ */
+
+import type { LSPDiagnostic } from "./client.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TsserverSyncRawDiagnostic {
+	message: string;
+	category: string;
+	code?: number;
+	startLocation?: { line: number; offset: number };
+	endLocation?: { line: number; offset: number };
+}
+
+/** Minimal LSP-service-shaped interface this module needs — avoids importing
+ * the full LSPService class and keeps the extracted module test-friendly. */
+export interface TsserverSyncCapableService {
+	getAdvertisedCommands?: (filePath?: string) => Promise<string[]>;
+	executeCommand?: (
+		filePath: string | undefined,
+		command: string,
+		args?: unknown[],
+	) => Promise<{ executed: boolean; result?: unknown; reason?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const TSSERVER_REQUEST_COMMAND = "typescript.tsserverRequest";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function isTsserverSyncRawDiagnostic(
+	value: unknown,
+): value is TsserverSyncRawDiagnostic {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	return typeof v.message === "string" && typeof v.category === "string";
+}
+
+export function tsserverSeverityFromCategory(category: string): 1 | 2 | 3 | 4 {
+	switch (category) {
+		case "error":
+			return 1;
+		case "warning":
+			return 2;
+		case "suggestion":
+			return 4; // Hint
+		default:
+			return 3; // "message" or unrecognized -> Info
+	}
+}
+
+/**
+ * Convert a tsserver-protocol sync diagnostic into pi-lens's LSP-shaped
+ * `LSPDiagnostic`. Both `line`/`offset` are 1-based in tsserver's protocol
+ * and 0-based in LSP — this conversion handles that.
+ */
+export function tsserverSyncDiagnosticToLsp(
+	d: TsserverSyncRawDiagnostic,
+): LSPDiagnostic {
+	const startLine = Math.max(0, (d.startLocation?.line ?? 1) - 1);
+	const startChar = Math.max(0, (d.startLocation?.offset ?? 1) - 1);
+	const endLine = Math.max(
+		0,
+		(d.endLocation?.line ?? d.startLocation?.line ?? 1) - 1,
+	);
+	const endChar = Math.max(
+		0,
+		(d.endLocation?.offset ?? d.startLocation?.offset ?? 1) - 1,
+	);
+	return {
+		severity: tsserverSeverityFromCategory(d.category),
+		message: d.message,
+		range: {
+			start: { line: startLine, character: startChar },
+			end: { line: endLine, character: endChar },
+		},
+		code: d.code,
+		source: "typescript",
+	};
+}
+
+/**
+ * Run a single tsserver sync diagnostic command via the LSP service's
+ * `executeCommand`. Returns the raw diagnostic array from the response body,
+ * or `undefined` if: the service has no `executeCommand`, the command wasn't
+ * executed, the response envelope isn't `{success:true, body:[...]}`, or
+ * any error is thrown.
+ */
+export async function runTsserverSyncCommand(
+	svc: TsserverSyncCapableService,
+	file: string,
+	command: "semanticDiagnosticsSync" | "syntacticDiagnosticsSync",
+): Promise<TsserverSyncRawDiagnostic[] | undefined> {
+	if (typeof svc.executeCommand !== "function") return undefined;
+	const outcome = await svc.executeCommand(file, TSSERVER_REQUEST_COMMAND, [
+		command,
+		{ file, includeLinePosition: true },
+	]);
+	if (!outcome.executed) return undefined;
+	const result = outcome.result as
+		| { success?: boolean; body?: unknown }
+		| undefined;
+	if (!result || result.success !== true || !Array.isArray(result.body)) {
+		return undefined;
+	}
+	return result.body.filter(isTsserverSyncRawDiagnostic);
+}
+
+/**
+ * #611/#707: attempt classic typescript-language-server's
+ * `typescript.tsserverRequest` escape hatch — a genuine synchronous
+ * request/response tsserver command, not push/timing-dependent — to get a
+ * definitive answer for a Tier-3 silent server's empty push-based result.
+ * Runs BOTH `semanticDiagnosticsSync` and `syntacticDiagnosticsSync`
+ * (mirroring what the server itself publishes on a dirty file) so a
+ * syntax-only error isn't missed.
+ *
+ * Returns `undefined` (never throws, never hangs beyond the existing
+ * `executeCommand` anti-deadlock backstop) when: the command isn't advertised
+ * by this server (older/different server/config), `executeCommand` throws
+ * (live-verified case: tsserver rejects with a `ResponseError` — "No
+ * Project." — for a file outside any tsconfig project) or times out, or the
+ * response shape isn't the expected `{success:true, body:[...]}` envelope.
+ * Every one of these must fall through to the existing "unconfirmed" behavior
+ * in the caller.
+ *
+ * `confirmed: true` with an empty `diagnostics` array = genuinely confirmed
+ * clean. `confirmed: true` with a non-empty array = real diagnostics the
+ * server had computed but never published (silentOnClean) — these must be
+ * surfaced to the caller, not discarded. `confirmed: false` = sync path
+ * unavailable, fall through to existing behavior.
+ */
+export async function attemptTsserverSyncDiagnostics(
+	file: string,
+	svc: TsserverSyncCapableService,
+): Promise<LSPDiagnostic[] | undefined> {
+	try {
+		if (typeof svc.getAdvertisedCommands !== "function") return undefined;
+		const advertised = await svc.getAdvertisedCommands(file);
+		if (!advertised.includes(TSSERVER_REQUEST_COMMAND)) return undefined;
+
+		const [semantic, syntactic] = await Promise.all([
+			runTsserverSyncCommand(svc, file, "semanticDiagnosticsSync"),
+			runTsserverSyncCommand(svc, file, "syntacticDiagnosticsSync"),
+		]);
+		if (semantic === undefined || syntactic === undefined) return undefined;
+
+		return [...syntactic, ...semantic].map(tsserverSyncDiagnosticToLsp);
+	} catch {
+		return undefined;
+	}
+}

--- a/tests/clients/lsp/service-tsserver-sync-confirm.test.ts
+++ b/tests/clients/lsp/service-tsserver-sync-confirm.test.ts
@@ -1,0 +1,337 @@
+/**
+ * #707: per-edit path tsserver sync clean-confirm tests.
+ *
+ * When the diagnostics wait for a primary-scope touch times out with an empty
+ * result and the primary server is tier-3-silent (classic typescript-language-
+ * server), `touchFile` must attempt the `typescript.tsserverRequest` escape
+ * hatch before marking the result inconclusive — turning "unconfirmed after
+ * wait budget" into "confirmed clean" (or confirmed with diagnostics) at the
+ * cost of a short sync RTT.
+ *
+ * Tests:
+ *   1. clean TS file — sync returns empty body → confirmed, inconclusive=false
+ *   2. dirty TS file — sync returns diagnostics → confirmed, findings surfaced
+ *   3. non-typescript server — sync never attempted
+ *   4. push arrives before timeout — sync never attempted (not a timeout case)
+ *   5. sync fails (throws) — falls through to inconclusive behavior unchanged
+ *   6. command not advertised — falls through to inconclusive behavior
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Module-level mocks set up BEFORE any imports of the tested module ---
+
+const getServersForFileWithConfig = vi.fn();
+const createLSPClient = vi.fn();
+
+vi.mock("../../../clients/lsp/config.js", () => ({
+	getServersForFileWithConfig,
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../../clients/lsp/client.js", () => ({
+	createLSPClient,
+}));
+
+// Prevent quiet-window registration side-effects in tests
+vi.mock("../../../clients/quiet-window.js", () => ({
+	registerQuietWindowTask: vi.fn(),
+}));
+
+vi.mock("../../../clients/latency-logger.js", () => ({
+	logLatency: vi.fn(),
+}));
+
+vi.mock("../../../clients/widget-state.js", () => ({
+	recordLsp: vi.fn(),
+}));
+
+vi.mock("../../../clients/cascade-logger.js", () => ({
+	logCascade: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FILE = "C:/repo/main.ts";
+
+function makeFakeProcess() {
+	return {
+		process: {
+			killed: false,
+			kill: vi.fn(),
+			on: vi.fn(),
+			removeListener: vi.fn(),
+		},
+		stdin: { on: vi.fn(), off: vi.fn(), write: vi.fn() },
+		stdout: { on: vi.fn(), off: vi.fn(), pipe: vi.fn() },
+		stderr: { on: vi.fn(), off: vi.fn() },
+		pid: 999,
+	};
+}
+
+function makeServer(
+	id: string,
+	extensions: string[] = [".ts"],
+	role?: "language" | "auxiliary",
+) {
+	return {
+		id,
+		name: id,
+		extensions,
+		root: async () => "C:/repo",
+		role,
+		spawn: vi.fn(async () => ({
+			process: makeFakeProcess(),
+			source: "test",
+		})),
+	};
+}
+
+function makeSyncResponse(
+	bodies: Partial<
+		Record<"semanticDiagnosticsSync" | "syntacticDiagnosticsSync", unknown[]>
+	>,
+) {
+	// The CLIENT's executeCommand is called as executeCommand(command, args)
+	// (the service layer strips the filePath before forwarding to the client).
+	return vi
+		.fn()
+		.mockImplementation(async (command: string, args: unknown[]) => {
+			// command is the outer "typescript.tsserverRequest"; first arg element
+			// is the inner tsserver sub-command name.
+			const sub = (args as [string, unknown])[0] as
+				| "semanticDiagnosticsSync"
+				| "syntacticDiagnosticsSync";
+			return {
+				executed: true,
+				result: {
+					success: true,
+					body: bodies[sub] ?? [],
+				},
+			};
+		});
+}
+
+/** A minimal fake LSP client shape that satisfies LSPService's needs for the
+ * primary-scope touchFile path. Callers can override individual methods. */
+function makeClient(overrides: Record<string, unknown> = {}) {
+	return {
+		serverId: "typescript",
+		root: "C:/repo",
+		isAlive: () => true,
+		shutdown: async () => {},
+		getWorkspaceDiagnosticsSupport: () => ({
+			advertised: false,
+			mode: "push-only" as const,
+			diagnosticProviderKind: "none",
+		}),
+		getOperationSupport: () => ({}),
+		getAdvertisedCommands: () => ["typescript.tsserverRequest"],
+		getLaunchVariant: () => undefined, // classic (not native-ts7)
+		getRawCapabilityKeys: () => [],
+		diagnosticsVersion: 0,
+		notify: {
+			open: vi.fn().mockResolvedValue(undefined),
+		},
+		// waitForDiagnostics resolves after a delay to simulate the timeout path.
+		// Default: resolves immediately (no diagnostics will land anyway).
+		waitForDiagnostics: vi.fn().mockResolvedValue(undefined),
+		getDiagnostics: vi.fn(() => []),
+		getAllDiagnostics: () => new Map(),
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("clean TS file: sync returns empty body → confirmed clean, inconclusive=false", async () => {
+		const client = makeClient({
+			executeCommand: makeSyncResponse({}), // empty bodies → clean
+		});
+		createLSPClient.mockResolvedValue(client);
+		getServersForFileWithConfig.mockReturnValue([makeServer("typescript")]);
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		// Use a very short wait so the diagnostics wait times out immediately
+		const result = await service.touchFile(FILE, "const x = 1;\n", {
+			clientScope: "primary",
+			diagnostics: "document",
+			collectDiagnostics: true,
+			// No maxClientWaitMs so spawn doesn't race a timer — only diagnostics wait is capped
+			maxDiagnosticsWaitMs: 1, // effectively zero — times out immediately
+			source: "test-707-clean",
+		});
+
+		expect(result).toBeDefined();
+		expect(result).toEqual([]);
+		// The sync confirm should have cleared the inconclusive flag
+		expect((result as any)?.inconclusive).toBeFalsy();
+	});
+
+	it("dirty TS file: sync returns diagnostics → confirmed with findings, inconclusive=false", async () => {
+		const syncDiag = {
+			message: "Type 'number' is not assignable to type 'string'.",
+			category: "error",
+			code: 2322,
+			startLocation: { line: 1, offset: 5 },
+			endLocation: { line: 1, offset: 10 },
+		};
+		const client = makeClient({
+			executeCommand: makeSyncResponse({ semanticDiagnosticsSync: [syncDiag] }),
+		});
+		createLSPClient.mockResolvedValue(client);
+		getServersForFileWithConfig.mockReturnValue([makeServer("typescript")]);
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		const result = await service.touchFile(FILE, "const x: string = 1;\n", {
+			clientScope: "primary",
+			diagnostics: "document",
+			collectDiagnostics: true,
+			maxDiagnosticsWaitMs: 1,
+			source: "test-707-dirty",
+		});
+
+		expect(result).toBeDefined();
+		expect(result!.length).toBe(1);
+		expect(result![0]?.message).toContain("not assignable to type 'string'");
+		expect((result as any)?.inconclusive).toBeFalsy();
+	});
+
+	it("non-typescript server (gopls): sync is never attempted", async () => {
+		// gopls is push-only but NOT silentOnClean — tier3-silent check won't fire
+		const executeCommand = vi.fn();
+		const client = makeClient({
+			serverId: "gopls",
+			executeCommand,
+			getAdvertisedCommands: () => [], // gopls doesn't advertise tsserverRequest
+			getWorkspaceDiagnosticsSupport: () => ({
+				advertised: false,
+				mode: "push-only" as const,
+				diagnosticProviderKind: "none",
+			}),
+			getLaunchVariant: () => undefined,
+		});
+		createLSPClient.mockResolvedValue(client);
+		getServersForFileWithConfig.mockReturnValue([makeServer("gopls", [".go"])]);
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		const result = await service.touchFile("C:/repo/main.go", "package main\n", {
+			clientScope: "primary",
+			diagnostics: "document",
+			collectDiagnostics: true,
+			maxDiagnosticsWaitMs: 1,
+			source: "test-707-gopls",
+		});
+
+		// gopls is not silentOnClean, so the sync path must not be attempted
+		expect(executeCommand).not.toHaveBeenCalled();
+		// result may be inconclusive (timeout), that's fine — we just verify no sync
+	});
+
+	it("push diagnostics arrive before timeout: sync never attempted", async () => {
+		const executeCommand = vi.fn();
+		const diag = {
+			severity: 1 as const,
+			message: "error from push",
+			range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+		};
+		const client = makeClient({
+			executeCommand,
+			// waitForDiagnostics resolves fast (push arrived)
+			waitForDiagnostics: vi.fn().mockResolvedValue(undefined),
+			getDiagnostics: vi.fn(() => [diag]),
+		});
+		createLSPClient.mockResolvedValue(client);
+		getServersForFileWithConfig.mockReturnValue([makeServer("typescript")]);
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		// Long enough wait that push "arrives" (getDiagnostics returns non-empty)
+		// and the timeout doesn't trigger.
+		const result = await service.touchFile(FILE, "const x: string = 1;\n", {
+			clientScope: "primary",
+			diagnostics: "document",
+			collectDiagnostics: true,
+			maxDiagnosticsWaitMs: 5000, // large — push arrives well within budget
+			source: "test-707-push-wins",
+		});
+
+		// The wait resolves before the budget — no timeout, so no sync call
+		expect(executeCommand).not.toHaveBeenCalled();
+		expect(result).toBeDefined();
+		expect(result!.length).toBeGreaterThan(0);
+	});
+
+	it("sync executeCommand throws: falls through to inconclusive behavior", async () => {
+		const client = makeClient({
+			executeCommand: vi.fn().mockRejectedValue(new Error("No Project.")),
+		});
+		createLSPClient.mockResolvedValue(client);
+		getServersForFileWithConfig.mockReturnValue([makeServer("typescript")]);
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		const result = await service.touchFile(FILE, "const x = 1;\n", {
+			clientScope: "primary",
+			diagnostics: "document",
+			collectDiagnostics: true,
+			maxDiagnosticsWaitMs: 1,
+			source: "test-707-throws",
+		});
+
+		// Sync failed — should be inconclusive (undefined or has inconclusive flag)
+		// Either undefined (no client ready) or an array with inconclusive=true
+		if (result !== undefined) {
+			expect((result as any)?.inconclusive).toBe(true);
+		}
+	});
+
+	it("command not advertised: falls through to inconclusive behavior", async () => {
+		const executeCommand = vi.fn();
+		const client = makeClient({
+			getAdvertisedCommands: () => [], // no tsserverRequest
+			executeCommand,
+		});
+		createLSPClient.mockResolvedValue(client);
+		getServersForFileWithConfig.mockReturnValue([makeServer("typescript")]);
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		const result = await service.touchFile(FILE, "const x = 1;\n", {
+			clientScope: "primary",
+			diagnostics: "document",
+			collectDiagnostics: true,
+			maxDiagnosticsWaitMs: 1,
+			source: "test-707-unadvertised",
+		});
+
+		expect(executeCommand).not.toHaveBeenCalled();
+		if (result !== undefined) {
+			expect((result as any)?.inconclusive).toBe(true);
+		}
+	});
+});

--- a/tests/clients/lsp/service-tsserver-sync-confirm.test.ts
+++ b/tests/clients/lsp/service-tsserver-sync-confirm.test.ts
@@ -1,20 +1,29 @@
 /**
  * #707: per-edit path tsserver sync clean-confirm tests.
  *
- * When the diagnostics wait for a primary-scope touch times out with an empty
- * result and the primary server is tier-3-silent (classic typescript-language-
- * server), `touchFile` must attempt the `typescript.tsserverRequest` escape
- * hatch before marking the result inconclusive — turning "unconfirmed after
- * wait budget" into "confirmed clean" (or confirmed with diagnostics) at the
- * cost of a short sync RTT.
+ * Racing variant: for a tier-3 silent primary (classic typescript-language-
+ * server), `touchFile` races the push wait against a grace-delayed
+ * `typescript.tsserverRequest` sync confirm (grace default 300ms, tunable via
+ * PI_LENS_TSSERVER_SYNC_GRACE_MS) — a clean file resolves at ~grace+RTT
+ * instead of burning the full push-wait budget. An end-of-wait fallback still
+ * covers the case where the race couldn't answer but the wait timed out empty.
  *
- * Tests:
+ * End-of-wait fallback tests (push wait resolves before the grace, so the
+ * race is decided by push and the fallback fires on the timed-out empty
+ * result):
  *   1. clean TS file — sync returns empty body → confirmed, inconclusive=false
  *   2. dirty TS file — sync returns diagnostics → confirmed, findings surfaced
  *   3. non-typescript server — sync never attempted
  *   4. push arrives before timeout — sync never attempted (not a timeout case)
  *   5. sync fails (throws) — falls through to inconclusive behavior unchanged
  *   6. command not advertised — falls through to inconclusive behavior
+ *
+ * Racing tests (grace pinned low via PI_LENS_TSSERVER_SYNC_GRACE_MS):
+ *   a. clean file — sync confirm resolves the touch WELL UNDER the wait budget
+ *   b. push arriving before the grace — no sync request ever goes out
+ *   c. sync failing mid-race — wait runs to its budget, end-of-wait fallback
+ *      still gets its shot (also fails → inconclusive preserved)
+ *   d. dirty-file sync winner — findings surfaced, not discarded
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -153,9 +162,11 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 		vi.resetModules();
 		getServersForFileWithConfig.mockReset();
 		createLSPClient.mockReset();
+		delete process.env.PI_LENS_TSSERVER_SYNC_GRACE_MS;
 	});
 
 	afterEach(() => {
+		delete process.env.PI_LENS_TSSERVER_SYNC_GRACE_MS;
 		vi.restoreAllMocks();
 	});
 
@@ -333,5 +344,166 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 		if (result !== undefined) {
 			expect((result as any)?.inconclusive).toBe(true);
 		}
+	});
+
+	// --- Racing variant (#707 upgrade): the sync confirm races the push wait ---
+
+	describe("racing sync confirm", () => {
+		it("clean file: racing sync confirm resolves the touch WELL UNDER the wait budget", async () => {
+			process.env.PI_LENS_TSSERVER_SYNC_GRACE_MS = "25";
+			const client = makeClient({
+				executeCommand: makeSyncResponse({}), // empty bodies → confirmed clean
+				// Push wait pinned: a silent-on-clean server never publishes on a
+				// clean file, so this wait would run to its full ~1000ms strategy
+				// budget (typescript aggregateWaitMs) if nothing raced it.
+				waitForDiagnostics: vi.fn(() => new Promise(() => {})),
+			});
+			createLSPClient.mockResolvedValue(client);
+			getServersForFileWithConfig.mockReturnValue([makeServer("typescript")]);
+
+			const { LSPService } = await import("../../../clients/lsp/index.js");
+			const service = new LSPService();
+
+			const started = Date.now();
+			const result = await service.touchFile(FILE, "const x = 1;\n", {
+				clientScope: "primary",
+				diagnostics: "document",
+				collectDiagnostics: true,
+				maxDiagnosticsWaitMs: 5000, // budget = min(5000, strategy 1000) = 1000ms
+				source: "test-707-race-clean",
+			});
+			const elapsed = Date.now() - started;
+
+			// The sync confirm answers at ~grace(25ms)+RTT — far below the 1000ms
+			// budget the pinned push wait would otherwise burn in full.
+			expect(elapsed).toBeLessThan(800);
+			expect(result).toBeDefined();
+			expect(result).toEqual([]);
+			expect((result as any)?.inconclusive).toBeFalsy();
+		});
+
+		it("dirty file: racing sync winner surfaces the diagnostics, not discarded", async () => {
+			process.env.PI_LENS_TSSERVER_SYNC_GRACE_MS = "25";
+			const syncDiag = {
+				message: "Cannot find name 'missingSymbol'.",
+				category: "error",
+				code: 2304,
+				startLocation: { line: 3, offset: 1 },
+				endLocation: { line: 3, offset: 14 },
+			};
+			const client = makeClient({
+				executeCommand: makeSyncResponse({
+					semanticDiagnosticsSync: [syncDiag],
+				}),
+				waitForDiagnostics: vi.fn(() => new Promise(() => {})), // push pinned
+			});
+			createLSPClient.mockResolvedValue(client);
+			getServersForFileWithConfig.mockReturnValue([makeServer("typescript")]);
+
+			const { LSPService } = await import("../../../clients/lsp/index.js");
+			const service = new LSPService();
+
+			const started = Date.now();
+			const result = await service.touchFile(FILE, "missingSymbol();\n", {
+				clientScope: "primary",
+				diagnostics: "document",
+				collectDiagnostics: true,
+				maxDiagnosticsWaitMs: 5000,
+				source: "test-707-race-dirty",
+			});
+			const elapsed = Date.now() - started;
+
+			expect(elapsed).toBeLessThan(800);
+			expect(result).toBeDefined();
+			expect(result!.length).toBe(1);
+			expect(result![0]?.message).toContain("Cannot find name");
+			// tsserver 1-based line 3/offset 1 → LSP 0-based line 2/character 0
+			expect(result![0]?.range.start).toEqual({ line: 2, character: 0 });
+			expect((result as any)?.inconclusive).toBeFalsy();
+		});
+
+		it("push arriving before the grace: no sync request ever goes out", async () => {
+			process.env.PI_LENS_TSSERVER_SYNC_GRACE_MS = "40";
+			const executeCommand = vi.fn();
+			const diag = {
+				severity: 1 as const,
+				message: "error from push",
+				range: {
+					start: { line: 0, character: 0 },
+					end: { line: 0, character: 5 },
+				},
+			};
+			const client = makeClient({
+				executeCommand,
+				// Push publishes almost immediately — well before the 40ms grace.
+				waitForDiagnostics: vi.fn(
+					() => new Promise((resolve) => setTimeout(resolve, 5)),
+				),
+				getDiagnostics: vi.fn(() => [diag]),
+			});
+			createLSPClient.mockResolvedValue(client);
+			getServersForFileWithConfig.mockReturnValue([makeServer("typescript")]);
+
+			const { LSPService } = await import("../../../clients/lsp/index.js");
+			const service = new LSPService();
+
+			const result = await service.touchFile(FILE, "const x: string = 1;\n", {
+				clientScope: "primary",
+				diagnostics: "document",
+				collectDiagnostics: true,
+				maxDiagnosticsWaitMs: 5000,
+				source: "test-707-race-push-first",
+			});
+
+			// Wait past the grace so the racer's timer has definitely fired — it
+			// must see the settled push wait and bail without a sync request.
+			await new Promise((resolve) => setTimeout(resolve, 80));
+
+			expect(executeCommand).not.toHaveBeenCalled();
+			expect(result).toBeDefined();
+			expect(result!.length).toBe(1);
+			expect((result as any)?.inconclusive).toBeFalsy();
+		});
+
+		it("sync failing mid-race: wait runs to its budget, end-of-wait fallback fires and inconclusive is preserved", async () => {
+			process.env.PI_LENS_TSSERVER_SYNC_GRACE_MS = "10";
+			const executeCommand = vi
+				.fn()
+				.mockRejectedValue(new Error("No Project."));
+			const client = makeClient({
+				executeCommand,
+				// Push wait respects its per-call timeout — resolves exactly at the
+				// budget, i.e. today's silent-server timeout behavior.
+				waitForDiagnostics: vi.fn(
+					(_file: string, timeoutMs: number) =>
+						new Promise((resolve) => setTimeout(resolve, timeoutMs)),
+				),
+			});
+			createLSPClient.mockResolvedValue(client);
+			getServersForFileWithConfig.mockReturnValue([makeServer("typescript")]);
+
+			const { LSPService } = await import("../../../clients/lsp/index.js");
+			const service = new LSPService();
+
+			const started = Date.now();
+			const result = await service.touchFile(FILE, "const x = 1;\n", {
+				clientScope: "primary",
+				diagnostics: "document",
+				collectDiagnostics: true,
+				maxDiagnosticsWaitMs: 100, // budget = min(100, 1000) = 100ms
+				source: "test-707-race-sync-fails",
+			});
+			const elapsed = Date.now() - started;
+
+			// The failed racing attempt must NOT shorten the wait — the push wait
+			// still ran to its 100ms budget.
+			expect(elapsed).toBeGreaterThanOrEqual(90);
+			// The racing attempt tried (executeCommand called), then the
+			// end-of-wait fallback tried again — both failed, so today's
+			// inconclusive behavior is preserved.
+			expect(executeCommand).toHaveBeenCalled();
+			expect(result).toBeDefined();
+			expect((result as any)?.inconclusive).toBe(true);
+		});
 	});
 });

--- a/tests/clients/lsp/service-tsserver-sync-confirm.test.ts
+++ b/tests/clients/lsp/service-tsserver-sync-confirm.test.ts
@@ -107,7 +107,7 @@ function makeSyncResponse(
 	// (the service layer strips the filePath before forwarding to the client).
 	return vi
 		.fn()
-		.mockImplementation(async (command: string, args: unknown[]) => {
+		.mockImplementation(async (_command: string, args: unknown[]) => {
 			// command is the outer "typescript.tsserverRequest"; first arg element
 			// is the inner tsserver sub-command name.
 			const sub = (args as [string, unknown])[0] as
@@ -247,7 +247,7 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 		const { LSPService } = await import("../../../clients/lsp/index.js");
 		const service = new LSPService();
 
-		const result = await service.touchFile("C:/repo/main.go", "package main\n", {
+		await service.touchFile("C:/repo/main.go", "package main\n", {
 			clientScope: "primary",
 			diagnostics: "document",
 			collectDiagnostics: true,

--- a/tools/lsp-diagnostics.ts
+++ b/tools/lsp-diagnostics.ts
@@ -31,6 +31,9 @@ import {
 import { detectFileRole } from "../clients/file-role.js";
 import type { LSPDiagnostic } from "../clients/lsp/client.js";
 import { classifyCascadeWaitTier } from "../clients/lsp/cascade-tier.js";
+import {
+	attemptTsserverSyncDiagnostics,
+} from "../clients/lsp/tsserver-sync.js";
 import { convertLspDiagnostics } from "../clients/dispatch/utils/lsp-diagnostics.js";
 import { reconcileScanDiagnostics } from "../clients/widget-state.js";
 import { baseName, compactRenderResult } from "./render-compact.js";
@@ -731,145 +734,9 @@ async function classifyEmptyResult(
 	}
 }
 
-// --- #611: tier-3 silent escape hatch (typescript.tsserverRequest sync commands) ---
-
-const TSSERVER_REQUEST_COMMAND = "typescript.tsserverRequest";
-
-interface TsserverSyncRawDiagnostic {
-	message: string;
-	category: string;
-	code?: number;
-	startLocation?: { line: number; offset: number };
-	endLocation?: { line: number; offset: number };
-}
-
-function isTsserverSyncRawDiagnostic(
-	value: unknown,
-): value is TsserverSyncRawDiagnostic {
-	if (!value || typeof value !== "object") return false;
-	const v = value as Record<string, unknown>;
-	return typeof v.message === "string" && typeof v.category === "string";
-}
-
-function tsserverSeverityFromCategory(category: string): 1 | 2 | 3 | 4 {
-	switch (category) {
-		case "error":
-			return 1;
-		case "warning":
-			return 2;
-		case "suggestion":
-			return 4; // Hint
-		default:
-			return 3; // "message" or unrecognized -> Info
-	}
-}
-
-/**
- * Convert a tsserver-protocol sync diagnostic into pi-lens's LSP-shaped
- * `LSPDiagnostic`. Empirically verified live (2026-07,
- * typescript-language-server 5.9.3, this repo's own tsconfig.json as the
- * fixture project): `workspace/executeCommand` with
- * `{command:"typescript.tsserverRequest",
- * arguments:["semanticDiagnosticsSync"|"syntacticDiagnosticsSync",
- * {file, includeLinePosition:true}]}` resolves
- * `{executed:true, result:{seq,type:"response",command,request_seq,success,
- * body:[...]}}`, where each `body` entry is tsserver's NATIVE protocol
- * diagnostic shape — `message`, `category` ("error"|"warning"|"suggestion"),
- * `code`, `startLocation`/`endLocation` as `{line, offset}` — NOT the LSP
- * `Diagnostic` shape, and both `line`/`offset` are 1-based (LSP is 0-based).
- */
-function tsserverSyncDiagnosticToLsp(
-	d: TsserverSyncRawDiagnostic,
-): LSPDiagnostic {
-	const startLine = Math.max(0, (d.startLocation?.line ?? 1) - 1);
-	const startChar = Math.max(0, (d.startLocation?.offset ?? 1) - 1);
-	const endLine = Math.max(
-		0,
-		(d.endLocation?.line ?? d.startLocation?.line ?? 1) - 1,
-	);
-	const endChar = Math.max(
-		0,
-		(d.endLocation?.offset ?? d.startLocation?.offset ?? 1) - 1,
-	);
-	return {
-		severity: tsserverSeverityFromCategory(d.category),
-		message: d.message,
-		range: {
-			start: { line: startLine, character: startChar },
-			end: { line: endLine, character: endChar },
-		},
-		code: d.code,
-		source: "typescript",
-	};
-}
-
-async function runTsserverSyncCommand(
-	lspService: NonNullable<ReturnType<typeof getLSPService>>,
-	file: string,
-	command: "semanticDiagnosticsSync" | "syntacticDiagnosticsSync",
-): Promise<TsserverSyncRawDiagnostic[] | undefined> {
-	const svc = lspService as NonNullable<ReturnType<typeof getLSPService>> & {
-		executeCommand?: (
-			filePath: string | undefined,
-			command: string,
-			args?: unknown[],
-		) => Promise<{ executed: boolean; result?: unknown; reason?: string }>;
-	};
-	if (typeof svc.executeCommand !== "function") return undefined;
-	const outcome = await svc.executeCommand(file, TSSERVER_REQUEST_COMMAND, [
-		command,
-		{ file, includeLinePosition: true },
-	]);
-	if (!outcome.executed) return undefined;
-	const result = outcome.result as
-		| { success?: boolean; body?: unknown }
-		| undefined;
-	if (!result || result.success !== true || !Array.isArray(result.body)) {
-		return undefined;
-	}
-	return result.body.filter(isTsserverSyncRawDiagnostic);
-}
-
-/**
- * #611: attempt classic typescript-language-server's `typescript.tsserverRequest`
- * escape hatch — a genuine synchronous request/response tsserver command, not
- * push/timing-dependent — to get a definitive answer for a Tier-3 silent
- * server's empty push-based result. Runs BOTH `semanticDiagnosticsSync` and
- * `syntacticDiagnosticsSync` (mirroring what the server itself publishes on a
- * dirty file) so a syntax-only error isn't missed.
- *
- * Returns `undefined` (never throws, never hangs beyond the existing
- * `executeCommand` anti-deadlock backstop) when: the command isn't advertised
- * by this server (older/different server/config), `executeCommand` throws
- * (live-verified case: tsserver rejects with a `ResponseError` — "No
- * Project." — for a file outside any tsconfig project) or times out, or the
- * response shape isn't the expected `{success:true, body:[...]}` envelope.
- * Every one of these must fall through to the existing "unconfirmed"
- * behavior in the caller.
- */
-async function attemptTsserverSyncDiagnostics(
-	file: string,
-	lspService: NonNullable<ReturnType<typeof getLSPService>>,
-): Promise<LSPDiagnostic[] | undefined> {
-	try {
-		const svc = lspService as NonNullable<ReturnType<typeof getLSPService>> & {
-			getAdvertisedCommands?: (filePath?: string) => Promise<string[]>;
-		};
-		if (typeof svc.getAdvertisedCommands !== "function") return undefined;
-		const advertised = await svc.getAdvertisedCommands(file);
-		if (!advertised.includes(TSSERVER_REQUEST_COMMAND)) return undefined;
-
-		const [semantic, syntactic] = await Promise.all([
-			runTsserverSyncCommand(lspService, file, "semanticDiagnosticsSync"),
-			runTsserverSyncCommand(lspService, file, "syntacticDiagnosticsSync"),
-		]);
-		if (semantic === undefined || syntactic === undefined) return undefined;
-
-		return [...syntactic, ...semantic].map(tsserverSyncDiagnosticToLsp);
-	} catch {
-		return undefined;
-	}
-}
+// --- #611/#707: tier-3 silent escape hatch (typescript.tsserverRequest sync
+// commands) — implementation extracted to clients/lsp/tsserver-sync.ts and
+// re-used from there by the per-edit dispatch path (#707). ---
 
 /**
  * #611: resolve an EMPTY diagnostic result for a Tier-3 silent server (see


### PR DESCRIPTION
## Summary

- **Extracts** the #611 tsserver-sync helpers (`attemptTsserverSyncDiagnostics`, `runTsserverSyncCommand`, `tsserverSyncDiagnosticToLsp`, `isTsserverSyncRawDiagnostic`, `tsserverSeverityFromCategory`, `TSSERVER_REQUEST_COMMAND`) from `tools/lsp-diagnostics.ts` into a new shared module `clients/lsp/tsserver-sync.ts`. The tool imports from there — zero behavior change on the tool path.
- **Races the sync confirm against the push wait** in `touchFile` (`clients/lsp/index.ts`): for a tier-3 silent primary (classic typescript-language-server), the per-edit diagnostics wait is raced against a grace-delayed `typescript.tsserverRequest` sync confirm. A clean TS file — the dominant per-edit case — resolves at **~grace+RTT (~300-350ms)** instead of burning the full ~1000ms push-wait budget.

## Design: race with grace delay, at the touchFile seam

**Seam at touchFile** (not the dispatch runner): wired inside the diagnostics-wait layer so every consumer (dispatch lsp-runner, pre-dispatch sync, warmup) benefits — not just one runner.

**Eligibility is evaluated once, BEFORE the wait starts**, cheapest gate first:
1. notify write succeeded, `collectDiagnostics`, `clientScope === "primary"`, single server — all synchronous flag checks;
2. `getStrategy(serverId).silentOnClean === true` — synchronous; only classic typescript-language-server carries this flag, so **non-typescript and pull-capable servers pay zero extra work, not even a snapshot read**;
3. `classifyCascadeWaitTier === "tier3-silent"` from the live capability snapshot — also excludes native-ts7 via `launchVariant` (it publishes on clean; #558).

**Race semantics** (grace default **300ms**, tunable via `PI_LENS_TSSERVER_SYNC_GRACE_MS`, read at call time following the `readEnvDiagnosticsWaitMs` pattern):
- Push diagnostics arriving **before the grace elapses** → the sync request never goes out. Zero new latency or requests on the push-answers path.
- **Sync answers first** → that's the confirmed result. Clean (`[]`) or dirty — the sync commands return the file's real syntactic+semantic state, so a dirty-file race win is still correct and its findings are surfaced, never discarded.
- **Sync unavailable/fails mid-race** (not advertised, `ResponseError: No Project.`, bad envelope) → the racer parks on a never-resolving promise; the push wait's own budget decides the race, exactly today's behavior. The racer never rejects, so the losing promise can never surface as an unhandled rejection.
- **End-of-wait fallback kept**: if the race couldn't answer and the wait timed out empty on an eligible touch, the sync confirm gets one last shot before the result is reported inconclusive — turning "unconfirmed after budget" into "confirmed at ~wait+RTT" even on the fallback path.

`raceToCompletion` (aggregation.ts) was considered per the wait-machinery guidance but it's a quality-threshold *collector* (accumulate results until good enough), not a first-winner race — a plain `Promise.race` with a parked-loser convention is the correct primitive here. No other wait restructuring was done (the per-server budget composition is byte-identical, only the `await` moved).

## Contract invariants (same as #611)

- Sync diagnostics on a dirty file are surfaced, not discarded (race winner AND fallback paths).
- Every failure mode falls through to today's exact behavior (inconclusive, full wait).
- No new wait/round-trip for non-typescript or pull-capable servers, or when push diagnostics arrive before the grace.

## Tests

Ten tests in `tests/clients/lsp/service-tsserver-sync-confirm.test.ts`:

**End-of-wait fallback** (6): clean confirm; dirty findings surfaced; non-typescript (gopls) never attempts sync; push-before-timeout never attempts sync; `executeCommand` throws → inconclusive preserved; command unadvertised → inconclusive preserved, no call.

**Racing** (4, grace pinned via env):
- **Clean file resolves WELL UNDER the wait budget**: push wait pinned unresolvable (the true silent-server shape), budget 1000ms, grace 25ms → the touch resolves confirmed-clean with `elapsed < 800ms` asserted (measured ~50ms in the run — vs the full 1000ms burn before).
- Push arriving before the grace → asserted `executeCommand` never called, even after sleeping past the grace timer.
- Sync failing mid-race → wait still runs to its full budget (`elapsed >= 90ms` of a 100ms budget asserted), end-of-wait fallback fires, `inconclusive === true` preserved.
- Dirty-file race winner → 1 finding surfaced with correct 1-based→0-based position conversion, not inconclusive.

Full runs: `lsp-diagnostics.test.ts` (tool, #611 coverage) + all of the above + `service-touch-collect` + `pipeline-lsp-sync` + `cascade-tier` + both sweep debounce tests: **104/104 pass**. `tests/clients/dispatch/`: **553/553 pass**. Two pre-existing environment flakes verified unrelated by running against the pre-change build: the sweep debounce-window tests flake identically under full parallel load (pass in isolation on both builds), and `tree-sitter-skip-test-files.test.ts` has a Windows EPERM temp-dir cleanup issue with all its tests passing.

## Expected latency win

Clean TS edit (the dominant case): from ~1043ms budget-bound (docs/lsp-latency-benchmark.md) to **~grace(300ms)+sync-RTT(<50ms) ≈ 350ms** — roughly **~700ms saved per clean edit**, and the dispatch lsp-runner now returns `status: "succeeded"` (confirmed clean) instead of `status: "skipped"` (inconclusive). Dirty edits are unaffected when the push beats the 300ms grace (typical: ~605ms benchmark), and still correct when it doesn't.

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)