### PR TITLE
feat(lsp): subagent light mode shortens idle reset and skips auxiliary servers

### DIFF
--- a/clients/dispatch/auxiliary-lsp.ts
+++ b/clients/dispatch/auxiliary-lsp.ts
@@ -19,6 +19,7 @@
 
 import type { LSPDiagnostic } from "../lsp/client.js";
 import { shouldDegradeAuxiliaryLsp } from "../lsp-budget.js";
+import { isSubagentSession } from "../subagent-mode.js";
 import type { FileRole } from "../file-role.js";
 import { findLocalOpengrepConfig } from "../opengrep-config.js";
 import { findLocalTyposConfig } from "../typos-config.js";
@@ -200,7 +201,12 @@ export type GetFlag = (flag: string) => boolean | string | undefined;
  * per-file: once over budget, this session never spawns its auxiliary fleet,
  * rather than flip-flopping file to file. */
 export function enabledAuxiliaryLspServerIds(getFlag: GetFlag): string[] {
-	if (shouldDegradeAuxiliaryLsp()) return [];
+	// #449 slice 2 (budget): skip auxiliaries when machine-wide LSP budget is
+	// exceeded. #713 (subagent light mode): reuse the same seam — a subagent
+	// session also skips auxiliaries; the parent session already runs them on
+	// the same cwd. PI_LENS_SUBAGENT_FULL=1 restores full behavior via
+	// isSubagentSession() returning false.
+	if (shouldDegradeAuxiliaryLsp() || isSubagentSession()) return [];
 	return AUXILIARY_LSP_PROFILES.flatMap((p) =>
 		p.enabledByDefault &&
 		!(p.killSwitchFlag && getFlag(p.killSwitchFlag) === true)

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -46,6 +46,7 @@ import { logLatency } from "./latency-logger.js";
 import { updateHeartbeat } from "./instance-registry.js";
 import { emitLensTurnFindings } from "./lens-events.js";
 import { RUNTIME_CONFIG } from "./runtime-config.js";
+import { isSubagentSession } from "./subagent-mode.js";
 import type { RuntimeCoordinator } from "./runtime-coordinator.js";
 import type { TestResult, TestRunnerClient } from "./test-runner-client.js";
 
@@ -203,10 +204,18 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	const files = Object.keys(turnState.files);
 
 	if (files.length === 0) {
-		dbg("turn_end: no modified files, scheduling LSP idle reset (240s)");
+		// #713: subagent sessions use a shorter idle reset (60s) — a short-lived
+		// task agent holding a warm fleet for 4 minutes after its last turn is
+		// pure waste under fan-out. Classify ONCE here so every tick in this call
+		// path shares the same answer. PI_LENS_SUBAGENT_FULL=1 restores 240s via
+		// isSubagentSession() returning false.
+		const idleResetMs = isSubagentSession() ? 60_000 : 240_000;
+		dbg(
+			`turn_end: no modified files, scheduling LSP idle reset (${idleResetMs / 1000}s)`,
+		);
 		if (!getFlag("no-lsp")) {
 			const sessionGeneration = runtime.sessionGeneration;
-			scheduleLSPIdleReset(resetLSPService, 240_000, {
+			scheduleLSPIdleReset(resetLSPService, idleResetMs, {
 				isCurrentSession: () => runtime.isCurrentSession(sessionGeneration),
 				onError: (err) => dbg(`lsp idle reset failed: ${err}`),
 			});

--- a/tests/clients/dispatch/auxiliary-lsp.test.ts
+++ b/tests/clients/dispatch/auxiliary-lsp.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { LSPDiagnostic } from "../../../clients/lsp/client.js";
 import {
 	AUXILIARY_LSP_PROFILES,
@@ -9,6 +9,7 @@ import {
 	retagAuxiliaryDiagnostics,
 } from "../../../clients/dispatch/auxiliary-lsp.js";
 import { convertLspDiagnostics } from "../../../clients/dispatch/utils/lsp-diagnostics.js";
+import { _resetSubagentModeForTests } from "../../../clients/subagent-mode.js";
 
 const diag = (over: Partial<LSPDiagnostic>): LSPDiagnostic =>
 	({
@@ -19,6 +20,14 @@ const diag = (over: Partial<LSPDiagnostic>): LSPDiagnostic =>
 	}) as LSPDiagnostic;
 
 describe("auxiliary LSP enablement", () => {
+	// #713: reset subagent classification between tests so env changes are picked up.
+	beforeEach(() => {
+		_resetSubagentModeForTests();
+	});
+	afterEach(() => {
+		_resetSubagentModeForTests();
+	});
+
 	it("opengrep is default-on (no kill-switch flag set)", () => {
 		const ids = enabledAuxiliaryLspServerIds(() => undefined);
 		expect(ids).toContain("opengrep");
@@ -41,6 +50,51 @@ describe("auxiliary LSP enablement", () => {
 		expect(enabledAuxiliaryLspServerIds((f) => f === "no-typos")).not.toContain(
 			"typos",
 		);
+	});
+
+	// #713: subagent light mode skips all auxiliary servers (same seam as budget
+	// degrade) — parent session already runs them on the same cwd.
+	it("subagent session returns empty auxiliary set (#713)", () => {
+		process.env.PI_SUBAGENT_CHILD = "1";
+		_resetSubagentModeForTests();
+		try {
+			expect(enabledAuxiliaryLspServerIds(() => undefined)).toEqual([]);
+		} finally {
+			delete process.env.PI_SUBAGENT_CHILD;
+			_resetSubagentModeForTests();
+		}
+	});
+
+	it("subagent session skips auxiliaries regardless of kill-switch flags (#713)", () => {
+		process.env.PI_SUBAGENT_CHILD = "1";
+		_resetSubagentModeForTests();
+		try {
+			// Even with no kill switches active, the subagent seam returns empty
+			const ids = enabledAuxiliaryLspServerIds(() => undefined);
+			expect(ids).not.toContain("opengrep");
+			expect(ids).not.toContain("zizmor");
+			expect(ids).not.toContain("typos");
+			expect(ids).toEqual([]);
+		} finally {
+			delete process.env.PI_SUBAGENT_CHILD;
+			_resetSubagentModeForTests();
+		}
+	});
+
+	it("PI_LENS_SUBAGENT_FULL=1 restores auxiliaries inside a subagent session (#713)", () => {
+		process.env.PI_SUBAGENT_CHILD = "1";
+		process.env.PI_LENS_SUBAGENT_FULL = "1";
+		_resetSubagentModeForTests();
+		try {
+			const ids = enabledAuxiliaryLspServerIds(() => undefined);
+			expect(ids).toContain("opengrep");
+			expect(ids).toContain("zizmor");
+			expect(ids).toContain("typos");
+		} finally {
+			delete process.env.PI_SUBAGENT_CHILD;
+			delete process.env.PI_LENS_SUBAGENT_FULL;
+			_resetSubagentModeForTests();
+		}
 	});
 });
 

--- a/tests/index-lsp-idle-reset.test.ts
+++ b/tests/index-lsp-idle-reset.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetSubagentModeForTests } from "../clients/subagent-mode.js";
 import { createPiMock } from "./support/pi-mock.js";
 
 const INTEGRATION_TIMEOUT_MS = 45_000;
@@ -121,6 +122,185 @@ describe("index.ts LSP idle reset", () => {
 			expect(lspStatuses().at(-1)).toBe("LSP Inactive");
 		} finally {
 			vi.useRealTimers();
+		}
+	}, INTEGRATION_TIMEOUT_MS);
+
+	// #713: subagent light mode uses a shorter idle reset (60s instead of 240s).
+	it("subagent session fires the idle reset at 60s, not 240s (#713)", async () => {
+		process.env.PI_SUBAGENT_CHILD = "1";
+		_resetSubagentModeForTests();
+
+		try {
+			const resetLSPService = vi.fn();
+			vi.doMock("../clients/lsp/index.js", () => ({
+				getLSPService: () => ({
+					touchFile: vi.fn(),
+					getAliveClientCount: () => 0,
+					getAliveServerIds: () => [],
+				}),
+				resetLSPService,
+			}));
+			vi.doMock("../clients/bootstrap.js", () => ({
+				loadBootstrapClients: async () => ({
+					knipClient: { isAvailable: () => false },
+					depChecker: { isAvailable: () => false },
+					testRunnerClient: { detectRunner: () => null },
+				}),
+			}));
+
+			const { default: registerExtension } = await import("../index.ts");
+			const { pi, handlers } = createMockPi({ "no-lsp": false });
+			registerExtension(pi);
+
+			const turnEnd = handlers.turn_end?.[0];
+			expect(turnEnd).toBeTypeOf("function");
+
+			const ctx = {
+				cwd: tmpDir,
+				ui: {
+					notify: vi.fn(),
+					setStatus: vi.fn(),
+					theme: { fg: (_color: string, text: string) => text },
+				},
+			};
+
+			vi.useFakeTimers();
+			try {
+				await turnEnd?.({}, ctx);
+
+				// Should NOT fire at 59 seconds
+				await vi.advanceTimersByTimeAsync(59_000);
+				expect(resetLSPService).not.toHaveBeenCalled();
+
+				// Should fire at exactly 60 seconds
+				await vi.advanceTimersByTimeAsync(1_000);
+				expect(resetLSPService).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		} finally {
+			delete process.env.PI_SUBAGENT_CHILD;
+			_resetSubagentModeForTests();
+		}
+	}, INTEGRATION_TIMEOUT_MS);
+
+	it("normal (non-subagent) session still uses 240s idle reset (#713)", async () => {
+		// Ensure no subagent env vars are set
+		delete process.env.PI_SUBAGENT_CHILD;
+		delete process.env.PI_SUBAGENT_CHILD_AGENT;
+		delete process.env.PI_SUBAGENT_PARENT_PID;
+		_resetSubagentModeForTests();
+
+		const resetLSPService = vi.fn();
+		vi.doMock("../clients/lsp/index.js", () => ({
+			getLSPService: () => ({
+				touchFile: vi.fn(),
+				getAliveClientCount: () => 0,
+				getAliveServerIds: () => [],
+			}),
+			resetLSPService,
+		}));
+		vi.doMock("../clients/bootstrap.js", () => ({
+			loadBootstrapClients: async () => ({
+				knipClient: { isAvailable: () => false },
+				depChecker: { isAvailable: () => false },
+				testRunnerClient: { detectRunner: () => null },
+			}),
+		}));
+
+		const { default: registerExtension } = await import("../index.ts");
+		const { pi, handlers } = createMockPi({ "no-lsp": false });
+		registerExtension(pi);
+
+		const turnEnd = handlers.turn_end?.[0];
+		expect(turnEnd).toBeTypeOf("function");
+
+		const ctx = {
+			cwd: tmpDir,
+			ui: {
+				notify: vi.fn(),
+				setStatus: vi.fn(),
+				theme: { fg: (_color: string, text: string) => text },
+			},
+		};
+
+		vi.useFakeTimers();
+		try {
+			await turnEnd?.({}, ctx);
+
+			// Should NOT fire at 60s (subagent threshold)
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(resetLSPService).not.toHaveBeenCalled();
+
+			// Should NOT fire at 239s
+			await vi.advanceTimersByTimeAsync(179_000);
+			expect(resetLSPService).not.toHaveBeenCalled();
+
+			// Should fire at 240s
+			await vi.advanceTimersByTimeAsync(1_000);
+			expect(resetLSPService).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	}, INTEGRATION_TIMEOUT_MS);
+
+	it("PI_LENS_SUBAGENT_FULL=1 restores 240s idle reset even in a subagent session (#713)", async () => {
+		process.env.PI_SUBAGENT_CHILD = "1";
+		process.env.PI_LENS_SUBAGENT_FULL = "1";
+		_resetSubagentModeForTests();
+
+		try {
+			const resetLSPService = vi.fn();
+			vi.doMock("../clients/lsp/index.js", () => ({
+				getLSPService: () => ({
+					touchFile: vi.fn(),
+					getAliveClientCount: () => 0,
+					getAliveServerIds: () => [],
+				}),
+				resetLSPService,
+			}));
+			vi.doMock("../clients/bootstrap.js", () => ({
+				loadBootstrapClients: async () => ({
+					knipClient: { isAvailable: () => false },
+					depChecker: { isAvailable: () => false },
+					testRunnerClient: { detectRunner: () => null },
+				}),
+			}));
+
+			const { default: registerExtension } = await import("../index.ts");
+			const { pi, handlers } = createMockPi({ "no-lsp": false });
+			registerExtension(pi);
+
+			const turnEnd = handlers.turn_end?.[0];
+			expect(turnEnd).toBeTypeOf("function");
+
+			const ctx = {
+				cwd: tmpDir,
+				ui: {
+					notify: vi.fn(),
+					setStatus: vi.fn(),
+					theme: { fg: (_color: string, text: string) => text },
+				},
+			};
+
+			vi.useFakeTimers();
+			try {
+				await turnEnd?.({}, ctx);
+
+				// Escape hatch: should NOT fire at 60s
+				await vi.advanceTimersByTimeAsync(60_000);
+				expect(resetLSPService).not.toHaveBeenCalled();
+
+				// Should fire at 240s (full behavior restored)
+				await vi.advanceTimersByTimeAsync(180_000);
+				expect(resetLSPService).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		} finally {
+			delete process.env.PI_SUBAGENT_CHILD;
+			delete process.env.PI_LENS_SUBAGENT_FULL;
+			_resetSubagentModeForTests();
 		}
 	}, INTEGRATION_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Summary

- **Shorter LSP idle reset in subagent sessions**: `clients/runtime-turn.ts` now classifies the session once per `turn_end` via `isSubagentSession()` and uses 60 s in subagent sessions vs 240 s for normal sessions. `PI_LENS_SUBAGENT_FULL=1` restores 240 s.
- **Skip auxiliary LSP servers in subagent sessions**: reused the existing budget-degrade seam in `clients/dispatch/auxiliary-lsp.ts` — `enabledAuxiliaryLspServerIds()` now returns `[]` when `shouldDegradeAuxiliaryLsp() || isSubagentSession()`. No parallel mechanism added. Primary per-edit diagnostics are completely unaffected.

## Test plan

- [ ] `tests/index-lsp-idle-reset.test.ts` — 3 new cases: subagent fires at 60 s, normal session still 240 s, `PI_LENS_SUBAGENT_FULL=1` restores 240 s
- [ ] `tests/clients/dispatch/auxiliary-lsp.test.ts` — 3 new cases: subagent returns empty auxiliary set, kill-switch flags irrelevant under subagent light mode, `PI_LENS_SUBAGENT_FULL=1` restores full auxiliary set
- [ ] All 4 idle-reset tests pass; all 34 auxiliary-lsp tests pass
- [ ] Build (`npm run build`) and lint (`npm run lint`) clean

Closes #713
Refs #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)