### PR TITLE
test: fix ENOTEMPTY teardown flake in lens-map.test.ts

### DIFF
--- a/tests/clients/lens-map.test.ts
+++ b/tests/clients/lens-map.test.ts
@@ -615,7 +615,14 @@ describe("generateLensMap", () => {
 	afterEach(() => {
 		if (previousDataDir === undefined) delete process.env.PILENS_DATA_DIR;
 		else process.env.PILENS_DATA_DIR = previousDataDir;
-		fs.rmSync(tmpDir, { recursive: true, force: true });
+		// Retry cleanup: generateLensMap can still be flushing writes into the
+		// data dir when afterEach runs, which surfaces as ENOTEMPTY on Linux.
+		fs.rmSync(tmpDir, {
+			recursive: true,
+			force: true,
+			maxRetries: 5,
+			retryDelay: 100,
+		});
 	});
 
 	it("writes a self-contained HTML file under the project data dir's reports/ folder", async () => {


### PR DESCRIPTION
Master went red on the #728 merge (Unit tests, ubuntu): `ENOTEMPTY: directory not empty, rmdir` during `afterEach` cleanup in `tests/clients/lens-map.test.ts`. This is a teardown race — `generateLensMap` can still be flushing async writes into the per-project data dir when `rmSync` runs — not a regression from the pi-tui bump.

Fix: use `rmSync`'s built-in `maxRetries`/`retryDelay`, which exist for exactly this error class (ENOTEMPTY/EBUSY/EPERM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)