### PR TITLE
ci(security): pin installers, verify mise, guard curl protos (closes #731)

### DIFF
--- a/.github/workflows/compat-smoke.yml
+++ b/.github/workflows/compat-smoke.yml
@@ -72,7 +72,9 @@ jobs:
       - name: Install pi
         run: |
           set -uxo pipefail
-          npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+          # Pinned deliberately (bump by hand when a newer pi release is
+          # verified — see #731).
+          npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.10
           echo "$(npm prefix -g)/bin" >> "$GITHUB_PATH"
 
       - name: Layer A — pinned-contract verification (no pi, no LLM)

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -84,7 +84,7 @@ jobs:
         shell: bash
         # --ignore-scripts: yarn's own postinstall isn't needed for the classic
         # CLI to function as the package manager under test.
-        run: npm i -g --ignore-scripts yarn@1
+        run: npm i -g --ignore-scripts yarn@1.22.22
 
       - name: Build + pack the current repo
         shell: bash

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -82,12 +82,17 @@ jobs:
       - name: Setup yarn (classic — hoists to node_modules like npm)
         if: matrix.pm == 'yarn'
         shell: bash
-        run: npm i -g yarn@1
+        # --ignore-scripts: yarn's own postinstall isn't needed for the classic
+        # CLI to function as the package manager under test.
+        run: npm i -g --ignore-scripts yarn@1
 
       - name: Build + pack the current repo
         shell: bash
         run: |
           set -euxo pipefail
+          # No --ignore-scripts here (S6505): this `npm ci` is OUR OWN package's
+          # install — the `prepare` script (grammar download + dist build) must
+          # run for the pack below to emit a working tarball.
           npm ci
           # prepare script builds dist; pack emits a tarball of the real files[] set.
           # `npm pack --silent` prints ONLY the tarball name to stdout — but the
@@ -164,7 +169,10 @@ jobs:
         shell: bash
         run: |
           set -uxo pipefail
-          PKG="@earendil-works/pi-coding-agent"
+          # Pinned deliberately (bump by hand when a newer pi release is
+          # verified — see #731): keeps a token-bearing CI job from pulling an
+          # arbitrary newest-on-registry version of a third-party package.
+          PKG="@earendil-works/pi-coding-agent@0.80.10"
           case "${{ matrix.pi_install }}" in
             npm-global)
               npm install -g --ignore-scripts "$PKG"
@@ -176,7 +184,9 @@ jobs:
               export PNPM_HOME="$HOME/.pnpm-global"; mkdir -p "$PNPM_HOME"
               export PATH="$PNPM_HOME:$PATH"
               pnpm config set global-bin-dir "$PNPM_HOME"
-              pnpm add -g "$PKG" || echo "::notice::pnpm add -g exit $? (blocked scripts?)"
+              # --ignore-scripts: pi's own lifecycle scripts aren't needed for
+              # this smoke test (same as the npm-global case above).
+              pnpm add -g --ignore-scripts "$PKG" || echo "::notice::pnpm add -g exit $? (blocked scripts?)"
               echo "$PNPM_HOME" >> "$GITHUB_PATH"
               echo "NPMCMD=pnpm" >> "$GITHUB_ENV" ;;
             bun-global)
@@ -188,7 +198,7 @@ jobs:
             curl)
               # Download then run (no pipe → no SIGPIPE/pipefail abort); the
               # installer ultimately `npm install -g`s pi when Node is present.
-              curl -fsSL --retry 3 --retry-delay 2 https://pi.dev/install.sh -o "$RUNNER_TEMP/pi-install.sh"
+              curl --proto '=https' --tlsv1.2 -fsSL --retry 3 --retry-delay 2 https://pi.dev/install.sh -o "$RUNNER_TEMP/pi-install.sh"
               sh "$RUNNER_TEMP/pi-install.sh" < /dev/null || echo "::notice::installer exit $? (verifying pi next)"
               echo "$(npm prefix -g)/bin" >> "$GITHUB_PATH"
               echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -252,11 +262,28 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7 # RPC driver
 
-      - name: Install mise
+      - name: Install mise (pinned + checksum-verified)
         shell: bash
+        env:
+          # Pinned deliberately (bump by hand after checking
+          # https://github.com/jdx/mise/releases and recomputing the sha256
+          # below — see #731): avoids `curl | sh`-ing an unpinned, unverified
+          # installer script straight off the network.
+          MISE_INSTALL_VERSION: v2026.7.7
+          MISE_INSTALL_SHA256: 0b98c2dc48edc807be860a76e14209afcfe36684c591f92337c5d9ff909e7740
         run: |
           set -uxo pipefail
-          curl -fsSL https://mise.run | sh
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            -o "$RUNNER_TEMP/mise-install.sh" \
+            "https://github.com/jdx/mise/releases/download/${MISE_INSTALL_VERSION}/install.sh"
+          # sha256sum (Linux) vs shasum -a 256 (macOS default) — both runner
+          # images ship one or the other; prefer sha256sum when present.
+          if command -v sha256sum >/dev/null 2>&1; then
+            echo "${MISE_INSTALL_SHA256}  $RUNNER_TEMP/mise-install.sh" | sha256sum -c -
+          else
+            echo "${MISE_INSTALL_SHA256}  $RUNNER_TEMP/mise-install.sh" | shasum -a 256 -c -
+          fi
+          sh "$RUNNER_TEMP/mise-install.sh"
           # Expose the mise binary AND its shim dir so later steps see the
           # mise-managed node/npm/pnpm/pi as shims (realpath-through-shim = the
           # #285 trigger). No `mise activate` — that PATH-injects the real bins and
@@ -281,7 +308,9 @@ jobs:
         shell: bash
         run: |
           set -uxo pipefail
-          npm install -g pnpm
+          # Pinned deliberately (bump by hand — see #731): avoids an
+          # unpinned global install pulling an arbitrary newest pnpm.
+          npm install -g --ignore-scripts pnpm@11.15.1
           mise reshim
           pnpm --version
 
@@ -289,7 +318,9 @@ jobs:
         shell: bash
         run: |
           set -uxo pipefail
-          PKG="@earendil-works/pi-coding-agent"
+          # Pinned deliberately (bump by hand when a newer pi release is
+          # verified — see #731).
+          PKG="@earendil-works/pi-coding-agent@0.80.10"
           case "${{ matrix.pi_via }}" in
             mise-node)
               # node from mise; pi as a plain npm-global under that node.


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/*.yml` per SonarCloud's 34 new-code vulnerability findings (issue #731, 4 rules):

- **S8482 (BLOCKER) — `curl | sh` for mise** (`install-smoke.yml`, mise-repro job): replaced `curl -fsSL https://mise.run | sh` with a pinned, integrity-checked install. Downloads `install.sh` from a specific pinned mise release tag (`v2026.7.7`) to a file, verifies it against a sha256 recorded in the workflow (computed once, checked on every run — TOFU with drift detection), then executes it. mise's own installer already embeds per-arch static checksums for the binary it downloads, so this closes the remaining gap (the installer script itself being fetched-and-executed unverified). Behavior preserved: mise still ends up on `PATH` the same way.

- **S8543 (MAJOR x4) — unpinned global installs of `@earendil-works/pi-coding-agent` / `pnpm`** in token-bearing jobs: pinned to the current latest verified versions —
  - `@earendil-works/pi-coding-agent@0.80.10` (compat-smoke.yml, install-smoke.yml pi-load + mise-repro jobs — pinned once at each `PKG=` assignment so every consumer, npm/pnpm/bun, inherits the pin)
  - `pnpm@11.15.1` (install-smoke.yml mise-repro job's "Install pnpm (the npmCommand) under mise node" step)
  
  Each pin has a comment noting it's deliberate and should be bumped by hand after verifying a newer release (per the issue's "keep drift-detection via a scheduled bump" guidance).

- **S6506 (MAJOR x2) — curl without an explicit TLS floor**: added `--proto '=https' --tlsv1.2` to the `pi.dev/install.sh` curl and the new mise-installer curl.

- **S6505 (MAJOR x16) — `--ignore-scripts` where lifecycle scripts aren't needed**:
  - `npm i -g yarn@1` → added `--ignore-scripts`
  - `pnpm add -g "$PKG"` (pi-coding-agent, pnpm-global case) → added `--ignore-scripts`, consistent with the npm-global case which already had it
  - `npm install -g pnpm` (mise-repro job) → added `--ignore-scripts`
  - `npm ci` (Build + pack the current repo step) → **left unchanged**, with a comment explaining why: this builds pi-lens's own package, whose `prepare` script (grammar download + dist build) must run for `npm pack` to emit a working tarball.
  - `pnpm add -g "$PKG"` was re-checked against the actual code: it installs `@earendil-works/pi-coding-agent`, not the packed pi-lens tarball (the pi-lens tarball install is a separate, untouched step earlier in the `smoke` job), so no lifecycle-script dependency concern applied.

## Not touched (per the issue's own assessment)

The remaining 12 S8543 findings, on this repo's own lockfile-governed `npm install --no-audit --no-fund` / `npm ci` steps, are dismissed as **false positives** — those installs must run pi-lens's own `prepare` script (grammar download + dist build) and are pinned by `package-lock.json`. Per the issue, these are being dismissed directly in the SonarCloud UI, not changed here.

## Validation

- `npx yaml-lint` passed on both modified workflow files.
- `actionlint` was not available in this environment; skipped per the task instructions.

## Test plan

- [ ] Let the pinned `install-smoke.yml` / `compat-smoke.yml` workflows run (scheduled/nightly or `workflow_dispatch`) and confirm all matrix cells still go green with the pinned versions and the new mise install path.
- [ ] Re-scan with SonarCloud and confirm the 5 addressed findings (S8482 x1, S8543 x4 in scope, S6506 x2, S6505 x4) clear, and dismiss the 12 false-positive S8543 findings in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)