### PR TITLE
fix(tool-policy): detect oxlint.config.ts/.mts and .oxlintrc.jsonc (closes #745)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`hasOxlintConfig` now detects `.oxlintrc.jsonc`, `oxlint.config.ts`, and `oxlint.config.mts`** (closes #745) — previously only `.oxlintrc.json`/`oxlint.json` were recognized, so projects using oxlint's TS-based config format (`oxlint.config.ts` + `defineConfig`) or the `.oxlintrc.jsonc` variant were treated as having no oxlint config at all, causing `getPreferredJstsLintRunners` to fall back to `["oxlint", "biome-check-json"]` instead of `["oxlint"]` and run `biome-check-json` as an uninvited fallback linter. New `OXLINT_CONFIGS` list (mirroring the existing `ESLINT_CONFIGS` pattern) covers all four oxlint-documented auto-discovery filenames alongside the legacy `oxlint.json` name.
+
 ## [3.8.71] - 2026-07-20
 
 ### Added

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -2252,13 +2252,22 @@ export function hasVitePlusConfig(cwd: string): boolean {
 	return false;
 }
 
+// Per https://oxc.rs/docs/guide/usage/linter/config.html, oxlint auto-discovers
+// `.oxlintrc.json`, `.oxlintrc.jsonc`, `oxlint.config.ts`, and `oxlint.config.mts`
+// (in addition to the legacy `oxlint.json` name pi-lens already recognized).
+const OXLINT_CONFIGS = [
+	".oxlintrc.json",
+	".oxlintrc.jsonc",
+	"oxlint.json",
+	"oxlint.config.ts",
+	"oxlint.config.mts",
+];
+
 export function hasOxlintConfig(cwd: string): boolean {
 	for (const dir of walkUpDirsUntilPackageJson(cwd)) {
-		if (
-			fs.existsSync(path.join(dir, ".oxlintrc.json")) ||
-			fs.existsSync(path.join(dir, "oxlint.json"))
-		)
-			return true;
+		for (const cfg of OXLINT_CONFIGS) {
+			if (fs.existsSync(path.join(dir, cfg))) return true;
+		}
 	}
 	return hasVitePlusConfig(cwd);
 }

--- a/tests/clients/tool-policy.test.ts
+++ b/tests/clients/tool-policy.test.ts
@@ -729,6 +729,50 @@ describe("tool-policy", () => {
 		}
 	});
 
+	it("hasOxlintConfig detects .oxlintrc.jsonc in a parent directory", () => {
+		const env = setupTestEnvironment("pi-lens-tool-policy-oxlint-jsonc-walkup-");
+		try {
+			createTempFile(env.tmpDir, ".oxlintrc.jsonc", "{\n// comment\n}\n");
+			const subDir = path.join(env.tmpDir, "src");
+			fs.mkdirSync(subDir, { recursive: true });
+			expect(hasOxlintConfig(subDir)).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("hasOxlintConfig detects oxlint.config.ts in a parent directory", () => {
+		const env = setupTestEnvironment("pi-lens-tool-policy-oxlint-config-ts-walkup-");
+		try {
+			createTempFile(
+				env.tmpDir,
+				"oxlint.config.ts",
+				'import { defineConfig } from "oxlint";\nexport default defineConfig({});\n',
+			);
+			const subDir = path.join(env.tmpDir, "src");
+			fs.mkdirSync(subDir, { recursive: true });
+			expect(hasOxlintConfig(subDir)).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("hasOxlintConfig detects oxlint.config.mts in a parent directory", () => {
+		const env = setupTestEnvironment("pi-lens-tool-policy-oxlint-config-mts-walkup-");
+		try {
+			createTempFile(
+				env.tmpDir,
+				"oxlint.config.mts",
+				'import { defineConfig } from "oxlint";\nexport default defineConfig({});\n',
+			);
+			const subDir = path.join(env.tmpDir, "src");
+			fs.mkdirSync(subDir, { recursive: true });
+			expect(hasOxlintConfig(subDir)).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("detects Vite+ as oxfmt/oxlint project configuration", () => {
 		const env = setupTestEnvironment("pi-lens-tool-policy-vite-plus-");
 		try {


### PR DESCRIPTION
Closes #745.

## What

`hasOxlintConfig()` in `clients/tool-policy.ts` only recognized `.oxlintrc.json` and `oxlint.json`, missing the full set oxlint auto-discovers (https://oxc.rs/docs/guide/usage/linter/config.html).

## Approach

Added an `OXLINT_CONFIGS` filename list (mirrors the existing `ESLINT_CONFIGS` pattern) covering all 4 oxlint-documented filenames plus the legacy `oxlint.json` name.

## Testing

- 3 new test cases in `tests/clients/tool-policy.test.ts` (`.oxlintrc.jsonc`, `oxlint.config.ts`, `oxlint.config.mts`, each via parent-directory walk-up)

## Checklist

- [x] Focused diff, clear purpose
- [x] New logic has tests
- [x] `npm run lint` passes
- [x] `npm test` passes (see note above on pre-existing unrelated flake)
- [x] Commit subject includes `(closes #745)`

