### PR TITLE
chore(deps): fix high npm audit advisories (brace-expansion, js-yaml)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,7 +1115,7 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "./dist/cli.js"
+				"pi-ai": "dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
@@ -3179,9 +3179,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -3352,9 +3352,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"funding": [
 				{
 					"type": "github",


### PR DESCRIPTION
Two high-severity advisories published today fail the `npm audit --omit=dev --audit-level=high` step of **Lint & type-check** on every branch (e.g. it's what's red on #749 and was red on #746's run):

- `brace-expansion` — DoS via exponential-time expansion (GHSA-3jxr-9vmj-r5cp) → 5.0.6 → **5.0.7**
- `js-yaml` — quadratic CPU via YAML merge-key chains (GHSA-52cp-r559-cp3m) → 4.2.0 → **4.3.0**

Plain `npm audit fix` patch bumps, lockfile only. Verified locally: `npm audit --omit=dev --audit-level=high` → 0 vulnerabilities, `npm run check:lockfile` ✓, build ✓.

Note: two advisories remain nested under `@earendil-works/pi-coding-agent`'s own `node_modules` (dev-only, not gated by CI) — they need an upstream pi-coding-agent release, not an override here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)