### PR TITLE
chore: add recent contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -784,6 +784,80 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "ymek",
+      "name": "Myke Stubbs",
+      "avatar_url": "https://avatars.githubusercontent.com/u/300569?v=4",
+      "profile": "https://github.com/ymek",
+      "contributions": [
+        "code",
+        "bug"
+      ]
+    },
+    {
+      "login": "black-snow",
+      "name": "Ronald",
+      "avatar_url": "https://avatars.githubusercontent.com/u/579733?v=4",
+      "profile": "https://github.com/black-snow",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
+      "login": "JSap0914",
+      "name": "JSap0914",
+      "avatar_url": "https://avatars.githubusercontent.com/u/116227558?v=4",
+      "profile": "https://github.com/JSap0914",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "AngriestBird",
+      "name": "Kenneth McCormick",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12663269?v=4",
+      "profile": "https://github.com/AngriestBird",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
+      "login": "knthmn",
+      "name": "Kent Hou Man",
+      "avatar_url": "https://avatars.githubusercontent.com/u/60438008?v=4",
+      "profile": "https://github.com/knthmn",
+      "contributions": [
+        "code",
+        "bug"
+      ]
+    },
+    {
+      "login": "aaronkyriesenbach",
+      "name": "Aaron Ky-Riesenbach",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12665860?v=4",
+      "profile": "https://github.com/aaronkyriesenbach",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
+      "login": "LovelyLoong",
+      "name": "可爱的龙",
+      "avatar_url": "https://avatars.githubusercontent.com/u/54889641?v=4",
+      "profile": "https://github.com/LovelyLoong",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
+      "login": "pppobear",
+      "name": "pppobear",
+      "avatar_url": "https://avatars.githubusercontent.com/u/21952175?v=4",
+      "profile": "https://github.com/pppobear",
+      "contributions": [
+        "bug"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ Thanks goes to these wonderful people:
       <td align="center" valign="top" width="14.28%"><a href="https://eisterman.dev/"><img src="https://avatars.githubusercontent.com/u/3028953?v=4" width="100px;" alt=""/><br /><sub><b>Federico Pasqua</b></sub></a><br /><a href="#bug-eisterman" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ymek"><img src="https://avatars.githubusercontent.com/u/300569?v=4" width="100px;" alt=""/><br /><sub><b>Myke Stubbs</b></sub></a><br /><a href="#code-ymek" title="Code">💻</a> <a href="#bug-ymek" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/black-snow"><img src="https://avatars.githubusercontent.com/u/579733?v=4" width="100px;" alt=""/><br /><sub><b>Ronald</b></sub></a><br /><a href="#bug-black-snow" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/JSap0914"><img src="https://avatars.githubusercontent.com/u/116227558?v=4" width="100px;" alt=""/><br /><sub><b>JSap0914</b></sub></a><br /><a href="#code-JSap0914" title="Code">💻</a></td>
+    </tr><br />
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/AngriestBird"><img src="https://avatars.githubusercontent.com/u/12663269?v=4" width="100px;" alt=""/><br /><sub><b>Kenneth McCormick</b></sub></a><br /><a href="#bug-AngriestBird" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/knthmn"><img src="https://avatars.githubusercontent.com/u/60438008?v=4" width="100px;" alt=""/><br /><sub><b>Kent Hou Man</b></sub></a><br /><a href="#code-knthmn" title="Code">💻</a> <a href="#bug-knthmn" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/aaronkyriesenbach"><img src="https://avatars.githubusercontent.com/u/12665860?v=4" width="100px;" alt=""/><br /><sub><b>Aaron Ky-Riesenbach</b></sub></a><br /><a href="#bug-aaronkyriesenbach" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/LovelyLoong"><img src="https://avatars.githubusercontent.com/u/54889641?v=4" width="100px;" alt=""/><br /><sub><b>可爱的龙</b></sub></a><br /><a href="#bug-LovelyLoong" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/pppobear"><img src="https://avatars.githubusercontent.com/u/21952175?v=4" width="100px;" alt=""/><br /><sub><b>pppobear</b></sub></a><br /><a href="#bug-pppobear" title="Bug reports">🐛</a></td>
     </tr>
 </tbody>
 </table>


### PR DESCRIPTION
## What
Updates `.all-contributorsrc` and the generated README contributors table with contributors missed by recent updates.

## Approach
- Cross-checked recently merged PRs and closed issues (via `gh pr list` / `gh issue list`) against the `contributors` array in `.all-contributorsrc`.
- Added new contributors:
  - **JSap0914** — `code` (PR #759, closes #758)
  - **AngriestBird** — `bug` (reported #758)
  - **knthmn** — `code`, `bug` (reported #745, fixed via PR #746)
  - **aaronkyriesenbach** — `bug` (reported #699)
  - **LovelyLoong** — `bug` (reported #637)
  - **pppobear** — `bug` (reported #622)
- Found that **ymek** and **black-snow** were already present in the generated README table (from an earlier hand-edit or partial sync) but missing from `.all-contributorsrc`, the source of truth — backfilled both there with the contribution types the README already showed (`ymek`: code+bug, `black-snow`: bug), so the two files are back in sync.
- Regenerated the table with `npx all-contributors-cli generate`, which is safe here since the custom `wrapperTemplate`/`rowTemplate` in `.all-contributorsrc` only appended new `<td>` cells — no reformatting of existing rows.
- No CHANGELOG entry: checked `git log --oneline -- .all-contributorsrc` and none of the prior contributor-list updates touched CHANGELOG.md.

## Testing
- `node -e "JSON.parse(...)"` — validated `.all-contributorsrc` is well-formed JSON.
- `npm run lint` (tsc) — passes, unaffected as expected.
- Manually diffed README.md: only new `<td>` cells were appended; the `<!-- ALL-CONTRIBUTORS-LIST:START -->` section still goes straight from `<table>`/`<tbody>` to the first populated `<tr>` with no blank lines or stray elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)