### PR TITLE
fix(config): mutation-control follow-ups — global autofix parity, MCP call-site cwd, shared parser, skip provenance (#792)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- mutation-control config follow-ups (#792): global `autofix.enabled` now honored (docs promised it, code ignored it), the MCP LSP-navigation tool now resolves project config from the request cwd, global+project config share one `{enabled}` parser with warn-once on invalid values, and mutation-skip debug lines name the deciding config source
+
 - deferred auto-format queue: records are now owned by the queuing session/turn — a read-only or concurrent-secondary subagent turn no longer flushes and formats another turn's pending files (#791)
 
 - compat-smoke behavioral harness: scratch-dir cleanup crash (ENOTEMPTY race) no longer discards assertion results and falsely reports Layer B contract drift (#785)

--- a/clients/config-enabled-shape.ts
+++ b/clients/config-enabled-shape.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared parser for the `{ enabled?: boolean }` shape used by BOTH the global
+ * config (`clients/lens-config.ts`, `~/.pi-lens/config.json`) and the project
+ * config (`clients/project-lens-config.ts`, `.pi-lens.json`) for their
+ * mutation-control keys (`format`, `autofix`, `actionableWarnings.autoFix`).
+ *
+ * Extracted (#792) so both loaders parse and warn on the identical shape
+ * identically instead of two independent hand-rolled implementations that had
+ * diverged in strictness — project warned on invalid `enabled` values via its
+ * own `warnInvalidConfigOnce`, global silently dropped them. This module has
+ * no dependency on either config module (avoids an import cycle) — callers
+ * supply their own `warnInvalid` callback so each config keeps its own
+ * warn-once plumbing (keyed by its own config path).
+ */
+
+export interface EnabledConfigShape {
+	/** Whether this mutation path is enabled. */
+	enabled?: boolean;
+}
+
+/**
+ * Parse a raw `{ enabled?: boolean }` value.
+ *
+ * - `undefined` input → `undefined` (key absent from the config).
+ * - Non-object (or array) input → `warnInvalid` is called, returns `undefined`.
+ * - Object with no `enabled` key → `{}` (present but nothing to say).
+ * - `enabled` present but not a boolean → `warnInvalid` is called, returns `{}`.
+ * - `enabled` a boolean → `{ enabled }`.
+ */
+export function parseEnabledShape(
+	value: unknown,
+	fieldPath: string,
+	warnInvalid: (reason: string) => void,
+): EnabledConfigShape | undefined {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		warnInvalid(`${fieldPath} must be an object`);
+		return undefined;
+	}
+
+	const raw = value as Record<string, unknown>;
+	if (!("enabled" in raw)) return {};
+	if (typeof raw.enabled !== "boolean") {
+		warnInvalid(`${fieldPath}.enabled must be a boolean`);
+		return {};
+	}
+	return { enabled: raw.enabled };
+}

--- a/clients/lens-config.ts
+++ b/clients/lens-config.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { parseEnabledShape } from "./config-enabled-shape.js";
 import type { PiLensProjectConfig } from "./project-lens-config.js";
 
 export type PiLensFormatMode = "deferred" | "immediate";
@@ -30,6 +31,14 @@ export interface PiLensGlobalConfig {
 		enabled?: boolean;
 		/** When to run auto-formatting after write/edit tool results. */
 		mode?: PiLensFormatMode;
+	};
+	autofix?: {
+		/**
+		 * Whether the pipeline may apply deterministic linter fixes (Biome,
+		 * Ruff, ESLint, ...). Defaults true. A project `.pi-lens.json`
+		 * `autofix.enabled` overrides this in either direction (#792).
+		 */
+		enabled?: boolean;
 	};
 	actionableWarnings?: {
 		/** Write turn-delta fixable warning reports and inject a short advisory. */
@@ -70,6 +79,27 @@ export function getPiLensGlobalConfigPath(homeDir = os.homedir()): string {
 	return path.join(homeDir, ".pi-lens", "config.json");
 }
 
+const warnedInvalidGlobalConfigs = new Set<string>();
+
+/**
+ * Same warn-once-per-(path, reason) contract as project-lens-config.ts's
+ * `warnInvalidConfigOnce` — a malformed global config value is logged once
+ * and then treated as absent, rather than silently dropped (#792).
+ */
+function warnInvalidGlobalConfigOnce(configPath: string, reason: string): void {
+	const key = `${configPath}:${reason}`;
+	if (warnedInvalidGlobalConfigs.has(key)) return;
+	warnedInvalidGlobalConfigs.add(key);
+	console.error(
+		`[pi-lens] ignoring invalid global config ${configPath}: ${reason}`,
+	);
+}
+
+/** For tests that need to force the warn-once cache to reset between cases. */
+export function resetGlobalConfigWarnCache(): void {
+	warnedInvalidGlobalConfigs.clear();
+}
+
 export function loadPiLensGlobalConfig(
 	configPath = getPiLensGlobalConfigPath(),
 ): PiLensGlobalConfig | undefined {
@@ -78,6 +108,8 @@ export function loadPiLensGlobalConfig(
 		if (!parsed || typeof parsed !== "object") return undefined;
 
 		const raw = parsed as Record<string, unknown>;
+		const warnInvalid = (reason: string) =>
+			warnInvalidGlobalConfigOnce(configPath, reason);
 		const dispatchRaw = raw.dispatch;
 		const dispatch =
 			dispatchRaw && typeof dispatchRaw === "object"
@@ -88,22 +120,23 @@ export function loadPiLensGlobalConfig(
 			widgetRaw && typeof widgetRaw === "object"
 				? (widgetRaw as Record<string, unknown>)
 				: undefined;
-		const formatRaw = raw.format;
-		const format =
-			formatRaw && typeof formatRaw === "object"
-				? (formatRaw as Record<string, unknown>)
+		const format = parseEnabledShape(raw.format, "format", warnInvalid);
+		const autofix = parseEnabledShape(raw.autofix, "autofix", warnInvalid);
+		const formatModeRaw = raw.format;
+		const formatModeSource =
+			formatModeRaw && typeof formatModeRaw === "object"
+				? (formatModeRaw as Record<string, unknown>)
 				: undefined;
 		const actionableWarningsRaw = raw.actionableWarnings;
 		const actionableWarnings =
 			actionableWarningsRaw && typeof actionableWarningsRaw === "object"
 				? (actionableWarningsRaw as Record<string, unknown>)
 				: undefined;
-		const actionableWarningsAutoFixRaw = actionableWarnings?.autoFix;
-		const actionableWarningsAutoFix =
-			actionableWarningsAutoFixRaw &&
-			typeof actionableWarningsAutoFixRaw === "object"
-				? (actionableWarningsAutoFixRaw as Record<string, unknown>)
-				: undefined;
+		const actionableWarningsAutoFix = parseEnabledShape(
+			actionableWarnings?.autoFix,
+			"actionableWarnings.autoFix",
+			warnInvalid,
+		);
 		const contextInjectionRaw = raw.contextInjection;
 		const contextInjection =
 			contextInjectionRaw && typeof contextInjectionRaw === "object"
@@ -115,8 +148,9 @@ export function loadPiLensGlobalConfig(
 				? (turnSummaryRaw as Record<string, unknown>)
 				: undefined;
 		const formatMode =
-			format?.mode === "immediate" || format?.mode === "deferred"
-				? format.mode
+			formatModeSource?.mode === "immediate" ||
+			formatModeSource?.mode === "deferred"
+				? (formatModeSource.mode as PiLensFormatMode)
 				: undefined;
 		const ignore = Array.isArray(raw.ignore)
 			? raw.ignore.filter((p): p is string => typeof p === "string")
@@ -142,11 +176,11 @@ export function loadPiLensGlobalConfig(
 				: undefined,
 			format: format
 				? {
-						enabled:
-							typeof format.enabled === "boolean" ? format.enabled : undefined,
+						enabled: format.enabled,
 						mode: formatMode,
 					}
 				: undefined,
+			autofix: autofix ? { enabled: autofix.enabled } : undefined,
 			actionableWarnings: actionableWarnings
 				? {
 						enabled:
@@ -162,12 +196,7 @@ export function loadPiLensGlobalConfig(
 								? actionableWarnings.deltaOnly
 								: undefined,
 						autoFix: actionableWarningsAutoFix
-							? {
-									enabled:
-										typeof actionableWarningsAutoFix.enabled === "boolean"
-											? actionableWarningsAutoFix.enabled
-											: undefined,
-								}
+							? { enabled: actionableWarningsAutoFix.enabled }
 							: undefined,
 					}
 				: undefined,
@@ -205,6 +234,10 @@ export function getGlobalAutoformatEnabled(configPath?: string): boolean {
 	return loadPiLensGlobalConfig(configPath)?.format?.enabled !== false;
 }
 
+export function getGlobalAutofixEnabled(configPath?: string): boolean {
+	return loadPiLensGlobalConfig(configPath)?.autofix?.enabled !== false;
+}
+
 export function getGlobalImmediateFormatDefault(configPath?: string): boolean {
 	return loadPiLensGlobalConfig(configPath)?.format?.mode === "immediate";
 }
@@ -219,45 +252,91 @@ export function getGlobalTurnSummaryEnabled(configPath?: string): boolean {
 	return loadPiLensGlobalConfig(configPath)?.turnSummary?.enabled === true;
 }
 
+/** Which tier decided a resolved flag's value — for provenance in debug/skip logs (#792). */
+export type PiLensFlagSource = "cli" | "project" | "global" | "default";
+
+export interface ResolvedPiLensFlag {
+	value: boolean | string | undefined;
+	source: PiLensFlagSource;
+}
+
+/**
+ * Resolve a flag AND report which config tier decided it — same precedence
+ * as {@link resolvePiLensFlag} (which now delegates here), just also
+ * returning the `source` so callers can log e.g.
+ * "(--no-autofix, source=project)" instead of a bare boolean (#792).
+ *
+ * Precedence (unchanged, maintainer decision — project wins over global,
+ * including re-enabling; only an explicit CLI disabling flag outranks
+ * project config): cli → project → global → default.
+ */
+export function resolvePiLensFlagWithSource(
+	name: string,
+	value: boolean | string | undefined,
+	config: PiLensGlobalConfig | undefined,
+	projectConfig?: PiLensProjectConfig,
+): ResolvedPiLensFlag {
+	if (value) return { value, source: "cli" };
+	if (name === "no-autoformat") {
+		if (projectConfig?.format?.enabled !== undefined) {
+			return { value: !projectConfig.format.enabled, source: "project" };
+		}
+		if (config?.format?.enabled === false) {
+			return { value: true, source: "global" };
+		}
+		return { value: false, source: "default" };
+	}
+	if (name === "no-autofix") {
+		if (projectConfig?.autofix?.enabled !== undefined) {
+			return { value: !projectConfig.autofix.enabled, source: "project" };
+		}
+		if (config?.autofix?.enabled === false) {
+			return { value: true, source: "global" };
+		}
+		return { value: false, source: "default" };
+	}
+	if (name === "immediate-format") {
+		const immediate = config?.format?.mode === "immediate";
+		return { value: immediate, source: immediate ? "global" : "default" };
+	}
+	if (name === "lens-actionable-warnings") {
+		const enabled = config?.actionableWarnings?.enabled === true;
+		return { value: enabled, source: enabled ? "global" : "default" };
+	}
+	if (name === "lens-actionable-warning-actions") {
+		const enabled = config?.actionableWarnings?.includeLspCodeActions === true;
+		return { value: enabled, source: enabled ? "global" : "default" };
+	}
+	if (name === "lens-actionable-warning-autofix") {
+		if (projectConfig?.actionableWarnings?.autoFix?.enabled !== undefined) {
+			return {
+				value: projectConfig.actionableWarnings.autoFix.enabled,
+				source: "project",
+			};
+		}
+		const enabled = config?.actionableWarnings?.autoFix?.enabled === true;
+		return { value: enabled, source: enabled ? "global" : "default" };
+	}
+	if (name === "lens-actionable-warning-all") {
+		const all = config?.actionableWarnings?.deltaOnly === false;
+		return { value: all, source: all ? "global" : "default" };
+	}
+	if (name === "no-lens-context") {
+		const disabled = config?.contextInjection?.enabled === false;
+		return { value: disabled, source: disabled ? "global" : "default" };
+	}
+	if (name === "lens-turn-summary") {
+		const enabled = config?.turnSummary?.enabled === true;
+		return { value: enabled, source: enabled ? "global" : "default" };
+	}
+	return { value, source: "default" };
+}
+
 export function resolvePiLensFlag(
 	name: string,
 	value: boolean | string | undefined,
 	config: PiLensGlobalConfig | undefined,
 	projectConfig?: PiLensProjectConfig,
 ): boolean | string | undefined {
-	if (value) return value;
-	if (name === "no-autoformat") {
-		if (projectConfig?.format?.enabled !== undefined) {
-			return !projectConfig.format.enabled;
-		}
-		return config?.format?.enabled === false;
-	}
-	if (name === "no-autofix") {
-		return projectConfig?.autofix?.enabled === false;
-	}
-	if (name === "immediate-format") {
-		return config?.format?.mode === "immediate";
-	}
-	if (name === "lens-actionable-warnings") {
-		return config?.actionableWarnings?.enabled === true;
-	}
-	if (name === "lens-actionable-warning-actions") {
-		return config?.actionableWarnings?.includeLspCodeActions === true;
-	}
-	if (name === "lens-actionable-warning-autofix") {
-		if (projectConfig?.actionableWarnings?.autoFix?.enabled !== undefined) {
-			return projectConfig.actionableWarnings.autoFix.enabled;
-		}
-		return config?.actionableWarnings?.autoFix?.enabled === true;
-	}
-	if (name === "lens-actionable-warning-all") {
-		return config?.actionableWarnings?.deltaOnly === false;
-	}
-	if (name === "no-lens-context") {
-		return config?.contextInjection?.enabled === false;
-	}
-	if (name === "lens-turn-summary") {
-		return config?.turnSummary?.enabled === true;
-	}
-	return value;
+	return resolvePiLensFlagWithSource(name, value, config, projectConfig).value;
 }

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -14,6 +14,7 @@
 
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
+import type { PiLensFlagSource } from "./lens-config.js";
 import { findNearestContaining } from "./path-utils.js";
 import {
 	recordFromDispatchDiagnostic,
@@ -231,6 +232,13 @@ export interface PipelineContext {
 	};
 	/** pi.getFlag accessor */
 	getFlag: (name: string) => boolean | string | undefined;
+	/**
+	 * Optional: resolve which config tier (cli/project/global/default) decided
+	 * a mutation flag's value, for provenance in dbg/skip logs (#792). Absent
+	 * ⇒ logs omit the `source=` suffix (existing tests that don't wire this
+	 * through keep passing unchanged).
+	 */
+	getFlagSource?: (name: string) => PiLensFlagSource;
 	/** Debug logger */
 	dbg: (msg: string) => void;
 	/**
@@ -557,6 +565,7 @@ export async function runAutofix(
 	getFlag: PipelineContext["getFlag"],
 	dbg: PipelineContext["dbg"],
 	deps: Pick<PipelineDeps, "biomeClient" | "ruffClient" | "fixedThisTurn">,
+	getFlagSource?: PipelineContext["getFlagSource"],
 ): Promise<{
 	fixedCount: number;
 	autofixTools: string[];
@@ -587,7 +596,10 @@ export async function runAutofix(
 	}
 
 	if (noAutofix) {
-		dbg(`autofix: skipped for ${filePath} (--no-autofix)`);
+		const source = getFlagSource?.("no-autofix");
+		dbg(
+			`autofix: skipped for ${filePath} (--no-autofix${source ? `, source=${source}` : ""})`,
+		);
 		return {
 			fixedCount,
 			autofixTools,
@@ -1082,7 +1094,7 @@ export async function runPipeline(
 	ctx: PipelineContext,
 	deps: PipelineDeps,
 ): Promise<PipelineResult> {
-	const { filePath, cwd, toolName, getFlag, dbg } = ctx;
+	const { filePath, cwd, toolName, getFlag, getFlagSource, dbg } = ctx;
 	const { getFormatService } = deps;
 
 	const phase = createPhaseTracker(toolName, filePath);
@@ -1133,6 +1145,11 @@ export async function runPipeline(
 		}
 	} else if (formatDeferred) {
 		dbg(`autoformat: deferred until agent_end for ${filePath}`);
+	} else if (autoformatDisabled) {
+		const source = getFlagSource?.("no-autoformat");
+		dbg(
+			`autoformat: skipped for ${filePath} (--no-autoformat${source ? `, source=${source}` : ""})`,
+		);
 	}
 	phase.end("format", {
 		formattersUsed,
@@ -1149,7 +1166,7 @@ export async function runPipeline(
 		changedFiles: autofixChangedFiles,
 		needsContentRefresh: fixRefresh,
 		skipReason: autofixSkipReason,
-	} = await runAutofix(filePath, cwd, getFlag, dbg, deps);
+	} = await runAutofix(filePath, cwd, getFlag, dbg, deps, getFlagSource);
 	for (const changedFile of autofixChangedFiles) {
 		piChangedFiles.add(path.resolve(changedFile));
 	}

--- a/clients/project-lens-config.ts
+++ b/clients/project-lens-config.ts
@@ -46,6 +46,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { parseEnabledShape } from "./config-enabled-shape.js";
 import { walkUpDirs } from "./path-utils.js";
 
 const PROJECT_CONFIG_BASENAMES = [".pi-lens.json", "pi-lens.json"];
@@ -252,22 +253,9 @@ function parseEnabledConfig(
 	fieldPath: string,
 	value: unknown,
 ): PiLensProjectMutationConfig | undefined {
-	if (value === undefined) return undefined;
-	if (!value || typeof value !== "object" || Array.isArray(value)) {
-		warnInvalidConfigOnce(configPath, `${fieldPath} must be an object`);
-		return undefined;
-	}
-
-	const raw = value as Record<string, unknown>;
-	if (!("enabled" in raw)) return {};
-	if (typeof raw.enabled !== "boolean") {
-		warnInvalidConfigOnce(
-			configPath,
-			`${fieldPath}.enabled must be a boolean`,
-		);
-		return {};
-	}
-	return { enabled: raw.enabled };
+	return parseEnabledShape(value, fieldPath, (reason) =>
+		warnInvalidConfigOnce(configPath, reason),
+	);
 }
 
 function parseConfigFile(configPath: string): PiLensProjectConfig {

--- a/clients/runtime-agent-end.ts
+++ b/clients/runtime-agent-end.ts
@@ -18,6 +18,7 @@ import {
 	appendProjectChange,
 	type ProjectChangeSource,
 } from "./project-changes.js";
+import type { PiLensFlagSource } from "./lens-config.js";
 import type { RuntimeCoordinator } from "./runtime-coordinator.js";
 
 /**
@@ -33,6 +34,8 @@ export const DEFERRED_FORMAT_STALE_AFTER_MS = 10 * 60_000;
 interface AgentEndDeps {
 	ctxCwd?: string;
 	getFlag: (name: string) => boolean | string | undefined;
+	/** Optional: provenance for dbg/skip logs — see `PipelineContext["getFlagSource"]` (#792). */
+	getFlagSource?: (name: string) => PiLensFlagSource;
 	notify: (msg: string, level: "info" | "warning" | "error") => void;
 	dbg: (msg: string) => void;
 	runtime: RuntimeCoordinator;
@@ -85,6 +88,7 @@ function recordProjectChange(args: {
 export async function handleAgentEnd({
 	ctxCwd,
 	getFlag,
+	getFlagSource,
 	notify,
 	dbg,
 	runtime,
@@ -191,6 +195,12 @@ export async function handleAgentEnd({
 
 	const autoformatDisabled = !!getFlag("no-autoformat");
 	if (autoformatDisabled) {
+		const source = getFlagSource?.("no-autoformat");
+		if (records.length > 0) {
+			dbg(
+				`agent_end deferred_format: skipping ${records.length} file(s) (--no-autoformat${source ? `, source=${source}` : ""})`,
+			);
+		}
 		for (const record of records) {
 			summary.skipped.push({
 				filePath: record.filePath,
@@ -340,6 +350,13 @@ export async function handleAgentEnd({
 				fixes: deferredFormatFixes,
 			});
 		}
+	}
+
+	if (!actionableAutofixEnabled) {
+		const source = getFlagSource?.("lens-actionable-warning-autofix");
+		dbg(
+			`agent_end actionable_warnings_autofix: skipped (lens-actionable-warning-autofix disabled${source ? `, source=${source}` : ""})`,
+		);
 	}
 
 	if (actionableAutofixEnabled) {

--- a/clients/runtime-tool-result.ts
+++ b/clients/runtime-tool-result.ts
@@ -19,6 +19,7 @@ import { getFormatService } from "./format-service.js";
 import { isExternalOrVendorFile } from "./path-utils.js";
 import { resolveLanguageRootForFile } from "./language-profile.js";
 import { logLatency } from "./latency-logger.js";
+import type { PiLensFlagSource } from "./lens-config.js";
 import type { LSPShutdownOptions } from "./lsp/client.js";
 import type { MetricsClient } from "./metrics-client.js";
 import { runPipeline, type PipelineResult } from "./pipeline.js";
@@ -45,6 +46,8 @@ interface ToolResultEvent {
 interface ToolResultDeps {
 	event: ToolResultEvent;
 	getFlag: (name: string) => boolean | string | undefined;
+	/** Optional: provenance for dbg/skip logs — see `PipelineContext["getFlagSource"]` (#792). */
+	getFlagSource?: (name: string) => PiLensFlagSource;
 	dbg: (msg: string) => void;
 	runtime: RuntimeCoordinator;
 	cacheManager: CacheManager;
@@ -302,6 +305,7 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 	const {
 		event,
 		getFlag,
+		getFlagSource,
 		dbg,
 		runtime,
 		cacheManager,
@@ -583,6 +587,7 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 				writeIndex,
 			},
 			getFlag,
+			getFlagSource,
 			dbg,
 			// #451: hand the deferred cascade live sequence accessors so the
 			// review-graph builder can skip its per-build O(project) sweep when

--- a/docs/globalconfig.md
+++ b/docs/globalconfig.md
@@ -6,11 +6,6 @@ Hide the diagnostics widget by default, run formatting immediately after write/e
 
 ```json
 {
-  "format": { "enabled": false },
-  "autofix": { "enabled": false },
-  "actionableWarnings": {
-    "autoFix": { "enabled": false }
-  },
   "ignore": [
     "**/*.snapshot",
     "scratch/**"
@@ -21,6 +16,9 @@ Hide the diagnostics widget by default, run formatting immediately after write/e
   "format": {
     "enabled": true,
     "mode": "immediate"
+  },
+  "autofix": {
+    "enabled": true
   },
   "actionableWarnings": {
     "enabled": true,
@@ -38,6 +36,8 @@ Hide the diagnostics widget by default, run formatting immediately after write/e
 ```
 
 `format.mode` can be `"deferred"` (default) or `"immediate"`. Set `format.enabled` to `false` to match `--no-autoformat`. `/lens-widget-toggle` still works as a session-only override.
+
+`autofix.enabled` (default `true`) is the global-config counterpart to the project `.pi-lens.json` `autofix.enabled` below — set it to `false` to match `--no-autofix` for every project that doesn't set its own `autofix.enabled`. As with `format.enabled` and `actionableWarnings.autoFix.enabled`, a project's own `.pi-lens.json` value overrides this global default in either direction (see "Mutation controls" below).
 
 `contextInjection.enabled` (default `true`) controls whether pi-lens prepends automatic findings — session-start guidance, turn-end findings, and test findings — into the next model turn. Set it to `false` (or use `--no-lens-context` / `PI_LENS_NO_CONTEXT_INJECTION=1` / `/lens-context-toggle`) to keep tools, LSP, read-guard, and formatting running while avoiding the prompt-cache invalidation that injected messages cause in long, cache-sensitive sessions. Findings are still cached, so `lens_diagnostics` and `/lens-health` keep working.
 
@@ -77,10 +77,28 @@ original write/edit:
 - `actionableWarnings.autoFix.enabled: false` disables conservative LSP
   quickfixes at `agent_end`.
 
-These settings do not disable LSP synchronization, lint dispatch, actionable
-warning reports, or diagnostics. Explicit disabling CLI flags
-(`--no-autoformat` and `--no-autofix`) take highest precedence; project
-settings take precedence over user-level global defaults.
+All three are supported at **both** tiers — the user-level
+`~/.pi-lens/config.json` above (applies to every project) and the per-project
+`.pi-lens.json` below (applies to one repo). These settings do not disable LSP
+synchronization, lint dispatch, actionable warning reports, or diagnostics.
+
+Precedence, highest to lowest:
+
+1. Explicit disabling CLI flags (`--no-autoformat`, `--no-autofix`) — always win.
+2. Project `.pi-lens.json` — wins over the global default in **either**
+   direction, including re-enabling a mutation path the user's global config
+   disabled (maintainer decision: a repo's own contract for its own files
+   takes precedence over a user's blanket preference; there is currently no
+   "hard off" global setting that outranks a project's `enabled: true` — see
+   #792). `actionableWarnings.autoFix.enabled` follows the same rule: project
+   wins outright when set, whether that means turning it on or off.
+3. Global `~/.pi-lens/config.json` — the user-level default when a project
+   doesn't say.
+4. Built-in default (`format`/`autofix` on, `actionableWarnings.autoFix` off).
+
+Nested/monorepo layering (a package-local `.pi-lens.json` overriding the
+repo-root config's mutation controls for just its own subtree, the way
+`ignore` already layers) is not implemented yet — tracked in #792.
 
 ### `ignore`
 

--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,7 @@ import { getAllToolStatuses } from "./clients/installer/index.js";
 import {
 	loadPiLensGlobalConfig,
 	resolvePiLensFlag,
+	resolvePiLensFlagWithSource,
 } from "./clients/lens-config.js";
 import { loadPiLensProjectConfig } from "./clients/project-lens-config.js";
 import { initLensEvents } from "./clients/lens-events.js";
@@ -459,6 +460,21 @@ export default function (pi: ExtensionAPI) {
 			: pi.getFlag(name);
 		const projectConfig = loadPiLensProjectConfig(runtime.projectRoot);
 		return resolvePiLensFlag(name, cliValue, globalConfig, projectConfig);
+	}
+
+	// #792: sibling of getLensFlag reporting WHICH config tier decided the
+	// value, so mutation-skip dbg lines can name it (e.g. "source=project")
+	// instead of a bare boolean. Threaded to pipeline/agent_end via the
+	// optional `getFlagSource` field — zero effect on getLensFlag itself.
+	function getLensFlagSource(name: string): ReturnType<
+		typeof resolvePiLensFlagWithSource
+	>["source"] {
+		const cliValue = globalConfigOnlyFlags.has(name)
+			? undefined
+			: pi.getFlag(name);
+		const projectConfig = loadPiLensProjectConfig(runtime.projectRoot);
+		return resolvePiLensFlagWithSource(name, cliValue, globalConfig, projectConfig)
+			.source;
 	}
 
 	let lensEnabled = !getLensFlag("no-lens");
@@ -1445,6 +1461,7 @@ export default function (pi: ExtensionAPI) {
 			return await handleToolResult({
 				event: event as any,
 				getFlag: (name: string) => getLensFlag(name),
+				getFlagSource: (name: string) => getLensFlagSource(name),
 				dbg,
 				runtime,
 				cacheManager,
@@ -1547,6 +1564,7 @@ export default function (pi: ExtensionAPI) {
 			await handleAgentEnd({
 				ctxCwd: ctx.cwd,
 				getFlag: (name: string) => getLensFlag(name),
+				getFlagSource: (name: string) => getLensFlagSource(name),
 				notify: (msg, level) => ctx.ui.notify(msg, level),
 				dbg,
 				runtime,

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -419,7 +419,16 @@ const lensDiagnosticsTool = createLensDiagnosticsTool(
 const astGrepClient = new AstGrepClient();
 const astGrepSearchTool = createAstGrepSearchTool(astGrepClient);
 const astGrepReplaceTool = createAstGrepReplaceTool(astGrepClient);
-const lspNavigationTool = createLspNavigationTool(createMcpHost().getFlag);
+// #792: unlike every other per-request `cwd` resolution in this file, this
+// tool used to be built ONCE at module load with `createMcpHost().getFlag`,
+// which freezes `projectRoot` at the server's own launch directory — a
+// project-config-gated flag consulted through this tool would silently read
+// whatever `.pi-lens.json` happens to sit there, never the caller's project.
+// Resolve lazily against the call's own `cwd` instead (config loads are
+// mtime-cached, so this stays cheap).
+const lspNavigationTool = createLspNavigationTool((name, cwd) =>
+	createMcpHost(undefined, cwd ?? DEFAULT_CWD).getFlag(name),
+);
 const lspDiagnosticsTool = createLspDiagnosticsTool();
 
 // Wrapped pi tools already declare their params as typebox (which IS JSON

--- a/tests/clients/lens-config.test.ts
+++ b/tests/clients/lens-config.test.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	getGlobalAutofixEnabled,
 	getGlobalAutoformatEnabled,
 	getGlobalContextInjectionEnabled,
 	getGlobalImmediateFormatDefault,
@@ -10,7 +11,9 @@ import {
 	getGlobalWidgetDefaultVisible,
 	getPiLensGlobalConfigPath,
 	loadPiLensGlobalConfig,
+	resetGlobalConfigWarnCache,
 	resolvePiLensFlag,
+	resolvePiLensFlagWithSource,
 } from "../../clients/lens-config.js";
 import { EMPTY_PROJECT_CONFIG } from "../../clients/project-lens-config.js";
 
@@ -33,9 +36,13 @@ function writeConfig(home: string, contents: string): string {
 beforeEach(() => {
 	previousConfigPath = process.env.PI_LENS_CONFIG_PATH;
 	delete process.env.PI_LENS_CONFIG_PATH;
+	resetGlobalConfigWarnCache();
+	vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterEach(() => {
+	vi.restoreAllMocks();
+	resetGlobalConfigWarnCache();
 	if (previousConfigPath === undefined) delete process.env.PI_LENS_CONFIG_PATH;
 	else process.env.PI_LENS_CONFIG_PATH = previousConfigPath;
 	for (const dir of tmpDirs.splice(0)) {
@@ -341,5 +348,208 @@ describe("global pi-lens config", () => {
 
 		expect(getGlobalWidgetDefaultVisible(missingPath)).toBe(true);
 		expect(getGlobalWidgetDefaultVisible(invalidPath)).toBe(true);
+	});
+
+	// #792: docs/globalconfig.md documented a global `autofix.enabled` example
+	// long before the parser/resolver actually honored it. These pin down the
+	// full precedence chain now that it's wired up.
+	describe("global autofix.enabled parity (#792)", () => {
+		it("parses autofix.enabled from global config", () => {
+			const home = makeTempHome();
+			const configPath = writeConfig(
+				home,
+				JSON.stringify({ autofix: { enabled: false } }),
+			);
+
+			expect(loadPiLensGlobalConfig(configPath)).toEqual({
+				autofix: { enabled: false },
+			});
+			expect(getGlobalAutofixEnabled(configPath)).toBe(false);
+		});
+
+		it("defaults autofix to enabled when config is missing or silent", () => {
+			const home = makeTempHome();
+			expect(getGlobalAutofixEnabled(path.join(home, "nope.json"))).toBe(true);
+			const configPath = writeConfig(home, JSON.stringify({ widget: {} }));
+			expect(getGlobalAutofixEnabled(configPath)).toBe(true);
+		});
+
+		it("global autofix.enabled=false disables --no-autofix's default", () => {
+			expect(
+				resolvePiLensFlag("no-autofix", false, { autofix: { enabled: false } }),
+			).toBe(true);
+			expect(
+				resolvePiLensFlag("no-autofix", false, { autofix: { enabled: true } }),
+			).toBe(false);
+			expect(resolvePiLensFlag("no-autofix", false, {})).toBe(false);
+		});
+
+		it("project autofix.enabled overrides global in EITHER direction (project wins, #792 maintainer decision)", () => {
+			const globalDisabled = { autofix: { enabled: false } };
+			const globalEnabled = { autofix: { enabled: true } };
+
+			// Project re-enables what global disabled.
+			expect(
+				resolvePiLensFlag("no-autofix", false, globalDisabled, {
+					...EMPTY_PROJECT_CONFIG,
+					autofix: { enabled: true },
+				}),
+			).toBe(false);
+			// Project disables regardless of global.
+			expect(
+				resolvePiLensFlag("no-autofix", false, globalEnabled, {
+					...EMPTY_PROJECT_CONFIG,
+					autofix: { enabled: false },
+				}),
+			).toBe(true);
+			// Explicit CLI flag still outranks everything.
+			expect(
+				resolvePiLensFlag("no-autofix", true, globalEnabled, {
+					...EMPTY_PROJECT_CONFIG,
+					autofix: { enabled: true },
+				}),
+			).toBe(true);
+		});
+
+		it("warns once (not repeatedly) on an invalid global autofix.enabled value", () => {
+			const home = makeTempHome();
+			const configPath = writeConfig(
+				home,
+				JSON.stringify({ autofix: { enabled: "no" } }),
+			);
+
+			expect(loadPiLensGlobalConfig(configPath)?.autofix?.enabled).toBeUndefined();
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining("autofix.enabled must be a boolean"),
+			);
+			const callsAfterFirst = (console.error as ReturnType<typeof vi.fn>).mock
+				.calls.length;
+
+			loadPiLensGlobalConfig(configPath);
+			loadPiLensGlobalConfig(configPath);
+			expect(
+				(console.error as ReturnType<typeof vi.fn>).mock.calls.length,
+			).toBe(callsAfterFirst);
+		});
+
+		it("warns once on an invalid global format.enabled and actionableWarnings.autoFix.enabled value", () => {
+			const home = makeTempHome();
+			const configPath = writeConfig(
+				home,
+				JSON.stringify({
+					format: { enabled: "nope" },
+					actionableWarnings: { autoFix: { enabled: 1 } },
+				}),
+			);
+
+			const parsed = loadPiLensGlobalConfig(configPath);
+			expect(parsed?.format?.enabled).toBeUndefined();
+			expect(parsed?.actionableWarnings?.autoFix?.enabled).toBeUndefined();
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining("format.enabled must be a boolean"),
+			);
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"actionableWarnings.autoFix.enabled must be a boolean",
+				),
+			);
+		});
+	});
+
+	describe("resolvePiLensFlagWithSource (#792)", () => {
+		it("reports source=cli when an explicit CLI value wins", () => {
+			expect(
+				resolvePiLensFlagWithSource("no-autofix", true, undefined, undefined),
+			).toEqual({ value: true, source: "cli" });
+			expect(
+				resolvePiLensFlagWithSource("no-autoformat", true, undefined, undefined),
+			).toEqual({ value: true, source: "cli" });
+		});
+
+		it("reports source=project when project config decides no-autofix/no-autoformat", () => {
+			const projectConfig = {
+				...EMPTY_PROJECT_CONFIG,
+				format: { enabled: false },
+				autofix: { enabled: false },
+			};
+			expect(
+				resolvePiLensFlagWithSource(
+					"no-autoformat",
+					false,
+					undefined,
+					projectConfig,
+				),
+			).toEqual({ value: true, source: "project" });
+			expect(
+				resolvePiLensFlagWithSource(
+					"no-autofix",
+					false,
+					undefined,
+					projectConfig,
+				),
+			).toEqual({ value: true, source: "project" });
+			expect(
+				resolvePiLensFlagWithSource(
+					"lens-actionable-warning-autofix",
+					undefined,
+					undefined,
+					{
+						...EMPTY_PROJECT_CONFIG,
+						actionableWarnings: { autoFix: { enabled: true } },
+					},
+				),
+			).toEqual({ value: true, source: "project" });
+		});
+
+		it("reports source=global when only global config decides", () => {
+			expect(
+				resolvePiLensFlagWithSource("no-autofix", false, {
+					autofix: { enabled: false },
+				}),
+			).toEqual({ value: true, source: "global" });
+			expect(
+				resolvePiLensFlagWithSource("no-autoformat", false, {
+					format: { enabled: false },
+				}),
+			).toEqual({ value: true, source: "global" });
+			expect(
+				resolvePiLensFlagWithSource("lens-actionable-warning-autofix", undefined, {
+					actionableWarnings: { autoFix: { enabled: true } },
+				}),
+			).toEqual({ value: true, source: "global" });
+		});
+
+		it("reports source=default when nothing overrides the built-in default", () => {
+			expect(
+				resolvePiLensFlagWithSource("no-autofix", false, undefined, undefined),
+			).toEqual({ value: false, source: "default" });
+			expect(
+				resolvePiLensFlagWithSource("no-autoformat", false, undefined, undefined),
+			).toEqual({ value: false, source: "default" });
+			expect(
+				resolvePiLensFlagWithSource(
+					"lens-actionable-warning-autofix",
+					undefined,
+					undefined,
+					undefined,
+				),
+			).toEqual({ value: false, source: "default" });
+		});
+
+		it("resolvePiLensFlag delegates to resolvePiLensFlagWithSource with zero behavior change", () => {
+			const globalConfig = { autofix: { enabled: false } };
+			const projectConfig = {
+				...EMPTY_PROJECT_CONFIG,
+				autofix: { enabled: true },
+			};
+			expect(resolvePiLensFlag("no-autofix", false, globalConfig, projectConfig)).toBe(
+				resolvePiLensFlagWithSource(
+					"no-autofix",
+					false,
+					globalConfig,
+					projectConfig,
+				).value,
+			);
+		});
 	});
 });

--- a/tests/clients/mcp/host-shim.test.ts
+++ b/tests/clients/mcp/host-shim.test.ts
@@ -40,6 +40,40 @@ describe("createMcpHost", () => {
 		expect(host.getFlag("lens-opengrep-config")).toBe("p/security");
 	});
 
+	it("resolves flags scoped to a per-call cwd, not a frozen module-load cwd (#792)", () => {
+		// Mirrors the fix in mcp/server.ts: `lspNavigationTool`'s getFlag used to
+		// be built ONCE at module load via `createMcpHost().getFlag` (defaulting
+		// to the server's own launch directory), so a project-config-gated flag
+		// consulted through that tool could never see the CALLER's project. The
+		// fix rebuilds the host per call: `(name, cwd) =>
+		// createMcpHost(undefined, cwd).getFlag(name)`. This test pins that a
+		// getFlag built this way resolves against whichever project root a given
+		// call passes, not whatever directory happened to be current when the
+		// closure was first created.
+		const projectA = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-mcp-cwd-a-"),
+		);
+		const projectB = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-mcp-cwd-b-"),
+		);
+		try {
+			fs.writeFileSync(
+				path.join(projectA, ".pi-lens.json"),
+				JSON.stringify({ autofix: { enabled: false } }),
+			);
+			// projectB has no .pi-lens.json — no project override.
+
+			const getFlag = (name: string, cwd?: string) =>
+				createMcpHost(undefined, cwd).getFlag(name);
+
+			expect(getFlag("no-autofix", projectA)).toBe(true);
+			expect(getFlag("no-autofix", projectB)).toBe(false);
+		} finally {
+			fs.rmSync(projectA, { recursive: true, force: true });
+			fs.rmSync(projectB, { recursive: true, force: true });
+		}
+	});
+
 	it("resolves mutation flags from project config", () => {
 		const projectRoot = fs.mkdtempSync(
 			path.join(os.tmpdir(), "pi-lens-mcp-project-config-"),

--- a/tests/tools/lsp-navigation.test.ts
+++ b/tests/tools/lsp-navigation.test.ts
@@ -181,6 +181,26 @@ describe("lsp_navigation tool", () => {
 		});
 	});
 
+	it("passes the call's ctx.cwd to getFlag (#792 — MCP host must resolve per-request project config, not the process's launch cwd)", async () => {
+		const calls: Array<{ name: string; cwd: string | undefined }> = [];
+		const tool = createLspNavigationTool((name, cwd) => {
+			calls.push({ name, cwd });
+			return false;
+		});
+
+		await tool.execute(
+			"call-1",
+			{ operation: "capabilities" },
+			new AbortController().signal,
+			null,
+			{ cwd: "/some/other/project" },
+		);
+
+		expect(calls).toEqual([
+			{ name: "no-lsp", cwd: "/some/other/project" },
+		]);
+	});
+
 	it("allows incomingCalls without path when callHierarchyItem exists", async () => {
 		const tool = createLspNavigationTool((flag) => flag === "lens-lsp");
 		const callHierarchyItem = {

--- a/tools/lsp-navigation.ts
+++ b/tools/lsp-navigation.ts
@@ -731,7 +731,15 @@ async function openFileBestEffort(
 }
 
 export function createLspNavigationTool(
-	getFlag: (name: string) => boolean | string | undefined,
+	/**
+	 * Resolves a flag, optionally scoped to a call's `cwd` (#792). Callers that
+	 * need per-request project config (e.g. the MCP host, which has no single
+	 * "current project root" the way an in-pi session does) can rebuild their
+	 * flag resolver against `cwd` instead of whatever directory the tool was
+	 * constructed in; callers that only have a single fixed project root (e.g.
+	 * pi's own `getLensFlag`) may ignore the second argument.
+	 */
+	getFlag: (name: string, cwd?: string) => boolean | string | undefined,
 ) {
 	return {
 		name: "lsp_navigation" as const,
@@ -985,7 +993,7 @@ export function createLspNavigationTool(
 				};
 			};
 
-			if (getFlag("no-lsp")) {
+			if (getFlag("no-lsp", ctx.cwd)) {
 				return finalize(
 					{
 						content: [


### PR DESCRIPTION
## What

Closes the four mechanical items tracked in #792 (follow-ups to the project-mutation-controls feature, #789/#790):

1. **Global `autofix.enabled` parity** — `docs/globalconfig.md` documented `autofix.enabled` as a global-config key, but `PiLensGlobalConfig` (`clients/lens-config.ts`) had no `autofix` field, and `resolvePiLensFlag`'s `no-autofix` branch only ever read `projectConfig`. Added the field + parser, and the `no-autofix` branch now falls back to global when project config doesn't specify a value — project still wins outright (either direction) when it does.
2. **Uncovered `createMcpHost()` call site** — `mcp/server.ts`'s `lspNavigationTool` was built once at module load via `createLspNavigationTool(createMcpHost().getFlag)`, freezing `projectRoot` at the server's launch directory. Every other tool in that file resolves `cwd` per request; this one never got the chance. It now rebuilds the host lazily per call: `createLspNavigationTool((name, cwd) => createMcpHost(undefined, cwd ?? DEFAULT_CWD).getFlag(name))`, and `tools/lsp-navigation.ts`'s `getFlag` call passes `ctx.cwd`. Config loads are mtime-cached, so this stays cheap.
3. **Parser centralization** — global and project config hand-parsed the identical `{enabled?: boolean}` shape independently, with diverging strictness (project warned via `warnInvalidConfigOnce`, global silently dropped invalid values). Extracted a shared `clients/config-enabled-shape.ts` helper (no dependency on either config module, so no import cycle) used by both, and gave the global loader the same warn-once-on-invalid-value behavior via a new `warnInvalidGlobalConfigOnce`.
4. **Provenance logging** — added `resolvePiLensFlagWithSource` (returns `{value, source: "cli"|"project"|"global"|"default"}`) alongside `resolvePiLensFlag`, which now delegates to it with zero behavior change. Threaded an optional `getFlagSource` through `PipelineContext`/`AgentEndDeps`/`ToolResultDeps` (wired in `index.ts` via a `getLensFlagSource` sibling to `getLensFlag`) so the mutation-skip dbg lines in `pipeline.ts` (autofix + autoformat skips) and `runtime-agent-end.ts` (deferred-format autoformat-disabled skip, actionable-warning-autofix gate) name which tier decided, e.g. `(--no-autofix, source=project)`.

`docs/globalconfig.md` is updated to state global vs. project mutation-control support and precedence accurately (project overrides global in either direction; explicit CLI disable flags always win highest), and fixes a pre-existing duplicate-key bug in its global-config example JSON.

## Approach

Maintainer decision from #792 preserved exactly as specified: **project config wins over global, including re-enabling** — no most-restrictive-wins semantics were added. Nested/monorepo layering of mutation controls (a package-local `.pi-lens.json` overriding just its own subtree) is intentionally NOT implemented here — it stays tracked in #792.

`getFlagSource` is optional everywhere it's threaded, so existing test constructions of `PipelineContext`/`AgentEndDeps`/`ToolResultDeps` that don't wire it through keep passing unchanged — logs simply omit the `source=` suffix when absent.

## Testing

- `npm run build` (tsc, foreground) — clean.
- `npm run lint` (tsc typecheck) — clean.
- `npm test` — full suite: 4168 passed, 10 failed, 10 skipped. All 10 failures are pre-existing/environmental (Windows temp-dir `EPERM` on cleanup, and event-loop/timing-budget tests timing out under full-suite parallel load — `source-filter-async`, `sgconfig`, `project-diagnostics`, `ast-grep-rule-precedence-followups`, `mcp/analyze-graph.smoke`, `lsp/workspace-diagnostics-sweep-batch-open`); none touch files this PR changed. Confirmed by rerunning every touched test file individually (`lens-config`, `project-lens-config`, `lsp-navigation`, `mcp/host-shim`, `pipeline`, `runtime-agent-end`, `runtime-tool-result`) — 133/133 passed.
- New/extended tests:
  - `tests/clients/lens-config.test.ts`: global `autofix.enabled` parity chain (global false disables, project true re-enables, project false wins regardless, explicit CLI wins over both), `resolvePiLensFlagWithSource` cli/project/global/default cases for `no-autofix`/`no-autoformat`/`lens-actionable-warning-autofix`, `resolvePiLensFlag` delegation parity, and warn-once behavior for invalid global `autofix.enabled`/`format.enabled`/`actionableWarnings.autoFix.enabled`.
  - `tests/tools/lsp-navigation.test.ts`: pins that `getFlag` receives the call's `ctx.cwd`.
  - `tests/clients/mcp/host-shim.test.ts`: mirrors the temp-project pattern to show a `(name, cwd) => createMcpHost(undefined, cwd).getFlag(name)` closure (matching the `mcp/server.ts` fix) resolves per-call against the passed cwd, not a frozen one.

Addresses the mechanical items of #792; nested-config layering and the precedence-policy question remain tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)