### PR TITLE
Cover symbol search role priors

### DIFF
--- a/tests/clients/word-index.test.ts
+++ b/tests/clients/word-index.test.ts
@@ -171,6 +171,22 @@ describe("searchWordIndex priors", () => {
 		expect(results[0].file).toBe("src/widget.ts");
 	});
 
+	it("demotes vendor and generated-tree matches below equivalent source code", () => {
+		const index = buildWordIndex([
+			{ path: "src/widget.ts", content: "function renderWidget() {}" },
+			{ path: "vendor/widget.ts", content: "function renderWidget() {}" },
+			{ path: "dist/widget.js", content: "function renderWidget() {}" },
+		]);
+		const results = searchWordIndex(index, "render widget");
+		const source = results.find((result) => result.file === "src/widget.ts");
+		const vendor = results.find((result) => result.file === "vendor/widget.ts");
+		const generated = results.find((result) => result.file === "dist/widget.js");
+
+		expect(results[0].file).toBe("src/widget.ts");
+		expect(source?.score).toBeGreaterThan(vendor?.score ?? 0);
+		expect(source?.score).toBeGreaterThan(generated?.score ?? 0);
+	});
+
 	it("boosts a well-connected file via centrality", () => {
 		const files = [
 			{ path: "src/a.ts", content: "function sharedHelper() {}" },


### PR DESCRIPTION
## Summary
- add regression coverage for vendor and generated-tree symbol-search matches
- verify equivalent source files remain ranked ahead of low-authority artifacts

Refs #655

## Validation
- `npx vitest run tests/clients/word-index.test.ts`
- `npm run lint`
