### PR TITLE
chore(types): TS7-compatible overload + union narrowing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **TypeScript 7 compatibility fixes (refs #809)** — narrowed ast-grep search test details and made the LSP `workspace/applyEdit` response overload-compatible, unblocking Dependabot PR #600.
+
 ### Added
 
 ### Changed

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -1017,7 +1017,9 @@ export function setupIncomingHandlers(
 	// as every other edit.
 	state.connection.onRequest(
 		"workspace/applyEdit",
-		async (params: { edit?: { changes?: unknown; documentChanges?: unknown } }) => {
+		async (
+			params: { edit?: { changes?: unknown; documentChanges?: unknown } },
+		): Promise<{ applied: boolean; failureReason?: string }> => {
 			if (state.serverEditsAllowed <= 0 || !params?.edit) {
 				return { applied: false, failureReason: "edit not solicited" };
 			}

--- a/tests/tools/ast-grep-search.test.ts
+++ b/tests/tools/ast-grep-search.test.ts
@@ -20,6 +20,21 @@ function makeClient(
 	} as Parameters<typeof createAstGrepSearchTool>[0];
 }
 
+type SearchDetails = {
+	matchLocations?: Array<{
+		file: string;
+		line: number;
+		endLine: number;
+		readSlice: { path: string; offset: number; limit: number };
+	}>;
+	suggestedDump?: { tool: string; lang: string };
+	searchReads?: Array<{ file: string; startLine: number; endLine: number }>;
+};
+
+function asSearchDetails(details: unknown): SearchDetails {
+	return details as SearchDetails;
+}
+
 describe("ast_grep_search tool", () => {
 	describe("telemetry sanitization", () => {
 		it("escapes NUL bytes and truncates long subprocess errors", () => {
@@ -522,7 +537,7 @@ describe("ast_grep_search tool", () => {
 				{ cwd: "." },
 			);
 
-			expect(result.details.matchLocations).toEqual([
+			expect(asSearchDetails(result.details).matchLocations).toEqual([
 				{
 					file: "src/rule.ts",
 					line: 5,
@@ -530,7 +545,7 @@ describe("ast_grep_search tool", () => {
 					readSlice: { path: "src/rule.ts", offset: 2, limit: 7 },
 				},
 			]);
-			expect(result.details.suggestedDump).toBeUndefined();
+			expect(asSearchDetails(result.details).suggestedDump).toBeUndefined();
 		});
 
 		it("suggests ast_grep_dump for YAML-rule zero matches", async () => {
@@ -551,8 +566,8 @@ describe("ast_grep_search tool", () => {
 				{ cwd: "." },
 			);
 
-			expect(result.details.matchLocations).toEqual([]);
-			expect(result.details.suggestedDump).toMatchObject({
+			expect(asSearchDetails(result.details).matchLocations).toEqual([]);
+			expect(asSearchDetails(result.details).suggestedDump).toMatchObject({
 				tool: "ast_grep_dump",
 				lang: "typescript",
 			});
@@ -580,7 +595,7 @@ describe("ast_grep_search tool", () => {
 		expect(result.isError).toBeUndefined();
 		expect(search).toHaveBeenCalledOnce();
 		expect(String(result.content[0].text)).toContain("1 match");
-		expect(result.details.suggestedDump).toBeUndefined();
+		expect(asSearchDetails(result.details).suggestedDump).toBeUndefined();
 	});
 
 	it("returns read handles for matched locations", async () => {
@@ -611,7 +626,7 @@ describe("ast_grep_search tool", () => {
 			{ cwd: "." },
 		);
 
-		expect(result.details.matchLocations).toEqual([
+		expect(asSearchDetails(result.details).matchLocations).toEqual([
 			{
 				file: "src/a.ts",
 				line: 10,
@@ -619,10 +634,10 @@ describe("ast_grep_search tool", () => {
 				readSlice: { path: "src/a.ts", offset: 8, limit: 7 },
 			},
 		]);
-		expect(result.details.searchReads).toEqual([
+		expect(asSearchDetails(result.details).searchReads).toEqual([
 			{ file: "src/a.ts", startLine: 10, endLine: 12 },
 		]);
-		expect(result.details.suggestedDump).toBeUndefined();
+		expect(asSearchDetails(result.details).suggestedDump).toBeUndefined();
 	});
 
 	it("clamps and caps readSlice context", async () => {
@@ -647,7 +662,7 @@ describe("ast_grep_search tool", () => {
 			{ cwd: "." },
 		);
 
-		expect(result.details.matchLocations).toEqual([
+		expect(asSearchDetails(result.details).matchLocations).toEqual([
 			{
 				file: "src/near-top.ts",
 				line: 1,
@@ -683,7 +698,7 @@ describe("ast_grep_search tool", () => {
 			{ cwd: "." },
 		);
 
-		expect(result.details.matchLocations).toEqual([
+		expect(asSearchDetails(result.details).matchLocations).toEqual([
 			{
 				file: "src/default.ts",
 				line: 10,
@@ -715,7 +730,7 @@ describe("ast_grep_search tool", () => {
 			{ cwd: "." },
 		);
 
-		expect(result.details.matchLocations).toEqual([
+		expect(asSearchDetails(result.details).matchLocations).toEqual([
 			{
 				file: "src/no-margin.ts",
 				line: 10,
@@ -741,8 +756,8 @@ describe("ast_grep_search tool", () => {
 			{ cwd: "." },
 		);
 
-		expect(result.details.matchLocations).toEqual([]);
-		expect(result.details.searchReads).toEqual([]);
+		expect(asSearchDetails(result.details).matchLocations).toEqual([]);
+		expect(asSearchDetails(result.details).searchReads).toEqual([]);
 	});
 
 	it("returns clear errors for missing or unsafe pattern/lang inputs", async () => {
@@ -861,7 +876,7 @@ describe("ast_grep_search tool", () => {
 		);
 
 		expect(String(result.content[0].text)).toContain("ast_grep_dump");
-		expect(result.details.suggestedDump).toMatchObject({
+		expect(asSearchDetails(result.details).suggestedDump).toMatchObject({
 			tool: "ast_grep_dump",
 			lang: "typescript",
 		});


### PR DESCRIPTION
## Summary

Prepares master for the TypeScript 7 migration (#809) so dependabot #600 (typescript 6.0.3 → 7.0.2) can rebase and go green. Code-only; no dependency or pin changes.

- `clients/lsp/client.ts`: the `workspace/applyEdit` request handler now declares `Promise<{ applied: boolean; failureReason?: string }>` explicitly — TS7's stricter overload selection rejected the inferred two-branch union. No runtime change.
- `tests/tools/ast-grep-search.test.ts`: one shared `asSearchDetails` helper narrows the result-details union before accessing `matchLocations`/`suggestedDump`/`searchReads` (14 sites); fields modeled as optional since a successful search legitimately lacks `suggestedDump`. No `as any`.

Assessment context (full TS7 sweep): these were the only 15 diagnostics; no tsconfig options removed, no programmatic compiler-API usage, and dist emit is byte-identical between TS6 and TS7 across all 328 files. Follow-ups after #600 lands: bump the `build:dist` `typescript@6` pin, then close #809. Measured lint-gate speedup on a dev machine: ~14.3s → ~2.1s.

## Verification

- TS 6.0.3 (committed devDep): `npm run build`, `npm run lint`, `npm run check:lockfile` pass; `ast-grep-search` 42/42; LSP integration (exercises the solicited `workspace/applyEdit` path) 25/25.
- TS 7.0.2 (local, not committed): `npx tsc --project tsconfig.json` and `--project tsconfig.build.json` — zero diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)