### PR TITLE
docs: refresh contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -866,6 +866,15 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "neumie",
+      "name": "Jakub Neumann",
+      "avatar_url": "https://avatars.githubusercontent.com/u/23665482?v=4",
+      "profile": "https://neumie.dev/",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Thanks goes to these wonderful people:
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/aaronkyriesenbach"><img src="https://avatars.githubusercontent.com/u/12665860?v=4" width="100px;" alt=""/><br /><sub><b>Aaron Ky-Riesenbach</b></sub></a><br /><a href="#bug-aaronkyriesenbach" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/LovelyLoong"><img src="https://avatars.githubusercontent.com/u/54889641?v=4" width="100px;" alt=""/><br /><sub><b>可爱的龙</b></sub></a><br /><a href="#bug-LovelyLoong" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/pppobear"><img src="https://avatars.githubusercontent.com/u/21952175?v=4" width="100px;" alt=""/><br /><sub><b>pppobear</b></sub></a><br /><a href="#bug-pppobear" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://neumie.dev/"><img src="https://avatars.githubusercontent.com/u/23665482?v=4" width="100px;" alt=""/><br /><sub><b>Jakub Neumann</b></sub></a><br /><a href="#code-neumie" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Adds @neumie (Jakub Neumann, PR #852) to the contributors table via the canonical `all-contributors-cli add neumie code` — one new entry in `.all-contributorsrc` and its generated README cell, no other churn. Refs #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)