### PR TITLE
chore(build): bump build:dist tsc pin to typescript@7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
-### Fixed
-
-- **TypeScript 7 compatibility fixes (refs #809)** — narrowed ast-grep search test details and made the LSP `workspace/applyEdit` response overload-compatible, unblocking Dependabot PR #600.
-
 ### Added
 
 ### Changed
 
+- **`build:dist` now compiles with TypeScript 7.0.2** (refs #809) — the dist emit pin moves from `typescript@6` to the same major as the dev dependency (#600); emitted output was verified byte-identical across all 328 files before the bump.
+
 ### Fixed
+
+- **TypeScript 7 compatibility fixes (refs #809)** — narrowed ast-grep search test details and made the LSP `workspace/applyEdit` response overload-compatible, unblocking Dependabot PR #600.
 
 - **ast-grep NAPI fallback now runs TSX-tagged rules and reports unsupported-language skips** (refs #282) — `.tsx` files use the `tsx` grammar for rule-language scoping, preserving the exact TypeScript/JavaScript twin behavior from #657; rules for languages the fallback cannot evaluate are logged once per rule instead of disappearing as zero matches.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	},
 	"scripts": {
 		"build": "tsc --project tsconfig.build.json",
-		"build:dist": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && npx --yes -p typescript@6 tsc --project tsconfig.dist.json --noCheck && npm run bundle:dist",
+		"build:dist": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && npx --yes -p typescript@7.0.2 tsc --project tsconfig.dist.json --noCheck && npm run bundle:dist",
 		"bundle:dist": "node scripts/bundle-dist.mjs",
 		"prepare": "npm run build:dist && node scripts/download-grammars.js --core --dest grammars",
 		"lint": "tsc --project tsconfig.json",


### PR DESCRIPTION
Final #809 step now that #600 is merged: `build:dist` compiles with the same TypeScript major as the dev dependency. The #809 assessment verified the `--noCheck` dist emit is byte-identical between 6.0.3 and 7.0.2 across all 328 emitted files, and I re-ran `npm run build:dist` locally under the new pin before committing. Also consolidates the duplicated `### Fixed` heading the recent CHANGELOG merge train left behind.

Closes #809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)