### PR TITLE
test(mcp): scale tools/call deadline in CI + untimed warm-up for analyze-graph smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,10 @@ jobs:
         run: npm run build
 
       - name: Run tests
+        env:
+          # Spawn-heavy MCP smokes retain a 20s local deadline but need room
+          # for loaded shared runners (#860).
+          PI_LENS_TEST_TIMEOUT_SCALE: '3'
         run: npm test
 
   # Simulates pi's real install path: a `git:` install runs `npm install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,6 +307,10 @@ node scripts/smoke-tools.mjs [--install] [--step2] [--verbose] [lang ...]   # li
 #   Lint covers ts/py/yaml/js/markdown/shell/css/html/toml/sql/dockerfile/terraform + toolchain-gated go/rust/csharp/powershell/zig/java/dart/php/ruby/kotlin/gleam/elixir (toolchain must be installed locally; CI nightly sets them up).
 curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=apmantza_pi-lens&branch=master&status=TO_REVIEW&ps=100"   # list open SonarCloud security hotspots (public API, no auth). Triage: real fix vs mark-Safe (this project has had S5852 ReDoS false-positives on trusted bounded tool output).
 npm run logs:smells   # scripts/analyze-pi-lens-logs.mjs — scans ~/.pi-lens/*.log for operational smells (diagnostic-blockers, slow-hook-path ≥5s, slow-runners ≥2.5s, cascade-slow-graphs ≥1s, lsp-availability-noise, read-guard-friction). Flags: --since 3d (default 2d), --limit, --json. READ CRITICALLY: much volume is user-project diagnostics (not pi-lens bugs) + self-noise from temp:pi-lens-smoke-* (my own --install cold-tool runs). Real pi-lens smells: cascade-slow-graphs + slow-hook-path (cold LSP + cascade hot-path).
+#   MCP spawn smokes keep a 20s local per-request default; set
+#   PI_LENS_TEST_TIMEOUT_SCALE to a positive finite multiplier (CI uses 3) when
+#   loaded runners need a larger deadline. analyze-graph.smoke.test.ts warms
+#   the server with a throwaway pilens_health call before its assertions.
 ```
 
 Because many test imports use `.js` specifiers while the source of truth is `.ts`, recompile after TS changes before running tests when local `.js` artifacts may exist/stale:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to pi-lens will be documented in this file.
 
 - **TypeScript 7 compatibility fixes (refs #809)** — narrowed ast-grep search test details and made the LSP `workspace/applyEdit` response overload-compatible, unblocking Dependabot PR #600.
 
+- **MCP smoke deadlines scale under CI load (refs #860)** — the shared MCP
+	test harness keeps its 20s local default, accepts the
+	`PI_LENS_TEST_TIMEOUT_SCALE` multiplier, and the analyze-graph smoke pays
+	server startup through a throwaway health call before its assertions.
+
 ### Added
 
 ### Changed

--- a/tests/mcp/analyze-graph.smoke.test.ts
+++ b/tests/mcp/analyze-graph.smoke.test.ts
@@ -84,6 +84,11 @@ describe("pilens_analyze (warm) maintains the review graph over MCP", () => {
 			"2025-06-18",
 		);
 		harness.notify("notifications/initialized");
+		// Pay the one-time server startup cost before the asserted request window.
+		await harness.request(2, "tools/call", {
+			name: "pilens_health",
+			arguments: {},
+		});
 	});
 
 	afterAll(() => {
@@ -187,6 +192,11 @@ describe("pilens_analyze (warm) also maintains the word index over MCP (#536 rid
 			"2025-06-18",
 		);
 		harness.notify("notifications/initialized");
+		// Pay the one-time server startup cost before the asserted request window.
+		await harness.request(2, "tools/call", {
+			name: "pilens_health",
+			arguments: {},
+		});
 	});
 
 	afterAll(() => {

--- a/tests/mcp/harness.ts
+++ b/tests/mcp/harness.ts
@@ -16,6 +16,14 @@ export const repoRoot = path.resolve(
 	"../..",
 );
 const serverJs = path.join(repoRoot, "mcp", "server.js");
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+// Spawn-heavy MCP smokes keep a tight local deadline, while CI can compensate
+// for a loaded runner without changing the production server's budgets.
+const testTimeoutScale = (() => {
+	const parsed = Number(process.env.PI_LENS_TEST_TIMEOUT_SCALE ?? "1");
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+})();
 
 export interface McpHarnessOptions {
 	/** Project root the server operates on (--cwd). Defaults to the repo root. */
@@ -33,7 +41,8 @@ export class McpHarness {
 	private defaultTimeoutMs: number;
 
 	constructor(options: McpHarnessOptions = {}) {
-		this.defaultTimeoutMs = options.defaultTimeoutMs ?? 20_000;
+		this.defaultTimeoutMs =
+			options.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS * testTimeoutScale;
 		this.child = spawn(
 			process.execPath,
 			[serverJs, `--cwd=${options.cwd ?? repoRoot}`],


### PR DESCRIPTION
## Summary

Fixes the analyze-graph MCP smoke flake that hit three unrelated PRs on 2026-07-28 (#853, #854, and docs-only #859), always as `timeout: tools/call` at exactly the 20s deadline under loaded runners.

- The deadline lives in the shared `tests/mcp/harness.ts` (`defaultTimeoutMs ?? 20_000`). It now accepts a `PI_LENS_TEST_TIMEOUT_SCALE` multiplier: positive finite values scale the shared default; invalid/zero/negative fall back to 1; explicit per-request timeouts are untouched. Local default stays a tight 20s so real hangs still fail fast in dev.
- CI's Unit tests job sets scale 3 (60s effective) for the spawn-heavy MCP smokes.
- Both analyze-graph suites now pay server spawn/startup cost through a throwaway `pilens_health` `tools/call` in `beforeAll` — it exercises the real server without mutating the review graph or word index, so the cold-graph and pre-seeded-index assertions keep their exact meaning while the timed test bodies no longer absorb startup cost.
- No assertions weakened; no production code touched. The one-off `module-report.test.ts` callbackSupport failure from the same day was checked and is unrelated (in-process path, doesn't use this harness).

Closes #860.

## Verification

- Analyze-graph smoke: 3/3 with no scale set (20s default) and 3/3 with `PI_LENS_TEST_TIMEOUT_SCALE=3`.
- Full `tests/mcp/`: 8 files, 38 tests pass at the default deadline.
- `npm run build`, `npm run lint` pass; AGENTS.md testing note and CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)