### PR TITLE
chore(deps): js-yaml 5-compatible imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Changed
 
+- **`js-yaml` imports are compatible with v5** (refs #391, #843) — use the
+	package's namespace exports so the central accessor and YAML rule tooling work
+	with both the current v4 dependency and the upcoming v5 release. `@types/js-yaml`
+	remains temporarily because js-yaml 4.3.0 needs its declarations; remove it
+	with the v5 Dependabot upgrade once the bundled declarations are active.
+
 - **`build:dist` now compiles with TypeScript 7.0.2** (refs #809) — the dist emit pin moves from `typescript@6` to the same major as the dev dependency (#600); emitted output was verified byte-identical across all 328 files before the bump.
 
 ### Fixed

--- a/clients/deps/js-yaml.ts
+++ b/clients/deps/js-yaml.ts
@@ -3,7 +3,7 @@
  * Exposes both the default export (callers that do `import yaml from …`) and the
  * named `dump`/`load` helpers, sourced from the one import.
  */
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 export default yaml;
 export const dump = yaml.dump;

--- a/scripts/gen-rule-catalogs.mjs
+++ b/scripts/gen-rule-catalogs.mjs
@@ -18,7 +18,7 @@ import {
 } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, relative } from "node:path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..");

--- a/tests/clients/ast-grep-rule-precedence-followups.test.ts
+++ b/tests/clients/ast-grep-rule-precedence-followups.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { js as sgJs, ts as sgTs } from "@ast-grep/napi";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	evaluateAstGrepRules,

--- a/tests/clients/coderabbit-ast-grep-rules.test.ts
+++ b/tests/clients/coderabbit-ast-grep-rules.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 const CODERABBIT_ROOT = path.join(
 	process.cwd(),

--- a/tests/clients/deps-js-yaml.test.ts
+++ b/tests/clients/deps-js-yaml.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import yaml from "../../clients/deps/js-yaml.js";
+
+describe("central js-yaml accessor", () => {
+	it("loads rule documents and dumps synthesized objects", () => {
+		const document = yaml.load(
+			"id: example-rule\nmessage: prefer the example\nrules:\n  - kind: identifier\n",
+		) as { id: string; message: string; rules: Array<{ kind: string }> };
+
+		expect(document).toEqual({
+			id: "example-rule",
+			message: "prefer the example",
+			rules: [{ kind: "identifier" }],
+		});
+		expect(yaml.dump({ id: document.id, enabled: true })).toBe(
+			"id: example-rule\nenabled: true\n",
+		);
+	});
+});

--- a/tests/clients/dispatch/runners/ast-grep-rule-validity.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-rule-validity.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { parse, Lang } from "@ast-grep/napi";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 // Guards the #239 Phase-2 invariant: EVERY shipped ast-grep rule must be
 // accepted by napi's native engine (root.findAll) — the SAME Rust core the


### PR DESCRIPTION
## Summary

Prepares master for the js-yaml 4.3.0 → 5.2.2 major bump (#391, dependabot #843). js-yaml 5's ESM entrypoint drops the default export, which currently zeroes out pi-lens's central accessor (`clients/deps/js-yaml.ts`) at runtime — 58 dispatch tests fail under v5 on unmodified master.

- Namespace imports (`import * as yaml`) replace default imports in the central accessor, `scripts/gen-rule-catalogs.mjs`, and the three test files that imported js-yaml directly. Works identically on both majors; the accessor's exported surface is unchanged so no call sites move.
- New `tests/clients/deps-js-yaml.test.ts` regression test proves load + dump through the accessor — the test that would have caught the v5 break.
- `@types/js-yaml` is deliberately **kept** for now: verified empirically that js-yaml 4.3.0 ships no declarations (`npm run build` fails TS7016 without @types). It becomes removable only with the v5 bump — tracked for the post-#843 cleanup, which will close #391.
- Assessment context: all 902 shipped rule/fixture YAML files contain zero YAML-1.1-isms, and v4 already parses `on`/`off`/`yes`/`no` as strings, so the v5 schema change is a no-op for this corpus — no schema pin needed.

Refs #391.

## Verification

- v4 (committed): `npm run build`, `npm run lint`, `npm run check:lockfile`, 19/19 across the four touched/new test files, `audit:astgrep-rule-pairs` clean.
- v5 (js-yaml@5.2.2 --no-save): `npm run build` passes; 20/20 across the regression test + napi fallback rule suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)