### PR TITLE
fix(rules): add missing defect_class metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Missing tree-sitter defect-class metadata is now covered** (refs #863) — loop-termination and `finally` control-flow rules now declare their taxonomy classes, keeping the rule audit complete.
+
 - **MCP smoke deadlines scale under CI load (refs #860)** — the shared MCP
 	test harness keeps its 20s local default, accepts the
 	`PI_LENS_TEST_TIMEOUT_SCALE` multiplier, and the analyze-graph smoke pays

--- a/rules/tree-sitter-queries/typescript/no-equality-in-for-condition.yml
+++ b/rules/tree-sitter-queries/typescript/no-equality-in-for-condition.yml
@@ -4,6 +4,7 @@ id: no-equality-in-for-condition
 name: Loose equality in for-loop condition
 severity: warning
 category: bug
+defect_class: correctness
 inline_tier: warning
 language: typescript
 

--- a/rules/tree-sitter-queries/typescript/no-jump-in-finally.yml
+++ b/rules/tree-sitter-queries/typescript/no-jump-in-finally.yml
@@ -4,6 +4,7 @@ id: no-jump-in-finally
 name: Control-flow jump in finally block
 severity: warning
 category: bug
+defect_class: silent-error
 inline_tier: warning
 language: typescript
 


### PR DESCRIPTION
Adds the two missing `defect_class` entries flagged by `npm run audit:tree-sitter` (185-file corpus, now `missingDefectClass: 0`):

- `no-equality-in-for-condition.yml` → `correctness`, matching the loop-termination precedents (infinite-loop / switch-termination rules);
- `no-jump-in-finally.yml` → `silent-error`, matching the swallowed/ignored-exception rules (empty handlers, discarded errors).

The audit script needed no change — it already hard-fails (`process.exit(1)`) on missing metadata, so with the corpus at zero this can't silently regress.

Closes #863.

`audit:tree-sitter` and `audit:rule-catalog` both pass (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)