### PR TITLE
chore(deps): drop @types/js-yaml — v5 ships its own declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Changed
 
+- **`@types/js-yaml` removed; js-yaml 5 migration complete** (closes #391) — with
+	js-yaml 5.2.2 in (#843) the package ships its own declarations, so the stub
+	types dev-dependency is gone and the lockfile regenerated. This completes the
+	v5 migration started with the namespace-import compatibility pass below.
+
 - **`js-yaml` imports are compatible with v5** (refs #391, #843) — use the
 	package's namespace exports so the central accessor and YAML rule tooling work
 	with both the current v4 dependency and the upcoming v5 release. `@types/js-yaml`

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
 			"devDependencies": {
 				"@biomejs/biome": "^2.4.10",
 				"@earendil-works/pi-coding-agent": "^0.82.1",
-				"@types/js-yaml": "^4.0.9",
 				"@types/node": "^26.0.0",
 				"@types/pidusage": "^2.0.5",
 				"@vitest/coverage-v8": "^4.1.5",
@@ -2967,13 +2966,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/js-yaml": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-			"integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.10",
 		"@earendil-works/pi-coding-agent": "^0.82.1",
-		"@types/js-yaml": "^4.0.9",
 		"@types/node": "^26.0.0",
 		"@types/pidusage": "^2.0.5",
 		"@vitest/coverage-v8": "^4.1.5",


### PR DESCRIPTION
Final step of the js-yaml 5 migration (#391): with 5.2.2 merged (#843), js-yaml ships its own TypeScript declarations, so the `@types/js-yaml` stub is removed and the lockfile regenerated. Verified: `npm run build`, `npm run lint` (tsc resolves the bundled `dist/js-yaml.d.ts`), `npm run check:lockfile`, and the accessor regression test pass under v5.

Closes #391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)