### PR TITLE
fix(dispatch): Gate-B supersede checks LSP liveness + launcher-consistent resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,12 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   Client shutdown's fire-and-forget instance-registry removal is serialized at
   its read-modify-write seam so concurrent removals cannot lose siblings;
   process-tree kills remain concurrent.
+- **Auxiliary LSP liveness is a read-only dispatch seam (#868).**
+  `clients/lsp/index.ts` exposes `isAuxiliaryLspAlive(serverId, filePath)` for
+  Gate-B fallback decisions. It resolves the matching root and inspects only
+  the existing client map; it must never spawn or warm a client. Dispatch-side
+  code imports this seam from `lsp/index.ts`, while `dispatch/auxiliary-lsp.ts`
+  remains free of the reverse import to avoid the LSP/auxiliary cycle.
 - **Warm-build staleness guard (#535).** The warm server lives for weeks, so it
   can silently keep serving OLD code after a `npm run build:dist`/merge changes
   `dist/mcp/server.js` on disk — dogfooding caught this live (a post-#517

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **ast-grep Gate-B now follows LSP liveness and launcher resolution** (refs #868) — the NAPI fallback no longer runs beside a healthy ast-grep LSP when the bundled native binary is resolvable but `ast-grep` is absent from PATH; it still engages when neither resolution path nor a live client is available.
+
 - **NAPI fallback unsupported-rule skips no longer spam the session log** (refs #282) — the per-rule terminal lines (one for each of the ~30 non-jsts catalog rules) are replaced by a single aggregated `astgrep_napi_unsupported_rules_skipped` entry in `latency.log` carrying per-language counts and rule ids.
 
 - **Missing tree-sitter defect-class metadata is now covered** (refs #863) — loop-termination and `finally` control-flow rules now declare their taxonomy classes, keeping the rule audit complete.

--- a/clients/dispatch/runners/ast-grep-napi.ts
+++ b/clients/dispatch/runners/ast-grep-napi.ts
@@ -22,6 +22,8 @@ import { logLatency } from "../../latency-logger.js";
 import { hasEslintConfig } from "../../tool-policy.js";
 import { enabledAuxiliaryLspServerIds } from "../auxiliary-lsp.js";
 import { classifyDefect } from "../diagnostic-taxonomy.js";
+import { isAuxiliaryLspAlive } from "../../lsp/index.js";
+import { resolveAstGrepNativeExe } from "../../lsp/wait-policy/index.js";
 import { PRIORITY } from "../priorities.js";
 import type {
 	Diagnostic,
@@ -513,7 +515,20 @@ const astGrepNapiRunner: RunnerDefinition = {
 		const astGrepLspEnabled = enabledAuxiliaryLspServerIds((f) =>
 			ctx.pi?.getFlag?.(f),
 		).includes("ast-grep");
-		if (astGrepLspEnabled && (await ctx.hasTool("ast-grep"))) {
+		// Gate B asks whether the LSP will handle this file, not whether a bare
+		// `ast-grep` command happens to be on PATH. The launcher first tries the
+		// platform-native package binary, then PATH; mirror that resolution here.
+		// A live client covers the already-warm case, while a resolvable binary
+		// covers the cold case before the LSP has spawned for this root.
+		const astGrepLspAlive = astGrepLspEnabled
+			? await isAuxiliaryLspAlive("ast-grep", ctx.filePath)
+			: false;
+		let astGrepBinaryResolvable = false;
+		if (astGrepLspEnabled && !astGrepLspAlive) {
+			astGrepBinaryResolvable =
+				Boolean(resolveAstGrepNativeExe()) || (await ctx.hasTool("ast-grep"));
+		}
+		if (astGrepLspEnabled && (astGrepLspAlive || astGrepBinaryResolvable)) {
 			return { status: "skipped", diagnostics: [], semantic: "none" };
 		}
 

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -1134,6 +1134,26 @@ export class LSPService {
 		return undefined;
 	}
 
+	/**
+	 * Read-only liveness check for one server/file pair. Unlike
+	 * `getClientForFile`, this never creates or warms a client; it only resolves
+	 * the server's root and checks the already-connected client map.
+	 */
+	async isServerAliveForFile(
+		serverId: string,
+		filePath: string,
+	): Promise<boolean> {
+		if (this.checkDestroyed()) return false;
+		for (const server of getServersForFileWithConfig(filePath)) {
+			if (server.id !== serverId) continue;
+			const root = await server.root(filePath);
+			if (!root) continue;
+			const key = `${server.id}:${normalizeMapKey(root)}`;
+			if (this.state.clients.get(key)?.isAlive()) return true;
+		}
+		return false;
+	}
+
 	private async ensureClientForServer(
 		filePath: string,
 		server: LSPServerInfo,
@@ -4131,6 +4151,18 @@ export function getLSPService(): LSPService {
 		globalLSPService = new LSPService(globalLSPGenerationHandoff);
 	}
 	return globalLSPService;
+}
+
+/**
+ * Cross-layer liveness seam for dispatch-side auxiliary gates. This is a
+ * liveness read only: it does not spawn, wait for initialization, or probe a
+ * binary.
+ */
+export async function isAuxiliaryLspAlive(
+	serverId: string,
+	filePath: string,
+): Promise<boolean> {
+	return getLSPService().isServerAliveForFile(serverId, filePath);
 }
 
 export function resetLSPService(options: LSPShutdownOptions = {}): void {

--- a/tests/clients/dispatch/runners/ast-grep-napi.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi.test.ts
@@ -4,6 +4,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FactStore } from "../../../../clients/dispatch/fact-store.js";
 import { setupTestEnvironment } from "../../test-utils.js";
 
+const { mockAuxiliaryLspAlive, mockResolveAstGrepNativeExe } = vi.hoisted(() => ({
+	mockAuxiliaryLspAlive: vi.fn().mockResolvedValue(false),
+	mockResolveAstGrepNativeExe: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../../../clients/lsp/index.js", () => ({
+	isAuxiliaryLspAlive: mockAuxiliaryLspAlive,
+}));
+
+vi.mock("../../../../clients/lsp/wait-policy/index.js", () => ({
+	resolveAstGrepNativeExe: mockResolveAstGrepNativeExe,
+}));
+
 // Mock heavy dependencies before importing the runner
 vi.mock("../../../../clients/tool-policy.js", () => ({
 	hasEslintConfig: vi.fn().mockReturnValue(false),
@@ -45,20 +58,67 @@ function createCtx(filePath: string, overrides: Partial<Record<string, unknown>>
 describe("ast-grep-napi runner — LSP supersede gate (#239 Phase 2)", () => {
 	beforeEach(() => {
 		vi.resetModules();
+		mockAuxiliaryLspAlive.mockResolvedValue(false);
+		mockResolveAstGrepNativeExe.mockReturnValue(undefined);
 	});
 
-	it("skips when the ast-grep LSP is enabled and its binary IS available", async () => {
+	it("skips when PATH fails but the bundled launcher binary resolves", async () => {
 		const env = setupTestEnvironment("pi-lens-ast-grep-gate-");
 		try {
 			const filePath = path.join(env.tmpDir, "file.ts");
 			fs.writeFileSync(filePath, "const r = arr.sort();\n"); // would match no-sort-without-comparator
+			mockResolveAstGrepNativeExe.mockReturnValue("/bundled/ast-grep.exe");
 			vi.doMock("@ast-grep/napi", () => ({ ts: { parse: vi.fn() } }));
 			const mod = await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
 			const result = await mod.default.run(
-				createCtx(filePath, { hasTool: async () => true }) as any,
+				createCtx(filePath, { hasTool: async () => false }) as any,
 			);
 			expect(result.status).toBe("skipped");
 			expect(result.diagnostics).toHaveLength(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("runs when the launcher binary and PATH are unavailable and no client is live", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-gate-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			vi.doMock("@ast-grep/napi", () => ({
+				ts: {
+					parse: vi.fn().mockReturnValue({
+						root: () => ({
+							children: () => [],
+							kind: () => "program",
+							range: () => ({ start: { line: 0, column: 0 }, end: { line: 1, column: 0 } }),
+							findAll: () => [],
+						}),
+					}),
+				},
+			}));
+			const mod = await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("succeeded");
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("skips when a live ast-grep LSP client is handling the file regardless of PATH", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-gate-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			mockAuxiliaryLspAlive.mockResolvedValue(true);
+			vi.doMock("@ast-grep/napi", () => ({ ts: { parse: vi.fn() } }));
+			const mod = await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/dispatch/runners/ast-grep-sonar-rules.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-sonar-rules.test.ts
@@ -1,6 +1,12 @@
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import { FactStore } from "../../../../clients/dispatch/fact-store.js";
 import { createTempFile, setupTestEnvironment } from "../../test-utils.js";
+
+// These are NAPI fallback integration tests. Keep the launcher Gate-B signal
+// absent explicitly now that the default install includes a bundled binary.
+vi.mock("../../../../clients/lsp/wait-policy/index.js", () => ({
+	resolveAstGrepNativeExe: () => undefined,
+}));
 
 // Integration test: runs the REAL ast-grep-napi runner against fixtures so the
 // actual shipped YAML rules (loaded from rules/ast-grep-rules/rules) execute

--- a/tests/clients/dispatch/runners/ast-grep-utils-block.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-utils-block.test.ts
@@ -7,6 +7,9 @@ const logLatency = vi.fn();
 vi.mock("../../../../clients/latency-logger.js", () => ({
 	logLatency: (entry: unknown) => logLatency(entry),
 }));
+vi.mock("../../../../clients/lsp/wait-policy/index.js", () => ({
+	resolveAstGrepNativeExe: () => undefined,
+}));
 
 const RULES_DIR = path.join(process.cwd(), "rules", "ast-grep-rules", "rules");
 


### PR DESCRIPTION
## Summary

Fixes #868: the napi Gate-B fallback ran on every dispatch alongside a healthy ast-grep LSP, because its availability probe (bare PATH spawn of `ast-grep --version`) and the LSP launcher (bundled `@ast-grep/cli-win32-x64-msvc` via `require.resolve`) resolved the same tool differently. On default installs with no PATH ast-grep — the common shape — the probe permanently cached `false` and napi double-ran all session (confirmed from live-session latency.log/cascade.log).

- New read-only seam: `LSPService.isServerAliveForFile()` + `isAuxiliaryLspAlive()` in `clients/lsp/index.ts` — resolves the file's root and checks the connected-client map only; never spawns, warms, or probes.
- Gate-B now supersedes when the LSP is enabled AND (live client for this file's root, OR the binary resolves the launcher's way — `resolveAstGrepNativeExe()` first, cached PATH probe last). Probe and launcher can no longer disagree.
- True fallback preserved: bundled unresolvable + PATH miss + no live client → napi engages (#308's no-binary gap stays closed).
- Two existing fallback tests updated to explicitly mock bundled resolution absent (they previously relied on PATH-miss implying fallback, which is exactly the assumption this bug lived in).

Closes #868.

## Tests

Three new Gate-B cases in `ast-grep-napi.test.ts`: superseded via bundled resolution (PATH miss), superseded via live client (regardless of PATH), true fallback when all three signals absent. Full dispatch suite: 563 passed (only the two known environment-bound CDP playground smokes failed). `npm run build`, `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)