### PR TITLE
test: real-runner coverage follow-ups from the #448 audit (refs #873)

### DIFF
--- a/tests/clients/coderabbit-ast-grep-rules.test.ts
+++ b/tests/clients/coderabbit-ast-grep-rules.test.ts
@@ -1,7 +1,11 @@
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import * as yaml from "js-yaml";
+import { resolveAstGrepNativeExe } from "../../clients/lsp/wait-policy/index.js";
+import { getAstGrepRuleSources } from "../../clients/sgconfig.js";
+import { setupTestEnvironment } from "./test-utils.js";
 
 const CODERABBIT_ROOT = path.join(
 	process.cwd(),
@@ -92,4 +96,62 @@ describe("vendored CodeRabbit ast-grep rules", () => {
 		expect(unsafeUtilityIds).toEqual([]);
 		expect(unresolvedRefs).toEqual([]);
 	});
+
+	it("parses and runs every sgconfig-shipped rule through the real engine", () => {
+		const source = getAstGrepRuleSources(process.cwd()).find(
+			(entry) => entry.origin === "bundled" && entry.tier === "secondary",
+		);
+		expect(source?.dir).toBe(CODERABBIT_RULES_DIR);
+		expect(collectRuleFiles(source!.dir)).toHaveLength(184);
+
+		const env = setupTestEnvironment("pi-lens-coderabbit-smoke-");
+		try {
+			const fixtures = path.join(env.tmpDir, "fixtures");
+			fs.mkdirSync(fixtures);
+			const extensions = [
+				"c",
+				"cpp",
+				"cs",
+				"go",
+				"html",
+				"java",
+				"js",
+				"kt",
+				"php",
+				"py",
+				"rb",
+				"rs",
+				"scala",
+				"swift",
+				"ts",
+			];
+			for (const extension of extensions) {
+				fs.writeFileSync(path.join(fixtures, `empty.${extension}`), "");
+			}
+			const relativeRuleDir = path
+				.relative(env.tmpDir, source!.dir)
+				.replace(/\\/g, "/");
+			const configPath = path.join(env.tmpDir, "sgconfig.yml");
+			fs.writeFileSync(
+				configPath,
+				`ruleDirs:\n  - ${JSON.stringify(relativeRuleDir)}\n`,
+			);
+			const astGrepExe = resolveAstGrepNativeExe();
+			expect(astGrepExe).toBeDefined();
+
+			expect(() =>
+				execFileSync(
+					astGrepExe!,
+					["scan", "--config", configPath, fixtures],
+					{
+						cwd: env.tmpDir,
+						encoding: "utf8",
+						stdio: ["ignore", "pipe", "pipe"],
+					},
+				),
+			).not.toThrow();
+		} finally {
+			env.cleanup();
+		}
+	}, 30_000);
 });

--- a/tests/clients/dispatch/runners/ast-grep-napi.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi.test.ts
@@ -228,6 +228,42 @@ describe("ast-grep-napi runner — skip paths", () => {
 	});
 });
 
+describe("ast-grep-napi runner — real shipped rule", () => {
+	it("loads and matches no-sort-without-comparator through the real YAML parser", async () => {
+		vi.resetModules();
+		mockAuxiliaryLspAlive.mockResolvedValue(false);
+		mockResolveAstGrepNativeExe.mockReturnValue(undefined);
+		vi.doUnmock("../../../../clients/dispatch/runners/yaml-rule-parser.js");
+		vi.doUnmock("../../../../clients/package-root.js");
+		// Earlier skip-path cases install per-test NAPI mocks. Replace any
+		// lingering doMock registration with the package's real implementation.
+		vi.doMock("@ast-grep/napi", async (importOriginal) => importOriginal());
+		const env = setupTestEnvironment("pi-lens-ast-grep-real-rule-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const sorted = values.sort();\n");
+			const mod = await import(
+				"../../../../clients/dispatch/runners/ast-grep-napi.js"
+			);
+			expect(await mod.loadSg()).toBeDefined();
+
+			const result = await mod.default.run(
+				createCtx(filePath, {
+					cwd: env.tmpDir,
+					hasTool: async () => false,
+				}) as any,
+			);
+
+			expect(result.status).toBe("succeeded");
+			expect(result.diagnostics.map((diagnostic) => diagnostic.rule)).toContain(
+				"no-sort-without-comparator",
+			);
+		} finally {
+			env.cleanup();
+		}
+	}, 30_000);
+});
+
 describe("ast-grep-napi runner — metadata", () => {
 	it("has expected runner id and appliesTo", async () => {
 		vi.resetModules();

--- a/tests/clients/dispatch/runners/tree-sitter-dispatch-behavior.test.ts
+++ b/tests/clients/dispatch/runners/tree-sitter-dispatch-behavior.test.ts
@@ -6,6 +6,10 @@
  * inline_tier blocking) and variable-shadowing (inline_tier review).
  */
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+	RunnerRegistry,
+	dispatchForFile,
+} from "../../../../clients/dispatch/dispatcher.js";
 import treeSitterRunner from "../../../../clients/dispatch/runners/tree-sitter.js";
 
 // Keep unrelated fire-and-forget review-graph enrichment out of real-runner tests.
@@ -74,5 +78,35 @@ describe("tree-sitter runner — dispatch filtering (#448)", () => {
 			.map((d) => d.line);
 		expect(fired).not.toContain("variable-shadowing");
 		expect(debuggerLines).toEqual([3]);
+	}, 30_000);
+
+	it("applies inline suppression to a diagnostic produced by the real rule", async () => {
+		const content = [
+			"function suppressed() {",
+			"\t// pi-lens-ignore: debugger-statement",
+			"\tdebugger;",
+			"}",
+			"function visible() {",
+			"\tdebugger;",
+			"}",
+			"",
+		].join("\n");
+		const { ctx, filePath } = env.addFile("suppression.ts", content, {
+			deltaMode: false,
+		});
+		ctx.facts.setFileFact(filePath, "file.content", content);
+		const registry = new RunnerRegistry();
+		registry.register(treeSitterRunner);
+
+		const result = await dispatchForFile(
+			ctx,
+			[{ mode: "all", runnerIds: [treeSitterRunner.id] }],
+			registry,
+		);
+		const debuggerLines = result.diagnostics
+			.filter((diagnostic) => diagnostic.rule === "debugger-statement")
+			.map((diagnostic) => diagnostic.line);
+
+		expect(debuggerLines).toEqual([6]);
 	}, 30_000);
 });

--- a/tests/clients/scan-exclusion-stack.test.ts
+++ b/tests/clients/scan-exclusion-stack.test.ts
@@ -23,7 +23,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resetProjectLensConfigCache } from "../../clients/project-lens-config.js";
 import { collectSourceFiles } from "../../clients/source-filter.js";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { removeTempDirSync } from "./test-utils.js";
 
 let tmpDir: string;
@@ -103,7 +103,7 @@ function surfaces(): Surface[] {
 			collect: () =>
 				// collectFiles is private; the walk needs no grammars loaded.
 				// biome-ignore lint/suspicious/noExplicitAny: private method under test
-				(new TreeSitterClient() as any).collectFiles(tmpDir, "typescript"),
+				(getSharedTreeSitterClient()! as any).collectFiles(tmpDir, "typescript"),
 			// Language-scoped by design — only the requested language's files.
 			mustInclude: ["src/real.ts"],
 			excludesTests: false,

--- a/tests/clients/tree-sitter-c-rules.test.ts
+++ b/tests/clients/tree-sitter-c-rules.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
 import { removeTempDirSync } from "./test-utils.js";
 
@@ -36,7 +36,7 @@ afterAll(() => {
 
 describe("tree-sitter C rules", () => {
 	it("matches memset-sensitive-data only on sensitive args", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getCQuery("memset-sensitive-data");
 
 		const positivePath = writeTempCFile(`
@@ -57,7 +57,7 @@ void clear_buffer(char* buf) {
 	});
 
 	it("matches noreturn-returns when return is present", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getCQuery("noreturn-returns");
 		const filePath = writeTempCFile(`
 __attribute__((noreturn)) void fatal() {
@@ -70,7 +70,7 @@ __attribute__((noreturn)) void fatal() {
 	});
 
 	it("matches no-octal-literals", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getCQuery("no-octal-literals");
 		const filePath = writeTempCFile(`
 int x = 010;
@@ -82,7 +82,7 @@ int y = 0x10;
 	});
 
 	it("matches no-reserved-identifiers", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getCQuery("no-reserved-identifiers");
 		const filePath = writeTempCFile(`
 int _Reserved = 1;
@@ -97,7 +97,7 @@ int normal = 3;
 	});
 
 	it("matches no-stdlib-name-as-id", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getCQuery("no-stdlib-name-as-id");
 		const filePath = writeTempCFile(`
 int malloc = 10;
@@ -109,7 +109,7 @@ int my_size = 20;
 	});
 
 	it("matches no-bit-fields", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getCQuery("no-bit-fields");
 		const filePath = writeTempCFile(`
 struct Flags {
@@ -122,7 +122,7 @@ struct Flags {
 	});
 
 	it("matches no-redundant-pointer-ops", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getCQuery("no-redundant-pointer-ops");
 		const filePath = writeTempCFile(`
 void test() {
@@ -137,7 +137,7 @@ void test() {
 	});
 
 	it("matches no-pointer-arithmetic-array-access", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getCQuery("no-pointer-arithmetic-array-access");
 		const filePath = writeTempCFile(`
 void test() {
@@ -150,7 +150,7 @@ void test() {
 	});
 
 	it("matches c-hardcoded-secrets", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getCQuery("c-hardcoded-secrets");
 		const filePath = writeTempCFile(`
 const char* api_key = "sk-1234567890abcdef";
@@ -162,7 +162,7 @@ const char* msg = "hello";
 	});
 
 	it("matches non-case-label-in-switch", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getCQuery("non-case-label-in-switch");
 		const filePath = writeTempCFile(`
 void test(int x) {

--- a/tests/clients/tree-sitter-client-init.test.ts
+++ b/tests/clients/tree-sitter-client-init.test.ts
@@ -60,10 +60,10 @@ describe("tree-sitter-client wasm resolution", () => {
 	});
 
 	it("TreeSitterClient.isAvailable returns true when grammars are installed", async () => {
-		const { TreeSitterClient } = await import(
-			"../../clients/tree-sitter-client.js"
+		const { getSharedTreeSitterClient } = await import(
+			"../../clients/tree-sitter-shared.js"
 		);
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		expect(client.isAvailable()).toBe(true);
 	});
 
@@ -82,10 +82,10 @@ describe("tree-sitter-client wasm resolution", () => {
 			}),
 		}));
 
-		const { TreeSitterClient } = await import(
-			"../../clients/tree-sitter-client.js"
+		const { getSharedTreeSitterClient } = await import(
+			"../../clients/tree-sitter-shared.js"
 		);
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		// resolvePackagePath fallback should still find the grammars
 		expect(client.isAvailable()).toBe(true);
 	});
@@ -96,11 +96,11 @@ describe("tree-sitter-client wasm resolution", () => {
 		// Force that state, then assert isAvailable recovers against the real fs
 		// (bundled grammars/ and/or web-tree-sitter/grammars are present) rather
 		// than staying stuck on the empty cache.
-		const { TreeSitterClient } = await import(
-			"../../clients/tree-sitter-client.js"
+		const { getSharedTreeSitterClient } = await import(
+			"../../clients/tree-sitter-shared.js"
 		);
 		// biome-ignore lint/suspicious/noExplicitAny: poke privates for the regression
-		const client = new TreeSitterClient() as any;
+		const client = getSharedTreeSitterClient() as any;
 		client.grammarsDir = "";
 		client._bundledGrammarsDir = undefined;
 

--- a/tests/clients/tree-sitter-command-injection-rules.test.ts
+++ b/tests/clients/tree-sitter-command-injection-rules.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
 import { removeTempDirSync } from "./test-utils.js";
 
@@ -34,7 +34,7 @@ afterAll(() => {
 
 describe("tree-sitter command injection rules", () => {
 	it("matches python command injection sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-command-injection");
 		const filePath = writeTempFile(
 			"py",
@@ -46,7 +46,7 @@ describe("tree-sitter command injection rules", () => {
 	});
 
 	it("does not match safe python subprocess invocation", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-command-injection");
 		const filePath = writeTempFile(
 			"py",
@@ -58,7 +58,7 @@ describe("tree-sitter command injection rules", () => {
 	});
 
 	it("matches go command injection sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("go-command-injection");
 		const filePath = writeTempFile(
 			"go",
@@ -70,7 +70,7 @@ describe("tree-sitter command injection rules", () => {
 	});
 
 	it("does not match safe go command invocation", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("go-command-injection");
 		const filePath = writeTempFile(
 			"go",
@@ -82,7 +82,7 @@ describe("tree-sitter command injection rules", () => {
 	});
 
 	it("matches ruby command injection sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ruby-command-injection");
 		expect(query.language).toBe("ruby");
 		const filePath = writeTempFile("rb", `system(cmd)\n`);
@@ -92,7 +92,7 @@ describe("tree-sitter command injection rules", () => {
 	});
 
 	it("matches typescript command injection sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-command-injection");
 		const filePath = writeTempFile(
 			"ts",
@@ -104,7 +104,7 @@ describe("tree-sitter command injection rules", () => {
 	});
 
 	it("does not match non-child-process exec-like calls", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-command-injection");
 		const filePath = writeTempFile("ts", `const tool = { exec: () => {} }; tool.exec();\n`);
 

--- a/tests/clients/tree-sitter-concurrency-rules.test.ts
+++ b/tests/clients/tree-sitter-concurrency-rules.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
 import { removeTempDirSync } from "./test-utils.js";
 
@@ -34,7 +34,7 @@ afterAll(() => {
 
 describe("tree-sitter concurrency rules", () => {
 	it("matches detached async call in TypeScript", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-detached-async-call");
 		const filePath = writeTempFile(
 			"ts",
@@ -45,7 +45,7 @@ describe("tree-sitter concurrency rules", () => {
 	});
 
 	it("matches threaded global state write in Python", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-thread-global-write");
 		const filePath = writeTempFile(
 			"py",

--- a/tests/clients/tree-sitter-go-rules.test.ts
+++ b/tests/clients/tree-sitter-go-rules.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
 import { removeTempDirSync } from "./test-utils.js";
 
@@ -33,7 +33,7 @@ afterAll(() => {
 
 describe("tree-sitter go rules", () => {
 	it("matches go-bare-error only when function returns error", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getGoQuery("go-bare-error");
 
 		const positivePath = writeTempGoFile(`package main
@@ -56,7 +56,7 @@ func run() int {
 	});
 
 	it("matches go-empty-if-err on empty err handler", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getGoQuery("go-empty-if-err");
 		const filePath = writeTempGoFile(`package main
 
@@ -73,7 +73,7 @@ func run() error {
 	});
 
 	it("matches go-ignored-call-result on discarded result", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getGoQuery("go-ignored-call-result");
 		const filePath = writeTempGoFile(`package main
 
@@ -87,7 +87,7 @@ func run() {
 	});
 
 	it("matches go-direct-panic on panic call", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getGoQuery("go-direct-panic");
 		const filePath = writeTempGoFile(`package main
 
@@ -103,7 +103,7 @@ func run(err error) {
 	});
 
 	it("matches go-log-fatal on terminating log call", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getGoQuery("go-log-fatal");
 		const filePath = writeTempGoFile(`package main
 

--- a/tests/clients/tree-sitter-imports.test.ts
+++ b/tests/clients/tree-sitter-imports.test.ts
@@ -18,7 +18,7 @@ import {
 	grammarBlockReason,
 	LANGUAGE_TO_GRAMMAR,
 } from "../../clients/grammar-source.js";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterSymbolExtractor } from "../../clients/tree-sitter-symbol-extractor.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
@@ -120,7 +120,7 @@ const CASES: Record<string, ImportCase> = {
 
 let client: TreeSitterClient;
 beforeAll(async () => {
-	client = new TreeSitterClient();
+	client = getSharedTreeSitterClient()!;
 	await client.init();
 });
 

--- a/tests/clients/tree-sitter-imports.test.ts
+++ b/tests/clients/tree-sitter-imports.test.ts
@@ -19,6 +19,7 @@ import {
 	LANGUAGE_TO_GRAMMAR,
 } from "../../clients/grammar-source.js";
 import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
+import type { TreeSitterClient } from "../../clients/tree-sitter-client.js";
 import { TreeSitterSymbolExtractor } from "../../clients/tree-sitter-symbol-extractor.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 

--- a/tests/clients/tree-sitter-lua-shared-module.test.ts
+++ b/tests/clients/tree-sitter-lua-shared-module.test.ts
@@ -10,7 +10,7 @@
  * cleanly and extracts symbols + imports.
  */
 import { beforeAll, describe, expect, it } from "vitest";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterSymbolExtractor } from "../../clients/tree-sitter-symbol-extractor.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
@@ -30,7 +30,7 @@ function countErrorNodes(node: { type: string; children?: unknown[] }): number {
 describe("lua survives the shared WASM Module (#255)", () => {
 	let client: TreeSitterClient;
 	beforeAll(async () => {
-		client = new TreeSitterClient();
+		client = getSharedTreeSitterClient()!;
 		await client.init();
 	});
 
@@ -74,7 +74,7 @@ describe("overridden yaml grammar loads (#427)", () => {
 	it("parses yaml cleanly (aggregator wasm was ABI-unloadable)", async () => {
 		const env = setupTestEnvironment("pi-lens-yaml427-");
 		try {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			await client.init();
 			// Load a second grammar first, mirroring a real multi-language session.
 			const py = createTempFile(env.tmpDir, "a.py", "import os\n");

--- a/tests/clients/tree-sitter-lua-shared-module.test.ts
+++ b/tests/clients/tree-sitter-lua-shared-module.test.ts
@@ -11,6 +11,7 @@
  */
 import { beforeAll, describe, expect, it } from "vitest";
 import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
+import type { TreeSitterClient } from "../../clients/tree-sitter-client.js";
 import { TreeSitterSymbolExtractor } from "../../clients/tree-sitter-symbol-extractor.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 

--- a/tests/clients/tree-sitter-new-blocker-rules.test.ts
+++ b/tests/clients/tree-sitter-new-blocker-rules.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
 import { removeTempDirSync } from "./test-utils.js";
 
@@ -34,7 +34,7 @@ afterAll(() => {
 
 describe("S1219 — switch non-case labels (TS)", () => {
 	it("matches non-case label inside switch", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("switch-non-case-labels-ts");
 		const filePath = writeTempFile(
 			"ts",
@@ -53,7 +53,7 @@ describe("S1219 — switch non-case labels (TS)", () => {
 	});
 
 	it("does not match normal switch", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("switch-non-case-labels-ts");
 		const filePath = writeTempFile(
 			"ts",
@@ -74,7 +74,7 @@ describe("S1219 — switch non-case labels (TS)", () => {
 
 describe("S2970 — incomplete assertion (TS)", () => {
 	it("matches bare expect() in test block", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
@@ -88,7 +88,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 	});
 
 	it("matches uncalled matcher in test block", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
@@ -102,7 +102,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 	});
 
 	it("matches uncalled matcher with not modifier", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
@@ -116,7 +116,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 	});
 
 	it("does not match complete assertion", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
@@ -130,7 +130,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 	});
 
 	it("does not match complete assertion with not modifier", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
@@ -144,7 +144,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 	});
 
 	it("does not match when expect is assigned (not a statement)", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
@@ -158,7 +158,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 	});
 
 	it("does not flag Chai property assertions", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",

--- a/tests/clients/tree-sitter-python-rules.test.ts
+++ b/tests/clients/tree-sitter-python-rules.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
@@ -28,7 +28,7 @@ afterAll(() => {
 describe("python tree-sitter rules", () => {
 	describe("return-in-generator", () => {
 		it("flags valued return in a synchronous generator", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("return-in-generator");
 			const filePath = writeTempFile(
 				`def gen():\n    yield 1\n    return 42\n`,
@@ -40,7 +40,7 @@ describe("python tree-sitter rules", () => {
 		});
 
 		it("does not flag normal coroutine return values", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("return-in-generator");
 			const filePath = writeTempFile(
 				`async def get_details(request):\n    await load(request)\n    return TemplateResponse('page.html', {'request': request})\n`,
@@ -52,7 +52,7 @@ describe("python tree-sitter rules", () => {
 		});
 
 		it("does not flag non-generator functions", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("return-in-generator");
 			const filePath = writeTempFile(`def compute():\n    return 42\n`);
 

--- a/tests/clients/tree-sitter-security-gap-rules.test.ts
+++ b/tests/clients/tree-sitter-security-gap-rules.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
 import { removeTempDirSync } from "./test-utils.js";
 
@@ -34,7 +34,7 @@ afterAll(() => {
 
 describe("tree-sitter security gap rules", () => {
 	it("matches python ssrf sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-ssrf");
 		const filePath = writeTempFile(
 			"py",
@@ -45,7 +45,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("does not match safe python literal URL request", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-ssrf");
 		const filePath = writeTempFile(
 			"py",
@@ -56,7 +56,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("matches python path traversal sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-path-traversal");
 		const filePath = writeTempFile("py", `open(base + user_path)\n`);
 		const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -64,7 +64,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("does not match static python file path", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-path-traversal");
 		const filePath = writeTempFile("py", `open("/tmp/safe.txt")\n`);
 		const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -72,7 +72,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("matches python sql injection sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-sql-injection");
 		const filePath = writeTempFile(
 			"py",
@@ -83,7 +83,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("does not match parameterized python sql", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-sql-injection");
 		const filePath = writeTempFile(
 			"py",
@@ -94,7 +94,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("does not match SQLAlchemy session.execute(stmt)", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-sql-injection");
 		const filePath = writeTempFile(
 			"py",
@@ -105,7 +105,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("does not match SQLAlchemy expression-builder execute calls", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-sql-injection");
 		const filePath = writeTempFile(
 			"py",
@@ -116,7 +116,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("matches raw cursor.execute(sql_identifier)", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-sql-injection");
 		const filePath = writeTempFile("py", `cursor.execute(sql)\n`);
 		const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -124,7 +124,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("matches python insecure deserialization sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-insecure-deserialization");
 		const filePath = writeTempFile(
 			"py",
@@ -135,7 +135,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("does not match safe python json deserialization", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-insecure-deserialization");
 		const filePath = writeTempFile("py", `import json\njson.loads(payload)\n`);
 		const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -143,7 +143,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("matches python weak hash usage and exposes metadata", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("python-weak-hash");
 		expect(query.cwe).toContain("CWE-327");
 		expect(query.owasp).toContain("A02");
@@ -155,7 +155,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("matches go sql injection sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("go-sql-injection");
 		const filePath = writeTempFile(
 			"go",
@@ -166,7 +166,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("does not match parameterized go sql", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("go-sql-injection");
 		const filePath = writeTempFile(
 			"go",
@@ -177,7 +177,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("matches typescript ssrf sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-ssrf");
 		const filePath = writeTempFile("ts", `await fetch(userUrl);\n`);
 		const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -185,7 +185,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("matches go path traversal sink", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("go-path-traversal");
 		const filePath = writeTempFile(
 			"go",
@@ -196,7 +196,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("matches go insecure random usage", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("go-insecure-random");
 		const filePath = writeTempFile(
 			"go",
@@ -207,7 +207,7 @@ describe("tree-sitter security gap rules", () => {
 	});
 
 	it("matches typescript weak hash usage", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("ts-weak-hash");
 		const filePath = writeTempFile(
 			"ts",

--- a/tests/clients/tree-sitter-slop-rules.test.ts
+++ b/tests/clients/tree-sitter-slop-rules.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
 import { removeTempDirSync } from "./test-utils.js";
 
@@ -35,7 +35,7 @@ afterAll(() => {
 describe("slop detection rules", () => {
 	describe("python-hallucinated-import", () => {
 		it("flags JSONResponse imported from requests", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-hallucinated-import");
 			const filePath = writeTempFile("py", `from requests import JSONResponse\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -43,7 +43,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags Depends imported from flask", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-hallucinated-import");
 			const filePath = writeTempFile("py", `from flask import Depends\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -51,7 +51,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags json.parse (JavaScript idiom)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-hallucinated-import");
 			const filePath = writeTempFile("py", `from json import parse\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -59,7 +59,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags dataclass imported from typing", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-hallucinated-import");
 			const filePath = writeTempFile("py", `from typing import dataclass\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -67,7 +67,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag correct dataclass import", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-hallucinated-import");
 			const filePath = writeTempFile("py", `from dataclasses import dataclass\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -75,7 +75,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag correct fastapi import", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-hallucinated-import");
 			const filePath = writeTempFile("py", `from fastapi import Depends\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -85,7 +85,7 @@ describe("slop detection rules", () => {
 
 	describe("python-cross-language-method", () => {
 		it("flags .push() on a list", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-cross-language-method");
 			const filePath = writeTempFile("py", `items.push(x)\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -93,7 +93,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags .equals() (Java idiom)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-cross-language-method");
 			const filePath = writeTempFile("py", `name.equals("foo")\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -101,7 +101,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags .forEach() (JavaScript idiom)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-cross-language-method");
 			const filePath = writeTempFile("py", `items.forEach(lambda x: print(x))\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -109,7 +109,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags .isEmpty() (Java idiom)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-cross-language-method");
 			const filePath = writeTempFile("py", `if s.isEmpty(): pass\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -117,7 +117,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag .append() (correct Python)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("python-cross-language-method");
 			const filePath = writeTempFile("py", `items.append(x)\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "python");
@@ -127,7 +127,7 @@ describe("slop detection rules", () => {
 
 	describe("ts-hallucinated-react-import", () => {
 		it("flags useRouter imported from react", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-hallucinated-react-import");
 			const filePath = writeTempFile("ts", `import { useRouter } from 'react';\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -135,7 +135,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags Link imported from react", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-hallucinated-react-import");
 			const filePath = writeTempFile("ts", `import { Link, Image } from 'react';\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -143,7 +143,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags getServerSideProps imported from react", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-hallucinated-react-import");
 			const filePath = writeTempFile("ts", `import { getServerSideProps } from 'react';\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -151,7 +151,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag useState imported from react", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-hallucinated-react-import");
 			const filePath = writeTempFile("ts", `import { useState, useEffect } from 'react';\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -159,7 +159,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag useRouter from next/navigation", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-hallucinated-react-import");
 			const filePath = writeTempFile("ts", `import { useRouter } from 'next/navigation';\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -169,7 +169,7 @@ describe("slop detection rules", () => {
 
 	describe("ts-react-antipatterns", () => {
 		it("flags setState inside a for-of loop", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-react-antipatterns");
 			const filePath = writeTempFile("ts", `for (const item of items) {\n  setCount(count + 1);\n}\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -177,7 +177,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags setState inside a while loop", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-react-antipatterns");
 			const filePath = writeTempFile("ts", `while (i < items.length) {\n  setItems([...items, i]);\n  i++;\n}\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -185,7 +185,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag setState outside a loop", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-react-antipatterns");
 			const filePath = writeTempFile("ts", `setCount(items.length);\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -193,7 +193,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag setTimeout inside a loop", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-react-antipatterns");
 			const filePath = writeTempFile(
 				"ts",
@@ -204,7 +204,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag setInterval inside a for loop", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-react-antipatterns");
 			const filePath = writeTempFile(
 				"ts",
@@ -217,7 +217,7 @@ describe("slop detection rules", () => {
 
 	describe("unsafe-regex", () => {
 		it("flags new RegExp with plain user-input interpolation", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("unsafe-regex");
 			const filePath = writeTempFile(
 				"ts",
@@ -228,7 +228,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag new RegExp when interpolation uses escapeRegExp", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("unsafe-regex");
 			const filePath = writeTempFile(
 				"ts",
@@ -239,7 +239,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag new RegExp when variable is named 'escaped'", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("unsafe-regex");
 			const filePath = writeTempFile(
 				"ts",
@@ -250,7 +250,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag new RegExp when interpolation uses .replace() chain (glob-to-regex pattern)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("unsafe-regex");
 			const filePath = writeTempFile(
 				"ts",
@@ -263,7 +263,7 @@ describe("slop detection rules", () => {
 
 	describe("long-parameter-list", () => {
 		it("flags a function with 6 required parameters", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("long-parameter-list");
 			const filePath = writeTempFile(
 				"ts",
@@ -274,7 +274,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag a function with 4 required + 2 optional parameters", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("long-parameter-list");
 			const filePath = writeTempFile(
 				"ts",
@@ -285,7 +285,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag a function with 4 required + 2 defaulted parameters", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("long-parameter-list");
 			const filePath = writeTempFile(
 				"ts",
@@ -298,7 +298,7 @@ describe("slop detection rules", () => {
 
 	describe("ts-xss-dom-sink", () => {
 		it("flags innerHTML = variable", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-xss-dom-sink");
 			const filePath = writeTempFile("ts", `el.innerHTML = userInput;\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -306,7 +306,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags outerHTML = call expression", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-xss-dom-sink");
 			const filePath = writeTempFile("ts", `el.outerHTML = getData();\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -314,7 +314,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags document.write(variable)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-xss-dom-sink");
 			const filePath = writeTempFile("ts", `document.write(content);\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -322,7 +322,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag innerHTML = string literal", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-xss-dom-sink");
 			const filePath = writeTempFile("ts", `el.innerHTML = "<b>safe</b>";\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -330,7 +330,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag textContent = variable (safe API)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-xss-dom-sink");
 			const filePath = writeTempFile("ts", `el.textContent = userInput;\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -340,7 +340,7 @@ describe("slop detection rules", () => {
 
 	describe("ts-dynamic-require", () => {
 		it("flags require(identifier)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-dynamic-require");
 			const filePath = writeTempFile("ts", `const mod = require(pluginName);\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -348,7 +348,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags require(member expression)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-dynamic-require");
 			const filePath = writeTempFile("ts", `const lib = require(config.libPath);\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -356,7 +356,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag require(string literal)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-dynamic-require");
 			const filePath = writeTempFile("ts", `const mod = require("./utils");\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -366,7 +366,7 @@ describe("slop detection rules", () => {
 
 	describe("ts-open-redirect", () => {
 		it("flags res.redirect(variable)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-open-redirect");
 			const filePath = writeTempFile("ts", `res.redirect(req.query.returnUrl);\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -374,7 +374,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags response.redirect(call expression)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-open-redirect");
 			const filePath = writeTempFile("ts", `response.redirect(getRedirectUrl());\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -382,7 +382,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags window.location.href = variable", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-open-redirect");
 			const filePath = writeTempFile("ts", `window.location.href = userInput;\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -390,7 +390,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag res.redirect(string literal)", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-open-redirect");
 			const filePath = writeTempFile("ts", `res.redirect("/home");\n`);
 			const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -400,7 +400,7 @@ describe("slop detection rules", () => {
 
 	describe("ts-nosql-injection", () => {
 		it("flags $where with unquoted key", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-nosql-injection");
 			const filePath = writeTempFile(
 				"ts",
@@ -411,7 +411,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("flags $where with quoted key", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-nosql-injection");
 			const filePath = writeTempFile(
 				"ts",
@@ -422,7 +422,7 @@ describe("slop detection rules", () => {
 		});
 
 		it("does not flag safe MongoDB equality query", async () => {
-			const client = new TreeSitterClient();
+			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("ts-nosql-injection");
 			const filePath = writeTempFile(
 				"ts",

--- a/tests/clients/tree-sitter-sonar-rules.test.ts
+++ b/tests/clients/tree-sitter-sonar-rules.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
@@ -27,7 +27,7 @@ afterAll(() => {
 
 describe("no-equality-in-for-condition (S888)", () => {
 	it("flags == in a for-loop termination condition", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("no-equality-in-for-condition");
 		const filePath = writeTempFile("for (let i = 0; i == n; i += 2) {}\n");
 		const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -35,7 +35,7 @@ describe("no-equality-in-for-condition (S888)", () => {
 	});
 
 	it("flags != in a for-loop termination condition", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("no-equality-in-for-condition");
 		const filePath = writeTempFile("for (let i = 0; i != n; i++) {}\n");
 		const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -43,7 +43,7 @@ describe("no-equality-in-for-condition (S888)", () => {
 	});
 
 	it("does not flag relational operators", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("no-equality-in-for-condition");
 		const filePath = writeTempFile("for (let i = 0; i < n; i++) {}\n");
 		const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -51,7 +51,7 @@ describe("no-equality-in-for-condition (S888)", () => {
 	});
 
 	it("does not flag strict equality (===/!==) which is a different operator", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("no-equality-in-for-condition");
 		const filePath = writeTempFile("for (let i = 0; i !== n; i++) {}\n");
 		const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -59,7 +59,7 @@ describe("no-equality-in-for-condition (S888)", () => {
 	});
 
 	it("does not flag == used in the loop body, only the condition", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("no-equality-in-for-condition");
 		const filePath = writeTempFile(
 			"for (let i = 0; i < n; i++) { if (a == b) {} }\n",
@@ -71,7 +71,7 @@ describe("no-equality-in-for-condition (S888)", () => {
 
 describe("no-jump-in-finally (S1143)", () => {
 	it("flags a return statement in a finally block", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("no-jump-in-finally");
 		const filePath = writeTempFile(
 			"function f() { try { return 1; } finally { return 2; } }\n",
@@ -81,7 +81,7 @@ describe("no-jump-in-finally (S1143)", () => {
 	});
 
 	it("flags a throw statement in a finally block", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("no-jump-in-finally");
 		const filePath = writeTempFile("try { work(); } finally { throw e; }\n");
 		const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -89,7 +89,7 @@ describe("no-jump-in-finally (S1143)", () => {
 	});
 
 	it("does not flag a finally block with no control-flow jump", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("no-jump-in-finally");
 		const filePath = writeTempFile("try { work(); } finally { cleanup(); }\n");
 		const matches = await client.runQueryOnFile(query, filePath, "typescript");
@@ -97,7 +97,7 @@ describe("no-jump-in-finally (S1143)", () => {
 	});
 
 	it("does not flag a return inside a nested function in finally", async () => {
-		const client = new TreeSitterClient();
+		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("no-jump-in-finally");
 		const filePath = writeTempFile(
 			"try { work(); } finally { arr.forEach((x) => { return x; }); }\n",

--- a/tests/clients/tree-sitter-symbols.test.ts
+++ b/tests/clients/tree-sitter-symbols.test.ts
@@ -13,7 +13,7 @@ import {
 	grammarBlockReason,
 	LANGUAGE_TO_GRAMMAR,
 } from "../../clients/grammar-source.js";
-import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import { TreeSitterSymbolExtractor } from "../../clients/tree-sitter-symbol-extractor.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
@@ -61,7 +61,7 @@ const CASES: Record<string, SymbolCase> = {
 
 let client: TreeSitterClient;
 beforeAll(async () => {
-	client = new TreeSitterClient();
+	client = getSharedTreeSitterClient()!;
 	await client.init();
 });
 

--- a/tests/clients/tree-sitter-symbols.test.ts
+++ b/tests/clients/tree-sitter-symbols.test.ts
@@ -14,6 +14,7 @@ import {
 	LANGUAGE_TO_GRAMMAR,
 } from "../../clients/grammar-source.js";
 import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
+import type { TreeSitterClient } from "../../clients/tree-sitter-client.js";
 import { TreeSitterSymbolExtractor } from "../../clients/tree-sitter-symbol-extractor.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 


### PR DESCRIPTION
Implements four of the five test-coverage follow-ups from the #448 real-runner harness audit (refs #873). Test-only diff; no production code changes.

- **Shared-client migration** (item 5): all direct `new TreeSitterClient()` constructions across 15 test suites now use the shared client accessor that `clients/tree-sitter-shared.ts` mandates, ending the duplicated grammar loads/state.
- **End-to-end suppression** (item 3): a new case in `tree-sitter-dispatch-behavior.test.ts` drives the real tree-sitter runner through `dispatchForFile`, proves the shipped `debugger-statement` rule fires, and verifies only the inline-suppressed occurrence is removed — the first suppression test against a diagnostic a real rule produced.
- **Napi runner vs shipped rules** (item 4): `ast-grep-napi.test.ts` gains an unmocked path that restores the real NAPI package and YAML parser, loads the shipped catalog, and matches `no-sort-without-comparator`; the existing parser-mocked control-flow cases are retained.
- **Vendored coderabbit smoke** (item 1): `coderabbit-ast-grep-rules.test.ts` resolves the bundled secondary source via `getAstGrepRuleSources`, pins all 184 vendored rule files, and runs the real native engine across fixtures for every vendored language family.

Item 2 (real-runner coverage for `clients/dispatch/runners/lsp.ts`) is intentionally not included and remains open on #873.

Verification: all 17 changed test files pass (184 passed, 2 skipped). Two local full-suite runs each surfaced a few failures in unrelated timing/network-sensitive suites (playground CDP smoke, event-loop occupancy budgets, LSP sweep coalescing) with different failure sets per run — environmental flakes on the local host, none in files this branch touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
