### PR TITLE
fix(scan): cover all supported tree-sitter languages in project scans (refs #882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Project scans run tree-sitter rules for every supported language, not just 10 extensions** (closes #882, refs #877, #880) — the scanner's `TREE_SITTER_EXT_TO_LANG` covered only ts/tsx/js/py/go/rs/rb, so files whose grammars and non-disabled rule dirs already exist (c, cpp, csharp, css, php, java, kotlin) were silently skipped by the tree-sitter phase of project scans. It now derives the shared per-edit resolver (`EXT_TO_LANG`) so c/cpp/csharp/php/css and the `.tsx`→tsx / `.jsx`→javascript nuances can't drift from the per-edit path, and layers java/kotlin on top (grammars + rule dirs exist but no per-edit `appliesTo`). A regression test asserts the map covers every non-disabled rule dir whose grammar is loadable.
 - **`.dart` files are now included in project-wide source enumeration** (closes #880, refs #876) — `ALL_SCANNABLE_EXTENSIONS` (`clients/source-filter.ts`) and `WARMUP_SOURCE_EXTS` (`clients/language-profile.ts`) were missing `.dart`, so Dart projects were fully supported per-edit (LSP, `dart-analyze`, `dart format`, autofix) but skipped by project-wide scans and cold-start language-profile warmup.
 - **Tree-sitter rules were compiled against the wrong grammar** — a compiled
 	query is bound to the language it compiled against, and running it on a tree

--- a/clients/project-diagnostics/scanner.ts
+++ b/clients/project-diagnostics/scanner.ts
@@ -6,8 +6,8 @@ import { runProviders } from "../dispatch/fact-runner.js";
 import { FactStore } from "../dispatch/fact-store.js";
 import {
 	canHandle as astGrepCanHandle,
-	evaluateAstGrepRules,
 	getLang as astGrepGetLang,
+	evaluateAstGrepRules,
 	loadSg,
 } from "../dispatch/runners/ast-grep-napi.js";
 import type { Diagnostic } from "../dispatch/types.js";
@@ -20,7 +20,10 @@ import {
 	queriesForLanguage,
 	queryLoader,
 } from "../tree-sitter-query-loader.js";
-import { getSharedTreeSitterClient } from "../tree-sitter-shared.js";
+import {
+	EXT_TO_LANG,
+	getSharedTreeSitterClient,
+} from "../tree-sitter-shared.js";
 import {
 	PROJECT_DIAGNOSTICS_CACHE_VERSION,
 	saveProjectDiagnosticsSnapshot,
@@ -48,26 +51,27 @@ const FACT_RULE_EXTENSIONS = new Set([
 	".mjs",
 	".cjs",
 ]);
-const TREE_SITTER_EXT_TO_LANG: Record<string, string> = {
-	".ts": "typescript",
-	".mts": "typescript",
-	".cts": "typescript",
-	// .tsx parses with the TSX grammar, not typescript: the typescript grammar
-	// produces ERROR nodes on JSX, and this id must match the one the fact
-	// providers resolve (`resolveTreeSitterLanguage`) or the file is parsed
-	// twice under two grammars. Typescript RULES still apply — see the
-	// query-set merge below, which compiles them against tsx.
-	".tsx": "tsx",
-	".js": "javascript",
-	".mjs": "javascript",
-	".cjs": "javascript",
-	".jsx": "javascript",
-	".py": "python",
-	".go": "go",
-	".rs": "rust",
-	".rb": "ruby",
+// Which languages the scan runs tree-sitter rules for: every language that has
+// (a loadable grammar) AND (a non-disabled rules/tree-sitter-queries/<lang>/ dir).
+//
+// The base is the shared per-edit resolver (EXT_TO_LANG — the single
+// ext→grammar-id authority), so c/cpp/csharp/php/css and the .tsx→tsx /
+// .jsx→javascript nuances can never drift from the per-edit path. `.tsx` resolves
+// to the tsx grammar (not typescript: the typescript grammar ERRORs on JSX);
+// typescript RULES still apply because `queriesForLanguage(...)` below merges the
+// typescript rule set onto tsx.
+//
+// java + kotlin are layered on here: they have loadable grammars and rule dirs
+// (java: 24 rules, kotlin: 1) but no per-edit runner `appliesTo` entry, so only
+// this broad project scan runs them. scanner.test.ts asserts this map covers
+// every non-disabled rule dir whose grammar is loadable, so adding a language dir
+// fails a test until its extension is registered here (or in EXT_TO_LANG).
+export const TREE_SITTER_EXT_TO_LANG: Record<string, string> = {
+	...EXT_TO_LANG,
+	".java": "java",
+	".kt": "kotlin",
+	".kts": "kotlin",
 };
-
 
 function normalizeSeverity(
 	severity: string | undefined,
@@ -153,9 +157,14 @@ async function scanTreeSitterAndFactRules(
 				const queries = queriesForLanguage(queryMap, langId);
 				try {
 					// ONE tree walk for the whole rule set, not one per rule (#675).
-					const found = await client.runQueriesOnFile(queries, filePath, langId, {
-						maxResults: 50,
-					});
+					const found = await client.runQueriesOnFile(
+						queries,
+						filePath,
+						langId,
+						{
+							maxResults: 50,
+						},
+					);
 					for (const { queryDef: query, match } of found) {
 						treeSitter.push({
 							filePath,

--- a/clients/tree-sitter-shared.ts
+++ b/clients/tree-sitter-shared.ts
@@ -48,11 +48,15 @@ export function _resetSharedTreeSitterClientForTests(): void {
 	_wasmAborted = false;
 }
 
-// Grammar selection by extension. `.tsx` → the tsx grammar (parses JSX); `.jsx` →
-// the javascript grammar. NOTE: the project scanner keeps its OWN ext→lang map
-// because its query lookup is keyed by language id (it maps `.tsx`→typescript to
-// reuse typescript queries) — do not fold that one in without re-keying its queries.
-const EXT_TO_LANG: Record<string, string> = {
+// Grammar selection by extension — the single ext→grammar-id authority. `.tsx` →
+// the tsx grammar (parses JSX); `.jsx` → the javascript grammar. The project
+// scanner (project-diagnostics/scanner.ts) DERIVES its map from this one so the
+// two can't drift: post-#877 both key `.tsx`→tsx (the old note here said the
+// scanner mapped `.tsx`→typescript to reuse typescript queries — that stopped
+// being true when #877 moved typescript-rule inheritance into
+// `queriesForLanguage`). The scanner layers only java/kotlin on top, whose
+// grammars + rule dirs exist but are not wired into a per-edit runner `appliesTo`.
+export const EXT_TO_LANG: Record<string, string> = {
 	".ts": "typescript",
 	".mts": "typescript",
 	".cts": "typescript",
@@ -90,7 +94,9 @@ const EXT_TO_LANG: Record<string, string> = {
 };
 
 /** Resolve a tree-sitter grammar/language id from a file path's extension. */
-export function resolveTreeSitterLanguage(filePath: string): string | undefined {
+export function resolveTreeSitterLanguage(
+	filePath: string,
+): string | undefined {
 	return EXT_TO_LANG[path.extname(filePath).toLowerCase()];
 }
 
@@ -107,7 +113,8 @@ export async function withTreeSitterRoot<T>(
 ): Promise<ParsedTreeOutcome<T>> {
 	const languageId = resolveTreeSitterLanguage(filePath);
 	const client = getSharedTreeSitterClient();
-	if (!languageId || !client || !(await client.init())) return { parsed: false };
+	if (!languageId || !client || !(await client.init()))
+		return { parsed: false };
 	return client.withParsedTree(filePath, languageId, content, (tree) =>
 		consume(tree.rootNode as TsNode),
 	);
@@ -117,7 +124,10 @@ export function childrenOfType(node: TsNode, type: string): TsNode[] {
 	return (node.children ?? []).filter((c: TsNode) => c && c.type === type);
 }
 
-export function firstChildOfType(node: TsNode, type: string): TsNode | undefined {
+export function firstChildOfType(
+	node: TsNode,
+	type: string,
+): TsNode | undefined {
 	return (node.children ?? []).find((c: TsNode) => c && c.type === type);
 }
 

--- a/tests/clients/project-diagnostics/scanner.test.ts
+++ b/tests/clients/project-diagnostics/scanner.test.ts
@@ -1,9 +1,19 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { scanProjectDiagnostics } from "../../../clients/project-diagnostics/scanner.js";
+import { LANGUAGE_TO_GRAMMAR } from "../../../clients/grammar-source.js";
 import { loadProjectDiagnosticsSnapshot } from "../../../clients/project-diagnostics/cache.js";
+import {
+	scanProjectDiagnostics,
+	TREE_SITTER_EXT_TO_LANG,
+} from "../../../clients/project-diagnostics/scanner.js";
+import {
+	getQueryLanguageKey,
+	isDisabledQueryDirectoryName,
+} from "../../../clients/tree-sitter-query-loader.js";
+import { EXT_TO_LANG } from "../../../clients/tree-sitter-shared.js";
 import { removeTempDirSync } from "../test-utils.js";
 
 let tmp: string;
@@ -14,6 +24,60 @@ beforeEach(() => {
 
 afterEach(() => {
 	removeTempDirSync(tmp);
+});
+
+describe("TREE_SITTER_EXT_TO_LANG scan coverage (#882)", () => {
+	const REPO_ROOT = path.resolve(
+		path.dirname(fileURLToPath(import.meta.url)),
+		"../../..",
+	);
+	const QUERIES_DIR = path.join(REPO_ROOT, "rules", "tree-sitter-queries");
+
+	// Every non-disabled rules/tree-sitter-queries/<lang>/ dir whose <lang> is a
+	// loadable grammar. These are the languages a project scan CAN and SHOULD run
+	// tree-sitter rules for.
+	const ruleLanguagesWithGrammar = fs
+		.readdirSync(QUERIES_DIR, { withFileTypes: true })
+		.filter((d) => d.isDirectory() && !isDisabledQueryDirectoryName(d.name))
+		.filter((d) =>
+			fs
+				.readdirSync(path.join(QUERIES_DIR, d.name))
+				.some((f) => f.endsWith(".yml")),
+		)
+		.map((d) => getQueryLanguageKey(d.name))
+		.filter((lang) => lang in LANGUAGE_TO_GRAMMAR);
+
+	const coveredLangs = new Set(Object.values(TREE_SITTER_EXT_TO_LANG));
+
+	// The regression guard for #882: a language that has rules + a grammar but no
+	// extension in the scanner map is silently skipped by every project scan. If a
+	// future rule dir is added, this fails until its extension is registered.
+	it.each([...new Set(ruleLanguagesWithGrammar)].sort())(
+		"scans every rule language with a loadable grammar: %s",
+		(lang) => {
+			expect(coveredLangs.has(lang)).toBe(true);
+		},
+	);
+
+	it("covers the languages #882 called out (java, kotlin, csharp, cpp, css, php, c)", () => {
+		for (const lang of ["java", "kotlin", "csharp", "cpp", "css", "php", "c"]) {
+			expect(coveredLangs.has(lang)).toBe(true);
+		}
+	});
+
+	it("stays a superset of the shared per-edit resolver so the two can't drift", () => {
+		// The scanner map derives EXT_TO_LANG, then layers java/kotlin on top — so
+		// every per-edit-resolvable extension must resolve identically in a scan.
+		for (const [ext, lang] of Object.entries(EXT_TO_LANG)) {
+			expect(TREE_SITTER_EXT_TO_LANG[ext]).toBe(lang);
+		}
+	});
+
+	it("only maps extensions to loadable grammars", () => {
+		for (const lang of coveredLangs) {
+			expect(lang in LANGUAGE_TO_GRAMMAR).toBe(true);
+		}
+	});
 });
 
 describe("scanProjectDiagnostics home ceiling (#747/#250)", () => {

--- a/tests/clients/tree-sitter-shared.test.ts
+++ b/tests/clients/tree-sitter-shared.test.ts
@@ -19,7 +19,7 @@ describe("resolveTreeSitterLanguage", () => {
 		[".ts", "typescript"],
 		[".mts", "typescript"],
 		[".cts", "typescript"],
-		[".tsx", "tsx"], // JSX-capable grammar (differs from the scanner's query-keyed map)
+		[".tsx", "tsx"], // JSX-capable grammar; the scanner derives this same mapping
 		[".js", "javascript"],
 		[".mjs", "javascript"],
 		[".cjs", "javascript"],


### PR DESCRIPTION
## Problem

`TREE_SITTER_EXT_TO_LANG` in `clients/project-diagnostics/scanner.ts` mapped only ts/tsx/js/jsx/mjs/cjs/py/go/rs/rb (10 extensions). Files of every other extension were silently dropped from the tree-sitter rule phase of project scans — even though loadable grammars **and** non-disabled rule directories already exist for many more languages. `java` alone ships **24** rules that never ran in any scan.

## Assessment

Cross-referencing the three authorities post-#877:

- **Loadable grammars** (`LANGUAGE_TO_GRAMMAR`, `clients/grammar-source.ts`): typescript, tsx, javascript, python, rust, go, java, kotlin, dart, c, cpp, elixir, ruby, bash, csharp, css, html, json, lua, ocaml, php, swift, toml, vue, yaml, zig.
- **Non-disabled rule dirs** (`rules/tree-sitter-queries/`, excluding `-disabled/`): c(12), cpp(6), csharp(5), css(1), go(17), java(24), javascript(2), kotlin(1), php(2), python(40), ruby(15), rust(6), tsx(2), typescript(31).
- **Per-edit resolver** (`EXT_TO_LANG`, `clients/tree-sitter-shared.ts`): already maps c/cpp/csharp/php/css correctly (and `.tsx`→tsx, `.jsx`→javascript). The scanner map was simply a stale subset of it.

**Scope chosen:** languages where a loadable grammar **AND** a non-disabled rule dir both exist → typescript, tsx, javascript, python, go, rust, ruby (already covered) **plus c, cpp, csharp, css, php, java, kotlin** (newly covered).

**Deliberately excluded:** swift and dart — grammars load but there are **no** rule dirs and no fact-provider support, so they'd parse for zero findings (dart source-enumeration is separately handled by #880/#881; swift is also grammar-blocked on Node ≥ 24). The fact-rule phase stays jsts-only (`FACT_RULE_EXTENSIONS`), unchanged.

## Fix

- The scanner map now **derives the shared per-edit resolver** (`EXT_TO_LANG`) and layers `.java`/`.kt`/`.kts` on top, so c/cpp/csharp/php/css and the `.tsx`→tsx / `.jsx`→javascript nuances are a **single source of truth** with the per-edit path and can't drift. java/kotlin are scanner-only (they have grammars + rules but no per-edit runner `appliesTo` entry — the project scan is the broad audit that runs them).
- Removed the now-stale comment in `tree-sitter-shared.ts` claiming the scanner keeps a divergent `.tsx`→typescript map (untrue since #877 moved typescript-rule inheritance into `queriesForLanguage`).
- **Regression test** (`tests/clients/project-diagnostics/scanner.test.ts`): asserts the scanner map covers **every** non-disabled `rules/tree-sitter-queries/<lang>/` dir whose grammar is loadable, and that it stays a superset of `EXT_TO_LANG`. Adding a future language dir now fails a test until its extension is registered.

## Scan-cost impact

Small. #877 measured 12.3s full / 3.6s rule phase at 10 extensions. The widened parse set is bounded by how many of these files a project actually has — in the pi-lens repo itself the newly-covered extensions total ~20 tracked files (5 php, 4 kt, 4 java, 3 css, 2 cs, 2 cpp), a negligible add. Typical JS/TS/Python projects gain nothing. Per #879, ~30 rules still fail closed on unimplemented post_filters, so some newly-covered languages may still report few findings — expected, not a regression.

Closes #882
Refs #877, #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)