### PR TITLE
fix(rules): rewrite ruby security tree-sitter rules against the real ruby grammar (refs #884)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Seven ruby security rules never compiled and never produced a finding** (refs
+	#884) — `ruby-command-injection`, `ruby-eval`, `ruby-insecure-deserialization`,
+	`ruby-insecure-random`, `ruby-open-struct`, `ruby-string-eval` and
+	`ruby-weak-hash` were authored against JavaScript-grammar node names
+	(`call_expression`, `method_call`, `command`, `interpolated_string`) that do not
+	exist in tree-sitter-ruby, so every one failed to compile with a "Bad node name"
+	error and was silently skipped. Each query is rewritten against the real ruby
+	grammar (`call` with `method:`/`receiver:` fields, `scope_resolution` receivers
+	for `Digest::MD5`, `string` for interpolated literals), with `#match?`/`#eq?`
+	predicates moved inside the pattern's outermost parens. Per-rule positive and
+	negative fixtures (`system` vs `File.read`, `Marshal.load` vs `YAML.safe_load`,
+	`rand` vs `SecureRandom`, `OpenStruct.new` vs `Struct.new`, `Digest::MD5` vs
+	`Digest::SHA256`, string vs block `class_eval`) pin the security intent.
 - **Project scans run tree-sitter rules for every supported language, not just 10 extensions** (closes #882, refs #877, #880) — the scanner's `TREE_SITTER_EXT_TO_LANG` covered only ts/tsx/js/py/go/rs/rb, so files whose grammars and non-disabled rule dirs already exist (c, cpp, csharp, css, php, java, kotlin) were silently skipped by the tree-sitter phase of project scans. It now derives the shared per-edit resolver (`EXT_TO_LANG`) so c/cpp/csharp/php/css and the `.tsx`→tsx / `.jsx`→javascript nuances can't drift from the per-edit path, and layers java/kotlin on top (grammars + rule dirs exist but no per-edit `appliesTo`). A regression test asserts the map covers every non-disabled rule dir whose grammar is loadable.
 - **`.dart` files are now included in project-wide source enumeration** (closes #880, refs #876) — `ALL_SCANNABLE_EXTENSIONS` (`clients/source-filter.ts`) and `WARMUP_SOURCE_EXTS` (`clients/language-profile.ts`) were missing `.dart`, so Dart projects were fully supported per-edit (LSP, `dart-analyze`, `dart format`, autofix) but skipped by project-wide scans and cold-start language-profile warmup.
 - **Tree-sitter rules were compiled against the wrong grammar** — a compiled

--- a/rules/tree-sitter-queries/ruby/ruby-command-injection.yml
+++ b/rules/tree-sitter-queries/ruby/ruby-command-injection.yml
@@ -19,19 +19,8 @@ description: |
 query: |
   (call
     method: (identifier) @FN
+    (#match? @FN "^(system|exec|spawn|popen|capture3|capture2|capture2e)$")
     arguments: (argument_list) @ARGS)
-  (#match? @FN "^(system|exec|spawn|popen|capture3|capture2|capture2e)$")
-
-  (command
-    method: (identifier) @FN
-    argument: (_) @ARGS)
-  (#match? @FN "^(system|exec|spawn|popen)$")
-
-  (call_expression
-    receiver: (constant) @NS
-    method: (identifier) @FN
-    arguments: (argument_list) @ARGS)
-  (#match? @FN "^(system|exec|spawn|popen|capture3|capture2|capture2e)$")
 
 metavars:
   - FN

--- a/rules/tree-sitter-queries/ruby/ruby-eval.yml
+++ b/rules/tree-sitter-queries/ruby/ruby-eval.yml
@@ -17,7 +17,7 @@ description: |
   ✅ FIX: Use send(), const_get(), or other metaprogramming instead.
 
 query: |
-  (method_call
+  (call
     method: (identifier) @METHOD
     (#eq? @METHOD "eval")
     arguments: (argument_list) @ARGS)

--- a/rules/tree-sitter-queries/ruby/ruby-insecure-deserialization.yml
+++ b/rules/tree-sitter-queries/ruby/ruby-insecure-deserialization.yml
@@ -16,12 +16,12 @@ description: |
   ✅ FIX: use safe serialization formats and strict schema validation.
 
 query: |
-  (call_expression
+  (call
     receiver: (constant) @MOD
-    method: (identifier) @FN
-    arguments: (argument_list (_) @DATA)
     (#match? @MOD "^(Marshal|YAML|Psych)$")
-    (#match? @FN "^(load|unsafe_load)$"))
+    method: (identifier) @FN
+    (#match? @FN "^(load|unsafe_load)$")
+    arguments: (argument_list (_) @DATA))
 
 metavars:
   - MOD

--- a/rules/tree-sitter-queries/ruby/ruby-insecure-random.yml
+++ b/rules/tree-sitter-queries/ruby/ruby-insecure-random.yml
@@ -16,19 +16,12 @@ description: |
   ✅ FIX: use SecureRandom.hex/base64/uuid.
 
 query: |
-  [
-    (call
-      method: (identifier) @FN
-      arguments: (argument_list) @ARGS)
-    (call_expression
-      receiver: (constant) @MOD
-      method: (identifier) @FN
-      arguments: (argument_list) @ARGS)
-  ]
-  (#match? @FN "^(rand|srand)$")
+  (call
+    method: (identifier) @FN
+    (#match? @FN "^(rand|srand)$")
+    arguments: (argument_list) @ARGS)
 
 metavars:
-  - MOD
   - FN
   - ARGS
 

--- a/rules/tree-sitter-queries/ruby/ruby-open-struct.yml
+++ b/rules/tree-sitter-queries/ruby/ruby-open-struct.yml
@@ -17,7 +17,7 @@ description: |
   ✅ FIX: Use Struct.new or a plain class with attr_accessor.
 
 query: |
-  (call_expression
+  (call
     receiver: (constant) @RECV
     (#eq? @RECV "OpenStruct")
     method: (identifier) @METHOD

--- a/rules/tree-sitter-queries/ruby/ruby-string-eval.yml
+++ b/rules/tree-sitter-queries/ruby/ruby-string-eval.yml
@@ -28,9 +28,8 @@ description: |
 query: |
   (call
     method: (identifier) @METHOD
-    arguments: (argument_list
-      [(string) (interpolated_string)] @ARG)
-    (#match? @METHOD "^(eval|class_eval|module_eval|instance_eval)$")) @CALL
+    (#match? @METHOD "^(eval|class_eval|module_eval|instance_eval)$")
+    arguments: (argument_list (string) @ARG)) @CALL
 
 metavars:
   - METHOD

--- a/rules/tree-sitter-queries/ruby/ruby-weak-hash.yml
+++ b/rules/tree-sitter-queries/ruby/ruby-weak-hash.yml
@@ -16,12 +16,12 @@ description: |
   ✅ FIX: use Digest::SHA256 or stronger algorithms.
 
 query: |
-  (call_expression
-    receiver: (constant) @MOD
+  (call
+    receiver: (scope_resolution) @MOD
+    (#match? @MOD "^(Digest::MD5|Digest::SHA1)$")
     method: (identifier) @FN
+    (#match? @FN "^(hexdigest|digest|base64digest)$")
     arguments: (argument_list) @ARGS)
-  (#match? @MOD "^(Digest::MD5|Digest::SHA1)$")
-  (#match? @FN "^(hexdigest|digest|base64digest)$")
 
 metavars:
   - MOD

--- a/tests/clients/tree-sitter-ruby-rules.test.ts
+++ b/tests/clients/tree-sitter-ruby-rules.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
+import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+
+// These rules (#884) were originally authored against JavaScript grammar node
+// names (`call_expression`, `method_call`, `command`, `interpolated_string`)
+// that do not exist in tree-sitter-ruby, so they never compiled and never
+// produced a finding. Each case below pins the rewritten query to the REAL
+// ruby grammar: it must flag the vulnerable form and leave the safe form alone.
+
+const cleanups: Array<() => void> = [];
+
+function writeTempFile(contents: string): string {
+	const env = setupTestEnvironment("pi-lens-ruby-rules-");
+	cleanups.push(env.cleanup);
+	return createTempFile(env.tmpDir, "sample.rb", contents);
+}
+
+async function getQuery(id: string) {
+	const loader = new TreeSitterQueryLoader();
+	const queries = await loader.loadQueries(process.cwd());
+	for (const langQueries of queries.values()) {
+		const found = langQueries.find((q) => q.id === id);
+		if (found) return found;
+	}
+	throw new Error(`missing query ${id}`);
+}
+
+async function run(id: string, source: string) {
+	const client = getSharedTreeSitterClient()!;
+	const query = await getQuery(id);
+	const filePath = writeTempFile(source);
+	return client.runQueryOnFile(query, filePath, "ruby");
+}
+
+afterAll(() => {
+	for (const cleanup of cleanups) cleanup();
+});
+
+describe("ruby security tree-sitter rules (#884)", () => {
+	describe("ruby-command-injection", () => {
+		it("flags a shell exec sink with interpolated input", async () => {
+			expect(
+				await run(
+					"ruby-command-injection",
+					`system("sh -c #{params[:cmd]}")\n`,
+				),
+			).toHaveLength(1);
+		});
+
+		it("flags a namespaced Open3 exec sink", async () => {
+			expect(
+				await run("ruby-command-injection", `Open3.capture3(cmd)\n`),
+			).toHaveLength(1);
+		});
+
+		it("does not flag a non-exec method call", async () => {
+			expect(
+				await run("ruby-command-injection", `File.read(path)\n`),
+			).toHaveLength(0);
+		});
+	});
+
+	describe("ruby-eval", () => {
+		it("flags eval with a variable argument", async () => {
+			expect(await run("ruby-eval", `eval(user_input)\n`)).toHaveLength(1);
+		});
+
+		it("does not flag const_get / send alternatives", async () => {
+			expect(
+				await run("ruby-eval", `Object.const_get(class_name)\n`),
+			).toHaveLength(0);
+		});
+	});
+
+	describe("ruby-insecure-deserialization", () => {
+		it("flags Marshal.load", async () => {
+			expect(
+				await run("ruby-insecure-deserialization", `Marshal.load(payload)\n`),
+			).toHaveLength(1);
+		});
+
+		it("flags YAML.unsafe_load", async () => {
+			expect(
+				await run("ruby-insecure-deserialization", `YAML.unsafe_load(data)\n`),
+			).toHaveLength(1);
+		});
+
+		it("does not flag YAML.safe_load", async () => {
+			expect(
+				await run("ruby-insecure-deserialization", `YAML.safe_load(data)\n`),
+			).toHaveLength(0);
+		});
+	});
+
+	describe("ruby-insecure-random", () => {
+		it("flags rand() used for a token", async () => {
+			expect(
+				await run("ruby-insecure-random", `token = rand(10_000_000)\n`),
+			).toHaveLength(1);
+		});
+
+		it("does not flag SecureRandom", async () => {
+			expect(
+				await run("ruby-insecure-random", `token = SecureRandom.hex(16)\n`),
+			).toHaveLength(0);
+		});
+	});
+
+	describe("ruby-open-struct", () => {
+		it("flags OpenStruct.new", async () => {
+			expect(
+				await run("ruby-open-struct", `person = OpenStruct.new(name: "Ada")\n`),
+			).toHaveLength(1);
+		});
+
+		it("does not flag Struct.new", async () => {
+			expect(
+				await run("ruby-open-struct", `Person = Struct.new(:name, :age)\n`),
+			).toHaveLength(0);
+		});
+	});
+
+	describe("ruby-string-eval", () => {
+		it("flags class_eval with a string argument", async () => {
+			expect(
+				await run("ruby-string-eval", `User.class_eval("def x; @x; end")\n`),
+			).toHaveLength(1);
+		});
+
+		it("does not flag the block form of class_eval", async () => {
+			expect(
+				await run(
+					"ruby-string-eval",
+					`User.class_eval do\n  define_method(:x) { 1 }\nend\n`,
+				),
+			).toHaveLength(0);
+		});
+	});
+
+	describe("ruby-weak-hash", () => {
+		it("flags Digest::MD5.hexdigest", async () => {
+			expect(
+				await run("ruby-weak-hash", `Digest::MD5.hexdigest(data)\n`),
+			).toHaveLength(1);
+		});
+
+		it("does not flag Digest::SHA256.hexdigest", async () => {
+			expect(
+				await run("ruby-weak-hash", `Digest::SHA256.hexdigest(data)\n`),
+			).toHaveLength(0);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Seven ruby security rules under `rules/tree-sitter-queries/ruby/` were authored with **JavaScript-grammar node names** (`call_expression`, `method_call`, `command`, `interpolated_string`) that do not exist in tree-sitter-ruby. Every one failed to compile with a `Bad node name` error and was silently skipped — they have **never produced a single finding**.

Verified the exact broken set by compile-sweeping the whole `ruby/` dir against the real `tree-sitter-ruby.wasm` grammar: the 7 below failed, the other 8 compiled. After the rewrite all 15 compile.

Each query is rewritten against the **real ruby AST** (learned by parsing representative snippets): Ruby's call node is `call` with `method:`/`receiver:`/`arguments:` fields; a single `call` pattern (receiver optional) covers both bare `system(...)` and namespaced `Open3.capture3(...)`; `Digest::MD5` is a `scope_resolution` receiver, not a plain constant; interpolated string literals are `string`, not `interpolated_string`; backticks are `subshell`. `#match?`/`#eq?` predicates are moved **inside each pattern's outermost parens** so web-tree-sitter binds them to the right pattern. metavars/post_filter/severity/message are kept intact (only `ruby-insecure-random` drops the now-unbound `MOD` metavar, since its receiver capture is gone).

## Per-rule table

| Rule | Old broken construct | New query (real grammar) | Verification |
|------|----------------------|--------------------------|--------------|
| `ruby-command-injection` | `(command …)` + `(call_expression receiver: (constant) …)` | `(call method: (identifier) @FN (#match? …) arguments: (argument_list) @ARGS)` — one pattern matches bare + namespaced sinks | flags `system("sh -c #{…}")`, `Open3.capture3(cmd)`; ignores `File.read(path)` |
| `ruby-eval` | `(method_call …)` | `(call method: (identifier) @METHOD (#eq? @METHOD "eval") …)` | flags `eval(user_input)`; ignores `Object.const_get(class_name)` |
| `ruby-insecure-deserialization` | `(call_expression receiver: (constant) …)` | `(call receiver: (constant) @MOD (#match? …) method: (identifier) @FN (#match? …) arguments: (argument_list (_) @DATA))` | flags `Marshal.load`, `YAML.unsafe_load`; ignores `YAML.safe_load` |
| `ruby-insecure-random` | top-level `[…]` alternation of `call` + `call_expression` | `(call method: (identifier) @FN (#match? @FN "^(rand\|srand)$") arguments: (argument_list) @ARGS)` | flags `rand(10_000_000)`; ignores `SecureRandom.hex(16)` |
| `ruby-open-struct` | `(call_expression receiver: (constant) …)` | `(call receiver: (constant) @RECV (#eq? @RECV "OpenStruct") method: (identifier) @METHOD (#eq? @METHOD "new"))` | flags `OpenStruct.new(…)`; ignores `Struct.new(…)` |
| `ruby-string-eval` | `[(string) (interpolated_string)]` | `(call method: (identifier) @METHOD (#match? …) arguments: (argument_list (string) @ARG)) @CALL` | flags `User.class_eval("def x; end")`; ignores block-form `class_eval do … end` |
| `ruby-weak-hash` | `(call_expression receiver: (constant) …)` with `#match? @MOD "Digest::MD5"` | `(call receiver: (scope_resolution) @MOD (#match? …) method: (identifier) @FN (#match? …) arguments: (argument_list) @ARGS)` | flags `Digest::MD5.hexdigest`; ignores `Digest::SHA256.hexdigest` |

## Verification

- Compile sweep: all 15 ruby rules compile against the real grammar (was 7 failing).
- New `tests/clients/tree-sitter-ruby-rules.test.ts`: 16 positive/negative cases, all pass.
- `tree-sitter-query-loader` + `tree-sitter-query-batch` suites: pass.
- CHANGELOG updated under `### Fixed`.

## Parallel-work contract (compile-guard PR)

At the time of pushing, no compile-guard branch (`fix/884-rule-compile-guard`) exists on the remote and there is no `KNOWN_BROKEN` allowlist on `master`. If that PR lands, its allowlist must **drop** these ids (all now compile and are covered by tests): `ruby-command-injection`, `ruby-eval`, `ruby-insecure-deserialization`, `ruby-insecure-random`, `ruby-open-struct`, `ruby-string-eval`, `ruby-weak-hash`.

refs #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
