### PR TITLE
fix(rules): repair non-compiling typescript/javascript tree-sitter rules (refs #884)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,33 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Eight enabled typescript/javascript tree-sitter rules whose queries never
+	compiled** (refs #884) — each had been silently dead since authoring because
+	its query failed to compile against the real grammar, so it matched nothing
+	and reported no diagnostics. Repaired against the actual node/field names and
+	verified end-to-end (matches the bug, leaves correct code alone):
+	`empty-switch-case`, `switch-case-termination`, `switch-case-termination-js`
+	(switch cases carry their statements as direct `body:` children, not a
+	`consequence: (statement_block)`); `infinite-loop` (`while (true)` wraps the
+	condition in a `parenthesized_expression`; `for (;;)` has an `empty_statement`
+	condition, not `(null)`); `duplicate-function-arg` (typescript parameters are
+	`required_parameter`, not bare `(identifier)`; now also catches non-adjacent
+	duplicates); `mixed-async-styles` (no `async_modifier` node — match the `async`
+	token); `switch-non-case-labels` (JS) (a `labeled_statement` lives inside a
+	`switch_case`, not directly under `switch_body`); and `ts-insecure-random`
+	(the inline `(?i)` regex flag is invalid in JS `RegExp` — dropped the
+	redundant name predicate and let the post-filter do the case-insensitive
+	check, walking up from the `Math.random()` call so chained forms like
+	`Math.random().toString(36)` are still attributed to their binding). Also
+	implemented the four post-filters these rules referenced but that were never
+	defined (`is_empty_block`, `no_break_or_return_in_body`, `same_param_name`,
+	`no_terminating_statement`), which the batch runner had been failing closed on.
+- **A column-0 comment after a `query: |` block no longer breaks the rule**
+	(refs #884) — the query-block extractor kept every line more-indented than the
+	key (to preserve `#eq?`/`#match?` predicate lines) but did not stop at a
+	document-level `# …` comment sitting between the block and the next key, so the
+	comment was appended to the query and made it fail to compile. This is what
+	kept `mixed-async-styles` dead even after its query was otherwise correct.
 - **Project scans run tree-sitter rules for every supported language, not just 10 extensions** (closes #882, refs #877, #880) — the scanner's `TREE_SITTER_EXT_TO_LANG` covered only ts/tsx/js/py/go/rs/rb, so files whose grammars and non-disabled rule dirs already exist (c, cpp, csharp, css, php, java, kotlin) were silently skipped by the tree-sitter phase of project scans. It now derives the shared per-edit resolver (`EXT_TO_LANG`) so c/cpp/csharp/php/css and the `.tsx`→tsx / `.jsx`→javascript nuances can't drift from the per-edit path, and layers java/kotlin on top (grammars + rule dirs exist but no per-edit `appliesTo`). A regression test asserts the map covers every non-disabled rule dir whose grammar is loadable.
 - **`.dart` files are now included in project-wide source enumeration** (closes #880, refs #876) — `ALL_SCANNABLE_EXTENSIONS` (`clients/source-filter.ts`) and `WARMUP_SOURCE_EXTS` (`clients/language-profile.ts`) were missing `.dart`, so Dart projects were fully supported per-edit (LSP, `dart-analyze`, `dart format`, autofix) but skipped by project-wide scans and cold-start language-profile warmup.
 - **Tree-sitter rules were compiled against the wrong grammar** — a compiled

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -1298,6 +1298,92 @@ export class TreeSitterClient {
 		]).has(tail.toLowerCase());
 	}
 
+	/**
+	 * The body statements of a `switch_case`, in order. A switch_case's named
+	 * children are `[value, ...statements]` (its statements are direct children,
+	 * not a wrapping statement_block), so drop the leading `case <value>` and any
+	 * comments.
+	 */
+	private switchCaseBodyStatements(caseNode: TreeSitterNode): TreeSitterNode[] {
+		// biome-ignore lint/suspicious/noExplicitAny: AST child iteration
+		const named = (caseNode.children ?? []).filter(
+			(c: any) => c.isNamed && !c.type.includes("comment"),
+		);
+		// First named child is the case's value expression (`case <value>`).
+		return named.slice(1);
+	}
+
+	/**
+	 * Whether a loop body contains a statement that can terminate the loop:
+	 * `return`/`throw` anywhere (they unwind past the loop), or a `break` that is
+	 * not swallowed by a nested loop/switch. Does not descend into nested
+	 * functions, whose `return` exits the function rather than the loop.
+	 */
+	private bodyHasLoopExit(
+		node: TreeSitterNode,
+		insideNestedLoop: boolean,
+	): boolean {
+		const NESTS_BREAK = new Set([
+			"for_statement",
+			"for_in_statement",
+			"while_statement",
+			"do_statement",
+			"switch_statement",
+		]);
+		const NESTED_FN = new Set([
+			"function_declaration",
+			"function_expression",
+			"arrow_function",
+			"method_definition",
+			"generator_function",
+			"generator_function_declaration",
+			"class_declaration",
+		]);
+		for (const child of node.children ?? []) {
+			const t = child.type;
+			if (NESTED_FN.has(t)) continue;
+			if (t === "return_statement" || t === "throw_statement") return true;
+			if (t === "break_statement" && !insideNestedLoop) return true;
+			if (this.bodyHasLoopExit(child, insideNestedLoop || NESTS_BREAK.has(t))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Name of the binding a node's value flows into: the declared name of an
+	 * enclosing `variable_declarator`, or the left-hand side of an enclosing
+	 * `assignment_expression`. Returns "" if the node is not part of a binding
+	 * (the walk stops at function/block/program boundaries so it never reaches
+	 * out to an unrelated outer binding).
+	 */
+	private enclosingBindingName(node: TreeSitterNode | undefined): string {
+		let cur: TreeSitterNode | null | undefined = node?.parent;
+		for (let depth = 0; cur && depth < 12; depth++) {
+			const t = cur.type;
+			if (t === "variable_declarator") {
+				const name = cur.children?.find((c) => c.isNamed);
+				return name?.text ?? "";
+			}
+			if (t === "assignment_expression") {
+				return cur.children?.[0]?.text ?? "";
+			}
+			if (
+				t === "statement_block" ||
+				t === "program" ||
+				t === "function_declaration" ||
+				t === "function_expression" ||
+				t === "arrow_function" ||
+				t === "method_definition"
+			) {
+				return "";
+			}
+			cur = cur.parent;
+		}
+		return "";
+	}
+
 	private isSafeSqlAlchemyExpressionCall(node: TreeSitterNode): boolean {
 		if (node.type !== "call") return false;
 		const callee = node.children?.[0]?.text ?? "";
@@ -1414,6 +1500,48 @@ export class TreeSitterClient {
 						c.type !== "block_comment",
 				);
 				return meaningful.length === 0;
+			}
+			case "is_empty_block": {
+				// empty-switch-case: keep a `switch_case` that has no body statements.
+				// A switch_case's named children are `[value, ...body statements]`
+				// (the case's statements are direct children, not a statement_block),
+				// so an empty case is one whose only named child is its `case <value>`.
+				const caseNode = captures.CASE;
+				if (!caseNode) return false;
+				return this.switchCaseBodyStatements(caseNode).length === 0;
+			}
+			case "no_break_or_return_in_body": {
+				// infinite-loop: keep a `while(true)`/`for(;;)` whose body contains no
+				// statement that can terminate the loop (break/return/throw). `continue`
+				// does not count — it keeps the loop running.
+				const bodyNode = captures.BODY;
+				if (!bodyNode) return false;
+				return !this.bodyHasLoopExit(bodyNode, false);
+			}
+			case "same_param_name": {
+				// duplicate-function-arg: keep the pair only when the two captured
+				// parameter identifiers share the same name.
+				const first = captures.PARAM1?.text;
+				const second = captures.NAME?.text;
+				return !!first && first === second;
+			}
+			case "no_terminating_statement": {
+				// switch-case-termination: keep a non-empty case (already known to be
+				// followed by another case via the query) whose last body statement is
+				// not a terminator, i.e. it falls through. Empty cases are handled by
+				// empty-switch-case, so require at least one body statement here.
+				const caseNode = captures.CASE;
+				if (!caseNode) return false;
+				const body = this.switchCaseBodyStatements(caseNode);
+				if (body.length === 0) return false;
+				const last = body[body.length - 1];
+				const TERMINATORS = new Set([
+					"break_statement",
+					"return_statement",
+					"throw_statement",
+					"continue_statement",
+				]);
+				return !TERMINATORS.has(last.type);
 			}
 			case "bare_except_only": {
 				const clauseNode = captures.CLAUSE;
@@ -1806,8 +1934,10 @@ export class TreeSitterClient {
 			case "ts_insecure_random_source": {
 				if (captures.OBJ?.text !== "Math" || captures.FN?.text !== "random")
 					return false;
-				// Only flag when assigned to a security-sensitive variable name
-				const varName = captures.VAR?.text ?? "";
+				// Only flag when the result flows into a security-sensitive binding.
+				// Walk up from the `Math.random()` call so chained forms such as
+				// `Math.random().toString(36)` are still attributed to their binding.
+				const varName = this.enclosingBindingName(captures.CALL ?? captures.VAR);
 				return /token|secret|password|key|nonce|salt|csrf|auth|session|credential|hash|otp|pin/i.test(
 					varName,
 				);

--- a/clients/tree-sitter-query-loader.ts
+++ b/clients/tree-sitter-query-loader.ts
@@ -402,12 +402,18 @@ export class TreeSitterQueryLoader {
 			const indent = indentMatch ? indentMatch[1].length : 0;
 			const trimmed = line.trim();
 
-			// Stop at new key with same or less indent (but not at comments)
-			if (
-				indent <= startIndent &&
-				trimmed.match(/^[a-z_]+:/) &&
-				!trimmed.startsWith("#")
-			) {
+			// Stop at a new top-level key (same or less indent than the key).
+			if (indent <= startIndent && trimmed.match(/^[a-z_]+:/)) {
+				break;
+			}
+
+			// A comment at or below the key's indent is a document-level comment
+			// that follows the block, not part of it — stop. Block-scalar content
+			// (including native tree-sitter predicate lines `#eq?`/`#match?`) is
+			// always MORE indented than the key, so those are preserved. Without
+			// this, a stray `# …` line between a `query: |` block and the next key
+			// was appended to the query and made it fail to compile (mixed-async).
+			if (trimmed.startsWith("#") && indent <= startIndent) {
 				break;
 			}
 

--- a/rules/tree-sitter-queries/javascript/switch-case-termination-js.yml
+++ b/rules/tree-sitter-queries/javascript/switch-case-termination-js.yml
@@ -26,16 +26,13 @@ description: |
   ```
 
 query: |
-  (switch_statement
-    body: (switch_body
-      (switch_case
-        consequence: (statement_block
-          (expression_statement) @LAST))
-      (switch_case) @NEXT))
+  (switch_body
+    (switch_case) @CASE
+    .
+    [(switch_case) (switch_default)])
 
 metavars:
-  - LAST
-  - NEXT
+  - CASE
 
 post_filter: no_terminating_statement
 

--- a/rules/tree-sitter-queries/javascript/switch-non-case-labels.yml
+++ b/rules/tree-sitter-queries/javascript/switch-non-case-labels.yml
@@ -19,8 +19,9 @@ description: |
 query: |
   (switch_statement
     body: (switch_body
-      (labeled_statement
-        (statement_identifier) @LABEL) @LABELED))
+      (switch_case
+        (labeled_statement
+          (statement_identifier) @LABEL) @LABELED)))
 
 metavars:
   - LABEL

--- a/rules/tree-sitter-queries/typescript/duplicate-function-arg.yml
+++ b/rules/tree-sitter-queries/typescript/duplicate-function-arg.yml
@@ -21,18 +21,13 @@ description: |
   ```
 
 query: |
-  (function_declaration
-    parameters: (formal_parameters
-      (identifier) @PARAM1
-      (identifier) @PARAM2))
-  (arrow_function
-    parameters: (formal_parameters
-      (identifier) @PARAM1
-      (identifier) @PARAM2))
+  (formal_parameters
+    (required_parameter (identifier) @PARAM1)
+    (required_parameter (identifier) @NAME))
 
 metavars:
   - PARAM1
-  - PARAM2
+  - NAME
 
 post_filter: same_param_name
 

--- a/rules/tree-sitter-queries/typescript/empty-switch-case.yml
+++ b/rules/tree-sitter-queries/typescript/empty-switch-case.yml
@@ -27,11 +27,10 @@ description: |
 query: |
   (switch_statement
     body: (switch_body
-      (switch_case
-        consequence: (statement_block) @BLOCK)))
+      (switch_case) @CASE))
 
 metavars:
-  - BLOCK
+  - CASE
 
 post_filter: is_empty_block
 

--- a/rules/tree-sitter-queries/typescript/infinite-loop.yml
+++ b/rules/tree-sitter-queries/typescript/infinite-loop.yml
@@ -24,10 +24,10 @@ description: |
 
 query: |
   (while_statement
-    condition: (true)
+    condition: (parenthesized_expression (true))
     body: (statement_block) @BODY)
   (for_statement
-    condition: (null)
+    condition: (empty_statement)
     body: (statement_block) @BODY)
 
 metavars:

--- a/rules/tree-sitter-queries/typescript/mixed-async-styles.yml
+++ b/rules/tree-sitter-queries/typescript/mixed-async-styles.yml
@@ -20,7 +20,16 @@ description: |
 
 query: |
   (function_declaration
-    (async_modifier)
+    "async"
+    body: (statement_block) @BODY)
+  (arrow_function
+    "async"
+    body: (statement_block) @BODY)
+  (method_definition
+    "async"
+    body: (statement_block) @BODY)
+  (function_expression
+    "async"
     body: (statement_block) @BODY)
 
 # Post-filter: Check if body contains both await and .then()

--- a/rules/tree-sitter-queries/typescript/switch-case-termination.yml
+++ b/rules/tree-sitter-queries/typescript/switch-case-termination.yml
@@ -26,16 +26,13 @@ description: |
   ```
 
 query: |
-  (switch_statement
-    body: (switch_body
-      (switch_case
-        consequence: (statement_block
-          (expression_statement) @LAST))
-      (switch_case) @NEXT))
+  (switch_body
+    (switch_case) @CASE
+    .
+    [(switch_case) (switch_default)])
 
 metavars:
-  - LAST
-  - NEXT
+  - CASE
 
 post_filter: no_terminating_statement
 

--- a/rules/tree-sitter-queries/typescript/ts-insecure-random.yml
+++ b/rules/tree-sitter-queries/typescript/ts-insecure-random.yml
@@ -16,22 +16,19 @@ description: |
   ✅ FIX: use crypto.getRandomValues / crypto.randomUUID / secure server-side RNG.
 
 query: |
-  (variable_declarator
-    name: (identifier) @VAR
-    value: (call_expression
-      function: (member_expression
-        object: (identifier) @OBJ
-        property: (property_identifier) @FN)
-      arguments: (arguments) @ARGS)
+  (call_expression
+    function: (member_expression
+      object: (identifier) @OBJ
+      property: (property_identifier) @FN)
+    arguments: (arguments) @ARGS
     (#eq? @OBJ "Math")
-    (#eq? @FN "random")
-    (#match? @VAR "(?i)(token|secret|password|key|nonce|salt|csrf|auth|session|credential|hash|otp|pin)"))
+    (#eq? @FN "random")) @CALL
 
 metavars:
   - OBJ
   - FN
   - ARGS
-  - VAR
+  - CALL
 
 post_filter: ts_insecure_random_source
 

--- a/tests/clients/tree-sitter-884-rules.test.ts
+++ b/tests/clients/tree-sitter-884-rules.test.ts
@@ -1,0 +1,266 @@
+/**
+ * #884 — tree-sitter rules whose queries never compiled (silently dead since
+ * authoring). Each rule below had a query that failed to compile against the
+ * real grammar (wrong node/field names, an invalid inline regex flag, or an
+ * unimplemented post_filter). These tests pin the repaired rules end-to-end:
+ * every one must match a minimal snippet embodying the bug it hunts and leave a
+ * nearby correct snippet alone.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { TreeSitterQueryLoader } from "../../clients/tree-sitter-query-loader.js";
+import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
+import { removeTempDirSync } from "./test-utils.js";
+
+const tmpDirs: string[] = [];
+
+function writeTempFile(ext: string, contents: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-884-"));
+	tmpDirs.push(dir);
+	const filePath = path.join(dir, `sample.${ext}`);
+	fs.writeFileSync(filePath, contents, "utf-8");
+	return filePath;
+}
+
+async function getQuery(id: string) {
+	const loader = new TreeSitterQueryLoader();
+	const queries = await loader.loadQueries(process.cwd());
+	for (const langQueries of queries.values()) {
+		const found = langQueries.find((q) => q.id === id);
+		if (found) return found;
+	}
+	throw new Error(`missing query ${id}`);
+}
+
+async function count(id: string, ext: string, lang: string, src: string) {
+	const client = getSharedTreeSitterClient()!;
+	const query = await getQuery(id);
+	const file = writeTempFile(ext, src);
+	return (await client.runQueryOnFile(query, file, lang)).length;
+}
+
+afterAll(() => {
+	for (const dir of tmpDirs) removeTempDirSync(dir);
+});
+
+describe("empty-switch-case (TS)", () => {
+	it("matches a case with no body", async () => {
+		expect(
+			await count(
+				"empty-switch-case",
+				"ts",
+				"typescript",
+				`switch (x) {\n case 1:\n case 2:\n  doWork();\n  break;\n}`,
+			),
+		).toBeGreaterThan(0);
+	});
+
+	it("does not match cases that all have bodies", async () => {
+		expect(
+			await count(
+				"empty-switch-case",
+				"ts",
+				"typescript",
+				`switch (x) {\n case 1:\n  doWork();\n  break;\n case 2:\n  other();\n  break;\n}`,
+			),
+		).toBe(0);
+	});
+});
+
+describe("infinite-loop (TS)", () => {
+	it("matches while(true) with no exit", async () => {
+		expect(
+			await count(
+				"infinite-loop",
+				"ts",
+				"typescript",
+				`while (true) {\n doWork();\n}`,
+			),
+		).toBeGreaterThan(0);
+	});
+
+	it("matches for(;;) with no exit", async () => {
+		expect(
+			await count("infinite-loop", "ts", "typescript", `for (;;) {\n tick();\n}`),
+		).toBeGreaterThan(0);
+	});
+
+	it("does not match while(true) that breaks", async () => {
+		expect(
+			await count(
+				"infinite-loop",
+				"ts",
+				"typescript",
+				`while (true) {\n if (done) break;\n doWork();\n}`,
+			),
+		).toBe(0);
+	});
+
+	it("does not match for(;;) that returns", async () => {
+		expect(
+			await count(
+				"infinite-loop",
+				"ts",
+				"typescript",
+				`for (;;) {\n return 1;\n}`,
+			),
+		).toBe(0);
+	});
+});
+
+describe("duplicate-function-arg (TS)", () => {
+	it("matches duplicate parameter names", async () => {
+		expect(
+			await count(
+				"duplicate-function-arg",
+				"ts",
+				"typescript",
+				`function add(a, a) { return a; }`,
+			),
+		).toBeGreaterThan(0);
+	});
+
+	it("matches non-adjacent duplicate parameters", async () => {
+		expect(
+			await count(
+				"duplicate-function-arg",
+				"ts",
+				"typescript",
+				`function f(a, b, a) { return a + b; }`,
+			),
+		).toBeGreaterThan(0);
+	});
+
+	it("does not match unique parameters", async () => {
+		expect(
+			await count(
+				"duplicate-function-arg",
+				"ts",
+				"typescript",
+				`function add(a, b) { return a + b; }`,
+			),
+		).toBe(0);
+	});
+});
+
+describe("mixed-async-styles (TS)", () => {
+	it("matches await mixed with a .then() chain", async () => {
+		expect(
+			await count(
+				"mixed-async-styles",
+				"ts",
+				"typescript",
+				`async function getUser() {\n const r = await fetch("/u");\n return r.json().then((d) => d.name);\n}`,
+			),
+		).toBeGreaterThan(0);
+	});
+
+	it("does not match consistent async/await", async () => {
+		expect(
+			await count(
+				"mixed-async-styles",
+				"ts",
+				"typescript",
+				`async function getUser() {\n const r = await fetch("/u");\n const d = await r.json();\n return d.name;\n}`,
+			),
+		).toBe(0);
+	});
+});
+
+describe("switch-case-termination (TS)", () => {
+	it("matches a case that falls through", async () => {
+		expect(
+			await count(
+				"switch-case-termination",
+				"ts",
+				"typescript",
+				`switch (x) {\n case 1:\n  doSomething();\n case 2:\n  break;\n}`,
+			),
+		).toBeGreaterThan(0);
+	});
+
+	it("does not match cases that terminate", async () => {
+		expect(
+			await count(
+				"switch-case-termination",
+				"ts",
+				"typescript",
+				`switch (x) {\n case 1:\n  return "one";\n case 2:\n  break;\n}`,
+			),
+		).toBe(0);
+	});
+});
+
+describe("ts-insecure-random (TS)", () => {
+	it("matches Math.random() feeding a security-sensitive binding", async () => {
+		expect(
+			await count(
+				"ts-insecure-random",
+				"ts",
+				"typescript",
+				`const token = Math.random().toString(36);`,
+			),
+		).toBeGreaterThan(0);
+	});
+
+	it("does not match Math.random() for a non-sensitive binding", async () => {
+		expect(
+			await count(
+				"ts-insecure-random",
+				"ts",
+				"typescript",
+				`const ratio = Math.random();`,
+			),
+		).toBe(0);
+	});
+});
+
+describe("switch-case-termination-js (JS)", () => {
+	it("matches a case that falls through", async () => {
+		expect(
+			await count(
+				"switch-case-termination-js",
+				"js",
+				"javascript",
+				`switch (x) {\n case 1:\n  doSomething();\n case 2:\n  break;\n}`,
+			),
+		).toBeGreaterThan(0);
+	});
+
+	it("does not match cases that terminate", async () => {
+		expect(
+			await count(
+				"switch-case-termination-js",
+				"js",
+				"javascript",
+				`switch (x) {\n case 1:\n  return "one";\n case 2:\n  break;\n}`,
+			),
+		).toBe(0);
+	});
+});
+
+describe("switch-non-case-labels-js (JS)", () => {
+	it("matches a non-case label inside a switch", async () => {
+		expect(
+			await count(
+				"switch-non-case-labels-js",
+				"js",
+				"javascript",
+				`switch (x) {\n case 1:\n  break;\n case 2:\n  myLabel:\n   doSomething();\n  break;\n}`,
+			),
+		).toBeGreaterThan(0);
+	});
+
+	it("does not match a normal switch", async () => {
+		expect(
+			await count(
+				"switch-non-case-labels-js",
+				"js",
+				"javascript",
+				`switch (x) {\n case 1:\n  break;\n default:\n  break;\n}`,
+			),
+		).toBe(0);
+	});
+});


### PR DESCRIPTION
Fixes the typescript and javascript tree-sitter rules from #884 — enabled rules whose queries never compiled, so they were silently dead since authoring (zero diagnostics, ever).

## Method
Compiled every rule in `rules/tree-sitter-queries/{typescript,javascript}/` against the real grammar via the built client, confirmed the exact failing set (8 rules), inspected the actual AST for representative snippets to learn the real node/field names, rewrote each query to its original intent, and verified each end-to-end: **(a)** compiles, **(b)** matches a minimal positive snippet, **(c)** does not match a nearby negative snippet. All 8 are pinned in `tests/clients/tree-sitter-884-rules.test.ts` (19 cases, all green). All 33 ts+js rules now compile (was 25).

## Per-rule fixes
| Rule | What was wrong | Fix |
|------|----------------|-----|
| `typescript/empty-switch-case` | `consequence: (statement_block)` is not how `switch_case` holds statements | Match `(switch_case) @CASE`; `is_empty_block` keeps cases with no body statements |
| `typescript/switch-case-termination` | same `consequence:`/`statement_block` mistake | Anchored `(switch_body (switch_case) @CASE . [(switch_case)(switch_default)])`; `no_terminating_statement` checks the last body statement |
| `javascript/switch-case-termination-js` | same as above | same fix |
| `typescript/infinite-loop` | `condition: (true)` / `condition: (null)` — wrong shapes | `while`: `condition: (parenthesized_expression (true))`; `for(;;)`: `condition: (empty_statement)`; `no_break_or_return_in_body` implemented |
| `typescript/duplicate-function-arg` | TS params are `required_parameter`, not bare `(identifier)` | Wrap in `required_parameter`; unanchored pair also catches non-adjacent dupes; `same_param_name` implemented |
| `typescript/mixed-async-styles` | no `async_modifier` node exists | Match the `async` token on function/arrow/method/function_expression; kept `has_mixed_async` |
| `javascript/switch-non-case-labels` | `labeled_statement` was placed directly under `switch_body` (invalid) | Nest it inside `switch_case`, mirroring the working TS rule |
| `typescript/ts-insecure-random` | inline `(?i)` regex flag is invalid in JS `RegExp` | Dropped the redundant name predicate (the post-filter already checks the name case-insensitively); match the `Math.random()` call and walk up to its binding so `Math.random().toString(36)` is still attributed correctly |

Also fixed a **query-loader bug**: a column-0 `# …` comment between a `query: |` block and the next key was appended to the query and broke compilation (this is what kept `mixed-async-styles` dead even after its query was correct). Indented `#eq?`/`#match?` predicate lines are still preserved. Only `mixed-async-styles` and one already-disabled rule had such a comment.

Implemented the four post-filters these rules referenced but that were never defined — `is_empty_block`, `no_break_or_return_in_body`, `same_param_name`, `no_terminating_statement` — which the batch runner had been failing closed on (so even a compiling query would have matched nothing).

## Danger note (#877)
javascript still does **not** inherit typescript rules. `duplicate-function-arg` deliberately uses `required_parameter` (TS-only); it is not wired to JS.

## Parallel-work contract (compile-guard, #884)
`fix/884-rule-compile-guard` has **not** merged into master as of this PR, so I did not touch its allowlist. When it lands, its `KNOWN_BROKEN` allowlist must **drop** these ids:
`empty-switch-case`, `switch-case-termination`, `switch-case-termination-js`, `infinite-loop`, `duplicate-function-arg`, `mixed-async-styles`, `switch-non-case-labels-js`, `ts-insecure-random`.

## Verification
- `tests/clients/tree-sitter-884-rules.test.ts` — 19/19 pass
- `tree-sitter-query-batch`, `tree-sitter-query-loader`, `tree-sitter-new-blocker-rules` — pass
- Full `tests/clients` suite: 3775 pass; the 5 flakes (ast-grep/LSP/startup-timing) are unrelated and pass in isolation
- `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)