### PR TITLE
fix(dispatch): gate entity extraction on skip threshold and batch per…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,19 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Small edits no longer pay the entity-extraction cost** (refs #885) — the
+	<5-line skip threshold only guarded the zero-diagnostics early return; a
+	second `extractEntitySnapshot` block ran unconditionally, so trivial edits
+	still spent ~500-800ms per dispatch and, on unsaved buffers, parsed stale
+	disk content (thrashing the parse-cache entry). Extraction is now one
+	threshold-guarded block that receives the same `file.content` override the
+	diagnostics phase used.
+- **The per-edit tree-sitter runner walks the tree once, not once per rule**
+	(refs #888) — the dispatch hot path ran ~30-40 `runQueryOnFile` walks per
+	edit behind a concurrency limiter that could not parallelize synchronous
+	WASM. It now calls `runQueriesOnFile` once (#675 batching) and distributes
+	the per-rule results; the per-rule `maxResults(10)` cap and modified-ranges
+	gating are unchanged.
 - **module-report parses plain JS under the correct tree-sitter grammar** (closes
 	#887) — `tsLangForFile` hand-rolled a local extension map that sent
 	`.js`/`.mjs`/`.cjs` to the typescript grammar and `.jsx` to tsx, while every

--- a/clients/dispatch/runners/tree-sitter.ts
+++ b/clients/dispatch/runners/tree-sitter.ts
@@ -267,6 +267,7 @@ async function extractEntitySnapshot(
 	client: TreeSitterClient,
 	filePath: string,
 	languageId: string,
+	contentOverride?: string,
 ): Promise<Map<string, string>> {
 	const defs = ENTITY_QUERIES[languageId] ?? [];
 	const snapshot = new Map<string, string>();
@@ -288,6 +289,10 @@ async function extractEntitySnapshot(
 			filePath,
 			languageId,
 			{ maxResults: 200 },
+			// Parse the same buffer content the diagnostics phase used (#885).
+			// Without this, unsaved buffers snapshot stale disk content and
+			// thrash the parse-cache entry the rule walk just populated.
+			contentOverride,
 		);
 
 		for (const match of matches) {
@@ -523,136 +528,126 @@ const treeSitterRunner: RunnerDefinition = {
 				? contentFromFacts
 				: undefined;
 
-		// Run queries in parallel with concurrency limit for optimal performance
-		const CONCURRENCY_LIMIT = 6;
-		const queryResults: Diagnostic[][] = [];
-
-		for (let i = 0; i < effectiveQueries.length; i += CONCURRENCY_LIMIT) {
-			// Yield the event loop between batches so already-resolved promises from
-			// other parallel groups (LSP, eslint skip, etc.) can drain. Each wasm query
-			// batch is synchronous CPU work that would otherwise pin the event loop for
-			// the full runner duration, making other runners' latency measurements wrong.
-			if (i > 0) await new Promise<void>((r) => setImmediate(r));
-			const batch = effectiveQueries.slice(i, i + CONCURRENCY_LIMIT);
-			const batchResults = await Promise.all(
-				batch.map(async (query) => {
-					const queryDiagnostics: Diagnostic[] = [];
-					try {
-						const matches = await client.runQueryOnFile(
-							query,
-							filePath,
-							languageId,
-							{ maxResults: 10 },
-							contentOverride,
-						);
-
-						for (const match of matches) {
-							// match.line/column are already 1-indexed — the client emits
-							// startPosition.row + 1 (tree-sitter-client searchFileWithQuery).
-							const { line, column } = match;
-
-							// Modified-ranges gate only applies to blocking-tier diagnostics.
-							// Warning-tier diagnostics always flow through for logging.
-							const isSeverityBlocking =
-								query.severity === "error" ||
-								query.inline_tier === "blocking" ||
-								SILENT_ERROR_QUERY_IDS.has(query.id);
-							if (
-								ctx.blockingOnly &&
-								isSeverityBlocking &&
-								!isLineInModifiedRanges(line, ctx.modifiedRanges)
-							) {
-								continue;
-							}
-
-							// Map severity to semantic
-							const semantic =
-								query.severity === "error"
-									? "blocking"
-									: query.severity === "warning"
-										? "warning"
-										: "none";
-							const defectClass =
-								(query.defect_class as any) ??
-								classifyDefect(query.id, "tree-sitter", query.message);
-							const suggestion =
-								query.has_fix && query.fix_action
-									? `${query.fix_action} this statement`
-									: semantic === "blocking"
-										? defaultFixSuggestion(defectClass, query.id)
-										: undefined;
-
-							const hasSuggestedFix = !!query.has_fix;
-							queryDiagnostics.push({
-								id: `tree-sitter:${query.id}:${line}`,
-								message: query.message.replace(
-									/\{\{(\w+)\}\}/g,
-									(_, name) => match.captures[name]?.trim() ?? `{{${name}}}`,
-								),
-								filePath,
-								line,
-								column,
-								severity: query.severity,
-								semantic,
-								tool: "tree-sitter",
-								rule: query.id,
-								defectClass,
-								// Surface fix intent to agent — tree-sitter never auto-applies;
-								// linters (biome/ruff/eslint) own the autofix phase.
-								fixable: hasSuggestedFix,
-								autoFixAvailable: false,
-								fixKind: hasSuggestedFix ? "suggestion" : undefined,
-								fixSuggestion: suggestion,
-								matchedText: match.matchedText || undefined,
-								astNodeType: match.nodeType || undefined,
-							});
-						}
-					} catch (err) {
-						// pi-lens-ignore: missing-error-propagation — per-query resilience loop, intentional
-						const msg = err instanceof Error ? err.message : String(err);
-						// Emscripten abort() corrupts the entire module-level wasm heap.
-						// Poison the singleton so no further queries attempt to use the dead runtime.
-						if (msg.includes("Aborted") || msg.includes("abort()")) {
-							markTreeSitterWasmAborted();
-							logTreeSitter({
-								phase: "query_error",
-								filePath,
-								languageId,
-								queryId: query.id,
-								error: "wasm_aborted_fatal",
-							});
-						} else {
-							console.error(`[tree-sitter] Query ${query.id} failed:`, err);
-							logTreeSitter({
-								phase: "query_error",
-								filePath,
-								languageId,
-								queryId: query.id,
-								error: msg,
-							});
-						}
-					}
-					return queryDiagnostics;
-				}),
+		// ONE tree walk for the whole effective rule set, not one per rule (#888).
+		// The per-rule loop re-walked the tree ~30-40 times per edit; the work is
+		// synchronous WASM, so the concurrency-limit batching only chunked CPU work
+		// without parallelizing anything. runQueriesOnFile concatenates the patterns
+		// in rule order and maps each match back to its owning rule, so the per-rule
+		// maxResults(10) cap, metavars, predicates and post-filters still apply and
+		// results stay grouped in rule order. The post-match gating below (modified
+		// ranges, severity mapping) is unchanged.
+		const diagnostics: Diagnostic[] = [];
+		try {
+			const found = await client.runQueriesOnFile(
+				effectiveQueries,
+				filePath,
+				languageId,
+				{ maxResults: 10 },
+				contentOverride,
 			);
-			queryResults.push(...batchResults);
+
+			for (const { queryDef: query, match } of found) {
+				// match.line/column are already 1-indexed — the client emits
+				// startPosition.row + 1 (tree-sitter-client searchFileWithQuery).
+				const { line, column } = match;
+
+				// Modified-ranges gate only applies to blocking-tier diagnostics.
+				// Warning-tier diagnostics always flow through for logging.
+				const isSeverityBlocking =
+					query.severity === "error" ||
+					query.inline_tier === "blocking" ||
+					SILENT_ERROR_QUERY_IDS.has(query.id);
+				if (
+					ctx.blockingOnly &&
+					isSeverityBlocking &&
+					!isLineInModifiedRanges(line, ctx.modifiedRanges)
+				) {
+					continue;
+				}
+
+				// Map severity to semantic
+				const semantic =
+					query.severity === "error"
+						? "blocking"
+						: query.severity === "warning"
+							? "warning"
+							: "none";
+				const defectClass =
+					(query.defect_class as any) ??
+					classifyDefect(query.id, "tree-sitter", query.message);
+				const suggestion =
+					query.has_fix && query.fix_action
+						? `${query.fix_action} this statement`
+						: semantic === "blocking"
+							? defaultFixSuggestion(defectClass, query.id)
+							: undefined;
+
+				const hasSuggestedFix = !!query.has_fix;
+				diagnostics.push({
+					id: `tree-sitter:${query.id}:${line}`,
+					message: query.message.replace(
+						/\{\{(\w+)\}\}/g,
+						(_, name) => match.captures[name]?.trim() ?? `{{${name}}}`,
+					),
+					filePath,
+					line,
+					column,
+					severity: query.severity,
+					semantic,
+					tool: "tree-sitter",
+					rule: query.id,
+					defectClass,
+					// Surface fix intent to agent — tree-sitter never auto-applies;
+					// linters (biome/ruff/eslint) own the autofix phase.
+					fixable: hasSuggestedFix,
+					autoFixAvailable: false,
+					fixKind: hasSuggestedFix ? "suggestion" : undefined,
+					fixSuggestion: suggestion,
+					matchedText: match.matchedText || undefined,
+					astNodeType: match.nodeType || undefined,
+				});
+			}
+		} catch (err) {
+			// pi-lens-ignore: missing-error-propagation — per-dispatch resilience, intentional
+			const msg = err instanceof Error ? err.message : String(err);
+			// Emscripten abort() corrupts the entire module-level wasm heap.
+			// Poison the singleton so no further queries attempt to use the dead runtime.
+			if (msg.includes("Aborted") || msg.includes("abort()")) {
+				markTreeSitterWasmAborted();
+				logTreeSitter({
+					phase: "query_error",
+					filePath,
+					languageId,
+					error: "wasm_aborted_fatal",
+				});
+			} else {
+				console.error("[tree-sitter] Batched query run failed:", err);
+				logTreeSitter({
+					phase: "query_error",
+					filePath,
+					languageId,
+					error: msg,
+				});
+			}
 		}
 
-		// Flatten all query results into final diagnostics array
-		const diagnostics: Diagnostic[] = queryResults.flat();
-
-		// Skip expensive entity extraction for trivial changes (< 5 lines)
-		// This avoids ~500-800ms overhead for small edits like single-line fixes
+		// Skip expensive entity extraction for trivial changes (< 5 lines).
+		// Before #885 this threshold only guarded the zero-diagnostics early
+		// return below; a second extractEntitySnapshot block ran UNCONDITIONALLY
+		// after it, so small edits (skipEntityExtraction=true) still paid the
+		// ~500-800ms snapshot cost on every dispatch. One guarded block now
+		// serves both paths.
 		const totalLinesChanged = getTotalLinesChanged(ctx.modifiedRanges);
 		const skipEntityExtraction =
 			totalLinesChanged < ENTITY_EXTRACTION_LINE_THRESHOLD;
 
-		if (diagnostics.length === 0 && !skipEntityExtraction) {
+		if (!skipEntityExtraction) {
 			try {
 				const snapshot = await extractEntitySnapshot(
 					client,
 					filePath,
 					languageId,
+					contentOverride,
 				);
 				const diff = recordEntitySnapshotDiff(ctx.facts, filePath, snapshot);
 				const changedEntityKeys = [
@@ -695,7 +690,9 @@ const treeSitterRunner: RunnerDefinition = {
 			} catch {
 				/* entity snapshot / blast-radius enrichment is best-effort */
 			}
+		}
 
+		if (diagnostics.length === 0) {
 			logTreeSitter({
 				phase: "runner_complete",
 				filePath,
@@ -714,48 +711,6 @@ const treeSitterRunner: RunnerDefinition = {
 		const blockingCount = diagnostics.filter(
 			(d) => d.semantic === "blocking",
 		).length;
-		try {
-			const snapshot = await extractEntitySnapshot(
-				client,
-				filePath,
-				languageId,
-			);
-			const diff = recordEntitySnapshotDiff(ctx.facts, filePath, snapshot);
-			const changedEntityKeys = [
-				...diff.added,
-				...diff.modified,
-				...diff.removed,
-			];
-
-			if (changedEntityKeys.length > 0) {
-				logTreeSitter({
-					phase: "entity_diff",
-					filePath,
-					languageId,
-					metadata: {
-						added: diff.added,
-						modified: diff.modified,
-						removed: diff.removed,
-						totalChanged: changedEntityKeys.length,
-					},
-				});
-
-				const lastBlast = blastCooldownByFile.get(filePath) ?? 0;
-				if (Date.now() - lastBlast < BLAST_COOLDOWN_MS) {
-					logTreeSitter({
-						phase: "blast_radius",
-						filePath,
-						languageId,
-						metadata: { skipped: "cooldown", cooldownMs: BLAST_COOLDOWN_MS },
-					});
-				} else {
-					blastCooldownByFile.set(filePath, Date.now());
-					runBlastRadiusInBackground(ctx.cwd, filePath, languageId, ctx.facts);
-				}
-			}
-		} catch {
-			// best-effort experimental telemetry only
-		}
 
 		logTreeSitter({
 			phase: "runner_complete",

--- a/tests/clients/dispatch/runners/tree-sitter-dispatch-behavior.test.ts
+++ b/tests/clients/dispatch/runners/tree-sitter-dispatch-behavior.test.ts
@@ -11,15 +11,30 @@ import {
 	dispatchForFile,
 } from "../../../../clients/dispatch/dispatcher.js";
 import treeSitterRunner from "../../../../clients/dispatch/runners/tree-sitter.js";
+import {
+	queriesForLanguage,
+	queryLoader,
+} from "../../../../clients/tree-sitter-query-loader.js";
+import { getSharedTreeSitterClient } from "../../../../clients/tree-sitter-shared.js";
 
-// Keep unrelated fire-and-forget review-graph enrichment out of real-runner tests.
+// Keep unrelated fire-and-forget review-graph enrichment out of real-runner
+// tests. Tracked as a vi.fn so the #885 suite can assert WHEN the runner
+// snapshots entities — never under the <5-line skip threshold.
+const { recordEntitySnapshotDiffMock } = vi.hoisted(() => ({
+	recordEntitySnapshotDiffMock: vi.fn(() => ({
+		added: [] as string[],
+		removed: [] as string[],
+		modified: [] as string[],
+	})),
+}));
+
 vi.mock(
 	"../../../../clients/review-graph/service.js",
 	async (importOriginal) => ({
 		...(await importOriginal<
 			typeof import("../../../../clients/review-graph/service.js")
 		>()),
-		recordEntitySnapshotDiff: () => ({ added: [], removed: [], modified: [] }),
+		recordEntitySnapshotDiff: recordEntitySnapshotDiffMock,
 	}),
 );
 import {
@@ -29,6 +44,10 @@ import {
 	type RealRunnerEnv,
 } from "../../../support/real-runner-ctx.js";
 let env: RealRunnerEnv;
+beforeAll(async () => {
+	env = makeRealRunnerEnv();
+	await assertGrammarAvailable("typescript");
+});
 afterAll(() => env?.cleanup());
 
 // Matches variable-shadowing and puts debugger statements on lines 3 and 8.
@@ -46,11 +65,6 @@ const MIXED_SRC = [
 ].join("\n");
 
 describe("tree-sitter runner — dispatch filtering (#448)", () => {
-	beforeAll(async () => {
-		env = makeRealRunnerEnv();
-		await assertGrammarAvailable("typescript");
-	});
-
 	// The positive review-tier assertion keeps both negative filters below from
 	// passing vacuously if the real query fails to compile.
 	it("runs review-tier rules and ignores modifiedRanges outside blockingOnly", async () => {
@@ -109,4 +123,113 @@ describe("tree-sitter runner — dispatch filtering (#448)", () => {
 
 		expect(debuggerLines).toEqual([6]);
 	}, 30_000);
+});
+
+describe("tree-sitter runner — entity extraction skip threshold (#885)", () => {
+	it("skips entity extraction for edits under the 5-line threshold", async () => {
+		recordEntitySnapshotDiffMock.mockClear();
+		const { ctx } = env.addFile("small-edit.ts", MIXED_SRC, {
+			modifiedRanges: [{ start: 3, end: 3 }], // one changed line
+		});
+		const result = await treeSitterRunner.run(ctx);
+		// Sanity: rules ran and fired — the skip below is the threshold, not a
+		// vacuous no-op dispatch.
+		expect(result.diagnostics.length).toBeGreaterThan(0);
+		expect(recordEntitySnapshotDiffMock).not.toHaveBeenCalled();
+	}, 30_000);
+
+	it("runs entity extraction exactly once for edits at the threshold", async () => {
+		recordEntitySnapshotDiffMock.mockClear();
+		const { ctx } = env.addFile("threshold-edit.ts", MIXED_SRC, {
+			modifiedRanges: [{ start: 1, end: 5 }], // five changed lines
+		});
+		const result = await treeSitterRunner.run(ctx);
+		expect(result.diagnostics.length).toBeGreaterThan(0);
+		expect(recordEntitySnapshotDiffMock).toHaveBeenCalledTimes(1);
+	}, 30_000);
+
+	it("snapshots the unsaved buffer content, not stale disk", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const spy = vi.spyOn(client, "runQueryOnFile");
+		try {
+			const buffer = `${MIXED_SRC}\nfunction unsavedEntity() {}\n`;
+			const { ctx, filePath } = env.addFile("unsaved-buffer.ts", MIXED_SRC, {
+				modifiedRanges: [{ start: 1, end: 6 }], // over threshold
+			});
+			ctx.facts.setFileFact(filePath, "file.content", buffer);
+			await treeSitterRunner.run(ctx);
+			// Rule queries go through runQueriesOnFile (#888); the only per-rule
+			// walks left are the entity snapshot's — and they must parse the
+			// buffer, not the on-disk copy missing unsavedEntity.
+			const entityCalls = spy.mock.calls.filter(([queryDef]) =>
+				queryDef.id.startsWith("entity-"),
+			);
+			expect(entityCalls.length).toBeGreaterThan(0);
+			for (const args of entityCalls) {
+				expect(args[4]).toBe(buffer);
+			}
+		} finally {
+			spy.mockRestore();
+		}
+	}, 30_000);
+});
+
+describe("tree-sitter runner — batched per-edit queries (#888)", () => {
+	it("walks the tree once via runQueriesOnFile, never per-rule", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const batchSpy = vi.spyOn(client, "runQueriesOnFile");
+		const perRuleSpy = vi.spyOn(client, "runQueryOnFile");
+		try {
+			const { ctx } = env.addFile("single-walk.ts", MIXED_SRC, {
+				// Small edit: entity extraction is skipped, so ANY per-rule walk
+				// would be a regression to the pre-#888 loop.
+				modifiedRanges: [{ start: 1, end: 2 }],
+			});
+			const result = await treeSitterRunner.run(ctx);
+			expect(result.diagnostics.length).toBeGreaterThan(0);
+			expect(batchSpy).toHaveBeenCalledTimes(1);
+			expect(batchSpy.mock.calls[0][0].length).toBeGreaterThan(0);
+			expect(perRuleSpy).not.toHaveBeenCalled();
+		} finally {
+			batchSpy.mockRestore();
+			perRuleSpy.mockRestore();
+		}
+	}, 30_000);
+
+	it("matches the legacy per-rule path rule-for-rule and line-for-line", async () => {
+		const { ctx, filePath } = env.addFile("batch-equivalence.ts", MIXED_SRC, {
+			modifiedRanges: [{ start: 1, end: 9 }],
+		});
+		const result = await treeSitterRunner.run(ctx);
+		expect(result.diagnostics.length).toBeGreaterThan(0);
+
+		// Oracle: the pre-#888 path — one runQueryOnFile walk per rule with the
+		// same per-rule maxResults(10) cap, no blockingOnly gating.
+		const client = getSharedTreeSitterClient()!;
+		await queryLoader.loadQueries(env.cwd);
+		const rules = queriesForLanguage(
+			new Map([
+				["typescript", queryLoader.getQueriesForLanguage("typescript")],
+			]),
+			"typescript",
+		);
+		expect(rules.length).toBeGreaterThan(0);
+		const legacy = new Set<string>();
+		for (const rule of rules) {
+			const matches = await client.runQueryOnFile(
+				rule,
+				filePath,
+				"typescript",
+				{ maxResults: 10 },
+			);
+			for (const match of matches) {
+				legacy.add(`${rule.id}:${match.line}:${match.column}`);
+			}
+		}
+
+		const batched = new Set(
+			result.diagnostics.map((d) => `${d.rule}:${d.line}:${d.column}`),
+		);
+		expect(batched).toEqual(legacy);
+	}, 60_000);
 });

--- a/tests/clients/dispatch/runners/tree-sitter-runner.test.ts
+++ b/tests/clients/dispatch/runners/tree-sitter-runner.test.ts
@@ -72,6 +72,78 @@ async function loadRunnerWithClient(isAvailable: boolean, initResult: boolean) {
 	return mod.default;
 }
 
+/**
+ * Like loadRunnerWithClient, but with one or more queries loaded and client
+ * spies for the batched (#888) and entity (#885) paths.
+ */
+async function loadRunnerWithQueries(queries: unknown[]) {
+	vi.resetModules();
+
+	const recordEntitySnapshotDiff = vi.fn(() => ({
+		added: [] as string[],
+		modified: [] as string[],
+		removed: [] as string[],
+	}));
+	const runQueriesOnFile = vi.fn().mockResolvedValue([]);
+	const runQueryOnFile = vi.fn().mockResolvedValue([]);
+
+	vi.doMock("../../../../clients/tree-sitter-logger.js", () => ({
+		logTreeSitter: vi.fn(),
+	}));
+	vi.doMock("../../../../clients/review-graph/service.js", () => ({
+		buildOrUpdateGraph: vi.fn().mockResolvedValue({}),
+		computeImpactCascade: vi.fn().mockReturnValue({
+			changedSymbols: [],
+			neighborFiles: [],
+			directImporters: [],
+			directCallers: [],
+			riskFlags: [],
+		}),
+		recordEntitySnapshotDiff,
+	}));
+	vi.doMock("../../../../clients/tree-sitter-query-loader.js", () => ({
+		queryLoader: {
+			loadQueries: vi.fn().mockResolvedValue([]),
+			getQueriesForLanguage: vi.fn().mockReturnValue(queries),
+			getAllQueries: vi.fn().mockReturnValue(queries),
+		},
+		queriesForLanguage: (q: Map<string, unknown[]>, languageId: string) =>
+			q.get(languageId) ?? [],
+		isDisabledQueryFilePath: () => false,
+	}));
+	vi.doMock("../../../../clients/cache/rule-cache.js", () => ({
+		RuleCache: class {
+			get() {
+				return null;
+			}
+			set() {}
+		},
+	}));
+	vi.doMock("../../../../clients/tree-sitter-client.js", () => {
+		function MockTreeSitterClient() {
+			return {
+				isAvailable: () => true,
+				init: () => Promise.resolve(true),
+				parseFile: () => Promise.resolve(null),
+				query: () => [],
+				runQueriesOnFile,
+				runQueryOnFile,
+			};
+		}
+		return { TreeSitterClient: MockTreeSitterClient };
+	});
+
+	const mod = await import(
+		"../../../../clients/dispatch/runners/tree-sitter.js"
+	);
+	return {
+		runner: mod.default,
+		recordEntitySnapshotDiff,
+		runQueriesOnFile,
+		runQueryOnFile,
+	};
+}
+
 describe("tree-sitter runner — metadata", () => {
 	beforeEach(() => vi.resetModules());
 
@@ -154,5 +226,81 @@ describe("tree-sitter runner — skip paths", () => {
 		const result = await runner.run(ctx as any);
 		expect(["skipped", "succeeded"]).toContain(result.status);
 		expect(result.diagnostics).toHaveLength(0);
+	});
+});
+
+describe("tree-sitter runner — entity extraction skip threshold (#885)", () => {
+	const fakeQuery = {
+		id: "fake-rule",
+		name: "fake-rule",
+		severity: "warning",
+		language: "typescript",
+		message: "fake",
+		query: "(identifier) @X",
+		metavars: ["X"],
+		has_fix: false,
+		filePath: "rules/tree-sitter-queries/typescript/fake-rule.yml",
+	};
+
+	it("skips entity extraction for edits under 5 changed lines", async () => {
+		const { runner, recordEntitySnapshotDiff, runQueryOnFile } =
+			await loadRunnerWithQueries([fakeQuery]);
+		const ctx = {
+			...createCtx("/fake/file.ts"),
+			modifiedRanges: [{ start: 10, end: 10 }], // 1 changed line
+		};
+		const result = await runner.run(ctx as any);
+		expect(result.status).toBe("succeeded");
+		expect(recordEntitySnapshotDiff).not.toHaveBeenCalled();
+		// No entity queries reached the client either.
+		expect(runQueryOnFile).not.toHaveBeenCalled();
+	});
+
+	it("runs entity extraction once for edits at/over 5 changed lines", async () => {
+		const { runner, recordEntitySnapshotDiff, runQueryOnFile } =
+			await loadRunnerWithQueries([fakeQuery]);
+		const ctx = {
+			...createCtx("/fake/file.ts"),
+			modifiedRanges: [{ start: 10, end: 14 }], // 5 changed lines
+		};
+		const result = await runner.run(ctx as any);
+		expect(result.status).toBe("succeeded");
+		expect(recordEntitySnapshotDiff).toHaveBeenCalledTimes(1);
+		// Only entity queries use the per-rule client path now.
+		expect(runQueryOnFile.mock.calls.length).toBeGreaterThan(0);
+		for (const args of runQueryOnFile.mock.calls) {
+			expect(args[0].id).toMatch(/^entity-/);
+		}
+	});
+});
+
+describe("tree-sitter runner — batched per-edit queries (#888)", () => {
+	const fakeQuery = {
+		id: "fake-rule",
+		name: "fake-rule",
+		severity: "warning",
+		language: "typescript",
+		message: "fake",
+		query: "(identifier) @X",
+		metavars: ["X"],
+		has_fix: false,
+		filePath: "rules/tree-sitter-queries/typescript/fake-rule.yml",
+	};
+
+	it("issues one runQueriesOnFile call with the per-rule cap", async () => {
+		const { runner, runQueriesOnFile, runQueryOnFile } =
+			await loadRunnerWithQueries([fakeQuery]);
+		const ctx = {
+			...createCtx("/fake/file.ts"),
+			modifiedRanges: [{ start: 10, end: 10 }],
+		};
+		await runner.run(ctx as any);
+		expect(runQueriesOnFile).toHaveBeenCalledTimes(1);
+		expect(runQueriesOnFile.mock.calls[0][0]).toEqual([
+			expect.objectContaining({ id: "fake-rule" }),
+		]);
+		expect(runQueriesOnFile.mock.calls[0][3]).toEqual({ maxResults: 10 });
+		// Small edit: no entity walks either.
+		expect(runQueryOnFile).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
…-edit tree-sitter queries (refs #885, #888)

#885: the <5-line skip threshold only guarded the zero-diagnostics early return; a second extractEntitySnapshot block ran unconditionally after it, so small edits (skipEntityExtraction=true) still paid ~500-800ms per dispatch. Merge into one threshold-guarded block, and pass the same file.content contentOverride the diagnostics phase used so unsaved buffers no longer snapshot stale disk content and thrash the parse-cache entry.

#888: the per-edit hot path ran one tree walk per rule (~30-40 runQueryOnFile calls) behind a CONCURRENCY_LIMIT that could not parallelize synchronous WASM. Call runQueriesOnFile once (#675 batching) and distribute the per-rule results; the per-rule maxResults(10) cap and modified-ranges gating happen post-match and are unchanged. Drop the now-pointless concurrency machinery.

Tests: mocked + real-engine assertions that small edits skip entity extraction (and at-threshold edits run it exactly once, on the buffer content), that the runner issues a single runQueriesOnFile call, and that batched results match the legacy per-rule path rule-for-rule on a fixture.

## Summary

Briefly describe what this PR does and which issue it resolves.

Closes #(issue)

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [ ] The change has tests (happy path, edge cases, regression test for bugs)
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [ ] `package-lock.json` is in sync with `package.json` (run `npm install` after dep changes)
- [ ] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there
- [ ] `CHANGELOG.md` has a `## [Unreleased]` entry **in this PR** for any user-facing change (Added/Changed/Fixed) — internal-only test/refactor PRs may skip it
- [ ] Commit subject includes the issue number: `(closes #NNN)` or `(refs #NNN)`

## What changed and why

Use this section for any non-obvious design decisions or gotchas the reviewer should know about.
