### PR TITLE
fix(rules): recognize terminators inside block-wrapped switch cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Block-wrapped switch cases no longer report false fall-through errors**
+	(refs #910) — `switch-case-termination` now follows trailing statement
+	blocks to recognize a nested `break`, `return`, `throw`, or `continue`, while
+	still flagging empty and non-terminating blocks.
 - **Small edits no longer pay the entity-extraction cost** (refs #885) — the
 	<5-line skip threshold only guarded the zero-diagnostics early return; a
 	second `extractEntitySnapshot` block ran unconditionally, so trivial edits

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -1578,7 +1578,18 @@ export class TreeSitterClient {
 				if (!caseNode) return false;
 				const body = this.switchCaseBodyStatements(caseNode);
 				if (body.length === 0) return false;
-				const last = body[body.length - 1];
+				let last = body[body.length - 1];
+				while (last.type === "statement_block") {
+					// A block-scoped case body terminates when its trailing statement
+					// terminates. Keep an empty block as the last node so it still
+					// reports fall-through.
+					const inner = (last.children ?? []).filter(
+						(c) => c.isNamed && !c.type.includes("comment"),
+					);
+					const next = inner[inner.length - 1];
+					if (!next) break;
+					last = next;
+				}
 				const TERMINATORS = new Set([
 					"break_statement",
 					"return_statement",

--- a/tests/clients/tree-sitter-884-rules.test.ts
+++ b/tests/clients/tree-sitter-884-rules.test.ts
@@ -191,6 +191,22 @@ describe("switch-case-termination (TS)", () => {
 			),
 		).toBe(0);
 	});
+
+	it.each([
+		["a block-wrapped terminating case", `{ const body = compute(); return body; }`, 0],
+		["a block-wrapped non-terminating case", `{ compute(); }`, 1],
+		["nested trailing blocks that terminate", `{ compute(); { return "one"; } }`, 0],
+		["an empty trailing block", `{ }`, 1],
+	])("%s", async (_name, caseBody, expected) => {
+		expect(
+			await count(
+				"switch-case-termination",
+				"ts",
+				"typescript",
+				`switch (x) {\n case 1: ${caseBody}\n case 2:\n  break;\n}`,
+			),
+		).toBe(expected);
+	});
 });
 
 describe("ts-insecure-random (TS)", () => {
@@ -238,6 +254,22 @@ describe("switch-case-termination-js (JS)", () => {
 				`switch (x) {\n case 1:\n  return "one";\n case 2:\n  break;\n}`,
 			),
 		).toBe(0);
+	});
+
+	it.each([
+		["a block-wrapped terminating case", `{ const body = compute(); return body; }`, 0],
+		["a block-wrapped non-terminating case", `{ compute(); }`, 1],
+		["nested trailing blocks that terminate", `{ compute(); { return "one"; } }`, 0],
+		["an empty trailing block", `{ }`, 1],
+	])("%s", async (_name, caseBody, expected) => {
+		expect(
+			await count(
+				"switch-case-termination-js",
+				"js",
+				"javascript",
+				`switch (x) {\n case 1: ${caseBody}\n case 2:\n  break;\n}`,
+			),
+		).toBe(expected);
 	});
 });
 


### PR DESCRIPTION
Closes #910

## Summary
- The `no_terminating_statement` post-filter now descends through trailing `statement_block`s to the last named non-comment statement before checking the TERMINATORS set, so `case x: { const y = f(); return y; }` is no longer flagged as a blocking fall-through FP. Applies to both `switch-case-termination` (TS) and `switch-case-termination-js` via the shared filter.
- Empty trailing blocks (`case 1: { }`) still flag as fall-through; nested trailing blocks terminate correctly.
- Parameterized tests for both rule variants: block-wrapped terminating (0 matches), block-wrapped non-terminating (1), nested trailing blocks (0), empty trailing block (1).

## Validation
Build + lint clean; 884-rules suite 27/27; 8 adjacent tree-sitter suites 118/118.

Implemented by a codex (gpt-5.6-sol) plegma worker, completed and verified by the orchestrator after a session interruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)