### PR TITLE
fix(diagnostics): do not persist truncated scan snapshot after mid-scan WASM abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **A mid-scan tree-sitter WASM abort no longer replaces the authoritative
+	project-diagnostics snapshot with a silently truncated result** (refs #891).
+	The partial scan is returned with `scanTruncated`, logs its completed/total
+	file counts and abort point, and leaves the previous complete cache intact.
 - **Small edits no longer pay the entity-extraction cost** (refs #885) — the
 	<5-line skip threshold only guarded the zero-diagnostics early return; a
 	second `extractEntitySnapshot` block ran unconditionally, so trivial edits

--- a/clients/project-diagnostics/scanner.ts
+++ b/clients/project-diagnostics/scanner.ts
@@ -15,7 +15,10 @@ import { isTestFile } from "../file-utils.js";
 import { isAtOrAboveHomeDir } from "../path-utils.js";
 import { getProjectDiagnosticsScannerMaxFiles } from "../project-scale.js";
 import { collectSourceFilesWithBudgetAsync } from "../source-filter.js";
-import { logTreeSitterCacheStats } from "../tree-sitter-logger.js";
+import {
+	logTreeSitter,
+	logTreeSitterCacheStats,
+} from "../tree-sitter-logger.js";
 import {
 	queriesForLanguage,
 	queryLoader,
@@ -23,6 +26,7 @@ import {
 import {
 	EXT_TO_LANG,
 	getSharedTreeSitterClient,
+	isTreeSitterWasmAborted,
 } from "../tree-sitter-shared.js";
 import {
 	PROJECT_DIAGNOSTICS_CACHE_VERSION,
@@ -112,6 +116,8 @@ function fromDispatchDiagnostic(
 interface TreeSitterAndFactScan {
 	treeSitter: ProjectDiagnostic[];
 	factRules: ProjectDiagnostic[];
+	filesScanned: number;
+	wasmAborted: boolean;
 }
 
 /**
@@ -142,16 +148,20 @@ async function scanTreeSitterAndFactRules(
 	const treeSitter: ProjectDiagnostic[] = [];
 	const factRules: ProjectDiagnostic[] = [];
 	let filesScanned = 0;
+	const wasmAbortedAtStart = isTreeSitterWasmAborted();
+	let wasmAborted = wasmAbortedAtStart;
 
 	const scan = async (): Promise<void> => {
 		for (const filePath of files) {
-			if (signal?.aborted) break;
+			if (signal?.aborted || isTreeSitterWasmAborted()) {
+				wasmAborted ||= isTreeSitterWasmAborted();
+				break;
+			}
 			if (isTestFile(filePath)) continue;
 			const ext = path.extname(filePath);
 			const langId = TREE_SITTER_EXT_TO_LANG[ext];
 			const factEligible = FACT_RULE_EXTENSIONS.has(ext);
 			if (!langId && !factEligible) continue;
-			filesScanned++;
 
 			if (queryMap && langId && client) {
 				const queries = queriesForLanguage(queryMap, langId);
@@ -185,6 +195,10 @@ async function scanTreeSitterAndFactRules(
 				} catch {
 					// Continue scanning other rules/files.
 				}
+				if (isTreeSitterWasmAborted()) {
+					wasmAborted = true;
+					break;
+				}
 			}
 
 			if (factEligible) {
@@ -198,13 +212,18 @@ async function scanTreeSitterAndFactRules(
 				} catch {
 					// Project scans are best-effort; one unparsable file should not abort the tool.
 				}
+				if (isTreeSitterWasmAborted()) {
+					wasmAborted = true;
+					break;
+				}
 			}
+			filesScanned++;
 		}
 	};
 
 	if (!client) {
 		await scan();
-		return { treeSitter, factRules };
+		return { treeSitter, factRules, filesScanned, wasmAborted };
 	}
 
 	const startedAt = Date.now();
@@ -217,7 +236,7 @@ async function scanTreeSitterAndFactRules(
 			stats,
 		});
 	});
-	return { treeSitter, factRules };
+	return { treeSitter, factRules, filesScanned, wasmAborted };
 }
 
 /**
@@ -323,14 +342,18 @@ export async function scanProjectDiagnostics(
 	// already file-capped, so phase granularity is enough to bound the work.
 	const runners: string[] = [];
 	const diagnostics: ProjectDiagnostic[] = [];
+	let wasmAborted = false;
+	let filesScanned = files.length;
 	if (!signal?.aborted) {
 		// Both runners parse the same file, so they share ONE file-major pass
 		// (#675) — the per-file order is what keeps the second one on a cache hit.
 		const scanned = await scanTreeSitterAndFactRules(cwd, files, signal);
 		diagnostics.push(...scanned.treeSitter, ...scanned.factRules);
 		runners.push("tree-sitter", "fact-rules");
+		wasmAborted = scanned.wasmAborted;
+		if (wasmAborted) filesScanned = scanned.filesScanned;
 	}
-	if (!signal?.aborted) {
+	if (!signal?.aborted && !wasmAborted) {
 		diagnostics.push(...(await scanAstGrepNapi(cwd, files)));
 		runners.push("ast-grep-napi");
 	}
@@ -340,19 +363,34 @@ export async function scanProjectDiagnostics(
 		tier: options.tier,
 		scannedAt: new Date().toISOString(),
 		diagnostics,
-		filesScanned: files.length,
+		filesScanned,
 		runners,
 	};
 	// #760: only present when true — keeps existing snapshots/serializations
 	// byte-identical for the untruncated (normal) case.
 	if (collected.entryBudgetExceeded) snapshot.scanTruncated = true;
+	if (wasmAborted) {
+		snapshot.scanTruncated = true;
+		logTreeSitter({
+			phase: "runner_skip",
+			filePath: cwd,
+			status: "aborted",
+			reason: "wasm_aborted_mid_scan",
+			metadata: {
+				scope: "project_diagnostics_scan",
+				filesScanned,
+				totalFiles: files.length,
+				abortPoint: filesScanned + 1,
+			},
+		});
+	}
 	// A cancelled scan yields a partial snapshot; don't persist it as the
 	// authoritative cross-session cache — only a complete run is cacheable.
 	// Likewise, an explicit `files` scan (#461) only covers a caller-chosen
 	// subset (e.g. git-staged files), not the whole project — persisting it
 	// would poison the cross-session cache with a partial view that a later
 	// unscoped `refreshRunners=cached` read would wrongly trust as complete.
-	if (signal?.aborted || options.files) return snapshot;
+	if (signal?.aborted || options.files || wasmAborted) return snapshot;
 	saveProjectDiagnosticsSnapshot(cwd, snapshot);
 	return snapshot;
 }

--- a/clients/project-diagnostics/types.ts
+++ b/clients/project-diagnostics/types.ts
@@ -40,6 +40,10 @@ export interface ProjectDiagnosticsSnapshot {
 	 * `unsafeRoot` this is NOT a refusal: a truncated analysis is still useful;
 	 * the flag only keeps a caller from reading the partial result as a
 	 * complete, clean sweep.
+	 *
+	 * Also true when tree-sitter's process-wide WASM runtime aborts during the
+	 * file-major pass. That partial result is returned for observability but is
+	 * never persisted over the last authoritative snapshot (#891).
 	 */
 	scanTruncated?: boolean;
 }

--- a/tests/clients/project-diagnostics/scanner-wasm-abort.test.ts
+++ b/tests/clients/project-diagnostics/scanner-wasm-abort.test.ts
@@ -1,0 +1,149 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+	aborted: false,
+	abortAfter: Number.POSITIVE_INFINITY,
+	parseCalls: 0,
+	log: vi.fn(),
+}));
+
+vi.mock("../../../clients/tree-sitter-shared.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import("../../../clients/tree-sitter-shared.js")
+		>();
+	const client = {
+		isAvailable: () => true,
+		init: async () => true,
+		runQueriesOnFile: async () => {
+			state.parseCalls++;
+			if (state.parseCalls === state.abortAfter) state.aborted = true;
+			return [];
+		},
+		withParseCacheMeasurement: async (scan: () => Promise<void>) => scan(),
+	};
+	return {
+		...actual,
+		getSharedTreeSitterClient: () => (state.aborted ? null : client),
+		isTreeSitterWasmAborted: () => state.aborted,
+	};
+});
+
+vi.mock("../../../clients/tree-sitter-query-loader.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import("../../../clients/tree-sitter-query-loader.js")
+		>();
+	return {
+		...actual,
+		queryLoader: { loadQueries: async () => new Map() },
+		queriesForLanguage: () => [{ id: "test", query: "(identifier) @id" }],
+	};
+});
+
+vi.mock(
+	"../../../clients/dispatch/runners/ast-grep-napi.js",
+	async (importOriginal) => {
+		const actual =
+			await importOriginal<
+				typeof import("../../../clients/dispatch/runners/ast-grep-napi.js")
+			>();
+		return {
+			...actual,
+			canHandle: () => false,
+			getLang: () => undefined,
+			evaluateAstGrepRules: () => [],
+			loadSg: async () => null,
+		};
+	},
+);
+
+vi.mock("../../../clients/tree-sitter-logger.js", () => ({
+	logTreeSitter: state.log,
+	logTreeSitterCacheStats: vi.fn(),
+}));
+
+import {
+	loadProjectDiagnosticsSnapshot,
+	saveProjectDiagnosticsSnapshot,
+} from "../../../clients/project-diagnostics/cache.js";
+import { scanProjectDiagnostics } from "../../../clients/project-diagnostics/scanner.js";
+import type { ProjectDiagnosticsSnapshot } from "../../../clients/project-diagnostics/types.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+let tmp: string;
+
+function priorSnapshot(): ProjectDiagnosticsSnapshot {
+	return {
+		version: 2,
+		cwd: tmp,
+		tier: "cheap",
+		scannedAt: "2026-01-01T00:00:00.000Z",
+		diagnostics: [
+			{
+				filePath: path.join(tmp, "old.ts"),
+				severity: "warning",
+				tool: "tree-sitter",
+				runner: "tree-sitter",
+				message: "authoritative",
+				source: "project-scan",
+			},
+		],
+		filesScanned: 3,
+		runners: ["tree-sitter"],
+	};
+}
+
+beforeEach(() => {
+	tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-scan-abort-"));
+	for (const name of ["a.ts", "b.ts", "c.ts"]) {
+		fs.writeFileSync(path.join(tmp, name), `export const ${name[0]} = 1;\n`);
+	}
+	state.aborted = false;
+	state.abortAfter = Number.POSITIVE_INFINITY;
+	state.parseCalls = 0;
+	state.log.mockClear();
+});
+
+afterEach(() => {
+	removeTempDirSync(tmp);
+});
+
+describe("project diagnostics mid-scan WASM abort (#891)", () => {
+	it("returns a marked partial scan, logs counts, and preserves the prior authoritative snapshot", async () => {
+		const prior = priorSnapshot();
+		saveProjectDiagnosticsSnapshot(tmp, prior);
+		state.abortAfter = 2;
+
+		const result = await scanProjectDiagnostics({ cwd: tmp, tier: "cheap" });
+
+		expect(result.scanTruncated).toBe(true);
+		expect(result.filesScanned).toBe(1);
+		expect(state.parseCalls).toBe(2);
+		expect(loadProjectDiagnosticsSnapshot(tmp)).toEqual(prior);
+		expect(state.log).toHaveBeenCalledWith(
+			expect.objectContaining({
+				reason: "wasm_aborted_mid_scan",
+				metadata: expect.objectContaining({
+					filesScanned: 1,
+					totalFiles: 3,
+					abortPoint: 2,
+				}),
+			}),
+		);
+	});
+
+	it("persists the complete snapshot when no WASM abort occurs", async () => {
+		const result = await scanProjectDiagnostics({ cwd: tmp, tier: "cheap" });
+
+		expect(result.scanTruncated).toBeUndefined();
+		expect(result.filesScanned).toBe(3);
+		expect(loadProjectDiagnosticsSnapshot(tmp)).toEqual(result);
+		expect(state.log).not.toHaveBeenCalledWith(
+			expect.objectContaining({ reason: "wasm_aborted_mid_scan" }),
+		);
+	});
+});


### PR DESCRIPTION
Closes #891

## Summary
- The file-major scan pass now polls `isTreeSitterWasmAborted()` (top of each file iteration and after each catch block) and breaks on transition — surfacing the poison the per-file catches otherwise hide.
- On abort: the ast-grep phase is skipped, the result carries `scanTruncated: true` + accurate `filesScanned`, telemetry logs `wasm_aborted_mid_scan` with filesScanned/totalFiles/abortPoint, and `saveProjectDiagnosticsSnapshot` is never called — a previously saved complete snapshot survives byte-for-byte.
- `filesScanned` now counts only fully completed files; `formatTruncationWarning` (existing #760 consumer) reports the abort case correctly.
- Regression tests: seeded prior snapshot survives an abort-on-second-parse scan deep-equal intact; no-abort persistence unchanged.

## Validation
Build + lint clean; project-diagnostics suite 41/41.

Implemented by a codex (gpt-5.6-sol) plegma worker, completed and verified by the orchestrator after a session interruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)