### PR TITLE
fix(perf): release scanned file content from the shared FactStore after each file's consumers finish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,11 @@ tools/                    ast-grep-search, lsp-navigation tool handlers
 tests/                    Vitest test suite (mirrors clients/ structure)
 ```
 
+Whole-project loops that reuse one `FactStore` must delete `file.content` after
+that file's consumers finish (in a `finally` so abort/error exits release it).
+Keep derived file facts and session facts: later cross-file consumers may still
+need those, but no scan may retain every processed file's full source string.
+
 ## MCP mirror (second host adapter — `mcp/` + `clients/lens-engine.ts`)
 
 pi-lens is also exposed as an **MCP server** so it can be used / live-tested /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Changed
 
+- **Project scans release each processed file's full source content** (refs #886)
+	instead of retaining every source string in their shared `FactStore` until the
+	scan ends; derived per-file facts and session facts remain available.
 - Repair eight non-compiling Java, C++, CSS and PHP tree-sitter rules (refs #884).
 - Repair four non-compiling Go, Rust, and Kotlin tree-sitter rules (refs #884).
 - **Project diagnostics now use one file-major scan pass** (refs #896) —

--- a/clients/dispatch/fact-store.ts
+++ b/clients/dispatch/fact-store.ts
@@ -32,6 +32,16 @@ export class FactStore implements ReadonlyFactStore {
     return this.fileFacts.get(normalizeMapKey(filePath))?.has(factId) ?? false;
   }
 
+  /** Drop one file fact without disturbing the file's derived facts.
+   *  Removes the per-file entry too when the deleted fact was its last value. */
+  deleteFileFact(filePath: string, factId: string): void {
+    const key = normalizeMapKey(filePath);
+    const facts = this.fileFacts.get(key);
+    if (!facts) return;
+    facts.delete(factId);
+    if (facts.size === 0) this.fileFacts.delete(key);
+  }
+
   /** Clear facts for one specific file only. Use at the start of each per-file dispatch call.
    *  Preserves facts for other files computed in the same turn.
    *  Normalizes filePath internally — callers pass raw paths. */

--- a/clients/project-diagnostics/scanner.ts
+++ b/clients/project-diagnostics/scanner.ts
@@ -272,31 +272,37 @@ async function scanFileMajorRules(
 				content = null;
 			}
 
-			await scanTreeSitterFile(filePath, langId, content);
-			if (isTreeSitterWasmAborted()) {
-				wasmAborted = true;
-				break;
-			}
-
-			if (factEligible) {
-				await scanFactRulesFile(filePath, content);
+			try {
+				await scanTreeSitterFile(filePath, langId, content);
 				if (isTreeSitterWasmAborted()) {
 					wasmAborted = true;
 					break;
 				}
-			}
 
-			if (signal?.aborted) {
-				// The former phase-major scan never started ast-grep after a
-				// phase-one abort. Discard earlier ast-grep work from this merged
-				// pass to preserve that partial-result contract.
-				astGrep.length = 0;
-				break;
+				if (factEligible) {
+					await scanFactRulesFile(filePath, content);
+					if (isTreeSitterWasmAborted()) {
+						wasmAborted = true;
+						break;
+					}
+				}
+
+				if (signal?.aborted) {
+					// The former phase-major scan never started ast-grep after a
+					// phase-one abort. Discard earlier ast-grep work from this merged
+					// pass to preserve that partial-result contract.
+					astGrep.length = 0;
+					break;
+				}
+				if (astGrepLang && content !== null) {
+					scanAstGrepFile(filePath, content, astGrepLang);
+				}
+				filesScanned++;
+			} finally {
+				// The shared scan store keeps derived facts for any later cross-file
+				// consumer, but no consumer after this iteration needs the source bytes.
+				facts.deleteFileFact(filePath, "file.content");
 			}
-			if (astGrepLang && content !== null) {
-				scanAstGrepFile(filePath, content, astGrepLang);
-			}
-			filesScanned++;
 		}
 		if (wasmAborted) {
 			// Mirror the phase-major #891 contract: the ast-grep phase never ran

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -1730,13 +1730,22 @@ async function addFileToGraph(
 	// the incremental/cascade path (a changed *.test.ts) never adds them either.
 	if (detectFileRole(file) === "test") return;
 	if (kind === "jsts") {
+		// Release content ONLY when this builder seeded it. The incremental
+		// per-edit path receives the LIVE dispatch FactStore (via the
+		// fire-and-forget blast-radius build), and the dispatch still reads
+		// file.content after its runner groups settle — inline suppressions,
+		// dispositions, and fact rules would race a delete and silently see
+		// undefined. Content the dispatch put there is the dispatch's to free.
+		const dispatchOwnsContent =
+			facts.getFileFact<string>(file, "file.content") !== undefined &&
+			contentOverride == null;
 		try {
 			await ensureReviewGraphFacts(file, cwd, facts, contentOverride);
 			addJsTsFile(graph, cwd, file, facts, ignoredIds);
 		} finally {
 			// The graph has copied every durable value it needs. Keep derived facts
 			// available to callers, but do not retain full source in a shared store.
-			facts.deleteFileFact(file, "file.content");
+			if (!dispatchOwnsContent) facts.deleteFileFact(file, "file.content");
 		}
 		return;
 	}

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -1730,8 +1730,14 @@ async function addFileToGraph(
 	// the incremental/cascade path (a changed *.test.ts) never adds them either.
 	if (detectFileRole(file) === "test") return;
 	if (kind === "jsts") {
-		await ensureReviewGraphFacts(file, cwd, facts, contentOverride);
-		addJsTsFile(graph, cwd, file, facts, ignoredIds);
+		try {
+			await ensureReviewGraphFacts(file, cwd, facts, contentOverride);
+			addJsTsFile(graph, cwd, file, facts, ignoredIds);
+		} finally {
+			// The graph has copied every durable value it needs. Keep derived facts
+			// available to callers, but do not retain full source in a shared store.
+			facts.deleteFileFact(file, "file.content");
+		}
 		return;
 	}
 	const languageId = mapKindToTreeSitterLanguage(kind, file);

--- a/tests/clients/dispatch/fact-store-lifecycle.test.ts
+++ b/tests/clients/dispatch/fact-store-lifecycle.test.ts
@@ -17,6 +17,15 @@ describe("FactStore lifecycle contract", () => {
     expect(store.getSessionFact("session.toolCache.biome")).toBe(true);
   });
 
+  it("deleteFileFact releases one value while preserving sibling derived facts", () => {
+    const store = new FactStore();
+    store.setFileFact("src/a.ts", "file.content", "full source");
+    store.setFileFact("src/a.ts", "file.imports", [{ source: "./b" }]);
+    store.deleteFileFact("src/a.ts", "file.content");
+    expect(store.getFileFact("src/a.ts", "file.content")).toBeUndefined();
+    expect(store.getFileFact("src/a.ts", "file.imports")).toEqual([{ source: "./b" }]);
+  });
+
   it("store is fully usable after clearAll — re-population works", () => {
     const store = new FactStore();
     store.setFileFact("/src/a.ts", "content", "original");

--- a/tests/clients/project-diagnostics/scanner.test.ts
+++ b/tests/clients/project-diagnostics/scanner.test.ts
@@ -2,7 +2,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
 import { LANGUAGE_TO_GRAMMAR } from "../../../clients/grammar-source.js";
 import { loadProjectDiagnosticsSnapshot } from "../../../clients/project-diagnostics/cache.js";
 import {
@@ -183,5 +184,50 @@ describe("scanProjectDiagnostics home ceiling (#747/#250)", () => {
 		});
 
 		expect(snapshot.unsafeRoot).toBeUndefined();
+	});
+});
+
+describe("scanProjectDiagnostics FactStore content lifecycle (#886)", () => {
+	it("releases each file's full content after its consumers finish", async () => {
+		const files = ["a.ts", "b.ts", "c.ts"].map((name, index) => {
+			const filePath = path.join(tmp, name);
+			fs.writeFileSync(
+				filePath,
+				`export const value${index} = "${name}-full-content-marker";\n`,
+			);
+			return filePath;
+		});
+		const released = new Set<string>();
+		const original = FactStore.prototype.deleteFileFact;
+		const deleteSpy = vi
+			.spyOn(FactStore.prototype, "deleteFileFact")
+			.mockImplementation(function (
+				this: FactStore,
+				filePath: string,
+				factId: string,
+			) {
+				if (factId === "file.content") {
+					expect(this.getFileFact(filePath, factId)).toContain(
+						"full-content-marker",
+					);
+					original.call(this, filePath, factId);
+					expect(this.getFileFact(filePath, factId)).toBeUndefined();
+					released.add(path.resolve(filePath));
+					return;
+				}
+				original.call(this, filePath, factId);
+			});
+
+		try {
+			await scanProjectDiagnostics({
+				cwd: tmp,
+				tier: "cheap",
+				files,
+			});
+		} finally {
+			deleteSpy.mockRestore();
+		}
+
+		expect(released).toEqual(new Set(files.map((file) => path.resolve(file))));
 	});
 });

--- a/tests/clients/review-graph/content-release.test.ts
+++ b/tests/clients/review-graph/content-release.test.ts
@@ -1,0 +1,66 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import {
+	buildOrUpdateGraph,
+	clearReviewGraphWorkspaceCache,
+} from "../../../clients/review-graph/builder.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+// #886 / #931 review: the builder releases full source content it seeded into a
+// shared FactStore, but must NEVER release content the DISPATCH put there — the
+// incremental blast-radius path runs fire-and-forget against the live dispatch
+// store, and inline suppressions / dispositions / fact rules still read
+// file.content after the runner groups settle. A delete would race them.
+describe("review-graph builder — file.content release ownership", () => {
+	const dirs: string[] = [];
+
+	beforeEach(() => {
+		clearReviewGraphWorkspaceCache();
+	});
+
+	afterEach(() => {
+		for (const dir of dirs.splice(0)) {
+			removeTempDirSync(dir);
+		}
+	});
+
+	function tmpProject(): { cwd: string; file: string; src: string } {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-content-rel-"));
+		dirs.push(cwd);
+		const src = "export function alpha(): number {\n\treturn 1;\n}\n";
+		const file = path.join(cwd, "alpha.ts");
+		fs.writeFileSync(file, src);
+		return { cwd, file, src };
+	}
+
+	it("releases content the builder itself loaded (builder-owned store)", async () => {
+		const { cwd, file } = tmpProject();
+		const facts = new FactStore();
+		await buildOrUpdateGraph(cwd, [file], facts);
+		expect(
+			facts.getFileFact<string>(file, "file.content"),
+		).toBeUndefined();
+	});
+
+	it("keeps content the dispatch seeded (live dispatch store)", async () => {
+		const { cwd, file, src } = tmpProject();
+		// First build so the incremental path is exercised on the second call.
+		await buildOrUpdateGraph(cwd, [file], new FactStore());
+
+		const dispatchStore = new FactStore();
+		const edited = `${src}export function beta(): number {\n\treturn 2;\n}\n`;
+		fs.writeFileSync(file, edited);
+		dispatchStore.setFileFact(file, "file.content", edited);
+
+		await buildOrUpdateGraph(cwd, [file], dispatchStore);
+
+		// The dispatch still owns this content — suppressions/dispositions read
+		// it after runner groups settle, so the builder must not have freed it.
+		expect(dispatchStore.getFileFact<string>(file, "file.content")).toBe(
+			edited,
+		);
+	});
+});


### PR DESCRIPTION
Closes #886.

The #917 folded scan loop seeds the shared FactStore with each file's full source under `fileFacts[path]["file.content"]` and only cleared it on a future re-visit that never happens during a scan — so a whole-project scan pinned every scanned file's content until the scan ended (hundreds of MB on large repos).

Fix: new `deleteFileFact()` releases only `file.content` — derived import/function facts and session facts stay intact — called in `finally` at the per-file consumer boundary in both the project-diagnostics scan loop and the review-graph shared-store builder, so error and WASM-abort exits release content too. The #891/#917 abort/persist invariants are unchanged.

Regression test observes the scanner-owned store directly: each full-content marker disappears immediately after its file's iteration (reference assertion, not timing).

Verification: build green, 21 test files / 237 tests passed (scanner WASM-abort, dispatch FactStore/flow, project-diagnostics, review-graph, project-report), lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)