### PR TITLE
fix: reject non-file latency log paths on Windows too

### DIFF
--- a/clients/performance-report.ts
+++ b/clients/performance-report.ts
@@ -284,6 +284,17 @@ async function readPhaseLogTail(
 	try {
 		handle = await fs.promises.open(filePath, "r");
 		const stat = await handle.stat();
+		if (!stat.isFile()) {
+			// POSIX rejects opening a directory with EISDIR, but Windows opens it
+			// successfully with size 0 — which would fall into the empty() branch
+			// and conflate "unreadable path" with "no data yet". Throw the same
+			// error POSIX would so both platforms surface the bad path.
+			const notAFile = new Error(
+				`EISDIR: illegal operation on a directory, read '${filePath}'`,
+			) as NodeJS.ErrnoException;
+			notAFile.code = "EISDIR";
+			throw notAFile;
+		}
 		if (stat.size === 0) return empty();
 
 		const sampleLimit = boundedPositiveInteger(


### PR DESCRIPTION
Follow-up to #906 (refs #767). POSIX open() on a directory throws EISDIR, but Windows opens it with size 0, which fell into the empty-report branch and conflated an unreadable path with 'no data yet'. Throw the POSIX-equivalent error after stat so both platforms surface the bad path; makes the #906 unreadable-path honesty test pass cross-platform (13/13 on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)