### PR TITLE
fix(observability): four honesty fixes — failed analyzers, word-index build state, disabled LSP servers, index coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,11 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   the existing client map; it must never spawn or warm a client. Dispatch-side
   code imports this seam from `lsp/index.ts`, while `dispatch/auxiliary-lsp.ts`
   remains free of the reverse import to avoid the LSP/auxiliary cycle.
+- **LSP circuit-breaker health includes absent clients (#927).**
+  `LSPService.getBrokenStatus()` is a read-only projection of temporary
+  cooldowns and session-permanent disablement; `pilens_health` renders those
+  server/root pairs even though `getStatus()` correctly contains live clients
+  only. Keep health/status calls spawn-free.
 - **Warm-build staleness guard (#535).** The warm server lives for weeks, so it
   can silently keep serving OLD code after a `npm run build:dist`/merge changes
   `dist/mcp/server.js` on disk — dogfooding caught this live (a post-#517

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,10 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   result distinguishes `building`, a safety `refused` outcome, and
   `last-build-failed`; the per-cwd guard remembers the last outcome and
   `clients/word-index-logger.ts` persists cold-build/debounced-persist failures
-  through `createNdjsonLogger` instead of swallowing them. Hits carry
+  through `createNdjsonLogger` instead of swallowing them. Serialized indexes
+  also carry `indexedFileCount`/`truncated` (missing fields on legacy snapshots
+  mean not truncated); both symbol-search surfaces return `coverage` and warn
+  when the file cap makes results partial. Hits carry
   `startLine`/`endLine` (best-matching line;
   `offset=startLine, limit=endLine-startLine+1`) instead of a raw `lines[]` array or
   a per-hit `read` block — #517 conformity, same as module_report below), `pilens_module_report` (navigable outline + signatures

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,12 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   phase 1 gave the word index a load→rebuild-if-stale→persist lifecycle in ALL
   startup modes — quick-mode's cold-start warmup pass now also refreshes it, not
   just the full-mode session task — and a cold query (no index yet) triggers one
-  bounded background build per cwd instead of blocking, returning `available: false`
-  - an actionable retry hint. Hits carry `startLine`/`endLine` (best-matching line;
+  bounded background build per cwd instead of blocking. Its `available: false`
+  result distinguishes `building`, a safety `refused` outcome, and
+  `last-build-failed`; the per-cwd guard remembers the last outcome and
+  `clients/word-index-logger.ts` persists cold-build/debounced-persist failures
+  through `createNdjsonLogger` instead of swallowing them. Hits carry
+  `startLine`/`endLine` (best-matching line;
   `offset=startLine, limit=endLine-startLine+1`) instead of a raw `lines[]` array or
   a per-hit `read` block — #517 conformity, same as module_report below), `pilens_module_report` (navigable outline + signatures
   the outline is module-level declarations + class members only — function-locals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **`pilens_health` keeps disabled LSP servers visible** (refs #927) —
+	permanently broken server/root pairs now render with their failure count, and
+	temporary circuit-breaker cooldowns expose their retry deadline.
 - **Cold `symbol_search` failures are now observable and honest** (refs #926) —
 	unavailable results distinguish an active build, a safety refusal, and the
 	last build's failure, while background build/persist errors reach a persistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Failed heavyweight analyzers no longer masquerade as clean runs** (refs #925) —
+	unsuccessful results are reported distinctly, omitted from cache so the next
+	session retries, and valid fix-worklog records survive neighboring corrupt lines.
+
 - **The footer refreshes as LSP servers come online during a cold
 	`lens_diagnostics mode=full` sweep** (refs #798), instead of showing
 	`LSP Inactive` until turn end. The repaint captures UI methods during the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Cold `symbol_search` failures are now observable and honest** (refs #926) —
+	unavailable results distinguish an active build, a safety refusal, and the
+	last build's failure, while background build/persist errors reach a persistent
+	NDJSON log.
 - **Failed heavyweight analyzers no longer masquerade as clean runs** (refs #925) —
 	unsuccessful results are reported distinctly, omitted from cache so the next
 	session retries, and valid fix-worklog records survive neighboring corrupt lines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Capped word indexes disclose partial coverage** (refs #928) — snapshots now
+	persist indexed-file count and truncation state, and both `symbol_search`
+	surfaces report coverage instead of presenting capped zero-hit results as
+	authoritative.
 - **`pilens_health` keeps disabled LSP servers visible** (refs #927) —
 	permanently broken server/root pairs now render with their failure count, and
 	temporary circuit-breaker cooldowns expose their retry deadline.

--- a/clients/fix-worklog.ts
+++ b/clients/fix-worklog.ts
@@ -82,7 +82,13 @@ export function readWorklog(cwd: string): WorklogEntry[] {
 		return raw
 			.split(/\r?\n/)
 			.filter(Boolean)
-			.map((line) => JSON.parse(line) as WorklogEntry);
+			.flatMap((line) => {
+				try {
+					return [JSON.parse(line) as WorklogEntry];
+				} catch {
+					return [];
+				}
+			});
 	} catch {
 		return [];
 	}

--- a/clients/lens-engine.ts
+++ b/clients/lens-engine.ts
@@ -361,6 +361,8 @@ export interface SymbolSearchResult {
 	available: boolean;
 	query: string;
 	results: SymbolSearchHit[];
+	/** Coverage of the persisted/warm index used for this answer. */
+	coverage?: { files: number; truncated: boolean };
 	/** Actionable guidance when `available` is false (#348 decision 3): the
 	 * index build was kicked off in the background (deduped per cwd), never
 	 * blocking this call — retry shortly. */
@@ -475,6 +477,7 @@ export async function symbolSearch(
 		available: true,
 		query,
 		results: hits,
+		coverage: { files: index.docCount, truncated: index.truncated === true },
 		snapshotGeneratedAt: snapshot?.generatedAt,
 	};
 }

--- a/clients/lens-engine.ts
+++ b/clients/lens-engine.ts
@@ -40,10 +40,12 @@ import type { ReviewGraph } from "./review-graph/types.js";
 import {
 	centralityFromReverseDeps,
 	deserializeWordIndex,
+	getWordIndexBuildStatus,
 	type RankedFile,
 	searchWordIndex,
 	triggerBackgroundWordIndexBuild,
 } from "./word-index.js";
+import { wordIndexDebug } from "./word-index-logger.js";
 
 // --- Facades (re-exported so adapters import only this module) ---------------
 
@@ -348,6 +350,8 @@ export interface SymbolSearchResult {
 	 * index build was kicked off in the background (deduped per cwd), never
 	 * blocking this call — retry shortly. */
 	hint?: string;
+	/** Why an unavailable index cannot currently answer authoritatively. */
+	unavailableReason?: "building" | "refused" | "last-build-failed";
 	/**
 	 * ISO timestamp the persisted project snapshot (`ProjectSnapshot.generatedAt`)
 	 * was last written — the snapshot backs BOTH the word index this search ranks
@@ -412,12 +416,29 @@ export async function symbolSearch(
 	const snapshot = loadProjectSnapshot(cwd);
 	const index = getOrLoadWarmWordIndex(cwd) ?? deserializeWordIndex(snapshot?.wordIndex);
 	if (!index) {
-		triggerBackgroundWordIndexBuild(cwd);
+		const priorStatus = getWordIndexBuildStatus(cwd);
+		const status =
+			priorStatus?.state === "refused"
+				? priorStatus
+				: triggerBackgroundWordIndexBuild(cwd, wordIndexDebug(cwd));
+		const unavailableReason =
+			priorStatus?.state === "failed"
+				? "last-build-failed"
+				: status.state === "refused"
+					? "refused"
+					: "building";
+		const hint =
+			unavailableReason === "refused"
+				? `Word index build was refused for safety: ${status.state === "refused" ? status.reason : "unsafe workspace root"}. Run symbol_search from inside a project directory.`
+				: unavailableReason === "last-build-failed"
+					? `The last word index build failed: ${priorStatus?.state === "failed" ? priorStatus.reason : "unknown error"}. A retry is now running in the background.`
+					: "Word index is building in the background for this workspace — retry this query shortly.";
 		return {
 			available: false,
 			query,
 			results: [],
-			hint: "Word index is building in the background for this workspace — retry this query shortly.",
+			unavailableReason,
+			hint,
 		};
 	}
 	// Boost well-connected files using the snapshot's reverse-dependency

--- a/clients/lens-engine.ts
+++ b/clients/lens-engine.ts
@@ -153,12 +153,27 @@ export function treeSitterRuntimeStatus(): TreeSitterRuntimeStatus {
 export interface LspStatus {
 	aliveClients: number;
 	servers: Array<{ serverId: string; root: string; connected: boolean }>;
+	brokenServers: ReturnType<ReturnType<typeof getLSPService>["getBrokenStatus"]>;
 }
 
 /** Alive LSP client count + per-server status. */
 export function lspStatus(): LspStatus {
 	const lsp = getLSPService();
-	return { aliveClients: lsp.getAliveClientCount(), servers: lsp.getStatus() };
+	return {
+		aliveClients: lsp.getAliveClientCount(),
+		servers: lsp.getStatus(),
+		brokenServers: lsp.getBrokenStatus(),
+	};
+}
+
+export function renderLspBrokenStatusLines(
+	brokenServers: LspStatus["brokenServers"],
+): string[] {
+	return brokenServers.map((server) =>
+		server.permanentlyBroken
+			? `  ✗ ${server.serverId} — disabled after ${server.failures} failures (${server.root})`
+			: `  ✗ ${server.serverId} — cooling down after ${server.failures} failure(s) until ${new Date(server.cooldownUntil).toISOString()} (${server.root})`,
+	);
 }
 
 /** Session diagnostic counters (shown / auto-fixed / unresolved …). */

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -4107,6 +4107,33 @@ export class LSPService {
 	}
 
 	/**
+	 * Read-only circuit-breaker status, including server/root pairs that have no
+	 * live client and would therefore be absent from getStatus().
+	 */
+	getBrokenStatus(): Array<{
+		serverId: string;
+		root: string;
+		failures: number;
+		permanentlyBroken: boolean;
+		cooldownUntil: number;
+	}> {
+		const keys = new Set([
+			...this.state.broken.keys(),
+			...this.permanentlyBroken,
+		]);
+		return [...keys].map((key) => {
+			const separator = key.indexOf(":");
+			return {
+				serverId: separator >= 0 ? key.slice(0, separator) : key,
+				root: separator >= 0 ? key.slice(separator + 1) : "",
+				failures: this.failureCounts.get(key) ?? 0,
+				permanentlyBroken: this.permanentlyBroken.has(key),
+				cooldownUntil: this.state.broken.get(key) ?? 0,
+			};
+		});
+	}
+
+	/**
 	 * Count clients that are currently alive (connected and initialized).
 	 * Lightweight — does not spawn or wait for anything.
 	 */

--- a/clients/mcp/analyze.ts
+++ b/clients/mcp/analyze.ts
@@ -36,6 +36,7 @@ import {
 	WORD_INDEX_MAX_BYTES,
 	type WordIndex,
 } from "../word-index.js";
+import { wordIndexDebug } from "../word-index-logger.js";
 import { createMcpHost } from "./host-shim.js";
 
 // #536: module-scoped FactStore for the warm-analyze graph seam, mirroring the
@@ -365,7 +366,7 @@ export async function analyzeFile(
 				} else {
 					updateWordIndexDocument(warmIndex, { path: absPath, content });
 				}
-				scheduleWordIndexPersist(cwd, warmIndex);
+				scheduleWordIndexPersist(cwd, warmIndex, wordIndexDebug(cwd));
 			} catch {
 				// unreadable/deleted, or an update failure — best-effort, same as the
 				// graph update above.

--- a/clients/project-diagnostics/extractors.ts
+++ b/clients/project-diagnostics/extractors.ts
@@ -43,12 +43,17 @@ interface ProjectDiagnosticExtractor<T> {
 	adapt: (cwd: string, result: T) => ProjectDiagnostic[];
 }
 
+export interface FailedProjectAnalyzer {
+	id: string;
+	summary: string;
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: heterogeneous result types per row
 const EXTRACTORS: ProjectDiagnosticExtractor<any>[] = [
 	{
 		id: "knip",
 		cacheKeys: ["knip"],
-		adapt: (cwd, r: { issues?: KnipIssue[] }) =>
+		adapt: (cwd, r: { success?: boolean; issues?: KnipIssue[] }) =>
 			knipIssuesToProjectDiagnostics(cwd, r.issues ?? []),
 	},
 	{
@@ -145,10 +150,16 @@ export function warmTriggerFor(extractorId: string): string {
 export function extractCachedProjectDiagnostics(
 	cacheManager: CacheManager,
 	cwd: string,
-): { diagnostics: ProjectDiagnostic[]; runners: string[]; cold: string[] } {
+): {
+	diagnostics: ProjectDiagnostic[];
+	runners: string[];
+	cold: string[];
+	failed: FailedProjectAnalyzer[];
+} {
 	const diagnostics: ProjectDiagnostic[] = [];
 	const runners: string[] = [];
 	const cold: string[] = [];
+	const failed: FailedProjectAnalyzer[] = [];
 	for (const extractor of EXTRACTORS) {
 		let data: unknown;
 		for (const key of extractor.cacheKeys) {
@@ -162,11 +173,24 @@ export function extractCachedProjectDiagnostics(
 			cold.push(extractor.id);
 			continue;
 		}
+		if (
+			typeof data === "object" &&
+			data !== null &&
+			"success" in data &&
+			data.success === false
+		) {
+			const summary =
+				"summary" in data && typeof data.summary === "string"
+					? data.summary
+					: "analyzer reported an unsuccessful run";
+			failed.push({ id: extractor.id, summary });
+			continue;
+		}
 		const adapted = extractor.adapt(cwd, data);
 		if (adapted.length > 0) {
 			diagnostics.push(...adapted);
 			runners.push(extractor.id);
 		}
 	}
-	return { diagnostics, runners, cold };
+	return { diagnostics, runners, cold, failed };
 }

--- a/clients/project-diagnostics/fresh-fetch.ts
+++ b/clients/project-diagnostics/fresh-fetch.ts
@@ -84,6 +84,7 @@ import { knipIssuesToProjectDiagnostics } from "./runner-adapters/knip.js";
 import { circularDepsToProjectDiagnostics } from "./runner-adapters/madge.js";
 import { trivyResultToProjectDiagnostics } from "./runner-adapters/trivy.js";
 import type { ProjectDiagnostic } from "./types.js";
+import type { FailedProjectAnalyzer } from "./extractors.js";
 
 export interface FreshProjectDiagnosticsResult {
 	diagnostics: ProjectDiagnostic[];
@@ -92,6 +93,8 @@ export interface FreshProjectDiagnosticsResult {
 	/** Extractor ids skipped this run (not applicable / tool unavailable, OR
 	 *  aborted before settling — see `abortedIds`). */
 	cold: string[];
+	/** Analyzers that ran but explicitly reported failure. */
+	failed: FailedProjectAnalyzer[];
 	/** Wall-clock ms spent per extractor id that actually ran (join time
 	 *  included when this call joined an already-in-flight scan). */
 	timings: Record<string, number>;
@@ -160,6 +163,7 @@ export async function fetchFreshProjectDiagnostics(
 			diagnostics: [],
 			runners: [],
 			cold: [...ANALYZER_IDS],
+			failed: [],
 			timings: {},
 			unsafeRoot: true,
 		};
@@ -167,6 +171,7 @@ export async function fetchFreshProjectDiagnostics(
 	const diagnostics: ProjectDiagnostic[] = [];
 	const runners: string[] = [];
 	const cold: string[] = [];
+	const failed: FailedProjectAnalyzer[] = [];
 	const timings: Record<string, number> = {};
 	const settledIds = new Set<string>();
 
@@ -176,6 +181,19 @@ export async function fetchFreshProjectDiagnostics(
 			diagnostics.push(...adapted);
 			pushUnique(runners, id);
 		}
+	}
+
+	function recordFailed(
+		id: string,
+		result: { summary?: string } | object,
+	): void {
+		failed.push({
+			id,
+			summary:
+				"summary" in result && typeof result.summary === "string"
+					? result.summary
+					: "analyzer reported an unsuccessful run",
+		});
 	}
 
 	function task(id: string, run: () => Promise<void>): Promise<void> {
@@ -191,6 +209,10 @@ export async function fetchFreshProjectDiagnostics(
 				analysisRoot,
 				getKnipIgnorePatterns(),
 			);
+			if (!result.success) {
+				recordFailed("knip", result);
+				return;
+			}
 			cacheManager.writeCache("knip", result, analysisRoot, {
 				scanDurationMs: Date.now() - startMs,
 			});
@@ -219,6 +241,10 @@ export async function fetchFreshProjectDiagnostics(
 				undefined,
 				isTsProject,
 			);
+			if (!result.success) {
+				recordFailed("jscpd", result);
+				return;
+			}
 			cacheManager.writeCache(scannerKey, result, analysisRoot, {
 				scanDurationMs: Date.now() - startMs,
 			});
@@ -269,6 +295,10 @@ export async function fetchFreshProjectDiagnostics(
 			const result = await clients.gitleaksClient.scan(analysisRoot, {
 				requireSignal: false,
 			});
+			if (!result.success) {
+				recordFailed("gitleaks", result);
+				return;
+			}
 			cacheManager.writeCache("gitleaks", result, analysisRoot, {
 				scanDurationMs: Date.now() - startMs,
 			});
@@ -291,6 +321,10 @@ export async function fetchFreshProjectDiagnostics(
 			}
 			const startMs = Date.now();
 			const result = await clients.govulncheckClient.analyze(analysisRoot);
+			if (!result.success) {
+				recordFailed("govulncheck", result);
+				return;
+			}
 			cacheManager.writeCache("govulncheck", result, analysisRoot, {
 				scanDurationMs: Date.now() - startMs,
 			});
@@ -313,6 +347,10 @@ export async function fetchFreshProjectDiagnostics(
 			}
 			const startMs = Date.now();
 			const result = await clients.trivyClient.scan(analysisRoot);
+			if (!result.success) {
+				recordFailed("trivy", result);
+				return;
+			}
 			cacheManager.writeCache("trivy", result, analysisRoot, {
 				scanDurationMs: Date.now() - startMs,
 			});
@@ -339,6 +377,10 @@ export async function fetchFreshProjectDiagnostics(
 					const cacheKey = `dead-code-${client.id}`;
 					const startMs = Date.now();
 					const result = await client.analyze(analysisRoot);
+					if (!result.success) {
+						recordFailed("dead-code", result);
+						return;
+					}
 					cacheManager.writeCache(cacheKey, result, analysisRoot, {
 						scanDurationMs: Date.now() - startMs,
 					});
@@ -377,8 +419,16 @@ export async function fetchFreshProjectDiagnostics(
 	if (outcome === "aborted") {
 		const abortedIds = ANALYZER_IDS.filter((id) => !settledIds.has(id));
 		for (const id of abortedIds) pushUnique(cold, id);
-		return { diagnostics, runners, cold, timings, aborted: true, abortedIds };
+		return {
+			diagnostics,
+			runners,
+			cold,
+			failed,
+			timings,
+			aborted: true,
+			abortedIds,
+		};
 	}
 
-	return { diagnostics, runners, cold, timings };
+	return { diagnostics, runners, cold, failed, timings };
 }

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -639,9 +639,11 @@ function scheduleStartupScans(
 				getKnipIgnorePatterns(),
 			);
 			if (!runtime.isCurrentSession(sessionGeneration)) return;
-			cacheManager.writeCache("knip", knipResult, analysisRoot, {
-				scanDurationMs: Date.now() - startMs,
-			});
+			if (knipResult.success) {
+				cacheManager.writeCache("knip", knipResult, analysisRoot, {
+					scanDurationMs: Date.now() - startMs,
+				});
+			}
 			dbg(`session_start Knip scan done (${Date.now() - startMs}ms)`);
 		}
 	});
@@ -676,9 +678,11 @@ function scheduleStartupScans(
 					isTsProject,
 				);
 				if (!runtime.isCurrentSession(sessionGeneration)) return;
-				cacheManager.writeCache(scannerKey, jscpdResult, analysisRoot, {
-					scanDurationMs: Date.now() - startMs,
-				});
+				if (jscpdResult.success) {
+					cacheManager.writeCache(scannerKey, jscpdResult, analysisRoot, {
+						scanDurationMs: Date.now() - startMs,
+					});
+				}
 				dbg(
 					`session_start jscpd scan done (${Date.now() - startMs}ms, isTsProject=${isTsProject})`,
 				);
@@ -711,9 +715,11 @@ function scheduleStartupScans(
 				const startMs = Date.now();
 				const result = await client.analyze(analysisRoot);
 				if (!runtime.isCurrentSession(sessionGeneration)) return undefined;
-				cacheManager.writeCache(cacheKey, result, analysisRoot, {
-					scanDurationMs: Date.now() - startMs,
-				});
+				if (result.success) {
+					cacheManager.writeCache(cacheKey, result, analysisRoot, {
+						scanDurationMs: Date.now() - startMs,
+					});
+				}
 				logDeadCodeScan({
 					language: client.language,
 					success: result.success,
@@ -762,9 +768,11 @@ function scheduleStartupScans(
 		const startMs = Date.now();
 		const result = await govulncheckClient.analyze(analysisRoot);
 		if (!runtime.isCurrentSession(sessionGeneration)) return;
-		cacheManager.writeCache("govulncheck", result, analysisRoot, {
-			scanDurationMs: Date.now() - startMs,
-		});
+		if (result.success) {
+			cacheManager.writeCache("govulncheck", result, analysisRoot, {
+				scanDurationMs: Date.now() - startMs,
+			});
+		}
 		dbg(
 			`session_start govulncheck: ${result.findings.length} reachable findings (${Date.now() - startMs}ms)`,
 		);
@@ -798,9 +806,11 @@ function scheduleStartupScans(
 		const startMs = Date.now();
 		const result = await gitleaksClient.scan(analysisRoot);
 		if (!runtime.isCurrentSession(sessionGeneration)) return;
-		cacheManager.writeCache("gitleaks", result, analysisRoot, {
-			scanDurationMs: Date.now() - startMs,
-		});
+		if (result.success) {
+			cacheManager.writeCache("gitleaks", result, analysisRoot, {
+				scanDurationMs: Date.now() - startMs,
+			});
+		}
 		dbg(
 			`session_start gitleaks: ${result.findings.length} findings (${Date.now() - startMs}ms)`,
 		);
@@ -836,9 +846,11 @@ function scheduleStartupScans(
 		const startMs = Date.now();
 		const result = await opengrepClient.scan(analysisRoot);
 		if (!runtime.isCurrentSession(sessionGeneration)) return;
-		cacheManager.writeCache("opengrep", result, analysisRoot, {
-			scanDurationMs: Date.now() - startMs,
-		});
+		if (result.success) {
+			cacheManager.writeCache("opengrep", result, analysisRoot, {
+				scanDurationMs: Date.now() - startMs,
+			});
+		}
 		dbg(
 			`session_start opengrep: ${result.findings.length} findings (${Date.now() - startMs}ms)`,
 		);
@@ -904,9 +916,11 @@ function scheduleStartupScans(
 		const startMs = Date.now();
 		const result = await trivyClient.scan(analysisRoot);
 		if (!runtime.isCurrentSession(sessionGeneration)) return;
-		cacheManager.writeCache("trivy", result, analysisRoot, {
-			scanDurationMs: Date.now() - startMs,
-		});
+		if (result.success) {
+			cacheManager.writeCache("trivy", result, analysisRoot, {
+				scanDurationMs: Date.now() - startMs,
+			});
+		}
 		dbg(
 			`session_start trivy: ${result.findings.length} CVE findings (${Date.now() - startMs}ms)`,
 		);

--- a/clients/word-index-logger.ts
+++ b/clients/word-index-logger.ts
@@ -1,0 +1,44 @@
+import * as path from "node:path";
+import { isTestMode } from "./env-utils.js";
+import { getGlobalPiLensDir } from "./file-utils.js";
+import { createNdjsonLogger } from "./ndjson-logger.js";
+
+const WORD_INDEX_LOG_FILE = path.join(getGlobalPiLensDir(), "word-index.log");
+const writer = createNdjsonLogger({ filePath: WORD_INDEX_LOG_FILE });
+
+export interface WordIndexLogEntry {
+	ts?: string;
+	phase: "cold-build" | "persist";
+	cwd: string;
+	outcome: "started" | "succeeded" | "refused" | "failed";
+	reason?: string;
+	durationMs?: number;
+	indexedFiles?: number;
+}
+
+export function logWordIndex(entry: WordIndexLogEntry): void {
+	if (isTestMode()) return;
+	writer.log({ ts: new Date().toISOString(), ...entry });
+}
+
+export function wordIndexDebug(cwd: string): (message: string) => void {
+	return (message) =>
+		logWordIndex({
+			phase: message.startsWith("word-index persist") ? "persist" : "cold-build",
+			cwd: path.resolve(cwd),
+			outcome: message.includes("failed")
+				? "failed"
+				: message.includes("skipped")
+					? "refused"
+					: "succeeded",
+			reason: message,
+		});
+}
+
+export function getWordIndexLogPath(): string {
+	return WORD_INDEX_LOG_FILE;
+}
+
+export function flushWordIndexLog(): Promise<void> {
+	return writer.flush();
+}

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -35,6 +35,8 @@ export interface WordIndex {
 	docLengths: Map<string, number>;
 	totalTokens: number;
 	docCount: number;
+	/** True when source collection hit its file cap, so searches may be incomplete. */
+	truncated?: boolean;
 	/**
 	 * Forward index (#348 phase 2): file → (token → distinct-line count for that
 	 * token in that file). Mirrors exactly what the postings list holds for this
@@ -149,7 +151,7 @@ export function tokenizeLine(line: string): string[] {
  * that repeats an identifier. Document length is the total indexed token count.
  */
 export function buildWordIndex(
-	files: Array<{ path: string; content: string }>,
+	files: Array<{ path: string; content: string }> & { truncated?: boolean },
 ): WordIndex {
 	const postings = new Map<string, WordHit[]>();
 	const docLengths = new Map<string, number>();
@@ -178,7 +180,14 @@ export function buildWordIndex(
 		totalTokens += docLength;
 	}
 
-	return { postings, docLengths, totalTokens, docCount: files.length, forward };
+	return {
+		postings,
+		docLengths,
+		totalTokens,
+		docCount: files.length,
+		truncated: files.truncated ?? false,
+		forward,
+	};
 }
 
 /**
@@ -296,7 +305,9 @@ export const WORD_INDEX_MAX_BYTES = 512 * 1024;
 export async function collectWordIndexDocs(
 	root: string,
 	shouldContinue: () => boolean = () => true,
-): Promise<Array<{ path: string; content: string }>> {
+): Promise<
+	Array<{ path: string; content: string }> & { truncated: boolean }
+> {
 	const { collectSourceFilesAsync } = await import("./source-filter.js");
 	// #747 hardening: pass the cap INTO the walk — without it,
 	// `collectSourceFilesAsync` defaults to an unbounded traversal and the
@@ -316,8 +327,12 @@ export async function collectWordIndexDocs(
 		maxFiles,
 		prioritizeCodeKinds: true,
 	});
-	if (!shouldContinue()) return [];
-	const docs: Array<{ path: string; content: string }> = [];
+	const truncated = files.length === maxFiles;
+	const docs = Object.assign(
+		[] as Array<{ path: string; content: string }>,
+		{ truncated },
+	);
+	if (!shouldContinue()) return docs;
 	let processed = 0;
 	for (const file of files.slice(0, maxFiles)) {
 		try {
@@ -459,6 +474,10 @@ export interface SerializedWordIndex {
 	/** Parallel to {@link files}: indexed token count per file. */
 	docLengths: number[];
 	totalTokens: number;
+	/** Number of files actually represented in this index. */
+	indexedFileCount?: number;
+	/** True when source collection reached its configured file cap. */
+	truncated?: boolean;
 	/**
 	 * Forward index (#348 phase 2): `[fileIdx, [[token, lineCount], …]]` per
 	 * file. Optional so pre-phase-2 snapshots parse unchanged. When ABSENT on
@@ -499,6 +518,8 @@ export function serializeWordIndex(index: WordIndex): SerializedWordIndex {
 		postings,
 		docLengths: files.map((file) => index.docLengths.get(file) ?? 0),
 		totalTokens: index.totalTokens,
+		indexedFileCount: index.docCount,
+		truncated: index.truncated,
 		forward,
 	};
 }
@@ -557,6 +578,7 @@ export function deserializeWordIndex(
 		totalTokens:
 			typeof data.totalTokens === "number" ? data.totalTokens : 0,
 		docCount: data.files.length,
+		truncated: data.truncated === true,
 		forward,
 	};
 }

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -572,11 +572,22 @@ export function deserializeWordIndex(
 // single background build, keyed by the resolved cwd so a burst of queries in
 // the same cold window only pays for one walk, and returns immediately.
 
-const inFlightBuilds = new Set<string>();
+export type WordIndexBuildStatus =
+	| { state: "building" }
+	| { state: "refused"; reason: string }
+	| { state: "failed"; reason: string };
+
+const buildStatuses = new Map<string, WordIndexBuildStatus>();
+
+export function getWordIndexBuildStatus(
+	cwd: string,
+): WordIndexBuildStatus | undefined {
+	return buildStatuses.get(path.resolve(cwd));
+}
 
 /** Test-only: reset the in-flight-build guard between test files/cases. */
 export function _resetWordIndexBuildGuardForTests(): void {
-	inFlightBuilds.clear();
+	buildStatuses.clear();
 }
 
 /**
@@ -591,7 +602,7 @@ export function triggerBackgroundWordIndexBuild(
 	cwd: string,
 	dbg?: (msg: string) => void,
 	options: { homeDir?: string } = {},
-): void {
+): WordIndexBuildStatus {
 	const key = path.resolve(cwd);
 	// #747 hardening: this trigger is the one word-index build path with NO
 	// session lifecycle in front of it (cold `symbol_search` queries, in-process
@@ -600,13 +611,16 @@ export function triggerBackgroundWordIndexBuild(
 	// a home-rooted cwd. Apply the same `isAtOrAboveHomeDir` ceiling here so a
 	// cold query from $HOME never starts a whole-home walk-and-read.
 	if (isAtOrAboveHomeDir(key, options.homeDir)) {
-		dbg?.(
-			`word-index cold-build: skipped — root at/above home directory (${key})`,
-		);
-		return;
+		const reason = `root at/above home directory (${key})`;
+		dbg?.(`word-index cold-build: skipped — ${reason}`);
+		const status = { state: "refused", reason } as const;
+		buildStatuses.set(key, status);
+		return status;
 	}
-	if (inFlightBuilds.has(key)) return;
-	inFlightBuilds.add(key);
+	const current = buildStatuses.get(key);
+	if (current?.state === "building") return current;
+	const status = { state: "building" } as const;
+	buildStatuses.set(key, status);
 	void (async () => {
 		const startMs = Date.now();
 		try {
@@ -631,12 +645,14 @@ export function triggerBackgroundWordIndexBuild(
 			dbg?.(
 				`word-index cold-build: ${index.docCount} files, ${index.postings.size} tokens (${Date.now() - startMs}ms)`,
 			);
+			buildStatuses.delete(key);
 		} catch (err) {
-			dbg?.(`word-index cold-build: failed: ${err}`);
-		} finally {
-			inFlightBuilds.delete(key);
+			const reason = err instanceof Error ? err.message : String(err);
+			buildStatuses.set(key, { state: "failed", reason });
+			dbg?.(`word-index cold-build: failed: ${reason}`);
 		}
 	})();
+	return status;
 }
 
 // --- Debounced per-edit persist (#348 phase 2) --------------------------------

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -40,6 +40,7 @@ import {
 	ensureLspConfig,
 	ipcPathForCwd,
 	lspStatus,
+	renderLspBrokenStatusLines,
 	type McpAnalyzeResult,
 	moduleReport,
 	projectReport,
@@ -1270,7 +1271,7 @@ async function callTool(
 	}
 
 	if (name === "pilens_health") {
-		const { aliveClients, servers } = lspStatus();
+		const { aliveClients, servers, brokenServers } = lspStatus();
 		const last = recentLatency(1)[0];
 		const stats = diagnosticStats();
 		const autoSession = getAutoSessionStatus();
@@ -1287,6 +1288,7 @@ async function callTool(
 				(server) =>
 					`  ${server.connected ? "✓" : "✗"} ${server.serverId} (${server.root})`,
 			),
+			...renderLspBrokenStatusLines(brokenServers),
 			last
 				? `Last dispatch: ${path.basename(last.filePath)} — ${last.totalDurationMs}ms, ${last.totalDiagnostics} diagnostic(s)`
 				: "Last dispatch: none yet",
@@ -1304,6 +1306,7 @@ async function callTool(
 		return toolText(lines.join("\n"), {
 			aliveClients,
 			servers,
+			brokenServers,
 			lastDispatch: last
 				? {
 						filePath: last.filePath,

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -1011,7 +1011,14 @@ async function callTool(
 			? args.paths.filter((p): p is string => typeof p === "string")
 			: undefined;
 		const lang = typeof args.lang === "string" ? args.lang : undefined;
-		const { available, results, hint, snapshotGeneratedAt } = await symbolSearch(
+		const {
+			available,
+			results,
+			hint,
+			unavailableReason,
+			coverage,
+			snapshotGeneratedAt,
+		} = await symbolSearch(
 			query,
 			cwd,
 			limit,
@@ -1020,18 +1027,23 @@ async function callTool(
 		if (!available) {
 			return toolText(
 				hint ?? "No word index for this workspace yet — run pilens_session_start first.",
-				{ available: false, query, hint },
+				{ available: false, query, hint, unavailableReason },
 				true,
 			);
 		}
 		const stalenessNote = graphStalenessNote(snapshotGeneratedAt, "Project snapshot");
 		if (results.length === 0) {
 			return toolText(
-				`No files matched "${query}".` + (stalenessNote ? `\n\n${stalenessNote}` : ""),
+				`No files matched "${query}".` +
+					(coverage
+						? `\nIndex covers ${coverage.files} files${coverage.truncated ? " (capped — results may be incomplete)" : ""}.`
+						: "") +
+					(stalenessNote ? `\n\n${stalenessNote}` : ""),
 				{
 					available: true,
 					query,
 					results: [],
+					coverage,
 					...(stalenessNote ? { staleness: stalenessNote } : {}),
 				},
 				true,
@@ -1046,6 +1058,11 @@ async function callTool(
 					`line ${result.startLine})`,
 			),
 			...(stalenessNote ? ["", stalenessNote] : []),
+			...(coverage
+				? [
+						`Index covers ${coverage.files} files${coverage.truncated ? " (capped — results may be incomplete)" : ""}.`,
+					]
+				: []),
 		];
 		// Compact (unindented) JSON — matches the module_report / read_symbol
 		// convention (#517): an agent parses this payload, it doesn't read it
@@ -1055,6 +1072,7 @@ async function callTool(
 			lines.join("\n"),
 			{
 				query,
+				coverage,
 				results: results.map((result) => {
 					const relFile = path.relative(cwd, result.file);
 					return {

--- a/tests/clients/lsp/broken-status.test.ts
+++ b/tests/clients/lsp/broken-status.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+	LSPService,
+} from "../../../clients/lsp/index.js";
+import {
+	renderLspBrokenStatusLines,
+} from "../../../clients/lens-engine.js";
+
+describe("LSP circuit-breaker health (#927)", () => {
+	it("exposes permanently disabled servers even without a live client", () => {
+		const service = new LSPService();
+		const key = "typescript:c:/work/project";
+		const internal = service as unknown as {
+			state: { broken: Map<string, number> };
+			failureCounts: Map<string, number>;
+			permanentlyBroken: Set<string>;
+		};
+		internal.state.broken.set(key, Date.now() + 60_000);
+		internal.failureCounts.set(key, 5);
+		internal.permanentlyBroken.add(key);
+
+		expect(service.getStatus()).toEqual([]);
+		const broken = service.getBrokenStatus();
+		expect(broken).toEqual([
+			{
+				serverId: "typescript",
+				root: "c:/work/project",
+				failures: 5,
+				permanentlyBroken: true,
+				cooldownUntil: expect.any(Number),
+			},
+		]);
+		expect(renderLspBrokenStatusLines(broken)[0]).toContain(
+			"✗ typescript — disabled after 5 failures",
+		);
+	});
+
+	it("renders temporary cooldowns with their deadline", () => {
+		const service = new LSPService();
+		const until = Date.parse("2026-07-30T12:00:00.000Z");
+		const key = "ruff:/work/project";
+		const internal = service as unknown as {
+			state: { broken: Map<string, number> };
+			failureCounts: Map<string, number>;
+			permanentlyBroken: Set<string>;
+		};
+		internal.state.broken.set(key, until);
+		internal.failureCounts.set(key, 2);
+
+		const line = renderLspBrokenStatusLines(service.getBrokenStatus())[0];
+		expect(line).toContain("ruff — cooling down after 2 failure(s)");
+		expect(line).toContain("2026-07-30T12:00:00.000Z");
+	});
+});

--- a/tests/clients/project-diagnostics.test.ts
+++ b/tests/clients/project-diagnostics.test.ts
@@ -706,6 +706,25 @@ describe("extractCachedProjectDiagnostics (registry)", () => {
 		);
 		expect(cold).not.toContain("jscpd");
 	});
+
+	it("reports an unsuccessful cached analyzer as failed, not clean or cold (#925)", () => {
+		const result = extractCachedProjectDiagnostics(
+			cacheManagerWith({
+				knip: {
+					success: false,
+					issues: [],
+					summary: "knip timed out",
+				},
+			}),
+			tmp,
+		);
+		expect(result.diagnostics).toEqual([]);
+		expect(result.runners).not.toContain("knip");
+		expect(result.cold).not.toContain("knip");
+		expect(result.failed).toEqual([
+			{ id: "knip", summary: "knip timed out" },
+		]);
+	});
 });
 
 describe("scanProjectDiagnostics", () => {

--- a/tests/clients/project-diagnostics/fresh-fetch.test.ts
+++ b/tests/clients/project-diagnostics/fresh-fetch.test.ts
@@ -35,6 +35,7 @@ function makeCacheManager() {
 function makeClients(
 	overrides: Partial<{
 		knipIssues: unknown[];
+		knipResult: unknown;
 		jscpdAvailable: boolean;
 		jscpdResult: unknown;
 		madgeAvailable: boolean;
@@ -43,15 +44,17 @@ function makeClients(
 ): BootstrapClients {
 	return {
 		knipClient: {
-			analyze: vi.fn().mockResolvedValue({
-				success: true,
-				issues: overrides.knipIssues ?? [],
-				unusedExports: [],
-				unusedFiles: [],
-				unusedDeps: [],
-				unlistedDeps: [],
-				summary: "ok",
-			}),
+			analyze: vi.fn().mockResolvedValue(
+				overrides.knipResult ?? {
+					success: true,
+					issues: overrides.knipIssues ?? [],
+					unusedExports: [],
+					unusedFiles: [],
+					unusedDeps: [],
+					unlistedDeps: [],
+					summary: "ok",
+				},
+			),
 		},
 		jscpdClient: {
 			ensureAvailable: vi
@@ -125,6 +128,30 @@ describe("fetchFreshProjectDiagnostics (#585)", () => {
 		expect(result.runners).toContain("knip");
 		expect(result.diagnostics.length).toBeGreaterThan(0);
 		expect(result.timings.knip).toBeGreaterThanOrEqual(0);
+	});
+
+	it("reports a failed knip run and does not cache it (#925)", async () => {
+		const cacheManager = makeCacheManager();
+		const clients = makeClients({
+			knipResult: {
+				success: false,
+				issues: [],
+				summary: "knip process failed",
+			},
+		});
+
+		const result = await fetchFreshProjectDiagnostics(cacheManager, tmp, clients);
+
+		expect(result.failed).toEqual([
+			{ id: "knip", summary: "knip process failed" },
+		]);
+		expect(result.runners).not.toContain("knip");
+		expect(cacheManager.writeCache).not.toHaveBeenCalledWith(
+			"knip",
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+		);
 	});
 
 	// #747: cwd at — or above — $HOME must never spawn a single analyzer; the

--- a/tests/clients/word-index.test.ts
+++ b/tests/clients/word-index.test.ts
@@ -268,6 +268,27 @@ describe("serializeWordIndex / deserializeWordIndex", () => {
 		expect(handler![1]).toEqual(expect.arrayContaining([0, 1]));
 	});
 
+	it("round-trips indexed-file coverage and truncation (#928)", () => {
+		const cappedFiles = Object.assign([...files], { truncated: true });
+		const serialized = serializeWordIndex(buildWordIndex(cappedFiles));
+		expect(serialized.indexedFileCount).toBe(2);
+		expect(serialized.truncated).toBe(true);
+		expect(deserializeWordIndex(serialized)).toMatchObject({
+			docCount: 2,
+			truncated: true,
+		});
+	});
+
+	it("treats missing legacy coverage fields as not truncated (#928)", () => {
+		const serialized = serializeWordIndex(buildWordIndex(files));
+		delete serialized.indexedFileCount;
+		delete serialized.truncated;
+		expect(deserializeWordIndex(serialized)).toMatchObject({
+			docCount: 2,
+			truncated: false,
+		});
+	});
+
 	it("returns null for malformed serialized input", () => {
 		expect(deserializeWordIndex(null)).toBeNull();
 		expect(deserializeWordIndex({} as never)).toBeNull();

--- a/tests/clients/word-index.test.ts
+++ b/tests/clients/word-index.test.ts
@@ -4,6 +4,7 @@ import {
 	buildWordIndex,
 	centralityFromReverseDeps,
 	deserializeWordIndex,
+	getWordIndexBuildStatus,
 	searchWordIndex,
 	serializeWordIndex,
 	splitIdentifier,
@@ -321,11 +322,45 @@ describe("triggerBackgroundWordIndexBuild (#348 cold-query stampede guard)", () 
 			expect(messages.some((m) => m.includes("at/above home directory"))).toBe(
 				true,
 			);
+			expect(getWordIndexBuildStatus(env.tmpDir)).toMatchObject({
+				state: "refused",
+				reason: expect.stringContaining("at/above home directory"),
+			});
 			// Give any (wrongly) scheduled build a beat to persist, then confirm
 			// nothing was written.
 			await new Promise((resolve) => setTimeout(resolve, 250));
 			expect(loadProjectSnapshot(env.tmpDir)?.wordIndex).toBeUndefined();
 		} finally {
+			env.cleanup();
+		}
+	}, 10_000);
+
+	it("remembers a failed build outcome after the in-flight attempt ends (#926)", async () => {
+		const env = setupTestEnvironment("pi-lens-wordindex-failed-");
+		const previousDataDir = process.env.PILENS_DATA_DIR;
+		try {
+			createTempFile(env.tmpDir, "src/a.ts", "export function helperA() {}");
+			process.env.PILENS_DATA_DIR = createTempFile(
+				env.tmpDir,
+				"not-a-directory",
+				"occupied",
+			);
+			const messages: string[] = [];
+			triggerBackgroundWordIndexBuild(env.tmpDir, (message) =>
+				messages.push(message),
+			);
+
+			await vi.waitFor(() => {
+				expect(getWordIndexBuildStatus(env.tmpDir)?.state).toBe("failed");
+			});
+			expect(getWordIndexBuildStatus(env.tmpDir)).toMatchObject({
+				state: "failed",
+				reason: expect.any(String),
+			});
+			expect(messages.some((message) => message.includes("failed"))).toBe(true);
+		} finally {
+			if (previousDataDir === undefined) delete process.env.PILENS_DATA_DIR;
+			else process.env.PILENS_DATA_DIR = previousDataDir;
 			env.cleanup();
 		}
 	}, 10_000);

--- a/tests/mcp/symbol-search.smoke.test.ts
+++ b/tests/mcp/symbol-search.smoke.test.ts
@@ -95,6 +95,7 @@ describe("pilens_symbol_search over MCP (tiny project, pre-seeded index)", () =>
 		expect((res.result as { isError?: boolean }).isError).toBeFalsy();
 		const payload = parseTrailer(res) as {
 			query: string;
+			coverage: { files: number; truncated: boolean };
 			results: Array<{
 				file: string;
 				score: number;
@@ -105,6 +106,8 @@ describe("pilens_symbol_search over MCP (tiny project, pre-seeded index)", () =>
 				lines?: unknown;
 			}>;
 		};
+		expect(payload.coverage).toEqual({ files: 1, truncated: false });
+		expect(textOf(res)).toContain("Index covers 1 files.");
 		expect(payload.results.length).toBeGreaterThan(0);
 		const hit = payload.results[0];
 		expect(hit.file.replace(/\\/g, "/")).toBe("auth.ts");

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -1175,6 +1175,31 @@ describe("lens_diagnostics mode=full", () => {
 		).toContain("knip");
 	});
 
+	it("mode=full renders failed analyzers as unknown, not clean (#925)", async () => {
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]),
+		};
+		freshFetchMocks.fetchFreshProjectDiagnostics.mockResolvedValue({
+			diagnostics: [],
+			runners: [],
+			cold: [],
+			failed: [{ id: "knip", summary: "knip timed out" }],
+			timings: { knip: 30_000 },
+		});
+
+		const result = await run(makeTool({}, lspService), {
+			mode: "full",
+			refreshRunners: "cached",
+		});
+		const text = String(result.content[0].text);
+		expect(text).toContain("failed (ran, but no trustworthy result)");
+		expect(text).toContain("knip — knip timed out");
+		expect(text).toContain("NOT a clean verdict");
+		expect(
+			(result.details as { failedAnalyzers?: unknown[] }).failedAnalyzers,
+		).toEqual([{ id: "knip", summary: "knip timed out" }]);
+	});
+
 	it("mode=full without refreshRunners never reports cold extractors (they weren't requested)", async () => {
 		mockSummaries.length = 0;
 		const lspService = {

--- a/tests/tools/symbol-search.test.ts
+++ b/tests/tools/symbol-search.test.ts
@@ -12,7 +12,13 @@ import {
 	clearReviewGraphWorkspaceCache,
 	getCachedReviewGraph,
 } from "../../clients/review-graph/builder.js";
-import { buildWordIndex, serializeWordIndex, _resetWordIndexBuildGuardForTests } from "../../clients/word-index.js";
+import {
+	buildWordIndex,
+	getWordIndexBuildStatus,
+	serializeWordIndex,
+	triggerBackgroundWordIndexBuild,
+	_resetWordIndexBuildGuardForTests,
+} from "../../clients/word-index.js";
 import { createSymbolSearchTool } from "../../tools/symbol-search.js";
 import { createTempFile, setupTestEnvironment } from "../clients/test-utils.js";
 
@@ -72,6 +78,41 @@ describe("symbol_search tool", () => {
 				{ timeout: 5000 },
 			);
 		} finally {
+			env.cleanup();
+		}
+	}, 10_000);
+
+	it("cold path exposes the last build failure instead of claiming only that it is building (#926)", async () => {
+		const env = setupTestEnvironment("pi-lens-symbolsearch-failed-");
+		const previousDataDir = process.env.PILENS_DATA_DIR;
+		try {
+			createTempFile(env.tmpDir, "src/auth.ts", "export const authenticate = true;");
+			process.env.PILENS_DATA_DIR = createTempFile(
+				env.tmpDir,
+				"occupied-data-root",
+				"not a directory",
+			);
+			triggerBackgroundWordIndexBuild(env.tmpDir);
+			await vi.waitFor(() => {
+				expect(getWordIndexBuildStatus(env.tmpDir)?.state).toBe("failed");
+			});
+
+			const tool = createSymbolSearchTool(() => env.tmpDir);
+			const result = await tool.execute(
+				"1",
+				{ query: "authenticate" },
+				undefined,
+				null,
+				{ cwd: env.tmpDir },
+			);
+			expect(result.details).toMatchObject({
+				available: false,
+				unavailableReason: "last-build-failed",
+			});
+			expect(String(result.content[0]?.text)).toMatch(/last word index build failed/i);
+		} finally {
+			if (previousDataDir === undefined) delete process.env.PILENS_DATA_DIR;
+			else process.env.PILENS_DATA_DIR = previousDataDir;
 			env.cleanup();
 		}
 	}, 10_000);

--- a/tests/tools/symbol-search.test.ts
+++ b/tests/tools/symbol-search.test.ts
@@ -30,8 +30,9 @@ afterEach(() => {
 function warmWordIndexSnapshot(
 	tmpDir: string,
 	files: Array<{ path: string; content: string }>,
+	truncated = false,
 ): void {
-	const index = buildWordIndex(files);
+	const index = buildWordIndex(Object.assign(files, { truncated }));
 	saveProjectSnapshot(tmpDir, {
 		version: PROJECT_SNAPSHOT_VERSION,
 		projectRoot: tmpDir,
@@ -43,9 +44,39 @@ function warmWordIndexSnapshot(
 		cachedExports: [],
 		wordIndex: serializeWordIndex(index),
 	});
+
 }
 
 describe("symbol_search tool", () => {
+	it("zero-hit output warns when the index is capped and exposes coverage (#928)", async () => {
+		const env = setupTestEnvironment("pi-lens-symbolsearch-capped-");
+		try {
+			warmWordIndexSnapshot(
+				env.tmpDir,
+				[{ path: "src/auth.ts", content: "export const authenticate = true;" }],
+				true,
+			);
+			const tool = createSymbolSearchTool(() => env.tmpDir);
+			const result = await tool.execute(
+				"1",
+				{ query: "definitely absent identifier" },
+				undefined,
+				null,
+				{ cwd: env.tmpDir },
+			);
+			expect(String(result.content[0]?.text)).toContain(
+				"Index covers 1 files (capped — results may be incomplete).",
+			);
+			expect(result.details).toMatchObject({
+				available: true,
+				count: 0,
+				coverage: { files: 1, truncated: true },
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("cold path: returns available:false with an actionable hint and kicks off a background build", async () => {
 		const env = setupTestEnvironment("pi-lens-symbolsearch-cold-");
 		try {

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -179,6 +179,7 @@ export function createLensDiagnosticsTool(
 			totalErrors?: number;
 			totalWarnings?: number;
 			coldRunners?: string[];
+			failedAnalyzers?: { id: string; summary: string }[];
 		}>(({ details, args, isError, text }) => {
 			// Streaming progress partials render the live bar (see scanningSummaryLine)
 			// instead of the details-driven summary, which would show "0 diagnostics"
@@ -197,22 +198,26 @@ export function createLensDiagnosticsTool(
 				details?.coldRunners && details.coldRunners.length > 0
 					? ` (${details.coldRunners.length} cold: ${details.coldRunners.join(", ")})`
 					: "";
+			const failedSuffix =
+				details?.failedAnalyzers && details.failedAnalyzers.length > 0
+					? ` (${details.failedAnalyzers.length} failed: ${details.failedAnalyzers.map((item) => item.id).join(", ")})`
+					: "";
 			if (mode === "delta") {
 				const aw = details?.actionableWarnings ?? 0;
 				const cq = details?.qualityIssues ?? 0;
 				const pd = details?.projectDiagnostics ?? 0;
 				if (aw + cq + pd === 0)
-					return `lens_diagnostics delta — clean${coldSuffix}`;
-				return `lens_diagnostics delta — ${aw} actionable · ${cq} quality · ${pd} project${coldSuffix}`;
+					return `lens_diagnostics delta — clean${coldSuffix}${failedSuffix}`;
+				return `lens_diagnostics delta — ${aw} actionable · ${cq} quality · ${pd} project${coldSuffix}${failedSuffix}`;
 			}
 			const b = details?.totalBlocking ?? 0;
 			const e = details?.totalErrors ?? 0;
 			const w = details?.totalWarnings ?? 0;
 			const files = details?.filesWithIssues ?? details?.filesChecked ?? 0;
 			if (b + e + w === 0) {
-				return `lens_diagnostics ${mode} — clean (${files} files)${coldSuffix}`;
+				return `lens_diagnostics ${mode} — clean (${files} files)${coldSuffix}${failedSuffix}`;
 			}
-			return `lens_diagnostics ${mode} — ${b} blocking · ${e} errors · ${w} warnings (${files} files)${coldSuffix}`;
+			return `lens_diagnostics ${mode} — ${b} blocking · ${e} errors · ${w} warnings (${files} files)${coldSuffix}${failedSuffix}`;
 		}),
 		parameters: Type.Object({
 			mode: Type.Optional(
@@ -1151,6 +1156,7 @@ async function formatFullMode(
 				diagnostics: [],
 				runners: [],
 				cold: [],
+				failed: [],
 				timings: {},
 			});
 	const [rawLspResults, rawProjectSnapshot, extracted] = await Promise.all([
@@ -1379,6 +1385,13 @@ async function formatFullMode(
 						", ",
 					)}. These analyzers have not contributed to this result — absence of their findings is NOT a clean verdict.`
 			: "";
+	const failedAnalyzers = extracted.failed ?? [];
+	const failedNote =
+		failedAnalyzers.length > 0
+			? `\n\nfailed (ran, but no trustworthy result): ${failedAnalyzers
+					.map(({ id, summary }) => `${id} — ${summary}`)
+					.join(", ")}. These analyzers were not cached and will be retried; absence of their findings is NOT a clean verdict.`
+			: "";
 	// #747/#250: the cheap project-diagnostics scan (scanProjectDiagnostics) and
 	// the LSP workspace sweep (collectWorkspaceDiagnosticFiles) both refuse to
 	// WALK from a cwd at/above $HOME — from there, walking would enumerate every
@@ -1429,6 +1442,7 @@ async function formatFullMode(
 		details: {
 			...result.details,
 			coldRunners: extracted.cold,
+			failedAnalyzers,
 			analyzerTimingsMs: extracted.timings,
 			analyzersAborted: extracted.aborted ?? false,
 			analyzersAbortedIds: extracted.abortedIds ?? [],
@@ -1484,6 +1498,7 @@ async function formatFullMode(
 						unconfirmedLspNote +
 						lspPrimaryVsAuxiliaryNote +
 						coldNote +
+						failedNote +
 						walkUnsafeRootNote +
 						scanTruncatedNote +
 						abortedNote +
@@ -1497,6 +1512,7 @@ async function formatFullMode(
 	if (
 		missingNote ||
 		coldNote ||
+		failedNote ||
 		walkUnsafeRootNote ||
 		scanTruncatedNote ||
 		abortedNote ||
@@ -1513,6 +1529,7 @@ async function formatFullMode(
 						unconfirmedLspNote +
 						lspPrimaryVsAuxiliaryNote +
 						coldNote +
+						failedNote +
 						walkUnsafeRootNote +
 						scanTruncatedNote +
 						abortedNote +

--- a/tools/symbol-search.ts
+++ b/tools/symbol-search.ts
@@ -34,6 +34,7 @@ export function createSymbolSearchTool(getProjectRoot: () => string) {
 			query?: string;
 			count?: number;
 			hint?: string;
+			unavailableReason?: string;
 		}>(({ details, isError }) => {
 			if (isError || details?.available === false) {
 				return `symbol_search "${details?.query ?? ""}" — unavailable${details?.hint ? `: ${details.hint}` : ""}`;
@@ -104,6 +105,7 @@ export function createSymbolSearchTool(getProjectRoot: () => string) {
 						available: false,
 						query: result.query,
 						hint: result.hint,
+						unavailableReason: result.unavailableReason,
 					},
 				};
 			}

--- a/tools/symbol-search.ts
+++ b/tools/symbol-search.ts
@@ -110,11 +110,22 @@ export function createSymbolSearchTool(getProjectRoot: () => string) {
 				};
 			}
 			if (result.results.length === 0) {
+				const coverageLine = result.coverage
+					? `Index covers ${result.coverage.files} files${result.coverage.truncated ? " (capped — results may be incomplete)" : ""}.`
+					: "";
 				return {
 					content: [
-						{ type: "text" as const, text: `No files matched "${params.query}".` },
+						{
+							type: "text" as const,
+							text: `No files matched "${params.query}".${coverageLine ? `\n${coverageLine}` : ""}`,
+						},
 					],
-					details: { available: true, query: result.query, count: 0 },
+					details: {
+						available: true,
+						query: result.query,
+						count: 0,
+						coverage: result.coverage,
+					},
 				};
 			}
 			const lines = [
@@ -124,6 +135,11 @@ export function createSymbolSearchTool(getProjectRoot: () => string) {
 						`  ${i + 1}. ${path.relative(cwd, hit.file)} ` +
 						`(score ${hit.score.toFixed(2)}, ${hit.hits} hit(s), line ${hit.startLine})`,
 				),
+				...(result.coverage
+					? [
+							`Index covers ${result.coverage.files} files${result.coverage.truncated ? " (capped — results may be incomplete)" : ""}.`,
+						]
+					: []),
 			];
 			// Compact (unindented) JSON payload, matching module_report/read_symbol
 			// (#517): path relative-to-cwd once per hit, no per-hit `read` block —
@@ -131,6 +147,7 @@ export function createSymbolSearchTool(getProjectRoot: () => string) {
 			const payload = {
 				available: true,
 				query: result.query,
+				coverage: result.coverage,
 				results: result.results.map((hit) => {
 					const relFile = path.relative(cwd, hit.file);
 					return {
@@ -152,6 +169,7 @@ export function createSymbolSearchTool(getProjectRoot: () => string) {
 					available: true,
 					query: result.query,
 					count: result.results.length,
+					coverage: result.coverage,
 				},
 			};
 		},


### PR DESCRIPTION
Closes #925, closes #926, closes #927, closes #928. Four commits, one per issue — all the same #533 honesty class from the observability audit.

- **#925** (`5ea76f44`): heavyweight analyzers with `success: false` are now classified as failed (rendered as unknown, not clean), never cached (so next session retries), across the whole fleet — not just knip; madge unchanged (no failure sentinel in its contract). Bonus: corrupt fix-worklog lines no longer discard valid neighbors.
- **#926** (`f313d9e5`): `symbol_search` distinguishes building / refused (with why) / last-build-failed; per-workspace build outcomes remembered; build+persist failures go to a new `word-index.log` on the shared NDJSON infra.
- **#927** (`3508ddc1`): LSP circuit-breaker state exposed read-only (no client spawns); `pilens_health` renders permanently disabled servers and cooldown deadlines, even at zero live clients — the #923 tree-sitter precedent, LSP edition.
- **#928** (`5de45546`): word indexes persist indexed-file count + truncation; legacy snapshots default to non-truncated; pi and MCP surfaces expose coverage and warn when capped results may be incomplete.

Verification (post master-merge `90b13826`): build green, 12 test files / 205 tests passed, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)