### PR TITLE
fix(installer): lifetime-coupled subprocesses, cross-process install lock, no installs from tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ All mutations of the shared managed `tools/` tree are also serialized by its
 atomic `.install.lock`; after waiting, re-run discovery before installing because
 the preceding process may already have satisfied the request. A lock is stale
 only after its recorded PID is confirmed dead.
+Vitest sets `PI_LENS_DISABLE_TOOL_INSTALL=1` before global setup and workers;
+ordinary tests must remain network/install-free. Real installer integration
+tests must explicitly opt in and use an isolated `PI_LENS_HOME`.
 
 Whole-project loops that reuse one `FactStore` must delete `file.content` after
 that file's consumers finish (in a `finally` so abort/error exits release it).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,12 @@ tools/                    ast-grep-search, lsp-navigation tool handlers
 tests/                    Vitest test suite (mirrors clients/ structure)
 ```
 
+Installer package-manager and archive-extraction subprocesses must use
+`safeSpawnAsync` with `lifetimeCoupled: true` and `ignoreAmbientSignal: true`.
+This gives timeouts an awaited Windows tree-kill and prevents interrupted parent
+processes from orphaning package-manager descendants; do not reintroduce raw
+`spawn(..., { shell: true })` for install mutations.
+
 Whole-project loops that reuse one `FactStore` must delete `file.content` after
 that file's consumers finish (in a `finally` so abort/error exits release it).
 Keep derived file facts and session facts: later cross-file consumers may still

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,9 @@ only after its recorded PID is confirmed dead.
 Vitest sets `PI_LENS_DISABLE_TOOL_INSTALL=1` before global setup and workers;
 ordinary tests must remain network/install-free. Real installer integration
 tests must explicitly opt in and use an isolated `PI_LENS_HOME`.
+Installer lifecycle integration tests use a fake package manager and isolated
+home; `PI_LENS_INSTALL_TIMEOUT_MS` exists to keep timeout coverage fast and
+must not become a production policy default.
 
 Whole-project loops that reuse one `FactStore` must delete `file.content` after
 that file's consumers finish (in a `finally` so abort/error exits release it).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,10 @@ Installer package-manager and archive-extraction subprocesses must use
 This gives timeouts an awaited Windows tree-kill and prevents interrupted parent
 processes from orphaning package-manager descendants; do not reintroduce raw
 `spawn(..., { shell: true })` for install mutations.
+All mutations of the shared managed `tools/` tree are also serialized by its
+atomic `.install.lock`; after waiting, re-run discovery before installing because
+the preceding process may already have satisfied the request. A lock is stale
+only after its recorded PID is confirmed dead.
 
 Whole-project loops that reuse one `FactStore` must delete `file.content` after
 that file's consumers finish (in a `finally` so abort/error exits release it).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ All notable changes to pi-lens will be documented in this file.
 	oxlint probe-cache entry without networking, and one-shot analysis explicitly
 	awaits probe-cache persistence before exit.
 
+- **Installer orphan/locking regressions are process-tested** (refs #945) —
+	fake package-manager coverage verifies Windows timeout tree-kill, exactly one
+	install across concurrent processes, explicit install-disable refusal, and
+	Vitest's default no-install environment.
+
 - **Standalone out-of-band review-graph build CLI** (refs #924) — `npx pi-lens
 	build-graph [--cwd <dir>]` reuses the session builder and queued atomic
 	persist path for CI/cron, forces the debounced snapshot write before exit,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to pi-lens will be documented in this file.
 	before stale recovery, bounds lock waits with an honest error, and rechecks
 	discovery after acquisition to avoid duplicate package-manager runs.
 
+- **Ordinary tests never install managed tools** (refs #945) — Vitest sets
+	`PI_LENS_DISABLE_TOOL_INSTALL=1`, its prewarm step creates a local synthetic
+	oxlint probe-cache entry without networking, and one-shot analysis explicitly
+	awaits probe-cache persistence before exit.
+
 - **Standalone out-of-band review-graph build CLI** (refs #924) — `npx pi-lens
 	build-graph [--cwd <dir>]` reuses the session builder and queued atomic
 	persist path for CI/cron, forces the debounced snapshot write before exit,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Installer subprocesses are lifetime-coupled** (refs #945) — npm, pip, gem,
+	and archive extraction now use the shared safe-spawn path, await full Windows
+	process-tree termination on timeout, and synchronously clean registered
+	installer children during parent exit/signals.
+
 - **Standalone out-of-band review-graph build CLI** (refs #924) — `npx pi-lens
 	build-graph [--cwd <dir>]` reuses the session builder and queued atomic
 	persist path for CI/cron, forces the debounced snapshot write before exit,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to pi-lens will be documented in this file.
 	process-tree termination on timeout, and synchronously clean registered
 	installer children during parent exit/signals.
 
+- **Managed tool installs are cross-process serialized** (refs #945) — a
+	dependency-free atomic lock protects the shared tools tree, verifies owners
+	before stale recovery, bounds lock waits with an honest error, and rechecks
+	discovery after acquisition to avoid duplicate package-manager runs.
+
 - **Standalone out-of-band review-graph build CLI** (refs #924) — `npx pi-lens
 	build-graph [--cwd <dir>]` reuses the session builder and queued atomic
 	persist path for CI/cron, forces the debounced snapshot write before exit,

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -91,7 +91,12 @@ async function acquireInstallLock(): Promise<{
 	reason?: string;
 }> {
 	await fs.mkdir(TOOLS_DIR, { recursive: true });
-	const timeoutMs = Number(process.env.PI_LENS_INSTALL_LOCK_TIMEOUT_MS) || 30_000;
+	// #946 review F2: the waiter's bound must exceed the owner's install bound
+	// (PI_LENS_INSTALL_TIMEOUT_MS, default 120s) — a 30s waiter gave up on a
+	// legitimate slow install and reported the tool unavailable for the whole
+	// session even though it arrived seconds later.
+	const timeoutMs =
+		Number(process.env.PI_LENS_INSTALL_LOCK_TIMEOUT_MS) || 150_000;
 	const deadline = Date.now() + timeoutMs;
 	let lastOwner = "unknown owner";
 
@@ -131,16 +136,44 @@ async function acquireInstallLock(): Promise<{
 					await fs.readFile(INSTALL_LOCK_PATH, "utf8"),
 				) as InstallLockOwner;
 				lastOwner = `pid=${owner.pid} createdAt=${owner.createdAt}`;
+				// #946 review F1: PID liveness alone cannot detect a hard-killed
+				// owner whose PID Windows has recycled — that lock would poison
+				// every future install with a full-timeout wait. A lock older
+				// than any legitimate install (owner install bound + slack) is
+				// stale regardless of what the PID now points at.
+				const maxAgeMs =
+					(Number(process.env.PI_LENS_INSTALL_TIMEOUT_MS) || 120_000) +
+					60_000;
+				const expired =
+					Number.isFinite(owner.createdAt) &&
+					Date.now() - owner.createdAt > maxAgeMs;
 				if (
-					Number.isInteger(owner.pid) &&
-					owner.pid > 0 &&
-					!isProcessAlive(owner.pid)
+					expired ||
+					(Number.isInteger(owner.pid) &&
+						owner.pid > 0 &&
+						!isProcessAlive(owner.pid))
 				) {
 					await fs.rm(INSTALL_LOCK_PATH, { force: true });
 					continue;
 				}
-			} catch {
-				lastOwner = "unreadable owner (not safely recoverable)";
+			} catch (readError) {
+				lastOwner = "unreadable owner";
+				// An unreadable/empty lock has no createdAt to age out — fall
+				// back to the file's own mtime for the max-age check so it is
+				// eventually recoverable (#946 review F1/F6).
+				try {
+					const stat = await fs.stat(INSTALL_LOCK_PATH);
+					const maxAgeMs =
+						(Number(process.env.PI_LENS_INSTALL_TIMEOUT_MS) || 120_000) +
+						60_000;
+					if (Date.now() - stat.mtimeMs > maxAgeMs) {
+						await fs.rm(INSTALL_LOCK_PATH, { force: true });
+						continue;
+					}
+				} catch {
+					// stat raced a release — loop and retry acquisition.
+				}
+				void readError;
 			}
 			await new Promise((resolve) => setTimeout(resolve, 100));
 		}
@@ -1355,18 +1388,37 @@ function scheduleProbeFlush(): void {
 	_probeCacheFlushTimer.unref?.();
 }
 
+let _probeCacheWriteInFlight: Promise<void> | null = null;
+
 /** Await pending probe-cache persistence before a one-shot process exits. */
 export async function flushProbeCache(): Promise<void> {
 	if (_probeCacheFlushTimer !== null) {
 		clearTimeout(_probeCacheFlushTimer);
 		_probeCacheFlushTimer = null;
 	}
-	if (!_probeCacheDirty || _probeCache === null) return;
+	// #946 review F4: if the 300ms timer's write already started, the dirty
+	// flag is false but the write may still be in flight — an immediate
+	// process.exit would truncate it. Always await the in-flight write.
+	if (!_probeCacheDirty || _probeCache === null) {
+		await _probeCacheWriteInFlight;
+		return;
+	}
 	_probeCacheDirty = false;
+	const write = (async () => {
+		try {
+			await fs.writeFile(
+				PROBE_CACHE_PATH,
+				JSON.stringify(_probeCache, null, 2),
+			);
+		} catch {
+			// Cache persistence is best effort; discovery remains authoritative.
+		}
+	})();
+	_probeCacheWriteInFlight = write;
 	try {
-		await fs.writeFile(PROBE_CACHE_PATH, JSON.stringify(_probeCache, null, 2));
-	} catch {
-		// Cache persistence is best effort; discovery remains authoritative.
+		await write;
+	} finally {
+		if (_probeCacheWriteInFlight === write) _probeCacheWriteInFlight = null;
 	}
 }
 

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -47,7 +47,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, statSync, unlinkSync } from "node:fs";
 import fs from "node:fs/promises";
 import https from "node:https";
 import { createRequire } from "node:module";
@@ -68,6 +68,87 @@ import { safeSpawnAsync } from "../safe-spawn.js";
 
 // Global installation directory for pi-lens tools
 const TOOLS_DIR = path.join(getGlobalPiLensDir(), "tools");
+const INSTALL_LOCK_PATH = path.join(TOOLS_DIR, ".install.lock");
+const activeInstallLocks = new Set<string>();
+let installLockExitCleanupRegistered = false;
+
+interface InstallLockOwner {
+	pid: number;
+	createdAt: number;
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+async function acquireInstallLock(): Promise<{
+	release?: () => Promise<void>;
+	reason?: string;
+}> {
+	await fs.mkdir(TOOLS_DIR, { recursive: true });
+	const timeoutMs = Number(process.env.PI_LENS_INSTALL_LOCK_TIMEOUT_MS) || 30_000;
+	const deadline = Date.now() + timeoutMs;
+	let lastOwner = "unknown owner";
+
+	while (Date.now() < deadline) {
+		try {
+			const handle = await fs.open(INSTALL_LOCK_PATH, "wx");
+			await handle.writeFile(
+				JSON.stringify({ pid: process.pid, createdAt: Date.now() }),
+			);
+			await handle.close();
+			activeInstallLocks.add(INSTALL_LOCK_PATH);
+			if (!installLockExitCleanupRegistered) {
+				installLockExitCleanupRegistered = true;
+				process.once("exit", () => {
+					for (const lockPath of activeInstallLocks) {
+						try {
+							unlinkSync(lockPath);
+						} catch {
+							// Best effort; the next owner verifies this PID is dead.
+						}
+					}
+				});
+			}
+			let released = false;
+			return {
+				release: async () => {
+					if (released) return;
+					released = true;
+					activeInstallLocks.delete(INSTALL_LOCK_PATH);
+					await fs.rm(INSTALL_LOCK_PATH, { force: true });
+				},
+			};
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+			try {
+				const owner = JSON.parse(
+					await fs.readFile(INSTALL_LOCK_PATH, "utf8"),
+				) as InstallLockOwner;
+				lastOwner = `pid=${owner.pid} createdAt=${owner.createdAt}`;
+				if (
+					Number.isInteger(owner.pid) &&
+					owner.pid > 0 &&
+					!isProcessAlive(owner.pid)
+				) {
+					await fs.rm(INSTALL_LOCK_PATH, { force: true });
+					continue;
+				}
+			} catch {
+				lastOwner = "unreadable owner (not safely recoverable)";
+			}
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+	}
+	return {
+		reason: `timed out after ${timeoutMs}ms waiting for shared tools install lock (${lastOwner})`,
+	};
+}
 
 // Directory for GitHub-downloaded binaries
 const GITHUB_BIN_DIR = path.join(getGlobalPiLensDir(), "bin");
@@ -3182,8 +3263,17 @@ export async function ensureTool(
 			return cacheResolvedPath(await getToolPath(toolId));
 		}
 
-		// Force download
-		const installed = await installTool(toolId);
+		const lock = await acquireInstallLock();
+		if (!lock.release) {
+			logSessionStart(`auto-install ensure ${toolId}: ${lock.reason}`);
+			return undefined;
+		}
+		let installed: boolean;
+		try {
+			installed = await installTool(toolId);
+		} finally {
+			await lock.release();
+		}
 		if (!installed) {
 			logSessionStart(
 				`auto-install ensure ${toolId}: force reinstall failed (${Date.now() - ensureStartMs}ms)`,
@@ -3283,7 +3373,25 @@ export async function ensureTool(
 			return undefined;
 		}
 
-		const installed = await installTool(toolId);
+		const lock = await acquireInstallLock();
+		if (!lock.release) {
+			logSessionStart(`auto-install ensure ${toolId}: ${lock.reason}`);
+			return undefined;
+		}
+		let installed: boolean;
+		try {
+			// Cross-process double-check: the lock waiter may now observe the tool
+			// installed by its predecessor and must not run a second package manager.
+			const installedByPeer = await getToolPath(toolId);
+			if (installedByPeer) {
+				resolvedPathCache.set(toolId, installedByPeer);
+				void updateProbeCache(toolId, installedByPeer);
+				return installedByPeer;
+			}
+			installed = await installTool(toolId);
+		} finally {
+			await lock.release();
+		}
 		if (!installed) {
 			logSessionStart(
 				`auto-install ensure ${toolId}: unavailable (${Date.now() - ensureStartMs}ms)`,

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -1344,14 +1344,24 @@ async function readProbeCache(): Promise<ProbeCache> {
 function scheduleProbeFlush(): void {
 	if (_probeCacheFlushTimer !== null) return;
 	_probeCacheFlushTimer = setTimeout(() => {
-		_probeCacheFlushTimer = null;
-		if (!_probeCacheDirty || _probeCache === null) return;
-		_probeCacheDirty = false;
-		void fs
-			.writeFile(PROBE_CACHE_PATH, JSON.stringify(_probeCache, null, 2))
-			.catch(() => {});
+		void flushProbeCache();
 	}, 300);
 	_probeCacheFlushTimer.unref?.();
+}
+
+/** Await pending probe-cache persistence before a one-shot process exits. */
+export async function flushProbeCache(): Promise<void> {
+	if (_probeCacheFlushTimer !== null) {
+		clearTimeout(_probeCacheFlushTimer);
+		_probeCacheFlushTimer = null;
+	}
+	if (!_probeCacheDirty || _probeCache === null) return;
+	_probeCacheDirty = false;
+	try {
+		await fs.writeFile(PROBE_CACHE_PATH, JSON.stringify(_probeCache, null, 2));
+	} catch {
+		// Cache persistence is best effort; discovery remains authoritative.
+	}
 }
 
 function isAstGrepVersionOutput(output: string): boolean {
@@ -3133,6 +3143,12 @@ async function installGemTool(
  * Install a tool by ID
  */
 export async function installTool(toolId: string): Promise<boolean> {
+	if (process.env.PI_LENS_DISABLE_TOOL_INSTALL === "1") {
+		logSessionStart(
+			`auto-install ${toolId}: refused — PI_LENS_DISABLE_TOOL_INSTALL=1`,
+		);
+		return false;
+	}
 	const tool = TOOLS.find((t) => t.id === toolId);
 	if (!tool) {
 		logSessionStart(`auto-install ${toolId}: unknown tool id`);
@@ -3262,6 +3278,12 @@ export async function ensureTool(
 			);
 			return cacheResolvedPath(await getToolPath(toolId));
 		}
+		if (process.env.PI_LENS_DISABLE_TOOL_INSTALL === "1") {
+			logSessionStart(
+				`auto-install ensure ${toolId}: refused — PI_LENS_DISABLE_TOOL_INSTALL=1`,
+			);
+			return undefined;
+		}
 
 		const lock = await acquireInstallLock();
 		if (!lock.release) {
@@ -3369,6 +3391,12 @@ export async function ensureTool(
 		if (opts?.allowInstall === false) {
 			logSessionStart(
 				`auto-install ensure ${toolId}: install disabled — discovery only, not found (${Date.now() - ensureStartMs}ms)`,
+			);
+			return undefined;
+		}
+		if (process.env.PI_LENS_DISABLE_TOOL_INSTALL === "1") {
+			logSessionStart(
+				`auto-install ensure ${toolId}: refused — PI_LENS_DISABLE_TOOL_INSTALL=1 (${Date.now() - ensureStartMs}ms)`,
 			);
 			return undefined;
 		}

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -1309,6 +1309,12 @@ export const TOOLS: ToolDefinition[] = [
 ];
 
 const ensureInFlight = new Map<string, Promise<string | undefined>>();
+const installFailureReasons = new Map<string, string>();
+
+/** Last honest install refusal/failure reason for callers that need diagnostics. */
+export function getInstallFailureReason(toolId: string): string | undefined {
+	return installFailureReasons.get(toolId);
+}
 
 // Session-lifetime cache: once a tool path is resolved, skip the process-spawn check on subsequent calls.
 const resolvedPathCache = new Map<string, string>();
@@ -1460,6 +1466,7 @@ export function resetProbeCacheStateForTesting(): void {
 	_probeCacheDirty = false;
 	resolvedPathCache.clear();
 	ensureInFlight.clear();
+	installFailureReasons.clear();
 	lastManagedInstallVersion.clear();
 	if (_probeCacheFlushTimer !== null) {
 		clearTimeout(_probeCacheFlushTimer);
@@ -2864,7 +2871,11 @@ async function installNpmTool(
 		// Resolve the package manager for the tools dir and build install args.
 		const isWindows = process.platform === "win32";
 		const pm = await resolveNodePackageManager(TOOLS_DIR);
-		const pmCommand = pmBinary(pm);
+		const testNpmScript =
+			process.env.PI_LENS_TEST_MODE === "1"
+				? process.env.PI_LENS_TEST_NPM_SCRIPT
+				: undefined;
+		const pmCommand = testNpmScript ? process.execPath : pmBinary(pm);
 		// Use --ignore-scripts unless the package explicitly needs postinstall
 		// (e.g. biome downloads a platform-specific native binary via postinstall).
 		const needsScripts = NEEDS_POSTINSTALL.has(packageName);
@@ -2872,7 +2883,8 @@ async function installNpmTool(
 			ignoreScripts: !needsScripts,
 		});
 
-		const INSTALL_TIMEOUT_MS = 120_000;
+		const INSTALL_TIMEOUT_MS =
+			Number(process.env.PI_LENS_INSTALL_TIMEOUT_MS) || 120_000;
 		const runInstallAttempt = async (
 			args: string[],
 		): Promise<{ ok: boolean; stderr: string }> => {
@@ -2888,7 +2900,10 @@ async function installNpmTool(
 			};
 		};
 
-		let outcome = await runInstallAttempt(baseInstallArgs);
+		let outcome = await runInstallAttempt([
+			...(testNpmScript ? [testNpmScript] : []),
+			...baseInstallArgs,
+		]);
 
 		// --legacy-peer-deps is npm-only; retry just npm's ERESOLVE failures.
 		const erResolve =
@@ -2905,7 +2920,10 @@ async function installNpmTool(
 			logSessionStart(
 				`auto-install npm ${packageName}: retry with --legacy-peer-deps after ERESOLVE`,
 			);
-			outcome = await runInstallAttempt(retryArgs);
+			outcome = await runInstallAttempt([
+				...(testNpmScript ? [testNpmScript] : []),
+				...retryArgs,
+			]);
 		}
 
 		if (!outcome.ok) {
@@ -3144,6 +3162,10 @@ async function installGemTool(
  */
 export async function installTool(toolId: string): Promise<boolean> {
 	if (process.env.PI_LENS_DISABLE_TOOL_INSTALL === "1") {
+		installFailureReasons.set(
+			toolId,
+			"installation disabled by PI_LENS_DISABLE_TOOL_INSTALL=1",
+		);
 		logSessionStart(
 			`auto-install ${toolId}: refused — PI_LENS_DISABLE_TOOL_INSTALL=1`,
 		);
@@ -3241,6 +3263,7 @@ export async function ensureTool(
 	toolId: string,
 	opts?: { forceReinstall?: boolean; allowInstall?: boolean },
 ): Promise<string | undefined> {
+	installFailureReasons.delete(toolId);
 	const cacheResolvedPath = (result: string | undefined): string | undefined => {
 		if (result) {
 			resolvedPathCache.set(toolId, result);
@@ -3279,6 +3302,10 @@ export async function ensureTool(
 			return cacheResolvedPath(await getToolPath(toolId));
 		}
 		if (process.env.PI_LENS_DISABLE_TOOL_INSTALL === "1") {
+			installFailureReasons.set(
+				toolId,
+				"installation disabled by PI_LENS_DISABLE_TOOL_INSTALL=1",
+			);
 			logSessionStart(
 				`auto-install ensure ${toolId}: refused — PI_LENS_DISABLE_TOOL_INSTALL=1`,
 			);
@@ -3395,6 +3422,10 @@ export async function ensureTool(
 			return undefined;
 		}
 		if (process.env.PI_LENS_DISABLE_TOOL_INSTALL === "1") {
+			installFailureReasons.set(
+				toolId,
+				"installation disabled by PI_LENS_DISABLE_TOOL_INSTALL=1",
+			);
 			logSessionStart(
 				`auto-install ensure ${toolId}: refused — PI_LENS_DISABLE_TOOL_INSTALL=1 (${Date.now() - ensureStartMs}ms)`,
 			);
@@ -3403,6 +3434,7 @@ export async function ensureTool(
 
 		const lock = await acquireInstallLock();
 		if (!lock.release) {
+			installFailureReasons.set(toolId, lock.reason ?? "install lock failed");
 			logSessionStart(`auto-install ensure ${toolId}: ${lock.reason}`);
 			return undefined;
 		}

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -64,6 +64,7 @@ import {
 	pmBinary,
 	resolveNodePackageManager,
 } from "../package-manager.js";
+import { safeSpawnAsync } from "../safe-spawn.js";
 
 // Global installation directory for pi-lens tools
 const TOOLS_DIR = path.join(getGlobalPiLensDir(), "tools");
@@ -2662,25 +2663,16 @@ async function installArchiveTool(
 		const tarBin = isWindows
 			? `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\tar.exe`
 			: "tar";
-		const extracted = await new Promise<{ ok: boolean; stderr: string }>(
-			(resolve) => {
-				const proc = spawn(tarBin, tarArgs, {
-					cwd: TOOLS_DIR,
-					stdio: ["ignore", "ignore", "pipe"],
-				});
-				let stderr = "";
-				proc.stderr?.on("data", (d) => (stderr += d));
-				const timer = setTimeout(() => {
-					proc.kill();
-					resolve({ ok: false, stderr: "extraction timed out" });
-				}, 120_000);
-				proc.on("exit", (code) => {
-					clearTimeout(timer);
-					resolve({ ok: code === 0, stderr });
-				});
-				proc.on("error", (err) => resolve({ ok: false, stderr: err.message }));
-			},
-		);
+		const extractResult = await safeSpawnAsync(tarBin, tarArgs, {
+			cwd: TOOLS_DIR,
+			timeout: 120_000,
+			ignoreAmbientSignal: true,
+			lifetimeCoupled: true,
+		});
+		const extracted = {
+			ok: extractResult.status === 0,
+			stderr: extractResult.error?.message ?? extractResult.stderr,
+		};
 		await fs.rm(tmpArchive, { force: true });
 		if (!extracted.ok) {
 			logSessionStart(
@@ -2792,34 +2784,18 @@ async function installNpmTool(
 		const INSTALL_TIMEOUT_MS = 120_000;
 		const runInstallAttempt = async (
 			args: string[],
-		): Promise<{ ok: boolean; stderr: string }> =>
-			new Promise((resolve) => {
-				const proc = spawn(pmCommand, args, {
-					cwd: TOOLS_DIR,
-					stdio: ["ignore", "pipe", "pipe"],
-					shell: isWindows, // Required for .cmd files on Windows
-				});
-
-				let stderr = "";
-				proc.stderr?.on("data", (data) => (stderr += data));
-
-				const timer = setTimeout(() => {
-					proc.kill();
-					resolve({
-						ok: false,
-						stderr: `install timed out after ${INSTALL_TIMEOUT_MS / 1000}s`,
-					});
-				}, INSTALL_TIMEOUT_MS);
-
-				proc.on("exit", (code) => {
-					clearTimeout(timer);
-					resolve({ ok: code === 0, stderr });
-				});
-				proc.on("error", (err) => {
-					clearTimeout(timer);
-					resolve({ ok: false, stderr: err.message });
-				});
+		): Promise<{ ok: boolean; stderr: string }> => {
+			const result = await safeSpawnAsync(pmCommand, args, {
+				cwd: TOOLS_DIR,
+				timeout: INSTALL_TIMEOUT_MS,
+				ignoreAmbientSignal: true,
+				lifetimeCoupled: true,
 			});
+			return {
+				ok: result.status === 0,
+				stderr: result.error?.message ?? result.stderr,
+			};
+		};
 
 		let outcome = await runInstallAttempt(baseInstallArgs);
 
@@ -2936,29 +2912,15 @@ async function installPipTool(
 
 		let lastError = "";
 		for (const candidate of pipCandidates) {
-			const outcome = await new Promise<{ ok: boolean; error: string }>(
-				(resolve) => {
-					const proc = spawn(candidate.command, candidate.args, {
-						stdio: ["ignore", "pipe", "pipe"],
-						shell: isWindows, // Required for .cmd files on Windows
-					});
-
-					let stderr = "";
-					proc.stderr?.on("data", (data) => (stderr += data));
-
-					proc.on("exit", (code) => {
-						if (code === 0) {
-							resolve({ ok: true, error: "" });
-						} else {
-							resolve({ ok: false, error: stderr.trim() });
-						}
-					});
-
-					proc.on("error", (err) => {
-						resolve({ ok: false, error: err.message });
-					});
-				},
-			);
+			const pipResult = await safeSpawnAsync(candidate.command, candidate.args, {
+				timeout: 120_000,
+				ignoreAmbientSignal: true,
+				lifetimeCoupled: true,
+			});
+			const outcome = {
+				ok: pipResult.status === 0,
+				error: (pipResult.error?.message ?? pipResult.stderr).trim(),
+			};
 
 			if (outcome.ok) {
 				// Ensure user-level scripts directory is available in current process PATH.
@@ -3057,24 +3019,19 @@ async function installGemTool(
 	packageName: string,
 ): Promise<string | undefined> {
 	try {
-		const isWindows = process.platform === "win32";
-		const outcome = await new Promise<{ ok: boolean; error: string }>(
-			(resolve) => {
-				const proc = spawn("gem", ["install", packageName, "--no-document"], {
-					stdio: ["ignore", "pipe", "pipe"],
-					shell: isWindows,
-				});
-
-				let stderr = "";
-				proc.stderr?.on("data", (data) => (stderr += data));
-				proc.on("exit", (code) => {
-					resolve({ ok: code === 0, error: stderr.trim() });
-				});
-				proc.on("error", (err) => {
-					resolve({ ok: false, error: err.message });
-				});
+		const gemResult = await safeSpawnAsync(
+			"gem",
+			["install", packageName, "--no-document"],
+			{
+				timeout: 120_000,
+				ignoreAmbientSignal: true,
+				lifetimeCoupled: true,
 			},
 		);
+		const outcome = {
+			ok: gemResult.status === 0,
+			error: (gemResult.error?.message ?? gemResult.stderr).trim(),
+		};
 
 		if (!outcome.ok) {
 			throw new Error(

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -61,6 +61,47 @@ export interface SafeSpawnOptions {
 	 * affects spawn behavior.
 	 */
 	resourceLabel?: string;
+	/**
+	 * Couple a long-lived, side-effecting child to this Node process. Registered
+	 * children are synchronously tree-killed during process exit/signals.
+	 * Windows Job Objects would make this kernel-enforced, but require a native
+	 * dependency; keep this dependency-free fallback until that follow-up.
+	 */
+	lifetimeCoupled?: boolean;
+}
+
+const lifetimeCoupledPids = new Set<number>();
+let lifetimeCleanupInstalled = false;
+
+function killPidTreeSync(pid: number): void {
+	if (process.platform === "win32") {
+		const taskkill = `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\taskkill.exe`;
+		spawnSync(taskkill, ["/F", "/T", "/PID", String(pid)], {
+			shell: false,
+			windowsHide: true,
+			stdio: "ignore",
+		});
+		return;
+	}
+	try {
+		process.kill(pid, "SIGKILL");
+	} catch {
+		// Child already exited.
+	}
+}
+
+function installLifetimeCleanup(): void {
+	if (lifetimeCleanupInstalled) return;
+	lifetimeCleanupInstalled = true;
+	process.once("exit", () => {
+		for (const pid of lifetimeCoupledPids) killPidTreeSync(pid);
+	});
+	for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as NodeJS.Signals[]) {
+		process.once(signal, () => {
+			for (const pid of lifetimeCoupledPids) killPidTreeSync(pid);
+			process.kill(process.pid, signal);
+		});
+	}
 }
 
 // ============================================================================
@@ -427,6 +468,10 @@ export async function safeSpawnAsync(
 			shell: false,
 			windowsVerbatimArguments,
 		});
+		if (options?.lifetimeCoupled && child.pid) {
+			installLifetimeCleanup();
+			lifetimeCoupledPids.add(child.pid);
+		}
 
 		// #620: bracket this spawn's lifetime with a short-interval CPU/RSS poll
 		// (started right here, stopped in the "close" handler below) so transient
@@ -447,13 +492,21 @@ export async function safeSpawnAsync(
 		// On Windows, shell:true means child.pid is cmd.exe — child.kill() only
 		// kills the wrapper, leaving the actual subprocess (e.g. knip/npx) alive
 		// as an orphan. Use taskkill /F /T to kill the full process tree instead.
-		const killTree = () => {
+		const killTree = async (): Promise<void> => {
 			if (isWindows && child.pid && child.pid > 0) {
 				const taskkill = `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\taskkill.exe`;
 				try {
-					spawn(taskkill, ["/F", "/T", "/PID", String(child.pid)], {
-						shell: false,
-						windowsHide: true,
+					await new Promise<void>((done) => {
+						const killer = spawn(taskkill, ["/F", "/T", "/PID", String(child.pid)], {
+							shell: false,
+							windowsHide: true,
+							stdio: "ignore",
+						});
+						killer.once("close", () => done());
+						killer.once("error", () => {
+							child.kill("SIGKILL");
+							done();
+						});
 					});
 				} catch {
 					child.kill("SIGKILL");
@@ -470,7 +523,7 @@ export async function safeSpawnAsync(
 		const onAbort = () => {
 			if (!killed && !child.killed) {
 				killed = true;
-				killTree();
+				void killTree();
 			}
 		};
 		abortSignal?.addEventListener("abort", onAbort, { once: true });
@@ -482,11 +535,12 @@ export async function safeSpawnAsync(
 		child.stderr?.on("data", (data) => (stderr += data));
 
 		// Timeout handling - KILL the process, don't just abandon it
+		let killPromise: Promise<void> | undefined;
 		const timeoutId = setTimeout(() => {
 			timedOut = true;
 			if (!killed && !child.killed) {
 				killed = true;
-				killTree();
+				killPromise = killTree();
 			}
 		}, timeout);
 
@@ -514,9 +568,11 @@ export async function safeSpawnAsync(
 		};
 
 		// Process completion
-		child.on("close", (code, signal) => {
+		child.on("close", async (code, signal) => {
 			clearTimeout(timeoutId);
 			abortSignal?.removeEventListener("abort", onAbort);
+			if (child.pid) lifetimeCoupledPids.delete(child.pid);
+			await killPromise;
 			const resourceUsage = finishResourceUsage();
 
 			if (timedOut) {
@@ -545,6 +601,7 @@ export async function safeSpawnAsync(
 		child.on("error", (err) => {
 			clearTimeout(timeoutId);
 			abortSignal?.removeEventListener("abort", onAbort);
+			if (child.pid) lifetimeCoupledPids.delete(child.pid);
 			const resourceUsage = finishResourceUsage();
 			resolve({ stdout, stderr, status: null, error: err, resourceUsage });
 		});

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -70,8 +70,23 @@ export interface SafeSpawnOptions {
 	lifetimeCoupled?: boolean;
 }
 
-const lifetimeCoupledPids = new Set<number>();
-let lifetimeCleanupInstalled = false;
+interface LifetimeCleanupState {
+	pids: Set<number>;
+	installed: boolean;
+}
+
+// Vitest reloads modules inside a reused worker. Keep this registry on the
+// process so those module instances share one signal/exit listener set.
+const lifetimeStateKey = Symbol.for("pi-lens.safe-spawn.lifetime-state");
+const processWithLifetimeState = process as typeof process & {
+	[lifetimeStateKey]?: LifetimeCleanupState;
+};
+const lifetimeState =
+	processWithLifetimeState[lifetimeStateKey] ??
+	(processWithLifetimeState[lifetimeStateKey] = {
+		pids: new Set<number>(),
+		installed: false,
+	});
 
 function killPidTreeSync(pid: number): void {
 	if (process.platform === "win32") {
@@ -91,14 +106,14 @@ function killPidTreeSync(pid: number): void {
 }
 
 function installLifetimeCleanup(): void {
-	if (lifetimeCleanupInstalled) return;
-	lifetimeCleanupInstalled = true;
+	if (lifetimeState.installed) return;
+	lifetimeState.installed = true;
 	process.once("exit", () => {
-		for (const pid of lifetimeCoupledPids) killPidTreeSync(pid);
+		for (const pid of lifetimeState.pids) killPidTreeSync(pid);
 	});
 	for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as NodeJS.Signals[]) {
 		process.once(signal, () => {
-			for (const pid of lifetimeCoupledPids) killPidTreeSync(pid);
+			for (const pid of lifetimeState.pids) killPidTreeSync(pid);
 			process.kill(process.pid, signal);
 		});
 	}
@@ -470,7 +485,7 @@ export async function safeSpawnAsync(
 		});
 		if (options?.lifetimeCoupled && child.pid) {
 			installLifetimeCleanup();
-			lifetimeCoupledPids.add(child.pid);
+			lifetimeState.pids.add(child.pid);
 		}
 
 		// #620: bracket this spawn's lifetime with a short-interval CPU/RSS poll
@@ -571,7 +586,7 @@ export async function safeSpawnAsync(
 		child.on("close", async (code, signal) => {
 			clearTimeout(timeoutId);
 			abortSignal?.removeEventListener("abort", onAbort);
-			if (child.pid) lifetimeCoupledPids.delete(child.pid);
+			if (child.pid) lifetimeState.pids.delete(child.pid);
 			await killPromise;
 			const resourceUsage = finishResourceUsage();
 
@@ -601,7 +616,7 @@ export async function safeSpawnAsync(
 		child.on("error", (err) => {
 			clearTimeout(timeoutId);
 			abortSignal?.removeEventListener("abort", onAbort);
-			if (child.pid) lifetimeCoupledPids.delete(child.pid);
+			if (child.pid) lifetimeState.pids.delete(child.pid);
 			const resourceUsage = finishResourceUsage();
 			resolve({ stdout, stderr, status: null, error: err, resourceUsage });
 		});

--- a/mcp/analyze-cli.ts
+++ b/mcp/analyze-cli.ts
@@ -94,6 +94,9 @@ async function main(): Promise<void> {
 			registerTurnState: true,
 		});
 	}
+	// One-shot consumers cannot rely on the installer's unref'd debounce.
+	const { flushProbeCache } = await import("../clients/installer/index.js");
+	await flushProbeCache();
 
 	if (result.counts.diagnostics === 0) process.exit(0); // clean → no noise
 

--- a/tests/clients/installer/installer-lifecycle.integration.test.ts
+++ b/tests/clients/installer/installer-lifecycle.integration.test.ts
@@ -1,0 +1,179 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { removeTempDirSync } from "../test-utils.js";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-installer-945-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function writeFakeNpm(dir: string): {
+	binDir: string;
+	counter: string;
+	script: string;
+} {
+	const binDir = path.join(dir, "fake-bin");
+	const counter = path.join(dir, "installs.log");
+	fs.mkdirSync(binDir, { recursive: true });
+	const script = path.join(binDir, "fake-npm.cjs");
+	fs.writeFileSync(
+		script,
+		[
+			'const fs = require("node:fs");',
+			'const path = require("node:path");',
+			'const { spawn } = require("node:child_process");',
+			'fs.appendFileSync(process.env.FAKE_NPM_COUNTER, "install\\n");',
+			'if (process.env.FAKE_NPM_SLOW === "1") {',
+			' const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });',
+			' fs.writeFileSync(process.env.FAKE_NPM_CHILD_PID, String(child.pid));',
+			' setInterval(() => {}, 1000);',
+			'} else {',
+			' const bin = path.join(process.env.PI_LENS_HOME, "tools", "node_modules", ".bin");',
+			' fs.mkdirSync(bin, { recursive: true });',
+			process.platform === "win32"
+				? ' fs.writeFileSync(path.join(bin, "oxlint.cmd"), "@echo off\\r\\necho oxlint 1.0.0\\r\\n");'
+				: ' fs.writeFileSync(path.join(bin, "oxlint"), "#!/bin/sh\\necho oxlint 1.0.0\\n", { mode: 0o750 });',
+			'}',
+		].join("\n"),
+	);
+	if (process.platform === "win32") {
+		fs.writeFileSync(
+			path.join(binDir, "npm.cmd"),
+			`@echo off\r\n"${process.execPath}" "${script}" %*\r\n`,
+		);
+	} else {
+		fs.writeFileSync(
+			path.join(binDir, "npm"),
+			`#!/bin/sh\nexec "${process.execPath}" "${script}" "$@"\n`,
+			{ mode: 0o750 },
+		);
+	}
+	return { binDir, counter, script };
+}
+
+function runEnsure(env: NodeJS.ProcessEnv): Promise<{
+	code: number | null;
+	stdout: string;
+	stderr: string;
+}> {
+	const program =
+		'import("./clients/installer/index.js").then(async m => {' +
+		'const value = await m.ensureTool("oxlint"); await new Promise(r => setTimeout(r, 500));' +
+		'const fs = await import("node:fs"); const path = await import("node:path");' +
+		'let log = ""; try { log = fs.readFileSync(path.join(process.env.PI_LENS_HOME, "sessionstart.log"), "utf8"); } catch {}' +
+		'console.log(JSON.stringify({ value, log, reason: m.getInstallFailureReason("oxlint") }));' +
+		"}).catch(e => { console.error(e); process.exitCode = 1; });";
+	return new Promise((resolve) => {
+		const child = spawn(process.execPath, ["-e", program], {
+			cwd: process.cwd(),
+			env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout.on("data", (data) => (stdout += data));
+		child.stderr.on("data", (data) => (stderr += data));
+		child.on("close", (code) => resolve({ code, stdout, stderr }));
+	});
+}
+
+function testEnv(
+	home: string,
+	counter: string,
+	script: string,
+): NodeJS.ProcessEnv {
+	const nodeDir = path.dirname(process.execPath);
+	const toolPath = nodeDir;
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		PI_LENS_HOME: home,
+		PI_LENS_DISABLE_TOOL_INSTALL: "0",
+		PI_LENS_DEBUG: "1",
+		PI_LENS_TEST_MODE: "1",
+		PI_LENS_TEST_NPM_SCRIPT: script,
+		FAKE_NPM_COUNTER: counter,
+	};
+	for (const key of Object.keys(env)) {
+		if (key.toLowerCase() === "path") delete env[key];
+	}
+	env.PATH = toolPath;
+	return env;
+}
+
+function pidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) removeTempDirSync(dir);
+});
+
+describe("installer process lifecycle (#945)", () => {
+	it.skipIf(process.platform !== "win32")(
+		"kills a fake npm's complete Windows process tree on timeout",
+		async () => {
+			const root = tempDir();
+			const home = path.join(root, "home");
+			const childPidFile = path.join(root, "child.pid");
+			const { counter, script } = writeFakeNpm(root);
+			const result = await runEnsure({
+				...testEnv(home, counter, script),
+				FAKE_NPM_SLOW: "1",
+				FAKE_NPM_CHILD_PID: childPidFile,
+				PI_LENS_INSTALL_TIMEOUT_MS: "500",
+			});
+			expect(result.code).toBe(0);
+			expect(fs.existsSync(childPidFile), JSON.stringify(result)).toBe(true);
+			const childPid = Number(fs.readFileSync(childPidFile, "utf8"));
+			await new Promise((resolve) => setTimeout(resolve, 250));
+			expect(pidAlive(childPid)).toBe(false);
+		},
+	);
+
+	it("serializes two processes so exactly one package-manager install runs", async () => {
+		const root = tempDir();
+		const home = path.join(root, "home");
+		const { counter, script } = writeFakeNpm(root);
+		const env = testEnv(home, counter, script);
+		const results = await Promise.all([runEnsure(env), runEnsure(env)]);
+		expect(results.map((result) => result.code)).toEqual([0, 0]);
+		expect(fs.existsSync(counter), JSON.stringify(results)).toBe(true);
+		expect(fs.readFileSync(counter, "utf8").trim().split(/\r?\n/)).toHaveLength(1);
+		expect(results.every((result) => /oxlint/.test(result.stdout))).toBe(true);
+	});
+
+	it("reports disabled installation and never spawns the package manager", async () => {
+		const root = tempDir();
+		const home = path.join(root, "home");
+		const { counter, script } = writeFakeNpm(root);
+		const result = await runEnsure({
+			...testEnv(home, counter, script),
+			PI_LENS_DISABLE_TOOL_INSTALL: "1",
+		});
+		expect(result.code).toBe(0);
+		const payload = JSON.parse(result.stdout) as { reason?: string };
+		expect(payload.reason).toBe(
+			"installation disabled by PI_LENS_DISABLE_TOOL_INSTALL=1",
+		);
+		expect(fs.existsSync(counter)).toBe(false);
+	});
+
+	it("ordinary Vitest execution has tool installation disabled", () => {
+		expect(process.env.PI_LENS_DISABLE_TOOL_INSTALL).toBe("1");
+	});
+
+	// A literal parent-exit orphan test is intentionally omitted: racing the test
+	// harness against Windows process teardown is flaky. The deterministic timeout
+	// case above exercises the same taskkill /T descendant-tree primitive.
+});

--- a/tests/clients/installer/tool-discovery.test.ts
+++ b/tests/clients/installer/tool-discovery.test.ts
@@ -81,6 +81,13 @@ const mockFsStat = vi.hoisted(() => vi.fn());
 const mockFsWriteFile = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockFsMkdir = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockFsAppendFile = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockFsOpen = vi.hoisted(() =>
+	vi.fn().mockResolvedValue({
+		writeFile: vi.fn().mockResolvedValue(undefined),
+		close: vi.fn().mockResolvedValue(undefined),
+	}),
+);
+const mockFsRm = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock("node:fs/promises", () => ({
 	default: {
@@ -90,6 +97,8 @@ vi.mock("node:fs/promises", () => ({
 		writeFile: mockFsWriteFile,
 		mkdir: mockFsMkdir,
 		appendFile: mockFsAppendFile,
+		open: mockFsOpen,
+		rm: mockFsRm,
 	},
 	readFile: mockFsReadFile,
 	access: mockFsAccess,
@@ -97,6 +106,8 @@ vi.mock("node:fs/promises", () => ({
 	writeFile: mockFsWriteFile,
 	mkdir: mockFsMkdir,
 	appendFile: mockFsAppendFile,
+	open: mockFsOpen,
+	rm: mockFsRm,
 }));
 
 // ── child_process spawn mock ────────────────────────────────────────────

--- a/tests/clients/installer/tool-discovery.test.ts
+++ b/tests/clients/installer/tool-discovery.test.ts
@@ -217,6 +217,7 @@ async function withEmptyPath<T>(fn: () => Promise<T>): Promise<T> {
 const savedPiLensHome = process.env.PI_LENS_HOME;
 
 beforeEach(() => {
+	delete process.env.PI_LENS_DISABLE_TOOL_INSTALL;
 	delete process.env.PI_LENS_HOME;
 	vi.clearAllMocks();
 	spawnCalls.length = 0;
@@ -229,6 +230,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	process.env.PI_LENS_DISABLE_TOOL_INSTALL = "1";
 	if (savedPiLensHome === undefined) delete process.env.PI_LENS_HOME;
 	else process.env.PI_LENS_HOME = savedPiLensHome;
 	vi.useRealTimers();

--- a/tests/clients/installer/version-drift.test.ts
+++ b/tests/clients/installer/version-drift.test.ts
@@ -73,6 +73,13 @@ const mockFsReadFile = vi.hoisted(() => vi.fn());
 const mockFsStat = vi.hoisted(() => vi.fn());
 const mockFsWriteFile = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockFsMkdir = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockFsOpen = vi.hoisted(() =>
+	vi.fn().mockResolvedValue({
+		writeFile: vi.fn().mockResolvedValue(undefined),
+		close: vi.fn().mockResolvedValue(undefined),
+	}),
+);
+const mockFsRm = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockFsAppendFile = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockFsChmod = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
@@ -83,6 +90,8 @@ vi.mock("node:fs/promises", () => ({
 		stat: mockFsStat,
 		writeFile: mockFsWriteFile,
 		mkdir: mockFsMkdir,
+		open: mockFsOpen,
+		rm: mockFsRm,
 		appendFile: mockFsAppendFile,
 		chmod: mockFsChmod,
 	},
@@ -91,6 +100,8 @@ vi.mock("node:fs/promises", () => ({
 	stat: mockFsStat,
 	writeFile: mockFsWriteFile,
 	mkdir: mockFsMkdir,
+	open: mockFsOpen,
+	rm: mockFsRm,
 	appendFile: mockFsAppendFile,
 	chmod: mockFsChmod,
 }));

--- a/tests/clients/installer/version-drift.test.ts
+++ b/tests/clients/installer/version-drift.test.ts
@@ -211,6 +211,7 @@ function fakeAccess(...allowed: string[]): void {
 const savedPiLensHome = process.env.PI_LENS_HOME;
 
 beforeEach(() => {
+	delete process.env.PI_LENS_DISABLE_TOOL_INSTALL;
 	delete process.env.PI_LENS_HOME;
 	vi.clearAllMocks();
 	spawnCalls.length = 0;
@@ -222,6 +223,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	process.env.PI_LENS_DISABLE_TOOL_INSTALL = "1";
 	if (savedPiLensHome === undefined) delete process.env.PI_LENS_HOME;
 	else process.env.PI_LENS_HOME = savedPiLensHome;
 	vi.useRealTimers();

--- a/tests/clients/safe-spawn-windows-command.test.ts
+++ b/tests/clients/safe-spawn-windows-command.test.ts
@@ -54,7 +54,13 @@ describe("buildWindowsShellCommand (Windows cmd.exe quoting — #214)", () => {
 
 describe("safeSpawnAsync command-line injection regression (#17)", () => {
 	it("does not execute shell syntax supplied as an argument", async () => {
-		const result = await safeSpawnAsync("echo", ["safe & echo INJECTED"]);
+		// Use a real executable on every platform; `echo` is only a cmd.exe shell
+		// builtin on Windows and therefore cannot exercise direct safe spawning.
+		const result = await safeSpawnAsync(process.execPath, [
+			"-e",
+			"console.log(process.argv[1])",
+			"safe & echo INJECTED",
+		]);
 		expect(result.error).toBeUndefined();
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain("safe & echo INJECTED");

--- a/tests/support/prewarm-tool-home.ts
+++ b/tests/support/prewarm-tool-home.ts
@@ -1,21 +1,8 @@
-// Global setup: seed a shared managed-tools template once per suite run.
-//
-// Every worker gets a fresh empty PI_LENS_HOME (vitest-setup.ts), so any test
-// that drives the real analyze pipeline (mcp/analyze-cli, the MCP server
-// smokes) used to pay a cold `ensureTool("oxlint")` npm install PER WORKER —
-// seconds each, network-dependent, and the source of wild run-to-run variance
-// (one analyze-cli file run measured 14s vs 47s on install luck alone). Build
-// the install once into a lockfile-keyed template under os.tmpdir() and hand
-// workers its probe-cache.json; ensureTool's probe-cache fast path then
-// resolves the template's binaries (read-only, safe to share) with zero
-// spawns. If the seed fails (offline), workers just fall back to the old
-// cold-install behavior.
-import { spawnSync } from "node:child_process";
+// Global setup: seed a synthetic, network-free oxlint tool template once.
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { removeTempDirSync } from "../clients/test-utils.js";
 
 // Under the installer's 24h probe-cache TTL so a handed-out cache is never
 // already expired mid-run.
@@ -44,41 +31,33 @@ export default function prewarmToolHome(): void {
 		// no template yet — build one below
 	}
 
-	const seedDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-tools-seed-"));
-	try {
-		const fixture = path.join(seedDir, "seed.ts");
-		fs.writeFileSync(fixture, "console.log(1);\n");
-		const runSeed = () =>
-			spawnSync(
-				process.execPath,
-				[
-					path.join(repoRoot, "mcp", "analyze-cli.js"),
-					`--file=${fixture}`,
-					`--cwd=${seedDir}`,
-				],
-				{
-					env: {
-						...process.env,
-						PI_LENS_HOME: template,
-						PI_LENS_CONFIG_PATH: "/nonexistent-pi-lens-tests/config.json",
-					},
-					timeout: 120_000,
-					stdio: "ignore",
+	fs.mkdirSync(path.join(template, "bin"), { recursive: true });
+	const shim = path.join(
+		template,
+		"bin",
+		process.platform === "win32" ? "oxlint.cmd" : "oxlint",
+	);
+	fs.writeFileSync(
+		shim,
+		process.platform === "win32"
+			? "@echo off\r\nexit /b 0\r\n"
+			: "#!/bin/sh\nexit 0\n",
+		{ mode: 0o750 },
+	);
+	const stat = fs.statSync(shim);
+	fs.writeFileSync(
+		probeCache,
+		JSON.stringify(
+			{
+				oxlint: {
+					path: shim,
+					mtimeMs: stat.mtimeMs,
+					cachedAt: Date.now(),
 				},
-			);
-		runSeed();
-		// The installer's probe-cache flush is a 300ms unref'd debounce, so a
-		// fast exit can drop it; a second (now warm, discovery-only) run rewrites
-		// the entries and stays alive past the flush.
-		if (!fs.existsSync(probeCache)) runSeed();
-		if (fs.existsSync(probeCache)) {
-			process.env.PI_LENS_TEST_TOOLS_TEMPLATE = template;
-		} else {
-			console.warn(
-				"[prewarm-tool-home] seed analyze produced no probe-cache; workers run with cold tool homes",
-			);
-		}
-	} finally {
-		removeTempDirSync(seedDir);
-	}
+			},
+			null,
+			2,
+		),
+	);
+	process.env.PI_LENS_TEST_TOOLS_TEMPLATE = template;
 }

--- a/tests/support/vitest-setup.ts
+++ b/tests/support/vitest-setup.ts
@@ -9,6 +9,7 @@ import * as path from "node:path";
 // behaviour). Tests that exercise the throttle override this in their own body
 // and call `flushReviewGraphPersistsForTests()`.
 process.env.PI_LENS_GRAPH_PERSIST_DEBOUNCE_MS = "0";
+process.env.PI_LENS_DISABLE_TOOL_INSTALL = "1";
 
 // Same rationale, word index (#348 phase 2): per-edit updates schedule a
 // debounced persist through the shared project-snapshot file. Default to a

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "vitest/config";
 
+// Applies to globalSetup as well as workers: ordinary tests never install tools.
+process.env.PI_LENS_DISABLE_TOOL_INSTALL ??= "1";
+
 // Minimal config — vitest defaults (test discovery, pools, etc.) are preserved.
 // Additions:
 //  - globalSetup fails fast on a stale in-place build, so tests can't silently


### PR DESCRIPTION
Closes #945. Four commits:

- **`be3b6b71`**: npm/pip/gem/archive installer subprocesses are lifetime-coupled — awaited Windows `taskkill /F /T` tree termination on timeout, active-child registry with exit/signal cleanup (the safe-spawn discipline the installer had bypassed with raw `spawn(..., {shell:true})` + wrapper-only `proc.kill()`).
- **`09302de2`**: atomic cross-process lock over the shared tools tree — dead-owner recovery after confirmed PID death, bounded wait, post-acquire discovery recheck, `finally` release. Kills the concurrent-suite npm races (ENOTEMPTY class).
- **`0570e9cf`**: `PI_LENS_DISABLE_TOOL_INSTALL` with a distinct honest refusal reason; awaited probe-cache flush for one-shot consumers (no more unref'd 300ms timer loss); vitest globalSetup prewarm replaced with a network-free synthetic oxlint shim.
- **`b0407f7b`**: regressions — Windows process-tree kill leaves no survivors, two processes ensuring one tool → one install, disabled-install refusal, vitest env assertion.

Background: four orphaned `npm install --ignore-scripts oxlint` processes were found live on the maintainer's machine today, parents dead 20+ minutes, spawned by the test suite's networked prewarm through the uncoupled installer spawn.

Verification: lint green; focused suites 157/157; full suite 4,630 passed / 11 skipped / 1 known load-sensitive ast-grep flake (passes in isolation). `npm test` global setup performs zero network installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)