### PR TITLE
fix(rules): make unsafe-regex advisory and suppress escaped-before-assignment false positives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -600,6 +600,8 @@ The GitHub release body is derived from the curated `CHANGELOG.md` section for t
 
 **Rule catalogs.** `docs/ast-grep_rules_catalog.md` + `docs/tree-sitter_rules_catalog.md` list every bundled rule **per language** and are **generated** — edit the rule files, not the docs, then `npm run docs:rule-catalogs` (`scripts/gen-rule-catalogs.mjs`). A `--check` run (in `tests/scripts/rule-catalogs.test.ts`) fails if they drift. ast-grep covers pi-lens-authored (`rules/ast-grep-rules/rules/`) + vendored CodeRabbit (`coderabbit/rules/`); tree-sitter covers `rules/tree-sitter-queries/<language>/`.
 
+**Tree-sitter post-filters.** Query rules may use the TypeScript-side `applyPostFilter` seam for bounded same-file AST checks that predicates cannot express; batched and single-rule execution both pass the parsed root. New filters must be implemented in `clients/tree-sitter-client.ts` because unknown filters fail closed.
+
 ## Build & packaging: precompiled dist + resource resolution (hard-won — #182)
 
 pi-lens ships **precompiled JS**, not TypeScript source, so pi doesn't jiti-transpile ~200 files on every cold start (~3.5s → ~1.5s; the load cost is logged as `pi-lens loaded: <ms>ms … (from dist|source)` in `sessionstart.log` + `extension_loaded` in `latency.log`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Downgrade TypeScript `unsafe-regex` to advisory and suppress escaped-before-
+  assignment false positives** (refs #932) — the coarse dynamic `RegExp`
+  heuristic no longer blocks edits and recognizes escape/replace calls in a
+  same-file identifier initializer; structural ReDoS detection remains with
+  the `redos-nested-quantifier` ast-grep rule.
+
 - **Standalone out-of-band review-graph build CLI** (refs #924) — `npx pi-lens
 	build-graph [--cwd <dir>]` reuses the session builder and queued atomic
 	persist path for CI/cron, forces the debounced snapshot write before exit,

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -952,6 +952,7 @@ export class TreeSitterClient {
 								entry.postFilter,
 								entry.postFilterParams,
 								captures,
+								tree.rootNode,
 							)
 						) {
 							continue;
@@ -1494,6 +1495,7 @@ export class TreeSitterClient {
 		postFilter: string,
 		postFilterParams: any,
 		captures: Record<string, TreeSitterNode>,
+		rootNode?: TreeSitterNode,
 	): boolean {
 		/**
 		 * Extract the list of declared slot names from a class_definition's
@@ -1549,6 +1551,42 @@ export class TreeSitterClient {
 		}
 
 		switch (postFilter) {
+			case "unsafe_regex_dynamic_identifier": {
+				// unsafe-regex is intentionally a coarse advisory heuristic. When the
+				// interpolation is a plain identifier, recover the common safe-before-
+				// assignment pattern without pretending to perform whole-program dataflow:
+				// find that identifier's same-file variable initializer and look for an
+				// escape-like callee or a replace() call in it.
+				const interpolation = captures.INTERPOLATION?.text ?? "";
+				const identifier = interpolation.match(
+					/^\$\{\s*([A-Za-z_$][\w$]*)\s*\}$/,
+				)?.[1];
+				if (!identifier || !rootNode) return true;
+
+				const hasEscapeSignal = (text: string): boolean =>
+					/\b(?:escape|Escape)\w*\s*\(|\.\s*replace\s*\(/.test(text);
+				const stack: TreeSitterNode[] = [rootNode];
+				while (stack.length > 0) {
+					const node = stack.pop();
+					if (!node) continue;
+					if (node.type === "variable_declarator") {
+						const named = node.children.filter((child) => child.isNamed);
+						const name = named.find(
+							(child) =>
+								(child.type === "identifier" ||
+									child.type === "type_identifier") &&
+								child.text === identifier,
+						);
+						if (name) {
+							const nameIndex = named.indexOf(name);
+							const initializer = named[nameIndex + 1];
+							if (initializer && hasEscapeSignal(initializer.text)) return false;
+						}
+					}
+					stack.push(...node.children);
+				}
+				return true;
+			}
 			case "is_generator_with_valued_return": {
 				const returnNode = captures.RETURN;
 				const functionNode =
@@ -2597,7 +2635,12 @@ export class TreeSitterClient {
 
 						if (
 							postFilter &&
-							!this.applyPostFilter(postFilter, postFilterParams, captures)
+							!this.applyPostFilter(
+								postFilter,
+								postFilterParams,
+								captures,
+								tree.rootNode,
+							)
 						) {
 							continue;
 						}

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -74,6 +74,9 @@ interface TreeSitterNode {
 	startPosition: { row: number; column: number };
 	startIndex: number;
 	endIndex: number;
+	/** web-tree-sitter field accessor — optional so mock nodes in tests
+	 * without field support still satisfy the interface. */
+	childForFieldName?: (field: string) => TreeSitterNode | null;
 }
 
 interface TreeSitterParserInstance {
@@ -1554,38 +1557,65 @@ export class TreeSitterClient {
 			case "unsafe_regex_dynamic_identifier": {
 				// unsafe-regex is intentionally a coarse advisory heuristic. When the
 				// interpolation is a plain identifier, recover the common safe-before-
-				// assignment pattern without pretending to perform whole-program dataflow:
-				// find that identifier's same-file variable initializer and look for an
-				// escape-like callee or a replace() call in it.
-				const interpolation = captures.INTERPOLATION?.text ?? "";
-				const identifier = interpolation.match(
-					/^\$\{\s*([A-Za-z_$][\w$]*)\s*\}$/,
-				)?.[1];
-				if (!identifier || !rootNode) return true;
+				// assignment pattern without pretending to perform whole-program
+				// dataflow. #949 review hardening: the LAST write (declarator or
+				// assignment) textually BEFORE the use decides — a later reassignment
+				// to user input un-suppresses, and an unrelated declaration after the
+				// use never suppresses. Initializers come from the "value" field (a
+				// type annotation is not an initializer), and bare .replace("a","b")
+				// is not escaping — only escape-named callees or .replace(/regex/
+				// count. Any internal error keeps the diagnostic: never silently
+				// suppress via a filter crash, and a throw here would abort the whole
+				// file's batch.
+				try {
+					const interpolationNode = captures.INTERPOLATION;
+					const interpolation = interpolationNode?.text ?? "";
+					const identifier = interpolation.match(
+						/^\$\{\s*([A-Za-z_$][\w$]*)\s*\}$/,
+					)?.[1];
+					if (!identifier || !rootNode || !interpolationNode) return true;
+					const useRow = interpolationNode.startPosition.row;
 
-				const hasEscapeSignal = (text: string): boolean =>
-					/\b(?:escape|Escape)\w*\s*\(|\.\s*replace\s*\(/.test(text);
-				const stack: TreeSitterNode[] = [rootNode];
-				while (stack.length > 0) {
-					const node = stack.pop();
-					if (!node) continue;
-					if (node.type === "variable_declarator") {
-						const named = node.children.filter((child) => child.isNamed);
-						const name = named.find(
-							(child) =>
-								(child.type === "identifier" ||
-									child.type === "type_identifier") &&
-								child.text === identifier,
-						);
-						if (name) {
-							const nameIndex = named.indexOf(name);
-							const initializer = named[nameIndex + 1];
-							if (initializer && hasEscapeSignal(initializer.text)) return false;
+					const hasEscapeSignal = (text: string): boolean =>
+						/\b(?:escape|Escape)\w*\s*\(/.test(text) ||
+						/\.\s*replace\s*\(\s*\//.test(text);
+
+					// Track the last write to the identifier before the use site.
+					let lastWriteRow = -1;
+					let lastWriteSafe = false;
+					const consider = (
+						row: number,
+						valueText: string | undefined,
+					): void => {
+						if (row >= useRow || row < lastWriteRow) return;
+						lastWriteRow = row;
+						lastWriteSafe =
+							valueText !== undefined && hasEscapeSignal(valueText);
+					};
+
+					const stack: TreeSitterNode[] = [rootNode];
+					while (stack.length > 0) {
+						const node = stack.pop();
+						if (!node) continue;
+						if (node.type === "variable_declarator") {
+							const name = node.childForFieldName?.("name");
+							if (name?.text === identifier) {
+								const initializer = node.childForFieldName?.("value");
+								consider(node.startPosition.row, initializer?.text);
+							}
+						} else if (node.type === "assignment_expression") {
+							const left = node.childForFieldName?.("left");
+							if (left?.type === "identifier" && left.text === identifier) {
+								const right = node.childForFieldName?.("right");
+								consider(node.startPosition.row, right?.text);
+							}
 						}
+						stack.push(...node.children);
 					}
-					stack.push(...node.children);
+					return lastWriteRow >= 0 && lastWriteSafe ? false : true;
+				} catch {
+					return true;
 				}
-				return true;
 			}
 			case "is_generator_with_valued_return": {
 				const returnNode = captures.RETURN;

--- a/docs/tree-sitter_rules_catalog.md
+++ b/docs/tree-sitter_rules_catalog.md
@@ -239,7 +239,7 @@ Rule source: `rules/tree-sitter-queries/<language>/`.
 | `ts-ssrf` | error | security | Potential SSRF sink — validate and allowlist outbound URLs |
 | `ts-weak-hash` | error | security | Weak hash primitive selected (md5/sha1) — use sha256+ for security-sensitive contexts |
 | `ts-xss-dom-sink` | error | security | XSS risk — dynamic value written to innerHTML/outerHTML or document.write() |
-| `unsafe-regex` | error | security | Dynamic regex from user input — can cause ReDoS (Regular Expression Denial of Service) |
+| `unsafe-regex` | warning | security | Dynamic regex from user input — can cause ReDoS (Regular Expression Denial of Service) |
 | `variable-shadowing` | warning | maintainability | Variable '{{NAME}}' shadows a parameter — use a distinct name |
 
 ## Disabled rules

--- a/rules/tree-sitter-queries/typescript/unsafe-regex.yml
+++ b/rules/tree-sitter-queries/typescript/unsafe-regex.yml
@@ -2,10 +2,10 @@
 # Detects dynamic regex construction that can lead to ReDoS
 id: unsafe-regex
 name: Dynamic Regex Construction
-severity: error
+severity: warning
 category: security
 defect_class: injection
-inline_tier: blocking
+inline_tier: warning
 language: typescript
 
 message: "Dynamic regex from user input — can cause ReDoS (Regular Expression Denial of Service)"
@@ -43,6 +43,8 @@ metavars:
   - CTOR
   - INTERPOLATION
   - PATTERN
+
+post_filter: unsafe_regex_dynamic_identifier
 
 has_fix: false
 

--- a/tests/clients/tree-sitter-slop-rules.test.ts
+++ b/tests/clients/tree-sitter-slop-rules.test.ts
@@ -234,6 +234,55 @@ describe("slop detection rules", () => {
 			expect(matches).toHaveLength(0);
 		});
 
+		it("suppresses when the declarator has a type annotation (value field, not positional)", async () => {
+			const client = getSharedTreeSitterClient()!;
+			const query = await getQuery("unsafe-regex");
+			const filePath = writeTempFile(
+				"ts",
+				`const alternation: string = markers.map((m) => escapeRegExp(m)).join("|");
+				const r = new RegExp(\`\b(\${alternation})\b\`, "gi");`,
+			);
+			const matches = await client.runQueryOnFile(query, filePath, "typescript");
+			expect(matches).toHaveLength(0);
+		});
+
+		it("still flags when the identifier is reassigned to user input after escaping", async () => {
+			const client = getSharedTreeSitterClient()!;
+			const query = await getQuery("unsafe-regex");
+			const filePath = writeTempFile(
+				"ts",
+				`let alternation = escapeRegExp(seed);
+				alternation = req.query.q;
+				const r = new RegExp(\`\${alternation}\`, "gi");`,
+			);
+			const matches = await client.runQueryOnFile(query, filePath, "typescript");
+			expect(matches.length).toBeGreaterThan(0);
+		});
+
+		it("still flags when the only same-named safe declaration comes after the use", async () => {
+			const client = getSharedTreeSitterClient()!;
+			const query = await getQuery("unsafe-regex");
+			const filePath = writeTempFile(
+				"ts",
+				`function build(pat: string) { return new RegExp(\`\${pat}\`); }
+				const pat = escapeRegExp(seed);`,
+			);
+			const matches = await client.runQueryOnFile(query, filePath, "typescript");
+			expect(matches.length).toBeGreaterThan(0);
+		});
+
+		it("does not treat a plain string replace as escaping", async () => {
+			const client = getSharedTreeSitterClient()!;
+			const query = await getQuery("unsafe-regex");
+			const filePath = writeTempFile(
+				"ts",
+				`const pat = userInput.replace("a", "b");
+				const r = new RegExp(\`\${pat}\`);`,
+			);
+			const matches = await client.runQueryOnFile(query, filePath, "typescript");
+			expect(matches.length).toBeGreaterThan(0);
+		});
+
 		it("flags new RegExp with plain user-input interpolation", async () => {
 			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("unsafe-regex");

--- a/tests/clients/tree-sitter-slop-rules.test.ts
+++ b/tests/clients/tree-sitter-slop-rules.test.ts
@@ -215,7 +215,25 @@ describe("slop detection rules", () => {
 		});
 	});
 
-	describe("unsafe-regex", () => {
+		describe("unsafe-regex", () => {
+		it("is advisory rather than blocking", async () => {
+			const query = await getQuery("unsafe-regex");
+			expect(query.severity).toBe("warning");
+			expect(query.inline_tier).toBe("warning");
+		});
+
+		it("does not flag an escaped identifier initialized through map", async () => {
+			const client = getSharedTreeSitterClient()!;
+			const query = await getQuery("unsafe-regex");
+			const filePath = writeTempFile(
+				"ts",
+				`const alternation = markers.map((m) => escapeRegExp(m).replace(/\\\\s+/g, "\\\\s+")).join("|");
+				const r = new RegExp(\`\\\\b(\${alternation})\\\\b\`, "gi");`,
+			);
+			const matches = await client.runQueryOnFile(query, filePath, "typescript");
+			expect(matches).toHaveLength(0);
+		});
+
 		it("flags new RegExp with plain user-input interpolation", async () => {
 			const client = getSharedTreeSitterClient()!;
 			const query = await getQuery("unsafe-regex");


### PR DESCRIPTION
Closes #932.

The TS tree-sitter rule `unsafe-regex` (error / blocking) flagged any `new RegExp(`…${x}…`)` whose interpolation text lacked escape|Escape|replace — a hard blocker on the common, safe pattern where escaping happens one statement before interpolation (confirmed FP on vetted code in dogfooding: `markers.map(m => escapeRegExp(m).replace(...)).join("|")`).

Layered fix:
1. **Downgraded to warning / advisory tier** — real ReDoS structure detection lives in the ast-grep `redos-nested-quantifier` rule; a coarse dynamic-RegExp heuristic must not hard-block edits.
2. **TS-side post-filter** via the existing `TreeSitterClient.applyPostFilter` seam (batch-query-preserved): when the interpolated expression is a plain identifier, its same-file `variable_declarator` initializer is checked for escape/replace calls and the diagnostic suppressed — killing the escaped-before-assignment FP class while genuinely unsafe `new RegExp(`${userInput}`)` still flags.

Regressions cover the exact reported pattern (suppressed), unescaped user interpolation (still flags), and the rule's original safe examples. Rule catalog regenerated; AGENTS.md documents the post-filter seam for future rule authors.

Verification: build + lint green; focused rule/query/runner/catalog suites 76 passed; full suite 4,625 passed with 4 known environment flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)