### PR TITLE
feat(observability): session-start latency phase records + host-boot vs extension-eval split

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,13 +233,24 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   within any per-call budget** — surfaced honestly via the `lsp` signal, never a
   silent "clean" 0. warm + an indexed server is the LSP-complete path.
 - **LSP reset teardown is concurrent but fully awaited (#851).**
-  `LSPService.shutdown()` starts every retiring client shutdown before awaiting
-  `Promise.allSettled`, so the process-kill grace tail is bounded by the slowest
-  client while per-client failures remain best-effort. The #850/#852 generation
-  handoff still waits for that service teardown before replacement spawn.
+	`LSPService.shutdown()` starts every retiring client shutdown before awaiting
+	`Promise.allSettled`, so the process-kill grace tail is bounded by the slowest
+	client while per-client failures remain best-effort. The #850/#852 generation
+	handoff still waits for that service teardown before replacement spawn.
+  Its existing `lsp_service_reset` latency phase is emitted after teardown and
+  reports the real end-to-end reset duration (plus reason/alive-client metadata),
+  not a zero-duration initiation marker (#948).
   Client shutdown's fire-and-forget instance-registry removal is serialized at
   its read-modify-write seam so concurrent removals cannot lose siblings;
-  process-tree kills remain concurrent.
+	process-tree kills remain concurrent.
+- **Session-start timing is end-to-end attributable (#948).** `index.ts` imports
+  `clients/startup-marker.ts` first, then logs `host_boot`, `extension_eval`, and
+  the continuity `extension_loaded` record. Primary session starts pass the host
+  hook/bootstrap timestamps into `handleSessionStart`, which records pre-handler,
+  runtime-reset, cleanup, sequence/snapshot (with bytes/freshness/seq), total, and
+  delayed warmup child phases in `latency.log`; concurrent secondaries emit only
+  `concurrent_session_bind`. Keep logging fire-and-forget and preserve contiguous
+  top-level timing so quick-start child durations remain within ~10 ms of total.
 - **Incremental review-graph snapshots are immutable by replacement (#939).**
   `updateGraphFiles` performs all node/edge edits on a clone, rebuilds derived
   indexes once at the end, then stores that finished graph directly in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Session-start latency is attributable end to end** (refs #948) â€” latency
+	telemetry now separates host boot from pi-lens evaluation and records quick
+	and full session-start totals, pre-handler/bootstrap work, runtime reset,
+	log cleanup, LSP reset, sequence/snapshot reads (including snapshot bytes),
+	and delayed warmup scan/profile/index phases.
+
 - **Installer subprocesses are lifetime-coupled** (refs #945) — npm, pip, gem,
 	and archive extraction now use the shared safe-spawn path, await full Windows
 	process-tree termination on timeout, and synchronously clean registered

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -4026,6 +4026,7 @@ export class LSPService {
 	 * Shutdown all LSP clients
 	 */
 	async shutdown(options: LSPShutdownOptions = {}): Promise<void> {
+		const resetStartedAt = Date.now();
 		if (this.checkDestroyed()) return;
 		this.isDestroyed = true;
 
@@ -4049,19 +4050,6 @@ export class LSPService {
 		// snapshot of what was released by this reset (post-teardown the count
 		// would always be zero, which is useless for root-cause analysis).
 		const aliveClients = this.getAliveClientCount();
-		logLatency({
-			type: "phase",
-			phase: "lsp_service_reset",
-			filePath: "",
-			durationMs: 0,
-			metadata: {
-				reason: options.reason ?? null,
-				aliveClients,
-				fast: !!options.fast,
-				processExiting: !!options.processExiting,
-			},
-		});
-
 		// Start every client teardown before awaiting any of them. A non-fast
 		// process-tree kill can spend its grace period per client, so awaiting in
 		// map order makes the reset tail O(clientCount * grace) instead of the
@@ -4073,6 +4061,19 @@ export class LSPService {
 				Promise.resolve().then(() => client.shutdown(options)),
 			),
 		);
+		logLatency({
+			type: "phase",
+			phase: "lsp_service_reset",
+			filePath: "",
+			startedAt: new Date(resetStartedAt).toISOString(),
+			durationMs: Date.now() - resetStartedAt,
+			metadata: {
+				reason: options.reason ?? null,
+				aliveClients,
+				fast: !!options.fast,
+				processExiting: !!options.processExiting,
+			},
+		});
 		this.state.clients.clear();
 		this.state.broken.clear();
 		this.workspaceProbeLogged.clear();

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -74,6 +74,12 @@ import { isWarmAttached } from "./warm-attach.js";
 
 interface SessionStartDeps {
 	ctxCwd?: string;
+	/** Host hook timestamp, so total includes work before this handler is entered. */
+	sessionStartFiredAt?: number;
+	sessionReason?: string;
+	handlerEnteredAt?: number;
+	bootstrapClientsStartedAt?: number;
+	bootstrapClientsDurationMs?: number;
 	getFlag: (name: string) => boolean | string | undefined;
 	notify: (msg: string, level: "info" | "warning" | "error") => void;
 	dbg: (msg: string) => void;
@@ -1097,7 +1103,37 @@ export const SESSION_START_GUIDANCE: string[] = [
 export async function handleSessionStart(
 	deps: SessionStartDeps,
 ): Promise<void> {
-	const sessionStartMs = Date.now();
+	const handlerEnteredAt = Date.now();
+	const sessionStartMs = deps.sessionStartFiredAt ?? handlerEnteredAt;
+	const cwdForTelemetry = deps.ctxCwd ?? process.cwd();
+	if (
+		deps.bootstrapClientsStartedAt !== undefined &&
+		deps.bootstrapClientsDurationMs !== undefined
+	) {
+		logLatency({
+			type: "phase",
+			filePath: cwdForTelemetry,
+			phase: "bootstrap_clients_load",
+			startedAt: new Date(deps.bootstrapClientsStartedAt).toISOString(),
+			durationMs: deps.bootstrapClientsDurationMs,
+			metadata: {
+				parent: "session_start_prehandler",
+				reason: deps.sessionReason,
+			},
+		});
+	}
+	if (deps.sessionStartFiredAt !== undefined) {
+		logLatency({
+			type: "phase",
+			filePath: cwdForTelemetry,
+			phase: "session_start_prehandler",
+			startedAt: new Date(deps.sessionStartFiredAt).toISOString(),
+			durationMs:
+				(deps.handlerEnteredAt ?? handlerEnteredAt) -
+				deps.sessionStartFiredAt,
+			metadata: { reason: deps.sessionReason },
+		});
+	}
 	// Cold-start input-latency mitigation. The first `session_start` of
 	// the process — i.e. the one that fires immediately after the user
 	// launches `pi` — must return as fast as possible so the TUI input
@@ -1155,6 +1191,7 @@ export async function handleSessionStart(
 			void (async () => {
 				try {
 					warmupDbg("warmup: starting background warmup");
+					const scanContextStartedAt = Date.now();
 					// Dynamic imports keep the warmup pipeline off the hot
 					// startup path — these modules don't load until the timer
 					// fires, well after the TUI is interactive.
@@ -1184,7 +1221,6 @@ export async function handleSessionStart(
 							`warmup: scan-context reused from cache (canWarm=${scan.canWarmCaches}${scan.reason ? `, reason=${scan.reason}` : ""})`,
 						);
 					} else {
-						const scanContextStartedAt = Date.now();
 						scan =
 							await startupScanModule.resolveStartupScanContextAsync(warmupCwd);
 						logLatency({
@@ -1207,6 +1243,13 @@ export async function handleSessionStart(
 							dbg: warmupDbg,
 						});
 					}
+					logLatency({
+						type: "phase",
+						phase: "warmup_scan_context",
+						filePath: warmupCwd,
+						startedAt: new Date(scanContextStartedAt).toISOString(),
+						durationMs: Date.now() - scanContextStartedAt,
+					});
 					// Respect the startup-scan guard (#250): canWarmCaches is false for
 					// home-dir / no-project-root / too-many-source-files. Proceeding into
 					// the language-profile source walk in those cases lets it root at an
@@ -1227,6 +1270,13 @@ export async function handleSessionStart(
 					warmupDbg(
 						`warmup: language-profile done in ${Date.now() - languageProfileStartedAt}ms`,
 					);
+					logLatency({
+						type: "phase",
+						phase: "warmup_language_profile",
+						filePath: warmupCwd,
+						startedAt: new Date(languageProfileStartedAt).toISOString(),
+						durationMs: Date.now() - languageProfileStartedAt,
+					});
 					// #348: fold the word-index build/refresh into this existing
 					// cold-start warmup pass so quick-mode (and any session whose very
 					// first session_start is forced quick) still ends up with a
@@ -1244,11 +1294,26 @@ export async function handleSessionStart(
 					warmupDbg(
 						`warmup: word-index done in ${Date.now() - wordIndexStartedAt}ms`,
 					);
+					logLatency({
+						type: "phase",
+						phase: "warmup_word_index",
+						filePath: warmupCwd,
+						startedAt: new Date(wordIndexStartedAt).toISOString(),
+						durationMs: Date.now() - wordIndexStartedAt,
+					});
 					warmupDbg(`warmup: total ${Date.now() - warmupStartedAt}ms`);
 				} catch (err) {
 					warmupDbg(`warmup: error ${err}`);
 					// Allow a future session to retry the warmup.
 					processGlobals.__piLensWarmupScheduled = false;
+				} finally {
+					logLatency({
+						type: "phase",
+						phase: "warmup_total",
+						filePath: warmupCwd,
+						startedAt: new Date(warmupStartedAt).toISOString(),
+						durationMs: Date.now() - warmupStartedAt,
+					});
 				}
 			})();
 		}, warmupDelayMs);
@@ -1300,9 +1365,26 @@ export async function handleSessionStart(
 	// in a prior session, or a differently-scoped shell) is picked up fresh.
 	resetSafeSpawnWindowsCommandCache();
 	runtime.resetForSession(sessionStartMs);
+	logLatency({
+		type: "phase",
+		phase: "session_start_runtime_reset",
+		filePath: ctxCwd ?? process.cwd(),
+		startedAt: new Date(handlerEnteredAt).toISOString(),
+		durationMs: Date.now() - handlerEnteredAt,
+		metadata: { mode: startupMode, reason: deps.sessionReason },
+	});
 
 	// Run log cleanup early in session start (non-blocking)
+	const logCleanupStartedAt = Date.now();
 	const logCleanup = runLogCleanup(dbg);
+	logLatency({
+		type: "phase",
+		phase: "session_start_log_cleanup",
+		filePath: ctxCwd ?? process.cwd(),
+		startedAt: new Date(logCleanupStartedAt).toISOString(),
+		durationMs: Date.now() - logCleanupStartedAt,
+		metadata: { mode: startupMode, reason: deps.sessionReason },
+	});
 	if (logCleanup.cleaned > 0 || logCleanup.rotated > 0) {
 		notify(`🧹 ${logCleanup.report}`, "info");
 	}
@@ -1320,8 +1402,17 @@ export async function handleSessionStart(
 	const cwd = ctxCwd ?? process.cwd();
 	if (quickMode) {
 		runtime.projectRoot = cwd;
+		const sequenceReadStartedAt = Date.now();
 		const snapshotRoot = resolveSnapshotRoot(cwd);
 		const latestSeq = readLatestProjectSequence(snapshotRoot);
+		logLatency({
+			type: "phase",
+			phase: "session_start_sequence_read",
+			filePath: cwd,
+			startedAt: new Date(sequenceReadStartedAt).toISOString(),
+			durationMs: Date.now() - sequenceReadStartedAt,
+			metadata: { entries: latestSeq.fileSeqByPath.size },
+		});
 		runtime.seedProjectSequence?.(
 			latestSeq.projectSeq,
 			latestSeq.fileSeqByPath,
@@ -1330,14 +1421,35 @@ export async function handleSessionStart(
 		dbg(
 			`session_start sequence: projectSeq=${effectiveSeq} fileSeqEntries=${latestSeq.fileSeqByPath.size}`,
 		);
+		const snapshotLoadStartedAt = Date.now();
+		const snapshotPath = getProjectSnapshotPath(snapshotRoot);
+		let snapshotBytes = 0;
+		try {
+			snapshotBytes = nodeFs.statSync(snapshotPath).size;
+		} catch {
+			// Missing snapshots are the normal cold-start case.
+		}
 		const snapshot = loadProjectSnapshot(snapshotRoot);
+		const snapshotFresh = isProjectSnapshotFresh(snapshot, effectiveSeq);
+		logLatency({
+			type: "phase",
+			phase: "session_start_snapshot_load",
+			filePath: cwd,
+			startedAt: new Date(snapshotLoadStartedAt).toISOString(),
+			durationMs: Date.now() - snapshotLoadStartedAt,
+			metadata: {
+				bytes: snapshotBytes,
+				fresh: snapshotFresh,
+				seq: snapshot?.seq ?? null,
+			},
+		});
 		logProjectSnapshotProbe({
 			dbg,
 			root: snapshotRoot,
 			currentProjectSeq: effectiveSeq,
 			snapshot,
 		});
-		if (isProjectSnapshotFresh(snapshot, effectiveSeq)) {
+		if (snapshotFresh) {
 			hydrateRuntimeFromProjectSnapshot(runtime, snapshot);
 		}
 		const quickTools: string[] = [];
@@ -1359,7 +1471,7 @@ export async function handleSessionStart(
 			filePath: cwd,
 			startedAt: new Date(sessionStartMs).toISOString(),
 			durationMs: totalDurationMs,
-			metadata: { mode: startupMode },
+			metadata: { mode: startupMode, reason: deps.sessionReason },
 		});
 		return;
 	}
@@ -1378,24 +1490,52 @@ export async function handleSessionStart(
 		}
 	}
 
+	const sequenceReadStartedAt = Date.now();
 	const snapshotRoot = resolveSnapshotRoot(cwd);
 	const latestSeq = readLatestProjectSequence(snapshotRoot);
+	logLatency({
+		type: "phase",
+		phase: "session_start_sequence_read",
+		filePath: cwd,
+		startedAt: new Date(sequenceReadStartedAt).toISOString(),
+		durationMs: Date.now() - sequenceReadStartedAt,
+		metadata: { entries: latestSeq.fileSeqByPath.size },
+	});
 	runtime.seedProjectSequence?.(latestSeq.projectSeq, latestSeq.fileSeqByPath);
 	const effectiveSeq = runtime.projectSeq ?? latestSeq.projectSeq;
 	dbg(
 		`session_start sequence: projectSeq=${effectiveSeq} fileSeqEntries=${latestSeq.fileSeqByPath.size}`,
 	);
 
+	const snapshotLoadStartedAt = Date.now();
+	const snapshotPath = getProjectSnapshotPath(snapshotRoot);
+	let snapshotBytes = 0;
+	try {
+		snapshotBytes = nodeFs.statSync(snapshotPath).size;
+	} catch {
+		// Missing snapshots are the normal cold-start case.
+	}
 	const snapshot = loadProjectSnapshot(snapshotRoot);
+	const snapshotFresh = isProjectSnapshotFresh(snapshot, effectiveSeq);
+	logLatency({
+		type: "phase",
+		phase: "session_start_snapshot_load",
+		filePath: cwd,
+		startedAt: new Date(snapshotLoadStartedAt).toISOString(),
+		durationMs: Date.now() - snapshotLoadStartedAt,
+		metadata: {
+			bytes: snapshotBytes,
+			fresh: snapshotFresh,
+			seq: snapshot?.seq ?? null,
+		},
+	});
 	logProjectSnapshotProbe({
 		dbg,
 		root: snapshotRoot,
 		currentProjectSeq: effectiveSeq,
 		snapshot,
 	});
-	const freshSnapshot = isProjectSnapshotFresh(snapshot, effectiveSeq)
-		? snapshot
-		: null;
+	const freshSnapshot = snapshotFresh ? snapshot : null;
 	if (freshSnapshot) {
 		hydrateRuntimeFromProjectSnapshot(runtime, freshSnapshot);
 	}
@@ -1705,6 +1845,6 @@ export async function handleSessionStart(
 		filePath: cwd,
 		startedAt: new Date(sessionStartMs).toISOString(),
 		durationMs: totalDurationMs,
-		metadata: { mode: startupMode },
+		metadata: { mode: startupMode, reason: deps.sessionReason },
 	});
 }

--- a/clients/session-start-observability.ts
+++ b/clients/session-start-observability.ts
@@ -1,0 +1,20 @@
+import { logLatency } from "./latency-logger.js";
+
+/**
+ * The complete observability path for a concurrent secondary. It deliberately
+ * emits one bind record only: secondary sessions skip every primary reset and
+ * hydration phase.
+ */
+export function logConcurrentSessionBind(args: {
+	secondaryCount: number;
+	sessionReason?: string;
+	sameCwd: boolean;
+}): void {
+	logLatency({
+		type: "phase",
+		filePath: "<pi-lens>",
+		phase: "concurrent_session_bind",
+		durationMs: 0,
+		metadata: args,
+	});
+}

--- a/clients/startup-marker.ts
+++ b/clients/startup-marker.ts
@@ -1,0 +1,7 @@
+import { performance } from "node:perf_hooks";
+
+/**
+ * Earliest pi-lens evaluation marker. `index.ts` must import this module first
+ * so host boot and pi-lens's own module-graph evaluation remain attributable.
+ */
+export const PI_LENS_EVAL_STARTED_MS = performance.now();

--- a/clients/startup-timing.ts
+++ b/clients/startup-timing.ts
@@ -1,4 +1,5 @@
 import { performance } from "node:perf_hooks";
+import { PI_LENS_EVAL_STARTED_MS } from "./startup-marker.js";
 
 /**
  * Startup timing for pi-lens.
@@ -36,4 +37,14 @@ export function markPiLensLoaded(): number {
 /** ms from pi process start to pi-lens load-complete, or undefined if unmarked. */
 export function getPiLensLoadMs(): number | undefined {
 	return loadMs;
+}
+
+/** ms from host process start until pi-lens evaluation began. */
+export const PI_LENS_HOST_BOOT_MS = Math.round(PI_LENS_EVAL_STARTED_MS);
+
+/** pi-lens module-graph evaluation time once markPiLensLoaded() has run. */
+export function getPiLensEvalMs(): number | undefined {
+	return loadMs === undefined
+		? undefined
+		: Math.max(0, loadMs - PI_LENS_HOST_BOOT_MS);
 }

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import "./clients/startup-marker.js";
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -114,7 +115,9 @@ import { createProjectReportTool } from "./tools/project-report.js";
 import { createSymbolSearchTool } from "./tools/symbol-search.js";
 import { logLatency } from "./clients/latency-logger.js";
 import {
+	getPiLensEvalMs,
 	markPiLensLoaded,
+	PI_LENS_HOST_BOOT_MS,
 	PI_LENS_LOADED_FROM,
 } from "./clients/startup-timing.js";
 import { toRunnerDisplayPath } from "./clients/dispatch/runner-context.js";
@@ -129,10 +132,12 @@ import {
 	startEventLoopMonitor,
 } from "./clients/event-loop-monitor.js";
 import { logSessionStart } from "./clients/sessionstart-logger.js";
+import { logConcurrentSessionBind } from "./clients/session-start-observability.js";
 
 // First executable statement: every import above has been evaluated, so the
 // full load/transpile cost has been paid. Capture it now.
 const PI_LENS_LOAD_MS = markPiLensLoaded();
+const PI_LENS_EVAL_MS = getPiLensEvalMs() ?? 0;
 // Start the event-loop occupancy monitor as early as possible so startup
 // blocks are captured. Native histogram — no per-event overhead. (#192)
 startEventLoopMonitor();
@@ -172,6 +177,20 @@ logLatency({
 	filePath: "<pi-lens>",
 	phase: "extension_loaded",
 	durationMs: PI_LENS_LOAD_MS,
+	metadata: { loadedFrom: PI_LENS_LOADED_FROM },
+});
+logLatency({
+	type: "phase",
+	filePath: "<pi-lens>",
+	phase: "host_boot",
+	durationMs: PI_LENS_HOST_BOOT_MS,
+	metadata: { loadedFrom: PI_LENS_LOADED_FROM },
+});
+logLatency({
+	type: "phase",
+	filePath: "<pi-lens>",
+	phase: "extension_eval",
+	durationMs: PI_LENS_EVAL_MS,
 	metadata: { loadedFrom: PI_LENS_LOADED_FROM },
 });
 
@@ -1152,6 +1171,7 @@ export default function (pi: ExtensionAPI) {
 	// --- Events ---
 
 	pi.on("session_start", async (event, ctx) => {
+		const sessionStartFiredAt = Date.now();
 		try {
 			dbg("session_start fired");
 
@@ -1217,16 +1237,10 @@ export default function (pi: ExtensionAPI) {
 				dbg(
 					`session_start: concurrent secondary detected (count=${sessionStartDecision.secondaryCount}) — skipping handleSessionStart`,
 				);
-				logLatency({
-					type: "phase",
-					filePath: "<pi-lens>",
-					phase: "concurrent_session_bind",
-					durationMs: 0,
-					metadata: {
-						secondaryCount: sessionStartDecision.secondaryCount,
-						sessionReason,
-						sameCwd: (ctx as { cwd?: string })?.cwd === process.cwd(),
-					},
+				logConcurrentSessionBind({
+					secondaryCount: sessionStartDecision.secondaryCount,
+					sessionReason,
+					sameCwd: (ctx as { cwd?: string })?.cwd === process.cwd(),
 				});
 				return;
 			}
@@ -1295,6 +1309,7 @@ export default function (pi: ExtensionAPI) {
 				dbg(`lsp config init failed: ${cfgErr}`);
 			}
 
+			const bootstrapClientsStartedAt = Date.now();
 			const {
 				metricsClient,
 				todoScanner,
@@ -1312,8 +1327,16 @@ export default function (pi: ExtensionAPI) {
 				rustClient,
 				deadCodeClients,
 			} = await loadBootstrapClients();
+			const bootstrapClientsDurationMs =
+				Date.now() - bootstrapClientsStartedAt;
+			const handlerEnteredAt = Date.now();
 			await handleSessionStart({
 				ctxCwd: ctx.cwd,
+				sessionStartFiredAt,
+				sessionReason,
+				handlerEnteredAt,
+				bootstrapClientsStartedAt,
+				bootstrapClientsDurationMs,
 				getFlag: (name: string) => getLensFlag(name),
 				notify: (msg, level) => ctx.ui.notify(msg, level),
 				dbg,

--- a/tests/clients/session-start-observability.test.ts
+++ b/tests/clients/session-start-observability.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LatencyEntry } from "../../clients/latency-logger.js";
+
+const latencyEntries = vi.hoisted(() => [] as LatencyEntry[]);
+vi.mock("../../clients/latency-logger.js", () => ({
+	logLatency: (entry: LatencyEntry) => latencyEntries.push(entry),
+}));
+
+import { logConcurrentSessionBind } from "../../clients/session-start-observability.js";
+
+describe("session-start observability", () => {
+	beforeEach(() => {
+		latencyEntries.length = 0;
+	});
+
+	it("a concurrent secondary emits only its bind record", () => {
+		logConcurrentSessionBind({
+			secondaryCount: 1,
+			sessionReason: "fork",
+			sameCwd: true,
+		});
+
+		expect(latencyEntries).toEqual([
+			{
+				type: "phase",
+				filePath: "<pi-lens>",
+				phase: "concurrent_session_bind",
+				durationMs: 0,
+				metadata: {
+					secondaryCount: 1,
+					sessionReason: "fork",
+					sameCwd: true,
+				},
+			},
+		]);
+	});
+});

--- a/tests/clients/startup-overhead.test.ts
+++ b/tests/clients/startup-overhead.test.ts
@@ -20,9 +20,15 @@
  */
 
 import * as os from "node:os";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleSessionStart } from "../../clients/runtime-session.js";
+import type { LatencyEntry } from "../../clients/latency-logger.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+
+const latencyEntries = vi.hoisted(() => [] as LatencyEntry[]);
+vi.mock("../../clients/latency-logger.js", () => ({
+	logLatency: (entry: LatencyEntry) => latencyEntries.push(entry),
+}));
 
 const QUICK_MODE_BUDGET_MS = 100;
 const FULL_MODE_BUDGET_MS = 500;
@@ -113,6 +119,10 @@ afterEach(() => {
 });
 
 describe("startup overhead — interactive path regression guard", () => {
+	beforeEach(() => {
+		latencyEntries.length = 0;
+	});
+
 	it(`quick mode self-reports within ${QUICK_MODE_BUDGET_MS}ms`, async () => {
 		const env = setupTestEnvironment("pi-lens-overhead-quick-");
 		const restoreMode = setStartupMode("quick");
@@ -124,6 +134,71 @@ describe("startup overhead — interactive path regression guard", () => {
 			const reported = extractReportedMs(dbgLog);
 			expect(reported).not.toBeNull();
 			expect(reported).toBeLessThan(QUICK_MODE_BUDGET_MS);
+		} finally {
+			env.cleanup();
+			restoreMode();
+		}
+	});
+
+	it("quick mode emits attributable phases whose top-level durations account for total", async () => {
+		const env = setupTestEnvironment("pi-lens-overhead-records-");
+		const restoreMode = setStartupMode("quick");
+		const firedAt = Date.now() - 3;
+
+		try {
+			await handleSessionStart({
+				...makeDeps(env.tmpDir),
+				sessionStartFiredAt: firedAt,
+				handlerEnteredAt: firedAt + 2,
+				bootstrapClientsStartedAt: firedAt,
+				bootstrapClientsDurationMs: 1,
+				sessionReason: "startup",
+			});
+
+			const phases = new Map(
+				latencyEntries.map((entry) => [entry.phase, entry]),
+			);
+			expect([...phases.keys()]).toEqual(
+				expect.arrayContaining([
+					"bootstrap_clients_load",
+					"session_start_prehandler",
+					"session_start_runtime_reset",
+					"session_start_log_cleanup",
+					"session_start_sequence_read",
+					"session_start_snapshot_load",
+					"session_start_total",
+				]),
+			);
+			expect(phases.get("session_start_total")?.metadata).toEqual({
+				mode: "quick",
+				reason: "startup",
+			});
+			expect(phases.get("session_start_sequence_read")?.metadata).toEqual(
+				expect.objectContaining({ entries: expect.any(Number) }),
+			);
+			expect(phases.get("session_start_snapshot_load")?.metadata).toEqual(
+				expect.objectContaining({
+					bytes: expect.any(Number),
+					fresh: expect.any(Boolean),
+				}),
+			);
+
+			const topLevel = [
+				"session_start_prehandler",
+				"session_start_runtime_reset",
+				"session_start_log_cleanup",
+				"session_start_sequence_read",
+				"session_start_snapshot_load",
+			];
+			const childSum = topLevel.reduce(
+				(sum, phase) => sum + (phases.get(phase)?.durationMs ?? 0),
+				0,
+			);
+			expect(
+				Math.abs(
+					(phases.get("session_start_total")?.durationMs ?? 0) - childSum,
+				),
+			).toBeLessThanOrEqual(10);
 		} finally {
 			env.cleanup();
 			restoreMode();

--- a/tests/clients/startup-timing.test.ts
+++ b/tests/clients/startup-timing.test.ts
@@ -34,4 +34,13 @@ describe("startup-timing", () => {
 		const m = await freshModule();
 		expect(["dist", "source"]).toContain(m.PI_LENS_LOADED_FROM);
 	});
+
+	it("splits host boot from extension evaluation", async () => {
+		const m = await freshModule();
+		const total = m.markPiLensLoaded();
+		const evaluation = m.getPiLensEvalMs();
+		expect(m.PI_LENS_HOST_BOOT_MS).toBeGreaterThanOrEqual(0);
+		expect(evaluation).toBeGreaterThanOrEqual(0);
+		expect(m.PI_LENS_HOST_BOOT_MS + (evaluation ?? 0)).toBe(total);
+	});
 });


### PR DESCRIPTION
Closes #948.

latency.log previously had ZERO session-start phase records, and `extension_loaded` (median 6.2s) conflated pi host boot with pi-lens's own eval (~0.6s benched). New records (all buffered fire-and-forget — no awaits added to the critical path):

- `host_boot` / `extension_eval` split via a first-imported eval-start marker (keeps `extension_loaded` for continuity)
- `session_start_total` {mode, reason} on quick AND full paths
- `session_start_prehandler` + child `bootstrap_clients_load`, `session_start_runtime_reset` (added beyond the spec — the handler-entry→cleanup gap was otherwise unmeasured), `session_start_log_cleanup`
- `session_start_sequence_read` {entries} — now also covers project-root resolution, which the accounting test caught as a hidden ~64ms segment
- `session_start_snapshot_load` {bytes, fresh, seq} (byte-stat inside the phase so a slow fs lookup can't hide)
- `warmup_total` + scan-context / language-profile / word-index children
- `lsp_service_reset` now measures completed teardown
- Concurrent secondaries emit ONLY `concurrent_session_bind`

The child-sum-vs-total accounting is itself tested within 10ms tolerance — the acceptance criterion from the issue — and the phase set already earned its keep during development by exposing the unmeasured root-resolution segment.

Verification: build green; 69 lifecycle/runtime/latency/wiring tests + 4 startup-overhead/accounting tests green (the 100ms quick-start guard flakes under 8-suite concurrency, passes in isolation — pre-existing); lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)