### PR TITLE
fix(ast-grep): no-console rules skip CLI scripts and logger sinks (closes #965)

### DIFF
--- a/clients/dispatch/runners/ast-grep-napi.ts
+++ b/clients/dispatch/runners/ast-grep-napi.ts
@@ -14,6 +14,7 @@ import {
 	loadAstGrepNapi,
 	type SgRoot,
 } from "../../deps/ast-grep-napi.js";
+import { minimatch } from "../../deps/minimatch.js";
 import {
 	type AstGrepRuleSource,
 	getAstGrepRuleSources,
@@ -150,6 +151,27 @@ function explicitRuleFixSuggestion(rule: YamlRule): string | undefined {
 
 function normalizeRuleId(ruleId: string): string {
 	return ruleId.replace(/-js$/, "");
+}
+
+/**
+ * `filePath` relative to `root`, forward-slashed, for matching a rule's
+ * `ignores` globs (#965). Falls back to the absolute (slash-normalized) path
+ * when `filePath` isn't under `root` (e.g. an out-of-tree temp file), so a
+ * glob like `scripts/**` simply never matches rather than throwing.
+ */
+function relativeForIgnoreGlob(filePath: string, root: string): string {
+	const rel = path.relative(root, filePath);
+	return (rel.startsWith("..") ? filePath : rel).split(path.sep).join("/");
+}
+
+function matchesRuleIgnores(
+	filePath: string,
+	root: string,
+	patterns: string[] | undefined,
+): boolean {
+	if (!patterns || patterns.length === 0) return false;
+	const rel = relativeForIgnoreGlob(filePath, root);
+	return patterns.some((pattern) => minimatch(rel, pattern, { dot: true }));
 }
 
 export function canHandle(filePath: string): boolean {
@@ -328,7 +350,8 @@ export function evaluateAstGrepRules(
 
 	// Shared with the raw sgconfig materializer so both surfaces walk the same
 	// workspace-rooted sources in the same precedence order.
-	const ruleSources = getAstGrepRuleSources(options.projectRoot ?? cwd);
+	const ignoreRoot = options.projectRoot ?? cwd;
+	const ruleSources = getAstGrepRuleSources(ignoreRoot);
 
 	for (const source of ruleSources) {
 		let rules: YamlRule[];
@@ -364,6 +387,10 @@ export function evaluateAstGrepRules(
 			if (seenRuleIds.has(rule.id)) continue;
 			seenRuleIds.add(rule.id);
 			if (blockingOnly && rule.severity !== "error") continue;
+			// Per-rule path carve-out (#965): a rule that's noise on CLI scripts or
+			// a project's own logging sink (e.g. no-console-except-error firing
+			// inside scripts/** or lib/logger.ts) opts out via `ignores`.
+			if (matchesRuleIgnores(filePath, ignoreRoot, rule.ignores)) continue;
 
 			if (
 				suppressLinterOverlap &&

--- a/clients/dispatch/runners/tree-sitter.ts
+++ b/clients/dispatch/runners/tree-sitter.ts
@@ -7,6 +7,7 @@
 
 import * as path from "node:path";
 import { RuleCache } from "../../cache/rule-cache.js";
+import { minimatch } from "../../deps/minimatch.js";
 import { isTestFile } from "../../file-utils.js";
 import {
 	buildOrUpdateGraph,
@@ -355,6 +356,28 @@ function getTotalLinesChanged(
 /** Threshold: skip entity extraction for changes under 5 lines */
 const ENTITY_EXTRACTION_LINE_THRESHOLD = 5;
 
+/**
+ * `filePath` relative to `root`, forward-slashed, for matching a rule's
+ * `ignore_paths` globs. Falls back to the absolute (slash-normalized) path
+ * when `filePath` isn't under `root` (e.g. an out-of-tree temp file), so a
+ * glob like `scripts/**` simply never matches rather than throwing.
+ */
+function relativeForIgnoreGlob(filePath: string, root: string): string {
+	const rel = path.relative(root, filePath);
+	const normalized = (rel.startsWith("..") ? filePath : rel).split(path.sep).join("/");
+	return normalized;
+}
+
+function matchesIgnorePaths(
+	filePath: string,
+	root: string,
+	patterns: string[] | undefined,
+): boolean {
+	if (!patterns || patterns.length === 0) return false;
+	const rel = relativeForIgnoreGlob(filePath, root);
+	return patterns.some((pattern) => minimatch(rel, pattern, { dot: true }));
+}
+
 const treeSitterRunner: RunnerDefinition = {
 	id: "tree-sitter",
 	appliesTo: ["jsts", "python", "go", "rust", "ruby", "cxx", "csharp", "php", "css"],
@@ -463,6 +486,7 @@ const treeSitterRunner: RunnerDefinition = {
 					defect_class: q.defect_class,
 					inline_tier: q.inline_tier,
 					skip_test_files: q.skip_test_files,
+					ignore_paths: q.ignore_paths,
 					has_fix: q.has_fix,
 					fix_action: q.fix_action,
 					filePath: q.filePath,
@@ -491,11 +515,20 @@ const treeSitterRunner: RunnerDefinition = {
 		// python-assert-production — `assert` is the idiomatic test assertion) opt
 		// out via `skip_test_files` while the runner otherwise runs on test files.
 		const fileIsTest = isTestFile(filePath);
+		// Per-rule path carve-out (#965): a rule that's noise on CLI scripts or a
+		// project's own logging sink (e.g. no-console-except-error firing inside
+		// scripts/** or lib/logger.ts) opts out via `ignore_paths`, the same way
+		// `skip_test_files` opts a rule out of test files above.
+		const ignoreRoot = ctx.projectRoot ?? ctx.cwd;
 		const effectiveQueries = (
 			ctx.blockingOnly
 				? languageQueries.filter((q) => q.inline_tier !== "review")
 				: languageQueries
-		).filter((q) => !(fileIsTest && q.skip_test_files));
+		).filter(
+			(q) =>
+				!(fileIsTest && q.skip_test_files) &&
+				!matchesIgnorePaths(filePath, ignoreRoot, q.ignore_paths),
+		);
 
 		logTreeSitter({
 			phase: "queries_loaded",

--- a/clients/dispatch/runners/yaml-rule-parser.ts
+++ b/clients/dispatch/runners/yaml-rule-parser.ts
@@ -61,6 +61,17 @@ export interface YamlRule {
 	// through unchanged. Without it, `matches: <name>` can't resolve and the
 	// rule silently produces zero matches (#663).
 	utils?: Record<string, YamlRuleCondition>;
+	/**
+	 * Skip this rule on files whose path (relative to the project root,
+	 * forward-slashed) matches any of these glob patterns — e.g. a
+	 * `scripts` directory glob plus a `logger.ts` basename glob for a
+	 * debug-output rule that's expected to fire in CLI entry points and the
+	 * logging sink itself (#965). Mirrors the tree-sitter query loader's
+	 * `ignore_paths` field (`clients/tree-sitter-query-loader.ts`) — same
+	 * shape/matching, kept as a separate opt-in per-rule field rather than a
+	 * blanket path exclusion so most rules are unaffected.
+	 */
+	ignores?: string[];
 }
 
 interface CachedRules {

--- a/clients/tree-sitter-query-loader.ts
+++ b/clients/tree-sitter-query-loader.ts
@@ -149,6 +149,18 @@ export interface TreeSitterQuery {
 	 * matter there), so this is a deliberate per-rule carve-out.
 	 */
 	skip_test_files?: boolean;
+	/**
+	 * Skip this rule on files whose path (relative to the project root,
+	 * forward-slashed) matches any of these glob patterns — e.g. a
+	 * `scripts` directory glob plus a `logger.ts` basename glob for a
+	 * debug-output rule that's expected to fire in CLI entry points and the
+	 * logging sink itself (#965). Same shape/matching as the ast-grep YAML
+	 * rule `ignores` field (`clients/dispatch/runners/yaml-rule-parser.ts`)
+	 * — kept as a separate opt-in field (not reusing `skip_test_files`'s
+	 * boolean) since "is a test file" and "is a CLI script / logger" are
+	 * unrelated axes a rule may need independently.
+	 */
+	ignore_paths?: string[];
 	has_fix: boolean;
 	fix_action?: string;
 	examples?: {
@@ -290,6 +302,9 @@ export class TreeSitterQueryLoader {
 					? (String(parsed.inline_tier) as "blocking" | "warning" | "review")
 					: undefined,
 				skip_test_files: parsed.skip_test_files === true,
+				ignore_paths: Array.isArray(parsed.ignore_paths)
+					? parsed.ignore_paths.map(String)
+					: undefined,
 				// Parse predicates if present
 				predicates: Array.isArray(parsed.predicates)
 					? parsed.predicates.map((p: any) => ({

--- a/rules/ast-grep-rules/rules/no-console-except-error-js.yml
+++ b/rules/ast-grep-rules/rules/no-console-except-error-js.yml
@@ -6,6 +6,16 @@ note: |
   console.log/debug/warn usually indicate leftover debug output shipped to
   production. Allow console.error ONLY inside catch blocks (logging the
   error there is useful for production triage).
+  Console output IS the point in a CLI script's own stdout contract and in
+  a logging implementation's console fallback/sink — flagging it there
+  just trains users to ignore the rule; `ignores` below carves those paths
+  out while application/library code elsewhere still gets flagged (#965).
+ignores:
+  - "scripts/**"
+  - "bin/**"
+  - "**/logger.ts"
+  - "**/logger.js"
+  - "**/logger.mjs"
 rule:
   any:
     - pattern: console.error($$$)

--- a/rules/ast-grep-rules/rules/no-console-except-error.yml
+++ b/rules/ast-grep-rules/rules/no-console-except-error.yml
@@ -6,6 +6,16 @@ note: |
   console.log/debug/warn usually indicate leftover debug output shipped to
   production. Allow console.error ONLY inside catch blocks (logging the
   error there is useful for production triage).
+  Console output IS the point in a CLI script's own stdout contract and in
+  a logging implementation's console fallback/sink — flagging it there
+  just trains users to ignore the rule; `ignores` below carves those paths
+  out while application/library code elsewhere still gets flagged (#965).
+ignores:
+  - "scripts/**"
+  - "bin/**"
+  - "**/logger.ts"
+  - "**/logger.js"
+  - "**/logger.mjs"
 rule:
   any:
     - pattern: console.error($$$)

--- a/rules/tree-sitter-queries/typescript/console-statement.yml
+++ b/rules/tree-sitter-queries/typescript/console-statement.yml
@@ -24,6 +24,17 @@ query: |
 
 post_filter: not_in_test_block  # skip test blocks — no-console-in-tests handles that case
 
+# Console output IS the point in a CLI script's own stdout contract and in a
+# logging implementation's console fallback/sink — flagging it there just
+# trains users to ignore the rule (#965). Application/library code outside
+# these paths still gets flagged.
+ignore_paths:
+  - "scripts/**"
+  - "bin/**"
+  - "**/logger.ts"
+  - "**/logger.js"
+  - "**/logger.mjs"
+
 metavars:
   - OBJ
   - METHOD

--- a/tests/clients/dispatch/runners/ast-grep-rule-ignores.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-rule-ignores.test.ts
@@ -1,0 +1,60 @@
+// #965: no-console-except-error should not flag CLI scripts or a logger
+// implementation's console fallback/sink, while still flagging accidental
+// console output in ordinary application source. Exercises the real
+// `ignores` glob carve-out (clients/dispatch/runners/ast-grep-napi.ts +
+// clients/dispatch/runners/yaml-rule-parser.ts) end to end through the
+// shipped no-console-except-error rule YAML.
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import astGrepNapiRunner from "../../../../clients/dispatch/runners/ast-grep-napi.js";
+import {
+	linesFor,
+	makeRealRunnerEnv,
+	napiFallbackHasTool,
+	type RealRunnerEnv,
+} from "../../../support/real-runner-ctx.js";
+
+vi.mock("../../../../clients/lsp/wait-policy/index.js", () => ({
+	resolveAstGrepNativeExe: () => undefined,
+}));
+
+let env: RealRunnerEnv;
+beforeAll(() => {
+	env = makeRealRunnerEnv({ hasTool: napiFallbackHasTool });
+});
+afterAll(() => env.cleanup());
+
+describe("no-console-except-error ignores CLI scripts and logger sinks (#965)", () => {
+	it("still flags accidental console.log in ordinary application source", async () => {
+		const { ctx } = env.addFile(
+			"src/widget.ts",
+			'console.log("leftover debug output");\n',
+		);
+		const result = await astGrepNapiRunner.run(ctx);
+		expect(linesFor(result.diagnostics, "no-console-except-error")).toEqual([
+			1,
+		]);
+	});
+
+	it("does not flag console output inside scripts/**", async () => {
+		const { ctx } = env.addFile(
+			"scripts/bench-startup.ts",
+			'console.log("benchmark result: 12ms");\n',
+		);
+		const result = await astGrepNapiRunner.run(ctx);
+		expect(linesFor(result.diagnostics, "no-console-except-error")).toEqual(
+			[],
+		);
+	});
+
+	it("does not flag console output inside a logger.ts implementation", async () => {
+		const { ctx } = env.addFile(
+			"lib/logger.ts",
+			'export function warn(msg: string) { console.warn(msg); }\n',
+		);
+		const result = await astGrepNapiRunner.run(ctx);
+		expect(linesFor(result.diagnostics, "no-console-except-error")).toEqual(
+			[],
+		);
+	});
+});


### PR DESCRIPTION
Closes #965. `no-console-except-error` / `console-statement` were flagging intentional `console` use in CLI scripts and the logger implementation itself. Adds a per-rule path carve-out seam to BOTH rule engines — `ignores` (ast-grep YAML) and `ignore_paths` (tree-sitter queries) — applied to `scripts/**`, `bin/**`, `**/logger.{ts,js,mjs}`. The rule still fires everywhere else. Verified: build + new `ast-grep-rule-ignores.test.ts` (3, through the real NAPI runner) + `ast-grep test` 251/251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)