### PR TITLE
fix(ast-grep): strict-(in)equality exempt == null / != null (closes #966)

### DIFF
--- a/rules/ast-grep-rules/rule-tests/strict-equality-js-test.yml
+++ b/rules/ast-grep-rules/rule-tests/strict-equality-js-test.yml
@@ -3,6 +3,9 @@ valid:
   - 'a === b'
   - 'a !== b'
   - 'a = b'
+  - 'value == null'
+  - 'null == value'
+  - 'value == undefined'
 invalid:
   - 'a == b'
   - 'a == "x"'

--- a/rules/ast-grep-rules/rule-tests/strict-equality-test.yml
+++ b/rules/ast-grep-rules/rule-tests/strict-equality-test.yml
@@ -3,6 +3,9 @@ valid:
   - 'a === b'
   - 'a !== b'
   - 'a = b'
+  - 'value == null'
+  - 'null == value'
+  - 'value == undefined'
 invalid:
   - 'a == b'
   - 'a == "x"'

--- a/rules/ast-grep-rules/rule-tests/strict-inequality-js-test.yml
+++ b/rules/ast-grep-rules/rule-tests/strict-inequality-js-test.yml
@@ -3,6 +3,9 @@ valid:
   - 'a !== b'
   - 'a === b'
   - 'a < b'
+  - 'value != null'
+  - 'null != value'
+  - 'value != undefined'
 invalid:
   - 'a != b'
   - 'a != "x"'

--- a/rules/ast-grep-rules/rule-tests/strict-inequality-test.yml
+++ b/rules/ast-grep-rules/rule-tests/strict-inequality-test.yml
@@ -3,6 +3,10 @@ valid:
   - 'a !== b'
   - 'a === b'
   - 'a < b'
+  - 'value != null'
+  - 'null != value'
+  - 'thinkingMap != null'
+  - 'value != undefined'
 invalid:
   - 'a != b'
   - 'a != "x"'

--- a/rules/ast-grep-rules/rules/strict-equality-js.yml
+++ b/rules/ast-grep-rules/rules/strict-equality-js.yml
@@ -5,6 +5,19 @@ severity: warning
 note: |
   == performs type coercion which leads to unexpected comparisons.
   Use === for strict equality checks.
+  EXCEPT `$X == null` / `$X == undefined` (and the reversed operand order):
+  `== null` is the canonical JS/TS idiom for "is null or undefined" —
+  rewriting it to `===` changes behavior by dropping the other nullish
+  case, which is a real bug, not a style fix (#966).
 rule:
-  pattern: $X == $Y
+  all:
+    - pattern: $X == $Y
+    - not:
+        any:
+          - has:
+              field: right
+              regex: "^(null|undefined)$"
+          - has:
+              field: left
+              regex: "^(null|undefined)$"
 fix: $X === $Y

--- a/rules/ast-grep-rules/rules/strict-equality.yml
+++ b/rules/ast-grep-rules/rules/strict-equality.yml
@@ -5,6 +5,19 @@ severity: warning
 note: |
   == performs type coercion which leads to unexpected comparisons.
   Use === for strict equality checks.
+  EXCEPT `$X == null` / `$X == undefined` (and the reversed operand order):
+  `== null` is the canonical JS/TS idiom for "is null or undefined" —
+  rewriting it to `===` changes behavior by dropping the other nullish
+  case, which is a real bug, not a style fix (#966).
 rule:
-  pattern: $X == $Y
+  all:
+    - pattern: $X == $Y
+    - not:
+        any:
+          - has:
+              field: right
+              regex: "^(null|undefined)$"
+          - has:
+              field: left
+              regex: "^(null|undefined)$"
 fix: $X === $Y

--- a/rules/ast-grep-rules/rules/strict-inequality-js.yml
+++ b/rules/ast-grep-rules/rules/strict-inequality-js.yml
@@ -5,6 +5,19 @@ severity: warning
 note: |
   != performs type coercion which leads to unexpected comparisons.
   Use !== for strict inequality checks.
+  EXCEPT `$X != null` / `$X != undefined` (and the reversed operand order):
+  `!= null` is the canonical JS/TS idiom for "is not null or undefined" —
+  rewriting it to `!==` changes behavior by dropping the other nullish
+  case, which is a real bug, not a style fix (#966).
 rule:
-  pattern: $X != $Y
+  all:
+    - pattern: $X != $Y
+    - not:
+        any:
+          - has:
+              field: right
+              regex: "^(null|undefined)$"
+          - has:
+              field: left
+              regex: "^(null|undefined)$"
 fix: $X !== $Y

--- a/rules/ast-grep-rules/rules/strict-inequality.yml
+++ b/rules/ast-grep-rules/rules/strict-inequality.yml
@@ -5,6 +5,19 @@ severity: warning
 note: |
   != performs type coercion which leads to unexpected comparisons.
   Use !== for strict inequality checks.
+  EXCEPT `$X != null` / `$X != undefined` (and the reversed operand order):
+  `!= null` is the canonical JS/TS idiom for "is not null or undefined" —
+  rewriting it to `!==` changes behavior by dropping the other nullish
+  case, which is a real bug, not a style fix (#966).
 rule:
-  pattern: $X != $Y
+  all:
+    - pattern: $X != $Y
+    - not:
+        any:
+          - has:
+              field: right
+              regex: "^(null|undefined)$"
+          - has:
+              field: left
+              regex: "^(null|undefined)$"
 fix: $X !== $Y


### PR DESCRIPTION
Closes #966. `strict-equality`/`strict-inequality` (and JS twins) flagged the intentional `== null`/`!= null` nullish idiom. Now exempts that exact pattern (either operand order) via a structural `has: field:left|right` check; every other loose comparison still fires. Verified: `ast-grep test` 251/251 (both-direction fixtures added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)