### PR TITLE
fix(project-diagnostics): knip no longer flags npm-overrides-only security pins (closes #968)

### DIFF
--- a/clients/knip-client.ts
+++ b/clients/knip-client.ts
@@ -53,6 +53,42 @@ const EMPTY_RESULT: Omit<KnipResult, "summary"> = {
 
 const ANALYSIS_TIMEOUT_MS = 30_000;
 
+/**
+ * Every package name referenced as a KEY (at any nesting depth — npm's
+ * `overrides` and pnpm's `pnpm.overrides` allow nested "for this dependency's
+ * sub-dependency" overrides) in `package.json`'s `overrides`, `resolutions`
+ * (Yarn's equivalent), or `pnpm.overrides` fields. These are the project's
+ * own explicit signal that a package is deliberately present to pin a
+ * resolution — not a source-imported dependency knip's import graph can see.
+ * Missing/malformed `package.json` degrades to an empty set (never throws) —
+ * this is a best-effort narrowing, not a required input.
+ */
+export function readOverridePinnedPackageNames(targetDir: string): Set<string> {
+	const names = new Set<string>();
+	let pkg: Record<string, unknown>;
+	try {
+		pkg = JSON.parse(
+			fs.readFileSync(path.join(targetDir, "package.json"), "utf-8"),
+		);
+	} catch {
+		return names;
+	}
+
+	const collectKeys = (value: unknown): void => {
+		if (!value || typeof value !== "object" || Array.isArray(value)) return;
+		for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+			names.add(key);
+			collectKeys(nested);
+		}
+	};
+
+	collectKeys(pkg.overrides);
+	collectKeys(pkg.resolutions);
+	collectKeys((pkg.pnpm as { overrides?: unknown } | undefined)?.overrides);
+
+	return names;
+}
+
 // --- Client ---
 
 export class KnipClient {
@@ -263,7 +299,45 @@ export class KnipClient {
 			};
 		}
 
-		return this.parseOutput(output);
+		return this.dropOverridePinnedDeps(this.parseOutput(output), targetDir);
+	}
+
+	/**
+	 * Drop `dependency`/`devDependency` issues for a package that's also
+	 * referenced as an npm `overrides` (or Yarn `resolutions` / pnpm
+	 * `pnpm.overrides`) key in this project's `package.json` (#968).
+	 *
+	 * A direct devDependency whose only job is pinning a vulnerable
+	 * transitive/peer resolution has no source import — that's WORKING AS
+	 * INTENDED, not dead code, and knip has no concept of "this dependency
+	 * exists only to satisfy an overrides entry" (it only sees imports).
+	 * `overrides`/`resolutions` are the project's own explicit, unambiguous
+	 * signal that the package is deliberately present — the same class of
+	 * signal `hardcoded-url`'s `SCREAMING_SNAKE_CASE` constant-name carve-out
+	 * and `ts-ssrf`'s constant-identifier carve-out lean on elsewhere in this
+	 * codebase — so this narrows the finding rather than suppressing
+	 * `dependency`/`devDependency` issues wholesale: a devDependency that
+	 * ISN'T also an overrides/resolutions key is still reported.
+	 */
+	private dropOverridePinnedDeps(
+		result: KnipResult,
+		targetDir: string,
+	): KnipResult {
+		if (result.unusedDeps.length === 0) return result;
+		const pinned = readOverridePinnedPackageNames(targetDir);
+		if (pinned.size === 0) return result;
+
+		const isPinnedDepIssue = (issue: KnipIssue): boolean =>
+			(issue.type === "dependency" || issue.type === "devDependency") &&
+			(pinned.has(issue.name) || (!!issue.package && pinned.has(issue.package)));
+
+		const issues = result.issues.filter((issue) => !isPinnedDepIssue(issue));
+		const unusedDeps = result.unusedDeps.filter(
+			(issue) => !isPinnedDepIssue(issue),
+		);
+		return unusedDeps.length === result.unusedDeps.length
+			? result
+			: { ...result, issues, unusedDeps };
 	}
 
 	private async getKnipEnvironment(targetDir: string): Promise<NodeJS.ProcessEnv> {

--- a/tests/clients/knip-client.test.ts
+++ b/tests/clients/knip-client.test.ts
@@ -3,7 +3,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { getProjectDataDir } from "../../clients/file-utils.js";
-import { KnipClient } from "../../clients/knip-client.js";
+import {
+	KnipClient,
+	readOverridePinnedPackageNames,
+} from "../../clients/knip-client.js";
 import { removeTempDirSync, setupTestEnvironment } from "./test-utils.js";
 
 vi.mock("../../clients/safe-spawn.js", () => ({
@@ -345,6 +348,91 @@ describe("knip-client", () => {
 		expect(result.issues).toHaveLength(1);
 		expect(result.unlistedDeps).toHaveLength(1);
 		expect(result.unlistedDeps[0].name).toBe("@acme/pkg");
+	});
+
+	it("readOverridePinnedPackageNames collects overrides/resolutions/pnpm.overrides keys (#968)", () => {
+		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-knip-overrides-");
+		try {
+			fs.writeFileSync(
+				path.join(tmpDir, "package.json"),
+				JSON.stringify({
+					name: "demo",
+					overrides: { "brace-expansion": "^2.0.0" },
+					resolutions: { protobufjs: "^7.6.5" },
+					pnpm: { overrides: { "nested-pkg": { "sub-pkg": "^1.0.0" } } },
+				}),
+			);
+
+			const names = readOverridePinnedPackageNames(tmpDir);
+			expect(names.has("brace-expansion")).toBe(true);
+			expect(names.has("protobufjs")).toBe(true);
+			expect(names.has("nested-pkg")).toBe(true);
+			expect(names.has("sub-pkg")).toBe(true);
+			expect(names.has("unrelated-pkg")).toBe(false);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("readOverridePinnedPackageNames degrades to an empty set on missing/malformed package.json", () => {
+		const tmpRoot = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-knip-overrides-missing-"),
+		);
+		try {
+			expect(readOverridePinnedPackageNames(tmpRoot).size).toBe(0);
+		} finally {
+			removeTempDirSync(tmpRoot);
+		}
+	});
+
+	it("does not report an unused devDependency that's also an overrides-only security pin (#968)", async () => {
+		const { tmpDir, cleanup } = setupTestEnvironment(
+			"pi-lens-knip-overrides-e2e-",
+		);
+		try {
+			fs.writeFileSync(
+				path.join(tmpDir, "package.json"),
+				JSON.stringify({
+					name: "demo",
+					overrides: { "brace-expansion": "^2.0.0" },
+					devDependencies: { "brace-expansion": "^2.0.0", "real-unused": "^1.0.0" },
+				}),
+			);
+
+			const safeSpawnMod = await import("../../clients/safe-spawn.js");
+			vi.mocked(safeSpawnMod.safeSpawnAsync).mockResolvedValueOnce({
+				error: null,
+				status: 0,
+				stdout: JSON.stringify({
+					issues: [
+						{
+							file: "package.json",
+							devDependencies: [
+								{ name: "brace-expansion" },
+								{ name: "real-unused" },
+							],
+						},
+					],
+				}),
+				stderr: "",
+			} as never);
+
+			const client = new KnipClient(false) as unknown as {
+				runAnalyze: (d: string) => Promise<{
+					unusedDeps: Array<{ name: string; type: string }>;
+					issues: unknown[];
+				}>;
+			};
+			const result = await client.runAnalyze(tmpDir);
+
+			// The overrides-pinned dep is dropped; a genuinely unused devDependency
+			// with no overrides entry still gets reported.
+			expect(result.unusedDeps.map((d) => d.name)).toEqual(["real-unused"]);
+			expect(result.issues).toHaveLength(1);
+		} finally {
+			cleanup();
+			vi.restoreAllMocks();
+		}
 	});
 
 	it("routes enumMembers into unusedExports (grouped format)", () => {


### PR DESCRIPTION
Closes #968. knip reported `dependency`/`devDependency` unused for packages present only to pin a transitive security fix via `overrides`/`resolutions`/`pnpm.overrides`. `knip-client.ts` now drops an unused-dep finding whose name is also a key in those maps (any nesting depth). Genuine unused deps still surface. Verified: build + `knip-client.test.ts` 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)