### PR TITLE
fix(fact-rules): unsafe-boundary recognizes fallback-via-assignment catch coverage (closes #969)

### DIFF
--- a/clients/dispatch/facts/try-catch-facts.ts
+++ b/clients/dispatch/facts/try-catch-facts.ts
@@ -2,6 +2,7 @@ import type { FactProvider } from "../fact-provider-types.js";
 import {
 	extractFactsFromTree,
 	firstChildOfType,
+	type TsNode,
 	walk,
 } from "./tree-sitter-facts.js";
 
@@ -21,6 +22,16 @@ export interface TryCatchSummary {
 	catchReturnsStructuredError: boolean;
 	/** Catch body is a documented intentional local fallback (has explaining comment) */
 	isDocumentedLocalFallback: boolean;
+	/**
+	 * Catch body mutates state (an assignment to an existing binding, e.g.
+	 * `tokenExpiresAt = Date.now() + FALLBACK_TTL`) as its fallback, rather
+	 * than rethrowing/logging/returning. This is a THIRD legitimate way a
+	 * catch clause can address "the exception is handled" — recognized
+	 * separately from `hasRethrow`/`hasLogging`/an explicit `return` because
+	 * none of those match a catch whose whole job is to fall back to a
+	 * degraded-but-working state via assignment (#969).
+	 */
+	catchHasFallbackAssignment: boolean;
 	/** Try body only reads/resolves local values — no async IO or side effects */
 	tryResolvesLocalValues: boolean;
 	/** Pattern: try { existsSync / statSync / readFileSync } catch { return default } */
@@ -30,6 +41,16 @@ export interface TryCatchSummary {
 }
 
 // --- Helpers ---
+
+/** Does `node`'s subtree contain an `assignment_expression` (`x = ...`, `x += ...`, …)? */
+function hasAssignmentExpression(node: TsNode | undefined): boolean {
+	if (!node) return false;
+	let found = false;
+	walk(node, (n) => {
+		if (n.type === "assignment_expression") found = true;
+	});
+	return found;
+}
 
 function isOnlyWhitespaceOrComments(text: string): boolean {
 	let stripped = text.replace(/\/\*[\s\S]*?\*\//g, "");
@@ -131,6 +152,7 @@ export const tryCatchFactProvider: FactProvider = {
 						STRUCTURED_ERROR_PATTERN.test(bodyText);
 					const isDocumentedLocalFallback =
 						EXPLAINING_COMMENT_PATTERN.test(bodyText);
+					const catchHasFallbackAssignment = hasAssignmentExpression(catchBody);
 
 					const catchLogsOnly =
 						hasLogging &&
@@ -159,6 +181,7 @@ export const tryCatchFactProvider: FactProvider = {
 						catchReturnsDefault,
 						catchReturnsStructuredError,
 						isDocumentedLocalFallback,
+						catchHasFallbackAssignment,
 						tryResolvesLocalValues,
 						isFilesystemExistenceProbe,
 						boundaryCategory,

--- a/clients/dispatch/rules/unsafe-boundary.ts
+++ b/clients/dispatch/rules/unsafe-boundary.ts
@@ -57,6 +57,12 @@ function hasCatchCoverage(fn: FunctionSummary, catches: TryCatchSummary[]): bool
 		if (c.hasRethrow || c.hasLogging || c.catchParam === null) return true;
 		// Catch body contains a return statement → structured error result
 		if (/\breturn\b/.test(c.bodyText)) return true;
+		// Catch body falls back by mutating existing state (e.g. extending a
+		// validity window on refresh failure) instead of rethrowing/logging/
+		// returning. That's still a real handler — the exception doesn't
+		// escape uncaught — just expressed via assignment rather than one of
+		// the three shapes above (#969).
+		if (c.catchHasFallbackAssignment) return true;
 		return false;
 	});
 }

--- a/tests/clients/dispatch/rules/unsafe-boundary.test.ts
+++ b/tests/clients/dispatch/rules/unsafe-boundary.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { FactStore } from "../../../../clients/dispatch/fact-store.js";
+import { functionFactProvider } from "../../../../clients/dispatch/facts/function-facts.js";
+import { tryCatchFactProvider } from "../../../../clients/dispatch/facts/try-catch-facts.js";
+import { unsafeBoundaryRule } from "../../../../clients/dispatch/rules/unsafe-boundary.js";
+import type { DispatchContext } from "../../../../clients/dispatch/types.js";
+import type { FileKind } from "../../../../clients/file-kinds.js";
+
+function makeCtx(filePath: string, facts: FactStore): DispatchContext {
+  return {
+    filePath,
+    cwd: "/tmp",
+    kind: "jsts" as FileKind,
+    fileRole: "source",
+    pi: { getFlag: () => undefined },
+    autofix: false,
+    deltaMode: false,
+    facts,
+    hasTool: async () => false,
+    log: () => {},
+  };
+}
+
+async function evaluate(filePath: string, content: string) {
+  const facts = new FactStore();
+  const ctx = makeCtx(filePath, facts);
+  facts.setFileFact(filePath, "file.content", content);
+  await functionFactProvider.run(ctx, facts);
+  await tryCatchFactProvider.run(ctx, facts);
+  return unsafeBoundaryRule.evaluate(ctx, facts);
+}
+
+describe("unsafeBoundaryRule", () => {
+  it("flags a genuinely uncovered async boundary call", async () => {
+    const content = `
+async function refreshToken(a: number, b: number, c: number, d: number, e: number) {
+  if (a) { if (b) { if (c) { if (d) { if (e) { console.log("deep"); } } } } }
+  return await fetch("https://example.com/refresh");
+}
+`;
+    const diagnostics = await evaluate("/tmp/uncovered.ts", content);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].rule).toBe("unsafe-boundary");
+  });
+
+  it("does not flag a nested catch that falls back via state mutation (#969)", async () => {
+    // Mirrors providers/qoder/auth.ts's refreshQoderToken shape: high
+    // complexity from an if/else branch structure, each branch wraps its
+    // IO call in a try/catch whose fallback is an assignment (extend
+    // validity) rather than a rethrow/log/return.
+    const content = `
+async function refreshQoderToken(a: number, b: number, c: number, d: number, e: number) {
+  let tokenExpiresAt = 0;
+  if (a) {
+    if (b) {
+      if (c) {
+        try {
+          credentialsFromPat(a);
+        } catch (err) {
+          tokenExpiresAt = Date.now() + 1000;
+        }
+      }
+    }
+  } else {
+    if (d) {
+      if (e) {
+        try {
+          await fetch("https://example.com/refresh");
+        } catch (err) {
+          tokenExpiresAt = Date.now() + 1000;
+        }
+      }
+    }
+  }
+  return tokenExpiresAt;
+}
+`;
+    const diagnostics = await evaluate("/tmp/covered.ts", content);
+    expect(diagnostics).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #969. `unsafe-boundary` missed a catch whose recovery is a plain state mutation (fallback assignment), reporting uncovered where coverage exists. Adds a `catchHasFallbackAssignment` fact; `hasCatchCoverage` now counts that as coverage. Verified: build + new `unsafe-boundary.test.ts` (2, both directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)