### PR TITLE
fix(fact-rules): async-noise exempts explicit Promise return type (closes #970)

### DIFF
--- a/clients/dispatch/facts/function-facts.ts
+++ b/clients/dispatch/facts/function-facts.ts
@@ -48,7 +48,7 @@ export interface FunctionSummary {
 	 * with a synchronous body) — `async` can't be dropped without breaking
 	 * the signature, so it isn't noise (#970).
 	 */
-	hasExplicitPromiseReturnType: boolean;
+	hasExplicitPromiseReturnType?: boolean;
 	/** McCabe cyclomatic complexity (branches + 1) */
 	cyclomaticComplexity: number;
 	/** Maximum control-flow nesting depth within the function */

--- a/clients/dispatch/facts/function-facts.ts
+++ b/clients/dispatch/facts/function-facts.ts
@@ -40,6 +40,15 @@ export interface FunctionSummary {
 	isPassThroughWrapper: boolean;
 	passThroughTarget?: string;
 	isBoundaryWrapper: boolean;
+	/**
+	 * The function/method declaration has an explicit `: Promise<...>` return
+	 * type annotation. An `async` function with no `await` but a declared
+	 * Promise return type is usually there to satisfy an interface/type
+	 * contract (e.g. implementing `ApiKeyAuth.resolve(): Promise<Result>`
+	 * with a synchronous body) — `async` can't be dropped without breaking
+	 * the signature, so it isn't noise (#970).
+	 */
+	hasExplicitPromiseReturnType: boolean;
 	/** McCabe cyclomatic complexity (branches + 1) */
 	cyclomaticComplexity: number;
 	/** Maximum control-flow nesting depth within the function */
@@ -298,6 +307,19 @@ function collectReceiverTypes(
 	return types;
 }
 
+/**
+ * Does this function/method declaration have an explicit `: Promise<...>`
+ * return type? The `type_annotation` for a return type is a DIRECT child of
+ * the function node itself (after `formal_parameters`, before the body) —
+ * distinct from a parameter's own `type_annotation`, which is nested inside
+ * `formal_parameters` and therefore invisible to `firstChildOfType` here.
+ */
+function hasExplicitPromiseReturnType(node: TsNode): boolean {
+	const returnType = firstChildOfType(node, "type_annotation");
+	if (!returnType) return false;
+	return /:\s*Promise\b/.test(returnType.text);
+}
+
 function hasAwaitInNode(node: TsNode): boolean {
 	let found = false;
 	walk(node, (n) => {
@@ -373,6 +395,7 @@ export const functionFactProvider: FactProvider = {
 						isPassThroughWrapper: passThrough.pass,
 						passThroughTarget: passThrough.target,
 						isBoundaryWrapper,
+						hasExplicitPromiseReturnType: hasExplicitPromiseReturnType(node),
 						cyclomaticComplexity: calcCyclomaticComplexity(body),
 						maxNestingDepth: calcMaxNestingDepth(body),
 						outgoingCalls: collectOutgoingCalls(body),

--- a/clients/dispatch/rules/async-noise.ts
+++ b/clients/dispatch/rules/async-noise.ts
@@ -27,6 +27,7 @@ export const asyncNoiseRule: FactRule = {
         !fn.hasAwait &&
         !fn.hasReturnAwaitCall &&
         !fn.isPassThroughWrapper &&
+        !fn.hasExplicitPromiseReturnType &&
         !ASYNC_INTERFACE_PATTERN.test(fn.name) &&
         // Skip single-statement functions — likely interface stubs or thin wrappers
         fn.statementCount > 1

--- a/tests/clients/dispatch/rules/async-noise.test.ts
+++ b/tests/clients/dispatch/rules/async-noise.test.ts
@@ -73,4 +73,48 @@ async function wrapper(v: number) {
     const diagnostics = asyncNoiseRule.evaluate(ctx, facts);
     expect(diagnostics).toHaveLength(0);
   });
+
+  it("does not flag an async function with an explicit Promise return type implementing an interface contract (#970)", async () => {
+    // Mirrors providers/kilo/kilo-auth.ts's resolveKiloApiKey: implements
+    // `ApiKeyAuth.resolve(): Promise<AuthResult | undefined>`. The body is
+    // synchronous (no await), but `async` is required by the declared
+    // Promise return type — dropping it is a type error, and
+    // `Promise.resolve(...)` is equivalent noise, not an improvement.
+    const filePath = "/tmp/resolve.ts";
+    const content = `
+async function resolveKiloApiKey(config: Config): Promise<AuthResult | undefined> {
+  if (!config.apiKey) {
+    return undefined;
+  }
+  return { apiKey: config.apiKey };
+}
+`;
+
+    const facts = new FactStore();
+    const ctx = makeCtx(filePath, facts);
+    facts.setFileFact(filePath, "file.content", content);
+    await functionFactProvider.run(ctx, facts);
+
+    const diagnostics = asyncNoiseRule.evaluate(ctx, facts);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("still flags async noise on a plain function with no Promise return type annotation", async () => {
+    const filePath = "/tmp/noise-multi.ts";
+    const content = `
+async function noisy(v: number) {
+  const a = v + 1;
+  return a * 2;
+}
+`;
+
+    const facts = new FactStore();
+    const ctx = makeCtx(filePath, facts);
+    facts.setFileFact(filePath, "file.content", content);
+    await functionFactProvider.run(ctx, facts);
+
+    const diagnostics = asyncNoiseRule.evaluate(ctx, facts);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].rule).toBe("async-noise");
+  });
 });


### PR DESCRIPTION
Closes #970. `async-noise` flagged Promise-returning callbacks that satisfy a required interface signature. Adds a `hasExplicitPromiseReturnType` fact from the declaration's own return-type annotation; the rule exempts it. Genuinely gratuitous async still fires. Verified: build + `async-noise.test.ts` 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)