### PR TITLE
fix(zizmor): honor native # zizmor: ignore[...] suppression (closes #971)

### DIFF
--- a/clients/dispatch/auxiliary-lsp.ts
+++ b/clients/dispatch/auxiliary-lsp.ts
@@ -99,6 +99,36 @@ export function isNosemgrepSuppressed(
 	);
 }
 
+/**
+ * zizmor's own native inline suppression: `# zizmor: ignore[audit-id[,audit-id]]`
+ * on the finding's own line (https://docs.zizmor.sh/usage/#ignoring-results —
+ * zizmor calls this "inline ignores"). Honoring it here mirrors
+ * `isNosemgrepSuppressed` for Opengrep — a per-finding suppression path a repo
+ * can reach for even without its own `zizmor.yml` (#971): e.g. a `# zizmor:
+ * ignore[artipacked]` on a checkout-only job's `actions/checkout` step, or
+ * `# zizmor: ignore[adhoc-packages]` on a `npm pack` tarball's local install
+ * line, both cases the audit has no way to tell "checkout-only, no artifact
+ * upload" or "this is testing our own just-built tarball" apart from a
+ * remote-package install without this local, human-authored signal.
+ */
+const ZIZMOR_IGNORE_RE = /#\s*zizmor:\s*ignore\[([^\]]+)\]/i;
+export function isZizmorIgnoreSuppressed(
+	d: LSPDiagnostic,
+	content: string,
+): boolean {
+	const startLine = d.range?.start?.line; // 0-based
+	if (startLine == null) return false;
+	const line = content.split("\n")[startLine];
+	if (!line) return false;
+	const match = ZIZMOR_IGNORE_RE.exec(line);
+	if (!match) return false;
+	const ruleId = String(d.code ?? "").toLowerCase();
+	return match[1]
+		.split(",")
+		.map((s) => s.trim().toLowerCase())
+		.includes(ruleId);
+}
+
 // #277 R7: every profile below used this exact same rule (ERROR-severity
 // findings block only when the workspace opted into curated/authored rules;
 // everything else stays advisory) — shared here instead of copy-pasted per
@@ -166,6 +196,11 @@ export const AUXILIARY_LSP_PROFILES: readonly AuxiliaryLspProfile[] = [
 		semantic: blockOnErrorWhenAllowed,
 		defectClass: (d) =>
 			classifyDefect(String(d.code ?? ""), "zizmor", d.message ?? ""),
+		// Honor zizmor's own native per-finding suppression (#971) — a documented
+		// escape hatch for a workflow-context judgment call the audit itself has no
+		// way to make (checkout-only vs. artifact-uploading job; a locally-built
+		// tarball install vs. an arbitrary remote package).
+		isSuppressed: isZizmorIgnoreSuppressed,
 	},
 	{
 		serverId: "typos",

--- a/tests/clients/dispatch/zizmor-ignore-suppression.test.ts
+++ b/tests/clients/dispatch/zizmor-ignore-suppression.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { isZizmorIgnoreSuppressed } from "../../../clients/dispatch/auxiliary-lsp.js";
+import type { LSPDiagnostic } from "../../../clients/lsp/client.js";
+
+// Minimal LSPDiagnostic for the matcher: it only reads range.start.line + code.
+function diag(line0Based: number, code?: string): LSPDiagnostic {
+	return {
+		range: {
+			start: { line: line0Based, character: 0 },
+			end: { line: line0Based, character: 1 },
+		},
+		message: "finding",
+		severity: 1,
+		code,
+	} as unknown as LSPDiagnostic;
+}
+
+describe("isZizmorIgnoreSuppressed (#971)", () => {
+	it("`# zizmor: ignore[artipacked]` suppresses a checkout-only job's finding", () => {
+		const content =
+			"steps:\n  - uses: actions/checkout@11bd719 # zizmor: ignore[artipacked]\n";
+		expect(isZizmorIgnoreSuppressed(diag(1, "artipacked"), content)).toBe(
+			true,
+		);
+	});
+
+	it("`# zizmor: ignore[adhoc-packages]` suppresses a local-tarball install", () => {
+		const content = 'run: npm install -g "$TARBALL" # zizmor: ignore[adhoc-packages]\n';
+		expect(
+			isZizmorIgnoreSuppressed(diag(0, "adhoc-packages"), content),
+		).toBe(true);
+	});
+
+	it("only suppresses the named audit id, not an unrelated one", () => {
+		const content = "run: foo # zizmor: ignore[artipacked]\n";
+		expect(isZizmorIgnoreSuppressed(diag(0, "artipacked"), content)).toBe(
+			true,
+		);
+		expect(
+			isZizmorIgnoreSuppressed(diag(0, "adhoc-packages"), content),
+		).toBe(false);
+	});
+
+	it("supports comma-separated audit ids", () => {
+		const content = "run: foo # zizmor: ignore[artipacked, adhoc-packages]\n";
+		expect(isZizmorIgnoreSuppressed(diag(0, "artipacked"), content)).toBe(
+			true,
+		);
+		expect(
+			isZizmorIgnoreSuppressed(diag(0, "adhoc-packages"), content),
+		).toBe(true);
+	});
+
+	it("does NOT suppress a finding on an unrelated line", () => {
+		const content = "run: foo # zizmor: ignore[artipacked]\nrun: bar\n";
+		expect(isZizmorIgnoreSuppressed(diag(1, "artipacked"), content)).toBe(
+			false,
+		);
+	});
+
+	it("is a no-op with no zizmor ignore comment", () => {
+		const content = "run: npm install -g \"$TARBALL\"\n";
+		expect(
+			isZizmorIgnoreSuppressed(diag(0, "adhoc-packages"), content),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
Closes #971. pi-lens surfaced zizmor CI-context warnings even where the workflow carried zizmor's own native `# zizmor: ignore[audit-id]` inline suppression. Adds `isZizmorIgnoreSuppressed` (mirrors the existing `# nosemgrep` handling for Opengrep), wired into the zizmor auxiliary profile's `isSuppressed`. Verified: build + new `zizmor-ignore-suppression.test.ts` 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)