### PR TITLE
test: de-flake grammar-heavy suites + timing-budget tests (refs #902)

### DIFF
--- a/tests/clients/review-graph-seq-fastpath.test.ts
+++ b/tests/clients/review-graph-seq-fastpath.test.ts
@@ -197,7 +197,14 @@ describe("review-graph seq fast path (#451)", () => {
 		}
 	});
 
-	it("periodic re-verify (every 20th build) resumes the full sweep", async () => {
+	// This test drives ~21 real `buildOrUpdateGraph` calls (one seed build plus
+	// up to 21 fast-path builds looking for the every-20th re-verify) — a
+	// time-budget issue, not a hang, under the default 5000ms timeout: it's
+	// comfortably under budget isolated, but under full-suite parallel fork
+	// contention that many sequential real builds can tip past 5s. Give it
+	// the same kind of generous headroom as `tests/index-integration.test.ts`'s
+	// `INTEGRATION_TIMEOUT_MS` — a genuine hang still fails, just later.
+	it("periodic re-verify (every 20th build) resumes the full sweep", { timeout: 30_000 }, async () => {
 		const env = setupTestEnvironment("pi-lens-seqfp-verify-");
 		try {
 			const aPath = createTempFile(

--- a/tests/clients/review-graph/incremental-equivalence.test.ts
+++ b/tests/clients/review-graph/incremental-equivalence.test.ts
@@ -140,13 +140,20 @@ describe("review-graph incremental/full-build equivalence (#939)", () => {
 					(Math.imul(randomState, 1_103_515_245) + 12_345) >>> 0;
 				return randomState / 0x1_0000_0000;
 			};
-			const incrementalRoot = fs.mkdtempSync(
-				path.join(os.tmpdir(), "pi-lens-inc-eq-a-"),
-			);
-			const fullRoot = fs.mkdtempSync(
-				path.join(os.tmpdir(), "pi-lens-inc-eq-b-"),
-			);
-			roots.push(incrementalRoot, fullRoot);
+			// Both arms share ONE mkdtemp'd parent with fixed subpaths (rather
+			// than two independent mkdtemp roots) so their absolute paths can
+			// never diverge in length/shape — cheap defense-in-depth against any
+			// future path-derived metadata leaking a difference between the
+			// incremental and full-rebuild arms. The actual root cause (a
+			// feature-hint classifier reading the absolute temp path) is already
+			// fixed at the source (#962/#972); this only guards against a
+			// regression reintroducing that class of bug.
+			const pairRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-inc-eq-"));
+			const incrementalRoot = path.join(pairRoot, "incremental");
+			const fullRoot = path.join(pairRoot, "full");
+			fs.mkdirSync(incrementalRoot, { recursive: true });
+			fs.mkdirSync(fullRoot, { recursive: true });
+			roots.push(pairRoot);
 			const state = new Map<string, string>([
 				["src/a.ts", "export const alpha = 1;\n"],
 				[

--- a/tests/clients/startup-overhead.test.ts
+++ b/tests/clients/startup-overhead.test.ts
@@ -30,7 +30,14 @@ vi.mock("../../clients/latency-logger.js", () => ({
 	logLatency: (entry: LatencyEntry) => latencyEntries.push(entry),
 }));
 
-const QUICK_MODE_BUDGET_MS = 100;
+// Measured mocked-path cost is single-digit ms (all clients/tools stubbed
+// unavailable, no real FS/process work) — the wide margin below is headroom
+// for scheduler jitter under full-suite parallel-fork contention, not a
+// reflection of real cost. Seen tripping at ~138-157ms under load despite
+// that; retry soaks rare spikes the same way `cascade-graph-occupancy.test.ts`
+// does. A genuine regression (e.g. an accidental sync `fs.readdirSync` over a
+// big tree sneaking onto this hot path) would still blow even this budget.
+const QUICK_MODE_BUDGET_MS = 500;
 const FULL_MODE_BUDGET_MS = 500;
 
 /** Extract the self-reported ms from "session_start total: Xms ..." dbg lines. */
@@ -123,22 +130,28 @@ describe("startup overhead — interactive path regression guard", () => {
 		latencyEntries.length = 0;
 	});
 
-	it(`quick mode self-reports within ${QUICK_MODE_BUDGET_MS}ms`, async () => {
-		const env = setupTestEnvironment("pi-lens-overhead-quick-");
-		const restoreMode = setStartupMode("quick");
-		const dbgLog: string[] = [];
+	it(
+		`quick mode self-reports within ${QUICK_MODE_BUDGET_MS}ms`,
+		{ retry: 2 },
+		async () => {
+			const env = setupTestEnvironment("pi-lens-overhead-quick-");
+			const restoreMode = setStartupMode("quick");
+			const dbgLog: string[] = [];
 
-		try {
-			await handleSessionStart(makeDeps(env.tmpDir, (msg) => dbgLog.push(msg)));
+			try {
+				await handleSessionStart(
+					makeDeps(env.tmpDir, (msg) => dbgLog.push(msg)),
+				);
 
-			const reported = extractReportedMs(dbgLog);
-			expect(reported).not.toBeNull();
-			expect(reported).toBeLessThan(QUICK_MODE_BUDGET_MS);
-		} finally {
-			env.cleanup();
-			restoreMode();
-		}
-	});
+				const reported = extractReportedMs(dbgLog);
+				expect(reported).not.toBeNull();
+				expect(reported).toBeLessThan(QUICK_MODE_BUDGET_MS);
+			} finally {
+				env.cleanup();
+				restoreMode();
+			}
+		},
+	);
 
 	it("quick mode emits attributable phases whose top-level durations account for total", async () => {
 		const env = setupTestEnvironment("pi-lens-overhead-records-");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,56 +3,130 @@ import { defineConfig } from "vitest/config";
 // Applies to globalSetup as well as workers: ordinary tests never install tools.
 process.env.PI_LENS_DISABLE_TOOL_INSTALL ??= "1";
 
-// Minimal config — vitest defaults (test discovery, pools, etc.) are preserved.
-// Additions:
-//  - globalSetup fails fast on a stale in-place build, so tests can't silently
-//    run against pre-edit compiled `.js` (#198).
-//  - worker heap headroom: the full suite occasionally died with a "Worker
-//    exited unexpectedly" + a `node::GetNodeReport` dump. That report is emitted
-//    by Node's OWN fatal-error handler (V8 heap-limit reached) — an external OS
-//    OOM-kill SIGKILLs with no dump — so the crash is a single long-lived worker
-//    hitting its own V8 heap ceiling, not system memory exhaustion (32-core /
-//    68 GB host). With `isolate: true` vitest resets each worker's module
-//    registry per file, so the native addons (the many tree-sitter grammars +
-//    @ast-grep/napi) are re-loaded file-after-file and their off- and on-heap
-//    buffers accumulate in the reused worker until a heavy worker tips over.
-//    `execArgv` passes --max-old-space-size to every spawned worker, giving that
-//    headroom WITHOUT capping worker count (no CI slowdown); aggregate risk is
-//    negligible (workers never all peak at once, and 4 GB × workers ≪ host RAM).
-//    Tune via PI_LENS_TEST_WORKER_HEAP_MB. NOTE: Vitest 4 flattened the config —
-//    `execArgv` is a direct `test` field (the v3 `poolOptions.forks.execArgv`
-//    nesting no longer exists and is silently ignored).
+// Background coding agents get worktrees under .claude/worktrees/ — vitest's
+// default exclude covers node_modules/.git/dist but NOT those, so a "full
+// suite" run in the main tree silently swept every agent's IN-PROGRESS
+// worktree tests too (seen 2026-07-11: 40+ phantom failures, all from
+// half-finished branches in sibling worktrees).
+const sharedExclude = [
+	"**/node_modules/**",
+	"**/dist/**",
+	"**/.{git,cache,output,temp}/**",
+	"**/.claude/**",
+];
+
+const sharedGlobalSetup = [
+	"./tests/support/check-build-freshness.ts",
+	"./tests/support/prewarm-grammars.ts",
+	// After check-build-freshness: the seed analyze runs the in-place build.
+	"./tests/support/prewarm-tool-home.ts",
+];
+
+const sharedSetupFiles = ["./tests/support/vitest-setup.ts"];
+
+// Local runs: cap forks at half the cores (measured 2026-07-29 on a
+// 16-core host, post dead-wait removal: 8 forks ≈ 40s / 9-11 GB peak
+// RSS; 6 forks ≈ 44s / 8 GB; the old uncapped 15 forks gave the same
+// memory for a slower wall). CI keeps vitest's default — its 4-core
+// runner has no worker headroom to give back. Memory-constrained runs:
+// PI_LENS_TEST_MAX_WORKERS=6.
+const sharedMaxWorkers = process.env.CI
+	? undefined
+	: Number(process.env.PI_LENS_TEST_MAX_WORKERS) || "50%";
+
+// Worker heap headroom: the full suite occasionally died with a "Worker
+// exited unexpectedly" + a `node::GetNodeReport` dump. That report is emitted
+// by Node's OWN fatal-error handler (V8 heap-limit reached) — an external OS
+// OOM-kill SIGKILLs with no dump — so the crash is a single long-lived worker
+// hitting its own V8 heap ceiling, not system memory exhaustion (32-core /
+// 68 GB host). With `isolate: true` (vitest's default) each worker's module
+// registry is reset per file, so the native addons (the many tree-sitter
+// grammars + @ast-grep/napi) are re-loaded file-after-file and their off- and
+// on-heap buffers accumulate in the reused worker until a heavy worker tips
+// over. `execArgv` passes --max-old-space-size to every spawned worker,
+// giving that headroom WITHOUT capping worker count (no CI slowdown);
+// aggregate risk is negligible (workers never all peak at once, and 4 GB ×
+// workers ≪ host RAM). Tune via PI_LENS_TEST_WORKER_HEAP_MB. NOTE: Vitest 4
+// flattened the config — `execArgv` is a direct `test` field (the v3
+// `poolOptions.forks.execArgv` nesting no longer exists and is silently
+// ignored).
+const sharedExecArgv = [
+	`--max-old-space-size=${process.env.PI_LENS_TEST_WORKER_HEAP_MB || 4096}`,
+];
+
+// Tier 1 fix (#902): these files all transitively drive real tree-sitter
+// grammar parses (via clients/review-graph/builder.js or the project-diagnostics
+// scanner), and `isolate: true` (required — see above, and removing it
+// reintroduces the V8 heap-ceiling crash) means each test FILE gets a fresh
+// module registry, so the native grammar addons get re-loaded/re-compiled
+// per file rather than once per worker. Grammar prewarm
+// (tests/support/prewarm-grammars.ts) only pre-fetches the wasm BYTES to
+// disk — it does nothing to stop several of these files re-compiling their
+// grammars concurrently once spread across forks under the default
+// `maxWorkers: "50%"`. That contention was intermittently blowing past the
+// fork teardown deadline ("Timeout terminating forks worker") even though
+// every test in the file had already passed. Carving this glob into its own
+// project with a small capped `maxWorkers` bounds how many of these heavy
+// files compile grammars at once, without reducing parallelism for the rest
+// of the suite (which keeps its existing `maxWorkers: "50%"` in the
+// "default" project below).
+const grammarHeavyInclude = [
+	"tests/clients/review-graph/shared-extraction-ir.test.ts",
+	"tests/clients/review-graph/tsconfig-paths.test.ts",
+	"tests/clients/review-graph/extract-symbols.test.ts",
+	"tests/clients/project-diagnostics/scanner.test.ts",
+];
+
 export default defineConfig({
 	test: {
-		// Background coding agents get worktrees under .claude/worktrees/ —
-		// vitest's default exclude covers node_modules/.git/dist but NOT those,
-		// so a "full suite" run in the main tree silently swept every agent's
-		// IN-PROGRESS worktree tests too (seen 2026-07-11: 40+ phantom failures,
-		// all from half-finished branches in sibling worktrees).
-		exclude: [
-			"**/node_modules/**",
-			"**/dist/**",
-			"**/.{git,cache,output,temp}/**",
-			"**/.claude/**",
-		],
-		globalSetup: [
-			"./tests/support/check-build-freshness.ts",
-			"./tests/support/prewarm-grammars.ts",
-			// After check-build-freshness: the seed analyze runs the in-place build.
-			"./tests/support/prewarm-tool-home.ts",
-		],
-		setupFiles: ["./tests/support/vitest-setup.ts"],
-		// Local runs: cap forks at half the cores (measured 2026-07-29 on a
-		// 16-core host, post dead-wait removal: 8 forks ≈ 40s / 9-11 GB peak
-		// RSS; 6 forks ≈ 44s / 8 GB; the old uncapped 15 forks gave the same
-		// memory for a slower wall). CI keeps vitest's default — its 4-core
-		// runner has no worker headroom to give back. Memory-constrained runs:
-		// PI_LENS_TEST_MAX_WORKERS=6.
-		maxWorkers: process.env.CI
-			? undefined
-			: Number(process.env.PI_LENS_TEST_MAX_WORKERS) || "50%",
-		execArgv: [
-			`--max-old-space-size=${process.env.PI_LENS_TEST_WORKER_HEAP_MB || 4096}`,
+		exclude: sharedExclude,
+		projects: [
+			{
+				test: {
+					name: "default",
+					exclude: [...sharedExclude, ...grammarHeavyInclude],
+					globalSetup: sharedGlobalSetup,
+					setupFiles: sharedSetupFiles,
+					maxWorkers: sharedMaxWorkers,
+					execArgv: sharedExecArgv,
+					// Vitest 4 requires distinct groupOrder whenever projects have
+					// different `maxWorkers` — see the "grammar-heavy" project below
+					// for why that's actually desirable here, not just a workaround.
+					sequence: { groupOrder: 0 },
+				},
+			},
+			{
+				test: {
+					name: "grammar-heavy",
+					include: grammarHeavyInclude,
+					exclude: sharedExclude,
+					globalSetup: sharedGlobalSetup,
+					setupFiles: sharedSetupFiles,
+					execArgv: sharedExecArgv,
+					// Cap, don't serialize: bounds concurrent grammar re-compiles to
+					// 2-at-a-time instead of whatever `maxWorkers: "50%"` would give
+					// them (the root cause above), without going fully sequential.
+					// NOTE: Vitest 4 removed `poolOptions.forks.maxForks` — pool
+					// concurrency knobs were unified into the top-level
+					// `maxWorkers` (applies to whichever pool is active; this repo
+					// uses the default `forks` pool everywhere).
+					maxWorkers: 2,
+					// Distinct groupOrder is required whenever projects have
+					// different `maxWorkers` (Vitest 4 throws otherwise). Side
+					// effect: scheduling groups run as sequential PHASES (group 0
+					// fully drains, then group 1 starts) rather than interleaved —
+					// a feature here, not a cost: it guarantees these 4
+					// grammar-heavy files never share fork-scheduling time with the
+					// rest of the suite, so they can never race a batch of OTHER
+					// files' concurrent grammar compiles either.
+					sequence: { groupOrder: 1 },
+					// Supplement, not a substitute for the maxForks cap above: give
+					// fork teardown more headroom in case a heavy grammar compile is
+					// still finishing when a test file's hooks wrap up.
+					hookTimeout: 60_000,
+					teardownTimeout: 30_000,
+				},
+			},
 		],
 	},
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -80,6 +80,10 @@ const grammarHeavyInclude = [
 export default defineConfig({
 	test: {
 		exclude: sharedExclude,
+		// Root-config-only in Vitest 4 (see the grammar-heavy project's comment
+		// below) — applies to every project's fork teardown, not just the
+		// grammar-heavy one, which is strictly more forgiving everywhere else.
+		teardownTimeout: 30_000,
 		projects: [
 			{
 				test: {
@@ -123,8 +127,12 @@ export default defineConfig({
 					// Supplement, not a substitute for the maxForks cap above: give
 					// fork teardown more headroom in case a heavy grammar compile is
 					// still finishing when a test file's hooks wrap up.
+					// NOTE: Vitest 4's per-project `ProjectConfig` type excludes
+					// `teardownTimeout` (it moved to root-config-only), so the 30s
+					// bump lives on the top-level `test` block below instead —
+					// applies to both projects, which only makes the default
+					// project's teardown MORE forgiving, never less.
 					hookTimeout: 60_000,
-					teardownTimeout: 30_000,
 				},
 			},
 		],


### PR DESCRIPTION
Implements the tiered flaky-test remediation plan (Tiers 1–2; Tier 3 was "merge #962", already landed via #972).

## Tier 1 — grammar-heavy suites (fixes "Timeout terminating forks worker")
Root cause: `isolate: true` (required — removing it reintroduces a V8 heap-ceiling crash) resets each worker's module registry per test *file*, so tree-sitter grammar addons re-compile per file; under `maxWorkers: "50%"` several heavy files race those WASM compiles across forks and miss the fork teardown deadline (tests already passed — it's teardown, not assertions). The grammar prefetch only downloads bytes, it doesn't stop the concurrent re-compile.

`vitest.config.ts` is split into two `test.projects`:
- **default** — everything except the 4 grammar-heavy files; unchanged behavior (same exclude incl. `.claude/**` worktrees, globalSetup, setupFiles, `maxWorkers: "50%"`, heap `execArgv`).
- **grammar-heavy** — exactly `review-graph/{shared-extraction-ir,tsconfig-paths,extract-symbols}.test.ts` + `project-diagnostics/scanner.test.ts`, capped at `maxWorkers: 2` with `hookTimeout/teardownTimeout` headroom. Distinct `sequence.groupOrder` runs it as a separate phase so these files never share fork-scheduling with the rest of the suite.

Vitest-4 API: `poolOptions.forks.maxForks` was removed → unified into top-level `maxWorkers`; distinct `groupOrder` is required when projects differ in `maxWorkers`.

## Tier 2 — timing-budget tests (keep the guard, kill the jitter)
- `review-graph-seq-fastpath.test.ts` "periodic re-verify" (21 real graph builds): explicit `{ timeout: 30_000 }` (was inheriting the default 5s), mirroring the `index-integration.test.ts` precedent.
- `startup-overhead.test.ts` quick-mode budget: `100 → 500ms` + `{ retry: 2 }`, with a comment quantifying the real (single-digit ms mocked) cost vs the threshold — the regression guard still catches a real 5–10× regression; scheduler-jitter false positives (138–157ms observed) stop.
- `incremental-equivalence.test.ts`: the two fixture roots now share one parent with fixed `incremental`/`full` subpaths — cheap defense-in-depth (root cause already fixed in #962/#972).

No `.skip`, no assertions removed.

## Verification (by the author, to double-check on merge)
- `npx vitest list`: **4741 tests / 434 files identical** before vs after — no coverage lost, no collection error.
- Full `npx vitest run`: **no "Timeout terminating forks worker" anywhere** in the log (grepped). 5 pre-existing, unrelated event-loop-occupancy flakes remain (`source-walk-occupancy`, `source-filter-async`, `ast-grep-rule-tests`) — out of scope, not touched here; flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)