### PR TITLE
fix(ast-grep): hardcoded-url no longer flags SCREAMING_SNAKE_CASE constants (closes #964)

### DIFF
--- a/rules/ast-grep-rules/rule-tests/hardcoded-url-js-test.yml
+++ b/rules/ast-grep-rules/rule-tests/hardcoded-url-js-test.yml
@@ -2,6 +2,7 @@ id: hardcoded-url-js
 valid:
   - 'const url = process.env.API_URL'
   - 'const x = "hello"'
+  - 'export const BASE_URL_CLINE = "https://api.cline.bot";'
 invalid:
   - 'const url = "https://api.example.com"'
   - 'const endpoint = "http://localhost:3000"'

--- a/rules/ast-grep-rules/rule-tests/hardcoded-url-test.yml
+++ b/rules/ast-grep-rules/rule-tests/hardcoded-url-test.yml
@@ -2,6 +2,8 @@ id: hardcoded-url
 valid:
   - 'const url = process.env.API_URL'
   - 'const x = "hello"'
+  - 'export const BASE_URL_CLINE = "https://api.cline.bot";'
+  - 'export const URL_KILO_TOS = "https://kilo.dev/tos";'
 invalid:
   - 'const url = "https://api.example.com"'
   - 'const endpoint = "http://localhost:3000"'

--- a/rules/ast-grep-rules/rules/hardcoded-url-js.yml
+++ b/rules/ast-grep-rules/rules/hardcoded-url-js.yml
@@ -9,9 +9,27 @@ note: |
   level for some shapes; using a regex on `variable_declarator` (the
   inner `name = value` node) catches all const/let/var URL assignments
   regardless of the surrounding keyword.
+  A `SCREAMING_SNAKE_CASE` name is the project-wide convention for a
+  deliberate, named constant (see e.g. `check_secret_pattern` in
+  tree-sitter-client.ts, which trusts the same convention for secrets).
+  Provider/integration endpoint constants (`BASE_URL_CLINE`, `URL_KILO_TOS`,
+  …) are declared this way on purpose — they are configuration, just
+  expressed as a JS constant instead of an env var — so exempting that
+  naming shape removes the low-signal noise while still catching a URL
+  hardcoded under an ordinary lower/camelCase name (#964).
 rule:
   any:
-    - kind: variable_declarator
-      regex: '"https?://'
-    - kind: assignment_expression
-      regex: '"https?://'
+    - all:
+        - kind: variable_declarator
+          regex: '"https?://'
+        - not:
+            has:
+              field: name
+              regex: "^[A-Z][A-Z0-9_]*$"
+    - all:
+        - kind: assignment_expression
+          regex: '"https?://'
+        - not:
+            has:
+              field: left
+              regex: "^[A-Z][A-Z0-9_]*$"

--- a/rules/ast-grep-rules/rules/hardcoded-url.yml
+++ b/rules/ast-grep-rules/rules/hardcoded-url.yml
@@ -9,9 +9,27 @@ note: |
   level for some shapes; using a regex on `variable_declarator` (the
   inner `name = value` node) catches all const/let/var URL assignments
   regardless of the surrounding keyword.
+  A `SCREAMING_SNAKE_CASE` name is the project-wide convention for a
+  deliberate, named constant (see e.g. `check_secret_pattern` in
+  tree-sitter-client.ts, which trusts the same convention for secrets).
+  Provider/integration endpoint constants (`BASE_URL_CLINE`, `URL_KILO_TOS`,
+  …) are declared this way on purpose — they are configuration, just
+  expressed as a TS constant instead of an env var — so exempting that
+  naming shape removes the low-signal noise while still catching a URL
+  hardcoded under an ordinary lower/camelCase name (#964).
 rule:
   any:
-    - kind: variable_declarator
-      regex: '"https?://'
-    - kind: assignment_expression
-      regex: '"https?://'
+    - all:
+        - kind: variable_declarator
+          regex: '"https?://'
+        - not:
+            has:
+              field: name
+              regex: "^[A-Z][A-Z0-9_]*$"
+    - all:
+        - kind: assignment_expression
+          regex: '"https?://'
+        - not:
+            has:
+              field: left
+              regex: "^[A-Z][A-Z0-9_]*$"


### PR DESCRIPTION
Closes #964. `hardcoded-url` (and its JS twin) flagged intentional named provider-endpoint constants. Adds a `not: has: {field: name/left, regex: "^[A-Z][A-Z0-9_]*$"}` exemption for SCREAMING_SNAKE_CASE-named `variable_declarator`/`assignment_expression`.

This is a **style/config** rule (flag inline hardcoded URLs), not a taint sink — a named uppercase URL constant is precisely the "deliberate configuration" pattern it should tolerate, so the name-only exemption is correct here. Adversarially reviewed: no security finding is lost (hardcoded-url never claimed to catch malicious destinations). Both-direction fixtures present — uppercase constants exempt, lowercase `const url = "..."` / `const endpoint = "..."` still flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)