### PR TITLE
fix(lsp): stop advertising unused window.workDoneProgress capability (closes #974)

### DIFF
--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -405,7 +405,16 @@ const INITIALIZE_TIMEOUT_MS = positiveIntFromEnv(
  */
 export const CLIENT_CAPABILITIES = {
 	general: { positionEncodings: ADVERTISED_POSITION_ENCODINGS },
-	window: { workDoneProgress: true },
+	// #974: workDoneProgress is intentionally NOT advertised. pi-lens never
+	// consumes `$/progress` notifications (grepped: zero listeners anywhere in
+	// clients/), so declaring the capability only invites servers to open
+	// progress tokens pi-lens will silently ignore — and opengrep's
+	// `--experimental` LSP mode crash-loops when it can't parse our
+	// spec-correct `{"result": null}` reply to its
+	// `window/workDoneProgress/create` request. "Only advertise what you
+	// implement" — the `window/workDoneProgress/create` handler below stays as
+	// a defensive no-op in case a server ignores capabilities and asks anyway.
+	window: {},
 	workspace: {
 		workspaceFolders: true,
 		configuration: true,

--- a/tests/clients/lsp/client-internals.test.ts
+++ b/tests/clients/lsp/client-internals.test.ts
@@ -81,12 +81,15 @@ describe("workDoneProgress capability (#974)", () => {
 		setupIncomingHandlers(state, {});
 
 		const onRequest = vi.mocked(state.connection.onRequest);
-		const registered = onRequest.mock.calls.find(
+		const calls = onRequest.mock.calls as unknown as Array<
+			[string, (...args: unknown[]) => unknown]
+		>;
+		const registered = calls.find(
 			(c) => c[0] === "window/workDoneProgress/create",
 		);
 		expect(registered, "handler registered as a defensive no-op").toBeDefined();
 
-		const handler = registered![1] as (...args: unknown[]) => unknown;
+		const handler = registered![1];
 		await expect(
 			handler({ token: "some-progress-token" }),
 		).resolves.toBeUndefined();

--- a/tests/clients/lsp/client-internals.test.ts
+++ b/tests/clients/lsp/client-internals.test.ts
@@ -66,6 +66,33 @@ describe("CLIENT_CAPABILITIES (#278 regression)", () => {
 	});
 });
 
+describe("workDoneProgress capability (#974)", () => {
+	// pi-lens never consumes `$/progress` notifications, so advertising
+	// window.workDoneProgress only invites servers to open progress tokens
+	// that go nowhere — and opengrep's `--experimental` LSP mode crash-loops
+	// when it can't parse pi-lens's spec-correct `{"result": null}` reply to
+	// the `window/workDoneProgress/create` request that capability solicits.
+	it("does not advertise window.workDoneProgress", () => {
+		expect(CLIENT_CAPABILITIES.window).not.toHaveProperty("workDoneProgress");
+	});
+
+	it("still answers an unsolicited window/workDoneProgress/create request without throwing", async () => {
+		const state = createMockState();
+		setupIncomingHandlers(state, {});
+
+		const onRequest = vi.mocked(state.connection.onRequest);
+		const registered = onRequest.mock.calls.find(
+			(c) => c[0] === "window/workDoneProgress/create",
+		);
+		expect(registered, "handler registered as a defensive no-op").toBeDefined();
+
+		const handler = registered![1] as (...args: unknown[]) => unknown;
+		await expect(
+			handler({ token: "some-progress-token" }),
+		).resolves.toBeUndefined();
+	});
+});
+
 function createMockConnection(): MessageConnection {
 	return {
 		sendNotification: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
Closes #974. Opengrep's `--experimental` LSP sends `window/workDoneProgress/create`; pi-lens replies with the spec-correct `result: null`, which opengrep's experimental mode mishandles → "Unhandled message" → crash-loop (`code=1`, ~20× across projects over 10 days). pi-lens advertised `window.workDoneProgress: true` but **never consumes `$/progress` anywhere** (grep-confirmed: zero `onNotification("$/progress")` consumers in `clients/`).

Fix: remove `workDoneProgress` from `CLIENT_CAPABILITIES` (global — safe because no server's functionality can regress on a capability pi-lens never acted on). The `window/workDoneProgress/create` handler is kept as a defensive spec-correct no-op in case a non-compliant server sends it anyway. Removes the exact stimulus opengrep can't handle.

Test: `tests/clients/lsp/client-internals.test.ts` asserts `CLIENT_CAPABILITIES.window` no longer advertises `workDoneProgress`. Build clean; `tests/clients/lsp/` 515 passed / 3 skipped.

**Note for reviewer:** the opengrep upstream/version angle (whether opengrep 1.25.0 → newer, or a non-`--experimental` mode, fixes the response handling) is **unverified** — couldn't reach opengrep docs from the worktree. This client fix is correct independently, but a human should check opengrep releases before assuming it's fully sufficient in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)