### PR TITLE
fix(lsp): workspace/configuration honors params.items (closes #983)

### DIFF
--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -906,6 +906,35 @@ export function applyDynamicCapabilities(state: LSPClientState): void {
 	}
 }
 
+/**
+ * Resolve a `workspace/configuration` request item's `section` (a dot-path,
+ * e.g. "scan.jobs") against the server's `initializationOptions` blob.
+ * - No section (undefined/empty) → the whole blob, per spec ("if a scope
+ *   isn't asked for" the client returns the full settings for that scope).
+ * - An unresolvable path → `null`, never the whole blob — a server asking
+ *   for a section it doesn't get must not silently receive unrelated config.
+ * Exported for the #983 regression test.
+ */
+export function resolveConfigurationSection(
+	initialization: Record<string, unknown> | undefined,
+	section: string | undefined,
+): unknown {
+	if (!initialization) return section ? null : {};
+	if (!section) return initialization;
+	let cur: unknown = initialization;
+	for (const part of section.split(".")) {
+		if (
+			typeof cur !== "object" ||
+			cur === null ||
+			!Object.prototype.hasOwnProperty.call(cur, part)
+		) {
+			return null;
+		}
+		cur = (cur as Record<string, unknown>)[part];
+	}
+	return cur;
+}
+
 // Exported (only) so tests can invoke the publishDiagnostics notification
 // handler directly against a mock LSPClientState/connection without spawning
 // a real language server. Not part of the public client API surface.
@@ -1065,9 +1094,21 @@ export function setupIncomingHandlers(
 			}
 		},
 	);
-	state.connection.onRequest("workspace/configuration", async () => [
-		initialization ?? {},
-	]);
+	// #983: the LSP spec requires the response array to have exactly one entry
+	// per requested item, each resolved against that item's `section` (a
+	// dot-path into the server's config, e.g. "scan.jobs") — not a fixed
+	// single-element array duplicating the whole blob for every item. An item
+	// with no `section` gets the whole blob (that's what "no section" means
+	// per spec); an unresolvable section gets `null`, never the whole blob.
+	state.connection.onRequest(
+		"workspace/configuration",
+		async (params: { items?: Array<{ section?: string }> }) => {
+			const items = params?.items ?? [];
+			return items.map((item) =>
+				resolveConfigurationSection(initialization, item?.section),
+			);
+		},
+	);
 	state.connection.onRequest("window/workDoneProgress/create", async () => {});
 }
 

--- a/tests/clients/lsp/client-internals.test.ts
+++ b/tests/clients/lsp/client-internals.test.ts
@@ -17,6 +17,7 @@ import {
 	clientWaitForDiagnostics,
 	handleNotifyChange,
 	navRequest,
+	resolveConfigurationSection,
 	runServerCommand,
 	setupIncomingHandlers,
 	stripDiagnosticNoiseLines,
@@ -161,6 +162,95 @@ function createMockState(overrides?: Partial<LSPClientState>): LSPClientState {
 	}
 	return state;
 }
+
+describe("resolveConfigurationSection (#983)", () => {
+	const initialization = {
+		scan: { configuration: ["auto"], onlyGitDirty: false, jobs: 16 },
+		metrics: { enabled: false },
+		doHover: false,
+	};
+
+	it("returns the whole blob for an item with no section", () => {
+		expect(resolveConfigurationSection(initialization, undefined)).toBe(
+			initialization,
+		);
+	});
+
+	it("resolves a top-level section", () => {
+		expect(resolveConfigurationSection(initialization, "metrics")).toEqual({
+			enabled: false,
+		});
+	});
+
+	it("resolves a nested dot-path section", () => {
+		expect(resolveConfigurationSection(initialization, "scan.jobs")).toBe(16);
+	});
+
+	it("returns null for an unknown section instead of the whole blob", () => {
+		expect(resolveConfigurationSection(initialization, "unknown.section")).toBe(
+			null,
+		);
+		expect(resolveConfigurationSection(initialization, "scan.nope")).toBe(null);
+	});
+
+	it("returns null for an unknown section when initialization is undefined", () => {
+		expect(resolveConfigurationSection(undefined, "anything")).toBe(null);
+	});
+});
+
+describe("workspace/configuration handler (#983)", () => {
+	// Per the LSP spec the response array's length MUST equal
+	// params.items.length, one resolved value per requested item — not a
+	// fixed single-element array duplicating the whole blob for every item.
+	it("returns one resolved entry per requested item, mixing known and unknown sections", async () => {
+		const initialization = {
+			scan: { jobs: 16 },
+			metrics: { enabled: false },
+		};
+		const state = createMockState();
+		setupIncomingHandlers(state, initialization);
+
+		const onRequest = vi.mocked(state.connection.onRequest);
+		const registered = onRequest.mock.calls.find(
+			(c) => c[0] === "workspace/configuration",
+		);
+		expect(registered).toBeDefined();
+		const handler = registered![1] as (
+			params: unknown,
+		) => Promise<unknown[]>;
+
+		const result = await handler({
+			items: [
+				{ section: "scan" },
+				{ section: "metrics.enabled" },
+				{ section: "nonexistent.section" },
+				{},
+			],
+		});
+
+		expect(result).toEqual([
+			{ jobs: 16 },
+			false,
+			null,
+			initialization,
+		]);
+	});
+
+	it("returns an empty array when the server requests zero items", async () => {
+		const state = createMockState();
+		setupIncomingHandlers(state, { scan: { jobs: 16 } });
+
+		const onRequest = vi.mocked(state.connection.onRequest);
+		const registered = onRequest.mock.calls.find(
+			(c) => c[0] === "workspace/configuration",
+		);
+		const handler = registered![1] as (
+			params: unknown,
+		) => Promise<unknown[]>;
+
+		expect(await handler({ items: [] })).toEqual([]);
+	});
+});
 
 describe("stripDiagnosticNoiseLines", () => {
 	it("removes bare URL and further-information diagnostic lines", () => {

--- a/tests/clients/lsp/client-internals.test.ts
+++ b/tests/clients/lsp/client-internals.test.ts
@@ -211,13 +211,14 @@ describe("workspace/configuration handler (#983)", () => {
 		setupIncomingHandlers(state, initialization);
 
 		const onRequest = vi.mocked(state.connection.onRequest);
-		const registered = onRequest.mock.calls.find(
+		const calls = onRequest.mock.calls as unknown as Array<
+			[string, (params: unknown) => Promise<unknown[]>]
+		>;
+		const registered = calls.find(
 			(c) => c[0] === "workspace/configuration",
 		);
 		expect(registered).toBeDefined();
-		const handler = registered![1] as (
-			params: unknown,
-		) => Promise<unknown[]>;
+		const handler = registered![1];
 
 		const result = await handler({
 			items: [
@@ -241,12 +242,13 @@ describe("workspace/configuration handler (#983)", () => {
 		setupIncomingHandlers(state, { scan: { jobs: 16 } });
 
 		const onRequest = vi.mocked(state.connection.onRequest);
-		const registered = onRequest.mock.calls.find(
+		const calls = onRequest.mock.calls as unknown as Array<
+			[string, (params: unknown) => Promise<unknown[]>]
+		>;
+		const registered = calls.find(
 			(c) => c[0] === "workspace/configuration",
 		);
-		const handler = registered![1] as (
-			params: unknown,
-		) => Promise<unknown[]>;
+		const handler = registered![1];
 
 		expect(await handler({ items: [] })).toEqual([]);
 	});


### PR DESCRIPTION
Closes #983. The `workspace/configuration` server→client handler ignored `params.items` and always returned a single-element `[initialization]`, violating the LSP spec (response array length must equal `params.items.length`, one value per requested `section`).

Fix: map over `params.items`, resolving each via a new `resolveConfigurationSection(initialization, section)`:
- no `section` → the whole `initialization` blob (spec meaning of an unscoped item)
- a known dot-path (e.g. `scan.jobs`) → that nested value
- an unresolvable path → `null` (never the whole blob)

Test: `tests/clients/lsp/client-internals.test.ts` — unit tests for `resolveConfigurationSection` + an end-to-end test invoking the registered handler with mixed known/unknown/no-section items, asserting array length and per-item content. Build clean; `tests/clients/lsp/` 520 passed / 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)