### PR TITLE
fix(security): ts-ssrf exempts only provably-literal const endpoints (closes #963)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **`ts-ssrf` no longer trusts naming convention as proof of a fixed URL**
+	(fixes #963) — the post-filter now resolves a bare `fetch(IDENT)` argument
+	against the file's AST and exempts it only when `IDENT` provably resolves
+	to a single `const` declarator initialized with a string literal (or a
+	template literal with no `${...}` substitutions). SCREAMING_SNAKE_CASE
+	naming is no longer sufficient by itself: `const TARGET_URL = req.query.url`
+	still flags, since the identifier's *initializer* — not its name — is
+	what's checked. Ambiguous/shadowed declarations, `let`/`var` bindings,
+	reassigned identifiers, and unresolved identifiers all fall through to the
+	existing broad heuristic and keep being flagged.
+
 - **Session warmup refreshes the word index incrementally** (refs #958) —
 	the persisted serializer now carries per-file mtimes. Startup still performs
 	the bounded source walk, but reuses unchanged postings, re-tokenizes only

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -1480,6 +1480,79 @@ export class TreeSitterClient {
 		return "";
 	}
 
+	/**
+	 * Resolves `name` (as used in the *same file*) to a provably fixed URL:
+	 * a `const` declarator whose initializer is a string literal, or a
+	 * template literal with no `${...}` substitutions.
+	 *
+	 * This is deliberately conservative — naming convention (e.g.
+	 * SCREAMING_SNAKE_CASE) proves nothing about provenance, so it is never
+	 * consulted here. Any of the following makes resolution fail (and the
+	 * caller must then treat the identifier as potentially tainted):
+	 *   - no declarator found for `name` in this file;
+	 *   - more than one declarator for `name` (ambiguous/shadowed — refuse
+	 *     rather than guess which one applies at the use site);
+	 *   - declared with `let`/`var` (not `const`);
+	 *   - the identifier is reassigned anywhere in the file
+	 *     (`name = ...`), even if the declaration itself is `const`-like in
+	 *     spirit — this also catches destructuring/compound-assignment
+	 *     edge cases conservatively since we only special-case a clean
+	 *     assignment_expression;
+	 *   - the initializer is not a plain string/no-substitution template
+	 *     literal (e.g. `process.env.X`, a function call, a member
+	 *     expression, another identifier).
+	 */
+	private resolvesToFileLiteralConst(
+		name: string,
+		rootNode: TreeSitterNode,
+	): boolean {
+		const constDeclarators: TreeSitterNode[] = [];
+		let hasNonConstBinding = false;
+		let hasReassignment = false;
+
+		const stack: TreeSitterNode[] = [rootNode];
+		while (stack.length > 0) {
+			const node = stack.pop();
+			if (!node) continue;
+			if (node.type === "variable_declarator") {
+				const nameNode = node.childForFieldName?.("name");
+				if (nameNode?.type === "identifier" && nameNode.text === name) {
+					const decl = node.parent;
+					const isConst =
+						decl?.type === "lexical_declaration" &&
+						(decl.children ?? []).some((c) => c.type === "const");
+					if (isConst) {
+						constDeclarators.push(node);
+					} else {
+						hasNonConstBinding = true;
+					}
+				}
+			} else if (node.type === "assignment_expression") {
+				const left = node.childForFieldName?.("left");
+				if (left?.type === "identifier" && left.text === name) {
+					hasReassignment = true;
+				}
+			}
+			for (const child of node.children ?? []) stack.push(child);
+		}
+
+		// Ambiguous (shadowed/duplicated), reassigned anywhere, or backed by a
+		// non-const binding somewhere in the file: refuse to resolve.
+		if (hasNonConstBinding || hasReassignment || constDeclarators.length !== 1) {
+			return false;
+		}
+
+		const valueNode = constDeclarators[0].childForFieldName?.("value");
+		if (!valueNode) return false;
+		if (valueNode.type === "string") return true;
+		if (valueNode.type === "template_string") {
+			return !(valueNode.children ?? []).some(
+				(c) => c.type === "template_substitution",
+			);
+		}
+		return false;
+	}
+
 	private isSafeSqlAlchemyExpressionCall(node: TreeSitterNode): boolean {
 		if (node.type !== "call") return false;
 		const callee = node.children?.[0]?.text ?? "";
@@ -2427,6 +2500,23 @@ export class TreeSitterClient {
 					"delete",
 				]);
 				if (!allowedFns.has(fn)) return false;
+				// A bare identifier that provably resolves (in this file) to a
+				// `const` initialized with a fixed string/template literal is a
+				// genuinely fixed URL — exempt it regardless of naming
+				// convention (SCREAMING_SNAKE_CASE proves nothing about
+				// provenance; see #963). Anything we cannot definitively prove
+				// falls through to the existing broad heuristic below, so
+				// member expressions, non-literal consts, reassigned
+				// bindings, and unresolved identifiers all keep being
+				// evaluated for taint as before — a false positive here is
+				// acceptable, a missed SSRF is not.
+				if (
+					rootNode &&
+					captures.URL?.type === "identifier" &&
+					this.resolvesToFileLiteralConst(urlText, rootNode)
+				) {
+					return false;
+				}
 				// Only flag when the URL argument looks like it could carry external
 				// input: member expressions (req.url, ctx.query.x) or identifiers
 				// whose names suggest user/external provenance. Plain generic names

--- a/tests/clients/tree-sitter-security-gap-rules.test.ts
+++ b/tests/clients/tree-sitter-security-gap-rules.test.ts
@@ -184,6 +184,108 @@ describe("tree-sitter security gap rules", () => {
 		expect(matches.length).toBeGreaterThan(0);
 	});
 
+	// Regression coverage for #963: naming convention alone (e.g.
+	// SCREAMING_SNAKE_CASE) must never be trusted as proof of a fixed URL.
+	// Only a provably literal-initialized `const` in the same file is exempt.
+	it("does not flag fetch of a const initialized with a string literal (#963)", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const query = await getQuery("ts-ssrf");
+		const filePath = writeTempFile(
+			"ts",
+			`const OPENAI_URL = "https://api.openai.com/v1";\nawait fetch(OPENAI_URL);\n`,
+		);
+		const matches = await client.runQueryOnFile(query, filePath, "typescript");
+		expect(matches.length).toBe(0);
+	});
+
+	it("does not flag fetch of a lowercase const initialized with a string literal", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const query = await getQuery("ts-ssrf");
+		const filePath = writeTempFile(
+			"ts",
+			`const targetUrl = "https://example.com/api";\nawait fetch(targetUrl);\n`,
+		);
+		const matches = await client.runQueryOnFile(query, filePath, "typescript");
+		expect(matches.length).toBe(0);
+	});
+
+	it("does not flag fetch of a const initialized with a substitution-free template literal", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const query = await getQuery("ts-ssrf");
+		const filePath = writeTempFile(
+			"ts",
+			"const OPENAI_URL = `https://api.openai.com/v1`;\nawait fetch(OPENAI_URL);\n",
+		);
+		const matches = await client.runQueryOnFile(query, filePath, "typescript");
+		expect(matches.length).toBe(0);
+	});
+
+	it("still flags fetch of an all-caps identifier assigned from tainted input (#963 regression this rework must not repeat)", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const query = await getQuery("ts-ssrf");
+		const filePath = writeTempFile(
+			"ts",
+			`const TARGET_URL = req.query.url;\nawait fetch(TARGET_URL);\n`,
+		);
+		const matches = await client.runQueryOnFile(query, filePath, "typescript");
+		expect(matches.length).toBeGreaterThan(0);
+	});
+
+	it("still flags fetch of an all-caps identifier assigned from a function call", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const query = await getQuery("ts-ssrf");
+		const filePath = writeTempFile(
+			"ts",
+			`const TARGET_URL = getUserSuppliedUrl();\nawait fetch(TARGET_URL);\n`,
+		);
+		const matches = await client.runQueryOnFile(query, filePath, "typescript");
+		expect(matches.length).toBeGreaterThan(0);
+	});
+
+	it("still flags fetch of an all-caps identifier assigned from a member expression", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const query = await getQuery("ts-ssrf");
+		const filePath = writeTempFile(
+			"ts",
+			`const TARGET_URL = settings.remoteEndpoint;\nawait fetch(TARGET_URL);\n`,
+		);
+		const matches = await client.runQueryOnFile(query, filePath, "typescript");
+		expect(matches.length).toBeGreaterThan(0);
+	});
+
+	it("still flags fetch of an all-caps identifier that is a function parameter", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const query = await getQuery("ts-ssrf");
+		const filePath = writeTempFile(
+			"ts",
+			`async function callWebhook(WEBHOOK_URL) {\n  await fetch(WEBHOOK_URL);\n}\n`,
+		);
+		const matches = await client.runQueryOnFile(query, filePath, "typescript");
+		expect(matches.length).toBeGreaterThan(0);
+	});
+
+	it("still flags fetch of a member expression (unchanged broad net)", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const query = await getQuery("ts-ssrf");
+		const filePath = writeTempFile(
+			"ts",
+			`await fetch(settings.endpoint);\n`,
+		);
+		const matches = await client.runQueryOnFile(query, filePath, "typescript");
+		expect(matches.length).toBeGreaterThan(0);
+	});
+
+	it("still flags fetch of a const reassigned after a literal initializer", async () => {
+		const client = getSharedTreeSitterClient()!;
+		const query = await getQuery("ts-ssrf");
+		const filePath = writeTempFile(
+			"ts",
+			`let TARGET_URL = "https://example.com";\nTARGET_URL = req.query.url;\nawait fetch(TARGET_URL);\n`,
+		);
+		const matches = await client.runQueryOnFile(query, filePath, "typescript");
+		expect(matches.length).toBeGreaterThan(0);
+	});
+
 	it("matches go path traversal sink", async () => {
 		const client = getSharedTreeSitterClient()!;
 		const query = await getQuery("go-path-traversal");


### PR DESCRIPTION
Closes #963. Reworked after an adversarial security review **rejected** the first attempt (`fix/963-ts-ssrf-fixed-endpoints`), which exempted any SCREAMING_SNAKE_CASE identifier by NAME and thereby silently missed real SSRF (`const USER_INPUT = req.query.url; fetch(USER_INPUT)` went unflagged — a #533 violation).

## Correct approach — prove it's a fixed literal, don't trust the name
New `resolvesToFileLiteralConst(name, rootNode)` in `clients/tree-sitter-client.ts`, called from the `ts_ssrf_sink` post-filter. A bare-identifier URL argument is exempted **only** when all hold, in the same file:
- exactly one `const` declarator for the name (ambiguous/shadowed → refuse),
- no `let`/`var` binding for it, no reassignment anywhere,
- initializer is a string literal or a template literal with **no** `${...}` substitutions.

On **any** resolution failure (unresolved, non-const, reassigned, or a non-literal initializer — `process.env.X`, a call, a member expression, another identifier) it **falls through to the pre-existing broad heuristic, unchanged** — so member expressions (`fetch(settings.endpoint)`), provenance-keyword names, and unresolved identifiers all keep being flagged exactly as before. Naming convention is never consulted. A false positive is acceptable; a missed SSRF is not.

## Tests (both directions, incl. the regression the old version failed)
`tests/clients/tree-sitter-security-gap-rules.test.ts` (+9): the critical positive — `const TARGET_URL = req.query.url; fetch(TARGET_URL)` **still flags** — plus assignment-from-call / -member / -param, and reassigned bindings, all still flag. Negatives confirm exemption only for genuinely literal consts (both UPPER_CASE and lowerCamelCase, and a no-substitution template).

## Verification
`npm run build` clean; `tree-sitter-security-gap-rules.test.ts` 29/29; **full** `npx tsc --project tsconfig.json --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)