### PR TITLE
fix(cli): out-of-band build-graph handles honest partial persist (closes #924, refs #936)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **`pi-lens build-graph` honestly reports a capped, over-the-cap persist**
+	(closes #924, refs #936 limit 3) — the CLI's build-attempt check no longer
+	mistakes the benign "succeeded, but persisted a partial subgraph" reason
+	(#960's over-cap circuit-breaker) for a hard failure: it now exits 0 and
+	prints a `PARTIAL persist` line with `persistedNodes=X/Y`,
+	`persistedEdges=X/Y`, and the cap that was hit, instead of either silently
+	reporting "done" or failing loudly on a build/persist that actually
+	succeeded. `flushReviewGraphPersist()` now returns the persisted
+	`coverage` so any standalone caller can make the same distinction.
+
 - **`ts-ssrf` no longer trusts naming convention as proof of a fixed URL**
 	(fixes #963) — the post-filter now resolves a bare `fetch(IDENT)` argument
 	against the file's AST and exempts it only when `IDENT` provably resolves

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -1512,6 +1512,9 @@ export interface ReviewGraphPersistFlushResult {
 	bytes?: number;
 	elements?: number;
 	reason?: string;
+	/** Honest total-vs-persisted counts when the cap forced a partial snapshot
+	 * (#936 limit 3) — standalone callers must surface this, not just "ok". */
+	coverage?: ReviewGraphPersistCoverage;
 }
 
 /**
@@ -1604,6 +1607,7 @@ export function flushReviewGraphPersist(
 			path: pending.cachePath,
 			bytes: gzip.byteLength,
 			elements: pending.elementCount,
+			coverage: pending.graph.persistCoverage,
 		};
 	} catch (err) {
 		const reason = err instanceof Error ? err.message : String(err);

--- a/mcp/cli.ts
+++ b/mcp/cli.ts
@@ -58,7 +58,13 @@ async function buildGraph(): Promise<void> {
 	const startedAt = Date.now();
 	const graph = await buildOrUpdateGraph(cwd, [], new FactStore());
 	const attempt = getLastReviewGraphBuildAttempt(cwd);
-	if (!attempt || attempt.outcome !== "succeeded" || attempt.reason) {
+	// "succeeded" can still carry a `reason` string — persistGraph() stamps one
+	// on to explain a partial (over-cap) persist, which is NOT a failure (#960
+	// made a capped persist honest-but-successful). Only "failed"/"skipped"
+	// (unsafe_root, source-file cap, thrown build error) are real failures; a
+	// benign reason on a succeeded build is surfaced later via coverage
+	// instead of being treated as fatal here.
+	if (!attempt || attempt.outcome !== "succeeded") {
 		fail(attempt?.reason ?? attempt?.outcome ?? "build produced no result");
 	}
 
@@ -85,6 +91,21 @@ async function buildGraph(): Promise<void> {
 	}
 
 	const durationMs = Date.now() - startedAt;
+	const coverage = persisted.coverage;
+	if (coverage?.partial) {
+		// #533/#936 honesty: an over-cap build DID succeed and DID persist, but
+		// only a subgraph — say so plainly instead of printing the same line a
+		// full build would, which would silently misrepresent a capped repo as
+		// fully covered.
+		process.stdout.write(
+			`pi-lens build-graph: PARTIAL persist (cap=${coverage.cap} exceeded) ` +
+				`files=${graph.fileNodes.size} nodes=${graph.nodes.size} ` +
+				`edges=${graph.edges.length} persistedNodes=${coverage.persistedNodes}/${coverage.totalNodes} ` +
+				`persistedEdges=${coverage.persistedEdges}/${coverage.totalEdges} ` +
+				`elements=${persisted.elements} jsonBytes=${persisted.bytes} durationMs=${durationMs}\n`,
+		);
+		return;
+	}
 	process.stdout.write(
 		`pi-lens build-graph: files=${graph.fileNodes.size} nodes=${graph.nodes.size} ` +
 			`edges=${graph.edges.length} elements=${persisted.elements} ` +

--- a/tests/mcp/build-graph-cli.test.ts
+++ b/tests/mcp/build-graph-cli.test.ts
@@ -8,6 +8,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { gunzipSync } from "node:zlib";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { removeTempDirSync } from "../clients/test-utils.js";
 
@@ -17,6 +18,7 @@ const binJs = path.join(repoRoot, "mcp", "cli.js");
 function runCli(
 	args: string[],
 	dataDir: string,
+	extraEnv?: Record<string, string>,
 ): Promise<{ stdout: string; stderr: string; code: number }> {
 	return new Promise((resolve, reject) => {
 		const child = spawn(process.execPath, [binJs, ...args], {
@@ -24,6 +26,7 @@ function runCli(
 				...process.env,
 				PILENS_DATA_DIR: dataDir,
 				PI_LENS_GRAPH_PERSIST_DEBOUNCE_MS: "60000",
+				...extraEnv,
 			},
 			stdio: ["ignore", "pipe", "pipe"],
 		});
@@ -96,5 +99,68 @@ describe("pi-lens build-graph CLI", () => {
 		expect(result.code).not.toBe(0);
 		expect(result.stdout).toBe("");
 		expect(result.stderr).toContain("pi-lens build-graph failed: unsafe_root");
+	});
+
+	// #936 limit 3 review: an over-cap out-of-band build must still exit 0 and
+	// persist a useful subgraph (#960's partial-persist circuit-breaker fix) —
+	// but the CLI must say PARTIAL, not print the same "done" line a full
+	// build would (#533 honesty). A prior version of this CLI mistook the
+	// benign "succeeded, but persisted partial" build-attempt reason for a
+	// hard failure and exited non-zero here.
+	it("persists a PARTIAL subgraph and surfaces it honestly when over the element cap", async () => {
+		const overCapTempRoot = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-build-graph-cli-overcap-"),
+		);
+		const overCapProjectDir = path.join(overCapTempRoot, "project");
+		const overCapDataDir = path.join(overCapTempRoot, "data");
+		fs.mkdirSync(path.join(overCapProjectDir, "src"), { recursive: true });
+		// A handful of interdependent files is enough to clear a cap of 1 element.
+		for (let i = 0; i < 5; i++) {
+			const importLine =
+				i === 0 ? "" : `import { value${i - 1} } from "./m${i - 1}.js";\n`;
+			const expr = i === 0 ? `${i}` : `${i} + value${i - 1}`;
+			fs.writeFileSync(
+				path.join(overCapProjectDir, "src", `m${i}.ts`),
+				`${importLine}export const value${i} = ${expr};\n`,
+			);
+		}
+		try {
+			const result = await runCli(
+				["build-graph", "--cwd", overCapProjectDir],
+				overCapDataDir,
+				{ PI_LENS_GRAPH_PERSIST_MAX_ELEMENTS: "1" },
+			);
+			expect(result.code).toBe(0);
+			expect(result.stdout).toMatch(/^pi-lens build-graph: PARTIAL persist/);
+			expect(result.stdout).toMatch(/persistedNodes=\d+\/\d+/);
+			expect(result.stdout).toMatch(/persistedEdges=\d+\/\d+/);
+			expect(result.stdout).toMatch(/cap=1/);
+
+			const snapshotPaths = fs
+				.readdirSync(overCapDataDir, { recursive: true })
+				.filter((entry) => String(entry).endsWith("review-graph.json.gz"))
+				.map((entry) => path.join(overCapDataDir, String(entry)));
+			expect(snapshotPaths).toHaveLength(1);
+			const persisted = JSON.parse(
+				gunzipSync(fs.readFileSync(snapshotPaths[0])).toString("utf-8"),
+			) as {
+				coverage?: {
+					partial: boolean;
+					cap: number;
+					totalNodes: number;
+					totalEdges: number;
+					persistedNodes: number;
+					persistedEdges: number;
+				};
+			};
+			expect(persisted.coverage?.partial).toBe(true);
+			expect(persisted.coverage?.cap).toBe(1);
+			expect(persisted.coverage?.persistedNodes ?? 0).toBeLessThanOrEqual(
+				persisted.coverage?.totalNodes ?? 0,
+			);
+			expect(persisted.coverage?.totalNodes ?? 0).toBeGreaterThan(0);
+		} finally {
+			removeTempDirSync(overCapTempRoot);
+		}
 	});
 });


### PR DESCRIPTION
Closes #924, refs #936 (limit 3 — out-of-band build; #936 stays open for limit 2, cross-session resume).

The out-of-band `build-graph` CLI (`mcp/cli.ts`) already existed from earlier #924 work — it correctly reuses `buildOrUpdateGraph` + `flushReviewGraphPersist` (same `reviewGraphCachePath`, same gzip format, no parallel walk). But its failure gate had a real bug surfaced by the #960 partial-persist landing:

`if (!attempt || attempt.outcome !== "succeeded" || attempt.reason) fail(...)` treated **any** non-empty `reason` on a `succeeded` build as fatal. But #960's `persistGraph()` stamps a `reason` — `"persisted partial review graph (X/Y elements…)"` — on a genuinely successful, honestly-capped persist. So an out-of-band build on a repo over `PI_LENS_GRAPH_PERSIST_MAX_ELEMENTS` (exactly the large-monorepo CI/cron case #924 exists for) would **exit non-zero and print "failed"** even though the build succeeded and a useful partial subgraph was written.

Fix:
- `clients/review-graph/builder.ts`: expose `coverage?: ReviewGraphPersistCoverage` on `ReviewGraphPersistFlushResult`.
- `mcp/cli.ts`: gate only on `outcome === "failed"/"skipped"` (unsafe root, source cap, thrown error); on a partial-but-successful persist, print an honest `PARTIAL persist (cap=N exceeded) … persistedNodes=X/Y persistedEdges=X/Y` line and exit 0 (#533 — a capped repo must not be misreported as fully covered). Full-persist and real-failure paths untouched.

Tests: `tests/mcp/build-graph-cli.test.ts` +over-cap case (`PI_LENS_GRAPH_PERSIST_MAX_ELEMENTS=1`) asserting exit 0, the `PARTIAL persist` stdout, and on-disk `coverage.partial === true`.

Verified: `npm run build` clean; `build-graph-cli.test.ts` 4/4; full `npx tsc --project tsconfig.json --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)