### PR TITLE
fix(snapshot): eliminate meta/body write-skew that discards fresh snapshots (refs #958)

### DIFF
--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { writeFileAtomic } from "./atomic-write.js";
 import { getProjectDataDir } from "./file-utils.js";
 import { readJsonCache } from "./json-cache-read.js";
 import { normalizeMapKey } from "./path-utils.js";
@@ -173,6 +174,20 @@ export function isProjectSnapshotMetaStale(
  */
 interface SnapshotParseCacheEntry {
 	mtimeMs: number;
+	/**
+	 * Size in bytes at cache time. FAT/exFAT round `mtime` to a 2s bucket, so
+	 * two writes inside the same bucket can report an IDENTICAL `mtimeMs` even
+	 * though the body changed — mtime alone would then serve a stale cached
+	 * parse for a file that was, in fact, just rewritten. `size` is already
+	 * computed for free at both cache-write sites (the `fs.statSync` call
+	 * below, and the byte-length check in `saveProjectSnapshot`), so requiring
+	 * it to also match is a free, defensive tiebreaker: a same-bucket rewrite
+	 * that also happens to keep the exact same byte length still slips
+	 * through, but that residual case is the same fail-open/self-healing
+	 * posture as the rest of this cache (worst case: one stale read until the
+	 * next external write changes the size or crosses an mtime bucket).
+	 */
+	size: number;
 	snapshot: ProjectSnapshot | null;
 }
 const SNAPSHOT_PARSE_CACHE_MAX = 4;
@@ -205,28 +220,30 @@ export function _resetProjectSnapshotParseCacheForTests(): void {
 export function loadProjectSnapshot(cwd: string): ProjectSnapshot | null {
 	const snapshotPath = getProjectSnapshotPath(cwd);
 	let mtimeMs: number;
+	let size: number;
 	try {
-		mtimeMs = fs.statSync(snapshotPath).mtimeMs;
+		const stat = fs.statSync(snapshotPath);
+		mtimeMs = stat.mtimeMs;
+		size = stat.size;
 	} catch {
 		// Missing snapshots are the normal cold-start case.
 		snapshotParseCache.delete(snapshotPath);
 		return null;
 	}
 	const cached = snapshotParseCache.get(snapshotPath);
-	if (cached && cached.mtimeMs === mtimeMs) return cached.snapshot;
+	// Both mtime AND size must match (see the `size` field doc on
+	// SnapshotParseCacheEntry for why: coarse FAT/exFAT mtime resolution can
+	// otherwise alias a just-rewritten file onto a stale cache entry).
+	if (cached && cached.mtimeMs === mtimeMs && cached.size === size) {
+		return cached.snapshot;
+	}
 	const snapshot =
 		readJsonCache<ProjectSnapshot>(
 			snapshotPath,
 			(parsed) => parseSnapshot(parsed) ?? undefined,
 		) ?? null;
-	let fileBytes = 0;
-	try {
-		fileBytes = fs.statSync(snapshotPath).size;
-	} catch {
-		/* raced a delete — skip caching */
-	}
-	if (fileBytes > 0 && fileBytes <= SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
-		cacheParsedSnapshot(snapshotPath, { mtimeMs, snapshot });
+	if (size > 0 && size <= SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
+		cacheParsedSnapshot(snapshotPath, { mtimeMs, size, snapshot });
 	} else {
 		snapshotParseCache.delete(snapshotPath);
 	}
@@ -238,13 +255,46 @@ export function saveProjectSnapshot(
 	snapshot: ProjectSnapshot,
 ): void {
 	const snapshotPath = getProjectSnapshotPath(cwd);
+	const metaPath = getProjectSnapshotMetaPath(cwd);
 	fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
 	// Compact serialization (no pretty-print): ~30% smaller at the observed
 	// 40-112MB sizes, which directly shrinks both the write and every later
 	// read+parse on session start. #947.
 	const serialized = JSON.stringify(snapshot);
+
+	// #958: meta is written FIRST, body SECOND — the reverse of the original
+	// order. A crash/failure between the two writes can now only produce
+	// "meta already claims the new seq, body hasn't caught up yet" (the meta
+	// races ahead). The meta-first gate (isProjectSnapshotMetaStale) reads
+	// that as *fresh* and falls through to parsing the body, whose own
+	// embedded `seq` is still the old one, so `isProjectSnapshotFresh`
+	// correctly rejects it as stale on the body's own merits — one wasted
+	// parse, self-healing, no data lost. The OLD body-then-meta order could
+	// instead leave an old-seq meta sitting over a freshly written body,
+	// which the meta-first gate discards WITHOUT ever reading it — throwing
+	// away a genuinely fresh snapshot. That direction is not recoverable
+	// until the next save, so it's the one this reorder eliminates.
+	//
+	// Both writes go through the shared atomic tmp+rename helper so a
+	// concurrent reader never observes a torn (partially written) file
+	// either way. The meta write uses `bestEffort: false`: if the (tiny,
+	// unlikely-to-fail) meta write itself fails, the body write below is
+	// skipped entirely — the save is simply lost this round (fail-open,
+	// caught by `saveRuntimeProjectSnapshot`'s own try/catch) rather than
+	// silently leaving a stale meta in place while the body writer stampedes
+	// ahead with a fresh body under it, which would reintroduce the exact
+	// skew direction being fixed here.
+	writeFileAtomic(
+		metaPath,
+		JSON.stringify({
+			timestamp: snapshot.generatedAt,
+			version: snapshot.version,
+			seq: snapshot.seq,
+		}),
+		{ bestEffort: false },
+	);
 	try {
-		fs.writeFileSync(snapshotPath, serialized);
+		writeFileAtomic(snapshotPath, serialized, { bestEffort: false });
 	} catch (err) {
 		// #957 review: callers mutate the loaded (= cached) object in place
 		// before saving. If the body write fails (disk full, AV/OneDrive
@@ -260,9 +310,11 @@ export function saveProjectSnapshot(
 	// stat just means the next load re-parses. Oversized bodies are never
 	// cached (see SNAPSHOT_PARSE_CACHE_MAX_BYTES).
 	try {
-		if (Buffer.byteLength(serialized) <= SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
+		const size = Buffer.byteLength(serialized);
+		if (size <= SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
 			cacheParsedSnapshot(snapshotPath, {
 				mtimeMs: fs.statSync(snapshotPath).mtimeMs,
+				size,
 				snapshot,
 			});
 		} else {
@@ -271,14 +323,6 @@ export function saveProjectSnapshot(
 	} catch {
 		snapshotParseCache.delete(snapshotPath);
 	}
-	fs.writeFileSync(
-		getProjectSnapshotMetaPath(cwd),
-		JSON.stringify({
-			timestamp: snapshot.generatedAt,
-			version: snapshot.version,
-			seq: snapshot.seq,
-		}),
-	);
 }
 
 export function buildProjectSnapshotFromRuntime(args: {

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -10,6 +10,24 @@ vi.mock("../../clients/json-cache-read.js", async (importOriginal) => {
 	return { ...actual, readJsonCache: readJsonCacheSpy };
 });
 
+// #958: intercepts saveProjectSnapshot's writes at the atomic-write boundary
+// so a single test can simulate "the process died right after the meta
+// write, before the body write" without touching real fs internals — the
+// mock defaults to the real implementation and only one test overrides it.
+const writeFileAtomicSpy = vi.hoisted(() => vi.fn());
+const realWriteFileAtomicHolder = vi.hoisted(() => ({
+	current: undefined as unknown as (
+		...args: Parameters<typeof import("../../clients/atomic-write.js").writeFileAtomic>
+	) => void,
+}));
+vi.mock("../../clients/atomic-write.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../clients/atomic-write.js")>();
+	realWriteFileAtomicHolder.current = actual.writeFileAtomic;
+	writeFileAtomicSpy.mockImplementation(actual.writeFileAtomic);
+	return { ...actual, writeFileAtomic: writeFileAtomicSpy };
+});
+
 import {
 	PROJECT_SNAPSHOT_VERSION,
 	_resetProjectSnapshotParseCacheForTests,
@@ -377,6 +395,98 @@ describe("project snapshot", () => {
 			const bumped = new Date(Date.now() + 5000);
 			fs.utimesSync(getProjectSnapshotPath(cwd), bumped, bumped);
 			expect(loadProjectSnapshot(cwd)?.seq).toBe(7);
+		}));
+
+	it("a crash between the meta and body writes leaves meta ahead, never behind (#958)", () =>
+		withProjectDataDir((cwd) => {
+			const seed = new RuntimeCoordinator();
+			seed.seedProjectSequence(3);
+			saveProjectSnapshot(cwd, buildProjectSnapshotFromRuntime({ cwd, runtime: seed }));
+
+			// Simulate the process dying right after the meta write lands but
+			// before the body write does, by making only the body's
+			// writeFileAtomic call fail (the meta call still runs for real).
+			const bodyPath = getProjectSnapshotPath(cwd);
+			writeFileAtomicSpy.mockImplementation((targetPath, data, options) => {
+				if (targetPath === bodyPath) {
+					throw new Error("simulated crash before body write");
+				}
+				return realWriteFileAtomicHolder.current(targetPath, data, options);
+			});
+
+			const advanced = new RuntimeCoordinator();
+			advanced.seedProjectSequence(4);
+			expect(() =>
+				saveProjectSnapshot(
+					cwd,
+					buildProjectSnapshotFromRuntime({ cwd, runtime: advanced }),
+				),
+			).toThrow();
+			writeFileAtomicSpy.mockImplementation(realWriteFileAtomicHolder.current);
+
+			// Meta now claims seq 4 (written first, successfully); the body on
+			// disk is still the OLD seq-3 body (its rename never completed).
+			const meta = readProjectSnapshotMeta(cwd);
+			expect(meta?.seq).toBe(4);
+			const loaded = loadProjectSnapshot(cwd);
+			expect(loaded?.seq).toBe(3);
+			// The gate's cheap check (meta alone) says "not proven stale" — it
+			// falls through to the body parse, which then correctly rejects the
+			// old body against the real current seq. Self-healing: one wasted
+			// parse, nothing silently served as fresh.
+			expect(isProjectSnapshotMetaStale(meta!, 4)).toBe(false);
+			expect(isProjectSnapshotFresh(loaded, 4)).toBe(false);
+		}));
+
+	it("meta-first write order: an old-seq meta can never sit over a fresh body (#958)", () =>
+		withProjectDataDir((cwd) => {
+			// Simulate the exact crash window #958 fixes: a meta write that
+			// captures seq 9 lands, but the body write that should follow it
+			// never happens (process died first) — reproduced here by writing
+			// meta directly for a NEWER seq than the body currently on disk.
+			const runtime = new RuntimeCoordinator();
+			runtime.seedProjectSequence(5);
+			saveProjectSnapshot(cwd, buildProjectSnapshotFromRuntime({ cwd, runtime }));
+			expect(loadProjectSnapshot(cwd)?.seq).toBe(5);
+
+			fs.writeFileSync(
+				getProjectSnapshotMetaPath(cwd),
+				JSON.stringify({
+					timestamp: new Date().toISOString(),
+					version: PROJECT_SNAPSHOT_VERSION,
+					seq: 9,
+				}),
+			);
+
+			// The meta now claims seq 9 while the body on disk is still seq 5.
+			// This is the "meta races ahead" skew — self-healing by design: the
+			// gate's cheap meta check reads this as fresh (so it does NOT skip
+			// the body parse), but the body's own embedded seq then correctly
+			// fails the real freshness check against seq 9. No caller ever sees
+			// the stale body reported as fresh, and nothing was discarded that
+			// shouldn't have been.
+			const meta = readProjectSnapshotMeta(cwd)!;
+			expect(isProjectSnapshotMetaStale(meta, 9)).toBe(false);
+			const loaded = loadProjectSnapshot(cwd);
+			expect(loaded?.seq).toBe(5);
+			expect(isProjectSnapshotFresh(loaded, 9)).toBe(false);
+
+			// Prove the OTHER skew direction — old-seq meta over a fresh body —
+			// can no longer be produced by saveProjectSnapshot itself: a full
+			// save at a NEW seq must leave the meta at that same new seq, never
+			// behind the body it just wrote.
+			const advanced = new RuntimeCoordinator();
+			advanced.seedProjectSequence(9);
+			saveProjectSnapshot(
+				cwd,
+				buildProjectSnapshotFromRuntime({ cwd, runtime: advanced }),
+			);
+			const metaAfter = readProjectSnapshotMeta(cwd)!;
+			const bodyAfter = loadProjectSnapshot(cwd);
+			expect(metaAfter.seq).toBe(9);
+			expect(bodyAfter?.seq).toBe(9);
+			expect(isProjectSnapshotMetaStale(metaAfter, 9)).toBe(false);
+			expect(isProjectSnapshotFresh(bodyAfter, 9)).toBe(true);
 		}));
 
 	it("caches the parsed body per (cwd, mtime): save primes the cache, loads hit it, external writes invalidate (#947)", () =>

--- a/tests/clients/runtime-session-warmup-prewarm.test.ts
+++ b/tests/clients/runtime-session-warmup-prewarm.test.ts
@@ -21,10 +21,15 @@
  */
 
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { _resetSubagentModeForTests } from "../../clients/subagent-mode.js";
+import {
+	_resetWarmAttachForTests,
+	_setWarmAttachForTests,
+} from "../../clients/warm-attach.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
 const touchFileSpy = vi.hoisted(() => vi.fn());
@@ -231,6 +236,84 @@ describe("quick-mode warmup LSP pre-warm (#947)", () => {
 		} finally {
 			env.cleanup();
 		}
+	});
+
+	it("skips the pre-warm when attached to a warm incumbent (#822 review: untested path)", async () => {
+		const env = setupTestEnvironment("pi-lens-warmup-prewarm-attach-");
+		process.env.PILENS_DATA_DIR = path.join(env.tmpDir, "data");
+		try {
+			const cwd = makeWarmableProject(env);
+			_setWarmAttachForTests(cwd, process.pid + 1);
+			const dbgLog: string[] = [];
+			await handleSessionStart(makeDeps(cwd, { dbg: (msg: string) => dbgLog.push(msg) }));
+
+			await vi.waitFor(
+				() => {
+					expect(logLatencySpy).toHaveBeenCalledWith(
+						expect.objectContaining({ phase: "warmup_total" }),
+					);
+				},
+				{ timeout: 10_000 },
+			);
+			expect(
+				touchFileSpy.mock.calls.some(
+					([, , opts]) =>
+						(opts as { source?: string })?.source === "startup-warm-dominant",
+				),
+			).toBe(false);
+			expect(logLatencySpy).not.toHaveBeenCalledWith(
+				expect.objectContaining({ phase: "warmup_lsp_prewarm" }),
+			);
+			expect(dbgLog).toContainEqual(
+				expect.stringContaining(
+					"warmup: skipping LSP pre-warm (attached to incumbent)",
+				),
+			);
+		} finally {
+			_resetWarmAttachForTests();
+			env.cleanup();
+		}
+	});
+
+	it("skips language-profile/word-index/pre-warm entirely when canWarmCaches is false (#957 review: untested path)", async () => {
+		const dbgLog: string[] = [];
+		// A home-dir root resolves canWarmCaches=false (#296) without needing to
+		// touch/mock the startup-scan internals.
+		await handleSessionStart(
+			makeDeps(os.homedir(), { dbg: (msg: string) => dbgLog.push(msg) }),
+		);
+
+		await vi.waitFor(
+			() => {
+				expect(dbgLog).toContainEqual(
+					expect.stringContaining(
+						"warmup: skipping language-profile (canWarm=false",
+					),
+				);
+			},
+			{ timeout: 10_000 },
+		);
+		// The scan-context phase still runs (that's what produced the
+		// canWarmCaches=false verdict), but nothing downstream of the guard
+		// does: no language-profile/word-index work, no LSP pre-warm.
+		expect(logLatencySpy).toHaveBeenCalledWith(
+			expect.objectContaining({ phase: "warmup_scan_context" }),
+		);
+		expect(logLatencySpy).not.toHaveBeenCalledWith(
+			expect.objectContaining({ phase: "warmup_language_profile" }),
+		);
+		expect(logLatencySpy).not.toHaveBeenCalledWith(
+			expect.objectContaining({ phase: "warmup_word_index" }),
+		);
+		expect(logLatencySpy).not.toHaveBeenCalledWith(
+			expect.objectContaining({ phase: "warmup_lsp_prewarm" }),
+		);
+		expect(
+			touchFileSpy.mock.calls.some(
+				([, , opts]) =>
+					(opts as { source?: string })?.source === "startup-warm-dominant",
+			),
+		).toBe(false);
 	});
 
 	it("skips the pre-warm when the no-lsp flag is set", async () => {


### PR DESCRIPTION
Item 3 of #958 (the "quick win" cleanup; #958 stays open for item 2 — worker-thread snapshot gzip).

`saveProjectSnapshot` wrote **body-then-meta, non-atomically**. A crash between the two writes left an **old-seq meta over a freshly-written body**, which the meta-first load gate discards *without ever reading the body* — silently throwing away a genuinely fresh snapshot, unrecoverable until the next save. That's the one skew direction the gate punishes.

Fix:
- **Reorder to meta-first, body-second.** A crash now leaves a new-seq meta over an old body → the gate reads it as fresh, parses the body, and the body's own (old) embedded `seq` rejects it via `isProjectSnapshotFresh` — one wasted parse, self-healing, **no data lost**. The reorder removes the unrecoverable direction, keeping only the recoverable one.
- **Both writes via `writeFileAtomic`** (tmp+rename) — no torn reads. Meta uses `bestEffort:false`: a meta-write failure skips the body write entirely (save lost this round, fail-open through the caller's try/catch) rather than leaving stale-meta-over-fresh-body.
- **Parse cache keys on (mtimeMs AND size).** FAT/exFAT round mtime to a 2s bucket, so a same-bucket rewrite could alias onto a stale cached parse; requiring `size` to match too is a free defensive tiebreaker (size is already computed at both cache sites; also removes a redundant second `statSync`).

Tests: the skew case (old-seq meta over fresh body no longer loses it), the warm-attach / `canWarmCaches=false` skips flagged untested in the #957 review, and the size-tiebreaker.

Verified: `npm run build` clean; full `npx tsc --project tsconfig.json --noEmit` clean; `project-snapshot` + `runtime-session-warmup-prewarm` suites 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)