### PR TITLE
feat(typos): ship a default identifier allowlist, deferring to any project config (closes #967)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ All notable changes to pi-lens will be documented in this file.
 	succeeded. `flushReviewGraphPersist()` now returns the persisted
 	`coverage` so any standalone caller can make the same distinction.
 
+- **Bundled default typos allowlist for projects without their own config**
+	(fixes #967) — the `typos` auxiliary LSP now injects a small pi-lens-shipped
+	`_typos.toml` (`rules/typos/_typos.toml`, `[default.extend-identifiers]`
+	only: `dito`, `unparseable`) via `initializationOptions.config` whenever a
+	project has no `typos.toml`/`_typos.toml`/`.typos.toml` of its own. A
+	project's own config still always wins outright: when one is found,
+	pi-lens injects nothing at all (rather than letting typos-lsp merge ours
+	on top and risk our defaults outranking the team's own allowlist on key
+	collisions).
+
 - **`ts-ssrf` no longer trusts naming convention as proof of a fixed URL**
 	(fixes #963) — the post-filter now resolves a bare `fetch(IDENT)` argument
 	against the file's AST and exempts it only when `IDENT` provably resolves

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -36,6 +36,8 @@ import { isZizmorAuditTarget, resolveZizmorGitHubToken } from "../zizmor-config.
 import { logLatency } from "../latency-logger.js";
 import { logSessionStart } from "../sessionstart-logger.js";
 import { findLocalSgconfig, resolveBaselineSgconfig } from "../sgconfig.js";
+import { findLocalTyposConfig } from "../typos-config.js";
+import { resolvePackagePath } from "../package-root.js";
 import { resolveAstGrepNativeExe } from "./wait-policy/index.js";
 import { isCommandAvailableAsync, safeSpawnAsync } from "../safe-spawn.js";
 import { type LSPProcess, launchLSP } from "./launch.js";
@@ -2802,6 +2804,22 @@ const TYPOS_EXTENSIONS: readonly string[] = Array.from(
 	new Set([...OPENGREP_EXTENSIONS, ...KIND_EXTENSIONS["markdown"]]),
 );
 
+// #967: typos-lsp's `initializationOptions.config` is a filesystem PATH to a
+// config file (confirmed against upstream source — crates/typos-lsp/src/lsp.rs
+// reads `config` as a string and tilde-expands it into a PathBuf; it is never
+// an inline TOML string nor a parsed table). typos-lsp then MERGES that config
+// with any repo-local one it discovers itself, with the injected config
+// taking precedence on key collisions — so a project's own config must never
+// be injected alongside ours (see findLocalTyposConfig below): honoring an
+// existing project config means injecting NOTHING, letting typos-lsp read the
+// project's file untouched.
+function typosInitialization(root: string): Record<string, unknown> | undefined {
+	if (findLocalTyposConfig(root)) return undefined;
+	return {
+		config: resolvePackagePath(import.meta.url, "rules", "typos", "_typos.toml"),
+	};
+}
+
 export const TyposServer: LSPServerInfo = {
 	id: "typos",
 	name: "typos Spell Checker",
@@ -2812,7 +2830,7 @@ export const TyposServer: LSPServerInfo = {
 	root: RootWithFallback(NearestRoot([".git"]), async () => process.cwd()),
 	availabilityKey: "typos-lsp",
 	async spawn(root, options) {
-		return resolveAndLaunch(
+		const launched = await resolveAndLaunch(
 			{
 				candidates: ["typos-lsp"],
 				args: [],
@@ -2821,6 +2839,9 @@ export const TyposServer: LSPServerInfo = {
 			},
 			options?.allowInstall,
 		);
+		if (!launched) return undefined;
+		const initialization = typosInitialization(root);
+		return initialization ? { ...launched, initialization } : launched;
 	},
 	autoInstall: async () => Boolean(await ensureTool("typos-lsp")),
 };

--- a/rules/typos/_typos.toml
+++ b/rules/typos/_typos.toml
@@ -1,0 +1,17 @@
+# pi-lens bundled default typos allowlist (#967).
+#
+# This file is injected as `initializationOptions.config` for the `typos-lsp`
+# auxiliary server ONLY when a project has no local typos config of its own
+# (`typos.toml` / `_typos.toml` / `.typos.toml` — see clients/typos-config.ts).
+# Any project-owned config always wins outright: pi-lens injects nothing in
+# that case, so this file never merges with (and can never outrank) a team's
+# own allowlist.
+#
+# Keep this list to evidenced false positives only — exact-identifier matches
+# via `extend-identifiers`, never the looser `extend-words` (which also
+# rewrites substrings inside unrelated words). Do not bulk-import a
+# dictionary here; every entry must have a provenance comment.
+
+[default.extend-identifiers]
+dito = "dito"            # #967 — real model/vendor namespace (provider-failover normalization prefix), not a misspelling of "ditto"
+unparseable = "unparseable"  # #967 — valid English spelling ("un-parseable"), not a typo of "unparsable"

--- a/tests/clients/lsp/typos-server-init.test.ts
+++ b/tests/clients/lsp/typos-server-init.test.ts
@@ -1,0 +1,124 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { removeTempDirSync } from "../test-utils.js";
+
+// Set test mode to isolate logging from production logs
+process.env.PI_LENS_TEST_MODE = "1";
+
+const ensureTool = vi.fn();
+const getToolEnvironment = vi.fn(async () => ({}));
+const launchLSP = vi.fn();
+
+vi.mock("../../../clients/installer/index.js", () => ({
+	ensureTool,
+	getToolEnvironment,
+}));
+
+vi.mock("../../../clients/lsp/launch.js", () => ({
+	launchLSP,
+}));
+
+vi.mock("../../../clients/latency-logger.js", () => ({
+	logLatency: vi.fn(),
+	resetLatencyLog: vi.fn(),
+}));
+
+const dirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of dirs.splice(0)) {
+		removeTempDirSync(dir);
+	}
+	ensureTool.mockReset();
+	launchLSP.mockReset();
+	vi.resetModules();
+});
+
+function makeRoot(): string {
+	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-typos-root-"));
+	dirs.push(tmp);
+	return tmp;
+}
+
+describe("TyposServer.spawn initialization (#967)", () => {
+	it("steps aside (injects no config) when the project has its own typos config", async () => {
+		const root = makeRoot();
+		fs.writeFileSync(path.join(root, "_typos.toml"), "[default]\n");
+		launchLSP.mockResolvedValue({ pid: 123 } as never);
+
+		const { TyposServer } = await import("../../../clients/lsp/server.js");
+		const result = await TyposServer.spawn(root, { allowInstall: false });
+
+		expect(result).toBeDefined();
+		expect(result?.initialization).toBeUndefined();
+	});
+
+	it("injects the bundled config when the project has no typos config", async () => {
+		const root = makeRoot();
+		launchLSP.mockResolvedValue({ pid: 123 } as never);
+
+		const { TyposServer } = await import("../../../clients/lsp/server.js");
+		const result = await TyposServer.spawn(root, { allowInstall: false });
+
+		expect(result).toBeDefined();
+		const config = result?.initialization?.config;
+		expect(typeof config).toBe("string");
+		expect(path.isAbsolute(config as string)).toBe(true);
+		expect(fs.existsSync(config as string)).toBe(true);
+		expect(path.basename(config as string)).toBe("_typos.toml");
+	});
+});
+
+describe("bundled default typos config (#967)", () => {
+	const bundledPath = path.resolve(
+		__dirname,
+		"../../../rules/typos/_typos.toml",
+	);
+
+	/**
+	 * pi-lens has no bundled TOML parser dependency, so this walks the file
+	 * with a minimal line parser (stripping comments/blank lines, tracking the
+	 * current `[section]`) — enough to assert structure without pulling in a
+	 * new dependency just for a test.
+	 */
+	function parseSimpleToml(raw: string): {
+		sections: string[];
+		entries: Record<string, Record<string, string>>;
+	} {
+		const sections: string[] = [];
+		const entries: Record<string, Record<string, string>> = {};
+		let currentSection: string | undefined;
+		for (const rawLine of raw.split(/\r?\n/)) {
+			const line = rawLine.replace(/#.*$/, "").trim();
+			if (!line) continue;
+			const sectionMatch = line.match(/^\[([^\]]+)\]$/);
+			if (sectionMatch) {
+				currentSection = sectionMatch[1];
+				sections.push(currentSection);
+				entries[currentSection] = {};
+				continue;
+			}
+			const kvMatch = line.match(/^(\S+)\s*=\s*"([^"]*)"$/);
+			if (kvMatch && currentSection) {
+				entries[currentSection][kvMatch[1]] = kvMatch[2];
+			}
+		}
+		return { sections, entries };
+	}
+
+	it("exists", () => {
+		expect(fs.existsSync(bundledPath)).toBe(true);
+	});
+
+	it("contains only [default.extend-identifiers] — no bulk word-list suppression", () => {
+		const raw = fs.readFileSync(bundledPath, "utf8");
+		const { sections, entries } = parseSimpleToml(raw);
+		expect(sections).toEqual(["default.extend-identifiers"]);
+		expect(entries["default.extend-identifiers"]).toEqual({
+			dito: "dito",
+			unparseable: "unparseable",
+		});
+	});
+});


### PR DESCRIPTION
Closes #967. pi-lens's bundled `typos-lsp` flagged first-party/valid identifiers (`dito`, `unparseable`) from the crate's built-in dictionary, and the only remedy was for every project to add its own `_typos.toml`. Ship a curated default instead — while **always respecting a project's own config**.

## Design — step-aside gate (mirrors OpengrepServer)
`typosInitialization(root)` on `TyposServer`:
- **Project has `typos.toml`/`_typos.toml`/`.typos.toml`** (`findLocalTyposConfig`) → return `undefined`, inject **nothing**. typos-lsp reads the project's config untouched.
- **No project config** → inject `initializationOptions.config` = the bundled `rules/typos/_typos.toml`.

**Why step-aside, not layer-under (spike-confirmed against upstream `typos-lsp` source, `crates/typos-lsp/src/lsp.rs`):** `initializationOptions.config` is a filesystem **path** (never inline TOML), and typos-lsp **merges** it with any discovered project config with the *injected* config taking precedence on key collisions. So layering ours in would let pi-lens's defaults **outrank** a team's own allowlist — injecting nothing when a project config exists is the only way to truly honor it.

## Honesty (#533)
`rules/typos/_typos.toml` contains **only** `[default.extend-identifiers]` (exact-identifier match, never the looser `extend-words`), seeded **only** with the two evidenced false positives, each with a `#967` provenance comment. No bulk dictionary import. A test guards that the file stays `extend-identifiers`-only so it can't silently grow into broad suppression.

## Packaging
`package.json` `files` already ships `rules/`, so the asset is published automatically (no change needed).

## Tests
`tests/clients/lsp/typos-server-init.test.ts`: step-aside when a fixture root has a config; bundled-path injection when it doesn't; and the `extend-identifiers`-only guard.

Verified: `npm run build` clean; `tests/clients/lsp` 554 passed / 3 skipped; full `npx tsc --project tsconfig.json --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)