### PR TITLE
feat(review-graph): resumable cross-session graph build checkpointing (#936 limit 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **The review-graph full build is now resumable across sessions** (refs #936
+	limit 2) — a cold full build (walk + tree-sitter parse of every source file)
+	previously restarted from scratch every session, so on a large repo with
+	short-lived sessions it could never finish. The extraction loop now
+	periodically checkpoints the PRE-resolution graph plus the exact set of files
+	already folded into it (with content hashes) to a dedicated
+	`review-graph.checkpoint.json.gz`, and a later session resumes from it,
+	re-walking only files that changed/appeared since. The checkpoint lives in
+	its own file (never the authoritative `review-graph.json.gz`) and its
+	hydrated graph carries `persistCoverage.inProgress` on top of `partial`, so
+	no reader (`getCachedReviewGraph`, `loadPersistedGraph`) can ever serve or
+	launder a mid-build checkpoint as a complete graph (honesty doctrine, #533).
+	Resume equivalence to a cold build is guaranteed by `addFileToGraph`'s
+	per-file contribution being order-independent (all cross-file linking is
+	deferred to `resolveDeferredSymbolEdges`): content-changed processed files
+	are evicted and re-walked, orphaned placeholder nodes are pruned, and any
+	removed file, ignored-id-set change, version bump, or git-identity mismatch
+	fails open to a cold build rather than risking a wrong graph. Checkpoint
+	stride/interval are tunable via `PI_LENS_GRAPH_CHECKPOINT_EVERY_FILES` /
+	`PI_LENS_GRAPH_CHECKPOINT_MIN_INTERVAL_MS`.
+
 - **`pi-lens build-graph` honestly reports a capped, over-the-cap persist**
 	(closes #924, refs #936 limit 3) — the CLI's build-attempt check no longer
 	mistakes the benign "succeeded, but persisted a partial subgraph" reason

--- a/clients/review-graph-logger.ts
+++ b/clients/review-graph-logger.ts
@@ -24,7 +24,10 @@ export interface ReviewGraphLogEntry {
 		| "persist_succeeded"
 		| "persist_skipped"
 		| "persist_failed"
-		| "worker_fallback";
+		| "worker_fallback"
+		// #936 limit 2: cross-session resumable full build (checkpointing).
+		| "checkpoint_written"
+		| "checkpoint_resumed";
 	cwd: string;
 	reason?: string;
 	durationMs?: number;
@@ -39,6 +42,12 @@ export interface ReviewGraphLogEntry {
 	serializeMs?: number;
 	writeMs?: number;
 	offloaded?: boolean;
+	// #936: checkpoint telemetry (files processed / reused / re-walked / target).
+	processed?: number;
+	reused?: number;
+	stale?: number;
+	remaining?: number;
+	target?: number;
 }
 
 export function logReviewGraph(entry: ReviewGraphLogEntry): void {

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -827,6 +827,13 @@ function rebuildIndexes(graph: ReviewGraph): void {
 
 const GRAPH_CACHE_FILENAME = "review-graph.json.gz";
 const LEGACY_GRAPH_CACHE_FILENAME = "review-graph.json";
+// #936 limit 2: the mid-build resume checkpoint lives in its OWN file, distinct
+// from the authoritative `review-graph.json.gz`. Keeping it separate is the
+// core honesty guarantee — `loadPersistedGraph` / `getCachedReviewGraph` only
+// ever read the authoritative snapshot, so a mid-build checkpoint can never be
+// laundered to a consumer as a complete graph. It is read back exclusively by
+// the full-build resume path (`loadReviewGraphCheckpoint`).
+const GRAPH_CHECKPOINT_FILENAME = "review-graph.checkpoint.json.gz";
 
 interface PersistedGraphData {
 	version: string;
@@ -1466,6 +1473,330 @@ function persistGraph(
 	// Don't keep the event loop alive solely for a cache write.
 	if (typeof timer.unref === "function") timer.unref();
 	_persistTimers.set(key, timer);
+}
+
+// --- Cross-session resumable full build (checkpointing, #936 limit 2) ---
+// A full build walks + tree-sitter-parses every source file, then resolves
+// cross-file edges once at the end. On a large repo with short-lived sessions
+// that whole pass can be killed before it finishes and, with no checkpoint,
+// the next session starts from scratch — so it may NEVER complete. During the
+// full-build extraction loop we periodically snapshot the PRE-resolution graph
+// plus the exact set of files already folded into it (with content hashes) to
+// a dedicated checkpoint file. A later session resumes from that snapshot,
+// re-walking only files that changed/appeared since, and finishes the build.
+//
+// Correctness (equivalence to a cold full build) rests on one property of the
+// extraction: `addFileToGraph`'s per-file contribution (the nodes it adds and
+// the edges it adds, with their metadata) depends ONLY on that file's content
+// and the cwd — never on other files or on processing order, because ALL
+// cross-file linking is deferred to `resolveDeferredSymbolEdges`, run once
+// after every file is in. So the pre-resolution graph is the order-independent
+// union of per-file contributions (shared placeholder / imported-file stub
+// nodes are created idempotently by id). Resuming therefore reconstructs the
+// identical pre-resolution graph as long as the reused files' contributions
+// are still current — which the content-hash + ignored-id + git gates below
+// enforce, failing open to a cold build on any doubt.
+
+const GRAPH_CHECKPOINT_EVERY_FILES_DEFAULT = 250;
+const GRAPH_CHECKPOINT_MIN_INTERVAL_MS_DEFAULT = 5_000;
+
+function graphCheckpointEveryFiles(): number {
+	const raw = Number(process.env.PI_LENS_GRAPH_CHECKPOINT_EVERY_FILES);
+	return Number.isFinite(raw) && raw > 0
+		? Math.floor(raw)
+		: GRAPH_CHECKPOINT_EVERY_FILES_DEFAULT;
+}
+
+function graphCheckpointMinIntervalMs(): number {
+	const raw = Number(process.env.PI_LENS_GRAPH_CHECKPOINT_MIN_INTERVAL_MS);
+	return Number.isFinite(raw) && raw >= 0
+		? raw
+		: GRAPH_CHECKPOINT_MIN_INTERVAL_MS_DEFAULT;
+}
+
+interface ReviewGraphCheckpointData {
+	version: string;
+	builtAt: string;
+	/**
+	 * Honesty marker (#936): this payload is a MID-BUILD snapshot, never a
+	 * complete graph. Only the resume path in `_doBuildGraph` ever reads it.
+	 */
+	inProgress: true;
+	/** Total files this build is walking toward — telemetry only. */
+	targetFileCount: number;
+	/** Files whose per-file contribution is already in `nodes`/`edges`, keyed to
+	 * the sha256 of the exact bytes extracted, so a later session can detect and
+	 * re-walk any that changed since. */
+	processedFiles: Array<[string, string]>;
+	/** Fingerprint of the untracked-AND-ignored id set (#694) used during
+	 * extraction. It steers import-edge target resolution, so a change would make
+	 * reused files' edges stale — resume fails open to a cold build on mismatch. */
+	ignoredIdsHash: string;
+	/** PRE-resolution nodes (resolveDeferredSymbolEdges has NOT run). */
+	nodes: Array<[string, ReviewGraphNode]>;
+	/** PRE-resolution edges (cross-file `calls`/`references` still point at
+	 * unresolved placeholder nodes). */
+	edges: ReviewGraphEdge[];
+	gitStamp?: { headCommit: string; worktreeRoot: string };
+}
+
+function reviewGraphCheckpointPath(cwd: string): string {
+	return path.join(getProjectDataDir(cwd), "cache", GRAPH_CHECKPOINT_FILENAME);
+}
+
+/** Stable fingerprint of the untracked-ignored id set. `undefined` (fetch
+ * degraded / not requested) hashes distinctly from an empty set, so a resume
+ * only reuses a checkpoint built under the same ignore state. */
+function hashIgnoredIds(ignoredIds: ReadonlySet<string> | undefined): string {
+	if (ignoredIds === undefined) return "unavailable";
+	const joined = [...ignoredIds].sort((a, b) => a.localeCompare(b)).join(" ");
+	return createHash("sha256").update(joined).digest("hex");
+}
+
+/**
+ * Write a mid-build checkpoint for `cwd`. Best-effort and synchronous (mirrors
+ * the exit-hook flush): a lost checkpoint only costs a cold rebuild next time.
+ * `graph` MUST be pre-resolution; `processedHashes` MUST contain exactly the
+ * files already folded into it.
+ */
+function writeReviewGraphCheckpoint(
+	cwd: string,
+	graph: ReviewGraph,
+	processedHashes: Map<string, string>,
+	targetFileCount: number,
+	ignoredIds: ReadonlySet<string> | undefined,
+): void {
+	try {
+		const cacheDir = path.join(getProjectDataDir(cwd), "cache");
+		const data: ReviewGraphCheckpointData = {
+			version: REVIEW_GRAPH_VERSION,
+			builtAt: new Date().toISOString(),
+			inProgress: true,
+			targetFileCount,
+			processedFiles: Array.from(processedHashes.entries()),
+			ignoredIdsHash: hashIgnoredIds(ignoredIds),
+			nodes: Array.from(graph.nodes.entries()),
+			edges: graph.edges,
+			gitStamp: resolveGitIdentity(cwd),
+		};
+		const gzip = gzipSync(JSON.stringify(data));
+		fs.mkdirSync(cacheDir, { recursive: true });
+		writeFileAtomic(reviewGraphCheckpointPath(cwd), gzip, { bestEffort: true });
+		logReviewGraph({
+			cwd,
+			phase: "checkpoint_written",
+			nodes: graph.nodes.size,
+			edges: graph.edges.length,
+			processed: processedHashes.size,
+			target: targetFileCount,
+		});
+	} catch {
+		// Best-effort: a failed checkpoint just means no resume next session.
+	}
+}
+
+/** Remove the checkpoint once a complete authoritative graph exists (or when a
+ * stale checkpoint is discarded). Best-effort. */
+function deleteReviewGraphCheckpoint(cwd: string): void {
+	fs.rm(reviewGraphCheckpointPath(cwd), { force: true }, () => {});
+}
+
+interface LoadedReviewGraphCheckpoint {
+	/** Hydrated PRE-resolution graph, marked partial + inProgress. */
+	graph: ReviewGraph;
+	processedHashes: Map<string, string>;
+	ignoredIdsHash: string;
+	targetFileCount: number;
+}
+
+/**
+ * Read back a checkpoint for `cwd`, gated on the graph version (single source of
+ * truth: {@link REVIEW_GRAPH_VERSION}) and, when both stamps resolve, the git
+ * identity — the same drop-on-mismatch guard `loadPersistedGraph` uses. Returns
+ * null (and best-effort deletes an unusable file) when absent/stale/corrupt.
+ * The returned graph carries `persistCoverage.inProgress` so it can never be
+ * mistaken for a complete graph if it escapes the resume path.
+ */
+function loadReviewGraphCheckpoint(
+	cwd: string,
+): LoadedReviewGraphCheckpoint | null {
+	const checkpointPath = reviewGraphCheckpointPath(cwd);
+	let data: ReviewGraphCheckpointData;
+	try {
+		if (!fs.existsSync(checkpointPath)) return null;
+		data = JSON.parse(
+			gunzipSync(fs.readFileSync(checkpointPath)).toString("utf-8"),
+		) as ReviewGraphCheckpointData;
+	} catch {
+		deleteReviewGraphCheckpoint(cwd);
+		return null;
+	}
+	if (data.version !== REVIEW_GRAPH_VERSION || data.inProgress !== true) {
+		deleteReviewGraphCheckpoint(cwd);
+		return null;
+	}
+	if (data.gitStamp) {
+		const current = resolveGitIdentity(cwd);
+		if (
+			current &&
+			(current.headCommit !== data.gitStamp.headCommit ||
+				current.worktreeRoot !== data.gitStamp.worktreeRoot)
+		) {
+			deleteReviewGraphCheckpoint(cwd);
+			return null;
+		}
+	}
+	const totalNodes = data.nodes.length;
+	const totalEdges = data.edges.length;
+	const graph: ReviewGraph = {
+		version: data.version,
+		builtAt: data.builtAt,
+		nodes: new Map(data.nodes),
+		edges: data.edges,
+		edgesByFrom: new Map(),
+		edgesByTo: new Map(),
+		fileNodes: new Map(),
+		symbolNodesByFile: new Map(),
+		changedSymbolsByFile: new Map(),
+		persistCoverage: {
+			partial: true,
+			inProgress: true,
+			cap: 0,
+			totalNodes,
+			totalEdges,
+			persistedNodes: totalNodes,
+			persistedEdges: totalEdges,
+		},
+	};
+	rebuildIndexes(graph);
+	return {
+		graph,
+		processedHashes: new Map(data.processedFiles),
+		ignoredIdsHash: data.ignoredIdsHash,
+		targetFileCount: data.targetFileCount,
+	};
+}
+
+/**
+ * Drop nodes with no `filePath` (shared placeholder / imported-file-stub /
+ * external / module nodes) that no edge references after a stale-file eviction.
+ * A cold full build's pre-resolution graph never contains such zero-edge
+ * placeholders (each is created immediately before an edge to it, and the full
+ * path removes no edges), so pruning them makes a reconciled resume graph
+ * node-for-node identical to a cold build BEFORE `resolveDeferredSymbolEdges`
+ * runs. Must be called only on a pre-resolution graph.
+ */
+function pruneOrphanNonFileNodes(graph: ReviewGraph): void {
+	const referenced = new Set<string>();
+	for (const edge of graph.edges) {
+		referenced.add(edge.from);
+		referenced.add(edge.to);
+	}
+	for (const [id, node] of graph.nodes) {
+		if (!node.filePath && !referenced.has(id)) graph.nodes.delete(id);
+	}
+}
+
+interface ResumedBuild {
+	graph: ReviewGraph;
+	fileHashes: Map<string, string>;
+	remaining: string[];
+}
+
+/**
+ * Attempt to resume a full build for `cwd` from a prior session's checkpoint.
+ * Returns a seed graph (the reconciled pre-resolution checkpoint), the content
+ * hashes of the files it reuses, and the list of files still to extract; or
+ * null when there is no usable checkpoint (caller does a cold full build).
+ *
+ * Reconciliation vs. the CURRENT target file set (`filesToBuild`):
+ *  - A processed file no longer in the target set (deleted/renamed/now-excluded)
+ *    can invalidate OTHER kept files' import edges, which this pass does not
+ *    rebuild — so ANY such removal fails open to a cold build (correctness over
+ *    reuse, per #936).
+ *  - A processed file still present but whose content changed is evicted and
+ *    re-walked (its contribution is self-contained; cross-file links re-resolve
+ *    globally at the end).
+ *  - The ignored-id fingerprint must match (import-edge resolution depends on
+ *    it), else fail open.
+ */
+async function tryResumeFromCheckpoint(
+	cwd: string,
+	filesToBuild: string[],
+	ignoredIds: ReadonlySet<string> | undefined,
+): Promise<ResumedBuild | null> {
+	const loaded = loadReviewGraphCheckpoint(cwd);
+	if (!loaded) return null;
+	if (loaded.ignoredIdsHash !== hashIgnoredIds(ignoredIds)) {
+		deleteReviewGraphCheckpoint(cwd);
+		return null;
+	}
+	const targetSet = new Set(filesToBuild);
+	// Removed-file guard: a processed file gone from the target set can leave a
+	// kept importer's edges stale — fail open rather than serve a wrong graph.
+	for (const file of loaded.processedHashes.keys()) {
+		if (!targetSet.has(file)) {
+			deleteReviewGraphCheckpoint(cwd);
+			return null;
+		}
+	}
+	// Detect content changes among processed files (chunked stat/hash sweep).
+	const reusableHashes = new Map<string, string>();
+	const stale: string[] = [];
+	let sinceYield = 0;
+	for (const [file, priorHash] of loaded.processedHashes) {
+		const currentHash = contentHashEntry(file);
+		if (currentHash === priorHash) reusableHashes.set(file, currentHash);
+		else stale.push(file);
+		if (++sinceYield >= STAT_YIELD_EVERY) {
+			sinceYield = 0;
+			await yieldToLoop();
+		}
+	}
+	if (reusableHashes.size === 0) {
+		// Nothing survivable — no benefit over a cold build; discard.
+		deleteReviewGraphCheckpoint(cwd);
+		return null;
+	}
+	const graph = loaded.graph;
+	// Evict every stale (content-changed) processed file so its outdated
+	// contribution is replaced by a fresh walk below.
+	for (const file of stale) removeFileOwnedGraphData(graph, file);
+	pruneOrphanNonFileNodes(graph);
+	graph.changedSymbolsByFile = new Map();
+	const remaining = filesToBuild.filter((file) => !reusableHashes.has(file));
+	logReviewGraph({
+		cwd,
+		phase: "checkpoint_resumed",
+		reused: reusableHashes.size,
+		stale: stale.length,
+		remaining: remaining.length,
+		target: filesToBuild.length,
+	});
+	return { graph, fileHashes: reusableHashes, remaining };
+}
+
+/** Test-only: inspect the on-disk resume checkpoint for `cwd` (raw payload),
+ * or null when none is present. Lets tests assert the honesty marker and the
+ * recorded processed-file set without exporting the whole checkpoint machinery. */
+export function _readReviewGraphCheckpointForTests(cwd: string):
+	| {
+			inProgress: boolean;
+			processedFiles: string[];
+			nodeCount: number;
+			edgeCount: number;
+			persistCoverage: ReviewGraphPersistCoverage | undefined;
+	  }
+	| null {
+	const loaded = loadReviewGraphCheckpoint(cwd);
+	if (!loaded) return null;
+	return {
+		inProgress: loaded.graph.persistCoverage?.inProgress === true,
+		processedFiles: [...loaded.processedHashes.keys()],
+		nodeCount: loaded.graph.nodes.size,
+		edgeCount: loaded.graph.edges.length,
+		persistCoverage: loaded.graph.persistCoverage,
+	};
 }
 
 /** Test hook: force any pending debounced persist to write immediately. */
@@ -3281,13 +3612,29 @@ async function _doBuildGraph(
 		}
 	}
 
-	// Tier 3: full build
-	const graph = createEmptyGraph();
+	// Tier 3: full build — resumed from a prior session's checkpoint when one is
+	// present and still current (#936 limit 2), else cold from an empty graph.
+	const resumed = await tryResumeFromCheckpoint(cwd, filesToBuild, ignoredIds);
+	const graph = resumed?.graph ?? createEmptyGraph();
+	const filesToExtract = resumed?.remaining ?? filesToBuild;
 	const treeSitterClient = getSharedTreeSitterClient();
 	const extractionStartedAt = Date.now();
-	const fileHashes = new Map<string, string>();
+	// Seeded with the reused files' hashes on resume so the completed snapshot
+	// still records a hash for every file (needed by #202 incremental next time).
+	const fileHashes = resumed?.fileHashes ?? new Map<string, string>();
+	// #936: after each file, snapshot the PRE-resolution graph + processed-file
+	// hashes so a killed session can resume. Gated by BOTH a file-count stride
+	// and a min wall-time interval so a long build pays only a handful of writes.
+	const checkpointEvery = graphCheckpointEveryFiles();
+	const checkpointMinIntervalMs = graphCheckpointMinIntervalMs();
+	const testStopAfter = Number(
+		process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER,
+	);
+	let filesSinceCheckpoint = 0;
+	let lastCheckpointMs = Date.now();
+	let extractedCount = 0;
 	const extractFiles = async (): Promise<void> => {
-		for (const file of filesToBuild) {
+		for (const file of filesToExtract) {
 			let content: string | null;
 			try {
 				const bytes = fs.readFileSync(file);
@@ -3303,6 +3650,40 @@ async function _doBuildGraph(
 			await addFileToGraph(graph, cwd, file, facts, ignoredIds, content);
 			if (normalizedChangedSet.has(file)) {
 				upsertChangedSymbols(graph, facts, file);
+			}
+			extractedCount++;
+			filesSinceCheckpoint++;
+			// Test seam: simulate a session killed mid-build after N files, having
+			// just written a checkpoint. The next (un-stopped) build resumes it.
+			if (
+				Number.isFinite(testStopAfter) &&
+				testStopAfter > 0 &&
+				extractedCount >= testStopAfter
+			) {
+				writeReviewGraphCheckpoint(
+					cwd,
+					graph,
+					fileHashes,
+					filesToBuild.length,
+					ignoredIds,
+				);
+				throw new Error("__review_graph_checkpoint_test_abort__");
+			}
+			const remainingAfter = filesToExtract.length - extractedCount;
+			if (
+				filesSinceCheckpoint >= checkpointEvery &&
+				remainingAfter >= checkpointEvery &&
+				Date.now() - lastCheckpointMs >= checkpointMinIntervalMs
+			) {
+				writeReviewGraphCheckpoint(
+					cwd,
+					graph,
+					fileHashes,
+					filesToBuild.length,
+					ignoredIds,
+				);
+				filesSinceCheckpoint = 0;
+				lastCheckpointMs = Date.now();
 			}
 		}
 	};
@@ -3331,9 +3712,26 @@ async function _doBuildGraph(
 		await extractAndDrainIr();
 	}
 
+	// #936: a changed file that was REUSED from the checkpoint (unchanged content)
+	// is never revisited by the extraction loop above, so run its changed-symbol
+	// upsert here — matching what a cold build's inline pass would have done.
+	if (resumed) {
+		for (const file of normalizedChangedSet) {
+			if (resumed.fileHashes.has(file)) {
+				upsertChangedSymbols(graph, facts, file);
+			}
+		}
+	}
+
 	resolveDeferredSymbolEdges(graph);
 	graph.version = REVIEW_GRAPH_VERSION;
 	graph.builtAt = new Date().toISOString();
+	// #936: the build is now complete over the full target set — drop the
+	// in-progress/partial marker a resumed seed carried so the finished graph is
+	// never mistaken for (or persisted as) a partial one, and retire the
+	// checkpoint now that an authoritative snapshot supersedes it.
+	graph.persistCoverage = undefined;
+	deleteReviewGraphCheckpoint(cwd);
 	// #202: the full-build pass hashes the same bytes it supplies to extraction,
 	// so change detection does not reread every file after the graph is built.
 	// #459: full rebuild ⇒ new generation.

--- a/clients/review-graph/types.ts
+++ b/clients/review-graph/types.ts
@@ -114,6 +114,17 @@ export interface ReviewGraphPersistCoverage {
 	totalEdges: number;
 	persistedNodes: number;
 	persistedEdges: number;
+	/**
+	 * #936 limit 2: set on a graph hydrated from a mid-build RESUME CHECKPOINT —
+	 * a snapshot taken while a full build was still walking files, so its
+	 * nodes/edges cover only the files processed so far AND its cross-file
+	 * `calls`/`references` edges are still unresolved (resolveDeferredSymbolEdges
+	 * has not run). Strictly stronger than `partial`: such a graph is never
+	 * complete AND never query-ready. It exists solely to seed the next session's
+	 * full build (see `loadReviewGraphCheckpoint`); no read accessor ever serves
+	 * it. Always accompanied by `partial: true`.
+	 */
+	inProgress?: true;
 }
 
 export interface ImpactCascadeResult {

--- a/tests/clients/review-graph/checkpoint-resume.test.ts
+++ b/tests/clients/review-graph/checkpoint-resume.test.ts
@@ -1,0 +1,211 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import {
+	_readReviewGraphCheckpointForTests,
+	buildOrUpdateGraph,
+	clearGraphCache,
+	clearReviewGraphWorkspaceCache,
+	getCachedReviewGraph,
+	reviewGraphCachePath,
+} from "../../../clients/review-graph/builder.js";
+import type { ReviewGraph } from "../../../clients/review-graph/types.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+// #936 limit 2: a full build must be resumable across sessions from a mid-build
+// checkpoint, producing a graph identical to a cold full build — with stale
+// (content-changed) entries re-walked and the mid-build checkpoint never served
+// or persisted as a complete graph.
+
+const roots: string[] = [];
+
+afterEach(() => {
+	clearReviewGraphWorkspaceCache();
+	clearGraphCache();
+	delete process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER;
+	delete process.env.PI_LENS_GRAPH_CHECKPOINT_EVERY_FILES;
+	delete process.env.PI_LENS_GRAPH_CHECKPOINT_MIN_INTERVAL_MS;
+	for (const root of roots.splice(0)) removeTempDirSync(root);
+});
+
+beforeEach(() => {
+	// Keep debounced persists from flushing mid-test (the arms use distinct
+	// roots, but this also keeps the checkpoint-delete assertions clean).
+	process.env.PI_LENS_GRAPH_PERSIST_DEBOUNCE_MS = "3600000";
+});
+
+function canonicalize(value: unknown, root: string): unknown {
+	const normalizedRoot = root.replaceAll("\\", "/");
+	return JSON.parse(
+		JSON.stringify(value, (_key, nested) =>
+			typeof nested === "string"
+				? nested
+						.replaceAll(root, "<root>")
+						.replaceAll(normalizedRoot, "<root>")
+				: nested,
+		),
+	) as unknown;
+}
+
+function sortedMap<T>(map: Map<string, T>): Array<[string, T]> {
+	return [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
+}
+
+// Compare node SET and edge SET (order-independent): a resumed build reconstructs
+// the same union of per-file contributions as a cold build, but the edge ARRAY
+// order can differ, which is not semantically meaningful (consumers use indexes).
+function graphShape(graph: ReviewGraph, root: string): unknown {
+	const nodes = sortedMap(graph.nodes);
+	const edges = [...graph.edges].sort((a, b) =>
+		JSON.stringify(a).localeCompare(JSON.stringify(b)),
+	);
+	return canonicalize({ nodes, edges }, root);
+}
+
+function writeFiles(root: string, files: Record<string, string>): void {
+	for (const [relative, content] of Object.entries(files)) {
+		const file = path.join(root, relative);
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+		fs.writeFileSync(file, content);
+	}
+}
+
+function makeRoot(prefix: string, files: Record<string, string>): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	roots.push(root);
+	writeFiles(root, files);
+	return root;
+}
+
+const SOURCES: Record<string, string> = {
+	"src/a.ts": "export const alpha = 1;\n",
+	"src/b.ts": "import { alpha } from './a';\nexport const beta = alpha;\n",
+	"src/c.ts": "import { beta } from './b';\nexport function gamma() { return beta; }\n",
+	"src/d.ts": "export function delta() { return 4; }\n",
+	"src/e.ts": "import { gamma } from './c';\nexport const eps = gamma();\n",
+	"src/f.ts": "import { delta } from './d';\nexport const zeta = delta();\n",
+};
+
+async function coldBuild(files: Record<string, string>): Promise<{
+	root: string;
+	graph: ReviewGraph;
+}> {
+	const root = makeRoot("pi-lens-ckpt-cold-", files);
+	clearReviewGraphWorkspaceCache(root);
+	clearGraphCache();
+	const graph = await buildOrUpdateGraph(root, [], new FactStore());
+	return { root, graph };
+}
+
+describe("review-graph resumable checkpoint (#936 limit 2)", () => {
+	it("resumes a killed build and produces a graph identical to a cold build", async () => {
+		const resumeRoot = makeRoot("pi-lens-ckpt-resume-", SOURCES);
+
+		// Session A: killed after 2 files, having written a checkpoint.
+		process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER = "2";
+		await expect(
+			buildOrUpdateGraph(resumeRoot, [], new FactStore()),
+		).rejects.toThrow(/checkpoint_test_abort/);
+
+		const checkpoint = _readReviewGraphCheckpointForTests(resumeRoot);
+		expect(checkpoint).not.toBeNull();
+		expect(checkpoint?.processedFiles.length).toBe(2);
+		// No authoritative snapshot was written by the aborted session.
+		expect(fs.existsSync(reviewGraphCachePath(resumeRoot))).toBe(false);
+
+		// New session: cold caches, no stop — must resume and finish.
+		delete process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER;
+		clearReviewGraphWorkspaceCache(resumeRoot);
+		clearGraphCache();
+		const resumed = await buildOrUpdateGraph(
+			resumeRoot,
+			[],
+			new FactStore(),
+		);
+
+		const cold = await coldBuild(SOURCES);
+		expect(graphShape(resumed, resumeRoot)).toEqual(
+			graphShape(cold.graph, cold.root),
+		);
+		// The completed graph is NOT partial/in-progress.
+		expect(resumed.persistCoverage?.partial).not.toBe(true);
+		expect(resumed.persistCoverage?.inProgress).not.toBe(true);
+
+		// Checkpoint retired once the authoritative build completed.
+		await waitFor(
+			() => _readReviewGraphCheckpointForTests(resumeRoot) === null,
+		);
+		expect(_readReviewGraphCheckpointForTests(resumeRoot)).toBeNull();
+	});
+
+	it("re-walks a checkpoint entry whose file changed between sessions", async () => {
+		const resumeRoot = makeRoot("pi-lens-ckpt-stale-", SOURCES);
+
+		// Session A: killed after 3 files.
+		process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER = "3";
+		await expect(
+			buildOrUpdateGraph(resumeRoot, [], new FactStore()),
+		).rejects.toThrow(/checkpoint_test_abort/);
+		const checkpoint = _readReviewGraphCheckpointForTests(resumeRoot);
+		expect(checkpoint?.processedFiles.length).toBe(3);
+
+		// Mutate one of the ALREADY-PROCESSED files so its checkpoint entry is
+		// now stale — the resume must detect this and re-walk it, not reuse the
+		// snapshot's outdated contribution.
+		const processedRel = checkpoint!.processedFiles
+			.map((abs) => path.relative(resumeRoot, abs).replaceAll("\\", "/"))
+			.find((rel) => rel in SOURCES);
+		expect(processedRel).toBeDefined();
+		const finalSources: Record<string, string> = { ...SOURCES };
+		finalSources[processedRel!] =
+			`${SOURCES[processedRel!]}export function extra_${processedRel!.replace(/\W/g, "_")}() { return 99; }\n`;
+		writeFiles(resumeRoot, { [processedRel!]: finalSources[processedRel!] });
+
+		delete process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER;
+		clearReviewGraphWorkspaceCache(resumeRoot);
+		clearGraphCache();
+		const resumed = await buildOrUpdateGraph(resumeRoot, [], new FactStore());
+
+		// Equivalent to a cold build over the POST-EDIT source set.
+		const cold = await coldBuild(finalSources);
+		expect(graphShape(resumed, resumeRoot)).toEqual(
+			graphShape(cold.graph, cold.root),
+		);
+	});
+
+	it("never serves a mid-build checkpoint as a complete graph", async () => {
+		const resumeRoot = makeRoot("pi-lens-ckpt-honesty-", SOURCES);
+
+		process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER = "2";
+		await expect(
+			buildOrUpdateGraph(resumeRoot, [], new FactStore()),
+		).rejects.toThrow(/checkpoint_test_abort/);
+
+		// A checkpoint exists and is explicitly marked in-progress/partial.
+		const checkpoint = _readReviewGraphCheckpointForTests(resumeRoot);
+		expect(checkpoint?.inProgress).toBe(true);
+		expect(checkpoint?.persistCoverage?.partial).toBe(true);
+		expect(checkpoint?.persistCoverage?.inProgress).toBe(true);
+
+		// The read-only accessor must NOT surface the checkpoint: no authoritative
+		// snapshot was written, so it degrades to "cold" (undefined) rather than
+		// serving a partial mid-build graph.
+		clearReviewGraphWorkspaceCache(resumeRoot);
+		clearGraphCache();
+		expect(getCachedReviewGraph(resumeRoot)).toBeUndefined();
+		expect(fs.existsSync(reviewGraphCachePath(resumeRoot))).toBe(false);
+	});
+});
+
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs = 2_000,
+): Promise<void> {
+	const started = Date.now();
+	while (!predicate()) {
+		if (Date.now() - started > timeoutMs) return;
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+}


### PR DESCRIPTION
Closes the last structural limit in #936: the Tier-3 full build restarted from scratch every session, so on a ~5–6k-file repo with short-lived sessions it might never finish. (Limit 1 — the 500K persist cap + honest partial coverage — and limit 3 — the #924 CLI — already landed.)

## Approach
The Tier-3 build walks + tree-sitter-parses every source file into a graph, then runs `resolveDeferredSymbolEdges` **once** at the end. Each file's contribution (`addFileToGraph`) depends only on that file's content + cwd — all cross-file linking is deferred — so the pre-resolution graph is the **order-independent union** of per-file contributions. That makes it safe to checkpoint mid-build and resume.

- **Checkpoint:** the pre-resolution graph + the sha256 content hashes of already-processed files, written periodically to a **dedicated** file `review-graph.checkpoint.json.gz`, gated by BOTH a 250-file stride AND a 5s min interval (and it skips the final chunk), so a long build pays only a handful of writes.
- **Resume:** a later full build loads the checkpoint, reconciles against the current file set, and extracts only the remaining/changed files, then resolves edges globally — producing a graph equivalent to a cold build.

## Honesty (#533) — two layers
1. The checkpoint is a **separate file**; the authoritative load path only ever reads `review-graph.json.gz`, so a mid-build checkpoint can never be served or laundered as complete. It is read back **only** by the resume path.
2. Defense in depth: the hydrated seed carries `persistCoverage.inProgress = true` on top of `partial = true`, so even if it escaped the resume path the existing partial-rejection gates reject it. On completion the working graph's `persistCoverage` is cleared and the checkpoint retired, so the finished graph is never persisted as partial. The resumed graph is only placed in the cache **after** completion.

## Resume-equivalence & stale handling
- **Content-changed** processed files: hash-mismatch → evicted via `removeFileOwnedGraphData`, orphans pruned, re-walked.
- **Removed** processed file (gone from target set): can stale a kept importer's edges → **fail open to a cold build** (correctness over reuse).
- **Ignored-id fingerprint** change, version bump, or empty reusable set → fail open.

## Verification
- `npm run build` clean; `npx tsc --project tsconfig.json --noEmit` (full CI lint gate) clean.
- `tests/clients/review-graph/checkpoint-resume.test.ts` (new, 3 tests: resume-equals-cold graphShape, stale-re-walk, honesty/in-progress marker) + the pre-existing `incremental-equivalence` full-build test: 6/6 pass.

## Follow-up (noted, not in scope)
Checkpoint writes are synchronous main-thread gzip (mirrors the existing exit-hook flush), gated so the cost is a few writes per build. Once #958 item-2 lands the worker-thread gzip persist, the checkpoint write is a natural candidate to offload to it.

Single source of truth (#883): reuses `REVIEW_GRAPH_VERSION`, `getGraphSourceFiles`, `removeFileOwnedGraphData`, `writeFileAtomic`, and the existing review-graph logger.

Refs #936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)