### PR TITLE
perf(snapshot): worker-thread gzip for project snapshot persist (#958 item 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **The review-graph resume checkpoint (#936) now offloads its gzip to the
+	shared persist worker** (refs #958, #883) — mid-build checkpoint writes
+	previously ran a synchronous `gzipSync` of the growing graph on the event
+	loop; they now stream the stringify+gzip through the same worker the
+	authoritative snapshot uses (via the newly-shared `writeGzipStageFile` core),
+	generation-gated so a slow write can't clobber a newer checkpoint or
+	resurrect one after the build completes and retires it, and falling back to a
+	synchronous write when the worker is unavailable. Best-effort as before — a
+	lost checkpoint only costs a cold rebuild.
+
 - **Project snapshot body is now written gzipped by a worker thread** (refs
 	#958 item 2) — the snapshot body (40-112MB observed) is persisted as
 	`project-snapshot.json.gz`, with the `JSON.stringify` + gzip run on a worker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Project snapshot body is now written gzipped by a worker thread** (refs
+	#958 item 2) — the snapshot body (40-112MB observed) is persisted as
+	`project-snapshot.json.gz`, with the `JSON.stringify` + gzip run on a worker
+	thread off the save path, mirroring the review graph's
+	`persist-worker.ts`/generation-gated-promotion pattern (gzip measured 5-10x
+	on top of the #957 compaction win; the review-graph's own measurement was
+	60MB → 1.4MB). A slow worker write for generation N is discarded rather than
+	promoted over a newer generation N+1 already on disk, and the loader still
+	reads the previous uncompressed `project-snapshot.json` for one compatibility
+	release so an upgrade never loses a snapshot. The save path deliberately does
+	NOT sync-gzip (the #950 review measured a naïve sync gzip regressing host
+	memory by +656MB); when the worker is unavailable/dies the pending body falls
+	back to a synchronous main-thread gzip write, surfaced via the logger rather
+	than silently presented as saved (#533). Read-your-writes across the async
+	promotion is preserved by an in-process authoritative "latest write" that
+	`loadProjectSnapshot` consults before disk, so the merge-write callers
+	(`saveRuntimeProjectSnapshot`, word index, reverse deps) never observe a
+	stale body in the promotion window.
+
 - **`pi-lens build-graph` honestly reports a capped, over-the-cap persist**
 	(closes #924, refs #936 limit 3) — the CLI's build-attempt check no longer
 	mistakes the benign "succeeded, but persisted a partial subgraph" reason

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Review-graph checkpoint discards and write failures are now observable**
+	(refs #936, #533) — a present resume checkpoint that's rejected now logs
+	`checkpoint_discarded` with a `reason` (`corrupt`, `version_mismatch`,
+	`not_in_progress`, `git_stamp_mismatch`, `ignored_ids_mismatch`,
+	`removed_file`, `all_stale`) instead of silently falling back to a full cold
+	rebuild, and a failed checkpoint write (worker error/death, promote failure,
+	sync-write failure) logs `checkpoint_write_failed` — so "why isn't my
+	checkpoint resuming / persisting?" is diagnosable from `review-graph.log`.
+
 - **The review-graph resume checkpoint (#936) now offloads its gzip to the
 	shared persist worker** (refs #958, #883) — mid-build checkpoint writes
 	previously ran a synchronous `gzipSync` of the growing graph on the event

--- a/clients/gzip-stage-write.ts
+++ b/clients/gzip-stage-write.ts
@@ -1,0 +1,68 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { createGzip } from "node:zlib";
+
+export interface GzipStageWriteMetrics {
+	/** Uncompressed byte length of the serialized JSON. */
+	rawBytes: number;
+	/** On-disk size of the gzipped stage file. */
+	gzBytes: number;
+	serializeMs: number;
+	writeMs: number;
+}
+
+/**
+ * Shared worker-thread body-persist core (#958, single source of truth #883):
+ * `JSON.stringify` → chunked `createGzip` pipeline → `<stagePath>.tmp-<pid>` →
+ * atomic rename to `stagePath`, returning byte/timing metrics. Both
+ * `clients/review-graph/persist-worker.ts` and
+ * `clients/project-snapshot-persist-worker.ts` call this so the streamed-gzip
+ * write lives in exactly one place; each worker's `parentPort` wiring owns its
+ * own request/result envelope and maps a thrown error onto its own `error`
+ * field. The chunked generator keeps the whole JSON string off a single giant
+ * Buffer (the whole reason the write is on a worker thread — a naïve sync gzip
+ * on the main save path regressed host memory by +656MB, per the #950 review).
+ *
+ * On failure the partial `.tmp` is removed and the error is rethrown for the
+ * caller to record; the `stagePath` itself is only ever created by the atomic
+ * rename, so a crash mid-write can never leave a torn stage file behind.
+ */
+export async function writeGzipStageFile(
+	data: unknown,
+	stagePath: string,
+	testDelayMs?: number,
+): Promise<GzipStageWriteMetrics> {
+	const tmpPath = `${stagePath}.tmp-${process.pid}`;
+	try {
+		if (testDelayMs) {
+			await new Promise((resolve) => setTimeout(resolve, testDelayMs));
+		}
+		const serializeStarted = performance.now();
+		const json = JSON.stringify(data);
+		const serializeMs = performance.now() - serializeStarted;
+		const rawBytes = Buffer.byteLength(json);
+
+		const writeStarted = performance.now();
+		await fs.promises.mkdir(path.dirname(stagePath), { recursive: true });
+		const chunks = function* () {
+			const chunkChars = 256 * 1024;
+			for (let offset = 0; offset < json.length; offset += chunkChars) {
+				yield json.slice(offset, offset + chunkChars);
+			}
+		};
+		await pipeline(
+			Readable.from(chunks()),
+			createGzip(),
+			fs.createWriteStream(tmpPath),
+		);
+		await fs.promises.rename(tmpPath, stagePath);
+		const writeMs = performance.now() - writeStarted;
+		const gzBytes = (await fs.promises.stat(stagePath)).size;
+		return { rawBytes, gzBytes, serializeMs, writeMs };
+	} catch (err) {
+		await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
+		throw err;
+	}
+}

--- a/clients/gzip-stage-write.ts
+++ b/clients/gzip-stage-write.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { parentPort } from "node:worker_threads";
 import { createGzip } from "node:zlib";
 
 export interface GzipStageWriteMetrics {
@@ -11,6 +12,29 @@ export interface GzipStageWriteMetrics {
 	gzBytes: number;
 	serializeMs: number;
 	writeMs: number;
+}
+
+/** Common request envelope every gzip-stage persist worker receives. Concrete
+ * workers extend this with their own routing fields (e.g. `cwd`, `elements`). */
+export interface GzipStageWorkerRequest {
+	id: number;
+	generation: number;
+	stagePath: string;
+	data: unknown;
+	testDelayMs?: number;
+}
+
+/** Common result envelope: the routing fields the worker echoes back, plus the
+ * write metrics (all optional — absent together with `error` set on failure). */
+export interface GzipStageWorkerResult {
+	id: number;
+	generation: number;
+	stagePath: string;
+	rawBytes?: number;
+	gzBytes?: number;
+	serializeMs?: number;
+	writeMs?: number;
+	error?: string;
 }
 
 /**
@@ -65,4 +89,44 @@ export async function writeGzipStageFile(
 		await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
 		throw err;
 	}
+}
+
+/**
+ * Install the standard gzip-stage persist worker message loop on `parentPort`:
+ * for each request, build the routing-field base result, run the shared
+ * {@link writeGzipStageFile}, and post back the base merged with either the
+ * write metrics or an `error`. Both persist workers (review-graph,
+ * project-snapshot) use this so the loop + error mapping live in one place;
+ * each supplies only how to derive its own result's routing fields from the
+ * request. Throws immediately if loaded outside a worker thread.
+ */
+export function serveGzipStageWorker<
+	Req extends GzipStageWorkerRequest,
+	Base extends { id: number; generation: number; stagePath: string },
+>(buildBaseResult: (request: Req) => Base): void {
+	const port = parentPort;
+	if (!port) {
+		throw new Error("gzip stage persist worker requires a parent port");
+	}
+	port.on("message", (request: Req) => {
+		void (async () => {
+			const result: Base & GzipStageWorkerResult = {
+				...buildBaseResult(request),
+			};
+			try {
+				const metrics = await writeGzipStageFile(
+					request.data,
+					request.stagePath,
+					request.testDelayMs,
+				);
+				result.rawBytes = metrics.rawBytes;
+				result.gzBytes = metrics.gzBytes;
+				result.serializeMs = metrics.serializeMs;
+				result.writeMs = metrics.writeMs;
+			} catch (err) {
+				result.error = err instanceof Error ? err.message : String(err);
+			}
+			port.postMessage(result);
+		})();
+	});
 }

--- a/clients/project-snapshot-persist-worker.ts
+++ b/clients/project-snapshot-persist-worker.ts
@@ -1,62 +1,26 @@
-import { parentPort } from "node:worker_threads";
-import { writeGzipStageFile } from "./gzip-stage-write.js";
+import {
+	type GzipStageWorkerRequest,
+	type GzipStageWorkerResult,
+	serveGzipStageWorker,
+} from "./gzip-stage-write.js";
 
 /**
  * Worker-thread persist for the project snapshot BODY (#958 item 2). The parent
  * (project-snapshot.ts) posts the (large) snapshot object plus a monotonic
  * `generation` and a per-generation `stagePath`; the streamed stringify+gzip
- * runs ENTIRELY off the main thread via the shared `writeGzipStageFile` core
- * (clients/gzip-stage-write.ts, also used by the review-graph persist worker),
- * then this posts back byte/timing metrics. The parent does the
- * generation-gated promotion (rename stage → canonical) so a slow write for an
- * older generation can never clobber a newer snapshot already on disk.
+ * runs entirely off the main thread via the shared gzip-stage worker loop
+ * (clients/gzip-stage-write.ts, also used by the review-graph persist worker).
+ * The parent does the generation-gated promotion (rename stage → canonical) so
+ * a slow write for an older generation can never clobber a newer snapshot.
+ * The project snapshot needs no extra routing fields beyond the shared base.
  */
-export interface ProjectSnapshotPersistWorkerRequest {
-	id: number;
-	generation: number;
-	stagePath: string;
-	data: unknown;
-	testDelayMs?: number;
-}
+export type ProjectSnapshotPersistWorkerRequest = GzipStageWorkerRequest;
+export type ProjectSnapshotPersistWorkerResult = GzipStageWorkerResult;
 
-export interface ProjectSnapshotPersistWorkerResult {
-	id: number;
-	generation: number;
-	stagePath: string;
-	rawBytes?: number;
-	gzBytes?: number;
-	serializeMs?: number;
-	writeMs?: number;
-	error?: string;
-}
-
-async function persist(
-	request: ProjectSnapshotPersistWorkerRequest,
-): Promise<void> {
-	const result: ProjectSnapshotPersistWorkerResult = {
+serveGzipStageWorker<ProjectSnapshotPersistWorkerRequest, ProjectSnapshotPersistWorkerResult>(
+	(request) => ({
 		id: request.id,
 		generation: request.generation,
 		stagePath: request.stagePath,
-	};
-	try {
-		const metrics = await writeGzipStageFile(
-			request.data,
-			request.stagePath,
-			request.testDelayMs,
-		);
-		result.rawBytes = metrics.rawBytes;
-		result.gzBytes = metrics.gzBytes;
-		result.serializeMs = metrics.serializeMs;
-		result.writeMs = metrics.writeMs;
-	} catch (err) {
-		result.error = err instanceof Error ? err.message : String(err);
-	}
-	parentPort?.postMessage(result);
-}
-
-if (!parentPort) {
-	throw new Error("project-snapshot persist worker requires a parent port");
-}
-parentPort.on("message", (request: ProjectSnapshotPersistWorkerRequest) => {
-	void persist(request);
-});
+	}),
+);

--- a/clients/project-snapshot-persist-worker.ts
+++ b/clients/project-snapshot-persist-worker.ts
@@ -1,23 +1,15 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { Readable } from "node:stream";
-import { pipeline } from "node:stream/promises";
 import { parentPort } from "node:worker_threads";
-import { createGzip } from "node:zlib";
+import { writeGzipStageFile } from "./gzip-stage-write.js";
 
 /**
- * Worker-thread persist for the project snapshot BODY (#958 item 2). Mirrors
- * `clients/review-graph/persist-worker.ts`: the parent posts the (large)
- * snapshot object plus a monotonic `generation` and a per-generation
- * `stagePath`; the worker does the `JSON.stringify` → chunked `createGzip`
- * pipeline → tmp file → atomic rename ENTIRELY off the main thread, then posts
- * back byte/timing metrics. The parent (project-snapshot.ts) does the
+ * Worker-thread persist for the project snapshot BODY (#958 item 2). The parent
+ * (project-snapshot.ts) posts the (large) snapshot object plus a monotonic
+ * `generation` and a per-generation `stagePath`; the streamed stringify+gzip
+ * runs ENTIRELY off the main thread via the shared `writeGzipStageFile` core
+ * (clients/gzip-stage-write.ts, also used by the review-graph persist worker),
+ * then this posts back byte/timing metrics. The parent does the
  * generation-gated promotion (rename stage → canonical) so a slow write for an
  * older generation can never clobber a newer snapshot already on disk.
- *
- * The stringify+gzip is deliberately NOT run synchronously on the save path:
- * the #950 review measured a naïve sync gzip regress host memory by +656MB, so
- * the whole point of this worker is to keep that cost off the event loop.
  */
 export interface ProjectSnapshotPersistWorkerRequest {
 	id: number;
@@ -46,37 +38,18 @@ async function persist(
 		generation: request.generation,
 		stagePath: request.stagePath,
 	};
-	const tmpPath = `${request.stagePath}.tmp-${process.pid}`;
 	try {
-		if (request.testDelayMs) {
-			await new Promise((resolve) => setTimeout(resolve, request.testDelayMs));
-		}
-		const serializeStarted = performance.now();
-		const json = JSON.stringify(request.data);
-		result.serializeMs = performance.now() - serializeStarted;
-		result.rawBytes = Buffer.byteLength(json);
-
-		const writeStarted = performance.now();
-		await fs.promises.mkdir(path.dirname(request.stagePath), {
-			recursive: true,
-		});
-		const chunks = function* () {
-			const chunkChars = 256 * 1024;
-			for (let offset = 0; offset < json.length; offset += chunkChars) {
-				yield json.slice(offset, offset + chunkChars);
-			}
-		};
-		await pipeline(
-			Readable.from(chunks()),
-			createGzip(),
-			fs.createWriteStream(tmpPath),
+		const metrics = await writeGzipStageFile(
+			request.data,
+			request.stagePath,
+			request.testDelayMs,
 		);
-		await fs.promises.rename(tmpPath, request.stagePath);
-		result.writeMs = performance.now() - writeStarted;
-		result.gzBytes = (await fs.promises.stat(request.stagePath)).size;
+		result.rawBytes = metrics.rawBytes;
+		result.gzBytes = metrics.gzBytes;
+		result.serializeMs = metrics.serializeMs;
+		result.writeMs = metrics.writeMs;
 	} catch (err) {
 		result.error = err instanceof Error ? err.message : String(err);
-		await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
 	}
 	parentPort?.postMessage(result);
 }

--- a/clients/project-snapshot-persist-worker.ts
+++ b/clients/project-snapshot-persist-worker.ts
@@ -1,0 +1,89 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { parentPort } from "node:worker_threads";
+import { createGzip } from "node:zlib";
+
+/**
+ * Worker-thread persist for the project snapshot BODY (#958 item 2). Mirrors
+ * `clients/review-graph/persist-worker.ts`: the parent posts the (large)
+ * snapshot object plus a monotonic `generation` and a per-generation
+ * `stagePath`; the worker does the `JSON.stringify` → chunked `createGzip`
+ * pipeline → tmp file → atomic rename ENTIRELY off the main thread, then posts
+ * back byte/timing metrics. The parent (project-snapshot.ts) does the
+ * generation-gated promotion (rename stage → canonical) so a slow write for an
+ * older generation can never clobber a newer snapshot already on disk.
+ *
+ * The stringify+gzip is deliberately NOT run synchronously on the save path:
+ * the #950 review measured a naïve sync gzip regress host memory by +656MB, so
+ * the whole point of this worker is to keep that cost off the event loop.
+ */
+export interface ProjectSnapshotPersistWorkerRequest {
+	id: number;
+	generation: number;
+	stagePath: string;
+	data: unknown;
+	testDelayMs?: number;
+}
+
+export interface ProjectSnapshotPersistWorkerResult {
+	id: number;
+	generation: number;
+	stagePath: string;
+	rawBytes?: number;
+	gzBytes?: number;
+	serializeMs?: number;
+	writeMs?: number;
+	error?: string;
+}
+
+async function persist(
+	request: ProjectSnapshotPersistWorkerRequest,
+): Promise<void> {
+	const result: ProjectSnapshotPersistWorkerResult = {
+		id: request.id,
+		generation: request.generation,
+		stagePath: request.stagePath,
+	};
+	const tmpPath = `${request.stagePath}.tmp-${process.pid}`;
+	try {
+		if (request.testDelayMs) {
+			await new Promise((resolve) => setTimeout(resolve, request.testDelayMs));
+		}
+		const serializeStarted = performance.now();
+		const json = JSON.stringify(request.data);
+		result.serializeMs = performance.now() - serializeStarted;
+		result.rawBytes = Buffer.byteLength(json);
+
+		const writeStarted = performance.now();
+		await fs.promises.mkdir(path.dirname(request.stagePath), {
+			recursive: true,
+		});
+		const chunks = function* () {
+			const chunkChars = 256 * 1024;
+			for (let offset = 0; offset < json.length; offset += chunkChars) {
+				yield json.slice(offset, offset + chunkChars);
+			}
+		};
+		await pipeline(
+			Readable.from(chunks()),
+			createGzip(),
+			fs.createWriteStream(tmpPath),
+		);
+		await fs.promises.rename(tmpPath, request.stagePath);
+		result.writeMs = performance.now() - writeStarted;
+		result.gzBytes = (await fs.promises.stat(request.stagePath)).size;
+	} catch (err) {
+		result.error = err instanceof Error ? err.message : String(err);
+		await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
+	}
+	parentPort?.postMessage(result);
+}
+
+if (!parentPort) {
+	throw new Error("project-snapshot persist worker requires a parent port");
+}
+parentPort.on("message", (request: ProjectSnapshotPersistWorkerRequest) => {
+	void persist(request);
+});

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -1,9 +1,17 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+import { gunzipSync, gzipSync } from "node:zlib";
 import { writeFileAtomic } from "./atomic-write.js";
 import { getProjectDataDir } from "./file-utils.js";
 import { readJsonCache } from "./json-cache-read.js";
+import { logLatency } from "./latency-logger.js";
 import { normalizeMapKey } from "./path-utils.js";
+import type {
+	ProjectSnapshotPersistWorkerRequest,
+	ProjectSnapshotPersistWorkerResult,
+} from "./project-snapshot-persist-worker.js";
 import type { ProjectLanguageProfile } from "./language-policy.js";
 import {
 	detectProjectConventions,
@@ -58,7 +66,27 @@ export interface ProjectSnapshot {
 	conventions?: ProjectConventions;
 }
 
+// #958 item 2: the canonical snapshot body is now streamed gzip
+// (`project-snapshot.json.gz`), written by a worker thread off the save path
+// (see the persist plumbing below). The previous uncompressed
+// `project-snapshot.json` remains readable for ONE compatibility release so an
+// upgrading user doesn't lose their snapshot — see loadSnapshotBody's legacy
+// fallback. gzip measured 5-10x on top of the #957 compaction win (the
+// review-graph's own measurement was 60MB → 1.4MB).
 export function getProjectSnapshotPath(cwd: string): string {
+	return path.join(
+		getProjectDataDir(cwd),
+		"cache",
+		"project-snapshot.json.gz",
+	);
+}
+
+/**
+ * Pre-#958 uncompressed body path. Read as a one-release fallback when no
+ * `.json.gz` is present; deleted whenever a fresh gz body is promoted so the
+ * two never coexist.
+ */
+export function getProjectSnapshotLegacyPath(cwd: string): string {
 	return path.join(getProjectDataDir(cwd), "cache", "project-snapshot.json");
 }
 
@@ -160,32 +188,28 @@ export function isProjectSnapshotMetaStale(
 
 /**
  * In-process parse cache for the snapshot body, keyed by file path and
- * validated by mtime. The body is large (40-112MB observed) and several
+ * validated by mtime+size. The body is large (40-112MB observed) and several
  * session-start/background consumers parse it seconds after we ourselves
  * wrote it — `saveRuntimeProjectSnapshot` alone re-parsed the file it had
  * just written 2-3x per session (~300-600ms of event-loop blocks). A hit
  * returns the already-parsed object; any external write changes the mtime
- * and forces a re-parse. #947.
- *
- * Deferred: gzipping the snapshot (as the review graph already does via its
- * worker-thread persist, `clients/review-graph/persist-worker.ts`) should
- * follow that same pattern — worker-offloaded stringify+gzip with
- * generation-gated promotion — rather than a sync gzip on the save path.
+ * and forces a re-parse. #947. This tier serves READER processes (module_report,
+ * mcp/analyze) that never write; the writer process's read-your-writes is
+ * served by the authoritative map below.
  */
 interface SnapshotParseCacheEntry {
 	mtimeMs: number;
 	/**
-	 * Size in bytes at cache time. FAT/exFAT round `mtime` to a 2s bucket, so
-	 * two writes inside the same bucket can report an IDENTICAL `mtimeMs` even
-	 * though the body changed — mtime alone would then serve a stale cached
-	 * parse for a file that was, in fact, just rewritten. `size` is already
-	 * computed for free at both cache-write sites (the `fs.statSync` call
-	 * below, and the byte-length check in `saveProjectSnapshot`), so requiring
-	 * it to also match is a free, defensive tiebreaker: a same-bucket rewrite
-	 * that also happens to keep the exact same byte length still slips
-	 * through, but that residual case is the same fail-open/self-healing
-	 * posture as the rest of this cache (worst case: one stale read until the
-	 * next external write changes the size or crosses an mtime bucket).
+	 * On-disk file size in bytes at cache time. FAT/exFAT round `mtime` to a 2s
+	 * bucket, so two writes inside the same bucket can report an IDENTICAL
+	 * `mtimeMs` even though the body changed — mtime alone would then serve a
+	 * stale cached parse for a file that was, in fact, just rewritten. `size`
+	 * is a free, defensive tiebreaker: a same-bucket rewrite that also keeps
+	 * the exact same byte length still slips through, but that residual case is
+	 * the same fail-open/self-healing posture as the rest of this cache. NOTE
+	 * (#958): for the gz body this is the COMPRESSED file size; the
+	 * cache-eligibility gate below uses the UNCOMPRESSED byte length instead,
+	 * because that is what actually bounds resident heap.
 	 */
 	size: number;
 	snapshot: ProjectSnapshot | null;
@@ -194,7 +218,8 @@ const SNAPSHOT_PARSE_CACHE_MAX = 4;
 // #957 review: the cache exists to avoid re-parsing NORMAL snapshots within a
 // session. A 112MB-class body parses to hundreds of MB of heap — pinning that
 // for process lifetime inverts the win, so oversized bodies are simply never
-// cached (they re-parse per read, exactly the pre-#947 behavior).
+// cached (they re-parse per read, exactly the pre-#947 behavior). Measured
+// against the UNCOMPRESSED body size, never the (much smaller) gz file size.
 const SNAPSHOT_PARSE_CACHE_MAX_BYTES = 24 * 1024 * 1024;
 const snapshotParseCache = new Map<string, SnapshotParseCacheEntry>();
 
@@ -212,55 +237,458 @@ function cacheParsedSnapshot(
 	}
 }
 
-/** Test hook: drop all cached parses (per-worker isolation). */
+/**
+ * Authoritative in-process "latest write" for a snapshot, keyed by canonical
+ * cwd (#958 item 2). The body is now written by a worker thread AFTER
+ * `saveProjectSnapshot` returns, so between a save and the worker's promotion
+ * the on-disk gz still holds the PREVIOUS generation. Reading disk in that
+ * window would serve stale data to the merge-write callers
+ * (`saveRuntimeProjectSnapshot`, word-index, reverse-deps) that do
+ * load→mutate→save and would silently drop each other's fields. Because every
+ * write in a process funnels through `saveProjectSnapshot` — and each process
+ * runs in its own worktree cwd, so there is effectively one writer per snapshot
+ * — the in-memory object we just handed the worker IS the authoritative truth
+ * for this process. `loadProjectSnapshot` consults it first and only falls
+ * through to disk when the on-disk file has an mtime STRICTLY NEWER than the
+ * one we last observed for our own write (an external writer we should honor).
+ */
+interface AuthoritativeSnapshotEntry {
+	snapshot: ProjectSnapshot;
+	/**
+	 * The mtime of the body file as we last wrote/observed it. Set to the
+	 * pre-write file's mtime at save time (or -Infinity when no file exists
+	 * yet), then updated to the promoted file's mtime once the worker (or the
+	 * sync fallback) lands the write. Load prefers this entry while the on-disk
+	 * mtime is `<=` this value.
+	 */
+	knownMtime: number;
+}
+const authoritativeSnapshots = new Map<string, AuthoritativeSnapshotEntry>();
+
+/** Test hook: drop all cached parses + authoritative writes (per-worker isolation). */
 export function _resetProjectSnapshotParseCacheForTests(): void {
 	snapshotParseCache.clear();
+	authoritativeSnapshots.clear();
+}
+
+/** Resolve which body file is currently on disk: gz canonical, else legacy. */
+function resolveSnapshotBodyPath(cwd: string): {
+	path: string;
+	gz: boolean;
+	mtimeMs: number;
+	size: number;
+} | null {
+	const gzPath = getProjectSnapshotPath(cwd);
+	try {
+		const stat = fs.statSync(gzPath);
+		return { path: gzPath, gz: true, mtimeMs: stat.mtimeMs, size: stat.size };
+	} catch {
+		/* fall through to the legacy uncompressed body */
+	}
+	const legacyPath = getProjectSnapshotLegacyPath(cwd);
+	try {
+		const stat = fs.statSync(legacyPath);
+		return {
+			path: legacyPath,
+			gz: false,
+			mtimeMs: stat.mtimeMs,
+			size: stat.size,
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Read + parse the body off disk, transparently gunzipping the `.json.gz`
+ * canonical form and falling back to the pre-#958 uncompressed `.json` body
+ * for one compatibility release. Returns the parsed snapshot (or null on any
+ * failure) plus the UNCOMPRESSED byte length, so the caller can apply the
+ * heap-bounded cache gate against the real body size rather than the gz size.
+ */
+// Test-observable count of ACTUAL disk body reads (both gz and legacy), so the
+// #947 meta-gate tests can assert "body parsed / not parsed" independently of
+// the compression format — the pre-#958 tests keyed this off a readJsonCache
+// spy, which the gz path (gunzip + JSON.parse) legitimately bypasses.
+let _snapshotBodyReadCountForTests = 0;
+export function getSnapshotBodyReadCountForTests(): number {
+	return _snapshotBodyReadCountForTests;
+}
+export function resetSnapshotBodyReadCountForTests(): void {
+	_snapshotBodyReadCountForTests = 0;
+}
+
+function readSnapshotBody(bodyPath: string, gz: boolean): {
+	snapshot: ProjectSnapshot | null;
+	rawBytes: number;
+} {
+	_snapshotBodyReadCountForTests++;
+	if (!gz) {
+		const snapshot =
+			readJsonCache<ProjectSnapshot>(
+				bodyPath,
+				(parsed) => parseSnapshot(parsed) ?? undefined,
+			) ?? null;
+		let rawBytes = 0;
+		try {
+			rawBytes = fs.statSync(bodyPath).size;
+		} catch {
+			/* best-effort */
+		}
+		return { snapshot, rawBytes };
+	}
+	try {
+		const json = gunzipSync(fs.readFileSync(bodyPath)).toString("utf-8");
+		const snapshot = parseSnapshot(JSON.parse(json)) ?? null;
+		return { snapshot, rawBytes: Buffer.byteLength(json) };
+	} catch {
+		// Corrupt / truncated gz, or a parse failure: fail open exactly like
+		// readJsonCache does — a null return rebuilds the snapshot.
+		return { snapshot: null, rawBytes: 0 };
+	}
 }
 
 export function loadProjectSnapshot(cwd: string): ProjectSnapshot | null {
-	const snapshotPath = getProjectSnapshotPath(cwd);
-	let mtimeMs: number;
-	let size: number;
-	try {
-		const stat = fs.statSync(snapshotPath);
-		mtimeMs = stat.mtimeMs;
-		size = stat.size;
-	} catch {
-		// Missing snapshots are the normal cold-start case.
-		snapshotParseCache.delete(snapshotPath);
+	const key = normalizeMapKey(cwd);
+	const body = resolveSnapshotBodyPath(cwd);
+	// Authoritative in-process write wins while our own (possibly still
+	// in-flight) write has not been superseded on disk by a newer external
+	// mtime. `body === null` means nothing is on disk yet — our just-scheduled
+	// write is the only truth, so serve it.
+	const authoritative = authoritativeSnapshots.get(key);
+	if (authoritative) {
+		const diskMtime = body ? body.mtimeMs : Number.NEGATIVE_INFINITY;
+		if (diskMtime <= authoritative.knownMtime) {
+			return authoritative.snapshot;
+		}
+		// An external writer moved past our write — honor disk and stop
+		// serving the now-stale in-memory object.
+		authoritativeSnapshots.delete(key);
+	}
+	if (!body) {
+		snapshotParseCache.delete(getProjectSnapshotPath(cwd));
 		return null;
 	}
-	const cached = snapshotParseCache.get(snapshotPath);
+	const cacheKey = body.path;
+	const cached = snapshotParseCache.get(cacheKey);
 	// Both mtime AND size must match (see the `size` field doc on
 	// SnapshotParseCacheEntry for why: coarse FAT/exFAT mtime resolution can
 	// otherwise alias a just-rewritten file onto a stale cache entry).
-	if (cached && cached.mtimeMs === mtimeMs && cached.size === size) {
+	if (cached && cached.mtimeMs === body.mtimeMs && cached.size === body.size) {
 		return cached.snapshot;
 	}
-	const snapshot =
-		readJsonCache<ProjectSnapshot>(
-			snapshotPath,
-			(parsed) => parseSnapshot(parsed) ?? undefined,
-		) ?? null;
-	if (size > 0 && size <= SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
-		cacheParsedSnapshot(snapshotPath, { mtimeMs, size, snapshot });
+	const { snapshot, rawBytes } = readSnapshotBody(body.path, body.gz);
+	if (rawBytes > 0 && rawBytes <= SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
+		cacheParsedSnapshot(cacheKey, {
+			mtimeMs: body.mtimeMs,
+			size: body.size,
+			snapshot,
+		});
 	} else {
-		snapshotParseCache.delete(snapshotPath);
+		snapshotParseCache.delete(cacheKey);
 	}
 	return snapshot;
+}
+
+// --- Worker-thread body persist (gzip off the save path, #958 item 2) --------
+//
+// Mirrors clients/review-graph/persist-worker.ts's parent plumbing: a monotonic
+// per-cwd `generation`, a worker that stringifies+gzips a per-generation stage
+// file, and generation-gated promotion (rename stage → canonical) so a slow
+// write for generation N can never clobber a newer generation N+1 already on
+// disk. When the worker is unavailable/dies, the pending body falls back to a
+// synchronous main-thread gzip write (the degraded path only — the #950 review
+// measured a naïve sync gzip as the DEFAULT save path regressing host memory by
+// +656MB, which is exactly why the worker exists).
+
+interface PendingSnapshotBody {
+	key: string;
+	cwd: string;
+	gzPath: string;
+	legacyPath: string;
+	stagePath: string;
+	snapshot: ProjectSnapshot;
+	generation: number;
+}
+const _snapshotGenerations = new Map<string, number>();
+const _snapshotWorkerRequests = new Map<number, PendingSnapshotBody>();
+let _snapshotPersistWorker: Worker | undefined;
+let _snapshotWorkerRequestId = 0;
+let _snapshotWorkerDisabled = false;
+let _lastSnapshotPersistErrorForTests: string | undefined;
+
+function snapshotWorkerEnabled(): boolean {
+	// The synchronous fallback writer is a legitimate degraded mode (hosts that
+	// can't spawn a worker); tests also force it so a save→load is fully
+	// synchronous. Production defaults to the worker.
+	const raw = process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC;
+	return !(raw === "1" || raw === "true");
+}
+
+function recordSnapshotPersistFailure(cwd: string, error: string): void {
+	// Honesty (#533): a failed async body write must be surfaced, never left to
+	// masquerade as a saved snapshot. The meta gate is already self-healing (an
+	// old body under a newer-seq meta is rejected on the body's own embedded
+	// seq), and dropping the authoritative entry means the next load reflects
+	// what is ACTUALLY on disk rather than the object we failed to persist.
+	_lastSnapshotPersistErrorForTests = error;
+	authoritativeSnapshots.delete(normalizeMapKey(cwd));
+	logLatency({
+		type: "phase",
+		phase: "project_snapshot_persist_failed",
+		filePath: getProjectSnapshotPath(cwd),
+		durationMs: 0,
+		metadata: { error },
+	});
+	console.error("[project-snapshot] body persist failed:", error);
+}
+
+function logSnapshotPersistSuccess(
+	pending: PendingSnapshotBody,
+	stats: {
+		rawBytes: number;
+		gzBytes: number;
+		serializeMs: number;
+		writeMs: number;
+		offloaded: boolean;
+	},
+): void {
+	logLatency({
+		type: "phase",
+		phase: "project_snapshot_persist",
+		filePath: pending.gzPath,
+		durationMs: stats.serializeMs + stats.writeMs,
+		metadata: { seq: pending.snapshot.seq, ...stats },
+	});
+}
+
+/**
+ * Reconcile the authoritative in-process entry with a body that just landed on
+ * disk: update its `knownMtime` so a subsequent load keeps serving our own
+ * object without re-parsing, and DROP oversized bodies (their post-promotion
+ * disk read is the pre-#947 behavior — we won't pin hundreds of MB of heap).
+ */
+function reconcileAuthoritativeAfterWrite(
+	pending: PendingSnapshotBody,
+	rawBytes: number,
+): void {
+	const entry = authoritativeSnapshots.get(pending.key);
+	// Only reconcile the entry that still belongs to THIS (latest) generation —
+	// a superseding save already replaced it with a newer object.
+	if (!entry || entry.snapshot !== pending.snapshot) return;
+	if (rawBytes > SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
+		authoritativeSnapshots.delete(pending.key);
+		return;
+	}
+	try {
+		entry.knownMtime = fs.statSync(pending.gzPath).mtimeMs;
+	} catch {
+		// If we can't stat our own write, leave knownMtime as-is; the worst case
+		// is one extra disk re-parse on the next load.
+	}
+}
+
+function writeSnapshotBodyOnMainThread(
+	pending: PendingSnapshotBody,
+	reason?: string,
+): void {
+	try {
+		const serializeStarted = performance.now();
+		const json = JSON.stringify(pending.snapshot);
+		const serializeMs = performance.now() - serializeStarted;
+		const rawBytes = Buffer.byteLength(json);
+		const writeStarted = performance.now();
+		const gzip = gzipSync(json);
+		fs.mkdirSync(path.dirname(pending.gzPath), { recursive: true });
+		writeFileAtomic(pending.gzPath, gzip, { bestEffort: false });
+		fs.rmSync(pending.legacyPath, { force: true });
+		reconcileAuthoritativeAfterWrite(pending, rawBytes);
+		logSnapshotPersistSuccess(pending, {
+			rawBytes,
+			gzBytes: gzip.byteLength,
+			serializeMs,
+			writeMs: performance.now() - writeStarted,
+			offloaded: false,
+		});
+		if (reason) _lastSnapshotPersistErrorForTests = reason;
+	} catch (err) {
+		recordSnapshotPersistFailure(
+			pending.cwd,
+			err instanceof Error ? err.message : String(err),
+		);
+	}
+}
+
+function handleSnapshotWorkerResult(
+	result: ProjectSnapshotPersistWorkerResult,
+): void {
+	const pending = _snapshotWorkerRequests.get(result.id);
+	if (!pending) {
+		fs.rm(result.stagePath, { force: true }, () => {});
+		return;
+	}
+	_snapshotWorkerRequests.delete(result.id);
+	if (
+		result.error ||
+		result.rawBytes === undefined ||
+		result.gzBytes === undefined ||
+		result.serializeMs === undefined ||
+		result.writeMs === undefined
+	) {
+		fs.rm(result.stagePath, { force: true }, () => {});
+		writeSnapshotBodyOnMainThread(pending, result.error ?? "invalid worker result");
+		return;
+	}
+	// Generation gate: a newer save already superseded this one — discard the
+	// stale stage file rather than promote it over the fresher body.
+	if (_snapshotGenerations.get(pending.key) !== result.generation) {
+		fs.rm(result.stagePath, { force: true }, () => {});
+		return;
+	}
+	try {
+		fs.renameSync(result.stagePath, pending.gzPath);
+		fs.rmSync(pending.legacyPath, { force: true });
+		reconcileAuthoritativeAfterWrite(pending, result.rawBytes);
+		logSnapshotPersistSuccess(pending, {
+			rawBytes: result.rawBytes,
+			gzBytes: result.gzBytes,
+			serializeMs: result.serializeMs,
+			writeMs: result.writeMs,
+			offloaded: true,
+		});
+	} catch (err) {
+		fs.rm(result.stagePath, { force: true }, () => {});
+		writeSnapshotBodyOnMainThread(
+			pending,
+			err instanceof Error ? err.message : String(err),
+		);
+	}
+}
+
+function handleSnapshotWorkerDeath(reason: string): void {
+	_snapshotPersistWorker = undefined;
+	_snapshotWorkerDisabled = true;
+	const requests = [..._snapshotWorkerRequests.values()];
+	_snapshotWorkerRequests.clear();
+	for (const pending of requests) writeSnapshotBodyOnMainThread(pending, reason);
+}
+
+function resolveSnapshotPersistWorkerPath(): string | undefined {
+	// esbuild does NOT rewrite new URL(...) asset refs, so from the bundled
+	// dist/index.js a sibling ./project-snapshot-persist-worker.js resolves
+	// beside the BUNDLE where nothing exists. Try the compiled-sibling layout
+	// first (source checkout / unbundled dist/clients tree), then the dist-tree
+	// path relative to the bundle entry — same shape as the review graph's
+	// resolvePersistWorkerPath (#950 review F1).
+	const candidates = [
+		new URL("./project-snapshot-persist-worker.js", import.meta.url),
+		new URL(
+			"./clients/project-snapshot-persist-worker.js",
+			import.meta.url,
+		),
+	];
+	for (const url of candidates) {
+		try {
+			const resolved = fileURLToPath(url);
+			if (fs.existsSync(resolved)) return resolved;
+		} catch {
+			/* try next layout */
+		}
+	}
+	return undefined;
+}
+
+function getSnapshotPersistWorker(): Worker | undefined {
+	if (_snapshotWorkerDisabled) return undefined;
+	if (_snapshotPersistWorker) return _snapshotPersistWorker;
+	try {
+		const workerPath = resolveSnapshotPersistWorkerPath();
+		if (workerPath === undefined) {
+			handleSnapshotWorkerDeath("persist worker script not found in any layout");
+			return undefined;
+		}
+		const worker = new Worker(workerPath);
+		worker.unref();
+		worker.on("message", handleSnapshotWorkerResult);
+		worker.on("error", (err: Error) => handleSnapshotWorkerDeath(err.message));
+		worker.on("exit", (code) => {
+			if (_snapshotPersistWorker === worker) _snapshotPersistWorker = undefined;
+			// Any body still queued when the worker exits was abandoned mid-flight
+			// (a crash, a `terminate()`, or host recycling) — it will never be
+			// promoted by this worker, so fall it back to the sync writer rather
+			// than let it vanish (honesty, #533). `terminate()` can report a 0
+			// exit code on some platforms, so this cannot key off `code !== 0`.
+			const stranded = [..._snapshotWorkerRequests.values()];
+			if (stranded.length > 0) {
+				_snapshotWorkerRequests.clear();
+				for (const pending of stranded) {
+					writeSnapshotBodyOnMainThread(
+						pending,
+						`persist worker exited with code ${code}`,
+					);
+				}
+			}
+			// Only an ABNORMAL exit disables respawning; a clean idle exit (nothing
+			// stranded) just drops the reference so the next persist respawns.
+			if (code !== 0) _snapshotWorkerDisabled = true;
+		});
+		_snapshotPersistWorker = worker;
+		return worker;
+	} catch (err) {
+		handleSnapshotWorkerDeath(err instanceof Error ? err.message : String(err));
+		return undefined;
+	}
+}
+
+// #950 review F3: a process that dies between a worker's staged write and its
+// promotion leaves project-snapshot.json.gz.stage-<pid>-<gen> (and the worker's
+// .tmp-<pid>) behind forever. Sweep leftovers from PRIOR processes once per
+// cache dir; our own live stage files carry this pid and are skipped.
+const _sweptSnapshotStageDirs = new Set<string>();
+function sweepStaleSnapshotStageFiles(cacheDir: string): void {
+	if (_sweptSnapshotStageDirs.has(cacheDir)) return;
+	_sweptSnapshotStageDirs.add(cacheDir);
+	fs.readdir(cacheDir, (err, entries) => {
+		if (err) return;
+		const ownMarker = `.stage-${process.pid}-`;
+		for (const entry of entries) {
+			if (!entry.startsWith("project-snapshot.json.gz.stage-")) continue;
+			if (entry.includes(ownMarker)) continue;
+			fs.rm(path.join(cacheDir, entry), { force: true }, () => {});
+		}
+	});
+}
+
+// Flush any in-flight worker writes synchronously at process teardown so a body
+// whose worker hasn't promoted yet isn't lost. Sync writes only (no child
+// spawn — the teardown libuv hazard); best-effort.
+let _snapshotExitHookInstalled = false;
+function ensureSnapshotPersistExitHook(): void {
+	if (_snapshotExitHookInstalled) return;
+	_snapshotExitHookInstalled = true;
+	process.once("exit", () => {
+		const requests = [..._snapshotWorkerRequests.values()];
+		_snapshotWorkerRequests.clear();
+		for (const pending of requests) {
+			// Only the newest generation per key still matters; older ones are
+			// superseded and their stage files are swept on next launch.
+			if (_snapshotGenerations.get(pending.key) !== pending.generation) continue;
+			writeSnapshotBodyOnMainThread(pending, "exit_hook");
+		}
+		void _snapshotPersistWorker?.terminate();
+	});
 }
 
 export function saveProjectSnapshot(
 	cwd: string,
 	snapshot: ProjectSnapshot,
 ): void {
-	const snapshotPath = getProjectSnapshotPath(cwd);
+	const gzPath = getProjectSnapshotPath(cwd);
+	const legacyPath = getProjectSnapshotLegacyPath(cwd);
 	const metaPath = getProjectSnapshotMetaPath(cwd);
-	fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
-	// Compact serialization (no pretty-print): ~30% smaller at the observed
-	// 40-112MB sizes, which directly shrinks both the write and every later
-	// read+parse on session start. #947.
-	const serialized = JSON.stringify(snapshot);
+	const cacheDir = path.dirname(gzPath);
+	const key = normalizeMapKey(cwd);
+	fs.mkdirSync(cacheDir, { recursive: true });
 
 	// #958: meta is written FIRST, body SECOND — the reverse of the original
 	// order. A crash/failure between the two writes can now only produce
@@ -275,15 +703,11 @@ export function saveProjectSnapshot(
 	// away a genuinely fresh snapshot. That direction is not recoverable
 	// until the next save, so it's the one this reorder eliminates.
 	//
-	// Both writes go through the shared atomic tmp+rename helper so a
-	// concurrent reader never observes a torn (partially written) file
-	// either way. The meta write uses `bestEffort: false`: if the (tiny,
-	// unlikely-to-fail) meta write itself fails, the body write below is
-	// skipped entirely — the save is simply lost this round (fail-open,
-	// caught by `saveRuntimeProjectSnapshot`'s own try/catch) rather than
-	// silently leaving a stale meta in place while the body writer stampedes
-	// ahead with a fresh body under it, which would reintroduce the exact
-	// skew direction being fixed here.
+	// The meta write is still SYNCHRONOUS (it is tiny) and uses
+	// `bestEffort: false`: if it fails, the body persist below is skipped
+	// entirely — the save is simply lost this round (fail-open, caught by
+	// `saveRuntimeProjectSnapshot`'s own try/catch) rather than leaving a
+	// stale meta in place while the body writer stampedes ahead.
 	writeFileAtomic(
 		metaPath,
 		JSON.stringify({
@@ -293,36 +717,103 @@ export function saveProjectSnapshot(
 		}),
 		{ bestEffort: false },
 	);
+
+	// Record the authoritative in-process write BEFORE handing the body off, so
+	// a merge-read between now and the worker's promotion sees our own object
+	// (the on-disk gz still holds the previous generation until promotion). The
+	// pre-write mtime is our baseline: while disk stays at it (or below), our
+	// object wins; a promotion or an external write moves past it.
+	let knownMtime = Number.NEGATIVE_INFINITY;
 	try {
-		writeFileAtomic(snapshotPath, serialized, { bestEffort: false });
-	} catch (err) {
-		// #957 review: callers mutate the loaded (= cached) object in place
-		// before saving. If the body write fails (disk full, AV/OneDrive
-		// lock), the cache would keep serving that never-persisted state
-		// under the old mtime — drop the entry so the next load re-reads
-		// what is actually on disk.
-		snapshotParseCache.delete(snapshotPath);
-		throw err;
-	}
-	// Prime the parse cache with the object we just wrote so the next
-	// loadProjectSnapshot (e.g. saveRuntimeProjectSnapshot's merge read
-	// seconds later) doesn't re-parse our own write. Best-effort: a failed
-	// stat just means the next load re-parses. Oversized bodies are never
-	// cached (see SNAPSHOT_PARSE_CACHE_MAX_BYTES).
-	try {
-		const size = Buffer.byteLength(serialized);
-		if (size <= SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
-			cacheParsedSnapshot(snapshotPath, {
-				mtimeMs: fs.statSync(snapshotPath).mtimeMs,
-				size,
-				snapshot,
-			});
-		} else {
-			snapshotParseCache.delete(snapshotPath);
-		}
+		knownMtime = fs.statSync(gzPath).mtimeMs;
 	} catch {
-		snapshotParseCache.delete(snapshotPath);
+		/* no prior gz body — baseline stays -Infinity */
 	}
+	authoritativeSnapshots.set(key, { snapshot, knownMtime });
+	// A stale disk-parse-cache entry for this path must not out-vote the fresh
+	// authoritative write once the latter is dropped (oversized bodies).
+	snapshotParseCache.delete(gzPath);
+
+	const generation = (_snapshotGenerations.get(key) ?? 0) + 1;
+	_snapshotGenerations.set(key, generation);
+	const stagePath = `${gzPath}.stage-${process.pid}-${generation}`;
+	const pending: PendingSnapshotBody = {
+		key,
+		cwd,
+		gzPath,
+		legacyPath,
+		stagePath,
+		snapshot,
+		generation,
+	};
+	sweepStaleSnapshotStageFiles(cacheDir);
+	ensureSnapshotPersistExitHook();
+
+	if (!snapshotWorkerEnabled()) {
+		writeSnapshotBodyOnMainThread(pending);
+		return;
+	}
+	const worker = getSnapshotPersistWorker();
+	if (!worker) {
+		writeSnapshotBodyOnMainThread(pending, "persist worker unavailable");
+		return;
+	}
+	const id = ++_snapshotWorkerRequestId;
+	_snapshotWorkerRequests.set(id, pending);
+	const request: ProjectSnapshotPersistWorkerRequest = {
+		id,
+		generation,
+		stagePath,
+		data: snapshot,
+		testDelayMs:
+			process.env.NODE_ENV === "test"
+				? Number(process.env.PI_LENS_TEST_SNAPSHOT_PERSIST_WORKER_DELAY_MS) ||
+					undefined
+				: undefined,
+	};
+	worker.postMessage(request);
+}
+
+// --- Test hooks for the worker persist path ---------------------------------
+
+/** Test-only: wait until worker requests have either landed or degraded. */
+export async function waitForProjectSnapshotPersistsForTests(): Promise<void> {
+	for (
+		let attempts = 0;
+		attempts < 200 && _snapshotWorkerRequests.size > 0;
+		attempts++
+	) {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}
+
+/** Test-only: force any in-flight worker body write to the sync main-thread path. */
+export function flushProjectSnapshotPersistsForTests(): void {
+	const requests = [..._snapshotWorkerRequests.values()];
+	_snapshotWorkerRequests.clear();
+	for (const pending of requests) {
+		if (_snapshotGenerations.get(pending.key) !== pending.generation) continue;
+		writeSnapshotBodyOnMainThread(pending);
+	}
+}
+
+/** Test-only: exercise the degraded worker-death path. */
+export async function terminateProjectSnapshotPersistWorkerForTests(): Promise<void> {
+	const worker = _snapshotPersistWorker;
+	if (worker) await worker.terminate();
+}
+
+/** Test-only: restore worker creation + clear generation state after a deliberate death. */
+export function resetProjectSnapshotPersistWorkerForTests(): void {
+	_snapshotWorkerDisabled = false;
+	_snapshotPersistWorker = undefined;
+	_snapshotWorkerRequests.clear();
+	_snapshotGenerations.clear();
+	_lastSnapshotPersistErrorForTests = undefined;
+}
+
+export function getProjectSnapshotPersistErrorForTests(): string | undefined {
+	return _lastSnapshotPersistErrorForTests;
 }
 
 export function buildProjectSnapshotFromRuntime(args: {

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -720,15 +720,17 @@ export function saveProjectSnapshot(
 
 	// Record the authoritative in-process write BEFORE handing the body off, so
 	// a merge-read between now and the worker's promotion sees our own object
-	// (the on-disk gz still holds the previous generation until promotion). The
+	// (the on-disk body still holds the previous generation until promotion). The
 	// pre-write mtime is our baseline: while disk stays at it (or below), our
-	// object wins; a promotion or an external write moves past it.
-	let knownMtime = Number.NEGATIVE_INFINITY;
-	try {
-		knownMtime = fs.statSync(gzPath).mtimeMs;
-	} catch {
-		/* no prior gz body — baseline stays -Infinity */
-	}
+	// object wins; a promotion or an external write moves past it. Baseline off
+	// the CURRENTLY-RESOLVED body — which is the legacy uncompressed
+	// `project-snapshot.json` in the one-release upgrade window before the first
+	// gz promotion — not gz-only: statting only gzPath there would leave the
+	// baseline at -Infinity, so the load gate (which resolves the legacy body's
+	// real, positive mtime) would reject our own fresh write and serve the stale
+	// legacy body to a merge-consumer, silently dropping this snapshot's fields.
+	const priorBody = resolveSnapshotBodyPath(cwd);
+	const knownMtime = priorBody ? priorBody.mtimeMs : Number.NEGATIVE_INFINITY;
 	authoritativeSnapshots.set(key, { snapshot, knownMtime });
 	// A stale disk-parse-cache entry for this path must not out-vote the fresh
 	// authoritative write once the latter is dropped (oversized bodies).

--- a/clients/review-graph-logger.ts
+++ b/clients/review-graph-logger.ts
@@ -27,7 +27,13 @@ export interface ReviewGraphLogEntry {
 		| "worker_fallback"
 		// #936 limit 2: cross-session resumable full build (checkpointing).
 		| "checkpoint_written"
-		| "checkpoint_resumed";
+		| "checkpoint_resumed"
+		// A present checkpoint was rejected (fail-open to a cold build) — `reason`
+		// says why, so "why isn't my checkpoint resuming?" is diagnosable.
+		| "checkpoint_discarded"
+		// An offloaded/sync checkpoint WRITE failed — resume won't be available
+		// next session; `reason` carries the cause.
+		| "checkpoint_write_failed";
 	cwd: string;
 	reason?: string;
 	durationMs?: number;

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -1286,7 +1286,15 @@ function handleCheckpointWorkerResult(
 	_checkpointWorkerRequests.delete(result.id);
 	// Best-effort: a failed offload just means no checkpoint for this stride —
 	// the prior stride's checkpoint is still on disk and the next stride retries.
+	// Still surface it: a SYSTEMIC failure (disk full, perms, worker crash-loop)
+	// makes resume silently never work, and `checkpoint_written` just stops.
 	if (result.error || result.gzBytes === undefined) {
+		logReviewGraph({
+			cwd: cp.cwd,
+			phase: "checkpoint_write_failed",
+			reason: "worker_error",
+			error: result.error ?? "worker returned no gz metrics",
+		});
 		fs.rm(result.stagePath, { force: true }, () => {});
 		return;
 	}
@@ -1309,7 +1317,13 @@ function handleCheckpointWorkerResult(
 			target: cp.target,
 			offloaded: true,
 		});
-	} catch {
+	} catch (err) {
+		logReviewGraph({
+			cwd: cp.cwd,
+			phase: "checkpoint_write_failed",
+			reason: "promote_failed",
+			error: err instanceof Error ? err.message : String(err),
+		});
 		fs.rm(result.stagePath, { force: true }, () => {});
 	}
 }
@@ -1327,6 +1341,12 @@ function handleWorkerDeath(reason: string): void {
 	const checkpoints = [..._checkpointWorkerRequests.values()];
 	_checkpointWorkerRequests.clear();
 	for (const cp of checkpoints) {
+		logReviewGraph({
+			cwd: cp.cwd,
+			phase: "checkpoint_write_failed",
+			reason: "worker_death",
+			error: reason,
+		});
 		fs.rm(cp.stagePath, { force: true }, () => {});
 	}
 }
@@ -1694,8 +1714,15 @@ function writeReviewGraphCheckpoint(
 	const cacheDir = path.dirname(checkpointPath);
 	try {
 		fs.mkdirSync(cacheDir, { recursive: true });
-	} catch {
-		return; // can't stage — skip this stride (best-effort)
+	} catch (err) {
+		// Can't stage — skip this stride (best-effort), but surface it.
+		logReviewGraph({
+			cwd,
+			phase: "checkpoint_write_failed",
+			reason: "mkdir_failed",
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return;
 	}
 	sweepStaleStageFiles(cacheDir);
 	ensurePersistExitHook();
@@ -1748,8 +1775,15 @@ function writeReviewGraphCheckpointSync(
 			processed: counts.processed,
 			target: counts.target,
 		});
-	} catch {
-		// Best-effort: a failed checkpoint just means no resume next session.
+	} catch (err) {
+		// Best-effort: a failed checkpoint just means no resume next session —
+		// but surface it so a persistent write failure isn't invisible.
+		logReviewGraph({
+			cwd,
+			phase: "checkpoint_write_failed",
+			reason: "sync_write_failed",
+			error: err instanceof Error ? err.message : String(err),
+		});
 	}
 }
 
@@ -1789,10 +1823,21 @@ function loadReviewGraphCheckpoint(
 			gunzipSync(fs.readFileSync(checkpointPath)).toString("utf-8"),
 		) as ReviewGraphCheckpointData;
 	} catch {
+		// A checkpoint file was present but unreadable — the operator would
+		// otherwise see a full cold rebuild with no hint the checkpoint existed.
+		logReviewGraph({ cwd, phase: "checkpoint_discarded", reason: "corrupt" });
 		deleteReviewGraphCheckpoint(cwd);
 		return null;
 	}
 	if (data.version !== REVIEW_GRAPH_VERSION || data.inProgress !== true) {
+		logReviewGraph({
+			cwd,
+			phase: "checkpoint_discarded",
+			reason:
+				data.version !== REVIEW_GRAPH_VERSION
+					? "version_mismatch"
+					: "not_in_progress",
+		});
 		deleteReviewGraphCheckpoint(cwd);
 		return null;
 	}
@@ -1803,6 +1848,11 @@ function loadReviewGraphCheckpoint(
 			(current.headCommit !== data.gitStamp.headCommit ||
 				current.worktreeRoot !== data.gitStamp.worktreeRoot)
 		) {
+			logReviewGraph({
+				cwd,
+				phase: "checkpoint_discarded",
+				reason: "git_stamp_mismatch",
+			});
 			deleteReviewGraphCheckpoint(cwd);
 			return null;
 		}
@@ -1889,6 +1939,13 @@ async function tryResumeFromCheckpoint(
 	const loaded = loadReviewGraphCheckpoint(cwd);
 	if (!loaded) return null;
 	if (loaded.ignoredIdsHash !== hashIgnoredIds(ignoredIds)) {
+		logReviewGraph({
+			cwd,
+			phase: "checkpoint_discarded",
+			reason: "ignored_ids_mismatch",
+			processed: loaded.processedHashes.size,
+			target: filesToBuild.length,
+		});
 		deleteReviewGraphCheckpoint(cwd);
 		return null;
 	}
@@ -1897,6 +1954,13 @@ async function tryResumeFromCheckpoint(
 	// kept importer's edges stale — fail open rather than serve a wrong graph.
 	for (const file of loaded.processedHashes.keys()) {
 		if (!targetSet.has(file)) {
+			logReviewGraph({
+				cwd,
+				phase: "checkpoint_discarded",
+				reason: "removed_file",
+				processed: loaded.processedHashes.size,
+				target: filesToBuild.length,
+			});
 			deleteReviewGraphCheckpoint(cwd);
 			return null;
 		}
@@ -1916,6 +1980,13 @@ async function tryResumeFromCheckpoint(
 	}
 	if (reusableHashes.size === 0) {
 		// Nothing survivable — no benefit over a cold build; discard.
+		logReviewGraph({
+			cwd,
+			phase: "checkpoint_discarded",
+			reason: "all_stale",
+			stale: stale.length,
+			target: filesToBuild.length,
+		});
 		deleteReviewGraphCheckpoint(cwd);
 		return null;
 	}

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -1035,6 +1035,27 @@ let _persistWorkerRequestId = 0;
 let _workerDisabled = false;
 let _lastWorkerFallbackReasonForTests: string | undefined;
 
+// #936/#958 follow-up: the mid-build resume checkpoint offloads its stringify+
+// gzip to the SAME shared persist worker (keeping the gzip of a growing graph
+// off the event loop during a background build). Tracked in a disjoint id/
+// generation space so handleWorkerResult routes a checkpoint promotion — a
+// distinct target path — without touching the authoritative-persist path. A
+// checkpoint write is best-effort: a lost one only costs a cold rebuild, so a
+// worker failure/death just drops it (the prior stride's checkpoint stays on
+// disk) rather than falling back like the authoritative persist does.
+interface PendingCheckpointWrite {
+	cwd: string;
+	generation: number;
+	checkpointPath: string;
+	stagePath: string;
+	nodes: number;
+	edges: number;
+	processed: number;
+	target: number;
+}
+const _checkpointGenerations = new Map<string, number>();
+const _checkpointWorkerRequests = new Map<number, PendingCheckpointWrite>();
+
 function persistedData(pending: PendingPersist): PersistedGraphData {
 	return {
 		version: pending.graph.version,
@@ -1202,6 +1223,14 @@ function writePendingOnMainThread(
 }
 
 function handleWorkerResult(result: ReviewGraphPersistWorkerResult): void {
+	// Checkpoint offloads share this worker but promote to a different target;
+	// route them out before the authoritative-persist path (disjoint id space,
+	// so a checkpoint id is never also an authoritative one).
+	const checkpoint = _checkpointWorkerRequests.get(result.id);
+	if (checkpoint) {
+		handleCheckpointWorkerResult(checkpoint, result);
+		return;
+	}
 	const request = _workerRequests.get(result.id);
 	if (!request) {
 		fs.rm(result.stagePath, { force: true }, () => {});
@@ -1246,6 +1275,41 @@ function handleWorkerResult(result: ReviewGraphPersistWorkerResult): void {
 	}
 }
 
+function handleCheckpointWorkerResult(
+	cp: PendingCheckpointWrite,
+	result: ReviewGraphPersistWorkerResult,
+): void {
+	_checkpointWorkerRequests.delete(result.id);
+	// Best-effort: a failed offload just means no checkpoint for this stride —
+	// the prior stride's checkpoint is still on disk and the next stride retries.
+	if (result.error || result.gzBytes === undefined) {
+		fs.rm(result.stagePath, { force: true }, () => {});
+		return;
+	}
+	// Generation gate: a newer checkpoint stride, or build completion / a
+	// discarded resume (deleteReviewGraphCheckpoint bumps the generation before
+	// removing the file), supersedes this write — discard the stale stage rather
+	// than resurrect a checkpoint over a fresher one or a completed build.
+	if (_checkpointGenerations.get(cp.cwd) !== cp.generation) {
+		fs.rm(result.stagePath, { force: true }, () => {});
+		return;
+	}
+	try {
+		fs.renameSync(result.stagePath, cp.checkpointPath);
+		logReviewGraph({
+			cwd: cp.cwd,
+			phase: "checkpoint_written",
+			nodes: cp.nodes,
+			edges: cp.edges,
+			processed: cp.processed,
+			target: cp.target,
+			offloaded: true,
+		});
+	} catch {
+		fs.rm(result.stagePath, { force: true }, () => {});
+	}
+}
+
 function handleWorkerDeath(reason: string): void {
 	_persistWorker = undefined;
 	_workerDisabled = true;
@@ -1253,6 +1317,13 @@ function handleWorkerDeath(reason: string): void {
 	_workerRequests.clear();
 	for (const { key, pending } of requests) {
 		writePendingOnMainThread(key, pending, reason);
+	}
+	// Best-effort checkpoints don't fall back (no retained DTO to pin heap); drop
+	// their in-flight requests and clean up any stage files they may have left.
+	const checkpoints = [..._checkpointWorkerRequests.values()];
+	_checkpointWorkerRequests.clear();
+	for (const cp of checkpoints) {
+		fs.rm(cp.stagePath, { force: true }, () => {});
 	}
 }
 
@@ -1553,11 +1624,36 @@ function hashIgnoredIds(ignoredIds: ReadonlySet<string> | undefined): string {
 	return createHash("sha256").update(joined).digest("hex");
 }
 
+/** Assemble the checkpoint DTO from the current PRE-resolution graph. Isolated
+ * so both the offloaded and synchronous writers serialize identical bytes. */
+function buildReviewGraphCheckpointData(
+	cwd: string,
+	graph: ReviewGraph,
+	processedHashes: Map<string, string>,
+	targetFileCount: number,
+	ignoredIds: ReadonlySet<string> | undefined,
+): ReviewGraphCheckpointData {
+	return {
+		version: REVIEW_GRAPH_VERSION,
+		builtAt: new Date().toISOString(),
+		inProgress: true,
+		targetFileCount,
+		processedFiles: Array.from(processedHashes.entries()),
+		ignoredIdsHash: hashIgnoredIds(ignoredIds),
+		nodes: Array.from(graph.nodes.entries()),
+		edges: graph.edges,
+		gitStamp: resolveGitIdentity(cwd),
+	};
+}
+
 /**
- * Write a mid-build checkpoint for `cwd`. Best-effort and synchronous (mirrors
- * the exit-hook flush): a lost checkpoint only costs a cold rebuild next time.
- * `graph` MUST be pre-resolution; `processedHashes` MUST contain exactly the
- * files already folded into it.
+ * Write a mid-build checkpoint for `cwd`. Best-effort. `graph` MUST be
+ * pre-resolution; `processedHashes` MUST contain exactly the files already
+ * folded into it. The stringify+gzip is offloaded to the shared persist worker
+ * (keeping the gzip of a growing graph off the event loop during a background
+ * build), generation-gated so a slow write can't clobber a newer checkpoint or
+ * resurrect one over a completed build; it falls back to a synchronous write
+ * when the worker is unavailable. A lost checkpoint only costs a cold rebuild.
  */
 function writeReviewGraphCheckpoint(
 	cwd: string,
@@ -1566,29 +1662,86 @@ function writeReviewGraphCheckpoint(
 	targetFileCount: number,
 	ignoredIds: ReadonlySet<string> | undefined,
 ): void {
+	const generation = (_checkpointGenerations.get(cwd) ?? 0) + 1;
+	_checkpointGenerations.set(cwd, generation);
+	let data: ReviewGraphCheckpointData;
 	try {
-		const cacheDir = path.join(getProjectDataDir(cwd), "cache");
-		const data: ReviewGraphCheckpointData = {
-			version: REVIEW_GRAPH_VERSION,
-			builtAt: new Date().toISOString(),
-			inProgress: true,
-			targetFileCount,
-			processedFiles: Array.from(processedHashes.entries()),
-			ignoredIdsHash: hashIgnoredIds(ignoredIds),
-			nodes: Array.from(graph.nodes.entries()),
-			edges: graph.edges,
-			gitStamp: resolveGitIdentity(cwd),
-		};
-		const gzip = gzipSync(JSON.stringify(data));
-		fs.mkdirSync(cacheDir, { recursive: true });
-		writeFileAtomic(reviewGraphCheckpointPath(cwd), gzip, { bestEffort: true });
-		logReviewGraph({
+		data = buildReviewGraphCheckpointData(
 			cwd,
-			phase: "checkpoint_written",
+			graph,
+			processedHashes,
+			targetFileCount,
+			ignoredIds,
+		);
+	} catch {
+		return; // best-effort — building the DTO failed, skip this stride
+	}
+	const worker = _workerDisabled ? undefined : getPersistWorker();
+	if (!worker) {
+		writeReviewGraphCheckpointSync(cwd, data, {
 			nodes: graph.nodes.size,
 			edges: graph.edges.length,
 			processed: processedHashes.size,
 			target: targetFileCount,
+		});
+		return;
+	}
+	const checkpointPath = reviewGraphCheckpointPath(cwd);
+	const cacheDir = path.dirname(checkpointPath);
+	try {
+		fs.mkdirSync(cacheDir, { recursive: true });
+	} catch {
+		return; // can't stage — skip this stride (best-effort)
+	}
+	sweepStaleStageFiles(cacheDir);
+	ensurePersistExitHook();
+	const id = ++_persistWorkerRequestId;
+	const stagePath = `${checkpointPath}.stage-${process.pid}-${generation}`;
+	_checkpointWorkerRequests.set(id, {
+		cwd,
+		generation,
+		checkpointPath,
+		stagePath,
+		nodes: graph.nodes.size,
+		edges: graph.edges.length,
+		processed: processedHashes.size,
+		target: targetFileCount,
+	});
+	const request: ReviewGraphPersistWorkerRequest = {
+		id,
+		cwd,
+		generation,
+		stagePath,
+		data,
+		elements: graph.nodes.size + graph.edges.length,
+		testDelayMs:
+			process.env.NODE_ENV === "test"
+				? Number(process.env.PI_LENS_TEST_PERSIST_WORKER_DELAY_MS) || undefined
+				: undefined,
+	};
+	worker.postMessage(request);
+}
+
+/** Synchronous checkpoint write — the worker-unavailable fallback and the
+ * teardown/test-seam path where an async promotion couldn't land in time. */
+function writeReviewGraphCheckpointSync(
+	cwd: string,
+	data: ReviewGraphCheckpointData,
+	counts: { nodes: number; edges: number; processed: number; target: number },
+): void {
+	try {
+		const gzip = gzipSync(JSON.stringify(data));
+		fs.mkdirSync(path.dirname(reviewGraphCheckpointPath(cwd)), {
+			recursive: true,
+		});
+		writeFileAtomic(reviewGraphCheckpointPath(cwd), gzip, { bestEffort: true });
+		logReviewGraph({
+			cwd,
+			phase: "checkpoint_written",
+			nodes: counts.nodes,
+			edges: counts.edges,
+			processed: counts.processed,
+			target: counts.target,
 		});
 	} catch {
 		// Best-effort: a failed checkpoint just means no resume next session.
@@ -1596,8 +1749,11 @@ function writeReviewGraphCheckpoint(
 }
 
 /** Remove the checkpoint once a complete authoritative graph exists (or when a
- * stale checkpoint is discarded). Best-effort. */
+ * stale checkpoint is discarded). Best-effort. Bumps the checkpoint generation
+ * first so any still-in-flight offloaded write for `cwd` is gated out and can
+ * never re-create the file after this delete. */
 function deleteReviewGraphCheckpoint(cwd: string): void {
+	_checkpointGenerations.set(cwd, (_checkpointGenerations.get(cwd) ?? 0) + 1);
 	fs.rm(reviewGraphCheckpointPath(cwd), { force: true }, () => {});
 }
 
@@ -1812,9 +1968,15 @@ export function flushReviewGraphPersistsForTests(): void {
 	}
 }
 
-/** Test-only: wait until worker requests have either landed or degraded. */
+/** Test-only: wait until worker requests (authoritative persist AND offloaded
+ * checkpoint) have either landed or degraded. */
 export async function waitForReviewGraphPersistsForTests(): Promise<void> {
-	for (let attempts = 0; attempts < 200 && _workerRequests.size > 0; attempts++) {
+	for (
+		let attempts = 0;
+		attempts < 200 &&
+		(_workerRequests.size > 0 || _checkpointWorkerRequests.size > 0);
+		attempts++
+	) {
 		await new Promise((resolve) => setTimeout(resolve, 10));
 	}
 }
@@ -1829,6 +1991,8 @@ export async function terminateReviewGraphPersistWorkerForTests(): Promise<void>
 export function resetReviewGraphPersistWorkerForTests(): void {
 	_workerDisabled = false;
 	_lastWorkerFallbackReasonForTests = undefined;
+	_checkpointWorkerRequests.clear();
+	_checkpointGenerations.clear();
 }
 
 export function getReviewGraphWorkerFallbackReasonForTests():
@@ -3654,18 +3818,29 @@ async function _doBuildGraph(
 			extractedCount++;
 			filesSinceCheckpoint++;
 			// Test seam: simulate a session killed mid-build after N files, having
-			// just written a checkpoint. The next (un-stopped) build resumes it.
+			// just written a checkpoint. Write SYNCHRONOUSLY so the checkpoint is
+			// deterministically on disk before the abort throw — the offloaded path
+			// would not have promoted yet. The next (un-stopped) build resumes it.
 			if (
 				Number.isFinite(testStopAfter) &&
 				testStopAfter > 0 &&
 				extractedCount >= testStopAfter
 			) {
-				writeReviewGraphCheckpoint(
+				writeReviewGraphCheckpointSync(
 					cwd,
-					graph,
-					fileHashes,
-					filesToBuild.length,
-					ignoredIds,
+					buildReviewGraphCheckpointData(
+						cwd,
+						graph,
+						fileHashes,
+						filesToBuild.length,
+						ignoredIds,
+					),
+					{
+						nodes: graph.nodes.size,
+						edges: graph.edges.length,
+						processed: fileHashes.size,
+						target: filesToBuild.length,
+					},
 				);
 				throw new Error("__review_graph_checkpoint_test_abort__");
 			}

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -1055,6 +1055,10 @@ interface PendingCheckpointWrite {
 }
 const _checkpointGenerations = new Map<string, number>();
 const _checkpointWorkerRequests = new Map<number, PendingCheckpointWrite>();
+// Test-observable: how many checkpoint writes actually took the OFFLOADED
+// (worker) path rather than the synchronous fallback, so a test can assert the
+// offload really fired instead of passing trivially on a completed build.
+let _checkpointOffloadCountForTests = 0;
 
 function persistedData(pending: PendingPersist): PersistedGraphData {
 	return {
@@ -1720,6 +1724,7 @@ function writeReviewGraphCheckpoint(
 				: undefined,
 	};
 	worker.postMessage(request);
+	_checkpointOffloadCountForTests++;
 }
 
 /** Synchronous checkpoint write — the worker-unavailable fallback and the
@@ -1993,6 +1998,12 @@ export function resetReviewGraphPersistWorkerForTests(): void {
 	_lastWorkerFallbackReasonForTests = undefined;
 	_checkpointWorkerRequests.clear();
 	_checkpointGenerations.clear();
+	_checkpointOffloadCountForTests = 0;
+}
+
+/** Test-only: count of checkpoint writes that took the offloaded worker path. */
+export function getCheckpointOffloadCountForTests(): number {
+	return _checkpointOffloadCountForTests;
 }
 
 export function getReviewGraphWorkerFallbackReasonForTests():

--- a/clients/review-graph/persist-worker.ts
+++ b/clients/review-graph/persist-worker.ts
@@ -1,58 +1,27 @@
-import { parentPort } from "node:worker_threads";
-import { writeGzipStageFile } from "../gzip-stage-write.js";
+import {
+	type GzipStageWorkerRequest,
+	type GzipStageWorkerResult,
+	serveGzipStageWorker,
+} from "../gzip-stage-write.js";
 
-export interface ReviewGraphPersistWorkerRequest {
-	id: number;
+export interface ReviewGraphPersistWorkerRequest extends GzipStageWorkerRequest {
 	cwd: string;
-	generation: number;
-	stagePath: string;
-	data: unknown;
 	elements: number;
-	testDelayMs?: number;
 }
 
-export interface ReviewGraphPersistWorkerResult {
-	id: number;
+export interface ReviewGraphPersistWorkerResult extends GzipStageWorkerResult {
 	cwd: string;
-	generation: number;
-	stagePath: string;
 	elements: number;
-	rawBytes?: number;
-	gzBytes?: number;
-	serializeMs?: number;
-	writeMs?: number;
-	error?: string;
 }
 
-async function persist(request: ReviewGraphPersistWorkerRequest): Promise<void> {
-	const result: ReviewGraphPersistWorkerResult = {
+// Streamed gzip stage write runs off the main thread via the shared core (see
+// clients/gzip-stage-write.ts); this worker only echoes its routing fields.
+serveGzipStageWorker<ReviewGraphPersistWorkerRequest, ReviewGraphPersistWorkerResult>(
+	(request) => ({
 		id: request.id,
 		cwd: request.cwd,
 		generation: request.generation,
 		stagePath: request.stagePath,
 		elements: request.elements,
-	};
-	// Shared streamed-gzip stage write (clients/gzip-stage-write.ts) — see there
-	// for why the gzip runs off the main thread.
-	try {
-		const metrics = await writeGzipStageFile(
-			request.data,
-			request.stagePath,
-			request.testDelayMs,
-		);
-		result.rawBytes = metrics.rawBytes;
-		result.gzBytes = metrics.gzBytes;
-		result.serializeMs = metrics.serializeMs;
-		result.writeMs = metrics.writeMs;
-	} catch (err) {
-		result.error = err instanceof Error ? err.message : String(err);
-	}
-	parentPort?.postMessage(result);
-}
-
-if (!parentPort) {
-	throw new Error("review-graph persist worker requires a parent port");
-}
-parentPort.on("message", (request: ReviewGraphPersistWorkerRequest) => {
-	void persist(request);
-});
+	}),
+);

--- a/clients/review-graph/persist-worker.ts
+++ b/clients/review-graph/persist-worker.ts
@@ -1,9 +1,5 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { Readable } from "node:stream";
-import { pipeline } from "node:stream/promises";
 import { parentPort } from "node:worker_threads";
-import { createGzip } from "node:zlib";
+import { writeGzipStageFile } from "../gzip-stage-write.js";
 
 export interface ReviewGraphPersistWorkerRequest {
 	id: number;
@@ -36,35 +32,20 @@ async function persist(request: ReviewGraphPersistWorkerRequest): Promise<void> 
 		stagePath: request.stagePath,
 		elements: request.elements,
 	};
-	const tmpPath = `${request.stagePath}.tmp-${process.pid}`;
+	// Shared streamed-gzip stage write (clients/gzip-stage-write.ts) — see there
+	// for why the gzip runs off the main thread.
 	try {
-		if (request.testDelayMs) {
-			await new Promise((resolve) => setTimeout(resolve, request.testDelayMs));
-		}
-		const serializeStarted = performance.now();
-		const json = JSON.stringify(request.data);
-		result.serializeMs = performance.now() - serializeStarted;
-		result.rawBytes = Buffer.byteLength(json);
-
-		const writeStarted = performance.now();
-		await fs.promises.mkdir(path.dirname(request.stagePath), { recursive: true });
-		const chunks = function* () {
-			const chunkChars = 256 * 1024;
-			for (let offset = 0; offset < json.length; offset += chunkChars) {
-				yield json.slice(offset, offset + chunkChars);
-			}
-		};
-		await pipeline(
-			Readable.from(chunks()),
-			createGzip(),
-			fs.createWriteStream(tmpPath),
+		const metrics = await writeGzipStageFile(
+			request.data,
+			request.stagePath,
+			request.testDelayMs,
 		);
-		await fs.promises.rename(tmpPath, request.stagePath);
-		result.writeMs = performance.now() - writeStarted;
-		result.gzBytes = (await fs.promises.stat(request.stagePath)).size;
+		result.rawBytes = metrics.rawBytes;
+		result.gzBytes = metrics.gzBytes;
+		result.serializeMs = metrics.serializeMs;
+		result.writeMs = metrics.writeMs;
 	} catch (err) {
 		result.error = err instanceof Error ? err.message : String(err);
-		await fs.promises.rm(tmpPath, { force: true }).catch(() => {});
 	}
 	parentPort?.postMessage(result);
 }

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { gunzipSync, gzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const readJsonCacheSpy = vi.hoisted(() => vi.fn());
 vi.mock("../../clients/json-cache-read.js", async (importOriginal) => {
@@ -32,15 +33,21 @@ import {
 	PROJECT_SNAPSHOT_VERSION,
 	_resetProjectSnapshotParseCacheForTests,
 	buildProjectSnapshotFromRuntime,
+	flushProjectSnapshotPersistsForTests,
+	getProjectSnapshotLegacyPath,
 	getProjectSnapshotMetaPath,
 	getProjectSnapshotPath,
+	getProjectSnapshotPersistErrorForTests,
 	hydrateRuntimeFromProjectSnapshot,
 	isProjectSnapshotFresh,
 	isProjectSnapshotMetaStale,
 	loadProjectSnapshot,
 	readProjectSnapshotMeta,
+	resetProjectSnapshotPersistWorkerForTests,
 	saveProjectSnapshot,
 	saveRuntimeProjectSnapshot,
+	terminateProjectSnapshotPersistWorkerForTests,
+	waitForProjectSnapshotPersistsForTests,
 } from "../../clients/project-snapshot.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { buildWordIndex, searchWordIndex } from "../../clients/word-index.js";
@@ -62,7 +69,42 @@ function withProjectDataDir<T>(fn: (cwd: string) => T): T {
 	}
 }
 
+// Async counterpart: the worker-persist tests await in-flight writes, so
+// cleanup must run only AFTER the body resolves (the sync variant's `finally`
+// would delete the tmp dir mid-write).
+async function withProjectDataDirAsync(
+	fn: (cwd: string) => Promise<void>,
+): Promise<void> {
+	const env = setupTestEnvironment("project-snapshot-");
+	const previousDataDir = process.env.PILENS_DATA_DIR;
+	process.env.PILENS_DATA_DIR = path.join(env.tmpDir, "data");
+	try {
+		await fn(path.join(env.tmpDir, "project"));
+	} finally {
+		if (previousDataDir === undefined) {
+			delete process.env.PILENS_DATA_DIR;
+		} else {
+			process.env.PILENS_DATA_DIR = previousDataDir;
+		}
+		env.cleanup();
+	}
+}
+
 describe("project snapshot", () => {
+	// These cover the SAVE/LOAD SEMANTICS, not the worker offload itself, so
+	// they force the synchronous main-thread body writer (`PI_LENS_SNAPSHOT_
+	// PERSIST_SYNC`) — a save then leaves the gz body on disk immediately, no
+	// async drain needed. The worker path (generation gating, fallback,
+	// round-trip) is exercised in its own describe block below. #958.
+	beforeEach(() => {
+		process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC = "1";
+		_resetProjectSnapshotParseCacheForTests();
+		resetProjectSnapshotPersistWorkerForTests();
+	});
+	afterEach(() => {
+		delete process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC;
+	});
+
 	it("builds, saves, and loads a runtime snapshot", () =>
 		withProjectDataDir((cwd) => {
 			const runtime = new RuntimeCoordinator();
@@ -373,28 +415,52 @@ describe("project snapshot", () => {
 			expect(readProjectSnapshotMeta(cwd)).toBeNull();
 		}));
 
-	it("serializes the snapshot body compactly, and still reads legacy pretty-printed bodies (#947)", () =>
+	it("writes a gzip body that round-trips through load (#958)", () =>
+		withProjectDataDir((cwd) => {
+			const runtime = new RuntimeCoordinator();
+			runtime.seedProjectSequence(7);
+			runtime.cachedExports.set("makeThing", path.join(cwd, "src", "a.ts"));
+			const snapshot = buildProjectSnapshotFromRuntime({ cwd, runtime });
+			saveProjectSnapshot(cwd, snapshot);
+
+			// The canonical body is gzip (magic bytes 0x1f 0x8b) and decompresses
+			// to the exact compact JSON — no pretty-print newlines.
+			const gz = fs.readFileSync(getProjectSnapshotPath(cwd));
+			expect(gz.subarray(0, 2)).toEqual(Buffer.from([0x1f, 0x8b]));
+			const json = gunzipSync(gz).toString("utf-8");
+			expect(json).not.toContain("\n");
+			expect(JSON.parse(json).seq).toBe(7);
+
+			// A fresh reader (no authoritative in-process write) must reconstruct
+			// the snapshot from disk alone.
+			_resetProjectSnapshotParseCacheForTests();
+			expect(loadProjectSnapshot(cwd)).toMatchObject({
+				seq: 7,
+				cachedExports: [["makeThing", path.join(cwd, "src", "a.ts")]],
+			});
+		}));
+
+	it("reads a legacy uncompressed .json body when no .gz is present (#958 one-release fallback)", () =>
 		withProjectDataDir((cwd) => {
 			const runtime = new RuntimeCoordinator();
 			runtime.seedProjectSequence(7);
 			const snapshot = buildProjectSnapshotFromRuntime({ cwd, runtime });
-			saveProjectSnapshot(cwd, snapshot);
 
-			// Compact: no pretty-print newlines; exactly the minimal JSON form.
-			const raw = fs.readFileSync(getProjectSnapshotPath(cwd), "utf-8");
-			expect(raw).not.toContain("\n");
-			expect(raw).toBe(JSON.stringify(JSON.parse(raw)));
+			// Simulate an install upgraded from the pre-#958 format: only the
+			// uncompressed body exists (pretty-printed, as older versions wrote).
+			const legacyPath = getProjectSnapshotLegacyPath(cwd);
+			fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+			fs.writeFileSync(legacyPath, JSON.stringify(snapshot, null, 2));
+			expect(fs.existsSync(getProjectSnapshotPath(cwd))).toBe(false);
 
-			// Legacy pretty-printed bodies (written by older pi-lens versions)
-			// must still parse.
 			_resetProjectSnapshotParseCacheForTests();
-			fs.writeFileSync(
-				getProjectSnapshotPath(cwd),
-				JSON.stringify(snapshot, null, 2),
-			);
-			const bumped = new Date(Date.now() + 5000);
-			fs.utimesSync(getProjectSnapshotPath(cwd), bumped, bumped);
 			expect(loadProjectSnapshot(cwd)?.seq).toBe(7);
+
+			// Once a fresh gz body is written, the stale legacy sibling is removed
+			// so the two formats never coexist.
+			saveProjectSnapshot(cwd, snapshot);
+			expect(fs.existsSync(getProjectSnapshotPath(cwd))).toBe(true);
+			expect(fs.existsSync(legacyPath)).toBe(false);
 		}));
 
 	it("a crash between the meta and body writes leaves meta ahead, never behind (#958)", () =>
@@ -416,16 +482,24 @@ describe("project snapshot", () => {
 
 			const advanced = new RuntimeCoordinator();
 			advanced.seedProjectSequence(4);
-			expect(() =>
-				saveProjectSnapshot(
-					cwd,
-					buildProjectSnapshotFromRuntime({ cwd, runtime: advanced }),
-				),
-			).toThrow();
+			// The body write now happens on the (sync) persist path, whose failure
+			// is caught and surfaced via the persist-error hook rather than thrown
+			// back to the caller — the meta write above already landed. Honesty
+			// (#533): the failure must be recorded, not silently swallowed.
+			saveProjectSnapshot(
+				cwd,
+				buildProjectSnapshotFromRuntime({ cwd, runtime: advanced }),
+			);
+			expect(getProjectSnapshotPersistErrorForTests()).toMatch(
+				/simulated crash before body write/,
+			);
 			writeFileAtomicSpy.mockImplementation(realWriteFileAtomicHolder.current);
 
 			// Meta now claims seq 4 (written first, successfully); the body on
-			// disk is still the OLD seq-3 body (its rename never completed).
+			// disk is still the OLD seq-3 body (its rename never completed). The
+			// failed write also dropped the authoritative in-process entry, so a
+			// load reflects what is ACTUALLY on disk (seq 3), never the seq-4
+			// object we failed to persist.
 			const meta = readProjectSnapshotMeta(cwd);
 			expect(meta?.seq).toBe(4);
 			const loaded = loadProjectSnapshot(cwd);
@@ -489,41 +563,143 @@ describe("project snapshot", () => {
 			expect(isProjectSnapshotFresh(bodyAfter, 9)).toBe(true);
 		}));
 
-	it("caches the parsed body per (cwd, mtime): save primes the cache, loads hit it, external writes invalidate (#947)", () =>
+	it("read-your-writes: a load after save serves the in-process object; an external write supersedes it (#947/#958)", () =>
 		withProjectDataDir((cwd) => {
 			_resetProjectSnapshotParseCacheForTests();
 			const runtime = new RuntimeCoordinator();
 			runtime.seedProjectSequence(7);
 			runtime.cachedExports.set("makeThing", path.join(cwd, "src", "a.ts"));
-			saveProjectSnapshot(cwd, buildProjectSnapshotFromRuntime({ cwd, runtime }));
-			readJsonCacheSpy.mockClear();
+			const saved = buildProjectSnapshotFromRuntime({ cwd, runtime });
+			saveProjectSnapshot(cwd, saved);
 
-			// Hit: a load right after our own save (the saveRuntimeProjectSnapshot
-			// merge-read pattern) must NOT re-read/re-parse the file.
+			// Read-your-writes: a load right after our own save (the
+			// saveRuntimeProjectSnapshot merge-read pattern) is served from the
+			// authoritative in-process entry — the exact object we just saved,
+			// even though the gz body was written by the (here sync) persist path.
 			const first = loadProjectSnapshot(cwd);
-			expect(first?.seq).toBe(7);
-			expect(readJsonCacheSpy).not.toHaveBeenCalled();
+			expect(first).toBe(saved);
+			expect(loadProjectSnapshot(cwd)).toBe(saved);
 
-			// A repeat load serves the same parsed object.
-			expect(loadProjectSnapshot(cwd)).toBe(first);
-			expect(readJsonCacheSpy).not.toHaveBeenCalled();
-
-			// An external write (different mtime) invalidates → re-parse.
+			// An external writer moves the gz body past our own write (newer
+			// mtime) → the authoritative entry is abandoned and disk wins.
 			const other = new RuntimeCoordinator();
 			other.seedProjectSequence(9);
-			const snapshotPath = getProjectSnapshotPath(cwd);
+			const gzPath = getProjectSnapshotPath(cwd);
 			fs.writeFileSync(
-				snapshotPath,
-				JSON.stringify(buildProjectSnapshotFromRuntime({ cwd, runtime: other })),
+				gzPath,
+				gzipSync(
+					JSON.stringify(
+						buildProjectSnapshotFromRuntime({ cwd, runtime: other }),
+					),
+				),
 			);
 			const bumped = new Date(Date.now() + 5000);
-			fs.utimesSync(snapshotPath, bumped, bumped);
+			fs.utimesSync(gzPath, bumped, bumped);
 			const third = loadProjectSnapshot(cwd);
-			expect(readJsonCacheSpy).toHaveBeenCalled();
+			expect(third).not.toBe(saved);
 			expect(third?.seq).toBe(9);
 
-			// Deleting the file invalidates and fails open to null.
-			fs.unlinkSync(snapshotPath);
+			// Deleting the body fails open to null.
+			fs.unlinkSync(gzPath);
 			expect(loadProjectSnapshot(cwd)).toBeNull();
+		}));
+});
+
+describe("project snapshot worker persist (#958)", () => {
+	// This block exercises the ACTUAL worker offload (default production path):
+	// no PI_LENS_SNAPSHOT_PERSIST_SYNC, so the body is stringified+gzipped on a
+	// worker thread and promoted under a generation gate.
+	afterEach(async () => {
+		flushProjectSnapshotPersistsForTests();
+		await waitForProjectSnapshotPersistsForTests();
+		resetProjectSnapshotPersistWorkerForTests();
+		_resetProjectSnapshotParseCacheForTests();
+		delete process.env.PI_LENS_TEST_SNAPSHOT_PERSIST_WORKER_DELAY_MS;
+	});
+
+	async function waitForFile(p: string, attempts = 40): Promise<boolean> {
+		for (let i = 0; i < attempts; i++) {
+			if (fs.existsSync(p)) return true;
+			await new Promise((r) => setTimeout(r, 25));
+		}
+		return fs.existsSync(p);
+	}
+
+	it("worker gzip round-trips through the load path", async () =>
+		withProjectDataDirAsync(async (cwd) => {
+			resetProjectSnapshotPersistWorkerForTests();
+			const runtime = new RuntimeCoordinator();
+			runtime.seedProjectSequence(7);
+			runtime.cachedExports.set("makeThing", path.join(cwd, "src", "a.ts"));
+			saveProjectSnapshot(cwd, buildProjectSnapshotFromRuntime({ cwd, runtime }));
+
+			const gzPath = getProjectSnapshotPath(cwd);
+			expect(await waitForFile(gzPath)).toBe(true);
+			await waitForProjectSnapshotPersistsForTests();
+			// Written by the worker: real gzip magic bytes.
+			expect(fs.readFileSync(gzPath).subarray(0, 2)).toEqual(
+				Buffer.from([0x1f, 0x8b]),
+			);
+
+			// A fresh reader reconstructs the snapshot from the worker-written gz.
+			_resetProjectSnapshotParseCacheForTests();
+			expect(loadProjectSnapshot(cwd)).toMatchObject({
+				seq: 7,
+				cachedExports: [["makeThing", path.join(cwd, "src", "a.ts")]],
+			});
+		}));
+
+	it("a slow generation-N worker write does NOT clobber a newer generation-N+1 body", async () =>
+		withProjectDataDirAsync(async (cwd) => {
+			resetProjectSnapshotPersistWorkerForTests();
+			// Delay every worker write so generation N is still in-flight when
+			// generation N+1 is scheduled and lands.
+			process.env.PI_LENS_TEST_SNAPSHOT_PERSIST_WORKER_DELAY_MS = "150";
+
+			const old = new RuntimeCoordinator();
+			old.seedProjectSequence(3);
+			saveProjectSnapshot(cwd, buildProjectSnapshotFromRuntime({ cwd, runtime: old }));
+
+			const fresh = new RuntimeCoordinator();
+			fresh.seedProjectSequence(4);
+			saveProjectSnapshot(
+				cwd,
+				buildProjectSnapshotFromRuntime({ cwd, runtime: fresh }),
+			);
+
+			// Let BOTH delayed worker writes complete. The generation gate must
+			// discard the stale gen-N (seq 3) result and keep only gen-N+1 (seq 4).
+			await waitForProjectSnapshotPersistsForTests();
+			await new Promise((r) => setTimeout(r, 100));
+
+			_resetProjectSnapshotParseCacheForTests();
+			expect(loadProjectSnapshot(cwd)?.seq).toBe(4);
+			// No stray stage files left behind.
+			const cacheDir = path.dirname(getProjectSnapshotPath(cwd));
+			expect(
+				fs.readdirSync(cacheDir).filter((f) => f.includes(".stage-")),
+			).toEqual([]);
+		}));
+
+	it("worker death degrades to a logged main-thread persist (honesty, #533)", async () =>
+		withProjectDataDirAsync(async (cwd) => {
+			resetProjectSnapshotPersistWorkerForTests();
+			process.env.PI_LENS_TEST_SNAPSHOT_PERSIST_WORKER_DELAY_MS = "1000";
+			const runtime = new RuntimeCoordinator();
+			runtime.seedProjectSequence(5);
+			saveProjectSnapshot(cwd, buildProjectSnapshotFromRuntime({ cwd, runtime }));
+
+			// Kill the worker mid-write: the queued body must fall back to the
+			// synchronous main-thread writer, not silently vanish.
+			await terminateProjectSnapshotPersistWorkerForTests();
+			await waitForProjectSnapshotPersistsForTests();
+
+			const gzPath = getProjectSnapshotPath(cwd);
+			expect(await waitForFile(gzPath)).toBe(true);
+			expect(getProjectSnapshotPersistErrorForTests()).toMatch(
+				/exited|unavailable|terminated/i,
+			);
+			_resetProjectSnapshotParseCacheForTests();
+			expect(loadProjectSnapshot(cwd)?.seq).toBe(5);
 		}));
 });

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -681,6 +681,41 @@ describe("project snapshot worker persist (#958)", () => {
 			).toEqual([]);
 		}));
 
+	it("read-your-writes across the legacy-upgrade window: an in-flight write shadows a stale legacy .json (#958)", async () =>
+		withProjectDataDirAsync(async (cwd) => {
+			resetProjectSnapshotPersistWorkerForTests();
+			// Simulate the one-release upgrade window from a pre-#958 install: only
+			// a legacy uncompressed body is on disk (a real, positive mtime); no .gz
+			// exists yet. The save baseline must key off THIS body, not gz-only —
+			// otherwise the load gate rejects our fresh in-process write and serves
+			// the stale legacy body to a merge-consumer, dropping fields.
+			const stale = new RuntimeCoordinator();
+			stale.seedProjectSequence(3);
+			const legacyPath = getProjectSnapshotLegacyPath(cwd);
+			fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+			fs.writeFileSync(
+				legacyPath,
+				JSON.stringify(buildProjectSnapshotFromRuntime({ cwd, runtime: stale })),
+			);
+
+			// Hold the worker write in-flight so the fresh gz is not promoted yet.
+			process.env.PI_LENS_TEST_SNAPSHOT_PERSIST_WORKER_DELAY_MS = "300";
+			const fresh = new RuntimeCoordinator();
+			fresh.seedProjectSequence(8);
+			saveProjectSnapshot(
+				cwd,
+				buildProjectSnapshotFromRuntime({ cwd, runtime: fresh }),
+			);
+
+			// gz not promoted yet — only the legacy body (+ a stage file) on disk.
+			expect(fs.existsSync(getProjectSnapshotPath(cwd))).toBe(false);
+			// A merge-consumer loading now must see our fresh in-process object
+			// (seq 8), NOT the stale legacy body (seq 3) it would otherwise re-read.
+			expect(loadProjectSnapshot(cwd)?.seq).toBe(8);
+
+			await waitForProjectSnapshotPersistsForTests();
+		}));
+
 	it("worker death degrades to a logged main-thread persist (honesty, #533)", async () =>
 		withProjectDataDirAsync(async (cwd) => {
 			resetProjectSnapshotPersistWorkerForTests();

--- a/tests/clients/review-graph/checkpoint-resume.test.ts
+++ b/tests/clients/review-graph/checkpoint-resume.test.ts
@@ -9,6 +9,7 @@ import {
 	clearGraphCache,
 	clearReviewGraphWorkspaceCache,
 	getCachedReviewGraph,
+	getCheckpointOffloadCountForTests,
 	resetReviewGraphPersistWorkerForTests,
 	reviewGraphCachePath,
 	waitForReviewGraphPersistsForTests,
@@ -191,6 +192,12 @@ describe("review-graph resumable checkpoint (#936 limit 2)", () => {
 		const graph = await buildOrUpdateGraph(root, [], new FactStore());
 		// Let any in-flight offloaded checkpoint promotion settle.
 		await waitForReviewGraphPersistsForTests();
+
+		// The offload path actually fired (not the sync fallback, and not zero
+		// checkpoints) — otherwise the assertions below hold trivially for any
+		// completed build. Two strides fire for 6 files at EVERY=2 (after files 2
+		// and 4; the last chunk is skipped since remainingAfter < EVERY).
+		expect(getCheckpointOffloadCountForTests()).toBeGreaterThanOrEqual(1);
 
 		// The offloaded checkpoints never corrupted the built graph: it matches a
 		// cold build exactly.

--- a/tests/clients/review-graph/checkpoint-resume.test.ts
+++ b/tests/clients/review-graph/checkpoint-resume.test.ts
@@ -9,7 +9,9 @@ import {
 	clearGraphCache,
 	clearReviewGraphWorkspaceCache,
 	getCachedReviewGraph,
+	resetReviewGraphPersistWorkerForTests,
 	reviewGraphCachePath,
+	waitForReviewGraphPersistsForTests,
 } from "../../../clients/review-graph/builder.js";
 import type { ReviewGraph } from "../../../clients/review-graph/types.js";
 import { removeTempDirSync } from "../test-utils.js";
@@ -24,6 +26,7 @@ const roots: string[] = [];
 afterEach(() => {
 	clearReviewGraphWorkspaceCache();
 	clearGraphCache();
+	resetReviewGraphPersistWorkerForTests();
 	delete process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER;
 	delete process.env.PI_LENS_GRAPH_CHECKPOINT_EVERY_FILES;
 	delete process.env.PI_LENS_GRAPH_CHECKPOINT_MIN_INTERVAL_MS;
@@ -173,6 +176,34 @@ describe("review-graph resumable checkpoint (#936 limit 2)", () => {
 		expect(graphShape(resumed, resumeRoot)).toEqual(
 			graphShape(cold.graph, cold.root),
 		);
+	});
+
+	it("offloads mid-build checkpoints to the persist worker without corrupting the result, and retires them on completion", async () => {
+		const root = makeRoot("pi-lens-ckpt-offload-", SOURCES);
+		// Fire an in-loop checkpoint every 2 files with no interval floor, so a
+		// 6-file cold build posts offloaded checkpoints mid-extraction (worker
+		// enabled — no TEST_STOP_AFTER, which would force the synchronous seam).
+		process.env.PI_LENS_GRAPH_CHECKPOINT_EVERY_FILES = "2";
+		process.env.PI_LENS_GRAPH_CHECKPOINT_MIN_INTERVAL_MS = "0";
+		clearReviewGraphWorkspaceCache(root);
+		clearGraphCache();
+
+		const graph = await buildOrUpdateGraph(root, [], new FactStore());
+		// Let any in-flight offloaded checkpoint promotion settle.
+		await waitForReviewGraphPersistsForTests();
+
+		// The offloaded checkpoints never corrupted the built graph: it matches a
+		// cold build exactly.
+		const cold = await coldBuild(SOURCES);
+		expect(graphShape(graph, root)).toEqual(graphShape(cold.graph, cold.root));
+		expect(graph.persistCoverage?.inProgress).not.toBe(true);
+		expect(graph.persistCoverage?.partial).not.toBe(true);
+
+		// A completed build retires its checkpoint AND a late offloaded promotion
+		// cannot resurrect it: deleteReviewGraphCheckpoint bumps the checkpoint
+		// generation, so any stage still in flight at completion is gated out.
+		await waitFor(() => _readReviewGraphCheckpointForTests(root) === null);
+		expect(_readReviewGraphCheckpointForTests(root)).toBeNull();
 	});
 
 	it("never serves a mid-build checkpoint as a complete graph", async () => {

--- a/tests/clients/runtime-session-scan-cache.test.ts
+++ b/tests/clients/runtime-session-scan-cache.test.ts
@@ -17,6 +17,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { gunzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	buildProjectSnapshotFromRuntime,
@@ -116,6 +117,10 @@ describe("startup-scan verdict cache in session_start (#699)", () => {
 	beforeEach(() => {
 		restoreStartupMode = setStartupMode("full");
 		previousDataDir = process.env.PILENS_DATA_DIR;
+		// #958: force the synchronous snapshot body writer so the gz body a
+		// session-start save produces is on disk immediately for the assertions
+		// below (the worker offload is covered by project-snapshot.test.ts).
+		process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC = "1";
 		resolveStartupScanContextSpy.mockClear();
 		resolveStartupScanContextAsyncSpy.mockClear();
 		logLatencySpy.mockClear();
@@ -126,6 +131,7 @@ describe("startup-scan verdict cache in session_start (#699)", () => {
 		restoreStartupMode();
 		if (previousDataDir === undefined) delete process.env.PILENS_DATA_DIR;
 		else process.env.PILENS_DATA_DIR = previousDataDir;
+		delete process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC;
 		_resetStartupScanVerdictTtlForTests();
 	});
 
@@ -163,7 +169,9 @@ describe("startup-scan verdict cache in session_start (#699)", () => {
 
 			const snapshotPath = getProjectSnapshotPath(cwd);
 			expect(fs.existsSync(snapshotPath)).toBe(true);
-			const snapshot = JSON.parse(fs.readFileSync(snapshotPath, "utf-8"));
+			const snapshot = JSON.parse(
+				gunzipSync(fs.readFileSync(snapshotPath)).toString("utf-8"),
+			);
 			expect(snapshot.startupScan).toBeDefined();
 			expect(snapshot.startupScan.canWarmCaches).toBe(true);
 			expect(typeof snapshot.startupScan.computedAt).toBe("number");

--- a/tests/clients/runtime-session-snapshot-gate.test.ts
+++ b/tests/clients/runtime-session-snapshot-gate.test.ts
@@ -25,6 +25,8 @@ import {
 	buildProjectSnapshotFromRuntime,
 	getProjectSnapshotMetaPath,
 	getProjectSnapshotPath,
+	getSnapshotBodyReadCountForTests,
+	resetSnapshotBodyReadCountForTests,
 	saveProjectSnapshot,
 } from "../../clients/project-snapshot.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
@@ -111,9 +113,10 @@ function seedSnapshot(cwd: string, seq: number): void {
 }
 
 function snapshotBodyReads(): number {
-	return readJsonCacheSpy.mock.calls.filter(([p]) =>
-		String(p).endsWith("project-snapshot.json"),
-	).length;
+	// #958: the body is gzip and read via gunzip+JSON.parse (bypassing
+	// readJsonCache), so body parses are counted through the dedicated hook
+	// rather than the readJsonCache spy (which still tracks the tiny meta reads).
+	return getSnapshotBodyReadCountForTests();
 }
 
 function snapshotMetaReads(): number {
@@ -148,8 +151,13 @@ describe("session_start snapshot meta-gate (#947)", () => {
 		globals.__piLensFirstSessionDone = true;
 		globals.__piLensWarmupScheduled = true;
 		process.env.PI_LENS_STARTUP_MODE = "quick";
+		// #958: force the synchronous body writer so `seedSnapshot` lands the gz
+		// body on disk before session start reads it (the worker offload is
+		// covered by project-snapshot.test.ts).
+		process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC = "1";
 		readJsonCacheSpy.mockClear();
 		logLatencySpy.mockClear();
+		resetSnapshotBodyReadCountForTests();
 		// Simulate a fresh process: the in-process parse cache (#947 commit 3)
 		// must not serve these assertions — session start should parse a body
 		// written by a PREVIOUS process.
@@ -161,6 +169,7 @@ describe("session_start snapshot meta-gate (#947)", () => {
 		globals.__piLensWarmupScheduled = prevWarmup;
 		if (prevStartupMode === undefined) delete process.env.PI_LENS_STARTUP_MODE;
 		else process.env.PI_LENS_STARTUP_MODE = prevStartupMode;
+		delete process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC;
 		if (previousDataDir === undefined) delete process.env.PILENS_DATA_DIR;
 		else process.env.PILENS_DATA_DIR = previousDataDir;
 	});

--- a/tests/clients/word-index-persist.test.ts
+++ b/tests/clients/word-index-persist.test.ts
@@ -7,7 +7,8 @@
  */
 
 import * as fs from "node:fs";
-import { afterEach, describe, expect, it } from "vitest";
+import { gunzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	buildWordIndex,
 	flushWordIndexPersistsForTests,
@@ -16,11 +17,26 @@ import {
 import { getProjectSnapshotPath } from "../../clients/project-snapshot.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
+/** Read the (now gzip, #958) snapshot body a persist wrote. */
+function readSnapshotBody(snapshotPath: string): {
+	wordIndex: { files: string[] };
+} {
+	return JSON.parse(gunzipSync(fs.readFileSync(snapshotPath)).toString("utf-8"));
+}
+
 const cleanups: Array<() => void> = [];
+beforeEach(() => {
+	// #958: the snapshot body is written by a worker thread by default; force
+	// the synchronous writer so a flushed debounce lands the gz body on disk
+	// deterministically (this suite tests the WORD-INDEX debounce, not the
+	// snapshot worker offload).
+	process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC = "1";
+});
 afterEach(() => {
 	flushWordIndexPersistsForTests();
 	while (cleanups.length) cleanups.pop()?.();
 	process.env.PI_LENS_WORD_INDEX_PERSIST_DEBOUNCE_MS = "0";
+	delete process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC;
 });
 
 function makeEnv() {
@@ -47,7 +63,7 @@ describe("word-index debounced persist (#348 phase 2)", () => {
 
 		const snapshotPath = getProjectSnapshotPath(env.tmpDir);
 		expect(await waitForFile(snapshotPath)).toBe(true);
-		const raw = JSON.parse(fs.readFileSync(snapshotPath, "utf-8"));
+		const raw = readSnapshotBody(snapshotPath);
 		expect(raw.wordIndex).toBeDefined();
 	});
 
@@ -67,7 +83,7 @@ describe("word-index debounced persist (#348 phase 2)", () => {
 
 		flushWordIndexPersistsForTests();
 		expect(await waitForFile(snapshotPath)).toBe(true);
-		const raw = JSON.parse(fs.readFileSync(snapshotPath, "utf-8"));
+		const raw = readSnapshotBody(snapshotPath);
 		// Only the LAST scheduled index should have been written (coalesced).
 		expect(
 			raw.wordIndex.files.some((f: string) => f.includes("a4.ts")),

--- a/tests/clients/word-index.test.ts
+++ b/tests/clients/word-index.test.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	buildWordIndex,
 	centralityFromReverseDeps,
@@ -302,7 +302,21 @@ describe("serializeWordIndex / deserializeWordIndex", () => {
 });
 
 describe("triggerBackgroundWordIndexBuild (#348 cold-query stampede guard)", () => {
+	beforeEach(() => {
+		// #958: the snapshot body is written by a worker thread by default. This
+		// suite seeds a snapshot and then triggers a background word-index build
+		// that reads it back (via `project-snapshot.js`) to preserve unrelated
+		// fields — but the test's own seed save goes through `project-snapshot.ts`,
+		// a DISTINCT module instance whose in-process authoritative-write map the
+		// build cannot see. Pre-#958 the synchronous disk write bridged the two;
+		// forcing the sync writer restores that so the cross-module read observes
+		// the seed on disk. (The async worker offload is covered directly by
+		// project-snapshot.test.ts.) Production imports `.js` everywhere — a single
+		// module instance — so the authoritative map bridges this without disk.
+		process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC = "1";
+	});
 	afterEach(() => {
+		delete process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC;
 		_resetWordIndexBuildGuardForTests();
 	});
 


### PR DESCRIPTION
Implements #958 item 2. The project-snapshot body is now stringified + gzipped on a **worker thread** and promoted via generation-gated atomic rename — mirroring `clients/review-graph/persist-worker.ts`. #957's compaction bought ~30%; gzip is 5–10× on top. Deliberately NOT a sync gzip on the save path (the #950 review measured a naïve sync gzip as the default path regressing host memory by +656MB — which is exactly why this is a worker).

Items 1 (incremental word-index refresh) and 3 (meta-write skew polish) are **not** in this PR.

## Design
- **New worker leaf** `clients/project-snapshot-persist-worker.ts` — faithful mirror of the review-graph persist worker (stringify → chunked `createGzip` → tmp → atomic rename, posts back byte/timing metrics). The parent orchestration (generation map, lifecycle, fallback, exit hook, stale-stage sweep) is mirrored inside `project-snapshot.ts`. Chose a focused mirror over generalizing the review-graph parent (which carries debounce / element-cap / partial-coverage / git-stamp concerns the snapshot path doesn't) — sharing would have been invasive and risked regressing that tested path.
- **On-disk format:** canonical body is now `project-snapshot.json.gz` (streamed gzip of the same compact JSON; `PROJECT_SNAPSHOT_VERSION` schema unchanged — only the container changed). `loadProjectSnapshot` resolves `.gz` first, then falls back to the pre-#958 uncompressed `project-snapshot.json` for one release; a fresh gz promotion deletes the stale legacy sibling. The tiny `.meta.json` sidecar is unchanged, still written synchronously meta-first (#990).

## Correctness / honesty (#533)
- **Generation gating:** per-cwd monotonic counter; the worker writes a per-generation stage file and the parent promotes only if `_snapshotGenerations.get(key) === result.generation`, so a slow gen-N write can never clobber a newer gen-N+1 body.
- **Read-your-writes:** because the body write is now async, an in-process authoritative "latest write" map lets `loadProjectSnapshot` serve our own object (keyed on `knownMtime`: our object wins while disk ≤ the pre-write baseline; a promotion or external write moves past it and evicts it). Prevents a merge-read between save and promotion from silently dropping field merges. Oversized (>24MB) bodies are dropped from the map after promotion so heap isn't pinned (pre-#947 disk-read posture).
- **Worker death / failure:** a dead/exited worker or invalid result falls the pending body back to the synchronous main-thread writer (never lost); a genuine write failure is surfaced via `logLatency` + `console.error` and drops the authoritative entry so loads reflect actual disk — never a false "saved". A `PI_LENS_SNAPSHOT_PERSIST_SYNC=1` seam forces the sync path for deterministic tests.
- **Crash safety:** exit hook flushes in-flight bodies synchronously; a `.stage-<pid>-<gen>` orphan from a prior process is swept once per cache dir.

## Shipping
The worker is emitted to `dist/clients/project-snapshot-persist-worker.js` by the existing `build:dist` tsc pass (`tsconfig.dist.json` includes `clients/**/*.ts`) — same mechanism the review-graph worker relies on; `resolveSnapshotPersistWorkerPath` resolves it from the bundle. No new bundle entry-point needed. If it were ever unresolvable, it degrades to the sync writer rather than crashing.

## Verification
- `npm run build` clean; `npx tsc --project tsconfig.json --noEmit` (full CI lint gate) clean.
- New regression tests: gz round-trip (save→load equals input), legacy uncompressed read fallback, stale-generation no-clobber, worker-death honesty (falls back + surfaces error, no false saved). Adapted suites (word-index-persist, runtime-session-scan-cache, runtime-session-snapshot-gate) gunzip the new format and force sync-mode where they test a different feature — coverage preserved. 34/34 across the touched suites.

## Follow-up
Natural synergy with #936's checkpoint (PR #994): its checkpoint write is currently sync main-thread gzip and could offload to this worker once both land.

Refs #958, #957, #950, #990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)