### PR TITLE
feat(observability): surface typos-config / snapshot-fallback / corrupt-body / oversized-drop (refs #533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Closed four observability gaps in recently-changed typos-config and
+	project-snapshot code** (refs #533) — none of these change behavior, only
+	what's now logged: (1) the typos LSP's inject-vs-step-aside decision
+	(#967) now logs a `typos_config_resolved` phase in `latency.log` /
+	`sessionstart.log` with `mode: "project_config" | "injected_default"` and
+	the resolved `configPath`, so which typos config is actually active is no
+	longer a guess; (2) a project-snapshot body persist that falls back to the
+	synchronous main-thread gzip because the persist worker died/was
+	unavailable now logs an explicit `project_snapshot_worker_fallback` phase
+	with the `reason` (previously only visible via a test-only variable, or
+	buried in an `offloaded:false` success line) — this is the +656MB-risk
+	degraded path from #950; (3) a corrupt/truncated gzipped snapshot body
+	(gunzip/JSON.parse failure) now logs `project_snapshot_body_corrupt`
+	before failing open to a rebuild, instead of being indistinguishable from
+	"no snapshot yet"; (4) dropping the in-process authoritative snapshot
+	entry for an oversized (>24MB) body now logs
+	`project_snapshot_authoritative_dropped_oversized` — low-priority, but no
+	longer silent.
+
 - **Review-graph checkpoint discards and write failures are now observable**
 	(refs #936, #533) — a present resume checkpoint that's rejected now logs
 	`checkpoint_discarded` with a `reason` (`corrupt`, `version_mismatch`,

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -2814,10 +2814,32 @@ const TYPOS_EXTENSIONS: readonly string[] = Array.from(
 // existing project config means injecting NOTHING, letting typos-lsp read the
 // project's file untouched.
 function typosInitialization(root: string): Record<string, unknown> | undefined {
-	if (findLocalTyposConfig(root)) return undefined;
-	return {
-		config: resolvePackagePath(import.meta.url, "rules", "typos", "_typos.toml"),
-	};
+	const localConfig = findLocalTyposConfig(root);
+	if (localConfig) {
+		logLatency({
+			type: "phase",
+			phase: "typos_config_resolved",
+			filePath: root,
+			durationMs: 0,
+			metadata: { mode: "project_config", configPath: localConfig },
+		});
+		logSessionStart(
+			`typos config resolved mode=project_config configPath=${localConfig}`,
+		);
+		return undefined;
+	}
+	const configPath = resolvePackagePath(import.meta.url, "rules", "typos", "_typos.toml");
+	logLatency({
+		type: "phase",
+		phase: "typos_config_resolved",
+		filePath: root,
+		durationMs: 0,
+		metadata: { mode: "injected_default", configPath },
+	});
+	logSessionStart(
+		`typos config resolved mode=injected_default configPath=${configPath}`,
+	);
+	return { config: configPath };
 }
 
 export const TyposServer: LSPServerInfo = {

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -511,17 +511,22 @@ function writeSnapshotBodyOnMainThread(
 	reason?: string,
 ): void {
 	if (reason) {
-		// A real degradation, not the "sync mode by default" case (no reason):
-		// the persist worker died/was unavailable and we fell back to a
-		// synchronous main-thread gzip, which is the +656MB-risk path (#950).
-		// Surface this explicitly rather than burying it in an
-		// `offloaded:false` success line below.
+		// We took the synchronous main-thread gzip path (the +656MB-risk path,
+		// #950) instead of the worker. Surface it rather than burying it in an
+		// `offloaded:false` success line below. `degraded` distinguishes a REAL
+		// degradation (worker died/unavailable/promote-failed) from the benign
+		// `exit_hook` teardown flush, so an operator triaging worker health isn't
+		// misled by normal process-exit flushes.
 		logLatency({
 			type: "phase",
 			phase: "project_snapshot_worker_fallback",
 			filePath: pending.gzPath,
 			durationMs: 0,
-			metadata: { reason, seq: pending.snapshot.seq },
+			metadata: {
+				reason,
+				seq: pending.snapshot.seq,
+				degraded: reason !== "exit_hook",
+			},
 		});
 	}
 	try {

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -341,9 +341,18 @@ function readSnapshotBody(bodyPath: string, gz: boolean): {
 		const json = gunzipSync(fs.readFileSync(bodyPath)).toString("utf-8");
 		const snapshot = parseSnapshot(JSON.parse(json)) ?? null;
 		return { snapshot, rawBytes: Buffer.byteLength(json) };
-	} catch {
+	} catch (err) {
 		// Corrupt / truncated gz, or a parse failure: fail open exactly like
-		// readJsonCache does — a null return rebuilds the snapshot.
+		// readJsonCache does — a null return rebuilds the snapshot. Log it so a
+		// corrupt body is diagnosable rather than indistinguishable from "no
+		// snapshot yet" (both return a null snapshot here).
+		logLatency({
+			type: "phase",
+			phase: "project_snapshot_body_corrupt",
+			filePath: bodyPath,
+			durationMs: 0,
+			metadata: { error: err instanceof Error ? err.message : String(err) },
+		});
 		return { snapshot: null, rawBytes: 0 };
 	}
 }
@@ -477,6 +486,15 @@ function reconcileAuthoritativeAfterWrite(
 	// a superseding save already replaced it with a newer object.
 	if (!entry || entry.snapshot !== pending.snapshot) return;
 	if (rawBytes > SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
+		// Benign but invisible otherwise: the next load will re-parse this body
+		// from disk instead of serving the in-process object.
+		logLatency({
+			type: "phase",
+			phase: "project_snapshot_authoritative_dropped_oversized",
+			filePath: pending.gzPath,
+			durationMs: 0,
+			metadata: { rawBytes, maxBytes: SNAPSHOT_PARSE_CACHE_MAX_BYTES },
+		});
 		authoritativeSnapshots.delete(pending.key);
 		return;
 	}
@@ -492,6 +510,20 @@ function writeSnapshotBodyOnMainThread(
 	pending: PendingSnapshotBody,
 	reason?: string,
 ): void {
+	if (reason) {
+		// A real degradation, not the "sync mode by default" case (no reason):
+		// the persist worker died/was unavailable and we fell back to a
+		// synchronous main-thread gzip, which is the +656MB-risk path (#950).
+		// Surface this explicitly rather than burying it in an
+		// `offloaded:false` success line below.
+		logLatency({
+			type: "phase",
+			phase: "project_snapshot_worker_fallback",
+			filePath: pending.gzPath,
+			durationMs: 0,
+			metadata: { reason, seq: pending.snapshot.seq },
+		});
+	}
 	try {
 		const serializeStarted = performance.now();
 		const json = JSON.stringify(pending.snapshot);


### PR DESCRIPTION
Closes four observability gaps found in the recent audit — all pure log additions through the **existing** loggers, no control-flow changes.

- **M4** — `typosInitialization` (`clients/lsp/server.ts`) now logs `typos_config_resolved` (`logLatency` + `logSessionStart`) with `{ mode: "project_config" | "injected_default", configPath }`, so an operator can tell whose typos config is active under #967's merge-with-precedence semantics. Logs the config **path**, never contents.
- **M5** — `writeSnapshotBodyOnMainThread` (`clients/project-snapshot.ts`) emits `project_snapshot_worker_fallback` (reason + seq) whenever it runs as a real degradation (worker died/unavailable/promotion-failed/exit-flush) — so "we fell back to a main-thread gzip" (the +656MB-risk path, #950) is explicit, not buried in an `offloaded:false` success line. Does NOT fire for the intentional sync-mode default (no `reason`).
- **M6** — `readSnapshotBody` gz-branch now logs `project_snapshot_body_corrupt` (path + error) before the fail-open null return, so a corrupt/truncated body is distinguishable from "no snapshot yet."
- **L2** — `reconcileAuthoritativeAfterWrite` logs `project_snapshot_authoritative_dropped_oversized` (rawBytes/maxBytes) when a >24MB body drops the in-process authoritative entry.

Behavior is unchanged everywhere — only log lines added (reuses `logLatency`/`logSessionStart`, no new logger, `#883`).

## Verification
- `npm run build` clean; `npx tsc --project tsconfig.json --noEmit` (full CI lint gate) clean.
- `tests/clients/project-snapshot.test.ts` + `tests/clients/lsp/` — 547 passed / 3 pre-existing skips. No new log-assertion tests: `logLatency`/`logSessionStart` no-op under `isTestMode()`, so the suites confirm behavior-preservation.

Refs #533. Follow-up to the observability audit (companion to the H1/M1 checkpoint observability already merged in #995).

🤖 Generated with [Claude Code](https://claude.com/claude-code)