### PR TITLE
feat(word-index): durable observability for build/refresh/persist (refs #958, #533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Word-index build/refresh/persist outcomes are now durably observable**
+	(refs #958, #926, #533) — every word-index signal previously rode solely on
+	the optional `dbg` callback, a documented no-op in the MCP host where
+	`symbol_search` reads the index. The structured logger (`~/.pi-lens/
+	word-index.log`, shared `createNdjsonLogger` infra) now records, independent
+	of `dbg`: the full-rebuild-vs-incremental decision plus honest coverage
+	(`indexedFileCount`/`truncated` and `refreshed`/`dropped`/`skipped`/`reused`
+	counts) for both the session-start and cold-query (MCP) build paths; a
+	swallowed snapshot **persist failure** as `persist_failed` (a silent stale
+	index otherwise leaves no trace); and the safety refusal for a root at/above
+	`$HOME`. The full-build collector (`collectWordIndexDocs`) now also returns a
+	`skipped` count for files it enumerated but could not index (over the byte
+	cap / unreadable), so a partial index is never reported as complete. The
+	fragile string-parsing `dbg` adapter this replaces is removed.
+
 - **Review-graph checkpoint discards and write failures are now observable**
 	(refs #936, #533) — a present resume checkpoint that's rejected now logs
 	`checkpoint_discarded` with a `reason` (`corrupt`, `version_mismatch`,

--- a/clients/lens-engine.ts
+++ b/clients/lens-engine.ts
@@ -45,7 +45,6 @@ import {
 	searchWordIndex,
 	triggerBackgroundWordIndexBuild,
 } from "./word-index.js";
-import { wordIndexDebug } from "./word-index-logger.js";
 
 // --- Facades (re-exported so adapters import only this module) ---------------
 
@@ -439,7 +438,7 @@ export async function symbolSearch(
 		const status =
 			priorStatus?.state === "refused"
 				? priorStatus
-				: triggerBackgroundWordIndexBuild(cwd, wordIndexDebug(cwd));
+				: triggerBackgroundWordIndexBuild(cwd);
 		const unavailableReason =
 			priorStatus?.state === "failed"
 				? "last-build-failed"

--- a/clients/mcp/analyze.ts
+++ b/clients/mcp/analyze.ts
@@ -36,7 +36,6 @@ import {
 	WORD_INDEX_MAX_BYTES,
 	type WordIndex,
 } from "../word-index.js";
-import { wordIndexDebug } from "../word-index-logger.js";
 import { createMcpHost } from "./host-shim.js";
 
 // #536: module-scoped FactStore for the warm-analyze graph seam, mirroring the
@@ -366,7 +365,7 @@ export async function analyzeFile(
 				} else {
 					updateWordIndexDocument(warmIndex, { path: absPath, content });
 				}
-				scheduleWordIndexPersist(cwd, warmIndex, wordIndexDebug(cwd));
+				scheduleWordIndexPersist(cwd, warmIndex);
 			} catch {
 				// unreadable/deleted, or an update failure — best-effort, same as the
 				// graph update above.

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -30,6 +30,7 @@ import {
 	getDefaultStartupTools,
 } from "./language-profile.js";
 import { logLatency } from "./latency-logger.js";
+import { logWordIndex } from "./word-index-logger.js";
 import { runLogCleanup } from "./log-cleanup.js";
 import { setSessionLanguages } from "./widget-state.js";
 import { initLSPConfig, loadLSPConfig } from "./lsp/config.js";
@@ -523,11 +524,32 @@ async function buildOrRefreshWordIndex(args: {
 				dbg(
 					`session_start word-index: incremental (seq=${effectiveSeq}, refreshed=${result.refreshed}, dropped=${result.dropped}, skipped=${result.skipped}, reused=${result.reused}, ${Date.now() - startMs}ms)`,
 				);
+				// M2, #958: the incremental-vs-full decision + honest coverage
+				// (indexedFileCount/truncated/skipped), independent of host `dbg`.
+				logWordIndex({
+					phase: "incremental_refresh",
+					cwd: snapshotRoot,
+					trigger: "session_start",
+					durationMs: Date.now() - startMs,
+					indexedFileCount: index.docCount,
+					tokens: index.postings.size,
+					truncated: index.truncated,
+					refreshed: result.refreshed,
+					dropped: result.dropped,
+					skipped: result.skipped,
+					reused: result.reused,
+				});
 				return result;
 			} catch (err) {
 				dbg(
 					`session_start word-index: incremental refresh failed; falling back to full rebuild (${err})`,
 				);
+				logWordIndex({
+					phase: "incremental_fallback",
+					cwd: snapshotRoot,
+					trigger: "session_start",
+					reason: err instanceof Error ? err.message : String(err),
+				});
 			}
 		}
 	}
@@ -549,10 +571,24 @@ async function buildOrRefreshWordIndex(args: {
 		`session_start word-index: rebuilt (absent/stale, seq=${effectiveSeq}) ` +
 			`${runtime.wordIndex.docCount} files, ${runtime.wordIndex.postings.size} tokens (${Date.now() - startMs}ms)`,
 	);
+	// M2, #958: full-rebuild decision + honest coverage. `docs.skipped` (L1)
+	// counts files the walk saw but could not index (unreadable / over the byte
+	// cap) so a partial index is never reported as complete (#533).
+	logWordIndex({
+		phase: "full_rebuild",
+		cwd: snapshotRoot,
+		trigger: "session_start",
+		durationMs: Date.now() - startMs,
+		indexedFileCount: runtime.wordIndex.docCount,
+		tokens: runtime.wordIndex.postings.size,
+		truncated: runtime.wordIndex.truncated,
+		skipped: docs.skipped,
+	});
 	return {
 		mode: "full",
 		refreshed: runtime.wordIndex.docCount,
 		dropped: 0,
+		skipped: docs.skipped,
 		reused: 0,
 	};
 }

--- a/clients/word-index-logger.ts
+++ b/clients/word-index-logger.ts
@@ -45,6 +45,9 @@ export type WordIndexLogPhase =
 	| "cold_build_refused"
 	/** Cold-query background build (build or persist) failed. */
 	| "cold_build_failed"
+	/** A debounced snapshot persist landed — confirms the index is kept fresh
+	 *  across edits (the durable record the MCP host's no-op `dbg` couldn't give). */
+	| "persist_succeeded"
 	/** A snapshot persist swallowed its error — every later query reads stale. */
 	| "persist_failed";
 
@@ -66,9 +69,14 @@ export interface WordIndexLogEntry {
 	/** Incremental: docs removed because they left the current file set. */
 	dropped?: number;
 	/**
-	 * Docs the walk saw but could not index this pass — unreadable / over the
-	 * byte cap. Surfaced on BOTH build paths so coverage stays honest (#533): a
-	 * skipped file is NOT silently treated as indexed or reused.
+	 * Files the walk enumerated but did NOT (re)index this pass — meaning is
+	 * per-phase (surfaced on both paths so coverage stays honest, #533):
+	 *  - full_rebuild: unreadable OR over the byte cap → genuinely ABSENT from
+	 *    the index (never counted as indexed).
+	 *  - incremental_refresh: stale files that failed to re-read this pass → their
+	 *    PRIOR postings are retained (and old mtime kept, so retried next pass);
+	 *    over-cap files are excluded from the index as on the full path.
+	 * Either way a skipped file is never counted as freshly indexed or reused.
 	 */
 	skipped?: number;
 	/** Incremental: docs reused unchanged (the whole point — reused ≫ refreshed). */
@@ -93,9 +101,4 @@ export function getWordIndexLogPath(): string {
 /** Resolve once all enqueued word-index writes are on disk (tests/shutdown). */
 export function flushWordIndexLog(): Promise<void> {
 	return writer.flush();
-}
-
-/** Teardown-only: force queued entries to disk before the process exits. */
-export function flushWordIndexLogSync(): void {
-	writer.flushSync();
 }

--- a/clients/word-index-logger.ts
+++ b/clients/word-index-logger.ts
@@ -1,44 +1,101 @@
+/**
+ * Persistent NDJSON trace of word-index build / refresh / persist outcomes
+ * (#926 durable reporting, extended for #958 incremental cross-session refresh).
+ *
+ * Every word-index signal used to ride solely on the optional `dbg` callback
+ * threaded through runtime-session / word-index. `dbg` varies by host and is a
+ * documented no-op in the MCP host (clients/mcp/session.ts's `dbg: noop`) —
+ * exactly the host where `pilens_symbol_search` READS this index. So the one
+ * decision that governs a query's freshness (full rebuild vs incremental
+ * refresh, and how many docs were refreshed/dropped/skipped/reused, whether the
+ * index is `truncated`, #928) and the one failure that silently corrupts every
+ * later query (a swallowed snapshot persist) were invisible precisely where
+ * they mattered — the same blind spot bus-events-logger.ts and
+ * review-graph-logger.ts were created to close.
+ *
+ * This gives the word index the same durable trace those siblings have via the
+ * shared `createNdjsonLogger` writer (self-registers for log-cleanup rotation),
+ * with `isTestMode()` gating writes off inside the test runner. Callers log
+ * DIRECTLY here — never through `dbg` — so the trace exists regardless of the
+ * host's `dbg` wiring.
+ */
 import * as path from "node:path";
 import { isTestMode } from "./env-utils.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
+import { getMaxLogSizeMB } from "./log-cleanup.js";
 import { createNdjsonLogger } from "./ndjson-logger.js";
 
 const WORD_INDEX_LOG_FILE = path.join(getGlobalPiLensDir(), "word-index.log");
-const writer = createNdjsonLogger({ filePath: WORD_INDEX_LOG_FILE });
+
+const writer = createNdjsonLogger({
+	filePath: WORD_INDEX_LOG_FILE,
+	maxBytes: getMaxLogSizeMB() * 1024 * 1024,
+});
+
+export type WordIndexLogPhase =
+	/** Full rebuild from a fresh file-walk-and-read (absent/stale/churned index). */
+	| "full_rebuild"
+	/** Only stale/new docs re-tokenized against a reused snapshot (#958). */
+	| "incremental_refresh"
+	/** Incremental refresh threw (churn, missing metadata, …) → full rebuild. */
+	| "incremental_fallback"
+	/** Stateless cold-query background build (MCP `symbol_search`, no session). */
+	| "cold_build"
+	/** Cold-query build refused for safety (root at/above $HOME). */
+	| "cold_build_refused"
+	/** Cold-query background build (build or persist) failed. */
+	| "cold_build_failed"
+	/** A snapshot persist swallowed its error — every later query reads stale. */
+	| "persist_failed";
 
 export interface WordIndexLogEntry {
 	ts?: string;
-	phase: "cold-build" | "persist";
+	phase: WordIndexLogPhase;
 	cwd: string;
-	outcome: "started" | "succeeded" | "refused" | "failed";
-	reason?: string;
+	/** Which lifecycle produced this: "session_start" | "cold_query" | "per_edit". */
+	trigger?: string;
 	durationMs?: number;
-	indexedFiles?: number;
+	/** Docs actually represented in the index (mirrors indexedFileCount, #928). */
+	indexedFileCount?: number;
+	/** True when the source walk reached its file cap — searches may be partial. */
+	truncated?: boolean;
+	/** Distinct token count (postings.size) — index breadth at a glance. */
+	tokens?: number;
+	/** Incremental: docs re-tokenized because their mtime changed. */
+	refreshed?: number;
+	/** Incremental: docs removed because they left the current file set. */
+	dropped?: number;
+	/**
+	 * Docs the walk saw but could not index this pass — unreadable / over the
+	 * byte cap. Surfaced on BOTH build paths so coverage stays honest (#533): a
+	 * skipped file is NOT silently treated as indexed or reused.
+	 */
+	skipped?: number;
+	/** Incremental: docs reused unchanged (the whole point — reused ≫ refreshed). */
+	reused?: number;
+	/** Refusal / fallback cause (cold_build_refused / incremental_fallback). */
+	reason?: string;
+	/** Failure detail (cold_build_failed / persist_failed). */
+	error?: string;
 }
 
 export function logWordIndex(entry: WordIndexLogEntry): void {
-	if (isTestMode()) return;
+	if (isTestMode()) {
+		return;
+	}
 	writer.log({ ts: new Date().toISOString(), ...entry });
-}
-
-export function wordIndexDebug(cwd: string): (message: string) => void {
-	return (message) =>
-		logWordIndex({
-			phase: message.startsWith("word-index persist") ? "persist" : "cold-build",
-			cwd: path.resolve(cwd),
-			outcome: message.includes("failed")
-				? "failed"
-				: message.includes("skipped")
-					? "refused"
-					: "succeeded",
-			reason: message,
-		});
 }
 
 export function getWordIndexLogPath(): string {
 	return WORD_INDEX_LOG_FILE;
 }
 
+/** Resolve once all enqueued word-index writes are on disk (tests/shutdown). */
 export function flushWordIndexLog(): Promise<void> {
 	return writer.flush();
+}
+
+/** Teardown-only: force queued entries to disk before the process exits. */
+export function flushWordIndexLogSync(): void {
+	writer.flushSync();
 }

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -22,6 +22,7 @@ import {
 	type DebounceScheduler,
 } from "./persist-debounce.js";
 import { getWordIndexMaxFilesDerived } from "./project-scale.js";
+import { logWordIndex } from "./word-index-logger.js";
 
 export interface WordHit {
 	file: string;
@@ -322,6 +323,14 @@ export async function collectWordIndexDocs(
 ): Promise<
 	Array<{ path: string; content: string; mtimeMs: number }> & {
 		truncated: boolean;
+		/**
+		 * Files the walk enumerated but this pass could NOT index — unreadable
+		 * (vanished / locked) or over `WORD_INDEX_MAX_BYTES`. Surfaced (L1, #958)
+		 * so the full-build path can report coverage honestly (#533) instead of
+		 * silently dropping them with no count, the way the incremental path
+		 * already reports its own `skipped`.
+		 */
+		skipped: number;
 	}
 > {
 	const { collectSourceFilesAsync } = await import("./source-filter.js");
@@ -346,7 +355,7 @@ export async function collectWordIndexDocs(
 	const truncated = files.length === maxFiles;
 	const docs = Object.assign(
 		[] as Array<{ path: string; content: string; mtimeMs: number }>,
-		{ truncated },
+		{ truncated, skipped: 0 },
 	);
 	if (!shouldContinue()) return docs;
 	let processed = 0;
@@ -359,9 +368,15 @@ export async function collectWordIndexDocs(
 					content: fs.readFileSync(file, "utf-8"),
 					mtimeMs: stat.mtimeMs,
 				});
+			} else {
+				// Over the byte cap — enumerated but deliberately not indexed. Count
+				// it (L1, #958) so callers can keep coverage honest instead of the
+				// old silent drop.
+				docs.skipped += 1;
 			}
 		} catch {
-			// unreadable / vanished file — skip
+			// unreadable / vanished file — skip, but count it (see above).
+			docs.skipped += 1;
 		}
 		if (++processed % 100 === 0) {
 			await new Promise<void>((resolve) => setImmediate(resolve));
@@ -767,6 +782,12 @@ export function triggerBackgroundWordIndexBuild(
 	if (isAtOrAboveHomeDir(key, options.homeDir)) {
 		const reason = `root at/above home directory (${key})`;
 		dbg?.(`word-index cold-build: skipped — ${reason}`);
+		logWordIndex({
+			phase: "cold_build_refused",
+			cwd: key,
+			trigger: "cold_query",
+			reason,
+		});
 		const status = { state: "refused", reason } as const;
 		buildStatuses.set(key, status);
 		return status;
@@ -799,11 +820,30 @@ export function triggerBackgroundWordIndexBuild(
 			dbg?.(
 				`word-index cold-build: ${index.docCount} files, ${index.postings.size} tokens (${Date.now() - startMs}ms)`,
 			);
+			// M2, #958: durable decision/coverage record for the MCP-critical cold
+			// path (this is where symbol_search reads the index and dbg is a no-op).
+			logWordIndex({
+				phase: "cold_build",
+				cwd: key,
+				trigger: "cold_query",
+				durationMs: Date.now() - startMs,
+				indexedFileCount: index.docCount,
+				tokens: index.postings.size,
+				truncated: index.truncated,
+				skipped: docs.skipped,
+			});
 			buildStatuses.delete(key);
 		} catch (err) {
 			const reason = err instanceof Error ? err.message : String(err);
 			buildStatuses.set(key, { state: "failed", reason });
 			dbg?.(`word-index cold-build: failed: ${reason}`);
+			logWordIndex({
+				phase: "cold_build_failed",
+				cwd: key,
+				trigger: "cold_query",
+				durationMs: Date.now() - startMs,
+				error: reason,
+			});
 		}
 	})();
 	return status;
@@ -881,6 +921,16 @@ async function writeWordIndexSnapshot(
 		);
 	} catch (err) {
 		dbg?.(`word-index persist: failed: ${err}`);
+		// M3, #958: a swallowed persist means every LATER symbol_search reads a
+		// stale index with no trace — the exact silent-failure this durable log
+		// exists to surface (dbg is a no-op in the MCP host).
+		logWordIndex({
+			phase: "persist_failed",
+			cwd: path.resolve(cwd),
+			trigger: "per_edit",
+			indexedFileCount: index.docCount,
+			error: err instanceof Error ? err.message : String(err),
+		});
 	}
 }
 

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -919,6 +919,17 @@ async function writeWordIndexSnapshot(
 		dbg?.(
 			`word-index persist: ${index.docCount} files, ${index.postings.size} tokens`,
 		);
+		// #958 review F1: durably record persist SUCCESS too, not just failures —
+		// in the MCP host (`dbg` is a no-op) this is the only signal that the index
+		// is actually being kept fresh across edits. Debounced (~1.5s), so not
+		// spammy. Mirrors the review graph's persist_succeeded.
+		logWordIndex({
+			phase: "persist_succeeded",
+			cwd: path.resolve(cwd),
+			trigger: "per_edit",
+			indexedFileCount: index.docCount,
+			tokens: index.postings.size,
+		});
 	} catch (err) {
 		dbg?.(`word-index persist: failed: ${err}`);
 		// M3, #958: a swallowed persist means every LATER symbol_search reads a

--- a/tests/clients/word-index-logger.test.ts
+++ b/tests/clients/word-index-logger.test.ts
@@ -1,0 +1,65 @@
+/**
+ * #926 durable word-index reporting, extended for #958. Verifies the shared
+ * NDJSON writer forwarding + the `isTestMode()` gate, mirroring
+ * latency-logger.test.ts's mock-the-writer pattern so no real file is touched.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const writerLog = vi.hoisted(() => vi.fn());
+const isTestModeRef = vi.hoisted(() => ({ value: false }));
+
+vi.mock("../../clients/env-utils.js", () => ({
+	isTestMode: () => isTestModeRef.value,
+	// getMaxLogSizeMB (below) is resolved from log-cleanup, which imports
+	// env-utils too; keep the surface minimal but complete for this test.
+}));
+vi.mock("../../clients/ndjson-logger.js", () => ({
+	createNdjsonLogger: () => ({
+		log: writerLog,
+		append: vi.fn(),
+		truncate: vi.fn(),
+		flush: vi.fn().mockResolvedValue(undefined),
+		flushSync: vi.fn(),
+	}),
+}));
+
+import { logWordIndex } from "../../clients/word-index-logger.js";
+
+describe("word-index-logger", () => {
+	beforeEach(() => {
+		writerLog.mockClear();
+		isTestModeRef.value = false;
+	});
+
+	it("stamps ts and forwards the structured decision/coverage fields", () => {
+		logWordIndex({
+			phase: "incremental_refresh",
+			cwd: "/proj",
+			trigger: "session_start",
+			indexedFileCount: 42,
+			truncated: false,
+			refreshed: 3,
+			dropped: 1,
+			skipped: 0,
+			reused: 38,
+		});
+
+		expect(writerLog).toHaveBeenCalledTimes(1);
+		expect(writerLog.mock.calls[0][0]).toEqual(
+			expect.objectContaining({
+				phase: "incremental_refresh",
+				cwd: "/proj",
+				indexedFileCount: 42,
+				refreshed: 3,
+				reused: 38,
+				ts: expect.any(String),
+			}),
+		);
+	});
+
+	it("is a no-op inside the test runner (isTestMode gate)", () => {
+		isTestModeRef.value = true;
+		logWordIndex({ phase: "persist_failed", cwd: "/proj", error: "boom" });
+		expect(writerLog).not.toHaveBeenCalled();
+	});
+});

--- a/tests/clients/word-index-observability.test.ts
+++ b/tests/clients/word-index-observability.test.ts
@@ -23,7 +23,6 @@ vi.mock("../../clients/word-index-logger.js", () => ({
 	logWordIndex: logSpy,
 	getWordIndexLogPath: () => "/dev/null/word-index.log",
 	flushWordIndexLog: vi.fn().mockResolvedValue(undefined),
-	flushWordIndexLogSync: vi.fn(),
 }));
 
 vi.mock("../../clients/project-snapshot.js", async (importOriginal) => {
@@ -46,6 +45,11 @@ beforeEach(() => {
 	logSpy.mockClear();
 	failPersist.value = false;
 	process.env.PI_LENS_WORD_INDEX_PERSIST_DEBOUNCE_MS = "0";
+	// The persist merges into the project snapshot, whose body write defaults to
+	// a worker thread (#958 item 2); force the sync writer so a successful
+	// persist test doesn't leave a worker handle open (this suite tests the
+	// word-index log, not the snapshot offload).
+	process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC = "1";
 });
 afterEach(async () => {
 	const { flushWordIndexPersistsForTests, _resetWordIndexBuildGuardForTests } =
@@ -53,6 +57,7 @@ afterEach(async () => {
 	flushWordIndexPersistsForTests();
 	_resetWordIndexBuildGuardForTests();
 	delete process.env.PI_LENS_WORD_INDEX_PERSIST_DEBOUNCE_MS;
+	delete process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC;
 	vi.restoreAllMocks();
 });
 
@@ -108,6 +113,43 @@ describe("word-index observability (#958)", () => {
 					error: expect.stringContaining("ENOSPC"),
 				}),
 			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("F1: a successful debounced persist emits a persist_succeeded record (the MCP-host freshness signal the old dbg adapter provided)", async () => {
+		const env = setupTestEnvironment("pi-lens-word-persist-ok-");
+		try {
+			const {
+				buildWordIndex,
+				scheduleWordIndexPersist,
+				flushWordIndexPersistsForTests,
+			} = await import("../../clients/word-index.js");
+			const index = buildWordIndex([
+				{ path: "a.ts", content: "export const alpha = 1;" },
+			]);
+
+			scheduleWordIndexPersist(env.tmpDir, index);
+			flushWordIndexPersistsForTests();
+			await flushMicrotasks();
+
+			const ok = logSpy.mock.calls.find(
+				(c) => c[0]?.phase === "persist_succeeded",
+			);
+			expect(ok).toBeDefined();
+			expect(ok?.[0]).toEqual(
+				expect.objectContaining({
+					phase: "persist_succeeded",
+					trigger: "per_edit",
+					indexedFileCount: 1,
+					tokens: expect.any(Number),
+				}),
+			);
+			// And no persist_failed on the success path.
+			expect(
+				logSpy.mock.calls.find((c) => c[0]?.phase === "persist_failed"),
+			).toBeUndefined();
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/word-index-observability.test.ts
+++ b/tests/clients/word-index-observability.test.ts
@@ -1,0 +1,171 @@
+/**
+ * #958 durable word-index observability — asserts the structured signals the
+ * audit flagged as missing are EMITTED at their source (independent of the
+ * host's `dbg`, which is a no-op in the MCP host):
+ *   - L1: `collectWordIndexDocs` reports a `skipped` count for files it saw but
+ *     could not index (over the byte cap / unreadable), so coverage stays
+ *     honest (#533) instead of a silent drop.
+ *   - M2: the cold-query background build logs its decision + coverage
+ *     (indexedFileCount / truncated / skipped).
+ *   - M3: a swallowed snapshot persist emits a `persist_failed` record.
+ *   - The safety refusal (root at/above $HOME) is durably recorded too.
+ *
+ * `logWordIndex` is mocked with a spy so the assertions read the exact entries
+ * the production code hands the durable logger, without touching disk.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+
+const { logSpy } = vi.hoisted(() => ({ logSpy: vi.fn() }));
+const { failPersist } = vi.hoisted(() => ({ failPersist: { value: false } }));
+
+vi.mock("../../clients/word-index-logger.js", () => ({
+	logWordIndex: logSpy,
+	getWordIndexLogPath: () => "/dev/null/word-index.log",
+	flushWordIndexLog: vi.fn().mockResolvedValue(undefined),
+	flushWordIndexLogSync: vi.fn(),
+}));
+
+vi.mock("../../clients/project-snapshot.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../clients/project-snapshot.js")>();
+	return {
+		...actual,
+		default: actual,
+		saveProjectSnapshot: (...args: unknown[]) => {
+			if (failPersist.value) throw new Error("ENOSPC: no space left on device");
+			return (actual.saveProjectSnapshot as (...a: unknown[]) => unknown)(...args);
+		},
+	};
+});
+
+async function flushMicrotasks(): Promise<void> {
+	for (let i = 0; i < 25; i++) await new Promise((r) => setTimeout(r, 5));
+}
+
+beforeEach(() => {
+	logSpy.mockClear();
+	failPersist.value = false;
+	process.env.PI_LENS_WORD_INDEX_PERSIST_DEBOUNCE_MS = "0";
+});
+afterEach(async () => {
+	const { flushWordIndexPersistsForTests, _resetWordIndexBuildGuardForTests } =
+		await import("../../clients/word-index.js");
+	flushWordIndexPersistsForTests();
+	_resetWordIndexBuildGuardForTests();
+	delete process.env.PI_LENS_WORD_INDEX_PERSIST_DEBOUNCE_MS;
+	vi.restoreAllMocks();
+});
+
+describe("word-index observability (#958)", () => {
+	it("L1: collectWordIndexDocs counts oversized + unreadable files as skipped, keeping coverage honest", async () => {
+		const env = setupTestEnvironment("pi-lens-word-skip-");
+		try {
+			const { collectWordIndexDocs, WORD_INDEX_MAX_BYTES } = await import(
+				"../../clients/word-index.js"
+			);
+			createTempFile(env.tmpDir, "src/small.ts", "export const kept = 1;");
+			createTempFile(
+				env.tmpDir,
+				"src/huge.ts",
+				`// x\nexport const big = "${"z".repeat(WORD_INDEX_MAX_BYTES + 16)}";\n`,
+			);
+
+			const docs = await collectWordIndexDocs(env.tmpDir);
+
+			// The small file is indexed; the oversized file is NOT — but it is
+			// COUNTED, not silently dropped.
+			expect(docs.some((d) => d.path.endsWith("small.ts"))).toBe(true);
+			expect(docs.some((d) => d.path.endsWith("huge.ts"))).toBe(false);
+			expect(docs.skipped).toBe(1);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("M3: a swallowed persist failure emits a persist_failed record (every later query would read stale)", async () => {
+		const env = setupTestEnvironment("pi-lens-word-persist-fail-");
+		try {
+			const { buildWordIndex, scheduleWordIndexPersist, flushWordIndexPersistsForTests } =
+				await import("../../clients/word-index.js");
+			const index = buildWordIndex([
+				{ path: "a.ts", content: "export const alpha = 1;" },
+			]);
+
+			failPersist.value = true;
+			scheduleWordIndexPersist(env.tmpDir, index);
+			flushWordIndexPersistsForTests();
+			await flushMicrotasks();
+
+			const persistFailed = logSpy.mock.calls.find(
+				(c) => c[0]?.phase === "persist_failed",
+			);
+			expect(persistFailed).toBeDefined();
+			expect(persistFailed?.[0]).toEqual(
+				expect.objectContaining({
+					phase: "persist_failed",
+					trigger: "per_edit",
+					indexedFileCount: 1,
+					error: expect.stringContaining("ENOSPC"),
+				}),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("M2: the cold-query background build logs its decision + honest coverage", async () => {
+		const env = setupTestEnvironment("pi-lens-word-cold-");
+		try {
+			createTempFile(env.tmpDir, "src/widget.ts", "export const renderWidget = 1;");
+			const { triggerBackgroundWordIndexBuild } = await import(
+				"../../clients/word-index.js"
+			);
+
+			triggerBackgroundWordIndexBuild(env.tmpDir);
+			await flushMicrotasks();
+
+			const coldBuild = logSpy.mock.calls.find(
+				(c) => c[0]?.phase === "cold_build",
+			);
+			expect(coldBuild).toBeDefined();
+			expect(coldBuild?.[0]).toEqual(
+				expect.objectContaining({
+					phase: "cold_build",
+					trigger: "cold_query",
+					truncated: false,
+					skipped: 0,
+				}),
+			);
+			expect(coldBuild?.[0].indexedFileCount).toBeGreaterThan(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("records the safety refusal when the root is at/above $HOME", async () => {
+		const env = setupTestEnvironment("pi-lens-word-refused-");
+		try {
+			const { triggerBackgroundWordIndexBuild } = await import(
+				"../../clients/word-index.js"
+			);
+			// homeDir == the build root ⇒ isAtOrAboveHomeDir refuses.
+			const status = triggerBackgroundWordIndexBuild(env.tmpDir, undefined, {
+				homeDir: env.tmpDir,
+			});
+
+			expect(status.state).toBe("refused");
+			const refused = logSpy.mock.calls.find(
+				(c) => c[0]?.phase === "cold_build_refused",
+			);
+			expect(refused).toBeDefined();
+			expect(refused?.[0]).toEqual(
+				expect.objectContaining({
+					phase: "cold_build_refused",
+					trigger: "cold_query",
+				}),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
Closes the word-index observability gap the audit flagged (M2/M3/L1). The incremental cross-session refresh feature itself (#958 item 1) was already implemented + tested in master (`refreshWordIndexIncrementally`, v2 `fileMtimes` serializer, `buildOrRefreshWordIndex` wiring) — what was missing was durable visibility into it.

Word-index signals previously rode solely on the optional `dbg` callback, which is a **no-op in the MCP host** (`clients/mcp/session.ts` `dbg: noop`) — exactly where `pilens_symbol_search` reads the index. So the full-vs-incremental decision, the refreshed/dropped/skipped/reused counts, `truncated`/`indexedFileCount`, and (worst) a **swallowed snapshot-persist failure** (every later query then reads a stale index) were all invisible where they mattered.

- Evolved the existing `word-index-logger.ts` (#926) from a fragile string-parsing `dbg` adapter into a structured `WordIndexLogEntry` (phases `full_rebuild`/`incremental_refresh`/`incremental_fallback`/`cold_build`/`cold_build_refused`/`cold_build_failed`/`persist_failed`; fields incl. refreshed/dropped/skipped/reused/truncated/indexedFileCount). Reuses the shared `createNdjsonLogger` → `~/.pi-lens/word-index.log` (same durable-trace pattern as `review-graph-logger`/`bus-events-logger`), with log rotation.
- **M2:** `buildOrRefreshWordIndex` (runtime-session.ts) logs the incremental-vs-full decision + counts.
- **M3:** `writeWordIndexSnapshot` persist-failure now logs `persist_failed` instead of swallowing into `dbg`.
- **L1:** `collectWordIndexDocs` now returns + logs a `skipped` count (unreadable/oversized files) on the FULL path, matching what the incremental path already did — a partial index is never logged as complete (#533).
- Callers log directly at the source; the `wordIndexDebug` string-parsing adapter is removed (`lens-engine.ts`, `mcp/analyze.ts` no longer thread it) — grep confirms zero remaining refs.

## Verification
- `npm run build` clean; `npx tsc --project tsconfig.json --noEmit` (full CI gate) clean.
- New `word-index-logger.test.ts` + `word-index-observability.test.ts` (skipped-count, persist_failed emission, cold-build decision/coverage/refusal, ts-stamp + isTestMode gate); word-index/runtime-session/symbol-search suites green (87 tests across touched suites).

Refs #958, #533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)