### PR TITLE
test(flaky): route remaining tool-runner test spawns through safeSpawn (finishes #902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,20 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Remaining test-suite spawns routed off `shell:true` to close the Windows-spawn flake class** (refs #902) —
+	`tests/clients/ast-grep-rule-precedence-followups.test.ts` (CLI probe + `runCli`),
+	`tests/clients/coderabbit-ast-grep-rules.test.ts` (vendored-catalog smoke),
+	`tests/clients/dispatch/runners/ast-grep-playground-verify.test.ts` (async `runVerify`),
+	`tests/clients/dead-code-client.test.ts` (vulture probe), and
+	`tests/clients/lsp/clangd-lazy-indexing.test.ts` (clangd `where`/`which` probe) now spawn
+	through the hardened `safeSpawn`/`safeSpawnAsync` (`clients/safe-spawn.ts`, #817) instead of
+	a raw `execFileSync`/`spawnSync`/`spawn`/`execSync` with a fresh, uncached `cmd.exe` wrapper
+	per call — the documented intermittent ENOENT/EAGAIN source under windows-latest CI's
+	parallel process-creation pressure. Completes the sweep PR #993 started for the two
+	ast-grep runner test files; `git` spawns are left as-is (no `.cmd` shim, so out of the flake
+	class) and the `mcp/*` and MCP harness spawns that need bidirectional stdin streaming are
+	left as-is (`safeSpawnAsync` only exposes a close-based result, not a live stdin/stdout pipe).
+
 - **Tree-sitter post-filters no longer leave silently dead rules** (refs #879) —
 	the 25 unknown filter references were resolved by implementing eight bounded,
 	fail-open-on-filter-error AST checks, expressing two conditions directly in

--- a/tests/clients/ast-grep-rule-precedence-followups.test.ts
+++ b/tests/clients/ast-grep-rule-precedence-followups.test.ts
@@ -1,10 +1,10 @@
-import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { js as sgJs, ts as sgTs } from "@ast-grep/napi";
 import * as yaml from "js-yaml";
 import { afterEach, describe, expect, it } from "vitest";
+import { safeSpawn } from "../../clients/safe-spawn.js";
 import {
 	evaluateAstGrepRules,
 	type AstGrepEvaluateOptions,
@@ -143,10 +143,16 @@ function napiDiagnostics(
 
 function findCli(): string | undefined {
 	for (const command of ["ast-grep", "sg"]) {
-		const result = spawnSync(command, ["--version"], {
-			encoding: "utf8",
-			shell: process.platform === "win32",
-		});
+		// #902: was `spawnSync(command, ..., { shell: process.platform ===
+		// "win32" })` — a fresh, uncached cmd.exe wrapper per call that
+		// intermittently failed to spawn at all under the process-creation
+		// pressure of a full parallel test-suite run on windows-latest CI
+		// (ENOENT/EAGAIN from the OS, not a real "CLI unavailable" signal).
+		// `safeSpawn` (shared with production, `clients/safe-spawn.ts`)
+		// resolves the command via a cached PATH+PATHEXT walk and spawns the
+		// resolved .exe/.com directly — same hardening #817 already gave the
+		// real dispatch spawn path (single source of truth, #883).
+		const result = safeSpawn(command, ["--version"]);
 		// The output must identify ast-grep, not merely exit 0: on Linux `sg` is
 		// util-linux's setgid runner, which exits 0 for `--version` and then fails
 		// every `scan --config` call — so the cliIt tests below ran against the
@@ -154,7 +160,7 @@ function findCli(): string | undefined {
 		// probes apply (clients/sg-runner.ts `probeCommand`,
 		// clients/dispatch/runners/utils/runner-helpers.ts).
 		const version = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-		if (result.status === 0 && /\bast[- ]grep\b/i.test(version)) {
+		if (result.status === 0 && !result.error && /\bast[- ]grep\b/i.test(version)) {
 			return command;
 		}
 	}
@@ -166,14 +172,20 @@ const cliIt = astGrepCli ? it : it.skip;
 
 function runCli(configPath: string, filePath: string) {
 	if (!astGrepCli) throw new Error("ast-grep CLI unavailable");
-	return spawnSync(
-		astGrepCli,
-		["scan", "--config", configPath, "--json=compact", filePath],
-		{
-			encoding: "utf8",
-			shell: process.platform === "win32",
-		},
-	);
+	// #902: safeSpawn instead of raw spawnSync(..., { shell: true }) — see
+	// findCli comment above.
+	const result = safeSpawn(astGrepCli, [
+		"scan",
+		"--config",
+		configPath,
+		"--json=compact",
+		filePath,
+	]);
+	return {
+		status: result.status,
+		stderr: result.stderr,
+		stdout: result.stdout,
+	};
 }
 
 afterEach(() => {

--- a/tests/clients/coderabbit-ast-grep-rules.test.ts
+++ b/tests/clients/coderabbit-ast-grep-rules.test.ts
@@ -1,9 +1,9 @@
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import * as yaml from "js-yaml";
 import { resolveAstGrepNativeExe } from "../../clients/lsp/wait-policy/index.js";
+import { safeSpawn } from "../../clients/safe-spawn.js";
 import { getAstGrepRuleSources } from "../../clients/sgconfig.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
@@ -139,17 +139,20 @@ describe("vendored CodeRabbit ast-grep rules", () => {
 			const astGrepExe = resolveAstGrepNativeExe();
 			expect(astGrepExe).toBeDefined();
 
-			expect(() =>
-				execFileSync(
-					astGrepExe!,
-					["scan", "--config", configPath, fixtures],
-					{
-						cwd: env.tmpDir,
-						encoding: "utf8",
-						stdio: ["ignore", "pipe", "pipe"],
-					},
-				),
-			).not.toThrow();
+			// #902: was `execFileSync(..., { shell: true })`-adjacent raw spawn.
+			// `astGrepExe` is already an absolute path resolved via
+			// `require.resolve` (no PATH/PATHEXT walk needed), but routing it
+			// through `safeSpawn` (shared with production, `clients/safe-spawn.ts`)
+			// keeps a single spawn strategy for every ast-grep invocation in this
+			// test tree (single source of truth, #883) instead of a second,
+			// hand-rolled one here.
+			const result = safeSpawn(
+				astGrepExe!,
+				["scan", "--config", configPath, fixtures],
+				{ cwd: env.tmpDir },
+			);
+			expect(result.error, result.stderr).toBeUndefined();
+			expect(result.status, result.stderr).toBe(0);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/dead-code-client.test.ts
+++ b/tests/clients/dead-code-client.test.ts
@@ -6,7 +6,6 @@
  * on PATH, and skips cleanly otherwise (mirrors the LSP smoke-skip pattern).
  */
 
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import path from "node:path";
@@ -20,6 +19,7 @@ import {
 	getDeadCodeClients,
 	type DeadCodeResult,
 } from "../../clients/dead-code-client.js";
+import { safeSpawn } from "../../clients/safe-spawn.js";
 import { removeTempDirSync, setupTestEnvironment } from "./test-utils.js";
 
 const REPO_ROOT = path.resolve(
@@ -39,16 +39,22 @@ const VULTURE_OUTPUT = [
 ].join("\n");
 
 function vultureAvailable(): boolean {
+	// #902: was `execFileSync(cmd[0], cmd[1], { stdio: "pipe" })`. On Windows,
+	// pip's console_scripts launcher for `vulture` is a bare-extension shim
+	// resolved via PATH+PATHEXT, which raw execFileSync (shell:false, no
+	// PATHEXT walk) can silently fail to find under load — a probe failure
+	// here means the whole guarded suite skips, so a spurious failure isn't
+	// just noise, it's a false "vulture unavailable" that hides real
+	// coverage. `safeSpawn` (shared with production, `clients/safe-spawn.ts`)
+	// resolves the command via a cached PATH+PATHEXT walk, same hardening
+	// #817 already gave the real dispatch spawn path (single source of
+	// truth, #883).
 	for (const cmd of [
 		["vulture", ["--version"]],
 		["python", ["-m", "vulture", "--version"]],
 	] as const) {
-		try {
-			execFileSync(cmd[0], cmd[1], { stdio: "pipe" });
-			return true;
-		} catch {
-			/* try next */
-		}
+		const result = safeSpawn(cmd[0], [...cmd[1]]);
+		if (result.status === 0 && !result.error) return true;
 	}
 	return false;
 }

--- a/tests/clients/dispatch/runners/ast-grep-playground-verify.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-playground-verify.test.ts
@@ -14,10 +14,10 @@
  * in the default `npm test` run; it's opt-in for local dev / nightly.
  */
 
-import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { safeSpawnAsync } from "../../../../clients/safe-spawn.js";
 
 const SCRIPT = join(process.cwd(), "scripts", "playground-verify-rule.mjs");
 const CHROME_CANDIDATES: string[] = [
@@ -42,41 +42,31 @@ interface VerifyResult {
 	engine_ms?: number;
 }
 
-function runVerify(ruleFile: string, args: string[] = [], timeoutMs = 60_000) {
-	return new Promise<VerifyResult>((resolve, reject) => {
-		const proc = spawn(process.execPath, [SCRIPT, ruleFile, ...args], {
-			stdio: ["ignore", "pipe", "pipe"],
-			windowsHide: true,
-		});
-		let stdout = "";
-		let stderr = "";
-		proc.stdout.on("data", (c) => (stdout += c));
-		proc.stderr.on("data", (c) => (stderr += c));
-		const timer = setTimeout(() => {
-			proc.kill();
-			reject(
-				new Error(`timeout after ${timeoutMs}ms: ${stderr.slice(0, 200)}`),
-			);
-		}, timeoutMs);
-		proc.on("close", (code) => {
-			clearTimeout(timer);
-			// Result is always on stdout (JSON) — stderr is diagnostic noise.
-			const last = stdout.trim().split("\n").pop() || "";
-			let parsed: VerifyResult;
-			try {
-				parsed = JSON.parse(last);
-			} catch (e) {
-				reject(
-					new Error(
-						`failed to parse result (exit ${code}): stdout=${stdout.slice(0, 300)} stderr=${stderr.slice(0, 300)}`,
-					),
-				);
-				return;
-			}
-			resolve(parsed);
-		});
-		proc.on("error", reject);
+// #902: was a hand-rolled `spawn(process.execPath, ...)` promise wrapper.
+// `safeSpawnAsync` (shared with production, `clients/safe-spawn.ts`) already
+// does timeout+kill, stdout/stderr accumulation, and spawn-error surfacing —
+// reusing it here instead of a second, hand-rolled spawn strategy (single
+// source of truth, #883). Behavior preserved: a spawn error or timeout still
+// rejects (via `result.error`), and a non-JSON stdout tail still rejects with
+// the same diagnostic message shape.
+async function runVerify(
+	ruleFile: string,
+	args: string[] = [],
+	timeoutMs = 60_000,
+): Promise<VerifyResult> {
+	const result = await safeSpawnAsync(process.execPath, [SCRIPT, ruleFile, ...args], {
+		timeout: timeoutMs,
 	});
+	if (result.error) throw result.error;
+	// Result is always on stdout (JSON) — stderr is diagnostic noise.
+	const last = result.stdout.trim().split("\n").pop() || "";
+	try {
+		return JSON.parse(last);
+	} catch {
+		throw new Error(
+			`failed to parse result (exit ${result.status}): stdout=${result.stdout.slice(0, 300)} stderr=${result.stderr.slice(0, 300)}`,
+		);
+	}
 }
 
 const skip = !chromeAvailable()

--- a/tests/clients/lsp/clangd-lazy-indexing.test.ts
+++ b/tests/clients/lsp/clangd-lazy-indexing.test.ts
@@ -6,23 +6,25 @@
  * context for api.hpp/api.cpp so apiSymbol can be found.
  */
 
-import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createLSPClient } from "../../../clients/lsp/client.js";
 import { launchLSP, stopLSP } from "../../../clients/lsp/launch.js";
+import { findCommand } from "../../../clients/safe-spawn.js";
 import { setupTestEnvironment } from "../test-utils.js";
 
-// Detect clangd availability at module load time
-const CLANGD: string | null = (() => {
-	try {
-		const bin = process.platform === "win32" ? "where clangd" : "which clangd";
-		return execSync(bin, { encoding: "utf8" }).trim() || null;
-	} catch {
-		return null;
-	}
-})();
+// Detect clangd availability at module load time.
+// #902: was `execSync("where clangd" / "which clangd", ...)` — execSync
+// always shells out (a fresh, uncached cmd.exe wrapper per call on Windows),
+// which intermittently failed to spawn at all under the process-creation
+// pressure of a full parallel test-suite run on windows-latest CI
+// (ENOENT/EAGAIN from the OS, not a real "clangd unavailable" signal).
+// `findCommand` (shared with production, `clients/safe-spawn.ts`) already
+// implements this exact where/which probe via the cached PATH+PATHEXT
+// resolution `safeSpawn` uses — reused here instead of a second, less
+// careful spawn strategy (single source of truth, #883).
+const CLANGD: string | null = findCommand("clangd");
 
 function createCompileCommandsJson(projectDir: string, files: string[]): void {
 	const entries = files.map((f) => ({


### PR DESCRIPTION
Finishes the "Windows spawn" item of #902. PR #993 routed the two ast-grep *runner* test files through the hardened `safeSpawn`; this sweeps the **rest of the class** — every remaining test that spawns a real external dev tool via raw `node:child_process` (which on Windows are `.cmd`/`.bat` shims that need a fresh uncached cmd.exe per call, the documented intermittent ENOENT/EAGAIN source under parallel process-creation pressure).

Swapped (single source of truth, #883 — same hardened resolution production dispatch uses):

| File | Sync/Async | Change |
|---|---|---|
| `ast-grep-rule-precedence-followups.test.ts` | sync | probe + scan → `safeSpawn` |
| `coderabbit-ast-grep-rules.test.ts` | sync | catalog scan → `safeSpawn` (kept `.not.toThrow()` via explicit error/status asserts) |
| `ast-grep-playground-verify.test.ts` | async | hand-rolled `spawn`+Promise → `safeSpawnAsync` |
| `dead-code-client.test.ts` | sync | vulture probe → `safeSpawn` |
| `lsp/clangd-lazy-indexing.test.ts` | sync | `execSync(where/which clangd)` → existing `findCommand()` |

Deliberately left (not the flake class): `node`/`process.execPath` spawns with streaming stdin (mcp harness, installer, scripts — `safeSpawnAsync`'s close-based API doesn't expose bidirectional streaming), `git` spawns (`git.exe` resolves directly, no shim), mocked spawns, and safe-spawn's own tests.

## Verification
- `npm run build` clean; `npx tsc --project tsconfig.json --noEmit` (full CI gate) clean.
- Each swapped suite run **3×** with `--no-file-parallelism` — all green, no flake. LSP-sweep-flush suites (the other #902 item) re-confirmed 20/20 × 3 runs. DEP0190 `shell:true` warning gone from all 5 swapped files.

With this, all three re-scoped #902 items are resolved (LSP sweep flush count #993, Windows spawn #993+this, startup-overhead already fixed) — **#902 is closeable** once this merges.

Refs #902.

🤖 Generated with [Claude Code](https://claude.com/claude-code)