### PR TITLE
perf(madge): parallelize per-turn dependency checks, guarding the circular-state race (refs #766)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Parallelized the per-turn madge dependency check** (refs #766) — the
+	turn-end circular-dependency pass previously ran one `await checkFile()`
+	per import-changed file in a sequential `for…await` loop, serializing N
+	madge subprocess spawns. `DependencyChecker.checkFilesBatch()` now runs
+	those spawns concurrently (bounded to 6 in flight) via a new turn-end
+	entry point. `DependencyChecker` keeps its circular-dep findings
+	(`lastCircular`/`circularFiles`) as shared instance state that a single-file
+	check overwrites wholesale, so naively parallelizing risked one file's
+	spawn clobbering a sibling's write depending on subprocess completion
+	order. The fix keeps every spawn's result local until all have settled,
+	then folds them into the shared state in original file order — matching
+	the sequential loop's file-by-file overwrite exactly, just without waiting
+	for each subprocess before starting the next. Behavior-preserving: same
+	per-file results, same final circular-dep state, same `dbg` logs — only
+	wall-clock time changes.
+
 - **Word-index build/refresh/persist outcomes are now durably observable**
 	(refs #958, #926, #533) — every word-index signal previously rode solely on
 	the optional `dbg` callback, a documented no-op in the MCP host where

--- a/clients/dependency-checker.ts
+++ b/clients/dependency-checker.ts
@@ -93,6 +93,33 @@ interface FileImports {
 	timestamp: number;
 }
 
+/**
+ * Defensive cap on concurrent madge spawns for a single `checkFilesBatch`
+ * call. A turn usually only touches 1-3 import-changed files, so this rarely
+ * binds — it just guards against a pathological turn (bulk rename/move) from
+ * fork-bombing subprocesses.
+ */
+const MADGE_BATCH_CONCURRENCY = 6;
+
+/** Run `mapper` over `items` with at most `concurrency` in flight at once. */
+async function mapWithConcurrency<T>(
+	items: T[],
+	concurrency: number,
+	mapper: (item: T) => Promise<void>,
+): Promise<void> {
+	if (items.length === 0) return;
+	let nextIndex = 0;
+	const workerCount = Math.max(1, Math.min(concurrency, items.length));
+	const workers = Array.from({ length: workerCount }, async () => {
+		while (true) {
+			const index = nextIndex++;
+			if (index >= items.length) return;
+			await mapper(items[index]);
+		}
+	});
+	await Promise.all(workers);
+}
+
 // --- Client ---
 
 export class DependencyChecker {
@@ -334,6 +361,49 @@ export class DependencyChecker {
 		normalized: string,
 		projectRoot: string,
 	): Promise<DepCheckResult> {
+		const spawnResult = await this.runMadgeSpawn(normalized, projectRoot);
+		if (!spawnResult.ok) {
+			return {
+				hasCircular: false,
+				circular: [],
+				checked: false,
+				cacheHit: false,
+			};
+		}
+
+		this.lastCircular = spawnResult.circular;
+		this.circularFiles = spawnResult.circularFiles;
+
+		return {
+			hasCircular: spawnResult.circular.length > 0,
+			circular: spawnResult.circular.filter(
+				(d) => d.file === normalized || d.path.includes(normalized),
+			),
+			checked: true,
+			cacheHit: false,
+			localSkips: spawnResult.localSkips,
+		};
+	}
+
+	/**
+	 * Run madge on a single file and parse its cycle output. Pure: unlike
+	 * `runCheckFile`, this does NOT mutate `lastCircular`/`circularFiles` — it
+	 * hands the parsed result back so callers can apply the shared-state update
+	 * themselves (`runCheckFile` does so immediately; `checkFilesBatch` defers
+	 * it so concurrent spawns can't clobber each other's writes, see #766).
+	 */
+	private async runMadgeSpawn(
+		normalized: string,
+		projectRoot: string,
+	): Promise<
+		| {
+				ok: true;
+				circular: CircularDep[];
+				circularFiles: Set<string>;
+				localSkips: number;
+		  }
+		| { ok: false }
+	> {
 		this.log(
 			`Imports changed for ${path.basename(normalized)}, checking dependencies...`,
 		);
@@ -352,12 +422,7 @@ export class DependencyChecker {
 
 			if (result.error) {
 				this.log(`Check error: ${result.error.message}`);
-				return {
-					hasCircular: false,
-					circular: [],
-					checked: false,
-					cacheHit: false,
-				};
+				return { ok: false };
 			}
 
 			const output = result.stdout || "[]";
@@ -381,9 +446,6 @@ export class DependencyChecker {
 				});
 			}
 
-			this.lastCircular = circular;
-			this.circularFiles = circularFiles;
-
 			const skips = parseMadgeSkips(result.stderr || "");
 			if (skips.local.length > 0) {
 				this.log(
@@ -391,24 +453,141 @@ export class DependencyChecker {
 				);
 			}
 
-			return {
-				hasCircular: circular.length > 0,
-				circular: circular.filter(
-					(d) => d.file === normalized || d.path.includes(normalized),
+			return { ok: true, circular, circularFiles, localSkips: skips.local.length };
+		} catch (err: any) {
+			this.log(`Check error: ${err.message}`);
+			return { ok: false };
+		}
+	}
+
+	/** Build the cache-hit `DepCheckResult` for `normalized` from current shared state. */
+	private buildCachedResult(normalized: string): DepCheckResult {
+		return {
+			hasCircular: this.circularFiles.has(normalized),
+			circular: this.lastCircular.filter(
+				(d) => d.file === normalized || d.path.includes(normalized),
+			),
+			checked: true,
+			cacheHit: true,
+		};
+	}
+
+	/**
+	 * Batch-check multiple files for circular deps in one turn-end pass,
+	 * running the madge subprocess spawns concurrently (bounded by
+	 * `MADGE_BATCH_CONCURRENCY`) instead of one at a time (#766).
+	 *
+	 * Equivalence with the sequential `for…await checkFile(file)` loop it
+	 * replaces:
+	 *  - Classification (existence + `importsChanged`) runs synchronously in
+	 *    original array order first — identical to what each sequential
+	 *    `checkFile()` call would do, including the `importCache` side effect.
+	 *  - Only the actual madge spawns for import-changed ("miss") files run
+	 *    concurrently; each one's parsed result stays LOCAL (no shared-state
+	 *    write) until every spawn has settled.
+	 *  - The shared `lastCircular`/`circularFiles` state is then folded by
+	 *    replaying the miss results in ORIGINAL array order (not completion
+	 *    order), so the final state — and each cache-hit file's result, which
+	 *    reads the state as of its position in the array — is byte-for-byte
+	 *    what the sequential last-write-wins loop would have produced. No
+	 *    concurrent write can clobber another's, because none are applied
+	 *    until after `Promise.all` resolves.
+	 */
+	async checkFilesBatch(
+		filePaths: string[],
+		cwd?: string,
+	): Promise<Map<string, DepCheckResult>> {
+		const projectRoot = path.resolve(cwd || process.cwd());
+		const results = new Map<string, DepCheckResult>();
+
+		type Entry =
+			| { kind: "missing"; file: string }
+			| { kind: "hit"; file: string; normalized: string }
+			| { kind: "miss"; file: string; normalized: string };
+
+		const entries: Entry[] = [];
+		for (const file of filePaths) {
+			const normalized = path.resolve(projectRoot, file);
+			if (!fs.existsSync(normalized)) {
+				entries.push({ kind: "missing", file });
+				continue;
+			}
+			entries.push(
+				this.importsChanged(normalized)
+					? { kind: "miss", file, normalized }
+					: { kind: "hit", file, normalized },
+			);
+		}
+
+		const missEntries = entries.filter(
+			(e): e is Extract<Entry, { kind: "miss" }> => e.kind === "miss",
+		);
+
+		const notAvailableResult: DepCheckResult = {
+			hasCircular: false,
+			circular: [],
+			checked: false,
+			cacheHit: false,
+		};
+
+		if (missEntries.length > 0 && !(await this.ensureAvailable())) {
+			// madge unavailable: mirrors checkFile()'s "not available" branch for
+			// every miss; hits still read whatever shared state already exists.
+			for (const entry of entries) {
+				if (entry.kind === "hit") {
+					results.set(entry.file, this.buildCachedResult(entry.normalized));
+				} else {
+					results.set(entry.file, notAvailableResult);
+				}
+			}
+			return results;
+		}
+
+		// Run the concurrent (bounded) madge spawns for the miss set only. Each
+		// result stays local — keyed by normalized path — until folded below.
+		const spawnResults = new Map<
+			string,
+			Awaited<ReturnType<DependencyChecker["runMadgeSpawn"]>>
+		>();
+		await mapWithConcurrency(missEntries, MADGE_BATCH_CONCURRENCY, async (entry) => {
+			spawnResults.set(
+				entry.normalized,
+				await this.runMadgeSpawn(entry.normalized, projectRoot),
+			);
+		});
+
+		// Fold in original order: each miss overwrites the shared state exactly
+		// as the sequential loop would, and each hit is resolved against the
+		// state as folded up to (but not past) its own position.
+		for (const entry of entries) {
+			if (entry.kind === "missing") {
+				results.set(entry.file, notAvailableResult);
+				continue;
+			}
+			if (entry.kind === "hit") {
+				results.set(entry.file, this.buildCachedResult(entry.normalized));
+				continue;
+			}
+			const spawnResult = spawnResults.get(entry.normalized);
+			if (!spawnResult || !spawnResult.ok) {
+				results.set(entry.file, notAvailableResult);
+				continue;
+			}
+			this.lastCircular = spawnResult.circular;
+			this.circularFiles = spawnResult.circularFiles;
+			results.set(entry.file, {
+				hasCircular: spawnResult.circular.length > 0,
+				circular: spawnResult.circular.filter(
+					(d) =>
+						d.file === entry.normalized || d.path.includes(entry.normalized),
 				),
 				checked: true,
 				cacheHit: false,
-				localSkips: skips.local.length,
-			};
-		} catch (err: any) {
-			this.log(`Check error: ${err.message}`);
-			return {
-				hasCircular: false,
-				circular: [],
-				checked: false,
-				cacheHit: false,
-			};
+				localSkips: spawnResult.localSkips,
+			});
 		}
+
+		return results;
 	}
 
 	/**

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -634,9 +634,15 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 			dbg(
 				`turn_end: madge checking ${madgeFiles.length} file(s) for circular deps`,
 			);
+			// Checked concurrently (bounded) rather than one `await` per file —
+			// the shared circular-dep state update is deferred/folded inside
+			// checkFilesBatch so concurrent spawns can't clobber each other (#766).
+			const absFiles = madgeFiles.map((file) => path.resolve(cwd, file));
+			const depResults = await depChecker.checkFilesBatch(absFiles, cwd);
 			for (const file of madgeFiles) {
 				const absPath = path.resolve(cwd, file);
-				const depResult = await depChecker.checkFile(absPath, cwd);
+				const depResult = depResults.get(absPath);
+				if (!depResult) continue;
 				if (depResult.localSkips && depResult.localSkips > 0) {
 					// Not silent: a skipped LOCAL import means madge couldn't resolve
 					// it into the graph, so a cycle through it would be missed.

--- a/tests/clients/dependency-checker-batch-race.test.ts
+++ b/tests/clients/dependency-checker-batch-race.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression test for #766: `checkFilesBatch` parallelizes the per-turn
+ * madge subprocess spawns that used to run one at a time in a sequential
+ * `for…await checkFile(file)` loop.
+ *
+ * The risk: `DependencyChecker` keeps `lastCircular`/`circularFiles` as
+ * shared instance state that each single-file madge run OVERWRITES (not
+ * merges). Sequentially, the file processed LAST in array order determines
+ * the final shared state. A naive `Promise.all` that mutates that shared
+ * state as soon as each spawn's own promise resolves makes the final state
+ * depend on subprocess COMPLETION order instead — nondeterministic and not
+ * equivalent to the sequential baseline.
+ *
+ * This test sets up two files whose madge results disagree (one reports a
+ * circular dependency, the other doesn't) and deliberately makes the
+ * array-first file's subprocess resolve LAST. A correct fix folds results in
+ * original array order regardless of completion order, so the final shared
+ * state (and `isInCircular`/`getCircularForFile`) must match what the
+ * sequential loop would have produced — i.e. the array-LAST file's result —
+ * even though its spawn completed FIRST.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const safeSpawnAsync = vi.fn();
+const safeSpawn = vi.fn();
+
+vi.mock("../../clients/safe-spawn.js", () => ({ safeSpawnAsync, safeSpawn }));
+vi.mock("../../clients/package-manager.js", () => ({
+	findNodeToolBinary: vi.fn(async () => "/fake/bin/madge"),
+}));
+
+describe("DependencyChecker.checkFilesBatch — concurrency race guard (#766)", () => {
+	let tmp: string;
+	let aPath: string;
+	let cPath: string;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pilens-madge-batch-"));
+		aPath = path.join(tmp, "a.ts");
+		cPath = path.join(tmp, "c.ts");
+		fs.writeFileSync(aPath, "import { b } from './b.js';\nexport const a = 1;\n");
+		fs.writeFileSync(cPath, "export const c = 1;\n");
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmp, { recursive: true, force: true });
+	});
+
+	/** Resolve slowly for `a.ts` (reports a circular dep) and fast for `c.ts`
+	 * (reports none) — completion order is REVERSED from array order. */
+	function mockSpawnDeps() {
+		safeSpawnAsync.mockImplementation(
+			async (_cmd: string, args: string[]) => {
+				const target = args[args.length - 1];
+				if (target === aPath) {
+					// Resolves LAST despite being array-FIRST.
+					await new Promise((resolve) => setTimeout(resolve, 40));
+					return {
+						status: 0,
+						error: null,
+						stdout: JSON.stringify([[aPath, path.join(tmp, "b.ts")]]),
+						stderr: "",
+					};
+				}
+				// c.ts resolves immediately with no cycle.
+				return {
+					status: 0,
+					error: null,
+					stdout: JSON.stringify([]),
+					stderr: "",
+				};
+			},
+		);
+	}
+
+	it("folds results in ARRAY order, not completion order, matching the sequential loop", async () => {
+		const { DependencyChecker } = await import(
+			"../../clients/dependency-checker.js"
+		);
+		mockSpawnDeps();
+
+		const checker = new DependencyChecker();
+		// Array order: a (slow, circular) first, then c (fast, clean) last.
+		const results = await checker.checkFilesBatch([aPath, cPath], tmp);
+
+		// Per-file local results must still be correct and not clobbered by
+		// the sibling call: a's own result reports its cycle...
+		expect(results.get(aPath)?.hasCircular).toBe(true);
+		// ...and c's own result reports none, regardless of completion order.
+		expect(results.get(cPath)?.hasCircular).toBe(false);
+
+		// The shared state, however, reflects last-array-order-wins (c),
+		// exactly like the sequential `for…await` loop would have left it —
+		// NOT last-to-complete-wins (which would be a, since a's spawn
+		// resolves after c's).
+		expect(checker.isInCircular(aPath)).toBe(false);
+		expect(checker.isInCircular(cPath)).toBe(false);
+		expect(checker.getCircularForFile(aPath)).toEqual([]);
+	});
+
+	it("matches a true sequential for…await run of the same files/mocks", async () => {
+		const { DependencyChecker } = await import(
+			"../../clients/dependency-checker.js"
+		);
+
+		// --- Sequential baseline ---
+		mockSpawnDeps();
+		const sequential = new DependencyChecker();
+		const seqResults = new Map<string, boolean>();
+		for (const file of [aPath, cPath]) {
+			const r = await sequential.checkFile(file, tmp);
+			seqResults.set(file, r.hasCircular);
+		}
+		const seqFinalIsInCircularA = sequential.isInCircular(aPath);
+		const seqFinalIsInCircularC = sequential.isInCircular(cPath);
+
+		// --- Batch (parallel) run, same mocks/inputs ---
+		vi.resetAllMocks();
+		mockSpawnDeps();
+		const batch = new DependencyChecker();
+		const batchResults = await batch.checkFilesBatch([aPath, cPath], tmp);
+
+		expect(batchResults.get(aPath)?.hasCircular).toBe(seqResults.get(aPath));
+		expect(batchResults.get(cPath)?.hasCircular).toBe(seqResults.get(cPath));
+		expect(batch.isInCircular(aPath)).toBe(seqFinalIsInCircularA);
+		expect(batch.isInCircular(cPath)).toBe(seqFinalIsInCircularC);
+	});
+
+	it("would fail under a naive completion-order-wins merge (sanity check on the mock setup)", async () => {
+		// This test does not exercise DependencyChecker at all — it just proves
+		// the mock setup in this file actually produces reversed completion
+		// order, which is the precondition the race-guard test above depends on.
+		mockSpawnDeps();
+		const order: string[] = [];
+		const done = Promise.all([
+			(async () => {
+				const r = await safeSpawnAsync("/fake/bin/madge", [
+					"--circular",
+					"--json",
+					aPath,
+				]);
+				order.push("a");
+				return r;
+			})(),
+			(async () => {
+				const r = await safeSpawnAsync("/fake/bin/madge", [
+					"--circular",
+					"--json",
+					cPath,
+				]);
+				order.push("c");
+				return r;
+			})(),
+		]);
+		await done;
+		// c (array-last) completes FIRST; a (array-first) completes LAST.
+		expect(order).toEqual(["c", "a"]);
+	});
+});


### PR DESCRIPTION
The low-risk half of #766. The per-turn madge check was a sequential `for…await` over import-changed files (`runtime-turn.ts`), serializing N subprocess spawns. This parallelizes it — the measured tail is madge-specific (the broadened #766 analysis confirmed the other 7 turn-end runners are already parallel + cache-only; vulture runs only at session-start).

## Change
- New `DependencyChecker.checkFilesBatch(files, cwd)`: classifies each file synchronously first (existence + `importsChanged`, **in original array order** — identical side effects to the old loop), then runs the madge subprocess spawns for the cache-*miss* files concurrently via a bounded pool (`MADGE_BATCH_CONCURRENCY = 6` — defensive; real turns touch 1–3 files). `runtime-turn.ts` calls it once instead of the per-file `await` loop; the per-file `dbg` logs (localSkips warning, circular note) still fire once per file.
- Does NOT add the dependency-closure cache (the behavior-affecting piece #766 tracks separately).

## Race fix (the whole risk)
`checkFile()` mutated shared `this.lastCircular`/`this.circularFiles` non-atomically. Extracted the spawn+parse into a **pure** `runMadgeSpawn()` that returns `{circular, circularFiles, localSkips}` touching no shared state (single source of truth — `runCheckFile` uses it too, so single-file `checkFile()` is behavior-unchanged). `checkFilesBatch` collects all concurrent results into a local map, then — **only after all settle** — applies the shared-state writes in **original array order**, replicating the sequential loop's last-write-wins exactly (deterministic by position, not by subprocess completion order).

## Verification
- `npm run build` clean; `npx tsc --project tsconfig.json --noEmit` (full CI gate) clean.
- New `dependency-checker-batch-race.test.ts`: two temp files where the array-last file's spawn resolves FIRST (completion order reversed from array order); asserts final `isInCircular`/`getCircularForFile` reflect array-order folding, matching sequential. **Verified it catches the race** — patched the batch to mutate shared state on each completion (naive `Promise.all`) → 2/3 tests failed; reverted → clean. dependency-checker + runtime-turn-session suites: 9/9 + 26/26.

## Notes for review
- `checkFilesBatch` bypasses `checkFile()`'s `checkInFlight` dedupe map — a concurrent `checkFile()` for the same file during a batch could redundantly spawn (perf-only edge, not correctness).
- Pre-existing quirk preserved exactly: `lastCircular`/`circularFiles` are fully overwritten per cache-miss file (not merged), so only the last file's data survives a multi-file turn — but `isInCircular`/`getCircularForFile` are **unused by any production call site** (repo-wide grep), so this shared state is effectively write-only today.

Refs #766. The dependency-closure cache (the larger p99 win) remains tracked separately as the behavior-affecting follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)