### PR TITLE
fix(resource-sampler): guarded Windows CPU/RSS sampling — pidusage's unguarded spawn crashed the host (refs #620, #533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Guarded Windows CPU/RSS resource sampling so a best-effort sampler can no
+	longer crash the pi host** (refs #620, #533) — `clients/resource-sampler.ts`
+	sampled CPU%/RSS via `pidusage`, whose Windows path shells out to `gwmi`
+	through an internal `spawn(..., { shell: "powershell.exe" })` that has no
+	try/catch and runs from inside a ChildProcess `close` callback. Under real
+	Windows handle/commit pressure that spawn can throw `spawn UNKNOWN`
+	(errno -4094) **synchronously in that detached callback**, which the call
+	site's `try { await pidusage() } catch {}` cannot catch → `uncaughtException`
+	→ the whole host process dies (observed live). pidusage 4.0.1 offers no
+	option to avoid the gwmi path. The sampler now runs its OWN fully guarded
+	`Get-CimInstance Win32_Process` query on Windows (never calling `pidusage`
+	there), mirroring the existing `findDescendantPidsWindows` guard: a
+	synchronous spawn throw, a child `error` event, and a non-zero/garbage exit
+	all resolve to a partial/empty map — the sampler can now only ever lose a
+	data point, never throw into the heartbeat/spawn path. RSS comes from
+	`WorkingSetSize`; CPU% is preserved via the same KernelModeTime/UserModeTime
+	delta-over-elapsed-wall-time computation gwmi uses (a small per-pid history
+	tracks the prior cumulative CPU time). Linux/macOS keep using `pidusage`
+	(procfs/`ps` — not the crash vector) unchanged. A pid absent from the
+	returned map still means "unsampled this tick", never zero.
+
 - **Parallelized the per-turn madge dependency check** (refs #766) — the
 	turn-end circular-dependency pass previously ran one `await checkFile()`
 	per import-changed file in a sequential `for…await` loop, serializing N

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
-### Fixed
-
 - **Guarded Windows CPU/RSS resource sampling so a best-effort sampler can no
 	longer crash the pi host** (refs #620, #533) — `clients/resource-sampler.ts`
 	sampled CPU%/RSS via `pidusage`, whose Windows path shells out to `gwmi`

--- a/clients/resource-sampler.ts
+++ b/clients/resource-sampler.ts
@@ -12,13 +12,24 @@
  *    `spawn()`, stopped at `child.on("close", ...)`), tracking peak/average
  *    CPU% and RSS for that one invocation.
  *
- * Uses `pidusage` (not a hand-rolled `/proc` vs `wmic`/perf-counters split):
- * Windows, macOS, and Linux each expose process CPU/RSS differently at the OS
- * level, and pidusage already abstracts that (procfs on Linux, `ps` on macOS,
- * PowerShell `Get-WmiObject`/CIM on Windows — not the deprecated `wmic.exe`
- * binary). It's a small pure-JS package (one transitive dep, `safe-buffer`),
- * so it bundles like the repo's other pure-JS runtime deps (minimatch,
- * js-yaml) rather than needing an EXTERNAL entry in scripts/bundle-dist.mjs.
+ * On **Linux/macOS** it uses `pidusage` (procfs on Linux, `ps` on macOS) — a
+ * small pure-JS package (one transitive dep, `safe-buffer`) that bundles like
+ * the repo's other pure-JS runtime deps (minimatch, js-yaml) rather than
+ * needing an EXTERNAL entry in scripts/bundle-dist.mjs.
+ *
+ * On **Windows** it does NOT use `pidusage`: pidusage's Windows path shells out
+ * to `gwmi` via an internal `spawn(..., { shell: "powershell.exe" })` that has
+ * NO try/catch, and it runs that spawn from inside a ChildProcess `close`
+ * callback (a detached async context). Under real Windows handle/commit
+ * pressure that `spawn()` can throw `spawn UNKNOWN` (errno -4094)
+ * **synchronously in that detached callback**, which no `try { await pidusage }
+ * catch {}` at the call site can catch → uncaughtException → the pi host
+ * crashes (#620, #533). pidusage 4.0.1 exposes no option to avoid the gwmi
+ * path. So on Windows this module runs its OWN fully guarded
+ * `Get-CimInstance Win32_Process` query (see `sampleProcessesWindows`),
+ * mirroring `findDescendantPidsWindows`'s guard pattern, and computes CPU%
+ * from the same KernelModeTime/UserModeTime delta-over-elapsed formula gwmi
+ * uses — so a spawn failure can only ever lose a data point, never throw.
  *
  * Every export here is best-effort: a sampling failure (pid already exited,
  * `pidusage` throwing, permission denied, etc.) must never throw into the
@@ -37,7 +48,11 @@ import { spawn as nodeSpawn } from "node:child_process";
 import * as path from "node:path";
 import pidusage from "pidusage";
 
-const isWindows = process.platform === "win32";
+// Read the platform live (not a module-load const) so both the Windows and the
+// POSIX sampling paths are exercisable in unit tests regardless of the host OS.
+function runningOnWindows(): boolean {
+	return process.platform === "win32";
+}
 
 export interface ProcessUsage {
 	rssBytes: number;
@@ -94,7 +109,7 @@ export function walkDescendantPids(
  * Mirrors the identity-verification CIM queries in clients/instance-reaper.ts.
  */
 async function findDescendantPidsWindows(rootPid: number): Promise<number[]> {
-	if (!isWindows || !Number.isFinite(rootPid) || rootPid <= 0) return [];
+	if (!runningOnWindows() || !Number.isFinite(rootPid) || rootPid <= 0) return [];
 	// One WQL query pulls every process's (pid, parentPid) pair; walk the BFS
 	// in JS rather than issuing N queries for N tree levels.
 	const psScript =
@@ -140,10 +155,134 @@ async function findDescendantPidsWindows(rootPid: number): Promise<number[]> {
 }
 
 /**
- * Sample CPU%/RSS for a set of pids in one batched `pidusage` call.
- * Best-effort: a pid pidusage can't resolve (already exited, permission
- * denied, etc.) is simply absent from the returned map — callers must treat
- * "absent" as "unsampled this tick", never as zero usage.
+ * Per-pid CPU-time history for the Windows CIM sampler. CPU% is a rate, so it
+ * needs two observations: `cpuMs` = cumulative kernel+user CPU time (ms) and
+ * `ts` = the wall clock (Date.now, ms) of that observation. The next sample
+ * computes `cpu% = ΔcpuMs / ΔwallMs * 100`, exactly as pidusage's gwmi does
+ * (it divides both to seconds first; the ratio is identical). Entries older
+ * than `CPU_HISTORY_MAX_AGE_MS` are pruned each tick so the map can't grow
+ * without bound as pids come and go.
+ */
+interface WindowsCpuHistoryEntry {
+	cpuMs: number;
+	ts: number;
+}
+const windowsCpuHistory = new Map<number, WindowsCpuHistoryEntry>();
+const CPU_HISTORY_MAX_AGE_MS = 60_000;
+
+/**
+ * TEST-ONLY: clear the Windows CPU%-history so a test's two-sample CPU%
+ * assertion starts from a known-empty state (module-level state otherwise
+ * persists across tests in the same worker).
+ */
+export function __resetWindowsCpuHistoryForTests(): void {
+	windowsCpuHistory.clear();
+}
+
+/**
+ * Windows-only CPU%/RSS sampling via a FULLY GUARDED `Get-CimInstance
+ * Win32_Process` query (mirrors `findDescendantPidsWindows`): a synchronous
+ * throw from `spawn` (the `spawn UNKNOWN` crash vector, #620), a `child`
+ * `error` event, or a non-zero/garbage exit all resolve to a partial/empty
+ * map — this function can NEVER throw or reject. Deliberately does NOT call
+ * `pidusage`, whose unguarded internal `gwmi` spawn is the crash we're fixing.
+ *
+ * RSS comes from `WorkingSetSize`; CPU% from `KernelModeTime`+`UserModeTime`
+ * (both in 100 ns units → ms via `/1e4`) differenced against this pid's prior
+ * sample over the elapsed wall time — the same computation pidusage's gwmi
+ * path uses. The first time a pid is seen it has no prior sample, so CPU% is
+ * reported as 0 for that tick and a real rate lands on the next one.
+ */
+async function sampleProcessesWindows(
+	valid: number[],
+): Promise<Map<number, ProcessUsage>> {
+	const result = new Map<number, ProcessUsage>();
+	if (valid.length === 0) return result;
+
+	// pids are pre-validated finite positive integers, so this WQL filter is
+	// injection-safe. One line per pid: "pid,workingSet,kernel100ns,user100ns".
+	const filter = valid.map((p) => `ProcessId=${p}`).join(" or ");
+	const psScript =
+		`Get-CimInstance Win32_Process -Filter "${filter}" ` +
+		"| Select-Object -Property ProcessId,WorkingSetSize,KernelModeTime,UserModeTime " +
+		'| ForEach-Object { "$($_.ProcessId),$($_.WorkingSetSize),$($_.KernelModeTime),$($_.UserModeTime)" }';
+
+	return await new Promise<Map<number, ProcessUsage>>((resolve) => {
+		try {
+			const powershell = path.join(
+				process.env.SystemRoot ?? String.raw`C:\Windows`,
+				"WindowsPowerShell",
+				"v1.0",
+				"powershell.exe",
+			);
+			const child = nodeSpawn(
+				powershell,
+				["-NoProfile", "-NonInteractive", "-Command", psScript],
+				{ shell: false, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] },
+			);
+			let out = "";
+			child.stdout?.on("data", (chunk) => {
+				out += chunk.toString();
+			});
+			// A spawn error (ENOENT, spawn UNKNOWN surfaced async, etc.) loses this
+			// tick's data for every pid but never rejects.
+			child.once("error", () => resolve(result));
+			child.once("close", () => {
+				try {
+					const now = Date.now();
+					const seen = new Set<number>();
+					for (const line of out.split(/\r?\n/)) {
+						const parts = line.split(",");
+						if (parts.length < 4) continue;
+						const pid = Number(parts[0]);
+						const workingSet = Number(parts[1]);
+						const kernel100ns = Number(parts[2]);
+						const user100ns = Number(parts[3]);
+						if (!Number.isFinite(pid) || pid <= 0) continue;
+						if (!Number.isFinite(workingSet)) continue;
+
+						const cpuMs = Math.round(kernel100ns / 1e4) + Math.round(user100ns / 1e4);
+						const prev = windowsCpuHistory.get(pid);
+						let cpuPercent = 0;
+						if (prev) {
+							const wallMs = now - prev.ts;
+							if (wallMs > 0) {
+								cpuPercent = ((cpuMs - prev.cpuMs) / wallMs) * 100;
+								if (!Number.isFinite(cpuPercent) || cpuPercent < 0) cpuPercent = 0;
+							}
+						}
+						windowsCpuHistory.set(pid, { cpuMs, ts: now });
+						seen.add(pid);
+						result.set(pid, { rssBytes: workingSet, cpuPercent });
+					}
+					// Prune stale history so pids that have gone away don't accumulate.
+					for (const [pid, entry] of windowsCpuHistory) {
+						if (!seen.has(pid) && now - entry.ts > CPU_HISTORY_MAX_AGE_MS) {
+							windowsCpuHistory.delete(pid);
+						}
+					}
+				} catch {
+					// Parsing must never throw into the resolve path; best-effort.
+				}
+				resolve(result);
+			});
+		} catch {
+			// Synchronous spawn throw (the `spawn UNKNOWN` crash vector) — resolve
+			// to whatever we have (empty), never propagate.
+			resolve(result);
+		}
+	});
+}
+
+/**
+ * Sample CPU%/RSS for a set of pids. Best-effort: a pid that can't be resolved
+ * (already exited, permission denied, spawn failed, etc.) is simply absent
+ * from the returned map — callers MUST treat "absent" as "unsampled this
+ * tick", never as zero usage.
+ *
+ * On Windows this uses a guarded CIM query (`sampleProcessesWindows`) and
+ * never touches `pidusage`, whose unguarded internal spawn could crash the
+ * host (#620, #533). On Linux/macOS it uses `pidusage`.
  */
 export async function sampleProcesses(
 	pids: number[],
@@ -151,6 +290,12 @@ export async function sampleProcesses(
 	const result = new Map<number, ProcessUsage>();
 	const valid = [...new Set(pids.filter((p) => Number.isFinite(p) && p > 0))];
 	if (valid.length === 0) return result;
+
+	if (runningOnWindows()) {
+		// Fully guarded; cannot throw/reject.
+		return await sampleProcessesWindows(valid);
+	}
+
 	try {
 		const stats = await pidusage(valid);
 		for (const pid of valid) {
@@ -254,7 +399,7 @@ export function startSpawnUsageSampler(
 	const tick = async () => {
 		if (stopped) return;
 		try {
-			const pids = isWindows
+			const pids = runningOnWindows()
 				? [targetPid, ...(await findDescendantPidsWindows(targetPid))]
 				: [targetPid];
 			const usageByPid = await sampleProcesses(pids);

--- a/tests/clients/resource-sampler.test.ts
+++ b/tests/clients/resource-sampler.test.ts
@@ -3,9 +3,20 @@
  * used both for long-lived-process heartbeat sampling (instance-registry
  * host + LSP children) and transient-spawn bracketing (safe-spawn.ts).
  *
- * `pidusage` is mocked throughout so these tests never touch real process
- * tables — mirrors clients/instance-reaper.ts's test style (pure decision
- * logic + injected fakes, no real spawns/kills).
+ * The sampler is platform-split: on Linux/macOS it uses `pidusage` (mocked
+ * here so tests never touch a real process table); on Windows it runs a fully
+ * guarded `Get-CimInstance Win32_Process` query (the `node:child_process`
+ * `spawn` is mocked so tests never spawn a real process, and each test drives
+ * the fake child's stdout / error / exit to exercise a specific path). Both
+ * branches are exercised by forcing `process.platform` per describe block, so
+ * coverage is identical regardless of the host OS this suite runs on.
+ *
+ * The whole point of the Windows path is #533/#620: pidusage's unguarded
+ * internal spawn could throw `spawn UNKNOWN` synchronously in a detached
+ * callback → uncaughtException → the pi host crashes. The regression tests
+ * below simulate that spawn failing every way (sync throw / error event /
+ * non-zero exit) and assert `sampleProcesses` still RESOLVES — a sampling
+ * failure can only ever lose a data point, never crash the caller.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -15,29 +26,74 @@ vi.mock("pidusage", () => ({
 	default: (...args: unknown[]) => pidusageMock(...args),
 }));
 
-// On Windows, startSpawnUsageSampler's poll tick resolves a live descendant
-// tree via a real `powershell.exe`/CIM query (findDescendantPidsWindows) —
-// mock `node:child_process` so these tests never spawn a real process for
-// that lookup; the fake child "closes" immediately with empty output, so the
-// descendant list is just `[]` and the sampler falls back to the bare pid.
+// Controllable fake `spawn`. Each test assigns `fakeSpawn` to shape the child's
+// behavior (emit stdout, emit an "error" event, close with a code, or throw
+// synchronously). Defaults to a child that closes immediately with empty
+// output — the neutral "no data this tick" shape.
+type SpawnFn = (...args: unknown[]) => unknown;
+let fakeSpawn: SpawnFn = () => makeFakeChild({ stdout: "" });
 vi.mock("node:child_process", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:child_process")>();
 	return {
 		...actual,
-		spawn: vi.fn(() => {
-			const child = {
-				stdout: { on: vi.fn() },
-				once: (event: string, cb: (...args: unknown[]) => void) => {
-					if (event === "close") queueMicrotask(() => cb(0));
-				},
-			};
-			return child;
-		}),
+		spawn: (...args: unknown[]) => fakeSpawn(...args),
 	};
 });
 
-const { sampleProcesses, UsageAccumulator, walkDescendantPids, startSpawnUsageSampler } =
-	await import("../../clients/resource-sampler.js");
+const {
+	sampleProcesses,
+	UsageAccumulator,
+	walkDescendantPids,
+	startSpawnUsageSampler,
+	__resetWindowsCpuHistoryForTests,
+} = await import("../../clients/resource-sampler.js");
+
+/**
+ * Build a fake ChildProcess that emits `stdout` (if any) then fires `close`
+ * with `code`, all on the microtask queue so `await`-ing the sampler flushes
+ * them. `emitError: true` fires an "error" event instead of closing normally.
+ */
+function makeFakeChild(opts: {
+	stdout?: string;
+	code?: number;
+	emitError?: boolean;
+}): unknown {
+	const handlers = new Map<string, (...a: unknown[]) => void>();
+	const dataCbs: Array<(chunk: Buffer) => void> = [];
+	const child = {
+		stdout: {
+			on: (event: string, cb: (chunk: Buffer) => void) => {
+				if (event === "data") dataCbs.push(cb);
+			},
+		},
+		once: (event: string, cb: (...a: unknown[]) => void) => {
+			handlers.set(event, cb);
+		},
+	};
+	queueMicrotask(() => {
+		if (opts.emitError) {
+			handlers.get("error")?.(new Error("spawn failed (async)"));
+			return;
+		}
+		if (opts.stdout) {
+			for (const cb of dataCbs) cb(Buffer.from(opts.stdout));
+		}
+		handlers.get("close")?.(opts.code ?? 0);
+	});
+	return child;
+}
+
+const realPlatform = process.platform;
+function setPlatform(platform: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", {
+		value: platform,
+		configurable: true,
+	});
+}
+afterEach(() => {
+	setPlatform(realPlatform);
+	fakeSpawn = () => makeFakeChild({ stdout: "" });
+});
 
 describe("UsageAccumulator (pure)", () => {
 	it("returns null when no sample was ever added", () => {
@@ -116,9 +172,10 @@ describe("walkDescendantPids (pure BFS)", () => {
 	});
 });
 
-describe("sampleProcesses", () => {
+describe("sampleProcesses (POSIX / pidusage path)", () => {
 	beforeEach(() => {
 		pidusageMock.mockReset();
+		setPlatform("linux");
 	});
 
 	it("returns an empty map and never calls pidusage for an empty pid list", async () => {
@@ -160,9 +217,102 @@ describe("sampleProcesses", () => {
 	});
 });
 
+describe("sampleProcesses (Windows / guarded CIM path)", () => {
+	beforeEach(() => {
+		pidusageMock.mockReset();
+		__resetWindowsCpuHistoryForTests();
+		setPlatform("win32");
+	});
+
+	it("never calls pidusage on Windows — the whole point of the fix", async () => {
+		fakeSpawn = () =>
+			makeFakeChild({ stdout: "111,1024,0,0\r\n", code: 0 });
+		await sampleProcesses([111]);
+		expect(pidusageMock).not.toHaveBeenCalled();
+	});
+
+	it("parses RSS (WorkingSetSize) from the CIM output; first tick reports cpu 0", async () => {
+		// One line: pid,workingSet,kernel100ns,user100ns
+		fakeSpawn = () =>
+			makeFakeChild({ stdout: "111,4096,0,0\r\n222,8192,0,0\r\n", code: 0 });
+
+		const result = await sampleProcesses([111, 222]);
+		expect(result.get(111)).toEqual({ rssBytes: 4096, cpuPercent: 0 });
+		expect(result.get(222)).toEqual({ rssBytes: 8192, cpuPercent: 0 });
+	});
+
+	it("computes CPU% from the kernel+user delta over elapsed wall time on the second tick", async () => {
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(0);
+			// Tick 1: cumulative CPU time = 0 (kernel=0,user=0). Seeds history.
+			fakeSpawn = () => makeFakeChild({ stdout: "111,4096,0,0\r\n", code: 0 });
+			const first = await sampleProcesses([111]);
+			expect(first.get(111)).toEqual({ rssBytes: 4096, cpuPercent: 0 });
+
+			// 10s of wall time elapses; the process burned 5s of CPU.
+			// UserModeTime is in 100 ns units → 5000 ms = 5000 * 1e4 = 5e7 units.
+			vi.setSystemTime(10_000);
+			fakeSpawn = () =>
+				makeFakeChild({ stdout: "111,4096,0,50000000\r\n", code: 0 });
+			const second = await sampleProcesses([111]);
+			// 5000 ms CPU / 10000 ms wall * 100 = 50%.
+			expect(second.get(111)?.cpuPercent).toBeCloseTo(50);
+			expect(second.get(111)?.rssBytes).toBe(4096);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	// --- Crash regression: the sampler must NEVER throw/reject (#533, #620) ---
+
+	it("RESOLVES (never rejects) when spawn throws SYNCHRONOUSLY — the spawn UNKNOWN crash vector", async () => {
+		fakeSpawn = () => {
+			// This is exactly what pidusage's unguarded internal spawn does under
+			// Windows handle/commit pressure: throw `spawn UNKNOWN` synchronously.
+			const err = new Error("spawn UNKNOWN") as Error & {
+				errno: number;
+				code: string;
+				syscall: string;
+			};
+			err.errno = -4094;
+			err.code = "UNKNOWN";
+			err.syscall = "spawn";
+			throw err;
+		};
+
+		await expect(sampleProcesses([111])).resolves.toBeInstanceOf(Map);
+		const result = await sampleProcesses([111]);
+		expect(result.size).toBe(0);
+	});
+
+	it("RESOLVES when the child emits an async 'error' event (e.g. ENOENT)", async () => {
+		fakeSpawn = () => makeFakeChild({ emitError: true });
+		await expect(sampleProcesses([111])).resolves.toEqual(new Map());
+	});
+
+	it("RESOLVES when the child exits non-zero with garbage stdout", async () => {
+		fakeSpawn = () =>
+			makeFakeChild({ stdout: "not-a-csv-line\r\n<<broken>>\r\n", code: 1 });
+		await expect(sampleProcesses([111])).resolves.toEqual(new Map());
+	});
+
+	it("returns an empty map and never spawns for an empty pid list", async () => {
+		const spy = vi.fn(() => makeFakeChild({ stdout: "" }));
+		fakeSpawn = spy;
+		const result = await sampleProcesses([]);
+		expect(result.size).toBe(0);
+		expect(spy).not.toHaveBeenCalled();
+	});
+});
+
 describe("startSpawnUsageSampler", () => {
 	beforeEach(() => {
 		pidusageMock.mockReset();
+		// Force POSIX so the tick samples the bare pid via pidusage (no CIM
+		// descendant lookup) — keeps these focused on the accumulate/bracket
+		// logic; the Windows sampling path is covered above.
+		setPlatform("linux");
 		vi.useFakeTimers();
 	});
 


### PR DESCRIPTION
**Fixes a live pi-host crash observed in dogfooding.** `resource-sampler.ts` sampled CPU%/RSS via `pidusage`, whose Windows path shells out to `gwmi` through an internal `spawn(..., {shell:"powershell.exe"})` with **no try/catch**, run from inside a ChildProcess `close` callback. Under real Windows handle/commit pressure that spawn throws `spawn UNKNOWN` (errno -4094) **synchronously in that detached callback** — which the call site's `try { await pidusage() } catch {}` cannot catch → `uncaughtException` → the whole host dies. pidusage 4.0.1 has no option to avoid the gwmi path. A best-effort telemetry sampler must never crash the host (#533; the file's own docstring says so).

## Fix
On **Windows**, `sampleProcesses` no longer calls `pidusage` — it runs its OWN fully guarded `Get-CimInstance Win32_Process` query (`sampleProcessesWindows`), mirroring the existing `findDescendantPidsWindows` guard: `try { nodeSpawn(...) } catch { resolve }` (catches the synchronous `spawn UNKNOWN`), `child.once("error", () => resolve)` (async spawn errors), and the entire close-handler parse body wrapped in try/catch → resolve. Every path resolves to a Map (partial/empty); the function has **no reachable throw/reject**. A pid absent from the map = "unsampled this tick", never zero. No global `uncaughtException` handler. **Linux/macOS keep `pidusage`** (procfs/ps — not the crash vector).

CPU%/RSS **preserved, not degraded**: RSS ← `WorkingSetSize`; CPU% ← `Δ(KernelModeTime+UserModeTime ms)/Δ(wall ms)*100` with a pruned per-pid history map — the same formula pidusage's gwmi uses (first tick 0, real rate next tick).

## Verification
- `npm run build` clean; `npx tsc --project tsconfig.json --noEmit` clean.
- `resource-sampler.test.ts` rewritten platform-aware + regression tests: sync-throw (`spawn UNKNOWN`, errno -4094), async `error` event, non-zero/garbage exit — each asserts `sampleProcesses` **resolves** (never rejects); RSS-parse correctness; two-tick CPU%=50% (fake timers); "never calls pidusage on Windows". Proven load-bearing: replacing the outer `try` with `if(true)` makes the sync-throw test fail with the exact host-crash reproduction. `resource-sampler` + `quiet-window` suites: 34 passed.

Refs #620, #533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)