### PR TITLE
fix(diagnostics): surface test-runner findings in lens_diagnostics project-wide path (closes #1004, refs #585, #533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,27 @@ All notable changes to pi-lens will be documented in this file.
 	writing back) and adapts it via the existing
 	`testRunnerFindingsToProjectDiagnostics`. Added a coverage guardrail
 	(`tests/clients/project-diagnostics/analyzer-coverage.test.ts`) that greps
-	the real session-start (`runHeavyweightTask`) and turn_end cache-writer
-	call sites and asserts every id is a member of `ANALYZER_IDS`, so this
-	whole #585 bug class can't silently regress again for a future analyzer.
+	the real session-start (`runHeavyweightTask`) and EVERY turn_end
+	`cacheManager.writeCache` call site in `runtime-turn.ts` (excluding a
+	short, explicit bookkeeping exclude-list — `errorDebt`/`turn-end-findings`/
+	`turn-end-findings-last` — that isn't analyzer-shaped) and asserts every
+	remaining id is a member of `ANALYZER_IDS`, so this whole #585 bug class
+	can't silently regress again for a future analyzer added to EITHER writer.
+	Adversarial review also caught two honesty/fidelity gaps in the initial
+	fix: (1) test-runner is cache-read, edit-scoped (the targeted test files
+	touched by the most recent turn's edits), unlike every other analyzer's
+	fresh whole-project scan — `mode=full` now emits an explicit "coverage is
+	edit-scoped, NOT a full-project run" caveat whenever test-runner
+	contributed findings (not only when cold), and a `stale` cached result
+	(the turn advanced before the test run finished) is prefixed
+	`[stale — from a prior turn]` in its diagnostic message, matching the
+	one-shot turn-context message's own stale wording; (2) `TestFailure.location`
+	(`"file.ts:42"`, set by the vitest/jest JSON parser in
+	`test-runner-client.ts`) never reached `ProjectDiagnostic.line`, so every
+	test-runner finding rendered as `L?:` — `runner-adapters/runner-findings.ts`
+	now parses a numeric trailing `:line[:col]` out of `location` (left alone
+	for pytest/mix's non-numeric `location` strings, which carry a test name or
+	module, not a line).
 
 - **Guarded Windows CPU/RSS resource sampling so a best-effort sampler can no
 	longer crash the pi host** (refs #620, #533) — `clients/resource-sampler.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ All notable changes to pi-lens will be documented in this file.
 	registry that shadowed `ANALYZER_IDS` and let opengrep silently diverge — was
 	removed so a single source of truth (#883) remains.
 
+- **Fixed: test-runner findings now surface project-wide in `lens_diagnostics
+	mode=full`** (closes #1004, refs #585, #533) — the same `ANALYZER_IDS`
+	omission #585/#1003 fixed for opengrep also orphaned test-runner: the
+	per-edit turn_end test fire (`runtime-turn.ts`) caches failures under
+	`"test-runner-findings"`, but `fetchFreshProjectDiagnostics`
+	(`project-diagnostics/fresh-fetch.ts`) never read that cache back, so test
+	failures never reached the agent for unedited/project-wide `mode=full`
+	calls. Unlike opengrep/gitleaks/trivy, this is wired as a CACHE-READ (not a
+	fresh scan): test-runner has no "whole project" run to trigger — turn_end
+	only ever runs the targeted, cascade-aware test files touched by that
+	turn's edits — so `fetchFreshProjectDiagnostics` now peeks at the same
+	`"test-runner-findings"` cache key (never re-running the suite, never
+	writing back) and adapts it via the existing
+	`testRunnerFindingsToProjectDiagnostics`. Added a coverage guardrail
+	(`tests/clients/project-diagnostics/analyzer-coverage.test.ts`) that greps
+	the real session-start (`runHeavyweightTask`) and turn_end cache-writer
+	call sites and asserts every id is a member of `ANALYZER_IDS`, so this
+	whole #585 bug class can't silently regress again for a future analyzer.
+
 - **Guarded Windows CPU/RSS resource sampling so a best-effort sampler can no
 	longer crash the pi host** (refs #620, #533) — `clients/resource-sampler.ts`
 	sampled CPU%/RSS via `pidusage`, whose Windows path shells out to `gwmi`

--- a/clients/project-diagnostics/extractors.ts
+++ b/clients/project-diagnostics/extractors.ts
@@ -42,6 +42,8 @@ const WARM_TRIGGER: Record<string, string> = {
 	opengrep: "runs at session-start",
 	trivy: "runs at session-start",
 	"dead-code": "runs at session-start (Python projects only)",
+	"test-runner":
+		"fires per-edit at turn_end (only after a source file with a discoverable test companion is edited)",
 };
 
 export function warmTriggerFor(analyzerId: string): string {

--- a/clients/project-diagnostics/fresh-fetch.ts
+++ b/clients/project-diagnostics/fresh-fetch.ts
@@ -67,7 +67,18 @@
  * "ran clean") and `abortedIds` (so a caller can render a more honest reason
  * than "not applicable").
  *
- * Refs: #585, #313 (the SecurityScanClient de-dupe prerequisite)
+ * One analyzer does NOT follow the trigger-or-join shape above: `test-runner`
+ * (#1004). Its "scan" is the per-edit turn_end test fire (`runtime-turn.ts`),
+ * which only ever runs the targeted/cascade-aware test files touched by a
+ * turn's edits — there is no whole-project run to trigger here, and forcing
+ * one on every mode=full call would be exactly the double-spawn-a-heavy-
+ * analyzer cost the de-dupe guards above exist to avoid. Its task is a plain
+ * cache-read of the `"test-runner-findings"` key turn_end already wrote,
+ * mirroring the pre-#585 `extractCachedProjectDiagnostics` registry's
+ * "test-runner" row (cache-only, never triggers a run) rather than the
+ * fresh-run pattern every other task here uses — see that task's own comment.
+ *
+ * Refs: #585, #313 (the SecurityScanClient de-dupe prerequisite), #1004
  */
 
 import * as fs from "node:fs";
@@ -86,6 +97,8 @@ import { jscpdResultToProjectDiagnostics } from "./runner-adapters/jscpd.js";
 import { knipIssuesToProjectDiagnostics } from "./runner-adapters/knip.js";
 import { circularDepsToProjectDiagnostics } from "./runner-adapters/madge.js";
 import { opengrepResultToProjectDiagnostics } from "./runner-adapters/opengrep.js";
+import type { TestRunnerFindingsCache } from "./runner-adapters/runner-findings.js";
+import { testRunnerFindingsToProjectDiagnostics } from "./runner-adapters/runner-findings.js";
 import { trivyResultToProjectDiagnostics } from "./runner-adapters/trivy.js";
 import type { ProjectDiagnostic } from "./types.js";
 import type { FailedProjectAnalyzer } from "./extractors.js";
@@ -119,8 +132,12 @@ export interface FreshProjectDiagnosticsResult {
 /** The heavyweight analyzers surfaced in `lens_diagnostics mode=full` — this is
  *  now the single source of truth for that list (#585 removed the parallel
  *  cache-only `EXTRACTORS` registry that used to shadow it). `warmTriggerFor`
- *  (extractors.ts) is keyed by these same ids for the "cold" honesty note. */
-const ANALYZER_IDS = [
+ *  (extractors.ts) is keyed by these same ids for the "cold" honesty note.
+ *  Exported so `tests/clients/project-diagnostics/analyzer-coverage.test.ts`
+ *  (#1004's guardrail) can assert every session-start/turn-end analyzer cache
+ *  writer id is a member — the exact #585-class check that would have caught
+ *  opengrep's (and then test-runner's, #1004) omission before it shipped. */
+export const ANALYZER_IDS = [
 	"knip",
 	"jscpd",
 	"madge",
@@ -129,6 +146,7 @@ const ANALYZER_IDS = [
 	"opengrep",
 	"trivy",
 	"dead-code",
+	"test-runner",
 ] as const;
 
 function pushUnique(list: string[], id: string): void {
@@ -430,6 +448,50 @@ export async function fetchFreshProjectDiagnostics(
 						Date.now() - startMs,
 					);
 				}),
+			);
+		}),
+
+		// test-runner — CACHE-READ only, unlike every task above (#1004). Its
+		// session cadence doesn't fit the "trigger-or-join a fresh run" shape the
+		// rest of this module uses: the actual scan is the per-edit turn_end fire
+		// in `runtime-turn.ts`, which only ever runs the (targeted, cascade-aware)
+		// test files touched by THIS turn's edits — there is no "whole project"
+		// test run to (re-)trigger here, and unconditionally spawning a full suite
+		// on every mode=full call would be the exact "heavy re-run on every call"
+		// cost this module's other tasks avoid via de-dupe/gating. So this task
+		// instead peeks at the `"test-runner-findings"` cache turn_end already
+		// wrote — the same cache key, the same adapter
+		// (`testRunnerFindingsToProjectDiagnostics`), and the same cache-only
+		// contract the pre-#585 `extractCachedProjectDiagnostics` registry's
+		// "test-runner" row used (see extractors.ts's removal note) — before #585
+		// dropped that reader without replacing this one row's semantics here.
+		// Deliberately never calls `writeCache`: there is nothing fresher to write
+		// back, only what turn_end already produced.
+		//
+		// No double-count / honesty gap (#533): `consumeTestFindings`
+		// (`runtime-context.ts`) reads-and-clears this SAME cache key once, to
+		// inject a one-shot "fix before continuing" message into the NEXT turn.
+		// This task only ever reads (never clears) it, so it can't race that
+		// consumption into re-delivering a message twice — at most it surfaces
+		// the same underlying failures a second time, through a different
+		// surface (the mode=full project snapshot) that was previously silently
+		// empty for this analyzer. If `consumeTestFindings` already cleared the
+		// cache before this runs, this task correctly sees nothing and reports
+		// `cold` rather than inventing stale data.
+		task("test-runner", async () => {
+			const startMs = Date.now();
+			const cached = cacheManager.readCache<TestRunnerFindingsCache>(
+				"test-runner-findings",
+				analysisRoot,
+			);
+			if (!cached?.data) {
+				cold.push("test-runner");
+				return;
+			}
+			record(
+				"test-runner",
+				testRunnerFindingsToProjectDiagnostics(cached.data),
+				Date.now() - startMs,
 			);
 		}),
 	];

--- a/clients/project-diagnostics/runner-adapters/runner-findings.ts
+++ b/clients/project-diagnostics/runner-adapters/runner-findings.ts
@@ -30,26 +30,61 @@ function failureMessage(failure: TestFailure): string {
 }
 
 /**
+ * `TestFailure.location` (`test-runner-client.ts`) is a free-form string that
+ * varies by parser: the vitest/jest JSON parser emits a real `"relPath:line"`
+ * (line only — its own `test.location.column` is dropped before it reaches
+ * this string, so column is never available from that source either), while
+ * the pytest text parser abuses the same field for `"file:testName"` (no
+ * digits) and the mix/ExUnit parser puts a bare module name in it (no colon
+ * at all). Only pull a `line`/`column` out when the trailing segment(s) are
+ * actually numeric, so pytest/mix locations are left alone (no line, same as
+ * before this change) instead of misparsing part of a name as a line number.
+ */
+const LOCATION_LINE_COL_RE = /:(\d+)(?::(\d+))?$/;
+
+function parseLocation(
+	location: string | undefined,
+): { line?: number; column?: number } {
+	if (!location) return {};
+	const match = LOCATION_LINE_COL_RE.exec(location);
+	if (!match) return {};
+	return {
+		line: Number.parseInt(match[1], 10),
+		...(match[2] ? { column: Number.parseInt(match[2], 10) } : {}),
+	};
+}
+
+/**
  * One diagnostic per test failure, attributed to the test file that reported
  * it (not the source file the agent edited — that's `sourceFile` on
  * `TestResult`, but the failure itself lives in the test file). A result with
  * no individual failures listed (a parser that couldn't extract them, or a
  * runner error) still gets one diagnostic so the file isn't silently blank.
+ *
+ * `stale` (from the cache's own `stale` flag, set at turn_end when the turn
+ * advanced before the test run finished — `runtime-turn.ts`) is surfaced as a
+ * message prefix, mirroring the one-shot turn-context-injection message's own
+ * stale wording (`consumeTestFindings`'s cached `content`) — a mode=full
+ * caller deserves the same "this may already be superseded" honesty the
+ * per-edit path already gives.
  */
 export function testResultToProjectDiagnostics(
 	result: TestResult,
+	stale = false,
 ): ProjectDiagnostic[] {
 	if (result.failed === 0 && !result.error) return [];
+	const stalePrefix = stale ? "[stale — from a prior turn] " : "";
 
 	if (result.failures.length > 0) {
 		return result.failures.map((failure) => ({
 			filePath: result.file,
+			...parseLocation(failure.location),
 			severity: "error",
 			semantic: "blocking",
 			tool: "test-runner",
 			runner: result.runner,
 			rule: `test:${result.runner}`,
-			message: failureMessage(failure),
+			message: `${stalePrefix}${failureMessage(failure)}`,
 			source: "project-scan",
 		}));
 	}
@@ -62,9 +97,11 @@ export function testResultToProjectDiagnostics(
 			tool: "test-runner",
 			runner: result.runner,
 			rule: `test:${result.runner}`,
-			message: result.error
-				? `Test run error: ${result.error}`
-				: `${result.failed} test(s) failed`,
+			message: `${stalePrefix}${
+				result.error
+					? `Test run error: ${result.error}`
+					: `${result.failed} test(s) failed`
+			}`,
 			source: "project-scan",
 		},
 	];
@@ -74,5 +111,7 @@ export function testRunnerFindingsToProjectDiagnostics(
 	cache: TestRunnerFindingsCache,
 ): ProjectDiagnostic[] {
 	if (!cache.results || cache.results.length === 0) return [];
-	return cache.results.flatMap((r) => testResultToProjectDiagnostics(r));
+	return cache.results.flatMap((r) =>
+		testResultToProjectDiagnostics(r, cache.stale),
+	);
 }

--- a/tests/clients/project-diagnostics/analyzer-coverage.test.ts
+++ b/tests/clients/project-diagnostics/analyzer-coverage.test.ts
@@ -1,0 +1,58 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { ANALYZER_IDS } from "../../../clients/project-diagnostics/fresh-fetch.js";
+
+/**
+ * #585 / #1004-class guardrail.
+ *
+ * Both #585 (opengrep) and #1004 (test-runner) were the SAME bug shape: an
+ * analyzer had a real cache writer (session-start's `runHeavyweightTask`
+ * wrapper in `runtime-session.ts`, or turn_end's dedicated test-fire in
+ * `runtime-turn.ts`) that scanned and cached findings, while
+ * `fetchFreshProjectDiagnostics`'s `ANALYZER_IDS` (the single source of truth
+ * for `lens_diagnostics mode=full`, #883) silently omitted the id — so the
+ * findings were real, cached, and never read back.
+ *
+ * Rather than hand-maintain a second list of "ids that should be in
+ * ANALYZER_IDS" (the exact parallel-list anti-pattern that caused #585 in the
+ * first place), this test greps the actual writer call sites in production
+ * source and asserts every id found there is a member of `ANALYZER_IDS`. A
+ * future analyzer wired into either writer without an `ANALYZER_IDS` entry
+ * fails this test instead of silently shipping an orphaned scan-and-cache
+ * path.
+ */
+
+const repoRoot = path.resolve(__dirname, "../../..");
+
+function readSource(relPath: string): string {
+	return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+}
+
+describe("mode=full analyzer coverage guardrail (#585, #1004)", () => {
+	it("every session-start runHeavyweightTask id is a member of ANALYZER_IDS", () => {
+		const source = readSource("clients/runtime-session.ts");
+		const ids = [...source.matchAll(/runHeavyweightTask\(\s*"([^"]+)"/g)].map(
+			(m) => m[1],
+		);
+
+		// Sanity check the regex itself still finds something — an empty match
+		// list would make the assertion below vacuously true if `runtime-session.ts`
+		// ever gets refactored to call the wrapper differently.
+		expect(ids.length).toBeGreaterThan(0);
+
+		for (const id of ids) {
+			expect(ANALYZER_IDS as readonly string[]).toContain(id);
+		}
+	});
+
+	it("the turn_end test-runner-findings cache writer is covered by ANALYZER_IDS's test-runner entry (#1004)", () => {
+		const source = readSource("clients/runtime-turn.ts");
+
+		// Sanity check the writer this guardrail is protecting still exists under
+		// the expected cache key — if it's ever renamed, this test should be
+		// updated deliberately rather than silently pass.
+		expect(source).toContain('"test-runner-findings"');
+		expect(ANALYZER_IDS as readonly string[]).toContain("test-runner");
+	});
+});

--- a/tests/clients/project-diagnostics/analyzer-coverage.test.ts
+++ b/tests/clients/project-diagnostics/analyzer-coverage.test.ts
@@ -46,13 +46,60 @@ describe("mode=full analyzer coverage guardrail (#585, #1004)", () => {
 		}
 	});
 
-	it("the turn_end test-runner-findings cache writer is covered by ANALYZER_IDS's test-runner entry (#1004)", () => {
-		const source = readSource("clients/runtime-turn.ts");
+	// #1004 review follow-up: the original version of this test hardcoded
+	// "test-runner-findings" + a single containment check side-by-side — that
+	// only catches a REGRESSION of that one id, not a future turn_end writer
+	// added without updating this test (the exact generalize-vs-narrow gap
+	// flagged in review). Generalized to grep EVERY `cacheManager.writeCache`
+	// call in `runtime-turn.ts`, the same way the session-start check above
+	// greps `runHeavyweightTask(`, so a new analyzer wired into turn_end is
+	// caught structurally instead of depending on someone remembering to touch
+	// this file too.
+	//
+	// Not every turn_end cache write is an analyzer-shaped, mode=full-relevant
+	// result, though: `errorDebt`/`turn-end-findings`/`turn-end-findings-last`
+	// are turn-end BOOKKEEPING (a one-shot aggregated context-injection message
+	// and its dedupe signature, not a distinct analyzer's findings) — there is
+	// no runner-adapter for them and there never should be, so they're
+	// explicitly excluded rather than silently ignored. Adding a NEW
+	// bookkeeping-only cache key means adding it here deliberately; anything
+	// else found by the grep must resolve to an `ANALYZER_IDS` member or this
+	// test fails — fail-closed, not fail-silent.
+	const TURN_END_BOOKKEEPING_KEYS = new Set([
+		"errorDebt",
+		"turn-end-findings",
+		"turn-end-findings-last",
+	]);
 
-		// Sanity check the writer this guardrail is protecting still exists under
-		// the expected cache key — if it's ever renamed, this test should be
-		// updated deliberately rather than silently pass.
-		expect(source).toContain('"test-runner-findings"');
-		expect(ANALYZER_IDS as readonly string[]).toContain("test-runner");
+	// The one place a turn_end cache KEY differs from the `ANALYZER_IDS` id
+	// that reads it back (`test-runner-findings` cache key → `test-runner`
+	// analyzer id, `runner-adapters/runner-findings.ts`). Every other turn_end
+	// analyzer writer (e.g. "knip") already writes under its own ANALYZER_IDS
+	// id directly.
+	const CACHE_KEY_TO_ANALYZER_ID: Record<string, string> = {
+		"test-runner-findings": "test-runner",
+	};
+
+	it("every turn_end analyzer-shaped cache writer id is a member of ANALYZER_IDS", () => {
+		const source = readSource("clients/runtime-turn.ts");
+		const keys = [
+			...source.matchAll(/cacheManager\.writeCache\(\s*"([^"]+)"/g),
+		].map((m) => m[1]);
+
+		// Sanity check the regex itself still finds something.
+		expect(keys.length).toBeGreaterThan(0);
+
+		const analyzerKeys = keys.filter(
+			(key) => !TURN_END_BOOKKEEPING_KEYS.has(key),
+		);
+		// And that at least one non-bookkeeping (analyzer-shaped) key exists —
+		// otherwise the exclusion list above could silently swallow everything
+		// and this test would pass vacuously.
+		expect(analyzerKeys.length).toBeGreaterThan(0);
+
+		for (const key of analyzerKeys) {
+			const id = CACHE_KEY_TO_ANALYZER_ID[key] ?? key;
+			expect(ANALYZER_IDS as readonly string[]).toContain(id);
+		}
 	});
 });

--- a/tests/clients/project-diagnostics/fresh-fetch.test.ts
+++ b/tests/clients/project-diagnostics/fresh-fetch.test.ts
@@ -486,7 +486,11 @@ describe("fetchFreshProjectDiagnostics (#585)", () => {
 			failed: 1,
 			duration: 42,
 			failures: [
-				{ name: "foo works", message: "expected true to be false" },
+				{
+					name: "foo works",
+					message: "expected true to be false",
+					location: "src/foo.test.ts:17",
+				},
 			],
 		};
 		(cacheManager.readCache as ReturnType<typeof vi.fn>).mockImplementation(
@@ -514,8 +518,13 @@ describe("fetchFreshProjectDiagnostics (#585)", () => {
 		);
 		expect(result.runners).toContain("test-runner");
 		const diag = result.diagnostics.find((d) => d.tool === "test-runner");
+		// #1004 review follow-up: `TestFailure.location` ("relPath:line") must
+		// reach `ProjectDiagnostic.line` — before the fix every test-runner
+		// finding rendered as `L?:` in lens-diagnostics, unlike jscpd/knip/madge
+		// which all carry real line numbers.
 		expect(diag).toMatchObject({
 			filePath: testResult.file,
+			line: 17,
 			severity: "error",
 			semantic: "blocking",
 			tool: "test-runner",
@@ -523,6 +532,40 @@ describe("fetchFreshProjectDiagnostics (#585)", () => {
 			rule: "test:vitest",
 			message: "foo works: expected true to be false",
 		});
+	});
+
+	// #1004 review follow-up (honesty gap, #533): test-runner's cache can be
+	// STALE (the turn advanced before the test run finished —
+	// `runtime-turn.ts`'s `stale` flag) — mode=full must not present a stale
+	// result as if it were fresh, the same way the one-shot turn-context
+	// message already prefixes stale failures.
+	it("prefixes test-runner findings with a stale marker when the cache says stale (#1004)", async () => {
+		const cacheManager = makeCacheManager();
+		const testResult = {
+			file: path.join(path.resolve(tmp), "src/bar.test.ts"),
+			runner: "vitest",
+			passed: 0,
+			failed: 1,
+			duration: 10,
+			failures: [{ name: "bar works", message: "boom" }],
+		};
+		(cacheManager.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+			(scanner: string) => {
+				if (scanner === "test-runner-findings") {
+					return {
+						data: { content: "FAIL", stale: true, results: [testResult] },
+						meta: { timestamp: new Date().toISOString() },
+					};
+				}
+				return null;
+			},
+		);
+		const clients = makeClients();
+
+		const result = await fetchFreshProjectDiagnostics(cacheManager, tmp, clients);
+
+		const diag = result.diagnostics.find((d) => d.tool === "test-runner");
+		expect(diag?.message).toMatch(/^\[stale/);
 	});
 
 	it("reports test-runner cold (not clean) when no turn_end cache exists yet (#1004)", async () => {

--- a/tests/clients/project-diagnostics/fresh-fetch.test.ts
+++ b/tests/clients/project-diagnostics/fresh-fetch.test.ts
@@ -191,6 +191,7 @@ describe("fetchFreshProjectDiagnostics (#585)", () => {
 			"opengrep",
 			"trivy",
 			"dead-code",
+			"test-runner",
 		]);
 		expect(clients.knipClient.analyze).not.toHaveBeenCalled();
 		expect(clients.jscpdClient.ensureAvailable).not.toHaveBeenCalled();
@@ -468,6 +469,70 @@ describe("fetchFreshProjectDiagnostics (#585)", () => {
 		expect(clients.opengrepClient.scan).not.toHaveBeenCalled();
 		expect(result.cold).toContain("opengrep");
 		expect(result.runners).not.toContain("opengrep");
+	});
+
+	// #1004 regression: test-runner was omitted from ANALYZER_IDS (the same
+	// #585-class gap opengrep had) — the turn_end test fire cached findings
+	// under "test-runner-findings" but nothing in fetchFreshProjectDiagnostics
+	// read them back, so mode=full silently dropped test failures for
+	// unedited/project-wide calls. This must FAIL on pre-fix code (ANALYZER_IDS
+	// missing "test-runner") and pass once the cache-read task is wired.
+	it("surfaces cached test-runner findings via mode=full without re-running the suite (#1004)", async () => {
+		const cacheManager = makeCacheManager();
+		const testResult = {
+			file: path.join(path.resolve(tmp), "src/foo.test.ts"),
+			runner: "vitest",
+			passed: 1,
+			failed: 1,
+			duration: 42,
+			failures: [
+				{ name: "foo works", message: "expected true to be false" },
+			],
+		};
+		(cacheManager.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+			(scanner: string) => {
+				if (scanner === "test-runner-findings") {
+					return {
+						data: { content: "FAIL", stale: false, results: [testResult] },
+						meta: { timestamp: new Date().toISOString() },
+					};
+				}
+				return null;
+			},
+		);
+		const clients = makeClients();
+
+		const result = await fetchFreshProjectDiagnostics(cacheManager, tmp, clients);
+
+		// Cache-read only — no client method exists to "run" test-runner here,
+		// and this must NOT write back to the cache (nothing fresher to write).
+		expect(cacheManager.writeCache).not.toHaveBeenCalledWith(
+			"test-runner-findings",
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+		);
+		expect(result.runners).toContain("test-runner");
+		const diag = result.diagnostics.find((d) => d.tool === "test-runner");
+		expect(diag).toMatchObject({
+			filePath: testResult.file,
+			severity: "error",
+			semantic: "blocking",
+			tool: "test-runner",
+			runner: "vitest",
+			rule: "test:vitest",
+			message: "foo works: expected true to be false",
+		});
+	});
+
+	it("reports test-runner cold (not clean) when no turn_end cache exists yet (#1004)", async () => {
+		const cacheManager = makeCacheManager();
+		const clients = makeClients();
+
+		const result = await fetchFreshProjectDiagnostics(cacheManager, tmp, clients);
+
+		expect(result.cold).toContain("test-runner");
+		expect(result.runners).not.toContain("test-runner");
 	});
 
 	it("runs every applicable dead-code language client and reports 'dead-code' cold only when none apply", async () => {

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -1200,6 +1200,70 @@ describe("lens_diagnostics mode=full", () => {
 		).toEqual([{ id: "knip", summary: "knip timed out" }]);
 	});
 
+	// #1004 review follow-up (honesty gap, #533): unlike every other
+	// fresh-fetch analyzer (a FRESH whole-project scan each call), test-runner
+	// is cache-read only — its findings only ever reflect the (targeted,
+	// cascade-aware) test file(s) touched by the most recent edit's turn_end
+	// fire, never a whole-project run. When it's warm-with-findings this must
+	// be called out explicitly, not folded silently into `runners`/
+	// `diagnostics` alongside the genuinely-project-wide analyzers.
+	it("mode=full notes test-runner coverage is edit-scoped, not project-wide, whenever it contributed findings (#1004)", async () => {
+		mockSummaries.length = 0;
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]),
+		};
+		projectDiagnosticsMocks.loadProjectDiagnosticsSnapshot.mockReturnValue(
+			undefined,
+		);
+		freshFetchMocks.fetchFreshProjectDiagnostics.mockResolvedValue({
+			diagnostics: [
+				{
+					filePath: "/proj/src/a.test.ts",
+					line: 17,
+					severity: "error",
+					semantic: "blocking",
+					tool: "test-runner",
+					runner: "vitest",
+					rule: "test:vitest",
+					message: "foo works: expected true to be false",
+					source: "project-scan",
+				},
+			],
+			runners: ["test-runner"],
+			cold: [],
+			timings: {},
+		});
+
+		const result = await run(makeTool({}, lspService), {
+			mode: "full",
+			refreshRunners: "cached",
+		});
+
+		const text = String(result.content[0].text);
+		expect(text).toContain("edit-scoped");
+		expect(text).toContain("NOT a full-project run");
+	});
+
+	it("mode=full does NOT emit the test-runner edit-scoped caveat when test-runner didn't contribute", async () => {
+		mockSummaries.length = 0;
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]),
+		};
+		freshFetchMocks.fetchFreshProjectDiagnostics.mockResolvedValue({
+			diagnostics: [],
+			runners: ["jscpd"],
+			cold: ["test-runner"],
+			timings: { jscpd: 5 },
+		});
+
+		const result = await run(makeTool({}, lspService), {
+			mode: "full",
+			refreshRunners: "cached",
+		});
+
+		expect(String(result.content[0].text)).not.toContain("edit-scoped");
+	});
+
 	it("mode=full without refreshRunners never reports cold extractors (they weren't requested)", async () => {
 		mockSummaries.length = 0;
 		const lspService = {

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -1385,6 +1385,24 @@ async function formatFullMode(
 						", ",
 					)}. These analyzers have not contributed to this result — absence of their findings is NOT a clean verdict.`
 			: "";
+	// #1004: unlike every other analyzer above (knip/jscpd/madge/gitleaks/
+	// govulncheck/opengrep/trivy/dead-code all run a FRESH whole-project scan
+	// per the fresh-fetch.ts header, so "clean" there really does mean "the
+	// whole project was checked this call"), test-runner has no whole-project
+	// run to trigger: its cache only ever reflects the (targeted,
+	// cascade-aware) test file(s) touched by the MOST RECENT edit's turn_end
+	// fire (`runtime-turn.ts`). Folding it into `runners`/`diagnostics` with no
+	// distinguishing note — as opposed to when it's cold, which already gets
+	// `coldNote` above — would let a caller mistake "test-runner ran
+	// project-wide and is clean" for "it only ever saw the 2 files edited an
+	// hour ago", exactly the false-empty/false-confidence #533 this whole
+	// module exists to prevent. Fires whenever test-runner CONTRIBUTED
+	// (`runners`), independent of whether it also has cold/failed entries this
+	// call — a caller needs this caveat on every mode=full response where
+	// test-runner findings are present, not only some.
+	const testRunnerEditScopedNote = extracted.runners.includes("test-runner")
+		? `\n\ntest-runner coverage is edit-scoped, NOT a full-project run: its findings only reflect the test file(s) touched by the most recent edit's turn_end fire, not a fresh whole-project test suite run (mode=full never re-runs the suite — see fresh-fetch.ts). Absence of test-runner findings elsewhere in the project is NOT a clean verdict, and presence here does not mean "just checked" — it may be from several turns ago.`
+		: "";
 	const failedAnalyzers = extracted.failed ?? [];
 	const failedNote =
 		failedAnalyzers.length > 0
@@ -1498,6 +1516,7 @@ async function formatFullMode(
 						unconfirmedLspNote +
 						lspPrimaryVsAuxiliaryNote +
 						coldNote +
+						testRunnerEditScopedNote +
 						failedNote +
 						walkUnsafeRootNote +
 						scanTruncatedNote +
@@ -1512,6 +1531,7 @@ async function formatFullMode(
 	if (
 		missingNote ||
 		coldNote ||
+		testRunnerEditScopedNote ||
 		failedNote ||
 		walkUnsafeRootNote ||
 		scanTruncatedNote ||
@@ -1529,6 +1549,7 @@ async function formatFullMode(
 						unconfirmedLspNote +
 						lspPrimaryVsAuxiliaryNote +
 						coldNote +
+						testRunnerEditScopedNote +
 						failedNote +
 						walkUnsafeRootNote +
 						scanTruncatedNote +


### PR DESCRIPTION
Closes #1004 — the same #585 orphaning class fixed for opengrep in #1003. test-runner findings reached the per-edit `turn_end` path but were absent from `lens_diagnostics mode=full` (unedited/project-wide), because `fetchFreshProjectDiagnostics.ANALYZER_IDS` omitted `test-runner` (the old cache-only extractor row that read them was removed as dead code in #1003).

## Fix
- Added `"test-runner"` to `ANALYZER_IDS` + a `task("test-runner", …)` in `fetchFreshProjectDiagnostics`.
- **Deliberate cache-read-only** (not the opengrep "fresh scan" pattern): traced the writer — `runtime-turn.ts` only ever runs the *targeted, cascade-aware* test file(s) touched by an edit; there is **no whole-project test run** to trigger or dedupe-join. Forcing a full suite on every mode=full call would be exactly the heavy re-run the dedup guards exist to avoid, and test-runner has no `SecurityScanClient` dedup to lean on. So the task **reads** `cacheManager.readCache("test-runner-findings")` and adapts via the pre-existing `testRunnerFindingsToProjectDiagnostics` — restoring the pre-#585 extractor row's read semantics on the new single source of truth (no parallel path invented).
- **No double-count / honesty:** `consumeTestFindings` (`runtime-context.ts`) reads-and-clears the same key once for a one-shot next-turn message; the new task only ever **reads** (never clears), so it can't race that — worst case it surfaces the same real failure through a second (previously silent) surface, never a fabricated one.

## Guardrail — the durable #585-class fix
New `tests/clients/project-diagnostics/analyzer-coverage.test.ts` **greps the real production writer call sites** (`runHeavyweightTask("…")` in `runtime-session.ts` + the `"test-runner-findings"` literal in `runtime-turn.ts`) and asserts every id is in `ANALYZER_IDS`. Source-reading, not a hand-maintained parallel list (#883) — a future analyzer wired to a writer without an `ANALYZER_IDS` entry now fails CI automatically, so this class can't silently regress again.

## Verification
- `npm run build` clean; `npx tsc --project tsconfig.json --noEmit` clean.
- New regression tests (cached test-runner surfaces via mode=full without re-running the suite; test-runner reports cold when no cache yet) + guardrail test — **confirmed fail on pre-fix code** (stashed the 2 production files → 5 tests fail with "test-runner missing"). fresh-fetch + analyzer-coverage + lens-diagnostics suites: 99/99.
- Note: `tests/clients/project-diagnostics.test.ts` (sibling file) OOM-crashes the vitest worker in the sandbox on BOTH pre- and post-fix base — pre-existing env memory constraint, unrelated to this diff.

Closes #1004. Refs #585, #533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)