### PR TITLE
fix(ast-grep): stop no-javascript-url flagging defensive javascript:-URL filters (refs #533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Fixed: `no-javascript-url`/`no-javascript-url-js` no longer flag defensive
+	`javascript:`-URL filters** (refs #533) — a dogfood run flagged code that was
+	*rejecting* `javascript:` links (e.g. `url.startsWith("javascript:")` inside a
+	guard) as if it were introducing one. The rule matched the `javascript:`
+	string literal alone with no way to tell "used as a sink" from "used to
+	detect/block it". Narrowed both rules to also exclude the literal when it's
+	the needle in `.startsWith`/`.endsWith`/`.includes`/`.indexOf`/`.search`/
+	`.match`, or one side of an `===`/`!==`/`==`/`!=` comparison — deliberately
+	NOT `.replace`/`.replaceAll`, since the literal there could be the malicious
+	replacement argument rather than the defensive search argument, and
+	excluding the whole call would hide that true positive. Added valid
+	fixtures reproducing the filter FP and an invalid fixture
+	(`str.replace("http:", "javascript:alert(1)")`) confirming the
+	replace-based sink is still caught.
+
 - **Contained spawn/callback failures that could crash the host (pidusage bug
 	class)** (refs #533) — a best-effort telemetry sampler recently killed a live
 	pi host with `Error: spawn UNKNOWN` (uncaughtException) because a bundled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,16 @@ All notable changes to pi-lens will be documented in this file.
 	`.match`, or one side of an `===`/`!==`/`==`/`!=` comparison — deliberately
 	NOT `.replace`/`.replaceAll`, since the literal there could be the malicious
 	replacement argument rather than the defensive search argument, and
-	excluding the whole call would hide that true positive. Added valid
-	fixtures reproducing the filter FP and an invalid fixture
-	(`str.replace("http:", "javascript:alert(1)")`) confirming the
-	replace-based sink is still caught.
+	excluding the whole call would hide that true positive. Both new exclusions
+	deliberately avoid `stopBy: end` (unlike the pre-existing test-literal
+	exclusion, which needs it) so the literal must be a DIRECT argument/operand
+	of the defensive call/comparison, not merely somewhere in its subtree — an
+	adversarial review caught that `stopBy: end` let a real sink smuggled
+	inside the call/comparison (e.g. `candidates.includes(link.href =
+	"javascript:...")`, a comma-operator sink, or `(a.href = "javascript:...")
+	=== expected`) go unflagged. Added valid fixtures reproducing the filter FP
+	and invalid fixtures for the replace-based sink and all three smuggled-sink
+	bypasses, confirmed against the real ast-grep 0.45.0 binary.
 
 - **Contained spawn/callback failures that could crash the host (pidusage bug
 	class)** (refs #533) — a best-effort telemetry sampler recently killed a live

--- a/rules/ast-grep-rules/rule-tests/no-javascript-url-js-test.yml
+++ b/rules/ast-grep-rules/rule-tests/no-javascript-url-js-test.yml
@@ -8,7 +8,12 @@ valid:
     it("rejects javascript: urls", () => {
       expect(openBrowser("javascript:alert(1)")).toBe(false);
     });
+  - 'const links = arr.filter((l) => !l.startsWith("javascript:"))'
+  - 'if (url.includes("javascript:")) return null;'
+  - 'const isBlocked = url === "javascript:alert(1)"'
+  - 'const safe = url !== "javascript:alert(1)"'
 invalid:
   - 'a.href = "javascript:alert(1)"'
   - 'a.href = "javascript:void(0)"'
   - 'const u = "javascript:alert(1)"'
+  - 'a.href = str.replace("http:", "javascript:alert(1)")'

--- a/rules/ast-grep-rules/rule-tests/no-javascript-url-js-test.yml
+++ b/rules/ast-grep-rules/rule-tests/no-javascript-url-js-test.yml
@@ -12,8 +12,13 @@ valid:
   - 'if (url.includes("javascript:")) return null;'
   - 'const isBlocked = url === "javascript:alert(1)"'
   - 'const safe = url !== "javascript:alert(1)"'
+  - 'url?.startsWith("javascript:")'
 invalid:
   - 'a.href = "javascript:alert(1)"'
   - 'a.href = "javascript:void(0)"'
   - 'const u = "javascript:alert(1)"'
   - 'a.href = str.replace("http:", "javascript:alert(1)")'
+  - 'if (candidates.includes(link.href = "javascript:alert(1)")) { doThing(); }'
+  - 'someArray.includes((a.href = "javascript:alert(1)", true));'
+  - 'if ((a.href = "javascript:alert(1)") === expected) { doThing(); }'
+  - 'const ok = (typeof (a.href = "javascript:alert(1)")) === "string";'

--- a/rules/ast-grep-rules/rule-tests/no-javascript-url-test.yml
+++ b/rules/ast-grep-rules/rule-tests/no-javascript-url-test.yml
@@ -12,7 +12,12 @@ valid:
     test.each(["javascript:alert(1)"])("rejects %s", (url) => {
       expect(openBrowser(url)).toBe(false);
     });
+  - 'const links = arr.filter((l) => !l.startsWith("javascript:"))'
+  - 'if (url.includes("javascript:")) return null;'
+  - 'const isBlocked = url === "javascript:alert(1)"'
+  - 'const safe = url !== "javascript:alert(1)"'
 invalid:
   - 'a.href = "javascript:alert(1)"'
   - 'a.href = "javascript:void(0)"'
   - 'const u = "javascript:alert(1)"'
+  - 'a.href = str.replace("http:", "javascript:alert(1)")'

--- a/rules/ast-grep-rules/rule-tests/no-javascript-url-test.yml
+++ b/rules/ast-grep-rules/rule-tests/no-javascript-url-test.yml
@@ -16,8 +16,13 @@ valid:
   - 'if (url.includes("javascript:")) return null;'
   - 'const isBlocked = url === "javascript:alert(1)"'
   - 'const safe = url !== "javascript:alert(1)"'
+  - 'url?.startsWith("javascript:")'
 invalid:
   - 'a.href = "javascript:alert(1)"'
   - 'a.href = "javascript:void(0)"'
   - 'const u = "javascript:alert(1)"'
   - 'a.href = str.replace("http:", "javascript:alert(1)")'
+  - 'if (candidates.includes(link.href = "javascript:alert(1)")) { doThing(); }'
+  - 'someArray.includes((a.href = "javascript:alert(1)", true));'
+  - 'if ((a.href = "javascript:alert(1)") === expected) { doThing(); }'
+  - 'const ok = (typeof (a.href = "javascript:alert(1)")) === "string";'

--- a/rules/ast-grep-rules/rules/no-javascript-url-js.yml
+++ b/rules/ast-grep-rules/rules/no-javascript-url-js.yml
@@ -25,6 +25,20 @@ note: |
   since the literal there could be the replacement (second) argument —
   i.e. the malicious payload being substituted IN — and excluding the
   whole call would hide that true positive.
+
+  IMPORTANT: unlike the expect/it/test/describe exclusion above, these two
+  new exclusions deliberately do NOT use `stopBy: end`. `inside` without
+  `stopBy` only checks the immediate parent, so the literal must be a
+  DIRECT argument/operand of the defensive call/comparison — not merely
+  somewhere in its subtree. Without this constraint, a real sink smuggled
+  inside the call/comparison would go unflagged, e.g.
+  `candidates.includes(link.href = "javascript:alert(1)")` (assignment
+  nested in `.includes()`'s argument), `arr.includes((a.href =
+  "javascript:...", true))` (comma operator), or `(a.href =
+  "javascript:...") === expected` (assignment nested in a `===` operand) —
+  in all three the literal's immediate parent is the assignment
+  expression, not the `arguments`/`binary_expression` node, so it stays
+  flagged.
 rule:
   kind: string
   regex: '^"javascript:'
@@ -37,13 +51,13 @@ rule:
             field: function
             regex: "^(expect|it|test|describe)(\\.\\w+)?$"
       - inside:
-          stopBy: end
-          kind: call_expression
-          has:
-            field: function
-            regex: "\\.(startsWith|endsWith|includes|indexOf|search|match)$"
+          kind: arguments
+          inside:
+            kind: call_expression
+            has:
+              field: function
+              regex: "\\.(startsWith|endsWith|includes|indexOf|search|match)$"
       - inside:
-          stopBy: end
           kind: binary_expression
           has:
             regex: "^(===|!==|==|!=)$"

--- a/rules/ast-grep-rules/rules/no-javascript-url-js.yml
+++ b/rules/ast-grep-rules/rules/no-javascript-url-js.yml
@@ -15,13 +15,35 @@ note: |
   `.only`/`.skip`/`.each` variants): a test asserting that a guard REJECTS a
   `javascript:` URL — e.g. `expect(openBrowser("javascript:...")).toBe(false)`
   — is the adversarial input the code is meant to reject, not a real sink.
+
+  Also excludes literals used as the needle in a defensive string check —
+  `url.startsWith("javascript:")`, `.endsWith(...)`, `.includes(...)`,
+  `.indexOf(...)`, `.search(...)`, `.match(...)` — or as one side of an
+  equality/inequality comparison (`url === "javascript:..."`). These are the
+  code detecting/rejecting a javascript: URL, not introducing one (refs
+  #533). Deliberately NOT excluded: `.replace(...)`/`.replaceAll(...)`,
+  since the literal there could be the replacement (second) argument —
+  i.e. the malicious payload being substituted IN — and excluding the
+  whole call would hide that true positive.
 rule:
   kind: string
   regex: '^"javascript:'
   not:
-    inside:
-      stopBy: end
-      kind: call_expression
-      has:
-        field: function
-        regex: "^(expect|it|test|describe)(\\.\\w+)?$"
+    any:
+      - inside:
+          stopBy: end
+          kind: call_expression
+          has:
+            field: function
+            regex: "^(expect|it|test|describe)(\\.\\w+)?$"
+      - inside:
+          stopBy: end
+          kind: call_expression
+          has:
+            field: function
+            regex: "\\.(startsWith|endsWith|includes|indexOf|search|match)$"
+      - inside:
+          stopBy: end
+          kind: binary_expression
+          has:
+            regex: "^(===|!==|==|!=)$"

--- a/rules/ast-grep-rules/rules/no-javascript-url.yml
+++ b/rules/ast-grep-rules/rules/no-javascript-url.yml
@@ -25,6 +25,20 @@ note: |
   since the literal there could be the replacement (second) argument —
   i.e. the malicious payload being substituted IN — and excluding the
   whole call would hide that true positive.
+
+  IMPORTANT: unlike the expect/it/test/describe exclusion above, these two
+  new exclusions deliberately do NOT use `stopBy: end`. `inside` without
+  `stopBy` only checks the immediate parent, so the literal must be a
+  DIRECT argument/operand of the defensive call/comparison — not merely
+  somewhere in its subtree. Without this constraint, a real sink smuggled
+  inside the call/comparison would go unflagged, e.g.
+  `candidates.includes(link.href = "javascript:alert(1)")` (assignment
+  nested in `.includes()`'s argument), `arr.includes((a.href =
+  "javascript:...", true))` (comma operator), or `(a.href =
+  "javascript:...") === expected` (assignment nested in a `===` operand) —
+  in all three the literal's immediate parent is the assignment
+  expression, not the `arguments`/`binary_expression` node, so it stays
+  flagged.
 rule:
   kind: string
   regex: '^"javascript:'
@@ -37,13 +51,13 @@ rule:
             field: function
             regex: "^(expect|it|test|describe)(\\.\\w+)?$"
       - inside:
-          stopBy: end
-          kind: call_expression
-          has:
-            field: function
-            regex: "\\.(startsWith|endsWith|includes|indexOf|search|match)$"
+          kind: arguments
+          inside:
+            kind: call_expression
+            has:
+              field: function
+              regex: "\\.(startsWith|endsWith|includes|indexOf|search|match)$"
       - inside:
-          stopBy: end
           kind: binary_expression
           has:
             regex: "^(===|!==|==|!=)$"

--- a/rules/ast-grep-rules/rules/no-javascript-url.yml
+++ b/rules/ast-grep-rules/rules/no-javascript-url.yml
@@ -15,13 +15,35 @@ note: |
   `.only`/`.skip`/`.each` variants): a test asserting that a guard REJECTS a
   `javascript:` URL — e.g. `expect(openBrowser("javascript:...")).toBe(false)`
   — is the adversarial input the code is meant to reject, not a real sink.
+
+  Also excludes literals used as the needle in a defensive string check —
+  `url.startsWith("javascript:")`, `.endsWith(...)`, `.includes(...)`,
+  `.indexOf(...)`, `.search(...)`, `.match(...)` — or as one side of an
+  equality/inequality comparison (`url === "javascript:..."`). These are the
+  code detecting/rejecting a javascript: URL, not introducing one (refs
+  #533). Deliberately NOT excluded: `.replace(...)`/`.replaceAll(...)`,
+  since the literal there could be the replacement (second) argument —
+  i.e. the malicious payload being substituted IN — and excluding the
+  whole call would hide that true positive.
 rule:
   kind: string
   regex: '^"javascript:'
   not:
-    inside:
-      stopBy: end
-      kind: call_expression
-      has:
-        field: function
-        regex: "^(expect|it|test|describe)(\\.\\w+)?$"
+    any:
+      - inside:
+          stopBy: end
+          kind: call_expression
+          has:
+            field: function
+            regex: "^(expect|it|test|describe)(\\.\\w+)?$"
+      - inside:
+          stopBy: end
+          kind: call_expression
+          has:
+            field: function
+            regex: "\\.(startsWith|endsWith|includes|indexOf|search|match)$"
+      - inside:
+          stopBy: end
+          kind: binary_expression
+          has:
+            regex: "^(===|!==|==|!=)$"


### PR DESCRIPTION
Fixes a false positive from a dogfood run: `no-javascript-url` flagged code that **filters out** `javascript:` links (the exact defense the rule wants), not one that introduces a sink. The rule matched the `javascript:` string literal without distinguishing a dangerous sink assignment from a defensive check.

`no-javascript-url` / `-js` are **pi-lens-authored** (`rules/ast-grep-rules/rules/`), so refined the rules directly (not a suppression). Added two exclusions under `not: any:` on both twins:
- literal is the argument to `.startsWith`/`.endsWith`/`.includes`/`.indexOf`/`.search`/`.match` (any receiver) — covers `url.startsWith("javascript:")`, `arr.filter(l => !l.startsWith("javascript:"))`, etc.
- literal is one side of a `===`/`!==`/`==`/`!=` comparison.

**Deliberately did NOT exempt `.replace`/`.replaceAll`** — there the literal can be the *replacement* argument, a real injection (`str.replace("http:", "javascript:alert(1)")`), which must still flag.

## TP preserved
Added valid fixtures (must NOT flag: the defensive `.startsWith`/`.includes`/`===`/`!==` cases) AND an invalid fixture (`a.href = str.replace("http:", "javascript:alert(1)")` — must still flag), keeping the pre-existing direct-assignment/declaration invalid cases. `ast-grep-rule-tests` + `ast-grep*` suites: **60/60**. `audit:rule-catalog` + `audit:astgrep-rule-pairs` clean (TS/JS twin pair intentional).

## Verification
`npm run build` clean; `npx tsc --project tsconfig.json --noEmit` clean.

Refs #533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)