### PR TITLE
fix(config): symmetric #533 signalling across global/project loaders (closes #1012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Config-consistency pass on the #166 flag registry (refs #166, #533)** — the
+	#883 registry core (scope split, precedence, negation) was audited consistent
+	and left untouched; the gaps were all in #533 malformed/unknown-input
+	signalling, asymmetric between the global and project loaders. (1) The
+	project loader (`.pi-lens.json`) now warns once on an unrecognized top-level
+	key — a typo like `maxProjectFile` or `lps` previously did nothing silently —
+	while tolerating the foreign namespaces the shared file legitimately carries
+	for the LSP loader (`servers`, `serverOverrides`, `disabledServers`,
+	`warmFiles`, plus `$schema`); a user-level-only lens key placed at project
+	scope (e.g. `lsp`, `tests`, `delta`) gets a distinct "not honored at project
+	scope" signal instead of being lumped in with typos. (2) The recognized-key
+	catalogs are single-sourced (#883): `GLOBAL_NON_FLAG_CONFIG_SECTIONS` and
+	`PROJECT_FOREIGN_CONFIG_NAMESPACES` are declared once beside `LENS_FLAGS`, and
+	both loaders derive flag sections from the registry, so adding a namespace is
+	a one-line edit and adding a flag needs none — replacing a drift-prone inline
+	literal set in the global loader. (3) Three global scalars
+	(`dispatch.runnerTimeoutFloorMs`, `widget.visible`, `format.mode`) that
+	silently coerced a present-but-malformed value to `undefined` now warn on
+	invalid input through the same path as `actionableWarnings.autoFix.maxFixes`,
+	while staying silent when the key is absent (no false warnings). (4) Removed
+	five dead global-only accessors that bypassed the precedence chain
+	(`getGlobalAutoformatEnabled`, `getGlobalAutofixEnabled`,
+	`getGlobalImmediateFormatDefault`, `getGlobalContextInjectionEnabled`,
+	`getGlobalTurnSummaryEnabled`) — no non-test callers existed. (5) Updated
+	`docs/globalconfig.md`, whose "unknown keys are ignored" claim was stale.
 - **Fixed: `ts-ssrf` no longer flags fixed/const endpoint URLs built with
 	`new URL(...)` as SSRF sinks, while still catching tainted URLs** (closes
 	#1000, refs #533, #963) — a project-wide pi-free scan flagged fixed outbound

--- a/clients/lens-config.ts
+++ b/clients/lens-config.ts
@@ -3,8 +3,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	assignFlagConfigSection,
+	flagConfigSectionKeys,
 	flagValueFromConfig,
 	getLensFlagSpec,
+	GLOBAL_NON_FLAG_CONFIG_SECTIONS,
 	LENS_FLAGS,
 	readFlagConfigValue,
 } from "./lens-flag-registry.js";
@@ -163,14 +165,20 @@ export function loadPiLensGlobalConfig(
 
 		const dispatch = asConfigObject(raw.dispatch);
 		if (dispatch) {
-			config.dispatch = {
-				runnerTimeoutFloorMs:
-					typeof dispatch.runnerTimeoutFloorMs === "number" &&
-					Number.isFinite(dispatch.runnerTimeoutFloorMs) &&
-					dispatch.runnerTimeoutFloorMs > 0
-						? dispatch.runnerTimeoutFloorMs
-						: undefined,
-			};
+			const floor = dispatch.runnerTimeoutFloorMs;
+			if (typeof floor === "number" && Number.isFinite(floor) && floor > 0) {
+				config.dispatch = { runnerTimeoutFloorMs: floor };
+			} else {
+				// #533: warn only when the key is PRESENT but malformed — an absent
+				// key stays silent so a config that never mentions it is not falsely
+				// flagged. Same warn-once path as the maxFixes case below.
+				if ("runnerTimeoutFloorMs" in dispatch) {
+					warnInvalid(
+						"dispatch.runnerTimeoutFloorMs must be a positive finite number",
+					);
+				}
+				config.dispatch = { runnerTimeoutFloorMs: undefined };
+			}
 		}
 
 		const autoFix = asConfigObject(
@@ -197,35 +205,44 @@ export function loadPiLensGlobalConfig(
 
 		const widget = asConfigObject(raw.widget);
 		if (widget) {
-			config.widget = {
-				visible:
-					typeof widget.visible === "boolean" ? widget.visible : undefined,
-			};
+			if (typeof widget.visible === "boolean") {
+				config.widget = { visible: widget.visible };
+			} else {
+				// #533: present-but-wrong-type warns; absent stays silent.
+				if ("visible" in widget) {
+					warnInvalid("widget.visible must be a boolean");
+				}
+				config.widget = { visible: undefined };
+			}
 		}
 
 		const format = asConfigObject(raw.format);
 		if (format) {
 			config.format ??= {};
 			const formatSection = config.format as Record<string, unknown>;
-			formatSection.mode =
-				format.mode === "immediate" || format.mode === "deferred"
-					? format.mode
-					: undefined;
+			if (format.mode === "immediate" || format.mode === "deferred") {
+				formatSection.mode = format.mode;
+			} else {
+				// #533: a present-but-invalid mode (e.g. "immedaite") warns and
+				// falls back; an absent mode stays silent.
+				if ("mode" in format) {
+					warnInvalid('format.mode must be "immediate" or "deferred"');
+				}
+				formatSection.mode = undefined;
+			}
 		}
 
 		// #533 hygiene: a completely unknown top-level key (e.g. a typo like
 		// `lps` for `lsp`) is otherwise dropped silently, so a setting the user
 		// thought they made does nothing with no signal. Warn once per key. The
-		// recognized set is derived from the flag registry (#883 single source
-		// of truth) plus the non-flag global sections handled above; `$schema`
-		// is allowed for editor JSON-schema associations.
+		// recognized set is single-sourced (#883): the flag sections derived
+		// from the registry plus the declared non-flag global sections
+		// (`GLOBAL_NON_FLAG_CONFIG_SECTIONS`, which co-locates `$schema` and the
+		// hand-parsed namespaces beside the registry). Adding a flag needs no
+		// edit here; adding a namespace is a one-line edit in that one constant.
 		const knownGlobalConfigKeys = new Set<string>([
-			...LENS_FLAGS.map((spec) => spec.configKey.split(".")[0]),
-			"ignore",
-			"dispatch",
-			"actionableWarnings",
-			"widget",
-			"$schema",
+			...flagConfigSectionKeys(LENS_FLAGS),
+			...GLOBAL_NON_FLAG_CONFIG_SECTIONS,
 		]);
 		for (const key of Object.keys(raw)) {
 			if (!knownGlobalConfigKeys.has(key)) {
@@ -247,28 +264,6 @@ export function getGlobalIgnorePatterns(configPath?: string): string[] {
 
 export function getGlobalWidgetDefaultVisible(configPath?: string): boolean {
 	return loadPiLensGlobalConfig(configPath)?.widget?.visible !== false;
-}
-
-export function getGlobalAutoformatEnabled(configPath?: string): boolean {
-	return loadPiLensGlobalConfig(configPath)?.format?.enabled !== false;
-}
-
-export function getGlobalAutofixEnabled(configPath?: string): boolean {
-	return loadPiLensGlobalConfig(configPath)?.autofix?.enabled !== false;
-}
-
-export function getGlobalImmediateFormatDefault(configPath?: string): boolean {
-	return loadPiLensGlobalConfig(configPath)?.format?.mode === "immediate";
-}
-
-export function getGlobalContextInjectionEnabled(configPath?: string): boolean {
-	return (
-		loadPiLensGlobalConfig(configPath)?.contextInjection?.enabled !== false
-	);
-}
-
-export function getGlobalTurnSummaryEnabled(configPath?: string): boolean {
-	return loadPiLensGlobalConfig(configPath)?.turnSummary?.enabled === true;
 }
 
 /** Per-turn quickfix cap; undefined means "use the built-in default of 5". */

--- a/clients/lens-flag-registry.ts
+++ b/clients/lens-flag-registry.ts
@@ -216,6 +216,57 @@ export function getLensFlagSpec(name: string): LensFlagSpec | undefined {
 export const PROJECT_SCOPED_LENS_FLAGS: readonly LensFlagSpec[] =
 	LENS_FLAGS.filter((spec) => spec.scope === "project");
 
+/**
+ * Recognized TOP-LEVEL sections of `~/.pi-lens/config.json` that are NOT
+ * derived from the flag registry — the non-flag namespaces the global loader
+ * parses by hand (`ignore`, `dispatch`, `widget`) plus `$schema` for editor
+ * JSON-schema association. Declared here, beside {@link LENS_FLAGS}, so the
+ * global unknown-key scan has ONE catalog to consult (#883) instead of a
+ * second hand-maintained literal set inline in the loader. Adding a future
+ * top-level namespace is a one-line edit HERE; adding a flag needs no edit at
+ * all (its section is registry-derived via {@link flagConfigSectionKeys}).
+ * Do NOT speculatively pre-add keys no loader reads yet (e.g. `languages` is
+ * #195's job) — this is an extension point, not a wishlist.
+ *
+ * `actionableWarnings` is intentionally absent: it is already a flag section
+ * (`actionableWarnings.enabled`, `.autoFix.enabled`, ...) so it is covered by
+ * the registry-derived set.
+ */
+export const GLOBAL_NON_FLAG_CONFIG_SECTIONS: readonly string[] = [
+	"ignore",
+	"dispatch",
+	"widget",
+	"$schema",
+];
+
+/**
+ * Foreign top-level namespaces that legitimately appear in a SHARED
+ * `.pi-lens.json` but belong to a DIFFERENT loader: the LSP config loader
+ * (`clients/lsp/config.ts`) reads `servers` / `serverOverrides` /
+ * `disabledServers` / `warmFiles` out of the very same file. The project-lens
+ * loader must TOLERATE these (never warn "unknown key") — they are not typos,
+ * just another subsystem's namespace. `$schema` is allowed for editor
+ * JSON-schema association. Declared once, here, for the same #883 reason as
+ * {@link GLOBAL_NON_FLAG_CONFIG_SECTIONS}.
+ */
+export const PROJECT_FOREIGN_CONFIG_NAMESPACES: readonly string[] = [
+	"servers",
+	"serverOverrides",
+	"disabledServers",
+	"warmFiles",
+	"$schema",
+];
+
+/**
+ * The distinct TOP-LEVEL section keys a set of flags lives under (the first
+ * dotted segment of each `configKey`). Both config loaders derive their
+ * recognized-key catalogs from this rather than restating flag sections, so a
+ * new flag never needs an unknown-key-scan edit (#166/#883).
+ */
+export function flagConfigSectionKeys(flags: readonly LensFlagSpec[]): string[] {
+	return [...new Set(flags.map((spec) => spec.configKey.split(".")[0]))];
+}
+
 function asConfigObject(value: unknown): Record<string, unknown> | undefined {
 	return value && typeof value === "object" && !Array.isArray(value)
 		? (value as Record<string, unknown>)

--- a/clients/project-lens-config.ts
+++ b/clients/project-lens-config.ts
@@ -77,18 +77,22 @@ import { findPiLensConfigMarkerInDir } from "./workspace-topology.js";
 const PROJECT_CONFIG_BASENAMES = [".pi-lens.json", "pi-lens.json"];
 
 /**
- * The project loader's OWN recognized top-level keys — the non-flag sections it
- * parses itself. The project-scoped flag sections (`format`, `autofix`,
- * `actionableWarnings`) are NOT listed here; they are derived from
- * `PROJECT_SCOPED_LENS_FLAGS` so the registry stays the single source of truth
- * (#883). Foreign namespaces the shared file also carries live in
- * `PROJECT_FOREIGN_CONFIG_NAMESPACES` beside the registry.
+ * The project loader's OWN recognized top-level keys — pi-lens-native sections,
+ * whether parsed here into typed fields (`ignore`, `rules`, `maxProjectFiles`,
+ * `reviewGraph`) or read off `PiLensProjectConfig.raw` by another pi-lens
+ * consumer (`trivy`, read via `.raw` in `trivy-client.ts`). The project-scoped
+ * flag sections (`format`, `autofix`, `actionableWarnings`) are NOT listed here;
+ * they are derived from `PROJECT_SCOPED_LENS_FLAGS` so the registry stays the
+ * single source of truth (#883). Foreign (non-pi-lens) namespaces the shared
+ * file also carries live in `PROJECT_FOREIGN_CONFIG_NAMESPACES` beside the
+ * registry.
  */
 const PROJECT_OWN_CONFIG_KEYS = [
 	"ignore",
 	"rules",
 	"maxProjectFiles",
 	"reviewGraph",
+	"trivy",
 ] as const;
 
 export interface PiLensProjectRuleConfig {

--- a/clients/project-lens-config.ts
+++ b/clients/project-lens-config.ts
@@ -63,7 +63,11 @@ import * as path from "node:path";
 import { toPositiveFinite } from "./env-utils.js";
 import {
 	assignFlagConfigSection,
+	flagConfigSectionKeys,
+	GLOBAL_NON_FLAG_CONFIG_SECTIONS,
+	LENS_FLAGS,
 	type LensFlagSpec,
+	PROJECT_FOREIGN_CONFIG_NAMESPACES,
 	PROJECT_SCOPED_LENS_FLAGS,
 	readFlagConfigValue,
 } from "./lens-flag-registry.js";
@@ -71,6 +75,21 @@ import { isAtOrAboveHomeDir, walkUpDirs } from "./path-utils.js";
 import { findPiLensConfigMarkerInDir } from "./workspace-topology.js";
 
 const PROJECT_CONFIG_BASENAMES = [".pi-lens.json", "pi-lens.json"];
+
+/**
+ * The project loader's OWN recognized top-level keys — the non-flag sections it
+ * parses itself. The project-scoped flag sections (`format`, `autofix`,
+ * `actionableWarnings`) are NOT listed here; they are derived from
+ * `PROJECT_SCOPED_LENS_FLAGS` so the registry stays the single source of truth
+ * (#883). Foreign namespaces the shared file also carries live in
+ * `PROJECT_FOREIGN_CONFIG_NAMESPACES` beside the registry.
+ */
+const PROJECT_OWN_CONFIG_KEYS = [
+	"ignore",
+	"rules",
+	"maxProjectFiles",
+	"reviewGraph",
+] as const;
 
 export interface PiLensProjectRuleConfig {
 	/** Optional override for the rule's primary numeric threshold. */
@@ -414,6 +433,41 @@ function parseConfigFile(configPath: string): PiLensProjectConfig {
 					);
 				}
 			}
+		}
+	}
+
+	// #533 hygiene: mirror the global loader's unknown-key warn so a typo in a
+	// shared `.pi-lens.json` (e.g. `maxProjectFile`, `lps`) produces a signal
+	// instead of silently doing nothing. The recognized set is single-sourced
+	// (#883): the project loader's own keys + the project-scoped flag sections
+	// (registry-derived) + the foreign namespaces the LSP loader reads from this
+	// same file. A key recognized ONLY at global scope (e.g. `lsp`, `tests`,
+	// `delta`) gets a distinct, honest signal that it does nothing here rather
+	// than being lumped in with typos — docs previously called this "silently
+	// ignored".
+	const knownProjectKeys = new Set<string>([
+		...PROJECT_OWN_CONFIG_KEYS,
+		...flagConfigSectionKeys(PROJECT_SCOPED_LENS_FLAGS),
+		...PROJECT_FOREIGN_CONFIG_NAMESPACES,
+	]);
+	const globalScopeOnlyKeys = new Set<string>(
+		[
+			...flagConfigSectionKeys(LENS_FLAGS),
+			...GLOBAL_NON_FLAG_CONFIG_SECTIONS,
+		].filter((key) => !knownProjectKeys.has(key)),
+	);
+	for (const key of Object.keys(obj)) {
+		if (knownProjectKeys.has(key)) continue;
+		if (globalScopeOnlyKeys.has(key)) {
+			warnInvalidConfigOnce(
+				configPath,
+				`"${key}" is a global-only pi-lens setting and is not honored in a project .pi-lens.json (set it in ~/.pi-lens/config.json or pass the matching CLI flag); ignored`,
+			);
+		} else {
+			warnInvalidConfigOnce(
+				configPath,
+				`unknown key "${key}" is not a recognized pi-lens setting (check for a typo); ignored`,
+			);
 		}
 	}
 

--- a/docs/globalconfig.md
+++ b/docs/globalconfig.md
@@ -1,6 +1,6 @@
 # Configuration
 
-pi-lens reads optional user preferences from `~/.pi-lens/config.json` (`%USERPROFILE%\\.pi-lens\\config.json` on Windows). Unknown keys are ignored, and missing or invalid config falls back to defaults.
+pi-lens reads optional user preferences from `~/.pi-lens/config.json` (`%USERPROFILE%\\.pi-lens\\config.json` on Windows). An unrecognized top-level key is logged once (to surface a typo like `lps` for `lsp`) and then ignored; `$schema` is always allowed for editor JSON-schema association. Missing or invalid config falls back to defaults.
 
 ## Every toggle, both ways
 
@@ -98,7 +98,7 @@ Turn subsystems off globally instead of retyping flags every session:
 
 In addition to the user-level `~/.pi-lens/config.json` above, pi-lens reads a per-project `.pi-lens.json` (or `pi-lens.json`) at the project root. Walked upward from the cwd, so a monorepo can keep the config at the repo root and have every subdir pick it up. The schema is intentionally small — only fields pi-lens actually honors:
 
-Note that most toggles from the table above are **user-level only**. Of them, a project config honors just the three [mutation controls](#mutation-controls) (`format.enabled`, `autofix.enabled`, `actionableWarnings.autoFix.enabled`). Putting something like `"lsp": { "enabled": false }` in a `.pi-lens.json` is silently ignored, since unknown keys never fail the parse. Set it in `~/.pi-lens/config.json` or pass `--no-lsp` instead.
+Note that most toggles from the table above are **user-level only**. Of them, a project config honors just the three [mutation controls](#mutation-controls) (`format.enabled`, `autofix.enabled`, `actionableWarnings.autoFix.enabled`). Putting a user-level toggle such as `"lsp": { "enabled": false }` in a `.pi-lens.json` is **not** honored at project scope; pi-lens now logs a one-time warning saying so rather than dropping it silently, so you get a signal instead of a setting that quietly does nothing. Set it in `~/.pi-lens/config.json` or pass `--no-lsp` instead. A genuinely unrecognized key (a typo) is likewise logged once. Foreign namespaces that a shared `.pi-lens.json` legitimately carries for the LSP loader (`servers`, `serverOverrides`, `disabledServers`, `warmFiles`) and `$schema` are tolerated without warning.
 
 ```json
 {
@@ -192,7 +192,7 @@ Explicit override for the review graph's own file budget (#775), for monorepos t
 
 ### Schema rules
 
-- Unknown top-level keys and unknown rule ids are ignored, so a forward-compat file with extra fields (e.g. an LSP `servers` block from `lsp.json`) won't break the parse.
+- Unknown rule ids are ignored (forward-compat). Unrecognized **top-level** keys are logged once and then ignored — never fatal to the parse. The LSP namespaces a shared file legitimately carries (`servers`, `serverOverrides`, `disabledServers`, `warmFiles`) and `$schema` are tolerated silently; a user-level-only lens key placed here (e.g. `lsp`, `tests`, `delta`) is logged as "not honored at project scope"; anything else is logged as a likely typo. The raw parsed JSON is still exposed for forward-compat consumers regardless.
 - Every toggle key in the table above must be a boolean, and its containing section must be an object. A wrong type is logged once and the key is treated as absent, so the flag falls through to its default rather than the whole file being rejected.
 - A malformed JSON file is logged once and treated as "no config" — your diagnostics never get blocked by a syntax error in your own config.
 - Rule thresholds must be positive finite numbers; invalid, zero, or negative values are logged once and ignored.

--- a/tests/clients/lens-config.test.ts
+++ b/tests/clients/lens-config.test.ts
@@ -4,11 +4,6 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	getGlobalActionableWarningMaxFixes,
-	getGlobalAutofixEnabled,
-	getGlobalAutoformatEnabled,
-	getGlobalContextInjectionEnabled,
-	getGlobalImmediateFormatDefault,
-	getGlobalTurnSummaryEnabled,
 	getGlobalWidgetDefaultVisible,
 	getPiLensGlobalConfigPath,
 	loadPiLensGlobalConfig,
@@ -134,8 +129,10 @@ describe("global pi-lens config", () => {
 			},
 		});
 		expect(getGlobalWidgetDefaultVisible(configPath)).toBe(false);
-		expect(getGlobalAutoformatEnabled(configPath)).toBe(true);
-		expect(getGlobalImmediateFormatDefault(configPath)).toBe(true);
+		const parsed = loadPiLensGlobalConfig(configPath);
+		// format.enabled:true → --no-autoformat stays off; mode:"immediate" → on.
+		expect(resolvePiLensFlag("no-autoformat", false, parsed)).toBe(false);
+		expect(resolvePiLensFlag("immediate-format", false, parsed)).toBe(true);
 	});
 
 	it("warns once on an unknown top-level config key but not on recognized ones", () => {
@@ -186,8 +183,11 @@ describe("global pi-lens config", () => {
 		expect(loadPiLensGlobalConfig(configPath)).toEqual({
 			format: { enabled: false, mode: undefined },
 		});
-		expect(getGlobalAutoformatEnabled(configPath)).toBe(false);
-		expect(getGlobalImmediateFormatDefault(configPath)).toBe(false);
+		const parsed = loadPiLensGlobalConfig(configPath);
+		// format.enabled:false → --no-autoformat resolves on; invalid mode falls
+		// back so immediate-format stays off.
+		expect(resolvePiLensFlag("no-autoformat", false, parsed)).toBe(true);
+		expect(resolvePiLensFlag("immediate-format", false, parsed)).toBe(false);
 	});
 
 	it("resolves formatting flags from global config unless CLI flags are set", () => {
@@ -307,7 +307,9 @@ describe("global pi-lens config", () => {
 		expect(loadPiLensGlobalConfig(configPath)).toEqual({
 			contextInjection: { enabled: false },
 		});
-		expect(getGlobalContextInjectionEnabled(configPath)).toBe(false);
+		expect(
+			resolvePiLensFlag("no-lens-context", false, loadPiLensGlobalConfig(configPath)),
+		).toBe(true);
 
 		// no-lens-context flag is true (i.e. "disable") when config disables injection
 		expect(
@@ -333,20 +335,33 @@ describe("global pi-lens config", () => {
 	it("defaults context injection to enabled when unset", () => {
 		const home = makeTempHome();
 		const configPath = writeConfig(home, JSON.stringify({ widget: {} }));
-		expect(getGlobalContextInjectionEnabled(configPath)).toBe(true);
-		// missing config file → enabled
+		// context injection default-on → no-lens-context resolves off (false).
 		expect(
-			getGlobalContextInjectionEnabled(path.join(home, "nope.json")),
-		).toBe(true);
+			resolvePiLensFlag("no-lens-context", false, loadPiLensGlobalConfig(configPath)),
+		).toBe(false);
+		// missing config file → still default-on
+		expect(
+			resolvePiLensFlag(
+				"no-lens-context",
+				false,
+				loadPiLensGlobalConfig(path.join(home, "nope.json")),
+			),
+		).toBe(false);
 	});
 
 	it("defaults turnSummary to disabled (opt-in, #484)", () => {
 		const home = makeTempHome();
-		expect(getGlobalTurnSummaryEnabled(path.join(home, "nope.json"))).toBe(
-			false,
-		);
+		expect(
+			resolvePiLensFlag(
+				"lens-turn-summary",
+				false,
+				loadPiLensGlobalConfig(path.join(home, "nope.json")),
+			),
+		).toBe(false);
 		const configPath = writeConfig(home, JSON.stringify({ widget: {} }));
-		expect(getGlobalTurnSummaryEnabled(configPath)).toBe(false);
+		expect(
+			resolvePiLensFlag("lens-turn-summary", false, loadPiLensGlobalConfig(configPath)),
+		).toBe(false);
 		expect(resolvePiLensFlag("lens-turn-summary", false, {})).toBe(false);
 	});
 
@@ -359,7 +374,9 @@ describe("global pi-lens config", () => {
 		expect(loadPiLensGlobalConfig(configPath)).toEqual({
 			turnSummary: { enabled: true },
 		});
-		expect(getGlobalTurnSummaryEnabled(configPath)).toBe(true);
+		expect(
+			resolvePiLensFlag("lens-turn-summary", false, loadPiLensGlobalConfig(configPath)),
+		).toBe(true);
 		expect(
 			resolvePiLensFlag("lens-turn-summary", false, {
 				turnSummary: { enabled: true },
@@ -440,14 +457,26 @@ describe("global pi-lens config", () => {
 			expect(loadPiLensGlobalConfig(configPath)).toEqual({
 				autofix: { enabled: false },
 			});
-			expect(getGlobalAutofixEnabled(configPath)).toBe(false);
+			// autofix.enabled:false → --no-autofix resolves on (true).
+			expect(
+				resolvePiLensFlag("no-autofix", false, loadPiLensGlobalConfig(configPath)),
+			).toBe(true);
 		});
 
 		it("defaults autofix to enabled when config is missing or silent", () => {
 			const home = makeTempHome();
-			expect(getGlobalAutofixEnabled(path.join(home, "nope.json"))).toBe(true);
+			// autofix default-on → no-autofix resolves off (false).
+			expect(
+				resolvePiLensFlag(
+					"no-autofix",
+					false,
+					loadPiLensGlobalConfig(path.join(home, "nope.json")),
+				),
+			).toBe(false);
 			const configPath = writeConfig(home, JSON.stringify({ widget: {} }));
-			expect(getGlobalAutofixEnabled(configPath)).toBe(true);
+			expect(
+				resolvePiLensFlag("no-autofix", false, loadPiLensGlobalConfig(configPath)),
+			).toBe(false);
 		});
 
 		it("global autofix.enabled=false disables --no-autofix's default", () => {
@@ -529,6 +558,97 @@ describe("global pi-lens config", () => {
 					"actionableWarnings.autoFix.enabled must be a boolean",
 				),
 			);
+		});
+	});
+
+	// #533: three sibling global scalars used to coerce a present-but-malformed
+	// value to undefined SILENTLY, unlike actionableWarnings.autoFix.maxFixes
+	// which already warned. These pin down that they now warn on present-invalid
+	// input and — the false-positive guard — stay silent when the key is absent.
+	describe("malformed global scalar value warns (#533 value-warn parity)", () => {
+		function warnedFor(substring: string): boolean {
+			return (console.error as ReturnType<typeof vi.fn>).mock.calls
+				.flat()
+				.some((arg) => typeof arg === "string" && arg.includes(substring));
+		}
+
+		it("warns once on a present-but-invalid widget.visible; absent stays silent", () => {
+			const home = makeTempHome();
+			const badPath = writeConfig(
+				home,
+				JSON.stringify({ widget: { visible: "yes" } }),
+			);
+			expect(loadPiLensGlobalConfig(badPath)).toEqual({
+				widget: { visible: undefined },
+			});
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining("widget.visible must be a boolean"),
+			);
+			const callsAfterFirst = (console.error as ReturnType<typeof vi.fn>).mock
+				.calls.length;
+			loadPiLensGlobalConfig(badPath);
+			expect(
+				(console.error as ReturnType<typeof vi.fn>).mock.calls.length,
+			).toBe(callsAfterFirst);
+
+			// Absent visible → no warn (false-positive guard).
+			const silentHome = makeTempHome();
+			const silentPath = writeConfig(silentHome, JSON.stringify({ widget: {} }));
+			loadPiLensGlobalConfig(silentPath);
+			expect(warnedFor("widget.visible")).toBe(true);
+			(console.error as ReturnType<typeof vi.fn>).mockClear();
+			loadPiLensGlobalConfig(silentPath);
+			expect(warnedFor("widget.visible")).toBe(false);
+		});
+
+		it("warns once on a present-but-invalid format.mode; absent stays silent", () => {
+			const home = makeTempHome();
+			const badPath = writeConfig(
+				home,
+				JSON.stringify({ format: { mode: "immedaite" } }),
+			);
+			expect(loadPiLensGlobalConfig(badPath)).toEqual({
+				format: { mode: undefined },
+			});
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining('format.mode must be "immediate" or "deferred"'),
+			);
+
+			// A config with only format.enabled (no mode) must NOT warn about mode.
+			(console.error as ReturnType<typeof vi.fn>).mockClear();
+			const silentHome = makeTempHome();
+			const silentPath = writeConfig(
+				silentHome,
+				JSON.stringify({ format: { enabled: true } }),
+			);
+			loadPiLensGlobalConfig(silentPath);
+			expect(warnedFor("format.mode")).toBe(false);
+		});
+
+		it("warns once on a present-but-invalid dispatch.runnerTimeoutFloorMs; absent stays silent", () => {
+			const home = makeTempHome();
+			const badPath = writeConfig(
+				home,
+				JSON.stringify({ dispatch: { runnerTimeoutFloorMs: "180000" } }),
+			);
+			expect(loadPiLensGlobalConfig(badPath)).toEqual({
+				dispatch: { runnerTimeoutFloorMs: undefined },
+			});
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"dispatch.runnerTimeoutFloorMs must be a positive finite number",
+				),
+			);
+
+			// An empty dispatch object (no floor key) must NOT warn.
+			(console.error as ReturnType<typeof vi.fn>).mockClear();
+			const silentHome = makeTempHome();
+			const silentPath = writeConfig(
+				silentHome,
+				JSON.stringify({ dispatch: {} }),
+			);
+			loadPiLensGlobalConfig(silentPath);
+			expect(warnedFor("dispatch.runnerTimeoutFloorMs")).toBe(false);
 		});
 	});
 

--- a/tests/clients/project-lens-config.test.ts
+++ b/tests/clients/project-lens-config.test.ts
@@ -415,6 +415,17 @@ describe("loadPiLensProjectConfig", () => {
 			expect(console.error).not.toHaveBeenCalled();
 		});
 
+		it("does NOT warn on the pi-lens-native `trivy` key (read via .raw)", () => {
+			// `trivy.enabled`/`trivy.minSeverity` are read off PiLensProjectConfig.raw
+			// by trivy-client.ts — a legitimate opt-in, must not look like a typo.
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({ trivy: { enabled: true, minSeverity: "HIGH" } }),
+			);
+			loadPiLensProjectConfig(tmpDir);
+			expect(console.error).not.toHaveBeenCalled();
+		});
+
 		it("signals that a global-only lens key is not honored at project scope", () => {
 			fs.writeFileSync(
 				path.join(tmpDir, ".pi-lens.json"),

--- a/tests/clients/project-lens-config.test.ts
+++ b/tests/clients/project-lens-config.test.ts
@@ -372,4 +372,78 @@ describe("loadPiLensProjectConfig", () => {
 			expect(calls.length).toBe(1);
 		});
 	});
+
+	// #533/#883: a shared `.pi-lens.json` typo must produce a signal, but the
+	// file is ALSO the LSP loader's home, so foreign namespaces must stay
+	// silent, and a user-level-only lens key gets a distinct scope signal.
+	describe("unknown-key warnings (#533)", () => {
+		function warnedFor(substring: string): boolean {
+			return (console.error as ReturnType<typeof vi.fn>).mock.calls
+				.flat()
+				.some((arg) => typeof arg === "string" && arg.includes(substring));
+		}
+
+		it("warns on a typo'd top-level key", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({ maxProjectFile: 5000, lps: { enabled: false } }),
+			);
+			loadPiLensProjectConfig(tmpDir);
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining('unknown key "maxProjectFile"'),
+			);
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining('unknown key "lps"'),
+			);
+		});
+
+		it("does NOT warn on foreign LSP namespaces or $schema", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					$schema: "https://example.com/pi-lens.json",
+					servers: { foo: { name: "foo" } },
+					serverOverrides: { rust: {} },
+					disabledServers: ["go"],
+					warmFiles: ["src/main.ts"],
+					// Legitimate project keys alongside them.
+					ignore: ["dist/**"],
+					format: { enabled: false },
+				}),
+			);
+			loadPiLensProjectConfig(tmpDir);
+			expect(console.error).not.toHaveBeenCalled();
+		});
+
+		it("signals that a global-only lens key is not honored at project scope", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({ lsp: { enabled: false }, tests: { enabled: false } }),
+			);
+			loadPiLensProjectConfig(tmpDir);
+			expect(warnedFor("not honored in a project")).toBe(true);
+			expect(warnedFor('"lsp"')).toBe(true);
+			expect(warnedFor('"tests"')).toBe(true);
+			// It is NOT reported as a typo — it is a real key, wrong scope.
+			expect(warnedFor('unknown key "lsp"')).toBe(false);
+		});
+
+		it("warns once for the same typo across re-parses (warn-once dedup)", async () => {
+			const p = path.join(tmpDir, ".pi-lens.json");
+			fs.writeFileSync(p, JSON.stringify({ maxProjectFile: 5000 }));
+			loadPiLensProjectConfig(tmpDir);
+			// Force a re-parse (new mtime) WITHOUT clearing the warn-once cache.
+			await new Promise((r) => setTimeout(r, 20));
+			fs.writeFileSync(p, JSON.stringify({ maxProjectFile: 5000, ignore: [] }));
+			loadPiLensProjectConfig(tmpDir);
+			const typoWarns = (console.error as ReturnType<typeof vi.fn>).mock.calls
+				.flat()
+				.filter(
+					(arg) =>
+						typeof arg === "string" &&
+						arg.includes('unknown key "maxProjectFile"'),
+				);
+			expect(typoWarns.length).toBe(1);
+		});
+	});
 });


### PR DESCRIPTION
Follow-up to #1011 (flag registry) — makes the malformed/unknown-input signalling **symmetric across the global (`~/.pi-lens/config.json`) and project (`.pi-lens.json`) loaders**. The #883 core (flag set, scope split, precedence, negation) was already consistent; these five fixes close the #533 gaps found by an audit (#1012).

1. **Project loader now warns on unknown/wrong-scope keys** — previously a typo in `.pi-lens.json` silently did nothing while global warned. Uses a distinct "global-only key, not honored at project scope" message for real-but-misplaced lens keys, and a foreign-namespace allowlist so the shared file's LSP keys (`servers`/`serverOverrides`/`disabledServers`/`warmFiles`/`$schema`) never false-warn.
2. **Single-sourced namespace catalogs** (`GLOBAL_NON_FLAG_CONFIG_SECTIONS`, `PROJECT_FOREIGN_CONFIG_NAMESPACES`, `flagConfigSectionKeys()`) in `lens-flag-registry.ts` — both loaders consult them; the global loader's inline literal set is gone (was a #883 smell + not forward-compatible).
3. **Stale doc fixed** — `globalconfig.md` no longer claims unknown keys are silently ignored.
4. **Global malformed-value consistency** — `dispatch.runnerTimeoutFloorMs`, `widget.visible`, `format.mode` now warn on present-but-malformed values (matching `maxFixes` and the stricter project loader); absent keys stay silent.
5. **Removed 5 dead `getGlobal*` accessors** that bypassed the precedence chain (no live callers; tests rewritten to the public API).

**Adversarial review caught a false-positive** (would have shipped otherwise): the project-native `trivy` key (read via `.raw` by `trivy-client.ts`, a documented opt-in) was missing from the allowlist, so every user with Trivy scanning enabled would have gotten a spurious "typo" warning. Fixed + regression test (verified to fail pre-fix).

New warn-tests verified to fail on pre-change code; absent-key false-positive guards verified. `build` + full `tsc` clean; config + LSP-config suites **149 pass**.

Closes #1012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)