### PR TITLE
fix(context): inject ephemeral findings before final message to preserve prompt cache (closes #1016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Cache-friendly ephemeral context injection (refs #1016, closes #1016)** — the
+	`context` event handler in `index.ts` now splices pi-lens's ephemeral turn-end
+	findings in **immediately before the final message** instead of prepending them
+	at message index 0. Prepending flipped `messages[0]` every turn, which
+	invalidated the entire prompt-cache prefix on every prefix-caching provider
+	(Anthropic, Bedrock, and OpenAI — all key the cache on the exact token prefix).
+	Inserting before the last message keeps `messages[0]` (the real first user turn)
+	byte-stable so the prior conversation stays cached, while still keeping the real
+	user prompt as the trailing message — preserving the trailing-`user` cache
+	breakpoint and the historical `fe0ed5da` guarantee that input is never empty (the
+	existing transcript is always preserved, never dropped; an empty transcript falls
+	back to the prior prepend-only behavior). Because the `context` event fires
+	before **every** provider call (not just at turn boundaries), a trailing-role
+	guard (`isPlainUserPrompt`) only splices before the last message when it is a
+	plain user prompt; when the tail is a mid-loop `tool_result` (or assistant/tool
+	message) the findings are **appended** after the whole transcript instead — a
+	pure append that both preserves the `tool_use`↔`tool_result` adjacency all three
+	providers require (splicing between them is an HTTP 400) and keeps the entire
+	prior transcript as an untouched cache prefix. Changes shipped `dist` behavior
+	(the handler lives in the bundled dist path).
+
 - **Config-consistency pass on the #166 flag registry (refs #166, #533)** — the
 	#883 registry core (scope split, precedence, negation) was audited consistent
 	and left untouched; the gaps were all in #533 malformed/unknown-input

--- a/index.ts
+++ b/index.ts
@@ -1787,9 +1787,41 @@ export default function (pi: ExtensionAPI) {
 	// --- Inject turn-end findings into next agent turn ---
 	// jscpd, madge, and turn-end delta results are cached at turn_end and consumed here
 	// via the context event, which fires before each provider request.
-	// Important: keep the user's prompt as the trailing message. Some provider bridges
-	// treat the final message as the active user action, so pi-lens context must be
-	// prepended instead of appended.
+	// Placement (#1016): splice the ephemeral pi-lens findings in IMMEDIATELY BEFORE
+	// the final message rather than prepending at index 0. Prepending flipped
+	// messages[0] every turn, which invalidated the entire prompt-cache prefix on
+	// EVERY prefix-caching provider (Anthropic, Bedrock, AND OpenAI — all key the
+	// cache on the exact token prefix). Inserting before the last message keeps
+	// messages[0] (the real first user turn) byte-stable so the prior conversation
+	// stays cached, AND keeps the real user prompt as the trailing message —
+	// preserving the trailing-`user` cache breakpoint and the historical fe0ed5da
+	// guarantee that input is never empty (existingMessages are always preserved,
+	// never dropped).
+	//
+	// The `context` event fires before EVERY provider/LLM call, not just at turn
+	// boundaries (clients/agent-nudge.ts), so mid-agentic-loop the trailing message
+	// is often a `tool_result` — which MUST stay immediately adjacent to the
+	// assistant message carrying its matching `tool_use`/`tool_calls`, across all of
+	// Anthropic, Bedrock, and OpenAI (a 400 otherwise). The trailing-role guard
+	// (isPlainUserPrompt) therefore only splices before the last message when it is a
+	// plain user prompt; otherwise it APPENDS after the whole transcript, which both
+	// preserves that adjacency and is still fully cache-friendly (the entire prior
+	// transcript stays an untouched prefix).
+	const isPlainUserPrompt = (msg: {
+		role: string;
+		content: unknown;
+	}): boolean => {
+		if (msg.role !== "user") return false;
+		// String content is a plain prompt; only an array of content blocks can
+		// carry a tool_result, which must not be preceded by an injected message.
+		if (!Array.isArray(msg.content)) return true;
+		return !msg.content.some(
+			(block) =>
+				typeof block === "object" &&
+				block !== null &&
+				(block as { type?: unknown }).type === "tool_result",
+		);
+	};
 	// biome-ignore lint/suspicious/noExplicitAny: pi.on("context") overload has TS resolution bug
 	(pi as any).on(
 		"context",
@@ -1816,8 +1848,33 @@ export default function (pi: ExtensionAPI) {
 					(event as { messages?: Array<{ role: string; content: unknown }> })
 						?.messages ?? [];
 
+				// Empty transcript (no turns yet): fall back to prepend semantics —
+				// there is no trailing user message to sit before, and we must never
+				// emit empty input (fe0ed5da: OpenAI Responses fails on empty input).
+				if (existingMessages.length === 0) {
+					return { messages: [...injectedMessages] };
+				}
+
+				const lastMessage = existingMessages[existingMessages.length - 1];
+
+				// Mid-loop the tail can be a tool_result (or assistant/tool) message;
+				// inserting before it would break tool_use↔tool_result adjacency. Only
+				// splice before the last message when it is a plain user prompt.
+				if (!isPlainUserPrompt(lastMessage)) {
+					// Append after the whole transcript — pure append preserves the
+					// adjacency AND leaves the entire prior transcript as an untouched
+					// cache prefix.
+					return { messages: [...existingMessages, ...injectedMessages] };
+				}
+
+				// Insert the injected block just before the final message so
+				// messages[0] stays stable and the real user prompt stays trailing.
 				return {
-					messages: [...injectedMessages, ...existingMessages],
+					messages: [
+						...existingMessages.slice(0, -1),
+						...injectedMessages,
+						lastMessage,
+					],
 				};
 			} catch (err) {
 				dbg(`context event error: ${err}`);

--- a/tests/index-integration.test.ts
+++ b/tests/index-integration.test.ts
@@ -293,10 +293,29 @@ describe("index.ts integration", () => {
 		}
 	}, INTEGRATION_TIMEOUT_MS);
 
-	it("context handler prepends injected guidance before the user prompt", async () => {
+	// #1016: pi-lens injects ephemeral turn-end findings via the `context` event.
+	// The findings are spliced in IMMEDIATELY BEFORE the final message rather than
+	// prepended at index 0, so messages[0] stays byte-stable across turns and the
+	// prompt-cache prefix on prefix-caching providers (Anthropic/Bedrock) survives.
+	// The real user prompt stays as the trailing message (cache breakpoint), and the
+	// existing transcript is never dropped (fe0ed5da: never emit empty input).
+	async function loadContextHandler() {
 		const { default: registerExtension } = await import("../index.ts");
 		const { pi, handlers } = createMockPi();
 		registerExtension(pi as any);
+		const context = handlers.context?.[0];
+		expect(context).toBeTypeOf("function");
+		return context as IntegrationHook;
+	}
+	const injectedMatcher = expect.objectContaining({
+		role: "user",
+		content: expect.stringContaining(
+			"[pi-lens automated context — not a user request]",
+		),
+	});
+
+	it("context handler injects guidance immediately before the final user prompt", async () => {
+		const context = await loadContextHandler();
 
 		const cacheManager = new CacheManager(false);
 		cacheManager.writeCache(
@@ -305,26 +324,170 @@ describe("index.ts integration", () => {
 			tmpDir,
 		);
 
-		const context = handlers.context?.[0];
-		expect(context).toBeTypeOf("function");
+		// A realistic multi-turn transcript: assistant + prior user turns precede
+		// the current user prompt. (With a single-message transcript the old
+		// prepend and the new before-final placement coincide, so a multi-message
+		// transcript is required to actually exercise the #1016 change.)
+		const firstUser = { role: "user", content: "Start the task" };
+		const assistant = { role: "assistant", content: "On it." };
+		const finalUser = { role: "user", content: "Fix the bug" };
+		const existing = [firstUser, assistant, finalUser];
 
-		const userMessage = { role: "user", content: "Fix the bug" };
-		const result = await context?.(
-			{ messages: [userMessage] },
+		const result = (await context(
+			{ messages: existing },
 			{ cwd: tmpDir },
+		)) as { messages: Array<{ role: string; content: unknown }> };
+
+		// Full expected ordering: prior turns, then injected block, then the final
+		// user prompt — [firstUser, assistant, <injected>, finalUser].
+		expect(result).toEqual({
+			messages: [firstUser, assistant, injectedMatcher, finalUser],
+		});
+
+		// (1) #1016 index-0 stability: messages[0] is untouched. This is the
+		// property that FAILS on the old prepend code (injected findings landed at
+		// index 0), and it is the actual prompt-cache win.
+		expect(result.messages[0]).toEqual(firstUser);
+
+		// (2) Final message unchanged: same role + content as the incoming prompt.
+		const last = result.messages[result.messages.length - 1];
+		expect(last).toEqual(finalUser);
+		expect(last.role).toBe("user");
+
+		// (3) Injected block sits at length - 2, immediately before the final msg.
+		expect(result.messages[result.messages.length - 2]).toEqual(injectedMatcher);
+
+		// (5) Non-empty input preserved (fe0ed5da): every existing message survives.
+		expect(result.messages).toHaveLength(existing.length + 1);
+		for (const msg of existing) {
+			expect(result.messages).toContainEqual(msg);
+		}
+	}, INTEGRATION_TIMEOUT_MS);
+
+	it("context injection keeps the prior-conversation prefix byte-identical across turns (#1016 cache win)", async () => {
+		const firstUser = { role: "user", content: "Start the task" };
+		const assistant = { role: "assistant", content: "On it." };
+		const finalUser = { role: "user", content: "Fix the bug" };
+		const baseTranscript = () => [
+			{ ...firstUser },
+			{ ...assistant },
+			{ ...finalUser },
+		];
+
+		// Turn A
+		const contextA = await loadContextHandler();
+		new CacheManager(false).writeCache(
+			"session-start-guidance",
+			{ content: "Finding A" },
+			tmpDir,
+		);
+		const resultA = (await contextA(
+			{ messages: baseTranscript() },
+			{ cwd: tmpDir },
+		)) as { messages: Array<{ role: string; content: unknown }> };
+
+		// Turn B — same base transcript, different injected finding. Fresh module
+		// registration to mirror a second independent turn.
+		vi.resetModules();
+		const contextB = await loadContextHandler();
+		new CacheManager(false).writeCache(
+			"session-start-guidance",
+			{ content: "Completely different Finding B" },
+			tmpDir,
+		);
+		const resultB = (await contextB(
+			{ messages: baseTranscript() },
+			{ cwd: tmpDir },
+		)) as { messages: Array<{ role: string; content: unknown }> };
+
+		// The prior conversation prefix (everything up to but excluding the
+		// injection point at length - 2) is identical between the two turns — this
+		// is exactly what a prefix-caching provider reuses.
+		const prefixA = resultA.messages.slice(0, resultA.messages.length - 2);
+		const prefixB = resultB.messages.slice(0, resultB.messages.length - 2);
+		expect(prefixA).toEqual(prefixB);
+		expect(prefixA).toEqual([firstUser, assistant]);
+
+		// They diverge only at the injection slot.
+		expect(resultA.messages[resultA.messages.length - 2]).not.toEqual(
+			resultB.messages[resultB.messages.length - 2],
+		);
+		// ...and reconverge on the trailing user prompt.
+		expect(resultA.messages[resultA.messages.length - 1]).toEqual(finalUser);
+		expect(resultB.messages[resultB.messages.length - 1]).toEqual(finalUser);
+	}, INTEGRATION_TIMEOUT_MS);
+
+	it("context handler falls back to prepend for an empty transcript (fe0ed5da: never empty input)", async () => {
+		const context = await loadContextHandler();
+		new CacheManager(false).writeCache(
+			"session-start-guidance",
+			{ content: "Use pi-lens tools when useful." },
+			tmpDir,
 		);
 
-		expect(result).toEqual({
-			messages: [
-				expect.objectContaining({
-					role: "user",
-					content: expect.stringContaining(
-						"[pi-lens automated context — not a user request]",
-					),
-				}),
-				userMessage,
-			],
-		});
+		const result = (await context({ messages: [] }, { cwd: tmpDir })) as {
+			messages: Array<{ role: string; content: unknown }>;
+		};
+
+		// Degenerate case: no trailing message to sit before, so we emit just the
+		// injected block (identical to pre-#1016 behavior) — never empty input.
+		expect(result.messages.length).toBeGreaterThan(0);
+		expect(result.messages[0]).toEqual(injectedMatcher);
+	}, INTEGRATION_TIMEOUT_MS);
+
+	it("context handler appends (does NOT splice before) a trailing tool_result so tool_use/tool_result adjacency survives mid-loop (#1016 guard)", async () => {
+		const context = await loadContextHandler();
+		new CacheManager(false).writeCache(
+			"session-start-guidance",
+			{ content: "Use pi-lens tools when useful." },
+			tmpDir,
+		);
+
+		// Mid-agentic-loop continuation: the tail is an assistant `tool_use` block
+		// immediately followed by the matching `user` `tool_result`. The `context`
+		// event fires on this call too, and splicing an injected `user` message
+		// BETWEEN them yields a 400 ("tool_use ids were found without tool_result
+		// blocks") on Anthropic/Bedrock/OpenAI. The injected findings must therefore
+		// be APPENDED after the tool_result, never inserted before it.
+		const firstUser = { role: "user", content: "Start the task" };
+		const toolUse = {
+			role: "assistant",
+			content: [{ type: "tool_use", id: "tu_1", name: "read", input: {} }],
+		};
+		const toolResult = {
+			role: "user",
+			content: [{ type: "tool_result", tool_use_id: "tu_1", content: "ok" }],
+		};
+		const existing = [firstUser, toolUse, toolResult];
+
+		const result = (await context(
+			{ messages: existing },
+			{ cwd: tmpDir },
+		)) as { messages: Array<{ role: string; content: unknown }> };
+
+		// tool_result stays IMMEDIATELY after its tool_use — nothing spliced between.
+		const toolUseIdx = result.messages.findIndex((m) => m === toolUse);
+		expect(toolUseIdx).toBeGreaterThanOrEqual(0);
+		expect(result.messages[toolUseIdx + 1]).toBe(toolResult);
+
+		// The findings are appended AFTER the whole transcript, not before the tail.
+		expect(result.messages.slice(0, existing.length)).toEqual(existing);
+		expect(result.messages[result.messages.length - 1]).toEqual(injectedMatcher);
+
+		// index-0 stability still holds (cache prefix preserved).
+		expect(result.messages[0]).toEqual(firstUser);
+	}, INTEGRATION_TIMEOUT_MS);
+
+	it("context handler is a no-op when there is nothing to inject", async () => {
+		const context = await loadContextHandler();
+		// No cache written → nothing to inject → handler returns undefined (no
+		// override), so a non-injecting turn is byte-identical to no handler.
+		const finalUser = { role: "user", content: "Fix the bug" };
+		const result = await context(
+			{ messages: [finalUser] },
+			{ cwd: tmpDir },
+		);
+		expect(result).toBeUndefined();
 	}, INTEGRATION_TIMEOUT_MS);
 
 	it("tool_call records full-file reads from read.path with full line coverage", async () => {

--- a/tests/index-wiring.test.ts
+++ b/tests/index-wiring.test.ts
@@ -323,7 +323,12 @@ describe("index.ts extension wiring", () => {
 			// Flip it on through the real command handler.
 			await pi.runCommand("lens-context-toggle", "", makeCtx({ cwd: tmp }));
 
-			// Now the same hook prepends the cached findings ahead of existing messages.
+			// Now the same hook injects the cached findings into the transcript.
+			// The lone existing message is a `system` message (not a plain user
+			// prompt), so the #1016 placement guard appends the findings after it
+			// rather than prepending — the original message stays first (so a real
+			// user prompt / system preamble keeps its position and the prompt-cache
+			// prefix), and the findings land at the tail.
 			const on = (await pi.emit(
 				"context",
 				{ messages: existing },
@@ -331,8 +336,8 @@ describe("index.ts extension wiring", () => {
 			)) as { messages: Array<{ role: string; content: string }> } | undefined;
 
 			expect(on?.messages, "expected injected messages").toBeDefined();
-			expect(on?.messages[0].content).toMatch(/TESTFINDINGS_XYZZY/);
-			expect(on?.messages.at(-1)).toEqual({ role: "system", content: "orig" });
+			expect(on?.messages[0]).toEqual({ role: "system", content: "orig" });
+			expect(on?.messages.at(-1)?.content).toMatch(/TESTFINDINGS_XYZZY/);
 		});
 	});
 


### PR DESCRIPTION
## Problem (#1016)

pi-lens injects ephemeral turn-end / nudge findings into the provider message array via the `context` event handler. The old code **prepended at index 0** every turn, flipping `messages[0]` and invalidating the **entire prompt-cache prefix on every injecting turn** — for every prefix-caching provider (Anthropic, Bedrock, **and** OpenAI). On long sessions this re-bills the whole conversation each turn.

## Fix

Insert the findings **immediately before the final message** instead of at index 0, so `messages[0]` stays byte-stable and the prior conversation stays cached; the real user prompt stays trailing (preserving the Anthropic/Bedrock trailing-`user` cache breakpoint).

### Trailing-role guard (the important part)

The `context` event fires before **every** provider call, not just at turn boundaries (`clients/agent-nudge.ts`). Mid-agentic-loop the tail is often a `tool_result`, which **must stay immediately adjacent** to the assistant message carrying its `tool_use`/`tool_calls` (HTTP 400 otherwise, on all three providers). So:

- **Plain user-prompt tail** → splice findings before it (cache-friendly, user prompt stays last).
- **tool_result / assistant / any non-plain-user tail** → **append** findings after the whole transcript. Pure append preserves tool_use↔tool_result adjacency *and* keeps the full prior transcript as an untouched cache prefix.
- **Empty transcript** → prepend fallback (`fe0ed5da`: never emit empty input).

All four injection sources (session guidance, turn-end findings, test findings, agent nudge — including actionable warnings) funnel through this single seam, so the guard covers all of them.

## Tests

Adds a regression test asserting a trailing `tool_result` stays adjacent to its `tool_use` (findings appended, not spliced between). **Verified to fail on the pre-guard code.** Existing #1016 tests (index-0 stability, prefix byte-stability, plain-user before-final placement, empty-transcript fallback) still pass — `vitest tests/index-integration.test.ts` 22/22 green; full `tsc` + `build:dist` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)