### PR TITLE
feat(observability): prompt-cache usage logging + request-side prefix-stability guard (closes #1018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Prompt-cache observability (refs #1018, closes #1018)** — two provider-independent
+	signals now land in `~/.pi-lens/latency.log` as `type: "phase"` records.
+	(1) Response-side: a defensively feature-detected `message_end` subscription
+	(clients/agent-nudge.ts pattern — guarded, never throws on older hosts) logs one
+	`cache_usage` record per assistant message that carries a `usage`, with
+	`metadata: { provider, model, cacheRead, cacheWrite, input, output, cost }`
+	(provider/model read straight off the assistant message; `cost` is the total).
+	Messages with no usage (or non-assistant messages) are skipped rather than
+	logged as zeros. (2) Request-side: the existing `context` handler now hashes
+	`messages[0]` on every call and logs a `cache_prefix_break` record
+	(`metadata: { turnIndex, previousHash, currentHash, sessionId, sessionRole }`,
+	plus a baseline record on first observation) whenever that hash changes
+	turn-over-turn — a regression guard that flags anything (pi-lens or otherwise)
+	breaking the byte-stable prefix #1016 established. The baseline is keyed by the
+	stable per-session id (`ctx.sessionManager.getSessionId()`) in a small bounded
+	LRU, so a resume/reload keeps comparing against its own baseline while a
+	new/fork or a concurrent in-process subagent (#473) gets an independent baseline
+	instead of a spurious cross-session break; each record is tagged with the
+	read-only #473 `sessionRole` classification, and a primary `session_shutdown`
+	drops the ended session's entry. The hash is pure observation: it never changes
+	the handler's injection behavior or return value, and runs even on non-injecting
+	turns. New `clients/cache-observability.ts`; no new dependencies.
+
 - **Cache-friendly ephemeral context injection (refs #1016, closes #1016)** — the
 	`context` event handler in `index.ts` now splices pi-lens's ephemeral turn-end
 	findings in **immediately before the final message** instead of prepending them

--- a/clients/cache-observability.ts
+++ b/clients/cache-observability.ts
@@ -1,0 +1,239 @@
+/**
+ * Prompt-cache observability (#1018).
+ *
+ * Two provider-independent signals, both sinking into ~/.pi-lens/latency.log
+ * via {@link logLatency} (matching the neighboring `type: "phase"` records):
+ *
+ *   1. Response-side cache usage (`cache_usage`) — on each assistant
+ *      `message_end`, record the provider-reported token/cost breakdown so a
+ *      session's actual cacheRead/cacheWrite behavior is queryable after the
+ *      fact. This is what the provider DID, not what we hoped it would do.
+ *
+ *   2. Request-side prefix stability (`cache_prefix_break`) — a content hash of
+ *      `messages[0]` observed on every `context` call. After #1016 the first
+ *      message must stay byte-stable across a whole session; a logged CHANGE
+ *      flags that something (pi-lens or otherwise) broke the cache prefix, which
+ *      would silently invalidate the entire prompt-cache on every prefix-caching
+ *      provider. Pure observation — it never alters context injection.
+ *
+ * Both paths are defensive: `usage` (and its fields) may be absent on older
+ * hosts or non-assistant messages, so every access is guarded and the handlers
+ * never throw — on error they `dbg(...)` and no-op, like the other index.ts
+ * event handlers.
+ */
+import { createHash } from "node:crypto";
+import { logLatency } from "./latency-logger.js";
+
+/** Shape we defensively read off an assistant `AgentMessage` (see pi-ai types). */
+interface AssistantUsageLike {
+	input?: number;
+	output?: number;
+	cacheRead?: number;
+	cacheWrite?: number;
+	cacheWrite1h?: number;
+	reasoning?: number;
+	totalTokens?: number;
+	cost?: {
+		input?: number;
+		output?: number;
+		cacheRead?: number;
+		cacheWrite?: number;
+		total?: number;
+	};
+}
+
+interface AssistantMessageLike {
+	role?: unknown;
+	provider?: unknown;
+	model?: unknown;
+	responseModel?: unknown;
+	usage?: unknown;
+}
+
+/**
+ * Part 1 — log one `cache_usage` record for an assistant `message_end` that
+ * carries a `usage`. Provider/model come straight off the message itself
+ * (`AssistantMessage.provider` / `.model` in pi-ai) — no dependency on the
+ * runtime telemetry identity. Skips silently (no record) when the message is
+ * not an assistant message or has no usage; never logs a zeros-only record for
+ * a message that simply lacks usage.
+ */
+export function logCacheUsage(
+	message: unknown,
+	dbg?: (msg: string) => void,
+): void {
+	try {
+		if (!message || typeof message !== "object") return;
+		const msg = message as AssistantMessageLike;
+		// Only assistant messages carry LLM usage; tool-result / user messages
+		// (and unknown custom AgentMessage variants) are skipped.
+		if (msg.role !== "assistant") return;
+		const usage = msg.usage;
+		if (!usage || typeof usage !== "object") return;
+		const u = usage as AssistantUsageLike;
+		logLatency({
+			type: "phase",
+			filePath: "<pi-lens>",
+			phase: "cache_usage",
+			durationMs: 0,
+			metadata: {
+				provider: typeof msg.provider === "string" ? msg.provider : undefined,
+				model: typeof msg.model === "string" ? msg.model : undefined,
+				cacheRead: u.cacheRead,
+				cacheWrite: u.cacheWrite,
+				input: u.input,
+				output: u.output,
+				// `Usage.cost` is a breakdown object; the total is the headline number.
+				cost: u.cost?.total,
+			},
+		});
+	} catch (err) {
+		dbg?.(`cache-usage: failed to log message_end usage: ${err}`);
+	}
+}
+
+/**
+ * Content hash of the first transcript message. Stable for identical content
+ * (role + content are serialized in a fixed order), so a changing hash means
+ * `messages[0]` actually changed byte-for-byte.
+ */
+function hashFirstMessage(first: { role?: unknown; content?: unknown }): string {
+	const serialized = JSON.stringify({ role: first.role, content: first.content });
+	return createHash("sha256").update(serialized).digest("hex");
+}
+
+/**
+ * Per-session baseline hash of `messages[0]`, keyed by the STABLE pi session id
+ * (`ctx.sessionManager.getSessionId()`). A single module-scoped var was wrong:
+ * in ONE process, multiple logical conversations touch this module, and they
+ * must not share a baseline —
+ *   - new / fork / a concurrent in-process subagent (#473) is a DIFFERENT id →
+ *     its OWN independent baseline, never compared against another id's (else a
+ *     benign session boundary logs a spurious `cache_prefix_break`, and a
+ *     concurrent subagent + its parent stomp each other's baseline, each
+ *     emitting a false positive — fatal for a signal whose value is trust);
+ *   - resume / reload reuse the SAME id → the baseline persists in-process, so a
+ *     genuine break induced by the resume is still caught (no blinding reset).
+ *
+ * Bounded as an insertion-ordered LRU (evict oldest-inserted past the cap) so a
+ * long-lived process cycling through many sessions can't grow this unbounded.
+ */
+const MAX_TRACKED_SESSIONS = 32;
+const prefixHashBySession = new Map<string, string>();
+
+/**
+ * Bucket key used when no session id is available (undefined/empty). Degrades
+ * gracefully to the old single-var semantics — one shared baseline — rather than
+ * throwing or dropping the signal.
+ */
+const NO_SESSION_KEY = "<no-session>";
+
+/**
+ * Store `hash` for `key`, refreshing its LRU recency (re-insert moves it to the
+ * newest position since `Map` preserves insertion order) and evicting the
+ * oldest-inserted entries once the cap is exceeded.
+ */
+function recordSessionHash(key: string, hash: string): void {
+	prefixHashBySession.delete(key);
+	prefixHashBySession.set(key, hash);
+	while (prefixHashBySession.size > MAX_TRACKED_SESSIONS) {
+		const oldest = prefixHashBySession.keys().next().value;
+		if (oldest === undefined) break;
+		prefixHashBySession.delete(oldest);
+	}
+}
+
+/**
+ * Part 2 — observe `messages[0]` stability turn-over-turn, keyed by session id.
+ * Logs a baseline the first time it sees a non-empty transcript FOR A GIVEN
+ * session id, then logs a `cache_prefix_break` whenever that same session's
+ * first-message hash changes. Pure observation: it never inspects or mutates
+ * anything but its own per-session hash map, and never throws.
+ *
+ * `sessionId` should be pi's STABLE id (`ctx.sessionManager.getSessionId()`),
+ * which uniquely identifies the CURRENTLY-firing session: a concurrent
+ * in-process subagent runs its own `AgentSession`/`sessionManager`, so its
+ * `context` calls carry a DIFFERENT id than the parent's and get their own
+ * baseline. (`runtime.telemetrySessionId` cannot be used here: per the #473
+ * guard a concurrent secondary skips `updateRuntimeIdentityFromEvent`, so that
+ * process-global singleton stays pinned to the PARENT — it would collapse
+ * parent and subagent onto one baseline.) Residual limitation: if the host ever
+ * does NOT supply a stable id, all such sessions collapse onto `NO_SESSION_KEY`
+ * and behave like the old single-var (a concurrent subagent could then still
+ * cross-contaminate) — accepted as graceful degradation, not silently perfect.
+ *
+ * Does nothing on an empty transcript (nothing to anchor a prefix to yet).
+ */
+export function observeCachePrefix(
+	messages: ReadonlyArray<{ role?: unknown; content?: unknown }> | undefined,
+	turnIndex: number,
+	sessionId?: string,
+	sessionRole?: "primary" | "concurrent-secondary",
+	dbg?: (msg: string) => void,
+): void {
+	try {
+		if (!messages || messages.length === 0) return;
+		const first = messages[0];
+		if (!first || typeof first !== "object") return;
+		const key = sessionId?.trim() ? sessionId.trim() : NO_SESSION_KEY;
+		const currentHash = hashFirstMessage(first);
+		const previousHash = prefixHashBySession.get(key);
+		if (previousHash === undefined) {
+			// Baseline: record this session's starting prefix so a later break has a
+			// reference point in the log. `previousHash: null` marks the baseline.
+			recordSessionHash(key, currentHash);
+			logLatency({
+				type: "phase",
+				filePath: "<pi-lens>",
+				phase: "cache_prefix_break",
+				durationMs: 0,
+				metadata: {
+					turnIndex,
+					previousHash: null,
+					currentHash,
+					baseline: true,
+					sessionId: key,
+					sessionRole,
+				},
+			});
+			return;
+		}
+		if (currentHash !== previousHash) {
+			logLatency({
+				type: "phase",
+				filePath: "<pi-lens>",
+				phase: "cache_prefix_break",
+				durationMs: 0,
+				metadata: {
+					turnIndex,
+					previousHash,
+					currentHash,
+					sessionId: key,
+					sessionRole,
+				},
+			});
+		}
+		// Refresh recency (and update the stored hash after a break) so an active
+		// session stays warm in the LRU and isn't evicted while still in use.
+		recordSessionHash(key, currentHash);
+	} catch (err) {
+		dbg?.(`cache-prefix: failed to observe messages[0]: ${err}`);
+	}
+}
+
+/**
+ * Drop a single session's prefix baseline. Called from the `session_shutdown`
+ * handler (primary path only — the concurrent-secondary guard there returns
+ * first, and the LRU cap backstops any secondary entry left behind) so an ended
+ * conversation's entry is reclaimed promptly rather than only when the LRU
+ * evicts it. Idempotent and never throws.
+ */
+export function clearCachePrefixSession(sessionId?: string): void {
+	const key = sessionId?.trim() ? sessionId.trim() : NO_SESSION_KEY;
+	prefixHashBySession.delete(key);
+}
+
+/** Clear all per-session prefix hashes. For tests / session boundaries. */
+export function resetCachePrefixObservation(): void {
+	prefixHashBySession.clear();
+}

--- a/index.ts
+++ b/index.ts
@@ -116,6 +116,11 @@ import { createProjectReportTool } from "./tools/project-report.js";
 import { createSymbolSearchTool } from "./tools/symbol-search.js";
 import { logLatency } from "./clients/latency-logger.js";
 import {
+	clearCachePrefixSession,
+	logCacheUsage,
+	observeCachePrefix,
+} from "./clients/cache-observability.js";
+import {
 	getPiLensEvalMs,
 	markPiLensLoaded,
 	PI_LENS_HOST_BOOT_MS,
@@ -1769,6 +1774,12 @@ export default function (pi: ExtensionAPI) {
 			return;
 		}
 
+		// #1018: drop this (primary) session's prefix baseline now it has ended,
+		// so its entry is reclaimed promptly instead of lingering until the LRU
+		// evicts it. Respects the #473 guard above (a concurrent-secondary
+		// shutdown returned already, so its entry is left for the LRU backstop).
+		clearCachePrefixSession(stableSessionId);
+
 		cancelLSPIdleReset();
 		// #449 slice 1: SYNC-only deregistration (no child spawns — see the
 		// processExiting note below); safe to call unconditionally here.
@@ -1783,6 +1794,26 @@ export default function (pi: ExtensionAPI) {
 		// cross-process instance registry's orphan reaper as the backstop (#472).
 		resetLSPService({ fast: true, processExiting: true, reason: "session_shutdown" });
 	});
+
+	// --- Prompt-cache response-side usage observability (#1018) ---
+	// On each assistant message_end, append ONE `cache_usage` latency record with
+	// the provider-reported token/cost breakdown. `message_end` is a newer host
+	// event; register defensively (clients/agent-nudge.ts pattern) — guard `pi.on`,
+	// wrap in try/catch, and never throw out of the handler — so an older pi host
+	// that never fires it simply produces no records rather than crashing wireup.
+	try {
+		// biome-ignore lint/suspicious/noExplicitAny: message_end overload absent on older host types
+		(pi as any).on?.("message_end", (event: { message?: unknown } | unknown) => {
+			if (!lensEnabled) return;
+			try {
+				logCacheUsage((event as { message?: unknown })?.message, dbg);
+			} catch (err) {
+				dbg(`message_end handler error: ${err}`);
+			}
+		});
+	} catch (err) {
+		dbg(`message_end subscribe failed (older pi host?): ${err}`);
+	}
 
 	// --- Inject turn-end findings into next agent turn ---
 	// jscpd, madge, and turn-end delta results are cached at turn_end and consumed here
@@ -1829,9 +1860,34 @@ export default function (pi: ExtensionAPI) {
 			event: { messages?: Array<{ role: string; content: unknown }> } | unknown,
 			ctx: { cwd?: string },
 		) => {
-			if (!lensEnabled || !contextInjectionEnabled) return;
+			if (!lensEnabled) return;
 			try {
 				const cwd = ctx.cwd ?? process.cwd();
+
+				const existingMessages =
+					(event as { messages?: Array<{ role: string; content: unknown }> })
+						?.messages ?? [];
+
+				// #1018 request-side prefix-stability guard. Pure observation — it runs
+				// on EVERY context call (including non-injecting turns and, above, when
+				// injection is disabled) so a cache-prefix break caused by pi-lens OR
+				// anything else is caught, and it never alters the return value below.
+				// Keyed by the STABLE per-session id (`ctx.sessionManager.getSessionId()`,
+				// same source session_start/#473 use) so a concurrent in-process subagent
+				// gets its own baseline instead of stomping the parent's, and tagged with
+				// the read-only #473 classification so the log is self-describing.
+				const prefixSessionId = getStableSessionId(ctx);
+				observeCachePrefix(
+					existingMessages,
+					runtime.turnIndex,
+					prefixSessionId,
+					classifyCurrentSessionEmission(ctx, prefixSessionId),
+					dbg,
+				);
+
+				// Injection is separately gated; when disabled we still observed above.
+				if (!contextInjectionEnabled) return;
+
 				const turnEndFindings = consumeTurnEndFindings(cacheManager, cwd);
 				const sessionGuidance = consumeSessionStartGuidance(cacheManager, cwd);
 				const testFindings = consumeTestFindings(cacheManager, cwd);
@@ -1843,10 +1899,6 @@ export default function (pi: ExtensionAPI) {
 					...(agentNudge?.messages ?? []),
 				];
 				if (injectedMessages.length === 0) return;
-
-				const existingMessages =
-					(event as { messages?: Array<{ role: string; content: unknown }> })
-						?.messages ?? [];
 
 				// Empty transcript (no turns yet): fall back to prepend semantics —
 				// there is no trailing user message to sit before, and we must never

--- a/tests/clients/cache-observability.test.ts
+++ b/tests/clients/cache-observability.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LatencyEntry } from "../../clients/latency-logger.js";
+
+const latencyEntries = vi.hoisted(() => [] as LatencyEntry[]);
+vi.mock("../../clients/latency-logger.js", () => ({
+	logLatency: (entry: LatencyEntry) => latencyEntries.push(entry),
+}));
+
+import {
+	clearCachePrefixSession,
+	logCacheUsage,
+	observeCachePrefix,
+	resetCachePrefixObservation,
+} from "../../clients/cache-observability.js";
+
+function assistantMessage(overrides?: Record<string, unknown>) {
+	return {
+		role: "assistant",
+		provider: "anthropic",
+		model: "claude-opus-4",
+		usage: {
+			input: 1200,
+			output: 340,
+			cacheRead: 8000,
+			cacheWrite: 512,
+			totalTokens: 9540,
+			cost: {
+				input: 0.01,
+				output: 0.02,
+				cacheRead: 0.003,
+				cacheWrite: 0.004,
+				total: 0.037,
+			},
+		},
+		stopReason: "stop",
+		timestamp: 0,
+		...overrides,
+	};
+}
+
+describe("cache-observability — response-side usage (#1018)", () => {
+	beforeEach(() => {
+		latencyEntries.length = 0;
+	});
+
+	it("logs one cache_usage record for an assistant message that carries usage", () => {
+		logCacheUsage(assistantMessage());
+
+		expect(latencyEntries).toEqual([
+			{
+				type: "phase",
+				filePath: "<pi-lens>",
+				phase: "cache_usage",
+				durationMs: 0,
+				metadata: {
+					provider: "anthropic",
+					model: "claude-opus-4",
+					cacheRead: 8000,
+					cacheWrite: 512,
+					input: 1200,
+					output: 340,
+					cost: 0.037,
+				},
+			},
+		]);
+	});
+
+	it("logs nothing for an assistant message with no usage (does not throw)", () => {
+		expect(() =>
+			logCacheUsage(assistantMessage({ usage: undefined })),
+		).not.toThrow();
+		expect(latencyEntries).toHaveLength(0);
+	});
+
+	it("logs nothing for a non-assistant (tool_result / user) message", () => {
+		logCacheUsage({
+			role: "toolResult",
+			toolName: "read",
+			usage: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		});
+		logCacheUsage({ role: "user", content: "hi" });
+		expect(latencyEntries).toHaveLength(0);
+	});
+
+	it("never throws on malformed input", () => {
+		expect(() => logCacheUsage(undefined)).not.toThrow();
+		expect(() => logCacheUsage(null)).not.toThrow();
+		expect(() => logCacheUsage("nope")).not.toThrow();
+		expect(latencyEntries).toHaveLength(0);
+	});
+});
+
+describe("cache-observability — request-side prefix stability (#1018)", () => {
+	beforeEach(() => {
+		latencyEntries.length = 0;
+		resetCachePrefixObservation();
+	});
+
+	const first = { role: "user", content: "the original first user turn" };
+	const changed = { role: "user", content: "a DIFFERENT first user turn" };
+	const SID = "session-alpha";
+
+	it("logs a baseline on first observation, then a break when messages[0] changes", () => {
+		observeCachePrefix([first, { role: "assistant", content: "ok" }], 0, SID, "primary");
+		expect(latencyEntries).toHaveLength(1);
+		const baseline = latencyEntries[0];
+		expect(baseline.phase).toBe("cache_prefix_break");
+		expect(baseline.metadata?.baseline).toBe(true);
+		expect(baseline.metadata?.previousHash).toBeNull();
+		expect(baseline.metadata?.sessionId).toBe(SID);
+		expect(baseline.metadata?.sessionRole).toBe("primary");
+		const baselineHash = baseline.metadata?.currentHash as string;
+		expect(typeof baselineHash).toBe("string");
+
+		// messages[0] changed within the SAME session -> one break record.
+		observeCachePrefix([changed, { role: "assistant", content: "ok" }], 1, SID, "primary");
+		expect(latencyEntries).toHaveLength(2);
+		const brk = latencyEntries[1];
+		expect(brk).toMatchObject({
+			type: "phase",
+			filePath: "<pi-lens>",
+			phase: "cache_prefix_break",
+			durationMs: 0,
+		});
+		expect(brk.metadata?.turnIndex).toBe(1);
+		expect(brk.metadata?.previousHash).toBe(baselineHash);
+		expect(brk.metadata?.currentHash).not.toBe(baselineHash);
+		expect(brk.metadata?.baseline).toBeUndefined();
+		expect(brk.metadata?.sessionId).toBe(SID);
+	});
+
+	it("logs NOTHING when messages[0] is identical across calls (same session)", () => {
+		observeCachePrefix([first, { role: "assistant", content: "turn 1" }], 0, SID);
+		expect(latencyEntries).toHaveLength(1); // baseline only
+
+		// Same messages[0] content, different later messages / turnIndex — no break.
+		observeCachePrefix([first, { role: "assistant", content: "turn 2 differs" }], 1, SID);
+		observeCachePrefix([{ role: "user", content: "the original first user turn" }], 2, SID);
+		expect(latencyEntries).toHaveLength(1);
+	});
+
+	it("does NOT log a break when a DIFFERENT session id first appears (subagent/new)", () => {
+		// Parent session establishes its baseline.
+		observeCachePrefix([first], 0, "session-parent", "primary");
+		expect(latencyEntries).toHaveLength(1);
+
+		// A concurrent subagent (different id) with a DIFFERENT messages[0] must NOT
+		// be compared against the parent — it gets its OWN baseline, no break.
+		observeCachePrefix([changed], 0, "session-subagent", "concurrent-secondary");
+		expect(latencyEntries).toHaveLength(2);
+		const sub = latencyEntries[1];
+		expect(sub.metadata?.baseline).toBe(true);
+		expect(sub.metadata?.previousHash).toBeNull();
+		expect(sub.metadata?.sessionId).toBe("session-subagent");
+		expect(sub.metadata?.sessionRole).toBe("concurrent-secondary");
+		expect(
+			latencyEntries.some((e) => e.metadata?.baseline === undefined),
+		).toBe(false); // no break record emitted for either session
+	});
+
+	it("keeps two concurrent sessions' baselines independent (no cross-contamination)", () => {
+		observeCachePrefix([first], 0, "sid-A", "primary");
+		observeCachePrefix([changed], 0, "sid-B", "concurrent-secondary");
+		latencyEntries.length = 0;
+
+		// Each session re-observing its OWN unchanged messages[0] => no break.
+		observeCachePrefix([first], 1, "sid-A", "primary");
+		observeCachePrefix([changed], 1, "sid-B", "concurrent-secondary");
+		expect(latencyEntries).toHaveLength(0);
+	});
+
+	it("resume: same session id across rounds keeps the baseline and catches a real break", () => {
+		observeCachePrefix([first], 0, "resumed-session");
+		expect(latencyEntries).toHaveLength(1); // baseline
+
+		// Simulate resume: SAME id observes again; unchanged => still no break.
+		observeCachePrefix([first], 1, "resumed-session");
+		expect(latencyEntries).toHaveLength(1);
+
+		// A genuine post-resume change to messages[0] IS caught.
+		observeCachePrefix([changed], 2, "resumed-session");
+		expect(latencyEntries).toHaveLength(2);
+		expect(latencyEntries[1].metadata?.baseline).toBeUndefined();
+		expect(latencyEntries[1].metadata?.sessionId).toBe("resumed-session");
+	});
+
+	it("clearCachePrefixSession drops one session's baseline (re-baselines on next observe)", () => {
+		observeCachePrefix([first], 0, "shutdown-session");
+		expect(latencyEntries).toHaveLength(1);
+
+		clearCachePrefixSession("shutdown-session");
+
+		// After clearing, the next observation re-logs a baseline (not a break),
+		// even with a changed messages[0].
+		observeCachePrefix([changed], 1, "shutdown-session");
+		expect(latencyEntries).toHaveLength(2);
+		expect(latencyEntries[1].metadata?.baseline).toBe(true);
+		expect(latencyEntries[1].metadata?.previousHash).toBeNull();
+	});
+
+	it("falls back to a single bucket when no session id is given", () => {
+		observeCachePrefix([first], 0);
+		expect(latencyEntries).toHaveLength(1);
+		expect(latencyEntries[0].metadata?.sessionId).toBe("<no-session>");
+
+		// Same fallback bucket, changed messages[0] => a break (old single-var semantics).
+		observeCachePrefix([changed], 1);
+		expect(latencyEntries).toHaveLength(2);
+		expect(latencyEntries[1].metadata?.baseline).toBeUndefined();
+		expect(latencyEntries[1].metadata?.sessionId).toBe("<no-session>");
+	});
+
+	it("LRU bound evicts oldest sessions past the cap without throwing", () => {
+		// Cap is 32; establish 40 distinct sessions, then re-observe the OLDEST.
+		for (let i = 0; i < 40; i++) {
+			observeCachePrefix([{ role: "user", content: `s${i}` }], 0, `lru-${i}`);
+		}
+		expect(latencyEntries).toHaveLength(40); // 40 baselines
+		latencyEntries.length = 0;
+
+		// lru-0 was evicted; re-observing it re-baselines rather than diffing.
+		expect(() =>
+			observeCachePrefix([{ role: "user", content: "s0" }], 1, "lru-0"),
+		).not.toThrow();
+		expect(latencyEntries).toHaveLength(1);
+		expect(latencyEntries[0].metadata?.baseline).toBe(true);
+	});
+
+	it("does nothing on an empty transcript and never throws", () => {
+		expect(() => observeCachePrefix([], 0, SID)).not.toThrow();
+		expect(() => observeCachePrefix(undefined, 0, SID)).not.toThrow();
+		expect(latencyEntries).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
Adds two provider-independent prompt-cache observability signals, both sinking into `~/.pi-lens/latency.log` via the existing `logLatency` helper (no new logging infra). Motivated by #1016 — we were reasoning about cache behavior blind.

## Part 1 — response-side cache usage (`cache_usage`)
Subscribes to the host `message_end` lifecycle event (feature-detected, silent no-op on older hosts). On each assistant message carrying `usage`, logs one record: `{ provider, model, cacheRead, cacheWrite, input, output, cost }`. This is what the provider actually DID — `cacheRead` should dominate turn-over-turn in a stable session, directly confirming #1016. Query: `grep cache_usage ~/.pi-lens/latency.log`.

## Part 2 — request-side prefix stability (`cache_prefix_break`)
In the `context` handler, hashes `messages[0]` each call and logs a break when it changes turn-over-turn — a permanent, provider-independent regression guard for #1016 (messages[0] must stay byte-stable across a session, or the whole prompt-cache prefix is invalidated).

### Session-keyed (handles resume / fork / reload / subagents)
The baseline is keyed by the stable pi session id (`ctx.sessionManager.getSessionId()`), not a single module var, so:
- **new / fork / concurrent in-process subagent (#473)** → different id → its own baseline; no cross-contamination, no spurious break at a benign session boundary.
- **resume / reload** → same id → baseline persists in-process, so a genuine resume-induced break is still caught.

Reuses existing session infra rather than re-deriving it: `classifyCurrentSessionEmission` (tags each record `sessionRole: primary|concurrent-secondary`), and the existing `session_shutdown` handler (gated behind the #473 concurrent-secondary guard) drops a primary session's entry on shutdown. Bounded LRU (32) as a leak backstop. `runtime.telemetrySessionId` was explicitly rejected — the #473 guard pins it to the parent, collapsing subagent + parent onto one baseline.

### Metadata shapes
- `cache_usage`: `{ provider, model, cacheRead, cacheWrite, input, output, cost }`
- `cache_prefix_break` (break): `{ turnIndex, previousHash, currentHash, sessionId, sessionRole }`; baseline: same + `{ previousHash: null, baseline: true }`.

## Tests / verification
`tests/clients/cache-observability.test.ts`: baseline-per-session, break within a session, no-break across different ids (new/subagent), two-concurrent-session independence, resume keeps baseline + catches a real break, teardown re-baselines, `<no-session>` fallback, LRU eviction, empty transcript. Full suite green except one confirmed-unrelated flaky LSP test (`ast-grep-rule-precedence-followups`, passes 3/3 in isolation — touches nothing in this change); full `tsc` + `build:dist` clean.

Closes #1018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)