### PR TITLE
fix(widget-state): normalize files-map path key so mode=all stops replaying a resolved blocker (closes #1020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **`lens_diagnostics mode=all` no longer replays a resolved blocker (refs #1020, closes #1020)** —
+	the widget-state `files` map was keyed by the raw, non-normalized path string,
+	so the SAME file could land under two different key forms in one session:
+	the forward-slash form (`C:/…/x.ts`) the LSP client + cascade fold produce via
+	`normalizeFilePath`, and the backslash form (`C:\…\x.ts`) that `mode=full`'s
+	clean reconcile (`result.filePath`) and `path.resolve`/event inputs produce on
+	Windows. A stale blocking entry and the fresh clean entry then coexisted as two
+	separate map entries. `mode=full` rendered clean because its merge re-keys every
+	summary through `path.resolve`, but `mode=all`'s `formatAllMode` reads
+	`getFileDiagnosticSummaries()` verbatim with no dedup, so it saw both and
+	rendered the stale entry's `blocking:1` as a 🔴 — a resolved state that replayed
+	as still-broken on every `mode=all` (worst on Windows + resumed sessions), and a
+	#533 honesty failure since the tool prompt tells agents to use `mode=all` to
+	verify no blockers remain. Fixed at source: every write/read seam on the `files`
+	map (and the `diagnosticsWriteGuard`) now folds its key through one normalizer,
+	`normalizeEphemeralMapKey` (slash-fold + win32-lowercase, no filesystem I/O —
+	chosen over the `realpathSync`-backed `normalizeMapKey` because this is a hot
+	write path), and `importWidgetState` folds persisted keys on rehydrate so a
+	`/`-key snapshot and a fresh `\`-key write collapse across a resumed session.
+	The human-readable display path on each record is preserved verbatim (rendering
+	and path-relative math unchanged). No new dependencies.
+
 - **Prompt-cache observability (refs #1018, closes #1018)** — two provider-independent
 	signals now land in `~/.pi-lens/latency.log` as `type: "phase"` records.
 	(1) Response-side: a defensively feature-detected `message_end` subscription

--- a/clients/widget-state.ts
+++ b/clients/widget-state.ts
@@ -2,8 +2,43 @@ import { stat } from "node:fs/promises";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import { visibleWidth } from "./deps/pi-tui.js";
+import { normalizeEphemeralMapKey } from "./path-utils.js";
 import { fitLine } from "./tui-fit.js";
 import { WriteOrderingGuard } from "./write-ordering-guard.js";
+
+/**
+ * Canonical key for the `files` map (and `diagnosticsWriteGuard`) — #1020.
+ *
+ * The SAME file reaches this module under DIFFERENT path forms in one session:
+ * forward-slash (`C:/…/x.ts`) from the LSP client + cascade fold via
+ * `normalizeFilePath`, and backslash (`C:\…\x.ts`) from mode=full's reconcile
+ * writing `result.filePath` and from `path.resolve`/event inputs on Windows.
+ * Keyed raw, those coexisted as two entries: `mode=full` re-keyed on read and
+ * the clean entry hid the stale one, but `mode=all`'s `formatAllMode` reads the
+ * summaries verbatim and rendered the stale `blocking:1` as a 🔴 (#1020) — a
+ * resolved state that replayed as still-broken on every `mode=all`.
+ *
+ * `normalizeEphemeralMapKey` (slash-fold + win32-lowercase, NO filesystem I/O)
+ * is chosen over `normalizeMapKey`/`normalizeFilePath`, which call
+ * `realpathSync.native()` — real disk I/O on EVERY diagnostic/runner/formatter
+ * write, far too heavy for this hot path. The key only needs to be a stable
+ * syntactic fold that collapses `\`↔`/` and Windows drive-letter case, which
+ * this does; on-disk canonical casing is irrelevant for merely deduplicating a
+ * process-local footer cache. The human-readable path is preserved separately
+ * on the record's `filePath` (see `toDisplayPath`) for rendering/summaries.
+ */
+function fileMapKey(filePath: string): string {
+	return normalizeEphemeralMapKey(filePath);
+}
+
+// The record keeps a real, human-readable display path in `FileRecord.filePath`
+// (drives the widget render, `getFileDiagnosticSummaries`, and diagnostic URIs).
+// It is the VERBATIM path the first writer for a given key supplied — never the
+// lowercased/normalized `fileMapKey`, which would render an ugly all-lowercase
+// path on Windows. Only the MAP KEY is normalized; the display path is
+// unchanged from pre-#1020 behavior, so rendering and path-relative math are
+// unaffected. First writer wins the display form (later writes for the same
+// normalized key reuse the existing record).
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -155,7 +190,11 @@ export function importWidgetState(state: PersistedWidgetState | undefined): bool
 	// "superseded" against a stale token.
 	diagnosticsWriteGuard.clear();
 	for (const f of state.files ?? []) {
-		files.set(f.filePath, {
+		// Fold persisted keys through the same normalizer as live writes (#1020),
+		// or a persisted forward-slash key stays split from a fresh backslash key
+		// across a resumed session — a primary repro condition. Keep a readable
+		// display path on the record.
+		files.set(fileMapKey(f.filePath), {
 			filePath: f.filePath,
 			runners: new Map(f.runners ?? []),
 			formatters: new Map(f.formatters ?? []),
@@ -210,7 +249,7 @@ export function recordFormatter(
 	const rec = getOrCreate(filePath);
 	rec.formatters.set(formatter, { changed, success });
 	rec.touchedAt = Date.now();
-	files.set(filePath, rec);
+	files.set(fileMapKey(filePath), rec);
 	requestRender();
 }
 
@@ -225,7 +264,7 @@ export function recordRunner(
 	rec.runners.set(runnerId, { status, count: diagnosticCount, durationMs });
 	rec.hasFinalDiagnosticsSnapshot = false;
 	rec.touchedAt = Date.now();
-	files.set(filePath, rec);
+	files.set(fileMapKey(filePath), rec);
 	requestRender();
 }
 
@@ -261,7 +300,7 @@ export function recordDiagnostics(
 	// the `clients/mcp/analyze.ts` on-demand call site, which has no per-edit
 	// ordering token) always proceeds, same as version-less LSP servers in the
 	// #555 guard.
-	if (!diagnosticsWriteGuard.shouldWrite(filePath, writeIndex)) return;
+	if (!diagnosticsWriteGuard.shouldWrite(fileMapKey(filePath), writeIndex)) return;
 
 	const rec = getOrCreate(filePath);
 	const base = pathToFileURL(filePath).href;
@@ -297,7 +336,7 @@ export function recordDiagnostics(
 	rec.allDiagnostics = normalized;
 	rec.hasFinalDiagnosticsSnapshot = true;
 	rec.touchedAt = Date.now();
-	files.set(filePath, rec);
+	files.set(fileMapKey(filePath), rec);
 	requestRender();
 }
 
@@ -361,13 +400,15 @@ export function reconcileScanDiagnostics(
 export async function reconcileStaleWidgetFiles(): Promise<number> {
 	const entries = [...files.entries()];
 	const staleKeys = await Promise.all(
-		entries.map(async ([filePath, rec]) => {
+		// `mapKey` is the normalized `files` key (used for deletion); stat the
+		// record's real display path, not the lowercased key (#1020).
+		entries.map(async ([mapKey, rec]) => {
 			try {
-				const st = await stat(filePath);
+				const st = await stat(rec.filePath);
 				// +1ms tolerance: a freshly-recorded file has touchedAt >= mtime.
-				return st.mtimeMs > rec.touchedAt + 1 ? filePath : undefined;
+				return st.mtimeMs > rec.touchedAt + 1 ? mapKey : undefined;
 			} catch {
-				return filePath; // deleted / unreadable → drop
+				return mapKey; // deleted / unreadable → drop
 			}
 		}),
 	);
@@ -449,12 +490,14 @@ export function getFileDiagnosticSummaries(): FileDiagnosticSummary[] {
  * been recorded (caller must not confuse "never seen" with "seen and clean";
  * an explicit `[]` from `recordDiagnostics` is a real empty array here).
  *
- * NOTE: `filePath` must be the exact string used to record the file — the
- * `files` map key is NOT normalized (pre-existing; see `getOrCreate`), so
- * callers should pass through the same value they gave `recordDiagnostics`.
+ * The `files` map key is normalized through `fileMapKey` (#1020), so any path
+ * form of the same file — forward-slash, backslash, or a different Windows
+ * drive-letter case — resolves to the same record. This read-side fold MUST
+ * stay identical to the write-side fold, or a file recorded under one form
+ * would silently read as `undefined` under another (e.g. via bus-publish).
  */
 export function getFileDiagnostics(filePath: string): WidgetDiagnostic[] | undefined {
-	const rec = files.get(filePath);
+	const rec = files.get(fileMapKey(filePath));
 	if (!rec) return undefined;
 	return rec.allDiagnostics.map((d) => ({ ...d }));
 }
@@ -780,8 +823,10 @@ function truncateBasename(name: string, maxWidth: number): string {
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function getOrCreate(filePath: string): FileRecord {
+	// Look up by the normalized key so mixed path forms of the same file share
+	// ONE record (#1020); keep the caller's verbatim path as the display path.
 	return (
-		files.get(filePath) ?? {
+		files.get(fileMapKey(filePath)) ?? {
 			filePath,
 			runners: new Map(),
 			formatters: new Map(),

--- a/tests/clients/widget-state.test.ts
+++ b/tests/clients/widget-state.test.ts
@@ -10,6 +10,7 @@ import {
 	getFileDiagnostics,
 	getFileDiagnosticSummaries,
 	getSessionLanguages,
+	importWidgetState,
 	reconcileScanDiagnostics,
 	recordDiagnostics,
 	recordFormatter,
@@ -762,6 +763,82 @@ describe("reconcileScanDiagnostics — full-scan/on-demand footer reconciliation
 		const result = getFileDiagnostics(filePath);
 		expect(result).toHaveLength(1);
 		expect(result?.[0]?.message).toBe("untokened confirmed scan");
+	});
+});
+
+describe("path-key normalization — same file under mixed separators collapses to one entry (#1020)", () => {
+	// The two forms differ ONLY in separator direction, so they fold to the same
+	// key on every platform (`normalizeEphemeralMapKey` converts `\`→`/` always,
+	// and additionally lowercases on win32). This is the exact split that made a
+	// resolved blocker replay on mode=all: the LSP/cascade fold records the
+	// forward-slash form, while mode=full's clean reconcile writes the backslash
+	// form (path.resolve / result.filePath on Windows).
+	const fwd = "C:/proj/dup.ts";
+	const back = "C:\\proj\\dup.ts";
+
+	it("a clean backslash-key reconcile overwrites a stale forward-slash-key blocker → one entry, blocking:0", () => {
+		recordDiagnostics(
+			fwd,
+			[
+				{
+					severity: "error",
+					semantic: "blocking",
+					message: "stale blocker",
+					rule: "X",
+				},
+			],
+			1,
+		);
+		reconcileScanDiagnostics(back, [], true, 2);
+
+		const summaries = getFileDiagnosticSummaries();
+		// Pre-fix: TWO entries (raw keys never collapsed) and the forward-slash one
+		// still reads blocking:1 — the #1020 replay.
+		expect(summaries).toHaveLength(1);
+		expect(summaries[0]?.blocking).toBe(0);
+		expect(summaries[0]?.diagnostics).toEqual([]);
+	});
+
+	it("importWidgetState folds a persisted forward-slash key so a later backslash reconcile hits the same entry", () => {
+		importWidgetState({
+			version: 1,
+			sessionLanguages: [],
+			files: [
+				{
+					filePath: fwd,
+					runners: [],
+					formatters: [],
+					diagnostics: [
+						{
+							severity: "error",
+							semantic: "blocking",
+							message: "persisted blocker",
+							rule: "X",
+						},
+					],
+					allDiagnostics: [
+						{
+							severity: "error",
+							semantic: "blocking",
+							message: "persisted blocker",
+							rule: "X",
+						},
+					],
+					diagnosticCounts: { blocking: 1, errors: 1, warnings: 0 },
+					hasFinalDiagnosticsSnapshot: true,
+					touchedAt: Date.now(),
+				},
+			],
+		});
+
+		// After resume, the clean full-scan reconcile arrives under the backslash
+		// form. Without the rehydrate fold, the persisted `/`-key stays split from
+		// this `\`-key and the blocker survives.
+		reconcileScanDiagnostics(back, [], true, 5);
+
+		const summaries = getFileDiagnosticSummaries();
+		expect(summaries).toHaveLength(1);
+		expect(summaries[0]?.blocking).toBe(0);
 	});
 });
 

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -1623,6 +1623,45 @@ describe("lens_diagnostics mode=all", () => {
 		expect(String(result.content[0].text)).toContain("No files diagnosed");
 	});
 
+	it("reports clean after a same-file backslash reconcile clears a forward-slash blocker (#1020)", async () => {
+		// Exercise the SOURCE fix end-to-end through the tool: drive the REAL
+		// widget-state (bypassing this file's module mock via importActual), record
+		// a stale blocker under the forward-slash form, then reconcile the SAME file
+		// clean under the backslash form — the exact mixed-key split that made
+		// mode=all replay a resolved blocker. Bridge the real summaries into the
+		// tool's mocked `getFileDiagnosticSummaries` so the tool sees precisely what
+		// the fixed widget state exposes.
+		const realWS = await vi.importActual<
+			typeof import("../../clients/widget-state.js")
+		>("../../clients/widget-state.js");
+		realWS.clearWidgetState();
+		try {
+			realWS.recordDiagnostics(
+				"/proj/src/dup.ts",
+				[
+					{
+						severity: "error",
+						semantic: "blocking",
+						message: "stale blocker",
+						rule: "X",
+					},
+				],
+				1,
+			);
+			realWS.reconcileScanDiagnostics("\\proj\\src\\dup.ts", [], true, 2);
+
+			mockSummaries.length = 0;
+			mockSummaries.push(...realWS.getFileDiagnosticSummaries());
+			// Pre-fix: two summaries reach the tool, one still blocking:1 → 🔴.
+			const result = await run(makeTool(), { mode: "all" });
+			const text = String(result.content[0].text);
+			expect(text).not.toContain("🔴");
+			expect(text).toContain("No");
+		} finally {
+			realWS.clearWidgetState();
+		}
+	});
+
 	it("flushes pending dispatches before reading (so just-fixed files refresh)", async () => {
 		const flush = vi.fn(async () => {});
 		const tool = createLensDiagnosticsTool(


### PR DESCRIPTION
## Bug (#1020)

`lens_diagnostics mode=all` replayed a stale 🔴 blocking LSP error on an already-fixed file even after a clean `mode=full` scan. Root cause: the widget-state `files` map was keyed by the **raw, non-normalized** path string, so the same file got recorded under two forms — forward-slash (LSP client + cascade fold via `normalizeFilePath`) and backslash (`mode=full` reconcile / `path.resolve` / event inputs on Windows). `mode=full` re-keys through `path.resolve` and collapses the pair (renders clean); `mode=all` reads `getFileDiagnosticSummaries()` verbatim with no dedup and sees **both** entries — the stale one still `blocking:1`. The #571 clean-reconcile wrote the fresh empty result under the *other* key form, so it never overwrote the stale entry → the blocker replayed every `mode=all`. #533-adjacent: a resolved state renders as still-broken and falsely blocks the agent (worst on Windows / resumed sessions).

## Fix

Normalize the `files`-map key at **every** seam through one `fileMapKey` helper (= `normalizeEphemeralMapKey`: slash-fold + win32-lowercase, **no filesystem I/O** — `normalizeMapKey`'s `realpathSync` would be far too heavy on this per-write hot path):

- write: `recordDiagnostics`, `recordRunner`, `recordFormatter`, `getOrCreate`, and the `diagnosticsWriteGuard.shouldWrite`;
- read: `getFileDiagnostics` (used by bus-publish) — identical fold, so no silent-miss;
- `reconcileStaleWidgetFiles` deletes by the map's own iteration key and `stat`s the real display path;
- `importWidgetState` **folds persisted keys on rehydrate** (fixes the resumed-session split).

The record's display `filePath` is kept **verbatim** (first-writer's form) — only the map *key* is normalized — so rendering / URIs / `path.relative` math are untouched. `dedupeByBasename` left as-is (now redundant for this case but still guards genuinely-distinct same-basename files).

## Tests

Both new tests **fail on pre-fix code** (recorded): a widget-state unit test (stale `/`-key blocker + clean `\`-key reconcile → one entry, `blocking:0`; plus a rehydrate case), and a tool-level test reproducing the exact `mode=all` replay symptom. The existing #571 test (single key form) is left intact. Full suite `4918 passed`; `tsc` + `build:dist` clean.

Found via the systematic path-key class sweep (see #1025); same class as #210 (read-guard) and #1024 (dispositions).

Closes #1020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)