### PR TITLE
test(flaky): phase the ast-grep LSP-winner test into a serial pool so it stops flaking under full-suite load (closes #1022)

### DIFF
--- a/tests/clients/ast-grep-rule-precedence-followups.test.ts
+++ b/tests/clients/ast-grep-rule-precedence-followups.test.ts
@@ -419,11 +419,33 @@ describe("project rule precedence follow-ups", { timeout: HEAVY_IO_TIMEOUT_MS },
 			if (!spawned) throw new Error("ast-grep LSP did not spawn");
 			expect(spawned.process.args).toContain("--config");
 
+			// #1022: use the server's OWN configured initialize budget (as
+			// production does at clients/lsp/index.ts:1358 —
+			// `initializeTimeoutMs: server.initializeTimeoutMs`) as the shared
+			// LSP timing budget here, instead of a shorter, invented constant.
+			// ast-grep's real budget (clients/lsp/server.ts,
+			// `AstGrepServer.initializeTimeoutMs`) is deliberately generous
+			// because the first scan of a session compiles the full rule set
+			// (~350 files incl. the CodeRabbit catalog) — and that compile cost
+			// can land either during the `initialize` handshake OR while
+			// computing the first document's diagnostics, depending on when
+			// the server actually parses the rule config. `waitForDiagnostics`
+			// (clients/lsp/client.ts) resolves silently on timeout rather than
+			// throwing, so a too-short wait here doesn't surface as a timeout
+			// error — it surfaces as a false "diagnostic not found" assertion
+			// failure, which is exactly what #1022 observed. A hardcoded 5s
+			// budget for either step undercut the server's own declared cost
+			// by 3x and could starve under full-parallel-suite CPU contention
+			// (this file is now also phased into its own low-concurrency
+			// vitest project — see vitest.config.ts's `lsp-spawn-heavy`
+			// project — so this budget-alignment is belt-and-braces, not the
+			// sole fix for the contention itself).
+			const lspBudgetMs = server.initializeTimeoutMs ?? 15_000;
 			const client = await createLSPClient({
 				serverId: "ast-grep",
 				process: spawned.process,
 				root,
-				initializeTimeoutMs: 5_000,
+				initializeTimeoutMs: lspBudgetMs,
 			});
 			try {
 				const minVersion = client.diagnosticsVersion;
@@ -432,7 +454,7 @@ describe("project rule precedence follow-ups", { timeout: HEAVY_IO_TIMEOUT_MS },
 					fs.readFileSync(filePath, "utf8"),
 					"typescript",
 				);
-				await client.waitForDiagnostics(filePath, 5_000, { minVersion });
+				await client.waitForDiagnostics(filePath, lspBudgetMs, { minVersion });
 				expect(
 					client
 						.getDiagnostics(filePath)
@@ -446,7 +468,12 @@ describe("project rule precedence follow-ups", { timeout: HEAVY_IO_TIMEOUT_MS },
 				await client.shutdown({ fast: true });
 			}
 		},
-		15_000,
+		// #1022: was a hardcoded 15_000 — too tight once both the initialize
+		// step and the diagnostics wait above can each legitimately consume up
+		// to the server's own ~15s budget. Give room for both budgets in
+		// sequence plus normal spawn/teardown overhead, rather than another
+		// disagreeing magic number.
+		40_000,
 	);
 
 	it("keeps TypeScript and JavaScript project winners aligned in NAPI", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -109,6 +109,31 @@ const timingSensitiveInclude = [
 	"tests/clients/cascade-graph-occupancy.test.ts",
 ];
 
+// #1022 fix: the "workspace LSP winner" case in this file spawns a REAL
+// ast-grep LSP child process and waits on its `initialize` handshake plus
+// its first-document diagnostics — both bounded by ast-grep's own
+// deliberately-generous initializeTimeoutMs (~15s, see clients/lsp/server.ts)
+// because the first scan of a session compiles the full rule set (~350
+// files incl. the CodeRabbit catalog). `client.waitForDiagnostics`
+// (clients/lsp/client.ts) resolves SILENTLY on timeout rather than throwing,
+// so under the "default" project's `maxWorkers: "50%"` fork storm — dozens
+// of sibling forks doing grammar compiles and their own process spawns —
+// CPU contention can starve this real spawn past its budget, and that
+// starvation surfaces not as a timeout but as a false "diagnostic not
+// found" assertion failure (confirmed via 2026-08-01 repro: solo run green
+// every time, full-suite run intermittently red on exactly this case).
+// Same fix shape as grammar-heavy/timing-sensitive above: phase this file
+// into its own low-concurrency, last-running project so its real-LSP-spawn
+// budget window never has to compete with the rest of the suite's fork
+// storm for CPU turns. This removes the CONTENTION rather than just
+// widening the timeout (see the companion budget-alignment fix in the test
+// file itself, which corrects the timeout values to match ast-grep's own
+// declared budget instead of a shorter invented constant — belt-and-braces,
+// not a substitute for phasing).
+const lspSpawnHeavyInclude = [
+	"tests/clients/ast-grep-rule-precedence-followups.test.ts",
+];
+
 export default defineConfig({
 	test: {
 		exclude: sharedExclude,
@@ -124,6 +149,7 @@ export default defineConfig({
 						...sharedExclude,
 						...grammarHeavyInclude,
 						...timingSensitiveInclude,
+						...lspSpawnHeavyInclude,
 					],
 					globalSetup: sharedGlobalSetup,
 					setupFiles: sharedSetupFiles,
@@ -192,6 +218,32 @@ export default defineConfig({
 					// that was intermittently starving their sampler and tripping the
 					// budget on ambient scheduling delay, not a real regression.
 					sequence: { groupOrder: 2 },
+					hookTimeout: 60_000,
+				},
+			},
+			{
+				test: {
+					name: "lsp-spawn-heavy",
+					include: lspSpawnHeavyInclude,
+					exclude: sharedExclude,
+					globalSetup: sharedGlobalSetup,
+					setupFiles: sharedSetupFiles,
+					execArgv: sharedExecArgv,
+					// Full serialization, not just a cap: this is a single file, so
+					// there are no siblings to share the phase with anyway — the
+					// point is to guarantee zero overlap with the "default" project's
+					// fork storm (the actual contention source, see #1022 above), not
+					// to bound intra-project concurrency.
+					maxWorkers: 1,
+					// Last phase: by the time this runs, "default", "grammar-heavy",
+					// and "timing-sensitive" have all fully drained, so the real
+					// ast-grep LSP spawn's initialize/diagnostics budget window gets
+					// a quiet host instead of racing the rest of the suite.
+					sequence: { groupOrder: 3 },
+					// Real LSP process spawn + rule-set compile can legitimately use
+					// most of its declared ~15s budget twice over (initialize, then
+					// first-document diagnostics) before shutdown; give teardown the
+					// same headroom as the other heavy projects.
 					hookTimeout: 60_000,
 				},
 			},


### PR DESCRIPTION
## Flake (#1022)

`tests/clients/ast-grep-rule-precedence-followups.test.ts` ("workspace LSP winner") intermittently failed under the full `npx vitest run` (parallel `maxWorkers: "50%"` fork storm) but passed in isolation.

**Mechanism:** the test spawns a real ast-grep LSP child and waits on `initialize` + first-document diagnostics via `client.waitForDiagnostics`, which resolves **silently** on timeout instead of throwing. The test hardcoded 5 s budgets while ast-grep's real production budget is 15 s (`lsp/server.ts:2718`, used at `lsp/index.ts:1358`) — deliberately generous because the first scan compiles the full rule set (~350 files incl. the CodeRabbit catalog). Under CPU contention from the fork storm, the real spawn blew past the 5 s window, and the silent-timeout surfaced as a *false* "diagnostic not found" assertion rather than a timeout error.

## Fix (deterministic, not a bare bump)

1. **Primary — remove the contention.** New `lsp-spawn-heavy` vitest project (`vitest.config.ts`) phases this one file into its own `maxWorkers: 1`, last-running group (`groupOrder: 3`), following the exact established convention already used for the `grammar-heavy` and `timing-sensitive` projects. The file is excluded from the `default` project (so it runs once, phased alone after the fork storm drains) — not double-run.
2. **Secondary — align the budget.** Use the server's real `initializeTimeoutMs ?? 15_000` for both the client-init and `waitForDiagnostics` calls instead of an invented 5 s constant, and raise the test's own timeout 15 s → 40 s to fit both budgets in sequence. Correct on its own merits (the test was under-budgeting vs production by 3×).

## Verification
Isolation: 11/11 pass. **Full suite (`npx vitest run`), 5 consecutive runs: 5/5 green** (`440 passed | 5 skipped` files, `4918 passed | 14 skipped` tests each — consistent file count confirms no double-run).

Follow-up noted (not blocking): `waitForDiagnostics`'s silent-timeout-resolve is a footgun for test authors (it turned a timeout into a misleading assertion failure here) — worth revisiting whether test-context callers should get a throwing variant.

Closes #1022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)