### PR TITLE
perf(session_start): bound the sequence_read replay via a snapshot-embedded sequence index (closes #1019)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,10 +257,22 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   `clients/startup-marker.ts` first, then logs `host_boot`, `extension_eval`, and
   the continuity `extension_loaded` record. Primary session starts pass the host
   hook/bootstrap timestamps into `handleSessionStart`, which records pre-handler,
-  runtime-reset, cleanup, sequence/snapshot (with bytes/freshness/seq), total, and
+  runtime-reset, sequence/snapshot (with bytes/freshness/seq), total, and
   delayed warmup child phases in `latency.log`; concurrent secondaries emit only
   `concurrent_session_bind`. Keep logging fire-and-forget and preserve contiguous
   top-level timing so quick-start child durations remain within ~10 ms of total.
+  #1019: `session_start_log_cleanup` is now emitted from a deferred `setImmediate`
+  (its `metadata.deferred:true`), NOT synchronously in the awaited chain, so it is
+  no longer a top-level critical-path phase — do not re-add it to the contiguous
+  top-level sum. **`session_start_sequence_read` is bounded** by a snapshot-embedded
+  sequence index (`SnapshotSequenceIndex`, mirrored in the meta sidecar): the quick
+  and full paths pass `snapshotSequenceBase(root)` to `readLatestProjectSequence`,
+  which folds only change-log entries with `seq > snapshot.seq` on top of the
+  hydrated base (O(changes-since-snapshot)) instead of replaying the whole log,
+  with a full-replay fallback for legacy/version-mismatch/ahead-of-log bases. The
+  embedded index is written by `buildProjectSnapshotFromRuntime` from the runtime's
+  live `{projectSeq, getFileSeqEntries()}` (always consistent with `snapshot.seq`);
+  side-writes (word-index/reverse-deps) carry it forward via their `existing` spread.
 - **Incremental review-graph snapshots are immutable by replacement (#939).**
   `updateGraphFiles` performs all node/edge edits on a clone, rebuilds derived
   indexes once at the end, then stores that finished graph directly in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Session-start perf: bound the change-log replay + defer log cleanup (closes #1019)** —
+	the interactive session-start path recomputed the project sequence by reading
+	the ENTIRE append-only change log and folding every line — and each fold does a
+	`normalizeMapKey`/`realpathSync.native()` syscall per historical entry, so the
+	`session_start_sequence_read` phase (measured ~94ms, ~47% of a 200ms warm start)
+	grew unbounded with total log length, not the working set. The project snapshot
+	now embeds the DERIVED sequence index (`projectSeq` + per-file `fileSeqByPath`)
+	as of its `seq` (`clients/project-snapshot.ts`), mirrored into the tiny
+	`project-snapshot.meta.json` sidecar so session-start can hydrate it WITHOUT
+	parsing the 40-112MB body (preserving the #947 skip-stale optimization).
+	`readLatestProjectSequence` (`clients/project-changes.ts`) gained an optional
+	base param: it hydrates that index (O(files-in-snapshot), keys already
+	normalized → no per-key `realpath`) and folds ONLY entries with
+	`seq > snapshot.seq` — O(changes-since-snapshot). The fold uses the SAME
+	`Math.max`/`normalizeMapKey` the full replay does, so the result is
+	byte-identical to a full replay (proven by an equivalence test suite covering
+	no-new-entries, new/existing files, deletes, gaps/out-of-order, and the empty
+	log) and order-independent. Correctness-first fallbacks to a full replay: a
+	legacy/missing meta with no embedded index, a version-mismatched meta, and a
+	snapshot whose `seq` is AHEAD of the log (truncation/rotation) — it never serves
+	a wrong seq. Wired into BOTH the quick/interactive and the full session-start
+	paths. Secondary: `log_cleanup` (~7ms) was moved off the synchronous critical
+	path into a deferred `setImmediate` (it still runs every session and notifies
+	async — nothing on the hot path consumed its result).
 - **Cascade honesty: degraded/uncomputed impact no longer renders as clean (refs #1023, closes #1023)** —
 	the cascade impact subsystem previously emitted an all-clear that was
 	indistinguishable from "genuinely nothing impacted" whenever it could NOT

--- a/clients/project-changes.ts
+++ b/clients/project-changes.ts
@@ -85,21 +85,123 @@ export function readChangesSince(
 		.slice(-limit);
 }
 
-export function readLatestProjectSequence(cwd: string): {
+export interface ProjectSequenceIndex {
 	projectSeq: number;
 	fileSeqByPath: Map<string, number>;
-} {
+}
+
+/**
+ * A snapshot-embedded sequence index used to BOUND the replay (#1019). It is
+ * the derived `{ projectSeq, fileSeqByPath }` as of `sinceSeq` (the snapshot's
+ * own `seq`), so `readLatestProjectSequence` can fold only the log entries with
+ * `seq > sinceSeq` on top of it instead of replaying the entire append-only
+ * log. Keys in `fileSeqByPath` are ALREADY in `normalizeMapKey(path.resolve())`
+ * form (they come straight from the runtime's `_fileSeq`, produced by the exact
+ * same normalization the full replay uses), so the partial path does NOT
+ * re-normalize them — that is the whole point: the per-entry
+ * `normalizeMapKey` calls `realpathSync.native()` (one filesystem syscall per
+ * historical entry), and skipping the O(entire-log) history is what turns the
+ * dominant session-start cost into O(changes-since-snapshot).
+ */
+export interface ProjectSequenceBase {
+	projectSeq: number;
+	fileSeqByPath: Iterable<readonly [string, number]>;
+	/** The snapshot's `seq`: entries at or below this are covered by the base. */
+	sinceSeq: number;
+}
+
+// Test-observable count of the EXPENSIVE per-entry folds (each one does a
+// `path.resolve` + `normalizeMapKey`/`realpathSync.native` syscall). Lets the
+// #1019 equivalence tests prove the partial path folds strictly FEWER entries
+// than the full replay for the same log — i.e. that the bound actually holds —
+// without a brittle spy on the path helpers.
+let _sequenceFoldCountForTests = 0;
+export function getSequenceFoldCountForTests(): number {
+	return _sequenceFoldCountForTests;
+}
+export function resetSequenceFoldCountForTests(): void {
+	_sequenceFoldCountForTests = 0;
+}
+
+function foldEntry(
+	entry: ProjectChangeEntry,
+	fileSeqByPath: Map<string, number>,
+): void {
+	_sequenceFoldCountForTests++;
+	const key = normalizeMapKey(path.resolve(entry.filePath));
+	fileSeqByPath.set(key, Math.max(fileSeqByPath.get(key) ?? 0, entry.fileSeq));
+}
+
+function fullReplay(entries: ProjectChangeEntry[]): ProjectSequenceIndex {
 	let projectSeq = 0;
 	const fileSeqByPath = new Map<string, number>();
-	for (const entry of readProjectChanges(cwd)) {
+	for (const entry of entries) {
 		projectSeq = Math.max(projectSeq, entry.seq);
-		const key = normalizeMapKey(path.resolve(entry.filePath));
-		fileSeqByPath.set(
-			key,
-			Math.max(fileSeqByPath.get(key) ?? 0, entry.fileSeq),
-		);
+		foldEntry(entry, fileSeqByPath);
 	}
 	return { projectSeq, fileSeqByPath };
+}
+
+/**
+ * Attempt the bounded partial replay: hydrate `base` (pre-normalized keys, no
+ * `realpath` cost) and fold ONLY entries with `seq > base.sinceSeq`. Returns
+ * `null` — signalling the caller to fall back to a full replay — whenever the
+ * base cannot be trusted to be byte-identical to a full replay:
+ *
+ *  - `base.sinceSeq` is AHEAD of the log's max seq (the log was truncated /
+ *    rotated below the snapshot, or the snapshot seq is simply ahead). Serving
+ *    the base would over-report the seq; the full replay reflects the real log.
+ *
+ * The result is provably equal to a full replay under the append-only,
+ * single-writer invariant (`base` == fold of the log up to `sinceSeq`): every
+ * historical file's seq is already in `base`, and folding the strictly-newer
+ * entries with the SAME `Math.max` the full replay uses reproduces the max over
+ * the whole log for both `projectSeq` and each file. `Math.max` makes the fold
+ * order-independent, so gaps / out-of-order entries are handled exactly as the
+ * full replay handles them.
+ */
+function partialReplay(
+	entries: ProjectChangeEntry[],
+	base: ProjectSequenceBase,
+): ProjectSequenceIndex | null {
+	let logMaxSeq = 0;
+	for (const entry of entries) {
+		if (entry.seq > logMaxSeq) logMaxSeq = entry.seq;
+	}
+	// Snapshot ahead of / newer than the log (truncation, rotation, or a stale
+	// log): the base describes a state the log no longer backs — never serve it.
+	if (base.sinceSeq > logMaxSeq) return null;
+
+	const fileSeqByPath = new Map<string, number>(base.fileSeqByPath);
+	let projectSeq = Math.max(0, base.projectSeq);
+	for (const entry of entries) {
+		if (entry.seq <= base.sinceSeq) continue; // covered by the base
+		projectSeq = Math.max(projectSeq, entry.seq);
+		foldEntry(entry, fileSeqByPath);
+	}
+	return { projectSeq, fileSeqByPath };
+}
+
+/**
+ * Compute the current `{ projectSeq, fileSeqByPath }` from the append-only
+ * change log. With no `base`, this is a full replay of the entire log. With a
+ * snapshot-embedded `base` (#1019), it folds only entries newer than
+ * `base.sinceSeq` on top of the base — O(changes since snapshot) instead of
+ * O(entire log) — and transparently falls back to a full replay when the base
+ * cannot be trusted (see `partialReplay`). A legacy/stale/missing snapshot
+ * simply passes no `base` (or one the guard rejects), so correctness never
+ * depends on the optimization being applicable.
+ */
+export function readLatestProjectSequence(
+	cwd: string,
+	base?: ProjectSequenceBase,
+): ProjectSequenceIndex {
+	const entries = readProjectChanges(cwd);
+	if (base) {
+		const partial = partialReplay(entries, base);
+		if (partial) return partial;
+	}
+	return fullReplay(entries);
 }
 
 export function appendProjectChange(

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -50,6 +50,21 @@ export interface ProjectSnapshotSymbol {
 	endLine?: number;
 }
 
+/**
+ * The derived project-changes sequence index as of `ProjectSnapshot.seq`
+ * (#1019). Persisting it lets session-start BOUND the change-log replay: hydrate
+ * this (O(files)) then fold only entries with `seq > snapshot.seq`
+ * (O(changes-since-snapshot)) instead of replaying the entire append-only log.
+ * `projectSeq` is invariably `=== snapshot.seq` (both come from the same
+ * `runtime.projectSeq` moment); `fileSeqByPath` uses the same
+ * `normalizeMapKey(path.resolve())` keys as the change-log replay, so no
+ * re-normalization (and no per-key `realpath` syscall) is needed on hydrate.
+ */
+export interface SnapshotSequenceIndex {
+	projectSeq: number;
+	fileSeqByPath: Array<[filePath: string, fileSeq: number]>;
+}
+
 export interface ProjectSnapshot {
 	version: typeof PROJECT_SNAPSHOT_VERSION;
 	projectRoot: string;
@@ -59,11 +74,26 @@ export interface ProjectSnapshot {
 	symbols: Record<string, ProjectSnapshotSymbol[]>;
 	reverseDeps: Record<string, string[]>;
 	cachedExports: Array<[name: string, filePath: string]>;
+	sequenceIndex?: SnapshotSequenceIndex;
 	wordIndex?: SerializedWordIndex;
 	projectRulesScan?: RuleScanResult;
 	startupScan?: StartupScanContext;
 	languageProfile?: ProjectLanguageProfile;
 	conventions?: ProjectConventions;
+}
+
+function parseSequenceIndex(value: unknown): SnapshotSequenceIndex | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const index = value as Partial<SnapshotSequenceIndex>;
+	if (typeof index.projectSeq !== "number") return undefined;
+	if (!Array.isArray(index.fileSeqByPath)) return undefined;
+	const fileSeqByPath = index.fileSeqByPath.filter(
+		(entry): entry is [string, number] =>
+			Array.isArray(entry) &&
+			typeof entry[0] === "string" &&
+			typeof entry[1] === "number",
+	);
+	return { projectSeq: index.projectSeq, fileSeqByPath };
 }
 
 // #958 item 2: the canonical snapshot body is now streamed gzip
@@ -131,6 +161,7 @@ function parseSnapshot(value: unknown): ProjectSnapshot | null {
 				typeof entry[0] === "string" &&
 				typeof entry[1] === "string",
 		),
+		sequenceIndex: parseSequenceIndex(snapshot.sequenceIndex),
 		wordIndex: snapshot.wordIndex,
 		projectRulesScan: snapshot.projectRulesScan,
 		startupScan: snapshot.startupScan,
@@ -143,6 +174,13 @@ export interface ProjectSnapshotMeta {
 	timestamp: string;
 	version: number;
 	seq: number;
+	/**
+	 * The derived sequence index as of `seq` (#1019), MIRRORED here from the
+	 * snapshot body so session-start can bound the change-log replay WITHOUT
+	 * parsing the (40-112MB) body — which would forfeit the #947 skip-stale
+	 * optimization. Absent on legacy metas (pre-#1019) → callers full-replay.
+	 */
+	sequenceIndex?: SnapshotSequenceIndex;
 }
 
 function parseSnapshotMeta(value: unknown): ProjectSnapshotMeta | null {
@@ -154,6 +192,7 @@ function parseSnapshotMeta(value: unknown): ProjectSnapshotMeta | null {
 		timestamp: typeof meta.timestamp === "string" ? meta.timestamp : "",
 		version: meta.version,
 		seq: meta.seq,
+		sequenceIndex: parseSequenceIndex(meta.sequenceIndex),
 	};
 }
 
@@ -751,6 +790,14 @@ export function saveProjectSnapshot(
 			timestamp: snapshot.generatedAt,
 			version: snapshot.version,
 			seq: snapshot.seq,
+			// #1019: mirror the derived sequence index (kept consistent with `seq`
+			// because both are stamped from the same runtime moment) so the
+			// interactive path can hydrate it from the tiny sidecar. Omitted when
+			// absent so a non-runtime side-write (word-index/reverse-deps) that
+			// carried no index doesn't stamp an empty one.
+			...(snapshot.sequenceIndex
+				? { sequenceIndex: snapshot.sequenceIndex }
+				: {}),
 		}),
 		{ bestEffort: false },
 	);
@@ -873,6 +920,15 @@ export function buildProjectSnapshotFromRuntime(args: {
 		cachedExports: [...args.runtime.cachedExports.entries()].sort((a, b) =>
 			a[0].localeCompare(b[0]),
 		),
+		// #1019: capture the runtime's live sequence index AT this seq. The runtime
+		// is seeded from the change log at session start and bumped in lockstep with
+		// every append, so `getFileSeqEntries()` IS the fold of the log up to
+		// `projectSeq` — and its keys are already `normalizeMapKey(path.resolve())`,
+		// the exact form the change-log replay produces.
+		sequenceIndex: {
+			projectSeq: args.runtime.projectSeq,
+			fileSeqByPath: args.runtime.getFileSeqEntries(),
+		},
 		wordIndex: args.runtime.wordIndex
 			? serializeWordIndex(args.runtime.wordIndex)
 			: undefined,

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -37,13 +37,17 @@ import { initLSPConfig, loadLSPConfig } from "./lsp/config.js";
 import { getLSPService } from "./lsp/index.js";
 import type { LSPShutdownOptions } from "./lsp/client.js";
 import type { MetricsClient } from "./metrics-client.js";
-import { readLatestProjectSequence } from "./project-changes.js";
+import {
+	type ProjectSequenceBase,
+	readLatestProjectSequence,
+} from "./project-changes.js";
 import {
 	getProjectSnapshotPath,
 	hydrateRuntimeFromProjectSnapshot,
 	isProjectSnapshotFresh,
 	isProjectSnapshotMetaStale,
 	loadProjectSnapshot,
+	PROJECT_SNAPSHOT_VERSION,
 	readProjectSnapshotMeta,
 	saveRuntimeProjectSnapshot,
 	type ProjectSnapshot,
@@ -148,6 +152,29 @@ function resolveSnapshotRoot(cwd: string): string {
  * snapshot written before the sidecar existed) falls through to parsing the
  * body exactly as before.
  */
+/**
+ * #1019: build the bounded-replay base from the snapshot's tiny meta sidecar.
+ * The sequence index is mirrored into the meta (not just the body) precisely so
+ * this read is cheap — reading it does NOT parse the 40-112MB body, preserving
+ * the #947 skip-stale optimization. Returns `undefined` (→ full replay) for a
+ * legacy meta with no embedded index, a version-mismatched meta (a foreign
+ * snapshot generation), or a missing meta. A seq-stale meta is NOT rejected
+ * here — folding the newer entries onto it is the whole point; the base's
+ * trustworthiness against a truncated/ahead log is guarded inside
+ * `readLatestProjectSequence` itself.
+ */
+function snapshotSequenceBase(root: string): ProjectSequenceBase | undefined {
+	const meta = readProjectSnapshotMeta(root);
+	if (!meta || meta.version !== PROJECT_SNAPSHOT_VERSION) return undefined;
+	const index = meta.sequenceIndex;
+	if (!index) return undefined;
+	return {
+		projectSeq: index.projectSeq,
+		fileSeqByPath: index.fileSeqByPath,
+		sinceSeq: meta.seq,
+	};
+}
+
 function loadSnapshotBodyUnlessStale(args: {
 	root: string;
 	currentProjectSeq: number;
@@ -493,7 +520,10 @@ async function buildOrRefreshWordIndex(args: {
 	if (!runtime.isCurrentSession(sessionGeneration)) return;
 	const startMs = Date.now();
 
-	const latestSeq = readLatestProjectSequence(snapshotRoot);
+	const latestSeq = readLatestProjectSequence(
+		snapshotRoot,
+		snapshotSequenceBase(snapshotRoot),
+	);
 	const effectiveSeq = runtime.projectSeq ?? latestSeq.projectSeq;
 	const snapshot = loadProjectSnapshot(snapshotRoot);
 	if (snapshot?.wordIndex) {
@@ -1541,20 +1571,36 @@ export async function handleSessionStart(
 		metadata: { mode: startupMode, reason: deps.sessionReason },
 	});
 
-	// Run log cleanup early in session start (non-blocking)
-	const logCleanupStartedAt = Date.now();
-	const logCleanup = runLogCleanup(dbg);
-	logLatency({
-		type: "phase",
-		phase: "session_start_log_cleanup",
-		filePath: ctxCwd ?? process.cwd(),
-		startedAt: new Date(logCleanupStartedAt).toISOString(),
-		durationMs: Date.now() - logCleanupStartedAt,
-		metadata: { mode: startupMode, reason: deps.sessionReason },
+	// #1019: log cleanup is deferred OFF the interactive critical path. It does
+	// synchronous fs sweeps (~7ms) whose only consumer is an async notification —
+	// nothing on the hot path reads its result — so running it inline just taxed
+	// every session start. It still runs every session (correctness unchanged),
+	// now on the next tick, and notifies when done. Errors are swallowed to a
+	// dbg line: a best-effort log sweep must never surface as a session failure.
+	const cleanupCwd = ctxCwd ?? process.cwd();
+	setImmediate(() => {
+		const logCleanupStartedAt = Date.now();
+		try {
+			const logCleanup = runLogCleanup(dbg);
+			logLatency({
+				type: "phase",
+				phase: "session_start_log_cleanup",
+				filePath: cleanupCwd,
+				startedAt: new Date(logCleanupStartedAt).toISOString(),
+				durationMs: Date.now() - logCleanupStartedAt,
+				metadata: {
+					mode: startupMode,
+					reason: deps.sessionReason,
+					deferred: true,
+				},
+			});
+			if (logCleanup.cleaned > 0 || logCleanup.rotated > 0) {
+				notify(`🧹 ${logCleanup.report}`, "info");
+			}
+		} catch (err) {
+			dbg(`session_start: deferred log cleanup failed: ${err}`);
+		}
 	});
-	if (logCleanup.cleaned > 0 || logCleanup.rotated > 0) {
-		notify(`🧹 ${logCleanup.report}`, "info");
-	}
 	dbg(`session_start startup mode: ${startupMode}`);
 
 	if (!getFlag("no-lsp")) {
@@ -1571,7 +1617,10 @@ export async function handleSessionStart(
 		runtime.projectRoot = cwd;
 		const sequenceReadStartedAt = Date.now();
 		const snapshotRoot = resolveSnapshotRoot(cwd);
-		const latestSeq = readLatestProjectSequence(snapshotRoot);
+		const latestSeq = readLatestProjectSequence(
+			snapshotRoot,
+			snapshotSequenceBase(snapshotRoot),
+		);
 		logLatency({
 			type: "phase",
 			phase: "session_start_sequence_read",
@@ -1665,7 +1714,10 @@ export async function handleSessionStart(
 
 	const sequenceReadStartedAt = Date.now();
 	const snapshotRoot = resolveSnapshotRoot(cwd);
-	const latestSeq = readLatestProjectSequence(snapshotRoot);
+	const latestSeq = readLatestProjectSequence(
+		snapshotRoot,
+		snapshotSequenceBase(snapshotRoot),
+	);
 	logLatency({
 		type: "phase",
 		phase: "session_start_sequence_read",

--- a/tests/clients/project-changes.test.ts
+++ b/tests/clients/project-changes.test.ts
@@ -1,10 +1,14 @@
 import * as path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	appendProjectChange,
 	getProjectChangeLogPath,
+	getSequenceFoldCountForTests,
+	type ProjectSequenceBase,
+	type ProjectSequenceIndex,
 	readChangesSince,
 	readLatestProjectSequence,
+	resetSequenceFoldCountForTests,
 } from "../../clients/project-changes.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { setupTestEnvironment } from "./test-utils.js";
@@ -78,5 +82,198 @@ describe("project change sequence", () => {
 			}
 			env.cleanup();
 		}
+	});
+});
+
+// #1019: the snapshot-bounded partial replay MUST be byte-identical to a full
+// replay for the same log state, and must fall back to a full replay for
+// legacy/ahead/missing bases. These tests are the primary correctness proof —
+// the partial path runs on the interactive session-start critical path.
+describe("readLatestProjectSequence partial replay (#1019)", () => {
+	let env: ReturnType<typeof setupTestEnvironment>;
+	let previousDataDir: string | undefined;
+	let cwd: string;
+
+	// OS-agnostic file paths under the isolated tmp dir; assertions never bake in
+	// a separator (keys are compared structurally as whole strings).
+	const fileA = () => path.join(cwd, "src", "a.ts");
+	const fileB = () => path.join(cwd, "src", "b.ts");
+	const fileC = () => path.join(cwd, "src", "nested", "c.ts");
+
+	function append(
+		seq: number,
+		filePath: string,
+		fileSeq: number,
+		source: "agent-edit" | "external" | "format" = "agent-edit",
+	): void {
+		appendProjectChange(cwd, {
+			seq,
+			timestamp: new Date(seq * 1000).toISOString(),
+			sessionId: "s",
+			turnIndex: 0,
+			source,
+			filePath,
+			fileSeq,
+		});
+	}
+
+	/** Structural, order-independent view for equality assertions. */
+	function shape(index: ProjectSequenceIndex): {
+		projectSeq: number;
+		files: Array<[string, number]>;
+	} {
+		return {
+			projectSeq: index.projectSeq,
+			files: [...index.fileSeqByPath.entries()].sort((a, b) =>
+				a[0].localeCompare(b[0]),
+			),
+		};
+	}
+
+	/**
+	 * Build a base exactly as production would: the derived index of the log AS
+	 * OF seq `sinceSeq`. We read the log after appending only the entries up to
+	 * `sinceSeq`, which is precisely what the runtime holds (and stamps into the
+	 * snapshot) at that seq.
+	 */
+	function baseAsOf(sinceSeq: number): ProjectSequenceBase {
+		const idx = readLatestProjectSequence(cwd);
+		return {
+			projectSeq: idx.projectSeq,
+			fileSeqByPath: [...idx.fileSeqByPath.entries()],
+			sinceSeq,
+		};
+	}
+
+	beforeEach(() => {
+		env = setupTestEnvironment("project-changes-partial-");
+		previousDataDir = process.env.PILENS_DATA_DIR;
+		process.env.PILENS_DATA_DIR = path.join(env.tmpDir, "data");
+		cwd = path.join(env.tmpDir, "project");
+	});
+
+	afterEach(() => {
+		if (previousDataDir === undefined) delete process.env.PILENS_DATA_DIR;
+		else process.env.PILENS_DATA_DIR = previousDataDir;
+		env.cleanup();
+	});
+
+	it("no new entries since S: partial == full (both == base)", () => {
+		append(1, fileA(), 1);
+		append(2, fileA(), 2);
+		append(3, fileB(), 1);
+		const base = baseAsOf(3);
+
+		const full = readLatestProjectSequence(cwd);
+		const partial = readLatestProjectSequence(cwd, base);
+		expect(shape(partial)).toEqual(shape(full));
+		expect(partial.projectSeq).toBe(3);
+	});
+
+	it("new entries for new + existing files: partial == full", () => {
+		append(1, fileA(), 1);
+		append(2, fileB(), 1);
+		const base = baseAsOf(2);
+		// existing file bumped + a brand-new file appears after S
+		append(3, fileA(), 2);
+		append(4, fileC(), 1);
+
+		const full = readLatestProjectSequence(cwd);
+		const partial = readLatestProjectSequence(cwd, base);
+		expect(shape(partial)).toEqual(shape(full));
+		expect(partial.projectSeq).toBe(4);
+	});
+
+	it("a file deleted/last-touched since S: partial == full", () => {
+		append(1, fileA(), 1);
+		append(2, fileB(), 1);
+		append(3, fileC(), 1);
+		const base = baseAsOf(3);
+		// a later 'external' delete-style change bumps fileB's seq; the fold keeps
+		// the max, so the key persists — partial must reproduce that exactly.
+		append(4, fileB(), 2, "external");
+
+		const full = readLatestProjectSequence(cwd);
+		const partial = readLatestProjectSequence(cwd, base);
+		expect(shape(partial)).toEqual(shape(full));
+		expect(partial.projectSeq).toBe(4);
+	});
+
+	it("empty log: partial (base at seq 0) == full == empty", () => {
+		const base: ProjectSequenceBase = {
+			projectSeq: 0,
+			fileSeqByPath: [],
+			sinceSeq: 0,
+		};
+		const full = readLatestProjectSequence(cwd);
+		const partial = readLatestProjectSequence(cwd, base);
+		expect(shape(full)).toEqual({ projectSeq: 0, files: [] });
+		expect(shape(partial)).toEqual(shape(full));
+	});
+
+	it("gaps / out-of-order entries after S: partial == full", () => {
+		append(1, fileA(), 1);
+		append(3, fileB(), 1); // gap: no seq 2
+		const base = baseAsOf(3);
+		// deliberately append out of seq order, and with a gap
+		append(6, fileC(), 1);
+		append(5, fileA(), 2);
+
+		const full = readLatestProjectSequence(cwd);
+		const partial = readLatestProjectSequence(cwd, base);
+		expect(shape(partial)).toEqual(shape(full));
+		expect(partial.projectSeq).toBe(6);
+	});
+
+	it("legacy snapshot (no base) folds the full log", () => {
+		append(1, fileA(), 1);
+		append(2, fileB(), 1);
+		const full = readLatestProjectSequence(cwd);
+		// undefined base is the legacy path — identical to a full replay.
+		const legacy = readLatestProjectSequence(cwd, undefined);
+		expect(shape(legacy)).toEqual(shape(full));
+		expect(legacy.projectSeq).toBe(2);
+	});
+
+	it("snapshot seq AHEAD of log: falls back to full replay (never serves the stale seq)", () => {
+		append(1, fileA(), 1);
+		append(2, fileB(), 1);
+		// A base whose sinceSeq is beyond the log's max seq (log truncated/rotated
+		// below the snapshot, or snapshot ahead). Its bogus contents must be
+		// ignored in favor of the real log.
+		const aheadBase: ProjectSequenceBase = {
+			projectSeq: 99,
+			fileSeqByPath: [["/bogus/ghost.ts", 42]],
+			sinceSeq: 99,
+		};
+		const full = readLatestProjectSequence(cwd);
+		const guarded = readLatestProjectSequence(cwd, aheadBase);
+		expect(shape(guarded)).toEqual(shape(full));
+		expect(guarded.projectSeq).toBe(2);
+		expect(
+			[...guarded.fileSeqByPath.keys()].some((k) => k.includes("ghost")),
+		).toBe(false);
+	});
+
+	it("bounds the work: partial folds strictly FEWER entries than full", () => {
+		for (let seq = 1; seq <= 18; seq++) {
+			append(seq, seq % 2 === 0 ? fileA() : fileB(), Math.ceil(seq / 2));
+		}
+		const base = baseAsOf(18);
+		append(19, fileA(), 10);
+		append(20, fileC(), 1);
+
+		resetSequenceFoldCountForTests();
+		readLatestProjectSequence(cwd);
+		const fullFolds = getSequenceFoldCountForTests();
+
+		resetSequenceFoldCountForTests();
+		readLatestProjectSequence(cwd, base);
+		const partialFolds = getSequenceFoldCountForTests();
+
+		// full replays every entry (20); partial folds only the 2 with seq > 18.
+		expect(fullFolds).toBe(20);
+		expect(partialFolds).toBe(2);
+		expect(partialFolds).toBeLessThan(fullFolds);
 	});
 });

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -136,6 +136,34 @@ describe("project snapshot", () => {
 			expect(isProjectSnapshotFresh(loaded, 7)).toBe(true);
 		}));
 
+	it("embeds the derived sequence index in BOTH the body and the meta sidecar (#1019)", () =>
+		withProjectDataDir((cwd) => {
+			// A runtime with a real per-file sequence state at seq=3.
+			const runtime = new RuntimeCoordinator();
+			runtime.bumpFileSeq(path.join(cwd, "src", "a.ts")); // seq 1, a:1
+			runtime.bumpFileSeq(path.join(cwd, "src", "a.ts")); // seq 2, a:2
+			runtime.bumpFileSeq(path.join(cwd, "src", "b.ts")); // seq 3, b:1
+			expect(runtime.projectSeq).toBe(3);
+
+			const snapshot = buildProjectSnapshotFromRuntime({ cwd, runtime });
+			// Body carries it, consistent with `seq`.
+			expect(snapshot.sequenceIndex?.projectSeq).toBe(3);
+			expect(snapshot.sequenceIndex?.projectSeq).toBe(snapshot.seq);
+			saveProjectSnapshot(cwd, snapshot);
+
+			// Round-trips through the body...
+			const loaded = loadProjectSnapshot(cwd);
+			expect(loaded?.sequenceIndex?.projectSeq).toBe(3);
+			// ...and, crucially, through the CHEAP meta sidecar (read without
+			// parsing the body) so the interactive path can hydrate the base.
+			const meta = readProjectSnapshotMeta(cwd);
+			expect(meta?.seq).toBe(3);
+			expect(meta?.sequenceIndex?.projectSeq).toBe(3);
+			const metaFiles = new Map(meta?.sequenceIndex?.fileSeqByPath ?? []);
+			// Keys are the same normalizeMapKey form the change-log replay uses.
+			expect([...metaFiles.values()].sort()).toEqual([1, 2]);
+		}));
+
 	it("persists the word index and hydrates a searchable copy", () =>
 		withProjectDataDir((cwd) => {
 			const runtime = new RuntimeCoordinator();

--- a/tests/clients/startup-overhead.test.ts
+++ b/tests/clients/startup-overhead.test.ts
@@ -171,12 +171,14 @@ describe("startup overhead — interactive path regression guard", () => {
 			const phases = new Map(
 				latencyEntries.map((entry) => [entry.phase, entry]),
 			);
+			// #1019: session_start_log_cleanup is intentionally NOT asserted here —
+			// it was deferred off the critical path (setImmediate) and so is not
+			// emitted synchronously within handleSessionStart's awaited chain.
 			expect([...phases.keys()]).toEqual(
 				expect.arrayContaining([
 					"bootstrap_clients_load",
 					"session_start_prehandler",
 					"session_start_runtime_reset",
-					"session_start_log_cleanup",
 					"session_start_sequence_read",
 					"session_start_snapshot_load",
 					"session_start_total",
@@ -199,7 +201,6 @@ describe("startup overhead — interactive path regression guard", () => {
 			const topLevel = [
 				"session_start_prehandler",
 				"session_start_runtime_reset",
-				"session_start_log_cleanup",
 				"session_start_sequence_read",
 				"session_start_snapshot_load",
 			];


### PR DESCRIPTION
## Problem (#1019)

The quick/interactive session-start path spent ~94 ms (≈47% of a 200 ms start) in `session_start_sequence_read` → `readLatestProjectSequence`, which folds the ENTIRE append-only project-changes log, calling `normalizeMapKey` → `realpathSync.native()` (one FS syscall) per historical entry. Cost grows with total log length, not the working set — an unbounded creep on the interactive path.

## Fix — snapshot-embedded sequence index (bounds the replay)

The project snapshot is already seq-stamped. Persist the derived `{ projectSeq, fileSeqByPath }` as of `snapshot.seq`, mirrored into the tiny **`project-snapshot.meta.json` sidecar** so the interactive path hydrates it **without parsing the 40–112 MB snapshot body** (preserving the #947 skip-stale optimization). Then fold only entries with `seq > snapshot.seq` — O(changes since snapshot) instead of O(entire log), eliminating the per-historical-entry `realpath` syscalls that were the measured dominator.

- **`readLatestProjectSequence(cwd, base?)`** — with a base, `partialReplay` hydrates it (keys already in `normalizeMapKey(path.resolve())` form, no re-normalization) and folds only `seq > base.sinceSeq` with the **same `Math.max`/normalizer** as the full replay → byte-identical result (append-only, single-writer invariant; gaps/out-of-order tolerated identically).
- **Fallbacks (never serve a wrong seq):** legacy/missing/version-mismatched meta → full replay; `base.sinceSeq > logMaxSeq` (truncation/rotation/stale/ahead) → `null` → full replay. Wired into all three call sites (quick path, full path, word-index warmup).
- All snapshot-write sites populate the field (`buildProjectSnapshotFromRuntime` + the `word-index.ts`/`reverse-deps.ts` side-writes carry it forward at the same seq).

## Secondary — defer `log_cleanup`

`runLogCleanup` moved off the synchronous critical path into `setImmediate` (still runs every session, notifies async) — ~7 ms removed; its `session_start_log_cleanup` phase now carries `deferred: true`.

## Correctness proof (the key deliverable)

Equivalence tests assert **partial == full** for: no-new-entries, new+existing files, delete/last-touch, gaps/out-of-order, empty log, legacy (no base → full), and snapshot-seq-ahead (→ fallback, returns real log seq). Plus an **entry-count bound** test (full folds 20 entries, partial folds exactly 2). Snapshot index round-trips through both body and meta sidecar. `startup-overhead` test updated for the deferred cleanup. OS-agnostic throughout (isolated tmp dirs, structural key comparison). Full suite `4937 passed`; `tsc` + `build:dist` clean.

_No live latency capture (no pi host in the worktree); the bound is proven structurally by the entry-count test + the eliminated per-entry `realpath` syscalls that were the 94 ms dominator._

Closes #1019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)