### PR TITLE
fix(quiet-window): no-op turn_summary_emit on a stale pi ctx instead of failing (closes #1039)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **`turn_summary_emit` quiet-window task no longer fails on a stale pi ctx (the #483 quiet window's most frequent live-dogfood error — 55×)** —
+	the `agent_settled` quiet-window task `turn_summary_emit` reads the
+	`lens-turn-summary` flag through `pi.getFlag()` (via `getLensFlag`). The task
+	holder's `pi` is refreshed on every activation, but the quiet window is fired
+	fire-and-forget from `agent_settled`, so an interim session
+	replacement/reload (`ctx.newSession/fork/switchSession/reload` — common in the
+	in-process subagent flow #473) invalidates that captured `pi`; the very next
+	`pi.getFlag()` then throws the SDK's stale-ctx guard. That throw sat OUTSIDE
+	the existing `sendMessage` try/catch, so it escaped the task and the scheduler
+	logged `quiet_window: task "turn_summary_emit" failed: … stale after session
+	replacement or reload` — 55 times across two weeks of dogfooding, the single
+	most frequent error in `~/.pi-lens/sessionstart.log`, and it fired even with
+	the feature OFF (the flag READ throws before the flag value is known). Fix:
+	the task now recognises the stale-ctx throw (new `isStaleExtensionCtxError`
+	message matcher) at both pi touch points (flag read + emit) and degrades to a
+	logged no-op — the session that run's summary belonged to is gone, so there is
+	nothing to emit into — while a genuine error still propagates to the scheduler
+	(recorded `ok:false`). User impact was minimal (a lost summary for the exact
+	settle that raced a session swap, plus log noise), not silent feature
+	degradation: in steady state the task runs `ok:true`. Separately, the
+	quiet-window runner now logs the failing task's **stack** (not just `${err}`'s
+	message) so the next failure is diagnosable from the log alone; it remains
+	strictly non-fatal (per-task try/catch, `runQuietWindow` never rethrows, and
+	`agent_settled` invokes it fire-and-forget — a failing task can never break the
+	turn). Regression test drives the registered task against a `pi` whose
+	`getFlag` throws the stale-ctx error and asserts a no-op (no throw, no emit);
+	it fails pre-fix.
 - **Word index no longer serves stale postings after a case/separator-divergent edit (refs #1025, closes #1025 item #2)** —
 	the word index's `docLengths`/`forward`/`fileMtimes` maps are keyed on file
 	paths, but the full/incremental BUILD keyed on the on-disk casing the

--- a/clients/quiet-window.ts
+++ b/clients/quiet-window.ts
@@ -160,7 +160,16 @@ export async function runQuietWindow(deps: QuietWindowDeps): Promise<void> {
 				await task.fn();
 			} catch (err) {
 				ok = false;
-				dbg(`quiet_window: task "${task.name}" failed: ${err}`);
+				// Surface the stack (not just the message) so the next failure is
+				// diagnosable from the log alone — a task can fail dozens of times
+				// and `${err}` (message only) may not pin the throw site. Still
+				// non-fatal: the loop continues and runQuietWindow never rethrows
+				// (see the finally below), so one bad task can't break the turn.
+				const detail =
+					err instanceof Error
+						? (err.stack ?? `${err.name}: ${err.message}`)
+						: String(err);
+				dbg(`quiet_window: task "${task.name}" failed: ${detail}`);
 			}
 			results.push({
 				name: task.name,

--- a/index.ts
+++ b/index.ts
@@ -207,6 +207,23 @@ function log(_msg: string) {
 	// Previously tied to --lens-verbose flag, now disabled
 }
 
+/**
+ * The pi SDK invalidates a captured `pi`/command ctx after a session
+ * replacement or reload (ctx.newSession/fork/switchSession/reload); every later
+ * `pi.*` call then throws with this signature (installed SDK:
+ * core/extensions/loader.js `assertActive`). We match by message — not `===` a
+ * captured instance — so a fire-and-forget task that races a session swap can
+ * recognise the benign stale-ctx throw and degrade to a no-op. Substring-matched
+ * on the stable "stale after session replacement or reload" phrase so it
+ * survives incidental wording changes around it.
+ */
+function isStaleExtensionCtxError(err: unknown): boolean {
+	return (
+		err instanceof Error &&
+		err.message.includes("stale after session replacement or reload")
+	);
+}
+
 // --- State ---
 
 const runtime = new RuntimeCoordinator();
@@ -1736,7 +1753,31 @@ export default function (pi: ExtensionAPI) {
 		registerQuietWindowTask("turn_summary_emit", () => {
 			const emitCtx = _turnSummaryEmitCtx;
 			if (!emitCtx || !emitCtx.isLensEnabled()) return;
-			if (!emitCtx.getLensFlag("lens-turn-summary")) return;
+			// The captured `pi` can go STALE between the activation that set this
+			// holder and this fire-and-forget quiet-window run: an interim
+			// newSession/fork/switchSession/reload invalidates the runtime, after
+			// which any `pi.*` call — the getFlag below (reached first), or the
+			// sendMessage later — throws the SDK's stale-ctx guard. That is benign
+			// here: the session this run's summary belonged to is gone, so there is
+			// nothing to emit into. Treat it as a no-op, NOT a task failure — this
+			// exact throw at the flag read (outside the sendMessage try/catch)
+			// spammed the live-dogfood sessionstart.log 55× as `quiet_window:
+			// task "turn_summary_emit" failed` — the single most frequent error in
+			// that log. A non-stale error still propagates to the scheduler so it
+			// is recorded (ok:false) + logged with its stack.
+			let turnSummaryEnabled: boolean | string | undefined;
+			try {
+				turnSummaryEnabled = emitCtx.getLensFlag("lens-turn-summary");
+			} catch (err) {
+				if (isStaleExtensionCtxError(err)) {
+					dbg(
+						"turn_summary_emit: skipped — captured pi ctx is stale (session replaced/reloaded before the quiet window ran)",
+					);
+					return;
+				}
+				throw err;
+			}
+			if (!turnSummaryEnabled) return;
 			if (runtime.turnSummary.isEmpty()) return;
 			const summaryStart = Date.now();
 			const cwd = runtime.projectRoot || process.cwd();
@@ -1756,6 +1797,12 @@ export default function (pi: ExtensionAPI) {
 						details,
 					});
 				} catch (sendErr) {
+					if (isStaleExtensionCtxError(sendErr)) {
+						dbg(
+							"turn_summary_emit: skipped emit — pi ctx went stale (session replaced/reloaded)",
+						);
+						return;
+					}
 					dbg(`turn-summary sendMessage failed: ${sendErr}`);
 				}
 			} else {

--- a/tests/index-integration.test.ts
+++ b/tests/index-integration.test.ts
@@ -1546,4 +1546,51 @@ describe("#484 turn-summary emit at the agent_settled quiet window", () => {
 		await driveEditThenTurnEnd(handlers, filePath);
 		await expect(fireAgentSettled(handlers)).resolves.not.toThrow();
 	}, INTEGRATION_TIMEOUT_MS);
+
+	it("no-ops (does not fail the quiet-window task) when the captured pi ctx has gone stale", async () => {
+		vi.doMock("../clients/pipeline.js", () => ({
+			runPipeline: vi.fn(async () => workingPipelineResult()),
+		}));
+		mockSuiteDeps();
+
+		const filePath = path.join(tmpDir, "src", "app.ts");
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, "export const x = 1;\n");
+
+		const { default: registerExtension } = await import("../index.ts");
+		const { pi, handlers, sentMessages } = createMockPi({
+			"lens-turn-summary": true,
+		});
+		registerExtension(pi as any);
+
+		// Populate the run's collector so the task would proceed past isEmpty()
+		// on a live ctx — proving the guard added by the fix, not an empty-run
+		// early return, is what makes this a no-op.
+		await driveEditThenTurnEnd(handlers, filePath);
+
+		// Simulate the SDK invalidating the captured pi after a session
+		// replacement/reload (newSession/fork/switchSession/reload): from then on
+		// every `pi.*` call throws the stale-ctx guard. The turn_summary_emit task
+		// hits pi.getFlag (via getLensFlag) FIRST — outside the sendMessage
+		// try/catch — so pre-fix that throw propagated out of the task and the
+		// real scheduler logged it 55× in live dogfood as `task
+		// "turn_summary_emit" failed` (the log's most frequent error).
+		const STALE_MSG =
+			"This extension ctx is stale after session replacement or reload. " +
+			"Do not use a captured pi or command ctx after ctx.newSession(), " +
+			"ctx.fork(), ctx.switchSession(), or ctx.reload().";
+		(pi as unknown as Record<string, unknown>).getFlag = () => {
+			throw new Error(STALE_MSG);
+		};
+
+		const task = quietTasks.find((t) => t.name === "turn_summary_emit");
+		expect(task).toBeDefined();
+		// Run the task directly: the suite's runQuietWindow stub swallows task
+		// throws (mirroring the real scheduler), so driving fireAgentSettled would
+		// hide the regression. Awaiting the task itself surfaces it — pre-fix this
+		// rejects with the stale-ctx Error; post-fix it resolves to a no-op.
+		await expect((async () => task?.fn())()).resolves.toBeUndefined();
+		// Nothing is emitted into the replaced session.
+		expect(sentMessages).toHaveLength(0);
+	}, INTEGRATION_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Bug (#1039)

`turn_summary_emit` (a #483 quiet-window task, fired fire-and-forget at `agent_settled`) threw **55×** in live dogfood logs — the most frequent error. Its captured `pi` goes **stale** when an interim session replacement/reload (#473 in-process-subagent flow) invalidates the runtime; the next `pi.*` call throws the SDK's `assertActive` stale-ctx guard. The throw lands at the **flag read** (`getLensFlag("lens-turn-summary")`), reached *before* the flag value is known — so it fires **even when the feature is OFF** (default) — and it sat outside the existing `sendMessage` try/catch, so it escaped as a task failure.

## Fix

- Added `isStaleExtensionCtxError()` (substring match on the stable *"stale after session replacement or reload"* phrase — matched by message, not a captured instance, so a fire-and-forget racer can recognize the benign throw). Guarded **both** `pi` touch points (flag read + `sendMessage`): stale → `dbg` no-op + return (the session this run's summary belonged to is gone — nothing to emit into); a **genuine** non-stale error still `throw`s to the scheduler so it's recorded `ok:false`.
- `clients/quiet-window.ts` now logs the failing task's **stack** (not just `${err}`), so the next failure is diagnosable from the log alone.
- **Non-fatal invariant preserved & verified:** each quiet-window task is individually try/caught, `runQuietWindow` never rethrows (`finally`), `agent_settled` invokes it fire-and-forget — a failing task can't break the turn.

## Impact
Not silent feature degradation — steady state runs `ok:true` and summaries emit; only the summary for the exact settle that raced a session swap was lost (plus the log spam).

## Tests
New regression test drives the emit against a stale captured ctx and asserts it **no-ops instead of rejecting** — **fails pre-fix** on the exact throw site (`index.ts:1739` → `getLensFlag` → `pi.getFlag`), recorded. Full suite `4953 passed` (0 failures); `tsc` + `build:dist` clean.

Closes #1039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)