### PR TITLE
fix(read-guard): persist and rehydrate read-set across session resume (closes #1041)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to pi-lens will be documented in this file.
 
 ## [Unreleased]
 
+- **Read-before-edit guard now survives a session resume (#1041)** — the
+	guard's read-set was in-memory only, so a `pi --session <id>` resume (which
+	resets the runtime to a fresh empty guard) falsely `zero_read`-blocked the
+	first edit of any file read in the prior session. The read-set now rides the
+	same #190 `PersistedSessionState` save/load path that widget diagnostics use:
+	`ReadGuard.exportState()`/`importState()` persist and rehydrate `reads`,
+	reconciling each read against current disk (line-hash verified) so a resume
+	drops any read whose file changed or vanished — a rehydrated read never masks
+	a real staleness. Forked sessions adopt the parent's read-set via the same
+	in-memory hand-off as widget state. Backward-compatible: the field is optional
+	and pre-#1041 persisted sessions load cleanly as "no prior reads".
+
 - **`turn_summary_emit` quiet-window task no longer fails on a stale pi ctx (the #483 quiet window's most frequent live-dogfood error — 55×)** —
 	the `agent_settled` quiet-window task `turn_summary_emit` reads the
 	`lens-turn-summary` flag through `pi.getFlag()` (via `getLensFlag`). The task

--- a/clients/read-guard.ts
+++ b/clients/read-guard.ts
@@ -90,6 +90,24 @@ export interface ReadGuardConfig {
 	}>;
 }
 
+/**
+ * Serializable snapshot of the guard's read-set (#1041). The in-memory `reads`
+ * map is process-bound, so a `pi --session <id>` resume — which resets the
+ * runtime to a fresh empty guard — used to falsely `zero_read`-block the first
+ * edit of any file the prior session had read. Persisting `reads` on the SAME
+ * #190 `PersistedSessionState` path that widget diagnostics ride lets a resumed
+ * session rehydrate its read history. Only `reads` is persisted: edits/written
+ * markers are re-derivable and `reads` is the payload that gates `checkEdit`.
+ * Keys are `normalizeFilePath` form (see {@link ReadGuard.key}) so the round
+ * trip re-folds identically on Windows/Linux.
+ */
+export interface PersistedReadGuardState {
+	version: number;
+	reads: Array<[string, ReadRecord[]]>;
+}
+
+const READ_GUARD_STATE_VERSION = 1;
+
 // --- Constants ---
 
 const DEFAULT_CONFIG: ReadGuardConfig = {
@@ -722,6 +740,72 @@ export class ReadGuard {
 	 */
 	getReadHistory(filePath: string): ReadRecord[] {
 		return this.reads.get(this.key(filePath)) ?? [];
+	}
+
+	/**
+	 * Snapshot the read-set for persistence across a session resume (#1041).
+	 * Mirrors widget-state's `exportWidgetState`: the Map is emitted as
+	 * `[key, records]` tuples, keys already in `normalizeFilePath` form. Only
+	 * `reads` is serialized — it is the payload `checkEdit`'s zero-read/coverage
+	 * checks consult. Safe to call even when the guard is disabled (an empty or
+	 * never-populated `reads` simply exports zero entries).
+	 */
+	exportState(): PersistedReadGuardState {
+		return {
+			version: READ_GUARD_STATE_VERSION,
+			reads: [...this.reads.entries()].map(([key, records]) => [
+				key,
+				records.map((record) => ({ ...record })),
+			]),
+		};
+	}
+
+	/**
+	 * Rehydrate a persisted read-set (#1041) into this (fresh, post-resume)
+	 * guard, with mandatory staleness reconciliation: each read is re-verified
+	 * against the CURRENT on-disk content via its recorded `lineHashes`, and any
+	 * read whose file changed (or no longer exists, or that carries no verifiable
+	 * hashes) is DROPPED. A rehydrated read must never mask a real staleness — a
+	 * resume must not let the agent edit a file that changed on disk while it
+	 * believed it held a fresh read. Kept reads are replayed through
+	 * {@link recordRead}, which re-keys through {@link key} (idempotent — the
+	 * exported keys are already normalized) and re-stamps FileTime so the next
+	 * `checkEdit` sees a consistent baseline. Version-guarded and null-safe:
+	 * `undefined` / a mismatched version / a missing field loads as "no prior
+	 * reads". Returns a count of imported vs dropped reads for logging.
+	 */
+	importState(state: PersistedReadGuardState | undefined): {
+		imported: number;
+		dropped: number;
+	} {
+		const result = { imported: 0, dropped: 0 };
+		if (!state || state.version !== READ_GUARD_STATE_VERSION) return result;
+		for (const entry of state.reads ?? []) {
+			const [rawPath, records] = entry;
+			if (!Array.isArray(records) || records.length === 0) continue;
+			const filePath = this.key(rawPath);
+			let lines: string[];
+			try {
+				lines = splitLines(fs.readFileSync(filePath, "utf-8"));
+			} catch {
+				// File gone since it was read → drop every read for it.
+				result.dropped += records.length;
+				continue;
+			}
+			for (const record of records) {
+				const rehydrated: ReadRecord = { ...record, filePath };
+				// readHashesStillMatch returns false when the recorded hashes no
+				// longer match disk OR when the read captured no hashes — both
+				// unverifiable, so both drop (safety over convenience).
+				if (this.readHashesStillMatch(rehydrated, lines)) {
+					this.recordRead(rehydrated);
+					result.imported += 1;
+				} else {
+					result.dropped += 1;
+				}
+			}
+		}
+		return result;
 	}
 
 	/**

--- a/clients/read-guard.ts
+++ b/clients/read-guard.ts
@@ -780,8 +780,17 @@ export class ReadGuard {
 	} {
 		const result = { imported: 0, dropped: 0 };
 		if (!state || state.version !== READ_GUARD_STATE_VERSION) return result;
-		for (const entry of state.reads ?? []) {
+		// A corrupt/hand-edited sidecar must degrade to "no prior reads", never
+		// throw: loadSessionState validates only version/widget, so a malformed
+		// `reads` reaches here. If importState threw, the session_start try/catch
+		// would abort the ENTIRE rehydration (incl. widget + mountLensWidget)
+		// rather than just skipping the read-set.
+		if (!Array.isArray(state.reads)) return result;
+		for (const entry of state.reads) {
+			// Skip anything that isn't a well-formed [key, records] tuple.
+			if (!Array.isArray(entry) || entry.length !== 2) continue;
 			const [rawPath, records] = entry;
+			if (typeof rawPath !== "string") continue;
 			if (!Array.isArray(records) || records.length === 0) continue;
 			const filePath = this.key(rawPath);
 			let lines: string[];

--- a/clients/session-state-store.ts
+++ b/clients/session-state-store.ts
@@ -14,6 +14,7 @@ import * as path from "node:path";
 import { writeFileAtomicAsync } from "./atomic-write.js";
 import { getProjectDataDir } from "./file-utils.js";
 import { readJsonCacheAsync } from "./json-cache-read.js";
+import type { PersistedReadGuardState } from "./read-guard.js";
 import type { PersistedWidgetState } from "./widget-state.js";
 
 const STATE_VERSION = 1;
@@ -23,6 +24,14 @@ export interface PersistedSessionState {
 	sessionId: string;
 	savedAt: number;
 	widget: PersistedWidgetState;
+	/**
+	 * Read-before-edit guard read-set (#1041). Optional and additive: sessions
+	 * persisted before this field existed simply omit it, and load cleanly as
+	 * "no prior reads" — so STATE_VERSION is deliberately NOT bumped (a bump
+	 * would reject those older files entirely and lose their widget rehydration
+	 * too). Rehydrated with disk-staleness reconciliation by ReadGuard.importState.
+	 */
+	readGuard?: PersistedReadGuardState;
 }
 
 /**
@@ -69,6 +78,7 @@ export async function saveSessionState(
 	cwd: string,
 	sessionId: string | undefined,
 	widget: PersistedWidgetState,
+	readGuard?: PersistedReadGuardState,
 ): Promise<void> {
 	if (!sessionId || !sessionId.trim()) return;
 	try {
@@ -79,6 +89,7 @@ export async function saveSessionState(
 			sessionId,
 			savedAt: Date.now(),
 			widget,
+			...(readGuard ? { readGuard } : {}),
 		};
 		const file = sessionFilePath(cwd, sessionId);
 		// bestEffort (default): a failed write/rename just means this snapshot is

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ import {
 	setRenderCallback,
 } from "./clients/widget-state.js";
 import { selectLspStatus } from "./clients/lsp-status.js";
+import type { PersistedReadGuardState } from "./clients/read-guard.js";
 import {
 	dropStaleFiles,
 	loadSessionState,
@@ -456,6 +457,10 @@ export default function (pi: ExtensionAPI) {
 	// `session_start` (reason="fork"). In-memory hand-off (same process) — avoids
 	// deriving the source id from a file path (the id lives in the file header).
 	let pendingForkSnapshot: PersistedWidgetState | undefined;
+	// #1041: the source session's read-guard read-set, stashed at
+	// `session_before_fork` alongside the widget snapshot so a forked session
+	// adopts its parent's read history (same in-memory hand-off pattern).
+	let pendingForkReadGuard: PersistedReadGuardState | undefined;
 	type LensWidgetTui = { requestRender: () => void };
 	type LensWidgetTheme = { fg: (color: string, s: string) => string };
 	type LensWidgetComponent = {
@@ -1335,25 +1340,39 @@ export default function (pi: ExtensionAPI) {
 				importWidgetState(pendingForkSnapshot);
 				const forkedFileCount = pendingForkSnapshot.files.length;
 				pendingForkSnapshot = undefined;
+				// #1041: adopt the source session's read history (staleness-reconciled
+				// against current disk) so the fork isn't zero-read-blocked on files
+				// the parent already read.
+				let forkReadImport: { imported: number; dropped: number } | undefined;
+				if (pendingForkReadGuard) {
+					forkReadImport = runtime.readGuard.importState(pendingForkReadGuard);
+					pendingForkReadGuard = undefined;
+				}
 				if (stableSessionId) {
 					void saveSessionState(
 						ctx.cwd ?? process.cwd(),
 						stableSessionId,
 						exportWidgetState(),
+						runtime.readGuard.exportState(),
 					);
 				}
 				dbg(
-					`session_start: fork — branched ${forkedFileCount} file(s) from source`,
+					`session_start: fork — branched ${forkedFileCount} file(s) from source` +
+						(forkReadImport
+							? `, read-guard +${forkReadImport.imported} (dropped ${forkReadImport.dropped})`
+							: ""),
 				);
 			} else if (startMode === "keep") {
 				dbg("session_start: reload — keeping widget state");
 			} else if (startMode === "clean") {
 				pendingForkSnapshot = undefined;
+				pendingForkReadGuard = undefined;
 				clearWidgetState();
 				dbg("session_start: new — clean widget");
 			} else {
 				// maybe-rehydrate: covers resume AND startup (e.g. `pi --session <id>`)
 				pendingForkSnapshot = undefined;
+				pendingForkReadGuard = undefined;
 				clearWidgetState();
 				if (stableSessionId) {
 					const persisted = await loadSessionState(
@@ -1369,9 +1388,20 @@ export default function (pi: ExtensionAPI) {
 						);
 						const dropped = persisted.widget.files.length - fresh.files.length;
 						importWidgetState(fresh);
+						// #1041: rehydrate the read-before-edit guard's read-set on the
+						// SAME path so the first post-resume edit of a previously-read
+						// file isn't falsely zero-read-blocked. importState reconciles
+						// each read against current disk (drops changed/missing files),
+						// so a resume never masks a real staleness.
+						const readImport = runtime.readGuard.importState(
+							persisted.readGuard,
+						);
 						dbg(
 							`session_start: ${reasonLabel} ${stableSessionId} — rehydrated ${fresh.files.length} file(s)` +
-								(dropped > 0 ? `, dropped ${dropped} stale` : ""),
+								(dropped > 0 ? `, dropped ${dropped} stale` : "") +
+								(readImport.imported > 0 || readImport.dropped > 0
+									? `; read-guard +${readImport.imported} read(s) (dropped ${readImport.dropped} stale)`
+									: ""),
 						);
 					} else {
 						dbg(
@@ -1399,8 +1429,12 @@ export default function (pi: ExtensionAPI) {
 	(pi as any).on("session_before_fork", () => {
 		try {
 			pendingForkSnapshot = exportWidgetState();
+			// #1041: the source guard is still live here (reset happens in the
+			// fork's own session_start, which fires later), so this captures the
+			// parent's read-set for the fork to adopt.
+			pendingForkReadGuard = runtime.readGuard.exportState();
 			dbg(
-				`session_before_fork: stashed ${pendingForkSnapshot.files.length} file(s) for the fork`,
+				`session_before_fork: stashed ${pendingForkSnapshot.files.length} file(s) + ${pendingForkReadGuard.reads.length} read-guard file(s) for the fork`,
 			);
 		} catch (forkErr) {
 			dbg(`session_before_fork crashed: ${forkErr}`);
@@ -1642,6 +1676,9 @@ export default function (pi: ExtensionAPI) {
 					ctx.cwd ?? process.cwd(),
 					runtime.telemetrySessionId,
 					exportWidgetState(),
+					// #1041: persist the read-guard read-set on the same snapshot so a
+					// later resume can rehydrate it (reconciled against disk on load).
+					runtime.readGuard.exportState(),
 				);
 			}
 

--- a/tests/clients/read-guard.test.ts
+++ b/tests/clients/read-guard.test.ts
@@ -1014,6 +1014,130 @@ describe("ReadGuard", () => {
 	});
 });
 
+// #1041: export/import of the read-set across a session resume.
+describe("ReadGuard export/import across resume (#1041)", () => {
+	// Write, then backdate mtime to BEFORE any guard's session start so the file
+	// reads as authored in a prior session (not "written this session"), which is
+	// exactly the resume scenario. Otherwise a just-written file's now-ish mtime
+	// makes wasWrittenThisSession() true and every edit is session-authored.
+	const LONG_AGO = new Date("2000-01-01T00:00:00Z");
+	function writeNumberedLines(filePath: string, count: number): void {
+		fs.writeFileSync(
+			filePath,
+			`${Array.from({ length: count }, (_, i) => `line${i + 1}`).join("\n")}\n`,
+		);
+		fs.utimesSync(filePath, LONG_AGO, LONG_AGO);
+	}
+
+	it("rehydrates a prior read so the first post-resume edit is allowed", () => {
+		const env = setupTestEnvironment("read-guard-resume-");
+		try {
+			const filePath = path.join(env.tmpDir, "foo.ts");
+			writeNumberedLines(filePath, 100);
+
+			// Session 1: read lines 1..100, then editing 40..50 is allowed.
+			const guard1 = createReadGuard("session-1");
+			guard1.recordRead(
+				createReadRecord(filePath, {
+					requestedOffset: 1,
+					requestedLimit: 100,
+					effectiveOffset: 1,
+					effectiveLimit: 100,
+				}),
+			);
+			expect(guard1.checkEdit(filePath, [40, 50]).action).toBe("allow");
+
+			// Session 2: a FRESH guard (models resetForSession wiping state) starts
+			// with no reads → would zero-read-block. After importing the persisted
+			// read-set, the same edit is allowed again.
+			const guard2 = createReadGuard("session-2");
+			expect(guard2.checkEdit(filePath, [40, 50]).action).toBe("block");
+
+			const result = guard2.importState(guard1.exportState());
+			expect(result).toEqual({ imported: 1, dropped: 0 });
+			expect(guard2.getReadHistory(filePath)).toHaveLength(1);
+			expect(guard2.checkEdit(filePath, [40, 50]).action).toBe("allow");
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("drops a rehydrated read whose file content changed on disk (staleness preserved)", () => {
+		const env = setupTestEnvironment("read-guard-resume-stale-");
+		try {
+			const filePath = path.join(env.tmpDir, "foo.ts");
+			writeNumberedLines(filePath, 100);
+
+			const guard1 = createReadGuard("session-1");
+			guard1.recordRead(
+				createReadRecord(filePath, {
+					requestedOffset: 1,
+					requestedLimit: 100,
+					effectiveOffset: 1,
+					effectiveLimit: 100,
+				}),
+			);
+			const exported = guard1.exportState();
+
+			// The file changes on disk between sessions (line 45 rewritten). Keep the
+			// mtime backdated so the drop is driven by the hash mismatch, not by a
+			// now-ish mtime tripping the session-authored allow.
+			const lines = fs.readFileSync(filePath, "utf-8").split("\n");
+			lines[44] = "line45-CHANGED";
+			fs.writeFileSync(filePath, lines.join("\n"));
+			fs.utimesSync(filePath, LONG_AGO, LONG_AGO);
+
+			// A rehydrated read must never mask a real staleness: the changed read
+			// is dropped, so the edit is (correctly) blocked as zero-read.
+			const guard2 = createReadGuard("session-2");
+			const result = guard2.importState(exported);
+			expect(result).toEqual({ imported: 0, dropped: 1 });
+			expect(guard2.getReadHistory(filePath)).toHaveLength(0);
+			expect(guard2.checkEdit(filePath, [40, 50]).action).toBe("block");
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("drops rehydrated reads for a file that no longer exists", () => {
+		const env = setupTestEnvironment("read-guard-resume-missing-");
+		try {
+			const filePath = path.join(env.tmpDir, "gone.ts");
+			writeNumberedLines(filePath, 10);
+			const guard1 = createReadGuard("session-1");
+			guard1.recordRead(
+				createReadRecord(filePath, {
+					requestedOffset: 1,
+					requestedLimit: 10,
+					effectiveOffset: 1,
+					effectiveLimit: 10,
+				}),
+			);
+			const exported = guard1.exportState();
+			fs.rmSync(filePath);
+
+			const guard2 = createReadGuard("session-2");
+			expect(guard2.importState(exported)).toEqual({ imported: 0, dropped: 1 });
+			expect(guard2.getReadHistory(filePath)).toHaveLength(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("import is a null-safe no-op for undefined / mismatched version", () => {
+		const env = setupTestEnvironment("read-guard-resume-compat-");
+		try {
+			const guard = createReadGuard("session-x");
+			expect(guard.importState(undefined)).toEqual({ imported: 0, dropped: 0 });
+			expect(
+				guard.importState({ version: 999, reads: [] }),
+			).toEqual({ imported: 0, dropped: 0 });
+		} finally {
+			env.cleanup();
+		}
+	});
+});
+
 // --- Helpers ---
 
 function createReadRecord(

--- a/tests/clients/read-guard.test.ts
+++ b/tests/clients/read-guard.test.ts
@@ -1136,6 +1136,40 @@ describe("ReadGuard export/import across resume (#1041)", () => {
 			env.cleanup();
 		}
 	});
+
+	it("degrades to a no-op on a malformed payload instead of throwing", () => {
+		const env = setupTestEnvironment("read-guard-resume-malformed-");
+		try {
+			const guard = createReadGuard("session-x");
+
+			// `reads` is not an array (corrupt / hand-edited sidecar).
+			const nonArrayReads = {
+				version: 1,
+				reads: {} as unknown,
+			} as unknown as import("../../clients/read-guard.js").PersistedReadGuardState;
+			expect(() => guard.importState(nonArrayReads)).not.toThrow();
+			expect(guard.importState(nonArrayReads)).toEqual({
+				imported: 0,
+				dropped: 0,
+			});
+
+			// `reads` array with a non-tuple element mixed in with a valid one.
+			const badElement = {
+				version: 1,
+				reads: [[normalizeFilePath("/src/x.ts"), []], 5],
+			} as unknown as import("../../clients/read-guard.js").PersistedReadGuardState;
+			expect(() => guard.importState(badElement)).not.toThrow();
+			expect(guard.importState(badElement)).toEqual({
+				imported: 0,
+				dropped: 0,
+			});
+
+			// The map is uncorrupted — nothing was recorded.
+			expect(guard.getReadHistory("/src/x.ts")).toHaveLength(0);
+		} finally {
+			env.cleanup();
+		}
+	});
 });
 
 // --- Helpers ---

--- a/tests/clients/session-state-store.test.ts
+++ b/tests/clients/session-state-store.test.ts
@@ -13,6 +13,7 @@ import {
 	saveSessionState,
 	sessionStartMode,
 } from "../../clients/session-state-store.js";
+import { createReadGuard } from "../../clients/read-guard.js";
 import {
 	clearWidgetState,
 	exportWidgetState,
@@ -284,5 +285,75 @@ describe("reconcileStaleWidgetFiles — live widget freshness (lens_diagnostics)
 
 		expect(await reconcileStaleWidgetFiles()).toBe(1);
 		expect(getFileDiagnosticSummaries()).toEqual([]);
+	});
+});
+
+describe("read-guard read-set persistence across resume (#1041)", () => {
+	it("save → load → import rehydrates the read-set so a resumed edit is allowed", async () => {
+		// Real file on disk so recordRead captures line hashes and importState can
+		// reconcile them against current content.
+		const fileDir = mkdtempSync(join(tmpdir(), "pi-lens-rg-resume-"));
+		const filePath = join(fileDir, "foo.ts");
+		writeFileSync(
+			filePath,
+			`${Array.from({ length: 50 }, (_, i) => `line${i + 1}`).join("\n")}\n`,
+		);
+		// Backdate mtime so the file reads as authored in a prior session (the
+		// resume scenario) rather than "written this session" — otherwise the edit
+		// is session-authored-allowed and the zero-read baseline assertion is moot.
+		const longAgo = new Date("2000-01-01T00:00:00Z");
+		utimesSync(filePath, longAgo, longAgo);
+		try {
+			// Session 1: record a read, then persist on the SAME #190 snapshot the
+			// widget state rides.
+			const guard1 = createReadGuard("resume-session");
+			guard1.recordRead({
+				filePath,
+				requestedOffset: 1,
+				requestedLimit: 50,
+				effectiveOffset: 1,
+				effectiveLimit: 50,
+				expandedByLsp: false,
+				turnIndex: 1,
+				writeIndex: 1,
+				timestamp: Date.now(),
+			});
+			await saveSessionState(
+				cwd,
+				"resume-session",
+				exportWidgetState(),
+				guard1.exportState(),
+			);
+
+			// Resume (maybe-rehydrate): fresh guard, load persisted state, import.
+			const loaded = await loadSessionState(cwd, "resume-session");
+			expect(loaded?.readGuard).toBeDefined();
+			const guard2 = createReadGuard("resume-session-2");
+			expect(guard2.checkEdit(filePath, [20, 30]).action).toBe("block");
+			const result = guard2.importState(loaded?.readGuard);
+			expect(result.imported).toBe(1);
+			expect(guard2.getReadHistory(filePath)).toHaveLength(1);
+			expect(guard2.checkEdit(filePath, [20, 30]).action).toBe("allow");
+		} finally {
+			rmSync(fileDir, { recursive: true, force: true });
+		}
+	});
+
+	it("backward-compat: a payload persisted with NO readGuard field loads clean", async () => {
+		seedDiagnostics();
+		// Old-style save (pre-#1041) omits the readGuard arg entirely.
+		await saveSessionState(cwd, "legacy-session", exportWidgetState());
+
+		const loaded = await loadSessionState(cwd, "legacy-session");
+		expect(loaded?.widget).toBeDefined();
+		expect(loaded?.readGuard).toBeUndefined();
+
+		// Importing the absent field is a null-safe no-op — no throw.
+		const guard = createReadGuard("legacy-session");
+		expect(() => guard.importState(loaded?.readGuard)).not.toThrow();
+		expect(guard.importState(loaded?.readGuard)).toEqual({
+			imported: 0,
+			dropped: 0,
+		});
 	});
 });


### PR DESCRIPTION
Closes #1041.

## Problem
The read-before-edit guard (`clients/read-guard.ts`) falsely blocked the first post-resume edit of any file read in the prior session. `ReadGuard.reads` is in-memory only; every `session_start` — including a `pi --session <id>` resume — calls `resetForSession()` → fresh empty guard. The resume path rehydrated only widget/diagnostic state (#190 sidecar); the read guard was never persisted or rehydrated. Result: after resume, `checkEdit` saw an empty read-set → zero-read `block: "Edit without read"`, contradicting the agent's own replayed context.

Class: **state-lifetime-across-resume** — the exact gap #190 closed for widget state, left unpatched for the read guard. NOT the #210/#1020 path-key class.

## Fix
Rides the **existing #190 `PersistedSessionState` sidecar** — no new sidecar or lifecycle:
- `ReadGuard.exportState()` / `importState()` serialize the `reads` map as `[normalizedKey, ReadRecord[]]` tuples.
- Wired at the widget-state save site (`turn_end`/`agent_settled`) and the `maybe-rehydrate` **and** `fork` `session_start` branches in `index.ts`, mirroring widget state 1:1. Fork parity via a `pendingForkReadGuard` in-memory hand-off.
- **Staleness reconciliation:** on import, each read is re-verified against current disk via the existing `readHashesStillMatch` line-hash machinery and **dropped** if the file changed, vanished, or carries no verifiable hashes — so a rehydrated read never masks a real staleness.
- Keys round-trip through `normalizeFilePath` (OS-agnostic).

## Compatibility
- `PersistedSessionState.readGuard` is optional and additive; `STATE_VERSION` intentionally NOT bumped (a bump would reject pre-#1041 payloads and lose their widget rehydration too). `PersistedReadGuardState` carries its own inner version.
- Old payloads (no `readGuard`) load clean and import as a no-op. Malformed `readGuard` payloads (non-array `reads`, non-tuple entries) degrade to "no prior reads" instead of throwing and aborting the whole rehydration.

## Tests
- Unit (`tests/clients/read-guard.test.ts`): fresh-guard-post-resume `importState` → `checkEdit` allows; changed-file-on-disk → rehydrated read dropped → `checkEdit` correctly blocks (staleness preserved); malformed-payload no-op.
- Integration (`tests/clients/session-state-store.test.ts`): save after a recorded read → `maybe-rehydrate` branch → `getReadHistory` non-empty; backward-compat for payloads with no `readGuard` field.
- Regression tests verified to FAIL on pre-fix code (neutering `importState` flips the 4 substantive #1041 tests red).
- Full suite: **4956 passed | 14 skipped**.

## Review
Adversarially reviewed (Opus): empirically attacked the staleness-masking path (grown/truncated file across resume, FileTime restamp) — held; drops rather than masks in every interleave. CRLF↔LF confirmed safe cross-OS. The malformed-payload defensive guards were added in response to that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)