### PR TITLE
feat(changelog): guard [Unreleased] against entries the release-notes summarizer would drop or truncate

### DIFF
--- a/scripts/changelog-release.mjs
+++ b/scripts/changelog-release.mjs
@@ -14,7 +14,11 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { promoteUnreleased, unreleasedHasEntries } from "./lib/changelog.mjs";
+import {
+  promoteUnreleased,
+  unreleasedHasEntries,
+  lintUnreleased,
+} from "./lib/changelog.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CHANGELOG_PATH = join(__dirname, "..", "CHANGELOG.md");
@@ -38,6 +42,23 @@ function main() {
   if (args.check) {
     if (!unreleasedHasEntries(text)) {
       console.error("`## [Unreleased]` has no entries to release.");
+      process.exit(1);
+    }
+    // Reject entries the release-notes summarizer would silently mangle
+    // (orphan bullets outside a `### ` heading; wrapped bold titles). Caught
+    // here so a bad entry fails at PR/release time, not after a broken release.
+    const problems = lintUnreleased(text);
+    if (problems.length) {
+      console.error(
+        "`## [Unreleased]` has entries the release-notes summarizer would drop or truncate:",
+      );
+      for (const p of problems) {
+        const hint =
+          p.kind === "orphan"
+            ? "move it under a `### Added/Changed/Fixed/Security` heading"
+            : "put the whole `**bold title (refs #NNN)**` on one line";
+        console.error(`  - [${p.kind}] "${p.text}" — ${hint}`);
+      }
       process.exit(1);
     }
     console.log("[Unreleased] has entries — ready to release.");

--- a/scripts/lib/changelog.d.mts
+++ b/scripts/lib/changelog.d.mts
@@ -15,6 +15,15 @@ export function normalizeVersion(version: string): string;
 export function extractSection(text: string, version: string): string | null;
 export function hasSection(text: string, version: string): boolean;
 export function unreleasedHasEntries(text: string): boolean;
+
+export interface ChangelogLintProblem {
+  kind: "orphan" | "wrapped-title";
+  line: number;
+  text: string;
+}
+
+export function lintSectionBody(body: string | null): ChangelogLintProblem[];
+export function lintUnreleased(text: string): ChangelogLintProblem[];
 export function promoteUnreleased(
   text: string,
   version: string,

--- a/scripts/lib/changelog.mjs
+++ b/scripts/lib/changelog.mjs
@@ -176,6 +176,64 @@ export function unreleasedHasEntries(text) {
   return body !== null && /^\s*[-*]\s/m.test(body);
 }
 
+/**
+ * Lint a section body for entries the release-notes summarizer
+ * (`summarizeSection`) would silently mangle. Returns a list of problems; an
+ * empty list means clean. Two failure modes, both learned from real broken
+ * v3.8.74 release notes:
+ *
+ *   1. `orphan` — a top-level `- ` entry that appears BEFORE the first `### `
+ *      category heading. `summarizeSection` only emits entries under a heading
+ *      (it skips lines while `heading === null`), so an orphan entry is dropped
+ *      from the release body entirely.
+ *   2. `wrapped-title` — a `- **…` entry whose bold title's closing `**` is not
+ *      on the same physical line as the opening. `summarizeSection` reads only
+ *      the entry's first line and emits only the text inside `**…**`, so a
+ *      wrapped title renders truncated AND drops any `(refs #NNN)` that trails
+ *      onto the continuation line.
+ *
+ * Line numbers are 1-based within the passed body.
+ *
+ * @param {string} body a section body (e.g. `extractSection(text, "Unreleased")`)
+ * @returns {Array<{ kind: "orphan" | "wrapped-title", line: number, text: string }>}
+ */
+export function lintSectionBody(body) {
+  const problems = [];
+  if (typeof body !== "string") return problems;
+  const lines = body.split(/\r?\n/);
+  let seenHeading = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trimEnd();
+    if (/^#{2,4}\s/.test(line)) {
+      seenHeading = true;
+      continue;
+    }
+    // Only column-0 `- ` bullets are top-level entries; indented continuation
+    // lines (tab/space + `-`) are part of the preceding entry's prose.
+    const entry = line.match(/^-\s+(.*)$/);
+    if (!entry) continue;
+    if (!seenHeading) {
+      problems.push({ kind: "orphan", line: i + 1, text: entry[1] });
+    }
+    if (entry[1].startsWith("**") && (line.match(/\*\*/g) || []).length < 2) {
+      problems.push({ kind: "wrapped-title", line: i + 1, text: entry[1] });
+    }
+  }
+  return problems;
+}
+
+/**
+ * Lint the `## [Unreleased]` section — the one authors edit per-PR — so a
+ * malformed entry is caught at PR time instead of at release. `[]` when clean.
+ * See {@link lintSectionBody} for the two problem kinds.
+ *
+ * @param {string} text full CHANGELOG.md contents
+ * @returns {ReturnType<typeof lintSectionBody>}
+ */
+export function lintUnreleased(text) {
+  return lintSectionBody(extractSection(text, "Unreleased"));
+}
+
 const EMPTY_UNRELEASED = [
   "## [Unreleased]",
   "",

--- a/tests/scripts/changelog.test.ts
+++ b/tests/scripts/changelog.test.ts
@@ -276,7 +276,7 @@ describe("changelog lib — lintSectionBody / lintUnreleased", () => {
   it("treats a null/missing body as clean", () => {
     // extractSection returns null for an absent section.
     expect(lintUnreleased("# Changelog\n\nno sections here")).toEqual([]);
-    expect(lintSectionBody(null as unknown as string)).toEqual([]);
+    expect(lintSectionBody(null)).toEqual([]);
   });
 });
 

--- a/tests/scripts/changelog.test.ts
+++ b/tests/scripts/changelog.test.ts
@@ -21,6 +21,8 @@ import {
   unreleasedHasEntries,
   promoteUnreleased,
   summarizeSection,
+  lintSectionBody,
+  lintUnreleased,
 } from "../../scripts/lib/changelog.mjs";
 
 const REPO_ROOT = path.resolve(
@@ -196,6 +198,88 @@ describe("changelog lib — summarizeSection", () => {
   });
 });
 
+// The linter mirrors the two ways summarizeSection silently mangled the
+// v3.8.74 release notes: entries added above the first `### ` heading were
+// dropped, and hard-wrapped bold titles rendered truncated without their refs.
+describe("changelog lib — lintSectionBody / lintUnreleased", () => {
+  it("passes a well-formed section", () => {
+    const body = [
+      "### Added",
+      "",
+      "- **A new thing (#10)** — with prose that wraps",
+      "  onto a continuation line, which is fine.",
+      "",
+      "### Fixed",
+      "",
+      "- **A fix (refs #20, closes #20)** — details.",
+      "",
+    ].join("\n");
+    expect(lintSectionBody(body)).toEqual([]);
+  });
+
+  it("flags an orphan entry above the first `### ` heading", () => {
+    const body = [
+      "- **Dropped by the summarizer (#1)** — no heading above it.",
+      "",
+      "### Fixed",
+      "",
+      "- **A fix (#2)** — fine.",
+      "",
+    ].join("\n");
+    const problems = lintSectionBody(body);
+    expect(problems).toHaveLength(1);
+    expect(problems[0].kind).toBe("orphan");
+    expect(problems[0].text).toContain("Dropped by the summarizer");
+  });
+
+  it("flags a bold title whose `**` does not close on the first line", () => {
+    const body = [
+      "### Fixed",
+      "",
+      "- **A title that wraps across a line break",
+      "  and only closes here (refs #33)** — prose.",
+      "",
+    ].join("\n");
+    const problems = lintSectionBody(body);
+    expect(problems).toHaveLength(1);
+    expect(problems[0].kind).toBe("wrapped-title");
+  });
+
+  it("does not flag indented continuation lines that start with `-`", () => {
+    const body = [
+      "### Changed",
+      "",
+      "- **Real entry (#4)** — a list follows:",
+      "  - an indented sub-bullet, not a top-level entry",
+      "  - another one",
+      "",
+    ].join("\n");
+    expect(lintSectionBody(body)).toEqual([]);
+  });
+
+  it("reports both problem kinds together", () => {
+    const body = [
+      "- **Orphan and wrapped at once",
+      "  closes here (#5)** — prose.",
+      "",
+      "### Fixed",
+      "",
+      "- **Clean (#6)** — ok.",
+      "",
+    ].join("\n");
+    const kinds = lintSectionBody(body)
+      .map((p) => p.kind)
+      .sort();
+    expect(kinds).toEqual(["orphan", "wrapped-title"]);
+  });
+
+  it("treats a null/missing body as clean", () => {
+    // extractSection returns null for an absent section.
+    expect(lintUnreleased("# Changelog\n\nno sections here")).toEqual([]);
+    expect(lintSectionBody(null as unknown as string)).toEqual([]);
+  });
+});
+
 describe("repo CHANGELOG.md contract", () => {
   it("has an Unreleased section (may be empty right after a release bump)", () => {
     // Existence, not entries: `changelog:release` promotes [Unreleased] to a
@@ -203,6 +287,19 @@ describe("repo CHANGELOG.md contract", () => {
     // fail on every release commit. `npm run changelog:check` guards the
     // has-entries precondition at the point it actually matters (pre-bump).
     expect(extractSection(CHANGELOG, "Unreleased")).not.toBeNull();
+  });
+
+  // Regression guard for the v3.8.74 release-notes breakage: new entries must be
+  // authored so the summarizer can render them — under a `### ` heading and with
+  // a single-line bold title. Fails at PR time on a malformed [Unreleased] entry.
+  it("has no [Unreleased] entries the release-notes summarizer would mangle", () => {
+    const problems = lintUnreleased(CHANGELOG);
+    expect(
+      problems,
+      `Malformed [Unreleased] entries:\n${problems
+        .map((p) => `  [${p.kind}] ${p.text}`)
+        .join("\n")}`,
+    ).toEqual([]);
   });
 
   // The CHANGELOG begins at the 3.x line; pre-3.x tags predate it (the backfill


### PR DESCRIPTION
## Why
The v3.8.74 release notes lost content two ways, both because entries weren't authored the way `summarizeSection` reads them:
- **Orphan entries** — bullets added ABOVE the first `### ` category heading are silently dropped (`summarizeSection` skips lines while `heading === null`). This is how the entire post-3.8.73 backlog nearly vanished from the release body.
- **Wrapped bold titles** — when a `- **Title (refs #NNN)**` is hard-wrapped so the closing `**` lands on a continuation line, the summarizer (which reads only the first physical line and emits only text inside `**…**`) renders the entry truncated mid-title AND drops its issue/PR refs.

Both were fixed by hand for v3.8.74; this prevents recurrence.

## What
- `lintSectionBody(body)` / `lintUnreleased(text)` in `scripts/lib/changelog.mjs` — return the offending entries (`kind: "orphan" | "wrapped-title"`, with line + text). Empty = clean. Indented continuation lines that start with `-` are correctly ignored (only column-0 bullets are entries).
- Wired into `npm run changelog:check` (`changelog-release.mjs --check`): a malformed `[Unreleased]` now fails with an actionable hint per entry ("move it under a `### …` heading" / "put the whole bold title on one line").
- Regression-guarded in the unit suite: a new `repo CHANGELOG.md contract` test asserts the live `[Unreleased]` is clean, so a bad entry fails at **PR time**, not after a broken release. Plus unit tests for both problem kinds, the both-at-once case, indented-sub-bullet non-flagging, and null-body handling.

## Tests
`tests/scripts/changelog.test.ts` — 24 passed locally (pure string parsing; OS-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)