### PR TITLE
feat(config): per-rule enable/disable in .pi-lens.json (closes #444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Added
 
+- **Project-level rule policy via `.pi-lens.json` `rules.<id>.disable` / `rules.<id>.select`** — a project's own config can now narrow what diagnostics actually surface.
+	Filtering is output-only, so the baseline, widget state, and dedup cache stay
+	authoritative and a policy edit never corrupts or resets delta tracking.
+	Matching is project-wide: the `<id>` key is a grouping label, not a filter
+	scope. Every `disable` list across every key unions into one drop list, and
+	every `select` list unions into one allowlist, so
+	`"security": { "disable": ["no-eval"] }` works without `security` being a real
+	rule id. Disable wins over select project-wide, even across different keys.
+	A non-empty `select` anywhere silences every rule not listed, project-wide, so
+	it is a big hammer (documented as such). Findings that carry no rule id at all
+	are exempt from select, since `Diagnostic.id` is a dedup key rather than a rule
+	id and measuring it against an allowlist would have silently dropped blocking
+	findings like eslint parse errors. A user lists `no-eval` once and the filter
+	covers `no-eval`, `ast-grep:no-eval`, and `no-eval-js`, reusing the rule-id
+	normalization that `inline-suppressions.ts` and `tools/lens-diagnostics.ts`'s
+	dedup already applied, now consolidated in
+	`clients/dispatch/rule-id-normalize.ts` so the three surfaces cannot drift.
+	That normalization conflates a rule whose real name ends in `-js` with its stem
+	(`prefer-js` with `prefer`), which is now pinned by tests and called out in the
+	docs. The policy applies on the per-edit dispatch path
+	(`clients/dispatch/dispatcher.ts`, resolved from the project root so a
+	package-local `.pi-lens.json` in a monorepo cannot shadow the root's policy,
+	matching the root `lens_diagnostics` already used) and across the
+	`lens_diagnostics` tool's `mode=delta`, `mode=all`, and `mode=full` paths. Each
+	loads the policy map once per call, filters after inline suppression and
+	disposition, and re-summarizes so the blocking/error/warning counts reflect the
+	drop, including delta mode's carried-over tally and mode=full's structured
+	`details` counts. In the project-config loader
+	(`clients/project-lens-config.ts`) the lists are tolerantly parsed: a non-array,
+	an empty array, or an all-whitespace array is logged once and dropped, matching
+	the existing threshold-validation warn-once contract. Threshold-only entries are
+	unaffected, and policy-only entries (no `threshold`) coexist cleanly. New
+	`tests/clients/dispatch/rule-policy.test.ts` (32 tests: matcher, normalization,
+	project-wide grouping, disable-wins-select, the `-js` conflation, the rule-less
+	select exemption, and the hot-path fast return),
+	`tests/clients/dispatch/rule-policy-dispatcher.test.ts` (10 tests covering
+	dispatch integration including monorepo root-versus-nested config resolution),
+	`tests/clients/dispatch/rule-id-normalize.test.ts` (8 tests), and
+	`tests/tools/lens-diagnostics-rule-policy.test.ts` (11 tests covering the three
+	mode paths, the delta carried-over tally, and mode=full's structured details).
+	Docs: `docs/settings.md` and `docs/globalconfig.md` gained the project-wide
+	schema, precedence, the select warning, and the `-js` caveat. #533 hygiene is
+	preserved, so typo and unknown-key warnings still surface and foreign LSP
+	namespaces stay silent.
+
 ### Changed
 
 - **Prompt-cache context attribution (refs #1018)** — add bounded `cache_context` latency records that correlate context injection sources, placement, message counts, sizes, and privacy-preserving hashes with provider `cache_usage` by session/turn, while keeping provider cache misses and local prefix changes distinct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,19 +33,29 @@ All notable changes to pi-lens will be documented in this file.
 	loads the policy map once per call, filters after inline suppression and
 	disposition, and re-summarizes so the blocking/error/warning counts reflect the
 	drop, including delta mode's carried-over tally and mode=full's structured
-	`details` counts. In the project-config loader
-	(`clients/project-lens-config.ts`) the lists are tolerantly parsed: a non-array,
-	an empty array, or an all-whitespace array is logged once and dropped, matching
-	the existing threshold-validation warn-once contract. Threshold-only entries are
-	unaffected, and policy-only entries (no `threshold`) coexist cleanly. New
-	`tests/clients/dispatch/rule-policy.test.ts` (32 tests: matcher, normalization,
-	project-wide grouping, disable-wins-select, the `-js` conflation, the rule-less
-	select exemption, and the hot-path fast return),
-	`tests/clients/dispatch/rule-policy-dispatcher.test.ts` (10 tests covering
-	dispatch integration including monorepo root-versus-nested config resolution),
-	`tests/clients/dispatch/rule-id-normalize.test.ts` (8 tests), and
-	`tests/tools/lens-diagnostics-rule-policy.test.ts` (11 tests covering the three
-	mode paths, the delta carried-over tally, and mode=full's structured details).
+	`details` counts. Silencing a rule is not the same as fixing it: the stored
+	delta baseline is deliberately unfiltered, so dispatch compares against a
+	policy-filtered view of it. Otherwise every disabled finding would sit in the
+	"fixed" set on every single dispatch and inflate the agent's resolved tally
+	(`trackAgentFixed`) for as long as the rule stayed off. In the project-config
+	loader (`clients/project-lens-config.ts`) the lists are tolerantly parsed: a
+	non-array, an empty array, or an all-whitespace array is logged once and
+	dropped, matching the existing threshold-validation warn-once contract.
+	Threshold-only entries are unaffected, and policy-only entries (no `threshold`)
+	coexist cleanly. A `rules.<key>` whose value is not an object, or whose keys are
+	all unrecognized, now warns instead of failing silent. That covers the two
+	shapes a user is most likely to reach for first, both of which parse as valid
+	JSON and do nothing: the lists written directly under `rules`, and `only`
+	instead of `select`. New `tests/clients/dispatch/rule-policy.test.ts` (32 tests:
+	matcher, normalization, project-wide grouping, disable-wins-select, the `-js`
+	conflation, the rule-less select exemption, and the hot-path fast return),
+	`tests/clients/dispatch/rule-policy-dispatcher.test.ts` (13 tests covering
+	dispatch integration including monorepo root-versus-nested config resolution,
+	baseline integrity, and the resolved-tally guard),
+	`tests/clients/dispatch/rule-id-normalize.test.ts` (7 tests), and
+	`tests/tools/lens-diagnostics-rule-policy.test.ts` (14 tests covering the three
+	mode paths, `select` on the cache-only paths, the delta carried-over tally, the
+	project-diagnostics delta report, and mode=full's structured details).
 	Docs: `docs/settings.md` and `docs/globalconfig.md` gained the project-wide
 	schema, precedence, the select warning, and the `-js` caveat. #533 hygiene is
 	preserved, so typo and unknown-key warnings still surface and foreign LSP

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -35,6 +35,7 @@ import { applyDispositions } from "../diagnostic-dispositions.js";
 import { applyInlineSuppressions } from "./inline-suppressions.js";
 import { getToolPlan } from "./plan.js";
 import { resolveRunnerPath } from "./runner-context.js";
+import { applyRulePolicy, rulePolicyMapFromConfig } from "./rule-policy.js";
 import { getToolProfile } from "./tool-profile.js";
 import type {
 	Diagnostic,
@@ -783,7 +784,30 @@ export async function dispatchForFile(
 		ctx.filePath,
 		fileContent,
 	);
-	let visibleDiagnostics = dispositionFiltered;
+	// Project rule policy (`.pi-lens.json` `rules.<id>.disable`/`select`) —
+	// output-only filtering applied AFTER inline suppression / disposition so
+	// the project's policy overlays the same set the renderer would see, but
+	// BEFORE widget state / baseline-related processing. The baseline below
+	// still uses `dedupedDiagnostics` (the unfiltered set), so editing a
+	// project's policy doesn't reset / corrupt delta baselines — the
+	// user-authored baseline comparison remains authoritative.
+	//
+	// Resolved from `ctx.projectRoot` (falling back to `ctx.cwd`), NOT
+	// `ctx.projectConfig` — `ctx.projectConfig` is loaded from the nested
+	// LANGUAGE root (`resolveLanguageRootForFile`), so in a monorepo where a
+	// package directory has its own `.pi-lens.json`, `discoverPiLensProjectConfig`'s
+	// upward walk stops there and never sees a repo-root policy.
+	// `lens_diagnostics` loads its policy map from `runtime.projectRoot`; using
+	// the same root here keeps the two surfaces in agreement. `ctx.projectConfig`
+	// itself is untouched — thresholds and mutation flags keep their existing
+	// language-root resolution.
+	const policyKept = applyRulePolicy(
+		dispositionFiltered,
+		rulePolicyMapFromConfig(
+			loadPiLensProjectConfig(ctx.projectRoot ?? ctx.cwd).rules,
+		),
+	);
+	let visibleDiagnostics = policyKept;
 	let resolvedCount = 0;
 	if (ctx.deltaMode && previousBaseline) {
 		const filtered = filterDelta(

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -801,18 +801,21 @@ export async function dispatchForFile(
 	// the same root here keeps the two surfaces in agreement. `ctx.projectConfig`
 	// itself is untouched — thresholds and mutation flags keep their existing
 	// language-root resolution.
-	const policyKept = applyRulePolicy(
-		dispositionFiltered,
-		rulePolicyMapFromConfig(
-			loadPiLensProjectConfig(ctx.projectRoot ?? ctx.cwd).rules,
-		),
+	const rulePolicy = rulePolicyMapFromConfig(
+		loadPiLensProjectConfig(ctx.projectRoot ?? ctx.cwd).rules,
 	);
+	const policyKept = applyRulePolicy(dispositionFiltered, rulePolicy);
 	let visibleDiagnostics = policyKept;
 	let resolvedCount = 0;
 	if (ctx.deltaMode && previousBaseline) {
+		// Silencing a rule is not fixing it. The stored baseline is deliberately
+		// unfiltered (below), so compare against a policy-filtered view of it —
+		// otherwise every disabled finding sits in `fixed` on every dispatch and
+		// inflates the agent's resolved tally (trackAgentFixed) forever. Only
+		// `fixed` changes: policy-dropped ids are absent from `after` either way.
 		const filtered = filterDelta(
 			visibleDiagnostics,
-			previousBaseline,
+			applyRulePolicy(previousBaseline, rulePolicy),
 			(d) => d.id,
 		);
 		visibleDiagnostics = promoteDeltaUnusedToBlockers(filtered.new);

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -156,9 +156,13 @@ export function createDispatchContext(
 	facts: FactStore,
 	blockingOnly?: boolean,
 	modifiedRanges?: import("./types.js").ModifiedRange[],
+	/** Authoritative workspace root; `cwd` may be a nested language root. */
+	projectRoot?: string,
 ): DispatchContext {
 	const absoluteFilePath = resolveRunnerPath(cwd, filePath);
-	const normalizedProjectRoot = normalizeMapKey(path.resolve(cwd));
+	const normalizedProjectRoot = normalizeMapKey(
+		path.resolve(projectRoot ?? cwd),
+	);
 	const normalizedCwd = normalizeMapKey(
 		resolveLanguageRootForFile(absoluteFilePath, cwd),
 	);

--- a/clients/dispatch/inline-suppressions.ts
+++ b/clients/dispatch/inline-suppressions.ts
@@ -10,6 +10,8 @@
  * diagnostic or the line immediately above it.
  */
 
+import { normalizeRuleId } from "./rule-id-normalize.js";
+
 export interface SuppressibleDiagnostic {
 	line?: number;
 	rule?: string;
@@ -23,11 +25,10 @@ const SUPPRESS_RE = /(?:\/\/|#)\s*pi-lens-ignore:\s*(.+)/;
  * The napi scan and the ast-grep LSP tag the same rule as `ast-grep:<id>` /
  * `<id>-js` in some surfaces (see `normalizeRuleForDedup` in lens-diagnostics);
  * a user's bare `<id>` must still suppress those, so we match the normalized form
- * as well as the raw one.
+ * as well as the raw one. Shared via `rule-id-normalize.ts` so the inline
+ * suppression parser and the project rule policy matcher apply the same
+ * normalization.
  */
-function normalizeSuppressRule(ruleId: string): string {
-	return ruleId.replace(/^ast-grep:/, "").replace(/-js$/, "");
-}
 
 /**
  * Drop diagnostics suppressed by an inline `pi-lens-ignore: <rule[,rule2]>`
@@ -66,7 +67,7 @@ export function applyInlineSuppressions<T extends SuppressibleDiagnostic>(
 		const rawId = d.rule ?? d.id ?? "";
 		const line = d.line ?? 1;
 		if (suppressed.has(`${line}:${rawId}`)) return false;
-		const normId = normalizeSuppressRule(rawId);
+		const normId = normalizeRuleId(rawId);
 		return normId === rawId || !suppressed.has(`${line}:${normId}`);
 	});
 }

--- a/clients/dispatch/inline-suppressions.ts
+++ b/clients/dispatch/inline-suppressions.ts
@@ -23,7 +23,7 @@ const SUPPRESS_RE = /(?:\/\/|#)\s*pi-lens-ignore:\s*(.+)/;
 /**
  * Normalize a rule id to the form a user writes in a `pi-lens-ignore` comment.
  * The napi scan and the ast-grep LSP tag the same rule as `ast-grep:<id>` /
- * `<id>-js` in some surfaces (see `normalizeRuleForDedup` in lens-diagnostics);
+ * `<id>-js` in some surfaces (see the dedup key in lens-diagnostics);
  * a user's bare `<id>` must still suppress those, so we match the normalized form
  * as well as the raw one. Shared via `rule-id-normalize.ts` so the inline
  * suppression parser and the project rule policy matcher apply the same

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -1689,6 +1689,7 @@ export async function dispatchLint(
 	cwd: string,
 	pi: PiAgentAPI,
 	modifiedRanges?: ModifiedRange[],
+	projectRoot?: string,
 ): Promise<string> {
 	// By default, only run BLOCKING rules for fast feedback on file write
 	// Uses persistent sessionBaselines so delta mode actually filters
@@ -1700,6 +1701,7 @@ export async function dispatchLint(
 		sessionFacts,
 		true,
 		modifiedRanges,
+		projectRoot,
 	);
 	sessionFacts.clearFileFactsFor(ctx.filePath);
 
@@ -1728,7 +1730,7 @@ export async function dispatchLintWithResult(
 	pi: PiAgentAPI,
 	modifiedRanges?: ModifiedRange[],
 	logContext?: LogContext,
-	options?: { blockingOnly?: boolean },
+	options?: { blockingOnly?: boolean; projectRoot?: string },
 ): Promise<DispatchResult> {
 	// Default true preserves the per-edit fast path (errors only). Callers that
 	// want the full picture (warnings + structural smells), e.g. the MCP review
@@ -1740,6 +1742,7 @@ export async function dispatchLintWithResult(
 		sessionFacts,
 		options?.blockingOnly ?? true,
 		modifiedRanges,
+		options?.projectRoot,
 	);
 	sessionFacts.clearFileFactsFor(ctx.filePath);
 
@@ -1810,7 +1813,11 @@ export async function dispatchLintDetailed(
 	filePath: string,
 	cwd: string,
 	pi: PiAgentAPI,
-	options?: { blockingOnly?: boolean; modifiedRanges?: ModifiedRange[] },
+	options?: {
+		blockingOnly?: boolean;
+		modifiedRanges?: ModifiedRange[];
+		projectRoot?: string;
+	},
 ): Promise<{ result: DispatchResult; runners: RunnerOutcome[] }> {
 	const empty: DispatchResult = {
 		diagnostics: [],
@@ -1831,6 +1838,7 @@ export async function dispatchLintDetailed(
 		sessionFacts,
 		options?.blockingOnly ?? false,
 		options?.modifiedRanges,
+		options?.projectRoot,
 	);
 	sessionFacts.clearFileFactsFor(ctx.filePath);
 

--- a/clients/dispatch/rule-id-normalize.ts
+++ b/clients/dispatch/rule-id-normalize.ts
@@ -1,0 +1,27 @@
+/**
+ * Normalize a rule id to the form a user typically writes in a
+ * `pi-lens-ignore` comment, an inline suppression, or a project-level
+ * `disable`/`select` list. Strips the `ast-grep:` LSP source prefix and the
+ * `-js` language suffix — the same forms `tools/lens-diagnostics.ts`'s
+ * `normalizeRuleForDedup` already collapsed across the LSP/napi surfaces so a
+ * single user-facing id (`no-eval`) catches every variant
+ * (`ast-grep:no-eval`, `no-eval`, `no-eval-js`).
+ *
+ * Shared by `clients/dispatch/inline-suppressions.ts` and
+ * `clients/dispatch/rule-policy.ts` (and previously duplicated in `tools/lens-
+ * diagnostics.ts`); consolidated here so the three surfaces can never drift.
+ */
+
+export function normalizeRuleId(ruleId: string): string {
+	return ruleId.replace(/^ast-grep:/, "").replace(/-js$/, "");
+}
+
+/**
+ * Back-compat alias for the dedup normalizer that lived in
+ * `tools/lens-diagnostics.ts`. Kept identical (same strip pipeline) so the
+ * two normalizations round-trip identically and the shared module can stand
+ * in for either without behavior change.
+ */
+export function normalizeRuleForDedup(ruleId: string): string {
+	return normalizeRuleId(ruleId);
+}

--- a/clients/dispatch/rule-id-normalize.ts
+++ b/clients/dispatch/rule-id-normalize.ts
@@ -3,7 +3,7 @@
  * `pi-lens-ignore` comment, an inline suppression, or a project-level
  * `disable`/`select` list. Strips the `ast-grep:` LSP source prefix and the
  * `-js` language suffix — the same forms `tools/lens-diagnostics.ts`'s
- * `normalizeRuleForDedup` already collapsed across the LSP/napi surfaces so a
+ * dedup key already collapsed across the LSP/napi surfaces so a
  * single user-facing id (`no-eval`) catches every variant
  * (`ast-grep:no-eval`, `no-eval`, `no-eval-js`).
  *
@@ -14,14 +14,4 @@
 
 export function normalizeRuleId(ruleId: string): string {
 	return ruleId.replace(/^ast-grep:/, "").replace(/-js$/, "");
-}
-
-/**
- * Back-compat alias for the dedup normalizer that lived in
- * `tools/lens-diagnostics.ts`. Kept identical (same strip pipeline) so the
- * two normalizations round-trip identically and the shared module can stand
- * in for either without behavior change.
- */
-export function normalizeRuleForDedup(ruleId: string): string {
-	return normalizeRuleId(ruleId);
 }

--- a/clients/dispatch/rule-policy.ts
+++ b/clients/dispatch/rule-policy.ts
@@ -94,17 +94,17 @@ function matchesRule(entry: string, raw: string, normalized: string): boolean {
 
 /**
  * Filter an array of diagnostics (returns a new array) by the project rule
- * policy map. Only `rule` is consulted: `Diagnostic.id` is a dedup key
- * (`eslint:unknown:12`), not a rule id, so measuring it against a project-wide
- * `select` allowlist would silently drop every rule-less finding, including
- * blocking ones like an eslint parse error. A diagnostic with no `rule` has
- * nothing to match on and is kept untouched.
+ * policy map. `rule` is preferred; code-only diagnostics use `code` as their
+ * policy key so project-diagnostics details and rendered summaries cannot
+ * disagree about a finding that has no explicit rule field. `Diagnostic.id`
+ * remains a dedup key (`eslint:unknown:12`), not a policy key, so id-only
+ * findings (including blocking parse errors) remain exempt.
  *
  * Used by both the per-edit dispatcher and the `lens-diagnostics` tool's
  * `mode=delta`/`mode=all`/`mode=full` paths so a project's own policy
  * applies consistently across every output surface.
  */
-export function applyRulePolicy<T extends { rule?: string }>(
+export function applyRulePolicy<T extends { rule?: string; code?: string }>(
 	diagnostics: T[],
 	policyMap: Record<string, unknown> | undefined,
 ): T[] {
@@ -126,7 +126,7 @@ export function applyRulePolicy<T extends { rule?: string }>(
 	if (!hasFilter) return diagnostics;
 
 	return diagnostics.filter((d) => {
-		const ruleId = d.rule;
+		const ruleId = d.rule ?? d.code;
 		if (!ruleId) return true;
 		const { dropped } = evaluateRulePolicy(ruleId, policyMap as RulePolicyMap);
 		return !dropped;

--- a/clients/dispatch/rule-policy.ts
+++ b/clients/dispatch/rule-policy.ts
@@ -1,0 +1,153 @@
+/**
+ * Project-level rule policy (`.pi-lens.json` `rules.<id>.disable` /
+ * `rules.<id>.select`) — output-only filtering of dispatches, so the project's
+ * own policy narrows what the user actually sees without widening the trusted
+ * surface area (widget state, baseline, dedup, and per-edit record stay
+ * authoritative).
+ *
+ * Matching is PROJECT-WIDE. The outer `rules.<key>` is a grouping label only —
+ * it does not scope which diagnostics a `disable`/`select` list under it can
+ * match. Every `disable` entry across every key is unioned into one drop list,
+ * and every `select` entry across every key is unioned into one allowlist.
+ * Disable is checked first, so it wins globally regardless of which key it's
+ * configured under.
+ *
+ * Match normalization is consolidated with the rest of the rule-id surfaces:
+ * `inline-suppressions.ts` and `lens-diagnostics.ts`'s `normalizeRuleForDedup`
+ * both strip the `ast-grep:` prefix and the `-js` suffix, so a user listing
+ * `no-eval` once under `disable` covers both the LSP tag (`ast-grep:no-eval`)
+ * and the napi tag (`no-eval` / `no-eval-js`). Sharing the normalization keeps
+ * the three surfaces from drifting.
+ */
+import { normalizeRuleForDedup } from "./rule-id-normalize.js";
+
+export interface RulePolicyEntry {
+	disable?: string[];
+	select?: string[];
+}
+
+/**
+ * A project's rule-config-key -> policy map (the same shape
+ * `PiLensProjectConfig.rules` already uses for `threshold`). The key is only
+ * a grouping label (e.g. `"security"`, `"my-rule-set"`) — it does not scope
+ * matching, which is project-wide across every key's `disable`/`select`
+ * lists (see the module doc comment). `Partial<>` so a threshold-only entry
+ * passes the type checker even though only `disable`/`select` are consulted
+ * at filter time.
+ */
+export type RulePolicyMap = Record<string, RulePolicyEntry | undefined>;
+
+/**
+ * Decide whether a rule id (in the form it's emitted on a diagnostic — e.g.
+ * `ast-grep:no-eval`, `no-eval-js`, `no-eval`, `ts:2322`) should be filtered
+ * out under a project's rule policy map. Returns `dropped: true` when the
+ * diagnostic would be hidden from output.
+ *
+ * Project-wide: every `disable` entry across every configured key is checked
+ * first (disable wins globally over select). Then every `select` entry
+ * across every key is unioned into one allowlist — a non-empty union that
+ * the rule doesn't match also drops it. An absent/empty union across all
+ * keys means "no restriction". Matching uses the same normalization as
+ * inline suppression so a configured `no-eval` entry covers
+ * `ast-grep:no-eval` and `no-eval-js`.
+ */
+export function evaluateRulePolicy(
+	ruleId: string,
+	policyMap: RulePolicyMap | undefined,
+): { dropped: boolean } {
+	if (!policyMap) return { dropped: false };
+	const raw = ruleId || "";
+	const norm = normalizeRuleForDedup(raw);
+
+	for (const entry of Object.values(policyMap)) {
+		if (!entry) continue;
+		for (const d of entry.disable ?? []) {
+			if (matchesRule(d, raw, norm)) return { dropped: true };
+		}
+	}
+
+	let hasSelect = false;
+	for (const entry of Object.values(policyMap)) {
+		if (!entry) continue;
+		for (const s of entry.select ?? []) {
+			hasSelect = true;
+			if (matchesRule(s, raw, norm)) return { dropped: false };
+		}
+	}
+	return { dropped: hasSelect };
+}
+
+function matchesRule(entry: string, raw: string, normalized: string): boolean {
+	if (entry === raw) return true;
+	return normalizeRuleForDedup(entry) === normalized;
+}
+
+/**
+ * Filter an array of diagnostics (returns a new array) by the project rule
+ * policy map. Only `rule` is consulted: `Diagnostic.id` is a dedup key
+ * (`eslint:unknown:12`), not a rule id, so measuring it against a project-wide
+ * `select` allowlist would silently drop every rule-less finding, including
+ * blocking ones like an eslint parse error. A diagnostic with no `rule` has
+ * nothing to match on and is kept untouched.
+ *
+ * Used by both the per-edit dispatcher and the `lens-diagnostics` tool's
+ * `mode=delta`/`mode=all`/`mode=full` paths so a project's own policy
+ * applies consistently across every output surface.
+ */
+export function applyRulePolicy<T extends { rule?: string }>(
+	diagnostics: T[],
+	policyMap: Record<string, unknown> | undefined,
+): T[] {
+	if (!policyMap) return diagnostics;
+	// Fast-path: if every entry has neither disable nor select, there is no
+	// output filter to apply. Keeps the hot path (most projects have only
+	// thresholds) cheap.
+	let hasFilter = false;
+	for (const rawEntry of Object.values(policyMap)) {
+		if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+			continue;
+		}
+		const entry = rawEntry as { disable?: string[]; select?: string[] };
+		if ((entry.disable?.length ?? 0) > 0 || (entry.select?.length ?? 0) > 0) {
+			hasFilter = true;
+			break;
+		}
+	}
+	if (!hasFilter) return diagnostics;
+
+	return diagnostics.filter((d) => {
+		const ruleId = d.rule;
+		if (!ruleId) return true;
+		const { dropped } = evaluateRulePolicy(ruleId, policyMap as RulePolicyMap);
+		return !dropped;
+	});
+}
+
+/**
+ * Build the policy map from a `PiLensProjectConfig.rules`-shaped value. Returns
+ * undefined when there's nothing to filter (the hot path), or a map suitable
+ * for `applyRulePolicy` otherwise. Excludes entries whose only field is
+ * `threshold` (a threshold is a separate concern handled elsewhere) so the
+ * filter step doesn't repeat the work.
+ */
+export function rulePolicyMapFromConfig(
+	rules: Record<string, unknown> | undefined,
+): RulePolicyMap | undefined {
+	if (!rules) return undefined;
+	let built: RulePolicyMap | undefined;
+	for (const [key, rawEntry] of Object.entries(rules)) {
+		if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+			continue;
+		}
+		const entry = rawEntry as { disable?: string[]; select?: string[] };
+		const hasDisable = (entry.disable?.length ?? 0) > 0;
+		const hasSelect = (entry.select?.length ?? 0) > 0;
+		if (!hasDisable && !hasSelect) continue;
+		built ??= {};
+		built[key] = {
+			...(hasDisable ? { disable: entry.disable } : {}),
+			...(hasSelect ? { select: entry.select } : {}),
+		};
+	}
+	return built;
+}

--- a/clients/dispatch/rule-policy.ts
+++ b/clients/dispatch/rule-policy.ts
@@ -59,22 +59,32 @@ export function evaluateRulePolicy(
 	const raw = ruleId || "";
 	const norm = normalizeRuleForDedup(raw);
 
-	for (const entry of Object.values(policyMap)) {
-		if (!entry) continue;
-		for (const d of entry.disable ?? []) {
-			if (matchesRule(d, raw, norm)) return { dropped: true };
-		}
+	if (scanList(policyMap, (e) => e.disable, raw, norm).matched) {
+		return { dropped: true };
 	}
+	const select = scanList(policyMap, (e) => e.select, raw, norm);
+	return { dropped: select.sawEntry && !select.matched };
+}
 
-	let hasSelect = false;
+/**
+ * Union one list (`disable` or `select`) across every key in the map and test
+ * the rule against it. `sawEntry` reports whether the union was non-empty,
+ * which is what makes a `select` union restrictive rather than absent.
+ */
+function scanList(
+	policyMap: RulePolicyMap,
+	pick: (entry: RulePolicyEntry) => string[] | undefined,
+	raw: string,
+	norm: string,
+): { matched: boolean; sawEntry: boolean } {
+	let sawEntry = false;
 	for (const entry of Object.values(policyMap)) {
-		if (!entry) continue;
-		for (const s of entry.select ?? []) {
-			hasSelect = true;
-			if (matchesRule(s, raw, norm)) return { dropped: false };
+		for (const candidate of (entry && pick(entry)) ?? []) {
+			sawEntry = true;
+			if (matchesRule(candidate, raw, norm)) return { matched: true, sawEntry };
 		}
 	}
-	return { dropped: hasSelect };
+	return { matched: false, sawEntry };
 }
 
 function matchesRule(entry: string, raw: string, normalized: string): boolean {

--- a/clients/dispatch/rule-policy.ts
+++ b/clients/dispatch/rule-policy.ts
@@ -13,13 +13,13 @@
  * configured under.
  *
  * Match normalization is consolidated with the rest of the rule-id surfaces:
- * `inline-suppressions.ts` and `lens-diagnostics.ts`'s `normalizeRuleForDedup`
+ * `inline-suppressions.ts` and `lens-diagnostics.ts`'s `normalizeRuleId`
  * both strip the `ast-grep:` prefix and the `-js` suffix, so a user listing
  * `no-eval` once under `disable` covers both the LSP tag (`ast-grep:no-eval`)
  * and the napi tag (`no-eval` / `no-eval-js`). Sharing the normalization keeps
  * the three surfaces from drifting.
  */
-import { normalizeRuleForDedup } from "./rule-id-normalize.js";
+import { normalizeRuleId } from "./rule-id-normalize.js";
 
 export interface RulePolicyEntry {
 	disable?: string[];
@@ -57,7 +57,7 @@ export function evaluateRulePolicy(
 ): { dropped: boolean } {
 	if (!policyMap) return { dropped: false };
 	const raw = ruleId || "";
-	const norm = normalizeRuleForDedup(raw);
+	const norm = normalizeRuleId(raw);
 
 	if (scanList(policyMap, (e) => e.disable, raw, norm).matched) {
 		return { dropped: true };
@@ -89,7 +89,7 @@ function scanList(
 
 function matchesRule(entry: string, raw: string, normalized: string): boolean {
 	if (entry === raw) return true;
-	return normalizeRuleForDedup(entry) === normalized;
+	return normalizeRuleId(entry) === normalized;
 }
 
 /**

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -221,7 +221,10 @@ function exceedsLspSyncLimits(
 
 export interface PipelineContext {
 	filePath: string;
+	/** Language/tool root used for runner execution and config resolution. */
 	cwd: string;
+	/** Authoritative workspace root used for project-wide policy and state. */
+	projectRoot?: string;
 	toolName: string;
 	modifiedRanges?: { start: number; end: number }[];
 	telemetry?: {
@@ -858,7 +861,6 @@ export async function runAutofix(
 				dbg(`autofix: oxlint --fix fixed ${filePath}`);
 				needsContentRefresh = true;
 			}
-			continue;
 		}
 	}
 
@@ -1232,6 +1234,7 @@ export async function runPipeline(
 			turnIndex: ctx.telemetry?.turnIndex ?? 0,
 			writeIndex: ctx.telemetry?.writeIndex ?? 0,
 		},
+		{ projectRoot: ctx.projectRoot },
 	);
 	recordDiagnostics(
 		filePath,

--- a/clients/project-lens-config.ts
+++ b/clients/project-lens-config.ts
@@ -98,6 +98,28 @@ const PROJECT_OWN_CONFIG_KEYS = [
 export interface PiLensProjectRuleConfig {
 	/** Optional override for the rule's primary numeric threshold. */
 	threshold?: number;
+	/**
+	 * Project-level disable list — rule ids whose diagnostics the project's
+	 * `.pi-lens.json` deliberately turns off. Output-only filtering (the
+	 * diagnostics are still recorded: widget state, baseline, and dispatch
+	 * dedup see them), so a project's own policy never widens the trusted
+	 * surface area beyond what the user actually sees. Matching is PROJECT-
+	 * WIDE: the `<id>` key this list lives under is a grouping label only, not
+	 * a filter scope — every `disable` list across every `rules.<key>` entry
+	 * is unioned before matching. Disable is stronger than `select` (below) —
+	 * a rule on both lists is dropped.
+	 */
+	disable?: string[];
+	/**
+	 * Project-level allowlist — when the UNION of `select` lists across every
+	 * `rules.<key>` entry is non-empty, ONLY the rule ids in that union
+	 * survive filtering; everything else is dropped, project-wide (an absent
+	 * or empty union everywhere is "no restriction"). Like `disable`, the
+	 * `<id>` key this list lives under does not scope which rules it can
+	 * match. A rule on both `select` and `disable` is dropped (disable wins —
+	 * explicit exclusion trumps explicit inclusion).
+	 */
+	select?: string[];
 }
 
 export interface PiLensProjectMutationConfig {
@@ -343,6 +365,35 @@ function warnInvalidConfigOnce(configPath: string, reason: string): void {
 	);
 }
 
+function parseRulePolicyList(
+	configPath: string,
+	ruleId: string,
+	key: "disable" | "select",
+	value: unknown,
+): { list: string[]; invalid: boolean } {
+	if (!Array.isArray(value)) {
+		warnInvalidConfigOnce(
+			configPath,
+			`rules.${ruleId}.${key} must be an array of strings`,
+		);
+		return { list: [], invalid: true };
+	}
+	const list: string[] = [];
+	for (const entry of value) {
+		if (typeof entry !== "string") continue;
+		const trimmed = entry.trim();
+		if (trimmed.length > 0) list.push(trimmed);
+	}
+	if (list.length === 0) {
+		warnInvalidConfigOnce(
+			configPath,
+			`rules.${ruleId}.${key} must be a non-empty array of strings`,
+		);
+		return { list: [], invalid: true };
+	}
+	return { list, invalid: false };
+}
+
 function parseConfigFile(configPath: string): PiLensProjectConfig {
 	let raw: unknown;
 	try {
@@ -381,17 +432,41 @@ function parseConfigFile(configPath: string): PiLensProjectConfig {
 				continue;
 			}
 			const r = ruleCfg as Record<string, unknown>;
+			const entry: PiLensProjectRuleConfig = {};
 			if (
 				typeof r.threshold === "number" &&
 				Number.isFinite(r.threshold) &&
 				r.threshold > 0
 			) {
-				rules[ruleId] = { threshold: r.threshold };
+				entry.threshold = r.threshold;
 			} else if ("threshold" in r) {
 				warnInvalidConfigOnce(
 					configPath,
 					`rules.${ruleId}.threshold must be a positive finite number`,
 				);
+			}
+			if ("disable" in r) {
+				const parsed = parseRulePolicyList(
+					configPath,
+					ruleId,
+					"disable",
+					r.disable,
+				);
+				if (!parsed.invalid) entry.disable = parsed.list;
+			}
+			if ("select" in r) {
+				const parsed = parseRulePolicyList(
+					configPath,
+					ruleId,
+					"select",
+					r.select,
+				);
+				if (!parsed.invalid) entry.select = parsed.list;
+			}
+			// Honor both threshold-only and policy-only entries; only drop if
+			// the entry had no recognized fields at all (e.g. { unrelated: true }).
+			if (entry.threshold !== undefined || entry.disable || entry.select) {
+				rules[ruleId] = entry;
 			}
 		}
 	}

--- a/clients/project-lens-config.ts
+++ b/clients/project-lens-config.ts
@@ -428,7 +428,14 @@ function parseConfigFile(configPath: string): PiLensProjectConfig {
 	if (obj.rules && typeof obj.rules === "object" && !Array.isArray(obj.rules)) {
 		const rawRules = obj.rules as Record<string, unknown>;
 		for (const [ruleId, ruleCfg] of Object.entries(rawRules)) {
+			// #444's own example writes the lists directly under `rules` (`rules.
+			// disable`), which lands here as an array and would otherwise be
+			// dropped without a word — the one shape a user is most likely to try.
 			if (!ruleCfg || typeof ruleCfg !== "object" || Array.isArray(ruleCfg)) {
+				warnInvalidConfigOnce(
+					configPath,
+					`rules.${ruleId} must be an object with threshold, disable, or select; ignored`,
+				);
 				continue;
 			}
 			const r = ruleCfg as Record<string, unknown>;
@@ -465,8 +472,20 @@ function parseConfigFile(configPath: string): PiLensProjectConfig {
 			}
 			// Honor both threshold-only and policy-only entries; only drop if
 			// the entry had no recognized fields at all (e.g. { unrelated: true }).
+			// A recognized-but-malformed field already warned above, so only warn
+			// here when nothing recognized was spelled at all — #444 proposed
+			// `only` rather than `select`, and that typo must not fail silent.
 			if (entry.threshold !== undefined || entry.disable || entry.select) {
 				rules[ruleId] = entry;
+			} else if (
+				!("threshold" in r) &&
+				!("disable" in r) &&
+				!("select" in r)
+			) {
+				warnInvalidConfigOnce(
+					configPath,
+					`rules.${ruleId} has no recognized setting (threshold, disable, select); ignored`,
+				);
 			}
 		}
 	}

--- a/clients/runtime-tool-result.ts
+++ b/clients/runtime-tool-result.ts
@@ -578,6 +578,7 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 		{
 			filePath,
 			cwd: dispatchCwd,
+			projectRoot: turnStateCwd,
 			toolName: event.toolName,
 			modifiedRanges,
 			telemetry: {

--- a/docs/globalconfig.md
+++ b/docs/globalconfig.md
@@ -167,10 +167,52 @@ Note: `maxProjectFiles` (below) is discovered differently — via an upward walk
 
 ### `rules`
 
-Per-rule threshold overrides. Currently honored:
+Per-rule threshold overrides and policy filters. Currently honored:
 
 - `high-complexity.threshold` — cyclomatic complexity (default `15`)
 - `high-fan-out.threshold` — distinct function calls (default `20`)
+- `<id>.disable` — disable diagnostics for the listed rule ids (output-only
+  filter). Same rule-id normalization as `pi-lens-ignore`: a user lists
+  `no-eval` once and the filter covers `no-eval`, `ast-grep:no-eval`, and
+  `no-eval-js`. Side effect: a rule whose real name genuinely ends in `-js`
+  (e.g. `prefer-js`) is conflated with its stem (`prefer`) — disabling or
+  selecting one also disables or selects the other.
+- `<id>.select` — allowlist of rule ids; only the listed rule ids survive
+  filtering. Disable wins over select project-wide, even when the two lists
+  are configured under different keys.
+
+The `<id>` key is a grouping label only — it does not scope which rules the
+`disable`/`select` list underneath it can match. Matching is **project-wide**:
+every `disable` list across every key is unioned into one drop list, and
+every `select` list across every key is unioned into one allowlist. So
+`"security": { "disable": ["no-eval"] }` disables `no-eval` regardless of
+`security` being the rule's own id, and two keys can each contribute to the
+same select union.
+
+```json
+{
+  "rules": {
+    "high-complexity": { "threshold": 25 },
+    "high-fan-out": { "threshold": 30 },
+    "no-eval": { "disable": ["no-eval", "no-eval-js", "ast-grep:no-eval"] },
+    "my-rule-set": { "select": ["rule-a", "rule-b"] }
+  }
+}
+```
+
+**Warning:** because select is project-wide, a non-empty `select` list
+*anywhere* in `rules` silences every rule not in that list, across the whole
+project — including tsc/eslint findings, not just the rule types you're
+thinking about when you write it. It's a big hammer; reach for `disable`
+instead unless you actually want an allowlist over everything. Findings that
+carry no rule id at all (an eslint parse error, for example) are exempt from
+select, so an allowlist can never hide them.
+
+Disable and select are output-only filters applied AFTER inline suppression,
+disposition, and dedup — the project-level policy never widens the trusted
+surface area (widget state, baseline, dedup cache stay authoritative). The
+baseline still records the full unfiltered set so a project-config edit does
+not corrupt delta baselines.
 
 ### `maxProjectFiles`
 
@@ -197,5 +239,6 @@ Explicit override for the review graph's own file budget (#775), for monorepos t
 - A malformed JSON file is logged once and treated as "no config" — your diagnostics never get blocked by a syntax error in your own config.
 - Rule thresholds must be positive finite numbers; invalid, zero, or negative values are logged once and ignored.
 - Mutation-control `enabled` values must be booleans; invalid values are logged once and ignored.
+- `rules.<id>.disable` and `rules.<id>.select` must each be a non-empty array of non-empty strings; a non-array value, an empty array, or an all-whitespace array is logged once and the entry is dropped. A policy-only entry (no `threshold`) is honored. A policy entry with an invalid value still keeps any valid `threshold` alongside it.
 - The depth sub-threshold of `high-complexity` (default `6`) is intentionally not exposed; only the cyclomatic-complexity knob ships today to keep the schema tight.
 - The file is mtime-cached, so editing it takes effect on the next scan without restarting the agent.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -87,6 +87,8 @@ field docs.
 | `actionableWarnings.autoFix.maxFixes` | global | `5` | Cap on quickfixes applied per turn (`0` = report only) |
 | `rules.high-complexity.threshold` | project | `15` | Cyclomatic-complexity threshold |
 | `rules.high-fan-out.threshold` | project | `20` | Distinct-function-call threshold |
+| `rules.<id>.disable` | project | absent | Disable diagnostics for a rule (output-only filter, project-wide; same normalization as `pi-lens-ignore`) |
+| `rules.<id>.select` | project | absent | Allowlist of rule ids (output-only filter, project-wide across every key; disable wins over select) |
 | `maxProjectFiles` | project | `2000` | Base scale knob; derives five subsystem size budgets |
 | `reviewGraph.maxFiles` | project | derived (clamped `100`–`20000`) | Explicit review-graph file budget |
 | `trivy.enabled` / `trivy.minSeverity` | project | off | Opt-in Trivy vulnerability scanning |
@@ -140,7 +142,8 @@ tolerated without warning; anything else is logged once as a likely typo.
   "ignore": ["**/*.test.ts", "vendor/**"],
   "rules": {
     "high-complexity": { "threshold": 25 },
-    "high-fan-out": { "threshold": 30 }
+    "high-fan-out": { "threshold": 30 },
+    "no-eval": { "disable": ["no-eval", "ast-grep:no-eval", "no-eval-js"] }
   },
   "maxProjectFiles": 5000,
   "format": { "enabled": false }

--- a/tests/clients/dispatch/integration.test.ts
+++ b/tests/clients/dispatch/integration.test.ts
@@ -5,6 +5,7 @@
  * with mocked dispatcher to avoid real tool spawning.
  */
 
+import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	dispatchLintWithResult,
@@ -12,6 +13,7 @@ import {
 	resetDispatchBaselines,
 	shouldDispatch,
 } from "../../../clients/dispatch/integration.js";
+import { normalizeMapKey } from "../../../clients/path-utils.js";
 
 // Mock dispatcher internals to avoid real runner execution
 vi.mock("../../../clients/dispatch/dispatcher.js", async (importOriginal) => {
@@ -188,6 +190,23 @@ describe("Dispatch Integration", () => {
 			expect(
 				vi.mocked(dispatchForFile).mock.calls.at(-1)?.[0].blockingOnly,
 			).toBe(false);
+		});
+
+		it("carries the authoritative workspace root separately from a language root", async () => {
+			await dispatchLintWithResult(
+				"app.ts",
+				"/repo/packages/pkg-a",
+				{ getFlag: () => false },
+				undefined,
+				undefined,
+				{ projectRoot: "/repo" },
+			);
+
+		const ctx = vi.mocked(dispatchForFile).mock.calls.at(-1)?.[0];
+		expect(ctx?.cwd).toBe(
+			normalizeMapKey(path.resolve("/repo/packages/pkg-a")),
+		);
+		expect(ctx?.projectRoot).toBe(normalizeMapKey(path.resolve("/repo")));
 		});
 	});
 

--- a/tests/clients/dispatch/rule-id-normalize.test.ts
+++ b/tests/clients/dispatch/rule-id-normalize.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the shared rule-id normalization
+ * (`clients/dispatch/rule-id-normalize.ts`). The same strip pipeline
+ * (`ast-grep:` prefix + `-js` suffix) is consumed by:
+ *
+ * - `clients/dispatch/inline-suppressions.ts` (matches `pi-lens-ignore` comments)
+ * - `clients/dispatch/rule-policy.ts` (matches `disable`/`select` list entries)
+ * - `tools/lens-diagnostics.ts` (dedup in mode=full merge)
+ *
+ * Diverging them would let a single user-facing rule id (e.g. `no-eval`)
+ * silently drop protection across the three surfaces. These tests probe
+ * the contract the matcher guarantees.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	normalizeRuleForDedup,
+	normalizeRuleId,
+} from "../../../clients/dispatch/rule-id-normalize.js";
+
+describe("rule-id-normalize", () => {
+	it("strips the ast-grep: prefix", () => {
+		expect(normalizeRuleId("ast-grep:no-eval")).toBe("no-eval");
+		expect(normalizeRuleForDedup("ast-grep:no-eval")).toBe("no-eval");
+	});
+
+	it("strips the -js suffix", () => {
+		expect(normalizeRuleId("no-eval-js")).toBe("no-eval");
+		expect(normalizeRuleForDedup("no-eval-js")).toBe("no-eval");
+	});
+
+	it("strips both forms (ast-grep: prefix + -js suffix)", () => {
+		expect(normalizeRuleId("ast-grep:no-eval-js")).toBe("no-eval");
+		expect(normalizeRuleForDedup("ast-grep:no-eval-js")).toBe("no-eval");
+	});
+
+	it("is a no-op on a bare rule id", () => {
+		expect(normalizeRuleId("no-eval")).toBe("no-eval");
+		expect(normalizeRuleForDedup("no-eval")).toBe("no-eval");
+	});
+
+	it("is idempotent (normalize is a fixed point)", () => {
+		const forms = ["no-eval", "ast-grep:no-eval", "no-eval-js", "ast-grep:no-eval-js"];
+		for (const form of forms) {
+			const once = normalizeRuleId(form);
+			const twice = normalizeRuleId(once);
+			expect(twice).toBe(once);
+		}
+	});
+
+	it("does NOT strip a substring -js (only the trailing suffix)", () => {
+		// `-js` mid-id is part of the rule name, not a language suffix.
+		// The regex `.replace(/-js$/, "")` only matches the trailing suffix.
+		expect(normalizeRuleId("no-js-comment")).toBe("no-js-comment");
+		expect(normalizeRuleId("jsdoc-extra")).toBe("jsdoc-extra");
+	});
+
+	it("collapses a distinct rule literally named '<stem>-js' onto its stem (documented conflation)", () => {
+		// `normalizeRuleId` can't tell a language-tag `-js` suffix (the napi
+		// variant of `no-eval`, i.e. `no-eval-js`) apart from a `-js` that's
+		// part of a rule's own name. A rule genuinely named `prefer-js`
+		// normalizes to the same "prefer" as an unrelated `prefer` rule — a
+		// deliberate side effect of the shared strip, not a bug. See this
+		// module's doc comment and docs/globalconfig.md.
+		expect(normalizeRuleId("prefer-js")).toBe(normalizeRuleId("prefer"));
+		expect(normalizeRuleId("prefer-js")).toBe("prefer");
+	});
+
+	it("normalizeRuleForDedup is the same as normalizeRuleId", () => {
+		// Back-compat alias must remain identical to canonical form — the
+		// dedup path in `tools/lens-diagnostics.ts` was the first user, and
+		// it shares the strip pipeline.
+		const samples = [
+			"no-eval",
+			"ast-grep:no-eval",
+			"no-eval-js",
+			"ast-grep:no-eval-js",
+			"high-complexity",
+		];
+		for (const sample of samples) {
+			expect(normalizeRuleForDedup(sample)).toBe(normalizeRuleId(sample));
+		}
+	});
+});

--- a/tests/clients/dispatch/rule-id-normalize.test.ts
+++ b/tests/clients/dispatch/rule-id-normalize.test.ts
@@ -12,30 +12,23 @@
  * the contract the matcher guarantees.
  */
 import { describe, expect, it } from "vitest";
-import {
-	normalizeRuleForDedup,
-	normalizeRuleId,
-} from "../../../clients/dispatch/rule-id-normalize.js";
+import { normalizeRuleId } from "../../../clients/dispatch/rule-id-normalize.js";
 
 describe("rule-id-normalize", () => {
 	it("strips the ast-grep: prefix", () => {
 		expect(normalizeRuleId("ast-grep:no-eval")).toBe("no-eval");
-		expect(normalizeRuleForDedup("ast-grep:no-eval")).toBe("no-eval");
 	});
 
 	it("strips the -js suffix", () => {
 		expect(normalizeRuleId("no-eval-js")).toBe("no-eval");
-		expect(normalizeRuleForDedup("no-eval-js")).toBe("no-eval");
 	});
 
 	it("strips both forms (ast-grep: prefix + -js suffix)", () => {
 		expect(normalizeRuleId("ast-grep:no-eval-js")).toBe("no-eval");
-		expect(normalizeRuleForDedup("ast-grep:no-eval-js")).toBe("no-eval");
 	});
 
 	it("is a no-op on a bare rule id", () => {
 		expect(normalizeRuleId("no-eval")).toBe("no-eval");
-		expect(normalizeRuleForDedup("no-eval")).toBe("no-eval");
 	});
 
 	it("is idempotent (normalize is a fixed point)", () => {
@@ -63,21 +56,5 @@ describe("rule-id-normalize", () => {
 		// module's doc comment and docs/globalconfig.md.
 		expect(normalizeRuleId("prefer-js")).toBe(normalizeRuleId("prefer"));
 		expect(normalizeRuleId("prefer-js")).toBe("prefer");
-	});
-
-	it("normalizeRuleForDedup is the same as normalizeRuleId", () => {
-		// Back-compat alias must remain identical to canonical form — the
-		// dedup path in `tools/lens-diagnostics.ts` was the first user, and
-		// it shares the strip pipeline.
-		const samples = [
-			"no-eval",
-			"ast-grep:no-eval",
-			"no-eval-js",
-			"ast-grep:no-eval-js",
-			"high-complexity",
-		];
-		for (const sample of samples) {
-			expect(normalizeRuleForDedup(sample)).toBe(normalizeRuleId(sample));
-		}
 	});
 });

--- a/tests/clients/dispatch/rule-policy-dispatcher.test.ts
+++ b/tests/clients/dispatch/rule-policy-dispatcher.test.ts
@@ -22,6 +22,7 @@ import type {
 	RunnerDefinition,
 	RunnerGroup,
 } from "../../../clients/dispatch/types.js";
+import { normalizeMapKey } from "../../../clients/path-utils.js";
 import { resetProjectLensConfigCache } from "../../../clients/project-lens-config.js";
 import { removeTempDirSync } from "../test-utils.js";
 
@@ -462,5 +463,111 @@ describe("dispatcher filter — resolves the policy from the project root, not t
 		const groups: RunnerGroup[] = [{ mode: "all", runnerIds: ["ast-grep"] }];
 		const result = await dispatchForFile(ctx, groups, registry);
 		expect(result.diagnostics).toHaveLength(0);
+	});
+});
+
+describe("dispatcher filter — delta baseline integrity", () => {
+	function policyDiagnostics(): Diagnostic[] {
+		return [
+			{
+				id: "no-eval-1",
+				message: "no-eval",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-eval",
+				line: 1,
+			},
+			{
+				id: "no-debugger-1",
+				message: "no-debugger",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-debugger",
+				line: 2,
+			},
+		];
+	}
+
+	function disableNoEval() {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({ rules: { "no-eval": { disable: ["no-eval"] } } }),
+		);
+	}
+
+	function registryFor(diagnostics: Diagnostic[]): RunnerRegistry {
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+		return registry;
+	}
+
+	const groups: RunnerGroup[] = [{ mode: "all", runnerIds: ["ast-grep"] }];
+
+	it("stores the policy-dropped diagnostic in the session baseline", async () => {
+		// Filtering is output-only: the persisted baseline must keep the full
+		// deduped set so removing the disable later doesn't report the rule as
+		// newly introduced. Moving applyRulePolicy above the baseline write
+		// breaks this and nothing else.
+		disableNoEval();
+		const facts = new FactStore();
+		const ctx = makeContext(tmpDir, facts);
+
+		const result = await dispatchForFile(
+			ctx,
+			groups,
+			registryFor(policyDiagnostics()),
+		);
+		expect(result.diagnostics.map((d) => d.rule)).toEqual(["no-debugger"]);
+
+		const baseline = facts.getSessionFact<Diagnostic[]>(
+			`session.baseline.${normalizeMapKey(ctx.filePath)}`,
+		);
+		expect(baseline?.map((d) => d.rule).sort()).toEqual([
+			"no-debugger",
+			"no-eval",
+		]);
+	});
+
+	it("does not count a policy-dropped rule as resolved on a later dispatch", async () => {
+		// The baseline is unfiltered by design, so `fixed` has to be measured
+		// against a policy-filtered view of it. Otherwise a disabled rule sits in
+		// `fixed` on every single dispatch and inflates trackAgentFixed forever.
+		disableNoEval();
+		const facts = new FactStore();
+
+		await dispatchForFile(
+			makeContext(tmpDir, facts),
+			groups,
+			registryFor(policyDiagnostics()),
+		);
+		const second = await dispatchForFile(
+			makeContext(tmpDir, facts),
+			groups,
+			registryFor(policyDiagnostics()),
+		);
+		expect(second.resolvedCount).toBe(0);
+	});
+
+	it("still counts a genuinely fixed rule as resolved", async () => {
+		// Guards the fix from over-correcting: a rule that stops firing and is
+		// NOT policy-dropped must still land in `fixed`.
+		disableNoEval();
+		const facts = new FactStore();
+
+		await dispatchForFile(
+			makeContext(tmpDir, facts),
+			groups,
+			registryFor(policyDiagnostics()),
+		);
+		const second = await dispatchForFile(
+			makeContext(tmpDir, facts),
+			groups,
+			registryFor(policyDiagnostics().filter((d) => d.rule === "no-eval")),
+		);
+		expect(second.resolvedCount).toBe(1);
 	});
 });

--- a/tests/clients/dispatch/rule-policy-dispatcher.test.ts
+++ b/tests/clients/dispatch/rule-policy-dispatcher.test.ts
@@ -450,15 +450,17 @@ describe("dispatcher filter — resolves the policy from the project root, not t
 
 		const ctx = createDispatchContext(
 			filePath,
-			tmpDir,
+			pkgDir,
 			{ getFlag: () => false },
 			new FactStore(),
 			false,
+			undefined,
+			tmpDir,
 		);
-		// Confirm the language root actually resolved to the nested package —
-		// otherwise this test wouldn't be exercising the bug at all.
-		expect(ctx.cwd).toBe(pkgDir);
-		expect(ctx.projectRoot).toBe(tmpDir);
+		// Confirm the language root and authoritative workspace root are distinct —
+		// otherwise this test wouldn't exercise the production monorepo boundary.
+		expect(ctx.cwd).toBe(normalizeMapKey(pkgDir));
+		expect(ctx.projectRoot).toBe(normalizeMapKey(tmpDir));
 
 		const groups: RunnerGroup[] = [{ mode: "all", runnerIds: ["ast-grep"] }];
 		const result = await dispatchForFile(ctx, groups, registry);

--- a/tests/clients/dispatch/rule-policy-dispatcher.test.ts
+++ b/tests/clients/dispatch/rule-policy-dispatcher.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Dispatcher integration tests for project-level rule policy
+ * (`rules.<id>.disable` / `rules.<id>.select`). Verifies the policy filter
+ * runs at the END of the dispatcher pipeline (after inline suppression +
+ * disposition) so the rendered `blockers` / `warnings` / `fixed` arrays
+ * reflect the user's project policy, while the baseline still records the
+ * full deduped set (a project rule edit does NOT corrupt delta baselines).
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	createDispatchContext,
+	dispatchForFile,
+} from "../../../clients/dispatch/dispatcher.js";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import { RunnerRegistry } from "../../../clients/dispatch/dispatcher.js";
+import type {
+	Diagnostic,
+	DispatchContext,
+	RunnerDefinition,
+	RunnerGroup,
+} from "../../../clients/dispatch/types.js";
+import { resetProjectLensConfigCache } from "../../../clients/project-lens-config.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+function makeContext(cwd: string, facts: FactStore): DispatchContext {
+	return createDispatchContext(
+		path.join(cwd, "a.ts"),
+		cwd,
+		{ getFlag: () => false },
+		facts,
+		false,
+	);
+}
+
+function mockRunner(
+	id: string,
+	diagnostics: Diagnostic[],
+): RunnerDefinition {
+	return {
+		id,
+		appliesTo: ["jsts"],
+		priority: 10,
+		enabledByDefault: true,
+		async run() {
+			return {
+				status: "succeeded",
+				diagnostics,
+				semantic: "warning",
+			};
+		},
+	};
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-rule-policy-"));
+	resetProjectLensConfigCache();
+});
+
+afterEach(() => {
+	removeTempDirSync(tmpDir);
+	resetProjectLensConfigCache();
+});
+
+describe("dispatcher filter — rules.<id>.disable", () => {
+	it("drops a matching diagnostic from the rendered output", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+
+		const diagnostics: Diagnostic[] = [
+			{
+				id: "no-eval-1",
+				message: "no-eval",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-eval",
+				line: 1,
+			},
+			{
+				id: "no-debugger-1",
+				message: "no-debugger",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-debugger",
+				line: 2,
+			},
+		];
+
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+
+		const ctx = makeContext(tmpDir, new FactStore());
+		const groups: RunnerGroup[] = [
+			{ mode: "all", runnerIds: ["ast-grep"] },
+		];
+
+		const result = await dispatchForFile(ctx, groups, registry);
+		expect(result.diagnostics.map((d) => d.rule)).toEqual(["no-debugger"]);
+		expect(result.warnings.map((d) => d.rule)).toEqual(["no-debugger"]);
+	});
+
+	it("drops the same rule under its LSP key (ast-grep: prefix) — normalization is shared", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+
+		const diagnostics: Diagnostic[] = [
+			{
+				id: "ast-grep-no-eval",
+				message: "no-eval (LSP tag)",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "ast-grep:no-eval",
+				line: 1,
+			},
+		];
+
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+
+		const ctx = makeContext(tmpDir, new FactStore());
+		const groups: RunnerGroup[] = [
+			{ mode: "all", runnerIds: ["ast-grep"] },
+		];
+
+		const result = await dispatchForFile(ctx, groups, registry);
+		expect(result.diagnostics).toHaveLength(0);
+	});
+
+	it("does NOT drop a rule that is not in any disable list", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+
+		const diagnostics: Diagnostic[] = [
+			{
+				id: "no-debugger-1",
+				message: "no-debugger",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-debugger",
+				line: 1,
+			},
+		];
+
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+
+		const ctx = makeContext(tmpDir, new FactStore());
+		const groups: RunnerGroup[] = [
+			{ mode: "all", runnerIds: ["ast-grep"] },
+		];
+
+		const result = await dispatchForFile(ctx, groups, registry);
+		expect(result.diagnostics).toHaveLength(1);
+		expect(result.diagnostics[0].rule).toBe("no-debugger");
+	});
+
+	it("warns nothing (no project config) — no drop, no warning", async () => {
+		// No `.pi-lens.json` → no policy applies → keep everything.
+		const diagnostics: Diagnostic[] = [
+			{
+				id: "no-eval-1",
+				message: "no-eval",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-eval",
+				line: 1,
+			},
+		];
+
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+
+		const ctx = makeContext(tmpDir, new FactStore());
+		const groups: RunnerGroup[] = [
+			{ mode: "all", runnerIds: ["ast-grep"] },
+		];
+
+		const result = await dispatchForFile(ctx, groups, registry);
+		expect(result.diagnostics).toHaveLength(1);
+	});
+});
+
+describe("dispatcher filter — rules.<id>.select", () => {
+	it("keeps only diagnostics matching a project-wide select list", async () => {
+		// Select is project-wide: the outer key (`no-eval`) is a grouping label
+		// only, not a filter scope. A non-empty select ANYWHERE silences every
+		// rule not listed, so `no-debugger` is dropped too even though it has
+		// no policy entry of its own.
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { select: ["no-eval"] } },
+			}),
+		);
+
+		const diagnostics: Diagnostic[] = [
+			{
+				id: "no-eval-1",
+				message: "no-eval",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-eval",
+				line: 1,
+			},
+			{
+				id: "no-debugger-1",
+				message: "no-debugger",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-debugger",
+				line: 2,
+			},
+		];
+
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+
+		const ctx = makeContext(tmpDir, new FactStore());
+		const groups: RunnerGroup[] = [
+			{ mode: "all", runnerIds: ["ast-grep"] },
+		];
+
+		const result = await dispatchForFile(ctx, groups, registry);
+		// Only `no-eval` survives — it's the sole entry in the project-wide
+		// select union. `no-debugger` is dropped even though it isn't
+		// configured under any key.
+		expect(result.diagnostics.map((d) => d.rule)).toEqual(["no-eval"]);
+	});
+
+	it("drops a diagnostic when select is configured but has no matching entry", async () => {
+		// The select list is `["no-debugger"]` — `no-eval` is NOT in the
+		// union, so it's dropped via the inverted-select rule.
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { select: ["no-debugger"] } },
+			}),
+		);
+
+		const diagnostics: Diagnostic[] = [
+			{
+				id: "no-eval-1",
+				message: "no-eval",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-eval",
+				line: 1,
+			},
+		];
+
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+
+		const ctx = makeContext(tmpDir, new FactStore());
+		const groups: RunnerGroup[] = [
+			{ mode: "all", runnerIds: ["ast-grep"] },
+		];
+
+		const result = await dispatchForFile(ctx, groups, registry);
+		expect(result.diagnostics).toHaveLength(0);
+	});
+
+	it("disable wins over select on the same rule key", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: {
+					"no-eval": { disable: ["no-eval"], select: ["no-eval"] },
+				},
+			}),
+		);
+
+		const diagnostics: Diagnostic[] = [
+			{
+				id: "no-eval-1",
+				message: "no-eval",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-eval",
+				line: 1,
+			},
+		];
+
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+
+		const ctx = makeContext(tmpDir, new FactStore());
+		const groups: RunnerGroup[] = [
+			{ mode: "all", runnerIds: ["ast-grep"] },
+		];
+
+		const result = await dispatchForFile(ctx, groups, registry);
+		expect(result.diagnostics).toHaveLength(0);
+	});
+});
+
+describe("dispatcher filter — threshold-only entries", () => {
+	it("threshold-only entries do NOT filter output (separate concern)", async () => {
+		// A `threshold: 25` entry is consumed by the rule evaluator, not the
+		// policy filter. The dispatcher should not interpreted it as a policy.
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "high-complexity": { threshold: 25 } },
+			}),
+		);
+
+		const diagnostics: Diagnostic[] = [
+			{
+				id: "no-eval-1",
+				message: "no-eval",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-eval",
+				line: 1,
+			},
+		];
+
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+
+		const ctx = makeContext(tmpDir, new FactStore());
+		const groups: RunnerGroup[] = [
+			{ mode: "all", runnerIds: ["ast-grep"] },
+		];
+
+		const result = await dispatchForFile(ctx, groups, registry);
+		expect(result.diagnostics).toHaveLength(1);
+	});
+});
+
+describe("dispatcher filter — blockers and warnings", () => {
+	it("a disable'd rule is dropped from blockers too (not just warnings)", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+
+		const diagnostics: Diagnostic[] = [
+			{
+				id: "no-eval-1",
+				message: "no-eval",
+				filePath: path.join(tmpDir, "a.ts"),
+				severity: "error",
+				semantic: "blocking",
+				tool: "ast-grep",
+				rule: "no-eval",
+				line: 1,
+			},
+		];
+
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+
+		const ctx = makeContext(tmpDir, new FactStore());
+		const groups: RunnerGroup[] = [
+			{ mode: "all", runnerIds: ["ast-grep"] },
+		];
+
+		const result = await dispatchForFile(ctx, groups, registry);
+		expect(result.diagnostics).toHaveLength(0);
+		expect(result.blockers).toHaveLength(0);
+		expect(result.hasBlockers).toBe(false);
+	});
+});
+
+describe("dispatcher filter — resolves the policy from the project root, not the language root", () => {
+	it("applies a repo-root policy even when the edited file's nested package has its own .pi-lens.json", async () => {
+		// `ctx.projectConfig` resolves from `resolveLanguageRootForFile` (the
+		// nested package dir in a monorepo) — the rule-policy map must NOT be
+		// derived from it, since `discoverPiLensProjectConfig`'s upward walk
+		// stops at the FIRST config found and would shadow the repo root's
+		// policy entirely. `lens_diagnostics` loads its policy map from
+		// `runtime.projectRoot`; the dispatcher must resolve the same way.
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		const pkgDir = path.join(tmpDir, "packages", "pkg-a");
+		fs.mkdirSync(pkgDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(pkgDir, "package.json"),
+			JSON.stringify({ name: "pkg-a" }),
+		);
+		// A nested config exists but defines no rule policy of its own — without
+		// the fix, this config (found first by the upward walk from the nested
+		// language root) would shadow the root's policy outright.
+		fs.writeFileSync(
+			path.join(pkgDir, ".pi-lens.json"),
+			JSON.stringify({ rules: { "high-complexity": { threshold: 30 } } }),
+		);
+
+		const filePath = path.join(pkgDir, "a.ts");
+		const diagnostics: Diagnostic[] = [
+			{
+				id: "no-eval-1",
+				message: "no-eval",
+				filePath,
+				severity: "warning",
+				semantic: "warning",
+				tool: "ast-grep",
+				rule: "no-eval",
+				line: 1,
+			},
+		];
+
+		const registry = new RunnerRegistry();
+		registry.register(mockRunner("ast-grep", diagnostics));
+
+		const ctx = createDispatchContext(
+			filePath,
+			tmpDir,
+			{ getFlag: () => false },
+			new FactStore(),
+			false,
+		);
+		// Confirm the language root actually resolved to the nested package —
+		// otherwise this test wouldn't be exercising the bug at all.
+		expect(ctx.cwd).toBe(pkgDir);
+		expect(ctx.projectRoot).toBe(tmpDir);
+
+		const groups: RunnerGroup[] = [{ mode: "all", runnerIds: ["ast-grep"] }];
+		const result = await dispatchForFile(ctx, groups, registry);
+		expect(result.diagnostics).toHaveLength(0);
+	});
+});

--- a/tests/clients/dispatch/rule-policy.test.ts
+++ b/tests/clients/dispatch/rule-policy.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for the project-level rule policy matcher
+ * (`clients/dispatch/rule-policy.ts`). Disable wins over select; rule ids
+ * normalize the same way the inline suppression parser and dedup normalizer
+ * do (`ast-grep:` prefix and `-js` suffix stripped). Returning the same
+ * canonical form across the three surfaces keeps a single user-facing
+ * `no-eval` entry from drifting across `inline-suppressions`, `disable`,
+ * and dedup.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	applyRulePolicy,
+	evaluateRulePolicy,
+	rulePolicyMapFromConfig,
+} from "../../../clients/dispatch/rule-policy.js";
+
+describe("rule-policy.matchesRule", () => {
+	it("drops a normal rule id", () => {
+		const policyMap = { "no-eval": { disable: ["no-eval"] } };
+		expect(evaluateRulePolicy("no-eval", policyMap)).toEqual({ dropped: true });
+	});
+
+	it("drops a normalized rule id (ast-grep: prefix, -js suffix)", () => {
+		const policyMap = { "no-eval": { disable: ["no-eval"] } };
+		// A user lists `no-eval` once under disable; the LSP/napi variants
+		// (`ast-grep:no-eval`, `no-eval-js`) must also be filtered.
+		expect(evaluateRulePolicy("ast-grep:no-eval", policyMap)).toEqual({
+			dropped: true,
+		});
+		expect(evaluateRulePolicy("no-eval-js", policyMap)).toEqual({
+			dropped: true,
+		});
+	});
+
+	it("drops when the entry list normalizes to the rule", () => {
+		// User lists the LSP-prefixed form in `disable`; the bare id still
+		// matches via normalization.
+		const policyMap = { "no-eval": { disable: ["ast-grep:no-eval"] } };
+		expect(evaluateRulePolicy("no-eval", policyMap)).toEqual({ dropped: true });
+	});
+
+	it("does NOT drop a different rule", () => {
+		const policyMap = { "no-eval": { disable: ["no-eval"] } };
+		expect(evaluateRulePolicy("no-debugger", policyMap)).toEqual({
+			dropped: false,
+		});
+	});
+
+	it("does NOT drop a rule that is absent from every disable list", () => {
+		// Neither the key nor the list names `no-eval`. Matching is list-based,
+		// so the unrelated `unused-vars` key is irrelevant either way.
+		const policyMap = { "unused-vars": { disable: ["no-unused-vars"] } };
+		expect(evaluateRulePolicy("no-eval", policyMap)).toEqual({ dropped: false });
+	});
+
+	it("keeps a rule with no policy (empty policyMap)", () => {
+		expect(evaluateRulePolicy("no-eval", undefined)).toEqual({ dropped: false });
+		expect(evaluateRulePolicy("no-eval", {})).toEqual({ dropped: false });
+	});
+
+	it("does not match a partial rule id (substring)", () => {
+		// `no-eval-fallback` is NOT the same rule as `no-eval` — the matcher
+		// must be exact, not substring containment.
+		const policyMap = { "no-eval": { disable: ["no-eval"] } };
+		expect(evaluateRulePolicy("no-eval-fallback", policyMap)).toEqual({
+			dropped: false,
+		});
+	});
+});
+
+describe("rule-policy.select", () => {
+	it("drops when no entry matches in select", () => {
+		const policyMap = { "no-eval": { select: ["no-debugger"] } };
+		expect(evaluateRulePolicy("no-eval", policyMap)).toEqual({ dropped: true });
+	});
+
+	it("keeps when an entry matches in select", () => {
+		const policyMap = { "no-eval": { select: ["no-eval", "no-debugger"] } };
+		expect(evaluateRulePolicy("no-eval", policyMap)).toEqual({ dropped: false });
+	});
+
+	it("matches normalized rule ids in select", () => {
+		const policyMap = { "no-eval": { select: ["no-eval"] } };
+		expect(evaluateRulePolicy("no-eval-js", policyMap)).toEqual({
+			dropped: false,
+		});
+	});
+
+	it("treats an empty select list as 'no restriction' (does NOT drop)", () => {
+		// No `select` entries at all → no allowlist filter → keep everything.
+		const policyMap = { "no-eval": { select: [] } };
+		expect(evaluateRulePolicy("no-eval", policyMap)).toEqual({ dropped: false });
+	});
+});
+
+describe("rule-policy.-js suffix conflation (documented, not a bug)", () => {
+	it("a disable naming the stem also drops a distinct rule literally named '<stem>-js'", () => {
+		// `prefer` and `prefer-js` are two different rules, but both normalize
+		// to "prefer". Disabling the stem catches the -js-suffixed rule too —
+		// deliberate side effect of the shared napi/LSP-variant normalization,
+		// documented in rule-id-normalize.ts and docs/globalconfig.md.
+		const policyMap = { prefer: { disable: ["prefer"] } };
+		expect(evaluateRulePolicy("prefer-js", policyMap)).toEqual({ dropped: true });
+	});
+
+	it("a select naming the stem also keeps a distinct rule literally named '<stem>-js'", () => {
+		const policyMap = { prefer: { select: ["prefer"] } };
+		expect(evaluateRulePolicy("prefer-js", policyMap)).toEqual({ dropped: false });
+	});
+
+	it("a disable naming the -js-suffixed rule also drops the unrelated stem rule (conflation is symmetric)", () => {
+		const policyMap = { prefer: { disable: ["prefer-js"] } };
+		expect(evaluateRulePolicy("prefer", policyMap)).toEqual({ dropped: true });
+	});
+
+	it("an exactly-spelled -js entry still matches its own rule", () => {
+		// The conflation above is one-way noise, not a hole: listing the -js id
+		// verbatim still drops the rule that carries that exact id.
+		const policyMap = { prefer: { disable: ["prefer-js"] } };
+		expect(evaluateRulePolicy("prefer-js", policyMap)).toEqual({ dropped: true });
+	});
+});
+
+describe("rule-policy.disable-wins-select", () => {
+	it("drops a rule on both disable and select lists", () => {
+		// Explicit exclusion overrides explicit inclusion.
+		const policyMap = {
+			"no-eval": { disable: ["no-eval"], select: ["no-eval"] },
+		};
+		expect(evaluateRulePolicy("no-eval", policyMap)).toEqual({ dropped: true });
+	});
+
+	it("drops a rule with disable match even if select has a non-matching entry", () => {
+		const policyMap = {
+			"no-eval": { disable: ["no-eval"], select: ["no-debugger"] },
+		};
+		expect(evaluateRulePolicy("no-eval", policyMap)).toEqual({ dropped: true });
+	});
+});
+
+describe("rule-policy.project-wide matching", () => {
+	it("a grouping key's disable list drops rules that don't share its name", () => {
+		// The outer key ("security") is a label only — it does not gate which
+		// rules the disable list under it can match.
+		const policyMap = {
+			security: { disable: ["no-eval", "no-new-func"] },
+		};
+		expect(evaluateRulePolicy("no-eval", policyMap)).toEqual({ dropped: true });
+		expect(evaluateRulePolicy("no-new-func", policyMap)).toEqual({
+			dropped: true,
+		});
+		expect(evaluateRulePolicy("no-debugger", policyMap)).toEqual({
+			dropped: false,
+		});
+	});
+
+	it("a select list under an unrelated key restricts every rule project-wide", () => {
+		const policyMap = {
+			"my-rule-set": { select: ["rule-a", "rule-b"] },
+		};
+		expect(evaluateRulePolicy("rule-a", policyMap)).toEqual({ dropped: false });
+		expect(evaluateRulePolicy("rule-b", policyMap)).toEqual({ dropped: false });
+		expect(evaluateRulePolicy("rule-c", policyMap)).toEqual({ dropped: true });
+	});
+
+	it("a select list does not drop a diagnostic that carries no rule id", () => {
+		// `Diagnostic.id` is a dedup key (`eslint:unknown:12`), not a rule id, so
+		// a rule-less finding must not be measured against the allowlist — an
+		// eslint parse error is blocking and has no ruleId.
+		const diagnostics = [
+			{ rule: "rule-a" },
+			{ id: "eslint:unknown:12" },
+			{ rule: "rule-c" },
+		];
+		const policyMap = { "my-rule-set": { select: ["rule-a"] } };
+		const result = applyRulePolicy(diagnostics, policyMap);
+		expect(result).toEqual([{ rule: "rule-a" }, { id: "eslint:unknown:12" }]);
+	});
+
+	it("disable wins across keys regardless of insertion order", () => {
+		const policyMap = {
+			a: { select: ["no-eval"] },
+			b: { disable: ["no-eval"] },
+		};
+		expect(evaluateRulePolicy("no-eval", policyMap)).toEqual({ dropped: true });
+
+		const reversed = {
+			b: { disable: ["no-eval"] },
+			a: { select: ["no-eval"] },
+		};
+		expect(evaluateRulePolicy("no-eval", reversed)).toEqual({ dropped: true });
+	});
+});
+
+describe("rule-policy.applyRulePolicy", () => {
+	it("drops matching diagnostics", () => {
+		const diagnostics = [
+			{ rule: "no-eval" },
+			{ rule: "no-debugger" },
+			{ rule: "ast-grep:no-eval" },
+		];
+		const policyMap = { "no-eval": { disable: ["no-eval"] } };
+		const result = applyRulePolicy(diagnostics, policyMap);
+		expect(result.map((d) => d.rule)).toEqual(["no-debugger"]);
+	});
+
+	it("keeps diagnostics without a recognizable rule id", () => {
+		const diagnostics = [
+			{ rule: "no-eval" }, // rule matches disable list → dropped
+			{ id: "anonymous" }, // no rule, has id — kept untouched
+			{}, // no rule or id at all — kept untouched
+		];
+		const policyMap = { "no-eval": { disable: ["no-eval"] } };
+		const result = applyRulePolicy(diagnostics, policyMap);
+		expect(result).toHaveLength(2);
+		// The first element should be the id-only diagnostic (no rule dropped).
+		expect(result[0]).toEqual({ id: "anonymous" });
+		expect(result[1]).toEqual({});
+	});
+
+	it("returns the same array reference when no policy applies", () => {
+		// Fast-path: no entries with disable/select → no-op identity.
+		const diagnostics = [{ rule: "no-eval" }, { rule: "no-debugger" }];
+		const policyMap = { "high-complexity": { threshold: 25 } };
+		const result = applyRulePolicy(diagnostics, policyMap);
+		expect(result).toBe(diagnostics);
+	});
+
+	it("returns the same array when policyMap is undefined", () => {
+		const diagnostics = [{ rule: "no-eval" }];
+		const result = applyRulePolicy(diagnostics, undefined);
+		expect(result).toBe(diagnostics);
+	});
+
+	it("applies the policy through a mixed map with the threshold-only entry first", () => {
+		// `rulePolicyMapFromConfig` always strips threshold-only entries before
+		// calling `applyRulePolicy`, but the function also gets raw config maps
+		// directly. The `hasFilter` scan must not stop at the first (threshold-
+		// only) entry and wrongly treat the whole map as filter-free.
+		const diagnostics = [{ rule: "no-eval" }, { rule: "no-debugger" }];
+		const policyMap = {
+			"high-complexity": { threshold: 25 },
+			"no-eval": { disable: ["no-eval"] },
+		};
+		const result = applyRulePolicy(diagnostics, policyMap);
+		expect(result.map((d) => d.rule)).toEqual(["no-debugger"]);
+	});
+
+	it("applies the policy through a mixed map with the policy entry first", () => {
+		const diagnostics = [{ rule: "no-eval" }, { rule: "no-debugger" }];
+		const policyMap = {
+			"no-eval": { disable: ["no-eval"] },
+			"high-complexity": { threshold: 25 },
+		};
+		const result = applyRulePolicy(diagnostics, policyMap);
+		expect(result.map((d) => d.rule)).toEqual(["no-debugger"]);
+	});
+
+	it("disabling one rule does not affect rules absent from the list", () => {
+		const diagnostics = [
+			{ rule: "no-eval" },
+			{ rule: "no-debugger" },
+			{ rule: "no-alert" },
+		];
+		const policyMap = { "no-eval": { disable: ["no-eval"] } };
+		const result = applyRulePolicy(diagnostics, policyMap);
+		expect(result.map((d) => d.rule)).toEqual(["no-debugger", "no-alert"]);
+	});
+});
+
+describe("rule-policy.rulePolicyMapFromConfig", () => {
+	it("returns undefined when no rules have policy fields", () => {
+		// Threshold-only entries are excluded — no filter work, so the
+		// hot path returns undefined to bail out early.
+		expect(
+			rulePolicyMapFromConfig({
+				"high-complexity": { threshold: 25 },
+				"high-fan-out": { threshold: 30 },
+			}),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when rules is undefined", () => {
+		expect(rulePolicyMapFromConfig(undefined)).toBeUndefined();
+	});
+
+	it("includes policy entries only", () => {
+		const map = rulePolicyMapFromConfig({
+			"high-complexity": { threshold: 25 },
+			"no-eval": { disable: ["no-eval"] },
+		});
+		expect(map).toBeDefined();
+		expect(Object.keys(map!)).toEqual(["no-eval"]);
+		expect(map!["no-eval"]).toEqual({ disable: ["no-eval"] });
+	});
+
+	it("preserves both disable and select on a single entry", () => {
+		const map = rulePolicyMapFromConfig({
+			"no-eval": { disable: ["no-eval"], select: ["no-eval"] },
+		});
+		expect(map).toEqual({
+			"no-eval": { disable: ["no-eval"], select: ["no-eval"] },
+		});
+	});
+});

--- a/tests/clients/dispatch/rule-policy.test.ts
+++ b/tests/clients/dispatch/rule-policy.test.ts
@@ -207,15 +207,25 @@ describe("rule-policy.applyRulePolicy", () => {
 	it("keeps diagnostics without a recognizable rule id", () => {
 		const diagnostics = [
 			{ rule: "no-eval" }, // rule matches disable list → dropped
-			{ id: "anonymous" }, // no rule, has id — kept untouched
-			{}, // no rule or id at all — kept untouched
+			{ id: "anonymous" }, // no rule or code, has id — kept untouched
+			{}, // no rule or code at all — kept untouched
 		];
 		const policyMap = { "no-eval": { disable: ["no-eval"] } };
 		const result = applyRulePolicy(diagnostics, policyMap);
 		expect(result).toHaveLength(2);
-		// The first element should be the id-only diagnostic (no rule dropped).
+		// The first element should be the id-only diagnostic (no rule or code).
 		expect(result[0]).toEqual({ id: "anonymous" });
 		expect(result[1]).toEqual({});
+	});
+
+	it("uses a code-only diagnostic as its policy key", () => {
+		const diagnostics = [
+			{ code: "no-eval" },
+			{ code: "no-debugger" },
+		];
+		const policyMap = { "no-eval": { disable: ["no-eval"] } };
+		const result = applyRulePolicy(diagnostics, policyMap);
+		expect(result).toEqual([{ code: "no-debugger" }]);
 	});
 
 	it("returns the same array reference when no policy applies", () => {

--- a/tests/clients/pipeline.test.ts
+++ b/tests/clients/pipeline.test.ts
@@ -182,6 +182,43 @@ describe("Pipeline", () => {
 		expect(result.fileModified).toBe(false);
 	});
 
+	it("passes the workspace root to dispatch when cwd is a nested language root", async () => {
+		const nestedDir = path.join(tmpDir, "packages", "pkg-a");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		const filePath = createTempFile(nestedDir, "nested.ts", "const x = 1;\n");
+		vi.mocked(dispatchLintWithResult).mockResolvedValue({
+			diagnostics: [],
+			blockers: [],
+			warnings: [],
+			baselineWarningCount: 0,
+			fixed: [],
+			resolvedCount: 0,
+			output: "",
+			blockerOutput: "",
+			hasBlockers: false,
+		});
+
+		await runPipeline(
+			createMockContext(filePath, {
+				cwd: nestedDir,
+				projectRoot: tmpDir,
+			}),
+			createMockDeps(),
+		);
+
+		expect(vi.mocked(dispatchLintWithResult)).toHaveBeenCalledWith(
+			filePath,
+			nestedDir,
+			expect.objectContaining({ getFlag: expect.any(Function) }),
+			undefined,
+			expect.objectContaining({
+				model: "unknown",
+				sessionId: "unknown",
+			}),
+			{ projectRoot: tmpDir },
+		);
+	});
+
 	describe("Format phase", () => {
 		it("defers format by default", async () => {
 			const filePath = createTempFile(tmpDir, "unformatted.ts", "const x=1");

--- a/tests/clients/project-lens-config.test.ts
+++ b/tests/clients/project-lens-config.test.ts
@@ -457,4 +457,204 @@ describe("loadPiLensProjectConfig", () => {
 			expect(typoWarns.length).toBe(1);
 		});
 	});
+
+	// `rules.<id>.disable` / `rules.<id>.select` are the project-level rule
+	// policy — output-only filtering applied by the dispatcher and the
+	// `lens_diagnostics` tool. Disable wins over select (explicit exclusion
+	// trumps explicit inclusion). The matcher normalizes rule ids so an entry
+	// listed as `no-eval` covers `ast-grep:no-eval` and `no-eval-js` (the same
+	// normalization the inline suppression parser already uses).
+	describe("rules.<id>.disable / rules.<id>.select", () => {
+		it("parses a disable list alongside a threshold", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: {
+						"high-complexity": {
+							threshold: 25,
+							disable: ["no-eval", "no-debugger"],
+						},
+					},
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["high-complexity"]).toEqual({
+				threshold: 25,
+				disable: ["no-eval", "no-debugger"],
+			});
+		});
+
+		it("parses a select list without any threshold", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: {
+						"high-complexity": { select: ["no-eval", "no-debugger"] },
+					},
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["high-complexity"]).toEqual({
+				select: ["no-eval", "no-debugger"],
+			});
+		});
+
+		it("accepts a policy-only entry (no threshold, only disable/select)", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: {
+						"unused-var": { disable: ["no-unused-vars"] },
+					},
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["unused-var"]).toEqual({
+				disable: ["no-unused-vars"],
+			});
+		});
+
+		it("filters non-string entries out of disable/select lists", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: {
+						"high-complexity": {
+							disable: ["no-eval", 42, null, "no-debugger", { x: 1 }],
+						},
+					},
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["high-complexity"]?.disable).toEqual([
+				"no-eval",
+				"no-debugger",
+			]);
+		});
+
+		it("trims whitespace around list entries", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: {
+						"high-complexity": { disable: ["  no-eval  ", " no-debugger"] },
+					},
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["high-complexity"]?.disable).toEqual([
+				"no-eval",
+				"no-debugger",
+			]);
+		});
+
+		it("warns once and drops a non-array disable", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: { "high-complexity": { disable: "no-eval" } },
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["high-complexity"]?.disable).toBeUndefined();
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"rules.high-complexity.disable must be an array of strings",
+				),
+			);
+		});
+
+		it("warns once and drops a non-array select", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: { "high-complexity": { select: { id: "no-eval" } } },
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["high-complexity"]?.select).toBeUndefined();
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"rules.high-complexity.select must be an array of strings",
+				),
+			);
+		});
+
+		it("warns once and drops an empty disable list", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: { "high-complexity": { disable: [] } },
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["high-complexity"]?.disable).toBeUndefined();
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"rules.high-complexity.disable must be a non-empty array of strings",
+				),
+			);
+		});
+
+		it("warns once and drops an empty/non-string select list", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: { "high-complexity": { select: [42, null, true] } },
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["high-complexity"]?.select).toBeUndefined();
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"rules.high-complexity.select must be a non-empty array of strings",
+				),
+			);
+		});
+
+		it("preserves threshold when an invalid disable value is dropped", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: { "high-complexity": { threshold: 25, disable: "bad" } },
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["high-complexity"]?.threshold).toBe(25);
+			expect(cfg.rules["high-complexity"]?.disable).toBeUndefined();
+		});
+
+		it("preserves both disable and select when both are valid", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: {
+						"high-complexity": {
+							disable: ["no-eval"],
+							select: ["no-debugger"],
+						},
+					},
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["high-complexity"]?.disable).toEqual(["no-eval"]);
+			expect(cfg.rules["high-complexity"]?.select).toEqual(["no-debugger"]);
+		});
+
+		it("does not warn on a forward-compat entry with no recognized fields", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({
+					rules: {
+						"future-rule": { unrelated: true },
+					},
+				}),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			// No recognized fields → entry not stored (forward-compat). No
+			// warning emitted either, since unrecognized keys are silently
+			// ignored for forward-compat rules per the existing describe block.
+			expect(cfg.rules["future-rule"]).toBeUndefined();
+		});
+	});
 });

--- a/tests/clients/project-lens-config.test.ts
+++ b/tests/clients/project-lens-config.test.ts
@@ -548,6 +548,50 @@ describe("loadPiLensProjectConfig", () => {
 			]);
 		});
 
+		it("warns when the lists are written directly under rules (#444's own example)", () => {
+			// `{"rules": {"disable": [...]}}` is the shape the issue proposed and
+			// the most likely thing a user tries. It parses as valid JSON and has
+			// zero effect, so it has to say so rather than fail silent.
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({ rules: { disable: ["no-eval"] } }),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules.disable).toBeUndefined();
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"rules.disable must be an object with threshold, disable, or select",
+				),
+			);
+		});
+
+		it("warns on a rule entry whose only key is unrecognized (e.g. #444's `only`)", () => {
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({ rules: { "no-eval": { only: ["no-eval"] } } }),
+			);
+			const cfg = loadPiLensProjectConfig(tmpDir);
+			expect(cfg.rules["no-eval"]).toBeUndefined();
+			expect(console.error).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"rules.no-eval has no recognized setting (threshold, disable, select)",
+				),
+			);
+		});
+
+		it("does not warn twice when a recognized field was merely malformed", () => {
+			// `disable` already warned about its own shape — adding a second
+			// "no recognized setting" line for the same entry would be noise.
+			fs.writeFileSync(
+				path.join(tmpDir, ".pi-lens.json"),
+				JSON.stringify({ rules: { "no-eval": { disable: "no-eval" } } }),
+			);
+			loadPiLensProjectConfig(tmpDir);
+			expect(console.error).not.toHaveBeenCalledWith(
+				expect.stringContaining("has no recognized setting"),
+			);
+		});
+
 		it("warns once and drops a non-array disable", () => {
 			fs.writeFileSync(
 				path.join(tmpDir, ".pi-lens.json"),

--- a/tests/tools/lens-diagnostics-rule-policy.test.ts
+++ b/tests/tools/lens-diagnostics-rule-policy.test.ts
@@ -591,6 +591,47 @@ describe("lens_diagnostics rule policy — mode=full (active scan)", () => {
 		expect(text).not.toContain("MSG-LSP-NO-EVAL");
 	});
 
+	it("applies policy even when a fresh full-mode file cannot be reread", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		// The LSP sweep can return a diagnostic for a file that disappears before
+		// the content-based suppression pass. Policy filtering must not depend on
+		// that second read succeeding.
+		const filePath = path.join(tmpDir, "src", "deleted.ts");
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([
+				{
+					filePath,
+					diagnostics: [
+						{
+							severity: 2,
+							message: "MSG-LSP-NO-EVAL-DELETED",
+							range: {
+								start: { line: 1, character: 0 },
+								end: { line: 1, character: 5 },
+							},
+							source: "ast-grep",
+							code: "no-eval",
+						},
+					],
+					count: 1,
+				},
+			]),
+		};
+
+		const result = await run(
+			makeTool(tmpDir, {}, lspService),
+			{ mode: "full" },
+			tmpDir,
+		);
+		const text = String(result.content[0].text);
+		expect(text).not.toContain("MSG-LSP-NO-EVAL-DELETED");
+	});
+
 	it("drops a disabled rule from the project-diagnostics snapshot", async () => {
 		fs.writeFileSync(
 			path.join(tmpDir, ".pi-lens.json"),
@@ -650,6 +691,52 @@ describe("lens_diagnostics rule policy — mode=full (active scan)", () => {
 		const text = String(result.content[0].text);
 		expect(text).toContain("MSG-PROJECT-NO-DEBUGGER");
 		expect(text).not.toContain("MSG-PROJECT-NO-EVAL");
+	});
+
+	it("applies policy consistently to code-only project diagnostics", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		const filePath = path.join(tmpDir, "src", "foo.ts");
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, "// empty file\n");
+
+		projectDiagnosticsMocks.loadProjectDiagnosticsSnapshot.mockReturnValue({
+			version: 1,
+			cwd: tmpDir,
+			tier: "cheap",
+			scannedAt: "2026-01-01T00:00:00.000Z",
+			filesScanned: 1,
+			runners: ["tree-sitter"],
+			diagnostics: [
+				{
+					filePath,
+					line: 5,
+					severity: "warning",
+					semantic: "warning",
+					tool: "tree-sitter",
+					runner: "tree-sitter",
+					code: "no-eval",
+					message: "MSG-CODE-ONLY-NO-EVAL",
+					source: "project-scan",
+				},
+			],
+		});
+
+		const result = await run(
+			makeTool(tmpDir, {}, { runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]) }),
+			{ mode: "full", refreshRunners: "cached" },
+			tmpDir,
+		);
+		const text = String(result.content[0].text);
+		const details = result.details as {
+			projectDiagnostics?: { diagnostics: number };
+		};
+		expect(details.projectDiagnostics?.diagnostics).toBe(0);
+		expect(text).not.toContain("MSG-CODE-ONLY-NO-EVAL");
 	});
 
 	it("details.projectDiagnostics/projectDiagnosticsDelta counts reflect the post-policy set", async () => {

--- a/tests/tools/lens-diagnostics-rule-policy.test.ts
+++ b/tests/tools/lens-diagnostics-rule-policy.test.ts
@@ -228,6 +228,97 @@ describe("lens_diagnostics rule policy — delta mode", () => {
 		expect(result.details).toMatchObject({ qualityIssues: 1 });
 	});
 
+	it("a project-wide select narrows the actionable warnings cache", async () => {
+		// select is the big hammer — a call site that forgets the filter fails
+		// open here, so the cache-only paths need their own coverage, not just
+		// mode=full's.
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "my-rule-set": { select: ["no-debugger"] } },
+			}),
+		);
+		const tool = makeTool(tmpDir, {
+			"actionable-warnings": {
+				files: [
+					{
+						filePath: path.join(tmpDir, "src/foo.ts"),
+						warnings: [
+							{
+								line: 1,
+								rule: "no-eval",
+								tool: "ast-grep",
+								message: "MSG-NO-EVAL",
+							},
+							{
+								line: 2,
+								rule: "no-debugger",
+								tool: "ast-grep",
+								message: "MSG-NO-DEBUGGER",
+							},
+						],
+					},
+				],
+				summary: { warnings: 2 },
+			},
+		});
+
+		const result = await run(tool, { mode: "delta" }, tmpDir);
+		const text = String(result.content[0].text);
+		expect(text).toContain("MSG-NO-DEBUGGER");
+		expect(text).not.toContain("MSG-NO-EVAL");
+		expect(result.details).toMatchObject({ actionableWarnings: 1 });
+	});
+
+	it("drops a disabled rule from the project-diagnostics delta report", async () => {
+		// filterDeltaReportDispositions is reached only from formatDeltaMode —
+		// mode=full's coverage of the same report says nothing about this path.
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		const filePath = path.join(tmpDir, "src/foo.ts");
+		projectDiagnosticsMocks.loadProjectDiagnosticsDeltaReport.mockReturnValue({
+			version: 1,
+			cwd: tmpDir,
+			generatedAt: "2026-01-01T00:00:00.000Z",
+			sessionId: "s1",
+			turnIndex: 1,
+			diagnostics: [
+				{
+					filePath,
+					line: 7,
+					severity: "warning",
+					semantic: "warning",
+					tool: "tree-sitter",
+					runner: "tree-sitter",
+					rule: "no-eval",
+					message: "MSG-DELTA-NO-EVAL",
+					source: "project-scan",
+				},
+				{
+					filePath,
+					line: 8,
+					severity: "warning",
+					semantic: "warning",
+					tool: "tree-sitter",
+					runner: "tree-sitter",
+					rule: "no-debugger",
+					message: "MSG-DELTA-NO-DEBUGGER",
+					source: "project-scan",
+				},
+			],
+			sources: ["tree-sitter"],
+		});
+
+		const result = await run(makeTool(tmpDir), { mode: "delta" }, tmpDir);
+		const text = String(result.content[0].text);
+		expect(text).toContain("MSG-DELTA-NO-DEBUGGER");
+		expect(text).not.toContain("MSG-DELTA-NO-EVAL");
+	});
+
 	it("does not change output when no project rule policy is configured", async () => {
 		// No `.pi-lens.json` is written → no policy applies → keep everything.
 		const tool = makeTool(tmpDir, {
@@ -326,6 +417,44 @@ describe("lens_diagnostics rule policy — mode=all (cache-only)", () => {
 		expect(text).toContain("MSG-NO-DEBUGGER");
 		expect(text).not.toContain("MSG-NO-EVAL");
 		// Counts reflect the policy drop.
+		expect(result.details).toMatchObject({ totalWarnings: 1 });
+	});
+
+	it("a project-wide select narrows a file's cached widget diagnostics", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "my-rule-set": { select: ["no-debugger"] } },
+			}),
+		);
+		mockSummaries.push({
+			filePath: path.join(tmpDir, "src/foo.ts"),
+			blocking: 0,
+			errors: 0,
+			warnings: 2,
+			hasFinalSnapshot: true,
+			diagnostics: [
+				{
+					severity: "warning",
+					message: "MSG-NO-EVAL",
+					line: 1,
+					rule: "no-eval",
+					tool: "ast-grep",
+				},
+				{
+					severity: "warning",
+					message: "MSG-NO-DEBUGGER",
+					line: 2,
+					rule: "no-debugger",
+					tool: "ast-grep",
+				},
+			],
+		});
+
+		const result = await run(makeTool(tmpDir), { mode: "all" }, tmpDir);
+		const text = String(result.content[0].text);
+		expect(text).toContain("MSG-NO-DEBUGGER");
+		expect(text).not.toContain("MSG-NO-EVAL");
 		expect(result.details).toMatchObject({ totalWarnings: 1 });
 	});
 

--- a/tests/tools/lens-diagnostics-rule-policy.test.ts
+++ b/tests/tools/lens-diagnostics-rule-policy.test.ts
@@ -1,0 +1,625 @@
+/**
+ * Tests for the project-level rule policy integration in `lens_diagnostics`
+ * (rules.<id>.disable / rules.<id>.select). The policy filter overlays all
+ * three modes (delta, all, full) so a project's `.pi-lens.json` is the
+ * single source of truth across the per-edit dispatcher, the cache-only
+ * tool reads, and the active scan's merge.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLensDiagnosticsTool } from "../../tools/lens-diagnostics.js";
+import { resetProjectLensConfigCache } from "../../clients/project-lens-config.js";
+import { removeTempDirSync } from "../clients/test-utils.js";
+
+// Mock the same heavy modules the lens-diagnostics tests already mock, so
+// these tests run quickly without spinning up real scanners/analyzers.
+const projectDiagnosticsMocks = vi.hoisted(() => ({
+	scanProjectDiagnostics: vi.fn(),
+	loadProjectDiagnosticsSnapshot: vi.fn(),
+	loadProjectDiagnosticsDeltaReport: vi.fn(),
+}));
+
+const freshFetchMocks = vi.hoisted(() => ({
+	fetchFreshProjectDiagnostics: vi.fn(),
+}));
+
+vi.mock("../../clients/project-diagnostics/fresh-fetch.js", () => ({
+	fetchFreshProjectDiagnostics: freshFetchMocks.fetchFreshProjectDiagnostics,
+}));
+
+vi.mock("../../clients/bootstrap.js", () => ({
+	loadBootstrapClients: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../../clients/project-diagnostics/scanner.js", () => ({
+	scanProjectDiagnostics: projectDiagnosticsMocks.scanProjectDiagnostics,
+}));
+
+vi.mock("../../clients/project-diagnostics/cache.js", () => ({
+	PROJECT_DIAGNOSTICS_CACHE_VERSION: 2,
+	loadProjectDiagnosticsSnapshot:
+		projectDiagnosticsMocks.loadProjectDiagnosticsSnapshot,
+	loadProjectDiagnosticsDeltaReport:
+		projectDiagnosticsMocks.loadProjectDiagnosticsDeltaReport,
+	reconcileProjectDiagnosticsSnapshot: (
+		snapshot: import("../../clients/project-diagnostics/types.js").ProjectDiagnosticsSnapshot,
+	) => ({ snapshot, staleDropped: 0 }),
+}));
+
+const mockSummaries: ReturnType<
+	typeof import("../../clients/widget-state.js")["getFileDiagnosticSummaries"]
+> = [];
+
+vi.mock("../../clients/widget-state.js", () => ({
+	getFileDiagnosticSummaries: () => mockSummaries,
+	reconcileStaleWidgetFiles: async () => 0,
+	reconcileScanDiagnostics: vi.fn(),
+}));
+
+function makeCacheManager(data: Record<string, unknown> = {}) {
+	return {
+		readCache: vi.fn((key: string) =>
+			data[key]
+				? { data: data[key], meta: { savedAt: "", scanner: key } }
+				: undefined,
+		),
+	};
+}
+
+function makeTool(
+	cwd: string,
+	cacheData: Record<string, unknown> = {},
+	lspService?: unknown,
+) {
+	return createLensDiagnosticsTool(
+		makeCacheManager(cacheData) as any,
+		() => cwd,
+		() => lspService as any,
+	);
+}
+
+function run(
+	tool: ReturnType<typeof makeTool>,
+	params: Record<string, unknown> = {},
+	cwd: string,
+) {
+	return tool.execute("1", params, new AbortController().signal, null, { cwd });
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-policy-diag-"));
+	projectDiagnosticsMocks.scanProjectDiagnostics.mockReset();
+	projectDiagnosticsMocks.loadProjectDiagnosticsSnapshot.mockReset();
+	projectDiagnosticsMocks.loadProjectDiagnosticsDeltaReport.mockReset();
+	freshFetchMocks.fetchFreshProjectDiagnostics.mockReset();
+	freshFetchMocks.fetchFreshProjectDiagnostics.mockResolvedValue({
+		diagnostics: [],
+		runners: [],
+		cold: [],
+		timings: {},
+	});
+	mockSummaries.length = 0;
+	resetProjectLensConfigCache();
+});
+
+afterEach(() => {
+	removeTempDirSync(tmpDir);
+	resetProjectLensConfigCache();
+});
+
+describe("lens_diagnostics rule policy — delta mode", () => {
+	it("drops a disabled rule from the actionable warnings cache", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		const tool = makeTool(tmpDir, {
+			"actionable-warnings": {
+				files: [
+					{
+						filePath: path.join(tmpDir, "src/foo.ts"),
+						warnings: [
+							{
+								line: 1,
+								rule: "no-eval",
+								tool: "ast-grep",
+								message: "MSG-NO-EVAL",
+							},
+							{
+								line: 2,
+								rule: "no-debugger",
+								tool: "ast-grep",
+								message: "MSG-NO-DEBUGGER",
+							},
+						],
+					},
+				],
+				summary: { warnings: 2 },
+			},
+		});
+
+		const result = await run(tool, { mode: "delta" }, tmpDir);
+		const text = String(result.content[0].text);
+		expect(text).toContain("MSG-NO-DEBUGGER");
+		expect(text).not.toContain("MSG-NO-EVAL");
+		expect(result.details).toMatchObject({ actionableWarnings: 1 });
+	});
+
+	it("drops a disabled rule that surfaces under ast-grep: prefix (normalization shared)", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		const tool = makeTool(tmpDir, {
+			"actionable-warnings": {
+				files: [
+					{
+						filePath: path.join(tmpDir, "src/foo.ts"),
+						warnings: [
+							{
+								line: 1,
+								rule: "ast-grep:no-eval",
+								tool: "ast-grep",
+								message: "MSG-LSP-NO-EVAL",
+							},
+						],
+					},
+				],
+				summary: { warnings: 1 },
+			},
+		});
+
+		const result = await run(tool, { mode: "delta" }, tmpDir);
+		const text = String(result.content[0].text);
+		// The disabled rule's message is dropped — the response renders as
+		// "no issues" with the warnings count at 0.
+		expect(text).not.toContain("MSG-LSP-NO-EVAL");
+		const details = result.details as {
+			warnings?: number;
+			actionableWarnings?: number;
+		};
+		expect(details.warnings ?? details.actionableWarnings ?? 0).toBe(0);
+	});
+
+	it("drops a disabled rule from the code-quality warnings cache", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-unused-vars": { disable: ["no-unused-vars"] } },
+			}),
+		);
+		const tool = makeTool(tmpDir, {
+			"code-quality-warnings": {
+				files: [
+					{
+						filePath: path.join(tmpDir, "src/bar.ts"),
+						warnings: [
+							{
+								line: 1,
+								rule: "no-unused-vars",
+								tool: "eslint",
+								message: "MSG-UNUSED",
+							},
+							{
+								line: 2,
+								rule: "high-complexity",
+								tool: "complexity",
+								message: "MSG-COMPLEXITY",
+							},
+						],
+					},
+				],
+				summary: { warnings: 2 },
+			},
+		});
+
+		const result = await run(tool, { mode: "delta" }, tmpDir);
+		const text = String(result.content[0].text);
+		expect(text).toContain("MSG-COMPLEXITY");
+		expect(text).not.toContain("MSG-UNUSED");
+		expect(result.details).toMatchObject({ qualityIssues: 1 });
+	});
+
+	it("does not change output when no project rule policy is configured", async () => {
+		// No `.pi-lens.json` is written → no policy applies → keep everything.
+		const tool = makeTool(tmpDir, {
+			"actionable-warnings": {
+				files: [
+					{
+						filePath: path.join(tmpDir, "src/foo.ts"),
+						warnings: [{ line: 1, rule: "no-eval", tool: "t", message: "MSG" }],
+					},
+				],
+				summary: { warnings: 1 },
+			},
+		});
+
+		const result = await run(tool, { mode: "delta" }, tmpDir);
+		expect(result.details).toMatchObject({ actionableWarnings: 1 });
+	});
+});
+
+describe("lens_diagnostics rule policy — delta mode carried-over tally", () => {
+	it("excludes a disabled rule from the 'carried over' count when the turn delta is empty", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		// No actionable/quality/project-delta cache data — the delta text falls
+		// through to reporting `getFileDiagnosticSummaries()` as "carried over
+		// from earlier this session".
+		mockSummaries.push({
+			filePath: path.join(tmpDir, "src/foo.ts"),
+			blocking: 0,
+			errors: 0,
+			warnings: 2,
+			hasFinalSnapshot: true,
+			diagnostics: [
+				{
+					severity: "warning",
+					message: "MSG-NO-EVAL",
+					line: 1,
+					rule: "no-eval",
+					tool: "ast-grep",
+				},
+				{
+					severity: "warning",
+					message: "MSG-NO-DEBUGGER",
+					line: 2,
+					rule: "no-debugger",
+					tool: "ast-grep",
+				},
+			],
+		});
+
+		const result = await run(makeTool(tmpDir), { mode: "delta" }, tmpDir);
+		const text = String(result.content[0].text);
+		expect(text).toContain("1 finding across 1 file carried over");
+		expect(text).not.toContain("2 findings across 1 file carried over");
+	});
+});
+
+describe("lens_diagnostics rule policy — mode=all (cache-only)", () => {
+	it("drops a disabled rule from a file's cached widget diagnostics", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		mockSummaries.push({
+			filePath: path.join(tmpDir, "src/foo.ts"),
+			blocking: 0,
+			errors: 0,
+			warnings: 2,
+			hasFinalSnapshot: true,
+			diagnostics: [
+				{
+					severity: "warning",
+					message: "MSG-NO-EVAL",
+					line: 1,
+					rule: "no-eval",
+					tool: "ast-grep",
+				},
+				{
+					severity: "warning",
+					message: "MSG-NO-DEBUGGER",
+					line: 2,
+					rule: "no-debugger",
+					tool: "ast-grep",
+				},
+			],
+		});
+
+		const result = await run(makeTool(tmpDir), { mode: "all" }, tmpDir);
+		const text = String(result.content[0].text);
+		expect(text).toContain("MSG-NO-DEBUGGER");
+		expect(text).not.toContain("MSG-NO-EVAL");
+		// Counts reflect the policy drop.
+		expect(result.details).toMatchObject({ totalWarnings: 1 });
+	});
+
+	it("does not filter when no policy applies (no project config)", async () => {
+		mockSummaries.push({
+			filePath: path.join(tmpDir, "src/foo.ts"),
+			blocking: 0,
+			errors: 0,
+			warnings: 1,
+			hasFinalSnapshot: true,
+			diagnostics: [
+				{
+					severity: "warning",
+					message: "MSG",
+					line: 1,
+					rule: "no-eval",
+					tool: "ast-grep",
+				},
+			],
+		});
+
+		const result = await run(makeTool(tmpDir), { mode: "all" }, tmpDir);
+		expect(result.details).toMatchObject({ totalWarnings: 1 });
+	});
+});
+
+describe("lens_diagnostics rule policy — mode=full (active scan)", () => {
+	it("a project-wide select narrows the mode=full gate to the listed rules", async () => {
+		// mode=full is the clean gate, so select's project-wide reach has to hold
+		// on the active-scan path too, not just the cache-only modes.
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "my-rule-set": { select: ["no-debugger"] } },
+			}),
+		);
+		const filePath = path.join(tmpDir, "src/foo.ts");
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, "// empty file\n");
+
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([
+				{
+					filePath,
+					diagnostics: [
+						{
+							severity: 2,
+							message: "MSG-LSP-NO-EVAL",
+							range: {
+								start: { line: 1, character: 0 },
+								end: { line: 1, character: 5 },
+							},
+							source: "ast-grep",
+							code: "no-eval",
+						},
+						{
+							severity: 2,
+							message: "MSG-LSP-NO-DEBUGGER",
+							range: {
+								start: { line: 2, character: 0 },
+								end: { line: 2, character: 5 },
+							},
+							source: "ast-grep",
+							code: "no-debugger",
+						},
+					],
+					count: 2,
+				},
+			]),
+		};
+
+		const result = await run(
+			makeTool(tmpDir, {}, lspService),
+			{ mode: "full" },
+			tmpDir,
+		);
+		const text = String(result.content[0].text);
+		expect(text).toContain("MSG-LSP-NO-DEBUGGER");
+		expect(text).not.toContain("MSG-LSP-NO-EVAL");
+	});
+
+	it("drops a disabled rule from a fresh LSP sweep result", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		// mode=full's policy filter runs inside `applyInlineSuppressionsToSummaries`,
+		// which reads the file content first. Create the file so the read
+		// succeeds and the policy path actually executes.
+		const filePath = path.join(tmpDir, "src/foo.ts");
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, "// empty file\n");
+
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([
+				{
+					filePath,
+					diagnostics: [
+						{
+							severity: 2,
+							message: "MSG-LSP-NO-EVAL",
+							range: {
+								start: { line: 1, character: 0 },
+								end: { line: 1, character: 5 },
+							},
+							source: "ast-grep",
+							code: "no-eval",
+						},
+						{
+							severity: 2,
+							message: "MSG-LSP-NO-DEBUGGER",
+							range: {
+								start: { line: 2, character: 0 },
+								end: { line: 2, character: 5 },
+							},
+							source: "ast-grep",
+							code: "no-debugger",
+						},
+					],
+					count: 2,
+				},
+			]),
+		};
+
+		const result = await run(
+			makeTool(tmpDir, {}, lspService),
+			{ mode: "full" },
+			tmpDir,
+		);
+		const text = String(result.content[0].text);
+		expect(text).toContain("MSG-LSP-NO-DEBUGGER");
+		expect(text).not.toContain("MSG-LSP-NO-EVAL");
+	});
+
+	it("drops a disabled rule from the project-diagnostics snapshot", async () => {
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		// Same reason as above — `applyInlineSuppressionsToSummaries` reads the
+		// file first; the merged-snapshot path needs the file to exist for the
+		// policy filter to actually run.
+		const filePath = path.join(tmpDir, "src/foo.ts");
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, "// empty file\n");
+
+		projectDiagnosticsMocks.loadProjectDiagnosticsSnapshot.mockReturnValue({
+			version: 1,
+			cwd: tmpDir,
+			tier: "cheap",
+			scannedAt: "2026-01-01T00:00:00.000Z",
+			filesScanned: 1,
+			runners: ["tree-sitter", "fact-rules"],
+			diagnostics: [
+				{
+					filePath,
+					line: 5,
+					severity: "warning",
+					semantic: "warning",
+					tool: "tree-sitter",
+					runner: "tree-sitter",
+					rule: "no-eval",
+					message: "MSG-PROJECT-NO-EVAL",
+					source: "project-scan",
+				},
+				{
+					filePath,
+					line: 6,
+					severity: "warning",
+					semantic: "warning",
+					tool: "tree-sitter",
+					runner: "tree-sitter",
+					rule: "no-debugger",
+					message: "MSG-PROJECT-NO-DEBUGGER",
+					source: "project-scan",
+				},
+			],
+		});
+
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]),
+		};
+
+		const result = await run(
+			makeTool(tmpDir, {}, lspService),
+			{ mode: "full", refreshRunners: "cached" },
+			tmpDir,
+		);
+		const text = String(result.content[0].text);
+		expect(text).toContain("MSG-PROJECT-NO-DEBUGGER");
+		expect(text).not.toContain("MSG-PROJECT-NO-EVAL");
+	});
+
+	it("details.projectDiagnostics/projectDiagnosticsDelta counts reflect the post-policy set", async () => {
+		// The structured `details` counts are computed from `projectSnapshot`/
+		// `projectDelta` BEFORE the merge into `summaries` — they must already
+		// be post-policy, or `details` disagrees with both the rendered text
+		// and totalWarnings/totalErrors.
+		fs.writeFileSync(
+			path.join(tmpDir, ".pi-lens.json"),
+			JSON.stringify({
+				rules: { "no-eval": { disable: ["no-eval"] } },
+			}),
+		);
+		const filePath = path.join(tmpDir, "src/foo.ts");
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, "// empty file\n");
+
+		projectDiagnosticsMocks.loadProjectDiagnosticsSnapshot.mockReturnValue({
+			version: 1,
+			cwd: tmpDir,
+			tier: "cheap",
+			scannedAt: "2026-01-01T00:00:00.000Z",
+			filesScanned: 1,
+			runners: ["tree-sitter"],
+			diagnostics: [
+				{
+					filePath,
+					line: 5,
+					severity: "warning",
+					semantic: "warning",
+					tool: "tree-sitter",
+					runner: "tree-sitter",
+					rule: "no-eval",
+					message: "MSG-SNAPSHOT-NO-EVAL",
+					source: "project-scan",
+				},
+				{
+					filePath,
+					line: 6,
+					severity: "warning",
+					semantic: "warning",
+					tool: "tree-sitter",
+					runner: "tree-sitter",
+					rule: "no-debugger",
+					message: "MSG-SNAPSHOT-NO-DEBUGGER",
+					source: "project-scan",
+				},
+			],
+		});
+		projectDiagnosticsMocks.loadProjectDiagnosticsDeltaReport.mockReturnValue({
+			version: 1,
+			cwd: tmpDir,
+			generatedAt: "2026-01-01T00:00:00.000Z",
+			sessionId: "s1",
+			turnIndex: 1,
+			diagnostics: [
+				{
+					filePath,
+					line: 7,
+					severity: "warning",
+					semantic: "warning",
+					tool: "tree-sitter",
+					runner: "tree-sitter",
+					rule: "no-eval",
+					message: "MSG-DELTA-NO-EVAL",
+					source: "project-scan",
+				},
+				{
+					filePath,
+					line: 8,
+					severity: "warning",
+					semantic: "warning",
+					tool: "tree-sitter",
+					runner: "tree-sitter",
+					rule: "no-debugger",
+					message: "MSG-DELTA-NO-DEBUGGER",
+					source: "project-scan",
+				},
+			],
+			sources: ["tree-sitter"],
+		});
+
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]),
+		};
+
+		const result = await run(
+			makeTool(tmpDir, {}, lspService),
+			{ mode: "full", refreshRunners: "cached" },
+			tmpDir,
+		);
+		const text = String(result.content[0].text);
+		const details = result.details as {
+			projectDiagnostics?: { diagnostics: number };
+			projectDiagnosticsDelta?: { diagnostics: number };
+		};
+		expect(details.projectDiagnostics?.diagnostics).toBe(1);
+		expect(details.projectDiagnosticsDelta?.diagnostics).toBe(1);
+		expect(text).not.toContain("MSG-SNAPSHOT-NO-EVAL");
+		expect(text).not.toContain("MSG-DELTA-NO-EVAL");
+	});
+});

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -18,9 +18,10 @@ import {
 	applyDispositions,
 	applyWeakDispositions,
 	getDisposition,
+	type DispositionCandidate,
 } from "../clients/diagnostic-dispositions.js";
 import { applyInlineSuppressions } from "../clients/dispatch/inline-suppressions.js";
-import { normalizeRuleForDedup } from "../clients/dispatch/rule-id-normalize.js";
+import { normalizeRuleId } from "../clients/dispatch/rule-id-normalize.js";
 import { applyRulePolicy, rulePolicyMapFromConfig } from "../clients/dispatch/rule-policy.js";
 import { loadPiLensProjectConfig } from "../clients/project-lens-config.js";
 import { compactRenderResult } from "./render-compact.js";
@@ -439,11 +440,12 @@ function filterDeltaReportDispositions(
 }
 
 /**
- * Cache the load rule-policy map from a project's `.pi-lens.json` — same
- * source the per-edit dispatch path uses, so a project's policy applies
- * consistently across every output surface. Filtered to entries that actually
- * have a `disable`/`select` list (thresholds are handled elsewhere), so the
- * hot path returns undefined for the common case and stays cheap.
+ * Load the rule-policy map from a project's `.pi-lens.json` — same source the
+ * per-edit dispatch path uses, so a project's policy applies consistently
+ * across every output surface. `loadPiLensProjectConfig` is mtime-cached, and
+ * the map is filtered to entries that actually have a `disable`/`select` list
+ * (thresholds are handled elsewhere), so the common case returns undefined and
+ * the filter step is skipped outright.
  */
 function loadProjectRulePolicyMap(cwd: string) {
 	return rulePolicyMapFromConfig(loadPiLensProjectConfig(cwd).rules);
@@ -485,26 +487,21 @@ function formatDeltaMode(
 	// the weak disposition filter (suppress/defer) here so a mark converges
 	// immediately, not only on the next edit. Weak-anchored → zero file I/O, so
 	// this stays "instant" (see applyWeakDispositions).
-	const actionableFiles = (actionable?.files ?? [])
-		.filter((file) => includeFile(file.filePath))
-		.map((file) => ({
-			filePath: file.filePath,
-			warnings: applyRulePolicy(
-				applyWeakDispositions(file.warnings ?? [], cwd, file.filePath),
-				policyMap,
-			),
-		}))
-		.filter((file) => file.warnings.length > 0);
-	const qualityFiles = (quality?.files ?? [])
-		.filter((file) => includeFile(file.filePath))
-		.map((file) => ({
-			filePath: file.filePath,
-			warnings: applyRulePolicy(
-				applyWeakDispositions(file.warnings ?? [], cwd, file.filePath),
-				policyMap,
-			),
-		}))
-		.filter((file) => file.warnings.length > 0);
+	const visibleWarningFiles = <W extends DispositionCandidate>(
+		files: Array<{ filePath: string; warnings?: W[] }> | undefined,
+	) =>
+		(files ?? [])
+			.filter((file) => includeFile(file.filePath))
+			.map((file) => ({
+				filePath: file.filePath,
+				warnings: applyRulePolicy(
+					applyWeakDispositions(file.warnings ?? [], cwd, file.filePath),
+					policyMap,
+				),
+			}))
+			.filter((file) => file.warnings.length > 0);
+	const actionableFiles = visibleWarningFiles(actionable?.files);
+	const qualityFiles = visibleWarningFiles(quality?.files);
 
 	const lines: string[] = [];
 
@@ -844,14 +841,13 @@ function projectDiagnosticToWidget(
 // LSP sweep and the napi scan don't double-report the same line. The
 // normalization itself now lives in `clients/dispatch/rule-id-normalize.ts` so the
 // inline suppression parser, the project rule-policy matcher, and dedup all apply
-// the same canonical form — `normalizeRuleForDedup` is the back-compat alias it
-// re-exports.
+// the same canonical form.
 
 function diagnosticDedupKey(
 	filePath: string,
 	diagnostic: WidgetDiagnostic,
 ): string {
-	const ruleId = normalizeRuleForDedup(diagnostic.rule ?? diagnostic.tool ?? "");
+	const ruleId = normalizeRuleId(diagnostic.rule ?? diagnostic.tool ?? "");
 	return [path.resolve(filePath), diagnostic.line ?? "?", ruleId].join(":");
 }
 

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -20,6 +20,9 @@ import {
 	getDisposition,
 } from "../clients/diagnostic-dispositions.js";
 import { applyInlineSuppressions } from "../clients/dispatch/inline-suppressions.js";
+import { normalizeRuleForDedup } from "../clients/dispatch/rule-id-normalize.js";
+import { applyRulePolicy, rulePolicyMapFromConfig } from "../clients/dispatch/rule-policy.js";
+import { loadPiLensProjectConfig } from "../clients/project-lens-config.js";
 import { compactRenderResult } from "./render-compact.js";
 import { combineAbortSignals } from "../clients/deadline-utils.js";
 import { getProjectIgnoreMatcher } from "../clients/file-utils.js";
@@ -413,11 +416,16 @@ function appendProjectDiagnosticsDeltaLines(
  * delta mode re-serves them. Anchored via `projectDiagnosticToWidget` so the
  * (tool, rule) an agent's mark binds to matches mode=full's own project-runner
  * filter (`applyInlineSuppressionsToSummaries`), keeping the two paths in
- * agreement. Weak-anchored → no file read.
+ * agreement. Weak-anchored → no file read. Also applies the project's
+ * `.pi-lens.json` `rules.<id>.disable`/`select` policy so a project's policy
+ * overlays the same delta report cache; the cache is otherwise insensitive to
+ * a project-config edit (the per-edit path picks it up immediately, but a
+ * non-dispatch tool query would replay the pre-edit state).
  */
 function filterDeltaReportDispositions(
 	report: ProjectDiagnosticsDeltaReport | undefined,
 	cwd: string,
+	policyMap: ReturnType<typeof rulePolicyMapFromConfig>,
 ): ProjectDiagnosticsDeltaReport | undefined {
 	if (!report?.diagnostics.length) return report;
 	const kept = report.diagnostics.filter(
@@ -425,9 +433,20 @@ function filterDeltaReportDispositions(
 			applyWeakDispositions([projectDiagnosticToWidget(d)], cwd, d.filePath)
 				.length === 1,
 	);
-	return kept.length === report.diagnostics.length
-		? report
-		: { ...report, diagnostics: kept };
+	const policyKept = applyRulePolicy(kept, policyMap);
+	if (policyKept.length === report.diagnostics.length) return report;
+	return { ...report, diagnostics: policyKept };
+}
+
+/**
+ * Cache the load rule-policy map from a project's `.pi-lens.json` — same
+ * source the per-edit dispatch path uses, so a project's policy applies
+ * consistently across every output surface. Filtered to entries that actually
+ * have a `disable`/`select` list (thresholds are handled elsewhere), so the
+ * hot path returns undefined for the common case and stays cheap.
+ */
+function loadProjectRulePolicyMap(cwd: string) {
+	return rulePolicyMapFromConfig(loadPiLensProjectConfig(cwd).rules);
 }
 
 function formatDeltaMode(
@@ -446,9 +465,17 @@ function formatDeltaMode(
 	);
 	const actionable = actionableEntry?.data;
 	const quality = qualityEntry?.data;
+	// Project rule policy (`.pi-lens.json` `rules.<id>.disable` /
+	// `rules.<id>.select`) — output-only filtering applied consistently across
+	// every mode. The cache-only delta/all paths would otherwise leak project-
+	// policy oversight (the per-edit dispatch already filters, but the cache
+	// snapshots predate the user's project config edit and would replay
+	// filtered findings). Weak-anchored like weak disposition — zero I/O.
+	const policyMap = loadProjectRulePolicyMap(cwd);
 	const projectDelta = filterDeltaReportDispositions(
 		loadProjectDiagnosticsDeltaReport(cwd),
 		cwd,
+		policyMap,
 	);
 	const ignoreFile = createCurrentIgnoreFilter(cwd);
 	const includeFile = (filePath: string) =>
@@ -462,14 +489,20 @@ function formatDeltaMode(
 		.filter((file) => includeFile(file.filePath))
 		.map((file) => ({
 			filePath: file.filePath,
-			warnings: applyWeakDispositions(file.warnings ?? [], cwd, file.filePath),
+			warnings: applyRulePolicy(
+				applyWeakDispositions(file.warnings ?? [], cwd, file.filePath),
+				policyMap,
+			),
 		}))
 		.filter((file) => file.warnings.length > 0);
 	const qualityFiles = (quality?.files ?? [])
 		.filter((file) => includeFile(file.filePath))
 		.map((file) => ({
 			filePath: file.filePath,
-			warnings: applyWeakDispositions(file.warnings ?? [], cwd, file.filePath),
+			warnings: applyRulePolicy(
+				applyWeakDispositions(file.warnings ?? [], cwd, file.filePath),
+				policyMap,
+			),
 		}))
 		.filter((file) => file.warnings.length > 0);
 
@@ -527,7 +560,10 @@ function formatDeltaMode(
 			.filter((f) => includeFile(f.filePath))
 			.map((f) => ({
 				...f,
-				diagnostics: applyWeakDispositions(f.diagnostics, cwd, f.filePath),
+				diagnostics: applyRulePolicy(
+					applyWeakDispositions(f.diagnostics, cwd, f.filePath),
+					policyMap,
+				),
 			}))
 			.filter((f) => f.diagnostics.length > 0);
 		const carriedIssues = carried.reduce((n, f) => n + f.diagnostics.length, 0);
@@ -717,6 +753,23 @@ function filterProjectDiagnosticsDeltaReport(
 	};
 }
 
+/**
+ * Apply the project rule policy to a project-diagnostics snapshot/delta
+ * report's `diagnostics` list, in place of the collection's shape. Used by
+ * `formatFullMode` so `projectSnapshot.diagnostics.length` /
+ * `projectDelta.diagnostics.length` — which feed both the merged summaries
+ * and the `details.projectDiagnostics`/`details.projectDiagnosticsDelta`
+ * counts — already reflect the policy instead of reporting a pre-policy
+ * count that disagrees with the rendered text.
+ */
+function applyProjectRulePolicy<T extends { diagnostics: ProjectDiagnostic[] }>(
+	value: T | undefined,
+	policyMap: ReturnType<typeof rulePolicyMapFromConfig>,
+): T | undefined {
+	if (!value) return undefined;
+	return { ...value, diagnostics: applyRulePolicy(value.diagnostics, policyMap) };
+}
+
 /** A diagnostic counts as error-like when it blocks or has error severity. */
 function isErrorLike(d: WidgetDiagnostic): boolean {
 	return d.semantic === "blocking" || d.severity === "error";
@@ -788,10 +841,11 @@ function projectDiagnosticToWidget(
 // violation must collapse to one finding in mode=full's merge regardless of which
 // engine produced it. Strip the `ast-grep:` source prefix and the `-js` language
 // suffix (the napi runner already treats `<id>` / `<id>-js` as one rule) so the
-// LSP sweep and the napi scan don't double-report the same line.
-function normalizeRuleForDedup(ruleId: string): string {
-	return ruleId.replace(/^ast-grep:/, "").replace(/-js$/, "");
-}
+// LSP sweep and the napi scan don't double-report the same line. The
+// normalization itself now lives in `clients/dispatch/rule-id-normalize.ts` so the
+// inline suppression parser, the project rule-policy matcher, and dedup all apply
+// the same canonical form — `normalizeRuleForDedup` is the back-compat alias it
+// re-exports.
 
 function diagnosticDedupKey(
 	filePath: string,
@@ -974,10 +1028,17 @@ function mergeDiagnosticsWithWidgetSummaries(
  * a read failure is fail-safe (keep the diagnostics rather than hide a finding on
  * an I/O error). Re-summarizes so the blocking/error/warning counts reflect the
  * suppression.
+ *
+ * Also applies the project's `.pi-lens.json` `rules.<id>.disable`/`select`
+ * policy AFTER inline suppression / disposition so the same set of findings
+ * the per-edit `dispatcher.ts` filters is what's rendered here. The policy
+ * map is passed in (computed once per `formatFullMode` call) rather than
+ * re-deriving per file — see `loadProjectRulePolicyMap(cwd)`.
  */
 async function applyInlineSuppressionsToSummaries(
 	summaries: FileDiagnosticSummary[],
 	cwd: string,
+	policyMap: ReturnType<typeof rulePolicyMapFromConfig>,
 ): Promise<FileDiagnosticSummary[]> {
 	return Promise.all(
 		summaries.map(async (summary) => {
@@ -994,11 +1055,16 @@ async function applyInlineSuppressionsToSummaries(
 			// diagnostics from a fresh LSP sweep/project scan that never went
 			// through that path, so without this a disposed finding reappears here.
 			const kept = applyDispositions(inlineKept, cwd, summary.filePath, content);
+			// Project rule policy (`.pi-lens.json` `rules.<id>.disable`/`select`).
+			// Applied after inline suppression / disposition so the policy's
+			// output-only filtering affects the same surface the per-edit path
+			// produces (no double-counting, no leftover policy-rejected findings).
+			const policyKept = applyRulePolicy(kept, policyMap);
 			// Tag `flagged` diagnostics for the render loop (formatAllMode). Content
 			// is already in hand here (unlike mode=all/delta's cache-only path), so
 			// this is the one place the tag can be computed without adding I/O to
 			// the "instant" modes.
-			for (const d of kept) {
+			for (const d of policyKept) {
 				// flagged is weak-anchored (module doc, diagnostic-dispositions.ts) so
 				// the tag survives incidental edits to the flagged line itself.
 				const { weak } = anchorsForDiagnostic(cwd, summary.filePath, d, content);
@@ -1006,10 +1072,10 @@ async function applyInlineSuppressionsToSummaries(
 					(d as { flagged?: boolean }).flagged = true;
 				}
 			}
-			if (kept.length === summary.diagnostics.length) return summary;
+			if (policyKept.length === summary.diagnostics.length) return summary;
 			return summarizeDiagnostics(
 				summary.filePath,
-				kept,
+				policyKept,
 				summary.hasFinalSnapshot,
 			);
 		}),
@@ -1233,6 +1299,17 @@ async function formatFullMode(
 			// Never let a footer-reconciliation hiccup fail the scan itself.
 		}
 	}
+	// Project rule policy (`.pi-lens.json` `rules.<id>.disable`/`select`) —
+	// loaded once per mode=full call, BEFORE `projectSnapshot`/`projectDelta`
+	// are built below, so `.diagnostics.length` on both (which feeds
+	// `details.projectDiagnostics`/`details.projectDiagnosticsDelta` as well
+	// as the merge into `summaries`) is the POST-policy count. Threaded into
+	// `applyInlineSuppressionsToSummaries` too (idempotent re-apply there) so
+	// the merged summaries honor the same policy the per-edit dispatch path
+	// applies. A project config read failure is treated as "no policy"
+	// (defensive, matches the `applyInlineSuppressionsToSummaries` read-error
+	// discipline).
+	const policyMap = loadProjectRulePolicyMap(cwd);
 	const scannedSnapshot = filterProjectDiagnosticsSnapshot(
 		rawProjectSnapshot,
 		includeFile,
@@ -1250,15 +1327,21 @@ async function formatFullMode(
 	// computed above, in the SAME `Promise.all` as the LSP sweep (#613) — only
 	// when the caller opted into project-runner state (otherwise it's the
 	// `Promise.resolve({...})` stub from `analyzersPromise` above).
-	const projectSnapshot = foldExtraDiagnosticsIntoSnapshot(
-		scannedSnapshot,
-		extracted.diagnostics.filter((d) => includeFile(d.filePath)),
-		extracted.runners,
-		cwd,
+	const projectSnapshot = applyProjectRulePolicy(
+		foldExtraDiagnosticsIntoSnapshot(
+			scannedSnapshot,
+			extracted.diagnostics.filter((d) => includeFile(d.filePath)),
+			extracted.runners,
+			cwd,
+		),
+		policyMap,
 	);
-	const projectDelta = filterProjectDiagnosticsDeltaReport(
-		loadProjectDiagnosticsDeltaReport(cwd),
-		includeFile,
+	const projectDelta = applyProjectRulePolicy(
+		filterProjectDiagnosticsDeltaReport(
+			loadProjectDiagnosticsDeltaReport(cwd),
+			includeFile,
+		),
+		policyMap,
 	);
 	// #630: only the CONFIRMED LSP results contribute diagnostics to the merge
 	// — an unconfirmed (timed-out/errored) file's placeholder `[]` must not be
@@ -1275,6 +1358,7 @@ async function formatFullMode(
 			projectDelta,
 		),
 		cwd,
+		policyMap,
 	);
 	const result = formatAllMode(cwd, severity, summaries, {
 		mode: "full",
@@ -1594,13 +1678,22 @@ function formatAllMode(
 	// post-dispatch lens_diagnostic_mark (suppress/defer) would otherwise still
 	// show here. Re-apply the weak filter (zero I/O) for the cache-only path and
 	// re-summarize so blocking/error/warning counts reflect the drop.
+	// Same project rule policy (`.pi-lens.json` `rules.<id>.disable`/`select`)
+	// overlays both modes: mode=full re-applies it after inline suppression /
+	// disposition (zero I/O), mode=all applies it here on the cache-only path.
+	// The full path's policyMover is loaded below in `applyInlineSuppressionsToSummaries`.
+	const policyMap = loadProjectRulePolicyMap(cwd);
 	const dispositioned = isFullMode
 		? summaries
 		: summaries.map((s) => {
 				const kept = applyWeakDispositions(s.diagnostics ?? [], cwd, s.filePath);
-				return kept.length === (s.diagnostics?.length ?? 0)
-					? s
-					: summarizeDiagnostics(s.filePath, kept, s.hasFinalSnapshot);
+				const policyKept = applyRulePolicy(kept, policyMap);
+				if (
+					policyKept.length === kept.length &&
+					kept.length === (s.diagnostics?.length ?? 0)
+				)
+					return s;
+				return summarizeDiagnostics(s.filePath, policyKept, s.hasFinalSnapshot);
 			});
 	const visibleSummaries = dispositioned.filter((s) => includeFile(s.filePath));
 

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -1043,7 +1043,17 @@ async function applyInlineSuppressionsToSummaries(
 			try {
 				content = await fs.readFile(summary.filePath, "utf8");
 			} catch {
-				return summary; // never hide a finding on a read error
+				// Inline suppression/disposition remains fail-open when the file cannot
+				// be read, but project policy does not depend on content and must still
+				// be applied so a fresh full-mode result cannot bypass `disable`/`select`.
+				const policyKept = applyRulePolicy(summary.diagnostics, policyMap);
+				return policyKept.length === summary.diagnostics.length
+					? summary
+					: summarizeDiagnostics(
+							summary.filePath,
+							policyKept,
+							summary.hasFinalSnapshot,
+						);
 			}
 			const inlineKept = applyInlineSuppressions(summary.diagnostics, content);
 			// #690: same false-positive/suppress/defer disposition filter the


### PR DESCRIPTION
## What

`.pi-lens.json` can now carry `rules.<id>.disable` / `rules.<id>.select` alongside the existing complexity thresholds, so a project can silence or allowlist individual rules without touching every call site. The policy applies on the per-edit dispatch path and across `lens_diagnostics` `mode=delta`, `mode=all`, and `mode=full`, re-summarizing so blocking/error/warning counts reflect the drop.

## Why

Closes #444. Suppression was previously either inline (`# pi-lens-ignore: <rule>`, per-site) or `ignore` path globs, which drop a whole file or dir from every scan. Nothing sat in between, so there was no way to turn off one noisy rule project-wide.

## How

Deviations from the issue sketch worth calling out:

- Schema is `rules.<id>.disable` / `rules.<id>.select`, not top-level `rules.disable` / `rules.only`. This keeps the existing per-rule shape instead of adding a sibling key. The `<id>` key is a grouping label, not a filter scope: every `disable` list unions into one drop list and every `select` list into one allowlist, so `"security": { "disable": ["no-eval"] }` works without `security` being a real rule id. Disable wins over select project-wide, across keys.
- A non-empty `select` anywhere silences every rule not listed, project-wide. It's a big hammer, and it's documented as one.
- Filtering is output-only. The baseline, widget state, and dedup cache still see everything, so editing the policy never corrupts or resets delta tracking.
- Findings that carry no rule id are exempt from `select`. `Diagnostic.id` is a dedup key rather than a rule id, and measuring it against an allowlist would have silently dropped blocking findings like eslint parse errors.
- Rule-id normalization (`ast-grep:<id>`, `<id>-js`) is consolidated in `clients/dispatch/rule-id-normalize.ts` so inline suppression, dedup, and the policy matcher can't drift. That normalization conflates a rule whose real name ends in `-js` with its stem (`prefer-js` with `prefer`); pinned by tests and called out in the docs.
- Dispatch resolves the config from the project root, so a package-local `.pi-lens.json` in a monorepo can't shadow the root's policy. That matches the root `lens_diagnostics` already used.

Lists are parsed tolerantly in `clients/project-lens-config.ts`: a non-array, an empty array, or an all-whitespace array is logged once and dropped, matching the existing threshold-validation warn-once contract. Threshold-only and policy-only entries both work. #533 hygiene is preserved, so typo and unknown-key warnings still surface and foreign LSP namespaces stay silent.

Docs: `docs/settings.md` and `docs/globalconfig.md` gained the schema, precedence, the select warning, and the `-js` caveat.
