### PR TITLE
fix: correct greetings workflow link (closes #1064)

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -24,7 +24,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: >
             Thanks for opening your first issue! Please check
-            [`CONTRIBUTING.md`](../../blob/master/CONTRIBUTING.md) for issue
+            [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) for issue
             templates and guidelines. A maintainer will triage this soon.
           pr_message: >
             Thanks for your first pull request! A maintainer will review it


### PR DESCRIPTION
Fixes the broken CONTRIBUTING.md link emitted by the greetings workflow.

The workflow now points at the pi-lens repository path.

Validation: YAML parse and git diff --check.