### PR TITLE
fix(deps): refresh minimatch security chain (refs #1067)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ast-grep/napi": "^0.45.0",
         "@earendil-works/pi-tui": "^0.83.0",
         "js-yaml": "^5.2.2",
-        "minimatch": "^10.2.5",
+        "minimatch": "^10.2.6",
         "pidusage": "^4.0.1",
         "typebox": "^1.0.0",
         "vscode-jsonrpc": "^9.0.0"
@@ -3516,9 +3516,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@ast-grep/napi": "^0.45.0",
     "@earendil-works/pi-tui": "^0.83.0",
     "js-yaml": "^5.2.2",
-    "minimatch": "^10.2.5",
+    "minimatch": "^10.2.6",
     "pidusage": "^4.0.1",
     "typebox": "^1.0.0",
     "vscode-jsonrpc": "^9.0.0"


### PR DESCRIPTION
Refresh the direct minimatch range and lock the production brace-expansion chain at 5.0.9 to clear GHSA-rgw5-rvv9-x895.

This is a dependency-only follow-up needed by the CI audit on #1067.

Validation:
- npm run check:lockfile
- npm audit --omit=dev --audit-level=high
- npm run lint