### PR TITLE
fix(safe-spawn): make non-Windows SIGTERM->SIGKILL escalation actually fire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,18 +32,50 @@ All notable changes to pi-lens will be documented in this file.
 	call (which never touches `proc.killed`), so the guard was either always-true
 	(unconditional SIGKILL after the window on the common group-kill path) or
 	dead (on the direct-child fallback path) — now tracked via a real `exit`
-	listener set once up front; (2) the `initialize()`-timeout 2s SIGKILL
-	backstop had the identical always-true `!lspProcess.process.killed` guard —
-	switched to `lspProcess.process.exitCode === null`, the process's own
-	observed-exit signal. Other `.killed` reads audited and left as-is because
-	they're liveness/status checks, not escalation-action gates:
-	`isClientAlive`'s `!state.lspProcess.process.killed` (redundant with
-	`isDestroyed`, already set from real exit/close handlers),
-	`checkProcessAlive`'s informational "was killed" health-check string,
-	`launch.ts`'s post-spawn immediate-failure check (`proc.killed` read before
-	any kill was ever sent), `scripts/with-test-lock.mjs`'s `.once`-registered
-	first-forward guard, and `scripts/smoke-tools.mjs`'s read of Node's own
-	`execFileSync` timeout-kill flag on the caught error object.
+	listener set once up front, seeded from the same `exitCode`/`signalCode`
+	pre-check the function's top-of-body early return already uses (a process
+	that was already dead on entry — reachable when `options.processExiting`
+	skips that early return — would otherwise miss its own "exit" event and
+	still draw a redundant group SIGKILL at the escalation window); (2) the
+	`initialize()`-timeout 2s SIGKILL backstop had the identical always-true
+	`!lspProcess.process.killed` guard — switched to `lspProcess.process.exitCode
+	=== null && lspProcess.process.signalCode === null` (both, not `exitCode`
+	alone: a process killed BY a signal — the common case here, since
+	`killProcessTree` above it signals rather than lets the process exit on its
+	own — has `exitCode === null` forever and only `signalCode` set, so
+	`exitCode` alone still re-armed the backstop's kill against an
+	already-dead corpse; harmless in practice since `ChildProcess#kill()` on an
+	exited handle is a swallowed no-op, but not an accurate "still alive"
+	read). Other `.killed` reads audited and left as-is because they're
+	liveness/status checks, not escalation-action gates: `isClientAlive`'s
+	`!state.lspProcess.process.killed` (redundant with `isDestroyed`, already
+	set from real exit/close handlers), `checkProcessAlive`'s informational
+	"was killed" health-check string, `launch.ts`'s post-spawn
+	immediate-failure check (`proc.killed` read before any kill was ever sent),
+	`scripts/with-test-lock.mjs`'s `.once`-registered first-forward guard, and
+	`scripts/smoke-tools.mjs`'s read of Node's own `execFileSync` timeout-kill
+	flag on the caught error object.
+
+	**Adversarial-review follow-up round:** the reviewer ran
+	`kill-process-tree.test.ts` against PRE-fix `client.ts` and it passed 7/7 —
+	the sibling fixes above had ZERO effective test coverage, because the
+	"non-fast shutdown escalates" mock (and the other pre-existing mocks in
+	that file) lacked `once`/never set `killed`, so BOTH the old dead guard and
+	the new fix's guard were vacuously permissive against them (the #1106
+	vacuous-mock class, recurring in mock form: a test's fixture is too weak to
+	distinguish correct from broken behavior, so it passes either way). Fixed
+	by: upgrading that test's mock to be `.once`-capable so it actually
+	exercises the `exited`-flag logic; adding two new `fast`-shutdown tests with
+	a real `.once`-capturing mock proving BOTH directions (exit observed before
+	the 1.5s window → no group SIGKILL; no exit observed → group SIGKILL at the
+	window) — the "no premature SIGKILL" direction fails against the pre-fix
+	`!proc.killed` guard (proven by temporarily reverting the guard and
+	re-running); and adding a real-subprocess POSIX-only test
+	(`tests/clients/lsp/initialize-timeout-backstop.test.ts`, skipped on win32
+	with an explicit reason — killProcessTree's Windows path is
+	`taskkill`-based, not signal-based, and is already covered by the
+	kill-process-tree suite) for the previously fully-untested `initialize()`
+	2s backstop.
 - **mtime-only cache freshness sweep (refs #1105)** — the #1092→#1096 arc bound
 	LSP-diagnostics freshness to real content; this sweep audited the OTHER
 	persisted/derived caches for the same "mtime unchanged ≠ content unchanged"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Dead SIGTERM→SIGKILL escalation guard on non-Windows kills (closes #1114)**
+	— `clients/safe-spawn.ts`'s non-Windows `killTree` branch armed a 1s
+	escalation timer gated on `if (!child.killed) child.kill("SIGKILL")`, but
+	Node sets `ChildProcess#killed = true` the moment `kill()` successfully
+	SENDS a signal — not when the child actually dies — so immediately after
+	the `child.kill("SIGTERM")` one line above, the guard was always false
+	and the SIGKILL escalation could never fire: a SIGTERM-ignoring child on
+	Linux/macOS was never force-killed. Fixed by tracking OBSERVED death via a
+	`closed` flag set synchronously (before any `await`) in the close/error
+	handlers, gating the escalation on `!closed` instead — composes cleanly
+	with the existing #1109/#1113 `escalationTimer` clear-on-close fix rather
+	than switching to the LSP `killProcessTree` analog's unconditional-SIGKILL
+	design, since `safeSpawnAsync` already has a real per-call close/error
+	observation point to hang the flag off of. Proven with a new "child
+	ignores SIGTERM → SIGKILL sent at the 1s mark" test
+	(`tests/clients/safe-spawn-kill-escalation-timer.test.ts`) that fails
+	against the pre-fix guard and passes post-fix; the existing #1109 timer-leak
+	tests (escalation timer cleared when close/error DOES arrive) remain green.
+	**Class sweep** of every `.killed` consumer under `clients/` and `scripts/`
+	found two siblings of the same shape in `clients/lsp/client.ts`'s
+	`killProcessTree`/`createLSPClient` and fixed both in this PR: (1) the
+	`fast`-shutdown escalation timer checked `!proc.killed`, but the primary
+	SIGTERM send there goes through the raw `process.kill(-pid, …)` process-group
+	call (which never touches `proc.killed`), so the guard was either always-true
+	(unconditional SIGKILL after the window on the common group-kill path) or
+	dead (on the direct-child fallback path) — now tracked via a real `exit`
+	listener set once up front; (2) the `initialize()`-timeout 2s SIGKILL
+	backstop had the identical always-true `!lspProcess.process.killed` guard —
+	switched to `lspProcess.process.exitCode === null`, the process's own
+	observed-exit signal. Other `.killed` reads audited and left as-is because
+	they're liveness/status checks, not escalation-action gates:
+	`isClientAlive`'s `!state.lspProcess.process.killed` (redundant with
+	`isDestroyed`, already set from real exit/close handlers),
+	`checkProcessAlive`'s informational "was killed" health-check string,
+	`launch.ts`'s post-spawn immediate-failure check (`proc.killed` read before
+	any kill was ever sent), `scripts/with-test-lock.mjs`'s `.once`-registered
+	first-forward guard, and `scripts/smoke-tools.mjs`'s read of Node's own
+	`execFileSync` timeout-kill flag on the caught error object.
 - **mtime-only cache freshness sweep (refs #1105)** — the #1092→#1096 arc bound
 	LSP-diagnostics freshness to real content; this sweep audited the OTHER
 	persisted/derived caches for the same "mtime unchanged ≠ content unchanged"

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -780,12 +780,27 @@ export async function killProcessTree(
 	};
 
 	try {
+		// #1114: gate the escalation on OBSERVED exit, not `proc.killed`. Node
+		// only sets `proc.killed = true` when `proc.kill()` (the ChildProcess
+		// method) successfully SENDS a signal — never when the process actually
+		// dies, and the primary SIGTERM path above goes through the raw
+		// `process.kill(-pid, …)` process-group call, which never touches
+		// `proc.killed` at all. Checking `!proc.killed` here was therefore
+		// either always-true (unconditional SIGKILL after the window,
+		// regardless of whether the group already died — group-kill path) or
+		// always-false/dead (direct-child fallback path, same shape as the
+		// safe-spawn escalation bug). An `exit` listener set once, up front,
+		// gives a real observed-death signal for both.
+		let exited = false;
+		proc.once?.("exit", () => {
+			exited = true;
+		});
 		if (!killPosixProcessGroup("SIGTERM")) {
 			killDirectChild("SIGTERM");
 		}
 		if (options.fast) {
 			const timer = setTimeout(() => {
-				if (!(proc as { killed?: boolean }).killed) {
+				if (!exited) {
 					logLatency({
 						type: "phase",
 						phase: "lsp_kill_escalation",
@@ -822,7 +837,7 @@ export async function killProcessTree(
 			}, 1500);
 			proc.once?.("exit", onExit);
 		});
-		if (!exitedInTime && !(proc as { killed?: boolean }).killed) {
+		if (!exitedInTime && !exited) {
 			logLatency({
 				type: "phase",
 				phase: "lsp_kill_escalation",
@@ -2200,7 +2215,16 @@ export async function createLSPClient(options: {
 			});
 		});
 		setTimeout(() => {
-			if (!lspProcess.process.killed && process.platform !== "win32") {
+			// #1114: gate on the process's own observed `exitCode`, not
+			// `.killed` — `killProcessTree` above signals the POSIX process
+			// GROUP via the raw `process.kill(-pid, …)`, which never touches
+			// this `ChildProcess` instance's `.killed` flag, so `!…killed`
+			// here was always true and this 2s backstop unconditionally
+			// re-sent SIGKILL even when the group had already exited.
+			if (
+				lspProcess.process.exitCode === null &&
+				process.platform !== "win32"
+			) {
 				lspProcess.process.kill("SIGKILL");
 			}
 		}, 2000);

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -790,8 +790,15 @@ export async function killProcessTree(
 		// regardless of whether the group already died — group-kill path) or
 		// always-false/dead (direct-child fallback path, same shape as the
 		// safe-spawn escalation bug). An `exit` listener set once, up front,
-		// gives a real observed-death signal for both.
-		let exited = false;
+		// gives a real observed-death signal for both. Seeded from the same
+		// `exitCode`/`signalCode` pre-check the top-of-function early return
+		// uses (:689) — that early return is skipped when
+		// `options.processExiting` is set, so a process that was ALREADY dead
+		// on entry can still reach here; without seeding, `exited` would stay
+		// false (the "exit" event already fired before this listener was
+		// attached) and the fast/non-fast branches below would still fire a
+		// redundant group SIGKILL at the escalation window.
+		let exited = proc.exitCode != null || proc.signalCode != null;
 		proc.once?.("exit", () => {
 			exited = true;
 		});
@@ -2215,14 +2222,22 @@ export async function createLSPClient(options: {
 			});
 		});
 		setTimeout(() => {
-			// #1114: gate on the process's own observed `exitCode`, not
-			// `.killed` — `killProcessTree` above signals the POSIX process
+			// #1114: gate on the process's own observed `exitCode`/`signalCode`,
+			// not `.killed` — `killProcessTree` above signals the POSIX process
 			// GROUP via the raw `process.kill(-pid, …)`, which never touches
-			// this `ChildProcess` instance's `.killed` flag, so `!…killed`
-			// here was always true and this 2s backstop unconditionally
-			// re-sent SIGKILL even when the group had already exited.
+			// this `ChildProcess` instance's `.killed` flag, so `!…killed` here
+			// was always true and this 2s backstop unconditionally re-sent
+			// SIGKILL even when the group had already exited. `exitCode` alone
+			// is insufficient too: a process that died FROM a signal (the
+			// common case here — killProcessTree's own SIGTERM/SIGKILL) has
+			// `exitCode === null` forever and only `signalCode` set, so
+			// checking `exitCode === null` alone still re-SIGKILLs that corpse
+			// on the common path (harmless — `kill()` on an already-exited pid
+			// is a swallowed no-op — but not actually "observed still alive").
+			// Require both null to mean "no exit observed by either signal".
 			if (
 				lspProcess.process.exitCode === null &&
+				lspProcess.process.signalCode === null &&
 				process.platform !== "win32"
 			) {
 				lspProcess.process.kill("SIGKILL");

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -459,6 +459,14 @@ export async function safeSpawnAsync(
 		// a ref'd 1s timer that outlives the child it was escalating against
 		// would keep a one-shot `pi --print` process alive for up to 1s.
 		let escalationTimer: ReturnType<typeof setTimeout> | undefined;
+		// #1114: `child.killed` is set by Node the moment `kill()` successfully
+		// SENDS a signal, not when the child actually dies — so gating the
+		// escalation on `!child.killed` right after a successful `SIGTERM` send
+		// is always false and the SIGKILL branch is unreachable. Track observed
+		// death via the close/error handlers instead (set synchronously, before
+		// any `await`, so a timer firing during the close handler's `await
+		// killPromise` still observes the flag correctly).
+		let closed = false;
 		const maxOutputBytes =
 			options?.maxOutputBytes !== undefined &&
 			Number.isFinite(options.maxOutputBytes) &&
@@ -630,7 +638,7 @@ export async function safeSpawnAsync(
 			} else {
 				child.kill("SIGTERM");
 				escalationTimer = setTimeout(() => {
-					if (!child.killed) child.kill("SIGKILL");
+					if (!closed) child.kill("SIGKILL");
 				}, 1000);
 			}
 		};
@@ -702,6 +710,7 @@ export async function safeSpawnAsync(
 
 		// Process completion
 		child.on("close", async (code, signal) => {
+			closed = true;
 			clearTimeout(timeoutId);
 			abortSignal?.removeEventListener("abort", onAbort);
 			if (child.pid) lifetimeState.pids.delete(child.pid);
@@ -751,6 +760,7 @@ export async function safeSpawnAsync(
 		});
 
 		child.on("error", (err) => {
+			closed = true;
 			clearTimeout(timeoutId);
 			abortSignal?.removeEventListener("abort", onAbort);
 			if (escalationTimer) clearTimeout(escalationTimer);

--- a/tests/clients/lsp/initialize-timeout-backstop.test.ts
+++ b/tests/clients/lsp/initialize-timeout-backstop.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #1114 follow-up (adversarial review of PR #1130) — the `initialize()`-timeout
+ * catch block in `createLSPClient` (clients/lsp/client.ts) has a 2s SIGKILL
+ * backstop that was completely untested. Pre-fix it read
+ * `if (!lspProcess.process.killed && ...)`: `killProcessTree` called just above
+ * it only ever signals the POSIX process GROUP via the raw
+ * `process.kill(-pid, …)` syscall (never the `ChildProcess#kill()` method), so
+ * `lspProcess.process.killed` never flips true — the guard was always-true and
+ * the backstop unconditionally re-sent `SIGKILL` to the (by then already-dead)
+ * process handle 2 seconds later, regardless of whether it had already exited.
+ * `ChildProcess#kill()` on an already-exited handle is a harmless no-op (it
+ * doesn't throw), so this never crashed anything — but it IS the same
+ * always-true-guard defect shape as the safe-spawn escalation bug, just with a
+ * harmless rather than a silent-failure consequence.
+ *
+ * This test uses a REAL child process (the fake LSP server fixture, same
+ * pattern as teardown-logging.test.ts) with `FAKE_LSP_IGNORE_INITIALIZE=1` so
+ * the handshake never completes and `initializeTimeoutMs` fires quickly. The
+ * fixture does not ignore SIGTERM, so `killProcessTree`'s real SIGTERM
+ * (routed through the process GROUP, since `launchLSP` detaches the child on
+ * POSIX) terminates it well within both killProcessTree's own 1.5s escalation
+ * window and this backstop's 2s window — giving a real, observable
+ * "already exited by the time the backstop fires" case. Post-fix (gate on
+ * `exitCode`/`signalCode` both being null — the P3-1 precision fix from the
+ * same review round, since a signal-killed process has `exitCode === null`
+ * forever and only `signalCode` set), the backstop must NOT call
+ * `kill("SIGKILL")` again. Pre-fix, it always did.
+ *
+ * POSIX-only (killProcessTree's Windows branch is architecturally different —
+ * `taskkill /F /T`, not signal-based — and is covered by
+ * tests/clients/lsp/kill-process-tree.test.ts instead).
+ */
+
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FAKE_SERVER_PATH = path.join(
+	__dirname,
+	"../../fixtures/fake-lsp-server.mjs",
+);
+
+const describeOrSkip = process.platform === "win32" ? describe.skip : describe;
+
+describeOrSkip(
+	"createLSPClient — initialize-timeout 2s SIGKILL backstop (#1114)",
+	() => {
+		it(
+			"does not re-send SIGKILL once killProcessTree's own SIGTERM has already ended the process",
+			async () => {
+				const { createLSPClient } = await import(
+					"../../../clients/lsp/client.js"
+				);
+				const { launchLSP } = await import("../../../clients/lsp/launch.js");
+
+				const proc = await launchLSP(process.execPath, [FAKE_SERVER_PATH], {
+					cwd: process.cwd(),
+					env: { ...process.env, FAKE_LSP_IGNORE_INITIALIZE: "1" },
+				});
+				const killSpy = vi.spyOn(proc.process, "kill");
+
+				await expect(
+					createLSPClient({
+						serverId: "fake-init-hang",
+						process: proc,
+						root: process.cwd(),
+						initializeTimeoutMs: 50,
+					}),
+				).rejects.toThrow();
+
+				// Wait past BOTH killProcessTree's own 1.5s non-fast escalation
+				// window and this backstop's 2s window. The real (non-ignoring)
+				// fake server dies from the initial SIGTERM well under either.
+				await new Promise((resolve) => setTimeout(resolve, 2500));
+
+				expect(
+					proc.process.exitCode !== null || proc.process.signalCode !== null,
+				).toBe(true);
+				// The core assertion: no redundant SIGKILL once death was already
+				// observed. Pre-fix (`!lspProcess.process.killed`), this always
+				// fired regardless.
+				expect(killSpy).not.toHaveBeenCalledWith("SIGKILL");
+			},
+			8_000,
+		);
+	},
+);

--- a/tests/clients/lsp/kill-process-tree.test.ts
+++ b/tests/clients/lsp/kill-process-tree.test.ts
@@ -117,7 +117,19 @@ describe("killProcessTree", () => {
 		});
 
 		it("non-fast shutdown escalates SIGTERM → SIGKILL on the process group", async () => {
-			const proc = { kill: vi.fn(() => true), unref: vi.fn() };
+			// #1114 follow-up: this mock must be `once`-capable so the
+			// escalation logic's real gate (an observed "exit" event, not the
+			// unreachable `proc.killed` send-flag) is actually exercised —
+			// without `.once`, `proc.once?.(...)` optional-chains to a no-op
+			// and the "exited" flag can never be set from true code changes,
+			// making the assertions below pass vacuously regardless of
+			// whether the escalation logic is correct.
+			const proc = {
+				kill: vi.fn(() => true),
+				unref: vi.fn(),
+				once: vi.fn(),
+				off: vi.fn(),
+			};
 			const done = killProcessTree(proc, 4242, {});
 
 			expect(processKillSpy).toHaveBeenCalledWith(-4242, "SIGTERM");
@@ -127,6 +139,55 @@ describe("killProcessTree", () => {
 			await done;
 
 			expect(processKillSpy).toHaveBeenCalledWith(-4242, "SIGKILL");
+		});
+
+		// #1114 follow-up (adversarial review of PR #1130): the pre-existing
+		// tests above use mocks that lack `.once`/never set `.killed`, so both
+		// the pre-fix `!proc.killed` guard AND the post-fix `!exited` guard
+		// were vacuously permissive there — neither test could actually catch
+		// a regression in the escalation logic. These two tests use an
+		// `.once`-capable mock that captures the real "exit" listener the fix
+		// registers, and assert BOTH directions of the `fast`-shutdown
+		// escalation timer (client.ts's `killProcessTree`, `options.fast`
+		// branch): no premature SIGKILL when the process is observed to exit
+		// within the window, and a real SIGKILL when it isn't.
+		it("fast shutdown SIGKILLs the process group when no exit is observed by the 1.5s window", async () => {
+			const proc = {
+				kill: vi.fn(() => true),
+				unref: vi.fn(),
+				once: vi.fn(),
+				off: vi.fn(),
+			};
+			await killProcessTree(proc, 4242, { fast: true });
+
+			expect(processKillSpy).toHaveBeenCalledWith(-4242, "SIGTERM");
+			expect(processKillSpy).not.toHaveBeenCalledWith(-4242, "SIGKILL");
+
+			await vi.advanceTimersByTimeAsync(1500);
+
+			expect(processKillSpy).toHaveBeenCalledWith(-4242, "SIGKILL");
+		});
+
+		it("fast shutdown skips the group SIGKILL when the process's exit is observed before the 1.5s window", async () => {
+			let exitListener: (() => void) | undefined;
+			const proc = {
+				kill: vi.fn(() => true),
+				unref: vi.fn(),
+				once: vi.fn((event: string, listener: () => void) => {
+					if (event === "exit") exitListener = listener;
+				}),
+				off: vi.fn(),
+			};
+			await killProcessTree(proc, 4242, { fast: true });
+
+			expect(processKillSpy).toHaveBeenCalledWith(-4242, "SIGTERM");
+			expect(exitListener).toBeDefined();
+
+			// The process dies well inside the escalation window.
+			exitListener?.();
+			await vi.advanceTimersByTimeAsync(1500);
+
+			expect(processKillSpy).not.toHaveBeenCalledWith(-4242, "SIGKILL");
 		});
 
 		it("resolves on the process's exit event without waiting out the escalation window", async () => {

--- a/tests/clients/safe-spawn-kill-escalation-timer.test.ts
+++ b/tests/clients/safe-spawn-kill-escalation-timer.test.ts
@@ -183,4 +183,45 @@ describe("safeSpawnAsync — non-Windows kill escalation timer cleanup (#1109)",
 		expect(result.error).toBeInstanceOf(Error);
 		expect(clearedHandles.has(escalationHandle)).toBe(true);
 	});
+
+	// #1114: the escalation callback itself was dead code — it checked
+	// `!child.killed`, but Node sets `child.killed = true` the moment
+	// `kill()` SENDS a signal (not when the child actually dies), so
+	// immediately after the `child.kill("SIGTERM")` one line above, the
+	// guard is always false and `child.kill("SIGKILL")` can never run. This
+	// is the "escalation fires" case the timer-cleanup tests above don't
+	// cover: they only ever emit "close"/"error" before the 1s mark, so the
+	// callback's *body* never executes in those tests. Here the child
+	// ignores SIGTERM outright (no close/error emitted at all) and we
+	// advance the fake clock past 1000ms — pre-fix this assertion fails
+	// because SIGKILL is never sent; post-fix (`!closed` gating, closed only
+	// flips true from an observed close/error) it fires as designed.
+	it("escalates SIGTERM to SIGKILL at the 1s mark when the child ignores SIGTERM (#1114)", async () => {
+		const child = makeFakeChild();
+		spawnMock.mockReturnValue(child);
+
+		const controller = new AbortController();
+		const resultPromise = safeSpawnAsync("fake-cmd", [], {
+			signal: controller.signal,
+			timeout: 30_000,
+		});
+		controller.abort();
+
+		// killTree's non-Windows branch runs synchronously off the abort
+		// listener: SIGTERM is sent and the 1s escalation timer is armed.
+		expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+		expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
+
+		// The child never emits "close" or "error" — it ignores SIGTERM.
+		// Advancing past the 1s escalation window must send SIGKILL.
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+
+		// Let the child actually die now so the pending promise settles and
+		// the test can complete cleanly.
+		child.killed = true;
+		child.emit("close", null, "SIGKILL");
+		const result = await resultPromise;
+		expect(result.failure).toBe("aborted");
+	});
 });

--- a/tests/fixtures/fake-lsp-server.mjs
+++ b/tests/fixtures/fake-lsp-server.mjs
@@ -51,8 +51,12 @@ function handle(raw) {
 		return;
 	}
 
-	// Initialize handshake
+	// Initialize handshake. FAKE_LSP_IGNORE_INITIALIZE simulates a hung server
+	// that never completes the handshake, so createLSPClient's
+	// initializeTimeoutMs/withTimeout fires and exercises the initialize-
+	// timeout kill + 2s SIGKILL-backstop path (#1114).
 	if (data.method === "initialize") {
+		if (process.env.FAKE_LSP_IGNORE_INITIALIZE === "1") return;
 		send({
 			jsonrpc: "2.0",
 			id: data.id,


### PR DESCRIPTION
## Summary

`clients/safe-spawn.ts`'s non-Windows `killTree` branch armed a 1s SIGTERM→SIGKILL escalation timer gated on `if (!child.killed) child.kill("SIGKILL")`. Node sets `ChildProcess#killed = true` the moment `kill()` successfully **sends** a signal — not when the child actually dies — so immediately after the `child.kill("SIGTERM")` one line above, the guard was always false and the SIGKILL escalation could never fire: a SIGTERM-ignoring child on Linux/macOS was never force-killed.

Closes #1114

## Type of change

- [x] Bug fix

## Area

- [x] area:lsp
- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (regression test for the bug, proven fail-then-pass; existing #1109 leak tests remain green)
- [x] `npm run lint` passes (tsc --project tsconfig.json — clean)
- [ ] `npm test` — **not run locally in full** (memory-tight dev machine; established #1122 precedent). Ran targeted suites locally instead (all green, see below) and am relying on CI for the full suite.
- [x] `npm run build:dist`-equivalent (`npm run build`, `tsc --project tsconfig.build.json`) succeeds
- [x] `package-lock.json` unchanged (no dep changes)
- [ ] `AGENTS.md` — no behavior/convention/invariant documented there changed; not updated
- [x] `CHANGELOG.md` has a `## [Unreleased]` entry for this fix
- [x] Commit subject includes `(closes #1114)`

## What changed and why

### Fix choice + rationale

Two directions were offered in the issue: (a) track a `closed`/`exited` flag from the close/exit handler and escalate `if (!closed)`, or (b) follow `killProcessTree`'s unconditional-SIGKILL-after-window design.

Chose **(a)** for `safeSpawnAsync`: it already has a single, well-defined per-call close/error observation point (the `child.on("close", ...)` / `child.on("error", ...)` handlers that PR #1113 already touched to clear `escalationTimer`), so a `closed` flag set synchronously — **before** any `await` — at the top of those handlers composes directly with that existing cleanup instead of introducing a second, unconditional-kill code path. The flag is set before the close handler's `await killPromise`, so even a timer callback that races the close handler's async gap still observes the correct value (JS is single-threaded; the flag is set on the very first synchronous tick of the handler).

`killProcessTree`'s unconditional-SIGKILL design (option b) remains the right shape for its own use case (no persistent per-call handler structure to hang a flag off outside the function itself), so it wasn't ported wholesale — but the sweep below found it had the *identical bug*, just expressed differently, and fixed it in place with the same "gate on observed death" principle rather than switching to a different design.

### Required test — fail-then-pass proof

Added to `tests/clients/safe-spawn-kill-escalation-timer.test.ts`:

> "escalates SIGTERM to SIGKILL at the 1s mark when the child ignores SIGTERM (#1114)"

Child never emits `close`/`error` (ignores SIGTERM); fake-timer-advance past the 1s mark must trigger `child.kill("SIGKILL")`.

- **Pre-fix** (`if (!child.killed) ...`): `AssertionError: expected "vi.fn()" to be called with arguments: [ 'SIGKILL' ]` — proves the guard was dead.
- **Post-fix** (`if (!closed) ...`): passes, along with the 2 pre-existing #1109 escalation-timer-cleanup tests (escalation timer cleared when close/error DOES arrive) — no regression on that leak fix.

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

### Class sweep

Grepped every `.killed` consumer under `clients/` and `scripts/`. Two siblings of the exact same shape ("escalation action gated on a flag that can never be meaningfully true at fire time") found and fixed in `clients/lsp/client.ts`:

1. **`killProcessTree`'s `fast`-shutdown escalation timer** (`if (!(proc as {killed?}).killed) ...` before a 1.5s SIGKILL): the primary SIGTERM send goes through the raw `process.kill(-pid, …)` process-group call, which never touches `proc.killed` at all — so this guard was either always-true (unconditional SIGKILL after the window, even when the group had already died — the common process-group-kill path) or dead (the direct-child fallback path only, same shape as the safe-spawn bug). Fixed with a real `proc.once("exit", ...)` listener registered once, up front, tracked via an `exited` flag — also reused to replace the redundant/secondary `.killed` check in the neighboring non-fast escalation branch (which was already correctly gated by a real `exitedInTime` signal, so not itself broken, just now consistent).
2. **`createLSPClient`'s `initialize()`-timeout 2s SIGKILL backstop** (`if (!lspProcess.process.killed && ...)`): same always-true shape, since `killProcessTree` above it also only ever signals via `process.kill(-pid, …)`. Switched to `lspProcess.process.exitCode === null`, the process's own real observed-exit signal (no listener needed — `exitCode` is a `ChildProcess` field Node maintains natively).

Audited and left as-is (liveness/status reads, not escalation-action gates, so the same-shape bug doesn't apply):

- `isClientAlive`'s `!state.lspProcess.process.killed` — redundant with `isDestroyed`, which is already set from real exit/close handlers elsewhere.
- `checkProcessAlive`'s informational "was killed" health-check string (not gating an action).
- `clients/lsp/launch.ts`'s post-spawn immediate-failure check (`proc.killed` read synchronously right after spawn, before any `kill()` has ever been called against that process — legitimately `false` at that point).
- `scripts/with-test-lock.mjs`'s `!child.killed` guard inside a `.once`-registered SIGINT/SIGTERM forwarder — this is the *first* kill call in that flow (no prior `child.kill()`), so the read is accurate, not an escalation-after-send check.
- `scripts/smoke-tools.mjs`'s `err?.killed === true` — reading Node's own `execFileSync` timeout-kill flag off a caught error object, informational only.

### Verification

- `npm run build` (tsc --project tsconfig.build.json) — clean
- `npx tsc --project tsconfig.json --noEmit` (lint) — clean
- Targeted local test runs (all green):
  - `tests/clients/safe-spawn-kill-escalation-timer.test.ts` (incl. new #1114 test) — 3/3
  - `tests/clients/safe-spawn-ambient-signal.test.ts`, `safe-spawn-sync-throw.test.ts`, `safe-spawn-resource-usage.test.ts`, `safe-spawn-windows-command.test.ts` — all pass
  - `tests/clients/lsp/kill-process-tree.test.ts` — all pass (incl. the pre-existing "non-fast shutdown escalates SIGTERM → SIGKILL" test)
  - `tests/clients/lsp/client-internals.test.ts`, `spawn-shutdown-race.test.ts`, `service-shutdown-concurrency.test.ts`, `lifecycle.test.ts`, `teardown-logging.test.ts`, `client-wait-timer-cleanup.test.ts` — 91/91 pass
- Full suite intentionally **not** run locally (memory-tight dev machine, #1122 precedent) — deferring to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)