### PR TITLE
fix(project-intelligence): close recorded micro-gaps from #1106/#1104 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Micro-gap sweep: recorded coverage/observability/doc gaps (refs #1106, refs #1104)**
+	- `session-state-store.ts`'s `loadSessionState` STATE_VERSION reject path
+		(a wrong-version persisted snapshot is ignored, not rehydrated) had no
+		test; `STATE_VERSION` is now exported so the new test can drive the
+		mismatch off the real constant (`STATE_VERSION + 1`) rather than a
+		hardcoded literal (#1116 pattern).
+	- `tests/clients/cache/rule-cache.test.ts`'s deliberate `raw.version = "v2"`
+		schema-mismatch override now pins `expect(CACHE_VERSION).not.toBe("v2")`
+		alongside it (#1082/#1116 pattern), so the assertion can't vacuously pass
+		if `CACHE_VERSION` ever became `"v2"`.
+	- The cascade `neighbor_touch` log entry (`clients/dispatch/integration.ts`)
+		now carries an `inconclusive` boolean in its metadata alongside
+		`bindingState`, so the two independent unconfirmed-touch causes (notify/
+		diagnostics wait lapsed vs. disk-diverged binding, #1093/#1095) are
+		distinguishable from `cascade.log` alone, without cross-referencing
+		`latency.log`.
+	- `tools/lens-diagnostics.ts`'s `includeGenerated` param description now
+		states it only takes effect with `mode=full refreshRunners=cheap/all`
+		(it's silently a no-op under `cached`/`none`, since no project scan runs
+		to apply it to) — a doc-only fix from PR #1115's review.
 - **mtime-only cache freshness sweep (refs #1105)** — the #1092→#1096 arc bound
 	LSP-diagnostics freshness to real content; this sweep audited the OTHER
 	persisted/derived caches for the same "mtime unchanged ≠ content unchanged"

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -563,12 +563,14 @@ function readBoundToCurrentDisk(
  * `rawDiags`, never off a spread/clone (which drops them). See the memo-freeze note
  * at the `getAllDiagnostics` call site.
  */
+function readInconclusive(rawDiags: unknown): boolean {
+	return (rawDiags as { inconclusive?: boolean })?.inconclusive === true;
+}
+
 function isConfirmedTouch(
 	rawDiags: readonly import("../lsp/client.js").LSPDiagnostic[],
 ): boolean {
-	const inconclusive =
-		(rawDiags as { inconclusive?: boolean }).inconclusive === true;
-	return !inconclusive && readBoundToCurrentDisk(rawDiags) !== false;
+	return !readInconclusive(rawDiags) && readBoundToCurrentDisk(rawDiags) !== false;
 }
 
 // #459: the reverse-dependency index is a pure function of the review graph.
@@ -1564,6 +1566,7 @@ export async function computeCascadeForFile(
 				// would make the wipe self-sustain).
 				const confirmed = isConfirmedTouch(rawDiags);
 				const bindingRejected = readBoundToCurrentDisk(rawDiags) === false;
+				const inconclusive = readInconclusive(rawDiags);
 				// #692: `source: "cascade"` no longer overrides `rule` (see the
 				// doc comment on the sibling call above) — dropped rather than
 				// migrated to `scanOrigin` since cascade output never touches
@@ -1605,11 +1608,17 @@ export async function computeCascadeForFile(
 					lspTouched: true,
 					lspServerCount: configuredServerCount,
 					coldSnapshot: isColdSnapshot,
-					// #1095: surface a bound-false (disk-diverged) touch so an unbinding
-					// server is diagnosable through the same channel as inconclusive skips.
-					...(bindingRejected && {
-						metadata: { bindingState: bindingStateLabel(false) },
-					}),
+					// #1104: an unconfirmed touch has two independent, otherwise
+					// indistinguishable causes — `inconclusive` (the notify/diagnostics
+					// wait lapsed its deadline) and bound-false (`bindingState`, #1095 —
+					// diagnostics computed against a diverged disk state). Surface
+					// `inconclusive` unconditionally so cascade.log alone (no
+					// cross-referencing latency.log) tells them apart; `bindingState`
+					// stays conditional since "bound" carries no extra signal.
+					metadata: {
+						inconclusive,
+						...(bindingRejected && { bindingState: bindingStateLabel(false) }),
+					},
 				});
 
 				// #1093/#1095: a completed, CONFIRMED active touch is a confirmed

--- a/clients/session-state-store.ts
+++ b/clients/session-state-store.ts
@@ -17,7 +17,7 @@ import { readJsonCacheAsync } from "./json-cache-read.js";
 import type { PersistedReadGuardState } from "./read-guard.js";
 import type { PersistedWidgetState } from "./widget-state.js";
 
-const STATE_VERSION = 1;
+export const STATE_VERSION = 1;
 
 export interface PersistedSessionState {
 	version: number;

--- a/tests/clients/cache/rule-cache.test.ts
+++ b/tests/clients/cache/rule-cache.test.ts
@@ -252,6 +252,9 @@ describe("RuleCache", () => {
 		expect(fs.existsSync(cacheFile)).toBe(true);
 
 		const raw = JSON.parse(fs.readFileSync(cacheFile, "utf-8"));
+		// Pin (#1082/#1116 pattern): the runtime constant must never coincide with
+		// this deliberate mismatch literal, or this test would vacuously pass.
+		expect(CACHE_VERSION).not.toBe("v2");
 		raw.version = "v2";
 		fs.writeFileSync(cacheFile, JSON.stringify(raw), "utf-8");
 

--- a/tests/clients/cascade-compute.test.ts
+++ b/tests/clients/cascade-compute.test.ts
@@ -28,6 +28,10 @@ const mocks = vi.hoisted(() => ({
 	),
 	formatImpactCascade: vi.fn(),
 	getLSPService: vi.fn(),
+	// #1104: logCascade no-ops under isTestMode(), so the only way to assert on
+	// its call shape (e.g. the neighbor_touch `inconclusive` metadata flag) is to
+	// spy on it directly rather than reading cascade.log.
+	logCascade: vi.fn(),
 }));
 
 vi.mock("../../clients/review-graph/service.js", () => ({
@@ -39,6 +43,12 @@ vi.mock("../../clients/review-graph/service.js", () => ({
 
 vi.mock("../../clients/lsp/index.js", () => ({
 	getLSPService: mocks.getLSPService,
+}));
+
+vi.mock("../../clients/cascade-logger.js", () => ({
+	logCascade: mocks.logCascade,
+	flushCascadeLog: vi.fn().mockResolvedValue(undefined),
+	getCascadeLogPath: vi.fn().mockReturnValue("/tmp/cascade.log"),
 }));
 
 const lspError = (message = "cascade error") => ({
@@ -113,6 +123,7 @@ describe("computeCascadeForFile", () => {
 		});
 		mocks.formatImpactCascade.mockReset().mockReturnValue("impact header");
 		mocks.getLSPService.mockReset();
+		mocks.logCascade.mockReset();
 		const { resetDispatchBaselines } = await import(
 			"../../clients/dispatch/integration.js"
 		);
@@ -1560,6 +1571,16 @@ describe("computeCascadeForFile", () => {
 				const diags = getFileDiagnostics(neighbor);
 				expect(diags).toHaveLength(1);
 				expect(diags?.[0]?.message).toBe("live cross-file error");
+
+				// #1104: the neighbor_touch log entry must carry `inconclusive` so the
+				// two unconfirmed-touch causes (inconclusive wait vs. bound-false disk
+				// divergence) are distinguishable from cascade.log alone.
+				const neighborTouchEntry = mocks.logCascade.mock.calls
+					.map(([entry]) => entry)
+					.find((entry) => entry.phase === "neighbor_touch");
+				expect(neighborTouchEntry?.metadata).toMatchObject({
+					inconclusive: true,
+				});
 			} finally {
 				env.cleanup();
 			}

--- a/tests/clients/session-state-store.test.ts
+++ b/tests/clients/session-state-store.test.ts
@@ -3,15 +3,24 @@
  * widget-state export/import that backs resume rehydration.
  */
 
-import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import {
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getProjectDataDir } from "../../clients/file-utils.js";
 import {
 	dropStaleFiles,
 	loadSessionState,
 	saveSessionState,
 	sessionStartMode,
+	STATE_VERSION,
 } from "../../clients/session-state-store.js";
 import { createReadGuard } from "../../clients/read-guard.js";
 import {
@@ -140,6 +149,30 @@ describe("session-state-store save/load (#190)", () => {
 		const loaded = await loadSessionState(cwd, "forked-session");
 		expect(importWidgetState(loaded?.widget)).toBe(true);
 		expect(getFileDiagnosticSummaries()).toEqual(before);
+	});
+
+	it("rejects and ignores a persisted snapshot whose version does not match STATE_VERSION (#1106)", async () => {
+		seedDiagnostics();
+		await saveSessionState(cwd, "wrong-version-session", exportWidgetState());
+
+		// Sanity: the freshly-saved snapshot loads fine at the current version.
+		const before = await loadSessionState(cwd, "wrong-version-session");
+		expect(before?.version).toBe(STATE_VERSION);
+
+		// Corrupt the on-disk version to a deliberate mismatch (never a hardcoded
+		// literal — #1116 pattern) and confirm the reject path is taken: the
+		// caller sees `undefined`, exactly like a missing/corrupt file.
+		const sessionsDir = join(getProjectDataDir(cwd), "sessions");
+		const [file] = readdirSync(sessionsDir).filter((f) =>
+			f.includes("wrong-version-session"),
+		);
+		const filePath = join(sessionsDir, file);
+		const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+		raw.version = STATE_VERSION + 1;
+		writeFileSync(filePath, JSON.stringify(raw));
+
+		const loaded = await loadSessionState(cwd, "wrong-version-session");
+		expect(loaded).toBeUndefined();
 	});
 
 	it("isolates sessions: one id's state does not leak into another", async () => {

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -268,7 +268,7 @@ export function createLensDiagnosticsTool(
 			includeGenerated: Type.Optional(
 				Type.Boolean({
 					description:
-						"mode=full only: scan WITHOUT the generated/artifact NAME-heuristic filter (lockfiles, gen.ts-style names, generated/ dirs, …). Default false. Use when a scan's 'excluded by generated-name heuristics' notice suggests a real file was skipped.",
+						"mode=full refreshRunners=cheap/all only (no effect with refreshRunners=cached/none, since no project scan runs to apply it to): scan WITHOUT the generated/artifact NAME-heuristic filter (lockfiles, gen.ts-style names, generated/ dirs, …). Default false. Use when a scan's 'excluded by generated-name heuristics' notice suggests a real file was skipped.",
 				}),
 			),
 			severity: Type.Optional(


### PR DESCRIPTION
## Summary

Four small, independently-scoped gaps recorded in prior PR/issue review comments, bundled into one micro-PR:

1. **session-state-store STATE_VERSION reject-path test** (recorded on `gh issue view 1106` post-close comment) — `loadSessionState`'s version-mismatch reject path (`state?.version !== STATE_VERSION`) had no test. Added one that persists valid state, then corrupts the on-disk `version` to `STATE_VERSION + 1` (driven off the exported constant, never a hardcoded literal — the #1116 pattern) and asserts `loadSessionState` returns `undefined`. `STATE_VERSION` is now exported from `clients/session-state-store.ts`.
2. **rule-cache pin** (same #1106 comment) — `tests/clients/cache/rule-cache.test.ts`'s deliberate `raw.version = "v2"` schema-mismatch override lacked the adjacent pin. Added `expect(CACHE_VERSION).not.toBe("v2")` (#1082/#1116 pattern) so the test can't vacuously pass if `CACHE_VERSION` ever became `"v2"`. `CACHE_VERSION` here is `clients/cache/rule-cache.ts`'s own constant — unrelated to `clients/call-graph.ts`'s `CACHE_VERSION` (not touched).
3. **neighbor_touch inconclusive logging** (`gh issue view 1104`, P3-4) — the cascade `neighbor_touch` log recorded `bindingState` but not `inconclusive`, so the two unconfirmed-touch causes (notify/diagnostics wait lapsed vs. disk-diverged binding) were indistinguishable from `cascade.log` alone. Added `inconclusive` to the log metadata in `clients/dispatch/integration.ts` (the flag was already read via `isConfirmedTouch`, factored out into a small `readInconclusive` helper shared with `isConfirmedTouch`). Added a metadata assertion to the existing inconclusive-touch test in `tests/clients/cascade-compute.test.ts` (mocked `clients/cascade-logger.js` since `logCascade` no-ops under `isTestMode()`, so there is no other way to observe the call shape).
4. **lens_diagnostics includeGenerated doc nit** (PR #1115 review comment) — the `includeGenerated` Typebox param in `tools/lens-diagnostics.ts` only takes effect when `refreshRunners` is `cheap`/`all` (silently a no-op under `cached`/`none`); the description string now says so. Description-only change.

## Evidence (fail-then-pass, items 1 and 3)

- **Item 1**: temporarily relaxed the reject-path condition to `if (!state.widget) return undefined;` (dropping the version check) → new test failed (`expected loaded to be undefined` — got the stale-version payload back). Restored the real check → test passes.
- **Item 3**: temporarily reverted the `metadata: { inconclusive, ... }` change back to the pre-fix conditional-only `bindingState` shape → new assertion failed (`expected undefined to match object { inconclusive: true }`). Restored the fix → test passes.

## Test plan

- [x] `npx vitest run tests/clients/session-state-store.test.ts` — 19 passed
- [x] `npx vitest run tests/clients/cache/rule-cache.test.ts` — 5 passed
- [x] `npx vitest run tests/clients/cascade-compute.test.ts` — 33 passed
- [x] `npm run build` (tsc, strict + noUnusedLocals) clean
- [ ] Full suite deferred to CI — this session ran on a memory-tight machine; only the touched test files were run locally, per the repo's documented constraint.

Out of scope (per instructions): did not rename `CACHE_VERSION` in `clients/call-graph.ts` (sibling-owned), and did not touch `safe-spawn.ts`, `symbol-id.ts`, `tree-sitter-client.ts`, or `function-facts.ts`.

refs #1106 (closed — recorded for the record, not reopened), refs #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)