### PR TITLE
fix(project-intelligence): gate cascade fallback-display paths on content binding (refs #1104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Cascade fallback-display paths re-displayed bound-false LSP snapshots (refs #1104)** —
+	#1100 gated the cascade's RECONCILE path (the footer/widget) onto content
+	binding (`boundToCurrentDisk`), but two DEGRADED-fallback DISPLAY paths in
+	`clients/dispatch/integration.ts` still re-read TTL-fresh `getAllDiagnostics()`
+	snapshots without consulting binding at all: the touch-error fallback (a
+	failed active LSP touch falling back to the passive snapshot) and
+	`appendFallbackNeighbors` (the CR-3/A2 degraded-fallback path when no
+	neighbor produced trustworthy LSP data). A bound-false snapshot — diagnostics
+	computed against a DIFFERENT disk state than what's currently on disk, e.g. a
+	pre-fix-edit read — could still reach cascade OUTPUT even though the widget
+	was protected. Both sites now apply the same false/`"unknown"`/true contract
+	#1095/#1100 already established for reconcile: `false` → skip the stale
+	display (logged via the cascade channel with `bindingState`), `"unknown"` →
+	unchanged (the pre-existing fallback contract), `true` → display. HONESTY
+	fix: filtering a display candidate could otherwise make a genuinely degraded
+	cascade look clean, so when every fallback candidate a run considered was
+	binding-rejected and nothing else produced output, the run now carries the
+	same `indeterminate` marker #1023 built for a degraded graph compute (new
+	`CascadeIndeterminateReason: "lsp_binding_rejected"`), so the turn-end
+	advisory still surfaces an honest note instead of silence. The `resultId`
+	pull-diagnostics plumbing that #1104 also tracks remains open — this covers
+	only the cascade display-binding gap (#1100 review P3-1).
 - **`parseSymbolKey` mis-parsed LSP-fallback symbol kinds (refs #1088)** —
 	the canonical-id parser whitelisted only the 7 kinds `buildSymbolId` mints
 	directly, but `addLspFallbackSymbols` mints ids using the much larger

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -1271,6 +1271,15 @@ export async function computeCascadeForFile(
 	const neighbors: CascadeResult["neighbors"] = [];
 	let producedLspData = false;
 	let coldSnapshotPaths: string[] = [];
+	// #1104: did any DEGRADED-fallback display path (touch-error fallback,
+	// appendFallbackNeighbors) withhold a TTL-fresh entry solely because its
+	// content binding was rejected (`boundToCurrentDisk === false` — computed
+	// against a diverged/pre-fix-edit disk state)? Tracked separately from
+	// `producedLspData` so the HONESTY check below can tell "genuinely nothing to
+	// show" apart from "something existed but was untrustworthy and was hidden" —
+	// the latter must not collapse into a clean-looking result (#1104 honesty
+	// rule, same doctrine as #1023's graph-degraded indeterminate marker).
+	let fallbackBindingRejected = false;
 
 	if (sortedNeighbors.length > 0) {
 		const snapshotPaths = sortedNeighbors.filter(shouldReadCascadeFromSnapshot);
@@ -1677,19 +1686,41 @@ export async function computeCascadeForFile(
 				dbg?.(
 					`cascade neighbor touch error for ${neighborPath}: ${result.reason}`,
 				);
+				const entry = allDiags.get(normalizeMapKey(neighborPath));
+				const ttlFresh =
+					entry != null && Date.now() - entry.ts < CASCADE_TTL_MS;
+				// #1104: consult binding before trusting a TTL-fresh fallback snapshot —
+				// MATCH #1100/#1095 semantics (false → skip, "unknown" → keep the
+				// pre-#1104 TTL-only behavior, true → use). Without this, a failed
+				// active touch could still re-display a bound-false (pre-fix-edit)
+				// snapshot even though the reconcile path (#1100) already refuses to
+				// trust it for the widget — the widget is protected but the display
+				// wasn't. Reading `.binding` triggers the lazy disk verify — done ONLY
+				// when TTL-fresh, same discipline as the snapshot-tier gate above.
+				const boundToDisk: BoundToCurrentDisk | undefined = ttlFresh
+					? readBoundToCurrentDisk(entry)
+					: undefined;
+				const bindingRejected = boundToDisk === false;
+				if (bindingRejected) fallbackBindingRejected = true;
 				logCascade({
 					phase: "neighbor_fallback",
 					filePath,
 					neighborFile: neighborPath,
 					fallbackUsed: true,
 					error: String(result.reason),
+					// #1104: distinguish a binding-rejected fallback (TTL-fresh but the
+					// server's view diverged from disk) from a plain TTL-stale/missing
+					// one — same conditional pattern as the neighbor_touch/neighbor_snapshot
+					// phases above.
+					...(bindingRejected && {
+						metadata: { bindingState: bindingStateLabel(boundToDisk) },
+					}),
 				});
-				const entry = allDiags.get(normalizeMapKey(neighborPath));
 				// #692: `source: "cascade"` dropped (see the doc comment above the
 				// first cascade call site in this file) — no longer affects `rule`
 				// and cascade output never touches persisted widget/dedup state.
 				const diags =
-					entry && Date.now() - entry.ts < CASCADE_TTL_MS
+					ttlFresh && !bindingRejected
 						? convertLspDiagnostics(
 								entry.diags
 									.filter((d) => d.severity === 1)
@@ -1710,7 +1741,14 @@ export async function computeCascadeForFile(
 	// CR-3/A2: degraded fallback when no neighbor produced trustworthy LSP data —
 	// not merely when the graph returned zero neighbors.
 	if (!producedLspData) {
-		appendFallbackNeighbors(neighbors, allDiags, normalizedFileKey, cwd);
+		const bindingRejected = appendFallbackNeighbors(
+			neighbors,
+			allDiags,
+			normalizedFileKey,
+			cwd,
+			filePath,
+		);
+		if (bindingRejected) fallbackBindingRejected = true;
 		if (neighbors.some((n) => n.reason === "fallback")) {
 			logCascade({
 				phase: "neighbor_fallback",
@@ -1729,6 +1767,23 @@ export async function computeCascadeForFile(
 		visibleNeighbors,
 		impact.neighborFiles.length,
 	);
+
+	// #1104 HONESTY: filtering a bound-false display candidate must not turn a
+	// degraded/indeterminate cascade into a clean-looking one (same doctrine as
+	// #1023's graph-degraded marker). If every candidate the degraded-fallback
+	// paths considered this run was binding-rejected and nothing else produced
+	// output, thread the SAME indeterminate marker #1023 built so the turn-end
+	// advisory (clients/runtime-turn.ts) surfaces an honest note instead of
+	// silence — never let a withheld-stale-snapshot run look like a genuine
+	// clean leaf. `!impact.indeterminate` preserves a graph-degraded marker that
+	// already exists (never overwritten).
+	if (!formatted && fallbackBindingRejected && !impact.indeterminate) {
+		impact.indeterminate = {
+			reason: "lsp_binding_rejected",
+			detail:
+				"cascade fallback diagnostics were withheld — stale snapshot content did not match current disk (binding rejected)",
+		};
+	}
 
 	const filesWithErrors = visibleNeighbors.filter(
 		(n) => n.diagnostics.length > 0,
@@ -1840,6 +1895,11 @@ function applyCascadeDeltaBaselines(
 	});
 }
 
+/**
+ * Returns `true` when at least one otherwise-eligible candidate was withheld
+ * because its content binding was rejected (#1104) — the caller folds this
+ * into the run-level `fallbackBindingRejected` flag for the honesty check.
+ */
 function appendFallbackNeighbors(
 	neighbors: CascadeResult["neighbors"],
 	allDiags: Map<
@@ -1848,10 +1908,13 @@ function appendFallbackNeighbors(
 	>,
 	normalizedFileKey: string,
 	cwd: string,
-): void {
+	filePath: string,
+): boolean {
 	const now = Date.now();
 	const seen = new Set(neighbors.map((n) => normalizeMapKey(n.filePath)));
-	for (const [diagPath, { diags, ts }] of allDiags) {
+	let bindingRejected = false;
+	for (const [diagPath, entry] of allDiags) {
+		const { diags, ts } = entry;
 		const diagKey = normalizeMapKey(diagPath);
 		if (diagKey === normalizedFileKey || seen.has(diagKey)) continue;
 		if (primaryFilesThisTurn.has(diagKey)) continue;
@@ -1863,6 +1926,24 @@ function appendFallbackNeighbors(
 		if (isTestRoleCollateral(diagPath)) continue;
 		if (!nodeFs.existsSync(diagPath)) continue;
 		if (now - ts > CASCADE_TTL_MS) continue;
+		// #1104: a TTL-fresh entry is not automatically trustworthy — consult
+		// binding the same way the reconcile path (#1100) and the touch-error
+		// fallback above do. `false` → skip (a stale/pre-fix-edit snapshot whose
+		// server view diverged from current disk); "unknown"/`true` → unchanged
+		// (the pre-#1104 fallback contract). Reading `.binding` triggers the lazy
+		// disk verify — done ONLY when TTL-fresh, per the established discipline.
+		const boundToDisk = readBoundToCurrentDisk(entry);
+		if (boundToDisk === false) {
+			bindingRejected = true;
+			logCascade({
+				phase: "neighbor_fallback",
+				filePath,
+				neighborFile: diagPath,
+				fallbackUsed: false,
+				metadata: { bindingState: bindingStateLabel(false) },
+			});
+			continue;
+		}
 		// #692: `source: "cascade"` dropped — see the doc comment above the
 		// first cascade `convertLspDiagnostics` call site in this file.
 		const errors = convertLspDiagnostics(
@@ -1879,6 +1960,7 @@ function appendFallbackNeighbors(
 		seen.add(diagKey);
 		if (neighbors.length >= MAX_FILES) break;
 	}
+	return bindingRejected;
 }
 
 function shouldReadCascadeFromSnapshot(filePath: string): boolean {

--- a/clients/review-graph/types.ts
+++ b/clients/review-graph/types.ts
@@ -143,7 +143,8 @@ export interface ReviewGraphPersistCoverage {
 export type CascadeIndeterminateReason =
 	| "graph_degraded" // review graph skipped (too_many_files / unsafe_root)
 	| "missing_node" // changed file has no node in the (otherwise-built) graph
-	| "error"; // the deferred compute threw before producing a result
+	| "error" // the deferred compute threw before producing a result
+	| "lsp_binding_rejected"; // #1104: every degraded-fallback display candidate was binding-rejected (stale/pre-fix-edit snapshot) and withheld
 
 export interface CascadeIndeterminate {
 	reason: CascadeIndeterminateReason;

--- a/tests/clients/cascade-compute.test.ts
+++ b/tests/clients/cascade-compute.test.ts
@@ -2005,4 +2005,270 @@ describe("computeCascadeForFile", () => {
 			}
 		});
 	});
+
+	// #1104: the cascade's DEGRADED/FALLBACK display paths (the touch-error
+	// fallback and appendFallbackNeighbors) previously re-read TTL-fresh
+	// `getAllDiagnostics()` snapshots WITHOUT consulting content binding — #1100
+	// gated the RECONCILE (footer/widget) path onto binding, but a bound-false
+	// (pre-fix-edit) snapshot could still reach cascade OUTPUT via these two
+	// tier3-silent corners. Tighten both to the same false/unknown/true contract
+	// #1100/#1095 already established for reconcile, and verify filtering a
+	// display candidate never quietly turns a degraded cascade into a
+	// clean-looking one.
+	describe("fallback-display binding gaps (#1104)", () => {
+		it("touch-error fallback excludes a bound-false TTL-fresh snapshot from cascade DISPLAY output", async () => {
+			const env = setupTestEnvironment("cascade-1104-touch-fallback-");
+			try {
+				const primary = path.join(env.tmpDir, "model.py");
+				const rejectedNeighbor = path.join(env.tmpDir, "stale_api.py");
+				const confirmedNeighbor = path.join(env.tmpDir, "live_api.py");
+				fs.writeFileSync(primary, "class User: pass\n");
+				fs.writeFileSync(rejectedNeighbor, "from model import User\n");
+				fs.writeFileSync(confirmedNeighbor, "from model import User\n");
+				mocks.computeImpactCascade.mockReturnValue(
+					impact(primary, [rejectedNeighbor, confirmedNeighbor]),
+				);
+				mocks.getLSPService.mockReturnValue({
+					// TTL-fresh snapshot for the neighbor whose active touch will fail —
+					// but bound-false (the server's view diverged from current disk, a
+					// pre-fix-edit read).
+					getAllDiagnostics: vi.fn().mockResolvedValue(
+						new Map([
+							[
+								rejectedNeighbor.split(path.sep).join("/"),
+								withBinding(
+									{ diags: [lspError("stale pre-fix error")], ts: Date.now() },
+									false,
+								),
+							],
+						]),
+					),
+					touchFile: vi
+						.fn()
+						.mockImplementation(async (filePath: string) => {
+							if (filePath === rejectedNeighbor) {
+								throw new Error("touch failed");
+							}
+							return [lspError("confirmed live error")];
+						}),
+					getDiagnostics: vi.fn(),
+				});
+
+				const { computeCascadeForFile } = await import(
+					"../../clients/dispatch/integration.js"
+				);
+				const result = await computeCascadeForFile(primary, env.tmpDir, {
+					turnSeq: 1,
+					writeSeq: 1,
+				});
+
+				const rejected = result?.result?.neighbors.find(
+					(n) => n.filePath === rejectedNeighbor,
+				);
+				// The stale/bound-false snapshot must not survive into the fallback
+				// entry's displayed diagnostics.
+				expect(rejected?.diagnostics ?? []).toEqual([]);
+				expect(
+					result?.result?.neighbors.some((n) =>
+						n.diagnostics.some((d) => d.message === "stale pre-fix error"),
+					),
+				).toBe(false);
+				// The genuinely confirmed neighbor's error still reaches output —
+				// proves the fix is a targeted skip, not a blanket suppression.
+				expect(result?.result?.formatted).toContain("confirmed live error");
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("characterization: touch-error fallback with unknown binding still displays the TTL-fresh snapshot exactly as before", async () => {
+			const env = setupTestEnvironment("cascade-1104-touch-fallback-unknown-");
+			try {
+				const primary = path.join(env.tmpDir, "model.py");
+				const neighbor = path.join(env.tmpDir, "api.py");
+				fs.writeFileSync(primary, "class User: pass\n");
+				fs.writeFileSync(neighbor, "from model import User\n");
+				mocks.computeImpactCascade.mockReturnValue(impact(primary, [neighbor]));
+				mocks.getLSPService.mockReturnValue({
+					getAllDiagnostics: vi.fn().mockResolvedValue(
+						new Map([
+							[
+								neighbor.split(path.sep).join("/"),
+								withBinding(
+									{ diags: [lspError("unknown-bound stale error")], ts: Date.now() },
+									"unknown",
+								),
+							],
+						]),
+					),
+					touchFile: vi.fn().mockRejectedValue(new Error("touch failed")),
+					getDiagnostics: vi.fn(),
+				});
+
+				const { computeCascadeForFile } = await import(
+					"../../clients/dispatch/integration.js"
+				);
+				const result = await computeCascadeForFile(primary, env.tmpDir, {
+					turnSeq: 1,
+					writeSeq: 1,
+				});
+
+				expect(
+					result?.result?.neighbors[0]?.diagnostics[0]?.message,
+				).toBe("unknown-bound stale error");
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("appendFallbackNeighbors excludes a bound-false TTL-fresh snapshot from cascade DISPLAY output", async () => {
+			const env = setupTestEnvironment("cascade-1104-append-fallback-");
+			try {
+				const primary = path.join(env.tmpDir, "main.ts");
+				// Unknown extension neighbor keeps producedLspData false (no LSP
+				// server configured), driving the run into appendFallbackNeighbors
+				// exactly like the pre-existing "falls back to passive snapshot" test.
+				const noLspNeighbor = path.join(env.tmpDir, "neighbor.foo");
+				const staleFile = path.join(env.tmpDir, "stale.ts");
+				const liveFile = path.join(env.tmpDir, "live.ts");
+				fs.writeFileSync(primary, "export const x = 1;\n");
+				fs.writeFileSync(noLspNeighbor, "neighbor\n");
+				fs.writeFileSync(staleFile, "const x = 1;\n");
+				fs.writeFileSync(liveFile, "const y = 2;\n");
+				mocks.computeImpactCascade.mockReturnValue(
+					impact(primary, [noLspNeighbor]),
+				);
+				mocks.getLSPService.mockReturnValue({
+					getAllDiagnostics: vi.fn().mockResolvedValue(
+						new Map([
+							[
+								staleFile.split(path.sep).join("/"),
+								withBinding(
+									{ diags: [lspError("stale collateral error")], ts: Date.now() },
+									false,
+								),
+							],
+							[
+								liveFile.split(path.sep).join("/"),
+								{ diags: [lspError("live collateral error")], ts: Date.now() },
+							],
+						]),
+					),
+					touchFile: vi.fn(),
+					getDiagnostics: vi.fn(),
+				});
+
+				const { computeCascadeForFile } = await import(
+					"../../clients/dispatch/integration.js"
+				);
+				const result = await computeCascadeForFile(primary, env.tmpDir, {
+					turnSeq: 1,
+					writeSeq: 1,
+				});
+
+				expect(
+					result?.result?.neighbors.some((n) => n.filePath === staleFile),
+				).toBe(false);
+				expect(result?.result?.formatted).not.toContain(
+					"stale collateral error",
+				);
+				expect(result?.result?.formatted).toContain("live collateral error");
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("characterization: appendFallbackNeighbors with unknown binding still displays the collateral entry exactly as before", async () => {
+			const env = setupTestEnvironment(
+				"cascade-1104-append-fallback-unknown-",
+			);
+			try {
+				const primary = path.join(env.tmpDir, "main.ts");
+				const noLspNeighbor = path.join(env.tmpDir, "neighbor.foo");
+				const fallbackFile = path.join(env.tmpDir, "already-open.ts");
+				fs.writeFileSync(primary, "export const x = 1;\n");
+				fs.writeFileSync(noLspNeighbor, "neighbor\n");
+				fs.writeFileSync(fallbackFile, "const x = 1;\n");
+				mocks.computeImpactCascade.mockReturnValue(
+					impact(primary, [noLspNeighbor]),
+				);
+				mocks.getLSPService.mockReturnValue({
+					getAllDiagnostics: vi.fn().mockResolvedValue(
+						new Map([
+							[
+								fallbackFile.split(path.sep).join("/"),
+								withBinding(
+									{ diags: [lspError("unknown-bound fallback error")], ts: Date.now() },
+									"unknown",
+								),
+							],
+						]),
+					),
+					touchFile: vi.fn(),
+					getDiagnostics: vi.fn(),
+				});
+
+				const { computeCascadeForFile } = await import(
+					"../../clients/dispatch/integration.js"
+				);
+				const result = await computeCascadeForFile(primary, env.tmpDir, {
+					turnSeq: 1,
+					writeSeq: 1,
+				});
+
+				expect(result?.result?.formatted).toContain(
+					"unknown-bound fallback error",
+				);
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("HONESTY: when every appendFallbackNeighbors candidate is binding-rejected, the cascade still renders degraded/indeterminate — never a silent clean", async () => {
+			const env = setupTestEnvironment("cascade-1104-honesty-");
+			try {
+				const primary = path.join(env.tmpDir, "main.ts");
+				const noLspNeighbor = path.join(env.tmpDir, "neighbor.foo");
+				const staleFile = path.join(env.tmpDir, "stale.ts");
+				fs.writeFileSync(primary, "export const x = 1;\n");
+				fs.writeFileSync(noLspNeighbor, "neighbor\n");
+				fs.writeFileSync(staleFile, "const x = 1;\n");
+				mocks.computeImpactCascade.mockReturnValue(
+					impact(primary, [noLspNeighbor]),
+				);
+				mocks.getLSPService.mockReturnValue({
+					getAllDiagnostics: vi.fn().mockResolvedValue(
+						new Map([
+							[
+								staleFile.split(path.sep).join("/"),
+								withBinding(
+									{ diags: [lspError("withheld stale error")], ts: Date.now() },
+									false,
+								),
+							],
+						]),
+					),
+					touchFile: vi.fn(),
+					getDiagnostics: vi.fn(),
+				});
+
+				const { computeCascadeForFile } = await import(
+					"../../clients/dispatch/integration.js"
+				);
+				const result = await computeCascadeForFile(primary, env.tmpDir, {
+					turnSeq: 1,
+					writeSeq: 1,
+				});
+
+				// Not a genuine clean leaf: the withheld candidate must surface an
+				// honest indeterminate advisory (#1023's doctrine, extended by
+				// #1104) instead of silently looking clean/no_neighbors.
+				expect(result?.skipReason).toBe("indeterminate");
+				expect(result?.indeterminate?.reason).toBe("lsp_binding_rejected");
+				expect(result?.result).toBeUndefined();
+			} finally {
+				env.cleanup();
+			}
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Fixes the P3-1 item from #1104's "Also fold in" section (the `resultId` pull-diagnostics main body of #1104 stays open — out of scope here).

#1100 gated the cascade's **reconcile** path (footer/widget) onto diagnostics content binding (`boundToCurrentDisk`, #1095), but two degraded-fallback **display** paths in `clients/dispatch/integration.ts` still re-read TTL-fresh `getAllDiagnostics()` snapshots without consulting binding at all:

- the touch-error fallback (a failed active LSP touch falls back to the passive snapshot)
- `appendFallbackNeighbors` (the CR-3/A2 degraded-fallback path when no neighbor produced trustworthy LSP data)

A bound-false snapshot — diagnostics computed against a *different* disk state than what's currently on disk, e.g. a pre-fix-edit read — could still reach cascade OUTPUT even though the widget was already protected by #1100.

## Changes

- Both display sites now apply the exact `false`/`"unknown"`/`true` contract #1095/#1100 already established for reconcile: `false` → skip the stale display (logged via the cascade channel with `bindingState`, the established pattern), `"unknown"` → unchanged (the pre-existing fallback contract), `true` → display.
- **Honesty fix**: filtering a display candidate must not turn a genuinely degraded cascade into a clean-looking one. Added `CascadeIndeterminateReason: "lsp_binding_rejected"` (`clients/review-graph/types.ts`) — when every fallback candidate a run considered was binding-rejected and nothing else produced output, the run now carries the same `indeterminate` marker #1023 built for a degraded graph compute, so the turn-end advisory (`clients/runtime-turn.ts`) still surfaces an honest note instead of silence.
- CHANGELOG entry under Unreleased (refs #1104, not closes — the issue stays open for the resultId body).

## Blast radius

`appendFallbackNeighbors` is a module-private helper, only called from `computeCascadeForFile` in the same file. `computeCascadeForFile` itself is called from `clients/pipeline.ts` (the per-edit cascade dispatch) and referenced by `clients/mcp/analyze.ts`'s cascade-adjacent commentary — no other call sites. No public API/type surface changed besides the additive `CascadeIndeterminateReason` union member (backward compatible).

## Test plan

- [x] New tests in `tests/clients/cascade-compute.test.ts` (`describe("fallback-display binding gaps (#1104)")`, 5 tests) exercising `computeCascadeForFile` end-to-end:
  - touch-error fallback excludes a bound-false snapshot from display (fail-then-pass verified against pre-fix source)
  - characterization: touch-error fallback with unknown binding is unchanged
  - `appendFallbackNeighbors` excludes a bound-false snapshot from display (fail-then-pass verified against pre-fix source)
  - characterization: `appendFallbackNeighbors` with unknown binding is unchanged
  - HONESTY: when every `appendFallbackNeighbors` candidate is binding-rejected, the run still reports `skipReason: "indeterminate"` / `indeterminate.reason: "lsp_binding_rejected"`, never `"clean"`
- [x] Fail-then-pass confirmed by temporarily reverting `integration.ts` to the pre-fix `HEAD` version, rebuilding, and re-running the 5 new tests: 3 fail (the two exclusion tests + the honesty test), 2 pass (the characterization tests) — exactly as expected. Restored the fix and reran: all 5 pass.
- [x] `npx tsc --noEmit` clean.
- [x] Touched-file + sibling cascade suites green locally: `cascade-compute.test.ts` (38/38), `cascade-turn-merge.test.ts`, `lsp/cascade-tier.test.ts`, `runtime-cascade-defer.test.ts` (73/73 combined).
- [x] Full local suite: 5383 passed, 13 skipped, 1 failed (`tests/clients/sgconfig.test.ts` — a 5s timeout on an unrelated ast-grep sgconfig baseline test, accompanied by a vitest worker-fork crash; unrelated to this diff — this file/area isn't touched by the change, and the change is a self-contained cascade display-path fix). Leaving full-suite confirmation to CI (Linux) per the note in AGENTS.md about dev-machine resource contention; flagging here in case it reproduces there too and needs separate triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)