### PR TITLE
fix(project-intelligence): shape-aware basename in generated-artifacts detection (closes #1161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **`generated-artifacts.ts` used module-default `path.basename` on Windows-shaped paths, under-detecting lockfiles/declarations off native Windows (closes #1161, sibling of #1150/#1152)** —
+	`hasStrongGeneratedArtifactPath` (lockfile match), `hasWeakGeneratedFileNamePattern`
+	(name-pattern match), and `isDeclarationFile` (`.d.ts`/`.d.mts`/`.d.cts` match)
+	all took the module-default `path.basename(filePath)` on shape-committed
+	input. On Linux CI, `path.basename("C:\\proj\\package-lock.json")` finds no
+	POSIX separator and returns the whole string unchanged, so
+	`LOCKFILE_NAMES.has(...)` misses — a Windows-shaped lockfile or declaration
+	path was silently treated as ordinary source. `generated-artifacts.ts` is
+	imported by `file-role.ts`'s `"generated"` branch, so this residual sat
+	within `detectFileRole`'s own call tree even after #1152 fixed the
+	dir-segment/basename split there. Fixed with a shared `basenameForShape`
+	helper that routes through `path.win32.basename` when `isWindowsPath`
+	(exported by #1152) is true, mirroring `file-role.ts`'s fix exactly —
+	shape-conditional, not shape-committed, so native-OS classification is
+	unchanged. The strong directory-segment match (`pathSegments`, which splits
+	on `[\\/]+`) was already shape-safe and untouched. Fail-then-pass regression
+	tests cover a `C:\...`-shaped lockfile and `.d.ts` literal.
 - **Quick-mode background warmup kept a one-shot `pi -p`/`--print` process alive (closes #1154)** —
 	`handleSessionStart` forces **quick mode** for both a real `pi -p`/`--print`
 	one-shot AND an interactive process's first session (to protect keystroke

--- a/clients/generated-artifacts.ts
+++ b/clients/generated-artifacts.ts
@@ -9,6 +9,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { isWindowsPath } from "./path-utils.js";
 
 const DEFAULT_HEADER_BYTES = 4096;
 
@@ -115,12 +116,30 @@ function pathSegments(filePath: string): string[] {
 		.filter(Boolean);
 }
 
+/**
+ * Shape-aware basename: a WINDOWS-SHAPED path (drive letter or UNC prefix,
+ * per `isWindowsPath`) is parsed with `path.win32.basename` regardless of the
+ * running OS, mirroring the `detectFileRole` fix in `file-role.ts` (refs
+ * #1152, #1150, #1161 — defect shape 2: a host-default `path` fn inside a
+ * shape-committed branch follows the *host* OS, so on Linux CI a `C:\...`
+ * path has no POSIX separator and the module-default `basename` returns the
+ * whole string unchanged, missing exact-name lookups like `LOCKFILE_NAMES`).
+ * Native same-OS paths (POSIX on Linux, win32 on Windows) are unaffected —
+ * on win32 this is a no-op since `win32.basename` already equals the module
+ * default there.
+ */
+function basenameForShape(filePath: string): string {
+	return isWindowsPath(filePath)
+		? path.win32.basename(filePath)
+		: path.basename(filePath);
+}
+
 export function isGeneratedArtifactDirectoryName(dirName: string): boolean {
 	return GENERATED_DIR_NAMES.has(dirName.trim().toLowerCase());
 }
 
 export function isDeclarationFile(filePath: string): boolean {
-	const base = path.basename(filePath).toLowerCase();
+	const base = basenameForShape(filePath).toLowerCase();
 	return DECLARATION_FILE_PATTERNS.some((pattern) => pattern.test(base));
 }
 
@@ -147,7 +166,7 @@ function hasStrongGeneratedArtifactPath(filePath: string): boolean {
 		return true;
 	}
 
-	const base = path.basename(filePath);
+	const base = basenameForShape(filePath);
 	if (LOCKFILE_NAMES.has(base.toLowerCase())) return true;
 	return MINIFIED_BUNDLE_FILE_PATTERNS.some((pattern) => pattern.test(base));
 }
@@ -166,7 +185,7 @@ function hasStrongGeneratedArtifactPath(filePath: string): boolean {
  * instead (the escape hatch's evidence checks are structurally dead for it).
  */
 function hasWeakGeneratedFileNamePattern(filePath: string): boolean {
-	const base = path.basename(filePath);
+	const base = basenameForShape(filePath);
 	return GENERATED_FILE_PATTERNS.some((pattern) => pattern.test(base));
 }
 

--- a/tests/clients/generated-artifacts.test.ts
+++ b/tests/clients/generated-artifacts.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+	isDeclarationFile,
+	isGeneratedOrArtifact,
+} from "../../clients/generated-artifacts.js";
+
+describe("generated-artifacts basename shape-coherence (refs #1161, sibling of #1150/#1152)", () => {
+	// Pre-fix, `hasStrongGeneratedArtifactPath`/`hasWeakGeneratedFileNamePattern`
+	// used the module-default `path.basename(filePath)`. On Linux CI that is
+	// POSIX `basename`, which finds no `/` in a `C:\...` path and returns the
+	// whole string unchanged — so `LOCKFILE_NAMES.has(base.toLowerCase())`
+	// misses a Windows-shaped lockfile path entirely. This test is meaningful
+	// on BOTH OSes per the #1024 discipline: it feeds the literal Windows-shaped
+	// string as INPUT (never a normalized/expected key), so on native Windows
+	// it exercises the (unchanged, already-correct) win32 `basename` path, and
+	// on Linux it exercises the new shape-committed `win32.basename` branch
+	// this fix adds. Pre-fix this FAILED on Linux (lockfile under-detected)
+	// while the forward-slash-shaped equivalent already passed.
+	it("detects a Windows-shaped lockfile path regardless of running OS", () => {
+		for (const filePath of [
+			"C:\\proj\\package-lock.json",
+			"C:\\proj\\yarn.lock",
+			"C:\\proj\\pnpm-lock.yaml",
+			"\\\\server\\share\\proj\\package-lock.json",
+		]) {
+			expect(isGeneratedOrArtifact(filePath)).toBe(true);
+		}
+	});
+
+	it("still detects a POSIX-shaped lockfile path (no regression for the common case)", () => {
+		expect(isGeneratedOrArtifact("/home/dev/project/package-lock.json")).toBe(
+			true,
+		);
+	});
+
+	// Same shape-2 defect, this time in `isDeclarationFile` (used by the
+	// `includeDeclarations` opt-in in `classifyGeneratedOrArtifactDetailed`).
+	it("detects a Windows-shaped .d.ts declaration path regardless of running OS", () => {
+		for (const filePath of [
+			"C:\\proj\\src\\types.d.ts",
+			"C:\\proj\\src\\types.d.mts",
+			"C:\\proj\\src\\types.d.cts",
+			"\\\\server\\share\\proj\\types.d.ts",
+		]) {
+			expect(isDeclarationFile(filePath)).toBe(true);
+		}
+	});
+
+	it("still detects a POSIX-shaped .d.ts declaration path (no regression for the common case)", () => {
+		expect(isDeclarationFile("/home/dev/project/src/types.d.ts")).toBe(true);
+	});
+
+	it("does not misclassify a hand-written file with 'gen' in a Windows-shaped path (no over-broad match)", () => {
+		expect(isGeneratedOrArtifact("C:\\proj\\src\\general.ts")).toBe(false);
+	});
+});


### PR DESCRIPTION
## What
Shape-2 fix (sibling of merged #1150/#1152): `clients/generated-artifacts.ts` used module-default `path.basename` on paths that can be Windows-shaped, so on Linux CI a `C:\...`/UNC lockfile or `.d.ts` path had its whole string returned → `LOCKFILE_NAMES`/pattern lookups missed → generated/declaration files under-detected. Since `generated-artifacts.ts` is imported by `file-role.ts`'s "generated" branch, this was a residual inside `detectFileRole`'s own call tree.

## Fix
New `basenameForShape(filePath)` helper: `isWindowsPath(filePath) ? path.win32.basename : path.basename` — shape-conditional, mirroring #1152's `detectFileRole` idiom exactly. Applied at all **3** basename sites (`isDeclarationFile`, `hasStrongGeneratedArtifactPath` lockfile/minified, `hasWeakGeneratedFileNamePattern`). `pathSegments` left unchanged — it splits on `[\/]+` regardless of `path.normalize`, already shape-safe (the strong directory-segment match).

## Tests
`tests/clients/generated-artifacts.test.ts` asserts detection on `C:\...` and `\server\share\...` lockfile + `.d.ts`/`.d.mts`/`.d.cts` literals regardless of running OS, plus POSIX no-regression. Windows-local can't discriminate (`basename===win32.basename`), so fail-then-pass was proven via a `path.posix.basename` simulation of the Linux host default; the fix's explicit `win32.basename` branch makes the result identical on real Linux CI.

Build/lint/changelog green; 48/48 across generated-artifacts + file-role + source-filter suites. `closes #1161`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)