### PR TITLE
fix(path): shape-aware toProjectRelativePath — shape-2 class sweep (closes #1163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **`toProjectRelativePath` never relativized a Windows-shaped path off native Windows (closes #1163, refs #1150/#1152/#1161/#1024)** —
+	shape-2 bug-class sweep of the `path.*`-on-cross-shaped-input hot zone.
+	`clients/path-utils.ts:toProjectRelativePath` used the host-default
+	`path.isAbsolute`/`path.relative` even when the input was Windows-shaped
+	(drive letter or UNC). On Linux CI, `path.isAbsolute("C:\\repo\\src\\x.ts")`
+	is `false` (no POSIX leading slash), so the function short-circuited and
+	returned the whole absolute path instead of the project-relative `src/x.ts`
+	it produces on Windows — a persisted call-graph symbol-key path or graph
+	display path (via `module-report`/`lens-map`'s `toDisplayPath` and
+	`call-graph`'s `formatImpact`) rendered as a full absolute path on Linux
+	(green-locally / wrong-on-CI, the #1024 divergence class). Fixed
+	shape-conditionally (`isWindowsPath(p) ? win32 : path`, the #1152 idiom):
+	a Windows-shaped path is parsed with `win32.*` on ANY OS; native same-OS
+	paths are unchanged. Fail-then-pass regression tests feed `C:\...`/UNC
+	literals as INPUT and assert the relative result on any OS (meaningful on
+	Linux CI). The rest of the swept hot zone
+	(`widget-state`/`file-utils`/`call-graph`/`installer`/`elixir-check`, plus
+	`file-role` #1152 and `resolveNonExisting` #1150 already fixed) was audited
+	and cleared as native-by-design — inputs are real on-disk paths the running
+	OS produced (cwd/project-roots/scanned files, `path.resolve`'d first) or
+	already fold through `normalizeEphemeralMapKey`/`PathKeyedMap`/the
+	regex-based `parseSymbolKey`.
 - **Quick-mode background warmup kept a one-shot `pi -p`/`--print` process alive (closes #1154)** —
 	`handleSessionStart` forces **quick mode** for both a real `pi -p`/`--print`
 	one-shot AND an interactive process's first session (to protect keystroke

--- a/clients/path-utils.ts
+++ b/clients/path-utils.ts
@@ -172,11 +172,27 @@ export function normalizeMapKey(filePath: string): string {
 	return normalizeFilePath(filePath);
 }
 
-/** Human-facing path relative to a project root when the file is inside it. */
+/**
+ * Human-facing path relative to a project root when the file is inside it.
+ *
+ * Parses by path SHAPE, not host OS (refs #1150/#1152, shape-2 class #1163):
+ * a Windows-shaped `filePath` (drive-letter/UNC — e.g. a persisted call-graph
+ * symbol-key path `C:\repo\src\x.ts` rehydrated on a Linux CI run) is split
+ * with `win32.*` regardless of `process.platform`. The host-default
+ * `isAbsolute`/`relative` find no drive-letter anchor in a win32 path on POSIX:
+ * `path.isAbsolute("C:\\repo\\x.ts")` returns FALSE on Linux, short-circuiting
+ * to the raw absolute path instead of ever relativizing it — so a file that IS
+ * under the project root renders as a full absolute path on Linux but the
+ * expected `src/x.ts` on Windows (green-locally / wrong-on-CI, the #1024
+ * divergence class). `win32.*` on a native POSIX path (Windows never sees one;
+ * Linux native paths aren't Windows-shaped) is never selected, so same-OS
+ * native paths are unchanged either way.
+ */
 export function toProjectRelativePath(filePath: string, projectRoot: string): string {
-	if (!path.isAbsolute(filePath)) return filePath.replace(/\\/g, "/");
-	const relative = path.relative(path.resolve(projectRoot), filePath);
-	return relative && !relative.startsWith("..") && !path.isAbsolute(relative)
+	const p = isWindowsPath(filePath) ? win32 : path;
+	if (!p.isAbsolute(filePath)) return filePath.replace(/\\/g, "/");
+	const relative = p.relative(p.resolve(projectRoot), filePath);
+	return relative && !relative.startsWith("..") && !p.isAbsolute(relative)
 		? relative.replace(/\\/g, "/")
 		: filePath.replace(/\\/g, "/");
 }

--- a/tests/clients/path-utils.test.ts
+++ b/tests/clients/path-utils.test.ts
@@ -11,6 +11,7 @@ import {
 	normalizeFilePath,
 	normalizeMapKey,
 	pathToUri,
+	toProjectRelativePath,
 	uriToPath,
 	walkUpDirs,
 } from "../../clients/path-utils.js";
@@ -82,6 +83,45 @@ describe("normalizeFilePath: Windows-shaped path is OS-coherent (refs #1150, cla
 	it("normalizeMapKey (the map-key entry point) yields the same stable key", () => {
 		expect(normalizeMapKey(nonExistent)).toBe(normalizeFilePath(nonExistent));
 		expect(normalizeMapKey(nonExistentBack)).toBe(normalizeMapKey(nonExistent));
+	});
+});
+
+describe("toProjectRelativePath: Windows-shaped path relativizes on ANY OS (refs #1163, class #1150/#1024)", () => {
+	// A drive-letter-shaped filePath UNDER a drive-letter-shaped projectRoot must
+	// relativize by win32 semantics on any OS — the shape decides the parser, not
+	// `process.platform`. PRE-FIX on Linux, the host-default `path.isAbsolute`
+	// returns false for a "C:\..." path (no POSIX leading slash), so the function
+	// short-circuited and returned the whole absolute path instead of the
+	// project-relative one. On Windows the same input relativized correctly, so a
+	// Linux CI run diverged from a green Windows run (the #1024 class). Inputs are
+	// fed as literals; the expectation is derived structurally, not hardcoded to a
+	// normalized key (the #1139/#1150 vacuous-fixture trap).
+	it("backslash form under a backslash root → forward-slashed project-relative path", () => {
+		expect(
+			toProjectRelativePath("C:\\repo\\src\\x.ts", "C:\\repo"),
+		).toBe("src/x.ts");
+	});
+
+	it("forward-slash win32 form under a win32 root → project-relative path", () => {
+		expect(
+			toProjectRelativePath("C:/repo/src/nested/y.ts", "C:/repo"),
+		).toBe("src/nested/y.ts");
+	});
+
+	it("UNC-shaped path under a UNC root relativizes rather than returning the whole path", () => {
+		const rel = toProjectRelativePath(
+			"\\\\host\\share\\proj\\src\\z.ts",
+			"\\\\host\\share\\proj",
+		);
+		expect(rel).toBe("src/z.ts");
+	});
+
+	it("a win32 file OUTSIDE the win32 root keeps the (slash-folded) absolute path", () => {
+		// Not under the root → not relativized; must stay the full path, never a
+		// "../"-prefixed escape.
+		expect(
+			toProjectRelativePath("C:\\other\\a.ts", "C:\\repo"),
+		).toBe("C:/other/a.ts");
 	});
 });
 


### PR DESCRIPTION
## What
Shape-2 class sweep (#1163). Members #1150/#1152/#1161 established the pattern (host-default `path` fn on cross-shaped input → wrong on Linux CI). This audits the full `isWindowsPath` hot zone + persisted-key seams.

## One offender found + fixed
`clients/path-utils.ts:176 toProjectRelativePath` used host-default `path.isAbsolute`/`path.relative`. On Linux, `path.isAbsolute("C:\repo\src\x.ts")` is `false` (no POSIX leading slash), so a file genuinely under the project root short-circuited and returned the whole absolute path instead of `src/x.ts`. Green on Windows, wrong on Linux CI (#1024 class). Reaches display output via `module-report.ts`/`lens-map.ts` `toDisplayPath` and `call-graph.ts` `formatImpact` on persisted/cross-OS symbol-key paths. Fixed shape-conditionally: `const p = isWindowsPath(filePath) ? win32 : path;`.

Regression tests feed `C:\...`/UNC literals as INPUT; fail-then-pass proven via `path.posix` emulation of the Linux host (Windows-local is vacuous since `path === win32`).

## Coverage (the sweep is the deliverable)
Every other hot-zone site classified **native-by-design SAFE** with a recorded reason — see the coverage table in #1163. Files cleared entirely: `file-utils.ts`, `call-graph.ts`, `installer/index.ts`, `elixir-check.ts`, `widget-state.ts`, plus persisted-key seams `review-graph/symbol-id.ts`, `path-keyed-map.ts`. Only `file-role.ts` + `path-utils.ts` branch on `isWindowsPath` (both already fixed via #1152/#1150); `toProjectRelativePath` was the last unfixed member.

No shape-1 (raw path-key) or shape-4 (unref) regressions introduced. `closes #1163`; refs #1150 #1152 #1161 #1024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)