### PR TITLE
fix(session): bound session_start sequence read so a host I/O stall can't block startup (closes #1162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **`session_start_sequence_read` was an unbounded synchronous blocking read on the session_start hot path (closes #1162)** —
+	`readLatestProjectSequence` called `fs.readFileSync` on the project
+	change-log before `session_start_total` returned; normally ~2ms, but under
+	host I/O pressure it had no escape hatch and was observed to balloon to
+	2125ms in production latency.log. A `setTimeout`/`Promise.race` timeout
+	cannot preempt a synchronous read (the thread only returns to the event
+	loop once the OS call returns), so the fix adds an async twin
+	(`readLatestProjectSequenceAsync`, `fs.promises.readFile`) and races it
+	against a 250ms budget (`PI_LENS_SEQUENCE_READ_BUDGET_MS`-overridable) in
+	both the quick-mode and full-mode session_start paths. On a healthy read
+	(the common case) this adds ~zero overhead; on a stalled read, session_start
+	proceeds immediately with the safe cold-start sequence (only gates
+	snapshot freshness, never correctness) while the real read finishes in the
+	background and re-seeds the runtime — skipped for a one-shot `pi --print`
+	process via `isPrintMode()`, screening the #1154/#1153 one-shot
+	referenced-handle retention class. The fallback is never silent: the
+	`session_start_sequence_read` latency line now carries a `timedOut` flag,
+	and a background reseed logs its own
+	`session_start_sequence_read_deferred_reseed` phase. Fail-then-pass
+	regression tests inject a controllable slow read and assert session_start
+	returns within budget, falls back to cold-start with the flag set, and
+	still seeds normally on the healthy path.
 - **Quick-mode background warmup kept a one-shot `pi -p`/`--print` process alive (closes #1154)** —
 	`handleSessionStart` forces **quick mode** for both a real `pi -p`/`--print`
 	one-shot AND an interactive process's first session (to protect keystroke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,20 @@ All notable changes to pi-lens will be documented in this file.
 	`session_start_sequence_read_deferred_reseed` phase. Fail-then-pass
 	regression tests inject a controllable slow read and assert session_start
 	returns within budget, falls back to cold-start with the flag set, and
-	still seeds normally on the healthy path.
+	still seeds normally on the healthy path. Adversarial review (#1168) caught
+	two P3s in this exact stall regime, both fixed in the same PR: (1) the
+	background reseed's `isCurrentSession` guard caught a cross-session move-on
+	but not a SAME-session advancement — an edit landing in the stall window
+	could have its `bumpFileSeq` result clobbered by a late reseed of the
+	pre-edit state; fixed with a `runtime.projectSeq > 0` guard (the cold seed
+	always sets it to exactly 0, so `> 0` at reseed time can only mean an
+	in-window bump happened). (2) The cold sentinel's `projectSeq: 0` was
+	indistinguishable from a project's legitimate first-ever snapshot (also
+	persisted at `seq === 0`), so a timed-out read could hydrate a stale seq-0
+	snapshot as fresh; fixed with a dedicated `UNKNOWN_PROJECT_SEQ` (`-1`)
+	sentinel fed only to the freshness check (never to `runtime.projectSeq`
+	itself, keeping fix (1)'s guard valid). Both have their own fail-then-pass
+	regression tests.
 - **Quick-mode background warmup kept a one-shot `pi -p`/`--print` process alive (closes #1154)** —
 	`handleSessionStart` forces **quick mode** for both a real `pi -p`/`--print`
 	one-shot AND an interactive process's first session (to protect keystroke

--- a/clients/project-changes.ts
+++ b/clients/project-changes.ts
@@ -73,6 +73,33 @@ export function readProjectChanges(cwd: string): ProjectChangeEntry[] {
 	}
 }
 
+/**
+ * Async twin of `readProjectChanges` (#1162). `fs.promises.readFile` — unlike
+ * the sync `readFileSync` above — YIELDS to the event loop, which is what lets
+ * a caller bound it with a `Promise.race` timeout: a `setTimeout` can never
+ * preempt a synchronous blocking read (the thread doesn't return to the event
+ * loop until the OS does), so a bounded read on the session_start hot path
+ * requires the async form. Same parse/error-swallow semantics as the sync
+ * version — a missing/corrupt log is the normal cold-start case, not a
+ * caller-visible error.
+ */
+export async function readProjectChangesAsync(
+	cwd: string,
+): Promise<ProjectChangeEntry[]> {
+	const logPath = getProjectChangeLogPath(cwd);
+	try {
+		const content = await fs.promises.readFile(logPath, "utf-8");
+		return content
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.map(parseChangeLine)
+			.filter((entry): entry is ProjectChangeEntry => Boolean(entry));
+	} catch {
+		return [];
+	}
+}
+
 export function readChangesSince(
 	cwd: string,
 	seq: number,
@@ -197,6 +224,24 @@ export function readLatestProjectSequence(
 	base?: ProjectSequenceBase,
 ): ProjectSequenceIndex {
 	const entries = readProjectChanges(cwd);
+	if (base) {
+		const partial = partialReplay(entries, base);
+		if (partial) return partial;
+	}
+	return fullReplay(entries);
+}
+
+/**
+ * Async twin of `readLatestProjectSequence` (#1162) — same fold logic, but
+ * reads the log via `readProjectChangesAsync` so a caller can bound the wait
+ * with a `Promise.race` timeout (see that function's doc comment for why the
+ * sync form can't be bounded at all).
+ */
+export async function readLatestProjectSequenceAsync(
+	cwd: string,
+	base?: ProjectSequenceBase,
+): Promise<ProjectSequenceIndex> {
+	const entries = await readProjectChangesAsync(cwd);
 	if (base) {
 		const partial = partialReplay(entries, base);
 		if (partial) return partial;

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -35,7 +35,9 @@ import { isAtOrAboveHomeDir } from "./path-utils.js";
 import { isPrintMode } from "./print-mode.js";
 import {
 	type ProjectSequenceBase,
+	type ProjectSequenceIndex,
 	readLatestProjectSequence,
+	readLatestProjectSequenceAsync,
 } from "./project-changes.js";
 import {
 	getProjectSnapshotPath,
@@ -243,6 +245,113 @@ function resolveStartupMode(): StartupMode {
 }
 
 // --- Session-start helpers ---
+
+// #1162: bound the session_start sequence read to this budget. The default
+// mirrors the issue's ~250ms figure; overridable for tests (mirrors the
+// `PI_LENS_WARMUP_DELAY_MS` precedent above) so a regression can use a tiny
+// budget instead of racing a real 250ms wall-clock wait.
+function sequenceReadBudgetMs(): number {
+	const raw = Number(process.env.PI_LENS_SEQUENCE_READ_BUDGET_MS ?? 250);
+	return Number.isFinite(raw) && raw > 0 ? raw : 250;
+}
+
+/**
+ * Bound the sequence read that gates snapshot freshness (#1162). Normally
+ * ~2ms, but the underlying read is a blocking `fs.readFileSync` that can
+ * balloon under host I/O pressure (2125ms observed) with NO escape hatch —
+ * and a `setTimeout`/`Promise.race` timeout can never preempt a *synchronous*
+ * read (the thread only returns to the event loop once the OS call
+ * returns). The fix is to read asynchronously (`readLatestProjectSequenceAsync`,
+ * which uses `fs.promises.readFile` and genuinely yields) so a timeout CAN
+ * win the race.
+ *
+ * On the healthy path (the overwhelming common case) the async read settles
+ * first and this adds ~zero overhead beyond one microtask hop. On a stalled
+ * read, the timeout wins: the caller proceeds immediately with a cold
+ * sequence (`{ projectSeq: 0, fileSeqByPath: empty }` — byte-identical to
+ * what a full replay of a missing/empty log already produces, so this is
+ * exactly the existing cold-start case, not a new code path) while the real
+ * read keeps running in the background. When it resolves, it re-seeds the
+ * runtime so the warm-start optimization is recovered for the NEXT
+ * session_start/turn instead of lost for the rest of the process — unless
+ * the session has since moved on (`runtime.isCurrentSession`) or this is a
+ * one-shot `pi --print` process (`isPrintMode()`), which has no future
+ * session in-process to benefit and where letting background work outlive
+ * settle is exactly the referenced-handle retention class #1154/#1153 just
+ * closed. The timeout timer itself is `.unref()`'d and always cleared on
+ * both race outcomes, so it never holds the process open either.
+ *
+ * Never silent (shape 10): the caller's `session_start_sequence_read`
+ * latency line always carries `timedOut`, and a successful deferred reseed
+ * logs its own `session_start_sequence_read_deferred_reseed` phase.
+ */
+async function readSequenceWithBudget(args: {
+	snapshotRoot: string;
+	base?: ProjectSequenceBase;
+	cwd: string;
+	runtime: RuntimeCoordinator;
+	sessionGeneration: number;
+	dbg: (msg: string) => void;
+}): Promise<{ latestSeq: ProjectSequenceIndex; timedOut: boolean }> {
+	const { snapshotRoot, base, cwd, runtime, sessionGeneration, dbg } = args;
+	const readPromise = readLatestProjectSequenceAsync(snapshotRoot, base);
+
+	let timeoutHandle: NodeJS.Timeout | undefined;
+	const timeoutPromise = new Promise<{ timedOut: true }>((resolve) => {
+		timeoutHandle = setTimeout(
+			() => resolve({ timedOut: true }),
+			sequenceReadBudgetMs(),
+		);
+		timeoutHandle.unref();
+	});
+
+	const raced = await Promise.race([
+		readPromise.then(
+			(latestSeq) => ({ timedOut: false as const, latestSeq }),
+		),
+		timeoutPromise,
+	]);
+	if (timeoutHandle) clearTimeout(timeoutHandle);
+
+	if (!raced.timedOut) {
+		return { latestSeq: raced.latestSeq, timedOut: false };
+	}
+
+	dbg(
+		`session_start: sequence read exceeded ${sequenceReadBudgetMs()}ms budget — falling back to cold-start sequence`,
+	);
+
+	if (!isPrintMode()) {
+		readPromise
+			.then((latestSeq) => {
+				if (!runtime.isCurrentSession(sessionGeneration)) return;
+				const reseedStartedAt = Date.now();
+				runtime.seedProjectSequence?.(
+					latestSeq.projectSeq,
+					latestSeq.fileSeqByPath,
+				);
+				logLatency({
+					type: "phase",
+					phase: "session_start_sequence_read_deferred_reseed",
+					filePath: cwd,
+					startedAt: new Date(reseedStartedAt).toISOString(),
+					durationMs: Date.now() - reseedStartedAt,
+					metadata: { entries: latestSeq.fileSeqByPath.size, deferred: true },
+				});
+				dbg(
+					`session_start: deferred sequence read completed — reseeded projectSeq=${latestSeq.projectSeq} fileSeqEntries=${latestSeq.fileSeqByPath.size}`,
+				);
+			})
+			.catch((err) => {
+				dbg(`session_start: deferred sequence read failed: ${err}`);
+			});
+	}
+
+	return {
+		latestSeq: { projectSeq: 0, fileSeqByPath: new Map<string, number>() },
+		timedOut: true,
+	};
+}
 
 async function igniteWarmFiles(
 	cwd: string,
@@ -1654,17 +1763,21 @@ export async function handleSessionStart(
 		runtime.projectRoot = cwd;
 		const sequenceReadStartedAt = Date.now();
 		const snapshotRoot = resolveSnapshotRoot(cwd);
-		const latestSeq = readLatestProjectSequence(
+		const { latestSeq, timedOut } = await readSequenceWithBudget({
 			snapshotRoot,
-			snapshotSequenceBase(snapshotRoot),
-		);
+			base: snapshotSequenceBase(snapshotRoot),
+			cwd,
+			runtime,
+			sessionGeneration: runtime.sessionGeneration,
+			dbg,
+		});
 		logLatency({
 			type: "phase",
 			phase: "session_start_sequence_read",
 			filePath: cwd,
 			startedAt: new Date(sequenceReadStartedAt).toISOString(),
 			durationMs: Date.now() - sequenceReadStartedAt,
-			metadata: { entries: latestSeq.fileSeqByPath.size },
+			metadata: { entries: latestSeq.fileSeqByPath.size, timedOut },
 		});
 		runtime.seedProjectSequence?.(
 			latestSeq.projectSeq,
@@ -1750,19 +1863,28 @@ export async function handleSessionStart(
 		}
 	}
 
+	// Captured here (not at first use, below) because #1162's bounded read
+	// needs it to gate the deferred reseed against a stale/moved-on session —
+	// it's stable for the rest of this call (no further `resetForSession`
+	// between here and the later uses of the same generation).
+	const sessionGeneration = runtime.sessionGeneration;
 	const sequenceReadStartedAt = Date.now();
 	const snapshotRoot = resolveSnapshotRoot(cwd);
-	const latestSeq = readLatestProjectSequence(
+	const { latestSeq, timedOut } = await readSequenceWithBudget({
 		snapshotRoot,
-		snapshotSequenceBase(snapshotRoot),
-	);
+		base: snapshotSequenceBase(snapshotRoot),
+		cwd,
+		runtime,
+		sessionGeneration,
+		dbg,
+	});
 	logLatency({
 		type: "phase",
 		phase: "session_start_sequence_read",
 		filePath: cwd,
 		startedAt: new Date(sequenceReadStartedAt).toISOString(),
 		durationMs: Date.now() - sequenceReadStartedAt,
-		metadata: { entries: latestSeq.fileSeqByPath.size },
+		metadata: { entries: latestSeq.fileSeqByPath.size, timedOut },
 	});
 	runtime.seedProjectSequence?.(latestSeq.projectSeq, latestSeq.fileSeqByPath);
 	const effectiveSeq = runtime.projectSeq ?? latestSeq.projectSeq;
@@ -2007,7 +2129,8 @@ export async function handleSessionStart(
 		analysisRoot,
 	);
 
-	const sessionGeneration = runtime.sessionGeneration;
+	// `sessionGeneration` was captured earlier (#1162's bounded sequence read
+	// needs it before this point) and is stable across this whole call.
 	if (!allowBootstrapTasks) {
 		dbg("session_start: skipping startup background scans (startup mode)");
 	} else if (!startupScan.canWarmCaches) {

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -255,6 +255,21 @@ function sequenceReadBudgetMs(): number {
 	return Number.isFinite(raw) && raw > 0 ? raw : 250;
 }
 
+// #1162 review follow-up (P3): the sentinel used ONLY for the snapshot
+// freshness check (`isProjectSnapshotFresh`/`isProjectSnapshotMetaStale`,
+// both `=== currentProjectSeq` equality) when a sequence read timed out.
+// Every real `projectSeq`/`snapshot.seq` is >= 0 (both derive from
+// `Math.max(0, ...)`/a monotonic fold starting at 0), so this value can
+// never collide with a legitimate seq — including a project's real
+// first-ever snapshot persisted at `seq === 0`, which the cold-seed's OWN
+// `projectSeq: 0` would otherwise alias. Deliberately kept separate from
+// `runtime.projectSeq` (which a timed-out read still seeds to plain `0`):
+// the reseed-advancement guard on the deferred continuation below needs
+// `runtime.projectSeq` to read exactly 0 immediately after a cold seed so
+// `> 0` reliably means "a bump happened in the stall window", which this
+// sentinel is never fed into.
+const UNKNOWN_PROJECT_SEQ = -1;
+
 /**
  * Bound the sequence read that gates snapshot freshness (#1162). Normally
  * ~2ms, but the underlying read is a blocking `fs.readFileSync` that can
@@ -325,6 +340,28 @@ async function readSequenceWithBudget(args: {
 		readPromise
 			.then((latestSeq) => {
 				if (!runtime.isCurrentSession(sessionGeneration)) return;
+				// #1162 review follow-up (P3): `isCurrentSession` alone catches a
+				// CROSS-session move-on but not a SAME-session advancement in the
+				// stall window. Interleaving: timeout -> cold seed sets
+				// projectSeq=0 -> handler returns -> agent edits file X ->
+				// `bumpFileSeq(X)` advances `_projectSeq`/`_fileSeq[X]` -> this
+				// deferred read completes. Reseeding here would blindly `.clear()`
+				// and repopulate `_fileSeq`/`_fileLastProjectSeq` from the STALE
+				// pre-edit snapshot, erasing the in-window bump for file X (a
+				// transient inconsistency that self-heals into a full sweep per
+				// `seedProjectSequence`'s empty-changed-map invariant — safe, but
+				// worth not doing). The cold seed always sets `projectSeq` to
+				// exactly 0, so `runtime.projectSeq > 0` here can ONLY be true if a
+				// `bumpFileSeq` ran since — i.e. an in-window edit — never a false
+				// positive from a legitimately-empty log (which leaves it at 0, and
+				// the reseed below is then still wanted: it recovers the real,
+				// possibly non-empty, result that arrived too late for the budget).
+				if (runtime.projectSeq > 0) {
+					dbg(
+						"session_start: deferred sequence read completed, but the session already advanced (in-window edit) — skipping reseed to avoid clobbering it",
+					);
+					return;
+				}
 				const reseedStartedAt = Date.now();
 				runtime.seedProjectSequence?.(
 					latestSeq.projectSeq,
@@ -1787,6 +1824,17 @@ export async function handleSessionStart(
 		dbg(
 			`session_start sequence: projectSeq=${effectiveSeq} fileSeqEntries=${latestSeq.fileSeqByPath.size}`,
 		);
+		// #1162 review follow-up (P3): a timed-out read's cold sentinel is
+		// `projectSeq: 0`, which is indistinguishable from a project's real
+		// first-ever snapshot (persisted with `seq === 0` before any change was
+		// logged). Feeding `effectiveSeq` (0) straight into the freshness check
+		// would let that legit seq-0 snapshot match and hydrate as FRESH even
+		// though the on-disk log has since moved past it. Use a value the
+		// freshness check can never match (`snapshot.seq` is always >= 0) ONLY
+		// for this gate when the read timed out — `runtime.projectSeq` itself
+		// stays 0 (untouched), which is what Fix 1's advancement guard above
+		// relies on to detect an in-window bump.
+		const freshnessSeq = timedOut ? UNKNOWN_PROJECT_SEQ : effectiveSeq;
 		const snapshotLoadStartedAt = Date.now();
 		const snapshotPath = getProjectSnapshotPath(snapshotRoot);
 		let snapshotBytes = 0;
@@ -1797,11 +1845,11 @@ export async function handleSessionStart(
 		}
 		const snapshotGate = loadSnapshotBodyUnlessStale({
 			root: snapshotRoot,
-			currentProjectSeq: effectiveSeq,
+			currentProjectSeq: freshnessSeq,
 			dbg,
 		});
 		const snapshot = snapshotGate.snapshot;
-		const snapshotFresh = isProjectSnapshotFresh(snapshot, effectiveSeq);
+		const snapshotFresh = isProjectSnapshotFresh(snapshot, freshnessSeq);
 		logLatency({
 			type: "phase",
 			phase: "session_start_snapshot_load",
@@ -1813,12 +1861,13 @@ export async function handleSessionStart(
 				fresh: snapshotFresh,
 				seq: snapshot?.seq ?? null,
 				...(snapshotGate.skippedStale ? { skippedStale: true } : {}),
+				...(timedOut ? { sequenceUnknown: true } : {}),
 			},
 		});
 		logProjectSnapshotProbe({
 			dbg,
 			root: snapshotRoot,
-			currentProjectSeq: effectiveSeq,
+			currentProjectSeq: freshnessSeq,
 			snapshot,
 		});
 		if (snapshotFresh) {
@@ -1891,6 +1940,13 @@ export async function handleSessionStart(
 	dbg(
 		`session_start sequence: projectSeq=${effectiveSeq} fileSeqEntries=${latestSeq.fileSeqByPath.size}`,
 	);
+	// #1162 review follow-up (P3) — see the matching comment in the quick-mode
+	// path above: a timed-out read's cold sentinel (`projectSeq: 0`) must
+	// never satisfy the freshness check, or a project's real first-ever
+	// snapshot (persisted at `seq === 0`) would hydrate as fresh despite the
+	// on-disk log having moved past it. `runtime.projectSeq` itself is left
+	// at 0, which Fix 1's advancement guard above depends on.
+	const freshnessSeq = timedOut ? UNKNOWN_PROJECT_SEQ : effectiveSeq;
 
 	const snapshotLoadStartedAt = Date.now();
 	const snapshotPath = getProjectSnapshotPath(snapshotRoot);
@@ -1902,11 +1958,11 @@ export async function handleSessionStart(
 	}
 	const snapshotGate = loadSnapshotBodyUnlessStale({
 		root: snapshotRoot,
-		currentProjectSeq: effectiveSeq,
+		currentProjectSeq: freshnessSeq,
 		dbg,
 	});
 	const snapshot = snapshotGate.snapshot;
-	const snapshotFresh = isProjectSnapshotFresh(snapshot, effectiveSeq);
+	const snapshotFresh = isProjectSnapshotFresh(snapshot, freshnessSeq);
 	logLatency({
 		type: "phase",
 		phase: "session_start_snapshot_load",
@@ -1918,12 +1974,13 @@ export async function handleSessionStart(
 			fresh: snapshotFresh,
 			seq: snapshot?.seq ?? null,
 			...(snapshotGate.skippedStale ? { skippedStale: true } : {}),
+			...(timedOut ? { sequenceUnknown: true } : {}),
 		},
 	});
 	logProjectSnapshotProbe({
 		dbg,
 		root: snapshotRoot,
-		currentProjectSeq: effectiveSeq,
+		currentProjectSeq: freshnessSeq,
 		snapshot,
 	});
 	const freshSnapshot = snapshotFresh ? snapshot : null;

--- a/tests/clients/runtime-session-sequence-read-budget.test.ts
+++ b/tests/clients/runtime-session-sequence-read-budget.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Regression tests for #1162 — `session_start_sequence_read` was a
+ * synchronous, UNBOUNDED blocking read (`fs.readFileSync`) on the
+ * session_start critical path. Normally ~2ms, but under host I/O pressure it
+ * balloons with no escape hatch (2125ms observed in production latency.log).
+ *
+ * A `setTimeout`/`Promise.race` timeout can never preempt a *synchronous*
+ * read — the thread only returns to the event loop once the OS call
+ * returns — so the fix switches the read to `fs.promises.readFile`
+ * (`readLatestProjectSequenceAsync`), which genuinely yields, and races it
+ * against a budget (`readSequenceWithBudget` in `clients/runtime-session.ts`,
+ * default 250ms, overridable via `PI_LENS_SEQUENCE_READ_BUDGET_MS` for
+ * tests). On timeout, session_start proceeds immediately with a safe
+ * cold-start sequence (`{ projectSeq: 0, fileSeqByPath: empty }` — this only
+ * gates snapshot freshness, never correctness) and the real read keeps
+ * running in the background, re-seeding the runtime once it resolves.
+ *
+ * These tests inject a controllable slow read (a stubbed
+ * `readLatestProjectSequenceAsync` that resolves only when the test tells
+ * it to) instead of a real wall-clock sleep, per #1024's OS-agnostic
+ * discipline — no flaky timing assumptions, and it proves the bound holds
+ * even when the underlying read has not yet returned at all. The "healthy
+ * path" test proves the fast case is unaffected. All tests FAIL on pre-fix
+ * code: pre-fix, `handleSessionStart` awaits the slow read directly (no
+ * race), so the "returns within budget" and "cold-start fallback" assertions
+ * would time out / never observe a `timedOut: true` metadata flag.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectSequenceIndex } from "../../clients/project-changes.js";
+import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
+import { _resetSubagentModeForTests } from "../../clients/subagent-mode.js";
+import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+
+const logLatencySpy = vi.hoisted(() => vi.fn());
+const readLatestProjectSequenceAsyncSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("../../clients/latency-logger.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../clients/latency-logger.js")>();
+	return { ...actual, logLatency: logLatencySpy };
+});
+
+vi.mock("../../clients/project-changes.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../clients/project-changes.js")>();
+	return {
+		...actual,
+		readLatestProjectSequenceAsync: readLatestProjectSequenceAsyncSpy,
+	};
+});
+
+vi.mock("../../clients/lsp/config.js", () => ({
+	loadLSPConfig: vi.fn().mockResolvedValue({}),
+	initLSPConfig: vi.fn().mockResolvedValue(undefined),
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../clients/lsp/index.js", () => ({
+	getLSPService: vi.fn(() => ({
+		touchFile: vi.fn().mockResolvedValue(undefined),
+		supportsLSP: () => false,
+	})),
+}));
+
+import { handleSessionStart } from "../../clients/runtime-session.js";
+
+function makeDeps(
+	ctxCwd: string,
+	runtime: RuntimeCoordinator,
+	overrides: Record<string, unknown> = {},
+) {
+	return {
+		ctxCwd,
+		getFlag: () => false,
+		notify: vi.fn(),
+		dbg: () => {},
+		log: () => {},
+		runtime,
+		metricsClient: { reset: () => {} },
+		cacheManager: { writeCache: () => {}, readCache: () => null },
+		todoScanner: { scanDirectory: () => ({ items: [] }) },
+		astGrepClient: {
+			isAvailable: () => false,
+			ensureAvailable: async () => false,
+			scanExports: async () => new Map(),
+		},
+		biomeClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		ruffClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		knipClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		jscpdClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		depChecker: { isAvailable: () => false, ensureAvailable: async () => false },
+		testRunnerClient: {
+			detectRunner: () => null,
+			runTestFile: () => ({ failed: 0, error: false }),
+		},
+		goClient: { isGoAvailableAsync: async () => false },
+		rustClient: { isAvailableAsync: async () => false },
+		ensureTool: vi.fn(async () => null),
+		cleanStaleTsBuildInfo: () => [],
+		resetDispatchBaselines: () => {},
+		resetLSPService: () => {},
+		...overrides,
+	} as any;
+}
+
+function makeProject(env: { tmpDir: string }): string {
+	const cwd = path.join(env.tmpDir, "project");
+	fs.mkdirSync(path.join(cwd, ".git"), { recursive: true });
+	createTempFile(env.tmpDir, "project/index.ts", "export const x = 1;\n");
+	return cwd;
+}
+
+/** A deferred promise the test controls the settle timing of. */
+function deferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+} {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+function spyOnSeed(runtime: RuntimeCoordinator): ReturnType<typeof vi.fn> {
+	const seedSpy = vi.fn();
+	const original = runtime.seedProjectSequence.bind(runtime);
+	runtime.seedProjectSequence = ((...args: [number, Map<string, number>?]) => {
+		seedSpy(...args);
+		return (original as (...a: typeof args) => void)(...args);
+	}) as typeof runtime.seedProjectSequence;
+	return seedSpy;
+}
+
+describe("#1162 — bounded session_start sequence read", () => {
+	const globals = globalThis as unknown as {
+		__piLensFirstSessionDone?: boolean;
+		__piLensWarmupScheduled?: boolean;
+	};
+	let prevArgv: string[];
+	let prevStartupMode: string | undefined;
+	let prevBudget: string | undefined;
+	let prevDelay: string | undefined;
+	let prevDataDir: string | undefined;
+	let prevFirst: boolean | undefined;
+	let prevWarmup: boolean | undefined;
+
+	beforeEach(() => {
+		prevArgv = process.argv;
+		prevStartupMode = process.env.PI_LENS_STARTUP_MODE;
+		prevBudget = process.env.PI_LENS_SEQUENCE_READ_BUDGET_MS;
+		prevDelay = process.env.PI_LENS_WARMUP_DELAY_MS;
+		prevDataDir = process.env.PILENS_DATA_DIR;
+		prevFirst = globals.__piLensFirstSessionDone;
+		prevWarmup = globals.__piLensWarmupScheduled;
+		// Avoid the unrelated first-session quick-warmup heuristic (#1154)
+		// firing background work that would confuse these assertions.
+		globals.__piLensFirstSessionDone = true;
+		globals.__piLensWarmupScheduled = true;
+		process.env.PI_LENS_STARTUP_MODE = "quick";
+		process.env.PI_LENS_SEQUENCE_READ_BUDGET_MS = "30";
+		process.argv = prevArgv.filter((a) => a !== "--print" && a !== "-p");
+		logLatencySpy.mockClear();
+		readLatestProjectSequenceAsyncSpy.mockReset();
+		_resetSubagentModeForTests();
+	});
+
+	afterEach(() => {
+		process.argv = prevArgv;
+		if (prevStartupMode === undefined) delete process.env.PI_LENS_STARTUP_MODE;
+		else process.env.PI_LENS_STARTUP_MODE = prevStartupMode;
+		if (prevBudget === undefined)
+			delete process.env.PI_LENS_SEQUENCE_READ_BUDGET_MS;
+		else process.env.PI_LENS_SEQUENCE_READ_BUDGET_MS = prevBudget;
+		if (prevDelay === undefined) delete process.env.PI_LENS_WARMUP_DELAY_MS;
+		else process.env.PI_LENS_WARMUP_DELAY_MS = prevDelay;
+		if (prevDataDir === undefined) delete process.env.PILENS_DATA_DIR;
+		else process.env.PILENS_DATA_DIR = prevDataDir;
+		globals.__piLensFirstSessionDone = prevFirst;
+		globals.__piLensWarmupScheduled = prevWarmup;
+		vi.restoreAllMocks();
+		_resetSubagentModeForTests();
+	});
+
+	it("returns within budget and falls back to cold-start when the sequence read stalls, then reseeds in the background once it resolves", async () => {
+		const env = setupTestEnvironment("pi-lens-seq-budget-slow-");
+		process.env.PILENS_DATA_DIR = path.join(env.tmpDir, "data");
+		try {
+			const cwd = makeProject(env);
+			const slowResult: ProjectSequenceIndex = {
+				projectSeq: 42,
+				fileSeqByPath: new Map([["/some/file.ts", 7]]),
+			};
+			const slow = deferred<ProjectSequenceIndex>();
+			readLatestProjectSequenceAsyncSpy.mockImplementation(() => slow.promise);
+
+			const runtime = new RuntimeCoordinator();
+			const seedSpy = spyOnSeed(runtime);
+
+			const startedAt = Date.now();
+			await handleSessionStart(makeDeps(cwd, runtime));
+			const elapsed = Date.now() - startedAt;
+
+			// Bounded: session_start returned even though the injected read has
+			// NOT resolved yet — pre-fix this `await` would hang until `slow`
+			// settles (never, in this test), so this line alone fails pre-fix.
+			// Generous slack above the 30ms budget absorbs CI scheduling jitter
+			// while staying far below any real host-pressure stall.
+			expect(elapsed).toBeLessThan(2000);
+
+			// Cold-start fallback: seeded with the safe empty sentinel.
+			expect(seedSpy).toHaveBeenCalledWith(0, new Map());
+
+			// Never silent (shape 10): the latency line distinguishes the
+			// fallback from a healthy read.
+			expect(logLatencySpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					phase: "session_start_sequence_read",
+					metadata: expect.objectContaining({ timedOut: true }),
+				}),
+			);
+
+			// Now let the slow read resolve and confirm the deferred reseed runs.
+			seedSpy.mockClear();
+			logLatencySpy.mockClear();
+			slow.resolve(slowResult);
+			await vi.waitFor(() => {
+				expect(seedSpy).toHaveBeenCalledWith(42, slowResult.fileSeqByPath);
+			});
+			expect(logLatencySpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					phase: "session_start_sequence_read_deferred_reseed",
+					metadata: expect.objectContaining({ deferred: true, entries: 1 }),
+				}),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("seeds normally on a healthy (fast) read — no fallback", async () => {
+		const env = setupTestEnvironment("pi-lens-seq-budget-fast-");
+		process.env.PILENS_DATA_DIR = path.join(env.tmpDir, "data");
+		try {
+			const cwd = makeProject(env);
+			const fastResult: ProjectSequenceIndex = {
+				projectSeq: 3,
+				fileSeqByPath: new Map([["/some/other.ts", 1]]),
+			};
+			readLatestProjectSequenceAsyncSpy.mockResolvedValue(fastResult);
+
+			const runtime = new RuntimeCoordinator();
+			const seedSpy = spyOnSeed(runtime);
+
+			await handleSessionStart(makeDeps(cwd, runtime));
+
+			expect(seedSpy).toHaveBeenCalledWith(3, fastResult.fileSeqByPath);
+			expect(logLatencySpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					phase: "session_start_sequence_read",
+					metadata: expect.objectContaining({ timedOut: false }),
+				}),
+			);
+			// Healthy path never falls back — no deferred-reseed phase logged.
+			expect(logLatencySpy).not.toHaveBeenCalledWith(
+				expect.objectContaining({
+					phase: "session_start_sequence_read_deferred_reseed",
+				}),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("does NOT reseed in the background for a one-shot `pi --print` invocation (shape 4 screen)", async () => {
+		const env = setupTestEnvironment("pi-lens-seq-budget-print-");
+		process.env.PILENS_DATA_DIR = path.join(env.tmpDir, "data");
+		process.argv = [...prevArgv, "--print"];
+		try {
+			const cwd = makeProject(env);
+			const slow = deferred<ProjectSequenceIndex>();
+			readLatestProjectSequenceAsyncSpy.mockImplementation(() => slow.promise);
+
+			const runtime = new RuntimeCoordinator();
+			const seedSpy = spyOnSeed(runtime);
+
+			await handleSessionStart(makeDeps(cwd, runtime));
+			expect(seedSpy).toHaveBeenCalledWith(0, new Map());
+			seedSpy.mockClear();
+			logLatencySpy.mockClear();
+
+			slow.resolve({ projectSeq: 99, fileSeqByPath: new Map() });
+			// Give the (would-be) background continuation a generous window to
+			// run if it were going to — post-fix it must not, since a one-shot
+			// print process has no future session in this process to benefit.
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			expect(seedSpy).not.toHaveBeenCalled();
+			expect(logLatencySpy).not.toHaveBeenCalledWith(
+				expect.objectContaining({
+					phase: "session_start_sequence_read_deferred_reseed",
+				}),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+});

--- a/tests/clients/runtime-session-sequence-read-budget.test.ts
+++ b/tests/clients/runtime-session-sequence-read-budget.test.ts
@@ -20,16 +20,23 @@
  * it to) instead of a real wall-clock sleep, per #1024's OS-agnostic
  * discipline — no flaky timing assumptions, and it proves the bound holds
  * even when the underlying read has not yet returned at all. The "healthy
- * path" test proves the fast case is unaffected. All tests FAIL on pre-fix
- * code: pre-fix, `handleSessionStart` awaits the slow read directly (no
- * race), so the "returns within budget" and "cold-start fallback" assertions
- * would time out / never observe a `timedOut: true` metadata flag.
+ * path" test proves the fast case is unaffected. The cold-start/deferred-
+ * reseed tests FAIL on pre-fix code: pre-fix, `handleSessionStart` calls the
+ * SYNC `readLatestProjectSequence` against the real filesystem — it ignores
+ * this test's async mock entirely (so it also returns quickly, just with the
+ * wrong un-bounded-by-design result) and never produces a `timedOut` metadata
+ * flag or a cold-start/deferred-reseed sequence, which is what these tests
+ * actually assert on.
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProjectSequenceIndex } from "../../clients/project-changes.js";
+import {
+	getProjectSnapshotLegacyPath,
+	PROJECT_SNAPSHOT_VERSION,
+} from "../../clients/project-snapshot.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { _resetSubagentModeForTests } from "../../clients/subagent-mode.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
@@ -205,10 +212,15 @@ describe("#1162 — bounded session_start sequence read", () => {
 			const elapsed = Date.now() - startedAt;
 
 			// Bounded: session_start returned even though the injected read has
-			// NOT resolved yet — pre-fix this `await` would hang until `slow`
-			// settles (never, in this test), so this line alone fails pre-fix.
-			// Generous slack above the 30ms budget absorbs CI scheduling jitter
-			// while staying far below any real host-pressure stall.
+			// NOT resolved yet. This line alone does NOT distinguish pre-/post-fix
+			// (pre-fix code calls the SYNC `readLatestProjectSequence` against the
+			// real filesystem, ignores this mock entirely, and also returns fast —
+			// it just returns the wrong, un-bounded-by-design result). The real
+			// pre-fix failures are below: the missing `timedOut` metadata flag and
+			// the absent cold-start/deferred-reseed behavior, which only the
+			// bounded-async path produces. Generous slack above the 30ms budget
+			// absorbs CI scheduling jitter while staying far below any real
+			// host-pressure stall.
 			expect(elapsed).toBeLessThan(2000);
 
 			// Cold-start fallback: seeded with the safe empty sentinel.
@@ -302,6 +314,109 @@ describe("#1162 — bounded session_start sequence read", () => {
 			expect(logLatencySpy).not.toHaveBeenCalledWith(
 				expect.objectContaining({
 					phase: "session_start_sequence_read_deferred_reseed",
+				}),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("does NOT clobber an in-window edit's bumped fileSeq — same-session advancement guard (review follow-up P3, closes #1168 finding 1)", async () => {
+		const env = setupTestEnvironment("pi-lens-seq-budget-advance-");
+		process.env.PILENS_DATA_DIR = path.join(env.tmpDir, "data");
+		try {
+			const cwd = makeProject(env);
+			const slow = deferred<ProjectSequenceIndex>();
+			readLatestProjectSequenceAsyncSpy.mockImplementation(() => slow.promise);
+
+			const runtime = new RuntimeCoordinator();
+			const seedSpy = spyOnSeed(runtime);
+
+			await handleSessionStart(makeDeps(cwd, runtime));
+			// Cold-start fallback, as in the slow-read test above.
+			expect(seedSpy).toHaveBeenCalledWith(0, new Map());
+			expect(runtime.projectSeq).toBe(0);
+
+			// Simulate an agent edit landing IN the stall window: AFTER the cold
+			// seed (session_start already returned) but BEFORE the deferred read
+			// resolves.
+			const editedFile = path.join(cwd, "index.ts");
+			const bump = runtime.bumpFileSeq(editedFile);
+			expect(bump.projectSeq).toBe(1);
+			expect(runtime.getFileSeq(editedFile)).toBe(1);
+
+			seedSpy.mockClear();
+			logLatencySpy.mockClear();
+
+			// The stalled read now resolves with a snapshot of the world from
+			// BEFORE the edit above — reseeding with it would erase the bump.
+			slow.resolve({
+				projectSeq: 42,
+				fileSeqByPath: new Map([["/some/other-file.ts", 7]]),
+			});
+			// Give the deferred continuation a generous window to run (or, per
+			// the fix, to observe the advancement and skip).
+			await new Promise((resolve) => setTimeout(resolve, 150));
+
+			// The guard must have skipped the reseed entirely — no clobber.
+			expect(seedSpy).not.toHaveBeenCalled();
+			expect(logLatencySpy).not.toHaveBeenCalledWith(
+				expect.objectContaining({
+					phase: "session_start_sequence_read_deferred_reseed",
+				}),
+			);
+			// The in-window bump survives completely untouched.
+			expect(runtime.getFileSeq(editedFile)).toBe(1);
+			expect(runtime.projectSeq).toBe(1);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("treats a seq-0 persisted snapshot as STALE (never fresh) when the read times out — cold-sentinel aliasing guard (review follow-up P3, closes #1168 finding 2)", async () => {
+		const env = setupTestEnvironment("pi-lens-seq-budget-seq0-");
+		process.env.PILENS_DATA_DIR = path.join(env.tmpDir, "data");
+		try {
+			const cwd = makeProject(env);
+
+			// A project's real first-ever snapshot: legitimately persisted at
+			// seq === 0, before any change was ever logged. The timed-out read's
+			// cold sentinel is ALSO projectSeq 0 — this is exactly the collision
+			// #1168's review caught.
+			const legacyPath = getProjectSnapshotLegacyPath(cwd);
+			fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+			fs.writeFileSync(
+				legacyPath,
+				JSON.stringify({
+					version: PROJECT_SNAPSHOT_VERSION,
+					projectRoot: cwd,
+					generatedAt: new Date().toISOString(),
+					seq: 0,
+					files: {},
+					symbols: {},
+					reverseDeps: {},
+					cachedExports: [],
+				}),
+			);
+
+			// The on-disk change log has since moved past seq 0 (a non-empty
+			// log), but the read never returns within the budget — this test
+			// only needs the timeout to fire, so the read is left pending.
+			readLatestProjectSequenceAsyncSpy.mockImplementation(
+				() => new Promise<ProjectSequenceIndex>(() => {}),
+			);
+
+			const runtime = new RuntimeCoordinator();
+			await handleSessionStart(makeDeps(cwd, runtime));
+
+			expect(logLatencySpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					phase: "session_start_snapshot_load",
+					metadata: expect.objectContaining({
+						fresh: false,
+						seq: 0,
+						sequenceUnknown: true,
+					}),
 				}),
 			);
 		} finally {


### PR DESCRIPTION
## What
`session_start_sequence_read` was a synchronous, unbounded blocking read on the session-start critical path (`readLatestProjectSequence` → `fs.readFileSync`). Normally ~2ms, but under host I/O pressure it blocked 2125ms (observed in latency.log, entries=0 — pure I/O stall, not computation). pi-lens wasn't the root cause but was the amplifier: an unbounded sync read with no escape hatch.

## Approach: async + race (not a sync-timeout, which is theatre)
A timeout CANNOT preempt a synchronous `readFileSync` (the thread blocks until the OS returns). So the read is made async (`fs.promises.readFile`, which yields) and raced against a budget:
- New `readProjectChangesAsync`/`readLatestProjectSequenceAsync` in `clients/project-changes.ts` (same fold logic, async source).
- `readSequenceWithBudget()` in `runtime-session.ts` races the async read against `sequenceReadBudgetMs()` (default 250ms, `PI_LENS_SEQUENCE_READ_BUDGET_MS`-overridable). On timeout: return the cold sentinel `{projectSeq:0, empty}` (byte-identical to a missing-log full replay — snapshot treated as stale, always SAFE) and continue the real read in the background, re-seeding via `runtime.seedProjectSequence` **unless** `!isCurrentSession` or `isPrintMode()`.
- Both call sites (quick + full path) converted; both `session_start_sequence_read` latency lines now carry `metadata.timedOut` so the fallback is observable (not silenced — shape 10).

## Shape-4 screen
The race's `setTimeout` is `.unref()`'d immediately and `clearTimeout`'d on both outcomes; the reseed is a plain continuation on the already-in-flight `fs.promises.readFile` (no stray handle) and is `isPrintMode()`-gated (reused from `clients/print-mode.ts`) so a one-shot `pi --print` never runs it.

## Tests
`tests/clients/runtime-session-sequence-read-budget.test.ts` (3): returns-within-budget + cold fallback on a slow read, seeds normally on a healthy read, print-mode skips reseed. Fail-then-pass verified (2/3 fail pre-fix — pre-fix always reads sync regardless of the injected slow read). Build/lint/changelog green.

`closes #1162`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)