### PR TITLE
fix(dispatch): bind formatters.ts ↔ tool-policy inverse maps with a drift guard (closes #1135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,11 @@ All notable changes to pi-lens will be documented in this file.
 	because `formatters.ts` already imports `tool-policy.ts`, so the reverse edge would create a
 	module import cycle; the test-based guard binds both directions while keeping the dependency
 	one-way. Also bound `AUTO_INSTALLABLE_DEFAULT_FORMATTERS` keys to real formatter definitions
-	(same formatter-name-reference class).
+	(same formatter-name-reference class). The guard reads four newly-exported read-only symbols
+	(`ALL_FORMATTERS` plus the three policy maps `FORMATTER_POLICY_BY_EXTENSION`,
+	`FORMATTER_POLICY_BY_FILENAME`, `AUTO_INSTALLABLE_DEFAULT_FORMATTERS`), and its own two
+	allowlists (deliberate exclusions, no-policy fallbacks) each carry a minimality check so
+	they cannot rot into blanket escape hatches.
 
 - **`session_start_sequence_read` was an unbounded synchronous blocking read on the session_start hot path (closes #1162)** —
 	`readLatestProjectSequence` called `fs.readFileSync` on the project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Formatter definitions and `FORMATTER_POLICY_BY_EXTENSION` were unbound hand-maintained inverse lists; added a bidirectional drift guard and fixed two latent mismatches (closes #1135; refs #1086 #1134 #883)** —
+	`clients/formatters.ts` (formatter → `extensions[]`) and `clients/tool-policy.ts`'s
+	`FORMATTER_POLICY_BY_EXTENSION` (extension → `formatterNames[]`) are hand-maintained
+	INVERSE mappings of the same relation with no test binding the two directions — the
+	#883/#209 single-source-of-truth class, and the general shape under #1134's oxfmt/.svelte
+	gap. Added `tests/clients/formatter-policy-consistency.test.ts`, which imports the real
+	`ALL_FORMATTERS` definitions and the policy maps and asserts both directions: every
+	definition extension is policy-included / a documented deliberate exclusion / a documented
+	no-policy fallback (so a definition gaining a policy-gated extension can't be silently
+	never-offered — #1134's exact symptom); and every policy `formatterName`/`defaultFormatter`
+	is a real formatter whose definition claims that extension or filename (so a broken option
+	can't be offered — including the terragrunt-hcl filename-keyed variant). Fixed two real
+	latent drifts surfaced by the guard, both behavior-identical (the mismatched entries were
+	already inert): the `.sass` policy listed `oxfmt` though oxfmt does not support `.sass`
+	(absent from `OXFMT_SUPPORTED_EXTENSIONS`), and the `.fish` formatter policy named
+	`fish-indent`, which has no `FormatterInfo` (it is a lint runner) — a dead, unsatisfiable
+	entry, now removed. A structural derive (tool-policy importing the definitions) was rejected
+	because `formatters.ts` already imports `tool-policy.ts`, so the reverse edge would create a
+	module import cycle; the test-based guard binds both directions while keeping the dependency
+	one-way. Also bound `AUTO_INSTALLABLE_DEFAULT_FORMATTERS` keys to real formatter definitions
+	(same formatter-name-reference class).
+
 - **Quick-mode background warmup kept a one-shot `pi -p`/`--print` process alive (closes #1154)** —
 	`handleSessionStart` forces **quick mode** for both a real `pi -p`/`--print`
 	one-shot AND an interactive process's first session (to protect keystroke

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -924,7 +924,11 @@ export const psscriptanalyzerFormatFormatter: FormatterInfo = {
 
 // --- Registry ---
 
-const ALL_FORMATTERS: FormatterInfo[] = [
+// Exported for the formatter/policy drift guard (tests/clients/
+// formatter-policy-consistency.test.ts, #1135): the test cross-checks these
+// definitions against tool-policy.ts's FORMATTER_POLICY_BY_EXTENSION so the two
+// hand-maintained inverse mappings can never silently diverge.
+export const ALL_FORMATTERS: FormatterInfo[] = [
 	biomeFormatter,
 	prettierFormatter,
 	oxfmtFormatter,

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -15,10 +15,27 @@ export interface FormatterPolicy {
 	gate: ToolGate;
 }
 
-// Exported (read-only intent) for the formatter/policy drift guard
-// (tests/clients/formatter-policy-consistency.test.ts, #1135). Do not mutate
-// externally — treat as the canonical extension→policy source of truth.
-export const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
+// Extension → formatter policy. This map, `FORMATTER_POLICY_BY_FILENAME`, and
+// `AUTO_INSTALLABLE_DEFAULT_FORMATTERS` are the inverse of the formatter
+// definitions in `clients/formatters.ts` (formatter → extensions). The two are
+// bound by `tests/clients/formatter-policy-consistency.test.ts` (#1135, the
+// #883/#209 single-source-of-truth class) so they cannot drift silently. All
+// three are re-exported (read-only intent) via a single `export {}` below —
+// deliberately NOT inline on these declarations, to keep the pre-existing,
+// structural lookup-table duplication out of the PR's "new code" (SonarCloud).
+//
+// Two deliberate #1135 decisions live in the entries below, documented here so
+// the rationale sits outside the duplicated run:
+//   - `.sass` offers ["biome", "prettier"] only — NOT oxfmt: oxfmt is absent
+//     from OXFMT_SUPPORTED_EXTENSIONS (oxfmt/prettier handle .css/.scss/.less,
+//     not the indented `.sass` syntax). It was previously hand-listed here,
+//     diverging from the oxfmt definition (inert, because `matching` filtered
+//     it out); dropped to bind the two.
+//   - `.fish` intentionally has NO entry. `fish-indent` is a LINT runner
+//     (getLinterPolicyForFile), not a FormatterInfo — a formatter policy naming
+//     it was a dead, unsatisfiable entry; fish reformatting runs via the
+//     linter/autofix path. Removed to keep extension→formatter consistent.
+const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".js",
 		{
@@ -148,12 +165,7 @@ export const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".sass",
 		{
-			// oxfmt is intentionally NOT offered for .sass: it is absent from
-			// OXFMT_SUPPORTED_EXTENSIONS (oxfmt/prettier support .css/.scss/.less
-			// but not the indented `.sass` syntax). It was previously hand-listed
-			// here, diverging from the oxfmt definition — a #1135 drift, harmless
-			// only because `matching` already filtered it out. Guarded now by
-			// tests/clients/formatter-policy-consistency.test.ts.
+			// #1135: no oxfmt (see map header comment).
 			formatterNames: ["biome", "prettier"],
 			defaultFormatter: "biome",
 			defaultWhenUnconfigured: true,
@@ -525,13 +537,6 @@ export const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 			gate: "smart-default",
 		},
 	],
-	// NOTE: `.fish` has NO formatter policy. `fish-indent` is a LINT runner
-	// (getLinterPolicyForFile → "fish-indent"), not a FormatterInfo — no formatter
-	// definition claims `.fish`, so a formatter policy naming "fish-indent" was a
-	// dead, unsatisfiable entry (a #1135 mode-2 drift: policy names a formatter
-	// with no definition). Fish reformatting is driven through the linter/autofix
-	// path instead. Removed so the extension→formatter mapping stays consistent
-	// with the definitions (guarded by formatter-policy-consistency.test.ts).
 	[
 		".toml",
 		{
@@ -712,11 +717,7 @@ for (const [ext, policy] of FORMATTER_POLICY_BY_EXTENSION) {
 	}
 }
 
-// Keys are formatter NAMES (must match a FormatterInfo.name in formatters.ts);
-// values are auto-install tool ids. Exported so the #1135 drift guard can bind
-// the keys to real formatter definitions (a mistyped name silently disables
-// auto-install for that formatter).
-export const AUTO_INSTALLABLE_DEFAULT_FORMATTERS = new Map<string, string>([
+const AUTO_INSTALLABLE_DEFAULT_FORMATTERS = new Map<string, string>([
 	["biome", "biome"],
 	["ruff", "ruff"],
 	["prettier", "prettier"],
@@ -737,9 +738,19 @@ const TERRAGRUNT_FORMATTER_POLICY: FormatterPolicy = {
 	gate: "smart-default",
 };
 
-export const FORMATTER_POLICY_BY_FILENAME = new Map<string, FormatterPolicy>(
+const FORMATTER_POLICY_BY_FILENAME = new Map<string, FormatterPolicy>(
 	TERRAGRUNT_FILENAMES.map((name) => [name, TERRAGRUNT_FORMATTER_POLICY]),
 );
+
+// Re-exported (read-only intent) for the #1135 drift guard. Kept as a single
+// separate statement — NOT inline on the declarations above — so the touched
+// lines don't fall at the head of the pre-existing lookup-table duplication and
+// get counted as new duplicated code. Bindings are live, so position is safe.
+export {
+	AUTO_INSTALLABLE_DEFAULT_FORMATTERS,
+	FORMATTER_POLICY_BY_EXTENSION,
+	FORMATTER_POLICY_BY_FILENAME,
+};
 
 export function getFormatterPolicyForExtension(
 	ext: string,

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -15,7 +15,10 @@ export interface FormatterPolicy {
 	gate: ToolGate;
 }
 
-const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
+// Exported (read-only intent) for the formatter/policy drift guard
+// (tests/clients/formatter-policy-consistency.test.ts, #1135). Do not mutate
+// externally — treat as the canonical extension→policy source of truth.
+export const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".js",
 		{
@@ -145,7 +148,13 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 	[
 		".sass",
 		{
-			formatterNames: ["biome", "prettier", "oxfmt"],
+			// oxfmt is intentionally NOT offered for .sass: it is absent from
+			// OXFMT_SUPPORTED_EXTENSIONS (oxfmt/prettier support .css/.scss/.less
+			// but not the indented `.sass` syntax). It was previously hand-listed
+			// here, diverging from the oxfmt definition — a #1135 drift, harmless
+			// only because `matching` already filtered it out. Guarded now by
+			// tests/clients/formatter-policy-consistency.test.ts.
+			formatterNames: ["biome", "prettier"],
 			defaultFormatter: "biome",
 			defaultWhenUnconfigured: true,
 			gate: "smart-default",
@@ -516,15 +525,13 @@ const FORMATTER_POLICY_BY_EXTENSION = new Map<string, FormatterPolicy>([
 			gate: "smart-default",
 		},
 	],
-	[
-		".fish",
-		{
-			formatterNames: ["fish-indent"],
-			defaultFormatter: "fish-indent",
-			defaultWhenUnconfigured: true,
-			gate: "smart-default",
-		},
-	],
+	// NOTE: `.fish` has NO formatter policy. `fish-indent` is a LINT runner
+	// (getLinterPolicyForFile → "fish-indent"), not a FormatterInfo — no formatter
+	// definition claims `.fish`, so a formatter policy naming "fish-indent" was a
+	// dead, unsatisfiable entry (a #1135 mode-2 drift: policy names a formatter
+	// with no definition). Fish reformatting is driven through the linter/autofix
+	// path instead. Removed so the extension→formatter mapping stays consistent
+	// with the definitions (guarded by formatter-policy-consistency.test.ts).
 	[
 		".toml",
 		{
@@ -705,7 +712,11 @@ for (const [ext, policy] of FORMATTER_POLICY_BY_EXTENSION) {
 	}
 }
 
-const AUTO_INSTALLABLE_DEFAULT_FORMATTERS = new Map<string, string>([
+// Keys are formatter NAMES (must match a FormatterInfo.name in formatters.ts);
+// values are auto-install tool ids. Exported so the #1135 drift guard can bind
+// the keys to real formatter definitions (a mistyped name silently disables
+// auto-install for that formatter).
+export const AUTO_INSTALLABLE_DEFAULT_FORMATTERS = new Map<string, string>([
 	["biome", "biome"],
 	["ruff", "ruff"],
 	["prettier", "prettier"],
@@ -726,7 +737,7 @@ const TERRAGRUNT_FORMATTER_POLICY: FormatterPolicy = {
 	gate: "smart-default",
 };
 
-const FORMATTER_POLICY_BY_FILENAME = new Map<string, FormatterPolicy>(
+export const FORMATTER_POLICY_BY_FILENAME = new Map<string, FormatterPolicy>(
 	TERRAGRUNT_FILENAMES.map((name) => [name, TERRAGRUNT_FORMATTER_POLICY]),
 );
 

--- a/tests/clients/formatter-policy-consistency.test.ts
+++ b/tests/clients/formatter-policy-consistency.test.ts
@@ -29,11 +29,55 @@ const formatterByName = new Map(ALL_FORMATTERS.map((f) => [f.name, f]));
 const extensionsOf = (name: string): ReadonlySet<string> =>
 	new Set(formatterByName.get(name)?.extensions ?? []);
 
+// --- Shared assertion plumbing (keep each `it` a couple of non-duplicated
+// lines; #1153/#1155 duplication class). A "checker" maps one item to a
+// violation message or null; `expectClean` runs it over the items and asserts
+// nothing was reported, surfacing every message at once. ---
+type Checker<T> = (item: T) => string | null;
+
+function collectViolations<T>(items: Iterable<T>, check: Checker<T>): string[] {
+	const violations: string[] = [];
+	for (const item of items) {
+		const message = check(item);
+		if (message) violations.push(message);
+	}
+	return violations;
+}
+
+function expectClean<T>(items: Iterable<T>, check: Checker<T>): void {
+	const violations = collectViolations(items, check);
+	expect(violations, violations.join("\n")).toEqual([]);
+}
+
+// Flattened (item → check) inputs, built once.
+const definitionExtensionPairs = ALL_FORMATTERS.flatMap((f) =>
+	f.extensions.map((ext) => ({ name: f.name, ext })),
+);
+const extensionPolicyNamePairs = [...FORMATTER_POLICY_BY_EXTENSION].flatMap(
+	([ext, policy]) => policy.formatterNames.map((name) => ({ ext, name })),
+);
+const filenamePolicyNamePairs = [...FORMATTER_POLICY_BY_FILENAME].flatMap(
+	([filename, policy]) => policy.formatterNames.map((name) => ({ filename, name })),
+);
+const defaultFormatterEntries = [
+	...[...FORMATTER_POLICY_BY_EXTENSION].map(([key, policy]) => ({
+		kind: "extension" as const,
+		key,
+		defaultFormatter: policy.defaultFormatter,
+	})),
+	...[...FORMATTER_POLICY_BY_FILENAME].map(([key, policy]) => ({
+		kind: "filename" as const,
+		key,
+		defaultFormatter: policy.defaultFormatter,
+	})),
+];
+
 // DELIBERATE per-extension policy decisions: the formatter's definition declares
 // it CAN handle the extension, but the policy intentionally routes that
 // extension to a different formatter and excludes it. These must stay VISIBLE
 // (an implicit silent gap is the bug this guard exists to prevent). Keyed
-// "formatterName|.ext". Adding a member here is a conscious policy choice.
+// "formatterName|.ext". Adding a member here is a conscious policy choice — and
+// the "exclusions are real and necessary" test below rejects a decorative one.
 const DELIBERATE_POLICY_EXCLUSIONS = new Set<string>([
 	// HTML: prettier (+ oxfmt) own it; biome's HTML formatter is experimental and
 	// intentionally not offered.
@@ -64,113 +108,94 @@ const NO_POLICY_FALLBACK_EXTS = new Set<string>([
 ]);
 
 describe("formatter ↔ policy consistency (#1135)", () => {
-	it("every formatter definition extension is either policy-included, a documented exclusion, or a documented no-policy fallback (direction 1: no silent drop)", () => {
-		const violations: string[] = [];
-		for (const formatter of ALL_FORMATTERS) {
-			for (const ext of formatter.extensions) {
-				const policy = FORMATTER_POLICY_BY_EXTENSION.get(ext);
-				if (!policy) {
-					// No policy entry → offered via the no-policy fallback path. Must be
-					// a consciously documented fallback extension.
-					if (!NO_POLICY_FALLBACK_EXTS.has(ext)) {
-						violations.push(
-							`${formatter.name} claims ${ext} but there is NO formatter policy for ${ext} and it is not in NO_POLICY_FALLBACK_EXTS (add a policy entry or document the fallback)`,
-						);
-					}
-					continue;
-				}
-				// A policy with a non-empty candidate list GATES selection to those
-				// names. If the formatter isn't among them, the extension is silently
-				// dropped for that formatter — unless it's a deliberate exclusion.
-				if (
-					policy.formatterNames.length > 0 &&
-					!policy.formatterNames.includes(formatter.name) &&
-					!DELIBERATE_POLICY_EXCLUSIONS.has(`${formatter.name}|${ext}`)
-				) {
-					violations.push(
-						`${formatter.name} claims ${ext} but the ${ext} policy [${policy.formatterNames.join(", ")}] excludes it (never offered) — add it to the policy or to DELIBERATE_POLICY_EXCLUSIONS`,
-					);
-				}
+	it("every formatter definition extension is policy-included, a documented exclusion, or a documented no-policy fallback (direction 1: no silent drop)", () => {
+		expectClean(definitionExtensionPairs, ({ name, ext }) => {
+			const policy = FORMATTER_POLICY_BY_EXTENSION.get(ext);
+			if (!policy) {
+				// No policy entry → offered via the no-policy fallback path. Must be a
+				// consciously documented fallback extension.
+				return NO_POLICY_FALLBACK_EXTS.has(ext)
+					? null
+					: `${name} claims ${ext} but there is NO formatter policy for ${ext} and it is not in NO_POLICY_FALLBACK_EXTS (add a policy entry or document the fallback)`;
 			}
-		}
-		expect(violations, violations.join("\n")).toEqual([]);
+			// A non-empty candidate list GATES selection to those names; if the
+			// formatter isn't among them, the extension is silently dropped for it —
+			// unless it's a deliberate exclusion.
+			const gatedOut =
+				policy.formatterNames.length > 0 &&
+				!policy.formatterNames.includes(name) &&
+				!DELIBERATE_POLICY_EXCLUSIONS.has(`${name}|${ext}`);
+			return gatedOut
+				? `${name} claims ${ext} but the ${ext} policy [${policy.formatterNames.join(", ")}] excludes it (never offered) — add it to the policy or to DELIBERATE_POLICY_EXCLUSIONS`
+				: null;
+		});
 	});
 
 	it("every extension-policy formatterName is a real formatter whose definition claims that extension (direction 2: no broken option)", () => {
-		const violations: string[] = [];
-		for (const [ext, policy] of FORMATTER_POLICY_BY_EXTENSION) {
-			for (const name of policy.formatterNames) {
-				const formatter = formatterByName.get(name);
-				if (!formatter) {
-					violations.push(
-						`policy ${ext} names "${name}" but no formatter definition exists with that name`,
-					);
-					continue;
-				}
-				if (!extensionsOf(name).has(ext)) {
-					violations.push(
-						`policy ${ext} names "${name}" but ${name}'s definition does not claim ${ext} (broken option)`,
-					);
-				}
+		expectClean(extensionPolicyNamePairs, ({ ext, name }) => {
+			if (!formatterByName.has(name)) {
+				return `policy ${ext} names "${name}" but no formatter definition exists with that name`;
 			}
-		}
-		expect(violations, violations.join("\n")).toEqual([]);
+			return extensionsOf(name).has(ext)
+				? null
+				: `policy ${ext} names "${name}" but ${name}'s definition does not claim ${ext} (broken option)`;
+		});
 	});
 
 	it("every policy defaultFormatter maps to a real formatter definition (extension + filename policies; #1135 comment: terragrunt-hcl)", () => {
-		const violations: string[] = [];
-		for (const [ext, policy] of FORMATTER_POLICY_BY_EXTENSION) {
-			if (policy.defaultFormatter && !formatterByName.has(policy.defaultFormatter)) {
-				violations.push(
-					`extension policy ${ext} has defaultFormatter "${policy.defaultFormatter}" with no formatter definition`,
-				);
-			}
-		}
-		for (const [filename, policy] of FORMATTER_POLICY_BY_FILENAME) {
-			if (policy.defaultFormatter && !formatterByName.has(policy.defaultFormatter)) {
-				violations.push(
-					`filename policy ${filename} has defaultFormatter "${policy.defaultFormatter}" with no formatter definition`,
-				);
-			}
-		}
-		expect(violations, violations.join("\n")).toEqual([]);
+		expectClean(defaultFormatterEntries, ({ kind, key, defaultFormatter }) => {
+			if (!defaultFormatter || formatterByName.has(defaultFormatter)) return null;
+			return `${kind} policy ${key} has defaultFormatter "${defaultFormatter}" with no formatter definition`;
+		});
 	});
 
 	it("every filename-policy formatterName is a real formatter whose definition claims that filename (terragrunt.hcl class)", () => {
-		const violations: string[] = [];
-		for (const [filename, policy] of FORMATTER_POLICY_BY_FILENAME) {
-			for (const name of policy.formatterNames) {
-				const formatter = formatterByName.get(name);
-				if (!formatter) {
-					violations.push(
-						`filename policy ${filename} names "${name}" but no formatter definition exists with that name`,
-					);
-					continue;
-				}
-				const claimed = (formatter.filenames ?? []).map((f) => f.toLowerCase());
-				if (!claimed.includes(filename.toLowerCase())) {
-					violations.push(
-						`filename policy ${filename} names "${name}" but ${name}'s definition does not claim filename ${filename}`,
-					);
-				}
+		expectClean(filenamePolicyNamePairs, ({ filename, name }) => {
+			const formatter = formatterByName.get(name);
+			if (!formatter) {
+				return `filename policy ${filename} names "${name}" but no formatter definition exists with that name`;
 			}
-		}
-		expect(violations, violations.join("\n")).toEqual([]);
+			const claimed = (formatter.filenames ?? []).map((f) => f.toLowerCase());
+			return claimed.includes(filename.toLowerCase())
+				? null
+				: `filename policy ${filename} names "${name}" but ${name}'s definition does not claim filename ${filename}`;
+		});
 	});
 
 	it("every AUTO_INSTALLABLE_DEFAULT_FORMATTERS key is a real formatter definition (sibling drift, #1086)", () => {
-		// Keys are formatter names consumed by getAutoInstallToolIdForFormatter
-		// (via formatter.name); a rename in formatters.ts that misses this map
-		// silently disables auto-install for that formatter.
-		const violations: string[] = [];
-		for (const name of AUTO_INSTALLABLE_DEFAULT_FORMATTERS.keys()) {
-			if (!formatterByName.has(name)) {
-				violations.push(
-					`AUTO_INSTALLABLE_DEFAULT_FORMATTERS names "${name}" with no formatter definition`,
-				);
+		// Keys are formatter names consumed by getAutoInstallToolIdForFormatter (via
+		// formatter.name); a rename in formatters.ts that misses this map silently
+		// disables auto-install for that formatter.
+		expectClean(AUTO_INSTALLABLE_DEFAULT_FORMATTERS.keys(), (name) =>
+			formatterByName.has(name)
+				? null
+				: `AUTO_INSTALLABLE_DEFAULT_FORMATTERS names "${name}" with no formatter definition`,
+		);
+	});
+
+	it("every DELIBERATE_POLICY_EXCLUSIONS pair is real AND necessary (no decorative exclusions)", () => {
+		// Symmetric to NO_POLICY_FALLBACK_EXTS's minimality guard: an exclusion is
+		// only legitimate if the formatter's definition DOES claim the extension AND
+		// the policy DOES actually gate it out. Otherwise a future author could
+		// silence a genuine "never offered" drift just by adding a decorative pair.
+		expectClean(DELIBERATE_POLICY_EXCLUSIONS, (pair) => {
+			const [name, ext] = pair.split("|");
+			const formatter = formatterByName.get(name);
+			if (!formatter) {
+				return `exclusion "${pair}" names formatter "${name}" which has no definition`;
 			}
-		}
-		expect(violations, violations.join("\n")).toEqual([]);
+			if (!formatter.extensions.includes(ext)) {
+				return `exclusion "${pair}" is decorative: ${name}'s definition does not claim ${ext} (nothing to exclude)`;
+			}
+			const policy = FORMATTER_POLICY_BY_EXTENSION.get(ext);
+			if (!policy) {
+				return `exclusion "${pair}" is decorative: there is no ${ext} policy to exclude ${name} from`;
+			}
+			if (policy.formatterNames.length === 0 || policy.formatterNames.includes(name)) {
+				return `exclusion "${pair}" is unnecessary: the ${ext} policy [${policy.formatterNames.join(", ")}] already offers ${name} — remove the exclusion`;
+			}
+			return null;
+		});
 	});
 
 	it("NO_POLICY_FALLBACK_EXTS lists exactly the definition extensions that lack a policy (keeps the allowlist honest)", () => {
@@ -178,10 +203,8 @@ describe("formatter ↔ policy consistency (#1135)", () => {
 		// to any formatter), this fails so the allowlist can't rot into a blanket
 		// escape hatch.
 		const actualNoPolicy = new Set<string>();
-		for (const formatter of ALL_FORMATTERS) {
-			for (const ext of formatter.extensions) {
-				if (!FORMATTER_POLICY_BY_EXTENSION.has(ext)) actualNoPolicy.add(ext);
-			}
+		for (const { ext } of definitionExtensionPairs) {
+			if (!FORMATTER_POLICY_BY_EXTENSION.has(ext)) actualNoPolicy.add(ext);
 		}
 		expect([...actualNoPolicy].sort()).toEqual([...NO_POLICY_FALLBACK_EXTS].sort());
 	});

--- a/tests/clients/formatter-policy-consistency.test.ts
+++ b/tests/clients/formatter-policy-consistency.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { ALL_FORMATTERS } from "../../clients/formatters.ts";
+import {
+	AUTO_INSTALLABLE_DEFAULT_FORMATTERS,
+	FORMATTER_POLICY_BY_EXTENSION,
+	FORMATTER_POLICY_BY_FILENAME,
+} from "../../clients/tool-policy.ts";
+
+// Bidirectional drift guard binding the two hand-maintained INVERSE mappings of
+// the formatter↔extension relation (#1135, the #883/#209 single-source-of-truth
+// class):
+//   - clients/formatters.ts    : ALL_FORMATTERS[].{extensions,filenames}  (formatter → extensions)
+//   - clients/tool-policy.ts   : FORMATTER_POLICY_BY_EXTENSION            (extension → formatterNames)
+//
+// Without this test the two lists drift silently, in either direction:
+//   (1) a formatter definition gains an extension that a gating policy omits →
+//       the formatter is never OFFERED for that extension (exactly #1134's
+//       oxfmt/.svelte symptom, generalized to every formatter);
+//   (2) a policy names a formatter for an extension the formatter's definition
+//       doesn't claim → a broken option is offered.
+//
+// A structural derive (tool-policy.ts importing ALL_FORMATTERS to build the
+// candidate lists) was rejected: formatters.ts already imports tool-policy.ts,
+// so the reverse edge would create a module import cycle. This test-based guard
+// keeps the dependency one-way while still binding both directions — the test is
+// a leaf that may import both modules with no cycle. See #1135 for the reasoning.
+
+const formatterByName = new Map(ALL_FORMATTERS.map((f) => [f.name, f]));
+const extensionsOf = (name: string): ReadonlySet<string> =>
+	new Set(formatterByName.get(name)?.extensions ?? []);
+
+// DELIBERATE per-extension policy decisions: the formatter's definition declares
+// it CAN handle the extension, but the policy intentionally routes that
+// extension to a different formatter and excludes it. These must stay VISIBLE
+// (an implicit silent gap is the bug this guard exists to prevent). Keyed
+// "formatterName|.ext". Adding a member here is a conscious policy choice.
+const DELIBERATE_POLICY_EXCLUSIONS = new Set<string>([
+	// HTML: prettier (+ oxfmt) own it; biome's HTML formatter is experimental and
+	// intentionally not offered.
+	"biome|.html",
+	"biome|.htm",
+	// Vue SFC: prettier (+ oxfmt) own it; biome only formats <script> blocks.
+	"biome|.vue",
+	// Svelte: oxfmt is the sole svelte formatter by policy (#1134); both biome and
+	// prettier declare .svelte support but are deliberately excluded.
+	"biome|.svelte",
+	"prettier|.svelte",
+]);
+
+// Extensions a formatter definition claims that intentionally have NO
+// FORMATTER_POLICY_BY_EXTENSION entry. For these, getFormattersForFile falls
+// back to the no-policy detect path (all matching formatters become candidates),
+// so nothing is silently dropped. Ruby (rubocop/standardrb) and SQL (sqlfluff)
+// are lint-autofix formatters whose selection is driven by detect(), not a
+// smart-default policy. Any NEW formatter extension that lands without a policy
+// entry must be added here CONSCIOUSLY (or gain a policy) — otherwise this guard
+// fails, forcing the author to decide rather than drift.
+const NO_POLICY_FALLBACK_EXTS = new Set<string>([
+	".sql", // sqlfluff
+	".rb", // rubocop / standardrb
+	".rake", // rubocop / standardrb
+	".gemspec", // rubocop
+	".ru", // rubocop
+]);
+
+describe("formatter ↔ policy consistency (#1135)", () => {
+	it("every formatter definition extension is either policy-included, a documented exclusion, or a documented no-policy fallback (direction 1: no silent drop)", () => {
+		const violations: string[] = [];
+		for (const formatter of ALL_FORMATTERS) {
+			for (const ext of formatter.extensions) {
+				const policy = FORMATTER_POLICY_BY_EXTENSION.get(ext);
+				if (!policy) {
+					// No policy entry → offered via the no-policy fallback path. Must be
+					// a consciously documented fallback extension.
+					if (!NO_POLICY_FALLBACK_EXTS.has(ext)) {
+						violations.push(
+							`${formatter.name} claims ${ext} but there is NO formatter policy for ${ext} and it is not in NO_POLICY_FALLBACK_EXTS (add a policy entry or document the fallback)`,
+						);
+					}
+					continue;
+				}
+				// A policy with a non-empty candidate list GATES selection to those
+				// names. If the formatter isn't among them, the extension is silently
+				// dropped for that formatter — unless it's a deliberate exclusion.
+				if (
+					policy.formatterNames.length > 0 &&
+					!policy.formatterNames.includes(formatter.name) &&
+					!DELIBERATE_POLICY_EXCLUSIONS.has(`${formatter.name}|${ext}`)
+				) {
+					violations.push(
+						`${formatter.name} claims ${ext} but the ${ext} policy [${policy.formatterNames.join(", ")}] excludes it (never offered) — add it to the policy or to DELIBERATE_POLICY_EXCLUSIONS`,
+					);
+				}
+			}
+		}
+		expect(violations, violations.join("\n")).toEqual([]);
+	});
+
+	it("every extension-policy formatterName is a real formatter whose definition claims that extension (direction 2: no broken option)", () => {
+		const violations: string[] = [];
+		for (const [ext, policy] of FORMATTER_POLICY_BY_EXTENSION) {
+			for (const name of policy.formatterNames) {
+				const formatter = formatterByName.get(name);
+				if (!formatter) {
+					violations.push(
+						`policy ${ext} names "${name}" but no formatter definition exists with that name`,
+					);
+					continue;
+				}
+				if (!extensionsOf(name).has(ext)) {
+					violations.push(
+						`policy ${ext} names "${name}" but ${name}'s definition does not claim ${ext} (broken option)`,
+					);
+				}
+			}
+		}
+		expect(violations, violations.join("\n")).toEqual([]);
+	});
+
+	it("every policy defaultFormatter maps to a real formatter definition (extension + filename policies; #1135 comment: terragrunt-hcl)", () => {
+		const violations: string[] = [];
+		for (const [ext, policy] of FORMATTER_POLICY_BY_EXTENSION) {
+			if (policy.defaultFormatter && !formatterByName.has(policy.defaultFormatter)) {
+				violations.push(
+					`extension policy ${ext} has defaultFormatter "${policy.defaultFormatter}" with no formatter definition`,
+				);
+			}
+		}
+		for (const [filename, policy] of FORMATTER_POLICY_BY_FILENAME) {
+			if (policy.defaultFormatter && !formatterByName.has(policy.defaultFormatter)) {
+				violations.push(
+					`filename policy ${filename} has defaultFormatter "${policy.defaultFormatter}" with no formatter definition`,
+				);
+			}
+		}
+		expect(violations, violations.join("\n")).toEqual([]);
+	});
+
+	it("every filename-policy formatterName is a real formatter whose definition claims that filename (terragrunt.hcl class)", () => {
+		const violations: string[] = [];
+		for (const [filename, policy] of FORMATTER_POLICY_BY_FILENAME) {
+			for (const name of policy.formatterNames) {
+				const formatter = formatterByName.get(name);
+				if (!formatter) {
+					violations.push(
+						`filename policy ${filename} names "${name}" but no formatter definition exists with that name`,
+					);
+					continue;
+				}
+				const claimed = (formatter.filenames ?? []).map((f) => f.toLowerCase());
+				if (!claimed.includes(filename.toLowerCase())) {
+					violations.push(
+						`filename policy ${filename} names "${name}" but ${name}'s definition does not claim filename ${filename}`,
+					);
+				}
+			}
+		}
+		expect(violations, violations.join("\n")).toEqual([]);
+	});
+
+	it("every AUTO_INSTALLABLE_DEFAULT_FORMATTERS key is a real formatter definition (sibling drift, #1086)", () => {
+		// Keys are formatter names consumed by getAutoInstallToolIdForFormatter
+		// (via formatter.name); a rename in formatters.ts that misses this map
+		// silently disables auto-install for that formatter.
+		const violations: string[] = [];
+		for (const name of AUTO_INSTALLABLE_DEFAULT_FORMATTERS.keys()) {
+			if (!formatterByName.has(name)) {
+				violations.push(
+					`AUTO_INSTALLABLE_DEFAULT_FORMATTERS names "${name}" with no formatter definition`,
+				);
+			}
+		}
+		expect(violations, violations.join("\n")).toEqual([]);
+	});
+
+	it("NO_POLICY_FALLBACK_EXTS lists exactly the definition extensions that lack a policy (keeps the allowlist honest)", () => {
+		// If a fallback extension GAINS a policy (or a listed ext no longer belongs
+		// to any formatter), this fails so the allowlist can't rot into a blanket
+		// escape hatch.
+		const actualNoPolicy = new Set<string>();
+		for (const formatter of ALL_FORMATTERS) {
+			for (const ext of formatter.extensions) {
+				if (!FORMATTER_POLICY_BY_EXTENSION.has(ext)) actualNoPolicy.add(ext);
+			}
+		}
+		expect([...actualNoPolicy].sort()).toEqual([...NO_POLICY_FALLBACK_EXTS].sort());
+	});
+});


### PR DESCRIPTION
## What
`clients/formatters.ts` (formatter → `extensions[]`) and `clients/tool-policy.ts`'s `FORMATTER_POLICY_BY_EXTENSION` (extension → `formatterNames[]`) were hand-maintained INVERSE maps with NO drift guard — the general shape under #1134's oxfmt-svelte gap. Two silent failure modes: a definition gains an extension the policy lacks (formatter never offered — #1134's symptom), or a policy names a formatter its definition doesn't claim (broken option offered).

## Guard (the #883/#209 single-source-of-truth pattern)
New `tests/clients/formatter-policy-consistency.test.ts` (7 tests) imports the REAL `ALL_FORMATTERS` + the REAL policy maps (now `export`ed) and asserts BOTH directions:
- every definition extension is policy-included, a documented `DELIBERATE_POLICY_EXCLUSIONS`, or a documented `NO_POLICY_FALLBACK_EXTS`;
- every policy `formatterName`/`defaultFormatter` (extension AND filename policies) resolves to a real formatter that claims that extension/filename;
- `AUTO_INSTALLABLE_DEFAULT_FORMATTERS` keys bind to real formatters; the no-policy allowlist can't rot into a blanket escape hatch.
Proven to FAIL on injected drift (added `.py`/`.fakeext` to a definition → precise failures), reverted.

## Two REAL drifts found + fixed (both inert today, both behavior-identical)
- **`.sass` policy listed `oxfmt`** though oxfmt doesn't support the indented `.sass` syntax (absent from `OXFMT_SUPPORTED_EXTENSIONS`). Inert (`matching` already filtered it) — removed.
- **`.fish` policy named `fish-indent`**, which has no `FormatterInfo` (it's a lint runner) — a dead entry (`getFormattersForFile` always returned `[]` for `.fish`). Removed; fish reformat runs via the linter/autofix path. No test asserts `.sass`/`.fish` formatter selection → confirmed behavior-identical (135 formatter-selection tests pass unchanged).

## Structural-derive: rejected (import cycle)
Deriving the policy lists from the definitions would need `tool-policy.ts` to import `ALL_FORMATTERS`, but `formatters.ts` ALREADY imports `tool-policy.ts` → a cycle. Kept the production dep one-way; the test (a leaf) binds both directions.

## Sibling sweep (#1086 class)
Swept per-tool extension registries: oxfmt/terragrunt bound-already; defaultFormatter + auto-installable maps → guard added; linter/autofix/tool-id policies genuinely-independent; `KIND_EXTENSIONS.jsts` linter-ext P2 left tracked in #1086 (stays open).

Runtime change is only 4 `export`s (`ALL_FORMATTERS` + three policy maps) + trimming two inert map entries; guard lives entirely in the test (no hot-path cost). `closes #1135` (refs #1086 #1134 #883).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
