### PR TITLE
fix(lsp,dispatch): convert cold-start sync readdir blocks to async (refs #1137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Windows drive-root & autofix-snapshot `readdirSync` blocked the event loop on slow cloud-backed dirs (refs #1137)** —
+	the genuine synchronous event-loop-block tier from #1122 (the 1.6–10.6 s
+	single-process blocks in `latency.log`, distinct from the machine-level
+	Modern-Standby/commit-exhaustion artifacts dispositioned in #1122 and tagged
+	`suspectSystemStall` by #1125). On a OneDrive/network-backed path a stalled
+	synchronous directory read blocks the Node loop — and pi's TUI — for the whole
+	stall. Converted the two clearly-live-path, low-risk offenders: (a) the Windows
+	Ruby drive-root enumeration (`readdirSync(driveRoot)` scanning `C:\` for
+	`ruby<N>` installer dirs), previously re-run **synchronously on every LSP spawn**
+	in `buildAugmentedPath` (PATH build) and on every Ruby candidate build in
+	`rubyBinCandidates` — now a shared `clients/lsp/ruby-drive-dirs.ts` module that
+	**memoizes** the result once per process (O(1) amortized) and reads the drive
+	root **off the loop** via `fs.promises.readdir` on the hot spawn path; and
+	(b) the `tool_result` autofix side-effect snapshot walk (`snapshotDirInto`,
+	`clients/pipeline.ts`), whose per-directory `readdirSync`/`statSync` are now
+	`fs.promises.readdir`/`stat` (the walk was already async + chunk-yielding, but
+	each synchronous per-dir read still blocked on a cloud stall). Same outputs,
+	just non-blocking. `measureMaxSyncBlockMs` occupancy guards assert the converted
+	drive-root path no longer holds the loop and fail against the pre-conversion
+	sync shape. Remaining suspect sites (the shared `walkTreeStackAsync` per-dir
+	read in `clients/source-walker.ts`; `hasProjectMarker`/`expandWorkspacePattern`
+	deep in sync memoized/bounded chains; the `safe-spawn.ts` Windows `spawnSync`
+	teardown/cached paths) are deferred as scoped follow-ups on #1137 — each ripples
+	into a widely-called sync API or subprocess-teardown correctness.
 - **Quick-mode background warmup kept a one-shot `pi -p`/`--print` process alive (closes #1154)** —
 	`handleSessionStart` forces **quick mode** for both a real `pi -p`/`--print`
 	one-shot AND an interactive process's first session (to protect keystroke

--- a/clients/lsp/launch.ts
+++ b/clients/lsp/launch.ts
@@ -20,6 +20,7 @@ import { isTestMode } from "../env-utils.js";
 import { getGlobalPiLensDir } from "../file-utils.js";
 import { findGlobalBinary } from "../package-manager.js";
 import { redactSecrets } from "../redact/secrets.js";
+import { getRubyVersionDirNamesAsync } from "./ruby-drive-dirs.js";
 
 export interface LSPProcess {
 	process: ChildProcess;
@@ -157,7 +158,7 @@ function getLiveWindowsPath(): string {
 	return _liveWindowsPath;
 }
 
-function buildAugmentedPath(basePath?: string): string {
+async function buildAugmentedPath(basePath?: string): Promise<string> {
 	const candidates: string[] = [];
 	const nodeDir = path.dirname(process.execPath);
 	if (nodeDir) {
@@ -174,15 +175,12 @@ function buildAugmentedPath(basePath?: string): string {
 		candidates.push(PI_LENS_TOOLS_BIN_DIR);
 		candidates.push(path.join(driveRoot, "Program Files", "Go", "bin"));
 		candidates.push(path.join(driveRoot, "Go", "bin"));
-		// Ruby installer drops versioned dirs (e.g. Ruby34-x64) on the drive root — scan dynamically
-		try {
-			for (const entry of fs.readdirSync(driveRoot)) {
-				if (/^ruby\d/i.test(entry)) {
-					candidates.push(path.join(driveRoot, entry, "bin"));
-				}
-			}
-		} catch {
-			// drive root not readable — skip
+		// Ruby installer drops versioned dirs (e.g. Ruby34-x64) on the drive root.
+		// Read off the event loop and memoized once per process (#1137): a
+		// synchronous drive-root enumeration on every LSP spawn blocked the loop
+		// for the whole stall on a slow cloud/network-backed drive root.
+		for (const entry of await getRubyVersionDirNamesAsync(driveRoot)) {
+			candidates.push(path.join(driveRoot, entry, "bin"));
 		}
 	}
 
@@ -497,7 +495,7 @@ export async function launchLSP(
 ): Promise<LSPProcess> {
 	const cwd = String(options.cwd ?? process.cwd());
 	const mergedEnv = { ...process.env, ...options.env };
-	const augmentedPath = buildAugmentedPath(resolvePathValue(mergedEnv));
+	const augmentedPath = await buildAugmentedPath(resolvePathValue(mergedEnv));
 	const env: NodeJS.ProcessEnv = {
 		...mergedEnv,
 		PATH: augmentedPath,

--- a/clients/lsp/ruby-drive-dirs.ts
+++ b/clients/lsp/ruby-drive-dirs.ts
@@ -1,0 +1,81 @@
+/**
+ * Windows Ruby-installer drive-root version-dir discovery (refs #1137).
+ *
+ * The Ruby installer drops versioned directories (e.g. `Ruby34-x64`) directly
+ * at a drive root, and the drive and version suffix vary — so both the LSP
+ * candidate builder (`rubyBinCandidates`) and the spawn PATH augmenter
+ * (`buildAugmentedPath`) scan the drive root for `ruby<N>...` directories.
+ *
+ * Enumerating a drive root **synchronously on every LSP spawn** was a genuine
+ * #1137 event-loop offender: a stalled cloud/network-backed drive-root
+ * `readdirSync` blocks the Node loop (and pi's TUI) for the entire stall. This
+ * module makes that enumeration:
+ *   1. **O(1) amortized** — the matching directory names are memoized for the
+ *      process (the set is static for a session; the previous inline code
+ *      equally required a restart to notice a new Ruby install on PATH), and
+ *   2. **non-blocking on the hot path** — `buildAugmentedPath` (called on every
+ *      spawn) reads the drive root via `fs.promises.readdir` off the loop.
+ *
+ * Both readers share ONE cache keyed by `driveRoot`, so at most one drive-root
+ * read happens per drive per process regardless of which reader runs first.
+ * Callers derive their own paths from the returned directory NAMES (the two
+ * readers build different suffixes: `bin/<tool>` vs `bin`), so only the raw
+ * `ruby<N>` names are cached.
+ */
+
+import * as fs from "node:fs";
+
+/** Matches the Ruby installer's `Ruby34-x64`, `ruby3.3`, … drive-root dirs. */
+const RUBY_VERSION_DIR = /^ruby\d/i;
+
+/** Process-lifetime memo of matching dir names, keyed by drive root (e.g. `C:\`). */
+const rubyDirNamesCache = new Map<string, string[]>();
+
+function filterRubyDirNames(entries: string[]): string[] {
+	return entries.filter((name) => RUBY_VERSION_DIR.test(name));
+}
+
+/**
+ * Memoized **synchronous** enumeration for sync callers (`rubyBinCandidates`).
+ * First call reads the drive root once (fail-open to `[]` on an unreadable
+ * root); every later call is a cache hit. If an async caller populated the
+ * cache first, this returns that result with no drive-root read at all.
+ */
+export function getRubyVersionDirNamesSync(driveRoot: string): string[] {
+	const cached = rubyDirNamesCache.get(driveRoot);
+	if (cached !== undefined) return cached;
+	let names: string[];
+	try {
+		names = filterRubyDirNames(fs.readdirSync(driveRoot));
+	} catch {
+		names = [];
+	}
+	rubyDirNamesCache.set(driveRoot, names);
+	return names;
+}
+
+/**
+ * Memoized **async** twin for the hot spawn path (`buildAugmentedPath`) — reads
+ * the drive root via `fs.promises.readdir` so a slow/stalled cloud-backed drive
+ * root never blocks the event loop. Shares the same process cache as the sync
+ * reader (identical content, so a benign sync/async populate race is fine).
+ */
+export async function getRubyVersionDirNamesAsync(
+	driveRoot: string,
+): Promise<string[]> {
+	const cached = rubyDirNamesCache.get(driveRoot);
+	if (cached !== undefined) return cached;
+	let names: string[];
+	try {
+		names = filterRubyDirNames(await fs.promises.readdir(driveRoot));
+	} catch {
+		names = [];
+	}
+	rubyDirNamesCache.set(driveRoot, names);
+	return names;
+}
+
+/** Test-only: clear the process memo so each case starts cold. */
+export function __resetRubyDriveDirsCacheForTest(): void {
+	rubyDirNamesCache.clear();
+}

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -7,7 +7,7 @@
  * - Platform-specific handling
  */
 
-import { existsSync, mkdirSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import {
 	access,
 	readFile,
@@ -44,6 +44,7 @@ import { type LSPProcess, launchLSP } from "./launch.js";
 import { createLombokJdtlsArgs } from "./lombok.js";
 import { resolveJavaRuntimeEnv } from "./jvm-runtime.js";
 import { normalizeMapKey } from "./path-utils.js";
+import { getRubyVersionDirNamesSync } from "./ruby-drive-dirs.js";
 
 // --- Types ---
 
@@ -683,20 +684,13 @@ function rubyBinCandidates(baseName: string): string[] {
 
 	if (isWin) {
 		// Ruby installer drops versioned dirs on C: by convention, but the drive
-		// and version suffix vary — scan what's actually present instead of hardcoding
+		// and version suffix vary — scan what's actually present instead of
+		// hardcoding. Memoized once per process (#1137): a synchronous drive-root
+		// enumeration per LSP spawn was an event-loop offender.
 		const driveRoot = path.parse(home).root; // e.g. "C:\"
-		try {
-			const entries = readdirSync(driveRoot);
-			for (const entry of entries) {
-				if (/^ruby\d/i.test(entry)) {
-					candidates.push(
-						path.join(driveRoot, entry, "bin", `${baseName}.bat`),
-					);
-					candidates.push(path.join(driveRoot, entry, "bin", baseName));
-				}
-			}
-		} catch {
-			// drive root not readable — skip
+		for (const entry of getRubyVersionDirNamesSync(driveRoot)) {
+			candidates.push(path.join(driveRoot, entry, "bin", `${baseName}.bat`));
+			candidates.push(path.join(driveRoot, entry, "bin", baseName));
 		}
 	}
 

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -122,7 +122,10 @@ async function snapshotDirInto(
 ): Promise<void> {
 	let entries: nodeFs.Dirent[];
 	try {
-		entries = nodeFs.readdirSync(dir, { withFileTypes: true });
+		// Async (#1137): a synchronous per-directory read blocks the loop for the
+		// whole stall on a slow cloud-backed (OneDrive) directory; fs.promises
+		// keeps this tool_result-path walk off the event loop.
+		entries = await nodeFs.promises.readdir(dir, { withFileTypes: true });
 	} catch {
 		return;
 	}
@@ -140,7 +143,7 @@ async function snapshotDirInto(
 		if (!entry.isFile()) continue;
 		if (ignoreMatcher.isIgnored(fullPath, false)) continue;
 		try {
-			const stat = nodeFs.statSync(fullPath);
+			const stat = await nodeFs.promises.stat(fullPath);
 			snapshot.set(path.resolve(fullPath), {
 				mtimeMs: stat.mtimeMs,
 				size: stat.size,

--- a/tests/clients/lsp/launch.test.ts
+++ b/tests/clients/lsp/launch.test.ts
@@ -5,6 +5,16 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { removeTempDirSync } from "../test-utils.js";
 
+// These launch tests use fake timers and don't exercise Windows Ruby drive-root
+// discovery. Stub the #1137 drive-root readers so `buildAugmentedPath`'s async
+// `fs.promises.readdir("C:\\")` (real threadpool I/O, not fake-timer driven)
+// can't stall the spawn sequence under `vi.useFakeTimers()`. Ruby-dir behavior
+// is covered by tests/clients/lsp/ruby-drive-dirs.test.ts.
+vi.mock("../../../clients/lsp/ruby-drive-dirs.js", () => ({
+	getRubyVersionDirNamesSync: () => [],
+	getRubyVersionDirNamesAsync: async () => [],
+}));
+
 describe("lsp launch", () => {
 	afterEach(() => {
 		vi.useRealTimers();

--- a/tests/clients/lsp/ruby-drive-dirs.test.ts
+++ b/tests/clients/lsp/ruby-drive-dirs.test.ts
@@ -1,0 +1,146 @@
+/**
+ * #1137 — the Windows Ruby drive-root enumeration was a synchronous
+ * `readdirSync(driveRoot)` run on every LSP spawn (`buildAugmentedPath`) and
+ * every Ruby candidate build (`rubyBinCandidates`). On a slow cloud/network
+ * backed drive root that blocks the Node event loop (and pi's TUI) for the
+ * whole stall.
+ *
+ * These tests pin the two guarantees of the fix:
+ *   1. **O(1) amortized** — the drive root is read at most once per process
+ *      (memoized), across any mix of the sync and async readers.
+ *   2. **Non-blocking hot path** — the async reader does NOT hold the event
+ *      loop while the drive-root read is in flight, whereas the sync reader
+ *      (the pre-fix code shape) does. This is the occupancy fail-then-pass
+ *      screen: same injected drive-root latency, sync blocks, async doesn't.
+ */
+
+import * as fs from "node:fs";
+import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
+
+// `vi.spyOn(fs, "readdirSync"/"promises")` cannot redefine node:fs's ESM
+// namespace exports directly, so wrap the module via vi.mock — keeps the real
+// implementations (importOriginal) but makes readdirSync and promises.readdir
+// individually mockable so tests can assert call counts and inject latency.
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		readdirSync: vi.fn(actual.readdirSync),
+		promises: { ...actual.promises, readdir: vi.fn(actual.promises.readdir) },
+	};
+});
+
+import {
+	__resetRubyDriveDirsCacheForTest,
+	getRubyVersionDirNamesAsync,
+	getRubyVersionDirNamesSync,
+} from "../../../clients/lsp/ruby-drive-dirs.js";
+import { measureMaxSyncBlockMs } from "../../support/perf-harness.js";
+
+const DRIVE = "C:\\";
+const ENTRIES = ["Ruby34-x64", "ruby3.3", "Program Files", "Windows", "temp"];
+const EXPECTED = ["Ruby34-x64", "ruby3.3"];
+
+// `readdirSync(driveRoot)` / `promises.readdir(driveRoot)` (no options) return
+// `string[]`; cast the mocks loosely so tests can drive them without fighting
+// node:fs's overloaded signatures.
+const readdirSyncMock = vi.mocked(fs.readdirSync) as unknown as Mock;
+const readdirAsyncMock = vi.mocked(fs.promises.readdir) as unknown as Mock;
+
+afterEach(() => {
+	__resetRubyDriveDirsCacheForTest();
+	readdirSyncMock.mockReset();
+	readdirAsyncMock.mockReset();
+});
+
+describe("ruby drive-root enumeration (#1137)", () => {
+	it("sync reader filters to ruby version dirs and memoizes the drive-root read", () => {
+		readdirSyncMock.mockReturnValue(ENTRIES);
+
+		expect(getRubyVersionDirNamesSync(DRIVE)).toEqual(EXPECTED);
+		expect(getRubyVersionDirNamesSync(DRIVE)).toEqual(EXPECTED);
+		expect(getRubyVersionDirNamesSync(DRIVE)).toEqual(EXPECTED);
+		// Memoized: the drive root is read exactly once despite three calls.
+		expect(readdirSyncMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("async reader filters and memoizes the drive-root read", async () => {
+		readdirAsyncMock.mockResolvedValue(ENTRIES);
+
+		await expect(getRubyVersionDirNamesAsync(DRIVE)).resolves.toEqual(EXPECTED);
+		await expect(getRubyVersionDirNamesAsync(DRIVE)).resolves.toEqual(EXPECTED);
+		expect(readdirAsyncMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("async populate satisfies later sync reads with no drive-root readdirSync", async () => {
+		readdirAsyncMock.mockResolvedValue(ENTRIES);
+
+		await getRubyVersionDirNamesAsync(DRIVE);
+		// The hot spawn path warmed the shared cache; the sync reader is a hit.
+		expect(getRubyVersionDirNamesSync(DRIVE)).toEqual(EXPECTED);
+		expect(readdirAsyncMock).toHaveBeenCalledTimes(1);
+		expect(readdirSyncMock).not.toHaveBeenCalled();
+	});
+
+	it("fails open to [] on an unreadable drive root (both readers)", async () => {
+		readdirSyncMock.mockImplementation(() => {
+			throw new Error("EPERM");
+		});
+		readdirAsyncMock.mockRejectedValue(new Error("EPERM"));
+
+		expect(getRubyVersionDirNamesSync(DRIVE)).toEqual([]);
+		__resetRubyDriveDirsCacheForTest();
+		await expect(getRubyVersionDirNamesAsync(DRIVE)).resolves.toEqual([]);
+	});
+
+	// Occupancy fail-then-pass screen (#902 measureMaxSyncBlockMs pattern).
+	// Same ~120ms drive-root latency injected two ways: a busy-loop inside
+	// readdirSync models the pre-fix synchronous enumeration (which blocks the
+	// loop), and a timer-delayed promises.readdir models the converted async
+	// path (which yields). The sync path MUST block; the async path MUST NOT.
+	const INJECTED_LATENCY_MS = 120;
+
+	it("sync enumeration BLOCKS the event loop for the drive-root latency (pre-fix shape)", async () => {
+		readdirSyncMock.mockImplementation(() => {
+			const until = Date.now() + INJECTED_LATENCY_MS;
+			while (Date.now() < until) {
+				/* busy-wait: a stalled synchronous drive-root read */
+			}
+			return ENTRIES;
+		});
+
+		const block = await measureMaxSyncBlockMs(async () => {
+			getRubyVersionDirNamesSync(DRIVE);
+		});
+		// The pre-fix sync enumeration holds the loop for essentially the whole
+		// stall — this is the regression the async conversion removes.
+		expect(block).toBeGreaterThan(INJECTED_LATENCY_MS * 0.6);
+	});
+
+	it("async enumeration does NOT block the event loop for the same latency (converted path)", async () => {
+		// Inject the SAME latency into BOTH APIs so this guard also catches a
+		// regression back to a synchronous drive-root read: the async path hits
+		// the (non-blocking) timer, but a revert to readdirSync would hit the
+		// busy-loop and blow the budget.
+		readdirSyncMock.mockImplementation(() => {
+			const until = Date.now() + INJECTED_LATENCY_MS;
+			while (Date.now() < until) {
+				/* busy-wait: a stalled synchronous drive-root read */
+			}
+			return ENTRIES;
+		});
+		readdirAsyncMock.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					setTimeout(() => resolve(ENTRIES), INJECTED_LATENCY_MS);
+				}),
+		);
+
+		const block = await measureMaxSyncBlockMs(async () => {
+			await getRubyVersionDirNamesAsync(DRIVE);
+		});
+		// The converted path awaits the drive-root read off the loop: the longest
+		// synchronous stretch is a tiny fraction of the injected latency.
+		expect(block).toBeLessThan(INJECTED_LATENCY_MS * 0.5);
+	});
+});


### PR DESCRIPTION
## What
Genuine sync event-loop-block tier from #1122 (#1137). **Measure-first** on real `~/.pi-lens/latency.log` (+ rotated): 48 loop_block records; the multi-million-ms entries are the OS-freeze/Modern-Standby class (excluded, would be `suspectSystemStall` under #1125); the genuine sub-20s tier (17197…767ms) clusters at **low `turnIndex` (1,2,3,8,11)** = cold-start/spawn-time. That points at the issue's LSP-spawn `readdirSync(driveRoot)` suspect, so that was prioritized.

## Converted
- **Windows Ruby drive-root enumeration** — `clients/lsp/server.ts:689` (`rubyBinCandidates`) and `clients/lsp/launch.ts:179` (`buildAugmentedPath`, runs on EVERY LSP spawn to build the child PATH). New shared `clients/lsp/ruby-drive-dirs.ts` memoizes the `ruby<N>` dir names once per process (O(1) amortized), with a sync reader (for the sync candidate builder) and an async reader (`fs.promises.readdir`) sharing one cache. `buildAugmentedPath` is now `async` (reads the drive root off the loop); `launchLSP` awaits it. Identical outputs.
- **tool_result autofix snapshot walk** — `clients/pipeline.ts` `snapshotDirInto`: per-dir `readdirSync`/`statSync` → `fs.promises.*`. Walk was already async+chunk-yielding (#368); each per-dir sync read still blocked on a cloud stall — now non-blocking. Same snapshot contents.

## Occupancy proof (fail-then-pass)
`tests/clients/lsp/ruby-drive-dirs.test.ts` (repo `measureMaxSyncBlockMs` harness): 120ms injected drive-root latency — converted path PASSES (loop free), reverting the helper to `readdirSync` FAILS (`120.26 > 60`). Also guards regression-to-sync.

## Shape screens
- Shape 4: no timer/Worker added — only an awaited `fs.promises.readdir`; nothing to unref.
- Shape 1: memo keyed by canonical `driveRoot` (`path.parse(home).root`), derived identically in both callers.
- Shape 6: process-lifetime memo won't see a mid-session Ruby install — intentional (matches repo's cache-once convention + the already-cached `getLiveWindowsPath` read in the same function); documented in the module header.
- #615 both-bounds: the pipeline awaits replace like-for-like sync syscalls (no new hang class; existing count-bound + chunk-yield retained). Did NOT add a half-#615 deadline/abort; flagged as optional follow-up.

## Deferred (kept open, `refs #1137`)
`source-walker.ts walkTreeStackAsync` (sync-generator, needs two-way-generator refactor), `language-profile.ts`/`workspace-modules.ts` (memoized/bounded, ripples through sync APIs), `safe-spawn.ts` Windows `spawnSync` (teardown/one-time/cached). `refs #1137` — issue stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)