### PR TITLE
fix(project-intelligence): add size second-axis to .pi-lens.json config caches — mtime-freshness class sweep (closes #1105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Config caches gated freshness on mtime alone — the mtime-only cache-freshness class sweep (closes #1105)** —
+	Completed the shape-6 (freshness stamp that doesn't cover the data's real
+	dependency) sweep the #1092→#1119 diagnostics/word-index arc deferred. Audited
+	every persisted/derived cache with an mtime/TTL key: word-index (#1119),
+	`rule-cache.ts` (`mtime:size`), `sgconfig.ts` (content-hashed), the
+	`yaml-rule-parser` project/bundled split (project rules content-hashed via
+	`loadYamlRulesFresh`, bundled dir-mtime is safe by process-lifetime
+	immutability), `reverse-deps` (snapshot-seq/generation-coupled), installer
+	`probe-cache` (existence re-validated every read + ast-grep version-family
+	verify — mtime is a refresh hint, not the correctness gate), `TreeCache`
+	(content-hash authoritative, #890), and the project-snapshot per-file
+	`mtime:size` entries — all already-hardened or safe. The one gap: the
+	`.pi-lens.json` config caches (`loadPiLensProjectConfig`/`loadPiLensConfigInDir`
+	in `clients/project-lens-config.ts`, and the ignore-matcher cache in
+	`clients/file-utils.ts`) gated reuse on the config file's **mtime alone**, so an
+	in-place edit that preserved mtime (git checkout timestamp restoration, a
+	same-second rewrite) but changed the file's byte length replayed a stale parsed
+	config / ignore matcher — a config that drives mutation, ignore, and rule
+	policy. Fixed by adding **`size` as the free second axis** of the review-graph
+	`size:mtimeMs` signature (threaded through `PiLensConfigMarker` in
+	`clients/workspace-topology.ts` — the same stat that yields mtime already reads
+	size, so the cheap hit path stays cheap, no content hashing on the hot path).
+	The residual (identical mtime AND identical size, changed content) matches the
+	review-graph/word-index accepted residual by design. Fail-then-pass regression
+	tests cover both cache gates (each proven to replay stale on the pre-fix
+	mtime-only code); FS-agnostic (mtime pinned via `utimesSync`, size varied by
+	content length) so they exercise the gate identically on Linux CI.
+
 - **Quick-mode background warmup kept a one-shot `pi -p`/`--print` process alive (closes #1154)** —
 	`handleSessionStart` forces **quick mode** for both a real `pi -p`/`--print`
 	one-shot AND an interactive process's first session (to protect keystroke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,21 +22,29 @@ All notable changes to pi-lens will be documented in this file.
 	verify — mtime is a refresh hint, not the correctness gate), `TreeCache`
 	(content-hash authoritative, #890), and the project-snapshot per-file
 	`mtime:size` entries — all already-hardened or safe. The one gap: the
-	`.pi-lens.json` config caches (`loadPiLensProjectConfig`/`loadPiLensConfigInDir`
-	in `clients/project-lens-config.ts`, and the ignore-matcher cache in
-	`clients/file-utils.ts`) gated reuse on the config file's **mtime alone**, so an
-	in-place edit that preserved mtime (git checkout timestamp restoration, a
+	`.pi-lens.json` config caches gated reuse on the config file's **mtime alone**,
+	so an in-place edit that preserved mtime (git checkout timestamp restoration, a
 	same-second rewrite) but changed the file's byte length replayed a stale parsed
 	config / ignore matcher — a config that drives mutation, ignore, and rule
-	policy. Fixed by adding **`size` as the free second axis** of the review-graph
-	`size:mtimeMs` signature (threaded through `PiLensConfigMarker` in
-	`clients/workspace-topology.ts` — the same stat that yields mtime already reads
-	size, so the cheap hit path stays cheap, no content hashing on the hot path).
-	The residual (identical mtime AND identical size, changed content) matches the
-	review-graph/word-index accepted residual by design. Fail-then-pass regression
-	tests cover both cache gates (each proven to replay stale on the pre-fix
-	mtime-only code); FS-agnostic (mtime pinned via `utimesSync`, size varied by
-	content length) so they exercise the gate identically on Linux CI.
+	policy. This spanned every freshness gate in the two files: the root parsed-
+	config caches (`loadPiLensProjectConfig`/`loadPiLensConfigInDir` in
+	`clients/project-lens-config.ts`), the root ignore-matcher cache, and — the
+	member found in adversarial review — the **nested `.pi-lens.json`/`.gitignore`
+	layering cache** (`patternsForDir`, #783) in `clients/file-utils.ts`, which
+	short-circuits AHEAD of the root caches so a preserved-mtime, length-changing
+	edit to a NESTED config replayed stale patterns for that subtree. Fixed by
+	adding **`size` as the free second axis** of the review-graph `size:mtimeMs`
+	signature to every gate — the root `.pi-lens.json` (threaded through
+	`PiLensConfigMarker` in `clients/workspace-topology.ts`), the root `.gitignore`
+	and global `~/.pi-lens/config.json` (via a shared `fileFreshnessSignature`
+	helper), and both the nested `.pi-lens.json` and nested `.gitignore` axes. The
+	same stat that yields mtime already reads size, so the cheap hit path stays
+	cheap (no content hashing on the hot path). The residual (identical mtime AND
+	identical size, changed content) matches the review-graph/word-index accepted
+	residual by design. Fail-then-pass regression tests cover the root and nested
+	gates (each proven to replay stale on the pre-fix mtime-only code); FS-agnostic
+	(mtime pinned via `utimesSync`, size varied by content length) so they exercise
+	the gates identically on Linux CI.
 
 - **Windows drive-root & autofix-snapshot `readdirSync` blocked the event loop on slow cloud-backed dirs (refs #1137)** —
 	the genuine synchronous event-loop-block tier from #1122 (the 1.6–10.6 s

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -375,8 +375,8 @@ function buildProjectIgnoreMatcher(
 	};
 
 	// Per-matcher path → pattern-verdict memo. The matcher itself is cached by
-	// `getProjectIgnoreMatcher` keyed on `.gitignore` mtime, so this Map's
-	// lifetime is bounded to a single set of ignore rules — when any
+	// `getProjectIgnoreMatcher` keyed on `.gitignore` size+mtime (#1105), so this
+	// Map's lifetime is bounded to a single set of ignore rules — when any
 	// `.gitignore` changes, the matcher is rebuilt and the memo is dropped
 	// with it. Without this memo, every background scan (comment scan, knip,
 	// jscpd, call-graph, source-filter, pipeline) recomputes O(ancestorDirs ×

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -500,6 +500,11 @@ const projectIgnoreMatcherCache = new Map<
 		gitignoreMtimeMs: number;
 		lensConfigPath: string | undefined;
 		lensConfigMtimeMs: number;
+		/** #1105 second axis: an mtime-preserving, length-changing config edit
+		 * (git checkout, same-second rewrite) must invalidate the ignore matcher
+		 * too, not just `loadPiLensProjectConfig`'s own cache. Size is free from the
+		 * stat that already produced `lensConfigMtimeMs`. */
+		lensConfigSize: number;
 		globalConfigMtimeMs: number;
 		matcher: ProjectIgnoreMatcher;
 	}
@@ -536,11 +541,12 @@ function lensConfigInfo(rootDir: string): {
 	info: ReturnType<typeof findPiLensProjectConfig>;
 	path: string | undefined;
 	mtimeMs: number;
+	size: number;
 } {
 	const info = findPiLensProjectConfig(rootDir);
 	return info
-		? { info, path: info.path, mtimeMs: info.mtimeMs }
-		: { info, path: undefined, mtimeMs: -1 };
+		? { info, path: info.path, mtimeMs: info.mtimeMs, size: info.size }
+		: { info, path: undefined, mtimeMs: -1, size: -1 };
 }
 
 export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
@@ -553,6 +559,7 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 		cached?.gitignoreMtimeMs === gitignoreMtime &&
 		cached?.lensConfigPath === lensConfig.path &&
 		cached?.lensConfigMtimeMs === lensConfig.mtimeMs &&
+		cached?.lensConfigSize === lensConfig.size &&
 		cached?.globalConfigMtimeMs === globalMtime
 	) {
 		return cached.matcher;
@@ -572,6 +579,7 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 		gitignoreMtimeMs: gitignoreMtime,
 		lensConfigPath: lensConfig.path,
 		lensConfigMtimeMs: lensConfig.mtimeMs,
+		lensConfigSize: lensConfig.size,
 		globalConfigMtimeMs: globalMtime,
 		matcher,
 	});

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -324,7 +324,9 @@ function buildProjectIgnoreMatcher(
 		string,
 		{
 			gitignoreMtimeMs: number;
+			gitignoreSize: number;
 			pilensMtimeMs: number;
+			pilensSize: number;
 			patterns: GitignorePattern[];
 		}
 	>();
@@ -340,12 +342,20 @@ function buildProjectIgnoreMatcher(
 	// caller (or the root-config lookup above) already loaded.
 	const patternsForDir = (dir: string): GitignorePattern[] => {
 		if (dir === resolvedRoot) return patterns;
-		const gitignoreMtime = gitignoreMtimeMs(dir);
-		const pilensMtime = findPiLensConfigInDir(dir)?.mtimeMs ?? -1;
+		const gitignoreSig = gitignoreSignature(dir);
+		// #1105: gate on size too. `findPiLensConfigInDir` returns `size` alongside
+		// `mtimeMs` (both from one stat), and `gitignoreSignature` reads both for
+		// the nested `.gitignore`, so an mtime-preserving, length-changing edit to
+		// EITHER nested source can no longer replay stale patterns for this subtree.
+		const pilensInfo = findPiLensConfigInDir(dir);
+		const pilensMtime = pilensInfo?.mtimeMs ?? -1;
+		const pilensSize = pilensInfo?.size ?? -1;
 		const cached = nestedCache.get(dir);
 		if (
-			cached?.gitignoreMtimeMs === gitignoreMtime &&
-			cached?.pilensMtimeMs === pilensMtime
+			cached?.gitignoreMtimeMs === gitignoreSig.mtimeMs &&
+			cached?.gitignoreSize === gitignoreSig.size &&
+			cached?.pilensMtimeMs === pilensMtime &&
+			cached?.pilensSize === pilensSize
 		) {
 			return cached.patterns;
 		}
@@ -355,8 +365,10 @@ function buildProjectIgnoreMatcher(
 			...parseGitignoreContent(nestedConfig.ignore.join("\n"), "pilens"),
 		];
 		nestedCache.set(dir, {
-			gitignoreMtimeMs: gitignoreMtime,
+			gitignoreMtimeMs: gitignoreSig.mtimeMs,
+			gitignoreSize: gitignoreSig.size,
 			pilensMtimeMs: pilensMtime,
+			pilensSize: pilensSize,
 			patterns: nextPatterns,
 		});
 		return nextPatterns;
@@ -498,6 +510,8 @@ const projectIgnoreMatcherCache = new Map<
 	string,
 	{
 		gitignoreMtimeMs: number;
+		/** #1105 second axis for the root `.gitignore` (see FreshnessSignature). */
+		gitignoreSize: number;
 		lensConfigPath: string | undefined;
 		lensConfigMtimeMs: number;
 		/** #1105 second axis: an mtime-preserving, length-changing config edit
@@ -506,29 +520,41 @@ const projectIgnoreMatcherCache = new Map<
 		 * stat that already produced `lensConfigMtimeMs`. */
 		lensConfigSize: number;
 		globalConfigMtimeMs: number;
+		/** #1105 second axis for the global `~/.pi-lens/config.json`. */
+		globalConfigSize: number;
 		matcher: ProjectIgnoreMatcher;
 	}
 >();
 
 /**
- * mtime of the global `~/.pi-lens/config.json` (or the PI_LENS_CONFIG_PATH
- * override). Part of the ignore-matcher cache key so editing global ignore
- * patterns takes effect without a restart (#252). -1 when absent.
+ * `size:mtimeMs` freshness signature for a single file (#1105). mtime alone
+ * misses an in-place edit that preserves the timestamp (git checkout, a
+ * same-second rewrite) but changes length; size is the free second axis (the
+ * same stat already reads it) that catches it. Every ignore-matcher freshness
+ * gate below (root + nested `.gitignore` and `.pi-lens.json`) compares BOTH
+ * axes so a preserved-mtime, length-changing edit can no longer replay a stale
+ * matcher. `{ mtimeMs: -1, size: -1 }` when the file is absent.
  */
-function globalConfigMtimeMs(): number {
+interface FreshnessSignature {
+	mtimeMs: number;
+	size: number;
+}
+
+function fileFreshnessSignature(filePath: string): FreshnessSignature {
 	try {
-		return fs.statSync(getPiLensGlobalConfigPath()).mtimeMs;
+		const stat = fs.statSync(filePath);
+		return { mtimeMs: stat.mtimeMs, size: stat.size };
 	} catch {
-		return -1;
+		return { mtimeMs: -1, size: -1 };
 	}
 }
 
-function gitignoreMtimeMs(rootDir: string): number {
-	try {
-		return fs.statSync(path.join(rootDir, ".gitignore")).mtimeMs;
-	} catch {
-		return -1;
-	}
+function globalConfigSignature(): FreshnessSignature {
+	return fileFreshnessSignature(getPiLensGlobalConfigPath());
+}
+
+function gitignoreSignature(rootDir: string): FreshnessSignature {
+	return fileFreshnessSignature(path.join(rootDir, ".gitignore"));
 }
 
 /**
@@ -551,24 +577,27 @@ function lensConfigInfo(rootDir: string): {
 
 export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 	const resolvedRoot = resolveGitIgnoreRoot(rootDir);
-	const gitignoreMtime = gitignoreMtimeMs(resolvedRoot);
+	const gitignoreSig = gitignoreSignature(resolvedRoot);
 	const lensConfig = lensConfigInfo(resolvedRoot);
-	const globalMtime = globalConfigMtimeMs();
+	const globalSig = globalConfigSignature();
 	const cached = projectIgnoreMatcherCache.get(resolvedRoot);
 	if (
-		cached?.gitignoreMtimeMs === gitignoreMtime &&
+		cached?.gitignoreMtimeMs === gitignoreSig.mtimeMs &&
+		cached?.gitignoreSize === gitignoreSig.size &&
 		cached?.lensConfigPath === lensConfig.path &&
 		cached?.lensConfigMtimeMs === lensConfig.mtimeMs &&
 		cached?.lensConfigSize === lensConfig.size &&
-		cached?.globalConfigMtimeMs === globalMtime
+		cached?.globalConfigMtimeMs === globalSig.mtimeMs &&
+		cached?.globalConfigSize === globalSig.size
 	) {
 		return cached.matcher;
 	}
 
 	// Load both configs fresh on cache miss. On a cache HIT (the common case)
-	// none of this runs — the only per-call cost is the mtime stats above. The
-	// project loader is itself mtime-cached; the global loader re-parses, but
-	// only here on miss (when some tracked mtime changed).
+	// none of this runs — the only per-call cost is the size:mtimeMs stats above
+	// (size is free from the same stat). The project loader is itself
+	// size:mtimeMs-cached; the global loader re-parses, but only here on miss
+	// (when some tracked signature changed).
 	const projectConfig = loadPiLensProjectConfig(resolvedRoot, lensConfig.info);
 	const matcher = createProjectIgnoreMatcher(
 		resolvedRoot,
@@ -576,11 +605,13 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 		getGlobalIgnorePatterns(),
 	);
 	projectIgnoreMatcherCache.set(resolvedRoot, {
-		gitignoreMtimeMs: gitignoreMtime,
+		gitignoreMtimeMs: gitignoreSig.mtimeMs,
+		gitignoreSize: gitignoreSig.size,
 		lensConfigPath: lensConfig.path,
 		lensConfigMtimeMs: lensConfig.mtimeMs,
 		lensConfigSize: lensConfig.size,
-		globalConfigMtimeMs: globalMtime,
+		globalConfigMtimeMs: globalSig.mtimeMs,
+		globalConfigSize: globalSig.size,
 		matcher,
 	});
 	return matcher;

--- a/clients/project-lens-config.ts
+++ b/clients/project-lens-config.ts
@@ -181,6 +181,16 @@ export const EMPTY_PROJECT_CONFIG: PiLensProjectConfig = {
 
 interface CacheEntry {
 	mtimeMs: number;
+	/**
+	 * Byte size at parse time (#1105). Reuse requires BOTH mtime and size to
+	 * match — size is the free second axis (the same stat already read it) that
+	 * catches an mtime-preserving, length-changing in-place edit (git checkout,
+	 * same-second rewrite) that mtime alone would replay stale. Residual (same
+	 * mtime AND same size) matches the review-graph `size:mtimeMs` accepted
+	 * residual; closing it would need a content hash on every gate check — the
+	 * hot-path cost the word-index #1105 fix deliberately declined.
+	 */
+	size: number;
 	config: PiLensProjectConfig;
 }
 
@@ -206,12 +216,20 @@ export function loadPiLensProjectConfig(
 	if (!configInfo) return EMPTY_PROJECT_CONFIG;
 
 	const cached = configCache.get(configInfo.path);
-	if (cached && cached.mtimeMs === configInfo.mtimeMs) {
+	if (
+		cached &&
+		cached.mtimeMs === configInfo.mtimeMs &&
+		cached.size === configInfo.size
+	) {
 		return cached.config;
 	}
 
 	const config = parseConfigFile(configInfo.path);
-	configCache.set(configInfo.path, { mtimeMs: configInfo.mtimeMs, config });
+	configCache.set(configInfo.path, {
+		mtimeMs: configInfo.mtimeMs,
+		size: configInfo.size,
+		config,
+	});
 	return config;
 }
 
@@ -226,6 +244,8 @@ export interface PiLensProjectConfigFileInfo {
 	path: string;
 	dir: string;
 	mtimeMs: number;
+	/** Byte size at stat time — the #1105 second freshness axis (see CacheEntry). */
+	size: number;
 }
 
 /**
@@ -246,7 +266,12 @@ export function findPiLensConfigInDir(
 ): PiLensProjectConfigFileInfo | undefined {
 	const marker = findPiLensConfigMarkerInDir(dir);
 	if (!marker) return undefined;
-	return { path: marker.path, dir: marker.dir, mtimeMs: marker.mtimeMs };
+	return {
+		path: marker.path,
+		dir: marker.dir,
+		mtimeMs: marker.mtimeMs,
+		size: marker.size,
+	};
 }
 
 export interface NestedProjectMutationValue {
@@ -291,12 +316,12 @@ export function loadPiLensConfigInDir(dir: string): PiLensProjectConfig {
 	if (!info) return EMPTY_PROJECT_CONFIG;
 
 	const cached = configCache.get(info.path);
-	if (cached && cached.mtimeMs === info.mtimeMs) {
+	if (cached && cached.mtimeMs === info.mtimeMs && cached.size === info.size) {
 		return cached.config;
 	}
 
 	const config = parseConfigFile(info.path);
-	configCache.set(info.path, { mtimeMs: info.mtimeMs, config });
+	configCache.set(info.path, { mtimeMs: info.mtimeMs, size: info.size, config });
 	return config;
 }
 
@@ -308,7 +333,8 @@ export function findPiLensProjectConfig(
 	if (cached && discoveryCacheStillFresh(cached)) {
 		if (!cached.info) return undefined;
 		const stat = safeFileStat(cached.info.path);
-		if (stat?.isFile()) return { ...cached.info, mtimeMs: stat.mtimeMs };
+		if (stat?.isFile())
+			return { ...cached.info, mtimeMs: stat.mtimeMs, size: stat.size };
 	}
 
 	const discovered = discoverPiLensProjectConfig(cacheKey);
@@ -347,7 +373,7 @@ function discoverPiLensProjectConfig(startDir: string): DiscoveryCacheEntry {
 			const stat = safeFileStat(candidate);
 			if (stat?.isFile()) {
 				return {
-					info: { path: candidate, dir, mtimeMs: stat.mtimeMs },
+					info: { path: candidate, dir, mtimeMs: stat.mtimeMs, size: stat.size },
 					dirMtimes,
 				};
 			}

--- a/clients/workspace-topology.ts
+++ b/clients/workspace-topology.ts
@@ -320,6 +320,15 @@ export interface PiLensConfigMarker {
 	path: string;
 	dir: string;
 	mtimeMs: number;
+	/**
+	 * Byte size of the config file at stat time (#1105). The config caches gate
+	 * reuse on this alongside `mtimeMs` — the free second axis of the review-graph
+	 * `size:mtimeMs` signature — so an in-place edit that PRESERVES mtime (git
+	 * checkout timestamp restoration, a same-second rewrite) but changes length no
+	 * longer replays a stale parsed config. The stat that yields `mtimeMs` already
+	 * reads `size`, so carrying it costs nothing.
+	 */
+	size: number;
 }
 
 /**
@@ -338,7 +347,12 @@ export function findPiLensConfigMarkerInDir(dir: string): PiLensConfigMarker | u
 		}
 	})();
 	if (!stat?.isFile()) return undefined;
-	return { path: markers.piLensConfigPath, dir: markers.dir, mtimeMs: stat.mtimeMs };
+	return {
+		path: markers.piLensConfigPath,
+		dir: markers.dir,
+		mtimeMs: stat.mtimeMs,
+		size: stat.size,
+	};
 }
 
 /**

--- a/tests/clients/project-lens-config.test.ts
+++ b/tests/clients/project-lens-config.test.ts
@@ -703,3 +703,40 @@ describe("loadPiLensProjectConfig", () => {
 		});
 	});
 });
+
+describe("config cache freshness (#1105 mtime+size)", () => {
+	// The config cache gates reuse on mtime alone before #1105; an in-place edit
+	// that PRESERVES mtime (git checkout timestamp restoration, a same-second
+	// rewrite) but changes the file's byte length replayed a stale parsed config.
+	// The fix adds `size` as the free second axis (the stat that yields mtime
+	// already read it). Both writes below are pinned to the SAME fixed mtime, so
+	// mtime is identical across the two loads and ONLY size differs — isolating
+	// exactly the residual the second axis closes. FS-agnostic (no case/separator
+	// assumptions), so it exercises the gate identically on Linux CI (#1024).
+	it("re-parses an mtime-preserving, length-changing config edit", () => {
+		const configPath = path.join(tmpDir, ".pi-lens.json");
+		const pinned = new Date("2020-01-01T00:00:00.000Z");
+
+		// First config — a longer ignore list (larger byte length).
+		fs.writeFileSync(
+			configPath,
+			JSON.stringify({ ignore: ["alpha/**", "beta/**", "gamma/**"] }),
+		);
+		fs.utimesSync(configPath, pinned, pinned);
+		const mtimeBefore = fs.statSync(configPath).mtimeMs;
+		const first = loadPiLensProjectConfig(tmpDir);
+		expect(first.ignore).toEqual(["alpha/**", "beta/**", "gamma/**"]);
+
+		// Rewrite in place with a SHORTER config, then restore the SAME mtime so
+		// the mtime-only gate would (wrongly) treat the cached entry as fresh.
+		fs.writeFileSync(configPath, JSON.stringify({ ignore: ["alpha/**"] }));
+		fs.utimesSync(configPath, pinned, pinned);
+		// The gate is now isolated to the size axis: mtime is provably identical.
+		expect(fs.statSync(configPath).mtimeMs).toBe(mtimeBefore);
+
+		// Cache is intentionally NOT reset — this asserts the in-process gate, not
+		// a cold read. Pre-#1105 (mtime-only) this returned the stale 3-entry list.
+		const second = loadPiLensProjectConfig(tmpDir);
+		expect(second.ignore).toEqual(["alpha/**"]);
+	});
+});

--- a/tests/clients/project-lens-ignore.test.ts
+++ b/tests/clients/project-lens-ignore.test.ts
@@ -194,3 +194,43 @@ describe("createProjectIgnoreMatcher with project config", () => {
 		expect(rel).not.toContain("fixtures/noise.ts");
 	});
 });
+
+describe("ignore-matcher cache freshness (#1105 mtime+size)", () => {
+	// The project-ignore matcher cache short-circuits on the config file's mtime
+	// alone before #1105 — so an in-place `.pi-lens.json` edit that preserves
+	// mtime (git checkout, same-second rewrite) but changes length replayed a
+	// stale matcher, even though the underlying parsed-config cache was fixed.
+	// Both writes are pinned to the SAME mtime, isolating the size axis. This is
+	// a SEPARATE gate from loadPiLensProjectConfig's: the matcher cache returns
+	// before ever consulting the config parse cache, so it needs its own size
+	// check. FS-agnostic → runs identically on Linux CI (#1024).
+	it("rebuilds the matcher on an mtime-preserving, length-changing edit", () => {
+		const configPath = path.join(tmpDir, ".pi-lens.json");
+		const pinned = new Date("2020-01-01T00:00:00.000Z");
+
+		// Longer config first (two ignore entries).
+		fs.writeFileSync(
+			configPath,
+			JSON.stringify({ ignore: ["**/skip-old/**", "**/also-skip/**"] }),
+		);
+		fs.utimesSync(configPath, pinned, pinned);
+		const first = getProjectIgnoreMatcher(tmpDir);
+		expect(first.isIgnored(path.join(tmpDir, "skip-old/x.ts"), false)).toBe(true);
+
+		// Shorter, different config; restore the SAME mtime.
+		fs.writeFileSync(
+			configPath,
+			JSON.stringify({ ignore: ["**/skip-new/**"] }),
+		);
+		fs.utimesSync(configPath, pinned, pinned);
+
+		const second = getProjectIgnoreMatcher(tmpDir);
+		expect(second.isIgnored(path.join(tmpDir, "skip-new/y.ts"), false)).toBe(
+			true,
+		);
+		// The stale rule no longer applies once the matcher is rebuilt.
+		expect(second.isIgnored(path.join(tmpDir, "skip-old/x.ts"), false)).toBe(
+			false,
+		);
+	});
+});

--- a/tests/clients/project-lens-ignore.test.ts
+++ b/tests/clients/project-lens-ignore.test.ts
@@ -233,4 +233,76 @@ describe("ignore-matcher cache freshness (#1105 mtime+size)", () => {
 			false,
 		);
 	});
+
+	// Nested-config path (#783 layering). The nested cache in `patternsForDir`
+	// short-circuits AHEAD of the root config/matcher caches: a NESTED
+	// `.pi-lens.json`/`.gitignore` change leaves the ROOT signatures unchanged, so
+	// the root matcher cache HITS and returns the SAME matcher instance — the
+	// nested cache is then the only gate deciding freshness for that subtree.
+	// Because the matcher (and its per-path `patternMemo`) is reused, the
+	// post-edit assertions use FRESH paths never queried before, so they exercise
+	// `patternsForDir` (and the nested cache) rather than a memoized verdict.
+	// A `.git` marker anchors `resolveGitIgnoreRoot` at tmpDir so the sub dir is a
+	// genuine nested ancestor. Pre-#1105 (mtime-only nested gate) these replayed
+	// stale patterns for the subtree. FS-agnostic → identical on Linux CI (#1024).
+	it("rebuilds nested .pi-lens.json patterns on an mtime-preserving, length-changing edit", () => {
+		fs.mkdirSync(path.join(tmpDir, ".git"));
+		const subDir = path.join(tmpDir, "pkg");
+		fs.mkdirSync(subDir);
+		const nestedConfig = path.join(subDir, ".pi-lens.json");
+		const pinned = new Date("2020-01-01T00:00:00.000Z");
+
+		// Longer nested ignore list first.
+		fs.writeFileSync(
+			nestedConfig,
+			JSON.stringify({ ignore: ["skip-old/**", "also-skip/**"] }),
+		);
+		fs.utimesSync(nestedConfig, pinned, pinned);
+		const matcher = getProjectIgnoreMatcher(tmpDir);
+		// Populate the nested cache for `subDir` (and the memo for this one path).
+		expect(matcher.isIgnored(path.join(subDir, "skip-old/x.ts"), false)).toBe(
+			true,
+		);
+
+		// Shorter, different nested config; restore the SAME mtime. Root config is
+		// untouched, so the same matcher instance keeps serving `subDir`.
+		fs.writeFileSync(nestedConfig, JSON.stringify({ ignore: ["skip-new/**"] }));
+		fs.utimesSync(nestedConfig, pinned, pinned);
+
+		// Fresh paths → bypass patternMemo → hit the nested cache gate.
+		expect(matcher.isIgnored(path.join(subDir, "skip-new/y.ts"), false)).toBe(
+			true,
+		);
+		expect(matcher.isIgnored(path.join(subDir, "skip-old/z.ts"), false)).toBe(
+			false,
+		);
+	});
+
+	it("rebuilds nested .gitignore patterns on an mtime-preserving, length-changing edit", () => {
+		fs.mkdirSync(path.join(tmpDir, ".git"));
+		const subDir = path.join(tmpDir, "pkg");
+		fs.mkdirSync(subDir);
+		const nestedGitignore = path.join(subDir, ".gitignore");
+		const pinned = new Date("2020-01-01T00:00:00.000Z");
+
+		// Longer nested .gitignore first.
+		fs.writeFileSync(nestedGitignore, "old-dir/\nextra-dir/\n");
+		fs.utimesSync(nestedGitignore, pinned, pinned);
+		const matcher = getProjectIgnoreMatcher(tmpDir);
+		expect(matcher.isIgnored(path.join(subDir, "old-dir/x.ts"), false)).toBe(
+			true,
+		);
+
+		// Shorter, different .gitignore; restore the SAME mtime.
+		fs.writeFileSync(nestedGitignore, "new-dir/\n");
+		fs.utimesSync(nestedGitignore, pinned, pinned);
+
+		// Fresh paths → bypass patternMemo → hit the nested cache gate.
+		expect(matcher.isIgnored(path.join(subDir, "new-dir/y.ts"), false)).toBe(
+			true,
+		);
+		expect(matcher.isIgnored(path.join(subDir, "old-dir/z.ts"), false)).toBe(
+			false,
+		);
+	});
 });


### PR DESCRIPTION
## What
Shape-6 class sweep (#1105): mtime-only cache freshness beyond diagnostics. The #1092→#1095/#1096 arc fixed the class for LSP diagnostics (mtime/TTL → content binding); this sweeps the other persisted/derived caches for the same "freshness stamp doesn't cover the data's real dependency" risk (stale-replay when content changes but mtime doesn't — git checkout, formatters preserving mtime, same-second writes).

## Coverage table (the sweep IS the deliverable)
| Cache | Verdict |
|---|---|
| word-index | already-hardened (#1119 `fileSizes` — refresh gate is `mtime OR size`) |
| rule-cache | already-hardened (`computeRuleHash` = `sha256(file:mtimeMs:size)`) |
| sgconfig gen cache | SAFE (`snapshotRuleSource` hashes full file content) |
| yaml-rule-parser | SAFE by design (project rules content-hashed; bundled rules immutable-in-process) |
| reverse-deps | SAFE (snapshot-`seq`/generation-coupled, not mtime) |
| installer probe-cache | SAFE (`fs.access` revalidates existence + version-family verify; mtime is a refresh hint) |
| TreeCache | already-hardened (content-hash authoritative; mtime only on content-less test path, #890) |
| project-snapshot | already-hardened (per-file `mtimeMs` **and** `size`) |
| **.pi-lens.json config + ignore-matcher caches** | **MEMBER → FIXED** |

## The fix (one member)
`project-lens-config.ts` (parsed-config cache) and the `projectIgnoreMatcherCache` in `file-utils.ts` gated reuse on the config file's **mtime alone** — an mtime-preserving, length-changing in-place edit replayed a stale parsed config / ignore matcher. Added `size` as the free second axis (review-graph `size:mtimeMs` pattern), threaded through `PiLensConfigMarker` (`workspace-topology.ts`), `PiLensProjectConfigFileInfo`/`CacheEntry` (`project-lens-config.ts`), and `projectIgnoreMatcherCache` (`file-utils.ts`). The stat that already produces mtime reads size too → **cheap hit path stays cheap, no content hashing on the hot path**.

## Fail-then-pass
- `project-lens-config.test.ts` — reverting the config-cache size check → stale 3-entry ignore list, fails.
- `project-lens-ignore.test.ts` — reverting only the matcher-cache size check → `expected false to be true`, proving the matcher gate is independently load-bearing (short-circuits before the config parse cache).
- Both restored → green. FS-agnostic: mtime pinned via `utimesSync`, size varied by content length (#1024-safe on Linux CI).

## Screens
No shape-1 (raw path-key) regression (same `path.resolve`d keys); no shape-4 (no timers/workers/children); no hot-path cost (size from the existing stat). No member deferred → `closes #1105` (refs #1095 #1088 #1020).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
