### PR TITLE
fix(lsp): thread resultId + content hash through pull-diagnostics binding (closes #1104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Pull-diagnostics entries never bound to document content, so they never demoted (closes #1104, refs #1095 #1096 #1100)** —
+	#1096 bound LSP diagnostics to a content fingerprint on the PUSH path
+	(`publishDiagnostics` version echo + send-time hash); the PULL path
+	(`textDocument/diagnostic`, `workspace/diagnostic`) recorded no fingerprint
+	at all, so pull-served cache entries read binding `"unknown"` forever and
+	the #1096 P2-1 service-sweep binding gate could never protect them. Fixed by
+	threading the server's `resultId` and a request-time content hash through
+	both pull requests: a `"full"` report is fingerprinted (the single-file path
+	reuses the exact sent-content hash `recordSentContent` already captures on
+	every didOpen/didChange — no extra read; the project-wide
+	`workspace/diagnostic` pull hashes disk bytes at request time since files
+	may not yet be open when it fires), and an `"unchanged"` report (now
+	requested via `previousResultId`/`previousResultIds`) inherits the prior
+	pull's diagnostics AND binding instead of being misread as a confirmed-clean
+	`[]` (the #570/#571 false-clean shape). The workspace pull-sweep record site
+	(`clients/lsp/index.ts`) now threads this `contentHash` into
+	`workspaceDiagnosticsCacheCtx.record()`, closing the gap the site's own
+	`#1095` doc comment used to document as intentional. Also closed an
+	AGENTS.md shape-5 gap in the sibling per-file touch path: `processFile` read
+	the `#1095` binding off the RAW `touchFile` diagnostics array before
+	`applyAuxiliarySuppressions`' `.filter()` rebuilds it (a `.filter()` copy
+	does not carry a source array's non-enumerable `.binding`), and
+	`LSPService.mergeBinding` no longer gates a contributor's `contentHash` on
+	that SAME contributor also carrying a `version` — pull bindings
+	legitimately carry a hash with no version, and the old gate silently
+	dropped it. Folded in two #1100-review P3s on the same surface: the
+	cascade's degraded/fallback display paths and the `lsp_binding_rejected`
+	indeterminate-advisory preamble (`clients/runtime-turn.ts`), which
+	previously reused the graph-unavailable wording even when the review graph
+	was fine and only the LSP display was withheld, now use a
+	binding-rejection-specific frame. Fail-then-pass regression tests cover:
+	the pull-sweep record site actually receiving a `contentHash`; a
+	pull-recorded entry whose content changed under a matching mtime being
+	demoted (not replayed) on the next sweep; the per-file touch path's binding
+	surviving the suppression filter; and the `"unchanged"`-report inheritance
+	on both the single-file and workspace pull protocols.
 - **Quick-mode background warmup kept a one-shot `pi -p`/`--print` process alive (closes #1154)** —
 	`handleSessionStart` forces **quick mode** for both a real `pi -p`/`--print`
 	one-shot AND an interactive process's first session (to protect keystroke

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -315,7 +315,16 @@ export interface LSPClientInfo {
 	requestWorkspaceDiagnostics(
 		budgetMs: number,
 	): Promise<
-		Array<{ filePath: string; diagnostics: LSPDiagnostic[] }> | undefined
+		| Array<{
+				filePath: string;
+				diagnostics: LSPDiagnostic[];
+				/** #1104: sha256 of the file bytes active at the moment this pull's
+				 *  answer for `filePath` was resolved — present for a "full" report
+				 *  (fresh read) or inherited from the prior pull for an "unchanged"
+				 *  one; absent only when the file could not be read. */
+				contentHash?: string;
+		  }>
+		| undefined
 	>;
 	/** Capability snapshot for navigation/edit operations */
 	getOperationSupport(): LSPOperationSupport;
@@ -525,6 +534,13 @@ const SHUTDOWN_REQUEST_TIMEOUT_MS = positiveIntFromEnv(
 	"PI_LENS_LSP_SHUTDOWN_TIMEOUT_MS",
 	1000,
 );
+// #1104: bound on `state.workspacePullResultCache` — one entry per distinct
+// file the server has ever returned a `resultId` for across this client's
+// lifetime. A full clear on overflow (rather than an LRU) is fine, same
+// reasoning as `DISK_BINDING_MEMO_MAX` in diagnostic-binding.ts: each entry is
+// cheaply rebuilt by the next full pull, the worst case is just one extra full
+// (non-`unchanged`) report per affected file.
+const WORKSPACE_PULL_RESULT_CACHE_MAX = 4096;
 // Anti-deadlock backstop for workspace/executeCommand. Deliberately generous
 // (30s): the command is mutating and legitimately long-running (a real server
 // refactor / organize-imports), so this must not truncate valid work — it only
@@ -633,6 +649,26 @@ export interface LSPClientState {
 	 *  behavior is unchanged. Kept in lockstep with `pushDiagnostics`: written on
 	 *  publish accept, cleared by `clearDiagnosticsForPath`. */
 	readonly diagnosticBindings: Map<string, StoredDiagnosticBinding>;
+	/** #1104: the server-issued `resultId` from the last `textDocument/diagnostic`
+	 *  pull for a path (primary or a `relatedDocuments` entry), so the NEXT pull
+	 *  can send it as `previousResultId` and receive an `unchanged` report instead
+	 *  of a full recompute. Cleared with the rest of a path's diagnostic state by
+	 *  `clearDiagnosticsForPath` so a resync never inherits a stale basis. */
+	readonly pullResultIds: Map<string, string>;
+	/** #1104: per-path cache of the last `workspace/diagnostic` pull's resultId +
+	 *  diagnostics + content binding, so an `unchanged` report in a LATER pull can
+	 *  inherit the prior basis instead of the record site staying stuck at
+	 *  "unknown" forever. Keyed by normalized path; `uri` retains the server's
+	 *  exact spelling for echoing back in `previousResultIds`. */
+	readonly workspacePullResultCache: Map<
+		string,
+		{
+			uri: string;
+			resultId: string;
+			diagnostics: LSPDiagnostic[];
+			contentHash?: string;
+		}
+	>;
 	readonly openDocuments: Set<string>;
 	/** Original URI spelling for each open document; path keys are normalized. */
 	readonly openDocumentUris?: Map<string, string>;
@@ -976,6 +1012,11 @@ function clearDiagnosticsForPath(
 	// `documentContentHashes` record is intentionally retained: it describes what
 	// we sent, which the NEXT publish for that version still needs to bind to.)
 	state.diagnosticBindings?.delete(normalizedPath);
+	// #1104: a resync invalidates any `unchanged`-report basis too — the next
+	// pull must not inherit a resultId/contentHash computed against the
+	// content this resync just replaced.
+	state.pullResultIds?.delete(normalizedPath);
+	state.workspacePullResultCache?.delete(normalizedPath);
 	legacy.diagnostics?.delete(normalizedPath);
 	legacy.diagnosticTimestamps?.delete(normalizedPath);
 }
@@ -1377,6 +1418,12 @@ async function clientRequestPullDiagnostics(
 ): Promise<PullDiagnosticsOutcome> {
 	if (!isClientAlive(state)) return { status: "unavailable" };
 	const uri = pathToFileURL(filePath).href;
+	const normalizedPath = normalizeMapKey(filePath);
+	// #1104: echo the last resultId we hold for this document so a server that
+	// hasn't changed its view can answer `kind: "unchanged"` instead of
+	// recomputing — see the `kind === "unchanged"` branch below for how that's
+	// honored (inherit, never treat an omitted `items` as clean).
+	const previousResultId = state.pullResultIds.get(normalizedPath);
 	try {
 		// withTimeout is the backstop against a hung pull-mode server: without it
 		// this await never settles unless the stream is destroyed. Bounded by the
@@ -1386,39 +1433,78 @@ async function clientRequestPullDiagnostics(
 		const report = await withTimeout(
 			safeSendRequest<{
 				kind?: string;
+				resultId?: string;
 				items?: LSPDiagnostic[];
-				relatedDocuments?: Record<string, { items?: LSPDiagnostic[] }>;
+				relatedDocuments?: Record<
+					string,
+					{ kind?: string; resultId?: string; items?: LSPDiagnostic[] }
+				>;
 			}>(state.connection, "textDocument/diagnostic", {
 				textDocument: { uri },
+				...(previousResultId !== undefined && { previousResultId }),
 			}),
 			Math.max(1, Math.min(PULL_REQUEST_TIMEOUT_MS, budgetMs)),
 		);
 
 		if (!report) return { status: "unavailable" };
 
-		const normalizedPath = normalizeMapKey(filePath);
-		const primaryItems = normalizeLspDiagnostics(report.items ?? []);
 		const now = Date.now();
-		state.documentPullDiagnostics.set(normalizedPath, primaryItems);
-		state.documentPullDiagnosticTimestamps.set(normalizedPath, now);
-		state.diagnosticsVersion += 1;
-		let totalCount = primaryItems.length;
+		// #1104: the fingerprint of the content we last sent for this document —
+		// the SAME `documentContentHashes` entry the push binding path uses
+		// (`recordSentContent` runs unconditionally on every didOpen/didChange,
+		// regardless of push/pull mode), so this costs no extra read. A pull
+		// response describes whatever the server had when it answered, which for
+		// a pi-lens-opened document is exactly that last-sent payload.
+		const sentHash = state.documentContentHashes.get(normalizedPath)?.hash;
+		let totalCount: number;
+		if (report.kind === "unchanged") {
+			// #1104: same resultId basis as last time — an omitted `items` here
+			// means "no change", NOT "clean". Overwriting with `[]` would be the
+			// exact false-clean shape #570/#571 already fixed for the touch path;
+			// keep the previously stored diagnostics and binding as-is.
+			totalCount = state.documentPullDiagnostics.get(normalizedPath)?.length ?? 0;
+			// Still a fresh confirmation as of `now` even though the content is
+			// unchanged — bump the timestamp so `getAllDiagnostics()` doesn't read
+			// this entry as aging purely because the server had nothing new to say.
+			state.documentPullDiagnosticTimestamps.set(normalizedPath, now);
+		} else {
+			const primaryItems = normalizeLspDiagnostics(report.items ?? []);
+			state.documentPullDiagnostics.set(normalizedPath, primaryItems);
+			state.documentPullDiagnosticTimestamps.set(normalizedPath, now);
+			state.diagnosticsVersion += 1;
+			state.diagnosticBindings.set(normalizedPath, { contentHash: sentHash });
+			totalCount = primaryItems.length;
+		}
+		if (report.resultId !== undefined) {
+			state.pullResultIds.set(normalizedPath, report.resultId);
+		} else {
+			state.pullResultIds.delete(normalizedPath);
+		}
 
 		if (report.relatedDocuments) {
 			for (const [relatedUri, related] of Object.entries(
 				report.relatedDocuments,
 			)) {
 				const relatedPath = uriToPath(relatedUri);
-				const relatedItems = normalizeLspDiagnostics(related?.items ?? []);
-				state.documentPullDiagnostics.set(
-					normalizeMapKey(relatedPath),
-					relatedItems,
-				);
-				state.documentPullDiagnosticTimestamps.set(
-					normalizeMapKey(relatedPath),
-					now,
-				);
-				totalCount += relatedItems.length;
+				const relatedNormalized = normalizeMapKey(relatedPath);
+				if (related?.kind === "unchanged") {
+					totalCount +=
+						state.documentPullDiagnostics.get(relatedNormalized)?.length ?? 0;
+					state.documentPullDiagnosticTimestamps.set(relatedNormalized, now);
+				} else {
+					const relatedItems = normalizeLspDiagnostics(related?.items ?? []);
+					state.documentPullDiagnostics.set(relatedNormalized, relatedItems);
+					state.documentPullDiagnosticTimestamps.set(relatedNormalized, now);
+					// #1104: a related document's diagnostics were NOT computed against
+					// content we independently sent/fingerprinted (we never requested
+					// it directly) — its binding stays honestly "unknown" rather than
+					// borrowing the primary document's hash.
+					state.diagnosticBindings.delete(relatedNormalized);
+					totalCount += relatedItems.length;
+				}
+				if (related?.resultId !== undefined) {
+					state.pullResultIds.set(relatedNormalized, related.resultId);
+				}
 			}
 		}
 
@@ -1442,31 +1528,87 @@ export async function clientRequestWorkspaceDiagnostics(
 	state: LSPClientState,
 	budgetMs: number,
 ): Promise<
-	Array<{ filePath: string; diagnostics: LSPDiagnostic[] }> | undefined
+	| Array<{ filePath: string; diagnostics: LSPDiagnostic[]; contentHash?: string }>
+	| undefined
 > {
 	if (!isClientAlive(state)) return undefined;
 	if (!state.workspaceDiagnosticsSupport.workspaceDiagnostics) return undefined;
 	try {
+		// #1104: echo every resultId we hold from a PRIOR pull so the server can
+		// answer `kind: "unchanged"` for files it hasn't recomputed, instead of
+		// resending (and us re-hashing) every file on every sweep.
+		const previousResultIds = Array.from(
+			state.workspacePullResultCache.values(),
+		).map((entry) => ({ uri: entry.uri, value: entry.resultId }));
 		const report = await withTimeout(
 			safeSendRequest<{
 				items?: Array<{
 					uri?: string;
 					kind?: string;
+					resultId?: string;
 					items?: LSPDiagnostic[];
 				}>;
-			}>(state.connection, "workspace/diagnostic", { previousResultIds: [] }),
+			}>(state.connection, "workspace/diagnostic", { previousResultIds }),
 			Math.max(1, budgetMs),
 		);
 		if (!report || !Array.isArray(report.items)) return undefined;
-		const out: Array<{ filePath: string; diagnostics: LSPDiagnostic[] }> = [];
+		const out: Array<{
+			filePath: string;
+			diagnostics: LSPDiagnostic[];
+			contentHash?: string;
+		}> = [];
 		for (const item of report.items) {
-			// Only "full" reports carry items; "unchanged" means "same as last pull"
-			// (none, since previousResultIds is empty on this one-shot request).
-			if (!item?.uri || item.kind !== "full") continue;
-			out.push({
-				filePath: uriToPath(item.uri),
-				diagnostics: normalizeLspDiagnostics(item.items ?? []),
-			});
+			if (!item?.uri) continue;
+			const filePath = uriToPath(item.uri);
+			const normalizedPath = normalizeMapKey(filePath);
+			if (item.kind === "unchanged") {
+				// #1104: inherit the prior pull's diagnostics + content binding for
+				// the SAME resultId basis — an "unchanged" report never carries
+				// `items`, so without this a file the server confirmed unchanged
+				// would silently drop out of the sweep result entirely.
+				const prior = state.workspacePullResultCache.get(normalizedPath);
+				if (!prior) continue; // no earlier basis to inherit — nothing to report
+				if (item.resultId !== undefined) {
+					state.workspacePullResultCache.set(normalizedPath, {
+						...prior,
+						resultId: item.resultId,
+					});
+				}
+				out.push({
+					filePath,
+					diagnostics: prior.diagnostics,
+					contentHash: prior.contentHash,
+				});
+				continue;
+			}
+			// "full" (or a non-conforming server omitting `kind`, per the LSP
+			// default) — recompute and re-fingerprint.
+			const diagnostics = normalizeLspDiagnostics(item.items ?? []);
+			// #1104: fingerprint the file bytes active AT REQUEST TIME. Best-effort —
+			// a read failure (deleted/unreadable mid-sweep) just leaves contentHash
+			// undefined, so the binding reads honestly "unknown", never fabricated.
+			let contentHash: string | undefined;
+			try {
+				contentHash = hashDiagnosticContent(await readFile(filePath, "utf-8"));
+			} catch {
+				contentHash = undefined;
+			}
+			if (item.resultId !== undefined) {
+				if (
+					state.workspacePullResultCache.size >= WORKSPACE_PULL_RESULT_CACHE_MAX
+				) {
+					state.workspacePullResultCache.clear();
+				}
+				state.workspacePullResultCache.set(normalizedPath, {
+					uri: item.uri,
+					resultId: item.resultId,
+					diagnostics,
+					contentHash,
+				});
+			} else {
+				state.workspacePullResultCache.delete(normalizedPath);
+			}
+			out.push({ filePath, diagnostics, contentHash });
 		}
 		return out;
 	} catch {
@@ -2202,6 +2344,8 @@ export async function createLSPClient(options: {
 		diagnosticDocVersions: new Map(),
 		documentContentHashes: new Map(),
 		diagnosticBindings: new Map(),
+		pullResultIds: new Map(),
+		workspacePullResultCache: new Map(),
 		openDocuments: new Set(),
 		openDocumentUris: new Map(),
 		pendingOpens: new Set(),

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -508,6 +508,18 @@ export interface LSPWorkspaceDiagnosticResult {
 	 * #1092 touchedAt-re-arming defect).
 	 */
 	observedAt?: number;
+	/**
+	 * #1104: sha256 of the file bytes this result's diagnostics were computed
+	 * against, when known — from the pull path's server-answered `resultId`
+	 * flow (a "full" `workspace/diagnostic`/`textDocument/diagnostic` report is
+	 * fingerprinted at request time; an "unchanged" report inherits the prior
+	 * fingerprint) or, for a per-file touch, the SAME `contentHash` the #1095
+	 * push-path binding records. Absent means "no hash available" (never
+	 * fabricated) — the cache-record site below then honestly stores no
+	 * contentHash and a later `lookup()`'s binding reads "unknown", exactly the
+	 * pre-#1104 behavior for that entry.
+	 */
+	contentHash?: string;
 }
 
 /**
@@ -2916,6 +2928,11 @@ export class LSPService {
 	 * else all "unknown" (or no contributors) → "unknown"; else true. The
 	 * surfaced version/contentHash come from the first contributor that carries
 	 * them — informational only; the load-bearing field is `boundToCurrentDisk`.
+	 * #1104: `version` and `contentHash` are tracked INDEPENDENTLY (not gated on
+	 * the same contributor carrying both) — a pull-sourced binding deliberately
+	 * has no `version` (the pull protocol has no version-echo concept) but does
+	 * carry a real `contentHash`; gating the latter on the former would silently
+	 * drop it here even though `boundToCurrentDisk` above already used it.
 	 */
 	private mergeBinding(
 		filePath: string,
@@ -2930,6 +2947,8 @@ export class LSPService {
 			);
 			if (version === undefined && entry?.version !== undefined) {
 				version = entry.version;
+			}
+			if (contentHash === undefined && entry?.contentHash !== undefined) {
 				contentHash = entry.contentHash;
 			}
 		}
@@ -4119,6 +4138,23 @@ export class LSPService {
 						?.inconclusive === true;
 				const timedOut = diagnostics === undefined || inconclusive;
 				if (timedOut) timedOutFiles += 1;
+				// #1104 (shape 5 — AGENTS.md): read the touch's content binding off
+				// the RAW `diagnostics` array here, before `applyAuxiliarySuppressions`
+				// below rebuilds it via `.filter()` — a `.filter()` result is a NEW
+				// array and does not carry over the source's non-enumerable
+				// `.binding` (see #1095's own `Object.defineProperty` comment: "JSON.
+				// stringify / spread / logging ... unaffected" cuts both ways — a
+				// derived COPY never gets it either). A version-less/pull-less
+				// server's `diagnostics` simply carries no `.binding`, so
+				// `contentHash` stays undefined here (honest "unknown" downstream),
+				// matching pre-#1104 behavior exactly.
+				const rawBinding = (
+					diagnostics as
+						| (typeof diagnostics & {
+								binding?: import("./diagnostic-binding.js").DiagnosticBinding;
+						  })
+						| undefined
+				)?.binding;
 				// #586: honor each auxiliary profile's native inline-suppression
 				// comment (e.g. opengrep's `// nosemgrep`, #441) — computed from the
 				// raw `diagnostics` (before this drops its non-enumerable
@@ -4142,6 +4178,7 @@ export class LSPService {
 					diagnostics: filteredDiagnostics ?? [],
 					count: filteredDiagnostics?.length ?? 0,
 					timedOut,
+					contentHash: rawBinding?.contentHash,
 				});
 			} catch (err) {
 				results.push({
@@ -4335,11 +4372,20 @@ export class LSPService {
 		for (const result of results) {
 			const scannedAt = scannedMtimeByFile.get(result.filePath);
 			if (result.error || result.timedOut || scannedAt === undefined) continue;
+			// #1104: thread the per-result `contentHash` (from either the
+			// `tryWorkspacePull` fast path or a per-file touch's own #1095 binding)
+			// into the cache entry — previously this call never passed one, so
+			// every pull-served entry read binding "unknown" forever and the #1095
+			// P2-1 service-sweep binding gate above (`cached.binding.
+			// boundToCurrentDisk !== false`) could never demote a pull-cached
+			// entry. Absent `contentHash` (no binding was available) behaves
+			// exactly as before.
 			workspaceDiagnosticsCacheCtx.record(
 				result.filePath,
 				workspaceSweepScopeKey,
 				result.diagnostics,
 				scannedAt,
+				result.contentHash,
 			);
 		}
 		workspaceDiagnosticsCacheCtx.persist();
@@ -4371,16 +4417,32 @@ export class LSPService {
 				Math.max(perFileMs, workspacePullBudgetMs()),
 			);
 			if (!report) return undefined;
-			const byPath = new Map<string, import("./client.js").LSPDiagnostic[]>();
+			const byPath = new Map<
+				string,
+				{
+					diagnostics: import("./client.js").LSPDiagnostic[];
+					contentHash?: string;
+				}
+			>();
 			for (const entry of report) {
-				byPath.set(normalizeMapKey(entry.filePath), entry.diagnostics);
+				byPath.set(normalizeMapKey(entry.filePath), entry);
 			}
 			return groupFiles.map((filePath) => {
-				const diagnostics = byPath.get(normalizeMapKey(filePath)) ?? [];
+				const entry = byPath.get(normalizeMapKey(filePath));
+				const diagnostics = entry?.diagnostics ?? [];
 				// A pull that got here returned a real workspace/diagnostic report
 				// (see the `!report` guard above) — always confirmed, unlike a
 				// per-file touchFile default-empty on timeout.
-				return { filePath, diagnostics, count: diagnostics.length, timedOut: false };
+				// #1104: `contentHash` comes straight from the client's pull layer —
+				// a file absent from the report (reported "clean" here) carries none,
+				// same honest "unknown" the record site already applies for it.
+				return {
+					filePath,
+					diagnostics,
+					count: diagnostics.length,
+					timedOut: false,
+					contentHash: entry?.contentHash,
+				};
 			});
 		} catch {
 			return undefined;

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -399,37 +399,82 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	// (over-correction guard).
 	const indeterminateRuns = cascadeRuns.filter((r) => r.indeterminate);
 	if (indeterminateRuns.length > 0) {
-		const byDetail = new Map<string, string[]>();
-		for (const r of indeterminateRuns) {
-			const detail =
-				r.indeterminate?.detail ??
-				(r.indeterminate?.reason === "missing_node"
-					? "changed file not in the review graph"
-					: "review graph unavailable");
-			const files = byDetail.get(detail) ?? [];
-			files.push(toRunnerDisplayPath(cwd, r.filePath));
-			byDetail.set(detail, files);
-		}
-		const lines: string[] = [];
-		for (const [detail, filesRaw] of byDetail) {
-			const files = [...new Set(filesRaw)];
-			const shown = files.slice(0, 5).join(", ");
-			const more = files.length > 5 ? ` (+${files.length - 5} more)` : "";
-			lines.push(`  • ${detail}: ${shown}${more}`);
-		}
-		const fileCount = new Set(
-			indeterminateRuns.map((r) => normalizeMapKey(r.filePath)),
-		).size;
-		const reasons = [...byDetail.keys()].join("; ");
+		// #1104 (review P3 on PR #1143, rides with the resultId main body): this
+		// preamble used to hardcode a graph-unavailability frame for EVERY
+		// indeterminate reason. That's accurate for `graph_degraded`/
+		// `missing_node`/`error` (the graph really couldn't produce a dependent
+		// set), but `lsp_binding_rejected` is a DIFFERENT failure shape — the
+		// graph WAS available and dependents WERE derived; only their LSP
+		// diagnostics display was withheld because a fallback snapshot's content
+		// binding didn't match current disk. Saying "the review graph was
+		// unavailable" for that case mis-attributes the cause. Bucket by reason
+		// family so each gets its own accurate frame.
+		const buildAdvisory = (
+			runs: typeof indeterminateRuns,
+			frame: {
+				lead: (fileCount: number, reasons: string) => string;
+				fallbackDetail: (
+					r: (typeof indeterminateRuns)[number],
+				) => string;
+			},
+		): string | undefined => {
+			if (runs.length === 0) return undefined;
+			const byDetail = new Map<string, string[]>();
+			for (const r of runs) {
+				const detail = r.indeterminate?.detail ?? frame.fallbackDetail(r);
+				const files = byDetail.get(detail) ?? [];
+				files.push(toRunnerDisplayPath(cwd, r.filePath));
+				byDetail.set(detail, files);
+			}
+			const lines: string[] = [];
+			for (const [detail, filesRaw] of byDetail) {
+				const files = [...new Set(filesRaw)];
+				const shown = files.slice(0, 5).join(", ");
+				const more = files.length > 5 ? ` (+${files.length - 5} more)` : "";
+				lines.push(`  • ${detail}: ${shown}${more}`);
+			}
+			const fileCount = new Set(
+				runs.map((r) => normalizeMapKey(r.filePath)),
+			).size;
+			const reasons = [...byDetail.keys()].join("; ");
+			return `${frame.lead(fileCount, reasons)}\n${lines.join("\n")}`;
+		};
+
+		const graphRuns = indeterminateRuns.filter(
+			(r) => r.indeterminate?.reason !== "lsp_binding_rejected",
+		);
+		const bindingRuns = indeterminateRuns.filter(
+			(r) => r.indeterminate?.reason === "lsp_binding_rejected",
+		);
+
 		// Factual/informational phrasing — the advisory tier wraps this with an
 		// "ℹ️ Advisory — no action required this turn:" label, so an imperative
 		// ("review dependents manually") would contradict it. The #533 substance
 		// stays: a clean cascade result does NOT cover these files' dependents.
-		advisoryParts.push(
-			`Cascade could not compute downstream impact for ${fileCount} edited file(s) this turn — ` +
+		const graphAdvisory = buildAdvisory(graphRuns, {
+			lead: (fileCount, reasons) =>
+				`Cascade could not compute downstream impact for ${fileCount} edited file(s) this turn — ` +
 				`the review graph was unavailable (${reasons}), so their dependents were not ` +
-				`cascade-checked and a clean cascade result does not cover them.\n${lines.join("\n")}`,
-		);
+				`cascade-checked and a clean cascade result does not cover them.`,
+			fallbackDetail: (r) =>
+				r.indeterminate?.reason === "missing_node"
+					? "changed file not in the review graph"
+					: "review graph unavailable",
+		});
+		if (graphAdvisory) advisoryParts.push(graphAdvisory);
+
+		const bindingAdvisory = buildAdvisory(bindingRuns, {
+			lead: (fileCount, reasons) =>
+				`Cascade identified dependents for ${fileCount} edited file(s) this turn, but their ` +
+				`diagnostics could not be freshly confirmed (${reasons}) and were withheld — a clean ` +
+				`cascade result does not cover them.`,
+			fallbackDetail: () => "cascade diagnostics withheld (binding rejected)",
+		});
+		if (bindingAdvisory) advisoryParts.push(bindingAdvisory);
+
+		const fileCount = new Set(
+			indeterminateRuns.map((r) => normalizeMapKey(r.filePath)),
+		).size;
 		logCascade({
 			phase: "cascade_indeterminate",
 			filePath: files[0] ?? cwd,

--- a/tests/clients/cascade-turn-merge.test.ts
+++ b/tests/clients/cascade-turn-merge.test.ts
@@ -190,6 +190,68 @@ describe("cascade turn-end merge", () => {
 		}
 	});
 
+	// #1104 (review P3 on PR #1143): the advisory preamble used to hardcode "the
+	// review graph was unavailable" for EVERY indeterminate reason. For
+	// `lsp_binding_rejected` that's a mis-attribution — the graph WAS available
+	// and dependents WERE derived; only the LSP diagnostics display was
+	// withheld because a fallback snapshot's content binding didn't match
+	// current disk. The advisory must use a reason-appropriate frame instead.
+	it("uses a binding-specific frame (not 'review graph was unavailable') for an lsp_binding_rejected run", async () => {
+		const env = setupTestEnvironment("cascade-binding-rejected-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const cacheManager = new CacheManager(false);
+			const primary = path.join(env.tmpDir, "edited.ts");
+			fs.writeFileSync(primary, "export const x = 1;\n");
+			cacheManager.addModifiedRange(
+				primary,
+				{ start: 1, end: 1 },
+				false,
+				env.tmpDir,
+			);
+
+			runtime.appendCascadeRun({
+				filePath: primary,
+				result: undefined,
+				neighborCount: 0,
+				diagnosticCount: 0,
+				skipReason: "indeterminate",
+				indeterminate: {
+					reason: "lsp_binding_rejected",
+					detail:
+						"cascade fallback diagnostics were withheld — stale snapshot content did not match current disk (binding rejected)",
+				},
+			});
+
+			await handleTurnEnd({
+				ctxCwd: env.tmpDir,
+				getFlag: () => false,
+				dbg: () => {},
+				runtime,
+				cacheManager,
+				knipClient: {
+					ensureAvailable: async () => false,
+					analyze: async () => EMPTY_KNIP_RESULT,
+				},
+				depChecker: { ensureAvailable: async () => false },
+				testRunnerClient: { getTestRunTarget: () => null },
+				resetLSPService: () => {},
+				resetFormatService: () => {},
+			} as any);
+
+			const findings = consumeTurnEndFindings(cacheManager, env.tmpDir);
+			const content = findings?.messages[0]?.content ?? "";
+			// HEADLINE (fails pre-#1104): the old hardcoded frame mis-attributed
+			// the cause to the review graph for every reason, including this one.
+			expect(content).not.toContain("the review graph was unavailable");
+			expect(content).toContain("edited.ts");
+			expect(content).toContain("binding rejected");
+			expect(content).toContain("Advisory — no action required this turn");
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	// #1023 over-correction guard: a HEALTHY run that genuinely found no
 	// dependents (skipReason "no_neighbors", no indeterminate marker) must NOT
 	// emit the advisory — a real clean leaf edit stays silent (no crying wolf).

--- a/tests/clients/lsp/client-internals.test.ts
+++ b/tests/clients/lsp/client-internals.test.ts
@@ -421,6 +421,8 @@ function createMockState(overrides?: Partial<LSPClientState>): LSPClientState {
 		diagnosticDocVersions: new Map(),
 		documentContentHashes: new Map(),
 		diagnosticBindings: new Map(),
+		pullResultIds: new Map(),
+		workspacePullResultCache: new Map(),
 		openDocuments: new Set(),
 		pendingOpens: new Set(),
 		workspaceDiagnosticsSupport: {
@@ -1258,6 +1260,201 @@ describe("clientWaitForDiagnostics — pull mode (#240)", () => {
 		expect(elapsed).toBeGreaterThanOrEqual(100);
 		// ...and did NOT hang on the never-resolving request.
 		expect(elapsed).toBeLessThan(2000);
+	});
+});
+
+// #1104: thread resultId + the request-time content fingerprint through the
+// PULL protocol (textDocument/diagnostic + workspace/diagnostic) so pull-
+// served diagnostics get the SAME content binding push-served ones have had
+// since #1095, instead of reading "unknown" forever. Mirrors #1095's own
+// client-internals binding tests in shape.
+describe("pull-diagnostics content binding (#1104)", () => {
+	const pullState = (): LSPClientState =>
+		createMockState({
+			serverId: "typescript",
+			workspaceDiagnosticsSupport: {
+				advertised: true,
+				mode: "pull",
+				workspaceDiagnostics: false,
+				diagnosticProviderKind: "object",
+			},
+		});
+
+	it("binds a 'full' textDocument/diagnostic report to the sent-content fingerprint and records its resultId", async () => {
+		const state = pullState();
+		const content = "const x = 1;\n";
+		// Mirror production: the document was opened/changed before the pull, so
+		// `documentContentHashes` already holds the exact fingerprint the pull's
+		// answer is presumed to describe — no extra disk read needed.
+		state.openDocuments.add(TEST_KEY);
+		state.documentContentHashes.set(TEST_KEY, {
+			version: 1,
+			hash: hashDiagnosticContent(content),
+		});
+		state.connection.sendRequest = vi.fn().mockResolvedValue({
+			kind: "full",
+			resultId: "r1",
+			items: [
+				{
+					severity: 1,
+					message: "boom",
+					range: {
+						start: { line: 0, character: 0 },
+						end: { line: 0, character: 0 },
+					},
+				},
+			],
+		});
+
+		await clientWaitForDiagnostics(state, TEST_FILE, 1000, { pullOnly: true });
+
+		expect(state.diagnosticBindings.get(TEST_KEY)).toEqual({
+			contentHash: hashDiagnosticContent(content),
+		});
+		expect(state.pullResultIds.get(TEST_KEY)).toBe("r1");
+	});
+
+	it("an 'unchanged' report (same resultId) inherits the prior diagnostics AND binding instead of reading as clean", async () => {
+		const state = pullState();
+		const content = "const x = 1;\n";
+		state.openDocuments.add(TEST_KEY);
+		state.documentContentHashes.set(TEST_KEY, {
+			version: 1,
+			hash: hashDiagnosticContent(content),
+		});
+		const sendRequest = vi.fn().mockResolvedValueOnce({
+			kind: "full",
+			resultId: "r1",
+			items: [
+				{
+					severity: 1,
+					message: "boom",
+					range: {
+						start: { line: 0, character: 0 },
+						end: { line: 0, character: 0 },
+					},
+				},
+			],
+		});
+		state.connection.sendRequest = sendRequest;
+		await clientWaitForDiagnostics(state, TEST_FILE, 1000, { pullOnly: true });
+		const bindingAfterFull = state.diagnosticBindings.get(TEST_KEY);
+		expect(bindingAfterFull?.contentHash).toBe(hashDiagnosticContent(content));
+
+		// Second pull: server confirms nothing changed (no `items`). Pre-#1104 this
+		// codepath always overwrote with `report.items ?? []` — an empty array —
+		// which would WRONGLY read as a confirmed-clean touch and silently wipe
+		// the still-live "boom" diagnostic (the #570/#571 false-clean shape).
+		sendRequest.mockResolvedValueOnce({ kind: "unchanged", resultId: "r1" });
+		await clientWaitForDiagnostics(state, TEST_FILE, 1000, { pullOnly: true });
+
+		// The prior finding AND its binding both survived the unchanged report.
+		expect(state.documentPullDiagnostics.get(TEST_KEY)?.length).toBe(1);
+		expect(state.diagnosticBindings.get(TEST_KEY)).toEqual(bindingAfterFull);
+		// The second request echoed the resultId from the first.
+		expect(sendRequest.mock.calls[1]?.[1]).toMatchObject({
+			previousResultId: "r1",
+		});
+	});
+
+	it("clearDiagnosticsForPath (a resync) drops the pull resultId basis so a later pull cannot inherit stale content", async () => {
+		const state = pullState();
+		state.openDocuments.add(TEST_KEY);
+		state.documentContentHashes.set(TEST_KEY, {
+			version: 1,
+			hash: hashDiagnosticContent("const x = 1;\n"),
+		});
+		state.connection.sendRequest = vi.fn().mockResolvedValue({
+			kind: "full",
+			resultId: "r1",
+			items: [],
+		});
+		await clientWaitForDiagnostics(state, TEST_FILE, 1000, { pullOnly: true });
+		expect(state.pullResultIds.get(TEST_KEY)).toBe("r1");
+
+		// A resync (didChange) clears diagnostic state for the path.
+		await handleNotifyChange(state, TEST_FILE, "const x = 2;\n");
+
+		expect(state.pullResultIds.has(TEST_KEY)).toBe(false);
+		expect(state.diagnosticBindings.has(TEST_KEY)).toBe(false);
+	});
+});
+
+describe("clientRequestWorkspaceDiagnostics content binding (#1104)", () => {
+	function pullSupportState(): LSPClientState {
+		return createMockState({
+			serverId: "typescript",
+			workspaceDiagnosticsSupport: {
+				advertised: true,
+				mode: "pull",
+				workspaceDiagnostics: true,
+				diagnosticProviderKind: "object",
+			},
+		});
+	}
+
+	it("fingerprints disk bytes at request time for a 'full' item and returns the hash", async () => {
+		const state = pullSupportState();
+		const filePath = path.join(os.tmpdir(), `pi-lens-1104-${Date.now()}.ts`);
+		const content = "const y = 2;\n";
+		fs.writeFileSync(filePath, content);
+		try {
+			const uri = pathToFileURL(filePath).href;
+			state.connection.sendRequest = vi.fn().mockResolvedValue({
+				items: [{ uri, kind: "full", resultId: "wr1", items: [] }],
+			});
+
+			const report = await clientRequestWorkspaceDiagnostics(state, 1000);
+
+			expect(report?.[0]?.contentHash).toBe(hashDiagnosticContent(content));
+		} finally {
+			fs.rmSync(filePath, { force: true });
+		}
+	});
+
+	it("an 'unchanged' item inherits the prior pull's diagnostics + contentHash and echoes previousResultIds on the next request", async () => {
+		const state = pullSupportState();
+		const filePath = path.join(os.tmpdir(), `pi-lens-1104b-${Date.now()}.ts`);
+		fs.writeFileSync(filePath, "const y = 2;\n");
+		try {
+			const uri = pathToFileURL(filePath).href;
+			const sendRequest = vi.fn().mockResolvedValueOnce({
+				items: [
+					{
+						uri,
+						kind: "full",
+						resultId: "wr1",
+						items: [
+							{
+								severity: 1,
+								message: "boom",
+								range: {
+									start: { line: 0, character: 0 },
+									end: { line: 0, character: 0 },
+								},
+							},
+						],
+					},
+				],
+			});
+			state.connection.sendRequest = sendRequest;
+			const first = await clientRequestWorkspaceDiagnostics(state, 1000);
+			const firstHash = first?.[0]?.contentHash;
+			expect(first?.[0]?.diagnostics.length).toBe(1);
+
+			sendRequest.mockResolvedValueOnce({
+				items: [{ uri, kind: "unchanged", resultId: "wr1" }],
+			});
+			const second = await clientRequestWorkspaceDiagnostics(state, 1000);
+
+			expect(second?.[0]?.diagnostics.length).toBe(1);
+			expect(second?.[0]?.contentHash).toBe(firstHash);
+			expect(sendRequest.mock.calls[1]?.[1]).toMatchObject({
+				previousResultIds: [{ uri, value: "wr1" }],
+			});
+		} finally {
+			fs.rmSync(filePath, { force: true });
+		}
 	});
 });
 

--- a/tests/clients/lsp/workspace-diagnostics-pull-binding.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-pull-binding.test.ts
@@ -1,0 +1,225 @@
+/**
+ * #1104: the workspace pull-sweep record site (`runWorkspaceDiagnostics` in
+ * clients/lsp/index.ts) used to call `workspaceDiagnosticsCacheCtx.record()`
+ * with NO contentHash — documented as an honest "unknown" (#1095's own doc
+ * comment). That meant every pull-served cache entry could never demote via
+ * the #1095 P2-1 service-sweep binding gate (`workspace-diagnostics-cache.
+ * test.ts` covers that gate directly with a hand-seeded entry).
+ *
+ * This suite proves the PRODUCE side end-to-end: a pull's `contentHash` (now
+ * threaded from `clients/lsp/client.ts`'s `requestWorkspaceDiagnostics`
+ * through `tryWorkspacePull`) actually reaches the persisted cache entry, and
+ * composing that with the pre-existing P2-1 CONSUME gate demotes a
+ * mtime-preserving content change that previously would have been replayed
+ * as confirmed forever.
+ *
+ * Also covers the sibling per-file touch path (`processFile`): the #1095
+ * push-path binding attached to `touchFile`'s returned diagnostics array is a
+ * NON-ENUMERABLE property (`Object.defineProperty(collected, "binding", ...)`).
+ * `applyAuxiliarySuppressions` rebuilds the array via `.filter()`, which does
+ * NOT carry non-enumerable properties on a copy (AGENTS.md shape 5) — so the
+ * record site must read the binding off the RAW diagnostics before that
+ * filter runs, not off the filtered copy.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hashDiagnosticContent } from "../../../clients/lsp/diagnostic-binding.js";
+import {
+	cacheKeyFor,
+	loadWorkspaceDiagnosticsCache,
+} from "../../../clients/lsp/workspace-diagnostics-cache.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+const getServersForFileWithConfig = vi.fn();
+const createLSPClient = vi.fn();
+vi.mock("../../../clients/lsp/config.js", () => ({
+	getServersForFileWithConfig,
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
+
+function makeServer(id: string, ext: string, root: string) {
+	return {
+		id,
+		name: id,
+		extensions: [ext],
+		root: async () => root,
+		spawn: vi.fn(async () => ({ process: {}, source: "test" })),
+	};
+}
+
+describe("runWorkspaceDiagnostics pull-sweep content binding (#1104)", () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		vi.resetModules();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+		tmp = fs.mkdtempSync(path.join(os.tmpdir(), "wsd-pull-binding-"));
+		fs.mkdirSync(path.join(tmp, ".pi-lens"));
+		process.env.PI_LENS_LSP_WORKSPACE_PULL = "1";
+	});
+	afterEach(() => {
+		delete process.env.PI_LENS_LSP_WORKSPACE_PULL;
+		removeTempDirSync(tmp);
+	});
+
+	it("threads the pull's contentHash into the persisted cache entry (previously always absent)", async () => {
+		const file = path.join(tmp, "a.py");
+		const content = "x = 1\n";
+		fs.writeFileSync(file, content);
+		const pyServer = makeServer("python", ".py", tmp);
+		getServersForFileWithConfig.mockImplementation((fp: string) =>
+			fp.endsWith(".py") ? [pyServer] : [],
+		);
+		const contentHash = hashDiagnosticContent(content);
+		createLSPClient.mockResolvedValue({
+			isAlive: () => true,
+			shutdown: async () => {},
+			serverId: "python",
+			getWorkspaceDiagnosticsSupport: () => ({
+				advertised: true,
+				mode: "pull" as const,
+				workspaceDiagnostics: true,
+				diagnosticProviderKind: "object",
+			}),
+			getOperationSupport: () => ({}),
+			notify: { open: vi.fn(async () => {}) },
+			requestWorkspaceDiagnostics: vi.fn(async () => [
+				{ filePath: file, diagnostics: [{ message: "boom" }], contentHash },
+			]),
+			waitForDiagnostics: vi.fn().mockResolvedValue(undefined),
+			getDiagnostics: vi.fn(() => []),
+		});
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		await new LSPService().runWorkspaceDiagnostics(tmp);
+
+		const cache = loadWorkspaceDiagnosticsCache(tmp);
+		const entry = cache?.entries[cacheKeyFor(file)];
+		expect(entry).toBeDefined();
+		// HEADLINE (fails pre-#1104): the record site never passed a contentHash
+		// at all, so this field was always undefined regardless of what the pull
+		// returned.
+		expect(entry?.contentHash).toBe(contentHash);
+	});
+
+	it("HEADLINE fail-then-pass: a pull-recorded entry whose content changed (mtime-preserving) is NOT replayed on the next sweep", async () => {
+		const file = path.join(tmp, "a.py");
+		const originalContent = "x = 1\n";
+		fs.writeFileSync(file, originalContent);
+		const pyServer = makeServer("python", ".py", tmp);
+		getServersForFileWithConfig.mockImplementation((fp: string) =>
+			fp.endsWith(".py") ? [pyServer] : [],
+		);
+		const requestWorkspaceDiagnostics = vi.fn(async () => [
+			{
+				filePath: file,
+				diagnostics: [{ message: "boom" }],
+				contentHash: hashDiagnosticContent(originalContent),
+			},
+		]);
+		createLSPClient.mockResolvedValue({
+			isAlive: () => true,
+			shutdown: async () => {},
+			serverId: "python",
+			getWorkspaceDiagnosticsSupport: () => ({
+				advertised: true,
+				mode: "pull" as const,
+				workspaceDiagnostics: true,
+				diagnosticProviderKind: "object",
+			}),
+			getOperationSupport: () => ({}),
+			notify: { open: vi.fn(async () => {}) },
+			requestWorkspaceDiagnostics,
+			waitForDiagnostics: vi.fn().mockResolvedValue(undefined),
+			getDiagnostics: vi.fn(() => []),
+		});
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		await service.runWorkspaceDiagnostics(tmp);
+		expect(requestWorkspaceDiagnostics).toHaveBeenCalledTimes(1);
+
+		// The file's real bytes changed WITHOUT an mtime bump — corrupt the
+		// persisted entry's contentHash the same deterministic way #1095's own
+		// P2-1 gate test does (`workspace-diagnostics-cache.test.ts`), avoiding
+		// OS mtime-resolution flakiness while representing exactly the same
+		// invalidation shape (recorded fingerprint no longer matches disk under
+		// a matching mtime).
+		const cachePath = path.join(
+			tmp,
+			".pi-lens",
+			"cache",
+			"lsp-workspace-diagnostics.json",
+		);
+		const raw = JSON.parse(fs.readFileSync(cachePath, "utf-8"));
+		const key = cacheKeyFor(file);
+		expect(raw.entries[key].contentHash).toBe(
+			hashDiagnosticContent(originalContent),
+		);
+		raw.entries[key].contentHash = hashDiagnosticContent("x = 999\n");
+		fs.writeFileSync(cachePath, JSON.stringify(raw, null, 2));
+
+		// A second sweep: pre-#1104 the entry's contentHash was NEVER recorded in
+		// the first place, so its binding always read "unknown" (`!== false`) and
+		// the cache hit would have been served — zero further pull calls. Post-
+		// #1104 the mismatch demotes the entry, so the sweep falls through to a
+		// fresh pull.
+		await service.runWorkspaceDiagnostics(tmp);
+		expect(requestWorkspaceDiagnostics).toHaveBeenCalledTimes(2);
+	});
+
+	it("threads a per-file touch's #1095 binding contentHash into the cache, surviving applyAuxiliarySuppressions' .filter() copy (shape 5)", async () => {
+		delete process.env.PI_LENS_LSP_WORKSPACE_PULL; // exercise the per-file touch path, not the pull fast path
+		const file = path.join(tmp, "a.ts");
+		const content = "const z = 1;\n";
+		fs.writeFileSync(file, content);
+		const tsServer = makeServer("typescript", ".ts", tmp);
+		getServersForFileWithConfig.mockImplementation((fp: string) =>
+			fp.endsWith(".ts") ? [tsServer] : [],
+		);
+		const contentHash = hashDiagnosticContent(content);
+		createLSPClient.mockResolvedValue({
+			isAlive: () => true,
+			shutdown: async () => {},
+			serverId: "typescript",
+			getWorkspaceDiagnosticsSupport: () => ({
+				advertised: false,
+				mode: "push-only" as const,
+				diagnosticProviderKind: "none",
+			}),
+			getOperationSupport: () => ({}),
+			notify: { open: vi.fn(async () => {}) },
+			waitForDiagnostics: vi.fn().mockResolvedValue(undefined),
+			// touchFile's real merge logic (index.ts, not mocked) composes each
+			// spawned client's `getDiagnosticBinding` into the non-enumerable
+			// `.binding` it attaches to the returned diagnostics array.
+			getDiagnosticBinding: () => ({ contentHash }),
+			getDiagnostics: vi.fn(() => [
+				{
+					severity: 1,
+					message: "boom",
+					range: {
+						start: { line: 0, character: 0 },
+						end: { line: 0, character: 0 },
+					},
+				},
+			]),
+		});
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		await new LSPService().runWorkspaceDiagnostics(tmp);
+
+		const cache = loadWorkspaceDiagnosticsCache(tmp);
+		const entry = cache?.entries[cacheKeyFor(file)];
+		expect(entry).toBeDefined();
+		// HEADLINE (fails pre-#1104): `processFile` read `.binding` off the
+		// FILTERED copy (or didn't read it at all), which never carries the
+		// source array's non-enumerable property.
+		expect(entry?.contentHash).toBe(contentHash);
+	});
+});


### PR DESCRIPTION
## What
Extends diagnostics content-binding to the LSP pull-diagnostics protocol (`closes #1104`). Follow-up to the merged #1095/#1096/#1100 push-path arc. (Two of the issue's three items — the cascade fallback-display binding gate and the `neighbor_touch` `inconclusive` field — were already merged via #1143; this does the remaining resultId main body + one leftover #1143-review P3 that explicitly "rides with the resultId work".)

## Core — thread resultId + content hash through both pull protocols (`clients/lsp/client.ts`)
- **`textDocument/diagnostic`** (`clientRequestPullDiagnostics`): sends `previousResultId`; reuses the existing sent-content hash (`documentContentHashes`, the same fingerprint `recordSentContent` already captures on every didOpen/didChange — **zero extra reads**) to populate `state.diagnosticBindings` on a `"full"` report. A `"kind":"unchanged"` report now **inherits** the prior diagnostics/binding instead of being misread as confirmed-clean `[]` (the #570/#571 false-clean shape).
- **`workspace/diagnostic`** (`clientRequestWorkspaceDiagnostics`): sends real `previousResultIds`; hashes disk bytes at request time for `"full"` items (new `state.workspacePullResultCache`, **bounded** like the existing disk-binding memo — shape 9); inherits basis for `"unchanged"` items.
- `clearDiagnosticsForPath` now also drops `pullResultIds`/`workspacePullResultCache` so a resync can't inherit a stale basis.

## Pull-sweep record site (`clients/lsp/index.ts`)
`LSPWorkspaceDiagnosticResult` gained `contentHash`; `tryWorkspacePull` + `processFile` populate it and pass it to `workspaceDiagnosticsCacheCtx.record()` — closing the exact gap the issue named ("pull-sweep record site passes no contentHash").

## Shape-5 fixes (side-channel property dropped through a copy)
- `processFile` reads `.binding` off the raw `touchFile` diagnostics **before** `applyAuxiliarySuppressions`'s `.filter()` rebuilds the array (a `.filter()` copy drops the non-enumerable `.binding`).
- Found + fixed a related bug in `LSPService.mergeBinding`: it gated a contributor's surfaced `contentHash` on that contributor **also** carrying a `version` — but pull bindings legitimately carry a hash with **no** version, so this silently dropped them even after the plumbing fix. Caught by a new test, not spec'd in the issue.

## P3 fold-in (`clients/runtime-turn.ts`)
The indeterminate-advisory preamble now branches by reason family: `graph_degraded`/`missing_node`/`error` keep byte-identical pre-existing wording (verified via untouched existing test); `lsp_binding_rejected` gets an accurate "dependents identified but diagnostics couldn't be freshly confirmed" frame instead of the wrong "review graph was unavailable."

## Tests
Fail-then-pass verified (patch/checkout/apply, never stash): 9 new/changed assertions fail on pre-fix. New `tests/clients/lsp/workspace-diagnostics-pull-binding.test.ts` (incl. the mtime-preserving demotion headline test), additions to `client-internals.test.ts` + `cascade-turn-merge.test.ts`. Build/lint/changelog green. One pre-existing UNRELATED failure noted (`trivy-config.test.ts` POSIX-path assumption, present on clean checkout, untouched here).

`closes #1104` (refs #1095 #1096 #1100 #1143).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
