### PR TITLE
fix(diagnostics): migrate inconclusive/binding side-channel flags to an enumerable wrapper (closes #1179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Structural shape-5 hardening: LSP `touchFile` now returns a `{ diags, inconclusive, binding }` wrapper whose flags survive any copy by construction, plus a fail-closed graph-build-info guard (closes #1179, refs #1108 #1094 #1096)** —
+	the #1108 audit found all five side-channel flags safe as-is (every consumer
+	reads off the original), but the three LSP diagnostics flags stayed
+	fragile-by-construction: a non-enumerable property hung on the returned
+	diagnostics array, silently dropped by any `[...]`/`.map`/`.filter`/
+	`structuredClone`/`JSON` copy between producer and consumer (the class that bit
+	as #1094 `inconclusive` and #1096 `binding`). `touchFile` now resolves an
+	explicit `TouchFileResult` wrapper (`clients/lsp/diagnostic-binding.ts`) with
+	`inconclusive` and `binding` as ENUMERABLE fields alongside `.diags`, so a copy
+	operates on `.diags` and can no longer drop them — the copy-loss is impossible
+	by construction. Every flag-reading consumer was migrated in lockstep (the
+	cascade `readInconclusive`/`readBoundToCurrentDisk`/`isConfirmedTouch` and its
+	`.filter()` site in `clients/dispatch/integration.ts`, the dispatch LSP runner,
+	the `lsp_diagnostics` tool, the workspace-sweep `lens_diagnostics mode=full`
+	path, and the warm-attach IPC producer — which continues to re-surface
+	`inconclusive` as an enumerable DTO field over the socket). Behavior is
+	IDENTICAL — same flags, same values, same decisions; only the carriage
+	changed. `getAllDiagnostics`'s per-entry `binding` is DELIBERATELY left as a
+	lazy non-enumerable getter on the documented read-off-original contract (making
+	it enumerable would fire the per-file disk stat+hash on any incidental spread —
+	the stat storm its laziness exists to prevent). Separately closes a latent P3
+	from the #1108 review: `getGraphBuildInfoForGraph`'s global-slot fallback could
+	serve a SIBLING graph's build-info on a `_graphBuildInfoByGraph` identity miss,
+	feeding the `graph_degraded` marker gate a (possibly healthy) sibling verdict —
+	a new `graphBuildInfoIsTrustworthy` guard fails CLOSED so an unstamped/rehydrated
+	graph surfaces an honest degraded/unknown advisory instead of a #533 false
+	clean. Inert on the live path (every build stamps its returned graph before the
+	cascade reads it). An ast-grep rule remains not viable (AGENTS.md shape 5 is
+	semantic; cross-ref #1158).
 - **Per-entry widget observation timestamps: a cross-file cascade merge no longer over-clears a whole footer record, dropping only the genuinely-stale entries (closes #1186, refs #1093 #1092 #1020)** —
 	`reconcileCascadeNeighborLspErrors` → `commitDiagnostics` used to stamp the
 	ENTIRE merged record's single `touchedAt` with the incoming `observedAt`

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -60,6 +60,7 @@ import {
 import { classifyCascadeWaitTier } from "../lsp/wait-policy/index.js";
 import {
 	type BoundToCurrentDisk,
+	type TouchFileResult,
 	bindingStateLabel,
 } from "../lsp/diagnostic-binding.js";
 import { getServersForFileWithConfig } from "../lsp/config.js";
@@ -71,6 +72,7 @@ import {
 	clearReviewGraphWorkspaceCache,
 	getGraphBuildInfoForGraph,
 	getGraphImportChanges,
+	graphBuildInfoIsTrustworthy,
 } from "../review-graph/builder.js";
 import {
 	buildReverseDependencyIndexFromGraph,
@@ -539,15 +541,17 @@ function cascadeReconcilableLspErrors(
 }
 
 /**
- * Read the content `binding` verdict off a raw diagnostics result (#1095).
+ * Read the content `binding` verdict off a diagnostics result (#1095).
  *
- * Both `touchFile` and `getAllDiagnostics` attach `binding` as a NON-enumerable
- * property (the latter as a lazy, disk-verifying getter). Reading it directly off
- * the producer's own object — never a spread/clone, which drops non-enumerables —
- * triggers the disk verify exactly once (memoized per result object). Returns
- * `undefined` when no binding was attached at all (a partially-mocked client, a
- * non-collecting touch) — indistinguishable from "unknown" at every call site,
- * which is the intended pre-#1095 fall-through.
+ * `touchFile` carries `binding` as an EXPLICIT enumerable field on its
+ * `TouchFileResult` wrapper (#1179), so it survives any copy of `.diags`.
+ * `getAllDiagnostics` still attaches `binding` as a lazy, disk-verifying
+ * NON-enumerable getter on each Map entry — reading it directly off the
+ * producer's own entry (never a spread/clone, which drops non-enumerables)
+ * triggers the disk verify exactly once (memoized per entry). Accepts either
+ * shape; returns `undefined` when no binding was attached at all (a partially-
+ * mocked client, a non-collecting touch) — indistinguishable from "unknown" at
+ * every call site, which is the intended pre-#1095 fall-through.
  */
 function readBoundToCurrentDisk(
 	rawDiags: unknown,
@@ -571,17 +575,15 @@ function readBoundToCurrentDisk(
  *    `"unknown"` both pass; `"unknown"` preserves pre-#1095 behavior for a
  *    version-less server exactly.
  *
- * Both flags are non-enumerable on the `touchFile` result — read them directly off
- * `rawDiags`, never off a spread/clone (which drops them). See the memo-freeze note
- * at the `getAllDiagnostics` call site.
+ * #1179: both flags are EXPLICIT enumerable fields on the `touchFile`
+ * `TouchFileResult` wrapper — read them off the wrapper (`rawDiags`), whose
+ * `.diags` a downstream `.filter()`/copy operates on without touching the flags.
  */
 function readInconclusive(rawDiags: unknown): boolean {
 	return (rawDiags as { inconclusive?: boolean })?.inconclusive === true;
 }
 
-function isConfirmedTouch(
-	rawDiags: readonly import("../lsp/client.js").LSPDiagnostic[],
-): boolean {
+function isConfirmedTouch(rawDiags: TouchFileResult): boolean {
 	return !readInconclusive(rawDiags) && readBoundToCurrentDisk(rawDiags) !== false;
 }
 
@@ -873,6 +875,15 @@ export async function computeCascadeForFile(
 		// a false positive: a graph-mutating build always mints a new generation.
 		// An unstamped graph (mode "skipped") always rebuilds.
 		const graphBuildInfo = getGraphBuildInfoForGraph(graph);
+		// #1179 fail-closed: `getGraphBuildInfoForGraph` falls back to the global
+		// last-build slot on a WeakMap identity miss, which — once some real build
+		// has stamped — could carry a SIBLING graph's healthy `mode: "cached"`. The
+		// degraded-marker gate below must not read a sibling's state, so it checks
+		// trustworthiness and, when the slot cannot be trusted for THIS graph, treats
+		// coverage as unknown (degraded) rather than clean. Always trustworthy on the
+		// live path — every `_doBuildGraph` return stamps the graph before the cascade
+		// reads it — so this is inert today and only hardens a future unstamped graph.
+		const graphBuildInfoTrustworthy = graphBuildInfoIsTrustworthy(graph);
 		const workspaceKey = normalizeMapKey(cwd);
 		const cachedReverseDeps = reverseDepsIndexCache.get(workspaceKey);
 		const importDelta = getGraphImportChanges(graph);
@@ -1018,14 +1029,20 @@ export async function computeCascadeForFile(
 		// degraded marker, NOT off `neighborFiles.length === 0`.
 		if (
 			(graphBuildInfo.mode === "skipped" ||
-				graph.persistCoverage?.partial === true) &&
+				graph.persistCoverage?.partial === true ||
+				!graphBuildInfoTrustworthy) &&
 			!impact.indeterminate
 		) {
 			const coverage = graph.persistCoverage;
 			impact.indeterminate = {
 				reason: "graph_degraded",
-				detail:
-					graphBuildInfo.mode === "skipped"
+				detail: !graphBuildInfoTrustworthy
+					? // #1179 fail-closed: the graph's own build-info was not found under
+						// its identity and the global slot may be a sibling build's — don't
+						// trust its mode. Surface an honest "unknown" advisory rather than a
+						// (possibly sibling-derived) all-clear.
+						"review graph coverage unknown — build state unavailable for this graph"
+					: graphBuildInfo.mode === "skipped"
 						? graphBuildInfo.skipReason === "too_many_files"
 							? `review graph disabled — ${graphBuildInfo.sourceFileCount ?? "?"} files over the ${graphBuildInfo.maxFileCount ?? "?"} cap`
 							: graphBuildInfo.skipReason === "unsafe_root"
@@ -1591,8 +1608,11 @@ export async function computeCascadeForFile(
 				// doc comment on the sibling call above) — dropped rather than
 				// migrated to `scanOrigin` since cascade output never touches
 				// persisted widget/dedup state.
+				// #1179: `.filter()` here operates on `rawDiags.diags`; the
+				// `inconclusive`/`binding` flags read above stay on the `rawDiags`
+				// wrapper and are unaffected by this copy (the shape-5 fix).
 				const diags = convertLspDiagnostics(
-					rawDiags.filter((d) => d.severity === 1).slice(0, MAX_PER_FILE),
+					rawDiags.diags.filter((d) => d.severity === 1).slice(0, MAX_PER_FILE),
 					neighborPath,
 				);
 				const durationMs = Date.now() - neighborStart;
@@ -1659,7 +1679,7 @@ export async function computeCascadeForFile(
 				if (confirmed) {
 					reconcileCascadeNeighborLspErrors(
 						neighborPath,
-						cascadeReconcilableLspErrors(rawDiags, neighborPath),
+						cascadeReconcilableLspErrors(rawDiags.diags, neighborPath),
 						writeSeq,
 					);
 				}

--- a/clients/dispatch/runners/lsp.ts
+++ b/clients/dispatch/runners/lsp.ts
@@ -168,8 +168,13 @@ const lspRunner: RunnerDefinition = {
 				Math.max(LSP_SPAWN_BUDGET_MS, LSP_DIAGNOSTICS_WAIT_MS),
 			);
 			usedWarmAttach = attached?.available === true;
+			// #1179 (shape-5 structural fix): both branches normalize to the
+			// `touchFile` wrapper shape. The warm-attach IPC branch resolves a plain
+			// diagnostics array (the socket cannot carry a side-channel; the IPC client
+			// already rejected any inconclusive answer, so `available` ⟹ confirmed) —
+			// wrap it as `{ diags }`; the incumbent branch already returns the wrapper.
 			const touched = attached?.available
-				? attached.response.diagnostics
+				? { diags: attached.response.diagnostics }
 				: await lspService.touchFile(ctx.filePath, content, {
 				diagnostics: "document",
 				collectDiagnostics: true,
@@ -182,10 +187,8 @@ const lspRunner: RunnerDefinition = {
 			if (touched === undefined) {
 				lspClientReady = false;
 			} else {
-				lspDiags = touched;
-				diagnosticsInconclusive =
-					(touched as typeof touched & { inconclusive?: boolean })
-						.inconclusive === true;
+				lspDiags = touched.diags;
+				diagnosticsInconclusive = touched.inconclusive === true;
 			}
 		} catch (err) {
 			serverFailed = true;

--- a/clients/lsp/diagnostic-binding.ts
+++ b/clients/lsp/diagnostic-binding.ts
@@ -45,29 +45,59 @@ export interface StoredDiagnosticBinding {
  * The read-time binding surfaced to consumers: the stored half plus the lazily
  * computed disk verdict.
  *
- * SIDE-CHANNEL CARRIAGE CONTRACT (#1108 shape-5 — copy-loss risk). A binding is
- * hung on a diagnostics result as a NON-enumerable property: `touchFile` attaches
- * it as a value and `getAllDiagnostics` as a lazy disk-verifying getter (both on
- * `clients/lsp/index.ts`), so it does NOT appear in the diagnostics array's own
- * enumeration. Consequences every consumer must honor:
- *   - READ IT OFF THE ORIGINAL producer object, never off a derived copy. Any
- *     `{...result}` / `[...result]` / `.map` / `.filter` / `structuredClone` /
- *     `JSON.parse(JSON.stringify(...))` between the producer and the read SILENTLY
- *     DROPS the binding — the consumer then reads `undefined` (indistinguishable
- *     from "unknown") and skips the #1092 staleness demotion. This is the class
- *     that bit as #1094 (`inconclusive`) and #1096 (`binding`); the cascade reads
- *     both flags off `rawDiags`/`entry` BEFORE its `.filter()` for exactly this
- *     reason (`clients/dispatch/integration.ts` `readBoundToCurrentDisk`).
- *   - IF IT MUST CROSS A SERIALIZATION BOUNDARY (the warm-attach IPC socket, a JSON
- *     round-trip), re-surface it as an EXPLICIT enumerable field on the transport
- *     wrapper — a non-enumerable side-channel never survives `JSON.stringify`. See
- *     `clients/warm-attach.ts`, which carries `inconclusive` as an enumerable
- *     response field precisely because the array's side-channel does not survive.
- * The structural fix (a `{ diags, inconclusive, binding }` wrapper that makes the
- * loss impossible by construction) is tracked as a follow-up to #1108 (#1179).
+ * SIDE-CHANNEL CARRIAGE CONTRACT (#1108 shape-5 — copy-loss risk). Two producers
+ * on `clients/lsp/index.ts` surface a binding:
+ *   - `touchFile` returns a `TouchFileResult` WRAPPER (`{ diags, inconclusive,
+ *     binding }`, below) — the #1179 structural fix. `inconclusive`/`binding` are
+ *     EXPLICIT ENUMERABLE fields on that wrapper, so a `[...]`/`.map`/`.filter`/
+ *     `structuredClone`/`JSON` copy of the DIAGNOSTICS (`.diags`) can no longer
+ *     drop them: the copy operates on `.diags`, the flags stay on the wrapper.
+ *   - `getAllDiagnostics` still attaches `binding` as a lazy, disk-verifying
+ *     NON-enumerable getter on each Map entry — deliberately NOT migrated to an
+ *     enumerable field, because enumerable would make an incidental spread/serialize
+ *     eagerly trigger the per-entry disk stat+hash (a stat storm the cascade's
+ *     TTL-gated read exists to avoid). That getter therefore KEEPS the read-off-
+ *     original contract:
+ *       - READ IT OFF THE ORIGINAL producer entry, never off a derived copy. Any
+ *         `{...entry}` / `structuredClone` / `JSON.parse(JSON.stringify(...))`
+ *         between the producer and the read SILENTLY DROPS the getter — the consumer
+ *         then reads `undefined` (indistinguishable from "unknown") and skips the
+ *         #1092 staleness demotion. This is the class that bit as #1094
+ *         (`inconclusive`) and #1096 (`binding`); the cascade reads the binding off
+ *         the original `entry` BEFORE any copy for exactly this reason
+ *         (`clients/dispatch/integration.ts` `readBoundToCurrentDisk`).
+ *   - IF A FLAG MUST CROSS A SERIALIZATION BOUNDARY (the warm-attach IPC socket, a
+ *     JSON round-trip), re-surface it as an EXPLICIT enumerable field on the
+ *     transport DTO — no side-channel (enumerable or not) survives `JSON.stringify`
+ *     of a `.diags` array. See `clients/warm-attach.ts`/`clients/mcp/ipc.ts`, which
+ *     carry `inconclusive` as an enumerable response field for exactly this reason.
  */
 export interface DiagnosticBinding extends StoredDiagnosticBinding {
 	boundToCurrentDisk: BoundToCurrentDisk;
+}
+
+/**
+ * #1179 (shape-5 structural fix): the confirmed shape a diagnostics-collecting
+ * `touchFile` resolves to. The diagnostics array plus the two former
+ * NON-enumerable side-channel flags (`inconclusive` #570/#1093, `binding` #1095)
+ * promoted to EXPLICIT ENUMERABLE fields on a wrapper, so the copy-loss class of
+ * #1094/#1096 is impossible BY CONSTRUCTION: a copy of the diagnostics operates on
+ * `.diags` and never touches the flags on the wrapper.
+ *
+ * `diags` is always present (empty array when nothing was collected). `inconclusive`
+ * is present-and-true only for a genuinely unconfirmed collect (the notify write
+ * and/or diagnostics wait lapsed its deadline) — absent/false means confirmed;
+ * consumers that care about trustworthiness (dispatch runners, the `lsp_diagnostics`
+ * tool, the cascade) MUST check it before treating an empty `.diags` as clean.
+ * `binding` is present only for a collecting touch that composed one (absent →
+ * "unknown", the honest #533 fall-through). A non-collecting touch
+ * (`collectDiagnostics: false` / `diagnostics: "none"`) resolves to `{ diags: [] }`
+ * with neither flag, exactly as before.
+ */
+export interface TouchFileResult {
+	diags: import("./client.js").LSPDiagnostic[];
+	inconclusive?: boolean;
+	binding?: DiagnosticBinding;
 }
 
 /**

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -46,6 +46,7 @@ import {
 	type DiagnosticBinding,
 	type DiskBindingCache,
 	type StoredDiagnosticBinding,
+	type TouchFileResult,
 } from "./diagnostic-binding.js";
 import { getServersForFileWithConfig, getServerInitOverride } from "./config.js";
 import { getLanguageId } from "./language.js";
@@ -1813,36 +1814,13 @@ export class LSPService {
 		content: string,
 		options: LSPTouchFileOptions = {},
 	): Promise<
-		| (import("./client.js").LSPDiagnostic[] & {
-				/**
-				 * True when this touch could NOT confirm its result — the notify
-				 * write and/or the diagnostics wait hit their deadline before the
-				 * server(s) confirmed completion. An `inconclusive` result must
-				 * never be read as "confirmed clean": the returned array may be
-				 * `[]` simply because nothing arrived in time, not because the
-				 * server actually reported zero diagnostics. Callers that care
-				 * about trustworthiness (dispatch runners, the `lsp_diagnostics`
-				 * tool) must check this before treating an empty result as clean.
-				 * Absent/`false` on a genuinely confirmed (fast or debounced-skip)
-				 * result — existing callers that only read the array are
-				 * unaffected (arrays are plain objects; this is a non-enumerable
-				 * bonus field, not a shape change).
-				 */
-				inconclusive?: boolean;
-				/**
-				 * #1095: content binding of the merged result — {version?,
-				 * contentHash?, boundToCurrentDisk} answering "were these
-				 * diagnostics computed against what's on disk now?" composed across
-				 * every contributing client. `boundToCurrentDisk === false` means
-				 * the server's view diverged from disk (a stale-but-fresh-looking
-				 * result); consumers must demote such a result to inconclusive
-				 * rather than trust it. "unknown" (version-less server, or disk
-				 * unreadable) preserves pre-#1095 behavior. Non-enumerable, like
-				 * `inconclusive`.
-				 */
-				binding?: DiagnosticBinding;
-			})
-		| undefined
+		// #1179 (shape-5 structural fix): a WRAPPER, not the bare array. `.diags`
+		// carries the diagnostics; `.inconclusive` (#570/#1093) and `.binding`
+		// (#1095) are EXPLICIT ENUMERABLE fields, so a `[...]`/`.map`/`.filter`/
+		// `JSON` copy of `.diags` cannot silently drop them (was the #1094/#1096
+		// copy-loss class — the flags used to ride the array as non-enumerable
+		// side-channels). See `TouchFileResult` for the field-presence contract.
+		TouchFileResult | undefined
 	> {
 		if (this.checkDestroyed()) return;
 		const startedAt = Date.now();
@@ -1930,7 +1908,9 @@ export class LSPService {
 					reason: "debounced_unchanged_content",
 				},
 			});
-			return [];
+			// #1179: a debounced skip collected nothing — resolve the wrapper's
+			// `.diags` as empty with neither flag (exactly the pre-wrapper `[]`).
+			return { diags: [] };
 		}
 
 		const languageId = getLanguageId(filePath) ?? "plaintext";
@@ -2712,23 +2692,26 @@ export class LSPService {
 			}
 		}
 
+		// #1179 (shape-5 structural fix): build the result WRAPPER. The two flags
+		// that used to ride the returned array as NON-enumerable side-channels
+		// (`Object.defineProperty(collected, ...)`, dropped by any `[...]`/`.filter`/
+		// `JSON` copy — the #1094/#1096 loss class) are now EXPLICIT ENUMERABLE
+		// fields on this wrapper. `.diags` holds the array a copy operates on, so the
+		// flags survive by construction. Field presence mirrors the old attachment
+		// conditions EXACTLY: `inconclusive` only for a confirmed-inconclusive
+		// collect, `binding` only for a collecting touch — a non-collecting touch
+		// keeps resolving `{ diags: [] }`, no flags.
+		const result: TouchFileResult = { diags: collected ?? [] };
+
 		if (collected !== undefined && inconclusive) {
-			// Non-enumerable so JSON.stringify / spread / logging of the
-			// diagnostics array is unaffected — this is a query-only bonus
-			// field, not a shape change existing array consumers need to know
-			// about.
-			Object.defineProperty(collected, "inconclusive", {
-				value: true,
-				enumerable: false,
-				configurable: true,
-			});
+			result.inconclusive = true;
 		}
 
-		// #1095: attach the merged content binding (non-enumerable, like
-		// `inconclusive`) so a consumer can ask whether these diagnostics were
-		// computed against current disk. Composed across every spawned client so a
-		// single client whose view diverged from disk marks the whole merged result
-		// mismatched. Disk verify is lazy + memoized per (file, mtime).
+		// #1095: attach the merged content binding so a consumer can ask whether
+		// these diagnostics were computed against current disk. Composed across every
+		// spawned client so a single client whose view diverged from disk marks the
+		// whole merged result mismatched. Disk verify is lazy + memoized per
+		// (file, mtime).
 		let binding: DiagnosticBinding | undefined;
 		if (collected !== undefined) {
 			binding = syncConfirmed
@@ -2745,11 +2728,7 @@ export class LSPService {
 							entry.client.getDiagnosticBinding?.(filePath),
 						),
 					);
-			Object.defineProperty(collected, "binding", {
-				value: binding,
-				enumerable: false,
-				configurable: true,
-			});
+			result.binding = binding;
 		}
 
 		// Only refresh the recent-touches entry when we actually pushed. Skipping
@@ -2795,7 +2774,7 @@ export class LSPService {
 				...(auxCutOffServerIds !== undefined && { auxCutOffServerIds }),
 			},
 		});
-		return collected ?? [];
+		return result;
 	}
 
 	/**
@@ -4250,8 +4229,16 @@ export class LSPService {
 				if (attached && !attached.available) {
 					await this.ensureWarmForSweep(filePath, { signal });
 				}
-				const diagnostics = attached?.available
-					? attached.response.diagnostics
+				// #1179 (shape-5 structural fix): normalize both sources into the
+				// `TouchFileResult` wrapper shape so the flag reads below come off
+				// EXPLICIT fields, not a non-enumerable side-channel a copy would drop.
+				// The warm-attach IPC branch resolves a plain diagnostics array with
+				// `inconclusive` re-surfaced as an enumerable DTO field (the socket can
+				// carry no binding, and the IPC client already rejects an inconclusive
+				// answer, so `available` implies confirmed) — wrap it as `{ diags }`;
+				// the incumbent branch already returns the wrapper.
+				const touchResult = attached?.available
+					? { diags: attached.response.diagnostics }
 					: await withDeadline(
 							this.touchFile(filePath, content, {
 								diagnostics: "document",
@@ -4269,34 +4256,22 @@ export class LSPService {
 							}),
 							{ ms: perFileMs, onTimeout: "undefined" },
 						);
+				const diagnostics = touchResult?.diags;
 				// #571: prefer #570's real per-touch inconclusive signal
-				// (`touchFile`'s non-enumerable `.inconclusive` flag — set when the
-				// notify write or the diagnostics wait itself timed out) over this
-				// sweep's own OUTER `perFileMs` deadline, which only catches a touch
-				// that never returned at all within budget. Either one means the
-				// result wasn't confirmed.
-				const inconclusive =
-					(diagnostics as (typeof diagnostics & { inconclusive?: boolean }))
-						?.inconclusive === true;
-				const timedOut = diagnostics === undefined || inconclusive;
+				// (`touchFile`'s `.inconclusive` flag — set when the notify write or the
+				// diagnostics wait itself timed out) over this sweep's own OUTER
+				// `perFileMs` deadline, which only catches a touch that never returned at
+				// all within budget. Either one means the result wasn't confirmed.
+				const inconclusive = touchResult?.inconclusive === true;
+				const timedOut = touchResult === undefined || inconclusive;
 				if (timedOut) timedOutFiles += 1;
-				// #1104 (shape 5 — AGENTS.md): read the touch's content binding off
-				// the RAW `diagnostics` array here, before `applyAuxiliarySuppressions`
-				// below rebuilds it via `.filter()` — a `.filter()` result is a NEW
-				// array and does not carry over the source's non-enumerable
-				// `.binding` (see #1095's own `Object.defineProperty` comment: "JSON.
-				// stringify / spread / logging ... unaffected" cuts both ways — a
-				// derived COPY never gets it either). A version-less/pull-less
-				// server's `diagnostics` simply carries no `.binding`, so
-				// `contentHash` stays undefined here (honest "unknown" downstream),
-				// matching pre-#1104 behavior exactly.
-				const rawBinding = (
-					diagnostics as
-						| (typeof diagnostics & {
-								binding?: import("./diagnostic-binding.js").DiagnosticBinding;
-						  })
-						| undefined
-				)?.binding;
+				// #1104 (shape 5 — AGENTS.md): the touch's content binding is an
+				// EXPLICIT enumerable field on the wrapper now (#1179), so it survives
+				// `applyAuxiliarySuppressions` below rebuilding `.diags` via `.filter()`
+				// — read it off `touchResult`, not off the derived array. A version-
+				// less/pull-less server composed no binding, so `contentHash` stays
+				// undefined here (honest "unknown" downstream), matching prior behavior.
+				const rawBinding = touchResult?.binding;
 				// #586: honor each auxiliary profile's native inline-suppression
 				// comment (e.g. opengrep's `// nosemgrep`, #441) — computed from the
 				// raw `diagnostics` (before this drops its non-enumerable
@@ -4666,6 +4641,13 @@ export class LSPService {
 		// consumer that arrives next. Non-enumerable so incidental spread/serialize
 		// (e.g. logging) can't trigger a stat storm; memoized per entry so repeated
 		// reads verify once.
+		// #1179: DELIBERATELY NOT migrated to an enumerable wrapper field (unlike the
+		// `touchFile` flags). Enumerable would make an incidental `{...entry}`/serialize
+		// eagerly fire this getter and stat every file — the exact stat storm the
+		// laziness above exists to prevent. It therefore stays on the read-off-original
+		// carriage contract (see `DiagnosticBinding`): every consumer reads `.binding`
+		// off the ORIGINAL Map entry (`clients/dispatch/integration.ts` reads it off
+		// `entry`, never a copy), and the cascade's TTL gate reads it only when fresh.
 		for (const [filePath, entry] of all) {
 			const stored = bindingsByPath.get(filePath) ?? [];
 			let memo: DiagnosticBinding | undefined;

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -265,14 +265,52 @@ let _lastGraphBuildInfo: GraphBuildInfo = {
 // The global slot above is retained for legacy status surfaces, but overlapping
 // deferred builds need a per-result identity for lifecycle telemetry.
 const _graphBuildInfoByGraph = new WeakMap<ReviewGraph, GraphBuildInfo>();
+// #1179: true once ANY graph has been stamped since the last cache clear — i.e.
+// `_lastGraphBuildInfo` may now hold a REAL build's info (a potential sibling)
+// rather than the pristine `mode: "full"` default. Used only by the fail-closed
+// safety read below to decide whether the global slot is safe to serve on a
+// WeakMap identity miss.
+let _anyGraphStamped = false;
 
 function setGraphBuildInfo(graph: ReviewGraph, info: GraphBuildInfo): void {
 	_lastGraphBuildInfo = info;
 	_graphBuildInfoByGraph.set(graph, info);
+	_anyGraphStamped = true;
 }
 
 export function getGraphBuildInfoForGraph(graph: ReviewGraph): GraphBuildInfo {
 	return _graphBuildInfoByGraph.get(graph) ?? _lastGraphBuildInfo;
+}
+
+/**
+ * #1179 (fail-closed guard, latent P3 from the #1108/#1180 side-channel audit).
+ * Whether `getGraphBuildInfoForGraph(graph)` can be TRUSTED to describe `graph`
+ * itself — for a SAFETY gate that must never read a sibling graph's state.
+ *
+ * `getGraphBuildInfoForGraph` deliberately falls back to the global
+ * `_lastGraphBuildInfo` slot on a WeakMap identity miss — fine for the telemetry
+ * and `updateGraphBuildInfo` base-read callers, where a sibling build's `mode` is
+ * only informational (and the first stamp of a graph legitimately bases off the
+ * prior slot). But a gate that decides degraded-vs-clean must not read a DIFFERENT
+ * graph's `mode: "cached"` (healthy) off that fallback, or it would mistake an
+ * unstamped/rehydrated graph for a clean leaf and serve a silent all-clear (the
+ * #533 false-clean trap). Such a caller reads THIS first and, when it returns
+ * false, fails CLOSED (treats coverage as unknown/degraded) instead of trusting
+ * the slot.
+ *
+ * Trustworthy iff EITHER the graph's own identity is present in the WeakMap (the
+ * fallback is not even taken), OR nothing has been stamped since the last cache
+ * clear (`_lastGraphBuildInfo` is still the pristine `mode: "full"` default, which
+ * cannot be a sibling's real state). Only a miss AFTER some real build has stamped
+ * — where the global slot could be a sibling's info — is untrustworthy.
+ *
+ * Live path: always trustworthy. Every `_doBuildGraph` return stamps the graph via
+ * `setGraphBuildInfo` before returning it, so the cascade reads the freshly-stamped
+ * same-identity instance (`has(graph)` true) and the miss branch is unreachable
+ * today. This only hardens a future path that ever surfaces an unstamped graph.
+ */
+export function graphBuildInfoIsTrustworthy(graph: ReviewGraph): boolean {
+	return _graphBuildInfoByGraph.has(graph) || !_anyGraphStamped;
 }
 
 function updateGraphBuildInfo(
@@ -304,6 +342,9 @@ export function clearReviewGraphWorkspaceCache(cwd?: string): void {
 		_sizeSkipVerdicts.delete(normalized);
 	}
 	_lastGraphBuildInfo = { reused: false, mode: "full", graphChanged: true };
+	// #1179: the global slot is back to the pristine default, so a subsequent
+	// identity miss can safely serve it again (it cannot be a sibling's state).
+	_anyGraphStamped = false;
 }
 
 export interface ReviewGraphWorkspaceCacheSnapshot {

--- a/clients/warm-attach.ts
+++ b/clients/warm-attach.ts
@@ -143,7 +143,12 @@ async function serveRequest(
 		result: {
 			route: "diagnostics",
 			version: WARM_DIAGNOSTICS_SCHEMA_VERSION,
-			diagnostics: touched ?? [],
+			// #1179: `touchFile` now returns the `{ diags, inconclusive, binding }`
+			// wrapper — take the array off `.diags`. This is the canonical shape-5
+			// serialization boundary: the diagnostics array crosses the IPC socket
+			// and `inconclusive` is re-surfaced below as an EXPLICIT enumerable DTO
+			// field (no side-channel survives `JSON.stringify`).
+			diagnostics: touched?.diags ?? [],
 			contentHash: req.contentHash,
 			servedAt,
 			fresh: servedAt <= req.deadlineAt && touched !== undefined,

--- a/tests/clients/cascade-compute.test.ts
+++ b/tests/clients/cascade-compute.test.ts
@@ -403,7 +403,7 @@ describe("computeCascadeForFile", () => {
 			fs.writeFileSync(primary, "class User: pass\n");
 			fs.writeFileSync(neighbor, "from model import User\n");
 			mocks.computeImpactCascade.mockReturnValue(impact(primary, [neighbor]));
-			const touchFile = vi.fn().mockResolvedValue([lspError("python broken")]);
+			const touchFile = vi.fn().mockResolvedValue({ diags: [lspError("python broken")] });
 			mocks.getLSPService.mockReturnValue({
 				getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
 				touchFile,
@@ -498,7 +498,7 @@ describe("computeCascadeForFile", () => {
 			mocks.computeImpactCascade.mockReturnValue(impact(primary, [neighbor]));
 			const touchFile = vi
 				.fn()
-				.mockResolvedValue([lspError("type error in neighbor")]);
+				.mockResolvedValue({ diags: [lspError("type error in neighbor")] });
 			mocks.getLSPService.mockReturnValue({
 				// Empty allDiags — no snapshot for neighbor (cold session)
 				getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
@@ -624,7 +624,7 @@ describe("computeCascadeForFile", () => {
 
 			const touchFile = vi
 				.fn()
-				.mockResolvedValue([lspError("type error in neighbor")]);
+				.mockResolvedValue({ diags: [lspError("type error in neighbor")] });
 			const getCapabilitySnapshots = vi.fn();
 			const getClientForFile = vi.fn();
 			mocks.getLSPService.mockReturnValue({
@@ -774,8 +774,8 @@ describe("computeCascadeForFile", () => {
 			// falls into touch pool). First cascade sets cache at writeSeq=1.
 			const touchFile = vi
 				.fn()
-				.mockResolvedValueOnce([lspError("error1")])
-				.mockResolvedValueOnce([lspError("error2")]);
+				.mockResolvedValueOnce({ diags: [lspError("error1")] })
+				.mockResolvedValueOnce({ diags: [lspError("error2")] });
 			mocks.getLSPService.mockReturnValue({
 				getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
 				touchFile,
@@ -1382,7 +1382,7 @@ describe("computeCascadeForFile", () => {
 				mocks.computeImpactCascade.mockReturnValue(impact(primary, [neighbor]));
 				mocks.getLSPService.mockReturnValue({
 					getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
-					touchFile: vi.fn().mockResolvedValue([lspError("python broken")]),
+					touchFile: vi.fn().mockResolvedValue({ diags: [lspError("python broken")] }),
 					getDiagnostics: vi.fn(),
 				});
 
@@ -1463,7 +1463,7 @@ describe("computeCascadeForFile", () => {
 				// No snapshot → cold-snapshot touch path; touch confirms an error.
 				mocks.getLSPService.mockReturnValue({
 					getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
-					touchFile: vi.fn().mockResolvedValue([lspError("cascade result")]),
+					touchFile: vi.fn().mockResolvedValue({ diags: [lspError("cascade result")] }),
 					getDiagnostics: vi.fn(),
 				});
 
@@ -1522,21 +1522,16 @@ describe("computeCascadeForFile", () => {
 				fs.writeFileSync(primary, "class User: pass\n");
 				fs.writeFileSync(neighbor, "from model import User\n");
 				mocks.computeImpactCascade.mockReturnValue(impact(primary, [neighbor]));
-				// The touch resolves `[]` but carries the `inconclusive: true` flag
+				// The touch resolves empty `.diags` but carries `inconclusive: true`
 				// (the diagnostics wait lapsed its budget) — NOT a confirmed clean.
 				// Reconciling it as clean would wipe a live finding (the #533
-				// false-clean trap). Set the flag exactly as the real `touchFile`
-				// does — a NON-enumerable property — so this test also catches a
-				// future regression where the code copies/spreads the array (which
-				// drops a non-enumerable flag) before reading `inconclusive`.
-				const inconclusive: unknown[] = [];
-				Object.defineProperty(inconclusive, "inconclusive", {
-					value: true,
-					enumerable: false,
-				});
+				// false-clean trap). #1179: the real `touchFile` now carries the flag
+				// as an EXPLICIT enumerable field on the `{ diags, inconclusive }`
+				// wrapper, so it survives any copy of `.diags` by construction — set
+				// it the same way here.
 				mocks.getLSPService.mockReturnValue({
 					getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
-					touchFile: vi.fn().mockResolvedValue(inconclusive),
+					touchFile: vi.fn().mockResolvedValue({ diags: [], inconclusive: true }),
 					getDiagnostics: vi.fn(),
 				});
 
@@ -1724,7 +1719,7 @@ describe("computeCascadeForFile", () => {
 				};
 				mocks.getLSPService.mockReturnValue({
 					getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
-					touchFile: vi.fn().mockResolvedValue([semgrep]),
+					touchFile: vi.fn().mockResolvedValue({ diags: [semgrep] }),
 					getDiagnostics: vi.fn(),
 				});
 
@@ -1802,7 +1797,7 @@ describe("computeCascadeForFile", () => {
 						]),
 					),
 					// The neighbor is actually clean now — a confirmed active re-check.
-					touchFile: vi.fn().mockResolvedValue([]),
+					touchFile: vi.fn().mockResolvedValue({ diags: [] }),
 					getDiagnostics: vi.fn(),
 				});
 
@@ -1949,11 +1944,16 @@ describe("computeCascadeForFile", () => {
 				fs.writeFileSync(primary, "class User: pass\n");
 				fs.writeFileSync(neighbor, "from model import User\n");
 				mocks.computeImpactCascade.mockReturnValue(impact(primary, [neighbor]));
-				// The touch resolves `[]` but is bound-false (computed against a diverged
-				// disk state) — NOT a confirmed clean, exactly like `inconclusive`.
+				// The touch resolves empty `.diags` but is bound-false (computed against
+				// a diverged disk state) — NOT a confirmed clean, exactly like
+				// `inconclusive`. #1179: the real `touchFile` carries `binding` as an
+				// EXPLICIT enumerable field on the wrapper (survives a `.diags` copy).
 				const touchFile = vi
 					.fn()
-					.mockImplementation(async () => withBinding([], false));
+					.mockImplementation(async () => ({
+						diags: [],
+						binding: { boundToCurrentDisk: false },
+					}));
 				mocks.getLSPService.mockReturnValue({
 					getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
 					touchFile,
@@ -2049,7 +2049,7 @@ describe("computeCascadeForFile", () => {
 							if (filePath === rejectedNeighbor) {
 								throw new Error("touch failed");
 							}
-							return [lspError("confirmed live error")];
+							return { diags: [lspError("confirmed live error")] };
 						}),
 					getDiagnostics: vi.fn(),
 				});

--- a/tests/clients/dispatch/runners/runner-status-semantics.test.ts
+++ b/tests/clients/dispatch/runners/runner-status-semantics.test.ts
@@ -13,6 +13,13 @@ const openFile = vi.fn();
 const touchFile = vi.fn();
 const getDiagnostics = vi.fn();
 const codeAction = vi.fn();
+
+// #1179: `touchFile` now resolves the `{ diags, inconclusive, binding }` wrapper
+// (shape-5 structural fix) — wrap a mocked diagnostics array in the same shape.
+const diagsResult = (
+	diags: unknown[],
+	extra: { inconclusive?: boolean } = {},
+) => ({ diags, ...extra });
 const readFileContent = vi.fn(() => "const x = 1;\n");
 const warmAttach = vi.hoisted(() => ({
 	diagnostics: vi.fn(),
@@ -227,7 +234,7 @@ describe("runner status/semantic edge cases", () => {
 			fs.writeFileSync(filePath, "const x = 1;\n");
 
 			supportsLSP.mockReturnValue(true);
-			touchFile.mockResolvedValue([]);
+			touchFile.mockResolvedValue(diagsResult([]));
 
 			const result = await runner.run(ctx(filePath, env.tmpDir) as never);
 			expect(result.status).toBe("succeeded");
@@ -288,11 +295,10 @@ describe("runner status/semantic edge cases", () => {
 			fs.writeFileSync(filePath, "const x = 1;\n");
 
 			supportsLSP.mockReturnValue(true);
-			const inconclusiveResult: unknown[] = [];
-			Object.defineProperty(inconclusiveResult, "inconclusive", {
-				value: true,
-			});
-			touchFile.mockResolvedValue(inconclusiveResult);
+			// #1179: empty `.diags` but `inconclusive: true` — an unconfirmed touch
+			// (notify/diagnostics wait lapsed). The flag is now an explicit enumerable
+			// wrapper field, so it survives any copy of `.diags` by construction.
+			touchFile.mockResolvedValue(diagsResult([], { inconclusive: true }));
 
 			const result = await runner.run(ctx(filePath, env.tmpDir) as never);
 			expect(result.status).toBe("skipped");
@@ -334,7 +340,7 @@ describe("runner status/semantic edge cases", () => {
 
 			hasLSP.mockResolvedValue(true);
 			openFile.mockResolvedValue(undefined);
-			touchFile.mockResolvedValue([
+			touchFile.mockResolvedValue(diagsResult([
 				{
 					severity: 1,
 					message: "Type 'number' is not assignable to type 'string'.",
@@ -344,7 +350,7 @@ describe("runner status/semantic edge cases", () => {
 					},
 					code: "2322",
 				},
-			]);
+			])); 
 			codeAction.mockResolvedValue([
 				{ title: "Change type of 'a' to 'number'", kind: "quickfix" },
 				{ title: "Convert number to string", kind: "quickfix" },
@@ -451,7 +457,7 @@ describe("runner status/semantic edge cases", () => {
 			fs.writeFileSync(filePath, "const x = 1;\n");
 
 			supportsLSP.mockReturnValue(true);
-			touchFile.mockResolvedValue([
+			touchFile.mockResolvedValue(diagsResult([
 				{
 					severity: 2,
 					message: "ast-grep finding",
@@ -472,7 +478,7 @@ describe("runner status/semantic edge cases", () => {
 					code: "some-rule",
 					source: "Semgrep",
 				},
-			]);
+			])); 
 
 			const result = await runner.run(
 				ctx(filePath, env.tmpDir, { fileRole: "test" }) as never,
@@ -493,7 +499,7 @@ describe("runner status/semantic edge cases", () => {
 			fs.writeFileSync(filePath, "const x = 1;\n");
 
 			supportsLSP.mockReturnValue(true);
-			touchFile.mockResolvedValue([
+			touchFile.mockResolvedValue(diagsResult([
 				{
 					severity: 2,
 					message: "ast-grep finding",
@@ -504,7 +510,7 @@ describe("runner status/semantic edge cases", () => {
 					code: "no-javascript-url",
 					source: "ast-grep",
 				},
-			]);
+			])); 
 
 			const result = await runner.run(ctx(filePath, env.tmpDir) as never);
 			expect(result.diagnostics).toHaveLength(1);
@@ -524,7 +530,7 @@ describe("runner status/semantic edge cases", () => {
 
 			hasLSP.mockResolvedValue(true);
 			openFile.mockResolvedValue(undefined);
-			touchFile.mockResolvedValue([
+			touchFile.mockResolvedValue(diagsResult([
 				{
 					severity: 1,
 					message: "Type 'number' is not assignable to type 'string'.",
@@ -534,7 +540,7 @@ describe("runner status/semantic edge cases", () => {
 					},
 					code: "2322",
 				},
-			]);
+			])); 
 			codeAction.mockResolvedValue([
 				{ title: "Move to a new file", kind: "refactor.move.newFile" },
 			]);
@@ -563,7 +569,7 @@ describe("runner status/semantic edge cases", () => {
 			hasLSP.mockResolvedValue(true);
 			openFile.mockResolvedValue(undefined);
 			touchFile.mockResolvedValue(
-				[0, 1, 2].map((line) => ({
+				diagsResult([0, 1, 2].map((line) => ({
 					severity: 1,
 					message: "Type 'number' is not assignable to type 'string'.",
 					range: {
@@ -572,7 +578,7 @@ describe("runner status/semantic edge cases", () => {
 					},
 					code: "2322",
 				})),
-			);
+			)); 
 			// Assert concurrency by observed overlap (max in-flight lookups), not
 			// wall-clock — elapsed-time bounds flake under parallel vitest load.
 			// Sequential awaits would never have more than 1 lookup in flight.

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -190,11 +190,13 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 		const result = await touchPromise;
 		// Touch resolved before aux deadline (3000ms) — we only waited ~610ms.
 		// Primary diagnostics included.
-		expect(Array.isArray(result)).toBe(true);
+		expect(Array.isArray(result?.diags)).toBe(true);
 		// Aux was cut off — its diagnostics may or may not be present depending
 		// on whether it resolved before the grace expired. Since aux takes 3000ms
 		// and grace is 500ms, aux is NOT included.
-		const messages = (result ?? []).map((d: { message: string }) => d.message);
+		const messages = (result?.diags ?? []).map(
+			(d: { message: string }) => d.message,
+		);
 		// Primary must be included (it answered before grace).
 		expect(messages).toContain("primary error");
 		// Aux must NOT be included (it didn't answer within grace).
@@ -233,7 +235,9 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 		await vi.advanceTimersByTimeAsync(10);
 
 		const result = await touchPromise;
-		const messages = (result ?? []).map((d: { message: string }) => d.message);
+		const messages = (result?.diags ?? []).map(
+			(d: { message: string }) => d.message,
+		);
 		// Both must be present — aux answered within grace.
 		expect(messages).toContain("primary error");
 		expect(messages).toContain("aux finding");
@@ -281,7 +285,9 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 		await vi.advanceTimersByTimeAsync(10);
 
 		const result = await touchPromise;
-		const messages = (result ?? []).map((d: { message: string }) => d.message);
+		const messages = (result?.diags ?? []).map(
+			(d: { message: string }) => d.message,
+		);
 		expect(messages).toContain("primary error");
 	});
 });

--- a/tests/clients/lsp/service-notify-per-server.test.ts
+++ b/tests/clients/lsp/service-notify-per-server.test.ts
@@ -131,7 +131,7 @@ describe("#743 — per-server notify-write deadlines", () => {
 		await vi.advanceTimersByTimeAsync(NOTIFY_BUDGET_MS + 20);
 		const result = await touchPromise;
 
-		expect(Array.isArray(result)).toBe(true);
+		expect(Array.isArray(result?.diags)).toBe(true);
 
 		// Both writes were attempted.
 		expect(stalledClient.notify.open).toHaveBeenCalledTimes(1);

--- a/tests/clients/lsp/service-touch-collect.test.ts
+++ b/tests/clients/lsp/service-touch-collect.test.ts
@@ -170,7 +170,7 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 			true,
 		);
 		expect(client.waitForDiagnostics).toHaveBeenCalledWith(FILE, 25);
-		expect(result).toEqual([diagnostic]);
+		expect(result?.diags).toEqual([diagnostic]);
 	});
 
 	it("skips notify.open on the second touch with identical content but still waits for diagnostics (#116)", async () => {
@@ -225,7 +225,7 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 
 		expect(client.notify.open).toHaveBeenCalledTimes(1);
 		expect(client.waitForDiagnostics).toHaveBeenCalledWith(FILE, 25);
-		expect(result).toEqual([diagnostic]);
+		expect(result?.diags).toEqual([diagnostic]);
 	});
 
 	it("sends notify.open again when the second touch has different content", async () => {
@@ -591,7 +591,7 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 
 			expect(client.notify.open).toHaveBeenCalled();
 			expect(elapsed).toBeLessThan(2000); // returned, did not hang on the write
-			expect(result).toEqual([]); // no fresh diagnostics, but no hang
+			expect(result?.diags).toEqual([]); // no fresh diagnostics, but no hang
 		} finally {
 			if (prev === undefined) delete process.env.PI_LENS_LSP_NOTIFY_BUDGET_MS;
 			else process.env.PI_LENS_LSP_NOTIFY_BUDGET_MS = prev;
@@ -678,7 +678,7 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 				maxDiagnosticsWaitMs: 8000,
 				source: "dispatch-lsp-runner",
 			});
-			expect(firstResult).toEqual([diagnostic]);
+			expect(firstResult?.diags).toEqual([diagnostic]);
 			expect((firstResult as any).inconclusive).not.toBe(true);
 			expect(service.getLastKnownDiagnostics(FILE)).toEqual([diagnostic]);
 
@@ -700,6 +700,17 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 			});
 
 			expect((secondResult as any).inconclusive).toBe(true);
+			// #1179 shape-5: on the REAL producer result, `inconclusive` is an
+			// enumerable OWN wrapper field, so it survives a copy of the result — it
+			// would be dropped here if it were still the pre-#1179 non-enumerable
+			// array side-channel with a spread intervening (#1094).
+			expect(
+				Object.prototype.propertyIsEnumerable.call(
+					secondResult,
+					"inconclusive",
+				),
+			).toBe(true);
+			expect({ ...secondResult }.inconclusive).toBe(true);
 			// The prior confirmed non-empty record must survive untouched.
 			expect(service.getLastKnownDiagnostics(FILE)).toEqual([diagnostic]);
 		});
@@ -748,7 +759,7 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 				source: "dispatch-lsp-runner",
 			});
 
-			expect(secondResult).toEqual([]);
+			expect(secondResult?.diags).toEqual([]);
 			expect((secondResult as any).inconclusive).not.toBe(true);
 			expect(service.getLastKnownDiagnostics(FILE)).toBeUndefined();
 		});

--- a/tests/clients/lsp/service-tsserver-sync-confirm.test.ts
+++ b/tests/clients/lsp/service-tsserver-sync-confirm.test.ts
@@ -191,9 +191,9 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 		});
 
 		expect(result).toBeDefined();
-		expect(result).toEqual([]);
+		expect(result?.diags).toEqual([]);
 		// The sync confirm should have cleared the inconclusive flag
-		expect((result as any)?.inconclusive).toBeFalsy();
+		expect(result?.inconclusive).toBeFalsy();
 	});
 
 	it("dirty TS file: sync returns diagnostics → confirmed with findings, inconclusive=false", async () => {
@@ -222,9 +222,17 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 		});
 
 		expect(result).toBeDefined();
-		expect(result!.length).toBe(1);
-		expect(result![0]?.message).toContain("not assignable to type 'string'");
-		expect((result as any)?.inconclusive).toBeFalsy();
+		expect(result!.diags.length).toBe(1);
+		expect(result!.diags[0]?.message).toContain("not assignable to type 'string'");
+		expect(result?.inconclusive).toBeFalsy();
+		// #1179 shape-5: on the REAL producer result, `binding` is an enumerable OWN
+		// wrapper field (a sync-confirmed touch composes {boundToCurrentDisk}), so it
+		// survives a copy of the result — it would be dropped if it were still the
+		// pre-#1179 non-enumerable array side-channel with a spread intervening (#1096).
+		expect(
+			Object.prototype.propertyIsEnumerable.call(result, "binding"),
+		).toBe(true);
+		expect({ ...result! }.binding?.boundToCurrentDisk).toBeDefined();
 	});
 
 	it("non-typescript server (gopls): sync is never attempted", async () => {
@@ -292,7 +300,7 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 		// The wait resolves before the budget — no timeout, so no sync call
 		expect(executeCommand).not.toHaveBeenCalled();
 		expect(result).toBeDefined();
-		expect(result!.length).toBeGreaterThan(0);
+		expect(result!.diags.length).toBeGreaterThan(0);
 	});
 
 	it("sync executeCommand throws: falls through to inconclusive behavior", async () => {
@@ -316,7 +324,7 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 		// Sync failed — should be inconclusive (undefined or has inconclusive flag)
 		// Either undefined (no client ready) or an array with inconclusive=true
 		if (result !== undefined) {
-			expect((result as any)?.inconclusive).toBe(true);
+			expect(result?.inconclusive).toBe(true);
 		}
 	});
 
@@ -342,7 +350,7 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 
 		expect(executeCommand).not.toHaveBeenCalled();
 		if (result !== undefined) {
-			expect((result as any)?.inconclusive).toBe(true);
+			expect(result?.inconclusive).toBe(true);
 		}
 	});
 
@@ -378,8 +386,8 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 			// budget the pinned push wait would otherwise burn in full.
 			expect(elapsed).toBeLessThan(800);
 			expect(result).toBeDefined();
-			expect(result).toEqual([]);
-			expect((result as any)?.inconclusive).toBeFalsy();
+			expect(result?.diags).toEqual([]);
+			expect(result?.inconclusive).toBeFalsy();
 		});
 
 		it("dirty file: racing sync winner surfaces the diagnostics, not discarded", async () => {
@@ -415,11 +423,11 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 
 			expect(elapsed).toBeLessThan(800);
 			expect(result).toBeDefined();
-			expect(result!.length).toBe(1);
-			expect(result![0]?.message).toContain("Cannot find name");
+			expect(result!.diags.length).toBe(1);
+			expect(result!.diags[0]?.message).toContain("Cannot find name");
 			// tsserver 1-based line 3/offset 1 → LSP 0-based line 2/character 0
-			expect(result![0]?.range.start).toEqual({ line: 2, character: 0 });
-			expect((result as any)?.inconclusive).toBeFalsy();
+			expect(result!.diags[0]?.range.start).toEqual({ line: 2, character: 0 });
+			expect(result?.inconclusive).toBeFalsy();
 		});
 
 		it("push arriving before the grace: no sync request ever goes out", async () => {
@@ -461,8 +469,8 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 
 			expect(executeCommand).not.toHaveBeenCalled();
 			expect(result).toBeDefined();
-			expect(result!.length).toBe(1);
-			expect((result as any)?.inconclusive).toBeFalsy();
+			expect(result!.diags.length).toBe(1);
+			expect(result?.inconclusive).toBeFalsy();
 		});
 
 		it("sync failing mid-race: wait runs to its budget, end-of-wait fallback fires and inconclusive is preserved", async () => {
@@ -503,7 +511,7 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 			// inconclusive behavior is preserved.
 			expect(executeCommand).toHaveBeenCalled();
 			expect(result).toBeDefined();
-			expect((result as any)?.inconclusive).toBe(true);
+			expect(result?.inconclusive).toBe(true);
 		});
 	});
 });

--- a/tests/clients/lsp/silent-clean-confirm.test.ts
+++ b/tests/clients/lsp/silent-clean-confirm.test.ts
@@ -164,8 +164,8 @@ describe("touchFile silent-clean push-only confirm (#799)", () => {
 		});
 
 		// Confirmed clean: an empty array, and NOT flagged inconclusive.
-		expect(Array.isArray(result)).toBe(true);
-		expect(result).toHaveLength(0);
+		expect(Array.isArray(result?.diags)).toBe(true);
+		expect(result?.diags).toHaveLength(0);
 		expect((result as { inconclusive?: boolean }).inconclusive).toBeUndefined();
 
 		// The env override (set in beforeEach) is what the wait actually pays
@@ -268,7 +268,7 @@ describe("touchFile capability-aware AGGREGATE wait (#814)", () => {
 		});
 
 		expect((result as { inconclusive?: boolean }).inconclusive).toBeUndefined();
-		expect(result).toEqual([finding]);
+		expect(result?.diags).toEqual([finding]);
 	});
 
 	it("(b) scope-all: the silent server's notify write TIMED OUT — falls back to today's timeout/inconclusive behavior", async () => {
@@ -379,8 +379,8 @@ describe("touchFile capability-aware AGGREGATE wait (#814)", () => {
 		});
 		const elapsedMs = Date.now() - startedAt;
 
-		expect(Array.isArray(result)).toBe(true);
-		expect(result).toHaveLength(0);
+		expect(Array.isArray(result?.diags)).toBe(true);
+		expect(result?.diags).toHaveLength(0);
 		expect((result as { inconclusive?: boolean }).inconclusive).toBeUndefined();
 		// marksman (1500ms) and typescript (1000ms) — the touch waits for the
 		// SLOWER of the two (marksman), not a shortened window.

--- a/tests/clients/lsp/touch-result-wrapper-copy.test.ts
+++ b/tests/clients/lsp/touch-result-wrapper-copy.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { TouchFileResult } from "../../../clients/lsp/diagnostic-binding.js";
+
+// #1179 / #1108 shape-5 (side-channel copy-loss). `touchFile` returns a WRAPPER
+// whose `inconclusive` (#570/#1093) and `binding` (#1095) flags are EXPLICIT
+// ENUMERABLE fields — the diagnostics array lives under `.diags`. A copy of the
+// diagnostics (`[...]`/`.map`/`.filter`/`JSON`) therefore operates on `.diags` and
+// CANNOT drop the flags on the wrapper — the copy-loss class that bit as #1094 /
+// #1096 is now impossible by construction. The negative-control test proves the
+// copy operations are genuinely lossy for the OLD non-enumerable array carriage,
+// so these tests would fail if the flags regressed to that carriage with a copy
+// intervening. Pure logic — meaningful on Linux CI (no FS / timing).
+
+const makeResult = (): TouchFileResult => ({
+	diags: [
+		{
+			severity: 1,
+			message: "type error",
+			range: {
+				start: { line: 0, character: 0 },
+				end: { line: 0, character: 1 },
+			},
+		} as unknown as TouchFileResult["diags"][number],
+	],
+	inconclusive: true,
+	binding: { boundToCurrentDisk: false },
+});
+
+describe("TouchFileResult wrapper — shape-5 copy survival (#1179)", () => {
+	it("inconclusive + binding are enumerable OWN fields (survive spread and JSON of the wrapper)", () => {
+		const result = makeResult();
+		expect(
+			Object.prototype.propertyIsEnumerable.call(result, "inconclusive"),
+		).toBe(true);
+		expect(Object.prototype.propertyIsEnumerable.call(result, "binding")).toBe(
+			true,
+		);
+
+		const spread = { ...result };
+		expect(spread.inconclusive).toBe(true);
+		expect(spread.binding?.boundToCurrentDisk).toBe(false);
+
+		const roundTripped = JSON.parse(JSON.stringify(result)) as TouchFileResult;
+		expect(roundTripped.inconclusive).toBe(true);
+		expect(roundTripped.binding?.boundToCurrentDisk).toBe(false);
+	});
+
+	it("copying .diags ([...], .filter, .map, JSON) leaves both flags on the wrapper intact", () => {
+		const result = makeResult();
+
+		// The exact copies a consumer performs on the diagnostics array — each used to
+		// silently drop a non-enumerable side-channel hung on the array itself.
+		const spreadCopy = [...result.diags];
+		const filteredCopy = result.diags.filter((d) => d.severity === 1);
+		const mappedCopy = result.diags.map((d) => d);
+		const jsonCopy = JSON.parse(JSON.stringify(result.diags));
+		for (const copy of [spreadCopy, filteredCopy, mappedCopy, jsonCopy]) {
+			expect(Array.isArray(copy)).toBe(true);
+			expect(copy).toHaveLength(1);
+		}
+
+		// After every copy of `.diags`, the flags still ride the wrapper — the read a
+		// consumer does off the wrapper (e.g. cascade `readInconclusive`) is unaffected.
+		expect(result.inconclusive).toBe(true);
+		expect(result.binding?.boundToCurrentDisk).toBe(false);
+	});
+
+	it("negative control: a non-enumerable flag on the ARRAY (the pre-#1179 carriage) IS dropped by every copy", () => {
+		// The old carriage: a non-enumerable flag hung directly on the diagnostics
+		// array. Readable off the ORIGINAL, but any copy drops it — this is exactly
+		// the #1094/#1096 loss the wrapper eliminates, and it proves the copies above
+		// are genuinely lossy (so the survival assertions are not vacuous).
+		const legacy: unknown[] = [];
+		Object.defineProperty(legacy, "inconclusive", {
+			value: true,
+			enumerable: false,
+			configurable: true,
+		});
+		expect((legacy as { inconclusive?: boolean }).inconclusive).toBe(true);
+
+		expect(([...legacy] as { inconclusive?: boolean }).inconclusive).toBe(
+			undefined,
+		);
+		expect(
+			(legacy.filter(() => true) as { inconclusive?: boolean }).inconclusive,
+		).toBe(undefined);
+		expect(
+			(legacy.map((d) => d) as { inconclusive?: boolean }).inconclusive,
+		).toBe(undefined);
+		expect(
+			(JSON.parse(JSON.stringify(legacy)) as { inconclusive?: boolean })
+				.inconclusive,
+		).toBe(undefined);
+	});
+});

--- a/tests/clients/review-graph/graph-build-info-failclosed.test.ts
+++ b/tests/clients/review-graph/graph-build-info-failclosed.test.ts
@@ -1,0 +1,86 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import {
+	buildOrUpdateGraph,
+	clearGraphCache,
+	clearReviewGraphWorkspaceCache,
+	getGraphBuildInfoForGraph,
+	graphBuildInfoIsTrustworthy,
+} from "../../../clients/review-graph/builder.js";
+import type { ReviewGraph } from "../../../clients/review-graph/types.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+// #1179 (latent P3 from the #1108/#1180 side-channel audit). `getGraphBuildInfoForGraph`
+// falls back to the global last-build slot on a `_graphBuildInfoByGraph` WeakMap
+// identity miss. Once a real build has stamped, that slot holds a REAL build's info,
+// so serving it for a DIFFERENT (unstamped/rehydrated) graph would leak a SIBLING
+// graph's skipped/healthy state — which the `graph_degraded` marker gate would then
+// mistake for a clean leaf (#533 false-clean trap). `graphBuildInfoIsTrustworthy`
+// fails CLOSED for that case so the gate surfaces a degraded/unknown verdict instead.
+
+const roots: string[] = [];
+
+afterEach(() => {
+	clearReviewGraphWorkspaceCache();
+	clearGraphCache();
+	for (const root of roots.splice(0)) removeTempDirSync(root);
+});
+
+async function buildRealGraph(): Promise<{ graph: ReviewGraph; root: string }> {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-graph-failclosed-"));
+	roots.push(root);
+	const file = path.join(root, "a.ts");
+	fs.writeFileSync(file, "export const a = 1;\n");
+	clearGraphCache();
+	const graph = await buildOrUpdateGraph(root, [file], new FactStore());
+	return { graph, root };
+}
+
+describe("graphBuildInfoIsTrustworthy — #1179 fail-closed WeakMap guard", () => {
+	it("a freshly built graph is trustworthy and reads its OWN build-info", async () => {
+		const { graph } = await buildRealGraph();
+		// Live-path invariant: the cascade reads the same-identity stamped instance.
+		expect(graphBuildInfoIsTrustworthy(graph)).toBe(true);
+		expect(graph).toBe(graph);
+		expect(getGraphBuildInfoForGraph(graph).mode).not.toBe(undefined);
+	});
+
+	it("an identity MISS after a sibling was stamped is UNtrustworthy — the raw fallback would leak the sibling's state", async () => {
+		const { graph: stamped } = await buildRealGraph();
+		const siblingInfo = getGraphBuildInfoForGraph(stamped);
+		// A graph never passed through the stamping path (a future rehydrated /
+		// deserialized instance). Its identity is absent from the WeakMap.
+		const rehydrated = {} as unknown as ReviewGraph;
+
+		// The RAW fallback serves the sibling's build-info verbatim (the hazard):
+		// `graph_degraded` would read this graph's coverage off a DIFFERENT graph.
+		expect(getGraphBuildInfoForGraph(rehydrated)).toBe(siblingInfo);
+
+		// The fail-closed guard refuses to trust that fallback for THIS graph, so the
+		// degraded-marker gate treats coverage as unknown rather than serving a
+		// (possibly healthy) sibling verdict.
+		expect(graphBuildInfoIsTrustworthy(rehydrated)).toBe(false);
+		// And the stamped sibling itself stays trustworthy (identity present).
+		expect(graphBuildInfoIsTrustworthy(stamped)).toBe(true);
+	});
+
+	it("with NOTHING stamped (pristine default slot), a miss is trustworthy — the default is nobody's real state", () => {
+		// No build has run since the afterEach clear reset `_anyGraphStamped`; the
+		// global slot is still the pristine `mode: "full"` default, which cannot be a
+		// sibling's state, so an unstamped graph safely reads it (no false degraded).
+		const fresh = {} as unknown as ReviewGraph;
+		expect(graphBuildInfoIsTrustworthy(fresh)).toBe(true);
+	});
+
+	it("clearing the workspace cache re-pristines the slot, so a subsequent miss is trustworthy again", async () => {
+		await buildRealGraph();
+		const rehydrated = {} as unknown as ReviewGraph;
+		expect(graphBuildInfoIsTrustworthy(rehydrated)).toBe(false);
+		clearReviewGraphWorkspaceCache();
+		// Slot is back to the default; the miss can no longer leak a sibling's state.
+		expect(graphBuildInfoIsTrustworthy(rehydrated)).toBe(true);
+	});
+});

--- a/tests/tools/lsp-diagnostics-cache.test.ts
+++ b/tests/tools/lsp-diagnostics-cache.test.ts
@@ -68,7 +68,7 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 			return id === "none" ? [] : [{ id }];
 		});
 
-		touchFile = vi.fn().mockResolvedValue([]);
+		touchFile = vi.fn().mockResolvedValue({ diags: [] });
 		mocked.service = {
 			touchFile,
 			getDiagnostics: vi.fn().mockResolvedValue([]),
@@ -135,14 +135,14 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 
 	it("never caches an inconclusive (timed-out) touch — the next call still touches it", async () => {
 		const files = writeFiles(["a.ts"]);
-		// `.inconclusive` flag set — collectDiagnosticsForFile's `timedOut` reads
-		// straight off this, same non-enumerable-flag contract touchFile uses.
-		const inconclusive = Object.assign([], { inconclusive: true });
+		// #1179: `inconclusive` is an explicit enumerable field on the touchFile
+		// wrapper now; `collectDiagnosticsForFile` reads `timedOut` straight off it.
+		const inconclusive = { diags: [], inconclusive: true };
 		touchFile.mockResolvedValueOnce(inconclusive);
 
 		await runBatch(files);
 		touchFile.mockClear();
-		touchFile.mockResolvedValue([]);
+		touchFile.mockResolvedValue({ diags: [] });
 
 		await runBatch(files);
 		// Not served from cache — an inconclusive result must never be cached.
@@ -173,7 +173,7 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 			range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
 			source: "typescript",
 		};
-		touchFile.mockResolvedValueOnce([diag]);
+		touchFile.mockResolvedValueOnce({ diags: [diag] });
 
 		const first = await runBatch(files);
 		expect(first.details?.totalDiagnostics).toBe(1);
@@ -192,7 +192,7 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 			range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
 			source: "typescript",
 		};
-		touchFile.mockResolvedValueOnce([diag]);
+		touchFile.mockResolvedValueOnce({ diags: [diag] });
 
 		await runBatch(files);
 		// The fresh touch was OBSERVED now → no observation-time override.

--- a/tests/tools/lsp-diagnostics.test.ts
+++ b/tests/tools/lsp-diagnostics.test.ts
@@ -857,9 +857,7 @@ describe("lsp_diagnostics tool", () => {
 	describe("#570 timed-out check is not confirmed-clean", () => {
 		it("single file: renders 'timed out' instead of a bare clean when touchFile is inconclusive", async () => {
 			const touchFile = vi.fn().mockImplementation(async () => {
-				const result: any[] = [];
-				Object.defineProperty(result, "inconclusive", { value: true });
-				return result;
+				return { diags: [], inconclusive: true };
 			});
 			(mocked.service as any).touchFile = touchFile;
 			const tool = createLspDiagnosticsTool();
@@ -893,7 +891,7 @@ describe("lsp_diagnostics tool", () => {
 		});
 
 		it("single file: a confirmed (non-inconclusive) touchFile result still renders plain clean", async () => {
-			const touchFile = vi.fn().mockResolvedValue([]);
+			const touchFile = vi.fn().mockResolvedValue({ diags: [] });
 			(mocked.service as any).touchFile = touchFile;
 			const tool = createLspDiagnosticsTool();
 			const tmpDir = fs.mkdtempSync(
@@ -926,13 +924,10 @@ describe("lsp_diagnostics tool", () => {
 			let call = 0;
 			const touchFile = vi.fn().mockImplementation(async () => {
 				call += 1;
-				const result: any[] = [];
 				// First file's touch times out; second file's touch is confirmed but
 				// its server is a #533 silent-on-clean tier (mocked.cascadeTier below).
-				if (call === 1) {
-					Object.defineProperty(result, "inconclusive", { value: true });
-				}
-				return result;
+				// #1179: `inconclusive` is an explicit enumerable wrapper field now.
+				return call === 1 ? { diags: [], inconclusive: true } : { diags: [] };
 			});
 			(mocked.service as any).touchFile = touchFile;
 			mocked.cascadeTier = "tier3-silent";
@@ -1034,9 +1029,7 @@ describe("lsp_diagnostics tool", () => {
 
 		it("does NOT reconcile a timed-out (#570 inconclusive) result into the footer", async () => {
 			const touchFile = vi.fn().mockImplementation(async () => {
-				const result: any[] = [];
-				Object.defineProperty(result, "inconclusive", { value: true });
-				return result;
+				return { diags: [], inconclusive: true };
 			});
 			(mocked.service as any).touchFile = touchFile;
 			const tmpDir = fs.mkdtempSync(
@@ -1067,20 +1060,20 @@ describe("lsp_diagnostics tool", () => {
 		// regression: the "non-empty = definitionally confirmed" doctrine is now
 		// gated on binding.
 		function staleTouchResult(messages: string[], bound: boolean | "unknown") {
-			const result: any[] = messages.map((message) => ({
-				severity: 1,
-				message,
-				range: {
-					start: { line: 0, character: 0 },
-					end: { line: 0, character: 1 },
-				},
-				source: "ts",
-			}));
-			Object.defineProperty(result, "binding", {
-				value: { boundToCurrentDisk: bound },
-				enumerable: false,
-			});
-			return result;
+			// #1179: the `touchFile` wrapper — `binding` is an EXPLICIT enumerable
+			// field (survives any copy of `.diags`), not a non-enumerable side-channel.
+			return {
+				diags: messages.map((message) => ({
+					severity: 1,
+					message,
+					range: {
+						start: { line: 0, character: 0 },
+						end: { line: 0, character: 1 },
+					},
+					source: "ts",
+				})),
+				binding: { boundToCurrentDisk: bound },
+			};
 		}
 
 		it("does NOT reconcile a NON-EMPTY result whose binding mismatches disk (T2 headline #1092)", async () => {
@@ -1373,7 +1366,7 @@ describe("lsp_diagnostics tool", () => {
 		});
 
 		it("serverScope: 'primary' passes clientScope: 'primary' to touchFile, skipping auxiliary scanners", async () => {
-			const touchFile = vi.fn().mockResolvedValue([]);
+			const touchFile = vi.fn().mockResolvedValue({ diags: [] });
 			(mocked.service as any).touchFile = touchFile;
 			const tool = createLspDiagnosticsTool();
 			const tmpDir = fs.mkdtempSync(
@@ -1420,7 +1413,7 @@ describe("lsp_diagnostics tool", () => {
 				},
 				source: "typescript",
 			};
-			const touchFile = vi.fn().mockResolvedValue([primaryOnlyDiagnostic]);
+			const touchFile = vi.fn().mockResolvedValue({ diags: [primaryOnlyDiagnostic] });
 			(mocked.service as any).touchFile = touchFile;
 			// If the bug regresses (a second, unscoped getDiagnostics() call feeds
 			// the actual content) this mock would return an aux-scanner finding
@@ -1501,7 +1494,7 @@ describe("lsp_diagnostics tool", () => {
 		});
 
 		it("default (no serverScope param) still passes clientScope: 'all' to touchFile", async () => {
-			const touchFile = vi.fn().mockResolvedValue([]);
+			const touchFile = vi.fn().mockResolvedValue({ diags: [] });
 			(mocked.service as any).touchFile = touchFile;
 			const tool = createLspDiagnosticsTool();
 			const tmpDir = fs.mkdtempSync(
@@ -1534,7 +1527,7 @@ describe("lsp_diagnostics tool", () => {
 		});
 
 		it("#629: neither waitMs nor serverScope:'primary' set (openFile-only path) is unchanged — getDiagnostics('full') still called, touchFile is not", async () => {
-			const touchFile = vi.fn().mockResolvedValue([]);
+			const touchFile = vi.fn().mockResolvedValue({ diags: [] });
 			(mocked.service as any).touchFile = touchFile;
 			const getDiagnostics = vi.fn().mockResolvedValue([]);
 			(mocked.service as any).getDiagnostics = getDiagnostics;

--- a/tools/lsp-diagnostics.ts
+++ b/tools/lsp-diagnostics.ts
@@ -33,6 +33,7 @@ import type { LSPDiagnostic } from "../clients/lsp/client.js";
 import {
 	hashDiagnosticContent,
 	type DiagnosticBinding,
+	type TouchFileResult,
 } from "../clients/lsp/diagnostic-binding.js";
 import { classifyCascadeWaitTier } from "../clients/lsp/wait-policy/index.js";
 import {
@@ -682,12 +683,8 @@ async function collectDiagnosticsForFile(
 	// `touched` is only undefined when touchFile itself couldn't produce a
 	// result (service destroyed, no clients resolved) — that's the one case
 	// that still needs the getDiagnostics() fallback below.
-	let touched:
-		| (LSPDiagnostic[] & {
-				inconclusive?: boolean;
-				binding?: DiagnosticBinding;
-		  })
-		| undefined;
+	// #1179: `touchFile` resolves the `{ diags, inconclusive, binding }` wrapper.
+	let touched: TouchFileResult | undefined;
 	let usedTouch = false;
 	try {
 		content = fs.readFileSync(absPath, "utf-8");
@@ -730,13 +727,7 @@ async function collectDiagnosticsForFile(
 					source: string;
 					clientScope: "all" | "primary";
 				},
-			) => Promise<
-				| (LSPDiagnostic[] & {
-						inconclusive?: boolean;
-						binding?: DiagnosticBinding;
-				  })
-				| undefined
-			>;
+			) => Promise<TouchFileResult | undefined>;
 		};
 		if (
 			(waitMs !== undefined || serverScope === "primary") &&
@@ -769,7 +760,7 @@ async function collectDiagnosticsForFile(
 	// common case back to a single LSP round trip instead of two.
 	const diagnostics =
 		usedTouch && touched !== undefined
-			? touched
+			? touched.diags
 			: await lspService.getDiagnostics(
 					absPath,
 					waitMs !== undefined ? "document" : "full",


### PR DESCRIPTION
## What
Closes #1179 — the structural shape-5 side-channel-flag hardening deferred from the #1108 audit. Migrates the `inconclusive`/`binding` flags from non-enumerable side-channels (droppable by any `[...]`/`.map`/`.filter`/`structuredClone`/`JSON` copy) to an **explicit enumerable wrapper**, so copy-loss is impossible by construction. **Carriage-only — no diagnostics logic changed** (249 tests across 17 suites confirm zero behavior change).

## 1. Wrapper migration
- **New `TouchFileResult` (`{ diags, inconclusive?, binding? }`)** in `clients/lsp/diagnostic-binding.ts` (carriage-contract doc rewritten). `touchFile` (`clients/lsp/index.ts`) returns it; `inconclusive`/`binding` are enumerable fields alongside `.diags`, so copies operate on `.diags` and can't drop the flags. Field presence mirrors the old `Object.defineProperty` conditions exactly.
- **Consumers migrated in lockstep:** `integration.ts` (`readInconclusive`/`readBoundToCurrentDisk`/`isConfirmedTouch` + the `.filter()` now on `.diags`), `runners/lsp.ts`, `tools/lsp-diagnostics.ts`, the `lens_diagnostics mode=full` sweep in `index.ts`, `warm-attach.ts` (still re-surfaces `inconclusive` as the enumerable IPC DTO field per #1108).
- **Left on the read-off-original contract (with reason):** `getAllDiagnostics`'s per-entry `binding` stays a **lazy non-enumerable getter** — making it enumerable would fire the per-file disk stat+hash on any incidental spread (the stat storm its laziness prevents); consumers already read off the original Map entry. `ipc.ts` unchanged (reads the JSON DTO, not a side-channel).

## 2. WeakMap fail-closed guard (latent P3 from the #1108 review)
`getGraphBuildInfoForGraph`'s global-slot fallback could serve a SIBLING graph's build-info on a `_graphBuildInfoByGraph` identity miss (#533 false-clean feeding the `graph_degraded` gate). New `graphBuildInfoIsTrustworthy(graph)` (`builder.ts`): trustworthy iff the graph's identity is stamped OR nothing stamped since the last cache clear (pristine default); the gate (`integration.ts`) treats an untrustworthy read as degraded/unknown. Inert on the live path (all 7 `_doBuildGraph` returns stamp before the cascade reads).

## Tests
- `touch-result-wrapper-copy.test.ts` — flags survive `{...}`/`[...]`/`.filter`/`.map`/`JSON` of `.diags`; **negative control proves the old non-enumerable-on-array carriage IS dropped** by every copy (survival assertions non-vacuous). Real-producer enumerability asserted in service-touch-collect/tsserver-sync-confirm.
- `graph-build-info-failclosed.test.ts` — identity miss after a sibling is stamped → untrustworthy (raw fallback demonstrably leaks the sibling); pristine slot trustworthy. RED verified (defeating the guard fails it).
- Build/lint/changelog green; 249 tests across the diagnostics/widget-state/cascade/integration/warm-attach/ipc/review-graph suites.

`closes #1179` (refs #1108 #1094 #1096).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
