### PR TITLE
fix(mcp): warm IPC side-channel is one-shot — consume the request line, dispatch at most once (closes #1219)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,10 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   (LSP-complete) and the bin never loads the dispatch graph; falls back to cold
   no-LSP local analysis. `pilens_analyze` (warm) + the hook auto-register edited
   files into turn-state (`addModifiedRange`) so `pilens_turn_end` needs no file list.
+  The channel is strictly **one-shot** — clients write exactly one request and
+  read one reply, so the server handler consumes the line and dispatches at most
+  once per connection (a non-consuming handler re-dispatched on stray bytes,
+  #1219); keep any new channel handler one-shot too.
 - **Same-workspace warm attach (#822, opt-in soak).** `PI_LENS_WARM_ATTACH=1`
   selects a PID-confirmed, heartbeat-fresh same-root incumbent from
   `instances.json`. The LSP runner sends versioned, content-hash-bound,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -914,6 +914,8 @@ All notable changes to pi-lens will be documented in this file.
 	semantics, primary LSP diagnostics, intentional test-runner findings, and
 	the generic project-diagnostics snapshot/delta display are all left as-is.
 
+- **The warm IPC side-channel re-dispatched the same request on stray bytes (closes [#1219](https://github.com/apmantza/pi-lens/issues/1219))** — the server's socket `data` handler (`mcp/server.ts` `startIpcServer`) buffered chunks but never consumed the request line, so any further `data` event on the connection — stray bytes without a newline still re-found the original line — re-ran the whole warm `analyzeFile` pass (three dispatches per connection in the pre-fix repro). The channel's clients write exactly one newline-delimited request and read one reply (`requestWarmAnalyze` ends the socket), so the handler is now strictly one-shot: `createWarmIpcLineReader` (`clients/mcp/ipc.ts`, re-exported through the lens-engine seam) accumulates chunks, dispatches the first complete line exactly once, and ignores everything after it. The stdio JSON-RPC loop already consumed its lines and is untouched. Regression tests drive the real reader: one request + stray bytes → exactly one dispatch (pre-fix: three), a second newline-terminated request is ignored, and a request split across chunks still assembles.
+
 ### Added
 
 - **tflint respects the project's linter policy (refs #1117)** — every other

--- a/clients/lens-engine.ts
+++ b/clients/lens-engine.ts
@@ -55,6 +55,7 @@ export {
 } from "./mcp/analyze.js";
 export { createMcpHost } from "./mcp/host-shim.js";
 export {
+	createWarmIpcLineReader,
 	ipcPathForCwd,
 	requestWarmAnalyze,
 	type WarmAnalyzeRequest,

--- a/clients/mcp/ipc.ts
+++ b/clients/mcp/ipc.ts
@@ -6,11 +6,12 @@
  * connects to it to get LSP-complete diagnostics from the warm process instead
  * of running its own cold analysis.
  *
- * This module is the CLIENT + the shared path derivation only — deliberately
- * light (node:net + type-only result), so the bin can try the warm path WITHOUT
- * loading the dispatch graph. The server side lives in mcp/server.ts (which
- * already holds the analysis engine). If the warm path is unavailable, the
- * client resolves `undefined` and the caller falls back to cold local analysis.
+ * This module is the CLIENT + the shared path derivation + the one-shot line
+ * reader the server wires into its socket (deliberately light: node:net +
+ * type-only result, so the bin can try the warm path WITHOUT loading the
+ * dispatch graph). The analysis engine lives in mcp/server.ts. If the warm
+ * path is unavailable, the client resolves `undefined` and the caller falls
+ * back to cold local analysis.
  */
 
 import * as crypto from "node:crypto";
@@ -333,4 +334,27 @@ export function requestWarmAnalyze(
 		socket.on("error", () => finish(undefined));
 		socket.on("close", () => finish(undefined));
 	});
+}
+
+/**
+ * One-shot line reader for the warm IPC socket (#1219). The clients write
+ * exactly one newline-terminated request per connection and read one reply, so
+ * the server must dispatch at most one line and ignore anything after it — a
+ * `data` handler that keeps re-reading the same buffered line re-dispatches
+ * the request on stray bytes. Returns the handler to attach to the socket's
+ * `data` event.
+ */
+export function createWarmIpcLineReader(
+	onLine: (line: string) => void,
+): (chunk: string) => void {
+	let buffer = "";
+	let dispatched = false;
+	return (chunk: string) => {
+		if (dispatched) return;
+		buffer += chunk;
+		const newline = buffer.indexOf("\n");
+		if (newline === -1) return;
+		dispatched = true;
+		onLine(buffer.slice(0, newline));
+	};
 }

--- a/clients/warm-attach.ts
+++ b/clients/warm-attach.ts
@@ -13,6 +13,7 @@ import { logLatency } from "./latency-logger.js";
 import { getLSPService } from "./lsp/index.js";
 import {
 	contentHash,
+	createWarmIpcLineReader,
 	diagnosticsIpcPathForCwd,
 	requestWarmCodeActions,
 	requestWarmDiagnostics,
@@ -169,22 +170,26 @@ function startServer(cwd: string): void {
 	}
 	const server = net.createServer((socket) => {
 		socket.setEncoding("utf8");
-		let buffer = "";
-		socket.on("data", (chunk: string) => {
-			buffer += chunk;
-			const newline = buffer.indexOf("\n");
-			if (newline === -1) return;
-			void (async () => {
-				try {
-					const req = JSON.parse(buffer.slice(0, newline)) as
-						| WarmDiagnosticsRequest
-						| WarmCodeActionsRequest;
-					socket.end(`${JSON.stringify(await serveRequest(req))}\n`);
-				} catch (error) {
-					socket.end(`${JSON.stringify({ error: String(error) })}\n`);
-				}
-			})();
-		});
+		// One-shot per connection (#1219 family): the same defect shape as the
+		// MCP warm socket — clients write exactly one request and read one
+		// reply, so a handler that kept re-reading the same buffered line
+		// re-dispatched the request on stray bytes. The shared reader consumes
+		// the line and ignores anything after it.
+		socket.on(
+			"data",
+			createWarmIpcLineReader((line) => {
+				void (async () => {
+					try {
+						const req = JSON.parse(line) as
+							| WarmDiagnosticsRequest
+							| WarmCodeActionsRequest;
+						socket.end(`${JSON.stringify(await serveRequest(req))}\n`);
+					} catch (error) {
+						socket.end(`${JSON.stringify({ error: String(error) })}\n`);
+					}
+				})();
+			}),
+		);
 	});
 	server.on("error", (error) => {
 		record("listener-error", cwd, String(error));

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -37,6 +37,7 @@ import {
 	analyzeFileFresh,
 	canRebuildPiLens,
 	createMcpHost,
+	createWarmIpcLineReader,
 	diagnosticStats,
 	ensureLspConfig,
 	ipcPathForCwd,
@@ -272,44 +273,46 @@ function startIpcServer(): void {
 
 	const ipc = net.createServer((socket) => {
 		socket.setEncoding("utf8");
-		let buffer = "";
-		socket.on("data", (chunk: string) => {
-			buffer += chunk;
-			const newline = buffer.indexOf("\n");
-			if (newline === -1) return;
-			const line = buffer.slice(0, newline);
-			void (async () => {
-				try {
-					// #535: the PostToolUse hook bin (mcp/analyze-cli.ts) already treats
-					// ANY error response as "no usable warm server" and falls back to
-					// its own cold, load-fresh-from-disk analysis path — so on a stale
-					// warm build, replying with an error IS the fresh-fork behavior for
-					// this channel, for free. No separate fresh-fork plumbing needed
-					// here: the client-side fallback already loads current code.
-					if (isWarmBuildStale()) {
-						console.error(
-							"[pi-lens-mcp] warm analyze: build stale, replying error so the hook falls back cold",
-						);
-						socket.end(
-							`${JSON.stringify({ error: "warm build stale — falling back to cold analysis" })}\n`,
-						);
-						return;
+		// One-shot per connection (#1219): clients write exactly one request and
+		// read one reply, so a handler that kept re-reading the same buffered
+		// line re-dispatched the request on stray bytes. The reader consumes the
+		// line and ignores anything after it.
+		socket.on(
+			"data",
+			createWarmIpcLineReader((line) => {
+				void (async () => {
+					try {
+						// #535: the PostToolUse hook bin (mcp/analyze-cli.ts) already treats
+						// ANY error response as "no usable warm server" and falls back to
+						// its own cold, load-fresh-from-disk analysis path — so on a stale
+						// warm build, replying with an error IS the fresh-fork behavior for
+						// this channel, for free. No separate fresh-fork plumbing needed
+						// here: the client-side fallback already loads current code.
+						if (isWarmBuildStale()) {
+							console.error(
+								"[pi-lens-mcp] warm analyze: build stale, replying error so the hook falls back cold",
+							);
+							socket.end(
+								`${JSON.stringify({ error: "warm build stale — falling back to cold analysis" })}\n`,
+							);
+							return;
+						}
+						const req = JSON.parse(line) as WarmAnalyzeRequest;
+						console.error(`[pi-lens-mcp] warm analyze: ${req.file}`);
+						// Warm = full LSP + an edit-detection path (register turn-state) +
+						// review-graph maintenance (#536 — this is an in-process, long-lived
+						// path, unlike the ephemeral `fresh` worker).
+						const result = await analyzeFile(req.file, req.cwd, {
+							registerTurnState: true,
+							updateGraph: true,
+						});
+						socket.end(`${JSON.stringify({ result })}\n`);
+					} catch (err) {
+						socket.end(`${JSON.stringify({ error: String(err) })}\n`);
 					}
-					const req = JSON.parse(line) as WarmAnalyzeRequest;
-					console.error(`[pi-lens-mcp] warm analyze: ${req.file}`);
-					// Warm = full LSP + an edit-detection path (register turn-state) +
-					// review-graph maintenance (#536 — this is an in-process, long-lived
-					// path, unlike the ephemeral `fresh` worker).
-					const result = await analyzeFile(req.file, req.cwd, {
-						registerTurnState: true,
-						updateGraph: true,
-					});
-					socket.end(`${JSON.stringify({ result })}\n`);
-				} catch (err) {
-					socket.end(`${JSON.stringify({ error: String(err) })}\n`);
-				}
-			})();
-		});
+				})();
+			}),
+		);
 		socket.on("error", () => socket.destroy());
 	});
 

--- a/tests/clients/mcp/ipc.test.ts
+++ b/tests/clients/mcp/ipc.test.ts
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { McpAnalyzeResult } from "../../../clients/mcp/analyze.js";
 import {
 	contentHash,
+	createWarmIpcLineReader,
 	diagnosticsIpcPathForCwd,
 	ipcPathForCwd,
 	requestWarmCodeActions,
@@ -314,5 +315,45 @@ describe("requestWarmAnalyze", () => {
 		const result = await requestWarmAnalyze(cwd, "/x/app.ts");
 		expect(result).toBeUndefined();
 		removeTempDirSync(cwd);
+	});
+});
+
+describe("createWarmIpcLineReader", () => {
+	it("dispatches exactly one line for one request followed by stray bytes (#1219)", () => {
+		const lines: string[] = [];
+		const handler = createWarmIpcLineReader((line) => lines.push(line));
+		handler(`${JSON.stringify({ file: "/x/a.ts" })}\n`);
+		// Pre-fix, the socket handler kept the consumed line in its buffer and
+		// re-dispatched it on any further data event — stray bytes after the
+		// request re-ran the whole warm analyze pass.
+		handler("stray");
+		handler("more");
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0])).toEqual({ file: "/x/a.ts" });
+	});
+
+	it("ignores a second newline-terminated request (one-shot per connection)", () => {
+		const lines: string[] = [];
+		const handler = createWarmIpcLineReader((line) => lines.push(line));
+		handler(`${JSON.stringify({ file: "/x/a.ts" })}\n`);
+		handler(`${JSON.stringify({ file: "/x/b.ts" })}\n`);
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0]).file).toBe("/x/a.ts");
+	});
+
+	it("assembles a request split across chunks before dispatching", () => {
+		const lines: string[] = [];
+		const handler = createWarmIpcLineReader((line) => lines.push(line));
+		handler('{"file":');
+		handler('"/x/a.ts"}\n');
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0]).file).toBe("/x/a.ts");
+	});
+
+	it("does not dispatch when no newline ever arrives", () => {
+		const lines: string[] = [];
+		const handler = createWarmIpcLineReader((line) => lines.push(line));
+		handler("partial");
+		expect(lines).toHaveLength(0);
 	});
 });

--- a/tests/clients/mcp/ipc.test.ts
+++ b/tests/clients/mcp/ipc.test.ts
@@ -341,6 +341,16 @@ describe("createWarmIpcLineReader", () => {
 		expect(JSON.parse(lines[0]).file).toBe("/x/a.ts");
 	});
 
+	it("dispatches only the first request when two arrive in one chunk (#1219)", () => {
+		const lines: string[] = [];
+		const handler = createWarmIpcLineReader((line) => lines.push(line));
+		handler(
+			`${JSON.stringify({ file: "/x/a.ts" })}\n${JSON.stringify({ file: "/x/b.ts" })}\n`,
+		);
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0]).file).toBe("/x/a.ts");
+	});
+
 	it("assembles a request split across chunks before dispatching", () => {
 		const lines: string[] = [];
 		const handler = createWarmIpcLineReader((line) => lines.push(line));


### PR DESCRIPTION
Closes #1219.

**Bug:** `mcp/server.ts` `startIpcServer`'s socket `data` handler buffered chunks but never consumed the request line, so any further `data` event on the connection — stray bytes without a newline still re-found the original line — re-ran the whole warm `analyzeFile` pass. Pre-fix repro: one request + two stray chunks = **three** dispatches. Since the channel's clients write exactly one newline-delimited request and read one reply (`requestWarmAnalyze` ends the socket), the handler is now strictly one-shot.

**Fix:** the line-extraction state machine is extracted to `createWarmIpcLineReader` (`clients/mcp/ipc.ts`, re-exported through the lens-engine seam — the socket handler only wires it): accumulates chunks, dispatches the first complete line exactly once, ignores everything after it. The stdio JSON-RPC loop already consumed its lines and is untouched (verified sibling).

**Tests** (drive the real reader, not a copy):
- one request + stray bytes → exactly one dispatch — **fails pre-fix with 3** (verified by reverting the reader to the non-consuming shape)
- a second newline-terminated request is ignored (one-shot per connection)
- a request split across chunks still assembles
- no newline → no dispatch

`tests/clients/mcp` + `tests/mcp` (spawn smokes): 15 files / 100 tests green. `npm run lint` clean. CHANGELOG entry added under Fixed.