### PR TITLE
fix: reap orphaned atomic-write staging files (closes #1228)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -681,7 +681,13 @@ POSIX; a real dogfooded fixture entry survived 13h stale because of exactly
 this), and the parent pid has no identity to verify against —
 `InstanceEntry` never recorded the parent's own command line. Marker
 protection (`collectLiveMarkers`) is keyed on pid-liveness alone —
-conservative on the destructive side, matching the kill predicate.
+conservative on the destructive side, matching the kill predicate. The same
+`clients/instance-reaper.ts` seam owns `sweepAtomicWriteStages()` (#1228),
+invoked fire-and-forget from `session_start` for project-data and global state
+roots. It inspects a bounded number of regular files whose names match only
+atomic-write `.tmp-<pid>`, `.tmp-<pid>-<seq>`, or
+`.tmp-<pid>-<thread>-<seq>` shapes; `process.pid` and every liveness-positive
+foreign pid are preserved. It uses no watcher or keep-alive handle.
 `isSubagentSession()` (`clients/subagent-mode.ts`) detects TWO env
 vocabularies: nicobailon/pi-subagents' `PI_SUBAGENT_CHILD=1`, and
 avtc-pi-subagent's `PI_SUBAGENT_CHILD_AGENT` + `PI_SUBAGENT_PARENT_PID` pair

--- a/clients/atomic-write.ts
+++ b/clients/atomic-write.ts
@@ -47,9 +47,10 @@
  *   - **No fsync/durability guarantee.** Neither the staging file nor the
  *     parent directory is fsync'd, so a power loss (as opposed to a process
  *     crash) may lose the rename.
- *   - **No orphan reaping.** A process killed between the staging write and
- *     the rename leaves an orphan staging file that nothing in this module
- *     collects; that lifecycle gap is tracked in #1228, not solved here.
+ *   - **No self-reaping.** A process killed between the staging write and the
+ *     rename leaves an orphan staging file. The next session_start performs a
+ *     bounded, liveness-checked sweep through the instance-reaper lifecycle
+ *     seam (#1228); this writer never watches or reaps its own files.
  *   - **Windows-specific loss under `bestEffort: true`.** `MoveFileEx` with
  *     `MOVEFILE_REPLACE_EXISTING` fails if a reader holds the destination
  *     open without `FILE_SHARE_DELETE`. On Windows this silently drops the
@@ -122,9 +123,8 @@ export function stagePathFor(targetPath: string): string {
 
 /**
  * Matches the trailing staging-file marker produced by {@link stagePathFor},
- * for sweepers that garbage-collect staging files orphaned by a crashed
- * process (tracked as a lifecycle gap in #1228 — this module does not reap
- * its own orphans).
+ * for the session-start sweeper that garbage-collects staging files orphaned
+ * by a crashed process (#1228). The writer itself does not reap or watch files.
  *
  * The trailing groups are optional so that staging files written by an older
  * build and still on disk are also swept — all three generations of the shape:
@@ -132,14 +132,11 @@ export function stagePathFor(targetPath: string): string {
  * `.tmp-<pid>-<threadId>-<seq>` (#1217).
  *
  * CAUTION for any sweeper adopting this pattern: it matches staging files by
- * *shape*, not by writer identity, so it will also match this process's own
- * still-being-written staging files unless the sweeper separately excludes
- * them by `process.pid`. `review-graph/builder.ts`'s `sweepStaleStageFiles`
- * cannot be pointed at this pattern as-is — its own-file guard is
- * `.stage-${process.pid}-`, which never appears in a `.tmp-<pid>-…` name, so
- * widening its match to `STAGE_TMP_PATTERN` without also adding a
- * `.tmp-${process.pid}-` (or equivalent pid) exclusion would delete its own
- * in-flight `writeFileAtomic` staging files mid-write.
+ * shape, not by writer identity, so it also matches this process's own
+ * still-being-written staging files. A safe sweeper must separately protect
+ * `process.pid` and use the shared conservative liveness check for foreign
+ * pids. The review-graph builder's narrower stage sweep intentionally remains
+ * separate because it owns a different `.stage-<pid>-<generation>` namespace.
  *
  * The optional groups also widen what matches versus a strict single-pid
  * pattern: e.g. `backup.tmp-2023-11` and `backup.tmp-2023-11-05` now match,
@@ -151,6 +148,16 @@ export function stagePathFor(targetPath: string): string {
  * staging files.
  */
 export const STAGE_TMP_PATTERN = /\.tmp-\d+(?:-\d+){0,2}$/;
+const STAGE_TMP_PID_PATTERN = /\.tmp-(\d+)(?:-\d+){0,2}$/;
+
+/** Extract a valid positive owner pid from an atomic-write staging basename. */
+export function stageOwnerPidFromName(name: string): number | undefined {
+	if (!STAGE_TMP_PATTERN.test(name)) return undefined;
+	const match = STAGE_TMP_PID_PATTERN.exec(name);
+	if (!match) return undefined;
+	const pid = Number(match[1]);
+	return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
+}
 
 /**
  * Synchronous atomic write of text or binary data to a per-call staging file,

--- a/clients/instance-reaper.ts
+++ b/clients/instance-reaper.ts
@@ -66,7 +66,10 @@ export const STALE_HEARTBEAT_MS = 6 * 60 * 60 * 1000;
 import { spawn as nodeSpawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { writeFileAtomicAsync } from "./atomic-write.js";
+import {
+	stageOwnerPidFromName,
+	writeFileAtomicAsync,
+} from "./atomic-write.js";
 import { spawnCollectStdout, unrefChildAndPipes } from "./child-unref.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
 import {
@@ -291,6 +294,98 @@ export function realIsPidAlive(pid: number): boolean {
 		// never treat as dead.
 		return true;
 	}
+}
+
+/** Maximum number of directory entries inspected by one staging sweep. */
+export const ATOMIC_STAGE_SWEEP_MAX_ENTRIES = 512;
+
+export interface AtomicStageSweepResult {
+	directories: number;
+	scanned: number;
+	removed: number;
+	liveSkipped: number;
+	truncated: boolean;
+}
+
+export interface AtomicStageSweepOptions {
+	/** Test-only cap override; production callers use the default cap. */
+	maxEntries?: number;
+	/** Injectable only for deterministic tests; defaults to the shared probe. */
+	isPidAlive?: (pid: number) => boolean;
+}
+
+/**
+ * Remove orphaned generic atomic-write staging files from pi-lens-owned
+ * directories. This is deliberately a directory-entry sweep, not a watcher:
+ * it runs from session_start, reads at most `maxEntries` entries per directory,
+ * and never creates a process-lifetime handle.
+ *
+ * Safety invariants:
+ * - only the three atomic-write `.tmp-<pid>[-<thread>[-<seq>]]` shapes match;
+ * - directories and symlinks are never removed;
+ * - this process's pid is always protected, and every foreign pid is checked
+ *   through the reaper's conservative ESRCH-only liveness seam;
+ * - every I/O failure is best-effort and cannot fail session_start.
+ */
+export async function sweepAtomicWriteStages(
+	directories: readonly string[],
+	options: AtomicStageSweepOptions = {},
+): Promise<AtomicStageSweepResult> {
+	const requestedMax = options.maxEntries ?? ATOMIC_STAGE_SWEEP_MAX_ENTRIES;
+	const maxEntries = Number.isFinite(requestedMax)
+		? Math.max(1, Math.floor(requestedMax))
+		: ATOMIC_STAGE_SWEEP_MAX_ENTRIES;
+	const isPidAlive = options.isPidAlive ?? realIsPidAlive;
+	const uniqueDirectories = [...new Set(directories)].filter(Boolean);
+	const result: AtomicStageSweepResult = {
+		directories: uniqueDirectories.length,
+		scanned: 0,
+		removed: 0,
+		liveSkipped: 0,
+		truncated: false,
+	};
+
+	for (const directory of uniqueDirectories) {
+		let handle: fs.Dir;
+		try {
+			handle = await fs.promises.opendir(directory);
+		} catch {
+			continue;
+		}
+		try {
+			let reachedEntryCap = true;
+			for (let i = 0; i < maxEntries; i++) {
+				const entry = await handle.read();
+				if (entry === null) {
+					reachedEntryCap = false;
+					break;
+				}
+				result.scanned++;
+				if (!entry.isFile()) continue;
+				const pid = stageOwnerPidFromName(entry.name);
+				if (pid === undefined) continue;
+				if (pid === process.pid || isPidAlive(pid)) {
+					result.liveSkipped++;
+					continue;
+				}
+				try {
+					await fs.promises.rm(path.join(directory, entry.name), {
+						force: true,
+					});
+					result.removed++;
+				} catch {
+					// A locked file or a concurrent rename is safe to leave for the
+					// next session-start sweep.
+				}
+			}
+			result.truncated ||= reachedEntryCap;
+		} catch {
+			// Directory reads are best-effort; preserve any completed removals.
+		} finally {
+			await handle.close().catch(() => {});
+		}
+	}
+	return result;
 }
 
 function windowsExe(name: string): string {

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -1932,8 +1932,9 @@ function ensurePersistExitHook(): void {
 // The bare `.tmp-<pid>` shape is never matched, which also makes this sweep
 // independent of any change to atomic-write's staging name (#1205). Dropping
 // that shape means the review-graph sweep is no longer the incidental GC for
-// other stores' orphaned atomic-write temps; that gap is now tracked by
-// #1228, not assumed to be owned elsewhere.
+// other stores' orphaned atomic-write temps; the generic `.tmp-*` namespace is
+// now swept at session_start by instance-reaper (#1228), not by this graph
+// artifact-specific pass.
 //
 // Liveness: an entry whose embedded stage pid is still alive belongs to a
 // concurrent healthy owner (or to us) and is skipped, reusing the reaper's

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -10,7 +10,11 @@ import type { DependencyChecker } from "./dependency-checker.js";
 import { getDiagnosticTracker } from "./diagnostic-tracker.js";
 import type { FileKind } from "./file-kinds.js";
 import { clearAllSessions as clearFileTimeSessions } from "./file-time.js";
-import { getKnipIgnorePatterns } from "./file-utils.js";
+import {
+	getGlobalPiLensDir,
+	getKnipIgnorePatterns,
+	getProjectDataDir,
+} from "./file-utils.js";
 import { GitleaksClient, type GitleaksResult } from "./gitleaks-client.js";
 import type { GoClient } from "./go-client.js";
 import {
@@ -78,6 +82,7 @@ import {
 	isSubagentSession,
 	subagentLightModeNotice,
 } from "./subagent-mode.js";
+import { sweepAtomicWriteStages } from "./instance-reaper.js";
 import type { TestRunnerClient } from "./test-runner-client.js";
 import type { TodoScanner } from "./todo-scanner.js";
 import { TrivyClient, type TrivyResult } from "./trivy-client.js";
@@ -1837,6 +1842,19 @@ export async function handleSessionStart(
 
 	const hasWorkspaceCwd = typeof ctxCwd === "string" && ctxCwd.length > 0;
 	const cwd = ctxCwd ?? process.cwd();
+	// #1228: generic atomic-write stages are shared by several project stores,
+	// so the review-graph-specific sweep cannot own this namespace. Sweep the
+	// project data roots and machine-global registry root once per session start;
+	// this is fire-and-forget and bounded so it never delays startup.
+	const projectDataDir = getProjectDataDir(cwd);
+	void sweepAtomicWriteStages([
+		projectDataDir,
+		path.join(projectDataDir, "cache"),
+		path.join(projectDataDir, "sessions"),
+		getGlobalPiLensDir(),
+	]).catch(() => {
+		// best-effort lifecycle cleanup — never fail session_start
+	});
 	if (quickMode) {
 		runtime.projectRoot = cwd;
 		const sequenceReadStartedAt = Date.now();

--- a/tests/clients/atomic-write-stage-gc.test.ts
+++ b/tests/clients/atomic-write-stage-gc.test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	ATOMIC_STAGE_SWEEP_MAX_ENTRIES,
+	sweepAtomicWriteStages,
+} from "../../clients/instance-reaper.js";
+
+const cleanup: string[] = [];
+
+function makeDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-stage-gc-"));
+	cleanup.push(dir);
+	return dir;
+}
+
+function stage(dir: string, name: string): string {
+	const file = path.join(dir, name);
+	fs.writeFileSync(file, "staging");
+	return file;
+}
+
+afterEach(() => {
+	while (cleanup.length > 0) {
+		fs.rmSync(cleanup.pop() as string, { recursive: true, force: true });
+	}
+});
+
+describe("sweepAtomicWriteStages (#1228)", () => {
+	it("removes dead-owner files in all supported old and current naming shapes", async () => {
+		const dir = makeDir();
+		const dead = [
+			stage(dir, "state.json.tmp-41001"),
+			stage(dir, "state.json.tmp-41002-7"),
+			stage(dir, "state.json.tmp-41003-2-7"),
+		];
+
+		const result = await sweepAtomicWriteStages([dir], {
+			isPidAlive: () => false,
+		});
+
+		expect(result.removed).toBe(3);
+		expect(dead.every((file) => !fs.existsSync(file))).toBe(true);
+	});
+
+	it("preserves live foreign owners and every current-process staging file", async () => {
+		const dir = makeDir();
+		const liveForeign = stage(dir, "state.json.tmp-42001-3-9");
+		const currentProcess = stage(
+			dir,
+			`state.json.tmp-${process.pid}-0-99`,
+		);
+		const unrelated = stage(dir, "state.json.tmp-42001-3-9-extra");
+		const ordinary = stage(dir, "state.json");
+
+		await sweepAtomicWriteStages([dir], {
+			isPidAlive: (pid) => pid === 42001,
+		});
+
+		expect(fs.existsSync(liveForeign)).toBe(true);
+		expect(fs.existsSync(currentProcess)).toBe(true);
+		expect(fs.existsSync(unrelated)).toBe(true);
+		expect(fs.existsSync(ordinary)).toBe(true);
+	});
+
+	it("does not remove directories or malformed/non-atomic names", async () => {
+		const dir = makeDir();
+		const namedDirectory = path.join(dir, "nested.tmp-43001");
+		fs.mkdirSync(namedDirectory);
+		const malformed = [
+			stage(dir, "state.tmp-43001-1-2-3"),
+			stage(dir, "state.tmp-43001-"),
+			stage(dir, "state.TMP-43001"),
+		];
+
+		await sweepAtomicWriteStages([dir], { isPidAlive: () => false });
+
+		expect(fs.existsSync(namedDirectory)).toBe(true);
+		expect(malformed.every((file) => fs.existsSync(file))).toBe(true);
+	});
+
+	it("stops after the configured bounded number of directory entries", async () => {
+		const dir = makeDir();
+		const files = Array.from({ length: 3 }, (_, i) =>
+			stage(dir, `state-${i}.tmp-4400${i}`),
+		);
+
+		const result = await sweepAtomicWriteStages([dir], {
+			maxEntries: 2,
+			isPidAlive: () => false,
+		});
+
+		expect(result.scanned).toBe(2);
+		expect(result.removed).toBe(2);
+		expect(result.truncated).toBe(true);
+		expect(files.filter((file) => fs.existsSync(file))).toHaveLength(1);
+	});
+
+	it("fails closed for missing directories and invalid owner pids", async () => {
+		const dir = makeDir();
+		const zeroPid = stage(dir, "state.tmp-0");
+		const hugePid = stage(dir, "state.tmp-999999999999999999999");
+
+		await expect(
+			sweepAtomicWriteStages(
+				[path.join(dir, "missing"), dir],
+				{ isPidAlive: () => false },
+			),
+		).resolves.toMatchObject({ directories: 2, removed: 0 });
+		expect(fs.existsSync(zeroPid)).toBe(true);
+		expect(fs.existsSync(hugePid)).toBe(true);
+		expect(ATOMIC_STAGE_SWEEP_MAX_ENTRIES).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary
- add a bounded session-start sweep for atomic-write `.tmp-*` staging files
- preserve current-process and live-owner files using the conservative PID-liveness seam
- cover project data, session/cache, machine-global, and managed tree-sitter grammar directories
- log bounded sweep results without delaying session startup

## Verification
- `npm run build`
- `npm run lint`
- 58 focused atomic-write/instance-reaper tests

## Invariants
- no watcher or process-exit handle
- dead-owner orphan cleanup only
- live/current PID protection
- old and current staging-name shapes remain supported
