### PR TITLE
test(sg-runner): real exit-2 and truncated-exit-1 failure coverage (refs #1087)

### DIFF
--- a/clients/sg-runner.ts
+++ b/clients/sg-runner.ts
@@ -154,6 +154,15 @@ function tryParseSgMatches(stdout: string): SgMatch[] | null {
 	}
 }
 
+function tryParseNonZeroSgMatches(
+	result: Pick<SpawnResult, "stdout" | "outputTruncated">,
+): SgMatch[] | null {
+	if (result.outputTruncated || !result.stdout.trim()) return null;
+	// Trimmed on purpose: a leading BOM survives JSON.parse's whitespace
+	// tolerance but String.trim() strips it (matches the pre-refactor guard).
+	return tryParseSgMatches(result.stdout.trim());
+}
+
 export class SgRunner {
 	private log: (msg: string) => void;
 	private sgPath: string | null = null;
@@ -492,8 +501,8 @@ export class SgRunner {
 			// exit code that means "scan succeeded with findings" must never be
 			// classified as a CLI failure — parse the matches. Only fall through
 			// to failure when the JSON isn't parseable (a real diagnostic).
-			if (result.status === 1 && stdout && !result.outputTruncated) {
-				const matches = tryParseSgMatches(stdout);
+			if (result.status === 1 && stdout) {
+				const matches = tryParseNonZeroSgMatches(result);
 				if (matches) {
 					return {
 						matches,
@@ -585,8 +594,8 @@ export class SgRunner {
 			// exit code that means "scan succeeded with findings" must never be
 			// classified as a CLI failure — parse the matches. Only fall through
 			// to failure when the JSON isn't parseable (a real diagnostic).
-			if (result.status === 1 && stdout && !result.outputTruncated) {
-				const matches = tryParseSgMatches(stdout);
+			if (result.status === 1 && stdout) {
+				const matches = tryParseNonZeroSgMatches(result);
 				if (matches) {
 					return { matches, status: result.status };
 				}

--- a/tests/clients/sg-runner.test.ts
+++ b/tests/clients/sg-runner.test.ts
@@ -495,6 +495,56 @@ describe("SgRunner", () => {
 			expect(result.matches).toEqual([]);
 			expect(result.error).toContain("bad rule");
 		});
+
+		it("reports a failure for exit 2 even when stdout parses as match JSON", async () => {
+			// Only exit 1 carries the "scan succeeded with findings" linter
+			// contract — any other nonzero exit is a real CLI failure and must
+			// NOT be laundered into matches, however plausible stdout looks.
+			safeSpawnAsync.mockResolvedValueOnce({
+				status: 2,
+				error: undefined,
+				stdout: JSON.stringify([
+					{
+						file: "src/a.js",
+						range: {
+							start: { line: 0, column: 0 },
+							end: { line: 0, column: 7 },
+						},
+						text: "eval(x)",
+					},
+				]),
+				stderr: "Error: invalid scan configuration",
+			});
+			const { SgRunner } = await import("../../clients/sg-runner.js");
+			const result = await new SgRunner().exec(["scan", "--json", "."]);
+			expect(result.matches).toEqual([]);
+			expect(result.error).toContain("invalid scan configuration");
+		});
+
+		it("treats truncated status-1 stdout as a failure, not as matches", async () => {
+			// A truncated JSON payload may still happen to parse (e.g. cut
+			// exactly at a match boundary) — the truncation flag must veto it.
+			safeSpawnAsync.mockResolvedValueOnce({
+				status: 1,
+				error: undefined,
+				stdout: JSON.stringify([
+					{
+						file: "src/a.js",
+						range: {
+							start: { line: 0, column: 0 },
+							end: { line: 0, column: 7 },
+						},
+						text: "eval(x)",
+					},
+				]),
+				stderr: "Scan succeeded and found error level diagnostics",
+				outputTruncated: true,
+			});
+			const { SgRunner } = await import("../../clients/sg-runner.js");
+			const result = await new SgRunner().exec(["scan", "--json", "."]);
+			expect(result.matches).toEqual([]);
+			expect(result.error).toBeDefined();
+		});
 	});
 
 	describe("buildBashRunArgs (Git Bash exec path — injection safety, code-scanning #12)", () => {


### PR DESCRIPTION
## Summary
- Extracts the exit-1-with-matches parse guard into `tryParseNonZeroSgMatches` (shared by `exec()` and `interpretScanResult()`), parsing **trimmed** stdout to match the pre-refactor guard (a leading BOM survives JSON.parse's whitespace tolerance but `trim()` strips it).
- Adds mutation-verified failure-path tests:
  - exit 2 with **plausible match JSON on stdout** must stay a CLI failure (kills a `status !== 0` relaxation mutant);
  - **truncated** exit-1 stdout must not be served as matches (kills a dropped-truncation-veto mutant — this guard previously had no test at either call site).

The P1 itself (exit-1 matches dropped) landed in #1103; P2/P3 items of #1087 remain open — refs, not closes.

## Verification
- `npx vitest run tests/clients/sg-runner.test.ts` — 24 passed
- Both mutants rebuilt and confirmed caught by exactly the new tests

Refs #1087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)