### PR TITLE
chore(ci): bump install-smoke pnpm pin to 11.21.0 (closes #641)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -74,7 +74,7 @@ jobs:
         if: matrix.pm == 'pnpm'
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 11.7.0
+          version: 11.21.0
 
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -163,7 +163,7 @@ jobs:
         if: matrix.pi_install == 'pnpm-global'
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 11.7.0
+          version: 11.21.0
 
       - name: Setup bun
         if: matrix.pi_install == 'bun-global'


### PR DESCRIPTION
Two-line pin bump; the install-smoke matrix on this PR is itself the validation the issue asked to wait for. Closes #641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)