### PR TITLE
fix(format): deterministic Kotlin formatter selection via Spotless detection (closes #1306)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1123,6 +1123,8 @@ Mixing different capture names in one `[...]` block causes tree-sitter to silent
 
 ## Current version / state
 
+**Multi-formatter extension policies resolve to one formatter (#1306):** explicit project configuration wins, and every policy with multiple candidates must name one unique `defaultFormatter` as its deterministic overlap tie-break. Kotlin Spotless selection is parsed from `build.gradle{.kts}` `spotless { kotlin { ... } }` blocks through `getSpotlessKotlinFormatter`; never add independent ktlint/ktfmt detection at a caller.
+
 v3.8.74. Release history lives in `CHANGELOG.md` (dated, versioned, kept current per-PR — see "Release notes" below) — this section previously duplicated it with an ever-growing, ever-staler narrative; don't refill it with a highlights list again.
 
 **Markdownlint default-config invariant (#833):** the Markdown dispatch runner invokes `markdownlint-cli2` with the package-owned `config/markdownlint/core.json` when no project markdownlint config is found; that config disables MD013 and sets MD024 to `siblings_only` so intentional repeated category headings in changelogs are allowed while duplicate sibling headings remain violations. A project config is left to markdownlint-cli2 unchanged (no runner-level rule overrides). `hasMarkdownlintConfig` must recognize every config filename supported by the installed markdownlint-cli2, including the `.markdownlint-cli2.*` and `.markdownlint.{jsonc,json,yaml,yml,cjs,mjs}` families.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1123,7 +1123,7 @@ Mixing different capture names in one `[...]` block causes tree-sitter to silent
 
 ## Current version / state
 
-**Multi-formatter extension policies resolve to one formatter (#1306):** explicit project configuration wins, and every policy with multiple candidates must name one unique `defaultFormatter` as its deterministic overlap tie-break. Kotlin Spotless selection is parsed from `build.gradle{.kts}` `spotless { kotlin { ... } }` blocks through `getSpotlessKotlinFormatter`; never add independent ktlint/ktfmt detection at a caller.
+**Multi-formatter extension policies resolve to one formatter (#1306):** explicit project configuration wins, and every policy with multiple candidates must name one unique `defaultFormatter` as its deterministic overlap tie-break. Kotlin Spotless selection is parsed from `build.gradle{.kts}` and `settings.gradle{.kts}` `spotless { kotlin { ... } }` blocks through `getSpotlessKotlinFormatter`; never add independent ktlint/ktfmt detection at a caller. Its small lexical pre-pass blanks comments and quoted strings before brace scanning (disabled `if (false)` blocks remain an explicit non-goal), and Gradle reads are memoized by path plus `mtimeMs` so repeated per-file selection does not repeat config I/O while mid-session edits invalidate naturally.
 
 v3.8.74. Release history lives in `CHANGELOG.md` (dated, versioned, kept current per-PR — see "Release notes" below) — this section previously duplicated it with an ever-growing, ever-staler narrative; don't refill it with a highlights list again.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Kotlin formatter selection follows Spotless configuration deterministically (closes #1306)** — a Spotless `kotlin { ktlint() }` block pins ktlint and `kotlin { ktfmt() }` pins ktfmt, so both selection branches cannot claim the same Kotlin file and unconfigured projects retain the style-preserving no-format policy.
+
 - **Turn-end madge telemetry stays compact and its batch metadata is runtime-tested (closes [#1250](https://github.com/apmantza/pi-lens/issues/1250), [#1251](https://github.com/apmantza/pi-lens/issues/1251))** — aggregate batch counters remain exact, while per-target timing breadcrumbs are retained only for spawns taking at least 100 ms and capped at 12 slow targets, preserving the smells-rollup lookback; the real turn-end path now verifies madge batch execution and metadata propagation.
 
 - **Rule-policy normalization and source-filter matrices no longer drift (closes #1087)** — P3.2 derives CodeRabbit's language suffixes from the vendored rules tree so disable/select and inline suppression cover every shipped language; P3.3 aligns source-twin precedence ordering with sibling resolution and adds a behavioral agreement guard while preserving the broad `.jsx` build-artifact fallback.

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -30,6 +30,7 @@ import {
 	hasCmakeFormatConfig,
 	hasGoogleJavaFormatConfig,
 	hasKtfmtConfig,
+	hasKtlintConfig,
 	hasNearestPackageJsonDependency,
 	hasNearestPackageJsonField,
 	hasOcamlformatConfig,
@@ -358,6 +359,8 @@ function hasExplicitFormatterConfig(
 			return hasGoogleJavaFormatConfig(cwd);
 		case "ktfmt":
 			return hasKtfmtConfig(cwd);
+		case "ktlint":
+			return hasKtlintConfig(cwd);
 		case "cljfmt":
 			return hasCljfmtConfig(cwd);
 		case "cmake-format":

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -74,6 +74,7 @@ import {
 	hasEslintConfig,
 	hasGolangciConfig,
 	hasKtfmtConfig,
+	hasKtlintConfig,
 	hasOxlintConfig,
 	hasRubocopConfig,
 	hasSqlfluffConfig,
@@ -636,6 +637,7 @@ export async function runAutofix(
 		hasGolangciConfig: hasGolangciConfig(cwd),
 		hasDetektConfig: hasDetektConfig(cwd),
 		hasKtfmtConfig: hasKtfmtConfig(cwd),
+		hasKtlintConfig: hasKtlintConfig(cwd),
 		hasOxlintConfig: hasOxlintConfig(cwd),
 	};
 	const autofixPolicy = getAutofixPolicyForFile(filePath, autofixContext);

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -2387,7 +2387,98 @@ const KTFMT_GRADLE_FILES = [
 	"settings.gradle",
 ];
 
-const KOTLIN_BUILD_FILES = ["build.gradle.kts", "build.gradle"];
+const KOTLIN_GRADLE_FILES = [
+	"build.gradle.kts",
+	"build.gradle",
+	"settings.gradle.kts",
+	"settings.gradle",
+];
+
+interface SpotlessKotlinConfigCacheEntry {
+	mtime: number;
+	ktlintConfig: boolean;
+	ktfmtConfig: boolean;
+}
+
+const spotlessKotlinConfigCache = new Map<
+	string,
+	SpotlessKotlinConfigCacheEntry
+>();
+let spotlessGradleReadCount = 0;
+
+/** Test-only observability for asserting the hot-path I/O bound. */
+export function _getSpotlessGradleReadCountForTests(): number {
+	return spotlessGradleReadCount;
+}
+
+/**
+ * Blank comments and quoted strings while preserving braces and newlines in
+ * executable Gradle source. This is deliberately a small lexical pre-pass,
+ * not a Groovy/Kotlin parser. In particular, statically disabled constructs
+ * such as `if (false) { ktlint() }` remain a documented false-positive.
+ */
+function stripGradleCommentsAndStrings(source: string): string {
+	let result = "";
+	let state: "code" | "line-comment" | "block-comment" | "string" = "code";
+	let quote = "";
+	for (let index = 0; index < source.length; index += 1) {
+		const char = source[index];
+		const next = source[index + 1];
+		if (state === "code") {
+			if (char === "/" && next === "/") {
+				result += "  ";
+				index += 1;
+				state = "line-comment";
+			} else if (char === "/" && next === "*") {
+				result += "  ";
+				index += 1;
+				state = "block-comment";
+			} else if (char === '"' || char === "'") {
+				result += " ";
+				quote = char;
+				state = "string";
+			} else {
+				result += char;
+			}
+			continue;
+		}
+
+		if (state === "line-comment") {
+			if (char === "\n" || char === "\r") {
+				result += char;
+				state = "code";
+			} else {
+				result += " ";
+			}
+			continue;
+		}
+
+		if (state === "block-comment") {
+			if (char === "*" && next === "/") {
+				result += "  ";
+				index += 1;
+				state = "code";
+			} else {
+				result += char === "\n" || char === "\r" ? char : " ";
+			}
+			continue;
+		}
+
+		if (char === "\\") {
+			result += " ";
+			if (index + 1 < source.length) {
+				result += source[index + 1] === "\n" ? "\n" : " ";
+				index += 1;
+			}
+		} else if (char === quote) {
+			result += " ";
+			state = "code";
+		} else {
+			result += char === "\n" || char === "\r" ? char : " ";
+		}
+	}
+	return result;
+}
 
 function namedGradleBlockBodies(source: string, name: string): string[] {
 	const bodies: string[] = [];
@@ -2417,18 +2508,29 @@ export function getSpotlessKotlinFormatter(
 	cwd: string,
 ): SpotlessKotlinFormatter | undefined {
 	for (const dir of walkUpDirs(cwd)) {
-		for (const gradle of KOTLIN_BUILD_FILES) {
+		for (const gradle of KOTLIN_GRADLE_FILES) {
 			const filePath = path.join(dir, gradle);
 			if (!fs.existsSync(filePath)) continue;
 			try {
-				const source = fs.readFileSync(filePath, "utf-8");
-				const kotlinBodies = namedGradleBlockBodies(source, "spotless").flatMap(
-					(spotless) => namedGradleBlockBodies(spotless, "kotlin"),
-				);
-				if (kotlinBodies.some((body) => /\bktlint\s*\(/.test(body)))
-					return "ktlint";
-				if (kotlinBodies.some((body) => /\bktfmt\s*\(/.test(body)))
-					return "ktfmt";
+				const mtime = fs.statSync(filePath).mtimeMs;
+				let config = spotlessKotlinConfigCache.get(filePath);
+				if (!config || config.mtime !== mtime) {
+					const source = stripGradleCommentsAndStrings(
+						fs.readFileSync(filePath, "utf-8"),
+					);
+					spotlessGradleReadCount += 1;
+					const kotlinBodies = namedGradleBlockBodies(source, "spotless").flatMap(
+						(spotless) => namedGradleBlockBodies(spotless, "kotlin"),
+					);
+					config = {
+						mtime,
+						ktlintConfig: kotlinBodies.some((body) => /\bktlint\s*\(/.test(body)),
+						ktfmtConfig: kotlinBodies.some((body) => /\bktfmt\s*\(/.test(body)),
+					};
+					spotlessKotlinConfigCache.set(filePath, config);
+				}
+				if (config.ktlintConfig) return "ktlint";
+				if (config.ktfmtConfig) return "ktfmt";
 			} catch {}
 		}
 	}

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -1302,6 +1302,7 @@ export interface LinterPolicyContext {
 	hasMypyConfig?: boolean;
 	hasDetektConfig?: boolean;
 	hasKtfmtConfig?: boolean;
+	hasKtlintConfig?: boolean;
 	hasTflintConfig?: boolean;
 }
 
@@ -1315,6 +1316,7 @@ export interface AutofixPolicyContext {
 	hasDetektConfig?: boolean;
 	hasOxlintConfig?: boolean;
 	hasKtfmtConfig?: boolean;
+	hasKtlintConfig?: boolean;
 }
 
 export function getLinterPolicyForFile(
@@ -1747,6 +1749,16 @@ export function getAutofixPolicyForFile(
 	}
 
 	if ([".kt", ".kts"].includes(ext)) {
+		if (context.hasKtlintConfig) {
+			return {
+				toolNames: ["ktlint", "ktfmt", "detekt"],
+				preferredTools: ["ktlint"],
+				defaultTool: "ktlint",
+				defaultWhenUnconfigured: false,
+				gate: "config-first",
+				safe: true,
+			};
+		}
 		// ktfmt is config-first and the project's explicit formatting choice, so it
 		// wins over both detekt and the ktlint smart-default when opted in (#129).
 		if (context.hasKtfmtConfig) {
@@ -2375,7 +2387,61 @@ const KTFMT_GRADLE_FILES = [
 	"settings.gradle",
 ];
 
+const KOTLIN_BUILD_FILES = ["build.gradle.kts", "build.gradle"];
+
+function namedGradleBlockBodies(source: string, name: string): string[] {
+	const bodies: string[] = [];
+	const startPattern = new RegExp(`\\b${name}\\s*\\{`, "g");
+	for (const match of source.matchAll(startPattern)) {
+		const open = source.indexOf("{", match.index);
+		let depth = 1;
+		for (let index = open + 1; index < source.length; index += 1) {
+			if (source[index] === "{") depth += 1;
+			if (source[index] === "}") depth -= 1;
+			if (depth === 0) {
+				bodies.push(source.slice(open + 1, index));
+				break;
+			}
+		}
+	}
+	return bodies;
+}
+
+export type SpotlessKotlinFormatter = "ktlint" | "ktfmt";
+
+/**
+ * Resolve the formatter elected by a Spotless `kotlin { ... }` block.
+ * ktlint is the deterministic tie-break if a malformed project names both.
+ */
+export function getSpotlessKotlinFormatter(
+	cwd: string,
+): SpotlessKotlinFormatter | undefined {
+	for (const dir of walkUpDirs(cwd)) {
+		for (const gradle of KOTLIN_BUILD_FILES) {
+			const filePath = path.join(dir, gradle);
+			if (!fs.existsSync(filePath)) continue;
+			try {
+				const source = fs.readFileSync(filePath, "utf-8");
+				const kotlinBodies = namedGradleBlockBodies(source, "spotless").flatMap(
+					(spotless) => namedGradleBlockBodies(spotless, "kotlin"),
+				);
+				if (kotlinBodies.some((body) => /\bktlint\s*\(/.test(body)))
+					return "ktlint";
+				if (kotlinBodies.some((body) => /\bktfmt\s*\(/.test(body)))
+					return "ktfmt";
+			} catch {}
+		}
+	}
+	return undefined;
+}
+
+export function hasKtlintConfig(cwd: string): boolean {
+	return getSpotlessKotlinFormatter(cwd) === "ktlint";
+}
+
 export function hasKtfmtConfig(cwd: string): boolean {
+	const spotlessFormatter = getSpotlessKotlinFormatter(cwd);
+	if (spotlessFormatter) return spotlessFormatter === "ktfmt";
 	for (const dir of walkUpDirs(cwd)) {
 		if (KTFMT_CONFIG_FILES.some((cfg) => fs.existsSync(path.join(dir, cfg))))
 			return true;

--- a/tests/clients/formatter-policy-consistency.test.ts
+++ b/tests/clients/formatter-policy-consistency.test.ts
@@ -108,6 +108,18 @@ const NO_POLICY_FALLBACK_EXTS = new Set<string>([
 ]);
 
 describe("formatter ↔ policy consistency (#1135)", () => {
+	it("every multi-formatter extension has one unique deterministic default (#1306)", () => {
+		expectClean(FORMATTER_POLICY_BY_EXTENSION, ([ext, policy]) => {
+			if (policy.formatterNames.length < 2) return null;
+			const uniqueNames = new Set(policy.formatterNames);
+			if (uniqueNames.size !== policy.formatterNames.length) {
+				return `${ext} contains duplicate formatter claims`;
+			}
+			return policy.defaultFormatter && uniqueNames.has(policy.defaultFormatter)
+				? null
+				: `${ext} has multiple formatter candidates but no defaultFormatter among them`;
+		});
+	});
 	it("every formatter definition extension is policy-included, a documented exclusion, or a documented no-policy fallback (direction 1: no silent drop)", () => {
 		expectClean(definitionExtensionPairs, ({ name, ext }) => {
 			const policy = FORMATTER_POLICY_BY_EXTENSION.get(ext);

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -31,6 +31,7 @@ import {
 	shfmtFormatter,
 } from "../../clients/formatters.ts";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+import { _getSpotlessGradleReadCountForTests } from "../../clients/tool-policy.js";
 
 // ---------------------------------------------------------------------------
 // Platform helpers
@@ -497,6 +498,32 @@ describe("getFormattersForFile — policy selection", () => {
 			expect(formatters.map((formatter) => formatter.name)).toEqual(["ktlint"]);
 			expect(formatters.some((formatter) => formatter.name === "ktfmt")).toBe(false);
 		}
+	});
+
+	it("selects ktlint for a 76-file multi-directory session with one Gradle read (#1306)", async () => {
+		createTempFile(
+			tmpDir,
+			"settings.gradle.kts",
+			"spotless {\n  kotlin {\n    ktlint()\n  }\n}\n",
+		);
+		const files = Array.from({ length: 76 }, (_, index) => {
+			const filePath = path.join(
+				tmpDir,
+				"modules",
+				`module-${index % 13}`,
+				"src",
+				`File${index}.kt`,
+			);
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, `class File${index}\n`);
+			return filePath;
+		});
+		const readsBefore = _getSpotlessGradleReadCountForTests();
+		for (const filePath of files) {
+			const formatters = await getFormattersForFile(filePath, tmpDir);
+			expect(formatters.map((formatter) => formatter.name)).toEqual(["ktlint"]);
+		}
+		expect(_getSpotlessGradleReadCountForTests() - readsBefore).toBe(1);
 	});
 
 	it("selects Spotless ktfmt and never ktlint (#1306)", async () => {

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -487,6 +487,28 @@ describe("getFormattersForFile — policy selection", () => {
 		});
 	});
 
+	it("selects Spotless ktlint on every invocation and never ktfmt (#1306)", async () => {
+		const fixtureRoot = path.resolve(
+			"tests/fixtures/formatter-policy/kotlin-ktlint",
+		);
+		const filePath = path.join(fixtureRoot, "src", "App.kt");
+		for (let invocation = 0; invocation < 5; invocation += 1) {
+			const formatters = await getFormattersForFile(filePath, fixtureRoot);
+			expect(formatters.map((formatter) => formatter.name)).toEqual(["ktlint"]);
+			expect(formatters.some((formatter) => formatter.name === "ktfmt")).toBe(false);
+		}
+	});
+
+	it("selects Spotless ktfmt and never ktlint (#1306)", async () => {
+		createTempFile(
+			tmpDir,
+			"build.gradle.kts",
+			"spotless {\n  kotlin {\n    ktfmt()\n  }\n}\n",
+		);
+		const formatters = await getFormattersForFile(fileIn(tmpDir, "App.kt"), tmpDir);
+		expect(formatters.map((formatter) => formatter.name)).toEqual(["ktfmt"]);
+	});
+
 	it("does not force swiftformat on unconfigured Swift files", async () => {
 		await withPathShim("swiftformat", async () => {
 			const filePath = fileIn(tmpDir, "App.swift");

--- a/tests/clients/tool-policy.test.ts
+++ b/tests/clients/tool-policy.test.ts
@@ -26,6 +26,8 @@ import {
 	hasDetektConfig,
 	hasJavaBuildDescriptor,
 	hasKtfmtConfig,
+	hasKtlintConfig,
+	getSpotlessKotlinFormatter,
 	hasEslintConfig,
 	hasGolangciConfig,
 	hasGoogleJavaFormatConfig,
@@ -254,6 +256,12 @@ describe("tool-policy", () => {
 		expect(
 			getAutofixPolicyForFile("/tmp/file.kt", { hasKtfmtConfig: true }),
 		).toMatchObject({ preferredTools: ["ktfmt"], gate: "config-first" });
+		expect(
+			getAutofixPolicyForFile("/tmp/file.kt", {
+				hasKtlintConfig: true,
+				hasKtfmtConfig: true,
+			}),
+		).toMatchObject({ preferredTools: ["ktlint"], gate: "config-first" });
 		expect(
 			getAutofixPolicyForFile("/tmp/file.kt", {
 				hasKtfmtConfig: true,
@@ -1076,6 +1084,30 @@ describe("tool-policy", () => {
 				"build.gradle.kts",
 				'plugins {\n  id("com.ncorti.ktfmt.gradle") version "0.21.0"\n}\n',
 			);
+			expect(hasKtfmtConfig(env.tmpDir)).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("pins Spotless kotlin ktlint and excludes ktfmt (#1306)", () => {
+		const env = setupTestEnvironment("pi-lens-tool-policy-spotless-ktlint-");
+		try {
+			createTempFile(env.tmpDir, "build.gradle", "spotless {\n  kotlin {\n    ktlint()\n  }\n}\n");
+			expect(getSpotlessKotlinFormatter(env.tmpDir)).toBe("ktlint");
+			expect(hasKtlintConfig(env.tmpDir)).toBe(true);
+			expect(hasKtfmtConfig(env.tmpDir)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("pins Spotless kotlin ktfmt and excludes ktlint (#1306)", () => {
+		const env = setupTestEnvironment("pi-lens-tool-policy-spotless-ktfmt-");
+		try {
+			createTempFile(env.tmpDir, "build.gradle.kts", "spotless {\n  kotlin {\n    ktfmt()\n  }\n}\n");
+			expect(getSpotlessKotlinFormatter(env.tmpDir)).toBe("ktfmt");
+			expect(hasKtlintConfig(env.tmpDir)).toBe(false);
 			expect(hasKtfmtConfig(env.tmpDir)).toBe(true);
 		} finally {
 			env.cleanup();

--- a/tests/clients/tool-policy.test.ts
+++ b/tests/clients/tool-policy.test.ts
@@ -53,6 +53,7 @@ import {
 	hasYamllintConfig,
 	isSafePipelineAutofixTool,
 	shouldAutoInstallTool,
+	_getSpotlessGradleReadCountForTests,
 } from "../../clients/tool-policy.ts";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
@@ -1109,6 +1110,73 @@ describe("tool-policy", () => {
 			expect(getSpotlessKotlinFormatter(env.tmpDir)).toBe("ktfmt");
 			expect(hasKtlintConfig(env.tmpDir)).toBe(false);
 			expect(hasKtfmtConfig(env.tmpDir)).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it.each([
+		["line comment", "spotless {\n  kotlin {\n    // ktlint()\n  }\n}\n"],
+		["block comment", "spotless {\n  kotlin {\n    /* ktlint() */\n  }\n}\n"],
+		["string literal", 'spotless {\n  kotlin {\n    val example = "ktlint()"\n  }\n}\n'],
+	])("ignores ktlint() in a %s (#1306)", (_kind, source) => {
+		const env = setupTestEnvironment("pi-lens-tool-policy-spotless-lexical-");
+		try {
+			createTempFile(env.tmpDir, "build.gradle.kts", source);
+			expect(getSpotlessKotlinFormatter(env.tmpDir)).toBeUndefined();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("documents disabled Gradle blocks as a lexical-scanner limitation (#1306)", () => {
+		const env = setupTestEnvironment("pi-lens-tool-policy-spotless-disabled-");
+		try {
+			createTempFile(
+				env.tmpDir,
+				"build.gradle.kts",
+				"spotless {\n  kotlin {\n    if (false) { ktlint() }\n  }\n}\n",
+			);
+			expect(getSpotlessKotlinFormatter(env.tmpDir)).toBe("ktlint");
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("detects Spotless Kotlin configuration in settings.gradle.kts (#1306)", () => {
+		const env = setupTestEnvironment("pi-lens-tool-policy-spotless-settings-");
+		try {
+			createTempFile(
+				env.tmpDir,
+				"settings.gradle.kts",
+				"spotless {\n  kotlin {\n    ktfmt()\n  }\n}\n",
+			);
+			const subDir = path.join(env.tmpDir, "modules", "app");
+			fs.mkdirSync(subDir, { recursive: true });
+			expect(getSpotlessKotlinFormatter(subDir)).toBe("ktfmt");
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("memoizes Spotless detection by Gradle path and mtime (#1306)", () => {
+		const env = setupTestEnvironment("pi-lens-tool-policy-spotless-memo-");
+		const gradlePath = createTempFile(
+			env.tmpDir,
+			"build.gradle.kts",
+			"spotless {\n  kotlin {\n    ktlint()\n  }\n}\n",
+		);
+		try {
+			const readsBefore = _getSpotlessGradleReadCountForTests();
+			for (let selection = 0; selection < 8; selection += 1) {
+				expect(getSpotlessKotlinFormatter(env.tmpDir)).toBe("ktlint");
+			}
+			expect(_getSpotlessGradleReadCountForTests() - readsBefore).toBe(1);
+
+			const nextMtime = new Date(fs.statSync(gradlePath).mtimeMs + 2_000);
+			fs.utimesSync(gradlePath, nextMtime, nextMtime);
+			expect(getSpotlessKotlinFormatter(env.tmpDir)).toBe("ktlint");
+			expect(_getSpotlessGradleReadCountForTests() - readsBefore).toBe(2);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/fixtures/formatter-policy/kotlin-ktlint/build.gradle
+++ b/tests/fixtures/formatter-policy/kotlin-ktlint/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'com.diffplug.spotless' version '6.25.0'
+}
+
+spotless {
+    kotlin {
+        ktlint()
+    }
+}

--- a/tests/fixtures/formatter-policy/kotlin-ktlint/src/App.kt
+++ b/tests/fixtures/formatter-policy/kotlin-ktlint/src/App.kt
@@ -1,0 +1,1 @@
+class App


### PR DESCRIPTION
## Summary
External report (#1306): `.kt` files resolved to ktfmt (config-first) or ktlint (smart-default) depending on which branch fired — 76/13 split in one repo whose build enforces ktlint via Spotless, producing commits that fail `spotlessCheck`.

Root cause: ktlint had no explicit-config detection, so a Spotless `kotlin { ktlint() }` block could never participate in the config-first tie-break, and per-directory decision caching amplified whichever branch won first.

Fix:
- Spotless block detection in build.gradle(.kts): `kotlin { ktlint() }` → ktlint pinned; `kotlin { ktfmt() }` → ktfmt pinned; both (malformed) → ktlint wins; neither → #1294's unconfigured gating.
- Class sweep: web (biome/prettier/oxfmt) and Python (black/ruff) families verified already-deterministic; Kotlin was the only racing pair. A new structural `formatter-policy-consistency` guard enforces unique candidates + exactly one applicable default for every multi-formatter extension, so the class can't regrow.
- Regression fixture loops five invocations: ktfmt never selected under Spotless-ktlint. Mutation-verified (detection disabled → red).

Closes #1306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)