### PR TITLE
test: present-path coverage for the top-tier always-absent stubs (refs #1252)

### DIFF
--- a/tests/clients/project-diagnostics/fresh-fetch.test.ts
+++ b/tests/clients/project-diagnostics/fresh-fetch.test.ts
@@ -293,6 +293,32 @@ describe("fetchFreshProjectDiagnostics (#585)", () => {
 			expect.anything(),
 		);
 		expect(result.runners).toContain("jscpd");
+		expect(cacheManager.writeCache).toHaveBeenCalledWith(
+			"jscpd-ts",
+			expect.objectContaining({ duplicatedLines: 4, percentage: 40 }),
+			path.resolve(tmp),
+			expect.anything(),
+		);
+	});
+
+	it("persists the present madge result for downstream diagnostics", async () => {
+		const cacheManager = makeCacheManager();
+		const madgeResult = {
+			circular: [[path.join(tmp, "src", "a.ts"), path.join(tmp, "src", "b.ts")]],
+			count: 1,
+		};
+		const clients = makeClients({ madgeAvailable: true, madgeResult });
+
+		const result = await fetchFreshProjectDiagnostics(cacheManager, tmp, clients);
+
+		expect(clients.depChecker.scanProject).toHaveBeenCalledWith(path.resolve(tmp));
+		expect(cacheManager.writeCache).toHaveBeenCalledWith(
+			"madge",
+			madgeResult,
+			path.resolve(tmp),
+			expect.anything(),
+		);
+		expect(result.cold).not.toContain("madge");
 	});
 
 	it("gates govulncheck/trivy on their own static signals, without cache reads", async () => {

--- a/tests/clients/runtime-session.test.ts
+++ b/tests/clients/runtime-session.test.ts
@@ -45,6 +45,10 @@ function setStartupMode(mode: "full" | "quick"): () => void {
 async function runSessionStart(
 	mode: "full" | "quick",
 	setup?: (tmpDir: string) => void,
+	overrides: {
+		astGrepEnsure?: () => Promise<boolean>;
+		scanExports?: () => Promise<Map<string, string>>;
+	} = {},
 ) {
 	const env = setupTestEnvironment("pi-lens-runtime-session-");
 	setup?.(env.tmpDir);
@@ -73,7 +77,10 @@ async function runSessionStart(
 	const scanDirectory = vi.fn(() => ({ items: [] }));
 	const scanFile = vi.fn((): unknown[] => []);
 	const ensureTool = vi.fn(async () => null);
-	const astGrepEnsure = vi.fn(async () => false);
+	const astGrepEnsure = vi.fn(overrides.astGrepEnsure ?? (async () => false));
+	const scanExports = vi.fn(
+		overrides.scanExports ?? (async () => new Map<string, string>()),
+	);
 	const biomeEnsure = vi.fn(async () => false);
 	const ruffEnsure = vi.fn(async () => false);
 	const knipEnsure = vi.fn(async () => false);
@@ -128,7 +135,7 @@ async function runSessionStart(
 			astGrepClient: {
 				isAvailable: () => false,
 				ensureAvailable: astGrepEnsure,
-				scanExports: async () => new Map(),
+				scanExports,
 			},
 			biomeClient: {
 				isAvailable: () => false,
@@ -206,6 +213,30 @@ async function runSessionStart(
 
 afterEach(() => {
 	delete process.env.PI_LENS_STARTUP_MODE;
+});
+
+it("executes the ast-grep export path and reports the returned exports", async () => {
+	const exports = new Map([
+		["readConfig", "src/config.ts"],
+		["writeConfig", "src/config.ts"],
+	]);
+	const scanExports = vi.fn(async () => exports);
+	const { env, astGrepEnsure, dbg } = await runSessionStart(
+		"full",
+		(tmpDir) => createTempFile(tmpDir, "package.json", JSON.stringify({ type: "module" })),
+		{ astGrepEnsure: async () => true, scanExports },
+	);
+	try {
+		await vi.waitFor(() => expect(astGrepEnsure).toHaveBeenCalled());
+		await vi.waitFor(() => expect(scanExports).toHaveBeenCalled());
+		await vi.waitFor(() =>
+			expect(dbg).toHaveBeenCalledWith(
+				expect.stringContaining("exports scan: 2 functions found"),
+			),
+		);
+	} finally {
+		await env.cleanup();
+	}
 });
 
 describe("runtime-session notifications", () => {


### PR DESCRIPTION
## Summary
Shape-7 sweep, top tier: the always-absent dependency stubs left present-path branches compile-checked-only. Adds behavior-asserting present-path tests (dependency result must reach the caller) for the confirmed #1251 victim class plus three representative categories: session-start ast-grep export ingestion, fresh-diagnostics jscpd propagation, fresh-diagnostics madge propagation. Mutation-verified 3/3 (wiring broken → red).

Full suite 5,966 green. Remaining inventory recorded on #1252 (refs, not closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)