### PR TITLE
test: record #1081 criterion-4 contention evidence on the planning-occupancy guard (closes #1229)

### DIFF
--- a/tests/clients/lsp/edits.test.ts
+++ b/tests/clients/lsp/edits.test.ts
@@ -863,6 +863,8 @@ describe("LSP workspace edits", () => {
 			expect(planned).toBe(count * 2);
 			expect(cpuMs).toBeLessThan(200);
 			expect(maxBlock).toBeLessThan(300);
+			// Criterion-4 evidence: the 4-worker full-suite run passed these occupancy
+			// assertions, so contention did not breach the 200ms CPU or 300ms sync-block budgets.
 		} finally { removeTempDirSync(tmpDir); }
 	});
 


### PR DESCRIPTION
## Summary
Verified the planning-occupancy guard under a REAL full-suite run (`MAX_WORKERS=4`), per #1081 criterion 4: 800 planned operations (400 text edits + 400 creates) stayed under the 200ms CPU / 300ms max-sync-block budgets with all 5,980 tests running concurrently — the guard does not rely on the phased quiet window. Full-suite: 521 files passed, 190.9s wall.

Change is the criterion-4 evidence comment on the guard itself (tests/clients/lsp/edits.test.ts:863); no behavior change.

Closes #1229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)