### PR TITLE
test(word-index): superseded-during-rebuild invariant lock (closes #1227)

### DIFF
--- a/tests/clients/word-index-superseded-during-rebuild.test.ts
+++ b/tests/clients/word-index-superseded-during-rebuild.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #1227 matrix row: a rebuild is superseded while it is in progress.
+ *
+ * The first build is paused at the real cooperative-budget yield seam. The
+ * yield hook starts generation 2 before generation 1 resumes, so the older
+ * builder's continuation observes supersession deterministically. Generation
+ * 1 must reject without exposing its private partial index; generation 2 must
+ * publish only its complete replacement.
+ *
+ * Invariant lock: the generation/continuation guard and staged builder state
+ * already enforce this contract in current code. If the guard is disabled,
+ * the first expectation below fails because the superseded build completes.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../clients/cooperative-budget.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../clients/cooperative-budget.js")>();
+	return {
+		...actual,
+		// Keep the test deterministic: every long-line checkpoint yields, without
+		// depending on how much CPU time happened to elapse before it.
+		yieldIfOverBudget: async () => {
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			return true;
+		},
+	};
+});
+
+import {
+	buildWordIndexAsync,
+	type WordIndex,
+} from "../../clients/word-index.js";
+
+function document(path: string, identifier: string) {
+	return {
+		path,
+		// A long line guarantees that buildWordIndexAsync reaches the real
+		// cooperative yield seam even on a fast or lightly loaded CI machine.
+		content: `${"x ".repeat(2_100)}export const ${identifier} = 1;`,
+		mtimeMs: 1,
+		size: 4_300,
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("word-index rebuild supersession (#1227)", () => {
+	it("never publishes a partial superseded result", async () => {
+		const oldDocs = Object.assign(
+			[
+				document("src/old-a.ts", "oldGenerationAlpha"),
+				document("src/old-b.ts", "oldGenerationBeta"),
+			],
+			{ truncated: false },
+		);
+		const newDocs = Object.assign(
+			[
+				document("src/new-a.ts", "newGenerationAlpha"),
+				document("src/new-b.ts", "newGenerationBeta"),
+			],
+			{ truncated: false },
+		);
+
+		let generation = 0;
+		let secondBuild: Promise<WordIndex> | undefined;
+		let yieldCount = 0;
+		const realSetImmediate = globalThis.setImmediate;
+		vi.spyOn(globalThis, "setImmediate").mockImplementation(
+			(callback, ...args) => {
+				if (yieldCount++ === 0) {
+					// This is the deterministic interleaving: generation 2 starts
+					// while generation 1 is suspended at its cooperative yield.
+					generation = 1;
+					secondBuild = buildWordIndexAsync(newDocs, () => generation === 1);
+				}
+				return realSetImmediate(callback, ...args);
+			},
+		);
+
+		const firstBuild = buildWordIndexAsync(oldDocs, () => generation === 0);
+		await expect(firstBuild).rejects.toThrow("word index build superseded");
+		expect(secondBuild).toBeDefined();
+
+		const replacement = await secondBuild!;
+		// Atomic publish: the replacement is complete, and none of generation 1's
+		// postings escaped from its private staged index.
+		expect(replacement.docCount).toBe(newDocs.length);
+		expect(replacement.postings.get("newgenerationalpha")).toEqual([
+			{ file: "src/new-a.ts", line: 1 },
+		]);
+		expect(replacement.postings.get("oldgenerationalpha")).toBeUndefined();
+		// No staged/partial object is handed to the caller on the superseded path:
+		// the only result is the fully-built generation-2 replacement.
+		expect(yieldCount).toBeGreaterThan(1);
+	});
+});


### PR DESCRIPTION
## Summary
The third and final #1227 matrix row: a rebuild superseded mid-flight (generation 2 starts while generation 1 is suspended at a cooperative-budget yield point — deterministic via a setImmediate spy, no sleeps/sampling per the #1298 lesson) must never publish the stale result, never expose partial state, and never leak staged artifacts.

Labeled an INVARIANT LOCK per the issue's acceptance criteria — the generation guards already hold; mutation evidence: removing the async builder's three supersession checks publishes the stale index and the test goes red.

Rows 1–2 landed in #1288. Closes #1227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)