### PR TITLE
docs(testing): require present-path coverage for new absent stubs (closes #1252)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1180,6 +1180,8 @@ v3.8.74. Release history lives in `CHANGELOG.md` (dated, versioned, kept current
 
 ## Test requirements
 
+A new always-absent dependency stub (a `vi.mock`/fixture that makes a dependency permanently unavailable) must ship with at least one present-path **behavior** test: the dependency's result must reach the caller, never just a bare no-throw assertion. #1251 is the failure case; #1310 is the pattern to follow.
+
 Every commit that adds or changes logic **must** include relevant tests before pushing. No exceptions:
 
 - New functions → unit tests covering the happy path, edge cases, and error paths.


### PR DESCRIPTION
## Summary
The re-scoped #1252 (per the issue's maintainer decision): forward enforcement over mass backfill. AGENTS.md's testing conventions now require every NEW always-absent dependency stub to ship with at least one present-path BEHAVIOR test (result reaching the caller, never bare no-throw), citing #1251 as the failure case and #1310 as the pattern. Bug-driven backfill for the existing tail is covered by the standing class-sweep rule.

The optional meta-test was skipped under the brief's fragility rule (a heuristic detector is worse than none — the #1284 evasion lessons).

Closes #1252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)