### PR TITLE
refactor(installer): fold the probe-cache onto durable-store; unify quarantine recovery into the shared lock (closes #1212)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,16 +10,19 @@ AGENTS.md is the durable context handed to every agent that works on pi-lens. **
 
 **Behavior-gating durable stores serialize read-modify-write.** Atomic rename
 prevents torn JSON but not lost sibling-process deltas. Use
-`clients/durable-store.ts` for short synchronous commits; it acquires the
-bounded PID lock, performs the authoritative disk re-read internally (callers
+`clients/durable-store.ts`; short synchronous commits acquire the bounded PID
+file lock, while awaited commits acquire its shared quarantine-directory
+variant. Both perform the authoritative disk re-read internally (callers
 receive only its serialized contents through `deserialize`, never supply a
 read callback), merges only the caller's delta, and publishes through a
 throwing atomic write. `afterWriteLocked` cache refreshes run after publication
 but before lock release so another writer cannot pair its stat with stale
 committed state; telemetry or other post-success work must preserve that
 ordering when it is state-coupled. The
-PID liveness check has a documented bounded PID-reuse exposure; its unique
-token prevents a late owner from deleting a replacement lock. Callers must
+PID liveness check has a documented bounded PID-reuse exposure. Both lock
+forms use unique ownership tokens; the awaited form renames stale locks and
+releases aside before token inspection, so a late owner cannot delete a
+replacement lock. Callers must
 choose contention policy explicitly: correctness-critical stores use
 `onContention: "throw"`; dispatch-adjacent best-effort stores use `"skip-log"`
 with a drop telemetry callback and skip the whole commit when acquisition
@@ -29,8 +32,11 @@ Generic atomic-write staging names are owned only by
 `clients/atomic-write-staging.ts`: mint, strict classification, owner-pid
 extraction, and the bounded session-start sweep must stay on that seam so a
 format change cannot drift from garbage collection. The installer probe cache
-keeps its older richer lock because quarantine recovery and install-lifetime
-aging predate the short-commit durable-store seam. (#1209, #1212)
+uses the awaited durable-store seam: its delta/version snapshot maps to
+`merge`, pending-update retirement and mirror refresh run in
+`afterWriteLocked`, and TTL/existence/mtime validation remains read-side
+policy. Turn-state remains separate pending a future ownership decision.
+(#1209, #1212)
 
 ## Issue and PR design contract
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Changed
 
-- **Shared durable-store and atomic-stage protocols (refs #1212, closes #1209)** — diagnostic dispositions and actionable-warning suppression now use one locked in-lock-reread/merge/throwing-atomic-write commit seam, while one staging namespace module owns `.tmp-<pid>-<threadId>-<seq>` minting, classification, and bounded own-stage sweeping. The installer probe cache retains its older quarantine-aware install lock; folding that richer protocol remains deferred under #1212.
+- **Installer probe-cache persistence now uses the shared durable-store protocol (closes #1212)** — awaited commits use the shared quarantine-recovering bounded PID lock, authoritative in-lock reread/delta merge, throwing atomic publication, and in-lock mirror refresh while retaining deferred/failed retry outcomes; TTL, existence, and mtime validation remain read-side policy. Turn-state folding remains a future decision, not part of this change.
+
+- **Shared durable-store and atomic-stage protocols (refs #1212, closes #1209)** — diagnostic dispositions and actionable-warning suppression now use one locked in-lock-reread/merge/throwing-atomic-write commit seam, while one staging namespace module owns `.tmp-<pid>-<threadId>-<seq>` minting, classification, and bounded own-stage sweeping.
 
 - **Standalone managed-tool clients share one typed availability/install seam (closes [#1290](https://github.com/apmantza/pi-lens/issues/1290), refs [#1214](https://github.com/apmantza/pi-lens/issues/1214))** — madge, Knip, Biome, and ast-grep now join Ruff/jscpd behind runner helpers. Single-command clients use the cached typed checker; ordered-candidate clients retain their local/global/npx/platform search through a typed custom-probe wrapper. The seam also owns managed child environments and read-only discovery, while a source coverage test rejects direct `ensureTool()` calls or bare managed-tool spawns outside sanctioned wrappers. Raw ENOENT consumers in `lsp/launch.ts` remain for #1214's safe-spawn-wide taxonomy.
 

--- a/clients/bounded-pid-file-lock.ts
+++ b/clients/bounded-pid-file-lock.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
 
 const waitArray = new Int32Array(new SharedArrayBuffer(4));
 
@@ -10,6 +12,193 @@ function ownerPidIsLive(pid: number): boolean {
 		return true;
 	} catch (error) {
 		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+interface QuarantinePidFileLockOptions extends BoundedPidFileLockOptions {
+	staleMs: number;
+}
+
+type QuarantineLockOwner = {
+	pid: number;
+	createdAt: number;
+	token: string;
+};
+
+function quarantinePath(lockPath: string, token: string): string {
+	return `${lockPath}.quarantine-${process.pid}-${token}`;
+}
+
+async function restoreQuarantinedLock(
+	lockPath: string,
+	quarantined: string,
+): Promise<void> {
+	try {
+		await fsp.rename(quarantined, lockPath);
+	} catch {
+		// A replacement owner may already hold the canonical name. Never overwrite it.
+	}
+}
+
+async function releaseQuarantineLock(
+	lockPath: string,
+	token: string,
+): Promise<void> {
+	const quarantined = quarantinePath(lockPath, `release-${token}`);
+	let renamed = false;
+	for (let attempt = 0; attempt < 3; attempt += 1) {
+		try {
+			await fsp.rename(lockPath, quarantined);
+			renamed = true;
+			break;
+		} catch (error) {
+			if (
+				(error as NodeJS.ErrnoException).code !== "ENOENT" ||
+				attempt === 2
+			) return;
+			await new Promise<void>((resolve) => setImmediate(resolve));
+		}
+	}
+	if (!renamed) return;
+	try {
+		const owner = JSON.parse(
+			await fsp.readFile(path.join(quarantined, "owner.json"), "utf8"),
+		) as Partial<QuarantineLockOwner>;
+		if (owner.token === token) {
+			await fsp.rm(quarantined, { recursive: true, force: true });
+		} else {
+			await restoreQuarantinedLock(lockPath, quarantined);
+		}
+	} catch {
+		await restoreQuarantinedLock(lockPath, quarantined);
+	}
+}
+
+function quarantineOwnerIsStale(
+	owner: QuarantineLockOwner,
+	staleMs: number,
+): boolean {
+	return Number.isInteger(owner.pid) && owner.pid > 0 &&
+		Number.isFinite(owner.createdAt) &&
+		(!ownerPidIsLive(owner.pid) || Date.now() - owner.createdAt > staleMs);
+}
+
+async function reclaimQuarantineLock(
+	lockPath: string,
+	staleMs: number,
+): Promise<boolean> {
+	const quarantined = quarantinePath(
+		lockPath,
+		`reclaim-${Date.now()}-${randomUUID()}`,
+	);
+	try {
+		await fsp.rename(lockPath, quarantined);
+	} catch {
+		return false;
+	}
+	let stale = false;
+	try {
+		const owner = JSON.parse(
+			await fsp.readFile(path.join(quarantined, "owner.json"), "utf8"),
+		) as QuarantineLockOwner;
+		stale = quarantineOwnerIsStale(owner, staleMs);
+	} catch {
+		try {
+			stale = Date.now() - (await fsp.stat(quarantined)).mtimeMs > staleMs;
+		} catch {
+			stale = false;
+		}
+	}
+	if (stale) {
+		await fsp.rm(quarantined, { recursive: true, force: true });
+		return true;
+	}
+	await restoreQuarantinedLock(lockPath, quarantined);
+	return false;
+}
+
+async function tryAcquireQuarantineLock(
+	lockPath: string,
+	staleMs: number,
+): Promise<(() => Promise<void>) | null> {
+	const owner: QuarantineLockOwner = {
+		pid: process.pid,
+		createdAt: Date.now(),
+		token: `${process.pid}-${Date.now()}-${randomUUID()}`,
+	};
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		try {
+			await fsp.mkdir(lockPath);
+			try {
+				await fsp.writeFile(
+					path.join(lockPath, "owner.json"),
+					JSON.stringify(owner),
+					"utf8",
+				);
+			} catch (error) {
+				await fsp.rm(lockPath, { recursive: true, force: true }).catch(() => {});
+				throw error;
+			}
+			return () => releaseQuarantineLock(lockPath, owner.token);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+		}
+		let stale: boolean;
+		try {
+			const existing = JSON.parse(
+				await fsp.readFile(path.join(lockPath, "owner.json"), "utf8"),
+			) as QuarantineLockOwner;
+			stale = quarantineOwnerIsStale(existing, staleMs);
+		} catch {
+			try {
+				stale = Date.now() - (await fsp.stat(lockPath)).mtimeMs > staleMs;
+			} catch {
+				stale = true;
+			}
+		}
+		if (!stale || !(await reclaimQuarantineLock(lockPath, staleMs))) return null;
+	}
+	return null;
+}
+
+/**
+ * Async directory-lock variant for commits that may span awaited I/O. Stale
+ * owners are renamed aside before inspection/removal; token-checked release
+ * likewise renames first, so a late owner can never delete its replacement.
+ */
+export async function acquireQuarantinePidFileLock(
+	lockPath: string,
+	options: QuarantinePidFileLockOptions & { onContention?: "throw" },
+): Promise<() => Promise<void>>;
+export async function acquireQuarantinePidFileLock(
+	lockPath: string,
+	options: QuarantinePidFileLockOptions & {
+		onContention: "skip-log";
+		logContention: () => void;
+	},
+): Promise<(() => Promise<void>) | null>;
+export async function acquireQuarantinePidFileLock(
+	lockPath: string,
+	options: QuarantinePidFileLockOptions & (
+		| { onContention?: "throw" }
+		| { onContention: "skip-log"; logContention: () => void }
+	),
+): Promise<(() => Promise<void>) | null> {
+	const deadline = Date.now() + options.waitMs;
+	for (;;) {
+		const release = await tryAcquireQuarantineLock(lockPath, options.staleMs);
+		if (release) return release;
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) {
+			if (options.onContention === "skip-log") {
+				options.logContention();
+				return null;
+			}
+			throw new Error(options.timeoutMessage);
+		}
+		await new Promise((resolve) =>
+			setTimeout(resolve, Math.min(options.retryMs, remaining)),
+		);
 	}
 }
 

--- a/clients/durable-store.ts
+++ b/clients/durable-store.ts
@@ -6,15 +6,18 @@
  * caller merges only its delta, publication is a throwing atomic replacement,
  * and success telemetry runs only after publication succeeds.
  *
- * The installer probe cache deliberately retains its richer, older lock. Its
- * quarantine recovery and install-lifetime ageing semantics predate this seam;
- * folding that protocol is follow-up work under #1212, not a safe mechanical
- * substitution for these short synchronous commits.
+ * Short synchronous commits use a file lock. Awaited commits use the shared
+ * quarantine directory lock, preserving bounded contention and stale-owner
+ * recovery without allowing a late release to delete a replacement owner.
  */
 
 import * as fs from "node:fs";
-import { writeFileAtomic } from "./atomic-write.js";
-import { acquireBoundedPidFileLock } from "./bounded-pid-file-lock.js";
+import fsp from "node:fs/promises";
+import { writeFileAtomic, writeFileAtomicAsync } from "./atomic-write.js";
+import {
+	acquireBoundedPidFileLock,
+	acquireQuarantinePidFileLock,
+} from "./bounded-pid-file-lock.js";
 
 interface DurableStoreCommitBase<T> {
 	path: string;
@@ -25,6 +28,11 @@ interface DurableStoreCommitBase<T> {
 	retryMs: number;
 	timeoutMessage: string;
 	afterWriteLocked?: (value: T) => void;
+}
+
+interface AsyncDurableStoreCommitBase<T> extends DurableStoreCommitBase<T> {
+	staleMs: number;
+	afterWriteLocked?: (value: T) => void | Promise<void>;
 }
 
 function readLocked(path: string): string | undefined {
@@ -78,4 +86,59 @@ export function commitDurableStore<T>(
 		release();
 	}
 	return committed;
+}
+
+async function readLockedAsync(path: string): Promise<string | undefined> {
+	try {
+		return await fsp.readFile(path, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw error;
+	}
+}
+
+export async function commitDurableStoreAsync<T>(
+	options: AsyncDurableStoreCommitBase<T> & { onContention?: "throw" },
+): Promise<T>;
+export async function commitDurableStoreAsync<T>(
+	options: AsyncDurableStoreCommitBase<T> & {
+		onContention: "skip-log";
+		logContention: () => void;
+	},
+): Promise<T | undefined>;
+export async function commitDurableStoreAsync<T>(
+	options: AsyncDurableStoreCommitBase<T> & (
+		| { onContention?: "throw" }
+		| { onContention: "skip-log"; logContention: () => void }
+	),
+): Promise<T | undefined> {
+	const release =
+		options.onContention === "skip-log"
+			? await acquireQuarantinePidFileLock(`${options.path}.lock`, {
+					waitMs: options.waitMs,
+					retryMs: options.retryMs,
+					staleMs: options.staleMs,
+					timeoutMessage: options.timeoutMessage,
+					onContention: "skip-log",
+					logContention: options.logContention,
+				})
+			: await acquireQuarantinePidFileLock(`${options.path}.lock`, {
+					waitMs: options.waitMs,
+					retryMs: options.retryMs,
+					staleMs: options.staleMs,
+					timeoutMessage: options.timeoutMessage,
+					onContention: "throw",
+				});
+	if (!release) return undefined;
+	try {
+		const current = options.deserialize(await readLockedAsync(options.path));
+		const committed = options.merge(current);
+		await writeFileAtomicAsync(options.path, options.serialize(committed), {
+			bestEffort: false,
+		});
+		await options.afterWriteLocked?.(committed);
+		return committed;
+	} finally {
+		await release();
+	}
 }

--- a/clients/durable-store.ts
+++ b/clients/durable-store.ts
@@ -19,7 +19,12 @@ import {
 	acquireQuarantinePidFileLock,
 } from "./bounded-pid-file-lock.js";
 
-interface DurableStoreCommitBase<T> {
+// Shared fields WITHOUT the post-write callback: the sync and async commit
+// variants declare their own callback signatures (void vs void|Promise<void>)
+// so neither widens the other's contract (sonar S6544 — a Promise-returning
+// callback behind a void-typed field is an unawaited-work hazard at the type
+// level; the async variant awaits its callback inside the lock).
+interface DurableStoreCommitCore<T> {
 	path: string;
 	deserialize: (contents: string | undefined) => T;
 	merge: (current: T) => T;
@@ -27,10 +32,13 @@ interface DurableStoreCommitBase<T> {
 	waitMs: number;
 	retryMs: number;
 	timeoutMessage: string;
+}
+
+interface DurableStoreCommitBase<T> extends DurableStoreCommitCore<T> {
 	afterWriteLocked?: (value: T) => void;
 }
 
-interface AsyncDurableStoreCommitBase<T> extends DurableStoreCommitBase<T> {
+interface AsyncDurableStoreCommitBase<T> extends DurableStoreCommitCore<T> {
 	staleMs: number;
 	afterWriteLocked?: (value: T) => void | Promise<void>;
 }

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -47,7 +47,6 @@
  */
 
 import { spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
 import { existsSync, statSync, unlinkSync } from "node:fs";
 import fs from "node:fs/promises";
 import https from "node:https";
@@ -58,7 +57,7 @@ import path from "node:path";
 const _installerRequire = createRequire(import.meta.url);
 import { createGunzip } from "node:zlib";
 import { logSessionStart } from "../sessionstart-logger.js";
-import { writeFileAtomicAsync } from "../atomic-write.js";
+import { commitDurableStoreAsync } from "../durable-store.js";
 import { getGlobalPiLensDir } from "../file-utils.js";
 import {
 	allAvailableGlobalBinDirs,
@@ -1409,19 +1408,11 @@ interface ProbeCacheEntry {
 type ProbeCache = Record<string, ProbeCacheEntry>;
 
 const PROBE_CACHE_PATH = path.join(getGlobalPiLensDir(), "probe-cache.json");
-const PROBE_CACHE_LOCK_PATH = `${PROBE_CACHE_PATH}.lock`;
-const PROBE_CACHE_LOCK_OWNER_PATH = path.join(PROBE_CACHE_LOCK_PATH, "owner.json");
 const PROBE_CACHE_LOCK_STALE_MS = 180_000;
 const PROBE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const PROBE_CACHE_FLUSH_LOCK_WAIT_MS = 250;
 const PROBE_CACHE_FLUSH_RETRY_DELAY_MS = 300;
 const PROBE_CACHE_FLUSH_RETRY_MAX_DELAY_MS = 30_000;
-
-type ProbeCacheLockOwner = {
-	pid: number;
-	createdAt: number;
-	token: string;
-};
 
 let _probeCache: ProbeCache | null = null;
 let _probeCacheDirty = false;
@@ -1463,178 +1454,6 @@ function markProbeCacheChange(toolId: string, entry: ProbeCacheEntry | null): vo
 	scheduleProbeFlush();
 }
 
-function isProbeCacheLockStale(owner: ProbeCacheLockOwner): boolean {
-	if (!Number.isInteger(owner.pid) || owner.pid <= 0) return false;
-	if (!Number.isFinite(owner.createdAt)) return false;
-	return (
-		!isProcessAlive(owner.pid) ||
-		Date.now() - owner.createdAt > PROBE_CACHE_LOCK_STALE_MS
-	);
-}
-
-function probeCacheLockQuarantinePath(token: string): string {
-	return `${PROBE_CACHE_LOCK_PATH}.quarantine-${process.pid}-${token}`;
-}
-
-function createProbeCacheLockToken(): string {
-	return `${process.pid}-${Date.now()}-${randomUUID()}`;
-}
-
-async function restoreProbeCacheLock(
-	quarantinePath: string,
-): Promise<void> {
-	try {
-		await fs.rename(quarantinePath, PROBE_CACHE_LOCK_PATH);
-	} catch {
-		// Another owner may have acquired the canonical path. Never remove or
-		// overwrite that owner; the quarantine is harmless and can be cleaned by a
-		// later stale-lock sweep.
-	}
-}
-
-async function releaseProbeCacheLock(token: string): Promise<void> {
-	const quarantinePath = probeCacheLockQuarantinePath(`release-${token}`);
-	let renamed = false;
-	for (let attempt = 0; attempt < 3; attempt += 1) {
-		try {
-			// Rename is the atomic ownership handoff. A late release cannot recursively
-			// remove a replacement owner that acquired the canonical path after stale
-			// reclamation.
-			await fs.rename(PROBE_CACHE_LOCK_PATH, quarantinePath);
-			renamed = true;
-			break;
-		} catch (error) {
-			// Another releaser or a stale-lock reclaimer may briefly own the canonical
-			// name's quarantine. Retry only that transient absence; never guess that a
-			// different error means this token owns the lock.
-			if (
-				(error as NodeJS.ErrnoException | undefined)?.code !== "ENOENT" ||
-				attempt === 2
-			) {
-				return;
-			}
-			await new Promise<void>((resolve) => setImmediate(resolve));
-		}
-	}
-	if (!renamed) return;
-	try {
-		const raw = await fs.readFile(
-			path.join(quarantinePath, "owner.json"),
-			"utf8",
-		);
-		const owner = JSON.parse(raw) as Partial<ProbeCacheLockOwner>;
-		if (owner.token === token) {
-			await fs.rm(quarantinePath, { recursive: true, force: true });
-		} else {
-			await restoreProbeCacheLock(quarantinePath);
-		}
-	} catch {
-		// If the owner record cannot be read, keep the lock rather than deleting a
-		// potentially newer owner's directory.
-		await restoreProbeCacheLock(quarantinePath);
-	}
-}
-
-async function tryReclaimProbeCacheLock(): Promise<boolean> {
-	const quarantinePath = probeCacheLockQuarantinePath(
-		`reclaim-${Date.now()}-${randomUUID()}`,
-	);
-	try {
-		// Moving the directory out of the canonical name is atomic. A new owner can
-		// only mkdir the canonical path after this move, so its directory is never
-		// recursively removed by stale-owner cleanup.
-		await fs.rename(PROBE_CACHE_LOCK_PATH, quarantinePath);
-	} catch {
-		return false;
-	}
-
-	let stale = false;
-	try {
-		const raw = await fs.readFile(
-			path.join(quarantinePath, "owner.json"),
-			"utf8",
-		);
-		stale = isProbeCacheLockStale(
-			JSON.parse(raw) as ProbeCacheLockOwner,
-		);
-	} catch {
-		try {
-			const stat = await fs.stat(quarantinePath);
-			stale = Date.now() - stat.mtimeMs > PROBE_CACHE_LOCK_STALE_MS;
-		} catch {
-			stale = false;
-		}
-	}
-
-	if (stale) {
-		await fs.rm(quarantinePath, { recursive: true, force: true });
-		return true;
-	}
-	await restoreProbeCacheLock(quarantinePath);
-	return false;
-}
-
-async function tryCreateProbeCacheLock(
-	owner: ProbeCacheLockOwner,
-): Promise<(() => Promise<void>) | null> {
-	try {
-		// A directory lock closes the unlink/check/recreate race: another owner
-		// cannot create the directory until this owner's recursive removal has
-		// completed, so release cannot remove a newer owner's lock.
-		await fs.mkdir(PROBE_CACHE_LOCK_PATH);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException | undefined)?.code === "EEXIST") {
-			return null;
-		}
-		throw error;
-	}
-
-	try {
-		await fs.writeFile(
-			PROBE_CACHE_LOCK_OWNER_PATH,
-			JSON.stringify(owner),
-			"utf8",
-		);
-	} catch (error) {
-		await fs.rm(PROBE_CACHE_LOCK_PATH, { recursive: true, force: true }).catch(
-			() => {},
-		);
-		throw error;
-	}
-	return () => releaseProbeCacheLock(owner.token);
-}
-
-async function isExistingProbeCacheLockStale(): Promise<boolean> {
-	try {
-		const raw = await fs.readFile(PROBE_CACHE_LOCK_OWNER_PATH, "utf8");
-		return isProbeCacheLockStale(JSON.parse(raw) as ProbeCacheLockOwner);
-	} catch {
-		try {
-			const stat = await fs.stat(PROBE_CACHE_LOCK_PATH);
-			return Date.now() - stat.mtimeMs > PROBE_CACHE_LOCK_STALE_MS;
-		} catch {
-			// The owner released between EEXIST and inspection; retry once.
-			return true;
-		}
-	}
-}
-
-async function tryAcquireProbeCacheLock(): Promise<(() => Promise<void>) | null> {
-	const owner: ProbeCacheLockOwner = {
-		pid: process.pid,
-		createdAt: Date.now(),
-		token: createProbeCacheLockToken(),
-	};
-
-	for (let attempt = 0; attempt < 2; attempt += 1) {
-		const release = await tryCreateProbeCacheLock(owner);
-		if (release) return release;
-		if (!(await isExistingProbeCacheLockStale())) return null;
-		if (!(await tryReclaimProbeCacheLock())) return null;
-	}
-	return null;
-}
-
 function scheduleProbeFlush(delayMs = PROBE_CACHE_FLUSH_RETRY_DELAY_MS): void {
 	if (_probeCacheFlushTimer !== null) return;
 	_probeCacheFlushTimer = setTimeout(() => {
@@ -1650,21 +1469,6 @@ function scheduleProbeFlushRetry(): void {
 	);
 	_probeCacheRetryAttempt += 1;
 	scheduleProbeFlush(delay);
-}
-
-async function acquireProbeCacheLockForFlush(): Promise<
-	(() => Promise<void>) | null
-> {
-	const deadline = Date.now() + PROBE_CACHE_FLUSH_LOCK_WAIT_MS;
-	while (true) {
-		const release = await tryAcquireProbeCacheLock();
-		if (release) return release;
-		const remaining = deadline - Date.now();
-		if (remaining <= 0) return null;
-		await new Promise((resolve) =>
-			setTimeout(resolve, Math.min(25, remaining)),
-		);
-	}
 }
 
 export type ProbeCacheFlushResult =
@@ -1686,23 +1490,13 @@ function snapshotProbeCacheChanges(): ProbeCacheFlushSnapshot {
 	};
 }
 
-async function readProbeCacheForFlush(): Promise<ProbeCache | undefined> {
-	try {
-		const raw = await fs.readFile(PROBE_CACHE_PATH, "utf-8");
-		const parsed: unknown = JSON.parse(raw);
-		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-			throw new Error("probe-cache root is not an object");
-		}
-		return parsed as ProbeCache;
-	} catch (err) {
-		if ((err as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
-			return {};
-		}
-		logSessionStart(
-			`auto-install probe-cache: merge read failed (${(err as NodeJS.ErrnoException | undefined)?.code ?? "invalid"}); preserving pending update`,
-		);
-		return undefined;
+function deserializeProbeCache(contents: string | undefined): ProbeCache {
+	if (contents === undefined) return {};
+	const parsed: unknown = JSON.parse(contents);
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("probe-cache root is not an object");
 	}
+	return parsed as ProbeCache;
 }
 
 function applyProbeCacheChanges(
@@ -1739,33 +1533,39 @@ function publishProbeCacheWrite(
 }
 
 async function writeProbeCache(): Promise<ProbeCacheFlushResult> {
-	const release = await acquireProbeCacheLockForFlush();
-	if (!release) {
-		// A one-shot caller gets a bounded asynchronous wait rather than an
-		// unbounded exit-path block. The explicit result tells it that persistence
-		// remains pending, and long-lived sessions get a backoff retry.
-		logSessionStart(
-			"auto-install probe-cache: flush deferred because another process owns the lock",
-		);
-		scheduleProbeFlushRetry();
-		return "deferred";
-	}
-
 	try {
 		// Snapshot versions before the awaited disk read/write. A new update for
 		// the same tool may arrive while the atomic write is in flight; its newer
 		// version must remain pending for the next flush.
 		const { changes, versions } = snapshotProbeCacheChanges();
-		// Re-read under the non-blocking lock, then apply only this process's
-		// changes. This is the read-modify-write isolation missing from a plain
-		// atomic rename: entries discovered by a sibling process survive.
-		const disk = await readProbeCacheForFlush();
-		if (!disk) return "failed";
-		applyProbeCacheChanges(disk, changes);
-		await writeFileAtomicAsync(PROBE_CACHE_PATH, JSON.stringify(disk, null, 2), {
-			bestEffort: false,
+		let result: ProbeCacheFlushResult = "written";
+		const committed = await commitDurableStoreAsync({
+			path: PROBE_CACHE_PATH,
+			deserialize: deserializeProbeCache,
+			merge: (disk) => {
+				applyProbeCacheChanges(disk, changes);
+				return disk;
+			},
+			serialize: (disk) => JSON.stringify(disk, null, 2),
+			waitMs: PROBE_CACHE_FLUSH_LOCK_WAIT_MS,
+			retryMs: 25,
+			staleMs: PROBE_CACHE_LOCK_STALE_MS,
+			timeoutMessage: "Timed out waiting for probe-cache lock",
+			onContention: "skip-log",
+			logContention: () => {
+				logSessionStart(
+					"auto-install probe-cache: flush deferred because another process owns the lock",
+				);
+			},
+			afterWriteLocked: (disk) => {
+				result = publishProbeCacheWrite(disk, versions);
+			},
 		});
-		return publishProbeCacheWrite(disk, versions);
+		if (committed === undefined) {
+			scheduleProbeFlushRetry();
+			return "deferred";
+		}
+		return result;
 	} catch (err) {
 		// Keep dirty state so a later timer/explicit flush can retry. The error
 		// is logged without paths, source, or command text; an unavailable cache
@@ -1775,8 +1575,6 @@ async function writeProbeCache(): Promise<ProbeCacheFlushResult> {
 		);
 		scheduleProbeFlushRetry();
 		return "failed";
-	} finally {
-		await release();
 	}
 }
 


### PR DESCRIPTION
## Summary
The last #1212 item: the installer probe-cache now commits through `commitDurableStoreAsync` — the delta/change-generation model feeds the authoritative in-lock merge callback, the in-memory mirror reconciles in `afterWriteLocked` (shape-12 correct), and deferred/failed flushes retain dirty state + retry.

Structural win: the quarantine-based stale-lock recovery (rename-aside + token-checked release, #1263 lineage) moved INTO `bounded-pid-file-lock.ts` — the repo now has ONE lock implementation; the installer's parallel machinery is deleted. The late-release-cannot-remove-new-owner property is preserved and tested.

Read-side TTL/existence/mtime validation unchanged. Turn-state folding deliberately not included (ownership decision recorded on the issue).

Mutation-verified: dropping the change-merge from the callback fails the "retains an update that arrives during atomic write" regression (3 red); restored green. 902 tests across installer/dispatch/probe-cache/lock/durable-store suites.

Closes #1212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)