### PR TITLE
fix(formatters): ruff format rejects --indent-style — unconfigured Python was never formatted (refs #1144)

### DIFF
--- a/.changelog/fix-nightly-smoke-formatter-gating.md
+++ b/.changelog/fix-nightly-smoke-formatter-gating.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Unconfigured Python files are formatted again (refs #1144)** — `ruff format` rejects the `--indent-style`/`--indent-width` flags the style-preserving defaults were passing, exiting 2 without touching the file; because ruff was not treated as a strict-exit formatter, every unconfigured Python file silently reported "already formatted" and was never reformatted. Style is now pinned through ruff's inline TOML overrides, and a nonzero ruff exit is surfaced as a formatting failure instead of a clean no-op.

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -402,6 +402,18 @@ async function indentationArgs(
 	if (tool === "prettier") {
 		return [indentation.style === "tab" ? "--use-tabs" : "--no-use-tabs", "--tab-width", String(indentation.width)];
 	}
+	if (tool === "ruff") {
+		// `ruff format` has NO --indent-style/--indent-width flags (it errors with
+		// "unexpected argument" and exits 2, which formatFile reports as a silent
+		// clean no-op because ruff is not strictExitCode). Style is pinned through
+		// inline TOML overrides instead (#1144 follow-up).
+		return [
+			"--config",
+			`indent-width=${indentation.width}`,
+			"--config",
+			`format.indent-style='${indentation.style}'`,
+		];
+	}
 	return ["--indent-style", indentation.style, "--indent-width", String(indentation.width)];
 }
 
@@ -541,6 +553,11 @@ export const ruffFormatter: FormatterInfo = {
 	name: "ruff",
 	command: ["ruff", "format", "$FILE"],
 	extensions: [".py", ".pyi"],
+	// Pure formatter: `ruff format` exits 0 on a successful in-place rewrite.
+	// Without this, an argument-rejection exit (2) touches nothing and reads as
+	// "already formatted" — the silent no-op that hid the bad --indent-style
+	// flags for a full release cycle.
+	strictExitCode: true,
 	async resolveCommand(filePath, cwd) {
 		const styleArgs = await indentationArgs(filePath, "ruff", cwd);
 		if (styleArgs === null) return SKIP_FORMATTING;

--- a/scripts/smoke-tools.d.mts
+++ b/scripts/smoke-tools.d.mts
@@ -41,6 +41,12 @@ export interface FormatFixture {
 	file: string;
 	formatter: string;
 	tools?: string[];
+	/**
+	 * "reformat" (default) — the formatter must rewrite the mis-formatted file.
+	 * "preserve" — #1144's style-preserving refusal: the formatter is selected
+	 * but must leave an unconfigured, style-less file byte-identical.
+	 */
+	expect?: "reformat" | "preserve";
 }
 export interface AutofixFixture {
 	lang: string;

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -696,6 +696,13 @@ const LSP_FIXTURES = [
  * `tools` are installer ids to prefetch under --install (formatters auto-install
  * via their own resolveCommand otherwise). Toolchain-gated entries only pass
  * where the language toolchain is present (⚠ skip otherwise).
+ *
+ * STYLE-PRESERVING CONTRACT (#1144). biome/prettier/ruff/shfmt refuse to format
+ * when the workspace has NO formatter config AND the file offers no indentation
+ * evidence to pin — formatting would otherwise impose the tool's stock style.
+ * A `reformat` fixture for one of those four must therefore ship a config OR
+ * contain indented lines, else it legitimately no-ops and the row fails. The
+ * `expect: "preserve"` fixture pins the refusal itself.
  */
 const FORMAT_FIXTURES = [
 	{
@@ -951,6 +958,18 @@ const FORMAT_FIXTURES = [
 		file: "messy.cpp",
 		formatter: "clang-format",
 		tools: [],
+	},
+	{
+		// Inverse of every row above: biome IS selected, but the workspace has no
+		// config and the file has no indented line, so #1144's style-preserving
+		// refusal must leave it byte-identical. A rewrite here means the stock
+		// style is being imposed on repos that never chose it.
+		lang: "preserve-unconfigured",
+		dir: "tests/fixtures/format-smoke/preserve-unconfigured",
+		file: "messy.js",
+		formatter: "biome",
+		expect: "preserve",
+		tools: ["biome"],
 	},
 ];
 
@@ -1767,6 +1786,17 @@ async function runFormatSmoke({ langs, install, verbose }) {
 					push("skip", `tool not installed (${err})`);
 				} else {
 					push("fail", `formatter failed to run: ${err}`);
+				}
+			} else if (fx.expect === "preserve") {
+				// #1144: unconfigured workspace + no indentation evidence ⇒ the
+				// formatter must refuse rather than impose its stock style.
+				if (target.changed) {
+					push(
+						"fail",
+						`${fx.formatter} rewrote an unconfigured file with no detectable style (style-preserving refusal expected)`,
+					);
+				} else {
+					push("pass", `${fx.formatter} preserved the unconfigured file`);
 				}
 			} else if (target.changed) {
 				push("pass", `${fx.formatter} reformatted the file`);

--- a/tests/clients/dispatch/format-smoke-style-contract.test.ts
+++ b/tests/clients/dispatch/format-smoke-style-contract.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Format-smoke style-contract drift guard (#1144 follow-up).
+ *
+ * #1144 made biome/prettier/ruff/shfmt style-PRESERVING: with no formatter
+ * config in the workspace AND no indented line to infer a style from, they
+ * refuse to format rather than impose their stock style. Every `--format` smoke
+ * fixture for those four was a flat, unindented snippet, so six rows
+ * (javascript, python, shell, css, html, yaml) silently began asserting a
+ * rewrite that the contract forbids — the nightly failed with "ran clean but
+ * left the mis-formatted file unchanged" and nothing in the unit suite noticed.
+ *
+ * This screens the whole matrix instead of the six that happened to fire: a
+ * `reformat` fixture driven by a style-pinning formatter must supply the style
+ * evidence its formatter needs, or it can never pass.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { hasDetectableIndentation } from "../../../clients/dispatch/indent-detect.js";
+// Typed via scripts/smoke-tools.d.mts (the harness itself is plain ESM JS).
+import { FORMAT_FIXTURES } from "../../../scripts/smoke-tools.mjs";
+
+const repoRoot = path.resolve(__dirname, "../../..");
+
+/** Formatters whose resolveCommand pins style from the file (indentationArgs). */
+const STYLE_PINNING = new Set(["biome", "prettier", "ruff", "shfmt"]);
+
+/** Config files that satisfy indentationArgs' "the repo already chose" branch. */
+const CONFIG_FILES = new Set([
+	".editorconfig",
+	".prettierrc",
+	".prettierrc.json",
+	".prettierrc.yaml",
+	".prettierrc.yml",
+	".prettierrc.js",
+	"prettier.config.js",
+	"biome.json",
+	"biome.jsonc",
+	"ruff.toml",
+	".ruff.toml",
+	"pyproject.toml",
+	"setup.cfg",
+	"package.json",
+]);
+
+function hasFormatterConfig(dir: string): boolean {
+	return fs
+		.readdirSync(dir)
+		.some((entry) => CONFIG_FILES.has(entry.toLowerCase()));
+}
+
+describe("format-smoke fixtures honor the style-preserving contract (#1144)", () => {
+	const pinned = FORMAT_FIXTURES.filter((fx) =>
+		STYLE_PINNING.has(fx.formatter),
+	);
+
+	it("covers every style-pinning formatter", () => {
+		expect(new Set(pinned.map((fx) => fx.formatter))).toEqual(STYLE_PINNING);
+	});
+
+	it.each(pinned.filter((fx) => fx.expect !== "preserve"))(
+		"$lang/$formatter supplies style evidence so a rewrite is reachable",
+		(fx) => {
+			const dir = path.join(repoRoot, fx.dir);
+			const content = fs.readFileSync(path.join(dir, fx.file), "utf8");
+			expect(
+				hasDetectableIndentation(content) || hasFormatterConfig(dir),
+				`${fx.dir}/${fx.file}: ${fx.formatter} refuses to format an unconfigured file with no indented line, so this fixture can only ever report "ran clean but left the mis-formatted file unchanged"`,
+			).toBe(true);
+		},
+	);
+
+	it("keeps a fixture that pins the refusal itself", () => {
+		const preserve = FORMAT_FIXTURES.filter((fx) => fx.expect === "preserve");
+		expect(preserve.length).toBeGreaterThan(0);
+		for (const fx of preserve) {
+			const dir = path.join(repoRoot, fx.dir);
+			const content = fs.readFileSync(path.join(dir, fx.file), "utf8");
+			expect(hasDetectableIndentation(content)).toBe(false);
+			expect(hasFormatterConfig(dir)).toBe(false);
+		}
+	});
+});

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -209,10 +209,18 @@ describe("resolveCommand — .venv", () => {
 		const cmd = await ruffFormatter.resolveCommand!(filePath, tmpDir);
 
 		expect(cmd).not.toBeNull();
-		expect(cmd).not.toContain("--indent-style");
-		expect(cmd).not.toContain("--indent-width");
-		expect(cmd).toContain("indent-width=4");
-		expect(cmd).toContain("format.indent-style='space'");
+		// Exact argv, not containment: containment stayed green when a review
+		// probe appended an invented flag — only strict equality screens CLI
+		// drift against the real ruff interface (#1336 review finding).
+		expect(cmd).toEqual([
+			binPath,
+			"format",
+			"--config",
+			"indent-width=4",
+			"--config",
+			"format.indent-style='space'",
+			filePath,
+		]);
 	});
 
 	it("ruff: pins detected tab indentation via --config", async () => {
@@ -223,7 +231,15 @@ describe("resolveCommand — .venv", () => {
 
 		const cmd = await ruffFormatter.resolveCommand!(filePath, tmpDir);
 
-		expect(cmd).toContain("format.indent-style='tab'");
+		expect(cmd).toEqual([
+			binPath,
+			"format",
+			"--config",
+			"indent-width=1",
+			"--config",
+			"format.indent-style='tab'",
+			filePath,
+		]);
 	});
 
 	it("ruff: skips when indentation is undetectable and no config exists", async () => {

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -196,6 +196,36 @@ describe("resolveCommand — .venv", () => {
 		expect(cmd).toContain(filePath);
 	});
 
+	// `ruff format` rejects --indent-style/--indent-width ("unexpected argument",
+	// exit 2). Because ruff is not strictExitCode, formatFile reported that as a
+	// clean unchanged file — every unconfigured Python file silently went
+	// unformatted. Style must be pinned via inline TOML overrides instead.
+	it("ruff: pins detected indentation via --config, never bare --indent-* flags", async () => {
+		const binPath = venvBin(tmpDir, "ruff");
+		makeFakeExe(binPath);
+		const filePath = fileIn(tmpDir, "main.py");
+		fs.writeFileSync(filePath, "def f():\n    return 1\n");
+
+		const cmd = await ruffFormatter.resolveCommand!(filePath, tmpDir);
+
+		expect(cmd).not.toBeNull();
+		expect(cmd).not.toContain("--indent-style");
+		expect(cmd).not.toContain("--indent-width");
+		expect(cmd).toContain("indent-width=4");
+		expect(cmd).toContain("format.indent-style='space'");
+	});
+
+	it("ruff: pins detected tab indentation via --config", async () => {
+		const binPath = venvBin(tmpDir, "ruff");
+		makeFakeExe(binPath);
+		const filePath = fileIn(tmpDir, "main.py");
+		fs.writeFileSync(filePath, "def f():\n\treturn 1\n");
+
+		const cmd = await ruffFormatter.resolveCommand!(filePath, tmpDir);
+
+		expect(cmd).toContain("format.indent-style='tab'");
+	});
+
 	it("ruff: skips when indentation is undetectable and no config exists", async () => {
 		const binPath = venvBin(tmpDir, "ruff");
 		makeFakeExe(binPath);

--- a/tests/fixtures/format-smoke/css/messy.css
+++ b/tests/fixtures/format-smoke/css/messy.css
@@ -1,1 +1,7 @@
-a{color:red ;margin:0}
+a {
+  color:red ;
+  margin:0
+}
+p {
+  padding : 1px;
+}

--- a/tests/fixtures/format-smoke/html/messy.html
+++ b/tests/fixtures/format-smoke/html/messy.html
@@ -1,1 +1,4 @@
-<html><head><title>x</title></head><body><p>hi</p></body></html>
+<html>
+  <head><title>x</title></head>
+  <body><p>hi</p><p>there</p></body>
+</html>

--- a/tests/fixtures/format-smoke/javascript/messy.js
+++ b/tests/fixtures/format-smoke/javascript/messy.js
@@ -1,2 +1,8 @@
-const   x=1 ;
-console.log(   x )
+const obj = {
+  a:1,
+  b : 2
+};
+function f() {
+  return   obj . a ;
+}
+console.log(   f() )

--- a/tests/fixtures/format-smoke/preserve-unconfigured/messy.js
+++ b/tests/fixtures/format-smoke/preserve-unconfigured/messy.js
@@ -1,0 +1,2 @@
+const   x=1 ;
+console.log(   x )

--- a/tests/fixtures/format-smoke/python/messy.py
+++ b/tests/fixtures/format-smoke/python/messy.py
@@ -1,2 +1,6 @@
-x = {  'a' :1}
-print(  x )
+def f():
+    x = {  'a' :1}
+    return  x
+
+
+print(  f() )

--- a/tests/fixtures/format-smoke/shell/messy.sh
+++ b/tests/fixtures/format-smoke/shell/messy.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+greet() {
+  echo "hello"
+}
 if true; then
-echo "hi"
+greet
 fi

--- a/tests/fixtures/format-smoke/yaml/messy.yaml
+++ b/tests/fixtures/format-smoke/yaml/messy.yaml
@@ -1,5 +1,7 @@
 a:    1
 b:  2
 list:
-- x
-- y
+  - x
+  - y
+nested:
+  key:   value


### PR DESCRIPTION
Root-causes the nightly **Tool smoke** failure ([run 31677169685](https://github.com/apmantza/pi-lens/actions/runs/31677169685)), where six formatter rows reported `ran clean but left the mis-formatted file unchanged`: `javascript/biome`, `python/ruff`, `shell/shfmt`, `css/biome`, `html/prettier`, `yaml/prettier`.

Two distinct defects, one production and one harness.

## Production — `ruff format` never ran

`ruff format` has **no** `--indent-style`/`--indent-width` flags. Passing them errors out:

```
$ ruff format --indent-style space --indent-width 4 t.py
error: unexpected argument '--indent-style' found
  tip: a similar argument exists: '--line-length'
```

`indentationArgs` (`clients/formatters.ts:405`) fed those flags to ruff along with biome. Because `ruffFormatter` was not `strictExitCode`, `formatFile` (`clients/formatters.ts:1186`) ignored the exit-2, read the untouched file back, and returned `{ success: true, changed: false }` — indistinguishable from "already formatted". **Every unconfigured Python file has silently gone unformatted since #1294 landed.**

Fix: pin style through ruff's inline TOML overrides, which are verified to work —

```
ruff format --config "indent-width=4" --config "format.indent-style='space'" t.py
```

and mark ruff `strictExitCode: true` so an argument rejection is loud rather than a silent clean no-op (same rationale already documented on `terragrunt-hcl`).

## Harness — fixtures could not satisfy the #1144 contract

#1144 made biome/prettier/ruff/shfmt **style-preserving**: with no formatter config in the workspace *and* no indented line to infer a style from, `resolveCommand` returns `SKIP_FORMATTING` rather than impose the tool's stock style (`clients/formatters.ts:399`).

Every `--format` fixture for those four was a flat one-or-two-line snippet with zero indented lines, e.g.

```js
const   x=1 ;
console.log(   x )
```

so the refusal fired **legitimately** and the harness read it as a failure. The six fixtures now carry an indentation convention alongside the non-indentation mess — which also makes them exercise the real spawn path, the path that had been masking the ruff bug above.

## Adjacent-surface + class sweep

- The four style-pinning formatters (biome/prettier/ruff/shfmt) are the entire at-risk set — no other `resolveCommand` in `formatters.ts` synthesizes style flags.
- `markdown`/`json` already ship a `.prettierrc`, so they were never gated; they stay as the proof that a *configured* path rewrites.
- biome (`--indent-style space --indent-width 2`), prettier (`--no-use-tabs --tab-width N`) and shfmt (`-i N`) args verified against the real binaries — ruff was the only invented CLI.
- New `preserve-unconfigured` fixture (`expect: "preserve"`) pins the #1144 refusal itself, so the contract cannot regress in the *other* direction.
- New `tests/clients/dispatch/format-smoke-style-contract.test.ts` screens the **whole** format-smoke matrix — any style-pinning `reformat` fixture must ship a config or contain an indented line — instead of waiting for the next six rows to fire in a nightly.

## Verification

Local smoke driver, all nine green (previously six failing):

```
✓  javascript   biome        biome reformatted the file
✓  python       ruff         ruff reformatted the file
✓  shell        shfmt        shfmt reformatted the file
✓  css          biome        biome reformatted the file
✓  html         prettier     prettier reformatted the file
✓  yaml         prettier     prettier reformatted the file
✓  markdown     prettier     prettier reformatted the file
✓  json         prettier     prettier reformatted the file
✓  preserve-unconfigured biome  biome preserved the unconfigured file

9 passed · 0 failed
```

Mutation-verified: reverting the ruff branch makes both new unit tests fail **and** turns the live `python/ruff` smoke row red with the exact nightly signature; reverting the javascript fixture makes the new drift guard fail with the diagnostic that explains why.

Full suite: 6037 passed. The handful of red files (`jscpd-client`, `dependency-checker-madge-*`, `review-graph/shared-extraction-ir`, timing-sensitive occupancy) reproduce identically on pristine `origin/master` in this environment — they are managed-tool-path/timing tests perturbed by the local `--install` smoke run, not regressions from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
