### PR TITLE
fix: route in-pi extension logging through ndjson sinks — no raw console writes (closes #1333)

### DIFF
--- a/.changelog/fix-1333-console-tui-migration.md
+++ b/.changelog/fix-1333-console-tui-migration.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **In-pi extension logging no longer corrupts the pi TUI layout (closes #1333)** — pi owns the terminal, so the 26 ungated and 20 verbose-gated `console.error`/`console.warn` sites under `clients/` were landing raw bytes mid-frame and desyncing pi's screen model. Every site now writes to a `createNdjsonLogger` sink (the subsystem's own `tree-sitter.log`/`review-graph.log`/`latency.log` where one exists, otherwise the new `~/.pi-lens/extension.log`), user-facing degradations (invalid config, offline grammar fetch, WASM abort) additionally surface through `ctx.ui.notify`, and `index.ts` installs a defensive console reroute so a transitively loaded dependency cannot write to the frame either.

--- a/clients/ast-grep-client.ts
+++ b/clients/ast-grep-client.ts
@@ -8,6 +8,7 @@
  * Rules: ./rules/ directory
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -174,7 +175,7 @@ export class AstGrepClient {
 				? projectRuleDir
 				: resolvePackagePath(import.meta.url, "rules"));
 		this.log = verbose
-			? (msg: string) => console.error(`[ast-grep] ${msg}`)
+			? createSubsystemLogger("ast-grep")
 			: () => {};
 		this.ruleManager = new AstGrepRuleManager(this.ruleDir, this.log);
 		this.runner = new SgRunner(verbose);

--- a/clients/biome-client.ts
+++ b/clients/biome-client.ts
@@ -8,6 +8,7 @@
  * Docs: https://biomejs.dev/
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { isFileKind } from "./file-kinds.js";
@@ -49,7 +50,7 @@ export class BiomeClient {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[biome] ${msg}`)
+			? createSubsystemLogger("biome")
 			: () => {};
 	}
 

--- a/clients/bootstrap.ts
+++ b/clients/bootstrap.ts
@@ -1,3 +1,4 @@
+import { logExtension } from "./extension-log.js";
 import type { AgentBehaviorClient } from "./agent-behavior-client.js";
 import type { BiomeClient } from "./biome-client.js";
 import type { ComplexityClient } from "./complexity-client.js";
@@ -69,19 +70,26 @@ async function logBootstrapFailures(
 	failures: { name: string; err: unknown }[],
 ): Promise<void> {
 	for (const { name, err } of failures) {
-		console.error(
-			`[pi-lens] analyzer "${name}" disabled (degraded mode): ${
+		logExtension({
+			subsystem: "bootstrap",
+			message: `analyzer "${name}" disabled (degraded mode): ${
 				(err as Error)?.message ?? String(err)
 			}`,
-		);
+			metadata: { analyzer: name },
+		});
 	}
 	try {
 		const { collectInstallDiagnostics, formatInstallDiagnostics } = await import(
 			"./install-diagnostics.js"
 		);
-		console.error(
-			formatInstallDiagnostics(collectInstallDiagnostics(), failures[0]?.err),
-		);
+		logExtension({
+			subsystem: "bootstrap",
+			message: formatInstallDiagnostics(
+				collectInstallDiagnostics(),
+				failures[0]?.err,
+			),
+			metadata: { kind: "install_diagnostics" },
+		});
 	} catch {
 		// the per-analyzer lines above already named the failures
 	}

--- a/clients/cache-manager.ts
+++ b/clients/cache-manager.ts
@@ -9,6 +9,7 @@
  * All paths are relative to project root (process.cwd()).
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getProjectDataDir } from "./file-utils.js";
@@ -103,7 +104,7 @@ export class CacheManager {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[cache] ${msg}`)
+			? createSubsystemLogger("cache")
 			: () => {};
 	}
 

--- a/clients/complexity-client.ts
+++ b/clients/complexity-client.ts
@@ -11,6 +11,7 @@
  * indicators. These are silent metrics surfaced in the session summary.
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import {
@@ -471,7 +472,7 @@ export class ComplexityClient {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[complexity] ${msg}`)
+			? createSubsystemLogger("complexity")
 			: () => {};
 	}
 

--- a/clients/console-guard-install.ts
+++ b/clients/console-guard-install.ts
@@ -1,0 +1,11 @@
+// #1333: install the console guard as an import side-effect so it runs before
+// any other module's initialization code. Installing inside the extension
+// factory is too late — by the time the factory runs, every static/transitive
+// import has already evaluated, so a dependency writing to console during
+// module init would still hit the TUI raw (#1338 review finding). This module
+// MUST remain the first import of index.ts; the enforcement test pins that.
+// installConsoleGuard() itself is idempotent and no-ops under test mode and
+// PI_LENS_CONSOLE_GUARD=0.
+import { installConsoleGuard } from "./extension-log.js";
+
+installConsoleGuard();

--- a/clients/dead-code-client.ts
+++ b/clients/dead-code-client.ts
@@ -12,6 +12,7 @@
  * implementing DeadCodeClient and adding to getDeadCodeClients().
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as path from "node:path";
 import { findNearestMarkerRoot } from "./path-utils.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
@@ -144,7 +145,7 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[dead-code:python] ${msg}`)
+			? createSubsystemLogger("dead-code:python")
 			: () => {};
 	}
 

--- a/clients/dependency-checker.ts
+++ b/clients/dependency-checker.ts
@@ -9,6 +9,7 @@
  * Docs: https://github.com/pahen/madge
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { findNodeToolBinary } from "./package-manager.js";
@@ -308,7 +309,7 @@ export class DependencyChecker {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[deps] ${msg}`)
+			? createSubsystemLogger("deps")
 			: () => {};
 		DependencyChecker.instances.add(new WeakRef(this));
 	}

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -14,6 +14,7 @@
  * - BaselineStore: Track pre-existing issues for delta mode
  */
 
+import { logExtension } from "../extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { FileKind } from "../file-kinds.js";
@@ -196,7 +197,13 @@ export function createDispatchContext(
 		},
 
 		log(message: string): void {
-			console.error(`[dispatch] ${message}`);
+			// #1333: pi owns the terminal — a runner advisory must never be a raw
+			// write. Every DispatchContext.log line lands in extension.log instead.
+			logExtension({
+				subsystem: "dispatch",
+				message,
+				metadata: { filePath: normalizedFilePath, kind },
+			});
 		},
 	};
 }

--- a/clients/dispatch/runners/lsp.ts
+++ b/clients/dispatch/runners/lsp.ts
@@ -12,6 +12,7 @@
  * unified runner that delegates to the LSP service.
  */
 
+import { logExtension } from "../../extension-log.js";
 import { getLSPService } from "../../lsp/index.js";
 import { RUNTIME_CONFIG } from "../../runtime-config.js";
 import { PRIORITY } from "../priorities.js";
@@ -199,9 +200,11 @@ const lspRunner: RunnerDefinition = {
 				failureReason.includes("connection") ||
 				failureReason.includes("JSON RPC")
 			) {
-				console.error(
-					`[lsp-runner] LSP server failed for ${diagnosticPath}: ${failureReason}`,
-				);
+				logExtension({
+					subsystem: "lsp-runner",
+					message: `LSP server failed for ${diagnosticPath}: ${failureReason}`,
+					metadata: { filePath: diagnosticPath },
+				});
 			}
 		}
 

--- a/clients/dispatch/runners/pyright.ts
+++ b/clients/dispatch/runners/pyright.ts
@@ -7,6 +7,7 @@
  * Requires: pyright (pip install pyright or npm install -g pyright)
  */
 
+import { logExtension } from "../../extension-log.js";
 import { getLSPService } from "../../lsp/index.js";
 import { safeSpawnAsync } from "../../safe-spawn.js";
 import { PRIORITY } from "../priorities.js";
@@ -111,9 +112,11 @@ const pyrightRunner: RunnerDefinition = {
 			};
 		// pi-lens-ignore: missing-error-propagation
 		} catch {
-			console.error(
-				`[runner:pyright] JSON parse failed for ${ctx.filePath} — raw output: ${output.slice(0, 200)}`,
-			);
+			logExtension({
+				subsystem: "runner:pyright",
+				message: `JSON parse failed for ${ctx.filePath} — raw output: ${output.slice(0, 200)}`,
+				metadata: { filePath: ctx.filePath },
+			});
 			return {
 				status: "failed",
 				diagnostics: [],

--- a/clients/dispatch/runners/tree-sitter.ts
+++ b/clients/dispatch/runners/tree-sitter.ts
@@ -643,7 +643,9 @@ const treeSitterRunner: RunnerDefinition = {
 					metadata: { queryIds: effectiveQueries.map((q) => q.id) },
 				});
 			} else {
-				console.error("[tree-sitter] Batched query run failed:", err);
+				// #1333: the logTreeSitter call below already carries this failure to
+				// tree-sitter.log — the console.error was a duplicate RAW write into
+				// pi's frame, not a second destination. Sink kept, write dropped.
 				logTreeSitter({
 					phase: "query_error",
 					filePath,

--- a/clients/event-loop-monitor.ts
+++ b/clients/event-loop-monitor.ts
@@ -40,6 +40,7 @@
  * letting them poison the "worst real block" high-water.
  */
 
+import { logExtension } from "./extension-log.js";
 import { monitorEventLoopDelay, type IntervalHistogram } from "node:perf_hooks";
 
 const NS_PER_MS = 1e6;
@@ -79,11 +80,12 @@ export function startEventLoopMonitor(resolutionMs = 20): void {
 		windowStartCpuMs = cpuTotalMs();
 	} catch (err) {
 		monitorUnavailable = true;
-		console.error(
-			`[pi-lens] event-loop occupancy telemetry disabled (runtime lacks monitorEventLoopDelay): ${
+		logExtension({
+			subsystem: "event-loop-monitor",
+			message: `event-loop occupancy telemetry disabled (runtime lacks monitorEventLoopDelay): ${
 				(err as Error)?.message ?? String(err)
 			}`,
-		);
+		});
 	}
 }
 

--- a/clients/extension-log.ts
+++ b/clients/extension-log.ts
@@ -1,0 +1,190 @@
+/**
+ * Terminal-safe diagnostic sink for the in-pi extension path (#1333).
+ *
+ * pi owns the terminal: it runs the TTY in raw mode and repaints with
+ * cursor-addressed diffs, so ANY byte an extension writes to stdout/stderr
+ * lands mid-frame and desyncs pi's model of the screen — the layout stays
+ * broken until a full repaint. `clients/`, `tools/`, `index.ts` and `i18n.ts`
+ * are all reachable from the extension entry, so none of them may call
+ * `console.*` or `process.std*.write`. (`mcp/`, `scripts/` and `bin/` DO own
+ * their stdout contract and keep their writes.)
+ *
+ * This module is the general-purpose replacement sink: one `createNdjsonLogger`
+ * instance over `<global pi-lens dir>/extension.log`, per the single-writer
+ * invariant in AGENTS.md. Subsystems that already own a log (tree-sitter,
+ * review-graph, cascade, latency, sessionstart) route to THAT log instead —
+ * this file is for the areas that had no sink at all.
+ *
+ * Three-channels rule (#482/#484/#485): everything written here is
+ * LOG-audience. A genuinely user-facing degradation must ALSO reach the human
+ * through the host's own render path (`ctx.ui.notify` / a display-only session
+ * entry) — never a raw write.
+ */
+
+import * as path from "node:path";
+import { isTestMode } from "./env-utils.js";
+import { getGlobalPiLensDir } from "./file-utils.js";
+import { getMaxLogSizeMB } from "./log-cleanup.js";
+import { createNdjsonLogger } from "./ndjson-logger.js";
+
+export const EXTENSION_LOG_FILE = path.join(
+	getGlobalPiLensDir(),
+	"extension.log",
+);
+
+const writer = createNdjsonLogger({
+	filePath: EXTENSION_LOG_FILE,
+	maxBytes: getMaxLogSizeMB() * 1024 * 1024,
+});
+
+/**
+ * `error`/`warn` mirror the console methods they replaced; `debug` is the level
+ * the previously verbose-gated client loggers write at (the gate is preserved
+ * at the call site — see `createSubsystemLogger`).
+ */
+export type ExtensionLogLevel = "error" | "warn" | "debug";
+
+export interface ExtensionLogEntry {
+	/** Owning area, e.g. `dispatch`, `format`, `lens-config`. */
+	subsystem: string;
+	message: string;
+	/** Defaults to `error` (the level every migrated ungated site wrote at). */
+	level?: ExtensionLogLevel;
+	metadata?: Record<string, unknown>;
+}
+
+export function logExtension(entry: ExtensionLogEntry): void {
+	if (isTestMode()) return;
+	writer.log({
+		ts: new Date().toISOString(),
+		pid: process.pid,
+		level: entry.level ?? "error",
+		subsystem: entry.subsystem,
+		message: entry.message,
+		...(entry.metadata ? { metadata: entry.metadata } : {}),
+	});
+}
+
+/**
+ * Drop-in replacement for the `verbose ? (msg) => console.error(...) : () => {}`
+ * shape that ~20 clients hand-rolled. The returned value is CALLABLE (so the
+ * `this.log = createSubsystemLogger("ruff")` migration is a one-line swap) and
+ * also carries explicit `error`/`warn`/`debug` methods.
+ *
+ * Gating stays at the call site: `verbose ? createSubsystemLogger(x) : noop`
+ * keeps the exact same "written only when verbose" semantics — what changed is
+ * the SINK, not the gate, so turning verbose on can never corrupt the frame.
+ */
+export interface SubsystemLogger {
+	(message: string, metadata?: Record<string, unknown>): void;
+	error(message: string, metadata?: Record<string, unknown>): void;
+	warn(message: string, metadata?: Record<string, unknown>): void;
+	debug(message: string, metadata?: Record<string, unknown>): void;
+}
+
+export function createSubsystemLogger(
+	subsystem: string,
+	defaultLevel: ExtensionLogLevel = "debug",
+): SubsystemLogger {
+	const at =
+		(level: ExtensionLogLevel) =>
+		(message: string, metadata?: Record<string, unknown>): void => {
+			logExtension({ subsystem, message, level, metadata });
+		};
+	const logger = at(defaultLevel) as SubsystemLogger;
+	logger.error = at("error");
+	logger.warn = at("warn");
+	logger.debug = at("debug");
+	return logger;
+}
+
+/** No-op with the `SubsystemLogger` shape, for the verbose-off branch. */
+export function noopSubsystemLogger(): SubsystemLogger {
+	const noop = (() => {}) as unknown as SubsystemLogger;
+	noop.error = () => {};
+	noop.warn = () => {};
+	noop.debug = () => {};
+	return noop;
+}
+
+export function getExtensionLogPath(): string {
+	return EXTENSION_LOG_FILE;
+}
+
+/** Resolve once all enqueued extension-log writes are on disk (tests/shutdown). */
+export function flushExtensionLog(): Promise<void> {
+	return writer.flush();
+}
+
+/** Teardown-only: force queued entries to disk before the process exits. */
+export function flushExtensionLogSync(): void {
+	writer.flushSync();
+}
+
+// --- Defense in depth: the console reroute -----------------------------------
+
+const CONSOLE_METHODS = [
+	"log",
+	"info",
+	"warn",
+	"error",
+	"debug",
+	"trace",
+	"dir",
+] as const;
+
+type ConsoleMethod = (typeof CONSOLE_METHODS)[number];
+
+let consoleGuardInstalled = false;
+
+function formatConsoleArgs(args: unknown[]): string {
+	return args
+		.map((arg) => {
+			if (typeof arg === "string") return arg;
+			if (arg instanceof Error) return arg.stack ?? arg.message;
+			try {
+				return JSON.stringify(arg) ?? String(arg);
+			} catch {
+				return String(arg);
+			}
+		})
+		.join(" ");
+}
+
+/**
+ * Patch every console method on the extension entry path so a transitively
+ * loaded dependency cannot write raw bytes into pi's frame — the pi-side
+ * mirror of `mcp/server.ts`'s `console.log = console.error` guard, which
+ * protects the JSON-RPC stdout channel for the same structural reason.
+ *
+ * This is a NET, not the fix: pi-lens's own sites are migrated to real sinks
+ * with real schemas. Idempotent, and inert under test mode (vitest owns the
+ * console) and under `PI_LENS_CONSOLE_GUARD=0`.
+ *
+ * Returns true when the patch was applied by this call.
+ */
+export function installConsoleGuard(): boolean {
+	if (consoleGuardInstalled) return false;
+	if (isTestMode()) return false;
+	if (process.env.PI_LENS_CONSOLE_GUARD === "0") return false;
+	consoleGuardInstalled = true;
+	const target = console as unknown as Record<ConsoleMethod, unknown>;
+	for (const method of CONSOLE_METHODS) {
+		if (typeof target[method] !== "function") continue;
+		target[method] = (...args: unknown[]): void => {
+			logExtension({
+				subsystem: "console",
+				level:
+					method === "warn" ? "warn" : method === "error" ? "error" : "debug",
+				message: formatConsoleArgs(args),
+				metadata: { method },
+			});
+		};
+	}
+	return true;
+}
+
+/** Test-only: forget that the guard was installed. */
+export function _resetConsoleGuardForTests(): void {
+	consoleGuardInstalled = false;
+}

--- a/clients/format-service.ts
+++ b/clients/format-service.ts
@@ -11,6 +11,7 @@
  * - Explicit config wins; otherwise smart defaults apply
  */
 
+import { logExtension } from "./extension-log.js";
 import * as path from "node:path";
 import { recordFormatter } from "./widget-state.js";
 import { FileTime } from "./file-time.js";
@@ -81,9 +82,12 @@ export class FormatService {
 
 		// Check if file was modified externally (safety check)
 		if (this.fileTime.hasChanged(absolutePath)) {
-			console.warn(
-				`[format] File ${absolutePath} modified externally, skipping format`,
-			);
+			logExtension({
+				subsystem: "format",
+				level: "warn",
+				message: `File ${absolutePath} modified externally, skipping format`,
+				metadata: { filePath: absolutePath },
+			});
 			return {
 				filePath: absolutePath,
 				formatters: [],

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -9,6 +9,7 @@
  * Inspired by OpenCode's formatter.ts pattern
  */
 
+import { logExtension } from "./extension-log.js";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { TERRAGRUNT_FILENAMES } from "./file-kinds.js";
@@ -65,9 +66,11 @@ export async function tryLazyInstallFormatterTool(
 		});
 		const ok = !res.error && res.status === 0;
 		if (!ok) {
-			console.error(
-				`[format] lazy-install rubocop failed: ${res.error?.message ?? res.stderr ?? "exit " + res.status}`,
-			);
+			logExtension({
+				subsystem: "format",
+				message: `lazy-install rubocop failed: ${res.error?.message ?? res.stderr ?? "exit " + res.status}`,
+				metadata: { tool: "rubocop", cwd },
+			});
 		}
 		return ok;
 	}
@@ -79,9 +82,11 @@ export async function tryLazyInstallFormatterTool(
 	});
 	const ok = !res.error && res.status === 0;
 	if (!ok) {
-		console.error(
-			`[format] lazy-install rustfmt failed: ${res.error?.message ?? res.stderr ?? "exit " + res.status}`,
-		);
+		logExtension({
+			subsystem: "format",
+			message: `lazy-install rustfmt failed: ${res.error?.message ?? res.stderr ?? "exit " + res.status}`,
+			metadata: { tool: "rustfmt", cwd },
+		});
 	}
 	return ok;
 }
@@ -1109,7 +1114,13 @@ export async function getFormattersForFile(
 				}
 			} catch (err) {
 				// pi-lens-ignore: missing-error-propagation — optional formatter detection, skip on failure
-				console.error(`[format] Detection failed for ${formatter.name}:`, err);
+				logExtension({
+					subsystem: "format",
+					message: `Detection failed for ${formatter.name}: ${
+						err instanceof Error ? err.message : String(err)
+					}`,
+					metadata: { formatter: formatter.name, cwd },
+				});
 			}
 		}
 	}

--- a/clients/go-client.ts
+++ b/clients/go-client.ts
@@ -7,6 +7,7 @@
  * Docs: https://pkg.go.dev/golang.org/x/tools/gopls
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { safeSpawnAsync } from "./safe-spawn.js";
@@ -47,7 +48,7 @@ export class GoClient {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[go] ${msg}`)
+			? createSubsystemLogger("go")
 			: () => {};
 	}
 

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -46,6 +46,7 @@
  * - GitHub releases (platform-specific binaries → ~/.pi-lens/bin/)
  */
 
+import { logExtension } from "../extension-log.js";
 import { spawn } from "node:child_process";
 import { existsSync, statSync, unlinkSync } from "node:fs";
 import fs from "node:fs/promises";
@@ -218,7 +219,14 @@ function installerPlatform(): NodeJS.Platform {
  */
 function debugLog(...args: unknown[]): void {
 	if (DEBUG) {
-		console.error("[auto-install:debug]", ...args);
+		// #1333: DEBUG gate preserved; sink is extension.log, never the TUI.
+		logExtension({
+			subsystem: "auto-install",
+			level: "debug",
+			message: args
+				.map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
+				.join(" "),
+		});
 	}
 }
 

--- a/clients/jscpd-client.ts
+++ b/clients/jscpd-client.ts
@@ -8,6 +8,7 @@
  * Docs: https://github.com/kucherenko/jscpd
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import { mkdtempSync } from "node:fs";
 import * as os from "node:os";
@@ -80,7 +81,7 @@ export class JscpdClient {
 	private log: (msg: string) => void;
 
 	constructor(verbose = false) {
-		this.log = verbose ? (msg) => console.error(`[jscpd] ${msg}`) : () => {};
+		this.log = verbose ? createSubsystemLogger("jscpd") : () => {};
 	}
 
 	/**

--- a/clients/knip-client.ts
+++ b/clients/knip-client.ts
@@ -9,6 +9,7 @@
  * Docs: https://knip.dev/
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getProjectDataDir } from "./file-utils.js";
@@ -128,7 +129,7 @@ export class KnipClient {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[knip] ${msg}`)
+			? createSubsystemLogger("knip")
 			: () => {};
 	}
 

--- a/clients/lens-config.ts
+++ b/clients/lens-config.ts
@@ -1,3 +1,5 @@
+import { logExtension } from "./extension-log.js";
+import { notifyUserDegradation } from "./user-notify.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -125,9 +127,16 @@ function warnInvalidGlobalConfigOnce(configPath: string, reason: string): void {
 	const key = `${configPath}:${reason}`;
 	if (warnedInvalidGlobalConfigs.has(key)) return;
 	warnedInvalidGlobalConfigs.add(key);
-	console.error(
-		`[pi-lens] ignoring invalid global config ${configPath}: ${reason}`,
-	);
+	const message = `ignoring invalid global config ${configPath}: ${reason}`;
+	logExtension({
+		subsystem: "lens-config",
+		level: "warn",
+		message,
+		metadata: { configPath, reason },
+	});
+	// HUMAN-audience too: a config the user wrote is being ignored. Routed
+	// through the host's own render path (#1333), never a raw write.
+	notifyUserDegradation(`pi-lens: ${message}`);
 }
 
 /** For tests that need to force the warn-once cache to reset between cases. */

--- a/clients/lens-events.ts
+++ b/clients/lens-events.ts
@@ -1,3 +1,4 @@
+import { logExtension } from "./extension-log.js";
 import type { Diagnostic } from "./dispatch/types.js";
 
 export const LENS_EVENT_VERSION = 1;
@@ -102,9 +103,12 @@ function emitLensEvent(eventName: LensEventName, payload: unknown): void {
 			if (!emit) {
 				if (!_droppedEmitLogged) {
 					_droppedEmitLogged = true;
-					console.error(
-						`[pi-lens] lens event dropped (no live bus): ${eventName} — further drops logged once per process`,
-					);
+					logExtension({
+						subsystem: "lens-events",
+						level: "warn",
+						message: `lens event dropped (no live bus): ${eventName} — further drops logged once per process`,
+						metadata: { eventName },
+					});
 				}
 				return;
 			}

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -8,6 +8,7 @@
  * - Request/response handling
  */
 
+import { logExtension } from "../extension-log.js";
 import { spawn as nodeSpawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { access, readFile } from "node:fs/promises";
@@ -1186,9 +1187,12 @@ export function setupIncomingHandlers(
 			const newDiags = normalizeLspDiagnostics(params.diagnostics || []);
 			const docVersion = params.version;
 			if (PUB_DEBUG) {
-				console.error(
-					`[lsp-pub] server=${state.serverId} pubVersion=${docVersion} docVersion=${state.documentVersions?.get(normalizedPath)} diags=${newDiags.length}`,
-				);
+				// #1333: PUB_DEBUG gate preserved; sink is extension.log.
+				logExtension({
+					subsystem: "lsp-pub",
+					level: "debug",
+					message: `server=${state.serverId} pubVersion=${docVersion} docVersion=${state.documentVersions?.get(normalizedPath)} diags=${newDiags.length}`,
+				});
 			}
 			const strategy = getStrategy(state.serverId);
 			// Record the document version these diagnostics were computed against

--- a/clients/lsp/config.ts
+++ b/clients/lsp/config.ts
@@ -47,6 +47,8 @@
  * clients/lsp/server.ts (e.g. "rust", "nix", "bash", "python", "go", "ts").
  */
 
+import { logExtension } from "../extension-log.js";
+import { notifyUserDegradation } from "../user-notify.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { getGlobalPiLensDir } from "../file-utils.js";
@@ -106,7 +108,15 @@ const CONFIG_PATHS = [".pi-lens/lsp.json", ".pi-lens.json", "pi-lsp.json"];
 
 function warnInvalidLSPConfig(configPath: string, error: unknown): void {
 	const reason = error instanceof Error ? error.message : String(error);
-	console.error(`[pi-lens] ignoring invalid LSP config ${configPath}: ${reason}`);
+	const message = `ignoring invalid LSP config ${configPath}: ${reason}`;
+	logExtension({
+		subsystem: "lsp-config",
+		level: "warn",
+		message,
+		metadata: { configPath, reason },
+	});
+	// HUMAN-audience too: the user's own lsp.json is being ignored (#1333).
+	notifyUserDegradation(`pi-lens: ${message}`);
 }
 
 async function readLSPConfig(configPath: string): Promise<LSPConfig | undefined> {

--- a/clients/metrics-client.ts
+++ b/clients/metrics-client.ts
@@ -11,6 +11,7 @@
  * they don't gate or interrupt the agent mid-task.
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -39,7 +40,7 @@ export class MetricsClient {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[metrics] ${msg}`)
+			? createSubsystemLogger("metrics")
 			: () => {};
 	}
 

--- a/clients/project-lens-config.ts
+++ b/clients/project-lens-config.ts
@@ -57,6 +57,8 @@
  * patterns apply to files inside that package, in addition to (and with
  * higher precedence than) the root config's `ignore` patterns.
  */
+import { logExtension } from "./extension-log.js";
+import { notifyUserDegradation } from "./user-notify.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -386,9 +388,15 @@ function warnInvalidConfigOnce(configPath: string, reason: string): void {
 	const key = `${configPath}:${reason}`;
 	if (warnedInvalidConfigs.has(key)) return;
 	warnedInvalidConfigs.add(key);
-	console.error(
-		`[pi-lens] ignoring invalid project config ${configPath}: ${reason}`,
-	);
+	const message = `ignoring invalid project config ${configPath}: ${reason}`;
+	logExtension({
+		subsystem: "project-lens-config",
+		level: "warn",
+		message,
+		metadata: { configPath, reason },
+	});
+	// HUMAN-audience too: the user's own `.pi-lens.json` is being ignored.
+	notifyUserDegradation(`pi-lens: ${message}`);
 }
 
 function parseRulePolicyList(

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -490,7 +490,8 @@ function recordSnapshotPersistFailure(cwd: string, error: string): void {
 		durationMs: 0,
 		metadata: { error },
 	});
-	console.error("[project-snapshot] body persist failed:", error);
+	// #1333: the logLatency call above already carries this failure to
+	// latency.log — the console.error was a duplicate RAW write into pi's frame.
 }
 
 function logSnapshotPersistSuccess(

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -1595,7 +1595,9 @@ function writePendingOnMainThread(
 			pending,
 			workerState,
 		);
-		console.error("[review-graph] cache persist failed:", message);
+		// #1333: recordPersistFailure already emits `phase: "persist_failed"` to
+		// review-graph.log with this same message — the console.error was a
+		// duplicate RAW write into pi's frame, not a second destination.
 	}
 }
 
@@ -2922,11 +2924,12 @@ async function ensureReviewGraphFacts(
 		await functionFactProvider.run(ctx, facts);
 		// pi-lens-ignore: missing-error-propagation
 	} catch (err) {
-		console.error(
-			`[pi-lens] review-graph structural facts disabled (degraded mode): ${
-				(err as Error)?.message ?? String(err)
-			}`,
-		);
+		logReviewGraph({
+			cwd,
+			phase: "build_skipped",
+			reason: "structural_facts_disabled",
+			error: (err as Error)?.message ?? String(err),
+		});
 	}
 }
 

--- a/clients/ruff-client.ts
+++ b/clients/ruff-client.ts
@@ -8,6 +8,7 @@
  * Docs: https://docs.astral.sh/ruff/
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { createAvailabilityChecker, resolveAvailableOrInstall } from "./dispatch/runners/utils/runner-helpers.js";
@@ -49,7 +50,7 @@ export class RuffClient {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[ruff] ${msg}`)
+			? createSubsystemLogger("ruff")
 			: () => {};
 	}
 

--- a/clients/rust-client.ts
+++ b/clients/rust-client.ts
@@ -7,6 +7,7 @@
  * Docs: https://doc.rust-lang.org/cargo/
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { safeSpawnAsync } from "./safe-spawn.js";
@@ -48,7 +49,7 @@ export class RustClient {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[rust] ${msg}`)
+			? createSubsystemLogger("rust")
 			: () => {};
 	}
 

--- a/clients/security-scan-client.ts
+++ b/clients/security-scan-client.ts
@@ -13,6 +13,7 @@
  * Refs: #130, #131, #132
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
 
 export abstract class SecurityScanClient<TResult> {
@@ -31,7 +32,7 @@ export abstract class SecurityScanClient<TResult> {
 		verbose = false,
 	) {
 		this.log = verbose
-			? (msg: string) => console.error(`[${toolName}] ${msg}`)
+			? createSubsystemLogger(toolName)
 			: () => {};
 	}
 

--- a/clients/sg-runner.ts
+++ b/clients/sg-runner.ts
@@ -5,6 +5,7 @@
  * Handles: spawn, spawnSync, temp dir management, JSON parsing.
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -175,7 +176,7 @@ export class SgRunner {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[sg-runner] ${msg}`)
+			? createSubsystemLogger("sg-runner")
 			: () => {};
 	}
 

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -11,6 +11,7 @@
  * specific file being edited, not the entire suite.
  */
 
+import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { minimatch } from "./deps/minimatch.js";
@@ -256,7 +257,7 @@ export class TestRunnerClient {
 
 	constructor(verbose = false) {
 		this.log = verbose
-			? (msg: string) => console.error(`[test-runner] ${msg}`)
+			? createSubsystemLogger("test-runner")
 			: () => {};
 	}
 

--- a/clients/tree-sitter-cache.ts
+++ b/clients/tree-sitter-cache.ts
@@ -12,6 +12,7 @@
  * oldest insertion, and hot per-edit files survive scan traffic (#890).
  */
 
+import { logTreeSitterDiagnostic } from "./tree-sitter-logger.js";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import { normalizeFilePath } from "./path-utils.js";
@@ -98,7 +99,12 @@ export class TreeCache {
 		this.counterObserver = counterObserver;
 		this.treeErrorObserver = treeErrorObserver;
 		this.debug = debug
-			? (msg: string) => console.error(`[tree-cache] ${msg}`)
+			? (msg: string) =>
+					logTreeSitterDiagnostic({
+						subsystem: "tree-cache",
+						level: "debug",
+						message: msg,
+					})
 			: () => {};
 	}
 

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -15,6 +15,8 @@
  *   "function $NAME($$$PARAMS) { $BODY }" matches function declarations
  */
 
+import { logTreeSitterDiagnostic } from "./tree-sitter-logger.js";
+import { notifyUserDegradation } from "./user-notify.js";
 import { AsyncLocalStorage } from "node:async_hooks";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
@@ -297,7 +299,13 @@ export class TreeSitterClient {
 	/** Debug logging helper */
 	private dbg(msg: string): void {
 		if (this.verbose) {
-			console.error(`[tree-sitter] ${msg}`); // pi-lens-ignore: console-statement — intentional verbose logger
+			// #1333: verbose gating is preserved, but the SINK is tree-sitter.log —
+			// a raw write would corrupt pi's frame the moment verbose is enabled.
+			logTreeSitterDiagnostic({
+				subsystem: "tree-sitter-client",
+				level: "debug",
+				message: msg,
+			});
 		}
 	}
 
@@ -472,20 +480,31 @@ export class TreeSitterClient {
 			const ok = await downloadGrammar(dir, grammarFile);
 			if (ok) {
 				if (!this.grammarsDir) this.grammarsDir = dir;
-				console.error(
-					`[pi-lens] fetched missing tree-sitter grammar ${grammarFile} at runtime (install scripts were skipped by the package manager)`,
-				);
+				logTreeSitterDiagnostic({
+					subsystem: "tree-sitter-client",
+					level: "warn",
+					message: `fetched missing tree-sitter grammar ${grammarFile} at runtime (install scripts were skipped by the package manager)`,
+					metadata: { grammarFile, outcome: "fetched" },
+				});
 			} else {
 				// Surface the degradation once per grammar (the promise cache dedupes)
 				// instead of failing silently — otherwise pnpm/bun users offline get
 				// no signal that a language's tree-sitter features are unavailable.
-				console.error(
-					`[pi-lens] tree-sitter grammar '${grammarFile}' is unavailable — ` +
-						`symbol search, module reports and structural rules for this language will be degraded. ` +
-						`The package manager skipped install scripts and the runtime download failed (offline or CDN unreachable). ` +
-						`Fix: reinstall with a manager that runs postinstall, allow its build scripts ` +
-						`(pnpm approve-builds / bun trustedDependencies), or restore network access.`,
-				);
+				const unavailable =
+					`tree-sitter grammar '${grammarFile}' is unavailable — ` +
+					`symbol search, module reports and structural rules for this language will be degraded. ` +
+					`The package manager skipped install scripts and the runtime download failed (offline or CDN unreachable). ` +
+					`Fix: reinstall with a manager that runs postinstall, allow its build scripts ` +
+					`(pnpm approve-builds / bun trustedDependencies), or restore network access.`;
+				logTreeSitterDiagnostic({
+					subsystem: "tree-sitter-client",
+					message: unavailable,
+					metadata: { grammarFile, outcome: "unavailable" },
+				});
+				// HUMAN-audience: an offline grammar fetch silently degrades this
+				// language's features, so it reaches the user through the HOST's
+				// render path (#1333) rather than a raw terminal write.
+				notifyUserDegradation(`pi-lens: ${unavailable}`);
 			}
 			return ok;
 		})();
@@ -1363,11 +1382,15 @@ export class TreeSitterClient {
 		const key = `${ruleId}:${languageId}`;
 		if (this.reportedCompileFailures.has(key)) return;
 		this.reportedCompileFailures.add(key);
-		console.error(
-			`[pi-lens] tree-sitter rule '${ruleId}' failed to compile against '${languageId}' — ` +
+		logTreeSitterDiagnostic({
+			subsystem: "tree-sitter-client",
+			languageId,
+			message:
+				`tree-sitter rule '${ruleId}' failed to compile against '${languageId}' — ` +
 				`matches for this rule are silently dropped rather than reported. ` +
 				`Fix the query in the rule definition to re-enable it. (${err})`,
-		);
+			metadata: { ruleId },
+		});
 	}
 
 	private hasChildToken(node: TreeSitterNode, token: string): boolean {
@@ -3457,21 +3480,27 @@ export class TreeSitterClient {
 	private reportPostFilterFailure(postFilter: string, reason: string): void {
 		if (this.reportedPostFilterFailures.has(postFilter)) return;
 		this.reportedPostFilterFailures.add(postFilter);
-		console.error(
-			`[pi-lens] tree-sitter rule post_filter '${postFilter}' failed — ` +
+		logTreeSitterDiagnostic({
+			subsystem: "tree-sitter-client",
+			message:
+				`tree-sitter rule post_filter '${postFilter}' failed — ` +
 				`keeping the diagnostic (fail-open): ${reason}.`,
-		);
+			metadata: { postFilter },
+		});
 	}
 
 	/** Warn once per unimplemented post_filter — a silent rule needs a trail. */
 	private reportMissingPostFilter(postFilter: string): void {
 		if (this.reportedMissingPostFilters.has(postFilter)) return;
 		this.reportedMissingPostFilters.add(postFilter);
-		console.error(
-			`[pi-lens] tree-sitter rule post_filter '${postFilter}' is not implemented — ` +
+		logTreeSitterDiagnostic({
+			subsystem: "tree-sitter-client",
+			message:
+				`tree-sitter rule post_filter '${postFilter}' is not implemented — ` +
 				`matches for the rules using it are suppressed rather than reported unfiltered. ` +
 				`Implement it in applyPostFilter (clients/tree-sitter-client.ts) to re-enable them.`,
-		);
+			metadata: { postFilter },
+		});
 	}
 
 	/**

--- a/clients/tree-sitter-logger.ts
+++ b/clients/tree-sitter-logger.ts
@@ -24,7 +24,11 @@ export interface TreeSitterLogEntry {
 		| "runner_complete"
 		| "entity_diff"
 		| "blast_radius"
-		| "cache_stats";
+		| "cache_stats"
+		// #1333: free-form operational text that used to be a raw console.error
+		// (or a verbose-gated one) from the tree-sitter stack. `reason` carries
+		// the message, `metadata.subsystem` the emitting module.
+		| "diagnostic";
 	filePath: string;
 	languageId?: string;
 	queryId?: string;
@@ -92,6 +96,37 @@ export function logTreeSitterCacheStats(options: {
 				totalLines: options.stats.totalLines,
 			},
 		},
+	});
+}
+
+/**
+ * The tree-sitter stack's terminal-safe diagnostic sink (#1333).
+ *
+ * pi owns the terminal, so nothing under `clients/` may `console.error`. The
+ * tree-sitter subsystem already owns `tree-sitter.log`, so its diagnostics stay
+ * there rather than moving to the generic `extension.log` — one log per
+ * subsystem, per the AGENTS.md logger invariant.
+ *
+ * `filePath` is optional because several of these fire process-wide (WASM
+ * abort, grammar fetch, rule compile) with no file in hand.
+ */
+export function logTreeSitterDiagnostic(entry: {
+	/** Emitting module, e.g. `tree-sitter-client`, `symbol-extractor`. */
+	subsystem: string;
+	message: string;
+	/** `debug` is what the previously verbose-gated loggers write at. */
+	level?: "error" | "warn" | "debug";
+	filePath?: string;
+	languageId?: string;
+	metadata?: Record<string, unknown>;
+}): void {
+	logTreeSitter({
+		phase: "diagnostic",
+		filePath: entry.filePath ?? "<tree-sitter>",
+		...(entry.languageId ? { languageId: entry.languageId } : {}),
+		status: entry.level ?? "error",
+		reason: entry.message,
+		metadata: { subsystem: entry.subsystem, ...(entry.metadata ?? {}) },
 	});
 }
 

--- a/clients/tree-sitter-query-loader.ts
+++ b/clients/tree-sitter-query-loader.ts
@@ -5,6 +5,7 @@
  * and provides them to the TreeSitterClient.
  */
 
+import { logTreeSitterDiagnostic } from "./tree-sitter-logger.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { resolvePackagePath } from "./package-root.js";
@@ -183,7 +184,12 @@ export class TreeSitterQueryLoader {
 	/** Debug logging helper */
 	private dbg(msg: string): void {
 		if (this.verbose) {
-			console.error(`[query-loader] ${msg}`);
+			// #1333: verbose gate preserved, sink moved to tree-sitter.log.
+			logTreeSitterDiagnostic({
+				subsystem: "query-loader",
+				level: "debug",
+				message: msg,
+			});
 		}
 	}
 

--- a/clients/tree-sitter-shared.ts
+++ b/clients/tree-sitter-shared.ts
@@ -13,6 +13,7 @@
  * consumer skips further tree-sitter work (previously only the runner tracked this,
  * while the other subsystems kept calling the dead runtime).
  */
+import { notifyUserDegradation } from "./user-notify.js";
 import * as path from "node:path";
 import {
 	type ParsedTreeOutcome,
@@ -61,9 +62,14 @@ export function markTreeSitterWasmAborted(): void {
 	_wasmAborted = true;
 	_wasmAbortedAt = new Date().toISOString();
 	_shared = null;
-	console.error(
-		"[pi-lens] tree-sitter WASM runtime aborted; structural analysis is disabled " +
+	// HUMAN-audience: structural analysis is dead for the rest of the process
+	// and only a restart recovers it. Reaches the user through the HOST's
+	// render path (#1333); the machine-readable record is the logTreeSitter
+	// `runtime_abort` entry below.
+	notifyUserDegradation(
+		"pi-lens: tree-sitter WASM runtime aborted; structural analysis is disabled " +
 			"for this process. Restart the pi-lens extension/MCP server to recover.",
+		"error",
 	);
 	logTreeSitter({
 		phase: "runtime_abort",

--- a/clients/tree-sitter-symbol-extractor.ts
+++ b/clients/tree-sitter-symbol-extractor.ts
@@ -3,6 +3,7 @@
  * Extracts definitions and references from source files
  */
 
+import { logTreeSitterDiagnostic } from "./tree-sitter-logger.js";
 import * as path from "node:path";
 import { loadWebTreeSitter } from "./deps/web-tree-sitter.js";
 import type { Symbol, SymbolKind, SymbolRef } from "./symbol-types.js";
@@ -695,10 +696,13 @@ export class TreeSitterSymbolExtractor {
 			return Boolean(this.defQuery || this.importQuery);
 		} catch (err) {
 			this.client.reportWasmAbort(err);
-			console.error(
-				`[symbol-extractor] Failed to init ${this.languageId}:`,
-				err,
-			);
+			logTreeSitterDiagnostic({
+				subsystem: "symbol-extractor",
+				languageId: this.languageId,
+				message: `Failed to init ${this.languageId}: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			});
 			return false;
 		}
 	}
@@ -709,9 +713,12 @@ export class TreeSitterSymbolExtractor {
 			return new Query(language, src);
 		} catch (err) {
 			if (this.client.reportWasmAbort(err)) throw err;
-			console.error(
-				`[symbol-extractor] ${this.languageId} ${label} query failed: ${(err as Error).message}`,
-			);
+			logTreeSitterDiagnostic({
+				subsystem: "symbol-extractor",
+				languageId: this.languageId,
+				message: `${this.languageId} ${label} query failed: ${(err as Error).message}`,
+				metadata: { query: label },
+			});
 			return null;
 		}
 	}

--- a/clients/user-notify.ts
+++ b/clients/user-notify.ts
@@ -1,0 +1,59 @@
+/**
+ * The HUMAN channel for degradations discovered deep in `clients/` (#1333).
+ *
+ * Most of what the migrated `console.*` sites emitted is LOG-audience and
+ * belongs in an ndjson sink (`clients/extension-log.ts`). A small set is
+ * genuinely user-facing — "the config file you wrote is being ignored", "this
+ * language's grammar could not be fetched, so its structural features are
+ * degraded", "the WASM runtime aborted; restart to recover". Those must reach
+ * the human through the HOST's own render path, never a raw terminal write
+ * (pi owns the terminal — see the module doc in `extension-log.ts`).
+ *
+ * `index.ts` wires a getter at extension init; modules deep in the tree call
+ * `notifyUserDegradation` without knowing anything about `ctx`. Per the
+ * #338/#798 detached-callback rule the notifier is resolved through a GETTER
+ * at delivery time — never captured once, because a session replacement
+ * invalidates the previously captured `ctx.ui`.
+ *
+ * Fail-soft by construction: with no host wired (MCP server, CLI, tests) this
+ * is a no-op and the ndjson sink remains the sole destination — the message is
+ * never lost, only un-rendered.
+ */
+
+export type UserNotifyLevel = "info" | "warning" | "error";
+
+export type UserNotifier = (message: string, level?: UserNotifyLevel) => void;
+
+let notifierGetter: (() => UserNotifier | undefined) | undefined;
+
+/** Called once from the extension entry with a getter over the live `ctx.ui.notify`. */
+export function wireUserNotifier(getter: () => UserNotifier | undefined): void {
+	notifierGetter = getter;
+}
+
+/** Test/teardown-only: drop the wired host. */
+export function resetUserNotifier(): void {
+	notifierGetter = undefined;
+}
+
+/** True when a host render path is available (for callers that want to branch). */
+export function hasUserNotifier(): boolean {
+	return notifierGetter !== undefined;
+}
+
+/**
+ * Best-effort delivery of a user-facing degradation. Never throws — a stale
+ * `ctx` after a session replacement must degrade to a no-op, not break the
+ * diagnostic path that called it.
+ */
+export function notifyUserDegradation(
+	message: string,
+	level: UserNotifyLevel = "warning",
+): void {
+	try {
+		const notify = notifierGetter?.();
+		notify?.(message, level);
+	} catch {
+		// The ndjson sink already holds this message; a dead host is not an error.
+	}
+}

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import "./clients/console-guard-install.js";
 import "./clients/startup-marker.js";
 import { installConsoleGuard } from "./clients/extension-log.js";
 import { wireUserNotifier } from "./clients/user-notify.js";
@@ -367,9 +368,11 @@ export default function (pi: ExtensionAPI) {
 	// `console.log = console.error` guard. pi owns the terminal (raw mode +
 	// cursor-addressed diff repaints), so a raw byte from ANY transitively
 	// loaded module desyncs its screen model. pi-lens's own sites are migrated
-	// to real ndjson sinks; this net catches everything else. Installed FIRST,
-	// before any client module can log during construction. No-op under test
-	// mode and under `PI_LENS_CONSOLE_GUARD=0`.
+	// to real ndjson sinks; this net catches everything else. The REAL install
+	// happens at import time via `clients/console-guard-install.js` (index.ts's
+	// first import) so module-init writes are covered too; this call is an
+	// idempotent re-install for tests that invoke the factory directly. No-op
+	// under test mode and under `PI_LENS_CONSOLE_GUARD=0`.
 	installConsoleGuard();
 	initI18n(pi);
 	// #1333 HUMAN channel: user-facing degradations found deep in clients/

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,6 @@
 import "./clients/startup-marker.js";
+import { installConsoleGuard } from "./clients/extension-log.js";
+import { wireUserNotifier } from "./clients/user-notify.js";
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -192,6 +194,21 @@ function dbg(msg: string) {
 }
 
 /**
+ * The most recent event ctx, kept ONLY so `clients/user-notify.ts` can resolve
+ * a live `ctx.ui.notify` at delivery time (#1333). Never dereferenced eagerly
+ * and never captured by a long-lived closure — a session replacement swaps the
+ * ctx, and `notifyUserDegradation` swallows the stale-ctx throw.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous pi event ctx shapes
+let latestEventCtx: any;
+
+/** Refresh the notify target from whichever event ctx just arrived. */
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous pi event ctx shapes
+function rememberEventCtx(ctx: any): void {
+	if (ctx?.ui) latestEventCtx = ctx;
+}
+
+/**
  * Best-effort read of the STABLE pi session id off an event ctx
  * (`ctx.sessionManager.getSessionId()`), the same accessor #473's
  * session_start handling and #791's deferred-format ownership tagging both
@@ -346,7 +363,26 @@ function cleanStaleTsBuildInfo(cwd: string): string[] {
 // --- Extension ---
 
 export default function (pi: ExtensionAPI) {
+	// #1333 — defense in depth, the pi-side mirror of `mcp/server.ts`'s
+	// `console.log = console.error` guard. pi owns the terminal (raw mode +
+	// cursor-addressed diff repaints), so a raw byte from ANY transitively
+	// loaded module desyncs its screen model. pi-lens's own sites are migrated
+	// to real ndjson sinks; this net catches everything else. Installed FIRST,
+	// before any client module can log during construction. No-op under test
+	// mode and under `PI_LENS_CONSOLE_GUARD=0`.
+	installConsoleGuard();
 	initI18n(pi);
+	// #1333 HUMAN channel: user-facing degradations found deep in clients/
+	// (invalid config, offline grammar fetch, WASM abort) reach the user
+	// through the host's own render path. Per the #338/#798 detached-callback
+	// rule the notifier is resolved from the LATEST event ctx at delivery time,
+	// never captured once — a session replacement invalidates the old ctx.ui.
+	wireUserNotifier(() => {
+		const ui = latestEventCtx?.ui;
+		if (!ui || typeof ui.notify !== "function") return undefined;
+		return (message: string, level?: "info" | "warning" | "error") =>
+			ui.notify(message, level ?? "warning");
+	});
 	const getLiveEvents = () => pi.events;
 	initLensEventsGetter(getLiveEvents);
 	const getLiveEmit = () => pi.events?.emit?.bind(pi.events);
@@ -1213,6 +1249,7 @@ export default function (pi: ExtensionAPI) {
 	// --- Events ---
 
 	pi.on("session_start", async (event, ctx) => {
+		rememberEventCtx(ctx);
 		const sessionStartFiredAt = Date.now();
 		try {
 			dbg("session_start fired");
@@ -1564,6 +1601,7 @@ export default function (pi: ExtensionAPI) {
 	// Real-time feedback on file writes/edits
 	// biome-ignore lint/suspicious/noExplicitAny: pi.on overload mismatch for tool_result event type
 	(pi as any).on("tool_result", async (event: any, ctx: any) => {
+		rememberEventCtx(ctx);
 		if (!lensEnabled) return;
 		updateRuntimeIdentityFromEvent(event);
 		// Publish this turn's abort signal so the dispatch's linter/type-check

--- a/tests/clients/event-loop-monitor-bun-compat.test.ts
+++ b/tests/clients/event-loop-monitor-bun-compat.test.ts
@@ -1,5 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+// #1333: these config/telemetry warnings no longer reach the terminal — pi owns
+// it — they go to the ndjson sink in `clients/extension-log.ts`. The sink mock
+// below forwards each entry's message to `console.error` so the assertions in
+// this file keep covering what they were written to cover (message content and
+// the warn-once dedup contract) without re-deriving every expectation. The
+// "no raw terminal write" half of the invariant is enforced repo-wide by
+// tests/clients/extension-terminal-silence.test.ts.
+vi.mock("../../clients/extension-log.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../clients/extension-log.js")>();
+	return {
+		...actual,
+		logExtension: (entry: { message: string }) => console.error(entry.message),
+	};
+});
+
+
 // Simulate a runtime that doesn't implement perf_hooks.monitorEventLoopDelay
 // (e.g. Bun < 1.3, which throws ERR_NOT_IMPLEMENTED when it is CALLED). The
 // monitor is purely observational, so extension load must NOT crash — it must

--- a/tests/clients/extension-log.test.ts
+++ b/tests/clients/extension-log.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Behavior of the terminal-safe extension sink and the console guard (#1333).
+ *
+ * These load `clients/extension-log.ts` with `PI_LENS_TEST_MODE=0` and a
+ * throwaway `PI_LENS_HOME`, because the sink deliberately no-ops under test
+ * mode (the same contract every other pi-lens ndjson logger keeps).
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let tempHome: string;
+const savedEnv: Record<string, string | undefined> = {};
+
+async function loadSink(): Promise<
+	typeof import("../../clients/extension-log.js")
+> {
+	vi.resetModules();
+	return await import("../../clients/extension-log.js");
+}
+
+function readLines(logFile: string): Record<string, unknown>[] {
+	if (!fs.existsSync(logFile)) return [];
+	return fs
+		.readFileSync(logFile, "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+beforeEach(() => {
+	tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-1333-"));
+	for (const key of [
+		"PI_LENS_TEST_MODE",
+		"PI_LENS_HOME",
+		"PI_LENS_CONSOLE_GUARD",
+	]) {
+		savedEnv[key] = process.env[key];
+	}
+	process.env.PI_LENS_TEST_MODE = "0";
+	process.env.PI_LENS_HOME = tempHome;
+	delete process.env.PI_LENS_CONSOLE_GUARD;
+});
+
+afterEach(() => {
+	for (const [key, value] of Object.entries(savedEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("extension-log sink (#1333)", () => {
+	it("writes an ndjson line instead of touching the terminal", async () => {
+		const sink = await loadSink();
+		const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		const stdout = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+		try {
+			sink.logExtension({
+				subsystem: "dispatch",
+				message: "no config detected, using defaults",
+				metadata: { filePath: "a.ts" },
+			});
+			await sink.flushExtensionLog();
+			expect(stderr).not.toHaveBeenCalled();
+			expect(stdout).not.toHaveBeenCalled();
+		} finally {
+			stderr.mockRestore();
+			stdout.mockRestore();
+		}
+
+		const lines = readLines(sink.getExtensionLogPath());
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toMatchObject({
+			subsystem: "dispatch",
+			level: "error",
+			message: "no config detected, using defaults",
+			metadata: { filePath: "a.ts" },
+		});
+		expect(typeof lines[0].ts).toBe("string");
+	});
+
+	it("createSubsystemLogger is callable and level-aware", async () => {
+		const sink = await loadSink();
+		const log = sink.createSubsystemLogger("ruff");
+		log("verbose detail");
+		log.warn("a warning");
+		log.error("an error");
+		await sink.flushExtensionLog();
+
+		const lines = readLines(sink.getExtensionLogPath());
+		expect(lines.map((l) => [l.subsystem, l.level, l.message])).toEqual([
+			["ruff", "debug", "verbose detail"],
+			["ruff", "warn", "a warning"],
+			["ruff", "error", "an error"],
+		]);
+	});
+
+	it("stays terminal-silent whether the verbose gate is on or off", async () => {
+		const sink = await loadSink();
+		const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		try {
+			// verbose OFF
+			sink.noopSubsystemLogger()("hidden");
+			// verbose ON — the migrated sink, not console
+			sink.createSubsystemLogger("biome")("shown");
+			await sink.flushExtensionLog();
+			expect(stderr).not.toHaveBeenCalled();
+		} finally {
+			stderr.mockRestore();
+		}
+		const messages = readLines(sink.getExtensionLogPath()).map(
+			(l) => l.message,
+		);
+		expect(messages).toEqual(["shown"]);
+	});
+});
+
+describe("console guard (#1333)", () => {
+	it("reroutes console.* into the sink and is idempotent", async () => {
+		const sink = await loadSink();
+		const original = console.error;
+		expect(sink.installConsoleGuard()).toBe(true);
+		expect(sink.installConsoleGuard()).toBe(false);
+		try {
+			expect(console.error).not.toBe(original);
+			const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+			console.error("rogue dependency line", { detail: 1 });
+			console.log("rogue stdout line");
+			expect(stderr).not.toHaveBeenCalled();
+			stderr.mockRestore();
+			await sink.flushExtensionLog();
+		} finally {
+			console.error = original;
+		}
+
+		const lines = readLines(sink.getExtensionLogPath()).filter(
+			(l) => l.subsystem === "console",
+		);
+		expect(lines.map((l) => [l.level, l.message])).toEqual([
+			["error", 'rogue dependency line {"detail":1}'],
+			["debug", "rogue stdout line"],
+		]);
+	});
+
+	it("is inert under test mode and under PI_LENS_CONSOLE_GUARD=0", async () => {
+		process.env.PI_LENS_TEST_MODE = "1";
+		let sink = await loadSink();
+		expect(sink.installConsoleGuard()).toBe(false);
+
+		process.env.PI_LENS_TEST_MODE = "0";
+		process.env.PI_LENS_CONSOLE_GUARD = "0";
+		sink = await loadSink();
+		expect(sink.installConsoleGuard()).toBe(false);
+	});
+});

--- a/tests/clients/extension-terminal-silence.test.ts
+++ b/tests/clients/extension-terminal-silence.test.ts
@@ -251,3 +251,13 @@ describe("extension path terminal silence (#1333)", () => {
 		}
 	});
 });
+
+// #1338 review: the guard must install as index.ts's FIRST import — a
+// factory-time install runs after all static imports have evaluated, leaving
+// import-time console writes unguarded.
+it("console guard is index.ts's first import (import-time install)", () => {
+	const src = fs.readFileSync(path.join(REPO_ROOT, "index.ts"), "utf8");
+	const firstImport = src.match(/^import .*$/m)?.[0] ?? "";
+	expect(firstImport).toContain("./clients/console-guard-install.js");
+});
+

--- a/tests/clients/extension-terminal-silence.test.ts
+++ b/tests/clients/extension-terminal-silence.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Enforcement: nothing reachable from the pi extension entry writes raw bytes
+ * to the terminal (#1333).
+ *
+ * pi owns the TTY (raw mode + cursor-addressed diff repaints), so a
+ * `console.*` or `process.std*.write` from `clients/`, `tools/`, `index.ts` or
+ * `i18n.ts` lands mid-frame and desyncs pi's model of the screen.
+ *
+ * Why this is a grep test and not the shipped ast-grep rules: pi-lens's
+ * `no-console-except-error` / `console-statement` rules deliberately PERMIT
+ * `console.error` inside a `catch` block ("useful for production triage"),
+ * which is right for a general-purpose library rule aimed at user projects and
+ * exactly wrong here — a large share of the original 26 offenders were inside
+ * `catch`. Rather than break that rule's policy for users, the extension path
+ * gets its own, stricter, structural check. Same shape as
+ * `managed-tool-seam-coverage.test.ts` (#1290).
+ *
+ * `mcp/**`, `scripts/**`, `bin/**` and `tests/**` are deliberately NOT scanned:
+ * they own their own stdout contract.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(".");
+
+/** Directories reachable from the pi extension entry. */
+const SCANNED_DIRS = ["clients", "tools"];
+/** Single files reachable from the pi extension entry. */
+const SCANNED_FILES = ["index.ts", "i18n.ts"];
+
+/**
+ * `clients/extension-log.ts` OWNS the console reroute — it is the one module
+ * allowed to name console methods, because patching them is its job.
+ */
+const ALLOWED_FILES = new Set(["clients/extension-log.ts"]);
+
+const CONSOLE_CALL =
+	/\bconsole\s*\.\s*(log|info|warn|error|debug|trace|dir|table)\s*\(/g;
+const RAW_WRITE = /\bprocess\s*\.\s*(stdout|stderr)\s*\.\s*write\s*\(/g;
+
+/**
+ * Blank out comments and string/template literal TEXT so a `console.log($MSG)`
+ * inside an ast-grep pattern documentation string is not mistaken for a call.
+ * Template `${...}` expressions are preserved (recursively scrubbed) — real
+ * code can live there.
+ */
+export function scrubCommentsAndStrings(source: string): string {
+	let out = "";
+	let i = 0;
+	const n = source.length;
+	// A `/` starts a REGEX (not division) when the previous non-space token
+	// cannot end an expression. Regex literals must be skipped whole: one that
+	// contains a quote — `/[$(){}[\].;:'"`]/` in tools/ast-grep-search.ts — would
+	// otherwise open a phantom string and desync the whole rest of the file.
+	const regexPrecursor =
+		/(^|[({[,;:=!&|?+\-*%~^<>]|\breturn|\btypeof|\bcase)\s*$/;
+	while (i < n) {
+		const c = source[i];
+		if (
+			c === "/" &&
+			source[i + 1] !== "/" &&
+			source[i + 1] !== "*" &&
+			regexPrecursor.test(out.slice(-16))
+		) {
+			i++;
+			let inClass = false;
+			while (i < n) {
+				const d = source[i];
+				if (d === "\\") {
+					i += 2;
+					continue;
+				}
+				if (d === "[") inClass = true;
+				else if (d === "]") inClass = false;
+				else if (d === "/" && !inClass) {
+					i++;
+					break;
+				} else if (d === "\n") break;
+				i++;
+			}
+			out += "/re/";
+			continue;
+		}
+		if (c === "/" && source[i + 1] === "/") {
+			while (i < n && source[i] !== "\n") i++;
+			continue;
+		}
+		if (c === "/" && source[i + 1] === "*") {
+			i += 2;
+			while (i < n && !(source[i] === "*" && source[i + 1] === "/")) i++;
+			i += 2;
+			continue;
+		}
+		if (c === '"' || c === "'") {
+			const quote = c;
+			i++;
+			while (i < n && source[i] !== quote) {
+				if (source[i] === "\\") i++;
+				i++;
+			}
+			i++;
+			out += '""';
+			continue;
+		}
+		if (c === "`") {
+			i++;
+			while (i < n) {
+				if (source[i] === "\\") {
+					i += 2;
+					continue;
+				}
+				if (source[i] === "`") {
+					i++;
+					break;
+				}
+				if (source[i] === "$" && source[i + 1] === "{") {
+					i += 2;
+					let depth = 1;
+					let expr = "";
+					while (i < n && depth > 0) {
+						const d = source[i];
+						if (d === "{") depth++;
+						else if (d === "}") {
+							depth--;
+							if (depth === 0) {
+								i++;
+								break;
+							}
+						}
+						expr += d;
+						i++;
+					}
+					out += `(${scrubCommentsAndStrings(expr)})`;
+					continue;
+				}
+				i++;
+			}
+			out += '""';
+			continue;
+		}
+		out += c;
+		i++;
+	}
+	return out;
+}
+
+function sourceFiles(dir: string): string[] {
+	if (!fs.existsSync(dir)) return [];
+	return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) return sourceFiles(full);
+		if (!entry.isFile()) return [];
+		return entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")
+			? [full]
+			: [];
+	});
+}
+
+function extensionPathFiles(): string[] {
+	return [
+		...SCANNED_DIRS.flatMap((dir) => sourceFiles(path.join(REPO_ROOT, dir))),
+		...SCANNED_FILES.map((file) => path.join(REPO_ROOT, file)).filter((file) =>
+			fs.existsSync(file),
+		),
+	];
+}
+
+function toRepoRelative(file: string): string {
+	return path.relative(REPO_ROOT, file).split(path.sep).join("/");
+}
+
+/** Every raw-terminal-write site in `source`, as `<line>: <matched text>`. */
+export function findRawTerminalWrites(source: string): string[] {
+	const scrubbed = scrubCommentsAndStrings(source);
+	const hits: string[] = [];
+	for (const pattern of [CONSOLE_CALL, RAW_WRITE]) {
+		pattern.lastIndex = 0;
+		for (const match of scrubbed.matchAll(pattern)) {
+			const line = scrubbed.slice(0, match.index).split("\n").length;
+			hits.push(`${line}: ${match[0]}`);
+		}
+	}
+	return hits;
+}
+
+describe("extension path terminal silence (#1333)", () => {
+	it("has no console.* or process.std*.write under clients/, tools/, index.ts, i18n.ts", () => {
+		const violations: string[] = [];
+		for (const file of extensionPathFiles()) {
+			const relative = toRepoRelative(file);
+			if (ALLOWED_FILES.has(relative)) continue;
+			for (const hit of findRawTerminalWrites(fs.readFileSync(file, "utf8"))) {
+				violations.push(`${relative}:${hit}`);
+			}
+		}
+		expect(violations).toEqual([]);
+	});
+
+	it("fires on a bare console.error — including one inside a catch block", () => {
+		// The exact shape the shipped `no-console-except-error` rules PERMIT, and
+		// the reason this test exists rather than a tweak to those rules.
+		const inCatch = `
+			try {
+				risky();
+			} catch (err) {
+				console.error("boom", err);
+			}
+		`;
+		expect(findRawTerminalWrites(inCatch)).toHaveLength(1);
+		expect(findRawTerminalWrites(`console.warn("x");`)).toHaveLength(1);
+		expect(findRawTerminalWrites(`process.stdout.write("x");`)).toHaveLength(1);
+		expect(findRawTerminalWrites(`process.stderr.write("x");`)).toHaveLength(1);
+	});
+
+	it("does not fire on console text inside comments or string literals", () => {
+		expect(findRawTerminalWrites(`// console.error("nope")`)).toEqual([]);
+		expect(findRawTerminalWrites(`/* console.log($MSG) */`)).toEqual([]);
+		expect(
+			findRawTerminalWrites(`const doc = "console.log($MSG) matches calls";`),
+		).toEqual([]);
+		expect(
+			findRawTerminalWrites("const doc = `use console.log($MSG) here`;"),
+		).toEqual([]);
+	});
+
+	it("skips regex literals whole, so a quote inside one cannot desync the scan", () => {
+		// The real shape from tools/ast-grep-search.ts. Without regex handling the
+		// `'` opens a phantom string literal and swallows the following code.
+		const source = [
+			"const hasAstSignals = /[$(){}[\\].;:'\"`]/.test(text);",
+			'console.error("still visible");',
+		].join("\n");
+		expect(findRawTerminalWrites(source)).toHaveLength(1);
+	});
+
+	it("leaves the hosts that own their stdout contract alone", () => {
+		// mcp/ deliberately writes (JSON-RPC + its own console.log→error guard);
+		// scanning it would be wrong, so assert it is outside the scan set.
+		const scanned = new Set(extensionPathFiles().map(toRepoRelative));
+		for (const owned of ["mcp/server.ts", "scripts", "bin", "tests"]) {
+			expect([...scanned].some((file) => file.startsWith(owned))).toBe(false);
+		}
+		// ...and that mcp/ really does still write, so this carve-out is live.
+		const mcpServer = path.join(REPO_ROOT, "mcp", "server.ts");
+		if (fs.existsSync(mcpServer)) {
+			expect(
+				findRawTerminalWrites(fs.readFileSync(mcpServer, "utf8")).length,
+			).toBeGreaterThan(0);
+		}
+	});
+});

--- a/tests/clients/lens-config.test.ts
+++ b/tests/clients/lens-config.test.ts
@@ -19,6 +19,22 @@ import {
 import { EMPTY_PROJECT_CONFIG } from "../../clients/project-lens-config.js";
 import { removeTempDirSync } from "./test-utils.js";
 
+// #1333: these config/telemetry warnings no longer reach the terminal — pi owns
+// it — they go to the ndjson sink in `clients/extension-log.ts`. The sink mock
+// below forwards each entry's message to `console.error` so the assertions in
+// this file keep covering what they were written to cover (message content and
+// the warn-once dedup contract) without re-deriving every expectation. The
+// "no raw terminal write" half of the invariant is enforced repo-wide by
+// tests/clients/extension-terminal-silence.test.ts.
+vi.mock("../../clients/extension-log.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../clients/extension-log.js")>();
+	return {
+		...actual,
+		logExtension: (entry: { message: string }) => console.error(entry.message),
+	};
+});
+
+
 const tmpDirs: string[] = [];
 let previousConfigPath: string | undefined;
 let previousEnvValues = new Map<string, string | undefined>();

--- a/tests/clients/lsp/config.test.ts
+++ b/tests/clients/lsp/config.test.ts
@@ -4,6 +4,22 @@ import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { removeTempDirSync } from "../test-utils.js";
 
+// #1333: these config/telemetry warnings no longer reach the terminal — pi owns
+// it — they go to the ndjson sink in `clients/extension-log.ts`. The sink mock
+// below forwards each entry's message to `console.error` so the assertions in
+// this file keep covering what they were written to cover (message content and
+// the warn-once dedup contract) without re-deriving every expectation. The
+// "no raw terminal write" half of the invariant is enforced repo-wide by
+// tests/clients/extension-terminal-silence.test.ts.
+vi.mock("../../../clients/extension-log.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../clients/extension-log.js")>();
+	return {
+		...actual,
+		logExtension: (entry: { message: string }) => console.error(entry.message),
+	};
+});
+
+
 const dirs: string[] = [];
 const defaultGlobalDir = process.env.PI_LENS_HOME;
 

--- a/tests/clients/project-lens-config.test.ts
+++ b/tests/clients/project-lens-config.test.ts
@@ -9,6 +9,22 @@ import {
 } from "../../clients/project-lens-config.js";
 import { removeTempDirSync } from "./test-utils.js";
 
+// #1333: these config/telemetry warnings no longer reach the terminal — pi owns
+// it — they go to the ndjson sink in `clients/extension-log.ts`. The sink mock
+// below forwards each entry's message to `console.error` so the assertions in
+// this file keep covering what they were written to cover (message content and
+// the warn-once dedup contract) without re-deriving every expectation. The
+// "no raw terminal write" half of the invariant is enforced repo-wide by
+// tests/clients/extension-terminal-silence.test.ts.
+vi.mock("../../clients/extension-log.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../clients/extension-log.js")>();
+	return {
+		...actual,
+		logExtension: (entry: { message: string }) => console.error(entry.message),
+	};
+});
+
+
 let tmpDir: string;
 
 beforeEach(() => {


### PR DESCRIPTION
Closes #1333.

pi owns the terminal — raw mode plus cursor-addressed diff repaints — so any byte an extension writes to stdout/stderr lands mid-frame and desyncs pi's model of the screen. This routes every `console.*` site reachable from the pi extension entry into a `createNdjsonLogger` sink, adds the human channel for the genuinely user-facing degradations, installs a defensive console reroute, and adds an enforcement test so the class can't regrow.

## Migration table

### Ungated sites (fired on real operational conditions)

| Site | Sink | Note |
| --- | --- | --- |
| `dispatch/dispatcher.ts:199` (`DispatchContext.log`) | `extension.log` · `dispatch` | the single highest-frequency offender; every runner advisory / precondition failure / crash flowed through here |
| `dispatch/runners/lsp.ts:202` | `extension.log` · `lsp-runner` | |
| `dispatch/runners/pyright.ts:114` | `extension.log` · `runner:pyright` | inside `catch` |
| `dispatch/runners/tree-sitter.ts:646` | `tree-sitter.log` | **duplicate dropped** — the adjacent `logTreeSitter({phase:"query_error"})` already carried the identical failure |
| `tree-sitter-client.ts:475` (grammar fetched) | `tree-sitter.log` · `warn` | |
| `tree-sitter-client.ts:482` (grammar unavailable) | `tree-sitter.log` + **`ctx.ui.notify`** | user-facing: offline grammar fetch |
| `tree-sitter-client.ts:1366` (rule compile fail) | `tree-sitter.log` | warn-once preserved |
| `tree-sitter-client.ts:3460` (post-filter threw) | `tree-sitter.log` | warn-once preserved |
| `tree-sitter-client.ts:3470` (post-filter unimplemented) | `tree-sitter.log` | warn-once preserved |
| `tree-sitter-shared.ts:64` (WASM abort) | **`ctx.ui.notify`** (`error`) | the machine-readable record is the existing `logTreeSitter({phase:"runtime_abort"})` right below |
| `tree-sitter-symbol-extractor.ts:698,712` | `tree-sitter.log` | WASM abort / query compile fail |
| `formatters.ts:68,82` (lazy-install failed) | `extension.log` · `format` | |
| `formatters.ts:1112` (`detect()` threw) | `extension.log` · `format` | inside `catch` |
| `format-service.ts:84` (`console.warn`) | `extension.log` · `format` · `warn` | |
| `lens-config.ts:128` (invalid global config) | `extension.log` + **`ctx.ui.notify`** | warn-once preserved |
| `project-lens-config.ts:389` (invalid `.pi-lens.json`) | `extension.log` + **`ctx.ui.notify`** | warn-once preserved |
| `lsp/config.ts:109` (invalid `lsp.json`) | `extension.log` + **`ctx.ui.notify`** | |
| `review-graph/builder.ts:1598` (cache persist failed) | `review-graph.log` | **duplicate dropped** — `recordPersistFailure` already emits `phase:"persist_failed"` with the same message |
| `review-graph/builder.ts:2925` (structural facts degraded) | `review-graph.log` `phase:"build_skipped"` | inside `catch` |
| `project-snapshot.ts:493` (body persist failed) | `latency.log` | **duplicate dropped** — the adjacent `logLatency({phase:"project_snapshot_persist_failed"})` already carried it |
| `bootstrap.ts:72,82` | `extension.log` · `bootstrap` | preinstall failures + install diagnostics |
| `event-loop-monitor.ts:82` | `extension.log` · `event-loop-monitor` | inside `catch` |
| `lens-events.ts:105` (dropped emit) | `extension.log` · `lens-events` · `warn` | log-once preserved |

### Verbose-gated sites — gate kept, sink changed

The gate stays exactly where it was (`verbose ? … : () => {}`); only the sink moved, so turning verbose on can never corrupt the frame.

| Sites | Sink |
| --- | --- |
| `ast-grep-client:177`, `biome-client:52`, `cache-manager:106`, `complexity-client:474`, `dead-code-client:147`, `dependency-checker:311`, `go-client:50`, `jscpd-client:83`, `knip-client:131`, `metrics-client:42`, `ruff-client:52`, `rust-client:51`, `sg-runner:178`, `security-scan-client:34`, **`test-runner-client:259`** (a 20th site the issue's sweep missed) | `extension.log` at `debug`, via `createSubsystemLogger(<tag>)` |
| `tree-sitter-client:300`, `tree-sitter-cache:101`, `tree-sitter-query-loader:186` | `tree-sitter.log` at `debug`, via `logTreeSitterDiagnostic` |
| `installer/index.ts:221` (`[auto-install:debug]`), `lsp/client.ts:1189` (`PUB_DEBUG`) | `extension.log` at `debug` |

The `pi-lens-ignore: console-statement` at `tree-sitter-client.ts:300` is removed as part of the migration.

## New seams

- **`clients/extension-log.ts`** — one `createNdjsonLogger` over `<getGlobalPiLensDir()>/extension.log` (rotating at `getMaxLogSizeMB()`, self-registering with `log-cleanup` like every other logger). Exports `logExtension`, `createSubsystemLogger` (callable **and** carrying `.error/.warn/.debug`, so the hand-rolled shape is a one-line swap), and `installConsoleGuard`.
- **`clients/user-notify.ts`** — the HUMAN channel. `index.ts` wires a getter; per the #338/#798 detached-callback rule the notifier is resolved from the latest event ctx **at delivery time**, never captured. Fail-soft: with no host wired (MCP, CLI, tests) it is a no-op and the ndjson sink remains the destination, so nothing is ever lost.
- **`logTreeSitterDiagnostic`** in `tree-sitter-logger.ts` — a new `phase: "diagnostic"` so the tree-sitter stack keeps its own log instead of spilling into the generic one.

## Defense in depth

`index.ts` now calls `installConsoleGuard()` as the very first statement of the extension entry, mirroring `mcp/server.ts:81`'s `console.log = console.error`. It patches `log/info/warn/error/debug/trace/dir` onto `logExtension`, so a transitively loaded dependency cannot write raw bytes into pi's frame either. Idempotent; inert under test mode and under `PI_LENS_CONSOLE_GUARD=0`. This is a net, not the fix — pi-lens's own sites got real sinks with real schemas.

## Enforcement

`tests/clients/extension-terminal-silence.test.ts` greps `clients/`, `tools/`, `index.ts`, `i18n.ts` for `console.*` and `process.std*.write`, **including inside `catch`** — precisely the shape the shipped `no-console-except-error` / `console-statement` rules deliberately permit. That allowance is right for a general-purpose library rule aimed at user projects and exactly wrong for a TUI-hosted extension, so rather than break the rule's policy for users the extension path gets its own stricter structural check (same shape as `managed-tool-seam-coverage.test.ts`, #1290). `mcp/**`, `scripts/**`, `bin/**`, `tests/**` are carved out, and the test asserts positively that `mcp/server.ts` still writes, so the carve-out stays live rather than becoming vacuous.

The scrubber strips comments, string literals, and — importantly — regex literals whole: `tools/ast-grep-search.ts` contains a character class with a quote in it, which would otherwise open a phantom string and silently swallow the rest of the file. That has its own regression case.

**Mutation-verified:** appending `try { (globalThis as any).x(); } catch (e) { console.error("rogue", e); }` to `clients/lens-events.ts` turns the test red with `clients/lens-events.ts:179: console.error(`; removing it turns it green.

## Not migrated / limitations

- **Notify reach.** `wireUserNotifier` resolves `ctx.ui.notify` off the most recent `session_start`/`tool_result` ctx. A degradation firing *before* the first such event (e.g. `loadPiLensGlobalConfig` during module init) reaches the ndjson sink but not the UI on that occasion. Per the issue's own guidance, no new plumbing was built speculatively; the log destination is always present.
- **Three duplicate writes were dropped, not re-sunk** (marked above). Each had an adjacent structured-logger call carrying the same information to the same subsystem log, so re-sinking would have double-written. No information is lost — check `logTreeSitter` / `logLatency` / `logReviewGraph` at each of those three sites.

## Verification

- `npm run build` — clean.
- `npx vitest run tests/clients/` — the 6 directly-affected files pass (154 tests).
- Full `npm test` (suite lock, `MAX_WORKERS=4`): **6036 passed, 17 skipped, 4 failed**. All 4 (`dependency-checker-madge-resolution` ×2, `dependency-checker-madge-memo-reset`, `jscpd-client`) reproduce identically on `origin/master` in this environment — they depend on globally-installed madge/jscpd binaries. Verified by checking `origin/master`'s sources into the worktree and re-running the same set.

Existing tests that asserted these warnings on a `console.error` spy (`lens-config`, `project-lens-config`, `lsp/config`, `event-loop-monitor-bun-compat`) now mock the sink and forward its message to the spy, so their real subject — message content and warn-once dedup — stays covered; the "no raw write" half is now enforced repo-wide by the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
