### PR TITLE
feat(safe-spawn): typed spawn-failure taxonomy — reinstall keys on tool-not-found only (closes #1214)

### DIFF
--- a/.changelog/feat-1214-spawn-failure-taxonomy.md
+++ b/.changelog/feat-1214-spawn-failure-taxonomy.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Spawn failures now distinguish missing tools from invalid working directories (closes #1214)** — Auto-install and reinstall paths run only when the executable itself is missing, preventing futile reinstall loops for cwd and permission failures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,14 @@ uses the awaited durable-store seam: its delta/version snapshot maps to
 policy. Turn-state remains separate pending a future ownership decision.
 (#1209, #1212)
 
+**Spawn repair decisions use the typed safe-spawn taxonomy.** A raw OS
+`ENOENT` can mean either a missing executable or an invalid child cwd. Consume
+`SpawnResult.spawnFailure.kind` / `SpawnFailureError.kind`, never errno or
+message text, and trigger install/reinstall only for `tool-not-found`.
+`cwd-unresolvable`, `permission-denied`, `spawn-failed`, `timeout`, and `killed`
+must remain non-repairable at that seam; the original errno-bearing Error is
+preserved as `cause`. (#1214)
+
 ## Issue and PR design contract
 
 - **Design the state space before coding.** For stateful, ordered, resource-mutating, or security-sensitive work, write the invariants, supported transitions, explicit deferrals, and a cross-product test matrix before implementation. Examples are not enough: cover operation order, preview/apply, validation/normalization/execution seams, failure atomicity, observability bounds, and OS/path/encoding axes. If adversarial review finds repeated cross-product defects, stop patching one symptom at a time and return to the model.

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -391,13 +391,14 @@ export function createAvailabilityChecker(
 
 			cache.available = false;
 			const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
-			if (result.failure === "spawn" && errorCode === "ENOENT") {
+			if (result.spawnFailure?.kind === "tool-not-found") {
 				resetPathWalkMemo();
 				cache.outcome = "missing";
 			} else if (
 				result.failure === "timeout" ||
 				result.failure === "aborted" ||
 				result.failure === "signal" ||
+				result.spawnFailure?.kind === "killed" ||
 				errorCode === "EAGAIN" ||
 				errorCode === "EBUSY"
 			) {

--- a/clients/lsp/launch.ts
+++ b/clients/lsp/launch.ts
@@ -21,6 +21,10 @@ import { getGlobalPiLensDir } from "../file-utils.js";
 import { isFullyQualified } from "../path-utils.js";
 import { findGlobalBinary } from "../package-manager.js";
 import { redactSecrets } from "../redact/secrets.js";
+import {
+	classifySpawnFailure,
+	SpawnFailureError,
+} from "../safe-spawn.js";
 import { getRubyVersionDirNamesAsync } from "./ruby-drive-dirs.js";
 
 export interface LSPProcess {
@@ -421,12 +425,12 @@ function _attachErrorHandler(
 			);
 		}
 
-		// If we have a reject function and this is an immediate spawn error, reject
-		if (
-			rejectOnImmediateError &&
-			(err as NodeJS.ErrnoException).code === "ENOENT"
-		) {
-			rejectOnImmediateError(err);
+		// Preserve intent at the boundary instead of leaking a raw errno check.
+		if (rejectOnImmediateError && logContext) {
+			void classifySpawnFailure(err, {
+				command: logContext.command,
+				cwd: logContext.cwd,
+			}).then(rejectOnImmediateError);
 		}
 	});
 
@@ -551,9 +555,11 @@ export async function launchLSP(
 		logSessionStart(
 			`lsp cmd-shim-invalid: ${spawnCommand} target missing — skipping candidate`,
 		);
-		throw new Error(
-			`LSP .cmd shim target not found: ${spawnCommand}. The npm package may not be installed.`,
+		const cause = Object.assign(
+			new Error(`LSP .cmd shim target not found: ${spawnCommand}`),
+			{ code: "ENOENT" },
 		);
+		throw await classifySpawnFailure(cause, { command, cwd });
 	}
 
 	// P0 FIX: Never spawn .ps1 wrappers on Windows — they hang when PowerShell
@@ -591,10 +597,10 @@ export async function launchLSP(
 				const needsShellGlobal = computeNeedsShell(globalBinPath);
 				proc = trySpawn(globalBinPath, args, cwd, env, needsShellGlobal);
 			} else {
-				throw err;
+				throw await classifySpawnFailure(err, { command, cwd });
 			}
 		} else {
-			throw err;
+			throw await classifySpawnFailure(err, { command, cwd });
 		}
 	}
 
@@ -634,15 +640,21 @@ export async function launchLSP(
 			let settled = false;
 
 			// Attach error handler that can reject for immediate errors
-			proc.on("error", (err: Error & { code?: string }) => {
-				if (!settled && (err.code === "ENOENT" || err.code === "EINVAL")) {
+			proc.on("error", (err: Error) => {
+				if (!settled) {
 					settled = true;
-					reject(
-						new Error(
-							`LSP server binary not found: ${command}. ` +
-								`Install it or check your PATH.${formatStartupStderr(startupStderr)}`,
-						),
-					);
+					void classifySpawnFailure(err, { command, cwd }).then((failure) => {
+						const detail = formatStartupStderr(startupStderr);
+						reject(
+							detail
+								? new SpawnFailureError(
+									failure.kind,
+									`${failure.message}${detail}`,
+									failure.cause,
+								)
+								: failure,
+						);
+					});
 				}
 			});
 

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -45,7 +45,11 @@ import { findLocalSgconfig, resolveBaselineSgconfig } from "../sgconfig.js";
 import { findLocalTyposConfig } from "../typos-config.js";
 import { resolvePackagePath } from "../package-root.js";
 import { resolveAstGrepNativeExe } from "./wait-policy/index.js";
-import { isCommandAvailableAsync, safeSpawnAsync } from "../safe-spawn.js";
+import {
+	hasSpawnFailureKind,
+	isCommandAvailableAsync,
+	safeSpawnAsync,
+} from "../safe-spawn.js";
 import { type LSPProcess, launchLSP } from "./launch.js";
 import { createLombokJdtlsArgs } from "./lombok.js";
 import { resolveJavaRuntimeEnv } from "./jvm-runtime.js";
@@ -217,15 +221,6 @@ function canInstall(allowInstall?: boolean): boolean {
 	return allowInstall !== false && !isLspInstallDisabled();
 }
 
-function isCommandNotFoundError(error: unknown): boolean {
-	const msg = String(error);
-	return (
-		msg.includes("not found") ||
-		msg.includes("ENOENT") ||
-		msg.includes("not recognized")
-	);
-}
-
 const DIRECT_LSP_NEGATIVE_TTL_MS = Math.max(
 	30_000,
 	Number.parseInt(
@@ -324,7 +319,7 @@ export async function resolveAndLaunch(
 	let lastRuntimeFailure: Error | undefined;
 	const trackRuntimeFailure = (err: unknown): void => {
 		const message = err instanceof Error ? err.message : String(err);
-		if (!isCommandNotFoundError(message)) {
+		if (!hasSpawnFailureKind(err, "tool-not-found")) {
 			lastRuntimeFailure = err instanceof Error ? err : new Error(message);
 		}
 	};
@@ -408,6 +403,13 @@ export async function resolveAndLaunch(
 		);
 		trackRuntimeFailure(failure.err);
 	}
+	const hasOnlyRepairableCandidateFailures = candidateFailures.every((failure) =>
+		hasSpawnFailureKind(failure.err, "tool-not-found"),
+	);
+	if (!hasOnlyRepairableCandidateFailures) {
+		if (lastRuntimeFailure) throw lastRuntimeFailure;
+		return undefined;
+	}
 
 	if (!canInstall(allowInstall)) {
 		logSessionStart(
@@ -490,7 +492,7 @@ export async function resolveAndLaunch(
 				// caches and download a managed copy from the registry.
 				const looksPathResolved =
 					!installed.includes("/") && !installed.includes("\\");
-				if (looksPathResolved) {
+				if (looksPathResolved && hasSpawnFailureKind(err, "tool-not-found")) {
 					logSessionStart(
 						`lsp launch managed retry force-reinstall tool=${spec.managedToolId}`,
 					);
@@ -845,7 +847,7 @@ function createInteractiveServer(spec: InteractiveServerSpec): LSPServerInfo {
 						: spec.initialization;
 				return { process: proc, source: "direct", initialization };
 			} catch (err) {
-				if (isCommandNotFoundError(err)) {
+				if (hasSpawnFailureKind(err, "tool-not-found")) {
 					markDirectLspCommandUnavailable(command);
 				}
 				return undefined;

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -36,11 +36,45 @@ export interface SpawnResourceUsage {
 
 export type SpawnFailureKind = "aborted" | "timeout" | "spawn" | "signal";
 
+export type SpawnFailureType =
+	| "tool-not-found"
+	| "cwd-unresolvable"
+	| "permission-denied"
+	| "spawn-failed"
+	| "timeout"
+	| "killed";
+
+/** Intent-level spawn failure. `cause` retains the original OS Error/errno. */
+export class SpawnFailureError extends Error {
+	readonly name = "SpawnFailureError";
+
+	constructor(
+		readonly kind: SpawnFailureType,
+		message: string,
+		readonly cause: Error,
+	) {
+		super(message, { cause });
+	}
+}
+
+export function hasSpawnFailureKind(
+	error: unknown,
+	kind: SpawnFailureType,
+): boolean {
+	return (
+		error instanceof Error &&
+		"kind" in error &&
+		(error as { kind?: unknown }).kind === kind
+	);
+}
+
 export interface SpawnResult {
 	stdout: string;
 	stderr: string;
 	status: number | null;
 	error?: Error;
+	/** Typed spawn-boundary failure; nonzero tool exits do not populate it. */
+	spawnFailure?: SpawnFailureError;
 	/** Structured failure reason; nonzero exit statuses are not spawn failures. */
 	failure?: SpawnFailureKind;
 	/** True when stdout or stderr was capped before process completion. */
@@ -50,6 +84,101 @@ export interface SpawnResult {
 	 *  first poll tick, or sampling failed for the whole invocation) — never
 	 *  read that as "zero resource usage". */
 	resourceUsage?: SpawnResourceUsage;
+}
+
+function toError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function errorCode(error: Error): string | undefined {
+	return (error as NodeJS.ErrnoException).code;
+}
+
+async function cwdIsUnresolvable(cwd: string | undefined): Promise<boolean> {
+	if (cwd === undefined) return false;
+	try {
+		return !(await fs.promises.stat(cwd)).isDirectory();
+	} catch {
+		return true;
+	}
+}
+
+function cwdIsUnresolvableSync(cwd: string | undefined): boolean {
+	if (cwd === undefined) return false;
+	try {
+		return !fs.statSync(cwd).isDirectory();
+	} catch {
+		return true;
+	}
+}
+
+/** Classify a raw Node spawn error without discarding its errno-bearing Error. */
+export async function classifySpawnFailure(
+	error: unknown,
+	options: { command: string; cwd?: string },
+): Promise<SpawnFailureError> {
+	const cause = toError(error);
+	const code = errorCode(cause);
+	if (code === "ENOENT" && (await cwdIsUnresolvable(options.cwd))) {
+		return new SpawnFailureError(
+			"cwd-unresolvable",
+			`Cannot spawn ${options.command}: working directory is unresolvable (${options.cwd})`,
+			cause,
+		);
+	}
+	if (code === "ENOENT") {
+		return new SpawnFailureError(
+			"tool-not-found",
+			`Cannot spawn ${options.command}: tool not found (${cause.message})`,
+			cause,
+		);
+	}
+	if (code === "EACCES" || code === "EPERM") {
+		return new SpawnFailureError(
+			"permission-denied",
+			`Cannot spawn ${options.command}: permission denied`,
+			cause,
+		);
+	}
+	return new SpawnFailureError(
+		"spawn-failed",
+		`Cannot spawn ${options.command}: ${cause.message}`,
+		cause,
+	);
+}
+
+function classifySpawnFailureSync(
+	error: unknown,
+	options: { command: string; cwd?: string },
+): SpawnFailureError {
+	const cause = toError(error);
+	const code = errorCode(cause);
+	if (code === "ENOENT" && cwdIsUnresolvableSync(options.cwd)) {
+		return new SpawnFailureError(
+			"cwd-unresolvable",
+			`Cannot spawn ${options.command}: working directory is unresolvable (${options.cwd})`,
+			cause,
+		);
+	}
+	if (code === "ENOENT") {
+		return new SpawnFailureError(
+			"tool-not-found",
+			`Cannot spawn ${options.command}: tool not found (${cause.message})`,
+			cause,
+		);
+	}
+	if (code === "EACCES" || code === "EPERM") {
+		return new SpawnFailureError(
+			"permission-denied",
+			`Cannot spawn ${options.command}: permission denied`,
+			cause,
+		);
+	}
+	return new SpawnFailureError(
+		"spawn-failed",
+		`Cannot spawn ${options.command}: ${cause.message}`,
+		cause,
+	);
 }
 
 export interface SafeSpawnOptions {
@@ -740,10 +869,8 @@ function findCmdUnsafeValue(
 
 function synthesizeEnoentError(command: string): NodeJS.ErrnoException {
 	// Shaped like Node's native `spawn <cmd> ENOENT` error (message/code/
-	// syscall/path) so existing `err.message.includes("ENOENT")` /
-	// `err.code === "ENOENT"` call sites (e.g. sg-runner.ts, lsp/launch.ts)
-	// keep working now that Windows resolution happens before spawn instead
-	// of inside cmd.exe.
+	// syscall/path) so the typed classifier retains the same diagnostic cause
+	// now that Windows resolution happens before spawn instead of inside cmd.exe.
 	const err = new Error(`spawn ${command} ENOENT`) as NodeJS.ErrnoException;
 	err.code = "ENOENT";
 	err.syscall = "spawn";
@@ -839,22 +966,26 @@ export async function safeSpawnAsync(
 	return new Promise((resolve) => {
 		// Check for early abort
 		if (abortSignal?.aborted) {
+			const cause = new Error("Spawn aborted before start");
 			resolve({
 				stdout: "",
 				stderr: "",
 				status: null,
-				error: new Error("Spawn aborted before start"),
+				error: cause,
 				failure: "aborted",
+				spawnFailure: new SpawnFailureError("killed", cause.message, cause),
 			});
 			return;
 		}
 		if (timeout <= 0) {
+			const cause = new Error(`Process timed out after ${timeout}ms`);
 			resolve({
 				stdout: "",
 				stderr: "",
 				status: null,
-				error: new Error(`Process timed out after ${timeout}ms`),
+				error: cause,
 				failure: "timeout",
+				spawnFailure: new SpawnFailureError("timeout", cause.message, cause),
 			});
 			return;
 		}
@@ -865,6 +996,7 @@ export async function safeSpawnAsync(
 		let aborted = false;
 		let killed = false;
 		let outputTruncated = false;
+		let spawnErrored = false;
 		// #1109: the non-Windows SIGTERM→SIGKILL escalation timer (armed in
 		// killTree below). Stored per-call (never shared) so the close/error
 		// handlers can clear it if the child exits before it fires — same
@@ -989,13 +1121,19 @@ export async function safeSpawnAsync(
 		}
 
 		if (resolutionError) {
-			resolve({
-				stdout: "",
-				stderr: "",
-				status: null,
-				error: resolutionError,
-				failure: "spawn",
-			});
+			void classifySpawnFailure(resolutionError, {
+				command,
+				cwd: options?.cwd,
+			}).then((spawnFailure) =>
+				resolve({
+					stdout: "",
+					stderr: "",
+					status: null,
+					error: resolutionError,
+					failure: "spawn",
+					spawnFailure,
+				}),
+			);
 			return;
 		}
 
@@ -1016,13 +1154,18 @@ export async function safeSpawnAsync(
 			// a rejection here could surface as an unhandledRejection that crashes
 			// the host. Resolve the failure gracefully instead — same contract as an
 			// asynchronously-emitted `'error'` event (handled below).
-			resolve({
+			const cause = toError(err);
+			void classifySpawnFailure(cause, { command, cwd: options?.cwd }).then(
+				(spawnFailure) =>
+					resolve({
 				stdout: "",
 				stderr: "",
 				status: null,
-				error: err instanceof Error ? err : new Error(String(err)),
+				error: cause,
 				failure: "spawn",
-			});
+				spawnFailure,
+					}),
+			);
 			return;
 		}
 		if (options?.lifetimeCoupled && child.pid) {
@@ -1147,6 +1290,7 @@ export async function safeSpawnAsync(
 
 		// Process completion
 		child.on("close", async (code, signal) => {
+			if (spawnErrored) return;
 			closed = true;
 			clearTimeout(timeoutId);
 			abortSignal?.removeEventListener("abort", onAbort);
@@ -1160,34 +1304,40 @@ export async function safeSpawnAsync(
 
 			const outputInfo = outputTruncated ? { outputTruncated: true } : {};
 			if (timedOut) {
+				const cause = new Error(
+					`Process timed out after ${timeout}ms (killed with ${signal || "SIGTERM"})`,
+				);
 				resolve({
 					stdout,
 					stderr,
 					status: null,
-					error: new Error(
-						`Process timed out after ${timeout}ms (killed with ${signal || "SIGTERM"})`,
-					),
+					error: cause,
 					failure: "timeout",
+					spawnFailure: new SpawnFailureError("timeout", cause.message, cause),
 					...outputInfo,
 					resourceUsage,
 				});
 			} else if (aborted) {
+				const cause = new Error("Spawn aborted");
 				resolve({
 					stdout,
 					stderr,
 					status: null,
-					error: new Error("Spawn aborted"),
+					error: cause,
 					failure: "aborted",
+					spawnFailure: new SpawnFailureError("killed", cause.message, cause),
 					...outputInfo,
 					resourceUsage,
 				});
 			} else if (signal) {
+				const cause = new Error(`Process killed by signal: ${signal}`);
 				resolve({
 					stdout,
 					stderr,
 					status: null,
-					error: new Error(`Process killed by signal: ${signal}`),
+					error: cause,
 					failure: "signal",
+					spawnFailure: new SpawnFailureError("killed", cause.message, cause),
 					...outputInfo,
 					resourceUsage,
 				});
@@ -1197,6 +1347,7 @@ export async function safeSpawnAsync(
 		});
 
 		child.on("error", (err) => {
+			spawnErrored = true;
 			closed = true;
 			clearTimeout(timeoutId);
 			abortSignal?.removeEventListener("abort", onAbort);
@@ -1206,15 +1357,26 @@ export async function safeSpawnAsync(
 			let failure: SpawnFailureKind = "spawn";
 			if (aborted) failure = "aborted";
 			else if (timedOut) failure = "timeout";
-			resolve({
-				stdout,
-				stderr,
-				status: null,
-				error: err,
-				failure,
-				...(outputTruncated ? { outputTruncated: true } : {}),
-				resourceUsage,
-			});
+			const controlFailure = aborted
+				? new SpawnFailureError("killed", err.message, err)
+				: timedOut
+					? new SpawnFailureError("timeout", err.message, err)
+					: undefined;
+			const finish = (spawnFailure: SpawnFailureError): void =>
+				resolve({
+					stdout,
+					stderr,
+					status: null,
+					error: err,
+					failure,
+					spawnFailure,
+					...(outputTruncated ? { outputTruncated: true } : {}),
+					resourceUsage,
+				});
+			if (controlFailure) finish(controlFailure);
+			else {
+				void classifySpawnFailure(err, { command, cwd: options?.cwd }).then(finish);
+			}
 		});
 	});
 }
@@ -1323,11 +1485,17 @@ export function safeSpawn(
 			resolveEffectiveWindowsCwd(options?.cwd, spawnEnv) ?? options?.cwd;
 		const resolved = resolveWindowsCommand(command, options?.cwd, spawnEnv);
 		if (!resolved) {
+			const error = synthesizeEnoentError(command);
 			return {
 				stdout: "",
 				stderr: "",
 				status: null,
-				error: synthesizeEnoentError(command),
+				error,
+				failure: "spawn",
+				spawnFailure: classifySpawnFailureSync(error, {
+					command,
+					cwd: options?.cwd,
+				}),
 			};
 		}
 
@@ -1341,17 +1509,23 @@ export function safeSpawn(
 			// extensionless) `command` string — plus every arg.
 			const unsafeValue = findCmdUnsafeValue(resolved.resolvedPath, args);
 			if (unsafeValue !== undefined) {
+				const error = new Error(
+					`Refusing to spawn "${resolved.resolvedPath}" via cmd.exe: ` +
+						`${JSON.stringify(unsafeValue)} contains a character ("` +
+						`, %, !, or CR/LF) that cannot be safely escaped on a ` +
+						`cmd.exe /c command line (CWE-78, #817). Rename/quote the ` +
+						"value or invoke the tool without going through cmd.exe.",
+				);
 				return {
 					stdout: "",
 					stderr: "",
 					status: null,
-					error: new Error(
-						`Refusing to spawn "${resolved.resolvedPath}" via cmd.exe: ` +
-							`${JSON.stringify(unsafeValue)} contains a character ("` +
-							`, %, !, or CR/LF) that cannot be safely escaped on a ` +
-							`cmd.exe /c command line (CWE-78, #817). Rename/quote the ` +
-							"value or invoke the tool without going through cmd.exe.",
-					),
+					error,
+					failure: "spawn",
+					spawnFailure: classifySpawnFailureSync(error, {
+						command,
+						cwd: options?.cwd,
+					}),
 				};
 			}
 			spawnCmd = `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\cmd.exe`;
@@ -1378,11 +1552,15 @@ export function safeSpawn(
 			windowsVerbatimArguments,
 		});
 
+		const spawnFailure = result.error
+			? classifySpawnFailureSync(result.error, { command, cwd: options?.cwd })
+			: undefined;
 		return {
 			stdout: result.stdout?.toString() || "",
 			stderr: result.stderr?.toString() || "",
 			status: result.status,
 			error: result.error,
+			...(spawnFailure ? { failure: "spawn" as const, spawnFailure } : {}),
 		};
 	}
 
@@ -1400,11 +1578,15 @@ export function safeSpawn(
 		windowsHide: true,
 	});
 
+	const spawnFailure = result.error
+		? classifySpawnFailureSync(result.error, { command, cwd: options?.cwd })
+		: undefined;
 	return {
 		stdout: result.stdout?.toString() || "",
 		stderr: result.stderr?.toString() || "",
 		status: result.status,
 		error: result.error,
+		...(spawnFailure ? { failure: "spawn" as const, spawnFailure } : {}),
 	};
 }
 

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -112,6 +112,39 @@ function cwdIsUnresolvableSync(cwd: string | undefined): boolean {
 	}
 }
 
+
+/**
+ * Best-effort presence probe used ONLY to disambiguate ENOENT when the cwd is
+ * ALSO unresolvable (#1340 review): a genuinely missing tool must classify as
+ * tool-not-found even under a broken cwd, or auto-install can never repair it.
+ * Absolute commands are probed directly (with PATHEXT variants on Windows);
+ * bare names scan PATH. A relative-with-separator command under a broken cwd
+ * is genuinely ambiguous -- we err toward cwd-unresolvable there, because
+ * repairing the cwd is actionable while a reinstall loop (#1199) is not.
+ */
+function commandProbablyPresent(command: string): boolean | "ambiguous" {
+	const exts =
+		process.platform === "win32"
+			? ["", ...(process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)]
+			: [""];
+	const existsWithExt = (base: string): boolean => {
+		for (const ext of exts) {
+			try {
+				if (fs.existsSync(base + ext)) return true;
+			} catch {
+				// unreadable candidate -- keep probing
+			}
+		}
+		return false;
+	};
+	if (path.isAbsolute(command)) return existsWithExt(command);
+	if (command.includes("/") || command.includes("\\")) return "ambiguous";
+	for (const dir of (process.env.PATH ?? "").split(path.delimiter)) {
+		if (dir && existsWithExt(path.join(dir, command))) return true;
+	}
+	return false;
+}
+
 /** Classify a raw Node spawn error without discarding its errno-bearing Error. */
 export async function classifySpawnFailure(
 	error: unknown,
@@ -119,7 +152,11 @@ export async function classifySpawnFailure(
 ): Promise<SpawnFailureError> {
 	const cause = toError(error);
 	const code = errorCode(cause);
-	if (code === "ENOENT" && (await cwdIsUnresolvable(options.cwd))) {
+	if (
+		code === "ENOENT" &&
+		(await cwdIsUnresolvable(options.cwd)) &&
+		commandProbablyPresent(options.command) !== false
+	) {
 		return new SpawnFailureError(
 			"cwd-unresolvable",
 			`Cannot spawn ${options.command}: working directory is unresolvable (${options.cwd})`,
@@ -153,7 +190,11 @@ function classifySpawnFailureSync(
 ): SpawnFailureError {
 	const cause = toError(error);
 	const code = errorCode(cause);
-	if (code === "ENOENT" && cwdIsUnresolvableSync(options.cwd)) {
+	if (
+		code === "ENOENT" &&
+		cwdIsUnresolvableSync(options.cwd) &&
+		commandProbablyPresent(options.command) !== false
+	) {
 		return new SpawnFailureError(
 			"cwd-unresolvable",
 			`Cannot spawn ${options.command}: working directory is unresolvable (${options.cwd})`,

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -145,16 +145,20 @@ function commandProbablyPresent(command: string): boolean | "ambiguous" {
 	return false;
 }
 
-/** Classify a raw Node spawn error without discarding its errno-bearing Error. */
-export async function classifySpawnFailure(
-	error: unknown,
+/**
+ * Shared errno->bucket mapping. `cwdUnresolvable` is the only async-vs-sync
+ * difference between the two public classifiers, so it arrives as a resolved
+ * flag and everything else lives once (Sonar duplication finding, #1340).
+ */
+function classifyWithCwdFlag(
+	cause: Error,
 	options: { command: string; cwd?: string },
-): Promise<SpawnFailureError> {
-	const cause = toError(error);
+	cwdUnresolvable: boolean,
+): SpawnFailureError {
 	const code = errorCode(cause);
 	if (
 		code === "ENOENT" &&
-		(await cwdIsUnresolvable(options.cwd)) &&
+		cwdUnresolvable &&
 		commandProbablyPresent(options.command) !== false
 	) {
 		return new SpawnFailureError(
@@ -184,42 +188,25 @@ export async function classifySpawnFailure(
 	);
 }
 
+/** Classify a raw Node spawn error without discarding its errno-bearing Error. */
+export async function classifySpawnFailure(
+	error: unknown,
+	options: { command: string; cwd?: string },
+): Promise<SpawnFailureError> {
+	const cause = toError(error);
+	const needsCwdProbe = errorCode(cause) === "ENOENT";
+	const cwdUnresolvable = needsCwdProbe && (await cwdIsUnresolvable(options.cwd));
+	return classifyWithCwdFlag(cause, options, cwdUnresolvable);
+}
+
 function classifySpawnFailureSync(
 	error: unknown,
 	options: { command: string; cwd?: string },
 ): SpawnFailureError {
 	const cause = toError(error);
-	const code = errorCode(cause);
-	if (
-		code === "ENOENT" &&
-		cwdIsUnresolvableSync(options.cwd) &&
-		commandProbablyPresent(options.command) !== false
-	) {
-		return new SpawnFailureError(
-			"cwd-unresolvable",
-			`Cannot spawn ${options.command}: working directory is unresolvable (${options.cwd})`,
-			cause,
-		);
-	}
-	if (code === "ENOENT") {
-		return new SpawnFailureError(
-			"tool-not-found",
-			`Cannot spawn ${options.command}: tool not found (${cause.message})`,
-			cause,
-		);
-	}
-	if (code === "EACCES" || code === "EPERM") {
-		return new SpawnFailureError(
-			"permission-denied",
-			`Cannot spawn ${options.command}: permission denied`,
-			cause,
-		);
-	}
-	return new SpawnFailureError(
-		"spawn-failed",
-		`Cannot spawn ${options.command}: ${cause.message}`,
-		cause,
-	);
+	const needsCwdProbe = errorCode(cause) === "ENOENT";
+	const cwdUnresolvable = needsCwdProbe && cwdIsUnresolvableSync(options.cwd);
+	return classifyWithCwdFlag(cause, options, cwdUnresolvable);
 }
 
 export interface SafeSpawnOptions {

--- a/clients/sg-runner.ts
+++ b/clients/sg-runner.ts
@@ -397,16 +397,22 @@ export class SgRunner {
 	private failureForSpawnResult(result: {
 		error?: Error;
 		failure?: string;
+		spawnFailure?: SpawnResult["spawnFailure"];
 	}): SgFailureKind | undefined {
 		if (result.failure === "aborted") return "aborted";
-		if (result.failure === "timeout") return "timeout";
-		if (
-			result.error &&
-			/ENOENT|not found|not installed/i.test(result.error.message)
-		) {
-			return "unavailable";
+		switch (result.spawnFailure?.kind) {
+			case "tool-not-found":
+				return "unavailable";
+			case "timeout":
+				return "timeout";
+			case "killed":
+				return result.failure === "aborted" ? "aborted" : "cli-failure";
+			case "cwd-unresolvable":
+			case "permission-denied":
+			case "spawn-failed":
+			case undefined:
+				return result.error ? "cli-failure" : undefined;
 		}
-		return result.error ? "cli-failure" : undefined;
 	}
 
 	private formatPatternError(stderr: string, args: string[]): string {

--- a/tests/clients/dispatch/runners/runner-helpers.test.ts
+++ b/tests/clients/dispatch/runners/runner-helpers.test.ts
@@ -24,6 +24,11 @@ const { logSessionStartSpy } = vi.hoisted(() => ({
 	logSessionStartSpy: vi.fn(),
 }));
 
+const missingSpawnFailure = () => ({
+	kind: "tool-not-found" as const,
+	cause: Object.assign(new Error("missing"), { code: "ENOENT" }),
+}) as never;
+
 vi.mock("../../../../clients/sessionstart-logger.js", () => ({
 	logSessionStart: logSessionStartSpy,
 }));
@@ -177,6 +182,7 @@ describe("runner-helpers availability checker", () => {
 			status: 1,
 			error: Object.assign(new Error("missing"), { code: "ENOENT" }),
 			failure: "spawn",
+			spawnFailure: missingSpawnFailure(),
 		});
 		vi.mocked(installerMod.ensureTool).mockResolvedValue("ruff");
 		const checker = createAvailabilityChecker("ruff");
@@ -274,6 +280,7 @@ describe("runner-helpers availability checker", () => {
 				status: null,
 				error: Object.assign(new Error("missing"), { code: "ENOENT" }),
 				failure: "spawn",
+				spawnFailure: missingSpawnFailure(),
 			});
 		vi.mocked(installerMod.isSpawnableCommand).mockResolvedValueOnce(false);
 		// Scoped count: earlier tests in this file legitimately trigger the
@@ -316,6 +323,7 @@ describe("runner-helpers availability checker", () => {
 			status: null,
 			error: Object.assign(new Error("spawn missing ENOENT"), { code: "ENOENT" }),
 			failure: "spawn",
+			spawnFailure: missingSpawnFailure(),
 		});
 		vi.mocked(installerMod.ensureTool).mockResolvedValue(undefined);
 
@@ -354,6 +362,7 @@ describe("runner-helpers availability checker", () => {
 			status: null,
 			error: Object.assign(new Error("spawn missing ENOENT"), { code: "ENOENT" }),
 			failure: "spawn",
+			spawnFailure: missingSpawnFailure(),
 		});
 		const checker = createAvailabilityChecker("missing-tool-success");
 

--- a/tests/clients/jscpd-client.test.ts
+++ b/tests/clients/jscpd-client.test.ts
@@ -47,6 +47,7 @@ describe("jscpd-client", () => {
 				.mockResolvedValueOnce({
 					error: Object.assign(new Error("not found"), { code: "ENOENT" }),
 					failure: "spawn",
+					spawnFailure: { kind: "tool-not-found" } as never,
 					status: 1,
 					stdout: "",
 					stderr: "",
@@ -68,6 +69,7 @@ describe("jscpd-client", () => {
 		vi.mocked(safeSpawnMod.safeSpawnAsync).mockResolvedValue({
 			error: Object.assign(new Error("not found"), { code: "ENOENT" }),
 			failure: "spawn",
+			spawnFailure: { kind: "tool-not-found" } as never,
 			status: 1,
 			stdout: "",
 			stderr: "",

--- a/tests/clients/lsp/resolve-and-launch-fallback.test.ts
+++ b/tests/clients/lsp/resolve-and-launch-fallback.test.ts
@@ -6,14 +6,18 @@ const { launchLSP } = vi.hoisted(() => ({ launchLSP: vi.fn() }));
 const { logLatency } = vi.hoisted(() => ({ logLatency: vi.fn() }));
 vi.mock("../../../clients/lsp/launch.js", () => ({ launchLSP }));
 vi.mock("../../../clients/latency-logger.js", () => ({ logLatency }));
+const { ensureTool } = vi.hoisted(() => ({ ensureTool: vi.fn(async () => null) }));
 vi.mock("../../../clients/installer/index.js", () => ({
-	ensureTool: vi.fn(async () => null),
+	ensureTool,
 	getToolEnvironment: () => ({}),
 }));
 
 import { resolveAndLaunch } from "../../../clients/lsp/server.ts";
+import { SpawnFailureError } from "../../../clients/safe-spawn.js";
 
 const fakeProc = { stdout: {}, stderr: {} } as never;
+const toolNotFound = (message: string) =>
+	Object.assign(new Error(message), { kind: "tool-not-found" as const });
 const failedPhases = () =>
 	logLatency.mock.calls.filter(
 		(c) => c[0]?.phase === "lsp_launch_candidate_failed",
@@ -45,8 +49,8 @@ describe("resolveAndLaunch — fallback failures are deferred", () => {
 
 	it("logs every candidate failure when ALL candidates fail", async () => {
 		launchLSP
-			.mockRejectedValueOnce(new Error("fail a"))
-			.mockRejectedValueOnce(new Error("fail b"));
+			.mockRejectedValueOnce(toolNotFound("fail a"))
+			.mockRejectedValueOnce(toolNotFound("fail b"));
 
 		const result = await resolveAndLaunch(
 			{ candidates: ["a", "b"], args: [], cwd: "/tmp/p" }, // no managedToolId
@@ -55,5 +59,23 @@ describe("resolveAndLaunch — fallback failures are deferred", () => {
 
 		expect(result).toBeUndefined();
 		expect(failedPhases()).toHaveLength(2);
+	});
+
+	it("does not install when a present tool fails because cwd is unresolvable", async () => {
+		const cause = Object.assign(new Error("spawn node ENOENT"), { code: "ENOENT" });
+		launchLSP.mockRejectedValue(
+			new SpawnFailureError("cwd-unresolvable", "working directory missing", cause),
+		);
+
+		await expect(
+			resolveAndLaunch({
+				candidates: [process.execPath],
+				args: ["--version"],
+				cwd: "/definitely/missing/pi-lens-cwd",
+				managedToolId: "typescript-language-server",
+			}, true),
+		).rejects.toMatchObject({ kind: "cwd-unresolvable" });
+
+		expect(ensureTool).not.toHaveBeenCalled();
 	});
 });

--- a/tests/clients/lsp/runtime-install-discovery.test.ts
+++ b/tests/clients/lsp/runtime-install-discovery.test.ts
@@ -32,6 +32,8 @@ import { ensureTool } from "../../../clients/installer/index.js";
 
 const isWin = process.platform === "win32";
 const sep = (...parts: string[]) => path.join(...parts);
+const toolNotFound = (message = "not found") =>
+	Object.assign(new Error(message), { kind: "tool-not-found" as const });
 
 describe("canonical-bin candidates (#241)", () => {
 	const savedGopath = process.env.GOPATH;
@@ -84,7 +86,7 @@ describe("runtime-install / discovery server wiring (#241)", () => {
 		logLatency.mockReset();
 		// Reject every candidate so resolveAndLaunch exhausts the list; we only
 		// inspect WHICH commands it tried. allowInstall:false keeps installs off.
-		launchLSP.mockRejectedValue(new Error("not found"));
+		launchLSP.mockRejectedValue(toolNotFound());
 	});
 
 	const triedCommands = () => launchLSP.mock.calls.map((c) => String(c[0]));
@@ -173,7 +175,7 @@ describe("runtime-install / discovery server wiring (#241)", () => {
 			if (command === globalPyrightLangserver) {
 				return { kill: vi.fn() } as never;
 			}
-			throw new Error(`not found: ${command}`);
+			throw toolNotFound(`not found: ${command}`);
 		});
 
 		try {

--- a/tests/clients/lsp/server-policy.test.ts
+++ b/tests/clients/lsp/server-policy.test.ts
@@ -4,6 +4,9 @@ import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { removeTempDirSync } from "../test-utils.js";
 
+const toolNotFound = (message = "ENOENT: command not found") =>
+	Object.assign(new Error(message), { kind: "tool-not-found" as const });
+
 const observedReadFileSync = vi.hoisted(() => vi.fn());
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>();
@@ -285,7 +288,7 @@ describe("lsp server policy", () => {
 		);
 		dirs.push(tmp);
 
-		launchLSP.mockRejectedValue(new Error("ENOENT: command not found"));
+		launchLSP.mockRejectedValue(toolNotFound());
 
 		const spawned = await CSharpServer.spawn(tmp, { allowInstall: false });
 		expect(spawned).toBeUndefined();
@@ -633,7 +636,7 @@ describe("lsp server policy", () => {
 		);
 		dirs.push(tmp);
 
-		launchLSP.mockRejectedValue(new Error("ENOENT: command not found"));
+		launchLSP.mockRejectedValue(toolNotFound());
 
 		const spawned = await BashServer.spawn(tmp, { allowInstall: false });
 		expect(spawned).toBeUndefined();
@@ -669,7 +672,7 @@ describe("lsp server policy", () => {
 		fs.writeFileSync(path.join(tmp, "package.json"), "{}\n");
 
 		process.env.PI_LENS_DISABLE_LSP_INSTALL = "1";
-		launchLSP.mockRejectedValue(new Error("ENOENT: command not found"));
+		launchLSP.mockRejectedValue(toolNotFound());
 
 		const spawned = await SvelteServer.spawn(tmp);
 		expect(spawned?.process).toBeUndefined();
@@ -683,7 +686,7 @@ describe("lsp server policy", () => {
 		dirs.push(tmp);
 		fs.writeFileSync(path.join(tmp, "package.json"), "{}\n");
 
-		launchLSP.mockRejectedValue(new Error("ENOENT: command not found"));
+		launchLSP.mockRejectedValue(toolNotFound());
 
 		const spawned = await SvelteServer.spawn(tmp, { allowInstall: false });
 		expect(spawned?.process).toBeUndefined();
@@ -776,7 +779,7 @@ describe("lsp server policy", () => {
 					pid: 1234,
 				};
 			}
-			throw new Error(`unexpected command: ${command}`);
+			throw toolNotFound(`unexpected command: ${command}`);
 		});
 
 		const spawned = await PythonServer.spawn(tmp, { allowInstall: true });
@@ -813,7 +816,7 @@ describe("lsp server policy", () => {
 					pid: 5678,
 				};
 			}
-			throw new Error(`unexpected command: ${command}`);
+			throw toolNotFound(`unexpected command: ${command}`);
 		});
 
 		const spawned = await PythonServer.spawn(tmp, { allowInstall: true });
@@ -850,7 +853,7 @@ describe("lsp server policy", () => {
 					pid: 4321,
 				};
 			}
-			throw new Error(`unexpected command: ${command}`);
+			throw toolNotFound(`unexpected command: ${command}`);
 		});
 
 		const spawned = await PythonServer.spawn(tmp, { allowInstall: true });
@@ -892,7 +895,7 @@ describe("lsp server policy", () => {
 					pid: 4321,
 				};
 			}
-			throw new Error(`unexpected command: ${command}`);
+			throw toolNotFound(`unexpected command: ${command}`);
 		});
 
 		const spawned = await TomlServer.spawn(tmp, { allowInstall: true });
@@ -921,7 +924,7 @@ describe("lsp server policy", () => {
 					pid: 2468,
 				};
 			}
-			throw new Error(`unexpected command: ${command}`);
+			throw toolNotFound(`unexpected command: ${command}`);
 		});
 
 		const spawned = await KotlinServer.spawn(tmp, { allowInstall: true });
@@ -937,7 +940,7 @@ describe("lsp server policy", () => {
 		ensureTool.mockResolvedValue(path.join(tmp, "bin", "zls.exe"));
 		launchLSP.mockImplementation(async (command: string) => {
 			if (command === "zls") {
-				throw new Error("ENOENT: command not found");
+				throw toolNotFound();
 			}
 			if (command.endsWith(path.join("bin", "zls.exe"))) {
 				return {
@@ -948,7 +951,7 @@ describe("lsp server policy", () => {
 					pid: 9753,
 				};
 			}
-			throw new Error(`unexpected command: ${command}`);
+			throw toolNotFound(`unexpected command: ${command}`);
 		});
 
 		const spawned = await ZigServer.spawn(tmp, { allowInstall: true });
@@ -1183,7 +1186,14 @@ describe("lsp server policy", () => {
 			launchLSP.mockImplementation(async (command: string) => {
 				calls.push(`launch(${command})`);
 				if (calls.length <= 2) {
-					throw new Error("BROKEN");
+					throw Object.assign(new Error("tool not found"), {
+						kind: "tool-not-found",
+					});
+				}
+				if (command === "rust-analyzer") {
+					throw Object.assign(new Error("tool not found"), {
+						kind: "tool-not-found",
+					});
 				}
 				if (command === MANAGED) {
 					return {
@@ -1194,7 +1204,7 @@ describe("lsp server policy", () => {
 						pid: 9999,
 					};
 				}
-				throw new Error(`unexpected: ${command} (call #${calls.length})`);
+				throw toolNotFound(`unexpected: ${command} (call #${calls.length})`);
 			});
 
 			ensureTool.mockImplementation(

--- a/tests/clients/ruff-client-dedupe.test.ts
+++ b/tests/clients/ruff-client-dedupe.test.ts
@@ -72,6 +72,7 @@ describe("RuffClient.ensureAvailable() — in-flight dedupe (#120)", () => {
 				status: 1,
 				error: Object.assign(new Error("not found"), { code: "ENOENT" }),
 				failure: "spawn",
+				spawnFailure: { kind: "tool-not-found" } as never,
 				stdout: "",
 				stderr: "",
 			})
@@ -98,6 +99,7 @@ describe("RuffClient.ensureAvailable() — in-flight dedupe (#120)", () => {
 			status: 1,
 			error: Object.assign(new Error("not found"), { code: "ENOENT" }),
 			failure: "spawn",
+			spawnFailure: { kind: "tool-not-found" } as never,
 			stdout: "",
 			stderr: "",
 		});

--- a/tests/clients/safe-spawn-failure-taxonomy.test.ts
+++ b/tests/clients/safe-spawn-failure-taxonomy.test.ts
@@ -28,6 +28,25 @@ describe("safe-spawn typed failure taxonomy", () => {
 		}
 	});
 
+	it("a genuinely missing tool classifies tool-not-found even under a broken cwd (#1340 review)", async () => {
+		const parent = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-spawn-cwd-"));
+		const missingCwd = path.join(parent, "gone");
+		try {
+			const result = await safeSpawnAsync(
+				"pi-lens-definitely-not-a-real-tool-1340",
+				["--version"],
+				{ cwd: missingCwd, timeout: 5_000 },
+			);
+
+			expect(result.failure).toBe("spawn");
+			// The cwd probe must NOT shadow the missing executable: reinstall is
+			// the correct repair here, and it keys on tool-not-found only.
+			expect(result.spawnFailure?.kind).toBe("tool-not-found");
+		} finally {
+			removeTempDirSync(parent);
+		}
+	});
+
 	it("classifies errno intent while preserving the original Error as cause", async () => {
 		const missing = Object.assign(new Error("spawn missing ENOENT"), { code: "ENOENT" });
 		const denied = Object.assign(new Error("spawn denied EACCES"), { code: "EACCES" });

--- a/tests/clients/safe-spawn-failure-taxonomy.test.ts
+++ b/tests/clients/safe-spawn-failure-taxonomy.test.ts
@@ -1,0 +1,63 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	classifySpawnFailure,
+	safeSpawnAsync,
+} from "../../clients/safe-spawn.js";
+import { removeTempDirSync } from "./test-utils.js";
+
+describe("safe-spawn typed failure taxonomy", () => {
+	it("distinguishes an unresolvable cwd from a missing present tool", async () => {
+		const parent = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-spawn-cwd-"));
+		const missingCwd = path.join(parent, "gone");
+		try {
+			const result = await safeSpawnAsync(process.execPath, ["--version"], {
+				cwd: missingCwd,
+				timeout: 5_000,
+			});
+
+			expect(result.failure).toBe("spawn");
+			expect(result.spawnFailure?.kind).toBe("cwd-unresolvable");
+			expect(
+				(result.spawnFailure?.cause as NodeJS.ErrnoException | undefined)?.code,
+			).toBe("ENOENT");
+		} finally {
+			removeTempDirSync(parent);
+		}
+	});
+
+	it("classifies errno intent while preserving the original Error as cause", async () => {
+		const missing = Object.assign(new Error("spawn missing ENOENT"), { code: "ENOENT" });
+		const denied = Object.assign(new Error("spawn denied EACCES"), { code: "EACCES" });
+		const other = Object.assign(new Error("spawn busy EBUSY"), { code: "EBUSY" });
+
+		const missingFailure = await classifySpawnFailure(missing, { command: "missing" });
+		const deniedFailure = await classifySpawnFailure(denied, { command: "denied" });
+		const otherFailure = await classifySpawnFailure(other, { command: "busy" });
+
+		expect(missingFailure.kind).toBe("tool-not-found");
+		expect(missingFailure.cause).toBe(missing);
+		expect(deniedFailure.kind).toBe("permission-denied");
+		expect(deniedFailure.cause).toBe(denied);
+		expect(otherFailure.kind).toBe("spawn-failed");
+		expect((otherFailure.cause as NodeJS.ErrnoException).code).toBe("EBUSY");
+	});
+
+	it("exposes timeout and killed as typed process-control failures", async () => {
+		const timeout = await safeSpawnAsync(process.execPath, ["--version"], {
+			timeout: 0,
+		});
+		const controller = new AbortController();
+		controller.abort();
+		const killed = await safeSpawnAsync(process.execPath, ["--version"], {
+			signal: controller.signal,
+		});
+
+		expect(timeout.spawnFailure?.kind).toBe("timeout");
+		expect(timeout.spawnFailure?.cause).toBe(timeout.error);
+		expect(killed.spawnFailure?.kind).toBe("killed");
+		expect(killed.spawnFailure?.cause).toBe(killed.error);
+	});
+});

--- a/tests/clients/sg-runner.test.ts
+++ b/tests/clients/sg-runner.test.ts
@@ -42,6 +42,29 @@ describe("SgRunner", () => {
 		ensureTool.mockResolvedValue(null);
 	});
 
+	describe("spawn-failure taxonomy consumption (#1214/#1199)", () => {
+		it("cwd-unresolvable with an ENOENT cause is NOT unavailable and does NOT reinstall", async () => {
+			const enoent = Object.assign(new Error("spawn ast-grep ENOENT"), {
+				code: "ENOENT",
+			});
+			safeSpawnAsync.mockResolvedValue({
+				status: null,
+				error: enoent,
+				failure: "spawn",
+				spawnFailure: { kind: "cwd-unresolvable", cause: enoent },
+				stdout: "",
+				stderr: "",
+			});
+			const { SgRunner } = await import("../../clients/sg-runner.js");
+			const runner = new SgRunner();
+			const result = await runner.execRaw(["run", "--pattern", "x"]);
+			// A raw `error.code === "ENOENT"` consumer regression maps this to
+			// unavailable and drives the #1199 reinstall loop — both must stay off.
+			expect(result.failure).not.toBe("unavailable");
+			expect(ensureTool).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("ensureAvailable()", () => {
 		it("returns true when ast-grep is in PATH", async () => {
 			safeSpawnAsync.mockResolvedValueOnce({


### PR DESCRIPTION
Salvaged from an interrupted worker run (implementation + focused verification complete; final full-suite lap cut short — CI takes it).

Implements #1214's typed failure discriminant at the safe-spawn boundary: `tool-not-found` | `cwd-unresolvable` | `permission-denied` | `spawn-failed` (original errno as `cause`) | `timeout` | `killed`.

- `sg-runner.ts` and `lsp/launch.ts` no longer string-match ENOENT; reinstall triggers on `tool-not-found` ONLY
- Regression: unresolvable cwd + present tool does NOT mark the tool unavailable and does NOT reinstall (the #1199 loop, made unreproducible) — platform-independent, no runIf(win32) gating
- Hardening beyond the issue: LSP fallback installation requires EVERY direct failure to be `tool-not-found`, so a mixed failure set can't become 'repairable'
- Old raw "not found" LSP mocks converted to the typed shape
- Focused suites: 112/112 in-worktree (106/106 on the salvage re-run); neighbors 143 green

Closes #1214

🤖 Generated with [Claude Code](https://claude.com/claude-code)