### PR TITLE
feat(dispatch): Helm chart lint runner (refs #1283, slice A)

### DIFF
--- a/.changelog/feat-1283-helm-lint.md
+++ b/.changelog/feat-1283-helm-lint.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Helm chart linting (refs #1283, slice A)** — YAML and `.tpl` edits within a chart now run one bounded, canonical-root-deduplicated `helm lint`; warnings remain advisory and chart/template errors block. Rendered-manifest validation remains deferred to slice B.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # pi-lens — agent context
 
+Helm chart linting uses the shared workspace-topology `Chart.yaml` marker. YAML
+and `.tpl` edits inside a chart dispatch one canonical-root-deduplicated,
+bounded `helm lint` pass through the ordinary typed availability/install seam.
+It is smart-default and read-only; rendered-manifest validation remains deferred
+to #1283 slice B.
+
 ## Maintaining this file (do this on every commit)
 
 AGENTS.md is the durable context handed to every agent that works on pi-lens. **Update it as part of the same commit that changes the world it describes** — never as a follow-up:

--- a/clients/dispatch/plan.ts
+++ b/clients/dispatch/plan.ts
@@ -139,6 +139,11 @@ export const LANGUAGE_CAPABILITY_MATRIX: Record<
 			{ mode: "all", runnerIds: ["actionlint"], filterKinds: ["yaml"] },
 		],
 	},
+	"helm-template": {
+		name: "Helm Template Linting",
+		capabilities: ["lint"],
+		writeGroups: [primary("helm-template")],
+	},
 	sql: {
 		name: "SQL Processing",
 		capabilities: ["format", "lint"],

--- a/clients/dispatch/runners/helm-lint.ts
+++ b/clients/dispatch/runners/helm-lint.ts
@@ -1,0 +1,187 @@
+import * as path from "node:path";
+import { PathKeyedMap } from "../../path-keyed-map.js";
+import { normalizeMapKey } from "../../path-utils.js";
+import { safeSpawnAsync } from "../../safe-spawn.js";
+import { findNearestDirWithMarker } from "../../workspace-topology.js";
+import { PRIORITY } from "../priorities.js";
+import type {
+	Diagnostic,
+	DispatchContext,
+	RunnerDefinition,
+	RunnerResult,
+} from "../types.js";
+import {
+	createAvailabilityChecker,
+	resolveAvailableOrInstall,
+	type AvailabilityOutcome,
+} from "./utils/runner-helpers.js";
+
+const helm = createAvailabilityChecker("helm", ".exe");
+const inFlightByChartRoot = new PathKeyedMap<Promise<RunnerResult>>(
+	normalizeMapKey,
+);
+const HELM_LINT_TIMEOUT_MS = 30_000;
+
+const SKIPPED: RunnerResult = {
+	status: "skipped",
+	diagnostics: [],
+	semantic: "none",
+};
+
+function isWithin(root: string, candidate: string): boolean {
+	const relative = path.relative(
+		normalizeMapKey(root),
+		normalizeMapKey(candidate),
+	);
+	return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+function diagnosticLocation(
+	message: string,
+	chartRoot: string,
+): { filePath: string; line?: number; message: string } {
+	const location = message.match(
+		/(?:^|\s)([^:\r\n]+\.(?:ya?ml|tpl|json))(?::(\d+))?(?::\d+)?(?::|\s)/i,
+	);
+	if (!location) {
+		return { filePath: path.join(chartRoot, "Chart.yaml"), message };
+	}
+	const candidate = path.resolve(chartRoot, location[1]);
+	return {
+		filePath: isWithin(chartRoot, candidate)
+			? candidate
+			: path.join(chartRoot, "Chart.yaml"),
+		line: location[2] ? Number(location[2]) : undefined,
+		message,
+	};
+}
+
+export function parseHelmLintOutput(raw: string, chartRoot: string): Diagnostic[] {
+	const diagnostics: Diagnostic[] = [];
+	for (const line of raw.split(/\r?\n/)) {
+		const match = line.trim().match(/^\[(INFO|WARNING|ERROR)\]\s*(.+)$/);
+		if (!match) continue;
+		const level = match[1];
+		const location = diagnosticLocation(match[2].trim(), chartRoot);
+		const severity = level === "ERROR" ? "error" : level === "WARNING" ? "warning" : "info";
+		diagnostics.push({
+			id: `helm-lint-${diagnostics.length + 1}-${level.toLowerCase()}`,
+			message: location.message,
+			filePath: location.filePath,
+			line: location.line,
+			column: 1,
+			severity,
+			semantic: severity === "error" ? "blocking" : "warning",
+			tool: "helm-lint",
+			rule: level.toLowerCase(),
+			fixable: false,
+		});
+	}
+	return diagnostics;
+}
+
+function failedResult(kind: string, message: string): RunnerResult {
+	return {
+		status: "failed",
+		diagnostics: [],
+		semantic: "warning",
+		failureKind: kind,
+		failureMessage: message.slice(0, 200),
+	};
+}
+
+async function lintChart(chartRoot: string, cwd: string): Promise<RunnerResult> {
+	const cmd = await resolveAvailableOrInstall(helm, "helm", cwd);
+	if (!cmd) {
+		const outcome: AvailabilityOutcome | null = helm.getOutcome(cwd);
+		return {
+			status: "failed",
+			diagnostics: [],
+			semantic: "warning",
+			failureKind: "unavailable",
+			failureMessage: `helm unavailable (${outcome ?? "unknown"})`,
+		};
+	}
+
+	const result = await safeSpawnAsync(cmd, ["lint", chartRoot], {
+		cwd,
+		timeout: HELM_LINT_TIMEOUT_MS,
+		deadlineAt: Date.now() + HELM_LINT_TIMEOUT_MS,
+		resourceLabel: "helm-lint",
+	});
+	const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+	const diagnostics = parseHelmLintOutput(output, chartRoot);
+	const typedFailure = result.spawnFailure?.kind;
+	if (typedFailure) {
+		const failureKind =
+			typedFailure === "tool-not-found"
+				? "unavailable"
+				: typedFailure === "timeout"
+					? "timeout"
+					: typedFailure === "killed" && result.failure === "aborted"
+						? "aborted"
+						: "server_error";
+		return failedResult(
+			failureKind,
+			result.error?.message || `helm lint ${typedFailure}`,
+		);
+	}
+	if (result.failure) {
+		return failedResult(
+			result.failure === "timeout" ? "timeout" : result.failure,
+			result.error?.message || `helm lint ${result.failure}`,
+		);
+	}
+	if (result.outputTruncated) {
+		return failedResult(
+			"parser_error",
+			"helm lint output was truncated before parsing completed",
+		);
+	}
+	const hasErrorDiagnostic = diagnostics.some(
+		(diagnostic) => diagnostic.severity === "error",
+	);
+	if (result.status !== 0 && !hasErrorDiagnostic) {
+		return failedResult(
+			output.trim() ? "parser_error" : "server_error",
+			output.trim() || "helm lint exited without an error diagnostic",
+		);
+	}
+	return {
+		status: "succeeded",
+		diagnostics,
+		semantic: diagnostics.some((item) => item.severity === "error")
+			? "blocking"
+			: diagnostics.length > 0
+				? "warning"
+				: "none",
+	};
+}
+
+const helmLintRunner: RunnerDefinition = {
+	id: "helm-lint",
+	appliesTo: ["yaml", "helm-template"],
+	priority: PRIORITY.GENERAL_ANALYSIS,
+	enabledByDefault: true,
+	skipTestFiles: false,
+	timeoutMs: 35_000,
+
+	async run(ctx: DispatchContext): Promise<RunnerResult> {
+		const workspaceRoot = path.resolve(ctx.projectRoot ?? ctx.cwd);
+		const startDir = path.dirname(path.resolve(ctx.filePath));
+		const discovered = findNearestDirWithMarker(startDir, "chartYamlPath");
+		if (!discovered) return SKIPPED;
+		const chartRoot = path.resolve(discovered);
+		if (!isWithin(workspaceRoot, chartRoot)) return SKIPPED;
+		const existing = inFlightByChartRoot.get(chartRoot);
+		if (existing) return existing;
+		const promise = lintChart(chartRoot, ctx.cwd).finally(() => {
+			if (inFlightByChartRoot.get(chartRoot) === promise)
+				inFlightByChartRoot.delete(chartRoot);
+		});
+		inFlightByChartRoot.set(chartRoot, promise);
+		return promise;
+	},
+};
+
+export default helmLintRunner;

--- a/clients/dispatch/runners/helm-lint.ts
+++ b/clients/dispatch/runners/helm-lint.ts
@@ -60,7 +60,17 @@ export function parseHelmLintOutput(raw: string, chartRoot: string): Diagnostic[
 	const diagnostics: Diagnostic[] = [];
 	for (const line of raw.split(/\r?\n/)) {
 		const match = line.trim().match(/^\[(INFO|WARNING|ERROR)\]\s*(.+)$/);
-		if (!match) continue;
+		if (!match) {
+			// helm indents multi-line diagnostic detail under its [LEVEL] header
+			// (#1342 review): fold continuation text into the open diagnostic
+			// instead of silently dropping it.
+			const last = diagnostics[diagnostics.length - 1];
+			if (last && /^\s+\S/.test(line)) {
+				last.message += `
+${line.trim()}`;
+			}
+			continue;
+		}
 		const level = match[1];
 		const location = diagnosticLocation(match[2].trim(), chartRoot);
 		const severity = level === "ERROR" ? "error" : level === "WARNING" ? "warning" : "info";

--- a/clients/dispatch/runners/index.ts
+++ b/clients/dispatch/runners/index.ts
@@ -18,6 +18,7 @@ import gleamCheckRunner from "./gleam-check.js";
 import goVetRunner from "./go-vet.js";
 import golangciRunner from "./golangci-lint.js";
 import hadolintRunner from "./hadolint.js";
+import helmLintRunner from "./helm-lint.js";
 import htmlhintRunner from "./htmlhint.js";
 import javacRunner from "./javac.js";
 import ktlintRunner from "./ktlint.js";
@@ -85,6 +86,7 @@ export function registerDefaultRunners(registry: RunnerRegistry): void {
 	registry.register(factRulesRunner); // FactRule pipeline — all registered rules (priority 21)
 	registry.register(htmlhintRunner); // HTML linting — tag pairs, attribute rules (priority 20)
 	registry.register(hadolintRunner); // Dockerfile linting — syntax, best practices (priority 20)
+	registry.register(helmLintRunner); // Helm chart linting (priority 20)
 	registry.register(valeRunner); // Prose/style linting for Markdown — config-gated (.vale.ini) (priority 30)
 	registry.register(phpLintRunner); // PHP syntax validation via php -l (priority 20)
 	registry.register(psScriptAnalyzerRunner); // PowerShell linting via PSScriptAnalyzer module (priority 20)

--- a/clients/file-kinds.ts
+++ b/clients/file-kinds.ts
@@ -23,6 +23,7 @@ export type FileKind =
 	| "gleam" // Gleam
 	| "go" // Go
 	| "haskell" // Haskell
+	| "helm-template" // Helm Go-template helper
 	| "html" // HTML
 	| "java" // Java
 	| "json" // JSON
@@ -131,6 +132,9 @@ export const KIND_EXTENSIONS: Record<FileKind, readonly string[]> = {
 	haskell: [
 		".hs",
 		".lhs",
+	],
+	"helm-template": [
+		".tpl",
 	],
 	html: [
 		".htm",
@@ -373,6 +377,7 @@ export const CODE_KINDS: ReadonlySet<FileKind> = new Set<FileKind>([
 	"gleam",
 	"go",
 	"haskell",
+	"helm-template",
 	"java",
 	"jsts",
 	"kotlin",
@@ -461,6 +466,7 @@ export function getFileKindLabel(kind: FileKind): string {
 		lua: "Lua",
 		zig: "Zig",
 		haskell: "Haskell",
+		"helm-template": "Helm template",
 		elixir: "Elixir",
 		gleam: "Gleam",
 		ocaml: "OCaml",
@@ -536,6 +542,7 @@ export function getLanguageId(kind: FileKind): string {
 		lua: "lua",
 		zig: "zig",
 		haskell: "haskell",
+		"helm-template": "helm",
 		elixir: "elixir",
 		gleam: "gleam",
 		ocaml: "ocaml",

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -604,6 +604,25 @@ export const TOOLS: ToolDefinition[] = [
 		},
 	},
 	{
+		id: "helm",
+		name: "Helm",
+		checkCommand: "helm",
+		checkArgs: ["version", "--short"],
+		installStrategy: "github",
+		binaryName: "helm",
+		github: {
+			repo: "helm/helm",
+			assetMatch: archAssetMatch({
+				linux: { x64: "linux-amd64.tar.gz", arm64: "linux-arm64.tar.gz" },
+				darwin: { x64: "darwin-amd64.tar.gz", arm64: "darwin-arm64.tar.gz" },
+				win32: { x64: "windows-amd64.zip", arm64: "windows-arm64.zip" },
+			}),
+			// Release archives nest the executable under an OS/arch directory;
+			// the installer searches recursively and adds the Windows suffix.
+			binaryInArchive: "helm",
+		},
+	},
+	{
 		// Opengrep: a single standalone binary per platform on GitHub releases —
 		// no login, no telemetry (the reason for switching off Semgrep, #111).
 		id: "opengrep",
@@ -3906,6 +3925,7 @@ export const GITHUB_TOOLS = [
 	"terraform-ls",
 	"zls",
 	"hadolint",
+	"helm",
 	"gitleaks",
 	"taplo",
 	"vale",

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -612,11 +612,14 @@ export const TOOLS: ToolDefinition[] = [
 		binaryName: "helm",
 		github: {
 			repo: "helm/helm",
-			assetMatch: archAssetMatch({
-				linux: { x64: "linux-amd64.tar.gz", arm64: "linux-arm64.tar.gz" },
-				darwin: { x64: "darwin-amd64.tar.gz", arm64: "darwin-arm64.tar.gz" },
-				win32: { x64: "windows-amd64.zip", arm64: "windows-arm64.zip" },
-			}),
+			assetMatch: (platform, arch) => {
+				// helm publishes per-OS archives: tar.gz for POSIX, zip for Windows.
+				const cpu = arch === "arm64" ? "arm64" : "amd64";
+				if (platform === "linux") return `linux-${cpu}.tar.gz`;
+				if (platform === "darwin") return `darwin-${cpu}.tar.gz`;
+				if (platform === "win32") return `windows-${cpu}.zip`;
+				return undefined;
+			},
 			// Release archives nest the executable under an OS/arch directory;
 			// the installer searches recursively and adds the Windows suffix.
 			binaryInArchive: "helm",

--- a/clients/language-policy.ts
+++ b/clients/language-policy.ts
@@ -76,6 +76,7 @@ export const LANGUAGE_POLICY: Record<FileKind, LanguagePolicy> = {
 	lua: { lspCapable: true },
 	zig: { lspCapable: true },
 	haskell: { lspCapable: true },
+	"helm-template": { lspCapable: false },
 	elixir: { lspCapable: true },
 	gleam: { lspCapable: true },
 	ocaml: { lspCapable: true },
@@ -139,7 +140,7 @@ const PRIMARY_DISPATCH_GROUPS: Partial<Record<FileKind, RunnerGroup>> = {
 	},
 	yaml: {
 		mode: "all",
-		runnerIds: ["lsp", "yamllint", "trivy-config"],
+		runnerIds: ["lsp", "yamllint", "trivy-config", "helm-lint"],
 		filterKinds: ["yaml"],
 	},
 	sql: {
@@ -201,6 +202,11 @@ const PRIMARY_DISPATCH_GROUPS: Partial<Record<FileKind, RunnerGroup>> = {
 	lua: { mode: "fallback", runnerIds: ["lsp"], filterKinds: ["lua"] },
 	zig: { mode: "all", runnerIds: ["lsp", "zig-check"], filterKinds: ["zig"] },
 	haskell: { mode: "fallback", runnerIds: ["lsp"], filterKinds: ["haskell"] },
+	"helm-template": {
+		mode: "all",
+		runnerIds: ["helm-lint"],
+		filterKinds: ["helm-template"],
+	},
 	elixir: {
 		mode: "all",
 		runnerIds: ["lsp", "elixir-check", "credo"],

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -847,6 +847,7 @@ export type LintRunnerName =
 	| "markdownlint"
 	| "htmlhint"
 	| "hadolint"
+	| "helm-lint"
 	| "golangci-lint"
 	| "phpstan"
 	| "ktlint"
@@ -996,6 +997,7 @@ const TOOL_EXECUTION_POLICY = new Map<string, ToolExecutionPolicy>([
 	["mypy", { gate: "config-first", autoInstall: true }],
 	["taplo", { gate: "smart-default", autoInstall: true }],
 	["hadolint", { gate: "smart-default", autoInstall: true }],
+	["helm", { gate: "smart-default", autoInstall: true }],
 	["htmlhint", { gate: "smart-default", autoInstall: true }],
 	["ktlint", { gate: "smart-default", autoInstall: true }],
 	// ktfmt is opt-in (a project's explicit formatting choice), so it only runs

--- a/clients/workspace-topology.ts
+++ b/clients/workspace-topology.ts
@@ -80,6 +80,7 @@ export interface DirectoryMarkers {
 	pnpmWorkspaceYamlPath: string | undefined;
 	cargoTomlPath: string | undefined;
 	goWorkPath: string | undefined;
+	chartYamlPath: string | undefined;
 }
 
 interface DirCacheEntry {
@@ -168,6 +169,7 @@ export function getDirectoryMarkers(dir: string): DirectoryMarkers {
 		pnpmWorkspaceYamlPath: resolveMarker("pnpm-workspace.yaml"),
 		cargoTomlPath: resolveMarker("Cargo.toml"),
 		goWorkPath: resolveMarker("go.work"),
+		chartYamlPath: resolveMarker("Chart.yaml"),
 	};
 	dirMarkerCache.set(resolvedDir, { dirMtimeMs, markers });
 	return markers;

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -75,6 +75,14 @@ const FIXTURES = [
 		expectDiagnostic: true,
 	},
 	{
+		lang: "helm",
+		dir: "tests/fixtures/tool-smoke/helm",
+		file: "templates/bad.yaml",
+		targets: ["helm-lint"],
+		tools: ["helm"],
+		expectDiagnostic: true,
+	},
+	{
 		lang: "javascript",
 		dir: "tests/fixtures/tool-smoke/javascript",
 		file: "bad.js",

--- a/tests/clients/dispatch/integration-groups.test.ts
+++ b/tests/clients/dispatch/integration-groups.test.ts
@@ -18,7 +18,12 @@ describe("dispatch integration groups", () => {
 		});
 
 		expect(groups).toHaveLength(2);
-		expect(groups[0].runnerIds).toEqual(["lsp", "yamllint", "trivy-config"]);
+		expect(groups[0].runnerIds).toEqual([
+			"lsp",
+			"yamllint",
+			"trivy-config",
+			"helm-lint",
+		]);
 		// mode:"all" — yamllint (smart-default) runs alongside the LSP rather than
 		// being suppressed when the LSP succeeds (#209 fallback→all fix).
 		expect(groups[0].mode).toBe("all");

--- a/tests/clients/dispatch/plan-exposure.test.ts
+++ b/tests/clients/dispatch/plan-exposure.test.ts
@@ -76,7 +76,14 @@ describe("dispatch plan exposure", () => {
 		const sqlIds = flattenRunnerIds(TOOL_PLANS.sql);
 
 		expect(yamlIds).toContain("yamllint");
+		expect(yamlIds).toContain("helm-lint");
 		expect(sqlIds).toContain("sqlfluff");
+	});
+
+	it("routes tpl helpers through the explicit Helm template plan", () => {
+		expect(flattenRunnerIds(TOOL_PLANS["helm-template"])).toEqual([
+			"helm-lint",
+		]);
 	});
 
 	it("routes html/docker/powershell/php/prisma through aligned primary plans", () => {

--- a/tests/clients/dispatch/runners/helm-lint.test.ts
+++ b/tests/clients/dispatch/runners/helm-lint.test.ts
@@ -1,0 +1,218 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DispatchContext } from "../../../../clients/dispatch/types.js";
+
+const { safeSpawnAsync, resolveAvailableOrInstall } = vi.hoisted(() => ({
+	safeSpawnAsync: vi.fn(),
+	resolveAvailableOrInstall: vi.fn(),
+}));
+
+vi.mock("../../../../clients/safe-spawn.js", () => ({ safeSpawnAsync }));
+vi.mock("../../../../clients/dispatch/runners/utils/runner-helpers.js", () => ({
+	createAvailabilityChecker: () => ({ getOutcome: () => "success" }),
+	resolveAvailableOrInstall,
+}));
+
+const { default: helmLintRunner, parseHelmLintOutput } = await import(
+	"../../../../clients/dispatch/runners/helm-lint.js"
+);
+
+function context(filePath: string, projectRoot: string): DispatchContext {
+	return {
+		filePath,
+		projectRoot,
+		cwd: projectRoot,
+		kind: filePath.endsWith(".tpl") ? "helm-template" : "yaml",
+		fileRole: "source",
+		pi: { getFlag: () => undefined },
+		autofix: false,
+		deltaMode: false,
+		facts: {} as DispatchContext["facts"],
+		hasTool: async () => true,
+		log: () => undefined,
+	};
+}
+
+function createChart(root: string, relativeFile: string): string {
+	fs.mkdirSync(path.join(root, "templates"), { recursive: true });
+	fs.writeFileSync(
+		path.join(root, "Chart.yaml"),
+		"apiVersion: v2\nname: test\nversion: 0.1.0\n",
+	);
+	const filePath = path.join(root, relativeFile);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, "value\n");
+	return filePath;
+}
+
+describe("helm-lint runner", () => {
+	let workspace: string;
+
+	beforeEach(() => {
+		workspace = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-helm-lint-"));
+		resolveAvailableOrInstall.mockReset();
+		resolveAvailableOrInstall.mockResolvedValue("helm");
+		safeSpawnAsync.mockReset();
+		safeSpawnAsync.mockResolvedValue({ status: 0, stdout: "", stderr: "" });
+	});
+
+	afterEach(() => {
+		fs.rmSync(workspace, { recursive: true, force: true });
+	});
+
+	it("parses info, warning, and error lines as successful findings", async () => {
+		const filePath = createChart(workspace, "templates/deployment.yaml");
+		safeSpawnAsync.mockResolvedValue({
+			status: 1,
+			stdout: [
+				"[INFO] Chart.yaml: icon is recommended",
+				"[WARNING] templates/deployment.yaml: deprecated API",
+				"[ERROR] templates/deployment.yaml:3: invalid template",
+			].join("\n"),
+			stderr: "Error: 1 chart(s) linted, 1 chart(s) failed",
+		});
+
+		const result = await helmLintRunner.run(context(filePath, workspace));
+
+		expect(result.status).toBe("succeeded");
+		expect(result.semantic).toBe("blocking");
+		expect(result.failureKind).toBeUndefined();
+		expect(result.diagnostics.map((d) => d.severity)).toEqual([
+			"info",
+			"warning",
+			"error",
+		]);
+		expect(result.diagnostics[2].line).toBe(3);
+	});
+
+	it("uses the tpl file kind and lints the nearest nested chart", async () => {
+		createChart(workspace, "templates/parent.yaml");
+		const subchart = path.join(workspace, "charts", "child");
+		const helper = createChart(subchart, "templates/_helpers.tpl");
+
+		await helmLintRunner.run(context(helper, workspace));
+
+		expect(safeSpawnAsync).toHaveBeenCalledWith(
+			"helm",
+			["lint", path.resolve(subchart)],
+			expect.objectContaining({
+				cwd: workspace,
+				timeout: 30_000,
+				deadlineAt: expect.any(Number),
+				resourceLabel: "helm-lint",
+			}),
+		);
+	});
+
+	it("deduplicates concurrent edits by canonical chart root", async () => {
+		const first = createChart(workspace, "templates/first.yaml");
+		const second = createChart(workspace, "templates/second.yaml");
+		let settle!: (value: { status: number; stdout: string; stderr: string }) => void;
+		safeSpawnAsync.mockReturnValue(
+			new Promise((resolve) => {
+				settle = resolve;
+			}),
+		);
+
+		const firstRun = helmLintRunner.run(context(first, workspace));
+		const secondRun = helmLintRunner.run(context(second, workspace));
+		await vi.waitFor(() => expect(safeSpawnAsync).toHaveBeenCalledTimes(1));
+		settle({ status: 0, stdout: "", stderr: "" });
+		await Promise.all([firstRun, secondRun]);
+
+		expect(resolveAvailableOrInstall).toHaveBeenCalledTimes(1);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips files with no chart and chart roots outside the workspace", async () => {
+		const plain = path.join(workspace, "plain.yaml");
+		fs.writeFileSync(plain, "value: true\n");
+		expect(await helmLintRunner.run(context(plain, workspace))).toMatchObject({
+			status: "skipped",
+		});
+
+		const outside = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-helm-outside-"));
+		try {
+			const outsideFile = createChart(outside, "values.yaml");
+			expect(await helmLintRunner.run(context(outsideFile, workspace))).toMatchObject({
+				status: "skipped",
+			});
+		} finally {
+			fs.rmSync(outside, { recursive: true, force: true });
+		}
+		expect(safeSpawnAsync).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["tool-not-found", "unavailable"],
+		["timeout", "timeout"],
+		["killed", "aborted"],
+	])("classifies typed %s spawn failures without errno text", async (kind, failureKind) => {
+		const filePath = createChart(workspace, "values.yaml");
+		safeSpawnAsync.mockResolvedValue({
+			status: null,
+			stdout: "",
+			stderr: "",
+			failure: kind === "timeout" ? "timeout" : "aborted",
+			spawnFailure: { kind },
+			error: new Error("opaque failure"),
+		});
+
+		const result = await helmLintRunner.run(context(filePath, workspace));
+
+		expect(result).toMatchObject({ status: "failed", failureKind });
+		expect(result.diagnostics).toEqual([]);
+	});
+
+	it("reports nonzero unparseable output as parser failure, never clean", async () => {
+		const filePath = createChart(workspace, "Chart.yaml");
+		safeSpawnAsync.mockResolvedValue({
+			status: 2,
+			stdout: "unexpected protocol text",
+			stderr: "",
+		});
+
+		expect(await helmLintRunner.run(context(filePath, workspace))).toMatchObject({
+			status: "failed",
+			failureKind: "parser_error",
+			diagnostics: [],
+		});
+	});
+
+	it("does not treat a warning-only nonzero exit or truncated output as complete", async () => {
+		const filePath = createChart(workspace, "values.yaml");
+		safeSpawnAsync.mockResolvedValueOnce({
+			status: 1,
+			stdout: "[WARNING] values.yaml: suspicious value",
+			stderr: "helm crashed after warning",
+		});
+		expect(await helmLintRunner.run(context(filePath, workspace))).toMatchObject({
+			status: "failed",
+			failureKind: "parser_error",
+		});
+
+		safeSpawnAsync.mockResolvedValueOnce({
+			status: 0,
+			stdout: "[INFO] Chart.yaml: icon is recommended",
+			stderr: "",
+			outputTruncated: true,
+		});
+		expect(await helmLintRunner.run(context(filePath, workspace))).toMatchObject({
+			status: "failed",
+			failureKind: "parser_error",
+		});
+	});
+});
+
+describe("parseHelmLintOutput", () => {
+	it("confines paths from Helm output to the chart", () => {
+		const chartRoot = path.resolve("chart-root");
+		const [diagnostic] = parseHelmLintOutput(
+			"[ERROR] ../../escaped.yaml:1: invalid",
+			chartRoot,
+		);
+		expect(diagnostic.filePath).toBe(path.join(chartRoot, "Chart.yaml"));
+	});
+});

--- a/tests/clients/dispatch/runners/helm-lint.test.ts
+++ b/tests/clients/dispatch/runners/helm-lint.test.ts
@@ -216,3 +216,24 @@ describe("parseHelmLintOutput", () => {
 		expect(diagnostic.filePath).toBe(path.join(chartRoot, "Chart.yaml"));
 	});
 });
+
+// #1342 review: helm indents multi-line detail under its [LEVEL] header —
+// continuations must fold into the diagnostic message, not vanish.
+describe("parseHelmLintOutput continuations", () => {
+	it("appends indented continuation lines to the preceding diagnostic", () => {
+		const raw = [
+			"[ERROR] templates/deploy.yaml: unable to parse YAML",
+			"	error converting YAML to JSON: yaml: line 12:",
+			"	  mapping values are not allowed in this context",
+			"[WARNING] templates/svc.yaml: icon is recommended",
+		].join("\n");
+		const diagnostics = parseHelmLintOutput(raw, "/repo/chart");
+		expect(diagnostics).toHaveLength(2);
+		expect(diagnostics[0].message).toContain("unable to parse YAML");
+		expect(diagnostics[0].message).toContain("error converting YAML to JSON");
+		expect(diagnostics[0].message).toContain("mapping values are not allowed");
+		expect(diagnostics[1].message).toContain("icon is recommended");
+		expect(diagnostics[1].message).not.toContain("mapping values");
+	});
+});
+

--- a/tests/clients/file-kinds.test.ts
+++ b/tests/clients/file-kinds.test.ts
@@ -20,3 +20,14 @@ describe("detectFileKind — terragrunt", () => {
 		expect(detectFileKind("/repo/infra/.terraform.lock.hcl")).toBeUndefined();
 	});
 });
+
+describe("detectFileKind — Helm templates", () => {
+	it("routes .tpl helpers through an explicit file kind", () => {
+		expect(detectFileKind("/repo/chart/templates/_helpers.tpl")).toBe(
+			"helm-template",
+		);
+		expect(detectFileKind("C:\\repo\\chart\\templates\\notes.TPL")).toBe(
+			"helm-template",
+		);
+	});
+});

--- a/tests/clients/workspace-topology.test.ts
+++ b/tests/clients/workspace-topology.test.ts
@@ -73,6 +73,7 @@ describe("getDirectoryMarkers — marker index correctness", () => {
 		write("pnpm-workspace.yaml", "packages:\n  - 'packages/*'\n");
 		write("Cargo.toml", "[workspace]\n");
 		write("go.work", "go 1.21\n");
+		write("Chart.yaml", "apiVersion: v2\n");
 		const markers = getDirectoryMarkers(root);
 		expect(markers.piLensConfigPath).toBe(path.join(root, ".pi-lens.json"));
 		expect(markers.tsconfigPath).toBe(path.join(root, "tsconfig.json"));
@@ -82,6 +83,7 @@ describe("getDirectoryMarkers — marker index correctness", () => {
 		);
 		expect(markers.cargoTomlPath).toBe(path.join(root, "Cargo.toml"));
 		expect(markers.goWorkPath).toBe(path.join(root, "go.work"));
+		expect(markers.chartYamlPath).toBe(path.join(root, "Chart.yaml"));
 	});
 
 	it("returns undefined markers for an empty directory", () => {

--- a/tests/fixtures/tool-smoke/helm/Chart.yaml
+++ b/tests/fixtures/tool-smoke/helm/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: pi-lens-smoke
+version: 0.1.0

--- a/tests/fixtures/tool-smoke/helm/templates/bad.yaml
+++ b/tests/fixtures/tool-smoke/helm/templates/bad.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name

--- a/tests/fixtures/tool-smoke/helm/values.yaml
+++ b/tests/fixtures/tool-smoke/helm/values.yaml
@@ -1,0 +1,1 @@
+name: smoke


### PR DESCRIPTION
## Summary

- extend the shared workspace-topology marker index with `Chart.yaml`
- dispatch YAML under the nearest chart plus explicit `.tpl`/`_helpers.tpl` file-kind plans to one canonical-root-deduplicated `helm lint`
- add typed spawn-failure handling, bounded ambient-abort-aware execution, Helm diagnostic parsing, managed GitHub/archive installation, unit coverage, and a real smoke fixture
- refs #1283; rendered-manifest validation remains explicitly deferred to slice B

## State model and failure semantics

- no containing chart, a chart above the home ceiling, or a chart outside the workspace: skip Helm
- Helm unavailable: failed/inconclusive with `failureKind: unavailable`
- exit 0: successful clean/findings result
- nonzero with parsed `[ERROR]`: successful findings result (not a runner crash)
- spawn, abort, timeout, truncation, or nonzero without a parsed error: failed/inconclusive, never clean
- no dependency update, cluster access, render step, or project-tree mutation

## Dispatch trigger matrix

| Edited file kind | Helm runner selected | Lints when inside chart |
| --- | --- | --- |
| YAML (`Chart.yaml`, `values*.yaml`, `templates/*.yaml`) | yes, alongside existing YAML checks | yes |
| Helm helper (`*.tpl`, including `_helpers.tpl`) | yes, explicit `helm-template` plan | yes |
| Any other kind | no | no |
| YAML / `.tpl` outside a discovered in-workspace chart | selected by kind | skips |

Nested/subchart edits use the nearest `Chart.yaml`; concurrent edits collapse by canonical chart-root key.

## Blast radius

The session did not expose pi-lens `module_report` / symbol-navigation tools, so the required structural blast-radius map was unavailable. Import/registry/call-site searches show the affected entry points are file-kind detection, plan construction, default runner registration, workspace marker discovery, installer/tool policy, and the nightly smoke harness. Existing YAML dispatch retains LSP, yamllint, Trivy-config, and actionlint composition; Helm is added alongside them and self-skips outside charts.

## Verification

- `npm run build` — passed
- `npx vitest run tests/clients/dispatch/` — 89 files, 734 tests passed
- focused file-kind/topology/installer tests — 4 files, 112 tests passed
- broader `tests/clients/` was attempted on Windows: 5,339 passed / 13 skipped / 4 failed in pre-existing Madge/Jscpd managed-path classification tests; the four reproduce in isolation and are outside this slice. Linux CI is authoritative per AGENTS.md.