### PR TITLE
feat(lsp): TS language-service idle eviction (refs #1332)

### DIFF
--- a/.changelog/feat-1332-ts-idle-eviction.md
+++ b/.changelog/feat-1332-ts-idle-eviction.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **TypeScript language services release idle program memory (refs #1332)** — After five inactive minutes (configurable with `PI_LENS_TS_IDLE_EVICT_MS`), TypeScript LSP clients shut down and rebuild transparently on the next request instead of retaining fully hydrated programs indefinitely.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,16 @@ uses the awaited durable-store seam: its delta/version snapshot maps to
 policy. Turn-state remains separate pending a future ownership decision.
 (#1209, #1212)
 
+**LSP idle eviction is lease-guarded across acquisition/use.** `isBusy()` only
+becomes true after a client request enters the transport, so it cannot protect
+the yield between manager selection and the first notify/request. Operations
+must acquire the manager-owned client lease under the spawn gate, validate that
+the selected client is still the published instance, and release in `finally`;
+idle and ceiling eviction skip leased keys. Deterministic race tests suspend the
+first client operation with `tests/clients/interleaving-kit.ts`, never sleeps.
+The TypeScript idle default is 20 minutes to preserve warm LSPs across subagent
+bursts; every non-idle removal path must also clear timer ownership. (#1332)
+
 **Spawn repair decisions use the typed safe-spawn taxonomy.** A raw OS
 `ENOENT` can mean either a missing executable or an invalid child cwd. Consume
 `SpawnResult.spawnFailure.kind` / `SpawnFailureError.kind`, never errno or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,12 @@ Unsupported pull responses are also recognized by the standard message-only
 variants (`method not found`, `unknown method`, and `unsupported method`).
 Status consumers receive detached, 200-character-bounded failure entries.
 
+TypeScript LSP clients are evicted after `PI_LENS_TS_IDLE_EVICT_MS` of inactivity
+(default five minutes). Eviction removes the client from service state before
+graceful shutdown, releasing the server-owned language-service programs and
+document registry; the next request rebuilds transparently. The per-root timers
+must stay unref'd, reset on reuse, busy-client guarded, and cleared on shutdown.
+
 Rule-id normalization derives its language suffixes from the bundled CodeRabbit rule tree at startup; tests must keep that derived set covered so new vendored language rules cannot silently evade project policy matching.
 
 Source-filter tests pin the ordering agreement between the forward precedence map, reverse source-twin candidates, and filesystem sibling resolution; the intentionally broad `.jsx` fallback remains part of that contract.

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -265,6 +265,14 @@ const TOUCH_DEBOUNCE_MS = Math.max(
 		1500,
 );
 const DEFAULT_LSP_CLIENT_CEILING = 24;
+const DEFAULT_TS_IDLE_EVICT_MS = 5 * 60_000;
+
+export function getTypeScriptIdleEvictMs(): number {
+	const parsed = Number.parseInt(process.env.PI_LENS_TS_IDLE_EVICT_MS ?? "", 10);
+	return Number.isSafeInteger(parsed) && parsed > 0
+		? parsed
+		: DEFAULT_TS_IDLE_EVICT_MS;
+}
 
 export function getLspClientCeiling(): number {
 	const parsed = Number.parseInt(process.env.PI_LENS_LSP_CLIENT_CEILING ?? "", 10);
@@ -929,6 +937,16 @@ export class LSPService {
 	private readonly notifyWriteBackpressureStreak = new Map<string, number>();
 	/** LRU clock for capacity eviction, keyed by the canonical server/root key. */
 	private readonly clientLastUsedAt = new Map<string, number>();
+	/**
+	 * Per-root idle eviction for TypeScript's large, rebuildable program graph.
+	 * Timers are unref'd so an idle language service cannot keep a one-shot host
+	 * alive, and are removed before shutdown so a concurrent request rebuilds
+	 * instead of receiving the retiring client.
+	 */
+	private readonly typeScriptIdleTimers = new Map<
+		string,
+		ReturnType<typeof setTimeout>
+	>();
 	/** Serializes capacity decisions with publication into `state.inFlight`. */
 	private clientSpawnGate: Promise<void> = Promise.resolve();
 	/** True after shutdown() has been called; blocks new operations */
@@ -1009,10 +1027,56 @@ export class LSPService {
 		this.state.demonstratedReady.delete(victimKey);
 		this.state.demonstratedCold.delete(victimKey);
 		this.clientLastUsedAt.delete(victimKey);
+		this.clearTypeScriptIdleTimer(victimKey);
 		logSessionStart(
 			`lsp client ceiling ${getLspClientCeiling()}: evicted idle LRU ${victimKey}`,
 		);
 		return true;
+	}
+
+	private clearTypeScriptIdleTimer(key: string): void {
+		const timer = this.typeScriptIdleTimers.get(key);
+		if (timer) clearTimeout(timer);
+		this.typeScriptIdleTimers.delete(key);
+	}
+
+	private scheduleTypeScriptIdleEviction(key: string): void {
+		if (!key.startsWith("typescript:")) return;
+		this.clearTypeScriptIdleTimer(key);
+		const lastUsedAt = this.clientLastUsedAt.get(key) ?? Date.now();
+		const timer = setTimeout(() => {
+			this.typeScriptIdleTimers.delete(key);
+			void this.withClientSpawnGate(async () => {
+				if (this.isDestroyed) return;
+				const client = this.state.clients.get(key);
+				if (!client?.isAlive()) return;
+				if (
+					client.isBusy?.() === true ||
+					(this.clientLastUsedAt.get(key) ?? 0) !== lastUsedAt
+				) {
+					this.scheduleTypeScriptIdleEviction(key);
+					return;
+				}
+
+				// Publish the cold state synchronously before awaiting teardown. A request
+				// arriving while shutdown is in progress therefore waits on the spawn gate
+				// and creates a fresh client; it can never receive this retiring one.
+				this.state.clients.delete(key);
+				this.state.clientSpawnedAt.delete(key);
+				this.state.demonstratedReady.delete(key);
+				this.state.demonstratedCold.delete(key);
+				this.clientLastUsedAt.delete(key);
+				try {
+					await client.shutdown({ reason: "typescript_idle_eviction" });
+				} catch {
+					// The strong manager reference is already gone; shutdown is best-effort
+					// like the other eviction paths and must not reject from a timer callback.
+				}
+				logSessionStart(`lsp typescript idle eviction: released ${key}`);
+			}).catch(() => {});
+		}, getTypeScriptIdleEvictMs());
+		timer.unref?.();
+		this.typeScriptIdleTimers.set(key, timer);
 	}
 
 	private fingerprintContent(content: string): string {
@@ -1166,6 +1230,8 @@ export class LSPService {
 		this.state.clients.delete(key);
 		this.state.clientSpawnedAt.delete(key);
 		this.state.demonstratedReady.delete(key);
+		this.clientLastUsedAt.delete(key);
+		this.clearTypeScriptIdleTimer(key);
 		logLatency({
 			type: "phase",
 			phase: "lsp_notify_backpressure_broken",
@@ -1487,6 +1553,7 @@ export class LSPService {
 		if (existing) {
 			if (existing.isAlive()) {
 				this.clientLastUsedAt.set(key, Date.now());
+				this.scheduleTypeScriptIdleEviction(key);
 				if (!this.warmStartLogged.has(key)) {
 					logSessionStart(
 						`lsp warm-start ${server.id}: reused root=${root} file=${filePath}`,
@@ -1540,6 +1607,7 @@ export class LSPService {
 			this.state.clients.delete(key);
 			this.state.clientSpawnedAt.delete(key);
 			this.clientLastUsedAt.delete(key);
+			this.clearTypeScriptIdleTimer(key);
 			this.state.broken.delete(key);
 
 			// #1127: count EARLY, non-intentional runtime exits toward the circuit
@@ -1841,6 +1909,7 @@ export class LSPService {
 			this.state.clients.set(key, client);
 			this.state.clientSpawnedAt.set(key, Date.now());
 			this.clientLastUsedAt.set(key, Date.now());
+			this.scheduleTypeScriptIdleEviction(key);
 			this.failureCounts.delete(key);
 			if (isOptionalServer) {
 				this.optionalDisabled.delete(key);
@@ -4901,6 +4970,9 @@ export class LSPService {
 		const resetStartedAt = Date.now();
 		if (this.checkDestroyed()) return;
 		this.isDestroyed = true;
+		for (const key of this.typeScriptIdleTimers.keys()) {
+			this.clearTypeScriptIdleTimer(key);
+		}
 
 		// Belt-and-braces: wait for any in-flight spawns so that Guard 1/2 in
 		// spawnClient can observe isDestroyed and clean up. Skip on the

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -265,7 +265,7 @@ const TOUCH_DEBOUNCE_MS = Math.max(
 		1500,
 );
 const DEFAULT_LSP_CLIENT_CEILING = 24;
-const DEFAULT_TS_IDLE_EVICT_MS = 5 * 60_000;
+const DEFAULT_TS_IDLE_EVICT_MS = 20 * 60_000;
 
 export function getTypeScriptIdleEvictMs(): number {
 	const parsed = Number.parseInt(process.env.PI_LENS_TS_IDLE_EVICT_MS ?? "", 10);
@@ -938,6 +938,12 @@ export class LSPService {
 	/** LRU clock for capacity eviction, keyed by the canonical server/root key. */
 	private readonly clientLastUsedAt = new Map<string, number>();
 	/**
+	 * Manager-owned use leases close the acquisition/use gap that `isBusy()`
+	 * cannot see: a caller may hold a selected client before its first request has
+	 * entered the client. Eviction skips any key with an outstanding lease.
+	 */
+	private readonly clientLeases = new Map<string, number>();
+	/**
 	 * Per-root idle eviction for TypeScript's large, rebuildable program graph.
 	 * Timers are unref'd so an idle language service cannot keep a one-shot host
 	 * alive, and are removed before shutdown so a concurrent request rebuilds
@@ -992,6 +998,85 @@ export class LSPService {
 		}
 	}
 
+	private async clientKeyFor(
+		entry: SpawnedServer,
+		filePath: string,
+	): Promise<string | undefined> {
+		const root = await entry.info.root(filePath);
+		return root ? `${entry.info.id}:${normalizeMapKey(root)}` : undefined;
+	}
+
+	private async acquireClientLease(
+		entry: SpawnedServer,
+		filePath: string,
+	): Promise<string | undefined> {
+		const key = await this.clientKeyFor(entry, filePath);
+		if (!key) return undefined;
+		return this.withClientSpawnGate(async () => {
+			if (this.isDestroyed || this.state.clients.get(key) !== entry.client) {
+				return undefined;
+			}
+			this.clientLeases.set(key, (this.clientLeases.get(key) ?? 0) + 1);
+			return key;
+		});
+	}
+
+	private async acquireClientLeases(
+		entries: readonly SpawnedServer[],
+		filePath: string,
+	): Promise<string[] | undefined> {
+		const keys = await Promise.all(
+			entries.map((entry) => this.clientKeyFor(entry, filePath)),
+		);
+		if (keys.some((key) => key === undefined)) return undefined;
+		const keyed = entries.map((entry, index) => [keys[index] as string, entry] as const);
+		return this.withClientSpawnGate(async () => {
+			if (
+				this.isDestroyed ||
+				keyed.some(([key, entry]) => this.state.clients.get(key) !== entry.client)
+			) {
+				return undefined;
+			}
+			for (const [key] of keyed) {
+				this.clientLeases.set(key, (this.clientLeases.get(key) ?? 0) + 1);
+			}
+			return keyed.map(([key]) => key);
+		});
+	}
+
+	private releaseClientLease(key: string): void {
+		const remaining = (this.clientLeases.get(key) ?? 1) - 1;
+		if (remaining > 0) {
+			this.clientLeases.set(key, remaining);
+			return;
+		}
+		this.clientLeases.delete(key);
+		if (this.state.clients.has(key)) {
+			this.clientLastUsedAt.set(key, Date.now());
+			this.scheduleTypeScriptIdleEviction(key);
+		}
+	}
+
+	private async withClientForFileUse<T>(
+		filePath: string,
+		maxWaitMs: number | undefined,
+		hardCapMs: number | undefined,
+		use: (entry: SpawnedServer) => Promise<T> | T,
+	): Promise<T | undefined> {
+		while (!this.isDestroyed) {
+			const entry = await this.getClientForFile(filePath, maxWaitMs, hardCapMs);
+			if (!entry) return undefined;
+			const leaseKey = await this.acquireClientLease(entry, filePath);
+			if (!leaseKey) continue;
+			try {
+				return await use(entry);
+			} finally {
+				this.releaseClientLease(leaseKey);
+			}
+		}
+		return undefined;
+	}
+
 	private async makeCapacityForClient(key: string): Promise<boolean> {
 		const occupiedKeys = new Set(this.state.inFlight.keys());
 		for (const [clientKey, client] of this.state.clients) {
@@ -1005,7 +1090,8 @@ export class LSPService {
 				([candidateKey, client]) =>
 					candidateKey !== key &&
 					client.isAlive() &&
-					client.isBusy?.() !== true,
+					client.isBusy?.() !== true &&
+					(this.clientLeases.get(candidateKey) ?? 0) === 0,
 			)
 			.sort(
 				([a], [b]) =>
@@ -1042,6 +1128,9 @@ export class LSPService {
 
 	private scheduleTypeScriptIdleEviction(key: string): void {
 		if (!key.startsWith("typescript:")) return;
+		// Pressure-gating these timers would require a separate reconciliation pass
+		// when the manager crosses the threshold; keep ownership simple and use the
+		// warm-LSP-friendly 20-minute default instead.
 		this.clearTypeScriptIdleTimer(key);
 		const lastUsedAt = this.clientLastUsedAt.get(key) ?? Date.now();
 		const timer = setTimeout(() => {
@@ -1052,6 +1141,7 @@ export class LSPService {
 				if (!client?.isAlive()) return;
 				if (
 					client.isBusy?.() === true ||
+					(this.clientLeases.get(key) ?? 0) > 0 ||
 					(this.clientLastUsedAt.get(key) ?? 0) !== lastUsedAt
 				) {
 					this.scheduleTypeScriptIdleEviction(key);
@@ -1967,19 +2057,19 @@ export class LSPService {
 		options?: { preserveDiagnostics?: boolean; spawnBudgetMs?: number },
 	): Promise<void> {
 		if (this.checkDestroyed()) return;
-		const spawned = await this.getClientForFile(
+		await this.withClientForFileUse(
 			filePath,
 			undefined,
 			options?.spawnBudgetMs,
-		);
-		if (!spawned) return;
-
-		const languageId = getLanguageId(filePath) ?? "plaintext";
-		await spawned.client.notify.open(
-			filePath,
-			content,
-			languageId,
-			options?.preserveDiagnostics,
+			async (spawned) => {
+				const languageId = getLanguageId(filePath) ?? "plaintext";
+				await spawned.client.notify.open(
+					filePath,
+					content,
+					languageId,
+					options?.preserveDiagnostics,
+				);
+			},
 		);
 	}
 
@@ -1988,10 +2078,9 @@ export class LSPService {
 	 */
 	async updateFile(filePath: string, content: string): Promise<void> {
 		if (this.checkDestroyed()) return;
-		const spawned = await this.getClientForFile(filePath);
-		if (!spawned) return;
-
-		await spawned.client.notify.change(filePath, content);
+		await this.withClientForFileUse(filePath, undefined, undefined, (spawned) =>
+			spawned.client.notify.change(filePath, content),
+		);
 	}
 
 	/**
@@ -2073,6 +2162,13 @@ export class LSPService {
 			});
 			return;
 		}
+		const leaseKeys = await this.acquireClientLeases(spawned, filePath);
+		if (!leaseKeys) {
+			// An idle eviction won between selection and lease admission. Resolve the
+			// now-current client set and replay; no notification targets the retiree.
+			return this.touchFile(filePath, content, options);
+		}
+		try {
 
 		const spawnedServerIds = spawned.map((entry) => entry.info.id);
 		if (
@@ -3028,6 +3124,9 @@ export class LSPService {
 			},
 		});
 		return result;
+		} finally {
+			for (const key of leaseKeys) this.releaseClientLease(key);
+		}
 	}
 
 	/**

--- a/tests/clients/lsp/typescript-idle-eviction.test.ts
+++ b/tests/clients/lsp/typescript-idle-eviction.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getServersForFileWithConfig = vi.fn();
+const createLSPClient = vi.fn();
+
+vi.mock("../../../clients/lsp/config.js", () => ({
+	getServersForFileWithConfig,
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
+
+function fakeClient(label: string, busy = false) {
+	return {
+		label,
+		isAlive: vi.fn(() => true),
+		isBusy: vi.fn(() => busy),
+		shutdown: vi.fn(async () => undefined),
+		getWorkspaceDiagnosticsSupport: vi.fn(() => ({
+			advertised: false,
+			mode: "push-only",
+			diagnosticProviderKind: "unavailable",
+		})),
+	};
+}
+
+function configureTypeScriptServer() {
+	const spawn = vi.fn(async () => ({
+		process: {
+			process: { killed: false },
+			stdin: {},
+			stdout: {},
+			stderr: {},
+			pid: 1332,
+		},
+	}));
+	getServersForFileWithConfig.mockReturnValue([
+		{
+			id: "typescript",
+			name: "TypeScript",
+			extensions: [".ts"],
+			root: async () => "/repo",
+			spawn,
+		},
+	]);
+	return spawn;
+}
+
+describe("TypeScript language-service idle eviction (#1332 b2)", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+		process.env.PI_LENS_TS_IDLE_EVICT_MS = "20";
+	});
+
+	afterEach(() => {
+		delete process.env.PI_LENS_TS_IDLE_EVICT_MS;
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("releases the idle client and transparently rebuilds on the next request", async () => {
+		vi.useFakeTimers();
+		const first = fakeClient("first");
+		const rebuilt = fakeClient("rebuilt");
+		createLSPClient.mockResolvedValueOnce(first).mockResolvedValueOnce(rebuilt);
+		const spawn = configureTypeScriptServer();
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		expect((await service.getClientForFile("/repo/main.ts"))?.client).toBe(first);
+		await vi.advanceTimersByTimeAsync(20);
+
+		// This is the release assertion: the manager has dropped the only strong
+		// client reference and completed the server-owned registry/program teardown.
+		expect(service.getAliveClientCount()).toBe(0);
+		expect(first.shutdown).toHaveBeenCalledWith({
+			reason: "typescript_idle_eviction",
+		});
+
+		expect((await service.getClientForFile("/repo/main.ts"))?.client).toBe(rebuilt);
+		expect(spawn).toHaveBeenCalledTimes(2);
+		expect(createLSPClient).toHaveBeenCalledTimes(2);
+		await service.shutdown();
+	});
+
+	it("does not evict an in-flight client and restarts its idle window", async () => {
+		vi.useFakeTimers();
+		const client = fakeClient("busy", true);
+		createLSPClient.mockResolvedValue(client);
+		configureTypeScriptServer();
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		await service.getClientForFile("/repo/main.ts");
+
+		await vi.advanceTimersByTimeAsync(20);
+		expect(client.shutdown).not.toHaveBeenCalled();
+		expect(service.getAliveClientCount()).toBe(1);
+
+		client.isBusy.mockReturnValue(false);
+		await vi.advanceTimersByTimeAsync(20);
+		expect(client.shutdown).toHaveBeenCalledWith({
+			reason: "typescript_idle_eviction",
+		});
+		expect(service.getAliveClientCount()).toBe(0);
+	});
+
+	it("unrefs the timer and clears it on service disposal", async () => {
+		const client = fakeClient("lifecycle");
+		createLSPClient.mockResolvedValue(client);
+		configureTypeScriptServer();
+		const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService() as LSPService & {
+			typeScriptIdleTimers: Map<string, ReturnType<typeof setTimeout>>;
+		};
+		await service.getClientForFile("/repo/main.ts");
+
+		const timer = [...service.typeScriptIdleTimers.values()][0];
+		expect(timer).toBeDefined();
+		expect(timer.hasRef?.()).toBe(false);
+		await service.shutdown();
+
+		expect(clearTimeoutSpy).toHaveBeenCalledWith(timer);
+		expect(service.typeScriptIdleTimers.size).toBe(0);
+	});
+});

--- a/tests/clients/lsp/typescript-idle-eviction.test.ts
+++ b/tests/clients/lsp/typescript-idle-eviction.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { suspendAt } from "../interleaving-kit.js";
 
 const getServersForFileWithConfig = vi.fn();
 const createLSPClient = vi.fn();
@@ -13,9 +14,15 @@ vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
 function fakeClient(label: string, busy = false) {
 	return {
 		label,
+		root: "/repo",
 		isAlive: vi.fn(() => true),
 		isBusy: vi.fn(() => busy),
 		shutdown: vi.fn(async () => undefined),
+		notify: {
+			open: vi.fn(async () => undefined),
+			change: vi.fn(async () => undefined),
+		},
+		diagnosticsVersion: 0,
 		getWorkspaceDiagnosticsSupport: vi.fn(() => ({
 			advertised: false,
 			mode: "push-only",
@@ -106,23 +113,82 @@ describe("TypeScript language-service idle eviction (#1332 b2)", () => {
 		expect(service.getAliveClientCount()).toBe(0);
 	});
 
+	it("lease-guards the acquire/use gap while didOpen is suspended", async () => {
+		vi.useFakeTimers();
+		const client = fakeClient("leased");
+		createLSPClient.mockResolvedValue(client);
+		configureTypeScriptServer();
+		const notification = suspendAt(client.notify.open);
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		const opened = service.openFile("/repo/main.ts", "const value = 1;");
+		await notification.admitted;
+		await vi.advanceTimersByTimeAsync(20);
+
+		expect(client.shutdown).not.toHaveBeenCalled();
+		expect(service.getAliveClientCount()).toBe(1);
+		notification.release();
+		await opened;
+		expect(client.notify.open).toHaveBeenCalledTimes(1);
+		expect(client.shutdown).not.toHaveBeenCalled();
+		await service.shutdown();
+		notification.restore();
+	});
+
+	it("clears TypeScript timer ownership on notify-backpressure eviction", async () => {
+		vi.useFakeTimers();
+		const client = fakeClient("backpressured");
+		createLSPClient.mockResolvedValue(client);
+		configureTypeScriptServer();
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		const harness = service as unknown as {
+			state: { clients: Map<string, typeof client> };
+			typeScriptIdleTimers: Map<string, ReturnType<typeof setTimeout>>;
+			recordNotifyWriteBackpressure(
+				key: string,
+				entry: unknown,
+				filePath: string,
+			): void;
+		};
+		const entry = await service.getClientForFile("/repo/main.ts");
+		expect(entry).toBeDefined();
+		expect(harness.typeScriptIdleTimers.size).toBe(1);
+		const key = [...harness.state.clients.keys()][0];
+		expect(key).toBeDefined();
+
+		for (let attempt = 0; attempt < 3; attempt++) {
+			harness.recordNotifyWriteBackpressure(
+				key as string,
+				entry as NonNullable<typeof entry>,
+				"/repo/main.ts",
+			);
+		}
+
+		expect(harness.typeScriptIdleTimers.size).toBe(0);
+		await vi.advanceTimersByTimeAsync(20);
+		expect(client.shutdown).toHaveBeenCalledTimes(1);
+	});
+
 	it("unrefs the timer and clears it on service disposal", async () => {
 		const client = fakeClient("lifecycle");
 		createLSPClient.mockResolvedValue(client);
 		configureTypeScriptServer();
 		const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 		const { LSPService } = await import("../../../clients/lsp/index.js");
-		const service = new LSPService() as LSPService & {
+		const service = new LSPService();
+		const harness = service as unknown as {
 			typeScriptIdleTimers: Map<string, ReturnType<typeof setTimeout>>;
 		};
 		await service.getClientForFile("/repo/main.ts");
 
-		const timer = [...service.typeScriptIdleTimers.values()][0];
+		const timer = [...harness.typeScriptIdleTimers.values()][0];
 		expect(timer).toBeDefined();
 		expect(timer.hasRef?.()).toBe(false);
 		await service.shutdown();
 
 		expect(clearTimeoutSpy).toHaveBeenCalledWith(timer);
-		expect(service.typeScriptIdleTimers.size).toBe(0);
+		expect(harness.typeScriptIdleTimers.size).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

Implements #1332 item (b2) only. TypeScript LSP clients now idle-evict after `PI_LENS_TS_IDLE_EVICT_MS` (default 20 minutes), releasing the server-owned TypeScript language service, hydrated programs, and document registry. The next file request cold-spawns and rebuilds transparently.

Current `origin/master` no longer imports TypeScript in-process (#402 enforces this); the measured TS object graph is owned by the spawned `typescript-language-server`/native TS LSP process. The contained release seam is therefore graceful client shutdown, which releases that whole object graph rather than attempting to reach into a third-party registry from the parent.

## State model / race safety

- Active request/reuse resets the per-root timer.
- Timer is `unref()`'d and all timers are cleared during service shutdown.
- Notify/use entry points acquire a manager-owned lease under the spawn gate and validate client identity before use; idle and ceiling eviction skip leased clients. A firing timer also checks `client.isBusy()` and restarts the idle window instead of evicting an in-flight request.
- Eviction is serialized with the spawn gate and removes the retiring client from manager state before awaiting shutdown. A concurrent request therefore waits and rebuilds; it cannot receive the retiring client.
- Ceiling eviction, dead-client cleanup, notify-backpressure eviction, and service shutdown all clear timer ownership.
- Item (c) thin secondaries, warm attachment, and IPC are untouched.

## Blast radius

Production code change is confined to `clients/lsp/index.ts`; the diff also updates `AGENTS.md` with the lease/timer invariant and adds LSP regression coverage. Affected dependents are existing `LSPService` file-request, client-spawn/reuse, eviction, and shutdown entry points. `module_report` was unavailable in this session; the fallback structural sweep covered every `state.clients.delete`, `clientLastUsedAt`, spawn publication, and shutdown path in the module.

## Verification

Required order was followed on the final code:

1. `npm run build` — pass
2. Targeted lease interleaving and notify-backpressure timer-ownership regressions — pass; removing `clearTypeScriptIdleTimer()` from the backpressure path makes the ownership test fail as intended
3. Full `tests/clients/lsp` — 64 passed, 3 skipped files; 598 passed, 4 skipped tests (the pre-fix head was 596 passed, 4 skipped)

The broader `tests/clients` run completed with six unrelated failures; serial rerun reduced that to four persistent failures in managed-tool resolution tests (`dependency-checker-madge-*`, `jscpd-client`), while 48/52 tests in that rerun passed. Those failures do not import or exercise the touched LSP module and align with the recent spawn-taxonomy area on master.

## Memory evidence

No defensible before/after `process.memoryUsage()` number is included: that API samples the parent, while the releasable TypeScript heap is server-process-owned on current master. The regression asserts the meaningful release boundary directly: manager strong-reference count falls to zero and graceful server shutdown completes before a subsequent request performs a second spawn/rebuild.

Refs #1332. Refs #1126. Does not close #1332 because item (c) remains design-gated.