### PR TITLE
fix(formatters): npx fallback honors SKIP_FORMATTING gating (closes #1345)

### DIFF
--- a/.changelog/fix-1345-npx-fallback-gate.md
+++ b/.changelog/fix-1345-npx-fallback-gate.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **npx formatter fallback honors style-preservation gating (closes #1345)** — Files that must be skipped by `SKIP_FORMATTING` no longer invoke the static Biome or Prettier `npx` fallback when a primary formatter command is unavailable.

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -1311,6 +1311,25 @@ export function firstDiagnosticLine(text: string | undefined): string | undefine
 	return undefined;
 }
 
+/**
+ * Resolve a formatter command without allowing the static command fallback to
+ * bypass a resolver's style-preservation refusal (#1345). `null` means the
+ * primary command is unavailable; the explicit sentinel means formatting is
+ * forbidden for this file and must be returned before the static command is
+ * materialized.
+ */
+async function resolveFormatterCommand(
+	formatter: FormatterInfo,
+	absolutePath: string,
+	cwd: string,
+): Promise<string[] | typeof SKIP_FORMATTING> {
+	const resolved = formatter.resolveCommand
+		? await formatter.resolveCommand(absolutePath, cwd)
+		: null;
+	if (resolved === SKIP_FORMATTING) return SKIP_FORMATTING;
+	return resolved ?? formatter.command.map((c) => c.replace("$FILE", absolutePath));
+}
+
 export async function formatFile(
 	filePath: string,
 	formatter: FormatterInfo,
@@ -1320,19 +1339,15 @@ export async function formatFile(
 		const cwd = path.dirname(absolutePath);
 		const contentBefore = await fs.readFile(absolutePath, "utf-8");
 
-		// Resolve command: prefer local (venv/vendor/node_modules) over global
-		const resolved = formatter.resolveCommand
-			? await formatter.resolveCommand(absolutePath, cwd)
-			: null;
-		if (resolved === SKIP_FORMATTING) {
+		// Resolve command: prefer local (venv/vendor/node_modules) over global.
+		// The shared seam must honor SKIP_FORMATTING before selecting the static
+		// command, including its npx fallback (#1345).
+		const cmd = await resolveFormatterCommand(formatter, absolutePath, cwd);
+		if (cmd === SKIP_FORMATTING) {
 			// Style-preserving refusal (#1144): no repo config and no detectable
 			// indentation to pin — formatting would impose the tool's stock style.
 			return { success: true, changed: false };
 		}
-		const cmd =
-			resolved ??
-			formatter.command.map((c) => c.replace("$FILE", absolutePath));
-
 		// Run formatter without blocking the event loop.
 		const result = await safeSpawnAsync(cmd[0], cmd.slice(1), {
 			timeout: 15000,

--- a/tests/clients/formatters-format-file.test.ts
+++ b/tests/clients/formatters-format-file.test.ts
@@ -206,5 +206,53 @@ describe("formatFile honors SKIP_FORMATTING (#1144)", () => {
 			env.cleanup();
 		}
 	});
-});
 
+	it("does not let an unavailable primary reach the npx fallback when gated", async () => {
+		const env = setupTestEnvironment("pi-lens-format-npx-gated-");
+		try {
+			const filePath = path.join(env.tmpDir, "bundle.js");
+			fs.writeFileSync(filePath, "const a=1;const b=2;const c=a+b;\n");
+			const mod = await import("../../clients/formatters.ts");
+			const formatter = {
+				...mod.prettierFormatter,
+				resolveCommand: async () => mod.SKIP_FORMATTING,
+			};
+
+			const result = await mod.formatFile(filePath, formatter);
+
+			expect(result).toEqual({ success: true, changed: false });
+			expect(safeSpawnAsync).not.toHaveBeenCalledWith(
+				"npx",
+				expect.anything(),
+				expect.anything(),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("uses the npx fallback when the primary is unavailable and the file is not gated", async () => {
+		const env = setupTestEnvironment("pi-lens-format-npx-available-");
+		try {
+			const filePath = path.join(env.tmpDir, "formatted.js");
+			fs.writeFileSync(filePath, "const value = 1;\n");
+			const mod = await import("../../clients/formatters.ts");
+			const formatter = {
+				...mod.prettierFormatter,
+				resolveCommand: async () => null,
+			};
+			safeSpawnAsync.mockResolvedValue({ status: 0, stdout: "", stderr: "" });
+
+			const result = await mod.formatFile(filePath, formatter);
+
+			expect(result).toEqual({ success: true, changed: false });
+			expect(safeSpawnAsync).toHaveBeenCalledWith(
+				"npx",
+				["prettier", "--write", filePath],
+				expect.objectContaining({ cwd: env.tmpDir }),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- centralize formatter command resolution so SKIP_FORMATTING is honored before static fallback selection
- prevent gated Biome/Prettier files from reaching the npx fallback when the primary command is unavailable
- retain the npx fallback for non-gated files and add a changelog entry

## Verification
- npm run build
- npx vitest run tests/clients/formatters.test.ts tests/clients/formatters-format-file.test.ts tests/clients/dispatch/
- mutation: removing the caller-side SKIP_FORMATTING gate caused 2 focused tests to fail (8 remained green)

Fallback inventory: Biome — bypass fixed; Prettier — bypass fixed; all other formatters in clients/formatters.ts — no npx fallback.

Closes #1345