### PR TITLE
fix(widget): render formatter failures, not just rewrites (closes #1346)

### DIFF
--- a/.changelog/fix-1346-widget-format-failures.md
+++ b/.changelog/fix-1346-widget-format-failures.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Formatter failures now appear in the diagnostics widget (closes #1346)** — Failed formatter runs render with a distinct error indication, remain deduplicated per formatter and file, and disappear after a successful retry.

--- a/clients/widget-state.ts
+++ b/clients/widget-state.ts
@@ -940,7 +940,10 @@ function formatFileRowVertical(
 	const blocking = rec.diagnosticCounts.blocking;
 	const errors = rec.diagnosticCounts.errors;
 	const warnings = rec.diagnosticCounts.warnings;
-	const dot =
+	const formatterFailed = hasFailedFormatter(rec);
+	const dot = formatterFailed
+		? red("x")
+		:
 		blocking > 0
 			? red("●")
 			: warnings > 0 || errors > 0
@@ -959,12 +962,16 @@ function formatFileRowVertical(
 				? " " + yellow(`${warnings}W`)
 				: " " + dim("clean");
 	const changedFormatters = [...rec.formatters.entries()]
-		.filter(([, f]) => f.changed)
+		.filter(([, f]) => f.changed && f.success)
+		.map(([name]) => name);
+	const failedFormatters = [...rec.formatters.entries()]
+		.filter(([, f]) => !f.success)
 		.map(([name]) => name);
 	const formatMark =
-		changedFormatters.length > 0
-			? dim(` fmt:${changedFormatters.join(",")}`)
-			: "";
+		(failedFormatters.length > 0
+			? red(` fmt-failed:${failedFormatters.join(",")}`)
+			: "") +
+		(changedFormatters.length > 0 ? dim(` fmt:${changedFormatters.join(",")}`) : "");
 	return ` ${dot} ${base}  ${dim(runnerNames)}${formatMark}${counts}`;
 }
 
@@ -1043,12 +1050,17 @@ function formatFileTokenHorizontal(
 	const errors = rec.diagnosticCounts.errors;
 	const warnings = rec.diagnosticCounts.warnings;
 	const formatterChanged = hasChangedFormatter(rec);
+	const formatterFailed = hasFailedFormatter(rec);
 
 	let dotChar: string;
 	if (blocking > 0) dotChar = red("●");
 	else if (errors > 0 || warnings > 0) dotChar = yellow("!");
 	else if (formatterChanged) dotChar = dim("✎");
 	else dotChar = dim("·");
+
+	if (formatterFailed && blocking === 0 && errors === 0 && warnings === 0) {
+		dotChar = red("x");
+	}
 
 	let countsStyled = "";
 	if (errors > 0 && warnings > 0) {
@@ -1103,11 +1115,15 @@ function getOrCreate(filePath: string): FileRecord {
 }
 
 function hasChangedFormatter(rec: FileRecord): boolean {
-	return [...rec.formatters.values()].some((f) => f.changed);
+	return [...rec.formatters.values()].some((f) => f.changed && f.success);
+}
+
+function hasFailedFormatter(rec: FileRecord): boolean {
+	return [...rec.formatters.values()].some((f) => !f.success);
 }
 
 function shouldRenderFile(rec: FileRecord): boolean {
-	return rec.hasFinalDiagnosticsSnapshot || hasChangedFormatter(rec);
+	return rec.hasFinalDiagnosticsSnapshot || hasChangedFormatter(rec) || hasFailedFormatter(rec);
 }
 
 function isPendingAnalysis(rec: FileRecord): boolean {

--- a/clients/widget-state.ts
+++ b/clients/widget-state.ts
@@ -257,7 +257,14 @@ export function importWidgetState(state: PersistedWidgetState | undefined): bool
 		files.set(fileMapKey(f.filePath), {
 			filePath: f.filePath,
 			runners: new Map(f.runners ?? []),
-			formatters: new Map(f.formatters ?? []),
+			// Failure entries do NOT survive a session restore (#1348 review):
+			// a fmt-failed marker is live advice about THIS session's last
+			// attempt; rehydrating one from a snapshot shows a stale failure the
+			// current session never observed (and same-mtime fixes would never
+			// clear it). Successes rehydrate as before.
+			formatters: new Map(
+				(f.formatters ?? []).filter(([, outcome]) => outcome?.success !== false),
+			),
 			diagnostics: migrateEntryStamps(f.diagnostics, recordTouchedAt),
 			allDiagnostics: migrateEntryStamps(f.allDiagnostics, recordTouchedAt),
 			diagnosticCounts: f.diagnosticCounts ?? {
@@ -941,14 +948,17 @@ function formatFileRowVertical(
 	const errors = rec.diagnosticCounts.errors;
 	const warnings = rec.diagnosticCounts.warnings;
 	const formatterFailed = hasFailedFormatter(rec);
-	const dot = formatterFailed
-		? red("x")
-		:
+	// Diagnostic severity outranks formatter failure (#1348 review): a file
+	// with blocking diagnostics shows the blocking dot even if a format also
+	// failed -- same precedence as the horizontal renderer.
+	const dot =
 		blocking > 0
 			? red("●")
-			: warnings > 0 || errors > 0
-				? yellow("!")
-				: green("✓");
+			: formatterFailed
+				? red("x")
+				: warnings > 0 || errors > 0
+					? yellow("!")
+					: green("✓");
 	const runnerNames = [...rec.runners.entries()]
 		.filter(([, r]) => r.status !== "skipped")
 		.map(([id]) => id)

--- a/tests/clients/widget-state.test.ts
+++ b/tests/clients/widget-state.test.ts
@@ -409,6 +409,35 @@ describe("widget-state renderWidget", () => {
 		expect(allLines).not.toContain("fmt:biome");
 	});
 
+	it("renders formatter failures with an error indication", () => {
+		const filePath = `${process.cwd()}/broken.ts`;
+		recordFormatter(filePath, "prettier", false, false);
+
+		const allLines = renderWidget(60, theme).join("");
+		expect(allLines).toContain("broken.ts");
+		expect(allLines).toContain("prettier");
+		expect(allLines).toContain("fmt-failed:");
+		expect(allLines).toContain("x");
+	});
+
+	it("clears a formatter failure after a subsequent success", () => {
+		const filePath = `${process.cwd()}/recovered.ts`;
+		recordFormatter(filePath, "prettier", false, false);
+		expect(renderWidget(60, theme).join("")).toContain("fmt-failed:");
+
+		recordFormatter(filePath, "prettier", false, true);
+		const allLines = renderWidget(60, theme).join("");
+		expect(allLines).not.toContain("recovered.ts");
+		expect(allLines).not.toContain("fmt-failed:");
+	});
+
+	it("does not render an unchanged successful formatter", () => {
+		const filePath = `${process.cwd()}/unchanged.ts`;
+		recordFormatter(filePath, "prettier", false, true);
+
+		expect(renderWidget(60, theme).join("")).not.toContain("unchanged.ts");
+	});
+
 	it("packs multiple files into a single row at horizontal widths", () => {
 		const a = `${process.cwd()}/alpha.ts`;
 		const b = `${process.cwd()}/beta.ts`;

--- a/tests/clients/widget-state.test.ts
+++ b/tests/clients/widget-state.test.ts
@@ -430,9 +430,14 @@ describe("widget-state renderWidget", () => {
 			{ severity: "error", semantic: "blocking", message: "bad", tool: "tsserver" },
 		]);
 		recordFormatter(filePath, "prettier", false, false);
-		const line = renderWidget(120, theme).join("");
-		expect(line).toContain("●");
-		expect(line).not.toMatch(/x .*both-failed/);
+		// Pin the FILE ROW's leading glyph, not the whole render (the #1348
+		// delta review proved whole-output contains-assertions stay green under
+		// a broken precedence branch).
+		const row = renderWidget(120, theme).find((l) => l.includes("both-failed"));
+		expect(row).toBeDefined();
+		const plain = row!.replace(/\[[0-9;]*m/g, "").trimStart();
+		expect(plain.startsWith("●")).toBe(true);
+		expect(plain.startsWith("x")).toBe(false);
 	});
 
 	it("blocking diagnostics outrank a formatter failure (vertical renderer)", () => {
@@ -441,9 +446,11 @@ describe("widget-state renderWidget", () => {
 			{ severity: "error", semantic: "blocking", message: "bad", tool: "tsserver" },
 		]);
 		recordFormatter(filePath, "prettier", false, false);
-		const line = renderWidget(40, theme).join("");
-		expect(line).toContain("●");
-		expect(line).not.toMatch(/x both-failed-v/);
+		const row = renderWidget(40, theme).find((l) => l.includes("both-failed-v"));
+		expect(row).toBeDefined();
+		const plain = row!.replace(/\[[0-9;]*m/g, "").trimStart();
+		expect(plain.startsWith("●")).toBe(true);
+		expect(plain.startsWith("x")).toBe(false);
 	});
 
 	// #1348 review P2: failure entries are session-scoped advice -- they do

--- a/tests/clients/widget-state.test.ts
+++ b/tests/clients/widget-state.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	__testing,
 	clearWidgetState,
+	exportWidgetState,
 	getFailedLspServerIds,
 	getFileDiagnostics,
 	getFileDiagnosticSummaries,
@@ -418,6 +419,46 @@ describe("widget-state renderWidget", () => {
 		expect(allLines).toContain("prettier");
 		expect(allLines).toContain("fmt-failed:");
 		expect(allLines).toContain("x");
+	});
+
+	// #1348 review P1: diagnostic severity outranks formatter failure in BOTH
+	// renderers -- a file with blocking diagnostics AND a failed format shows
+	// the blocking dot, not the formatter x.
+	it("blocking diagnostics outrank a formatter failure (horizontal renderer)", () => {
+		const filePath = `${process.cwd()}/both-failed.ts`;
+		recordDiagnostics(filePath, [
+			{ severity: "error", semantic: "blocking", message: "bad", tool: "tsserver" },
+		]);
+		recordFormatter(filePath, "prettier", false, false);
+		const line = renderWidget(120, theme).join("");
+		expect(line).toContain("●");
+		expect(line).not.toMatch(/x .*both-failed/);
+	});
+
+	it("blocking diagnostics outrank a formatter failure (vertical renderer)", () => {
+		const filePath = `${process.cwd()}/both-failed-v.ts`;
+		recordDiagnostics(filePath, [
+			{ severity: "error", semantic: "blocking", message: "bad", tool: "tsserver" },
+		]);
+		recordFormatter(filePath, "prettier", false, false);
+		const line = renderWidget(40, theme).join("");
+		expect(line).toContain("●");
+		expect(line).not.toMatch(/x both-failed-v/);
+	});
+
+	// #1348 review P2: failure entries are session-scoped advice -- they do
+	// NOT survive export/import; successes rehydrate as before.
+	it("formatter failures do not survive a session restore", () => {
+		const failPath = `${process.cwd()}/stale-fail.ts`;
+		const okPath = `${process.cwd()}/ok-changed.ts`;
+		recordFormatter(failPath, "prettier", false, false);
+		recordFormatter(okPath, "biome", true, true);
+		const snapshot = exportWidgetState();
+		clearWidgetState();
+		expect(importWidgetState(snapshot)).toBe(true);
+		const line = renderWidget(120, theme).join("");
+		expect(line).not.toContain("fmt-failed:");
+		expect(line).not.toContain("stale-fail.ts");
 	});
 
 	it("clears a formatter failure after a subsequent success", () => {


### PR DESCRIPTION
## Summary
- render formatter failures in the widget with a red x and mt-failed: marker
- keep successful unchanged formatters hidden and clear a failure after success
- add regression coverage and changelog entry

## Verification
- 
pm run build
- 
pm run lint
- 9 targeted widget/index sibling test files: 130 passed
- mutation: restoring changed-only rendering made 2 widget-state tests fail

Closes #1346