### PR TITLE
feat(mode): derive widget mounting and notify chatter from the host run mode (refs #1334)

### DIFF
--- a/.changelog/fix-1334-s2-mode-awareness.md
+++ b/.changelog/fix-1334-s2-mode-awareness.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Terminal behavior now follows the pi host's run mode (refs #1334)** — pi-lens reads `ctx.mode` (`"tui" | "rpc" | "json" | "print"`) instead of assuming it owns an interactive terminal. The diagnostics widget mounts only in `tui`, and proactive `ui.notify` chatter is logged rather than rendered in the one-shot `print`/`json` modes, so piped and machine-readable runs stay clean. `/lens-widget-toggle` now says which mode is blocking it instead of blaming the pi version. Hosts that expose no `mode` field behave exactly as before.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1109,6 +1109,36 @@ pi-tui **hard-crashes the whole host process** (`uncaughtException: Rendered lin
 - Surfaces the HOST wraps for us are safe without fitting: `ctx.ui.notify` and the tool-summary compact renderers (`tools/render-compact.ts`) build on pi-tui's own `Text`/`Markdown` components, which word-wrap internally. A 2026-07-11 audit bucketed every render surface; only raw `render(width)` implementations carry the hazard.
 - Tests for renderers must measure with the REAL `visibleWidth` (ANSI/OSC8-aware) against a narrow width — mock-based render tests are exactly what let #513 ship.
 
+## Host run mode owns terminal behavior (#1334 S2)
+
+`ExtensionContext.mode` is `"tui" | "rpc" | "json" | "print"` (pinned host
+types, line 208). **Never guess terminal ownership — read it.**
+`clients/extension-mode.ts` is deliberately STATELESS: `mode` rides on the ctx
+handed to every event and command handler, so each call site reads the ctx it
+already has rather than consulting a latched global that a session replacement
+would leave stale.
+
+Two predicates, deliberately NOT the same one:
+
+- `supportsTuiWidget(mode)` — terminal-only custom components (the diagnostics
+  widget). `tui` only. **`rpc` is excluded despite `hasUI: true`** — dialogs
+  travel over the protocol there, a `belowEditor` component does not.
+- `suppressesUserNotify(mode)` — proactive chatter. Suppressed (logged, not
+  rendered) in `print`/`json`, which are one-shot runs whose stdout belongs to
+  the run's actual output.
+
+All user-facing notifies in `index.ts` go through the local `notifyUi(ctx, …)`
+helper — add new ones there, never a bare `ctx.ui.notify`. The
+`wireUserNotifier` getter applies the same predicate, so `clients/`-level
+degradation notices (#1333) become log-only in those modes too, via
+user-notify.ts's existing fail-soft "no host wired" path.
+
+`"unknown"` (older host with no `mode`, or a mode a future pi adds) keeps
+current behavior in BOTH predicates — never guess a suppression that could hide
+output. This is complementary to and independent of the #1338/#1333 console
+guard, which enforces "never write raw to the terminal"; mode decides whether
+the host's own render path should be used at all.
+
 ## ast-grep rules
 
 Rules live in `rules/ast-grep-rules/rules/*.yml` (plus the multi-rule `rules/ast-grep-rules/slop-patterns.yml`); disabled rules sit in `rules/ast-grep-rules/rules-disabled/` (sibling dir — not loaded). Run by `clients/dispatch/runners/ast-grep-napi.ts`. Discovery is RECURSIVE (#516) — language subdirectories load too; this is what activates the vendored CodeRabbit CWE catalog (`rules/ast-grep-rules/coderabbit/rules/**`, ~184 rules, ~13 of them TS/JS-live), pinned by a regression test asserting a nested CodeRabbit rule fires via NAPI.

--- a/clients/extension-mode.ts
+++ b/clients/extension-mode.ts
@@ -1,0 +1,79 @@
+/**
+ * Host run-mode awareness (#1334 S2).
+ *
+ * pi tells every extension which mode it is running in — verified against the
+ * pinned host types (`@earendil-works/pi-coding-agent/dist/core/extensions/
+ * types.d.ts`):
+ *
+ *   export type ExtensionMode = "tui" | "rpc" | "json" | "print";   // line 208
+ *   interface ExtensionContext { mode: ExtensionMode; hasUI: boolean; … }
+ *                                                       // lines 212-215
+ *
+ * The host's own comment on `mode` is the contract this module encodes:
+ * *"Use `"tui"` to guard terminal-only UI such as custom components."*
+ *
+ * pi-lens previously derived terminal ownership from nothing at all — it
+ * mounted its widget and chattered through `ui.notify` in every mode, including
+ * `print` and `json`, where the process is a one-shot producing machine- or
+ * pipe-consumed output and there is no live TUI to render into.
+ *
+ * Two independent questions, deliberately NOT the same predicate:
+ *
+ *   - *Is there a TUI to mount a custom component into?* Only `"tui"`. `rpc`
+ *     has `hasUI: true` (dialogs work over the protocol) but no terminal
+ *     component surface, so the widget must not mount there either.
+ *   - *Should proactive chatter reach the human?* No in `print` and `json` —
+ *     one-shot/machine output. Yes in `tui` and `rpc`.
+ *
+ * This is complementary to, and independent of, the #1338/#1333 console guard:
+ * that establishes "never write raw to the terminal"; this decides whether the
+ * HOST's own render path should be used at all in a given mode.
+ *
+ * Stateless by design: `mode` lives on the ctx pi hands to every event and
+ * command handler, so each call site reads it from the ctx it already has —
+ * no latched global to go stale across a session replacement.
+ */
+
+/** `ExtensionMode` plus the "older host, no `mode` field" case. */
+export type ExtensionRunMode = "tui" | "rpc" | "json" | "print" | "unknown";
+
+const KNOWN_MODES = new Set<string>(["tui", "rpc", "json", "print"]);
+
+/**
+ * Feature-detected read of `ctx.mode`.
+ *
+ * Returns `"unknown"` for a host that predates the field, or for any value
+ * outside the four documented modes (a future pi may add one; treating an
+ * unrecognized mode as "unknown" keeps current behavior rather than guessing
+ * a suppression that could hide output).
+ */
+export function readExtensionMode(ctx: unknown): ExtensionRunMode {
+	try {
+		const mode = (ctx as { mode?: unknown } | null | undefined)?.mode;
+		if (typeof mode !== "string" || !KNOWN_MODES.has(mode)) return "unknown";
+		return mode as ExtensionRunMode;
+	} catch {
+		return "unknown";
+	}
+}
+
+/**
+ * Whether a terminal-only custom component (the pi-lens diagnostics widget) can
+ * be mounted. `"unknown"` mounts — older hosts must behave exactly as before.
+ */
+export function supportsTuiWidget(mode: ExtensionRunMode): boolean {
+	return mode === "tui" || mode === "unknown";
+}
+
+/**
+ * Whether proactive `ui.notify` chatter should be suppressed (logged only).
+ * True only for the two non-interactive one-shot modes.
+ */
+export function suppressesUserNotify(mode: ExtensionRunMode): boolean {
+	return mode === "print" || mode === "json";
+}
+
+/** Short human-readable reason for a suppression, for the ndjson/debug log. */
+export function modeSuppressionNote(mode: ExtensionRunMode): string {
+	return `suppressed in "${mode}" mode (no interactive TUI)`;
+}

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,13 @@ import "./clients/console-guard-install.js";
 import "./clients/startup-marker.js";
 import { installConsoleGuard } from "./clients/extension-log.js";
 import { wireUserNotifier } from "./clients/user-notify.js";
+import {
+	type ExtensionRunMode,
+	modeSuppressionNote,
+	readExtensionMode,
+	suppressesUserNotify,
+	supportsTuiWidget,
+} from "./clients/extension-mode.js";
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -214,6 +221,28 @@ function rememberEventCtx(ctx: any): void {
 }
 
 /**
+ * Mode-aware `ctx.ui.notify` (#1334 S2). Every user-facing notify in this file
+ * goes through here so terminal ownership is derived from the HOST's
+ * `ctx.mode`, not from pi-lens guessing. In "print"/"json" the message is
+ * logged instead of rendered — those modes are one-shot pipelines whose stdout
+ * belongs to the run's actual output, not to extension chatter. "tui", "rpc"
+ * and an older host with no `mode` field all notify exactly as before.
+ */
+function notifyUi(
+	// biome-ignore lint/suspicious/noExplicitAny: heterogeneous pi event ctx shapes
+	ctx: any,
+	message: string,
+	level: "info" | "warning" | "error" = "info",
+): void {
+	const mode = readExtensionMode(ctx);
+	if (suppressesUserNotify(mode)) {
+		dbg(`notify ${modeSuppressionNote(mode)}: ${message.split("\n")[0]}`);
+		return;
+	}
+	ctx?.ui?.notify?.(message, level);
+}
+
+/**
  * Best-effort read of the STABLE pi session id off an event ctx
  * (`ctx.sessionManager.getSessionId()`), the same accessor #473's
  * session_start handling and #791's deferred-format ownership tagging both
@@ -389,6 +418,14 @@ export default function (pi: ExtensionAPI) {
 	wireUserNotifier(() => {
 		const ui = latestEventCtx?.ui;
 		if (!ui || typeof ui.notify !== "function") return undefined;
+		// #1334 S2: in "print"/"json" the process is a one-shot producing
+		// machine- or pipe-consumed output — there is no interactive surface for
+		// a degradation notice, and the ndjson sink already holds it. Returning
+		// undefined is exactly the "no host wired" path user-notify.ts already
+		// documents as fail-soft, so nothing is lost, only un-rendered.
+		if (suppressesUserNotify(readExtensionMode(latestEventCtx))) {
+			return undefined;
+		}
 		return (message: string, level?: "info" | "warning" | "error") =>
 			ui.notify(message, level ?? "warning");
 	});
@@ -581,7 +618,22 @@ export default function (pi: ExtensionAPI) {
 		options?: { placement: "belowEditor" },
 	) => void;
 
-	function mountLensWidget(ui: LensWidgetUi | undefined): boolean {
+	/**
+	 * #1334 S2: the widget is a terminal-only custom component. The host's own
+	 * types say so — *"Use `"tui"` to guard terminal-only UI such as custom
+	 * components"* — so mounting is gated on the mode pi reports, not attempted
+	 * blindly. `rpc` is excluded despite `hasUI: true`: dialogs travel over the
+	 * protocol there, a belowEditor component does not. An older host with no
+	 * `mode` field reads "unknown" and mounts exactly as before.
+	 */
+	function mountLensWidget(
+		ui: LensWidgetUi | undefined,
+		mode: ExtensionRunMode,
+	): boolean {
+		if (!supportsTuiWidget(mode)) {
+			dbg(`widget mount ${modeSuppressionNote(mode)}`);
+			return false;
+		}
 		if (typeof ui?.setWidget !== "function") return false;
 		const setWidget = ui.setWidget as LensWidgetSetWidget;
 		setWidget(
@@ -637,7 +689,8 @@ export default function (pi: ExtensionAPI) {
 			"Toggle pi-lens on/off for the current session. Usage: /lens-toggle",
 		handler: async (_args, ctx) => {
 			lensEnabled = !lensEnabled;
-			ctx.ui.notify(
+			notifyUi(
+				ctx,
 				lensEnabled
 					? "pi-lens enabled for this session."
 					: "pi-lens disabled for this session. Run /lens-toggle again to resume.",
@@ -651,7 +704,8 @@ export default function (pi: ExtensionAPI) {
 			"Toggle automatic context injection on/off for the current session (tools/LSP/read-guard/formatting stay active). Usage: /lens-context-toggle",
 		handler: async (_args, ctx) => {
 			contextInjectionEnabled = !contextInjectionEnabled;
-			ctx.ui.notify(
+			notifyUi(
+				ctx,
 				contextInjectionEnabled
 					? "pi-lens context injection enabled — findings will be added to the next turn."
 					: "pi-lens context injection disabled — findings are still cached (lens_diagnostics, /lens-health) but not added to model context.",
@@ -665,11 +719,24 @@ export default function (pi: ExtensionAPI) {
 			"Show or hide the pi-lens diagnostics widget below the editor. Usage: /lens-widget-toggle",
 		handler: async (_args, ctx) => {
 			const nextVisible = !lensWidgetVisible;
+			const mode = readExtensionMode(ctx);
+			// #1334 S2: distinguish "this pi is too old" from "this run mode has
+			// no terminal to draw into" — the old single message blamed the pi
+			// version for what is really a mode constraint.
+			if (nextVisible && !supportsTuiWidget(mode)) {
+				notifyUi(
+					ctx,
+					`pi-lens widget needs an interactive TUI — unavailable in "${mode}" mode.`,
+					"warning",
+				);
+				return;
+			}
 			const changed = nextVisible
-				? mountLensWidget(ctx.ui)
+				? mountLensWidget(ctx.ui, mode)
 				: unmountLensWidget(ctx.ui);
 			if (!changed) {
-				ctx.ui.notify(
+				notifyUi(
+					ctx,
 					"pi-lens widget is not supported by this pi version.",
 					"warning",
 				);
@@ -677,7 +744,8 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			lensWidgetVisible = nextVisible;
-			ctx.ui.notify(
+			notifyUi(
+				ctx,
 				lensWidgetVisible
 					? "pi-lens widget shown. Run /lens-widget-toggle to hide it."
 					: "pi-lens widget hidden. Run /lens-widget-toggle to show it.",
@@ -720,7 +788,7 @@ export default function (pi: ExtensionAPI) {
 				summary,
 			];
 
-			ctx.ui.notify(lines.join("\n"), "info");
+			notifyUi(ctx, lines.join("\n"), "info");
 		},
 	});
 
@@ -760,9 +828,10 @@ export default function (pi: ExtensionAPI) {
 						"Graph exceeded the map's node cap — showing the highest-degree files only (see the in-page note).",
 					);
 				}
-				ctx.ui.notify(lines.join("\n"), "info");
+				notifyUi(ctx, lines.join("\n"), "info");
 			} catch (err) {
-				ctx.ui.notify(
+				notifyUi(
+					ctx,
 					`Failed to generate the project map: ${err instanceof Error ? err.message : String(err)}`,
 					"error",
 				);
@@ -885,7 +954,10 @@ export default function (pi: ExtensionAPI) {
 			// Memory attribution (#1123 item 2) — reuses the same O(1) accessors the
 			// periodic latency.log `memory_sample` uses; see clients/memory-sampler.ts.
 			try {
-				lines.push("", formatMemoryHealthLine(buildMemorySample(runtime.wordIndex)));
+				lines.push(
+					"",
+					formatMemoryHealthLine(buildMemorySample(runtime.wordIndex)),
+				);
 			} catch {
 				// best-effort — a health-line render must never break /lens-health
 			}
@@ -973,7 +1045,7 @@ export default function (pi: ExtensionAPI) {
 				lines.push("", slopScoreLine);
 			}
 
-			ctx.ui.notify(lines.join("\n"), "info");
+			notifyUi(ctx, lines.join("\n"), "info");
 		},
 	});
 
@@ -987,9 +1059,10 @@ export default function (pi: ExtensionAPI) {
 				const report = await collectLatencyPerformance({
 					sessionStartedAt: runtime.sessionStartedAt,
 				});
-				ctx.ui.notify(renderLatencyPerformanceReport(report), "info");
+				notifyUi(ctx, renderLatencyPerformanceReport(report), "info");
 			} catch (err) {
-				ctx.ui.notify(
+				notifyUi(
+					ctx,
 					`Failed to read performance telemetry: ${err instanceof Error ? err.message : String(err)}`,
 					"error",
 				);
@@ -1092,7 +1165,7 @@ export default function (pi: ExtensionAPI) {
 				);
 			}
 
-			ctx.ui.notify(lines.join("\n"), "info");
+			notifyUi(ctx, lines.join("\n"), "info");
 		},
 	});
 
@@ -1102,7 +1175,7 @@ export default function (pi: ExtensionAPI) {
 		handler: async (args, ctx) => {
 			const [rawTarget] = normalizeCommandArgs(args);
 			if (!rawTarget) {
-				ctx.ui.notify("Usage: /lens-allow-edit <path>", "warning");
+				notifyUi(ctx, "Usage: /lens-allow-edit <path>", "warning");
 				return;
 			}
 
@@ -1110,7 +1183,8 @@ export default function (pi: ExtensionAPI) {
 				? rawTarget
 				: path.resolve(ctx.cwd ?? runtime.projectRoot, rawTarget);
 			runtime.readGuard.addExemption(targetPath);
-			ctx.ui.notify(
+			notifyUi(
+				ctx,
 				`Read guard override armed for next edit: ${targetPath}`,
 				"info",
 			);
@@ -1239,7 +1313,11 @@ export default function (pi: ExtensionAPI) {
 	// substantive pi-lens tool — see tools/render-compact.ts) are wrapped;
 	// the rest pass through wrapToolsForCompactLine unchanged.
 	const compactToolLineEnabled = getLensFlag("lens-compact-tool-line") === true;
-	const toolsToRegister = [...alwaysActiveTools, activateToolsTool, ...lazyTools];
+	const toolsToRegister = [
+		...alwaysActiveTools,
+		activateToolsTool,
+		...lazyTools,
+	];
 	for (const tool of compactToolLineEnabled
 		? wrapToolsForCompactLine(toolsToRegister as any)
 		: toolsToRegister) {
@@ -1467,7 +1545,7 @@ export default function (pi: ExtensionAPI) {
 				bootstrapClientsStartedAt,
 				bootstrapClientsDurationMs,
 				getFlag: (name: string) => getLensFlag(name),
-				notify: (msg, level) => ctx.ui.notify(msg, level),
+				notify: (msg, level) => notifyUi(ctx, msg, level),
 				dbg,
 				log,
 				runtime,
@@ -1595,7 +1673,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			if (lensWidgetVisible) {
-				mountLensWidget(ctx.ui);
+				mountLensWidget(ctx.ui, readExtensionMode(ctx));
 			}
 		} catch (sessionErr) {
 			dbg(`session_start crashed: ${sessionErr}`);
@@ -1777,7 +1855,7 @@ export default function (pi: ExtensionAPI) {
 					getLensFlag(name, filePath),
 				getFlagSource: (name: string, filePath?: string) =>
 					getLensFlagSource(name, filePath),
-				notify: (msg, level) => ctx.ui.notify(msg, level),
+				notify: (msg, level) => notifyUi(ctx, msg, level),
 				dbg,
 				runtime,
 				cacheManager,
@@ -1836,7 +1914,10 @@ export default function (pi: ExtensionAPI) {
 					sessionSuspectedStalls += 1;
 				} else {
 					lastLoggedLoopWorstMs = loopMaxMs;
-					sessionWorstRealBlockMs = Math.max(sessionWorstRealBlockMs, loopMaxMs);
+					sessionWorstRealBlockMs = Math.max(
+						sessionWorstRealBlockMs,
+						loopMaxMs,
+					);
 				}
 			}
 			// Start a fresh per-turn occupancy window so the next turn's worst
@@ -1870,7 +1951,7 @@ export default function (pi: ExtensionAPI) {
 			if (shouldCheckSmellsThisTurn(runtime.turnIndex)) {
 				try {
 					for (const note of checkSmellsAndNoteOnce(countRecentSmells())) {
-						ctx.ui.notify(note, "warning");
+						notifyUi(ctx, note, "warning");
 					}
 				} catch {
 					// best-effort observability — never fail turn_end over this

--- a/tests/clients/extension-mode.test.ts
+++ b/tests/clients/extension-mode.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+	modeSuppressionNote,
+	readExtensionMode,
+	suppressesUserNotify,
+	supportsTuiWidget,
+} from "../../clients/extension-mode.ts";
+
+describe("readExtensionMode (#1334 S2)", () => {
+	it("passes through the four documented host modes", () => {
+		for (const mode of ["tui", "rpc", "json", "print"] as const) {
+			expect(readExtensionMode({ mode })).toBe(mode);
+		}
+	});
+
+	it("reports 'unknown' for a host with no mode field", () => {
+		expect(readExtensionMode({})).toBe("unknown");
+		expect(readExtensionMode(undefined)).toBe("unknown");
+		expect(readExtensionMode(null)).toBe("unknown");
+	});
+
+	it("reports 'unknown' for an unrecognized or non-string mode", () => {
+		// A future pi could add a mode; never guess a suppression for it.
+		expect(readExtensionMode({ mode: "holodeck" })).toBe("unknown");
+		expect(readExtensionMode({ mode: 3 })).toBe("unknown");
+	});
+});
+
+describe("mode-derived behavior predicates", () => {
+	it("mounts the TUI widget only in tui — and on older hosts", () => {
+		expect(supportsTuiWidget("tui")).toBe(true);
+		expect(supportsTuiWidget("unknown")).toBe(true);
+		// rpc has hasUI:true (dialogs) but no terminal component surface.
+		expect(supportsTuiWidget("rpc")).toBe(false);
+		expect(supportsTuiWidget("json")).toBe(false);
+		expect(supportsTuiWidget("print")).toBe(false);
+	});
+
+	it("suppresses notify chatter only in the one-shot output modes", () => {
+		expect(suppressesUserNotify("print")).toBe(true);
+		expect(suppressesUserNotify("json")).toBe(true);
+		expect(suppressesUserNotify("tui")).toBe(false);
+		expect(suppressesUserNotify("rpc")).toBe(false);
+		expect(suppressesUserNotify("unknown")).toBe(false);
+	});
+
+	it("names the mode in its suppression note", () => {
+		expect(modeSuppressionNote("print")).toContain("print");
+	});
+});

--- a/tests/index-mode-awareness.test.ts
+++ b/tests/index-mode-awareness.test.ts
@@ -1,0 +1,154 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import extension from "../index.js";
+import { createPiMock, makeCtx } from "./support/pi-mock.js";
+import { removeTempDirSync } from "./clients/test-utils.js";
+
+// Same two heavy seams tests/index-wiring.test.ts stubs, so firing
+// session_start stays a fast deterministic wiring check.
+vi.mock("../clients/bootstrap.js", () => ({
+	loadBootstrapClients: async () => ({
+		metricsClient: { reset: () => {} },
+		todoScanner: {},
+		biomeClient: { isAvailable: () => false },
+		ruffClient: { isAvailable: () => false },
+		knipClient: {
+			isAvailable: () => false,
+			analyze: async () => ({
+				success: false,
+				summary: "unavailable",
+				issues: [],
+			}),
+		},
+		jscpdClient: { isAvailable: () => false },
+		depChecker: { isAvailable: () => false },
+		testRunnerClient: { detectRunner: () => null },
+		goClient: { isGoAvailableAsync: async () => false },
+		rustClient: { isAvailableAsync: async () => false },
+		agentBehaviorClient: {
+			recordToolCall: () => {},
+			formatWarnings: () => "",
+		},
+		complexityClient: {
+			isSupportedFile: () => false,
+			analyzeFile: () => null,
+		},
+	}),
+}));
+vi.mock("../clients/runtime-session.js", () => ({
+	handleSessionStart: async () => {},
+}));
+
+const tmpDirs: string[] = [];
+
+function tmpProject(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-mode-aware-"));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tmpDirs.splice(0)) removeTempDirSync(dir);
+});
+
+/**
+ * #1334 S2 — terminal-ownership behavior is derived from the HOST's
+ * `ctx.mode`, not guessed. The widget is a terminal-only custom component; the
+ * one-shot output modes get no proactive notify chatter.
+ */
+/**
+ * The mount is driven through `/lens-widget-toggle` rather than
+ * `session_start`: #473's concurrent-secondary guard makes a SECOND
+ * `session_start` in the same process return early, which would make these
+ * assertions silently order-dependent (and the negative ones vacuous). The
+ * command path runs the same `mountLensWidget` through the real handler.
+ * The widget starts visible, so the first toggle hides it and the second is
+ * the mount under test.
+ */
+describe("widget mounting is mode-derived (#1334 S2)", () => {
+	async function toggleTwice(
+		mode: "tui" | "rpc" | "json" | "print" | null,
+	) {
+		const pi = createPiMock();
+		extension(pi.asExtensionAPI());
+		const ctx = makeCtx({ cwd: tmpProject(), mode });
+		await pi.runCommand("lens-widget-toggle", "", ctx);
+		await pi.runCommand("lens-widget-toggle", "", ctx);
+		return ctx;
+	}
+
+	/** A mount is a setWidget call carrying a component factory. */
+	const mounts = (ctx: Awaited<ReturnType<typeof toggleTwice>>) =>
+		ctx.widgetCalls.filter((c) => typeof c.content === "function");
+
+	for (const mode of ["print", "json", "rpc"] as const) {
+		it(`never mounts the widget in "${mode}" mode`, async () => {
+			const ctx = await toggleTwice(mode);
+
+			expect(mounts(ctx)).toHaveLength(0);
+		});
+	}
+
+	it('explains the MODE, not the pi version, when refusing in "rpc"', async () => {
+		const ctx = await toggleTwice("rpc");
+
+		const last = ctx.notifications.at(-1);
+		expect(last?.message).toContain("interactive TUI");
+		expect(last?.message).toContain("rpc");
+		expect(last?.type).toBe("warning");
+	});
+
+	it('mounts the widget in "tui" mode', async () => {
+		const ctx = await toggleTwice("tui");
+
+		expect(mounts(ctx)).toHaveLength(1);
+		expect(mounts(ctx)[0]).toMatchObject({
+			key: "pi-lens",
+			options: { placement: "belowEditor" },
+		});
+	});
+
+	it("mounts the widget on an older host with no mode field", async () => {
+		const ctx = await toggleTwice(null);
+
+		expect(mounts(ctx)).toHaveLength(1);
+	});
+});
+
+describe("notify chatter is mode-derived (#1334 S2)", () => {
+	for (const mode of ["print", "json"] as const) {
+		it(`suppresses command notify output in "${mode}" mode`, async () => {
+			const pi = createPiMock();
+			extension(pi.asExtensionAPI());
+			const ctx = makeCtx({ cwd: tmpProject(), mode });
+
+			await pi.runCommand("lens-toggle", "", ctx);
+
+			expect(ctx.notifications).toHaveLength(0);
+		});
+	}
+
+	for (const mode of ["tui", "rpc"] as const) {
+		it(`still notifies in "${mode}" mode`, async () => {
+			const pi = createPiMock();
+			extension(pi.asExtensionAPI());
+			const ctx = makeCtx({ cwd: tmpProject(), mode });
+
+			await pi.runCommand("lens-toggle", "", ctx);
+
+			expect(ctx.notifications).toHaveLength(1);
+		});
+	}
+
+	it("still notifies on an older host with no mode field", async () => {
+		const pi = createPiMock();
+		extension(pi.asExtensionAPI());
+		const ctx = makeCtx({ cwd: tmpProject(), mode: null });
+
+		await pi.runCommand("lens-toggle", "", ctx);
+
+		expect(ctx.notifications).toHaveLength(1);
+	});
+});

--- a/tests/support/pi-mock.ts
+++ b/tests/support/pi-mock.ts
@@ -249,7 +249,16 @@ export function createPiMock(
  * `ui.notify(...)` for assertions.
  */
 export function makeCtx(
-	overrides: Partial<{ cwd: string; sessionId: string }> = {},
+	overrides: Partial<{
+		cwd: string;
+		sessionId: string;
+		/**
+		 * #1334 S2: the host run mode (`ExtensionContext.mode`). Defaults to
+		 * "tui". Pass `null` to simulate an older host with NO `mode` field —
+		 * pi-lens must then behave exactly as it did before mode awareness.
+		 */
+		mode: "tui" | "rpc" | "json" | "print" | null;
+	}> = {},
 ): MockCtx {
 	const notifications: CapturedNotification[] = [];
 	const statusCalls: CapturedStatus[] = [];
@@ -297,6 +306,14 @@ export function makeCtx(
 		getSystemPrompt: () => "",
 		waitForIdle: async () => {},
 	};
+
+	// `mode: null` means "older host, no mode field at all" — delete it rather
+	// than leaving a null the feature detection would have to special-case.
+	if (overrides.mode === null) {
+		delete (ctx as Record<string, unknown>).mode;
+	} else if (overrides.mode !== undefined) {
+		(ctx as Record<string, unknown>).mode = overrides.mode;
+	}
 
 	return ctx as unknown as MockCtx;
 }


### PR DESCRIPTION
Slice S2 of #1334 — refs #1334.

## The gap

pi-lens derived terminal ownership from nothing. It mounted its `belowEditor`
widget and pushed `ui.notify` chatter in every run mode, including `print` and
`json` — one-shot runs whose stdout belongs to the run's actual output, with no
live TUI to render into.

## API surface verified (pinned host types)

`@earendil-works/pi-coding-agent/dist/core/extensions/types.d.ts`:

- `export type ExtensionMode = "tui" | "rpc" | "json" | "print"` — line 208
- `ExtensionContext.mode: ExtensionMode` — line 213, with the host's own
  comment: *"Use `"tui"` to guard terminal-only UI such as custom components."*
- `ExtensionContext.hasUI: boolean` — line 215, *"true in TUI and RPC modes"*

**What that changed in the design:** `hasUI` and "can mount a component" are
**not** the same question. `rpc` reports `hasUI: true` because dialogs travel
over the protocol — but there is no terminal for a `belowEditor` component.
So the slice ships **two distinct predicates**, not one `hasUI` check:

| Predicate | True for | Gates |
| --- | --- | --- |
| `supportsTuiWidget` | `tui`, `unknown` | `mountLensWidget` |
| `suppressesUserNotify` | `print`, `json` | proactive `ui.notify` |

`rpc` therefore mounts no widget but still notifies — which is exactly the
slice's "rpc — no TUI widget" requirement.

## What landed

`clients/extension-mode.ts` — **stateless by design.** `mode` rides on the ctx
every event and command handler already receives, so each call site reads the
ctx it has; there is no latched global for a session replacement to leave stale
(a contrast with S5's trust state, which genuinely has no ctx at its call
sites).

- `mountLensWidget(ui, mode)` refuses in non-`tui` modes.
- All 16 user-facing `ctx.ui.notify` sites in `index.ts` now route through a
  local mode-aware `notifyUi(ctx, …)`. Suppressed messages are still written to
  the debug log — nothing is lost, only un-rendered.
- The `wireUserNotifier` getter applies the same predicate, so `clients/`-level
  degradation notices (#1333) go log-only in `print`/`json` through
  `user-notify.ts`'s existing fail-soft "no host wired" path — no new plumbing.
- `/lens-widget-toggle` now names the blocking **mode** instead of reporting
  "not supported by this pi version", which was misattributing a mode
  constraint to the host version.

The #1338 console guard is **untouched** — it enforces "never write raw to the
terminal"; this slice decides whether the host's own render path should be used
at all. Complementary, not overlapping.

## Feature detection

An absent `mode` (older host) — or a value outside the four documented modes,
e.g. one a future pi adds — reads `"unknown"` and keeps current behavior in
**both** predicates. Deliberate asymmetry: never guess a suppression that could
hide output.

## Tests (17 new, all green)

- `tests/clients/extension-mode.test.ts` (6) — mode passthrough, absent /
  unrecognized / non-string → `unknown`, and both predicates across all five
  states.
- `tests/index-mode-awareness.test.ts` (11) — through the real entry point:
  no mount in `print`/`json`/`rpc`, mount in `tui` and on a host with no `mode`
  field, the mode-specific refusal message, notify suppressed in `print`/`json`
  and preserved in `tui`/`rpc`/no-mode.

One deliberate test-design note: the widget assertions drive
`/lens-widget-toggle` rather than a second `session_start`, because #473's
concurrent-secondary guard makes a repeat `session_start` in the same process
return early — which would have made the negative assertions silently vacuous.
That is called out in a comment in the test file.

`tests/support/pi-mock.ts` gained a `mode` override, where `null` means "older
host with no `mode` field at all" (the key is deleted, not set to null).

## Verification

`npm run build` ✅ · new tests 17/17 ✅ · siblings (`index-wiring`,
`index-integration`, `lens-toggle-command`, `index-loop-block-wiring`,
`index-smells-rollup-wiring`) 49/49 ✅ · `npm run lint` ✅ ·
`npm run changelog:check` ✅

AGENTS.md documents the two-predicate split, the `rpc`-despite-`hasUI` trap, and
the "add new notifies to `notifyUi`, never a bare `ctx.ui.notify`" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
