### PR TITLE
feat(ci): validate per-issue close keywords (closes #1320)

### DIFF
--- a/.changelog/feat-1320-close-keyword-ci.md
+++ b/.changelog/feat-1320-close-keyword-ci.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Per-issue close-keyword CI validation** — Rejects comma-separated GitHub close lists and verifies merged PR close targets.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,20 @@ on:
     branches: [master]
 
 jobs:
+  close-keyword-lint:
+    name: Close-keyword syntax
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Validate per-issue close keywords
+        run: node scripts/check-close-keywords.mjs --lint-pr
+
   lint-and-typecheck:
     name: Lint & type-check
     runs-on: ubuntu-latest

--- a/.github/workflows/close-keyword-verification.yml
+++ b/.github/workflows/close-keyword-verification.yml
@@ -1,0 +1,25 @@
+name: Verify merged PR close keywords
+
+on:
+  pull_request:
+    branches: [master]
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+jobs:
+  verify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Verify referenced issues closed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/check-close-keywords.mjs --verify-merged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,13 @@ empty result, while the project ignore matcher remains authoritative.
 
 A pi coding-agent extension that runs automated checks on every file write/edit. Dispatches async parallel runners (LSP, biome, ruff, ast-grep, tree-sitter, jscpd, knip, Madge, and language-specific linters/build checks) and injects findings as context injections at turn-end and session-start.
 
+CI validates GitHub close-keyword syntax through `scripts/check-close-keywords.mjs`:
+PR bodies may not use a comma-separated close list because GitHub applies only
+the first issue per keyword; use one keyword per issue (`Closes #A. Closes #B.`).
+The merged-PR workflow rechecks each same-repository close target and comments on
+the PR when a referenced issue is missing or remains open. Keep the parser pure
+and unit-tested; workflow YAML should only pass the event to the script.
+
 The shipped ast-grep catalog includes `no-bare-host-path-in-win32-branch`
 (#1158 shape 2). It deliberately matches only the consequence of an `if`
 guarded by `isWindowsPath` or `isFullyQualifiedWin32`; host-default path calls

--- a/scripts/check-close-keywords.d.mts
+++ b/scripts/check-close-keywords.d.mts
@@ -1,0 +1,13 @@
+export declare const INVALID_CLOSE_KEYWORD_MESSAGE: string;
+export declare function stripNonSemanticMarkdown(body?: string): string;
+export declare function parseCloseKeywords(body?: string): {
+	issues: number[];
+	commaLists: number[];
+	offendingLines: string[];
+};
+export declare function lintCloseKeywords(body?: string): {
+	issues: number[];
+	commaLists: number[];
+	offendingLines: string[];
+	valid: boolean;
+};

--- a/scripts/check-close-keywords.mjs
+++ b/scripts/check-close-keywords.mjs
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const CLOSE_KEYWORD = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b/gi;
+const CLOSE_ISSUE = /\s*:?[ \t]*#(\d+)/y;
+const COMMA_ISSUE = /\s*,\s*#(\d+)/y;
+
+export const INVALID_CLOSE_KEYWORD_MESSAGE =
+	'Invalid close-keyword syntax: GitHub only applies the first issue in a comma-separated close list. Use one close keyword per issue, for example "Closes #123. Closes #456." (not "Closes #123, #456").';
+
+/**
+ * Parse same-repository issues named by GitHub close keywords.
+ * Cross-repository references (owner/repo#123) intentionally do not match.
+ */
+export function parseCloseKeywords(body = "") {
+	const issues = [];
+	const commaLists = [];
+
+	for (const match of body.matchAll(CLOSE_KEYWORD)) {
+		const rest = body.slice(match.index + match[0].length);
+		CLOSE_ISSUE.lastIndex = 0;
+		const issue = CLOSE_ISSUE.exec(rest);
+		if (!issue) continue;
+
+		const number = Number(issue[1]);
+		if (!issues.includes(number)) issues.push(number);
+
+		COMMA_ISSUE.lastIndex = 0;
+		if (COMMA_ISSUE.exec(rest.slice(issue[0].length))) {
+			commaLists.push(number);
+		}
+	}
+
+	return { issues, commaLists };
+}
+
+export function lintCloseKeywords(body = "") {
+	const parsed = parseCloseKeywords(body);
+	return {
+		...parsed,
+		valid: parsed.commaLists.length === 0,
+	};
+}
+
+function eventPayload() {
+	const eventPath = process.env.GITHUB_EVENT_PATH;
+	if (!eventPath) throw new Error("GITHUB_EVENT_PATH is required");
+	return JSON.parse(readFileSync(eventPath, "utf8"));
+}
+
+function lintPullRequest() {
+	const result = lintCloseKeywords(eventPayload().pull_request?.body ?? "");
+	if (!result.valid) {
+		console.error(INVALID_CLOSE_KEYWORD_MESSAGE);
+		process.exitCode = 1;
+		return;
+	}
+	console.log(`Close-keyword syntax OK (${result.issues.length} issue${result.issues.length === 1 ? "" : "s"} referenced).`);
+}
+
+function issueState(repository, number) {
+	try {
+		return execFileSync("gh", ["api", `repos/${repository}/issues/${number}`, "--jq", ".state"], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		}).trim();
+	} catch {
+		return "not found";
+	}
+}
+
+function verifyMergedPullRequest() {
+	const event = eventPayload();
+	const pullRequest = event.pull_request;
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!pullRequest || !repository) throw new Error("Pull request event and GITHUB_REPOSITORY are required");
+
+	const { issues } = parseCloseKeywords(pullRequest.body ?? "");
+	const unresolved = issues
+		.map((number) => ({ number, state: issueState(repository, number) }))
+		.filter(({ state }) => state !== "closed");
+	if (unresolved.length === 0) {
+		console.log(`Post-merge close verification OK (${issues.length} issue${issues.length === 1 ? "" : "s"} closed).`);
+		return;
+	}
+
+	const details = unresolved.map(({ number, state }) => `#${number} (${state})`).join(", ");
+	const message = `Post-merge close verification found issue(s) that were not closed: ${details}. GitHub only applies the first issue in a comma-separated close list; use one close keyword per issue (for example, "Closes #123. Closes #456.").`;
+	console.error(message);
+	execFileSync("gh", ["pr", "comment", String(pullRequest.number), "--repo", repository, "--body", message], {
+		stdio: "inherit",
+	});
+	process.exitCode = 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+	try {
+		if (process.argv[2] === "--lint-pr") lintPullRequest();
+		else if (process.argv[2] === "--verify-merged") verifyMergedPullRequest();
+		else throw new Error("Usage: node scripts/check-close-keywords.mjs --lint-pr|--verify-merged");
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : error);
+		process.exitCode = 1;
+	}
+}

--- a/scripts/check-close-keywords.mjs
+++ b/scripts/check-close-keywords.mjs
@@ -10,15 +10,36 @@ export const INVALID_CLOSE_KEYWORD_MESSAGE =
 	'Invalid close-keyword syntax: GitHub only applies the first issue in a comma-separated close list. Use one close keyword per issue, for example "Closes #123. Closes #456." (not "Closes #123, #456").';
 
 /**
+ * Remove markdown regions where a close keyword is quotation, not intent
+ * (#1355 review): fenced code blocks, inline code spans, and blockquote
+ * lines. A PR body QUOTING the bad form as documentation must not fail its
+ * own check -- GitHub itself still parses keywords in these regions, so this
+ * is deliberately stricter than the platform: quoted forms are exempt from
+ * OUR lint while remaining the author's responsibility platform-side.
+ */
+export function stripNonSemanticMarkdown(body = "") {
+	return body
+		.replace(/```[\s\S]*?```/g, "")
+		.replace(/`[^`\n]*`/g, "")
+		.split("\n")
+		.filter((line) => !/^\s*>/.test(line))
+		.join("\n");
+}
+
+/**
  * Parse same-repository issues named by GitHub close keywords.
  * Cross-repository references (owner/repo#123) intentionally do not match.
+ * The body is scanned AFTER stripNonSemanticMarkdown so quoted examples in
+ * code fences/blockquotes are not linted as real syntax.
  */
 export function parseCloseKeywords(body = "") {
+	const scanned = stripNonSemanticMarkdown(body);
 	const issues = [];
 	const commaLists = [];
+	const offendingLines = [];
 
-	for (const match of body.matchAll(CLOSE_KEYWORD)) {
-		const rest = body.slice(match.index + match[0].length);
+	for (const match of scanned.matchAll(CLOSE_KEYWORD)) {
+		const rest = scanned.slice(match.index + match[0].length);
 		CLOSE_ISSUE.lastIndex = 0;
 		const issue = CLOSE_ISSUE.exec(rest);
 		if (!issue) continue;
@@ -29,10 +50,15 @@ export function parseCloseKeywords(body = "") {
 		COMMA_ISSUE.lastIndex = 0;
 		if (COMMA_ISSUE.exec(rest.slice(issue[0].length))) {
 			commaLists.push(number);
+			const lineStart = scanned.lastIndexOf("\n", match.index) + 1;
+			const lineEnd = scanned.indexOf("\n", match.index);
+			offendingLines.push(
+				scanned.slice(lineStart, lineEnd === -1 ? undefined : lineEnd).trim(),
+			);
 		}
 	}
 
-	return { issues, commaLists };
+	return { issues, commaLists, offendingLines };
 }
 
 export function lintCloseKeywords(body = "") {
@@ -53,6 +79,9 @@ function lintPullRequest() {
 	const result = lintCloseKeywords(eventPayload().pull_request?.body ?? "");
 	if (!result.valid) {
 		console.error(INVALID_CLOSE_KEYWORD_MESSAGE);
+		for (const line of result.offendingLines) {
+			console.error(`  offending line: ${line}`);
+		}
 		process.exitCode = 1;
 		return;
 	}
@@ -86,11 +115,27 @@ function verifyMergedPullRequest() {
 	}
 
 	const details = unresolved.map(({ number, state }) => `#${number} (${state})`).join(", ");
-	const message = `Post-merge close verification found issue(s) that were not closed: ${details}. GitHub only applies the first issue in a comma-separated close list; use one close keyword per issue (for example, "Closes #123. Closes #456.").`;
+	const marker = "<!-- close-keyword-verifier -->";
+	const message = `${marker}
+Post-merge close verification found issue(s) that were not closed: ${details}. GitHub only applies the first issue in a comma-separated close list; use one close keyword per issue (for example, "Closes #123. Closes #456.").`;
 	console.error(message);
-	execFileSync("gh", ["pr", "comment", String(pullRequest.number), "--repo", repository, "--body", message], {
-		stdio: "inherit",
-	});
+	// Idempotence (#1355 review): a rerun must not stack duplicate comments.
+	let alreadyCommented = false;
+	try {
+		const existing = execFileSync(
+			"gh",
+			["pr", "view", String(pullRequest.number), "--repo", repository, "--json", "comments", "--jq", ".comments[].body"],
+			{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+		);
+		alreadyCommented = existing.includes(marker);
+	} catch {
+		// listing failed -- fall through and comment rather than stay silent
+	}
+	if (!alreadyCommented) {
+		execFileSync("gh", ["pr", "comment", String(pullRequest.number), "--repo", repository, "--body", message], {
+			stdio: "inherit",
+		});
+	}
 	process.exitCode = 1;
 }
 

--- a/tests/scripts/check-close-keywords.test.ts
+++ b/tests/scripts/check-close-keywords.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+	INVALID_CLOSE_KEYWORD_MESSAGE,
+	lintCloseKeywords,
+	parseCloseKeywords,
+} from "../../scripts/check-close-keywords.mjs";
+
+describe("close-keyword parser (#1320)", () => {
+	it("parses one close keyword", () => {
+		expect(parseCloseKeywords("Closes #123")).toEqual({ issues: [123], commaLists: [] });
+	});
+
+	it("parses multiple correctly separated close keywords", () => {
+		expect(parseCloseKeywords("Fixes #1. resolves #2; CLOSED #3")).toEqual({
+			issues: [1, 2, 3],
+			commaLists: [],
+		});
+	});
+
+	it("flags a comma-separated close list", () => {
+		expect(lintCloseKeywords("Closes #123, #456")).toEqual({
+			issues: [123],
+			commaLists: [123],
+			valid: false,
+		});
+	});
+
+	it("accepts comma punctuation between separately keyworded issues", () => {
+		expect(lintCloseKeywords("Closes #123, fixes #456").valid).toBe(true);
+	});
+
+	it("does not treat refs as close keywords", () => {
+		expect(parseCloseKeywords("Refs #123, relates to #456")).toEqual({ issues: [], commaLists: [] });
+	});
+
+	it("handles case variants and optional colon", () => {
+		expect(parseCloseKeywords("CLOSES: #7; FiXeD #8; ResolveD #9").issues).toEqual([7, 8, 9]);
+	});
+
+	it("ignores cross-repository references", () => {
+		expect(parseCloseKeywords("Closes owner/repo#123; fixes #456")).toEqual({
+			issues: [456],
+			commaLists: [],
+		});
+	});
+
+	it("deduplicates repeated issue references", () => {
+		expect(parseCloseKeywords("Closes #12. Fixes #12").issues).toEqual([12]);
+	});
+
+	it("exposes the exact lint failure message", () => {
+		expect(INVALID_CLOSE_KEYWORD_MESSAGE).toBe(
+			'Invalid close-keyword syntax: GitHub only applies the first issue in a comma-separated close list. Use one close keyword per issue, for example "Closes #123. Closes #456." (not "Closes #123, #456").',
+		);
+	});
+});

--- a/tests/scripts/check-close-keywords.test.ts
+++ b/tests/scripts/check-close-keywords.test.ts
@@ -7,18 +7,18 @@ import {
 
 describe("close-keyword parser (#1320)", () => {
 	it("parses one close keyword", () => {
-		expect(parseCloseKeywords("Closes #123")).toEqual({ issues: [123], commaLists: [] });
+		expect(parseCloseKeywords("Closes #123")).toMatchObject({ issues: [123], commaLists: [] });
 	});
 
 	it("parses multiple correctly separated close keywords", () => {
-		expect(parseCloseKeywords("Fixes #1. resolves #2; CLOSED #3")).toEqual({
+		expect(parseCloseKeywords("Fixes #1. resolves #2; CLOSED #3")).toMatchObject({
 			issues: [1, 2, 3],
 			commaLists: [],
 		});
 	});
 
 	it("flags a comma-separated close list", () => {
-		expect(lintCloseKeywords("Closes #123, #456")).toEqual({
+		expect(lintCloseKeywords("Closes #123, #456")).toMatchObject({
 			issues: [123],
 			commaLists: [123],
 			valid: false,
@@ -30,7 +30,7 @@ describe("close-keyword parser (#1320)", () => {
 	});
 
 	it("does not treat refs as close keywords", () => {
-		expect(parseCloseKeywords("Refs #123, relates to #456")).toEqual({ issues: [], commaLists: [] });
+		expect(parseCloseKeywords("Refs #123, relates to #456")).toMatchObject({ issues: [], commaLists: [] });
 	});
 
 	it("handles case variants and optional colon", () => {
@@ -38,7 +38,7 @@ describe("close-keyword parser (#1320)", () => {
 	});
 
 	it("ignores cross-repository references", () => {
-		expect(parseCloseKeywords("Closes owner/repo#123; fixes #456")).toEqual({
+		expect(parseCloseKeywords("Closes owner/repo#123; fixes #456")).toMatchObject({
 			issues: [456],
 			commaLists: [],
 		});
@@ -53,4 +53,25 @@ describe("close-keyword parser (#1320)", () => {
 			'Invalid close-keyword syntax: GitHub only applies the first issue in a comma-separated close list. Use one close keyword per issue, for example "Closes #123. Closes #456." (not "Closes #123, #456").',
 		);
 	});
+
+	// #1355 review: quoted examples are documentation, not intent.
+	it("ignores close keywords inside fenced code blocks", () => {
+		const result = lintCloseKeywords(
+			"Real.\n```\nCloses #1, #2\n```\nCloses #99.",
+		);
+		expect(result.valid).toBe(true);
+		expect(result.issues).toEqual([99]);
+	});
+
+	it("ignores close keywords in blockquotes and inline code", () => {
+		expect(lintCloseKeywords("> Closes #1, #2\nCloses #99.").valid).toBe(true);
+		expect(lintCloseKeywords("Use `Closes #1, #2` never. Closes #7.").valid).toBe(true);
+	});
+
+	it("reports the offending line for a comma list", () => {
+		const result = lintCloseKeywords("Intro.\nCloses #12, #13\nOutro.");
+		expect(result.valid).toBe(false);
+		expect(result.offendingLines).toEqual(["Closes #12, #13"]);
+	});
 });
+


### PR DESCRIPTION
## Summary
- reject comma-separated GitHub close-keyword lists in PR bodies
- verify merged PR close targets and comment when an issue remains open or is missing
- add parser tests and changelog entry

## Verification
- npm run build
- npx vitest run tests/scripts/check-close-keywords.test.ts (9 passed)
- npm run changelog:check

Closes #1320.