### PR TITLE
feat(ci): scheduled stale-open-issue detector (closes #1323)

### DIFF
--- a/.changelog/feat-1323-stale-open-issue-detector.md
+++ b/.changelog/feat-1323-stale-open-issue-detector.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Weekly stale open-issue detector (closes #1323)** — the scheduled GitHub workflow reports open issues referenced by closing-shaped `master` commits or issue-named regression tests for human triage; it never closes issues automatically.

--- a/.github/workflows/stale-open-issues.yml
+++ b/.github/workflows/stale-open-issues.yml
@@ -1,0 +1,27 @@
+name: Stale open-issue detector (weekly)
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Monday 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  detect:
+    name: Detect stale open issues
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "22"
+      - name: Detect and publish candidates
+        run: node scripts/detect-stale-open-issues.mjs

--- a/.github/workflows/stale-open-issues.yml
+++ b/.github/workflows/stale-open-issues.yml
@@ -5,14 +5,15 @@ on:
     - cron: "0 7 * * 1" # Monday 07:00 UTC
   workflow_dispatch: {}
 
-permissions:
-  contents: read
-  issues: write
+permissions: {}
 
 jobs:
   detect:
     name: Detect stale open issues
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      issues: write # single detector summary comment
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_REPOSITORY: ${{ github.repository }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,12 @@ This is the payoff of the two disciplines above: a bounded checklist of defect *
 
 `isFullyQualified` follows host path semantics. Use `isFullyQualifiedWin32` or `isFullyQualifiedPosix` when the consuming path grammar is fixed independently of the host (for example, safe-spawn's Windows resolver).
 
+The weekly stale-open-issue detector is detection-only: `.github/workflows/stale-open-issues.yml`
+calls `scripts/detect-stale-open-issues.mjs`, which uses the bounded GitHub REST
+fetcher seam in `scripts/lib/stale-open-issues.mjs` to inspect open issues and
+bounded `master` commit details. It comments one candidate summary on #1323 and
+writes the workflow summary; it must never close or edit detected issues.
+
 The LSP status surface includes a bounded per-client history of operational
 diagnostic-pull failures; unsupported `-32601` responses are intentionally
 excluded. Strategy-gated `didSave` remains separate and out of scope here.

--- a/scripts/detect-stale-open-issues.mjs
+++ b/scripts/detect-stale-open-issues.mjs
@@ -6,14 +6,32 @@ const repository = process.env.GITHUB_REPOSITORY;
 const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 if (!repository || !token) throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN/GH_TOKEN are required");
 const runUrl = process.env.GITHUB_SERVER_URL && process.env.GITHUB_RUN_ID ? `${process.env.GITHUB_SERVER_URL}/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}` : undefined;
-const candidates = await detectStaleOpenIssues({ fetcher: defaultFetcher(token), repository });
-const summary = formatSummary(candidates, { runUrl });
+const { candidates, truncatedCommits } = await detectStaleOpenIssues({ fetcher: defaultFetcher(token), repository });
+const summary = formatSummary(candidates, { runUrl, truncatedCommits });
 console.log(summary);
 if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
 if (candidates.length > 0) {
-	await fetch(`https://api.github.com/repos/${repository}/issues/${DETECTOR_ISSUE}/comments`, {
-		method: "POST",
-		headers: { accept: "application/vnd.github+json", authorization: `Bearer ${token}`, "content-type": "application/json" },
+	const headers = { accept: "application/vnd.github+json", authorization: `Bearer ${token}`, "content-type": "application/json" };
+	// Idempotence (#1356 review): update the previous detector comment instead
+	// of stacking a new one every week. The marker is the first summary line.
+	const marker = "<!-- pi-lens-stale-open-issue-detector -->";
+	let existingId;
+	try {
+		const listed = await fetch(`https://api.github.com/repos/${repository}/issues/${DETECTOR_ISSUE}/comments?per_page=100`, { headers });
+		if (listed.ok) {
+			for (const comment of await listed.json()) {
+				if (typeof comment?.body === "string" && comment.body.startsWith(marker)) existingId = comment.id;
+			}
+		}
+	} catch {
+		// listing failed -- fall through to POST rather than stay silent
+	}
+	const url = existingId
+		? `https://api.github.com/repos/${repository}/issues/comments/${existingId}`
+		: `https://api.github.com/repos/${repository}/issues/${DETECTOR_ISSUE}/comments`;
+	await fetch(url, {
+		method: existingId ? "PATCH" : "POST",
+		headers,
 		body: JSON.stringify({ body: summary }),
 	});
 }

--- a/scripts/detect-stale-open-issues.mjs
+++ b/scripts/detect-stale-open-issues.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { DETECTOR_ISSUE, defaultFetcher, detectStaleOpenIssues, formatSummary } from "./lib/stale-open-issues.mjs";
+
+const repository = process.env.GITHUB_REPOSITORY;
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+if (!repository || !token) throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN/GH_TOKEN are required");
+const runUrl = process.env.GITHUB_SERVER_URL && process.env.GITHUB_RUN_ID ? `${process.env.GITHUB_SERVER_URL}/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}` : undefined;
+const candidates = await detectStaleOpenIssues({ fetcher: defaultFetcher(token), repository });
+const summary = formatSummary(candidates, { runUrl });
+console.log(summary);
+if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
+if (candidates.length > 0) {
+	await fetch(`https://api.github.com/repos/${repository}/issues/${DETECTOR_ISSUE}/comments`, {
+		method: "POST",
+		headers: { accept: "application/vnd.github+json", authorization: `Bearer ${token}`, "content-type": "application/json" },
+		body: JSON.stringify({ body: summary }),
+	});
+}

--- a/scripts/lib/stale-open-issues.d.mts
+++ b/scripts/lib/stale-open-issues.d.mts
@@ -10,6 +10,6 @@ export function detectStaleOpenIssues(options: {
 	fetcher: (url: string, init?: RequestInit) => Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
 	repository: string;
 	branch?: string;
-}): Promise<StaleIssueCandidate[]>;
-export function formatSummary(candidates: StaleIssueCandidate[], options?: { runUrl?: string }): string;
+}): Promise<{ candidates: StaleIssueCandidate[]; truncatedCommits: number }>;
+export function formatSummary(candidates: StaleIssueCandidate[], options?: { runUrl?: string; truncatedCommits?: number }): string;
 export function defaultFetcher(token: string): (url: string, init?: RequestInit) => Promise<Response>;

--- a/scripts/lib/stale-open-issues.d.mts
+++ b/scripts/lib/stale-open-issues.d.mts
@@ -1,0 +1,15 @@
+export const MAX_PAGES: number;
+export const PAGE_SIZE: number;
+export const MAX_COMMIT_DETAILS: number;
+export const DETECTOR_ISSUE: number;
+export interface StaleIssueCandidate {
+	issue: { number: number; title: string; html_url: string; pull_request?: unknown };
+	evidence: string[];
+}
+export function detectStaleOpenIssues(options: {
+	fetcher: (url: string, init?: RequestInit) => Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
+	repository: string;
+	branch?: string;
+}): Promise<StaleIssueCandidate[]>;
+export function formatSummary(candidates: StaleIssueCandidate[], options?: { runUrl?: string }): string;
+export function defaultFetcher(token: string): (url: string, init?: RequestInit) => Promise<Response>;

--- a/scripts/lib/stale-open-issues.mjs
+++ b/scripts/lib/stale-open-issues.mjs
@@ -1,0 +1,80 @@
+/** Detection logic for the scheduled stale-open-issue check (#1323). */
+
+export const MAX_PAGES = 3;
+export const PAGE_SIZE = 100;
+export const MAX_COMMIT_DETAILS = 100;
+export const DETECTOR_ISSUE = 1323;
+
+const CLOSING_REFERENCE = /\b(?:closes|fixes|resolves)\s+#(\d+)\b/gi;
+const ISSUE_NUMBER = /(?:^|[^\d])#?(\d+)(?!\d)/g;
+
+function numbersFromClosingText(text) {
+	const numbers = new Set();
+	for (const match of String(text ?? "").matchAll(CLOSING_REFERENCE)) numbers.add(Number(match[1]));
+	return numbers;
+}
+
+function numbersFromTestFilename(filename) {
+	const normalized = String(filename).replaceAll("\\", "/");
+	if (!/(^|\/)(?:test|tests|__tests__)(\/|$)|\.(?:test|spec)\./i.test(normalized)) return new Set();
+	const basename = normalized.slice(normalized.lastIndexOf("/") + 1);
+	const numbers = new Set();
+	for (const match of basename.matchAll(ISSUE_NUMBER)) numbers.add(Number(match[1]));
+	return numbers;
+}
+
+function addEvidence(byIssue, issueNumber, evidence) {
+	const current = byIssue.get(issueNumber) ?? [];
+	if (!current.includes(evidence)) current.push(evidence);
+	byIssue.set(issueNumber, current);
+}
+
+async function getJson(fetcher, url) {
+	const response = await fetcher(url, { headers: { accept: "application/vnd.github+json" } });
+	if (!response.ok) throw new Error(`GitHub API ${response.status} for ${url}`);
+	return response.json();
+}
+
+async function paged(fetcher, baseUrl, params = {}) {
+	const values = [];
+	for (let page = 1; page <= MAX_PAGES; page++) {
+		const query = new URLSearchParams({ ...params, per_page: String(PAGE_SIZE), page: String(page) });
+		const batch = await getJson(fetcher, `${baseUrl}?${query}`);
+		if (!Array.isArray(batch)) throw new Error(`GitHub API returned a non-array for ${baseUrl}`);
+		values.push(...batch);
+		if (batch.length < PAGE_SIZE) break;
+	}
+	return values;
+}
+
+export async function detectStaleOpenIssues({ fetcher, repository, branch = "master" }) {
+	const openIssues = await paged(fetcher, `https://api.github.com/repos/${repository}/issues`, { state: "open" });
+	const issueNumbers = new Set(openIssues.filter((issue) => !issue.pull_request).map((issue) => issue.number));
+	const byIssue = new Map();
+	const commits = await paged(fetcher, `https://api.github.com/repos/${repository}/commits`, { sha: branch });
+	for (const commit of commits.slice(0, MAX_COMMIT_DETAILS)) {
+		const commitText = commit.commit?.message ?? commit.message ?? "";
+		for (const number of numbersFromClosingText(commitText)) {
+			if (issueNumbers.has(number)) addEvidence(byIssue, number, `closing-shaped commit ${commit.sha.slice(0, 7)}`);
+		}
+		const detail = await getJson(fetcher, `https://api.github.com/repos/${repository}/commits/${commit.sha}`);
+		for (const file of Array.isArray(detail.files) ? detail.files : []) {
+			for (const number of numbersFromTestFilename(file.filename)) {
+				if (issueNumbers.has(number)) addEvidence(byIssue, number, `regression-test file ${file.filename}`);
+			}
+		}
+	}
+	return openIssues.filter((issue) => byIssue.has(issue.number)).map((issue) => ({ issue, evidence: byIssue.get(issue.number) })).sort((a, b) => a.issue.number - b.issue.number);
+}
+
+export function formatSummary(candidates, { runUrl } = {}) {
+	const lines = ["<!-- pi-lens-stale-open-issue-detector -->", "## Stale open-issue candidates", "", "Detection only: a human must verify the evidence and close or update an issue. This job never closes issues.", ""];
+	if (candidates.length === 0) lines.push("No candidates found.");
+	else for (const { issue, evidence } of candidates) lines.push(`- [#${issue.number}](${issue.html_url}) **${issue.title}** — ${evidence.join("; ")}`);
+	if (runUrl) lines.push("", `Workflow run: ${runUrl}`);
+	return lines.join("\n");
+}
+
+export function defaultFetcher(token) {
+	return (url, init) => fetch(url, { ...init, headers: { ...init?.headers, authorization: `Bearer ${token}` } });
+}

--- a/scripts/lib/stale-open-issues.mjs
+++ b/scripts/lib/stale-open-issues.mjs
@@ -10,7 +10,13 @@ const ISSUE_NUMBER = /(?:^|[^\d])#?(\d+)(?!\d)/g;
 
 function numbersFromClosingText(text) {
 	const numbers = new Set();
-	for (const match of String(text ?? "").matchAll(CLOSING_REFERENCE)) numbers.add(Number(match[1]));
+	let scanned = String(text ?? "");
+	// #1356 review: quoted keyword text and reverts are not closing intent.
+	// A revert un-does the closing commit, and prose quoting the form (docs,
+	// changelog snippets) merely mentions it.
+	if (/^\s*Revert\b/i.test(scanned)) return numbers;
+	scanned = scanned.replace(/"[^"\n]*"/g, "").replace(/`[^`\n]*`/g, "");
+	for (const match of scanned.matchAll(CLOSING_REFERENCE)) numbers.add(Number(match[1]));
 	return numbers;
 }
 
@@ -64,13 +70,16 @@ export async function detectStaleOpenIssues({ fetcher, repository, branch = "mas
 			}
 		}
 	}
-	return openIssues.filter((issue) => byIssue.has(issue.number)).map((issue) => ({ issue, evidence: byIssue.get(issue.number) })).sort((a, b) => a.issue.number - b.issue.number);
+	const candidates = openIssues.filter((issue) => byIssue.has(issue.number)).map((issue) => ({ issue, evidence: byIssue.get(issue.number) })).sort((a, b) => a.issue.number - b.issue.number);
+	// No silent caps (#1356 review): say how many commits went unexamined.
+	return { candidates, truncatedCommits: Math.max(0, commits.length - MAX_COMMIT_DETAILS) };
 }
 
-export function formatSummary(candidates, { runUrl } = {}) {
+export function formatSummary(candidates, { runUrl, truncatedCommits = 0 } = {}) {
 	const lines = ["<!-- pi-lens-stale-open-issue-detector -->", "## Stale open-issue candidates", "", "Detection only: a human must verify the evidence and close or update an issue. This job never closes issues.", ""];
 	if (candidates.length === 0) lines.push("No candidates found.");
 	else for (const { issue, evidence } of candidates) lines.push(`- [#${issue.number}](${issue.html_url}) **${issue.title}** — ${evidence.join("; ")}`);
+	if (truncatedCommits > 0) lines.push("", `Note: ${truncatedCommits} commit(s) beyond the ${MAX_COMMIT_DETAILS}-detail cap were NOT examined this run.`);
 	if (runUrl) lines.push("", `Workflow run: ${runUrl}`);
 	return lines.join("\n");
 }

--- a/tests/scripts/stale-open-issues.test.ts
+++ b/tests/scripts/stale-open-issues.test.ts
@@ -18,8 +18,9 @@ describe("stale open-issue detector (#1323)", () => {
 			"/repos/acme/repo/commits": [{ sha: "abcdef123", commit: { message: "fix: finished it (closes #10)" } }],
 			"/repos/acme/repo/commits/abcdef123": { files: [{ filename: "tests/regression-10.test.ts" }] },
 		});
-		const result = await detectStaleOpenIssues({ fetcher, repository: "acme/repo" });
-		expect(result).toEqual([{ issue: expect.objectContaining({ number: 10 }), evidence: ["closing-shaped commit abcdef1", "regression-test file tests/regression-10.test.ts"] }]);
+		const { candidates, truncatedCommits } = await detectStaleOpenIssues({ fetcher, repository: "acme/repo" });
+		expect(candidates).toEqual([{ issue: expect.objectContaining({ number: 10 }), evidence: ["closing-shaped commit abcdef1", "regression-test file tests/regression-10.test.ts"] }]);
+		expect(truncatedCommits).toBe(0);
 	});
 
 	it("ignores issues absent from the open-issue response and non-test filenames", async () => {
@@ -28,12 +29,51 @@ describe("stale open-issue detector (#1323)", () => {
 			"/repos/acme/repo/commits": [{ sha: "abc", commit: { message: "docs: mention fixes #12" } }],
 			"/repos/acme/repo/commits/abc": { files: [{ filename: "src/12.ts" }] },
 		});
-		expect(await detectStaleOpenIssues({ fetcher, repository: "acme/repo" })).toEqual([]);
+		expect((await detectStaleOpenIssues({ fetcher, repository: "acme/repo" })).candidates).toEqual([]);
+	});
+
+	// #1356 review: quoted keyword text and reverts are not closing intent.
+	it("ignores quoted and reverted closing-shaped text", async () => {
+		const { fetcher } = fakeGithub({
+			"/repos/acme/repo/issues": [{ number: 42, title: "open" }],
+			"/repos/acme/repo/commits": [
+				{ sha: "a1", commit: { message: 'docs: quote "closes #42" as an example' } },
+				{ sha: "a2", commit: { message: 'Revert "fix: closes #42"' } },
+			],
+			"/repos/acme/repo/commits/a1": { files: [] },
+			"/repos/acme/repo/commits/a2": { files: [] },
+		});
+		expect((await detectStaleOpenIssues({ fetcher, repository: "acme/repo" })).candidates).toEqual([]);
+	});
+
+	// #1356 review: the commit-detail cap must be reported, never silent.
+	it("reports commits beyond the detail cap in the summary", async () => {
+		const commits = Array.from({ length: MAX_COMMIT_DETAILS + 5 }, (_, i) => ({
+			sha: `sha${i}`,
+			commit: { message: "chore: routine" },
+		}));
+		const data: Record<string, unknown> = { "/repos/acme/repo/issues": [], "/repos/acme/repo/commits": commits };
+		for (const c of commits) data[`/repos/acme/repo/commits/${c.sha}`] = { files: [] };
+		// Page-aware: the commit list is served once, then empty, so pagination
+		// terminates and the cap arithmetic sees exactly `commits.length`.
+		const served = new Set<string>();
+		const fetcher = async (url: string) => {
+			const key = url.replace("https://api.github.com", "").split("?")[0];
+			let payload = data[key] ?? [];
+			if (key === "/repos/acme/repo/commits") {
+				payload = served.has(url) || served.has(key) ? [] : payload;
+				served.add(key);
+			}
+			return { ok: true, status: 200, json: async () => payload };
+		};
+		const { candidates, truncatedCommits } = await detectStaleOpenIssues({ fetcher, repository: "acme/repo" });
+		expect(truncatedCommits).toBe(5);
+		expect(formatSummary(candidates, { truncatedCommits })).toContain("5 commit(s) beyond");
 	});
 
 	it("keeps API work bounded and formats one detection-only summary", async () => {
 		const { fetcher, calls } = fakeGithub({ "/repos/acme/repo/issues": [], "/repos/acme/repo/commits": [] });
-		expect(await detectStaleOpenIssues({ fetcher, repository: "acme/repo" })).toEqual([]);
+		expect((await detectStaleOpenIssues({ fetcher, repository: "acme/repo" })).candidates).toEqual([]);
 		expect(MAX_PAGES).toBe(3);
 		expect(PAGE_SIZE).toBe(100);
 		expect(MAX_COMMIT_DETAILS).toBe(100);

--- a/tests/scripts/stale-open-issues.test.ts
+++ b/tests/scripts/stale-open-issues.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { detectStaleOpenIssues, formatSummary, MAX_COMMIT_DETAILS, MAX_PAGES, PAGE_SIZE } from "../../scripts/lib/stale-open-issues.mjs";
+
+function fakeGithub(data: Record<string, unknown>) {
+	const calls: string[] = [];
+	const fetcher = async (url: string) => {
+		calls.push(url);
+		const key = url.replace("https://api.github.com", "").split("?")[0];
+		return { ok: true, status: 200, json: async () => data[key] ?? [] };
+	};
+	return { fetcher, calls };
+}
+
+describe("stale open-issue detector (#1323)", () => {
+	it("flags open issues from closing-shaped commits and issue-named regression tests", async () => {
+		const { fetcher } = fakeGithub({
+			"/repos/acme/repo/issues": [{ number: 10, title: "still open", html_url: "https://github.com/acme/repo/issues/10" }, { number: 11, title: "already a PR", pull_request: {}, html_url: "https://github.com/acme/repo/issues/11" }],
+			"/repos/acme/repo/commits": [{ sha: "abcdef123", commit: { message: "fix: finished it (closes #10)" } }],
+			"/repos/acme/repo/commits/abcdef123": { files: [{ filename: "tests/regression-10.test.ts" }] },
+		});
+		const result = await detectStaleOpenIssues({ fetcher, repository: "acme/repo" });
+		expect(result).toEqual([{ issue: expect.objectContaining({ number: 10 }), evidence: ["closing-shaped commit abcdef1", "regression-test file tests/regression-10.test.ts"] }]);
+	});
+
+	it("ignores issues absent from the open-issue response and non-test filenames", async () => {
+		const { fetcher } = fakeGithub({
+			"/repos/acme/repo/issues": [{ number: 10, title: "open" }, { number: 12, title: "pull request", pull_request: {} }],
+			"/repos/acme/repo/commits": [{ sha: "abc", commit: { message: "docs: mention fixes #12" } }],
+			"/repos/acme/repo/commits/abc": { files: [{ filename: "src/12.ts" }] },
+		});
+		expect(await detectStaleOpenIssues({ fetcher, repository: "acme/repo" })).toEqual([]);
+	});
+
+	it("keeps API work bounded and formats one detection-only summary", async () => {
+		const { fetcher, calls } = fakeGithub({ "/repos/acme/repo/issues": [], "/repos/acme/repo/commits": [] });
+		expect(await detectStaleOpenIssues({ fetcher, repository: "acme/repo" })).toEqual([]);
+		expect(MAX_PAGES).toBe(3);
+		expect(PAGE_SIZE).toBe(100);
+		expect(MAX_COMMIT_DETAILS).toBe(100);
+		expect(calls[0]).toContain("per_page=100");
+		expect(formatSummary([], { runUrl: "https://example/run" })).toContain("never closes issues");
+	});
+});


### PR DESCRIPTION
## Summary

- add a weekly scheduled detector for open issues whose numbers appear in closing-shaped master commits or issue-named regression-test files
- publish one aggregate candidate comment on #1323 and the Actions job summary when candidates exist
- keep detection-only behavior: no issue is auto-closed or edited
- bound GitHub API pagination and commit-detail requests

## Verification

- npm run build
- npx vitest run tests/scripts/stale-open-issues.test.ts (3/3 tests)

Refs #1323