### PR TITLE
fix(tests): injectable pid-liveness seam — no more real-process-table assumptions (closes #1352)

### DIFF
--- a/.changelog/fix-1352-pid-liveness-seam.md
+++ b/.changelog/fix-1352-pid-liveness-seam.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Instance-registry liveness tests no longer depend on arbitrary runner PIDs (refs #1352)** — synthetic dead PIDs are classified through deterministic test seams, preserving coverage of footprint exclusion, registry pruning, and vanished-instance wiring without relying on the CI process table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
-- **Instance-registry liveness tests no longer depend on arbitrary runner PIDs (refs #1352)** — synthetic dead PIDs are classified through deterministic test seams, preserving coverage of footprint exclusion, registry pruning, and vanished-instance wiring without relying on the CI process table.
-
 - **LSP roots and per-session clients are conservatively bounded (closes #1325, refs #1126, refs #1129)** — manifest-bearing fixture conventions (`tests/fixtures`, `__fixtures__`, and `testdata`), gitignored directories, and atomic-write staging namespaces no longer become standalone LSP roots; their files attach to the nearest eligible ancestor project. Client reuse remains keyed by server and normalized resolved root, while a configurable `PI_LENS_LSP_CLIENT_CEILING` (24 by default) evicts the least-recently-used idle client through graceful shutdown before spawning another and never evicts a client with an active LSP request.
 
 - **Fully qualified Windows paths use one shared classifier (closes [#1213](https://github.com/apmantza/pi-lens/issues/1213))** — drive-relative (`C:foo`) and rooted-relative (`\\foo`) paths are no longer mistaken for self-contained absolute paths; UNC and drive-absolute paths remain fully qualified across command validation, installer caching, and managed-tool retention.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Instance-registry liveness tests no longer depend on arbitrary runner PIDs (refs #1352)** — synthetic dead PIDs are classified through deterministic test seams, preserving coverage of footprint exclusion, registry pruning, and vanished-instance wiring without relying on the CI process table.
+
 - **LSP roots and per-session clients are conservatively bounded (closes #1325, refs #1126, refs #1129)** — manifest-bearing fixture conventions (`tests/fixtures`, `__fixtures__`, and `testdata`), gitignored directories, and atomic-write staging namespaces no longer become standalone LSP roots; their files attach to the nearest eligible ancestor project. Client reuse remains keyed by server and normalized resolved root, while a configurable `PI_LENS_LSP_CLIENT_CEILING` (24 by default) evicts the least-recently-used idle client through graceful shutdown before spawning another and never evicts a client with an active LSP request.
 
 - **Fully qualified Windows paths use one shared classifier (closes [#1213](https://github.com/apmantza/pi-lens/issues/1213))** — drive-relative (`C:foo`) and rooted-relative (`\\foo`) paths are no longer mistaken for self-contained absolute paths; UNC and drive-absolute paths remain fully qualified across command validation, installer caching, and managed-tool retention.

--- a/tests/clients/instance-registry.test.ts
+++ b/tests/clients/instance-registry.test.ts
@@ -79,8 +79,10 @@ describe("instance-registry", () => {
 
 	it("round-trips mixed old and new registry entries through read, register, and reap", async () => {
 		const now = new Date().toISOString();
+		const oldPid = process.pid + 100_001;
+		const newPid = process.pid + 100_002;
 		const oldEntry = {
-			pid: 424241,
+			pid: oldPid,
 			startedAt: now,
 			projectRoot: "/old",
 			lspChildren: [],
@@ -90,7 +92,7 @@ describe("instance-registry", () => {
 		};
 		const newEntry = {
 			...oldEntry,
-			pid: 424242,
+			pid: newPid,
 			projectRoot: "/new",
 			subagent: {
 				marker: "avtc-pi-subagent",
@@ -416,6 +418,7 @@ describe("instance-registry", () => {
 			const { computeResourceFootprint } = await import(
 				"../../clients/instance-registry.js"
 			);
+			const deadPid = process.pid + 100_003;
 			const registry = [
 				{
 					pid: 1,
@@ -428,7 +431,7 @@ describe("instance-registry", () => {
 					lspChildren: [],
 				},
 				{
-					pid: 22624, // hard-killed pi process (#735 repro pid)
+					pid: deadPid, // classified by the injected predicate below
 					startedAt: "t",
 					projectRoot: "/dead",
 					rssBytes: 233 * 1024 * 1024,
@@ -438,7 +441,7 @@ describe("instance-registry", () => {
 					lspChildren: [],
 				},
 			];
-			const isPidAlive = (pid: number) => pid === 1;
+			const isPidAlive = (pid: number) => pid !== deadPid;
 
 			const footprint = computeResourceFootprint(registry, isPidAlive);
 
@@ -474,6 +477,7 @@ describe("instance-registry", () => {
 		it("getResourceFootprint excludes a dead-pid instance and opportunistically prunes it from the registry file", async () => {
 			const { registerInstance, recordLspChild, getResourceFootprint, readInstanceRegistry } =
 				await import("../../clients/instance-registry.js");
+			const deadPid = process.pid + 100_000;
 			await registerInstance("/proj");
 			await recordLspChild({ pid: 7002, serverId: "typescript", command: "tsserver" });
 
@@ -482,7 +486,7 @@ describe("instance-registry", () => {
 			// which always stamps the CURRENT process's own live pid).
 			const raw = JSON.parse(fs.readFileSync(registryFilePath(), "utf-8"));
 			raw.instances.push({
-				pid: 424242, // guaranteed-dead fake pid for this test
+				pid: deadPid, // classified by the injected predicate below
 				startedAt: "t",
 				projectRoot: "/dead-project",
 				rssBytes: 233 * 1024 * 1024,
@@ -493,16 +497,16 @@ describe("instance-registry", () => {
 			});
 			fs.writeFileSync(registryFilePath(), JSON.stringify(raw), "utf-8");
 
-			const isPidAlive = (pid: number) => pid !== 424242;
+			const isPidAlive = (pid: number) => pid !== deadPid;
 			const footprint = await getResourceFootprint(isPidAlive);
 
 			expect(footprint.instanceCount).toBe(1);
-			expect(footprint.perInstance.map((i) => i.pid)).not.toContain(424242);
+			expect(footprint.perInstance.map((i) => i.pid)).not.toContain(deadPid);
 
 			// Prune is fire-and-forget — wait a tick for the background write.
 			await new Promise((r) => setTimeout(r, 20));
 			const remaining = await readInstanceRegistry();
-			expect(remaining.map((i) => i.pid)).not.toContain(424242);
+			expect(remaining.map((i) => i.pid)).not.toContain(deadPid);
 			expect(remaining).toHaveLength(1);
 		});
 

--- a/tests/index-vanished-instance-wiring.test.ts
+++ b/tests/index-vanished-instance-wiring.test.ts
@@ -18,8 +18,8 @@ import { removeTempDirSync } from "./clients/test-utils.js";
  * `isTestMode()` — see clients/sessionstart-logger.ts) so the exact line is
  * observable without depending on real sessionstart.log I/O.
  *
- * pid 424242 is the repo's established "guaranteed-dead fake pid" convention
- * for registry tests (see tests/clients/instance-registry.test.ts).
+ * The synthetic pid below is made dead deterministically by the test's
+ * process.kill(pid, 0) seam; it never relies on the runner's process table.
  */
 
 vi.mock("../clients/bootstrap.js", () => ({
@@ -79,17 +79,26 @@ describe("index session_start vanished-instance wiring (#1123 item 2)", () => {
 		if (prevDataDir === undefined) delete process.env.PILENS_DATA_DIR;
 		else process.env.PILENS_DATA_DIR = prevDataDir;
 		removeTempDirSync(tmp);
+		vi.restoreAllMocks();
 		vi.clearAllMocks();
 	});
 
 	it("logs the marker for a dead-pid registry entry, then the reaper still prunes it", async () => {
+		const deadPid = process.pid + 100_000;
+		const realProcessKill = process.kill.bind(process);
+		vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+			if (pid === deadPid && signal === 0) {
+				throw Object.assign(new Error("synthetic dead pid"), { code: "ESRCH" });
+			}
+			return realProcessKill(pid, signal);
+		});
 		fs.mkdirSync(process.env.PI_LENS_HOME as string, { recursive: true });
 		fs.writeFileSync(
 			registryFilePath(),
 			JSON.stringify({
 				instances: [
 					{
-						pid: 424242,
+						pid: deadPid,
 						startedAt: "2026-08-06T20:00:00.000Z",
 						projectRoot: "/dead-project",
 						rssBytes: 512 * 1024 * 1024,
@@ -117,7 +126,7 @@ describe("index session_start vanished-instance wiring (#1123 item 2)", () => {
 			.filter((line) => line.includes("previous instance pid"));
 		expect(markerLines).toHaveLength(1);
 		const line = markerLines[0];
-		expect(line).toContain("previous instance pid 424242");
+		expect(line).toContain(`previous instance pid ${deadPid}`);
 		expect(line).toContain("2026-08-06T22:30:00.000Z");
 		expect(line).toContain("512MB");
 		expect(line).toContain("exited without shutdown");
@@ -125,7 +134,7 @@ describe("index session_start vanished-instance wiring (#1123 item 2)", () => {
 		// The reaper's own dead-pid prune still ran afterward — the marker read
 		// must not have swallowed or blocked it.
 		const raw = JSON.parse(fs.readFileSync(registryFilePath(), "utf-8"));
-		expect(raw.instances.map((i: { pid: number }) => i.pid)).not.toContain(424242);
+		expect(raw.instances.map((i: { pid: number }) => i.pid)).not.toContain(deadPid);
 	});
 
 	it("logs nothing when the registry has no dead entries", async () => {


### PR DESCRIPTION
## Summary

Closes #1352.

The existing `getResourceFootprint(isPidAlive = realIsPidAlive)` predicate seam is now used with process-independent synthetic PIDs in the registry tests. The end-to-end vanished-instance wiring test controls only `process.kill(pid, 0)` for its synthetic PID and delegates all other process operations to the real implementation.

## Verification

- `npm run build`
- `npx vitest run tests/clients/instance-registry.test.ts tests/index-vanished-instance-wiring.test.ts`: 31/31
- `tests/clients/instance-registry.test.ts` repeated 5x: 29/29 each run
- Hardcoded-PID class sweep: removed the `424242` runner-table assumptions; remaining numeric PID fixtures are inert payloads or use injected fake predicates.
- Added test-infrastructure entry to `CHANGELOG.md`.