### PR TITLE
fix: installer probe-cache onto durable-store; finish cooperative-yield conversion (closes #1354)

### DIFF
--- a/.changelog/fix-1354-durable-probe-cache-yield.md
+++ b/.changelog/fix-1354-durable-probe-cache-yield.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Re-home probe-cache ageing and cooperative yields (closes #1354)** — authoritative probe-cache commits now prune expired entries while preserving durable-store quarantine recovery; the remaining corpus-scaled scan yields use the cooperative time budget.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,9 @@ extraction, and the bounded session-start sweep must stay on that seam so a
 format change cannot drift from garbage collection. The installer probe cache
 uses the awaited durable-store seam: its delta/version snapshot maps to
 `merge`, pending-update retirement and mirror refresh run in
-`afterWriteLocked`, and TTL/existence/mtime validation remains read-side
-policy. Turn-state remains separate pending a future ownership decision.
+`afterWriteLocked`; TTL ageing is also applied inside the authoritative merge,
+while existence/mtime validation remains read-side policy. Turn-state remains
+separate pending a future ownership decision.
 (#1209, #1212)
 
 **LSP idle eviction is lease-guarded across acquisition/use.** `isBusy()` only

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -1544,6 +1544,21 @@ function applyProbeCacheChanges(
 	}
 }
 
+/**
+ * Install-lifetime ageing belongs to the authoritative merge, not only to the
+ * lookup path: a sibling process may have left expired entries on disk since
+ * this process loaded its in-memory snapshot. The async durable-store lock
+ * supplies the probe cache's former quarantine/stale-owner recovery.
+ */
+function ageProbeCache(disk: ProbeCache): void {
+	const cutoff = Date.now() - PROBE_CACHE_TTL_MS;
+	for (const [toolId, entry] of Object.entries(disk)) {
+		if (!Number.isFinite(entry.cachedAt) || entry.cachedAt < cutoff) {
+			delete disk[toolId];
+		}
+	}
+}
+
 function publishProbeCacheWrite(
 	disk: ProbeCache,
 	snapshotVersions: Map<string, number>,
@@ -1578,6 +1593,7 @@ async function writeProbeCache(): Promise<ProbeCacheFlushResult> {
 			path: PROBE_CACHE_PATH,
 			deserialize: deserializeProbeCache,
 			merge: (disk) => {
+				ageProbeCache(disk);
 				applyProbeCacheChanges(disk, changes);
 				return disk;
 			},

--- a/clients/language-profile.ts
+++ b/clients/language-profile.ts
@@ -369,6 +369,9 @@ export async function collectSourceFilesForWarmup(
 					break walk;
 				}
 			}
+			// Each iteration performs only bounded dirent/ext/ignore checks. Keep the
+			// count cadence: the cost does not scale with the corpus item size, and
+			// this walk's existing matched-file ceiling bounds the total work.
 			if (++processedSinceYield % yieldEvery === 0) {
 				// See countSourceFilesWithinLimitAsync for why setImmediate.
 				await new Promise<void>((resolve) => setImmediate(resolve));

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -11,6 +11,7 @@ import { getDiagnosticTracker } from "./diagnostic-tracker.js";
 import { resetDispatchAvailabilityState } from "./dispatch/runners/utils/runner-helpers.js";
 import type { FileKind } from "./file-kinds.js";
 import { clearAllSessions as clearFileTimeSessions } from "./file-time.js";
+import { createDeadline, yieldIfOverBudget } from "./cooperative-budget.js";
 import {
 	getGlobalPiLensDir,
 	getKnipIgnorePatterns,
@@ -635,13 +636,13 @@ async function collectTodoBaselineItems(
 		// blocks the event loop before the per-file scan loop below even starts.
 		const files = await getSourceFilesAsync(analysisRoot, true);
 		if (!stillCurrent()) return items;
-		let processedSinceYield = 0;
+		const deadline = createDeadline(8);
 		for (const file of files) {
 			if (!stillCurrent()) return items;
 			scanOneTodoFile(scanner, file, items);
-			if (++processedSinceYield % 30 === 0) {
-				await new Promise<void>((resolve) => setImmediate(resolve));
-			}
+			// scanFile cost scales with the file contents, so a count cadence cannot
+			// bound the event-loop block across differently-sized corpora.
+			await yieldIfOverBudget(deadline);
 		}
 	} catch {
 		const todoResult = scanner.scanDirectory(analysisRoot);

--- a/tests/clients/installer/probe-cache.test.ts
+++ b/tests/clients/installer/probe-cache.test.ts
@@ -226,6 +226,41 @@ describe("updateProbeCache", () => {
 		expect(written[TOOL_ID]).toMatchObject({ path: TOOL_PATH });
 	});
 
+	it("ages expired sibling entries during the authoritative merge", async () => {
+		const staleTool = "old-tool";
+		const freshTool = "fresh-tool";
+		const freshEntry = {
+			path: "/other/process/fresh-tool",
+			mtimeMs: MTIME_MS + 2,
+			cachedAt: Date.now(),
+		};
+		mockFsReadFile
+			.mockResolvedValueOnce(JSON.stringify({}))
+			.mockResolvedValueOnce(
+				JSON.stringify({
+					[staleTool]: {
+						path: "/other/process/old-tool",
+						mtimeMs: MTIME_MS,
+						cachedAt: Date.now() - 25 * 60 * 60 * 1000,
+					},
+					[freshTool]: freshEntry,
+				}),
+			);
+		mockFsStat.mockResolvedValue({ mtimeMs: MTIME_MS });
+
+		await updateProbeCache(TOOL_ID, TOOL_PATH);
+		await flushProbeCache();
+
+		const [, content] = mockWriteFileAtomicAsync.mock.calls[0] as [
+			string,
+			string,
+		];
+		const written = JSON.parse(content) as Record<string, unknown>;
+		expect(written[staleTool]).toBeUndefined();
+		expect(written[freshTool]).toEqual(freshEntry);
+		expect(written[TOOL_ID]).toMatchObject({ path: TOOL_PATH });
+	});
+
 	it("recovers a stale lock using its owner age", async () => {
 		mockFsMkdir
 			.mockRejectedValueOnce(Object.assign(new Error("busy"), { code: "EEXIST" }))

--- a/tests/clients/installer/probe-cache.test.ts
+++ b/tests/clients/installer/probe-cache.test.ts
@@ -363,4 +363,28 @@ describe("updateProbeCache", () => {
 		) as Record<string, unknown>;
 		expect(second["late-tool"]).toMatchObject({ path: "/managed/late-tool" });
 	});
+
+	// #1359 review: lost-update proof — a commit whose authoritative read sees
+	// ANOTHER writer's entry must fold both results, never clobber. The
+	// durable-store contract does this via the locked authoritative read; this
+	// pins the probe-cache merge callback's side of the bargain.
+	it("folds another writer's entry seen at authoritative read (no lost update)", async () => {
+		mockFsStat.mockResolvedValue({ mtimeMs: MTIME_MS });
+		// The other process committed "other-tool" between our update and our
+		// flush: the locked authoritative read returns their payload.
+		mockFsReadFile.mockResolvedValue(
+			JSON.stringify({
+				"other-tool": { path: "/managed/other-tool", mtimeMs: MTIME_MS, cachedAt: Date.now() },
+			}),
+		);
+
+		await updateProbeCache(TOOL_ID, TOOL_PATH);
+		expect(await flushProbeCache()).toBe("written");
+
+		const written = JSON.parse(
+			(mockWriteFileAtomicAsync.mock.calls[0] as [string, string])[1],
+		) as Record<string, unknown>;
+		expect(written[TOOL_ID]).toBeDefined();
+		expect(written["other-tool"]).toMatchObject({ path: "/managed/other-tool" });
+	});
 });


### PR DESCRIPTION
## Summary\n- ages probe-cache entries inside the authoritative durable-store merge callback\n- retains durable-store awaited quarantine/stale-owner recovery and contention retry behavior\n- keeps language-profile's constant-cost modulus cadence with an exemption comment\n- converts runtime-session's file-content-scaled TODO scan to the cooperative budget helper\n- adds changelog entry and authoritative aging regression coverage\n\n## Semantic mapping\n- Aging: stale entries are pruned during the locked authoritative-read merge, before the caller's delta is applied. This handles entries discovered by sibling processes after the local in-memory read.\n- Quarantine recovery: the installer now relies on commitDurableStoreAsync's shared quarantine-directory lock, stale-owner reclamation, and token-checked release. The old installer-specific directory lock/quarantine protocol is removed; no residual semantic remains for lock recovery. Corrupt payloads retain the existing fail-open/retry behavior through the durable-store deserialize/flush error path.\n\n## Yield decisions\n- clients/language-profile.ts: kept the modulus. Each dirent iteration is bounded constant-cost and the walk has an existing matched-file ceiling; a time-budget conversion would add no meaningful protection.\n- clients/runtime-session.ts:642: converted. scanFile cost scales with file contents, so item-count cadence cannot bound event-loop occupancy.\n\n## Verification\n- 
pm run build: passed\n- targeted Vitest: 4 files, 48 passed\n- broader 	ests/clients: 462 files passed, 5,424 passed, 13 skipped; 5 unrelated failures (managed/global tool-resolution expectations and an sgconfig timeout)\n