### PR TITLE
feat(lsp): pull-failure telemetry + lifecycle/protocol test seams (refs #1292, items 1+3)

### DIFF
--- a/.changelog/feat-1292-lsp-acquisition-race.md
+++ b/.changelog/feat-1292-lsp-acquisition-race.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Deterministic LSP acquisition-race coverage (refs #1292)** — concurrent initialization and an aborted waiter now assert single-client ownership, zero leaked leases, and teardown reaping through the shared interleaving kit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1322,6 +1322,11 @@ v3.8.74. Release history lives in `CHANGELOG.md` (dated, versioned, kept current
 
 ## Test requirements
 
+LSP acquisition-race tests suspend the initialize/create-client seam with
+`tests/clients/interleaving-kit.ts`; do not use timing sleeps. Assert the
+in-flight owner, lease count, publication cleanup, and shutdown reap so an
+aborted waiter cannot pass while pinning or orphaning a client.
+
 A new always-absent dependency stub (a `vi.mock`/fixture that makes a dependency permanently unavailable) must ship with at least one present-path **behavior** test: the dependency's result must reach the caller, never just a bare no-throw assertion. #1251 is the failure case; #1310 is the pattern to follow.
 
 Every commit that adds or changes logic **must** include relevant tests before pushing. No exceptions:

--- a/tests/clients/lsp/service-race.test.ts
+++ b/tests/clients/lsp/service-race.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { suspendAt } from "../interleaving-kit.js";
 
 const getServersForFileWithConfig = vi.fn();
 const createLSPClient = vi.fn();
@@ -31,10 +32,13 @@ describe("LSPService race hardening", () => {
 	it("deduplicates concurrent spawn for same server/root key", async () => {
 		const { LSPService } = await import("../../../clients/lsp/index.js");
 		const service = new LSPService();
+		const client = {
+			isAlive: () => true,
+			shutdown: vi.fn(async () => {}),
+		};
+		const initialize = suspendAt(createLSPClient, async () => client);
 
-		const spawn = vi.fn(async () => {
-			await new Promise((resolve) => setTimeout(resolve, 10));
-			return {
+		const spawn = vi.fn(async () => ({
 				process: {
 					process: { killed: false },
 					stdin: {} as any,
@@ -42,8 +46,7 @@ describe("LSPService race hardening", () => {
 					stderr: {} as any,
 					pid: 123,
 				},
-			};
-		});
+			}));
 
 		getServersForFileWithConfig.mockReturnValue([
 			{
@@ -56,29 +59,23 @@ describe("LSPService race hardening", () => {
 		]);
 
 		const file = "C:/repo/main.py";
-		const [a, b, c] = await Promise.all([
-			service.getClientForFile(file),
-			service.getClientForFile(file),
-			service.getClientForFile(file),
-		]);
+		const first = service.getClientForFile(file);
+		await initialize.admitted;
+		const second = service.getClientForFile(file);
+		initialize.release();
+		const [a, b] = await Promise.all([first, second]);
 
 		expect(spawn).toHaveBeenCalledTimes(1);
 		expect(createLSPClient).toHaveBeenCalledTimes(1);
 		expect(a?.client).toBeTruthy();
 		expect(b?.client).toBeTruthy();
-		expect(c?.client).toBeTruthy();
+		initialize.restore();
 	});
 
 	it("does not orphan the in-flight client when a waiter times out", async () => {
 		const { LSPService } = await import("../../../clients/lsp/index.js");
 		const service = new LSPService();
-		let releaseSpawn!: () => void;
-		const spawnGate = new Promise<void>((resolve) => {
-			releaseSpawn = resolve;
-		});
-		const spawn = vi.fn(async () => {
-			await spawnGate;
-			return {
+		const spawn = vi.fn(async () => ({
 				process: {
 					process: { killed: false },
 					stdin: {} as any,
@@ -86,12 +83,12 @@ describe("LSPService race hardening", () => {
 					stderr: {} as any,
 					pid: 321,
 				},
-			};
-		});
-		createLSPClient.mockResolvedValue({
+			}));
+		const client = {
 			isAlive: () => true,
-			shutdown: async () => {},
-		});
+			shutdown: vi.fn(async () => {}),
+		};
+		const initialize = suspendAt(createLSPClient, async () => client);
 		getServersForFileWithConfig.mockReturnValue([
 			{
 				id: "python",
@@ -104,14 +101,27 @@ describe("LSPService race hardening", () => {
 
 		const file = "C:/repo/main.py";
 		const timedOut = service.getClientForFile(file, 1);
-		await new Promise((resolve) => setTimeout(resolve, 5));
+		await initialize.admitted;
 		expect(await timedOut).toBeUndefined();
-		releaseSpawn();
+		const internal = service as unknown as {
+			state: { inFlight: Map<string, unknown>; clients: Map<string, unknown> };
+			clientLeases: Map<string, number>;
+		};
+		expect(internal.state.inFlight.size).toBe(1);
+		expect(internal.clientLeases.size).toBe(0);
+
+		initialize.release();
 		await service.getClientForFile(file);
 
 		expect(spawn).toHaveBeenCalledTimes(1);
 		expect(createLSPClient).toHaveBeenCalledTimes(1);
 		expect(service.getAliveClientCount()).toBe(1);
+		expect(internal.state.inFlight.size).toBe(0);
+		expect(internal.clientLeases.size).toBe(0);
+		await service.shutdown();
+		expect(client.shutdown).toHaveBeenCalledTimes(1);
+		expect(internal.state.clients.size).toBe(0);
+		initialize.restore();
 	});
 
 	it("retries broken server after cooldown window", async () => {


### PR DESCRIPTION
## Summary

Completes the remaining acceptance gap for #1292 items 1 and 3 on top of the already-merged telemetry/protocol implementation in #1313:

- replaces timing-based acquisition tests with deterministic suspendAt interleavings at the create/initialize seam;
- proves two concurrent acquisitions perform exactly one spawn/initialize;
- proves a timed-out (aborted) waiter leaves one owned in-flight client, zero leases, clears publication state, and the client is reaped on shutdown;
- adds the required Added changelog fragment and durable test convention.

Item 2 (didSave strategy) remains explicitly out of scope. No settle delays, dual-store simplification, cancellation changes, or pull retry/fallback changes.

## Existing item 1 + item 3 seams retained

- 10-entry operational pullFailureHistory, excluding -32601 and supported message variants, surfaced through LSPClientInfo → LSPService.getStatus() → lspStatus().
- process-tree cleanup wiring assertions on Windows (	askkill /T) and POSIX process groups.
- shutdown protocol fixture covering server requests, dynamic registration, didClose, and late diagnostics.
- pull-fallback honesty: operational pull failure retains push diagnostics and telemetry; unsupported pull records nothing.

## Mutation verification

- Disabled both in-flight reuse guards: service-race.test.ts failed twice because spawn was called 2 times instead of 1.
- Disabled pull-failure recording: client-internals.test.ts failed the fallback-history assertion and both operational-failure rows (3 red tests).
- Restored both mutations before final verification.

## Verification

- 
pm run build
- 
px vitest run tests/clients/lsp/ — 65 files passed, 3 skipped; 602 tests passed, 4 skipped (606 total)
- 
pm run lint

Blast-radius tooling note: the installed pi-lens structural tools were unavailable in this session. Production modules were not changed by this follow-up; affected test seam is LSPService.getClientForFile in-flight ownership and shutdown cleanup.

Refs #1292.