### PR TITLE
fix(agent-behavior): treat same-path writes as file knowledge in blind-write check

### DIFF
--- a/clients/agent-behavior-client.ts
+++ b/clients/agent-behavior-client.ts
@@ -2,7 +2,8 @@
  * AgentBehaviorClient for pi-lens
  *
  * Tracks tool call sequences and flags anti-patterns in real-time:
- * - Blind writes: editing or writing without reading first
+ * - Blind writes: editing or writing without reading first (a same-session
+ *   write/edit of the same path counts as file knowledge)
  * - Thrashing: repeated identical tool calls with no progress
  *
  * No external dependencies — purely tracks tool call history.
@@ -95,7 +96,17 @@ export class AgentBehaviorClient {
 		// Check for blind writes
 		if (WRITE_OPS.has(toolName)) {
 			const recentWindow = this.toolHistory.slice(-BLIND_WRITE_WINDOW);
-			const hasRecentRead = recentWindow.some((r) => READ_OPS.has(r.toolName));
+			// A read in the window proves file knowledge; so does a same-session
+			// write/edit of THIS path — the agent authored the content, so the
+			// write-then-edit loop on a self-authored file is not a blind write.
+			const hasRecentRead = recentWindow.some(
+				(r) =>
+					READ_OPS.has(r.toolName) ||
+					(WRITE_OPS.has(r.toolName) &&
+						r.filePath !== undefined &&
+						normalizedPath !== null &&
+						normalizeMapKey(r.filePath) === normalizedPath),
+			);
 
 			if (!hasRecentRead && recentWindow.length > 0) {
 				// Count how many writes in the window without reads

--- a/tests/clients/agent-behavior-client.test.ts
+++ b/tests/clients/agent-behavior-client.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { AgentBehaviorClient } from "../../clients/agent-behavior-client.js";
+
+const FORT = "/repo/roblox-project/blender/build_fort.py";
+const OTHER_A = "/repo/src/server/LayoutStore.luau";
+const OTHER_B = "/repo/src/server/Rooms.luau";
+const OTHER_C = "/repo/src/server/Tank.luau";
+
+function blindWriteWarnings(
+	warnings: ReturnType<AgentBehaviorClient["recordToolCall"]>,
+): string[] {
+	return warnings.filter((w) => w.type === "blind-write").map((w) => w.message);
+}
+
+describe("AgentBehaviorClient blind-write detection", () => {
+	it("does not flag the write-then-edit loop on a self-authored file", () => {
+		const client = new AgentBehaviorClient();
+
+		expect(blindWriteWarnings(client.recordToolCall("write", FORT))).toEqual(
+			[],
+		);
+		// Four consecutive edits on the file the agent just authored must stay
+		// quiet: the session's own write/edit of this path is file knowledge.
+		for (let i = 0; i < 4; i++) {
+			expect(blindWriteWarnings(client.recordToolCall("edit", FORT))).toEqual(
+				[],
+			);
+		}
+	});
+
+	it("does not flag edits on a file authored earlier in the window", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("write", OTHER_A);
+		client.recordToolCall("edit", OTHER_B);
+		// Second edit of OTHER_B: the first edit of the same path is still in
+		// the window, so this is not a blind write.
+		expect(blindWriteWarnings(client.recordToolCall("edit", OTHER_B))).toEqual(
+			[],
+		);
+	});
+
+	it("still flags an edit of a never-authored file after a write storm", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("edit", OTHER_A);
+		client.recordToolCall("edit", OTHER_B);
+		// OTHER_C was never read and never written this session; two writes
+		// without a read precede it, so it warns.
+		const warnings = blindWriteWarnings(client.recordToolCall("edit", OTHER_C));
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("BLIND WRITE");
+		expect(warnings[0]).toContain(OTHER_C);
+	});
+
+	it("still treats any read in the window as file knowledge", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("edit", OTHER_A);
+		client.recordToolCall("edit", OTHER_B);
+		client.recordToolCall("read", OTHER_C);
+		expect(blindWriteWarnings(client.recordToolCall("edit", OTHER_C))).toEqual(
+			[],
+		);
+	});
+
+	it("ignores same-path writes whose path is missing", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("write");
+		client.recordToolCall("edit");
+		// No paths recorded anywhere: nothing can count as knowledge of the
+		// target path, so the two-write threshold still trips.
+		const warnings = blindWriteWarnings(client.recordToolCall("edit", OTHER_C));
+		expect(warnings).toHaveLength(1);
+	});
+});
+
+describe("AgentBehaviorClient thrashing detection", () => {
+	it("still flags three consecutive identical tool+file calls", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("edit", FORT);
+		client.recordToolCall("edit", FORT);
+		const warnings = client.recordToolCall("edit", FORT);
+
+		const thrashing = warnings.filter((w) => w.type === "thrashing");
+		expect(thrashing).toHaveLength(1);
+		// The same edit is NOT a blind write anymore (self-authored path).
+		expect(blindWriteWarnings(warnings)).toEqual([]);
+	});
+});
+
+describe("AgentBehaviorClient reset", () => {
+	it("clears history so a later edit storm can warn again", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("write", FORT);
+		client.recordToolCall("edit", FORT);
+		client.reset();
+		client.recordToolCall("edit", OTHER_A);
+		client.recordToolCall("edit", OTHER_B);
+
+		expect(blindWriteWarnings(client.recordToolCall("edit", OTHER_C))).toHaveLength(
+			1,
+		);
+	});
+});


### PR DESCRIPTION
Fixes #1364.

## Problem

`AgentBehaviorClient.recordToolCall` flags BLIND WRITE on edits to a file the
agent itself created moments earlier. The window check only accepts `READ_OPS`
as evidence of file knowledge; a same-session `write`/`edit` of the same path
never counts. Result: the common write-then-edit loop on a self-authored file
warns on every edit after the second.

Field repro: agent creates `build_fort.py` with `write`, iterates with `edit`
— every edit after the second returned `⚠ BLIND WRITE ... without reading in
the last 5 tool calls`. Also seen as a burst of four identical warnings across
server modules authored in the same session.

## Change

In the blind-write check, a recent write/edit of the **same normalized path**
(via `normalizeMapKey`) now satisfies the knowledge requirement alongside
reads:

```ts
const hasRecentRead = recentWindow.some(
  (r) =>
    READ_OPS.has(r.toolName) ||
    (WRITE_OPS.has(r.toolName) &&
      r.filePath !== undefined &&
      normalizedPath !== null &&
      normalizeMapKey(r.filePath) === normalizedPath),
);
```

Unchanged: the 5-call window, the `writesWithoutRead >= 2` threshold, thrashing
detection, and per-file edit counting. Records without a path cannot match.

## Tests

New `tests/clients/agent-behavior-client.test.ts` (7 tests):

- write-then-edit loop on one file stays quiet (4 consecutive edits)
- edits of a file authored earlier in the window stay quiet
- edit of a never-authored file after a two-write storm still warns
- a read in the window still suppresses (regression guard)
- path-less writes cannot suppress the warning
- thrashing still fires at 3 consecutive identical calls
- `reset()` restores the warn behaviour

Verification: `npm run build`, `npm run lint`, full `npm test` — **6225
passed, 0 failed** (547 files). `package-lock.json` untouched.

QA on the reporting side (write-then-edit loop in the original session) is
offered and will run once this lands in a release.