### PR TITLE
feat(observability): session degradation ledger + spawn-bucket telemetry in pilens_health (refs #1292, items 4-5)

### DIFF
--- a/.changelog/feat-1292-degradation-ledger.md
+++ b/.changelog/feat-1292-degradation-ledger.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Session degradation telemetry in health and performance reports (refs #1292 items 4–5)** — Trust refusals, output-mode suppressions, TypeScript idle evictions, grammar blocks, untrusted formatter skips, and actionable spawn-failure buckets now remain visible as bounded per-session telemetry; LSP pull failures also appear beneath their server in `pilens_health`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,12 @@ This is the payoff of the two disciplines above: a bounded checklist of defect *
 
 ## What it is
 
+Behavioral degradation is recorded through `clients/degradation-ledger.ts`, a
+per-session in-memory store retaining the latest 20 entries per kind while
+counting overflow. New quiet refusal/degradation paths must call
+`recordDegradation`; `pilens_health` exposes the detached structured summary and
+human-readable section, and `/lens-perf` includes the same current-session view.
+
 `isFullyQualified` follows host path semantics. Use `isFullyQualifiedWin32` or `isFullyQualifiedPosix` when the consuming path grammar is fixed independently of the host (for example, safe-spawn's Windows resolver).
 
 The weekly stale-open-issue detector is detection-only: `.github/workflows/stale-open-issues.yml`

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -36,11 +36,25 @@ export function recordDegradation(record: DegradationRecord): void {
 		groups.set(record.kind, group);
 	}
 	group.count += 1;
-	group.entries.push({ subject: record.subject, reason: record.reason });
+	// Bounded at RECORD time (#1366 review): reasons carry arbitrary error
+	// text; a 10KB message must never become a 10KB health line or a 10KB
+	// retained string.
+	group.entries.push({
+		subject: truncateForLedger(record.subject),
+		reason: truncateForLedger(record.reason),
+	});
 	if (group.entries.length > ENTRIES_PER_KIND) group.entries.shift();
 }
 
 /** Detached snapshot, grouped in first-seen kind order. */
+const LEDGER_FIELD_MAX = 200;
+
+function truncateForLedger(text: string): string {
+	return text.length > LEDGER_FIELD_MAX
+		? `${text.slice(0, LEDGER_FIELD_MAX)}…`
+		: text;
+}
+
 export function getDegradationSummary(): DegradationGroup[] {
 	return [...groups.entries()].map(([kind, group]) => ({
 		kind,

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -1,0 +1,69 @@
+/** Bounded, process-local telemetry for behavior degraded during one session. */
+
+export type DegradationKind =
+	| "trust-refusal"
+	| "mode-suppression"
+	| "ts-idle-eviction"
+	| "spawn-failure"
+	| "formatter-skip"
+	| "grammar-blocked";
+
+export interface DegradationRecord {
+	kind: DegradationKind;
+	subject: string;
+	reason: string;
+}
+
+export interface DegradationGroup {
+	kind: DegradationKind;
+	/** Exact number recorded, including events no longer retained. */
+	count: number;
+	/** Number omitted from latestReasons by the per-kind bound. */
+	droppedCount: number;
+	latestReasons: Array<{ subject: string; reason: string }>;
+}
+
+const ENTRIES_PER_KIND = 20;
+const groups = new Map<
+	DegradationKind,
+	{ count: number; entries: Array<{ subject: string; reason: string }> }
+>();
+
+export function recordDegradation(record: DegradationRecord): void {
+	let group = groups.get(record.kind);
+	if (!group) {
+		group = { count: 0, entries: [] };
+		groups.set(record.kind, group);
+	}
+	group.count += 1;
+	group.entries.push({ subject: record.subject, reason: record.reason });
+	if (group.entries.length > ENTRIES_PER_KIND) group.entries.shift();
+}
+
+/** Detached snapshot, grouped in first-seen kind order. */
+export function getDegradationSummary(): DegradationGroup[] {
+	return [...groups.entries()].map(([kind, group]) => ({
+		kind,
+		count: group.count,
+		droppedCount: group.count - group.entries.length,
+		latestReasons: group.entries.map((entry) => ({ ...entry })),
+	}));
+}
+
+export function renderDegradationLines(summary = getDegradationSummary()): string[] {
+	if (summary.length === 0) return [];
+	return [
+		"Degradations:",
+		...summary.map((group) => {
+			const latest = group.latestReasons.at(-1);
+			return `  ⚠ ${group.kind}: ${group.count}${latest ? ` — ${latest.subject}: ${latest.reason}` : ""}`;
+		}),
+	];
+}
+
+/** Session-boundary/test reset. */
+export function resetDegradationLedger(): void {
+	groups.clear();
+}
+
+export const DEGRADATION_ENTRIES_PER_KIND = ENTRIES_PER_KIND;

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -10,7 +10,6 @@
  */
 
 import { logExtension } from "./extension-log.js";
-import { recordDegradation } from "./degradation-ledger.js";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { TERRAGRUNT_FILENAMES } from "./file-kinds.js";

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -10,6 +10,7 @@
  */
 
 import { logExtension } from "./extension-log.js";
+import { recordDegradation } from "./degradation-ledger.js";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { TERRAGRUNT_FILENAMES } from "./file-kinds.js";
@@ -1338,6 +1339,11 @@ async function resolveFormatterCommand(
 		fallback[0] === "npx" &&
 		!assertInstallAllowed(`formatter npx fallback: ${formatter.name}`)
 	) {
+		recordDegradation({
+			kind: "formatter-skip",
+			subject: formatter.name,
+			reason: "npx fallback disabled because project is untrusted",
+		});
 		return SKIP_FORMATTING;
 	}
 	return fallback;

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -1339,11 +1339,9 @@ async function resolveFormatterCommand(
 		fallback[0] === "npx" &&
 		!assertInstallAllowed(`formatter npx fallback: ${formatter.name}`)
 	) {
-		recordDegradation({
-			kind: "formatter-skip",
-			subject: formatter.name,
-			reason: "npx fallback disabled because project is untrusted",
-		});
+		// No second ledger entry here (#1366 review): assertInstallAllowed just
+		// recorded the trust-refusal with this formatter's context — recording
+		// formatter-skip too would count one user-visible degradation twice.
 		return SKIP_FORMATTING;
 	}
 	return fallback;

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -22,6 +22,7 @@ import { applyAuxiliarySuppressions } from "../dispatch/auxiliary-lsp.js";
 import { detectFileRole } from "../file-role.js";
 import { logLatency } from "../latency-logger.js";
 import { logSessionStart } from "../sessionstart-logger.js";
+import { recordDegradation } from "../degradation-ledger.js";
 import {
 	isLspSpawnAllowedByTrust,
 	assertInstallAllowed,
@@ -1168,6 +1169,11 @@ export class LSPService {
 					// like the other eviction paths and must not reject from a timer callback.
 				}
 				logSessionStart(`lsp typescript idle eviction: released ${key}`);
+				recordDegradation({
+					kind: "ts-idle-eviction",
+					subject: key,
+					reason: "idle TypeScript client released to bound memory",
+				});
 			}).catch(() => {});
 		}, getTypeScriptIdleEvictMs());
 		timer.unref?.();

--- a/clients/project-trust.ts
+++ b/clients/project-trust.ts
@@ -35,6 +35,7 @@
  */
 
 import { logExtension } from "./extension-log.js";
+import { recordDegradation } from "./degradation-ledger.js";
 
 export type ProjectTrustState = "trusted" | "untrusted" | "unknown";
 
@@ -148,6 +149,11 @@ export function isToolInstallAllowedByTrust(): boolean {
 /** Central gate for operations that may download or install executable content. */
 export function assertInstallAllowed(context: string): boolean {
 	if (isToolInstallAllowedByTrust()) return true;
+	recordDegradation({
+		kind: "trust-refusal",
+		subject: context,
+		reason: projectTrustDenialReason() ?? "project trust denied",
+	});
 	if (!installRefusalWarnings.has(context)) {
 		if (installRefusalWarnings.size >= INSTALL_REFUSAL_WARNING_CAP) {
 			installRefusalWarnings.clear();

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -8,6 +8,7 @@ import { deadCodeIssueCount } from "./dead-code-client.js";
 import { logDeadCodeScan } from "./dead-code-logger.js";
 import type { DependencyChecker } from "./dependency-checker.js";
 import { getDiagnosticTracker } from "./diagnostic-tracker.js";
+import { resetDegradationLedger } from "./degradation-ledger.js";
 import { resetDispatchAvailabilityState } from "./dispatch/runners/utils/runner-helpers.js";
 import type { FileKind } from "./file-kinds.js";
 import { clearAllSessions as clearFileTimeSessions } from "./file-time.js";
@@ -1457,6 +1458,7 @@ export const SESSION_START_GUIDANCE: string[] = [
 export async function handleSessionStart(
 	deps: SessionStartDeps,
 ): Promise<void> {
+	resetDegradationLedger();
 	const handlerEnteredAt = Date.now();
 	const sessionStartMs = deps.sessionStartFiredAt ?? handlerEnteredAt;
 	const cwdForTelemetry = deps.ctxCwd ?? process.cwd();

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -23,6 +23,8 @@ import {
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { logLatency } from "./latency-logger.js";
+import { recordDegradation } from "./degradation-ledger.js";
+import { logExtension } from "./extension-log.js";
 import { isFullyQualifiedWin32 } from "./path-utils.js";
 import { startSpawnUsageSampler } from "./resource-sampler.js";
 
@@ -156,36 +158,71 @@ function classifyWithCwdFlag(
 	cwdUnresolvable: boolean,
 ): SpawnFailureError {
 	const code = errorCode(cause);
+	let failure: SpawnFailureError;
 	if (
 		code === "ENOENT" &&
 		cwdUnresolvable &&
 		commandProbablyPresent(options.command) !== false
 	) {
-		return new SpawnFailureError(
+		failure = new SpawnFailureError(
 			"cwd-unresolvable",
 			`Cannot spawn ${options.command}: working directory is unresolvable (${options.cwd})`,
 			cause,
 		);
-	}
-	if (code === "ENOENT") {
-		return new SpawnFailureError(
+	} else if (code === "ENOENT") {
+		failure = new SpawnFailureError(
 			"tool-not-found",
 			`Cannot spawn ${options.command}: tool not found (${cause.message})`,
 			cause,
 		);
-	}
-	if (code === "EACCES" || code === "EPERM") {
-		return new SpawnFailureError(
+	} else if (code === "EACCES" || code === "EPERM") {
+		failure = new SpawnFailureError(
 			"permission-denied",
 			`Cannot spawn ${options.command}: permission denied`,
 			cause,
 		);
+	} else {
+		failure = new SpawnFailureError(
+			"spawn-failed",
+			`Cannot spawn ${options.command}: ${cause.message}`,
+			cause,
+		);
 	}
-	return new SpawnFailureError(
-		"spawn-failed",
-		`Cannot spawn ${options.command}: ${cause.message}`,
-		cause,
-	);
+	recordSpawnClassification(failure, options);
+	return failure;
+}
+
+const loggedSpawnClassifications = new Set<string>();
+const SPAWN_CLASSIFICATION_LOG_CAP = 200;
+
+function recordSpawnClassification(
+	failure: SpawnFailureError,
+	options: { command: string; cwd?: string },
+): void {
+	const pair = `${failure.kind}\0${options.command}`;
+	if (!loggedSpawnClassifications.has(pair)) {
+		if (loggedSpawnClassifications.size >= SPAWN_CLASSIFICATION_LOG_CAP) {
+			loggedSpawnClassifications.clear();
+		}
+		loggedSpawnClassifications.add(pair);
+		logExtension({
+			subsystem: "safe-spawn",
+			level: "debug",
+			message: "spawn failure classified",
+			metadata: {
+				kind: failure.kind,
+				command: options.command,
+				cwd: options.cwd,
+			},
+		});
+	}
+	if (failure.kind !== "tool-not-found") {
+		recordDegradation({
+			kind: "spawn-failure",
+			subject: options.command,
+			reason: `${failure.kind}${options.cwd ? ` in ${options.cwd}` : ""}`,
+		});
+	}
 }
 
 /** Classify a raw Node spawn error without discarding its errno-bearing Error. */
@@ -681,6 +718,7 @@ const windowsCommandCache = new Map<string, WindowsCommandCacheEntry>();
 /** Reset after session replacement or a successful managed install. */
 export function resetSafeSpawnWindowsCommandCache(): void {
 	windowsCommandCache.clear();
+	loggedSpawnClassifications.clear();
 }
 
 function cacheWindowsCommandResult(

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -28,6 +28,7 @@ import {
 	LANGUAGE_TO_GRAMMAR,
 } from "./grammar-source.js";
 import { resolvePackagePath } from "./package-root.js";
+import { recordDegradation } from "./degradation-ledger.js";
 import {
 	assertInstallAllowed,
 	getProjectTrustGeneration,
@@ -481,6 +482,11 @@ export class TreeSitterClient {
 				message: unavailable,
 				metadata: { grammarFile, outcome: "trust-gated" },
 			});
+			recordDegradation({
+				kind: "grammar-blocked",
+				subject: grammarFile,
+				reason: "runtime grammar download blocked because project is untrusted",
+			});
 			// Lazy clear-on-transition (#1363 review): compare the trust
 			// generation at use time -- no listener registration, no retention.
 			const generation = getProjectTrustGeneration();
@@ -528,6 +534,11 @@ export class TreeSitterClient {
 					subsystem: "tree-sitter-client",
 					message: unavailable,
 					metadata: { grammarFile, outcome: "unavailable" },
+				});
+				recordDegradation({
+					kind: "grammar-blocked",
+					subject: grammarFile,
+					reason: "runtime grammar download failed",
 				});
 				// HUMAN-audience: an offline grammar fetch silently degrades this
 				// language's features, so it reaches the user through the HOST's
@@ -626,6 +637,11 @@ export class TreeSitterClient {
 			this.dbg(
 				`Grammar ${grammarFile} blocked on this runtime — ${blockReason}`,
 			);
+			recordDegradation({
+				kind: "grammar-blocked",
+				subject: grammarFile,
+				reason: blockReason,
+			});
 			return null;
 		}
 

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,10 @@ import "./clients/console-guard-install.js";
 import "./clients/startup-marker.js";
 import { installConsoleGuard } from "./clients/extension-log.js";
 import { wireUserNotifier } from "./clients/user-notify.js";
+import {
+	getDegradationSummary,
+	recordDegradation,
+} from "./clients/degradation-ledger.js";
 import { adoptProjectTrustFromContext } from "./clients/project-trust.js";
 import {
 	type ExtensionRunMode,
@@ -237,6 +241,11 @@ function notifyUi(
 ): void {
 	const mode = readExtensionMode(ctx);
 	if (suppressesUserNotify(mode)) {
+		recordDegradation({
+			kind: "mode-suppression",
+			subject: "ctx.ui.notify",
+			reason: modeSuppressionNote(mode),
+		});
 		dbg(`notify ${modeSuppressionNote(mode)}: ${message.split("\n")[0]}`);
 		return;
 	}
@@ -425,6 +434,12 @@ export default function (pi: ExtensionAPI) {
 		// undefined is exactly the "no host wired" path user-notify.ts already
 		// documents as fail-soft, so nothing is lost, only un-rendered.
 		if (suppressesUserNotify(readExtensionMode(latestEventCtx))) {
+			const mode = readExtensionMode(latestEventCtx);
+			recordDegradation({
+				kind: "mode-suppression",
+				subject: "user degradation notice",
+				reason: modeSuppressionNote(mode),
+			});
 			return undefined;
 		}
 		return (message: string, level?: "info" | "warning" | "error") =>
@@ -1060,7 +1075,15 @@ export default function (pi: ExtensionAPI) {
 				const report = await collectLatencyPerformance({
 					sessionStartedAt: runtime.sessionStartedAt,
 				});
-				notifyUi(ctx, renderLatencyPerformanceReport(report), "info");
+				const degradations = getDegradationSummary();
+				const degradationText = degradations.length
+					? `\n\nDegradations:\n${degradations.map((group) => `  ${group.kind}: ${group.count} (${group.latestReasons.at(-1)?.subject}: ${group.latestReasons.at(-1)?.reason})`).join("\n")}`
+					: "";
+				notifyUi(
+					ctx,
+					`${renderLatencyPerformanceReport(report)}${degradationText}`,
+					"info",
+				);
 			} catch (err) {
 				notifyUi(
 					ctx,

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -26,6 +26,10 @@ import { fileURLToPath } from "node:url";
 import { AstGrepClient } from "../clients/ast-grep-client.js";
 import { CacheManager } from "../clients/cache-manager.js";
 import {
+	getDegradationSummary,
+	renderDegradationLines,
+} from "../clients/degradation-ledger.js";
+import {
 	acknowledgeTurnEnd,
 	analyzeFile,
 	analyzeFileFresh,
@@ -1499,6 +1503,7 @@ async function callTool(
 		const stats = diagnosticStats();
 		const autoSession = getAutoSessionStatus();
 		const treeSitter = treeSitterRuntimeStatus();
+		const degradations = getDegradationSummary();
 		// #1272, following the #544 precedent: the Stop hook is a separate,
 		// short-lived process, so a turn-end it skipped left no trace here at all
 		// — a dead integration looked exactly like a clean turn, forever. The
@@ -1513,11 +1518,15 @@ async function callTool(
 				? `Tree-sitter: DEGRADED — WASM runtime aborted${treeSitter.abortedAt ? ` at ${treeSitter.abortedAt}` : ""}; restart this server to recover`
 				: "Tree-sitter: available",
 			`LSP: ${aliveClients} alive client(s)`,
-			...servers.map(
-				(server) =>
-					`  ${server.connected ? "✓" : "✗"} ${server.serverId} (${server.root})`,
-			),
+			...servers.flatMap((server) => [
+				`  ${server.connected ? "✓" : "✗"} ${server.serverId} (${server.root})`,
+				...server.pullFailureHistory.slice(-1).map(
+					(failure) =>
+						`    ⚠ diagnostics pull failed: ${failure.method}${failure.code !== undefined ? ` (${failure.code})` : ""} — ${failure.message}`,
+				),
+			]),
 			...renderLspBrokenStatusLines(brokenServers),
+			...renderDegradationLines(degradations),
 			last
 				? `Last dispatch: ${path.basename(last.filePath)} — ${last.totalDurationMs}ms, ${last.totalDiagnostics} diagnostic(s)`
 				: "Last dispatch: none yet",
@@ -1557,6 +1566,7 @@ async function callTool(
 			treeSitter,
 			turnEnd,
 			resourceFootprint: footprint,
+			degradations,
 		});
 	}
 

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -1522,7 +1522,7 @@ async function callTool(
 				`  ${server.connected ? "✓" : "✗"} ${server.serverId} (${server.root})`,
 				...server.pullFailureHistory.slice(-1).map(
 					(failure) =>
-						`    ⚠ diagnostics pull failed: ${failure.method}${failure.code !== undefined ? ` (${failure.code})` : ""} — ${failure.message}`,
+						`    ⚠ diagnostics pull failed: ${failure.method}${failure.code !== undefined ? ` (${failure.code})` : ""} — ${failure.message.length > 200 ? `${failure.message.slice(0, 200)}…` : failure.message}`,
 				),
 			]),
 			...renderLspBrokenStatusLines(brokenServers),

--- a/tests/clients/degradation-ledger.test.ts
+++ b/tests/clients/degradation-ledger.test.ts
@@ -43,4 +43,22 @@ describe("session degradation ledger", () => {
 			"  ⚠ grammar-blocked: 1 — swift.wasm: runtime unsafe",
 		]);
 	});
+
+	// #1366 review: reasons carry arbitrary error text -- bounded at record
+	// time so health lines and retained strings stay small.
+	it("truncates oversized subjects and reasons at record time", () => {
+		resetDegradationLedger();
+		recordDegradation({
+			kind: "trust-refusal",
+			subject: "s".repeat(500),
+			reason: "r".repeat(10_000),
+		});
+		const [group] = getDegradationSummary();
+		const latest = group.latestReasons.at(-1)!;
+		expect(latest.subject.length).toBeLessThanOrEqual(201);
+		expect(latest.reason.length).toBeLessThanOrEqual(201);
+		const lines = renderDegradationLines();
+		expect(Math.max(...lines.map((l) => l.length))).toBeLessThan(500);
+	});
 });
+

--- a/tests/clients/degradation-ledger.test.ts
+++ b/tests/clients/degradation-ledger.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	DEGRADATION_ENTRIES_PER_KIND,
+	getDegradationSummary,
+	recordDegradation,
+	renderDegradationLines,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
+
+beforeEach(resetDegradationLedger);
+
+describe("session degradation ledger", () => {
+	it("groups kinds and returns detached latest reasons", () => {
+		recordDegradation({ kind: "spawn-failure", subject: "a", reason: "denied" });
+		recordDegradation({ kind: "trust-refusal", subject: "b", reason: "untrusted" });
+		recordDegradation({ kind: "spawn-failure", subject: "c", reason: "bad cwd" });
+		const summary = getDegradationSummary();
+		expect(summary.map(({ kind, count }) => ({ kind, count }))).toEqual([
+			{ kind: "spawn-failure", count: 2 },
+			{ kind: "trust-refusal", count: 1 },
+		]);
+		expect(summary[0].latestReasons.at(-1)).toEqual({ subject: "c", reason: "bad cwd" });
+		summary[0].latestReasons[0].reason = "mutated";
+		expect(getDegradationSummary()[0].latestReasons[0].reason).toBe("denied");
+	});
+
+	it("bounds retained entries per kind while counting beyond the cap", () => {
+		for (let i = 0; i < DEGRADATION_ENTRIES_PER_KIND + 7; i++) {
+			recordDegradation({ kind: "formatter-skip", subject: `f${i}`, reason: `r${i}` });
+		}
+		const [group] = getDegradationSummary();
+		expect(group.count).toBe(DEGRADATION_ENTRIES_PER_KIND + 7);
+		expect(group.droppedCount).toBe(7);
+		expect(group.latestReasons).toHaveLength(DEGRADATION_ENTRIES_PER_KIND);
+		expect(group.latestReasons[0].subject).toBe("f7");
+	});
+
+	it("renders a health section only when degraded", () => {
+		expect(renderDegradationLines()).toEqual([]);
+		recordDegradation({ kind: "grammar-blocked", subject: "swift.wasm", reason: "runtime unsafe" });
+		expect(renderDegradationLines()).toEqual([
+			"Degradations:",
+			"  ⚠ grammar-blocked: 1 — swift.wasm: runtime unsafe",
+		]);
+	});
+});

--- a/tests/clients/lsp/typescript-idle-eviction.test.ts
+++ b/tests/clients/lsp/typescript-idle-eviction.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { suspendAt } from "../interleaving-kit.js";
+const recordDegradation = vi.hoisted(() => vi.fn());
+vi.mock("../../../clients/degradation-ledger.js", () => ({ recordDegradation }));
 
 const getServersForFileWithConfig = vi.fn();
 const createLSPClient = vi.fn();
@@ -55,6 +57,7 @@ function configureTypeScriptServer() {
 
 describe("TypeScript language-service idle eviction (#1332 b2)", () => {
 	beforeEach(() => {
+		recordDegradation.mockClear();
 		vi.resetModules();
 		getServersForFileWithConfig.mockReset();
 		createLSPClient.mockReset();
@@ -84,6 +87,11 @@ describe("TypeScript language-service idle eviction (#1332 b2)", () => {
 		expect(service.getAliveClientCount()).toBe(0);
 		expect(first.shutdown).toHaveBeenCalledWith({
 			reason: "typescript_idle_eviction",
+		});
+		expect(recordDegradation).toHaveBeenCalledWith({
+			kind: "ts-idle-eviction",
+		subject: expect.stringMatching(/^typescript:.*repo$/),
+			reason: "idle TypeScript client released to bound memory",
 		});
 
 		expect((await service.getClientForFile("/repo/main.ts"))?.client).toBe(rebuilt);

--- a/tests/clients/project-trust-install-bypasses.test.ts
+++ b/tests/clients/project-trust-install-bypasses.test.ts
@@ -3,6 +3,10 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setProjectTrustState, resetProjectTrust } from "../../clients/project-trust.js";
 import { setupTestEnvironment } from "./test-utils.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
 
 const { safeSpawnAsync } = vi.hoisted(() => ({
 	safeSpawnAsync: vi.fn(async () => ({ status: 0, stdout: "", stderr: "" })),
@@ -15,6 +19,7 @@ vi.mock("../../clients/safe-spawn.js", async (importOriginal) => ({
 vi.mock("../../clients/user-notify.js", () => ({ notifyUserDegradation }));
 
 beforeEach(() => {
+	resetDegradationLedger();
 	safeSpawnAsync.mockClear();
 	notifyUserDegradation.mockClear();
 });
@@ -40,6 +45,11 @@ describe("central project-trust install gate (#1334 review)", () => {
 			const formatter = { name: "npx-test", command: ["npx", "pkg", "$FILE"], extensions: [".ts"], async detect() { return true; } };
 			setProjectTrustState("untrusted");
 			expect(await formatFile(file, formatter)).toEqual({ success: true, changed: false });
+			expect(getDegradationSummary()).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ kind: "formatter-skip", count: 1 }),
+				]),
+			);
 			expect(safeSpawnAsync).not.toHaveBeenCalled();
 			setProjectTrustState("trusted");
 			await formatFile(file, formatter);
@@ -96,6 +106,11 @@ describe("central project-trust install gate (#1334 review)", () => {
 		expect(await client.ensureGrammar("tree-sitter-trust-missing.wasm")).toBe(false);
 		expect(await client.ensureGrammar("tree-sitter-trust-missing.wasm")).toBe(false);
 		expect(notifyUserDegradation).toHaveBeenCalledTimes(1);
+		expect(getDegradationSummary()).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ kind: "grammar-blocked", count: 2 }),
+			]),
+		);
 		expect(fetchSpy).not.toHaveBeenCalled();
 		// #1363 delta: dedupe is generation-lazy, not permanent -- a trust
 		// TRANSITION re-arms the notification for the same grammar.

--- a/tests/clients/project-trust-install-bypasses.test.ts
+++ b/tests/clients/project-trust-install-bypasses.test.ts
@@ -45,11 +45,16 @@ describe("central project-trust install gate (#1334 review)", () => {
 			const formatter = { name: "npx-test", command: ["npx", "pkg", "$FILE"], extensions: [".ts"], async detect() { return true; } };
 			setProjectTrustState("untrusted");
 			expect(await formatFile(file, formatter)).toEqual({ success: true, changed: false });
-			expect(getDegradationSummary()).toEqual(
+			// #1366 review: ONE ledger entry per user-visible degradation — the
+			// trust seam records it (with the formatter context); the formatter
+			// site must not add a second kind for the same event.
+			const summary = getDegradationSummary();
+			expect(summary).toEqual(
 				expect.arrayContaining([
-					expect.objectContaining({ kind: "formatter-skip", count: 1 }),
+					expect.objectContaining({ kind: "trust-refusal", count: 1 }),
 				]),
 			);
+			expect(summary.find((g) => g.kind === "formatter-skip")).toBeUndefined();
 			expect(safeSpawnAsync).not.toHaveBeenCalled();
 			setProjectTrustState("trusted");
 			await formatFile(file, formatter);

--- a/tests/clients/project-trust.test.ts
+++ b/tests/clients/project-trust.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
 
 const { logExtension } = vi.hoisted(() => ({ logExtension: vi.fn() }));
 import {
@@ -17,6 +21,7 @@ vi.mock("../../clients/extension-log.js", () => ({ logExtension }));
 
 afterEach(() => {
 	resetProjectTrust();
+	resetDegradationLedger();
 	logExtension.mockClear();
 });
 
@@ -59,6 +64,9 @@ describe("project-trust policy gates", () => {
 		setProjectTrustState("untrusted");
 		expect(assertInstallAllowed("test install")).toBe(false);
 		expect(assertInstallAllowed("test install")).toBe(false);
+		expect(getDegradationSummary()).toEqual([
+			expect.objectContaining({ kind: "trust-refusal", count: 2 }),
+		]);
 		expect(
 			logExtension.mock.calls.filter(([entry]) => entry.level === "warn"),
 		).toHaveLength(1);

--- a/tests/clients/safe-spawn-failure-taxonomy.test.ts
+++ b/tests/clients/safe-spawn-failure-taxonomy.test.ts
@@ -1,14 +1,26 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+const logExtension = vi.hoisted(() => vi.fn());
+vi.mock("../../clients/extension-log.js", () => ({ logExtension }));
 import {
 	classifySpawnFailure,
+	resetSafeSpawnWindowsCommandCache,
 	safeSpawnAsync,
 } from "../../clients/safe-spawn.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
 import { removeTempDirSync } from "./test-utils.js";
 
 describe("safe-spawn typed failure taxonomy", () => {
+	beforeEach(() => {
+		logExtension.mockClear();
+		resetDegradationLedger();
+		resetSafeSpawnWindowsCommandCache();
+	});
 	it("distinguishes an unresolvable cwd from a missing present tool", async () => {
 		const parent = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-spawn-cwd-"));
 		const missingCwd = path.join(parent, "gone");
@@ -62,6 +74,24 @@ describe("safe-spawn typed failure taxonomy", () => {
 		expect(deniedFailure.cause).toBe(denied);
 		expect(otherFailure.kind).toBe("spawn-failed");
 		expect((otherFailure.cause as NodeJS.ErrnoException).code).toBe("EBUSY");
+		expect(logExtension).toHaveBeenCalledTimes(3);
+		expect(logExtension).toHaveBeenCalledWith(
+			expect.objectContaining({
+				level: "debug",
+				metadata: { kind: "permission-denied", command: "denied", cwd: undefined },
+			}),
+		);
+		expect(getDegradationSummary()).toEqual([
+			expect.objectContaining({ kind: "spawn-failure", count: 2 }),
+		]);
+	});
+
+	it("logs only once per command and bucket while tallying each failure", async () => {
+		const denied = Object.assign(new Error("denied"), { code: "EACCES" });
+		await classifySpawnFailure(denied, { command: "same", cwd: "/work" });
+		await classifySpawnFailure(denied, { command: "same", cwd: "/else" });
+		expect(logExtension).toHaveBeenCalledTimes(1);
+		expect(getDegradationSummary()[0].count).toBe(2);
 	});
 
 	it("exposes timeout and killed as typed process-control failures", async () => {

--- a/tests/index-mode-awareness.test.ts
+++ b/tests/index-mode-awareness.test.ts
@@ -5,6 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import extension from "../index.js";
 import { createPiMock, makeCtx } from "./support/pi-mock.js";
 import { removeTempDirSync } from "./clients/test-utils.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../clients/degradation-ledger.js";
 
 // Same two heavy seams tests/index-wiring.test.ts stubs, so firing
 // session_start stays a fast deterministic wiring check.
@@ -50,6 +54,7 @@ function tmpProject(): string {
 }
 
 afterEach(() => {
+	resetDegradationLedger();
 	for (const dir of tmpDirs.splice(0)) removeTempDirSync(dir);
 });
 
@@ -127,6 +132,9 @@ describe("notify chatter is mode-derived (#1334 S2)", () => {
 			await pi.runCommand("lens-toggle", "", ctx);
 
 			expect(ctx.notifications).toHaveLength(0);
+			expect(getDegradationSummary()).toEqual([
+				expect.objectContaining({ kind: "mode-suppression", count: 1 }),
+			]);
 		});
 	}
 


### PR DESCRIPTION
## Summary

Implements #1292 checklist items 4–5 and audit G11:

- adds a bounded, per-session in-memory degradation ledger with exact grouped counts, overflow accounting, detached latest reasons, reset, and health rendering
- records trust refusals, print/json notify suppressions, TypeScript idle eviction, trust/runtime/download grammar blocks, untrusted npx formatter skips, and non-tool-not-found spawn classifications
- emits one debug `logExtension` classification row per `(command, kind)` per session, with `{ kind, command, cwd }`; taxonomy/control flow is unchanged
- exposes degradations in `pilens_health` text + structured payload and `/lens-perf`; renders the latest operational pull failure beneath each LSP server row

## State model / invariants

- The ledger is process-local and resets at the shared `handleSessionStart` seam used by pi and MCP.
- Each kind retains only the latest 20 events, while `count` remains exact and `droppedCount` makes overflow explicit.
- Returned summaries are detached so status consumers cannot mutate live telemetry.
- Empty health/perf output omits the Degradations section.
- `tool-not-found` remains excluded from degradation tallying because it is the expected auto-install signal; all other errno classifier buckets are tallied.
- Spawn debug logging is bounded to 200 unique command/kind pairs, with the set reset at session start through the existing safe-spawn session reset seam.

## Blast radius

The required `module_report(..., blastRadius: true)` tool was unavailable in this environment. Direct source/dependent searches identified these affected entry points/callbacks: shared session start; `assertInstallAllowed`; pi mode-aware notify getter and direct notify seam; TypeScript idle-eviction timer callback; tree-sitter grammar ensure/load; formatter command resolution; sync/async spawn classifiers; `/lens-perf`; and MCP `pilens_health`. The ledger is dependency-free and synchronous; it adds no timers, I/O, or async hot-path work.

## Verification

Mandatory order completed on final restored head:

1. `npm run build` — passed
2. targeted Vitest (7 files, 47 tests) — passed
3. `npm run lint` — passed

Mutation verification:

- removed `assertInstallAllowed`'s record call → project-trust ledger assertion failed
- removed formatter npx-skip's record call → formatter-skip ledger assertion failed
- restored both calls, rebuilt, and reran all gates green

## Test matrix

- grouping, detached snapshots, latest-reason order
- per-kind retention cap and exact overflow counts
- clean vs degraded health section rendering
- trust, mode, TS idle, grammar, formatter, and spawn call-site wiring
- spawn taxonomy unchanged; tool-not-found excluded; actionable buckets tallied
- once-per-command/kind classifier logging with metadata
- Windows-safe TS subject assertion (path shape is not hardcoded)
- existing MCP health smoke and structured payload compatibility

## Non-goals

- no changes to spawn classification taxonomy or repair behavior
- no persistence across sessions/processes
- no changes to LSP pull retry/fallback semantics