### PR TITLE
fix(agent-behavior): same-path writes count as file knowledge (closes #1364)

### DIFF
--- a/.changelog/fix-1364-blind-write-self-authored.md
+++ b/.changelog/fix-1364-blind-write-self-authored.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **BLIND WRITE no longer fires on self-authored files (closes #1364)** — A `write`/`edit` of the same normalized path earlier in the blind-write window now counts as file knowledge, so the common author-then-iterate loop (create a file with `write`, refine it with successive `edit` calls) stays quiet. A genuinely stale edit of a file not touched in the window still warns, and the two-write threshold, 5-call window, and thrashing detection are unchanged. Thanks to @snrogers for the field report and the fix.

--- a/clients/agent-behavior-client.ts
+++ b/clients/agent-behavior-client.ts
@@ -2,7 +2,8 @@
  * AgentBehaviorClient for pi-lens
  *
  * Tracks tool call sequences and flags anti-patterns in real-time:
- * - Blind writes: editing or writing without reading first
+ * - Blind writes: editing or writing without reading first (a same-session
+ *   write/edit of the same path counts as file knowledge)
  * - Thrashing: repeated identical tool calls with no progress
  *
  * No external dependencies — purely tracks tool call history.
@@ -95,7 +96,17 @@ export class AgentBehaviorClient {
 		// Check for blind writes
 		if (WRITE_OPS.has(toolName)) {
 			const recentWindow = this.toolHistory.slice(-BLIND_WRITE_WINDOW);
-			const hasRecentRead = recentWindow.some((r) => READ_OPS.has(r.toolName));
+			// A read in the window proves file knowledge; so does a same-session
+			// write/edit of THIS path — the agent authored the content, so the
+			// write-then-edit loop on a self-authored file is not a blind write.
+			const hasRecentRead = recentWindow.some(
+				(r) =>
+					READ_OPS.has(r.toolName) ||
+					(WRITE_OPS.has(r.toolName) &&
+						r.filePath !== undefined &&
+						normalizedPath !== null &&
+						normalizeMapKey(r.filePath) === normalizedPath),
+			);
 
 			if (!hasRecentRead && recentWindow.length > 0) {
 				// Count how many writes in the window without reads

--- a/tests/clients/agent-behavior-client.test.ts
+++ b/tests/clients/agent-behavior-client.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { AgentBehaviorClient } from "../../clients/agent-behavior-client.js";
+
+const FORT = "/repo/roblox-project/blender/build_fort.py";
+const OTHER_A = "/repo/src/server/LayoutStore.luau";
+const OTHER_B = "/repo/src/server/Rooms.luau";
+const OTHER_C = "/repo/src/server/Tank.luau";
+
+function blindWriteWarnings(
+	warnings: ReturnType<AgentBehaviorClient["recordToolCall"]>,
+): string[] {
+	return warnings.filter((w) => w.type === "blind-write").map((w) => w.message);
+}
+
+describe("AgentBehaviorClient blind-write detection", () => {
+	it("does not flag the write-then-edit loop on a self-authored file", () => {
+		const client = new AgentBehaviorClient();
+
+		expect(blindWriteWarnings(client.recordToolCall("write", FORT))).toEqual(
+			[],
+		);
+		// Four consecutive edits on the file the agent just authored must stay
+		// quiet: the session's own write/edit of this path is file knowledge.
+		for (let i = 0; i < 4; i++) {
+			expect(blindWriteWarnings(client.recordToolCall("edit", FORT))).toEqual(
+				[],
+			);
+		}
+	});
+
+	it("does not flag edits on a file authored earlier in the window", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("write", OTHER_A);
+		client.recordToolCall("edit", OTHER_B);
+		// Second edit of OTHER_B: the first edit of the same path is still in
+		// the window, so this is not a blind write.
+		expect(blindWriteWarnings(client.recordToolCall("edit", OTHER_B))).toEqual(
+			[],
+		);
+	});
+
+	it("still flags an edit of a never-authored file after a write storm", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("edit", OTHER_A);
+		client.recordToolCall("edit", OTHER_B);
+		// OTHER_C was never read and never written this session; two writes
+		// without a read precede it, so it warns.
+		const warnings = blindWriteWarnings(client.recordToolCall("edit", OTHER_C));
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("BLIND WRITE");
+		expect(warnings[0]).toContain(OTHER_C);
+	});
+
+	it("still treats any read in the window as file knowledge", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("edit", OTHER_A);
+		client.recordToolCall("edit", OTHER_B);
+		client.recordToolCall("read", OTHER_C);
+		expect(blindWriteWarnings(client.recordToolCall("edit", OTHER_C))).toEqual(
+			[],
+		);
+	});
+
+	it("ignores same-path writes whose path is missing", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("write");
+		client.recordToolCall("edit");
+		// No paths recorded anywhere: nothing can count as knowledge of the
+		// target path, so the two-write threshold still trips.
+		const warnings = blindWriteWarnings(client.recordToolCall("edit", OTHER_C));
+		expect(warnings).toHaveLength(1);
+	});
+});
+
+describe("AgentBehaviorClient thrashing detection", () => {
+	it("still flags three consecutive identical tool+file calls", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("edit", FORT);
+		client.recordToolCall("edit", FORT);
+		const warnings = client.recordToolCall("edit", FORT);
+
+		const thrashing = warnings.filter((w) => w.type === "thrashing");
+		expect(thrashing).toHaveLength(1);
+		// The same edit is NOT a blind write anymore (self-authored path).
+		expect(blindWriteWarnings(warnings)).toEqual([]);
+	});
+});
+
+describe("AgentBehaviorClient reset", () => {
+	it("clears history so a later edit storm can warn again", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("write", FORT);
+		client.recordToolCall("edit", FORT);
+		client.reset();
+		client.recordToolCall("edit", OTHER_A);
+		client.recordToolCall("edit", OTHER_B);
+
+		expect(blindWriteWarnings(client.recordToolCall("edit", OTHER_C))).toHaveLength(
+			1,
+		);
+	});
+});


### PR DESCRIPTION
Adopts @snrogers' #1365 — their commit is cherry-picked here **unmodified, with
authorship preserved**; the only commit of mine is the `.changelog/` entry.
(Note: GitHub serves their commit with an anonymized author field, `_ <_@_.com>`;
credit is therefore carried explicitly in the changelog entry and here.)

Both #1364 and #1365 were closed by the reporter without explanation. The bug
was independently verified before adopting.

## Verification

**Reproduced on `master`** by driving `AgentBehaviorClient.recordToolCall`
directly (`write build_fort.py` then four `edit` calls, per the field repro):

```
write /repo/blender/build_fort.py => (no warnings)
edit  /repo/blender/build_fort.py => (no warnings)
edit  /repo/blender/build_fort.py => ⚠ BLIND WRITE — … without reading in the last 5 tool calls.
edit  /repo/blender/build_fort.py => 🔴 THRASHING … | ⚠ BLIND WRITE — …
edit  /repo/blender/build_fort.py => ⚠ BLIND WRITE — …
```

**Consumer trace — the warnings are live, not dead code.** `recordToolCall` is
wired from `index.ts:1781` and `clients/runtime-tool-call.ts:1016` into
`handleToolResult` as `agentBehaviorRecord`; `clients/runtime-tool-result.ts:1013`
appends `formatBehaviorWarnings(behaviorWarnings)` to the tool_result output text
whenever `!result.hasBlockers`. The false positive was reaching the model.

**Mutation check.** Reverting only the predicate (back to
`recentWindow.some((r) => READ_OPS.has(r.toolName))`) turns **3 of the 7 new
tests red** — the self-authored write-then-edit cases and the thrashing test's
"not also a blind write" assertion — while the four regression guards (read
suppresses, never-authored file still warns, path-less writes cannot suppress,
`reset()`) stay green. Restored; 7/7 pass.

**Correctness review of the predicate.**
- `toolHistory.push({ toolName, filePath, timestamp })` is unconditional, so
  write records do carry `filePath` for the predicate to read.
- Both sides of the comparison go through `normalizeMapKey`, the same helper
  the file already uses for its `fileEditCount` key — verified to match across
  separator and case variants (`C:\repo\Build_Fort.py` vs `C:/repo/build_fort.py`).
- First-write semantics are unchanged: a brand-new path has no prior record, so
  the predicate cannot match and behavior is identical to before.

## Known residual (not addressed here — deliberately out of scope)

Two pre-existing behaviors this fix does not change, both confirmed empirically:

1. **Knowledge is window-bounded.** Self-authorship only counts while the write
   is still inside the 5-call window. After five intervening non-read calls the
   warning returns on a self-authored file. In practice most interleaved calls
   are `READ_OPS` (`bash`/`grep`/`read`), which suppress independently, so this
   is rare — but a durable per-path "authored this session" set (as the
   read-guard already keeps) would be the complete fix. Worth a follow-up issue.
2. **Creating a brand-new file after a two-write storm still warns**, even
   though creating a file cannot be a blind write. Separate false-positive
   class, pre-existing, untouched.

Also spotted while reviewing (pre-existing, unrelated, not touched):
`getEditCount` reads `fileEditCount.get(filePath)` with a **raw** path while the
setter keys by `normalizeMapKey(filePath)`, so it returns `0` for any path
needing normalization — the raw-path-key defect shape. Will file separately.

## Checks

- `npm run build` — clean
- `npm run lint` (tsc) — clean
- `npm run changelog:check` — 24 entries validated
- `npx vitest run tests/clients/agent-behavior-client.test.ts` — **7 passed**
- Sibling suites touching the seam (`runtime-tool-result`, `runtime-tool-call`,
  `bootstrap-fail-soft`, `index-wiring`, `index-integration`,
  `actionable-warnings`) — **67 passed**
- Full suite — 6238 passed / 542 files. The handful of red files are
  environment- and timing-dependent flakes (madge/jscpd binary resolution,
  event-loop occupancy budgets) that differ run to run and do not touch
  agent-behavior.

Closes #1364. Supersedes #1365.
