### PR TITLE
fix(review-graph): bail the size gate at cap+1 instead of walking the whole tree (closes #1372)

### DIFF
--- a/.changelog/fix-1372-review-graph-size-gate.md
+++ b/.changelog/fix-1372-review-graph-size-gate.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Review-graph size gates stop at the cap sentinel (closes #1372)** — the shared cooperative source walk now stops at `maxFileCount + 1`, reports the partial count honestly as “more than N files,” and emits a distinct near-miss telemetry event within 5% of the cap.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,13 @@ This is the payoff of the two disciplines above: a bounded checklist of defect *
 
 ## What it is
 
+The review-graph size gate uses the shared cooperative source walker with a
+`maxFileCount + 1` sentinel: it stops at the first over-cap source entry, so
+skip telemetry and user-facing messages must describe the count as “more than
+N files,” not as an exact total. Counts within 5% above the cap also emit the
+separate `review_graph_size_near_miss` phase for boundary-flap observability;
+this is telemetry only and does not add hysteresis. (#1372)
+
 Behavioral degradation is recorded through `clients/degradation-ledger.ts`, a
 per-session in-memory store retaining the latest 20 entries per kind while
 counting overflow. New quiet refusal/degradation paths must call

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -1044,7 +1044,9 @@ export async function computeCascadeForFile(
 						"review graph coverage unknown — build state unavailable for this graph"
 					: graphBuildInfo.mode === "skipped"
 						? graphBuildInfo.skipReason === "too_many_files"
-							? `review graph disabled — ${graphBuildInfo.sourceFileCount ?? "?"} files over the ${graphBuildInfo.maxFileCount ?? "?"} cap`
+							? graphBuildInfo.sourceFileCountTruncated
+								? `review graph disabled — more than ${graphBuildInfo.maxFileCount ?? "?"} files (cap ${graphBuildInfo.maxFileCount ?? "?"})`
+								: `review graph disabled — ${graphBuildInfo.sourceFileCount ?? "?"} files over the ${graphBuildInfo.maxFileCount ?? "?"} cap`
 							: graphBuildInfo.skipReason === "unsafe_root"
 								? "review graph skipped — workspace root is at/above home dir"
 								: `review graph unavailable (${graphBuildInfo.skipReason ?? "skipped"})`

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -931,6 +931,18 @@ function clearReviewGraphSizeSkip(cwd: string): void {
 	_sizeSkipVerdicts.delete(normalizeMapKey(cwd));
 }
 
+const REVIEW_GRAPH_SIZE_NEAR_MISS_RATIO = 0.05;
+
+function isReviewGraphSizeNearMiss(
+	sourceFileCount: number,
+	maxFileCount: number,
+): boolean {
+	return (
+		sourceFileCount > maxFileCount &&
+		sourceFileCount <= maxFileCount * (1 + REVIEW_GRAPH_SIZE_NEAR_MISS_RATIO)
+	);
+}
+
 /**
  * The most recent size-skip verdict for `cwd`, if one was recorded and it's
  * still within its TTL — undefined once expired (a shrink or a raised cap
@@ -971,6 +983,13 @@ export function _setReviewGraphEntryBudgetForTests(
 	_reviewGraphEntryBudgetForTests = maxScanEntries;
 }
 
+let _reviewGraphEntryCounterForTests: (() => void) | undefined;
+export function _setReviewGraphEntryCounterForTests(
+	counter?: () => void,
+): void {
+	_reviewGraphEntryCounterForTests = counter;
+}
+
 export async function getGraphSourceFiles(
 	cwd: string,
 ): Promise<GraphSourceFilesResult> {
@@ -996,6 +1015,9 @@ export async function getGraphSourceFiles(
 			...(_reviewGraphEntryBudgetForTests === undefined
 				? {}
 				: { maxScanEntries: _reviewGraphEntryBudgetForTests }),
+			...(_reviewGraphEntryCounterForTests === undefined
+				? {}
+				: { onEntryVisited: _reviewGraphEntryCounterForTests }),
 		});
 	if (entryBudgetExceeded) {
 		logLatency({
@@ -4507,8 +4529,25 @@ async function _doBuildGraph(
 				cwd,
 				sourceFileCount,
 				maxFileCount: maxGraphFiles,
+				sourceFileCountLabel: `more than ${maxGraphFiles} files`,
+				sourceFileCountTruncated: true,
 			},
 		});
+		if (isReviewGraphSizeNearMiss(sourceFileCount, maxGraphFiles)) {
+			logLatency({
+				type: "phase",
+				phase: "review_graph_size_near_miss",
+				filePath: cwd,
+				durationMs: 0,
+				metadata: {
+					cwd,
+					maxFileCount: maxGraphFiles,
+					sourceFileCount,
+					sourceFileCountLabel: `more than ${maxGraphFiles} files`,
+					sourceFileCountTruncated: true,
+				},
+			});
+		}
 		setGraphBuildInfo(graph, {
 			reused: false,
 			mode: "skipped",

--- a/clients/source-filter.ts
+++ b/clients/source-filter.ts
@@ -238,6 +238,8 @@ export interface SourceCollectionOptions {
 	 * consistently with startup-scan's entry budget. Refs #760.
 	 */
 	maxScanEntries?: number;
+	/** Test-only traversal counter; called once for each directory entry visited. */
+	onEntryVisited?: () => void;
 	/**
 	 * Give CODE_KINDS files priority within the `maxFiles` cap (#894 review).
 	 * With broadened enumeration, a walk-order pile of data/doc files
@@ -841,6 +843,7 @@ export async function collectSourceFilesWithBudgetAsync(
 	await walkTreeStackAsync(
 		rootDir,
 		(entry, fullPath) => {
+			options?.onEntryVisited?.();
 			if (!chargeEntryBudget(budget)) return "stop"; // entry budget (#760)
 			const { recurseInto, keepFile } = classifyEntry(
 				entry,

--- a/tests/clients/review-graph.service.test.ts
+++ b/tests/clients/review-graph.service.test.ts
@@ -20,6 +20,7 @@ import {
 	getCachedReviewGraph,
 	getGraphSourceFiles,
 	getLastGraphBuildInfo,
+	_setReviewGraphEntryCounterForTests,
 	isReviewGraphMigrationNeeded,
 	REVIEW_GRAPH_VERSION,
 } from "../../clients/review-graph/builder.js";
@@ -660,6 +661,109 @@ describe("review graph service", () => {
 				}),
 			});
 			expect(skipCall?.[0]?.metadata?.sourceFileCount).toBeGreaterThan(2);
+			expect(skipCall?.[0]?.metadata?.sourceFileCountLabel).toBe(
+				"more than 2 files",
+			);
+		} finally {
+			if (previous === undefined)
+				delete process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES;
+			else process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES = previous;
+			env.cleanup();
+		}
+	});
+
+	it("stops the size-gate walk at cap+1 visited entries", async () => {
+		const env = setupTestEnvironment("pi-lens-review-graph-cap-bound-");
+		const previous = process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES;
+		process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES = "3";
+		let visited = 0;
+		_setReviewGraphEntryCounterForTests(() => {
+			visited += 1;
+		});
+		try {
+			for (let i = 0; i < 12; i += 1) {
+				createTempFile(
+					env.tmpDir,
+					`source-${i}.ts`,
+					`export const source${i} = ${i};\n`,
+				);
+			}
+			await buildOrUpdateGraph(env.tmpDir, [], new FactStore());
+			expect(getLastGraphBuildInfo()).toMatchObject({
+				mode: "skipped",
+				skipReason: "too_many_files",
+				maxFileCount: 3,
+			});
+			expect(visited).toBeLessThanOrEqual(4);
+		} finally {
+			_setReviewGraphEntryCounterForTests();
+			if (previous === undefined)
+				delete process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES;
+			else process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES = previous;
+			env.cleanup();
+		}
+	});
+
+	it("keeps the complete under-cap walk and does not report a near miss", async () => {
+		const env = setupTestEnvironment("pi-lens-review-graph-cap-under-");
+		const previous = process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES;
+		process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES = "3";
+		let visited = 0;
+		_setReviewGraphEntryCounterForTests(() => {
+			visited += 1;
+		});
+		(logLatency as ReturnType<typeof vi.fn>).mockClear();
+		try {
+			for (let i = 0; i < 2; i += 1) {
+				createTempFile(
+					env.tmpDir,
+					`source-${i}.ts`,
+					`export const source${i} = ${i};\n`,
+				);
+			}
+			const graph = await buildOrUpdateGraph(env.tmpDir, [], new FactStore());
+			expect(getLastGraphBuildInfo()?.skipReason).not.toBe("too_many_files");
+			expect(graph.fileNodes.size).toBe(2);
+			expect(visited).toBe(2);
+			expect(
+				(logLatency as ReturnType<typeof vi.fn>).mock.calls.some(
+					(args) => args[0]?.phase === "review_graph_size_near_miss",
+				),
+			).toBe(false);
+		} finally {
+			_setReviewGraphEntryCounterForTests();
+			if (previous === undefined)
+				delete process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES;
+			else process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES = previous;
+			env.cleanup();
+		}
+	});
+
+	it("logs a distinct near-miss event within 5% of the cap", async () => {
+		const env = setupTestEnvironment("pi-lens-review-graph-near-miss-");
+		const previous = process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES;
+		process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES = "20";
+		(logLatency as ReturnType<typeof vi.fn>).mockClear();
+		try {
+			for (let i = 0; i < 21; i += 1) {
+				createTempFile(
+					env.tmpDir,
+					`source-${i}.ts`,
+					`export const source${i} = ${i};\n`,
+				);
+			}
+			await buildOrUpdateGraph(env.tmpDir, [], new FactStore());
+			const nearMissCall = (logLatency as ReturnType<typeof vi.fn>).mock.calls.find(
+				(args) => args[0]?.phase === "review_graph_size_near_miss",
+			);
+			expect(nearMissCall?.[0]).toMatchObject({
+				phase: "review_graph_size_near_miss",
+				metadata: expect.objectContaining({
+					maxFileCount: 20,
+					sourceFileCount: 21,
+					sourceFileCountLabel: "more than 20 files",
+				}),
+			});
 		} finally {
 			if (previous === undefined)
 				delete process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES;


### PR DESCRIPTION
Summary: retain the shared cooperative source walk's maxFileCount + 1 early-abort sentinel and add bounded-work regression coverage; report skip counts honestly as more than N files and make dispatch messaging sentinel-aware; emit review_graph_size_near_miss telemetry within 5% of the cap without changing hysteresis behavior. Verification: npm run build; targeted review-graph Vitest (4 files, 55 tests passed); npm run lint; npm run changelog:check; mutation removing maxFiles: maxGraphFiles + 1 made the bounded-work test fail (12 visits > cap+1 limit of 4). Closes #1372.