### PR TITLE
fix(memory): per-root word-index eviction; snapshot postings de-dup (closes #1370, refs #1332)

### DIFF
--- a/.changelog/fix-1370-word-index-eviction.md
+++ b/.changelog/fix-1370-word-index-eviction.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Bound warm word-index memory (closes #1370, refs #1332)** — idle/LRU per-root eviction now releases inactive indexes safely, while persisted snapshot postings no longer remain duplicated in long-lived in-memory caches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,9 @@ unref'd, and cleared on every removal/reset path; lifecycle eviction belongs in
 the word-index NDJSON log, never the degradation ledger. Snapshot persistence
 may retain serialized postings only until publication: afterward authoritative
 and parse caches must not pin them, because that duplicates the mutable warm
-index's expanded postings graph. (#1370)
+index's expanded postings graph. The parse cache instead keeps a shallow
+postings-stripped snapshot for metadata/report consumers; a cold analyze reloads
+the full body once and immediately rewarms the leased per-root index. (#1370)
 
 Helm chart linting uses the shared workspace-topology `Chart.yaml` marker. YAML
 and `.tpl` edits inside a chart dispatch one canonical-root-deduplicated,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # pi-lens — agent context
 
+MCP warm word indexes are bounded per root in `clients/mcp/analyze.ts`: callers
+must acquire/release a lease around every use, because idle and LRU eviction
+must never retire an index mid-query. Idle timers are generation-owned,
+unref'd, and cleared on every removal/reset path; lifecycle eviction belongs in
+the word-index NDJSON log, never the degradation ledger. Snapshot persistence
+may retain serialized postings only until publication: afterward authoritative
+and parse caches must not pin them, because that duplicates the mutable warm
+index's expanded postings graph. (#1370)
+
 Helm chart linting uses the shared workspace-topology `Chart.yaml` marker. YAML
 and `.tpl` edits inside a chart dispatch one canonical-root-deduplicated,
 bounded `helm lint` pass through the ordinary typed availability/install seam.

--- a/clients/lens-engine.ts
+++ b/clients/lens-engine.ts
@@ -27,7 +27,7 @@ import {
 } from "./instance-registry.js";
 import { initLSPConfig } from "./lsp/config.js";
 import { getLSPService } from "./lsp/index.js";
-import { getOrLoadWarmWordIndex } from "./mcp/analyze.js";
+import { acquireWarmWordIndex } from "./mcp/analyze.js";
 import { normalizeMapKey } from "./path-utils.js";
 import { scanProjectDiagnostics } from "./project-diagnostics/scanner.js";
 import type { ProjectDiagnosticsSnapshot } from "./project-diagnostics/types.js";
@@ -489,7 +489,7 @@ function toSymbolSearchHit(result: RankedFile): SymbolSearchHit {
  * cwd, never blocking this call) so a retry shortly after succeeds (#348
  * decision 3).
  *
- * #536 rider: prefers the warm in-memory index (`getOrLoadWarmWordIndex`,
+ * #536 rider: prefers the warm in-memory index (`acquireWarmWordIndex`,
  * clients/mcp/analyze.ts) over a fresh disk read when one exists for this
  * cwd — a warm `pilens_analyze` call updates that live copy synchronously but
  * persists it to disk on a debounce (default 1500ms), so without this a query
@@ -521,9 +521,10 @@ export async function symbolSearch(
 	options: SymbolSearchOptions = {},
 ): Promise<SymbolSearchResult> {
 	const snapshot = loadProjectSnapshot(cwd);
-	const index =
-		getOrLoadWarmWordIndex(cwd) ?? deserializeWordIndex(snapshot?.wordIndex);
+	const warmLease = acquireWarmWordIndex(cwd);
+	const index = warmLease.index ?? deserializeWordIndex(snapshot?.wordIndex);
 	if (!index) {
+		warmLease.release();
 		const priorStatus = getWordIndexBuildStatus(cwd);
 		const status =
 			priorStatus?.state === "refused"
@@ -551,17 +552,19 @@ export async function symbolSearch(
 	}
 	// Boost well-connected files using the snapshot's reverse-dependency
 	// (importedBy) counts; snapshot keys are normalized, index keys are raw.
-	const centrality = centralityFromReverseDeps(
-		index,
-		snapshot?.reverseDeps,
-		(file) => normalizeMapKey(path.resolve(file)),
-	);
-	const fileFilter = buildSymbolSearchFileFilter(cwd, options);
-	const results = searchWordIndex(index, query, {
-		limit,
-		centrality,
-		fileFilter,
-	});
+	let centrality: Map<string, number>;
+	let results: RankedFile[];
+	try {
+		centrality = centralityFromReverseDeps(
+			index,
+			snapshot?.reverseDeps,
+			(file) => normalizeMapKey(path.resolve(file)),
+		);
+		const fileFilter = buildSymbolSearchFileFilter(cwd, options);
+		results = searchWordIndex(index, query, { limit, centrality, fileFilter });
+	} finally {
+		warmLease.release();
+	}
 	const hits = results.map(toSymbolSearchHit);
 
 	const { getCachedReviewGraph } = await import("./review-graph/builder.js");

--- a/clients/lens-engine.ts
+++ b/clients/lens-engine.ts
@@ -31,7 +31,7 @@ import { acquireWarmWordIndex } from "./mcp/analyze.js";
 import { normalizeMapKey } from "./path-utils.js";
 import { scanProjectDiagnostics } from "./project-diagnostics/scanner.js";
 import type { ProjectDiagnosticsSnapshot } from "./project-diagnostics/types.js";
-import { loadProjectSnapshot } from "./project-snapshot.js";
+import { loadProjectSnapshotWithoutWordIndex } from "./project-snapshot.js";
 import type { ReviewGraph } from "./review-graph/types.js";
 import {
 	getTreeSitterRuntimeStatus,
@@ -39,7 +39,6 @@ import {
 } from "./tree-sitter-shared.js";
 import {
 	centralityFromReverseDeps,
-	deserializeWordIndex,
 	getWordIndexBuildStatus,
 	type RankedFile,
 	searchWordIndex,
@@ -520,9 +519,9 @@ export async function symbolSearch(
 	limit = 20,
 	options: SymbolSearchOptions = {},
 ): Promise<SymbolSearchResult> {
-	const snapshot = loadProjectSnapshot(cwd);
 	const warmLease = acquireWarmWordIndex(cwd);
-	const index = warmLease.index ?? deserializeWordIndex(snapshot?.wordIndex);
+	const snapshot = loadProjectSnapshotWithoutWordIndex(cwd);
+	const index = warmLease.index;
 	if (!index) {
 		warmLease.release();
 		const priorStatus = getWordIndexBuildStatus(cwd);

--- a/clients/mcp/analyze.ts
+++ b/clients/mcp/analyze.ts
@@ -14,10 +14,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import {
-	CacheManager,
-	MCP_TURN_STATE_OWNER_ID,
-} from "../cache-manager.js";
+import { CacheManager, MCP_TURN_STATE_OWNER_ID } from "../cache-manager.js";
 import {
 	CASCADE_GRAPH_KINDS,
 	dispatchLintWithResult,
@@ -28,6 +25,8 @@ import type { Diagnostic } from "../dispatch/types.js";
 import { detectFileKind } from "../file-kinds.js";
 import { getDiagnosticTracker } from "../diagnostic-tracker.js";
 import { getLSPService } from "../lsp/index.js";
+import { PathKeyedMap } from "../path-keyed-map.js";
+import { normalizeMapKey } from "../path-utils.js";
 import { loadProjectSnapshot } from "../project-snapshot.js";
 import { buildOrUpdateGraph } from "../review-graph/service.js";
 import { recordDiagnostics } from "../widget-state.js";
@@ -39,6 +38,7 @@ import {
 	WORD_INDEX_MAX_BYTES,
 	type WordIndex,
 } from "../word-index.js";
+import { logWordIndex } from "../word-index-logger.js";
 import { createMcpHost } from "./host-shim.js";
 
 // #536: module-scoped FactStore for the warm-analyze graph seam, mirroring the
@@ -61,7 +61,90 @@ const warmGraphFacts = new FactStore();
 // nothing usable" (index missing or pre-phase-2/no-forward-map), distinct from
 // "never checked" (key absent) — avoids re-attempting a snapshot load with no
 // forward index on every single analyze call.
-const warmWordIndexes = new Map<string, WordIndex | undefined>();
+const DEFAULT_WORD_INDEX_IDLE_EVICT_MS = 20 * 60_000;
+const DEFAULT_WORD_INDEX_MAX_WARM_ROOTS = 8;
+
+interface WarmWordIndexEntry {
+	index: WordIndex | undefined;
+	timer: ReturnType<typeof setTimeout> | undefined;
+	leases: number;
+	lastUsedAt: number;
+	generation: number;
+}
+
+const warmWordIndexes = new PathKeyedMap<WarmWordIndexEntry>(normalizeMapKey);
+
+function positiveEnv(name: string, fallback: number): number {
+	const parsed = Number.parseInt(process.env[name] ?? "", 10);
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function idleEvictMs(): number {
+	return positiveEnv(
+		"PI_LENS_WORD_INDEX_IDLE_EVICT_MS",
+		DEFAULT_WORD_INDEX_IDLE_EVICT_MS,
+	);
+}
+
+function maxWarmRoots(): number {
+	return positiveEnv(
+		"PI_LENS_WORD_INDEX_MAX_WARM_ROOTS",
+		DEFAULT_WORD_INDEX_MAX_WARM_ROOTS,
+	);
+}
+
+function clearWarmWordIndexTimer(entry: WarmWordIndexEntry): void {
+	if (entry.timer) clearTimeout(entry.timer);
+	entry.timer = undefined;
+}
+
+function evictWarmWordIndex(
+	key: string,
+	entry: WarmWordIndexEntry,
+	reason: "idle" | "lru",
+): boolean {
+	if (entry.leases > 0 || warmWordIndexes.get(key) !== entry) return false;
+	clearWarmWordIndexTimer(entry);
+	warmWordIndexes.delete(key);
+	logWordIndex({
+		phase: "warm_cache_evicted",
+		cwd: key,
+		trigger: "mcp",
+		reason,
+	});
+	return true;
+}
+
+function scheduleWarmWordIndexIdleEviction(
+	key: string,
+	entry: WarmWordIndexEntry,
+): void {
+	clearWarmWordIndexTimer(entry);
+	const generation = ++entry.generation;
+	const timer = setTimeout(() => {
+		entry.timer = undefined;
+		if (warmWordIndexes.get(key) !== entry || entry.generation !== generation)
+			return;
+		if (!evictWarmWordIndex(key, entry, "idle"))
+			scheduleWarmWordIndexIdleEviction(key, entry);
+	}, idleEvictMs());
+	timer.unref?.();
+	entry.timer = timer;
+}
+
+function enforceWarmWordIndexLruCap(): void {
+	while (warmWordIndexes.size > maxWarmRoots()) {
+		const victim = [...warmWordIndexes.entries()]
+			.filter(([, entry]) => entry.leases === 0)
+			.sort(([, a], [, b]) => a.lastUsedAt - b.lastUsedAt)[0];
+		if (!victim || !evictWarmWordIndex(victim[0], victim[1], "lru")) return;
+	}
+}
+
+export interface WarmWordIndexLease {
+	index: WordIndex | undefined;
+	release(): void;
+}
 
 /**
  * Look up (loading from the persisted snapshot on first use per cwd) the warm
@@ -71,17 +154,39 @@ const warmWordIndexes = new Map<string, WordIndex | undefined>();
  * following a warm `pilens_analyze` call in the SAME process would read a
  * stale on-disk snapshot until the debounced persist (default 1500ms) flushes.
  */
-export function getOrLoadWarmWordIndex(cwd: string): WordIndex | undefined {
+export function acquireWarmWordIndex(cwd: string): WarmWordIndexLease {
 	const key = path.resolve(cwd);
-	if (warmWordIndexes.has(key)) return warmWordIndexes.get(key);
-	const snapshot = loadProjectSnapshot(key);
-	const index = deserializeWordIndex(snapshot?.wordIndex) ?? undefined;
-	// Same phase-2 rule as updateWordIndexForCascade: no forward index ⇒ no
-	// incremental primitive available, so don't cache it as "usable" — this
-	// call site's whole point is the incremental single-doc update.
-	const usable = index?.forward ? index : undefined;
-	warmWordIndexes.set(key, usable);
-	return usable;
+	let entry = warmWordIndexes.get(key);
+	if (!entry) {
+		const snapshot = loadProjectSnapshot(key);
+		const index = deserializeWordIndex(snapshot?.wordIndex) ?? undefined;
+		entry = {
+			index: index?.forward ? index : undefined,
+			timer: undefined,
+			leases: 0,
+			lastUsedAt: Date.now(),
+			generation: 0,
+		};
+		warmWordIndexes.set(key, entry);
+	}
+	entry.leases++;
+	entry.lastUsedAt = Date.now();
+	scheduleWarmWordIndexIdleEviction(key, entry);
+	enforceWarmWordIndexLruCap();
+	let released = false;
+	return {
+		index: entry.index,
+		release() {
+			if (released) return;
+			released = true;
+			entry.leases = Math.max(0, entry.leases - 1);
+			entry.lastUsedAt = Date.now();
+			if (warmWordIndexes.get(key) === entry) {
+				scheduleWarmWordIndexIdleEviction(key, entry);
+				enforceWarmWordIndexLruCap();
+			}
+		},
+	};
 }
 
 /**
@@ -89,7 +194,22 @@ export function getOrLoadWarmWordIndex(cwd: string): WordIndex | undefined {
  * unrelated test cases in the same vitest worker.
  */
 export function _resetWarmWordIndexCacheForTests(): void {
+	for (const entry of warmWordIndexes.values()) clearWarmWordIndexTimer(entry);
 	warmWordIndexes.clear();
+}
+
+export function _getWarmWordIndexCacheStateForTests(): {
+	size: number;
+	keys: string[];
+	timers: Array<ReturnType<typeof setTimeout>>;
+} {
+	return {
+		size: warmWordIndexes.size,
+		keys: [...warmWordIndexes.keys()],
+		timers: [...warmWordIndexes.values()].flatMap((entry) =>
+			entry.timer ? [entry.timer] : [],
+		),
+	};
 }
 
 // Generous warm-up budgets: a cold language server needs to spawn AND publish
@@ -370,21 +490,26 @@ export async function analyzeFile(
 		// INTERNALLY (PathKeyedMap), so this edit-form key and the build path's
 		// walk-derived key converge on the same entry regardless of casing/
 		// separator — the old duplicate-orphan hazard is gone at the map layer.
-		const warmIndex = getOrLoadWarmWordIndex(cwd);
-		if (warmIndex) {
-			try {
-				const content = fs.readFileSync(absPath, "utf8");
-				const byteLength = Buffer.byteLength(content, "utf-8");
-				if (byteLength > WORD_INDEX_MAX_BYTES) {
-					removeWordIndexDocument(warmIndex, absPath);
-				} else {
-					updateWordIndexDocument(warmIndex, { path: absPath, content });
+		const warmLease = acquireWarmWordIndex(cwd);
+		const warmIndex = warmLease.index;
+		try {
+			if (warmIndex) {
+				try {
+					const content = fs.readFileSync(absPath, "utf8");
+					const byteLength = Buffer.byteLength(content, "utf-8");
+					if (byteLength > WORD_INDEX_MAX_BYTES) {
+						removeWordIndexDocument(warmIndex, absPath);
+					} else {
+						updateWordIndexDocument(warmIndex, { path: absPath, content });
+					}
+					scheduleWordIndexPersist(cwd, warmIndex);
+				} catch {
+					// unreadable/deleted, or an update failure — best-effort, same as the
+					// graph update above.
 				}
-				scheduleWordIndexPersist(cwd, warmIndex);
-			} catch {
-				// unreadable/deleted, or an update failure — best-effort, same as the
-				// graph update above.
 			}
+		} finally {
+			warmLease.release();
 		}
 	}
 

--- a/clients/project-report.ts
+++ b/clients/project-report.ts
@@ -36,7 +36,7 @@
 
 import * as path from "node:path";
 import { normalizeMapKey, toProjectRelativePath } from "./path-utils.js";
-import { loadProjectSnapshot } from "./project-snapshot.js";
+import { loadProjectSnapshotWithoutWordIndex } from "./project-snapshot.js";
 import type { ReviewGraph } from "./review-graph/types.js";
 
 export interface ProjectReportOptions {
@@ -279,7 +279,7 @@ function buildFileDegrees(graph: ReviewGraph): FileDegrees {
 
 function computeTrust(graph: ReviewGraph, cwd: string): ProjectReportTrust {
 	const filesCovered = graph.fileNodes.size;
-	const snapshot = loadProjectSnapshot(cwd);
+	const snapshot = loadProjectSnapshotWithoutWordIndex(cwd);
 	const snapshotFileCount = snapshot ? Object.keys(snapshot.files).length : 0;
 	const persistedTotal = graph.persistCoverage?.totalFiles ?? 0;
 	const filesTotal = Math.max(filesCovered, snapshotFileCount, persistedTotal);

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -260,6 +260,12 @@ const SNAPSHOT_PARSE_CACHE_MAX = 4;
 const SNAPSHOT_PARSE_CACHE_MAX_BYTES = 24 * 1024 * 1024;
 const snapshotParseCache = new Map<string, SnapshotParseCacheEntry>();
 
+function withoutWordIndex(snapshot: ProjectSnapshot | null): ProjectSnapshot | null {
+	if (!snapshot?.wordIndex) return snapshot;
+	const { wordIndex: _releasedPostings, ...stripped } = snapshot;
+	return stripped;
+}
+
 function cacheParsedSnapshot(
 	snapshotPath: string,
 	entry: SnapshotParseCacheEntry,
@@ -306,6 +312,13 @@ const authoritativeSnapshots = new Map<string, AuthoritativeSnapshotEntry>();
 export function _resetProjectSnapshotParseCacheForTests(): void {
 	snapshotParseCache.clear();
 	authoritativeSnapshots.clear();
+}
+
+/** Test hook: prove the parse-cache tier never owns serialized postings. */
+export function _projectSnapshotParseCacheRetainsWordIndexForTests(): boolean {
+	return [...snapshotParseCache.values()].some(
+		(entry) => entry.snapshot?.wordIndex !== undefined,
+	);
 }
 
 /** Resolve which body file is currently on disk: gz canonical, else legacy. */
@@ -397,7 +410,10 @@ function readSnapshotBody(
 	}
 }
 
-export function loadProjectSnapshot(cwd: string): ProjectSnapshot | null {
+function loadProjectSnapshotInternal(
+	cwd: string,
+	requireWordIndex: boolean,
+): ProjectSnapshot | null {
 	const key = normalizeMapKey(cwd);
 	const body = resolveSnapshotBodyPath(cwd);
 	// Authoritative in-process write wins while our own (possibly still
@@ -424,26 +440,43 @@ export function loadProjectSnapshot(cwd: string): ProjectSnapshot | null {
 	// SnapshotParseCacheEntry for why: coarse FAT/exFAT mtime resolution can
 	// otherwise alias a just-rewritten file onto a stale cache entry).
 	if (cached && cached.mtimeMs === body.mtimeMs && cached.size === body.size) {
-		return cached.snapshot;
+		if (!requireWordIndex || !cached.snapshot || cached.snapshot.wordIndex) {
+			return cached.snapshot;
+		}
 	}
 	const { snapshot, rawBytes } = readSnapshotBody(body.path, body.gz);
-	// Serialized postings expand into a much larger object graph. Keeping that
-	// graph here duplicates the live warm WordIndex, so word-index snapshots are
-	// deliberately one-shot disk reads rather than parse-cache residents (#1370).
+	// Serialized postings expand into a much larger object graph. Cache only a
+	// shallow postings-stripped body: metadata/report consumers stay warm while
+	// the live warm WordIndex remains the sole retained postings graph (#1370).
+	const cacheSnapshot = withoutWordIndex(snapshot);
 	if (
 		rawBytes > 0 &&
-		rawBytes <= SNAPSHOT_PARSE_CACHE_MAX_BYTES &&
-		!snapshot?.wordIndex
+		(rawBytes <= SNAPSHOT_PARSE_CACHE_MAX_BYTES || snapshot?.wordIndex)
 	) {
 		cacheParsedSnapshot(cacheKey, {
 			mtimeMs: body.mtimeMs,
 			size: body.size,
-			snapshot,
+			snapshot: cacheSnapshot,
 		});
 	} else {
 		snapshotParseCache.delete(cacheKey);
 	}
 	return snapshot;
+}
+
+/** Load the canonical body, including serialized postings when present. */
+export function loadProjectSnapshot(cwd: string): ProjectSnapshot | null {
+	return loadProjectSnapshotInternal(cwd, true);
+}
+
+/**
+ * Load snapshot metadata without retaining or re-reading serialized postings.
+ * After publication this is served by the postings-stripped parse cache.
+ */
+export function loadProjectSnapshotWithoutWordIndex(
+	cwd: string,
+): ProjectSnapshot | null {
+	return loadProjectSnapshotInternal(cwd, false);
 }
 
 // --- Worker-thread body persist (gzip off the save path, #958 item 2) --------
@@ -541,6 +574,16 @@ function reconcileAuthoritativeAfterWrite(
 	// WordIndex owns mutable Map/PathKeyedMap state. Drop the authoritative copy
 	// after publication; later merge-writers rehydrate the canonical disk body.
 	if (pending.snapshot.wordIndex) {
+		try {
+			const stat = fs.statSync(pending.gzPath);
+			cacheParsedSnapshot(pending.gzPath, {
+				mtimeMs: stat.mtimeMs,
+				size: stat.size,
+				snapshot: withoutWordIndex(pending.snapshot),
+			});
+		} catch {
+			// A cache miss is safe: the first metadata consumer reconstructs it.
+		}
 		authoritativeSnapshots.delete(pending.key);
 		logLatency({
 			type: "phase",

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -104,11 +104,7 @@ function parseSequenceIndex(value: unknown): SnapshotSequenceIndex | undefined {
 // fallback. gzip measured 5-10x on top of the #957 compaction win (the
 // review-graph's own measurement was 60MB → 1.4MB).
 export function getProjectSnapshotPath(cwd: string): string {
-	return path.join(
-		getProjectDataDir(cwd),
-		"cache",
-		"project-snapshot.json.gz",
-	);
+	return path.join(getProjectDataDir(cwd), "cache", "project-snapshot.json.gz");
 }
 
 /**
@@ -202,7 +198,9 @@ function parseSnapshotMeta(value: unknown): ProjectSnapshotMeta | null {
  * legacy installs — callers must treat a `null` return as "no opinion" and
  * fall through to parsing the body. #947.
  */
-export function readProjectSnapshotMeta(cwd: string): ProjectSnapshotMeta | null {
+export function readProjectSnapshotMeta(
+	cwd: string,
+): ProjectSnapshotMeta | null {
 	const meta = readJsonCache<ProjectSnapshotMeta>(
 		getProjectSnapshotMetaPath(cwd),
 		(parsed) => parseSnapshotMeta(parsed) ?? undefined,
@@ -357,7 +355,10 @@ export function resetSnapshotBodyReadCountForTests(): void {
 	_snapshotBodyReadCountForTests = 0;
 }
 
-function readSnapshotBody(bodyPath: string, gz: boolean): {
+function readSnapshotBody(
+	bodyPath: string,
+	gz: boolean,
+): {
 	snapshot: ProjectSnapshot | null;
 	rawBytes: number;
 } {
@@ -426,7 +427,14 @@ export function loadProjectSnapshot(cwd: string): ProjectSnapshot | null {
 		return cached.snapshot;
 	}
 	const { snapshot, rawBytes } = readSnapshotBody(body.path, body.gz);
-	if (rawBytes > 0 && rawBytes <= SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
+	// Serialized postings expand into a much larger object graph. Keeping that
+	// graph here duplicates the live warm WordIndex, so word-index snapshots are
+	// deliberately one-shot disk reads rather than parse-cache residents (#1370).
+	if (
+		rawBytes > 0 &&
+		rawBytes <= SNAPSHOT_PARSE_CACHE_MAX_BYTES &&
+		!snapshot?.wordIndex
+	) {
 		cacheParsedSnapshot(cacheKey, {
 			mtimeMs: body.mtimeMs,
 			size: body.size,
@@ -527,6 +535,22 @@ function reconcileAuthoritativeAfterWrite(
 	// Only reconcile the entry that still belongs to THIS (latest) generation —
 	// a superseding save already replaced it with a newer object.
 	if (!entry || entry.snapshot !== pending.snapshot) return;
+	// The worker needs the serialized snapshot until promotion completes, but
+	// retaining it afterward duplicates the mutable warm index's postings. A
+	// shared reference is unsafe: ProjectSnapshot stores serialized arrays while
+	// WordIndex owns mutable Map/PathKeyedMap state. Drop the authoritative copy
+	// after publication; later merge-writers rehydrate the canonical disk body.
+	if (pending.snapshot.wordIndex) {
+		authoritativeSnapshots.delete(pending.key);
+		logLatency({
+			type: "phase",
+			phase: "project_snapshot_word_index_released",
+			filePath: pending.gzPath,
+			durationMs: 0,
+			metadata: { rawBytes },
+		});
+		return;
+	}
 	if (rawBytes > SNAPSHOT_PARSE_CACHE_MAX_BYTES) {
 		// Benign but invisible otherwise: the next load will re-parse this body
 		// from disk instead of serving the in-process object.
@@ -676,7 +700,8 @@ function handleSnapshotWorkerDeath(reason: string): void {
 	_snapshotWorkerDisabled = true;
 	const requests = [..._snapshotWorkerRequests.values()];
 	_snapshotWorkerRequests.clear();
-	for (const pending of requests) dispatchMainThreadWriteThroughSeam(pending, reason);
+	for (const pending of requests)
+		dispatchMainThreadWriteThroughSeam(pending, reason);
 }
 
 function resolveSnapshotPersistWorkerPath(): string | undefined {
@@ -688,10 +713,7 @@ function resolveSnapshotPersistWorkerPath(): string | undefined {
 	// resolvePersistWorkerPath (#950 review F1).
 	const candidates = [
 		new URL("./project-snapshot-persist-worker.js", import.meta.url),
-		new URL(
-			"./clients/project-snapshot-persist-worker.js",
-			import.meta.url,
-		),
+		new URL("./clients/project-snapshot-persist-worker.js", import.meta.url),
 	];
 	for (const url of candidates) {
 		try {
@@ -710,7 +732,9 @@ function getSnapshotPersistWorker(): Worker | undefined {
 	try {
 		const workerPath = resolveSnapshotPersistWorkerPath();
 		if (workerPath === undefined) {
-			handleSnapshotWorkerDeath("persist worker script not found in any layout");
+			handleSnapshotWorkerDeath(
+				"persist worker script not found in any layout",
+			);
 			return undefined;
 		}
 		const worker = new Worker(workerPath);
@@ -792,7 +816,8 @@ function ensureSnapshotPersistExitHook(): void {
 		for (const pending of requests) {
 			// Only the newest generation per key still matters; older ones are
 			// superseded and their stage files are swept on next launch.
-			if (_snapshotGenerations.get(pending.key) !== pending.generation) continue;
+			if (_snapshotGenerations.get(pending.key) !== pending.generation)
+				continue;
 			writeSnapshotBodyOnMainThread(pending, "exit_hook");
 		}
 		void _snapshotPersistWorker?.terminate();
@@ -945,7 +970,9 @@ export function resetProjectSnapshotPersistWorkerForTests(): void {
 }
 
 /** Test-only mutation switch for proving the supersession invariant. */
-export function setProjectSnapshotGenerationGateForTests(enabled: boolean): void {
+export function setProjectSnapshotGenerationGateForTests(
+	enabled: boolean,
+): void {
 	_snapshotGenerationGateEnabledForTests = enabled;
 }
 
@@ -1048,7 +1075,11 @@ export function saveRuntimeProjectSnapshot(args: {
 			// isProjectSnapshotFresh on load, seq mismatch) would get silently
 			// re-stamped with the CURRENT seq by this save, "laundering" a stale
 			// index into looking fresh before the word-index task even runs.
-			if (!snapshot.wordIndex && existing.wordIndex && existing.seq === snapshot.seq) {
+			if (
+				!snapshot.wordIndex &&
+				existing.wordIndex &&
+				existing.seq === snapshot.seq
+			) {
 				snapshot.wordIndex = existing.wordIndex;
 			}
 		}

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -5,7 +5,7 @@ import { logLatency } from "./latency-logger.js";
 import { resolvePackagePath } from "./package-root.js";
 import { findNearestContaining, walkUpDirs } from "./path-utils.js";
 import type { ProjectConventions } from "./project-conventions.js";
-import { loadProjectSnapshot } from "./project-snapshot.js";
+import { loadProjectSnapshotWithoutWordIndex } from "./project-snapshot.js";
 
 export type ToolGate = "config-first" | "smart-default" | "mixed";
 
@@ -1604,7 +1604,7 @@ export function getLinterPolicyForFile(
 export function getCachedProjectConventions(
 	cwd: string,
 ): ProjectConventions | undefined {
-	const snapshot = loadProjectSnapshot(cwd);
+	const snapshot = loadProjectSnapshotWithoutWordIndex(cwd);
 	return snapshot?.conventions;
 }
 

--- a/clients/word-index-logger.ts
+++ b/clients/word-index-logger.ts
@@ -45,6 +45,8 @@ export type WordIndexLogPhase =
 	| "cold_build_refused"
 	/** Cold-query background build (build or persist) failed. */
 	| "cold_build_failed"
+	/** A warm MCP index was normally released by idle/LRU lifecycle policy. */
+	| "warm_cache_evicted"
 	/** A debounced snapshot persist landed — confirms the index is kept fresh
 	 *  across edits (the durable record the MCP host's no-op `dbg` couldn't give). */
 	| "persist_succeeded"

--- a/tests/clients/mcp-word-index-eviction.test.ts
+++ b/tests/clients/mcp-word-index-eviction.test.ts
@@ -1,0 +1,153 @@
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	_getWarmWordIndexCacheStateForTests,
+	_resetWarmWordIndexCacheForTests,
+	acquireWarmWordIndex,
+} from "../../clients/mcp/analyze.js";
+import {
+	PROJECT_SNAPSHOT_VERSION,
+	_resetProjectSnapshotParseCacheForTests,
+	getSnapshotBodyReadCountForTests,
+	loadProjectSnapshot,
+	resetSnapshotBodyReadCountForTests,
+	saveProjectSnapshot,
+} from "../../clients/project-snapshot.js";
+import {
+	buildWordIndex,
+	searchWordIndex,
+	serializeWordIndex,
+} from "../../clients/word-index.js";
+import { suspendAt } from "./interleaving-kit.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+function persistIndex(cwd: string, symbol: string): void {
+	const index = buildWordIndex([
+		{
+			path: path.join(cwd, "src", `${symbol}.ts`),
+			content: `export const ${symbol} = true;`,
+		},
+	]);
+	saveProjectSnapshot(cwd, {
+		version: PROJECT_SNAPSHOT_VERSION,
+		projectRoot: cwd,
+		generatedAt: new Date().toISOString(),
+		seq: 0,
+		files: {},
+		symbols: {},
+		reverseDeps: {},
+		cachedExports: [],
+		wordIndex: serializeWordIndex(index),
+	});
+}
+
+describe("MCP warm word-index lifecycle (#1370)", () => {
+	let cleanup: (() => void) | undefined;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		const env = setupTestEnvironment("word-index-eviction-");
+		cleanup = env.cleanup;
+		process.env.PILENS_DATA_DIR = path.join(env.tmpDir, "data");
+		process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC = "1";
+		process.env.PI_LENS_WORD_INDEX_IDLE_EVICT_MS = "20";
+		process.env.PI_LENS_WORD_INDEX_MAX_WARM_ROOTS = "8";
+	});
+
+	afterEach(() => {
+		_resetWarmWordIndexCacheForTests();
+		_resetProjectSnapshotParseCacheForTests();
+		delete process.env.PILENS_DATA_DIR;
+		delete process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC;
+		delete process.env.PI_LENS_WORD_INDEX_IDLE_EVICT_MS;
+		delete process.env.PI_LENS_WORD_INDEX_MAX_WARM_ROOTS;
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		cleanup?.();
+	});
+
+	it("idle-evicts and performs a real deserialize rebuild on the next query", async () => {
+		const cwd = path.join(process.env.PILENS_DATA_DIR!, "project");
+		persistIndex(cwd, "authenticateUser");
+		const first = acquireWarmWordIndex(cwd);
+		expect(searchWordIndex(first.index!, "authenticate user")).toHaveLength(1);
+		const firstIndex = first.index;
+		first.release();
+
+		await vi.advanceTimersByTimeAsync(20);
+		expect(_getWarmWordIndexCacheStateForTests().size).toBe(0);
+
+		const rebuilt = acquireWarmWordIndex(cwd);
+		expect(rebuilt.index).not.toBe(firstIndex);
+		expect(searchWordIndex(rebuilt.index!, "authenticate user")).toHaveLength(
+			1,
+		);
+		rebuilt.release();
+	});
+
+	it("lease-guards a suspended query from idle eviction", async () => {
+		const cwd = path.join(process.env.PILENS_DATA_DIR!, "busy-project");
+		persistIndex(cwd, "leasedSymbol");
+		const lease = acquireWarmWordIndex(cwd);
+		const queryStep = vi.fn(async (index: NonNullable<typeof lease.index>) =>
+			searchWordIndex(index, "leased symbol"),
+		);
+		const suspension = suspendAt(queryStep, async (index) =>
+			searchWordIndex(index, "leased symbol"),
+		);
+		const query = queryStep(lease.index!).finally(() => lease.release());
+		await suspension.admitted;
+
+		await vi.advanceTimersByTimeAsync(20);
+		expect(_getWarmWordIndexCacheStateForTests().size).toBe(1);
+		suspension.release();
+		expect(await query).toHaveLength(1);
+		suspension.restore();
+	});
+
+	it("evicts the least-recently-used idle root at the configured cap", async () => {
+		process.env.PI_LENS_WORD_INDEX_MAX_WARM_ROOTS = "2";
+		const roots = ["oldest", "middle", "newest"].map((name) =>
+			path.join(process.env.PILENS_DATA_DIR!, name),
+		);
+		for (const [i, root] of roots.entries()) {
+			persistIndex(root, `symbol${i}`);
+			const lease = acquireWarmWordIndex(root);
+			lease.release();
+			await vi.advanceTimersByTimeAsync(1);
+		}
+		expect(_getWarmWordIndexCacheStateForTests().size).toBe(2);
+		expect(_getWarmWordIndexCacheStateForTests().keys).not.toContain(roots[0]);
+		const rebuiltOldest = acquireWarmWordIndex(roots[0]);
+		rebuiltOldest.release();
+		// Re-adding the evicted oldest root must evict one of the two prior residents.
+		expect(_getWarmWordIndexCacheStateForTests().size).toBe(2);
+	});
+
+	it("unrefs owned timers and clears them on disposal", () => {
+		const cwd = path.join(process.env.PILENS_DATA_DIR!, "dispose-project");
+		persistIndex(cwd, "disposeSymbol");
+		const lease = acquireWarmWordIndex(cwd);
+		lease.release();
+		const timer = _getWarmWordIndexCacheStateForTests().timers[0];
+		expect(timer).toBeDefined();
+		expect(timer?.hasRef?.()).toBe(false);
+		const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+		_resetWarmWordIndexCacheForTests();
+		expect(clearSpy).toHaveBeenCalledWith(timer);
+		expect(_getWarmWordIndexCacheStateForTests()).toMatchObject({
+			size: 0,
+			keys: [],
+			timers: [],
+		});
+	});
+
+	it("does not retain serialized postings in authoritative or parse caches", () => {
+		const cwd = path.join(process.env.PILENS_DATA_DIR!, "snapshot-project");
+		persistIndex(cwd, "snapshotSymbol");
+		resetSnapshotBodyReadCountForTests();
+		expect(loadProjectSnapshot(cwd)?.wordIndex).toBeDefined();
+		expect(loadProjectSnapshot(cwd)?.wordIndex).toBeDefined();
+		expect(getSnapshotBodyReadCountForTests()).toBe(2);
+	});
+});

--- a/tests/clients/mcp-word-index-eviction.test.ts
+++ b/tests/clients/mcp-word-index-eviction.test.ts
@@ -5,11 +5,12 @@ import {
 	_resetWarmWordIndexCacheForTests,
 	acquireWarmWordIndex,
 } from "../../clients/mcp/analyze.js";
+import { symbolSearch } from "../../clients/lens-engine.js";
 import {
 	PROJECT_SNAPSHOT_VERSION,
+	_projectSnapshotParseCacheRetainsWordIndexForTests,
 	_resetProjectSnapshotParseCacheForTests,
 	getSnapshotBodyReadCountForTests,
-	loadProjectSnapshot,
 	resetSnapshotBodyReadCountForTests,
 	saveProjectSnapshot,
 } from "../../clients/project-snapshot.js";
@@ -142,12 +143,26 @@ describe("MCP warm word-index lifecycle (#1370)", () => {
 		});
 	});
 
-	it("does not retain serialized postings in authoritative or parse caches", () => {
+	it("re-reads the full body once per warm-index eviction cycle and serves metadata from the stripped cache", async () => {
 		const cwd = path.join(process.env.PILENS_DATA_DIR!, "snapshot-project");
 		persistIndex(cwd, "snapshotSymbol");
+		// Model a reader process that did not perform the write/promotion itself.
+		_resetProjectSnapshotParseCacheForTests();
 		resetSnapshotBodyReadCountForTests();
-		expect(loadProjectSnapshot(cwd)?.wordIndex).toBeDefined();
-		expect(loadProjectSnapshot(cwd)?.wordIndex).toBeDefined();
+
+		expect((await symbolSearch("snapshot symbol", cwd)).results).toHaveLength(1);
+		// acquireWarmWordIndex performs the sole full-body read; symbolSearch's
+		// metadata load shares the postings-stripped cached body.
+		expect(getSnapshotBodyReadCountForTests()).toBe(1);
+		expect(_projectSnapshotParseCacheRetainsWordIndexForTests()).toBe(false);
+
+		expect((await symbolSearch("snapshot symbol", cwd)).results).toHaveLength(1);
+		expect(getSnapshotBodyReadCountForTests()).toBe(1);
+
+		await vi.advanceTimersByTimeAsync(20);
+		expect(_getWarmWordIndexCacheStateForTests().size).toBe(0);
+		expect((await symbolSearch("snapshot symbol", cwd)).results).toHaveLength(1);
 		expect(getSnapshotBodyReadCountForTests()).toBe(2);
+		expect(_projectSnapshotParseCacheRetainsWordIndexForTests()).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

- bound MCP `warmWordIndexes` to 8 roots by default (`PI_LENS_WORD_INDEX_MAX_WARM_ROOTS`) with least-recently-used eviction
- idle-evict each root after 20 minutes by default (`PI_LENS_WORD_INDEX_IDLE_EVICT_MS`), with generation-owned unref'd timers and transparent disk deserialize on reuse
- lease every query/update use so idle and LRU eviction cannot retire an in-flight index; every removal/reset clears timer ownership
- log normal lifecycle evictions to the word-index NDJSON sink, never the degradation ledger
- release serialized snapshot postings after persistence and keep word-index bodies out of the long-lived parse cache

## Snapshot verdict

A shared live reference is unsafe: `ProjectSnapshot.wordIndex` is the serialized array representation while the warm `WordIndex` is mutable Map/PathKeyedMap state. The safe de-dup boundary is publication: the persist worker may retain serialized postings until promotion, then the authoritative entry is released. Word-index snapshot bodies are one-shot disk parses and are not retained in the parse cache, so later merge-writers rehydrate canonical serialized state without mutation coupling.

## State model / failure semantics

- acquire increments the root lease and refreshes generation/timer/LRU age
- idle callback evicts only when entry identity + timer generation still match and leases are zero; otherwise it restarts the idle window
- LRU skips leased entries and may temporarily exceed the cap until a lease releases
- release is idempotent and cannot re-arm a timer after reset/removal
- reset clears every owned timer before clearing the PathKeyedMap
- next acquisition after eviction performs a real snapshot deserialize

## Blast radius

`module_report` was unavailable in this session. The fallback structural sweep covered every warm-cache get/set/delete/clear and its two consumers: MCP per-edit updates and `symbolSearch`. Snapshot load/save dependents include runtime session hydration, reverse-deps, project reports, tool policy, and word-index persistence; targeted snapshot and word-index suites cover their shared persistence seam.

## Verification

Required order on the final tree:

1. `npm run build` — pass
2. targeted word-index + analyze + snapshot Vitest run — 19 passed, 1 skipped files; 146 passed, 1 skipped tests
3. `npm run lint` — pass
4. changelog added

Mutation proof: temporarily removing the `entry.leases > 0` guard made the suspended-query regression fail (`cache size 0`, expected `1`). Restoring it returns the targeted run to green.

Closes #1370. Refs #1332. Refs #1344.