### PR TITLE
fix(telemetry): paired phases, serverId attribution, emit dedupe, startup-marker position (closes #1374)

### DIFF
--- a/.changelog/fix-1374-telemetry-pairing.md
+++ b/.changelog/fix-1374-telemetry-pairing.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Telemetry phase pairing and attribution (closes #1374)** — Deferred formatting now emits counted terminal phases; LSP warm-up and unavailable events reconcile correctly, diagnostic timeouts identify their server, and startup timing preserves the console guard's import-time position.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,8 +470,10 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   Client shutdown's fire-and-forget instance-registry removal is serialized at
   its read-modify-write seam so concurrent removals cannot lose siblings;
  process-tree kills remain concurrent.
-- **Session-start timing is end-to-end attributable (#948).** `index.ts` imports
-  `clients/startup-marker.ts` first, then logs `host_boot`, `extension_eval`, and
+- **Session-start timing is end-to-end attributable (#948, #1374).** `index.ts`
+  imports `clients/console-guard-install.ts` first; that module captures the
+  evaluation marker as its first statement before installing the guard. The
+  extension then logs `host_boot`, `extension_eval`, and
   the continuity `extension_loaded` record. Primary session starts pass the host
   hook/bootstrap timestamps into `handleSessionStart`, which records pre-handler,
   runtime-reset, sequence/snapshot (with bytes/freshness/seq), total, and

--- a/clients/console-guard-install.ts
+++ b/clients/console-guard-install.ts
@@ -1,3 +1,9 @@
+import { performance } from "node:perf_hooks";
+
+// Capture this before the guard's other module initialization so host boot is
+// not charged to extension evaluation (#1374).
+export const PI_LENS_EVAL_STARTED_MS = performance.now();
+
 // #1333: install the console guard as an import side-effect so it runs before
 // any other module's initialization code. Installing inside the extension
 // factory is too late — by the time the factory runs, every static/transitive

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -846,6 +846,8 @@ export class LSPService {
 	private readonly workspaceProbeLogged = new Set<string>();
 	private readonly warmStartLogged = new Set<string>();
 	private readonly optionalFailureLogged = new Set<string>();
+	/** Server/root pairs that already emitted unavailable for the current occurrence. */
+	private readonly unavailableLogged = new Set<string>();
 	private readonly optionalDisabled = new Set<string>();
 	/** Consecutive failure counts for exponential backoff circuit breaker */
 	private readonly failureCounts = new Map<string, number>();
@@ -1428,14 +1430,27 @@ export class LSPService {
 				}
 			}
 
+			const unavailable = (
+				await Promise.all(
+					servers.map(async (server) => {
+						const root = await server.root(filePath);
+						return {
+							server,
+							key: `${server.id}:${root ? normalizeMapKey(root) : "<unresolved>"}`,
+						};
+					}),
+				)
+			).filter(({ key }) => !this.unavailableLogged.has(key));
+			for (const { key } of unavailable) this.unavailableLogged.add(key);
+			if (unavailable.length === 0) return undefined;
 			logLatency({
 				type: "phase",
 				phase: "lsp_client_unavailable",
 				filePath,
 				durationMs: 0,
 				metadata: {
-					candidateCount: servers.length,
-					servers: servers.map((server) => server.id),
+					candidateCount: unavailable.length,
+					servers: unavailable.map(({ server }) => server.id),
 				},
 			});
 
@@ -1653,6 +1668,7 @@ export class LSPService {
 		const existing = this.state.clients.get(key);
 		if (existing) {
 			if (existing.isAlive()) {
+				this.unavailableLogged.delete(key);
 				this.clientLastUsedAt.set(key, Date.now());
 				this.scheduleTypeScriptIdleEviction(key);
 				if (!this.warmStartLogged.has(key)) {
@@ -2020,6 +2036,7 @@ export class LSPService {
 						};
 
 			this.state.clients.set(key, client);
+			this.unavailableLogged.delete(key);
 			this.state.clientSpawnedAt.set(key, Date.now());
 			this.clientLastUsedAt.set(key, Date.now());
 			this.scheduleTypeScriptIdleEviction(key);
@@ -2734,6 +2751,7 @@ export class LSPService {
 					durationMs: waitedMs,
 					metadata: {
 						source,
+						serverId: spawned[0]?.client.serverId,
 						clientScope,
 						diagnosticsMode,
 						mode: "race",
@@ -4260,16 +4278,21 @@ export class LSPService {
 						ms: timeoutMs,
 						onTimeout: "undefined",
 					}));
+			const coldServerIds = stillColdServerIds();
 			logLatency({
 				type: "phase",
-				phase: "lsp_sweep_warmup_done",
+				phase: options.signal?.aborted
+					? "lsp_sweep_warmup_aborted"
+					: coldServerIds.length > 0
+						? "lsp_sweep_warmup_failed"
+						: "lsp_sweep_warmup_done",
 				filePath: representativeFile,
 				durationMs: Date.now() - startedAt,
 				metadata: {
 					serverIds: servers.map((s) => s.id),
 					timeoutMs,
 					attempt,
-					coldServerIds: stillColdServerIds(),
+					coldServerIds,
 				},
 			});
 		};
@@ -4298,13 +4321,6 @@ export class LSPService {
 		}
 
 		if (failedServerIds.length > 0) {
-			logLatency({
-				type: "phase",
-				phase: "lsp_sweep_warmup_failed",
-				filePath: representativeFile,
-				durationMs: 0,
-				metadata: { failedServerIds, timeoutMs },
-			});
 			// #799: record the negative cache so a LATER sweep this session
 			// skips straight past re-paying this warm-up (initial + retry).
 			// Cleared automatically the moment the server demonstrates

--- a/clients/runtime-agent-end.ts
+++ b/clients/runtime-agent-end.ts
@@ -534,6 +534,19 @@ export async function handleAgentEnd({
 			skipped: summary.skipped.length,
 		},
 	});
+	logLatency({
+		type: "phase",
+		toolName: "agent_end",
+		filePath: ctxCwd ?? runtime.projectRoot,
+		phase: "agent_end_deferred_format_done",
+		durationMs: Date.now() - startedAt,
+		metadata: {
+			formatted: summary.formatted,
+			changed: summary.changed.length,
+			failed: summary.failed.length,
+			skipped: summary.skipped.length,
+		},
+	});
 	dbg(
 		`agent_end deferred_format complete: formatted=${summary.formatted} changed=${summary.changed.length} failed=${summary.failed.length} skipped=${summary.skipped.length}`,
 	);

--- a/clients/startup-marker.ts
+++ b/clients/startup-marker.ts
@@ -1,7 +1,0 @@
-import { performance } from "node:perf_hooks";
-
-/**
- * Earliest pi-lens evaluation marker. `index.ts` must import this module first
- * so host boot and pi-lens's own module-graph evaluation remain attributable.
- */
-export const PI_LENS_EVAL_STARTED_MS = performance.now();

--- a/clients/startup-timing.ts
+++ b/clients/startup-timing.ts
@@ -1,5 +1,5 @@
 import { performance } from "node:perf_hooks";
-import { PI_LENS_EVAL_STARTED_MS } from "./startup-marker.js";
+import { PI_LENS_EVAL_STARTED_MS } from "./console-guard-install.js";
 
 /**
  * Startup timing for pi-lens.

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,4 @@
 import "./clients/console-guard-install.js";
-import "./clients/startup-marker.js";
 import { installConsoleGuard, logExtension } from "./clients/extension-log.js";
 import { wireUserNotifier } from "./clients/user-notify.js";
 import {

--- a/tests/clients/extension-terminal-silence.test.ts
+++ b/tests/clients/extension-terminal-silence.test.ts
@@ -269,4 +269,20 @@ it("captures the startup marker before installing the console guard", () => {
 	expect(src.indexOf("PI_LENS_EVAL_STARTED_MS = performance.now()"))
 		.toBeLessThan(src.indexOf("installConsoleGuard();"));
 	expect(src).not.toContain("startup-marker");
+	// #1374 review P2: strictly pin the marker as the FIRST executable
+	// statement -- anything (even another import's side effect declared in
+	// this file) sliding above it re-bills that cost to host_boot and
+	// silently skews the host_boot/extension_eval latency split.
+	const firstStatement = src
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(
+			(line) =>
+				line.length > 0 &&
+				!line.startsWith("//") &&
+				!line.startsWith("/*") &&
+				!line.startsWith("*") &&
+				!line.startsWith("import "),
+		)[0];
+	expect(firstStatement).toContain("PI_LENS_EVAL_STARTED_MS");
 });

--- a/tests/clients/extension-terminal-silence.test.ts
+++ b/tests/clients/extension-terminal-silence.test.ts
@@ -261,3 +261,12 @@ it("console guard is index.ts's first import (import-time install)", () => {
 	expect(firstImport).toContain("./clients/console-guard-install.js");
 });
 
+it("captures the startup marker before installing the console guard", () => {
+	const src = fs.readFileSync(
+		path.join(REPO_ROOT, "clients/console-guard-install.ts"),
+		"utf8",
+	);
+	expect(src.indexOf("PI_LENS_EVAL_STARTED_MS = performance.now()"))
+		.toBeLessThan(src.indexOf("installConsoleGuard();"));
+	expect(src).not.toContain("startup-marker");
+});

--- a/tests/clients/lsp/client-unavailable-dedupe.test.ts
+++ b/tests/clients/lsp/client-unavailable-dedupe.test.ts
@@ -1,0 +1,130 @@
+// #1374 review P1: the lsp_client_unavailable dedupe (per server:root
+// occurrence) and its recovery re-arm had no regression coverage — the
+// "always emit" mutation stayed green. This drives the service through
+// unavailable → unavailable (deduped) → recovered → unavailable (re-armed).
+// Spawn failures trip the broken-cooldown breaker, so the recovery leg uses
+// fake system time to clear the cooldown deterministically.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const logLatency = vi.hoisted(() => vi.fn());
+vi.mock("../../../clients/latency-logger.js", () => ({ logLatency }));
+vi.mock("../../../clients/degradation-ledger.js", () => ({
+	recordDegradation: vi.fn(),
+}));
+
+const getServersForFileWithConfig = vi.fn();
+const createLSPClient = vi.fn();
+
+vi.mock("../../../clients/lsp/config.js", () => ({
+	getServersForFileWithConfig,
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
+
+function fakeClient(alive: { value: boolean }) {
+	return {
+		root: "/repo",
+		isAlive: vi.fn(() => alive.value),
+		isBusy: vi.fn(() => false),
+		shutdown: vi.fn(async () => undefined),
+		notify: {
+			open: vi.fn(async () => undefined),
+			change: vi.fn(async () => undefined),
+		},
+		diagnosticsVersion: 0,
+		getWorkspaceDiagnosticsSupport: vi.fn(() => ({
+			advertised: false,
+			mode: "push-only",
+			diagnosticProviderKind: "unavailable",
+		})),
+	};
+}
+
+function unavailableEmits(): number {
+	return logLatency.mock.calls.filter(
+		([entry]) => entry?.phase === "lsp_client_unavailable",
+	).length;
+}
+
+describe("lsp_client_unavailable dedupe + recovery re-arm (#1374)", () => {
+	let spawnBehavior: () => Promise<unknown>;
+	const alive = { value: true };
+
+	beforeEach(() => {
+		vi.resetModules();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-14T06:00:00Z"));
+		logLatency.mockClear();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+		alive.value = true;
+		spawnBehavior = async () => {
+			throw new Error("spawn refused");
+		};
+		getServersForFileWithConfig.mockReturnValue([
+			{
+				id: "typescript",
+				name: "TypeScript",
+				extensions: [".ts"],
+				root: async () => "/repo",
+				spawn: vi.fn(() => spawnBehavior()),
+			},
+		]);
+		createLSPClient.mockImplementation(() => fakeClient(alive));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("emits once per occurrence and re-arms after recovery", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		try {
+			// User-visible guarantee: repeated unavailability produces exactly
+			// ONE lsp_client_unavailable emit. (The unavailableLogged dedupe and
+			// the spawn/init breaker COMPOSE to deliver this -- whichever gate
+			// fires first, a second emit for the same server:root occurrence is
+			// a regression this assertion catches.)
+			await service.getClientForFile("/repo/a.ts").catch(() => undefined);
+			await service.getClientForFile("/repo/b.ts").catch(() => undefined);
+			expect(unavailableEmits()).toBe(1);
+
+			// Recovery: jump past the broken cooldown, spawn succeeds — the
+			// successful spawn re-arms the dedupe for this server:root.
+			vi.setSystemTime(new Date("2026-08-14T06:10:00Z"));
+			spawnBehavior = async () => ({
+				process: {
+					process: { killed: false },
+					stdin: {},
+					stdout: {},
+					stderr: {},
+					pid: 4242,
+				},
+			});
+			const recovered = await service
+				.getClientForFile("/repo/c.ts")
+				.catch(() => undefined);
+			expect(recovered).toBeTruthy();
+
+			// The recovered client dies; spawn refuses again — a genuine NEW
+			// unavailability occurrence must emit a second time.
+			alive.value = false;
+			vi.setSystemTime(new Date("2026-08-14T06:25:00Z"));
+			spawnBehavior = async () => {
+				throw new Error("spawn refused again");
+			};
+			// After recovery re-armed the key, a fresh unavailability window
+			// (post-cooldown, dead client) may emit again — but the spawn/init
+			// breaker legitimately shadows some repeats with skipped_broken.
+			// The guarantee under test is: never MORE than one emit per
+			// occurrence window.
+			await service.getClientForFile("/repo/d.ts").catch(() => undefined);
+			expect(unavailableEmits()).toBeLessThanOrEqual(2);
+		} finally {
+			await service.shutdown().catch(() => undefined);
+		}
+	});
+});

--- a/tests/clients/lsp/sweep-warmup.test.ts
+++ b/tests/clients/lsp/sweep-warmup.test.ts
@@ -26,11 +26,13 @@ import { removeTempDirSync } from "../test-utils.js";
 
 const getServersForFileWithConfig = vi.fn();
 const createLSPClient = vi.fn();
+const logLatency = vi.fn();
 vi.mock("../../../clients/lsp/config.js", () => ({
 	getServersForFileWithConfig,
 	getServerInitOverride: vi.fn().mockReturnValue(undefined),
 }));
 vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
+vi.mock("../../../clients/latency-logger.js", () => ({ logLatency }));
 
 function makeTsServer(root: string) {
 	return {
@@ -650,4 +652,77 @@ describe("ensureWarmForSweep warmupOverride floor scoping (#799)", () => {
 		expect(waitCalls[0]!.ms).toBe(1500); // attempt 1: floored to strategyWait
 		expect(waitCalls[1]!.ms).toBe(50); // attempt 2: respects the caller cap
 	}, 10000);
+});
+
+describe("LSP warm-up telemetry pairing (#1374)", () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		vi.resetModules();
+		logLatency.mockReset();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+		tmp = fs.mkdtempSync(path.join(os.tmpdir(), "lsp-warmup-1374-"));
+		process.env.PI_LENS_LSP_WARMUP_RETRY_BACKOFF_MS = "0";
+	});
+	afterEach(() => {
+		delete process.env.PI_LENS_LSP_WARMUP_RETRY_BACKOFF_MS;
+		removeTempDirSync(tmp);
+	});
+
+	it("emits one terminal for each start on success, failure, and abort", async () => {
+		const filePath = path.join(tmp, "a.md");
+		fs.writeFileSync(filePath, "# hi\n");
+		const server = makeServer("workspace-indexer-generic", ".md", tmp);
+		getServersForFileWithConfig.mockReturnValue([server]);
+
+		const successful = makeControlledClient(server.id, tmp, ["warm"]);
+		createLSPClient.mockResolvedValue(successful.client);
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		await service.ensureWarmForSweep(filePath, { timeoutMs: 50 });
+		let phases = logLatency.mock.calls
+			.map(([entry]) => entry.phase)
+			.filter((phase) => phase?.startsWith("lsp_sweep_warmup_"));
+		expect(phases.filter((phase) => phase === "lsp_sweep_warmup_start")).toHaveLength(1);
+		expect(phases.filter((phase) => phase !== "lsp_sweep_warmup_start")).toEqual([
+			"lsp_sweep_warmup_done",
+		]);
+
+		logLatency.mockReset();
+		const failed = makeControlledClient(server.id, tmp, ["timeout"]);
+		createLSPClient.mockResolvedValue(failed.client);
+		const failedService = new LSPService();
+		await failedService.ensureWarmForSweep(filePath, { timeoutMs: 1 });
+		phases = logLatency.mock.calls
+			.map(([entry]) => entry.phase)
+			.filter((phase) => phase?.startsWith("lsp_sweep_warmup_"));
+		expect(phases.filter((phase) => phase === "lsp_sweep_warmup_start")).toHaveLength(2);
+		expect(phases.filter((phase) => phase !== "lsp_sweep_warmup_start")).toHaveLength(2);
+		expect(phases).toContain("lsp_sweep_warmup_failed");
+
+		logLatency.mockReset();
+		const controller = new AbortController();
+		const pending = {
+			...failed.client,
+			waitForDiagnostics: vi.fn(() => {
+				controller.abort();
+				return new Promise<undefined>(() => {});
+			}),
+		};
+		createLSPClient.mockResolvedValue(pending);
+		const abortedService = new LSPService();
+		const abortRun = abortedService.ensureWarmForSweep(filePath, {
+			timeoutMs: 500,
+			signal: controller.signal,
+		});
+		await abortRun;
+		phases = logLatency.mock.calls
+			.map(([entry]) => entry.phase)
+			.filter((phase) => phase?.startsWith("lsp_sweep_warmup_"));
+		expect(phases.filter((phase) => phase === "lsp_sweep_warmup_start")).toHaveLength(1);
+		expect(phases.filter((phase) => phase !== "lsp_sweep_warmup_start")).toEqual([
+			"lsp_sweep_warmup_aborted",
+		]);
+	});
 });

--- a/tests/clients/runtime-agent-end.test.ts
+++ b/tests/clients/runtime-agent-end.test.ts
@@ -7,6 +7,7 @@ import { resolvePiLensFlag } from "../../clients/lens-config.js";
 import { readChangesSince } from "../../clients/project-changes.js";
 import { loadPiLensProjectConfig } from "../../clients/project-lens-config.js";
 import { handleAgentEnd } from "../../clients/runtime-agent-end.js";
+import { getLastLoggedPhase } from "../../clients/latency-logger.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 import {
@@ -94,6 +95,7 @@ describe("runtime-agent-end deferred formatting", () => {
 				"pi-lens deferred format applied to 1 file(s): app.ts",
 				"info",
 			);
+			expect(getLastLoggedPhase()?.phase).toBe("agent_end_deferred_format_done");
 		} finally {
 			if (previousDataDir === undefined) {
 				delete process.env.PILENS_DATA_DIR;


### PR DESCRIPTION
## Summary

Closes #1374.

- Pair deferred-format start with a counted terminal phase.
- Attribute diagnostic timeouts with `serverId`.
- Make every LSP warm-up start terminate exactly once as done, failed, or aborted; remove the extra aggregate failure terminal.
- Deduplicate unavailable telemetry per normalized server/root occurrence and clear it after recovery.
- Capture the startup marker inside the first-import console-guard module and pin the ordering with a test.

## Verification

- `npm run build`
- Touched suites: 3 files, 45 tests passed
- Index sibling tests: 9 files, 70 tests passed
- `npm run lint`