### PR TITLE
fix(agent-behavior): normalize getEditCount reads — raw-path-key class sweep (closes #1369)

### DIFF
--- a/.changelog/fix-1369-editcount-key.md
+++ b/.changelog/fix-1369-editcount-key.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Edit counts now match normalized file paths (closes #1369)** — `AgentBehaviorClient.getEditCount` now uses the same path normalization as edit recording, so mixed-separator and case-variant lookups return the recorded count.

--- a/clients/agent-behavior-client.ts
+++ b/clients/agent-behavior-client.ts
@@ -159,7 +159,7 @@ export class AgentBehaviorClient {
 	 * Get edit count for a file in this session.
 	 */
 	getEditCount(filePath: string): number {
-		return this.fileEditCount.get(filePath) ?? 0;
+		return this.fileEditCount.get(normalizeMapKey(filePath)) ?? 0;
 	}
 
 	/**

--- a/tests/clients/agent-behavior-client.test.ts
+++ b/tests/clients/agent-behavior-client.test.ts
@@ -106,3 +106,13 @@ describe("AgentBehaviorClient reset", () => {
 		);
 	});
 });
+
+describe("AgentBehaviorClient edit counts", () => {
+	it("matches mixed-separator and case-variant paths", () => {
+		const client = new AgentBehaviorClient();
+
+		client.recordToolCall("edit", "C:\\Repo\\SRC\\File.ts");
+
+		expect(client.getEditCount("c:/repo/src/file.ts")).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary
- normalize getEditCount reads with normalizeMapKey
- add mixed-separator/case-variant regression coverage
- complete the same-file path-key class sweep; no other mismatches found

Closes #1369.

## Verification
- Pre-fix regression: red (1 failed, 7 passed)
- Build: passed
- Agent behavior + sibling runtime-tool suites: 4 files, 38 tests passed
- Lint: passed
- Fresh branch merge-base: c22a5b29818680b83cc3409c541bb987545933e9