### PR TITLE
fix(widget): re-assert mount when the host UI is replaced; log silent mount failures (closes #1381)

### DIFF
--- a/.changelog/fix-1381-widget-remount.md
+++ b/.changelog/fix-1381-widget-remount.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Re-assert widget mounts after host UI replacement (closes #1381)** — The diagnostics widget remounts on the live UI at turn start when needed, while preserving mode and user visibility gates; unsupported widget hosts now emit a log-once diagnostic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,13 @@ clients/
   mcp/                     host-neutral facades: analyze, session, review, ipc, host-shim
   runtime-session.ts      session_start handler — snapshot hydrate, tool preinstall, background scans, LSP warm
   project-snapshot.ts     Versioned seq-stamped project snapshot cache
+
+The diagnostics widget records the exact `ctx.ui` identity only after a
+successful `setWidget` mount. A visible widget re-asserts that mount on
+`turn_start` when the host replaces its UI object; this remains gated by the
+live run mode and `lensWidgetVisible`, so a user toggle-off or headless mode is
+never undone. Missing `ui.setWidget` is a log-once-per-extension-session
+diagnostic rather than a silent mount failure. (#1381)
   project-changes.ts      Append-only project/file sequence change log
   reverse-deps.ts         Snapshot-backed reverse dependency index/query helpers
   word-index.ts           Identifier inverted index + BM25 ranking (#162) — built in the session scan, persisted with per-file mtimes in the snapshot; consumed by BOTH the pi symbol_search tool and the MCP pilens_symbol_search mirror (#348 phase 1); session warmup preflights the bounded current file set and incrementally refreshes only sparse stale/new/deleted documents. A stale set whose ESTIMATED WORK exceeds one full rebuild (posting-scan + re-read cost vs totalTokens + corpus re-read cost), a dense stale set (≥32 documents AND >30% of the corpus), >30% file-set churn, or legacy metadata selects a separately-built full replacement BEFORE mutating the old index (#1197): repeated per-document posting-array filters become effectively quadratic (2,061 all-stale docs took 216.8s vs a 7.5s full build), and because per-document cost GROWS with the corpus no density ratio or absolute count is a bound — 800 docs / 239 stale at 29.875% measured 90.6s with a 39.6s loop block. Every bulk path (async build + both refresh loops) yields on an ~8ms monotonic budget OR'd with its item checkpoint — never count-only, which bounds nothing when per-item cost is unbounded — including within large documents and after any line ≥4,096 chars. Synchronous `buildWordIndex` is the small/test/reference primitive only. Superseded builds never publish a partial index and never escape as an exception into a caller's warmup pass.

--- a/index.ts
+++ b/index.ts
@@ -672,6 +672,8 @@ export default function (pi: ExtensionAPI) {
 	// from the registry's PI_LENS_NO_CONTEXT_INJECTION env binding (#166).
 	let contextInjectionEnabled = !getLensFlag("no-lens-context");
 	let lensWidgetVisible = globalConfig?.widget?.visible !== false;
+	let mountedLensWidgetUi: LensWidgetUi | undefined;
+	let widgetMountFailureLogged = false;
 	// #190 Phase 2: snapshot of the source session's diagnostics, captured at
 	// `session_before_fork` and adopted by the forked session at the subsequent
 	// `session_start` (reason="fork"). In-memory hand-off (same process) — avoids
@@ -714,7 +716,17 @@ export default function (pi: ExtensionAPI) {
 			dbg(`widget mount ${modeSuppressionNote(mode)}`);
 			return false;
 		}
-		if (typeof ui?.setWidget !== "function") return false;
+		if (typeof ui?.setWidget !== "function") {
+			if (!widgetMountFailureLogged) {
+				widgetMountFailureLogged = true;
+				logExtension({
+					subsystem: "widget",
+					level: "debug",
+					message: "widget mount unavailable: host ui.setWidget is missing",
+				});
+			}
+			return false;
+		}
 		const setWidget = ui.setWidget as LensWidgetSetWidget;
 		setWidget(
 			"pi-lens",
@@ -737,6 +749,7 @@ export default function (pi: ExtensionAPI) {
 			},
 			{ placement: "belowEditor" },
 		);
+		mountedLensWidgetUi = ui;
 		return true;
 	}
 
@@ -746,6 +759,7 @@ export default function (pi: ExtensionAPI) {
 		if (typeof ui?.setWidget !== "function") return false;
 		const setWidget = ui.setWidget as LensWidgetSetWidget;
 		setWidget("pi-lens", undefined);
+		mountedLensWidgetUi = undefined;
 		return true;
 	}
 
@@ -1891,6 +1905,13 @@ export default function (pi: ExtensionAPI) {
 		// Trust can change without a new session. Re-adopt before this turn can
 		// reach any install-capable or LSP-spawn path.
 		adoptProjectTrustFromPorts(hostPorts);
+		if (
+			lensWidgetVisible &&
+			ctx?.ui &&
+			(mountedLensWidgetUi === undefined || mountedLensWidgetUi !== ctx.ui)
+		) {
+			mountLensWidget(ctx.ui, readExtensionMode(ctx));
+		}
 		runtime.beginTurn();
 		clearLastAnalyzedStateCache();
 

--- a/tests/index-mode-awareness.test.ts
+++ b/tests/index-mode-awareness.test.ts
@@ -10,6 +10,12 @@ import {
 	resetDegradationLedger,
 } from "../clients/degradation-ledger.js";
 
+const { logExtensionSpy } = vi.hoisted(() => ({ logExtensionSpy: vi.fn() }));
+vi.mock("../clients/extension-log.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../clients/extension-log.js")>()),
+	logExtension: logExtensionSpy,
+}));
+
 // Same two heavy seams tests/index-wiring.test.ts stubs, so firing
 // session_start stays a fast deterministic wiring check.
 vi.mock("../clients/bootstrap.js", () => ({
@@ -119,6 +125,57 @@ describe("widget mounting is mode-derived (#1334 S2)", () => {
 		const ctx = await toggleTwice(null);
 
 		expect(mounts(ctx)).toHaveLength(1);
+	});
+
+	it("re-mounts on the live UI when the host replaces it (#1381)", async () => {
+		const pi = createPiMock();
+		extension(pi.asExtensionAPI());
+		const ctxA = makeCtx({ cwd: tmpProject(), mode: "tui" });
+		const ctxB = makeCtx({ cwd: ctxA.cwd, mode: "tui" });
+		const setWidgetA = vi.spyOn(ctxA.ui, "setWidget");
+		const setWidgetB = vi.spyOn(ctxB.ui, "setWidget");
+
+		await pi.runCommand("lens-widget-toggle", "", ctxA);
+		await pi.runCommand("lens-widget-toggle", "", ctxA);
+		await pi.emit("turn_start", {}, ctxB);
+
+		expect(setWidgetA.mock.calls.filter(([, content]) => typeof content === "function")).toHaveLength(1);
+		expect(setWidgetB.mock.calls.filter(([, content]) => typeof content === "function")).toHaveLength(1);
+	});
+
+	it("does not resurrect a widget toggled off before a UI replacement (#1381)", async () => {
+		const pi = createPiMock();
+		extension(pi.asExtensionAPI());
+		const ctxA = makeCtx({ cwd: tmpProject(), mode: "tui" });
+		const ctxB = makeCtx({ cwd: ctxA.cwd, mode: "tui" });
+		const setWidgetB = vi.spyOn(ctxB.ui, "setWidget");
+
+		await pi.runCommand("lens-widget-toggle", "", ctxA);
+		await pi.runCommand("lens-widget-toggle", "", ctxA);
+		await pi.runCommand("lens-widget-toggle", "", ctxA);
+		await pi.emit("turn_start", {}, ctxB);
+
+		expect(setWidgetB).not.toHaveBeenCalled();
+	});
+
+	it("logs a missing setWidget host once and never throws (#1381)", async () => {
+		const pi = createPiMock();
+		extension(pi.asExtensionAPI());
+		logExtensionSpy.mockClear();
+		const ctx = makeCtx({ cwd: tmpProject(), mode: "tui" });
+		delete (ctx.ui as { setWidget?: unknown }).setWidget;
+
+		await expect(pi.runCommand("lens-widget-toggle", "", ctx)).resolves.toBeUndefined();
+		await expect(pi.runCommand("lens-widget-toggle", "", ctx)).resolves.toBeUndefined();
+		await expect(pi.emit("turn_start", {}, ctx)).resolves.toBeUndefined();
+
+		expect(
+			logExtensionSpy.mock.calls.filter(
+				([entry]) =>
+					entry.message ===
+					"widget mount unavailable: host ui.setWidget is missing",
+			),
+		).toHaveLength(1);
 	});
 });
 


### PR DESCRIPTION
## Summary

Closes #1381.

- Records the UI object identity only after a successful widget mount.
- Re-asserts the idempotent mount on 	urn_start when the live host UI changes.
- Preserves lensWidgetVisible and run-mode gating, so toggled-off/headless sessions stay off.
- Logs missing ui.setWidget once per extension session.

## Verification

- 
pm run build
- 
px vitest run tests/index-wiring.test.ts tests/index-integration.test.ts tests/index-mode-awareness.test.ts — 52 passed
- 
pm run lint
- 
pm run changelog:check — 30 entries validated
- Mutation check: removing the UI identity comparison made the replacement regression fail (13 passed, 1 failed).