### PR TITLE
fix(session): re-wire ctx-derived plumbing on every session_start; occurrence-scoped stale suppression (closes #1383)

### DIFF
--- a/.changelog/fix-1383-bus-rewire.md
+++ b/.changelog/fix-1383-bus-rewire.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Widget and inter-extension bus updates recover after session replacement (closes #1383)** — every `session_start`, including the #473 guarded in-process subagent path, now reclaims activation-scoped bus, notifier, and widget-render wiring before returning. Stale bus failures are logged and ledgered once per failure occurrence, with a successful publish re-arming observability for a later channel death.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,12 @@ The captured-at-subscribe / used-after-replace shape also applies to pi's
 `events` API: `pi.events.emit` is a session-bound wrapper whose runtime is
 invalidated on replacement. Long-lived publishers must retain a getter and
 resolve the emitter at delivery time; deferred callbacks must resolve inside
-the callback, never before scheduling. This is the pattern established by
-#1128 for the bus and lens-event publishers.
+the callback, never before scheduling. The getter itself is activation-scoped:
+module-singleton bus/notifier/widget-render plumbing must be re-wired from the
+current factory on every `session_start`, BEFORE the #473 concurrent-secondary
+guard can return, because a sibling activation can overwrite the singleton and
+later go stale. Emit-failure suppression is occurrence-scoped (success re-arms
+it), and a stale occurrence records one `bus-stale` degradation. (#1128, #1383)
 
 This is the payoff of the two disciplines above: a bounded checklist of defect *shapes* that each recurred ≥2× across the arc. Read it at task start; when your change matches a shape, treat the screen as an acceptance criterion (and the regression test the shape implies). Each entry is **SHAPE → SCREEN (when you touch X, verify Y) → canonical example → detection**. Where a shape has a fuller treatment above, this cross-references rather than restates it.
 

--- a/clients/bus-publish.ts
+++ b/clients/bus-publish.ts
@@ -20,7 +20,12 @@
 import { logBusEvent } from "./bus-events-logger.js";
 import { normalizeFilePath } from "./path-utils.js";
 import { appendRecentTouches } from "./recent-touches.js";
-import { createLiveBusEmitter, type BusEmitFn, type BusEmitGetter } from "./live-bus-emitter.js";
+import {
+	createLiveBusEmitter,
+	recordStaleBusFailure,
+	type BusEmitFn,
+	type BusEmitGetter,
+} from "./live-bus-emitter.js";
 
 export const BUS_FILES_TOUCHED_EVENT = "pilens:files:touched";
 export const BUS_FILES_TOUCHED_VERSION = 1;
@@ -198,6 +203,7 @@ export function publishFilesTouched(args: PublishFilesTouchedArgs): void {
 			}));
 		}
 		busEmit(BUS_FILES_TOUCHED_EVENT, payload);
+		hasLoggedFailure = false;
 		logBusEvent({
 			event: BUS_FILES_TOUCHED_EVENT,
 			outcome: "emitted",
@@ -215,6 +221,7 @@ export function publishFilesTouched(args: PublishFilesTouchedArgs): void {
 		});
 		if (!hasLoggedFailure) {
 			hasLoggedFailure = true;
+			recordStaleBusFailure(BUS_FILES_TOUCHED_EVENT, err);
 			args.dbg?.(
 				`bus-publish: pilens:files:touched emit failed (further failures suppressed): ${err}`,
 			);

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -6,7 +6,8 @@ export type DegradationKind =
 	| "ts-idle-eviction"
 	| "spawn-failure"
 	| "formatter-skip"
-	| "grammar-blocked";
+	| "grammar-blocked"
+	| "bus-stale";
 
 export interface DegradationRecord {
 	kind: DegradationKind;

--- a/clients/diagnostics-publish.ts
+++ b/clients/diagnostics-publish.ts
@@ -61,7 +61,12 @@
  */
 import { logBusEvent } from "./bus-events-logger.js";
 import { normalizeFilePath } from "./path-utils.js";
-import { createLiveBusEmitter, type BusEmitFn, type BusEmitGetter } from "./live-bus-emitter.js";
+import {
+	createLiveBusEmitter,
+	recordStaleBusFailure,
+	type BusEmitFn,
+	type BusEmitGetter,
+} from "./live-bus-emitter.js";
 import { isBusPublishEnabled } from "./bus-publish.js";
 
 export const BUS_DIAGNOSTICS_EVENT = "pilens:diagnostics";
@@ -253,6 +258,7 @@ export function publishDiagnostics(args: PublishDiagnosticsArgs): void {
 			files: fileEntries,
 		};
 		busEmit(BUS_DIAGNOSTICS_EVENT, payload);
+		hasLoggedFailure = false;
 		logBusEvent({
 			event: BUS_DIAGNOSTICS_EVENT,
 			outcome: "emitted",
@@ -269,6 +275,7 @@ export function publishDiagnostics(args: PublishDiagnosticsArgs): void {
 		});
 		if (!hasLoggedFailure) {
 			hasLoggedFailure = true;
+			recordStaleBusFailure(BUS_DIAGNOSTICS_EVENT, err);
 			args.dbg?.(
 				`diagnostics-publish: pilens:diagnostics emit failed (further failures suppressed): ${err}`,
 			);

--- a/clients/disposition-publish.ts
+++ b/clients/disposition-publish.ts
@@ -24,7 +24,12 @@
 import { logBusEvent } from "./bus-events-logger.js";
 import { isBusPublishEnabled } from "./bus-publish.js";
 import { normalizeFilePath } from "./path-utils.js";
-import { createLiveBusEmitter, type BusEmitFn, type BusEmitGetter } from "./live-bus-emitter.js";
+import {
+	createLiveBusEmitter,
+	recordStaleBusFailure,
+	type BusEmitFn,
+	type BusEmitGetter,
+} from "./live-bus-emitter.js";
 
 export const BUS_DISPOSITION_EVENT = "pilens:diagnostic:disposition";
 export const BUS_DISPOSITION_VERSION = 1;
@@ -127,6 +132,7 @@ export function publishDisposition(args: PublishDispositionArgs): void {
 			reason: args.reason,
 		};
 		busEmit(BUS_DISPOSITION_EVENT, payload);
+		hasLoggedFailure = false;
 		logBusEvent({
 			event: BUS_DISPOSITION_EVENT,
 			outcome: "emitted",
@@ -141,6 +147,7 @@ export function publishDisposition(args: PublishDispositionArgs): void {
 		});
 		if (!hasLoggedFailure) {
 			hasLoggedFailure = true;
+			recordStaleBusFailure(BUS_DISPOSITION_EVENT, err);
 			args.dbg?.(
 				`disposition-publish: pilens:diagnostic:disposition emit failed (further failures suppressed): ${err}`,
 			);

--- a/clients/format-events-publish.ts
+++ b/clients/format-events-publish.ts
@@ -70,7 +70,12 @@
 import { logBusEvent } from "./bus-events-logger.js";
 import { isBusPublishEnabled } from "./bus-publish.js";
 import { normalizeFilePath } from "./path-utils.js";
-import { createLiveBusEmitter, type BusEmitFn, type BusEmitGetter } from "./live-bus-emitter.js";
+import {
+	createLiveBusEmitter,
+	recordStaleBusFailure,
+	type BusEmitFn,
+	type BusEmitGetter,
+} from "./live-bus-emitter.js";
 
 export const BUS_FORMAT_QUEUED_EVENT = "pilens:format:queued";
 export const BUS_FORMAT_QUEUED_VERSION = 1;
@@ -193,6 +198,7 @@ export function publishFormatQueued(args: PublishFormatQueuedArgs): void {
 			tool: args.tool,
 		};
 		busEmit(BUS_FORMAT_QUEUED_EVENT, payload);
+		hasLoggedQueuedFailure = false;
 		logBusEvent({
 			event: BUS_FORMAT_QUEUED_EVENT,
 			outcome: "emitted",
@@ -208,6 +214,7 @@ export function publishFormatQueued(args: PublishFormatQueuedArgs): void {
 		});
 		if (!hasLoggedQueuedFailure) {
 			hasLoggedQueuedFailure = true;
+			recordStaleBusFailure(BUS_FORMAT_QUEUED_EVENT, err);
 			args.dbg?.(
 				`format-events-publish: pilens:format:queued emit failed (further failures suppressed): ${err}`,
 			);
@@ -265,6 +272,7 @@ export function publishFormatStart(args: PublishFormatStartArgs): void {
 			fileCount: paths.length,
 		};
 		busEmit(BUS_FORMAT_START_EVENT, payload);
+		hasLoggedStartFailure = false;
 		logBusEvent({
 			event: BUS_FORMAT_START_EVENT,
 			outcome: "emitted",
@@ -280,6 +288,7 @@ export function publishFormatStart(args: PublishFormatStartArgs): void {
 		});
 		if (!hasLoggedStartFailure) {
 			hasLoggedStartFailure = true;
+			recordStaleBusFailure(BUS_FORMAT_START_EVENT, err);
 			args.dbg?.(
 				`format-events-publish: pilens:format:start emit failed (further failures suppressed): ${err}`,
 			);
@@ -342,6 +351,7 @@ export function publishAutofixStart(args: PublishAutofixStartArgs): void {
 			eligibleCount: args.eligibleCount,
 		};
 		busEmit(BUS_AUTOFIX_START_EVENT, payload);
+		hasLoggedAutofixStartFailure = false;
 		logBusEvent({
 			event: BUS_AUTOFIX_START_EVENT,
 			outcome: "emitted",
@@ -357,6 +367,7 @@ export function publishAutofixStart(args: PublishAutofixStartArgs): void {
 		});
 		if (!hasLoggedAutofixStartFailure) {
 			hasLoggedAutofixStartFailure = true;
+			recordStaleBusFailure(BUS_AUTOFIX_START_EVENT, err);
 			args.dbg?.(
 				`format-events-publish: pilens:autofix:start emit failed (further failures suppressed): ${err}`,
 			);

--- a/clients/live-bus-emitter.ts
+++ b/clients/live-bus-emitter.ts
@@ -1,3 +1,5 @@
+import { recordDegradation } from "./degradation-ledger.js";
+
 /** Resolve a pi event-bus emitter at delivery time, not subscription time. */
 export type BusEmitFn = (channel: string, data: unknown) => void;
 export type BusEmitGetter = () => BusEmitFn | undefined;
@@ -7,6 +9,15 @@ export interface LiveBusEmitter {
 	wireGetter(getter: BusEmitGetter | undefined): void;
 	get(): BusEmitFn | undefined;
 	reset(): void;
+}
+
+const STALE_CTX_MESSAGE = "This extension ctx is stale after session replacement";
+
+/** Ledger a dead activation once, at the publisher's occurrence-window guard. */
+export function recordStaleBusFailure(subject: string, error: unknown): void {
+	const reason = String(error);
+	if (!reason.includes(STALE_CTX_MESSAGE)) return;
+	recordDegradation({ kind: "bus-stale", subject, reason });
 }
 
 export function createLiveBusEmitter(): LiveBusEmitter {

--- a/index.ts
+++ b/index.ts
@@ -508,13 +508,21 @@ export default function (pi: ExtensionAPI) {
 	// never captured once — a session replacement invalidates the old ctx.ui.
 	// #1334 S2: the ports notifier owns mode suppression + live-ctx resolution
 	// (per-call, never captured -- the #338/#798 detached-callback rule).
-	wireUserNotifier(hostPorts);
-	initLensEventsGetter(() => ({ emit: hostPorts.emit.lens }));
-	const getLiveEmit = () => hostPorts.emit.bus;
-	wireBusEmitterGetter(getLiveEmit);
-	wireDiagnosticsBusEmitterGetter(getLiveEmit);
-	wireDispositionBusEmitterGetter(getLiveEmit);
-	wireFormatEventsBusEmitterGetter(getLiveEmit);
+	const refreshCtxDerivedPlumbing = (): void => {
+		// These targets are module singletons, while hostPorts is scoped to this
+		// extension activation. A sibling activation can overwrite them and then
+		// become stale; every session_start must reclaim them before #473 can
+		// return early for a concurrent in-process subagent. (#1383)
+		wireUserNotifier(hostPorts);
+		initLensEventsGetter(() => ({ emit: hostPorts.emit.lens }));
+		const getLiveEmit = () => hostPorts.emit.bus;
+		wireBusEmitterGetter(getLiveEmit);
+		wireDiagnosticsBusEmitterGetter(getLiveEmit);
+		wireDispositionBusEmitterGetter(getLiveEmit);
+		wireFormatEventsBusEmitterGetter(getLiveEmit);
+		setRenderCallback(() => hostPorts.render.invalidate());
+	};
+	refreshCtxDerivedPlumbing();
 	// #485: read-only bus subscriber — never publishes, so the #482 loop guard
 	// (ingest -> write -> publish) has no write side to trip here.
 	wireAgentNudgeSubscriber({
@@ -1459,6 +1467,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (event, ctx) => {
 		rememberEventCtx(ctx);
+		refreshCtxDerivedPlumbing();
 		const sessionStartFiredAt = Date.now();
 		try {
 			dbg("session_start fired");

--- a/tests/clients/bus-publish.test.ts
+++ b/tests/clients/bus-publish.test.ts
@@ -19,12 +19,17 @@ import {
 	wireBusEmitter,
 	wireBusEmitterGetter,
 } from "../../clients/bus-publish.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
 
 describe("bus-publish — pilens:files:touched (#482)", () => {
 	const originalEnv = process.env.PI_LENS_BUS_PUBLISH;
 
 	beforeEach(() => {
 		_resetForTests();
+		resetDegradationLedger();
 		appendRecentTouches.mockClear();
 		appendRecentTouches.mockResolvedValue(undefined);
 		logBusEvent.mockClear();
@@ -32,6 +37,7 @@ describe("bus-publish — pilens:files:touched (#482)", () => {
 
 	afterEach(() => {
 		_resetForTests();
+		resetDegradationLedger();
 		if (originalEnv === undefined) {
 			delete process.env.PI_LENS_BUS_PUBLISH;
 		} else {
@@ -195,6 +201,36 @@ describe("bus-publish — pilens:files:touched (#482)", () => {
 			}),
 		).not.toThrow();
 		expect(dbg).toHaveBeenCalledTimes(1);
+	});
+
+	it("logs and ledgers each stale occurrence after a successful recovery", () => {
+		const stale = vi.fn(() => {
+			throw new Error("This extension ctx is stale after session replacement or reload");
+		});
+		const recovered = vi.fn();
+		let currentEmit: (channel: string, data: unknown) => void = stale;
+		wireBusEmitterGetter(() => currentEmit);
+		const dbg = vi.fn();
+		const publish = (path: string) =>
+			publishFilesTouched({ reason: "autofix", paths: [path], cwd: "/repo", dbg });
+
+		publish("/repo/a.ts");
+		publish("/repo/b.ts");
+		expect(dbg).toHaveBeenCalledTimes(1);
+		expect(getDegradationSummary()).toEqual([
+			expect.objectContaining({ kind: "bus-stale", count: 1 }),
+		]);
+
+		currentEmit = recovered;
+		publish("/repo/recovered.ts");
+		expect(recovered).toHaveBeenCalledTimes(1);
+
+		currentEmit = stale;
+		publish("/repo/c.ts");
+		expect(dbg).toHaveBeenCalledTimes(2);
+		expect(getDegradationSummary()).toEqual([
+			expect.objectContaining({ kind: "bus-stale", count: 2 }),
+		]);
 	});
 
 	describe("#502: fix-provenance additive fields", () => {

--- a/tests/index-wiring.test.ts
+++ b/tests/index-wiring.test.ts
@@ -6,6 +6,16 @@ import { CacheManager } from "../clients/cache-manager.js";
 import { getLatencyLogPath } from "../clients/latency-logger.js";
 import { LENS_FLAGS } from "../clients/lens-flag-registry.js";
 import extension from "../index.js";
+import {
+	_resetForTests as resetBusPublishForTests,
+	publishFilesTouched,
+	wireBusEmitter,
+} from "../clients/bus-publish.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../clients/degradation-ledger.js";
+import { _resetSessionLifecycleForTests } from "../clients/session-lifecycle.js";
 import { createPiMock, makeCtx } from "./support/pi-mock.js";
 import { removeTempDirSync } from "./clients/test-utils.js";
 
@@ -91,6 +101,74 @@ const EXPECTED_HOOKS = [
 ];
 
 describe("index.ts extension wiring", () => {
+	it("re-wires a recovered bus on a #473-guarded subagent session_start (#1383)", async () => {
+		_resetSessionLifecycleForTests();
+		resetBusPublishForTests();
+		resetDegradationLedger();
+		try {
+			const parent = createPiMock();
+			const parentApi = parent.asExtensionAPI();
+			(parentApi as unknown as { events: { emit: ReturnType<typeof vi.fn> } }).events = {
+				emit: vi.fn(),
+			};
+			extension(parentApi);
+			await parent.emit(
+				"session_start",
+				{ reason: "startup" },
+				makeCtx({ cwd: process.cwd(), sessionId: "parent" }),
+			);
+
+			const dbg = vi.fn();
+			wireBusEmitter(() => {
+				throw new Error("This extension ctx is stale after session replacement or reload");
+			});
+			publishFilesTouched({
+				reason: "autofix",
+				paths: ["/repo/stale.ts"],
+				cwd: "/repo",
+				dbg,
+			});
+			expect(dbg).toHaveBeenCalledTimes(1);
+			expect(getDegradationSummary()).toEqual([
+				expect.objectContaining({ kind: "bus-stale", count: 1 }),
+			]);
+
+			const recoveredEmit = vi.fn();
+			const subagent = createPiMock();
+			const subagentApi = subagent.asExtensionAPI();
+			(subagentApi as unknown as { events: { emit: typeof recoveredEmit } }).events = {
+				emit: recoveredEmit,
+			};
+			extension(subagentApi);
+			// Model another activation winning the module singleton after factory
+			// load. The guarded session_start itself must reclaim the wiring.
+			wireBusEmitter(() => {
+				throw new Error("This extension ctx is stale after session replacement or reload");
+			});
+			await subagent.emit(
+				"session_start",
+				{ reason: "startup" },
+				makeCtx({ cwd: process.cwd(), sessionId: "subagent" }),
+			);
+			publishFilesTouched({
+				reason: "autofix",
+				paths: ["/repo/recovered.ts"],
+				cwd: "/repo",
+				dbg,
+			});
+
+			expect(recoveredEmit).toHaveBeenCalledWith(
+				"pilens:files:touched",
+				expect.objectContaining({ paths: [expect.stringContaining("recovered.ts")] }),
+			);
+			expect(dbg).toHaveBeenCalledTimes(1);
+		} finally {
+			_resetSessionLifecycleForTests();
+			resetBusPublishForTests();
+			resetDegradationLedger();
+		}
+	});
+
 	describe("registration", () => {
 		it("registers every expected flag, command, tool, and lifecycle hook", () => {
 			const pi = createPiMock();


### PR DESCRIPTION
## Summary

- re-wire activation-scoped bus/lens emitters, notifier, and widget render callback on every `session_start`, before the #473 concurrent-secondary early return
- make every bus publisher's failure suppression occurrence-scoped: a successful publish re-arms failure logging
- record one `kind=bus-stale` degradation per stale failure window for `pilens_health`

## Diagnosis and invariants

The #1367 ports resolve their methods per call, but each `HostPorts` object still closes over one activation-scoped `pi`. Module-singleton emitter getters can therefore be overwritten by a sibling activation; when that activation is invalidated, the getter permanently routes through its stale `pi.events` wrapper. Re-resolving the method inside that same ports object does not cross the activation boundary.

The #473 guard must continue skipping destructive shared runtime/LSP reset for a concurrent in-process subagent, but it must not skip cheap ctx-derived plumbing refresh. The refresh now runs before classification can return. Full session starts preserve their existing reset behavior.

Failure semantics remain fail-soft. A stale occurrence logs and ledgers once; repeated failures in the same window stay suppressed; any successful publish ends the window. Non-stale emit failures retain log-once behavior but are not mislabeled `bus-stale`.

## Blast radius

`module_report(..., { blastRadius: true })` was run before and after editing `index.ts`, `clients/live-bus-emitter.ts`, all four bus publisher modules, and `clients/degradation-ledger.ts`. The available graph reported no `usedBy`/blast-radius data; callback extraction identified the extension factory and its ctx/render/emit closures in `index.ts`. Direct dependents exercised here are the files-touched, diagnostics, disposition, format/autofix publishers, lens events, notifier, widget render callback, session lifecycle guard, and degradation health rendering.

## Verification

- `npm run build` — pass
- targeted Vitest: 8 files, 189 tests passed (`bus-publish`, diagnostics/format publishers, lens-events, runtime-session-lifecycle, session-lifecycle, widget-state, index-wiring)
- focused restored-head regression: 1 passed, 13 skipped
- `npm run lint` — pass
- `git diff --check` — pass

Mutation verification: removed only `refreshCtxDerivedPlumbing()` from the `session_start` handler, rebuilt, and ran the focused recovery test. It failed at the recovered `pilens:files:touched` assertion (1 failed, 13 skipped), proving factory-time wiring alone cannot satisfy the guarded recovery contract. Restored the call, rebuilt, and the test passed.

## Coordination

PR #1382 remains open and owns UI remount-on-replaced-`ctx.ui`. This PR does not reproduce that change; it fixes the independent event-delivery starvation seam so a remounted widget continues receiving live updates.