### PR TITLE
fix: add #1388 consistency drift guards

### DIFF
--- a/.changelog/fix-1388-drift-guards.md
+++ b/.changelog/fix-1388-drift-guards.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Prevented consistency drift in language fixtures and extension handling (refs #1388)** — call-graph fixtures now cover every symbol-query language, JS/TS facts share the canonical extension policy, and bash file-access tracking derives source extensions from `KIND_EXTENSIONS`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,12 @@ Rule-id normalization derives its language suffixes from the bundled CodeRabbit 
 
 Source-filter tests pin the ordering agreement between the forward precedence map, reverse source-twin candidates, and filesystem sibling resolution; the intentionally broad `.jsx` fallback remains part of that contract.
 
+Extension policy tests bind JS/TS fact applicability and bash source-like file
+access to `KIND_EXTENSIONS`; the only intentional exceptions are the documented
+Vue/Svelte fact exclusion and the small legacy text/config allowlist in
+`clients/file-kinds.ts`. Keep new language extensions there rather than adding
+provider-local regexes or sets.
+
 LSP root exclusion recognizes fixture conventions by exact path segment; Go's
 `testdata` convention applies ancestor-wide, but names such as `testdata-tools`
 remain ordinary project directories. The positive `.gitignore` glob precheck is

--- a/clients/bash-file-access.ts
+++ b/clients/bash-file-access.ts
@@ -15,6 +15,7 @@
  */
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
+import { isReadableSourceFile } from "./file-kinds.js";
 import { countFileLines } from "./read-guard-tool-lines.js";
 import type { SearchReadLocation } from "./search-read-registration.js";
 
@@ -26,11 +27,6 @@ export interface ReadSpan {
 	/** Number of lines read. */
 	limit: number;
 }
-
-// Source-ish extensions worth registering. Anchored end-check → linear (no
-// catastrophic backtracking).
-const READABLE_EXT_RE =
-	/\.(?:ts|tsx|js|jsx|mjs|cjs|py|sh|rs|go|cs|java|kt|rb|php|c|cpp|cc|h|hpp|json|jsonc|yaml|yml|toml|md|txt|env|cfg|conf|ini|html|css|scss|less|xml|sql|vue|svelte)$/i;
 
 function stripQuotes(token: string): string {
 	if (token.length >= 2) {
@@ -148,7 +144,7 @@ function tokenizeSegment(segment: string): string[] {
 /** Resolve a token to an absolute path if it looks like a source file. */
 function resolveCandidate(token: string, cwd: string): string | null {
 	const cleaned = stripQuotes(token);
-	if (!cleaned || cleaned.startsWith("-") || !READABLE_EXT_RE.test(cleaned)) {
+	if (!cleaned || cleaned.startsWith("-") || !isReadableSourceFile(cleaned)) {
 		return null;
 	}
 	return path.isAbsolute(cleaned) ? cleaned : path.resolve(cwd, cleaned);

--- a/clients/dispatch/facts/function-facts.ts
+++ b/clients/dispatch/facts/function-facts.ts
@@ -1,4 +1,5 @@
 import type { FactProvider } from "../fact-provider-types.js";
+import { isJstsFactFile } from "../../file-kinds.js";
 import { findOwnerName } from "../../symbol-containment.js";
 import {
 	extractFactsFromTree,
@@ -86,11 +87,6 @@ const FUNCTION_TYPES = new Set([
 	"function_expression",
 	"arrow_function",
 ]);
-
-// The same tree-sitter TypeScript integration parses both TS/TSX and the
-// JavaScript grammar. Keep this extension set local to the provider rather
-// than adding another parser or a JS-specific extraction path.
-const FUNCTION_FACT_EXTS = /\.(?:c|m)?(?:js|jsx|ts|tsx)$/i;
 
 // Decision points for McCabe complexity (matches the old ts.SyntaxKind set).
 const COMPLEXITY_TYPES = new Set([
@@ -364,7 +360,7 @@ export const functionFactProvider: FactProvider = {
 	provides: ["file.functionSummaries", "file.functionFactsCoverage"],
 	requires: ["file.content"],
 	appliesTo(ctx) {
-		return FUNCTION_FACT_EXTS.test(ctx.filePath);
+		return isJstsFactFile(ctx.filePath);
 	},
 	async run(ctx, store) {
 		await extractFactsFromTree(

--- a/clients/dispatch/facts/import-facts.ts
+++ b/clients/dispatch/facts/import-facts.ts
@@ -1,4 +1,5 @@
 import { logLatency } from "../../latency-logger.js";
+import { isJstsFactFile } from "../../file-kinds.js";
 import type { FactProvider } from "../fact-provider-types.js";
 import {
 	childrenOfType,
@@ -30,20 +31,6 @@ export interface ReExportEntry {
 	/** Names re-exported. Empty array means `export * from '...'`. */
 	names: string[];
 }
-
-// JS/TS extensions this provider handles (→ tree-sitter typescript/tsx/javascript
-// grammars via resolveTreeSitterLanguage). Ported off the `typescript` compiler API
-// onto tree-sitter (#402) — the parse is served from the shared, cached client.
-const JSTS_EXTS = new Set([
-	".ts",
-	".tsx",
-	".mts",
-	".cts",
-	".js",
-	".jsx",
-	".mjs",
-	".cjs",
-]);
 
 function stripQuotes(raw: string): string {
 	return raw.replace(/^["'`]+|["'`]+$/g, "");
@@ -114,8 +101,7 @@ export const importFactProvider: FactProvider = {
 	provides: ["file.imports", "file.reexports", "file.importFactsCoverage"],
 	requires: ["file.content"],
 	appliesTo(ctx) {
-		const ext = ctx.filePath.slice(ctx.filePath.lastIndexOf(".")).toLowerCase();
-		return JSTS_EXTS.has(ext);
+		return isJstsFactFile(ctx.filePath);
 	},
 	async run(ctx, store) {
 		const content = store.getFileFact<string>(ctx.filePath, "file.content");

--- a/clients/file-kinds.ts
+++ b/clients/file-kinds.ts
@@ -231,6 +231,47 @@ export const KIND_EXTENSIONS: Record<FileKind, readonly string[]> = {
 	],
 };
 
+/** Return whether a path has an extension registered for the given file kind. */
+export function hasKindExtension(filePath: string, kind: FileKind): boolean {
+	const extension = extname(filePath).toLowerCase();
+	return KIND_EXTENSIONS[kind].some((candidate) => candidate === extension);
+}
+
+// Fact providers intentionally stay on the ordinary JS/TS source extensions.
+// Vue/Svelte files are classified as jsts for project-wide discovery, but their
+// embedded-language contents are not valid inputs for these tree-sitter facts.
+// Keep that one policy decision here so the function and import providers agree.
+const JSTS_FACT_EXTENSIONS = new Set(
+	KIND_EXTENSIONS.jsts.filter((extension) => ![".vue", ".svelte"].includes(extension)),
+);
+
+/** Whether the JS/TS fact providers should parse this path. */
+export function isJstsFactFile(filePath: string): boolean {
+	return JSTS_FACT_EXTENSIONS.has(extname(filePath).toLowerCase());
+}
+
+// Bash access tracking also accepts common text/config files which do not have
+// a semantic FileKind. Every source extension is derived from KIND_EXTENSIONS;
+// only this explicit legacy text/config allowlist lives outside that registry.
+const NON_KIND_READABLE_EXTENSIONS = new Set([
+	".txt",
+	".env",
+	".cfg",
+	".conf",
+	".ini",
+	".xml",
+]);
+
+/** Whether bash file-access parsing should treat a path as source-like. */
+export function isReadableSourceFile(filePath: string): boolean {
+	const extension = extname(filePath).toLowerCase();
+	return (
+		Object.keys(KIND_EXTENSIONS).some((kind) =>
+			hasKindExtension(filePath, kind as FileKind),
+		) || NON_KIND_READABLE_EXTENSIONS.has(extension)
+	);
+}
+
 // --- Shared Project Root Markers ---
 
 /**

--- a/clients/lsp/edits.ts
+++ b/clients/lsp/edits.ts
@@ -591,6 +591,9 @@ function planWorkspaceEdit(
 	const addIndex = (key: string): void => {
 		const ancestors: string[] = [];
 		let current = key;
+		// `key` is a normalized URI index key, not an on-disk directory. The
+		// index intentionally uses the key's own separator/root semantics, so
+		// walkUpDirs (which resolves through the host filesystem) is not suitable.
 		while (true) {
 			const set = descendants.get(current) ?? new Set<string>();
 			set.add(key);

--- a/clients/tree-sitter-symbol-extractor.ts
+++ b/clients/tree-sitter-symbol-extractor.ts
@@ -513,6 +513,11 @@ SYMBOL_QUERIES.javascript = {
     `,
 };
 
+/** Language keys with symbol queries; used by fixture drift guards. */
+export function getSymbolQueryLanguages(): readonly string[] {
+	return Object.keys(SYMBOL_QUERIES);
+}
+
 // Per-language import-source extraction (#249). Optional and independent of
 // SYMBOL_QUERIES: a language without an entry simply yields no imports (its
 // symbols still extract). Each query captures the import source text as

--- a/tests/clients/extension-predicate-coverage.test.ts
+++ b/tests/clients/extension-predicate-coverage.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+	KIND_EXTENSIONS,
+	isJstsFactFile,
+	isReadableSourceFile,
+} from "../../clients/file-kinds.js";
+import { functionFactProvider } from "../../clients/dispatch/facts/function-facts.js";
+import { importFactProvider } from "../../clients/dispatch/facts/import-facts.js";
+
+const contextFor = (filePath: string) => ({ filePath }) as never;
+
+describe("extension predicate coverage", () => {
+	it("keeps both JS/TS fact providers bound to the canonical jsts extensions", () => {
+		for (const extension of KIND_EXTENSIONS.jsts) {
+			const appliesToFacts = isJstsFactFile(`fixture${extension}`);
+			expect(functionFactProvider.appliesTo(contextFor(`fixture${extension}`))).toBe(
+				appliesToFacts,
+			);
+			expect(importFactProvider.appliesTo(contextFor(`fixture${extension}`))).toBe(
+				appliesToFacts,
+			);
+		}
+
+		expect(isJstsFactFile("fixture.cjsx")).toBe(false);
+		expect(isJstsFactFile("fixture.mjsx")).toBe(false);
+	});
+
+	it("accepts every canonical kind extension for bash file access", () => {
+		for (const extensions of Object.values(KIND_EXTENSIONS)) {
+			for (const extension of extensions) {
+				expect(isReadableSourceFile(`fixture${extension}`)).toBe(true);
+			}
+		}
+	});
+
+	it("preserves the explicit non-kind text/config allowlist", () => {
+		for (const extension of [".txt", ".env", ".cfg", ".conf", ".ini", ".xml"]) {
+			expect(isReadableSourceFile(`fixture${extension}`)).toBe(true);
+		}
+	});
+});

--- a/tests/clients/extension-predicate-coverage.test.ts
+++ b/tests/clients/extension-predicate-coverage.test.ts
@@ -21,8 +21,14 @@ describe("extension predicate coverage", () => {
 			);
 		}
 
+		// The pre-#1388 regex `\.(?:c|m)?(?:js|jsx|ts|tsx)$` also matched these
+		// four compound suffixes. None exists in any toolchain (TypeScript ships
+		// .mts/.cts but no JSX variants of them), so their removal is deliberate,
+		// not a regression — this pins that decision.
 		expect(isJstsFactFile("fixture.cjsx")).toBe(false);
 		expect(isJstsFactFile("fixture.mjsx")).toBe(false);
+		expect(isJstsFactFile("fixture.ctsx")).toBe(false);
+		expect(isJstsFactFile("fixture.mtsx")).toBe(false);
 	});
 
 	it("accepts every canonical kind extension for bash file access", () => {

--- a/tests/clients/tree-sitter-call-graph.test.ts
+++ b/tests/clients/tree-sitter-call-graph.test.ts
@@ -6,7 +6,10 @@ import { buildCallGraph } from "../../clients/call-graph.js";
 import { grammarBlockReason, LANGUAGE_TO_GRAMMAR } from "../../clients/grammar-source.js";
 import { getSharedTreeSitterClient } from "../../clients/tree-sitter-shared.js";
 import type { TreeSitterClient } from "../../clients/tree-sitter-client.js";
-import { TreeSitterSymbolExtractor } from "../../clients/tree-sitter-symbol-extractor.js";
+import {
+	getSymbolQueryLanguages,
+	TreeSitterSymbolExtractor,
+} from "../../clients/tree-sitter-symbol-extractor.js";
 import type { Symbol, SymbolRef } from "../../clients/symbol-types.js";
 
 const FIXTURE_ROOT = path.resolve(
@@ -98,6 +101,20 @@ async function buildFixtureGraph(fixture: CallFixture) {
 }
 
 describe("Tree-sitter call-graph fixtures", () => {
+	it("covers every language with a symbol query", () => {
+		const fixtureLanguages = new Set([
+			...CALL_FIXTURES.map((fixture) => fixture.language),
+			...TYPE_REFERENCE_FIXTURES.map((fixture) => fixture.language),
+		]);
+		const missing = getSymbolQueryLanguages().filter(
+			(language) => !fixtureLanguages.has(language),
+		);
+		expect(
+			missing,
+			"every SYMBOL_QUERIES language needs a call-graph or type-reference fixture",
+		).toEqual([]);
+	});
+
 	for (const fixture of CALL_FIXTURES) {
 		const blocked = Boolean(
 			grammarBlockReason(LANGUAGE_TO_GRAMMAR[fixture.language]),


### PR DESCRIPTION
## Summary

- Add a symbol-query language fixture coverage guard for call-graph fixtures.
- Derive JS/TS fact applicability and bash readable-source detection from KIND_EXTENSIONS, with documented intentional exceptions.
- Document why walkUpDirs does not fit the normalized-key LSP edit index.
- Update durable agent guidance and add a Fixed changelog entry.

Refs #1388

## Verification

- npm run build
- Targeted Vitest suites: 6 files, 124 passed, 1 skipped
- LSP edits suite: 1 file, 53 passed
- npm run lint
- npm run changelog:check