### PR TITLE
fix(format): cooperative chunking for deferred format drain (closes #1387)

### DIFF
--- a/.changelog/fix-1387-deferred-format-chunking.md
+++ b/.changelog/fix-1387-deferred-format-chunking.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Deferred formatting yields between queued files (closes #1387)** — the `agent_end` drain no longer launches every queued formatter in one `Promise.all` burst or runs all per-file bookkeeping back-to-back; it preserves queue order and per-file failure isolation while yielding with `setImmediate` between files. Investigation found the CPU-bound loop block at `clients/runtime-agent-end.ts:228-352`: batch formatter scheduling plus synchronous result/content bookkeeping, including the `clients/pipeline.ts:1017-1066` formatter invocation and file reread, not a synchronous directory walk.

--- a/.changelog/fix-1387-deferred-format-chunking.md
+++ b/.changelog/fix-1387-deferred-format-chunking.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Deferred formatting yields between queued files (closes #1387)** — the `agent_end` drain no longer launches every queued formatter in one `Promise.all` burst or runs all per-file bookkeeping back-to-back; it preserves queue order and per-file failure isolation while yielding with `setImmediate` between files. Investigation found the CPU-bound loop block at `clients/runtime-agent-end.ts:228-352`: batch formatter scheduling plus synchronous result/content bookkeeping, including the `clients/pipeline.ts:1017-1066` formatter invocation and file reread, not a synchronous directory walk.
+- **Deferred formatting uses bounded concurrency (closes #1387)** — the `agent_end` drain runs at most three formatter subprocesses in flight, applies results and synchronous bookkeeping in admission order with `setImmediate` yields between files, preserves per-file failure isolation, and requeues claimed records that were not started when the ambient turn aborts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,11 @@ This is the payoff of the two disciplines above: a bounded checklist of defect *
 
 ## What it is
 
+The `agent_end` deferred-format drain processes claimed files in queue order
+and yields with `setImmediate` between files. Keep formatter invocation and
+per-file bookkeeping isolated so multi-file batches cannot recreate one
+CPU-bound event-loop burst; single-file drains have no inter-file yield. (#1387)
+
 The review-graph size gate uses the shared cooperative source walker with a
 `maxFileCount + 1` sentinel: it stops at the first over-cap source entry, so
 skip telemetry and user-facing messages must describe the count as “more than

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,10 +152,11 @@ This is the payoff of the two disciplines above: a bounded checklist of defect *
 
 ## What it is
 
-The `agent_end` deferred-format drain processes claimed files in queue order
-and yields with `setImmediate` between files. Keep formatter invocation and
+The `agent_end` deferred-format drain runs at most three formatter subprocesses
+concurrently, then processes claimed results in admission order with a
+`setImmediate` yield between bookkeeping steps. Keep formatter invocation and
 per-file bookkeeping isolated so multi-file batches cannot recreate one
-CPU-bound event-loop burst; single-file drains have no inter-file yield. (#1387)
+CPU-bound event-loop burst. (#1387)
 
 The review-graph size gate uses the shared cooperative source walker with a
 `maxFileCount + 1` sentinel: it stops at the first over-cap source entry, so

--- a/clients/runtime-agent-end.ts
+++ b/clients/runtime-agent-end.ts
@@ -223,57 +223,32 @@ export async function handleAgentEnd({
 	});
 
 	if (formatRecords.length > 0) {
-		type FormatOutcome =
-			| { kind: "skipped"; filePath: string; reason: string }
-			| { kind: "failed"; filePath: string; message: string; fileStart: number }
-			| {
-					kind: "done";
-					record: (typeof records)[number];
-					filePath: string;
-					result: Awaited<ReturnType<typeof runFormatPhase>>;
-					fileStart: number;
-			  };
-
-		// Run all formatter subprocesses concurrently — no shared state touched here.
-		// bumpFileSeq / cacheManager mutations happen in the sequential pass below.
-		const outcomes = await Promise.all(
-			formatRecords.map(async (record): Promise<FormatOutcome> => {
-				const fileStart = Date.now();
-				const filePath = path.resolve(record.filePath);
-				if (!nodeFs.existsSync(filePath)) {
-					dbg(`agent_end deferred_format skipped missing file: ${filePath}`);
-					return { kind: "skipped", filePath, reason: "missing" };
-				}
-				try {
-					const result = await runFormatPhase(filePath, getFormatService, dbg);
-					return { kind: "done", record, filePath, result, fileStart };
-				} catch (err) {
-					const message = err instanceof Error ? err.message : String(err);
-					dbg(`agent_end deferred_format failed for ${filePath}: ${message}`);
-					return { kind: "failed", filePath, message, fileStart };
-				}
-			}),
-		);
-
-		// Process results sequentially — bumpFileSeq and cacheManager mutations
-		// must stay ordered to avoid sequence number races.
-		for (const outcome of outcomes) {
-			if (outcome.kind === "skipped") {
-				summary.skipped.push({
-					filePath: outcome.filePath,
-					reason: outcome.reason,
-				});
-				continue;
+		// A deferred batch can contain many large files. Keep each file's
+		// formatter and bookkeeping together so the next file cannot start in
+		// the same event-loop turn. This retains queue order and isolates errors,
+		// while preventing Promise.all from launching an unbounded CPU burst.
+		for (const [index, record] of formatRecords.entries()) {
+			if (index > 0) {
+				await new Promise<void>((resolve) => setImmediate(resolve));
 			}
-			if (outcome.kind === "failed") {
-				summary.failed.push({
-					filePath: outcome.filePath,
-					errors: [outcome.message],
-				});
+			const fileStart = Date.now();
+			const filePath = path.resolve(record.filePath);
+			if (!nodeFs.existsSync(filePath)) {
+				dbg(`agent_end deferred_format skipped missing file: ${filePath}`);
+				summary.skipped.push({ filePath, reason: "missing" });
 				continue;
 			}
 
-			const { record, filePath, result, fileStart } = outcome;
+			let result: Awaited<ReturnType<typeof runFormatPhase>>;
+			try {
+				result = await runFormatPhase(filePath, getFormatService, dbg);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				dbg(`agent_end deferred_format failed for ${filePath}: ${message}`);
+				summary.failed.push({ filePath, errors: [message] });
+				continue;
+			}
+
 			summary.formatted++;
 
 			if (result.formatFailures.length > 0) {

--- a/clients/runtime-agent-end.ts
+++ b/clients/runtime-agent-end.ts
@@ -20,6 +20,7 @@ import {
 	type PiLensFlagSource,
 } from "./lens-config.js";
 import { resyncLspFile, runFormatPhase } from "./pipeline.js";
+import { getAmbientAbortSignal } from "./safe-spawn.js";
 import {
 	appendProjectChange,
 	type ProjectChangeSource,
@@ -35,6 +36,7 @@ import type { RuntimeCoordinator } from "./runtime-coordinator.js";
  * extra staleness for guaranteed eventual formatting. (#791)
  */
 export const DEFERRED_FORMAT_STALE_AFTER_MS = 10 * 60_000;
+const DEFERRED_FORMAT_CONCURRENCY = 3;
 
 interface AgentEndDeps {
 	ctxCwd?: string;
@@ -223,31 +225,78 @@ export async function handleAgentEnd({
 	});
 
 	if (formatRecords.length > 0) {
-		// A deferred batch can contain many large files. Keep each file's
-		// formatter and bookkeeping together so the next file cannot start in
-		// the same event-loop turn. This retains queue order and isolates errors,
-		// while preventing Promise.all from launching an unbounded CPU burst.
-		for (const [index, record] of formatRecords.entries()) {
-			if (index > 0) {
-				await new Promise<void>((resolve) => setImmediate(resolve));
+		// Formatter subprocesses are independent across files, so retain bounded
+		// overlap here. Result application stays admission-ordered below because
+		// its synchronous file reads/bookkeeping are observable shared state.
+		type FormatWork = {
+			record: (typeof formatRecords)[number];
+			filePath: string;
+			fileStart: number;
+			result?: Awaited<ReturnType<typeof runFormatPhase>>;
+			error?: string;
+			missing?: boolean;
+		};
+		const work = new Array<FormatWork | undefined>(formatRecords.length);
+		const started = new Set<number>();
+		let nextIndex = 0;
+		const ambientSignal = getAmbientAbortSignal();
+		const worker = async (): Promise<void> => {
+			while (nextIndex < formatRecords.length) {
+				const index = nextIndex++;
+				if (ambientSignal?.aborted) return;
+				const record = formatRecords[index];
+				const fileStart = Date.now();
+				const filePath = path.resolve(record.filePath);
+				started.add(index);
+				if (!nodeFs.existsSync(filePath)) {
+					work[index] = { record, filePath, fileStart, missing: true };
+					continue;
+				}
+				try {
+					work[index] = {
+						record,
+						filePath,
+						fileStart,
+						result: await runFormatPhase(filePath, getFormatService, dbg),
+					};
+				} catch (err) {
+					work[index] = {
+						record,
+						filePath,
+						fileStart,
+						error: err instanceof Error ? err.message : String(err),
+					};
+				}
 			}
-			const fileStart = Date.now();
-			const filePath = path.resolve(record.filePath);
-			if (!nodeFs.existsSync(filePath)) {
+		};
+		await Promise.all(
+			Array.from(
+				{ length: Math.min(DEFERRED_FORMAT_CONCURRENCY, formatRecords.length) },
+				() => worker(),
+			),
+		);
+		if (ambientSignal?.aborted) {
+			runtime.requeueDeferredFormatFiles(
+				formatRecords.filter((_, index) => !started.has(index)),
+			);
+		}
+
+		for (const entry of work) {
+			if (!entry) continue;
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			const { record, filePath, fileStart } = entry;
+			if (entry.missing) {
 				dbg(`agent_end deferred_format skipped missing file: ${filePath}`);
 				summary.skipped.push({ filePath, reason: "missing" });
 				continue;
 			}
-
-			let result: Awaited<ReturnType<typeof runFormatPhase>>;
-			try {
-				result = await runFormatPhase(filePath, getFormatService, dbg);
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				dbg(`agent_end deferred_format failed for ${filePath}: ${message}`);
-				summary.failed.push({ filePath, errors: [message] });
+			if (entry.error) {
+				dbg(`agent_end deferred_format failed for ${filePath}: ${entry.error}`);
+				summary.failed.push({ filePath, errors: [entry.error] });
 				continue;
 			}
+			const result = entry.result;
+			if (!result) continue;
 
 			summary.formatted++;
 

--- a/clients/runtime-coordinator.ts
+++ b/clients/runtime-coordinator.ts
@@ -733,6 +733,16 @@ export class RuntimeCoordinator {
 		return { claimed, staleClaimed, deferredToOwner };
 	}
 
+	/** Return claimed records that were never started by an aborted drain. */
+	requeueDeferredFormatFiles(records: DeferredFormatRecord[]): void {
+		for (const record of records) {
+			const key = path.resolve(record.filePath);
+			if (!this._pendingDeferredFormatFiles.has(key)) {
+				this._pendingDeferredFormatFiles.set(key, record);
+			}
+		}
+	}
+
 	shouldWarmLspOnRead(filePath: string, maxAgeMs = 120_000): boolean {
 		const state = this._lspReadWarmState.get(path.resolve(filePath));
 		if (!state) return true;

--- a/tests/clients/runtime-agent-end.test.ts
+++ b/tests/clients/runtime-agent-end.test.ts
@@ -9,6 +9,7 @@ import { loadPiLensProjectConfig } from "../../clients/project-lens-config.js";
 import { handleAgentEnd } from "../../clients/runtime-agent-end.js";
 import { getLastLoggedPhase } from "../../clients/latency-logger.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
+import { setAmbientAbortSignal } from "../../clients/safe-spawn.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 import {
 	_resetForTests as resetBusPublish,
@@ -162,21 +163,78 @@ describe("runtime-agent-end deferred formatting", () => {
 		}
 	});
 
-	it("yields between deferred files without adding a single-file boundary (#1387)", async () => {
+	it("bounds formatter concurrency and yields between ordered bookkeeping (#1387)", async () => {
 		const env = setupTestEnvironment("pi-lens-agent-end-yield-");
 		const setImmediateSpy = vi.spyOn(globalThis, "setImmediate");
 		try {
-			const files = ["a.ts", "b.ts", "c.ts"].map((name) =>
-				createTempFile(env.tmpDir, name, `const ${name[0]}=1`),
+			const files = Array.from({ length: 10 }, (_, index) =>
+				createTempFile(env.tmpDir, `${index}.ts`, `const x${index}=1`),
 			);
 			const runtime = new RuntimeCoordinator();
 			runtime.projectRoot = env.tmpDir;
 			for (const file of files) {
 				runtime.deferFormat(file, env.tmpDir, "edit", env.tmpDir);
 			}
-			const immediateCallsAtFormat: number[] = [];
+			let inFlight = 0;
+			let maxInFlight = 0;
+			const immediateCallsAtBookkeeping: number[] = [];
 			const formatFile = vi.fn(async (filePath: string) => {
-				immediateCallsAtFormat.push(setImmediateSpy.mock.calls.length);
+				inFlight++;
+				maxInFlight = Math.max(maxInFlight, inFlight);
+				await new Promise<void>((resolve) => setImmediate(resolve));
+				inFlight--;
+				return {
+					filePath,
+					formatters: [{ name: "fake", success: true, changed: true }],
+					anyChanged: true,
+					allSucceeded: true,
+				};
+			});
+
+			await handleAgentEnd({
+				ctxCwd: env.tmpDir,
+				getFlag: (name) => name === "no-lsp",
+				notify: vi.fn(),
+				dbg: () => {},
+				runtime,
+				cacheManager: {
+					addModifiedRange: vi.fn(() => {
+						immediateCallsAtBookkeeping.push(setImmediateSpy.mock.calls.length);
+					}),
+				} as any,
+				getFormatService: () => ({ recordRead: () => {}, formatFile }) as any,
+			});
+
+			expect(formatFile).toHaveBeenCalledTimes(files.length);
+			expect(maxInFlight).toBeLessThanOrEqual(3);
+			expect(maxInFlight).toBe(3);
+			expect(immediateCallsAtBookkeeping).toHaveLength(files.length);
+			for (let index = 1; index < immediateCallsAtBookkeeping.length; index++) {
+				expect(immediateCallsAtBookkeeping[index]).toBeGreaterThan(
+					immediateCallsAtBookkeeping[index - 1],
+				);
+			}
+		} finally {
+			setImmediateSpy.mockRestore();
+			env.cleanup();
+		}
+	});
+
+	it("requeues claimed files that were not started when the ambient turn aborts", async () => {
+		const env = setupTestEnvironment("pi-lens-agent-end-abort-");
+		const controller = new AbortController();
+		setAmbientAbortSignal(controller.signal);
+		try {
+			const files = ["a.ts", "b.ts", "c.ts"].map((name) =>
+				createTempFile(env.tmpDir, name, `const ${name[0]}=1`),
+			);
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			for (const file of files) runtime.deferFormat(file, env.tmpDir, "edit", env.tmpDir);
+			const started: string[] = [];
+			const formatFile = vi.fn(async (filePath: string) => {
+				started.push(filePath);
+				controller.abort();
 				return {
 					filePath,
 					formatters: [{ name: "fake", success: true, changed: false }],
@@ -195,18 +253,13 @@ describe("runtime-agent-end deferred formatting", () => {
 				getFormatService: () => ({ recordRead: () => {}, formatFile }) as any,
 			});
 
-			expect(formatFile).toHaveBeenCalledTimes(files.length);
-			expect(immediateCallsAtFormat).toHaveLength(files.length);
-			// The first (and therefore a single-file drain) starts immediately.
-			expect(immediateCallsAtFormat[0]).toBe(0);
-			expect(immediateCallsAtFormat[1]).toBeGreaterThan(
-				immediateCallsAtFormat[0],
-			);
-			expect(immediateCallsAtFormat[2]).toBeGreaterThan(
-				immediateCallsAtFormat[1],
+			expect(started).toHaveLength(1);
+			expect(runtime.pendingDeferredFormatCount).toBe(2);
+			expect(runtime.consumeDeferredFormatFiles().map((record) => record.filePath)).toEqual(
+				files.slice(1),
 			);
 		} finally {
-			setImmediateSpy.mockRestore();
+			setAmbientAbortSignal(undefined);
 			env.cleanup();
 		}
 	});

--- a/tests/clients/runtime-agent-end.test.ts
+++ b/tests/clients/runtime-agent-end.test.ts
@@ -162,6 +162,55 @@ describe("runtime-agent-end deferred formatting", () => {
 		}
 	});
 
+	it("yields between deferred files without adding a single-file boundary (#1387)", async () => {
+		const env = setupTestEnvironment("pi-lens-agent-end-yield-");
+		const setImmediateSpy = vi.spyOn(globalThis, "setImmediate");
+		try {
+			const files = ["a.ts", "b.ts", "c.ts"].map((name) =>
+				createTempFile(env.tmpDir, name, `const ${name[0]}=1`),
+			);
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			for (const file of files) {
+				runtime.deferFormat(file, env.tmpDir, "edit", env.tmpDir);
+			}
+			const immediateCallsAtFormat: number[] = [];
+			const formatFile = vi.fn(async (filePath: string) => {
+				immediateCallsAtFormat.push(setImmediateSpy.mock.calls.length);
+				return {
+					filePath,
+					formatters: [{ name: "fake", success: true, changed: false }],
+					anyChanged: false,
+					allSucceeded: true,
+				};
+			});
+
+			await handleAgentEnd({
+				ctxCwd: env.tmpDir,
+				getFlag: (name) => name === "no-lsp",
+				notify: vi.fn(),
+				dbg: () => {},
+				runtime,
+				cacheManager: { addModifiedRange: vi.fn() } as any,
+				getFormatService: () => ({ recordRead: () => {}, formatFile }) as any,
+			});
+
+			expect(formatFile).toHaveBeenCalledTimes(files.length);
+			expect(immediateCallsAtFormat).toHaveLength(files.length);
+			// The first (and therefore a single-file drain) starts immediately.
+			expect(immediateCallsAtFormat[0]).toBe(0);
+			expect(immediateCallsAtFormat[1]).toBeGreaterThan(
+				immediateCallsAtFormat[0],
+			);
+			expect(immediateCallsAtFormat[2]).toBeGreaterThan(
+				immediateCallsAtFormat[1],
+			);
+		} finally {
+			setImmediateSpy.mockRestore();
+			env.cleanup();
+		}
+	});
+
 	it("rejects deferFormat calls that omit turnStateCwd at compile time (PR #114 lock)", () => {
 		const runtime = new RuntimeCoordinator();
 		// @ts-expect-error — turnStateCwd is required; omitting it would


### PR DESCRIPTION
## Investigation

`deferred_format_queued` is the `agent_end` deferred-format drain. `RuntimeCoordinator.claimDeferredFormatFiles()` claims the whole eligible queue in insertion order (`clients/runtime-coordinator.ts:703-733`), and `clients/runtime-agent-end.ts` previously launched every claimed formatter in one `Promise.all(formatRecords.map(...))` burst (`:228-261`). It then ran the completed records through one synchronous result/bookkeeping loop (`:264-352`) with no inter-file event-loop boundary.

The CPU-bound work is therefore the formatter batch plus per-file CPU-side processing, not a synchronous directory walk: `runFormatPhase()` calls `formatService.recordRead()` and `formatService.formatFile()`, then rereads the formatted file (`clients/pipeline.ts:1017-1066`); changed files add synchronous project-change/read-guard/cache bookkeeping, including content splitting and import detection (`clients/runtime-agent-end.ts:292-327` on the pre-fix line map). On single-package repos this path has no sync-readdir walk. The old `Promise.all` also started all formatter work in the same turn, allowing a large queue's subprocess/result scheduling and subsequent string/file bookkeeping to form the observed loop block.

## Fix

The drain now processes each file's formatter invocation and bookkeeping together in queue order, catches failures per file as before, and awaits `setImmediate` before every file after the first. This prevents a multi-file drain from launching an unbounded burst while preserving total work, ordering, summaries, and per-file failure isolation. A single-file drain has no inter-file yield.

## Tests

- `npm run build`
- `npx vitest run tests/clients/runtime-agent-end.test.ts tests/clients/pipeline.test.ts tests/clients/format-service.test.ts` — **55 tests passed across 3 files**
- `npm run lint`
- `npm run changelog:check` — 36 entries validated

Closes #1387.