### PR TITLE
fix(lsp,call-graph): canonicalize URI edit and call-graph keys (refs #1388)

### DIFF
--- a/.changelog/fix-1388-uri-buckets-callgraph-keys.md
+++ b/.changelog/fix-1388-uri-buckets-callgraph-keys.md
@@ -1,3 +1,4 @@
+---
 section: Fixed
 ---
 

--- a/.changelog/fix-1388-uri-buckets-callgraph-keys.md
+++ b/.changelog/fix-1388-uri-buckets-callgraph-keys.md
@@ -1,0 +1,4 @@
+section: Fixed
+---
+
+- **Canonicalized LSP edit merge buckets and call-graph path comparisons (refs #1388)** — equivalent URI spellings now share conflict/deduplication buckets while preserving the first display URI, and call-graph symbol/reference indexes normalize file keys consistently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,12 @@ Unsupported pull responses are also recognized by the standard message-only
 variants (`method not found`, `unknown method`, and `unsupported method`).
 Status consumers receive detached, 200-character-bounded failure entries.
 
+LSP workspace-edit merge buckets are keyed by `pathIndexKey`, not raw URI
+spelling; each canonical bucket retains its first URI as the display key.
+Call-graph `allSymbols`/`allRefs` file keys are `normalizeMapKey`-canonical,
+and lookup, cross-file filtering, and same-file classification must use that
+same canonical form.
+
 TypeScript LSP clients are evicted after `PI_LENS_TS_IDLE_EVICT_MS` of inactivity
 (default five minutes). Eviction removes the client from service state before
 graceful shutdown, releasing the server-owned language-service programs and

--- a/clients/call-graph.ts
+++ b/clients/call-graph.ts
@@ -338,7 +338,9 @@ export function buildCallGraph(
 ): FunctionCallGraph {
 	// Keep the lookup index canonical even for legacy direct callers that still
 	// construct these maps from display paths; persisted/review-graph callers
-	// already satisfy the canonical-key contract documented above.
+	// already satisfy the canonical-key contract documented above. A caller that
+	// supplies TWO raw spellings of the same file gets last-writer-wins here —
+	// raw compatibility is best-effort tolerance, not a merge contract.
 	const canonicalSymbols = new Map<string, Symbol[]>();
 	for (const [filePath, symbols] of allSymbols) canonicalSymbols.set(normalizeMapKey(filePath), symbols);
 	const defIndex = buildDefIndex(canonicalSymbols);

--- a/clients/call-graph.ts
+++ b/clients/call-graph.ts
@@ -261,15 +261,15 @@ const STDLIB_NAMES = new Set([
 	"open", "isinstance", "issubclass", "type", "super", "hasattr", "getattr",
 	"setattr", "enumerate", "zip", "map", "filter", "sorted", "reversed",
 	// Go
-	"fmt", "log", "os", "io", "err", "make", "append", "len", "cap", "copy",
+	"fmt", "log", "os", "io", "err", "make", "append", "cap", "copy",
 	"close", "delete", "panic", "recover", "new",
 	// Rust
-	"println", "eprintln", "print", "eprint", "vec", "Some", "None", "Ok", "Err",
-	"Box", "Rc", "Arc", "String", "Vec", "HashMap", "HashSet", "format",
+	"eprintln", "eprint", "vec", "Some", "None", "Ok", "Err",
+	"Box", "Rc", "Arc", "Vec", "HashMap", "HashSet", "format",
 	// Java/Kotlin
-	"System", "println", "toString", "equals", "hashCode", "Objects",
+	"System", "toString", "equals", "hashCode", "Objects",
 	// Generic
-	"new", "this", "self", "super", "nil", "null", "undefined", "true", "false",
+	"this", "self", "nil", "null", "undefined", "true", "false",
 ]);
 
 // ── Core resolution ────────────────────────────────────────────────────────────
@@ -330,11 +330,18 @@ function findEnclosingSymbol(
  * it is deliberately not used by the review-graph adapter (#1070).
  */
 export function buildCallGraph(
+	/** Keys are normalizeMapKey-canonical file paths; Symbol.filePath values retain their display spelling. */
 	allSymbols: Map<string, Symbol[]>,
+	/** Keys are normalizeMapKey-canonical caller file paths; SymbolRef.filePath retains its display spelling. */
 	allRefs: Map<string, SymbolRef[]>,
 	inputCoverage?: CallGraphEvidenceCoverage,
 ): FunctionCallGraph {
-	const defIndex = buildDefIndex(allSymbols);
+	// Keep the lookup index canonical even for legacy direct callers that still
+	// construct these maps from display paths; persisted/review-graph callers
+	// already satisfy the canonical-key contract documented above.
+	const canonicalSymbols = new Map<string, Symbol[]>();
+	for (const [filePath, symbols] of allSymbols) canonicalSymbols.set(normalizeMapKey(filePath), symbols);
+	const defIndex = buildDefIndex(canonicalSymbols);
 	const callees = new Map<SymbolKey, Set<SymbolKey>>();
 	const callers = new Map<SymbolKey, Set<SymbolKey>>();
 	const inDegree = new Map<SymbolKey, number>();
@@ -359,7 +366,8 @@ export function buildCallGraph(
 			 };
 
 	for (const [callerFile, refs] of allRefs) {
-		const callerSymbols = allSymbols.get(callerFile) ?? [];
+		const callerFileKey = normalizeMapKey(callerFile);
+		const callerSymbols = canonicalSymbols.get(callerFileKey) ?? [];
 		for (const ref of refs) {
 			totalRefs++;
 			if (!hasInputCoverage) {
@@ -420,7 +428,7 @@ export function buildCallGraph(
 				const crossFileDefs = defs
 					.map((id) => defIndex.byId.get(id))
 					.filter((candidate): candidate is Symbol =>
-						candidate !== undefined && candidate.filePath !== callerFile,
+						candidate !== undefined && normalizeMapKey(candidate.filePath) !== callerFileKey,
 					);
 				if (crossFileDefs.length === 0) {
 					if (!hasInputCoverage) coverage.unsupportedEvidence++;
@@ -447,7 +455,7 @@ export function buildCallGraph(
 			let producedEdge = false;
 			let duplicateRef = false;
 			for (const { callee, resolution, candidateCount } of candidates) {
-				if (normalizeMapKey(callee.filePath) === normalizeMapKey(callerFile)) {
+				if (normalizeMapKey(callee.filePath) === callerFileKey) {
 					// This projection is intentionally cross-file-only. A canonical
 					// same-file target is resolved by the source graph, but is represented
 					// by an explicit coverage category rather than as unsupported evidence.

--- a/clients/lsp/edits.ts
+++ b/clients/lsp/edits.ts
@@ -457,24 +457,25 @@ export async function normalizeWorkspaceEditToUtf16(
 
 export function flattenWorkspaceTextEdits(edit: { changes?: Record<string, unknown[]>; documentChanges?: unknown[] }): Map<string, LSPTextEdit[]> {
 	parseWorkspaceEdit(edit);
-	const out = new Map<string, LSPTextEdit[]>();
+	const buckets = new Map<string, { uri: string; edits: LSPTextEdit[] }>();
 	const push = (uri: string, edits: unknown[]) => {
 		const textEdits = parseTextEdits(edits, uri);
 		if (textEdits.length === 0) return;
-		const existing = out.get(uri);
-		if (existing) existing.push(...textEdits);
-		else out.set(uri, [...textEdits]);
+		const key = pathIndexKey(uri);
+		const existing = buckets.get(key);
+		if (existing) existing.edits.push(...textEdits);
+		else buckets.set(key, { uri, edits: [...textEdits] });
 	};
 	for (const [uri, edits] of Object.entries(edit.changes ?? {})) push(uri, edits);
 	for (const change of edit.documentChanges ?? []) {
 		const text = parseTextDocumentEdit(change, "documentChanges");
 		if (text) push(text.textDocument.uri, text.edits);
 	}
-	return out;
+	return new Map([...buckets.values()].map(({ uri, edits }) => [uri, edits]));
 }
 
 function textEditKey(uri: string, edit: LSPTextEdit): string {
-	return [uri, edit.range.start.line, edit.range.start.character, edit.range.end.line, edit.range.end.character, edit.newText].join(":");
+	return [pathIndexKey(uri), edit.range.start.line, edit.range.start.character, edit.range.end.line, edit.range.end.character, edit.newText].join(":");
 }
 
 export interface MergeWorkspaceEditsResult {
@@ -485,7 +486,7 @@ export interface MergeWorkspaceEditsResult {
 }
 
 export function mergeWorkspaceTextEditsByPriority(entries: Array<{ serverId: string; edit: { changes?: Record<string, unknown[]>; documentChanges?: unknown[] } | null | undefined }>): MergeWorkspaceEditsResult {
-	const merged = new Map<string, LSPTextEdit[]>();
+	const merged = new Map<string, { uri: string; edits: LSPTextEdit[] }>();
 	// Exact-duplicate dedup is a CROSS-SERVER concern only: two servers proposing
 	// the identical non-empty replace should collapse to one. Zero-width inserts
 	// are never deduplicated here — same as `validateTextEdits` on the normal
@@ -503,7 +504,9 @@ export function mergeWorkspaceTextEditsByPriority(entries: Array<{ serverId: str
 		serverIds.push(entry.serverId);
 		if (!entry.edit) continue;
 		for (const [uri, edits] of flattenWorkspaceTextEdits(entry.edit)) {
-			const kept = merged.get(uri) ?? [];
+			const key = pathIndexKey(uri);
+			const bucket = merged.get(key) ?? { uri, edits: [] };
+			const kept = bucket.edits;
 			for (const edit of edits) {
 				inputEditCount += 1;
 				const exactKey = isEmptyRange(edit.range) ? undefined : textEditKey(uri, edit);
@@ -515,11 +518,11 @@ export function mergeWorkspaceTextEditsByPriority(entries: Array<{ serverId: str
 				if (exactKey !== undefined) seenExact.add(exactKey);
 				kept.push(edit);
 			}
-			if (kept.length > 0) merged.set(uri, kept);
+			if (kept.length > 0) merged.set(key, bucket);
 		}
 	}
 	const changes: Record<string, LSPTextEdit[]> = {};
-	for (const [uri, edits] of merged) changes[uri] = edits;
+	for (const { uri, edits } of merged.values()) changes[uri] = edits;
 	return { edit: { changes }, droppedConflicts, inputEditCount, serverIds };
 }
 

--- a/tests/clients/call-graph.test.ts
+++ b/tests/clients/call-graph.test.ts
@@ -124,6 +124,24 @@ describe("buildCallGraph", () => {
 		expect(graph.callers.size).toBe(0);
 	});
 
+	it("normalizes divergent caller path casing for same-file classification", () => {
+		// Windows-shaped paths exercise normalizeMapKey's case/separator fold on
+		// both Windows and Linux CI without assuming the host filesystem casing.
+		const canonical = "C:\\Proj\\Caller.ts";
+		const divergent = "c:/proj/caller.ts";
+		const allSymbols = new Map([
+			[divergent, [sym(canonical, "caller"), sym(canonical, "helper")]],
+		]);
+		const graph = buildCallGraph(allSymbols, new Map([[divergent, [{
+			...ref(divergent, "helper"),
+			targetId: `${canonical}:helper`,
+			resolution: "exact",
+		}]]]));
+		expect(graph.callees.size).toBe(0);
+		expect(graph.callers.size).toBe(0);
+		expect(graph.coverage?.sameFileEvidence).toBe(1);
+	});
+
 	it("uses the file-level fallback after a completed function", () => {
 		const fileA = "/proj/a.ts";
 		const fileB = "/proj/b.ts";
@@ -828,4 +846,3 @@ describe("saveCallGraph / loadCallGraph", () => {
 		});
 	});
 });
-

--- a/tests/clients/lsp/edits.test.ts
+++ b/tests/clients/lsp/edits.test.ts
@@ -120,6 +120,28 @@ describe("LSP workspace edits", () => {
 		]);
 	});
 
+	it("merges divergent URI spellings into one conflict bucket", () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-lsp-uri-bucket-"));
+		try {
+			const filePath = path.join(tmpDir, "shared.ts");
+			fs.writeFileSync(filePath, "abcdef", "utf-8");
+			const uri = pathToFileURL(filePath).href;
+			const divergentUri = uri.replace(/\/([^/]+)$/, (_, name: string) =>
+				`/%${name.charCodeAt(0).toString(16).padStart(2, "0")}${name.slice(1)}`,
+			);
+			const edit = (newText: string) => ({ range: { start: { line: 0, character: 1 }, end: { line: 0, character: 4 } }, newText });
+			const result = mergeWorkspaceTextEditsByPriority([
+				{ serverId: "primary", edit: { changes: { [uri]: [edit("first")] } } },
+				{ serverId: "secondary", edit: { changes: { [divergentUri]: [edit("second")] } } },
+			]);
+			expect(divergentUri).not.toBe(uri);
+			expect(result.droppedConflicts).toBe(1);
+			expect(result.edit.changes).toEqual({ [uri]: [edit("first")] });
+		} finally {
+			removeTempDirSync(tmpDir);
+		}
+	});
+
 	it("collapses byte-identical non-empty duplicate edits", async () => {
 		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-lsp-edits-"));
 		const filePath = path.join(tmpDir, "duplicate.ts");


### PR DESCRIPTION
## Summary

- Re-key LSP workspace-edit flatten/merge/dedup buckets by `pathIndexKey`, preserving the first display URI per canonical file — divergent spellings of one file (`file:///c%3A/...` vs `file:///C:/...`) no longer land in separate buckets, so cross-server conflicting edits are detected instead of both applied.
- Normalize call-graph symbol/reference lookups and same-file/cross-file classification consistently; document the canonical-key contract on `allSymbols`/`allRefs` and dedupe the duplicated `STDLIB_NAMES` literals.
- Add divergent-URI and divergent-path regression tests.

Refs #1388 (the P1/P2 items — raw-URI edit-merge buckets and the call-graph key mix). Does not close it: #1388's P3a (codebase-model version/cache identity) remains.

## Verification

- `npm run build`
- targeted edits + call-graph suites: 2 files, 91 tests
- `npm run lint`
- mutation: raw URI bucketing fails the new regression as expected
