### PR TITLE
fix(memory): bound tier-1 heap caches with LRU + idle decay (refs #1389)

### DIFF
--- a/.changelog/fix-1389-tier1-cache-decay.md
+++ b/.changelog/fix-1389-tier1-cache-decay.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Bound and idle-evict review-graph workspaces and authoritative project snapshots (refs #1389).**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,14 @@ Rule-id normalization derives its language suffixes from the bundled CodeRabbit 
 
 Source-filter tests pin the ordering agreement between the forward precedence map, reverse source-twin candidates, and filesystem sibling resolution; the intentionally broad `.jsx` fallback remains part of that contract.
 
+Review-graph workspace caches and authoritative project snapshots are bounded to
+8 roots and use 20-minute per-root idle eviction by default. Their windows are
+env-tunable with `PI_LENS_REVIEW_GRAPH_IDLE_EVICT_MS` and
+`PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS`; graph eviction also drops completed
+build-dedup promises so the next access is a true cold rebuild. Async graph
+writes carry a per-workspace epoch, preventing an in-flight build from
+resurrecting an evicted entry. (#1389)
+
 LSP root exclusion recognizes fixture conventions by exact path segment; Go's
 `testdata` convention applies ancestor-wide, but names such as `testdata-tools`
 remain ordinary project directories. The positive `.gitignore` glob precheck is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,12 @@ This is the payoff of the two disciplines above: a bounded checklist of defect *
 
 ## What it is
 
+Review-graph workspace cache invalidation uses a process-wide epoch component
+that survives all-workspace clears; per-workspace eviction/reset increments the
+workspace component. Any new in-flight cache publication must capture and pass
+the combined epoch. Authoritative project-snapshot deletion goes through the
+single timer-clearing helper so idle timers cannot retain deleted generations.
+
 The review-graph size gate uses the shared cooperative source walker with a
 `maxFileCount + 1` sentinel: it stops at the first over-cap source entry, so
 skip telemetry and user-facing messages must describe the count as “more than

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -305,12 +305,59 @@ interface AuthoritativeSnapshotEntry {
 	 * mtime is `<=` this value.
 	 */
 	knownMtime: number;
+	lastUsedAt: number;
+	idleTimer?: ReturnType<typeof setTimeout>;
 }
 const authoritativeSnapshots = new Map<string, AuthoritativeSnapshotEntry>();
+const PROJECT_SNAPSHOT_MAX_WARM_ROOTS = 8;
+const PROJECT_SNAPSHOT_IDLE_EVICT_MS_DEFAULT = 20 * 60_000;
+
+function projectSnapshotIdleEvictMs(): number {
+	const value = Number.parseInt(process.env.PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS ?? "", 10);
+	return Number.isSafeInteger(value) && value > 0 ? value : PROJECT_SNAPSHOT_IDLE_EVICT_MS_DEFAULT;
+}
+
+function clearAuthoritativeSnapshotTimer(entry: AuthoritativeSnapshotEntry): void {
+	if (entry.idleTimer) clearTimeout(entry.idleTimer);
+	entry.idleTimer = undefined;
+}
+
+function scheduleAuthoritativeSnapshotEviction(key: string, entry: AuthoritativeSnapshotEntry): void {
+	clearAuthoritativeSnapshotTimer(entry);
+	const generation = entry.lastUsedAt;
+	entry.idleTimer = setTimeout(() => {
+		entry.idleTimer = undefined;
+		if (authoritativeSnapshots.get(key) !== entry || entry.lastUsedAt !== generation) return;
+		authoritativeSnapshots.delete(key);
+	}, projectSnapshotIdleEvictMs());
+	entry.idleTimer.unref?.();
+}
+
+function touchAuthoritativeSnapshot(key: string, entry: AuthoritativeSnapshotEntry): void {
+	entry.lastUsedAt = Date.now();
+	scheduleAuthoritativeSnapshotEviction(key, entry);
+}
+
+function enforceAuthoritativeSnapshotCap(): void {
+	while (authoritativeSnapshots.size > PROJECT_SNAPSHOT_MAX_WARM_ROOTS) {
+		const victim = [...authoritativeSnapshots.entries()].sort(([, a], [, b]) => a.lastUsedAt - b.lastUsedAt)[0];
+		if (!victim) return;
+		clearAuthoritativeSnapshotTimer(victim[1]);
+		authoritativeSnapshots.delete(victim[0]);
+	}
+}
+
+/** Test-only cache keys, in LRU order from oldest to newest. */
+export function _getAuthoritativeSnapshotCacheKeysForTests(): string[] {
+	return [...authoritativeSnapshots.entries()]
+		.sort(([, a], [, b]) => a.lastUsedAt - b.lastUsedAt)
+		.map(([key]) => key);
+}
 
 /** Test hook: drop all cached parses + authoritative writes (per-worker isolation). */
 export function _resetProjectSnapshotParseCacheForTests(): void {
 	snapshotParseCache.clear();
+	for (const entry of authoritativeSnapshots.values()) clearAuthoritativeSnapshotTimer(entry);
 	authoritativeSnapshots.clear();
 }
 
@@ -424,6 +471,7 @@ function loadProjectSnapshotInternal(
 	if (authoritative) {
 		const diskMtime = body ? body.mtimeMs : Number.NEGATIVE_INFINITY;
 		if (diskMtime <= authoritative.knownMtime) {
+			touchAuthoritativeSnapshot(key, authoritative);
 			return authoritative.snapshot;
 		}
 		// An external writer moved past our write — honor disk and stop
@@ -927,7 +975,14 @@ export function saveProjectSnapshot(
 	// legacy body to a merge-consumer, silently dropping this snapshot's fields.
 	const priorBody = resolveSnapshotBodyPath(cwd);
 	const knownMtime = priorBody ? priorBody.mtimeMs : Number.NEGATIVE_INFINITY;
-	authoritativeSnapshots.set(key, { snapshot, knownMtime });
+	const authoritativeEntry: AuthoritativeSnapshotEntry = {
+		snapshot,
+		knownMtime,
+		lastUsedAt: Date.now(),
+	};
+	authoritativeSnapshots.set(key, authoritativeEntry);
+	scheduleAuthoritativeSnapshotEviction(key, authoritativeEntry);
+	enforceAuthoritativeSnapshotCap();
 	// A stale disk-parse-cache entry for this path must not out-vote the fresh
 	// authoritative write once the latter is dropped (oversized bodies).
 	snapshotParseCache.delete(gzPath);

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -322,13 +322,19 @@ function clearAuthoritativeSnapshotTimer(entry: AuthoritativeSnapshotEntry): voi
 	entry.idleTimer = undefined;
 }
 
+function deleteAuthoritativeSnapshot(key: string): void {
+	const entry = authoritativeSnapshots.get(key);
+	if (entry) clearAuthoritativeSnapshotTimer(entry);
+	authoritativeSnapshots.delete(key);
+}
+
 function scheduleAuthoritativeSnapshotEviction(key: string, entry: AuthoritativeSnapshotEntry): void {
 	clearAuthoritativeSnapshotTimer(entry);
 	const generation = entry.lastUsedAt;
 	entry.idleTimer = setTimeout(() => {
 		entry.idleTimer = undefined;
 		if (authoritativeSnapshots.get(key) !== entry || entry.lastUsedAt !== generation) return;
-		authoritativeSnapshots.delete(key);
+		deleteAuthoritativeSnapshot(key);
 	}, projectSnapshotIdleEvictMs());
 	entry.idleTimer.unref?.();
 }
@@ -343,7 +349,7 @@ function enforceAuthoritativeSnapshotCap(): void {
 		const victim = [...authoritativeSnapshots.entries()].sort(([, a], [, b]) => a.lastUsedAt - b.lastUsedAt)[0];
 		if (!victim) return;
 		clearAuthoritativeSnapshotTimer(victim[1]);
-		authoritativeSnapshots.delete(victim[0]);
+		deleteAuthoritativeSnapshot(victim[0]);
 	}
 }
 
@@ -476,7 +482,7 @@ function loadProjectSnapshotInternal(
 		}
 		// An external writer moved past our write — honor disk and stop
 		// serving the now-stale in-memory object.
-		authoritativeSnapshots.delete(key);
+		deleteAuthoritativeSnapshot(key);
 	}
 	if (!body) {
 		snapshotParseCache.delete(getProjectSnapshotPath(cwd));
@@ -571,7 +577,7 @@ function recordSnapshotPersistFailure(cwd: string, error: string): void {
 	// seq), and dropping the authoritative entry means the next load reflects
 	// what is ACTUALLY on disk rather than the object we failed to persist.
 	_lastSnapshotPersistErrorForTests = error;
-	authoritativeSnapshots.delete(normalizeMapKey(cwd));
+	deleteAuthoritativeSnapshot(normalizeMapKey(cwd));
 	logLatency({
 		type: "phase",
 		phase: "project_snapshot_persist_failed",
@@ -632,7 +638,7 @@ function reconcileAuthoritativeAfterWrite(
 		} catch {
 			// A cache miss is safe: the first metadata consumer reconstructs it.
 		}
-		authoritativeSnapshots.delete(pending.key);
+		deleteAuthoritativeSnapshot(pending.key);
 		logLatency({
 			type: "phase",
 			phase: "project_snapshot_word_index_released",
@@ -652,7 +658,7 @@ function reconcileAuthoritativeAfterWrite(
 			durationMs: 0,
 			metadata: { rawBytes, maxBytes: SNAPSHOT_PARSE_CACHE_MAX_BYTES },
 		});
-		authoritativeSnapshots.delete(pending.key);
+		deleteAuthoritativeSnapshot(pending.key);
 		return;
 	}
 	try {

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -156,9 +156,7 @@ const extractorCache = new Map<string, TreeSitterSymbolExtractor | null>();
 // invocation. A separate workspace cache below preserves the expensive parsed
 // graph across invocations when source file mtimes/sizes have not changed.
 const _buildCache = new Map<string, Promise<ReviewGraph>>();
-const _workspaceGraphCache = new Map<
-	string,
-	{
+interface WorkspaceGraphCacheEntry {
 		signature: string;
 		fileSignatures: Map<string, string>;
 		fileHashes?: Map<string, string>;
@@ -176,8 +174,67 @@ const _workspaceGraphCache = new Map<
 		fastPathSinceVerify?: number;
 		/** #459: generation of this entry's graph content — see ReviewGraph.buildGeneration. */
 		buildGeneration?: number;
+		lastUsedAt: number;
+		idleTimer?: ReturnType<typeof setTimeout>;
+}
+const _workspaceGraphCache = new Map<string, WorkspaceGraphCacheEntry>();
+const REVIEW_GRAPH_MAX_WARM_WORKSPACES = 8;
+const REVIEW_GRAPH_IDLE_EVICT_MS_DEFAULT = 20 * 60_000;
+const _workspaceCacheEpochs = new Map<string, number>();
+
+function reviewGraphIdleEvictMs(): number {
+	const value = Number.parseInt(process.env.PI_LENS_REVIEW_GRAPH_IDLE_EVICT_MS ?? "", 10);
+	return Number.isSafeInteger(value) && value > 0 ? value : REVIEW_GRAPH_IDLE_EVICT_MS_DEFAULT;
+}
+
+function clearWorkspaceGraphTimer(entry: { idleTimer?: ReturnType<typeof setTimeout> }): void {
+	if (entry.idleTimer) clearTimeout(entry.idleTimer);
+	entry.idleTimer = undefined;
+}
+
+function evictWorkspaceGraph(key: string, entry: WorkspaceGraphCacheEntry): void {
+	if (_workspaceGraphCache.get(key) !== entry) return;
+	clearWorkspaceGraphTimer(entry);
+	for (const buildKey of _buildCache.keys()) {
+		const separator = buildKey.indexOf("|");
+		if (separator >= 0 && normalizeMapKey(buildKey.slice(0, separator)) === key) {
+			_buildCache.delete(buildKey);
+		}
 	}
->();
+	_workspaceCacheEpochs.set(key, (_workspaceCacheEpochs.get(key) ?? 0) + 1);
+	_workspaceGraphCache.delete(key);
+}
+
+function scheduleWorkspaceGraphEviction(key: string, entry: WorkspaceGraphCacheEntry): void {
+	clearWorkspaceGraphTimer(entry);
+	const epoch = _workspaceCacheEpochs.get(key) ?? 0;
+	entry.idleTimer = setTimeout(() => {
+		entry.idleTimer = undefined;
+		if (_workspaceGraphCache.get(key) !== entry || (_workspaceCacheEpochs.get(key) ?? 0) !== epoch) return;
+		evictWorkspaceGraph(key, entry);
+	}, reviewGraphIdleEvictMs());
+	entry.idleTimer.unref?.();
+}
+
+function touchWorkspaceGraph(key: string): void {
+	const entry = _workspaceGraphCache.get(key);
+	if (!entry) return;
+	entry.lastUsedAt = Date.now();
+	scheduleWorkspaceGraphEviction(key, entry);
+}
+
+function setWorkspaceGraph(key: string, entry: Omit<WorkspaceGraphCacheEntry, "lastUsedAt" | "idleTimer">, epoch?: number): boolean {
+	if (epoch !== undefined && (_workspaceCacheEpochs.get(key) ?? 0) !== epoch) return false;
+	const resident: WorkspaceGraphCacheEntry = { ...entry, lastUsedAt: Date.now() };
+	_workspaceGraphCache.set(key, resident);
+	scheduleWorkspaceGraphEviction(key, resident);
+	while (_workspaceGraphCache.size > REVIEW_GRAPH_MAX_WARM_WORKSPACES) {
+		const victim = [..._workspaceGraphCache.entries()].sort(([, a], [, b]) => a.lastUsedAt - b.lastUsedAt)[0];
+		if (!victim) break;
+		evictWorkspaceGraph(victim[0], victim[1]);
+	}
+	return true;
+}
 
 // #459: process-wide monotonic source for ReviewGraph.buildGeneration stamps.
 // Never reset (uniqueness is the invariant — a workspace-cache clear must not
@@ -330,7 +387,9 @@ export function clearGraphCache(): void {
 export function clearReviewGraphWorkspaceCache(cwd?: string): void {
 	if (cwd === undefined) {
 		_buildCache.clear();
+		for (const entry of _workspaceGraphCache.values()) clearWorkspaceGraphTimer(entry);
 		_workspaceGraphCache.clear();
+		_workspaceCacheEpochs.clear();
 		_sizeSkipVerdicts.clear();
 	} else {
 		const normalized = normalizeMapKey(cwd);
@@ -339,6 +398,9 @@ export function clearReviewGraphWorkspaceCache(cwd?: string): void {
 				_buildCache.delete(key);
 			}
 		}
+		const entry = _workspaceGraphCache.get(normalized);
+		if (entry) clearWorkspaceGraphTimer(entry);
+		_workspaceCacheEpochs.set(normalized, (_workspaceCacheEpochs.get(normalized) ?? 0) + 1);
 		_workspaceGraphCache.delete(normalized);
 		_sizeSkipVerdicts.delete(normalized);
 	}
@@ -379,6 +441,13 @@ export function getReviewGraphWorkspaceCacheSnapshot(): ReviewGraphWorkspaceCach
 	};
 }
 
+/** Test-only cache keys, including the LRU order from oldest to newest. */
+export function _getReviewGraphWorkspaceCacheKeysForTests(): string[] {
+	return [..._workspaceGraphCache.entries()]
+		.sort(([, a], [, b]) => a.lastUsedAt - b.lastUsedAt)
+		.map(([key]) => key);
+}
+
 export function _getReviewGraphCacheStateForTests(cwd: string):
 	| {
 			signature: string;
@@ -388,6 +457,7 @@ export function _getReviewGraphCacheStateForTests(cwd: string):
 	| undefined {
 	const cached = _workspaceGraphCache.get(normalizeMapKey(cwd));
 	if (!cached) return undefined;
+	touchWorkspaceGraph(normalizeMapKey(cwd));
 	return {
 		signature: cached.signature,
 		fileSignatures: new Map(cached.fileSignatures),
@@ -415,6 +485,7 @@ export function getReviewGraphCacheIdentity(
 ): ReviewGraphCacheIdentity | undefined {
 	const cached = _workspaceGraphCache.get(normalizeMapKey(cwd));
 	if (!cached) return undefined;
+	touchWorkspaceGraph(normalizeMapKey(cwd));
 	// #1088: `version` is the constant schema tag ("v8" today) — identical for
 	// every live graph, so comparing it can never detect that `graph` is a
 	// stale instance the workspace cache has since replaced (e.g. a concurrent
@@ -526,6 +597,7 @@ export function getCachedReviewGraph(cwd: string): ReviewGraph | undefined {
 	if (getReviewGraphSizeSkipVerdict(cwd)) return undefined;
 	const cached = _workspaceGraphCache.get(key);
 	if (cached) {
+		touchWorkspaceGraph(key);
 		ensureIndexed(cached.graph);
 		return cached.graph;
 	}
@@ -542,7 +614,7 @@ export function getCachedReviewGraph(cwd: string): ReviewGraph | undefined {
 		allowPartial: true,
 	});
 	if (!disk) return undefined;
-	_workspaceGraphCache.set(key, {
+	setWorkspaceGraph(key, {
 		signature: disk.signature,
 		fileSignatures: disk.fileSignatures,
 		fileHashes: disk.fileHashes,
@@ -4059,6 +4131,7 @@ interface IncrementalCtx {
 	seqAtBuildStart?: number;
 	/** #694: untracked-AND-ignored ids, fetched once per build — see `_doBuildGraph`. */
 	ignoredIds?: ReadonlySet<string>;
+	cacheEpoch?: number;
 }
 
 /**
@@ -4132,14 +4205,14 @@ async function tryIncrementalFromCache(
 		for (const file of ctx.normalizedChanged) {
 			upsertChangedSymbols(graph, ctx.facts, file);
 		}
-		_workspaceGraphCache.set(ctx.normalizedCwd, {
+		setWorkspaceGraph(ctx.normalizedCwd, {
 			signature: ctx.signature,
 			fileSignatures: new Map(ctx.fileSignatures),
 			fileHashes: hashes,
 			graph: cloneGraph(cached.graph),
 			buildGeneration: generation,
 			...verifiedCacheFields(ctx.seqAtBuildStart),
-		});
+		}, ctx.cacheEpoch);
 		// #260: pure drift leaves the graph unchanged — don't rewrite the disk blob.
 		setGraphBuildInfo(graph, {
 			reused: true,
@@ -4171,14 +4244,14 @@ async function tryIncrementalFromCache(
 	// #459: real re-extract ⇒ new generation.
 	const generation = ++_graphGenerationCounter;
 	graph.buildGeneration = generation;
-	_workspaceGraphCache.set(ctx.normalizedCwd, {
+	setWorkspaceGraph(ctx.normalizedCwd, {
 		signature: ctx.signature,
 		fileSignatures: new Map(ctx.fileSignatures),
 		fileHashes: hashes,
 		graph,
 		buildGeneration: generation,
 		...verifiedCacheFields(ctx.seqAtBuildStart),
-	});
+	}, ctx.cacheEpoch);
 	const persistReason = persistGraph(
 		ctx.cwd,
 		ctx.signature,
@@ -4232,6 +4305,7 @@ async function trySeqFastpath(
 	seqHint: GraphSeqHint,
 	seqAtBuildStart: number,
 	ignoredIds?: ReadonlySet<string>,
+	cacheEpoch?: number,
 ): Promise<SeqFastpathResult> {
 	const cached = _workspaceGraphCache.get(normalizedCwd);
 	// Condition 2: need an in-process complete entry that recorded a build seq.
@@ -4373,7 +4447,7 @@ async function trySeqFastpath(
 	// #459: real re-extract ⇒ new generation.
 	const generation = ++_graphGenerationCounter;
 	graph.buildGeneration = generation;
-	_workspaceGraphCache.set(normalizedCwd, {
+	setWorkspaceGraph(normalizedCwd, {
 		signature: nextSignature,
 		fileSignatures: nextSignatures,
 		fileHashes: hashes,
@@ -4384,7 +4458,7 @@ async function trySeqFastpath(
 		builtAtProjectSeq: seqAtBuildStart,
 		lastFullVerifyMs: cached.lastFullVerifyMs,
 		fastPathSinceVerify: sinceVerify + 1,
-	});
+	}, cacheEpoch);
 	const persistReason = persistGraph(
 		cwd,
 		nextSignature,
@@ -4422,6 +4496,7 @@ async function _doBuildGraph(
 	buildId?: number,
 ): Promise<ReviewGraph> {
 	const normalizedCwd = normalizeMapKey(cwd);
+	const cacheEpoch = _workspaceCacheEpochs.get(normalizedCwd) ?? 0;
 	const normalizedChanged = changedFiles.map((file) => normalizeMapKey(file));
 	const normalizedChangedSet = new Set(normalizedChanged);
 	logCwdWorktreeMismatchOnce(cwd);
@@ -4490,6 +4565,7 @@ async function _doBuildGraph(
 			seqHint,
 			seqAtBuildStart,
 			await ignoredIdsPromise,
+			cacheEpoch,
 		);
 		if ("graph" in fast) return fast.graph;
 		seqFastpathFallback = fast.fallback;
@@ -4622,6 +4698,7 @@ async function _doBuildGraph(
 			facts,
 			seqAtBuildStart,
 			ignoredIds,
+			cacheEpoch,
 		});
 		if (incremental) {
 			updateGraphBuildInfo(incremental, { seqFastpathFallback });
@@ -4646,14 +4723,14 @@ async function _doBuildGraph(
 		// process's derived caches don't exist here; in-process derived caches from
 		// before a workspace-cache clear must not match it).
 		const generation = ++_graphGenerationCounter;
-		_workspaceGraphCache.set(normalizedCwd, {
+		setWorkspaceGraph(normalizedCwd, {
 			signature,
 			fileSignatures: new Map(fileSignatures),
 			fileHashes: diskCached.fileHashes,
 			graph: cloneGraph(diskCached.graph),
 			buildGeneration: generation,
 			...verifiedCacheFields(seqAtBuildStart),
-		});
+		}, cacheEpoch);
 		setGraphBuildInfo(graph, {
 			reused: true,
 			mode: "cached",
@@ -4846,14 +4923,14 @@ async function _doBuildGraph(
 	// Keep the content generation on the persisted snapshot instance too, so
 	// scheduled persistence logs join the same graph identity as build success.
 	graphSnapshot.buildGeneration = generation;
-	_workspaceGraphCache.set(normalizedCwd, {
+	setWorkspaceGraph(normalizedCwd, {
 		signature,
 		fileSignatures: new Map(fileSignatures),
 		fileHashes,
 		graph: graphSnapshot,
 		buildGeneration: generation,
 		...verifiedCacheFields(seqAtBuildStart),
-	});
+	}, cacheEpoch);
 	const persistReason = persistGraph(
 		cwd,
 		signature,

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -180,7 +180,15 @@ interface WorkspaceGraphCacheEntry {
 const _workspaceGraphCache = new Map<string, WorkspaceGraphCacheEntry>();
 const REVIEW_GRAPH_MAX_WARM_WORKSPACES = 8;
 const REVIEW_GRAPH_IDLE_EVICT_MS_DEFAULT = 20 * 60_000;
+// A workspace-wide clear must invalidate builds for workspaces that are not
+// resident yet, too. This process-wide component therefore survives cache
+// deletion; per-workspace eviction/reset increments the map component below.
+let _workspaceCacheEpoch = 0;
 const _workspaceCacheEpochs = new Map<string, number>();
+
+function workspaceCacheEpoch(key: string): number {
+	return _workspaceCacheEpoch + (_workspaceCacheEpochs.get(key) ?? 0);
+}
 
 function reviewGraphIdleEvictMs(): number {
 	const value = Number.parseInt(process.env.PI_LENS_REVIEW_GRAPH_IDLE_EVICT_MS ?? "", 10);
@@ -207,10 +215,10 @@ function evictWorkspaceGraph(key: string, entry: WorkspaceGraphCacheEntry): void
 
 function scheduleWorkspaceGraphEviction(key: string, entry: WorkspaceGraphCacheEntry): void {
 	clearWorkspaceGraphTimer(entry);
-	const epoch = _workspaceCacheEpochs.get(key) ?? 0;
+	const epoch = workspaceCacheEpoch(key);
 	entry.idleTimer = setTimeout(() => {
 		entry.idleTimer = undefined;
-		if (_workspaceGraphCache.get(key) !== entry || (_workspaceCacheEpochs.get(key) ?? 0) !== epoch) return;
+		if (_workspaceGraphCache.get(key) !== entry || workspaceCacheEpoch(key) !== epoch) return;
 		evictWorkspaceGraph(key, entry);
 	}, reviewGraphIdleEvictMs());
 	entry.idleTimer.unref?.();
@@ -224,7 +232,7 @@ function touchWorkspaceGraph(key: string): void {
 }
 
 function setWorkspaceGraph(key: string, entry: Omit<WorkspaceGraphCacheEntry, "lastUsedAt" | "idleTimer">, epoch?: number): boolean {
-	if (epoch !== undefined && (_workspaceCacheEpochs.get(key) ?? 0) !== epoch) return false;
+	if (epoch !== undefined && workspaceCacheEpoch(key) !== epoch) return false;
 	const resident: WorkspaceGraphCacheEntry = { ...entry, lastUsedAt: Date.now() };
 	_workspaceGraphCache.set(key, resident);
 	scheduleWorkspaceGraphEviction(key, resident);
@@ -389,7 +397,7 @@ export function clearReviewGraphWorkspaceCache(cwd?: string): void {
 		_buildCache.clear();
 		for (const entry of _workspaceGraphCache.values()) clearWorkspaceGraphTimer(entry);
 		_workspaceGraphCache.clear();
-		_workspaceCacheEpochs.clear();
+		_workspaceCacheEpoch++;
 		_sizeSkipVerdicts.clear();
 	} else {
 		const normalized = normalizeMapKey(cwd);
@@ -408,6 +416,15 @@ export function clearReviewGraphWorkspaceCache(cwd?: string): void {
 	// #1179: the global slot is back to the pristine default, so a subsequent
 	// identity miss can safely serve it again (it cannot be a sibling's state).
 	_anyGraphStamped = false;
+}
+
+let _reviewGraphBuildGateForTests: (() => Promise<void>) | undefined;
+
+/** Test seam for deterministically interleaving a build with cache eviction. */
+export function _setReviewGraphBuildGateForTests(
+	gate: (() => Promise<void>) | undefined,
+): void {
+	_reviewGraphBuildGateForTests = gate;
 }
 
 export interface ReviewGraphWorkspaceCacheSnapshot {
@@ -4496,7 +4513,8 @@ async function _doBuildGraph(
 	buildId?: number,
 ): Promise<ReviewGraph> {
 	const normalizedCwd = normalizeMapKey(cwd);
-	const cacheEpoch = _workspaceCacheEpochs.get(normalizedCwd) ?? 0;
+	const cacheEpoch = workspaceCacheEpoch(normalizedCwd);
+	await _reviewGraphBuildGateForTests?.();
 	const normalizedChanged = changedFiles.map((file) => normalizeMapKey(file));
 	const normalizedChangedSet = new Set(normalizedChanged);
 	logCwdWorktreeMismatchOnce(cwd);
@@ -4662,6 +4680,7 @@ async function _doBuildGraph(
 	// base too, so the build falls through to a full rebuild.
 	if (memCached?.graph.persistCoverage?.partial) memCached = undefined;
 	if (memCached?.signature === signature) {
+		touchWorkspaceGraph(normalizedCwd);
 		const graph = cloneGraph(memCached.graph);
 		rebuildIndexes(graph);
 		graph.changedSymbolsByFile.clear();

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -4514,7 +4514,10 @@ async function _doBuildGraph(
 ): Promise<ReviewGraph> {
 	const normalizedCwd = normalizeMapKey(cwd);
 	const cacheEpoch = workspaceCacheEpoch(normalizedCwd);
-	await _reviewGraphBuildGateForTests?.();
+	// `await undefined` still yields a microtask, which reorders overlapping
+	// builds in production where no test gate is installed — only await a gate
+	// that exists.
+	if (_reviewGraphBuildGateForTests) await _reviewGraphBuildGateForTests();
 	const normalizedChanged = changedFiles.map((file) => normalizeMapKey(file));
 	const normalizedChangedSet = new Set(normalizedChanged);
 	logCwdWorktreeMismatchOnce(cwd);

--- a/tests/clients/graph-cache.test.ts
+++ b/tests/clients/graph-cache.test.ts
@@ -11,6 +11,7 @@ import {
 	getReviewGraphCacheIdentity,
 	getReviewGraphWorkspaceCacheSnapshot,
 	_getReviewGraphWorkspaceCacheKeysForTests,
+	_setReviewGraphBuildGateForTests,
 } from "../../clients/review-graph/builder.js";
 import { normalizeMapKey } from "../../clients/path-utils.js";
 import {
@@ -35,10 +36,37 @@ describe("buildOrUpdateGraph — Promise dedup cache", () => {
 	});
 
 	afterEach(() => {
+		_setReviewGraphBuildGateForTests(undefined);
 		vi.unstubAllEnvs();
 		for (const dir of dirs.splice(0)) {
 			removeTempDirSync(dir);
 		}
+	});
+
+	it("does not resurrect a build captured before an all-workspace reset", async () => {
+		const cwd = tmpDir();
+		const facts = new FactStore();
+		let release!: () => void;
+		const admitted = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		let entered!: () => void;
+		const started = new Promise<void>((resolve) => {
+			entered = resolve;
+		});
+		_setReviewGraphBuildGateForTests(async () => {
+			entered();
+			await admitted;
+		});
+
+		const build = buildOrUpdateGraph(cwd, [], facts);
+		await started;
+		clearReviewGraphWorkspaceCache();
+		release();
+
+		const graph = await build;
+		expect(graph).toHaveProperty("nodes");
+		expect(getReviewGraphWorkspaceCacheSnapshot().cacheEntries).toBe(0);
 	});
 
 	function tmpDir(): string {

--- a/tests/clients/graph-cache.test.ts
+++ b/tests/clients/graph-cache.test.ts
@@ -9,7 +9,10 @@ import {
 	clearReviewGraphWorkspaceCache,
 	getLastGraphBuildInfo,
 	getReviewGraphCacheIdentity,
+	getReviewGraphWorkspaceCacheSnapshot,
+	_getReviewGraphWorkspaceCacheKeysForTests,
 } from "../../clients/review-graph/builder.js";
+import { normalizeMapKey } from "../../clients/path-utils.js";
 import {
 	createTempFile,
 	removeTempDirSync,
@@ -51,6 +54,35 @@ describe("buildOrUpdateGraph — Promise dedup cache", () => {
 		const p2 = buildOrUpdateGraph(cwd, [path.join(cwd, "a.ts")], facts);
 		expect(p1).toBe(p2);
 		await p1;
+	});
+
+	it("evicts an idle workspace and rebuilds it", async () => {
+		vi.useFakeTimers();
+		vi.stubEnv("PI_LENS_REVIEW_GRAPH_IDLE_EVICT_MS", "1000");
+		const cwd = tmpDir();
+		const facts = new FactStore();
+		const first = await buildOrUpdateGraph(cwd, [], facts);
+		expect(getReviewGraphWorkspaceCacheSnapshot().cacheEntries).toBe(1);
+		vi.advanceTimersByTime(1001);
+		expect(getReviewGraphWorkspaceCacheSnapshot().cacheEntries).toBe(0);
+		const second = await buildOrUpdateGraph(cwd, [], facts);
+		expect(second).not.toBe(first);
+		expect(second.nodes.size).toBe(first.nodes.size);
+		vi.useRealTimers();
+	});
+
+	it("keeps the eight most recently used workspaces", async () => {
+		const facts = new FactStore();
+		const roots: string[] = [];
+		for (let i = 0; i < 9; i++) {
+			const cwd = tmpDir();
+			roots.push(cwd);
+			await buildOrUpdateGraph(cwd, [], facts);
+		}
+		const keys = _getReviewGraphWorkspaceCacheKeysForTests();
+		expect(keys).toHaveLength(8);
+		expect(keys).not.toContain(normalizeMapKey(roots[0]));
+		expect(keys).toContain(normalizeMapKey(roots[8]));
 	});
 
 	it("normalises changedFiles order — same promise regardless of sort order", async () => {

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -32,6 +32,7 @@ vi.mock("../../clients/atomic-write.js", async (importOriginal) => {
 import {
 	PROJECT_SNAPSHOT_VERSION,
 	_resetProjectSnapshotParseCacheForTests,
+	_getAuthoritativeSnapshotCacheKeysForTests,
 	buildProjectSnapshotFromRuntime,
 	flushProjectSnapshotPersistsForTests,
 	getProjectSnapshotLegacyPath,
@@ -51,6 +52,7 @@ import {
 	terminateProjectSnapshotPersistWorkerForTests,
 	waitForProjectSnapshotPersistsForTests,
 } from "../../clients/project-snapshot.js";
+import type { ProjectSnapshot } from "../../clients/project-snapshot.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { buildWordIndex, searchWordIndex } from "../../clients/word-index.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
@@ -137,6 +139,29 @@ describe("project snapshot", () => {
 				cachedExports: [["makeThing", path.join(cwd, "src", "a.ts")]],
 			});
 			expect(isProjectSnapshotFresh(loaded, 7)).toBe(true);
+		}));
+
+	it("bounds and idles authoritative snapshots", () =>
+		withProjectDataDir((cwd) => {
+			vi.useFakeTimers();
+			vi.stubEnv("PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS", "1000");
+			const makeSnapshot = (root: string): ProjectSnapshot => ({
+				version: PROJECT_SNAPSHOT_VERSION,
+				projectRoot: root,
+				generatedAt: new Date().toISOString(),
+				seq: 0,
+				files: {},
+				symbols: {},
+				reverseDeps: {},
+				cachedExports: [],
+			});
+			for (let i = 0; i < 9; i++) saveProjectSnapshot(path.join(cwd, `root-${i}`), makeSnapshot(path.join(cwd, `root-${i}`)));
+			const keys = _getAuthoritativeSnapshotCacheKeysForTests();
+			expect(keys).toHaveLength(8);
+			expect(keys[0]).toContain("root-1");
+			vi.advanceTimersByTime(1001);
+			expect(_getAuthoritativeSnapshotCacheKeysForTests()).toHaveLength(0);
+			vi.useRealTimers();
 		}));
 
 	it("embeds the derived sequence index in BOTH the body and the meta sidecar (#1019)", () =>

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -164,6 +164,33 @@ describe("project snapshot", () => {
 			vi.useRealTimers();
 		}));
 
+	it("clears the idle timer when an authoritative entry is deleted", () =>
+		withProjectDataDir((cwd) => {
+			vi.useFakeTimers();
+			vi.stubEnv("PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS", "1000");
+			const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+			const snapshot: ProjectSnapshot = {
+				version: PROJECT_SNAPSHOT_VERSION,
+				projectRoot: cwd,
+				generatedAt: new Date().toISOString(),
+				seq: 0,
+				files: {},
+				symbols: {},
+				reverseDeps: {},
+				cachedExports: [],
+			};
+			saveProjectSnapshot(cwd, snapshot);
+			const bodyPath = getProjectSnapshotPath(cwd);
+			const future = new Date(Date.now() + 10_000);
+			fs.utimesSync(bodyPath, future, future);
+			expect(loadProjectSnapshot(cwd)).not.toBeNull();
+			expect(clearTimeoutSpy).toHaveBeenCalled();
+
+			vi.advanceTimersByTime(1001);
+			expect(_getAuthoritativeSnapshotCacheKeysForTests()).toEqual([]);
+			vi.useRealTimers();
+		}));
+
 	it("embeds the derived sequence index in BOTH the body and the meta sidecar (#1019)", () =>
 		withProjectDataDir((cwd) => {
 			// A runtime with a real per-file sequence state at seq=3.


### PR DESCRIPTION
## Summary

- Add 8-root LRU caps and 20-minute (env-tunable) per-root idle decay to the review-graph workspace cache and the authoritative project-snapshot cache — the two largest heap retainers from the #1389 audit.
- Preserve existing freshness/generation guards; a per-workspace epoch prevents an in-flight build from resurrecting an evicted entry, and every snapshot-deletion site clears its idle timer.
- Add idle-recovery and LRU regression coverage (eviction → cold rebuild returns equivalent data).

Refs #1389 (Tier 1 only). Does not close it: Tiers 2–3 (read-guard, tree-sitter query caches, workspace-topology, and the smaller batchable caches) remain.

## Validation

- `npm run build`
- targeted Vitest: 8 cache suites + persist suite green
- `npm run lint`
