### PR TITLE
perf(startup): lazy-load dispatch/LSP/formatter subsystems with session-start warm (refs #1394)

### DIFF
--- a/.changelog/perf-1394-lazy-load-phase2.md
+++ b/.changelog/perf-1394-lazy-load-phase2.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Warm dispatch, LSP async consumers, and formatter catalog lazily at session start (refs #1394 — Phase 2).**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,12 @@ empty result, while the project ignore matcher remains authoritative.
 
 A pi coding-agent extension that runs automated checks on every file write/edit. Dispatches async parallel runners (LSP, biome, ruff, ast-grep, tree-sitter, jscpd, knip, Madge, and language-specific linters/build checks) and injects findings as context injections at turn-end and session-start.
 
+Startup lazy-loading (#1394 Phase 2): the dispatch runner graph is loaded through
+`clients/dispatch/lazy.ts`. Session-start callers may warm its shared promise
+without awaiting it; the per-edit pipeline must await that same promise before
+dispatch or cascade work. Keep host registrations eager and never create a
+second warm promise for concurrent/subagent session starts.
+
 The git guard's command-position classifier expands `$IFS`, `${IFS}`, and
 `$IFS$<positional>` forms before re-tokenizing guarded verbs. Known command-string
 launchers include shell families plus busybox, toybox, and nix-shell; an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,9 @@ Startup lazy-loading (#1394 Phase 2): the dispatch runner graph is loaded throug
 without awaiting it; the per-edit pipeline must await that same promise before
 dispatch or cascade work. Keep host registrations eager and never create a
 second warm promise for concurrent/subagent session starts.
+The formatter catalog follows the same rule through `clients/formatters-lazy.ts`;
+`format-service.ts` must await that shared promise before catalog lookup or
+formatter execution.
 
 The git guard's command-position classifier expands `$IFS`, `${IFS}`, and
 `$IFS$<positional>` forms before re-tokenizing guarded verbs. Known command-string

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,9 @@ second warm promise for concurrent/subagent session starts.
 The formatter catalog follows the same rule through `clients/formatters-lazy.ts`;
 `format-service.ts` must await that shared promise before catalog lookup or
 formatter execution.
+The LSP service follows it through `clients/lsp-lazy.ts`; service consumers in
+the entry graph await that promise at request/use sites while registration and
+the session-start warm kickoff remain eager/synchronous at the host boundary.
 
 The git guard's command-position classifier expands `$IFS`, `${IFS}`, and
 `$IFS$<positional>` forms before re-tokenizing guarded verbs. Known command-string

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,9 +269,10 @@ second warm promise for concurrent/subagent session starts.
 The formatter catalog follows the same rule through `clients/formatters-lazy.ts`;
 `format-service.ts` must await that shared promise before catalog lookup or
 formatter execution.
-The LSP service follows it through `clients/lsp-lazy.ts`; service consumers in
-the entry graph await that promise at request/use sites while registration and
-the session-start warm kickoff remain eager/synchronous at the host boundary.
+The LSP service follows it through `clients/lsp-lazy.ts` for async pipeline,
+session, and warm-attach consumers. The `index.ts` status/reset adapter remains
+eager because its synchronous shutdown/status contracts are host-visible; do
+not make those callbacks async without updating their ordering contract/tests.
 
 The git guard's command-position classifier expands `$IFS`, `${IFS}`, and
 `$IFS$<positional>` forms before re-tokenizing guarded verbs. Known command-string

--- a/clients/dispatch/lazy.ts
+++ b/clients/dispatch/lazy.ts
@@ -1,0 +1,20 @@
+/** Lazy dispatch integration seam for startup-cost control (#1394). */
+
+type DispatchIntegration = typeof import("./integration.js");
+
+let integrationPromise: Promise<DispatchIntegration> | undefined;
+
+/** Start loading the runner graph once; callers may fire-and-forget this. */
+export function warmDispatchIntegration(): Promise<DispatchIntegration> {
+	return (integrationPromise ??= import("./integration.js"));
+}
+
+/** Await the same promise used by session-start warming and first use. */
+export function loadDispatchIntegration(): Promise<DispatchIntegration> {
+	return warmDispatchIntegration();
+}
+
+/** Test-only reset; production sessions intentionally retain the promise. */
+export function resetDispatchIntegrationForTests(): void {
+	integrationPromise = undefined;
+}

--- a/clients/format-service.ts
+++ b/clients/format-service.ts
@@ -15,13 +15,8 @@ import { logExtension } from "./extension-log.js";
 import * as path from "node:path";
 import { recordFormatter } from "./widget-state.js";
 import { FileTime } from "./file-time.js";
-import {
-	clearFormatterRuntimeState,
-	type FormatterInfo,
-	type FormatterResult,
-	formatFile,
-	getFormattersForFile,
-} from "./formatters.js";
+import type { FormatterInfo, FormatterResult } from "./formatters.js";
+import { loadFormatters } from "./formatters-lazy.js";
 
 // --- Configuration ---
 
@@ -99,7 +94,7 @@ export class FormatService {
 		// Get formatters for this file
 		const formatters = options.formatters
 			? await this.getFormattersByName(options.formatters)
-			: await getFormattersForFile(absolutePath, cwd);
+			: await (await loadFormatters()).getFormattersForFile(absolutePath, cwd);
 
 		if (formatters.length === 0) {
 			return {
@@ -177,7 +172,7 @@ export class FormatService {
 				});
 
 				const result = await Promise.race([
-					formatFile(filePath, formatter),
+					loadFormatters().then(({ formatFile }) => formatFile(filePath, formatter)),
 					timeoutPromise,
 				]);
 				results.push(result);
@@ -199,9 +194,7 @@ export class FormatService {
 	 * Get formatters by name (for explicit formatter selection)
 	 */
 	private async getFormattersByName(names: string[]): Promise<FormatterInfo[]> {
-		const { listAllFormatters, ...formatters } = await import(
-			"./formatters.js"
-		);
+		const { listAllFormatters, ...formatters } = await loadFormatters();
 		const allNames = listAllFormatters();
 
 		return names
@@ -244,7 +237,9 @@ export class FormatService {
 	 * Clear detection cache
 	 */
 	clearCache(): void {
-		clearFormatterRuntimeState();
+		void loadFormatters().then(({ clearFormatterRuntimeState }) =>
+			clearFormatterRuntimeState(),
+		);
 	}
 }
 
@@ -271,7 +266,9 @@ export function getFormatService(
 }
 
 export function resetFormatService(): void {
-	clearFormatterRuntimeState();
+	void loadFormatters().then(({ clearFormatterRuntimeState }) =>
+		clearFormatterRuntimeState(),
+	);
 	globalFormatService = null;
 	currentSessionID = null;
 }

--- a/clients/formatters-lazy.ts
+++ b/clients/formatters-lazy.ts
@@ -1,0 +1,12 @@
+/** Shared lazy formatter catalog seam (#1394). */
+
+type FormatterModule = typeof import("./formatters.js");
+let formatterPromise: Promise<FormatterModule> | undefined;
+
+export function warmFormatters(): Promise<FormatterModule> {
+	return (formatterPromise ??= import("./formatters.js"));
+}
+
+export function loadFormatters(): Promise<FormatterModule> {
+	return warmFormatters();
+}

--- a/clients/lsp-lazy.ts
+++ b/clients/lsp-lazy.ts
@@ -1,0 +1,12 @@
+/** Shared lazy LSP service seam (#1394). */
+
+type LspModule = typeof import("./lsp/index.js");
+let lspPromise: Promise<LspModule> | undefined;
+
+export function warmLspService(): Promise<LspModule> {
+	return (lspPromise ??= import("./lsp/index.js"));
+}
+
+export function loadLspService(): Promise<LspModule> {
+	return warmLspService();
+}

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -28,10 +28,7 @@ import type { BiomeClient } from "./biome-client.js";
 import { recordDiagnostics } from "./widget-state.js";
 import { getDiagnosticLogger } from "./diagnostic-logger.js";
 import { getDiagnosticTracker } from "./diagnostic-tracker.js";
-import {
-	computeCascadeForFile,
-	dispatchLintWithResult,
-} from "./dispatch/integration.js";
+import { loadDispatchIntegration } from "./dispatch/lazy.js";
 import { toRunnerDisplayPath } from "./dispatch/runner-context.js";
 import {
 	createAvailabilityChecker,
@@ -990,7 +987,11 @@ function toPilensDiagnosticEntry(d: Diagnostic): PilensDiagnosticEntry {
 	return entry;
 }
 
-type DispatchResult = Awaited<ReturnType<typeof dispatchLintWithResult>>;
+	type DispatchResult = Awaited<
+		ReturnType<
+			(typeof import("./dispatch/integration.js"))["dispatchLintWithResult"]
+		>
+	>;
 function buildAllClearOutput(
 	_dispatchResult: DispatchResult,
 	elapsed: number,
@@ -1252,6 +1253,8 @@ export async function runPipeline(
 	const piApi: PiAgentAPI = {
 		getFlag: getFlag as (flag: string) => boolean | string | undefined,
 	};
+	const { dispatchLintWithResult, computeCascadeForFile } =
+		await loadDispatchIntegration();
 	const dispatchResult = await dispatchLintWithResult(
 		filePath,
 		cwd,

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -54,7 +54,7 @@ import {
 	wasPreviouslyReportedDirty,
 	type PilensDiagnosticEntry,
 } from "./diagnostics-publish.js";
-import { getLSPService } from "./lsp/index.js";
+import { loadLspService } from "./lsp-lazy.js";
 import type { MetricsClient } from "./metrics-client.js";
 import { clearGraphCache } from "./review-graph/builder.js";
 import type { RuffClient } from "./ruff-client.js";
@@ -908,7 +908,7 @@ export async function resyncLspFile(
 	if (limitCheck.tooLarge) return;
 
 	try {
-		const lspService = getLSPService();
+		const lspService = (await loadLspService()).getLSPService();
 		if (lspService.supportsLSP(filePath)) {
 			// Push the final post-format/post-fix content through touchFile (not the
 			// bare openFile) so it registers in the touch-debounce map via

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -35,7 +35,7 @@ import { logLatency } from "./latency-logger.js";
 import { runLogCleanup } from "./log-cleanup.js";
 import type { LSPShutdownOptions } from "./lsp/client.js";
 import { initLSPConfig, loadLSPConfig } from "./lsp/config.js";
-import { getLSPService } from "./lsp/index.js";
+import { loadLspService } from "./lsp-lazy.js";
 import type { MetricsClient } from "./metrics-client.js";
 import type { OpengrepClient, OpengrepResult } from "./opengrep-client.js";
 import { isAtOrAboveHomeDir } from "./path-utils.js";
@@ -411,7 +411,7 @@ async function igniteWarmFiles(
 		await initLSPConfig(cwd);
 		if (!runtime.isCurrentSession(sessionGeneration)) return;
 
-		const lspService = getLSPService();
+		const lspService = (await loadLspService()).getLSPService();
 		const total = warmFiles.length;
 		let loaded = 0;
 		let errors = 0;
@@ -467,7 +467,7 @@ async function igniteDominantLanguageWarm(
 		await initLSPConfig(cwd);
 		if (!runtime.isCurrentSession(sessionGeneration)) return;
 
-		const lspService = getLSPService();
+		const lspService = (await loadLspService()).getLSPService();
 		const { collectSourceFilesAsync } = await import("./source-filter.js");
 		const { CODE_KINDS, detectFileKind } = await import("./file-kinds.js");
 		// Async, event-loop-yielding walk (deferred off the interactive path).

--- a/clients/warm-attach.ts
+++ b/clients/warm-attach.ts
@@ -10,7 +10,7 @@ import {
 	STALE_HEARTBEAT_MS,
 } from "./instance-reaper.js";
 import { logLatency } from "./latency-logger.js";
-import { getLSPService } from "./lsp/index.js";
+import { loadLspService } from "./lsp-lazy.js";
 import {
 	contentHash,
 	createWarmIpcLineReader,
@@ -92,7 +92,7 @@ async function serveRequest(
 					if (Date.now() > req.deadlineAt) {
 						throw new Error("deadline exceeded");
 					}
-					return getLSPService().codeAction(
+					return (await loadLspService()).getLSPService().codeAction(
 						req.file,
 						range.start.line,
 						range.start.character,
@@ -125,7 +125,7 @@ async function serveRequest(
 	if (Date.now() > req.deadlineAt || contentHash(req.content) !== req.contentHash) {
 		return { error: "stale request" };
 	}
-	const touched = await getLSPService().touchFile(req.file, req.content, {
+	const touched = await (await loadLspService()).getLSPService().touchFile(req.file, req.content, {
 		diagnostics: "document",
 		collectDiagnostics: true,
 		clientScope: "with-auxiliary",

--- a/index.ts
+++ b/index.ts
@@ -80,7 +80,8 @@ import { registerCascadeTierReconcileTask } from "./clients/lsp/cascade-tier.js"
 import { formatCascadeNeighborDiagnostics } from "./clients/cascade-format.js";
 import { convertLspDiagnostics } from "./clients/dispatch/utils/lsp-diagnostics.js";
 import { initLSPConfig } from "./clients/lsp/config.js";
-import { warmLspService, loadLspService } from "./clients/lsp-lazy.js";
+import { getLSPService, resetLSPService } from "./clients/lsp/index.js";
+import { warmLspService } from "./clients/lsp-lazy.js";
 import {
 	sweepOrphans,
 	sweepUntrackedOrphans,
@@ -186,19 +187,7 @@ import { logConcurrentSessionBind } from "./clients/session-start-observability.
 import { warmFormatters } from "./clients/formatters-lazy.js";
 
 type DispatchIntegration = Awaited<ReturnType<typeof loadDispatchIntegration>>;
-type LspModule = Awaited<ReturnType<typeof loadLspService>>;
 let loadedDispatchIntegration: DispatchIntegration | undefined;
-let loadedLspModule: LspModule | undefined;
-
-function warmLspAtSessionStart(): void {
-	void warmLspService().then((module) => { loadedLspModule = module; }).catch((err) => {
-		logExtension({ subsystem: "lsp", level: "warn", message: `LSP warm failed: ${err}` });
-	});
-}
-
-function resetLspService(options?: Parameters<LspModule["resetLSPService"]>[0]): void {
-	void loadLspService().then(({ resetLSPService }) => resetLSPService(options));
-}
 
 function warmDispatchAtSessionStart(): void {
 	void warmDispatchIntegration().then((integration) => {
@@ -575,7 +564,7 @@ export default function (pi: ExtensionAPI) {
 			// failed server is suppressed when a live sibling covers its language
 			// (alt-LSP fallback) or its kind is no longer in use this session.
 			const { activeIds, failedIds } = selectLspStatus(
-				loadedLspModule?.getLSPService().getAliveServerIds() ?? [],
+				getLSPService().getAliveServerIds(),
 				getFailedLspServerIds(),
 				getSessionLanguages(),
 			);
@@ -982,7 +971,10 @@ export default function (pi: ExtensionAPI) {
 				0,
 			);
 
-			const reports = loadedDispatchIntegration?.getLatencyReports() ?? [];
+			const dispatchIntegration =
+				loadedDispatchIntegration ?? (await loadDispatchIntegration());
+			loadedDispatchIntegration = dispatchIntegration;
+			const reports = dispatchIntegration.getLatencyReports();
 			const last = reports.length > 0 ? reports[reports.length - 1] : undefined;
 			const diagStats = getDiagnosticTracker().getStats();
 			const slowRunners = last
@@ -1015,7 +1007,7 @@ export default function (pi: ExtensionAPI) {
 					count: crashEntries.length,
 				}),
 			];
-			const slopScoreLine = loadedDispatchIntegration?.getDispatchSlopScoreLine() ?? "";
+			const slopScoreLine = dispatchIntegration.getDispatchSlopScoreLine();
 
 			if (crashEntries.length > 0) {
 				lines.push("", t("lens.health.topCrashFiles", "Top crash files:"));
@@ -1145,7 +1137,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			// LSP status
-			const lspClients = loadedLspModule?.getLSPService().getStatus() ?? [];
+			const lspClients = getLSPService().getStatus();
 			if (lspClients.length > 0) {
 				lines.push("", "LSP servers:");
 				for (const { serverId, root, connected } of lspClients) {
@@ -1158,11 +1150,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			// Cascade summary
-			const cascadeStats = loadedDispatchIntegration?.getCascadeSessionStats() ?? {
-				runs: 0,
-				diagnosticsSurfaced: 0,
-				coldSnapshotTouches: 0,
-			};
+			const cascadeStats = dispatchIntegration.getCascadeSessionStats();
 			if (cascadeStats.runs > 0) {
 				lines.push(
 					"",
@@ -1510,7 +1498,9 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (event, ctx) => {
 		warmDispatchAtSessionStart();
-		warmLspAtSessionStart();
+		void warmLspService().catch((err) =>
+			logExtension({ subsystem: "lsp", level: "warn", message: `LSP warm failed: ${err}` }),
+		);
 		void warmFormatters().catch((err) =>
 			logExtension({ subsystem: "format", level: "warn", message: `formatter warm failed: ${err}` }),
 		);
@@ -1737,7 +1727,7 @@ export default function (pi: ExtensionAPI) {
 					(await import("./clients/installer/index.js")).ensureTool(name),
 				cleanStaleTsBuildInfo,
 				resetDispatchBaselines,
-				resetLSPService: resetLspService,
+				resetLSPService,
 			});
 			ctx.ui && updateLspStatus(ctx.ui.setStatus, ctx.ui.theme);
 
@@ -1878,7 +1868,7 @@ export default function (pi: ExtensionAPI) {
 			cacheManager,
 			ensureLSPConfigInitialized,
 			updateLspStatus,
-			resetLSPService: resetLspService,
+			resetLSPService,
 		});
 	});
 
@@ -1923,7 +1913,7 @@ export default function (pi: ExtensionAPI) {
 				biomeClient,
 				ruffClient,
 				metricsClient,
-				resetLSPService: resetLspService,
+				resetLSPService,
 				readGuard: runtime.readGuard,
 				agentBehaviorRecord: (toolName, filePath) =>
 					agentBehaviorClient.recordToolCall(toolName, filePath),
@@ -2161,7 +2151,7 @@ export default function (pi: ExtensionAPI) {
 				// must not touch ctx.ui after session replacement/reload (#338).
 				resetLSPService: () => {
 					try {
-						resetLspService({ reason: "idle" });
+						resetLSPService({ reason: "idle" });
 					} finally {
 						repaintLspStatus?.();
 					}
@@ -2224,7 +2214,7 @@ export default function (pi: ExtensionAPI) {
 	// turn ended through the SAME turn-end cascade seam (append a CascadeRun the
 	// next turn_end merges), reusing the existing neighbor→turn-end formatting —
 	// previously this outcome was logs-only, a silent under-report (#533).
-	registerCascadeTierReconcileTask(() => loadedLspModule?.getLSPService()!, {
+	registerCascadeTierReconcileTask(() => getLSPService(), {
 		onResolvedFound: ({ filePath, diagnostics }) => {
 			const cwd = runtime.projectRoot;
 			const diags = convertLspDiagnostics(
@@ -2435,7 +2425,7 @@ export default function (pi: ExtensionAPI) {
 		// children when a parent dies) — they rely on stdin EOF, LSP
 		// `initialize.processId` self-watchdog compliance, and the #449/#472
 		// cross-process instance registry's orphan reaper as the backstop (#472).
-		resetLspService({
+		resetLSPService({
 			fast: true,
 			processExiting: true,
 			reason: "session_shutdown",

--- a/index.ts
+++ b/index.ts
@@ -48,12 +48,7 @@ import {
 	sessionStartMode,
 } from "./clients/session-state-store.js";
 import { getDiagnosticTracker } from "./clients/diagnostic-tracker.js";
-import {
-	getCascadeSessionStats,
-	getDispatchSlopScoreLine,
-	getLatencyReports,
-	resetDispatchBaselines,
-} from "./clients/dispatch/integration.js";
+import { warmDispatchIntegration, loadDispatchIntegration } from "./clients/dispatch/lazy.js";
 import {
 	getFormatService,
 	resetFormatService,
@@ -188,6 +183,23 @@ import {
 } from "./clients/event-loop-monitor.js";
 import { logSessionStart } from "./clients/sessionstart-logger.js";
 import { logConcurrentSessionBind } from "./clients/session-start-observability.js";
+
+type DispatchIntegration = Awaited<ReturnType<typeof loadDispatchIntegration>>;
+let loadedDispatchIntegration: DispatchIntegration | undefined;
+
+function warmDispatchAtSessionStart(): void {
+	void warmDispatchIntegration().then((integration) => {
+		loadedDispatchIntegration = integration;
+	}).catch((err) => {
+		logExtension({ subsystem: "dispatch", level: "warn", message: `dispatch warm failed: ${err}` });
+	});
+}
+
+function resetDispatchBaselines(cwd?: string): void {
+	void loadDispatchIntegration().then(({ resetDispatchBaselines }) => {
+		resetDispatchBaselines(cwd);
+	});
+}
 
 // First executable statement: every import above has been evaluated, so the
 // full load/transpile cost has been paid. Capture it now.
@@ -957,7 +969,7 @@ export default function (pi: ExtensionAPI) {
 				0,
 			);
 
-			const reports = getLatencyReports();
+			const reports = loadedDispatchIntegration?.getLatencyReports() ?? [];
 			const last = reports.length > 0 ? reports[reports.length - 1] : undefined;
 			const diagStats = getDiagnosticTracker().getStats();
 			const slowRunners = last
@@ -990,7 +1002,7 @@ export default function (pi: ExtensionAPI) {
 					count: crashEntries.length,
 				}),
 			];
-			const slopScoreLine = getDispatchSlopScoreLine();
+			const slopScoreLine = loadedDispatchIntegration?.getDispatchSlopScoreLine() ?? "";
 
 			if (crashEntries.length > 0) {
 				lines.push("", t("lens.health.topCrashFiles", "Top crash files:"));
@@ -1133,7 +1145,11 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			// Cascade summary
-			const cascadeStats = getCascadeSessionStats();
+			const cascadeStats = loadedDispatchIntegration?.getCascadeSessionStats() ?? {
+				runs: 0,
+				diagnosticsSurfaced: 0,
+				coldSnapshotTouches: 0,
+			};
 			if (cascadeStats.runs > 0) {
 				lines.push(
 					"",
@@ -1480,6 +1496,7 @@ export default function (pi: ExtensionAPI) {
 	// --- Events ---
 
 	pi.on("session_start", async (event, ctx) => {
+		warmDispatchAtSessionStart();
 		rememberEventCtx(ctx);
 		refreshCtxDerivedPlumbing();
 		const sessionStartFiredAt = Date.now();

--- a/index.ts
+++ b/index.ts
@@ -80,7 +80,7 @@ import { registerCascadeTierReconcileTask } from "./clients/lsp/cascade-tier.js"
 import { formatCascadeNeighborDiagnostics } from "./clients/cascade-format.js";
 import { convertLspDiagnostics } from "./clients/dispatch/utils/lsp-diagnostics.js";
 import { initLSPConfig } from "./clients/lsp/config.js";
-import { getLSPService, resetLSPService } from "./clients/lsp/index.js";
+import { warmLspService, loadLspService } from "./clients/lsp-lazy.js";
 import {
 	sweepOrphans,
 	sweepUntrackedOrphans,
@@ -186,7 +186,19 @@ import { logConcurrentSessionBind } from "./clients/session-start-observability.
 import { warmFormatters } from "./clients/formatters-lazy.js";
 
 type DispatchIntegration = Awaited<ReturnType<typeof loadDispatchIntegration>>;
+type LspModule = Awaited<ReturnType<typeof loadLspService>>;
 let loadedDispatchIntegration: DispatchIntegration | undefined;
+let loadedLspModule: LspModule | undefined;
+
+function warmLspAtSessionStart(): void {
+	void warmLspService().then((module) => { loadedLspModule = module; }).catch((err) => {
+		logExtension({ subsystem: "lsp", level: "warn", message: `LSP warm failed: ${err}` });
+	});
+}
+
+function resetLspService(options?: Parameters<LspModule["resetLSPService"]>[0]): void {
+	void loadLspService().then(({ resetLSPService }) => resetLSPService(options));
+}
 
 function warmDispatchAtSessionStart(): void {
 	void warmDispatchIntegration().then((integration) => {
@@ -563,7 +575,7 @@ export default function (pi: ExtensionAPI) {
 			// failed server is suppressed when a live sibling covers its language
 			// (alt-LSP fallback) or its kind is no longer in use this session.
 			const { activeIds, failedIds } = selectLspStatus(
-				getLSPService().getAliveServerIds(),
+				loadedLspModule?.getLSPService().getAliveServerIds() ?? [],
 				getFailedLspServerIds(),
 				getSessionLanguages(),
 			);
@@ -1133,7 +1145,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			// LSP status
-			const lspClients = getLSPService().getStatus();
+			const lspClients = loadedLspModule?.getLSPService().getStatus() ?? [];
 			if (lspClients.length > 0) {
 				lines.push("", "LSP servers:");
 				for (const { serverId, root, connected } of lspClients) {
@@ -1498,6 +1510,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (event, ctx) => {
 		warmDispatchAtSessionStart();
+		warmLspAtSessionStart();
 		void warmFormatters().catch((err) =>
 			logExtension({ subsystem: "format", level: "warn", message: `formatter warm failed: ${err}` }),
 		);
@@ -1724,7 +1737,7 @@ export default function (pi: ExtensionAPI) {
 					(await import("./clients/installer/index.js")).ensureTool(name),
 				cleanStaleTsBuildInfo,
 				resetDispatchBaselines,
-				resetLSPService,
+				resetLSPService: resetLspService,
 			});
 			ctx.ui && updateLspStatus(ctx.ui.setStatus, ctx.ui.theme);
 
@@ -1865,7 +1878,7 @@ export default function (pi: ExtensionAPI) {
 			cacheManager,
 			ensureLSPConfigInitialized,
 			updateLspStatus,
-			resetLSPService,
+			resetLSPService: resetLspService,
 		});
 	});
 
@@ -1910,7 +1923,7 @@ export default function (pi: ExtensionAPI) {
 				biomeClient,
 				ruffClient,
 				metricsClient,
-				resetLSPService,
+				resetLSPService: resetLspService,
 				readGuard: runtime.readGuard,
 				agentBehaviorRecord: (toolName, filePath) =>
 					agentBehaviorClient.recordToolCall(toolName, filePath),
@@ -2148,7 +2161,7 @@ export default function (pi: ExtensionAPI) {
 				// must not touch ctx.ui after session replacement/reload (#338).
 				resetLSPService: () => {
 					try {
-						resetLSPService({ reason: "idle" });
+						resetLspService({ reason: "idle" });
 					} finally {
 						repaintLspStatus?.();
 					}
@@ -2211,7 +2224,7 @@ export default function (pi: ExtensionAPI) {
 	// turn ended through the SAME turn-end cascade seam (append a CascadeRun the
 	// next turn_end merges), reusing the existing neighbor→turn-end formatting —
 	// previously this outcome was logs-only, a silent under-report (#533).
-	registerCascadeTierReconcileTask(() => getLSPService(), {
+	registerCascadeTierReconcileTask(() => loadedLspModule?.getLSPService()!, {
 		onResolvedFound: ({ filePath, diagnostics }) => {
 			const cwd = runtime.projectRoot;
 			const diags = convertLspDiagnostics(
@@ -2422,7 +2435,7 @@ export default function (pi: ExtensionAPI) {
 		// children when a parent dies) — they rely on stdin EOF, LSP
 		// `initialize.processId` self-watchdog compliance, and the #449/#472
 		// cross-process instance registry's orphan reaper as the backstop (#472).
-		resetLSPService({
+		resetLspService({
 			fast: true,
 			processExiting: true,
 			reason: "session_shutdown",

--- a/index.ts
+++ b/index.ts
@@ -183,6 +183,7 @@ import {
 } from "./clients/event-loop-monitor.js";
 import { logSessionStart } from "./clients/sessionstart-logger.js";
 import { logConcurrentSessionBind } from "./clients/session-start-observability.js";
+import { warmFormatters } from "./clients/formatters-lazy.js";
 
 type DispatchIntegration = Awaited<ReturnType<typeof loadDispatchIntegration>>;
 let loadedDispatchIntegration: DispatchIntegration | undefined;
@@ -1497,6 +1498,9 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (event, ctx) => {
 		warmDispatchAtSessionStart();
+		void warmFormatters().catch((err) =>
+			logExtension({ subsystem: "format", level: "warn", message: `formatter warm failed: ${err}` }),
+		);
 		rememberEventCtx(ctx);
 		refreshCtxDerivedPlumbing();
 		const sessionStartFiredAt = Date.now();

--- a/tests/clients/dispatch/lazy-liveness.test.ts
+++ b/tests/clients/dispatch/lazy-liveness.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("dispatch session warm/first-use liveness (#1394)", () => {
+	it("uses one warmed promise and executes dispatch work at first use", async () => {
+		const ran = vi.fn(async () => ({ diagnostics: [{ tool: "dispatch" }] }));
+		vi.doMock("../../../clients/dispatch/integration.js", () => ({
+			dispatchLintWithResult: ran,
+		}));
+		const { warmDispatchIntegration, loadDispatchIntegration } = await import(
+			"../../../clients/dispatch/lazy.js"
+		);
+
+		// Session-shaped lifecycle: session_start warms without awaiting, then the
+		// first tool_result awaits the same promise before doing real work.
+		const warm = warmDispatchIntegration();
+		const firstUse = await loadDispatchIntegration();
+		const result = await firstUse.dispatchLintWithResult(
+			"file.ts",
+			process.cwd(),
+			{ getFlag: () => undefined },
+		);
+
+		expect(await warm).toBe(firstUse);
+		expect(ran).toHaveBeenCalledTimes(1);
+		expect(result.diagnostics).toHaveLength(1);
+	});
+});

--- a/tests/clients/dispatch/lazy-liveness.test.ts
+++ b/tests/clients/dispatch/lazy-liveness.test.ts
@@ -1,27 +1,60 @@
-import { describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPiMock, makeCtx } from "../../support/pi-mock.js";
+
+const dispatchResult = {
+	diagnostics: [{ tool: "dispatch", message: "dispatch fired" }],
+	blockers: [], warnings: [], baselineWarningCount: 0, fixed: [],
+	resolvedCount: 0, output: "dispatch output", blockerOutput: "", hasBlockers: false,
+};
 
 describe("dispatch session warm/first-use liveness (#1394)", () => {
-	it("uses one warmed promise and executes dispatch work at first use", async () => {
-		const ran = vi.fn(async () => ({ diagnostics: [{ tool: "dispatch" }] }));
-		vi.doMock("../../../clients/dispatch/integration.js", () => ({
-			dispatchLintWithResult: ran,
+	afterEach(() => vi.resetModules());
+
+	it("session_start -> edit tool_result produces dispatch output", async () => {
+		vi.resetModules();
+		vi.doMock("../../../clients/dispatch/integration.js", async (importOriginal) => ({
+			...await importOriginal<typeof import("../../../clients/dispatch/integration.js")>(),
+			dispatchLintWithResult: async () => dispatchResult,
 		}));
-		const { warmDispatchIntegration, loadDispatchIntegration } = await import(
-			"../../../clients/dispatch/lazy.js"
-		);
+		vi.doMock("../../../clients/bootstrap.js", () => ({
+			loadBootstrapClients: async () => ({
+				metricsClient: { reset: () => {} }, todoScanner: {},
+				biomeClient: { isAvailable: () => false, isSupportedFile: () => false }, ruffClient: { isAvailable: () => false, isSupportedFile: () => false },
+				knipClient: { isAvailable: () => false, analyze: async () => ({ issues: [] }) },
+				jscpdClient: { isAvailable: () => false }, depChecker: { isAvailable: () => false },
+				testRunnerClient: { detectRunner: () => null }, goClient: { isGoAvailableAsync: async () => false },
+				rustClient: { isAvailableAsync: async () => false },
+				agentBehaviorClient: { recordToolCall: () => [], formatWarnings: () => "" },
+				complexityClient: { isSupportedFile: () => false, analyzeFile: () => null },
+			}),
+		}));
+		vi.doMock("../../../clients/lsp/index.js", () => ({
+			getLSPService: () => ({
+				touchFile: async () => [], supportsLSP: () => false,
+				getStatus: () => [], getAliveServerIds: () => [],
+			}), resetLSPService: () => {},
+		}));
+		const { default: registerExtension } = await import("../../../index.ts");
+		const pi = createPiMock({ "no-lsp": true, "no-autoformat": true });
+		registerExtension(pi.asExtensionAPI());
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-dispatch-live-"));
+		const filePath = path.join(cwd, "src", "live.ts");
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(filePath, "export const live = 1;\n");
+		try {
+			await pi.emit("session_start", {}, makeCtx({ cwd }));
+			await pi.emit("turn_start", {}, makeCtx({ cwd }));
+			const result = await pi.emit("tool_result", {
+				toolName: "edit", input: { path: filePath },
+				details: { diff: "+ 1 export const live = 2;" }, content: [{ type: "text", text: "ok" }],
+			}, makeCtx({ cwd }));
 
-		// Session-shaped lifecycle: session_start warms without awaiting, then the
-		// first tool_result awaits the same promise before doing real work.
-		const warm = warmDispatchIntegration();
-		const firstUse = await loadDispatchIntegration();
-		const result = await firstUse.dispatchLintWithResult(
-			"file.ts",
-			process.cwd(),
-			{ getFlag: () => undefined },
-		);
-
-		expect(await warm).toBe(firstUse);
-		expect(ran).toHaveBeenCalledTimes(1);
-		expect(result.diagnostics).toHaveLength(1);
-	});
+			expect(JSON.stringify(result)).toContain("dispatch output");
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	}, 30_000);
 });

--- a/tests/clients/formatters-lazy-liveness.test.ts
+++ b/tests/clients/formatters-lazy-liveness.test.ts
@@ -1,22 +1,40 @@
-import { describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPiMock, makeCtx } from "../support/pi-mock.js";
 
 describe("formatter session warm/first-use liveness (#1394)", () => {
-	it("warms the catalog and executes formatting through the same promise", async () => {
-		const formatFile = vi.fn(async () => ({ success: true, changed: true }));
-		vi.doMock("../../clients/formatters.js", () => ({
-			formatFile,
-			getFormattersForFile: async () => [],
-			listAllFormatters: () => [],
-			clearFormatterRuntimeState: vi.fn(),
-		}));
-		const { warmFormatters, loadFormatters } = await import(
-			"../../clients/formatters-lazy.js"
-		);
-		const warm = warmFormatters();
-		const firstUse = await loadFormatters();
-		await firstUse.formatFile("file.ts", { name: "test" } as never);
+	afterEach(() => vi.resetModules());
 
-		expect(await warm).toBe(firstUse);
-		expect(formatFile).toHaveBeenCalledTimes(1);
-	});
+	it("session_start -> immediate format edit actually changes the file", async () => {
+		vi.resetModules();
+		vi.doMock("../../clients/formatters.js", async (importOriginal) => ({
+			...await importOriginal<typeof import("../../clients/formatters.js")>(),
+			getFormattersForFile: async () => [{ name: "test-formatter", command: ["test-formatter"] }],
+			formatFile: async (filePath: string) => { fs.writeFileSync(filePath, "export const formatted = true;\n"); return { success: true, changed: true }; },
+		}));
+		vi.doMock("../../clients/lsp/index.js", () => ({ getLSPService: () => ({ touchFile: async () => [], supportsLSP: () => false, getStatus: () => [], getAliveServerIds: () => [] }), resetLSPService: () => {} }));
+		vi.doMock("../../clients/dispatch/integration.js", async (importOriginal) => ({
+			...await importOriginal<typeof import("../../clients/dispatch/integration.js")>(),
+			dispatchLintWithResult: async () => ({ diagnostics: [], blockers: [], warnings: [], baselineWarningCount: 0, fixed: [], resolvedCount: 0, output: "formatter pipeline output", blockerOutput: "", hasBlockers: false }),
+		}));
+		vi.doMock("../../clients/bootstrap.js", () => ({ loadBootstrapClients: async () => ({
+			metricsClient: { reset: () => {} }, todoScanner: {}, biomeClient: { isAvailable: () => false, isSupportedFile: () => false }, ruffClient: { isAvailable: () => false, isSupportedFile: () => false },
+			knipClient: { isAvailable: () => false, analyze: async () => ({ issues: [] }) }, jscpdClient: { isAvailable: () => false }, depChecker: { isAvailable: () => false }, testRunnerClient: { detectRunner: () => null },
+			goClient: { isGoAvailableAsync: async () => false }, rustClient: { isAvailableAsync: async () => false }, agentBehaviorClient: { recordToolCall: () => [], formatWarnings: () => "" }, complexityClient: { isSupportedFile: () => false, analyzeFile: () => null },
+		}) }));
+		const { default: registerExtension } = await import("../../index.ts");
+		const pi = createPiMock({ "immediate-format": true, "no-lsp": true });
+		registerExtension(pi.asExtensionAPI());
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-format-live-"));
+		const filePath = path.join(cwd, "live.ts");
+		fs.writeFileSync(filePath, "export const formatted = false;\n");
+		try {
+			await pi.emit("session_start", {}, makeCtx({ cwd }));
+			await pi.emit("turn_start", {}, makeCtx({ cwd }));
+			await pi.emit("tool_result", { toolName: "edit", input: { path: filePath }, details: { diff: "+ 1 export const formatted = false;" }, content: [{ type: "text", text: "ok" }] }, makeCtx({ cwd }));
+			expect(fs.readFileSync(filePath, "utf8")).toContain("formatted = true");
+		} finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+	}, 30_000);
 });

--- a/tests/clients/formatters-lazy-liveness.test.ts
+++ b/tests/clients/formatters-lazy-liveness.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("formatter session warm/first-use liveness (#1394)", () => {
+	it("warms the catalog and executes formatting through the same promise", async () => {
+		const formatFile = vi.fn(async () => ({ success: true, changed: true }));
+		vi.doMock("../../clients/formatters.js", () => ({
+			formatFile,
+			getFormattersForFile: async () => [],
+			listAllFormatters: () => [],
+			clearFormatterRuntimeState: vi.fn(),
+		}));
+		const { warmFormatters, loadFormatters } = await import(
+			"../../clients/formatters-lazy.js"
+		);
+		const warm = warmFormatters();
+		const firstUse = await loadFormatters();
+		await firstUse.formatFile("file.ts", { name: "test" } as never);
+
+		expect(await warm).toBe(firstUse);
+		expect(formatFile).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/clients/lsp-lazy-liveness.test.ts
+++ b/tests/clients/lsp-lazy-liveness.test.ts
@@ -1,19 +1,43 @@
-import { describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPiMock, makeCtx } from "../support/pi-mock.js";
+import { removeTempDirSync } from "./test-utils.js";
 
 describe("LSP session warm/first-use liveness (#1394)", () => {
-	it("warms once and services a first-use request", async () => {
-		const request = vi.fn(async () => ({ diagnostics: [] }));
-		vi.doMock("../../clients/lsp/index.js", () => ({
-			getLSPService: () => ({ request }),
-		}));
-		const { warmLspService, loadLspService } = await import(
-			"../../clients/lsp-lazy.js"
-		);
-		const warm = warmLspService();
-		const firstUse = await loadLspService();
-		await (firstUse.getLSPService() as unknown as { request: (file: string) => Promise<unknown> }).request("file.ts");
+	afterEach(() => vi.resetModules());
 
-		expect(await warm).toBe(firstUse);
-		expect(request).toHaveBeenCalledTimes(1);
-	});
+	it("session_start -> first edit services the LSP and produces pipeline output", async () => {
+		vi.resetModules();
+		const touchFile = vi.fn(async () => []);
+		vi.doMock("../../clients/lsp/index.js", () => ({
+			getLSPService: () => ({ touchFile, supportsLSP: () => true, getStatus: () => [], getAliveServerIds: () => [] }),
+			resetLSPService: () => {},
+		}));
+		vi.doMock("../../clients/dispatch/integration.js", async (importOriginal) => ({
+			...await importOriginal<typeof import("../../clients/dispatch/integration.js")>(),
+			dispatchLintWithResult: async () => ({ diagnostics: [], blockers: [], warnings: [], baselineWarningCount: 0, fixed: [], resolvedCount: 0, output: "lsp pipeline output", blockerOutput: "", hasBlockers: false }),
+		}));
+		vi.doMock("../../clients/bootstrap.js", () => ({ loadBootstrapClients: async () => ({
+			metricsClient: { reset: () => {} }, todoScanner: {},
+			biomeClient: { isAvailable: () => false, isSupportedFile: () => false }, ruffClient: { isAvailable: () => false, isSupportedFile: () => false },
+			knipClient: { isAvailable: () => false, analyze: async () => ({ issues: [] }) }, jscpdClient: { isAvailable: () => false }, depChecker: { isAvailable: () => false },
+			testRunnerClient: { detectRunner: () => null }, goClient: { isGoAvailableAsync: async () => false }, rustClient: { isAvailableAsync: async () => false },
+			agentBehaviorClient: { recordToolCall: () => [], formatWarnings: () => "" }, complexityClient: { isSupportedFile: () => false, analyzeFile: () => null },
+		}) }));
+		const { default: registerExtension } = await import("../../index.ts");
+		const pi = createPiMock({ "no-autoformat": true });
+		registerExtension(pi.asExtensionAPI());
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-lsp-live-"));
+		const filePath = path.join(cwd, "live.ts");
+		fs.writeFileSync(filePath, "export const live = 1;\n");
+		try {
+			await pi.emit("session_start", {}, makeCtx({ cwd }));
+			await pi.emit("turn_start", {}, makeCtx({ cwd }));
+			const result = await pi.emit("tool_result", { toolName: "edit", input: { path: filePath }, details: { diff: "+ 1 export const live = 2;" }, content: [{ type: "text", text: "ok" }] }, makeCtx({ cwd }));
+			expect(touchFile).toHaveBeenCalled();
+			expect(JSON.stringify(result)).toContain("lsp pipeline output");
+		} finally { removeTempDirSync(cwd); }
+	}, 30_000);
 });

--- a/tests/clients/lsp-lazy-liveness.test.ts
+++ b/tests/clients/lsp-lazy-liveness.test.ts
@@ -11,7 +11,7 @@ describe("LSP session warm/first-use liveness (#1394)", () => {
 		);
 		const warm = warmLspService();
 		const firstUse = await loadLspService();
-		await firstUse.getLSPService().request("file.ts");
+		await (firstUse.getLSPService() as unknown as { request: (file: string) => Promise<unknown> }).request("file.ts");
 
 		expect(await warm).toBe(firstUse);
 		expect(request).toHaveBeenCalledTimes(1);

--- a/tests/clients/lsp-lazy-liveness.test.ts
+++ b/tests/clients/lsp-lazy-liveness.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("LSP session warm/first-use liveness (#1394)", () => {
+	it("warms once and services a first-use request", async () => {
+		const request = vi.fn(async () => ({ diagnostics: [] }));
+		vi.doMock("../../clients/lsp/index.js", () => ({
+			getLSPService: () => ({ request }),
+		}));
+		const { warmLspService, loadLspService } = await import(
+			"../../clients/lsp-lazy.js"
+		);
+		const warm = warmLspService();
+		const firstUse = await loadLspService();
+		await firstUse.getLSPService().request("file.ts");
+
+		expect(await warm).toBe(firstUse);
+		expect(request).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

Phase 2 startup lazy-loading for #1394, split into independent shared warm/first-use promises.

- Dispatch/integration: `clients/dispatch/lazy.ts`; warmed at `session_start`, awaited by the edit pipeline before dispatch/cascade work.
  - Liveness: `tests/clients/dispatch/lazy-liveness.test.ts`
  - Mutation proof: disabling the warm seam made the test fail with `mutation: dispatch warm disabled`.
- LSP service consumers: `clients/lsp-lazy.ts`; warmed at `session_start`, awaited by async pipeline/session/warm-attach consumers.
  - Liveness: `tests/clients/lsp-lazy-liveness.test.ts`
  - Mutation proof: disabling the warm seam made the test fail with `mutation: LSP warm disabled`.
  - `index.ts` status/reset adapter remains eager because its synchronous host-visible ordering contract is covered by existing integration tests.
- Formatter catalog: `clients/formatters-lazy.ts`; warmed at `session_start`, awaited by catalog lookup and formatter execution.
  - Liveness: `tests/clients/formatters-lazy-liveness.test.ts`
  - Mutation proof: disabling the warm seam made the test fail with `mutation: formatter warm disabled`.

## Verification

- `npm run build` passed.
- Targeted liveness + index wiring tests passed (17 tests); broader index integration passed (42 tests across liveness/wiring/integration run after the synchronous-contract adjustment).
- `npm run lint` passed.
- No usable post-change isolated import timing was emitted by the host; Phase-1 reported a 903.3/1123.2ms min/median full-entry wall-time envelope.