### PR TITLE
docs: refresh README/docs for v4 + contributors

### DIFF
--- a/.changelog/docs-v4-readme-contributors.md
+++ b/.changelog/docs-v4-readme-contributors.md
@@ -1,0 +1,15 @@
+---
+section: Changed
+---
+
+- **Refresh README/docs for v4 and update contributors** — reconciled the
+  README feature list and `docs/` reference against current code: documented
+  the four memory idle-eviction env vars (`PI_LENS_TS_IDLE_EVICT_MS`,
+  `PI_LENS_WORD_INDEX_IDLE_EVICT_MS`, `PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS`,
+  `PI_LENS_REVIEW_GRAPH_IDLE_EVICT_MS`), the session degradation ledger
+  surfaced through `pilens_health`/`/lens-health`, deferred-format bounded
+  concurrency, and the `--lens-guard` commit/push blocker; linked
+  `docs/mcp.md` from the README and added an MCP-server bullet. Added six
+  external contributors (Nathan Cooke, Eli Stark, Marvin Aziz, Mark Faga,
+  aeturnal, floatGray) to the README contributors table, sourced from
+  `git shortlog` and merged-PR authorship.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ pi-lens gives AI coding agents fast, language-aware feedback while they write/ed
 - `/lens-map` — interactive HTML dependency map of the project
 - Read-guard and edit-autopatch support to reduce bad edits
 - Background security/dependency scans for opted-in projects
+- Runtime health telemetry (`/lens-health`) including a bounded degradation
+  ledger for silently-degraded behavior (LSP breakers, formatter
+  skips/failures, idle evictions, timeouts)
+- MCP server (experimental) so Claude Code or any MCP client can drive the
+  same diagnostics/read-substitute tools pi-lens exposes to pi
 
 ## Install
 
@@ -70,6 +75,8 @@ pi install git:github.com/apmantza/pi-lens
   and formatters
 - [Dependencies](docs/dependencies.md) — auto-install policy and external tools
 - [Custom rules](docs/custom-rules.md) — project ast-grep and tree-sitter rules
+- [MCP server](docs/mcp.md) — experimental MCP server for Claude Code and
+  other MCP clients
 
 ## Contributing
 
@@ -206,6 +213,12 @@ Thanks goes to these wonderful people:
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/pppobear"><img src="https://avatars.githubusercontent.com/u/21952175?v=4" width="100px;" alt=""/><br /><sub><b>pppobear</b></sub></a><br /><a href="#bug-pppobear" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/3choBoomer"><img src="https://avatars.githubusercontent.com/u/521828?v=4" width="100px;" alt=""/><br /><sub><b>Nathan Cooke</b></sub></a><br /><a href="#code-3choBoomer" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/white-hat"><img src="https://avatars.githubusercontent.com/u/922988?v=4" width="100px;" alt=""/><br /><sub><b>Eli Stark</b></sub></a><br /><a href="#code-white-hat" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/marvtub"><img src="https://avatars.githubusercontent.com/u/33159023?v=4" width="100px;" alt=""/><br /><sub><b>Marvin Aziz</b></sub></a><br /><a href="#code-marvtub" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/mjfaga"><img src="https://avatars.githubusercontent.com/u/7584015?v=4" width="100px;" alt=""/><br /><sub><b>Mark Faga</b></sub></a><br /><a href="#code-mjfaga" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/aeturnal"><img src="https://avatars.githubusercontent.com/u/219271200?v=4" width="100px;" alt=""/><br /><sub><b>aeturnal</b></sub></a><br /><a href="#code-aeturnal" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/floatGray"><img src="https://avatars.githubusercontent.com/u/44295302?v=4" width="100px;" alt=""/><br /><sub><b>floatGray</b></sub></a><br /><a href="#code-floatGray" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -207,7 +207,7 @@ Verified in `index.ts`:
 | `/lens-toggle` | Turn pi-lens on/off for the session. |
 | `/lens-context-toggle` | Toggle context injection (tools/LSP/read-guard/formatting stay active). |
 | `/lens-widget-toggle` | Show/hide the diagnostics footer widget. |
-| `/lens-health` | Runtime health: pipeline crashes, slow runners, last dispatch latency. |
+| `/lens-health` | Runtime health: pipeline crashes, slow runners, last dispatch latency, and a bounded degradation-ledger summary (trust refusals, LSP breakers, formatter skips/failures, idle evictions, WASM aborts, timeout tallies). |
 | `/lens-perf` | Slowest latency-log phases (p50/p99). |
 | `/lens-tools` | Tool installation status (global / auto-installed / npx fallback). |
 | `/lens-tdi` | Technical Debt Index and project health trend. |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -195,6 +195,33 @@ honored.
 Node cap for `/lens-map` (default 500). Graphs with more files keep only the
 highest-degree ones and render a visible truncation note.
 
+## Memory / idle eviction
+
+Several in-memory caches release their contents after a period of inactivity so a
+long-running session does not retain hydrated state indefinitely. Each has an
+env-tunable window; all default to 20 minutes (`1200000` ms).
+
+### `PI_LENS_TS_IDLE_EVICT_MS`
+
+Idle window (ms) after which TypeScript language-service clients release their
+hydrated program and shut down, rebuilding transparently on the next request.
+**Default:** 20 minutes (`1200000`).
+
+### `PI_LENS_WORD_INDEX_IDLE_EVICT_MS`
+
+Idle window (ms) after which the persisted word index (`symbol_search`'s BM25
+index) is released from memory. **Default:** 20 minutes (`1200000`).
+
+### `PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS`
+
+Idle window (ms) after which the cached project snapshot is released from
+memory. **Default:** 20 minutes (`1200000`).
+
+### `PI_LENS_REVIEW_GRAPH_IDLE_EVICT_MS`
+
+Idle window (ms) after which the in-memory review graph (`file → symbol →
+dependency`) is released. **Default:** 20 minutes (`1200000`).
+
 ## Bus events
 
 ### `PI_LENS_BUS_PUBLISH`

--- a/docs/features.md
+++ b/docs/features.md
@@ -40,6 +40,21 @@ Repositories can disable all immediate and deferred auto-format mutations with
 keeping formatter detection, lint dispatch, LSP synchronization, and
 diagnostics available.
 
+Deferred formatting (the `agent_end` default) runs with **bounded
+concurrency**: at most three formatter subprocesses in flight at once, with
+results applied in admission order and cooperative yields between files, so a
+large batch of queued files can't stall the event loop or the turn-end pass.
+
+### Commit/Push Guard (Experimental)
+
+`--lens-guard` (also `guard.enabled: true` in `~/.pi-lens/config.json`) opts
+into blocking `git commit`/`git push` while unresolved pi-lens blockers exist.
+Detection covers normalized wrapper launchers, shell-escaped and
+keyword/combined-flag verb forms, and shell substitutions, while literal text
+in non-executing contexts remains allowed. Off by default; see
+[docs/agent-guide.md](agent-guide.md) and [docs/settings.md](settings.md) for
+the full behavior and honest limits.
+
 ### Review Graph - Cascade Diagnostics
 
 pi-lens builds a review graph (`file → symbol → dependency`) during session and uses it at turn end to render an impact cascade: which files were affected by a change and how diagnostics propagated through the dependency graph. Nodes track kind, language, and export status; edges track contains/imports/calls/references.
@@ -319,7 +334,7 @@ pi-lens ships an MCP (Model Context Protocol) server so Claude Code — or any M
 | **Per-edit** | `pilens_analyze`, `pilens_lsp_diagnostics`, `pilens_lsp_navigation`, `pilens_ast_grep_search`, `pilens_ast_grep_replace`, `pilens_module_report`, `pilens_read_symbol` | The fast pipeline (format → autofix → LSP diagnostics → parallel runners) plus the structured read-substitute pair. `analyze` accepts `mode: warm \| fresh` — `warm` reuses the server's in-process LSP, `fresh` forks a worker that loads freshly-built code from disk so the result reflects the latest commit. |
 | **Per-turn** | `pilens_turn_end` | Drives the **real** `handleTurnEnd` (knip incremental, dep-circular, cascade, tests, actionable+code-quality warnings) — not a re-implementation. Caller-supplied edited files are auto-registered into turn-state via `addModifiedRange`. |
 | **Per-session** | `pilens_session_start` | Drives the **real** `handleSessionStart` — full jscpd/knip/madge/govulncheck/gitleaks/trivy scans + complexity baselines + LSP warm. The error-debt baseline is not currently populated by the production session-start path. |
-| **Project / observability** | `pilens_project_scan`, `pilens_diagnostics`, `pilens_health`, `pilens_latency`, `pilens_symbol_search` | Cheap project-wide scans, cached diagnostic state, latency telemetry, ranked identifier search (BM25 over the persisted word index — see [docs/word-index.md](word-index.md)). Cross-file blast radius now lives in `pilens_module_report`'s `blastRadius` option. |
+| **Project / observability** | `pilens_project_scan`, `pilens_diagnostics`, `pilens_health`, `pilens_latency`, `pilens_symbol_search` | Cheap project-wide scans, cached diagnostic state, latency telemetry, ranked identifier search (BM25 over the persisted word index — see [docs/word-index.md](word-index.md)). Cross-file blast radius now lives in `pilens_module_report`'s `blastRadius` option. `pilens_health` (and its pi-side `/lens-health` counterpart) also reports a bounded, process-local **degradation ledger** — trust refusals, mode suppressions, LSP breaker trips, formatter skips/failures, TypeScript/word-index/review-graph/project-snapshot idle evictions, WASM aborts, and diagnostics-timeout tallies — so silently degraded behavior stays visible instead of vanishing into a log. |
 | **Lifecycle / loop** | `pilens_rebuild` | Runs `npm run build:dist` so `pilens_analyze mode=fresh` reflects the latest commit. Makes the review loop self-contained: commit → `pilens_rebuild` → `pilens_analyze mode=fresh` → `pilens_latency`. |
 
 **Honest limits** (live-tested, documented in `mcp.md`):

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -5,7 +5,10 @@ pi-lens registers the following slash commands with the pi host:
 - `/lens-toggle` — toggle pi-lens on/off for the current session without restarting
 - `/lens-context-toggle` — toggle automatic context injection on/off for the session (tools/LSP/read-guard/formatting stay active)
 - `/lens-widget-toggle` — show/hide the pi-lens diagnostics widget below the editor
-- `/lens-health` — runtime health, latency, and diagnostic telemetry
+- `/lens-health` — runtime health, latency, and diagnostic telemetry, including
+  bounded per-session degradation counts (trust refusals, LSP breakers,
+  formatter skips/failures, idle evictions, WASM aborts, timeout tallies, and
+  more)
 - `/lens-perf` — independent top-five p50 and p99 rankings for the current process session and machine-wide active latency-log window
 - `/lens-allow-edit <path>` — override the read-before-edit guard for a single edit
 - `/lens-tools` — tool installation status: globally installed, auto-installed, or npx fallback


### PR DESCRIPTION
## Summary

Pre-v4-release docs audit. Reconciles README.md and docs/ against what the code actually does now, and adds external contributors missing from the README's all-contributors table.

### README / docs changes (and why)

- **Memory idle-eviction env vars documented** (`docs/environment-variables.md`, new "Memory / idle eviction" section) — verified all four exist and default to 20 min (`1200000` ms): `PI_LENS_TS_IDLE_EVICT_MS` (`clients/lsp/index.ts`), `PI_LENS_WORD_INDEX_IDLE_EVICT_MS` (`clients/mcp/analyze.ts`), `PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS` (`clients/project-snapshot.ts`), `PI_LENS_REVIEW_GRAPH_IDLE_EVICT_MS` (`clients/review-graph/builder.ts`). None were previously documented outside the generic "grep the source" catch-all.
- **Session degradation ledger documented** (`docs/features.md`, `docs/agent-guide.md`, `docs/tools.md`) — verified `clients/degradation-ledger.ts` and its wiring into `pilens_health`/`/lens-health` in `mcp/server.ts`. Previously `pilens_health` was listed as a tool with no mention of the ledger it now surfaces (trust refusals, LSP breakers, formatter skips/failures, idle evictions, WASM aborts, timeout tallies).
- **Deferred-format bounded concurrency documented** (`docs/features.md`) — verified via `clients/runtime-agent-end.ts` and `.changelog/fix-1387-deferred-format-chunking.md` (closes #1387): at most 3 formatter subprocesses in flight, admission-order apply, cooperative `setImmediate` yields.
- **Commit/push guard given its own Features section** (`docs/features.md`) — `--lens-guard` / `guard.enabled` was already documented in agent-guide.md/settings.md/usage.md but absent from the main features reference; added a short cross-linked section rather than duplicating the full behavior writeup.
- **MCP server linked from the README** — `docs/mcp.md` exists and features.md has a substantial "MCP Server (Experimental)" section, but the README's docs list and "What It Does" bullets never mentioned it. Added both.
- Verified no broken internal doc links in README.md (checked every relative link resolves).

### NOT documented (flagged, not invented)

- `--lens-turn-end-madge` — grepped `clients/lens-flag-registry.ts` (the single source of truth for CLI/config flags) and it is **not present**, so it appears unmerged. Left undocumented per instructions rather than guessing at behavior.
- Did not touch `package.json` or version numbers (release's job).

### Contributors

Added six external (non-owner) contributors to the README's all-contributors table, cross-checked against both `git shortlog -sne origin/master` and `gh pr list --state merged --json author` so each has a real merged PR, not just a stray commit:

| Login | Name | Source |
|---|---|---|
| `3choBoomer` | Nathan Cooke | PR #1264 ("Expose generic read-recording bridge via process global"); matches `git shortlog` (`Nathan Cooke <ncooke@shipt.com>`, 5 commits) |
| `white-hat` | Eli Stark | PR #1254 (Marksman fix); matches `git shortlog` (`Eli Stark <i@whitehat.com.ua>`, 5 commits) |
| `marvtub` | Marvin Aziz | PR #1077 (ast-grep false-positive fix); matches `git shortlog` |
| `mjfaga` | Mark Faga | PR #1066 (LSP workspace-edit ordering fix); matches `git shortlog` |
| `aeturnal` | aeturnal (no public real name on GitHub) | PR #1149 (project-intelligence persistence fix) |
| `floatGray` | floatGray (no public real name on GitHub) | PR #1051 (read-guard did-you-mean fix) |

All avatar URLs verified to resolve (HTTP 200) before adding table rows.

### Unsure / left alone

- No git history match anywhere for a "3choBoomer" *report* beyond the PR above, or for any contributor literally matching an example name given in the task brief that turned out not to exist in this repo's history — none fabricated.
- Left the existing footer note ("commit identities not represented in the table...") as-is; it already excluded the six added logins so needed no edit.
- Did not restructure or shorten the README's existing "What It Does" bullet list beyond the two additions — kept existing tone/order per instructions.

## Verification

- `npm run changelog:check` — passes (44 entries validated), including the new `.changelog/docs-v4-readme-contributors.md` (Changed section, front-matter present).
- Docs-only change; no build/test required. Skipped `npm run lint` (TypeScript-only, N/A for markdown-only diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)