### PR TITLE
fix: stable facade from fixedThisTurn getter (refs #1414)

### DIFF
--- a/clients/runtime-coordinator.ts
+++ b/clients/runtime-coordinator.ts
@@ -652,15 +652,19 @@ export class RuntimeCoordinator {
 	}
 
 	get fixedThisTurn(): PathSetLike {
-		return {
+		// Self-referencing local so chained add() returns the same facade
+		// instead of re-entering this getter and allocating a new one per call
+		// (sonar S7725).
+		const facade: PathSetLike = {
 			add: (filePath) => {
 				this._fixedThisTurn.set(filePath, true);
-				return this.fixedThisTurn;
+				return facade;
 			},
 			has: (filePath) => this._fixedThisTurn.has(filePath),
 			delete: (filePath) => this._fixedThisTurn.delete(filePath),
 			clear: () => this._fixedThisTurn.clear(),
 		};
+		return facade;
 	}
 
 	get projectRulesScan(): RuleScanResult {


### PR DESCRIPTION
Post-merge fix-forward for the SonarCloud quality-gate failure on #1420: the `fixedThisTurn` façade's `add()` returned `this.fixedThisTurn`, recursively re-entering the getter and allocating a new façade per chained call (rule S7725, new-reliability-rating 4). The façade now self-references a local. Build, strict lint, and the coordinator/tool-result suites pass.

Refs #1414

🤖 Generated with [Claude Code](https://claude.com/claude-code)