### PR TITLE
docs(skills): fix lsp-navigation parameter names; qualify source-repo-only paths

### DIFF
--- a/skills/pi-lens-lsp-navigation/SKILL.md
+++ b/skills/pi-lens-lsp-navigation/SKILL.md
@@ -13,39 +13,39 @@ Use `lsp_diagnostics` before builds/tests or after touching several files:
 
 | Need | Tool call |
 |---|---|
-| Check one file | `lsp_diagnostics({ filePath: "src/file.ts" })` |
-| Check a folder | `lsp_diagnostics({ filePath: "src/", severity: "error" })` |
-| Check exact touched files | `lsp_diagnostics({ filePaths: ["src/a.ts", "src/b.ts"], concurrency: 8 })` |
-| Slow server (Rust, Java) | `lsp_diagnostics({ filePaths: files, waitMs: 2000 })` |
-| Include warnings | `lsp_diagnostics({ filePaths: files, severity: "all" })` |
+| Check one file | `lsp_diagnostics({ path: "src/file.ts" })` |
+| Check a folder | `lsp_diagnostics({ path: "src/", severity: "error" })` |
+| Check exact touched files | `lsp_diagnostics({ paths: ["src/a.ts", "src/b.ts"], concurrency: 8 })` |
+| Slow server (Rust, Java) | `lsp_diagnostics({ paths: files, waitMs: 2000 })` |
+| Include warnings | `lsp_diagnostics({ paths: files, severity: "all" })` |
 
-Prefer explicit `filePaths` batches after multi-file edits — bounded concurrency, no unrelated directory noise.
+Prefer explicit `paths` batches after multi-file edits — bounded concurrency, no unrelated directory noise.
 
 ## Navigation (Code Intelligence)
 
 | Question | Operation | Parameters |
 |---|---|---|
-| Where is this defined? | `definition` | filePath, line, character |
-| Where is this symbol's *type* defined? | `typeDefinition` | filePath, line, character |
-| Where is this declared (vs defined)? | `declaration` | filePath, line, character |
-| Find all usages | `references` | filePath, line, character |
-| What type is this? | `hover` | filePath, line, character |
-| Call signature | `signatureHelp` | filePath, line, character (at arg position) |
-| Symbols in this file | `documentSymbol` | filePath |
-| Find symbol across project | `workspaceSymbol` | query + filePath (strongly recommended) |
-| Quick fixes available | `codeAction` | filePath, line, character, endLine, endCharacter |
-| Rename symbol safely | `rename` | filePath, line, character, newName |
-| Who implements this? | `implementation` | filePath, line, character |
-| Who calls this function? | `prepareCallHierarchy` → `incomingCalls` | filePath, line, character |
-| What does this call? | `prepareCallHierarchy` → `outgoingCalls` | filePath, line, character |
-| What commands does the server offer? | `capabilities` | (optional filePath) — lists advertised commands |
+| Where is this defined? | `definition` | path, line, character |
+| Where is this symbol's *type* defined? | `typeDefinition` | path, line, character |
+| Where is this declared (vs defined)? | `declaration` | path, line, character |
+| Find all usages | `references` | path, line, character |
+| What type is this? | `hover` | path, line, character |
+| Call signature | `signatureHelp` | path, line, character (at arg position) |
+| Symbols in this file | `documentSymbol` | path |
+| Find symbol across project | `workspaceSymbol` | query + path (strongly recommended) |
+| Quick fixes available | `codeAction` | path, line, character, endLine, endCharacter |
+| Rename symbol safely | `rename` | path, line, character, newName |
+| Who implements this? | `implementation` | path, line, character |
+| Who calls this function? | `prepareCallHierarchy` → `incomingCalls` | path, line, character |
+| What does this call? | `prepareCallHierarchy` → `outgoingCalls` | path, line, character |
+| What commands does the server offer? | `capabilities` | (optional path) — lists advertised commands |
 | Run a server command (e.g. organize imports) | `executeCommand` | command (+ commandArguments); dry-run unless `apply:true` |
 
 ## Call Hierarchy Pattern
 
 ```
 // Step 1
-lsp_navigation(operation="prepareCallHierarchy", filePath="src/api.ts", line=42, character=10)
+lsp_navigation(operation="prepareCallHierarchy", path="src/api.ts", line=42, character=10)
 // → returns callHierarchyItem
 
 // Step 2
@@ -56,7 +56,7 @@ lsp_navigation(operation="outgoingCalls", callHierarchyItem=<item from step 1>)
 ## Operational Notes
 
 - **`definition` returns nothing?** The file may not be open/indexed yet. Read it first, then retry.
-- **`workspaceSymbol` empty?** Always pass `filePath`. Unscoped queries are best-effort and frequently return nothing. If TypeScript returns "No Project", open the scoped file first.
+- **`workspaceSymbol` empty?** Always pass `path`. Unscoped queries are best-effort and frequently return nothing. If TypeScript returns "No Project", open the scoped file first.
 - **`references`** — query from the *definition site* for full cross-file coverage; usage-site queries can be partial.
 - **`signatureHelp`** — only valid at call-site argument positions; declaration positions return empty.
 - **`workspaceDiagnostics`** — tracked push snapshot only, not an active check. Use `lsp_diagnostics` when you need fresh results.

--- a/skills/pi-lens-write-ast-grep-rule/SKILL.md
+++ b/skills/pi-lens-write-ast-grep-rule/SKILL.md
@@ -141,7 +141,7 @@ The parser is a real YAML parser, so unquoted special chars throw and the rule i
      rule is not enough for standalone `.js` coverage, so shipped user-facing
      TS/JS rules that should fire under the ast-grep LSP usually need a `-js`
      twin with `language: JavaScript` plus its own fixture.
-   - the in-process NAPI fallback (`ast-grep-napi.ts`) parses the target file's
+   - the in-process NAPI fallback (`ast-grep-napi.ts` — pi-lens source checkout only, not present in the installed package) parses the target file's
      own grammar and currently runs both TS and JS rules on every jsts file. A
      grammar-agnostic twin can therefore duplicate in fallback mode.
    - **Decide explicitly:** if the rule must cover `.js` through the ast-grep
@@ -169,9 +169,9 @@ The parser is a real YAML parser, so unquoted special chars throw and the rule i
        const f=(n,k)=>{let c=n.kind()===k?1:0;for(const x of n.children())c+=f(x,k);return c};
        console.log(f(r,"subscript_expression"))})'   # >0 means the kind is real
 
-✅ Test through the REAL runner from the repo root — it loads the actual shipped
+✅ Test through the REAL runner from the pi-lens source checkout's repo root — it loads the actual shipped
    rules from rules/ast-grep-rules/rules. Assert on diagnostic `rule` ids:
-     const res = await runner.run(ctx);  // ctx.filePath = temp .ts, cwd = repo
+     const res = await runner.run(ctx);  // ctx.filePath = temp .ts, cwd = repo  (pi-lens source checkout only — not present in the installed package)
    For pattern/kind/regex-only rules (CLI-identical semantics) `ast-grep scan` is fine.
 
 ✅ Before shipping any text/regex detector, FP-scan the codebase:

--- a/skills/pi-lens-write-tree-sitter-rule/SKILL.md
+++ b/skills/pi-lens-write-tree-sitter-rule/SKILL.md
@@ -6,7 +6,7 @@ description: Use when writing a new pi-lens tree-sitter query rule YAML file —
 # Writing a pi-lens tree-sitter Rule
 
 Drop path: `rules/tree-sitter-queries/<language>/<id>.yml`  
-Language dir is **lowercase**: `typescript` `javascript` `tsx` `python` `go` `rust` `java` `csharp` `kotlin` `ruby` `cpp` `c` `css`
+Language dir is **lowercase**: `typescript` `javascript` `tsx` `python` `go` `rust` `java` `csharp` `kotlin` `php` `ruby` `cpp` `c` `css`
 
 Project rules merge with built-ins (both run). To disable a language's built-ins: rename dir to `<lang>-disabled/`.
 
@@ -115,6 +115,8 @@ predicates:
    treeSitterRunner.run() via makeRealRunnerCtx (tests/support/real-runner-ctx.ts) —
    runQueryOnFile bypasses dispatch (skip_test_files, tiers, delta, rule cache).
    Template: tests/clients/dispatch/runners/tree-sitter-skip-test-files.test.ts.
+   (These test paths exist only in a pi-lens source checkout — the installed
+   npm package ships no tests/ directory.)
 
 ✅ JS files also run typescript/ rules (shared grammar) — one rule in
    rules/tree-sitter-queries/typescript/ covers BOTH .ts and .js. No -js copy needed.


### PR DESCRIPTION
## Problem

The `pi-lens-lsp-navigation` skill instructs agents to call the tools as PRIMARY code-intelligence, but every documented example uses parameter names the tool schemas reject:

```ts
lsp_diagnostics({ filePath: "src/file.ts" })   // schema accepts only path/paths
lsp_navigation({ filePath: ..., line: ... })     // schema accepts only path
```

`lsp_diagnostics` declares `path`/`paths` (dist/tools/lsp-diagnostics.js) and `lsp_navigation` declares `path` (dist/tools/lsp-navigation.js). There is no `filePath` alias anywhere, so a call made exactly per the doc sends no target and errors. 22 occurrences fixed with a mechanical rename; table shapes untouched.

## Also included

- **write-ast-grep-rule / write-tree-sitter-rule**: the cited paths (`ast-grep-napi.ts`, repo-root `runner.run(ctx)`, `tests/support/real-runner-ctx.ts`, `tests/clients/...`) exist only in a pi-lens source checkout — the installed npm package ships no such files. Annotated so agents loading the shipped skill don't hunt for missing paths. Also added `php` to the enabled language-dir list (`rules/tree-sitter-queries/php/` ships in the package).
- Kept `ctx.filePath` inside the runner-API code sample untouched — that is the runner's own context shape, not a tool parameter.

## Verification

- `grep -ci filepath` in the lsp-navigation skill: 22 → 0
- diff vs the shipped skill files is limited to exactly these changes