### PR TITLE
fix: skip bus publishes through confirmed-stale session ctx (refs #1415)

### DIFF
--- a/.changelog/fix-1415-stale-ctx-producers.md
+++ b/.changelog/fix-1415-stale-ctx-producers.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Bus publishers avoid stale session contexts (closes #1415)** — Event producers re-resolve the current activation at delivery time and intentionally skip a confirmed-stale session target instead of logging a failed emit.

--- a/.changelog/fix-1415-stale-ctx-producers.md
+++ b/.changelog/fix-1415-stale-ctx-producers.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Bus publishers avoid stale session contexts (closes #1415)** — Event producers re-resolve the current activation at delivery time and intentionally skip a confirmed-stale session target instead of logging a failed emit.
+- **Bus publishers avoid stale session contexts (refs #1415)** — Event producers re-resolve the current activation at delivery time and intentionally skip a confirmed-stale session target instead of logging a failed emit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,10 @@ The captured-at-subscribe / used-after-replace shape also applies to pi's
 `events` API: `pi.events.emit` is a session-bound wrapper whose runtime is
 invalidated on replacement. Long-lived publishers must retain a getter and
 resolve the emitter at delivery time; deferred callbacks must resolve inside
-the callback, never before scheduling. The getter itself is activation-scoped:
+the callback, never before scheduling. The resolved target must carry its ctx;
+the shared live-emitter seam probes that ctx immediately before delivery and
+records `skipped_stale_session` instead of invoking a confirmed-stale target.
+The getter itself is activation-scoped:
 module-singleton bus/notifier/widget-render plumbing must be re-wired from the
 current factory on every `session_start`, BEFORE the #473 concurrent-secondary
 guard can return, because a sibling activation can overwrite the singleton and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ The captured-at-subscribe / used-after-replace shape also applies to pi's
 `events` API: `pi.events.emit` is a session-bound wrapper whose runtime is
 invalidated on replacement. Long-lived publishers must retain a getter and
 resolve the emitter at delivery time; deferred callbacks must resolve inside
-the callback, never before scheduling. The resolved target must carry its ctx;
+the callback, never before scheduling. The resolved target carries the process-latest event ctx (a per-activation ctx is a known refinement, #1415);
 the shared live-emitter seam probes that ctx immediately before delivery and
 records `skipped_stale_session` instead of invoking a confirmed-stale target.
 The getter itself is activation-scoped:

--- a/clients/bus-events-logger.ts
+++ b/clients/bus-events-logger.ts
@@ -26,6 +26,9 @@
  * spam one identical line per write batch for an entire session with zero
  * new information after the first. Both are gated log-once-per-process, the
  * same `hasLoggedFailure` shape the producers already use for emit_failed.
+ * `skipped_stale_session` is an info-level per-occurrence outcome: the emit
+ * seam intentionally declined a target whose associated ctx was confirmed
+ * stale, so it is neither a bus failure nor input for the smells rollup.
  * The empty-batch branch (`paths.length === 0` / `files.length === 0`) is
  * NOT logged at all: every call site already guards against invoking these
  * functions with nothing to report (see clients/pipeline.ts,
@@ -57,12 +60,14 @@ export type BusEventOutcome =
 	| "emitted"
 	| "skipped_unwired"
 	| "skipped_disabled"
+	| "skipped_stale_session"
 	| "emit_failed";
 
 export interface BusEventLogEntry {
 	ts: string;
 	event: BusEventName;
 	outcome: BusEventOutcome;
+	level?: "info";
 	cwd: string;
 	/** paths.length (files:touched) / files.length (diagnostics), for `emitted`. */
 	fileCount?: number;

--- a/clients/bus-publish.ts
+++ b/clients/bus-publish.ts
@@ -174,8 +174,18 @@ export function publishFilesTouched(args: PublishFilesTouchedArgs): void {
 		args.dbg?.(`bus-publish: recent-touches append failed: ${err}`);
 	});
 
-	const busEmit = liveEmitter.get();
-	if (!busEmit) {
+	const resolution = liveEmitter.resolve();
+	if (resolution.outcome === "stale-session") {
+		logBusEvent({
+			event: BUS_FILES_TOUCHED_EVENT,
+			outcome: "skipped_stale_session",
+			level: "info",
+			cwd: normalizeFilePath(args.cwd),
+			reason: args.reason,
+		});
+		return;
+	}
+	if (resolution.outcome === "unwired") {
 		if (!hasLoggedUnwired) {
 			hasLoggedUnwired = true;
 			logBusEvent({
@@ -187,6 +197,7 @@ export function publishFilesTouched(args: PublishFilesTouchedArgs): void {
 		}
 		return;
 	}
+	const busEmit = resolution.emit;
 
 	try {
 		const payload: FilesTouchedPayload = {

--- a/clients/diagnostics-publish.ts
+++ b/clients/diagnostics-publish.ts
@@ -218,8 +218,17 @@ export function publishDiagnostics(args: PublishDiagnosticsArgs): void {
 		}
 		return;
 	}
-	const busEmit = liveEmitter.get();
-	if (!busEmit) {
+	const resolution = liveEmitter.resolve();
+	if (resolution.outcome === "stale-session") {
+		logBusEvent({
+			event: BUS_DIAGNOSTICS_EVENT,
+			outcome: "skipped_stale_session",
+			level: "info",
+			cwd: normalizeFilePath(args.cwd),
+		});
+		return;
+	}
+	if (resolution.outcome === "unwired") {
 		if (!hasLoggedUnwired) {
 			hasLoggedUnwired = true;
 			logBusEvent({
@@ -230,6 +239,7 @@ export function publishDiagnostics(args: PublishDiagnosticsArgs): void {
 		}
 		return;
 	}
+	const busEmit = resolution.emit;
 
 	try {
 		const fileEntries: PilensDiagnosticsFileEntry[] = args.files.map((f) => {

--- a/clients/disposition-publish.ts
+++ b/clients/disposition-publish.ts
@@ -105,8 +105,17 @@ export function publishDisposition(args: PublishDispositionArgs): void {
 		}
 		return;
 	}
-	const busEmit = liveEmitter.get();
-	if (!busEmit) {
+	const resolution = liveEmitter.resolve();
+	if (resolution.outcome === "stale-session") {
+		logBusEvent({
+			event: BUS_DISPOSITION_EVENT,
+			outcome: "skipped_stale_session",
+			level: "info",
+			cwd: normalizeFilePath(args.cwd),
+		});
+		return;
+	}
+	if (resolution.outcome === "unwired") {
 		if (!hasLoggedUnwired) {
 			hasLoggedUnwired = true;
 			logBusEvent({
@@ -117,6 +126,7 @@ export function publishDisposition(args: PublishDispositionArgs): void {
 		}
 		return;
 	}
+	const busEmit = resolution.emit;
 
 	try {
 		const payload: PilensDispositionPayload = {

--- a/clients/format-events-publish.ts
+++ b/clients/format-events-publish.ts
@@ -179,8 +179,17 @@ export function publishFormatQueued(args: PublishFormatQueuedArgs): void {
 		}
 		return;
 	}
-	const busEmit = liveEmitter.get();
-	if (!busEmit) {
+	const resolution = liveEmitter.resolve();
+	if (resolution.outcome === "stale-session") {
+		logBusEvent({
+			event: BUS_FORMAT_QUEUED_EVENT,
+			outcome: "skipped_stale_session",
+			level: "info",
+			cwd: normalizeFilePath(args.cwd),
+		});
+		return;
+	}
+	if (resolution.outcome === "unwired") {
 		if (!hasLoggedQueuedUnwired) {
 			hasLoggedQueuedUnwired = true;
 			logBusEvent({
@@ -191,6 +200,7 @@ export function publishFormatQueued(args: PublishFormatQueuedArgs): void {
 		}
 		return;
 	}
+	const busEmit = resolution.emit;
 
 	try {
 		const payload: FormatQueuedPayload = {
@@ -254,8 +264,17 @@ export function publishFormatStart(args: PublishFormatStartArgs): void {
 		}
 		return;
 	}
-	const busEmit = liveEmitter.get();
-	if (!busEmit) {
+	const resolution = liveEmitter.resolve();
+	if (resolution.outcome === "stale-session") {
+		logBusEvent({
+			event: BUS_FORMAT_START_EVENT,
+			outcome: "skipped_stale_session",
+			level: "info",
+			cwd: normalizeFilePath(args.cwd),
+		});
+		return;
+	}
+	if (resolution.outcome === "unwired") {
 		if (!hasLoggedStartUnwired) {
 			hasLoggedStartUnwired = true;
 			logBusEvent({
@@ -266,6 +285,7 @@ export function publishFormatStart(args: PublishFormatStartArgs): void {
 		}
 		return;
 	}
+	const busEmit = resolution.emit;
 
 	try {
 		const paths = args.paths.map((p) => normalizeFilePath(p));
@@ -333,8 +353,17 @@ export function publishAutofixStart(args: PublishAutofixStartArgs): void {
 		}
 		return;
 	}
-	const busEmit = liveEmitter.get();
-	if (!busEmit) {
+	const resolution = liveEmitter.resolve();
+	if (resolution.outcome === "stale-session") {
+		logBusEvent({
+			event: BUS_AUTOFIX_START_EVENT,
+			outcome: "skipped_stale_session",
+			level: "info",
+			cwd: normalizeFilePath(args.cwd),
+		});
+		return;
+	}
+	if (resolution.outcome === "unwired") {
 		if (!hasLoggedAutofixStartUnwired) {
 			hasLoggedAutofixStartUnwired = true;
 			logBusEvent({
@@ -345,6 +374,7 @@ export function publishAutofixStart(args: PublishAutofixStartArgs): void {
 		}
 		return;
 	}
+	const busEmit = resolution.emit;
 
 	try {
 		const paths = args.paths.map((p) => normalizeFilePath(p));

--- a/clients/live-bus-emitter.ts
+++ b/clients/live-bus-emitter.ts
@@ -1,13 +1,23 @@
 import { recordDegradation } from "./degradation-ledger.js";
+import { probeCtxActive } from "./session-lifecycle.js";
 
-/** Resolve a pi event-bus emitter at delivery time, not subscription time. */
+/** Resolve a pi event-bus emitter and its ctx at delivery time, not
+ * subscription time. */
 export type BusEmitFn = (channel: string, data: unknown) => void;
-export type BusEmitGetter = () => BusEmitFn | undefined;
+export interface BusEmitTarget {
+	emit: BusEmitFn;
+	ctx: unknown;
+}
+export type BusEmitGetter = () => BusEmitFn | BusEmitTarget | undefined;
+export type BusEmitResolution =
+	| { outcome: "ready"; emit: BusEmitFn }
+	| { outcome: "unwired" }
+	| { outcome: "stale-session" };
 
 export interface LiveBusEmitter {
 	wire(emit: BusEmitFn | undefined): void;
 	wireGetter(getter: BusEmitGetter | undefined): void;
-	get(): BusEmitFn | undefined;
+	resolve(): BusEmitResolution;
 	reset(): void;
 }
 
@@ -32,8 +42,19 @@ export function createLiveBusEmitter(): LiveBusEmitter {
 			getter = next;
 			emit = undefined;
 		},
-		get() {
-			return getter?.() ?? emit;
+		resolve() {
+			// Invoke the getter for every delivery so session_start rewiring can
+			// replace a captured pre-await activation with the current primary. When
+			// the current target is nevertheless confirmed stale, never invoke it.
+			const target = getter?.() ?? emit;
+			if (!target) return { outcome: "unwired" };
+			if (typeof target === "function") {
+				return { outcome: "ready", emit: target };
+			}
+			if (probeCtxActive(target.ctx) === false) {
+				return { outcome: "stale-session" };
+			}
+			return { outcome: "ready", emit: target.emit };
 		},
 		reset() {
 			emit = undefined;

--- a/index.ts
+++ b/index.ts
@@ -535,7 +535,7 @@ export default function (pi: ExtensionAPI) {
 		// return early for a concurrent in-process subagent. (#1383)
 		wireUserNotifier(hostPorts);
 		initLensEventsGetter(() => ({ emit: hostPorts.emit.lens }));
-		const getLiveEmit = () => hostPorts.emit.bus;
+		const getLiveEmit = () => ({ emit: hostPorts.emit.bus, ctx: latestEventCtx });
 		wireBusEmitterGetter(getLiveEmit);
 		wireDiagnosticsBusEmitterGetter(getLiveEmit);
 		wireDispositionBusEmitterGetter(getLiveEmit);

--- a/tests/clients/bus-publish.test.ts
+++ b/tests/clients/bus-publish.test.ts
@@ -77,6 +77,61 @@ describe("bus-publish — pilens:files:touched (#482)", () => {
 		)).toBe(false);
 	});
 
+	it("skips a resolved emitter whose session ctx is stale", () => {
+		const emit = vi.fn();
+		const staleCtx = {
+			isIdle: () => {
+				throw new Error("This extension ctx is stale after session replacement or reload");
+			},
+		};
+		wireBusEmitterGetter(() => ({ emit, ctx: staleCtx }));
+
+		publishFilesTouched({
+			reason: "autofix",
+			paths: ["/repo/src/a.ts"],
+			cwd: "/repo",
+		});
+
+		expect(emit).not.toHaveBeenCalled();
+		expect(logBusEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: BUS_FILES_TOUCHED_EVENT,
+				outcome: "skipped_stale_session",
+				level: "info",
+			}),
+		);
+		expect(logBusEvent.mock.calls.some(([entry]) =>
+			(entry as { outcome?: string }).outcome === "emit_failed",
+		)).toBe(false);
+	});
+
+	it("re-resolves and publishes through the fresh session ctx", () => {
+		const staleEmit = vi.fn();
+		const freshEmit = vi.fn();
+		let current: {
+			emit: (channel: string, data: unknown) => void;
+			ctx: { isIdle: () => unknown };
+		} = {
+			emit: staleEmit,
+			ctx: {
+				isIdle: () => {
+					throw new Error("This extension ctx is stale after session replacement or reload");
+				},
+			},
+		};
+		wireBusEmitterGetter(() => current);
+		current = { emit: freshEmit, ctx: { isIdle: () => false } };
+
+		publishFilesTouched({
+			reason: "autofix",
+			paths: ["/repo/src/a.ts"],
+			cwd: "/repo",
+		});
+
+		expect(staleEmit).not.toHaveBeenCalled();
+		expect(freshEmit).toHaveBeenCalledTimes(1);
+	});
+
 	it("emits the exact payload shape from the issue: v, source, reason, paths, cwd", () => {
 		const emit = vi.fn();
 		wireBusEmitter(emit);

--- a/tests/clients/bus-publish.test.ts
+++ b/tests/clients/bus-publish.test.ts
@@ -105,6 +105,32 @@ describe("bus-publish — pilens:files:touched (#482)", () => {
 		)).toBe(false);
 	});
 
+	it("fails open when the probe cannot classify the ctx", () => {
+		// The tri-state matters: only a CONFIRMED-stale ctx (probe === false)
+		// may skip delivery. A ctx without isIdle (undefined) and a ctx whose
+		// probe throws a NON-stale error (undefined — "don't guess") must both
+		// fall through to the emit, where a real failure still logs
+		// emit_failed. Silent inversion here would drop telemetry for any
+		// odd-shaped ctx.
+		for (const oddCtx of [
+			{},
+			{ isIdle: () => { throw new Error("boom, not the stale fragment"); } },
+		]) {
+			const emit = vi.fn();
+			wireBusEmitterGetter(() => ({ emit, ctx: oddCtx }));
+			publishFilesTouched({
+				reason: "autofix",
+				paths: ["/repo/src/a.ts"],
+				cwd: "/repo",
+			});
+			expect(emit).toHaveBeenCalledTimes(1);
+			expect(logBusEvent.mock.calls.some(([entry]) =>
+				(entry as { outcome?: string }).outcome === "skipped_stale_session",
+			)).toBe(false);
+			vi.clearAllMocks();
+		}
+	});
+
 	it("re-resolves and publishes through the fresh session ctx", () => {
 		const staleEmit = vi.fn();
 		const freshEmit = vi.fn();

--- a/tests/clients/format-events-publish.test.ts
+++ b/tests/clients/format-events-publish.test.ts
@@ -17,6 +17,7 @@ import {
 	publishFormatQueued,
 	publishFormatStart,
 	wireFormatEventsBusEmitter,
+	wireFormatEventsBusEmitterGetter,
 } from "../../clients/format-events-publish.js";
 import { _resetForTests as _resetBusPublishForTests } from "../../clients/bus-publish.js";
 
@@ -48,6 +49,27 @@ describe("format-events-publish — pilens:format:queued / pilens:format:start (
 					tool: "write",
 				}),
 			).not.toThrow();
+		});
+
+		it("skips a stale session target without attempting emit", () => {
+			const emit = vi.fn();
+			wireFormatEventsBusEmitterGetter(() => ({
+				emit,
+				ctx: {
+					isIdle: () => {
+						throw new Error("This extension ctx is stale after session replacement or reload");
+					},
+				},
+			}));
+
+			publishFormatQueued({ filePath: "/repo/a.ts", cwd: "/repo", tool: "write" });
+
+			expect(emit).not.toHaveBeenCalled();
+			expect(logBusEvent).toHaveBeenCalledWith(expect.objectContaining({
+				event: BUS_FORMAT_QUEUED_EVENT,
+				outcome: "skipped_stale_session",
+				level: "info",
+			}));
 		});
 
 		it("emits the exact payload shape: v, source, filePath, cwd, tool", () => {

--- a/tests/clients/smells-rollup.test.ts
+++ b/tests/clients/smells-rollup.test.ts
@@ -116,6 +116,10 @@ describe("countRecentSmells", () => {
 		writeLines(path.join(tmpDir, "bus-events.log"), [
 			staleCtxLine(),
 			staleCtxLine(),
+			JSON.stringify({
+				outcome: "skipped_stale_session",
+				error: "Error: ctx is stale after session replacement",
+			}),
 			JSON.stringify({ outcome: "emitted", event: "x" }),
 			JSON.stringify({ outcome: "emit_failed", error: "ECONNRESET" }),
 			"not json at all",


### PR DESCRIPTION
## Summary

Bus-event producers no longer publish through a captured extension ctx after session replacement. The shared `live-bus-emitter` resolves `{emit, ctx}` at delivery time and runs the existing `probeCtxActive` check immediately before every delivery: a confirmed-stale target is skipped with a new `skipped_stale_session` outcome (info level) instead of attempting the emit and logging `emit_failed`; fresh getters re-resolve and deliver (session_start rewires the getter before any new deliveries). The tri-state is strict — only `=== false` skips; unclassifiable ctx shapes fail open to the emit path so real failures still surface as `emit_failed`, and the smells-rollup counter (`staleCtxEmitFailed`) is unaffected by intentional skips, keeping the #1123 smell meaningful.

Scope boundary, deliberate: `lens-events.ts` keeps its bare emit shape — its bare catch never writes bus-events.log, so it cannot feed the smell; folding it in is a possible follow-up. The concurrent-secondary variant (probe subject is the process-latest ctx, not the emitting activation's own — a narrow false-skip/false-ready window that self-heals on the next turn event) remains open on #1415 with an `ownEventCtx` refinement sketched; hence refs, not closes.

## Verification

- Adversarial review verdict: MERGE. TOCTOU-safe (emit still wrapped in the producers' catch — a race lands as a genuine `emit_failed`), tri-state verified strict, probe cost negligible (leaf module, no I/O), background-closure re-resolution traced end-to-end, log volume bounded by the NDJSON size cap.
- Red-first verified by reviewer mutation (gate neutered → 2 tests fail for the right reason), restored.
- The one suspicious combined-run test timeout was verified NOT a regression via a controlled branch-vs-master comparison (branch faster than master).
- Full suite run by the reviewer: 6380 passed; all 11 failures reproduced on master or proved load-flaky with varying test names (7/8 isolated passes).
- Review follow-ups applied: fail-open branch pinned with tests, changelog softened to refs, AGENTS.md wording corrected.

Refs #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)
