### PR TITLE
fix: hasKind description + hasDescendantKind parity on ast_grep_replace (#1423)

### DIFF
--- a/.changelog/fix-1423-haskind-parity.md
+++ b/.changelog/fix-1423-haskind-parity.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **`ast_grep_replace` now matches `ast_grep_search`'s `hasKind`/`hasDescendantKind` surface (closes #1423)** — `ast_grep_replace`'s `hasKind` param description wrongly said "contain a descendant"; it actually restricts to an **immediate child** (ast-grep default `stopBy: neighbor`), same as `ast_grep_search`. The description now matches the real behavior. `ast_grep_replace` also gained the `hasDescendantKind` param `ast_grep_search` already had — the explicit recursive form (`stopBy: end`) for when the target kind is nested below an immediate child; it's mutually exclusive with `hasKind`, surfaced as a clear synthesis error from both tools. `skills/pi-lens-ast-grep/SKILL.md`'s structural-intent table drops the now-obsolete "replace has no `hasDescendantKind`" divergence warning and documents both params as available on both tools.

--- a/skills/pi-lens-ast-grep/SKILL.md
+++ b/skills/pi-lens-ast-grep/SKILL.md
@@ -56,11 +56,11 @@ Use these instead of writing raw YAML:
 |---|---|---|
 | `insideKind` | both | Only match inside an ancestor of this node kind (searches ALL ancestors, `stopBy: end`) |
 | `hasKind` | both | Only match nodes whose **immediate child** has this kind (`stopBy: neighbor` — NOT recursive) |
-| `hasDescendantKind` | `ast_grep_search` only | Only match nodes containing this kind **anywhere in their descendants** (`stopBy: end`) — use this instead of `hasKind` when the target isn't a direct child |
+| `hasDescendantKind` | both | Only match nodes containing this kind **anywhere in their descendants** (`stopBy: end`) — use this instead of `hasKind` when the target isn't a direct child |
 | `follows` | both | Only match nodes preceded by a sibling matching this pattern |
 | `precedes` | both | Only match nodes followed by a sibling matching this pattern |
 
-⚠ `ast_grep_replace` has no `hasDescendantKind` param — only `hasKind` (immediate child, same as `ast_grep_search`'s). Refs #1423.
+`hasKind` and `hasDescendantKind` are mutually exclusive on both tools — combining them errors.
 
 ```
 # console.log only inside functions

--- a/tests/clients/ast-grep-replace-descendant-kind.e2e.test.ts
+++ b/tests/clients/ast-grep-replace-descendant-kind.e2e.test.ts
@@ -1,0 +1,71 @@
+/**
+ * End-to-end proof that `ast_grep_replace`'s new `hasDescendantKind` param
+ * (#1423) actually changes match behavior against the real ast-grep CLI —
+ * not just that it parses into YAML. `hasKind` is ast-grep's default
+ * immediate-child `has` (stopBy: neighbor); `hasDescendantKind` is the
+ * explicit recursive form (stopBy: end). A target whose matching kind sits
+ * a level below the immediate child (nested inside an `if` block) must
+ * match under `hasDescendantKind` but NOT under `hasKind`.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AstGrepClient } from "../../clients/ast-grep-client.js";
+import { synthesizeReplaceRule } from "../../clients/ast-grep-yaml-synth.js";
+
+describe("ast_grep_replace hasDescendantKind — real ast-grep CLI behavioral proof (#1423)", () => {
+	let tmpDir: string;
+	let filePath: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-hdk-"));
+		filePath = path.join(tmpDir, "sample.ts");
+		// `await deepCall()` is nested two levels below the function_declaration's
+		// immediate child (statement_block -> if_statement -> statement_block ->
+		// expression_statement -> await_expression) — NOT an immediate child.
+		fs.writeFileSync(
+			filePath,
+			[
+				"async function outer() {",
+				"  if (true) {",
+				"    await deepCall();",
+				"  }",
+				"}",
+			].join("\n"),
+			"utf8",
+		);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("hasKind (immediate child) does NOT match a deep descendant", async () => {
+		const client = new AstGrepClient();
+		expect(await client.ensureAvailable()).toBe(true);
+		const ruleYaml = synthesizeReplaceRule({
+			pattern: "async function $NAME() { $$$BODY }",
+			lang: "typescript",
+			rewrite: "async function $NAME() { /* matched */ $$$BODY }",
+			hasKind: "await_expression",
+		});
+		const result = await client.replaceWithRule(ruleYaml, [filePath], false);
+		expect(result.error).toBeUndefined();
+		expect(result.matches).toHaveLength(0);
+	});
+
+	it("hasDescendantKind (recursive) DOES match the same deep descendant", async () => {
+		const client = new AstGrepClient();
+		expect(await client.ensureAvailable()).toBe(true);
+		const ruleYaml = synthesizeReplaceRule({
+			pattern: "async function $NAME() { $$$BODY }",
+			lang: "typescript",
+			rewrite: "async function $NAME() { /* matched */ $$$BODY }",
+			hasDescendantKind: "await_expression",
+		});
+		const result = await client.replaceWithRule(ruleYaml, [filePath], false);
+		expect(result.error).toBeUndefined();
+		expect(result.matches).toHaveLength(1);
+	});
+});

--- a/tests/clients/ast-grep-yaml-synth.test.ts
+++ b/tests/clients/ast-grep-yaml-synth.test.ts
@@ -264,4 +264,29 @@ describe("synthesizeReplaceRule", () => {
 		expect(yaml).toContain("inside:");
 		expect(yaml).toContain("fix:");
 	});
+
+	it("supports hasDescendantKind with stopBy: end, alongside fix (#1423)", () => {
+		const yaml = synthesizeReplaceRule({
+			pattern: "var $X",
+			lang: "javascript",
+			rewrite: "let $X",
+			hasDescendantKind: "await_expression",
+		});
+		expect(yaml).toContain("has:");
+		expect(yaml).toContain("kind: await_expression");
+		expect(yaml).toContain("stopBy: end");
+		expect(yaml).toContain("fix:");
+	});
+
+	it("rejects hasKind and hasDescendantKind combined on replace (#1423)", () => {
+		expect(() =>
+			synthesizeReplaceRule({
+				pattern: "var $X",
+				lang: "javascript",
+				rewrite: "let $X",
+				hasKind: "identifier",
+				hasDescendantKind: "await_expression",
+			}),
+		).toThrow(/mutually exclusive/);
+	});
 });

--- a/tests/tools/ast-grep-replace.test.ts
+++ b/tests/tools/ast-grep-replace.test.ts
@@ -29,6 +29,22 @@ describe("ast_grep_replace tool", () => {
 			expect(langSchema.enum).toContain("python");
 			expect(langSchema.enum).toContain("rust");
 		});
+
+		it("hasKind description describes immediate-child semantics, not descendant (#1423)", () => {
+			const tool = createAstGrepReplaceTool(makeClient());
+			const properties = (tool.parameters as { properties: Record<string, unknown> }).properties;
+			const hasKindSchema = properties.hasKind as { description: string };
+			expect(hasKindSchema.description).not.toContain("descendant");
+			expect(hasKindSchema.description.toLowerCase()).toContain("immediate child");
+		});
+
+		it("advertises hasDescendantKind alongside hasKind (#1423)", () => {
+			const tool = createAstGrepReplaceTool(makeClient());
+			const properties = (tool.parameters as { properties: Record<string, unknown> }).properties;
+			expect(properties).toHaveProperty("hasDescendantKind");
+			const hasDescendantKindSchema = properties.hasDescendantKind as { description: string };
+			expect(hasDescendantKindSchema.description.toLowerCase()).toContain("descendant");
+		});
 	});
 
 	describe("lang double-quote stripping", () => {
@@ -138,6 +154,48 @@ describe("ast_grep_replace tool", () => {
 			);
 			expect(replace).toHaveBeenCalledOnce();
 			expect(replaceWithRule).not.toHaveBeenCalled();
+		});
+
+		it("routes to replaceWithRule when hasDescendantKind is set, producing stopBy: end (#1423)", async () => {
+			const replaceWithRule = vi.fn().mockResolvedValue({ matches: [], totalMatches: 0, applied: false });
+			const replace = vi.fn();
+			const tool = createAstGrepReplaceTool(makeClient({ replaceWithRule, replace }));
+			await tool.execute(
+				"r4",
+				{ pattern: "var $X", rewrite: "let $X", lang: "typescript", hasDescendantKind: "await_expression" },
+				new AbortController().signal,
+				null,
+				{ cwd: "." },
+			);
+			expect(replaceWithRule).toHaveBeenCalledOnce();
+			expect(replace).not.toHaveBeenCalled();
+			const calledYaml = replaceWithRule.mock.calls[0][0] as string;
+			expect(calledYaml).toContain("has:");
+			expect(calledYaml).toContain("kind: await_expression");
+			expect(calledYaml).toContain("stopBy: end");
+			expect(calledYaml).toContain("fix:");
+		});
+
+		it("errors clearly when hasKind and hasDescendantKind are combined (#1423)", async () => {
+			const replaceWithRule = vi.fn();
+			const tool = createAstGrepReplaceTool(makeClient({ replaceWithRule }));
+			const result = await tool.execute(
+				"r5",
+				{
+					pattern: "var $X",
+					rewrite: "let $X",
+					lang: "typescript",
+					hasKind: "identifier",
+					hasDescendantKind: "await_expression",
+				},
+				new AbortController().signal,
+				null,
+				{ cwd: "." },
+			);
+			expect(replaceWithRule).not.toHaveBeenCalled();
+			expect(result.isError).toBe(true);
+			const text = String(result.content[0].text);
+			expect(text).toContain("mutually exclusive");
 		});
 	});
 

--- a/tools/ast-grep-replace.ts
+++ b/tools/ast-grep-replace.ts
@@ -85,7 +85,16 @@ export function createAstGrepReplaceTool(astGrepClient: AstGrepClient) {
 				Type.String({ description: "Restrict matches to nodes inside an ancestor of this AST node kind. Synthesizes a YAML rule." }),
 			),
 			hasKind: Type.Optional(
-				Type.String({ description: "Restrict matches to nodes that contain a descendant of this AST node kind." }),
+				Type.String({
+					description:
+						'Restrict matches to nodes whose immediate child has this AST node kind (ast-grep default stopBy: neighbor). Example: `hasKind: "await_expression"`.',
+				}),
+			),
+			hasDescendantKind: Type.Optional(
+				Type.String({
+					description:
+						"Restrict matches to nodes containing this AST node kind anywhere in their descendants. Explicit recursive form (`stopBy: end`); use this instead of `hasKind` when nesting is not immediate.",
+				}),
 			),
 			follows: Type.Optional(
 				Type.String({ description: "Restrict matches to nodes that immediately follow a sibling matching this pattern." }),
@@ -113,7 +122,7 @@ export function createAstGrepReplaceTool(astGrepClient: AstGrepClient) {
 		) {
 			const startedAt = Date.now();
 			const { pattern, rewrite, paths, apply, strictness,
-				insideKind, hasKind, follows, precedes } = params as {
+				insideKind, hasKind, hasDescendantKind, follows, precedes } = params as {
 				pattern: string;
 				rewrite: string;
 				lang: string;
@@ -122,6 +131,7 @@ export function createAstGrepReplaceTool(astGrepClient: AstGrepClient) {
 				strictness?: string;
 				insideKind?: string;
 				hasKind?: string;
+				hasDescendantKind?: string;
 				follows?: string;
 				precedes?: string;
 			};
@@ -181,10 +191,10 @@ export function createAstGrepReplaceTool(astGrepClient: AstGrepClient) {
 			const searchPaths = paths?.length ? paths : [ctx.cwd || "."];
 
 			// Phase 3: structural-intent params → synthesize YAML with fix: field
-			if (hasStructuralIntent({ insideKind, hasKind, follows, precedes })) {
+			if (hasStructuralIntent({ insideKind, hasKind, hasDescendantKind, follows, precedes })) {
 				let ruleYaml: string;
 				try {
-					ruleYaml = synthesizeReplaceRule({ pattern, lang, rewrite, insideKind, hasKind, follows, precedes });
+					ruleYaml = synthesizeReplaceRule({ pattern, lang, rewrite, insideKind, hasKind, hasDescendantKind, follows, precedes });
 				} catch (err) {
 					logOutcome("error", { errorRaw: String(err) });
 					return { content: [{ type: "text" as const, text: `Error synthesizing rule: ${err}` }], isError: true, details: {} };


### PR DESCRIPTION
## Summary

Closes the two remaining #1423 items after the doc half landed in #1428:

- `ast_grep_replace`'s `hasKind` description claimed descendant matching; the verified behavior (shared `synthesizeRule`, ast-grep default `stopBy: neighbor`) is immediate-child. Description now matches `ast_grep_search`'s accurate wording.
- `ast_grep_replace` gains `hasDescendantKind` (explicit recursive form, `stopBy: end`), mirroring search's schema and plumbing exactly; mutual exclusion with `hasKind` is enforced by the shared synth throw, so both tools' error paths are identical by construction. Skill table updated — the cross-tool divergence warning from #1428 is now obsolete and replaced with unified per-tool rows.

## Verification

- Behavioral e2e with the real ast-grep CLI: a deeply nested `await_expression` gets **0 matches under `hasKind`** and **1 match under `hasDescendantKind`** — proving the semantics, not just the schema.
- Schema/routing/mutual-exclusion tests added; synth tests extended for the replace path; the #1428 skill-doc-drift suite passes unchanged (the schema addition legalizes the new table row automatically).
- 103 tests across 5 files green; build + strict lint + changelog fragment clean. Reviewed via diff inspection against the session's prior verification of this exact seam (two independent rounds already established the hasKind ground truth).

Closes #1423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
