### PR TITLE
fix: per-activation event ctx and guarded lens emits (#1415)

### DIFF
--- a/.changelog/fix-1415-stale-ctx-producers.md
+++ b/.changelog/fix-1415-stale-ctx-producers.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Bus publishers keep activation context ownership (closes #1415)** — Event producers pair each live emitter with its activation context, guard lens events through the shared stale-session seam, and retain the process-latest context only as a boot-window fallback.
+- **Bus publishers keep activation context ownership (closes #1415)** — Event producers pair each live emitter with its OWN activation's context (no fallback to a process-global "latest ctx", which could belong to an unrelated sibling activation) and guard lens events through the shared stale-session seam with the same occurrence-scoped failure gating every other producer uses. Lens emit failures now count toward the `bus-stale` degradation smell like every other producer's — intentional: a probe-undefined or resolve/emit race on the lens path is a genuine failure that should be visible, not silently excluded.

--- a/.changelog/fix-1415-stale-ctx-producers.md
+++ b/.changelog/fix-1415-stale-ctx-producers.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Bus publishers avoid stale session contexts (refs #1415)** — Event producers re-resolve the current activation at delivery time and intentionally skip a confirmed-stale session target instead of logging a failed emit.
+- **Bus publishers keep activation context ownership (closes #1415)** — Event producers pair each live emitter with its activation context, guard lens events through the shared stale-session seam, and retain the process-latest context only as a boot-window fallback.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,21 +164,7 @@ For human contributors and issue/PR authors, see `CONTRIBUTING.md` at the repo r
 
 ### Recurring defect shapes — screen against these BEFORE you write code
 
-The captured-at-subscribe / used-after-replace shape also applies to pi's
-`events` API: `pi.events.emit` is a session-bound wrapper whose runtime is
-invalidated on replacement. Long-lived publishers must retain a getter and
-resolve the emitter at delivery time; deferred callbacks must resolve inside
-the callback, never before scheduling. The resolved target pairs the emitter
-with its activation-owned event ctx and uses the process-latest ctx only during
-the activation's boot window. The shared live-emitter seam probes that ctx
-immediately before delivery and
-records `skipped_stale_session` instead of invoking a confirmed-stale target.
-The getter itself is activation-scoped:
-module-singleton bus/notifier/widget-render plumbing must be re-wired from the
-current factory on every `session_start`, BEFORE the #473 concurrent-secondary
-guard can return, because a sibling activation can overwrite the singleton and
-later go stale. Emit-failure suppression is occurrence-scoped (success re-arms
-it), and a stale occurrence records one `bus-stale` degradation. (#1128, #1383)
+The captured-at-subscribe / used-after-replace shape also applies to pi's `events` API: `pi.events.emit` is a session-bound wrapper whose runtime is invalidated on replacement. Long-lived publishers must retain a getter and resolve the emitter at delivery time; deferred callbacks must resolve inside the callback, never before scheduling. The resolved target pairs the emitter with its OWN activation's event ctx — never a process-global "latest ctx", which can belong to an unrelated sibling activation after a replacement and would silently pass the stale-session probe (a live-looking ctx with no relation to the paired emitter, dropping every publish until the new activation's own first handler arrives; #1415). The shared live-emitter seam probes that ctx immediately before delivery and records `skipped_stale_session` instead of invoking a confirmed-stale target. The getter itself is activation-scoped: module-singleton bus/notifier/widget-render plumbing must be re-wired from the current factory on every `session_start`, BEFORE the #473 concurrent-secondary guard can return, because a sibling activation can overwrite the singleton and later go stale. Emit-failure suppression is occurrence-scoped (success re-arms it), and a stale occurrence records one `bus-stale` degradation. (#1128, #1383, #1415)
 
 This is the payoff of the two disciplines above: a bounded checklist of defect *shapes* that each recurred ≥2× across the arc. Read it at task start; when your change matches a shape, treat the screen as an acceptance criterion (and the regression test the shape implies). Each entry is **SHAPE → SCREEN (when you touch X, verify Y) → canonical example → detection**. Where a shape has a fuller treatment above, this cross-references rather than restates it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,8 +168,10 @@ The captured-at-subscribe / used-after-replace shape also applies to pi's
 `events` API: `pi.events.emit` is a session-bound wrapper whose runtime is
 invalidated on replacement. Long-lived publishers must retain a getter and
 resolve the emitter at delivery time; deferred callbacks must resolve inside
-the callback, never before scheduling. The resolved target carries the process-latest event ctx (a per-activation ctx is a known refinement, #1415);
-the shared live-emitter seam probes that ctx immediately before delivery and
+the callback, never before scheduling. The resolved target pairs the emitter
+with its activation-owned event ctx and uses the process-latest ctx only during
+the activation's boot window. The shared live-emitter seam probes that ctx
+immediately before delivery and
 records `skipped_stale_session` instead of invoking a confirmed-stale target.
 The getter itself is activation-scoped:
 module-singleton bus/notifier/widget-render plumbing must be re-wired from the

--- a/clients/bus-events-logger.ts
+++ b/clients/bus-events-logger.ts
@@ -1,13 +1,20 @@
 /**
  * Persistent NDJSON trace of `pi.events` bus publish attempts
  * (`pilens:files:touched` #482 / `pilens:diagnostics` #502 /
- * `pilens:format:queued` + `pilens:format:start` #673).
+ * `pilens:diagnostic:disposition` / `pilens:format:queued` +
+ * `pilens:format:start` + `pilens:autofix:start` #673/#684 /
+ * `pi-lens/analysis-complete` + `pi-lens/findings` + `pi-lens/turn-findings`
+ * #1415) — nine event names across five producers.
  *
- * All four producers (clients/bus-publish.ts, clients/diagnostics-publish.ts,
- * clients/format-events-publish.ts) are fire-and-forget: on failure or on a
- * structural no-op (never wired, kill switch off) they only invoke an
- * optional `dbg` callback, which varies by host and is a documented no-op in
- * the MCP host (clients/mcp/session.ts's `dbg: noop`). That leaves
+ * All five producers (clients/bus-publish.ts, clients/diagnostics-publish.ts,
+ * clients/disposition-publish.ts, clients/format-events-publish.ts,
+ * clients/lens-events.ts) are fire-and-forget: on failure or on a structural
+ * no-op (never wired, kill switch off) the four #482/#502/#673/#684
+ * producers only invoke an optional `dbg` callback, which varies by host and
+ * is a documented no-op in the MCP host (clients/mcp/session.ts's
+ * `dbg: noop`); `lens-events.ts` (#1415) has no `dbg` param at all — its
+ * events are purely observational inter-extension telemetry, so this NDJSON
+ * trace is its ONLY failure-visible surface. Either way, that leaves
  * bus-publish outcomes invisible in exactly the context where they matter
  * most — same failure shape as the #544 MCP session_start incident this repo
  * already fixed once.

--- a/clients/bus-events-logger.ts
+++ b/clients/bus-events-logger.ts
@@ -54,7 +54,10 @@ export type BusEventName =
 	| "pilens:diagnostic:disposition"
 	| "pilens:format:queued"
 	| "pilens:format:start"
-	| "pilens:autofix:start";
+	| "pilens:autofix:start"
+	| "pi-lens/analysis-complete"
+	| "pi-lens/findings"
+	| "pi-lens/turn-findings";
 
 export type BusEventOutcome =
 	| "emitted"

--- a/clients/bus-publish.ts
+++ b/clients/bus-publish.ts
@@ -23,6 +23,7 @@ import { appendRecentTouches } from "./recent-touches.js";
 import {
 	createLiveBusEmitter,
 	recordStaleBusFailure,
+	resolveLiveBusEmitter,
 	type BusEmitFn,
 	type BusEmitGetter,
 } from "./live-bus-emitter.js";
@@ -174,17 +175,12 @@ export function publishFilesTouched(args: PublishFilesTouchedArgs): void {
 		args.dbg?.(`bus-publish: recent-touches append failed: ${err}`);
 	});
 
-	const resolution = liveEmitter.resolve();
-	if (resolution.outcome === "stale-session") {
-		logBusEvent({
-			event: BUS_FILES_TOUCHED_EVENT,
-			outcome: "skipped_stale_session",
-			level: "info",
-			cwd: normalizeFilePath(args.cwd),
-			reason: args.reason,
-		});
-		return;
-	}
+	const resolution = resolveLiveBusEmitter(liveEmitter, {
+		event: BUS_FILES_TOUCHED_EVENT,
+		cwd: normalizeFilePath(args.cwd),
+		reason: args.reason,
+	});
+	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedUnwired) {
 			hasLoggedUnwired = true;

--- a/clients/bus-publish.ts
+++ b/clients/bus-publish.ts
@@ -175,11 +175,11 @@ export function publishFilesTouched(args: PublishFilesTouchedArgs): void {
 		args.dbg?.(`bus-publish: recent-touches append failed: ${err}`);
 	});
 
-	const resolution = resolveLiveBusEmitter(liveEmitter, {
+	const resolution = resolveLiveBusEmitter(liveEmitter, () => ({
 		event: BUS_FILES_TOUCHED_EVENT,
 		cwd: normalizeFilePath(args.cwd),
 		reason: args.reason,
-	});
+	}));
 	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedUnwired) {

--- a/clients/diagnostics-publish.ts
+++ b/clients/diagnostics-publish.ts
@@ -219,10 +219,10 @@ export function publishDiagnostics(args: PublishDiagnosticsArgs): void {
 		}
 		return;
 	}
-	const resolution = resolveLiveBusEmitter(liveEmitter, {
+	const resolution = resolveLiveBusEmitter(liveEmitter, () => ({
 		event: BUS_DIAGNOSTICS_EVENT,
 		cwd: normalizeFilePath(args.cwd),
-	});
+	}));
 	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedUnwired) {

--- a/clients/diagnostics-publish.ts
+++ b/clients/diagnostics-publish.ts
@@ -64,6 +64,7 @@ import { normalizeFilePath } from "./path-utils.js";
 import {
 	createLiveBusEmitter,
 	recordStaleBusFailure,
+	resolveLiveBusEmitter,
 	type BusEmitFn,
 	type BusEmitGetter,
 } from "./live-bus-emitter.js";
@@ -218,16 +219,11 @@ export function publishDiagnostics(args: PublishDiagnosticsArgs): void {
 		}
 		return;
 	}
-	const resolution = liveEmitter.resolve();
-	if (resolution.outcome === "stale-session") {
-		logBusEvent({
-			event: BUS_DIAGNOSTICS_EVENT,
-			outcome: "skipped_stale_session",
-			level: "info",
-			cwd: normalizeFilePath(args.cwd),
-		});
-		return;
-	}
+	const resolution = resolveLiveBusEmitter(liveEmitter, {
+		event: BUS_DIAGNOSTICS_EVENT,
+		cwd: normalizeFilePath(args.cwd),
+	});
+	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedUnwired) {
 			hasLoggedUnwired = true;

--- a/clients/disposition-publish.ts
+++ b/clients/disposition-publish.ts
@@ -106,10 +106,10 @@ export function publishDisposition(args: PublishDispositionArgs): void {
 		}
 		return;
 	}
-	const resolution = resolveLiveBusEmitter(liveEmitter, {
+	const resolution = resolveLiveBusEmitter(liveEmitter, () => ({
 		event: BUS_DISPOSITION_EVENT,
 		cwd: normalizeFilePath(args.cwd),
-	});
+	}));
 	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedUnwired) {

--- a/clients/disposition-publish.ts
+++ b/clients/disposition-publish.ts
@@ -27,6 +27,7 @@ import { normalizeFilePath } from "./path-utils.js";
 import {
 	createLiveBusEmitter,
 	recordStaleBusFailure,
+	resolveLiveBusEmitter,
 	type BusEmitFn,
 	type BusEmitGetter,
 } from "./live-bus-emitter.js";
@@ -105,16 +106,11 @@ export function publishDisposition(args: PublishDispositionArgs): void {
 		}
 		return;
 	}
-	const resolution = liveEmitter.resolve();
-	if (resolution.outcome === "stale-session") {
-		logBusEvent({
-			event: BUS_DISPOSITION_EVENT,
-			outcome: "skipped_stale_session",
-			level: "info",
-			cwd: normalizeFilePath(args.cwd),
-		});
-		return;
-	}
+	const resolution = resolveLiveBusEmitter(liveEmitter, {
+		event: BUS_DISPOSITION_EVENT,
+		cwd: normalizeFilePath(args.cwd),
+	});
+	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedUnwired) {
 			hasLoggedUnwired = true;

--- a/clients/format-events-publish.ts
+++ b/clients/format-events-publish.ts
@@ -73,6 +73,7 @@ import { normalizeFilePath } from "./path-utils.js";
 import {
 	createLiveBusEmitter,
 	recordStaleBusFailure,
+	resolveLiveBusEmitter,
 	type BusEmitFn,
 	type BusEmitGetter,
 } from "./live-bus-emitter.js";
@@ -179,16 +180,11 @@ export function publishFormatQueued(args: PublishFormatQueuedArgs): void {
 		}
 		return;
 	}
-	const resolution = liveEmitter.resolve();
-	if (resolution.outcome === "stale-session") {
-		logBusEvent({
-			event: BUS_FORMAT_QUEUED_EVENT,
-			outcome: "skipped_stale_session",
-			level: "info",
-			cwd: normalizeFilePath(args.cwd),
-		});
-		return;
-	}
+	const resolution = resolveLiveBusEmitter(liveEmitter, {
+		event: BUS_FORMAT_QUEUED_EVENT,
+		cwd: normalizeFilePath(args.cwd),
+	});
+	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedQueuedUnwired) {
 			hasLoggedQueuedUnwired = true;
@@ -264,16 +260,11 @@ export function publishFormatStart(args: PublishFormatStartArgs): void {
 		}
 		return;
 	}
-	const resolution = liveEmitter.resolve();
-	if (resolution.outcome === "stale-session") {
-		logBusEvent({
-			event: BUS_FORMAT_START_EVENT,
-			outcome: "skipped_stale_session",
-			level: "info",
-			cwd: normalizeFilePath(args.cwd),
-		});
-		return;
-	}
+	const resolution = resolveLiveBusEmitter(liveEmitter, {
+		event: BUS_FORMAT_START_EVENT,
+		cwd: normalizeFilePath(args.cwd),
+	});
+	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedStartUnwired) {
 			hasLoggedStartUnwired = true;
@@ -353,16 +344,11 @@ export function publishAutofixStart(args: PublishAutofixStartArgs): void {
 		}
 		return;
 	}
-	const resolution = liveEmitter.resolve();
-	if (resolution.outcome === "stale-session") {
-		logBusEvent({
-			event: BUS_AUTOFIX_START_EVENT,
-			outcome: "skipped_stale_session",
-			level: "info",
-			cwd: normalizeFilePath(args.cwd),
-		});
-		return;
-	}
+	const resolution = resolveLiveBusEmitter(liveEmitter, {
+		event: BUS_AUTOFIX_START_EVENT,
+		cwd: normalizeFilePath(args.cwd),
+	});
+	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedAutofixStartUnwired) {
 			hasLoggedAutofixStartUnwired = true;

--- a/clients/format-events-publish.ts
+++ b/clients/format-events-publish.ts
@@ -180,10 +180,10 @@ export function publishFormatQueued(args: PublishFormatQueuedArgs): void {
 		}
 		return;
 	}
-	const resolution = resolveLiveBusEmitter(liveEmitter, {
+	const resolution = resolveLiveBusEmitter(liveEmitter, () => ({
 		event: BUS_FORMAT_QUEUED_EVENT,
 		cwd: normalizeFilePath(args.cwd),
-	});
+	}));
 	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedQueuedUnwired) {
@@ -260,10 +260,10 @@ export function publishFormatStart(args: PublishFormatStartArgs): void {
 		}
 		return;
 	}
-	const resolution = resolveLiveBusEmitter(liveEmitter, {
+	const resolution = resolveLiveBusEmitter(liveEmitter, () => ({
 		event: BUS_FORMAT_START_EVENT,
 		cwd: normalizeFilePath(args.cwd),
-	});
+	}));
 	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedStartUnwired) {
@@ -344,10 +344,10 @@ export function publishAutofixStart(args: PublishAutofixStartArgs): void {
 		}
 		return;
 	}
-	const resolution = resolveLiveBusEmitter(liveEmitter, {
+	const resolution = resolveLiveBusEmitter(liveEmitter, () => ({
 		event: BUS_AUTOFIX_START_EVENT,
 		cwd: normalizeFilePath(args.cwd),
-	});
+	}));
 	if (resolution.outcome === "stale-session") return;
 	if (resolution.outcome === "unwired") {
 		if (!hasLoggedAutofixStartUnwired) {

--- a/clients/host-ports.ts
+++ b/clients/host-ports.ts
@@ -25,8 +25,14 @@ export interface HostPorts {
 		sink(subsystem: string): HostLogSink;
 	};
 	readonly emit: {
+		/**
+		 * Every `pi.events` publish, including the `pi-lens/*` producer family
+		 * (clients/lens-events.ts). A separate `.lens` port existed briefly but
+		 * was never wired to anything but this same `emit` function — removed
+		 * as vestigial (#1415 review) rather than kept as a distinction with no
+		 * behavioral difference.
+		 */
 		bus(channel: string, payload: unknown): void;
-		lens(channel: string, payload: unknown): void;
 	};
 	readonly status: {
 		set(name: string, value: string): void;
@@ -77,7 +83,7 @@ export function createDefaultHostPorts(
 			suppressesUserNotify: () => false,
 		},
 		log: { extension: () => {}, debug: () => {}, sink: () => () => {} },
-		emit: { bus: () => {}, lens: () => {} },
+		emit: { bus: () => {} },
 		status: { set: () => {} },
 		spawn: { abortSignal: () => undefined, isAllowed: () => true },
 		render: { invalidate: () => {} },

--- a/clients/lens-events.ts
+++ b/clients/lens-events.ts
@@ -1,5 +1,13 @@
 import { logExtension } from "./extension-log.js";
 import type { Diagnostic } from "./dispatch/types.js";
+import { logBusEvent } from "./bus-events-logger.js";
+import { normalizeFilePath } from "./path-utils.js";
+import {
+	createLiveBusEmitter,
+	recordStaleBusFailure,
+	resolveLiveBusEmitter,
+	type BusEmitGetter,
+} from "./live-bus-emitter.js";
 
 export const LENS_EVENT_VERSION = 1;
 
@@ -14,7 +22,6 @@ type LensEventName = (typeof LENS_EVENT_NAMES)[keyof typeof LENS_EVENT_NAMES];
 type LensEventBus = {
 	emit?: (event: string, payload: unknown) => void;
 };
-type LensEventBusGetter = () => LensEventBus | undefined;
 
 export interface LensTelemetryPayload {
 	model: string;
@@ -54,18 +61,15 @@ export interface LensTurnFindingsPayload {
 	content: string;
 }
 
-let lensEventBus: LensEventBus | undefined;
-let lensEventBusGetter: LensEventBusGetter | undefined;
+const liveEmitter = createLiveBusEmitter();
 
 export function initLensEvents(pi: { events?: LensEventBus }): void {
-	lensEventBus = pi.events;
-	lensEventBusGetter = undefined;
+	liveEmitter.wire(pi.events?.emit);
 }
 
 /** Keep deferred deliveries on the live extension activation. */
-export function initLensEventsGetter(getter: LensEventBusGetter | undefined): void {
-	lensEventBusGetter = getter;
-	lensEventBus = undefined;
+export function initLensEventsGetter(getter: BusEmitGetter | undefined): void {
+	liveEmitter.wireGetter(getter);
 }
 
 function truncateText(
@@ -97,25 +101,37 @@ let _droppedEmitLogged = false;
 
 function emitLensEvent(eventName: LensEventName, payload: unknown): void {
 	setImmediate(() => {
-		try {
-			const bus = lensEventBusGetter?.() ?? lensEventBus;
-			const emit = bus?.emit;
-			if (!emit) {
-				if (!_droppedEmitLogged) {
-					_droppedEmitLogged = true;
-					logExtension({
-						subsystem: "lens-events",
-						level: "warn",
-						message: `lens event dropped (no live bus): ${eventName} — further drops logged once per process`,
-						metadata: { eventName },
-					});
-				}
-				return;
+		const cwd = normalizeFilePath((payload as { cwd?: string }).cwd ?? process.cwd());
+		const resolution = resolveLiveBusEmitter(liveEmitter, {
+			event: eventName,
+			cwd,
+		});
+		if (resolution.outcome === "stale-session") return;
+		if (resolution.outcome === "unwired") {
+			if (!_droppedEmitLogged) {
+				_droppedEmitLogged = true;
+				logExtension({
+					subsystem: "lens-events",
+					level: "warn",
+					message: `lens event dropped (no live bus): ${eventName} — further drops logged once per process`,
+					metadata: { eventName },
+				});
 			}
-			emit.call(bus, eventName, payload);
-		} catch {
+			return;
+		}
+		try {
+			resolution.emit(eventName, payload);
+			logBusEvent({ event: eventName, outcome: "emitted", cwd });
+		} catch (err) {
+			logBusEvent({
+				event: eventName,
+				outcome: "emit_failed",
+				cwd,
+				error: String(err),
+			});
+			recordStaleBusFailure(eventName, err);
 			// Inter-extension events are observational. A listener must never break
-			// the pi-lens hook path or delay agent progress with error handling noise.
+			// the pi-lens hook path or delay agent progress.
 		}
 	});
 }

--- a/clients/lens-events.ts
+++ b/clients/lens-events.ts
@@ -19,10 +19,6 @@ export const LENS_EVENT_NAMES = {
 
 type LensEventName = (typeof LENS_EVENT_NAMES)[keyof typeof LENS_EVENT_NAMES];
 
-type LensEventBus = {
-	emit?: (event: string, payload: unknown) => void;
-};
-
 export interface LensTelemetryPayload {
 	model: string;
 	sessionId: string;
@@ -63,10 +59,6 @@ export interface LensTurnFindingsPayload {
 
 const liveEmitter = createLiveBusEmitter();
 
-export function initLensEvents(pi: { events?: LensEventBus }): void {
-	liveEmitter.wire(pi.events?.emit);
-}
-
 /** Keep deferred deliveries on the live extension activation. */
 export function initLensEventsGetter(getter: BusEmitGetter | undefined): void {
 	liveEmitter.wireGetter(getter);
@@ -99,13 +91,30 @@ function normalizeDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
 // process — enough to notice a permanently-missing bus without spamming.
 let _droppedEmitLogged = false;
 
+// Emit-failure gating (H1, #1415 review): occurrence-scoped, matching every
+// other producer's `hasLoggedFailure` guard (see clients/bus-publish.ts) and
+// AGENTS.md's "one bus-stale degradation per occurrence" invariant. A success
+// re-arms it, so a later failure records a fresh degradation rather than
+// being silently absorbed by an earlier one.
+let hasLoggedFailure = false;
+
+/** Test-only: reset module state between test files. */
+export function _resetForTests(): void {
+	liveEmitter.reset();
+	_droppedEmitLogged = false;
+	hasLoggedFailure = false;
+}
+
 function emitLensEvent(eventName: LensEventName, payload: unknown): void {
 	setImmediate(() => {
-		const cwd = normalizeFilePath((payload as { cwd?: string }).cwd ?? process.cwd());
-		const resolution = resolveLiveBusEmitter(liveEmitter, {
+		const rawCwd = (payload as { cwd?: string }).cwd ?? process.cwd();
+		// M1: normalizeFilePath is a sync realpathSync.native on Windows — build
+		// the resolveLiveBusEmitter log entry lazily so the ready-path (the
+		// common case) never pays it. Only the stale-session branch needs it.
+		const resolution = resolveLiveBusEmitter(liveEmitter, () => ({
 			event: eventName,
-			cwd,
-		});
+			cwd: normalizeFilePath(rawCwd),
+		}));
 		if (resolution.outcome === "stale-session") return;
 		if (resolution.outcome === "unwired") {
 			if (!_droppedEmitLogged) {
@@ -119,8 +128,10 @@ function emitLensEvent(eventName: LensEventName, payload: unknown): void {
 			}
 			return;
 		}
+		const cwd = normalizeFilePath(rawCwd);
 		try {
 			resolution.emit(eventName, payload);
+			hasLoggedFailure = false;
 			logBusEvent({ event: eventName, outcome: "emitted", cwd });
 		} catch (err) {
 			logBusEvent({
@@ -129,7 +140,10 @@ function emitLensEvent(eventName: LensEventName, payload: unknown): void {
 				cwd,
 				error: String(err),
 			});
-			recordStaleBusFailure(eventName, err);
+			if (!hasLoggedFailure) {
+				hasLoggedFailure = true;
+				recordStaleBusFailure(eventName, err);
+			}
 			// Inter-extension events are observational. A listener must never break
 			// the pi-lens hook path or delay agent progress.
 		}

--- a/clients/live-bus-emitter.ts
+++ b/clients/live-bus-emitter.ts
@@ -1,12 +1,17 @@
 import { recordDegradation } from "./degradation-ledger.js";
 import { probeCtxActive } from "./session-lifecycle.js";
+import {
+	logBusEvent,
+	type BusEventLogEntry,
+} from "./bus-events-logger.js";
 
 /** Resolve a pi event-bus emitter and its ctx at delivery time, not
  * subscription time. */
 export type BusEmitFn = (channel: string, data: unknown) => void;
 export interface BusEmitTarget {
 	emit: BusEmitFn;
-	ctx: unknown;
+	/** Optional for legacy/direct wiring; an absent ctx makes the probe inconclusive. */
+	ctx?: unknown;
 }
 export type BusEmitGetter = () => BusEmitFn | BusEmitTarget | undefined;
 export type BusEmitResolution =
@@ -61,4 +66,20 @@ export function createLiveBusEmitter(): LiveBusEmitter {
 			getter = undefined;
 		},
 	};
+}
+
+/** Resolve through the shared stale-session guard and record a declined target. */
+export function resolveLiveBusEmitter(
+	liveEmitter: LiveBusEmitter,
+	entry: Omit<BusEventLogEntry, "ts" | "outcome" | "level">,
+): BusEmitResolution {
+	const resolution = liveEmitter.resolve();
+	if (resolution.outcome === "stale-session") {
+		logBusEvent({
+			...entry,
+			outcome: "skipped_stale_session",
+			level: "info",
+		});
+	}
+	return resolution;
 }

--- a/clients/live-bus-emitter.ts
+++ b/clients/live-bus-emitter.ts
@@ -10,8 +10,16 @@ import {
 export type BusEmitFn = (channel: string, data: unknown) => void;
 export interface BusEmitTarget {
 	emit: BusEmitFn;
-	/** Optional for legacy/direct wiring; an absent ctx makes the probe inconclusive. */
-	ctx?: unknown;
+	/**
+	 * Required (L3, #1415 review): every `BusEmitTarget` wiring must pair its
+	 * emitter with the ctx it belongs to, or use the bare-function
+	 * `BusEmitFn` union arm instead (which the resolver treats as ctxless by
+	 * construction, not by an omitted field). Making `ctx` optional here let a
+	 * wiring forget it silently — the stale-session guard would then never
+	 * fire for that target. A caller with no ctx to pair should reach for the
+	 * `BusEmitFn` arm, not `{ emit, ctx: undefined }`.
+	 */
+	ctx: unknown;
 }
 export type BusEmitGetter = () => BusEmitFn | BusEmitTarget | undefined;
 export type BusEmitResolution =
@@ -68,15 +76,25 @@ export function createLiveBusEmitter(): LiveBusEmitter {
 	};
 }
 
-/** Resolve through the shared stale-session guard and record a declined target. */
+/**
+ * Resolve through the shared stale-session guard and record a declined
+ * target.
+ *
+ * `entry` is a THUNK, not a value (M1, #1415 review): building the log entry
+ * (every producer's version normalizes `cwd` via `normalizeFilePath`, a sync
+ * `realpathSync.native` call on Windows) is real per-publish cost that used
+ * to be paid on EVERY call regardless of outcome, even though it is only
+ * consumed on the `stale-session` branch. Invoking the thunk only there means
+ * the common `ready` path pays nothing for it.
+ */
 export function resolveLiveBusEmitter(
 	liveEmitter: LiveBusEmitter,
-	entry: Omit<BusEventLogEntry, "ts" | "outcome" | "level">,
+	entry: () => Omit<BusEventLogEntry, "ts" | "outcome" | "level">,
 ): BusEmitResolution {
 	const resolution = liveEmitter.resolve();
 	if (resolution.outcome === "stale-session") {
 		logBusEvent({
-			...entry,
+			...entry(),
 			outcome: "skipped_stale_session",
 			level: "info",
 		});

--- a/index.ts
+++ b/index.ts
@@ -504,6 +504,16 @@ function cleanStaleTsBuildInfo(cwd: string): string[] {
 // --- Extension ---
 
 export default function (pi: ExtensionAPI) {
+	// Event contexts belong to the activation that owns this factory closure.
+	// The process-global latest ctx remains only a boot-window fallback.
+	// biome-ignore lint/suspicious/noExplicitAny: heterogeneous pi event ctx shapes
+	let ownEventCtx: any;
+	// biome-ignore lint/suspicious/noExplicitAny: heterogeneous pi event ctx shapes
+	const rememberOwnEventCtx = (ctx: any): void => {
+		if (!ctx) return;
+		ownEventCtx = ctx;
+		rememberEventCtx(ctx);
+	};
 	let renderInvalidator: (() => void) | undefined;
 	const hostPorts = createHostPorts(pi, {
 		getContext: () => latestEventCtx,
@@ -534,8 +544,11 @@ export default function (pi: ExtensionAPI) {
 		// become stale; every session_start must reclaim them before #473 can
 		// return early for a concurrent in-process subagent. (#1383)
 		wireUserNotifier(hostPorts);
-		initLensEventsGetter(() => ({ emit: hostPorts.emit.lens }));
-		const getLiveEmit = () => ({ emit: hostPorts.emit.bus, ctx: latestEventCtx });
+		const getLiveEmit = () => ({
+			emit: hostPorts.emit.bus,
+			ctx: ownEventCtx ?? latestEventCtx,
+		});
+		initLensEventsGetter(getLiveEmit);
 		wireBusEmitterGetter(getLiveEmit);
 		wireDiagnosticsBusEmitterGetter(getLiveEmit);
 		wireDispositionBusEmitterGetter(getLiveEmit);
@@ -1511,7 +1524,7 @@ export default function (pi: ExtensionAPI) {
 		void warmFormatters().catch((err) =>
 			logExtension({ subsystem: "format", level: "warn", message: `formatter warm failed: ${err}` }),
 		);
-		rememberEventCtx(ctx);
+		rememberOwnEventCtx(ctx);
 		refreshCtxDerivedPlumbing();
 		const sessionStartFiredAt = Date.now();
 		try {
@@ -1882,7 +1895,7 @@ export default function (pi: ExtensionAPI) {
 	// Real-time feedback on file writes/edits
 	// biome-ignore lint/suspicious/noExplicitAny: pi.on overload mismatch for tool_result event type
 	(pi as any).on("tool_result", async (event: any, ctx: any) => {
-		rememberEventCtx(ctx);
+		rememberOwnEventCtx(ctx);
 		if (!lensEnabled) return;
 		updateRuntimeIdentityFromEvent(event);
 		// Publish this turn's abort signal so the dispatch's linter/type-check
@@ -1940,7 +1953,7 @@ export default function (pi: ExtensionAPI) {
 	// --- Turn end: batch jscpd/madge on collected files, then clear state ---
 	// Clear cascade snapshot at start of each new turn so stale data never leaks
 	pi.on("turn_start", (_event: any, ctx) => {
-		rememberEventCtx(ctx);
+		rememberOwnEventCtx(ctx);
 		// Trust can change without a new session. Re-adopt before this turn can
 		// reach any install-capable or LSP-spawn path.
 		adoptProjectTrustFromPorts(hostPorts);

--- a/index.ts
+++ b/index.ts
@@ -346,7 +346,7 @@ export function createHostPorts(
 			sink: (subsystem) => (entry) =>
 				logExtension({ subsystem, level: "debug", message: "host sink entry", metadata: { entry } }),
 		},
-		emit: { bus: emit, lens: emit },
+		emit: { bus: emit },
 		status: { set: (name, value) => context()?.ui?.setStatus?.(name, value) },
 		spawn: { abortSignal: () => context()?.signal, isAllowed: assertInstallAllowed },
 		render: { invalidate: () => options.getRenderInvalidator?.()?.() },
@@ -546,7 +546,16 @@ export default function (pi: ExtensionAPI) {
 		wireUserNotifier(hostPorts);
 		const getLiveEmit = () => ({
 			emit: hostPorts.emit.bus,
-			ctx: ownEventCtx ?? latestEventCtx,
+			// H2 (#1415 review): NOT `?? latestEventCtx`. The global belongs to
+			// whichever activation last received an event — a SIBLING activation
+			// after a replacement, with no relation to this closure's `pi.events`.
+			// Falling back to it pairs a live emitter with a foreign ctx, which
+			// the stale-session probe cannot catch (it looks live) and silently
+			// drops every publish until this activation's own first handler
+			// fires. An unset `ownEventCtx` (this activation's own boot window)
+			// must probe undefined -> "ready" -> delivery attempted, exactly like
+			// today, not borrow a sibling's ctx.
+			ctx: ownEventCtx,
 		});
 		initLensEventsGetter(getLiveEmit);
 		wireBusEmitterGetter(getLiveEmit);

--- a/tests/clients/bus-producer-coverage.test.ts
+++ b/tests/clients/bus-producer-coverage.test.ts
@@ -3,18 +3,89 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { LENS_EVENT_NAMES } from "../../clients/lens-events.js";
 
-const PRODUCERS = [
-	"bus-publish.ts",
-	"diagnostics-publish.ts",
-	"disposition-publish.ts",
-	"format-events-publish.ts",
-	"lens-events.ts",
-] as const;
+const clientsDir = path.resolve(process.cwd(), "clients");
+
+/**
+ * Files that own the shared live-emitter seam itself, not a producer that
+ * routes THROUGH it. `live-bus-emitter.ts` defines `resolveLiveBusEmitter`
+ * and calls `logBusEvent` directly for the `skipped_stale_session` outcome —
+ * it is not expected to contain a `resolveLiveBusEmitter(` call site.
+ * `bus-events-logger.ts` is the NDJSON sink every producer (and the resolver)
+ * imports; it emits nothing itself.
+ */
+const SEAM_FILES = new Set(["live-bus-emitter.ts", "bus-events-logger.ts"]);
+
+/**
+ * M3 (#1415 review): the producer list used to be hand-maintained (a
+ * third-copy antipattern per the single-source-of-truth discipline) — derive
+ * it instead by sweeping `clients/*.ts` for files that import
+ * `bus-events-logger.js`, the shared NDJSON trace every real producer writes
+ * to on every publish attempt. A new producer that starts emitting bus
+ * events but forgets to route through `resolveLiveBusEmitter` is caught
+ * automatically, without anyone remembering to add it to a list here.
+ */
+function discoverProducerFiles(): string[] {
+	return fs
+		.readdirSync(clientsDir)
+		.filter((file) => file.endsWith(".ts") && !SEAM_FILES.has(file))
+		.filter((file) => {
+			const source = fs.readFileSync(path.join(clientsDir, file), "utf8");
+			return /from\s+["']\.\/bus-events-logger\.js["']/.test(source);
+		})
+		.sort();
+}
+
+/**
+ * Allowlist for a literal `.emit(` call site inside a producer file (M3b,
+ * #1415 review). The ONLY sanctioned shape is `resolution.emit(...)` — the
+ * value `resolveLiveBusEmitter` itself returned, already probed for a stale
+ * ctx. Every other `.emit(` (a raw getter invoked and called directly, a
+ * captured `pi.events` reference, a bus/target local dereferenced without
+ * going through the resolver) bypasses the stale-session guard entirely,
+ * which is exactly the shape the reviewer's planted `rawGetter?.().emit(...)`
+ * bypass exploited while the file-existence sweep above stayed green.
+ *
+ * If a producer ever legitimately needs a non-bus `EventEmitter`-typed local
+ * (unrelated to the pi.events bus), extend this allowlist with that
+ * identifier explicitly — do not widen the regex.
+ */
+const SANCTIONED_EMIT_CALLERS = new Set(["resolution"]);
+
+/**
+ * Find every `<expr>.emit(` call site in `source` and return the identifier
+ * (or other token) immediately before `.emit(`, so callers can check it
+ * against `SANCTIONED_EMIT_CALLERS`. Returns `null` for a call site whose
+ * preceding token isn't a simple identifier (e.g. `().emit(`) — those are
+ * always violations since no allowlisted caller can produce that shape.
+ */
+function findEmitCallSites(source: string): Array<{ caller: string | null; index: number }> {
+	const sites: Array<{ caller: string | null; index: number }> = [];
+	const pattern = /\.emit\(/g;
+	let match: RegExpExecArray | null;
+	// biome-ignore lint/suspicious/noAssignInExpressions: exec-loop is the standard idiom
+	while ((match = pattern.exec(source))) {
+		const before = source.slice(0, match.index);
+		const callerMatch = before.match(/([A-Za-z_$][A-Za-z0-9_$]*)$/);
+		sites.push({ caller: callerMatch ? callerMatch[1] : null, index: match.index });
+	}
+	return sites;
+}
 
 describe("bus producer guarded-seam coverage", () => {
 	it("routes every event producer through the shared live emitter resolver", () => {
-		const clientsDir = path.resolve(process.cwd(), "clients");
-		for (const file of PRODUCERS) {
+		const producers = discoverProducerFiles();
+		// Sanity: the sweep must actually find the known producer family, not
+		// silently discover zero files (a discovery bug would make every
+		// assertion below vacuously pass on an empty list).
+		expect(producers).toEqual([
+			"bus-publish.ts",
+			"diagnostics-publish.ts",
+			"disposition-publish.ts",
+			"format-events-publish.ts",
+			"lens-events.ts",
+		]);
+
+		for (const file of producers) {
 			const source = fs.readFileSync(path.join(clientsDir, file), "utf8");
 			expect(source, file).toContain("resolveLiveBusEmitter(");
 			expect(source, file).not.toMatch(/liveEmitter\.resolve\s*\(/);
@@ -30,6 +101,20 @@ describe("bus producer guarded-seam coverage", () => {
 				file !== "live-bus-emitter.ts" && /liveEmitter\.resolve\s*\(/.test(source),
 		);
 		expect(directResolvers).toEqual([]);
+	});
+
+	it("has no bare .emit( call outside the resolveLiveBusEmitter path", () => {
+		const producers = discoverProducerFiles();
+		const violations: string[] = [];
+		for (const file of producers) {
+			const source = fs.readFileSync(path.join(clientsDir, file), "utf8");
+			for (const { caller, index } of findEmitCallSites(source)) {
+				if (caller && SANCTIONED_EMIT_CALLERS.has(caller)) continue;
+				const line = source.slice(0, index).split("\n").length;
+				violations.push(`${file}:${line} — unsanctioned \`.emit(\` call (caller: ${caller ?? "<non-identifier>"})`);
+			}
+		}
+		expect(violations).toEqual([]);
 	});
 
 	it("keeps the complete lens producer family in the guarded producer set", () => {

--- a/tests/clients/bus-producer-coverage.test.ts
+++ b/tests/clients/bus-producer-coverage.test.ts
@@ -1,0 +1,42 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { LENS_EVENT_NAMES } from "../../clients/lens-events.js";
+
+const PRODUCERS = [
+	"bus-publish.ts",
+	"diagnostics-publish.ts",
+	"disposition-publish.ts",
+	"format-events-publish.ts",
+	"lens-events.ts",
+] as const;
+
+describe("bus producer guarded-seam coverage", () => {
+	it("routes every event producer through the shared live emitter resolver", () => {
+		const clientsDir = path.resolve(process.cwd(), "clients");
+		for (const file of PRODUCERS) {
+			const source = fs.readFileSync(path.join(clientsDir, file), "utf8");
+			expect(source, file).toContain("resolveLiveBusEmitter(");
+			expect(source, file).not.toMatch(/liveEmitter\.resolve\s*\(/);
+			expect(source, file).not.toMatch(/(?:lensEventBusGetter|busEmitterGetter)\?\.\(/);
+		}
+
+		const productionSources = fs
+			.readdirSync(clientsDir)
+			.filter((file) => file.endsWith(".ts"))
+			.map((file) => [file, fs.readFileSync(path.join(clientsDir, file), "utf8")] as const);
+		const directResolvers = productionSources.filter(
+			([file, source]) =>
+				file !== "live-bus-emitter.ts" && /liveEmitter\.resolve\s*\(/.test(source),
+		);
+		expect(directResolvers).toEqual([]);
+	});
+
+	it("keeps the complete lens producer family in the guarded producer set", () => {
+		expect(Object.values(LENS_EVENT_NAMES)).toEqual([
+			"pi-lens/analysis-complete",
+			"pi-lens/findings",
+			"pi-lens/turn-findings",
+		]);
+	});
+});

--- a/tests/clients/host-ports.test.ts
+++ b/tests/clients/host-ports.test.ts
@@ -25,7 +25,6 @@ describe("HostPorts contract (#1358 S2)", () => {
 			ports.log.debug("x");
 			ports.log.sink("test")({ x: 1 });
 			ports.emit.bus("x", {});
-			ports.emit.lens("x", {});
 			ports.status.set("x", "y");
 			ports.render.invalidate();
 			ports.tools.setActive(["x"]);
@@ -39,7 +38,7 @@ describe("HostPorts contract (#1358 S2)", () => {
 			trust: { isProjectTrusted: () => "trusted" },
 			mode: { current: () => "rpc", supportsTuiWidget: () => false, suppressesUserNotify: () => false },
 			log: { extension: () => called.push("extension"), debug: () => called.push("debug"), sink: () => () => called.push("sink") },
-			emit: { bus: () => called.push("bus"), lens: () => called.push("lens") },
+			emit: { bus: () => called.push("bus") },
 			status: { set: () => called.push("status") },
 			spawn: { abortSignal: () => AbortSignal.abort(), isAllowed: () => false },
 			render: { invalidate: () => called.push("render") },
@@ -49,7 +48,7 @@ describe("HostPorts contract (#1358 S2)", () => {
 			tools: { has: async () => true, getActive: () => ["read"], setActive: () => called.push("tools") },
 		});
 		fake.notify.user("x"); fake.log.extension({ subsystem: "x", message: "x" }); fake.log.debug("x"); fake.log.sink("x")({});
-		fake.emit.bus("x", {}); fake.emit.lens("x", {}); fake.status.set("x", "x"); fake.render.invalidate(); fake.tools.setActive([]);
+		fake.emit.bus("x", {}); fake.status.set("x", "x"); fake.render.invalidate(); fake.tools.setActive([]);
 		expect(fake.trust.isProjectTrusted()).toBe("trusted");
 		expect(fake.mode.current()).toBe("rpc");
 		expect(fake.spawn.abortSignal()?.aborted).toBe(true);
@@ -60,7 +59,7 @@ describe("HostPorts contract (#1358 S2)", () => {
 		expect(fake.flags.get("x")).toBe(true);
 		expect(await fake.tools.has("x")).toBe(true);
 		expect(fake.tools.getActive()).toEqual(["read"]);
-		expect(called).toEqual(["notify", "extension", "debug", "sink", "bus", "lens", "status", "render", "tools"]);
+		expect(called).toEqual(["notify", "extension", "debug", "sink", "bus", "status", "render", "tools"]);
 	});
 
 	// #1367 review: parity must be proven against the REAL adapter fed an

--- a/tests/clients/lens-events.test.ts
+++ b/tests/clients/lens-events.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Diagnostic } from "../../clients/dispatch/types.js";
 import {
+	_resetForTests,
 	emitLensAnalysisComplete,
 	emitLensTurnFindings,
-	initLensEvents,
 	initLensEventsGetter,
 	LENS_EVENT_NAMES,
 } from "../../clients/lens-events.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
 
 const waitImmediate = () => new Promise((resolve) => setImmediate(resolve));
 
@@ -35,13 +39,24 @@ function baseAnalysisPayload(
 }
 
 describe("lens inter-extension events", () => {
+	beforeEach(() => {
+		_resetForTests();
+		resetDegradationLedger();
+	});
+
+	afterEach(() => {
+		_resetForTests();
+		resetDegradationLedger();
+	});
+
 	it("resolves the live bus when a deferred emit crosses session replacement", async () => {
 		const oldEmit = vi.fn((_event: string, _payload: unknown): void => {
 			throw new Error("This extension ctx is stale after session replacement");
 		});
 		const newEmit = vi.fn((_event: string, _payload: unknown): void => {});
-		let currentBus: { emit: (event: string, payload: unknown) => void } = {
+		let currentBus: { emit: (event: string, payload: unknown) => void; ctx: undefined } = {
 			emit: oldEmit,
+			ctx: undefined,
 		};
 		initLensEventsGetter(() => currentBus);
 
@@ -54,7 +69,7 @@ describe("lens inter-extension events", () => {
 			advisorySections: 0,
 			content: "after replacement",
 		});
-		currentBus = { emit: newEmit };
+		currentBus = { emit: newEmit, ctx: undefined };
 		await waitImmediate();
 
 		expect(oldEmit).not.toHaveBeenCalled();
@@ -88,7 +103,7 @@ describe("lens inter-extension events", () => {
 
 	it("emits analysis-complete for every analysis and findings only when diagnostics exist", async () => {
 		const emit = vi.fn();
-		initLensEvents({ events: { emit } });
+		initLensEventsGetter(() => ({ emit, ctx: undefined }));
 
 		emitLensAnalysisComplete(baseAnalysisPayload());
 		await waitImmediate();
@@ -142,7 +157,7 @@ describe("lens inter-extension events", () => {
 
 	it("emits turn-end findings with bounded content", async () => {
 		const emit = vi.fn();
-		initLensEvents({ events: { emit } });
+		initLensEventsGetter(() => ({ emit, ctx: undefined }));
 
 		emitLensTurnFindings({
 			cwd: "/repo",
@@ -165,5 +180,56 @@ describe("lens inter-extension events", () => {
 				content: expect.stringMatching(/…$/),
 			}),
 		);
+	});
+
+	it("gates emit-failure degradation to one-per-occurrence, re-armed by a success (H1, #1415)", async () => {
+		// Mirrors clients/bus-publish.ts's `hasLoggedFailure` pattern (see
+		// tests/clients/bus-publish.test.ts's "logs and ledgers each stale
+		// occurrence after a successful recovery"). Before this fix,
+		// lens-events.ts called recordStaleBusFailure/recordDegradation
+		// UNGATED on every failed emit — two consecutive failures would have
+		// recorded two degradations instead of one.
+		const failingEmit = vi.fn((_event: string, _payload: unknown): void => {
+			throw new Error("This extension ctx is stale after session replacement");
+		});
+		const okEmit = vi.fn((_event: string, _payload: unknown): void => {});
+		let currentEmit: typeof failingEmit = failingEmit;
+		initLensEventsGetter(() => ({
+			emit: (event: string, payload: unknown) => currentEmit(event, payload),
+			ctx: undefined,
+		}));
+
+		const publish = (content: string) =>
+			emitLensTurnFindings({
+				cwd: "/repo",
+				filePaths: [],
+				sessionId: "session-1",
+				turnIndex: 1,
+				blockerSections: 0,
+				advisorySections: 0,
+				content,
+			});
+
+		publish("first");
+		await waitImmediate();
+		publish("second");
+		await waitImmediate();
+
+		expect(getDegradationSummary()).toEqual([
+			expect.objectContaining({ kind: "bus-stale", count: 1 }),
+		]);
+
+		currentEmit = okEmit;
+		publish("recovered");
+		await waitImmediate();
+		expect(okEmit).toHaveBeenCalledTimes(1);
+
+		currentEmit = failingEmit;
+		publish("third");
+		await waitImmediate();
+
+		expect(getDegradationSummary()).toEqual([
+			expect.objectContaining({ kind: "bus-stale", count: 2 }),
+		]);
 	});
 });

--- a/tests/clients/lens-events.test.ts
+++ b/tests/clients/lens-events.test.ts
@@ -61,6 +61,31 @@ describe("lens inter-extension events", () => {
 		expect(newEmit).toHaveBeenCalledTimes(1);
 	});
 
+	it("does not invoke a lens emitter whose paired ctx is stale", async () => {
+		const emit = vi.fn();
+		initLensEventsGetter(() => ({
+			emit,
+			ctx: {
+				isIdle: () => {
+					throw new Error("This extension ctx is stale after session replacement");
+				},
+			},
+		}));
+
+		emitLensTurnFindings({
+			cwd: "/repo",
+			filePaths: [],
+			sessionId: "session-1",
+			turnIndex: 1,
+			blockerSections: 0,
+			advisorySections: 0,
+			content: "stale",
+		});
+		await waitImmediate();
+
+		expect(emit).not.toHaveBeenCalled();
+	});
+
 	it("emits analysis-complete for every analysis and findings only when diagnostics exist", async () => {
 		const emit = vi.fn();
 		initLensEvents({ events: { emit } });

--- a/tests/index-wiring.test.ts
+++ b/tests/index-wiring.test.ts
@@ -170,6 +170,117 @@ describe("index.ts extension wiring", () => {
 		}
 	});
 
+	it("probes the ctx owned by the activation whose emitter is selected", async () => {
+		_resetSessionLifecycleForTests();
+		resetBusPublishForTests();
+		try {
+			const liveCtx = makeCtx({ cwd: process.cwd(), sessionId: "live-owner" });
+			const staleCtx = makeCtx({ cwd: process.cwd(), sessionId: "stale-sibling" });
+			staleCtx.isIdle = () => {
+				throw new Error("This extension ctx is stale after session replacement");
+			};
+
+			const ownerEmit = vi.fn();
+			const owner = createPiMock();
+			const ownerApi = owner.asExtensionAPI();
+			(ownerApi as unknown as { events: { emit: typeof ownerEmit } }).events = {
+				emit: ownerEmit,
+			};
+			extension(ownerApi);
+			await owner.emit("session_start", { reason: "startup" }, liveCtx);
+
+			const sibling = createPiMock();
+			extension(sibling.asExtensionAPI());
+			// Reclaim the process-global publisher for the owner, then let a stale
+			// sibling handler overwrite only the process-global fallback ctx.
+			await owner.emit("session_start", { reason: "resume" }, liveCtx);
+			await sibling.emit("turn_start", {}, staleCtx);
+			publishFilesTouched({
+				reason: "autofix",
+				paths: ["/repo/live-owner.ts"],
+				cwd: "/repo",
+			});
+
+			expect(
+				ownerEmit.mock.calls.filter(([event]) => event === "pilens:files:touched"),
+			).toHaveLength(1);
+		} finally {
+			_resetSessionLifecycleForTests();
+			resetBusPublishForTests();
+		}
+	});
+
+	it("skips a stale owning ctx even when the global fallback is fresh", async () => {
+		_resetSessionLifecycleForTests();
+		resetBusPublishForTests();
+		try {
+			const staleOwnerCtx = makeCtx({ cwd: process.cwd(), sessionId: "stale-owner" });
+			staleOwnerCtx.isIdle = () => {
+				throw new Error("This extension ctx is stale after session replacement");
+			};
+			const freshGlobalCtx = makeCtx({ cwd: process.cwd(), sessionId: "fresh-sibling" });
+			const ownerEmit = vi.fn();
+			const owner = createPiMock();
+			const ownerApi = owner.asExtensionAPI();
+			(ownerApi as unknown as { events: { emit: typeof ownerEmit } }).events = {
+				emit: ownerEmit,
+			};
+			extension(ownerApi);
+			await owner.emit("session_start", { reason: "startup" }, staleOwnerCtx);
+
+			const sibling = createPiMock();
+			extension(sibling.asExtensionAPI());
+			await owner.emit("session_start", { reason: "resume" }, staleOwnerCtx);
+			await sibling.emit("turn_start", {}, freshGlobalCtx);
+			publishFilesTouched({
+				reason: "autofix",
+				paths: ["/repo/stale-owner.ts"],
+				cwd: "/repo",
+			});
+
+			expect(
+				ownerEmit.mock.calls.filter(([event]) => event === "pilens:files:touched"),
+			).toHaveLength(0);
+		} finally {
+			_resetSessionLifecycleForTests();
+			resetBusPublishForTests();
+		}
+	});
+
+	it("falls back to the latest event ctx before an activation receives one", async () => {
+		_resetSessionLifecycleForTests();
+		resetBusPublishForTests();
+		try {
+			const seed = createPiMock();
+			extension(seed.asExtensionAPI());
+			await seed.emit(
+				"turn_start",
+				{},
+				makeCtx({ cwd: process.cwd(), sessionId: "boot-fallback" }),
+			);
+
+			const bootEmit = vi.fn();
+			const boot = createPiMock();
+			const bootApi = boot.asExtensionAPI();
+			(bootApi as unknown as { events: { emit: typeof bootEmit } }).events = {
+				emit: bootEmit,
+			};
+			extension(bootApi);
+			publishFilesTouched({
+				reason: "autofix",
+				paths: ["/repo/boot.ts"],
+				cwd: "/repo",
+			});
+
+			expect(
+				bootEmit.mock.calls.filter(([event]) => event === "pilens:files:touched"),
+			).toHaveLength(1);
+		} finally {
+			_resetSessionLifecycleForTests();
+			resetBusPublishForTests();
+		}
+	});
+
 	describe("registration", () => {
 		it("registers every expected flag, command, tool, and lifecycle hook", () => {
 			const pi = createPiMock();

--- a/tests/index-wiring.test.ts
+++ b/tests/index-wiring.test.ts
@@ -247,17 +247,33 @@ describe("index.ts extension wiring", () => {
 		}
 	});
 
-	it("falls back to the latest event ctx before an activation receives one", async () => {
+	it("delivers through its own boot window without borrowing a stale sibling's ctx (H2, #1415)", async () => {
+		// Pins the boot-window behavior directly, replacing a test that
+		// asserted delivery via `ownEventCtx ?? latestEventCtx` -- the
+		// reviewer proved that assertion vacuous, since it passes exactly
+		// the same way with the fallback arm removed (an unset ownEventCtx
+		// probes as inconclusive and falls through to "ready" either way).
+		//
+		// This version proves the fallback's ABSENCE actually matters: a
+		// sibling activation ("A") sets the process-global latest-ctx to a
+		// CONFIRMED-STALE ctx. Under the old `?? latestEventCtx` fallback, a
+		// fresh boot activation ("B") with no ctx of its own would have
+		// paired its live emitter with A's stale ctx and been silently
+		// DROPPED (stale-session). With the fallback removed, B's own unset
+		// `ownEventCtx` correctly probes as undefined (inconclusive) rather
+		// than confirmed-stale, so delivery is still attempted.
 		_resetSessionLifecycleForTests();
 		resetBusPublishForTests();
 		try {
-			const seed = createPiMock();
-			extension(seed.asExtensionAPI());
-			await seed.emit(
-				"turn_start",
-				{},
-				makeCtx({ cwd: process.cwd(), sessionId: "boot-fallback" }),
-			);
+			const staleSiblingCtx = makeCtx({ cwd: process.cwd(), sessionId: "stale-sibling" });
+			staleSiblingCtx.isIdle = () => {
+				throw new Error("This extension ctx is stale after session replacement");
+			};
+			const sibling = createPiMock();
+			extension(sibling.asExtensionAPI());
+			// Sets the process-global `latestEventCtx` to a confirmed-stale ctx
+			// belonging to a DIFFERENT activation than the one created below.
+			await sibling.emit("turn_start", {}, staleSiblingCtx);
 
 			const bootEmit = vi.fn();
 			const boot = createPiMock();
@@ -266,6 +282,8 @@ describe("index.ts extension wiring", () => {
 				emit: bootEmit,
 			};
 			extension(bootApi);
+			// Boot activation never receives an event of its own -- its
+			// `ownEventCtx` closure variable stays unset.
 			publishFilesTouched({
 				reason: "autofix",
 				paths: ["/repo/boot.ts"],


### PR DESCRIPTION
## Summary

Each activation now tracks its own event ctx. The stale-probe checks the ctx that backs the emit, not the process-global one. The global fallback is removed. It could only cause false skips, because the global can belong to a sibling activation.

Lens events now route through the guarded emitter seam. They gain durable emitted, stale-skip, and failure outcomes. Lens failures now count toward the bus-stale smell. That change is intentional: genuine failures should count.

The four hand-copied producer stale-blocks are folded into one shared resolver. The resolver takes a thunk, so the ready path pays no extra normalization. A structural coverage test derives the producer list from imports and rejects bare emit calls.

## Verification

Two full adversarial rounds. Round one found two blockers and six smaller findings. All were fixed and re-verified by the same reviewer with re-run probes:

- The new boot-window test fails if the removed fallback returns.
- The lens degradation gate proves one-per-occurrence with re-arm.
- The thunk removes the resolver's sync realpath from the ready path (measured).
- Both reviewer bypasses re-planted and caught with file:line messages.
- `latestEventCtx` stays: the #1333 user-notify seam still consumes it.

Build, lint, and 165 targeted tests pass. The full suite matched master's failure set in round one. The flagged timing test passed a controlled branch-versus-master comparison.

Closes #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)
