### PR TITLE
feat: lang/file/ext prefix filters for word-index queries (#1450)

### DIFF
--- a/.changelog/feat-1450-word-index-prefix-filters.md
+++ b/.changelog/feat-1450-word-index-prefix-filters.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Prefix filters for word-index queries: lang, file, ext (Closes #1450)** — `symbol_search`/`pilens_symbol_search` queries can now mix plain terms with composable `lang:`, `file:`, and `ext:` prefix filters, plus `-` negation, e.g. `lang:jsts file:clients/ -file:test rank`. A hand-rolled tokenizer (`parseWordIndexQuery` in `clients/word-index.ts`) splits filters from terms; `lang:` resolves through `KIND_EXTENSIONS` (`clients/file-kinds.ts`), the single source of truth, so there is no second, hand-maintained language list. Filters apply as a pre-ranking predicate, composing with the existing `paths`/`lang` structured options, before BM25/priors/centrality scoring runs. An unrecognized prefix or `lang:` kind throws a typed `WordIndexQueryError` naming the supported list instead of silently degrading to a literal search term.

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -21,6 +21,7 @@ import {
 	forEachCooperatively,
 	yieldIfOverBudget,
 } from "./cooperative-budget.js";
+import { KIND_EXTENSIONS, type FileKind } from "./file-kinds.js";
 import { PathKeyedMap } from "./path-keyed-map.js";
 import { isAtOrAboveHomeDir, normalizeEphemeralMapKey } from "./path-utils.js";
 import {
@@ -1061,10 +1062,246 @@ export async function refreshWordIndexIncrementally(
 	};
 }
 
+// --- Query prefix filters (#1450) --------------------------------------------
+//
+// Composable `lang:`/`file:`/`ext:` filters mixed into the plain query string,
+// e.g. `lang:ts file:clients/ -file:test rank`. Hand-rolled tokenizer (a regex
+// split per whitespace token) rather than a grammar — the issue's explicit
+// direction, and the query language is small enough that a grammar would be
+// pure overhead. Landed HERE, in `searchWordIndex` (the word-index query entry
+// point), so both the pi `symbol_search` tool and the MCP
+// `pilens_symbol_search` mirror inherit the syntax for free: they already pass
+// their `query` argument straight through to `symbolSearch` → `searchWordIndex`
+// with no filter-specific plumbing of their own.
+
+/** The three supported inline query-filter prefixes (#1450). */
+export type WordIndexQueryFilterKey = "lang" | "file" | "ext";
+
+export const WORD_INDEX_QUERY_FILTER_KEYS: readonly WordIndexQueryFilterKey[] =
+	["lang", "file", "ext"];
+
+export interface WordIndexQueryFilter {
+	key: WordIndexQueryFilterKey;
+	value: string;
+	/** True when the token was `-key:value` — always subtracts, never OR's with a positive filter of the same key. */
+	negated: boolean;
+}
+
+export interface ParsedWordIndexQuery {
+	/** The query with filter tokens stripped, ready for {@link tokenizeLine} — identical to the input when it contains no filters. */
+	terms: string;
+	filters: WordIndexQueryFilter[];
+}
+
+/** Thrown by {@link parseWordIndexQuery}/{@link buildWordIndexQueryFilter} for
+ * an unrecognized `key:` prefix or an unrecognized `lang:` value — a query
+ * typo fails loudly with the supported list instead of silently degrading
+ * into a literal search term (#1450 acceptance criterion). */
+export class WordIndexQueryError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "WordIndexQueryError";
+	}
+}
+
+const WORD_INDEX_FILTER_TOKEN_RE = /^(-)?([A-Za-z][A-Za-z0-9_-]*):(.+)$/;
+
+/**
+ * Split a word-index query string into plain search terms and `key:value`
+ * prefix filters (#1450). Whitespace-delimited, one regex per token — no
+ * quoting scheme invented here, matching the pre-existing query path (which
+ * never supported quoting either). A `-` immediately before a recognized
+ * `key:` negates that filter; a bare `-term` (no colon) is left as an
+ * ordinary token, unchanged from prior behavior — `tokenizeLine` already
+ * strips the leading `-` when it extracts identifiers.
+ *
+ * An unrecognized `key:` (e.g. `type:foo`) throws {@link WordIndexQueryError}
+ * naming the supported prefixes, rather than falling through as a literal
+ * term — a typo must fail loudly, never silently rank as if the filter never
+ * existed. An empty value (`lang:`) is not treated as a filter token at all
+ * (kept as a term) since there is nothing to filter by.
+ */
+export function parseWordIndexQuery(query: string): ParsedWordIndexQuery {
+	const filters: WordIndexQueryFilter[] = [];
+	const termParts: string[] = [];
+	for (const raw of query.split(/\s+/)) {
+		if (!raw) continue;
+		const match = raw.match(WORD_INDEX_FILTER_TOKEN_RE);
+		if (!match) {
+			termParts.push(raw);
+			continue;
+		}
+		const [, negation, keyRaw, value] = match;
+		const key = keyRaw.toLowerCase();
+		if (!value) {
+			termParts.push(raw);
+			continue;
+		}
+		if (!(WORD_INDEX_QUERY_FILTER_KEYS as readonly string[]).includes(key)) {
+			throw new WordIndexQueryError(
+				`Unsupported word-index filter "${keyRaw}:" in query — supported prefixes: ${WORD_INDEX_QUERY_FILTER_KEYS.map((k) => `${k}:`).join(", ")}.`,
+			);
+		}
+		filters.push({
+			key: key as WordIndexQueryFilterKey,
+			value,
+			negated: negation === "-",
+		});
+	}
+	return { terms: termParts.join(" "), filters };
+}
+
+/** `lang:X` → the extension set for FileKind X (case-insensitive), drawn
+ * exclusively from `KIND_EXTENSIONS` (clients/file-kinds.ts) — the single
+ * source of truth (#894 invariant: no second, hand-maintained language list).
+ * An unrecognized kind throws {@link WordIndexQueryError} listing the accepted
+ * kinds (KIND_EXTENSIONS' own keys), the same loud-failure contract as an
+ * unsupported `key:` prefix. */
+function resolveLangExtensions(value: string): readonly string[] {
+	const kind = value.toLowerCase() as FileKind;
+	const extensions = KIND_EXTENSIONS[kind];
+	if (!extensions) {
+		const known = Object.keys(KIND_EXTENSIONS).sort().join(", ");
+		throw new WordIndexQueryError(
+			`Unknown lang: "${value}" in word-index query — supported languages: ${known}.`,
+		);
+	}
+	return extensions;
+}
+
+/** `ext:ts` / `ext:.ts` → normalized to a single leading-dot, lowercased form for extname comparison. */
+function normalizeExtFilterValue(value: string): string {
+	return `.${value.replace(/^\.+/, "").toLowerCase()}`;
+}
+
+interface ResolvedWordIndexFilter {
+	key: WordIndexQueryFilterKey;
+	negated: boolean;
+	test: (file: string, displayPath: string) => boolean;
+}
+
+function resolveWordIndexFilter(
+	filter: WordIndexQueryFilter,
+): ResolvedWordIndexFilter {
+	if (filter.key === "lang") {
+		const extensions = resolveLangExtensions(filter.value);
+		return {
+			key: filter.key,
+			negated: filter.negated,
+			test: (file) => extensions.includes(path.extname(file).toLowerCase()),
+		};
+	}
+	if (filter.key === "ext") {
+		const normalized = normalizeExtFilterValue(filter.value);
+		return {
+			key: filter.key,
+			negated: filter.negated,
+			test: (file) => path.extname(file).toLowerCase() === normalized,
+		};
+	}
+	// "file": substring match against the index's own normalized display path
+	// (#1450 — see the doc comment on {@link buildWordIndexQueryFilter} for the
+	// case-behavior choice). Both sides fold through `wordIndexKey` so the
+	// comparison matches the SAME normalization the index's own path keys use.
+	const needle = wordIndexKey(filter.value);
+	return {
+		key: filter.key,
+		negated: filter.negated,
+		test: (_file, displayPath) => displayPath.includes(needle),
+	};
+}
+
+/**
+ * Build a pre-ranking predicate from parsed query filters (#1450). Composes
+ * (AND) with `searchWordIndex`'s pre-existing `fileFilter` option (#771) —
+ * `symbol_search`'s structured `paths`/`lang` params and this query's inline
+ * filters both apply when both are present.
+ *
+ * Semantics: multiple positive filters of the SAME key OR together
+ * (`lang:ts lang:go` matches either); filters of DIFFERENT keys AND
+ * (`lang:ts file:clients/` requires both); a negated filter always subtracts,
+ * regardless of any positive filter sharing its key.
+ *
+ * All filters are RESOLVED EAGERLY (extension lookups, `WordIndexQueryError`
+ * thrown) here at build time — before any candidate file is tested — so a bad
+ * `lang:` value fails once, loudly, rather than per-file during the scoring
+ * loop.
+ *
+ * `file:` case behavior: matched via `wordIndexKey` (this module's single
+ * path-key normalizer, `normalizeEphemeralMapKey`) on BOTH the candidate path
+ * and the filter value — slash-folded everywhere, and case-folded ONLY on
+ * win32 (Windows' case-insensitive filesystem), preserved on POSIX. This
+ * mirrors the SAME normalization the word index's own path-keyed maps already
+ * apply (#1025), rather than inventing a second, divergent case rule for this
+ * one filter. The candidate path matched is the RAW index-stored path (not
+ * cwd-relativized) — the index already stores paths in the form the caller
+ * built it with (relative in tests, absolute in the real project walk), and
+ * an absolute path's tail always contains its project-relative suffix, so
+ * `file:clients/word-index.ts` still matches naturally either way.
+ */
+export function buildWordIndexQueryFilter(
+	filters: readonly WordIndexQueryFilter[],
+): ((file: string) => boolean) | undefined {
+	if (filters.length === 0) return undefined;
+	const resolved = filters.map(resolveWordIndexFilter);
+	const positivesByKey = new Map<
+		WordIndexQueryFilterKey,
+		ResolvedWordIndexFilter[]
+	>();
+	const negatives: ResolvedWordIndexFilter[] = [];
+	for (const r of resolved) {
+		if (r.negated) {
+			negatives.push(r);
+			continue;
+		}
+		const group = positivesByKey.get(r.key) ?? [];
+		group.push(r);
+		positivesByKey.set(r.key, group);
+	}
+	return (file: string) => {
+		const displayPath = wordIndexKey(file);
+		for (const negative of negatives) {
+			if (negative.test(file, displayPath)) return false;
+		}
+		for (const group of positivesByKey.values()) {
+			if (!group.some((r) => r.test(file, displayPath))) return false;
+		}
+		return true;
+	};
+}
+
+function combineFileFilters(
+	a: ((file: string) => boolean) | undefined,
+	b: ((file: string) => boolean) | undefined,
+): ((file: string) => boolean) | undefined {
+	if (!a) return b;
+	if (!b) return a;
+	return (file: string) => a(file) && b(file);
+}
+
 /**
  * Rank files for a query by BM25 over the query's identifier tokens, then apply
  * priors: demote test/vendor and doc/data files, and boost by graph centrality
  * when supplied. Returns the top {@link RankOptions.limit} files, highest first.
+ *
+ * The query string may mix plain terms with `lang:`/`file:`/`ext:` prefix
+ * filters (+ `-` negation, #1450) — parsed by {@link parseWordIndexQuery} and
+ * applied as a `fileFilter` (composed, AND, with any caller-supplied one)
+ * BEFORE scoring, same as the pre-existing `paths`/`lang` options (#771): a
+ * surviving file's score is unaffected by filtering. A query with no filter
+ * tokens reproduces prior output byte-for-byte.
+ *
+ * DF-normalization note: BM25's per-token `idf` is computed from `docFrequency`
+ * over the FULL (unfiltered) postings for that token — `fileFilter` (whether
+ * from `options.fileFilter` or from this query's inline filters) is applied
+ * AFTER `idf` is computed, per file, inside the same loop. This means a
+ * filtered query reuses the GLOBAL, corpus-wide document frequency rather than
+ * recomputing it over just the filtered subset. That is the pre-existing #771
+ * behavior this change does not alter; it is an acceptable approximation
+ * (idf reflects true corpus rarity, not an artifact of the filter) and keeps
+ * filtered/unfiltered scores for the SAME file directly comparable, which is
+ * the property #1450 asks for ("BM25 and centrality stay comparable within
+ * the filtered set").
  */
 export function searchWordIndex(
 	index: WordIndex,
@@ -1079,7 +1316,11 @@ export function searchWordIndex(
 		fileFilter,
 	} = options;
 
-	const queryTokens = [...new Set(tokenizeLine(query))];
+	const parsedQuery = parseWordIndexQuery(query);
+	const queryFilter = buildWordIndexQueryFilter(parsedQuery.filters);
+	const combinedFilter = combineFileFilters(fileFilter, queryFilter);
+
+	const queryTokens = [...new Set(tokenizeLine(parsedQuery.terms))];
 	if (queryTokens.length === 0) return [];
 
 	const docCount = index.docCount || 1;
@@ -1107,7 +1348,7 @@ export function searchWordIndex(
 		);
 
 		for (const [file, lines] of linesByFile) {
-			if (fileFilter && !fileFilter(file)) continue;
+			if (combinedFilter && !combinedFilter(file)) continue;
 			const termFrequency = lines.length;
 			const docLength = index.docLengths.get(file) ?? avgDocLength;
 			const denominator =

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -1167,7 +1167,7 @@ function resolveLangExtensions(value: string): readonly string[] {
 	const kind = value.toLowerCase() as FileKind;
 	const extensions = KIND_EXTENSIONS[kind];
 	if (!extensions) {
-		const known = Object.keys(KIND_EXTENSIONS).sort().join(", ");
+		const known = Object.keys(KIND_EXTENSIONS).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)).join(", ");
 		throw new WordIndexQueryError(
 			`Unknown lang: "${value}" in word-index query — supported languages: ${known}.`,
 		);

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -1138,9 +1138,15 @@ export function parseWordIndexQuery(query: string): ParsedWordIndexQuery {
 			continue;
 		}
 		if (!(WORD_INDEX_QUERY_FILTER_KEYS as readonly string[]).includes(key)) {
-			throw new WordIndexQueryError(
-				`Unsupported word-index filter "${keyRaw}:" in query — supported prefixes: ${WORD_INDEX_QUERY_FILTER_KEYS.map((k) => `${k}:`).join(", ")}.`,
-			);
+			// Not a recognized filter key. Ordinary search terms legitimately
+			// contain colons (std::vector, error:foo, http://…, C:\ paths, a
+			// TODO:tag), and the old tokenizer searched them fine — a hard
+			// error here is a usability regression, not typo protection. The
+			// token passes through as a plain term; the loud-failure contract
+			// survives where it is unambiguous: a KNOWN key with a bad value
+			// (lang:notalang) still throws.
+			termParts.push(raw);
+			continue;
 		}
 		filters.push({
 			key: key as WordIndexQueryFilterKey,

--- a/docs/word-index.md
+++ b/docs/word-index.md
@@ -62,7 +62,10 @@ of the SAME key OR together; different keys AND; negations always subtract.
 Filters are applied as a `fileFilter` predicate BEFORE BM25/priors/centrality
 scoring (same seam as the pre-existing `paths`/`lang` structured options,
 #771), so a surviving file's score is unaffected by filtering. An unrecognized
-`key:` prefix, or an unrecognized `lang:` kind, throws `WordIndexQueryError`
+`key:` token passes through as an ordinary search term (colon-bearing terms
+like `std::vector`, URLs, and Windows paths search normally). Only a
+recognized key with a bad value — an unrecognized `lang:` kind — throws
+`WordIndexQueryError`
 naming the supported list — never silently falls through as a literal search
 term. Both the pi `symbol_search` tool and the MCP `pilens_symbol_search`
 mirror inherit the syntax for free since both pass their `query` argument

--- a/docs/word-index.md
+++ b/docs/word-index.md
@@ -42,6 +42,38 @@ HTTPServer    → httpserver, http, server
 each through `splitIdentifier`; queries are tokenized the same way so
 `"authenticate user"` matches `authenticateUser`, `auth_user`, etc.
 
+## Query prefix filters (#1450)
+
+The query string can mix plain terms with composable `key:value` filters,
+parsed by `parseWordIndexQuery` (`clients/word-index.ts`) before tokenization:
+
+- `lang:<kind>` — restrict to a file kind's extensions, drawn from
+  `KIND_EXTENSIONS` (`clients/file-kinds.ts`) — the single source of truth
+  (#894 invariant), so there is no second, hand-maintained language list here.
+- `file:<substr>` — path substring match against the index's own stored path,
+  normalized through `wordIndexKey` (case-folded on win32 only, matching how
+  the index's own path-keyed maps already fold win32 paths, #1025).
+- `ext:<ext>` — literal extension match (`ext:ts` and `ext:.ts` are
+  equivalent).
+- Any filter may be negated with a leading `-` (`-file:test`).
+
+Example: `lang:jsts file:clients/ -file:test rank`. Multiple positive filters
+of the SAME key OR together; different keys AND; negations always subtract.
+Filters are applied as a `fileFilter` predicate BEFORE BM25/priors/centrality
+scoring (same seam as the pre-existing `paths`/`lang` structured options,
+#771), so a surviving file's score is unaffected by filtering. An unrecognized
+`key:` prefix, or an unrecognized `lang:` kind, throws `WordIndexQueryError`
+naming the supported list — never silently falls through as a literal search
+term. Both the pi `symbol_search` tool and the MCP `pilens_symbol_search`
+mirror inherit the syntax for free since both pass their `query` argument
+straight through to `searchWordIndex` (the entry point where parsing happens).
+
+DF-normalization: BM25's per-token `idf` is computed from the FULL,
+unfiltered posting for that token before `fileFilter` is applied per
+candidate file — a filtered query reuses the global, corpus-wide document
+frequency rather than recomputing it over the filtered subset. Documented as
+an acceptable approximation (see the doc comment on `searchWordIndex`).
+
 ## Lifecycle
 
 The index is built/refreshed in **every** startup mode: load the persisted

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -705,7 +705,8 @@ const ALL_TOOLS = [
 			properties: {
 				query: {
 					type: "string",
-					description: "Identifier-ish query, e.g. 'authenticate user'.",
+					description:
+						"Identifier-ish query, e.g. 'authenticate user'. Mix in composable prefix filters: lang:<kind> (e.g. lang:jsts, lang:python — kinds from file-kinds.ts), file:<substr> (path substring), ext:<ext> (e.g. ext:ts or ext:.ts), each optionally negated with a leading '-' (-file:test). Filters apply before ranking; e.g. 'lang:jsts file:clients/ -file:test rank'. Unknown prefixes/kinds error with the supported list.",
 				},
 				cwd: { type: "string" },
 				limit: {

--- a/tests/clients/word-index.test.ts
+++ b/tests/clients/word-index.test.ts
@@ -12,7 +12,6 @@ import {
 	splitIdentifier,
 	tokenizeLine,
 	WORD_INDEX_FORMAT_VERSION,
-	WORD_INDEX_QUERY_FILTER_KEYS,
 	WordIndexQueryError,
 	wordIndexKey,
 	_resetWordIndexBuildGuardForTests,
@@ -120,18 +119,34 @@ describe("parseWordIndexQuery (#1450)", () => {
 		]);
 	});
 
-	it("throws WordIndexQueryError for an unknown prefix, naming the supported list", () => {
-		expect(() => parseWordIndexQuery("type:foo rank")).toThrow(WordIndexQueryError);
+	it("passes an unknown colon token through as an ordinary term", () => {
+		// Legitimate search terms carry colons: C++ scope operators, log
+		// prefixes, URLs, Windows paths, TODO tags. None may throw; all must
+		// search as plain terms, matching the pre-filter behavior.
+		for (const query of [
+			"std::vector rank",
+			"error:foo",
+			"http://example.com",
+			"TODO:fixme",
+			String.raw`C:\Users\foo`,
+			"type:foo rank",
+		]) {
+			const parsed = parseWordIndexQuery(query);
+			expect(parsed.filters).toEqual([]);
+			expect(parsed.terms).toBe(query);
+		}
+	});
+
+	it("still throws WordIndexQueryError for a KNOWN key with a bad value", () => {
+		// The throw lives at filter-build time (eager resolution), not parse.
+		const parsed = parseWordIndexQuery("lang:notalang rank");
 		let caught: unknown;
 		try {
-			parseWordIndexQuery("type:foo rank");
+			buildWordIndexQueryFilter(parsed.filters);
 		} catch (err) {
 			caught = err;
 		}
 		expect(caught).toBeInstanceOf(WordIndexQueryError);
-		for (const key of WORD_INDEX_QUERY_FILTER_KEYS) {
-			expect((caught as Error).message).toContain(`${key}:`);
-		}
 	});
 
 	it("treats a bare hyphenated term (no colon) as an ordinary term, not a filter", () => {

--- a/tests/clients/word-index.test.ts
+++ b/tests/clients/word-index.test.ts
@@ -2,17 +2,23 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	buildWordIndex,
+	buildWordIndexQueryFilter,
 	centralityFromReverseDeps,
 	deserializeWordIndex,
 	getWordIndexBuildStatus,
+	parseWordIndexQuery,
 	searchWordIndex,
 	serializeWordIndex,
 	splitIdentifier,
 	tokenizeLine,
 	WORD_INDEX_FORMAT_VERSION,
+	WORD_INDEX_QUERY_FILTER_KEYS,
+	WordIndexQueryError,
+	wordIndexKey,
 	_resetWordIndexBuildGuardForTests,
 	triggerBackgroundWordIndexBuild,
 } from "../../clients/word-index.ts";
+import { KIND_EXTENSIONS } from "../../clients/file-kinds.ts";
 import { loadProjectSnapshot } from "../../clients/project-snapshot.ts";
 import { createTempFile, setupTestEnvironment } from "./test-utils.ts";
 
@@ -65,6 +71,191 @@ describe("tokenizeLine", () => {
 
 	it("returns nothing for a line with no identifiers", () => {
 		expect(tokenizeLine("   () => { + - * }")).toEqual([]);
+	});
+});
+
+// #1450: lang:/file:/ext: prefix filters mixed into the plain query string.
+describe("parseWordIndexQuery (#1450)", () => {
+	it("splits plain terms with no filters, unchanged", () => {
+		const parsed = parseWordIndexQuery("authenticate user");
+		expect(parsed.terms).toBe("authenticate user");
+		expect(parsed.filters).toEqual([]);
+	});
+
+	it("extracts a lang: filter", () => {
+		const parsed = parseWordIndexQuery("lang:jsts rank");
+		expect(parsed.terms.trim()).toBe("rank");
+		expect(parsed.filters).toEqual([{ key: "lang", value: "jsts", negated: false }]);
+	});
+
+	it("extracts a file: filter", () => {
+		const parsed = parseWordIndexQuery("file:clients/ rank");
+		expect(parsed.terms.trim()).toBe("rank");
+		expect(parsed.filters).toEqual([
+			{ key: "file", value: "clients/", negated: false },
+		]);
+	});
+
+	it("extracts an ext: filter", () => {
+		const parsed = parseWordIndexQuery("ext:ts rank");
+		expect(parsed.terms.trim()).toBe("rank");
+		expect(parsed.filters).toEqual([{ key: "ext", value: "ts", negated: false }]);
+	});
+
+	it("extracts a negated filter with a leading -", () => {
+		const parsed = parseWordIndexQuery("-file:test rank");
+		expect(parsed.terms.trim()).toBe("rank");
+		expect(parsed.filters).toEqual([
+			{ key: "file", value: "test", negated: true },
+		]);
+	});
+
+	it("extracts mixed filters and terms in the issue's own example", () => {
+		const parsed = parseWordIndexQuery("lang:ts file:clients/ -file:test rank");
+		expect(parsed.terms.trim()).toBe("rank");
+		expect(parsed.filters).toEqual([
+			{ key: "lang", value: "ts", negated: false },
+			{ key: "file", value: "clients/", negated: false },
+			{ key: "file", value: "test", negated: true },
+		]);
+	});
+
+	it("throws WordIndexQueryError for an unknown prefix, naming the supported list", () => {
+		expect(() => parseWordIndexQuery("type:foo rank")).toThrow(WordIndexQueryError);
+		let caught: unknown;
+		try {
+			parseWordIndexQuery("type:foo rank");
+		} catch (err) {
+			caught = err;
+		}
+		expect(caught).toBeInstanceOf(WordIndexQueryError);
+		for (const key of WORD_INDEX_QUERY_FILTER_KEYS) {
+			expect((caught as Error).message).toContain(`${key}:`);
+		}
+	});
+
+	it("treats a bare hyphenated term (no colon) as an ordinary term, not a filter", () => {
+		const parsed = parseWordIndexQuery("-rank other");
+		expect(parsed.filters).toEqual([]);
+		expect(parsed.terms.trim()).toBe("-rank other");
+	});
+
+	it("treats an empty-value key: as an ordinary term, not a filter", () => {
+		const parsed = parseWordIndexQuery("lang: rank");
+		expect(parsed.filters).toEqual([]);
+		expect(parsed.terms.trim()).toBe("lang: rank");
+	});
+});
+
+// `file:` case behavior mirrors the SAME normalizer the index's own
+// path-keyed maps already fold through (#1025) — probe its REAL behavior
+// rather than branching on `process.platform` (the #1024/shape-2/shape-7
+// class): folds case only where the host's map-key normalizer does
+// (win32), never on a case-sensitive FS (e.g. Linux CI), so this test is
+// honest either way instead of vacuously passing.
+const WORD_INDEX_KEY_FOLDS_CASE = wordIndexKey("A.ts") === wordIndexKey("a.ts");
+
+describe("buildWordIndexQueryFilter (#1450)", () => {
+	it("lang: accepts every KIND_EXTENSIONS key — no second, hand-maintained language list (#894)", () => {
+		// Coverage-style assertion: the accepted `lang:` values ARE
+		// KIND_EXTENSIONS' own keys, proven by resolving each key through the
+		// real filter builder rather than any duplicated list.
+		for (const kind of Object.keys(KIND_EXTENSIONS)) {
+			const predicate = buildWordIndexQueryFilter([
+				{ key: "lang", value: kind, negated: false },
+			]);
+			expect(predicate).toBeTypeOf("function");
+		}
+	});
+
+	it("lang: throws for an unrecognized kind, listing known kinds", () => {
+		expect(() =>
+			buildWordIndexQueryFilter([{ key: "lang", value: "klingon", negated: false }]),
+		).toThrow(WordIndexQueryError);
+	});
+
+	it("lang: matches files by KIND_EXTENSIONS extension set", () => {
+		const predicate = buildWordIndexQueryFilter([
+			{ key: "lang", value: "python", negated: false },
+		]);
+		expect(predicate?.("scripts/tool.py")).toBe(true);
+		expect(predicate?.("src/tool.ts")).toBe(false);
+	});
+
+	it("ext: normalizes with or without a leading dot", () => {
+		const withDot = buildWordIndexQueryFilter([
+			{ key: "ext", value: ".ts", negated: false },
+		]);
+		const withoutDot = buildWordIndexQueryFilter([
+			{ key: "ext", value: "ts", negated: false },
+		]);
+		expect(withDot?.("src/tool.ts")).toBe(true);
+		expect(withoutDot?.("src/tool.ts")).toBe(true);
+		expect(withDot?.("src/tool.tsx")).toBe(false);
+	});
+
+	it("file: substring-matches the (wordIndexKey-normalized) path", () => {
+		const predicate = buildWordIndexQueryFilter([
+			{ key: "file", value: "clients/", negated: false },
+		]);
+		expect(predicate?.("clients/word-index.ts")).toBe(true);
+		expect(predicate?.("tools/symbol-search.ts")).toBe(false);
+	});
+
+	it("file: matches regardless of separator (backslash vs forward slash, all platforms)", () => {
+		const predicate = buildWordIndexQueryFilter([
+			{ key: "file", value: "clients/word-index.ts", negated: false },
+		]);
+		expect(predicate?.("sub\\clients\\word-index.ts")).toBe(true);
+	});
+
+	it.skipIf(!WORD_INDEX_KEY_FOLDS_CASE)(
+		"file: is case-insensitive on a case-insensitive FS (win32)",
+		() => {
+			const predicate = buildWordIndexQueryFilter([
+				{ key: "file", value: "CLIENTS/", negated: false },
+			]);
+			expect(predicate?.("clients/word-index.ts")).toBe(true);
+		},
+	);
+
+	it.skipIf(WORD_INDEX_KEY_FOLDS_CASE)(
+		"file: is case-SENSITIVE on a case-sensitive FS (POSIX/Linux CI)",
+		() => {
+			const predicate = buildWordIndexQueryFilter([
+				{ key: "file", value: "CLIENTS/", negated: false },
+			]);
+			expect(predicate?.("clients/word-index.ts")).toBe(false);
+		},
+	);
+
+	it("same-key positive filters OR together", () => {
+		const predicate = buildWordIndexQueryFilter([
+			{ key: "lang", value: "python", negated: false },
+			{ key: "lang", value: "go", negated: false },
+		]);
+		expect(predicate?.("a.py")).toBe(true);
+		expect(predicate?.("b.go")).toBe(true);
+		expect(predicate?.("c.ts")).toBe(false);
+	});
+
+	it("different-key filters AND together", () => {
+		const predicate = buildWordIndexQueryFilter([
+			{ key: "lang", value: "jsts", negated: false },
+			{ key: "file", value: "clients/", negated: false },
+		]);
+		expect(predicate?.("clients/word-index.ts")).toBe(true);
+		expect(predicate?.("tools/word-index.ts")).toBe(false);
+		expect(predicate?.("clients/tool.py")).toBe(false);
+	});
+
+	it("negations always subtract, even against a matching positive filter", () => {
+		const predicate = buildWordIndexQueryFilter([
+			{ key: "file", value: "clients/", negated: false },
+			{ key: "file", value: "test", negated: true },
+		]);
+		expect(predicate?.("clients/word-index.ts")).toBe(true);
+		expect(predicate?.("clients/word-index.test.ts")).toBe(false);
 	});
 });
 
@@ -153,6 +344,93 @@ describe("searchWordIndex fileFilter (#771)", () => {
 		});
 		const plain = searchWordIndex(index, "user");
 		expect(withUndefinedFilter).toEqual(plain);
+	});
+});
+
+// #1450: the SAME query-string filter syntax exercised end-to-end through
+// searchWordIndex, which is the word-index query entry point both symbol_search
+// and pilens_symbol_search forward their raw `query` argument into unchanged.
+describe("searchWordIndex inline query filters (#1450)", () => {
+	const files = [
+		{
+			path: "src/auth/login.ts",
+			content:
+				"export function authenticateUser(credentials) {\n  return verifyPassword(credentials);\n}",
+		},
+		{
+			path: "src/user/profile.ts",
+			content:
+				"export function loadUserProfile(userId) {\n  return db.users.find(userId);\n}",
+		},
+		{
+			path: "scripts/authenticate.py",
+			content: "def authenticate_user(id):\n    return id\n",
+		},
+		{
+			path: "src/user/profile.test.ts",
+			content:
+				"export function loadUserProfile(userId) {\n  return db.users.find(userId);\n}",
+		},
+	];
+
+	it("an unfiltered query is byte-identical to before (regression guard)", () => {
+		const index = buildWordIndex(files);
+		const before = searchWordIndex(index, "user");
+		const after = searchWordIndex(index, "user");
+		expect(after).toEqual(before);
+	});
+
+	it("filters BEFORE ranking: the filtered top hit differs from the unfiltered global top", () => {
+		const index = buildWordIndex(files);
+		const unfiltered = searchWordIndex(index, "user");
+		// The global top hit for "user" is whichever file scores highest overall.
+		expect(unfiltered[0].file).not.toBe("scripts/authenticate.py");
+
+		// Excluding the global top via a lang: filter changes what wins.
+		const filtered = searchWordIndex(index, "lang:python user");
+		expect(filtered).toHaveLength(1);
+		expect(filtered[0].file).toBe("scripts/authenticate.py");
+		expect(filtered[0].file).not.toBe(unfiltered[0].file);
+	});
+
+	it("file: filter scopes hits to a path substring", () => {
+		const index = buildWordIndex(files);
+		const results = searchWordIndex(index, "file:auth/ user");
+		expect(results.map((r) => r.file)).toEqual(["src/auth/login.ts"]);
+	});
+
+	it("negated file: filter excludes matching paths", () => {
+		const index = buildWordIndex(files);
+		const results = searchWordIndex(index, "-file:test profile");
+		expect(results.map((r) => r.file)).toEqual(["src/user/profile.ts"]);
+	});
+
+	it("combined lang:/file:/-file: filters from the issue's own example", () => {
+		const index = buildWordIndex(files);
+		const results = searchWordIndex(index, "lang:jsts file:src/ -file:test user");
+		expect(results.map((r) => r.file).sort()).toEqual(
+			["src/auth/login.ts", "src/user/profile.ts"].sort(),
+		);
+	});
+
+	it("an unknown lang: value propagates WordIndexQueryError out of searchWordIndex", () => {
+		const index = buildWordIndex(files);
+		expect(() => searchWordIndex(index, "lang:klingon user")).toThrow(
+			WordIndexQueryError,
+		);
+	});
+
+	it("empty result after filtering is a normal empty array, not a thrown error", () => {
+		const index = buildWordIndex(files);
+		expect(searchWordIndex(index, "lang:go user")).toEqual([]);
+	});
+
+	it("composes (AND) with a caller-supplied fileFilter option", () => {
+		const index = buildWordIndex(files);
+		const results = searchWordIndex(index, "lang:jsts user", {
+			fileFilter: (file) => file.startsWith("src/auth/"),
+		});
+		expect(results.map((r) => r.file)).toEqual(["src/auth/login.ts"]);
 	});
 });
 

--- a/tests/tools/symbol-search.test.ts
+++ b/tests/tools/symbol-search.test.ts
@@ -448,20 +448,30 @@ describe("symbol_search tool", () => {
 			}
 		});
 
-		it("unknown prefix (e.g. type:foo) fails loudly with the supported list, not as a literal term", async () => {
+		it("an unknown colon token searches as a plain term; a bad lang: value fails loudly", async () => {
 			const env = setupTestEnvironment("pi-lens-symbolsearch-queryunknown-");
 			try {
 				makeFixture(env);
 				const tool = createSymbolSearchTool(() => env.tmpDir);
-				const result = await tool.execute(
+				// Colon-bearing term: no error, ordinary search (old behavior).
+				const passThrough = await tool.execute(
 					"1",
 					{ query: "type:foo authenticate user" },
 					undefined,
 					null,
 					{ cwd: env.tmpDir },
 				);
-				expect(result.isError).toBe(true);
-				expect(String(result.content[0]?.text)).toMatch(/lang:|file:|ext:/);
+				expect(passThrough.isError).not.toBe(true);
+				// Known key, bad value: the loud-failure contract survives.
+				const badValue = await tool.execute(
+					"2",
+					{ query: "lang:notalang authenticate user" },
+					undefined,
+					null,
+					{ cwd: env.tmpDir },
+				);
+				expect(badValue.isError).toBe(true);
+				expect(String(badValue.content[0]?.text)).toContain("lang");
 			} finally {
 				env.cleanup();
 			}

--- a/tests/tools/symbol-search.test.ts
+++ b/tests/tools/symbol-search.test.ts
@@ -373,6 +373,125 @@ describe("symbol_search tool", () => {
 		});
 	});
 
+	// #1450: lang:/file:/ext: prefix filters (+ `-` negation) embedded in the
+	// query STRING itself — distinct from the structured `paths`/`lang` params
+	// tested above (#771), and exercised through the same tool entry point.
+	describe("inline query prefix filters (#1450)", () => {
+		function makeFixture(env: { tmpDir: string }) {
+			const tsFile = createTempFile(
+				env.tmpDir,
+				"src/auth/login.ts",
+				"export function authenticateUser(id) { return id; }",
+			);
+			const pyFile = createTempFile(
+				env.tmpDir,
+				"scripts/authenticate.py",
+				"def authenticate_user(id):\n    return id\n",
+			);
+			warmWordIndexSnapshot(env.tmpDir, [
+				{ path: tsFile, content: "export function authenticateUser(id) { return id; }" },
+				{
+					path: pyFile,
+					content: "def authenticate_user(id):\n    return id\n",
+				},
+			]);
+			return { tsFile, pyFile };
+		}
+
+		it("lang: filters hits to one file kind before ranking", async () => {
+			const env = setupTestEnvironment("pi-lens-symbolsearch-querylang-");
+			try {
+				makeFixture(env);
+				const tool = createSymbolSearchTool(() => env.tmpDir);
+				const result = await tool.execute(
+					"1",
+					{ query: "lang:python authenticate user" },
+					undefined,
+					null,
+					{ cwd: env.tmpDir },
+				);
+				const text = String(result.content[0]?.text);
+				const payload = JSON.parse(text.slice(text.indexOf("{"))) as {
+					results: Array<{ file: string }>;
+				};
+				expect(payload.results).toHaveLength(1);
+				expect(payload.results[0].file.replace(/\\/g, "/")).toBe(
+					"scripts/authenticate.py",
+				);
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("file: filter scopes hits to a path substring", async () => {
+			const env = setupTestEnvironment("pi-lens-symbolsearch-queryfile-");
+			try {
+				makeFixture(env);
+				const tool = createSymbolSearchTool(() => env.tmpDir);
+				const result = await tool.execute(
+					"1",
+					{ query: "file:src/auth authenticate user" },
+					undefined,
+					null,
+					{ cwd: env.tmpDir },
+				);
+				const text = String(result.content[0]?.text);
+				const payload = JSON.parse(text.slice(text.indexOf("{"))) as {
+					results: Array<{ file: string }>;
+				};
+				expect(payload.results).toHaveLength(1);
+				expect(payload.results[0].file.replace(/\\/g, "/")).toBe(
+					"src/auth/login.ts",
+				);
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("unknown prefix (e.g. type:foo) fails loudly with the supported list, not as a literal term", async () => {
+			const env = setupTestEnvironment("pi-lens-symbolsearch-queryunknown-");
+			try {
+				makeFixture(env);
+				const tool = createSymbolSearchTool(() => env.tmpDir);
+				const result = await tool.execute(
+					"1",
+					{ query: "type:foo authenticate user" },
+					undefined,
+					null,
+					{ cwd: env.tmpDir },
+				);
+				expect(result.isError).toBe(true);
+				expect(String(result.content[0]?.text)).toMatch(/lang:|file:|ext:/);
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("unfiltered inline-filter-free queries reproduce today's output (regression guard)", async () => {
+			const env = setupTestEnvironment("pi-lens-symbolsearch-querynofilter-");
+			try {
+				makeFixture(env);
+				const tool = createSymbolSearchTool(() => env.tmpDir);
+				const result = await tool.execute(
+					"1",
+					{ query: "authenticate user" },
+					undefined,
+					null,
+					{ cwd: env.tmpDir },
+				);
+				const text = String(result.content[0]?.text);
+				const payload = JSON.parse(text.slice(text.indexOf("{"))) as {
+					results: Array<{ file: string }>;
+				};
+				expect(payload.results.map((r) => r.file.replace(/\\/g, "/")).sort()).toEqual(
+					["scripts/authenticate.py", "src/auth/login.ts"].sort(),
+				);
+			} finally {
+				env.cleanup();
+			}
+		});
+	});
+
 	// #771: graph-aware hit annotations — read-only, present only when the
 	// cached review graph happens to be warm; a cold cache must neither
 	// annotate nor trigger a build (the tool's latency profile is unchanged).

--- a/tools/symbol-search.ts
+++ b/tools/symbol-search.ts
@@ -43,7 +43,8 @@ export function createSymbolSearchTool(getProjectRoot: () => string) {
 		}),
 		parameters: Type.Object({
 			query: Type.String({
-				description: "Identifier-ish query, e.g. 'authenticate user'.",
+				description:
+					"Identifier-ish query, e.g. 'authenticate user'. Mix in composable prefix filters: lang:<kind> (e.g. lang:jsts, lang:python — kinds from file-kinds.ts), file:<substr> (path substring), ext:<ext> (e.g. ext:ts or ext:.ts), each optionally negated with a leading '-' (-file:test). Filters apply before ranking; e.g. 'lang:jsts file:clients/ -file:test rank'. Unknown prefixes/kinds error with the supported list.",
 			}),
 			limit: Type.Optional(
 				Type.Number({


### PR DESCRIPTION
## Summary

Word-index queries gain composable prefix filters mixed with plain terms: `lang:ts file:clients/ -file:test rank`. A hand-rolled tokenizer splits filters from terms. `lang:` derives from `KIND_EXTENSIONS` — proven by a set-equality test, no second language list. Filters apply before ranking; BM25 idf stays corpus-global, documented as deliberate. Both `symbol_search` surfaces inherit the syntax through the single query entry point with zero plumbing.

Colon-bearing search terms are safe. `std::vector`, `error:` log terms, URLs, and pasted Windows paths search as ordinary terms. Only a recognized key with a bad value (`lang:notalang`) fails loudly.

## Verification

Adversarial review round one returned FIX FIRST on exactly that point: the original tokenizer threw on any unknown colon token, a usability regression the reviewer proved with six real query shapes. Fixed; regression tests cover all six plus the surviving loud-failure case. Everything else was verified clean in review: tool-layer error rendering on both surfaces, fileFilter composition without double-filtering, the KIND_EXTENSIONS drift-proof assertion, docs accuracy, and a red-first filter-neutering check (13 tests red). 87 targeted tests, build, lint, and changelog pass.

Closes #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)
