### PR TITLE
feat: attribute worklog diagnostics to model and provider (#1448)

### DIFF
--- a/.changelog/feat-1448-worklog-model-attribution.md
+++ b/.changelog/feat-1448-worklog-model-attribution.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Attribute worklog and disposition entries to the model/provider that produced them (closes #1448)** — `WorklogEntry` and `DispositionLogEntry` gain optional `model`/`provider` fields, populated at append time from the runtime's telemetry identity (`RuntimeCoordinator.telemetryModelId`/`telemetryProviderId`) and blank when the runtime doesn't know its identity. Provider is the host's explicit value when reported, else a conservative parse of the model id (`clients/model-provider.ts`: a single `/` or `:` separator, or a small known-prefix table; blank on ambiguity — never guessed). `npm run logs:smells` now prints a per-model rollup (rule × model counts, auto-fixed vs. agent-required rates) from `worklog.jsonl`. Old worklog/disposition-log entries stay valid; readers treat both fields as optional.

--- a/clients/diagnostic-dispositions.ts
+++ b/clients/diagnostic-dispositions.ts
@@ -388,6 +388,7 @@ function emitMarkTelemetry(
 	anchor: string,
 	reason: string | undefined,
 	existing: DispositionEntry | undefined,
+	identity: { model?: string; provider?: string } | undefined,
 ): void {
 	try {
 		logDispositionEvent({
@@ -400,6 +401,8 @@ function emitMarkTelemetry(
 			reason,
 			anchor,
 			previousDisposition: existing?.disposition,
+			model: identity?.model || undefined,
+			provider: identity?.provider || undefined,
 		});
 		publishDisposition({
 			cwd,
@@ -432,6 +435,7 @@ export function markDisposition(
 	target: DispositionMarkTarget,
 	disposition: Disposition,
 	reason?: string,
+	identity?: { model?: string; provider?: string },
 ): string {
 	const anchor =
 		disposition === "false-positive"
@@ -443,7 +447,7 @@ export function markDisposition(
 	const existing = readState(cwd).dispositions?.[anchor];
 	if (disposition === "defer") {
 		deferredThisSession.add(anchor);
-		emitMarkTelemetry(cwd, target, disposition, anchor, reason, existing);
+		emitMarkTelemetry(cwd, target, disposition, anchor, reason, existing, identity);
 		return anchor;
 	}
 
@@ -463,7 +467,7 @@ export function markDisposition(
 		lineText,
 	};
 	commitDisposition(cwd, anchor, entry);
-	emitMarkTelemetry(cwd, target, disposition, anchor, reason, existing);
+	emitMarkTelemetry(cwd, target, disposition, anchor, reason, existing, identity);
 	return anchor;
 }
 

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -161,6 +161,10 @@ export function createDispatchContext(
 	projectRoot?: string,
 	/** Ordered per-file pipeline token, when this is a post-write dispatch. */
 	writeIndex?: number,
+	/** Runtime telemetry identity, when known (#1448) — threaded to the
+	 * worklog append; see DispatchContext.telemetryModel's doc. */
+	telemetryModel?: string,
+	telemetryProvider?: string,
 ): DispatchContext {
 	const absoluteFilePath = resolveRunnerPath(cwd, filePath);
 	const normalizedProjectRoot = normalizeMapKey(
@@ -191,6 +195,8 @@ export function createDispatchContext(
 		blockingOnly,
 		modifiedRanges,
 		writeIndex,
+		telemetryModel,
+		telemetryProvider,
 
 		async hasTool(command: string): Promise<boolean> {
 			return checkToolAvailability(command, facts);
@@ -852,11 +858,16 @@ export async function dispatchForFile(
 	);
 	const fixedItems = visibleDiagnostics.filter((d) => d.semantic === "fixed");
 
-	// Append fixed and fixable diagnostics to the persistent worklog
+	// Append fixed and fixable diagnostics to the persistent worklog, attributed
+	// to the runtime's active model/provider when known (#1448).
+	const worklogIdentity = {
+		model: ctx.telemetryModel,
+		provider: ctx.telemetryProvider,
+	};
 	if (fixedItems.length > 0) {
 		import("../fix-worklog.js")
 			.then(({ appendToWorklog }) => {
-				appendToWorklog(ctx.cwd, fixedItems, true);
+				appendToWorklog(ctx.cwd, fixedItems, true, worklogIdentity);
 			})
 			.catch(() => {});
 	}
@@ -864,7 +875,7 @@ export async function dispatchForFile(
 	if (fixableWarnings.length > 0) {
 		import("../fix-worklog.js")
 			.then(({ appendToWorklog }) => {
-				appendToWorklog(ctx.cwd, fixableWarnings, false);
+				appendToWorklog(ctx.cwd, fixableWarnings, false, worklogIdentity);
 			})
 			.catch(() => {});
 	}

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -2190,6 +2190,10 @@ export async function dispatchLintWithResult(
 		projectRoot?: string;
 		/** Ordered per-file pipeline token, when called from tool_result. */
 		writeIndex?: number;
+		/** Runtime telemetry identity, when known (#1448) — see
+		 * DispatchContext.telemetryModel's doc. */
+		telemetryModel?: string;
+		telemetryProvider?: string;
 	},
 ): Promise<DispatchResult> {
 	// Default true preserves the per-edit fast path (errors only). Callers that
@@ -2204,6 +2208,8 @@ export async function dispatchLintWithResult(
 		modifiedRanges,
 		options?.projectRoot,
 		options?.writeIndex,
+		options?.telemetryModel,
+		options?.telemetryProvider,
 	);
 	sessionFacts.clearFileFactsFor(ctx.filePath);
 

--- a/clients/dispatch/types.ts
+++ b/clients/dispatch/types.ts
@@ -182,6 +182,11 @@ export interface DispatchContext {
 	readonly modifiedRanges?: ModifiedRange[];
 	/** Ordered per-file pipeline token used by widget reconciliation (#1198). */
 	readonly writeIndex?: number;
+	/** Model/provider active for this dispatch, when the runtime knows it
+	 * (#1448) — threaded to the worklog append so repair history can be
+	 * attributed. Blank/absent outside a live agent turn (e.g. project scans). */
+	readonly telemetryModel?: string;
+	readonly telemetryProvider?: string;
 
 	hasTool(command: string): Promise<boolean>;
 	log(message: string): void;

--- a/clients/disposition-logger.ts
+++ b/clients/disposition-logger.ts
@@ -49,6 +49,11 @@ export interface DispositionLogEntry {
 	/** The store entry's disposition this mark overwrote, when it did — the
 	 * re-mark history the latest-wins store loses. */
 	previousDisposition?: string;
+	/** Model/provider active when the mark was made, when known (#1448 class
+	 * sweep — same optional-attribution pattern as WorklogEntry). Blank when
+	 * the runtime doesn't know its identity. */
+	model?: string;
+	provider?: string;
 }
 
 export function logDispositionEvent(entry: DispositionLogEntry): void {

--- a/clients/fix-worklog.ts
+++ b/clients/fix-worklog.ts
@@ -24,6 +24,19 @@ export interface WorklogEntry {
 	fixable: boolean;
 	fixSuggestion?: string;
 	autoFixed: boolean;
+	/** Model/provider that produced the code this diagnostic fired against
+	 * (#1448). Optional — blank/omitted whenever the runtime doesn't know the
+	 * active identity (e.g. project-wide scans outside a live agent turn).
+	 * Old entries predate these fields entirely; readers must treat both as
+	 * optional. */
+	model?: string;
+	provider?: string;
+}
+
+/** Identity to attribute a worklog append to, when known. */
+export interface WorklogIdentity {
+	model?: string;
+	provider?: string;
 }
 
 // --- Paths ---
@@ -43,6 +56,7 @@ export function appendToWorklog(
 	cwd: string,
 	diagnostics: Diagnostic[],
 	autoFixed: boolean,
+	identity?: WorklogIdentity,
 ): void {
 	if (diagnostics.length === 0) return;
 
@@ -50,6 +64,8 @@ export function appendToWorklog(
 	try {
 		fs.mkdirSync(path.dirname(worklogPath), { recursive: true });
 		const timestamp = new Date().toISOString();
+		const model = identity?.model?.trim() || undefined;
+		const provider = identity?.provider?.trim() || undefined;
 		const lines =
 			diagnostics
 				.map((d) => {
@@ -64,6 +80,8 @@ export function appendToWorklog(
 						fixable: d.fixable ?? false,
 						fixSuggestion: d.fixSuggestion,
 						autoFixed,
+						model,
+						provider,
 					};
 					return JSON.stringify(entry);
 				})

--- a/clients/mcp/analyze.ts
+++ b/clients/mcp/analyze.ts
@@ -412,6 +412,10 @@ export async function analyzeFile(
 
 	const reportsBefore = getLatencyReports().length;
 	const start = Date.now();
+	// No telemetryModel/telemetryProvider here (#1448): this MCP facade has no
+	// RuntimeCoordinator to hold a host-reported identity (see the module doc
+	// above), so any worklog entries this dispatch produces get a blank
+	// model/provider — that's correct, not a gap.
 	const result = await dispatchLintWithResult(
 		absPath,
 		cwd,

--- a/clients/model-provider.ts
+++ b/clients/model-provider.ts
@@ -1,0 +1,53 @@
+/**
+ * Provider derivation for worklog/disposition attribution (#1448).
+ *
+ * The host reports `provider` and `model` as separate fields on its telemetry
+ * events (see `updateRuntimeIdentityFromEvent` in index.ts and the
+ * `tool_result` handler in clients/runtime-tool-result.ts) MOST of the time —
+ * so the common case needs no parsing at all. This parser exists only for the
+ * fallback: a model id supplied without an explicit provider.
+ *
+ * Derivation rule (conservative — returns "" rather than guess):
+ *   1. A single `/` or `:` separator splits the id into `<provider>/<rest>`
+ *      or `<provider>:<rest>` — e.g. "anthropic/claude-sonnet-4-5",
+ *      "openai:gpt-5". The left segment is lowercased and returned AS-IS
+ *      (no allowlist check) since an explicit separator is deliberate host
+ *      structure, not a guess.
+ *   2. No separator: match a known model-id PREFIX against a small table of
+ *      vendor naming conventions (claude- -> anthropic; gpt-, o1-, o3- ->
+ *      openai; gemini- -> google; llama- -> meta; mistral-, mixtral- ->
+ *      mistral; command- -> cohere). First match wins.
+ *   3. Anything else (unrecognized prefix, multiple separators, empty
+ *      string) is ambiguous -> "".
+ */
+
+const KNOWN_PREFIXES: [prefix: string, provider: string][] = [
+	["claude-", "anthropic"],
+	["gpt-", "openai"],
+	["o1-", "openai"],
+	["o3-", "openai"],
+	["gemini-", "google"],
+	["llama-", "meta"],
+	["mistral-", "mistral"],
+	["mixtral-", "mistral"],
+	["command-", "cohere"],
+];
+
+export function deriveProviderFromModelId(modelId: string | undefined): string {
+	const id = modelId?.trim().toLowerCase();
+	if (!id) return "";
+
+	const separators = [...id].filter((c) => c === "/" || c === ":").length;
+	if (separators === 1) {
+		const sep = id.includes("/") ? "/" : ":";
+		const [providerPart, ...rest] = id.split(sep);
+		if (providerPart && rest.join(sep).length > 0) return providerPart;
+		return "";
+	}
+	if (separators > 1) return "";
+
+	for (const [prefix, provider] of KNOWN_PREFIXES) {
+		if (id.startsWith(prefix)) return provider;
+	}
+	return "";
+}

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -239,6 +239,10 @@ export interface PipelineContext {
 		sessionId: string;
 		turnIndex: number;
 		writeIndex: number;
+		/** Raw model id / provider, separate from the combined `model` display
+		 * string above — worklog attribution (#1448) wants the two apart. */
+		modelId?: string;
+		provider?: string;
 	};
 	/** pi.getFlag accessor */
 	getFlag: (name: string, filePath?: string) => boolean | string | undefined;
@@ -1283,6 +1287,8 @@ export async function runPipeline(
 		{
 			projectRoot: ctx.projectRoot,
 			writeIndex: ctx.telemetry?.writeIndex,
+			telemetryModel: ctx.telemetry?.modelId,
+			telemetryProvider: ctx.telemetry?.provider,
 		},
 	);
 	recordDiagnostics(

--- a/clients/runtime-coordinator.ts
+++ b/clients/runtime-coordinator.ts
@@ -13,6 +13,7 @@ import { ReadGuard } from "./read-guard.js";
 import type { RuleScanResult } from "./rules-scanner.js";
 import { RUNTIME_CONFIG } from "./runtime-config.js";
 import { TurnSummaryCollector } from "./turn-summary.js";
+import { deriveProviderFromModelId } from "./model-provider.js";
 
 export interface ErrorDebtBaseline {
 	testsPassed: boolean;
@@ -106,6 +107,13 @@ export class RuntimeCoordinator {
 	private _lifecycleReason: string | undefined;
 	private _hasStableSessionId = false;
 	private _telemetryModel = "unknown";
+	// Raw model/provider identity, separate from the combined `provider/model`
+	// display string above — worklog/disposition attribution (#1448) wants the
+	// two fields apart, blank when the host never supplied them. `_telemetryProvider`
+	// is the explicit host value when given, else derived from the model id
+	// (deriveProviderFromModelId, blank on ambiguity — never guessed).
+	private _telemetryModelId = "";
+	private _telemetryProvider = "";
 	private _turnIndex = 0;
 	private _writeIndex = 0;
 	private _projectSeq = 0;
@@ -170,6 +178,8 @@ export class RuntimeCoordinator {
 		this._telemetrySessionId = `lens-${Date.now().toString(36)}-${randomBytes(4).toString("hex")}`;
 		this._hasStableSessionId = false;
 		this._telemetryModel = "unknown";
+		this._telemetryModelId = "";
+		this._telemetryProvider = "";
 		this._turnIndex = 0;
 		this._writeIndex = 0;
 		this._projectSeq = 0;
@@ -325,6 +335,15 @@ export class RuntimeCoordinator {
 		} else if (provider) {
 			this._telemetryModel = provider;
 		}
+		if (model) this._telemetryModelId = model;
+		if (provider) {
+			this._telemetryProvider = provider;
+		} else if (model && !this._telemetryProvider) {
+			// Only fall back to derivation when no provider has ever been reported
+			// this session — an explicit provider (even from an earlier call) must
+			// never be overwritten by a same-session guess.
+			this._telemetryProvider = deriveProviderFromModelId(model);
+		}
 	}
 
 	get telemetrySessionId(): string {
@@ -360,6 +379,19 @@ export class RuntimeCoordinator {
 
 	get telemetryModel(): string {
 		return this._telemetryModel;
+	}
+
+	/** Raw model id (never the combined `provider/model` display string), blank
+	 * when the host hasn't reported one this session. Worklog/disposition
+	 * attribution (#1448) reads this, not {@link telemetryModel}. */
+	get telemetryModelId(): string {
+		return this._telemetryModelId;
+	}
+
+	/** Explicit host-reported provider, or a conservative derivation from the
+	 * model id (see clients/model-provider.ts), blank when neither is known. */
+	get telemetryProviderId(): string {
+		return this._telemetryProvider;
 	}
 
 	get turnIndex(): number {

--- a/clients/runtime-coordinator.ts
+++ b/clients/runtime-coordinator.ts
@@ -114,6 +114,12 @@ export class RuntimeCoordinator {
 	// (deriveProviderFromModelId, blank on ambiguity — never guessed).
 	private _telemetryModelId = "";
 	private _telemetryProvider = "";
+	// True once a host has supplied an explicit provider this session. An
+	// explicit provider is never downgraded by a derivation from a later
+	// model-only call; a DERIVED provider, by contrast, is re-derived on
+	// every model-only call so a mid-session model switch (e.g. gpt-5-mini →
+	// claude-sonnet-4-5) doesn't leave a stale provider from the old model.
+	private _telemetryProviderIsExplicit = false;
 	private _turnIndex = 0;
 	private _writeIndex = 0;
 	private _projectSeq = 0;
@@ -180,6 +186,7 @@ export class RuntimeCoordinator {
 		this._telemetryModel = "unknown";
 		this._telemetryModelId = "";
 		this._telemetryProvider = "";
+		this._telemetryProviderIsExplicit = false;
 		this._turnIndex = 0;
 		this._writeIndex = 0;
 		this._projectSeq = 0;
@@ -338,10 +345,16 @@ export class RuntimeCoordinator {
 		if (model) this._telemetryModelId = model;
 		if (provider) {
 			this._telemetryProvider = provider;
-		} else if (model && !this._telemetryProvider) {
-			// Only fall back to derivation when no provider has ever been reported
-			// this session — an explicit provider (even from an earlier call) must
-			// never be overwritten by a same-session guess.
+			this._telemetryProviderIsExplicit = true;
+		} else if (model && !this._telemetryProviderIsExplicit) {
+			// No explicit provider has ever been reported this session, so the
+			// provider is (still) a derivation — re-derive it from the CURRENT
+			// model id every time. Without this, a stale derived provider from
+			// an earlier model would survive a mid-session model switch (e.g.
+			// gpt-5-mini → claude-sonnet-4-5 with no explicit provider on
+			// either call) because the old "has any provider ever been set"
+			// guard treated the derived value as sticky. An explicit provider,
+			// once set, is never touched here regardless of later model calls.
 			this._telemetryProvider = deriveProviderFromModelId(model);
 		}
 	}

--- a/clients/runtime-tool-result.ts
+++ b/clients/runtime-tool-result.ts
@@ -797,6 +797,8 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 				sessionId: runtime.telemetrySessionId,
 				turnIndex: runtime.turnIndex,
 				writeIndex,
+				modelId: runtime.telemetryModelId,
+				provider: runtime.telemetryProviderId,
 			},
 			getFlag,
 			getFlagSource,

--- a/index.ts
+++ b/index.ts
@@ -1445,7 +1445,10 @@ function activateExtension(hostPi: ExtensionAPI) {
 			readGuard: runtime.readGuard,
 			dbg,
 		}),
-		createLensDiagnosticMarkTool(() => runtime.projectRoot),
+		createLensDiagnosticMarkTool(() => runtime.projectRoot, () => ({
+			model: runtime.telemetryModelId,
+			provider: runtime.telemetryProviderId,
+		})),
 	];
 	const LAZY_TOOL_CATALOG: ActivatableToolInfo[] = [
 		{

--- a/scripts/analyze-pi-lens-logs.mjs
+++ b/scripts/analyze-pi-lens-logs.mjs
@@ -12,6 +12,7 @@
  *   ~/.pi-lens/actionable-warnings*.log  JSONL advisory pipeline (inject/suppress)
  *   ~/.pi-lens/ast-grep-tools*.log   JSONL MCP ast-grep search/replace telemetry
  *   ~/.pi-lens/logs/*.jsonl          JSONL diagnostic findings
+ *   ~/.pi-lens/projects/<slug>/worklog.jsonl  JSONL fix worklog (rule/tool/model/provider, #1448)
  */
 
 import fs from "node:fs";
@@ -69,6 +70,7 @@ async function main() {
 		analyzeSessionStart(files.sessionStart, state),
 		analyzeActionableWarnings(files.actionableWarnings, state),
 		analyzeAstGrepTools(files.astGrepTools, state),
+		analyzeWorklog(files.worklog, state),
 	]);
 
 	const report = buildReport(state);
@@ -139,6 +141,13 @@ function discoverLogFiles(logRoot, archived) {
 		.filter((name) => name.endsWith(".jsonl"))
 		.map((name) => path.join(logsDir, name));
 
+	// worklog.jsonl lives per-project under projects/<slug>/ (getProjectDataDir),
+	// not at the log root — walk one level to find every project's file (#1448).
+	const projectsDir = path.join(logRoot, "projects");
+	const worklogs = safeReaddir(projectsDir)
+		.map((slug) => path.join(projectsDir, slug, "worklog.jsonl"))
+		.filter((file) => fs.existsSync(file));
+
 	const byPrefix = (prefix) =>
 		allRootFiles.filter((file) => {
 			const base = path.basename(file);
@@ -156,6 +165,7 @@ function discoverLogFiles(logRoot, archived) {
 		actionableWarnings: byPrefix("actionable-warnings"),
 		astGrepTools: byPrefix("ast-grep-tools"),
 		diagnostics: dailyLogs,
+		worklog: worklogs,
 	};
 }
 
@@ -262,6 +272,14 @@ function createState(files) {
 			calls: 0,
 			errors: [],
 			slow: [],
+		},
+		worklog: {
+			// key: "<rule>||<model>" (model "" when the entry predates #1448 or the
+			// runtime didn't know it) -> { total, autoFixed }
+			byRuleModel: new Map(),
+			byModel: counter(),
+			byModelAutoFixed: counter(),
+			byProvider: counter(),
 		},
 	};
 }
@@ -733,6 +751,39 @@ async function analyzeAstGrepTools(files, state) {
 					byDuration,
 				);
 			}
+		});
+	}
+}
+
+/**
+ * Per-model rollup (#1448): rule × model counts and auto-fixed vs
+ * agent-required rates, from worklog.jsonl's optional `model`/`provider`
+ * fields. Entries predating #1448 (or written outside a live agent turn)
+ * have neither field — bucketed under the empty-string model/provider key so
+ * "unattributed" volume stays visible rather than silently dropped.
+ */
+async function analyzeWorklog(files, state) {
+	for (const file of files) {
+		await forEachJsonLine(file, "worklog", state, (entry) => {
+			const ts = dateOf(entry.timestamp);
+			if (!inWindow(ts)) return;
+			state.seen.inc("worklog");
+			const rule = entry.rule ?? "unknown";
+			const model = entry.model ?? "";
+			const provider = entry.provider ?? "";
+			const key = `${rule}||${model}`;
+			const row = state.worklog.byRuleModel.get(key) ?? {
+				rule,
+				model,
+				total: 0,
+				autoFixed: 0,
+			};
+			row.total += 1;
+			if (entry.autoFixed) row.autoFixed += 1;
+			state.worklog.byRuleModel.set(key, row);
+			state.worklog.byModel.inc(model || "(unknown)");
+			if (entry.autoFixed) state.worklog.byModelAutoFixed.inc(model || "(unknown)");
+			state.worklog.byProvider.inc(provider || "(unknown)");
 		});
 	}
 }
@@ -1259,6 +1310,17 @@ function buildReport(state) {
 			errors: state.astGrep.errors.slice(0, limit),
 			slow: state.astGrep.slow.slice(0, limit),
 		},
+		worklog: {
+			byModel: state.worklog.byModel.top(limit * 2),
+			byProvider: state.worklog.byProvider.top(limit * 2),
+			byRuleModel: [...state.worklog.byRuleModel.values()]
+				.map((row) => ({
+					...row,
+					autoFixedRate: row.total ? row.autoFixed / row.total : 0,
+				}))
+				.sort((a, b) => b.total - a.total)
+				.slice(0, limit * 3),
+		},
 	};
 }
 
@@ -1397,6 +1459,23 @@ function printReport(report) {
 			`  started=${ws.started} completed=${ws.completed} incomplete=${ws.incomplete} aborted=${ws.aborted} fileTimeouts=${ws.timedOutFilesTotal} (in ${ws.timedOutSweeps} sweeps)`,
 		);
 	}
+	const wl = report.worklog;
+	if (wl && (wl.byModel.length || wl.byRuleModel.length)) {
+		console.log("\nWorklog per-model rollup (#1448)");
+		console.log(
+			`  by model: ${wl.byModel.map((x) => `${x.key}=${x.count}`).join(", ")}`,
+		);
+		if (wl.byProvider.length)
+			console.log(
+				`  by provider: ${wl.byProvider.map((x) => `${x.key}=${x.count}`).join(", ")}`,
+			);
+		console.log("  rule × model (auto-fixed vs agent-required):");
+		for (const row of wl.byRuleModel.slice(0, limit))
+			console.log(
+				`    ${String(row.total).padStart(5)}  ${row.rule} [${row.model || "(unknown)"}]  autoFixed=${row.autoFixed} (${(row.autoFixedRate * 100).toFixed(0)}%)`,
+			);
+	}
+
 	const timeouts = Object.entries(report.latency.phaseTimeouts ?? {});
 	if (timeouts.length) {
 		console.log("\nPhase timeouts");

--- a/tests/clients/diagnostic-dispositions.test.ts
+++ b/tests/clients/diagnostic-dispositions.test.ts
@@ -641,6 +641,29 @@ describe("mark telemetry (#690 — NDJSON log + pilens:diagnostic:disposition)",
 		expect(logDispositionEvent).toHaveBeenCalledTimes(1);
 	});
 
+	it("attributes the mark to model/provider when an identity is supplied (#1448)", () => {
+		markDisposition(
+			cwd(),
+			{ cwd: cwd(), filePath: filePath(), ...diag, content },
+			"flagged",
+			undefined,
+			{ model: "claude-sonnet-4-5", provider: "anthropic" },
+		);
+		expect(logDispositionEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: "claude-sonnet-4-5",
+				provider: "anthropic",
+			}),
+		);
+	});
+
+	it("leaves model/provider blank when no identity is supplied", () => {
+		mark("flagged");
+		expect(logDispositionEvent).toHaveBeenCalledWith(
+			expect.objectContaining({ model: undefined, provider: undefined }),
+		);
+	});
+
 	it("swallows an emit throw — the mark itself must never fail on telemetry", () => {
 		wireDispositionBusEmitter(() => {
 			throw new Error("bus explosion");

--- a/tests/clients/dispatch/dispatcher-worklog-identity.test.ts
+++ b/tests/clients/dispatch/dispatcher-worklog-identity.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Middle-of-pipe wiring test for #1448 model/provider attribution.
+ *
+ * file-utils.test.ts covers the appendToWorklog ENDPOINT (does the write
+ * redact/shape identity correctly) and runtime-coordinator.test.ts covers
+ * the RuntimeCoordinator ENDPOINT (does setTelemetryIdentity derive/track
+ * correctly). Neither exercises the seam between them: createDispatchContext
+ * threading telemetryModel/telemetryProvider into a DispatchContext, and the
+ * real (unmocked) dispatchForFile reading ctx.telemetryModel/telemetryProvider
+ * to build the worklogIdentity it hands to appendToWorklog.
+ *
+ * integration.test.ts drives dispatchLintWithResult but mocks dispatchForFile
+ * out entirely (see clients/dispatch/dispatcher.js mock at the top of that
+ * file), so a severed identity thread inside dispatchForFile itself would
+ * pass every existing suite silently. This test uses the REAL
+ * createDispatchContext + dispatchForFile (dispatchLintWithResult's own
+ * implementation, minus the module-scoped sessionRunnerRegistry) so a
+ * severance at that seam goes red here.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../clients/fix-worklog.js", () => ({
+	appendToWorklog: vi.fn(),
+}));
+
+import {
+	createDispatchContext,
+	dispatchForFile,
+	RunnerRegistry,
+} from "../../../clients/dispatch/dispatcher.js";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import { appendToWorklog } from "../../../clients/fix-worklog.js";
+import type { RunnerGroup } from "../../../clients/dispatch/types.js";
+import { createMockRunner } from "../../mocks/runner-factory.js";
+
+describe("dispatcher worklog identity wiring (#1448)", () => {
+	let registry: RunnerRegistry;
+
+	beforeEach(() => {
+		registry = new RunnerRegistry();
+		vi.mocked(appendToWorklog).mockReset();
+	});
+
+	it("threads telemetryModel/telemetryProvider from createDispatchContext through the real dispatchForFile into appendToWorklog", async () => {
+		registry.register(
+			createMockRunner({
+				id: "fixable-warning-runner",
+				appliesTo: ["jsts"],
+				runResult: {
+					status: "succeeded",
+					diagnostics: [
+						{
+							id: "fixable-1",
+							message: "Unused import",
+							filePath: "test.ts",
+							line: 1,
+							severity: "warning",
+							semantic: "warning",
+							tool: "fixable-warning-runner",
+							fixable: true,
+						},
+					],
+					semantic: "warning",
+				},
+			}),
+		);
+
+		const ctx = createDispatchContext(
+			"test.ts",
+			"/project",
+			{ getFlag: () => false },
+			new FactStore(),
+			false, // blockingOnly=false so the warning survives categorization
+			undefined, // modifiedRanges
+			undefined, // projectRoot
+			undefined, // writeIndex
+			"claude-sonnet-4-5", // telemetryModel — this is the identity under test
+			"anthropic", // telemetryProvider
+		);
+		const groups: RunnerGroup[] = [
+			{ mode: "all", runnerIds: ["fixable-warning-runner"] },
+		];
+
+		await dispatchForFile(ctx, groups, registry);
+
+		await vi.waitFor(() => {
+			expect(appendToWorklog).toHaveBeenCalled();
+		});
+
+		const call = vi.mocked(appendToWorklog).mock.calls.find(
+			(args) => args[2] === false, // the fixable-warnings append, not the fixed-items one
+		);
+		expect(call).toBeDefined();
+		expect(call?.[3]).toEqual({
+			model: "claude-sonnet-4-5",
+			provider: "anthropic",
+		});
+	});
+});

--- a/tests/clients/dispatch/integration.test.ts
+++ b/tests/clients/dispatch/integration.test.ts
@@ -15,7 +15,13 @@ import {
 } from "../../../clients/dispatch/integration.js";
 import { normalizeMapKey } from "../../../clients/path-utils.js";
 
-// Mock dispatcher internals to avoid real runner execution
+// Mock dispatcher internals to avoid real runner execution. createDispatchContext
+// is wrapped (not replaced) — real implementation, but call-args are now
+// observable via vi.mocked(createDispatchContext).mock.calls. This is what
+// closes the options->createDispatchContext positional passthrough hop
+// (integration.ts:2202-2213): dispatchForFile being fully mocked meant a
+// severed telemetryModel/telemetryProvider passthrough there went unnoticed
+// by every existing case in this file.
 vi.mock("../../../clients/dispatch/dispatcher.js", async (importOriginal) => {
 	const mod =
 		await importOriginal<
@@ -24,6 +30,7 @@ vi.mock("../../../clients/dispatch/dispatcher.js", async (importOriginal) => {
 	return {
 		...mod,
 		dispatchForFile: vi.fn(),
+		createDispatchContext: vi.fn(mod.createDispatchContext),
 	};
 });
 
@@ -38,7 +45,10 @@ vi.mock("../../../clients/dispatch/fact-runner.js", async (importOriginal) => {
 	};
 });
 
-import { dispatchForFile } from "../../../clients/dispatch/dispatcher.js";
+import {
+	createDispatchContext,
+	dispatchForFile,
+} from "../../../clients/dispatch/dispatcher.js";
 import { runProviders } from "../../../clients/dispatch/fact-runner.js";
 
 const emptyDispatchResult = {
@@ -59,6 +69,7 @@ describe("Dispatch Integration", () => {
 		vi.mocked(dispatchForFile).mockReset();
 		vi.mocked(dispatchForFile).mockResolvedValue(emptyDispatchResult);
 		vi.mocked(runProviders).mockReset();
+		vi.mocked(createDispatchContext).mockClear();
 	});
 
 	describe("dispatchLintWithResult", () => {
@@ -207,6 +218,30 @@ describe("Dispatch Integration", () => {
 			normalizeMapKey(path.resolve("/repo/packages/pkg-a")),
 		);
 		expect(ctx?.projectRoot).toBe(normalizeMapKey(path.resolve("/repo")));
+		});
+
+		it("passes telemetryModel/telemetryProvider through to createDispatchContext (#1448)", async () => {
+			await dispatchLintWithResult(
+				"app.ts",
+				"/project",
+				{ getFlag: () => false },
+				undefined,
+				undefined,
+				{
+					telemetryModel: "claude-sonnet-4-5",
+					telemetryProvider: "anthropic",
+				},
+			);
+
+			const call = vi.mocked(createDispatchContext).mock.calls.at(-1);
+			// Positional args per createDispatchContext's signature: ...,
+			// projectRoot, writeIndex, telemetryModel, telemetryProvider.
+			expect(call?.[8]).toBe("claude-sonnet-4-5");
+			expect(call?.[9]).toBe("anthropic");
+
+			const ctx = vi.mocked(dispatchForFile).mock.calls.at(-1)?.[0];
+			expect(ctx?.telemetryModel).toBe("claude-sonnet-4-5");
+			expect(ctx?.telemetryProvider).toBe("anthropic");
 		});
 	});
 

--- a/tests/clients/file-utils.test.ts
+++ b/tests/clients/file-utils.test.ts
@@ -136,6 +136,106 @@ describe("getProjectDataDir", () => {
 		);
 	});
 
+	// #1448: model/provider attribution
+	it("carries model and provider when an identity is supplied", () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-worklog-model-"));
+		process.env.PILENS_DATA_DIR = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-global-data-"),
+		);
+
+		appendToWorklog(
+			cwd,
+			[
+				{
+					id: "demo-id",
+					tool: "eslint",
+					severity: "warning",
+					semantic: "warning",
+					filePath: path.join(cwd, "src", "index.ts"),
+					message: "demo",
+					rule: "demo-rule",
+					line: 1,
+					column: 1,
+					fixable: true,
+				},
+			],
+			false,
+			{ model: "claude-sonnet-4-5", provider: "anthropic" },
+		);
+
+		const entries = readWorklog(cwd);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].model).toBe("claude-sonnet-4-5");
+		expect(entries[0].provider).toBe("anthropic");
+	});
+
+	it("omits model and provider from the persisted line when identity is unknown", () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-worklog-blank-"));
+		process.env.PILENS_DATA_DIR = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-global-data-"),
+		);
+
+		appendToWorklog(
+			cwd,
+			[
+				{
+					id: "demo-id",
+					tool: "eslint",
+					severity: "warning",
+					semantic: "warning",
+					filePath: path.join(cwd, "src", "index.ts"),
+					message: "demo",
+					rule: "demo-rule",
+					line: 1,
+					column: 1,
+					fixable: true,
+				},
+			],
+			false,
+		);
+
+		const raw = fs.readFileSync(
+			path.join(getProjectDataDir(cwd), "worklog.jsonl"),
+			"utf8",
+		);
+		expect(raw).not.toContain('"model"');
+		expect(raw).not.toContain('"provider"');
+
+		const entries = readWorklog(cwd);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].model).toBeUndefined();
+		expect(entries[0].provider).toBeUndefined();
+	});
+
+	it("parses old-shape entries that predate the model/provider fields", () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-worklog-old-"));
+		process.env.PILENS_DATA_DIR = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-global-data-"),
+		);
+		fs.mkdirSync(getProjectDataDir(cwd), { recursive: true });
+		const oldEntry = {
+			timestamp: new Date().toISOString(),
+			filePath: path.join(cwd, "src", "legacy.ts"),
+			rule: "legacy-rule",
+			tool: "eslint",
+			message: "legacy entry, no model/provider fields at all",
+			line: 1,
+			fixable: false,
+			autoFixed: true,
+		};
+		fs.writeFileSync(
+			path.join(getProjectDataDir(cwd), "worklog.jsonl"),
+			`${JSON.stringify(oldEntry)}\n`,
+			"utf8",
+		);
+
+		const entries = readWorklog(cwd);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].rule).toBe("legacy-rule");
+		expect(entries[0].model).toBeUndefined();
+		expect(entries[0].provider).toBeUndefined();
+	});
+
 	it("stores rule cache under the configured data directory", () => {
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-rule-cache-"));
 		const prev = process.env.PILENS_DATA_DIR;

--- a/tests/clients/model-provider.test.ts
+++ b/tests/clients/model-provider.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { deriveProviderFromModelId } from "../../clients/model-provider.js";
+
+describe("deriveProviderFromModelId (#1448)", () => {
+	it("returns blank for undefined/empty input", () => {
+		expect(deriveProviderFromModelId(undefined)).toBe("");
+		expect(deriveProviderFromModelId("")).toBe("");
+		expect(deriveProviderFromModelId("   ")).toBe("");
+	});
+
+	it("splits a provider/model id on a single slash separator", () => {
+		expect(deriveProviderFromModelId("anthropic/claude-sonnet-4-5")).toBe("anthropic");
+	});
+
+	it("splits a provider:model id on a single colon separator", () => {
+		expect(deriveProviderFromModelId("openai:gpt-5")).toBe("openai");
+	});
+
+	it("lowercases the derived provider", () => {
+		expect(deriveProviderFromModelId("Anthropic/Claude-Sonnet-4-5")).toBe("anthropic");
+	});
+
+	it("matches known vendor prefixes when there is no separator", () => {
+		expect(deriveProviderFromModelId("claude-sonnet-4-5")).toBe("anthropic");
+		expect(deriveProviderFromModelId("gpt-5")).toBe("openai");
+		expect(deriveProviderFromModelId("o1-preview")).toBe("openai");
+		expect(deriveProviderFromModelId("o3-mini")).toBe("openai");
+		expect(deriveProviderFromModelId("gemini-2.5-pro")).toBe("google");
+		expect(deriveProviderFromModelId("llama-3.1-70b")).toBe("meta");
+		expect(deriveProviderFromModelId("mistral-large")).toBe("mistral");
+		expect(deriveProviderFromModelId("mixtral-8x7b")).toBe("mistral");
+		expect(deriveProviderFromModelId("command-r-plus")).toBe("cohere");
+	});
+
+	it("returns blank for an unrecognized prefix rather than guessing", () => {
+		expect(deriveProviderFromModelId("some-custom-finetune")).toBe("");
+	});
+
+	it("returns blank when the id has more than one separator (ambiguous)", () => {
+		expect(deriveProviderFromModelId("anthropic/claude/sonnet")).toBe("");
+		expect(deriveProviderFromModelId("a/b:c")).toBe("");
+	});
+
+	it("returns blank when a separator has nothing on one side", () => {
+		expect(deriveProviderFromModelId("/claude-sonnet-4-5")).toBe("");
+		expect(deriveProviderFromModelId("anthropic/")).toBe("");
+	});
+});

--- a/tests/clients/runtime-coordinator.test.ts
+++ b/tests/clients/runtime-coordinator.test.ts
@@ -90,6 +90,56 @@ describe("RuntimeCoordinator", () => {
 		expect(runtime.shouldWarmLspOnRead(filePath)).toBe(true);
 	});
 
+	describe("telemetry model/provider identity (#1448)", () => {
+		it("exposes the raw model id separately from the combined display string", () => {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ model: "claude-sonnet-4-5", provider: "anthropic" });
+
+			expect(runtime.telemetryModelId).toBe("claude-sonnet-4-5");
+			expect(runtime.telemetryProviderId).toBe("anthropic");
+			expect(runtime.telemetryModel).toBe("anthropic/claude-sonnet-4-5");
+		});
+
+		it("derives a blank provider before any identity is set", () => {
+			const runtime = new RuntimeCoordinator();
+
+			expect(runtime.telemetryModelId).toBe("");
+			expect(runtime.telemetryProviderId).toBe("");
+		});
+
+		it("derives provider from a known model-id prefix when the host omits provider", () => {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ model: "claude-sonnet-4-5" });
+
+			expect(runtime.telemetryProviderId).toBe("anthropic");
+		});
+
+		it("leaves provider blank when the model id is ambiguous", () => {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ model: "some-custom-finetune" });
+
+			expect(runtime.telemetryProviderId).toBe("");
+		});
+
+		it("never lets a later ambiguous model overwrite an already-known provider", () => {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ model: "gpt-5", provider: "openai" });
+			runtime.setTelemetryIdentity({ model: "some-custom-finetune" });
+
+			expect(runtime.telemetryProviderId).toBe("openai");
+		});
+
+		it("resetForSession clears the raw model/provider identity", () => {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ model: "claude-sonnet-4-5", provider: "anthropic" });
+
+			runtime.resetForSession();
+
+			expect(runtime.telemetryModelId).toBe("");
+			expect(runtime.telemetryProviderId).toBe("");
+		});
+	});
+
 	describe("getFilesChangedSince (#451)", () => {
 		it("returns only files bumped after the given projectSeq", () => {
 			const runtime = new RuntimeCoordinator();

--- a/tests/clients/runtime-coordinator.test.ts
+++ b/tests/clients/runtime-coordinator.test.ts
@@ -129,6 +129,17 @@ describe("RuntimeCoordinator", () => {
 			expect(runtime.telemetryProviderId).toBe("openai");
 		});
 
+		it("re-derives a DERIVED provider across a mid-session model switch with no explicit provider", () => {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ model: "gpt-5-mini" });
+			expect(runtime.telemetryProviderId).toBe("openai");
+
+			// Switch models without an explicit provider — the stale "openai"
+			// derivation must not survive; it has to re-derive for the new model.
+			runtime.setTelemetryIdentity({ model: "claude-sonnet-4-5" });
+			expect(runtime.telemetryProviderId).toBe("anthropic");
+		});
+
 		it("resetForSession clears the raw model/provider identity", () => {
 			const runtime = new RuntimeCoordinator();
 			runtime.setTelemetryIdentity({ model: "claude-sonnet-4-5", provider: "anthropic" });

--- a/tests/scripts/analyze-pi-lens-logs.test.ts
+++ b/tests/scripts/analyze-pi-lens-logs.test.ts
@@ -202,6 +202,72 @@ describe("analyze-pi-lens-logs.mjs", () => {
 			.join("\n");
 		fs.writeFileSync(path.join(root, "sessionstart.log"), `${sessionstart}\n`);
 
+		// projects/<slug>/worklog.jsonl (#1448) — two projects, mixing attributed
+		// and unattributed (pre-#1448 / unknown-identity) entries so the rollup
+		// exercises rule × model grouping AND blank-model bucketing together.
+		const worklogA = [
+			{
+				timestamp: NOW,
+				filePath: "/proj/a/x.ts",
+				rule: "no-unused-vars",
+				tool: "eslint",
+				message: "x is unused",
+				line: 1,
+				fixable: true,
+				autoFixed: true,
+				model: "claude-sonnet-4-5",
+				provider: "anthropic",
+			},
+			{
+				timestamp: NOW,
+				filePath: "/proj/a/y.ts",
+				rule: "no-unused-vars",
+				tool: "eslint",
+				message: "y is unused",
+				line: 2,
+				fixable: true,
+				autoFixed: false,
+				model: "claude-sonnet-4-5",
+				provider: "anthropic",
+			},
+			// Pre-#1448 shape: no model/provider fields at all.
+			{
+				timestamp: NOW,
+				filePath: "/proj/a/z.ts",
+				rule: "no-unused-vars",
+				tool: "eslint",
+				message: "z is unused",
+				line: 3,
+				fixable: true,
+				autoFixed: true,
+			},
+		]
+			.map((e) => JSON.stringify(e))
+			.join("\n");
+		const projA = path.join(root, "projects", "proj-a");
+		fs.mkdirSync(projA, { recursive: true });
+		fs.writeFileSync(path.join(projA, "worklog.jsonl"), `${worklogA}\n`);
+
+		const worklogB = [
+			{
+				timestamp: NOW,
+				filePath: "/proj/b/w.ts",
+				rule: "no-explicit-any",
+				tool: "eslint",
+				message: "unexpected any",
+				line: 4,
+				fixable: false,
+				autoFixed: false,
+				model: "gpt-5",
+				provider: "openai",
+			},
+		]
+			.map((e) => JSON.stringify(e))
+			.join("\n");
+		const projB = path.join(root, "projects", "proj-b");
+		fs.mkdirSync(projB, { recursive: true });
+		fs.writeFileSync(path.join(projB, "worklog.jsonl"), `${worklogB}\n`);
+
 		report = runReport(root);
 	});
 
@@ -286,6 +352,51 @@ describe("analyze-pi-lens-logs.mjs", () => {
 			(s: any) => s.id === "lsp-workspace-file-timeouts",
 		);
 		expect(timeouts?.count).toBe(1);
+	});
+
+	describe("worklog per-model rollup (#1448)", () => {
+		it("discovers worklog.jsonl under each project's data dir", () => {
+			expect(report.filesScanned.worklog).toBe(2);
+			expect(report.rowsSeen.worklog).toBe(4);
+		});
+
+		it("groups rule x model counts, bucketing unattributed entries as blank", () => {
+			const rows: { rule: string; model: string; total: number; autoFixed: number }[] =
+				report.worklog.byRuleModel;
+			const attributed = rows.find(
+				(r) => r.rule === "no-unused-vars" && r.model === "claude-sonnet-4-5",
+			);
+			expect(attributed).toBeDefined();
+			expect(attributed?.total).toBe(2);
+			expect(attributed?.autoFixed).toBe(1);
+
+			const blank = rows.find((r) => r.rule === "no-unused-vars" && r.model === "");
+			expect(blank).toBeDefined();
+			expect(blank?.total).toBe(1);
+			expect(blank?.autoFixed).toBe(1);
+
+			const other = rows.find(
+				(r) => r.rule === "no-explicit-any" && r.model === "gpt-5",
+			);
+			expect(other?.total).toBe(1);
+			expect(other?.autoFixed).toBe(0);
+		});
+
+		it("rolls up totals by model and by provider, with an (unknown) bucket", () => {
+			const byModel = Object.fromEntries(
+				report.worklog.byModel.map((x: { key: string; count: number }) => [x.key, x.count]),
+			);
+			expect(byModel["claude-sonnet-4-5"]).toBe(2);
+			expect(byModel["gpt-5"]).toBe(1);
+			expect(byModel["(unknown)"]).toBe(1);
+
+			const byProvider = Object.fromEntries(
+				report.worklog.byProvider.map((x: { key: string; count: number }) => [x.key, x.count]),
+			);
+			expect(byProvider.anthropic).toBe(2);
+			expect(byProvider.openai).toBe(1);
+			expect(byProvider["(unknown)"]).toBe(1);
+		});
 	});
 
 	it("surfaces ast-grep tool errors as a smell", () => {

--- a/tools/lens-diagnostic-mark.ts
+++ b/tools/lens-diagnostic-mark.ts
@@ -198,7 +198,12 @@ function verifyLine(
 	}
 }
 
-export function createLensDiagnosticMarkTool(getCwd: () => string) {
+export function createLensDiagnosticMarkTool(
+	getCwd: () => string,
+	/** Runtime telemetry identity, when known (#1448 class sweep) — attributed
+	 * onto the disposition log alongside the mark. */
+	getIdentity?: () => { model?: string; provider?: string },
+) {
 	return {
 		name: "lens_diagnostic_mark" as const,
 		label: "Mark Diagnostic",
@@ -387,6 +392,7 @@ export function createLensDiagnosticMarkTool(getCwd: () => string) {
 				},
 				disposition,
 				reason,
+				getIdentity?.(),
 			);
 
 			const verb =


### PR DESCRIPTION
## Summary

Worklog and disposition entries now record which model and provider produced the code they describe. The runtime tracks the raw model id and provider separately from the display string. The dispatch path threads both into every worklog append. The disposition path carries them through `markDisposition`. The analyzer gains a per-model rollup: rule by model counts, auto-fixed versus agent-required rates, and by-provider totals.

Provider derivation is conservative. The host's explicit fields win and are never downgraded. A derived provider re-derives on every model switch. Ambiguous ids stay blank. The MCP facade writes blank attribution by design — it has no runtime — and says so in a comment.

## Verification

Three review rounds. Round one found a real bug: a derived provider froze across mid-session model switches, poisoning the per-model archaeology this feature exists for. Fixed with an explicit-versus-derived flag; the reviewer re-ran its probe and two extra lifecycle scenarios against the rebuilt module. Round two found the middle-of-pipe wiring had no regression test — the reviewer severed the identity and nothing went red. Two tests now close both hops (dispatcher identity build, and the untyped positional passthrough in `dispatchLintWithResult`), each proven red under the reviewer's exact severance and restored. 99 targeted tests, build, lint, and changelog pass.

Closes #1448

🤖 Generated with [Claude Code](https://claude.com/claude-code)
