### PR TITLE
fix: distinguish role-excluded files from missing graph nodes (#1445)

### DIFF
--- a/.changelog/fix-1445-missing-node-cause.md
+++ b/.changelog/fix-1445-missing-node-cause.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Cascade no longer blames the review graph for test-file edits (closes #1445)** — A `missing_node` cascade result had two causes that read the same but meant opposite things: a real gap in the graph, and a test file excluded from the graph by design (#260). Test-file edits now get a distinct `excluded_by_role` reason that stays in telemetry but never reaches the agent as a "review graph was unavailable" advisory. A genuinely missing source file still reports `missing_node` and still triggers the advisory.

--- a/clients/review-graph/query.ts
+++ b/clients/review-graph/query.ts
@@ -1,3 +1,4 @@
+import { detectFileRole } from "../file-role.js";
 import { normalizeMapKey } from "../path-utils.js";
 import type { ModuleGraph } from "./workspace-modules.js";
 import {
@@ -128,6 +129,30 @@ export function computeImpactCascade(
 	const normalizedFile = normalizeMapKey(changedFile);
 	const fileNodeId = graph.fileNodes.get(normalizedFile);
 	if (!fileNodeId) {
+		// #1445: a missing node has two causes that look identical here but mean
+		// opposite things — "the graph SHOULD know this file but doesn't" (a real
+		// gap) versus "this file's role is excluded from the graph by design"
+		// (test files, #260 — every graph-admission chokepoint in builder.ts
+		// guards on this exact condition, `detectFileRole(file) === "test"`;
+		// reused verbatim here rather than a second role list). A test edit not
+		// cascading is expected behavior, not a graph failure, so it must not
+		// produce the "review graph was unavailable" advisory that misled agents
+		// into distrusting a healthy graph 19% of the time in dogfooding.
+		if (detectFileRole(normalizedFile) === "test") {
+			return {
+				filePath: normalizedFile,
+				changedSymbols: [],
+				directImporters: [],
+				directCallers: [],
+				neighborFiles: [],
+				riskFlags: [],
+				indeterminate: {
+					reason: "excluded_by_role",
+					detail:
+						"test-role file — excluded from the review graph by design (#260)",
+				},
+			};
+		}
 		// #1023: the changed file has no node in the graph — we CANNOT enumerate
 		// its dependents, so this empty result is "couldn't compute", NOT "nothing
 		// depends on it". Mark it indeterminate so callers surface an honest

--- a/clients/review-graph/types.ts
+++ b/clients/review-graph/types.ts
@@ -142,7 +142,8 @@ export interface ReviewGraphPersistCoverage {
  */
 export type CascadeIndeterminateReason =
 	| "graph_degraded" // review graph skipped (too_many_files / unsafe_root)
-	| "missing_node" // changed file has no node in the (otherwise-built) graph
+	| "missing_node" // changed file has no node in the (otherwise-built) graph, and the graph SHOULD know it — a real gap
+	| "excluded_by_role" // #1445: changed file has no node because its role (test, #260) is excluded from the graph BY DESIGN — not a gap, never agent-facing
 	| "error" // the deferred compute threw before producing a result
 	| "lsp_binding_rejected"; // #1104: every degraded-fallback display candidate was binding-rejected (stale/pre-fix-edit snapshot) and withheld
 

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -523,8 +523,17 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 			return `${frame.lead(fileCount, reasons)}\n${lines.join("\n")}`;
 		};
 
+		// #1445: `excluded_by_role` (test files excluded from the graph BY DESIGN,
+		// #260) is never agent-facing — it is not a graph failure, and #1080
+		// already excludes test-role files from every neighbor surface, so "a
+		// clean result does not cover them" would itself be a false claim. It
+		// stays visible in the `cascade_indeterminate` log below (metadata-only,
+		// info-level) so the log can tell an intentional exclusion from a real
+		// graph gap, but it never reaches `buildAdvisory`/the agent.
 		const graphRuns = indeterminateRuns.filter(
-			(r) => r.indeterminate?.reason !== "lsp_binding_rejected",
+			(r) =>
+				r.indeterminate?.reason !== "lsp_binding_rejected" &&
+				r.indeterminate?.reason !== "excluded_by_role",
 		);
 		const bindingRuns = indeterminateRuns.filter(
 			(r) => r.indeterminate?.reason === "lsp_binding_rejected",

--- a/tests/clients/cascade-turn-merge.test.ts
+++ b/tests/clients/cascade-turn-merge.test.ts
@@ -743,6 +743,83 @@ describe("cascade turn-end merge", () => {
 		}
 	});
 
+	// #1445: a `missing_node` compute has two causes that read identically to
+	// the advisory text but mean opposite things — "the graph genuinely
+	// doesn't know this file" versus "this file's role (test, #260) is
+	// excluded from the graph BY DESIGN". The latter is expected behavior, not
+	// a graph failure, and must not produce the "review graph was unavailable"
+	// advisory that mis-attributes the cause to agents (19% of dogfooded
+	// cascades in the reporting window were exactly this false alarm on
+	// test-file edits against a healthy graph). RED on pre-fix code: before
+	// #1445 every `missing_node` — role-excluded or not — fed the same
+	// graph-unavailability frame.
+	it("does NOT surface a graph-unavailability advisory for a test-file edit excluded by role", async () => {
+		const env = setupTestEnvironment("cascade-excluded-by-role-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const cacheManager = new CacheManager(false);
+			const primary = path.join(env.tmpDir, "widget.test.ts");
+			fs.writeFileSync(primary, "import './widget';\n");
+			cacheManager.addModifiedRange(
+				primary,
+				{ start: 1, end: 1 },
+				false,
+				env.tmpDir,
+			);
+
+			runtime.appendCascadeRun({
+				filePath: primary,
+				result: undefined,
+				neighborCount: 0,
+				diagnosticCount: 0,
+				skipReason: "indeterminate",
+				indeterminate: {
+					reason: "excluded_by_role",
+					detail:
+						"test-role file — excluded from the review graph by design (#260)",
+				},
+			});
+
+			logCascadeMock.mockClear();
+			await handleTurnEnd({
+				ctxCwd: env.tmpDir,
+				getFlag: () => false,
+				dbg: () => {},
+				runtime,
+				cacheManager,
+				knipClient: {
+					ensureAvailable: async () => false,
+					analyze: async () => EMPTY_KNIP_RESULT,
+				},
+				depChecker: { ensureAvailable: async () => false },
+				testRunnerClient: { getTestRunTarget: () => null },
+				resetLSPService: () => {},
+				resetFormatService: () => {},
+			} as any);
+
+			const findings = consumeTurnEndFindings(cacheManager, env.tmpDir);
+			const content = findings?.messages[0]?.content ?? "";
+			// No wrong-cause advisory reaches the agent at all for this run.
+			expect(content).not.toContain(
+				"Cascade could not compute downstream impact",
+			);
+			expect(content).not.toContain("the review graph was unavailable");
+			expect(content).not.toContain("widget.test.ts");
+
+			// The distinction is STILL visible in telemetry (info-level, not
+			// agent-facing) — cascade_indeterminate logs the real reason so the log
+			// can tell an intentional exclusion from a genuine graph gap.
+			const indeterminateLog = logCascadeMock.mock.calls
+				.map((args) => args[0])
+				.find((entry) => entry?.phase === "cascade_indeterminate");
+			expect(indeterminateLog?.metadata?.reasons).toContain(
+				"excluded_by_role",
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	// #1023 over-correction guard: a HEALTHY run that genuinely found no
 	// dependents (skipReason "no_neighbors", no indeterminate marker) must NOT
 	// emit the advisory — a real clean leaf edit stays silent (no crying wolf).

--- a/tests/clients/review-graph/missing-node-cause.test.ts
+++ b/tests/clients/review-graph/missing-node-cause.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #1445: `computeImpactCascade` returns `indeterminate: { reason:
+ * "missing_node" }` whenever the changed file has no node in the graph — but
+ * that has two causes that read identically to the caller and mean opposite
+ * things:
+ *
+ *  - genuinely missing: the graph SHOULD know this file but doesn't (a real
+ *    gap the "review graph was unavailable" advisory should keep flagging).
+ *  - excluded by role: the file's role (test, #260) is refused at every
+ *    graph-admission chokepoint by design — `builder.ts`'s own predicate,
+ *    `detectFileRole(file) === "test"` (see `tests-free-graph.test.ts`'s
+ *    #1080 baseline). A test edit not cascading is expected behavior, not a
+ *    graph failure.
+ *
+ * Before the fix, both causes collapsed onto the same `missing_node` reason,
+ * so a healthy graph (2615 nodes in the reporting dogfood run) blamed itself
+ * for every test-file edit — 19% of cascades in the observed window.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { detectFileRole } from "../../../clients/file-role.js";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import {
+	buildOrUpdateGraph,
+	clearReviewGraphWorkspaceCache,
+} from "../../../clients/review-graph/builder.js";
+import { computeImpactCascade } from "../../../clients/review-graph/service.js";
+import { normalizeMapKey } from "../../../clients/path-utils.js";
+import { createTempFile, setupTestEnvironment } from "../test-utils.js";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length) cleanups.pop()?.();
+	clearReviewGraphWorkspaceCache();
+});
+
+function makeEnv(prefix = "pi-lens-missing-node-cause-") {
+	const env = setupTestEnvironment(prefix);
+	cleanups.push(env.cleanup);
+	return env;
+}
+
+describe("missing_node cause disambiguation (#1445)", () => {
+	it("a test-file edit reports excluded_by_role, not missing_node (RED on pre-fix code)", async () => {
+		const env = makeEnv();
+		createTempFile(
+			env.tmpDir,
+			"widget.ts",
+			["export function render() {", "  return 1;", "}"].join("\n"),
+		);
+		const testFile = createTempFile(
+			env.tmpDir,
+			"widget.test.ts",
+			["import { render } from './widget';", "render();"].join("\n"),
+		);
+
+		const facts = new FactStore();
+		const graph = await buildOrUpdateGraph(env.tmpDir, [], facts);
+
+		// Baseline (#1080): the healthy graph really did build and really does
+		// NOT contain the test file — this is not a degraded/cold graph.
+		expect(graph.nodes.size).toBeGreaterThan(0);
+		expect(graph.fileNodes.has(normalizeMapKey(testFile))).toBe(false);
+
+		const impact = computeImpactCascade(graph, testFile, env.tmpDir);
+		expect(impact.indeterminate?.reason).toBe("excluded_by_role");
+		expect(impact.indeterminate?.reason).not.toBe("missing_node");
+	});
+
+	it("a genuinely-missing source file still reports missing_node (no regression)", async () => {
+		const env = makeEnv();
+		createTempFile(
+			env.tmpDir,
+			"known.ts",
+			["export const known = 1;", ""].join("\n"),
+		);
+
+		const facts = new FactStore();
+		const graph = await buildOrUpdateGraph(env.tmpDir, [], facts);
+		expect(graph.nodes.size).toBeGreaterThan(0);
+
+		// A source-role file that was never part of the build (outside cwd, so
+		// it never enters the graph) — an honest gap, not a role exclusion.
+		const unknownFile = env.tmpDir.replace(/\\/g, "/") + "/unrelated-src.ts";
+		expect(detectFileRole(unknownFile)).not.toBe("test");
+		expect(graph.fileNodes.has(normalizeMapKey(unknownFile))).toBe(false);
+
+		const impact = computeImpactCascade(graph, unknownFile, env.tmpDir);
+		expect(impact.indeterminate?.reason).toBe("missing_node");
+	});
+
+	// #894 pattern: the exclusion decision must derive from the SAME predicate
+	// builder.ts uses at its own graph-admission chokepoints
+	// (`detectFileRole(file) === "test"`), never a second hand-rolled role
+	// list. Sweep a representative set of role-classified filenames and assert
+	// the two seams agree — a role builder.ts would refuse always reports
+	// excluded_by_role here, and a role builder.ts would admit (but that never
+	// actually entered THIS graph) always reports missing_node.
+	it.each([
+		["foo.test.ts", "test"],
+		["foo.spec.ts", "test"],
+		["tests/foo.ts", "test"],
+		["spec_foo.py", "test"],
+		["plain-source.ts", "source"],
+		["mod.rs", "init"],
+	] as const)(
+		"agrees with detectFileRole(%s) === %s on the excluded_by_role/missing_node split",
+		async (relPath, expectedRole) => {
+			const env = makeEnv(`pi-lens-missing-node-cause-sweep-`);
+			createTempFile(env.tmpDir, "anchor.ts", "export const anchor = 1;\n");
+			const facts = new FactStore();
+			const graph = await buildOrUpdateGraph(env.tmpDir, [], facts);
+
+			const absPath = `${env.tmpDir.replace(/\\/g, "/")}/${relPath}`;
+			expect(detectFileRole(absPath)).toBe(expectedRole);
+			expect(graph.fileNodes.has(normalizeMapKey(absPath))).toBe(false);
+
+			const impact = computeImpactCascade(graph, absPath, env.tmpDir);
+			const expectedReason =
+				expectedRole === "test" ? "excluded_by_role" : "missing_node";
+			expect(impact.indeterminate?.reason).toBe(expectedReason);
+		},
+	);
+});


### PR DESCRIPTION
## Summary

Test-file edits produced a wrong-cause "review graph was unavailable" advisory on 19% of cascades. The graph excludes test files by design, but the cascade reported their absence as a missing node. The fix classifies the cause at the source: a file the builder excludes by role gets a distinct `excluded_by_role` reason. Those runs leave the agent-facing advisory entirely and stay visible in the `cascade_indeterminate` telemetry. Genuinely missing source files keep the advisory. The role check reuses the builder's own admission predicate — no second role list.

## Verification

Adversarial review verdict: MERGE. The reviewer built the builder-versus-fix parity table across all six admission chokepoints and found exact predicate agreement on the reachable surface. Both mutations ran red (five tests on the classification revert, one on the bucketing revert) and restored green. Fixture diversity covers four distinct role-detection signal paths. One pre-existing nuance recorded for the class: size-limit exclusions still surface as missing-node — outside this issue's scope, noted for #1461's staleness-adjacent cause work. 20 targeted tests, build, lint, and changelog pass.

Closes #1445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
