### PR TITLE
fix(lsp): derive default aux grace from auxiliary server wait budget

### DIFF
--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -2711,14 +2711,27 @@ export class LSPService {
 						const auxWaits = perServerWaits
 							.map((p, i) =>
 								spawned[i].info.role === "auxiliary"
-									? { promise: p, serverId: spawned[i].info.id }
+									? {
+											promise: p,
+											serverId: spawned[i].info.id,
+											timeout: timeoutFor(spawned[i].client.serverId),
+										}
 									: null,
 							)
 							.filter(
-								(x): x is { promise: Promise<void | undefined>; serverId: string } =>
-									x !== null,
+								(
+									x,
+								): x is {
+									promise: Promise<void | undefined>;
+									serverId: string;
+									timeout: number;
+								} => x !== null,
 							);
-						const auxGraceMs = readEnvAuxGraceMs() ?? 500;
+						const derivedAuxGraceMs = Math.max(
+							500,
+							...auxWaits.map((a) => a.timeout),
+						);
+						const auxGraceMs = readEnvAuxGraceMs() ?? derivedAuxGraceMs;
 						// After all primaries settle, give auxiliaries at most auxGraceMs.
 						// Late aux results are dropped from the wait (advisory only — they
 						// land in the client cache and surface on the next edit); aux servers
@@ -3457,7 +3470,20 @@ export class LSPService {
 				),
 				graceMs,
 				descriptors: diagDescriptors,
-				auxGraceMs: readEnvAuxGraceMs(),
+				auxGraceMs:
+					readEnvAuxGraceMs() ??
+					Math.max(
+						500,
+						...spawned
+							.filter((entry) => entry.info.role === "auxiliary")
+							.map(
+								(entry) =>
+									getStrategy(
+										entry.info.id,
+										entry.client.getLaunchVariant?.(),
+									).aggregateWaitMs,
+							),
+					),
 			},
 		);
 

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -290,6 +290,73 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 		);
 		expect(messages).toContain("primary error");
 	});
+
+	it("derives aux grace from auxiliary server timeout when env override is absent (#1458)", async () => {
+		// When PI_LENS_AUX_GRACE_MS is NOT set, aux grace derives from the auxiliary server's aggregateWaitMs (3500ms for opengrep)
+		// rather than cutting off at a flat 500ms.
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		// Primary settles at 100ms; opengrep aux takes 1200ms (which is >500ms flat grace, but <= 3500ms aggregateWaitMs).
+		const primaryClient = makeClient(100, [makeDiagnostic("primary error")]);
+		const auxClient = makeClient(1200, [makeDiagnostic("opengrep security alert")]);
+
+		const primaryServer = makePrimaryServer("ts-primary");
+		const auxServer = makeAuxServer("opengrep");
+
+		getServersForFileWithConfig.mockReturnValue([primaryServer, auxServer]);
+		createLSPClient
+			.mockResolvedValueOnce(primaryClient)
+			.mockResolvedValueOnce(auxClient);
+
+		await service.getClientsForFile(FILE);
+
+		const touchPromise = service.touchFile(FILE, "content-issue-1458", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep"],
+			collectDiagnostics: true,
+			diagnostics: "document",
+		});
+
+		// Advance past primary (100ms) + 1200ms aux settlement.
+		await vi.advanceTimersByTimeAsync(1300);
+		await vi.advanceTimersByTimeAsync(10);
+
+		const result = await touchPromise;
+		const messages = (result?.diags ?? []).map(
+			(d: { message: string }) => d.message,
+		);
+		expect(messages).toContain("primary error");
+		expect(messages).toContain("opengrep security alert");
+	});
+
+	it("getDiagnostics derives aux grace from auxiliary server strategy aggregateWaitMs (#1458)", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		const primaryClient = makeClient(100, [makeDiagnostic("primary error")]);
+		const auxClient = makeClient(1200, [makeDiagnostic("opengrep finding")]);
+
+		const primaryServer = makePrimaryServer("ts-primary");
+		const auxServer = makeAuxServer("opengrep");
+
+		getServersForFileWithConfig.mockReturnValue([primaryServer, auxServer]);
+		createLSPClient
+			.mockResolvedValueOnce(primaryClient)
+			.mockResolvedValueOnce(auxClient);
+
+		await service.getClientsForFile(FILE);
+
+		const diagPromise = service.getDiagnostics(FILE, "document");
+
+		await vi.advanceTimersByTimeAsync(1300);
+		await vi.advanceTimersByTimeAsync(10);
+
+		const result = await diagPromise;
+		const messages = (result ?? []).map((d: { message: string }) => d.message);
+		expect(messages).toContain("primary error");
+		expect(messages).toContain("opengrep finding");
+	});
 });
 
 describe("R8 — aux grace: raceToCompletion per-role unit tests", () => {


### PR DESCRIPTION
## Problem
In `clients/lsp/index.ts`, when auxiliary servers run on the `with-auxiliary` path, `auxGraceMs` was hardcoded to `readEnvAuxGraceMs() ?? 500`. Once language-primary servers settled (e.g. within 100ms), auxiliary tools with higher aggregate wait budgets (e.g., `opengrep` with 3500ms or `ast-grep` with 1800ms) were cut off after 500ms of grace. This resulted in premature timeouts (`auxCutOffServerIds`) and dropped findings on per-edit touches despite valid configured budgets (#1458).

## Solution
- In `LSPService.touchFile`, derive default `auxGraceMs` as `Math.max(500, ...auxWaits.map(a => a.timeout))` when `PI_LENS_AUX_GRACE_MS` environment variable is not explicitly provided.
- In `LSPService.getDiagnostics`, derive default `auxGraceMs` as `Math.max(500, ...auxiliaryStrategyTimeouts)` when `PI_LENS_AUX_GRACE_MS` is absent.
- Add regression test in `tests/clients/lsp/service-aux-grace.test.ts` verifying that without environment variable override, aux grace derives from the auxiliary server's configured timeout (e.g. 3500ms for opengrep) and collects findings rather than cutting off early.

Fixes #1458
