### PR TITLE
fix(dispatch): stop latching a slow tool probe as a missing install (#1467)

### DIFF
--- a/.changelog/fix-1467-availability-latching.md
+++ b/.changelog/fix-1467-availability-latching.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **A slow tool check no longer disables an installed tool for the whole session (closes #1467)** — When the check for knip, madge, govulncheck, or vulture timed out, pi-lens remembered the tool as unavailable until you restarted, and told you to install a tool that was already installed. Knip produced no findings for weeks because of this. A timed-out check is now retried after a short wait, the message says the check timed out instead of naming the wrong cause, a failed run keeps the last good cached findings instead of overwriting them, and each decision is recorded in `latency.log` as an `availability_decision` entry with its cause and timing.

--- a/clients/dead-code-client.ts
+++ b/clients/dead-code-client.ts
@@ -227,6 +227,13 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 		let sawTransient = false;
 		let transientCause: ReturnType<typeof classifyProbeFailure>["cause"] =
 			"probe-timeout";
+		// Accumulated across ALL candidates, because the failure verdicts below
+		// are about the whole sweep rather than any one probe. Reporting zero
+		// here would erase the evidence that cracked #1467: four 5s probes and
+		// a stalled host look identical to an absent tool without these two
+		// numbers.
+		const sweepStartedAt = Date.now();
+		let sweepHostStallMs = 0;
 		for (const c of candidates) {
 			const sampler = startHostStallSampler();
 			const startedAt = Date.now();
@@ -238,6 +245,7 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 				});
 			} finally {
 				hostStallMs = sampler.stop();
+				sweepHostStallMs += hostStallMs;
 			}
 			if (!probe.error && probe.status === 0) {
 				this.resolved = c;
@@ -272,7 +280,8 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 				verdict: "unavailable",
 				outcome: "transient",
 				cause: transientCause,
-				elapsedMs: 0,
+				elapsedMs: Date.now() - sweepStartedAt,
+				hostStallMs: sweepHostStallMs,
 				latched: false,
 				retryAfterMs,
 				budgetMs: 5000,
@@ -286,7 +295,8 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 			verdict: "unavailable",
 			outcome: "missing",
 			cause: "not-found",
-			elapsedMs: 0,
+			elapsedMs: Date.now() - sweepStartedAt,
+			hostStallMs: sweepHostStallMs,
 			latched: true,
 			budgetMs: 5000,
 		});

--- a/clients/dead-code-client.ts
+++ b/clients/dead-code-client.ts
@@ -16,6 +16,12 @@ import { createSubsystemLogger } from "./extension-log.js";
 import * as path from "node:path";
 import { findNearestMarkerRoot } from "./path-utils.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
+import {
+	classifyProbeFailure,
+	createAvailabilityLatch,
+	logAvailabilityDecision,
+	startHostStallSampler,
+} from "./dispatch/runners/utils/availability-policy.js";
 
 // --- Types ---
 
@@ -137,7 +143,12 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 	readonly id = "python";
 	readonly language = "Python";
 
-	private available: boolean | null = null;
+	/**
+	 * Transient-aware memo (#1467): only a durable "vulture is not installed"
+	 * verdict is remembered for the session. A probe that timed out expires and
+	 * is re-probed, so vulture cannot be disabled for the process by one stall.
+	 */
+	private readonly availabilityLatch = createAvailabilityLatch();
 	private resolved: { cmd: string; prefix: string[] } | null = null;
 	private ensureInFlight: Promise<boolean> | null = null;
 	private inFlight = new Map<string, Promise<DeadCodeResult>>();
@@ -187,7 +198,8 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 	}
 
 	async ensureAvailable(): Promise<boolean> {
-		if (this.available !== null) return this.available;
+		const memo = this.availabilityLatch.read();
+		if (memo !== null) return memo;
 		if (this.ensureInFlight) return this.ensureInFlight;
 		this.ensureInFlight = this.doEnsureAvailable();
 		try {
@@ -210,19 +222,74 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 			{ cmd: "python", prefix: ["-m", "vulture"] },
 			{ cmd: "python3", prefix: ["-m", "vulture"] },
 		];
+		// A timeout on ANY candidate means the machine, not the tool, answered —
+		// the run gets a bounded retry instead of a permanent skip (#1467).
+		let sawTransient = false;
+		let transientCause: ReturnType<typeof classifyProbeFailure>["cause"] =
+			"probe-timeout";
 		for (const c of candidates) {
-			const probe = await safeSpawnAsync(c.cmd, [...c.prefix, "--version"], {
-				timeout: 5000,
-			});
+			const sampler = startHostStallSampler();
+			const startedAt = Date.now();
+			let probe: Awaited<ReturnType<typeof safeSpawnAsync>>;
+			let hostStallMs: number;
+			try {
+				probe = await safeSpawnAsync(c.cmd, [...c.prefix, "--version"], {
+					timeout: 5000,
+				});
+			} finally {
+				hostStallMs = sampler.stop();
+			}
 			if (!probe.error && probe.status === 0) {
 				this.resolved = c;
-				this.available = true;
+				this.availabilityLatch.noteAvailable();
 				this.log(`vulture found: ${[c.cmd, ...c.prefix].join(" ")}`);
+				logAvailabilityDecision({
+					tool: "vulture",
+					verdict: "available",
+					outcome: "success",
+					cause: "ok",
+					elapsedMs: Date.now() - startedAt,
+					latched: true,
+					hostStallMs,
+					budgetMs: 5000,
+				});
 				return true;
 			}
+			const classified = classifyProbeFailure(probe, { hostStallMs });
+			if (classified.outcome === "transient") {
+				sawTransient = true;
+				transientCause = classified.cause;
+			}
 		}
-		this.available = false;
+		if (sawTransient) {
+			const retryAfterMs = this.availabilityLatch.noteUnavailable(
+				"transient",
+				transientCause,
+			);
+			this.log("vulture probe timed out; will retry (not treated as missing)");
+			logAvailabilityDecision({
+				tool: "vulture",
+				verdict: "unavailable",
+				outcome: "transient",
+				cause: transientCause,
+				elapsedMs: 0,
+				latched: false,
+				retryAfterMs,
+				budgetMs: 5000,
+			});
+			return false;
+		}
+		this.availabilityLatch.noteUnavailable("missing", "not-found");
 		this.log("vulture not installed; skipping (no auto-install)");
+		logAvailabilityDecision({
+			tool: "vulture",
+			verdict: "unavailable",
+			outcome: "missing",
+			cause: "not-found",
+			elapsedMs: 0,
+			latched: true,
+			budgetMs: 5000,
+		});
 		return false;
 	}
 

--- a/clients/dependency-checker.ts
+++ b/clients/dependency-checker.ts
@@ -21,6 +21,7 @@ import {
 	getManagedToolEnvironment,
 	resolveAvailableOrInstall,
 } from "./dispatch/runners/utils/runner-helpers.js";
+import { createAvailabilityLatch } from "./dispatch/runners/utils/availability-policy.js";
 
 // --- Types ---
 
@@ -261,7 +262,8 @@ export class DependencyChecker {
 			unclassifiedFailureOutcome: "missing",
 		},
 	);
-	private available: boolean | null = null;
+	/** Transient-aware availability memo — see `ensureAvailable` (#1467). */
+	private readonly availabilityLatch = createAvailabilityLatch();
 	private ensureInFlight: Promise<boolean> | null = null;
 	private checkInFlight = new Map<string, Promise<DepCheckResult>>();
 	private scanInFlight = new Map<
@@ -441,11 +443,16 @@ export class DependencyChecker {
 	}
 
 	/**
-	 * Check if madge is available, auto-install if not
+	 * Check if madge is available, auto-install if not.
+	 *
+	 * Shares knip's latch policy (#1467): only a durable verdict is memoized, so
+	 * a probe that timed out — madge's `--version` is ~0.7 s today, but a host
+	 * event-loop stall can expire any budget — does not disable madge for the
+	 * life of the process.
 	 */
 	async ensureAvailable(cwd = process.cwd()): Promise<boolean> {
-		// Fast path: already checked
-		if (this.available !== null) return this.available;
+		const memo = this.availabilityLatch.read();
+		if (memo !== null) return memo;
 		if (this.ensureInFlight) return this.ensureInFlight;
 
 		this.ensureInFlight = this.doEnsureAvailable(cwd);
@@ -462,8 +469,16 @@ export class DependencyChecker {
 			"madge",
 			cwd,
 		);
-		this.available = resolved !== null;
-		return this.available;
+		if (resolved !== null) {
+			this.availabilityLatch.noteAvailable();
+			return true;
+		}
+		const verdict = this.madgeAvailability.getVerdict(cwd);
+		this.availabilityLatch.noteUnavailable(
+			verdict.outcome ?? "missing",
+			verdict.cause ?? "not-found",
+		);
+		return false;
 	}
 
 	/**

--- a/clients/dispatch/runners/utils/availability-policy.ts
+++ b/clients/dispatch/runners/utils/availability-policy.ts
@@ -1,0 +1,336 @@
+/**
+ * Shared availability policy for tool probes (#1467).
+ *
+ * A `--version` probe answers one question — "can I run this tool right now?" —
+ * and it can fail for two very different reasons:
+ *
+ *   * the tool is **missing**: a durable fact about the machine, worth caching
+ *     for the session and worth an "install it" message;
+ *   * the probe was **transient**: a timeout, an abort, an EAGAIN. That is
+ *     evidence about *this moment*, not about the tool. Caching it as a
+ *     permanent `false` disables a healthy tool for the life of the process,
+ *     and wording it as "not installed" sends the user to reinstall something
+ *     that is already on disk.
+ *
+ * knip hit exactly that: a 5 s host-side probe budget, an event-loop stall that
+ * ate most of it, a latched `false`, and three days of "Knip not available.
+ * Install with: npm install -D knip" over a knip that answered `--version` in
+ * 0.8 s outside the host. This module owns the policy so every client — the
+ * `createAvailabilityChecker` seam, knip, madge, govulncheck, vulture — shares
+ * one taxonomy, one retry rule, and one message split.
+ *
+ * Kept dependency-light on purpose (only the latency logger) so client modules
+ * can import the policy without pulling in the dispatch/installer graph.
+ */
+
+import { logLatency } from "../../../latency-logger.js";
+
+export type AvailabilityOutcome =
+	| "success"
+	| "missing"
+	| "transient"
+	| "non-installable";
+
+/**
+ * Why a probe reached its verdict. `outcome` decides the control flow (install
+ * / retry / give up); `cause` is what we tell the user and log, and it is the
+ * only thing that distinguishes "timed out" from "not installed".
+ */
+export type AvailabilityCause =
+	| "ok"
+	| "fast-path"
+	| "not-found"
+	| "probe-timeout"
+	| "host-stall"
+	| "probe-rejected"
+	| "bad-cwd"
+	| "policy-denied";
+
+export interface AvailabilityDecision {
+	tool: string;
+	verdict: "available" | "unavailable";
+	outcome: AvailabilityOutcome;
+	cause: AvailabilityCause;
+	/** Wall time the probe took, ms. 0 for fast paths and cached decisions. */
+	elapsedMs: number;
+	/** True when this verdict is remembered until the next session reset. */
+	latched: boolean;
+	/** Host event-loop stall observed while the probe was in flight, ms. */
+	hostStallMs?: number;
+	/** For a non-latched verdict: how long until the next probe is allowed. */
+	retryAfterMs?: number;
+	/** Probe budget the verdict was measured against, ms. */
+	budgetMs?: number;
+}
+
+/**
+ * Cooldown after a transient failure. Bounded exponential so a genuinely sick
+ * machine is not re-probed every call, while a one-off stall costs at most one
+ * cooldown: 30 s, 60 s, 120 s … capped at 5 min.
+ */
+export const TRANSIENT_BASE_COOLDOWN_MS = 30_000;
+export const TRANSIENT_MAX_COOLDOWN_MS = 300_000;
+
+/**
+ * A timeout the host itself caused is not evidence about the tool at all, so it
+ * gets a short fixed cooldown (just enough to avoid a probe storm while the
+ * loop is still stalling) and never escalates.
+ */
+export const HOST_STALL_COOLDOWN_MS = 5_000;
+
+/**
+ * Host stall, in ms, that has to overlap a probe window before we stop counting
+ * a timeout as evidence about the tool. Well under the smallest probe budget
+ * (1.5 s) so a stall can only ever *soften* a verdict we would otherwise latch.
+ */
+export const HOST_STALL_EVIDENCE_MS = 500;
+
+/** Never mistake a transient verdict for a durable one. */
+export function isLatchingOutcome(outcome: AvailabilityOutcome): boolean {
+	return outcome !== "transient";
+}
+
+export function transientRetryDelayMs(
+	attempts: number,
+	cause: AvailabilityCause,
+): number {
+	if (cause === "host-stall") return HOST_STALL_COOLDOWN_MS;
+	const exponent = Math.max(0, attempts - 1);
+	return Math.min(
+		TRANSIENT_MAX_COOLDOWN_MS,
+		TRANSIENT_BASE_COOLDOWN_MS * 2 ** Math.min(exponent, 10),
+	);
+}
+
+/** The subset of a spawn result the classification actually reads. */
+export interface ProbeFailureShape {
+	/** The spawn's Error, whose `code` carries the errno when there is one. */
+	error?: Error | null;
+	status?: number | null;
+	failure?: string;
+	spawnFailure?: { kind?: string };
+}
+
+export interface ClassifyOptions {
+	/** Host stall observed during the probe window, ms. */
+	hostStallMs?: number;
+	/** Compatibility for legacy probes whose test doubles carry no failure kind. */
+	unclassifiedFailureOutcome?: AvailabilityOutcome;
+}
+
+/**
+ * Classify a failed probe into an outcome + cause.
+ *
+ * The stall arm is the #1467 fix for the measurement itself: the probe budget
+ * is enforced by a HOST-side `setTimeout`, so a stalled event loop expires the
+ * budget while the child is still healthy and mid-startup. When a stall
+ * overlapped the window we keep the outcome transient but re-cause it as
+ * `host-stall`, which shortens the cooldown and — critically — says so in the
+ * telemetry, instead of silently blaming the tool.
+ */
+export function classifyProbeFailure(
+	result: ProbeFailureShape,
+	options: ClassifyOptions = {},
+): { outcome: AvailabilityOutcome; cause: AvailabilityCause } {
+	const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+	if (result.spawnFailure?.kind === "tool-not-found") {
+		return { outcome: "missing", cause: "not-found" };
+	}
+	if (
+		result.failure === "timeout" ||
+		result.failure === "aborted" ||
+		result.failure === "signal" ||
+		result.spawnFailure?.kind === "killed" ||
+		result.spawnFailure?.kind === "timeout" ||
+		errorCode === "EAGAIN" ||
+		errorCode === "EBUSY"
+	) {
+		const stalled = (options.hostStallMs ?? 0) >= HOST_STALL_EVIDENCE_MS;
+		return {
+			outcome: "transient",
+			cause: stalled ? "host-stall" : "probe-timeout",
+		};
+	}
+	// A present command that rejects its version probe (or an EACCES/EINVAL/
+	// UNKNOWN failure) is not repaired by reinstalling it.
+	const outcome = options.unclassifiedFailureOutcome ?? "non-installable";
+	return {
+		outcome,
+		cause: outcome === "missing" ? "not-found" : "probe-rejected",
+	};
+}
+
+/**
+ * Accumulate how long the host event loop was blocked while something else was
+ * in flight. A timer scheduled every `intervalMs` that fires late by L ms means
+ * the loop was unavailable for L ms of the window — exactly the time the probe
+ * budget was being spent on the host rather than on the child.
+ *
+ * `unref`'d and cleared on the single settle path, so it can never hold a
+ * print-mode process open (recurring defect shape 4).
+ */
+export function startHostStallSampler(intervalMs = 100): { stop: () => number } {
+	let stallMs = 0;
+	let last = Date.now();
+	let stopped = false;
+	const timer: NodeJS.Timeout | undefined = setInterval(() => {
+		const now = Date.now();
+		const lateness = now - last - intervalMs;
+		if (lateness > 0) stallMs += lateness;
+		last = now;
+	}, intervalMs);
+	timer?.unref?.();
+	return {
+		stop: (): number => {
+			if (stopped) return Math.round(stallMs);
+			stopped = true;
+			clearInterval(timer);
+			// A stall in progress when the probe settles is still stall inside the
+			// window; count the tail the interval never got to observe.
+			const tail = Date.now() - last - intervalMs;
+			if (tail > 0) stallMs += tail;
+			return Math.round(stallMs);
+		},
+	};
+}
+
+/**
+ * A transient-aware availability latch for clients that memoize their own
+ * `available` flag (knip, madge, govulncheck, vulture).
+ *
+ * `read()` returns `null` when the caller must probe again — either it has
+ * never probed, or the last failure was transient and its cooldown has expired.
+ * Only a durable outcome (`missing` / `non-installable`) is remembered for the
+ * whole session, which is the invariant that stops one slow second at warm-up
+ * from disabling an installed tool for the life of the process.
+ */
+export interface AvailabilityLatch {
+	read(): boolean | null;
+	noteAvailable(cause?: AvailabilityCause): void;
+	/** Returns the retry delay in ms; 0 means the verdict is latched. */
+	noteUnavailable(outcome: AvailabilityOutcome, cause: AvailabilityCause): number;
+	reset(): void;
+	getOutcome(): AvailabilityOutcome | null;
+	getCause(): AvailabilityCause | null;
+	/** Epoch ms after which a transient verdict may be re-probed; 0 if latched. */
+	getRetryAtMs(): number;
+}
+
+export function createAvailabilityLatch(): AvailabilityLatch {
+	let available: boolean | null = null;
+	let outcome: AvailabilityOutcome | null = null;
+	let cause: AvailabilityCause | null = null;
+	let retryAtMs = 0;
+	let transientAttempts = 0;
+
+	return {
+		read(): boolean | null {
+			if (available !== false) return available;
+			if (outcome !== "transient") return false;
+			return Date.now() >= retryAtMs ? null : false;
+		},
+		noteAvailable(nextCause: AvailabilityCause = "ok"): void {
+			available = true;
+			outcome = "success";
+			cause = nextCause;
+			retryAtMs = 0;
+			transientAttempts = 0;
+		},
+		noteUnavailable(
+			nextOutcome: AvailabilityOutcome,
+			nextCause: AvailabilityCause,
+		): number {
+			available = false;
+			outcome = nextOutcome;
+			cause = nextCause;
+			if (isLatchingOutcome(nextOutcome)) {
+				retryAtMs = 0;
+				return 0;
+			}
+			transientAttempts += 1;
+			const delay = transientRetryDelayMs(transientAttempts, nextCause);
+			retryAtMs = Date.now() + delay;
+			return delay;
+		},
+		reset(): void {
+			available = null;
+			outcome = null;
+			cause = null;
+			retryAtMs = 0;
+			transientAttempts = 0;
+		},
+		getOutcome: () => outcome,
+		getCause: () => cause,
+		getRetryAtMs: () => retryAtMs,
+	};
+}
+
+/** True when the verdict came from a probe that never got a fair hearing. */
+export function isTransientDecision(
+	decision: { outcome?: AvailabilityOutcome | null } | null | undefined,
+): boolean {
+	return decision?.outcome === "transient";
+}
+
+/**
+ * THE message split. Every "tool X is unavailable" string a user or agent sees
+ * is produced here, so "the probe timed out" can never be worded as "install
+ * it" again. `installHint` is the command that would actually fix a genuinely
+ * missing tool.
+ */
+export function describeUnavailability(options: {
+	tool: string;
+	installHint: string;
+	outcome?: AvailabilityOutcome | null;
+	cause?: AvailabilityCause | null;
+	elapsedMs?: number;
+	retryAfterMs?: number;
+}): string {
+	const { tool, installHint } = options;
+	if (options.outcome !== "transient") {
+		return `${tool} not available. Install with: ${installHint}`;
+	}
+	const elapsed = options.elapsedMs ? ` after ${options.elapsedMs}ms` : "";
+	const stalled =
+		options.cause === "host-stall"
+			? " (the pi host event loop stalled during the probe window, so the budget expired on the host side)"
+			: "";
+	const retry = options.retryAfterMs
+		? ` Retrying in ${Math.round(options.retryAfterMs / 1000)}s.`
+		: " It will be retried.";
+	return `${tool} availability probe timed out${elapsed}${stalled}. ${tool} is not reported missing — this is a probe timeout, not a missing install.${retry}`;
+}
+
+/**
+ * One record per availability DECISION (not per cache hit), so a probe that is
+ * failing is visible in latency.log the same day instead of being inferred from
+ * three days of silence.
+ *
+ * Bounded by construction: the seam probes each tool at most once per cwd per
+ * session generation, plus once per expired transient cooldown.
+ */
+export function logAvailabilityDecision(
+	decision: AvailabilityDecision,
+	filePath = "<pi-lens>",
+): void {
+	logLatency({
+		type: "phase",
+		phase: "availability_decision",
+		filePath,
+		durationMs: Math.round(decision.elapsedMs),
+		metadata: {
+			tool: decision.tool,
+			verdict: decision.verdict,
+			outcome: decision.outcome,
+			cause: decision.cause,
+			latched: decision.latched,
+			...(decision.hostStallMs !== undefined && {
+				hostStallMs: decision.hostStallMs,
+			}),
+			...(decision.retryAfterMs !== undefined && {
+				retryAfterMs: decision.retryAfterMs,
+			}),
+			...(decision.budgetMs !== undefined && { budgetMs: decision.budgetMs }),
+		},
+	});
+}

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -33,6 +33,29 @@ import {
 	shouldAutoInstallTool,
 } from "../../../tool-policy.js";
 import type { DispatchContext } from "../../types.js";
+import {
+	type AvailabilityCause,
+	type AvailabilityOutcome,
+	classifyProbeFailure,
+	isLatchingOutcome,
+	logAvailabilityDecision,
+	startHostStallSampler,
+	transientRetryDelayMs,
+} from "./availability-policy.js";
+
+export type {
+	AvailabilityCause,
+	AvailabilityDecision,
+	AvailabilityOutcome,
+} from "./availability-policy.js";
+export {
+	createAvailabilityLatch,
+	classifyProbeFailure,
+	describeUnavailability,
+	isTransientDecision,
+	logAvailabilityDecision,
+	startHostStallSampler,
+} from "./availability-policy.js";
 
 /**
  * True when the LSP runner will cover `ctx.filePath` via the given PRIMARY server
@@ -129,12 +152,6 @@ export function createVenvFinder(
 // AVAILABILITY CHECKER FACTORY
 // =============================================================================
 
-export type AvailabilityOutcome =
-	| "success"
-	| "missing"
-	| "transient"
-	| "non-installable";
-
 export type ClientAvailabilityResult<T> =
 	| { outcome: "success"; value: T }
 	| { outcome: Exclude<AvailabilityOutcome, "success">; value?: undefined };
@@ -169,6 +186,13 @@ type AvailabilityCache = {
 	available: boolean | null;
 	command: string | null;
 	outcome: AvailabilityOutcome | null;
+	cause: AvailabilityCause | null;
+	/** How long the last probe took, ms — surfaced in the unavailable message. */
+	elapsedMs: number;
+	/** Epoch ms after which a transient `false` may be re-probed; 0 = latched. */
+	retryAtMs: number;
+	/** Consecutive transient failures, for the bounded exponential cooldown. */
+	transientAttempts: number;
 };
 
 export interface AvailabilityCheckerOptions {
@@ -271,6 +295,17 @@ export function resetDispatchAvailabilityState(): void {
 	availabilityStateGeneration += 1;
 }
 
+/** What the last probe for a cwd decided, for messaging and telemetry (#1467). */
+export interface AvailabilityVerdict {
+	outcome: AvailabilityOutcome | null;
+	cause: AvailabilityCause | null;
+	elapsedMs: number;
+	/** True when the verdict is remembered until the next session reset. */
+	latched: boolean;
+	/** Epoch ms after which a transient verdict may be re-probed; 0 = latched. */
+	retryAtMs: number;
+}
+
 /**
  * Create a cached availability checker for a command.
  * The checker will look for the command in venv first, then global.
@@ -280,6 +315,13 @@ export function resetDispatchAvailabilityState(): void {
  * `zig --version`). Passing the wrong probe makes the runner silently skip on
  * every machine, so toolchains with a non-standard version command must override
  * this.
+ *
+ * ## Latch policy (#1467)
+ *
+ * A `missing` / `non-installable` verdict is durable and is cached for the
+ * session. A `transient` verdict — timeout, abort, EAGAIN — is NOT: it is
+ * cached only for a bounded cooldown, after which the next caller re-probes.
+ * An installed tool therefore recovers on its own, without a host restart.
  */
 export function createAvailabilityChecker(
 	command: string,
@@ -290,6 +332,7 @@ export function createAvailabilityChecker(
 	isAvailableAsync: (cwd?: string) => Promise<boolean>;
 	getCommand: (cwd?: string) => string | null;
 	getOutcome: (cwd?: string) => AvailabilityOutcome | null;
+	getVerdict: (cwd?: string) => AvailabilityVerdict;
 	reset: () => void;
 } {
 	const cacheByCwd = new PathKeyedMap<AvailabilityCache>(
@@ -324,16 +367,77 @@ export function createAvailabilityChecker(
 			available: null,
 			command: null,
 			outcome: null,
+			cause: null,
+			elapsedMs: 0,
+			retryAtMs: 0,
+			transientAttempts: 0,
 		};
 		cacheByCwd.set(key, created);
 		return created;
+	}
+
+	/** Record a verdict on the cache and emit exactly one decision record. */
+	function noteDecision(
+		cache: AvailabilityCache,
+		resolvedCwd: string,
+		verdict: {
+			available: boolean;
+			outcome: AvailabilityOutcome;
+			cause: AvailabilityCause;
+			elapsedMs: number;
+			hostStallMs?: number;
+		},
+	): void {
+		cache.available = verdict.available;
+		cache.outcome = verdict.outcome;
+		cache.cause = verdict.cause;
+		cache.elapsedMs = verdict.elapsedMs;
+		let retryAfterMs: number | undefined;
+		if (verdict.available) {
+			cache.retryAtMs = 0;
+			cache.transientAttempts = 0;
+		} else if (isLatchingOutcome(verdict.outcome)) {
+			cache.retryAtMs = 0;
+			cache.transientAttempts = 0;
+		} else {
+			cache.transientAttempts += 1;
+			retryAfterMs = transientRetryDelayMs(
+				cache.transientAttempts,
+				verdict.cause,
+			);
+			cache.retryAtMs = Date.now() + retryAfterMs;
+		}
+		logAvailabilityDecision(
+			{
+				tool: command,
+				verdict: verdict.available ? "available" : "unavailable",
+				outcome: verdict.outcome,
+				cause: verdict.cause,
+				elapsedMs: verdict.elapsedMs,
+				latched: verdict.available || isLatchingOutcome(verdict.outcome),
+				...(verdict.hostStallMs !== undefined && {
+					hostStallMs: verdict.hostStallMs,
+				}),
+				...(retryAfterMs !== undefined && { retryAfterMs }),
+				budgetMs: options.probeTimeout ?? 5000,
+			},
+			resolvedCwd,
+		);
 	}
 
 	async function isAvailableAsync(cwd?: string): Promise<boolean> {
 		ensureCurrentGeneration();
 		const resolvedCwd = cwd || process.cwd();
 		const cache = getCache(resolvedCwd);
-		if (cache.available === false) return false;
+		if (cache.available === false) {
+			// A durable "this machine does not have the tool" stays cached; a
+			// transient probe failure only holds until its cooldown expires, so an
+			// installed tool cannot be disabled for the life of the process by one
+			// slow second at warm-up (#1467).
+			if (cache.outcome !== "transient") return false;
+			if (Date.now() < cache.retryAtMs) return false;
+			cache.available = null;
+		}
 		if (cache.available === true && cache.command) {
 			if (await isSpawnableCommand(cache.command)) return true;
 			// Cached-positive spawn feedback: a removed absolute path or vanished
@@ -341,6 +445,7 @@ export function createAvailabilityChecker(
 			cache.available = null;
 			cache.command = null;
 			cache.outcome = null;
+			cache.cause = null;
 		}
 
 		const key = path.resolve(resolvedCwd);
@@ -352,9 +457,13 @@ export function createAvailabilityChecker(
 		promise = (async () => {
 			const fastPath = options.fastPath?.();
 			if (fastPath) {
-				cache.available = true;
-				cache.outcome = "success";
 				cache.command = fastPath;
+				noteDecision(cache, resolvedCwd, {
+					available: true,
+					outcome: "success",
+					cause: "fast-path",
+					elapsedMs: 0,
+				});
 				return true;
 			}
 
@@ -364,51 +473,71 @@ export function createAvailabilityChecker(
 			try {
 				const cwdStat = await fs.promises.stat(resolvedCwd);
 				if (!cwdStat.isDirectory()) {
-					cache.available = false;
-					cache.outcome = "non-installable";
+					noteDecision(cache, resolvedCwd, {
+						available: false,
+						outcome: "non-installable",
+						cause: "bad-cwd",
+						elapsedMs: 0,
+					});
 					return false;
 				}
 			} catch {
-				cache.available = false;
-				cache.outcome = "non-installable";
+				noteDecision(cache, resolvedCwd, {
+					available: false,
+					outcome: "non-installable",
+					cause: "bad-cwd",
+					elapsedMs: 0,
+				});
 				return false;
 			}
 
 			const cmd = findCommand(resolvedCwd);
 			const env = await options.environment?.(resolvedCwd);
-			const result = await safeSpawnAsync(cmd, versionArgs, {
-				timeout: options.probeTimeout ?? 5000,
-				cwd: resolvedCwd,
-				env,
-			});
+			// The probe budget is enforced by a HOST-side timer, so host event-loop
+			// stalls are charged to the child. Measure the stall that overlapped the
+			// window and hand it to the classifier (#1467).
+			const stallSampler = startHostStallSampler();
+			const startedAt = Date.now();
+			let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
+			let hostStallMs: number;
+			try {
+				result = await safeSpawnAsync(cmd, versionArgs, {
+					timeout: options.probeTimeout ?? 5000,
+					cwd: resolvedCwd,
+					env,
+				});
+			} finally {
+				hostStallMs = stallSampler.stop();
+			}
+			const elapsedMs = Date.now() - startedAt;
 
 			if (!result.error && result.status === 0) {
-				cache.available = true;
-				cache.outcome = "success";
 				cache.command = cmd;
+				noteDecision(cache, resolvedCwd, {
+					available: true,
+					outcome: "success",
+					cause: "ok",
+					elapsedMs,
+					hostStallMs,
+				});
 				return true;
 			}
 
-			cache.available = false;
-			const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
-			if (result.spawnFailure?.kind === "tool-not-found") {
-				resetPathWalkMemo();
-				cache.outcome = "missing";
-			} else if (
-				result.failure === "timeout" ||
-				result.failure === "aborted" ||
-				result.failure === "signal" ||
-				result.spawnFailure?.kind === "killed" ||
-				errorCode === "EAGAIN" ||
-				errorCode === "EBUSY"
-			) {
-				cache.outcome = "transient";
-			} else {
-				// A present command that rejects its version probe (or an EACCES/
-				// EINVAL/UNKNOWN failure) is not repaired by reinstalling it.
-				cache.outcome =
-					options.unclassifiedFailureOutcome ?? "non-installable";
-			}
+			const { outcome, cause } = classifyProbeFailure(result, {
+				hostStallMs,
+				unclassifiedFailureOutcome: options.unclassifiedFailureOutcome,
+			});
+			// Only a TYPED tool-not-found invalidates the PATH walk memo; an
+			// `unclassifiedFailureOutcome: "missing"` compatibility verdict is a
+			// guess, not evidence that PATH changed.
+			if (result.spawnFailure?.kind === "tool-not-found") resetPathWalkMemo();
+			noteDecision(cache, resolvedCwd, {
+				available: false,
+				outcome,
+				cause,
+				elapsedMs,
+				hostStallMs,
+			});
 			return false;
 		})().finally(() => {
 			// A session reset clears this map and a caller may immediately start a
@@ -436,7 +565,20 @@ export function createAvailabilityChecker(
 		return getCache(cwd || process.cwd()).outcome;
 	}
 
-	return { isAvailableAsync, getCommand, getOutcome, reset };
+	function getVerdict(cwd?: string): AvailabilityVerdict {
+		ensureCurrentGeneration();
+		const cache = getCache(cwd || process.cwd());
+		return {
+			outcome: cache.outcome,
+			cause: cache.cause,
+			elapsedMs: cache.elapsedMs,
+			latched:
+				cache.available !== false || isLatchingOutcome(cache.outcome ?? "missing"),
+			retryAtMs: cache.retryAtMs,
+		};
+	}
+
+	return { isAvailableAsync, getCommand, getOutcome, getVerdict, reset };
 }
 
 /**

--- a/clients/govulncheck-client.ts
+++ b/clients/govulncheck-client.ts
@@ -23,6 +23,7 @@ import * as path from "node:path";
 import { safeSpawnAsync } from "./safe-spawn.js";
 import { assertInstallAllowed } from "./project-trust.js";
 import { SecurityScanClient } from "./security-scan-client.js";
+import { classifyProbeFailure } from "./dispatch/runners/utils/availability-policy.js";
 
 // --- Types ---
 
@@ -121,6 +122,15 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 			this.available = true;
 			return true;
 		}
+		if (this.probeWasTransient()) {
+			// #1467: a timed-out/killed probe says nothing about whether
+			// govulncheck is on PATH. Latching `false` here disabled it for the
+			// life of the process; a `go install` here would be a heavyweight
+			// reaction to a host hiccup. Record an expiring verdict, retry later.
+			this.log("govulncheck probe timed out; retrying later (not installing)");
+			this.markTransientlyUnavailable(this.lastProbeCause ?? "probe-timeout");
+			return false;
+		}
 		if (!assertInstallAllowed("govulncheck go install")) {
 			// Deliberately NOT latching `available = false` (#1350 delta review):
 			// trust denial is policy, not tool absence -- a later trust grant
@@ -139,6 +149,12 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 			timeout: 5000,
 		});
 		if (goOnPath.error || goOnPath.status !== 0) {
+			const { outcome, cause } = classifyProbeFailure(goOnPath);
+			if (outcome === "transient") {
+				this.log("`go version` probe timed out; retrying govulncheck later");
+				this.markTransientlyUnavailable(cause);
+				return false;
+			}
 			this.log("go binary not on PATH — cannot auto-install govulncheck");
 			this.available = false;
 			return false;

--- a/clients/knip-client.ts
+++ b/clients/knip-client.ts
@@ -12,7 +12,7 @@
 import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getProjectDataDir } from "./file-utils.js";
+import { getGlobalPiLensDir, getProjectDataDir } from "./file-utils.js";
 import { findNearestMarkerRoot } from "./path-utils.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
 import {
@@ -20,6 +20,10 @@ import {
 	getManagedToolEnvironment,
 	resolveAvailableOrInstall,
 } from "./dispatch/runners/utils/runner-helpers.js";
+import {
+	createAvailabilityLatch,
+	describeUnavailability,
+} from "./dispatch/runners/utils/availability-policy.js";
 
 // --- Types ---
 
@@ -46,6 +50,13 @@ export interface KnipResult {
 	unusedDeps: KnipIssue[];
 	unlistedDeps: KnipIssue[];
 	summary: string;
+	/**
+	 * Why an unsuccessful run failed, in a form readers can branch on without
+	 * pattern-matching prose (#1467). `unavailable-transient` marks a result the
+	 * cache must NOT keep over a good one and the turn loop must not treat as a
+	 * hard knip failure — the tool is installed, the probe just timed out.
+	 */
+	failureKind?: "unavailable-transient" | "unavailable-missing";
 }
 
 const EMPTY_RESULT: Omit<KnipResult, "summary"> = {
@@ -97,6 +108,31 @@ export function readOverridePinnedPackageNames(targetDir: string): Set<string> {
 
 // --- Client ---
 
+/**
+ * Managed knip shim on disk, or null. Mirrors jscpd's fast path: when
+ * `~/.pi-lens/tools/node_modules/.bin/knip*` exists the tool IS installed, so
+ * resolving availability needs no spawn at all — and a spawn that cannot happen
+ * cannot time out (#1467).
+ */
+function findManagedKnipBinary(): string | null {
+	const base = path.join(
+		getGlobalPiLensDir(),
+		"tools",
+		"node_modules",
+		".bin",
+		"knip",
+	);
+	const candidates =
+		process.platform === "win32"
+			? [`${base}.cmd`, `${base}.exe`, base]
+			: [base];
+	try {
+		return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+	} catch {
+		return null;
+	}
+}
+
 export class KnipClient {
 	private readonly knipAvailability = createAvailabilityChecker(
 		"knip",
@@ -105,9 +141,15 @@ export class KnipClient {
 		{
 			environment: (cwd) => getManagedToolEnvironment("knip", cwd),
 			unclassifiedFailureOutcome: "missing",
+			fastPath: findManagedKnipBinary,
 		},
 	);
-	private knipAvailable: boolean | null = null;
+	/**
+	 * Client-side memo. Only a DURABLE verdict is latched — a transient probe
+	 * failure expires, so an installed knip becomes available again without a
+	 * host restart (#1467).
+	 */
+	private readonly availabilityLatch = createAvailabilityLatch();
 	private knipCommand = "knip";
 	private ensureInFlight: Promise<boolean> | null = null;
 	private log: (msg: string) => void;
@@ -160,11 +202,16 @@ export class KnipClient {
 	}
 
 	/**
-	 * Check if knip CLI is available, auto-install if not
+	 * Check if knip CLI is available, auto-install if not.
+	 *
+	 * The memo returns `null` when the last verdict was transient and its
+	 * cooldown has expired, which re-enters the probe. That is the difference
+	 * between "knip is missing" (a fact worth caching) and "the probe timed out"
+	 * (a moment worth retrying).
 	 */
 	async ensureAvailable(): Promise<boolean> {
-		// Fast path: already checked
-		if (this.knipAvailable !== null) return this.knipAvailable;
+		const memo = this.availabilityLatch.read();
+		if (memo !== null) return memo;
 		if (this.ensureInFlight) return this.ensureInFlight;
 
 		this.ensureInFlight = this.doEnsureAvailable();
@@ -176,14 +223,47 @@ export class KnipClient {
 	}
 
 	private async doEnsureAvailable(): Promise<boolean> {
+		const cwd = process.cwd();
 		const resolved = await resolveAvailableOrInstall(
 			this.knipAvailability,
 			"knip",
-			process.cwd(),
+			cwd,
 		);
-		this.knipAvailable = resolved !== null;
-		if (resolved) this.knipCommand = resolved;
-		return this.knipAvailable;
+		if (resolved !== null) {
+			this.knipCommand = resolved;
+			this.availabilityLatch.noteAvailable();
+			return true;
+		}
+		const verdict = this.knipAvailability.getVerdict(cwd);
+		this.availabilityLatch.noteUnavailable(
+			verdict.outcome ?? "missing",
+			verdict.cause ?? "not-found",
+		);
+		return false;
+	}
+
+	/**
+	 * The single place a knip-unavailable result is worded. A transient probe
+	 * failure must never be reported as "install knip" — knip is on disk.
+	 */
+	private unavailableResult(): KnipResult {
+		const verdict = this.knipAvailability.getVerdict(process.cwd());
+		const transient = verdict.outcome === "transient";
+		const retryAfterMs = verdict.retryAtMs
+			? Math.max(0, verdict.retryAtMs - Date.now())
+			: undefined;
+		return {
+			...EMPTY_RESULT,
+			failureKind: transient ? "unavailable-transient" : "unavailable-missing",
+			summary: describeUnavailability({
+				tool: "Knip",
+				installHint: "npm install -D knip",
+				outcome: verdict.outcome,
+				cause: verdict.cause,
+				elapsedMs: verdict.elapsedMs,
+				retryAfterMs,
+			}),
+		};
 	}
 
 	/**
@@ -214,10 +294,7 @@ export class KnipClient {
 		}
 
 		if (!(await this.ensureAvailable())) {
-			return {
-				...EMPTY_RESULT,
-				summary: "Knip not available. Install with: npm install -D knip",
-			};
+			return this.unavailableResult();
 		}
 
 		const key = path.resolve(targetDir);

--- a/clients/latency-logger.ts
+++ b/clients/latency-logger.ts
@@ -68,6 +68,11 @@ let lastPhase: { phase: string; ts: string } | undefined;
  * #1453: `tool_set_mutation` records an active-tool-set rewrite (zero-duration
  * bookkeeping, and it fires during session_start where a real stall must stay
  * attributed to the work around it), so it is excluded for the same reason.
+ * #1467: `availability_decision` records a tool-probe verdict. Its `durationMs`
+ * is the child's own probe time (often zero for a fast path or a cached
+ * decision) and the record is bookkeeping ABOUT a probe, not host work — a
+ * loop_block landing next to one must stay attributed to whatever really
+ * stalled the loop, which is frequently the very thing that expired the probe.
  */
 const LAST_PHASE_EXCLUDED = new Set([
 	"loop_block",
@@ -78,6 +83,7 @@ const LAST_PHASE_EXCLUDED = new Set([
 	"agent_end_deferred_mutation_requeue",
 	"session_end_bus_rollup",
 	"tool_set_mutation",
+	"availability_decision",
 ]);
 
 /**

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -612,6 +612,10 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 		newIssues?: number;
 		blockerIssues?: number;
 		reason?: string;
+		/** Set when the failure was an availability verdict, not a knip run. */
+		failureKind?: string;
+		/** True when a failed run left the previous good cache in place (#1467). */
+		cacheKept?: boolean;
 	} = {};
 	if (runtime.isStartupScanInFlight("knip")) {
 		dbg("turn_end: skipping knip (startup scan still in flight)");
@@ -622,9 +626,13 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 		// run tool checks every turn. Also back off after a timeout/kill so every
 		// agent turn does not spend 30s launching another heavyweight knip process.
 		const prevKnip = cacheManager.readCache<KnipResult>("knip", cwd);
+		// An availability failure is NOT a hard knip failure: knip never ran, so
+		// there is nothing to back off from, and backing off would make an
+		// expiring probe verdict permanent again (#1467).
 		const previousFailedHard =
 			prevKnip &&
 			!prevKnip.data.success &&
+			!prevKnip.data.failureKind &&
 			/(timed out|killed|SIGTERM|SIGKILL|SIGABRT)/i.test(prevKnip.data.summary);
 
 		if (previousFailedHard) {
@@ -634,13 +642,26 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 			knipMeta = { skipped: true, reason: prevKnip.data.summary };
 		} else {
 			const knipResult = await knipClient.analyze(cwd, getKnipIgnorePatterns());
-			cacheManager.writeCache("knip", knipResult, cwd);
+			// Never overwrite a good scan with a failure (#925, #1467): the 194-byte
+			// "not available" record replaced 149 KB of real findings in every
+			// dogfood project and readers then served the failure as the answer.
+			// The last good result stays until a new successful scan replaces it.
+			const wouldPoisonCache = !knipResult.success && prevKnip?.data.success;
+			if (wouldPoisonCache) {
+				dbg(
+					`turn_end: keeping last good knip cache; this run failed: ${knipResult.summary}`,
+				);
+			} else {
+				cacheManager.writeCache("knip", knipResult, cwd);
+			}
 			knipMeta = {
 				success: knipResult.success,
 				totalIssues: knipResult.issues.length,
 				newIssues: 0,
 				blockerIssues: 0,
 				...(!knipResult.success && { reason: knipResult.summary }),
+				...(knipResult.failureKind && { failureKind: knipResult.failureKind }),
+				...(wouldPoisonCache && { cacheKept: true }),
 			};
 
 			if (knipResult.success && knipResult.issues.length > 0) {

--- a/clients/security-scan-client.ts
+++ b/clients/security-scan-client.ts
@@ -15,9 +15,39 @@
 
 import { createSubsystemLogger } from "./extension-log.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
+import {
+	type AvailabilityCause,
+	type AvailabilityOutcome,
+	classifyProbeFailure,
+	createAvailabilityLatch,
+	logAvailabilityDecision,
+	startHostStallSampler,
+} from "./dispatch/runners/utils/availability-policy.js";
 
 export abstract class SecurityScanClient<TResult> {
-	protected available: boolean | null = null;
+	/**
+	 * Availability memo, backed by the shared transient-aware latch (#1467).
+	 *
+	 * Assigning `false` still means "durable: this machine does not have the
+	 * tool" — every existing subclass write keeps its meaning. A probe that
+	 * merely timed out must go through `markTransientlyUnavailable` instead, so
+	 * it expires and the tool can come back without a host restart.
+	 */
+	private readonly availabilityLatch = createAvailabilityLatch();
+	protected get available(): boolean | null {
+		return this.availabilityLatch.read();
+	}
+	protected set available(value: boolean | null) {
+		if (value === true) this.availabilityLatch.noteAvailable();
+		else if (value === false)
+			this.availabilityLatch.noteUnavailable("missing", "not-found");
+		else this.availabilityLatch.reset();
+	}
+
+	/** Outcome/cause of the most recent `probeVersion` call. */
+	protected lastProbeOutcome: AvailabilityOutcome | null = null;
+	protected lastProbeCause: AvailabilityCause | null = null;
+
 	private ensureInFlight: Promise<boolean> | null = null;
 	protected readonly inFlight = new Map<string, Promise<TResult>>();
 	protected binaryPath: string | null = null;
@@ -57,17 +87,69 @@ export abstract class SecurityScanClient<TResult> {
 
 	/**
 	 * Spawn `toolName <versionArgs>` and report whether it answered cleanly.
-	 * Does NOT mutate `this.available` — callers decide what a hit/miss means.
+	 * Does NOT mutate `this.available` — callers decide what a hit/miss means —
+	 * but it does classify the failure (`lastProbeOutcome`/`lastProbeCause`) and
+	 * emit one availability-decision record, so a probe that keeps timing out is
+	 * visible in latency.log rather than inferred from silence (#1467).
 	 */
 	protected async probeVersion(versionArgs: string[]): Promise<boolean> {
-		const probe = await safeSpawnAsync(this.toolName, versionArgs, {
-			timeout: 5000,
-		});
+		const sampler = startHostStallSampler();
+		const startedAt = Date.now();
+		let probe: Awaited<ReturnType<typeof safeSpawnAsync>>;
+		let hostStallMs: number;
+		try {
+			probe = await safeSpawnAsync(this.toolName, versionArgs, {
+				timeout: 5000,
+			});
+		} finally {
+			hostStallMs = sampler.stop();
+		}
+		const elapsedMs = Date.now() - startedAt;
 		if (!probe.error && probe.status === 0) {
+			this.lastProbeOutcome = "success";
+			this.lastProbeCause = "ok";
 			this.log(`${this.toolName} found: ${probe.stdout.trim().split("\n")[0]}`);
+			logAvailabilityDecision({
+				tool: this.toolName,
+				verdict: "available",
+				outcome: "success",
+				cause: "ok",
+				elapsedMs,
+				latched: true,
+				hostStallMs,
+				budgetMs: 5000,
+			});
 			return true;
 		}
+		const { outcome, cause } = classifyProbeFailure(probe, { hostStallMs });
+		this.lastProbeOutcome = outcome;
+		this.lastProbeCause = cause;
+		logAvailabilityDecision({
+			tool: this.toolName,
+			verdict: "unavailable",
+			outcome,
+			cause,
+			elapsedMs,
+			latched: outcome !== "transient",
+			hostStallMs,
+			budgetMs: 5000,
+		});
 		return false;
+	}
+
+	/** True when the last probe failed for a reason that is not the tool's fault. */
+	protected probeWasTransient(): boolean {
+		return this.lastProbeOutcome === "transient";
+	}
+
+	/**
+	 * Record a non-durable unavailability: the verdict expires after a cooldown
+	 * and the next `ensureAvailable` re-probes.
+	 */
+	protected markTransientlyUnavailable(
+		cause: AvailabilityCause = "probe-timeout",
+	): void {
+		this.availabilityLatch.noteUnavailable("transient", cause);
 	}
 
 	/**
@@ -79,6 +161,15 @@ export abstract class SecurityScanClient<TResult> {
 		if (await this.probeVersion(versionArgs)) {
 			this.available = true;
 			return true;
+		}
+		if (this.probeWasTransient()) {
+			// A timed-out probe is not evidence the tool is absent, so it must not
+			// trigger an install NOR latch a permanent `false`.
+			this.log(
+				`${this.toolName} availability probe timed out; not installing, will retry`,
+			);
+			this.markTransientlyUnavailable(this.lastProbeCause ?? "probe-timeout");
+			return false;
 		}
 		this.log(`${this.toolName} not found, attempting auto-install`);
 		const { ensureTool } = await import("./installer/index.js");

--- a/tests/clients/availability-latching-clients.test.ts
+++ b/tests/clients/availability-latching-clients.test.ts
@@ -128,6 +128,42 @@ describe("knip availability (#1467)", () => {
 		}
 	});
 
+	// The timeout test above proves the WORDING, not the wiring: it never
+	// asserts a duration, so dropping `elapsedMs` on the way from the probe to
+	// the message leaves it green. That figure is the whole forensic value of
+	// the record — "probe timed out" without it cannot distinguish a tool that
+	// answered slowly from a host that never gave it the loop, which is the
+	// distinction #1467 turned on. So make the probe cost real time and assert
+	// the message reports it.
+	it("reports how long the probe actually took, not just that it timed out", async () => {
+		const spawn = await spawnMock();
+		// `Date` is faked suite-wide, so a real setTimeout would still measure
+		// zero. Advance the clock the probe reads, which is both deterministic
+		// and closer to what a 5s budget expiring actually looks like.
+		spawn.mockImplementation(async () => {
+			vi.setSystemTime(new Date(Date.now() + 4800));
+			return timeoutResult as never;
+		});
+
+		const { KnipClient } = await import("../../clients/knip-client.js");
+		const client = new KnipClient(false);
+		const projectDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-1467-elapsed-"),
+		);
+		try {
+			fs.writeFileSync(path.join(projectDir, "package.json"), '{"name":"d"}');
+
+			const failed = await client.analyze(projectDir);
+			expect(failed.failureKind).toBe("unavailable-transient");
+
+			const elapsed = failed.summary.match(/after (\d+)ms/);
+			expect(elapsed).not.toBeNull();
+			expect(Number(elapsed?.[1])).toBe(4800);
+		} finally {
+			removeTempDirSync(projectDir);
+		}
+	});
+
 	it("still tells the user to install a genuinely missing knip", async () => {
 		(await spawnMock()).mockResolvedValue(missingResult as never);
 

--- a/tests/clients/availability-latching-clients.test.ts
+++ b/tests/clients/availability-latching-clients.test.ts
@@ -1,0 +1,205 @@
+/**
+ * #1467 — the four spawn-probed clients that shared the latching shape all
+ * inherit the new semantics: knip and madge through
+ * `createAvailabilityChecker`, govulncheck through `SecurityScanClient`, and
+ * vulture through the shared availability latch. Each is asserted only for its
+ * WIRING to the seam; the policy itself is proved once in
+ * `dispatch/runners/availability-latching.test.ts`.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TRANSIENT_BASE_COOLDOWN_MS } from "../../clients/dispatch/runners/utils/availability-policy.ts";
+import { resetDispatchAvailabilityState } from "../../clients/dispatch/runners/utils/runner-helpers.ts";
+import { removeTempDirSync } from "./test-utils.js";
+
+const { piLensDirHolder } = vi.hoisted(() => ({
+	piLensDirHolder: { dir: "" },
+}));
+
+vi.mock("../../clients/file-utils.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../clients/file-utils.js")>()),
+	getGlobalPiLensDir: () => piLensDirHolder.dir,
+}));
+
+vi.mock("../../clients/safe-spawn.js", () => ({
+	safeSpawn: vi.fn(() => ({ stdout: "", stderr: "", status: 1 })),
+	safeSpawnAsync: vi.fn(async () => ({ stdout: "", stderr: "", status: 1 })),
+}));
+
+vi.mock("../../clients/installer/index.js", () => ({
+	ensureTool: vi.fn(async () => null),
+	isSpawnableCommand: vi.fn(async () => true),
+	resetPathWalkMemo: vi.fn(),
+	getToolEnvironment: vi.fn(async () => ({ ...process.env })),
+}));
+
+vi.mock("../../clients/sessionstart-logger.js", () => ({
+	logSessionStart: vi.fn(),
+}));
+
+const timeoutResult = {
+	stdout: "",
+	stderr: "",
+	status: null,
+	error: new Error("Process timed out after 5000ms"),
+	failure: "timeout",
+	spawnFailure: { kind: "timeout" },
+};
+
+const missingResult = {
+	stdout: "",
+	stderr: "",
+	status: null,
+	error: Object.assign(new Error("spawn missing ENOENT"), { code: "ENOENT" }),
+	failure: "spawn",
+	spawnFailure: { kind: "tool-not-found" },
+};
+
+const versionOk = { stdout: "6.4.1", stderr: "", status: 0 };
+
+let tmpHome = "";
+
+async function spawnMock() {
+	const mod = await import("../../clients/safe-spawn.js");
+	return vi.mocked(mod.safeSpawnAsync);
+}
+
+beforeEach(async () => {
+	tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-1467-home-"));
+	piLensDirHolder.dir = tmpHome;
+	(await spawnMock()).mockReset();
+	resetDispatchAvailabilityState();
+	vi.useFakeTimers({ toFake: ["Date"] });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	removeTempDirSync(tmpHome);
+});
+
+function advancePastCooldown(): void {
+	vi.setSystemTime(new Date(Date.now() + TRANSIENT_BASE_COOLDOWN_MS + 1));
+}
+
+describe("knip availability (#1467)", () => {
+	it("resolves the managed binary with no spawn at all", async () => {
+		const binDir = path.join(tmpHome, "tools", "node_modules", ".bin");
+		fs.mkdirSync(binDir, { recursive: true });
+		const binName = process.platform === "win32" ? "knip.cmd" : "knip";
+		fs.writeFileSync(path.join(binDir, binName), "");
+
+		const { KnipClient } = await import("../../clients/knip-client.js");
+		const client = new KnipClient(false);
+
+		expect(await client.ensureAvailable()).toBe(true);
+		expect(await spawnMock()).not.toHaveBeenCalled();
+	});
+
+	it("reports a probe timeout as a timeout, and recovers without a restart", async () => {
+		const spawn = await spawnMock();
+		spawn.mockResolvedValue(timeoutResult as never);
+
+		const { KnipClient } = await import("../../clients/knip-client.js");
+		const client = new KnipClient(false);
+		const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-1467-proj-"));
+		try {
+			fs.writeFileSync(path.join(projectDir, "package.json"), '{"name":"d"}');
+
+			const failed = await client.analyze(projectDir);
+			expect(failed.success).toBe(false);
+			expect(failed.failureKind).toBe("unavailable-transient");
+			expect(failed.summary).toContain("timed out");
+			expect(failed.summary).not.toContain("Install with");
+
+			// Later in the SAME process the probe answers. Pre-fix, `knipAvailable`
+			// held `false` for the life of the client and knip stayed dead.
+			advancePastCooldown();
+			spawn.mockImplementation(async (_cmd, args) =>
+				(args as string[]).includes("--version")
+					? (versionOk as never)
+					: ({ stdout: "", stderr: "", status: 0 } as never),
+			);
+			expect(await client.ensureAvailable()).toBe(true);
+		} finally {
+			removeTempDirSync(projectDir);
+		}
+	});
+
+	it("still tells the user to install a genuinely missing knip", async () => {
+		(await spawnMock()).mockResolvedValue(missingResult as never);
+
+		const { KnipClient } = await import("../../clients/knip-client.js");
+		const client = new KnipClient(false);
+		const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-1467-miss-"));
+		try {
+			fs.writeFileSync(path.join(projectDir, "package.json"), '{"name":"d"}');
+			const result = await client.analyze(projectDir);
+			expect(result.failureKind).toBe("unavailable-missing");
+			expect(result.summary).toBe(
+				"Knip not available. Install with: npm install -D knip",
+			);
+		} finally {
+			removeTempDirSync(projectDir);
+		}
+	});
+});
+
+describe("madge availability (#1467)", () => {
+	it("re-probes after a transient failure instead of skipping for the session", async () => {
+		const spawn = await spawnMock();
+		spawn.mockResolvedValue(timeoutResult as never);
+
+		const { DependencyChecker } = await import("../../clients/dependency-checker.js");
+		const checker = new DependencyChecker(false);
+		expect(await checker.ensureAvailable(process.cwd())).toBe(false);
+
+		advancePastCooldown();
+		spawn.mockResolvedValue(versionOk as never);
+		expect(await checker.ensureAvailable(process.cwd())).toBe(true);
+	});
+});
+
+describe("govulncheck availability (#1467)", () => {
+	it("does not latch — and does not `go install` — on a timed-out probe", async () => {
+		const spawn = await spawnMock();
+		spawn.mockResolvedValue(timeoutResult as never);
+
+		const { GovulncheckClient } = await import("../../clients/govulncheck-client.js");
+		const client = new GovulncheckClient(false);
+		expect(await client.ensureAvailable()).toBe(false);
+		// One probe only: the install path must not be entered on a host hiccup.
+		expect(spawn).toHaveBeenCalledTimes(1);
+
+		advancePastCooldown();
+		spawn.mockResolvedValue(versionOk as never);
+		expect(await client.ensureAvailable()).toBe(true);
+	});
+});
+
+describe("vulture availability (#1467)", () => {
+	it("re-probes after a transient failure, but latches a real absence", async () => {
+		const spawn = await spawnMock();
+		spawn.mockResolvedValue(timeoutResult as never);
+
+		const { PythonDeadCodeClient } = await import("../../clients/dead-code-client.js");
+		const client = new PythonDeadCodeClient(false);
+		expect(await client.ensureAvailable()).toBe(false);
+		const probesAfterTransient = spawn.mock.calls.length;
+
+		advancePastCooldown();
+		spawn.mockResolvedValue(versionOk as never);
+		expect(await client.ensureAvailable()).toBe(true);
+		expect(spawn.mock.calls.length).toBeGreaterThan(probesAfterTransient);
+
+		const absent = new PythonDeadCodeClient(false);
+		spawn.mockResolvedValue(missingResult as never);
+		expect(await absent.ensureAvailable()).toBe(false);
+		const probesAfterMissing = spawn.mock.calls.length;
+		vi.setSystemTime(new Date(Date.now() + 10 * TRANSIENT_BASE_COOLDOWN_MS));
+		expect(await absent.ensureAvailable()).toBe(false);
+		expect(spawn.mock.calls.length).toBe(probesAfterMissing);
+	});
+});

--- a/tests/clients/dispatch/runners/availability-latching.test.ts
+++ b/tests/clients/dispatch/runners/availability-latching.test.ts
@@ -241,6 +241,28 @@ describe("availability policy: cause taxonomy and messages (#1467)", () => {
 		}
 		expect(sampler.stop()).toBeGreaterThan(400);
 	});
+
+	// The test above never exercises the interval: nothing fires during a
+	// synchronous block, so its whole figure comes from the tail computed in
+	// stop(). Zeroing the interval's accumulation therefore leaves it green,
+	// which would retire the sampler's entire reason for existing — and with
+	// it the host-stall vs probe-timeout split that decides whether a verdict
+	// latches. Here the loop RECOVERS before stop(), so the tail is negligible
+	// and the figure can only come from the interval observing its own
+	// lateness.
+	it("attributes a stall the loop recovered from before the probe settled", async () => {
+		vi.useRealTimers();
+		const sampler = startHostStallSampler(50);
+		const until = Date.now() + 400;
+		while (Date.now() < until) {
+			// Same deliberate block, but the sampler keeps running afterwards.
+		}
+		// Let the loop run quietly: the first tick after the block reports ~400ms
+		// of lateness, and subsequent ticks are on time, so `last` ends up fresh.
+		await new Promise((r) => setTimeout(r, 200));
+		const stallMs = sampler.stop();
+		expect(stallMs).toBeGreaterThan(300);
+	});
 });
 
 describe("availability latch: shared client-side memo (#1467)", () => {

--- a/tests/clients/dispatch/runners/availability-latching.test.ts
+++ b/tests/clients/dispatch/runners/availability-latching.test.ts
@@ -1,0 +1,283 @@
+/**
+ * #1467 — a transient probe failure must not latch permanent unavailability.
+ *
+ * These assert the SHARED seam (`createAvailabilityChecker` + the availability
+ * policy), which is what knip, madge, jscpd and every other spawn-probed client
+ * resolve through. Per-client wiring is covered in
+ * `availability-latching-clients.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	classifyProbeFailure,
+	createAvailabilityLatch,
+	describeUnavailability,
+	HOST_STALL_COOLDOWN_MS,
+	startHostStallSampler,
+	TRANSIENT_BASE_COOLDOWN_MS,
+	transientRetryDelayMs,
+} from "../../../../clients/dispatch/runners/utils/availability-policy.ts";
+import {
+	createAvailabilityChecker,
+	resetDispatchAvailabilityState,
+} from "../../../../clients/dispatch/runners/utils/runner-helpers.ts";
+
+const { logLatencySpy } = vi.hoisted(() => ({ logLatencySpy: vi.fn() }));
+
+vi.mock("../../../../clients/latency-logger.js", () => ({
+	logLatency: logLatencySpy,
+	getLastLoggedPhase: () => undefined,
+}));
+
+vi.mock("../../../../clients/sessionstart-logger.js", () => ({
+	logSessionStart: vi.fn(),
+}));
+
+vi.mock("../../../../clients/safe-spawn.js", () => ({
+	safeSpawn: vi.fn(() => ({ stdout: "", stderr: "", status: 1 })),
+	safeSpawnAsync: vi.fn(async () => ({ stdout: "", stderr: "", status: 1 })),
+}));
+
+vi.mock("../../../../clients/installer/index.js", () => ({
+	ensureTool: vi.fn(async () => null),
+	isSpawnableCommand: vi.fn(async () => true),
+	resetPathWalkMemo: vi.fn(),
+	getToolEnvironment: vi.fn(async () => ({ ...process.env })),
+}));
+
+const timeoutResult = () => ({
+	stdout: "",
+	stderr: "",
+	status: null,
+	error: Object.assign(new Error("Process timed out after 5000ms"), {}),
+	failure: "timeout" as const,
+	spawnFailure: { kind: "timeout" } as never,
+});
+
+const missingResult = () => ({
+	stdout: "",
+	stderr: "",
+	status: null,
+	error: Object.assign(new Error("spawn missing ENOENT"), { code: "ENOENT" }),
+	failure: "spawn" as const,
+	spawnFailure: { kind: "tool-not-found" } as never,
+});
+
+const okResult = () => ({ stdout: "1.0.0", stderr: "", status: 0 });
+
+const decisions = () =>
+	logLatencySpy.mock.calls
+		.map((call) => call[0])
+		.filter((entry) => entry?.phase === "availability_decision");
+
+describe("availability seam: transient failures do not latch (#1467)", () => {
+	beforeEach(async () => {
+		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
+		vi.mocked(safeSpawnMod.safeSpawnAsync).mockReset();
+		logLatencySpy.mockReset();
+		resetDispatchAvailabilityState();
+		vi.useFakeTimers({ toFake: ["Date"] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("re-probes after the cooldown and reports the tool available again", async () => {
+		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
+		vi.mocked(safeSpawnMod.safeSpawnAsync).mockResolvedValue(timeoutResult());
+		const checker = createAvailabilityChecker("slowtool");
+
+		expect(await checker.isAvailableAsync(process.cwd())).toBe(false);
+		expect(checker.getOutcome(process.cwd())).toBe("transient");
+
+		// Inside the cooldown the verdict is reused — no probe storm.
+		expect(await checker.isAvailableAsync(process.cwd())).toBe(false);
+		expect(safeSpawnMod.safeSpawnAsync).toHaveBeenCalledTimes(1);
+
+		// After the cooldown the seam must ask again. On current (pre-fix) code
+		// the cached `false` is permanent and this stays false forever.
+		vi.setSystemTime(new Date(Date.now() + TRANSIENT_BASE_COOLDOWN_MS + 1));
+		vi.mocked(safeSpawnMod.safeSpawnAsync).mockResolvedValue(okResult());
+		expect(await checker.isAvailableAsync(process.cwd())).toBe(true);
+		expect(safeSpawnMod.safeSpawnAsync).toHaveBeenCalledTimes(2);
+		expect(checker.getOutcome(process.cwd())).toBe("success");
+		expect(checker.getCommand(process.cwd())).toBe("slowtool");
+	});
+
+	it("still latches a genuine missing tool and never re-probes it", async () => {
+		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
+		vi.mocked(safeSpawnMod.safeSpawnAsync).mockResolvedValue(missingResult());
+		const checker = createAvailabilityChecker("absenttool");
+
+		expect(await checker.isAvailableAsync(process.cwd())).toBe(false);
+		expect(checker.getOutcome(process.cwd())).toBe("missing");
+
+		vi.setSystemTime(new Date(Date.now() + 10 * TRANSIENT_BASE_COOLDOWN_MS));
+		expect(await checker.isAvailableAsync(process.cwd())).toBe(false);
+		expect(safeSpawnMod.safeSpawnAsync).toHaveBeenCalledTimes(1);
+		expect(checker.getVerdict(process.cwd())).toMatchObject({
+			outcome: "missing",
+			cause: "not-found",
+			latched: true,
+			retryAtMs: 0,
+		});
+	});
+
+	it("escalates the cooldown so a sick machine is not re-probed every call", () => {
+		expect(transientRetryDelayMs(1, "probe-timeout")).toBe(
+			TRANSIENT_BASE_COOLDOWN_MS,
+		);
+		expect(transientRetryDelayMs(2, "probe-timeout")).toBe(
+			TRANSIENT_BASE_COOLDOWN_MS * 2,
+		);
+		expect(transientRetryDelayMs(50, "probe-timeout")).toBe(300_000);
+		// A host stall is not evidence about the tool, so its retry stays short
+		// and never escalates.
+		expect(transientRetryDelayMs(7, "host-stall")).toBe(HOST_STALL_COOLDOWN_MS);
+	});
+
+	it("writes one availability decision record per verdict", async () => {
+		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
+		vi.mocked(safeSpawnMod.safeSpawnAsync).mockResolvedValue(timeoutResult());
+		const checker = createAvailabilityChecker("telemetrytool", "", ["--version"], {
+			probeTimeout: 1500,
+		});
+
+		await checker.isAvailableAsync(process.cwd());
+		await checker.isAvailableAsync(process.cwd());
+
+		// One decision, not one per call: the record marks a decision, not a hit.
+		expect(decisions()).toHaveLength(1);
+		expect(decisions()[0]).toMatchObject({
+			type: "phase",
+			phase: "availability_decision",
+			metadata: {
+				tool: "telemetrytool",
+				verdict: "unavailable",
+				outcome: "transient",
+				cause: "probe-timeout",
+				latched: false,
+				retryAfterMs: TRANSIENT_BASE_COOLDOWN_MS,
+				budgetMs: 1500,
+			},
+		});
+		expect(decisions()[0].metadata.hostStallMs).toBeTypeOf("number");
+	});
+
+	it("resolves through a fastPath without spawning, and says so in telemetry", async () => {
+		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
+		const checker = createAvailabilityChecker("fasttool", "", ["--version"], {
+			fastPath: () => "/managed/bin/fasttool",
+		});
+
+		expect(await checker.isAvailableAsync(process.cwd())).toBe(true);
+		expect(safeSpawnMod.safeSpawnAsync).not.toHaveBeenCalled();
+		expect(decisions()[0].metadata).toMatchObject({
+			tool: "fasttool",
+			verdict: "available",
+			cause: "fast-path",
+		});
+	});
+});
+
+describe("availability policy: cause taxonomy and messages (#1467)", () => {
+	it("blames the host, not the tool, when a stall overlapped the probe window", () => {
+		expect(classifyProbeFailure(timeoutResult(), { hostStallMs: 0 })).toEqual({
+			outcome: "transient",
+			cause: "probe-timeout",
+		});
+		expect(classifyProbeFailure(timeoutResult(), { hostStallMs: 4618 })).toEqual({
+			outcome: "transient",
+			cause: "host-stall",
+		});
+		expect(classifyProbeFailure(missingResult(), { hostStallMs: 4618 })).toEqual({
+			outcome: "missing",
+			cause: "not-found",
+		});
+	});
+
+	it("words a timed-out probe as a timeout, never as a missing install", () => {
+		const transient = describeUnavailability({
+			tool: "Knip",
+			installHint: "npm install -D knip",
+			outcome: "transient",
+			cause: "probe-timeout",
+			elapsedMs: 5528,
+			retryAfterMs: 30_000,
+		});
+		expect(transient).toContain("timed out");
+		expect(transient).toContain("5528ms");
+		expect(transient).not.toContain("Install with");
+
+		const missing = describeUnavailability({
+			tool: "Knip",
+			installHint: "npm install -D knip",
+			outcome: "missing",
+			cause: "not-found",
+		});
+		expect(missing).toBe("Knip not available. Install with: npm install -D knip");
+	});
+
+	it("names the host stall in the message when the loop, not the tool, stalled", () => {
+		const message = describeUnavailability({
+			tool: "Knip",
+			installHint: "npm install -D knip",
+			outcome: "transient",
+			cause: "host-stall",
+			elapsedMs: 5528,
+		});
+		expect(message).toContain("event loop stalled");
+		expect(message).not.toContain("Install with");
+	});
+
+	it("measures a synchronous host block against the probe window", () => {
+		vi.useRealTimers();
+		const sampler = startHostStallSampler(50);
+		const until = Date.now() + 600;
+		while (Date.now() < until) {
+			// Deliberate synchronous block: this is exactly what expires a
+			// host-side probe budget while the child is still healthy.
+		}
+		expect(sampler.stop()).toBeGreaterThan(400);
+	});
+});
+
+describe("availability latch: shared client-side memo (#1467)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers({ toFake: ["Date"] });
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns null (re-probe) once a transient verdict's cooldown expires", () => {
+		const latch = createAvailabilityLatch();
+		expect(latch.read()).toBeNull();
+
+		const delay = latch.noteUnavailable("transient", "probe-timeout");
+		expect(delay).toBe(TRANSIENT_BASE_COOLDOWN_MS);
+		expect(latch.read()).toBe(false);
+
+		vi.setSystemTime(new Date(Date.now() + delay + 1));
+		expect(latch.read()).toBeNull();
+	});
+
+	it("keeps a durable verdict for the whole session", () => {
+		const latch = createAvailabilityLatch();
+		expect(latch.noteUnavailable("missing", "not-found")).toBe(0);
+		vi.setSystemTime(new Date(Date.now() + 3_600_000));
+		expect(latch.read()).toBe(false);
+		expect(latch.getCause()).toBe("not-found");
+	});
+
+	it("clears transient escalation once the tool answers", () => {
+		const latch = createAvailabilityLatch();
+		latch.noteUnavailable("transient", "probe-timeout");
+		latch.noteAvailable();
+		expect(latch.read()).toBe(true);
+		expect(latch.noteUnavailable("transient", "probe-timeout")).toBe(
+			TRANSIENT_BASE_COOLDOWN_MS,
+		);
+	});
+});

--- a/tests/clients/latency-logger.test.ts
+++ b/tests/clients/latency-logger.test.ts
@@ -55,6 +55,18 @@ describe("getLastLoggedPhase (loop_block attribution, #1122/#1123)", () => {
 		expect(getLastLoggedPhase()?.phase).toBe("word_index_build");
 	});
 
+	it("does not let an availability decision win block attribution (#1467)", () => {
+		logLatency({ type: "phase", phase: "knip", filePath: "<x>", durationMs: 5 });
+		logLatency({
+			type: "phase",
+			phase: "availability_decision",
+			filePath: "<pi-lens>",
+			durationMs: 5528,
+			metadata: { tool: "knip", cause: "host-stall" },
+		});
+		expect(getLastLoggedPhase()?.phase).toBe("knip");
+	});
+
 	it("ignores non-phase entries", () => {
 		logLatency({ type: "phase", phase: "cascade", filePath: "<x>", durationMs: 1 });
 		logLatency({ type: "runner", filePath: "a.ts", durationMs: 1, runnerId: "biome" });

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -571,6 +571,97 @@ describe("knip turn-end backoff", () => {
 			env.cleanup();
 		}
 	});
+
+	it("keeps the last good result when a run fails (#925 / #1467)", async () => {
+		const env = setupTestEnvironment("pi-lens-knip-cache-keep-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const cacheManager = new CacheManager(false);
+			const filePath = path.join(env.tmpDir, "src/current.ts");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, "export const x = 1;\n");
+			cacheManager.addModifiedRange(
+				filePath,
+				{ start: 1, end: 1 },
+				false,
+				env.tmpDir,
+			);
+			const good = {
+				...EMPTY_KNIP_RESULT,
+				success: true,
+				issues: [{ type: "export", name: "unusedThing", file: "src/old.ts" }],
+				unusedExports: [
+					{ type: "export", name: "unusedThing", file: "src/old.ts" },
+				],
+				summary: "Found 1 issues",
+			};
+			cacheManager.writeCache("knip", good, env.tmpDir);
+
+			await handleTurnEnd(
+				makeTurnEndDeps(runtime, cacheManager, {
+					ctxCwd: env.tmpDir,
+					knipClient: {
+						ensureAvailable: async () => false,
+						analyze: async () => ({
+							...EMPTY_KNIP_RESULT,
+							success: false,
+							failureKind: "unavailable-transient",
+							summary: "Knip availability probe timed out after 5528ms.",
+						}),
+					},
+				}),
+			);
+
+			// Pre-fix, this 194-byte failure record replaced the real findings and
+			// every reader afterwards served the failure as the answer.
+			const cached = cacheManager.readCache<typeof good>("knip", env.tmpDir);
+			expect(cached?.data.success).toBe(true);
+			expect(cached?.data.issues).toHaveLength(1);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("does not back off when the cached failure was an availability verdict", async () => {
+		const env = setupTestEnvironment("pi-lens-knip-availability-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const cacheManager = new CacheManager(false);
+			const filePath = path.join(env.tmpDir, "src/current.ts");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, "export const x = 1;\n");
+			cacheManager.addModifiedRange(
+				filePath,
+				{ start: 1, end: 1 },
+				false,
+				env.tmpDir,
+			);
+			cacheManager.writeCache(
+				"knip",
+				{
+					...EMPTY_KNIP_RESULT,
+					success: false,
+					failureKind: "unavailable-transient",
+					summary: "Knip availability probe timed out after 5528ms.",
+				},
+				env.tmpDir,
+			);
+			const analyze = vi.fn(async () => EMPTY_KNIP_RESULT);
+
+			await handleTurnEnd(
+				makeTurnEndDeps(runtime, cacheManager, {
+					ctxCwd: env.tmpDir,
+					knipClient: { ensureAvailable: async () => true, analyze },
+				}),
+			);
+
+			// knip never ran, so there is nothing to back off from — and backing
+			// off on the word "timed out" is how a probe verdict became permanent.
+			expect(analyze).toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+		}
+	});
 });
 
 // ── Call-graph impact delta persistence (#179 / #533) ────────────────────────


### PR DESCRIPTION
Closes #1467.

## Problem

knip reported "not available — install with `npm install -D knip`" for weeks while it was installed and healthy. The message named the wrong cause, and the state was permanent for the session.

Two defects compounded. The availability probe latched *any* failure, including a timeout, into a permanent unavailable verdict — so one slow first run under load disabled the tool until restart. And the message rendered every failure as a missing install, so the one signal a reader had pointed at the wrong problem and invited a fix that would not have helped.

The same latch sat in front of madge, govulncheck, and vulture.

## Change

A timed-out probe is now retried after a short wait instead of latching; only a genuine negative (the tool is really not there) is remembered. The message distinguishes a timeout from a missing install. A failed run keeps the last good cached findings rather than overwriting them with nothing, so a transient failure no longer looks like a clean result.

The policy lives in one place, `availability-policy.ts`, and the four clients share it rather than each carrying their own copy of the rule.

## Observability

`availability_decision` is new in `latency.log` and records every probe verdict with its cause and timing. This is the record that did not exist: for weeks the only externally visible signal was a message asserting the wrong cause, and nothing distinguished "probed and absent" from "probe timed out" from "cached from an earlier decision". Those are now separate causes on separate rows, so the failure this fixes would be a single grep next time.

The phase is bookkeeping about a probe rather than host work, and its duration is often zero, so it joins `LAST_PHASE_EXCLUDED` — otherwise it would absorb `loop_block` attribution from whatever actually stalled the loop, which is frequently the very thing that expired the probe.

## Verification

Build, lint, and changelog validation clean. 59 tests across the touched files, including new coverage for the transient-probe latch, the cache-retention policy, and the session-scoped decision cache.
