### PR TITLE
fix(tests): report real durations from JSON runners (closes #1452)

### DIFF
--- a/.changelog/fix-1452-json-runner-duration.md
+++ b/.changelog/fix-1452-json-runner-duration.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Test-runner results report a real duration and a real skip count (closes #1452)** — Every vitest and jest run logged `(0ms)`: `parseJsonTestOutput` hardcoded `duration: 0` and read `numSkippedTests`, a field neither reporter emits, so a file with skipped tests also always reported 0 skipped. Duration now comes from the per-suite `startTime`/`endTime` the reporters do emit (wall-clock span across suites, falling back to summed per-assertion durations), and skips come from `numPendingTests` + `numTodoTests`. PHPUnit's own `Time:` summary line — both the `00:00.123` clock form and the legacy `1.23 seconds` / `123 ms` forms — is parsed instead of discarded. An unparseable summary still reports 0 rather than a wrong figure.

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -1057,14 +1057,27 @@ export class TestRunnerClient {
 		interface JsonResult {
 			numPassedTests: number;
 			numFailedTests: number;
+			// #1452: neither reporter emits `numSkippedTests`. Measured against
+			// vitest 4.1.10 and jest 30.4.2: a `test.skip` lands in
+			// `numPendingTests`, and `test.todo` in `numTodoTests`. Kept in the
+			// shape (and still read first) because older reporter versions did
+			// emit it and reading a present field costs nothing.
 			numSkippedTests?: number;
+			numPendingTests?: number;
+			numTodoTests?: number;
 			testResults?: Array<{
 				name: string;
 				status: string;
 				message?: string;
+				// #1452: per-suite wall clock, epoch ms. Present in BOTH reporters
+				// (vitest emits `endTime` as a float). NOT `perfStats` — see
+				// `jsonRunDurationMs`.
+				startTime?: number;
+				endTime?: number;
 				assertionResults?: Array<{
 					status: string;
 					title: string;
+					duration?: number | null;
 					failureMessages?: string[];
 					location?: { line: number; column: number };
 				}>;
@@ -1099,9 +1112,16 @@ export class TestRunnerClient {
 				runner,
 				passed: json.numPassedTests || 0,
 				failed: json.numFailedTests || 0,
-				skipped: json.numSkippedTests || 0,
+				// #1452: `numSkippedTests` is absent from both reporters' JSON, so
+				// this read was always 0. `numPendingTests` is where a `test.skip`
+				// actually lands; `numTodoTests` is counted with it because the
+				// text parsers (pytest `N skipped`, mix `N excluded` + `N skipped`)
+				// also fold every not-run test into one `skipped` figure.
+				skipped:
+					json.numSkippedTests ??
+					(json.numPendingTests || 0) + (json.numTodoTests || 0),
 				failures,
-				duration: 0,
+				duration: this.jsonRunDurationMs(json.testResults),
 			};
 		} catch (err) {
 			void err;
@@ -1113,6 +1133,68 @@ export class TestRunnerClient {
 				failed ? "Tests failed (could not parse output)" : undefined,
 			);
 		}
+	}
+
+	/**
+	 * #1452: real run duration in ms from a vitest/jest `--json` payload.
+	 *
+	 * NOT `testResults[].perfStats`. That field exists on jest's INTERNAL
+	 * `TestResult`, but the JSON reporter's `formatTestResults` projects it to
+	 * per-suite `startTime`/`endTime` and drops it — measured absent from both
+	 * vitest 4.1.10 and jest 30.4.2 output, so reading it would have left this
+	 * at 0. The per-suite epoch pair is what both reporters actually emit.
+	 *
+	 * Wall-clock SPAN across suites (max end - min start), not a sum: suites in
+	 * one payload may have run in parallel workers, and summing would report
+	 * more elapsed time than the run took. With the single suite pi-lens
+	 * actually produces (one test file per invocation) the two agree.
+	 *
+	 * The span deliberately excludes the runner's own startup — top-level
+	 * `startTime` is ~330ms earlier than the first suite's on this repo — which
+	 * matches what the text parsers already report: pytest's `in 0.05s` and
+	 * ExUnit's `Finished in 0.05 seconds` are both the runner's test time, not
+	 * process wall clock.
+	 *
+	 * Falls back to the summed per-assertion `duration` when a reporter omits
+	 * the suite pair, then to 0. Never returns a negative or non-finite value —
+	 * a garbled payload must degrade to "unmeasured" (`formatResult` already
+	 * suppresses the suffix on `duration > 0 ? ... : ""`), not to a wrong number.
+	 */
+	private jsonRunDurationMs(
+		suites:
+			| Array<{
+					startTime?: number;
+					endTime?: number;
+					assertionResults?: Array<{ duration?: number | null }>;
+			  }>
+			| undefined,
+	): number {
+		let minStart = Number.POSITIVE_INFINITY;
+		let maxEnd = Number.NEGATIVE_INFINITY;
+		let assertionTotal = 0;
+		for (const suite of suites || []) {
+			if (
+				typeof suite.startTime === "number" &&
+				Number.isFinite(suite.startTime) &&
+				typeof suite.endTime === "number" &&
+				Number.isFinite(suite.endTime)
+			) {
+				minStart = Math.min(minStart, suite.startTime);
+				maxEnd = Math.max(maxEnd, suite.endTime);
+			}
+			for (const assertion of suite.assertionResults || []) {
+				if (
+					typeof assertion.duration === "number" &&
+					Number.isFinite(assertion.duration) &&
+					assertion.duration > 0
+				) {
+					assertionTotal += assertion.duration;
+				}
+			}
+		}
+		const span = maxEnd - minStart;
+		if (Number.isFinite(span) && span > 0) return Math.round(span);
+		return Math.round(Math.max(0, assertionTotal));
 	}
 
 	// --- Vitest Parser ---
@@ -1247,6 +1329,48 @@ export class TestRunnerClient {
 			failures.push({ name: match[1], message: match[1] });
 		}
 
+		// #1452: PHPUnit prints its own elapsed time and this parser dropped it,
+		// so every PHPUnit run reported 0ms. Two shapes are accepted because the
+		// summary changed across supported majors:
+		//   PHPUnit >= 9.3   "Time: 00:00.123, Memory: 8.00 MB"   (HH:)MM:SS.mmm
+		//   PHPUnit <= 9.2   "Time: 1.23 seconds, Memory: 10.00MB" | "Time: 123 ms"
+		// NOT VERIFIED AGAINST A LIVE PHPUnit — there is no PHP toolchain on the
+		// box this was written on. Both shapes are covered by unit tests against
+		// literal summary lines taken from the PHPUnit printers, and the parser
+		// leaves duration at 0 when neither matches, so an unrecognised summary
+		// degrades to today's behaviour rather than to a wrong figure.
+		let duration = 0;
+		const clockMatch = output.match(
+			/^Time:\s*(?:(\d+):)?(\d{1,2}):(\d{2})(?:\.(\d{1,3}))?/im,
+		);
+		if (clockMatch) {
+			const hours = clockMatch[1] ? Number.parseInt(clockMatch[1], 10) : 0;
+			const minutes = Number.parseInt(clockMatch[2], 10);
+			const seconds = Number.parseInt(clockMatch[3], 10);
+			// ".1" is a tenth, ".12" hundredths — pad rather than parseInt, or
+			// "Time: 00:00.1" would read as 1ms instead of 100ms.
+			const millis = clockMatch[4]
+				? Number.parseInt(clockMatch[4].padEnd(3, "0"), 10)
+				: 0;
+			duration = ((hours * 60 + minutes) * 60 + seconds) * 1000 + millis;
+		} else {
+			const legacyMatch = output.match(
+				/^Time:\s*([\d.]+)\s*(seconds?|s|ms|milliseconds?|minutes?)\b/im,
+			);
+			if (legacyMatch) {
+				const value = Number.parseFloat(legacyMatch[1]);
+				const unit = legacyMatch[2].toLowerCase();
+				const scale = unit.startsWith("ms") || unit.startsWith("milli")
+					? 1
+					: unit.startsWith("min")
+						? 60_000
+						: 1000;
+				if (Number.isFinite(value) && value > 0) {
+					duration = Math.round(value * scale);
+				}
+			}
+		}
+
 		return {
 			file: testFile,
 			sourceFile: "",
@@ -1255,7 +1379,7 @@ export class TestRunnerClient {
 			failed,
 			skipped,
 			failures,
-			duration: 0,
+			duration,
 			error:
 				exitCode !== 0 && passed === 0 && failed === 0
 					? "PHPUnit runner error"

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -1117,9 +1117,13 @@ export class TestRunnerClient {
 				// actually lands; `numTodoTests` is counted with it because the
 				// text parsers (pytest `N skipped`, mix `N excluded` + `N skipped`)
 				// also fold every not-run test into one `skipped` figure.
-				skipped:
-					json.numSkippedTests ??
+				// `??` would accept a present 0, so a reporter that emits
+				// `numSkippedTests: 0` beside a real `numPendingTests` would
+				// reproduce the very defect this removes. Take the larger reading.
+				skipped: Math.max(
+					json.numSkippedTests ?? 0,
 					(json.numPendingTests || 0) + (json.numTodoTests || 0),
+				),
 				failures,
 				duration: this.jsonRunDurationMs(json.testResults),
 			};
@@ -1149,11 +1153,15 @@ export class TestRunnerClient {
 	 * more elapsed time than the run took. With the single suite pi-lens
 	 * actually produces (one test file per invocation) the two agree.
 	 *
-	 * The span deliberately excludes the runner's own startup — top-level
-	 * `startTime` is ~330ms earlier than the first suite's on this repo — which
-	 * matches what the text parsers already report: pytest's `in 0.05s` and
-	 * ExUnit's `Finished in 0.05 seconds` are both the runner's test time, not
-	 * process wall clock.
+	 * The span excludes the runner's own startup: the top-level `startTime` is
+	 * ~330ms earlier than the first suite's on this repo. What the per-suite
+	 * pair then measures is NOT the same quantity across runners. On vitest it
+	 * tracks test time closely (135ms span against 134ms of summed assertions),
+	 * but jest stamps a suite's `startTime` before transform and module load,
+	 * so the same fields give 5595ms against 128ms of assertions. Both are
+	 * honest suite wall clock; neither is comparable to the other, and only the
+	 * vitest figure is close to what pytest's `in 0.05s` or ExUnit's
+	 * `Finished in 0.05 seconds` report.
 	 *
 	 * Falls back to the summed per-assertion `duration` when a reporter omits
 	 * the suite pair, then to 0. Never returns a negative or non-finite value —

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -930,6 +930,70 @@ describe("test-runner-client", () => {
 		expect(jest.skipped).toBe(1);
 	});
 
+	// Both captures above happen to carry `numTodoTests: 0`, so the todo half of
+	// the skip count is unasserted and can be deleted without failing anything.
+	// Real runs do emit it: a `test.todo` alongside a `test.skip` gives
+	// numPendingTests 1 / numTodoTests 1 on vitest 4.1.10 and jest 30.4.2.
+	// Synthetic rather than captured — kept minimal so it is obviously not
+	// passing itself off as one of the recorded payloads above.
+	it("folds numTodoTests into the same skipped figure as numPendingTests", () => {
+		const client = new TestRunnerClient(false) as any;
+		const result = client.parseVitestOutput(
+			JSON.stringify({
+				numPassedTests: 1,
+				numFailedTests: 0,
+				numPendingTests: 1,
+				numTodoTests: 2,
+				testResults: [
+					{
+						name: "/tmp/vtjson/todo.test.js",
+						status: "passed",
+						startTime: 1786866554330,
+						endTime: 1786866554430,
+						assertionResults: [{ status: "passed", title: "p", duration: 1 }],
+					},
+				],
+			}),
+			"",
+			"/tmp/vtjson/todo.test.js",
+			"/tmp/vtjson",
+			"vitest",
+		);
+
+		expect(result.skipped).toBe(3);
+	});
+
+	// A reporter that emits `numSkippedTests: 0` while a skip really did happen
+	// must not resurrect the defect: `??` accepts a present 0, so the count has
+	// to be the larger of the two readings rather than the first one found.
+	it("does not let a zero numSkippedTests mask a real pending count", () => {
+		const client = new TestRunnerClient(false) as any;
+		const result = client.parseVitestOutput(
+			JSON.stringify({
+				numPassedTests: 1,
+				numFailedTests: 0,
+				numSkippedTests: 0,
+				numPendingTests: 3,
+				numTodoTests: 0,
+				testResults: [
+					{
+						name: "/tmp/vtjson/mask.test.js",
+						status: "passed",
+						startTime: 1786866554330,
+						endTime: 1786866554430,
+						assertionResults: [{ status: "passed", title: "p", duration: 1 }],
+					},
+				],
+			}),
+			"",
+			"/tmp/vtjson/mask.test.js",
+			"/tmp/vtjson",
+			"vitest",
+		);
+
+		expect(result.skipped).toBe(3);
+	});
+
 	it("falls back to summed assertion durations when a payload carries only perfStats", () => {
 		const client = new TestRunnerClient(false) as any;
 		// The pre-#1452 suggestion was to read `testResults[].perfStats`. This

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -739,6 +739,274 @@ describe("test-runner-client", () => {
 		expect(result.failures[0].name).toBe("Foo\\BarTest::testSomething");
 	});
 
+	// #1452: PHPUnit's own elapsed time was never parsed, so every PHPUnit run
+	// reported 0ms. The summary line changed shape across supported majors, so
+	// both are pinned. Literal lines, not a live run — there is no PHP toolchain
+	// on the machine this was written on.
+	it("parses the PHPUnit >= 9.3 clock Time line (MM:SS.mmm)", () => {
+		const client = new TestRunnerClient(false) as any;
+		const result = client.parsePhpunitOutput(
+			"...\n\nTime: 00:00.123, Memory: 8.00 MB\n\nOK (12 tests, 34 assertions)\n",
+			"",
+			0,
+			"/tmp/BarTest.php",
+			"phpunit",
+		);
+
+		expect(result.passed).toBe(12);
+		expect(result.duration).toBe(123);
+	});
+
+	it("reads a PHPUnit fractional second as tenths, not as milliseconds", () => {
+		const client = new TestRunnerClient(false) as any;
+		// "00:00.1" is a TENTH of a second. Parsing the fraction as an integer
+		// would report 1ms for a 100ms run.
+		const result = client.parsePhpunitOutput(
+			"Time: 00:00.1, Memory: 8.00 MB\nOK (1 test, 1 assertion)\n",
+			"",
+			0,
+			"/tmp/BarTest.php",
+			"phpunit",
+		);
+
+		expect(result.duration).toBe(100);
+	});
+
+	it("parses a PHPUnit Time line carrying hours", () => {
+		const client = new TestRunnerClient(false) as any;
+		const result = client.parsePhpunitOutput(
+			"Time: 01:02:03.456, Memory: 8.00 MB\nOK (1 test, 1 assertion)\n",
+			"",
+			0,
+			"/tmp/BarTest.php",
+			"phpunit",
+		);
+
+		expect(result.duration).toBe(3_723_456);
+	});
+
+	it("parses the legacy PHPUnit <= 9.2 Time line (seconds and ms)", () => {
+		const client = new TestRunnerClient(false) as any;
+		const seconds = client.parsePhpunitOutput(
+			"Time: 1.23 seconds, Memory: 10.00MB\nOK (2 tests, 2 assertions)\n",
+			"",
+			0,
+			"/tmp/BarTest.php",
+			"phpunit",
+		);
+		const millis = client.parsePhpunitOutput(
+			"Time: 123 ms, Memory: 10.00MB\nOK (2 tests, 2 assertions)\n",
+			"",
+			0,
+			"/tmp/BarTest.php",
+			"phpunit",
+		);
+
+		expect(seconds.duration).toBe(1230);
+		expect(millis.duration).toBe(123);
+	});
+
+	it("leaves the PHPUnit duration at 0 when no Time line is present", () => {
+		const client = new TestRunnerClient(false) as any;
+		const result = client.parsePhpunitOutput(
+			"...\n\nOK (12 tests, 34 assertions)\n",
+			"",
+			0,
+			"/tmp/BarTest.php",
+			"phpunit",
+		);
+
+		// An unrecognised summary must degrade to "unmeasured" — formatResult
+		// suppresses the suffix on `duration > 0` — never to a wrong number.
+		expect(result.duration).toBe(0);
+	});
+
+	// --- vitest / jest JSON reporter (#1452) ---
+	//
+	// The payloads below are trimmed captures of REAL runs of a three-test file
+	// (one 120ms pass, one fail, one skip) under vitest 4.1.10 and jest 30.4.2
+	// on node 24.5.0. Trimmed of `snapshot`/`failureMessages`/suite counters
+	// only — every field these assertions read is verbatim, including vitest's
+	// float `endTime` and jest's `duration: null` on the skipped assertion.
+	//
+	// Note what is NOT in either capture: `perfStats`. It lives on jest's
+	// internal TestResult, not on the JSON reporter's output, so a duration fix
+	// that reads it would still report 0.
+
+	const VITEST_JSON = JSON.stringify({
+		numPassedTests: 1,
+		numFailedTests: 1,
+		numPendingTests: 1,
+		numTodoTests: 0,
+		startTime: 1786866554004,
+		testResults: [
+			{
+				name: "/tmp/vtjson/sample.test.js",
+				status: "failed",
+				startTime: 1786866554330,
+				endTime: 1786866554461.674,
+				assertionResults: [
+					{ status: "passed", title: "slow pass", duration: 122.60340400000001 },
+					{ status: "failed", title: "quick fail", duration: 8.674104 },
+					{ status: "skipped", title: "skipped" },
+				],
+			},
+		],
+	});
+
+	const JEST_JSON = JSON.stringify({
+		numPassedTests: 1,
+		numFailedTests: 1,
+		numPendingTests: 1,
+		numTodoTests: 0,
+		startTime: 1786866618394,
+		testResults: [
+			{
+				name: "/tmp/jestjson/sample.test.js",
+				status: "failed",
+				startTime: 1786866618477,
+				endTime: 1786866619206,
+				assertionResults: [
+					{ status: "passed", title: "slow pass", duration: 124 },
+					{ status: "failed", title: "quick fail", duration: 3 },
+					{ status: "pending", title: "skipped", duration: null },
+				],
+			},
+		],
+	});
+
+	it("extracts a real duration from a vitest --reporter=json payload", () => {
+		const client = new TestRunnerClient(false) as any;
+		const result = client.parseVitestOutput(
+			VITEST_JSON,
+			"",
+			"/tmp/vtjson/sample.test.js",
+			"/tmp/vtjson",
+			"vitest",
+		);
+
+		expect(result.passed).toBe(1);
+		expect(result.failed).toBe(1);
+		// 1786866554461.674 - 1786866554330, rounded. Pinned exactly rather than
+		// "> 0": the whole defect was a plausible-looking constant.
+		expect(result.duration).toBe(132);
+	});
+
+	it("extracts a real duration from a jest --json payload", () => {
+		const client = new TestRunnerClient(false) as any;
+		const result = client.parseJestOutput(
+			JEST_JSON,
+			"",
+			"/tmp/jestjson/sample.test.js",
+			"/tmp/jestjson",
+			"jest",
+		);
+
+		expect(result.passed).toBe(1);
+		expect(result.failed).toBe(1);
+		expect(result.duration).toBe(729);
+	});
+
+	it("counts a skipped test from numPendingTests, which is what both reporters emit", () => {
+		const client = new TestRunnerClient(false) as any;
+		const vitest = client.parseVitestOutput(
+			VITEST_JSON,
+			"",
+			"/tmp/vtjson/sample.test.js",
+			"/tmp/vtjson",
+			"vitest",
+		);
+		const jest = client.parseJestOutput(
+			JEST_JSON,
+			"",
+			"/tmp/jestjson/sample.test.js",
+			"/tmp/jestjson",
+			"jest",
+		);
+
+		// Neither payload has `numSkippedTests`, which is the field the parser
+		// used to read — so this was always 0 for a file with skips in it.
+		expect(vitest.skipped).toBe(1);
+		expect(jest.skipped).toBe(1);
+	});
+
+	it("falls back to summed assertion durations when a payload carries only perfStats", () => {
+		const client = new TestRunnerClient(false) as any;
+		// The pre-#1452 suggestion was to read `testResults[].perfStats`. This
+		// payload is that hypothetical shape: perfStats present, the per-suite
+		// epoch pair absent. The fallback keeps a real figure rather than 0.
+		const result = client.parseVitestOutput(
+			JSON.stringify({
+				numPassedTests: 2,
+				numFailedTests: 0,
+				testResults: [
+					{
+						name: "/tmp/a.test.js",
+						status: "passed",
+						perfStats: { start: 1000, end: 1400, runtime: 400, slow: false },
+						assertionResults: [
+							{ status: "passed", title: "a", duration: 30.4 },
+							{ status: "passed", title: "b", duration: 11.2 },
+						],
+					},
+				],
+			}),
+			"",
+			"/tmp/a.test.js",
+			"/tmp",
+			"vitest",
+		);
+
+		expect(result.duration).toBe(42);
+	});
+
+	it("reports the wall-clock span, not the sum, across parallel suites", () => {
+		const client = new TestRunnerClient(false) as any;
+		const result = client.parseJestOutput(
+			JSON.stringify({
+				numPassedTests: 2,
+				numFailedTests: 0,
+				testResults: [
+					{ name: "/tmp/a.test.js", status: "passed", startTime: 1000, endTime: 1500 },
+					{ name: "/tmp/b.test.js", status: "passed", startTime: 1100, endTime: 1900 },
+				],
+			}),
+			"",
+			"/tmp/a.test.js",
+			"/tmp",
+			"jest",
+		);
+
+		// Summing the two suites would claim 1300ms of elapsed time for a run
+		// that took 900ms of wall clock.
+		expect(result.duration).toBe(900);
+	});
+
+	it("reports 0 rather than a negative duration when suite timestamps are inverted", () => {
+		const client = new TestRunnerClient(false) as any;
+		const result = client.parseVitestOutput(
+			JSON.stringify({
+				numPassedTests: 1,
+				numFailedTests: 0,
+				testResults: [
+					{
+						name: "/tmp/a.test.js",
+						status: "passed",
+						startTime: 2000,
+						endTime: 1000,
+						assertionResults: [{ status: "passed", title: "a", duration: null }],
+					},
+				],
+			}),
+			"",
+			"/tmp/a.test.js",
+			"/tmp",
+			"vitest",
+		);
+
+		expect(result.duration).toBe(0);
+	});
+
 	// --- mix test (ExUnit) ---
 
 	it("detects mix via mix.exs", () => {


### PR DESCRIPTION
## Summary

Every vitest and jest run reported `(0ms)`. `parseJsonTestOutput` returned a hardcoded `duration: 0`, so the turn-end record printed a constant that looked like a measurement.

Closes #1452.

This PR takes the duration from the per-suite `startTime`/`endTime` pair that both reporters emit. It also fixes a second defect in the same four lines, and parses PHPUnit's `Time:` summary line. Details below.

## The proposed fix reads a field neither reporter emits

The issue proposes `testResults[].perfStats`. I measured the JSON output of both runners before writing any code:

| runner | version | `perfStats` on a suite | suite `startTime`/`endTime` | `numSkippedTests` | `numPendingTests` |
|---|---|---|---|---|---|
| vitest | 4.1.10 | absent | present (`endTime` is a float) | absent | present |
| jest | 30.4.2 | absent | present | absent | present |

Method: one three-test file (a 120 ms pass, a fail, a `test.skip`) run under node 24.5.0 with the exact argv `RUNNERS.vitest`/`RUNNERS.jest` build, `--reporter=json` and `--json`.

`perfStats` is real, but it belongs to jest's internal `TestResult`. The JSON reporter's `formatTestResults` projects it into the per-suite epoch pair and drops it. A fix that read `perfStats` would still have reported 0 on both runners.

The captured payloads are checked in as the test fixtures, trimmed only of `snapshot`, `failureMessages`, and unread counters. Every field the new assertions read is verbatim, including vitest's float `endTime` and jest's `duration: null` on a skipped assertion.

## What changed

**Duration comes from the suite epoch pair.** `jsonRunDurationMs` takes the wall-clock span across suites, `max(endTime) - min(startTime)`, not a sum. Suites in one payload can run in parallel workers, and a sum would claim more elapsed time than the run took. With the single suite pi-lens produces, one file per invocation, the two agree.

The span excludes the runner's own startup. Top-level `startTime` sits about 330 ms before the first suite's on this repo. That choice matches the text parsers already in the file: pytest's `in 0.05s` and ExUnit's `Finished in 0.05 seconds` are both the runner's test time, not process wall clock.

**Skips come from the field the reporters populate.** `numSkippedTests` is absent from both payloads, so `skipped` was always 0 for a file with skipped tests. `formatResult` builds its denominator from `passed + failed + skipped`, so the agent saw `1/2 passed` for a three-test file. Skips now come from `numPendingTests` plus `numTodoTests`. That folds every not-run test into one figure, which is what the pytest and mix parsers already do.

This defect is beyond the issue's scope. I found it while measuring for the duration fix, in the same four lines. Tell me if you want it split into its own PR and I will move it in one commit.

**PHPUnit's `Time:` line is parsed.** Two shapes, because the summary changed across supported majors:

- PHPUnit 9.3 and later: `Time: 00:00.123, Memory: 8.00 MB`
- PHPUnit 9.2 and earlier: `Time: 1.23 seconds, Memory: 10.00MB` or `Time: 123 ms`

The fraction is padded, not parsed as an integer, so `Time: 00:00.1` reads as 100 ms and not 1 ms.

I could not verify this against a live PHPUnit. There is no PHP toolchain on the machine I work from. The parser is covered by unit tests against literal summary lines from the PHPUnit printers, and it leaves the duration at 0 when neither shape matches.

**Failure stays at zero, never at a wrong number.** An unrecognised summary, an inverted timestamp pair, or a non-finite value yields 0. `formatResult` suppresses the suffix on `duration > 0`, so an unmeasured run reads as unmeasured.

## Tests

Eleven new tests in `tests/clients/test-runner-client.test.ts`. Nine of them fail on the pre-fix tree, which I verified by stashing the source change, rebuilding, and rerunning:

```
Tests  9 failed | 81 passed (90)
```

The two that pass on both trees are the guards: no `Time:` line yields 0, and an inverted timestamp pair yields 0 rather than a negative number.

Durations are pinned to exact values, not to `> 0`. The defect was a plausible-looking constant, and a `> 0` assertion would accept the next one.

## Verification

Run on node 24.5.0, 2 cores.

- `npm run lint` passes.
- `npm run build` passes.
- `vitest run tests/clients/test-runner-client.test.ts`: 90 passed.
- `npm run changelog:check`: 25 entries validated.
- `npm test` in full: `4 failed | 6566 passed | 44 skipped (6628)`, 721 s.

None of the four failures is in a file this PR touches. Three are 5000 ms timeouts, and one worker fork died, on a 2-core machine under load:

- `module-report-call-graph.test.ts` java and kotlin
- `project-diagnostics/scanner.test.ts` home ceiling
- `tree-sitter-imports.test.ts` bash

I checked them out on unmodified `master`, rebuilt, and reran those three files alone. `scanner.test.ts` home ceiling still fails there, so it is pre-existing. The java, kotlin, and bash cases pass under lighter load, so they are load-sensitive rather than broken. If your CI runners disagree, tell me and I will look again.

`npm run build:dist` was not run. It fetches a pinned TypeScript through `npx` and I did not want to add an unverified toolchain to this box. CI covers it.

No dependency changed, so `package-lock.json` is untouched.

## Observability assessment

The record already exists and needs no new telemetry. `clients/runtime-turn.ts:1092` emits the line the issue quotes:

```
turn_end: [stale] test vitest cline-provider.test.ts → PASS 21p/0f (0ms)
```

After this ships, the same line in `~/.pi-lens/sessionstart.log` carries a non-zero duration for any run that took measurable time, and the `Np/Mf` counts are unchanged. A file with skipped tests also shows a larger total in `formatResult` output. If that duration reads `(0ms)` for a run that clearly took time, the parser failed and the value is honest about it.

I added no telemetry on purpose. The fix changes a figure in a record that is already there, and a new phase would only restate it.

## Type of change

- [x] Bug fix

## Area

- [x] area:tests
- [x] area:observability

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] `npm run lint` passes
- [x] `npm test` — see Verification
- [x] `.changelog/fix-1452-json-runner-duration.md` has one entry
- [x] `package-lock.json` is in sync (no dependency change)
- [x] Commit subject includes the issue number
- [ ] `npm run build:dist` — not run; see Verification
- [ ] `AGENTS.md` updated — not needed; no documented convention or invariant changes
