### PR TITLE
fix(dispatch): report real runner durations, say unmeasured otherwise (#1479, #1480)

### DIFF
--- a/.changelog/fix-1479-1480-runner-durations.md
+++ b/.changelog/fix-1479-1480-runner-durations.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Test-run durations are reported honestly (closes [#1479](https://github.com/apmantza/pi-lens/issues/1479), closes [#1480](https://github.com/apmantza/pi-lens/issues/1480))** — The turn-end log printed `(0ms)` for a run that was never timed, so an absent measurement was indistinguishable from a sub-millisecond one; it now prints `(unmeasured)`. Behind it, the generic runner parser read an elapsed time only for go and hardcoded `0` for the rest. Cargo, dotnet/vstest, maven/surefire, rspec, and minitest durations are now parsed from the summary block each runner already prints. Gradle stays unmeasured on purpose: its console output carries no test elapsed time, and the build time is not the same number. Multi-class maven runs are also scored by the surefire aggregate rather than by their first test class.

--- a/clients/run-duration.ts
+++ b/clients/run-duration.ts
@@ -1,0 +1,48 @@
+/**
+ * #1479: one place decides whether a test run was actually timed.
+ *
+ * `TestResult.duration` carries two different facts in one number. A run that
+ * took 40ms reports 40. A run with no suite timestamps, an `emptyResult`, or a
+ * runner error also reports a number — 0 — and the turn-end log printed that
+ * as `(0ms)`, which reads as a measurement of zero. A reader could not tell
+ * "measured 0" from "never measured", which is the confusion #1452 was
+ * reported for and the reason #1480 is otherwise unverifiable from the log.
+ *
+ * Every parser in `test-runner-client.ts` degrades to 0 when it cannot find an
+ * elapsed time (see `jsonRunDurationMs` and `parsePhpunitOutput`, both #1452),
+ * so 0 is the agreed sentinel for "unmeasured". This module is the only place
+ * that spells out what that sentinel means, so the log line and the
+ * agent-facing `formatResult` cannot drift apart.
+ *
+ * Kept in its own module rather than exported from `test-runner-client.ts`:
+ * `runtime-turn.ts` needs it on the hot turn-end path, and the client is
+ * deliberately loaded lazily (`bootstrap.ts` dynamic-imports it), so a value
+ * import from there would drag the whole runner into startup.
+ */
+
+/** True only for a duration that represents a real measurement. */
+export function isMeasuredDuration(
+	duration: number | null | undefined,
+): duration is number {
+	return (
+		typeof duration === "number" && Number.isFinite(duration) && duration > 0
+	);
+}
+
+/**
+ * Normalise a parsed elapsed time to the `TestResult.duration` contract.
+ *
+ * Negative, NaN, and non-finite inputs collapse to the unmeasured sentinel: a
+ * garbled summary must degrade to "we did not measure this", never to a wrong
+ * number.
+ */
+export function toMeasuredDurationMs(duration: number): number {
+	return isMeasuredDuration(duration) ? Math.round(duration) : 0;
+}
+
+/** Render a duration for a log line: `123ms`, or `unmeasured` when absent. */
+export function formatRunDurationMs(
+	duration: number | null | undefined,
+): string {
+	return isMeasuredDuration(duration) ? `${Math.round(duration)}ms` : "unmeasured";
+}

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -63,6 +63,7 @@ import { RUNTIME_CONFIG } from "./runtime-config.js";
 import { isSubagentSession } from "./subagent-mode.js";
 import type { RuntimeCoordinator } from "./runtime-coordinator.js";
 import type { TurnStateOwner } from "./cache-manager.js";
+import { formatRunDurationMs } from "./run-duration.js";
 import type { TestResult, TestRunnerClient } from "./test-runner-client.js";
 import {
 	MAX_ADVISORY_AFFECTED_FILES,
@@ -1110,7 +1111,10 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 						const summary =
 							error && passed === 0 && failed === 0
 								? `error: ${error}`
-								: `${failed > 0 ? "FAIL" : "PASS"} ${passed}p/${failed}f (${duration}ms)`;
+								// #1479: `(0ms)` read as a measurement of zero for a run
+								// that was never timed. `formatRunDurationMs` prints
+								// `(unmeasured)` for the absent case instead.
+								: `${failed > 0 ? "FAIL" : "PASS"} ${passed}p/${failed}f (${formatRunDurationMs(duration)})`;
 						dbg(
 							`turn_end: ${stale ? "[stale] " : ""}test ${runner} ${shortFile} → ${summary}`,
 						);

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -17,6 +17,7 @@ import * as path from "node:path";
 import { minimatch } from "./deps/minimatch.js";
 import { detectFileRole } from "./file-role.js";
 import { findGlobalBinary } from "./package-manager.js";
+import { isMeasuredDuration, toMeasuredDurationMs } from "./run-duration.js";
 import { safeSpawn, safeSpawnAsync } from "./safe-spawn.js";
 
 // --- Types ---
@@ -1460,6 +1461,153 @@ export class TestRunnerClient {
 
 	// --- Generic text parser for non-JSON runners ---
 
+	/**
+	 * #1480: elapsed time for the runners `parseGenericRunnerOutput` handles.
+	 *
+	 * Before this, only go's `ok  pkg  0.25s` was read and every other runner
+	 * reported a hardcoded 0 — a constant that the turn-end log then printed as
+	 * a measurement. Each runner below prints its elapsed time in the same
+	 * summary block this parser already regexes for pass/fail counts.
+	 *
+	 * One parser serves all runners, so every pattern is anchored to the line
+	 * that carries the counts (`^test result:`, the `Failed:/Passed:` summary,
+	 * `^Finished in`). That matters for the same reason #1452's PHPUnit `Time:`
+	 * pattern is anchored: an unanchored /m alternation takes the FIRST match
+	 * over stdout+stderr, and a failure diff quoting "Finished in ..." would
+	 * beat the real summary. Probes run in a fixed order and the first measured
+	 * value wins, so one runner's output cannot be scored by another's pattern.
+	 *
+	 * Formats and how each was verified:
+	 *
+	 * - go — `ok  example.com/pkg  0.253s`. Pre-existing pattern, unchanged
+	 *   apart from the shared finite/positive guard.
+	 *
+	 * - cargo — `test result: ok. 3 passed; 0 failed; 1 ignored; 0 measured;
+	 *   0 filtered out; finished in 0.253s`. NOT VERIFIED AGAINST A LIVE CARGO
+	 *   RUN — this box has no MSVC linker, so `cargo test` cannot link. Format
+	 *   read out of the libtest printer shipped with the local rustc 1.94.1:
+	 *   `library/test/src/formatters/pretty.rs` builds `"; finished in
+	 *   {exec_time}"` and `library/test/src/time.rs` renders `TestSuiteExecTime`
+	 *   as `{:.2}s`. Older rustc omits the suffix entirely; that degrades to
+	 *   unmeasured.
+	 *
+	 * - dotnet/vstest — `Failed: 1, Passed: 2, Skipped: 0, Total: 3, Duration:
+	 *   1 m 30 s - t.dll (net8.0)`. NOT VERIFIED AGAINST A LIVE `dotnet test` —
+	 *   NuGet restore has no network here. Format read out of the
+	 *   vstest.console.dll shipped with the local .NET SDK 8.0.423, which holds
+	 *   the literal `{0} - Failed: {1}, Passed: {2}, Skipped: {3}, Total: {4},
+	 *   Duration: {5}` next to the unit literals `" h"`, `" m"`, `" s"`,
+	 *   `" ms"`, `"< 1 ms"`. The duration is a space-joined token list, so it
+	 *   is summed rather than read as one number. `< 1 ms` carries no number
+	 *   and stays unmeasured.
+	 *
+	 * - maven/surefire — `Tests run: 4, Failures: 0, Errors: 0, Skipped: 0,
+	 *   Time elapsed: 0.05 s -- in com.example.AppTest`. NOT VERIFIED AGAINST A
+	 *   LIVE MAVEN — no mvn on this box. Summed across the per-class lines,
+	 *   because surefire prints `Time elapsed` per test class and its final
+	 *   `Results:` total carries no time. `[INFO] Total time: 3.4 s` is
+	 *   deliberately NOT used: that is whole-build wall clock including compile,
+	 *   which would report a wrong number rather than none. Surefire 2.x wrote
+	 *   `sec` where 3.x writes `s`; both are accepted.
+	 *
+	 * - rspec — `Finished in 0.32394 seconds (files took 0.49427 seconds to
+	 *   load)`. VERIFIED against a live rspec-core 3.13.6 run on ruby 3.4.10.
+	 *   The minutes form (`Finished in 2 minutes 15.14 seconds`) comes from
+	 *   `RSpec::Core::Formatters::Helpers.format_duration` in the same
+	 *   installed gem; rspec never prints hours. Load time trails the run time
+	 *   on the same line and must not be read instead of it.
+	 *
+	 * - minitest — `Finished in 0.254594s, 7.8557 runs/s, 7.8557 assertions/s.`
+	 *   VERIFIED against a live minitest 5.25.4 run on ruby 3.4.10. The format
+	 *   string is `"Finished in %.6fs, ..."` in minitest.rb, always seconds.
+	 *
+	 * - gradle — deliberately left unmeasured. Gradle's console summary
+	 *   (`4 tests completed, 1 failed`) carries no elapsed time, and `BUILD
+	 *   SUCCESSFUL in 3s` is whole-build wall clock including compile and
+	 *   dependency resolution. Reporting that as test time would be a wrong
+	 *   number; #1479 makes the absence legible in the log instead.
+	 */
+	private parseGenericRunnerDuration(output: string): number {
+		// go: "ok  	example.com/pkg	0.253s"
+		const goSummary = output.match(/ok\s+\S+\s+([\d.]+)s/m);
+		if (goSummary) {
+			const ms = toMeasuredDurationMs(Number.parseFloat(goSummary[1]) * 1000);
+			if (ms > 0) return ms;
+		}
+
+		// cargo: "...; 0 filtered out; finished in 0.25s"
+		const cargoTime = output.match(
+			/^test result:.*?;\s*finished in\s+([\d.]+)\s*s\b/im,
+		);
+		if (cargoTime) {
+			const ms = toMeasuredDurationMs(Number.parseFloat(cargoTime[1]) * 1000);
+			if (ms > 0) return ms;
+		}
+
+		// dotnet/vstest: "..., Total: 3, Duration: 1 m 30 s - t.dll (net8.0)".
+		// Anchored to the counts line, and the tail stops at the " - <dll>"
+		// separator so an assembly name can never be scanned for units.
+		const dotnetTime = output.match(
+			/Failed:\s*\d+,\s*Passed:\s*\d+,\s*Skipped:\s*\d+,\s*Total:\s*\d+,\s*Duration:\s*([^\r\n-]+)/i,
+		);
+		// `< 1 ms` is vstest's "too fast to name a number". Summing the tokens
+		// would report 1ms, a number it never claimed.
+		if (dotnetTime && !/^\s*</.test(dotnetTime[1])) {
+			let total = 0;
+			// "ms" before "m", or "250 ms" scores as 250 minutes.
+			const units: Record<string, number> = {
+				ms: 1,
+				s: 1000,
+				m: 60_000,
+				h: 3_600_000,
+			};
+			for (const token of dotnetTime[1].matchAll(
+				/([\d.]+)\s*(ms|h|m|s)\b/gi,
+			)) {
+				total += Number.parseFloat(token[1]) * units[token[2].toLowerCase()];
+			}
+			const ms = toMeasuredDurationMs(total);
+			if (ms > 0) return ms;
+		}
+
+		// maven/surefire: summed across per-class "Time elapsed" lines.
+		let surefireTotal = 0;
+		for (const line of output.matchAll(
+			/^.*Tests run:\s*\d+,.*?Time elapsed:\s*([\d.]+)\s*(?:s|sec|secs|seconds)\b.*$/gim,
+		)) {
+			const seconds = Number.parseFloat(line[1]);
+			if (Number.isFinite(seconds) && seconds > 0) surefireTotal += seconds;
+		}
+		if (surefireTotal > 0) {
+			const ms = toMeasuredDurationMs(surefireTotal * 1000);
+			if (ms > 0) return ms;
+		}
+
+		// rspec: "Finished in 2 minutes 15.14 seconds (files took 0.5 ...)"
+		const rspecTime = output.match(
+			/^Finished in\s+(?:([\d.]+)\s+minutes?\s+)?([\d.]+)\s+seconds?/im,
+		);
+		if (rspecTime) {
+			const minutes = rspecTime[1] ? Number.parseFloat(rspecTime[1]) : 0;
+			const ms = toMeasuredDurationMs(
+				minutes * 60_000 + Number.parseFloat(rspecTime[2]) * 1000,
+			);
+			if (ms > 0) return ms;
+		}
+
+		// minitest: "Finished in 0.254594s, 7.8557 runs/s, ..."
+		const minitestTime = output.match(/^Finished in\s+([\d.]+)s\s*,/im);
+		if (minitestTime) {
+			const ms = toMeasuredDurationMs(
+				Number.parseFloat(minitestTime[1]) * 1000,
+			);
+			if (ms > 0) return ms;
+		}
+
+		// gradle and anything unrecognised: unmeasured, not zero-as-measurement.
+		return 0;
+	}
+
 	private parseGenericRunnerOutput(
 		stdout: string,
 		stderr: string,
@@ -1473,12 +1621,7 @@ export class TestRunnerClient {
 		let passed = 0;
 		let failed = exitCode === 0 ? 0 : 1;
 		let skipped = 0;
-		let duration = 0;
-
-		const goSummary = output.match(/ok\s+\S+\s+([\d.]+)s/m);
-		if (goSummary) {
-			duration = Number.parseFloat(goSummary[1]) * 1000;
-		}
+		const duration = this.parseGenericRunnerDuration(output);
 
 		const cargoSummary = output.match(
 			/test result:\s+\w+\.\s+(\d+)\s+passed;\s+(\d+)\s+failed;\s+(\d+)\s+ignored;/i,
@@ -1498,9 +1641,17 @@ export class TestRunnerClient {
 			skipped = Number.parseInt(dotnetSummary[3], 10);
 		}
 
-		const mavenSummary = output.match(
-			/Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+),\s*Skipped:\s*(\d+)/i,
-		);
+		// #1480 (adjacent): surefire prints one `Tests run:` line PER TEST CLASS
+		// and then the aggregate under `Results:`. Taking the first match scored
+		// a multi-class run by its first class alone — a two-class run with a
+		// failure in the second class reported 0 failures. The aggregate is
+		// last, and for a single-class run first and last are the same line.
+		const mavenMatches = [
+			...output.matchAll(
+				/Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+),\s*Skipped:\s*(\d+)/gi,
+			),
+		];
+		const mavenSummary = mavenMatches[mavenMatches.length - 1];
 		if (mavenSummary) {
 			const total = Number.parseInt(mavenSummary[1], 10);
 			const failures = Number.parseInt(mavenSummary[2], 10);
@@ -1594,8 +1745,11 @@ export class TestRunnerClient {
 			return ""; // No tests to report
 		}
 
-		const durationStr =
-			result.duration > 0 ? ` (${(result.duration / 1000).toFixed(2)}s)` : "";
+		// #1479: same "was this measured at all" question the turn-end log asks,
+		// answered from the same predicate so the two surfaces cannot drift.
+		const durationStr = isMeasuredDuration(result.duration)
+			? ` (${(result.duration / 1000).toFixed(2)}s)`
+			: "";
 
 		if (result.failed === 0) {
 			return `[Tests] ✓ ${result.passed}/${total} passed${durationStr} — ${result.runner}`;

--- a/tests/clients/run-duration.test.ts
+++ b/tests/clients/run-duration.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatRunDurationMs,
+	isMeasuredDuration,
+	toMeasuredDurationMs,
+} from "../../clients/run-duration.js";
+
+// #1479: `TestResult.duration` uses 0 as the "never measured" sentinel. These
+// pin the sentinel's meaning, because two surfaces (the turn-end log and
+// `formatResult`) now read it from here.
+describe("test duration reporting (#1479)", () => {
+	it("renders a measured duration in ms", () => {
+		expect(formatRunDurationMs(253)).toBe("253ms");
+		expect(formatRunDurationMs(1)).toBe("1ms");
+	});
+
+	it("renders the unmeasured sentinel as words, never as 0ms", () => {
+		expect(formatRunDurationMs(0)).toBe("unmeasured");
+	});
+
+	it("renders a garbled duration as unmeasured rather than a wrong number", () => {
+		expect(formatRunDurationMs(-1)).toBe("unmeasured");
+		expect(formatRunDurationMs(Number.NaN)).toBe("unmeasured");
+		expect(formatRunDurationMs(Number.POSITIVE_INFINITY)).toBe("unmeasured");
+		expect(formatRunDurationMs(null)).toBe("unmeasured");
+		expect(formatRunDurationMs(undefined)).toBe("unmeasured");
+	});
+
+	it("rounds a fractional duration to whole milliseconds", () => {
+		expect(formatRunDurationMs(40.6)).toBe("41ms");
+		// Rounds, does not truncate: 40.6 is nearer 41ms.
+		expect(toMeasuredDurationMs(40.6)).toBe(41);
+		expect(toMeasuredDurationMs(40.4)).toBe(40);
+	});
+
+	it("collapses every non-measurement to the 0 sentinel", () => {
+		expect(toMeasuredDurationMs(-7)).toBe(0);
+		expect(toMeasuredDurationMs(Number.NaN)).toBe(0);
+		expect(toMeasuredDurationMs(Number.POSITIVE_INFINITY)).toBe(0);
+		expect(toMeasuredDurationMs(0)).toBe(0);
+	});
+
+	it("agrees with the predicate the formatters branch on", () => {
+		expect(isMeasuredDuration(0)).toBe(false);
+		expect(isMeasuredDuration(0.5)).toBe(true);
+		expect(isMeasuredDuration(Number.NaN)).toBe(false);
+	});
+});

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -1787,6 +1787,92 @@ describe("turn_end test runner — stale results are cached, not discarded", () 
 	});
 });
 
+// ── #1479: the turn-end log separates "measured 0" from "unmeasured" ─────────
+
+describe("turn_end test runner — duration reporting (#1479)", () => {
+	async function runAndCaptureTurnEndLog(duration: number, failed: number) {
+		const env = setupTestEnvironment("pi-lens-test-duration-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "duration-session" });
+			const cacheManager = new CacheManager(false);
+
+			const srcFile = path.join(env.tmpDir, "src/foo.ts");
+			const testFile = path.join(env.tmpDir, "src/foo.test.ts");
+			fs.mkdirSync(path.dirname(srcFile), { recursive: true });
+			fs.writeFileSync(srcFile, "export const x = 1;\n");
+			fs.writeFileSync(testFile, "test('x', () => {});\n");
+			cacheManager.addModifiedRange(
+				srcFile,
+				{ start: 1, end: 1 },
+				false,
+				env.tmpDir,
+				"duration-session",
+			);
+
+			const dbg = vi.fn();
+			await handleTurnEnd(
+				makeTurnEndDeps(runtime, cacheManager, {
+					ctxCwd: env.tmpDir,
+					dbg,
+					testRunnerClient: {
+						getTestRunTarget: () => ({
+							testFile,
+							runner: "cargo",
+							config: {} as any,
+							strategy: "related" as const,
+						}),
+						runTestFileAsync: async () => ({
+							file: testFile,
+							sourceFile: srcFile,
+							runner: "cargo",
+							passed: 1,
+							failed,
+							skipped: 0,
+							failures: [],
+							duration,
+						}),
+						formatResult: () => "[Tests] ✗ — cargo",
+					},
+				}),
+			);
+			await new Promise((r) => setImmediate(r));
+
+			return (dbg.mock.calls as string[][])
+				.map((c) => c[0])
+				.filter((line) => line.startsWith("turn_end: test "));
+		} finally {
+			env.cleanup();
+		}
+	}
+
+	it("prints (unmeasured), not (0ms), when the run was never timed", async () => {
+		const lines = await runAndCaptureTurnEndLog(0, 0);
+
+		// The whole point: a reader must not be able to mistake an absent
+		// measurement for a run that took under a millisecond.
+		expect(lines).toEqual([
+			"turn_end: test cargo foo.test.ts → PASS 1p/0f (unmeasured)",
+		]);
+	});
+
+	it("prints the exact measured duration when the run was timed", async () => {
+		const lines = await runAndCaptureTurnEndLog(253, 1);
+
+		expect(lines).toEqual([
+			"turn_end: test cargo foo.test.ts → FAIL 1p/1f (253ms)",
+		]);
+	});
+
+	it("treats a garbled negative duration as unmeasured, not as a number", async () => {
+		const lines = await runAndCaptureTurnEndLog(-7, 0);
+
+		expect(lines).toEqual([
+			"turn_end: test cargo foo.test.ts → PASS 1p/0f (unmeasured)",
+		]);
+	});
+});
+
 // ── #628: cascade-neighbor test companions are also fired ─────────────────────
 
 describe("turn_end test runner — cascade neighbors get their own test companion run", () => {

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -62,6 +62,311 @@ describe("test-runner-client", () => {
 		expect(result.failed).toBe(1);
 	});
 
+	// #1479: the agent-facing surface reads the same "was this measured"
+	// predicate the turn-end log reads, so the two cannot drift.
+	describe("formatResult duration suffix (#1479)", () => {
+		const format = (duration: number) =>
+			new TestRunnerClient(false).formatResult({
+				file: "/tmp/foo.test.ts",
+				sourceFile: "",
+				runner: "vitest",
+				passed: 2,
+				failed: 0,
+				skipped: 0,
+				failures: [],
+				duration,
+			});
+
+		it("prints the suffix for a measured run", () => {
+			expect(format(1230)).toContain(" (1.23s)");
+		});
+
+		it("omits the suffix for an unmeasured run", () => {
+			expect(format(0)).not.toContain("(");
+		});
+
+		it("omits the suffix for a non-finite duration rather than printing it", () => {
+			expect(format(Number.POSITIVE_INFINITY)).not.toContain("(");
+			expect(format(Number.NaN)).not.toContain("(");
+		});
+	});
+
+	// #1480: `parseGenericRunnerOutput` hardcoded duration 0 for every runner
+	// but go, so the turn-end log printed a constant that looked like a
+	// measurement. Durations are pinned to EXACT values here: a `> 0` assertion
+	// would accept the next plausible constant, which is how this defect class
+	// survived #1452's sweep in the first place.
+	describe("generic runner durations (#1480)", () => {
+		const parse = (output: string, runner: string, exitCode = 0) =>
+			(new TestRunnerClient(false) as any).parseGenericRunnerOutput(
+				output,
+				"",
+				exitCode,
+				`/tmp/test.${runner}`,
+				runner,
+			);
+
+		// Format from the libtest printer shipped with the local rustc 1.94.1
+		// (`formatters/pretty.rs` + `time.rs`), NOT a live `cargo test` — this
+		// box has no MSVC linker, so cargo cannot link a test binary.
+		it("parses the cargo test-result summary duration", () => {
+			const result = parse(
+				[
+					"running 3 tests",
+					"test tests::ok1 ... ok",
+					"test tests::ign ... ignored",
+					"",
+					"test result: ok. 2 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.25s",
+					"",
+				].join("\n"),
+				"cargo",
+			);
+
+			expect(result.passed).toBe(2);
+			expect(result.skipped).toBe(1);
+			expect(result.duration).toBe(250);
+		});
+
+		it("ignores a cargo panic message that mimics the summary suffix", () => {
+			// First-match hazard: the assertion diff below carries the same
+			// "; finished in ..." text the summary does. The pattern is anchored
+			// to the start of the `test result:` line so the diff cannot win.
+			const result = parse(
+				[
+					"thread 'tests::bad' panicked at src/lib.rs:9:",
+					'  left: "; finished in 99.9s"',
+					"",
+					"test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.50s",
+				].join("\n"),
+				"cargo",
+				101,
+			);
+
+			expect(result.duration).toBe(500);
+		});
+
+		it("leaves cargo unmeasured when the summary carries no elapsed time", () => {
+			// Older rustc omits the suffix entirely.
+			const result = parse(
+				"test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out",
+				"cargo",
+			);
+
+			expect(result.passed).toBe(2);
+			expect(result.duration).toBe(0);
+		});
+
+		// Format from the vstest.console.dll shipped with the local .NET SDK
+		// 8.0.423 (summary literal plus the " h"/" m"/" s"/" ms"/"< 1 ms" unit
+		// literals), NOT a live `dotnet test` — NuGet restore has no network.
+		it("parses the dotnet/vstest summary duration in ms", () => {
+			const result = parse(
+				"Failed!  - Failed:     1, Passed:     2, Skipped:     0, Total:     3, Duration: 250 ms - t.dll (net8.0)",
+				"dotnet",
+				1,
+			);
+
+			expect(result.failed).toBe(1);
+			expect(result.passed).toBe(2);
+			expect(result.duration).toBe(250);
+		});
+
+		it("sums the dotnet/vstest multi-unit duration token list", () => {
+			// vstest joins unit tokens with spaces rather than printing one
+			// number, so "1 m 30 s" is 90s and "2 s 345 ms" is 2345ms.
+			const minutes = parse(
+				"Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3, Duration: 1 m 30 s - t.dll (net8.0)",
+				"dotnet",
+			);
+			const seconds = parse(
+				"Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3, Duration: 2 s 345 ms - t.dll (net8.0)",
+				"dotnet",
+			);
+			const hours = parse(
+				"Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3, Duration: 1 h 2 m - t.dll (net8.0)",
+				"dotnet",
+			);
+
+			expect(minutes.duration).toBe(90_000);
+			expect(seconds.duration).toBe(2345);
+			expect(hours.duration).toBe(3_720_000);
+		});
+
+		it("leaves dotnet unmeasured when vstest reports sub-millisecond", () => {
+			// "< 1 ms" carries no number to report. Claiming 0 would be a
+			// measurement; leaving it unmeasured is the honest record.
+			const result = parse(
+				"Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: < 1 ms - t.dll (net8.0)",
+				"dotnet",
+			);
+
+			expect(result.passed).toBe(1);
+			expect(result.duration).toBe(0);
+		});
+
+		// Surefire format from its console reporter, NOT a live maven run —
+		// there is no mvn on this box.
+		it("sums the maven/surefire per-class Time elapsed lines", () => {
+			const result = parse(
+				[
+					"[INFO] Running com.example.AppTest",
+					"[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.05 s -- in com.example.AppTest",
+					"[INFO] Running com.example.OtherTest",
+					"[INFO] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.125 s -- in com.example.OtherTest",
+					"[INFO] Results:",
+					"[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0",
+					"[INFO] Total time:  9.876 s",
+				].join("\n"),
+				"maven",
+				1,
+			);
+
+			// 50 + 125. NOT 9876: "[INFO] Total time" is whole-build wall clock
+			// including compile, and reporting it as test time would be a wrong
+			// number rather than an absent one.
+			expect(result.duration).toBe(175);
+			expect(result.failed).toBe(1);
+		});
+
+		it("scores a multi-class maven run by the aggregate, not the first class", () => {
+			// Adjacent first-match defect the duration fixture exposed: surefire
+			// prints a `Tests run:` line per class, so reading the FIRST one
+			// reported the second class's failure as a pass.
+			const result = parse(
+				[
+					"[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.05 s -- in com.example.AppTest",
+					"[INFO] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.125 s -- in com.example.OtherTest",
+					"[INFO] Results:",
+					"[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0",
+				].join("\n"),
+				"maven",
+				1,
+			);
+
+			expect(result.failed).toBe(1);
+			expect(result.passed).toBe(3);
+		});
+
+		it("accepts the surefire 2.x 'sec' spelling", () => {
+			const result = parse(
+				"Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 sec - in com.example.AppTest",
+				"maven",
+			);
+
+			expect(result.duration).toBe(12);
+		});
+
+		// REAL capture: rspec-core 3.13.6 on ruby 3.4.10.
+		it("parses the rspec Finished-in line", () => {
+			const result = parse(
+				[
+					".F",
+					"",
+					"Finished in 0.32394 seconds (files took 0.49427 seconds to load)",
+					"2 examples, 1 failure",
+				].join("\n"),
+				"rspec",
+				1,
+			);
+
+			expect(result.passed).toBe(1);
+			expect(result.failed).toBe(1);
+			// 323.94ms, NOT the 494.27ms file-load time that trails it on the
+			// same line.
+			expect(result.duration).toBe(324);
+		});
+
+		it("parses the rspec minutes form", () => {
+			// From RSpec::Core::Formatters::Helpers.format_duration in the
+			// installed gem: past 60s it prints "N minutes M.MM seconds".
+			const result = parse(
+				[
+					"Finished in 2 minutes 15.14 seconds (files took 0.5 seconds to load)",
+					"2 examples, 0 failures",
+				].join("\n"),
+				"rspec",
+			);
+
+			expect(result.duration).toBe(135_140);
+		});
+
+		it("ignores an rspec failure diff that mimics the Finished-in line", () => {
+			// First-match hazard: the quoted expectation below would win an
+			// unanchored /m match. The pattern requires the line to START with
+			// "Finished in", which rspec's own summary does and a diff does not.
+			const result = parse(
+				[
+					"Failures:",
+					"",
+					"  1) demo fails",
+					"     Failure/Error: expect(log).to eq 'Finished in 99 seconds'",
+					"",
+					"Finished in 0.32394 seconds (files took 0.49427 seconds to load)",
+					"2 examples, 1 failure",
+				].join("\n"),
+				"rspec",
+				1,
+			);
+
+			expect(result.duration).toBe(324);
+		});
+
+		// REAL capture: minitest 5.25.4 on ruby 3.4.10.
+		it("parses the minitest Finished-in line", () => {
+			const result = parse(
+				[
+					"Run options: --seed 63795",
+					"",
+					"F.",
+					"",
+					"Finished in 0.254594s, 7.8557 runs/s, 7.8557 assertions/s.",
+					"",
+					"2 runs, 2 assertions, 1 failures, 0 errors, 0 skips",
+				].join("\n"),
+				"minitest",
+				1,
+			);
+
+			expect(result.passed).toBe(1);
+			expect(result.failed).toBe(1);
+			expect(result.duration).toBe(255);
+		});
+
+		// Gradle's console summary carries no elapsed time and "BUILD
+		// SUCCESSFUL in 3s" is whole-build wall clock, so this stays unmeasured
+		// on purpose. #1479 makes that absence legible in the log.
+		it("leaves gradle unmeasured rather than borrowing the build time", () => {
+			const result = parse(
+				[
+					"> Task :test FAILED",
+					"4 tests completed, 1 failed",
+					"BUILD FAILED in 3s",
+				].join("\n"),
+				"gradle",
+				1,
+			);
+
+			expect(result.failed).toBe(1);
+			expect(result.passed).toBe(3);
+			expect(result.duration).toBe(0);
+		});
+
+		it("still parses the go package summary duration", () => {
+			const result = parse(
+				"ok  \texample.com/pkg\t0.253s\n",
+				"go",
+			);
+
+			expect(result.duration).toBe(253);
+		});
+
+		it("leaves an unrecognised runner summary unmeasured", () => {
+			const result = parse("everything is fine\n", "somethingelse");
+
+			expect(result.duration).toBe(0);
+		});
+	});
+
 	it("prefers failed-first target when failure cache exists", () => {
 		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 		cleanups.push(cleanup);


### PR DESCRIPTION
Closes #1479. Closes #1480.

## Problem

#1452 fixed the measurement for vitest and jest. The reporting half stayed broken.

The turn-end log rendered `(${duration}ms)` unconditionally, so a runner error, an `emptyResult`, and a run that genuinely took under a millisecond all printed `(0ms)`. A reader could not tell "measured zero" from "never measured". And `parseGenericRunnerOutput` hardcoded `duration = 0` for every runner but go, so cargo, dotnet, maven, rspec, minitest and gradle each printed a constant that looked like a measurement.

## Change

**#1479 first**, because #1480 is unverifiable without it: until the log can say "unmeasured", a fixed runner and a broken one look identical. A new `clients/run-duration.ts` holds the sentinel policy — 0 means unmeasured, and negative, NaN and non-finite collapse to it. The behavioral change in `runtime-turn.ts` is one line.

It is a separate module rather than an export from `test-runner-client.ts` because that client is deliberately lazy-loaded from `bootstrap.ts`; a value import would pull the whole runner onto the startup path.

**#1480** adds one anchored probe per runner. First measured value wins; an unrecognised summary stays unmeasured.

| Runner | How the format was verified |
|---|---|
| rspec | Live run, rspec-core 3.13.6 on ruby 3.4.10 |
| minitest | Live run, minitest 5.25.4 on ruby 3.4.10 |
| cargo | Upstream source only — no MSVC linker here, so `cargo test` cannot link. Read from the libtest printer in local rustc 1.94.1. |
| dotnet/vstest | Upstream binary only — NuGet restore has no network here. Format and unit literals extracted from `vstest.console.dll` in local SDK 8.0.423. |
| maven/surefire | Upstream console format only — no mvn on this box. |
| gradle | **Deliberately left unmeasured.** |
| go | Unchanged, now behind the shared guard. |

Every unverified case says `NOT VERIFIED AGAINST A LIVE ...` in the source comment, following the precedent #1475 set for PHPUnit.

Gradle is the interesting one. Its console summary carries no test elapsed time — `BUILD SUCCESSFUL in 3s` is build wall clock, which includes compilation and would overstate the test run. It stays `(unmeasured)` forever, on purpose. A wrong number is worse than an honest absence, and that is the whole point of #1479.

## Two adjacent defects the fixtures exposed

Both fixed here, both outside the issues as filed:

- Surefire prints `Tests run:` **per test class**, and the old first-match read scored a multi-class run by its first class alone. A failure in the second class reported as zero failures. Now reads the aggregate.
- `formatResult` on a raw `duration > 0` would have printed `(Infinity s)`.

## Observability

The record is `~/.pi-lens/extension.log`, the `turn_end: test <runner> <file> → …` line. No new instrumentation.

Before, an untimed run and a sub-millisecond run were the same bytes. After, a fixed runner reads `PASS 12p/0f (324ms)` and an unfixed one reads `PASS 12p/0f (unmeasured)` — so grepping `turn_end: test` for `(unmeasured)` by runner name enumerates exactly which runners still lack a duration. Gradle will always appear there, which is the intended legible record of "we do not have this number" rather than a silent zero.

## Verification

Build, lint, and changelog validation clean. 185 tests across 5 files, plus the shared-seam siblings of `runtime-turn.ts` (`index-integration`, `cascade-turn-merge`, `packaging`, `build-freshness-guard`, `analyzer-coverage`).

17 mutations, every mutant rebuilt before running — the build-freshness guard makes an unrebuilt sweep read falsely all-red. Zero surviving mutants. Two survivors were caught and dealt with rather than reported as passes: a `Math.trunc` mutant survived a weak `40.4 → 40` assertion until a `40.6 → 41` case was added, and one unit-alternation reorder is a genuine equivalent mutant, killed instead by removing the `\b` it relies on.

Anchoring was tested directly: two tests exist only to prove a cargo panic message and an rspec failure diff cannot impersonate their summary lines, and both die when the anchor is removed.

Full suite not run; CI is authoritative.

## Deliberately left out

`< 1 ms` from vstest reports unmeasured rather than 0. It is a real sub-millisecond measurement, but the sentinel cannot express it and inventing a 0 would re-create #1479. Expressing it needs a third state on `TestResult`.

`parsePytestOutput`, `parseMixTestOutput` and `jsonRunDurationMs` already guard correctly and were not rewired through the shared sentinel, which would widen the diff past both issues. Filed as #1484.
