### PR TITLE
fix(dispatch): stop latching timed-out probes across seven tools (#1476)

### DIFF
--- a/.changelog/fix-1476-availability-latch-siblings.md
+++ b/.changelog/fix-1476-availability-latch-siblings.md
@@ -7,7 +7,10 @@ section: Fixed
   a missing install, the way knip and madge already did. Before this, one stalled
   second at session warm-up latched "tool is not installed" for the life of the
   process, and biome and ast-grep also paid for an auto-install nobody needed. A
-  transient verdict now expires and the tool comes back without a restart, and
-  every verdict is recorded in `latency.log` as `availability_decision` with its
-  cause and timing. A coverage test derived from the source tree keeps the next
-  tool from reintroducing the shape.
+  transient verdict now expires and the tool comes back without a restart, its
+  cooldown escalates on a host that stays sick, and every verdict is recorded in
+  `latency.log` as `availability_decision` with its cause, timing and retry
+  schedule. A structural coverage test parses `clients/` and fails when a new
+  version probe parks its verdict outside the shared policy; the hand-rolled
+  latches that predate it are listed in the test as named, shrink-only gaps
+  rather than being quietly excluded.

--- a/.changelog/fix-1476-availability-latch-siblings.md
+++ b/.changelog/fix-1476-availability-latch-siblings.md
@@ -1,0 +1,13 @@
+---
+section: Fixed
+---
+
+- **A slow first probe no longer disables an installed tool (closes #1476)** —
+  biome, ast-grep, Go, cargo and govulncheck now tell a probe timeout apart from
+  a missing install, the way knip and madge already did. Before this, one stalled
+  second at session warm-up latched "tool is not installed" for the life of the
+  process, and biome and ast-grep also paid for an auto-install nobody needed. A
+  transient verdict now expires and the tool comes back without a restart, and
+  every verdict is recorded in `latency.log` as `availability_decision` with its
+  cause and timing. A coverage test derived from the source tree keeps the next
+  tool from reintroducing the shape.

--- a/clients/biome-client.ts
+++ b/clients/biome-client.ts
@@ -59,6 +59,14 @@ export class BiomeClient {
 	private readonly availabilityLatch = createAvailabilityLatch();
 	/** Cause of the last probe, read when the resolution comes back. */
 	private lastProbeCause: AvailabilityCause | null = null;
+	/**
+	 * Measurements of the last failed probe, held until the latch decides how
+	 * long the verdict lasts. The decision record is emitted after that, so it
+	 * can carry `retryAfterMs` — a latch you can see is worth little if the
+	 * retry schedule is not greppable beside it (#1474).
+	 */
+	private lastProbeElapsedMs = 0;
+	private lastProbeHostStallMs = 0;
 	// Per-cwd cache of the resolved biome binary. Keying by cwd matters in
 	// monorepos where different sub-packages each ship their own biome
 	// installation; sharing one slot across the whole client would cause
@@ -221,16 +229,10 @@ export class BiomeClient {
 		const failureOutcome: Exclude<AvailabilityOutcome, "success"> =
 			outcome === "success" ? "non-installable" : outcome;
 		this.lastProbeCause = cause;
-		logAvailabilityDecision({
-			tool: "biome",
-			verdict: "unavailable",
-			outcome: failureOutcome,
-			cause,
-			elapsedMs,
-			latched: failureOutcome !== "transient",
-			hostStallMs,
-			budgetMs: PROBE_TIMEOUT_MS,
-		});
+		this.lastProbeElapsedMs = elapsedMs;
+		this.lastProbeHostStallMs = hostStallMs;
+		// The record is emitted by `doEnsureAvailable`, once the latch has said how
+		// long this verdict holds.
 		return { outcome: failureOutcome };
 	}
 
@@ -246,14 +248,41 @@ export class BiomeClient {
 		});
 		if (resolved.outcome === "success") {
 			this.availabilityLatch.noteAvailable();
+			// The probe itself logs a clean hit. This arm is the other way to
+			// succeed — the install repaired a durable miss — and it needs its own
+			// record, or "biome went missing and came back" reads as silence.
+			if (this.lastProbeCause !== null && this.lastProbeCause !== "ok") {
+				logAvailabilityDecision({
+					tool: "biome",
+					verdict: "available",
+					outcome: "success",
+					cause: "ok",
+					elapsedMs: this.lastProbeElapsedMs,
+					latched: true,
+					hostStallMs: this.lastProbeHostStallMs,
+					budgetMs: PROBE_TIMEOUT_MS,
+				});
+			}
 			return true;
 		}
 		// A transient probe expires; a durable verdict is remembered for the
 		// session exactly as before.
-		this.availabilityLatch.noteUnavailable(
+		const cause = this.lastProbeCause ?? "not-found";
+		const retryAfterMs = this.availabilityLatch.noteUnavailable(
 			resolved.outcome,
-			this.lastProbeCause ?? "not-found",
+			cause,
 		);
+		logAvailabilityDecision({
+			tool: "biome",
+			verdict: "unavailable",
+			outcome: resolved.outcome,
+			cause,
+			elapsedMs: this.lastProbeElapsedMs,
+			latched: resolved.outcome !== "transient",
+			hostStallMs: this.lastProbeHostStallMs,
+			...(retryAfterMs > 0 && { retryAfterMs }),
+			budgetMs: PROBE_TIMEOUT_MS,
+		});
 		if (resolved.outcome === "transient") {
 			this.log("biome availability probe timed out; will retry (not installing)");
 		}

--- a/clients/biome-client.ts
+++ b/clients/biome-client.ts
@@ -16,7 +16,18 @@ import { getGlobalPiLensDir } from "./file-utils.js";
 import { findGlobalBinary } from "./package-manager.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
 import { biomeConfigArgs } from "./tool-policy.js";
-import { resolveManagedToolClient } from "./dispatch/runners/utils/runner-helpers.js";
+import {
+	type ClientAvailabilityResult,
+	resolveManagedToolClient,
+} from "./dispatch/runners/utils/runner-helpers.js";
+import {
+	type AvailabilityCause,
+	type AvailabilityOutcome,
+	classifyProbeFailure,
+	createAvailabilityLatch,
+	logAvailabilityDecision,
+	startHostStallSampler,
+} from "./dispatch/runners/utils/availability-policy.js";
 
 // --- Types ---
 
@@ -34,8 +45,20 @@ export interface BiomeDiagnostic {
 
 // --- Client ---
 
+const PROBE_TIMEOUT_MS = 10_000;
+
 export class BiomeClient {
-	private biomeAvailable: boolean | null = null;
+	/**
+	 * Availability memo, backed by the shared transient-aware latch (#1476).
+	 *
+	 * Biome is the hot-path formatter: before this, ANY probe failure — a
+	 * timeout included — collapsed to `{ outcome: "missing" }`, which both
+	 * triggered an install and latched `false` for the life of the process. One
+	 * slow first format then disabled formatting until restart.
+	 */
+	private readonly availabilityLatch = createAvailabilityLatch();
+	/** Cause of the last probe, read when the resolution comes back. */
+	private lastProbeCause: AvailabilityCause | null = null;
 	// Per-cwd cache of the resolved biome binary. Keying by cwd matters in
 	// monorepos where different sub-packages each ship their own biome
 	// installation; sharing one slot across the whole client would cause
@@ -132,9 +155,14 @@ export class BiomeClient {
 	 * `ensureInFlight` promise so probing/auto-install isn't duplicated.
 	 * Mirrors the dedupe pattern in `SgRunner` / `KnipClient` /
 	 * `DependencyChecker`.
+	 *
+	 * The memo returns `null` when the last verdict was transient and its
+	 * cooldown expired, which re-enters the probe: "biome is not installed" is a
+	 * fact worth caching, "the probe timed out" is a moment worth retrying.
 	 */
 	async ensureAvailable(): Promise<boolean> {
-		if (this.biomeAvailable !== null) return this.biomeAvailable;
+		const memo = this.availabilityLatch.read();
+		if (memo !== null) return memo;
 		if (this.ensureInFlight) return this.ensureInFlight;
 
 		this.ensureInFlight = this.doEnsureAvailable();
@@ -145,23 +173,91 @@ export class BiomeClient {
 		}
 	}
 
+	/**
+	 * Probe `biome --version` and classify the failure through the shared
+	 * policy. Only a durable verdict (`missing` / `non-installable`) may reach
+	 * the install branch of `resolveManagedToolClient`; a transient one returns
+	 * as `transient`, which that seam passes straight back without installing.
+	 */
+	private async probeBiome(): Promise<ClientAvailabilityResult<true>> {
+		// The probe budget is enforced by a HOST-side timer, so a stalled event
+		// loop expires it while the child is still healthy. Measure the stall
+		// that overlapped the window and let the classifier see it (#1467).
+		const sampler = startHostStallSampler();
+		const startedAt = Date.now();
+		let result: Awaited<ReturnType<typeof this.spawnBiomeAsync>>;
+		let hostStallMs: number;
+		try {
+			result = await this.spawnBiomeAsync(["--version"], PROBE_TIMEOUT_MS);
+		} finally {
+			hostStallMs = sampler.stop();
+		}
+		const elapsedMs = Date.now() - startedAt;
+
+		if (!result.error && result.status === 0) {
+			this.lastProbeCause = "ok";
+			logAvailabilityDecision({
+				tool: "biome",
+				verdict: "available",
+				outcome: "success",
+				cause: "ok",
+				elapsedMs,
+				latched: true,
+				hostStallMs,
+				budgetMs: PROBE_TIMEOUT_MS,
+			});
+			return { outcome: "success", value: true };
+		}
+
+		// `unclassifiedFailureOutcome: "missing"` preserves the pre-#1476
+		// meaning of a plain non-zero exit (npx reporting no biome package):
+		// still "missing", still installable. Only the timeout/abort arm changes.
+		const { outcome, cause } = classifyProbeFailure(result, {
+			hostStallMs,
+			unclassifiedFailureOutcome: "missing",
+		});
+		// `classifyProbeFailure` is typed over the full outcome union but never
+		// returns "success" for a failed probe; narrow it for the seam's type.
+		const failureOutcome: Exclude<AvailabilityOutcome, "success"> =
+			outcome === "success" ? "non-installable" : outcome;
+		this.lastProbeCause = cause;
+		logAvailabilityDecision({
+			tool: "biome",
+			verdict: "unavailable",
+			outcome: failureOutcome,
+			cause,
+			elapsedMs,
+			latched: failureOutcome !== "transient",
+			hostStallMs,
+			budgetMs: PROBE_TIMEOUT_MS,
+		});
+		return { outcome: failureOutcome };
+	}
+
 	private async doEnsureAvailable(): Promise<boolean> {
-		const outcome = await resolveManagedToolClient({
+		const resolved = await resolveManagedToolClient({
 			toolId: "biome",
 			cwd: process.cwd(),
-			probe: async () => {
-				const result = await this.spawnBiomeAsync(["--version"], 10000);
-				return !result.error && result.status === 0
-					? { outcome: "success" as const, value: true }
-					: { outcome: "missing" as const };
-			},
+			probe: () => this.probeBiome(),
 			acceptInstalled: (installedPath) => {
 				this.autoInstalledBinaryPath = installedPath;
 				return true;
 			},
 		});
-		this.biomeAvailable = outcome.outcome === "success";
-		return this.biomeAvailable;
+		if (resolved.outcome === "success") {
+			this.availabilityLatch.noteAvailable();
+			return true;
+		}
+		// A transient probe expires; a durable verdict is remembered for the
+		// session exactly as before.
+		this.availabilityLatch.noteUnavailable(
+			resolved.outcome,
+			this.lastProbeCause ?? "not-found",
+		);
+		if (resolved.outcome === "transient") {
+			this.log("biome availability probe timed out; will retry (not installing)");
+		}
+		return false;
 	}
 
 	/**

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -31,6 +31,12 @@ import { loadPiLensProjectConfig } from "../project-lens-config.js";
 import { RUNTIME_CONFIG, getRunnerTimeoutFloorMs } from "../runtime-config.js";
 import { safeSpawnAsync } from "../safe-spawn.js";
 import { classifyDiagnostic } from "./diagnostic-taxonomy.js";
+import {
+	classifyProbeFailure,
+	logAvailabilityDecision,
+	startHostStallSampler,
+	transientRetryDelayMs,
+} from "./runners/utils/availability-policy.js";
 import type { FactStore } from "./fact-store.js";
 import { applyDispositions } from "../diagnostic-dispositions.js";
 import { applyInlineSuppressions } from "./inline-suppressions.js";
@@ -100,7 +106,29 @@ export function normalizeCacheKey(cmd: string): string {
 	return `session.toolCache.${normalized}`;
 }
 
-async function checkToolAvailability(
+/** Probe budget for the generic `hasTool` availability check, ms. */
+const TOOL_PROBE_TIMEOUT_MS = 5000;
+
+/**
+ * Session fact holding the epoch ms after which a TRANSIENT verdict for a
+ * command may be re-probed. Kept beside the boolean fact so both share the
+ * session's lifetime — no second global to reset (#1476).
+ */
+function transientRetryKey(command: string): string {
+	return `${normalizeCacheKey(command)}.retryAt`;
+}
+
+/**
+ * Is `command` usable right now? Cached per session.
+ *
+ * Latch policy (#1467/#1476): a `false` from a genuine absence is durable and
+ * is remembered for the session. A `false` from a TIMED-OUT probe is not — this
+ * is the highest-traffic availability consumer in the codebase, and caching a
+ * host stall here silently disabled a healthy tool for every later dispatch in
+ * the session. A transient verdict instead holds only for a bounded cooldown,
+ * which also stops a sick host from being re-probed on every dispatch.
+ */
+export async function checkToolAvailability(
 	command: string,
 	facts: FactStore,
 ): Promise<boolean> {
@@ -109,6 +137,8 @@ async function checkToolAvailability(
 	if (cached !== undefined) {
 		return cached;
 	}
+	const retryAt = facts.getSessionFact<number>(transientRetryKey(command));
+	if (retryAt !== undefined && Date.now() < retryAt) return false;
 	// A command that isn't even on disk can't pass a --version probe; the ~μs
 	// stat/PATH walk saves a guaranteed-to-fail spawn round-trip per cold tool.
 	if (!(await isSpawnableCommand(command))) {
@@ -116,12 +146,59 @@ async function checkToolAvailability(
 		return false;
 	}
 	try {
-		const result = await safeSpawnAsync(command, ["--version"], {
-			timeout: 5000,
+		// The budget is enforced by a HOST-side timer, so measure the loop stall
+		// that overlapped the window and let the shared classifier read it.
+		const sampler = startHostStallSampler();
+		const startedAt = Date.now();
+		let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
+		let hostStallMs: number;
+		try {
+			result = await safeSpawnAsync(command, ["--version"], {
+				timeout: TOOL_PROBE_TIMEOUT_MS,
+			});
+		} finally {
+			hostStallMs = sampler.stop();
+		}
+		const elapsedMs = Date.now() - startedAt;
+		if (result.status === 0) {
+			facts.setSessionFact(key, true);
+			logAvailabilityDecision({
+				tool: command,
+				verdict: "available",
+				outcome: "success",
+				cause: "ok",
+				elapsedMs,
+				latched: true,
+				hostStallMs,
+				budgetMs: TOOL_PROBE_TIMEOUT_MS,
+			});
+			return true;
+		}
+		// `missing` for anything unclassified preserves the pre-#1476 meaning of
+		// a non-zero exit: durable, cached for the session.
+		const { outcome, cause } = classifyProbeFailure(result, {
+			hostStallMs,
+			unclassifiedFailureOutcome: "missing",
 		});
-		const available = result.status === 0;
-		facts.setSessionFact(key, available);
-		return available;
+		let retryAfterMs: number | undefined;
+		if (outcome === "transient") {
+			retryAfterMs = transientRetryDelayMs(1, cause);
+			facts.setSessionFact(transientRetryKey(command), Date.now() + retryAfterMs);
+		} else {
+			facts.setSessionFact(key, false);
+		}
+		logAvailabilityDecision({
+			tool: command,
+			verdict: "unavailable",
+			outcome,
+			cause,
+			elapsedMs,
+			latched: outcome !== "transient",
+			hostStallMs,
+			...(retryAfterMs !== undefined && { retryAfterMs }),
+			budgetMs: TOOL_PROBE_TIMEOUT_MS,
+		});
+		return false;
 	} catch {
 		facts.setSessionFact(key, false);
 		return false;

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -119,6 +119,21 @@ function transientRetryKey(command: string): string {
 }
 
 /**
+ * Consecutive transient verdicts for a command, so the cooldown ESCALATES the
+ * way the policy documents (30 s, 60 s, 120 s … capped at 5 min) instead of
+ * sitting flat at 30 s.
+ *
+ * This is the highest-traffic availability consumer in the product. A flat
+ * cooldown here means a permanently sick host is re-probed every 30 s per
+ * command for the whole session — ten times the storm the policy claims to
+ * bound, and the one place the bound matters most. `createAvailabilityChecker`
+ * tracks the same counter; this keeps the two seams telling one story.
+ */
+function transientAttemptsKey(command: string): string {
+	return `${normalizeCacheKey(command)}.transientAttempts`;
+}
+
+/**
  * Is `command` usable right now? Cached per session.
  *
  * Latch policy (#1467/#1476): a `false` from a genuine absence is durable and
@@ -162,6 +177,10 @@ export async function checkToolAvailability(
 		const elapsedMs = Date.now() - startedAt;
 		if (result.status === 0) {
 			facts.setSessionFact(key, true);
+			// The tool answered: retire the cooldown facts rather than leaving a
+			// stale retry deadline behind a `true`.
+			facts.setSessionFact(transientRetryKey(command), 0);
+			facts.setSessionFact(transientAttemptsKey(command), 0);
 			logAvailabilityDecision({
 				tool: command,
 				verdict: "available",
@@ -182,10 +201,14 @@ export async function checkToolAvailability(
 		});
 		let retryAfterMs: number | undefined;
 		if (outcome === "transient") {
-			retryAfterMs = transientRetryDelayMs(1, cause);
+			const attempts =
+				(facts.getSessionFact<number>(transientAttemptsKey(command)) ?? 0) + 1;
+			facts.setSessionFact(transientAttemptsKey(command), attempts);
+			retryAfterMs = transientRetryDelayMs(attempts, cause);
 			facts.setSessionFact(transientRetryKey(command), Date.now() + retryAfterMs);
 		} else {
 			facts.setSessionFact(key, false);
+			facts.setSessionFact(transientAttemptsKey(command), 0);
 		}
 		logAvailabilityDecision({
 			tool: command,

--- a/clients/dispatch/runners/utils/candidate-probe.ts
+++ b/clients/dispatch/runners/utils/candidate-probe.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared PATH-candidate availability sweep (#1476 Sonar follow-up, S3776).
+ *
+ * `go-client.ts` and `rust-client.ts` resolve their toolchain the same way:
+ * walk a platform candidate list, treat a candidate with a path separator as
+ * an existence check, and probe a bare command with a version flag on a
+ * fixed host-side budget, classifying any failure through the shared policy
+ * so a host stall cannot be mistaken for "the tool is not installed". The
+ * migration to `availability-policy.ts` wrote that sweep out twice, and the
+ * duplication was also what pushed both call sites over the Cognitive
+ * Complexity limit. This is that sweep, written once.
+ */
+
+import * as fs from "node:fs";
+import { safeSpawnAsync } from "../../../safe-spawn.js";
+import {
+	type AvailabilityCause,
+	classifyProbeFailure,
+	startHostStallSampler,
+} from "./availability-policy.js";
+
+export interface CandidateSweepResult {
+	/** The candidate that answered, or `null` if none did. */
+	foundPath: string | null;
+	/** Whether any candidate in the sweep failed transiently. */
+	sawTransient: boolean;
+	/** The cause of the last transient failure seen, for the retry decision. */
+	transientCause: AvailabilityCause;
+	/** Total host event-loop stall observed across the sweep, ms. */
+	hostStallMs: number;
+}
+
+/**
+ * Walk `candidates` in order. A candidate containing a path separator is
+ * resolved with `fs.existsSync`; a bare command is probed by spawning it with
+ * `probeArgs` on a `timeoutMs` host-side budget. Returns on the first
+ * candidate that answers; a candidate that throws is skipped, matching the
+ * original per-client sweeps.
+ */
+export async function probeAvailabilityCandidates(
+	candidates: readonly string[],
+	probeArgs: readonly string[],
+	timeoutMs: number,
+): Promise<CandidateSweepResult> {
+	let sawTransient = false;
+	let transientCause: AvailabilityCause = "probe-timeout";
+	let hostStallMs = 0;
+
+	for (const candidate of candidates) {
+		try {
+			if (candidate.includes("\\") || candidate.includes("/")) {
+				if (fs.existsSync(candidate)) {
+					return { foundPath: candidate, sawTransient, transientCause, hostStallMs };
+				}
+				continue;
+			}
+			// Host-side budget: measure the loop stall that overlapped the probe so
+			// the shared policy can tell "no toolchain" from "the host was busy".
+			const sampler = startHostStallSampler();
+			let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
+			let stallMs: number;
+			try {
+				result = await safeSpawnAsync(candidate, [...probeArgs], {
+					timeout: timeoutMs,
+				});
+			} finally {
+				stallMs = sampler.stop();
+				hostStallMs += stallMs;
+			}
+			if (!result.error && result.status === 0) {
+				return { foundPath: candidate, sawTransient, transientCause, hostStallMs };
+			}
+			const { outcome, cause } = classifyProbeFailure(result, {
+				hostStallMs: stallMs,
+			});
+			if (outcome === "transient") {
+				sawTransient = true;
+				transientCause = cause;
+			}
+		} catch (err) {
+			void err;
+		}
+	}
+
+	return { foundPath: null, sawTransient, transientCause, hostStallMs };
+}

--- a/clients/dispatch/runners/utils/candidate-probe.ts
+++ b/clients/dispatch/runners/utils/candidate-probe.ts
@@ -77,8 +77,12 @@ export async function probeAvailabilityCandidates(
 				sawTransient = true;
 				transientCause = cause;
 			}
-		} catch (err) {
-			void err;
+		} catch {
+			// A candidate that throws is one this host does not have — the sweep's
+			// normal case, not an error worth surfacing. The verdict comes from
+			// whether any LATER candidate answers, and a genuine host problem
+			// still reaches the caller as a transient through `classifyProbeFailure`
+			// above rather than through a thrown spawn.
 		}
 	}
 

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -37,6 +37,7 @@ import {
 	type AvailabilityCause,
 	type AvailabilityOutcome,
 	classifyProbeFailure,
+	createAvailabilityLatch,
 	isLatchingOutcome,
 	logAvailabilityDecision,
 	startHostStallSampler,
@@ -108,6 +109,36 @@ if (typeof __dirname !== "undefined") {
 
 // Managed tools directory (~/.pi-lens/tools) — where ensureTool() installs binaries
 const _managedToolsDir = path.join(getGlobalPiLensDir(), "tools");
+
+/**
+ * The managed shim for a Node CLI tool (`~/.pi-lens/tools/node_modules/.bin/<tool>`),
+ * or null when it is not on disk.
+ *
+ * When the shim exists the tool IS installed, so availability needs no spawn at
+ * all — and a spawn that cannot happen cannot time out (#1467). knip and jscpd
+ * each carried a line-for-line copy of this resolver; #1476 folds them into one
+ * definition so the next managed tool inherits the fast path instead of a
+ * fourth copy.
+ *
+ * The pi-lens dir is read per call, never memoized at module load, so tests that
+ * point `getGlobalPiLensDir` at a temp home still see their own tree.
+ */
+export function findManagedNodeToolBinary(tool: string): string | null {
+	const base = path.join(
+		getGlobalPiLensDir(),
+		"tools",
+		"node_modules",
+		".bin",
+		tool,
+	);
+	const candidates =
+		process.platform === "win32" ? [`${base}.cmd`, `${base}.exe`, base] : [base];
+	try {
+		return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+	} catch {
+		return null;
+	}
+}
 
 // =============================================================================
 // VENV-AWARE COMMAND FINDER
@@ -824,10 +855,19 @@ export function resolveAvailableOrInstall(
 // SHARED AST-GREP AVAILABILITY
 // =============================================================================
 
-// Shared ast-grep availability cache across all slop runners
-let sgAvailable: boolean | null = null;
+/**
+ * Shared ast-grep availability across all slop runners, behind the transient-
+ * aware latch (#1476). This module-level memo carried the same shape `SgRunner`
+ * did — one failed sweep, including a timeout, disabled ast-grep for every slop
+ * runner for the life of the process.
+ */
+const sgLatch = createAvailabilityLatch();
 let sgCmd: string | null = null;
 let sgCmdArgs: string[] = [];
+/** Classification of the current sweep, accumulated across candidates. */
+let sgSweepSawTransient = false;
+let sgSweepTransientCause: AvailabilityCause = "probe-timeout";
+let sgSweepHostStallMs = 0;
 
 function isAstGrepVersionOutput(output: string): boolean {
 	return /\bast[- ]grep\b/i.test(output);
@@ -837,14 +877,30 @@ async function probeAstGrepCommandAsync(
 	cmd: string,
 	argsPrefix: string[] = [],
 ): Promise<boolean> {
-	const check = await safeSpawnAsync(cmd, [...argsPrefix, "--version"], {
-		timeout: 5000,
-	});
-	return (
+	const sampler = startHostStallSampler();
+	let check: Awaited<ReturnType<typeof safeSpawnAsync>>;
+	let hostStallMs: number;
+	try {
+		check = await safeSpawnAsync(cmd, [...argsPrefix, "--version"], {
+			timeout: 5000,
+		});
+	} finally {
+		hostStallMs = sampler.stop();
+		sgSweepHostStallMs += hostStallMs;
+	}
+	if (
 		!check.error &&
 		check.status === 0 &&
 		isAstGrepVersionOutput(`${check.stdout}\n${check.stderr}`)
-	);
+	) {
+		return true;
+	}
+	const { outcome, cause } = classifyProbeFailure(check, { hostStallMs });
+	if (outcome === "transient") {
+		sgSweepSawTransient = true;
+		sgSweepTransientCause = cause;
+	}
+	return false;
 }
 
 /** Pre-filter local node_modules/.bin candidates that actually exist on disk. */
@@ -883,7 +939,7 @@ let sgAvailabilityGeneration = availabilityStateGeneration;
 
 function ensureCurrentSgGeneration(): void {
 	if (sgAvailabilityGeneration === availabilityStateGeneration) return;
-	sgAvailable = null;
+	sgLatch.reset();
 	sgCmd = null;
 	sgCmdArgs = [];
 	sgAvailableInFlight = null;
@@ -892,14 +948,21 @@ function ensureCurrentSgGeneration(): void {
 
 export async function isSgAvailableAsync(): Promise<boolean> {
 	ensureCurrentSgGeneration();
-	if (sgAvailable !== null) return sgAvailable;
+	// `read()` returns null when the last verdict was transient and its cooldown
+	// expired: re-probe rather than stay dead for the session (#1476).
+	const memo = sgLatch.read();
+	if (memo !== null) return memo;
 	if (sgAvailableInFlight) return sgAvailableInFlight;
 
 	sgAvailableInFlight = (async () => {
+		const startedAt = Date.now();
+		sgSweepSawTransient = false;
+		sgSweepTransientCause = "probe-timeout";
+		sgSweepHostStallMs = 0;
 		// 1. Local node_modules/.bin
 		for (const localBin of buildSgLocalBins()) {
 			if (await probeAstGrepCommandAsync(localBin)) {
-				sgCmd = localBin; sgCmdArgs = []; sgAvailable = true;
+				sgCmd = localBin; sgCmdArgs = []; noteSgAvailable(startedAt);
 				return true;
 			}
 		}
@@ -907,7 +970,7 @@ export async function isSgAvailableAsync(): Promise<boolean> {
 		// 2. Global PATH
 		for (const cmd of ["ast-grep", "sg"]) {
 			if (await probeAstGrepCommandAsync(cmd)) {
-				sgCmd = cmd; sgCmdArgs = []; sgAvailable = true;
+				sgCmd = cmd; sgCmdArgs = []; noteSgAvailable(startedAt);
 				return true;
 			}
 		}
@@ -917,24 +980,64 @@ export async function isSgAvailableAsync(): Promise<boolean> {
 		for (const name of ["ast-grep", "sg"]) {
 			const globalBin = await findGlobalBinary(name);
 			if (globalBin && (await probeAstGrepCommandAsync(globalBin))) {
-				sgCmd = globalBin; sgCmdArgs = []; sgAvailable = true;
+				sgCmd = globalBin; sgCmdArgs = []; noteSgAvailable(startedAt);
 				return true;
 			}
 		}
 
 		// 3. npx --no (cache-only, no silent download).
 		if (await probeAstGrepCommandAsync("npx", ["--no", "--", "ast-grep"])) {
-			sgCmd = "npx"; sgCmdArgs = ["--no", "--", "ast-grep"]; sgAvailable = true;
+			sgCmd = "npx"; sgCmdArgs = ["--no", "--", "ast-grep"]; noteSgAvailable(startedAt);
 			return true;
 		}
 
-		sgAvailable = false;
+		// A timeout on ANY candidate is evidence about the host, not the tool.
+		noteSgUnavailable(
+			startedAt,
+			sgSweepSawTransient ? "transient" : "missing",
+			sgSweepSawTransient ? sgSweepTransientCause : "not-found",
+		);
 		return false;
 	})().finally(() => {
 		sgAvailableInFlight = null;
 	});
 
 	return sgAvailableInFlight;
+}
+
+/** Record a successful shared-ast-grep sweep, with one decision record. */
+function noteSgAvailable(startedAt: number): void {
+	sgLatch.noteAvailable();
+	logAvailabilityDecision({
+		tool: "ast-grep",
+		verdict: "available",
+		outcome: "success",
+		cause: "ok",
+		elapsedMs: Date.now() - startedAt,
+		latched: true,
+		hostStallMs: sgSweepHostStallMs,
+		budgetMs: 5000,
+	});
+}
+
+/** Record a failed shared-ast-grep sweep; a transient verdict expires. */
+function noteSgUnavailable(
+	startedAt: number,
+	outcome: "missing" | "transient",
+	cause: AvailabilityCause,
+): void {
+	const retryAfterMs = sgLatch.noteUnavailable(outcome, cause);
+	logAvailabilityDecision({
+		tool: "ast-grep",
+		verdict: "unavailable",
+		outcome,
+		cause,
+		elapsedMs: Date.now() - startedAt,
+		latched: outcome !== "transient",
+		hostStallMs: sgSweepHostStallMs,
+		...(retryAfterMs > 0 && { retryAfterMs }),
+		budgetMs: 5000,
+	});
 }
 
 export function getSgCommand(): { cmd: string; args: string[] } {

--- a/clients/dispatch/runners/utils/toolchain-availability.ts
+++ b/clients/dispatch/runners/utils/toolchain-availability.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared toolchain-availability lifecycle (#1476 Sonar follow-up).
+ *
+ * `candidate-probe.ts` factored out the PATH sweep the Go and Rust clients ran,
+ * but the LIFECYCLE around it stayed written twice: the transient-aware latch,
+ * the in-flight dedupe that keeps concurrent first-time callers to one sweep,
+ * the path memo, and the two `availability_decision` records. Two copies of one
+ * rule is how #1467's fix missed seven sites, so the rule lives here once and
+ * each client contributes only its configuration.
+ *
+ * Callers keep their own public method names — `isGoAvailableAsync`,
+ * `findCargoPathAsync` — because other modules call them; only the body moves.
+ */
+
+import {
+	type AvailabilityCause,
+	createAvailabilityLatch,
+	logAvailabilityDecision,
+} from "./availability-policy.js";
+import { probeAvailabilityCandidates } from "./candidate-probe.js";
+
+export interface ToolchainAvailabilityConfig {
+	/** Tool name as it appears in the `availability_decision` record. */
+	tool: string;
+	/** Human label for the "found" log line, e.g. `Go`, `Cargo`. */
+	label: string;
+	/** Candidates probed on Windows, in order. */
+	windowsPaths: readonly string[];
+	/** Candidates probed everywhere else, in order. */
+	unixPaths: readonly string[];
+	/** Version-probe arguments for the bare PATH candidate. */
+	probeArgs: readonly string[];
+	/** Host-side budget for one probe, ms. */
+	budgetMs: number;
+	/** Verbose-mode logger; a no-op when the client is quiet. */
+	log: (msg: string) => void;
+}
+
+export interface ToolchainAvailability {
+	/** Resolved executable path, memoized once a candidate answers. */
+	findPath: () => Promise<string | null>;
+	/** Availability verdict, behind the transient-aware latch. */
+	isAvailable: () => Promise<boolean>;
+}
+
+/**
+ * Own one toolchain's availability: sweep the platform candidate list, memoize
+ * the path that answered, and park the verdict behind the shared latch so a
+ * timed-out probe expires instead of latching "the toolchain is not installed"
+ * for the life of the process.
+ */
+export function createToolchainAvailability(
+	config: ToolchainAvailabilityConfig,
+): ToolchainAvailability {
+	const availabilityLatch = createAvailabilityLatch();
+	let toolPath: string | null = null;
+	/** Classification of the candidate sweep, for the retry decision. */
+	let sweepSawTransient = false;
+	let sweepTransientCause: AvailabilityCause = "probe-timeout";
+	let sweepHostStallMs = 0;
+	let ensureInFlight: Promise<boolean> | null = null;
+
+	async function findPath(): Promise<string | null> {
+		if (toolPath) return toolPath;
+
+		const paths =
+			process.platform === "win32" ? config.windowsPaths : config.unixPaths;
+		const sweep = await probeAvailabilityCandidates(
+			paths,
+			config.probeArgs,
+			config.budgetMs,
+		);
+		sweepSawTransient = sweep.sawTransient;
+		sweepTransientCause = sweep.transientCause;
+		sweepHostStallMs = sweep.hostStallMs;
+		if (sweep.foundPath) toolPath = sweep.foundPath;
+		return sweep.foundPath;
+	}
+
+	async function resolveAvailability(): Promise<boolean> {
+		const startedAt = Date.now();
+		const found = (await findPath()) !== null;
+		if (found) {
+			availabilityLatch.noteAvailable();
+			config.log(`${config.label} found: ${toolPath}`);
+			logAvailabilityDecision({
+				tool: config.tool,
+				verdict: "available",
+				outcome: "success",
+				cause: "ok",
+				elapsedMs: Date.now() - startedAt,
+				latched: true,
+				hostStallMs: sweepHostStallMs,
+				budgetMs: config.budgetMs,
+			});
+			return true;
+		}
+		// A timed-out version probe is evidence about this moment, not about
+		// whether the toolchain is installed; it expires instead of latching.
+		const outcome = sweepSawTransient ? "transient" : "missing";
+		const cause = sweepSawTransient ? sweepTransientCause : "not-found";
+		const retryAfterMs = availabilityLatch.noteUnavailable(outcome, cause);
+		logAvailabilityDecision({
+			tool: config.tool,
+			verdict: "unavailable",
+			outcome,
+			cause,
+			elapsedMs: Date.now() - startedAt,
+			latched: outcome !== "transient",
+			hostStallMs: sweepHostStallMs,
+			...(retryAfterMs > 0 && { retryAfterMs }),
+			budgetMs: config.budgetMs,
+		});
+		return false;
+	}
+
+	async function isAvailable(): Promise<boolean> {
+		// `read()` returns null when the last verdict was transient and its
+		// cooldown expired, which re-enters the candidate sweep (#1476).
+		const memo = availabilityLatch.read();
+		if (memo !== null) return memo;
+		// Now that a verdict can expire, concurrent callers arriving just after a
+		// cooldown must share ONE sweep rather than each spawning their own.
+		if (ensureInFlight) return ensureInFlight;
+		ensureInFlight = resolveAvailability();
+		try {
+			return await ensureInFlight;
+		} finally {
+			ensureInFlight = null;
+		}
+	}
+
+	return { findPath, isAvailable };
+}

--- a/clients/go-client.ts
+++ b/clients/go-client.ts
@@ -10,11 +10,9 @@
 import { createSubsystemLogger } from "./extension-log.js";
 import * as path from "node:path";
 import {
-	type AvailabilityCause,
-	createAvailabilityLatch,
-	logAvailabilityDecision,
-} from "./dispatch/runners/utils/availability-policy.js";
-import { probeAvailabilityCandidates } from "./dispatch/runners/utils/candidate-probe.js";
+	type ToolchainAvailability,
+	createToolchainAvailability,
+} from "./dispatch/runners/utils/toolchain-availability.js";
 
 // --- Types ---
 
@@ -50,102 +48,41 @@ const GO_UNIX_PATHS = [
 
 export class GoClient {
 	/**
-	 * Availability memo, behind the shared transient-aware latch (#1476). The
-	 * PATH candidate is resolved by spawning `go version` with a 3 s budget, so
-	 * a host stall could latch "no Go toolchain" for the whole session and
+	 * Availability lifecycle, behind the shared transient-aware latch (#1476).
+	 * The PATH candidate is resolved by spawning `go version` with a 3 s budget,
+	 * so a host stall could latch "no Go toolchain" for the whole session and
 	 * silently disable every Go diagnostic until restart.
 	 */
-	private readonly availabilityLatch = createAvailabilityLatch();
-	private goPath: string | null = null;
-	/** Classification of the candidate sweep, for the retry decision. */
-	private sweepSawTransient = false;
-	private sweepTransientCause: AvailabilityCause = "probe-timeout";
-	private sweepHostStallMs = 0;
-	private ensureInFlight: Promise<boolean> | null = null;
+	private readonly availability: ToolchainAvailability;
 	private log: (msg: string) => void;
 
 	constructor(verbose = false) {
 		this.log = verbose
 			? createSubsystemLogger("go")
 			: () => {};
+		this.availability = createToolchainAvailability({
+			tool: "go",
+			label: "Go",
+			windowsPaths: GO_WINDOWS_PATHS,
+			unixPaths: GO_UNIX_PATHS,
+			probeArgs: ["version"],
+			budgetMs: PROBE_TIMEOUT_MS,
+			log: (msg) => this.log(msg),
+		});
 	}
 
 	/**
 	 * Find go executable path (async — probes PATH candidates off the event loop).
 	 */
 	async findGoPathAsync(): Promise<string | null> {
-		if (this.goPath) return this.goPath;
-
-		const paths =
-			process.platform === "win32" ? GO_WINDOWS_PATHS : GO_UNIX_PATHS;
-		const sweep = await probeAvailabilityCandidates(
-			paths,
-			["version"],
-			PROBE_TIMEOUT_MS,
-		);
-		this.sweepSawTransient = sweep.sawTransient;
-		this.sweepTransientCause = sweep.transientCause;
-		this.sweepHostStallMs = sweep.hostStallMs;
-		if (sweep.foundPath) this.goPath = sweep.foundPath;
-		return sweep.foundPath;
+		return this.availability.findPath();
 	}
 
 	/**
 	 * Check if Go is installed (cached)
 	 */
 	async isGoAvailableAsync(): Promise<boolean> {
-		// `read()` returns null when the last verdict was transient and its
-		// cooldown expired, which re-enters the candidate sweep (#1476).
-		const memo = this.availabilityLatch.read();
-		if (memo !== null) return memo;
-		// Now that a verdict can expire, concurrent callers arriving just after a
-		// cooldown must share ONE sweep rather than each spawning their own.
-		if (this.ensureInFlight) return this.ensureInFlight;
-		this.ensureInFlight = this.resolveAvailability();
-		try {
-			return await this.ensureInFlight;
-		} finally {
-			this.ensureInFlight = null;
-		}
-	}
-
-	private async resolveAvailability(): Promise<boolean> {
-		const startedAt = Date.now();
-		const found = (await this.findGoPathAsync()) !== null;
-		if (found) {
-			this.availabilityLatch.noteAvailable();
-			this.log(`Go found: ${this.goPath}`);
-			logAvailabilityDecision({
-				tool: "go",
-				verdict: "available",
-				outcome: "success",
-				cause: "ok",
-				elapsedMs: Date.now() - startedAt,
-				latched: true,
-				hostStallMs: this.sweepHostStallMs,
-				budgetMs: PROBE_TIMEOUT_MS,
-			});
-			return true;
-		}
-		// A timed-out `go version` is evidence about this moment, not about
-		// whether the toolchain is installed; it expires instead of latching.
-		const outcome = this.sweepSawTransient ? "transient" : "missing";
-		const cause = this.sweepSawTransient
-			? this.sweepTransientCause
-			: "not-found";
-		const retryAfterMs = this.availabilityLatch.noteUnavailable(outcome, cause);
-		logAvailabilityDecision({
-			tool: "go",
-			verdict: "unavailable",
-			outcome,
-			cause,
-			elapsedMs: Date.now() - startedAt,
-			latched: outcome !== "transient",
-			hostStallMs: this.sweepHostStallMs,
-			...(retryAfterMs > 0 && { retryAfterMs }),
-			budgetMs: PROBE_TIMEOUT_MS,
-		});
-		return false;
+		return this.availability.isAvailable();
 	}
 
 	/**

--- a/clients/go-client.ts
+++ b/clients/go-client.ts
@@ -11,6 +11,13 @@ import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { safeSpawnAsync } from "./safe-spawn.js";
+import {
+	type AvailabilityCause,
+	classifyProbeFailure,
+	createAvailabilityLatch,
+	logAvailabilityDecision,
+	startHostStallSampler,
+} from "./dispatch/runners/utils/availability-policy.js";
 
 // --- Types ---
 
@@ -33,6 +40,9 @@ const GO_WINDOWS_PATHS = [
 	"go.exe", // PATH
 ];
 
+/** Budget for the PATH candidate's `go version` probe, ms. */
+const PROBE_TIMEOUT_MS = 3_000;
+
 const GO_UNIX_PATHS = [
 	"/usr/local/go/bin/go",
 	"/usr/bin/go",
@@ -42,8 +52,19 @@ const GO_UNIX_PATHS = [
 // --- Client ---
 
 export class GoClient {
-	private goAvailable: boolean | null = null;
+	/**
+	 * Availability memo, behind the shared transient-aware latch (#1476). The
+	 * PATH candidate is resolved by spawning `go version` with a 3 s budget, so
+	 * a host stall could latch "no Go toolchain" for the whole session and
+	 * silently disable every Go diagnostic until restart.
+	 */
+	private readonly availabilityLatch = createAvailabilityLatch();
 	private goPath: string | null = null;
+	/** Classification of the candidate sweep, for the retry decision. */
+	private sweepSawTransient = false;
+	private sweepTransientCause: AvailabilityCause = "probe-timeout";
+	private sweepHostStallMs = 0;
+	private ensureInFlight: Promise<boolean> | null = null;
 	private log: (msg: string) => void;
 
 	constructor(verbose = false) {
@@ -60,6 +81,9 @@ export class GoClient {
 
 		const paths =
 			process.platform === "win32" ? GO_WINDOWS_PATHS : GO_UNIX_PATHS;
+		this.sweepSawTransient = false;
+		this.sweepTransientCause = "probe-timeout";
+		this.sweepHostStallMs = 0;
 
 		for (const p of paths) {
 			try {
@@ -70,13 +94,30 @@ export class GoClient {
 						return p;
 					}
 				} else {
-					// Relative (PATH) - try running it
-					const result = await safeSpawnAsync(p, ["version"], {
-						timeout: 3000,
-					});
+					// Relative (PATH) - try running it. The 3 s budget is enforced by a
+					// HOST-side timer, so measure the loop stall that overlapped it and
+					// let the shared policy tell "no Go" from "the host was busy".
+					const sampler = startHostStallSampler();
+					let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
+					let hostStallMs: number;
+					try {
+						result = await safeSpawnAsync(p, ["version"], {
+							timeout: PROBE_TIMEOUT_MS,
+						});
+					} finally {
+						hostStallMs = sampler.stop();
+						this.sweepHostStallMs += hostStallMs;
+					}
 					if (!result.error && result.status === 0) {
 						this.goPath = p;
 						return p;
+					}
+					const { outcome, cause } = classifyProbeFailure(result, {
+						hostStallMs,
+					});
+					if (outcome === "transient") {
+						this.sweepSawTransient = true;
+						this.sweepTransientCause = cause;
 					}
 				}
 			} catch (err) {
@@ -91,12 +132,58 @@ export class GoClient {
 	 * Check if Go is installed (cached)
 	 */
 	async isGoAvailableAsync(): Promise<boolean> {
-		if (this.goAvailable !== null) return this.goAvailable;
-		this.goAvailable = (await this.findGoPathAsync()) !== null;
-		if (this.goAvailable) {
-			this.log(`Go found: ${this.goPath}`);
+		// `read()` returns null when the last verdict was transient and its
+		// cooldown expired, which re-enters the candidate sweep (#1476).
+		const memo = this.availabilityLatch.read();
+		if (memo !== null) return memo;
+		// Now that a verdict can expire, concurrent callers arriving just after a
+		// cooldown must share ONE sweep rather than each spawning their own.
+		if (this.ensureInFlight) return this.ensureInFlight;
+		this.ensureInFlight = this.resolveAvailability();
+		try {
+			return await this.ensureInFlight;
+		} finally {
+			this.ensureInFlight = null;
 		}
-		return this.goAvailable;
+	}
+
+	private async resolveAvailability(): Promise<boolean> {
+		const startedAt = Date.now();
+		const found = (await this.findGoPathAsync()) !== null;
+		if (found) {
+			this.availabilityLatch.noteAvailable();
+			this.log(`Go found: ${this.goPath}`);
+			logAvailabilityDecision({
+				tool: "go",
+				verdict: "available",
+				outcome: "success",
+				cause: "ok",
+				elapsedMs: Date.now() - startedAt,
+				latched: true,
+				hostStallMs: this.sweepHostStallMs,
+				budgetMs: PROBE_TIMEOUT_MS,
+			});
+			return true;
+		}
+		// A timed-out `go version` is evidence about this moment, not about
+		// whether the toolchain is installed; it expires instead of latching.
+		const outcome = this.sweepSawTransient ? "transient" : "missing";
+		const cause = this.sweepSawTransient
+			? this.sweepTransientCause
+			: "not-found";
+		const retryAfterMs = this.availabilityLatch.noteUnavailable(outcome, cause);
+		logAvailabilityDecision({
+			tool: "go",
+			verdict: "unavailable",
+			outcome,
+			cause,
+			elapsedMs: Date.now() - startedAt,
+			latched: outcome !== "transient",
+			hostStallMs: this.sweepHostStallMs,
+			...(retryAfterMs > 0 && { retryAfterMs }),
+			budgetMs: PROBE_TIMEOUT_MS,
+		});
+		return false;
 	}
 
 	/**

--- a/clients/go-client.ts
+++ b/clients/go-client.ts
@@ -8,16 +8,13 @@
  */
 
 import { createSubsystemLogger } from "./extension-log.js";
-import * as fs from "node:fs";
 import * as path from "node:path";
-import { safeSpawnAsync } from "./safe-spawn.js";
 import {
 	type AvailabilityCause,
-	classifyProbeFailure,
 	createAvailabilityLatch,
 	logAvailabilityDecision,
-	startHostStallSampler,
 } from "./dispatch/runners/utils/availability-policy.js";
+import { probeAvailabilityCandidates } from "./dispatch/runners/utils/candidate-probe.js";
 
 // --- Types ---
 
@@ -81,51 +78,16 @@ export class GoClient {
 
 		const paths =
 			process.platform === "win32" ? GO_WINDOWS_PATHS : GO_UNIX_PATHS;
-		this.sweepSawTransient = false;
-		this.sweepTransientCause = "probe-timeout";
-		this.sweepHostStallMs = 0;
-
-		for (const p of paths) {
-			try {
-				if (p.includes("\\") || p.includes("/")) {
-					// Absolute path - check if exists
-					if (fs.existsSync(p)) {
-						this.goPath = p;
-						return p;
-					}
-				} else {
-					// Relative (PATH) - try running it. The 3 s budget is enforced by a
-					// HOST-side timer, so measure the loop stall that overlapped it and
-					// let the shared policy tell "no Go" from "the host was busy".
-					const sampler = startHostStallSampler();
-					let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
-					let hostStallMs: number;
-					try {
-						result = await safeSpawnAsync(p, ["version"], {
-							timeout: PROBE_TIMEOUT_MS,
-						});
-					} finally {
-						hostStallMs = sampler.stop();
-						this.sweepHostStallMs += hostStallMs;
-					}
-					if (!result.error && result.status === 0) {
-						this.goPath = p;
-						return p;
-					}
-					const { outcome, cause } = classifyProbeFailure(result, {
-						hostStallMs,
-					});
-					if (outcome === "transient") {
-						this.sweepSawTransient = true;
-						this.sweepTransientCause = cause;
-					}
-				}
-			} catch (err) {
-				void err;
-			}
-		}
-
-		return null;
+		const sweep = await probeAvailabilityCandidates(
+			paths,
+			["version"],
+			PROBE_TIMEOUT_MS,
+		);
+		this.sweepSawTransient = sweep.sawTransient;
+		this.sweepTransientCause = sweep.transientCause;
+		this.sweepHostStallMs = sweep.hostStallMs;
+		if (sweep.foundPath) this.goPath = sweep.foundPath;
+		return sweep.foundPath;
 	}
 
 	/**

--- a/clients/govulncheck-client.ts
+++ b/clients/govulncheck-client.ts
@@ -26,6 +26,7 @@ import { SecurityScanClient } from "./security-scan-client.js";
 import {
 	classifyProbeFailure,
 	logAvailabilityDecision,
+	startHostStallSampler,
 } from "./dispatch/runners/utils/availability-policy.js";
 
 // --- Types ---
@@ -150,14 +151,35 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 		// project has a go.mod the user has the Go toolchain by definition.
 		// Same shape as rust-clippy / cargo: lean on the language's own
 		// install mechanism rather than adding a new installer strategy.
-		const goOnPath = await safeSpawnAsync("go", ["version"], {
-			timeout: 5000,
-		});
+		const goProbeStartedAt = Date.now();
+		const goSampler = startHostStallSampler();
+		let goOnPath: Awaited<ReturnType<typeof safeSpawnAsync>>;
+		let goHostStallMs: number;
+		try {
+			goOnPath = await safeSpawnAsync("go", ["version"], {
+				timeout: 5000,
+			});
+		} finally {
+			goHostStallMs = goSampler.stop();
+		}
 		if (goOnPath.error || goOnPath.status !== 0) {
-			const { outcome, cause } = classifyProbeFailure(goOnPath);
+			const { outcome, cause } = classifyProbeFailure(goOnPath, {
+				hostStallMs: goHostStallMs,
+			});
 			if (outcome === "transient") {
 				this.log("`go version` probe timed out; retrying govulncheck later");
-				this.markTransientlyUnavailable(cause);
+				const retryAfterMs = this.markTransientlyUnavailable(cause);
+				logAvailabilityDecision({
+					tool: "govulncheck",
+					verdict: "unavailable",
+					outcome,
+					cause,
+					elapsedMs: Date.now() - goProbeStartedAt,
+					latched: false,
+					hostStallMs: goHostStallMs,
+					...(retryAfterMs > 0 && { retryAfterMs }),
+					budgetMs: 5000,
+				});
 				return false;
 			}
 			this.log("go binary not on PATH — cannot auto-install govulncheck");
@@ -167,11 +189,18 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 
 		this.log("govulncheck not found, attempting auto-install via go install");
 		const installStartedAt = Date.now();
-		const install = await safeSpawnAsync(
-			"go",
-			["install", "golang.org/x/vuln/cmd/govulncheck@latest"],
-			{ timeout: INSTALL_TIMEOUT_MS },
-		);
+		const installSampler = startHostStallSampler();
+		let install: Awaited<ReturnType<typeof safeSpawnAsync>>;
+		let installHostStallMs: number;
+		try {
+			install = await safeSpawnAsync(
+				"go",
+				["install", "golang.org/x/vuln/cmd/govulncheck@latest"],
+				{ timeout: INSTALL_TIMEOUT_MS },
+			);
+		} finally {
+			installHostStallMs = installSampler.stop();
+		}
 		if (install.error || install.status !== 0) {
 			this.log(
 				`govulncheck auto-install failed: ${(install.stderr ?? "").slice(0, 200)}`,
@@ -183,9 +212,11 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 			// A non-zero exit (module not found, compile error) still latches:
 			// that IS evidence about this machine, and retrying it every turn
 			// would be a `go install` storm.
-			const { outcome, cause } = classifyProbeFailure(install);
+			const { outcome, cause } = classifyProbeFailure(install, {
+				hostStallMs: installHostStallMs,
+			});
 			if (outcome === "transient") {
-				this.markTransientlyUnavailable(cause);
+				const retryAfterMs = this.markTransientlyUnavailable(cause);
 				// One record per decision, so an install that keeps timing out is
 				// readable in latency.log the same day (#1467's forensic trail).
 				logAvailabilityDecision({
@@ -195,6 +226,8 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 					cause,
 					elapsedMs: Date.now() - installStartedAt,
 					latched: false,
+					hostStallMs: installHostStallMs,
+					...(retryAfterMs > 0 && { retryAfterMs }),
 					budgetMs: INSTALL_TIMEOUT_MS,
 				});
 				return false;
@@ -206,9 +239,17 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 		// `go install` writes to `$GOBIN` or `$GOPATH/bin`. The user may not
 		// have that on `$PATH`. Re-probe by name (works when it is on PATH)
 		// then fall back to the canonical bin dirs.
-		const reprobe = await safeSpawnAsync("govulncheck", ["-version"], {
-			timeout: 5000,
-		});
+		const reprobeStartedAt = Date.now();
+		const reprobeSampler = startHostStallSampler();
+		let reprobe: Awaited<ReturnType<typeof safeSpawnAsync>>;
+		let reprobeHostStallMs: number;
+		try {
+			reprobe = await safeSpawnAsync("govulncheck", ["-version"], {
+				timeout: 5000,
+			});
+		} finally {
+			reprobeHostStallMs = reprobeSampler.stop();
+		}
 		if (!reprobe.error && reprobe.status === 0) {
 			this.log("govulncheck auto-installed and found on PATH");
 			this.available = true;
@@ -243,19 +284,25 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 		// The install SUCCEEDED, so the tool is on this machine somewhere. If the
 		// re-probe merely timed out, latching "not installed" would be the #1467
 		// mistake one step later in the same function (#1476).
-		const { outcome, cause } = classifyProbeFailure(reprobe);
+		const { outcome, cause } = classifyProbeFailure(reprobe, {
+			hostStallMs: reprobeHostStallMs,
+		});
 		if (outcome === "transient") {
 			this.log(
 				"govulncheck installed but the re-probe timed out; retrying later",
 			);
-			this.markTransientlyUnavailable(cause);
+			const retryAfterMs = this.markTransientlyUnavailable(cause);
 			logAvailabilityDecision({
 				tool: "govulncheck",
 				verdict: "unavailable",
 				outcome,
 				cause,
-				elapsedMs: 0,
+				// The re-probe's own wall time. A hard-coded 0 here was the #1474
+				// defect verbatim: a duration field that measures nothing.
+				elapsedMs: Date.now() - reprobeStartedAt,
 				latched: false,
+				hostStallMs: reprobeHostStallMs,
+				...(retryAfterMs > 0 && { retryAfterMs }),
 				budgetMs: 5000,
 			});
 			return false;

--- a/clients/govulncheck-client.ts
+++ b/clients/govulncheck-client.ts
@@ -23,7 +23,10 @@ import * as path from "node:path";
 import { safeSpawnAsync } from "./safe-spawn.js";
 import { assertInstallAllowed } from "./project-trust.js";
 import { SecurityScanClient } from "./security-scan-client.js";
-import { classifyProbeFailure } from "./dispatch/runners/utils/availability-policy.js";
+import {
+	classifyProbeFailure,
+	logAvailabilityDecision,
+} from "./dispatch/runners/utils/availability-policy.js";
 
 // --- Types ---
 
@@ -59,6 +62,8 @@ const EMPTY_RESULT: Omit<GovulncheckResult, "scannedAt"> = {
 };
 
 const SCAN_TIMEOUT_MS = 120_000;
+/** Budget for the `go install` auto-install, ms. */
+const INSTALL_TIMEOUT_MS = 60_000;
 
 // --- Internal: raw record shapes from govulncheck's JSON stream ---
 
@@ -161,15 +166,39 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 		}
 
 		this.log("govulncheck not found, attempting auto-install via go install");
+		const installStartedAt = Date.now();
 		const install = await safeSpawnAsync(
 			"go",
 			["install", "golang.org/x/vuln/cmd/govulncheck@latest"],
-			{ timeout: 60_000 },
+			{ timeout: INSTALL_TIMEOUT_MS },
 		);
 		if (install.error || install.status !== 0) {
 			this.log(
 				`govulncheck auto-install failed: ${(install.stderr ?? "").slice(0, 200)}`,
 			);
+			// #1476: `go install` runs against a 60 s budget over the network. A
+			// timed-out or killed install says nothing about whether govulncheck
+			// can ever be installed here, so it must not latch the durable
+			// "tool is not installed" verdict the way a real install refusal does.
+			// A non-zero exit (module not found, compile error) still latches:
+			// that IS evidence about this machine, and retrying it every turn
+			// would be a `go install` storm.
+			const { outcome, cause } = classifyProbeFailure(install);
+			if (outcome === "transient") {
+				this.markTransientlyUnavailable(cause);
+				// One record per decision, so an install that keeps timing out is
+				// readable in latency.log the same day (#1467's forensic trail).
+				logAvailabilityDecision({
+					tool: "govulncheck",
+					verdict: "unavailable",
+					outcome,
+					cause,
+					elapsedMs: Date.now() - installStartedAt,
+					latched: false,
+					budgetMs: INSTALL_TIMEOUT_MS,
+				});
+				return false;
+			}
 			this.available = false;
 			return false;
 		}
@@ -211,6 +240,26 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 			}
 		}
 
+		// The install SUCCEEDED, so the tool is on this machine somewhere. If the
+		// re-probe merely timed out, latching "not installed" would be the #1467
+		// mistake one step later in the same function (#1476).
+		const { outcome, cause } = classifyProbeFailure(reprobe);
+		if (outcome === "transient") {
+			this.log(
+				"govulncheck installed but the re-probe timed out; retrying later",
+			);
+			this.markTransientlyUnavailable(cause);
+			logAvailabilityDecision({
+				tool: "govulncheck",
+				verdict: "unavailable",
+				outcome,
+				cause,
+				elapsedMs: 0,
+				latched: false,
+				budgetMs: 5000,
+			});
+			return false;
+		}
 		this.log(
 			"govulncheck auto-install succeeded but binary not locatable — check $GOBIN / $GOPATH",
 		);

--- a/clients/jscpd-client.ts
+++ b/clients/jscpd-client.ts
@@ -15,14 +15,17 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
 	getExcludedDirGlobs,
-	getGlobalPiLensDir,
 	getProjectIgnoreGlobs,
 	getProjectIgnoreMatcher,
 } from "./file-utils.js";
 import { findNodeToolBinary } from "./package-manager.js";
 import { isAtOrAboveHomeDir, isFullyQualified } from "./path-utils.js";
 import { getJscpdMaxEntriesDerived } from "./project-scale.js";
-import { createAvailabilityChecker, resolveAvailableOrInstall } from "./dispatch/runners/utils/runner-helpers.js";
+import {
+	createAvailabilityChecker,
+	findManagedNodeToolBinary,
+	resolveAvailableOrInstall,
+} from "./dispatch/runners/utils/runner-helpers.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
 import { shouldRecurseIntoDir, walkTreeStackSync } from "./source-walker.js";
 
@@ -57,13 +60,8 @@ const SCAN_TIMEOUT_MS = 30_000;
 
 const jscpdAvailability = createAvailabilityChecker("jscpd", "", ["--version"], {
 	probeTimeout: 1500,
-	fastPath: () => {
-		const localBase = path.join(getGlobalPiLensDir(), "tools", "node_modules", ".bin", "jscpd");
-		const candidates = process.platform === "win32"
-			? [`${localBase}.cmd`, `${localBase}.exe`, localBase]
-			: [localBase];
-		return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
-	},
+	// One definition of the managed-shim fast path, shared with knip (#1476).
+	fastPath: () => findManagedNodeToolBinary("jscpd"),
 });
 
 // --- Client ---

--- a/clients/knip-client.ts
+++ b/clients/knip-client.ts
@@ -12,11 +12,12 @@
 import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getGlobalPiLensDir, getProjectDataDir } from "./file-utils.js";
+import { getProjectDataDir } from "./file-utils.js";
 import { findNearestMarkerRoot } from "./path-utils.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
 import {
 	createAvailabilityChecker,
+	findManagedNodeToolBinary,
 	getManagedToolEnvironment,
 	resolveAvailableOrInstall,
 } from "./dispatch/runners/utils/runner-helpers.js";
@@ -108,31 +109,6 @@ export function readOverridePinnedPackageNames(targetDir: string): Set<string> {
 
 // --- Client ---
 
-/**
- * Managed knip shim on disk, or null. Mirrors jscpd's fast path: when
- * `~/.pi-lens/tools/node_modules/.bin/knip*` exists the tool IS installed, so
- * resolving availability needs no spawn at all — and a spawn that cannot happen
- * cannot time out (#1467).
- */
-function findManagedKnipBinary(): string | null {
-	const base = path.join(
-		getGlobalPiLensDir(),
-		"tools",
-		"node_modules",
-		".bin",
-		"knip",
-	);
-	const candidates =
-		process.platform === "win32"
-			? [`${base}.cmd`, `${base}.exe`, base]
-			: [base];
-	try {
-		return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
-	} catch {
-		return null;
-	}
-}
-
 export class KnipClient {
 	private readonly knipAvailability = createAvailabilityChecker(
 		"knip",
@@ -141,7 +117,7 @@ export class KnipClient {
 		{
 			environment: (cwd) => getManagedToolEnvironment("knip", cwd),
 			unclassifiedFailureOutcome: "missing",
-			fastPath: findManagedKnipBinary,
+			fastPath: () => findManagedNodeToolBinary("knip"),
 		},
 	);
 	/**

--- a/clients/rust-client.ts
+++ b/clients/rust-client.ts
@@ -11,6 +11,13 @@ import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { safeSpawnAsync } from "./safe-spawn.js";
+import {
+	type AvailabilityCause,
+	classifyProbeFailure,
+	createAvailabilityLatch,
+	logAvailabilityDecision,
+	startHostStallSampler,
+} from "./dispatch/runners/utils/availability-policy.js";
 
 // --- Types ---
 
@@ -33,6 +40,9 @@ const CARGO_WINDOWS_PATHS = [
 	"cargo.exe", // PATH
 ];
 
+/** Budget for the PATH candidate's `cargo --version` probe, ms. */
+const PROBE_TIMEOUT_MS = 3_000;
+
 const CARGO_UNIX_PATHS = [
 	path.join(process.env.HOME || "", ".cargo", "bin", "cargo"),
 	"/usr/local/cargo/bin/cargo",
@@ -43,8 +53,19 @@ const CARGO_UNIX_PATHS = [
 // --- Client ---
 
 export class RustClient {
-	private cargoAvailable: boolean | null = null;
+	/**
+	 * Availability memo, behind the shared transient-aware latch (#1476). The
+	 * PATH candidate is resolved by spawning `cargo --version` with a 3 s budget,
+	 * so a host stall could latch "no cargo" for the session and silently disable
+	 * every Rust diagnostic until restart.
+	 */
+	private readonly availabilityLatch = createAvailabilityLatch();
 	private cargoPath: string | null = null;
+	/** Classification of the candidate sweep, for the retry decision. */
+	private sweepSawTransient = false;
+	private sweepTransientCause: AvailabilityCause = "probe-timeout";
+	private sweepHostStallMs = 0;
+	private ensureInFlight: Promise<boolean> | null = null;
 	private log: (msg: string) => void;
 
 	constructor(verbose = false) {
@@ -61,6 +82,9 @@ export class RustClient {
 
 		const paths =
 			process.platform === "win32" ? CARGO_WINDOWS_PATHS : CARGO_UNIX_PATHS;
+		this.sweepSawTransient = false;
+		this.sweepTransientCause = "probe-timeout";
+		this.sweepHostStallMs = 0;
 
 		for (const p of paths) {
 			try {
@@ -70,12 +94,29 @@ export class RustClient {
 						return p;
 					}
 				} else {
-					const result = await safeSpawnAsync(p, ["--version"], {
-						timeout: 3000,
-					});
+					// Host-side budget: measure the loop stall that overlapped the probe
+					// so the shared policy can tell "no cargo" from "the host was busy".
+					const sampler = startHostStallSampler();
+					let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
+					let hostStallMs: number;
+					try {
+						result = await safeSpawnAsync(p, ["--version"], {
+							timeout: PROBE_TIMEOUT_MS,
+						});
+					} finally {
+						hostStallMs = sampler.stop();
+						this.sweepHostStallMs += hostStallMs;
+					}
 					if (!result.error && result.status === 0) {
 						this.cargoPath = p;
 						return p;
+					}
+					const { outcome, cause } = classifyProbeFailure(result, {
+						hostStallMs,
+					});
+					if (outcome === "transient") {
+						this.sweepSawTransient = true;
+						this.sweepTransientCause = cause;
 					}
 				}
 			} catch (err) {
@@ -90,12 +131,58 @@ export class RustClient {
 	 * Check if cargo is installed (cached)
 	 */
 	async isAvailableAsync(): Promise<boolean> {
-		if (this.cargoAvailable !== null) return this.cargoAvailable;
-		this.cargoAvailable = (await this.findCargoPathAsync()) !== null;
-		if (this.cargoAvailable) {
-			this.log(`Cargo found: ${this.cargoPath}`);
+		// `read()` returns null when the last verdict was transient and its
+		// cooldown expired, which re-enters the candidate sweep (#1476).
+		const memo = this.availabilityLatch.read();
+		if (memo !== null) return memo;
+		// Now that a verdict can expire, concurrent callers arriving just after a
+		// cooldown must share ONE sweep rather than each spawning their own.
+		if (this.ensureInFlight) return this.ensureInFlight;
+		this.ensureInFlight = this.resolveAvailability();
+		try {
+			return await this.ensureInFlight;
+		} finally {
+			this.ensureInFlight = null;
 		}
-		return this.cargoAvailable;
+	}
+
+	private async resolveAvailability(): Promise<boolean> {
+		const startedAt = Date.now();
+		const found = (await this.findCargoPathAsync()) !== null;
+		if (found) {
+			this.availabilityLatch.noteAvailable();
+			this.log(`Cargo found: ${this.cargoPath}`);
+			logAvailabilityDecision({
+				tool: "cargo",
+				verdict: "available",
+				outcome: "success",
+				cause: "ok",
+				elapsedMs: Date.now() - startedAt,
+				latched: true,
+				hostStallMs: this.sweepHostStallMs,
+				budgetMs: PROBE_TIMEOUT_MS,
+			});
+			return true;
+		}
+		// A timed-out `cargo --version` is evidence about this moment, not about
+		// whether the toolchain is installed; it expires instead of latching.
+		const outcome = this.sweepSawTransient ? "transient" : "missing";
+		const cause = this.sweepSawTransient
+			? this.sweepTransientCause
+			: "not-found";
+		const retryAfterMs = this.availabilityLatch.noteUnavailable(outcome, cause);
+		logAvailabilityDecision({
+			tool: "cargo",
+			verdict: "unavailable",
+			outcome,
+			cause,
+			elapsedMs: Date.now() - startedAt,
+			latched: outcome !== "transient",
+			hostStallMs: this.sweepHostStallMs,
+			...(retryAfterMs > 0 && { retryAfterMs }),
+			budgetMs: PROBE_TIMEOUT_MS,
+		});
+		return false;
 	}
 
 	/**

--- a/clients/rust-client.ts
+++ b/clients/rust-client.ts
@@ -10,11 +10,9 @@
 import { createSubsystemLogger } from "./extension-log.js";
 import * as path from "node:path";
 import {
-	type AvailabilityCause,
-	createAvailabilityLatch,
-	logAvailabilityDecision,
-} from "./dispatch/runners/utils/availability-policy.js";
-import { probeAvailabilityCandidates } from "./dispatch/runners/utils/candidate-probe.js";
+	type ToolchainAvailability,
+	createToolchainAvailability,
+} from "./dispatch/runners/utils/toolchain-availability.js";
 
 // --- Types ---
 
@@ -51,102 +49,41 @@ const CARGO_UNIX_PATHS = [
 
 export class RustClient {
 	/**
-	 * Availability memo, behind the shared transient-aware latch (#1476). The
-	 * PATH candidate is resolved by spawning `cargo --version` with a 3 s budget,
-	 * so a host stall could latch "no cargo" for the session and silently disable
-	 * every Rust diagnostic until restart.
+	 * Availability lifecycle, behind the shared transient-aware latch (#1476).
+	 * The PATH candidate is resolved by spawning `cargo --version` with a 3 s
+	 * budget, so a host stall could latch "no cargo" for the session and silently
+	 * disable every Rust diagnostic until restart.
 	 */
-	private readonly availabilityLatch = createAvailabilityLatch();
-	private cargoPath: string | null = null;
-	/** Classification of the candidate sweep, for the retry decision. */
-	private sweepSawTransient = false;
-	private sweepTransientCause: AvailabilityCause = "probe-timeout";
-	private sweepHostStallMs = 0;
-	private ensureInFlight: Promise<boolean> | null = null;
+	private readonly availability: ToolchainAvailability;
 	private log: (msg: string) => void;
 
 	constructor(verbose = false) {
 		this.log = verbose
 			? createSubsystemLogger("rust")
 			: () => {};
+		this.availability = createToolchainAvailability({
+			tool: "cargo",
+			label: "Cargo",
+			windowsPaths: CARGO_WINDOWS_PATHS,
+			unixPaths: CARGO_UNIX_PATHS,
+			probeArgs: ["--version"],
+			budgetMs: PROBE_TIMEOUT_MS,
+			log: (msg) => this.log(msg),
+		});
 	}
 
 	/**
 	 * Find cargo executable path (async — probes PATH candidates off the event loop).
 	 */
 	async findCargoPathAsync(): Promise<string | null> {
-		if (this.cargoPath) return this.cargoPath;
-
-		const paths =
-			process.platform === "win32" ? CARGO_WINDOWS_PATHS : CARGO_UNIX_PATHS;
-		const sweep = await probeAvailabilityCandidates(
-			paths,
-			["--version"],
-			PROBE_TIMEOUT_MS,
-		);
-		this.sweepSawTransient = sweep.sawTransient;
-		this.sweepTransientCause = sweep.transientCause;
-		this.sweepHostStallMs = sweep.hostStallMs;
-		if (sweep.foundPath) this.cargoPath = sweep.foundPath;
-		return sweep.foundPath;
+		return this.availability.findPath();
 	}
 
 	/**
 	 * Check if cargo is installed (cached)
 	 */
 	async isAvailableAsync(): Promise<boolean> {
-		// `read()` returns null when the last verdict was transient and its
-		// cooldown expired, which re-enters the candidate sweep (#1476).
-		const memo = this.availabilityLatch.read();
-		if (memo !== null) return memo;
-		// Now that a verdict can expire, concurrent callers arriving just after a
-		// cooldown must share ONE sweep rather than each spawning their own.
-		if (this.ensureInFlight) return this.ensureInFlight;
-		this.ensureInFlight = this.resolveAvailability();
-		try {
-			return await this.ensureInFlight;
-		} finally {
-			this.ensureInFlight = null;
-		}
-	}
-
-	private async resolveAvailability(): Promise<boolean> {
-		const startedAt = Date.now();
-		const found = (await this.findCargoPathAsync()) !== null;
-		if (found) {
-			this.availabilityLatch.noteAvailable();
-			this.log(`Cargo found: ${this.cargoPath}`);
-			logAvailabilityDecision({
-				tool: "cargo",
-				verdict: "available",
-				outcome: "success",
-				cause: "ok",
-				elapsedMs: Date.now() - startedAt,
-				latched: true,
-				hostStallMs: this.sweepHostStallMs,
-				budgetMs: PROBE_TIMEOUT_MS,
-			});
-			return true;
-		}
-		// A timed-out `cargo --version` is evidence about this moment, not about
-		// whether the toolchain is installed; it expires instead of latching.
-		const outcome = this.sweepSawTransient ? "transient" : "missing";
-		const cause = this.sweepSawTransient
-			? this.sweepTransientCause
-			: "not-found";
-		const retryAfterMs = this.availabilityLatch.noteUnavailable(outcome, cause);
-		logAvailabilityDecision({
-			tool: "cargo",
-			verdict: "unavailable",
-			outcome,
-			cause,
-			elapsedMs: Date.now() - startedAt,
-			latched: outcome !== "transient",
-			hostStallMs: this.sweepHostStallMs,
-			...(retryAfterMs > 0 && { retryAfterMs }),
-			budgetMs: PROBE_TIMEOUT_MS,
-		});
-		return false;
+		return this.availability.isAvailable();
 	}
 
 	/**

--- a/clients/rust-client.ts
+++ b/clients/rust-client.ts
@@ -8,16 +8,13 @@
  */
 
 import { createSubsystemLogger } from "./extension-log.js";
-import * as fs from "node:fs";
 import * as path from "node:path";
-import { safeSpawnAsync } from "./safe-spawn.js";
 import {
 	type AvailabilityCause,
-	classifyProbeFailure,
 	createAvailabilityLatch,
 	logAvailabilityDecision,
-	startHostStallSampler,
 } from "./dispatch/runners/utils/availability-policy.js";
+import { probeAvailabilityCandidates } from "./dispatch/runners/utils/candidate-probe.js";
 
 // --- Types ---
 
@@ -82,49 +79,16 @@ export class RustClient {
 
 		const paths =
 			process.platform === "win32" ? CARGO_WINDOWS_PATHS : CARGO_UNIX_PATHS;
-		this.sweepSawTransient = false;
-		this.sweepTransientCause = "probe-timeout";
-		this.sweepHostStallMs = 0;
-
-		for (const p of paths) {
-			try {
-				if (p.includes("\\") || p.includes("/")) {
-					if (fs.existsSync(p)) {
-						this.cargoPath = p;
-						return p;
-					}
-				} else {
-					// Host-side budget: measure the loop stall that overlapped the probe
-					// so the shared policy can tell "no cargo" from "the host was busy".
-					const sampler = startHostStallSampler();
-					let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
-					let hostStallMs: number;
-					try {
-						result = await safeSpawnAsync(p, ["--version"], {
-							timeout: PROBE_TIMEOUT_MS,
-						});
-					} finally {
-						hostStallMs = sampler.stop();
-						this.sweepHostStallMs += hostStallMs;
-					}
-					if (!result.error && result.status === 0) {
-						this.cargoPath = p;
-						return p;
-					}
-					const { outcome, cause } = classifyProbeFailure(result, {
-						hostStallMs,
-					});
-					if (outcome === "transient") {
-						this.sweepSawTransient = true;
-						this.sweepTransientCause = cause;
-					}
-				}
-			} catch (err) {
-				void err;
-			}
-		}
-
-		return null;
+		const sweep = await probeAvailabilityCandidates(
+			paths,
+			["--version"],
+			PROBE_TIMEOUT_MS,
+		);
+		this.sweepSawTransient = sweep.sawTransient;
+		this.sweepTransientCause = sweep.transientCause;
+		this.sweepHostStallMs = sweep.hostStallMs;
+		if (sweep.foundPath) this.cargoPath = sweep.foundPath;
+		return sweep.foundPath;
 	}
 
 	/**

--- a/clients/security-scan-client.ts
+++ b/clients/security-scan-client.ts
@@ -145,11 +145,15 @@ export abstract class SecurityScanClient<TResult> {
 	/**
 	 * Record a non-durable unavailability: the verdict expires after a cooldown
 	 * and the next `ensureAvailable` re-probes.
+	 *
+	 * Returns that cooldown in ms so the caller can put it in its decision
+	 * record. A latch you can read in `latency.log` without the retry schedule
+	 * beside it only tells you the tool is off, not when it comes back.
 	 */
 	protected markTransientlyUnavailable(
 		cause: AvailabilityCause = "probe-timeout",
-	): void {
-		this.availabilityLatch.noteUnavailable("transient", cause);
+	): number {
+		return this.availabilityLatch.noteUnavailable("transient", cause);
 	}
 
 	/**

--- a/clients/sg-runner.ts
+++ b/clients/sg-runner.ts
@@ -190,9 +190,19 @@ export class SgRunner {
 	 */
 	private readonly availabilityLatch = createAvailabilityLatch();
 	private ensureInFlight: Promise<boolean> | null = null;
-	/** Whether ANY candidate in the current sweep failed for a transient reason. */
+	/**
+	 * Whether a DIRECT candidate — one that would have been ast-grep itself —
+	 * failed for a transient reason in the current sweep. Only these block the
+	 * install: a slow `npx` says nothing about whether ast-grep is on this
+	 * machine, and letting it block turned "ast-grep is genuinely absent on a
+	 * slow host" into "ast-grep is never installed and npx is re-spawned every
+	 * sweep, forever".
+	 */
 	private sweepSawTransient = false;
 	private sweepTransientCause: AvailabilityCause = "probe-timeout";
+	/** A transient on the npx fallback: not evidence, but not nothing either. */
+	private sweepFallbackTransient = false;
+	private sweepFallbackCause: AvailabilityCause = "probe-timeout";
 	/** Host stall summed over every probe of the current sweep, ms. */
 	private sweepHostStallMs = 0;
 
@@ -229,6 +239,8 @@ export class SgRunner {
 		const startedAt = Date.now();
 		this.sweepSawTransient = false;
 		this.sweepTransientCause = "probe-timeout";
+		this.sweepFallbackTransient = false;
+		this.sweepFallbackCause = "probe-timeout";
 		this.sweepHostStallMs = 0;
 
 		// Step 1: PATH — canonical binary names + npx fallback.
@@ -236,7 +248,10 @@ export class SgRunner {
 		const pathCommand = await this.probeCommandCandidates([
 			{ cmd: "ast-grep", argsPrefix: [] },
 			{ cmd: "sg", argsPrefix: [] },
-			{ cmd: "npx", argsPrefix: ["--no", "--", "ast-grep"] },
+			// `npx --no -- ast-grep` starts a Node process before it can answer, so
+			// it is the candidate most likely to blow a 5 s budget on a cold or busy
+			// box. Marked a fallback so its timeout cannot veto the install.
+			{ cmd: "npx", argsPrefix: ["--no", "--", "ast-grep"], fallback: true },
 		]);
 		if (pathCommand) {
 			this.sgPath = pathCommand.cmd;
@@ -284,10 +299,16 @@ export class SgRunner {
 			}
 		}
 
-		// A timeout on ANY candidate means the machine answered, not the tool
+		// A timeout on a DIRECT candidate means the machine answered, not the tool
 		// (#1476). Installing ast-grep because the host event loop stalled is a
 		// heavyweight reaction to a hiccup, and latching the result disabled the
 		// tool until restart. Retry the sweep later instead.
+		//
+		// The npx fallback is deliberately NOT part of this test. Gating the
+		// install on it regressed the very host this change targets: a slow box
+		// with no ast-grep timed out `npx --no -- ast-grep` every sweep, so the
+		// install below was never reached and the slow npx was re-spawned on each
+		// escalating retry instead — worse than the latch it replaced.
 		if (this.sweepSawTransient) {
 			this.log(
 				"ast-grep availability probe timed out; will retry (not installing)",
@@ -316,6 +337,15 @@ export class SgRunner {
 			return true;
 		}
 
+		// The install failed AND the npx fallback never got a fair hearing, so
+		// "ast-grep is not installed" is not a fact yet. Expire the verdict.
+		if (this.sweepFallbackTransient) {
+			return this.noteUnavailable(
+				startedAt,
+				"transient",
+				this.sweepFallbackCause,
+			);
+		}
 		return this.noteUnavailable(startedAt, "missing", "not-found");
 	}
 
@@ -453,6 +483,7 @@ export class SgRunner {
 	private async probeCommand(
 		cmd: string,
 		argsPrefix: string[],
+		fallback = false,
 	): Promise<boolean> {
 		// Host-side budget: measure the loop stall that overlapped the window so
 		// the classifier can tell "the tool is slow" from "the host was busy".
@@ -476,17 +507,28 @@ export class SgRunner {
 		}
 		const { outcome, cause } = classifyProbeFailure(result, { hostStallMs });
 		if (outcome === "transient") {
-			this.sweepSawTransient = true;
-			this.sweepTransientCause = cause;
+			if (fallback) {
+				this.sweepFallbackTransient = true;
+				this.sweepFallbackCause = cause;
+			} else {
+				this.sweepSawTransient = true;
+				this.sweepTransientCause = cause;
+			}
 		}
 		return false;
 	}
 
 	private async probeCommandCandidates(
-		candidates: Array<{ cmd: string; argsPrefix: string[] }>,
+		candidates: Array<{ cmd: string; argsPrefix: string[]; fallback?: boolean }>,
 	): Promise<{ cmd: string; argsPrefix: string[] } | undefined> {
 		for (const candidate of candidates) {
-			if (await this.probeCommand(candidate.cmd, candidate.argsPrefix)) {
+			if (
+				await this.probeCommand(
+					candidate.cmd,
+					candidate.argsPrefix,
+					candidate.fallback ?? false,
+				)
+			) {
 				return candidate;
 			}
 		}

--- a/clients/sg-runner.ts
+++ b/clients/sg-runner.ts
@@ -16,6 +16,13 @@ import {
 import { getProjectIgnoreGlobs } from "./file-utils.js";
 import { findGlobalBinary } from "./package-manager.js";
 import { safeSpawnAsync, type SpawnResult } from "./safe-spawn.js";
+import {
+	type AvailabilityCause,
+	classifyProbeFailure,
+	createAvailabilityLatch,
+	logAvailabilityDecision,
+	startHostStallSampler,
+} from "./dispatch/runners/utils/availability-policy.js";
 
 /**
  * Build the `bash -c` argv that runs `cmd` with `allArgs` as POSITIONAL
@@ -109,6 +116,8 @@ export interface SgScanResult {
 }
 
 const DEFAULT_EXEC_TIMEOUT_MS = 30_000;
+/** Budget for a single `--version` candidate probe, ms. */
+const PROBE_TIMEOUT_MS = 5_000;
 const MAX_SG_OUTPUT_BYTES = 8 * 1024 * 1024;
 
 /**
@@ -171,8 +180,21 @@ export class SgRunner {
 	private log: (msg: string) => void;
 	private sgPath: string | null = null;
 	private sgArgsPrefix: string[] = [];
-	private available: boolean | null = null;
+	/**
+	 * Availability memo, backed by the shared transient-aware latch (#1476).
+	 *
+	 * Before this, one failed sweep over every candidate — timeouts included —
+	 * latched `false` for the life of the process AND ran a full auto-install
+	 * first. A host stall during warm-up therefore both disabled ast-grep until
+	 * restart and paid for an install nobody needed.
+	 */
+	private readonly availabilityLatch = createAvailabilityLatch();
 	private ensureInFlight: Promise<boolean> | null = null;
+	/** Whether ANY candidate in the current sweep failed for a transient reason. */
+	private sweepSawTransient = false;
+	private sweepTransientCause: AvailabilityCause = "probe-timeout";
+	/** Host stall summed over every probe of the current sweep, ms. */
+	private sweepHostStallMs = 0;
 
 	constructor(verbose = false) {
 		this.log = verbose
@@ -189,8 +211,10 @@ export class SgRunner {
 	 * `KnipClient.ensureAvailable` and `DependencyChecker.ensureAvailable`.
 	 */
 	async ensureAvailable(): Promise<boolean> {
-		// Fast path: already checked.
-		if (this.available !== null) return this.available;
+		// Fast path: already decided. `read()` returns null when the last verdict
+		// was transient and its cooldown expired, which re-enters the sweep.
+		const memo = this.availabilityLatch.read();
+		if (memo !== null) return memo;
 		if (this.ensureInFlight) return this.ensureInFlight;
 
 		this.ensureInFlight = this.doEnsureAvailable();
@@ -202,6 +226,11 @@ export class SgRunner {
 	}
 
 	private async doEnsureAvailable(): Promise<boolean> {
+		const startedAt = Date.now();
+		this.sweepSawTransient = false;
+		this.sweepTransientCause = "probe-timeout";
+		this.sweepHostStallMs = 0;
+
 		// Step 1: PATH — canonical binary names + npx fallback.
 		// Prefer ast-grep over sg on Linux: /usr/bin/sg is util-linux, not ast-grep.
 		const pathCommand = await this.probeCommandCandidates([
@@ -212,8 +241,7 @@ export class SgRunner {
 		if (pathCommand) {
 			this.sgPath = pathCommand.cmd;
 			this.sgArgsPrefix = pathCommand.argsPrefix;
-			this.available = true;
-			this.log(`ast-grep found on PATH: ${pathCommand.cmd}`);
+			this.noteAvailable(startedAt, `ast-grep found on PATH: ${pathCommand.cmd}`);
 			return true;
 		}
 
@@ -226,8 +254,7 @@ export class SgRunner {
 			if (globalBin && (await this.probeCommand(globalBin, []))) {
 				this.sgPath = globalBin;
 				this.sgArgsPrefix = [];
-				this.available = true;
-				this.log(`ast-grep found in global bin: ${globalBin}`);
+				this.noteAvailable(startedAt, `ast-grep found in global bin: ${globalBin}`);
 				return true;
 			}
 		}
@@ -239,8 +266,10 @@ export class SgRunner {
 		if (platformBinary) {
 			this.sgPath = platformBinary;
 			this.sgArgsPrefix = [];
-			this.available = true;
-			this.log(`ast-grep found via platform package: ${platformBinary}`);
+			this.noteAvailable(
+				startedAt,
+				`ast-grep found via platform package: ${platformBinary}`,
+			);
 			return true;
 		}
 
@@ -250,10 +279,24 @@ export class SgRunner {
 			if (brewBinary) {
 				this.sgPath = brewBinary;
 				this.sgArgsPrefix = [];
-				this.available = true;
-				this.log(`ast-grep found via Homebrew: ${brewBinary}`);
+				this.noteAvailable(startedAt, `ast-grep found via Homebrew: ${brewBinary}`);
 				return true;
 			}
+		}
+
+		// A timeout on ANY candidate means the machine answered, not the tool
+		// (#1476). Installing ast-grep because the host event loop stalled is a
+		// heavyweight reaction to a hiccup, and latching the result disabled the
+		// tool until restart. Retry the sweep later instead.
+		if (this.sweepSawTransient) {
+			this.log(
+				"ast-grep availability probe timed out; will retry (not installing)",
+			);
+			return this.noteUnavailable(
+				startedAt,
+				"transient",
+				this.sweepTransientCause,
+			);
 		}
 
 		// Step 4: install via the typed shared seam, then validate the returned
@@ -269,12 +312,53 @@ export class SgRunner {
 		if (installed.outcome === "success") {
 			this.sgPath = installed.value;
 			this.sgArgsPrefix = [];
-			this.available = true;
-			this.log(`ast-grep auto-installed: ${installed.value}`);
+			this.noteAvailable(startedAt, `ast-grep auto-installed: ${installed.value}`);
 			return true;
 		}
 
-		this.available = false;
+		return this.noteUnavailable(startedAt, "missing", "not-found");
+	}
+
+	/** Record a successful sweep: available, latched, one decision record. */
+	private noteAvailable(startedAt: number, message: string): void {
+		this.availabilityLatch.noteAvailable();
+		this.log(message);
+		logAvailabilityDecision({
+			tool: "ast-grep",
+			verdict: "available",
+			outcome: "success",
+			cause: "ok",
+			elapsedMs: Date.now() - startedAt,
+			latched: true,
+			hostStallMs: this.sweepHostStallMs,
+			budgetMs: PROBE_TIMEOUT_MS,
+		});
+	}
+
+	/**
+	 * Record a failed sweep. A `transient` outcome expires after a bounded
+	 * cooldown; anything else is remembered for the session, as before. The
+	 * elapsed/stall numbers describe the WHOLE sweep, because the verdict is
+	 * about the sweep rather than any single candidate — reporting zero here
+	 * would erase the evidence that cracked #1467.
+	 */
+	private noteUnavailable(
+		startedAt: number,
+		outcome: "missing" | "transient",
+		cause: AvailabilityCause,
+	): false {
+		const retryAfterMs = this.availabilityLatch.noteUnavailable(outcome, cause);
+		logAvailabilityDecision({
+			tool: "ast-grep",
+			verdict: "unavailable",
+			outcome,
+			cause,
+			elapsedMs: Date.now() - startedAt,
+			latched: outcome !== "transient",
+			hostStallMs: this.sweepHostStallMs,
+			...(retryAfterMs > 0 && { retryAfterMs }),
+			budgetMs: PROBE_TIMEOUT_MS,
+		});
 		return false;
 	}
 
@@ -360,18 +444,42 @@ export class SgRunner {
 		return /\bast[- ]grep\b/i.test(output);
 	}
 
+	/**
+	 * Probe one candidate. A failure is CLASSIFIED, not merely counted: a
+	 * timeout/abort marks the whole sweep transient so the caller retries later
+	 * instead of installing and latching. A command that answers but is not
+	 * ast-grep (Linux `/usr/bin/sg` is util-linux) is a durable no.
+	 */
 	private async probeCommand(
 		cmd: string,
 		argsPrefix: string[],
 	): Promise<boolean> {
-		const result = await safeSpawnAsync(cmd, [...argsPrefix, "--version"], {
-			timeout: 5000,
-		});
-		return (
+		// Host-side budget: measure the loop stall that overlapped the window so
+		// the classifier can tell "the tool is slow" from "the host was busy".
+		const sampler = startHostStallSampler();
+		let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
+		let hostStallMs: number;
+		try {
+			result = await safeSpawnAsync(cmd, [...argsPrefix, "--version"], {
+				timeout: PROBE_TIMEOUT_MS,
+			});
+		} finally {
+			hostStallMs = sampler.stop();
+			this.sweepHostStallMs += hostStallMs;
+		}
+		if (
 			!result.error &&
 			result.status === 0 &&
 			this.isAstGrepVersionOutput(`${result.stdout}\n${result.stderr}`)
-		);
+		) {
+			return true;
+		}
+		const { outcome, cause } = classifyProbeFailure(result, { hostStallMs });
+		if (outcome === "transient") {
+			this.sweepSawTransient = true;
+			this.sweepTransientCause = cause;
+		}
+		return false;
 	}
 
 	private async probeCommandCandidates(

--- a/tests/clients/availability-latching-siblings.test.ts
+++ b/tests/clients/availability-latching-siblings.test.ts
@@ -1,0 +1,355 @@
+/**
+ * #1476 — the three availability consumers the #1467 class sweep missed, plus
+ * the shared ast-grep memo the #1476 sweep found: biome, `SgRunner`,
+ * `isSgAvailableAsync`, and govulncheck's `go install`.
+ *
+ * Each one latched ANY probe failure — a timeout included — as a permanent
+ * "the tool is not installed" verdict, and biome and `SgRunner` ran a full
+ * auto-install on the way there.
+ *
+ * Every describe block pins the two verdicts that must NOT change (a genuine
+ * absence, a successful probe) beside the transient case that must. A migration
+ * that quietly redefined "missing" for the hot-path formatter would be worse
+ * than the bug it fixes.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TRANSIENT_BASE_COOLDOWN_MS } from "../../clients/dispatch/runners/utils/availability-policy.ts";
+
+/**
+ * Reset through the SAME module instance the clients load (the compiled `.js`),
+ * not the `.ts` source: the shared ast-grep memo lives in module state, and a
+ * reset applied to a second instance of the module silently resets nothing.
+ */
+async function resetDispatchAvailabilityState(): Promise<void> {
+	const helpers = await import(
+		"../../clients/dispatch/runners/utils/runner-helpers.js"
+	);
+	helpers.resetDispatchAvailabilityState();
+}
+
+const { safeSpawnAsync, safeSpawn, ensureTool } = vi.hoisted(() => ({
+	safeSpawnAsync: vi.fn(),
+	safeSpawn: vi.fn(),
+	ensureTool: vi.fn(),
+}));
+
+vi.mock("../../clients/safe-spawn.js", () => ({
+	safeSpawn,
+	safeSpawnAsync,
+	isCommandAvailableAsync: vi.fn(async () => false),
+}));
+
+vi.mock("../../clients/installer/index.js", () => ({
+	ensureTool,
+	isSpawnableCommand: vi.fn(async () => true),
+	resetPathWalkMemo: vi.fn(),
+	getToolEnvironment: vi.fn(async () => ({})),
+}));
+
+vi.mock("../../clients/package-manager.js", () => ({
+	findGlobalBinary: vi.fn(async () => undefined),
+	findNodeToolBinary: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../clients/project-trust.js", () => ({
+	assertInstallAllowed: vi.fn(() => true),
+}));
+
+/** A probe the host killed at its budget: says nothing about the tool. */
+const timeoutResult = {
+	stdout: "",
+	stderr: "",
+	status: null,
+	error: new Error("Process timed out after 5000ms"),
+	failure: "timeout",
+	spawnFailure: { kind: "timeout" },
+};
+
+/** A probe that proved the tool is not on this machine. */
+const missingResult = {
+	stdout: "",
+	stderr: "",
+	status: null,
+	error: Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }),
+	failure: "spawn",
+	spawnFailure: { kind: "tool-not-found" },
+};
+
+const okResult = (stdout: string) => ({
+	stdout,
+	stderr: "",
+	status: 0,
+	error: undefined,
+});
+
+function advancePastCooldown(): void {
+	vi.setSystemTime(new Date(Date.now() + TRANSIENT_BASE_COOLDOWN_MS + 1));
+}
+
+beforeEach(async () => {
+	vi.resetAllMocks();
+	ensureTool.mockResolvedValue(null);
+	safeSpawn.mockReturnValue({ stdout: "", stderr: "", status: 1 });
+	await resetDispatchAvailabilityState();
+	vi.useFakeTimers({ toFake: ["Date"] });
+});
+
+afterEach(async () => {
+	vi.useRealTimers();
+	await resetDispatchAvailabilityState();
+});
+
+describe("BiomeClient availability (#1476)", () => {
+	it("pins a genuine absence: latched false, and an install IS attempted", async () => {
+		safeSpawnAsync.mockResolvedValue(missingResult);
+		const { BiomeClient } = await import("../../clients/biome-client.js");
+		const client = new BiomeClient();
+
+		expect(await client.ensureAvailable()).toBe(false);
+		expect(ensureTool).toHaveBeenCalledWith("biome");
+		const probesAfterFirst = safeSpawnAsync.mock.calls.length;
+
+		// A durable verdict is remembered for the session: no second probe.
+		expect(await client.ensureAvailable()).toBe(false);
+		expect(safeSpawnAsync.mock.calls.length).toBe(probesAfterFirst);
+	});
+
+	it("pins a successful probe: available, and no install", async () => {
+		safeSpawnAsync.mockResolvedValue(okResult("biome 1.9.4"));
+		const { BiomeClient } = await import("../../clients/biome-client.js");
+		const client = new BiomeClient();
+
+		expect(await client.ensureAvailable()).toBe(true);
+		expect(ensureTool).not.toHaveBeenCalled();
+	});
+
+	it("a timed-out probe neither installs nor latches, and recovers", async () => {
+		safeSpawnAsync.mockResolvedValue(timeoutResult);
+		const { BiomeClient } = await import("../../clients/biome-client.js");
+		const client = new BiomeClient();
+
+		expect(await client.ensureAvailable()).toBe(false);
+		// Pre-fix, the timeout collapsed to `missing`, which installed biome.
+		expect(ensureTool).not.toHaveBeenCalled();
+
+		// Inside the cooldown the verdict holds, so a stalling host cannot be
+		// re-probed on every keystroke.
+		const probes = safeSpawnAsync.mock.calls.length;
+		expect(await client.ensureAvailable()).toBe(false);
+		expect(safeSpawnAsync.mock.calls.length).toBe(probes);
+
+		// After the cooldown the very same client re-probes and biome comes back
+		// without a host restart. Pre-fix this stayed false forever.
+		advancePastCooldown();
+		safeSpawnAsync.mockResolvedValue(okResult("biome 1.9.4"));
+		expect(await client.ensureAvailable()).toBe(true);
+	});
+
+	it("concurrent first-time callers share one probe (no retry storm)", async () => {
+		let release: ((value: unknown) => void) | undefined;
+		safeSpawnAsync.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					release = resolve;
+				}),
+		);
+		const { BiomeClient } = await import("../../clients/biome-client.js");
+		const client = new BiomeClient();
+		const calls = [
+			client.ensureAvailable(),
+			client.ensureAvailable(),
+			client.ensureAvailable(),
+		];
+		await Promise.resolve();
+		await new Promise((r) => setTimeout(r, 0));
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+		release?.(okResult("biome 1.9.4"));
+		expect(await Promise.all(calls)).toEqual([true, true, true]);
+	});
+});
+
+describe("SgRunner availability (#1476)", () => {
+	it("pins a genuine absence: latched false, and an install IS attempted", async () => {
+		safeSpawnAsync.mockResolvedValue(missingResult);
+		const { SgRunner } = await import("../../clients/sg-runner.js");
+		const runner = new SgRunner();
+
+		expect(await runner.ensureAvailable()).toBe(false);
+		expect(ensureTool).toHaveBeenCalledWith("ast-grep");
+		const probes = safeSpawnAsync.mock.calls.length;
+		expect(await runner.ensureAvailable()).toBe(false);
+		expect(safeSpawnAsync.mock.calls.length).toBe(probes);
+	});
+
+	it("pins a successful probe: available, and no install", async () => {
+		safeSpawnAsync.mockResolvedValue(okResult("ast-grep 0.32.3"));
+		const { SgRunner } = await import("../../clients/sg-runner.js");
+		const runner = new SgRunner();
+
+		expect(await runner.ensureAvailable()).toBe(true);
+		expect(ensureTool).not.toHaveBeenCalled();
+	});
+
+	it("a timed-out sweep neither installs nor latches, and recovers", async () => {
+		safeSpawnAsync.mockResolvedValue(timeoutResult);
+		const { SgRunner } = await import("../../clients/sg-runner.js");
+		const runner = new SgRunner();
+
+		expect(await runner.ensureAvailable()).toBe(false);
+		// Pre-fix this ran a full ast-grep auto-install because the host stalled.
+		expect(ensureTool).not.toHaveBeenCalled();
+
+		advancePastCooldown();
+		safeSpawnAsync.mockResolvedValue(okResult("ast-grep 0.32.3"));
+		expect(await runner.ensureAvailable()).toBe(true);
+	});
+});
+
+describe("shared ast-grep availability (#1476)", () => {
+	it("pins a genuine absence: latched false for the session", async () => {
+		safeSpawnAsync.mockResolvedValue(missingResult);
+		const { isSgAvailableAsync } = await import(
+			"../../clients/dispatch/runners/utils/runner-helpers.js"
+		);
+
+		expect(await isSgAvailableAsync()).toBe(false);
+		const probes = safeSpawnAsync.mock.calls.length;
+		expect(probes).toBeGreaterThan(0);
+		expect(await isSgAvailableAsync()).toBe(false);
+		expect(safeSpawnAsync.mock.calls.length).toBe(probes);
+	});
+
+	it("a timed-out sweep expires and re-probes after the cooldown", async () => {
+		safeSpawnAsync.mockResolvedValue(timeoutResult);
+		const { isSgAvailableAsync } = await import(
+			"../../clients/dispatch/runners/utils/runner-helpers.js"
+		);
+
+		expect(await isSgAvailableAsync()).toBe(false);
+		const probes = safeSpawnAsync.mock.calls.length;
+		// Held inside the cooldown: no probe storm while the host is still sick.
+		expect(await isSgAvailableAsync()).toBe(false);
+		expect(safeSpawnAsync.mock.calls.length).toBe(probes);
+
+		advancePastCooldown();
+		safeSpawnAsync.mockResolvedValue(okResult("ast-grep 0.32.3"));
+		expect(await isSgAvailableAsync()).toBe(true);
+	});
+});
+
+describe("govulncheck availability (#1476)", () => {
+	/** Route each spawn by command so install order stays readable. */
+	function route(handlers: {
+		govulncheck?: unknown[];
+		go?: unknown[];
+		install?: unknown;
+	}): void {
+		const govulncheckQueue = [...(handlers.govulncheck ?? [])];
+		const goQueue = [...(handlers.go ?? [])];
+		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) => {
+			if (cmd === "govulncheck") {
+				return govulncheckQueue.shift() ?? missingResult;
+			}
+			if (cmd === "go" && args[0] === "install") {
+				return handlers.install ?? okResult("");
+			}
+			return goQueue.shift() ?? okResult("go version go1.23.0");
+		});
+	}
+
+	it("pins the install path: probe misses, go installs, re-probe succeeds", async () => {
+		route({
+			govulncheck: [missingResult, okResult("govulncheck v1.1.3")],
+			install: okResult(""),
+		});
+		const { GovulncheckClient } = await import(
+			"../../clients/govulncheck-client.js"
+		);
+		const client = new GovulncheckClient();
+
+		expect(await client.ensureAvailable()).toBe(true);
+	});
+
+	it("pins a failed install (non-zero exit): latched false, no re-install", async () => {
+		route({
+			govulncheck: [missingResult],
+			install: { stdout: "", stderr: "no matching versions", status: 1 },
+		});
+		const { GovulncheckClient } = await import(
+			"../../clients/govulncheck-client.js"
+		);
+		const client = new GovulncheckClient();
+
+		expect(await client.ensureAvailable()).toBe(false);
+		const spawns = safeSpawnAsync.mock.calls.length;
+		expect(await client.ensureAvailable()).toBe(false);
+		expect(safeSpawnAsync.mock.calls.length).toBe(spawns);
+	});
+
+	it("a timed-out `go install` does not latch, and recovers", async () => {
+		route({ govulncheck: [missingResult], install: timeoutResult });
+		const { GovulncheckClient } = await import(
+			"../../clients/govulncheck-client.js"
+		);
+		const client = new GovulncheckClient();
+
+		expect(await client.ensureAvailable()).toBe(false);
+
+		// Pre-fix, the 60 s network budget expiring once disabled govulncheck for
+		// the life of the process.
+		advancePastCooldown();
+		route({ govulncheck: [okResult("govulncheck v1.1.3")] });
+		expect(await client.ensureAvailable()).toBe(true);
+	});
+});
+
+describe("dispatch hasTool availability (#1476)", () => {
+	/** The generic seam every CLI runner gates on: `ctx.hasTool(command)`. */
+	async function load() {
+		const dispatcher = await import("../../clients/dispatch/dispatcher.js");
+		const { FactStore } = await import("../../clients/dispatch/fact-store.js");
+		return { checkToolAvailability: dispatcher.checkToolAvailability, facts: new FactStore() };
+	}
+
+	it("pins a successful probe: available, and cached for the session", async () => {
+		safeSpawnAsync.mockResolvedValue(okResult("1.2.3"));
+		const { checkToolAvailability, facts } = await load();
+
+		expect(await checkToolAvailability("sometool", facts)).toBe(true);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+		expect(await checkToolAvailability("sometool", facts)).toBe(true);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+	});
+
+	it("pins a genuine absence: latched false for the session", async () => {
+		safeSpawnAsync.mockResolvedValue({
+			stdout: "",
+			stderr: "",
+			status: 1,
+			error: undefined,
+		});
+		const { checkToolAvailability, facts } = await load();
+
+		expect(await checkToolAvailability("sometool", facts)).toBe(false);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+		expect(await checkToolAvailability("sometool", facts)).toBe(false);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+	});
+
+	it("a timed-out probe does not latch, and the tool comes back", async () => {
+		safeSpawnAsync.mockResolvedValue(timeoutResult);
+		const { checkToolAvailability, facts } = await load();
+
+		expect(await checkToolAvailability("sometool", facts)).toBe(false);
+		// Held for the cooldown: a stalling host is not re-probed every dispatch.
+		expect(await checkToolAvailability("sometool", facts)).toBe(false);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+
+		// Pre-fix, this false was a session fact and every later dispatch in the
+		// session skipped the tool.
+		advancePastCooldown();
+		safeSpawnAsync.mockResolvedValue(okResult("1.2.3"));
+		expect(await checkToolAvailability("sometool", facts)).toBe(true);
+	});
+});

--- a/tests/clients/availability-latching-siblings.test.ts
+++ b/tests/clients/availability-latching-siblings.test.ts
@@ -14,7 +14,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { TRANSIENT_BASE_COOLDOWN_MS } from "../../clients/dispatch/runners/utils/availability-policy.ts";
+import {
+	HOST_STALL_COOLDOWN_MS,
+	TRANSIENT_BASE_COOLDOWN_MS,
+} from "../../clients/dispatch/runners/utils/availability-policy.ts";
 
 /**
  * Reset through the SAME module instance the clients load (the compiled `.js`),
@@ -28,11 +31,31 @@ async function resetDispatchAvailabilityState(): Promise<void> {
 	helpers.resetDispatchAvailabilityState();
 }
 
-const { safeSpawnAsync, safeSpawn, ensureTool } = vi.hoisted(() => ({
+const { safeSpawnAsync, safeSpawn, ensureTool, logLatency } = vi.hoisted(() => ({
 	safeSpawnAsync: vi.fn(),
 	safeSpawn: vi.fn(),
 	ensureTool: vi.fn(),
+	logLatency: vi.fn(),
 }));
+
+// Spread the real module: only `logLatency` is intercepted, so the rest of the
+// import graph keeps working.
+vi.mock("../../clients/latency-logger.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../clients/latency-logger.js")>();
+	return { ...actual, logLatency };
+});
+
+/** Availability decision records emitted for `tool`, oldest first. */
+function decisionsFor(tool: string): Array<Record<string, unknown>> {
+	return logLatency.mock.calls
+		.map((call) => call[0] as Record<string, unknown>)
+		.filter(
+			(entry) =>
+				entry?.phase === "availability_decision" &&
+				(entry.metadata as Record<string, unknown> | undefined)?.tool === tool,
+		);
+}
 
 vi.mock("../../clients/safe-spawn.js", () => ({
 	safeSpawn,
@@ -304,6 +327,115 @@ describe("govulncheck availability (#1476)", () => {
 	});
 });
 
+describe("SgRunner: a slow npx must not veto the install (#1489 review)", () => {
+	/** Route the sweep per command so each candidate's verdict is explicit. */
+	function route(byCommand: Record<string, unknown>, fallback: unknown): void {
+		safeSpawnAsync.mockImplementation(async (cmd: string) =>
+			cmd in byCommand ? byCommand[cmd] : fallback,
+		);
+	}
+
+	it("installs when ast-grep is genuinely absent and only npx timed out", async () => {
+		// The exact shape of a cold or busy Windows box: the binary is not there,
+		// and `npx --no -- ast-grep` cannot answer inside a 5 s budget because it
+		// has to start Node first. Gating the install on ANY transient turned this
+		// into "never install, re-spawn the slow npx every sweep, forever".
+		route(
+			{
+				"ast-grep": missingResult,
+				sg: missingResult,
+				npx: timeoutResult,
+				"/managed/ast-grep": okResult("ast-grep 0.32.3"),
+			},
+			missingResult,
+		);
+		ensureTool.mockResolvedValue("/managed/ast-grep");
+		const { SgRunner } = await import("../../clients/sg-runner.js");
+		const runner = new SgRunner();
+
+		expect(await runner.ensureAvailable()).toBe(true);
+		expect(ensureTool).toHaveBeenCalledWith("ast-grep");
+	});
+
+	it("still refuses to install when a DIRECT candidate timed out", async () => {
+		// The #1476 guarantee, unchanged: `ast-grep` itself failing to answer is a
+		// statement about the host, not about the tool.
+		route({ "ast-grep": timeoutResult, sg: missingResult, npx: missingResult }, missingResult);
+		const { SgRunner } = await import("../../clients/sg-runner.js");
+		const runner = new SgRunner();
+
+		expect(await runner.ensureAvailable()).toBe(false);
+		expect(ensureTool).not.toHaveBeenCalled();
+	});
+
+	it("does not latch 'missing' when the install fails after an npx timeout", async () => {
+		route({ "ast-grep": missingResult, sg: missingResult, npx: timeoutResult }, missingResult);
+		ensureTool.mockResolvedValue(null);
+		const { SgRunner } = await import("../../clients/sg-runner.js");
+		const runner = new SgRunner();
+
+		expect(await runner.ensureAvailable()).toBe(false);
+		expect(ensureTool).toHaveBeenCalledWith("ast-grep");
+
+		// npx never got a fair hearing, so "ast-grep is not installed" is not a
+		// fact yet; the verdict expires and a later sweep finds it.
+		advancePastCooldown();
+		safeSpawnAsync.mockResolvedValue(okResult("ast-grep 0.32.3"));
+		expect(await runner.ensureAvailable()).toBe(true);
+	});
+});
+
+describe("biome records its retry schedule (#1489 review)", () => {
+	it("a transient verdict carries retryAfterMs, not just a latch flag", async () => {
+		safeSpawnAsync.mockResolvedValue(timeoutResult);
+		const { BiomeClient } = await import("../../clients/biome-client.js");
+
+		expect(await new BiomeClient().ensureAvailable()).toBe(false);
+		const decisions = decisionsFor("biome");
+		const unavailable = decisions.filter(
+			(entry) =>
+				(entry.metadata as Record<string, unknown>).verdict === "unavailable",
+		);
+		expect(unavailable).toHaveLength(1);
+		const metadata = unavailable[0]?.metadata as Record<string, unknown>;
+		expect(metadata.latched).toBe(false);
+		// Pre-fix the return of `noteUnavailable` was discarded, so the record said
+		// "off" without ever saying "back at".
+		expect(metadata.retryAfterMs).toBe(TRANSIENT_BASE_COOLDOWN_MS);
+	});
+});
+
+describe("govulncheck records a real duration (#1489 review)", () => {
+	it("the post-install re-probe reports its own elapsed time and cooldown", async () => {
+		// `elapsedMs: 0` was hard-coded here — the #1474 defect verbatim, a
+		// duration field that measures nothing. Burn 1234 ms inside the re-probe
+		// so a re-hard-coded zero cannot pass.
+		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) => {
+			if (cmd === "go" && args[0] === "install") return okResult("");
+			if (cmd === "go") return okResult("go version go1.23.0");
+			if (cmd === "govulncheck" && safeSpawnAsync.mock.calls.length > 1) {
+				vi.setSystemTime(new Date(Date.now() + 1234));
+				return timeoutResult;
+			}
+			return missingResult;
+		});
+		const { GovulncheckClient } = await import(
+			"../../clients/govulncheck-client.js"
+		);
+
+		expect(await new GovulncheckClient().ensureAvailable()).toBe(false);
+		const reprobe = decisionsFor("govulncheck").at(-1);
+		expect(reprobe?.durationMs).toBe(1234);
+		const metadata = reprobe?.metadata as Record<string, unknown>;
+		// The 1234 ms burned above is host time, not tool time — and now that the
+		// re-probe is sampled, the classifier sees it and says so: a short
+		// host-stall cooldown instead of the tool's own escalating one.
+		expect(metadata.hostStallMs).toBeGreaterThan(500);
+		expect(metadata.cause).toBe("host-stall");
+		expect(metadata.retryAfterMs).toBe(HOST_STALL_COOLDOWN_MS);
+	});
+});
+
 describe("dispatch hasTool availability (#1476)", () => {
 	/** The generic seam every CLI runner gates on: `ctx.hasTool(command)`. */
 	async function load() {
@@ -351,5 +483,54 @@ describe("dispatch hasTool availability (#1476)", () => {
 		advancePastCooldown();
 		safeSpawnAsync.mockResolvedValue(okResult("1.2.3"));
 		expect(await checkToolAvailability("sometool", facts)).toBe(true);
+	});
+
+	it("the cooldown ESCALATES across repeated transients (#1489 review)", async () => {
+		// The attempt count was hard-coded to 1, so the backoff sat flat at 30 s
+		// forever. On a permanently sick host that is a re-probe every 30 s per
+		// command for the whole session — ten times the storm the policy bounds,
+		// at the highest-traffic consumer in the product.
+		safeSpawnAsync.mockResolvedValue(timeoutResult);
+		const { checkToolAvailability, facts } = await load();
+
+		expect(await checkToolAvailability("sometool", facts)).toBe(false);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+
+		// First cooldown: 30 s. Second verdict is attempt 2, so 60 s.
+		vi.setSystemTime(new Date(Date.now() + TRANSIENT_BASE_COOLDOWN_MS + 1));
+		expect(await checkToolAvailability("sometool", facts)).toBe(false);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(2);
+
+		// 30 s later is still inside the second cooldown: no third probe.
+		vi.setSystemTime(new Date(Date.now() + TRANSIENT_BASE_COOLDOWN_MS + 1));
+		expect(await checkToolAvailability("sometool", facts)).toBe(false);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(2);
+
+		// 60 s after the second verdict, it re-probes and the tool comes back.
+		vi.setSystemTime(new Date(Date.now() + TRANSIENT_BASE_COOLDOWN_MS + 1));
+		safeSpawnAsync.mockResolvedValue(okResult("1.2.3"));
+		expect(await checkToolAvailability("sometool", facts)).toBe(true);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(3);
+	});
+
+	it("a later success retires the cooldown facts (#1489 review)", async () => {
+		safeSpawnAsync.mockResolvedValue(timeoutResult);
+		const { checkToolAvailability, facts } = await load();
+		expect(await checkToolAvailability("sometool", facts)).toBe(false);
+		expect(
+			facts.getSessionFact<number>("session.toolCache.sometool.retryAt"),
+		).toBeGreaterThan(0);
+
+		advancePastCooldown();
+		safeSpawnAsync.mockResolvedValue(okResult("1.2.3"));
+		expect(await checkToolAvailability("sometool", facts)).toBe(true);
+		expect(
+			facts.getSessionFact<number>("session.toolCache.sometool.retryAt"),
+		).toBe(0);
+		expect(
+			facts.getSessionFact<number>(
+				"session.toolCache.sometool.transientAttempts",
+			),
+		).toBe(0);
 	});
 });

--- a/tests/clients/availability-latching-toolchains.test.ts
+++ b/tests/clients/availability-latching-toolchains.test.ts
@@ -1,0 +1,162 @@
+/**
+ * #1476 sweep result — `GoClient` and `RustClient` carried the same latch shape
+ * as the three sites the issue named: the PATH candidate is resolved by
+ * spawning `go version` / `cargo --version` against a 3 s host-side budget, and
+ * ANY failure was memoized as "no toolchain" for the life of the process. A
+ * stalled event loop at warm-up silently disabled every Go or Rust diagnostic
+ * until restart.
+ *
+ * `node:fs` is mocked so the absolute install-path candidates never resolve:
+ * whether a dev box or CI image happens to have Go installed must not decide
+ * what these tests exercise.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TRANSIENT_BASE_COOLDOWN_MS } from "../../clients/dispatch/runners/utils/availability-policy.ts";
+
+const { safeSpawnAsync } = vi.hoisted(() => ({ safeSpawnAsync: vi.fn() }));
+
+vi.mock("../../clients/safe-spawn.js", () => ({
+	safeSpawnAsync,
+	safeSpawn: vi.fn(),
+	isCommandAvailableAsync: vi.fn(async () => false),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return { ...actual, default: actual, existsSync: () => false };
+});
+
+const timeoutResult = {
+	stdout: "",
+	stderr: "",
+	status: null,
+	error: new Error("Process timed out after 3000ms"),
+	failure: "timeout",
+	spawnFailure: { kind: "timeout" },
+};
+
+const missingResult = {
+	stdout: "",
+	stderr: "",
+	status: null,
+	error: Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }),
+	failure: "spawn",
+	spawnFailure: { kind: "tool-not-found" },
+};
+
+const okResult = (stdout: string) => ({
+	stdout,
+	stderr: "",
+	status: 0,
+	error: undefined,
+});
+
+function advancePastCooldown(): void {
+	vi.setSystemTime(new Date(Date.now() + TRANSIENT_BASE_COOLDOWN_MS + 1));
+}
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	vi.useFakeTimers({ toFake: ["Date"] });
+	return () => vi.useRealTimers();
+});
+
+describe("GoClient availability (#1476)", () => {
+	it("pins a successful probe: available", async () => {
+		safeSpawnAsync.mockResolvedValue(okResult("go version go1.23.0"));
+		const { GoClient } = await import("../../clients/go-client.js");
+		const client = new GoClient();
+
+		expect(await client.isGoAvailableAsync()).toBe(true);
+	});
+
+	it("pins a genuine absence: latched false, no re-probe", async () => {
+		safeSpawnAsync.mockResolvedValue(missingResult);
+		const { GoClient } = await import("../../clients/go-client.js");
+		const client = new GoClient();
+
+		expect(await client.isGoAvailableAsync()).toBe(false);
+		const probes = safeSpawnAsync.mock.calls.length;
+		expect(probes).toBeGreaterThan(0);
+		expect(await client.isGoAvailableAsync()).toBe(false);
+		expect(safeSpawnAsync.mock.calls.length).toBe(probes);
+	});
+
+	it("a timed-out probe expires, and Go comes back without a restart", async () => {
+		safeSpawnAsync.mockResolvedValue(timeoutResult);
+		const { GoClient } = await import("../../clients/go-client.js");
+		const client = new GoClient();
+
+		expect(await client.isGoAvailableAsync()).toBe(false);
+		const probes = safeSpawnAsync.mock.calls.length;
+		// Held inside the cooldown — a sick host is not re-probed on every call.
+		expect(await client.isGoAvailableAsync()).toBe(false);
+		expect(safeSpawnAsync.mock.calls.length).toBe(probes);
+
+		advancePastCooldown();
+		safeSpawnAsync.mockResolvedValue(okResult("go version go1.23.0"));
+		expect(await client.isGoAvailableAsync()).toBe(true);
+	});
+
+	it("concurrent first-time callers share one sweep (no probe storm)", async () => {
+		safeSpawnAsync.mockResolvedValue(okResult("go version go1.23.0"));
+		const { GoClient } = await import("../../clients/go-client.js");
+		const client = new GoClient();
+
+		const results = await Promise.all([
+			client.isGoAvailableAsync(),
+			client.isGoAvailableAsync(),
+			client.isGoAvailableAsync(),
+		]);
+		expect(results).toEqual([true, true, true]);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("RustClient availability (#1476)", () => {
+	it("pins a successful probe: available", async () => {
+		safeSpawnAsync.mockResolvedValue(okResult("cargo 1.82.0"));
+		const { RustClient } = await import("../../clients/rust-client.js");
+		const client = new RustClient();
+
+		expect(await client.isAvailableAsync()).toBe(true);
+	});
+
+	it("pins a genuine absence: latched false, no re-probe", async () => {
+		safeSpawnAsync.mockResolvedValue(missingResult);
+		const { RustClient } = await import("../../clients/rust-client.js");
+		const client = new RustClient();
+
+		expect(await client.isAvailableAsync()).toBe(false);
+		const probes = safeSpawnAsync.mock.calls.length;
+		expect(probes).toBeGreaterThan(0);
+		expect(await client.isAvailableAsync()).toBe(false);
+		expect(safeSpawnAsync.mock.calls.length).toBe(probes);
+	});
+
+	it("a timed-out probe expires, and cargo comes back without a restart", async () => {
+		safeSpawnAsync.mockResolvedValue(timeoutResult);
+		const { RustClient } = await import("../../clients/rust-client.js");
+		const client = new RustClient();
+
+		expect(await client.isAvailableAsync()).toBe(false);
+		advancePastCooldown();
+		safeSpawnAsync.mockResolvedValue(okResult("cargo 1.82.0"));
+		expect(await client.isAvailableAsync()).toBe(true);
+	});
+
+	it("concurrent first-time callers share one sweep (no probe storm)", async () => {
+		safeSpawnAsync.mockResolvedValue(okResult("cargo 1.82.0"));
+		const { RustClient } = await import("../../clients/rust-client.js");
+		const client = new RustClient();
+
+		const results = await Promise.all([
+			client.isAvailableAsync(),
+			client.isAvailableAsync(),
+			client.isAvailableAsync(),
+		]);
+		expect(results).toEqual([true, true, true]);
+		expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/clients/availability-policy-coverage.test.ts
+++ b/tests/clients/availability-policy-coverage.test.ts
@@ -5,9 +5,22 @@
  * "tool is not installed" verdict. Its class sweep still missed three more, and
  * the #1476 sweep found three beyond those — including `ctx.hasTool`, the
  * generic seam every CLI runner gates on. The next tool would have been the
- * eleventh. This test is the durable close: it DERIVES the consumer list from
- * the source tree and fails when any consumer decides availability with its own
- * copy of the rule.
+ * eleventh. This test DERIVES the consumer list from the source tree and fails
+ * when a consumer it can SEE decides availability with its own copy of the rule.
+ *
+ * It is not a proof that no such consumer exists, and it must not be cited as
+ * one. A verification round invented twelve shapes it does not catch — accessor
+ * pairs, WeakMap and symbol-keyed stores, cross-module probe helpers, spawn
+ * behind a constructor-assigned indirection, string-union verdicts — and three
+ * of those are already idiomatic in this repo. Five known unrouted sites are
+ * invisible to it today: `createCwdCachedProbe` with its eslint, credo and
+ * rust-clippy consumers (#1494), `formatters.ts` (#1495) and
+ * `package-manager.ts` (#1496); the last two memoize a resolved PATH rather than
+ * a boolean verdict, so the verdict-shape rule cannot reach them at all.
+ *
+ * The first version of this gate was regexes and a review broke it seven ways in
+ * one sitting. Treating a gate as proof is how that happened; every widening
+ * below is pinned by a fixture so the next narrowing is visible.
  *
  * ## Structural, and per unit
  *
@@ -59,7 +72,7 @@ const repoRoot = path.resolve(
 const KNOWN_GAPS: ReadonlyArray<{ id: string; why: string }> = [
 	{
 		id: "clients/pipeline.ts::tryEslintFix",
-		why: "`_eslintCache` latches an eslint --version verdict per cwd+PATH; filed from the #1489 review alongside createCwdCachedProbe's credo/rust-clippy consumers.",
+		why: "`_eslintCache` latches an eslint --version verdict per cwd+PATH. Filed as #1494. Note this baseline covers ONLY this unit — `createCwdCachedProbe`'s eslint/credo/rust-clippy consumers are unrouted too but the gate does not detect them, so their absence here is a blind spot, not a clean bill.",
 	},
 ];
 
@@ -87,6 +100,24 @@ const KNOWN_CONSUMERS = [
  * without a fixture is how the gate silently narrows again.
  */
 const EVASIONS: ReadonlyArray<{ name: string; source: string }> = [
+	{
+		// A verification round found this one escaping, and the cause was a bug
+		// rather than a scoping choice: memo writes resolve against the DECLARED
+		// name, and the analyser took the last dot segment, so `registry.toolAvailable`
+		// looked up a declaration called `toolAvailable` and found nothing. The
+		// same slip let a nested `cached.entries.set(...)` through.
+		name: "a verdict parked on a module-level registry object",
+		source: `
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			const registry: { toolAvailable: boolean | null } = { toolAvailable: null };
+			export async function hasTool(): Promise<boolean> {
+				if (registry.toolAvailable !== null) return registry.toolAvailable;
+				const probe = await safeSpawnAsync("newtool", ["--version"], {});
+				registry.toolAvailable = probe.status === 0;
+				return registry.toolAvailable;
+			}
+		`,
+	},
 	{
 		name: "a Map<string, boolean> cwd cache instead of an `avail`-named field",
 		source: `

--- a/tests/clients/availability-policy-coverage.test.ts
+++ b/tests/clients/availability-policy-coverage.test.ts
@@ -209,6 +209,24 @@ const EVASIONS: ReadonlyArray<{ name: string; source: string }> = [
 		`,
 	},
 	{
+		// Pins the #1476 follow-up widening: `createToolchainAvailability` counts
+		// as routed ONLY when it is the shared helper. A same-named factory from
+		// anywhere else is a private copy of the rule, which is the defect.
+		name: "a lookalike availability factory imported from outside the policy",
+		source: `
+			import { createToolchainAvailability } from "./tool-checks.js";
+			export class NewToolClient {
+				private readonly availability = createToolchainAvailability({
+					tool: "newtool",
+					probeArgs: ["--version"],
+				});
+				async ensureAvailable(): Promise<boolean> {
+					return this.availability.isAvailable();
+				}
+			}
+		`,
+	},
+	{
 		name: "the defect shape plus a comment that names availability-policy.js",
 		source: `
 			import { safeSpawnAsync } from "./safe-spawn.js";
@@ -383,6 +401,31 @@ describe("availability policy coverage (#1476)", () => {
 	it("a migrated client passes the gate", async () => {
 		const units = await analyzeAvailabilityUnits(
 			COMPLIANT,
+			"clients/new-tool-client.ts",
+		);
+		expect(units.map((unit) => unit.unit)).toEqual(["NewToolClient"]);
+		expect(units[0]?.governed).toBe(true);
+	});
+
+	it("a client that delegates its lifecycle to the shared helper is routed", async () => {
+		// The #1476 follow-up moved the latch, the in-flight dedupe and the
+		// decision records out of `go-client.ts` and `rust-client.ts` and into
+		// `toolchain-availability.ts`. The clients must stay VISIBLE as consumers
+		// — a refactor that made them vanish from the scan would read as green
+		// while removing them from the gate's coverage.
+		const units = await analyzeAvailabilityUnits(
+			`
+				import { createToolchainAvailability } from "./dispatch/runners/utils/toolchain-availability.js";
+				export class NewToolClient {
+					private readonly availability = createToolchainAvailability({
+						tool: "newtool",
+						probeArgs: ["--version"],
+					});
+					async ensureAvailable(): Promise<boolean> {
+						return this.availability.isAvailable();
+					}
+				}
+			`,
 			"clients/new-tool-client.ts",
 		);
 		expect(units.map((unit) => unit.unit)).toEqual(["NewToolClient"]);

--- a/tests/clients/availability-policy-coverage.test.ts
+++ b/tests/clients/availability-policy-coverage.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Coverage gate for the shared availability policy (#1476).
+ *
+ * #1467 fixed four clients that each latched a timed-out probe as a permanent
+ * "tool is not installed" verdict. Its class sweep still missed three more, and
+ * the #1476 sweep found three beyond those — including `ctx.hasTool`, the
+ * generic seam every CLI runner gates on. The next tool would have been the
+ * eleventh. This test is the durable close: it DERIVES the consumer list from the
+ * source tree and fails when any consumer decides availability with its own
+ * copy of the rule.
+ *
+ * ## How the list is derived — and why it is not a list
+ *
+ * A hand-maintained roster of consumers is exactly the defect shape #883
+ * established: it drifts the moment someone adds a tool, and a test that lies
+ * is worse than no test. So the set is computed by scanning `clients/**\/*.ts`
+ * for the shape that defines the defect:
+ *
+ *   1. the module spawns a VERSION PROBE (a spawn call plus a version-flag
+ *      literal in the same file) — it decides availability by running the tool;
+ *   2. it MEMOIZES the verdict — an `avail`-named boolean/`null` field or
+ *      variable, an assignment to one, a session fact (the dispatcher's memo
+ *      for `hasTool`), or one of the shared memo factories.
+ *
+ * Anything matching both must route through `availability-policy.ts`: directly,
+ * via `createAvailabilityChecker` (which applies the policy internally), or by
+ * extending `SecurityScanClient` (which does the same for the scanners).
+ *
+ * ## What this gate does NOT prove
+ *
+ * Granularity is per FILE. A module that already imports the policy for one
+ * memo can still add a second, hand-rolled one beside it and stay green here —
+ * `runner-helpers.ts` held exactly such a second memo (the shared ast-grep
+ * cache) until #1476. Per-declaration binding would need real type analysis;
+ * the review question stays "does every latch in this file go through the
+ * policy", and this gate covers the file-level case that recurred twice.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"..",
+);
+const clientsRoot = path.join(repoRoot, "clients");
+
+/** The module runs a tool to decide whether the tool is there. */
+const VERSION_PROBE =
+	/\b(?:safeSpawnAsync|safeSpawn|spawnSync|spawn)\s*\(/;
+const VERSION_ARG = /"(?:--version|-version|-V|version|--Version)"/;
+/** The verdict is remembered, rather than recomputed per call. */
+const AVAILABILITY_MEMO = new RegExp(
+	[
+		// The shared memo factories.
+		"createAvailabilityLatch\\(\\)",
+		"createAvailabilityChecker\\(",
+		// A hand-rolled memo: `private fooAvailable: boolean | null = null`.
+		"(?:private|protected|public|let|var)\\s+(?:readonly\\s+)?[A-Za-z_$][\\w$]*[Aa]vail[\\w$]*\\s*(?::[^=;]*)?=\\s*(?:null|false|true)\\b",
+		// …or a write to one: `this.available = false`.
+		"\\bthis\\.[\\w$]*[Aa]vail[\\w$]*\\s*=\\s*(?:null|false|true)\\b",
+		// …or a session fact, which is the dispatcher's memo for `hasTool`.
+		"setSessionFact\\(",
+	].join("|"),
+);
+/** The three legitimate ways to reach the shared policy. */
+const ROUTED_THROUGH_POLICY =
+	/availability-policy\.js|createAvailabilityChecker|extends SecurityScanClient/;
+
+function* walkTs(dir: string): Generator<string> {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === "node_modules") continue;
+			yield* walkTs(full);
+		} else if (
+			entry.isFile() &&
+			entry.name.endsWith(".ts") &&
+			!entry.name.endsWith(".d.ts") &&
+			!entry.name.endsWith(".test.ts")
+		) {
+			yield full;
+		}
+	}
+}
+
+function isAvailabilityConsumer(source: string): boolean {
+	return (
+		VERSION_PROBE.test(source) &&
+		VERSION_ARG.test(source) &&
+		AVAILABILITY_MEMO.test(source)
+	);
+}
+
+interface Consumer {
+	file: string;
+	routed: boolean;
+}
+
+function collectConsumers(): Consumer[] {
+	const consumers: Consumer[] = [];
+	for (const file of walkTs(clientsRoot)) {
+		const source = fs.readFileSync(file, "utf-8");
+		if (!isAvailabilityConsumer(source)) continue;
+		consumers.push({
+			file: path.relative(repoRoot, file).replace(/\\/g, "/"),
+			routed: ROUTED_THROUGH_POLICY.test(source),
+		});
+	}
+	return consumers.sort((a, b) => a.file.localeCompare(b.file));
+}
+
+describe("availability policy coverage (#1476)", () => {
+	const consumers = collectConsumers();
+
+	it("every availability consumer routes through the shared policy", () => {
+		const unrouted = consumers.filter((c) => !c.routed).map((c) => c.file);
+		expect(unrouted, [
+			"These modules decide tool availability with their own copy of the rule.",
+			"Route them through clients/dispatch/runners/utils/availability-policy.ts",
+			"(directly, via createAvailabilityChecker, or via SecurityScanClient) so a",
+			"timed-out probe cannot latch as 'the tool is not installed' (#1467/#1476).",
+		].join(" ")).toEqual([]);
+	});
+
+	it("the derived set actually covers the known consumers", () => {
+		// Guards the scan itself: a regex that stopped matching would make the
+		// assertion above pass over an empty set — defect shape 7, a vacuous test.
+		const files = consumers.map((c) => c.file);
+		for (const known of [
+			"clients/biome-client.ts",
+			"clients/sg-runner.ts",
+			"clients/go-client.ts",
+			"clients/rust-client.ts",
+			"clients/knip-client.ts",
+			"clients/dead-code-client.ts",
+			"clients/dependency-checker.ts",
+			"clients/govulncheck-client.ts",
+			"clients/jscpd-client.ts",
+			"clients/dispatch/runners/utils/runner-helpers.ts",
+			"clients/dispatch/dispatcher.ts",
+		]) {
+			expect(files).toContain(known);
+		}
+	});
+
+	it("the shape rule can fail: an unrouted hand-rolled latch is detected", () => {
+		// The mutation proof, inline: if this synthetic module were added to
+		// clients/, the gate above would flag it.
+		const reintroduced = `
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			export class NewToolClient {
+				private toolAvailable: boolean | null = null;
+				async ensureAvailable(): Promise<boolean> {
+					if (this.toolAvailable !== null) return this.toolAvailable;
+					const probe = await safeSpawnAsync("newtool", ["--version"], {});
+					this.toolAvailable = !probe.error && probe.status === 0;
+					return this.toolAvailable;
+				}
+			}
+		`;
+		expect(isAvailabilityConsumer(reintroduced)).toBe(true);
+		expect(ROUTED_THROUGH_POLICY.test(reintroduced)).toBe(false);
+	});
+});

--- a/tests/clients/availability-policy-coverage.test.ts
+++ b/tests/clients/availability-policy-coverage.test.ts
@@ -5,164 +5,370 @@
  * "tool is not installed" verdict. Its class sweep still missed three more, and
  * the #1476 sweep found three beyond those — including `ctx.hasTool`, the
  * generic seam every CLI runner gates on. The next tool would have been the
- * eleventh. This test is the durable close: it DERIVES the consumer list from the
- * source tree and fails when any consumer decides availability with its own
+ * eleventh. This test is the durable close: it DERIVES the consumer list from
+ * the source tree and fails when any consumer decides availability with its own
  * copy of the rule.
  *
- * ## How the list is derived — and why it is not a list
+ * ## Structural, and per unit
  *
- * A hand-maintained roster of consumers is exactly the defect shape #883
- * established: it drifts the moment someone adds a tool, and a test that lies
- * is worse than no test. So the set is computed by scanning `clients/**\/*.ts`
- * for the shape that defines the defect:
+ * The analysis lives in `tests/support/availability-gate.ts` and runs on the
+ * real AST (`@ast-grep/napi`), not on file text. Two properties come from that
+ * and both were bought with review findings:
  *
- *   1. the module spawns a VERSION PROBE (a spawn call plus a version-flag
- *      literal in the same file) — it decides availability by running the tool;
- *   2. it MEMOIZES the verdict — an `avail`-named boolean/`null` field or
- *      variable, an assignment to one, a session fact (the dispatcher's memo
- *      for `hasTool`), or one of the shared memo factories.
+ *   * "routed through the policy" means an `import_statement` node binds a
+ *     policy symbol. A `// route this through availability-policy.js` comment
+ *     used to clear a file. It no longer parses as anything at all.
+ *   * the unit of judgement is a top-level declaration, not a file. The
+ *     file-level gate cleared `runner-helpers.ts` and `govulncheck-client.ts`
+ *     because each already imported the policy for a DIFFERENT memo, hiding two
+ *     of the seven sites this change migrates.
  *
- * Anything matching both must route through `availability-policy.ts`: directly,
- * via `createAvailabilityChecker` (which applies the policy internally), or by
- * extending `SecurityScanClient` (which does the same for the scanners).
+ * A unit is a consumer when it spawns a version probe AND parks the verdict in
+ * state that outlives the call. It must then reach the shared policy: directly,
+ * via `createAvailabilityChecker`, or by extending `SecurityScanClient`.
  *
- * ## What this gate does NOT prove
+ * ## The known-gap baseline
  *
- * Granularity is per FILE. A module that already imports the policy for one
- * memo can still add a second, hand-rolled one beside it and stay green here —
- * `runner-helpers.ts` held exactly such a second memo (the shared ast-grep
- * cache) until #1476. Per-declaration binding would need real type analysis;
- * the review question stays "does every latch in this file go through the
- * policy", and this gate covers the file-level case that recurred twice.
+ * `KNOWN_GAPS` is a shrink-only list of latches that predate this gate and are
+ * tracked separately. It is not the hand-maintained roster #883 warned about:
+ * nothing is added to it silently — a NEW unrouted consumer fails the gate, and
+ * a baseline entry that stops being flagged ALSO fails, so a fix cannot leave
+ * dead scaffolding behind.
  */
 
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+	type AvailabilityUnit,
+	analyzeAvailabilityUnits,
+	scanClientsTree,
+	unitId,
+} from "../support/availability-gate.js";
 
 const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
 	"..",
 	"..",
 );
-const clientsRoot = path.join(repoRoot, "clients");
 
-/** The module runs a tool to decide whether the tool is there. */
-const VERSION_PROBE =
-	/\b(?:safeSpawnAsync|safeSpawn|spawnSync|spawn)\s*\(/;
-const VERSION_ARG = /"(?:--version|-version|-V|version|--Version)"/;
-/** The verdict is remembered, rather than recomputed per call. */
-const AVAILABILITY_MEMO = new RegExp(
-	[
-		// The shared memo factories.
-		"createAvailabilityLatch\\(\\)",
-		"createAvailabilityChecker\\(",
-		// A hand-rolled memo: `private fooAvailable: boolean | null = null`.
-		"(?:private|protected|public|let|var)\\s+(?:readonly\\s+)?[A-Za-z_$][\\w$]*[Aa]vail[\\w$]*\\s*(?::[^=;]*)?=\\s*(?:null|false|true)\\b",
-		// …or a write to one: `this.available = false`.
-		"\\bthis\\.[\\w$]*[Aa]vail[\\w$]*\\s*=\\s*(?:null|false|true)\\b",
-		// …or a session fact, which is the dispatcher's memo for `hasTool`.
-		"setSessionFact\\(",
-	].join("|"),
-);
-/** The three legitimate ways to reach the shared policy. */
-const ROUTED_THROUGH_POLICY =
-	/availability-policy\.js|createAvailabilityChecker|extends SecurityScanClient/;
+/**
+ * Hand-rolled latches that predate this gate. Each is a real instance of the
+ * shape, filed for its own fix; none may grow without a review noticing.
+ */
+const KNOWN_GAPS: ReadonlyArray<{ id: string; why: string }> = [
+	{
+		id: "clients/pipeline.ts::tryEslintFix",
+		why: "`_eslintCache` latches an eslint --version verdict per cwd+PATH; filed from the #1489 review alongside createCwdCachedProbe's credo/rust-clippy consumers.",
+	},
+];
 
-function* walkTs(dir: string): Generator<string> {
-	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-		const full = path.join(dir, entry.name);
-		if (entry.isDirectory()) {
-			if (entry.name === "node_modules") continue;
-			yield* walkTs(full);
-		} else if (
-			entry.isFile() &&
-			entry.name.endsWith(".ts") &&
-			!entry.name.endsWith(".d.ts") &&
-			!entry.name.endsWith(".test.ts")
-		) {
-			yield full;
-		}
-	}
-}
+/** Every consumer the #1467/#1476 sweeps migrated; the scan must still see them. */
+const KNOWN_CONSUMERS = [
+	"clients/biome-client.ts::BiomeClient",
+	"clients/dead-code-client.ts::PythonDeadCodeClient",
+	"clients/dependency-checker.ts::DependencyChecker",
+	"clients/dispatch/dispatcher.ts::checkToolAvailability",
+	"clients/dispatch/runners/utils/runner-helpers.ts::createAvailabilityChecker",
+	// The second latch in the same file — invisible to a per-file gate.
+	"clients/dispatch/runners/utils/runner-helpers.ts::isSgAvailableAsync",
+	"clients/go-client.ts::GoClient",
+	"clients/govulncheck-client.ts::GovulncheckClient",
+	"clients/jscpd-client.ts::jscpdAvailability",
+	"clients/knip-client.ts::KnipClient",
+	"clients/rust-client.ts::RustClient",
+	"clients/sg-runner.ts::SgRunner",
+];
 
-function isAvailabilityConsumer(source: string): boolean {
-	return (
-		VERSION_PROBE.test(source) &&
-		VERSION_ARG.test(source) &&
-		AVAILABILITY_MEMO.test(source)
-	);
-}
-
-interface Consumer {
-	file: string;
-	routed: boolean;
-}
-
-function collectConsumers(): Consumer[] {
-	const consumers: Consumer[] = [];
-	for (const file of walkTs(clientsRoot)) {
-		const source = fs.readFileSync(file, "utf-8");
-		if (!isAvailabilityConsumer(source)) continue;
-		consumers.push({
-			file: path.relative(repoRoot, file).replace(/\\/g, "/"),
-			routed: ROUTED_THROUGH_POLICY.test(source),
-		});
-	}
-	return consumers.sort((a, b) => a.file.localeCompare(b.file));
-}
-
-describe("availability policy coverage (#1476)", () => {
-	const consumers = collectConsumers();
-
-	it("every availability consumer routes through the shared policy", () => {
-		const unrouted = consumers.filter((c) => !c.routed).map((c) => c.file);
-		expect(unrouted, [
-			"These modules decide tool availability with their own copy of the rule.",
-			"Route them through clients/dispatch/runners/utils/availability-policy.ts",
-			"(directly, via createAvailabilityChecker, or via SecurityScanClient) so a",
-			"timed-out probe cannot latch as 'the tool is not installed' (#1467/#1476).",
-		].join(" ")).toEqual([]);
-	});
-
-	it("the derived set actually covers the known consumers", () => {
-		// Guards the scan itself: a regex that stopped matching would make the
-		// assertion above pass over an empty set — defect shape 7, a vacuous test.
-		const files = consumers.map((c) => c.file);
-		for (const known of [
-			"clients/biome-client.ts",
-			"clients/sg-runner.ts",
-			"clients/go-client.ts",
-			"clients/rust-client.ts",
-			"clients/knip-client.ts",
-			"clients/dead-code-client.ts",
-			"clients/dependency-checker.ts",
-			"clients/govulncheck-client.ts",
-			"clients/jscpd-client.ts",
-			"clients/dispatch/runners/utils/runner-helpers.ts",
-			"clients/dispatch/dispatcher.ts",
-		]) {
-			expect(files).toContain(known);
-		}
-	});
-
-	it("the shape rule can fail: an unrouted hand-rolled latch is detected", () => {
-		// The mutation proof, inline: if this synthetic module were added to
-		// clients/, the gate above would flag it.
-		const reintroduced = `
+/**
+ * The seven ways a reviewer broke the regex version of this gate, each written
+ * as it would appear in `clients/`. Every one must read as an unrouted
+ * consumer. They are the gate's own regression suite: widening the vocabulary
+ * without a fixture is how the gate silently narrows again.
+ */
+const EVASIONS: ReadonlyArray<{ name: string; source: string }> = [
+	{
+		name: "a Map<string, boolean> cwd cache instead of an `avail`-named field",
+		source: `
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			const cacheByCwd = new Map<string, boolean>();
+			export async function hasTool(cwd: string): Promise<boolean> {
+				const hit = cacheByCwd.get(cwd);
+				if (hit !== undefined) return hit;
+				const probe = await safeSpawnAsync("newtool", ["--version"], { cwd });
+				cacheByCwd.set(cwd, probe.status === 0);
+				return probe.status === 0;
+			}
+		`,
+	},
+	{
+		name: "a field named `installed`",
+		source: `
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			export class NewToolClient {
+				private installed: boolean | null = null;
+				async ensureAvailable(): Promise<boolean> {
+					if (this.installed !== null) return this.installed;
+					const probe = await safeSpawnAsync("newtool", ["--version"], {});
+					this.installed = probe.status === 0;
+					return this.installed;
+				}
+			}
+		`,
+	},
+	{
+		name: "a closure factory holding `let cached`",
+		source: `
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			export function createNewToolProbe(): () => Promise<boolean> {
+				let cached: boolean | null = null;
+				return async () => {
+					if (cached !== null) return cached;
+					const probe = await safeSpawnAsync("newtool", ["--version"], {});
+					cached = probe.status === 0;
+					return cached;
+				};
+			}
+		`,
+	},
+	{
+		name: "a probe flag hoisted into a const rather than written as a literal",
+		source: `
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			const VERSION_ARGS = ["--version"];
+			export class NewToolClient {
+				private toolAvailable: boolean | null = null;
+				async ensureAvailable(): Promise<boolean> {
+					if (this.toolAvailable !== null) return this.toolAvailable;
+					const probe = await safeSpawnAsync("newtool", VERSION_ARGS, {});
+					this.toolAvailable = probe.status === 0;
+					return this.toolAvailable;
+				}
+			}
+		`,
+	},
+	{
+		name: "a probe that asks with `-v`",
+		source: `
 			import { safeSpawnAsync } from "./safe-spawn.js";
 			export class NewToolClient {
 				private toolAvailable: boolean | null = null;
 				async ensureAvailable(): Promise<boolean> {
 					if (this.toolAvailable !== null) return this.toolAvailable;
-					const probe = await safeSpawnAsync("newtool", ["--version"], {});
-					this.toolAvailable = !probe.error && probe.status === 0;
+					const probe = await safeSpawnAsync("newtool", ["-v"], {});
+					this.toolAvailable = probe.status === 0;
 					return this.toolAvailable;
 				}
 			}
-		`;
-		expect(isAvailabilityConsumer(reintroduced)).toBe(true);
-		expect(ROUTED_THROUGH_POLICY.test(reintroduced)).toBe(false);
+		`,
+	},
+	{
+		name: "an optional boolean field with no initialiser",
+		source: `
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			export class NewToolClient {
+				private fooAvailable?: boolean;
+				async ensureAvailable(): Promise<boolean> {
+					if (this.fooAvailable !== undefined) return this.fooAvailable;
+					const probe = await safeSpawnAsync("newtool", ["--version"], {});
+					this.fooAvailable = probe.status === 0;
+					return this.fooAvailable;
+				}
+			}
+		`,
+	},
+	{
+		name: "the defect shape plus a comment that names availability-policy.js",
+		source: `
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			// TODO: route this through availability-policy.js
+			export class NewToolClient {
+				private toolAvailable: boolean | null = null;
+				async ensureAvailable(): Promise<boolean> {
+					if (this.toolAvailable !== null) return this.toolAvailable;
+					const probe = await safeSpawnAsync("newtool", ["--version"], {});
+					this.toolAvailable = probe.status === 0;
+					return this.toolAvailable;
+				}
+			}
+		`,
+	},
+];
+
+/** The positive control: the same client, migrated. It must pass. */
+const COMPLIANT = `
+	import { safeSpawnAsync } from "./safe-spawn.js";
+	import {
+		classifyProbeFailure,
+		createAvailabilityLatch,
+	} from "./dispatch/runners/utils/availability-policy.js";
+	export class NewToolClient {
+		private readonly availabilityLatch = createAvailabilityLatch();
+		async ensureAvailable(): Promise<boolean> {
+			const memo = this.availabilityLatch.read();
+			if (memo !== null) return memo;
+			const probe = await safeSpawnAsync("newtool", ["--version"], {});
+			if (probe.status === 0) {
+				this.availabilityLatch.noteAvailable();
+				return true;
+			}
+			const { outcome, cause } = classifyProbeFailure(probe);
+			this.availabilityLatch.noteUnavailable(outcome, cause);
+			return false;
+		}
+	}
+`;
+
+describe("availability policy coverage (#1476)", () => {
+	let consumers: AvailabilityUnit[];
+
+	beforeAll(async () => {
+		consumers = await scanClientsTree(repoRoot);
+	});
+
+	it("every availability consumer routes through the shared policy", () => {
+		const baseline = new Set(KNOWN_GAPS.map((gap) => gap.id));
+		const unrouted = consumers
+			.filter((unit) => !unit.governed)
+			.map(unitId)
+			.filter((id) => !baseline.has(id));
+		expect(
+			unrouted,
+			[
+				"These units decide tool availability with their own copy of the rule.",
+				"Route them through clients/dispatch/runners/utils/availability-policy.ts",
+				"(directly, via createAvailabilityChecker, or via SecurityScanClient) so a",
+				"timed-out probe cannot latch as 'the tool is not installed' (#1467/#1476).",
+			].join(" "),
+		).toEqual([]);
+	});
+
+	it("the known-gap baseline is still accurate", () => {
+		// A baseline entry that stopped being flagged is scaffolding around a fix
+		// that already landed; deleting it is part of the fix.
+		const flagged = new Set(
+			consumers.filter((unit) => !unit.governed).map(unitId),
+		);
+		const stale = KNOWN_GAPS.map((gap) => gap.id).filter(
+			(id) => !flagged.has(id),
+		);
+		expect(
+			stale,
+			"These KNOWN_GAPS entries are no longer flagged — delete them.",
+		).toEqual([]);
+	});
+
+	it("the derived set actually covers the known consumers", () => {
+		// Guards the scan itself: an analysis that stopped matching would make the
+		// assertion above pass over an empty set — defect shape 7, a vacuous test.
+		const ids = consumers.map(unitId);
+		for (const known of KNOWN_CONSUMERS) {
+			expect(ids).toContain(known);
+		}
+	});
+
+	describe("the gate catches every shape the review evaded it with", () => {
+		for (const evasion of EVASIONS) {
+			it(evasion.name, async () => {
+				const units = await analyzeAvailabilityUnits(
+					evasion.source,
+					"clients/new-tool-client.ts",
+				);
+				expect(
+					units.map((unit) => unit.unit),
+					"the analysis did not recognise this as an availability consumer",
+				).not.toEqual([]);
+				expect(
+					units.filter((unit) => unit.governed),
+					"an unrouted latch was reported as routed through the policy",
+				).toEqual([]);
+			});
+		}
+	});
+
+	it("flags a second hand-rolled latch beside a compliant one", async () => {
+		// The per-FILE gate cleared this shape, and that is how two of the seven
+		// sites this change migrates stayed invisible: the file already imported
+		// the policy, for a different memo.
+		const units = await analyzeAvailabilityUnits(
+			`
+				import { safeSpawnAsync } from "./safe-spawn.js";
+				import { createAvailabilityLatch } from "./dispatch/runners/utils/availability-policy.js";
+				export class MigratedClient {
+					private readonly availabilityLatch = createAvailabilityLatch();
+					async ensureAvailable(): Promise<boolean> {
+						const memo = this.availabilityLatch.read();
+						if (memo !== null) return memo;
+						const probe = await safeSpawnAsync("newtool", ["--version"], {});
+						if (probe.status === 0) {
+							this.availabilityLatch.noteAvailable();
+							return true;
+						}
+						this.availabilityLatch.noteUnavailable("missing", "not-found");
+						return false;
+					}
+				}
+				let secondToolAvailable: boolean | null = null;
+				export async function isSecondToolAvailable(): Promise<boolean> {
+					if (secondToolAvailable !== null) return secondToolAvailable;
+					const probe = await safeSpawnAsync("secondtool", ["--version"], {});
+					secondToolAvailable = probe.status === 0;
+					return secondToolAvailable;
+				}
+			`,
+			"clients/two-latches.ts",
+		);
+		expect(units.filter((unit) => !unit.governed).map((unit) => unit.unit)).toEqual(
+			["isSecondToolAvailable"],
+		);
+		expect(units.filter((unit) => unit.governed).map((unit) => unit.unit)).toEqual(
+			["MigratedClient"],
+		);
+	});
+
+	it("follows a probe that lives one helper away from the latch", async () => {
+		// `runner-helpers.ts` pre-#1476: the `--version` literal and the spawn sat
+		// in `probeAstGrepCommandAsync` while the latch sat in `isSgAvailableAsync`.
+		const units = await analyzeAvailabilityUnits(
+			`
+				import { safeSpawnAsync } from "./safe-spawn.js";
+				let toolAvailable: boolean | null = null;
+				async function probeTool(cmd: string): Promise<boolean> {
+					const check = await safeSpawnAsync(cmd, ["--version"], { timeout: 5000 });
+					return !check.error && check.status === 0;
+				}
+				export async function isToolAvailableAsync(): Promise<boolean> {
+					if (toolAvailable !== null) return toolAvailable;
+					toolAvailable = await probeTool("newtool");
+					return toolAvailable;
+				}
+			`,
+			"clients/helper-split.ts",
+		);
+		expect(units.map((unit) => unit.unit)).toContain("isToolAvailableAsync");
+		expect(units.filter((unit) => unit.governed)).toEqual([]);
+	});
+
+	it("a migrated client passes the gate", async () => {
+		const units = await analyzeAvailabilityUnits(
+			COMPLIANT,
+			"clients/new-tool-client.ts",
+		);
+		expect(units.map((unit) => unit.unit)).toEqual(["NewToolClient"]);
+		expect(units[0]?.governed).toBe(true);
+	});
+
+	it("a client with no probe is not a consumer at all", async () => {
+		// The scan must not drag in every module that happens to own a cache.
+		const units = await analyzeAvailabilityUnits(
+			`
+				const cacheByCwd = new Map<string, boolean>();
+				export function rememberTrust(cwd: string, trusted: boolean): void {
+					cacheByCwd.set(cwd, trusted);
+				}
+			`,
+			"clients/trust-cache.ts",
+		);
+		expect(units).toEqual([]);
 	});
 });

--- a/tests/support/availability-gate.ts
+++ b/tests/support/availability-gate.ts
@@ -1,0 +1,627 @@
+/**
+ * Structural analyser behind the availability-policy coverage gate (#1476).
+ *
+ * The first cut of this gate was a bag of regexes over file text, and a review
+ * broke it seven different ways in one sitting: a `Map<string, boolean>` cache,
+ * a field called `installed`, a `let cached` closure, a probe flag hoisted into
+ * a const, `["-v"]` instead of `["--version"]`, a `?: boolean` field with no
+ * initialiser, and — the one that hurt — a `// TODO: route through
+ * availability-policy.js` COMMENT, which made the file read as compliant.
+ *
+ * So this is an AST analysis, not a text scan. It parses each module with
+ * `@ast-grep/napi` (already a runtime dependency) and asks structural
+ * questions:
+ *
+ *   * does the module IMPORT the policy — an `import_statement` node, so a
+ *     comment or a dead string can never answer yes;
+ *   * does a unit run a VERSION PROBE — a spawn-shaped call plus a version flag
+ *     reachable from that unit, including one hoisted into a const;
+ *   * does it MEMOIZE the verdict — a write to state that OUTLIVES the call
+ *     (class field, module-level binding, factory closure, session fact), which
+ *     is what makes a bad verdict stick.
+ *
+ * ## Units, not files
+ *
+ * Granularity is per top-level declaration ("unit"), not per file. The
+ * file-level version of this gate cleared `runner-helpers.ts` and
+ * `govulncheck-client.ts` because each already imported the policy for a
+ * DIFFERENT memo — 2 of the 7 sites this change migrates hid behind their own
+ * neighbours. A unit is one top-level class or function, so a second
+ * hand-rolled latch beside a compliant one is its own unit and is judged on its
+ * own.
+ *
+ * ## What it still cannot prove
+ *
+ * Names carry part of the load: a memo is recognised by an availability-ish
+ * identifier holding boolean-ish state. A latch named `q7` with a probe spliced
+ * in from another module is out of reach without full type resolution. The
+ * vocabulary is deliberately wide (see `MEMO_NAME`), and every widening is
+ * pinned by an evasion fixture in the gate's test.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { loadAstGrepNapi } from "../../clients/deps/ast-grep-napi.js";
+import type { SgNode } from "../../clients/deps/ast-grep-napi.js";
+
+/** Calls that hand a command line to the OS. */
+const SPAWN_CALLS = new Set([
+	"exec",
+	"execFile",
+	"execFileSync",
+	"execSync",
+	"safeSpawn",
+	"safeSpawnAsync",
+	"safeSpawnSync",
+	"spawn",
+	"spawnAsync",
+	"spawnSync",
+]);
+
+/**
+ * Calls that spawn on the unit's behalf. A module that delegates its probe to
+ * `createAvailabilityChecker` or a `probeX` helper is still probing.
+ */
+const SPAWN_DELEGATES =
+	/^(?:probe|spawn|exec|run|which|isCommandAvailable|createAvailabilityChecker|createCwdCachedProbe|resolveCommandWithInstallFallback|verifyOrInstall)/i;
+
+/** Every flag a CLI is asked for its version with. */
+const VERSION_FLAGS = new Set([
+	"--version",
+	"--Version",
+	"-version",
+	"-V",
+	"-v",
+	"/version",
+	"version",
+]);
+
+/**
+ * Identifiers that name an availability verdict. Wide on purpose: the review
+ * evaded the first draft with `installed`, `cached`, and a bare `Map` named
+ * `cache`, none of which contained "avail".
+ */
+const MEMO_NAME =
+	/(?:avail|install|present|detect|cache|found|usable|missing|exists|supported|latch|probed|hastool|ready|enabled)/i;
+
+/**
+ * What the parked state has to LOOK like to be an availability verdict. Without
+ * this the scan drags in every string cache a probing module happens to own —
+ * the installer's `resolvedPathCache`, spotbugs' findings cache — and a gate
+ * that cries wolf gets a baseline entry instead of a fix.
+ */
+const VERDICT_SHAPE = /\bboolean\b|Avail|Latch/i;
+
+const BOOL_LITERAL = /^(?:true|false|null|undefined)$/;
+
+/** Cheap pre-filter for the tree scan, DERIVED from `VERSION_FLAGS` (#883). */
+const VERSION_FLAG_TEXT = new RegExp(
+	`["'\`](?:${[...VERSION_FLAGS]
+		.map((flag) => flag.replace(/[.*+?^${}()|[\]\\/-]/g, "\\$&"))
+		.join("|")})["'\`]`,
+);
+
+/** Names that only exist because the shared policy is doing the work. */
+const POLICY_FACTORIES = new Set([
+	"createAvailabilityChecker",
+	"createAvailabilityLatch",
+]);
+const POLICY_CALLS = new Set([
+	...POLICY_FACTORIES,
+	"classifyProbeFailure",
+	"isLatchingOutcome",
+	"isTransientDecision",
+	"transientRetryDelayMs",
+]);
+/** The `SecurityScanClient` seam applies the policy inside the base class. */
+const BASE_CLASS_SEAM = new Set([
+	"ensureViaInstaller",
+	"markTransientlyUnavailable",
+	"probeVersion",
+	"probeWasTransient",
+]);
+
+const FUNCTION_KINDS = new Set([
+	"arrow_function",
+	"function_declaration",
+	"function_expression",
+	"generator_function_declaration",
+	"method_definition",
+]);
+
+export interface AvailabilityUnit {
+	/** Repo-relative POSIX path of the module. */
+	file: string;
+	/** Top-level declaration the finding belongs to. */
+	unit: string;
+	/** The memoized verdict that made this unit a consumer. */
+	memo: string;
+	/** True when the verdict is produced or classified by the shared policy. */
+	governed: boolean;
+}
+
+/** `"foo"` / `'foo'` → `foo`. */
+function unquote(text: string): string {
+	return text.replace(/^["'`]/, "").replace(/["'`]$/, "");
+}
+
+function baseName(callee: string): string {
+	const parts = callee.split(".");
+	return parts[parts.length - 1] ?? callee;
+}
+
+/** Stable identity for a node, used as a scope key. */
+function scopeKey(node: SgNode | null): string {
+	if (!node) return "<module>";
+	const r = node.range();
+	return `${r.start.index}:${r.end.index}`;
+}
+
+interface Decl {
+	name: string;
+	/** Scope the binding LIVES in — a write from a deeper scope outlives the call. */
+	scope: string;
+	isClassField: boolean;
+	typeText: string;
+	valueText: string;
+}
+
+interface Write {
+	target: string;
+	base: string;
+	/** Scope the write happens in. */
+	scope: string;
+	isThisMember: boolean;
+	/** The value being parked, when it is visible at the write site. */
+	valueText: string;
+}
+
+interface UnitFacts {
+	name: string;
+	/** Base names of every call in the unit, for module-local call-graph reach. */
+	calls: Set<string>;
+	decls: Decl[];
+	writes: Write[];
+	sessionFact: boolean;
+	spawns: boolean;
+	versionFlag: boolean;
+	policyCalls: Set<string>;
+	seamCalls: Set<string>;
+	extendsSecurityScanClient: boolean;
+	latchDecl: string | null;
+}
+
+/**
+ * Collect the facts for one top-level unit in a single descent, carrying the
+ * enclosing function scope so "does this state outlive the call?" is answerable.
+ */
+function collectUnit(
+	root: SgNode,
+	constInitializers: Map<string, string>,
+	policyHandles: Map<string, string>,
+): Omit<UnitFacts, "name"> {
+	const facts: Omit<UnitFacts, "name"> = {
+		calls: new Set(),
+		decls: [],
+		writes: [],
+		sessionFact: false,
+		spawns: false,
+		versionFlag: false,
+		policyCalls: new Set(),
+		seamCalls: new Set(),
+		extendsSecurityScanClient: false,
+		latchDecl: null,
+	};
+
+	const visit = (node: SgNode, scope: string): void => {
+		const kind = String(node.kind());
+		const childScope = FUNCTION_KINDS.has(kind) ? scopeKey(node) : scope;
+
+		switch (kind) {
+			case "string_fragment":
+				if (VERSION_FLAGS.has(node.text())) facts.versionFlag = true;
+				break;
+			case "class_heritage":
+				if (/\bextends\s+SecurityScanClient\b/.test(node.text())) {
+					facts.extendsSecurityScanClient = true;
+				}
+				break;
+			case "call_expression": {
+				const callee = node.field("function")?.text() ?? "";
+				const name = baseName(callee);
+				facts.calls.add(name);
+				if (SPAWN_CALLS.has(name) || SPAWN_DELEGATES.test(name)) {
+					facts.spawns = true;
+				}
+				if (POLICY_CALLS.has(name)) facts.policyCalls.add(name);
+				// `java.isAvailableAsync(cwd)` where `java` is a module-level
+				// `createAvailabilityChecker(…)` handle: the policy owns that verdict,
+				// so the unit is routed even though it names no policy symbol itself.
+				const factory = policyHandles.get(callee.split(".")[0] ?? "");
+				if (factory) facts.policyCalls.add(factory);
+				if (BASE_CLASS_SEAM.has(name)) facts.seamCalls.add(name);
+				if (name === "setSessionFact") facts.sessionFact = true;
+				// `cache.set(key, verdict)` parks a verdict in a container.
+				if (name === "set" && callee.includes(".")) {
+					const container = callee.slice(0, callee.lastIndexOf("."));
+					const args = node.field("arguments")?.children() ?? [];
+					facts.writes.push({
+						target: callee,
+						base: baseName(container),
+						scope: childScope,
+						isThisMember: container.startsWith("this."),
+						valueText: args[args.length - 2]?.text() ?? "",
+					});
+				}
+				// A version flag hoisted into a const is still a version flag.
+				for (const arg of node.field("arguments")?.children() ?? []) {
+					const hoisted = constInitializers.get(arg.text());
+					if (hoisted && hasVersionFlagText(hoisted)) facts.versionFlag = true;
+				}
+				break;
+			}
+			case "public_field_definition":
+			case "variable_declarator": {
+				const name = node.field("name")?.text() ?? "";
+				const valueText = node.field("value")?.text() ?? "";
+				if (POLICY_FACTORIES.has(baseName(valueText.split("(")[0] ?? ""))) {
+					facts.latchDecl = name;
+				}
+				facts.decls.push({
+					name,
+					scope,
+					isClassField: kind === "public_field_definition",
+					typeText: node.field("type")?.text() ?? "",
+					valueText,
+				});
+				break;
+			}
+			case "assignment_expression": {
+				// Every write is recorded; `findMemo` decides which ones park an
+				// availability VERDICT. Filtering on the right-hand side here missed
+				// `toolAvailable = await probeTool(cmd)` — the latch whose verdict is
+				// computed a function away, which is precisely the shape that hid in
+				// `runner-helpers.ts`.
+				const left = node.field("left")?.text() ?? "";
+				const right = (node.field("right")?.text() ?? "").trim();
+				facts.writes.push({
+					target: left,
+					base: baseName(left),
+					scope: childScope,
+					isThisMember: left.startsWith("this."),
+					valueText: right,
+				});
+				break;
+			}
+			default:
+				break;
+		}
+
+		for (const child of node.children()) visit(child, childScope);
+	};
+
+	visit(root, "<module>");
+	return facts;
+}
+
+function hasVersionFlagText(text: string): boolean {
+	return VERSION_FLAG_TEXT.test(text);
+}
+
+/**
+ * The memo test: state that OUTLIVES the probe call. A local `let ok = …`
+ * rebuilt on every call cannot latch anything, so it is not a memo — which is
+ * why `installer/index.ts`'s per-call `status.installed` report is not a
+ * finding, while `pipeline.ts`'s module-level `_eslintCache` is.
+ */
+function findMemo(
+	facts: Omit<UnitFacts, "name">,
+	moduleDecls: Map<string, Decl>,
+): string | null {
+	if (facts.sessionFact) return "setSessionFact";
+	if (facts.latchDecl) return facts.latchDecl;
+
+	// Module-level bindings are in scope for every unit, and a `const cache = new
+	// Map()` at the top of the file is exactly where a latch hides from a
+	// function that writes to it — `pipeline.ts`'s `_eslintCache` is that shape.
+	const declsByName = new Map<string, Decl>(moduleDecls);
+	for (const decl of facts.decls) {
+		declsByName.set(decl.name, decl);
+	}
+
+	for (const write of facts.writes) {
+		if (!MEMO_NAME.test(write.target)) continue;
+		const decl = declsByName.get(write.base);
+		// A class member always outlives the method that writes it — including an
+		// inherited accessor with no declaration in this file.
+		const persistent =
+			write.isThisMember ||
+			(decl !== undefined &&
+				(decl.isClassField ||
+					decl.scope === "<module>" ||
+					// Declared in an ENCLOSING scope (a factory closure), written from
+					// within: the classic memoizing-closure latch. Containment matters —
+					// a same-named local in a sibling branch outlives nothing.
+					enclosesScope(decl.scope, write.scope)));
+		if (!persistent) continue;
+		if (holdsVerdict(decl, write.valueText, write.target)) return write.target;
+	}
+
+	for (const decl of facts.decls) {
+		if (!MEMO_NAME.test(decl.name)) continue;
+		if (!decl.isClassField && decl.scope !== "<module>") continue;
+		if (holdsVerdict(decl, "", decl.name)) return decl.name;
+	}
+	return null;
+}
+
+/** Is `outer` a strictly enclosing scope of `inner`? Keys are source ranges. */
+function enclosesScope(outer: string, inner: string): boolean {
+	if (outer === inner) return false;
+	if (outer === "<module>") return true;
+	if (inner === "<module>") return false;
+	const [outerStart, outerEnd] = outer.split(":").map(Number);
+	const [innerStart, innerEnd] = inner.split(":").map(Number);
+	return (
+		(outerStart ?? 0) <= (innerStart ?? 0) && (outerEnd ?? 0) >= (innerEnd ?? 0)
+	);
+}
+
+/** Does this state hold an availability VERDICT, rather than arbitrary data? */
+function holdsVerdict(
+	decl: Decl | undefined,
+	writtenValue: string,
+	target: string,
+): boolean {
+	const shape = `${decl?.typeText ?? ""} ${decl?.valueText ?? ""} ${writtenValue}`;
+	if (VERDICT_SHAPE.test(shape)) return true;
+	if (BOOL_LITERAL.test(writtenValue.trim())) return true;
+	return /avail/i.test(target);
+}
+
+/**
+ * A unit is governed when the shared policy — reached through a real import
+ * binding — decides or classifies its verdict.
+ */
+function isGoverned(
+	facts: Omit<UnitFacts, "name">,
+	policyBindings: Set<string>,
+	securityScanClientImported: boolean,
+): boolean {
+	for (const call of facts.policyCalls) {
+		if (policyBindings.has(call)) return true;
+	}
+	if (
+		facts.extendsSecurityScanClient &&
+		securityScanClientImported &&
+		facts.seamCalls.size > 0
+	) {
+		return true;
+	}
+	return false;
+}
+
+/** Import BINDINGS — an `import_statement` node, never a comment. */
+function readImports(root: SgNode): {
+	policyBindings: Set<string>;
+	securityScanClientImported: boolean;
+} {
+	const policyBindings = new Set<string>();
+	let securityScanClientImported = false;
+	const visit = (node: SgNode): void => {
+		if (node.kind() === "import_statement") {
+			const source = unquote(node.field("source")?.text() ?? "");
+			const clause = node
+				.children()
+				.find((child) => child.kind() === "import_clause");
+			const names = (clause?.text() ?? "")
+				.replace(/[{}]/g, " ")
+				.split(/[\s,]+/)
+				.filter(Boolean);
+			const fromPolicy = /availability-policy\.js$/.test(source);
+			const fromHelpers = /runner-helpers\.js$/.test(source);
+			for (const name of names) {
+				if (fromPolicy && POLICY_CALLS.has(name)) policyBindings.add(name);
+				if (fromHelpers && name === "createAvailabilityChecker") {
+					policyBindings.add(name);
+				}
+				if (name === "SecurityScanClient") securityScanClientImported = true;
+			}
+		}
+		for (const child of node.children()) visit(child);
+	};
+	visit(root);
+	return { policyBindings, securityScanClientImported };
+}
+
+/** Top-level bindings, which are in scope — and alive — for every unit. */
+function readModuleDecls(root: SgNode): Map<string, Decl> {
+	const decls = new Map<string, Decl>();
+	for (const stmt of topLevelUnits(root)) {
+		if (stmt.kind() !== "lexical_declaration" && stmt.kind() !== "variable_declaration") {
+			continue;
+		}
+		for (const child of stmt.children()) {
+			if (child.kind() !== "variable_declarator") continue;
+			const name = child.field("name")?.text();
+			if (!name) continue;
+			decls.set(name, {
+				name,
+				scope: "<module>",
+				isClassField: false,
+				typeText: child.field("type")?.text() ?? "",
+				valueText: child.field("value")?.text() ?? "",
+			});
+		}
+	}
+	return decls;
+}
+
+/** Module-level `const X = …` initializers, for resolving hoisted probe args. */
+function readConstInitializers(root: SgNode): Map<string, string> {
+	const map = new Map<string, string>();
+	const visit = (node: SgNode): void => {
+		if (node.kind() === "variable_declarator") {
+			const name = node.field("name")?.text();
+			const value = node.field("value")?.text();
+			if (name && value && !map.has(name)) map.set(name, value);
+		}
+		for (const child of node.children()) visit(child);
+	};
+	visit(root);
+	return map;
+}
+
+function unitLabel(node: SgNode): string {
+	const named = node.field("name")?.text();
+	if (named) return named;
+	const declarator = node
+		.children()
+		.find((child) => child.kind() === "variable_declarator");
+	const declared = declarator?.field("name")?.text();
+	if (declared) return declared;
+	return String(node.kind());
+}
+
+/**
+ * The unit list: every top-level declaration, with `export` unwrapped so
+ * `export function f` and `function f` are the same unit.
+ */
+function topLevelUnits(root: SgNode): SgNode[] {
+	const units: SgNode[] = [];
+	for (const stmt of root.children()) {
+		let node = stmt;
+		if (node.kind() === "export_statement") {
+			const inner = node
+				.children()
+				.find(
+					(child) => child.kind() !== "export" && child.kind() !== "default",
+				);
+			if (inner) node = inner;
+		}
+		if (node.kind() === "import_statement" || node.kind() === "comment") continue;
+		units.push(node);
+	}
+	return units;
+}
+
+export async function analyzeAvailabilityUnits(
+	source: string,
+	file: string,
+): Promise<AvailabilityUnit[]> {
+	const napi = await loadAstGrepNapi();
+	const root = napi.parse(napi.Lang.TypeScript, source).root();
+	const { policyBindings, securityScanClientImported } = readImports(root);
+	const constInitializers = readConstInitializers(root);
+	const moduleDecls = readModuleDecls(root);
+	// A module that DEFINES a policy symbol (the policy itself, and the helpers
+	// module that owns `createAvailabilityChecker`) is bound to it as surely as
+	// one that imports it.
+	for (const unit of topLevelUnits(root)) {
+		const label = unitLabel(unit);
+		if (POLICY_CALLS.has(label)) policyBindings.add(label);
+	}
+	const policyHandles = new Map<string, string>();
+	for (const [name, decl] of moduleDecls) {
+		const factory = baseName(decl.valueText.split("(")[0] ?? "");
+		if (POLICY_FACTORIES.has(factory)) policyHandles.set(name, factory);
+	}
+
+	const units = topLevelUnits(root).map((node) => ({
+		node,
+		name: unitLabel(node),
+		facts: collectUnit(node, constInitializers, policyHandles),
+	}));
+	propagateProbeReach(units);
+
+	const found: AvailabilityUnit[] = [];
+	for (const unit of units) {
+		const { facts } = unit;
+		if (!facts.spawns || !facts.versionFlag) continue;
+		const memo = findMemo(facts, moduleDecls);
+		if (!memo) continue;
+		found.push({
+			file,
+			unit: unit.name,
+			memo,
+			governed: isGoverned(facts, policyBindings, securityScanClientImported),
+		});
+	}
+	return found;
+}
+
+/**
+ * Carry "this reaches a version probe" across module-local helpers, to a fixed
+ * point.
+ *
+ * `runner-helpers.ts` is why this exists: pre-#1476 its shared ast-grep latch
+ * lived in `isSgAvailableAsync` while the `--version` literal and the spawn sat
+ * one function away in `probeAstGrepCommandAsync`. Judging each unit only on its
+ * own text let that latch — one of the two sites the file-level gate missed —
+ * read as innocent.
+ */
+function propagateProbeReach(
+	units: Array<{ name: string; facts: Omit<UnitFacts, "name"> }>,
+): void {
+	const byName = new Map(units.map((unit) => [unit.name, unit.facts]));
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const unit of units) {
+			for (const call of unit.facts.calls) {
+				const callee = byName.get(call);
+				if (!callee || callee === unit.facts) continue;
+				if (callee.versionFlag && !unit.facts.versionFlag) {
+					unit.facts.versionFlag = true;
+					changed = true;
+				}
+				if (callee.spawns && !unit.facts.spawns) {
+					unit.facts.spawns = true;
+					changed = true;
+				}
+			}
+		}
+	}
+}
+
+function* walkTs(dir: string): Generator<string> {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === "node_modules") continue;
+			yield* walkTs(full);
+		} else if (
+			entry.isFile() &&
+			entry.name.endsWith(".ts") &&
+			!entry.name.endsWith(".d.ts") &&
+			!entry.name.endsWith(".test.ts")
+		) {
+			yield full;
+		}
+	}
+}
+
+export async function scanClientsTree(
+	repoRoot: string,
+): Promise<AvailabilityUnit[]> {
+	const clientsRoot = path.join(repoRoot, "clients");
+	const found: AvailabilityUnit[] = [];
+	for (const file of walkTs(clientsRoot)) {
+		const source = fs.readFileSync(file, "utf-8");
+		// Parsing every module in `clients/` costs seconds. A module with no
+		// version flag ANYWHERE in its text cannot contain a version probe — the
+		// hoisted-const case reads its initializer from the same file — so this
+		// skip cannot hide a consumer, only make the gate affordable.
+		if (!VERSION_FLAG_TEXT.test(source)) continue;
+		const rel = path.relative(repoRoot, file).split(path.sep).join("/");
+		found.push(...(await analyzeAvailabilityUnits(source, rel)));
+	}
+	return found.sort((a, b) =>
+		`${a.file}::${a.unit}`.localeCompare(`${b.file}::${b.unit}`),
+	);
+}
+
+/** `clients/foo.ts::Bar` — the identity a gate finding is keyed by. */
+export function unitId(unit: AvailabilityUnit): string {
+	return `${unit.file}::${unit.unit}`;
+}

--- a/tests/support/availability-gate.ts
+++ b/tests/support/availability-gate.ts
@@ -60,10 +60,11 @@ const SPAWN_CALLS = new Set([
 
 /**
  * Calls that spawn on the unit's behalf. A module that delegates its probe to
- * `createAvailabilityChecker` or a `probeX` helper is still probing.
+ * `createAvailabilityChecker`, `createToolchainAvailability` or a `probeX`
+ * helper is still probing.
  */
 const SPAWN_DELEGATES =
-	/^(?:probe|spawn|exec|run|which|isCommandAvailable|createAvailabilityChecker|createCwdCachedProbe|resolveCommandWithInstallFallback|verifyOrInstall)/i;
+	/^(?:probe|spawn|exec|run|which|isCommandAvailable|createAvailabilityChecker|createCwdCachedProbe|createToolchainAvailability|resolveCommandWithInstallFallback|verifyOrInstall)/i;
 
 /** Every flag a CLI is asked for its version with. */
 const VERSION_FLAGS = new Set([
@@ -105,6 +106,10 @@ const VERSION_FLAG_TEXT = new RegExp(
 const POLICY_FACTORIES = new Set([
 	"createAvailabilityChecker",
 	"createAvailabilityLatch",
+	// Owns the latch, the in-flight dedupe and the decision records for the
+	// toolchain clients (#1476). A client that hands its lifecycle to this
+	// factory is routed as surely as one that calls the latch itself.
+	"createToolchainAvailability",
 ]);
 const POLICY_CALLS = new Set([
 	...POLICY_FACTORIES,
@@ -434,9 +439,15 @@ function readImports(root: SgNode): {
 				.filter(Boolean);
 			const fromPolicy = /availability-policy\.js$/.test(source);
 			const fromHelpers = /runner-helpers\.js$/.test(source);
+			// The module that owns the toolchain lifecycle, same standing as
+			// `runner-helpers.ts` for `createAvailabilityChecker`.
+			const fromToolchain = /utils\/toolchain-availability\.js$/.test(source);
 			for (const name of names) {
 				if (fromPolicy && POLICY_CALLS.has(name)) policyBindings.add(name);
 				if (fromHelpers && name === "createAvailabilityChecker") {
+					policyBindings.add(name);
+				}
+				if (fromToolchain && name === "createToolchainAvailability") {
 					policyBindings.add(name);
 				}
 				if (name === "SecurityScanClient") securityScanClientImported = true;

--- a/tests/support/availability-gate.ts
+++ b/tests/support/availability-gate.ts
@@ -150,6 +150,20 @@ function baseName(callee: string): string {
 	return parts[parts.length - 1] ?? callee;
 }
 
+/**
+ * The declared name a member expression hangs off: `registry` for
+ * `registry.toolAvailable`, `cached` for `cached.entries.set`.
+ *
+ * Memo writes are resolved against declarations, and it is the ROOT that is
+ * declared — the trailing segments are properties of it. Taking the last
+ * segment instead loses the container entirely, so a verdict parked on a
+ * module-level registry object reads as an undeclared local and escapes the
+ * gate.
+ */
+function rootName(expr: string): string {
+	return expr.split(".")[0] ?? expr;
+}
+
 /** Stable identity for a node, used as a scope key. */
 function scopeKey(node: SgNode | null): string {
 	if (!node) return "<module>";
@@ -247,7 +261,7 @@ function collectUnit(
 					const args = node.field("arguments")?.children() ?? [];
 					facts.writes.push({
 						target: callee,
-						base: baseName(container),
+						base: rootName(container),
 						scope: childScope,
 						isThisMember: container.startsWith("this."),
 						valueText: args[args.length - 2]?.text() ?? "",
@@ -286,7 +300,7 @@ function collectUnit(
 				const right = (node.field("right")?.text() ?? "").trim();
 				facts.writes.push({
 					target: left,
-					base: baseName(left),
+					base: rootName(left),
 					scope: childScope,
 					isThisMember: left.startsWith("this."),
 					valueText: right,


### PR DESCRIPTION
Closes #1476.

## Problem

#1467 fixed one instance of a defect and left six behind. A probe failure of any kind — including a timeout — was remembered as a durable "tool is not installed" verdict for the session, so one slow first run under load disabled an installed tool until restart and the message blamed a missing install.

The issue named three sites. A sweep for the shape found four more.

## What was migrated

Named in the issue:

- **`clients/biome-client.ts`** — collapsed every failure to `{ outcome: "missing" }`, so a timeout both triggered an install and latched false. Biome is a hot-path formatter, so this was the most user-visible.
- **`clients/sg-runner.ts`** — every candidate probe failure latched, after first running a full auto-install. A transient sweep now short-circuits *before* the install.
- **`clients/govulncheck-client.ts`** — a timed-out `go install` and a timed-out re-probe of a successful install now mark transient. A non-zero install exit still latches deliberately: retrying that every turn is a `go install` storm.

Found by the sweep:

- **`clients/dispatch/dispatcher.ts` `checkToolAvailability`** — the largest, and nobody had named it. This is `ctx.hasTool`, the generic gate every CLI runner passes through, and it cached a stalled probe as a session fact.
- **`isSgAvailableAsync` in `runner-helpers.ts`** — the shared ast-grep memo behind every slop runner, carrying `SgRunner`'s exact shape one directory away from the policy.
- **`clients/go-client.ts` and `clients/rust-client.ts`** — `go version` / `cargo --version` on a 3 s budget. A stall disabled every Go or Rust diagnostic for the session. Both also gained in-flight sweep sharing, which matters now that verdicts expire.

Also folds in `findManagedNodeToolBinary(name)`, replacing the line-for-line duplicate that the deduplicating PR itself added to `knip-client.ts` and `jscpd-client.ts`.

## The durable close

The first version of this gate did not work. It scanned for the defect shape with regexes, and a review wrote seven files carrying that shape into `clients/` — all seven passed. A file counted as compliant if it contained the string `availability-policy.js` **anywhere**, so a `// TODO: route through availability-policy.js` comment marked it clean. Against master it flagged only 5 of the 7 sites this PR migrates, and could never have found two of them, because both already imported the policy for a different memo and the gate judged per file.

That is worse than a hand-written list: a list is visibly incomplete, a derived gate reads as proof.

`tests/support/availability-gate.ts` now analyses the AST with `@ast-grep/napi`, already a runtime dependency. Three properties, each bought with one of the evasions:

- **Routing means an `import_statement` binds a policy symbol.** A comment is not an import statement.
- **Judgement is per top-level unit, not per file**, with module-local call-graph propagation to a fixed point — the pre-fix `runner-helpers.ts` latch sat one function away from its `--version` literal and its spawn.
- **A memo is state that outlives the call** holding a verdict shape, which is what separates `pipeline.ts`'s `_eslintCache` from a per-call status report.

All seven evasions are now fixtures the gate must flag, plus a second hand-rolled latch beside a compliant one in the same file, a probe one helper away from its latch, and two positive controls. Against master it flags 6 of 7, adding `runner-helpers.ts::isSgAvailableAsync` — the second-latch case that was the crux.

It does **not** flag pre-fix `govulncheck-client.ts`, and that is correct rather than a miss: its memo was `SecurityScanClient`'s policy-backed latch, and its defect was a durable `false` written from a transient install failure *inside* a governed memo. Different shape. The rule was not stretched to manufacture a seventh hit.

**Named limits, so this is not read as proof again.** `clients/pipeline.ts::tryEslintFix` remains unrouted and is a named baseline entry — shrink-only, so a new violation fails the gate and a baseline entry that stops being flagged also fails, meaning a fix cannot leave scaffolding behind. And the verdict-shape rule does not see `formatters.ts` or `package-manager.ts` (#1495, #1496), because their memos hold resolved paths rather than boolean verdicts.

## Observability

Every migrated tool now emits one `availability_decision` per verdict carrying `outcome`, `cause`, `elapsedMs`, `hostStallMs`, `retryAfterMs` and `budgetMs` — including govulncheck's two transient branches, which previously logged nothing at all. A latched tool is now a single grep instead of an inference from weeks of silence, which is the gap that let knip stay dead.

Confirmed `availability_decision` remains in `LAST_PHASE_EXCLUDED`, so these zero-duration decision records cannot poison `loop_block` attribution.

## Verification

**Behavior preservation first.** 14 pins covering genuine absence and successful probe for every tool pass on pre-fix code, so the change is provably confined to the transient path. Against reverted clients, 12 failed and 14 passed — nine regression assertions fail without the fix.

Three `ctx.hasTool` tests cannot run pre-fix because that seam was module-private; their binding rests on mutation instead, and the commit message says so rather than implying a red-first proof they do not have.

**11 mutants, all red**, each with a full rebuild between: the biome latch, the sg-runner transient gate, the shared-sg verdict, govulncheck install classification, the go and rust verdicts, both dedupe paths, the dispatcher fact write, the managed-shim resolver, and a synthetic unrouted client against the coverage gate.

Build, lint and changelog clean. 26 tests across the three new files; 791 of 792 across the dispatch suite and 12 related files.

**The one failure is pre-existing.** `tests/clients/jscpd-client.test.ts > uses the managed executable after PATH installation` fails identically with `clients/` reverted to master. It expects the second spawn to use the managed path and gets `npx`, most likely because this dev machine has a managed jscpd shim that trips the fast path. Filed as #1491, untouched here.

No full suite; CI is authoritative.

## Sweep correction

The review found the sweep is **not** complete, and one miss is in a file this PR edits. Correcting the record rather than leaving the claim above to stand:

- `createCwdCachedProbe` (`runner-helpers.ts:627`) carries the exact shape and feeds eslint (5 s), credo (10 s, the slowest probe in the repo) and rust-clippy (8 s). Filed as #1494.
- `clients/formatters.ts` was excluded here as "filesystem detection with no memoized spawn verdict". **That is wrong on both halves.** `which()` at `:199` is a `safeSpawnAsync` with a 5 s timeout, and its result is memoized in `detectionCache`, invalidated only by config mtime or LRU — never by time. One stalled `which rustfmt` disables Rust formatting until the user edits a config file. Filed as #1495.
- `clients/package-manager.ts:95` memoizes a package-manager probe forever; a timeout silently downgrades the session to npm, with the wrong lockfile semantics. Filed as #1496.

None are fixed here — each needs its own regression proof — but the claim that the sweep was thorough should not have been made without them.

## Left for follow-ups

`clients/dispatch/runners/psscriptanalyzer.ts` carries the same latch but bypasses `safe-spawn` entirely via a hand-rolled `spawnPs` that returns `status: null` on timeout, so it has no failure taxonomy to classify. Migrating it means routing it through `safeSpawnAsync` first. Filed as #1490.

Screened and correctly excluded: `test-runner-client.ts`'s `availableRunners` and `formatters.ts`'s `detect` are filesystem and package.json detection with no memoized spawn verdict.




