### PR TITLE
fix(lsp): narrow confirmation when an auxiliary is cut off (#1470)

### DIFF
--- a/.changelog/fix-1470-cutoff-conclusive.md
+++ b/.changelog/fix-1470-cutoff-conclusive.md
@@ -9,7 +9,9 @@ section: Fixed
   discarded: it names the servers it does not speak for, so `lsp_diagnostics` says
   which coverage is missing, the cascade no longer wipes a live finding on that
   evidence, the workspace sweep stops caching a partially covered result, and the
-  per-edit lane stops reporting an empty result as checked. A primary that
+  per-edit lane stops reporting an empty result as checked — on both the
+  incumbent-touch route and the warm-attach route a per-edit check takes in a
+  live session. A primary that
   answered stays trustworthy — its findings still reach you. A related gap stays
   open: a scanner that answers within its budget but publishes nothing still reads
   as clean (#1493).

--- a/.changelog/fix-1470-cutoff-conclusive.md
+++ b/.changelog/fix-1470-cutoff-conclusive.md
@@ -1,0 +1,12 @@
+---
+section: Fixed
+---
+
+- **A cut-off auxiliary no longer reads as confirmed clean (closes #1470)** — When
+  the aux grace timer cut off a scanner such as opengrep, the touch still reported
+  an unqualified confirmation, so a hung security scanner produced a result that
+  read as a clean bill of health. The confirmation is now narrowed rather than
+  discarded: it names the servers it does not speak for, so `lsp_diagnostics` says
+  which coverage is missing, the cascade no longer wipes a live finding on that
+  evidence, and the per-edit lane stops reporting an empty result as checked. A
+  primary that answered stays trustworthy — its findings still reach you.

--- a/.changelog/fix-1470-cutoff-conclusive.md
+++ b/.changelog/fix-1470-cutoff-conclusive.md
@@ -8,5 +8,8 @@ section: Fixed
   read as a clean bill of health. The confirmation is now narrowed rather than
   discarded: it names the servers it does not speak for, so `lsp_diagnostics` says
   which coverage is missing, the cascade no longer wipes a live finding on that
-  evidence, and the per-edit lane stops reporting an empty result as checked. A
-  primary that answered stays trustworthy — its findings still reach you.
+  evidence, the workspace sweep stops caching a partially covered result, and the
+  per-edit lane stops reporting an empty result as checked. A primary that
+  answered stays trustworthy — its findings still reach you. A related gap stays
+  open: a scanner that answers within its budget but publishes nothing still reads
+  as clean (#1493).

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -62,6 +62,7 @@ import {
 	type BoundToCurrentDisk,
 	type TouchFileResult,
 	bindingStateLabel,
+	touchCoverageGap,
 } from "../lsp/diagnostic-binding.js";
 import { getServersForFileWithConfig } from "../lsp/config.js";
 import { getLSPService } from "../lsp/index.js";
@@ -572,6 +573,11 @@ function readBoundToCurrentDisk(
  * a future flag cannot be silently missed at just one of the several gate sites:
  *  - `inconclusive` (#1093/#571): the notify/diagnostics wait lapsed its deadline,
  *    so a resolved `[]` is NOT a confirmed clean (the #533 false-clean trap).
+ *  - a COVERAGE GAP (#1470): an auxiliary's push wait was cut off by the aux grace
+ *    timer, so the merged result is missing whatever that scanner would have said.
+ *    Such a touch is deliberately NOT `inconclusive` (the primary answered), which
+ *    is exactly why it needs naming here: reading `!inconclusive` alone would let a
+ *    hung opengrep wipe a live footer finding and seed the recently-clean cache.
  *  - `binding.boundToCurrentDisk === false` (#1095): the diagnostics were computed
  *    against a DIFFERENT disk state than what is on disk now (the server's view
  *    diverged / a pre-fix buffer) — not an observation of current disk. `true` and
@@ -587,7 +593,11 @@ function readInconclusive(rawDiags: unknown): boolean {
 }
 
 function isConfirmedTouch(rawDiags: TouchFileResult): boolean {
-	return !readInconclusive(rawDiags) && readBoundToCurrentDisk(rawDiags) !== false;
+	return (
+		!readInconclusive(rawDiags) &&
+		touchCoverageGap(rawDiags).length === 0 &&
+		readBoundToCurrentDisk(rawDiags) !== false
+	);
 }
 
 // #459: the reverse-dependency index is a pure function of the review graph.
@@ -1734,6 +1744,10 @@ export async function computeCascadeForFile(
 				const confirmed = isConfirmedTouch(rawDiags);
 				const bindingRejected = readBoundToCurrentDisk(rawDiags) === false;
 				const inconclusive = readInconclusive(rawDiags);
+				// #1470: the third, independent reason a touch is unconfirmed — an
+				// auxiliary our grace timer cut off. Logged alongside the other two so
+				// cascade.log alone still tells the three apart.
+				const unconfirmedServerIds = touchCoverageGap(rawDiags);
 				// #692: `source: "cascade"` no longer overrides `rule` (see the
 				// doc comment on the sibling call above) — dropped rather than
 				// migrated to `scanOrigin` since cascade output never touches
@@ -1789,6 +1803,9 @@ export async function computeCascadeForFile(
 					metadata: {
 						inconclusive,
 						...(bindingRejected && { bindingState: bindingStateLabel(false) }),
+						...(unconfirmedServerIds.length > 0 && {
+							unconfirmedServerIds: [...unconfirmedServerIds],
+						}),
 					},
 				});
 

--- a/clients/dispatch/runners/lsp.ts
+++ b/clients/dispatch/runners/lsp.ts
@@ -177,11 +177,23 @@ const lspRunner: RunnerDefinition = {
 			usedWarmAttach = attached?.available === true;
 			// #1179 (shape-5 structural fix): both branches normalize to the
 			// `touchFile` wrapper shape. The warm-attach IPC branch resolves a plain
-			// diagnostics array (the socket cannot carry a side-channel; the IPC client
-			// already rejected any inconclusive answer, so `available` ⟹ confirmed) —
-			// wrap it as `{ diags }`; the incumbent branch already returns the wrapper.
+			// diagnostics array — `available` no longer implies a fully confirmed
+			// answer: a `partial` confirmation (an auxiliary cut off by the grace
+			// timer) is served as `available: true` too (the IPC gate at
+			// `clients/mcp/ipc.ts:248` rejects only `inconclusive`). Carry the
+			// incumbent's `unconfirmedServerIds` onto the wrapper so
+			// `touchCoverageGap` below sees it — dropping it here is the same
+			// false-clean defect already fixed at `clients/lsp/index.ts` (the
+			// workspace sweep wrapper) and `tools/lsp-diagnostics.ts` (the tool
+			// consumer); wrap it as `{ diags }`; the incumbent branch already
+			// returns the wrapper.
 			const touched = attached?.available
-				? { diags: attached.response.diagnostics }
+				? {
+						diags: attached.response.diagnostics,
+						...(attached.response.unconfirmedServerIds !== undefined && {
+							unconfirmedServerIds: attached.response.unconfirmedServerIds,
+						}),
+					}
 				: await lspService.touchFile(ctx.filePath, content, {
 				diagnostics: "document",
 				collectDiagnostics: true,

--- a/clients/dispatch/runners/lsp.ts
+++ b/clients/dispatch/runners/lsp.ts
@@ -13,6 +13,7 @@
  */
 
 import { logExtension } from "../../extension-log.js";
+import { touchCoverageGap } from "../../lsp/diagnostic-binding.js";
 import { getLSPService } from "../../lsp/index.js";
 import { RUNTIME_CONFIG } from "../../runtime-config.js";
 import { PRIORITY } from "../priorities.js";
@@ -143,6 +144,11 @@ const lspRunner: RunnerDefinition = {
 		// one spawned server) — an empty `lspDiags` in that case is NOT a
 		// confirmed clean result and must not be reported as one (#570).
 		let diagnosticsInconclusive = false;
+		// #1470: server ids the touch carries no evidence for — an auxiliary whose
+		// push wait our aux grace timer cut off. The touch is NOT inconclusive (the
+		// primary answered, and its findings below are real), so this is tracked
+		// separately: the only claim it invalidates is "0 diagnostics means clean".
+		let unconfirmedServerIds: readonly string[] = [];
 		let usedWarmAttach = false;
 		let failureReason = "";
 		const content = readFileContent(ctx.filePath);
@@ -190,6 +196,7 @@ const lspRunner: RunnerDefinition = {
 			} else {
 				lspDiags = touched.diags;
 				diagnosticsInconclusive = touched.inconclusive === true;
+				unconfirmedServerIds = touchCoverageGap(touched);
 			}
 		} catch (err) {
 			serverFailed = true;
@@ -252,6 +259,20 @@ const lspRunner: RunnerDefinition = {
 		}
 
 		if (lspDiags.length === 0) {
+			if (unconfirmedServerIds.length > 0) {
+				// #1470: an auxiliary was cut off by the aux grace timer, so this empty
+				// merged result is missing whatever that scanner would have said — a
+				// hung opengrep must not read as a clean bill of health on the security
+				// lane. `RunnerResult` has no channel for "clean for these servers,
+				// unknown for those", so the only honest verdict this seam can express
+				// for an EMPTY result is "not checked" — which is what "skipped" means
+				// here, and it lets the coverage notice say so once. Nothing is thrown
+				// away: the primary answered with zero findings, so there is nothing to
+				// report; when it DOES have findings the branches below still report
+				// them (see the non-empty path), which is how a trustworthy primary
+				// stays trustworthy under a cut-off auxiliary.
+				return { status: "skipped", diagnostics: [], semantic: "none" };
+			}
 			return {
 				status: "succeeded",
 				diagnostics: [],

--- a/clients/lsp/diagnostic-binding.ts
+++ b/clients/lsp/diagnostic-binding.ts
@@ -87,7 +87,11 @@ export interface DiagnosticBinding extends StoredDiagnosticBinding {
  * `diags` is always present (empty array when nothing was collected). `inconclusive`
  * is present-and-true only for a genuinely unconfirmed collect (the notify write
  * and/or diagnostics wait lapsed its deadline). `confirmation` is present only when
- * this touch completed its configured diagnostics/confirmation policy. It is required
+ * this touch completed its configured diagnostics/confirmation policy — `"confirmed"`
+ * for every spawned server, or (#1470) `"partial"` when an auxiliary's push wait was
+ * cut off by the aux grace timer and `unconfirmedServerIds` names it. A partial touch
+ * is deliberately NOT `inconclusive`: the primary answered and its findings stand;
+ * only the claim of full coverage is withdrawn. It is required
  * before treating an empty result from a known silent-on-clean server as clean, but is
  * not a substitute for a consumer's stricter scope-specific fallback — notably, an
  * all-scope classic TypeScript touch still needs the tool's synchronous tsserver check.
@@ -108,9 +112,51 @@ export interface DiagnosticBinding extends StoredDiagnosticBinding {
  */
 export interface TouchFileResult {
 	diags: import("./client.js").LSPDiagnostic[];
-	confirmation?: "confirmed";
+	confirmation?: "confirmed" | "partial";
 	inconclusive?: boolean;
+	/**
+	 * #1470: server ids this touch carries NO evidence for. Populated (and
+	 * `confirmation` narrowed to `"partial"`) when an auxiliary's push wait was
+	 * cut off by the aux grace timer — R8/#714's `auxCutOffServerIds`. Absent
+	 * when every spawned server got to answer for itself.
+	 */
+	unconfirmedServerIds?: string[];
 	binding?: DiagnosticBinding;
+}
+
+/**
+ * #1470: the single source of truth for "which servers did this touch NOT hear
+ * from". Read this instead of comparing `confirmation` to a string literal — a
+ * consumer that tests `confirmation === "confirmed"` is correct only by accident
+ * (it happens to fail closed for `"partial"`), and one that tests `!inconclusive`
+ * is outright wrong, because a partially-confirmed touch is deliberately NOT
+ * inconclusive: the primary's answer is still trustworthy and must survive.
+ */
+export function touchCoverageGap(
+	result: TouchFileResult | undefined,
+): readonly string[] {
+	return result?.unconfirmedServerIds ?? [];
+}
+
+/**
+ * #1470: did this touch complete its configured confirmation policy at all —
+ * `"confirmed"` (for every spawned server) or `"partial"` (for every server
+ * except the named cut-off auxiliaries)?
+ *
+ * This is deliberately NOT `confirmation === "confirmed"`. A consumer asking
+ * "did the PRIMARY confirm?" must answer yes for a partial touch: `partial`
+ * implies neither the notify write nor the diagnostics wait lapsed, so the
+ * silent-clean gates ran to completion exactly as they do for a full
+ * confirmation. Reading `=== "confirmed"` there looks safely fail-closed but
+ * reports "the language server could not confirm clean" when the truth is "the
+ * language server confirmed clean and a scanner was cut off" — the same overclaim
+ * pointing the other way. Pair this with {@link touchCoverageGap}, which names
+ * what the touch does not speak for.
+ */
+export function touchCompletedConfirmationPolicy(
+	result: TouchFileResult | undefined,
+): boolean {
+	return result?.confirmation !== undefined;
 }
 
 /**

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -54,6 +54,7 @@ import {
 	bindingStateLabel,
 	composeBoundToCurrentDisk,
 	createDiskBindingCache,
+	touchCoverageGap,
 	type BoundToCurrentDisk,
 	type DiagnosticBinding,
 	type DiskBindingCache,
@@ -3242,10 +3243,13 @@ export class LSPService {
 
 		// #1470: an auxiliary whose push wait was CUT OFF by the aux grace timer
 		// (R8/#714) contributed exactly as much evidence about this file as one that
-		// went silent inside its own budget — none. The silent case already reads as
-		// inconclusive; the cut-off case did not, so a hung opengrep resolved
+		// went silent inside its own budget — none. A hung opengrep resolved
 		// `confirmation: "confirmed"` and read as confirmed-clean on the security
-		// lane. This does NOT flip the touch to inconclusive: that would discard a
+		// lane. (The SILENT case still does, and is NOT addressed here: a scanner
+		// that settles inside its own budget without publishing also yields an
+		// unqualified confirmation. Same #533 class, same lane, different door —
+		// filed as #1493, deliberately untouched by this change.)
+		// This does NOT flip the touch to inconclusive: that would discard a
 		// primary answer that IS trustworthy (#533 honesty doctrine cuts both ways —
 		// overclaiming and underclaiming are both dishonest). Instead the confirmation
 		// is NARROWED: `"partial"`, naming the servers it does not speak for, so every
@@ -4937,7 +4941,17 @@ export class LSPService {
 				// answer, so `available` implies confirmed) — wrap it as `{ diags }`;
 				// the incumbent branch already returns the wrapper.
 				const touchResult = attached?.available
-					? { diags: attached.response.diagnostics }
+					? {
+							diags: attached.response.diagnostics,
+							// #1470: the incumbent's coverage gap crosses the socket as an
+							// explicit DTO field, so carry it onto the wrapper the sweep
+							// reads. Dropping it here would let a partially covered
+							// incumbent answer be persisted as a confirmed sweep result —
+							// the same false clean this change closes on the local route.
+							...(attached.response.unconfirmedServerIds !== undefined && {
+								unconfirmedServerIds: attached.response.unconfirmedServerIds,
+							}),
+						}
 					: await withDeadline(
 							this.touchFile(filePath, content, {
 								diagnostics: "document",
@@ -4962,7 +4976,19 @@ export class LSPService {
 				// `perFileMs` deadline, which only catches a touch that never returned at
 				// all within budget. Either one means the result wasn't confirmed.
 				const inconclusive = touchResult?.inconclusive === true;
-				const timedOut = touchResult === undefined || inconclusive;
+				// #1470: a cut-off auxiliary is the THIRD reason this result is not a
+				// confirmed observation, and it is deliberately not `inconclusive`. The
+				// record loop below persists every `!timedOut` result into the workspace
+				// cache, so reading `inconclusive` alone caches a partially covered
+				// answer as clean and replays it on every later sweep. Today the only
+				// route that can reach this branch with a gap is the warm-attach
+				// incumbent, whose touch runs `clientScope: "with-auxiliary"`; the
+				// sweep's own local touch uses `clientScope: "all"`, which never arms
+				// the aux grace timer at all. Both are gated here so a future scope
+				// change cannot reopen the hole silently.
+				const coverageGap = touchCoverageGap(touchResult).length > 0;
+				const timedOut =
+					touchResult === undefined || inconclusive || coverageGap;
 				if (timedOut) timedOutFiles += 1;
 				// #1104 (shape 5 — AGENTS.md): the touch's content binding is an
 				// EXPLICIT enumerable field on the wrapper now (#1179), so it survives

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -3267,9 +3267,16 @@ export class LSPService {
 		//
 		// #1470: same per-server reasoning for a CUT-OFF auxiliary. "Demonstrated
 		// ready" means this server answered for this file; an auxiliary our grace
-		// timer cut off demonstrably did not, so marking it warm would let
-		// `ensureWarmForSweep` skip the warm-up round trip on the strength of a touch
-		// it never answered.
+		// timer cut off demonstrably did not.
+		//
+		// NO TEST PINS THIS LINE, and that is a property of today's readers rather
+		// than a coverage gap: `ensureWarmForSweep` filters `role === "auxiliary"`
+		// out of its server list entirely, so no reader consumes an auxiliary's
+		// `demonstratedReady` mark and deleting this `continue` changes no observable
+		// behavior (verified by mutation — the LSP suite stays green). It stays
+		// because the mark's meaning is "this server answered", and the moment any
+		// reader stops filtering auxiliaries out, marking a cut-off scanner warm
+		// would let it skip a warm-up it never earned.
 		const notifyTimedOutServerIds = new Set(notifyWriteTimedOutServerIds);
 		const cutOffServerIds = new Set(unconfirmedServerIds);
 		if (diagnosticsMode !== "none" && !diagnosticsTimedOut) {

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -3240,6 +3240,20 @@ export class LSPService {
 		// confirmed answer.
 		const inconclusive = notifyWriteTimedOut || diagnosticsTimedOut;
 
+		// #1470: an auxiliary whose push wait was CUT OFF by the aux grace timer
+		// (R8/#714) contributed exactly as much evidence about this file as one that
+		// went silent inside its own budget — none. The silent case already reads as
+		// inconclusive; the cut-off case did not, so a hung opengrep resolved
+		// `confirmation: "confirmed"` and read as confirmed-clean on the security
+		// lane. This does NOT flip the touch to inconclusive: that would discard a
+		// primary answer that IS trustworthy (#533 honesty doctrine cuts both ways —
+		// overclaiming and underclaiming are both dishonest). Instead the confirmation
+		// is NARROWED: `"partial"`, naming the servers it does not speak for, so every
+		// consumer that treats confirmation as proof of coverage fails closed while
+		// the primary's findings still flow.
+		const unconfirmedServerIds = auxCutOffServerIds ?? [];
+		const coverageGap = unconfirmedServerIds.length > 0;
+
 		// #667: a confirmed (non-inconclusive) diagnostics-mode touch is the
 		// "actually warm" signal `ensureWarmForSweep` waits for — mark every
 		// spawned server so a later sweep in this session sees the check as a
@@ -3250,10 +3264,18 @@ export class LSPService {
 		// write stalled must still be eligible, so only servers whose OWN write
 		// timed out are skipped here (rather than gating the whole loop on the
 		// file-level `inconclusive`).
+		//
+		// #1470: same per-server reasoning for a CUT-OFF auxiliary. "Demonstrated
+		// ready" means this server answered for this file; an auxiliary our grace
+		// timer cut off demonstrably did not, so marking it warm would let
+		// `ensureWarmForSweep` skip the warm-up round trip on the strength of a touch
+		// it never answered.
 		const notifyTimedOutServerIds = new Set(notifyWriteTimedOutServerIds);
+		const cutOffServerIds = new Set(unconfirmedServerIds);
 		if (diagnosticsMode !== "none" && !diagnosticsTimedOut) {
 			for (const entry of spawned) {
 				if (notifyTimedOutServerIds.has(entry.info.id)) continue;
+				if (cutOffServerIds.has(entry.info.id)) continue;
 				const key = await this.demonstratedReadyKeyFor(entry.info, filePath);
 				if (key) this.markDemonstratedReadyKey(key);
 			}
@@ -3268,7 +3290,14 @@ export class LSPService {
 		// empty `collected` must never erase a previously-confirmed non-empty
 		// record (that's the #570 bug — a timeout silently reporting as clean
 		// and wiping out known-good diagnostic state).
-		if (collected !== undefined && !inconclusive) {
+		// #1470: a PARTIAL touch is the same hazard wearing a different flag. Its
+		// merged array is missing whatever the cut-off auxiliary would have said, so
+		// priming the cache with it would let `actionable-warnings`' hash-guarded
+		// read replay a partially-covered result as an authoritative observation —
+		// and an empty one would DELETE a previously-confirmed record on the strength
+		// of a scanner that never answered. Skip the prime; the next read pays a real
+		// round trip instead of trusting an incomplete one.
+		if (collected !== undefined && !inconclusive && !coverageGap) {
 			const normalizedKey = normalizeMapKey(filePath);
 			if (collected.length > 0) {
 				this.lastKnownDiagnostics.set(normalizedKey, collected);
@@ -3292,6 +3321,13 @@ export class LSPService {
 
 		if (collected !== undefined && inconclusive) {
 			result.inconclusive = true;
+		} else if (collected !== undefined && coverageGap) {
+			// #1470: narrowed, not collapsed. The primary's findings ride along in
+			// `.diags` exactly as before; what changes is that the touch now states
+			// which servers it does not speak for, so no consumer can read this as a
+			// full clean bill of health.
+			result.confirmation = "partial";
+			result.unconfirmedServerIds = [...unconfirmedServerIds];
 		} else if (collected !== undefined) {
 			// Preserve the lower-level affirmative result across consumers. In
 			// particular, the silent-clean gates above clear diagnosticsTimedOut only
@@ -3364,6 +3400,13 @@ export class LSPService {
 				}),
 				diagnosticsTimedOut,
 				inconclusive,
+				// #1470: the touch's own honesty verdict, so a `cut_off` row in
+				// `lsp_aux_wait_outcome` can be joined to the touch that produced it and
+				// shown NOT to have claimed confirmation for that server's coverage.
+				// Absent for a non-collecting touch, which claims nothing either way.
+				...(result.confirmation !== undefined && {
+					confirmation: result.confirmation,
+				}),
 				// R8 (#714): server ids of auxiliaries whose push wait was cut off by
 				// the aux grace window (primary settled clean + aux timed out in grace).
 				// Absent when no aux was cut off. These servers' diagnostics are

--- a/clients/mcp/ipc.ts
+++ b/clients/mcp/ipc.ts
@@ -86,8 +86,20 @@ export interface WarmDiagnosticsResponse {
 	 * flag is carried explicitly rather than inferred. Optional: an incumbent
 	 * built before this field simply omits it, and the consumer then falls back
 	 * to today's unconfirmed handling.
+	 *
+	 * #1470: `"partial"` is the narrowed verdict — the incumbent's touch completed,
+	 * but an auxiliary was cut off by the aux grace timer and `unconfirmedServerIds`
+	 * names it. A consumer testing `=== "confirmed"` therefore fails closed for free;
+	 * one that wants the narrowing reads the id list.
 	 */
-	confirmation?: "confirmed";
+	confirmation?: "confirmed" | "partial";
+	/**
+	 * #1470: server ids the incumbent's touch carries no evidence for. Present only
+	 * alongside `confirmation: "partial"`. Re-surfaced as an EXPLICIT enumerable DTO
+	 * field for the same reason `inconclusive` is: no side-channel survives
+	 * `JSON.stringify` of the diagnostics array.
+	 */
+	unconfirmedServerIds?: string[];
 }
 
 export interface WarmCodeActionRange {

--- a/clients/warm-attach.ts
+++ b/clients/warm-attach.ts
@@ -135,6 +135,11 @@ async function serveRequest(
 		source: "warm-attach-incumbent",
 	});
 	const servedAt = Date.now();
+	// #1470: the coverage gap is read through the shared helper, never re-derived
+	// from `confirmation === "partial"`. The two fields are set together today, so
+	// either test passes — which is exactly the coincidence `touchCoverageGap`'s
+	// own doc comment warns against. One reader, one rule.
+	const coverageGap = touchCoverageGap(touched);
 	if (servedAt <= req.deadlineAt && touched !== undefined && !touched.inconclusive) {
 		state.servedDiagnosticHashes.set(
 			normalizeFilePath(req.file),
@@ -167,10 +172,10 @@ async function serveRequest(
 			// would be indistinguishable from an old incumbent that never sent the
 			// field — and the whole point of narrowing is that the reader can tell
 			// which coverage is real.
-			...(touched?.confirmation === "partial"
+			...(coverageGap.length > 0
 				? {
 						confirmation: "partial" as const,
-						unconfirmedServerIds: [...touchCoverageGap(touched)],
+						unconfirmedServerIds: [...coverageGap],
 					}
 				: {}),
 		},

--- a/clients/warm-attach.ts
+++ b/clients/warm-attach.ts
@@ -10,6 +10,7 @@ import {
 	STALE_HEARTBEAT_MS,
 } from "./instance-reaper.js";
 import { logLatency } from "./latency-logger.js";
+import { touchCoverageGap } from "./lsp/diagnostic-binding.js";
 import { loadLspService } from "./lsp-lazy.js";
 import {
 	contentHash,
@@ -160,6 +161,17 @@ async function serveRequest(
 			// server is indistinguishable from "never answered" on the far side.
 			...(touched?.confirmation === "confirmed"
 				? { confirmation: "confirmed" as const }
+				: {}),
+			// #1470: a PARTIAL touch crosses the socket as itself rather than as a
+			// missing key. Omitting it would still fail closed on the far side, but it
+			// would be indistinguishable from an old incumbent that never sent the
+			// field — and the whole point of narrowing is that the reader can tell
+			// which coverage is real.
+			...(touched?.confirmation === "partial"
+				? {
+						confirmation: "partial" as const,
+						unconfirmedServerIds: [...touchCoverageGap(touched)],
+					}
 				: {}),
 		},
 	};

--- a/tests/clients/cascade-compute.test.ts
+++ b/tests/clients/cascade-compute.test.ts
@@ -2007,6 +2007,72 @@ describe("computeCascadeForFile", () => {
 			}
 		});
 
+		it("a PARTIALLY confirmed active touch (auxiliary cut off) does NOT wipe a live footer finding (#1470)", async () => {
+			const env = setupTestEnvironment("cascade-reconcile-partial-touch-");
+			try {
+				const primary = path.join(env.tmpDir, "model.py");
+				const neighbor = path.join(env.tmpDir, "api.py");
+				fs.writeFileSync(primary, "class User: pass\n");
+				fs.writeFileSync(neighbor, "from model import User\n");
+				mocks.computeImpactCascade.mockReturnValue(impact(primary, [neighbor]));
+				// #1470: the touch resolves empty `.diags` and is NOT inconclusive —
+				// the primary answered — but an auxiliary was cut off by the aux grace
+				// timer, so the merged result is missing that scanner's coverage. Pre-
+				// fix, `isConfirmedTouch` read only `inconclusive`, so this wiped the
+				// live finding and seeded the recently-clean cache, making the wipe
+				// self-sustaining on the next cascade.
+				mocks.getLSPService.mockReturnValue({
+					getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
+					touchFile: vi.fn().mockResolvedValue({
+						diags: [],
+						confirmation: "partial",
+						unconfirmedServerIds: ["opengrep"],
+					}),
+					getDiagnostics: vi.fn(),
+				});
+
+				const { computeCascadeForFile, getDispatchCascadeCacheStats } =
+					await import("../../clients/dispatch/integration.js");
+				const { recordDiagnostics, getFileDiagnostics } = await import(
+					"../../clients/widget-state.js"
+				);
+
+				recordDiagnostics(
+					neighbor,
+					[
+						{
+							tool: "lsp",
+							severity: "error",
+							semantic: "blocking",
+							message: "live cross-file error",
+						},
+					],
+					1,
+				);
+
+				await computeCascadeForFile(primary, env.tmpDir, {
+					turnSeq: 1,
+					writeSeq: 5,
+				});
+
+				const diags = getFileDiagnostics(neighbor);
+				expect(diags).toHaveLength(1);
+				expect(diags?.[0]?.message).toBe("live cross-file error");
+				// Not cached as a confirmed neighbor result either.
+				expect(getDispatchCascadeCacheStats().neighborTouchCacheSize).toBe(0);
+				// The third unconfirmed-touch cause is named in cascade.log, so it is
+				// distinguishable from the inconclusive and bound-false causes.
+				const neighborTouchEntry = mocks.logCascade.mock.calls
+					.map(([entry]) => entry)
+					.find((entry) => entry.phase === "neighbor_touch");
+				expect(neighborTouchEntry?.metadata).toMatchObject({
+					unconfirmedServerIds: ["opengrep"],
+				});
+			} finally {
+				env.cleanup();
+			}
+		});
+
 		it("a confirmed LSP-clean cascade clears the neighbor's LSP error but PRESERVES a live biome finding (merge, not replace)", async () => {
 			const env = setupTestEnvironment("cascade-reconcile-merge-");
 			try {

--- a/tests/clients/dispatch/runners/runner-status-semantics.test.ts
+++ b/tests/clients/dispatch/runners/runner-status-semantics.test.ts
@@ -384,6 +384,38 @@ describe("runner status/semantic edge cases", () => {
 		}
 	});
 
+	it("lsp runner returns skipped for a warm-attached EMPTY result whose auxiliary was cut off (#1470)", async () => {
+		// The same #1470 shape as the incumbent-touch test above, but on the
+		// warm-attach IPC route: `available: true` with an empty diagnostics
+		// array and `unconfirmedServerIds` on the response DTO. The wrapper this
+		// runner builds from a warm-attach answer must carry that field through
+		// to `touchCoverageGap`, not drop it — a hung opengrep must not read as
+		// a clean bill of health here either.
+		const runner = (await import("../../../../clients/dispatch/runners/lsp.js"))
+			.default;
+		const env = setupTestEnvironment("pi-lens-lsp-warm-cutoff-");
+		try {
+			const filePath = path.join(env.tmpDir, "main.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+
+			warmAttach.diagnostics.mockResolvedValue({
+				available: true,
+				response: {
+					diagnostics: [],
+					confirmation: "partial",
+					unconfirmedServerIds: ["opengrep"],
+				},
+			});
+
+			const result = await runner.run(ctx(filePath, env.tmpDir) as never);
+			expect(result.status).toBe("skipped");
+			expect(result.diagnostics).toEqual([]);
+			expect(touchFile).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("lsp runner returns warning semantic when server open fails", async () => {
 		const runner = (await import("../../../../clients/dispatch/runners/lsp.js"))
 			.default;

--- a/tests/clients/dispatch/runners/runner-status-semantics.test.ts
+++ b/tests/clients/dispatch/runners/runner-status-semantics.test.ts
@@ -18,7 +18,14 @@ const codeAction = vi.fn();
 // (shape-5 structural fix) — wrap a mocked diagnostics array in the same shape.
 const diagsResult = (
 	diags: unknown[],
-	extra: { inconclusive?: boolean } = {},
+	extra: {
+		inconclusive?: boolean;
+		// #1470: the narrowed confirmation an aux cut off by the grace timer
+		// produces — the touch is NOT inconclusive, but it no longer speaks for
+		// the named servers.
+		confirmation?: "confirmed" | "partial";
+		unconfirmedServerIds?: string[];
+	} = {},
 ) => ({ diags, ...extra });
 const readFileContent = vi.fn(() => "const x = 1;\n");
 const warmAttach = vi.hoisted(() => ({
@@ -303,6 +310,75 @@ describe("runner status/semantic edge cases", () => {
 			const result = await runner.run(ctx(filePath, env.tmpDir) as never);
 			expect(result.status).toBe("skipped");
 			expect(result.diagnostics).toEqual([]);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("lsp runner returns skipped for an EMPTY result whose auxiliary was cut off (#1470)", async () => {
+		// The practical shape from #1470: opengrep hangs, our grace timer cuts it
+		// off, the primary answers clean. The touch is deliberately NOT
+		// inconclusive (the primary's answer is real), so the pre-fix runner
+		// reported "succeeded / no-diagnostics" — a clean bill of health on the
+		// security lane for a scan that never ran. `RunnerResult` has no
+		// per-server coverage channel, so "skipped" is the honest verdict for an
+		// EMPTY result and the coverage notice says so.
+		const runner = (await import("../../../../clients/dispatch/runners/lsp.js"))
+			.default;
+		const env = setupTestEnvironment("pi-lens-lsp-cutoff-");
+		try {
+			const filePath = path.join(env.tmpDir, "main.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+
+			supportsLSP.mockReturnValue(true);
+			touchFile.mockResolvedValue(
+				diagsResult([], {
+					confirmation: "partial",
+					unconfirmedServerIds: ["opengrep"],
+				}),
+			);
+
+			const result = await runner.run(ctx(filePath, env.tmpDir) as never);
+			expect(result.status).toBe("skipped");
+			expect(result.diagnostics).toEqual([]);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("lsp runner still reports the PRIMARY's findings when only an auxiliary was cut off (#1470)", async () => {
+		// The other half of the narrowing: collapsing a partial touch to
+		// skipped/inconclusive across the board would discard a trustworthy
+		// primary answer. Real findings must still reach the agent.
+		const runner = (await import("../../../../clients/dispatch/runners/lsp.js"))
+			.default;
+		const env = setupTestEnvironment("pi-lens-lsp-cutoff-findings-");
+		try {
+			const filePath = path.join(env.tmpDir, "main.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+
+			supportsLSP.mockReturnValue(true);
+			codeAction.mockResolvedValue([]);
+			touchFile.mockResolvedValue(
+				diagsResult(
+					[
+						{
+							severity: 1,
+							message: "Type error",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 5 },
+							},
+						},
+					],
+					{ confirmation: "partial", unconfirmedServerIds: ["opengrep"] },
+				),
+			);
+
+			const result = await runner.run(ctx(filePath, env.tmpDir) as never);
+			expect(result.status).toBe("failed");
+			expect(result.failureKind).toBe("blocking_diagnostics");
+			expect(result.diagnostics[0]?.message).toContain("Type error");
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -848,3 +848,169 @@ describe("R8 — aux grace: raceToCompletion per-role unit tests", () => {
 		expect(result.find((r) => r.id === "primary")).toBeDefined();
 	});
 });
+
+/**
+ * #1470 — a cut-off auxiliary must not yield a conclusive touch.
+ *
+ * The three-way probe the #1458 review used, promoted from telemetry into the
+ * touch's own honesty state. All three auxiliaries carry the SAME amount of
+ * evidence about the file in the failing cases — none — so all three must be
+ * distinguishable in what the touch CLAIMS:
+ *
+ *   - silent inside its own budget → `inconclusive` (pre-existing, unchanged)
+ *   - published within grace       → `confirmation: "confirmed"`
+ *   - hung, grace timer wins       → `confirmation: "partial"` naming it
+ *
+ * The pre-fix defect: the hung case resolved `confirmation: "confirmed"` with
+ * `inconclusive: undefined`, so a hung opengrep read as confirmed-clean on the
+ * security lane.
+ */
+describe("#1470 — cut-off auxiliary honesty", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.resetModules();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+		logLatency.mockReset();
+		delete process.env.PI_LENS_AUX_GRACE_MS;
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		delete process.env.PI_LENS_AUX_GRACE_MS;
+	});
+
+	/**
+	 * Drives one touch with a primary that answers at 800ms and a single
+	 * auxiliary whose own wait settles at `auxDelayMs`, then returns both the
+	 * touch result and the `lsp_aux_wait_outcome` row it produced — so each probe
+	 * can assert that the telemetry outcome and the claimed confirmation agree.
+	 */
+	async function probe(
+		auxDelayMs: number,
+		auxDiags: ReturnType<typeof makeDiagnostic>[],
+	) {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		getServersForFileWithConfig.mockReturnValue([
+			makePrimaryServer("ts-primary"),
+			makeAuxServer("opengrep"),
+		]);
+		createLSPClient
+			.mockResolvedValueOnce(
+				makeClient(800, [], { serverId: "ts-primary" }),
+			)
+			.mockResolvedValueOnce(
+				makeClient(auxDelayMs, auxDiags, { serverId: "opengrep" }),
+			);
+		await service.getClientsForFile(FILE);
+
+		const touch = service.touchFile(FILE, "probe", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep"],
+			collectDiagnostics: true,
+			diagnostics: "document",
+		});
+		// 800 (primary) + 2000 (aux ceiling) + slack covers every probe.
+		await vi.advanceTimersByTimeAsync(3000);
+		const result = await touch;
+		const outcomes = logLatency.mock.calls.find(
+			([entry]) => entry.phase === "lsp_aux_wait_outcome",
+		)?.[0]?.metadata?.outcomes as
+			| Array<{ serverId: string; outcome: string }>
+			| undefined;
+		return { result, outcome: outcomes?.[0]?.outcome };
+	}
+
+	it("a HUNG auxiliary (cut_off) narrows the confirmation and names the server", async () => {
+		// Aux wait outlives the 2000ms ceiling → our grace timer wins.
+		const { result, outcome } = await probe(3000, [makeDiagnostic("never")]);
+		expect(outcome).toBe("cut_off");
+		// The defect: this was "confirmed" with no coverage caveat at all.
+		expect(result?.confirmation).toBe("partial");
+		expect(result?.unconfirmedServerIds).toEqual(["opengrep"]);
+		// NARROWED, not collapsed — the primary answered, so the touch is not
+		// inconclusive and its diagnostics are not discarded (#533 cuts both ways).
+		expect(result?.inconclusive).toBeUndefined();
+	});
+
+	it("a SILENT auxiliary is left exactly as it was — #1470 narrows only cut_off", async () => {
+		// Aux settles at 900ms, inside its own budget, publishing nothing — the
+		// same silent-scanner shape #1458's evidence-based outcome test uses. The
+		// issue's acceptance criterion is that this path is UNCHANGED: whatever
+		// honesty verdict it produced before (in the dogfood run, an inconclusive
+		// touch, because a silent aux burns the budget that is also the touch's
+		// detection deadline) it still produces. It must not acquire a cut_off
+		// coverage gap it did not earn.
+		const { result, outcome } = await probe(900, []);
+		expect(outcome).toBe("silent");
+		expect(result?.confirmation).not.toBe("partial");
+		expect(result?.unconfirmedServerIds).toBeUndefined();
+	});
+
+	it("an auxiliary that PUBLISHES within grace still yields an unqualified confirmation", async () => {
+		const { result, outcome } = await probe(
+			900,
+			[makeDiagnostic("aux finding")],
+		);
+		expect(outcome).toBe("answered");
+		expect(result?.confirmation).toBe("confirmed");
+		expect(result?.unconfirmedServerIds).toBeUndefined();
+		expect(
+			(result?.diags ?? []).map((d: { message: string }) => d.message),
+		).toContain("aux finding");
+	});
+
+	it("records the narrowed verdict on the same lsp_touch_file row as auxCutOffServerIds", async () => {
+		// Observability contract from the issue: a `cut_off` row must coincide
+		// with a touch that no longer claims confirmation for that server. Both
+		// facts have to be readable from latency.log without a code read.
+		await probe(3000, [makeDiagnostic("never")]);
+		expect(logLatency).toHaveBeenCalledWith(
+			expect.objectContaining({
+				phase: "lsp_touch_file",
+				metadata: expect.objectContaining({
+					confirmation: "partial",
+					auxCutOffServerIds: ["opengrep"],
+					inconclusive: false,
+				}),
+			}),
+		);
+	});
+
+	it("does not prime the last-known cache from a partially covered touch", async () => {
+		// #570's wipe class re-entering through the cut-off door: the merged array
+		// is missing whatever the cut-off scanner would have said, so an empty one
+		// must not delete a previously-confirmed record and a non-empty one must
+		// not be replayed as an authoritative observation.
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		getServersForFileWithConfig.mockReturnValue([
+			makePrimaryServer("ts-primary"),
+			makeAuxServer("opengrep"),
+		]);
+		createLSPClient
+			.mockResolvedValueOnce(
+				makeClient(100, [makeDiagnostic("primary error")], {
+					serverId: "ts-primary",
+				}),
+			)
+			.mockResolvedValueOnce(makeClient(3000, [], { serverId: "opengrep" }));
+		await service.getClientsForFile(FILE);
+
+		const content = "cache-probe";
+		const touch = service.touchFile(FILE, content, {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep"],
+			collectDiagnostics: true,
+			diagnostics: "document",
+		});
+		await vi.advanceTimersByTimeAsync(3000);
+		const result = await touch;
+		expect(result?.confirmation).toBe("partial");
+		expect(
+			service.getLastKnownDiagnostics(FILE, hashDiagnosticContent(content)),
+		).toBeUndefined();
+	});
+});

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -935,6 +935,49 @@ describe("#1470 — cut-off auxiliary honesty", () => {
 		expect(result?.inconclusive).toBeUndefined();
 	});
 
+	// CLASS SWEEP (#1470's own acceptance criterion). opengrep is the scanner the
+	// issue was reported against, and today it is the ONLY auxiliary whose
+	// declared budget (3500ms) exceeds the 2000ms ceiling — which is precisely the
+	// condition that makes our grace timer win with time left on the touch's own
+	// deadline, producing a cut-off that is not also a timeout. ast-grep (1800),
+	// typos (1500) and zizmor (2000) are cut off AT the touch deadline instead, so
+	// they already fell into `diagnosticsTimedOut` and read as inconclusive.
+	//
+	// That is a property of today's numbers, not of the code: `PI_LENS_AUX_GRACE_MS`
+	// moves the ceiling for every auxiliary, and any budget change moves the
+	// boundary. So the narrowing is keyed on `role === "auxiliary"` — the same
+	// predicate that builds `auxWaits` — never on a server id. Lowering the ceiling
+	// puts each of the four into the cut-off shape and each must narrow identically.
+	it.each(["opengrep", "ast-grep", "zizmor", "typos"])(
+		"narrows the confirmation for a cut-off %s, not just opengrep",
+		async (auxId) => {
+			// Ceiling well under every declared budget, so the grace timer wins with
+			// the touch's own deadline (the aux's declared budget) still far away.
+			process.env.PI_LENS_AUX_GRACE_MS = "300";
+			const { LSPService } = await import("../../../clients/lsp/index.js");
+			const service = new LSPService();
+			getServersForFileWithConfig.mockReturnValue([
+				makePrimaryServer("ts-primary"),
+				makeAuxServer(auxId),
+			]);
+			createLSPClient
+				.mockResolvedValueOnce(makeClient(100, [], { serverId: "ts-primary" }))
+				.mockResolvedValueOnce(makeClient(9000, [], { serverId: auxId }));
+			await service.getClientsForFile(FILE);
+
+			const touch = service.touchFile(FILE, "sweep", {
+				clientScope: "with-auxiliary",
+				auxiliaryServerIds: [auxId],
+				collectDiagnostics: true,
+				diagnostics: "document",
+			});
+			await vi.advanceTimersByTimeAsync(500);
+			const result = await touch;
+			expect(result?.confirmation).toBe("partial");
+			expect(result?.unconfirmedServerIds).toEqual([auxId]);
+		},
+	);
+
 	it("a SILENT auxiliary is left exactly as it was — #1470 narrows only cut_off", async () => {
 		// Aux settles at 900ms, inside its own budget, publishing nothing — the
 		// same silent-scanner shape #1458's evidence-based outcome test uses. The

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -853,17 +853,22 @@ describe("R8 — aux grace: raceToCompletion per-role unit tests", () => {
  * #1470 — a cut-off auxiliary must not yield a conclusive touch.
  *
  * The three-way probe the #1458 review used, promoted from telemetry into the
- * touch's own honesty state. All three auxiliaries carry the SAME amount of
- * evidence about the file in the failing cases — none — so all three must be
- * distinguishable in what the touch CLAIMS:
+ * touch's own honesty state. What the touch CLAIMS in each case, as of this
+ * change:
  *
- *   - silent inside its own budget → `inconclusive` (pre-existing, unchanged)
- *   - published within grace       → `confirmation: "confirmed"`
- *   - hung, grace timer wins       → `confirmation: "partial"` naming it
+ *   - published within grace       → `confirmation: "confirmed"` (correct)
+ *   - hung, grace timer wins       → `confirmation: "partial"` naming it (fixed here)
+ *   - silent inside its own budget → `confirmation: "confirmed"` (STILL WRONG)
  *
- * The pre-fix defect: the hung case resolved `confirmation: "confirmed"` with
- * `inconclusive: undefined`, so a hung opengrep read as confirmed-clean on the
- * security lane.
+ * The pre-fix defect this change closes: the hung case resolved
+ * `confirmation: "confirmed"` with `inconclusive: undefined`, so a hung opengrep
+ * read as confirmed-clean on the security lane.
+ *
+ * The third line is a KNOWN, SEPARATELY FILED GAP (#1493), not a claim of
+ * correctness: a silent scanner carries exactly as little evidence as a hung one
+ * and still reads as clean. It is the same #533 class in the same lane, neither
+ * introduced nor closed by #1470, and the probe below pins today's wrong answer
+ * so #1493's fix has to come through this file.
  */
 describe("#1470 — cut-off auxiliary honesty", () => {
 	beforeEach(() => {
@@ -936,18 +941,30 @@ describe("#1470 — cut-off auxiliary honesty", () => {
 	});
 
 	// CLASS SWEEP (#1470's own acceptance criterion). opengrep is the scanner the
-	// issue was reported against, and today it is the ONLY auxiliary whose
-	// declared budget (3500ms) exceeds the 2000ms ceiling — which is precisely the
-	// condition that makes our grace timer win with time left on the touch's own
-	// deadline, producing a cut-off that is not also a timeout. ast-grep (1800),
-	// typos (1500) and zizmor (2000) are cut off AT the touch deadline instead, so
-	// they already fell into `diagnosticsTimedOut` and read as inconclusive.
+	// issue was reported against, and under today's DEFAULTS it is the only
+	// auxiliary that can reach the cut-off shape: `budgetMs = Math.min(
+	// timeoutFor(id), auxCeilingMs)` (index.ts), and the aux's OWN
+	// `waitForDiagnostics` timer is armed when `perServerWaits` is built —
+	// strictly before the grace timer, which is armed only after
+	// `Promise.all(primaryWaits)`. So when the two budgets are equal the aux's
+	// own timer always resolves first and the race reads "answered", never
+	// "cut_off". `cut_off` therefore requires the ceiling to be STRICTLY LESS
+	// than the declared budget: opengrep (3500) qualifies against the 2000
+	// default; zizmor (2000) never can, and ast-grep (1800) and typos (1500)
+	// cannot either.
 	//
-	// That is a property of today's numbers, not of the code: `PI_LENS_AUX_GRACE_MS`
-	// moves the ceiling for every auxiliary, and any budget change moves the
-	// boundary. So the narrowing is keyed on `role === "auxiliary"` — the same
-	// predicate that builds `auxWaits` — never on a server id. Lowering the ceiling
-	// puts each of the four into the cut-off shape and each must narrow identically.
+	// What those three do INSTEAD is NOT "read as inconclusive". A silent
+	// auxiliary that settles inside its own budget still yields
+	// `confirmation: "confirmed"` with no coverage caveat — the sibling probe
+	// below pins that, and it is the separately filed #1493. #1470 neither
+	// introduces nor closes it.
+	//
+	// The cut-off boundary is a property of today's numbers, not of the code:
+	// `PI_LENS_AUX_GRACE_MS` moves the ceiling for every auxiliary, and any budget
+	// change moves the boundary. So the narrowing is keyed on `role ===
+	// "auxiliary"` — the same predicate that builds `auxWaits` — never on a server
+	// id. Lowering the ceiling puts each of the four into the cut-off shape and
+	// each must narrow identically.
 	it.each(["opengrep", "ast-grep", "zizmor", "typos"])(
 		"narrows the confirmation for a cut-off %s, not just opengrep",
 		async (auxId) => {
@@ -978,17 +995,28 @@ describe("#1470 — cut-off auxiliary honesty", () => {
 		},
 	);
 
-	it("a SILENT auxiliary is left exactly as it was — #1470 narrows only cut_off", async () => {
+	it("KNOWN GAP (#1493): a SILENT auxiliary STILL reads as confirmed clean — #1470 narrows only cut_off", async () => {
 		// Aux settles at 900ms, inside its own budget, publishing nothing — the
-		// same silent-scanner shape #1458's evidence-based outcome test uses. The
-		// issue's acceptance criterion is that this path is UNCHANGED: whatever
-		// honesty verdict it produced before (in the dogfood run, an inconclusive
-		// touch, because a silent aux burns the budget that is also the touch's
-		// detection deadline) it still produces. It must not acquire a cut_off
-		// coverage gap it did not earn.
+		// same silent-scanner shape #1458's evidence-based outcome test uses.
+		//
+		// This asserts what is TRUE TODAY, not what should be true. The touch
+		// resolves `confirmation: "confirmed"` with an empty `diags` and no
+		// `inconclusive` flag, so a scanner that said nothing at all reads as a
+		// clean bill of health — the #533 class, in the same lane, arriving through
+		// a different door than #1470's cut_off. It is NOT introduced by #1470 and
+		// NOT fixed by it; it is filed separately as #1493.
+		//
+		// The assertion #1470 actually owns is the last one: a silent aux must not
+		// acquire a cut_off coverage gap it did not earn. The confirmed/inconclusive
+		// assertions above it are a REGRESSION FENCE for #1493 — when that issue is
+		// fixed this test must fail, and the fix should rewrite it to assert the
+		// narrowed verdict rather than delete it.
 		const { result, outcome } = await probe(900, []);
 		expect(outcome).toBe("silent");
-		expect(result?.confirmation).not.toBe("partial");
+		expect(result?.confirmation).toBe("confirmed"); // #1493: the false clean
+		expect(result?.inconclusive).toBeUndefined(); // #1493: not even flagged
+		expect(result?.diags).toEqual([]);
+		// #1470's own contract: no cut_off gap was earned here.
 		expect(result?.unconfirmedServerIds).toBeUndefined();
 	});
 

--- a/tests/clients/lsp/workspace-diagnostics-warm-attach.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-warm-attach.test.ts
@@ -88,6 +88,40 @@ describe("runWorkspaceDiagnostics warm attach sweeps (#822)", () => {
 		expect(warmup).not.toHaveBeenCalled();
 	});
 
+	// #1470: the sweep's own honesty gate. `runWorkspaceDiagnostics` persists
+	// every `!timedOut` result into the workspace-diagnostics cache, and it read
+	// only `inconclusive` — which a partially covered touch deliberately is not.
+	// The incumbent touches with `clientScope: "with-auxiliary"`, so it is the one
+	// route into this sweep that can produce a coverage gap today, and the gap has
+	// to reach the `timedOut` computation or the sweep caches a partial answer as
+	// a confirmed clean and replays it on every later sweep.
+	it("does not cache a sweep result whose auxiliary the incumbent could not cover (#1470)", async () => {
+		fs.mkdirSync(path.join(tmp, ".pi-lens"));
+		const file = path.join(tmp, "a.ts");
+		fs.writeFileSync(file, "const x = 1;\n");
+		tryWarmAttachedDiagnostics.mockResolvedValue({
+			available: true,
+			response: {
+				diagnostics: [],
+				confirmation: "partial",
+				unconfirmedServerIds: ["typos"],
+			},
+		});
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const results = await new LSPService().runWorkspaceDiagnostics(tmp, {
+			files: [file],
+		});
+
+		expect(results[0]?.timedOut).toBe(true);
+		const { cacheKeyFor, loadWorkspaceDiagnosticsCache } = await import(
+			"../../../clients/lsp/workspace-diagnostics-cache.js"
+		);
+		expect(
+			loadWorkspaceDiagnosticsCache(tmp)?.entries[cacheKeyFor(file)],
+		).toBeUndefined();
+	});
+
 	it("promotes after an IPC failure and completes that file and the remainder locally", async () => {
 		const files = ["a.ts", "b.ts", "c.ts"].map((name) =>
 			path.join(tmp, name),

--- a/tests/clients/warm-attach-confirmation.test.ts
+++ b/tests/clients/warm-attach-confirmation.test.ts
@@ -120,6 +120,28 @@ describe("#1253 — warm-attach serves the touch confirmation", () => {
 		expect(result.diagnostics).toHaveLength(1);
 	});
 
+	it("carries the NARROWED confirmation and the server ids across the wire (#1470)", async () => {
+		// A partial touch is not inconclusive — the primary answered — so without
+		// an explicit narrowed value the far side would read `confirmation` as
+		// absent and be unable to tell "old incumbent" from "opengrep was cut off".
+		touchFile.mockResolvedValue({
+			diags: [],
+			confirmation: "partial",
+			unconfirmedServerIds: ["opengrep"],
+		});
+
+		const result = await serve();
+		const overTheWire = JSON.parse(
+			JSON.stringify(result),
+		) as WarmDiagnosticsResponse;
+
+		expect(overTheWire.confirmation).toBe("partial");
+		expect(overTheWire.unconfirmedServerIds).toEqual(["opengrep"]);
+		// The load-bearing consequence: every existing consumer tests
+		// `=== "confirmed"`, so the narrowing fails closed for free.
+		expect(overTheWire.confirmation).not.toBe("confirmed");
+	});
+
 	it("survives the JSON round trip the socket actually performs", async () => {
 		touchFile.mockResolvedValue({ diags: [], confirmation: "confirmed" });
 

--- a/tests/clients/warm-attach-confirmation.test.ts
+++ b/tests/clients/warm-attach-confirmation.test.ts
@@ -142,6 +142,24 @@ describe("#1253 — warm-attach serves the touch confirmation", () => {
 		expect(overTheWire.confirmation).not.toBe("confirmed");
 	});
 
+	it("reads the coverage gap through touchCoverageGap, not off the confirmation string (#1470)", async () => {
+		// `touchCoverageGap`'s own doc comment forbids re-deriving the rule from a
+		// `confirmation` string literal. The producer sets both fields together
+		// today, so a re-derivation passes every other test in this file — this one
+		// hands the serve path a touch that names a coverage gap WITHOUT the
+		// narrowed string, which is exactly what a second producer (or a widened
+		// confirmation vocabulary) would look like. One reader, one rule.
+		touchFile.mockResolvedValue({
+			diags: [],
+			unconfirmedServerIds: ["opengrep"],
+		});
+
+		const result = await serve();
+
+		expect(result.confirmation).toBe("partial");
+		expect(result.unconfirmedServerIds).toEqual(["opengrep"]);
+	});
+
 	it("survives the JSON round trip the socket actually performs", async () => {
 		touchFile.mockResolvedValue({ diags: [], confirmation: "confirmed" });
 

--- a/tests/tools/lsp-diagnostics.test.ts
+++ b/tests/tools/lsp-diagnostics.test.ts
@@ -1167,6 +1167,144 @@ describe("lsp_diagnostics tool", () => {
 			}
 		});
 
+		// #1470 F2: the WARM-ATTACH consumer path. A warm session never reaches the
+		// local `touchFile` branch above — `isWarmAttached()` sends every file to
+		// the incumbent instead — so the two tests below are the ones that actually
+		// cover the default route. Without them, dropping
+		// `attached.response.unconfirmedServerIds` or narrowing the incumbent's
+		// `confirmation !== undefined` check back to `=== "confirmed"` restores the
+		// exact pre-fix false clean while the whole tools suite stays green.
+		it("carries the INCUMBENT's coverage gap into the rendered result (#1470)", async () => {
+			// Non-empty result on purpose: this is the `total > 0` render branch,
+			// where the coverage line is appended after the findings rather than
+			// after "No auxiliary findings." Both branches must say it.
+			mocked.warmAttached = true;
+			mocked.attachedDiagnostics.mockResolvedValue({
+				available: true,
+				response: {
+					diagnostics: [
+						{
+							severity: 1,
+							message: "from incumbent",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 1 },
+							},
+							source: "marksman",
+						},
+					],
+					confirmation: "partial",
+					unconfirmedServerIds: ["opengrep"],
+				},
+			});
+			const tmpDir = fs.mkdtempSync(
+				path.join(os.tmpdir(), "pi-lens-attached-cutoff-findings-"),
+			);
+			const file = path.join(tmpDir, "README.md");
+			fs.writeFileSync(file, "# Example\n");
+
+			try {
+				const result = await runMarkdown(
+					{ path: file, severity: "all", serverScope: "all", waitMs: 500 },
+					[file],
+				);
+				const text = result.content?.[0]?.text ?? "";
+				expect(result.details?.unconfirmedServerIds).toEqual(["opengrep"]);
+				expect(text).toContain("from incumbent");
+				expect(text).toContain("Auxiliary coverage INCOMPLETE");
+				expect(text).toContain("opengrep");
+			} finally {
+				removeTempDirSync(tmpDir);
+			}
+		});
+
+		it("an INCUMBENT partial confirmation still counts as the primary's confirmation (#1470)", async () => {
+			// The other half of the warm-attach consumer contract. Reading the
+			// incumbent's verdict as `=== "confirmed"` looks safely fail-closed, but
+			// it drops the primary's real confirmation on the floor and renders the
+			// silent-on-clean apology for a primary that DID confirm — the same
+			// overclaim pointing the other way. The honest output demotes the FILE
+			// verdict and names the scanner, nothing more.
+			mocked.cascadeTier = "tier3-silent";
+			mocked.warmAttached = true;
+			mocked.attachedDiagnostics.mockResolvedValue({
+				available: true,
+				response: {
+					diagnostics: [],
+					confirmation: "partial",
+					unconfirmedServerIds: ["opengrep"],
+				},
+			});
+			const tmpDir = fs.mkdtempSync(
+				path.join(os.tmpdir(), "pi-lens-attached-cutoff-clean-"),
+			);
+			const file = path.join(tmpDir, "README.md");
+			fs.writeFileSync(file, "# Example\n");
+
+			try {
+				const result = await runMarkdown(
+					{ path: file, severity: "all", serverScope: "all", waitMs: 500 },
+					[file],
+				);
+				const text = result.content?.[0]?.text ?? "";
+				expect(result.details?.unconfirmed).toBe(true);
+				expect(result.details?.unconfirmedServerIds).toEqual(["opengrep"]);
+				expect(text).toContain("Auxiliary coverage INCOMPLETE");
+				expect(text).not.toContain("push-only, silent-on-clean");
+			} finally {
+				removeTempDirSync(tmpDir);
+			}
+		});
+
+		// #1470 F3: the BATCH/directory route has its own demotion site
+		// (`collectFileDiagnosticResult`), and its own consequence — the persisted
+		// workspace-diagnostics cache, whose write gate is `confirmation !==
+		// "unconfirmed"`. Without the demotion a partially covered batch result is
+		// recorded as a confirmed clean and replayed by every later sweep, so the
+		// false clean outlives the touch that produced it.
+		it("a batch file whose auxiliary was cut off is neither counted clean nor cached (#1470)", async () => {
+			mocked.cascadeTier = "tier3-silent";
+			const touchFile = vi.fn().mockResolvedValue({
+				diags: [],
+				confirmation: "partial",
+				unconfirmedServerIds: ["opengrep"],
+			});
+			(mocked.service as any).touchFile = touchFile;
+			const tmpDir = fs.mkdtempSync(
+				path.join(os.tmpdir(), "pi-lens-batch-cutoff-"),
+			);
+			const dataDir = path.join(tmpDir, "data");
+			const previousDataDir = process.env.PILENS_DATA_DIR;
+			process.env.PILENS_DATA_DIR = dataDir;
+			const file = path.join(tmpDir, "README.md");
+			fs.writeFileSync(file, "# Example\n");
+
+			try {
+				const first = await runMarkdown(
+					{ paths: [file], severity: "all", serverScope: "all", waitMs: 500 },
+					[file],
+				);
+				expect(first.details?.cleanFiles).toBe(0);
+				expect(first.details?.unconfirmedFiles).toBe(1);
+
+				// The replay half: a second batch over the same unchanged file must
+				// still pay a real touch. A cached "clean" entry would serve the
+				// lookup instead, and the partial answer would read as confirmed
+				// forever after.
+				touchFile.mockClear();
+				const second = await runMarkdown(
+					{ paths: [file], severity: "all", serverScope: "all", waitMs: 500 },
+					[file],
+				);
+				expect(touchFile).toHaveBeenCalledTimes(1);
+				expect(second.details?.cleanFiles).toBe(0);
+			} finally {
+				if (previousDataDir === undefined) delete process.env.PILENS_DATA_DIR;
+				else process.env.PILENS_DATA_DIR = previousDataDir;
+				removeTempDirSync(tmpDir);
+			}
+		});
+
 		it("missing confirmation metadata stays unconfirmed and does not try a TypeScript command", async () => {
 			mocked.cascadeTier = "tier3-silent";
 			const getAdvertisedCommands = vi.fn().mockResolvedValue([]);

--- a/tests/tools/lsp-diagnostics.test.ts
+++ b/tests/tools/lsp-diagnostics.test.ts
@@ -1130,6 +1130,43 @@ describe("lsp_diagnostics tool", () => {
 			}
 		});
 
+		it("a cut-off auxiliary demotes the file verdict but keeps the primary line honest (#1470)", async () => {
+			// The narrowing, end to end on the tool that IS the security lane's read
+			// surface. The primary confirmed clean; opengrep was cut off. Pre-fix
+			// this rendered "Primary LSP: confirmed clean." + "No auxiliary
+			// findings." with `unconfirmed: false` — a clean bill of health for a
+			// scan that never ran. It must now say which coverage is missing WITHOUT
+			// claiming the primary failed to confirm (that would be the same
+			// overclaim pointing the other way).
+			mocked.cascadeTier = "tier3-silent";
+			(mocked.service as any).touchFile = vi.fn().mockResolvedValue({
+				diags: [],
+				confirmation: "partial",
+				unconfirmedServerIds: ["opengrep"],
+			});
+			const tmpDir = fs.mkdtempSync(
+				path.join(os.tmpdir(), "pi-lens-marksman-cutoff-"),
+			);
+			const file = path.join(tmpDir, "README.md");
+			fs.writeFileSync(file, "# Example\n");
+
+			try {
+				const result = await runMarkdown(
+					{ path: file, severity: "all", serverScope: "all", waitMs: 500 },
+					[file],
+				);
+				const text = result.content?.[0]?.text ?? "";
+				expect(result.details?.unconfirmed).toBe(true);
+				expect(result.details?.unconfirmedServerIds).toEqual(["opengrep"]);
+				expect(text).toContain("Auxiliary coverage INCOMPLETE");
+				expect(text).toContain("opengrep");
+				// The primary's own verdict is untouched — no silent-on-clean text.
+				expect(text).not.toContain("push-only, silent-on-clean");
+			} finally {
+				removeTempDirSync(tmpDir);
+			}
+		});
+
 		it("missing confirmation metadata stays unconfirmed and does not try a TypeScript command", async () => {
 			mocked.cascadeTier = "tier3-silent";
 			const getAdvertisedCommands = vi.fn().mockResolvedValue([]);

--- a/tools/lsp-diagnostics.ts
+++ b/tools/lsp-diagnostics.ts
@@ -32,6 +32,8 @@ import { detectFileRole } from "../clients/file-role.js";
 import type { LSPDiagnostic } from "../clients/lsp/client.js";
 import {
 	hashDiagnosticContent,
+	touchCompletedConfirmationPolicy,
+	touchCoverageGap,
 	type DiagnosticBinding,
 	type TouchFileResult,
 } from "../clients/lsp/diagnostic-binding.js";
@@ -668,6 +670,16 @@ type DiagnosticsCollectionResult = {
 	 */
 	confirmedByTouch: boolean;
 	/**
+	 * #1470: server ids the touch carries no evidence for — an auxiliary whose push
+	 * wait was cut off by the aux grace timer. Empty when every spawned server got
+	 * to answer. `confirmedByTouch` stays TRUE in that case: the primary's own
+	 * confirmation is untouched, and conflating the two would report a hung opengrep
+	 * as "typescript could not confirm clean", which is a different lie. The caller
+	 * demotes the FILE-level verdict to "unconfirmed" while keeping the primary line
+	 * honest.
+	 */
+	unconfirmedServerIds: readonly string[];
+	/**
 	 * #692: the file content read while collecting (undefined only when the
 	 * read itself failed) — reused by the widget-reconcile caller so it can
 	 * derive `fileRole` for `retagAuxiliaryDiagnostics`'s `skipTestFiles` gate
@@ -740,9 +752,16 @@ async function collectDiagnosticsForFile(
 					// confirmation: it carries the same caveat all-scope local
 					// touches do, and classic TypeScript still needs the primary-only
 					// tsserver sync check below rather than this verdict.
+					// #1470: `"partial"` counts, for the same reason the local touch
+					// branch below accepts it — the incumbent's primary confirmed; only
+					// a named auxiliary did not.
 					confirmedByTouch:
-						attached.response.confirmation === "confirmed" &&
+						attached.response.confirmation !== undefined &&
 						primaryServerId(absPath) !== "typescript",
+					// #1470: the incumbent's narrowed verdict, carried as an explicit DTO
+					// field across the socket. An older incumbent omits it → empty → the
+					// pre-#1470 handling, unchanged.
+					unconfirmedServerIds: attached.response.unconfirmedServerIds ?? [],
 					content,
 				};
 			}
@@ -814,12 +833,21 @@ async function collectDiagnosticsForFile(
 	// one; the openFile-only / getDiagnostics fallback leaves it undefined →
 	// "unknown", no demotion).
 	const binding = usedTouch ? touched?.binding : undefined;
+	// #1470: `"partial"` counts here. `confirmedByTouch` feeds
+	// `canTrustTouchConfirmation`, which asks about the PRIMARY's own verdict —
+	// and a partial touch is one whose primary confirmed while an auxiliary was
+	// cut off. Excluding it would render "Primary LSP: unconfirmed" for a primary
+	// that did confirm. The coverage gap is carried separately, below.
 	const confirmedByTouch =
-		usedTouch && touched?.confirmation === "confirmed";
+		usedTouch && touchCompletedConfirmationPolicy(touched);
 	return {
 		diagnostics: filtered,
 		timedOut,
 		confirmedByTouch,
+		// #1470: only a touch actually contributes a coverage gap; the
+		// openFile+getDiagnostics fallback never reports one, which is honest —
+		// that path claims no confirmation at all.
+		unconfirmedServerIds: usedTouch ? touchCoverageGap(touched) : [],
 		content,
 		binding,
 	};
@@ -1078,6 +1106,7 @@ async function collectFileDiagnosticResult(
 		diagnostics: rawDiags,
 		timedOut,
 		confirmedByTouch,
+		unconfirmedServerIds,
 		content: collectedContent,
 		binding,
 	} = await collectDiagnosticsForFile(file, lspService, waitMs, serverScope);
@@ -1118,6 +1147,14 @@ async function collectFileDiagnosticResult(
 	// re-cementing path). "unknown"/true bindings leave the verdict untouched.
 	const boundMismatch = binding?.boundToCurrentDisk === false;
 	if (boundMismatch) confirmation = "unconfirmed";
+	// #1470: an auxiliary cut off by the aux grace timer contributed no evidence
+	// about this file, so a "clean" verdict computed from the merged result would
+	// be claiming coverage this batch does not have. Demote it — that also keeps
+	// the entry out of the workspace cache below, which would otherwise replay the
+	// partial answer as a confirmed clean on every later sweep.
+	if (unconfirmedServerIds.length > 0 && confirmation === "clean") {
+		confirmation = "unconfirmed";
+	}
 	const filteredDiags = applySeverityFilter(effectiveRawDiags, severity);
 	reconcileWidgetFromLspResult(
 		file,
@@ -1172,6 +1209,7 @@ async function runFileDiagnostics(
 		diagnostics: rawDiags,
 		timedOut,
 		confirmedByTouch,
+		unconfirmedServerIds,
 		content: collectedContent,
 		binding,
 	} = await collectDiagnosticsForFile(absPath, lspService, waitMs, serverScope);
@@ -1216,6 +1254,15 @@ async function runFileDiagnostics(
 	// longer "definitionally confirmed". "unknown"/true bindings are unchanged.
 	const boundMismatch = binding?.boundToCurrentDisk === false;
 	if (boundMismatch) confirmation = "unconfirmed";
+	// #1470: NARROWED, not collapsed. An auxiliary the aux grace timer cut off makes
+	// the FILE-level verdict unconfirmed — the merged result is missing whatever that
+	// scanner would have said, and this tool is the security lane's read surface. The
+	// PRIMARY's own verdict is untouched (`primaryCoverageGapOnly` below), so a
+	// TypeScript answer stays "confirmed clean" on its own line while an explicit
+	// line names the scanner whose coverage is absent.
+	const primaryCoverageGapOnly =
+		unconfirmedServerIds.length > 0 && confirmation === "clean";
+	if (primaryCoverageGapOnly) confirmation = "unconfirmed";
 	const filtered = applySeverityFilter(effectiveRawDiags, severity);
 	const total = filtered.length;
 	const truncated = total > MAX_DIAGNOSTICS;
@@ -1246,7 +1293,11 @@ async function runFileDiagnostics(
 				"Re-check after the server settles, or increase waitMs."
 			);
 		}
-		if (unconfirmed) {
+		// #1470: a file demoted ONLY because an auxiliary was cut off must not render
+		// the silent-on-clean text — the primary did confirm, and saying otherwise is
+		// the same overclaim in the opposite direction. The coverage line below names
+		// what is actually missing.
+		if (unconfirmed && !primaryCoverageGapOnly) {
 			return (
 				`Primary LSP${primaryId ? ` (${primaryId})` : ""}: unconfirmed — ` +
 				"cannot confirm clean (push-only, silent-on-clean, e.g. classic " +
@@ -1261,11 +1312,22 @@ async function runFileDiagnostics(
 		return `Primary LSP${primaryId ? ` (${primaryId})` : ""}: ${primaryDiags.length} diagnostic${primaryDiags.length === 1 ? "" : "s"}.`;
 	})();
 
+	// #1470: this is the narrowing made readable. It states exactly which servers
+	// this result does NOT speak for, so "no auxiliary findings" can never be read
+	// as "the security scanners found nothing".
+	const coverageLine =
+		unconfirmedServerIds.length > 0
+			? `Auxiliary coverage INCOMPLETE — ${[...unconfirmedServerIds].join(", ")} did not answer within the wait budget, so ${unconfirmedServerIds.length === 1 ? "its findings are" : "their findings are"} NOT included here. This is not a clean bill of health for ${unconfirmedServerIds.length === 1 ? "that scanner" : "those scanners"}; re-check after the next edit, or use waitMs to wait longer.`
+			: undefined;
+
 	let text: string;
 	if (total === 0) {
-		text = [primaryLine, "", unavailable ?? "No auxiliary findings."].join(
-			"\n",
-		);
+		text = [
+			primaryLine,
+			"",
+			unavailable ?? "No auxiliary findings.",
+			...(coverageLine ? [coverageLine] : []),
+		].join("\n");
 	} else {
 		const lines = [primaryLine, ""];
 		if (primaryDiags.length > 0) {
@@ -1275,6 +1337,7 @@ async function runFileDiagnostics(
 			lines.push(`Auxiliary findings (${auxiliaryDiags.length}):`);
 			lines.push(...auxiliaryDiags.map(formatDiag));
 		}
+		if (coverageLine) lines.push("", coverageLine);
 		if (unavailable) lines.unshift(unavailable, "");
 		if (truncated) {
 			lines.unshift(
@@ -1306,6 +1369,11 @@ async function runFileDiagnostics(
 			truncated,
 			unconfirmed,
 			timedOut: unconfirmed ? timedOut : undefined,
+			// #1470: which servers this result does NOT speak for. Absent when it
+			// speaks for all of them.
+			...(unconfirmedServerIds.length > 0 && {
+				unconfirmedServerIds: [...unconfirmedServerIds],
+			}),
 			lspHealth,
 			waitMs,
 		},


### PR DESCRIPTION
Closes #1470.

## Problem

A touch whose auxiliary scanner was cut off by the grace timer returned `inconclusive: undefined` and `confirmation: "confirmed"`. A touch whose auxiliary went silent inside its own budget returned `inconclusive: true`. Both carry the same evidence about the file from that scanner — none — but only one said so.

In practice: a hung opengrep produced a result that read as confirmed-clean on the security lane.

`inconclusive` is `notifyWriteTimedOut || diagnosticsTimedOut` (R8/#714). Neither term covers the `cut_off` outcome #1473 introduced, and `auxCutOffServerIds` was populated but never consumed for honesty.

## Change

`TouchFileResult.confirmation` becomes `"confirmed" | "partial"`, with `unconfirmedServerIds` naming the servers the touch does not speak for.

The blunt fix — marking the whole touch inconclusive whenever an auxiliary was cut off — was rejected deliberately. It discards a TypeScript answer that genuinely arrived just because opengrep hung. A `partial` touch leaves `inconclusive` unset, so the primary's findings still flow, and states which coverage is missing rather than throwing the good coverage away.

Two exported helpers in `diagnostic-binding.ts`, `touchCoverageGap()` and `touchCompletedConfirmationPolicy()`, are the single source of truth so the rule is not re-derived per consumer.

## The audit found the same overclaim pointing the other way

`confirmedByTouch` in `tools/lsp-diagnostics.ts` gated on `=== "confirmed"`, which looks safely fail-closed. It is not: that call asks about the **primary's** verdict, so a partial touch rendered "Primary LSP (marksman): unconfirmed — push-only, silent-on-clean…" for a server that had confirmed. Reporting a server as unconfirmed when it answered is the same defect as reporting a hung one as clean.

It now accepts `partial`, and the file-level verdict is demoted separately with an explicit coverage line.

## Why only opengrep was ever observed — and a correction

The class sweep found that opengrep is the only auxiliary whose declared budget (3500 ms) exceeds the 2000 ms ceiling, which is the condition that lets the grace timer win while the touch deadline is still far away. ast-grep (1800), zizmor (2000) and typos (1500) cannot currently be cut off at all.

The mechanism is timer arming order, not a comparison: the auxiliary's own `waitForDiagnostics` timer is armed when `perServerWaits` is built, strictly before the grace timer, which is armed only after the primaries settle. So `cut_off` requires the ceiling to be strictly less than the declared budget. `PI_LENS_AUX_GRACE_MS` moves that boundary for all four.

**An earlier version of this description claimed the other three "already tripped `diagnosticsTimedOut` and read inconclusive", so only opengrep could produce a false clean. That is wrong**, and the review disproved it by running the path. It does not hold at all. A primary answering at 800 ms with a **single** silent auxiliary at 900 ms, inside its own budget, already yields `{confirmation: "confirmed", inconclusive: undefined, diags: []}`. Every auxiliary configuration is exposed, not only multi-auxiliary ones.

That is the same #533 class on the sibling outcome, it predates this PR, and it is filed as #1493. The silent-case test here is rewritten to assert what is true today and point at that issue, rather than passing while implying correctness.

`notifyWriteTimedOut` has no equivalent gap: it is per-server but folds into touch-wide `inconclusive`, so it already fails closed.

## Consumers

Changed: `dispatch/integration.ts` `isConfirmedTouch` (no reconcile, no neighbour cache, no recently-clean seed, plus `unconfirmedServerIds` in `cascade.log`); the `lsp/index.ts` last-known cache prime, so a partial empty result can no longer delete a confirmed record — #570's wipe class arriving through the cut-off door; `dispatch/runners/lsp.ts`; the `warm-attach.ts` and `mcp/ipc.ts` DTO; `tools/lsp-diagnostics.ts`.

Checked and unchanged, with reasons: `lens-diagnostics.ts` inherits `timedOut`; the workspace sweep excludes opengrep by config; `widget-state.ts` callers compute `confirmed` themselves; `pipeline.ts`, `runtime-session.ts`, `runtime-tool-call.ts`, `mcp/analyze.ts` and `lsp-navigation.ts` are non-collecting or discard the result.

## Observability

The existing `lsp_touch_file` row now carries `confirmation`, so a `cut_off` row in `lsp_aux_wait_outcome` joins to a touch that demonstrably no longer claims that coverage. No new record. Cascade neighbours log `unconfirmedServerIds` beside the existing causes.

## Verification

Pre-fix red proven: source reverted and rebuilt, three of the five #1470 probes fail. The other two assert deliberately unchanged behavior for the silent and answered cases.

Ten mutants, all red, each with a full rebuild between: never emit partial, drop the cache-prime guard, drop `confirmation` from latency metadata, drop the gap from `isConfirmedTouch`, drop the runner skip branch, drop partial from the DTO, drop the file-level demotion, drop the coverage line, revert `confirmedByTouch` to strict equality, and re-key the narrowing on the id `opengrep` (which turns three of the four auxiliary probes red).

One mutant stays green by design: dropping the `demonstratedReady` cut-off skip. `ensureWarmForSweep` filters auxiliaries out, so no reader consumes an auxiliary's mark. The guard is kept and the comment states plainly that no test pins it and why.

Build, lint and changelog clean. 17 files, 346 tests, all passing, including the `index-wiring` and `index-integration` seam siblings.

A broader 175-file batch showed two nondeterministic failures across two runs — `server-policy` csharp marker probes and a `watch-queue` flush count — each passing on the other run, neither touching these paths. Load-sensitive timing under parallel execution. CI is authoritative.

## A second correction, from the fix round

The review asked for the coverage gap to be folded into the workspace sweep's `timedOut` because lowering `PI_LENS_AUX_GRACE_MS` would make a sweep touch go partial. That premise is wrong: `hasTouchAuxiliaries` requires `clientScope: "with-auxiliary"`, and the sweep touches with `clientScope: "all"`, so the auxiliary grace timer is never armed on that route and `auxCutOffServerIds` stays undefined whatever the ceiling.

The hole is real but arrives through a different door — the **warm-attach incumbent**, which does touch `with-auxiliary` and whose partial answer was served as `available: true`, because the IPC gate rejects only `inconclusive`. So the sweep did cache a partially covered incumbent answer as clean. That route is now fixed and pinned, and the source comment states the asymmetry so the next reader does not repeat the misdiagnosis.

## Left out deliberately

Cascade output renders no marker for a partially covered neighbour, though it renders one for `inconclusive`. It no longer wipes the footer, but the agent is not told. That needs a `cascade-types` field plus formatter work.

The `getDiagnostics` lane deletes `lastKnownDiagnostics` on an empty merge without knowing which auxiliary was cut off. It claims no confirmation anywhere, so it cannot produce the false-clean, but plumbing cut-off identity through `aggregation.ts` would close it — and that seam is exactly what #1488 proposes to consolidate.


