### PR TITLE
test(perf): pin source-walk hot-path reach

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,7 @@ pi-lens hooks run on pi's event loop. Read the "Performance" section of `AGENTS.
 - The build-freshness guard (`tests/support/check-build-freshness.ts`) will fail fast if source `.ts` is newer than its `.js`.
 - For extension wiring tests, use `tests/support/pi-mock.ts`.
 - For live tool/LSP validation, use `scripts/smoke-tools.mjs` (opt-in, not a per-PR gate).
+- Walk/profile reach (what percent of the hot-path clients a representative tree actually executes) lives in `tests/clients/profiling-coverage.test.ts`, using `tests/support/v8-coverage.ts`. Occupancy tests still own event-loop stalls; do not fold this into `timingSensitiveInclude` unless it starts sampling `measureMaxSyncBlockMs` / `process.cpuUsage`.
 
 ## Other contribution areas
 

--- a/tests/clients/profiling-coverage.test.ts
+++ b/tests/clients/profiling-coverage.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Profiling coverage: what percent of the walk/profile hot path a
+ * representative source-tree workload actually executes.
+ *
+ * Occupancy tests (`source-walk-occupancy.test.ts`) guard event-loop stalls.
+ * This is the complementary reach metric — pyinstrument-style "did the
+ * profiler even touch the production modules" — using V8 precise coverage
+ * on the in-place compiled clients. Thresholds sit below a measured local
+ * run so ambient fork-pool noise cannot flake them, but a workload that
+ * stops calling the walkers will fail.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { _resetGeneratedArtifactCaches } from "../../clients/generated-artifacts.js";
+import { detectProjectLanguageProfileAsync } from "../../clients/language-profile.js";
+import {
+	collectSourceFiles,
+	collectSourceFilesAsync,
+} from "../../clients/source-filter.js";
+import { countSourceFilesWithinLimitAsync } from "../../clients/startup-scan.js";
+import { generateSourceTree } from "../support/perf-harness.js";
+import {
+	summarizePreciseCoverage,
+	withPreciseCoverage,
+} from "../support/v8-coverage.js";
+import { removeTempDirSync } from "./test-utils.js";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const TREE_SIZE = 400;
+
+/** Compiled in-place clients the walk/profile workload must reach. */
+const HOT_PATH = [
+	"clients/file-kinds.js",
+	"clients/file-utils.js",
+	"clients/generated-artifacts.js",
+	"clients/language-profile.js",
+	"clients/path-utils.js",
+	"clients/source-filter.js",
+	"clients/source-walker.js",
+	"clients/startup-scan.js",
+] as const;
+
+// Floors from a local measured run of this fixture (function 95.3%, block 68.1%,
+// all 8 files touched). Leave headroom for smaller hosts / cached header hits.
+const MIN_FILES_TOUCHED = HOT_PATH.length;
+const MIN_FUNCTION_PCT = 70;
+const MIN_BLOCK_PCT = 45;
+
+let tmpDir: string;
+
+beforeAll(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-profiling-coverage-"));
+	generateSourceTree(tmpDir, TREE_SIZE);
+}, 60_000);
+
+afterAll(() => {
+	removeTempDirSync(tmpDir);
+});
+
+beforeEach(() => {
+	_resetGeneratedArtifactCaches();
+});
+
+describe(`profiling coverage of walk/profile hot path (~${TREE_SIZE} files)`, () => {
+	it(
+		"executes a minimum share of functions and blocks in the hot-path clients",
+		{ timeout: 30_000 },
+		async () => {
+			const { result, scripts } = await withPreciseCoverage(async () => {
+				const syncFiles = collectSourceFiles(tmpDir);
+				const asyncFiles = await collectSourceFilesAsync(tmpDir);
+				const profile = await detectProjectLanguageProfileAsync(tmpDir);
+				const counted = await countSourceFilesWithinLimitAsync(tmpDir, 1_000_000);
+				return { syncFiles, asyncFiles, profile, counted };
+			});
+
+			expect(result.syncFiles.length).toBeGreaterThan(0);
+			expect(result.asyncFiles).toEqual(result.syncFiles);
+			expect(result.counted).toBeGreaterThan(0);
+			expect(result.profile).toBeTruthy();
+
+			const summary = summarizePreciseCoverage(scripts, {
+				root: repoRoot,
+				include: HOT_PATH,
+			});
+			const missing = HOT_PATH.filter(
+				(file) => !summary.files.some((entry) => entry.file === file && entry.functionsHit > 0),
+			);
+
+			expect(
+				missing,
+				`hot-path modules with zero executed functions: ${missing.join(", ") || "(none)"}`,
+			).toEqual([]);
+			expect(summary.filesTouched).toBeGreaterThanOrEqual(MIN_FILES_TOUCHED);
+			expect(summary.functionPct).toBeGreaterThanOrEqual(MIN_FUNCTION_PCT);
+			expect(summary.blockPct).toBeGreaterThanOrEqual(MIN_BLOCK_PCT);
+		},
+	);
+});

--- a/tests/support/v8-coverage.test.ts
+++ b/tests/support/v8-coverage.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+	fileFromScriptUrl,
+	summarizePreciseCoverage,
+} from "./v8-coverage.js";
+
+const root = "/repo";
+
+describe("summarizePreciseCoverage", () => {
+	it("maps file URLs under root and ignores outsiders", () => {
+		expect(fileFromScriptUrl("file:///repo/clients/source-filter.js", root)).toBe(
+			"clients/source-filter.js",
+		);
+		expect(fileFromScriptUrl("file:///elsewhere/x.js", root)).toBeUndefined();
+		expect(fileFromScriptUrl("node:internal/process", root)).toBeUndefined();
+	});
+
+	it("reports per-file and aggregate function/block percentages", () => {
+		const summary = summarizePreciseCoverage(
+			[
+				{
+					url: "file:///repo/clients/hot.js",
+					functions: [
+						{ functionName: "a", ranges: [{ count: 2 }, { count: 0 }] },
+						{ functionName: "b", ranges: [{ count: 0 }] },
+					],
+				},
+				{
+					url: "file:///repo/clients/cold.js",
+					functions: [{ functionName: "c", ranges: [{ count: 0 }] }],
+				},
+				{
+					url: "file:///repo/tests/ignore.js",
+					functions: [{ functionName: "noise", ranges: [{ count: 9 }] }],
+				},
+			],
+			{ root, include: ["clients/hot.js", "clients/cold.js", "clients/missing.js"] },
+		);
+
+		expect(summary.filesTotal).toBe(3);
+		expect(summary.filesTouched).toBe(1);
+		expect(summary.functionPct).toBeCloseTo((1 / 3) * 100);
+		expect(summary.blockPct).toBeCloseTo((1 / 4) * 100);
+		expect(summary.files.map((file) => file.file)).toEqual([
+			"clients/cold.js",
+			"clients/hot.js",
+			"clients/missing.js",
+		]);
+		expect(summary.files.find((file) => file.file === "clients/missing.js")).toEqual({
+			file: "clients/missing.js",
+			functionCount: 0,
+			functionsHit: 0,
+			blockCount: 0,
+			blocksHit: 0,
+			functionPct: 0,
+			blockPct: 0,
+		});
+	});
+});

--- a/tests/support/v8-coverage.ts
+++ b/tests/support/v8-coverage.ts
@@ -1,0 +1,151 @@
+/**
+ * Precise V8 coverage for a workload — the TypeScript analogue of
+ * "run pyinstrument and report what percent of the code it touched."
+ *
+ * Occupancy tests already guard event-loop stalls. This reports *reach*:
+ * of the compiled client modules in `include`, how many functions and
+ * block ranges actually executed while `work` ran. Scripts compiled
+ * before coverage starts still count subsequent calls.
+ */
+
+import { Session } from "node:inspector/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { toPosix } from "../../clients/path-utils.js";
+
+export interface ScriptCoverageLike {
+	url: string;
+	functions: readonly {
+		functionName: string;
+		ranges: readonly { count: number }[];
+	}[];
+}
+
+export interface FileCoverage {
+	file: string;
+	functionCount: number;
+	functionsHit: number;
+	blockCount: number;
+	blocksHit: number;
+	functionPct: number;
+	blockPct: number;
+}
+
+export interface CoverageSummary {
+	files: FileCoverage[];
+	filesTouched: number;
+	filesTotal: number;
+	functionPct: number;
+	blockPct: number;
+}
+
+export function fileFromScriptUrl(url: string, root: string): string | undefined {
+	if (!url.startsWith("file:")) return undefined;
+	try {
+		const absolute = fileURLToPath(url);
+		const relative = toPosix(path.relative(root, absolute));
+		if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+			return undefined;
+		}
+		return relative;
+	} catch {
+		return undefined;
+	}
+}
+
+function ratio(hit: number, total: number): number {
+	return total === 0 ? 0 : (hit / total) * 100;
+}
+
+export function summarizePreciseCoverage(
+	scripts: readonly ScriptCoverageLike[],
+	options: { root: string; include: readonly string[] },
+): CoverageSummary {
+	const wanted = new Map(options.include.map((file) => [toPosix(file), true]));
+	const byFile = new Map<
+		string,
+		{ functionCount: number; functionsHit: number; blockCount: number; blocksHit: number }
+	>();
+	for (const file of wanted.keys()) {
+		byFile.set(file, {
+			functionCount: 0,
+			functionsHit: 0,
+			blockCount: 0,
+			blocksHit: 0,
+		});
+	}
+
+	for (const script of scripts) {
+		const file = fileFromScriptUrl(script.url, options.root);
+		if (!file || !wanted.has(file)) continue;
+		const bucket = byFile.get(file);
+		if (!bucket) continue;
+		for (const fn of script.functions) {
+			bucket.functionCount += 1;
+			if (fn.ranges.some((range) => range.count > 0)) bucket.functionsHit += 1;
+			for (const range of fn.ranges) {
+				bucket.blockCount += 1;
+				if (range.count > 0) bucket.blocksHit += 1;
+			}
+		}
+	}
+
+	const files: FileCoverage[] = [...byFile.entries()]
+		.map(([file, counts]) => ({
+			file,
+			...counts,
+			functionPct: ratio(counts.functionsHit, counts.functionCount),
+			blockPct: ratio(counts.blocksHit, counts.blockCount),
+		}))
+		.sort((a, b) => a.file.localeCompare(b.file));
+
+	let functionCount = 0;
+	let functionsHit = 0;
+	let blockCount = 0;
+	let blocksHit = 0;
+	let filesTouched = 0;
+	for (const file of files) {
+		functionCount += file.functionCount;
+		functionsHit += file.functionsHit;
+		blockCount += file.blockCount;
+		blocksHit += file.blocksHit;
+		if (file.functionsHit > 0) filesTouched += 1;
+	}
+
+	return {
+		files,
+		filesTouched,
+		filesTotal: files.length,
+		functionPct: ratio(functionsHit, functionCount),
+		blockPct: ratio(blocksHit, blockCount),
+	};
+}
+
+export async function withPreciseCoverage<T>(
+	work: () => Promise<T>,
+): Promise<{ result: T; scripts: ScriptCoverageLike[] }> {
+	const session = new Session();
+	session.connect();
+	try {
+		await session.post("Profiler.enable");
+		await session.post("Profiler.startPreciseCoverage", {
+			callCount: true,
+			detailed: true,
+		});
+		const result = await work();
+		const { result: scripts } = await session.post("Profiler.takePreciseCoverage");
+		return { result, scripts };
+	} finally {
+		try {
+			await session.post("Profiler.stopPreciseCoverage");
+		} catch {
+			// coverage may already be stopped if takePreciseCoverage failed
+		}
+		try {
+			await session.post("Profiler.disable");
+		} catch {
+			// ignore
+		}
+		session.disconnect();
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1509.

This adds a test-only V8 precise-coverage helper and a representative source-tree workload. The guard proves that the source-walk occupancy fixture still executes the production modules it claims to measure.

The workload exercises:

- synchronous and asynchronous source collection;
- project language profiling;
- bounded source counting;
- all eight declared walk/profile hot-path modules.

The test requires every selected module to execute at least one function. Conservative aggregate floors require 70% function reach and 45% block reach. The measured local baseline was 95.3% and 68.1%, respectively.

This does not change production code, extension runtime behavior, package dependencies, or the installed pi-lens package.

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:perf
- [x] area:tests

## Checklist

- [x] I have read `CONTRIBUTING.md` and `AGENTS.md`
- [x] The change has tests for URL filtering, missing files, and aggregate function/block reach
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Focused tests pass: 3/3
- [x] `npm run changelog:check` passes
- [x] No production dependencies or package metadata changed
- [x] No changelog entry is included because this is an internal-only test guard
- [ ] The full suite is completely green locally; it has the same 10 environment-sensitive failures as frozen `master`

## Full-suite baseline

Candidate branch: 6,743 passed, 42 skipped, 10 failed across 9 files.

A separate worktree at frozen base `d35b7279` produced the same 10 failures in the same 9 files: `advisory-provenance-finding-paths`, `coderabbit-ast-grep-rules`, `diagnostic-dispositions`, `runtime-tool-result`, `installer/version-drift`, `lsp/workspace-diagnostics-pull-binding`, `lsp/workspace-diagnostics-cache`, two `cache/rule-cache` cases, and `tools/lsp-diagnostics-cache`.

The candidate adds exactly three passing tests and no new failure.

## What changed and why

The existing occupancy tests measure event-loop stalls. A workload regression could stop calling the production walkers and make those tests easier to pass. This PR adds the complementary reach invariant: the workload must touch the intended production modules and execute a bounded share of their compiled functions and block ranges.

The reach test remains outside `timingSensitiveInclude`. It does not sample wall-clock latency, `process.cpuUsage`, or event-loop occupancy.

This PR was prepared by an AI agent under human supervision. The original implementation and authorship remain Don Yin's.
