### PR TITLE
fix(dispatch): report runner-start failures as errors, not test failures (closes #1487)

### DIFF
--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -1312,7 +1312,16 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 						dbg(
 							`turn_end: ${stale ? "[stale] " : ""}test ${runner} ${shortFile} → ${summary}`,
 						);
-						if (failed > 0) {
+						// #1524: also fires on `error` alone, not just `failed > 0`.
+						// A runner-error result (the suite never started — spawn/
+						// config failure) has `failed === 0` by construction, so
+						// gating on `failed > 0` alone dropped it silently: the
+						// agent got no context at all, and the empty `failures`
+						// array below sent this result down the "all tests
+						// passed" branch, clearing any prior real test-failure
+						// git-guard blocker. `formatResult` already renders the
+						// error-only case as "Could not run tests: ...".
+						if (failed > 0 || error) {
 							const formatted = testRunnerClient.formatResult(r.value);
 							if (formatted) failures.push(formatted);
 						}
@@ -1344,14 +1353,25 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 							cwd,
 						);
 						if (getFlag("lens-guard") && firedSessionId === runtime.telemetrySessionId) {
-							clearGitGuardTestFailure(
-								cacheManager,
-								cwd,
-								runtime,
-								resultValues
-									.filter((value) => value.failed === 0)
-									.map((value) => value.file),
-							);
+							// #1524: `&& !value.error` — a runner-error result has
+							// `failed === 0` (the suite never ran, so nothing could
+							// fail), but it is not a pass. Without the filter it
+							// would clear a prior real test-failure git-guard
+							// blocker on the strength of a suite that never
+							// started. And the call itself is skipped when this
+							// list is empty rather than passed as `[]`:
+							// `clearGitGuardTestFailure`'s own empty-array
+							// fallback treats "no files named" as "clear every
+							// blocked file", so an all-error batch (one go file,
+							// runner-error, zero clean files) would otherwise
+							// clear every blocker through that fallback instead
+							// of clearing none.
+							const cleanFiles = resultValues
+								.filter((value) => value.failed === 0 && !value.error)
+								.map((value) => value.file);
+							if (cleanFiles.length > 0) {
+								clearGitGuardTestFailure(cacheManager, cwd, runtime, cleanFiles);
+							}
 							mergeGitGuardTestFailure(
 								cacheManager,
 								cwd,

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -1750,8 +1750,17 @@ export class TestRunnerClient {
 		const lower = output.toLowerCase();
 
 		let passed = 0;
-		let failed = exitCode === 0 ? 0 : 1;
+		// #1487: NOT `exitCode === 0 ? 0 : 1`. Pre-seeding `failed` to 1 on a
+		// non-zero exit made the runner-error branch below unreachable — it
+		// requires `failed === 0`, which a spawn/config/load failure (no
+		// counts to parse) could never reach once this had already claimed
+		// the slot. `matched` tracks whether a count parser actually found
+		// real counts; the exit-code-distrust fallback further down uses it
+		// to tell "a runner that never ran" from "a runner whose summary
+		// legitimately parsed to zero failures".
+		let failed = 0;
 		let skipped = 0;
+		let matched = false;
 		// #1480: `number | undefined`, and sourced per runner. This used to be
 		// `let duration = 0` with only go's probe able to move it, so every
 		// other runner reported a zero it never measured.
@@ -1764,6 +1773,7 @@ export class TestRunnerClient {
 			passed = Number.parseInt(cargoSummary[1], 10);
 			failed = Number.parseInt(cargoSummary[2], 10);
 			skipped = Number.parseInt(cargoSummary[3], 10);
+			matched = true;
 		}
 
 		const dotnetSummary = output.match(
@@ -1773,6 +1783,7 @@ export class TestRunnerClient {
 			failed = Number.parseInt(dotnetSummary[1], 10);
 			passed = Number.parseInt(dotnetSummary[2], 10);
 			skipped = Number.parseInt(dotnetSummary[3], 10);
+			matched = true;
 		}
 
 		// #1480 (adjacent, duration-independent): surefire prints one
@@ -1816,6 +1827,7 @@ export class TestRunnerClient {
 			failed = mavenFailed;
 			skipped = mavenSkipped;
 			passed = Math.max(0, total - failed - skipped);
+			matched = true;
 		}
 
 		const rspecSummary = output.match(
@@ -1825,6 +1837,7 @@ export class TestRunnerClient {
 			const total = Number.parseInt(rspecSummary[1], 10);
 			failed = Number.parseInt(rspecSummary[2], 10);
 			passed = Math.max(0, total - failed);
+			matched = true;
 		}
 
 		const minitestSummary = output.match(
@@ -1836,6 +1849,7 @@ export class TestRunnerClient {
 			const errors = Number.parseInt(minitestSummary[3], 10);
 			failed = failures + errors;
 			passed = Math.max(0, total - failed);
+			matched = true;
 		}
 
 		const gradleSummary = output.match(
@@ -1845,13 +1859,19 @@ export class TestRunnerClient {
 			const total = Number.parseInt(gradleSummary[1], 10);
 			failed = Number.parseInt(gradleSummary[2], 10);
 			passed = Math.max(0, total - failed);
+			matched = true;
 		}
 
-		// Captured BEFORE the guard below, which rewrites `failed` out of the
-		// state this condition reads. Without this the runner-error string
-		// silently became unreachable.
+		// #1487: gated on `!matched`, not on `failed === 0`. A non-zero exit
+		// with NO count parser match — a spawn/config/load failure, nothing
+		// ran — is infrastructure, not a test verdict: report it as a runner
+		// error. A non-zero exit a count parser DID match (even to a
+		// legitimate `failed === 0`, e.g. a green last module of a red
+		// reactor) is a real run that produced real counts, so it is never a
+		// runner error, and the exit-code-distrust guard below still forces
+		// at least one failure so it can't render as PASS.
 		const runnerError =
-			exitCode !== 0 && failed === 0 && lower.includes("error")
+			exitCode !== 0 && !matched && lower.includes("error")
 				? `Runner ${runner} exited with ${exitCode}`
 				: undefined;
 
@@ -1861,8 +1881,11 @@ export class TestRunnerClient {
 		// module of a red reactor build, a failure outside any test — and the
 		// turn-end log would then print PASS over a build the runner rejected.
 		// Trust the exit code: no parse of the text may talk it out of at least
-		// one failure.
-		if (exitCode !== 0 && failed === 0) {
+		// one failure. Skipped when `runnerError` is set — that case already
+		// reports through `formatResult`'s runner-error branch, which requires
+		// `passed === 0 && failed === 0` to stay reachable, and forcing
+		// `failed` to 1 here would make it unreachable again (#1487).
+		if (exitCode !== 0 && failed === 0 && !runnerError) {
 			failed = 1;
 		}
 

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -1884,15 +1884,48 @@ export class TestRunnerClient {
 		const goFailNames = [
 			...output.matchAll(/--- FAIL:[^\S\n]+([^\s(]+)/g),
 		];
+		// #1524-r4: only COUNT unparented failures. go prints a `--- FAIL:`
+		// line for every level of a failing subtest tree — `TestA` AND
+		// `TestA/sub` each get their own line for what is really one
+		// underlying failure — so counting every line inflated `failed`
+		// (two lines here read as two failures for one broken test). A name
+		// containing "/" whose prefix up to that "/" is itself in the list
+		// is a subtest of an already-counted parent; only names that are
+		// NOT such a subtest count. `goFailNames` itself (all lines) is
+		// still what decides `matched`/the runner-error veto below and
+		// what's listed in `failures` — subtest names are still useful
+		// detail there, just not double-counted.
+		const goFailNameSet = new Set(goFailNames.map((m) => m[1].trim()));
+		const goTopLevelFailCount = goFailNames.filter((m) => {
+			const name = m[1].trim();
+			const slash = name.indexOf("/");
+			return slash === -1 || !goFailNameSet.has(name.slice(0, slash));
+		}).length;
 		if (runner === "go") {
-			const goFailPackage = /^FAIL[^\S\n]+\S+/m.test(output);
+			// #1524-r4: `(?![^\n]*\[(?:build|setup) failed\])` rejects go's
+			// INFRASTRUCTURE verdict lines — `FAIL <pkg> [build failed]` (a
+			// compile error) and `FAIL <pkg> [setup failed]` (no packages to
+			// test) — which matched the same shape as a real `FAIL <pkg>
+			// <duration>` test verdict line. Neither ran a single test; both
+			// were rendering as `✗ 1/1 failed ✗ go failure` instead of the
+			// runner error they are.
+			const goFailPackage =
+				/^FAIL(?![^\n]*\[(?:build|setup) failed\])[^\S\n]+\S+/m.test(
+					output,
+				);
 			const goOkPackages = [
 				...output.matchAll(/^ok[^\S\n]+\S+[^\S\n]+[\d.]+s/gm),
 			];
 			if (goFailNames.length > 0 || goFailPackage) {
-				failed = Math.max(failed, goFailNames.length || 1);
+				failed = Math.max(failed, goTopLevelFailCount || 1);
 				matched = true;
-			} else if (goOkPackages.length > 0) {
+			}
+			// #1524-r4: unconditional, not `else if`. A multi-package run
+			// can have BOTH a real failure and packages that passed clean —
+			// `ok a` / `--- FAIL: TestB` / `ok c` is 2 passed AND 1 failed,
+			// not "1 failed, 0 passed" with the green packages silently
+			// dropped because the fail branch above already ran.
+			if (goOkPackages.length > 0) {
 				passed = Math.max(passed, goOkPackages.length);
 				matched = true;
 			}
@@ -1952,6 +1985,18 @@ export class TestRunnerClient {
 			exitCode !== 0 && !matched && goFailNames.length === 0 && lower.includes("error")
 				? `Runner ${runner} exited with ${exitCode}`
 				: undefined;
+
+		// #1524-r4 (tidy): a runner-error result reports through
+		// `formatResult`'s runner-error branch, not the failed-tests
+		// branch, so any name `otherNames` picked up before this was
+		// decided (e.g. a same-line `Failure: cannot load such file`)
+		// would sit in `failures` unused but visible to anything reading
+		// the raw `TestResult` — an error result with a non-empty
+		// `failures` list is a self-contradiction. Clear it here so the
+		// result is one or the other, never both.
+		if (runnerError) {
+			failures.length = 0;
+		}
 
 		// #1480 (adjacent): a non-zero exit is the runner saying the run
 		// failed. Every count parser above can legitimately arrive at

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -1862,24 +1862,66 @@ export class TestRunnerClient {
 			matched = true;
 		}
 
-		// #1487/#1524: failure NAMES are extracted before `runnerError` is
-		// decided, not after. `--- FAIL: TestParse` (go) or a bare `Error:`
-		// line (an unrecognised runner) is direct evidence the suite ran and
-		// produced a verdict, even for a runner with no count parser above —
-		// go has no entry in the cargo/dotnet/maven/rspec/minitest/gradle
-		// matches, so `matched` alone can't tell "never started" from "ran
-		// and failed" for it. Deciding `runnerError` first and extracting
-		// names after (the pre-#1524 order) meant a real go test failure
-		// with "error" in its own output — `unexpected error: bad token` —
-		// still had `matched === false` and rendered as "Could not run
-		// tests" while `failures` silently held the real failing test name.
-		const failures: TestFailure[] = [];
-		const names = [
-			...output.matchAll(/--- FAIL:\s+([^\s(]+)/g),
-			...output.matchAll(/\bFAILED\s+([^\n]+)/g),
-			...output.matchAll(/Failure:\s+([^\n]+)/g),
+		// #1487/#1524/#1524-r3: `--- FAIL: TestName` is extracted first and
+		// separately from the other two name patterns, because it is the
+		// ONLY one of the three that is unambiguous evidence a real go test
+		// ran — see the `runnerError` comment below for why the other two
+		// may no longer veto on their own. go otherwise has no count parser
+		// at all (only a duration probe), so without this go's `matched`
+		// stayed false even on a real failure.
+		//
+		// #1524-r3: go ALSO gets a real count parser here, not just a name
+		// extractor. A panic inside `TestMain`/package `init` (exit 2) never
+		// prints a `--- FAIL:` line — there is no test to name, the process
+		// died before any test ran — so `goFailNames` alone left `matched`
+		// false and such a panic hit the same runner-error branch as a
+		// spawn failure, even though `go test` DID run and DID fail. `FAIL
+		// \t<pkg>` is go's own per-package verdict line and is printed for
+		// exactly this case; `ok  <pkg>  <n>s` is its pass counterpart.
+		// Package-line counts, like the go duration probe above, take the
+		// FIRST package summary only — the same known limit already
+		// documented on `parseGenericRunnerDuration`.
+		const goFailNames = [
+			...output.matchAll(/--- FAIL:[^\S\n]+([^\s(]+)/g),
 		];
-		for (const m of names.slice(0, 5)) {
+		if (runner === "go") {
+			const goFailPackage = /^FAIL[^\S\n]+\S+/m.test(output);
+			const goOkPackages = [
+				...output.matchAll(/^ok[^\S\n]+\S+[^\S\n]+[\d.]+s/gm),
+			];
+			if (goFailNames.length > 0 || goFailPackage) {
+				failed = Math.max(failed, goFailNames.length || 1);
+				matched = true;
+			} else if (goOkPackages.length > 0) {
+				passed = Math.max(passed, goOkPackages.length);
+				matched = true;
+			}
+		}
+
+		// #1524-r3: anchored to line START (`^`), and `[^\S\n]` (horizontal
+		// whitespace only) in place of `\s` between the keyword and the
+		// name. The prior `\bFAILED\s+([^\n]+)` and `Failure:\s+([^\n]+)`
+		// let their OWN `\s+` gap cross the newline: a bare `FAILED` at the
+		// end of a line has nothing after it on that line, so `\s+` ate the
+		// newline itself and `([^\n]+)` captured the FIRST TOKEN OF THE
+		// NEXT LINE as the "test name" — proven on a gradle compile failure
+		// (`> Task :compileJava FAILED` followed by
+		// `FAILURE: Build failed with an exception.`, which then rendered
+		// as the invented failure name) and the newline-spanning shape in
+		// general (`FAILED\n\nsome trailing note` → name "some trailing
+		// note"). Requiring `(\S.*)$` on the SAME line makes a keyword with
+		// nothing following it on that line simply not match, rather than
+		// reaching across for content that was never the name.
+		const failures: TestFailure[] = [];
+		for (const m of goFailNames.slice(0, 5)) {
+			failures.push({ name: m[1].trim(), message: m[1].trim() });
+		}
+		const otherNames = [
+			...output.matchAll(/^[^\S\n]*FAILED[^\S\n]+(\S.*)$/gm),
+			...output.matchAll(/^[^\S\n]*Failure:[^\S\n]+(\S.*)$/gm),
+		];
+		for (const m of otherNames) {
+			if (failures.length >= 5) break;
 			failures.push({ name: m[1].trim(), message: m[1].trim() });
 		}
 
@@ -1892,16 +1934,22 @@ export class TestRunnerClient {
 		// runner error, and the exit-code-distrust guard below still forces
 		// at least one failure so it can't render as PASS.
 		//
-		// #1524: also gated on `failures.length === 0`. `matched` only
-		// covers the runners with a count parser above; go (and any other
-		// unrecognised runner) has none, so a real `--- FAIL:`/`Error:` name
-		// pulled out just above is the only signal a text-only runner's
-		// failure ran to completion. Requiring both keeps a genuine
-		// spawn/config failure (no counts, no failure names) reported as a
-		// runner error while a real failing run — matched or not — is never
-		// downgraded out from under its own failure name.
+		// #1524-r3: the veto is `goFailNames.length === 0`, NOT
+		// `failures.length === 0`. Only `--- FAIL:` is a marker a test
+		// runner emits SPECIFICALLY for a failed test; `FAILED`/`Failure:`
+		// are generic words a build tool prints for reasons that have
+		// nothing to do with a test — a gradle task failing to compile, a
+		// maven goal failing before surefire ever runs, an rspec file that
+		// never loaded. Letting those two veto the runner-error branch on
+		// their own reintroduced #1487's exact symptom for the commonest
+		// gradle/maven/rspec failure shapes (proven: `[ERROR] Failed to
+		// execute goal ... FAILED` and rspec's `Failure: cannot load such
+		// file` both rendered as a fabricated test failure instead of the
+		// runner error they actually are). They still label a name onto
+		// `failures` above when `matched` or `goFailNames` already settled
+		// the question some other way, but they no longer settle it alone.
 		const runnerError =
-			exitCode !== 0 && !matched && failures.length === 0 && lower.includes("error")
+			exitCode !== 0 && !matched && goFailNames.length === 0 && lower.includes("error")
 				? `Runner ${runner} exited with ${exitCode}`
 				: undefined;
 

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -1862,6 +1862,27 @@ export class TestRunnerClient {
 			matched = true;
 		}
 
+		// #1487/#1524: failure NAMES are extracted before `runnerError` is
+		// decided, not after. `--- FAIL: TestParse` (go) or a bare `Error:`
+		// line (an unrecognised runner) is direct evidence the suite ran and
+		// produced a verdict, even for a runner with no count parser above —
+		// go has no entry in the cargo/dotnet/maven/rspec/minitest/gradle
+		// matches, so `matched` alone can't tell "never started" from "ran
+		// and failed" for it. Deciding `runnerError` first and extracting
+		// names after (the pre-#1524 order) meant a real go test failure
+		// with "error" in its own output — `unexpected error: bad token` —
+		// still had `matched === false` and rendered as "Could not run
+		// tests" while `failures` silently held the real failing test name.
+		const failures: TestFailure[] = [];
+		const names = [
+			...output.matchAll(/--- FAIL:\s+([^\s(]+)/g),
+			...output.matchAll(/\bFAILED\s+([^\n]+)/g),
+			...output.matchAll(/Failure:\s+([^\n]+)/g),
+		];
+		for (const m of names.slice(0, 5)) {
+			failures.push({ name: m[1].trim(), message: m[1].trim() });
+		}
+
 		// #1487: gated on `!matched`, not on `failed === 0`. A non-zero exit
 		// with NO count parser match — a spawn/config/load failure, nothing
 		// ran — is infrastructure, not a test verdict: report it as a runner
@@ -1870,8 +1891,17 @@ export class TestRunnerClient {
 		// reactor) is a real run that produced real counts, so it is never a
 		// runner error, and the exit-code-distrust guard below still forces
 		// at least one failure so it can't render as PASS.
+		//
+		// #1524: also gated on `failures.length === 0`. `matched` only
+		// covers the runners with a count parser above; go (and any other
+		// unrecognised runner) has none, so a real `--- FAIL:`/`Error:` name
+		// pulled out just above is the only signal a text-only runner's
+		// failure ran to completion. Requiring both keeps a genuine
+		// spawn/config failure (no counts, no failure names) reported as a
+		// runner error while a real failing run — matched or not — is never
+		// downgraded out from under its own failure name.
 		const runnerError =
-			exitCode !== 0 && !matched && lower.includes("error")
+			exitCode !== 0 && !matched && failures.length === 0 && lower.includes("error")
 				? `Runner ${runner} exited with ${exitCode}`
 				: undefined;
 
@@ -1893,15 +1923,6 @@ export class TestRunnerClient {
 			passed = 1;
 		}
 
-		const failures: TestFailure[] = [];
-		const names = [
-			...output.matchAll(/--- FAIL:\s+([^\s(]+)/g),
-			...output.matchAll(/\bFAILED\s+([^\n]+)/g),
-			...output.matchAll(/Failure:\s+([^\n]+)/g),
-		];
-		for (const m of names.slice(0, 5)) {
-			failures.push({ name: m[1].trim(), message: m[1].trim() });
-		}
 		if (failures.length === 0 && failed > 0) {
 			const firstLine =
 				output
@@ -1911,6 +1932,12 @@ export class TestRunnerClient {
 					.slice(0, 300) || `Tests failed for runner ${runner}`;
 			failures.push({ name: `${runner} failure`, message: firstLine });
 		}
+
+		this.log(
+			runnerError
+				? `Generic runner ${runner}: never started (${runnerError})`
+				: `Generic runner ${runner}: ran (matched=${matched}, passed=${passed}, failed=${failed}, failures=${failures.length})`,
+		);
 
 		return {
 			file: testFile,

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import { CacheManager } from "../../clients/cache-manager.js";
 import { snapshotAdvisoryProvenance } from "../../clients/advisory-provenance.js";
 import {
+	evaluateGitGuard,
+	mergeGitGuardTestFailure,
+} from "../../clients/git-guard.js";
+import {
 	consumeSessionStartGuidance,
 	consumeTestFindings,
 	consumeTurnEndFindings,
@@ -1847,6 +1851,93 @@ describe("turn_end test runner — stale results are cached, not discarded", () 
 			expect(cached?.data?.content).toContain("[Tests] ✗ 0/1 passed");
 			expect(cached?.data?.stale).toBe(false);
 			expect(cached?.data?.content).not.toContain("prior turn");
+		} finally {
+			env.cleanup();
+		}
+	});
+});
+
+// ── #1524: a runner-error result must not clear a real git-guard blocker ──────
+//
+// A runner that never started (spawn/config/load failure) reports
+// `failed === 0` — nothing ran, so nothing could fail — but it is not a pass.
+// Before this fix, `turn_end` only pushed a formatted message into its local
+// `failures` array when `failed > 0`, so a runner-error result left that
+// array empty and fell into the "all tests passed" branch, which called
+// `clearGitGuardTestFailure` unconditionally and erased a real prior
+// test-failure blocker.
+
+describe("turn_end test runner — a runner-error result does not clear a real git-guard blocker (#1524)", () => {
+	it("keeps a pre-existing test-failure blocker after a runner-start failure", async () => {
+		const env = setupTestEnvironment("pi-lens-test-guard-error-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			runtime.setTelemetryIdentity({ sessionId: "guard-error-session" });
+			const cacheManager = new CacheManager(false);
+
+			const srcFile = path.join(env.tmpDir, "src/main.go");
+			fs.mkdirSync(path.dirname(srcFile), { recursive: true });
+			fs.writeFileSync(srcFile, "package main\n");
+			cacheManager.addModifiedRange(
+				srcFile,
+				{ start: 1, end: 1 },
+				false,
+				env.tmpDir,
+				"guard-error-session",
+			);
+
+			// Seed a REAL prior test-failure blocker on this exact go test file
+			// — a previous turn genuinely ran it and it failed. The scenario
+			// under test is this same file now failing to even START (a
+			// spawn/config error), which must not read as "it passed" and
+			// clear the blocker it earned last turn.
+			const goTestFile = path.join(env.tmpDir, "src/main_test.go");
+			fs.writeFileSync(goTestFile, "package main\n");
+			mergeGitGuardTestFailure(
+				cacheManager,
+				env.tmpDir,
+				runtime,
+				"[Tests] ✗ 0/1 passed — go",
+				[goTestFile],
+			);
+			expect(evaluateGitGuard(runtime, cacheManager, env.tmpDir).block).toBe(true);
+
+			const runnerErrorResult = {
+				file: goTestFile,
+				sourceFile: srcFile,
+				runner: "go",
+				passed: 0,
+				failed: 0,
+				skipped: 0,
+				failures: [],
+				duration: 1,
+				error: "Runner go exited with 1",
+			};
+			await handleTurnEnd(
+				makeTurnEndDeps(runtime, cacheManager, {
+					ctxCwd: env.tmpDir,
+					getFlag: (flag: string) => flag === "lens-guard",
+					testRunnerClient: {
+						getTestRunTarget: () => ({
+							testFile: goTestFile,
+							runner: "go",
+							config: {} as any,
+							strategy: "related" as const,
+						}),
+						runTestFileAsync: async () => runnerErrorResult,
+						formatResult: (r: { error?: string; passed: number; failed: number }) =>
+							r.error && r.passed === 0 && r.failed === 0
+								? `[Tests] ⚠ Could not run tests: ${r.error}`
+								: "",
+					},
+				}),
+			);
+			await new Promise((resolve) => setImmediate(resolve));
+
+			// The prior real test-failure blocker must still be in force — a
+			// suite that never started must not read as a pass that clears it.
+			expect(evaluateGitGuard(runtime, cacheManager, env.tmpDir).block).toBe(true);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -813,6 +813,94 @@ describe("test-runner-client", () => {
 		});
 	});
 
+	// #1524-r4: a third review pass found three residuals in the go count
+	// parser round 3 added.
+	//
+	// S3: `/^FAIL[^\S\n]+\S+/m` (a real per-package verdict line) also
+	// matched go's INFRASTRUCTURE verdict lines — `FAIL <pkg> [build
+	// failed]` (a compile error) and `FAIL <pkg> [setup failed]` (no
+	// packages to test). Neither ran a single test, but both rendered as a
+	// fabricated `✗ 1/1 failed` instead of the runner error they are.
+	//
+	// S4a: the ok-package pass count was in an `else if` off the fail
+	// branch, so a mixed multi-package run — some packages clean, one
+	// package with a real failure — silently dropped the clean packages'
+	// pass count.
+	//
+	// S4b: every `--- FAIL:` line was counted, but go prints one PER LEVEL
+	// of a failing subtest tree — a parent `TestA` and its child
+	// `TestA/sub` both get a line for what is one underlying failure — so
+	// counting lines inflated `failed`.
+	describe("go infrastructure verdicts, mixed-package counts, subtests (#1524-r4)", () => {
+		const parse = (output: string, exitCode: number, runner = "go") =>
+			(new TestRunnerClient(false) as any).parseGenericRunnerOutput(
+				"",
+				output,
+				exitCode,
+				`/tmp/test.${runner}`,
+				runner,
+			);
+
+		it("reports a go compile failure ([build failed]) as a runner error", () => {
+			const result = parse(
+				"# example.com/pkg\n./main_test.go:8:2: undefined: Bar (compile error)\nFAIL\texample.com/pkg [build failed]\n",
+				1,
+			);
+
+			expect(result.error).toBe("Runner go exited with 1");
+			expect(result.failed).toBe(0);
+			expect(result.failures).toEqual([]);
+		});
+
+		it("reports a go setup failure ([setup failed]) as a runner error", () => {
+			const result = parse(
+				"FAIL\texample.com/pkg [setup failed]\nerror: no packages to test\n",
+				1,
+			);
+
+			expect(result.error).toBe("Runner go exited with 1");
+			expect(result.failed).toBe(0);
+			expect(result.failures).toEqual([]);
+		});
+
+		it("counts clean packages as passed alongside a real failure in the same run", () => {
+			const result = parse(
+				"ok  \texample.com/a\t0.01s\n--- FAIL: TestB\n    b_test.go:5: assertion failed\nFAIL\texample.com/b\t0.01s\nok  \texample.com/c\t0.02s\n",
+				1,
+			);
+
+			expect(result.passed).toBe(2);
+			expect(result.failed).toBe(1);
+		});
+
+		it("does not double-count a failing subtest against its already-counted parent", () => {
+			const result = parse(
+				"--- FAIL: TestA\n--- FAIL: TestA/sub1\n--- FAIL: TestA/sub2\nFAIL\texample.com/pkg\t0.01s\n",
+				1,
+			);
+
+			expect(result.failed).toBe(1);
+		});
+	});
+
+	// #1524-r4 (tidy): a runner-error result must not also carry leftover
+	// failure names — the two branches of `formatResult` are mutually
+	// exclusive, so a `TestResult` claiming both is self-contradictory.
+	describe("a runner-error result has no leftover failure names (#1524-r4 tidy)", () => {
+		it("clears failures when the rspec load-error text also matches a same-line Failure: name", () => {
+			const result = (new TestRunnerClient(false) as any).parseGenericRunnerOutput(
+				"",
+				"An error occurred while loading ./spec/foo_spec.rb.\nFailure: cannot load such file -- foo\n",
+				1,
+				"/tmp/spec/foo_spec.rb",
+				"rspec",
+			);
+
+			expect(result.error).toBe("Runner rspec exited with 1");
+			expect(result.failures).toEqual([]);
+		});
+	});
+
 	// #1480 P3: `parseFloat(seconds) * 1000` is not an integer count of
 	// milliseconds. `in 2.01s` is 2009.9999999999998, and the turn-end log
 	// prints the number as it stands.

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -689,9 +689,19 @@ describe("test-runner-client", () => {
 			);
 		});
 
-		it("reports an unknown-runner (bazel) failure, not a runner error", () => {
+		it("reports an unknown-runner (bazel) failure with a parseable count summary, not a runner error", () => {
+			// #1524-r3: updated from the original round's fixture, which
+			// relied on a bare `FAILED ...`/`Error: ...` text pair alone to
+			// veto the runner-error branch. That is exactly the ambiguous
+			// shape #1524-r3 removed the veto from — see the gradle/maven/
+			// rspec runner-error tests below, which use the same bare-text
+			// shape and now correctly render AS runner errors. An
+			// unrecognised runner with no `--- FAIL:` marker of its own can
+			// still report a real failure, but only via a count summary a
+			// parser actually recognises (rspec's `N examples, N failures`
+			// applies to any runner name, not just `rspec`).
 			const result = parse(
-				"FAILED //pkg:test\nError: expected 1 to equal 2\n",
+				"3 examples, 1 failure\nError: expected 1 to equal 2\n",
 				1,
 				"bazel",
 			);
@@ -706,6 +716,100 @@ describe("test-runner-client", () => {
 			expect(result.error).toBe("Runner go exited with 1");
 			expect(result.failed).toBe(0);
 			expect(result.failures).toEqual([]);
+		});
+	});
+
+	// #1524-r3: a round-2 review found the fix itself had two defects.
+	//
+	// S2: the `FAILED`/`Failure:` name regexes let their own `\s+` gap cross
+	// a newline. A bare keyword at end-of-line has nothing after it on that
+	// line, so the gap ate the newline and the capture grabbed the FIRST
+	// TOKEN OF THE NEXT LINE as the "test name" — and, worse, that invented
+	// name then counted as evidence a test ran, vetoing the runner-error
+	// branch for build-tool failures (a gradle task failing to compile, a
+	// maven goal failing before surefire runs, an rspec file that never
+	// loaded) that have nothing to do with any test.
+	//
+	// S3: go's only text evidence was `--- FAIL: TestName`, which a panic in
+	// `TestMain`/package `init` never prints — the process dies before any
+	// test runs, so there is no test to name. That real go failure (exit 2,
+	// `FAIL\t<pkg>`, no `--- FAIL:`) still hit the runner-error branch.
+	describe("failure-name regexes and go's count parser (#1524-r3)", () => {
+		const parse = (
+			output: string,
+			exitCode: number,
+			runner: string,
+			runnerFile = `/tmp/test.${runner}`,
+		) =>
+			(new TestRunnerClient(false) as any).parseGenericRunnerOutput(
+				"",
+				output,
+				exitCode,
+				runnerFile,
+				runner,
+			);
+
+		it("reports a gradle compile failure as a runner error, not a fabricated test failure", () => {
+			const result = parse(
+				"> Task :compileJava FAILED\n\nFAILURE: Build failed with an exception.\n\n* What went wrong:\nexecution failed\nerror: cannot find symbol\n",
+				1,
+				"gradle",
+			);
+
+			expect(result.error).toBe("Runner gradle exited with 1");
+			expect(result.failed).toBe(0);
+			expect(result.failures).toEqual([]);
+		});
+
+		it("reports a maven failed-goal build as a runner error, not a fabricated test failure", () => {
+			const result = parse(
+				"[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project foo: Compilation failure: FAILED\n[ERROR] error: cannot find symbol\n",
+				1,
+				"maven",
+			);
+
+			expect(result.error).toBe("Runner maven exited with 1");
+			expect(result.failed).toBe(0);
+			expect(result.failures).toEqual([]);
+		});
+
+		it("reports an rspec load error as a runner error, not a fabricated test failure", () => {
+			const result = parse(
+				"An error occurred while loading ./spec/foo_spec.rb.\nFailure:\n  cannot load such file -- foo\n",
+				1,
+				"rspec",
+			);
+
+			expect(result.error).toBe("Runner rspec exited with 1");
+			expect(result.failed).toBe(0);
+			expect(result.failures).toEqual([]);
+		});
+
+		it("reports a go panic in TestMain as a test failure, not a runner error", () => {
+			// No `--- FAIL:` — the process died in TestMain/init before any
+			// individual test ran — but `FAIL\t<pkg>` is go's own verdict
+			// line for exactly this case, and the go count parser reads it.
+			// Uses go's real nil-pointer panic wording, which contains
+			// "error" ("runtime error: ...") — the S3 scenario specifically
+			// requires that word present, or the old code's `lower.includes
+			// ("error")` gate would never have fired in the first place and
+			// this test would not prove the bug.
+			const result = parse(
+				"panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x476f00]\n\ngoroutine 1 [running]:\nexample.com/pkg.TestMain(0x0)\n\t/repo/main_test.go:10 +0x20\nFAIL\texample.com/pkg\t0.00s\n",
+				2,
+				"go",
+			);
+
+			expect(result.error).toBeUndefined();
+			expect(result.failed).toBeGreaterThan(0);
+		});
+
+		it("does not invent a failure name from the line after a newline-spanning FAILED", () => {
+			const result = parse("FAILED\n\nsome trailing note\n", 1, "cargo");
+
+			expect(
+				result.failures.some((f: { name: string }) => f.name === "some trailing note"),
+			).toBe(false);
 		});
 	});
 

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -638,6 +638,77 @@ describe("test-runner-client", () => {
 		});
 	});
 
+	// #1524: a REAL failing run must never be downgraded to "could not run
+	// tests" just because its runner has no count parser in
+	// `parseGenericRunnerDuration`/the count-matching block above. go (the
+	// `default:` case's only text-only runner with no cargo/dotnet/maven/
+	// rspec/minitest/gradle summary shape) never sets `matched`, so before
+	// this fix `exitCode !== 0 && !matched && lower.includes("error")` fired
+	// on a genuine `--- FAIL:`/panic that happened to mention the word
+	// "error" — a real failing test rendered as a runner-start error, and
+	// the failing test's own name was extracted into `failures` and then
+	// discarded because `runnerError` was already decided first.
+	describe("a real failing run is never downgraded to a runner error (#1524)", () => {
+		const parse = (
+			output: string,
+			exitCode: number,
+			runner = "go",
+			runnerFile = `/tmp/test.${runner}`,
+		) =>
+			(new TestRunnerClient(false) as any).parseGenericRunnerOutput(
+				"",
+				output,
+				exitCode,
+				runnerFile,
+				runner,
+			);
+
+		it("reports a go test failure by name, not as a runner error", () => {
+			const result = parse(
+				"--- FAIL: TestParse\n    parse_test.go:22: unexpected error: bad token\nFAIL\texample.com/pkg\t0.01s\n",
+				1,
+			);
+
+			expect(result.error).toBeUndefined();
+			expect(result.failed).toBeGreaterThan(0);
+			expect(result.failures).toEqual(
+				expect.arrayContaining([expect.objectContaining({ name: "TestParse" })]),
+			);
+		});
+
+		it("reports a go panic by name, not as a runner error", () => {
+			const result = parse(
+				"--- FAIL: TestBoom\npanic: runtime error: index out of range [3] with length 3\n\ngoroutine 1 [running]:\nFAIL\texample.com/pkg\t0.01s\n",
+				2,
+			);
+
+			expect(result.error).toBeUndefined();
+			expect(result.failed).toBeGreaterThan(0);
+			expect(result.failures).toEqual(
+				expect.arrayContaining([expect.objectContaining({ name: "TestBoom" })]),
+			);
+		});
+
+		it("reports an unknown-runner (bazel) failure, not a runner error", () => {
+			const result = parse(
+				"FAILED //pkg:test\nError: expected 1 to equal 2\n",
+				1,
+				"bazel",
+			);
+
+			expect(result.error).toBeUndefined();
+			expect(result.failed).toBeGreaterThan(0);
+		});
+
+		it("still reports a genuine runner-start failure as an error (no failure names, #1487 stays green)", () => {
+			const result = parse("go: cannot find main module; error initializing", 1);
+
+			expect(result.error).toBe("Runner go exited with 1");
+			expect(result.failed).toBe(0);
+			expect(result.failures).toEqual([]);
+		});
+	});
+
 	// #1480 P3: `parseFloat(seconds) * 1000` is not an integer count of
 	// milliseconds. `in 2.01s` is 2009.9999999999998, and the turn-end log
 	// prints the number as it stands.

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -576,6 +576,68 @@ describe("test-runner-client", () => {
 		});
 	});
 
+	// #1487: a runner that never ran (spawn/config/load failure) must not be
+	// reported to the agent as a failing test. `failed` used to be pre-seeded
+	// to 1 for any non-zero exit, which made the runner-error branch
+	// (`failed === 0`) unreachable on exactly the path it exists for.
+	describe("runner-start failures report as errors, not test failures (#1487)", () => {
+		const parse = (output: string, exitCode: number, runner = "cargo") =>
+			(new TestRunnerClient(false) as any).parseGenericRunnerOutput(
+				"",
+				output,
+				exitCode,
+				`/tmp/test.${runner}`,
+				runner,
+			);
+
+		it("reports a non-zero exit with no counts and error text as a runner error, not a failing test", () => {
+			const result = parse("error: could not load configuration file", 1);
+
+			expect(result.error).toBe("Runner cargo exited with 1");
+			expect(result.passed).toBe(0);
+			expect(result.failed).toBe(0);
+		});
+
+		it("does not invent a failure name for a runner-start error", () => {
+			const result = parse("error: could not load configuration file", 1);
+
+			expect(result.failures).toEqual([]);
+		});
+
+		it("renders the runner-error surface, not a failed-test surface", () => {
+			const client = new TestRunnerClient(false);
+			const result = parse("error: could not load configuration file", 1);
+
+			expect(client.formatResult(result)).toBe(
+				"[Tests] ⚠ Could not run tests: Runner cargo exited with 1",
+			);
+		});
+
+		it("still reports parsed counts, and never PASS, for a non-zero exit with real counts", () => {
+			// Counts DID parse (0 failed via the cargo summary), so this is a
+			// real run, not a runner-start failure — the #1480 guard must
+			// still force at least one failure rather than reading it as a
+			// runner error.
+			const result = parse(
+				"test result: ok. 3 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out",
+				1,
+			);
+
+			expect(result.error).toBeUndefined();
+			expect(result.failed).toBeGreaterThan(0);
+		});
+
+		it("still reports a failure for a non-zero exit with no counts and no error text", () => {
+			// No count parser matched AND no "error" text — ambiguous, but
+			// still a non-zero exit, so the #1480 exit-code-distrust guard
+			// must still apply and this must not render as PASS.
+			const result = parse("unexpected termination", 1);
+
+			expect(result.error).toBeUndefined();
+			expect(result.failed).toBeGreaterThan(0);
+		});
+	});
+
 	// #1480 P3: `parseFloat(seconds) * 1000` is not an integer count of
 	// milliseconds. `in 2.01s` is 2009.9999999999998, and the turn-end log
 	// prints the number as it stands.


### PR DESCRIPTION
## What

`parseGenericRunnerOutput` pre-seeded `failed = 1` for any non-zero exit,
before any count parser ran. That made the runner-error branch below it —
which requires `failed === 0` — permanently unreachable on the one path it
exists for: a spawn, config, or load failure where nothing ran. The agent
saw `✗ 1/1 failed, 0 passed` with an invented failure name matching the
project directory, and an instruction to "fix failing tests" for tests that
never ran.

## Why

A spawn/start failure is infrastructure, not a test verdict. The fix tracks
whether a count parser actually matched real counts (`matched`) instead of
relying on `failed === 0`, which the premature seed had already polluted:

- Non-zero exit, no parser matched, error text present → runner error
  (`formatResult` renders `⚠ Could not run tests: ...`), no invented
  failure name.
- Non-zero exit, a parser DID match — even to a legitimate `failed === 0`,
  e.g. a green last module of a red `--fail-at-end` reactor — still goes
  through the existing #1480 exit-code-distrust guard and can never render
  as PASS.

Diff is scoped to `clients/test-runner-client.ts`'s `parseGenericRunnerOutput`
and its test file only; no touches to `availability-policy.ts` or
`runner-helpers.ts` (the concurrent #1494/#1496 probe-latch work).

## Review round 2

An adversarial review of the first round found two blockers:

1. **Real failures downgraded for any runner with no count parser.**
   `matched` only covers runners with a count-parser match (cargo, dotnet,
   maven, rspec, minitest, gradle). go has none — only a duration parser —
   so a genuinely failing go run (`--- FAIL: TestParse` +
   `unexpected error: bad token`, exit 1) had `matched === false` and hit
   the same "error" text the runner-error branch looks for. It rendered as
   `⚠ Could not run tests` instead of naming the failing test, even though
   the failure name was already sitting in `failures` — `runnerError` was
   decided before failure-name extraction ran.

   Fixed by moving failure-name extraction (`--- FAIL:`/`FAILED`/`Failure:`)
   before the `runnerError` decision and requiring `failures.length === 0`
   in addition to `!matched`. A runner with no count parser but a real
   failure name is never downgraded; a genuine spawn/config failure (no
   counts, no failure names) still reports as a runner error.

2. **The downgraded state silently cleared a real git-guard blocker.**
   `runtime-turn.ts` only pushed agent context when `failed > 0`, so a
   runner-error result (`failed === 0` by construction — nothing ran, so
   nothing could fail) produced no agent-visible message at all, and fell
   into the "all tests passed" branch, which calls `clearGitGuardTestFailure`
   unconditionally. A go suite that failed to even start could erase a real
   test-failure commit blocker from a prior turn.

   Fixed by also pushing context when `error` is set, filtering runner-error
   files out of the "clean" set passed to `clearGitGuardTestFailure`, and
   skipping that call entirely when the clean set is empty — its own
   fallback treats an empty file list as "clear every blocked file", which
   an all-error batch would otherwise trigger through the back door.

   Also added a log line distinguishing "runner never started" from a real
   run, so the downgrade path is legible in the runner's own logs instead of
   a bare `dbg` line.

## Review round 3

A second adversarial pass confirmed both round-2 blockers fixed (re-probed
all four inversions plus mixed-batch git-guard behavior) but found the round
itself had introduced one new defect and left one residual:

1. **(New) The `FAILED`/`Failure:` name regexes were too loose.**
   `\bFAILED\s+([^\n]+)` let its own `\s+` gap cross a newline: a bare
   `FAILED` at the end of a line has nothing after it on that line, so the
   gap ate the newline and `([^\n]+)` captured the next line's first token
   as the "test name". Worse, that invented name then counted as evidence a
   test ran, so it could veto the runner-error branch for build failures
   that have nothing to do with any test. Proven inversions: a gradle
   compile failure (`> Task :compileJava FAILED` followed by
   `FAILURE: Build failed with an exception.`), a maven failed-goal build,
   and an rspec load error (`Failure:` with nothing after it on that line)
   all rendered as a fabricated test failure instead of the runner error
   they actually are — #1487's exact symptom, reintroduced by round 2's own
   fix.

   Fixed in three parts:
   - Anchored both patterns to line start and swapped `\s` for `[^\S\n]`
     (horizontal whitespace only) in the gap before the captured name, so a
     keyword with nothing following it on its own line simply does not
     match instead of reaching into the next line.
   - Restricted the runner-error veto to `--- FAIL:` alone. It's the only
     one of the three markers a test runner emits *specifically* for a
     failed test; `FAILED`/`Failure:` are generic words a build tool prints
     for reasons that have nothing to do with a test. They still label a
     name onto `failures` once `matched` or `--- FAIL:` has already settled
     the question some other way, but no longer settle it themselves.
   - Gave go a real count parser (see next item), so go — the one runner
     whose only failure evidence came from these name patterns — no longer
     needs them to avoid the runner-error branch.

2. **(Residual) go still had no real count parser, only a name extractor.**
   A panic inside `TestMain`/package `init` (exit 2) never prints
   `--- FAIL:` — the process dies before any test runs, so there's no test
   to name — but it's still a real failure `go test` reported. That case
   still fell through to the runner-error branch.

   Fixed by counting `--- FAIL:` occurrences as failed evidence and reading
   go's own `FAIL\t<pkg>` / `ok  <pkg>  <n>s` package-summary lines as
   pass/fail evidence when no individual test name is present. Takes the
   first package summary only, the same known limit already documented on
   the adjacent go duration probe.

   The existing bazel #1524 test relied on bare `FAILED ...`/`Error: ...`
   text alone to avoid runner-error — exactly the ambiguous shape this round
   removes the veto from — so its fixture now uses a count summary a parser
   actually recognises (`N examples, N failures`, which applies to any
   runner name), matching the corrected behavior instead of the one this
   round retired.

   On the reviewer's note about the downgrade log being verbose-gated
   `dbg`-only: `TestRunnerClient` has no existing lightweight counter or
   degradation-tracking mechanism to wire into (`recordResult` tracks
   per-file pass/fail state for retry logic, not degradation events; no
   `logLatency`-style telemetry exists in this file). Left as the
   verbose-gated log added in round 2, noted here rather than added as new
   infrastructure out of scope for this fix.

## Review round 4

A fourth pass confirmed all prior blockers fixed and the #1480
exit-code-distrust guard clean through the new go parser, but found three
residuals in that parser plus one optional tidy:

1. **go's package-line probe also matched INFRASTRUCTURE verdicts.**
   `/^FAIL[^\S\n]+\S+/m` (added in round 3 to recognise a real `FAIL <pkg>
   <duration>` test verdict) also matched `FAIL <pkg> [build failed]` (a
   compile error) and `FAIL <pkg> [setup failed]` (no packages to test).
   Neither ran a single test, but both rendered as a fabricated
   `✗ 1/1 failed ✗ go failure` instead of the runner error they are.

   Fixed with a negative lookahead — `(?![^\n]*\[(?:build|setup)
   failed\])` — right after `FAIL`, so a line whose rest contains either
   bracket suffix simply does not match.

2. **The ok-package pass count was `else if` off the fail branch.** A
   mixed multi-package run — `ok a` / `--- FAIL: TestB` / `ok c` — has 2
   packages that passed clean and 1 real failure, but the `else if`
   dropped the clean packages' pass count once the fail branch had already
   run, reporting `1 failed, 0 passed` instead of `1 failed, 2 passed`.

   Made the ok-package count unconditional — both branches can be true in
   the same run.

3. **Every `--- FAIL:` line was counted, inflating subtest failures.** go
   prints one `--- FAIL:` line PER LEVEL of a failing subtest tree — a
   parent `TestA` and its child `TestA/sub` both get a line for what is
   one underlying failure — so `TestA` + `TestA/sub1` + `TestA/sub2`
   counted as 3 failures for 1 broken test.

   Fixed by counting only names with no parent already in the same list —
   a name containing `/` is excluded when its prefix up to that `/` is
   itself a matched name. The full name list (parents and subtests both)
   is still what decides `matched`/the runner-error veto and what's listed
   in `failures`; only the COUNT is deduplicated.

4. **(Optional tidy, applied)** A runner-error result could still carry
   leftover failure names extracted before the veto was decided (e.g. a
   same-line `Failure: cannot load such file`), even though
   `formatResult`'s two branches are mutually exclusive. `failures` is now
   cleared whenever `runnerError` is set, so a `TestResult` is never both
   at once.

## Verification

**Round 1** (original #1487 fix):
- Red-first: reverted the source change only (kept the new tests), ran
  `npx vitest run tests/clients/test-runner-client.test.ts -t "1487"` on
  pre-fix code — 3 of 5 new tests failed for the exact reported reason
  (`error` undefined, invented `cargo failure` name, `✗ 1/1 failed` surface
  instead of the runner-error surface).
- Reapplied the fix: same targeted test run — 138/138 pass, including all
  5 new regression tests.

**Round 2**:
- Red-first: saved the full diff as a patch, reverted only the two source
  files (`clients/test-runner-client.ts`, `clients/runtime-turn.ts`) while
  keeping the 4 new tests, rebuilt, and ran them against pre-fix code — all
  4 failed for the exact reported reasons (go/panic/bazel failures rendered
  as `Runner ... exited with N` instead of naming the failure; the seeded
  git-guard test-failure blocker was cleared by a runner-error result).
  `git apply` (never `git stash`) restored the fix afterward.
- Reapplied the fix and reran: `tests/clients/test-runner-client.test.ts`
  (142/142), `tests/clients/runtime-turn-session.test.ts` (45/45,
  including the new git-guard regression test), plus
  `runtime-turn-dead-code.test.ts`, all four `pipeline*.test.ts` files,
  `run-duration.test.ts`, and `git-guard.test.ts` — 254/254 pass.
- All 5 original #1487 tests still pass, unchanged.

**Round 3**:
- Red-first: saved the full diff as a patch, reverted only
  `clients/test-runner-client.ts` while keeping the 5 new tests, rebuilt,
  and ran them against round-2 code — all 5 failed for the exact reported
  reasons: the gradle/maven/rspec fixtures rendered `error: undefined`
  instead of a runner error (the invented cross-newline name defeated the
  veto); the go `TestMain` panic rendered `Runner go exited with 2` instead
  of a failing test; the newline-spanning `FAILED\n\nsome trailing note`
  fixture invented a failure literally named "some trailing note".
  `git apply` (never `git stash`) restored the fix afterward.
- Reapplied the fix and reran the reviewer's four-file set plus the git-guard
  set: `tests/clients/test-runner-client.test.ts` (147/147),
  `tests/clients/pipeline.test.ts`, `pipeline-autofix-config.test.ts`,
  `pipeline-eslint-autofix.test.ts`, `pipeline-lsp-sync.test.ts`,
  `pipeline-snapshot-occupancy.test.ts`, `run-duration.test.ts`,
  `runtime-turn-session.test.ts`, `runtime-turn-dead-code.test.ts`, and
  `git-guard.test.ts` — 259/259 pass across all 10 files.
- All 9 pre-round-3 #1487/#1524 tests still pass (5 original + 4 from round
  2, one fixture updated to match the tightened, correct veto behavior — see
  round 3 notes above); 14/14 pass in the combined `#1487`/`#1524` test
  filter.
**Round 4**:
- Red-first: saved the full diff as a patch, reverted only
  `clients/test-runner-client.ts` while keeping the 5 new tests, rebuilt,
  and ran them against round-3 code — all 5 failed for the exact reported
  reasons: the `[build failed]`/`[setup failed]` fixtures rendered
  `error: undefined` instead of a runner error; the mixed-package fixture
  reported `0 passed` instead of `2`; the subtest fixture reported
  `failed: 3` instead of `1`; the rspec load-error fixture kept a leftover
  failure name (`"cannot load such file -- foo"`) alongside `error` set.
  `git apply` (never `git stash`) restored the fix afterward.
- Reapplied the fix and reran: `tests/clients/test-runner-client.test.ts`
  (152/152) alone, then the reviewer's four-file set plus the git-guard set
  together — `test-runner-client.test.ts`, all four `pipeline*.test.ts`
  files, `run-duration.test.ts`, `runtime-turn-session.test.ts`,
  `runtime-turn-dead-code.test.ts`, and `git-guard.test.ts` — 264/264 pass
  across all 10 files.
- `npm run build` (`tsc --project tsconfig.build.json`) clean before and
  after each test run in every round — the tests import the compiled
  `clients/*.js` output, not the `.ts` source directly.
- Full suite left to CI, per project policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpSQeAhgjMTDskzyVMmjFH

