### PR TITLE
fix(tree-sitter): fail closed on malformed textPredicates (closes #1523)

### DIFF
--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -13,7 +13,8 @@ export type DegradationKind =
 	| "formatter-failure"
 	| "wasm-abort"
 	| "lsp-diagnostics-timeout"
-	| "bus-stale";
+	| "bus-stale"
+	| "query-predicates-invalid";
 
 export interface DegradationRecord {
 	kind: unknown;

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -20,6 +20,10 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
+import {
+	recordDegradation,
+	recordDegradationOnce,
+} from "./degradation-ledger.js";
 import { loadWebTreeSitter } from "./deps/web-tree-sitter.js";
 import { getProjectIgnoreMatcher, isExcludedDirName } from "./file-utils.js";
 import {
@@ -28,7 +32,6 @@ import {
 	LANGUAGE_TO_GRAMMAR,
 } from "./grammar-source.js";
 import { resolvePackagePath } from "./package-root.js";
-import { recordDegradation } from "./degradation-ledger.js";
 import {
 	assertInstallAllowed,
 	getProjectTrustGeneration,
@@ -2765,8 +2768,7 @@ export class TreeSitterClient {
 			}
 			case "eq_mod_fn": {
 				// Belt-and-braces re-check of the #eq? predicates that
-				// evaluatePredicates already enforces (clients/tree-sitter-client.ts),
-				// plus the first-argument check that predicates can't express.
+				// evaluatePredicates already enforces (clients/tree-sitter-client.ts).
 				// This filter re-applies the #eq? checks at post_filter time.
 				const mod = captures.MOD?.text ?? "";
 				const fn = captures.FN?.text ?? "";
@@ -3608,11 +3610,15 @@ export class TreeSitterClient {
 	private queriesWithInvalidTextPredicates = new WeakSet<any>();
 
 	/**
-	 * Session-level latch so the "textPredicates is malformed" diagnostic logs
-	 * once total, not once per Query object. Query results are cached with LRU
-	 * eviction (see the query cache above), so a stripped/renamed property would
-	 * otherwise re-trigger this log on every cache rebuild for the life of the
-	 * session — unbounded log volume for what is, functionally, one event.
+	 * Latch so the "textPredicates is malformed" diagnostic log line fires once
+	 * per `TreeSitterClient` instance for the life of the process (this client is
+	 * a process-wide singleton in production — see clients/tree-sitter-shared.ts),
+	 * not once per Query object. Query results are cached with LRU eviction (see
+	 * the query cache above), so a stripped/renamed property would otherwise
+	 * re-trigger this log on every cache rebuild — unbounded log volume for what
+	 * is, functionally, one event. This gates ONLY the log line: process-wide
+	 * log volume is the concern here, not the user-facing degradation record
+	 * below, which must re-arm every session (see recordDegradationOnce).
 	 */
 	private textPredicatesInvalidLogged = false;
 
@@ -3624,8 +3630,8 @@ export class TreeSitterClient {
 	 * #match?/#eq? predicates that rules rely on for correctness, and because this
 	 * runs for every match of every query, it would zero out ALL structural matches
 	 * across every language while pi-lens reports "no issues found." Fail loud (log
-	 * once per session, record a degradation so it reaches the user) and closed
-	 * (report the query has no usable predicates) instead of guessing.
+	 * once per client instance, record a degradation so it reaches the user) and
+	 * closed (report the query has no usable predicates) instead of guessing.
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter Query instances
 	private hasValidTextPredicates(query: any): boolean {
@@ -3643,19 +3649,24 @@ export class TreeSitterClient {
 						"for this query are dropped rather than reported unfiltered.",
 					metadata: { textPredicatesType: typeof query?.textPredicates },
 				});
-				// User-facing signal (#1523 review F1): without this, the blackout is
-				// invisible outside tree-sitter.log — pi-lens silently reports "no
-				// issues found" for every structural rule in every language instead
-				// of surfacing that its predicate evaluation is degraded.
-				recordDegradation({
-					kind: "query-predicates-invalid",
-					subject: "web-tree-sitter",
-					reason:
-						"Query.textPredicates is missing or not an array — #match?/#eq? " +
-						"predicates cannot be evaluated; structural matches relying on them " +
-						"are dropped fail-closed",
-				});
 			}
+			// User-facing signal (#1523 review F1), re-armed every session via the
+			// ledger's own once-per-kind/subject dedupe (recordDegradationOnce's
+			// onceKeys is cleared by resetDegradationLedger, which handleSessionStart
+			// calls first thing — clients/runtime-session.ts). The TreeSitterClient
+			// singleton and its `textPredicatesInvalidLogged` latch above both
+			// survive session_start, so gating this on that same boolean would make
+			// the blackout invisible from session 2 onward (review R1, AGENTS.md
+			// shape 10). Single source of truth: let the ledger own this dedupe
+			// instead of hand-rolling a second one here.
+			recordDegradationOnce({
+				kind: "query-predicates-invalid",
+				subject: "web-tree-sitter",
+				reason:
+					"Query.textPredicates is missing or not an array — #match?/#eq? " +
+					"predicates cannot be evaluated; structural matches relying on them " +
+					"are dropped fail-closed",
+			});
 		}
 		return valid;
 	}

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -3597,14 +3597,56 @@ export class TreeSitterClient {
 	}
 
 	/**
+	 * Queries whose `textPredicates` shape has been checked (#1523). web-tree-sitter
+	 * compiles #match?/#eq? predicates into `query.textPredicates[patternIndex]`, but
+	 * the property is untyped and undocumented on the public Query type. Validate its
+	 * shape once per Query object rather than on every match.
+	 */
+	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter Query instances
+	private queriesWithInvalidTextPredicates = new WeakSet<any>();
+	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter Query instances
+	private queriesWithValidatedTextPredicates = new WeakSet<any>();
+
+	/**
+	 * Typed accessor for `query.textPredicates`, validated once at query-construction
+	 * (first-use) time. If the property is missing or the wrong shape — e.g. a future
+	 * web-tree-sitter upgrade renames or removes it — `query.textPredicates?.[i] ?? []`
+	 * would silently mean "no predicates for this pattern," passing every match through
+	 * unfiltered. That's a silent fail-open on #match?/#eq? predicates that rules rely
+	 * on for correctness. Fail loud (log once) and closed (report the query has no
+	 * usable predicates) instead of guessing.
+	 */
+	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter Query instances
+	private hasValidTextPredicates(query: any): boolean {
+		if (this.queriesWithValidatedTextPredicates.has(query)) {
+			return !this.queriesWithInvalidTextPredicates.has(query);
+		}
+		this.queriesWithValidatedTextPredicates.add(query);
+		const valid = Array.isArray(query?.textPredicates);
+		if (!valid) {
+			this.queriesWithInvalidTextPredicates.add(query);
+			logTreeSitterDiagnostic({
+				subsystem: "tree-sitter-client",
+				message:
+					"web-tree-sitter Query.textPredicates is missing or not an array — " +
+					"#match?/#eq? predicates cannot be evaluated. Failing CLOSED: matches " +
+					"for this query are dropped rather than reported unfiltered.",
+				metadata: { textPredicatesType: typeof query?.textPredicates },
+			});
+		}
+		return valid;
+	}
+
+	/**
 	 * Evaluate text predicates (#match?, #eq?) for a query match.
 	 * web-tree-sitter stores these as compiled functions in query.textPredicates[patternIndex]
 	 * and does NOT apply them automatically via .matches().
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter types
 	private evaluatePredicates(query: any, match: any): boolean {
+		if (!this.hasValidTextPredicates(query)) return false;
 		const predicates: Array<(captures: unknown) => boolean> =
-			query.textPredicates?.[match.patternIndex] ?? [];
+			query.textPredicates[match.patternIndex] ?? [];
 		return predicates.every((fn) => fn(match.captures));
 	}
 

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -2764,20 +2764,19 @@ export class TreeSitterClient {
 				return !hasExceptionSpec;
 			}
 			case "eq_mod_fn": {
-				// Workaround for web-tree-sitter not auto-applying #eq? predicates
-				// on the structural pattern of a query that has predicates. The
-				// query captures @MOD, @FN but the predicates aren't enforced
-				// (see evaluatePredicates in clients/tree-sitter-client.ts).
+				// Belt-and-braces re-check of the #eq? predicates that
+				// evaluatePredicates already enforces (clients/tree-sitter-client.ts),
+				// plus the first-argument check that predicates can't express.
 				// This filter re-applies the #eq? checks at post_filter time.
 				const mod = captures.MOD?.text ?? "";
 				const fn = captures.FN?.text ?? "";
 				return mod === "threading" && fn === "Thread";
 			}
 			case "regex_first_arg_identifier": {
-				// Workaround for web-tree-sitter not auto-applying #eq?/#match?
-				// predicates on the structural pattern (see evaluatePredicates).
-				// This post_filter re-applies both predicate checks AND
-				// the first-argument check:
+				// Belt-and-braces re-check of the #eq?/#match? predicates that
+				// evaluatePredicates already enforces, plus the first-argument
+				// check that predicates can't express. This post_filter re-applies
+				// both predicate checks AND the first-argument check:
 				// 1. MOD must be "re"  (would-be #eq? @MOD "re")
 				// 2. FUNC must match the regex method pattern (#match? @FUNC ...)
 				// 3. First arg must be an identifier (dynamic pattern)
@@ -3597,56 +3596,88 @@ export class TreeSitterClient {
 	}
 
 	/**
-	 * Queries whose `textPredicates` shape has been checked (#1523). web-tree-sitter
-	 * compiles #match?/#eq? predicates into `query.textPredicates[patternIndex]`, but
-	 * the property is untyped and undocumented on the public Query type. Validate its
-	 * shape once per Query object rather than on every match.
+	 * Queries whose `textPredicates` shape has already failed validation (#1523).
+	 * web-tree-sitter compiles #match?/#eq? predicates into
+	 * `query.textPredicates[patternIndex]`, but the property is untyped and
+	 * undocumented on the public Query type. `Array.isArray` is O(1), so re-checking
+	 * it on every match costs nothing — this WeakSet exists only so a query that's
+	 * already known-bad short-circuits without re-deriving that verdict, not to
+	 * memoize the check itself.
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter Query instances
 	private queriesWithInvalidTextPredicates = new WeakSet<any>();
-	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter Query instances
-	private queriesWithValidatedTextPredicates = new WeakSet<any>();
 
 	/**
-	 * Typed accessor for `query.textPredicates`, validated once at query-construction
-	 * (first-use) time. If the property is missing or the wrong shape — e.g. a future
-	 * web-tree-sitter upgrade renames or removes it — `query.textPredicates?.[i] ?? []`
-	 * would silently mean "no predicates for this pattern," passing every match through
-	 * unfiltered. That's a silent fail-open on #match?/#eq? predicates that rules rely
-	 * on for correctness. Fail loud (log once) and closed (report the query has no
-	 * usable predicates) instead of guessing.
+	 * Session-level latch so the "textPredicates is malformed" diagnostic logs
+	 * once total, not once per Query object. Query results are cached with LRU
+	 * eviction (see the query cache above), so a stripped/renamed property would
+	 * otherwise re-trigger this log on every cache rebuild for the life of the
+	 * session — unbounded log volume for what is, functionally, one event.
+	 */
+	private textPredicatesInvalidLogged = false;
+
+	/**
+	 * Typed accessor for `query.textPredicates`. If the property is missing or the
+	 * wrong shape — e.g. a future web-tree-sitter upgrade renames or removes it —
+	 * `query.textPredicates?.[i] ?? []` would silently mean "no predicates for this
+	 * pattern," passing every match through unfiltered. That's a silent fail-open on
+	 * #match?/#eq? predicates that rules rely on for correctness, and because this
+	 * runs for every match of every query, it would zero out ALL structural matches
+	 * across every language while pi-lens reports "no issues found." Fail loud (log
+	 * once per session, record a degradation so it reaches the user) and closed
+	 * (report the query has no usable predicates) instead of guessing.
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter Query instances
 	private hasValidTextPredicates(query: any): boolean {
-		if (this.queriesWithValidatedTextPredicates.has(query)) {
-			return !this.queriesWithInvalidTextPredicates.has(query);
-		}
-		this.queriesWithValidatedTextPredicates.add(query);
+		if (this.queriesWithInvalidTextPredicates.has(query)) return false;
 		const valid = Array.isArray(query?.textPredicates);
 		if (!valid) {
 			this.queriesWithInvalidTextPredicates.add(query);
-			logTreeSitterDiagnostic({
-				subsystem: "tree-sitter-client",
-				message:
-					"web-tree-sitter Query.textPredicates is missing or not an array — " +
-					"#match?/#eq? predicates cannot be evaluated. Failing CLOSED: matches " +
-					"for this query are dropped rather than reported unfiltered.",
-				metadata: { textPredicatesType: typeof query?.textPredicates },
-			});
+			if (!this.textPredicatesInvalidLogged) {
+				this.textPredicatesInvalidLogged = true;
+				logTreeSitterDiagnostic({
+					subsystem: "tree-sitter-client",
+					message:
+						"web-tree-sitter Query.textPredicates is missing or not an array — " +
+						"#match?/#eq? predicates cannot be evaluated. Failing CLOSED: matches " +
+						"for this query are dropped rather than reported unfiltered.",
+					metadata: { textPredicatesType: typeof query?.textPredicates },
+				});
+				// User-facing signal (#1523 review F1): without this, the blackout is
+				// invisible outside tree-sitter.log — pi-lens silently reports "no
+				// issues found" for every structural rule in every language instead
+				// of surfacing that its predicate evaluation is degraded.
+				recordDegradation({
+					kind: "query-predicates-invalid",
+					subject: "web-tree-sitter",
+					reason:
+						"Query.textPredicates is missing or not an array — #match?/#eq? " +
+						"predicates cannot be evaluated; structural matches relying on them " +
+						"are dropped fail-closed",
+				});
+			}
 		}
 		return valid;
 	}
 
 	/**
-	 * Evaluate text predicates (#match?, #eq?) for a query match.
-	 * web-tree-sitter stores these as compiled functions in query.textPredicates[patternIndex]
-	 * and does NOT apply them automatically via .matches().
+	 * Evaluate text predicates (#match?, #eq?) for a query match. web-tree-sitter
+	 * 0.25's `Query.matches()` DOES apply these predicates itself (probed on the
+	 * shipped grammars — see clients/tree-sitter-symbol-extractor.ts), so this is a
+	 * belt-and-braces re-filter, not a workaround for missing enforcement. It also
+	 * doubles as the fail-closed guard (#1523): if `query.textPredicates` is ever
+	 * missing or malformed, this drops the match instead of assuming it already
+	 * passed upstream.
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter types
 	private evaluatePredicates(query: any, match: any): boolean {
 		if (!this.hasValidTextPredicates(query)) return false;
+		// `?.` guards a post-validation removal of the property (e.g. a later
+		// mutation strips it after the first successful check) so the read can't
+		// throw here — an uncaught throw would be swallowed by the outer try/catch
+		// in searchFileWithQuery and silently zero out matches for the whole file.
 		const predicates: Array<(captures: unknown) => boolean> =
-			query.textPredicates[match.patternIndex] ?? [];
+			query.textPredicates?.[match.patternIndex] ?? [];
 		return predicates.every((fn) => fn(match.captures));
 	}
 
@@ -3682,7 +3713,9 @@ export class TreeSitterClient {
 							}
 						}
 
-						// Evaluate #match? and #eq? predicates that web-tree-sitter doesn't enforce automatically
+						// Belt-and-braces re-check of #match?/#eq? predicates (web-tree-sitter
+						// 0.25's Query.matches() already applies them) plus the fail-closed
+						// guard for a malformed query.textPredicates (see evaluatePredicates).
 						if (!this.evaluatePredicates(query, match)) {
 							continue;
 						}

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -3598,27 +3598,14 @@ export class TreeSitterClient {
 	}
 
 	/**
-	 * Queries whose `textPredicates` shape has already failed validation (#1523).
-	 * web-tree-sitter compiles #match?/#eq? predicates into
-	 * `query.textPredicates[patternIndex]`, but the property is untyped and
-	 * undocumented on the public Query type. `Array.isArray` is O(1), so re-checking
-	 * it on every match costs nothing — this WeakSet exists only so a query that's
-	 * already known-bad short-circuits without re-deriving that verdict, not to
-	 * memoize the check itself.
-	 */
-	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter Query instances
-	private queriesWithInvalidTextPredicates = new WeakSet<any>();
-
-	/**
 	 * Latch so the "textPredicates is malformed" diagnostic log line fires once
 	 * per `TreeSitterClient` instance for the life of the process (this client is
 	 * a process-wide singleton in production — see clients/tree-sitter-shared.ts),
-	 * not once per Query object. Query results are cached with LRU eviction (see
-	 * the query cache above), so a stripped/renamed property would otherwise
-	 * re-trigger this log on every cache rebuild — unbounded log volume for what
-	 * is, functionally, one event. This gates ONLY the log line: process-wide
-	 * log volume is the concern here, not the user-facing degradation record
-	 * below, which must re-arm every session (see recordDegradationOnce).
+	 * not once per call. This gates ONLY the log line: process-wide log volume is
+	 * the concern here, not the user-facing degradation record below, which must
+	 * re-arm every session (see recordDegradationOnce) — including for a Query
+	 * object the LRU query cache (queryCache/queryBatchCache above) kept alive
+	 * across a session boundary, since the cache is evicted, never cleared.
 	 */
 	private textPredicatesInvalidLogged = false;
 
@@ -3632,13 +3619,23 @@ export class TreeSitterClient {
 	 * across every language while pi-lens reports "no issues found." Fail loud (log
 	 * once per client instance, record a degradation so it reaches the user) and
 	 * closed (report the query has no usable predicates) instead of guessing.
+	 *
+	 * No WeakSet short-circuit for already-known-bad queries here (#1523 review
+	 * R1): `Array.isArray` is O(1), so memoizing it buys nothing, and a
+	 * process-lifetime WeakSet would make the SAME cached Query object (the query
+	 * cache is LRU-evicted, never cleared) skip straight past
+	 * `recordDegradationOnce` on every call after the first — which is exactly
+	 * what made the degradation record fail to re-arm across a session boundary
+	 * for a query the cache kept warm. `recordDegradationOnce` itself is called
+	 * unconditionally on every invalid check; the ledger's own once-per-kind/
+	 * subject dedupe (cleared by resetDegradationLedger, which handleSessionStart
+	 * calls first thing — clients/runtime-session.ts) is the single source of
+	 * truth for "how often does this actually get recorded."
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: web-tree-sitter Query instances
 	private hasValidTextPredicates(query: any): boolean {
-		if (this.queriesWithInvalidTextPredicates.has(query)) return false;
 		const valid = Array.isArray(query?.textPredicates);
 		if (!valid) {
-			this.queriesWithInvalidTextPredicates.add(query);
 			if (!this.textPredicatesInvalidLogged) {
 				this.textPredicatesInvalidLogged = true;
 				logTreeSitterDiagnostic({
@@ -3650,15 +3647,9 @@ export class TreeSitterClient {
 					metadata: { textPredicatesType: typeof query?.textPredicates },
 				});
 			}
-			// User-facing signal (#1523 review F1), re-armed every session via the
-			// ledger's own once-per-kind/subject dedupe (recordDegradationOnce's
-			// onceKeys is cleared by resetDegradationLedger, which handleSessionStart
-			// calls first thing — clients/runtime-session.ts). The TreeSitterClient
-			// singleton and its `textPredicatesInvalidLogged` latch above both
-			// survive session_start, so gating this on that same boolean would make
-			// the blackout invisible from session 2 onward (review R1, AGENTS.md
-			// shape 10). Single source of truth: let the ledger own this dedupe
-			// instead of hand-rolling a second one here.
+			// User-facing signal (#1523 review F1). Called unconditionally on every
+			// invalid check (not gated by a client-lifetime latch) so it re-arms
+			// every session, per the R1 fix above.
 			recordDegradationOnce({
 				kind: "query-predicates-invalid",
 				subject: "web-tree-sitter",

--- a/tests/clients/tree-sitter-1523-textpredicates-fail-closed.test.ts
+++ b/tests/clients/tree-sitter-1523-textpredicates-fail-closed.test.ts
@@ -1,0 +1,65 @@
+/**
+ * evaluatePredicates fails closed on malformed textPredicates (#1523).
+ *
+ * web-tree-sitter compiles #match?/#eq? predicates into an undocumented,
+ * untyped `query.textPredicates[patternIndex]` array. The old implementation
+ * read it as `query.textPredicates?.[patternIndex] ?? []` — if a future
+ * web-tree-sitter upgrade renames or drops that property, the `?? []`
+ * silently means "no predicates," and every match is reported as if its
+ * #match?/#eq? predicates passed. These tests prove the fix fails CLOSED
+ * (drops the match) instead of failing open (passes it) when the property
+ * is missing or the wrong shape.
+ */
+import { describe, expect, it } from "vitest";
+import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
+
+// biome-ignore lint/suspicious/noExplicitAny: reaching a private method for a focused unit test
+function evaluatePredicates(client: TreeSitterClient, query: any, match: any): boolean {
+	return (client as any).evaluatePredicates(query, match);
+}
+
+// A predicate that would reject every match — if it silently ran, the match
+// would be dropped. We use it to prove the fail-closed path never even
+// reaches predicate evaluation when the array is malformed.
+const alwaysFalse = () => false;
+
+describe("evaluatePredicates fails closed on malformed textPredicates (#1523)", () => {
+	it("drops the match when textPredicates is entirely missing (stripped/renamed property)", () => {
+		const client = new TreeSitterClient();
+		// A real web-tree-sitter Query object always has a textPredicates array.
+		// Simulate an upstream removal/rename by constructing one without it.
+		const query = {} as { textPredicates?: unknown };
+		const match = { patternIndex: 0, captures: [] };
+
+		// Fail-closed: the match must be dropped (predicates unverifiable),
+		// never silently reported as "no predicates, pass".
+		expect(evaluatePredicates(client, query, match)).toBe(false);
+	});
+
+	it("drops the match when textPredicates is the wrong shape (not an array)", () => {
+		const client = new TreeSitterClient();
+		const query = { textPredicates: undefined as unknown };
+		const match = { patternIndex: 0, captures: [] };
+
+		expect(evaluatePredicates(client, query, match)).toBe(false);
+	});
+
+	it("still evaluates real predicates normally when textPredicates is a valid array", () => {
+		const client = new TreeSitterClient();
+		const query = { textPredicates: [[alwaysFalse]] };
+		const match = { patternIndex: 0, captures: [] };
+
+		// Valid shape, predicate says no: still fails, but for the RIGHT reason
+		// (the predicate itself), not because the shape was unverifiable.
+		expect(evaluatePredicates(client, query, match)).toBe(false);
+	});
+
+	it("passes a match with no predicates for its pattern, given a valid textPredicates array", () => {
+		const client = new TreeSitterClient();
+		// Pattern 0 has predicates; pattern 1 legitimately has none defined.
+		const query = { textPredicates: [[alwaysFalse]] };
+		const match = { patternIndex: 1, captures: [] };
+
+		expect(evaluatePredicates(client, query, match)).toBe(true);
+	});
+});

--- a/tests/clients/tree-sitter-1523-textpredicates-fail-closed.test.ts
+++ b/tests/clients/tree-sitter-1523-textpredicates-fail-closed.test.ts
@@ -10,11 +10,19 @@
  * (drops the match) instead of failing open (passes it) when the property
  * is missing or the wrong shape.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
 import { TreeSitterClient } from "../../clients/tree-sitter-client.js";
 
 // biome-ignore lint/suspicious/noExplicitAny: reaching a private method for a focused unit test
-function evaluatePredicates(client: TreeSitterClient, query: any, match: any): boolean {
+function evaluatePredicates(
+	client: TreeSitterClient,
+	query: any,
+	match: any,
+): boolean {
 	return (client as any).evaluatePredicates(query, match);
 }
 
@@ -24,6 +32,10 @@ function evaluatePredicates(client: TreeSitterClient, query: any, match: any): b
 const alwaysFalse = () => false;
 
 describe("evaluatePredicates fails closed on malformed textPredicates (#1523)", () => {
+	afterEach(() => {
+		resetDegradationLedger();
+	});
+
 	it("drops the match when textPredicates is entirely missing (stripped/renamed property)", () => {
 		const client = new TreeSitterClient();
 		// A real web-tree-sitter Query object always has a textPredicates array.
@@ -61,5 +73,60 @@ describe("evaluatePredicates fails closed on malformed textPredicates (#1523)", 
 		const match = { patternIndex: 1, captures: [] };
 
 		expect(evaluatePredicates(client, query, match)).toBe(true);
+	});
+
+	it("records a degradation when textPredicates is malformed, so the blackout reaches the user (#1523 review F1)", () => {
+		const client = new TreeSitterClient();
+		const query = {} as { textPredicates?: unknown };
+		const match = { patternIndex: 0, captures: [] };
+
+		evaluatePredicates(client, query, match);
+
+		expect(getDegradationSummary()).toEqual([
+			expect.objectContaining({
+				kind: "query-predicates-invalid",
+				count: 1,
+			}),
+		]);
+	});
+
+	it("logs the malformed-textPredicates degradation once per session, not once per Query object (#1523 review F2)", () => {
+		const client = new TreeSitterClient();
+		const match = { patternIndex: 0, captures: [] };
+
+		// Simulate the LRU query cache rebuilding: a fresh Query object each time
+		// (as would happen on cache eviction), each with the same stripped shape.
+		evaluatePredicates(client, {} as { textPredicates?: unknown }, match);
+		evaluatePredicates(client, {} as { textPredicates?: unknown }, match);
+		evaluatePredicates(client, {} as { textPredicates?: unknown }, match);
+
+		// One event recorded per query (fail-closed still applies to each), but the
+		// underlying diagnostic log is a session-level latch — the degradation count
+		// still reflects one record per offending query object, but must not grow
+		// unbounded from re-validating the exact same Query instance.
+		const summary = getDegradationSummary();
+		expect(summary).toHaveLength(1);
+		expect(summary[0]).toMatchObject({ kind: "query-predicates-invalid" });
+	});
+
+	it("fails closed without throwing when textPredicates is removed after a prior successful validation (#1523 review F3)", () => {
+		const client = new TreeSitterClient();
+		const query: { textPredicates?: unknown } = {
+			textPredicates: [[alwaysFalse]],
+		};
+		const match = { patternIndex: 0, captures: [] };
+
+		// First evaluation: valid shape, evaluates normally.
+		expect(evaluatePredicates(client, query, match)).toBe(false);
+
+		// Simulate a post-validation removal of the property on the SAME query
+		// object (e.g. a later mutation strips it after the first successful check).
+		delete query.textPredicates;
+
+		// Must fail closed (drop the match), not throw — a throw here would be
+		// swallowed by searchFileWithQuery's outer catch and silently zero out
+		// every match in the file instead of just this one.
+		expect(() => evaluatePredicates(client, query, match)).not.toThrow();
+		expect(evaluatePredicates(client, query, match)).toBe(false);
 	});
 });

--- a/tests/clients/tree-sitter-1523-textpredicates-fail-closed.test.ts
+++ b/tests/clients/tree-sitter-1523-textpredicates-fail-closed.test.ts
@@ -113,12 +113,21 @@ describe("evaluatePredicates fails closed on malformed textPredicates (#1523)", 
 		});
 	});
 
-	it("re-records the degradation after a session boundary (#1523 review R1)", () => {
+	it("re-records the degradation after a session boundary, for the SAME cached Query object (#1523 review R1)", () => {
 		const client = new TreeSitterClient();
 		const match = { patternIndex: 0, captures: [] };
+		// One Query object, reused across the reset boundary below. This is the
+		// realistic case: queryCache/queryBatchCache (clients/tree-sitter-client.ts
+		// ~:189/:191) are LRU-EVICTED only, never cleared — a session boundary does
+		// NOT force a fresh Query object. A prior version of this test handed
+		// session 2 a fresh `{}`, which passed even with a process-lifetime
+		// short-circuit that skipped recordDegradationOnce for any already-seen
+		// query — the exact bug R1 identifies. Reusing the same object here is
+		// what actually exercises that path.
+		const query = {} as { textPredicates?: unknown };
 
 		// Session 1: a stripped query blackout gets recorded.
-		evaluatePredicates(client, {} as { textPredicates?: unknown }, match);
+		evaluatePredicates(client, query, match);
 		expect(getDegradationSummary()).toEqual([
 			expect.objectContaining({ kind: "query-predicates-invalid", count: 1 }),
 		]);
@@ -127,15 +136,16 @@ describe("evaluatePredicates fails closed on malformed textPredicates (#1523)", 
 		// first thing (clients/runtime-session.ts), but the TreeSitterClient
 		// singleton survives it (clients/tree-sitter-shared.ts only nulls it on
 		// a WASM abort) — so `client` here stands in for session 2 reusing the
-		// same warm instance.
+		// same warm instance, and `query` stands in for the same cached Query
+		// object surviving with it.
 		resetDegradationLedger();
 		expect(getDegradationSummary()).toEqual([]);
 
-		// Session 2: the SAME stripped-query condition recurs (a different Query
-		// object, since the query cache doesn't survive either, but the same
-		// upstream malformation). The blackout must be visible again, not
-		// permanently silenced by a latch that never re-arms.
-		evaluatePredicates(client, {} as { textPredicates?: unknown }, match);
+		// Session 2: the exact same Query object flows through evaluatePredicates
+		// again (e.g. a cache hit on a query that was never evicted). The
+		// blackout must be visible again, not permanently silenced by a
+		// process-lifetime short-circuit that never re-arms.
+		evaluatePredicates(client, query, match);
 		expect(getDegradationSummary()).toEqual([
 			expect.objectContaining({ kind: "query-predicates-invalid", count: 1 }),
 		]);

--- a/tests/clients/tree-sitter-1523-textpredicates-fail-closed.test.ts
+++ b/tests/clients/tree-sitter-1523-textpredicates-fail-closed.test.ts
@@ -90,7 +90,7 @@ describe("evaluatePredicates fails closed on malformed textPredicates (#1523)", 
 		]);
 	});
 
-	it("logs the malformed-textPredicates degradation once per session, not once per Query object (#1523 review F2)", () => {
+	it("records the malformed-textPredicates degradation once, not once per Query object (#1523 review F2)", () => {
 		const client = new TreeSitterClient();
 		const match = { patternIndex: 0, captures: [] };
 
@@ -100,13 +100,45 @@ describe("evaluatePredicates fails closed on malformed textPredicates (#1523)", 
 		evaluatePredicates(client, {} as { textPredicates?: unknown }, match);
 		evaluatePredicates(client, {} as { textPredicates?: unknown }, match);
 
-		// One event recorded per query (fail-closed still applies to each), but the
-		// underlying diagnostic log is a session-level latch — the degradation count
-		// still reflects one record per offending query object, but must not grow
-		// unbounded from re-validating the exact same Query instance.
+		// Three distinct offending Query objects must still collapse to ONE
+		// ledger record. Asserting only `toHaveLength(1)` on the kind list is
+		// vacuous here — a single kind bucket has length 1 whether it holds one
+		// record or three, so it can't tell a working dedupe from a missing one.
+		// Assert the record COUNT instead.
 		const summary = getDegradationSummary();
 		expect(summary).toHaveLength(1);
-		expect(summary[0]).toMatchObject({ kind: "query-predicates-invalid" });
+		expect(summary[0]).toMatchObject({
+			kind: "query-predicates-invalid",
+			count: 1,
+		});
+	});
+
+	it("re-records the degradation after a session boundary (#1523 review R1)", () => {
+		const client = new TreeSitterClient();
+		const match = { patternIndex: 0, captures: [] };
+
+		// Session 1: a stripped query blackout gets recorded.
+		evaluatePredicates(client, {} as { textPredicates?: unknown }, match);
+		expect(getDegradationSummary()).toEqual([
+			expect.objectContaining({ kind: "query-predicates-invalid", count: 1 }),
+		]);
+
+		// Session boundary: handleSessionStart calls resetDegradationLedger()
+		// first thing (clients/runtime-session.ts), but the TreeSitterClient
+		// singleton survives it (clients/tree-sitter-shared.ts only nulls it on
+		// a WASM abort) — so `client` here stands in for session 2 reusing the
+		// same warm instance.
+		resetDegradationLedger();
+		expect(getDegradationSummary()).toEqual([]);
+
+		// Session 2: the SAME stripped-query condition recurs (a different Query
+		// object, since the query cache doesn't survive either, but the same
+		// upstream malformation). The blackout must be visible again, not
+		// permanently silenced by a latch that never re-arms.
+		evaluatePredicates(client, {} as { textPredicates?: unknown }, match);
+		expect(getDegradationSummary()).toEqual([
+			expect.objectContaining({ kind: "query-predicates-invalid", count: 1 }),
+		]);
 	});
 
 	it("fails closed without throwing when textPredicates is removed after a prior successful validation (#1523 review F3)", () => {


### PR DESCRIPTION
## What

`evaluatePredicates` in `clients/tree-sitter-client.ts` read web-tree-sitter's
undocumented, untyped `query.textPredicates[patternIndex]` as
`query.textPredicates?.[patternIndex] ?? []`. If that property were ever
renamed or dropped by a web-tree-sitter upgrade, the `?? []` fallback would
silently mean "no predicates," and every match would pass regardless of its
`#match?`/`#eq?` predicates — a correctness-critical filter turned into a
no-op with no error, no log, nothing.

## Why

`#match?`/`#eq?` predicates are how many tree-sitter rules narrow structural
matches to the actual defect. `evaluatePredicates` is a belt-and-braces
re-filter — web-tree-sitter 0.25's `Query.matches()` already applies these
predicates itself (probed on the shipped grammars, documented in
`clients/tree-sitter-symbol-extractor.ts`) — plus the fail-closed guard this
PR adds. Silently passing every predicate on a shape mismatch would make
every predicate-bearing rule fire on every structural match, with no signal
that anything had gone wrong.

## Fix

- Added `hasValidTextPredicates(query)`. If `query.textPredicates` isn't an
  array, it logs and `evaluatePredicates` fails CLOSED (drops the match)
  instead of failing open (passing it).
- Legitimate "no predicates defined for this specific pattern" (a valid
  array, just an empty/undefined slot at that index) is unaffected — matches
  for patterns with no predicates still pass.

## Review round

An adversarial review of the first version found four defects, all fixed in
the second commit:

- **F1 (High) — silent kill switch.** The original fail-closed guard only
  wrote a `tree-sitter.log` line. `evaluatePredicates` runs for every match
  of every query, so an upstream rename would zero out ALL structural
  matches in all languages while pi-lens reported "no issues found," with
  nothing user-facing. Added a `recordDegradation` call (same mechanism used
  elsewhere in this file for wasm aborts and blocked grammars) so the
  blackout reaches the user as a degradation, not just a log line.
- **F2 (Medium) — unbounded re-logging.** "Once per Query object" isn't
  "once per session": the query cache is LRU with eviction, so a stripped
  property would re-log on every cache rebuild for the life of a session.
  Replaced the per-Query validated-WeakSet with a single boolean latch for
  the log (superseded by round 3 below, which splits the log latch from the
  degradation record).
- **F3 (Low) — a `?.` regressed to a non-optional index read** on the
  memoized-valid path. If the property vanished post-validation, the read
  would throw, get swallowed by the outer `catch`, and silently zero out
  every match in the file. Restored the `?.`.
- **F4 (Low) — two WeakSets did the job of one.** `Array.isArray` is O(1);
  only the log needed memoizing, not the check itself. Collapsed to a single
  WeakSet (for known-bad short-circuiting) plus the boolean log latch, and
  dropped the second WeakSet.
- **F5 (Doc) — inaccurate comments.** Three comments in this file claimed
  web-tree-sitter doesn't auto-apply `#match?`/`#eq?` predicates, contradicting
  `clients/tree-sitter-symbol-extractor.ts:533`, which documents that 0.25's
  `Query.matches()` DOES apply them (probed on the shipped grammars).
  Corrected all three to describe `evaluatePredicates` as a belt-and-braces
  re-filter plus the fail-closed guard, not a workaround for missing
  enforcement.

Round-2 verification of the fix above confirmed F1/F3/F5 landed correctly
(the reviewer probed the rendered degradation line, both post-validation
mutation directions, and the grammar-level predicate behavior) and found two
further defects, fixed in the third commit:

- **R1 (High) — the degradation never re-arms across sessions.** F1's fix
  gated the `recordDegradation` call behind the SAME instance boolean that
  latches the log line. `resetDegradationLedger()` is the first line of
  `handleSessionStart` (`clients/runtime-session.ts`), but the
  `TreeSitterClient` singleton survives `session_start`
  (`clients/tree-sitter-shared.ts` only nulls it on a WASM abort) — so after
  session 1, further stripped queries kept failing closed but the ledger
  rendered clean. The blackout went invisible from session 2 onward
  (AGENTS.md defect shape 10). Fixed by switching to
  `recordDegradationOnce({ kind: "query-predicates-invalid", ... })`: its own
  `onceKeys` set is cleared by `resetDegradationLedger()`, so it re-records
  exactly once per session. The instance boolean now gates ONLY the
  `logTreeSitterDiagnostic` line, where unbounded per-Query log volume (not
  session boundaries) is the actual concern — single source of truth, the
  ledger owns its own dedupe instead of a hand-rolled second one.
- **R2 (Medium) — the F2 test was vacuous.**
  `expect(summary).toHaveLength(1)` counts kind buckets, not records, so it
  passed even with the dedupe removed (mutation-proven: reverting to an
  unconditional `recordDegradation` call still produced a `summary` of
  length 1, just with `count: 3`). Strengthened the assertion to
  `summary[0].count === 1`, and added a new test that calls
  `resetDegradationLedger()` between two blackouts and asserts the record
  comes back — binding R1 directly. Retitled the test (nothing about
  logging is assertable — `logTreeSitterDiagnostic` early-returns under
  `isTestMode()`) and fixed the now-false "one record per offending query
  object" comment.
- **R3 (Low) — copy-pasted comment.** The `eq_mod_fn` post_filter comment
  claimed "plus the first-argument check that predicates can't express,"
  copy-pasted from the neighboring `regex_first_arg_identifier` case.
  `eq_mod_fn`'s body is just `mod === "threading" && fn === "Thread"` — no
  first-argument check exists there. Removed the false clause.
- **R4 (Low) — inaccurate latch scope in the JSDoc.** Said the log latch was
  "once per session"; it's actually once per `TreeSitterClient` instance for
  the life of the process (a singleton in production). Corrected the
  wording as part of the R1 fix.

Round-3 verification confirmed R2/R3/R4 fixed (via the reviewer's own
mutations) and found one residual, fixed in the fourth commit:

- **R1 residual (High) — the WeakSet short-circuit still blocked replay for
  the SAME cached Query object.** Round 3 fixed `recordDegradationOnce`
  re-arming after a reset, but `hasValidTextPredicates` still opened with
  `if (this.queriesWithInvalidTextPredicates.has(query)) return false;` —
  a process-lifetime WeakSet. `queryCache`/`queryBatchCache` are LRU-evicted
  only, never cleared, so a Query object that stays warm across a session
  boundary hits that early return and never reaches `recordDegradationOnce`
  again: sessions 2-5 read an empty ledger while matches kept silently
  dropping. The round-3 regression test only proved the reset path worked
  because it handed a fresh `{}` to session 2 each time, side-stepping the
  WeakSet entirely — its "the query cache doesn't survive either" comment
  was false. Fixed (reviewer-prescribed) by deleting the WeakSet outright:
  `Array.isArray` is O(1), so memoizing it bought nothing, and the only
  effect it had was suppressing the degradation record on repeat calls —
  the opposite of what a session-scoped record needs.
  `hasValidTextPredicates` now computes `valid` fresh every call and calls
  `recordDegradationOnce` unconditionally when invalid; the ledger's own
  once-per-kind/subject dedupe is the sole source of truth for record
  frequency.

## Class sweep

Grepped `clients/` for the same shape — `(x as any).prop ?? <permissive
default>` reads against third-party/undocumented objects. Nothing else
matched that exact shape. The closest sibling is `jscpd-client.ts:324`
(`data.statistics?.total ?? {}` on jscpd's JSON output), but that's a
different domain (missing stats produce an empty report, not a silently
passed security/correctness predicate) and out of scope for this fix.

## Verification

**First round:**
- New regression test:
  `tests/clients/tree-sitter-1523-textpredicates-fail-closed.test.ts`.
- Confirmed RED on pre-fix code (via `git diff > fix.patch` +
  `git checkout -- clients/tree-sitter-client.ts`, never `git stash`):
  ```
  × drops the match when textPredicates is entirely missing (stripped/renamed property)
    AssertionError: expected true to be false
  × drops the match when textPredicates is the wrong shape (not an array)
    AssertionError: expected true to be false
  ```
- GREEN after `git apply fix.patch` + rebuild: 4/4 new tests pass.
- Ran the broader tree-sitter predicate/post-filter suites to confirm no
  regression on real `#match?`/`#eq?` rules: `tree-sitter-879-post-filters`,
  `tree-sitter-query-batch`, `tree-sitter-query-884`,
  `tree-sitter-python-rules`, `tree-sitter-command-injection-rules`,
  `tree-sitter-security-gap-rules`, `tree-sitter-884-rules` — 178/178 passed.

**Review round (this update):**
- Added 3 new assertions to the same test file, one per testable finding:
  F1 (a malformed `textPredicates` records a `query-predicates-invalid`
  degradation), F2 (three fresh Query objects with the same bad shape log
  through the once-per-session latch, not once-per-Query), F3 (a property
  removed after a prior successful validation fails closed without
  throwing). `logTreeSitterDiagnostic` early-returns under `isTestMode()`,
  so the log line itself isn't assertable in vitest — the degradation
  record is, and that's what these assert.
- Confirmed RED on pre-review-round code (`git diff > fix1523.patch` +
  `git checkout -- clients/tree-sitter-client.ts clients/degradation-ledger.ts`,
  never `git stash`): all 3 new assertions failed, including the F3 test
  actually throwing `TypeError: Cannot read properties of undefined
  (reading '0')` — the exact defect the finding described.
- GREEN after `git apply fix1523.patch` + rebuild: all 7 tests in the file
  pass.
- `npm run build` (`tsc --project tsconfig.build.json`) run clean before
  every test invocation.
- Full targeted suite: `npx vitest run tests/clients/tree-sitter-*.test.ts`
  — 436 passed, 3 skipped (26 files), beating the prior review's 429/3
  baseline by the 7 tests added to this file.

**Round 3 (this update, R1/R2/R3/R4):**
- Strengthened the F2 test (`count === 1` instead of `toHaveLength(1)`) and
  added a new test: record, `resetDegradationLedger()`, record again,
  assert the record reappears.
- Confirmed RED on pre-round-3 code (`git diff clients/tree-sitter-client.ts
  > round3_client.patch` + `git checkout -- clients/tree-sitter-client.ts`,
  never `git stash`): the new reset-boundary test failed —
  `expected [] to deeply equal [ ObjectContaining{…} ]`, i.e. the ledger
  stayed empty after the reset, reproducing R1 exactly.
- Mutation-proved the strengthened F2 assertion: with the client fix
  reverted, hand-mutated `hasValidTextPredicates` to call
  `recordDegradation` unconditionally (removing the dedupe R1 replaces).
  Re-ran the suite — the `count === 1` assertion failed with
  `count: 3` (three distinct stripped Query objects, no dedupe), the exact
  failure the old vacuous `toHaveLength(1)` assertion would have missed.
  Reverted the mutation and reapplied the real fix (`git checkout --` +
  `git apply round3_client.patch`).
- GREEN after the real fix: all 8 tests in the file pass.
- `npm run build` (`tsc --project tsconfig.build.json`) run clean before
  every test invocation.
- Full targeted suite: `npx vitest run tests/clients/tree-sitter-*.test.ts
  tests/clients/degradation-ledger.test.ts` — 450 passed, 3 skipped
  (27 files), beating round 2's reviewer baseline of 449/3.

**Round 4 (this update, R1 residual):**
- Rewrote the R1 test to reuse ONE Query object across the
  `resetDegradationLedger()` boundary, instead of a fresh `{}` per call —
  the realistic case, since `queryCache`/`queryBatchCache` are LRU-evicted
  only and a session boundary doesn't force a fresh Query object.
- Confirmed RED on pre-round-4 code (`git diff clients/tree-sitter-client.ts
  > round4_client.patch` + `git checkout -- clients/tree-sitter-client.ts`,
  never `git stash`): the reused-object version failed —
  `expected [] to deeply equal [ ObjectContaining{…} ]` — the ledger stayed
  empty after the reset for the same Query object, reproducing the R1
  residual exactly as the reviewer's probe described.
- GREEN after `git apply round4_client.patch` + rebuild: all 8 tests in the
  file pass.
- `npm run build` (`tsc --project tsconfig.build.json`) run clean before
  every test invocation.
- Full targeted suite: `npx vitest run tests/clients/tree-sitter-*.test.ts
  tests/clients/degradation-ledger.test.ts` — 450 passed, 3 skipped
  (27 files), matching round 3's baseline.
- Full suite deferred to CI (concurrent-agent test-contention policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpSQeAhgjMTDskzyVMmjFH


