### PR TITLE
fix(tests): Windows-agnostic v8-coverage fixture, absolute reach floors (closes #1521)

### DIFF
--- a/tests/clients/profiling-coverage.test.ts
+++ b/tests/clients/profiling-coverage.test.ts
@@ -13,25 +13,54 @@
  * `walkTreeStackAsync` and reimplementing the walk inline — barely moves the
  * 8-file aggregate (source-walker.js is one of eight files, and other
  * callers of the shared walker still exercise most of it), so the ratio
- * floor never tripped. This guard now uses PER-MODULE absolute
- * function-count floors (deterministic reach on the fixed TREE_SIZE
- * fixture — no timing, so no ambient-noise headroom needed) plus explicit
- * named-must-execute checks for the two delegation entry points #1521 named,
- * so a bypass of either one fails this test directly instead of hiding
- * inside an aggregate that "cannot fail."
+ * floor never tripped. This guard uses PER-MODULE absolute function-count
+ * floors (deterministic reach on the fixed TREE_SIZE fixture — no timing, so
+ * no ambient-noise headroom needed) plus direct call-site proofs, so a
+ * bypass fails this test directly instead of hiding inside an aggregate that
+ * "cannot fail."
+ *
+ * #1521 review round 2 fixed two further gaps in that first pass:
+ *
+ *  - `clients/path-utils.js` is itself platform-branched (`normalizeFilePath`,
+ *    `normalizeEphemeralMapKey` early-return on non-win32; downstream,
+ *    `safe-spawn.ts`'s win32-only git-binary check reaches
+ *    `isFullyQualifiedWin32`). A function-count floor measured on Windows
+ *    does not hold on Linux CI for this file — the exact defect shape 2 this
+ *    guard otherwise exists to catch. `path-utils.js` is EXCLUDED from
+ *    `MIN_FUNCTIONS_HIT` and covered instead by `MUST_EXECUTE_FUNCTIONS`
+ *    entries confirmed to sit behind OS-agnostic call sites (see the comment
+ *    above that constant).
+ *
+ *  - The combined workload calls `collectSourceFilesAsync` (source-filter.ts)
+ *    AND `countSourceFilesWithinLimitAsync` (startup-scan.ts), and BOTH
+ *    delegate to `source-walker.ts`'s `walkTreeStackAsync`. A V8-coverage
+ *    named-hit check against the combined capture proves only "someone
+ *    reached walkTreeStackAsync," not that source-filter.ts's OWN delegation
+ *    does — an async-only bypass of source-filter's call site would stay
+ *    invisible (startup-scan's separate call keeps the function marked
+ *    hit). A second V8-coverage capture scoped to just `collectSourceFilesAsync`
+ *    was tried and rejected: sharing a process with the combined-capture test
+ *    left previously-JIT-warmed functions in `file-utils.js`/`path-utils.js`
+ *    invisible to the LATER capture (V8 precise coverage only reliably
+ *    instruments a function across a fresh `startPreciseCoverage` window if
+ *    it hasn't already been optimized away in an earlier window), which
+ *    silently corrupted the unrelated function-count floors below. Per-call-
+ *    site delegation is proven with `vi.spyOn` instead — a call-graph fact,
+ *    not a coverage-instrumentation artifact, so it carries no such risk.
  */
 
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { _resetGeneratedArtifactCaches } from "../../clients/generated-artifacts.js";
 import { detectProjectLanguageProfileAsync } from "../../clients/language-profile.js";
 import {
 	collectSourceFiles,
 	collectSourceFilesAsync,
 } from "../../clients/source-filter.js";
+import * as sourceWalker from "../../clients/source-walker.js";
 import { countSourceFilesWithinLimitAsync } from "../../clients/startup-scan.js";
 import { generateSourceTree } from "../support/perf-harness.js";
 import {
@@ -60,39 +89,59 @@ const MIN_FILES_TOUCHED = HOT_PATH.length;
 
 /**
  * Absolute per-module function-count floors (#1521), measured against a
- * local run of this fixture (functionsHit / functionCount):
+ * local (Windows) run of this fixture (functionsHit / functionCount):
  *   file-kinds.js 2/2, file-utils.js 31/32, generated-artifacts.js 17/17,
- *   language-profile.js 9/9, path-utils.js 16/16, source-filter.js 30/34,
- *   source-walker.js 11/11, startup-scan.js 6/6.
+ *   language-profile.js 9/9, source-filter.js 30/34, source-walker.js 11/11,
+ *   startup-scan.js 6/6.
  * Each floor keeps a small margin (1-3 functions) for the one path known to
  * vary with filesystem/cache state (the generated-header content probe in
  * `source-filter.ts`), NOT for ambient timing noise — this metric is
  * deterministic reach on a fixed synthetic tree, so the margin stays tight
  * enough that dropping even one meaningfully-sized module's function trips
  * its own floor instead of hiding in an aggregate.
+ *
+ * `clients/path-utils.js` is deliberately absent — see the file header.
  */
-const MIN_FUNCTIONS_HIT: Record<(typeof HOT_PATH)[number], number> = {
+const MIN_FUNCTIONS_HIT: Partial<Record<(typeof HOT_PATH)[number], number>> = {
 	"clients/file-kinds.js": 2,
 	"clients/file-utils.js": 29,
 	"clients/generated-artifacts.js": 16,
 	"clients/language-profile.js": 8,
-	"clients/path-utils.js": 15,
 	"clients/source-filter.js": 27,
 	"clients/source-walker.js": 10,
 	"clients/startup-scan.js": 5,
 };
 
 /**
- * Named must-execute functions (#1521) — the two shared-walker delegation
- * entry points the guard exists to protect. `source-filter.ts`'s sync
- * collector calls ONLY `walkTreeRecursiveSync` for its traversal and no
- * other hot-path caller reaches it, so bypassing that delegation (e.g.
- * reimplementing the walk inline instead of calling through
- * `source-walker.ts`) zeroes this function specifically while barely
- * denting the file's aggregate percentage or the 8-file rollup.
+ * Named must-execute functions (#1521), covering `clients/path-utils.js`
+ * only — the shared-walker delegation entry points are proven separately via
+ * `vi.spyOn` below (see the file header for why). Each entry's CALL SITE
+ * (not necessarily the callee's own internal branching) was confirmed
+ * OS-independent by reading the actual code path this workload exercises —
+ * function-level coverage only needs the function invoked, not which
+ * internal branch ran, so a callee that branches on `process.platform`
+ * internally (e.g. `normalizeFilePath`) is still safe to require as long as
+ * every caller reaches it unconditionally:
+ *   - `normalizeFilePath`/`normalizeMapKey`: `language-profile.ts`'s
+ *     project-profile cache.
+ *   - `normalizeEphemeralMapKey`: `source-filter.ts`'s sibling-probe cache.
+ *   - `direntsHaveMarkerGlobMatch`/`nameMatchesMarkerGlob`:
+ *     `language-profile.ts`'s marker-glob scan.
+ *   - `isWindowsPath`: `generated-artifacts.ts`'s `basenameForShape`,
+ *     checked for every candidate file regardless of platform.
+ * Deliberately EXCLUDES `isFullyQualifiedWin32`, which IS platform-gated
+ * (only reachable via `safe-spawn.ts`'s win32-only git-binary validation
+ * branch) and so cannot appear in a cross-OS list.
  */
 const MUST_EXECUTE_FUNCTIONS: Record<string, readonly string[]> = {
-	"clients/source-walker.js": ["walkTreeRecursiveSync", "walkTreeStackAsync"],
+	"clients/path-utils.js": [
+		"normalizeFilePath",
+		"normalizeMapKey",
+		"normalizeEphemeralMapKey",
+		"direntsHaveMarkerGlobMatch",
+		"nameMatchesMarkerGlob",
+		"isWindowsPath",
+	],
 };
 
 let tmpDir: string;
@@ -110,9 +159,19 @@ beforeEach(() => {
 	_resetGeneratedArtifactCaches();
 });
 
+// The coverage-measuring describe block runs FIRST and deliberately owns the
+// only `it` in this file that calls the hot-path functions before any other
+// test has (see file header on why a second/later capture — or even just a
+// prior plain, uninstrumented call in the same process — leaves already-
+// JIT-warmed functions in `file-utils.js`/`path-utils.js` invisible to a
+// LATER V8 precise-coverage capture and corrupts the function-count floors).
+// The `vi.spyOn` delegation tests below run second for exactly this reason:
+// they don't measure coverage, so running after is safe, but running BEFORE
+// silently shrank `file-utils.js`'s measured function count during review
+// (31/32 dropped to 15/15) — caught by rerunning locally, not by inspection.
 describe(`profiling coverage of walk/profile hot path (~${TREE_SIZE} files)`, () => {
 	it(
-		"executes a minimum share of functions and blocks in the hot-path clients",
+		"executes a minimum share of functions in the hot-path clients",
 		{ timeout: 30_000 },
 		async () => {
 			const { result, scripts } = await withPreciseCoverage(async () => {
@@ -135,42 +194,23 @@ describe(`profiling coverage of walk/profile hot path (~${TREE_SIZE} files)`, ()
 			const missing = HOT_PATH.filter(
 				(file) => !summary.files.some((entry) => entry.file === file && entry.functionsHit > 0),
 			);
-
 			expect(
 				missing,
 				`hot-path modules with zero executed functions: ${missing.join(", ") || "(none)"}`,
 			).toEqual([]);
 			expect(summary.filesTouched).toBeGreaterThanOrEqual(MIN_FILES_TOUCHED);
 
-			// Per-module absolute function-count floors (#1521) — replaces the
-			// 8-file aggregate ratio a module-scoped regression could hide inside.
-			const shortfalls = HOT_PATH.filter((file) => {
-				const entry = summary.files.find((f) => f.file === file);
-				return (entry?.functionsHit ?? 0) < MIN_FUNCTIONS_HIT[file];
-			}).map((file) => {
-				const entry = summary.files.find((f) => f.file === file);
-				return `${file}: ${entry?.functionsHit ?? 0}/${MIN_FUNCTIONS_HIT[file]} functions`;
-			});
-			expect(shortfalls, `modules under their function-count floor: ${shortfalls.join(", ") || "(none)"}`).toEqual(
-				[],
-			);
-
-			// Named must-execute functions (#1521) — the shared-walker delegation
-			// entry points a bypass would silently skip without moving the
-			// per-file function count enough to trip the floor above.
-			const executedByFile = new Map<string, Set<string>>();
-			for (const script of scripts) {
-				const file = fileFromScriptUrl(script.url, repoRoot);
-				if (!file) continue;
-				const hit = executedByFile.get(file) ?? new Set<string>();
-				for (const fn of script.functions) {
-					if (fn.ranges.some((range) => range.count > 0)) hit.add(fn.functionName);
-				}
-				executedByFile.set(file, hit);
-			}
+			// Named must-execute functions (#1521, path-utils.js only — see the
+			// comment above MUST_EXECUTE_FUNCTIONS) checked BEFORE the per-module
+			// floor below, so a failure here always reports on its own merit
+			// rather than being masked by the floor check throwing first.
 			const missingNamed: string[] = [];
 			for (const [file, names] of Object.entries(MUST_EXECUTE_FUNCTIONS)) {
-				const hit = executedByFile.get(file) ?? new Set<string>();
+				const script = scripts.find((s) => fileFromScriptUrl(s.url, repoRoot) === file);
+				const hit = new Set<string>();
+				for (const fn of script?.functions ?? []) {
+					if (fn.ranges.some((range) => range.count > 0)) hit.add(fn.functionName);
+				}
 				for (const name of names) {
 					if (!hit.has(name)) missingNamed.push(`${file}#${name}`);
 				}
@@ -179,6 +219,72 @@ describe(`profiling coverage of walk/profile hot path (~${TREE_SIZE} files)`, ()
 				missingNamed,
 				`must-execute functions never called: ${missingNamed.join(", ") || "(none)"}`,
 			).toEqual([]);
+
+			// Per-module absolute function-count floors (#1521) — replaces the
+			// 8-file aggregate ratio a module-scoped regression could hide inside.
+			// Message reports hit/floor AND the module's total functionCount, so a
+			// misfire from an intentional refactor (functionCount itself dropped —
+			// recalibrate the floor) reads differently from a real regression
+			// (functionCount unchanged, hit dropped — functions exist but never
+			// ran).
+			const shortfalls = Object.entries(MIN_FUNCTIONS_HIT)
+				.filter(([file, floor]) => {
+					const entry = summary.files.find((f) => f.file === file);
+					return (entry?.functionsHit ?? 0) < (floor ?? 0);
+				})
+				.map(([file, floor]) => {
+					const entry = summary.files.find((f) => f.file === file);
+					return `${file}: ${entry?.functionsHit ?? 0}/${floor} functions hit (module has ${entry?.functionCount ?? 0} total)`;
+				});
+			expect(
+				shortfalls,
+				`modules under their function-count floor: ${shortfalls.join(", ") || "(none)"}`,
+			).toEqual([]);
+
+			// Block-level signal (#1521 review round 2, finding 4): the original
+			// aggregate `blockPct` floor is dropped rather than replaced with a
+			// per-module absolute block-count floor. Block counts are FINER-grained
+			// than function counts (a single function's internal branches can vary
+			// by filesystem/cache state — see source-filter.ts's generated-header
+			// probe — independent of any platform difference), so an absolute
+			// per-module block floor measured on Windows would misfire on Linux CI
+			// even for platform-INDEPENDENT files, for reasons unrelated to a real
+			// regression. Function-level floors plus the `vi.spyOn` delegation
+			// proofs below (a spied call necessarily executed at least one block of
+			// its target) are the chosen trade-off: falsifiable and OS-stable, at
+			// the cost of aggregate block-percentage signal for regressions that
+			// change control flow WITHIN an already-reached function.
 		},
 	);
+});
+
+describe("shared-walker delegation call sites (#1521)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// Per-call-site proof, not coverage-instrumentation inference: a spy is a
+	// direct call-graph fact, so it can't be fooled by (or corrupt) V8
+	// coverage windows the way a second precise-coverage capture would (see
+	// file header). `source-filter.ts`'s sync collector is source-walker.ts's
+	// ONLY caller of `walkTreeRecursiveSync` in this codebase today, but the
+	// spy proves it directly rather than relying on that staying true.
+	it("collectSourceFiles (sync) calls walkTreeRecursiveSync directly", () => {
+		const spy = vi.spyOn(sourceWalker, "walkTreeRecursiveSync");
+		const files = collectSourceFiles(tmpDir);
+		expect(files.length).toBeGreaterThan(0);
+		expect(spy).toHaveBeenCalled();
+	});
+
+	// `startup-scan.ts`'s countSourceFilesWithinLimitAsync ALSO calls
+	// walkTreeStackAsync, so a workload that exercises both callers can't
+	// tell which one produced a coverage hit — this test calls ONLY
+	// collectSourceFilesAsync, so the spy assertion is per-call-site evidence
+	// for source-filter.ts's own delegation specifically.
+	it("collectSourceFilesAsync (async) calls walkTreeStackAsync directly", async () => {
+		const spy = vi.spyOn(sourceWalker, "walkTreeStackAsync");
+		const files = await collectSourceFilesAsync(tmpDir);
+		expect(files.length).toBeGreaterThan(0);
+		expect(spy).toHaveBeenCalled();
+	});
 });

--- a/tests/clients/profiling-coverage.test.ts
+++ b/tests/clients/profiling-coverage.test.ts
@@ -15,52 +15,39 @@
  * callers of the shared walker still exercise most of it), so the ratio
  * floor never tripped. This guard uses PER-MODULE absolute function-count
  * floors (deterministic reach on the fixed TREE_SIZE fixture — no timing, so
- * no ambient-noise headroom needed) plus direct call-site proofs, so a
- * bypass fails this test directly instead of hiding inside an aggregate that
- * "cannot fail."
+ * no ambient-noise headroom needed), so a bypass fails this test directly
+ * instead of hiding inside an aggregate that "cannot fail."
  *
- * #1521 review round 2 fixed two further gaps in that first pass:
+ * The shared-walker delegation entry points (`walkTreeRecursiveSync`,
+ * `walkTreeStackAsync`) are proven separately, per call site, via
+ * `vi.spyOn` in `source-filter-walker-delegation.test.ts` — its own file,
+ * not a second `describe` here, because sharing a process with THIS file's
+ * coverage capture is unsafe: see that file's header for why (round 3
+ * review; a two-describe-block version in this same file was order-coupled
+ * and would misfire under `.only`/`-t`/`--sequence.shuffle`).
  *
- *  - `clients/path-utils.js` is itself platform-branched (`normalizeFilePath`,
- *    `normalizeEphemeralMapKey` early-return on non-win32; downstream,
- *    `safe-spawn.ts`'s win32-only git-binary check reaches
- *    `isFullyQualifiedWin32`). A function-count floor measured on Windows
- *    does not hold on Linux CI for this file — the exact defect shape 2 this
- *    guard otherwise exists to catch. `path-utils.js` is EXCLUDED from
- *    `MIN_FUNCTIONS_HIT` and covered instead by `MUST_EXECUTE_FUNCTIONS`
- *    entries confirmed to sit behind OS-agnostic call sites (see the comment
- *    above that constant).
- *
- *  - The combined workload calls `collectSourceFilesAsync` (source-filter.ts)
- *    AND `countSourceFilesWithinLimitAsync` (startup-scan.ts), and BOTH
- *    delegate to `source-walker.ts`'s `walkTreeStackAsync`. A V8-coverage
- *    named-hit check against the combined capture proves only "someone
- *    reached walkTreeStackAsync," not that source-filter.ts's OWN delegation
- *    does — an async-only bypass of source-filter's call site would stay
- *    invisible (startup-scan's separate call keeps the function marked
- *    hit). A second V8-coverage capture scoped to just `collectSourceFilesAsync`
- *    was tried and rejected: sharing a process with the combined-capture test
- *    left previously-JIT-warmed functions in `file-utils.js`/`path-utils.js`
- *    invisible to the LATER capture (V8 precise coverage only reliably
- *    instruments a function across a fresh `startPreciseCoverage` window if
- *    it hasn't already been optimized away in an earlier window), which
- *    silently corrupted the unrelated function-count floors below. Per-call-
- *    site delegation is proven with `vi.spyOn` instead — a call-graph fact,
- *    not a coverage-instrumentation artifact, so it carries no such risk.
+ * `clients/path-utils.js` is itself platform-branched (`normalizeFilePath`,
+ * `normalizeEphemeralMapKey` early-return on non-win32; downstream,
+ * `safe-spawn.ts`'s win32-only git-binary check reaches
+ * `isFullyQualifiedWin32`). A function-count floor measured on Windows does
+ * not hold on Linux CI for this file — the exact defect shape 2 this guard
+ * otherwise exists to catch. `path-utils.js` is EXEMPT from
+ * `MIN_FUNCTIONS_HIT` (see `FLOOR_EXEMPT`) and covered instead by
+ * `MUST_EXECUTE_FUNCTIONS` entries confirmed to sit behind OS-agnostic call
+ * sites (see the comment above that constant).
  */
 
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { _resetGeneratedArtifactCaches } from "../../clients/generated-artifacts.js";
 import { detectProjectLanguageProfileAsync } from "../../clients/language-profile.js";
 import {
 	collectSourceFiles,
 	collectSourceFilesAsync,
 } from "../../clients/source-filter.js";
-import * as sourceWalker from "../../clients/source-walker.js";
 import { countSourceFilesWithinLimitAsync } from "../../clients/startup-scan.js";
 import { generateSourceTree } from "../support/perf-harness.js";
 import {
@@ -88,6 +75,19 @@ const HOT_PATH = [
 const MIN_FILES_TOUCHED = HOT_PATH.length;
 
 /**
+ * Hot-path files EXEMPT from `MIN_FUNCTIONS_HIT` — single source of truth
+ * for "this file is deliberately unfloored," checked below by
+ * `assertFloorCoverageIsExhaustive` so a ninth `HOT_PATH` entry can't slip
+ * in unguarded by both the floor table and this set (#1521 review round 3,
+ * finding 4: a `Partial<Record<...>>` floor table alone permits silent
+ * omission with no error).
+ *
+ * `clients/path-utils.js`: see the file header — platform-branched, so a
+ * Windows-measured absolute floor does not hold on Linux CI.
+ */
+const FLOOR_EXEMPT = new Set<(typeof HOT_PATH)[number]>(["clients/path-utils.js"]);
+
+/**
  * Absolute per-module function-count floors (#1521), measured against a
  * local (Windows) run of this fixture (functionsHit / functionCount):
  *   file-kinds.js 2/2, file-utils.js 31/32, generated-artifacts.js 17/17,
@@ -99,10 +99,8 @@ const MIN_FILES_TOUCHED = HOT_PATH.length;
  * deterministic reach on a fixed synthetic tree, so the margin stays tight
  * enough that dropping even one meaningfully-sized module's function trips
  * its own floor instead of hiding in an aggregate.
- *
- * `clients/path-utils.js` is deliberately absent — see the file header.
  */
-const MIN_FUNCTIONS_HIT: Partial<Record<(typeof HOT_PATH)[number], number>> = {
+const MIN_FUNCTIONS_HIT: Record<Exclude<(typeof HOT_PATH)[number], "clients/path-utils.js">, number> = {
 	"clients/file-kinds.js": 2,
 	"clients/file-utils.js": 29,
 	"clients/generated-artifacts.js": 16,
@@ -113,10 +111,31 @@ const MIN_FUNCTIONS_HIT: Partial<Record<(typeof HOT_PATH)[number], number>> = {
 };
 
 /**
+ * Every `HOT_PATH` entry must be either floored (`MIN_FUNCTIONS_HIT`) or
+ * explicitly exempt (`FLOOR_EXEMPT`) — never silently neither. Runs once at
+ * module load (not inside an `it`) so a config mistake fails loudly on
+ * import rather than passing silently because the file it forgot to floor
+ * never got checked.
+ */
+function assertFloorCoverageIsExhaustive(): void {
+	const floored = new Set(Object.keys(MIN_FUNCTIONS_HIT));
+	const uncovered = HOT_PATH.filter((file) => !floored.has(file) && !FLOOR_EXEMPT.has(file));
+	if (uncovered.length > 0) {
+		throw new Error(
+			`HOT_PATH entries with neither a MIN_FUNCTIONS_HIT floor nor a FLOOR_EXEMPT entry: ${uncovered.join(", ")}`,
+		);
+	}
+	const both = HOT_PATH.filter((file) => floored.has(file) && FLOOR_EXEMPT.has(file));
+	if (both.length > 0) {
+		throw new Error(`HOT_PATH entries both floored and exempt (pick one): ${both.join(", ")}`);
+	}
+}
+assertFloorCoverageIsExhaustive();
+
+/**
  * Named must-execute functions (#1521), covering `clients/path-utils.js`
- * only — the shared-walker delegation entry points are proven separately via
- * `vi.spyOn` below (see the file header for why). Each entry's CALL SITE
- * (not necessarily the callee's own internal branching) was confirmed
+ * only (its `FLOOR_EXEMPT` replacement signal). Each entry's CALL SITE (not
+ * necessarily the callee's own internal branching) was confirmed
  * OS-independent by reading the actual code path this workload exercises —
  * function-level coverage only needs the function invoked, not which
  * internal branch ran, so a callee that branches on `process.platform`
@@ -159,16 +178,6 @@ beforeEach(() => {
 	_resetGeneratedArtifactCaches();
 });
 
-// The coverage-measuring describe block runs FIRST and deliberately owns the
-// only `it` in this file that calls the hot-path functions before any other
-// test has (see file header on why a second/later capture — or even just a
-// prior plain, uninstrumented call in the same process — leaves already-
-// JIT-warmed functions in `file-utils.js`/`path-utils.js` invisible to a
-// LATER V8 precise-coverage capture and corrupts the function-count floors).
-// The `vi.spyOn` delegation tests below run second for exactly this reason:
-// they don't measure coverage, so running after is safe, but running BEFORE
-// silently shrank `file-utils.js`'s measured function count during review
-// (31/32 dropped to 15/15) — caught by rerunning locally, not by inspection.
 describe(`profiling coverage of walk/profile hot path (~${TREE_SIZE} files)`, () => {
 	it(
 		"executes a minimum share of functions in the hot-path clients",
@@ -204,12 +213,21 @@ describe(`profiling coverage of walk/profile hot path (~${TREE_SIZE} files)`, ()
 			// comment above MUST_EXECUTE_FUNCTIONS) checked BEFORE the per-module
 			// floor below, so a failure here always reports on its own merit
 			// rather than being masked by the floor check throwing first.
+			//
+			// Accumulates hit function names across EVERY script entry that
+			// resolves to a given file (#1521 review round 3, finding 3), not
+			// just the first match `scripts.find()` would return — an ESM/CJS
+			// double-load or a URL-casing duplicate would otherwise silently
+			// drop coverage from a second entry for the same file, producing a
+			// false "never called" red.
 			const missingNamed: string[] = [];
 			for (const [file, names] of Object.entries(MUST_EXECUTE_FUNCTIONS)) {
-				const script = scripts.find((s) => fileFromScriptUrl(s.url, repoRoot) === file);
 				const hit = new Set<string>();
-				for (const fn of script?.functions ?? []) {
-					if (fn.ranges.some((range) => range.count > 0)) hit.add(fn.functionName);
+				for (const script of scripts) {
+					if (fileFromScriptUrl(script.url, repoRoot) !== file) continue;
+					for (const fn of script.functions) {
+						if (fn.ranges.some((range) => range.count > 0)) hit.add(fn.functionName);
+					}
 				}
 				for (const name of names) {
 					if (!hit.has(name)) missingNamed.push(`${file}#${name}`);
@@ -222,15 +240,18 @@ describe(`profiling coverage of walk/profile hot path (~${TREE_SIZE} files)`, ()
 
 			// Per-module absolute function-count floors (#1521) — replaces the
 			// 8-file aggregate ratio a module-scoped regression could hide inside.
-			// Message reports hit/floor AND the module's total functionCount, so a
-			// misfire from an intentional refactor (functionCount itself dropped —
-			// recalibrate the floor) reads differently from a real regression
-			// (functionCount unchanged, hit dropped — functions exist but never
-			// ran).
+			// Message reports hit/floor AND the module's total functionCount:
+			// V8 only lists functions actually compiled during THIS capture
+			// window (#1521's own finding), so under a genuine bypass
+			// functionCount drops WITH hit — that pairing (both down, same
+			// amount) is exactly what a lost call site looks like, NOT a signal
+			// to recalibrate the floor. Recalibrate only when the drop traces to
+			// an intentional refactor of the module itself (fewer functions
+			// defined, not fewer reached).
 			const shortfalls = Object.entries(MIN_FUNCTIONS_HIT)
 				.filter(([file, floor]) => {
 					const entry = summary.files.find((f) => f.file === file);
-					return (entry?.functionsHit ?? 0) < (floor ?? 0);
+					return (entry?.functionsHit ?? 0) < floor;
 				})
 				.map(([file, floor]) => {
 					const entry = summary.files.find((f) => f.file === file);
@@ -250,41 +271,11 @@ describe(`profiling coverage of walk/profile hot path (~${TREE_SIZE} files)`, ()
 			// per-module block floor measured on Windows would misfire on Linux CI
 			// even for platform-INDEPENDENT files, for reasons unrelated to a real
 			// regression. Function-level floors plus the `vi.spyOn` delegation
-			// proofs below (a spied call necessarily executed at least one block of
-			// its target) are the chosen trade-off: falsifiable and OS-stable, at
-			// the cost of aggregate block-percentage signal for regressions that
-			// change control flow WITHIN an already-reached function.
+			// proofs in `source-filter-walker-delegation.test.ts` (a spied call
+			// necessarily executed at least one block of its target) are the
+			// chosen trade-off: falsifiable and OS-stable, at the cost of
+			// aggregate block-percentage signal for regressions that change
+			// control flow WITHIN an already-reached function.
 		},
 	);
-});
-
-describe("shared-walker delegation call sites (#1521)", () => {
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
-
-	// Per-call-site proof, not coverage-instrumentation inference: a spy is a
-	// direct call-graph fact, so it can't be fooled by (or corrupt) V8
-	// coverage windows the way a second precise-coverage capture would (see
-	// file header). `source-filter.ts`'s sync collector is source-walker.ts's
-	// ONLY caller of `walkTreeRecursiveSync` in this codebase today, but the
-	// spy proves it directly rather than relying on that staying true.
-	it("collectSourceFiles (sync) calls walkTreeRecursiveSync directly", () => {
-		const spy = vi.spyOn(sourceWalker, "walkTreeRecursiveSync");
-		const files = collectSourceFiles(tmpDir);
-		expect(files.length).toBeGreaterThan(0);
-		expect(spy).toHaveBeenCalled();
-	});
-
-	// `startup-scan.ts`'s countSourceFilesWithinLimitAsync ALSO calls
-	// walkTreeStackAsync, so a workload that exercises both callers can't
-	// tell which one produced a coverage hit — this test calls ONLY
-	// collectSourceFilesAsync, so the spy assertion is per-call-site evidence
-	// for source-filter.ts's own delegation specifically.
-	it("collectSourceFilesAsync (async) calls walkTreeStackAsync directly", async () => {
-		const spy = vi.spyOn(sourceWalker, "walkTreeStackAsync");
-		const files = await collectSourceFilesAsync(tmpDir);
-		expect(files.length).toBeGreaterThan(0);
-		expect(spy).toHaveBeenCalled();
-	});
 });

--- a/tests/clients/profiling-coverage.test.ts
+++ b/tests/clients/profiling-coverage.test.ts
@@ -5,9 +5,20 @@
  * Occupancy tests (`source-walk-occupancy.test.ts`) guard event-loop stalls.
  * This is the complementary reach metric — pyinstrument-style "did the
  * profiler even touch the production modules" — using V8 precise coverage
- * on the in-place compiled clients. Thresholds sit below a measured local
- * run so ambient fork-pool noise cannot flake them, but a workload that
- * stops calling the walkers will fail.
+ * on the in-place compiled clients.
+ *
+ * #1521: the original guard checked an AGGREGATE ratio across all 8 hot-path
+ * files. A module-scoped regression — e.g. `source-filter.ts` silently
+ * bypassing its delegation to `source-walker.ts`'s `walkTreeRecursiveSync`/
+ * `walkTreeStackAsync` and reimplementing the walk inline — barely moves the
+ * 8-file aggregate (source-walker.js is one of eight files, and other
+ * callers of the shared walker still exercise most of it), so the ratio
+ * floor never tripped. This guard now uses PER-MODULE absolute
+ * function-count floors (deterministic reach on the fixed TREE_SIZE
+ * fixture — no timing, so no ambient-noise headroom needed) plus explicit
+ * named-must-execute checks for the two delegation entry points #1521 named,
+ * so a bypass of either one fails this test directly instead of hiding
+ * inside an aggregate that "cannot fail."
  */
 
 import * as fs from "node:fs";
@@ -24,6 +35,7 @@ import {
 import { countSourceFilesWithinLimitAsync } from "../../clients/startup-scan.js";
 import { generateSourceTree } from "../support/perf-harness.js";
 import {
+	fileFromScriptUrl,
 	summarizePreciseCoverage,
 	withPreciseCoverage,
 } from "../support/v8-coverage.js";
@@ -44,11 +56,44 @@ const HOT_PATH = [
 	"clients/startup-scan.js",
 ] as const;
 
-// Floors from a local measured run of this fixture (function 95.3%, block 68.1%,
-// all 8 files touched). Leave headroom for smaller hosts / cached header hits.
 const MIN_FILES_TOUCHED = HOT_PATH.length;
-const MIN_FUNCTION_PCT = 70;
-const MIN_BLOCK_PCT = 45;
+
+/**
+ * Absolute per-module function-count floors (#1521), measured against a
+ * local run of this fixture (functionsHit / functionCount):
+ *   file-kinds.js 2/2, file-utils.js 31/32, generated-artifacts.js 17/17,
+ *   language-profile.js 9/9, path-utils.js 16/16, source-filter.js 30/34,
+ *   source-walker.js 11/11, startup-scan.js 6/6.
+ * Each floor keeps a small margin (1-3 functions) for the one path known to
+ * vary with filesystem/cache state (the generated-header content probe in
+ * `source-filter.ts`), NOT for ambient timing noise — this metric is
+ * deterministic reach on a fixed synthetic tree, so the margin stays tight
+ * enough that dropping even one meaningfully-sized module's function trips
+ * its own floor instead of hiding in an aggregate.
+ */
+const MIN_FUNCTIONS_HIT: Record<(typeof HOT_PATH)[number], number> = {
+	"clients/file-kinds.js": 2,
+	"clients/file-utils.js": 29,
+	"clients/generated-artifacts.js": 16,
+	"clients/language-profile.js": 8,
+	"clients/path-utils.js": 15,
+	"clients/source-filter.js": 27,
+	"clients/source-walker.js": 10,
+	"clients/startup-scan.js": 5,
+};
+
+/**
+ * Named must-execute functions (#1521) — the two shared-walker delegation
+ * entry points the guard exists to protect. `source-filter.ts`'s sync
+ * collector calls ONLY `walkTreeRecursiveSync` for its traversal and no
+ * other hot-path caller reaches it, so bypassing that delegation (e.g.
+ * reimplementing the walk inline instead of calling through
+ * `source-walker.ts`) zeroes this function specifically while barely
+ * denting the file's aggregate percentage or the 8-file rollup.
+ */
+const MUST_EXECUTE_FUNCTIONS: Record<string, readonly string[]> = {
+	"clients/source-walker.js": ["walkTreeRecursiveSync", "walkTreeStackAsync"],
+};
 
 let tmpDir: string;
 
@@ -96,8 +141,44 @@ describe(`profiling coverage of walk/profile hot path (~${TREE_SIZE} files)`, ()
 				`hot-path modules with zero executed functions: ${missing.join(", ") || "(none)"}`,
 			).toEqual([]);
 			expect(summary.filesTouched).toBeGreaterThanOrEqual(MIN_FILES_TOUCHED);
-			expect(summary.functionPct).toBeGreaterThanOrEqual(MIN_FUNCTION_PCT);
-			expect(summary.blockPct).toBeGreaterThanOrEqual(MIN_BLOCK_PCT);
+
+			// Per-module absolute function-count floors (#1521) — replaces the
+			// 8-file aggregate ratio a module-scoped regression could hide inside.
+			const shortfalls = HOT_PATH.filter((file) => {
+				const entry = summary.files.find((f) => f.file === file);
+				return (entry?.functionsHit ?? 0) < MIN_FUNCTIONS_HIT[file];
+			}).map((file) => {
+				const entry = summary.files.find((f) => f.file === file);
+				return `${file}: ${entry?.functionsHit ?? 0}/${MIN_FUNCTIONS_HIT[file]} functions`;
+			});
+			expect(shortfalls, `modules under their function-count floor: ${shortfalls.join(", ") || "(none)"}`).toEqual(
+				[],
+			);
+
+			// Named must-execute functions (#1521) — the shared-walker delegation
+			// entry points a bypass would silently skip without moving the
+			// per-file function count enough to trip the floor above.
+			const executedByFile = new Map<string, Set<string>>();
+			for (const script of scripts) {
+				const file = fileFromScriptUrl(script.url, repoRoot);
+				if (!file) continue;
+				const hit = executedByFile.get(file) ?? new Set<string>();
+				for (const fn of script.functions) {
+					if (fn.ranges.some((range) => range.count > 0)) hit.add(fn.functionName);
+				}
+				executedByFile.set(file, hit);
+			}
+			const missingNamed: string[] = [];
+			for (const [file, names] of Object.entries(MUST_EXECUTE_FUNCTIONS)) {
+				const hit = executedByFile.get(file) ?? new Set<string>();
+				for (const name of names) {
+					if (!hit.has(name)) missingNamed.push(`${file}#${name}`);
+				}
+			}
+			expect(
+				missingNamed,
+				`must-execute functions never called: ${missingNamed.join(", ") || "(none)"}`,
+			).toEqual([]);
 		},
 	);
 });

--- a/tests/clients/source-filter-walker-delegation.test.ts
+++ b/tests/clients/source-filter-walker-delegation.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Per-call-site proof that `source-filter.ts`'s sync and async collectors
+ * each delegate directly to `source-walker.ts`'s shared walker engine
+ * (`walkTreeRecursiveSync` / `walkTreeStackAsync`), instead of silently
+ * reimplementing the walk inline (#1521).
+ *
+ * A spy is a call-graph fact, not a coverage-instrumentation artifact — this
+ * is deliberately its OWN test file (a separate vitest worker/process),
+ * not a second `describe` in `profiling-coverage.test.ts`. Round 3 review
+ * found the two-describe-block version order-coupled: the spy tests must
+ * run AFTER the coverage-capture test in that file, because merely CALLING
+ * the hot-path functions (even without coverage instrumentation active)
+ * JIT-warms `file-utils.js`/`path-utils.js` enough that a LATER V8
+ * precise-coverage capture in the same process silently loses functions
+ * (`file-utils.js` measured 15/15 instead of 31/32 during review) —
+ * corrupting the unrelated function-count floors. That ordering held only
+ * by declaration order and a prose comment: `.only`, a `-t` filter, or
+ * `--sequence.shuffle` could silently flip it. Splitting into a separate
+ * file removes the shared-process contract entirely — nothing in this file
+ * calls `withPreciseCoverage`, so there is nothing left to warm.
+ *
+ * `startup-scan.ts`'s `countSourceFilesWithinLimitAsync` ALSO calls
+ * `walkTreeStackAsync`, so a workload that exercises both callers can't
+ * tell which one produced a hit — each test below calls ONLY the ONE
+ * collector under test, so the spy assertion is per-call-site evidence for
+ * that collector's own delegation specifically.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+	collectSourceFiles,
+	collectSourceFilesAsync,
+} from "../../clients/source-filter.js";
+import * as sourceWalker from "../../clients/source-walker.js";
+import { generateSourceTree } from "../support/perf-harness.js";
+import { removeTempDirSync } from "./test-utils.js";
+
+const TREE_SIZE = 400;
+
+let tmpDir: string;
+
+beforeAll(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-walker-delegation-"));
+	generateSourceTree(tmpDir, TREE_SIZE);
+}, 60_000);
+
+afterAll(() => {
+	removeTempDirSync(tmpDir);
+});
+
+describe("shared-walker delegation call sites (#1521)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// `source-filter.ts`'s sync collector is source-walker.ts's ONLY caller of
+	// `walkTreeRecursiveSync` in this codebase today, but the spy proves it
+	// directly rather than relying on that staying true.
+	it("collectSourceFiles (sync) calls walkTreeRecursiveSync directly", () => {
+		const spy = vi.spyOn(sourceWalker, "walkTreeRecursiveSync");
+		const files = collectSourceFiles(tmpDir);
+		expect(files.length).toBeGreaterThan(0);
+		expect(spy).toHaveBeenCalled();
+	});
+
+	it("collectSourceFilesAsync (async) calls walkTreeStackAsync directly", async () => {
+		const spy = vi.spyOn(sourceWalker, "walkTreeStackAsync");
+		const files = await collectSourceFilesAsync(tmpDir);
+		expect(files.length).toBeGreaterThan(0);
+		expect(spy).toHaveBeenCalled();
+	});
+});

--- a/tests/support/v8-coverage.test.ts
+++ b/tests/support/v8-coverage.test.ts
@@ -1,17 +1,26 @@
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
 	fileFromScriptUrl,
 	summarizePreciseCoverage,
 } from "./v8-coverage.js";
 
-const root = "/repo";
+// Host-rooted, not a POSIX literal: on Windows `file:///repo/...` has no
+// drive letter and fileURLToPath() throws, so the fixture must derive an
+// absolute root via path.resolve and build URLs with pathToFileURL —
+// never hardcode a POSIX-shaped path or assume process.platform.
+const root = path.resolve(path.sep, "repo");
+const url = (...segments: string[]) => pathToFileURL(path.join(root, ...segments)).toString();
 
 describe("summarizePreciseCoverage", () => {
 	it("maps file URLs under root and ignores outsiders", () => {
-		expect(fileFromScriptUrl("file:///repo/clients/source-filter.js", root)).toBe(
+		expect(fileFromScriptUrl(url("clients", "source-filter.js"), root)).toBe(
 			"clients/source-filter.js",
 		);
-		expect(fileFromScriptUrl("file:///elsewhere/x.js", root)).toBeUndefined();
+		expect(
+			fileFromScriptUrl(pathToFileURL(path.resolve(path.sep, "elsewhere", "x.js")).toString(), root),
+		).toBeUndefined();
 		expect(fileFromScriptUrl("node:internal/process", root)).toBeUndefined();
 	});
 
@@ -19,18 +28,18 @@ describe("summarizePreciseCoverage", () => {
 		const summary = summarizePreciseCoverage(
 			[
 				{
-					url: "file:///repo/clients/hot.js",
+					url: url("clients", "hot.js"),
 					functions: [
 						{ functionName: "a", ranges: [{ count: 2 }, { count: 0 }] },
 						{ functionName: "b", ranges: [{ count: 0 }] },
 					],
 				},
 				{
-					url: "file:///repo/clients/cold.js",
+					url: url("clients", "cold.js"),
 					functions: [{ functionName: "c", ranges: [{ count: 0 }] }],
 				},
 				{
-					url: "file:///repo/tests/ignore.js",
+					url: url("tests", "ignore.js"),
 					functions: [{ functionName: "noise", ranges: [{ count: 9 }] }],
 				},
 			],


### PR DESCRIPTION
## What changed

**Part (a) — Windows-red fixture.** `tests/support/v8-coverage.test.ts`
hardcoded `file:///repo/...` (POSIX-shaped) file URLs. `fileURLToPath()`
throws on Windows for a URL with no drive letter, so `fileFromScriptUrl`
caught the error and returned `undefined` for every case, failing all
assertions. Fixed by deriving the root via `path.resolve(path.sep, "repo")`
and building URLs with `pathToFileURL` — matches shape 2 in AGENTS.md
(a POSIX literal fed to a normalizer that must handle both host shapes).

**Part (b) — reach floors that cannot fail.**
`tests/clients/profiling-coverage.test.ts` guarded reach with an 8-file
AGGREGATE ratio (`functionPct >= 70`, `blockPct >= 45`). A module-scoped
regression barely moves an 8-file aggregate, so the floor could not fail
on the mutation this issue names. Replaced with absolute per-module
function-count floors plus direct call-site proofs for the shared-walker
delegation.

## Review round 2

An adversarial review of the first pass found Linux CI red plus a blind
spot, both fixed at commit `676143c3`:

**Finding 1 (blocker) — floor calibrated on Windows flipped which OS broke.**
`clients/path-utils.ts` branches on `process.platform` (`normalizeFilePath`,
`normalizeEphemeralMapKey` early-return on non-win32; downstream,
`safe-spawn.ts`'s win32-only git-binary check reaches
`isFullyQualifiedWin32`), so the Windows-measured floor (16 hit) read only
14 on Linux CI — defect shape 2, reintroduced by a PR that cites defect
shape 2. Fix: excluded `path-utils.js` from the absolute-floor table
entirely; covers it instead with named must-execute functions whose CALL
SITES (read directly in the source, not inferred) are unconditional on
both OSes.

**Finding 2 (high) — guard blind to an async-only regression.** The named
check for `walkTreeStackAsync` only proved "someone called it" —
`startup-scan.ts` delegates to the same function as `source-filter.ts`, so
bypassing just source-filter's async delegation stayed invisible in a
combined-workload coverage capture. Fix: replaced both delegation checks
with `vi.spyOn` call-site proofs, each calling only the ONE collector under
test.

**Finding 3 (medium) — floor misfires read as regressions.** Shortfall
messages report `hit/floor` AND the module's total `functionCount`.

**Finding 4 (low) — block-level signal dropped.** Documented the trade-off
in a code comment.

## Review round 3 (final)

Round-2 verification confirmed all three round-1 findings fixed with the
reviewer's own mutations. Four residuals — one required, three cheap —
fixed at commit `c46873ab`:

**Required (finding 1) — the guard was order-coupled and misfired under
shuffle.** The round-2 fix put the `vi.spyOn` delegation checks in a
second `describe` in the SAME file as the coverage capture, defended only
by a prose comment saying the capture must run first (merely calling the
hot-path functions — even without coverage active — JIT-warms
`file-utils.js`/`path-utils.js`, so a coverage capture running AFTER the
spy tests silently lost functions: 15/15 instead of 31/32). `.only`, a
`-t` filter, or an inserted `describe` could flip that order silently.
Fix: moved the two spy tests into their own file,
`tests/clients/source-filter-walker-delegation.test.ts` — a separate
vitest process shares nothing with the coverage capture, so the ordering
contract is gone rather than merely documented.

**Cheap fix 2 — inverted floor-shortfall guidance.** The message told
readers "functionCount dropped → recalibrate the floor." Under the exact
regression this guard exists to catch, V8 only lists functions compiled
during the capture window (round 1's own finding), so under a genuine
bypass `functionCount` drops WITH `hit` — that pairing is exactly what a
lost call site looks like, not a signal to loosen the guard. Reworded:
recalibrate only when the drop traces to an intentional refactor of the
module itself.

**Cheap fix 3 — `scripts.find()` dropped duplicate script entries.** The
must-execute check kept only the first script entry resolving to a given
file; an ESM/CJS double-load or URL-casing duplicate would silently drop
coverage from a second entry, producing a false "never called" red.
Restored the accumulate-across-all-matching-entries form.

**Cheap fix 4 — silent-omission risk in the floor table.** `MIN_FUNCTIONS_HIT`
was a `Partial<Record<...>>`, so a ninth `HOT_PATH` file could go
unfloored with no error. Added an explicit `FLOOR_EXEMPT` set
(`path-utils.js`'s new home) plus a load-time assertion
(`assertFloorCoverageIsExhaustive`) that every `HOT_PATH` entry is either
floored or exempt, never neither — single source of truth, fails loudly
on import if violated.

## Verification

- Windows-local (this host), full targeted set:
  `npx vitest run tests/clients/profiling-coverage.test.ts tests/clients/source-filter-walker-delegation.test.ts tests/support/v8-coverage.test.ts tests/clients/source-filter-async.test.ts`
  → 4 files, 21 tests, green.
- **Shuffle-run proof (round 3 acceptance test):** `npx vitest run
  tests/clients/profiling-coverage.test.ts --sequence.shuffle`, run 3
  times with different seeds — all green (the file now contains a single
  `it`, since the order-coupled second `describe` moved out entirely, so
  there is structurally nothing left for shuffle to reorder).
- **Async-only mutation re-check against the new spy file:** reapplied the
  inline bypass of `walkTreeStackAsync` in `source-filter.ts` (sync path
  and `startup-scan.ts` untouched), rebuilt, reran
  `source-filter-walker-delegation.test.ts` — RED:
  `AssertionError: expected "walkTreeStackAsync" to be called at least
  once`. `profiling-coverage.test.ts` run alongside still PASSED on its
  own, confirming the split preserves each file's independent signal
  (the coverage floor genuinely can't see an async-only bypass; the spy
  file is what catches it, exactly as designed). Reverted — `git diff
  clients/source-filter.ts` empty — rebuilt, reran: green.
- `npm run build` ran clean before every test pass.
- Full suite deferred to CI (concurrent-agent test-contention policy).

## Linux CI (head `676143c3`, round 2)

- **Unit tests: success.**
- **Lint & type-check: success.**
- `Analyze (ruby)` (CodeQL) showed `failure` on that head but this PR
  touches only `.test.ts` files (no Ruby anywhere) — confirmed via `gh pr
  diff --name-only`. Not a required check, not caused by this PR.

CI on round 3's head (`c46873ab`) not yet confirmed at time of writing —
watch `gh pr checks 1526` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpSQeAhgjMTDskzyVMmjFH
