### PR TITLE
fix(lsp): split the java probe's timeout from genuine absence (closes #1538)

### DIFF
--- a/clients/lsp/jvm-runtime.ts
+++ b/clients/lsp/jvm-runtime.ts
@@ -153,21 +153,75 @@ let _cachedEnv: { value: NodeJS.ProcessEnv | undefined } | undefined;
  */
 const javaAvailabilityLatch = createAvailabilityLatch();
 
+/**
+ * Shared spawn while a probe is in flight (#1538 follow-up). Without this, two
+ * concurrent `resolveJavaRuntimeEnv` calls — e.g. a multi-root Java project
+ * spawning jdtls per root — each fire their own 5 s `where`/`which java`, and
+ * every expired cooldown reopens that window for the process's whole
+ * lifetime, not just at startup.
+ */
+let inFlightJavaProbe: Promise<boolean | undefined> | null = null;
+
 export function _resetJvmRuntimeCacheForTests(): void {
 	_cachedEnv = undefined;
 	javaAvailabilityLatch.reset();
+	inFlightJavaProbe = null;
 }
 
 /**
  * Probe `java` on PATH, distinguishing a durable verdict (found, or genuinely
  * absent) from a transient probe failure. Returns `true`/`false` for a durable
- * verdict; `undefined` when the probe was transient, so the caller must not
- * treat this call as proof `java` is absent.
+ * verdict; `undefined` when the probe was transient — including a memo served
+ * from mid-cooldown — so the caller must not treat this call as proof `java`
+ * is absent.
+ *
+ * `AvailabilityLatch.read()` returns `false` (not `null`) for BOTH a durable
+ * "not found" AND a transient verdict whose cooldown hasn't expired yet — the
+ * latch's own contract is "cache a safe fallback answer for this call", not
+ * "this is durable". Blindly forwarding that `false` as durable is exactly
+ * the #1538 bug moved one call deeper: jdtls's failed-spawn retry
+ * (`BROKEN_BASE_COOLDOWN_MS`, `clients/lsp/index.ts`) re-enters
+ * `resolveJavaRuntimeEnv` ~15-20 s later — inside this probe's 30 s transient
+ * cooldown — so the very first retry after a stall would otherwise still
+ * launder into the permanent `_cachedEnv`. Only `javaAvailabilityLatch`'s own
+ * `outcome` distinguishes the two; a durable verdict is never `"transient"`.
  */
-async function probeJavaOnPath(): Promise<boolean | undefined> {
+function probeJavaOnPath(): Promise<boolean | undefined> {
 	const memo = javaAvailabilityLatch.read();
-	if (memo !== null) return memo;
+	if (memo !== null) {
+		if (javaAvailabilityLatch.getOutcome() === "transient") {
+			// Served from the memo, but the cooldown from the earlier stall
+			// hasn't expired — this is NOT a durable verdict. Log it (otherwise
+			// this state leaves zero record in latency.log) and surface
+			// `undefined` so the caller never writes the session cache.
+			logAvailabilityDecision({
+				tool: "java",
+				verdict: "unavailable",
+				outcome: "transient",
+				cause: javaAvailabilityLatch.getCause() ?? "probe-timeout",
+				elapsedMs: 0,
+				latched: false,
+				retryAfterMs: Math.max(
+					0,
+					javaAvailabilityLatch.getRetryAtMs() - Date.now(),
+				),
+				budgetMs: JAVA_PROBE_TIMEOUT_MS,
+			});
+			return Promise.resolve(undefined);
+		}
+		return Promise.resolve(memo);
+	}
 
+	if (inFlightJavaProbe) return inFlightJavaProbe;
+	inFlightJavaProbe = runJavaProbe().finally(() => {
+		inFlightJavaProbe = null;
+	});
+	return inFlightJavaProbe;
+}
+
+/** The actual `where`/`which java` spawn + classification. Never call this
+ * directly — go through `probeJavaOnPath()`, which memoizes and dedupes it. */
+async function runJavaProbe(): Promise<boolean | undefined> {
 	const finder = process.platform === "win32" ? "where" : "which";
 	const startedAt = Date.now();
 	const sampler = startHostStallSampler();

--- a/clients/lsp/jvm-runtime.ts
+++ b/clients/lsp/jvm-runtime.ts
@@ -15,10 +15,17 @@
 import { existsSync, readdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import {
+	classifyProbeFailure,
+	createAvailabilityLatch,
+	logAvailabilityDecision,
+	startHostStallSampler,
+} from "../dispatch/runners/utils/availability-policy.js";
 import { getGlobalPiLensDir } from "../file-utils.js";
-import { isCommandAvailableAsync } from "../safe-spawn.js";
+import { safeSpawnAsync } from "../safe-spawn.js";
 
 const JAVA_EXE = process.platform === "win32" ? "java.exe" : "java";
+const JAVA_PROBE_TIMEOUT_MS = 5_000;
 
 /** jdtls requires a JDK ≥ 17 to run; recent builds prefer 21. */
 const MIN_JAVA_MAJOR = 17;
@@ -136,37 +143,124 @@ export function discoverJdkHome(
 
 let _cachedEnv: { value: NodeJS.ProcessEnv | undefined } | undefined;
 
+/**
+ * Availability latch for the `java` PATH probe (#1538, the #1467 latch family's
+ * benign-direction sibling). A stalled probe is not evidence the tool is
+ * missing — only a genuine "not found" (or a genuinely resolvable `java`) is a
+ * durable fact worth caching for the session. A transient verdict (timeout,
+ * abort, host stall) expires on the shared cooldown and is re-probed on the
+ * next demand instead of pinning whatever `JAVA_HOME` happened to be ambient.
+ */
+const javaAvailabilityLatch = createAvailabilityLatch();
+
 export function _resetJvmRuntimeCacheForTests(): void {
 	_cachedEnv = undefined;
+	javaAvailabilityLatch.reset();
+}
+
+/**
+ * Probe `java` on PATH, distinguishing a durable verdict (found, or genuinely
+ * absent) from a transient probe failure. Returns `true`/`false` for a durable
+ * verdict; `undefined` when the probe was transient, so the caller must not
+ * treat this call as proof `java` is absent.
+ */
+async function probeJavaOnPath(): Promise<boolean | undefined> {
+	const memo = javaAvailabilityLatch.read();
+	if (memo !== null) return memo;
+
+	const finder = process.platform === "win32" ? "where" : "which";
+	const startedAt = Date.now();
+	const sampler = startHostStallSampler();
+	let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
+	let hostStallMs: number;
+	try {
+		result = await safeSpawnAsync(finder, ["java"], {
+			timeout: JAVA_PROBE_TIMEOUT_MS,
+		});
+	} finally {
+		hostStallMs = sampler.stop();
+	}
+	const elapsedMs = Date.now() - startedAt;
+
+	if (result.status === 0 && !result.error) {
+		javaAvailabilityLatch.noteAvailable();
+		logAvailabilityDecision({
+			tool: "java",
+			verdict: "available",
+			outcome: "success",
+			cause: "ok",
+			elapsedMs,
+			latched: true,
+			hostStallMs,
+			budgetMs: JAVA_PROBE_TIMEOUT_MS,
+		});
+		return true;
+	}
+
+	// A `where`/`which` that ran fine and found nothing is a genuine absence,
+	// same as a pre-existing #1496/#1467 sibling; anything else (timeout,
+	// abort, host stall) is transient and must not latch.
+	const { outcome, cause } = classifyProbeFailure(result, {
+		hostStallMs,
+		unclassifiedFailureOutcome: "missing",
+	});
+	const retryAfterMs = javaAvailabilityLatch.noteUnavailable(outcome, cause);
+	logAvailabilityDecision({
+		tool: "java",
+		verdict: "unavailable",
+		outcome,
+		cause,
+		elapsedMs,
+		latched: outcome !== "transient",
+		hostStallMs,
+		...(retryAfterMs > 0 && { retryAfterMs }),
+		budgetMs: JAVA_PROBE_TIMEOUT_MS,
+	});
+	return outcome === "transient" ? undefined : false;
 }
 
 /**
  * Spawn-env overlay that makes a JVM-gated server (jdtls) launch when `java`
  * isn't on PATH. Returns undefined when `java` is already resolvable (respect
  * the user's PATH java) or when no JDK can be discovered (fail as before).
- * Memoized per process — discovery is filesystem-only but stable for a session.
+ *
+ * Memoized per process — but only once the verdict is durable. A JDK found by
+ * filesystem discovery is always safe to cache immediately: `discoverJdkHome`
+ * is pure stat/readdir, unaffected by the PATH probe's timing. When no JDK is
+ * discovered AND the PATH probe was transient, nothing is cached — the next
+ * call re-probes (respecting the latch's own cooldown) instead of pinning a
+ * "no override" verdict that a stalled probe never earned (#1538).
  */
 export async function resolveJavaRuntimeEnv(): Promise<
 	NodeJS.ProcessEnv | undefined
 > {
 	if (_cachedEnv) return _cachedEnv.value;
+
 	// `java` already on PATH — nothing to inject; defer to the user's runtime.
-	if (await isCommandAvailableAsync("java")) {
+	const javaOnPath = await probeJavaOnPath();
+	if (javaOnPath === true) {
 		_cachedEnv = { value: undefined };
 		return undefined;
 	}
+
 	const home = discoverJdkHome();
-	if (!home) {
-		_cachedEnv = { value: undefined };
-		return undefined;
+	if (home) {
+		const binDir = path.join(home, "bin");
+		const currentPath = process.env.PATH ?? process.env.Path ?? "";
+		_cachedEnv = {
+			value: {
+				JAVA_HOME: home,
+				PATH: binDir + path.delimiter + currentPath,
+			},
+		};
+		return _cachedEnv.value;
 	}
-	const binDir = path.join(home, "bin");
-	const currentPath = process.env.PATH ?? process.env.Path ?? "";
-	_cachedEnv = {
-		value: {
-			JAVA_HOME: home,
-			PATH: binDir + path.delimiter + currentPath,
-		},
-	};
-	return _cachedEnv.value;
+
+	// No JDK discovered. Cache "no override" only when the PATH probe gave a
+	// durable "not found" — a transient probe (timeout/host-stall) must not
+	// pin this session to `undefined` forever.
+	if (javaOnPath === false) {
+		_cachedEnv = { value: undefined };
+	}
+	return undefined;
 }

--- a/tests/clients/lsp/jvm-runtime.test.ts
+++ b/tests/clients/lsp/jvm-runtime.test.ts
@@ -2,21 +2,84 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	_resetJvmRuntimeCacheForTests,
-	discoverJdkHome,
-	resolveJavaRuntimeEnv,
-} from "../../../clients/lsp/jvm-runtime.js";
+import { TRANSIENT_BASE_COOLDOWN_MS } from "../../../clients/dispatch/runners/utils/availability-policy.js";
 import { removeTempDirSync } from "../test-utils.js";
 
 const isWin = process.platform === "win32";
 const JAVA_EXE = isWin ? "java.exe" : "java";
 
-vi.mock("../../../clients/safe-spawn.js", async (importOriginal) => ({
-	...(await importOriginal<typeof import("../../../clients/safe-spawn.js")>()),
-	isCommandAvailableAsync: vi.fn(),
+const { safeSpawnAsync, allowedFsRoots } = vi.hoisted(() => ({
+	safeSpawnAsync: vi.fn(),
+	allowedFsRoots: [] as string[],
 }));
-import { isCommandAvailableAsync } from "../../../clients/safe-spawn.js";
+
+// `jvm-runtime.ts` probes `java` through `safeSpawnAsync` directly (#1538),
+// mirroring the #1496 package-manager fix — mock at that boundary. Also
+// reimplement `isCommandAvailableAsync` (not `importOriginal`'d — the real
+// function's internal `safeSpawnAsync` call is bound to its OWN module's
+// unmocked binding, so importing it would bypass this mock and hit the real
+// system PATH). Pre-fix `jvm-runtime.ts` probes through `isCommandAvailableAsync`;
+// post-fix code calls `safeSpawnAsync` directly — routing both through the
+// same hoisted mock lets one test file exercise both at the same boundary and
+// prove the pre-fix code fails on its own logic, not a missing export.
+vi.mock("../../../clients/safe-spawn.js", () => ({
+	safeSpawnAsync,
+	safeSpawn: vi.fn(),
+	isCommandAvailableAsync: async (command: string) => {
+		const finder = process.platform === "win32" ? "where" : "which";
+		const result = await safeSpawnAsync(finder, [command], { timeout: 5000 });
+		return result.status === 0 && !result.error;
+	},
+}));
+
+// `discoverJdkHome`'s default `candidateRoots()` scans real per-platform
+// install locations (Program Files\Eclipse Adoptium, /usr/lib/jvm, …), and
+// `resolveJavaRuntimeEnv` calls it with no args — so on a dev/CI box that
+// actually has a JDK installed, an unfenced test would "discover" the real
+// one and the "no JDK on this host" scenarios could never be exercised.
+// Fence `readdirSync` to only see directories tests explicitly register
+// (their own tmp dirs); every other root reads as empty, same as `childDirs`
+// already treats an unreadable root. `existsSync` (the direct JAVA_HOME
+// check) is untouched.
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		readdirSync: (base: string, options?: unknown) => {
+			if (allowedFsRoots.some((root) => base.startsWith(root))) {
+				return (actual.readdirSync as (...args: unknown[]) => unknown)(
+					base,
+					options,
+				);
+			}
+			const error = new Error(`ENOENT: fenced for tests: ${base}`) as NodeJS.ErrnoException;
+			error.code = "ENOENT";
+			throw error;
+		},
+	};
+});
+
+const timeoutResult = {
+	stdout: "",
+	stderr: "",
+	status: null,
+	error: new Error("Process timed out after 5000ms"),
+	failure: "timeout",
+	spawnFailure: { kind: "timeout" },
+};
+
+/** A real `where`/`which` that ran fine and found nothing: genuine absence. */
+const notFoundResult = { stdout: "", stderr: "", status: 1 };
+
+const okResult = { stdout: "/usr/bin/java\n", stderr: "", status: 0 };
+
+function finder(): string {
+	return process.platform === "win32" ? "where" : "which";
+}
+
+function advancePastCooldown(): void {
+	vi.setSystemTime(new Date(Date.now() + TRANSIENT_BASE_COOLDOWN_MS + 1));
+}
 
 describe("jvm-runtime — JDK discovery (#241)", () => {
 	const dirs: string[] = [];
@@ -25,6 +88,7 @@ describe("jvm-runtime — JDK discovery (#241)", () => {
 	function tmpDir(): string {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-jdk-"));
 		dirs.push(dir);
+		allowedFsRoots.push(dir);
 		return dir;
 	}
 
@@ -36,9 +100,12 @@ describe("jvm-runtime — JDK discovery (#241)", () => {
 		return home;
 	}
 
-	beforeEach(() => {
+	beforeEach(async () => {
+		const { _resetJvmRuntimeCacheForTests } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		_resetJvmRuntimeCacheForTests();
-		vi.mocked(isCommandAvailableAsync).mockReset();
+		safeSpawnAsync.mockReset();
 		// Passing `undefined` for the javaHome arg re-activates its
 		// `= process.env.JAVA_HOME` default, so a CI runner with JAVA_HOME set
 		// (GitHub's Ubuntu image has one) would leak its real JDK into the scan.
@@ -55,13 +122,19 @@ describe("jvm-runtime — JDK discovery (#241)", () => {
 		}
 	});
 
-	it("finds a JDK under a scanned root", () => {
+	it("finds a JDK under a scanned root", async () => {
+		const { discoverJdkHome } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		const root = tmpDir();
 		const home = fakeJdk(root, "jdk-21.0.11.10-hotspot");
 		expect(discoverJdkHome([root], undefined)).toBe(home);
 	});
 
-	it("picks the highest version among several", () => {
+	it("picks the highest version among several", async () => {
+		const { discoverJdkHome } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		const root = tmpDir();
 		fakeJdk(root, "jdk-17.0.9");
 		const newer = fakeJdk(root, "jdk-21.0.11");
@@ -69,14 +142,20 @@ describe("jvm-runtime — JDK discovery (#241)", () => {
 		expect(discoverJdkHome([root], undefined)).toBe(newer);
 	});
 
-	it("ignores JDKs below the minimum major (17)", () => {
+	it("ignores JDKs below the minimum major (17)", async () => {
+		const { discoverJdkHome } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		const root = tmpDir();
 		fakeJdk(root, "jdk1.8.0_402"); // legacy 8 — too old for jdtls
 		fakeJdk(root, "jdk-11.0.20"); // 11 — too old
 		expect(discoverJdkHome([root], undefined)).toBeUndefined();
 	});
 
-	it("honours an explicit JAVA_HOME over scanned roots", () => {
+	it("honours an explicit JAVA_HOME over scanned roots", async () => {
+		const { discoverJdkHome } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		const root = tmpDir();
 		fakeJdk(root, "jdk-21.0.11");
 		const javaHomeRoot = tmpDir();
@@ -84,11 +163,17 @@ describe("jvm-runtime — JDK discovery (#241)", () => {
 		expect(discoverJdkHome([root], javaHome)).toBe(javaHome);
 	});
 
-	it("returns undefined when no JDK exists", () => {
+	it("returns undefined when no JDK exists", async () => {
+		const { discoverJdkHome } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		expect(discoverJdkHome([tmpDir()], undefined)).toBeUndefined();
 	});
 
-	it("returns undefined when JAVA_HOME points at a non-JDK", () => {
+	it("returns undefined when JAVA_HOME points at a non-JDK", async () => {
+		const { discoverJdkHome } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		const bogus = tmpDir(); // no bin/java
 		expect(discoverJdkHome([tmpDir()], bogus)).toBeUndefined();
 	});
@@ -101,16 +186,27 @@ describe("jvm-runtime — resolveJavaRuntimeEnv (#241)", () => {
 	function tmpDir(): string {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-jdkenv-"));
 		dirs.push(dir);
+		allowedFsRoots.push(dir);
 		return dir;
 	}
 
-	beforeEach(() => {
+	beforeEach(async () => {
+		const { _resetJvmRuntimeCacheForTests } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		_resetJvmRuntimeCacheForTests();
-		vi.mocked(isCommandAvailableAsync).mockReset();
+		safeSpawnAsync.mockReset();
+		// See the first describe block: clear the host's real JAVA_HOME so
+		// `resolveJavaRuntimeEnv`'s unfenced `discoverJdkHome()` call can't pick
+		// up an actual JDK on a dev/CI box; tests that need one set it back
+		// explicitly, pointed at a fenced tmp dir.
 		savedJavaHome = process.env.JAVA_HOME;
+		delete process.env.JAVA_HOME;
+		vi.useFakeTimers({ toFake: ["Date"] });
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		if (savedJavaHome === undefined) delete process.env.JAVA_HOME;
 		else process.env.JAVA_HOME = savedJavaHome;
 		for (const dir of dirs.splice(0)) {
@@ -119,12 +215,22 @@ describe("jvm-runtime — resolveJavaRuntimeEnv (#241)", () => {
 	});
 
 	it("injects nothing when java is already on PATH", async () => {
-		vi.mocked(isCommandAvailableAsync).mockResolvedValue(true);
+		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) =>
+			cmd === finder() && args[0] === "java" ? okResult : notFoundResult,
+		);
+		const { resolveJavaRuntimeEnv } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
 	});
 
 	it("injects JAVA_HOME + PATH from a discovered JDK when java is absent", async () => {
-		vi.mocked(isCommandAvailableAsync).mockResolvedValue(false);
+		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) =>
+			cmd === finder() && args[0] === "java" ? notFoundResult : notFoundResult,
+		);
+		const { resolveJavaRuntimeEnv } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		const home = path.join(tmpDir(), "jdk-21");
 		fs.mkdirSync(path.join(home, "bin"), { recursive: true });
 		fs.writeFileSync(
@@ -142,10 +248,108 @@ describe("jvm-runtime — resolveJavaRuntimeEnv (#241)", () => {
 		);
 	});
 
-	it("memoizes the result across calls", async () => {
-		vi.mocked(isCommandAvailableAsync).mockResolvedValue(true);
+	it("memoizes a durable verdict across calls", async () => {
+		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) =>
+			cmd === finder() && args[0] === "java" ? okResult : notFoundResult,
+		);
+		const { resolveJavaRuntimeEnv } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
 		await resolveJavaRuntimeEnv();
 		await resolveJavaRuntimeEnv();
-		expect(vi.mocked(isCommandAvailableAsync)).toHaveBeenCalledTimes(1);
+		const javaProbes = safeSpawnAsync.mock.calls.filter(
+			([cmd, args]) => cmd === finder() && args[0] === "java",
+		).length;
+		expect(javaProbes).toBe(1);
+	});
+
+	/**
+	 * THE regression proof (#1538): the `java` probe times out (a transient
+	 * host-side 5 s budget expiry, the #1467 latch family's benign-direction
+	 * sibling) and no JDK is discoverable on this host. Pre-fix, the timeout
+	 * was indistinguishable from a genuine absence — both cached
+	 * `{ value: undefined }` forever, pinning whatever ambient `JAVA_HOME` (or
+	 * lack of one) happened to be in effect for the rest of the session.
+	 * Post-fix, a transient verdict must not be cached: this call must FAIL on
+	 * pre-fix code, which returns `undefined` from BOTH calls with only one
+	 * probe recorded (latched after the first).
+	 */
+	it("a timed-out probe is not cached: retried on the next demand call", async () => {
+		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) =>
+			cmd === finder() && args[0] === "java" ? timeoutResult : notFoundResult,
+		);
+		const { resolveJavaRuntimeEnv } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
+
+		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
+		// The transient verdict's own short cooldown (#1467's policy) means an
+		// IMMEDIATE re-call correctly doesn't re-probe yet — that's the "short
+		// cooldown so repeated calls don't pay 5s each" half of the fix. Advance
+		// past it to prove the verdict was never latched for the SESSION.
+		advancePastCooldown();
+		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
+
+		const javaProbes = safeSpawnAsync.mock.calls.filter(
+			([cmd, args]) => cmd === finder() && args[0] === "java",
+		).length;
+		// Pre-fix: the first timeout latches `false` forever, so the second call
+		// hits the `_cachedEnv` memo and never re-probes — this assertion fails
+		// (probes stays at 1). Post-fix: a transient verdict is never cached, so
+		// resolveJavaRuntimeEnv re-probes once its cooldown expires.
+		expect(javaProbes).toBeGreaterThan(1);
+	});
+
+	it("a genuine absence (no JDK, no java) caches: not re-probed", async () => {
+		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) =>
+			cmd === finder() && args[0] === "java" ? notFoundResult : notFoundResult,
+		);
+		const { resolveJavaRuntimeEnv } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
+
+		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
+		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
+
+		const javaProbes = safeSpawnAsync.mock.calls.filter(
+			([cmd, args]) => cmd === finder() && args[0] === "java",
+		).length;
+		expect(javaProbes).toBe(1);
+	});
+
+	it("recovers after a transient failure: a later successful probe is used, not the stall", async () => {
+		let call = 0;
+		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) => {
+			if (cmd === finder() && args[0] === "java") {
+				call += 1;
+				return call === 1 ? timeoutResult : okResult;
+			}
+			return notFoundResult;
+		});
+		const { resolveJavaRuntimeEnv } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
+
+		// First call: probe stalls, no JDK discoverable — falls back to
+		// undefined (no override) for THIS call, but must not cache it.
+		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
+		// Second call, past the transient cooldown: `java` is reachable again —
+		// correctly discovered and (since java is now on PATH) still no override
+		// needed, but this time as a DURABLE verdict, proven by the probe having
+		// run again.
+		advancePastCooldown();
+		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
+
+		const javaProbes = safeSpawnAsync.mock.calls.filter(
+			([cmd, args]) => cmd === finder() && args[0] === "java",
+		).length;
+		expect(javaProbes).toBe(2);
+
+		// Now durable: a third call must not probe again.
+		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
+		const javaProbesAfter = safeSpawnAsync.mock.calls.filter(
+			([cmd, args]) => cmd === finder() && args[0] === "java",
+		).length;
+		expect(javaProbesAfter).toBe(2);
 	});
 });

--- a/tests/clients/lsp/jvm-runtime.test.ts
+++ b/tests/clients/lsp/jvm-runtime.test.ts
@@ -8,10 +8,24 @@ import { removeTempDirSync } from "../test-utils.js";
 const isWin = process.platform === "win32";
 const JAVA_EXE = isWin ? "java.exe" : "java";
 
-const { safeSpawnAsync, allowedFsRoots } = vi.hoisted(() => ({
+const { safeSpawnAsync, allowedFsRoots, logLatencySpy } = vi.hoisted(() => ({
 	safeSpawnAsync: vi.fn(),
 	allowedFsRoots: [] as string[],
+	logLatencySpy: vi.fn(),
 }));
+
+// Assert an `availability_decision` record lands even for a memo served
+// mid-cooldown — the review-round finding that this state left zero trace in
+// latency.log.
+vi.mock("../../../clients/latency-logger.js", () => ({
+	logLatency: logLatencySpy,
+	getLastLoggedPhase: () => undefined,
+}));
+
+const decisions = () =>
+	logLatencySpy.mock.calls
+		.map((call) => call[0])
+		.filter((entry) => entry?.phase === "availability_decision");
 
 // `jvm-runtime.ts` probes `java` through `safeSpawnAsync` directly (#1538),
 // mirroring the #1496 package-manager fix — mock at that boundary. Also
@@ -196,6 +210,7 @@ describe("jvm-runtime — resolveJavaRuntimeEnv (#241)", () => {
 		);
 		_resetJvmRuntimeCacheForTests();
 		safeSpawnAsync.mockReset();
+		logLatencySpy.mockReset();
 		// See the first describe block: clear the host's real JAVA_HOME so
 		// `resolveJavaRuntimeEnv`'s unfenced `discoverJdkHome()` call can't pick
 		// up an actual JDK on a dev/CI box; tests that need one set it back
@@ -273,6 +288,19 @@ describe("jvm-runtime — resolveJavaRuntimeEnv (#241)", () => {
 	 * Post-fix, a transient verdict must not be cached: this call must FAIL on
 	 * pre-fix code, which returns `undefined` from BOTH calls with only one
 	 * probe recorded (latched after the first).
+	 *
+	 * Review-round addition: the in-cooldown call between the two probes is
+	 * the exact shape a real jdtls retry hits. jdtls's failed-spawn cooldown
+	 * (`BROKEN_BASE_COOLDOWN_MS`, `clients/lsp/index.ts`) is ~15-20s, inside
+	 * this probe's 30s transient cooldown, so the FIRST retry after a stall
+	 * always lands here. `AvailabilityLatch.read()` returns `false` (not
+	 * `null`) for that in-cooldown call — indistinguishable at that layer from
+	 * a durable "not found" — so a naive caller launders it into `_cachedEnv`
+	 * anyway, one call deeper than the original bug. Proven by: the in-cooldown
+	 * call must not add a probe, AND a later call past the cooldown must still
+	 * re-probe (proof `_cachedEnv` was never written by the in-cooldown call).
+	 * It must also leave an `availability_decision` record — the reviewer's
+	 * "zero record in latency.log" finding.
 	 */
 	it("a timed-out probe is not cached: retried on the next demand call", async () => {
 		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) =>
@@ -283,20 +311,39 @@ describe("jvm-runtime — resolveJavaRuntimeEnv (#241)", () => {
 		);
 
 		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
-		// The transient verdict's own short cooldown (#1467's policy) means an
-		// IMMEDIATE re-call correctly doesn't re-probe yet — that's the "short
-		// cooldown so repeated calls don't pay 5s each" half of the fix. Advance
-		// past it to prove the verdict was never latched for the SESSION.
+
+		// An IMMEDIATE re-call lands inside the transient cooldown (the
+		// jdtls-retry shape above). It must not spawn a second probe...
+		logLatencySpy.mockClear();
+		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
+		const probesDuringCooldown = safeSpawnAsync.mock.calls.filter(
+			([cmd, args]) => cmd === finder() && args[0] === "java",
+		).length;
+		expect(probesDuringCooldown).toBe(1);
+		// ...but it must still be recorded: this is the state that left zero
+		// trace in latency.log pre-fix-round-2.
+		expect(decisions()).toContainEqual(
+			expect.objectContaining({
+				phase: "availability_decision",
+				metadata: expect.objectContaining({
+					tool: "java",
+					verdict: "unavailable",
+					outcome: "transient",
+				}),
+			}),
+		);
+
+		// Advance past the cooldown to prove the in-cooldown call above never
+		// latched anything into `_cachedEnv`: pre-#1538-round-2, that call would
+		// have written `_cachedEnv = { value: undefined }`, and THIS call would
+		// short-circuit on it without probing — the assertion below would fail
+		// (probes would stay at 1 forever).
 		advancePastCooldown();
 		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
 
 		const javaProbes = safeSpawnAsync.mock.calls.filter(
 			([cmd, args]) => cmd === finder() && args[0] === "java",
 		).length;
-		// Pre-fix: the first timeout latches `false` forever, so the second call
-		// hits the `_cachedEnv` memo and never re-probes — this assertion fails
-		// (probes stays at 1). Post-fix: a transient verdict is never cached, so
-		// resolveJavaRuntimeEnv re-probes once its cooldown expires.
 		expect(javaProbes).toBeGreaterThan(1);
 	});
 
@@ -333,10 +380,19 @@ describe("jvm-runtime — resolveJavaRuntimeEnv (#241)", () => {
 		// First call: probe stalls, no JDK discoverable — falls back to
 		// undefined (no override) for THIS call, but must not cache it.
 		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
-		// Second call, past the transient cooldown: `java` is reachable again —
-		// correctly discovered and (since java is now on PATH) still no override
-		// needed, but this time as a DURABLE verdict, proven by the probe having
-		// run again.
+		// An immediate in-cooldown retry (the real jdtls-retry shape) must not
+		// spawn a probe, and — the point of this test — must not launder the
+		// transient verdict into the session cache either.
+		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
+		const probesDuringCooldown = safeSpawnAsync.mock.calls.filter(
+			([cmd, args]) => cmd === finder() && args[0] === "java",
+		).length;
+		expect(probesDuringCooldown).toBe(1);
+		// Past the transient cooldown: `java` is reachable again — correctly
+		// discovered and (since java is now on PATH) still no override needed,
+		// but this time as a DURABLE verdict, proven by the probe having run
+		// again. If the in-cooldown call above had wrongly cached `undefined`,
+		// this call would short-circuit on `_cachedEnv` and never re-probe.
 		advancePastCooldown();
 		expect(await resolveJavaRuntimeEnv()).toBeUndefined();
 
@@ -351,5 +407,36 @@ describe("jvm-runtime — resolveJavaRuntimeEnv (#241)", () => {
 			([cmd, args]) => cmd === finder() && args[0] === "java",
 		).length;
 		expect(javaProbesAfter).toBe(2);
+	});
+
+	/**
+	 * MEDIUM (review round): without a shared in-flight promise, two concurrent
+	 * `resolveJavaRuntimeEnv` calls each fire their own 5s probe — the shape a
+	 * multi-root Java project hits spawning jdtls per root, and (post-blocker-fix)
+	 * a shape that recurs every time a transient cooldown expires, not just once
+	 * at startup. Mirrors `clients/package-manager.ts`'s `inFlightProbes` pattern
+	 * (the #1496 sibling this fix already cites).
+	 */
+	it("concurrent calls share one probe", async () => {
+		let spawnCount = 0;
+		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) => {
+			if (cmd === finder() && args[0] === "java") {
+				spawnCount += 1;
+				return okResult;
+			}
+			return notFoundResult;
+		});
+		const { resolveJavaRuntimeEnv } = await import(
+			"../../../clients/lsp/jvm-runtime.js"
+		);
+
+		const results = await Promise.all([
+			resolveJavaRuntimeEnv(),
+			resolveJavaRuntimeEnv(),
+			resolveJavaRuntimeEnv(),
+		]);
+
+		expect(results).toEqual([undefined, undefined, undefined]);
+		expect(spawnCount).toBe(1);
 	});
 });


### PR DESCRIPTION
## What

`clients/lsp/jvm-runtime.ts`'s `resolveJavaRuntimeEnv()` cached both
"java is on PATH" and "java is not on PATH" as `{ value: undefined }`
with no distinction between them. A 5s `isCommandAvailableAsync("java")`
timeout landed in the same "not found" arm as a genuine absence, so a
single stalled probe pinned "no JDK override" for the rest of the
session, latching whatever ambient `JAVA_HOME` happened to be in
effect at that moment.

## Why

This is the #1467 latch family's benign-direction sibling, filed by
the #1494 class sweep. The failure direction is mild -- `undefined`
means "don't override", so jdtls falls back to the ambient
`JAVA_HOME` rather than being disabled -- but a host where the probe
stalls once keeps a stale or wrong `JAVA_HOME` for the whole session,
exactly the JDK discovery was meant to correct.

## How

`resolveJavaRuntimeEnv()` routes the `java` PATH probe through
`availability-policy.ts`'s `classifyProbeFailure` /
`createAvailabilityLatch` -- the shared taxonomy #1467 introduced and
#1496 (`package-manager.ts`) already uses for the identical shape:

- A spawn timeout, abort, or host stall is `transient`: never cached,
  retried on the next demand call once the shared cooldown expires.
- A JDK found by filesystem discovery (`discoverJdkHome`) is cached
  immediately regardless of the PATH probe's outcome -- discovery is
  pure `stat`/`readdir`, unaffected by spawn timing.
- A genuine "not found" (the probe ran fine, found nothing) with no
  discoverable JDK still caches `undefined` for the session, matching
  the issue's acceptance criteria.

No reset/generation hook exists today for this cache (or for its
sibling latches) to wire a "JDK installed mid-session" escape hatch
into -- the JDK-download half of #241 is still deferred and there's
no production caller of `_resetJvmRuntimeCacheForTests()`. Left that
out of scope; the existing test-only reset now also resets the new
latch and in-flight probe.

### Review round

An adversarial review of the first version of this PR found a blocker
one call deeper than the original bug, plus a medium:

- **Blocker -- in-cooldown memo laundered into the permanent cache.**
  `AvailabilityLatch.read()` returns `false` (not `null`) for BOTH a
  durable "not found" and a transient verdict whose cooldown hasn't
  expired -- the latch's contract is "give this call a safe answer",
  not "this is durable". `probeJavaOnPath` forwarded that `false`
  verbatim, so `resolveJavaRuntimeEnv` wrote it straight into
  `_cachedEnv` for the session. The timing makes this the *common*
  path, not an edge case: jdtls's failed-spawn retry
  (`BROKEN_BASE_COOLDOWN_MS`, `clients/lsp/index.ts`, ~15-20s) lands
  inside this probe's 30s transient cooldown, so the first retry after
  any stall would have re-entered `resolveJavaRuntimeEnv` while still
  cooling down and latched `undefined` anyway. Fixed: `probeJavaOnPath`
  now checks the latch's own `outcome`, not just its boolean memo -- a
  `"transient"` outcome always returns `undefined`, regardless of what
  `read()` reports, so the caller never writes the cache from a
  verdict that never got a fair hearing. That in-cooldown path is now
  logged too (`availability_decision`), closing the "zero record in
  latency.log" gap the review flagged.
- **Medium -- no in-flight dedupe.** Two concurrent
  `resolveJavaRuntimeEnv` calls (a multi-root Java project spawning
  jdtls per root) each fired their own 5s probe, and after the blocker
  fix, every expired cooldown reopens that window for the rest of the
  session, not just at startup. Fixed by mirroring
  `clients/package-manager.ts`'s `inFlightProbes` pattern (the #1496
  sibling this PR already cites): concurrent callers share one probe.
- **Not fixed here (reviewer-judged follow-up, noted for the
  record):** `classifyProbeFailure`'s `unclassifiedFailureOutcome:
  "missing"` latches an EACCES-failed finder as a durable absence.
  That's the existing #1467 family-wide convention
  (`package-manager.ts:161` is identical) and the fail direction here
  is benign -- it falls back to the ambient `JAVA_HOME` rather than
  disabling jdtls.

## Verification

- `npm run build` clean, `npm run lint` (`tsc --project tsconfig.json`) clean.
- `tests/clients/lsp/jvm-runtime.test.ts`: 13/13 pass on the fix
  (12 from the first round + 1 new concurrency test; two existing
  tests extended with an in-cooldown assertion per the review).
- Red-run proof, round 1 (checked out pre-fix `jvm-runtime.ts` from
  `origin/master`, rebuilt, ran the test file): exactly the two
  original regression tests failed with clean assertion mismatches.
  Restored the fix afterward; 12/12 passed again.
- Red-run proof, round 2 (checked out the round-1 fix commit's
  `jvm-runtime.ts` -- i.e. pre-this-round's-changes -- kept the
  round-2 test file, rebuilt, ran the test file): exactly the three
  new/extended tests failed, cleanly:
  - `a timed-out probe is not cached: retried on the next demand call`
    -- missing `availability_decision` record for the in-cooldown call
    (`expected [] to deep equally contain ObjectContaining{…}`).
  - `recovers after a transient failure: a later successful probe is
    used, not the stall` -- `expected 1 to be 2` (the in-cooldown call
    laundered `undefined` into `_cachedEnv`, so the later durable call
    never re-probed).
  - `concurrent calls share one probe` -- `expected 3 to be 1`.
  Restored the round-2 fix afterward; 13/13 passed again.
- Sanity sweep (all pass, 102/102): `tests/clients/lsp/lombok.test.ts`,
  `tests/clients/lsp/runtime-install-discovery.test.ts`,
  `tests/clients/package-manager-availability-latch.test.ts`,
  `tests/clients/package-manager.test.ts`,
  `tests/clients/availability-policy-coverage.test.ts`,
  `tests/clients/availability-latching-siblings.test.ts`,
  `tests/clients/dispatch/runners/availability-latching.test.ts`.
- `tests/clients/lsp/` full directory (first round): 688 passed, 1
  unrelated flake (`server-policy.test.ts`'s csharp-marker test timed
  out under parallel load, passed cleanly in isolation -- not touched
  by this change). Not re-run in full this round; targeted + sanity
  sweep covers the changed surface.
- Full suite not run here; deferred to CI per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpSQeAhgjMTDskzyVMmjFH
