### PR TITLE
docs(agents): add VERIFY and FIX ROUND protocols (refs #1499)

### DIFF
--- a/.claude/agents/pi-lens-fixer.md
+++ b/.claude/agents/pi-lens-fixer.md
@@ -42,6 +42,19 @@ instructions say so.
    with an honest review-round section. Never argue with a probe — reproduce
    it first.
 
+## Fix rounds
+
+When the orchestrator resumes you with `FIX ROUND` plus review findings, apply
+them on the same branch without being re-briefed on process: reproduce each
+finding before fixing it (never argue with a probe), red-first tests for every
+behavioral fix, rebuild, rerun targeted suites plus anything the findings
+touched, push the same branch, verify Unit tests and Lint genuinely execute on
+the new head (merge origin/master first if the PR reads DIRTY — additive
+resolutions, and screen the merged result SEMANTICALLY: a textually clean merge
+can still recombine into a bug when master moved the seam you built on), and
+update the PR body with an honest review-round section. Report what changed per
+finding with its red-run evidence.
+
 ## Report format
 
 Outcome first: branch, PR URL, then root cause in two sentences, red-run

--- a/.claude/agents/pi-lens-reviewer.md
+++ b/.claude/agents/pi-lens-reviewer.md
@@ -47,6 +47,18 @@ merge — you report internally to the orchestrator.
 7. Clean up: revert all mutations, delete probe files, confirm
    `git status --porcelain` is empty. Junctions (if you created any) removed.
 
+## Verification rounds
+
+When the orchestrator resumes you with `VERIFY <head-sha>` plus a claims list,
+that is a fix-round verification. Without being told each time: fetch the head,
+rebuild, re-run YOUR original probes for every finding the claims say is fixed
+(never accept the fixer's word or tests as proof), probe each claim's edge
+specifically, re-run the targeted suites, and read CI on that exact head
+(Unit tests must have genuinely executed). Construct at least one NEW attack
+against the fix itself — fix rounds introduce defects at the same rate they
+remove them in this repo's history. Report verdict first: merge-ready or
+still-needs-changes with the same rigor as round one.
+
 ## Report format
 
 Verdict first (merge-ready / needs changes / conflicted), then findings ranked


### PR DESCRIPTION
Bakes the round-lifecycle boilerplate into the committed agent playbooks (follow-up to #1553). Reviewer gains a VERIFY protocol (own probes, one new attack per fix round); fixer gains a FIX ROUND protocol including the semantic-merge screen from #1547's textually-clean-but-semantically-broken master merge. Docs only; verified by reading — no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpSQeAhgjMTDskzyVMmjFH