### PR TITLE
Availability gate: whitelist policy-handle memos for routing inheritance (closes #1552)

### DIFF
--- a/.changelog/fix-1552-policy-handle-whitelist.md
+++ b/.changelog/fix-1552-policy-handle-whitelist.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **The availability-policy coverage gate no longer waves through a verdict that dodges the word "boolean" (refs #1552)** — Routing inheritance decided whether a unit that delegates its spawn to a routed helper may borrow that helper's coverage. It worked as a blacklist: inherit unless the unit's own memo "looks boolean". A `Map<string, "yes" | "no">` string-union verdict spells neither "boolean" nor a policy-factory name and slipped through, and a genuine boolean reached through a type alias slipped through the same way, since the word only ever appears in the alias's own declaration. The gate now works as a whitelist: a unit inherits routing only when its own memo is traceably a policy factory's handle, directly or through one hop of a module-local wrapper. An unrecognised shape defaults to unrouted instead of routed.

--- a/tests/clients/availability-policy-coverage.test.ts
+++ b/tests/clients/availability-policy-coverage.test.ts
@@ -260,6 +260,64 @@ const EVASIONS: ReadonlyArray<{ name: string; source: string }> = [
 		`,
 	},
 	{
+		// #1552. `isBooleanVerdictShape` was a BLACKLIST: inherit routing unless
+		// the unit's own memo "looks boolean". A string-union verdict never spells
+		// "boolean" and never spells a factory name either — it is neither a
+		// latch nor a handle, and the blacklist waved it through anyway.
+		name: "a string-union verdict that is neither boolean nor a policy handle",
+		source: `
+			import { createCwdCachedProbe } from "./dispatch/runners/utils/runner-helpers.js";
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			function makeToolProbe(cmd: string) {
+				return createCwdCachedProbe(
+					(cwd) => safeSpawnAsync(cmd, ["--version"], { timeout: 5000, cwd }),
+					{ tool: "newtool" },
+				);
+			}
+			const toolAvailableByCwd = new Map<string, "yes" | "no">();
+			export function getToolProbe(cmd: string) {
+				return async (cwd: string) => {
+					const hit = toolAvailableByCwd.get(cwd);
+					if (hit !== undefined) return hit === "yes";
+					const probed = await makeToolProbe(cmd)(cwd);
+					toolAvailableByCwd.set(cwd, probed ? "yes" : "no");
+					return probed;
+				};
+			}
+		`,
+	},
+	{
+		// #1552. The same laundering shape as the `Promise<boolean>` probe above,
+		// but the boolean is reached through a type alias. A blacklist that
+		// text-matches `\bboolean\b` on the memo's own type never sees it — the
+		// alias's own declaration is the only place the word appears — so it
+		// misclassifies the memo as "not boolean" and inherits routing it never
+		// earned. The whitelist does not need to catch this spelling: an alias
+		// name is not a factory name either, so it is refused by default.
+		name: "a hand-rolled boolean latch reached through a type alias",
+		source: `
+			import { createCwdCachedProbe } from "./dispatch/runners/utils/runner-helpers.js";
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			type ToolVerdict = boolean;
+			function makeToolProbe(cmd: string) {
+				return createCwdCachedProbe(
+					(cwd) => safeSpawnAsync(cmd, ["--version"], { timeout: 5000, cwd }),
+					{ tool: "newtool" },
+				);
+			}
+			const toolAvailableByCwd = new Map<string, ToolVerdict>();
+			export function getToolProbe(cmd: string) {
+				return (cwd: string) => {
+					const hit = toolAvailableByCwd.get(cwd);
+					if (hit !== undefined) return Promise.resolve(hit);
+					const probed = makeToolProbe(cmd)(cwd);
+					probed.then((verdict) => toolAvailableByCwd.set(cwd, verdict));
+					return probed;
+				};
+			}
+		`,
+	},
+	{
 		name: "the defect shape plus a comment that names availability-policy.js",
 		source: `
 			import { safeSpawnAsync } from "./safe-spawn.js";

--- a/tests/clients/availability-policy-coverage.test.ts
+++ b/tests/clients/availability-policy-coverage.test.ts
@@ -318,6 +318,87 @@ const EVASIONS: ReadonlyArray<{ name: string; source: string }> = [
 		`,
 	},
 	{
+		// #1552 round 2. The whitelist's own shape check read `writtenValue` — the
+		// WRITE's inlined expression — alongside the declaration's own type/value,
+		// so inlining the routed wrapper's call straight into the `.set(...)`
+		// site let its name leak into a plain `Map<string, boolean>` latch's
+		// shape and pass it off as a handle, even though the DECLARATION never
+		// mentions a factory or a wrapper at all.
+		name: "a hand-rolled boolean latch whose write inlines the routed wrapper's call",
+		source: `
+			import { createCwdCachedProbe } from "./dispatch/runners/utils/runner-helpers.js";
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			function makeToolProbe(cmd: string) {
+				return createCwdCachedProbe(
+					(cwd) => safeSpawnAsync(cmd, ["--version"], { timeout: 5000, cwd }),
+					{ tool: "newtool" },
+				);
+			}
+			const toolAvailableByCwd = new Map<string, boolean>();
+			export async function getToolProbe(cmd: string, cwd: string): Promise<boolean> {
+				const hit = toolAvailableByCwd.get(cwd);
+				if (hit !== undefined) return hit;
+				toolAvailableByCwd.set(cwd, await makeToolProbe(cmd)(cwd));
+				return toolAvailableByCwd.get(cwd) ?? false;
+			}
+		`,
+	},
+	{
+		// #1552 round 2. `findMemo`'s `sessionFact` early return fired before the
+		// `policyHandleOnly` branch, so ANY unit that records a session fact read
+		// as holding a policy handle regardless of shape — `setSessionFact`
+		// records a value, it never calls a `POLICY_FACTORY`, so this must never
+		// grant inheritance on its own.
+		name: "a session-fact latch that delegates its spawn to a routed helper",
+		source: `
+			import { createCwdCachedProbe } from "./dispatch/runners/utils/runner-helpers.js";
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			function makeToolProbe(cmd: string) {
+				return createCwdCachedProbe(
+					(cwd) => safeSpawnAsync(cmd, ["--version"], { timeout: 5000, cwd }),
+					{ tool: "newtool" },
+				);
+			}
+			export async function checkToolAvailability(cmd: string, cwd: string): Promise<boolean> {
+				const probed = await makeToolProbe(cmd)(cwd);
+				setSessionFact("toolAvailable", probed);
+				return probed;
+			}
+		`,
+	},
+	{
+		// #1552's own second probe: a genuine boolean reached through
+		// `ReturnType<typeof asVerdict>` rather than a plain type alias — a
+		// distinct indirection shape from the alias probe above. The whitelist
+		// does not need to catch this spelling either: `asVerdict` is not a
+		// factory and never appears in `policyHandles`, so it is refused by
+		// default the same way the alias is.
+		name: "a hand-rolled boolean latch reached through ReturnType<typeof asVerdict>",
+		source: `
+			import { createCwdCachedProbe } from "./dispatch/runners/utils/runner-helpers.js";
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			function makeToolProbe(cmd: string) {
+				return createCwdCachedProbe(
+					(cwd) => safeSpawnAsync(cmd, ["--version"], { timeout: 5000, cwd }),
+					{ tool: "newtool" },
+				);
+			}
+			function asVerdict(v: boolean): boolean {
+				return v;
+			}
+			const toolAvailableByCwd = new Map<string, ReturnType<typeof asVerdict>>();
+			export function getToolProbe(cmd: string) {
+				return (cwd: string) => {
+					const hit = toolAvailableByCwd.get(cwd);
+					if (hit !== undefined) return Promise.resolve(hit);
+					const probed = makeToolProbe(cmd)(cwd);
+					probed.then((verdict) => toolAvailableByCwd.set(cwd, verdict));
+					return probed;
+				};
+			}
+		`,
+	},
+	{
 		name: "the defect shape plus a comment that names availability-policy.js",
 		source: `
 			import { safeSpawnAsync } from "./safe-spawn.js";

--- a/tests/support/availability-gate.ts
+++ b/tests/support/availability-gate.ts
@@ -51,22 +51,32 @@
  * An unrecognised shape now defaults to NOT inheriting, which is the safe
  * default a blacklist can never offer — it must relearn every disguise.
  *
- * The whitelist has its own known blind spots, both narrower than the
- * blacklist's:
+ * The whitelist has its own known blind spots:
  *
  *   * a wrapper reached through TWO hops of module-local helpers (unit A calls
  *     helper B, which calls helper C, which calls the factory) is invisible —
  *     `policyHandles` is built from each unit's own direct `policyCalls`, not
  *     propagated transitively, so only a one-hop wrapper like `makeEslintProbe`
- *     is recognised;
+ *     is recognised. This narrows what a unit may inherit routing from, so it
+ *     is a false NEGATIVE (an actually-routed unit reads as unrouted) — the
+ *     safer failure direction, and the one the whitelist was built for;
  *   * a `POLICY_FACTORY` imported under a renamed binding
  *     (`import { createCwdCachedProbe as ccp }`) does not match the factory's
- *     canonical name and reads as a hand-rolled latch, not a handle.
- *
- * Both narrow the set of things a unit may WRONGLY inherit routing from, so
- * either failure mode is a false NEGATIVE (an actually-routed unit gets flagged
- * unrouted) rather than the false POSITIVE the blacklist was prone to — a
- * safer place for an unproven shape to land.
+ *     canonical name and reads as a hand-rolled latch, not a handle. Also a
+ *     false negative, and not new here — the boolean-shape blacklist this
+ *     replaced had the same gap, since neither version resolves import
+ *     aliases;
+ *   * the whitelist reads a memo's DECLARED shape (`typeText`/`valueText`)
+ *     only — never a write's own inlined expression, and never a session fact
+ *     (`setSessionFact` records a value, it does not call a factory). A round
+ *     of review (#1552 round 2) found both omissions matter: reading a
+ *     write's text let an inlined wrapper call
+ *     (`cache.set(cwd, await makeToolProbe(cwd))`) leak the wrapper's name
+ *     into a plain `Map<string, boolean>` latch's shape, and an unguarded
+ *     session-fact check returned non-null unconditionally, so either read as
+ *     a policy handle and inherited routing it never earned — the false
+ *     POSITIVE the whitelist exists to rule out. Both are fixed; the
+ *     `EVASIONS` fixtures below pin them.
  */
 
 import * as fs from "node:fs";
@@ -382,7 +392,12 @@ function findMemo(
 	// through a type alias never spells a factory name and is refused by
 	// default, which is what a blacklist on "looks like a boolean" could not
 	// guarantee (#1552 evaded it by never spelling the banned word).
-	if (facts.sessionFact) return "setSessionFact";
+	// A session fact is not a factory-built HANDLE — `setSessionFact` records a
+	// value, it never calls a `POLICY_FACTORY` — so in `policyHandleOnly` mode
+	// its presence must not itself grant inheritance. In the default mode it is
+	// still the memo: a unit that only ever writes a session fact has no other
+	// state to report.
+	if (facts.sessionFact && !options.policyHandleOnly) return "setSessionFact";
 	// A latch built by a policy factory IS a policy handle, in both senses of
 	// the question this function is asked.
 	if (facts.latchDecl) return facts.latchDecl;
@@ -411,7 +426,7 @@ function findMemo(
 					enclosesScope(decl.scope, write.scope)));
 		if (!persistent) continue;
 		if (options.policyHandleOnly) {
-			if (isPolicyHandleMemoShape(decl, write.valueText, options.policyHandles ?? new Map())) {
+			if (isPolicyHandleMemoShape(decl, options.policyHandles ?? new Map())) {
 				return write.target;
 			}
 			continue;
@@ -423,7 +438,7 @@ function findMemo(
 		if (!MEMO_NAME.test(decl.name)) continue;
 		if (!decl.isClassField && decl.scope !== "<module>") continue;
 		if (options.policyHandleOnly) {
-			if (isPolicyHandleMemoShape(decl, "", options.policyHandles ?? new Map())) {
+			if (isPolicyHandleMemoShape(decl, options.policyHandles ?? new Map())) {
 				return decl.name;
 			}
 			continue;
@@ -446,13 +461,21 @@ function findMemo(
  * straight to a factory (`makeEslintProbe` ← `createCwdCachedProbe`) — so
  * `Map<string, ReturnType<typeof makeEslintProbe>>` is recognised without a
  * second, hand-rolled classifier.
+ *
+ * Deliberately reads only the DECLARATION's own `typeText`/`valueText`, never
+ * a write's inlined value: a review probe (#1552 round 2) inlined the wrapper
+ * call straight into the write site —
+ * `toolAvailableByCwd.set(cwd, await makeToolProbe(cmd)(cwd))` against a plain
+ * `Map<string, boolean>` declaration — and reading the write's own text let
+ * the wrapper's name leak into a hand-rolled boolean latch's shape and pass it
+ * off as a handle. A write can echo whatever name it likes; only what the
+ * variable was DECLARED to hold is evidence of what it actually is.
  */
 function isPolicyHandleMemoShape(
 	decl: Decl | undefined,
-	writtenValue: string,
 	policyHandles: Map<string, string>,
 ): boolean {
-	const shape = `${decl?.typeText ?? ""} ${decl?.valueText ?? ""} ${writtenValue}`;
+	const shape = `${decl?.typeText ?? ""} ${decl?.valueText ?? ""}`;
 	for (const factory of POLICY_FACTORIES) {
 		if (new RegExp(`\\b${factory}\\b`).test(shape)) return true;
 	}

--- a/tests/support/availability-gate.ts
+++ b/tests/support/availability-gate.ts
@@ -37,6 +37,36 @@
  * in from another module is out of reach without full type resolution. The
  * vocabulary is deliberately wide (see `MEMO_NAME`), and every widening is
  * pinned by an evasion fixture in the gate's test.
+ *
+ * ROUTING INHERITANCE — whether a unit that does not spawn its own probe may
+ * borrow the routing of the callee it delegates the spawn to — used to be a
+ * BLACKLIST: inherit unless the unit's own memo "looks boolean". A #1529 review
+ * (#1552) broke that with a memo that is neither boolean nor a policy handle
+ * (`Map<string, "yes" | "no">`) and with a genuine boolean reached through a
+ * type alias no factory name ever touches — neither spells "boolean", so both
+ * inherited routing they never earned. It is now a WHITELIST
+ * (`isPolicyHandleMemoShape`): inherit only when the unit's own memo is
+ * traceably a `POLICY_FACTORY`'s handle, directly or one hop through a
+ * module-local wrapper (`Map<string, ReturnType<typeof makeEslintProbe>>`).
+ * An unrecognised shape now defaults to NOT inheriting, which is the safe
+ * default a blacklist can never offer — it must relearn every disguise.
+ *
+ * The whitelist has its own known blind spots, both narrower than the
+ * blacklist's:
+ *
+ *   * a wrapper reached through TWO hops of module-local helpers (unit A calls
+ *     helper B, which calls helper C, which calls the factory) is invisible —
+ *     `policyHandles` is built from each unit's own direct `policyCalls`, not
+ *     propagated transitively, so only a one-hop wrapper like `makeEslintProbe`
+ *     is recognised;
+ *   * a `POLICY_FACTORY` imported under a renamed binding
+ *     (`import { createCwdCachedProbe as ccp }`) does not match the factory's
+ *     canonical name and reads as a hand-rolled latch, not a handle.
+ *
+ * Both narrow the set of things a unit may WRONGLY inherit routing from, so
+ * either failure mode is a false NEGATIVE (an actually-routed unit gets flagged
+ * unrouted) rather than the false POSITIVE the blacklist was prone to — a
+ * safer place for an unproven shape to land.
  */
 
 import * as fs from "node:fs";
@@ -341,16 +371,21 @@ function hasVersionFlagText(text: string): boolean {
 function findMemo(
 	facts: Omit<UnitFacts, "name">,
 	moduleDecls: Map<string, Decl>,
-	options: { booleanOnly?: boolean } = {},
+	options: { policyHandleOnly?: boolean; policyHandles?: Map<string, string> } = {},
 ): string | null {
-	// `booleanOnly` asks the narrower question that decides ROUTING INHERITANCE:
-	// does this unit park a boolean VERDICT of its own? A memo holding a policy
-	// handle (`Map<string, ReturnType<typeof makeEslintProbe>>`) is the routed
-	// shape; a memo holding `boolean` / `Promise<boolean>` is a hand-rolled latch
-	// and must never inherit a helper's routing.
+	// `policyHandleOnly` asks the narrower question that decides ROUTING
+	// INHERITANCE (#1552): does this unit park a POLICY HANDLE of its own — a
+	// verdict object a `POLICY_FACTORY` built, directly or one hop through a
+	// module-local wrapper? Only that shape may borrow a callee's routing.
+	// Everything else defaults to NOT inheriting: a plain boolean, a
+	// `Map<string, "yes" | "no">` string-union verdict, or a boolean reached
+	// through a type alias never spells a factory name and is refused by
+	// default, which is what a blacklist on "looks like a boolean" could not
+	// guarantee (#1552 evaded it by never spelling the banned word).
 	if (facts.sessionFact) return "setSessionFact";
-	// A latch built by a policy factory is a handle, not a boolean verdict.
-	if (facts.latchDecl && !options.booleanOnly) return facts.latchDecl;
+	// A latch built by a policy factory IS a policy handle, in both senses of
+	// the question this function is asked.
+	if (facts.latchDecl) return facts.latchDecl;
 
 	// Module-level bindings are in scope for every unit, and a `const cache = new
 	// Map()` at the top of the file is exactly where a latch hides from a
@@ -375,8 +410,10 @@ function findMemo(
 					// a same-named local in a sibling branch outlives nothing.
 					enclosesScope(decl.scope, write.scope)));
 		if (!persistent) continue;
-		if (options.booleanOnly) {
-			if (isBooleanVerdictShape(decl, write.valueText)) return write.target;
+		if (options.policyHandleOnly) {
+			if (isPolicyHandleMemoShape(decl, write.valueText, options.policyHandles ?? new Map())) {
+				return write.target;
+			}
 			continue;
 		}
 		if (holdsVerdict(decl, write.valueText, write.target)) return write.target;
@@ -385,8 +422,10 @@ function findMemo(
 	for (const decl of facts.decls) {
 		if (!MEMO_NAME.test(decl.name)) continue;
 		if (!decl.isClassField && decl.scope !== "<module>") continue;
-		if (options.booleanOnly) {
-			if (isBooleanVerdictShape(decl, "")) return decl.name;
+		if (options.policyHandleOnly) {
+			if (isPolicyHandleMemoShape(decl, "", options.policyHandles ?? new Map())) {
+				return decl.name;
+			}
 			continue;
 		}
 		if (holdsVerdict(decl, "", decl.name)) return decl.name;
@@ -395,19 +434,32 @@ function findMemo(
 }
 
 /**
- * Does this state hold a BOOLEAN verdict — the hand-rolled-latch shape — rather
- * than a handle the shared policy owns? Deliberately narrower than
- * `holdsVerdict`: no `avail`-in-the-name fallback, because a map of policy
- * handles is usually named after availability and is exactly what must still be
- * allowed to inherit its helper's routing.
+ * Does this state hold a POLICY HANDLE — a verdict object a `POLICY_FACTORY`
+ * built, directly or through one hop of a module-local wrapper — rather than a
+ * hand-rolled latch? This is the WHITELIST #1552 replaced the boolean-shape
+ * blacklist with: reachability to a factory NAME is the only thing that grants
+ * inheritance, so an unrecognised shape is refused rather than accepted.
+ *
+ * `policyHandles` is the same name→factory map `collectUnit` already resolves
+ * member-call reach against (`java.isAvailableAsync` ← `createAvailabilityChecker`),
+ * extended with every top-level function whose OWN body hands its verdict
+ * straight to a factory (`makeEslintProbe` ← `createCwdCachedProbe`) — so
+ * `Map<string, ReturnType<typeof makeEslintProbe>>` is recognised without a
+ * second, hand-rolled classifier.
  */
-function isBooleanVerdictShape(
+function isPolicyHandleMemoShape(
 	decl: Decl | undefined,
 	writtenValue: string,
+	policyHandles: Map<string, string>,
 ): boolean {
 	const shape = `${decl?.typeText ?? ""} ${decl?.valueText ?? ""} ${writtenValue}`;
-	if (/\bboolean\b/i.test(shape)) return true;
-	return BOOL_LITERAL.test(writtenValue.trim());
+	for (const factory of POLICY_FACTORIES) {
+		if (new RegExp(`\\b${factory}\\b`).test(shape)) return true;
+	}
+	for (const handleName of policyHandles.keys()) {
+		if (new RegExp(`\\b${handleName}\\b`).test(shape)) return true;
+	}
+	return false;
 }
 
 /** Is `outer` a strictly enclosing scope of `inner`? Keys are source ranges. */
@@ -595,7 +647,20 @@ export async function analyzeAvailabilityUnits(
 		name: unitLabel(node),
 		facts: collectUnit(node, constInitializers, policyHandles),
 	}));
-	propagateProbeReach(units, moduleDecls);
+	// A top-level FUNCTION whose own body hands its verdict straight to a
+	// factory (`makeEslintProbe` returns `createCwdCachedProbe(...)`) is a
+	// handle producer as surely as a module-level `const x = createXxx(...)` —
+	// `collectUnit` already recorded that reach in the unit's own `policyCalls`,
+	// with no propagation needed, since the call sits in the function's own
+	// body. Folding it into the same `policyHandles` map is what lets
+	// `Map<string, ReturnType<typeof makeEslintProbe>>` read as a policy handle
+	// via the ONE whitelist (#1552), instead of a second name-matching rule.
+	for (const unit of units) {
+		for (const call of unit.facts.policyCalls) {
+			if (POLICY_FACTORIES.has(call)) policyHandles.set(unit.name, call);
+		}
+	}
+	propagateProbeReach(units, moduleDecls, policyHandles);
 
 	const found: AvailabilityUnit[] = [];
 	for (const unit of units) {
@@ -626,21 +691,29 @@ export async function analyzeAvailabilityUnits(
 function propagateProbeReach(
 	units: Array<{ name: string; facts: Omit<UnitFacts, "name"> }>,
 	moduleDecls: Map<string, Decl>,
+	policyHandles: Map<string, string>,
 ): void {
 	const byName = new Map(units.map((unit) => [unit.name, unit.facts]));
 	// Whether a unit spawns on its OWN, captured before propagation starts. A
 	// unit that owns its spawn owns its classification too, so it never inherits
 	// a neighbour's routing (that separation is why the gate judges per unit).
 	const ownSpawn = new Map(units.map((unit) => [unit.facts, unit.facts.spawns]));
-	// A unit that parks a BOOLEAN verdict of its own is a hand-rolled latch, and
-	// no amount of routing in the helper it borrows the spawn from makes that
-	// latch transient-aware. A review probe re-added #1494's own latch beside
-	// `getEslintProbe`, delegating the spawn to the routed factory, and the first
-	// version of this propagation read it as routed.
-	const ownBooleanMemo = new Map(
+	// WHITELIST (#1552): a unit may only inherit a callee's routing when its OWN
+	// memo is itself traceable to a policy factory — a handle, not a hand-rolled
+	// latch. The inverse (blacklist "not recognisably boolean") let anything
+	// unspoken through: a `Map<string, "yes" | "no">` string-union verdict, or a
+	// boolean reached through a type alias, neither of which spell "boolean",
+	// evaded it and inherited routing they never earned. A review probe re-added
+	// #1494's own latch beside `getEslintProbe`, delegating the spawn to the
+	// routed factory, and the first version of this propagation read it as
+	// routed for the same reason.
+	const ownPolicyHandleMemo = new Map(
 		units.map((unit) => [
 			unit.facts,
-			findMemo(unit.facts, moduleDecls, { booleanOnly: true }) !== null,
+			findMemo(unit.facts, moduleDecls, {
+				policyHandleOnly: true,
+				policyHandles,
+			}) !== null,
 		]),
 	);
 	let changed = true;
@@ -667,7 +740,7 @@ function propagateProbeReach(
 				if (
 					callee.spawns &&
 					!ownSpawn.get(unit.facts) &&
-					!ownBooleanMemo.get(unit.facts)
+					ownPolicyHandleMemo.get(unit.facts)
 				) {
 					for (const policyCall of callee.policyCalls) {
 						if (unit.facts.policyCalls.has(policyCall)) continue;


### PR DESCRIPTION
## What

Inverts the availability-policy coverage gate's routing-inheritance check
(`tests/support/availability-gate.ts`) from a boolean-shape blacklist to a
policy-handle whitelist.

Before: a unit that delegates its spawn to a routed helper inherited that
helper's coverage *unless* its own memo "looked boolean"
(`isBooleanVerdictShape`, a text match on `\bboolean\b` plus a bool-literal
check). Anything that never spelled "boolean" slipped through.

After: a unit inherits routing only when its own memo is traceably a policy
factory's handle — directly, or through one hop of a module-local wrapper
(`isPolicyHandleMemoShape`). Reuses the same name→factory `policyHandles` map
`collectUnit` already resolves member-call reach against, extended with
top-level functions whose own body hands its verdict straight to a factory
(`makeEslintProbe` → `createCwdCachedProbe`), rather than a second classifier.

## Why

Filed as #1552 from the #1529 round-2 review: `Map<string, "yes" | "no">`
(a string-union verdict) and a boolean reached through a type alias both
evade the blacklist, since neither spells "boolean" in the memo's own
declared type. A whitelist doesn't need to catch every disguise — an
unrecognised shape now defaults to *not* inheriting, which is the safe
default a blacklist can never offer.

## Verification

- `npm run build` before every test run.
- Four evasion fixtures added to `EVASIONS`
  (`tests/clients/availability-policy-coverage.test.ts`):
  - a string-union verdict (`Map<string, "yes" | "no">`) delegating its spawn
    to a routed helper
  - a hand-rolled boolean latch reached through a `type ToolVerdict = boolean`
    alias, delegating its spawn to a routed helper
  - a hand-rolled boolean latch reached through
    `ReturnType<typeof asVerdict>` — #1552's own second probe, added in the
    review round below
  - a hand-rolled boolean latch whose write inlines the routed wrapper's call,
    and a session-fact latch that delegates its spawn to a routed helper —
    both added in the review round below
- Full `availability-policy-coverage.test.ts` green on the fixed tree: 23/23.
- Regression check: dumped `scanClientsTree(repoRoot)` output before and
  after the change — all 22 real consumers the scan currently finds keep the
  exact same `governed` verdict (byte-identical output), reconfirmed after
  the review-round fix below.
- `npx tsc --noEmit` on both the build and full (test-inclusive) tsconfig:
  clean.
- Did not run the full repo test suite (per test-contention policy); ran the
  targeted file plus confirmed no other test file references
  `availability-gate` (`tests/clients/availability-policy-coverage.test.ts`
  is the only one). CI is authoritative for the full suite.

## Notes for reviewer

- #1529/#1532/#1534 (merged into master 2026-08-17) already introduced the
  `booleanOnly`/`isBooleanVerdictShape` blacklist this PR replaces — this
  branch was rebased onto current `origin/master` after the review round, so
  it sits on top of everything merged since, not a stale point.
- Known blind spot the whitelist has, same standing as on master before this
  fix: a `POLICY_FACTORY` imported under a renamed binding
  (`import { createCwdCachedProbe as ccp }`) doesn't match the canonical
  factory name — the boolean-shape blacklist had the identical gap, so this
  is not a regression, just carried forward. A wrapper reached through *two*
  hops of module-local helpers is also invisible, since `policyHandles` is
  built from each unit's own direct `policyCalls`, not propagated
  transitively. Both fail toward a false *negative* (an actually-routed unit
  reads as unrouted) — the safer direction.

## Review round (adversarial, head 41c47b93 → 127d1ad8)

An adversarial review found two HIGH false positives in the first round's
whitelist implementation, both now fixed on this branch:

- **F1 (HIGH).** `isPolicyHandleMemoShape` folded a write's own inlined
  expression into the shape it tested, alongside the declaration's
  type/value. A latch that inlines the routed wrapper's call straight into
  the write site (`cache.set(cwd, await makeToolProbe(cwd))`) against a plain
  `Map<string, boolean>` declaration let the wrapper's name leak into the
  shape and pass as a handle. Fixed: the check now reads only the
  declaration's own `typeText`/`valueText`, never a write's text.
- **F2 (HIGH).** `findMemo`'s `sessionFact` early return fired before the
  `policyHandleOnly` branch could run, so any unit recording a session fact
  read as holding a policy handle regardless of shape — `setSessionFact`
  never calls a factory and must not grant inheritance by itself. Fixed:
  guarded the return on `!policyHandleOnly`.
- **F3.** The header's blind-spot note claimed both known gaps were false
  *negatives*; F1/F2 were false *positives*, so the claim was wrong on its
  own terms. Rewritten to describe the actual gaps (renamed import alias,
  two-hop wrapper — both false negatives) separately from the two fixed false
  positives.
- **F4.** Added #1552's own literal second probe
  (`ReturnType<typeof asVerdict>`) as a distinct fixture, and corrected the
  header to not claim the renamed-import blind spot as new to this PR — it
  already existed on the blacklist it replaces.

Red-first proof for both new probes, against the pre-fix head (41c47b93):
`npx vitest run tests/clients/availability-policy-coverage.test.ts` — both
new tests failed (`an unrouted latch was reported as routed through the
policy`), 21/23 passed. After the fix: 23/23 passed. The 22-consumer
`scanClientsTree` dump stayed byte-identical before and after. Rebased onto
current `origin/master` (no conflicts — no other open work touches these two
files). Pushed to `127d1ad8`; `gh pr checks` confirms Unit tests and Lint &
type-check both executed (not skipped) and passed on that head.

Refs #1552
