### PR TITLE
Availability gate: anchor policy-handle detection to type constructors (closes #1566)

### DIFF
--- a/.changelog/fix-1566-policy-handle-type-constructor.md
+++ b/.changelog/fix-1566-policy-handle-type-constructor.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **The availability-policy coverage gate no longer inherits routing from a memo that merely mentions a policy handle's name (refs #1566)** — The #1552 whitelist checked whether a policy handle's name appeared anywhere in the memo's declared type or value. A memo typed `Awaited<ReturnType<ReturnType<typeof makeToolProbe>>>` unwraps a routed wrapper's return type down to a plain boolean, and a memo built by `emptyCache<boolean>(makeToolProbe)` merely hands the wrapper to an unrelated helper as an argument — both spell the handle's name without holding the handle, and both inherited routing they never earned. The gate now requires the handle's name to be the memo's own un-nested `ReturnType<typeof name>` or its own direct `= name(...)` call, so a name present anywhere else in the text no longer counts.

--- a/tests/clients/availability-policy-coverage.test.ts
+++ b/tests/clients/availability-policy-coverage.test.ts
@@ -399,6 +399,69 @@ const EVASIONS: ReadonlyArray<{ name: string; source: string }> = [
 		`,
 	},
 	{
+		// #1566 (NE1). The whitelist's handle-name check was a bare `\bname\b`
+		// substring test over the memo's declared type, so a type that merely
+		// MENTIONS the wrapper's name still passed even after unwrapping it all
+		// the way down to a plain boolean. `ReturnType<ReturnType<typeof
+		// makeToolProbe>>` takes the wrapper's own return type apart twice, and
+		// `Awaited<...>` strips the outer promise, landing on the same bare
+		// `boolean` the blacklist used to catch by word alone — the handle's
+		// name is present in the text, but the memo does not hold the handle.
+		name: "a boolean latch typed by unwrapping the wrapper's own return type",
+		source: `
+			import { createCwdCachedProbe } from "./dispatch/runners/utils/runner-helpers.js";
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			function makeToolProbe(cmd: string) {
+				return createCwdCachedProbe(
+					(cwd) => safeSpawnAsync(cmd, ["--version"], { timeout: 5000, cwd }),
+					{ tool: "newtool" },
+				);
+			}
+			const toolAvailableByCwd = new Map<
+				string,
+				Awaited<ReturnType<ReturnType<typeof makeToolProbe>>>
+			>();
+			export async function getToolProbe(cmd: string, cwd: string): Promise<boolean> {
+				const hit = toolAvailableByCwd.get(cwd);
+				if (hit !== undefined) return hit;
+				const verdict = await makeToolProbe(cmd)(cwd);
+				toolAvailableByCwd.set(cwd, verdict);
+				return verdict;
+			}
+		`,
+	},
+	{
+		// #1566 (NE2). Same laundering as NE1, from the other direction: the
+		// handle's name shows up only as a bare CALL ARGUMENT to an unrelated
+		// helper, never as the memo's own type. `emptyCache<boolean>` is what
+		// actually shapes the memo — a boolean map — and `makeToolProbe` is
+		// merely handed to it, the way a probe factory might be handed to a
+		// scheduler. Master's blacklist caught this one by luck (the word
+		// "boolean" in the call's own type argument); the whitelist has no
+		// such luck to fall back on and must refuse on shape, not on which
+		// names appear in the text.
+		name: "a boolean cache from a helper that merely takes the wrapper as an argument",
+		source: `
+			import { createCwdCachedProbe } from "./dispatch/runners/utils/runner-helpers.js";
+			import { safeSpawnAsync } from "./safe-spawn.js";
+			import { emptyCache } from "./cache-utils.js";
+			function makeToolProbe(cmd: string) {
+				return createCwdCachedProbe(
+					(cwd) => safeSpawnAsync(cmd, ["--version"], { timeout: 5000, cwd }),
+					{ tool: "newtool" },
+				);
+			}
+			const cache = emptyCache<boolean>(makeToolProbe);
+			export async function getToolProbe(cmd: string, cwd: string): Promise<boolean> {
+				const hit = cache.get(cwd);
+				if (hit !== undefined) return hit;
+				const verdict = await makeToolProbe(cmd)(cwd);
+				cache.set(cwd, verdict);
+				return verdict;
+			}
+		`,
+	},
+	{
 		name: "the defect shape plus a comment that names availability-policy.js",
 		source: `
 			import { safeSpawnAsync } from "./safe-spawn.js";

--- a/tests/support/availability-gate.ts
+++ b/tests/support/availability-gate.ts
@@ -76,7 +76,24 @@
  *     session-fact check returned non-null unconditionally, so either read as
  *     a policy handle and inherited routing it never earned — the false
  *     POSITIVE the whitelist exists to rule out. Both are fixed; the
- *     `EVASIONS` fixtures below pin them.
+ *     `EVASIONS` fixtures below pin them;
+ *   * (#1566) the same "reads only the declared shape" rule from the point
+ *     above had its own gap: the shape check was a bare `\bname\b` substring
+ *     test, so a declared type or value that merely MENTIONED a handle's
+ *     name — anywhere in the text — passed, whether or not the memo actually
+ *     held that handle. `Map<string, Awaited<ReturnType<ReturnType<typeof
+ *     makeToolProbe>>>>` unwraps the wrapper's own return type twice and
+ *     peels the promise, landing on a plain `boolean`; `emptyCache<boolean>
+ *     (makeToolProbe)` merely hands the wrapper to an unrelated helper as an
+ *     argument. Both spell the handle's name and neither holds it. The check
+ *     is now shape-anchored: a handle counts only when its name is the
+ *     memo's own un-nested `ReturnType<typeof name>` (what a legitimate
+ *     one-hop wrapper like `makeEslintProbe` still spells exactly) or the
+ *     memo's own direct `= name(...)` call — never a name merely present
+ *     somewhere in the text. This closes the two fixtures below without
+ *     narrowing the one-hop wrapper case #1552 was built for; the residual
+ *     blind spots two points above (transitive wrapper hops, renamed policy
+ *     imports) are unchanged and still tracked there.
  */
 
 import * as fs from "node:fs";
@@ -477,12 +494,65 @@ function isPolicyHandleMemoShape(
 ): boolean {
 	const shape = `${decl?.typeText ?? ""} ${decl?.valueText ?? ""}`;
 	for (const factory of POLICY_FACTORIES) {
-		if (new RegExp(`\\b${factory}\\b`).test(shape)) return true;
+		if (
+			isDeclaredAsTypeConstructor(shape, factory) ||
+			isDirectCall(shape, factory)
+		) {
+			return true;
+		}
 	}
 	for (const handleName of policyHandles.keys()) {
-		if (new RegExp(`\\b${handleName}\\b`).test(shape)) return true;
+		if (
+			isDeclaredAsTypeConstructor(shape, handleName) ||
+			isDirectCall(shape, handleName)
+		) {
+			return true;
+		}
 	}
 	return false;
+}
+
+/**
+ * Does `name` appear as the memo's own `ReturnType<typeof name>` — one hop,
+ * un-nested — rather than merely somewhere in the declaration's text? (#1566)
+ *
+ * The bare `\bname\b` substring test this replaces reads the handle's name
+ * off ANY position in the type, so unwrapping a wrapper's return type all
+ * the way down to a plain `boolean` (`Awaited<ReturnType<ReturnType<typeof
+ * makeToolProbe>>>`) still spelled the name and passed — the type mentions
+ * the handle, but the memo does not hold it. Requiring `ReturnType<typeof
+ * name>` to sit un-wrapped (nothing but whitespace, `Map<string, …>`, or the
+ * start of the text immediately before it) is what a legitimate one-hop
+ * wrapper handle (`Map<string, ReturnType<typeof makeEslintProbe>>`, #1494)
+ * still spells exactly, while the doubled/`Awaited`-peeled evasion above
+ * does not — its `ReturnType<typeof name>` is immediately preceded by
+ * another `ReturnType<` or `Awaited<`, which this rejects.
+ */
+function isDeclaredAsTypeConstructor(shape: string, name: string): boolean {
+	const normalized = shape.replace(/\s+/g, "");
+	const needle = `ReturnType<typeof${name}>`;
+	let from = 0;
+	for (;;) {
+		const at = normalized.indexOf(needle, from);
+		if (at === -1) return false;
+		const before = normalized.slice(Math.max(0, at - "ReturnType<".length), at);
+		if (!/(?:ReturnType|Awaited)<$/.test(before)) return true;
+		from = at + 1;
+	}
+}
+
+/**
+ * Does the declaration's own value directly CALL `name` — `= name(...)` —
+ * rather than merely pass `name` as an argument to something else? (#1566)
+ *
+ * `emptyCache<boolean>(makeToolProbe)` hands the wrapper to an unrelated
+ * helper; the memo it produces is whatever `emptyCache` returns (a plain
+ * boolean map), not the wrapper's own handle. A bare substring test could
+ * not tell "calls" from "is handed to", which is exactly how that shape
+ * inherited routing it never earned.
+ */
+function isDirectCall(shape: string, name: string): boolean {
+	return baseName(shape.trim().split("(")[0] ?? "") === name;
 }
 
 /** Is `outer` a strictly enclosing scope of `inner`? Keys are source ranges. */


### PR DESCRIPTION
## What

Both NE1/NE2 fixtures from #1566 are now pinned in `EVASIONS` and the
underlying whitelist gap they exercise is fixed, not just documented.

## Why

The #1552 whitelist (`isPolicyHandleMemoShape`) decided whether a unit
may inherit a delegated probe's routing by testing whether a policy
handle's name appeared **anywhere** in the memo's declared type or
value text (`\bname\b`). Two shapes spelled the name without holding
the handle:

- **NE1**: `Map<string, Awaited<ReturnType<ReturnType<typeof
  makeToolProbe>>>>` unwraps the wrapper's own return type twice and
  peels the promise, landing on a plain `boolean`.
- **NE2**: `emptyCache<boolean>(makeToolProbe)` hands the wrapper to
  an unrelated helper as a bare call argument; the memo it produces is
  whatever `emptyCache` returns, not the wrapper's handle.

Both inherited routing coverage they never earned.

## Fix

`isPolicyHandleMemoShape` now requires a handle's name to be the
memo's own **un-nested** `ReturnType<typeof name>` (rejecting a name
immediately wrapped by another `ReturnType<` or `Awaited<`), or the
memo's own **direct** `= name(...)` call — never a name merely present
somewhere in the text. The legitimate one-hop wrapper shape #1552 was
built for (`Map<string, ReturnType<typeof makeEslintProbe>>`, the real
`eslint.ts`/`rust-clippy.ts` consumers) still spells exactly that
pattern and keeps its verdict.

## Verification

- Both NE1/NE2 fixtures proven red on pre-fix code (checked out the
  pre-fix `availability-gate.ts`, re-ran with the fixtures added —
  both failed with `governed: true`), then green after the narrowing.
- `npx vitest run tests/clients/availability-policy-coverage.test.ts`
  — 25/25 pass, including all existing evasions, the known-consumer
  coverage check, and the two new fixtures.
- `scanClientsTree`'s dump over the real `clients/` tree diffed
  byte-for-byte before/after the fix — identical. No false positive
  and no false negative on any of the 22 known real consumers.
- `npm run build` clean before every test run.
- Full suite deferred to CI (repo policy: targeted files during
  iteration, full suite is CI's job).

No other open PR touches `tests/support/availability-gate.ts` or
`tests/clients/availability-policy-coverage.test.ts` (checked via `gh
pr list` + file lists), so no merge-order conflict expected.

Refs #1489, refs #1552, refs #1558.
Closes #1566.