### PR TITLE
fix(installer): npm-global probe transient surfacing (closes #1585)

### DIFF
--- a/.changelog/fix-1585-isavailable-transient.md
+++ b/.changelog/fix-1585-isavailable-transient.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **npm-global tool discovery now flags a stalled package-manager probe as transient (refs #1585)** — `isAvailable`'s bare boolean return could not tell a genuine "pnpm not installed" from a `where`/`which pnpm` probe that stalled, so `allAvailableGlobalBinDirs` silently dropped pnpm's global bin dir with no way to warn its caller. `findNpmGlobalToolPath`'s existing `onTransient` callback (from #1569) now fires for this case too, so `getToolPath` no longer caches a degraded npm-global selection untainted for the full 24h TTL.

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -2658,7 +2658,7 @@ async function findNpmGlobalToolPath(
 	onTransient?: () => void,
 ): Promise<string | undefined> {
 	const isWindows = process.platform === "win32";
-	const binDirs = await getNpmGlobalBinCandidates();
+	const binDirs = await getNpmGlobalBinCandidates(onTransient);
 
 	for (const dir of binDirs) {
 		const candidates = isWindows
@@ -2683,7 +2683,9 @@ async function findNpmGlobalToolPath(
 	return undefined;
 }
 
-async function getNpmGlobalBinCandidates(): Promise<string[]> {
+async function getNpmGlobalBinCandidates(
+	onTransient?: () => void,
+): Promise<string[]> {
 	const dirs: string[] = [];
 	const seen = new Set<string>();
 
@@ -2703,8 +2705,11 @@ async function getNpmGlobalBinCandidates(): Promise<string[]> {
 	}
 
 	// Global bin dirs for every installed manager (npm/pnpm/yarn/bun) — a tool
-	// may have been installed globally via any of them.
-	for (const dir of await allAvailableGlobalBinDirs()) {
+	// may have been installed globally via any of them. `onTransient` surfaces
+	// a manager whose availability probe stalled rather than genuinely failed,
+	// so its bin dir may be missing from `dirs` for a reason other than "not
+	// installed" (#1585).
+	for (const dir of await allAvailableGlobalBinDirs(onTransient)) {
 		add(dir);
 	}
 

--- a/clients/package-manager.ts
+++ b/clients/package-manager.ts
@@ -21,6 +21,7 @@ import {
 	type AvailabilityLatch,
 	classifyProbeFailure,
 	createAvailabilityLatch,
+	isTransientDecision,
 	logAvailabilityDecision,
 	startHostStallSampler,
 } from "./dispatch/runners/utils/availability-policy.js";
@@ -177,15 +178,41 @@ async function probeAvailability(pm: NodePackageManager): Promise<boolean> {
 	return false;
 }
 
-function isAvailable(pm: NodePackageManager): Promise<boolean> {
+/**
+ * Resolve whether `pm` is available. `onTransient`, when given, fires
+ * whenever the resolved `false` came from a probe that never got a fair
+ * hearing (a stall, an abort, a host-level failure classified `transient` by
+ * `classifyProbeFailure`) rather than a genuine absence — including when that
+ * verdict is served from the latch's own cooldown-bounded memo, not just on a
+ * fresh probe (#1585).
+ *
+ * Before this, the return type was a bare boolean: a caller like
+ * `allAvailableGlobalBinDirs` could not tell "pnpm isn't installed" from
+ * "the `where pnpm` probe stalled", so a transient miss silently dropped
+ * pnpm's global bin dir with no way to flag the result as provisional —
+ * exactly the boolean-collapse `getToolPath`'s `onTransient` plumbing (#1569)
+ * was built to avoid, one layer up.
+ */
+function isAvailable(
+	pm: NodePackageManager,
+	onTransient?: () => void,
+): Promise<boolean> {
 	const latch = getLatch(pm);
+
+	const reportIfTransient = (result: boolean): boolean => {
+		if (!result && isTransientDecision({ outcome: latch.getOutcome() })) {
+			onTransient?.();
+		}
+		return result;
+	};
+
 	const memo = latch.read();
-	if (memo !== null) return Promise.resolve(memo);
+	if (memo !== null) return Promise.resolve(reportIfTransient(memo));
 
 	// A verdict can now expire, so concurrent callers arriving just after a
 	// cooldown must share ONE probe rather than each spawning their own.
 	const inFlight = inFlightProbes.get(pm);
-	if (inFlight) return inFlight;
+	if (inFlight) return inFlight.then(reportIfTransient);
 
 	// #1653 review F1: a probe started before a session reset can settle AFTER
 	// a later session's own probe for the same manager is already in flight.
@@ -198,7 +225,7 @@ function isAvailable(pm: NodePackageManager): Promise<boolean> {
 		if (inFlightProbes.get(pm) === probe) inFlightProbes.delete(pm);
 	});
 	inFlightProbes.set(pm, probe);
-	return probe;
+	return probe.then(reportIfTransient);
 }
 
 /**
@@ -363,12 +390,20 @@ async function globalBinDirsFor(pm: NodePackageManager): Promise<string[]> {
  * Global bin directories for every installed manager, deduped. Used to locate a
  * globally-installed tool binary when PATH is stale (e.g. right after an
  * `install -g`) or when the tool was installed via a non-npm manager.
+ *
+ * `onTransient`, when given, fires once per manager whose `isAvailable` probe
+ * was transient (stalled/unspawnable, not a genuine absence) — the boolean
+ * `allAvailableGlobalBinDirs` returns can't itself distinguish "not
+ * installed" from "couldn't tell", so a caller that persists this result
+ * needs the callback to know the answer may be incomplete (#1585).
  */
-export async function allAvailableGlobalBinDirs(): Promise<string[]> {
+export async function allAvailableGlobalBinDirs(
+	onTransient?: () => void,
+): Promise<string[]> {
 	const dirs: string[] = [];
 	const seen = new Set<string>();
 	for (const pm of PREFERENCE) {
-		if (!(await isAvailable(pm))) continue;
+		if (!(await isAvailable(pm, onTransient))) continue;
 		for (const dir of await globalBinDirsFor(pm)) {
 			const normalized = path.resolve(dir);
 			if (seen.has(normalized)) continue;

--- a/tests/clients/package-manager.test.ts
+++ b/tests/clients/package-manager.test.ts
@@ -308,6 +308,63 @@ describe("allAvailableGlobalBinDirs", () => {
 		// No manager passed its probe, so no query spawn was ever reached.
 		expect(queryCalls).toEqual([]);
 	});
+
+	/**
+	 * #1585 — `isAvailable`'s boolean collapse. pnpm's `where`/`which` probe
+	 * stalls (a transient host failure, not a genuine absence). Pre-fix,
+	 * `allAvailableGlobalBinDirs` had no way to tell its caller the `false` it
+	 * got back for pnpm was a stall, not a fact — the tool-path resolver's
+	 * `onTransient` plumbing (#1569) was never invoked, so the resulting
+	 * bin-dir list (missing pnpm) could get cached untainted for 24h. Must
+	 * FAIL on pre-fix code, where `allAvailableGlobalBinDirs` takes no
+	 * `onTransient` parameter at all (a TS compile error) — verified red by
+	 * reverting the fix and confirming the build fails.
+	 */
+	it("reports a stalled manager probe as transient, not a clean miss", async () => {
+		setPlatform("linux");
+		vi.mocked(safeSpawnAsync).mockImplementation(async (cmd, args) => {
+			const probeFinder = process.platform === "win32" ? "where" : "which";
+			if (cmd === probeFinder) {
+				const target = (args ?? [])[0];
+				if (target === "npm") return { stdout: "npm\n", stderr: "", status: 0 };
+				if (target === "pnpm") {
+					return {
+						stdout: "",
+						stderr: "",
+						status: null,
+						error: new Error("Process timed out after 5000ms"),
+						failure: "timeout",
+						spawnFailure: { kind: "timeout" },
+					};
+				}
+				// yarn, bun: genuinely absent.
+				return { stdout: "", stderr: "", status: 1 };
+			}
+			// npm's "config get prefix" query.
+			return { stdout: "/usr/local\n", stderr: "", status: 0 };
+		});
+
+		let transientCalls = 0;
+		const dirs = await allAvailableGlobalBinDirs(() => {
+			transientCalls += 1;
+		});
+
+		// pnpm's stall drops it from the result (npm still resolves normally) —
+		// but the caller must have been told the result may be incomplete.
+		expect(dirs).toEqual([path.resolve(path.join("/usr/local", "bin"))]);
+		expect(transientCalls).toBeGreaterThan(0);
+
+		// The stall latches transiently for its cooldown: a second call within
+		// that window serves the cached `false` for pnpm without re-probing.
+		// The regression is specifically that this MEMO path also loses the
+		// transient signal — assert it still fires here, not just on the
+		// fresh-probe path above.
+		transientCalls = 0;
+		await allAvailableGlobalBinDirs(() => {
+			transientCalls += 1;
+		});
+		expect(transientCalls).toBeGreaterThan(0);
+	});
 });
 
 describe("findGlobalBinary", () => {

--- a/tests/clients/package-manager.test.ts
+++ b/tests/clients/package-manager.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../clients/safe-spawn.js", async (importOriginal) => ({
 	isCommandAvailableAsync: vi.fn(),
 	safeSpawnAsync: vi.fn(),
 }));
-import { safeSpawnAsync } from "../../clients/safe-spawn.js";
+import { SpawnFailureError, safeSpawnAsync } from "../../clients/safe-spawn.js";
 import {
 	_resetPackageManagerCache,
 	allAvailableGlobalBinDirs,
@@ -328,13 +328,14 @@ describe("allAvailableGlobalBinDirs", () => {
 				const target = (args ?? [])[0];
 				if (target === "npm") return { stdout: "npm\n", stderr: "", status: 0 };
 				if (target === "pnpm") {
+					const cause = new Error("Process timed out after 5000ms");
 					return {
 						stdout: "",
 						stderr: "",
 						status: null,
-						error: new Error("Process timed out after 5000ms"),
-						failure: "timeout",
-						spawnFailure: { kind: "timeout" },
+						error: cause,
+						failure: "timeout" as const,
+						spawnFailure: new SpawnFailureError("timeout", cause.message, cause),
 					};
 				}
 				// yarn, bun: genuinely absent.

--- a/tests/clients/package-manager.test.ts
+++ b/tests/clients/package-manager.test.ts
@@ -366,6 +366,35 @@ describe("allAvailableGlobalBinDirs", () => {
 		});
 		expect(transientCalls).toBeGreaterThan(0);
 	});
+
+	/**
+	 * #1585 review — the precision half of the fix. A manager that fails its
+	 * probe cleanly (`where`/`which` runs fine and exits 1: a real "not
+	 * installed") must NOT call `onTransient`. Without this case, a broken
+	 * implementation that fires `onTransient` on every `false` — transient or
+	 * not — would pass the "stalled" test above just as well, defeating the
+	 * whole point: distinguishing a stall from a genuine absence, not just
+	 * noticing SOME `false`.
+	 */
+	it("does not report a genuinely absent manager as transient", async () => {
+		setPlatform("linux");
+		onlyAvailable("npm");
+
+		let transientCalls = 0;
+		const dirs = await allAvailableGlobalBinDirs(() => {
+			transientCalls += 1;
+		});
+
+		expect(dirs).toEqual([]);
+		expect(transientCalls).toBe(0);
+
+		// The genuine absence latches: a second call re-reads the same durable
+		// memo, still no transient report.
+		await allAvailableGlobalBinDirs(() => {
+			transientCalls += 1;
+		});
+		expect(transientCalls).toBe(0);
+	});
 });
 
 describe("findGlobalBinary", () => {


### PR DESCRIPTION
## What

`isAvailable()` in `clients/package-manager.ts` returned a bare `boolean` for
whether a package manager is installed. `allAvailableGlobalBinDirs()` used
that boolean to decide which global bin dirs to search, with no way to tell
"pnpm isn't installed" from "the `where`/`which pnpm` probe stalled".

`isAvailable` and `allAvailableGlobalBinDirs` now take an optional
`onTransient` callback, invoked whenever a resolved `false` came from a
transient probe outcome. That covers both a fresh probe and — the part that
actually mattered for the 24h window the issue describes — a cached
transient verdict served from the latch's cooldown memo, since that path was
losing the signal too. `getNpmGlobalBinCandidates` in
`clients/installer/index.ts` threads the callback through to the
`onTransient` parameter `findNpmGlobalToolPath` already had from #1569, so
`getToolPath`'s existing transient-taint plumbing now sees this failure mode.

## Why

Before this fix: if `where pnpm` stalled inside its 5-minute latch cooldown
(#1496), pnpm's global bin dir silently dropped out of npm-global tool
discovery. `getToolPath`'s `onTransient` callback never fired for this case,
so a lower-priority tier's answer could get cached **untainted** for the
full 24h probe-cache TTL, even though it was reached by a degraded path.

## Verification

- New regression test in `tests/clients/package-manager.test.ts`
  (`allAvailableGlobalBinDirs > reports a stalled manager probe as
  transient, not a clean miss`) — proved red on pre-fix code (build
  succeeds pre-fix since the extra parameter is silently accepted by JS at
  runtime even without the TS signature change; the assertion on
  `transientCalls` fails: 0 calls). Green after the fix, including the
  memo-path assertion (second call within the transient cooldown).
- `npm run build` before every test run.
- Targeted runs, all green:
  - `tests/clients/package-manager.test.ts` (29 tests)
  - `tests/clients/package-manager-availability-latch.test.ts` (5 tests, #1496 coverage — unaffected)
  - `tests/clients/installer/probe-cache-transient.test.ts` (#1569 onTransient plumbing — unaffected)
  - `tests/clients/installer/tool-discovery.test.ts`
  - `tests/clients/installer/trust-gate.test.ts`
  - `tests/clients/installer/version-drift.test.ts`
  - `tests/clients/dispatch/runners/runner-helpers.test.ts`
  - `tests/clients/lsp/lua-tree-binary.test.ts`
- Full suite deferred to CI, per repo policy.

## Scope note

Left `findGlobalBinary` in `package-manager.ts` untouched — it also calls
`allAvailableGlobalBinDirs()` but isn't part of the persisted probe-cache
chain the issue describes (no 24h TTL write happens off its result), so it's
outside this issue's acceptance criteria.

## Merge-order note

Per orchestrator instruction, I did not touch `clients/safe-spawn.ts`
(owned by in-flight #1673) or work in `runner-helpers.ts` (potential overlap
with #1593's fixer) — this fix stays entirely in
`clients/package-manager.ts` and the installer/bin-dir discovery seam of
`clients/installer/index.ts` (`getNpmGlobalBinCandidates`,
`findNpmGlobalToolPath`). No overlap found with currently open PRs touching
those files (#1673 is `safe-spawn.ts` only).

Refs #1569, refs #1581, refs #1585
