### PR TITLE
fix(availability): retained winner cannot outlive its own durable miss (closes #1593)

### DIFF
--- a/.changelog/fix-1593-retained-arm-durable-miss.md
+++ b/.changelog/fix-1593-retained-arm-durable-miss.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **The retained-winner arm no longer re-serves an ast-grep command this same sweep just proved gone** — both the shared `isSgAvailableAsync` sweep and `SgRunner.ensureAvailable()` retain a provisional winner across a stalled sibling tier, but neither checked whether the memoized winner itself was among the candidates that ENOENTed in that same pass. A previous provisional winner (say `npx`) that goes durably missing while an unrelated tier merely stalls used to still answer available with the dead command; the sweep now tracks which candidates it proved durably absent and skips the retained arm when the memoized command is one of them, falling through to the genuine-absence path instead (#1593).

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -1594,6 +1594,15 @@ let sgSweepHostStallMs = 0;
  * list is written to latency.log (#1568 review F3).
  */
 let sgSweepUnreachable: string[] = [];
+/**
+ * Candidates that were probed and answered DURABLY missing this sweep — a
+ * real ENOENT/non-installable verdict, not a stall (#1593). The retained-arm
+ * fallback below only knows the sweep saw SOME transient candidate; without
+ * this list it cannot tell "the memoized winner itself just proved absent"
+ * from "an unrelated sibling merely stalled", and re-serves a command this
+ * very sweep disproved.
+ */
+let sgSweepDurablyMissing: string[] = [];
 
 function isAstGrepVersionOutput(output: string): boolean {
 	return /\bast[- ]grep\b/i.test(output);
@@ -1627,6 +1636,8 @@ async function probeAstGrepCommandAsync(
 		sgSweepTransientCause = cause;
 		const name = path.basename(cmd);
 		if (!sgSweepUnreachable.includes(name)) sgSweepUnreachable.push(name);
+	} else if (!sgSweepDurablyMissing.includes(cmd)) {
+		sgSweepDurablyMissing.push(cmd);
 	}
 	return false;
 }
@@ -1688,6 +1699,7 @@ export async function isSgAvailableAsync(): Promise<boolean> {
 		sgSweepTransientCause = "probe-timeout";
 		sgSweepHostStallMs = 0;
 		sgSweepUnreachable = [];
+		sgSweepDurablyMissing = [];
 		// 1. Local node_modules/.bin
 		for (const localBin of buildSgLocalBins()) {
 			if (await probeAstGrepCommandAsync(localBin)) {
@@ -1725,8 +1737,15 @@ export async function isSgAvailableAsync(): Promise<boolean> {
 		// #1476's principle applies to the result as much as to the probe: a
 		// timeout says nothing about the tool, so it cannot erase a command this
 		// process proved working one cooldown ago. Keep serving it and re-arm
-		// (#1568 review F1).
-		if (sgSweepSawTransient && sgLatch.isProvisional() && sgCmd !== null) {
+		// (#1568 review F1) — UNLESS this very sweep just proved the memoized
+		// command durably missing (#1593): a sibling tier stalling is not license
+		// to re-serve a winner that ENOENTed a moment ago in the same pass.
+		if (
+			sgSweepSawTransient &&
+			sgLatch.isProvisional() &&
+			sgCmd !== null &&
+			!sgSweepDurablyMissing.includes(sgCmd)
+		) {
 			noteSgAvailable(startedAt, { retained: true });
 			return true;
 		}

--- a/clients/sg-runner.ts
+++ b/clients/sg-runner.ts
@@ -221,6 +221,15 @@ export class SgRunner {
 	private sweepFallbackCause: AvailabilityCause = "probe-timeout";
 	/** Host stall summed over every probe of the current sweep, ms. */
 	private sweepHostStallMs = 0;
+	/**
+	 * Candidates — direct or fallback — that this sweep probed and found
+	 * DURABLY missing (real ENOENT/non-installable, not a stall) (#1593). The
+	 * retained-arm fallback below only sees whether SOME candidate stalled; this
+	 * list lets it also check whether the memoized winner itself is one of the
+	 * candidates this very sweep just disproved, rather than re-serving a
+	 * command that ENOENTed a moment ago because an unrelated sibling stalled.
+	 */
+	private sweepDurablyMissing: string[] = [];
 
 	constructor(verbose = false) {
 		this.log = verbose
@@ -259,6 +268,7 @@ export class SgRunner {
 		this.sweepFallbackTransient = false;
 		this.sweepFallbackCause = "probe-timeout";
 		this.sweepHostStallMs = 0;
+		this.sweepDurablyMissing = [];
 
 		// Step 1: PATH — canonical binary names + npx fallback.
 		// Prefer ast-grep over sg on Linux: /usr/bin/sg is util-linux, not ast-grep.
@@ -332,7 +342,13 @@ export class SgRunner {
 			// run #1476 backwards — a timeout erasing a positive result — and it
 			// would send the sweep on to Step 4 to install a tool that is already
 			// runnable. Keep the winner and re-arm the cooldown (#1568 review F1).
-			if (this.availabilityLatch.isProvisional() && this.sgPath) {
+			// #1593: a sibling tier stalling this sweep is not license to re-serve
+			// a winner that THIS SAME sweep just proved durably missing.
+			if (
+				this.availabilityLatch.isProvisional() &&
+				this.sgPath &&
+				!this.sweepDurablyMissing.includes(this.sgPath)
+			) {
 				this.noteAvailable(
 					startedAt,
 					`ast-grep re-probe stalled; keeping ${this.sgPath}`,
@@ -610,6 +626,8 @@ export class SgRunner {
 					this.sweepUnreachable.push(name);
 				}
 			}
+		} else if (!this.sweepDurablyMissing.includes(cmd)) {
+			this.sweepDurablyMissing.push(cmd);
 		}
 		return false;
 	}

--- a/tests/clients/dispatch/runners/runner-helpers.test.ts
+++ b/tests/clients/dispatch/runners/runner-helpers.test.ts
@@ -343,6 +343,72 @@ describe("runner-helpers availability checker", () => {
 		expect(getSgCommand().cmd).toContain("ast-grep");
 	});
 
+	it("does not re-serve a retained ast-grep winner this sweep just proved durably missing (#1593)", async () => {
+		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
+		try {
+			vi.useFakeTimers({ toFake: ["Date"] });
+			vi.setSystemTime(new Date(1_700_000_000_000));
+
+			// Sweep 1: every earlier tier stalls (transient); npx answers, so the
+			// win is provisional and memoized as `cmd: "npx"`.
+			vi.mocked(safeSpawnMod.safeSpawnAsync).mockImplementation(((
+				cmd: string,
+			) => {
+				if (cmd === "npx") {
+					return Promise.resolve({
+						stdout: "ast-grep 0.40.0",
+						stderr: "",
+						status: 0,
+					});
+				}
+				return Promise.resolve({
+					stdout: "",
+					stderr: "",
+					status: null,
+					failure: "timeout",
+					spawnFailure: { kind: "timeout" },
+				});
+			}) as never);
+			expect(await isSgAvailableAsync()).toBe(true);
+			expect(getSgCommand().cmd).toBe("npx");
+
+			// Let the provisional cooldown expire so the next call re-sweeps
+			// instead of serving the memoized verdict straight from the latch.
+			vi.setSystemTime(new Date(Date.now() + 301_000));
+
+			// Sweep 2: the memoized winner (npx) now ENOENTs — durably missing —
+			// while an unrelated earlier tier merely stalls again. The retained
+			// arm must NOT re-serve the dead `npx` command just because a sibling
+			// stalled in the same sweep.
+			vi.mocked(safeSpawnMod.safeSpawnAsync).mockImplementation(((
+				cmd: string,
+			) => {
+				if (cmd === "npx") {
+					return Promise.resolve({
+						stdout: "",
+						stderr: "",
+						status: null,
+						error: Object.assign(new Error("npx ENOENT"), {
+							code: "ENOENT",
+						}),
+						failure: "spawn",
+						spawnFailure: { kind: "tool-not-found" },
+					});
+				}
+				return Promise.resolve({
+					stdout: "",
+					stderr: "",
+					status: null,
+					failure: "timeout",
+					spawnFailure: { kind: "timeout" },
+				});
+			}) as never);
+			expect(await isSgAvailableAsync()).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("bounds missing-tool installs to one attempt and records the failure", async () => {
 		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
 		const installerMod = await import("../../../../clients/installer/index.js");

--- a/tests/clients/sg-runner.test.ts
+++ b/tests/clients/sg-runner.test.ts
@@ -158,6 +158,66 @@ describe("SgRunner", () => {
 			await runner.ensureAvailable();
 			expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
 		});
+
+		it("does not re-serve a retained ast-grep winner this sweep just proved durably missing (#1593)", async () => {
+			try {
+				vi.useFakeTimers({ toFake: ["Date"] });
+				vi.setSystemTime(new Date(1_700_000_000_000));
+
+				const { SgRunner } = await import("../../clients/sg-runner.js");
+				const runner = new SgRunner();
+
+				// Sweep 1: the direct candidates (ast-grep, sg) stall (transient);
+				// the npx fallback answers, so the win is provisional and memoized
+				// as the npx command.
+				safeSpawnAsync.mockImplementation(async (cmd: string) => {
+					if (cmd === "npx") {
+						return { status: 0, error: null, stdout: "ast-grep 0.42.1", stderr: "" };
+					}
+					return {
+						status: null,
+						error: undefined,
+						stdout: "",
+						stderr: "",
+						failure: "timeout" as const,
+						spawnFailure: { kind: "timeout" as const },
+					};
+				});
+				expect(await runner.ensureAvailable()).toBe(true);
+
+				// Let the provisional cooldown expire so the next call re-sweeps
+				// instead of serving the memoized verdict straight from the latch.
+				vi.setSystemTime(new Date(Date.now() + 301_000));
+
+				// Sweep 2: the memoized winner (npx) now ENOENTs — durably missing —
+				// while ast-grep/sg merely stall again. The retained arm must NOT
+				// re-serve the dead `npx` command just because a sibling stalled in
+				// the same sweep.
+				safeSpawnAsync.mockImplementation(async (cmd: string) => {
+					if (cmd === "npx") {
+						return {
+							status: null,
+							error: Object.assign(new Error("npx ENOENT"), { code: "ENOENT" }),
+							stdout: "",
+							stderr: "",
+							failure: "spawn" as const,
+							spawnFailure: { kind: "tool-not-found" as const },
+						};
+					}
+					return {
+						status: null,
+						error: undefined,
+						stdout: "",
+						stderr: "",
+						failure: "timeout" as const,
+						spawnFailure: { kind: "timeout" as const },
+					};
+				});
+				expect(await runner.ensureAvailable()).toBe(false);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
 	});
 
 	describe("tempScanAsync()", () => {


### PR DESCRIPTION
## What

The retained-winner arm in both ast-grep availability sites now checks whether the memoized winner itself was proved durably missing during the current sweep, not just whether some candidate stalled.

## Why

`isSgAvailableAsync` (runner-helpers.ts) and `SgRunner.ensureAvailable()` (sg-runner.ts) both keep serving a provisional ast-grep winner across a sweep where an earlier candidate stalls, so a slow host doesn't erase a command proven to work one cooldown ago (#1568 review F1). The guard was `sweepSawTransient && isProvisional() && winner !== null` — it never checked whether the winner itself answered this same sweep.

That let a genuinely dead winner through: previous provisional winner `npx` now ENOENTs while another tier merely stalls, and the retained arm still answers `available: true` with `cmd: npx`, re-serving the dead path. The genuine-absence branch never got a look-in because one stalled sibling armed retention regardless of what happened to the winner.

Both sites now track which candidates were probed and came back durably missing (not transient) this sweep, and skip the retained arm when the memoized command is among them.

## How verified

- Red-first: reverted the source fix on each site in turn, ran the new regression test, confirmed it failed (`expected true to be false`) on both `runner-helpers.test.ts` and `sg-runner.test.ts`. Reapplied the fix, both pass.
- `npm run build` before every test run.
- Targeted: `tests/clients/dispatch/runners/runner-helpers.test.ts` (48/48) and `tests/clients/sg-runner.test.ts` (26/26).
- Sibling-site sweep: ran every test file that references `isSgAvailableAsync`, `getSgCommand`, or `SgRunner` availability — `ast-grep-client-replace.test.ts`, `ast-grep-severity-error.test.ts`, `availability-latching-siblings.test.ts`, `availability-policy-coverage.test.ts`, `session-start-parallelism.test.ts`, `tool-tier-degraded-selection.test.ts`, `tests/support/availability-gate.ts` — all green (75/75).
- `npm run lint` (tsc --project tsconfig.json) clean.
- Full suite deferred to CI, per repo policy.

## Scope

Both call sites named in the issue (runner-helpers.ts and sg-runner.ts) are fixed and covered by a symmetric regression test each. `clients/safe-spawn.ts` was not touched — that file is owned by in-flight PR #1673.

## Merge order

No file overlap with any other open PR (#1673, #1690–#1692, etc.). Safe to merge independently.

Refs #1593, #1568, #1577.
