### PR TITLE
fix(dispatch): preserve biome info/hint tiers, name info in CLI path (#1791)

### DIFF
--- a/.changelog/biome-severity-tiers.md
+++ b/.changelog/biome-severity-tiers.md
@@ -1,0 +1,12 @@
+---
+section: Fixed
+---
+
+- **Preserve biome's info/hint severity, and name info in the ast-grep CLI
+  summary** — `biome-check` collapsed every non-error biome diagnostic to
+  `warning`, even though biome's own JSON declares `information` and `hint`
+  tiers. Biome findings now carry the same four-tier `Diagnostic.severity`
+  ast-grep-napi adopted in #1787: `information` maps to `info`, `hint` stays
+  `hint`. Only `error` still blocks. The on-demand ast-grep CLI path's
+  `formatDiagnostics` summary also gained an `info(s)` bucket — an info
+  finding was previously counted in the total but named in no tier line.

--- a/.changelog/biome-severity-tiers.md
+++ b/.changelog/biome-severity-tiers.md
@@ -2,11 +2,11 @@
 section: Fixed
 ---
 
-- **Preserve biome's info/hint severity, and name info in the ast-grep CLI
-  summary** — `biome-check` collapsed every non-error biome diagnostic to
-  `warning`, even though biome's own JSON declares `information` and `hint`
-  tiers. Biome findings now carry the same four-tier `Diagnostic.severity`
-  ast-grep-napi adopted in #1787: `information` maps to `info`, `hint` stays
-  `hint`. Only `error` still blocks. The on-demand ast-grep CLI path's
-  `formatDiagnostics` summary also gained an `info(s)` bucket — an info
-  finding was previously counted in the total but named in no tier line.
+- **Preserve biome's info/hint severity in dispatch** — `biome-check`
+  collapsed every non-error biome diagnostic to `warning`, even though
+  biome's own JSON declares `information` and `hint` tiers. Biome findings
+  now carry the same four-tier `Diagnostic.severity` ast-grep-napi adopted
+  in #1787: `information` maps to `info`, `hint` stays `hint`. Only `error`
+  still blocks. The on-demand ast-grep CLI path's `formatDiagnostics`
+  summary also gained an `info(s)` bucket — an info finding was previously
+  counted in the total but named in no tier line.

--- a/clients/ast-grep-client.ts
+++ b/clients/ast-grep-client.ts
@@ -811,11 +811,13 @@ message: found
 
 		const errors = diags.filter((d) => d.severity === "error");
 		const warnings = diags.filter((d) => d.severity === "warning");
+		const infos = diags.filter((d) => d.severity === "info");
 		const hints = diags.filter((d) => d.severity === "hint");
 
 		let output = `[ast-grep] ${diags.length} structural issue(s)`;
 		if (errors.length) output += ` — ${errors.length} error(s)`;
 		if (warnings.length) output += ` — ${warnings.length} warning(s)`;
+		if (infos.length) output += ` — ${infos.length} info(s)`;
 		if (hints.length) output += ` — ${hints.length} hint(s)`;
 		output += ":\n";
 

--- a/clients/dispatch/runners/biome-check.ts
+++ b/clients/dispatch/runners/biome-check.ts
@@ -35,7 +35,32 @@ interface BiomeDiagnostic {
 	tags?: string[];
 }
 
-function parseBiomeJson(
+/**
+ * Map biome's own severity vocabulary onto the four-tier `Diagnostic.severity`
+ * (clients/dispatch/types.ts), the same way `normalizeRuleSeverity` does for
+ * ast-grep-napi post-#1787. Biome names its info tier `"information"`; every
+ * other tier is a direct pass-through. An unrecognized value falls back to
+ * `"warning"` — the tier every biome diagnostic reported at before this fix,
+ * so reviving hint/info never silently demotes an existing finding.
+ */
+export function normalizeBiomeSeverity(
+	raw: BiomeDiagnostic["severity"] | undefined,
+): Diagnostic["severity"] {
+	switch (raw) {
+		case "error":
+			return "error";
+		case "information":
+			return "info";
+		case "hint":
+			return "hint";
+		case "warning":
+			return "warning";
+		default:
+			return "warning";
+	}
+}
+
+export function parseBiomeJson(
 	raw: string,
 	filePath: string,
 ): { diagnostics: Diagnostic[]; parseError?: string } {
@@ -51,7 +76,7 @@ function parseBiomeJson(
 				filePath,
 				line: d.location.start.line,
 				column: d.location.start.column,
-				severity: d.severity === "error" ? "error" : "warning",
+				severity: normalizeBiomeSeverity(d.severity),
 				semantic: d.severity === "error" ? "blocking" : ("warning" as const),
 				tool: "biome",
 				rule: d.category,

--- a/tests/clients/ast-grep-client-format-diagnostics.test.ts
+++ b/tests/clients/ast-grep-client-format-diagnostics.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { AstGrepClient } from "../../clients/ast-grep-client.js";
+import type { AstGrepDiagnostic } from "../../clients/ast-grep-types.js";
+
+/**
+ * #1791: `formatDiagnostics` is the on-demand ast-grep CLI path's rendering
+ * seam (`clients/ast-grep-client.ts:811-813`). It bucketed error/warning/hint
+ * but had no `info` bucket, so an info-tier finding was counted in the total
+ * header but never named in any tier line — the same "declared tier, silently
+ * dropped from a tally" defect shape #1787 fixed for the napi path.
+ */
+function diag(overrides: Partial<AstGrepDiagnostic>): AstGrepDiagnostic {
+	return {
+		line: 1,
+		column: 1,
+		endLine: 1,
+		endColumn: 5,
+		severity: "warning",
+		message: "example finding",
+		rule: "example-rule",
+		file: "example.ts",
+		...overrides,
+	};
+}
+
+describe("AstGrepClient.formatDiagnostics — severity tier rendering", () => {
+	it("names the info tier alongside error/warning/hint", () => {
+		const client = new AstGrepClient();
+		const output = client.formatDiagnostics([
+			diag({ severity: "error", rule: "e1" }),
+			diag({ severity: "warning", rule: "w1" }),
+			diag({ severity: "info", rule: "i1" }),
+			diag({ severity: "hint", rule: "h1" }),
+		]);
+
+		expect(output).toContain("1 error(s)");
+		expect(output).toContain("1 warning(s)");
+		expect(output).toContain("1 info(s)");
+		expect(output).toContain("1 hint(s)");
+	});
+
+	it("counts every info-tier finding, not just the first", () => {
+		const client = new AstGrepClient();
+		const output = client.formatDiagnostics([
+			diag({ severity: "info", rule: "i1" }),
+			diag({ severity: "info", rule: "i2" }),
+			diag({ severity: "info", rule: "i3" }),
+		]);
+
+		expect(output).toContain("3 info(s)");
+	});
+
+	it("omits the info line entirely when no info findings are present", () => {
+		const client = new AstGrepClient();
+		const output = client.formatDiagnostics([
+			diag({ severity: "warning", rule: "w1" }),
+		]);
+
+		expect(output).not.toContain("info(s)");
+	});
+});

--- a/tests/clients/dispatch/runners/biome-check.test.ts
+++ b/tests/clients/dispatch/runners/biome-check.test.ts
@@ -1,50 +1,26 @@
 import { describe, expect, it } from "vitest";
+import {
+	normalizeBiomeSeverity,
+	parseBiomeJson as parseBiomeJsonImpl,
+} from "../../../../clients/dispatch/runners/biome-check.js";
 
 /****************************************************************
  * NOTE: This test file tests the Biome JSON parser logic.
  *
  * The actual biome-check runner spawns the biome CLI binary,
  * which isn't available in tests. Instead, we test the JSON
- * parsing logic directly with mock Biome JSON output.
+ * parsing logic directly with mock Biome JSON output, importing
+ * the REAL `parseBiomeJson`/`normalizeBiomeSeverity` from the
+ * compiled runner rather than an inlined copy (#1791) — a private
+ * copy here would silently drift from the shipped mapping.
  *
  * To run integration tests with the actual biome binary,
  * use the doctor command or manual testing.
  ****************************************************************/
 
 describe("biome-check JSON parser", () => {
-	// Inline the parser function for testing
-	// (The actual implementation is in biome-check.ts)
 	function parseBiomeJson(raw: string, filePath: string) {
-		interface BiomeDiagnostic {
-			severity: "error" | "warning" | "information" | "hint";
-			category: string;
-			message: string;
-			location: {
-				source: string;
-				start: { line: number; column: number };
-				end: { line: number; column: number };
-			};
-			tags?: string[];
-		}
-
-		try {
-			const result = JSON.parse(raw);
-			const diagnostics: BiomeDiagnostic[] = result.diagnostics || [];
-
-			return diagnostics.map((d) => ({
-				id: `biome:${d.category}:${d.location.start.line}`,
-				message: d.message,
-				filePath,
-				line: d.location.start.line,
-				column: d.location.start.column,
-				severity: d.severity === "error" ? "error" : "warning",
-				semantic: d.severity === "error" ? "blocking" : ("warning" as const),
-				tool: "biome",
-				rule: d.category,
-			}));
-		} catch {
-			return [];
-		}
+		return parseBiomeJsonImpl(raw, filePath).diagnostics;
 	}
 
 	describe("parseBiomeJson", () => {
@@ -67,7 +43,10 @@ describe("biome-check JSON parser", () => {
 			const result = parseBiomeJson(biomeOutput, "/src/test.ts");
 
 			expect(result).toHaveLength(1);
-			expect(result[0]).toEqual({
+			// #1791: toMatchObject, not toEqual — the real parser also carries
+			// fixable/autoFixAvailable/fixKind (driven by getAutofixCapability),
+			// which the old test's private inlined copy never produced.
+			expect(result[0]).toMatchObject({
 				id: "biome:noShadow:10",
 				message: "Do not shadow variables",
 				filePath: "/src/test.ts",
@@ -206,11 +185,45 @@ describe("biome-check JSON parser", () => {
 			expect(result[0].semantic).toBe("blocking");
 			expect(result[1].severity).toBe("warning");
 			expect(result[1].semantic).toBe("warning");
-			// information and hint are mapped to warning (non-blocking)
-			expect(result[2].severity).toBe("warning");
+			// #1791: biome's "information" tier now survives as Diagnostic
+			// severity "info", instead of being collapsed into "warning".
+			expect(result[2].severity).toBe("info");
 			expect(result[2].semantic).toBe("warning");
-			expect(result[3].severity).toBe("warning");
+			// "hint" survives as-is; only "error" is a blocking semantic.
+			expect(result[3].severity).toBe("hint");
 			expect(result[3].semantic).toBe("warning");
+		});
+
+		it("keeps blocking classification error-only when info/hint tiers are present", () => {
+			// #1791: reviving hint/info severity must not widen what blocks.
+			const biomeOutput = JSON.stringify({
+				diagnostics: [
+					{
+						severity: "information",
+						category: "i1",
+						message: "Info",
+						location: {
+							source: "f",
+							start: { line: 1, column: 1 },
+							end: { line: 1, column: 1 },
+						},
+					},
+					{
+						severity: "hint",
+						category: "h1",
+						message: "Hint",
+						location: {
+							source: "f",
+							start: { line: 2, column: 1 },
+							end: { line: 2, column: 1 },
+						},
+					},
+				],
+			});
+
+			const result = parseBiomeJson(biomeOutput, "/src/test.ts");
+
+			expect(result.every((d) => d.semantic !== "blocking")).toBe(true);
 		});
 
 		it("uses correct id format", () => {
@@ -232,6 +245,23 @@ describe("biome-check JSON parser", () => {
 			const result = parseBiomeJson(biomeOutput, "/project/config.ts");
 
 			expect(result[0].id).toBe("biome:noHardcodedCredentials:42");
+		});
+	});
+
+	describe("normalizeBiomeSeverity", () => {
+		it("maps each of biome's four declared tiers independently", () => {
+			// #1791: each branch asserted independently so deleting/merging any
+			// one of them into the "warning" fallback reds this test.
+			expect(normalizeBiomeSeverity("error")).toBe("error");
+			expect(normalizeBiomeSeverity("warning")).toBe("warning");
+			expect(normalizeBiomeSeverity("information")).toBe("info");
+			expect(normalizeBiomeSeverity("hint")).toBe("hint");
+		});
+
+		it("falls back to warning for an unrecognized value", () => {
+			expect(
+				normalizeBiomeSeverity(undefined as unknown as "warning"),
+			).toBe("warning");
 		});
 	});
 });


### PR DESCRIPTION
## What changed

Two remainders from the #1787 severity-preservation review, both filed as #1791.

1. **`clients/dispatch/runners/biome-check.ts`.** biome's own JSON type
   declares `"error" | "warning" | "information" | "hint"`, but the mapper
   collapsed everything non-error to `"warning"`. `normalizeBiomeSeverity`
   maps each tier independently — `information` becomes `info`, `hint`
   survives as `hint` — the same per-tier approach `normalizeRuleSeverity`
   uses for ast-grep-napi post-#1787. An unrecognized value still falls back
   to `warning`, so nothing already reporting at warning is demoted.
2. **`clients/ast-grep-client.ts:811-816`** (the on-demand ast-grep CLI
   path). `formatDiagnostics` bucketed error, warning, and hint but had no
   `info` bucket. An info-tier finding was counted in the total header but
   named in no tier line. Added the missing bucket.

**Blocking classification is untouched.** `semantic: d.severity === "error" ?
"blocking" : "warning"` in biome-check.ts is unchanged — only `error` blocks,
exactly as before this PR.

## Why

Same defect shape as #1787: a producer or formatter silently flattens the
four-tier `Diagnostic.severity` enum, so a tool's own quiet-tier findings
either get relabeled to a louder tier (biome) or counted-but-unnamed (the
CLI formatter). #1787 fixed the shape for the napi runner path; this PR
closes the two sites its own review round found still open.

## Test-fixture defect fixed along the way

`tests/clients/dispatch/runners/biome-check.test.ts` tested a **private
inlined copy** of `parseBiomeJson`, not the real implementation in
`biome-check.ts` — AGENTS.md defect shape 7 (vacuous fixture). The test could
never have caught this bug: the collapse lived in the real file, the test
exercised a hand-copied stand-in. `parseBiomeJson` is now exported and the
test imports the real function, so it can't silently drift from the shipped
mapping again.

## Class sweep

The coordinator widened this sweep beyond #1787's own review-round scope to
cover every `Diagnostic`/`ProjectDiagnostic` PRODUCER, not just dispatch
runners and formatters. The class: "a producer maps its tool's native
severity vocabulary onto `Diagnostic.severity`/`ProjectDiagnosticSeverity`
and silently collapses a real tier the tool emits." This is now the class's
reference sweep — logged in full so a future instance can diff against it.

**Commands run:**

```
grep -rn 'severity\s*===\|severity\s*!==\|\.severity)' clients/ tools/ mcp/ index.ts --include=*.ts
grep -rn 'severity === "warning"\|severity !== "warning"' clients/ tools/ mcp/ index.ts scripts/ --include=*.ts
grep -rn 'warnings++\|warnings += \|warningCount' clients/ tools/ mcp/ index.ts --include=*.ts
grep -rn 'severity:.*"error".*".*".*".*"' clients/dispatch/runners/*.ts clients/project-diagnostics/runner-adapters/*.ts
```

**1. `clients/dispatch/runners/` (original scope, all 40 runners reviewed).**

| Site | Verdict |
| --- | --- |
| `biome-check.ts:54` | **Fixed here.** biome declares `"information"`/`"hint"`; both were collapsed to `"warning"`. |
| `ast-grep-napi.ts` | Already correct (#1787). |
| `psscriptanalyzer.ts:300` | Already correct. PSScriptAnalyzer's own severities are Error/Warning/Information only (no Hint); the mapper's declared 3-value type (`"error" \| "warning" \| "info"`) matches that vocabulary exactly and maps all three. |
| `eslint.ts:82` | Already correct. ESLint's own severity is 1 (warn) or 2 (error) only — a 2-value native vocabulary, so a 2-value mapper loses nothing. |
| `pyright.ts:146` | **Not fixed here — filed as #1802.** Pyright's `--outputjson` output declares `"error" \| "warning" \| "information"`; `"information"` collapses to `"warning"`, same shape as biome. `diag` is typed `any` here (no compile-time union the way biome's typed interface gave this PR), which is itself worth fixing alongside. Re-homed rather than folded into this PR: it's a different, untested runner and deserves its own red-first regression, not a scope-creep fix riding on #1791's tests. |
| `rust-clippy.ts:262` | **Flagged, not confirmed** (in #1802). `message.level === "error" ? "error" : "warning"` — rustc/clippy's top-level `level` is occasionally `"note"`, not just error/warning, but confidence is low enough (most clippy lints only ever emit warn/error at top level) that it needs dedicated investigation before treating it as a real instance. |
| `oxlint.ts`, `ruff.ts`, `stylelint.ts` | Already correct as far as can be shown. Their `severity` field is declared `string` (untyped) in this codebase, not a literal union — no type-level evidence of an unmapped tier the way biome's/pyright's declared/native unions provide. Not proven clean, but not provably broken either; no action taken. |
| `helm-render.ts:487`, `trivy-config.ts:149` | Already correct by design. Both map a CVE severity string (`"CRITICAL"` vs. everything else) to error/warning — a deliberate two-bucket collapse of a much larger CVE severity scale (CRITICAL/HIGH/MEDIUM/LOW), not a case of an unused `Diagnostic.severity` tier being dropped. Out of scope for this class (a design choice about SEVERITY THRESHOLDS, not a silently-dropped ENUM VALUE). |
| Every other runner (`cpp-check`, `dart-analyze`, `detekt`, `dotnet-build`, `elixir-check`, `golangci-lint`, `hadolint`, `helm-lint`, `htmlhint`, `javac`, `mypy`, `rubocop`, `shellcheck`, `swiftlint`, `terragrunt`, `tflint`, `yamllint`, `zig-check`, `utils/diagnostic-parsers.ts`, `utils.ts`) | Already correct. Each of these tools' own diagnostic output is genuinely two-valued (error/warning or pass/fail) at the source — a 2-value `Diagnostic.severity` mapper drops nothing because there is nothing more granular to drop. |

**2. `clients/project-diagnostics/runner-adapters/` (widened scope).**

| Site | Verdict |
| --- | --- |
| `opengrep.ts:17-28` | Already correct. Maps semgrep-compatible `ERROR`/`WARNING`/`INFO` fully (no `hint` — semgrep has none). |
| `call-graph-impact.ts:60-76` | Already correct. `WillBreak`→warning, `MayBreak`→info are both used; the `Review` tier is deliberately excluded (documented, not silently miscounted — `formatImpact` surfaces it only as a bare count). |
| `gitleaks.ts:16-38` | Already correct. gitleaks has no native severity field; info/error is a pi-lens-derived classification (scratch-path demotion, #1562), not a tool-tier collapse. |
| `trivy.ts:11-33` | Already correct, but a documented deliberate design choice worth naming: every CVE finding reports `"warning"` regardless of trivy's own CRITICAL/HIGH/MEDIUM/LOW severity, with the real severity folded into the message text instead. Not a silent collapse (comment at `:9` states the design), but flagging it here since a future maintainer might want CVE severity to drive the diagnostic tier. Out of scope for this PR — a design decision, not a bug. |
| `govulncheck.ts`, `jscpd.ts`, `madge.ts`, `dead-code.ts`, `knip.ts`, `runner-findings.ts` | Already correct. None of these tools has a native multi-value severity field — blocking/warning is derived from the finding's CATEGORY (unlisted dependency, test failure, etc.), not a collapsed severity string. |

**3. LSP mapping.**

| Site | Verdict |
| --- | --- |
| `tools/lens-diagnostics.ts:1010-1015` `lspSeverityName` | Already correct. Maps all four LSP `DiagnosticSeverity` values to four distinct strings: 1→error, 2→warning, 3→info (an explicit `if`), and everything else (4/Hint) falls through to the function's default `return "hint"`. All four LSP tiers reach four distinct outputs. |
| `clients/dispatch/utils/lsp-diagnostics.ts:34-35` `convertLspDiagnostics` | Already correct, though written more implicitly: `severityMap = {1: "error", 2: "warning", 4: "hint"}` with `?? "info"` as the fallback for the missing key `3`. LSP severity 3 (Information) resolves to `"info"` via that fallback — correct, but only by omission rather than an explicit map entry, so it's easy to misread as a collapse. Left as-is (behavior is correct and has existing coverage); not touched by this PR since it isn't broken. |
| `clients/dispatch/auxiliary-lsp.ts:373-375` | Already correct — different concern. This demotes `severity: "error"` to `"warning"` specifically when an auxiliary LSP profile's policy disallows blocking, to keep the visible severity label consistent with the (already-softened) `semantic`. It never touches info/hint and isn't a tool-vocabulary collapse. |
| The various `d.severity === 1` sites (`cascade-format.ts`, `dispatch/integration.ts`, `dispatch/runners/lsp.ts`, `lsp/inferred-project.ts`) | Already correct — deliberate error-only filters for specific gates (e.g., "which LSP diagnostics are errors for this blocking check"), not producers assigning `Diagnostic.severity` from a collapsed native vocabulary. |

**Net result:** two sites fixed here (the original #1791 scope), one new
confirmed instance filed as #1802 (pyright.ts), one flagged-but-unconfirmed
candidate also in #1802 (rust-clippy.ts), everything else in the widened
scope is either genuinely two-valued at the source or a documented,
deliberate design choice.

## Blast radius

- **`normalizeBiomeSeverity`** is called from exactly one site,
  `parseBiomeJson`'s diagnostic mapper. Its only caller is the
  `biome-check-json` runner (`biomeCheckJsonRunner.run`). Downstream
  consumers of `Diagnostic.severity` already handle all four tiers as of
  #1787 (widget-state tally, lens-diagnostics tally, actionable-warnings
  gate) — this PR feeds them a previously-impossible input (`info`/`hint`
  from biome) through an already-widened pipe, semantic-identical to what
  #1787 did for ast-grep-napi.
- **`formatDiagnostics`** (`AstGrepClient`, ast-grep-client.ts) has **no
  production caller** in this build — grepped `\.formatDiagnostics\(` and
  `formatDiagnostics` repo-wide (`.ts` and compiled `.js`); the only hits
  outside `ast-grep-client.ts` itself are the unrelated
  `dispatch/utils/format-utils.ts` function of the same name and a comment.
  It's exercised here only through the new direct unit tests. Recording
  this plainly rather than implying a wider effect.
- Tier rendering only. No new severities are introduced (both are already
  part of the four-tier `Diagnostic.severity` enum from #1787); this PR
  only fixes which tier two specific producers/formatters report.

## Observability

No new failure path — this is a display/classification correctness fix, not
a new degradation source. The record that proves it works in production is
the `Diagnostic.severity` field itself on a biome-produced diagnostic: an
`information`-tier biome finding now carries `severity: "info"` wherever
that diagnostic is logged or rendered (dispatcher diagnostics, turn-end
advisories), instead of `"warning"`.

## Verification

`npm run build` before every test run.

**Red-first, on pre-fix code** (`git diff > .fix.patch` /
`git checkout -- clients/ast-grep-client.ts clients/dispatch/runners/biome-check.ts`
/ `git apply .fix.patch` — never stash):

```
 ❯ tests/clients/dispatch/runners/biome-check.test.ts (13 failed, missing exports)
 ❯ tests/clients/ast-grep-client-format-diagnostics.test.ts (2 failed)
     × names the info tier alongside error/warning/hint
       expected '... — 1 error(s) — 1 warning(s) — 1 hint(s):' to contain '1 info(s)'
     × counts every info-tier finding, not just the first
       expected '[ast-grep] 3 structural issue(s):...' to contain '3 info(s)'
```

**Mutation-proofed** (each mutation applied to the fixed code, confirmed red,
then reverted):

| Mutation | Result |
| --- | --- |
| Drop `case "information": return "info"` from `normalizeBiomeSeverity` | 2 red (`biome-check.test.ts`) |
| Drop the `if (infos.length)` line from `formatDiagnostics` | 2 red (`ast-grep-client-format-diagnostics.test.ts`) |

**Green, post-fix:** `biome-check.test.ts`, `biome-check-runner.test.ts`,
`ast-grep-client-format-diagnostics.test.ts`, `ast-grep-client-replace.test.ts`,
`actionable-warnings.test.ts`, `code-quality-warnings.test.ts`,
`widget-state.test.ts`, `severity-tier-consumers.test.ts`,
`ast-grep-severity-tiers.test.ts`, `lens-diagnostics.test.ts`,
`session-state-conformance.test.ts` — 11 files, 270 passed. `npm run lint`
clean. Full suite deferred to CI.

Closes #1791.
