### PR TITLE
fix(dispatch): skip classpath-less javac fallback inside Maven/Gradle projects (closes #1877)

### DIFF
--- a/.changelog/fix-1877-javac-build-descriptor-gate.md
+++ b/.changelog/fix-1877-javac-build-descriptor-gate.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **javac fallback skips classpath-less compiles inside Maven/Gradle projects (closes #1877)** — when the Java LSP runner misses its wait budget, dispatch falls back to the `javac` runner, which compiles the single file with no `-classpath`/`-sourcepath`. On build-tool projects every non-JDK import becomes a blocking `package does not exist` false positive that gates agent edits and stays cached in session diagnostics after jdtls recovers. The runner now walks up from the edited file with the shared `hasJavaBuildDescriptor` seam (the same gate SpotBugs uses) and returns `skipped` when a `pom.xml`, `build.gradle(.kts)`, or `settings.gradle(.kts)` is present; the dispatcher's coverage notice reports the LSP gap honestly. Standalone `.java` files with no descriptor keep the javac fallback.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,11 @@ It is smart-default and read-only. Rendered-manifest validation (#1283 slice B)
 ships beside it as the separately-gated, OFF-by-default `helm-render` runner —
 see the IaC-misconfig note in the pipeline section.
 
+The javac standalone-file fallback walks for Maven/Gradle descriptors from the
+edited file's directory through `DispatchContext.projectRoot` inclusive. Never
+let a descriptor above the session project suppress the fallback; nested module
+descriptors inside the project still gate it. (#1877)
+
 Mechanical ast-grep rules may expose a `fix:` only when one syntax rewrite is
 unambiguous. Reflect.apply remains diagnostic-only because an own shadowed
 `.apply` changes the obvious rewrite's semantics. Two-argument Reflect.get uses

--- a/clients/dispatch/runners/javac.ts
+++ b/clients/dispatch/runners/javac.ts
@@ -62,7 +62,9 @@ const javacRunner: RunnerDefinition = {
 		// false blocking diagnostics (#1877). jdtls owns those projects; this
 		// runner keeps its value for standalone files with no build descriptor.
 		// Same shared descriptor walk the SpotBugs gate uses.
-		if (hasJavaBuildDescriptor(path.dirname(absPath))) {
+		if (
+			hasJavaBuildDescriptor(path.dirname(absPath), ctx.projectRoot ?? ctx.cwd)
+		) {
 			ctx.log?.(
 				"javac: skipped — file is inside a Maven/Gradle project; a classpath-less compile would emit false positives",
 			);

--- a/clients/dispatch/runners/javac.ts
+++ b/clients/dispatch/runners/javac.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import { safeSpawnAsync } from "../../safe-spawn.js";
+import { hasJavaBuildDescriptor } from "../../tool-policy.js";
 import { PRIORITY } from "../priorities.js";
 import type {
 	Diagnostic,
@@ -53,6 +54,21 @@ const javacRunner: RunnerDefinition = {
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {
 		const cwd = ctx.cwd || process.cwd();
+		const absPath = path.resolve(cwd, ctx.filePath);
+
+		// Inside a Maven/Gradle project a classpath-less single-file compile
+		// cannot produce a valid verdict: every non-JDK import becomes a
+		// "package does not exist" error, and the fallback turns those into
+		// false blocking diagnostics (#1877). jdtls owns those projects; this
+		// runner keeps its value for standalone files with no build descriptor.
+		// Same shared descriptor walk the SpotBugs gate uses.
+		if (hasJavaBuildDescriptor(path.dirname(absPath))) {
+			ctx.log?.(
+				"javac: skipped — file is inside a Maven/Gradle project; a classpath-less compile would emit false positives",
+			);
+			return { status: "skipped", diagnostics: [], semantic: "none" };
+		}
+
 		if (!(await (javac.isAvailableAsync(cwd)))) {
 			return { status: "skipped", diagnostics: [], semantic: "none" };
 		}
@@ -61,8 +77,6 @@ const javacRunner: RunnerDefinition = {
 		if (!cmd) {
 			return { status: "skipped", diagnostics: [], semantic: "none" };
 		}
-
-		const absPath = path.resolve(cwd, ctx.filePath);
 		const result = await safeSpawnAsync(
 			cmd,
 			["-Xlint:none", "-proc:none", absPath],

--- a/clients/tool-policy.ts
+++ b/clients/tool-policy.ts
@@ -3,7 +3,11 @@ import * as path from "node:path";
 import { TERRAGRUNT_FILENAMES } from "./file-kinds.js";
 import { logLatency } from "./latency-logger.js";
 import { resolvePackagePath } from "./package-root.js";
-import { findNearestContaining, walkUpDirs } from "./path-utils.js";
+import {
+	findNearestContaining,
+	normalizeMapKey,
+	walkUpDirs,
+} from "./path-utils.js";
 import type { ProjectConventions } from "./project-conventions.js";
 import { loadProjectSnapshotWithoutWordIndex } from "./project-snapshot.js";
 
@@ -2701,10 +2705,18 @@ const COMPILED_CLASSES_DIRS = [
 	path.join("bin", "main"),
 ];
 
-export function hasJavaBuildDescriptor(cwd: string): boolean {
+export function hasJavaBuildDescriptor(cwd: string, ceiling?: string): boolean {
+	const normalizedCeiling = ceiling
+		? normalizeMapKey(path.resolve(ceiling))
+		: undefined;
 	for (const dir of walkUpDirs(cwd)) {
 		if (JAVA_BUILD_DESCRIPTORS.some((d) => fs.existsSync(path.join(dir, d))))
 			return true;
+		if (
+			normalizedCeiling &&
+			normalizeMapKey(path.resolve(dir)) === normalizedCeiling
+		)
+			break;
 	}
 	return false;
 }

--- a/tests/clients/dispatch/javac-dispatch-integration.test.ts
+++ b/tests/clients/dispatch/javac-dispatch-integration.test.ts
@@ -1,0 +1,124 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	clearCoverageNoticeState,
+	createDispatchContext,
+	dispatchForFile,
+	RunnerRegistry,
+} from "../../../clients/dispatch/dispatcher.js";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import javacRunner from "../../../clients/dispatch/runners/javac.js";
+import type { RunnerResult } from "../../../clients/dispatch/types.js";
+import { setupTestEnvironment } from "../test-utils.js";
+
+const { safeSpawnAsync } = vi.hoisted(() => ({
+	safeSpawnAsync: vi.fn(),
+}));
+
+vi.mock("../../../clients/safe-spawn.js", () => ({ safeSpawnAsync }));
+
+vi.mock("../../../clients/dispatch/runners/utils/runner-helpers.js", () => ({
+	createAvailabilityChecker: (command: string) => ({
+		isAvailableAsync: async () => true,
+		getCommand: () => command,
+	}),
+}));
+
+describe("javac dispatcher integration (#1877)", () => {
+	beforeEach(() => {
+		clearCoverageNoticeState();
+		safeSpawnAsync.mockReset();
+		safeSpawnAsync.mockResolvedValue({
+			error: null,
+			status: 0,
+			stdout: "",
+			stderr: "",
+		});
+	});
+
+	it("reports unavailable analysis when the descriptor gate skips javac", async () => {
+		const env = setupTestEnvironment("pi-lens-javac-dispatch-notice-");
+		try {
+			const filePath = path.join(env.tmpDir, "module", "src", "App.java");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, "class App {}\n");
+			fs.writeFileSync(path.join(env.tmpDir, "pom.xml"), "<project />\n");
+
+			const registry = createJavaRegistry();
+			const outcomes = new Map<string, RunnerResult>();
+			const ctx = createDispatchContext(
+				filePath,
+				env.tmpDir,
+				{ getFlag: () => false },
+				new FactStore(),
+				undefined,
+				undefined,
+				env.tmpDir,
+			);
+			const result = await dispatchForFile(
+				ctx,
+				[{ mode: "all", runnerIds: ["lsp", "javac"] }],
+				registry,
+				(id, runnerResult) => outcomes.set(id, runnerResult),
+			);
+
+			expect(outcomes.get("lsp")?.status).toBe("skipped");
+			expect(outcomes.get("javac")?.status).toBe("skipped");
+			expect(safeSpawnAsync).not.toHaveBeenCalled();
+			expect(result.output).toContain("Pi-lens java analysis unavailable");
+			expect(result.output).toContain("not a clean result");
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("does not let a descriptor above projectRoot gate javac", async () => {
+		const env = setupTestEnvironment("pi-lens-javac-dispatch-ceiling-");
+		try {
+			const projectRoot = path.join(env.tmpDir, "session-project");
+			const filePath = path.join(projectRoot, "scratch", "App.java");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, "class App {}\n");
+			fs.writeFileSync(path.join(env.tmpDir, "pom.xml"), "<project />\n");
+
+			const registry = createJavaRegistry();
+			const outcomes = new Map<string, RunnerResult>();
+			const ctx = createDispatchContext(
+				filePath,
+				projectRoot,
+				{ getFlag: () => false },
+				new FactStore(),
+				undefined,
+				undefined,
+				projectRoot,
+			);
+			await dispatchForFile(
+				ctx,
+				[{ mode: "all", runnerIds: ["lsp", "javac"] }],
+				registry,
+				(id, runnerResult) => outcomes.set(id, runnerResult),
+			);
+
+			expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+			expect(outcomes.get("javac")?.status).toBe("succeeded");
+		} finally {
+			env.cleanup();
+		}
+	});
+});
+
+function createJavaRegistry(): RunnerRegistry {
+	const registry = new RunnerRegistry();
+	registry.register({
+		id: "lsp",
+		appliesTo: ["java"],
+		priority: 4,
+		enabledByDefault: true,
+		async run() {
+			return { status: "skipped", diagnostics: [], semantic: "none" };
+		},
+	});
+	registry.register(javacRunner);
+	return registry;
+}

--- a/tests/clients/dispatch/runners/javac-build-descriptor-gate.test.ts
+++ b/tests/clients/dispatch/runners/javac-build-descriptor-gate.test.ts
@@ -1,0 +1,119 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { makeRunnerCtx } from "../../../support/runner-ctx.js";
+import { setupTestEnvironment } from "../../test-utils.js";
+
+// #1877: inside a Maven/Gradle project the classpath-less javac fallback
+// turns every non-JDK import into a blocking "package does not exist" false
+// positive. The runner must skip when a build descriptor walks up from the
+// file, and keep compiling standalone files with no descriptor.
+
+const safeSpawn = vi.fn();
+const safeSpawnAsync = vi.fn((...args: Parameters<typeof safeSpawn>) =>
+	Promise.resolve(safeSpawn(...args)),
+);
+
+vi.mock("../../../../clients/safe-spawn.js", () => ({
+	safeSpawn,
+	safeSpawnAsync,
+}));
+
+vi.mock("../../../../clients/dispatch/runners/utils/runner-helpers.js", () => ({
+	createAvailabilityChecker: (command: string) => ({
+		isAvailable: () => true,
+		isAvailableAsync: async () => true,
+		getCommand: () => command,
+	}),
+}));
+
+async function runJavac(filePath: string, cwd: string) {
+	const runner = (
+		await import("../../../../clients/dispatch/runners/javac.js")
+	).default;
+	return runner.run(makeRunnerCtx(filePath, cwd, { kind: "java" }) as never);
+}
+
+describe("javac build-descriptor gate (#1877)", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		safeSpawn.mockReset();
+		safeSpawnAsync.mockReset();
+		safeSpawnAsync.mockImplementation((...args: Parameters<typeof safeSpawn>) =>
+			Promise.resolve(safeSpawn(...args)),
+		);
+		// If the gate fails open, javac reports a clean compile — any status
+		// other than "skipped" then proves a spawn the gate should have
+		// prevented.
+		safeSpawn.mockReturnValue({
+			error: null,
+			status: 0,
+			stdout: "",
+			stderr: "",
+		});
+	});
+
+	it("skips when a pom.xml sits above the file", async () => {
+		const env = setupTestEnvironment("pi-lens-javac-gate-maven-");
+		try {
+			const filePath = path.join(env.tmpDir, "src", "main", "java", "App.java");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, "class App {}\n");
+			fs.writeFileSync(path.join(env.tmpDir, "pom.xml"), "<project />\n");
+
+			const result = await runJavac(filePath, env.tmpDir);
+
+			expect(result.status).toBe("skipped");
+			expect(result.diagnostics).toEqual([]);
+			expect(result.semantic).toBe("none");
+			expect(safeSpawn).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("finds a descriptor below the dispatch cwd (multi-module walk starts at the file)", async () => {
+		const env = setupTestEnvironment("pi-lens-javac-gate-gradle-");
+		try {
+			// The walk must start at the FILE's directory, not the cwd: the
+			// module descriptor sits below the workspace root.
+			const moduleDir = path.join(env.tmpDir, "module-a");
+			const filePath = path.join(moduleDir, "src", "App.java");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, "class App {}\n");
+			fs.writeFileSync(path.join(moduleDir, "build.gradle.kts"), "// module\n");
+
+			const result = await runJavac(filePath, env.tmpDir);
+
+			expect(result.status).toBe("skipped");
+			expect(result.diagnostics).toEqual([]);
+			expect(safeSpawn).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("still compiles standalone files with no build descriptor", async () => {
+		const env = setupTestEnvironment("pi-lens-javac-gate-standalone-");
+		try {
+			const filePath = path.join(env.tmpDir, "App.java");
+			fs.writeFileSync(filePath, "class App {}\n");
+			safeSpawn.mockReturnValue({
+				error: null,
+				status: 1,
+				stdout: "",
+				stderr: `${filePath}:3: error: cannot find symbol`,
+			});
+
+			const result = await runJavac(filePath, env.tmpDir);
+
+			expect(safeSpawn).toHaveBeenCalledTimes(1);
+			expect(result.status).toBe("failed");
+			expect(result.semantic).toBe("blocking");
+			expect(result.diagnostics[0]?.tool).toBe("javac");
+			expect(result.diagnostics[0]?.line).toBe(3);
+		} finally {
+			env.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

When jdtls transiently misses its diagnostic wait budget, the classpath-less `javac` fallback emits blocking `package does not exist` false positives on Maven/Gradle projects. This PR gates the `javac` runner on build-descriptor absence: a file inside a Maven/Gradle project is skipped, and the dispatcher's existing coverage notice reports the LSP gap honestly. Implements item 1 of #1877 (the surgical gate). Item 2 (severity demotion) is deliberately left to the maintainer.

## Problem

The Java dispatch group is `mode: "fallback"` with `runnerIds: ["lsp", "javac"]` (`clients/dispatch/language-policy.ts`). When `touchFile` misses its budget, the lsp runner returns `skipped` (intentional, #570), and the javac runner spawns `javac -Xlint:none -proc:none <file>` with no `-classpath` and no `-sourcepath` (`clients/dispatch/runners/javac.ts`). Every non-JDK import — including the project's own same-module packages — becomes a `package does not exist` / `cannot find symbol` error tagged `semantic: "blocking"`. These false blockers gate agent edits and stay cached in session diagnostics, replayed by `lens_diagnostics mode=all` after jdtls recovers.

Evidence: #1877 records five incidents in one session on a multi-module Maven repo — including 100 blocking diagnostics for a file jdtls reported clean seconds later.

## Fix

In `clients/dispatch/runners/javac.ts`, before spawning javac:

- Walk up from the edited file's directory with the shared `hasJavaBuildDescriptor` seam (`clients/tool-policy.ts`) — the same descriptor set (`pom.xml`, `build.gradle(.kts)`, `settings.gradle(.kts)`) and the same walk the SpotBugs group gate (#133) uses. No duplicated utility.
- Descriptor found → return the runner's ordinary `{ status: "skipped", diagnostics: [], semantic: "none" }` shape, same as its existing skip paths. The gate sits before the availability probe, so a Maven/Gradle fallback spawns nothing.
- The walk starts at the file's directory, not the dispatch cwd, so a module descriptor below a workspace root (multi-module Maven/Gradle) still gates.
- Standalone `.java` files outside any build-tool project keep today's behavior — the runner's legitimate purpose.

## Tests

New: `tests/clients/dispatch/runners/javac-build-descriptor-gate.test.ts` — three tests using real descriptor files on disk and the real `hasJavaBuildDescriptor` (only `safeSpawnAsync` and tool availability are mocked):

- `pom.xml` above the file → `skipped`, no spawn.
- `build.gradle.kts` below the dispatch cwd → `skipped` — pins the walk start at the file's directory; a cwd-based walk would miss it.
- No descriptor → javac still spawns and its diagnostics still parse (behavior unchanged).

Results:

- Red-first: both gate tests fail with `succeeded` on the ungated code (a spawn happens), pass with the gate.
- Mutation check: deleting the gate turns both red again.
- `tests/clients/dispatch/` + `tests/clients/tool-policy.test.ts`: 110 files, 1138 tests passed, 0 failed.
- `npm run lint` clean.

## Blast radius

`javac.ts` is imported only by the runner registry (`clients/dispatch/runners/index.ts`) and reached only through the java fallback group. Dispatch policy, other runners, and the descriptor helper (unit-tested since #133) are untouched.

## Observability

The skip is visible in existing records: the per-runner rows in `~/.pi-lens/latency.log` show `javac=skipped` instead of `javac=failed` after an `lsp=skipped` window, and the runner emits one `ctx.log` reason line ("javac: skipped — file is inside a Maven/Gradle project; a classpath-less compile would emit false positives"). Production confirmation of this fix: no further `javac=failed` incidents on build-tool projects in `latency.log`.
