### PR TITLE
fix(lsp): distinguish spawn-in-flight from no-clients on warm touch (closes #1875)

### DIFF
--- a/.changelog/1875.md
+++ b/.changelog/1875.md
@@ -1,0 +1,8 @@
+---
+section: Fixed
+---
+
+- **Distinguish a slow LSP warm spawn from no clients ([closes #1875](https://github.com/apmantza/pi-lens/issues/1875))** —
+  a read warm whose bounded wait expires now reports that its primary server
+  is still spawning. A touch reports no clients only when no matching spawn
+  remains in flight. The next read reuses the existing single-flight spawn.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@ Coverage markers are deduped per session by normalized kind, file, and the
 normalized silent-scanner set. A changed set admits a new marker, and a marker
 is appended after primary diagnostics so both remain visible.
 
+Bounded LSP warm touches preserve the spawn coordinator's lifecycle evidence:
+an empty ready-client set reports `spawn_in_flight_budget_elapsed` while a
+matching primary single-flight spawn remains pending, and
+`no_clients_none_spawning` only when none does. Read the existing `inFlight`
+state at the touch verdict; do not add a second pending-warm latch. (#1875)
+
 Post-fix decision observability is durable and bounded: advisory delivery logs
 one `advisory_provenance_decision` per consume, classic TypeScript project
 identity logs every success/failure outcome, deferred mutation drains summarize

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,9 @@ Bounded LSP warm touches preserve the spawn coordinator's lifecycle evidence:
 an empty ready-client set reports `spawn_in_flight_budget_elapsed` while a
 matching primary single-flight spawn remains pending, and
 `no_clients_none_spawning` only when none does. Read the existing `inFlight`
-state at the touch verdict; do not add a second pending-warm latch. (#1875)
+state at the touch verdict; correlate the full `serverId:root` key using the
+root resolved by acquisition, and do not add a second pending-warm latch.
+(#1875, #1875 fix round)
 
 Post-fix decision observability is durable and bounded: advisory delivery logs
 one `advisory_provenance_decision` per consume, classic TypeScript project

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -3272,6 +3272,14 @@ export class LSPService {
 						: 0;
 		}
 		if (spawned.length === 0) {
+			// A bounded caller can lose the client race while the single-flight spawn
+			// it started is still progressing. Preserve that lifecycle evidence in the
+			// touch verdict instead of reclassifying an empty ready set as absence.
+			// `isSpawnInFlight` reads the spawn coordinator's own state and filters to
+			// primary candidates, so this stays coupled to the dedupe mechanism.
+			const failureKind = this.isSpawnInFlight(filePath)
+				? "spawn_in_flight_budget_elapsed"
+				: "no_clients_none_spawning";
 			logLatency({
 				type: "phase",
 				phase: "lsp_touch_file",
@@ -3284,7 +3292,7 @@ export class LSPService {
 					diagnosticsMode,
 					source,
 					maxClientWaitMs: options.maxClientWaitMs,
-					failureKind: "no_clients",
+					failureKind,
 				},
 			});
 			return;

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -2177,6 +2177,7 @@ export class LSPService {
 		filePath: string,
 		maxWaitMs?: number,
 		hardCapMs?: number,
+		resolvedRoots?: Map<string, string>,
 	): Promise<SpawnedServer | undefined> {
 		if (this.checkDestroyed()) return undefined;
 		// Primary selection considers language servers only — auxiliary servers
@@ -2207,7 +2208,11 @@ export class LSPService {
 
 			// Try each matching server
 			for (const server of servers) {
-				const spawned = await this.ensureClientForServer(filePath, server);
+				const spawned = await this.ensureClientForServer(
+					filePath,
+					server,
+					resolvedRoots,
+				);
 				if (spawned) {
 					logLatency({
 						type: "phase",
@@ -2318,6 +2323,7 @@ export class LSPService {
 	async getClientsForFile(
 		filePath: string,
 		excludeServerIds?: ReadonlySet<string>,
+		resolvedRoots?: Map<string, string>,
 	): Promise<{ clients: SpawnedServer[]; serverCountAttempted: number }> {
 		const allServers = getServersForFileWithConfig(filePath);
 		const servers =
@@ -2334,7 +2340,9 @@ export class LSPService {
 		const serverCountAttempted = roots.filter(Boolean).length;
 
 		const spawned = await Promise.all(
-			servers.map((server) => this.ensureClientForServer(filePath, server)),
+			servers.map((server) =>
+				this.ensureClientForServer(filePath, server, resolvedRoots),
+			),
 		);
 		return {
 			clients: spawned.filter((entry): entry is SpawnedServer =>
@@ -2609,6 +2617,7 @@ export class LSPService {
 	private async ensureClientForServer(
 		filePath: string,
 		server: LSPServerInfo,
+		resolvedRoots?: Map<string, string>,
 	): Promise<SpawnedServer | undefined> {
 		const handoff = this.generationHandoff;
 		if (handoff) {
@@ -2621,6 +2630,9 @@ export class LSPService {
 
 		const root = await this.resolveServerRoot(server, filePath);
 		if (!root || this.checkDestroyed()) return undefined;
+		if (server.role !== "auxiliary") {
+			resolvedRoots?.set(server.id, normalizeMapKey(root));
+		}
 		const allowInstall = this.shouldAllowInstall(server.id);
 
 		const normalizedRoot = normalizeMapKey(root);
@@ -3244,12 +3256,14 @@ export class LSPService {
 		const clientScope: LSPTouchClientScope =
 			options.clientScope ?? (diagnosticsMode === "full" ? "all" : "primary");
 		const useAllClients = clientScope === "all";
+		const resolvedPrimaryRoots = new Map<string, string>();
 		let spawned: SpawnedServer[];
 		let serverCountAttempted: number;
 		if (useAllClients) {
 			const result = await this.getClientsForFile(
 				filePath,
 				options.excludeServerIds,
+				resolvedPrimaryRoots,
 			);
 			spawned = result.clients;
 			serverCountAttempted = result.serverCountAttempted;
@@ -3257,7 +3271,12 @@ export class LSPService {
 			// Primary language server + the enabled cross-cutting auxiliaries
 			// (opengrep, …). The aggregation layer merges/dedups their diagnostics.
 			const [entry, aux] = await Promise.all([
-				this.getClientForFile(filePath, options.maxClientWaitMs),
+				this.getClientForFile(
+					filePath,
+					options.maxClientWaitMs,
+					undefined,
+					resolvedPrimaryRoots,
+				),
 				this.getAuxiliaryClientsForFile(
 					filePath,
 					new Set(options.auxiliaryServerIds ?? []),
@@ -3269,6 +3288,8 @@ export class LSPService {
 			const entry = await this.getClientForFile(
 				filePath,
 				options.maxClientWaitMs,
+				undefined,
+				resolvedPrimaryRoots,
 			);
 			spawned = entry ? [entry] : [];
 			serverCountAttempted =
@@ -3284,7 +3305,10 @@ export class LSPService {
 			// touch verdict instead of reclassifying an empty ready set as absence.
 			// `isSpawnInFlight` reads the spawn coordinator's own state and filters to
 			// primary candidates, so this stays coupled to the dedupe mechanism.
-			const failureKind = this.isSpawnInFlight(filePath)
+			const failureKind = this.isSpawnInFlight(
+				filePath,
+				resolvedPrimaryRoots,
+			)
 				? "spawn_in_flight_budget_elapsed"
 				: "no_clients_none_spawning";
 			logLatency({
@@ -7660,24 +7684,18 @@ export class LSPService {
 	 * unrelated auxiliary spawn would downgrade a genuinely wedged primary to
 	 * a benign "spawn-in-flight" verdict — the worse misreport direction.
 	 *
-	 * Root-blind: the match is a `${server.id}:` PREFIX over inFlight keys, not
-	 * an exact `${server.id}:${root}` match, because root resolution
-	 * (resolveServerRoot) is async and this must stay synchronous for the
-	 * caller's bail path. A same-server spawn in an unrelated workspace root
-	 * also reports true. Rare in practice (this codebase is single-root per
-	 * pi-lens session in the overwhelming common case) and the failure mode is
-	 * the same "downgrade wedged to spawn-in-flight" direction as the
-	 * auxiliary case above — acceptable for a log-wording hint, not a gate.
+	 * The touch path supplies roots resolved before acquisition. Matching the full
+	 * server/root key prevents another workspace's spawn from relabeling this one.
+	 * Root resolution is already complete, and this check stays synchronous.
+	 * The failure mode is limited to the matching workspace key.
 	 * Pure lookup — does not spawn or wait for a client.
 	 */
-	isSpawnInFlight(filePath: string): boolean {
-		const servers = getServersForFileWithConfig(filePath).filter(
-			(s) => s.role !== "auxiliary",
-		);
-		if (servers.length === 0) return false;
-		const prefixes = servers.map((server) => `${server.id}:`);
-		for (const key of this.state.inFlight.keys()) {
-			if (prefixes.some((prefix) => key.startsWith(prefix))) return true;
+	isSpawnInFlight(
+		_filePath: string,
+		resolvedRoots: ReadonlyMap<string, string> = new Map(),
+	): boolean {
+		for (const [serverId, root] of resolvedRoots) {
+			if (this.state.inFlight.has(`${serverId}:${root}`)) return true;
 		}
 		return false;
 	}

--- a/tests/clients/lsp/service-race.test.ts
+++ b/tests/clients/lsp/service-race.test.ts
@@ -252,18 +252,57 @@ describe("LSPService race hardening", () => {
 		]);
 
 		const file = "C:/repo/new.json";
-		expect(service.isSpawnInFlight(file)).toBe(false);
+		const roots = new Map<string, string>();
+		expect(service.isSpawnInFlight(file, roots)).toBe(false);
 
-		const pending = service.getClientForFile(file);
+		const pending = service.getClientForFile(file, undefined, undefined, roots);
 		await initialize.admitted;
 		// The spawn is now parked mid-initialize, exactly the state a resync
 		// deadline can expire during (#1766's cold-start-vs-wedged race).
-		expect(service.isSpawnInFlight(file)).toBe(true);
+		expect(service.isSpawnInFlight(file, roots)).toBe(true);
 
 		initialize.release();
 		await pending;
-		expect(service.isSpawnInFlight(file)).toBe(false);
+		expect(service.isSpawnInFlight(file, roots)).toBe(false);
 		initialize.restore();
+	});
+
+	it("does not classify another workspace's spawn as in-flight", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		const internal = service as unknown as {
+			state: { inFlight: Map<string, Promise<undefined>> };
+		};
+		let release!: () => void;
+		const pending = new Promise<undefined>((resolve) => {
+			release = () => resolve(undefined);
+		});
+		internal.state.inFlight.set("marksman:C:/repo-a", pending);
+		getServersForFileWithConfig.mockReturnValue([
+			{
+				id: "marksman",
+				name: "Marksman",
+				extensions: [".md"],
+				root: async () => "C:/repo-b",
+				spawn: vi.fn(async () => undefined),
+			},
+		]);
+
+		await service.touchFile("C:/repo-b/README.md", "# repo b\n", {
+			diagnostics: "none",
+			clientScope: "primary",
+			maxClientWaitMs: 1,
+			source: "tool_call:read",
+		});
+		expect(logLatency).toHaveBeenCalledWith(
+			expect.objectContaining({
+				phase: "lsp_touch_file",
+				metadata: expect.objectContaining({
+					failureKind: "no_clients_none_spawning",
+				}),
+			}),
+		);
+		release();
 	});
 
 	it("isSpawnInFlight is false for a file type with no configured server", () => {

--- a/tests/clients/lsp/service-race.test.ts
+++ b/tests/clients/lsp/service-race.test.ts
@@ -3,6 +3,7 @@ import { suspendAt } from "../interleaving-kit.js";
 
 const getServersForFileWithConfig = vi.fn();
 const createLSPClient = vi.fn();
+const logLatency = vi.fn();
 
 vi.mock("../../../clients/lsp/config.js", () => ({
 	getServersForFileWithConfig,
@@ -13,11 +14,14 @@ vi.mock("../../../clients/lsp/client.js", () => ({
 	createLSPClient,
 }));
 
+vi.mock("../../../clients/latency-logger.js", () => ({ logLatency }));
+
 describe("LSPService race hardening", () => {
 	beforeEach(() => {
 		vi.resetModules();
 		getServersForFileWithConfig.mockReset();
 		createLSPClient.mockReset();
+		logLatency.mockReset();
 		createLSPClient.mockResolvedValue({
 			isAlive: () => true,
 			shutdown: async () => {},
@@ -121,6 +125,96 @@ describe("LSPService race hardening", () => {
 		await service.shutdown();
 		expect(client.shutdown).toHaveBeenCalledTimes(1);
 		expect(internal.state.clients.size).toBe(0);
+		initialize.restore();
+	});
+
+	it("distinguishes a warm-touch budget miss while its single spawn remains in flight", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		const client = {
+			serverId: "marksman",
+			isAlive: () => true,
+			shutdown: vi.fn(async () => {}),
+			getOperationSupport: () => ({}),
+			getWorkspaceDiagnosticsSupport: () => ({
+				advertised: false,
+				mode: "push-only" as const,
+				diagnosticProviderKind: "none",
+			}),
+			getAdvertisedCommands: () => [],
+			getRawCapabilityKeys: () => [],
+			notify: { open: vi.fn().mockResolvedValue(undefined) },
+		};
+		const initialize = suspendAt(createLSPClient, async () => client);
+		const spawn = vi.fn(async () => ({
+			process: {
+				process: { killed: false },
+				stdin: {} as any,
+				stdout: {} as any,
+				stderr: {} as any,
+				pid: 1875,
+			},
+		}));
+		getServersForFileWithConfig.mockReturnValue([
+			{
+				id: "marksman",
+				name: "Marksman",
+				extensions: [".md"],
+				root: async () => "C:/repo",
+				spawn,
+			},
+		]);
+
+		const file = "C:/repo/README.md";
+		const firstRead = service.touchFile(file, "# first\n", {
+			diagnostics: "none",
+			clientScope: "primary",
+			maxClientWaitMs: 1,
+			source: "tool_call:read",
+		});
+		await initialize.admitted;
+		expect(await firstRead).toBeUndefined();
+		expect(logLatency).toHaveBeenCalledWith(
+			expect.objectContaining({
+				phase: "lsp_touch_file",
+				metadata: expect.objectContaining({
+					failureKind: "spawn_in_flight_budget_elapsed",
+				}),
+			}),
+		);
+
+		initialize.release();
+		await initialize.completed;
+		const secondRead = await service.touchFile(file, "# first\n", {
+			diagnostics: "none",
+			clientScope: "primary",
+			maxClientWaitMs: 1,
+			source: "tool_call:read",
+		});
+
+		expect(secondRead).toEqual({ diags: [] });
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(createLSPClient).toHaveBeenCalledTimes(1);
+		expect(client.notify.open).toHaveBeenCalledTimes(1);
+
+		logLatency.mockClear();
+		getServersForFileWithConfig.mockReturnValue([]);
+		expect(
+			await service.touchFile("C:/repo/notes.unknown", "none\n", {
+				diagnostics: "none",
+				clientScope: "primary",
+				maxClientWaitMs: 1,
+				source: "tool_call:read",
+			}),
+		).toBeUndefined();
+		expect(logLatency).toHaveBeenCalledWith(
+			expect.objectContaining({
+				phase: "lsp_touch_file",
+				metadata: expect.objectContaining({
+					failureKind: "no_clients_none_spawning",
+				}),
+			}),
+		);
 		initialize.restore();
 	});
 


### PR DESCRIPTION
## Outcome  Bounded read-warm touches now distinguish a primary LSP spawn that is still in flight from a true no-client state. The completed spawn remains single-flight and serves the next read without a second process.  ## Design  This uses acceptance-criteria design (a), backed by the existing spawn coordinator. `LSPService.state.inFlight` already deduplicates `serverId:root` spawns, and `isSpawnInFlight` already derives primary-only lifecycle evidence from that map for the #1766 timeout path. The touch verdict now reads the same evidence when its ready-client set is empty:  - `spawn_in_flight_budget_elapsed`: the bounded client wait elapsed while a matching primary spawn remains pending. - `no_clients_none_spawning`: no client is ready and no matching primary spawn remains pending.  A separate pending-warm latch would duplicate coordinator state and create another lifecycle to clear. A probe-cache budget would also make a fire-and-forget warm wait longer without improving user latency.  ## Red proofs  - Pre-fix real-path test: expected `spawn_in_flight_budget_elapsed`; `lsp_touch_file` instead recorded `failureKind: no_clients` while the slow fake marksman initialization remained suspended. - Mutation proof: replacing the discrimination with unconditional `no_clients_none_spawning` makes the same test fail. It receives `no_clients_none_spawning` where it requires `spawn_in_flight_budget_elapsed`.  The test uses `suspendAt(createLSPClient, ...)`, drives `LSPService.touchFile` with `source: tool_call:read`, releases the real spawn coordination seam, and proves the next touch succeeds with exactly one server spawn and one client construction.  ## Class sweep  | Surface | Budget versus slow resource | Existing verdict | Action | | --- | --- | --- | --- | | `touchFile` primary acquisition | Yes; 750 ms read warm versus cold marksman | Conflated empty and in-flight as `no_clients` | Fixed with coordinator evidence | | Autofix LSP resync | Yes; outer sync budget versus cold spawn or wedged write | `spawn-in-flight`, `timeout`, or `aborted` since #1766 | No change | | `lsp_client_wait_timeout` | Yes; acquisition wait | Carries budget, server IDs, and client health; touch owns the final verdict | No duplicate verdict added | | Aggregate diagnostics | No bounded spawn acquisition | `no_clients` or `no_clients_stale` describes settled acquisition | No change | | LSP runtime and command probes | Typed probe/spawn timeout classifications | Preserve unavailable, timeout, and spawn-failure evidence | No conflation found | | Installer and lazy-runner single flights | Callers reuse and await the in-flight promise | No empty result while work remains pending | No change |  ## Blast radius and cost  `module_report` and symbol-navigation tools were unavailable in this worker. Import and call-site inspection shows the changed production branch is reached through `LSPService.touchFile`; read warm in `clients/runtime-tool-call.ts` and autofix resync in `clients/pipeline.ts` are the relevant callers. Spawn publication, leases, diagnostics callbacks, and the public `getClientForFile` result remain unchanged.  Successful touches pay zero additional work. Only an already-failed empty-client touch performs the existing primary-server lookup and a bounded scan of the in-flight client keys.  ## Verification  - `npm run build` - `npx vitest run tests/clients/lsp/service-race.test.ts tests/clients/pipeline-lsp-sync.test.ts tests/clients/lsp/client-unavailable-dedupe.test.ts` (17 passed) - `npx vitest run tests/clients/session-state-conformance.test.ts` (62 passed) - `npm run lint` - `npm run changelog:check` (180 entries validated)  No full suite was run, as requested.  *Drafted by a codex worker via plegma; maintainer verification follows.*  
## Fix round: #1875 root correlation

The empty-client verdict now receives the primary `serverId:root` identities resolved by acquisition and matches the complete coordinator key. A pending spawn in `repo-a` no longer relabels a settled touch in `repo-b`.

Red-proof against the pre-fix serverId-prefix matcher, verbatim:

```text
 × |default| tests/clients/lsp/service-race.test.ts > LSPService race hardening > does not classify another workspace's spawn as in-flight
   → expected vi.fn() to be called with arguments: [ ObjectContaining{…} ]

Received:

  2nd vi.fn() call:

  [
-   ObjectContaining {
-     metadata: ObjectContaining {
-       failureKind: no_clients_none_spawning,
+   {
+     durationMs: 2,
+     filePath: C:/repo-b/readme.md,
+     metadata: {
+       clientScope: primary,
+       diagnosticsMode: none,
+       failureKind: spawn_in_flight_budget_elapsed,
+       maxClientWaitMs: 1,
+       serverCountAttempted: 1,
+       serverCountReady: 0,
+       source: tool_call:read,
      },
-     phase: lsp_touch_file,
+     phase: lsp_touch_file,
+     type: phase,
    },
  ]

Number of calls: 2
```

Verification for this fix round: `npm run build`; race, touch, and session-state-conformance tests: 80 passed. No full suite was run.