### PR TITLE
feat(lsp): record which client served workspace-scope queries (closes #1854)

### DIFF
--- a/.changelog/feat-1854-workspace-client-attribution.md
+++ b/.changelog/feat-1854-workspace-client-attribution.md
@@ -1,0 +1,9 @@
+---
+section: Changed
+---
+
+- **Workspace-scope LSP queries identify their serving client ([refs #1854](https://github.com/apmantza/pi-lens/issues/1854))** —
+  the existing `lsp_navigation_result` latency record now names the LSP server
+  that answered each no-path workspace query. Aggregated operation support
+  records a bounded per-capability contributor map, so multi-primary routing
+  defects are visible without adding another log surface.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,14 @@ Coverage markers are deduped per session by normalized kind, file, and the
 normalized silent-scanner set. A changed set admits a new marker, and a marker
 is appended after primary diagnostics so both remain visible.
 
+No-filePath workspace-scope LSP queries use a request-local attribution
+collector. `lsp_navigation_result` records the serving server id for each
+single-client answer and a fixed-key per-capability contributor map for
+aggregated operation support. Capability snapshot client ids are capped, with
+the full count preserved. Never replace this with shared last-client state;
+concurrent navigation requests must not overwrite each other's attribution.
+(#1854)
+
 Post-fix decision observability is durable and bounded: advisory delivery logs
 one `advisory_provenance_decision` per consume, classic TypeScript project
 identity logs every success/failure outcome, deferred mutation drains summarize

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -52,6 +52,7 @@ import {
 } from "../path-utils.js";
 import type {
 	LSPClientInfo,
+	LSPOperationSupport,
 	LSPPullFailure,
 	LSPShutdownOptions,
 } from "./client.js";
@@ -91,6 +92,27 @@ import {
 	type LSPCapabilitySnapshot,
 } from "./wait-policy/index.js";
 export type { LSPCapabilitySnapshot } from "./wait-policy/index.js";
+
+const WORKSPACE_ATTRIBUTION_CLIENT_CAP = 16;
+
+/**
+ * Request-local attribution for no-filePath workspace queries. The fixed site
+ * and capability keys plus the capped client list keep the caller's existing
+ * latency record bounded. Callers create one collector per request; the
+ * service never stores shared "last client" state that concurrent calls could
+ * overwrite.
+ */
+export interface LSPWorkspaceScopeAttribution {
+	workspaceSymbol?: string;
+	getAdvertisedCommands?: string;
+	executeCommand?: string;
+	getOperationSupport?: {
+		baseClientId: string;
+		contributors: Partial<Record<keyof LSPOperationSupport, string>>;
+	};
+	getCapabilitySnapshots?: { clientIds: string[]; clientCount: number };
+	getWorkspaceDiagnosticsSupport?: string;
+}
 import { raceToCompletion, type PromiseDescriptor } from "./aggregation.js";
 import {
 	applyWorkspaceEdit,
@@ -5677,8 +5699,10 @@ export class LSPService {
 	 */
 	private selectWorkspaceScopeClient(
 		predicate?: (client: LSPClientInfo) => boolean,
-	): LSPClientInfo | undefined {
-		let auxFallback: LSPClientInfo | undefined;
+	): { client: LSPClientInfo; serverId: string } | undefined {
+		let auxFallback:
+			| { client: LSPClientInfo; serverId: string }
+			| undefined;
 		for (const [key, client] of this.state.clients) {
 			if (!client.isAlive()) continue;
 			if (predicate && !predicate(client)) continue;
@@ -5686,10 +5710,10 @@ export class LSPService {
 			const serverId = separator >= 0 ? key.slice(0, separator) : key;
 			const role = LSP_SERVERS.find((s) => s.id === serverId)?.role;
 			if (role === "auxiliary") {
-				if (!auxFallback) auxFallback = client;
+				if (!auxFallback) auxFallback = { client, serverId };
 				continue;
 			}
-			return client;
+			return { client, serverId };
 		}
 		return auxFallback;
 	}
@@ -5711,7 +5735,11 @@ export class LSPService {
 	 * auxiliary; only when none of the spawned clients support it does this
 	 * fall back to `[]`.
 	 */
-	async workspaceSymbol(query: string, filePath?: string) {
+	async workspaceSymbol(
+		query: string,
+		filePath?: string,
+		attribution?: LSPWorkspaceScopeAttribution,
+	) {
 		if (filePath) {
 			const spawned = await this.getClientForFile(
 				filePath,
@@ -5726,7 +5754,8 @@ export class LSPService {
 			(client) => client.getOperationSupport().workspaceSymbol,
 		);
 		if (!target) return [];
-		return target.workspaceSymbol(query);
+		if (attribution) attribution.workspaceSymbol = target.serverId;
+		return target.client.workspaceSymbol(query);
 	}
 
 	/**
@@ -5735,7 +5764,10 @@ export class LSPService {
 	 * a primary over an auxiliary scanner spawned first (#1812 sweep — see
 	 * `selectWorkspaceScopeClient`).
 	 */
-	async getAdvertisedCommands(filePath?: string): Promise<string[]> {
+	async getAdvertisedCommands(
+		filePath?: string,
+		attribution?: LSPWorkspaceScopeAttribution,
+	): Promise<string[]> {
 		if (filePath) {
 			const spawned = await this.getClientForFile(
 				filePath,
@@ -5745,7 +5777,9 @@ export class LSPService {
 			return spawned.client.getAdvertisedCommands();
 		}
 		const first = this.selectWorkspaceScopeClient();
-		return first ? first.getAdvertisedCommands() : [];
+		if (!first) return [];
+		if (attribution) attribution.getAdvertisedCommands = first.serverId;
+		return first.client.getAdvertisedCommands();
 	}
 
 	/**
@@ -5760,6 +5794,7 @@ export class LSPService {
 		command: string,
 		args?: unknown[],
 		mutationContext?: LspMutationContext,
+		attribution?: LSPWorkspaceScopeAttribution,
 	): Promise<{ executed: boolean; result?: unknown; reason?: string }> {
 		if (filePath) {
 			const spawned = await this.getClientForFile(
@@ -5773,7 +5808,8 @@ export class LSPService {
 		}
 		const first = this.selectWorkspaceScopeClient();
 		if (!first) return { executed: false, reason: "no active LSP server" };
-		return first.executeCommand(command, args, mutationContext);
+		if (attribution) attribution.executeCommand = first.serverId;
+		return first.client.executeCommand(command, args, mutationContext);
 	}
 
 	/**
@@ -5842,6 +5878,7 @@ export class LSPService {
 	 */
 	async getOperationSupport(
 		filePath?: string,
+		attribution?: LSPWorkspaceScopeAttribution,
 	): Promise<import("./client.js").LSPOperationSupport | null> {
 		if (filePath) {
 			const spawned = await this.getClientForFile(filePath);
@@ -5855,16 +5892,29 @@ export class LSPService {
 			typeof client.getOperationSupport === "function";
 		const first = this.selectWorkspaceScopeClient(readable);
 		if (!first) return null;
-		const aggregate = { ...first.getOperationSupport() };
+		const aggregate = { ...first.client.getOperationSupport() };
+		const contributors: Partial<Record<keyof LSPOperationSupport, string>> = {};
 		for (const capability of Object.keys(aggregate) as Array<
 			keyof import("./client.js").LSPOperationSupport
 		>) {
-			if (aggregate[capability]) continue;
+			if (aggregate[capability]) {
+				contributors[capability] = first.serverId;
+				continue;
+			}
 			const supporter = this.selectWorkspaceScopeClient(
 				(client) =>
 					readable(client) && Boolean(client.getOperationSupport()[capability]),
 			);
-			if (supporter) aggregate[capability] = true;
+			if (supporter) {
+				aggregate[capability] = true;
+				contributors[capability] = supporter.serverId;
+			}
+		}
+		if (attribution) {
+			attribution.getOperationSupport = {
+				baseClientId: first.serverId,
+				contributors,
+			};
 		}
 		return aggregate;
 	}
@@ -5875,6 +5925,7 @@ export class LSPService {
 	 */
 	async getCapabilitySnapshots(
 		filePath?: string,
+		attribution?: LSPWorkspaceScopeAttribution,
 	): Promise<LSPCapabilitySnapshot[]> {
 		if (this.checkDestroyed()) return [];
 		const snapshots: LSPCapabilitySnapshot[] = [];
@@ -5915,11 +5966,20 @@ export class LSPService {
 				launchVariant: client.getLaunchVariant?.(),
 			});
 		}
+		if (attribution) {
+			attribution.getCapabilitySnapshots = {
+				clientIds: snapshots
+					.slice(0, WORKSPACE_ATTRIBUTION_CLIENT_CAP)
+					.map((snapshot) => snapshot.serverId),
+				clientCount: snapshots.length,
+			};
+		}
 		return snapshots;
 	}
 
 	async getWorkspaceDiagnosticsSupport(
 		filePath?: string,
+		attribution?: LSPWorkspaceScopeAttribution,
 	): Promise<import("./client.js").LSPWorkspaceDiagnosticsSupport | null> {
 		if (filePath) {
 			const spawned = await this.getClientForFile(filePath);
@@ -5931,9 +5991,10 @@ export class LSPService {
 
 		const first = this.selectWorkspaceScopeClient();
 		if (!first) return null;
-		const getter = first.getWorkspaceDiagnosticsSupport;
+		const getter = first.client.getWorkspaceDiagnosticsSupport;
 		if (typeof getter !== "function") return null;
-		return getter();
+		if (attribution) attribution.getWorkspaceDiagnosticsSupport = first.serverId;
+		return getter.call(first.client);
 	}
 
 	/**

--- a/tests/tools/lsp-navigation-workspace-attribution.test.ts
+++ b/tests/tools/lsp-navigation-workspace-attribution.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { serviceHolder, logLatency } = vi.hoisted(() => ({
+	serviceHolder: { current: null as unknown },
+	logLatency: vi.fn(),
+}));
+
+vi.mock("../../clients/latency-logger.js", () => ({ logLatency }));
+vi.mock("../../clients/lsp/index.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../clients/lsp/index.js")>();
+	return { ...actual, getLSPService: () => serviceHolder.current };
+});
+
+import { LSPService } from "../../clients/lsp/index.js";
+import type { LSPOperationSupport } from "../../clients/lsp/client.js";
+import { createLspNavigationTool } from "../../tools/lsp-navigation.js";
+
+const support = (workspaceSymbol: boolean): LSPOperationSupport => ({
+	definition: false,
+	typeDefinition: false,
+	declaration: false,
+	references: false,
+	hover: false,
+	signatureHelp: false,
+	documentSymbol: false,
+	workspaceSymbol,
+	codeAction: false,
+	rename: false,
+	implementation: false,
+	callHierarchy: false,
+});
+
+function client(workspaceSymbol: boolean) {
+	return {
+		isAlive: () => true,
+		getOperationSupport: () => support(workspaceSymbol),
+		workspaceSymbol: vi.fn(async () =>
+			workspaceSymbol ? [{ name: "servedByTypescript", kind: 12 }] : [],
+		),
+	};
+}
+
+function injectClient(service: LSPService, key: string, value: unknown): void {
+	(
+		service as unknown as { state: { clients: Map<string, unknown> } }
+	).state.clients.set(key, value);
+}
+
+describe("workspace-scope LSP client attribution (#1854)", () => {
+	beforeEach(() => {
+		logLatency.mockReset();
+	});
+
+	it("records the serving client when two real primary map entries can disagree", async () => {
+		const json = client(false);
+		const typescript = client(true);
+		const service = new LSPService();
+		injectClient(service, "json:C:/workspace", json);
+		injectClient(service, "typescript:C:/workspace", typescript);
+		serviceHolder.current = service;
+
+		const tool = createLspNavigationTool((flag) => flag === "lens-lsp");
+		const result = await tool.execute(
+			"workspace-attribution",
+			{ operation: "workspaceSymbol", query: "servedByTypescript" },
+			new AbortController().signal,
+			null,
+			{ cwd: "C:/workspace" },
+		);
+
+		expect(result.isError).toBeUndefined();
+		expect(json.workspaceSymbol).not.toHaveBeenCalled();
+		expect(typescript.workspaceSymbol).toHaveBeenCalledOnce();
+
+		const record = logLatency.mock.calls
+			.map(([entry]) => entry as Record<string, unknown>)
+			.find((entry) => entry.phase === "lsp_navigation_result");
+		expect(record).toBeDefined();
+		expect(record?.metadata).toMatchObject({
+			workspaceScopeAttribution: {
+				getOperationSupport: {
+					baseClientId: "json",
+					contributors: { workspaceSymbol: "typescript" },
+				},
+				workspaceSymbol: "typescript",
+			},
+		});
+		expect(record?.metadata).not.toMatchObject({
+			workspaceScopeAttribution: { workspaceSymbol: "json" },
+		});
+	});
+});

--- a/tests/tools/lsp-navigation.test.ts
+++ b/tests/tools/lsp-navigation.test.ts
@@ -257,7 +257,7 @@ describe("lsp_navigation tool", () => {
 		expect(
 			(mocked.service as { workspaceSymbol: ReturnType<typeof vi.fn> })
 				.workspaceSymbol,
-		).toHaveBeenCalledWith("ReportProcessor", undefined);
+		).toHaveBeenCalledWith("ReportProcessor", undefined, expect.any(Object));
 	});
 
 	it("executeCommand dry-runs by default and does NOT execute", async () => {

--- a/tools/lsp-navigation.ts
+++ b/tools/lsp-navigation.ts
@@ -21,7 +21,10 @@ import {
 	applyWorkspaceEdit,
 	summarizeWorkspaceEdit,
 } from "../clients/lsp/edits.js";
-import { getLSPService } from "../clients/lsp/index.js";
+import {
+	getLSPService,
+	type LSPWorkspaceScopeAttribution,
+} from "../clients/lsp/index.js";
 import type { SearchReadLocation } from "../clients/search-read-registration.js";
 import { buildLspNavigationEnvelope } from "./lsp-structured-output.js";
 import { SYMBOL_KIND_NAMES } from "../clients/lsp-document-symbols.js";
@@ -919,6 +922,7 @@ export function createLspNavigationTool(
 			let columnResolution: SymbolColumnResolution | undefined;
 			let mutationContext: LspMutationContext | undefined;
 			let requestedApply = false;
+			const workspaceScopeAttribution: LSPWorkspaceScopeAttribution = {};
 
 			const finalize = (
 				payload: {
@@ -958,6 +962,9 @@ export function createLspNavigationTool(
 						supported,
 						diagnosticsMode,
 						columnResolution,
+						...(Object.keys(workspaceScopeAttribution).length > 0
+							? { workspaceScopeAttribution }
+							: {}),
 					},
 				});
 
@@ -1140,9 +1147,12 @@ export function createLspNavigationTool(
 
 			const lspService = getLSPService();
 			if (operation === "capabilities") {
-				const snapshots = await lspService.getCapabilitySnapshots(
-					rawPath ? filePath : undefined,
-				);
+				const snapshots = rawPath
+					? await lspService.getCapabilitySnapshots(filePath)
+					: await lspService.getCapabilitySnapshots(
+							undefined,
+							workspaceScopeAttribution,
+						);
 				const output = formatCapabilities(
 					snapshots,
 					rawPath ? filePath : undefined,
@@ -1166,9 +1176,12 @@ export function createLspNavigationTool(
 			}
 
 			if (operation === "workspaceDiagnostics") {
-				const wsDiagSupport = await lspService.getWorkspaceDiagnosticsSupport(
-					rawPath ? filePath : undefined,
-				);
+				const wsDiagSupport = rawPath
+					? await lspService.getWorkspaceDiagnosticsSupport(filePath)
+					: await lspService.getWorkspaceDiagnosticsSupport(
+							undefined,
+							workspaceScopeAttribution,
+						);
 				diagnosticsMode = wsDiagSupport?.mode ?? "unknown";
 
 				if (rawPath && !filePathIsDirectory) {
@@ -1377,10 +1390,13 @@ export function createLspNavigationTool(
 			const lspEndChar = (endCharacter ?? resolvedCharacter.character) - 1;
 
 			const runWorkspaceSymbolOperation = async (): Promise<SymbolNode[]> => {
-				supported = operationSupportStatus(
-					operation,
-					await lspService.getOperationSupport(rawPath ? filePath : undefined),
-				);
+				const support = rawPath
+					? await lspService.getOperationSupport(filePath)
+					: await lspService.getOperationSupport(
+							undefined,
+							workspaceScopeAttribution,
+						);
+				supported = operationSupportStatus(operation, support);
 				if (supported === false) {
 					throw new Error(
 						"__UNSUPPORTED__ Active LSP server does not advertise support for workspaceSymbol",
@@ -1395,10 +1411,13 @@ export function createLspNavigationTool(
 					await openFileBestEffort(lspService, filePath);
 				}
 				try {
-					const raw = await lspService.workspaceSymbol(
-						query ?? "",
-						rawPath ? filePath : undefined,
-					);
+					const raw = rawPath
+						? await lspService.workspaceSymbol(query ?? "", filePath)
+						: await lspService.workspaceSymbol(
+								query ?? "",
+								undefined,
+								workspaceScopeAttribution,
+							);
 					const filtered = (Array.isArray(raw) ? raw : [raw]).filter(
 						(s) =>
 							typeof s === "object" &&
@@ -1545,9 +1564,12 @@ export function createLspNavigationTool(
 								"__BADINPUT__ command parameter required for executeCommand",
 							);
 						}
-						const advertised = await lspService.getAdvertisedCommands(
-							rawPath ? filePath : undefined,
-						);
+						const advertised = rawPath
+							? await lspService.getAdvertisedCommands(filePath)
+							: await lspService.getAdvertisedCommands(
+									undefined,
+									workspaceScopeAttribution,
+								);
 						const isAdvertised = advertised.includes(command);
 						// Dry-run by default: report advertisement status without running.
 						// Mutation only on explicit apply:true (and the client re-checks
@@ -1569,12 +1591,20 @@ export function createLspNavigationTool(
 								`__UNSUPPORTED__ command "${command}" is not advertised by the active LSP server (advertised: ${advertised.join(", ") || "none"})`,
 							);
 						}
-						return lspService.executeCommand(
-							rawPath ? filePath : undefined,
-							command,
-							commandArguments,
-							mutationContext,
-						);
+						return rawPath
+							? lspService.executeCommand(
+									filePath,
+									command,
+									commandArguments,
+									mutationContext,
+								)
+							: lspService.executeCommand(
+									undefined,
+									command,
+									commandArguments,
+									mutationContext,
+									workspaceScopeAttribution,
+								);
 					}
 					case "incomingCalls": {
 						if (!callHierarchyItem) {


### PR DESCRIPTION
## Outcome

Workspace-scope LSP navigation records now identify the client that served each no-`filePath` query in the existing `lsp_navigation_result` latency row. Aggregated operation support records its base client and a fixed-key per-capability contributor map. Capability snapshot attribution caps the client-id list at 16 and preserves the full count.

## Population sweep

| Site | Verdict | Existing record extension |
| --- | --- | --- |
| `workspaceSymbol` | no record surface — extended nearest caller record | `lsp_navigation_result.metadata.workspaceScopeAttribution.workspaceSymbol` |
| `getAdvertisedCommands` | no record surface — extended nearest caller record | `lsp_navigation_result.metadata.workspaceScopeAttribution.getAdvertisedCommands` |
| `executeCommand` | no record surface — extended nearest caller record | `lsp_navigation_result.metadata.workspaceScopeAttribution.executeCommand` |
| `getCapabilitySnapshots` | already carried server ids in the answer; extended caller record | capped `getCapabilitySnapshots.clientIds` plus `clientCount` |
| `getWorkspaceDiagnosticsSupport` | no record surface — extended nearest caller record | `lsp_navigation_result.metadata.workspaceScopeAttribution.getWorkspaceDiagnosticsSupport` |
| aggregated `getOperationSupport` | no record surface — extended nearest caller record | `getOperationSupport.baseClientId` plus fixed-key `contributors` |

The service methods have no independent latency or dispatch record. Their nearest existing caller surface is `tools/lsp-navigation.ts`'s `lsp_navigation_result` phase, so this change uses a request-local collector and extends that row. It does not add a log file or shared last-client state.

## Verification

- `npm run build`
- `npm run lint`
- Seven focused LSP operation/navigation and session-state files: 120 tests passed.
- Final focused rerun after the contributor-map shape adjustment: 101 tests passed across four files.
- No full suite was run, as requested.

The two-primary test uses a real `LSPService.state.clients` map with `json` inserted before `typescript`. JSON supplies the aggregate base answer, while TypeScript supplies and serves `workspaceSymbol`; the latency row distinguishes both identities.

Red proof: removing `workspaceScopeAttribution` from the existing record and rebuilding made the new test fail because the row contained no client identity. This reproduces the pre-fix record shape. The same mutation, dropping the id-bearing field while leaving routing intact, turns the test red.

The repository's requested `module_report`/symbol navigation tools were unavailable in this worker environment. I mapped the production call sites with repository search instead. The affected entry point is `lsp_navigation`; direct service callers remain source-compatible because the attribution collector is optional. This change adds only bounded object assignment and fixed-key collection to the existing workspace-query path.

Refs #1854

*Drafted by a codex worker via plegma; maintainer verification follows.*