### PR TITLE
fix(dispatch): demote context-free compiler findings (closes #1885)

### DIFF
--- a/.changelog/fix-1885-context-free-compiler-semantics.md
+++ b/.changelog/fix-1885-context-free-compiler-semantics.md
@@ -1,0 +1,10 @@
+---
+section: Fixed
+---
+
+- **Keep context-free compiler findings non-blocking ([closes #1885](https://github.com/apmantza/pi-lens/issues/1885))** —
+  standalone javac, C/C++ syntax checks, Zig single-file builds, and direct
+  elixirc runs still report useful compiler errors, but no longer stop an edit
+  when missing project classpaths, build flags, modules, or dependencies could
+  have caused the finding. A recovered Java LSP clean result also replaces any
+  javac findings already held in session diagnostics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,13 @@ edited file's directory through `DispatchContext.projectRoot` inclusive. Never
 let a descriptor above the session project suppress the fallback; nested module
 descriptors inside the project still gate it. (#1877)
 
+Context-free compiler runners preserve compiler severity but never claim a
+blocking semantic when the invocation lacks the project inputs needed to prove
+that verdict. This applies to standalone javac, C/C++ syntax checks without a
+compile database, `zig build-exe` without build.zig module context, and direct
+elixirc without Mix; project-backed Mix and dotnet builds may still block.
+(#1885)
+
 Mechanical ast-grep rules may expose a `fix:` only when one syntax rewrite is
 unambiguous. Reflect.apply remains diagnostic-only because an own shadowed
 `.apply` changes the obvious rewrite's semantics. Two-argument Reflect.get uses

--- a/clients/dispatch/runners/cpp-check.ts
+++ b/clients/dispatch/runners/cpp-check.ts
@@ -155,7 +155,9 @@ function parseGccLikeOutput(raw: string, filePath: string): Diagnostic[] {
 			line: Number.parseInt(lineStr, 10) || 1,
 			column: Number.parseInt(colStr || "1", 10) || 1,
 			severity,
-			semantic: severity === "error" ? "blocking" : "warning",
+			// This single-file syntax check has no compile database, include path,
+			// or build flags. It can inform, but cannot prove a project blocker.
+			semantic: "warning",
 			tool: "cpp-check",
 			rule: severityLabel.toLowerCase(),
 			fixable: false,
@@ -186,7 +188,8 @@ function parseMsvcOutput(raw: string, filePath: string): Diagnostic[] {
 			line: Number.parseInt(lineStr, 10) || 1,
 			column: Number.parseInt(colStr || "1", 10) || 1,
 			severity,
-			semantic: severity === "error" ? "blocking" : "warning",
+			// MSVC is invoked with the same context-free single-file contract.
+			semantic: "warning",
 			tool: "cpp-check",
 			rule,
 			fixable: false,
@@ -258,7 +261,7 @@ const cppCheckRunner: RunnerDefinition = {
 		return {
 			status: hasErrors ? "failed" : "succeeded",
 			diagnostics,
-			semantic: hasErrors ? "blocking" : "warning",
+			semantic: "warning",
 			rawOutput: raw,
 		};
 	},

--- a/clients/dispatch/runners/elixir-check.ts
+++ b/clients/dispatch/runners/elixir-check.ts
@@ -191,7 +191,17 @@ const elixirCheckRunner: RunnerDefinition = {
 		}
 
 		const raw = `${result.stderr || ""}\n${result.stdout || ""}`;
-		const diagnostics = parseElixirOutput(raw, ctx.filePath, cwd);
+		const hasProjectContext = command === "mix";
+		const diagnostics = parseElixirOutput(raw, ctx.filePath, cwd).map((d) =>
+			hasProjectContext
+				? d
+				: {
+						...d,
+						// A direct elixirc invocation cannot resolve Mix dependencies.
+						// Standalone findings inform the agent, but cannot block it.
+						semantic: "warning" as const,
+					},
+		);
 		if (diagnostics.length === 0) {
 			if (result.status && result.status !== 0) {
 				return {
@@ -204,13 +214,13 @@ const elixirCheckRunner: RunnerDefinition = {
 								`${command} exited non-zero without structured diagnostics`,
 							filePath: ctx.filePath,
 							severity: "error",
-							semantic: "blocking",
+							semantic: hasProjectContext ? "blocking" : "warning",
 							tool: "elixir-check",
 							rule: command,
 							fixable: false,
 						},
 					],
-					semantic: "blocking",
+					semantic: hasProjectContext ? "blocking" : "warning",
 				};
 			}
 			return { status: "succeeded", diagnostics: [], semantic: "none" };

--- a/clients/dispatch/runners/javac.ts
+++ b/clients/dispatch/runners/javac.ts
@@ -35,7 +35,9 @@ function parseJavacOutput(raw: string, filePath: string): Diagnostic[] {
 			line: lineNum,
 			column: 1,
 			severity,
-			semantic: severity === "error" ? "blocking" : "warning",
+			// A standalone single-file javac run has no project classpath. It can
+			// report useful syntax/type evidence, but it cannot prove a blocker.
+			semantic: "warning",
 			tool: "javac",
 			rule: "compile",
 			fixable: false,
@@ -107,7 +109,7 @@ const javacRunner: RunnerDefinition = {
 		return {
 			status: hasErrors ? "failed" : "succeeded",
 			diagnostics,
-			semantic: hasErrors ? "blocking" : "warning",
+			semantic: "warning",
 		};
 	},
 };

--- a/clients/dispatch/runners/zig-check.ts
+++ b/clients/dispatch/runners/zig-check.ts
@@ -34,7 +34,9 @@ function parseZigOutput(raw: string, filePath: string): Diagnostic[] {
 			line: Number.parseInt(lineStr, 10) || 1,
 			column: Number.parseInt(colStr, 10) || 1,
 			severity,
-			semantic: severity === "error" ? "blocking" : "warning",
+			// `zig build-exe <file>` does not load build.zig module/import context.
+			// Its findings are useful evidence, but cannot prove a project blocker.
+			semantic: "warning",
 			tool: "zig",
 			rule: `zig-${level}`,
 			fixable: false,
@@ -107,7 +109,7 @@ const zigCheckRunner: RunnerDefinition = {
 		return {
 			status: hasErrors ? "failed" : "succeeded",
 			diagnostics,
-			semantic: hasErrors ? "blocking" : "warning",
+			semantic: "warning",
 		};
 	},
 };

--- a/tests/clients/dispatch/javac-dispatch-integration.test.ts
+++ b/tests/clients/dispatch/javac-dispatch-integration.test.ts
@@ -10,6 +10,11 @@ import {
 import { FactStore } from "../../../clients/dispatch/fact-store.js";
 import javacRunner from "../../../clients/dispatch/runners/javac.js";
 import type { RunnerResult } from "../../../clients/dispatch/types.js";
+import {
+	clearWidgetState,
+	getFileDiagnostics,
+	recordDiagnostics,
+} from "../../../clients/widget-state.js";
 import { setupTestEnvironment } from "../test-utils.js";
 
 const { safeSpawnAsync } = vi.hoisted(() => ({
@@ -28,6 +33,7 @@ vi.mock("../../../clients/dispatch/runners/utils/runner-helpers.js", () => ({
 describe("javac dispatcher integration (#1877)", () => {
 	beforeEach(() => {
 		clearCoverageNoticeState();
+		clearWidgetState();
 		safeSpawnAsync.mockReset();
 		safeSpawnAsync.mockResolvedValue({
 			error: null,
@@ -35,6 +41,62 @@ describe("javac dispatcher integration (#1877)", () => {
 			stdout: "",
 			stderr: "",
 		});
+	});
+
+	it("replaces an earlier javac cache entry when LSP recovers clean", async () => {
+		const env = setupTestEnvironment("pi-lens-javac-cache-recovery-");
+		try {
+			const filePath = path.join(env.tmpDir, "module", "src", "App.java");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, "class App {}\n");
+			fs.writeFileSync(path.join(env.tmpDir, "pom.xml"), "<project />\n");
+
+			// Reproduce the poisoned state from a pre-gate LSP-skipped window.
+			recordDiagnostics(filePath, [
+				{
+					tool: "javac",
+					rule: "compile",
+					message: "package dependency does not exist",
+					severity: "error",
+					semantic: "blocking",
+				},
+			]);
+			expect(getFileDiagnostics(filePath)?.[0]?.tool).toBe("javac");
+
+			let lspReady = false;
+			const registry = createJavaRegistry(() => lspReady);
+			const ctx = createDispatchContext(
+				filePath,
+				env.tmpDir,
+				{ getFlag: () => false },
+				new FactStore(),
+				undefined,
+				undefined,
+				env.tmpDir,
+			);
+
+			const skipped = await dispatchForFile(
+				ctx,
+				[{ mode: "fallback", runnerIds: ["lsp", "javac"] }],
+				registry,
+			);
+			recordDiagnostics(filePath, skipped.diagnostics);
+			expect(skipped.output).toContain("analysis unavailable");
+			expect(safeSpawnAsync).not.toHaveBeenCalled();
+
+			lspReady = true;
+			const recovered = await dispatchForFile(
+				ctx,
+				[{ mode: "fallback", runnerIds: ["lsp", "javac"] }],
+				registry,
+			);
+			recordDiagnostics(filePath, recovered.diagnostics);
+
+			expect(recovered.diagnostics).toEqual([]);
+			expect(getFileDiagnostics(filePath)).toEqual([]);
+		} finally {
+			env.cleanup();
+		}
 	});
 
 	it("reports unavailable analysis when the descriptor gate skips javac", async () => {
@@ -108,7 +170,7 @@ describe("javac dispatcher integration (#1877)", () => {
 	});
 });
 
-function createJavaRegistry(): RunnerRegistry {
+function createJavaRegistry(lspReady: () => boolean = () => false): RunnerRegistry {
 	const registry = new RunnerRegistry();
 	registry.register({
 		id: "lsp",
@@ -116,7 +178,11 @@ function createJavaRegistry(): RunnerRegistry {
 		priority: 4,
 		enabledByDefault: true,
 		async run() {
-			return { status: "skipped", diagnostics: [], semantic: "none" };
+			return {
+				status: lspReady() ? "succeeded" : "skipped",
+				diagnostics: [],
+				semantic: "none",
+			};
 		},
 	});
 	registry.register(javacRunner);

--- a/tests/clients/dispatch/runners/java-csharp-runners.test.ts
+++ b/tests/clients/dispatch/runners/java-csharp-runners.test.ts
@@ -36,7 +36,7 @@ describe("java/csharp fallback runners", () => {
 		);
 	});
 
-	it("parses javac blocking diagnostics for the edited file", async () => {
+	it("keeps standalone javac diagnostics non-blocking", async () => {
 		const env = setupTestEnvironment("pi-lens-javac-runner-");
 		try {
 			const filePath = path.join(env.tmpDir, "src", "App.java");
@@ -55,8 +55,9 @@ describe("java/csharp fallback runners", () => {
 			);
 
 			expect(result.status).toBe("failed");
-			expect(result.semantic).toBe("blocking");
+			expect(result.semantic).toBe("warning");
 			expect(result.diagnostics[0]?.tool).toBe("javac");
+			expect(result.diagnostics[0]?.semantic).toBe("warning");
 			expect(result.diagnostics[0]?.line).toBe(7);
 		} finally {
 			env.cleanup();
@@ -131,8 +132,9 @@ describe("java/csharp fallback runners", () => {
 			} as never);
 
 			expect(result.status).toBe("failed");
-			expect(result.semantic).toBe("blocking");
+			expect(result.semantic).toBe("warning");
 			expect(result.diagnostics[0]?.tool).toBe("cpp-check");
+			expect(result.diagnostics[0]?.semantic).toBe("warning");
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/dispatch/runners/javac-build-descriptor-gate.test.ts
+++ b/tests/clients/dispatch/runners/javac-build-descriptor-gate.test.ts
@@ -109,8 +109,9 @@ describe("javac build-descriptor gate (#1877)", () => {
 
 			expect(safeSpawn).toHaveBeenCalledTimes(1);
 			expect(result.status).toBe("failed");
-			expect(result.semantic).toBe("blocking");
+			expect(result.semantic).toBe("warning");
 			expect(result.diagnostics[0]?.tool).toBe("javac");
+			expect(result.diagnostics[0]?.semantic).toBe("warning");
 			expect(result.diagnostics[0]?.line).toBe(3);
 		} finally {
 			env.cleanup();

--- a/tests/clients/dispatch/runners/secondary-language-runners.test.ts
+++ b/tests/clients/dispatch/runners/secondary-language-runners.test.ts
@@ -134,6 +134,34 @@ describe("secondary language fallback runners", () => {
 		}
 	});
 
+	it("keeps context-free zig compiler diagnostics non-blocking", async () => {
+		const env = setupTestEnvironment("pi-lens-zig-contextless-");
+		try {
+			const filePath = path.join(env.tmpDir, "src", "main.zig");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(filePath, "pub fn main() void {}\n");
+			safeSpawnAsync.mockResolvedValue({
+				error: null,
+				status: 1,
+				stdout: "",
+				stderr: `${filePath}:2:1: error: unable to load module`,
+			});
+
+			const runner = (await import(
+				"../../../../clients/dispatch/runners/zig-check.js"
+			)).default;
+			const result = await runner.run(
+				createCtx("zig", filePath, env.tmpDir) as never,
+			);
+
+			expect(result.status).toBe("failed");
+			expect(result.semantic).toBe("warning");
+			expect(result.diagnostics[0]?.semantic).toBe("warning");
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("surfaces a blocking diagnostic when gleam exits non-zero without structured output", async () => {
 		const env = setupTestEnvironment("pi-lens-gleam-runner-");
 		try {
@@ -192,6 +220,34 @@ describe("secondary language fallback runners", () => {
 			expect(result.status).toBe("failed");
 			expect(result.semantic).toBe("blocking");
 			expect(result.diagnostics[0]?.tool).toBe("elixir-check");
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("keeps standalone elixirc diagnostics non-blocking", async () => {
+		const env = setupTestEnvironment("pi-lens-elixirc-contextless-");
+		try {
+			const filePath = path.join(env.tmpDir, "app.ex");
+			fs.writeFileSync(filePath, "defmodule App do\n");
+			safeSpawnAsync.mockResolvedValue({
+				error: null,
+				status: 1,
+				stdout: "",
+				stderr:
+					"** (CompileError) app.ex:1:1: module Dependency is not loaded",
+			});
+
+			const runner = (await import(
+				"../../../../clients/dispatch/runners/elixir-check.js"
+			)).default;
+			const result = await runner.run(
+				createCtx("elixir", filePath, env.tmpDir) as never,
+			);
+
+			expect(result.status).toBe("succeeded");
+			expect(result.semantic).toBe("warning");
+			expect(result.diagnostics[0]?.semantic).toBe("warning");
 		} finally {
 			env.cleanup();
 		}


### PR DESCRIPTION
## Outcome

Context-free compiler fallbacks still report useful errors, but they no longer claim blocking authority without the project inputs needed to prove it. A recovered clean Java LSP dispatch also replaces any javac findings already stored for that file.

Closes #1885.

## Demotion

- `javac` preserves compiler severity and failed status, but every standalone finding and runner result is advisory (`clients/dispatch/runners/javac.ts:38`). The existing Maven/Gradle descriptor gate remains unchanged.
- The family sweep found the same live blocking defect in `cpp-check`, `zig-check`, and direct `elixirc`. They now use warning semantics at `clients/dispatch/runners/cpp-check.ts:158`, `clients/dispatch/runners/zig-check.ts:37`, and `clients/dispatch/runners/elixir-check.ts:194`.
- Mix-backed Elixir compilation keeps blocking authority because it runs with project dependencies.

## Cache hygiene verdict

No production eviction change is needed. The per-edit pipeline passes the complete dispatch snapshot to `recordDiagnostics` (`clients/pipeline.ts:1423`). That function normalizes and commits a whole-file replacement (`clients/widget-state.ts:458`, `clients/widget-state.ts:500`, `clients/widget-state.ts:552`), so a later LSP success supersedes all earlier runner entries for the same file.

The dispatcher integration test reproduces a prior javac cache entry, runs an LSP-skipped window where the descriptor gate prevents javac, then recovers to an LSP-clean result. The final cache is empty (`tests/clients/dispatch/javac-dispatch-integration.test.ts:55`, `:83`, `:93`).

## Family sweep

| Member | Project context and blocking verdict | Disposition |
| --- | --- | --- |
| javac | Single file, no classpath/sourcepath; was blocking | Fixed here |
| cpp-check (clang/gcc/cl) | Single file, no compile database/include/build flags; was blocking | Fixed here |
| zig-check | `zig build-exe <file>` ignores build.zig module context; was blocking | Fixed here |
| elixir-check | `mix compile` is project-backed; direct `elixirc` is not | Fixed direct path; Mix already correct |
| php-lint | Single-file parser, but verdict is syntax-only and does not require project context | Already correct |
| phpstan | Requires PHPStan config before it can block | Already correct |
| dotnet-build | Requires and builds a solution/project target | Already correct |
| pyright / mypy | Pyright resolves from project cwd/environment; mypy requires project config | Already correct |
| go-vet / rust-clippy | Resolve package/module descriptors and run package-backed tools | Already correct |
| dart-analyze / detekt | Analyzer resolves package context; detekt requires config | Already correct |
| gleam-check | Runs project-wide `gleam check` from the project cwd | Already correct |
| cue-vet | Uses package-directory evaluation, with deliberate package-less single-file handling | Already correct |
| prisma-validate | Validates the complete schema file; its verdict does not require an external project graph | Already correct |
| spotbugs | Requires compiled classes and remains advisory | Already correct |
| tsc | No standalone tsc dispatch runner exists | Not applicable |

No sibling remains to file from this sweep.

## Verification

- `npm run build`
- `npm run lint`
- Javac, dispatcher, failure-taxonomy, session-state conformance: 9 files, 120 tests passed.
- Diagnostic-taxonomy wiring and changelog suites: 3 files, 26 tests passed.
- Javac mutation: restoring blocking semantics made 2 tests fail.
- Family mutation: restoring C/C++, Zig, and direct-elixirc blocking semantics made 3 tests fail.
- No full suite was run, as requested.

## Blast radius

The repository-required `module_report`/`read_symbol` tools were unavailable in this environment. Static import and dispatch-policy tracing shows these runners enter through the shared runner registry and their language groups. The changes only narrow semantic authority; compiler severity and project-backed paths remain intact. The cache change is test-only because the existing whole-file replacement seam already supplies the required behavior.

## Disclosure

This PR was implemented and reviewed with Codex under maintainer supervision.