### PR TITLE
fix(session): re-arm formatter which-latches at session_start (closes #1895)

### DIFF
--- a/.changelog/1895.md
+++ b/.changelog/1895.md
@@ -1,0 +1,1 @@
+- **Formatter PATH availability re-arms at session start (closes #1895)** — clear formatter `which` latches with the primary session reset so formatter binaries installed or removed between sessions are detected.

--- a/.changelog/1895.md
+++ b/.changelog/1895.md
@@ -1,1 +1,0 @@
-- **Formatter PATH availability re-arms at session start (closes #1895)** — clear formatter `which` latches with the primary session reset so formatter binaries installed or removed between sessions are detected.

--- a/.changelog/fix-1895-which-latch-rearm.md
+++ b/.changelog/fix-1895-which-latch-rearm.md
@@ -1,0 +1,8 @@
+---
+section: Fixed
+---
+
+- **Formatter PATH availability re-arms at session start (closes [#1895](https://github.com/apmantza/pi-lens/issues/1895))** —
+  formatter `which` latches now clear with the primary session reset, so a
+  formatter binary installed or removed between sessions is detected on the
+  next session instead of keeping the previous session's verdict.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,11 @@ Session-start lifecycle hooks must tolerate capability-shaped injected clients.
 Optional reset methods may be absent from test doubles or embedders and must not
 turn session initialization into a failure; concrete clients still reset state.
 
+Formatter PATH which-latches are session-scoped and must be re-armed in the
+primary `handleSessionStart` reset block beside dispatch availability. Their
+module-local state is not covered by the dispatch generation, and secondary
+session guards must continue to skip both resets. (#1895)
+
 Per-edit LSP dispatch preserves the touch's correlated `unconfirmedServerIds`
 through `RunnerResult` and runner latency assembly. The agent coverage notice
 renders the bounded scanner set before considering a successful primary result,

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -301,8 +301,16 @@ async function detectCandidate(
 	};
 }
 
-/** Drop the PATH verdicts, so a newly installed binary is visible at once. */
-export function resetWhichLatches(): void {
+/**
+ * Drop the PATH verdicts, so a newly installed binary is visible at once.
+ *
+ * Module-private on purpose. Clearing the latches alone does NOT re-arm
+ * formatter availability: `getFormattersForFile` answers from `detectionCache`
+ * before it ever probes PATH, so a caller that wants a genuine re-probe must
+ * drop both. `clearFormatterCache` is that pair, and it is the only reset a
+ * session boundary should call (#1895 review round).
+ */
+function resetWhichLatches(): void {
 	whichLatchByCommand.clear();
 	whichTransientCommands.clear();
 	cooldownRecordedForRetryAtMs.clear();
@@ -1727,6 +1735,16 @@ export async function getFormattersForFile(
 	return enabled;
 }
 
+/**
+ * Re-arm formatter availability: drop both the per-cwd selection cache and the
+ * PATH latches.
+ *
+ * #1895: this is the session-boundary reset. Both halves are required. The
+ * latches decide whether `which` runs at all, but `detectionCache` short-
+ * circuits ahead of them — a same-cwd lookup returns the previous verdict's
+ * formatter names without reaching a probe. Clearing only the latches
+ * therefore re-arms every directory EXCEPT the one the user is working in.
+ */
 export function clearFormatterCache(): void {
 	detectionCache.clear();
 	resetWhichLatches();

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -302,7 +302,7 @@ async function detectCandidate(
 }
 
 /** Drop the PATH verdicts, so a newly installed binary is visible at once. */
-function resetWhichLatches(): void {
+export function resetWhichLatches(): void {
 	whichLatchByCommand.clear();
 	whichTransientCommands.clear();
 	cooldownRecordedForRetryAtMs.clear();

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -49,7 +49,7 @@ import type { MetricsClient } from "./metrics-client.js";
 import type { OpengrepClient, OpengrepResult } from "./opengrep-client.js";
 import { resetManagedToolRefreshSession } from "./installer/managed-tool-refresh-session.js";
 import { _resetPackageManagerCache } from "./package-manager.js";
-import { resetWhichLatches } from "./formatters.js";
+import { clearFormatterCache } from "./formatters.js";
 import { isAtOrAboveHomeDir } from "./path-utils.js";
 import { isPrintMode } from "./print-mode.js";
 import {
@@ -2081,11 +2081,15 @@ export async function handleSessionStart(
 	// the tool for the rest of the process lifetime. Clear it here, same
 	// boundary as the other per-session caches on this line.
 	resetDispatchAvailabilityState();
-	// #1895: formatter PATH verdicts are session-scoped, but their which latches
-	// live in formatters.ts and are not covered by the dispatch generation.
-	// Re-arm them here so a formatter installed or removed between sessions is
-	// observed by the next session.
-	resetWhichLatches();
+	// #1895: formatter PATH verdicts are session-scoped, but they live in
+	// formatters.ts and are not covered by the dispatch generation. Re-arm them
+	// here so a formatter installed or removed between sessions is observed by
+	// the next session. `clearFormatterCache` drops the per-cwd selection cache
+	// as well as the which latches, which is what a real re-probe needs: the
+	// selection cache answers a same-cwd lookup before any probe runs, so
+	// clearing the latches alone would leave the stale verdict standing in the
+	// one directory the user is working in.
+	clearFormatterCache();
 	// #1535: same #1266 pattern, one caller earlier — the `gh auth token` latch
 	// zizmor's spawn reads is process-lived storage whose durability contract is
 	// per SESSION, not per process. Without this, a user who runs `gh auth

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -49,6 +49,7 @@ import type { MetricsClient } from "./metrics-client.js";
 import type { OpengrepClient, OpengrepResult } from "./opengrep-client.js";
 import { resetManagedToolRefreshSession } from "./installer/managed-tool-refresh-session.js";
 import { _resetPackageManagerCache } from "./package-manager.js";
+import { resetWhichLatches } from "./formatters.js";
 import { isAtOrAboveHomeDir } from "./path-utils.js";
 import { isPrintMode } from "./print-mode.js";
 import {
@@ -2080,6 +2081,11 @@ export async function handleSessionStart(
 	// the tool for the rest of the process lifetime. Clear it here, same
 	// boundary as the other per-session caches on this line.
 	resetDispatchAvailabilityState();
+	// #1895: formatter PATH verdicts are session-scoped, but their which latches
+	// live in formatters.ts and are not covered by the dispatch generation.
+	// Re-arm them here so a formatter installed or removed between sessions is
+	// observed by the next session.
+	resetWhichLatches();
 	// #1535: same #1266 pattern, one caller earlier — the `gh auth token` latch
 	// zizmor's spawn reads is process-lived storage whose durability contract is
 	// per SESSION, not per process. Without this, a user who runs `gh auth

--- a/tests/clients/runtime-session-dispatch-reset.test.ts
+++ b/tests/clients/runtime-session-dispatch-reset.test.ts
@@ -179,6 +179,50 @@ describe("dispatch availability suppression is reset at session start (#1266)", 
 		expect(rustfmtProbes()).toBeGreaterThan(afterFirst);
 	});
 
+	// #1895 review round: the case above uses a NEW cwd, so it never reaches the
+	// per-cwd detection cache. A session replacement in the SAME directory does.
+	// `getFormattersForFile` returns cached formatter NAMES from `detectionCache`
+	// and short-circuits before any `which` probe, so clearing only the which
+	// latches leaves the previous session's verdict in force for the one
+	// directory the user is actually working in. The session reset has to drop
+	// both.
+	it("re-probes a latched-missing formatter in the SAME cwd after handleSessionStart", async () => {
+		const { clearFormatterCache, getFormattersForFile } = await import(
+			"../../clients/formatters.js"
+		);
+		// Arrange only: the module registry is shared across tests in this file,
+		// so the preceding case leaves rustfmt latched. Start from a clean slate
+		// so the seeding step below genuinely probes.
+		clearFormatterCache();
+		const filePath = `${tmpDir}/lib.rs`;
+		const fs = await import("node:fs");
+		fs.writeFileSync(filePath, "fn main() {}\n");
+		const spawnMod = await import("../../clients/safe-spawn.js");
+		const spawnMock = vi.mocked(spawnMod.safeSpawnAsync);
+		const finder = process.platform === "win32" ? "where" : "which";
+		const rustfmtProbes = () =>
+			spawnMock.mock.calls.filter(
+				(call) =>
+					String(call[0]) === finder &&
+					(call[1] as string[] | undefined)?.[0] === "rustfmt",
+			).length;
+
+		// Seed the absent-formatter verdict, and confirm it is genuinely cached:
+		// a second lookup in the same cwd must not re-probe.
+		await getFormattersForFile(filePath, tmpDir);
+		const afterFirst = rustfmtProbes();
+		expect(afterFirst).toBeGreaterThan(0);
+		await getFormattersForFile(filePath, tmpDir);
+		expect(rustfmtProbes()).toBe(afterFirst);
+
+		await handleSessionStart(makeDeps(tmpDir));
+
+		// Same cwd, same file, no config-file edit — the next lookup must probe
+		// PATH again rather than replay the previous session's answer.
+		await getFormattersForFile(filePath, tmpDir);
+		expect(rustfmtProbes()).toBeGreaterThan(afterFirst);
+	});
+
 	// #1490: psscriptanalyzer's interpreter and module verdicts live in
 	// module-local latches, so `resetDispatchAvailabilityState`'s generation
 	// counter — the mechanism every other runner inherits — does not reach them.

--- a/tests/clients/runtime-session-dispatch-reset.test.ts
+++ b/tests/clients/runtime-session-dispatch-reset.test.ts
@@ -145,6 +145,40 @@ describe("dispatch availability suppression is reset at session start (#1266)", 
 		expect(ensureToolMock).toHaveBeenCalledTimes(2);
 	});
 
+	// #1895: formatter PATH latches are module-local and therefore are not
+	// advanced by resetDispatchAvailabilityState's generation counter. Drive
+	// the session reset seam, rather than calling resetWhichLatches directly.
+	it("re-probes a latched-missing formatter after handleSessionStart", async () => {
+		const { getFormattersForFile } = await import("../../clients/formatters.js");
+		const filePath = `${tmpDir}/lib.rs`;
+		const nextCwd = `${tmpDir}-next`;
+		const nextFilePath = `${nextCwd}/lib.rs`;
+		const fs = await import("node:fs");
+		fs.mkdirSync(nextCwd);
+		fs.writeFileSync(filePath, "fn main() {}\n");
+		fs.writeFileSync(nextFilePath, "fn main() {}\n");
+		const spawnMod = await import("../../clients/safe-spawn.js");
+		const spawnMock = vi.mocked(spawnMod.safeSpawnAsync);
+		const finder = process.platform === "win32" ? "where" : "which";
+		const rustfmtProbes = () =>
+			spawnMock.mock.calls.filter(
+				(call) =>
+					String(call[0]) === finder &&
+					(call[1] as string[] | undefined)?.[0] === "rustfmt",
+			).length;
+
+		await getFormattersForFile(filePath, tmpDir);
+		const afterFirst = rustfmtProbes();
+		expect(afterFirst).toBeGreaterThan(0);
+		await getFormattersForFile(filePath, tmpDir);
+		expect(rustfmtProbes()).toBe(afterFirst);
+
+		await handleSessionStart(makeDeps(tmpDir));
+
+		await getFormattersForFile(nextFilePath, nextCwd);
+		expect(rustfmtProbes()).toBeGreaterThan(afterFirst);
+	});
+
 	// #1490: psscriptanalyzer's interpreter and module verdicts live in
 	// module-local latches, so `resetDispatchAvailabilityState`'s generation
 	// counter — the mechanism every other runner inherits — does not reach them.

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -500,9 +500,18 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 			"#1810: the cache maps (biome binary path, rule name) to that rule's real fix tier, read live from `biome explain <rule>`. That answer is a static property of the running binary — it cannot change without a different biome install, which is itself a different cache key — so there is nothing for a session boundary to invalidate. No probe: arming it for real requires spawning the actual biome binary, which this generic registry sweep does not do; `tests/clients/dispatch/runners/biome-check-runner.test.ts`'s dedicated cache/reset tests cover the re-arm behavior with a mocked spawn instead.",
 	},
 	{
-		id: "formatters:runtimeState",
+		id: "formatters:whichLatches",
 		module: "formatters.ts",
 		state: "whichLatchByCommand, whichTransientCommands, cooldownRecordedForRetryAtMs",
+		policy: "session_start",
+		resetName: "resetWhichLatches",
+		reason:
+			"#1895: formatter PATH availability is session-scoped, but these module-local latches are not covered by the dispatch availability generation. A formatter installed or removed between sessions must be re-probed.",
+	},
+	{
+		id: "formatters:runtimeState",
+		module: "formatters.ts",
+		state: "detectionCache",
 		policy: "turn_end",
 		resetName: "clearFormatterRuntimeState",
 		reason:

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -502,11 +502,11 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 	{
 		id: "formatters:whichLatches",
 		module: "formatters.ts",
-		state: "whichLatchByCommand, whichTransientCommands, cooldownRecordedForRetryAtMs",
+		state: "whichLatchByCommand, whichTransientCommands, cooldownRecordedForRetryAtMs (cleared together with detectionCache)",
 		policy: "session_start",
-		resetName: "resetWhichLatches",
+		resetName: "clearFormatterCache",
 		reason:
-			"#1895: formatter PATH availability is session-scoped, but these module-local latches are not covered by the dispatch availability generation. A formatter installed or removed between sessions must be re-probed.",
+			"#1895: formatter PATH availability is session-scoped, but these module-local latches are not covered by the dispatch availability generation. A formatter installed or removed between sessions must be re-probed. The reset is `clearFormatterCache`, not the latch clear alone: `getFormattersForFile` answers a same-cwd lookup from `detectionCache` before it reaches a `which` probe, so dropping the latches without the selection cache re-arms every directory except the working one (review round on PR #1896).",
 	},
 	{
 		id: "formatters:runtimeState",


### PR DESCRIPTION
## Outcome

Formatter PATH availability now re-arms on the primary `session_start` path. A formatter installed or removed between sessions is re-probed instead of inheriting a stale `which` verdict.

Re-arming takes both halves of the formatter state. The `which` latches decide whether a PATH probe runs at all, but `getFormattersForFile` answers a same-cwd lookup from the per-cwd `detectionCache` and returns the previous verdict's formatter names before it reaches a probe (`clients/formatters.ts:1552`). Clearing the latches alone therefore re-armed every directory except the one the user is working in. The session boundary now calls the existing `clearFormatterCache`, which drops the selection cache and the latches together.

## Changes

- Call `clearFormatterCache()` beside `resetDispatchAvailabilityState` in `handleSessionStart`. It already pairs `detectionCache.clear()` with `resetWhichLatches()`, so the session boundary has one reset export rather than two half-resets, and `resetWhichLatches` stays module-private.
- Keep the reset behind the existing primary-session guard; concurrent secondary sessions do not reset shared state.
- Add two real `handleSessionStart` regression tests — a new-cwd case and a same-cwd session replacement — and register the latch store as `session_start` state naming the reset that is actually wired.
- Add `.changelog/fix-1895-which-latch-rearm.md` and update `AGENTS.md` with the lifecycle invariant.

## Class audit

| Store | Verdict | Evidence |
| --- | --- | --- |
| Formatter `whichLatchByCommand` / transient sets and `detectionCache` | Fixed here | `clearFormatterCache()` in `handleSessionStart` (`clients/runtime-session.ts`, beside `resetDispatchAvailabilityState`); implementation in `clients/formatters.ts`; registry entry `formatters:whichLatches` in `tests/support/session-state-registry.ts` |
| Package-manager `availabilityLatches` | Already re-arms | `_resetPackageManagerCache` in `handleSessionStart`; implementation `clients/package-manager.ts:244` |
| Direct-LSP `directLspCommandUnavailableUntil` | Missing production session reset; follow-up required | Store and TTL are in `clients/lsp/server.ts:331-380`; no session-start reset is present. Expiry is time-based, not a session boundary. |
| ESLint, Rust-Clippy, and other cwd-cached runner maps | Already re-arm through the shared generation | `resetDispatchAvailabilityState` in `handleSessionStart`; generation reset implementation at `clients/dispatch/runners/utils/runner-helpers.ts:776` |
| PSScriptAnalyzer latches | Already re-arms explicitly | `resetPsScriptAnalyzerAvailability` in `handleSessionStart`; implementation at `clients/dispatch/runners/psscriptanalyzer.ts:143` |
| Toolchain availability | Process/client lifetime by current design; follow-up audit required if session replacement must invalidate positive paths | Per-client latch and `toolPath` are created by `createToolchainAvailability` at `clients/dispatch/runners/utils/toolchain-availability.ts:53`; no shared session reset seam exists. |
| Installer `resolvedPathCache` | Missing production session reset; follow-up required | Cache is documented as session-lifetime at `clients/installer/index.ts:1566`; clearing is currently only in the test helper at `clients/installer/index.ts:1941`. Fully qualified cached paths are revalidated, but bare command cache entries are not. |

The two missing stores and the toolchain lifecycle question are intentionally not represented as fixed acceptance criteria for this PR. They should be filed separately with dedicated re-arm tests.

## Verification

- `npm run build`, `npm run lint` — both clean.
- Suites run: `runtime-session-dispatch-reset`, `session-state-conformance`, `formatters`, `formatters-which-latch`, `formatter-degraded-selection`, `formatter-probe-commands`.
- Baseline on `master`: **244 tests passed**. On this branch: **247 tests passed**. The +3 is the two new `handleSessionStart` cases plus one conformance case, because this PR splits the single `formatters:runtimeState` registry row into `formatters:whichLatches` (session_start) and `formatters:runtimeState` (turn_end), and the conformance suite is parametrized per row. An earlier body reported 251; that figure is not reproducible and 244 → 247 replaces it.
- Red proof, whole file running against the pre-fix source, which is this fix with the `detectionCache` half removed:

```
 × re-probes a latched-missing formatter in the SAME cwd after handleSessionStart
AssertionError: expected 1 to be greater than 1
 ❯ tests/clients/runtime-session-dispatch-reset.test.ts:223:27
      Tests  1 failed | 5 passed (6)
```

- The earlier new-cwd case reds the same way when `resetWhichLatches()` is deleted.
- No full suite run; CI is authoritative for it.

## Blast radius

`clearFormatterCache()` runs once per session start. `detectionCache` is already cleared every turn through `resetFormatService()` → `clearFormatterRuntimeState()`, so clearing it again at the session boundary adds no work on any hot path. The cost of a session start is one extra `which` probe per formatter the next save actually needs.

## Disclosure

This PR was prepared with Codex. A later review round found the re-arm incomplete and the fix above closes it; that round was prepared with Claude.
