### PR TITLE
Fix workspace refresh reach for monorepo caches (closes #1707)

### DIFF
--- a/.changelog/1707.md
+++ b/.changelog/1707.md
@@ -1,0 +1,7 @@
+---
+section: Fixed
+---
+
+- **Reach never-swept monorepo caches on workspace refresh ([closes #1707](https://github.com/apmantza/pi-lens/issues/1707))** —
+  a nested language-server root now clears its enclosing workspace-diagnostics
+  cache through the bounded session workspace-root chain.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,13 @@ of parsing partial output as a clean empty result. Sampler timeouts inject the
 reaper's tree-kill-and-verify hook and settle only after its fate is known.
 (#1863, #1864)
 
+**Workspace refresh walks the bounded ancestor cache chain.** A language server
+root can be a nested monorepo member while workspace diagnostics persist under
+the enclosing sweep root. `workspace/diagnostic/refresh` clears the client
+root and each ancestor through the session cwd, so a never-swept member cannot
+leave its prior workspace cache alive; it never walks above that ceiling.
+(#1707)
+
 ## Issue and PR design contract
 
 - **Design the state space before coding.** For stateful, ordered, resource-mutating, or security-sensitive work, write the invariants, supported transitions, explicit deferrals, and a cross-product test matrix before implementation. Examples are not enough: cover operation order, preview/apply, validation/normalization/execution seams, failure atomicity, observability bounds, and OS/path/encoding axes. If adversarial review finds repeated cross-product defects, stop patching one symptom at a time and return to the model.

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -59,7 +59,7 @@ import { getStrategy } from "./wait-policy/index.js";
 import { WatchedFilesQueue } from "./watch-queue.js";
 import {
 	clearAllWorkspaceDiagnosticsCaches,
-	clearWorkspaceDiagnosticsCache,
+	clearWorkspaceDiagnosticsCacheAtAndAbove,
 } from "./workspace-diagnostics-cache.js";
 
 // Opt-in publishDiagnostics trace (PILENS_PUB_DEBUG=1) — read once, negligible
@@ -2292,7 +2292,7 @@ export function setupIncomingHandlers(
 		// `state.root` — that residual gap is tracked in #1707, not silently
 		// claimed as solved (see `clearAllWorkspaceDiagnosticsCaches`'s doc
 		// comment for the full shape).
-		clearWorkspaceDiagnosticsCache(state.root);
+		clearWorkspaceDiagnosticsCacheAtAndAbove(state.root);
 		// #1669 review F3: a server-initiated "everything may be stale" signal
 		// must drop the SAME per-document state a normal resync already drops
 		// via `clearDiagnosticsForPath` (pullResultIds, pushDiagnostics,

--- a/clients/lsp/workspace-diagnostics-cache.ts
+++ b/clients/lsp/workspace-diagnostics-cache.ts
@@ -156,6 +156,39 @@ export function clearAllWorkspaceDiagnosticsCaches(): void {
 	}
 }
 
+/**
+ * Clear the client root and every ancestor up to the session workspace root.
+ * A language server may identify a nested monorepo member while the sweep
+ * stores that member's files in the enclosing workspace cache. The refresh
+ * request knows the former, so walk only the bounded ancestor chain rather
+ * than writing to unrelated filesystem roots.
+ */
+export function clearWorkspaceDiagnosticsCacheAtAndAbove(
+	cwd: string,
+	ceiling = process.cwd(),
+): void {
+	const root = path.resolve(cwd);
+	const workspaceRoot = path.resolve(ceiling);
+	clearWorkspaceDiagnosticsCache(root);
+	const relative = path.relative(workspaceRoot, root);
+	if (
+		relative.startsWith(".." + path.sep) ||
+		relative === ".." ||
+		path.isAbsolute(relative)
+	) {
+		return;
+	}
+	if (normalizeMapKey(root) === normalizeMapKey(workspaceRoot)) return;
+	let ancestor = path.dirname(root);
+	while (true) {
+		clearWorkspaceDiagnosticsCache(ancestor);
+		if (normalizeMapKey(ancestor) === normalizeMapKey(workspaceRoot)) return;
+		const parent = path.dirname(ancestor);
+		if (parent === ancestor) return;
+		ancestor = parent;
+	}
+}
+
 // #1669 (review round): per-cwd epoch, mirroring
 // `clients/review-graph/builder.ts`'s workspace-cache epoch shape — AGENTS.md's
 // canonical pattern for "a durable commit followed by an out-of-guard mirror

--- a/tests/clients/lsp/refresh-and-sync-kind.test.ts
+++ b/tests/clients/lsp/refresh-and-sync-kind.test.ts
@@ -836,6 +836,45 @@ describe("workspace/diagnostic/refresh reaches an unregistered cwd's on-disk cac
 	});
 });
 
+describe("workspace/diagnostic/refresh reaches a never-swept monorepo cache (#1707)", () => {
+	it("clears the sweep-root cache when the client root is a nested member", async () => {
+		const workspaceRoot = fs.mkdtempSync(
+			path.join(process.cwd(), "pi-lens-refresh-1707-"),
+		);
+		const memberRoot = path.join(workspaceRoot, "packages", "member");
+		fs.mkdirSync(memberRoot, { recursive: true });
+		try {
+			const filePath = path.join(workspaceRoot, "packages", "member", "stale.ts");
+			const { saveWorkspaceDiagnosticsCache, WORKSPACE_DIAGNOSTICS_CACHE_VERSION } =
+				await import("../../../clients/lsp/workspace-diagnostics-cache.js");
+			saveWorkspaceDiagnosticsCache(workspaceRoot, {
+				version: WORKSPACE_DIAGNOSTICS_CACHE_VERSION,
+				entries: {
+					[normalizeMapKey(filePath)]: {
+						diagnostics: [{ message: "stale" } as any],
+						count: 1,
+						mtimeMs: 1,
+						scannedAt: Date.now(),
+						scopeKey: "all|",
+					},
+				},
+			});
+
+			const state = createMockState({ root: memberRoot });
+			setupIncomingHandlers(state, {});
+			const calls = vi.mocked(state.connection.onRequest).mock.calls as unknown as Array<
+				[string, (...args: unknown[]) => unknown]
+			>;
+			const handler = calls.find((c) => c[0] === "workspace/diagnostic/refresh")?.[1];
+			await handler!();
+
+			expect(Object.keys(loadWorkspaceDiagnosticsCache(workspaceRoot)?.entries ?? {})).toHaveLength(0);
+		} finally {
+			fs.rmSync(workspaceRoot, { recursive: true, force: true });
+		}
+	});
+});
+
 describe("createWorkspaceDiagnosticsCacheContext.lookup() honors a mid-sweep clear (#1669 review N4)", () => {
 	it("stops serving pre-refresh entries for the REST of an in-flight sweep, not only at persist() time", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-refresh-n4-"));


### PR DESCRIPTION
## Outcome\n\nCloses #1707. workspace/diagnostic/refresh now clears a nested language-server root and each bounded ancestor through the session workspace root. A never-swept monorepo member can no longer leave its enclosing persisted diagnostics cache untouched.\n\n## Why\n\nThe refresh handler previously cleared registered sweep roots and state.root. A nested member's cache can live at an enclosing sweep root that this process had never registered, so refresh left stale entries available to the later first sweep.\n\n## Invariants\n\n- Clear the client root and only ancestors within the session workspace-root ceiling.\n- Preserve the existing registered-root and direct-root clears.\n- Do not walk above the session cwd or write unrelated cache files.\n- Refresh remains synchronous before its protocol reply.\n\n## Verification\n\n- Red-first: the new never-swept monorepo fixture fails on the pre-fix implementation because the enclosing cache retains one entry.\n- Mutation proof: changing the helper call to use state.root as its ceiling fails the same regression.\n- 
pm run build: passed before Vitest.\n- Targeted plus governance/conformance: 4 files, 187 tests passed.\n- 
pm run lint: passed.\n- 
pm run changelog:check: passed, 192 entries validated.\n- Full suite: delegated to CI.\n\n## Scope\n\nThis change extends the existing workspace-diagnostics cache refresh seam. It does not alter language-root discovery or membership walking; it bounds invalidation using the already resolved client root and session cwd.\n\nGenerated with Codex assistance.