### PR TITLE
fix: Gate LSP navigation capabilities (closes #1826)

### DIFF
--- a/.changelog/1826.md
+++ b/.changelog/1826.md
@@ -1,0 +1,9 @@
+---
+section: Fixed
+---
+
+- **LSP navigation verifies capabilities at the client boundary ([closes #1826](https://github.com/apmantza/pi-lens/issues/1826))** —
+  definition, hover, rename, code actions, and the remaining file-scoped
+  navigation methods now reject unsupported requests before dispatch. This
+  second check preserves the tool-layer gate and distinguishes unsupported
+  servers from supporting servers that return no results.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,13 @@ aggregated operation support. Capability snapshot client ids are capped, with
 the full count preserved. Never replace this with shared last-client state;
 concurrent navigation requests must not overwrite each other's attribution.
 (#1854)
+
+File-scoped LSP navigation is capability-gated twice: the tool layer rejects
+unsupported requests before opening a file, and every `LSPService` navigation
+chokepoint re-checks the resolved client's `getOperationSupport()` snapshot.
+An unsupported client-layer request throws the `__UNSUPPORTED__` discriminator;
+do not collapse it into the clean empty result returned by a supporting server.
+(#1826)
 Bounded LSP warm touches preserve the spawn coordinator's lifecycle evidence:
 an empty ready-client set reports `spawn_in_flight_budget_elapsed` while a
 matching primary single-flight spawn remains pending, and

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -5638,6 +5638,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return [];
+		if (!spawned.client.getOperationSupport().definition) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for definition",
+			);
+		}
 		return spawned.client.definition(filePath, line, character);
 	}
 
@@ -5650,6 +5655,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return [];
+		if (!spawned.client.getOperationSupport().typeDefinition) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for typeDefinition",
+			);
+		}
 		return spawned.client.typeDefinition(filePath, line, character);
 	}
 
@@ -5662,6 +5672,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return [];
+		if (!spawned.client.getOperationSupport().declaration) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for declaration",
+			);
+		}
 		return spawned.client.declaration(filePath, line, character);
 	}
 
@@ -5679,6 +5694,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return [];
+		if (!spawned.client.getOperationSupport().references) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for references",
+			);
+		}
 		return spawned.client.references(
 			filePath,
 			line,
@@ -5696,6 +5716,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return null;
+		if (!spawned.client.getOperationSupport().hover) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for hover",
+			);
+		}
 		return spawned.client.hover(filePath, line, character);
 	}
 
@@ -5708,6 +5733,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return null;
+		if (!spawned.client.getOperationSupport().signatureHelp) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for signatureHelp",
+			);
+		}
 		return spawned.client.signatureHelp(filePath, line, character);
 	}
 
@@ -5720,6 +5750,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return [];
+		if (!spawned.client.getOperationSupport().documentSymbol) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for documentSymbol",
+			);
+		}
 		return spawned.client.documentSymbol(filePath);
 	}
 
@@ -6063,6 +6098,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return [];
+		if (!spawned.client.getOperationSupport().codeAction) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for codeAction",
+			);
+		}
 		return spawned.client.codeAction(
 			filePath,
 			line,
@@ -6086,6 +6126,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return null;
+		if (!spawned.client.getOperationSupport().rename) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for rename",
+			);
+		}
 		return spawned.client.rename(filePath, line, character, newName);
 	}
 
@@ -6398,6 +6443,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return [];
+		if (!spawned.client.getOperationSupport().implementation) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for implementation",
+			);
+		}
 		return spawned.client.implementation(filePath, line, character);
 	}
 
@@ -6414,6 +6464,11 @@ export class LSPService {
 			NAV_CLIENT_WAIT_TIMEOUT_MS,
 		);
 		if (!spawned) return [];
+		if (!spawned.client.getOperationSupport().callHierarchy) {
+			throw new Error(
+				"__UNSUPPORTED__ Active LSP server does not advertise support for prepareCallHierarchy",
+			);
+		}
 		return spawned.client.prepareCallHierarchy(filePath, line, character);
 	}
 

--- a/tests/clients/lsp/navigation-capability-gates.test.ts
+++ b/tests/clients/lsp/navigation-capability-gates.test.ts
@@ -1,0 +1,152 @@
+/**
+ * #1826: every file-scoped navigation chokepoint must re-check the capability
+ * advertised by the resolved client. The tool layer normally performs the
+ * first check; these direct service calls bypass it to prove the second layer.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { LSPOperationSupport } from "../../../clients/lsp/client.js";
+import { LSPService } from "../../../clients/lsp/index.js";
+
+const FILE = "C:/repo/main.ts";
+const EMPTY_SUPPORT: LSPOperationSupport = {
+	definition: false,
+	typeDefinition: false,
+	declaration: false,
+	references: false,
+	hover: false,
+	signatureHelp: false,
+	documentSymbol: false,
+	workspaceSymbol: false,
+	codeAction: false,
+	rename: false,
+	implementation: false,
+	callHierarchy: false,
+};
+
+type Operation = Exclude<keyof LSPOperationSupport, "workspaceSymbol">;
+
+const CASES: ReadonlyArray<{
+	operation: Operation | "prepareCallHierarchy";
+	capability: Operation;
+	args: readonly unknown[];
+	empty: unknown;
+}> = [
+	{
+		operation: "definition",
+		capability: "definition",
+		args: [FILE, 0, 1],
+		empty: [],
+	},
+	{
+		operation: "typeDefinition",
+		capability: "typeDefinition",
+		args: [FILE, 0, 1],
+		empty: [],
+	},
+	{
+		operation: "declaration",
+		capability: "declaration",
+		args: [FILE, 0, 1],
+		empty: [],
+	},
+	{
+		operation: "references",
+		capability: "references",
+		args: [FILE, 0, 1, true],
+		empty: [],
+	},
+	{ operation: "hover", capability: "hover", args: [FILE, 0, 1], empty: null },
+	{
+		operation: "signatureHelp",
+		capability: "signatureHelp",
+		args: [FILE, 0, 1],
+		empty: null,
+	},
+	{
+		operation: "documentSymbol",
+		capability: "documentSymbol",
+		args: [FILE],
+		empty: [],
+	},
+	{
+		operation: "codeAction",
+		capability: "codeAction",
+		args: [FILE, 0, 1, 0, 2],
+		empty: [],
+	},
+	{
+		operation: "rename",
+		capability: "rename",
+		args: [FILE, 0, 1, "next"],
+		empty: null,
+	},
+	{
+		operation: "implementation",
+		capability: "implementation",
+		args: [FILE, 0, 1],
+		empty: [],
+	},
+	{
+		operation: "prepareCallHierarchy",
+		capability: "callHierarchy",
+		args: [FILE, 0, 1],
+		empty: [],
+	},
+];
+
+function harness(capability: Operation, supported: boolean, empty: unknown) {
+	const dispatch = vi.fn().mockResolvedValue(empty);
+	const client = {
+		getOperationSupport: () => ({
+			...EMPTY_SUPPORT,
+			[capability]: supported,
+		}),
+		[capability === "callHierarchy" ? "prepareCallHierarchy" : capability]:
+			dispatch,
+	};
+	const service = new LSPService();
+	service.getClientForFile = vi.fn().mockResolvedValue({ client, info: {} });
+	return { service, dispatch };
+}
+
+describe.each(CASES)(
+	"LSPService $operation capability gate (#1826)",
+	(testCase) => {
+		it("returns the unsupported discriminator without dispatching", async () => {
+			const { service, dispatch } = harness(
+				testCase.capability,
+				false,
+				testCase.empty,
+			);
+			const invoke = (
+				service as unknown as Record<
+					string,
+					(...args: unknown[]) => Promise<unknown>
+				>
+			)[testCase.operation].bind(service);
+
+			await expect(invoke(...testCase.args)).rejects.toThrow(
+				`__UNSUPPORTED__ Active LSP server does not advertise support for ${testCase.operation}`,
+			);
+			expect(dispatch).not.toHaveBeenCalled();
+		});
+
+		it("preserves a supported server's clean empty result", async () => {
+			const { service, dispatch } = harness(
+				testCase.capability,
+				true,
+				testCase.empty,
+			);
+			const invoke = (
+				service as unknown as Record<
+					string,
+					(...args: unknown[]) => Promise<unknown>
+				>
+			)[testCase.operation].bind(service);
+
+			await expect(invoke(...testCase.args)).resolves.toEqual(testCase.empty);
+			expect(dispatch).toHaveBeenCalledWith(...testCase.args);
+		});
+	},
+);

--- a/tests/tools/lsp-navigation.test.ts
+++ b/tests/tools/lsp-navigation.test.ts
@@ -611,7 +611,9 @@ describe("lsp_navigation tool", () => {
 	// pair proves both directions: unsupported reports the discriminator,
 	// and a genuinely supporting server with zero callers still reports a
 	// clean empty (not a false "unsupported").
-	it("reports the unsupported discriminator when the server never advertised callHierarchyProvider", async () => {
+	it.each(["incomingCalls", "outgoingCalls"] as const)(
+		"reports the unsupported discriminator for %s when the server never advertised callHierarchyProvider",
+		async (operation) => {
 		const tool = createLspNavigationTool((flag) => flag === "lens-lsp");
 		(
 			mocked.service as { getOperationSupport: ReturnType<typeof vi.fn> }
@@ -629,9 +631,9 @@ describe("lsp_navigation tool", () => {
 			implementation: false,
 			callHierarchy: false,
 		});
-		const incomingCallsSpy = (
-			mocked.service as { incomingCalls: ReturnType<typeof vi.fn> }
-		).incomingCalls;
+		const operationSpy = (
+			mocked.service as Record<typeof operation, ReturnType<typeof vi.fn>>
+		)[operation];
 		const callHierarchyItem = {
 			name: "foo",
 			kind: 12,
@@ -647,22 +649,25 @@ describe("lsp_navigation tool", () => {
 		};
 
 		const result = await tool.execute(
-			"unsupported-incoming",
-			{ operation: "incomingCalls", callHierarchyItem },
+			`unsupported-${operation}`,
+			{ operation, callHierarchyItem },
 			new AbortController().signal,
 			null,
 			{ cwd: "." },
 		);
 
-		expect(incomingCallsSpy).not.toHaveBeenCalled();
+		expect(operationSpy).not.toHaveBeenCalled();
 		expect(result.isError).toBe(true);
 		expect(result.details?.emptyReason).toBe("unsupported");
 		expect(String(result.content[0]?.text)).toContain(
-			"does not advertise support for incomingCalls",
+			`does not advertise support for ${operation}`,
 		);
-	});
+		},
+	);
 
-	it("reports a clean empty (not unsupported) when a supporting server finds zero callers", async () => {
+	it.each(["incomingCalls", "outgoingCalls"] as const)(
+		"reports a clean empty (not unsupported) when %s finds zero calls",
+		async (operation) => {
 		const tool = createLspNavigationTool((flag) => flag === "lens-lsp");
 		(
 			mocked.service as { getOperationSupport: ReturnType<typeof vi.fn> }
@@ -680,9 +685,9 @@ describe("lsp_navigation tool", () => {
 			implementation: false,
 			callHierarchy: true,
 		});
-		(
-			mocked.service as { outgoingCalls: ReturnType<typeof vi.fn> }
-		).outgoingCalls = vi.fn().mockResolvedValue([]);
+		(mocked.service as Record<typeof operation, ReturnType<typeof vi.fn>>)[
+			operation
+		] = vi.fn().mockResolvedValue([]);
 		const callHierarchyItem = {
 			name: "leaf",
 			kind: 12,
@@ -698,20 +703,22 @@ describe("lsp_navigation tool", () => {
 		};
 
 		const result = await tool.execute(
-			"supported-empty-outgoing",
-			{ operation: "outgoingCalls", callHierarchyItem },
+			`supported-empty-${operation}`,
+			{ operation, callHierarchyItem },
 			new AbortController().signal,
 			null,
 			{ cwd: "." },
 		);
 
 		expect(
-			(mocked.service as { outgoingCalls: ReturnType<typeof vi.fn> })
-				.outgoingCalls,
+			(mocked.service as Record<typeof operation, ReturnType<typeof vi.fn>>)[
+				operation
+			],
 		).toHaveBeenCalledWith(callHierarchyItem);
 		expect(result.isError).toBeUndefined();
 		expect(result.details?.emptyReason).toBe("no-call-hierarchy-results");
-	});
+		},
+	);
 
 	it("opens scoped file before workspaceSymbol query", async () => {
 		const tool = createLspNavigationTool((flag) => flag === "lens-lsp");


### PR DESCRIPTION
## Outcome

Adds defense-in-depth capability checks at every file-scoped LSP navigation service chokepoint named by #1826. Unsupported clients now raise the existing `__UNSUPPORTED__` discriminator before dispatch, while supporting clients can still return a clean empty result.

This is not a live user-facing bug fix. The tool layer already gates all 11 operations in `tools/lsp-navigation.ts`; this PR adds the second check at the client boundary.

Closes #1826.

## Population sweep

| Operation | Client-layer state | Capability | Reason |
| --- | --- | --- | --- |
| `definition` | gated at client | `definition` | Added in this PR |
| `typeDefinition` | gated at client | `typeDefinition` | Added in this PR |
| `declaration` | gated at client | `declaration` | Added in this PR |
| `references` | gated at client | `references` | Added in this PR |
| `hover` | gated at client | `hover` | Added in this PR |
| `signatureHelp` | gated at client | `signatureHelp` | Added in this PR |
| `documentSymbol` | gated at client | `documentSymbol` | Added in this PR; some callers already gated it |
| `codeAction` | gated at client | `codeAction` | Added in this PR |
| `rename` | gated at client | `rename` | Added in this PR |
| `implementation` | gated at client | `implementation` | Added in this PR |
| `prepareCallHierarchy` | gated at client | `callHierarchy` | Added in this PR; the protocol shares `callHierarchyProvider` |
| `workspaceSymbol` | already had it | `workspaceSymbol` | Existing #1789/#1851 file and workspace routing |
| `incomingCalls` | already had it | `callHierarchy` | Existing #1803 gate |
| `outgoingCalls` | already had it | `callHierarchy` | Existing #1803 gate |
| `executeCommand` | not applicable | advertised command allowlist | Uses command advertisement, not `LSPOperationSupport` |

The #1827 non-blocking test nit was still present. The tool-layer unsupported and supported-empty checks now run for both `incomingCalls` and `outgoingCalls`.

## Verification

- `npm run build`
- Navigation, operation support, workspace attribution, call hierarchy, workspace symbol, #1851 aggregation, and session-state conformance: 7 files, 139 tests passed
- `npm run changelog:check`: 192 entries validated
- Full suite intentionally not run, as requested in #1826 implementation scope

## Mutation proofs

Each operation's client gate was independently replaced with `false && !support`. Its own unsupported test failed because the promise resolved to the underlying empty value instead of rejecting. Each run produced exactly one failed test; the supported-empty control remained green.

| Operation | Mutation result |
| --- | --- |
| `definition` | red, 1 failed |
| `typeDefinition` | red, 1 failed |
| `declaration` | red, 1 failed |
| `references` | red, 1 failed |
| `hover` | red, 1 failed |
| `signatureHelp` | red, 1 failed |
| `documentSymbol` | red, 1 failed |
| `codeAction` | red, 1 failed |
| `rename` | red, 1 failed |
| `implementation` | red, 1 failed |
| `prepareCallHierarchy` | red, 1 failed |

## AI disclosure

Implemented and tested with Codex. The maintainer supervised the work and requested the scope, branch, verification matrix, mutation proofs, and PR content.