### PR TITLE
fix(lsp): Preserve per-server sweep answers (refs #1549)

### DIFF
--- a/.changelog/fix-1549-cascade-per-server-verdict.md
+++ b/.changelog/fix-1549-cascade-per-server-verdict.md
@@ -1,7 +1,9 @@
 ---
-type: fix
+section: Fixed
 ---
 
-Keep workspace-sweep diagnostics from answering language servers when an
-auxiliary scanner misses its deadline. The result now names only the uncovered
-scanner lanes and avoids caching or reconciling the partially covered snapshot.
+- **A workspace sweep no longer speaks for a scanner that missed its deadline (refs [#1549](https://github.com/apmantza/pi-lens/issues/1549))** —
+  when an auxiliary scanner misses the sweep deadline, the result now names the
+  uncovered lanes instead of reporting the file as fully answered. A partially
+  covered snapshot is never cached and never reconciled into the widget, so a
+  later read re-asks the scanner that stayed silent.

--- a/.changelog/fix-1549-cascade-per-server-verdict.md
+++ b/.changelog/fix-1549-cascade-per-server-verdict.md
@@ -1,0 +1,7 @@
+---
+type: fix
+---
+
+Keep workspace-sweep diagnostics from answering language servers when an
+auxiliary scanner misses its deadline. The result now names only the uncovered
+scanner lanes and avoids caching or reconciling the partially covered snapshot.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ aggregated operation support. Capability snapshot client ids are capped, with
 the full count preserved. Never replace this with shared last-client state;
 concurrent navigation requests must not overwrite each other's attribution.
 (#1854)
+
+Workspace-diagnostics per-file sweep verdicts preserve per-server evidence. A
+primary answer remains deliverable when an auxiliary is silent or cut off; the
+result carries that lane in `unconfirmedServerIds` and stays ineligible for the
+fully-covered workspace cache and footer replacement. Never reconstruct the gap
+from a touch-wide timeout: consume `touchFile`'s frozen coverage set. (#1549)
 Bounded LSP warm touches preserve the spawn coordinator's lifecycle evidence:
 an empty ready-client set reports `spawn_in_flight_budget_elapsed` while a
 matching primary single-flight spawn remains pending, and

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -7530,9 +7530,13 @@ export class LSPService {
 		const partiallyCoveredFiles = results.filter(
 			(result) => (result.unconfirmedServerIds?.length ?? 0) > 0,
 		).length;
+		// Code-unit comparator (#1883): this list ships as the
+		// `unconfirmedServerIds` field on the `lsp_workspace_diagnostics` record,
+		// so its order must be deterministic across locales — localeCompare is
+		// deliberately avoided.
 		const unconfirmedServerIds = [
 			...new Set(results.flatMap((result) => result.unconfirmedServerIds ?? [])),
-		].sort();
+		].sort((a, b) => Number(a > b) - Number(a < b));
 		logLatency({
 			type: "phase",
 			phase: "lsp_workspace_diagnostics",

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -658,9 +658,9 @@ export interface LSPTouchFileOptions {
  *   notify write or the diagnostics wait itself timed out. Also used for a
  *   group skipped after a failed pre-sweep server warm-up (#744) — the
  *   check was never even attempted, which is inconclusive, not a timeout.
- * - `coverage_gap` — an auxiliary scanner never reported for this touch
- *   (breaker-open, deferred resync, or a silent/cut-off wait — see
- *   `touchCoverageGap`).
+ * - `coverage_gap` — legacy/downstream classification for an auxiliary
+ *   scanner gap. New sweep results carry the lane ids in
+ *   `unconfirmedServerIds` without setting the file-wide `timedOut` verdict.
  * - `service_destroyed` — the LSP service was torn down (`resetLSPService`)
  *   while this sweep was still in flight; the remainder of the sweep never
  *   even attempted a language-server round trip for this file.
@@ -687,15 +687,17 @@ export interface LSPWorkspaceDiagnosticResult {
 	count: number;
 	error?: string;
 	/**
-	 * True when this file's per-file check was NOT confirmed — either
+	 * True when this file's primary per-file check was NOT confirmed — either
 	 * `touchFile`'s own `.inconclusive` flag was set (#570: the notify write
 	 * or the diagnostics wait itself timed out), the OUTER `perFileMs`
 	 * `withDeadline` wrapper never got a result back at all, or the check
 	 * threw. `diagnostics` is a default-empty placeholder in every one of
 	 * those cases, not a confirmed result, and must not be treated as
 	 * "confirmed clean" by any caller reconciling this into cached state
-	 * (#571). Absent/false means the per-file check completed within budget
-	 * AND was confirmed; workspace-pull results (`tryWorkspacePull`) are
+	 * (#571). An auxiliary-only gap is represented separately by
+	 * `unconfirmedServerIds`: answering lanes remain usable, while cache and
+	 * state-replacement consumers still require full coverage. Absent/false
+	 * means the primary check completed within budget; workspace-pull results are
 	 * always confirmed (a pull either returns a real report or the caller
 	 * falls back to per-file, never a silent empty default).
 	 */
@@ -706,6 +708,13 @@ export interface LSPWorkspaceDiagnosticResult {
 	 * produces; absent only on a legacy/test double that predates this field.
 	 */
 	unconfirmedReason?: LSPWorkspaceUnconfirmedReason;
+	/**
+	 * Auxiliary lanes that did not contribute evidence for this file. Their
+	 * absence narrows coverage, but does not invalidate diagnostics returned by
+	 * answering servers. A result carrying this field is usable for delivery,
+	 * but is not eligible to replace the fully-covered workspace cache.
+	 */
+	unconfirmedServerIds?: string[];
 	/**
 	 * #744: true when this file's per-file check was never even attempted
 	 * because its primary language server failed the pre-sweep warm-up (an
@@ -7173,9 +7182,12 @@ export class LSPService {
 				// still never enters the grace wait, but it now derives the SAME evidence
 				// from post-wait state, so a silent auxiliary narrows this scope too
 				// instead of aggregating as a confirmed clean. Every route is gated here.
-				const coverageGap = touchCoverageGap(touchResult).length > 0;
-				const timedOut =
-					touchResult === undefined || inconclusive || coverageGap;
+				const unconfirmedServerIds = touchCoverageGap(touchResult);
+				const coverageGap = unconfirmedServerIds.length > 0;
+				// #1549: the sweep verdict is per answering lane. An auxiliary gap
+				// narrows coverage, but a primary answer remains usable; only absence of
+				// the touch result or a primary-scoped inconclusive verdict poisons it.
+				const timedOut = touchResult === undefined || inconclusive;
 				if (timedOut) timedOutFiles += 1;
 				// #1618: WHY, in priority order — the outer deadline (nothing came
 				// back at all) outranks an inner inconclusive signal, which outranks
@@ -7185,9 +7197,7 @@ export class LSPService {
 						? "budget"
 						: inconclusive
 							? "inconclusive"
-							: coverageGap
-								? "coverage_gap"
-								: undefined;
+							: undefined;
 				// #1104 (shape 5 — AGENTS.md): the touch's content binding is an
 				// EXPLICIT enumerable field on the wrapper now (#1179), so it survives
 				// `applyAuxiliarySuppressions` below rebuilding `.diags` via `.filter()`
@@ -7217,8 +7227,10 @@ export class LSPService {
 					filePath,
 					diagnostics: filteredDiagnostics ?? [],
 					count: filteredDiagnostics?.length ?? 0,
-					timedOut,
-					unconfirmedReason,
+					...(timedOut && { timedOut: true, unconfirmedReason }),
+					...(coverageGap && {
+						unconfirmedServerIds: [...unconfirmedServerIds],
+					}),
 					contentHash: rawBinding?.contentHash,
 					boundToCurrentDisk: rawBinding?.boundToCurrentDisk,
 					writeIndex: writeIndexByPath.get(normalizeMapKey(filePath)),
@@ -7439,6 +7451,12 @@ export class LSPService {
 			const reason = result.unconfirmedReason ?? "budget";
 			unconfirmedByReason[reason] = (unconfirmedByReason[reason] ?? 0) + 1;
 		}
+		const partiallyCoveredFiles = results.filter(
+			(result) => (result.unconfirmedServerIds?.length ?? 0) > 0,
+		).length;
+		const unconfirmedServerIds = [
+			...new Set(results.flatMap((result) => result.unconfirmedServerIds ?? [])),
+		].sort();
 		logLatency({
 			type: "phase",
 			phase: "lsp_workspace_diagnostics",
@@ -7456,6 +7474,8 @@ export class LSPService {
 				maxFiles,
 				timedOutFiles,
 				unconfirmedByReason,
+				partiallyCoveredFiles,
+				...(unconfirmedServerIds.length > 0 && { unconfirmedServerIds }),
 				aborted: signal?.aborted ?? false,
 			},
 		});
@@ -7473,7 +7493,14 @@ export class LSPService {
 		// freshness check; nothing here needs to explicitly evict them).
 		for (const result of results) {
 			const scannedAt = scannedMtimeByFile.get(result.filePath);
-			if (result.error || result.timedOut || scannedAt === undefined) continue;
+			if (
+				result.error ||
+				result.timedOut ||
+				(result.unconfirmedServerIds?.length ?? 0) > 0 ||
+				scannedAt === undefined
+			) {
+				continue;
+			}
 			// #1104: thread the per-result `contentHash` (from either the
 			// `tryWorkspacePull` fast path or a per-file touch's own #1095 binding)
 			// into the cache entry — previously this call never passed one, so

--- a/tests/clients/lsp/workspace-diagnostics-per-server-verdict.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-per-server-verdict.test.ts
@@ -1,0 +1,75 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { removeTempDirSync } from "../test-utils.js";
+
+const getServersForFileWithConfig = vi.fn();
+vi.mock("../../../clients/lsp/config.js", () => ({
+	getServersForFileWithConfig,
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+vi.mock("../../../clients/lsp/client.js", () => ({
+	createLSPClient: vi.fn(),
+}));
+
+describe("#1549 workspace sweep per-server verdict", () => {
+	let root: string;
+
+	beforeEach(() => {
+		vi.resetModules();
+		getServersForFileWithConfig.mockReset();
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "lsp-sweep-verdict-"));
+	});
+
+	afterEach(() => removeTempDirSync(root));
+
+	it("keeps a fast primary finding when one auxiliary is silent and names only that lane", async () => {
+		const filePath = path.join(root, "answer.ts");
+		fs.writeFileSync(filePath, "const answer: string = 42;\n");
+		getServersForFileWithConfig.mockReturnValue([
+			{
+				id: "typescript",
+				name: "typescript",
+				extensions: [".ts"],
+				root: async () => root,
+			},
+		]);
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		vi.spyOn(service, "ensureWarmForSweep").mockResolvedValue({
+			performedWarmup: false,
+			failedServerIds: [],
+		});
+		vi.spyOn(service, "getClientsForFile").mockResolvedValue({
+			clients: [],
+			primarySpawnInFlight: false,
+		} as never);
+		vi.spyOn(service, "touchFile").mockResolvedValue({
+			diags: [
+				{
+					severity: 1,
+					message: "Type 'number' is not assignable to type 'string'.",
+					source: "typescript",
+					range: {
+						start: { line: 0, character: 6 },
+						end: { line: 0, character: 12 },
+					},
+				},
+			],
+			confirmation: "partial",
+			unconfirmedServerIds: ["typos"],
+		} as never);
+
+		const [result] = await service.runWorkspaceDiagnostics(root, {
+			files: [filePath],
+		});
+
+		expect(result.diagnostics.map((diag) => diag.message)).toEqual([
+			"Type 'number' is not assignable to type 'string'.",
+		]);
+		expect(result.timedOut).toBeUndefined();
+		expect(result.unconfirmedServerIds).toEqual(["typos"]);
+	});
+});

--- a/tests/clients/lsp/workspace-diagnostics-warm-attach.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-warm-attach.test.ts
@@ -88,13 +88,20 @@ describe("runWorkspaceDiagnostics warm attach sweeps (#822)", () => {
 		expect(warmup).not.toHaveBeenCalled();
 	});
 
-	// #1470: the sweep's own honesty gate. `runWorkspaceDiagnostics` persists
-	// every `!timedOut` result into the workspace-diagnostics cache, and it read
-	// only `inconclusive` — which a partially covered touch deliberately is not.
-	// The incumbent touches with `clientScope: "with-auxiliary"`, so it is the one
-	// route into this sweep that can produce a coverage gap today, and the gap has
-	// to reach the `timedOut` computation or the sweep caches a partial answer as
-	// a confirmed clean and replays it on every later sweep.
+	// #1470: the sweep's own honesty gate. The incumbent touches with
+	// `clientScope: "with-auxiliary"`, so it is the one route into this sweep
+	// that can produce a coverage gap today. A partially covered answer must
+	// never be persisted as a confirmed clean and replayed on every later sweep.
+	//
+	// #1549 remapped HOW the gap is carried, not WHETHER it blocks the cache.
+	// Before, the gap collapsed the whole file to `timedOut: true`, which also
+	// discarded the primary's usable answer. #1470's own "suggested direction"
+	// rejects that collapse: a primary that answered stays trustworthy when only
+	// an auxiliary was cut off. The gap now rides on `unconfirmedServerIds`, the
+	// sweep's cache write requires an empty `unconfirmedServerIds` as well as
+	// `!timedOut`, and `timedOut` is reserved for primary-scoped failures. This
+	// test asserts the same protection through the new state: the uncovered lane
+	// is named on the result, and the file stays out of the cache.
 	it("does not cache a sweep result whose auxiliary the incumbent could not cover (#1470)", async () => {
 		fs.mkdirSync(path.join(tmp, ".pi-lens"));
 		const file = path.join(tmp, "a.ts");
@@ -113,7 +120,7 @@ describe("runWorkspaceDiagnostics warm attach sweeps (#822)", () => {
 			files: [file],
 		});
 
-		expect(results[0]?.timedOut).toBe(true);
+		expect(results[0]?.unconfirmedServerIds).toEqual(["typos"]);
 		const { cacheKeyFor, loadWorkspaceDiagnosticsCache } = await import(
 			"../../../clients/lsp/workspace-diagnostics-cache.js"
 		);

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -691,6 +691,46 @@ describe("lens_diagnostics mode=full", () => {
 		});
 	});
 
+	it("#1549 delivers an answering server's finding while naming only the silent auxiliary lane", async () => {
+		mockSummaries.length = 0;
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([
+				{
+					filePath: "/proj/src/partial.ts",
+					diagnostics: [
+						{
+							severity: 1,
+							message: "fast TypeScript answer",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 4 },
+							},
+							source: "typescript",
+						},
+					],
+					count: 1,
+					unconfirmedServerIds: ["typos"],
+				},
+			]),
+		};
+
+		const result = await run(makeTool({}, lspService), { mode: "full" });
+		const text = String(result.content[0].text);
+
+		expect(text).toContain("fast TypeScript answer");
+		expect(text).toContain("Auxiliary coverage incomplete: typos");
+		expect(text).not.toContain("LSP sweep: 0 file(s) confirmed");
+		expect(result.details).toMatchObject({
+			lspFilesConfirmed: 1,
+			lspFilesUnconfirmed: 0,
+			lspFilesPartiallyCovered: 1,
+			unconfirmedLspServerIds: ["typos"],
+		});
+		// Partial coverage may be delivered, but it cannot replace a footer
+		// snapshot that may still contain the silent scanner's prior finding.
+		expect(reconcileScanDiagnosticsMock).not.toHaveBeenCalled();
+	});
+
 	it("uses an event-captured repaint when a server becomes ready mid-sweep (#798/#338)", async () => {
 		const repaint = vi.fn();
 		const capture = vi.fn(() => repaint);

--- a/tests/tools/lsp-diagnostics-cache.test.ts
+++ b/tests/tools/lsp-diagnostics-cache.test.ts
@@ -90,6 +90,22 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 		});
 	}
 
+	/** The on-disk cache's entry map, or `{}` when nothing was written. */
+	function cacheEntries(): Record<string, { mtimeMs: number }> {
+		const cacheFile = path.join(
+			tmpDir,
+			".pi-lens",
+			"cache",
+			"lsp-workspace-diagnostics.json",
+		);
+		if (!fs.existsSync(cacheFile)) return {};
+		return (
+			JSON.parse(fs.readFileSync(cacheFile, "utf8")) as {
+				entries?: Record<string, { mtimeMs: number }>;
+			}
+		).entries ?? {};
+	}
+
 	async function runBatch(paths: string[]) {
 		const tool = createLspDiagnosticsTool();
 		return tool.execute(
@@ -182,6 +198,130 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 		const second = await runBatch(files);
 		expect(touchFile).not.toHaveBeenCalled();
 		expect(second.details?.totalDiagnostics).toBe(1);
+	});
+
+	// #1549 review round, coverage gap (a). `collectFileDiagnosticResult` has two
+	// independent guards against caching a partially covered answer: it demotes
+	// `confirmation` to "unconfirmed" when the result is CLEAN, and the cache
+	// write additionally requires `unconfirmedServerIds.length === 0`. Every
+	// pre-existing partial fixture in the suite is EMPTY, so the demotion alone
+	// carried them and the second guard could be deleted with all tests still
+	// green. A NON-EMPTY partial result is the case only the second guard covers:
+	// a non-empty answer is confirmed by this function's own doctrine, so nothing
+	// demotes it, and without the gate the sweep would persist a snapshot that no
+	// scanner vouched for and replay it as complete on every later batch.
+	it("never caches a NON-EMPTY result whose auxiliary did not answer — the next call still touches it", async () => {
+		const files = writeFiles(["a.ts"]);
+		const diag = {
+			severity: 1,
+			message: "boom",
+			range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+			source: "typescript",
+		};
+		touchFile.mockResolvedValueOnce({
+			diags: [diag],
+			confirmation: "partial",
+			unconfirmedServerIds: ["opengrep"],
+		});
+
+		const first = await runBatch(files);
+		// The findings still reach the caller — the gap narrows COVERAGE, it does
+		// not discard the primary's answer (#1470's own stated direction).
+		expect(first.details?.totalDiagnostics).toBe(1);
+		expect(cacheEntries()).toEqual({});
+
+		touchFile.mockClear();
+		touchFile.mockResolvedValue({ diags: [] });
+		const second = await runBatch(files);
+		expect(second.isError).toBeUndefined();
+		// Contrast with the fully covered case directly above, where the second
+		// call is served from the cache and touchFile is never reached.
+		expect(touchFile).toHaveBeenCalledTimes(1);
+	});
+
+	// #1549 review round, coverage gap (b): the persistent cache's partial/full
+	// transition matrix. Nothing pinned what happens when coverage CHANGES
+	// between two sweeps of the same file, in either direction.
+	it("partial then full: the partial sweep records nothing, and the later full sweep upgrades the file into the cache", async () => {
+		const files = writeFiles(["a.ts"]);
+		// Non-empty on purpose, for the same reason as the case above: an empty
+		// partial is carried by the clean-demotion rule, so an empty fixture here
+		// would pass with the coverage gate deleted.
+		touchFile.mockResolvedValueOnce({
+			diags: [
+				{
+					severity: 1,
+					message: "boom",
+					range: {
+						start: { line: 0, character: 0 },
+						end: { line: 0, character: 1 },
+					},
+					source: "typescript",
+				},
+			],
+			confirmation: "partial",
+			unconfirmedServerIds: ["opengrep"],
+		});
+
+		await runBatch(files);
+		expect(cacheEntries()).toEqual({});
+
+		// Same file, same bytes, but opengrep answers this time.
+		touchFile.mockClear();
+		touchFile.mockResolvedValue({ diags: [], confirmation: "confirmed" });
+		await runBatch(files);
+		expect(touchFile).toHaveBeenCalledTimes(1);
+		expect(Object.keys(cacheEntries())).toHaveLength(1);
+
+		// And the upgraded entry now serves the next sweep.
+		touchFile.mockClear();
+		await runBatch(files);
+		expect(touchFile).not.toHaveBeenCalled();
+	});
+
+	it("full then partial on a CHANGED file: the stale full entry is not overwritten and stays mtime-ineligible", async () => {
+		const files = writeFiles(["a.ts"]);
+		await runBatch(files);
+		const cachedFull = cacheEntries();
+		expect(Object.keys(cachedFull)).toHaveLength(1);
+		const key = Object.keys(cachedFull)[0]!;
+
+		// The file changes, so the cached entry is already mtime-ineligible. The
+		// re-touch comes back partially covered.
+		const future = new Date(Date.now() + 60_000);
+		fs.writeFileSync(files[0]!, "x2\n");
+		fs.utimesSync(files[0]!, future, future);
+		touchFile.mockClear();
+		touchFile.mockResolvedValue({
+			diags: [
+				{
+					severity: 1,
+					message: "boom",
+					range: {
+						start: { line: 0, character: 0 },
+						end: { line: 0, character: 1 },
+					},
+					source: "typescript",
+				},
+			],
+			confirmation: "partial",
+			unconfirmedServerIds: ["opengrep"],
+		});
+		await runBatch(files);
+		expect(touchFile).toHaveBeenCalledTimes(1);
+
+		// The partial answer must not be written over the old entry: the cache
+		// still holds the ORIGINAL scan, whose mtime no longer matches disk.
+		const after = cacheEntries();
+		expect(Object.keys(after)).toEqual([key]);
+		expect(after[key]?.mtimeMs).toBe(cachedFull[key]?.mtimeMs);
+		expect(after[key]?.mtimeMs).not.toBe(fs.statSync(files[0]!).mtimeMs);
+
+		// So the next sweep still re-touches rather than replaying a snapshot for
+		// bytes nobody scanned.
+		touchFile.mockClear();
+		await runBatch(files);
+		expect(touchFile).toHaveBeenCalledTimes(1);
 	});
 
 	it("a cache-hit reconcile stamps the footer with the cache's ORIGINAL scan time, not now (#1093/#1092)", async () => {

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -138,6 +138,9 @@ type WorkspaceLspDiagnosticResult = {
 	timedOut?: boolean;
 	// #1618: WHY `timedOut` is true — see LSPWorkspaceUnconfirmedReason.
 	unconfirmedReason?: LSPWorkspaceUnconfirmedReason;
+	// Auxiliary lanes that did not answer. Other servers' diagnostics remain
+	// usable, but this result must not replace fully-covered cached/widget state.
+	unconfirmedServerIds?: string[];
 	// #1093: set only for cache-hit results (a replay of an older scan) — the
 	// wall-clock time the diagnostics were originally observed. Threaded into the
 	// footer reconcile so a cache-served mode=full doesn't re-arm the widget's
@@ -1642,6 +1645,12 @@ async function formatFullMode(
 			!result.error &&
 			!mismatchedLspResults.has(result),
 	);
+	const fullyCoveredLspResults = confirmedLspResults.filter(
+		(result) => (result.unconfirmedServerIds?.length ?? 0) === 0,
+	);
+	const partiallyCoveredLspResults = confirmedLspResults.filter(
+		(result) => (result.unconfirmedServerIds?.length ?? 0) > 0,
+	);
 	const unconfirmedLspResults = lspResults.filter(
 		(result) =>
 			result.timedOut ||
@@ -1651,7 +1660,7 @@ async function formatFullMode(
 	// #571: reconcile this scan's fresh, CONFIRMED per-file results into the
 	// footer cache. A footer write is never allowed to fail the tool call, so
 	// any unexpected throw is swallowed.
-	for (const result of confirmedLspResults) {
+	for (const result of fullyCoveredLspResults) {
 		try {
 			// #692: provenance label ONLY — must never affect `rule`/identity (see
 			// `ConvertLspDiagnosticsOptions.scanOrigin`'s doc comment).
@@ -1820,6 +1829,17 @@ async function formatFullMode(
 					.join(
 						", ",
 					)}${unconfirmedLspResults.length > 20 ? ", …" : ""}. These files' LSP contribution is excluded from this result; re-run mode=full to retry them (they may still show findings above from cached/project-runner state).`
+			: "";
+	const uncoveredScannerIds = [
+		...new Set(
+			partiallyCoveredLspResults.flatMap(
+				(result) => result.unconfirmedServerIds ?? [],
+			),
+		),
+	].sort();
+	const auxiliaryCoverageNote =
+		uncoveredScannerIds.length > 0
+			? `\n\n⚠ Auxiliary coverage incomplete: ${uncoveredScannerIds.join(", ")} did not answer for ${partiallyCoveredLspResults.length} file(s). Findings from answering servers are included; this is not a clean verdict for the named scanner lane(s).`
 			: "";
 	// #646: primary-vs-auxiliary split of the raw LSP-sweep findings (before
 	// they're merged into the widget-state summaries below), mirroring
@@ -2049,6 +2069,8 @@ async function formatFullMode(
 			// any files unconfirmed" without re-deriving it from the text.
 			lspFilesConfirmed: confirmedLspResults.length,
 			lspFilesUnconfirmed: unconfirmedLspResults.length,
+			lspFilesPartiallyCovered: partiallyCoveredLspResults.length,
+			unconfirmedLspServerIds: uncoveredScannerIds,
 			unconfirmedLspFiles: unconfirmedLspResults.map(
 				(result) => result.filePath,
 			),
@@ -2100,6 +2122,7 @@ async function formatFullMode(
 						result.content[0].text +
 						note +
 						unconfirmedLspNote +
+						auxiliaryCoverageNote +
 						lspPrimaryVsAuxiliaryNote +
 						coldNote +
 						testRunnerEditScopedNote +
@@ -2132,6 +2155,7 @@ async function formatFullMode(
 		cachedAgeNote ||
 		cheapScanStatusNote ||
 		unconfirmedLspNote ||
+		auxiliaryCoverageNote ||
 		lspPrimaryVsAuxiliaryNote
 	) {
 		return {
@@ -2141,6 +2165,7 @@ async function formatFullMode(
 					text:
 						result.content[0].text +
 						unconfirmedLspNote +
+						auxiliaryCoverageNote +
 						lspPrimaryVsAuxiliaryNote +
 						coldNote +
 						testRunnerEditScopedNote +

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -1863,13 +1863,17 @@ async function formatFullMode(
 						", ",
 					)}${unconfirmedLspResults.length > 20 ? ", …" : ""}. These files' LSP contribution is excluded from this result; re-run mode=full to retry them (they may still show findings above from cached/project-runner state).`
 			: "";
+	// Code-unit comparator (#1883): this list ships as the
+	// `unconfirmedLspServerIds` structured field and as the lane names in the
+	// agent-visible coverage note, so its order must be deterministic across
+	// locales — localeCompare is deliberately avoided.
 	const uncoveredScannerIds = [
 		...new Set(
 			partiallyCoveredLspResults.flatMap(
 				(result) => result.unconfirmedServerIds ?? [],
 			),
 		),
-	].sort();
+	].sort((a, b) => Number(a > b) - Number(a < b));
 	const auxiliaryCoverageNote =
 		uncoveredScannerIds.length > 0
 			? `\n\n⚠ Auxiliary coverage incomplete: ${uncoveredScannerIds.join(", ")} did not answer for ${partiallyCoveredLspResults.length} file(s). Findings from answering servers are included; this is not a clean verdict for the named scanner lane(s).`

--- a/tools/lsp-diagnostics.ts
+++ b/tools/lsp-diagnostics.ts
@@ -1325,7 +1325,12 @@ async function collectFileDiagnosticResult(
 	// result — same false-clean bug class `runWorkspaceDiagnostics`'s cache
 	// wiring guards against. #1095: the entry carries the content fingerprint so a
 	// later lookup can verify it against disk beyond the mtime proxy.
-	if (cacheCtx && scopeKey !== undefined && confirmation !== "unconfirmed") {
+	if (
+		cacheCtx &&
+		scopeKey !== undefined &&
+		confirmation !== "unconfirmed" &&
+		unconfirmedServerIds.length === 0
+	) {
 		cacheCtx.record(
 			file,
 			scopeKey,


### PR DESCRIPTION
## Outcome

The workspace-diagnostics touch loop now keeps diagnostics from answering servers when an auxiliary scanner is silent or cut off. It carries the frozen `unconfirmedServerIds` coverage set through the sweep, renders a named auxiliary coverage marker, and prevents partially covered results from replacing the workspace cache or footer state.

The poisoning site was `clients/lsp/index.ts:7177` before this branch. It folded `coverageGap` into the file-wide `timedOut` verdict. The updated site is `clients/lsp/index.ts:7190`.

## State model

- A missing result or primary-scoped inconclusive result remains file-wide unconfirmed.
- An auxiliary-only gap keeps answering-server findings usable and names only the uncovered lanes.
- Only fully covered results may enter the workspace cache or replace footer state.
- The sibling `lsp_diagnostics` batch path already retained non-empty answers. Its cache gate now also rejects partial coverage.

## Verification

- Red first: the new real workspace-sweep regression test failed because `result.timedOut` was `true` for a TypeScript finding plus silent `typos` lane.
- Mutation proof: restoring `touchResult === undefined || inconclusive || coverageGap` made that same assertion fail again. The consumer test continued to prove that the finding and named marker are coupled.
- `npm run build`: passed.
- `npm run lint`: passed.
- Cascade, touch, lens, and conformance selection: 8 files, 290 tests passed.
- Final direct sweep and consumer selection: 2 files, 103 tests passed.
- Full suite: not run, as requested.

## Scope and closure

This PR uses `refs`, not `closes`. It completes the honestly deferred workspace-diagnostics touch-loop work named by PR #1805. Issue #1549 still records a dogfood measurement gate and the separately deferred latency-log retention work, so its original acceptance criteria are not all complete in this PR.

## AI disclosure

This change was implemented and tested with Codex. The maintainer directed the scope and will review the final patch.

Refs #1549
Refs #1805