### PR TITLE
fix(session): re-arm remaining store resets (closes #1897)

### DIFF
--- a/.changelog/1897.md
+++ b/.changelog/1897.md
@@ -1,0 +1,7 @@
+---
+section: Fixed
+---
+
+- **Re-arm direct-LSP and installer availability caches ([closes #1897](https://github.com/apmantza/pi-lens/issues/1897))** —
+  the primary `session_start` clears negative direct-LSP cooldowns and
+  resolved installer paths, so tools added between sessions are probed again.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,13 @@ of parsing partial output as a clean empty result. Sampler timeouts inject the
 reaper's tree-kill-and-verify hook and settle only after its fate is known.
 (#1863, #1864)
 
+**Session-start availability resets include direct LSP and installer path positives.**
+Direct-LSP negative cooldowns and installer bare-command path positives are
+session facts: the former can recover when a command appears, and the latter
+returns without a spawnability check. `handleSessionStart` clears both behind
+the primary-only session-start guard; the session-state registry records the
+two reset seams. (#1897)
+
 ## Issue and PR design contract
 
 - **Design the state space before coding.** For stateful, ordered, resource-mutating, or security-sensitive work, write the invariants, supported transitions, explicit deferrals, and a cross-product test matrix before implementation. Examples are not enough: cover operation order, preview/apply, validation/normalization/execution seams, failure atomicity, observability bounds, and OS/path/encoding axes. If adversarial review finds repeated cross-product defects, stop patching one symptom at a time and return to the model.

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -1565,6 +1565,11 @@ export function getLastEnsureResolutionSource(
 // Session-lifetime cache: once a tool path is resolved, skip the process-spawn check on subsequent calls.
 const resolvedPathCache = new BoundedLruCache<string, string>(256);
 
+/** Re-arm resolved tool paths when a new session may have changed PATH. */
+export function resetResolvedPathCache(): void {
+	resolvedPathCache.clear();
+}
+
 // --- Persistent probe cache ---
 
 interface ProbeCacheEntry {
@@ -1945,7 +1950,7 @@ export function resetProbeCacheStateForTesting(): void {
 	_probeCacheChangeVersions.clear();
 	_probeCacheChangeGeneration = 0;
 	_probeCacheRetryAttempt = 0;
-	resolvedPathCache.clear();
+	resetResolvedPathCache();
 	ensureInFlight.clear();
 	installFailureReasons.clear();
 	installAttempts.clear();

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -331,6 +331,17 @@ const DIRECT_LSP_NEGATIVE_TTL_MS = Math.max(
 const directLspCommandUnavailableUntil = new Map<string, number>();
 const directLspCommandSkipLoggedUntil = new Map<string, number>();
 
+/** Re-arm direct-command availability for the next session. */
+export function resetDirectLspCommandAvailability(): void {
+	directLspCommandUnavailableUntil.clear();
+	directLspCommandSkipLoggedUntil.clear();
+}
+
+/** Test seam for seeding the real negative-cache path. */
+export function _markDirectLspCommandUnavailableForTests(command: string): void {
+	markDirectLspCommandUnavailable(command);
+}
+
 function pruneExpiredDirectLspNegativeEntries(now = Date.now()): void {
 	for (const [command, until] of directLspCommandUnavailableUntil) {
 		if (until <= now) {

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -44,10 +44,12 @@ import { runLogCleanup } from "./log-cleanup.js";
 import type { LSPShutdownOptions } from "./lsp/client.js";
 import { initLSPConfig, loadLSPConfig } from "./lsp/config.js";
 import { resetWorkspaceDiagnosticsCacheSession } from "./lsp/workspace-diagnostics-session.js";
+import { resetDirectLspCommandAvailability } from "./lsp/server.js";
 import { loadLspService } from "./lsp-lazy.js";
 import type { MetricsClient } from "./metrics-client.js";
 import type { OpengrepClient, OpengrepResult } from "./opengrep-client.js";
 import { resetManagedToolRefreshSession } from "./installer/managed-tool-refresh-session.js";
+import { resetResolvedPathCache } from "./installer/index.js";
 import { _resetPackageManagerCache } from "./package-manager.js";
 import { isAtOrAboveHomeDir } from "./path-utils.js";
 import { isPrintMode } from "./print-mode.js";
@@ -2103,6 +2105,10 @@ export async function handleSessionStart(
 	// from `clearFormatterRuntimeState()`, which runs every turn, so a failing
 	// install re-spawned every turn instead of once per session.
 	resetLazyInstallAttempts();
+	// #1897: direct-LSP negative availability and bare installer paths are
+	// session facts. A command or PATH entry can appear between sessions.
+	resetDirectLspCommandAvailability();
+	resetResolvedPathCache();
 	// #1653: pnpm/yarn/bun/npm's availability latches (package-manager.ts) are
 	// module-local, same #1490/#1535 shape as the two lines above — the
 	// generation counter above does not reach them. Without this line, a

--- a/tests/clients/installer/version-drift.test.ts
+++ b/tests/clients/installer/version-drift.test.ts
@@ -174,6 +174,22 @@ vi.mock("node:child_process", () => ({
 	spawnSync: mockSpawnSync,
 }));
 
+// isCommandAvailable (the PATH-walk used to resolve a BARE checkCommand, e.g.
+// "madge") reads `node:fs`'s statSync directly — it never touches the
+// `node:fs/promises` mock above. Mirrors path-walk-memo.test.ts's pattern.
+// Default behavior delegates to the REAL statSync: safeSpawnAsync (used by
+// installTool's npm-install spawn) also calls statSync(cwd) as a preflight,
+// against a real, existing directory — overriding it wholesale would break
+// every install-spawning test in this file, not just the new PATH-walk one.
+const mockStatSync = vi.hoisted(() => vi.fn());
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	mockStatSync.mockImplementation((...args: Parameters<typeof actual.statSync>) =>
+		actual.statSync(...args),
+	);
+	return { ...actual, statSync: mockStatSync };
+});
+
 import * as path from "node:path";
 import {
 	ensureTool,
@@ -238,9 +254,14 @@ beforeEach(() => {
 	spawnCalls.length = 0;
 	versionOutput.value = "";
 	resetProbeCacheStateForTesting();
+	// A bare-command positive (no fs.access, no probe-cache fallback) does not
+	// self-heal like a fully-qualified one does when fakeAccess() below denies
+	// everything — it would otherwise leak from one test into the next.
+	resetResolvedPathCache();
 	mockFsReadFile.mockRejectedValue(new Error("ENOENT"));
 	mockFsStat.mockResolvedValue({ mtimeMs: Date.now() });
 	fakeAccess(/* nothing */);
+	mockStatSync.mockClear();
 });
 
 afterEach(() => {
@@ -312,6 +333,51 @@ describe("version-pin drift detection (#589)", () => {
 		resetResolvedPathCache();
 		expect(await ensureTool("jscpd")).toBe(JSCPD_BIN);
 		expect(mockFsAccess).toHaveBeenCalledTimes(2);
+	});
+
+	// #1902 review: the test above only proves the reset works for a FULLY
+	// QUALIFIED cached path, which takes the fs.access branch at
+	// installer/index.ts:5015-5018 — a branch that never needed the reset,
+	// because a stale fully-qualified positive is already evicted on its own
+	// the next time fs.access rejects it. resetResolvedPathCache's actual
+	// reason to exist is the BARE-command branch at :5011-5014, where a
+	// checkCommand resolved off PATH (madge here — unpinned npm tool, no
+	// version-drift complication) is cached and returned from the in-memory
+	// session cache with NO fs.access, NO re-probe, and NO way to self-heal
+	// mid-session. Neutering resetResolvedPathCache's body leaves the test
+	// above green but must turn this one red.
+	it("clears the positive path cache for a bare, PATH-resolved tool so the next ensure re-discovers it", async () => {
+		const savedPath = process.env.PATH;
+		process.env.PATH = TEST_HOME;
+		const realStatSync = mockStatSync.getMockImplementation();
+		try {
+			mockStatSync.mockImplementation(() => ({ isFile: () => true, size: 1 }) as never);
+
+			const first = await ensureTool("madge");
+			expect(first).toBe("madge");
+			const statCallsAfterFirst = mockStatSync.mock.calls.length;
+			expect(statCallsAfterFirst).toBeGreaterThan(0);
+
+			// Same-session re-ensure: fast path 1 (session-cache) returns the bare
+			// cached command directly — no fs.access, no fresh PATH walk.
+			const second = await ensureTool("madge");
+			expect(second).toBe("madge");
+			expect(mockStatSync.mock.calls.length).toBe(statCallsAfterFirst);
+
+			resetResolvedPathCache();
+
+			// A fresh session must not trust the stale bare positive — it has to
+			// re-walk PATH, because a bare command has no persistent probe-cache
+			// fallback (updateProbeCache stats the resolved path and swallows a
+			// bare command's ENOENT).
+			const third = await ensureTool("madge");
+			expect(third).toBe("madge");
+			expect(mockStatSync.mock.calls.length).toBeGreaterThan(statCallsAfterFirst);
+		} finally {
+			if (realStatSync) mockStatSync.mockImplementation(realStatSync);
+			if (savedPath === undefined) delete process.env.PATH;
+			else process.env.PATH = savedPath;
+		}
 	});
 
 	it("evicts a cached positive when the resolved binary is deleted", async () => {

--- a/tests/clients/installer/version-drift.test.ts
+++ b/tests/clients/installer/version-drift.test.ts
@@ -178,6 +178,7 @@ import * as path from "node:path";
 import {
 	ensureTool,
 	getToolPath,
+	resetResolvedPathCache,
 	resetProbeCacheStateForTesting,
 	TOOLS,
 } from "../../../clients/installer/index.js";
@@ -300,6 +301,17 @@ describe("version-pin drift detection (#589)", () => {
 		expect(second).toBe(JSCPD_BIN);
 		// In-memory resolvedPathCache fast path — no new spawn on the second call.
 		expect(spawnCalls).toHaveLength(0);
+	});
+
+	it("clears the positive path cache so the next ensure rechecks the tool", async () => {
+		fakeAccess(JSCPD_BIN);
+		versionOutput.value = `${JSCPD_PINNED_VERSION}\n`;
+		expect(await ensureTool("jscpd")).toBe(JSCPD_BIN);
+		spawnCalls.length = 0;
+
+		resetResolvedPathCache();
+		expect(await ensureTool("jscpd")).toBe(JSCPD_BIN);
+		expect(mockFsAccess).toHaveBeenCalledTimes(2);
 	});
 
 	it("evicts a cached positive when the resolved binary is deleted", async () => {

--- a/tests/clients/runtime-session-dispatch-reset.test.ts
+++ b/tests/clients/runtime-session-dispatch-reset.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../clients/safe-spawn.js", () => ({
 
 vi.mock("../../clients/installer/index.js", () => ({
 	ensureTool: vi.fn(async () => undefined),
+	resetResolvedPathCache: vi.fn(),
 	// Not spawnable — forces resolveCommandWithInstallFallback down the
 	// install-fallback path (rather than the --version probe path) where
 	// noteInstallFailure/suppression lives.
@@ -143,6 +144,20 @@ describe("dispatch availability suppression is reset at session start (#1266)", 
 		);
 		expect(third).toBeNull();
 		expect(ensureToolMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("re-arms direct-LSP negative availability through handleSessionStart", async () => {
+		const lspServer = await import("../../clients/lsp/server.js");
+		lspServer._markDirectLspCommandUnavailableForTests("appeared-lsp");
+		expect(
+			lspServer.isDirectLspCommandTemporarilyUnavailable("appeared-lsp"),
+		).toBe(true);
+
+		await handleSessionStart(makeDeps(tmpDir));
+
+		expect(
+			lspServer.isDirectLspCommandTemporarilyUnavailable("appeared-lsp"),
+		).toBe(false);
 	});
 
 	// #1490: psscriptanalyzer's interpreter and module verdicts live in

--- a/tests/clients/runtime-session-dispatch-reset.test.ts
+++ b/tests/clients/runtime-session-dispatch-reset.test.ts
@@ -146,6 +146,23 @@ describe("dispatch availability suppression is reset at session start (#1266)", 
 		expect(ensureToolMock).toHaveBeenCalledTimes(2);
 	});
 
+	// #1902 review: session-state-conformance.test.ts only proves the registry
+	// KNOWS about resetResolvedPathCache's reset seam (a structural/name check).
+	// Nothing asserted that handleSessionStart's call to it actually fires. The
+	// wiring test above exercises resetResolvedPathCache only indirectly through
+	// ensureTool's mock, so it would stay green even if the
+	// `resetResolvedPathCache()` line at runtime-session.ts:2111 were deleted.
+	it("calls resetResolvedPathCache directly from handleSessionStart", async () => {
+		const installerMod = await import("../../clients/installer/index.js");
+		const resetResolvedPathCacheMock = vi.mocked(
+			installerMod.resetResolvedPathCache,
+		);
+
+		await handleSessionStart(makeDeps(tmpDir));
+
+		expect(resetResolvedPathCacheMock).toHaveBeenCalled();
+	});
+
 	it("re-arms direct-LSP negative availability through handleSessionStart", async () => {
 		const lspServer = await import("../../clients/lsp/server.js");
 		lspServer._markDirectLspCommandUnavailableForTests("appeared-lsp");

--- a/tests/index-integration.test.ts
+++ b/tests/index-integration.test.ts
@@ -336,9 +336,16 @@ describe("index.ts integration", () => {
 		const primary = createMockPi();
 		registerExtension(primary.pi as any);
 		await primary.trigger("session_start", {}, makeCtx({ cwd: tmpDir, sessionId: "primary" }));
+		const lspServer = await import("../clients/lsp/server.js");
+		lspServer._markDirectLspCommandUnavailableForTests("secondary-must-not-reset");
 		const secondary = createMockPi();
 		registerExtension(secondary.pi as any);
 		await secondary.trigger("session_start", {}, makeCtx({ cwd: tmpDir, sessionId: "secondary" }));
+		expect(
+			lspServer.isDirectLspCommandTemporarilyUnavailable(
+				"secondary-must-not-reset",
+			),
+		).toBe(true);
 		telemetry.recordVerifiedPathAttributionGuess();
 		await secondary.trigger("session_shutdown", {}, makeCtx({ cwd: tmpDir, sessionId: "secondary" }));
 		expect(

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -457,6 +457,24 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 			"The PATH walk memo must not outlive a session that installed something onto PATH.",
 	},
 	{
+		id: "installer:resolvedPathCache",
+		module: "installer/index.ts",
+		state: "resolvedPathCache",
+		policy: "session_start",
+		resetName: "resetResolvedPathCache",
+		reason:
+			"Bare cached commands return without a spawnability check, so a PATH change between sessions must clear this positive cache.",
+	},
+	{
+		id: "lsp-server:directCommandUnavailable",
+		module: "lsp/server.ts",
+		state: "directLspCommandUnavailableUntil, directLspCommandSkipLoggedUntil",
+		policy: "session_start",
+		resetName: "resetDirectLspCommandAvailability",
+		reason:
+			"A direct-LSP command that appears between sessions must receive a fresh availability probe instead of inheriting the prior negative cooldown.",
+	},
+	{
 		id: "lsp-server:classicTsRepairGuard",
 		module: "lsp/server.ts",
 		state: "the classic-tsserver repair guard",


### PR DESCRIPTION
## Outcome

The primary `session_start` now re-arms both remaining availability stores from #1897. Concurrent secondary sessions still skip the shared reset path.

## Decisions and evidence

| Store | Decision | Evidence |
| --- | --- | --- |
| Direct-LSP `directLspCommandUnavailableUntil` | Re-arm at primary `session_start` | `clients/lsp/server.ts:331-380` stores the negative cooldown; a command that appears between sessions must receive a fresh probe. |
| Installer `resolvedPathCache` | Re-arm at primary `session_start` | `clients/installer/index.ts:5005-5010` returns bare cached commands without a spawnability/existence check. Fully qualified paths alone use `fs.access`, so a cache reset matches the installer's existing conventions. |

The session-state registry records both stores and their reset seams. The shared reset block is adjacent to the formatter reset added by #1896, which has since merged; this branch merges `origin/master` and resolves the AGENTS.md overlap by keeping both paragraphs.

## Tests and verification

- `npm run build`
- `npm run test:unit -- tests/clients/runtime-session-dispatch-reset.test.ts tests/clients/installer/version-drift.test.ts tests/clients/session-state-conformance.test.ts` — 3 files, 76 tests passed (pre-review-round baseline).
- `npm run test:unit -- tests/clients/lsp/classic-repair-rearm.test.ts tests/clients/lsp/server-policy.test.ts tests/clients/installer/path-walk-memo.test.ts` — 3 files, 79 tests passed.
- `npm run test:integration -- tests/index-integration.test.ts` — 2 files, 58 tests passed.
- `npm run changelog:check` — 192 entries validated.
- Red proof: removing `resetDirectLspCommandAvailability()` made the real `handleSessionStart` test fail; restoring it passed.
- No full suite run.

## Review round (post-merge with #1896)

An adversarial review found the installer test for the reset was vacuous, and the wiring test for it was unasserted. Both are fixed on this branch; here's what changed and why.

**F1 — the installer reset test never exercised the branch it exists for (fixed).**
`tests/clients/installer/version-drift.test.ts`'s "clears the positive path cache" test seeded a fully-qualified `JSCPD_BIN`. That path takes the `fs.access` branch at `clients/installer/index.ts:5015-5018`, which self-heals on its own the next time `fs.access` rejects a stale positive — it never needed `resetResolvedPathCache()`. Neutering the reset's body left that test green.

The rewrite adds a second test using a bare, PATH-resolved command (`madge`, an unpinned npm tool — no version-drift interaction). It mocks `node:fs`'s `statSync` (the same pattern as `path-walk-memo.test.ts`) to simulate `madge` on `PATH`, seeds a bare cache entry, calls the real `resetResolvedPathCache()`, and asserts the next `ensureTool("madge")` re-walks `PATH` instead of replaying the stale bare positive. This is the branch at `:5011-5014` that returns from the session cache with no `fs.access` call at all.

Red proof (neutering `resetResolvedPathCache`'s body to a no-op):
```
FAIL tests/clients/installer/version-drift.test.ts > ... > clears the positive path cache for a bare, PATH-resolved tool so the next ensure re-discovers it
AssertionError: expected 1 to be greater than 1
```
Restoring the body: 8/8 pass.

**F2 — blast radius of the installer reset (documented, not previously stated).**
A bare, PATH-resolved tool has no persistent probe-cache fallback: `updateProbeCache` `fs.stat`s the resolved path and silently drops a bare command's `ENOENT` (`clients/installer/index.ts:1929-1942`). So the reset's cost, per PATH-resolved tool per session, is one fresh `PATH` walk (`isCommandAvailable`, `statSync`-based, no spawn) on the first `ensureTool` call after the session boundary — and, only for tools whose install strategy also checks a version pin (a much smaller subset), a `--version` spawn.

Measured: `TOOLS` in `clients/installer/index.ts` defines 62 entries, every one with a bare `checkCommand`. Any of the 62 that a given machine already has on `PATH` (rather than resolved through pi-lens's own managed installer under `~/.pi-lens/tools`) is a candidate for this branch. The walk itself is µs-scale per the function's own doc comment; the only new spawn is the already-existing version-pin drift check, unaffected by this PR.

**F3 — the dispatch-reset wiring test never asserted the reset ran (fixed).**
`tests/clients/runtime-session-dispatch-reset.test.ts` mocks `resetResolvedPathCache` but nothing asserted the mock was called — the existing "retries a suppressed tool's install" test exercises it only indirectly, through `ensureTool`'s mock, so it stayed green even with the wiring line deleted. Added a dedicated test asserting `resetResolvedPathCacheMock` was called from `handleSessionStart`.

Red proof (deleting the `resetResolvedPathCache()` call at `clients/runtime-session.ts:2111`):
```
FAIL tests/clients/runtime-session-dispatch-reset.test.ts > ... > calls resetResolvedPathCache directly from handleSessionStart
AssertionError: expected "vi.fn()" to be called at least once
```
Restoring the call: 6/6 pass.

The direct-LSP twin ("re-arms direct-LSP negative availability through handleSessionStart") already asserts real before/after state (`isDirectLspCommandTemporarilyUnavailable`), not just a mock call — it needed no change.

**Conflict with #1896.** #1896 merged first. Merging `origin/master` produced two conflicts: `AGENTS.md` (additive — kept both paragraphs) and `tests/clients/runtime-session-dispatch-reset.test.ts` (additive — kept this PR's two new tests plus #1896's two formatter re-probe tests, in the same `describe` block).

**Composed test run on the merged tree** (this PR's targeted files + the review's symbol-grep sweep, 6 files):
```
npx vitest run tests/clients/runtime-session-dispatch-reset.test.ts tests/clients/installer/version-drift.test.ts tests/clients/session-state-conformance.test.ts tests/clients/lsp/classic-repair-rearm.test.ts tests/clients/lsp/server-policy.test.ts tests/clients/installer/path-walk-memo.test.ts
```
6 files, 161 tests passed. Plus `tests/index-integration.test.ts` — 33 tests passed. Combined: 194 tests passed, 0 failed.

No full suite run; CI is authoritative.

## Disclosure

This PR was prepared with Codex. Codex implemented the initial changes, tests, registry entry, changelog, branch, commit, push, and PR. The review round above (F1/F2/F3, the master merge, and its composition proof) was done by a Claude fix-round agent responding to an adversarial review. All decisions and evidence are recorded above for maintainer review.
