### PR TITLE
fix: recognize formatter writes (closes #1903)

### DIFF
--- a/.changelog/1903-formatter-write-recognition.md
+++ b/.changelog/1903-formatter-write-recognition.md
@@ -1,0 +1,8 @@
+---
+section: Fixed
+---
+
+- **Avoid false read-guard blocks after formatter writes ([closes #1903](https://github.com/apmantza/pi-lens/issues/1903))** —
+  Bash-invoked in-place formatters and fixers now refresh explicit file write
+  stamps. A uniquely resolved edit `oldText` also overrides coarse FileTime
+  staleness, while missing or ambiguous content evidence remains blocked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,13 @@ generation may reuse a successful result; explicit fresh-analysis callers omit
 it. Cache hits and executions are separately labeled, and session start clears
 the memo before the startup scan can prime it. (#1868)
 
+Bash write attribution recognizes common in-place formatter and fixer commands
+only when their source-file targets are explicit. Bare project-scoped `cargo
+fmt` and `dotnet format` remain unresolvable without a workspace walk. At the
+read guard's FileTime gate, uniquely resolved live `oldText` is stronger content
+evidence and softens staleness; ambiguous or missing `oldText` never does.
+(#1903)
+
 Coverage markers are deduped per session by normalized kind, file, and the
 normalized silent-scanner set. A changed set admits a new marker, and a marker
 is appended after primary diagnostics so both remain visible.

--- a/clients/bash-file-access.ts
+++ b/clients/bash-file-access.ts
@@ -4,7 +4,8 @@
  *
  *   - VIEW commands (cat/head/tail/sed -n) → reads, recorded with the exact line
  *     range shown (like the Read tool's delivered range).
- *   - WRITE commands (redirects, tee, sed -i, cp/mv dest, touch) → the agent
+ *   - WRITE commands (redirects, tee, sed -i, cp/mv dest, touch, and explicit
+ *     in-place formatter/fixer targets) → the agent
  *     authored/owns the resulting file, exactly like the Write tool — these are
  *     registered via noteCreatedFile + recordWritten so a follow-up edit is not
  *     blocked.
@@ -167,6 +168,41 @@ function parseCountFlag(token: string): number | undefined {
 
 function commandSegments(command: string): string[][] {
 	return tokenizeShellCommand(command).map((segment) => segment.tokens);
+}
+
+/** Unwrap the common agent-authored `npx <tool>` launcher form. */
+function unwrapCommand(tokens: string[]): { verb: string; args: string[] } {
+	let verb = path.basename(tokens[0] ?? "");
+	let args = tokens.slice(1);
+	if (verb === "npx") {
+		while (args[0] === "-y" || args[0] === "--yes") args = args.slice(1);
+		verb = path.basename(args[0] ?? "");
+		args = args.slice(1);
+	}
+	return { verb, args };
+}
+
+/**
+ * Return source-file operands while excluding values consumed by known options.
+ * This stays deliberately narrower than a general CLI parser: only formatter
+ * options whose values can themselves look like source files belong here.
+ */
+function formatterFileArgs(
+	args: string[],
+	start = 0,
+	valueOptions: ReadonlySet<string> = new Set(),
+): string[] {
+	const files: string[] = [];
+	for (let i = start; i < args.length; i += 1) {
+		const arg = args[i] ?? "";
+		if (valueOptions.has(arg)) {
+			i += 1;
+			continue;
+		}
+		if (arg === "--" || arg.startsWith("-")) continue;
+		files.push(arg);
+	}
+	return files;
 }
 
 /** Find redirect targets without treating quoted `>` characters as syntax. */
@@ -468,7 +504,8 @@ export function extractGrepSearchReadsFromOutput(
  * Extract files a bash command WROTE/created, so the read-guard can treat them
  * as authored by the agent (mirrors the Write tool). Handles:
  *   redirects: `> FILE`, `>> FILE`, `N> FILE`, `&> FILE` (with or without space)
- *   tee [-a] FILE...,  sed -i ... FILE,  cp/mv/install ... DEST,  touch FILE...
+ *   tee [-a] FILE..., sed -i ... FILE, cp/mv/install ... DEST, touch FILE...,
+ *   and common in-place formatter/fixer invocations with explicit file targets.
  *
  * Returns absolute paths. The file need not exist yet (it may be created) —
  * existence is confirmed later by recordWritten at tool_result time.
@@ -498,8 +535,7 @@ export function extractWrittenPathsFromCommand(
 	}
 	for (const tokens of commandSegments(command)) {
 		if (tokens.length === 0) continue;
-		const verb = path.basename(tokens[0] ?? "");
-		const args = tokens.slice(1);
+		const { verb, args } = unwrapCommand(tokens);
 
 		if (verb === "tee" || verb === "touch") {
 			for (const a of args) if (!a.startsWith("-")) add(a);
@@ -516,6 +552,47 @@ export function extractWrittenPathsFromCommand(
 			// flag this same branch already ignores.
 			const files = args.filter((a) => !a.startsWith("-"));
 			if (files.length >= 1) add(files[files.length - 1]); // destination
+		} else if (verb === "biome") {
+			const sub = args[0];
+			if ((sub === "format" || sub === "check") && args.includes("--write")) {
+				for (const file of formatterFileArgs(args, 1, new Set(["--config-path"]))) add(file);
+			}
+		} else if (verb === "prettier" && args.includes("--write")) {
+			for (const file of formatterFileArgs(args, 0, new Set(["--config", "--ignore-path", "--parser", "--plugin"]))) add(file);
+		} else if (verb === "eslint" && args.includes("--fix")) {
+			for (const file of formatterFileArgs(args, 0, new Set(["--config", "--ignore-path", "--parser", "--plugin"]))) add(file);
+		} else if (verb === "ruff") {
+			const sub = args[0];
+			if (sub === "format" || args.includes("--fix")) {
+				const start = sub === "format" || sub === "check" ? 1 : 0;
+				for (const file of formatterFileArgs(args, start, new Set(["--config"]))) add(file);
+			}
+		} else if (verb === "gofmt" && args.includes("-w")) {
+			for (const file of formatterFileArgs(args)) add(file);
+		} else if (verb === "cargo" && args[0] === "fmt") {
+			// Bare cargo fmt is project-scoped and cannot be enumerated without a
+			// filesystem walk. Only explicit rustfmt operands after `--` are safe.
+			const separator = args.indexOf("--");
+			if (separator >= 0) {
+				for (const file of formatterFileArgs(args, separator + 1, new Set(["--edition", "--config-path"]))) add(file);
+			}
+		} else if (verb === "rustfmt") {
+			for (const file of formatterFileArgs(args, 0, new Set(["--edition", "--config-path"]))) add(file);
+		} else if (verb === "black") {
+			for (const file of formatterFileArgs(args, 0, new Set(["--config", "--exclude", "--include", "--line-length", "--target-version"]))) add(file);
+		} else if (verb === "clang-format" && args.includes("-i")) {
+			for (const file of formatterFileArgs(args, 0, new Set(["--style", "--fallback-style", "--assume-filename"]))) add(file);
+		} else if (verb === "dotnet" && args[0] === "format") {
+			// dotnet format is normally solution-scoped. `--include` is the one
+			// invocation form that provides attributable source paths.
+			for (let i = 1; i < args.length; i += 1) {
+				if (args[i] === "--include" && args[i + 1]) {
+					for (const file of (args[i + 1] ?? "").split(",")) add(file);
+					i += 1;
+				} else if (args[i]?.startsWith("--include=")) {
+					for (const file of (args[i] ?? "").slice("--include=".length).split(",")) add(file);
+				}
+			}
 		} else if (verb === "git") {
 			// git ops that REWRITE working-tree files with explicit paths:
 			//   git checkout [<ref>] -- <files>   git restore [opts] <files>

--- a/clients/read-guard.ts
+++ b/clients/read-guard.ts
@@ -698,9 +698,16 @@ export class ReadGuard {
 		// 2. FileTime check (actual staleness)
 		let ignoredOwnEditStaleness = false;
 		let ignoredHashStaleness = false;
+		let ignoredOldTextResolvedStaleness = false;
 		if (this.fileTime.hasChanged(filePath)) {
 			const lastRead = fileReads[fileReads.length - 1];
-			if (this.canTreatStalenessAsOwnPriorEdit(filePath, lastRead.timestamp)) {
+			if (options?.oldTextResolved === true) {
+				// The host-facing preflight sets this only after oldText resolves to
+				// exactly one span in the live bytes. That content evidence is newer
+				// and stronger than FileTime's coarse external-write signal, matching
+				// the skipSnapshotCheck exception at the later range-stale gate.
+				ignoredOldTextResolvedStaleness = true;
+			} else if (this.canTreatStalenessAsOwnPriorEdit(filePath, lastRead.timestamp)) {
 				ignoredOwnEditStaleness = true;
 			} else if (
 				this.canIgnoreStalenessByHashes(
@@ -850,10 +857,15 @@ export class ReadGuard {
 
 		const verdict = this.allow();
 		this.recordVerdict(filePath, "edit", touchedLines, verdict, {
-			reasonKind: viaSymbol ? "symbol_coverage" : "range_coverage",
+			reasonKind: ignoredOldTextResolvedStaleness
+				? "file_modified_oldtext_unique"
+				: viaSymbol
+					? "symbol_coverage"
+					: "range_coverage",
 			viaSymbol,
 			ignoredOwnEditStaleness,
 			ignoredHashStaleness,
+			oldTextResolved: ignoredOldTextResolvedStaleness,
 		});
 		return verdict;
 	}

--- a/tests/clients/bash-file-access.test.ts
+++ b/tests/clients/bash-file-access.test.ts
@@ -191,6 +191,19 @@ describe("extractWrittenPathsFromCommand — bash writes", () => {
 		["git restore <file>", (f) => `git restore ${f}`],
 		["git restore --staged <file>", (f) => `git restore --staged ${f}`],
 		["git mv destination (#1668 review F2)", (f) => `git mv /other/src.ts ${f}`],
+		["biome format --write", (f) => `npx biome format --write ${f}`],
+		["biome check --write", (f) => `biome check --write ${f}`],
+		["prettier --write", (f) => `prettier --write ${f}`],
+		["eslint --fix", (f) => `eslint --fix ${f}`],
+		["ruff format", (f) => `ruff format ${f}`],
+		["ruff check --fix", (f) => `ruff check --fix ${f}`],
+		["ruff --fix", (f) => `ruff --fix ${f}`],
+		["gofmt -w", (f) => `gofmt -w ${f}`],
+		["cargo fmt explicit path", (f) => `cargo fmt -- ${f}`],
+		["rustfmt explicit path", (f) => `rustfmt ${f}`],
+		["black", (f) => `black ${f}`],
+		["clang-format -i", (f) => `clang-format -i ${f}`],
+		["dotnet format --include", (f) => `dotnet format --include ${f}`],
 	];
 
 	for (const [label, build] of cases) {
@@ -233,6 +246,21 @@ describe("extractWrittenPathsFromCommand — bash writes", () => {
 		expect(extractWrittenPathsFromCommand(`git stash pop`, tmp)).toHaveLength(
 			0,
 		);
+	});
+
+	it("does not invent paths for project-scoped formatter invocations", () => {
+		expect(extractWrittenPathsFromCommand("cargo fmt", tmp)).toHaveLength(0);
+		expect(extractWrittenPathsFromCommand("dotnet format", tmp)).toHaveLength(0);
+		expect(extractWrittenPathsFromCommand("rustfmt", tmp)).toHaveLength(0);
+	});
+
+	it("does not register formatter operands without their write flag", () => {
+		const f = pathIn("a.ts");
+		expect(extractWrittenPathsFromCommand(`biome format ${f}`, tmp)).not.toContain(f);
+		expect(extractWrittenPathsFromCommand(`prettier ${f}`, tmp)).not.toContain(f);
+		expect(extractWrittenPathsFromCommand(`eslint ${f}`, tmp)).not.toContain(f);
+		expect(extractWrittenPathsFromCommand(`gofmt ${f}`, tmp)).not.toContain(f);
+		expect(extractWrittenPathsFromCommand(`clang-format ${f}`, tmp)).not.toContain(f);
 	});
 });
 

--- a/tests/clients/bash-read-guard-integration.test.ts
+++ b/tests/clients/bash-read-guard-integration.test.ts
@@ -23,12 +23,14 @@ vi.mock("../../clients/read-guard-logger.js", () => ({
 	getReadGuardLogPath: vi.fn(() => "/dev/null"),
 }));
 
+const fileTimeState = vi.hoisted(() => ({ hasChanged: false }));
+
 // Mock FileTime so range coverage (not mtime) decides the verdict — same as
 // read-guard.test.ts.
 vi.mock("../../clients/file-time.js", () => ({
 	createFileTime: () => ({
 		read: vi.fn(),
-		hasChanged: vi.fn(() => false),
+		hasChanged: vi.fn(() => fileTimeState.hasChanged),
 		assert: vi.fn(),
 		get: vi.fn(),
 	}),
@@ -76,6 +78,7 @@ function applyBashAccess(
 }
 
 beforeEach(() => {
+	fileTimeState.hasChanged = false;
 	tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-brgi-"));
 });
 afterEach(() => {
@@ -103,6 +106,18 @@ describe("bash file access → read-guard", () => {
 		const f = fileWithLines("a.ts", 100);
 		applyBashAccess(guard, `echo "x" > ${f}`, tmp);
 		expect(guard.checkEdit(f, [40, 40]).action).toBe("allow");
+	});
+
+	it("a byte-identical npx biome format write refreshes the read stamp (#1903 B1)", () => {
+		const guard = createReadGuard("s");
+		const f = fileWithLines("plane.ts", 100);
+		applyBashAccess(guard, `cat ${f}`, tmp);
+		// The formatter rewrites the inode/mtime but produces identical bytes.
+		fs.writeFileSync(f, fs.readFileSync(f));
+		fileTimeState.hasChanged = true;
+		applyBashAccess(guard, `npx biome format --write ${f}`, tmp);
+
+		expect(guard.checkEdit(f).action).toBe("allow");
 	});
 
 	it("ls (no content) does NOT unblock an edit", () => {

--- a/tests/clients/read-guard.test.ts
+++ b/tests/clients/read-guard.test.ts
@@ -245,6 +245,56 @@ describe("ReadGuard", () => {
 				env.cleanup();
 			}
 		});
+
+		it("softens file_modified when oldText uniquely resolves against live bytes", () => {
+			const env = setupTestEnvironment("read-guard-oldtext-live-");
+			try {
+				const filePath = path.join(env.tmpDir, "api.ts");
+				fs.writeFileSync(filePath, "alpha\nunique target\nomega\n");
+				const guard = createReadGuard("test-session");
+				guard.recordRead(createReadRecord(filePath, { effectiveLimit: 1 }));
+				fileTimeState.hasChanged = true;
+
+				const verdict = guard.checkEdit(filePath, [2, 2], undefined, {
+					skipSnapshotCheck: true,
+					oldTextResolved: true,
+				});
+
+				expect(verdict.action).toBe("allow");
+				expect(logReadGuardEvent).toHaveBeenCalledWith(
+					expect.objectContaining({
+						event: "edit_allowed",
+						metadata: expect.objectContaining({
+							reasonKind: "file_modified_oldtext_unique",
+							oldTextResolved: true,
+						}),
+					}),
+				);
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("keeps file_modified blocked when oldText does not resolve uniquely", () => {
+			const env = setupTestEnvironment("read-guard-oldtext-unresolved-");
+			try {
+				const filePath = path.join(env.tmpDir, "api.ts");
+				fs.writeFileSync(filePath, "alpha\nduplicate\nduplicate\n");
+				const guard = createReadGuard("test-session");
+				guard.recordRead(createReadRecord(filePath, { effectiveLimit: 1 }));
+				fileTimeState.hasChanged = true;
+
+				const verdict = guard.checkEdit(filePath, [2, 2], undefined, {
+					skipSnapshotCheck: false,
+					oldTextResolved: false,
+				});
+
+				expect(verdict.action).toBe("block");
+				expect(verdict.reason).toContain("File modified since read");
+			} finally {
+				env.cleanup();
+			}
+		});
 	});
 
 	describe("Range snapshot validation building blocks", () => {


### PR DESCRIPTION
## Outcome

Bash-invoked in-place formatters now refresh the read guard's write stamp when
the command names resolvable source files. A uniquely resolved live `oldText`
also satisfies stale FileTime evidence. Missing or ambiguous content evidence
still blocks.

## Formatter verdicts

| Member | Verdict | Written paths |
| --- | --- | --- |
| `biome format --write` | Added | Explicit source-file operands; `npx biome` is unwrapped. |
| `biome check --write` | Added | Explicit source-file operands. |
| `prettier --write` | Added | Explicit source-file operands; known option values are excluded. |
| `eslint --fix` | Added | Explicit source-file operands; known option values are excluded. |
| `ruff format` | Added | Explicit source-file operands. |
| `ruff check --fix` / `ruff --fix` | Added | Explicit source-file operands. |
| `gofmt -w` | Added | Explicit source-file operands. |
| `cargo fmt` | Recognized, partly resolvable | Explicit operands after `--` are recorded. Bare project-scoped runs are skipped because enumerating writes requires a workspace walk. |
| `rustfmt` | Added when resolvable | Explicit source-file operands are recorded. A fileless invocation is skipped because it does not identify a disk target. |
| `black` | Added when resolvable | Explicit source-file operands are recorded. Directories and globs are not expanded. |
| `clang-format -i` | Added | Explicit source-file operands. |
| `dotnet format` | Recognized, partly resolvable | Source files supplied by `--include` are recorded. A bare solution-scoped run is skipped because it does not identify its write set. |

## Safety model

- The new FileTime exception reads the existing `contentMatchValidated` bridge.
  That bridge is set only when host-space `oldText` resolution is unique.
- The allow record uses the distinct reason
  `file_modified_oldtext_unique`.
- A false or absent unique-resolution signal retains the existing
  `file_modified` hard block.
- Formatter option values, project roots, directories, and unexpanded globs do
  not become synthetic source writes.

## Red-first and mutation proof

Pre-fix regression run:

```text
Test Files  2 failed | 1 passed (3)
Tests  13 failed | 120 passed (133)
FAIL ... registers biome format --write
AssertionError: expected [] to include 'C:\Users\apman\AppData\Local\Temp\pi-…'
FAIL ... softens file_modified when oldText uniquely resolves against live bytes
AssertionError: expected 'block' to be 'allow' // Object.is equality
Expected: "allow"
Received: "block"
```

Formatter-member mutation (`prettier` arm disabled):

```text
Test Files  1 failed (1)
Tests  1 failed | 65 skipped (66)
FAIL ... registers prettier --write
AssertionError: expected [] to include 'C:\Users\apman\AppData\Local\Temp\pi-…'
```

Uniqueness mutation (`=== true` weakened to `!== undefined`):

```text
Test Files  1 failed (1)
Tests  1 failed | 60 skipped (61)
FAIL ... keeps file_modified blocked when oldText does not resolve uniquely
AssertionError: expected 'allow' to be 'block' // Object.is equality
Expected: "block"
Received: "allow"
```

## Verification

- `npm run lint`
- `npm run build`
- 11 targeted Vitest files: read guard, bash file access/integration,
  runtime-tool-call, session-state conformance, and changelog validation
- 330 tests passed
- Full suite intentionally not run, as requested in #1903.

## Disclosure

This change was implemented by OpenAI Codex under maintainer direction and
review.

Closes #1903
