### PR TITLE
feat(ci): merge-train warden — mechanical DIRTY/red-CI/BEHIND handling (refs #1844)

### DIFF
--- a/.changelog/feat-1844-merge-train-warden.md
+++ b/.changelog/feat-1844-merge-train-warden.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Merge-train warden (refs #1844)** — A scheduled workflow now sweeps every open PR every 10 minutes and mechanizes what a human was doing by hand during the release drive: label and comment once (deduped) when a PR turns merge-conflicted (`mergeStateStatus: DIRTY`), call the native update-branch API when an armed auto-merge PR falls behind, and label and comment once (deduped) when a required check (`Unit tests`, `Lint & type-check`) fails on the current head. It never resolves conflicts, merges, or pushes to a PR branch. A new fast-fail CI job validates `.changelog/` fragments in under a second, ahead of the full Unit-tests lap, so a malformed fragment fails fast instead of after a full suite run.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -72,3 +72,9 @@
 - name: breaking
   color: b60205
   description: Breaking change
+- name: conflict
+  color: e11d21
+  description: Merge-train warden - mergeStateStatus is DIRTY; required checks are silently skipped until resolved
+- name: red-ci
+  color: e11d21
+  description: Merge-train warden - a required check is failing on the current head

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,26 @@ jobs:
       - name: Validate per-issue close keywords
         run: node scripts/check-close-keywords.mjs --lint-pr
 
+  # #1844: the changelog-fragment format error hit four PRs in one day, each
+  # costing a full ~4-minute Unit-tests lap to discover. This job runs ONLY
+  # the fragment parser (no `npm install`, no `npm run build` -- it is pure
+  # Node against .changelog/*.md) so a bad fragment fails in seconds. It is
+  # additive early signal, not a replacement for the Unit-tests job below,
+  # which still runs the full changelog-entries.test.ts as part of the suite.
+  changelog-fragment-fastfail:
+    name: Changelog fragment (fast-fail)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Validate changelog fragments
+        run: node scripts/check-changelog-fragments.mjs
+
   lint-and-typecheck:
     name: Lint & type-check
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-train-warden.yml
+++ b/.github/workflows/merge-train-warden.yml
@@ -1,0 +1,44 @@
+name: Merge-train warden
+
+# Mechanical version of the checks the maintainer ran session-side across
+# the 2026-08-20 release drive: DIRTY PRs sitting invisible until polled,
+# armed auto-merge PRs falling BEHIND with no automatic nudge, and red CI on
+# an armed PR discovered only by manual polling (#1844). This workflow
+# OBSERVES AND ANNOTATES ONLY -- it never resolves a conflict, never merges,
+# and never pushes to a PR branch. The one exception is the "update branch"
+# call for a PR that already has auto-merge armed, which is the same
+# GitHub-sanctioned button a human clicks in the PR UI.
+#
+# workflow_dispatch is included so this can be smoke-run on demand after
+# merge -- a scheduled trigger cannot be exercised pre-merge (see the PR body
+# for what was and was not testable before this landed).
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  warden:
+    name: Sweep open PRs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      pull-requests: write # label + comment on PRs, call update-branch
+      actions: read # check-run visibility on the head commit
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "22"
+
+      - name: Sweep open PRs for DIRTY / BEHIND / red-CI
+        run: node scripts/merge-train-warden.mjs

--- a/.github/workflows/merge-train-warden.yml
+++ b/.github/workflows/merge-train-warden.yml
@@ -18,6 +18,13 @@ on:
     - cron: "*/10 * * * *"
   workflow_dispatch: {}
 
+# A run still going at the 10-minute mark should finish, not race a fresh
+# one over the same PRs (double-comment risk); the next scheduled tick picks
+# up whatever the first run didn't reach.
+concurrency:
+  group: merge-train-warden
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
@@ -27,7 +34,8 @@ jobs:
     permissions:
       contents: read # checkout
       pull-requests: write # label + comment on PRs, call update-branch
-      actions: read # check-run visibility on the head commit
+      actions: read # workflow-run visibility
+      checks: read # check-run conclusions on the head commit (statusCheckRollup)
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_REPOSITORY: ${{ github.repository }}

--- a/scripts/check-changelog-fragments.mjs
+++ b/scripts/check-changelog-fragments.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Fast-fail changelog-fragment validator (refs #1844).
+//
+// Reuses parseEntry/validateChangelogEntries from rollup-changelog.mjs --
+// the SAME parser tests/scripts/changelog-entries.test.ts exercises and that
+// the release rollup relies on. This script adds no parsing rules of its
+// own; it exists only to run that check standing alone, with no `npm
+// install` and no `npm run build`, so a bad fragment fails in seconds
+// instead of after the full Unit-tests lap (#1844 comment: four PRs in one
+// day paid a full CI lap each for this).
+//
+// Usage: node scripts/check-changelog-fragments.mjs
+
+import { validateChangelogEntries } from "./rollup-changelog.mjs";
+
+try {
+  const entries = validateChangelogEntries();
+  console.log(`changelog fragments OK (${entries.length} entr${entries.length === 1 ? "y" : "ies"} in .changelog/)`);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/lib/merge-train-warden.d.mts
+++ b/scripts/lib/merge-train-warden.d.mts
@@ -1,0 +1,30 @@
+export const CONFLICT_LABEL: string;
+export const RED_CI_LABEL: string;
+export const REQUIRED_CHECKS: string[];
+export const PAGE_SIZE: number;
+export const MAX_PAGES: number;
+
+export type FetchFn = (url: string, init?: { method?: string; body?: string; headers?: Record<string, string> }) => Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
+
+export interface WardenPr {
+	number: number;
+	url: string;
+	headSha: string | undefined;
+	mergeStateStatus: string;
+	autoMergeEnabled: boolean;
+	labels: Set<string>;
+	failingRequiredChecks: Array<{ name: string; url?: string }>;
+}
+
+export type WardenAction =
+	| { type: "add-label"; label: string }
+	| { type: "remove-label"; label: string }
+	| { type: "comment"; body: string }
+	| { type: "update-branch" };
+
+export function fetchOpenPullRequests(fetcher: FetchFn, owner: string, name: string): Promise<WardenPr[]>;
+export function decideActions(pr: WardenPr): WardenAction[];
+export function applyAction(fetcher: FetchFn, owner: string, repo: string, pr: WardenPr, action: WardenAction): Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
+export function runWarden(options: { fetcher: FetchFn; owner: string; repo: string }): Promise<
+	Array<{ number: number; url: string; mergeStateStatus: string; applied: string[]; errors: string[] }>
+>;

--- a/scripts/lib/merge-train-warden.d.mts
+++ b/scripts/lib/merge-train-warden.d.mts
@@ -13,18 +13,32 @@ export interface WardenPr {
 	mergeStateStatus: string;
 	autoMergeEnabled: boolean;
 	labels: Set<string>;
+	checksUnknown: boolean;
 	failingRequiredChecks: Array<{ name: string; url?: string }>;
+	unresolvedRequiredChecks: string[];
 }
 
 export type WardenAction =
 	| { type: "add-label"; label: string }
 	| { type: "remove-label"; label: string }
 	| { type: "comment"; body: string }
-	| { type: "update-branch" };
+	| { type: "update-branch" }
+	| { type: "note"; benign: boolean; message: string };
 
-export function fetchOpenPullRequests(fetcher: FetchFn, owner: string, name: string): Promise<WardenPr[]>;
+export interface WardenError {
+	message: string;
+	benign: boolean;
+}
+
+export interface WardenResult {
+	number: number | null;
+	url: string | null;
+	mergeStateStatus: string | null;
+	applied: string[];
+	errors: WardenError[];
+}
+
+export function fetchOpenPullRequests(fetcher: FetchFn, owner: string, name: string): Promise<{ prs: WardenPr[]; errors: string[] }>;
 export function decideActions(pr: WardenPr): WardenAction[];
 export function applyAction(fetcher: FetchFn, owner: string, repo: string, pr: WardenPr, action: WardenAction): Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
-export function runWarden(options: { fetcher: FetchFn; owner: string; repo: string }): Promise<
-	Array<{ number: number; url: string; mergeStateStatus: string; applied: string[]; errors: string[] }>
->;
+export function runWarden(options: { fetcher: FetchFn; owner: string; repo: string }): Promise<WardenResult[]>;

--- a/scripts/lib/merge-train-warden.mjs
+++ b/scripts/lib/merge-train-warden.mjs
@@ -15,6 +15,13 @@ export const RED_CI_LABEL = "red-ci";
 export const REQUIRED_CHECKS = ["Unit tests", "Lint & type-check"];
 export const PAGE_SIZE = 50;
 export const MAX_PAGES = 4; // 200 open PRs is far above this repo's steady state; bail rather than loop forever.
+// Recorded-but-ok REST failures (review round 1, F4): a closed/deleted PR
+// (404), a label-add racing another tick (409), or update-branch on a fork
+// with maintainer edits off / already up to date (422) are expected noise on
+// a 10-minute cadence, not warden bugs. Only a status OUTSIDE this set marks
+// the scheduled run red, so the run doesn't email every 10 minutes for
+// benign races.
+const BENIGN_HTTP_STATUSES = new Set([404, 409, 422]);
 
 const PR_QUERY = `
 query($owner: String!, $name: String!, $after: String) {
@@ -52,6 +59,11 @@ query($owner: String!, $name: String!, $after: String) {
 }
 `;
 
+// Returns the raw GraphQL payload ({ data, errors }) instead of throwing on
+// `errors` (review round 1, F6): GraphQL can return PARTIAL data alongside
+// errors, and the caller decides how to treat that -- collapsing straight to
+// a throw would crash the bare top-level await in the CLI entry point and
+// lose the whole run's summary instead of skipping the affected page.
 async function graphql(fetcher, query, variables) {
   const response = await fetcher("https://api.github.com/graphql", {
     method: "POST",
@@ -59,18 +71,42 @@ async function graphql(fetcher, query, variables) {
     body: JSON.stringify({ query, variables }),
   });
   if (!response.ok) throw new Error(`GitHub GraphQL API ${response.status}`);
-  const payload = await response.json();
-  if (payload.errors?.length) throw new Error(`GitHub GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`);
-  return payload.data;
+  return response.json();
 }
 
 function normalizePr(node) {
   const labels = new Set((node.labels?.nodes ?? []).map((l) => l.name));
   const headCommit = node.commits?.nodes?.[0]?.commit;
-  const contexts = headCommit?.statusCheckRollup?.contexts?.nodes ?? [];
-  const failingRequiredChecks = contexts
-    .filter((c) => c.__typename === "CheckRun" && REQUIRED_CHECKS.includes(c.name) && c.conclusion === "FAILURE")
-    .map((c) => ({ name: c.name, url: c.detailsUrl }));
+  const rollup = headCommit?.statusCheckRollup;
+  // A null/absent rollup (review round 1, F2) is NOT the same as "zero
+  // failing checks" -- it means GitHub hasn't told us anything about the
+  // head commit's checks yet (permissions gap, brand-new commit, API hiccup).
+  // Collapsing that to "clean" would strip an existing red-ci label on pure
+  // absence of information. checksUnknown lets decideActions distinguish
+  // "confirmed no failures" from "we don't know".
+  const checksUnknown = rollup == null;
+  const contexts = rollup?.contexts?.nodes ?? [];
+  const checkRunsByName = new Map();
+  for (const c of contexts) {
+    if (c.__typename === "CheckRun") checkRunsByName.set(c.name, c);
+  }
+  const failingRequiredChecks = [];
+  // A required check that hasn't reported yet (absent from the rollup) or is
+  // mid-run (conclusion null: queued/in-progress/re-queued) is UNRESOLVED,
+  // not "not failing" (review round 1, F3). Only a settled non-FAILURE
+  // conclusion counts as positive evidence of passing.
+  //
+  // The REQUIRED_CHECKS loop below is the ONLY filter that keeps a failing
+  // non-required check (e.g. SonarCloud) from tripping red-ci (review round
+  // 1, F5) -- it looks up exactly the required names, ignoring every other
+  // key checkRunsByName may hold.
+  const unresolvedRequiredChecks = [];
+  for (const name of REQUIRED_CHECKS) {
+    const run = checkRunsByName.get(name);
+    if (!run) unresolvedRequiredChecks.push(name);
+    else if (run.conclusion === "FAILURE") failingRequiredChecks.push({ name, url: run.detailsUrl });
+    else if (!run.conclusion) unresolvedRequiredChecks.push(name);
+  }
   return {
     number: node.number,
     url: node.url,
@@ -78,28 +114,39 @@ function normalizePr(node) {
     mergeStateStatus: node.mergeStateStatus,
     autoMergeEnabled: Boolean(node.autoMergeRequest),
     labels,
+    checksUnknown,
     failingRequiredChecks,
+    unresolvedRequiredChecks,
   };
 }
 
 /**
  * Single paginated list call (per PR, bounded by MAX_PAGES): rate-limit
  * conscious by construction. If GitHub returns a non-array/malformed page,
- * bail gracefully with whatever was collected rather than throwing away
- * partial progress or looping unboundedly.
+ * a request throws, or a page comes back with partial `errors`, bail
+ * gracefully with whatever PRs were already collected plus a recorded error
+ * -- never throw out of this function (review round 1, F6).
  */
 export async function fetchOpenPullRequests(fetcher, owner, name) {
   const prs = [];
+  const errors = [];
   let after;
   for (let page = 0; page < MAX_PAGES; page++) {
-    const data = await graphql(fetcher, PR_QUERY, { owner, name, after });
-    const connection = data?.repository?.pullRequests;
+    let payload;
+    try {
+      payload = await graphql(fetcher, PR_QUERY, { owner, name, after });
+    } catch (error) {
+      errors.push(`GraphQL request failed: ${error instanceof Error ? error.message : String(error)}`);
+      break;
+    }
+    if (payload?.errors?.length) errors.push(`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`);
+    const connection = payload?.data?.repository?.pullRequests;
     if (!connection || !Array.isArray(connection.nodes)) break;
     for (const node of connection.nodes) prs.push(normalizePr(node));
     if (!connection.pageInfo?.hasNextPage) break;
     after = connection.pageInfo.endCursor;
   }
-  return prs;
+  return { prs, errors };
 }
 
 /**
@@ -107,34 +154,60 @@ export async function fetchOpenPullRequests(fetcher, owner, name) {
  * this is what a test drives without a network mock. Dedupe is structural:
  * a comment is proposed only on the transition INTO a labeled state (label
  * absent -> label needed), never while the label already sits on the PR.
+ * A human removing the label manually re-arms the next comment -- that is
+ * the label's whole job as the dedupe key, so the comment body itself
+ * carries no separate marker to scan for (review round 1, F9).
  */
 export function decideActions(pr) {
   const actions = [];
   const isDirty = pr.mergeStateStatus === "DIRTY";
+  // Recovery requires a POSITIVELY KNOWN non-DIRTY state (review round 1,
+  // F1). GitHub reports mergeStateStatus: UNKNOWN for every open PR for a
+  // few seconds after each push while it recomputes mergeability -- treating
+  // that as "clean again" would strip the conflict label and then
+  // immediately re-add it plus re-comment on the very next tick.
+  const isConfirmedNotDirty = pr.mergeStateStatus !== "DIRTY" && pr.mergeStateStatus !== "UNKNOWN";
   const hasConflictLabel = pr.labels.has(CONFLICT_LABEL);
   if (isDirty && !hasConflictLabel) {
     actions.push({ type: "add-label", label: CONFLICT_LABEL });
     actions.push({
       type: "comment",
-      body: "<!-- pi-lens-merge-train-warden:conflict -->\nThis PR is merge-conflicted; required checks are silently skipped until resolved.",
+      body: "This PR is merge-conflicted; required checks are silently skipped until resolved.",
     });
-  } else if (!isDirty && hasConflictLabel) {
+  } else if (isConfirmedNotDirty && hasConflictLabel) {
     actions.push({ type: "remove-label", label: CONFLICT_LABEL });
   }
+  // mergeStateStatus: UNKNOWN + label present falls through both branches
+  // above: no action either direction, by construction.
 
   if (pr.autoMergeEnabled && pr.mergeStateStatus === "BEHIND") {
     actions.push({ type: "update-branch" });
   }
 
   const hasRedCiLabel = pr.labels.has(RED_CI_LABEL);
-  if (pr.failingRequiredChecks.length > 0 && !hasRedCiLabel) {
+  if (pr.checksUnknown) {
+    // Can't tell clean from errored (review round 1, F2): never strip an
+    // existing red-ci label on missing data, and record why so the run
+    // summary distinguishes "confirmed green" from "didn't check".
+    if (hasRedCiLabel) {
+      actions.push({
+        type: "note",
+        benign: true,
+        message: `PR #${pr.number}: statusCheckRollup missing on the head commit; red-ci recovery check skipped this run`,
+      });
+    }
+  } else if (pr.failingRequiredChecks.length > 0 && !hasRedCiLabel) {
     actions.push({ type: "add-label", label: RED_CI_LABEL });
     const lines = pr.failingRequiredChecks.map((c) => `- **${c.name}** failed${c.url ? ` — ${c.url}` : ""}`);
     actions.push({
       type: "comment",
-      body: `<!-- pi-lens-merge-train-warden:red-ci -->\nA required check is failing on the current head:\n\n${lines.join("\n")}`,
+      body: `A required check is failing on the current head:\n\n${lines.join("\n")}`,
     });
-  } else if (pr.failingRequiredChecks.length === 0 && hasRedCiLabel) {
+  } else if (pr.failingRequiredChecks.length === 0 && pr.unresolvedRequiredChecks.length === 0 && hasRedCiLabel) {
+    // Only remove once every required check has a SETTLED non-failure
+    // conclusion. A re-queued check (conclusion null) stays in
+    // unresolvedRequiredChecks, so this branch does not fire and the label
+    // does not flap while the re-run is in flight (review round 1, F3).
     actions.push({ type: "remove-label", label: RED_CI_LABEL });
   }
 
@@ -153,7 +226,8 @@ async function restJson(fetcher, method, url, body) {
 /**
  * Apply one decided action against the REST API. Every failure is caught by
  * the caller (runWarden) and recorded per-PR -- one PR's API hiccup must
- * never abort the run for every other open PR.
+ * never abort the run for every other open PR. "note" actions carry no API
+ * call and are recorded directly by runWarden.
  */
 export async function applyAction(fetcher, owner, repo, pr, action) {
   const base = `https://api.github.com/repos/${owner}/${repo}`;
@@ -174,22 +248,42 @@ export async function applyAction(fetcher, owner, repo, pr, action) {
 /**
  * Run the warden over every open PR. Returns a per-PR log so the caller can
  * print a run summary; a PR whose API calls fail is recorded but does not
- * stop the sweep over the rest of the list.
+ * stop the sweep over the rest of the list. Each recorded error carries a
+ * `benign` flag (review round 1, F4): a benign HTTP status (see
+ * BENIGN_HTTP_STATUSES) or a "note" is expected noise, never cause for the
+ * scheduled run itself to go red; anything else is a real failure.
  */
 export async function runWarden({ fetcher, owner, repo }) {
-  const prs = await fetchOpenPullRequests(fetcher, owner, repo);
+  const { prs, errors: listErrors } = await fetchOpenPullRequests(fetcher, owner, repo);
   const results = [];
+  if (listErrors.length > 0) {
+    results.push({
+      number: null,
+      url: null,
+      mergeStateStatus: null,
+      applied: [],
+      errors: listErrors.map((message) => ({ message, benign: false })),
+    });
+  }
   for (const pr of prs) {
     const actions = decideActions(pr);
     const applied = [];
     const errors = [];
     for (const action of actions) {
+      if (action.type === "note") {
+        errors.push({ message: action.message, benign: action.benign ?? true });
+        continue;
+      }
       try {
         const response = await applyAction(fetcher, owner, repo, pr, action);
-        if (!response.ok) errors.push(`${action.type} ${action.label ?? ""} -> HTTP ${response.status}`.trim());
-        else applied.push(action.type + (action.label ? `:${action.label}` : ""));
+        if (!response.ok) {
+          const message = `${action.type} ${action.label ?? ""} -> HTTP ${response.status}`.trim();
+          errors.push({ message, benign: BENIGN_HTTP_STATUSES.has(response.status) });
+        } else {
+          applied.push(action.type + (action.label ? `:${action.label}` : ""));
+        }
       } catch (error) {
-        errors.push(`${action.type} -> ${error instanceof Error ? error.message : String(error)}`);
+        errors.push({ message: `${action.type} -> ${error instanceof Error ? error.message : String(error)}`, benign: false });
       }
     }
     results.push({ number: pr.number, url: pr.url, mergeStateStatus: pr.mergeStateStatus, applied, errors });

--- a/scripts/lib/merge-train-warden.mjs
+++ b/scripts/lib/merge-train-warden.mjs
@@ -1,0 +1,198 @@
+/**
+ * Merge-train warden (#1844): the mechanical version of the checks a human
+ * was running session-side across the 2026-08-20 release drive -- polling
+ * open PRs for merge conflicts, stale auto-merge, and red required checks.
+ *
+ * The warden OBSERVES AND ANNOTATES ONLY. It never resolves conflicts,
+ * never merges, and never pushes to a PR branch. The one exception is the
+ * GitHub-sanctioned "update branch" kick for a PR that already has auto-merge
+ * armed and has fallen BEHIND -- that is the same button a human clicks in
+ * the PR UI, exposed here as the API GitHub documents for it.
+ */
+
+export const CONFLICT_LABEL = "conflict";
+export const RED_CI_LABEL = "red-ci";
+export const REQUIRED_CHECKS = ["Unit tests", "Lint & type-check"];
+export const PAGE_SIZE = 50;
+export const MAX_PAGES = 4; // 200 open PRs is far above this repo's steady state; bail rather than loop forever.
+
+const PR_QUERY = `
+query($owner: String!, $name: String!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: OPEN, first: ${PAGE_SIZE}, after: $after, orderBy: { field: UPDATED_AT, direction: DESC }) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        url
+        mergeStateStatus
+        autoMergeRequest { enabledAt }
+        labels(first: 50) { nodes { name } }
+        commits(last: 1) {
+          nodes {
+            commit {
+              oid
+              statusCheckRollup {
+                contexts(first: 100) {
+                  nodes {
+                    __typename
+                    ... on CheckRun {
+                      name
+                      conclusion
+                      detailsUrl
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+async function graphql(fetcher, query, variables) {
+  const response = await fetcher("https://api.github.com/graphql", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!response.ok) throw new Error(`GitHub GraphQL API ${response.status}`);
+  const payload = await response.json();
+  if (payload.errors?.length) throw new Error(`GitHub GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`);
+  return payload.data;
+}
+
+function normalizePr(node) {
+  const labels = new Set((node.labels?.nodes ?? []).map((l) => l.name));
+  const headCommit = node.commits?.nodes?.[0]?.commit;
+  const contexts = headCommit?.statusCheckRollup?.contexts?.nodes ?? [];
+  const failingRequiredChecks = contexts
+    .filter((c) => c.__typename === "CheckRun" && REQUIRED_CHECKS.includes(c.name) && c.conclusion === "FAILURE")
+    .map((c) => ({ name: c.name, url: c.detailsUrl }));
+  return {
+    number: node.number,
+    url: node.url,
+    headSha: headCommit?.oid,
+    mergeStateStatus: node.mergeStateStatus,
+    autoMergeEnabled: Boolean(node.autoMergeRequest),
+    labels,
+    failingRequiredChecks,
+  };
+}
+
+/**
+ * Single paginated list call (per PR, bounded by MAX_PAGES): rate-limit
+ * conscious by construction. If GitHub returns a non-array/malformed page,
+ * bail gracefully with whatever was collected rather than throwing away
+ * partial progress or looping unboundedly.
+ */
+export async function fetchOpenPullRequests(fetcher, owner, name) {
+  const prs = [];
+  let after;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const data = await graphql(fetcher, PR_QUERY, { owner, name, after });
+    const connection = data?.repository?.pullRequests;
+    if (!connection || !Array.isArray(connection.nodes)) break;
+    for (const node of connection.nodes) prs.push(normalizePr(node));
+    if (!connection.pageInfo?.hasNextPage) break;
+    after = connection.pageInfo.endCursor;
+  }
+  return prs;
+}
+
+/**
+ * Decide what the warden should do for one PR. Pure function, no I/O --
+ * this is what a test drives without a network mock. Dedupe is structural:
+ * a comment is proposed only on the transition INTO a labeled state (label
+ * absent -> label needed), never while the label already sits on the PR.
+ */
+export function decideActions(pr) {
+  const actions = [];
+  const isDirty = pr.mergeStateStatus === "DIRTY";
+  const hasConflictLabel = pr.labels.has(CONFLICT_LABEL);
+  if (isDirty && !hasConflictLabel) {
+    actions.push({ type: "add-label", label: CONFLICT_LABEL });
+    actions.push({
+      type: "comment",
+      body: "<!-- pi-lens-merge-train-warden:conflict -->\nThis PR is merge-conflicted; required checks are silently skipped until resolved.",
+    });
+  } else if (!isDirty && hasConflictLabel) {
+    actions.push({ type: "remove-label", label: CONFLICT_LABEL });
+  }
+
+  if (pr.autoMergeEnabled && pr.mergeStateStatus === "BEHIND") {
+    actions.push({ type: "update-branch" });
+  }
+
+  const hasRedCiLabel = pr.labels.has(RED_CI_LABEL);
+  if (pr.failingRequiredChecks.length > 0 && !hasRedCiLabel) {
+    actions.push({ type: "add-label", label: RED_CI_LABEL });
+    const lines = pr.failingRequiredChecks.map((c) => `- **${c.name}** failed${c.url ? ` — ${c.url}` : ""}`);
+    actions.push({
+      type: "comment",
+      body: `<!-- pi-lens-merge-train-warden:red-ci -->\nA required check is failing on the current head:\n\n${lines.join("\n")}`,
+    });
+  } else if (pr.failingRequiredChecks.length === 0 && hasRedCiLabel) {
+    actions.push({ type: "remove-label", label: RED_CI_LABEL });
+  }
+
+  return actions;
+}
+
+async function restJson(fetcher, method, url, body) {
+  const response = await fetcher(url, {
+    method,
+    headers: { accept: "application/vnd.github+json", "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return response;
+}
+
+/**
+ * Apply one decided action against the REST API. Every failure is caught by
+ * the caller (runWarden) and recorded per-PR -- one PR's API hiccup must
+ * never abort the run for every other open PR.
+ */
+export async function applyAction(fetcher, owner, repo, pr, action) {
+  const base = `https://api.github.com/repos/${owner}/${repo}`;
+  switch (action.type) {
+    case "add-label":
+      return restJson(fetcher, "POST", `${base}/issues/${pr.number}/labels`, { labels: [action.label] });
+    case "remove-label":
+      return restJson(fetcher, "DELETE", `${base}/issues/${pr.number}/labels/${encodeURIComponent(action.label)}`);
+    case "comment":
+      return restJson(fetcher, "POST", `${base}/issues/${pr.number}/comments`, { body: action.body });
+    case "update-branch":
+      return restJson(fetcher, "PUT", `${base}/pulls/${pr.number}/update-branch`, { expected_head_sha: pr.headSha });
+    default:
+      throw new Error(`unknown warden action type: ${action.type}`);
+  }
+}
+
+/**
+ * Run the warden over every open PR. Returns a per-PR log so the caller can
+ * print a run summary; a PR whose API calls fail is recorded but does not
+ * stop the sweep over the rest of the list.
+ */
+export async function runWarden({ fetcher, owner, repo }) {
+  const prs = await fetchOpenPullRequests(fetcher, owner, repo);
+  const results = [];
+  for (const pr of prs) {
+    const actions = decideActions(pr);
+    const applied = [];
+    const errors = [];
+    for (const action of actions) {
+      try {
+        const response = await applyAction(fetcher, owner, repo, pr, action);
+        if (!response.ok) errors.push(`${action.type} ${action.label ?? ""} -> HTTP ${response.status}`.trim());
+        else applied.push(action.type + (action.label ? `:${action.label}` : ""));
+      } catch (error) {
+        errors.push(`${action.type} -> ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    results.push({ number: pr.number, url: pr.url, mergeStateStatus: pr.mergeStateStatus, applied, errors });
+  }
+  return results;
+}

--- a/scripts/merge-train-warden.mjs
+++ b/scripts/merge-train-warden.mjs
@@ -6,30 +6,47 @@
 import { appendFileSync } from "node:fs";
 import { runWarden } from "./lib/merge-train-warden.mjs";
 
-const repository = process.env.GITHUB_REPOSITORY;
-const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-if (!repository || !token) throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN/GH_TOKEN are required");
-const [owner, repo] = repository.split("/");
+async function main() {
+  const repository = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!repository || !token) throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN/GH_TOKEN are required");
+  const [owner, repo] = repository.split("/");
 
-const fetcher = (url, init) =>
-  fetch(url, {
-    ...init,
-    headers: { ...init?.headers, authorization: `Bearer ${token}` },
-  });
+  const fetcher = (url, init) =>
+    fetch(url, {
+      ...init,
+      headers: { ...init?.headers, authorization: `Bearer ${token}` },
+    });
 
-const results = await runWarden({ fetcher, owner, repo });
+  const results = await runWarden({ fetcher, owner, repo });
 
-const lines = [`Merge-train warden: swept ${results.length} open PR(s).`];
-for (const r of results) {
-  if (r.applied.length === 0 && r.errors.length === 0) continue;
-  lines.push(`- #${r.number} (${r.mergeStateStatus}) ${r.url}`);
-  if (r.applied.length > 0) lines.push(`  applied: ${r.applied.join(", ")}`);
-  if (r.errors.length > 0) lines.push(`  ERRORS: ${r.errors.join("; ")}`);
+  const lines = [`Merge-train warden: swept ${results.length} record(s) (PR sweep + any list-level errors).`];
+  for (const r of results) {
+    if (r.applied.length === 0 && r.errors.length === 0) continue;
+    lines.push(`- ${r.number === null ? "(list fetch)" : `#${r.number} (${r.mergeStateStatus}) ${r.url}`}`);
+    if (r.applied.length > 0) lines.push(`  applied: ${r.applied.join(", ")}`);
+    if (r.errors.length > 0) {
+      lines.push(`  ${r.errors.map((e) => `${e.benign ? "note" : "ERROR"}: ${e.message}`).join("; ")}`);
+    }
+  }
+  if (lines.length === 1) lines.push("No PR needed a warden action this run.");
+  const summary = lines.join("\n");
+  console.log(summary);
+  if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
+
+  // Only a NON-benign error marks the scheduled run red (review round 1, F4)
+  // -- a closed PR racing a label call, or an update-branch 422 on a fork,
+  // is expected noise on a 10-minute cadence, not a warden failure worth
+  // emailing about every tick.
+  const hadFatalErrors = results.some((r) => r.errors.some((e) => !e.benign));
+  if (hadFatalErrors) process.exitCode = 1;
 }
-if (lines.length === 1) lines.push("No PR needed a warden action this run.");
-const summary = lines.join("\n");
-console.log(summary);
-if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
 
-const hadErrors = results.some((r) => r.errors.length > 0);
-if (hadErrors) process.exitCode = 1;
+main().catch((error) => {
+  // Defense in depth (review round 1, F6): runWarden already catches and
+  // records everything it can attribute to a specific PR or the list call,
+  // but a startup failure (bad env, DNS) must still fail loudly and visibly
+  // instead of an unhandled-rejection stack trace with no summary line.
+  console.error(`Merge-train warden failed to run: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/merge-train-warden.mjs
+++ b/scripts/merge-train-warden.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// CI entry point for the merge-train warden (#1844). See
+// scripts/lib/merge-train-warden.mjs for the decision logic and
+// .github/workflows/merge-train-warden.yml for the schedule.
+
+import { appendFileSync } from "node:fs";
+import { runWarden } from "./lib/merge-train-warden.mjs";
+
+const repository = process.env.GITHUB_REPOSITORY;
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+if (!repository || !token) throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN/GH_TOKEN are required");
+const [owner, repo] = repository.split("/");
+
+const fetcher = (url, init) =>
+  fetch(url, {
+    ...init,
+    headers: { ...init?.headers, authorization: `Bearer ${token}` },
+  });
+
+const results = await runWarden({ fetcher, owner, repo });
+
+const lines = [`Merge-train warden: swept ${results.length} open PR(s).`];
+for (const r of results) {
+  if (r.applied.length === 0 && r.errors.length === 0) continue;
+  lines.push(`- #${r.number} (${r.mergeStateStatus}) ${r.url}`);
+  if (r.applied.length > 0) lines.push(`  applied: ${r.applied.join(", ")}`);
+  if (r.errors.length > 0) lines.push(`  ERRORS: ${r.errors.join("; ")}`);
+}
+if (lines.length === 1) lines.push("No PR needed a warden action this run.");
+const summary = lines.join("\n");
+console.log(summary);
+if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
+
+const hadErrors = results.some((r) => r.errors.length > 0);
+if (hadErrors) process.exitCode = 1;

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyAction, CONFLICT_LABEL, decideActions, fetchOpenPullRequests, RED_CI_LABEL, runWarden } from "../../scripts/lib/merge-train-warden.mjs";
+import { applyAction, CONFLICT_LABEL, decideActions, fetchOpenPullRequests, MAX_PAGES, RED_CI_LABEL, runWarden } from "../../scripts/lib/merge-train-warden.mjs";
 
 function pr(overrides: Record<string, unknown> = {}) {
 	return {
@@ -9,7 +9,9 @@ function pr(overrides: Record<string, unknown> = {}) {
 		mergeStateStatus: "CLEAN",
 		autoMergeEnabled: false,
 		labels: new Set<string>(),
+		checksUnknown: false,
 		failingRequiredChecks: [] as Array<{ name: string; url?: string }>,
+		unresolvedRequiredChecks: [] as string[],
 		...overrides,
 	};
 }
@@ -30,9 +32,23 @@ describe("merge-train warden decision logic (#1844)", () => {
 		expect(actions).toEqual([]);
 	});
 
-	it("removes the conflict label once the PR is clean again", () => {
+	it("removes the conflict label once the PR is confirmed clean again", () => {
 		const actions = decideActions(pr({ mergeStateStatus: "CLEAN", labels: new Set([CONFLICT_LABEL]) }));
 		expect(actions).toEqual([{ type: "remove-label", label: CONFLICT_LABEL }]);
+	});
+
+	// Review round 1, F1: GitHub reports UNKNOWN for every open PR for a few
+	// seconds after each push while it recomputes mergeability. Treating that
+	// as "clean again" would strip the label, then immediately re-add it and
+	// re-comment on the very next 10-minute tick.
+	it("takes no conflict action while mergeStateStatus is UNKNOWN, even with the label present", () => {
+		const actions = decideActions(pr({ mergeStateStatus: "UNKNOWN", labels: new Set([CONFLICT_LABEL]) }));
+		expect(actions).toEqual([]);
+	});
+
+	it("takes no conflict action while mergeStateStatus is UNKNOWN and unlabeled", () => {
+		const actions = decideActions(pr({ mergeStateStatus: "UNKNOWN" }));
+		expect(actions).toEqual([]);
 	});
 
 	it("kicks update-branch only when auto-merge is armed AND the PR is BEHIND", () => {
@@ -56,14 +72,43 @@ describe("merge-train warden decision logic (#1844)", () => {
 		expect(actions).toEqual([]);
 	});
 
-	it("removes red-ci once every required check is green again", () => {
-		const actions = decideActions(pr({ failingRequiredChecks: [], labels: new Set([RED_CI_LABEL]) }));
+	it("removes red-ci once every required check has a settled non-failure conclusion", () => {
+		const actions = decideActions(pr({ failingRequiredChecks: [], unresolvedRequiredChecks: [], labels: new Set([RED_CI_LABEL]) }));
 		expect(actions).toEqual([{ type: "remove-label", label: RED_CI_LABEL }]);
 	});
 
-	it("never proposes a merge or a push -- only label, comment, and the sanctioned update-branch kick", () => {
-		const allowed = new Set(["add-label", "remove-label", "comment", "update-branch"]);
-		for (const state of ["DIRTY", "BEHIND", "CLEAN", "BLOCKED", "UNSTABLE"]) {
+	// Review round 1, F3: a re-queued required check reports conclusion null
+	// while it reruns. Reading that as "not failing" (empty
+	// failingRequiredChecks) would flap the label off and re-comment on the
+	// next failure, once per re-run.
+	it("does not remove red-ci while a previously-failing required check is unresolved (re-queued)", () => {
+		const actions = decideActions(pr({ failingRequiredChecks: [], unresolvedRequiredChecks: ["Unit tests"], labels: new Set([RED_CI_LABEL]) }));
+		expect(actions).toEqual([]);
+	});
+
+	// Review round 1, F2: a null/absent statusCheckRollup is missing
+	// information, not evidence of a clean run. Must not silently strip an
+	// existing red-ci label; must record why so "confirmed green" and
+	// "didn't check" stay distinguishable in the run summary (an
+	// empty-vs-errored guard).
+	it("does not remove red-ci when the rollup is unknown, and records why", () => {
+		const actions = decideActions(pr({ checksUnknown: true, failingRequiredChecks: [], unresolvedRequiredChecks: [], labels: new Set([RED_CI_LABEL]) }));
+		expect(actions).toEqual([{ type: "note", benign: true, message: expect.stringContaining("statusCheckRollup missing") }]);
+	});
+
+	it("takes no red-ci action when the rollup is unknown and the PR is not labeled (nothing to protect)", () => {
+		const actions = decideActions(pr({ checksUnknown: true, failingRequiredChecks: [], unresolvedRequiredChecks: [] }));
+		expect(actions).toEqual([]);
+	});
+
+	it("still removes red-ci on a genuinely all-green rollup (checksUnknown false) -- distinct from the unknown-rollup case", () => {
+		const actions = decideActions(pr({ checksUnknown: false, failingRequiredChecks: [], unresolvedRequiredChecks: [], labels: new Set([RED_CI_LABEL]) }));
+		expect(actions).toEqual([{ type: "remove-label", label: RED_CI_LABEL }]);
+	});
+
+	it("never proposes a merge or a push -- only label, comment, note, and the sanctioned update-branch kick", () => {
+		const allowed = new Set(["add-label", "remove-label", "comment", "update-branch", "note"]);
+		for (const state of ["DIRTY", "BEHIND", "CLEAN", "BLOCKED", "UNSTABLE", "UNKNOWN"]) {
 			for (const auto of [true, false]) {
 				const actions = decideActions(pr({ mergeStateStatus: state, autoMergeEnabled: auto, failingRequiredChecks: [{ name: "Unit tests" }] }));
 				for (const action of actions) expect(allowed.has(action.type)).toBe(true);
@@ -87,59 +132,132 @@ function fakeGithub(routes: Record<string, unknown>) {
 	return { fetcher, calls };
 }
 
+function checkRun(name: string, conclusion: string | null, detailsUrl = `https://example/${name}`) {
+	return { __typename: "CheckRun", name, conclusion, detailsUrl };
+}
+
+function graphqlPage(nodes: unknown[], hasNextPage = false, endCursor: string | null = null) {
+	return { data: { repository: { pullRequests: { pageInfo: { hasNextPage, endCursor }, nodes } } } };
+}
+
+function prNode(overrides: Record<string, unknown> = {}) {
+	return {
+		number: 7,
+		url: "https://github.com/acme/repo/pull/7",
+		mergeStateStatus: "DIRTY",
+		autoMergeRequest: null,
+		labels: { nodes: [] },
+		commits: { nodes: [{ commit: { oid: "deadbeef", statusCheckRollup: { contexts: { nodes: [] } } } }] },
+		...overrides,
+	};
+}
+
 describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 	it("normalizes a GraphQL page into flat PR records with failing required checks", async () => {
-		const page = {
-			data: {
-				repository: {
-					pullRequests: {
-						pageInfo: { hasNextPage: false, endCursor: null },
-						nodes: [
-							{
-								number: 7,
-								url: "https://github.com/acme/repo/pull/7",
-								mergeStateStatus: "DIRTY",
-								autoMergeRequest: null,
-								labels: { nodes: [] },
-								commits: {
-									nodes: [
-										{
-											commit: {
-												oid: "deadbeef",
-												statusCheckRollup: {
-													contexts: {
-														nodes: [
-															{ __typename: "CheckRun", name: "Unit tests", conclusion: "FAILURE", detailsUrl: "https://example/run/1" },
-															{ __typename: "CheckRun", name: "Lint & type-check", conclusion: "SUCCESS", detailsUrl: "https://example/run/2" },
-														],
-													},
-												},
-											},
-										},
-									],
+		const page = graphqlPage([
+			prNode({
+				commits: {
+					nodes: [
+						{
+							commit: {
+								oid: "deadbeef",
+								statusCheckRollup: {
+									contexts: { nodes: [checkRun("Unit tests", "FAILURE", "https://example/run/1"), checkRun("Lint & type-check", "SUCCESS", "https://example/run/2")] },
 								},
 							},
-						],
-					},
+						},
+					],
 				},
-			},
-		};
+			}),
+		]);
 		const { fetcher } = fakeGithub({ "POST /graphql": page });
-		const prs = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		const { prs, errors } = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(errors).toEqual([]);
 		expect(prs).toEqual([
 			expect.objectContaining({
 				number: 7,
 				mergeStateStatus: "DIRTY",
 				headSha: "deadbeef",
 				autoMergeEnabled: false,
+				checksUnknown: false,
 				failingRequiredChecks: [{ name: "Unit tests", url: "https://example/run/1" }],
+				unresolvedRequiredChecks: [],
 			}),
 		]);
 	});
 
+	// Review round 1, F5: the required-checks filter must actually filter.
+	// Deleting the `REQUIRED_CHECKS.includes(c.name)` guard in normalizePr
+	// (so any failing check counts, including non-required ones) must turn
+	// this test red.
+	it("ignores a failing check that is not in REQUIRED_CHECKS (e.g. SonarCloud)", async () => {
+		const page = graphqlPage([
+			prNode({
+				commits: {
+					nodes: [{ commit: { oid: "deadbeef", statusCheckRollup: { contexts: { nodes: [checkRun("SonarCloud Code Analysis", "FAILURE")] } } } }],
+				},
+			}),
+		]);
+		const { fetcher } = fakeGithub({ "POST /graphql": page });
+		const { prs } = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(prs[0].failingRequiredChecks).toEqual([]);
+		expect(prs[0].unresolvedRequiredChecks).toEqual(["Unit tests", "Lint & type-check"]);
+	});
+
+	it("marks a required check missing from the rollup as unresolved, not passing", async () => {
+		const page = graphqlPage([prNode({ commits: { nodes: [{ commit: { oid: "deadbeef", statusCheckRollup: { contexts: { nodes: [checkRun("Unit tests", "SUCCESS")] } } } }] } })]);
+		const { fetcher } = fakeGithub({ "POST /graphql": page });
+		const { prs } = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(prs[0].failingRequiredChecks).toEqual([]);
+		expect(prs[0].unresolvedRequiredChecks).toEqual(["Lint & type-check"]);
+	});
+
+	it("marks a re-queued required check (conclusion null) as unresolved", async () => {
+		const page = graphqlPage([prNode({ commits: { nodes: [{ commit: { oid: "deadbeef", statusCheckRollup: { contexts: { nodes: [checkRun("Unit tests", null)] } } } }] } })]);
+		const { fetcher } = fakeGithub({ "POST /graphql": page });
+		const { prs } = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(prs[0].unresolvedRequiredChecks).toContain("Unit tests");
+		expect(prs[0].failingRequiredChecks).toEqual([]);
+	});
+
+	it("flags checksUnknown when statusCheckRollup is null", async () => {
+		const page = graphqlPage([prNode({ commits: { nodes: [{ commit: { oid: "deadbeef", statusCheckRollup: null } }] } })]);
+		const { fetcher } = fakeGithub({ "POST /graphql": page });
+		const { prs } = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(prs[0].checksUnknown).toBe(true);
+	});
+
 	it("bails gracefully on a malformed page instead of throwing", async () => {
 		const { fetcher } = fakeGithub({ "POST /graphql": { data: { repository: { pullRequests: { nodes: "not-an-array" } } } } });
-		await expect(fetchOpenPullRequests(fetcher, "acme", "repo")).resolves.toEqual([]);
+		await expect(fetchOpenPullRequests(fetcher, "acme", "repo")).resolves.toEqual({ prs: [], errors: [] });
+	});
+
+	// Review round 1, F6: GraphQL can return partial `data` alongside
+	// `errors`. This must be skip-and-record, not an uncaught throw out of
+	// the bare top-level await in the CLI entry point.
+	it("records GraphQL errors instead of throwing, keeping any partial data collected", async () => {
+		const { fetcher } = fakeGithub({ "POST /graphql": { data: { repository: { pullRequests: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [prNode({ number: 1 })] } } }, errors: [{ message: "some field errored" }] } });
+		const { prs, errors } = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(prs).toHaveLength(1);
+		expect(errors[0]).toContain("some field errored");
+	});
+
+	it("records a thrown GraphQL request failure instead of propagating", async () => {
+		const fetcher = async () => {
+			throw new Error("network down");
+		};
+		const { prs, errors } = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(prs).toEqual([]);
+		expect(errors[0]).toContain("network down");
+	});
+
+	// Review round 1, F8: pin MAX_PAGES with a fixture that counts calls
+	// against an always-hasNextPage response, so lowering/raising the loop
+	// bound independently of the exported constant turns this red.
+	it("stops paginating at exactly MAX_PAGES calls when every page claims hasNextPage", async () => {
+		const { fetcher, calls } = fakeGithub({ "POST /graphql": graphqlPage([], true, "cursor") });
+		await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(calls).toHaveLength(MAX_PAGES);
 	});
 
 	it("applyAction issues the exact REST call for each action type", async () => {
@@ -158,27 +276,35 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 	});
 
 	it("records one PR's API failure without aborting the sweep over the rest", async () => {
-		const page = {
-			data: {
-				repository: {
-					pullRequests: {
-						pageInfo: { hasNextPage: false, endCursor: null },
-						nodes: [
-							{ number: 1, url: "u1", mergeStateStatus: "DIRTY", autoMergeRequest: null, labels: { nodes: [] }, commits: { nodes: [] } },
-							{ number: 2, url: "u2", mergeStateStatus: "DIRTY", autoMergeRequest: null, labels: { nodes: [] }, commits: { nodes: [] } },
-						],
-					},
-				},
-			},
-		};
+		const page = graphqlPage([prNode({ number: 1, url: "u1" }), prNode({ number: 2, url: "u2" })]);
 		const { fetcher } = fakeGithub({
 			"POST /graphql": page,
-			"POST /repos/acme/repo/issues/1/labels": () => ({ ok: false, status: 422, json: async () => ({}) }),
+			"POST /repos/acme/repo/issues/1/labels": () => ({ ok: false, status: 500, json: async () => ({}) }),
 		});
 		const results = await runWarden({ fetcher, owner: "acme", repo: "repo" });
 		expect(results).toHaveLength(2);
-		expect(results[0].errors.length).toBeGreaterThan(0);
+		expect(results[0].errors).toEqual([{ message: expect.stringContaining("HTTP 500"), benign: false }]);
 		expect(results[1].errors).toEqual([]);
 		expect(results[1].applied).toContain(`add-label:${CONFLICT_LABEL}`);
+	});
+
+	// Review round 1, F4: a closed/deleted PR (404), a racing label add (409),
+	// or an update-branch on a fork with maintainer edits off (422) are
+	// expected noise on a 10-minute cadence -- they must be recorded but must
+	// NOT be counted as a reason for the scheduled run to exit non-zero.
+	it("classifies 404/409/422 REST failures as benign, and everything else as fatal", async () => {
+		const page = graphqlPage([prNode({ number: 1 })]);
+		const { fetcher } = fakeGithub({
+			"POST /graphql": page,
+			"POST /repos/acme/repo/issues/1/labels": () => ({ ok: false, status: 404, json: async () => ({}) }),
+		});
+		const results = await runWarden({ fetcher, owner: "acme", repo: "repo" });
+		expect(results[0].errors).toEqual([{ message: expect.stringContaining("HTTP 404"), benign: true }]);
+	});
+
+	it("records a list-level GraphQL error as its own result entry with number: null", async () => {
+		const { fetcher } = fakeGithub({ "POST /graphql": { data: null, errors: [{ message: "resource not accessible" }] } });
+		const results = await runWarden({ fetcher, owner: "acme", repo: "repo" });
+		expect(results).toEqual([{ number: null, url: null, mergeStateStatus: null, applied: [], errors: [{ message: expect.stringContaining("resource not accessible"), benign: false }] }]);
 	});
 });

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { applyAction, CONFLICT_LABEL, decideActions, fetchOpenPullRequests, RED_CI_LABEL, runWarden } from "../../scripts/lib/merge-train-warden.mjs";
+
+function pr(overrides: Record<string, unknown> = {}) {
+	return {
+		number: 1,
+		url: "https://github.com/acme/repo/pull/1",
+		headSha: "abc123",
+		mergeStateStatus: "CLEAN",
+		autoMergeEnabled: false,
+		labels: new Set<string>(),
+		failingRequiredChecks: [] as Array<{ name: string; url?: string }>,
+		...overrides,
+	};
+}
+
+describe("merge-train warden decision logic (#1844)", () => {
+	it("labels and comments once when a clean PR turns DIRTY", () => {
+		const actions = decideActions(pr({ mergeStateStatus: "DIRTY" }));
+		expect(actions).toEqual([
+			{ type: "add-label", label: CONFLICT_LABEL },
+			expect.objectContaining({ type: "comment", body: expect.stringContaining("merge-conflicted") }),
+		]);
+	});
+
+	// Dedupe by label presence: mutating this to `false` (always re-add/comment)
+	// must turn this test red -- that is the vacuous-guard screen.
+	it("does not re-label or re-comment a PR already labeled conflict", () => {
+		const actions = decideActions(pr({ mergeStateStatus: "DIRTY", labels: new Set([CONFLICT_LABEL]) }));
+		expect(actions).toEqual([]);
+	});
+
+	it("removes the conflict label once the PR is clean again", () => {
+		const actions = decideActions(pr({ mergeStateStatus: "CLEAN", labels: new Set([CONFLICT_LABEL]) }));
+		expect(actions).toEqual([{ type: "remove-label", label: CONFLICT_LABEL }]);
+	});
+
+	it("kicks update-branch only when auto-merge is armed AND the PR is BEHIND", () => {
+		expect(decideActions(pr({ mergeStateStatus: "BEHIND", autoMergeEnabled: true }))).toContainEqual({ type: "update-branch" });
+		expect(decideActions(pr({ mergeStateStatus: "BEHIND", autoMergeEnabled: false }))).not.toContainEqual({ type: "update-branch" });
+		expect(decideActions(pr({ mergeStateStatus: "CLEAN", autoMergeEnabled: true }))).not.toContainEqual({ type: "update-branch" });
+	});
+
+	it("labels and comments once when a required check fails, naming it with its run link", () => {
+		const actions = decideActions(pr({ failingRequiredChecks: [{ name: "Unit tests", url: "https://example/run/9" }] }));
+		expect(actions).toEqual([
+			{ type: "add-label", label: RED_CI_LABEL },
+			expect.objectContaining({ type: "comment", body: expect.stringContaining("Unit tests") }),
+		]);
+		const commentAction = actions[1] as { body: string };
+		expect(commentAction.body).toContain("https://example/run/9");
+	});
+
+	it("does not re-label or re-comment a PR already labeled red-ci", () => {
+		const actions = decideActions(pr({ failingRequiredChecks: [{ name: "Unit tests" }], labels: new Set([RED_CI_LABEL]) }));
+		expect(actions).toEqual([]);
+	});
+
+	it("removes red-ci once every required check is green again", () => {
+		const actions = decideActions(pr({ failingRequiredChecks: [], labels: new Set([RED_CI_LABEL]) }));
+		expect(actions).toEqual([{ type: "remove-label", label: RED_CI_LABEL }]);
+	});
+
+	it("never proposes a merge or a push -- only label, comment, and the sanctioned update-branch kick", () => {
+		const allowed = new Set(["add-label", "remove-label", "comment", "update-branch"]);
+		for (const state of ["DIRTY", "BEHIND", "CLEAN", "BLOCKED", "UNSTABLE"]) {
+			for (const auto of [true, false]) {
+				const actions = decideActions(pr({ mergeStateStatus: state, autoMergeEnabled: auto, failingRequiredChecks: [{ name: "Unit tests" }] }));
+				for (const action of actions) expect(allowed.has(action.type)).toBe(true);
+			}
+		}
+	});
+});
+
+function fakeGithub(routes: Record<string, unknown>) {
+	const calls: Array<{ method: string; url: string; body?: unknown }> = [];
+	const fetcher = async (url: string, init?: { method?: string; body?: string }) => {
+		const method = init?.method ?? "GET";
+		const body = init?.body ? JSON.parse(init.body) : undefined;
+		calls.push({ method, url, body });
+		const key = `${method} ${url.replace("https://api.github.com", "").split("?")[0]}`;
+		const entry = routes[key];
+		if (entry === undefined) return { ok: true, status: 200, json: async () => ({}) };
+		if (typeof entry === "function") return entry(body);
+		return { ok: true, status: 200, json: async () => entry };
+	};
+	return { fetcher, calls };
+}
+
+describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
+	it("normalizes a GraphQL page into flat PR records with failing required checks", async () => {
+		const page = {
+			data: {
+				repository: {
+					pullRequests: {
+						pageInfo: { hasNextPage: false, endCursor: null },
+						nodes: [
+							{
+								number: 7,
+								url: "https://github.com/acme/repo/pull/7",
+								mergeStateStatus: "DIRTY",
+								autoMergeRequest: null,
+								labels: { nodes: [] },
+								commits: {
+									nodes: [
+										{
+											commit: {
+												oid: "deadbeef",
+												statusCheckRollup: {
+													contexts: {
+														nodes: [
+															{ __typename: "CheckRun", name: "Unit tests", conclusion: "FAILURE", detailsUrl: "https://example/run/1" },
+															{ __typename: "CheckRun", name: "Lint & type-check", conclusion: "SUCCESS", detailsUrl: "https://example/run/2" },
+														],
+													},
+												},
+											},
+										},
+									],
+								},
+							},
+						],
+					},
+				},
+			},
+		};
+		const { fetcher } = fakeGithub({ "POST /graphql": page });
+		const prs = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(prs).toEqual([
+			expect.objectContaining({
+				number: 7,
+				mergeStateStatus: "DIRTY",
+				headSha: "deadbeef",
+				autoMergeEnabled: false,
+				failingRequiredChecks: [{ name: "Unit tests", url: "https://example/run/1" }],
+			}),
+		]);
+	});
+
+	it("bails gracefully on a malformed page instead of throwing", async () => {
+		const { fetcher } = fakeGithub({ "POST /graphql": { data: { repository: { pullRequests: { nodes: "not-an-array" } } } } });
+		await expect(fetchOpenPullRequests(fetcher, "acme", "repo")).resolves.toEqual([]);
+	});
+
+	it("applyAction issues the exact REST call for each action type", async () => {
+		const { fetcher, calls } = fakeGithub({});
+		const record = pr({ number: 5, headSha: "abc123" });
+		await applyAction(fetcher, "acme", "repo", record, { type: "add-label", label: CONFLICT_LABEL });
+		await applyAction(fetcher, "acme", "repo", record, { type: "remove-label", label: CONFLICT_LABEL });
+		await applyAction(fetcher, "acme", "repo", record, { type: "comment", body: "hi" });
+		await applyAction(fetcher, "acme", "repo", record, { type: "update-branch" });
+		expect(calls).toEqual([
+			{ method: "POST", url: "https://api.github.com/repos/acme/repo/issues/5/labels", body: { labels: [CONFLICT_LABEL] } },
+			{ method: "DELETE", url: "https://api.github.com/repos/acme/repo/issues/5/labels/conflict", body: undefined },
+			{ method: "POST", url: "https://api.github.com/repos/acme/repo/issues/5/comments", body: { body: "hi" } },
+			{ method: "PUT", url: "https://api.github.com/repos/acme/repo/pulls/5/update-branch", body: { expected_head_sha: "abc123" } },
+		]);
+	});
+
+	it("records one PR's API failure without aborting the sweep over the rest", async () => {
+		const page = {
+			data: {
+				repository: {
+					pullRequests: {
+						pageInfo: { hasNextPage: false, endCursor: null },
+						nodes: [
+							{ number: 1, url: "u1", mergeStateStatus: "DIRTY", autoMergeRequest: null, labels: { nodes: [] }, commits: { nodes: [] } },
+							{ number: 2, url: "u2", mergeStateStatus: "DIRTY", autoMergeRequest: null, labels: { nodes: [] }, commits: { nodes: [] } },
+						],
+					},
+				},
+			},
+		};
+		const { fetcher } = fakeGithub({
+			"POST /graphql": page,
+			"POST /repos/acme/repo/issues/1/labels": () => ({ ok: false, status: 422, json: async () => ({}) }),
+		});
+		const results = await runWarden({ fetcher, owner: "acme", repo: "repo" });
+		expect(results).toHaveLength(2);
+		expect(results[0].errors.length).toBeGreaterThan(0);
+		expect(results[1].errors).toEqual([]);
+		expect(results[1].applied).toContain(`add-label:${CONFLICT_LABEL}`);
+	});
+});


### PR DESCRIPTION
## What

Two mechanical checks, both requested in the #1844 comment from the
2026-08-20 release drive:

1. **`.github/workflows/merge-train-warden.yml`** — scheduled every 10
   minutes, plus `workflow_dispatch`. One paginated GraphQL call lists every
   open PR with `mergeStateStatus`, `autoMergeRequest`, labels, and the head
   commit's check-run rollup. Per PR:
   - `mergeStateStatus: DIRTY` and no `conflict` label → add the label, post
     one comment ("this PR is merge-conflicted; required checks are
     silently skipped until resolved"). Recovery requires a POSITIVELY
     KNOWN non-DIRTY state — `UNKNOWN` (GitHub's transient status while it
     recomputes mergeability after every push) never removes the label. No
     repeat comments — dedupe is structural (label presence gates the
     comment).
   - Auto-merge armed and `mergeStateStatus: BEHIND` → call the REST
     `update-branch` API. This is the same button a human clicks in the PR
     UI; the warden never pushes to the branch itself.
   - A required check (`Unit tests`, `Lint & type-check`) has `conclusion:
     FAILURE` on the head commit and no `red-ci` label → add the label,
     post one comment naming the failing check(s) with their run links.
     The label is removed only once EVERY required check has a settled
     non-failure conclusion — a re-queued check (conclusion `null`) counts
     as unresolved, not passing, so a rerun in flight can't flap the label.
     A `null`/absent `statusCheckRollup` on the head commit is treated as
     "don't know", never as "clean" — an existing `red-ci` label is left in
     place and the run records why, rather than silently stripping it on
     missing data.
   - The warden only labels, comments, and calls `update-branch`. It never
     resolves a conflict, never merges, never pushes to a PR branch.
   - Token scope: `pull-requests: write`, `contents: read` (checkout only),
     `actions: read` (workflow-run visibility), `checks: read` (check-run
     conclusions feeding `statusCheckRollup`).
   - One paginated GraphQL call per run bounds the rate-limit cost, capped
     at `MAX_PAGES` (4); a malformed page, a thrown request, or a GraphQL
     response carrying partial `errors` alongside `data` is recorded and
     skipped rather than thrown — the CLI entry point also wraps its
     top-level logic so a genuine startup failure (bad env, DNS) still
     fails loudly instead of an unhandled-rejection stack trace.
   - Per-PR REST failures are recorded, and only a non-benign one (outside
     404/409/422 — closed PR, racing label add, update-branch on a fork
     with edits off) marks the scheduled run's exit code non-zero, so the
     workflow doesn't email every 10 minutes for expected races.
   - `concurrency: { group: merge-train-warden, cancel-in-progress: false }`
     — a run still in flight at the next tick finishes rather than racing a
     fresh sweep over the same PRs.
   - Adds the `conflict` and `red-ci` labels to `.github/labels.yml` so the
     existing label-sync workflow provisions their color/description on
     merge to master. (The warden's own `POST /labels` call auto-creates a
     missing label with a default color the first time it runs, so this
     isn't a blocker for the warden working — just for the labels having
     the intended color before the sync runs.)

2. **Fast-fail changelog validation** — a new `changelog-fragment-fastfail`
   job in `.github/workflows/ci.yml`, `pull_request`-triggered. It runs
   `scripts/check-changelog-fragments.mjs`, a thin wrapper around
   `validateChangelogEntries` from `scripts/rollup-changelog.mjs` — the same
   parser `tests/scripts/changelog-entries.test.ts` exercises. No `npm
   install`, no `npm run build`: pure Node against `.changelog/*.md`. It is
   additive early signal alongside the existing `Unit tests` job (which
   still runs the full suite including `changelog-entries.test.ts`), not a
   replacement — no required-gate conflict.

## Why

Four PRs paid a full ~4-minute `Unit tests` CI lap in one day to discover a
malformed changelog fragment. Five PRs sat silently `DIRTY` — required
checks skipped — until a human polled and noticed. Red CI on an armed PR
was also discovered only by polling. All three were mitigated by hand
during the release drive (the #1844 comment documents the day's evidence);
this PR makes the same checks mechanical and durable.

## Verification

- `npm run build` then `npx vitest run tests/scripts/merge-train-warden.test.ts
  tests/scripts/changelog-entries.test.ts tests/scripts/changelog.test.ts
  tests/scripts/rollup-changelog.test.ts` — 63 passed across 4 files (27 of
  those in `merge-train-warden.test.ts`, the file this PR adds).
- `npm run lint` — clean.
- Downloaded `actionlint` v1.7.7 (Windows amd64 release binary; no npm
  package for it) and ran it across every workflow file in the repo,
  including the two touched here — zero findings, both rounds.
- `node scripts/check-changelog-fragments.mjs` run directly: passes on the
  current `.changelog/`, and fails with the expected parser error when a
  fragment missing front matter is dropped in (proved red, then removed).

## Review round 1

An adversarial pass returned 10 findings; all are addressed on this head.

- **F1 (HIGH, fixed):** `mergeStateStatus: UNKNOWN` was being treated as
  "clean again", which strips the `conflict` label on GitHub's transient
  post-push recompute state and then re-adds it plus re-comments on the
  very next 10-minute tick. Fixed: recovery now requires
  `mergeStateStatus !== "DIRTY" && mergeStateStatus !== "UNKNOWN"`.
  Fixture: `UNKNOWN` + label present → no action either direction, proven
  red on the old guard then green.
- **F2 (HIGH, fixed):** a `null`/absent `statusCheckRollup` collapsed to
  zero failing checks (silent recovery), and the workflow granted
  `actions: read` where check-run visibility needs `checks: read`. Fixed
  both: added `checks: read`; `normalizePr` now sets `checksUnknown` and
  `decideActions` records a `note` instead of removing the label when
  `checksUnknown` is true. Fixtures: null-rollup + `red-ci` label → no
  removal, a recorded note; a distinct genuine-all-green fixture (rollup
  present, zero failures) still removes the label — proven both directions.
- **F3 (MED, fixed):** a re-queued required check (`conclusion: null`) was
  read as "not failing" → empty `failingRequiredChecks` → premature label
  removal + a flap on every rerun. Fixed: `normalizePr` now tracks
  `unresolvedRequiredChecks` (absent from the rollup or `conclusion: null`);
  removal requires both lists empty. Fixture: label present + one
  unresolved required check → no removal, proven red on the old guard.
- **F4 (MED, fixed):** per-PR benign races (404 on a closed PR, 409 racing
  another tick, 422 on `update-branch`) were marking the whole scheduled run
  red, which would email every 10 minutes for expected noise. Fixed: each
  REST failure now carries a `benign` flag (`BENIGN_HTTP_STATUSES = {404,
  409, 422}`); the CLI only sets a non-zero exit code when a NON-benign
  error exists. Fixture proves 404 → benign; a separate fixture proves 500
  → non-benign (both directions covered, the second catching a
  mutate-to-always-benign probe the first one missed).
- **F5 (MED, fixed):** added a fixture with a failing NON-required check
  (`SonarCloud Code Analysis`) asserting no action is taken. The obvious
  one-line guard (`REQUIRED_CHECKS.includes(c.name)` while building the
  lookup map) turned out to be redundant — the real filter is the
  `for (const name of REQUIRED_CHECKS)` loop that only ever looks up
  required names. Removed the redundant check, documented the real guard
  in a comment, and proved mutating THAT loop (iterating
  `checkRunsByName.keys()` instead) turns the SonarCloud fixture red.
- **F6 (LOW, fixed):** a partial GraphQL response (`data` + `errors`
  together) threw out of `graphql()`, which would propagate through the
  bare top-level `await runWarden(...)` in the CLI as an unhandled
  rejection with no run summary. Fixed: `graphql()` returns the raw payload
  instead of throwing on `errors`; `fetchOpenPullRequests` records both
  GraphQL-level errors and thrown request failures, keeping any partial
  `prs` already collected; `runWarden` surfaces list-level errors as a
  `number: null` result entry; the CLI also wraps its `main()` in a
  `.catch` as defense in depth. Fixtures cover partial data+errors, a
  thrown request, and the `number: null` result shape.
- **F7 (LOW, fixed):** added
  `concurrency: { group: merge-train-warden, cancel-in-progress: false }`.
- **F8 (LOW, fixed):** added a fixture that feeds `hasNextPage: true` on
  every page and asserts the call count equals the imported `MAX_PAGES`
  constant — proven red when the loop bound is hardcoded to a different
  number than `MAX_PAGES`.
- **F9 (NIT, addressed):** the HTML-comment marker embedded in each posted
  comment body was write-only — nothing ever scanned for it, since dedupe
  already runs entirely on label presence (the mechanism the original issue
  spec asked for). Dropped the dead marker text; the code comment on
  `decideActions` now states explicitly that removing the label is how a
  human re-arms the next comment.
- **F10 (NIT, addressed):** corrected the blast-radius claim above — a
  `POST /labels` call auto-creates a missing label with a default color; it
  does not 404. `labels.yml`'s sync only affects color/description timing.

Test count was also corrected in this round: the original body claimed 53
tests across the relevant files; the accurate count (after round 1) was 48,
and after round 2's new fixtures it's 63 (see Verification above).

## What could not be tested pre-merge

The `schedule` trigger itself cannot be exercised before merge — GitHub
only starts running a scheduled workflow once it exists on the default
branch. `workflow_dispatch` is included specifically so the maintainer can
smoke-run the warden on demand right after merge, against the real set of
open PRs, before trusting the schedule. The tests mock the fetcher, so the
GraphQL query shape (field names, union-type fragments) is verified for
internal consistency but not against GitHub's live schema. First post-merge
run is the real test of that.

## Blast radius

- New workflow, new scripts, new label additions — no existing code path
  touched. `ci.yml`'s existing jobs (`close-keyword-lint`,
  `lint-and-typecheck`, `test`, `prod-install-build`, `install-test`) are
  unchanged; the new `changelog-fragment-fastfail` job is additive and
  does not appear in branch-protection required-checks, so it cannot become
  a new required gate by accident.
- No process spawns beyond `node` in a fresh Actions runner; the warden's
  own script only calls `fetch`.
- `red-ci`/`conflict` labels are new repo state; `POST /labels` auto-creates
  them with a default color on first use, so the warden works even before
  `labels.yml`'s sync runs (see F10 above).

## Observability

The workflow run's job log (and `$GITHUB_STEP_SUMMARY`) prints one line per
PR that received an action or carries a recorded error/note, distinguishing
`applied:` from `note:`/`ERROR:` per entry — that's the record proving the
warden worked (or didn't) on a given tick, in Actions → Merge-train warden
→ Sweep open PRs.

## Merge-order / overlap

No open PR touches `.github/workflows/` or `.github/labels.yml`
(`gh pr list --json headRefName,files` checked before branching). No
composition risk with the current queue.

Refs #1844.
