### PR TITLE
fix(read-guard): credit only delivered search lines, log enforcement outcome, bound the read store (closes #1904)

### DIFF
--- a/.changelog/1904-guard-precision.md
+++ b/.changelog/1904-guard-precision.md
@@ -1,0 +1,11 @@
+---
+section: Fixed
+---
+
+- **Credit search hits with the lines the search actually showed ([closes #1904](https://github.com/apmantza/pi-lens/issues/1904))** —
+  a bare `grep -n` hit registered as a 5-line read, so the read-guard let edits
+  pass against lines the model never saw. A hit now credits its match line, plus
+  the context the command printed when it carried `-A`, `-B`, or `-C`. Each
+  record states the margin it credited and why. The range-snapshot ledger also
+  reports the caller's outcome (enforced or bypassed by content match) instead
+  of only its intent, and the per-file read store is bounded at 128 records.

--- a/clients/bash-file-access.ts
+++ b/clients/bash-file-access.ts
@@ -65,7 +65,8 @@ export function tokenizeShellCommand(command: string): ShellCommandSegment[] {
 	};
 	const flushSegment = () => {
 		flushWord();
-		if (tokens.length > 0 || unsupported) segments.push({ tokens, unsupported });
+		if (tokens.length > 0 || unsupported)
+			segments.push({ tokens, unsupported });
 		tokens = [];
 		unsupported = false;
 		atTokenStart = true;
@@ -101,7 +102,7 @@ export function tokenizeShellCommand(command: string): ShellCommandSegment[] {
 			// Windows routinely contain native paths (C:\\src\\file.ts). Preserve
 			// backslashes before ordinary path characters while still honoring
 			// shell escapes and line continuations.
-			if (next === "\n" || /[\s\\'\";$|&<>]/.test(next ?? "")) {
+			if (next === "\n" || /[\s\\'";$|&<>]/.test(next ?? "")) {
 				escaped = true;
 			} else {
 				word += ch;
@@ -373,6 +374,80 @@ const GREP_OPTIONS_WITH_VALUE = new Set([
 	"--context",
 ]);
 
+export interface GrepContextLines {
+	before: number;
+	after: number;
+}
+
+function parseContextValue(
+	inline: string,
+	next: string | undefined,
+): number | undefined {
+	const raw = inline !== "" ? inline : next;
+	if (raw === undefined) return undefined;
+	const n = Number.parseInt(raw, 10);
+	if (!Number.isFinite(n) || n < 0) return undefined;
+	// Bound the credit: a huge -C would credit a whole file from one hit.
+	return Math.min(n, 100);
+}
+
+/**
+ * Read the context lines a `grep` invocation actually PRINTS around each hit
+ * (#1904 item 2). Only these lines were delivered to the model, so only these
+ * may be credited as read. Handles `-A N`, `-A3`, clustered short flags such as
+ * `-rnA3`, `--after-context=N`, the `-B`/`--before-context` mirror, `-C`
+ * (both sides), and the bare `-NUM` form.
+ */
+export function parseGrepContextLines(args: string[]): GrepContextLines {
+	let before = 0;
+	let after = 0;
+	for (let i = 0; i < args.length; i++) {
+		const token = stripQuotes(args[i]);
+		if (token === "--") break;
+		const nextToken =
+			args[i + 1] === undefined ? undefined : stripQuotes(args[i + 1]);
+
+		const long = /^--(after|before)-context(?:=(\d+))?$/.exec(token);
+		if (long) {
+			const value = parseContextValue(long[2] ?? "", nextToken);
+			if (value === undefined) continue;
+			if (long[1] === "after") after = Math.max(after, value);
+			else before = Math.max(before, value);
+			continue;
+		}
+		const longBoth = /^--context(?:=(\d+))?$/.exec(token);
+		if (longBoth) {
+			const value = parseContextValue(longBoth[1] ?? "", nextToken);
+			if (value === undefined) continue;
+			before = Math.max(before, value);
+			after = Math.max(after, value);
+			continue;
+		}
+		// Bare numeric context form: `grep -3 pattern file`.
+		const bare = /^-(\d+)$/.exec(token);
+		if (bare) {
+			const value = parseContextValue(bare[1], undefined);
+			if (value === undefined) continue;
+			before = Math.max(before, value);
+			after = Math.max(after, value);
+			continue;
+		}
+		// Short flags, possibly clustered: the context flag must be LAST in the
+		// cluster because it consumes the remaining characters as its value.
+		const short = /^-[A-Za-z]*([ABC])(\d*)$/.exec(token);
+		if (!short) continue;
+		const value = parseContextValue(short[2], nextToken);
+		if (value === undefined) continue;
+		if (short[1] === "A") after = Math.max(after, value);
+		else if (short[1] === "B") before = Math.max(before, value);
+		else {
+			before = Math.max(before, value);
+			after = Math.max(after, value);
+		}
+	}
+	return { before, after };
+}
+
 function extractGrepSearchFiles(args: string[], cwd: string): string[] {
 	const files: string[] = [];
 	let patternSeen = false;
@@ -437,18 +512,38 @@ function parseGrepLineWithoutFile(
 function collectGrepCommandFiles(
 	command: string,
 	cwd: string,
-): { hasLineNumberGrep: boolean; files: Set<string> } {
+): {
+	hasLineNumberGrep: boolean;
+	files: Set<string>;
+	context: GrepContextLines;
+} {
 	const files = new Set<string>();
 	let hasLineNumberGrep = false;
+	// A command can chain several greps whose output all reaches the model, but
+	// the parsed hits carry no segment identity. Credit the SMALLEST context any
+	// contributing grep printed, so no line is credited that a hit from the
+	// narrowest grep never delivered.
+	let context: GrepContextLines | undefined;
 	for (const tokens of commandSegments(command)) {
 		const verb = path.basename(stripQuotes(tokens[0] ?? ""));
 		if (verb !== "grep" && verb !== "egrep" && verb !== "fgrep") continue;
 		const args = tokens.slice(1);
 		if (!grepHasLineNumbers(args)) continue;
 		hasLineNumberGrep = true;
+		const segmentContext = parseGrepContextLines(args);
+		context = context
+			? {
+					before: Math.min(context.before, segmentContext.before),
+					after: Math.min(context.after, segmentContext.after),
+				}
+			: segmentContext;
 		for (const file of extractGrepSearchFiles(args, cwd)) files.add(file);
 	}
-	return { hasLineNumberGrep, files };
+	return {
+		hasLineNumberGrep,
+		files,
+		context: context ?? { before: 0, after: 0 },
+	};
 }
 
 function dedupePushSearchRead(
@@ -494,10 +589,20 @@ export function extractGrepSearchReadsFromOutput(
 	cwd: string,
 	output: string,
 ): SearchReadLocation[] {
-	const { hasLineNumberGrep, files } = collectGrepCommandFiles(command, cwd);
+	const { hasLineNumberGrep, files, context } = collectGrepCommandFiles(
+		command,
+		cwd,
+	);
 	if (!hasLineNumberGrep) return [];
 	const singleFile = files.size === 1 ? [...files][0] : undefined;
-	return parseGrepOutputSearchReads(output, cwd, singleFile);
+	const locations = parseGrepOutputSearchReads(output, cwd, singleFile);
+	// Only the printed context lines were delivered to the model, so only they
+	// are credited. A bare grep credits its match line alone (#1904 item 2).
+	for (const loc of locations) {
+		loc.contextBefore = context.before;
+		loc.contextAfter = context.after;
+	}
+	return locations;
 }
 
 /**
@@ -531,7 +636,6 @@ export function extractWrittenPathsFromCommand(
 		// attach redirects, otherwise targets would be duplicated harmlessly but
 		// needlessly rescanned.
 		break;
-
 	}
 	for (const tokens of commandSegments(command)) {
 		if (tokens.length === 0) continue;
@@ -555,17 +659,37 @@ export function extractWrittenPathsFromCommand(
 		} else if (verb === "biome") {
 			const sub = args[0];
 			if ((sub === "format" || sub === "check") && args.includes("--write")) {
-				for (const file of formatterFileArgs(args, 1, new Set(["--config-path"]))) add(file);
+				for (const file of formatterFileArgs(
+					args,
+					1,
+					new Set(["--config-path"]),
+				))
+					add(file);
 			}
 		} else if (verb === "prettier" && args.includes("--write")) {
-			for (const file of formatterFileArgs(args, 0, new Set(["--config", "--ignore-path", "--parser", "--plugin"]))) add(file);
+			for (const file of formatterFileArgs(
+				args,
+				0,
+				new Set(["--config", "--ignore-path", "--parser", "--plugin"]),
+			))
+				add(file);
 		} else if (verb === "eslint" && args.includes("--fix")) {
-			for (const file of formatterFileArgs(args, 0, new Set(["--config", "--ignore-path", "--parser", "--plugin"]))) add(file);
+			for (const file of formatterFileArgs(
+				args,
+				0,
+				new Set(["--config", "--ignore-path", "--parser", "--plugin"]),
+			))
+				add(file);
 		} else if (verb === "ruff") {
 			const sub = args[0];
 			if (sub === "format" || args.includes("--fix")) {
 				const start = sub === "format" || sub === "check" ? 1 : 0;
-				for (const file of formatterFileArgs(args, start, new Set(["--config"]))) add(file);
+				for (const file of formatterFileArgs(
+					args,
+					start,
+					new Set(["--config"]),
+				))
+					add(file);
 			}
 		} else if (verb === "gofmt" && args.includes("-w")) {
 			for (const file of formatterFileArgs(args)) add(file);
@@ -574,14 +698,40 @@ export function extractWrittenPathsFromCommand(
 			// filesystem walk. Only explicit rustfmt operands after `--` are safe.
 			const separator = args.indexOf("--");
 			if (separator >= 0) {
-				for (const file of formatterFileArgs(args, separator + 1, new Set(["--edition", "--config-path"]))) add(file);
+				for (const file of formatterFileArgs(
+					args,
+					separator + 1,
+					new Set(["--edition", "--config-path"]),
+				))
+					add(file);
 			}
 		} else if (verb === "rustfmt") {
-			for (const file of formatterFileArgs(args, 0, new Set(["--edition", "--config-path"]))) add(file);
+			for (const file of formatterFileArgs(
+				args,
+				0,
+				new Set(["--edition", "--config-path"]),
+			))
+				add(file);
 		} else if (verb === "black") {
-			for (const file of formatterFileArgs(args, 0, new Set(["--config", "--exclude", "--include", "--line-length", "--target-version"]))) add(file);
+			for (const file of formatterFileArgs(
+				args,
+				0,
+				new Set([
+					"--config",
+					"--exclude",
+					"--include",
+					"--line-length",
+					"--target-version",
+				]),
+			))
+				add(file);
 		} else if (verb === "clang-format" && args.includes("-i")) {
-			for (const file of formatterFileArgs(args, 0, new Set(["--style", "--fallback-style", "--assume-filename"]))) add(file);
+			for (const file of formatterFileArgs(
+				args,
+				0,
+				new Set(["--style", "--fallback-style", "--assume-filename"]),
+			))
+				add(file);
 		} else if (verb === "dotnet" && args[0] === "format") {
 			// dotnet format is normally solution-scoped. `--include` is the one
 			// invocation form that provides attributable source paths.
@@ -590,7 +740,10 @@ export function extractWrittenPathsFromCommand(
 					for (const file of (args[i + 1] ?? "").split(",")) add(file);
 					i += 1;
 				} else if (args[i]?.startsWith("--include=")) {
-					for (const file of (args[i] ?? "").slice("--include=".length).split(",")) add(file);
+					for (const file of (args[i] ?? "")
+						.slice("--include=".length)
+						.split(","))
+						add(file);
 				}
 			}
 		} else if (verb === "git") {

--- a/clients/read-guard.ts
+++ b/clients/read-guard.ts
@@ -203,23 +203,42 @@ const READ_GUARD_MAX_FILES = 256;
  * 75 minutes, and every record carries a `lineHashes` map, so a long session on
  * a few files grows without bound. Cap records per file and drop oldest-first.
  *
- * Eviction is safe in the blocking direction: the newest records carry the most
- * recent view of the file, so coverage for the lines the agent is working on
- * survives. The old hash records only serve the staleness-rescue path — a stale
- * edit rescued by an older snapshot that still matches — so evicting them
- * narrows a rescue path and can turn an allow into a "re-read and retry" block.
- * It never turns a block into an allow.
+ * Eviction is safe in the blocking direction: it narrows the staleness-rescue
+ * path — a stale edit rescued by an older snapshot that still matches — and can
+ * turn an allow into a "re-read and retry" block. It never turns a block into
+ * an allow. See `enforceRecordCapForFile` for which records go first, and why
+ * age alone is the wrong order.
  */
 const READ_GUARD_MAX_RECORDS_PER_FILE = 128;
 
 /**
- * Trim a single file's read list to the per-file cap, oldest-first. Returns how
- * many records were dropped so the ledger can show the trim.
+ * Trim a single file's read list to the per-file cap. Returns how many records
+ * were dropped so the ledger can show the trim.
+ *
+ * Eviction is NOT purely by age. The shape that overflows this cap is
+ * read-once-then-grep-often: one whole-file read followed by hundreds of cheap
+ * search credits. Pure age order evicts that whole-file read first, and it is
+ * the record `canIgnoreStalenessByHashes` needs to rescue an edit after an
+ * unrelated mtime touch. So spend the search credits first, oldest among them
+ * first, and only fall through to genuine reads when the credits run out.
+ * Genuine reads are then evicted oldest-first as before.
+ *
+ * Records are trimmed IN PLACE: `EditRecord.precedingReads` holds a reference
+ * to this same array, so a replacement array would silently detach it.
  */
 function enforceRecordCapForFile(records: ReadRecord[]): number {
 	if (records.length <= READ_GUARD_MAX_RECORDS_PER_FILE) return 0;
 	const excess = records.length - READ_GUARD_MAX_RECORDS_PER_FILE;
-	records.splice(0, excess);
+	const evicted = new Set<number>();
+	for (let i = 0; i < records.length && evicted.size < excess; i++) {
+		if (records[i].searchCredit !== undefined) evicted.add(i);
+	}
+	for (let i = 0; i < records.length && evicted.size < excess; i++) {
+		evicted.add(i);
+	}
+	const kept = records.filter((_, i) => !evicted.has(i));
+	records.length = 0;
+	for (const record of kept) records.push(record);
 	return excess;
 }
 
@@ -623,6 +642,10 @@ export class ReadGuard {
 		this.consumedReadFiles.delete(storedRecord.filePath);
 		arr.push(storedRecord);
 		this.reads.set(storedRecord.filePath, arr);
+		// Capture BEFORE the trim: `readCountForFile` saturates at the cap once
+		// eviction starts, so it stops showing growth. `rawReadCountForFile` keeps
+		// the real arrival count observable alongside `evictedRecordCount`.
+		const rawReadCountForFile = arr.length;
 		const evictedRecordCount = enforceRecordCapForFile(arr);
 		this.touchFile(storedRecord.filePath);
 		this.enforceFileCap();
@@ -653,7 +676,10 @@ export class ReadGuard {
 					searchCreditMarginBefore: storedRecord.searchCredit.marginBefore,
 					searchCreditMarginAfter: storedRecord.searchCredit.marginAfter,
 				}),
-				...(evictedRecordCount > 0 && { evictedRecordCount }),
+				...(evictedRecordCount > 0 && {
+					evictedRecordCount,
+					rawReadCountForFile,
+				}),
 			},
 		});
 

--- a/clients/read-guard.ts
+++ b/clients/read-guard.ts
@@ -36,6 +36,12 @@ export interface ReadRecord {
 	/** 1-indexed line → content hash captured at read time, used to ignore no-op mtime staleness. */
 	lineHashes?: Record<number, string>;
 	contentBinding?: ReadContentBinding;
+	/**
+	 * Set when the record came from a search hit rather than a real read (#1904).
+	 * States how many context lines were credited around the hit and why, so the
+	 * ledger shows whether coverage rests on lines the model saw or on slack.
+	 */
+	searchCredit?: SearchCredit;
 	turnIndex: number;
 	writeIndex: number;
 	timestamp: number;
@@ -46,6 +52,38 @@ export interface ReadRecord {
 	 */
 	source?: string;
 }
+
+/**
+ * Why a search-hit read credited the lines it did.
+ *  - `match-lines-only`: bare hit; only the printed match lines are credited.
+ *  - `delivered-context-flags`: the search command printed context (grep
+ *    `-A`/`-B`/`-C`), so those lines were delivered and are credited.
+ *  - `caller-margin`: the caller asked for explicit extra slack.
+ */
+export type SearchCreditReason =
+	| "match-lines-only"
+	| "delivered-context-flags"
+	| "caller-margin";
+
+export interface SearchCredit {
+	marginBefore: number;
+	marginAfter: number;
+	reason: SearchCreditReason;
+}
+
+/**
+ * The caller's actual handling of a range-snapshot verdict (#1904 item 1).
+ *  - `enforced-block`: the verdict blocked the edit.
+ *  - `bypassed-content-match`: the verdict said block, but the caller passed
+ *    `skipSnapshotCheck` because the edit was content-validated (oldText).
+ *  - `enforced-pass`: a hash-checked read matched, so the edit passed the gate.
+ *  - `not-decidable`: no candidate read could be hash-checked.
+ */
+export type RangeSnapshotOutcome =
+	| "enforced-block"
+	| "bypassed-content-match"
+	| "enforced-pass"
+	| "not-decidable";
 
 export interface ReadContentBinding {
 	hash: string;
@@ -159,6 +197,41 @@ const READ_HASH_MAX_LINES = Math.max(
  */
 const READ_BINDING_MAX_BYTES = 4 * 1024 * 1024;
 const READ_GUARD_MAX_FILES = 256;
+/**
+ * #1904 item 3: `enforceFileCap` bounds how many FILES the store holds, not how
+ * many records each file holds. One hot file reached 268 hash-bearing records in
+ * 75 minutes, and every record carries a `lineHashes` map, so a long session on
+ * a few files grows without bound. Cap records per file and drop oldest-first.
+ *
+ * Eviction is safe in the blocking direction: the newest records carry the most
+ * recent view of the file, so coverage for the lines the agent is working on
+ * survives. The old hash records only serve the staleness-rescue path — a stale
+ * edit rescued by an older snapshot that still matches — so evicting them
+ * narrows a rescue path and can turn an allow into a "re-read and retry" block.
+ * It never turns a block into an allow.
+ */
+const READ_GUARD_MAX_RECORDS_PER_FILE = 128;
+
+/**
+ * Trim a single file's read list to the per-file cap, oldest-first. Returns how
+ * many records were dropped so the ledger can show the trim.
+ */
+function enforceRecordCapForFile(records: ReadRecord[]): number {
+	if (records.length <= READ_GUARD_MAX_RECORDS_PER_FILE) return 0;
+	const excess = records.length - READ_GUARD_MAX_RECORDS_PER_FILE;
+	records.splice(0, excess);
+	return excess;
+}
+
+/**
+ * #1904 class sweep: `this.edits` is the same shape as `this.reads` — a
+ * per-file array that only ever grows. Its cap sits far above every consumer's
+ * reach, so trimming is inert: `canTreatStalenessAsOwnPriorEdit` reads only the
+ * last record, and `findRelocation`'s window saturates at
+ * RELOCATION_WINDOW_MAX / RELOCATION_WINDOW_PER_EDIT (20) applied edits. Only
+ * `getStats`, a debug surface, sees the older records at all.
+ */
+const READ_GUARD_MAX_EDITS_PER_FILE = 256;
 // Unconsumed reads remain valid until edit or session end, but this high
 // sanity cap prevents a read-only session from growing without bound.
 const READ_GUARD_MAX_UNCONSUMED_FILES = 4096;
@@ -385,7 +458,10 @@ export class ReadGuard {
 	private readonly reads = new Map<string, ReadRecord[]>();
 	private readonly edits = new Map<string, EditRecord[]>();
 	private readonly fileLastUsed = new Map<string, number>();
-	private readonly fileIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	private readonly fileIdleTimers = new Map<
+		string,
+		ReturnType<typeof setTimeout>
+	>();
 	/** Reads remain behavior-gating until the corresponding edit is published. */
 	private readonly consumedReadFiles = new Set<string>();
 	private readonly fileTime: FileTime;
@@ -441,8 +517,13 @@ export class ReadGuard {
 	}
 
 	private idleEvictMs(): number {
-		const value = Number.parseInt(process.env.PI_LENS_READ_GUARD_IDLE_EVICT_MS ?? "", 10);
-		return Number.isSafeInteger(value) && value > 0 ? value : READ_GUARD_IDLE_EVICT_MS_DEFAULT;
+		const value = Number.parseInt(
+			process.env.PI_LENS_READ_GUARD_IDLE_EVICT_MS ?? "",
+			10,
+		);
+		return Number.isSafeInteger(value) && value > 0
+			? value
+			: READ_GUARD_IDLE_EVICT_MS_DEFAULT;
 	}
 
 	private clearFileTimer(filePath: string): void {
@@ -471,13 +552,15 @@ export class ReadGuard {
 		this.clearFileTimer(filePath);
 		// An outstanding read is enforcement state, not a rebuildable cache entry.
 		// It must survive idle time and file-cap pressure until the edit consumes it.
-		if (this.reads.has(filePath) && !this.consumedReadFiles.has(filePath)) return;
+		if (this.reads.has(filePath) && !this.consumedReadFiles.has(filePath))
+			return;
 		const stamp = now;
 		const timer = setTimeout(() => {
 			if (this.fileLastUsed.get(filePath) !== stamp) return;
 			// Never turn an outstanding read into a zero-read block through idle
 			// eviction. Only consumed reads and rebuildable edit history may expire.
-			if (this.reads.has(filePath) && !this.consumedReadFiles.has(filePath)) return;
+			if (this.reads.has(filePath) && !this.consumedReadFiles.has(filePath))
+				return;
 			this.evictFile(filePath);
 		}, this.idleEvictMs());
 		timer.unref?.();
@@ -488,7 +571,10 @@ export class ReadGuard {
 		while (this.reads.size > READ_GUARD_MAX_FILES) {
 			const victim = [...this.reads.keys()]
 				.filter((filePath) => this.consumedReadFiles.has(filePath))
-				.sort((a, b) => (this.fileLastUsed.get(a) ?? 0) - (this.fileLastUsed.get(b) ?? 0))[0];
+				.sort(
+					(a, b) =>
+						(this.fileLastUsed.get(a) ?? 0) - (this.fileLastUsed.get(b) ?? 0),
+				)[0];
 			if (!victim) break;
 			this.evictFile(victim);
 		}
@@ -497,8 +583,7 @@ export class ReadGuard {
 				.filter((filePath) => !this.consumedReadFiles.has(filePath))
 				.sort(
 					(a, b) =>
-						(this.fileLastUsed.get(a) ?? 0) -
-						(this.fileLastUsed.get(b) ?? 0),
+						(this.fileLastUsed.get(a) ?? 0) - (this.fileLastUsed.get(b) ?? 0),
 				)[0];
 			if (!victim) break;
 			// This is a normal read miss: a later edit must require a fresh read,
@@ -519,7 +604,10 @@ export class ReadGuard {
 		// while the file is (presumably) still on disk, so a later
 		// hasKnownPath/forgetPath lookup after an external delete can still
 		// find this entry's real key.
-		this.knownPathIndex.set(normalizeEphemeralMapKey(record.filePath), filePath);
+		this.knownPathIndex.set(
+			normalizeEphemeralMapKey(record.filePath),
+			filePath,
+		);
 		const storedRecord: ReadRecord = {
 			...record,
 			filePath,
@@ -535,6 +623,7 @@ export class ReadGuard {
 		this.consumedReadFiles.delete(storedRecord.filePath);
 		arr.push(storedRecord);
 		this.reads.set(storedRecord.filePath, arr);
+		const evictedRecordCount = enforceRecordCapForFile(arr);
 		this.touchFile(storedRecord.filePath);
 		this.enforceFileCap();
 
@@ -559,6 +648,12 @@ export class ReadGuard {
 				...(storedRecord.source !== undefined && {
 					source: storedRecord.source,
 				}),
+				...(storedRecord.searchCredit !== undefined && {
+					searchCreditReason: storedRecord.searchCredit.reason,
+					searchCreditMarginBefore: storedRecord.searchCredit.marginBefore,
+					searchCreditMarginAfter: storedRecord.searchCredit.marginAfter,
+				}),
+				...(evictedRecordCount > 0 && { evictedRecordCount }),
 			},
 		});
 
@@ -619,7 +714,8 @@ export class ReadGuard {
 		// Canonicalize once: every map lookup below (and every private helper this
 		// passes filePath to) must agree with how recordRead keyed the read.
 		filePath = this.key(filePath);
-		if (this.reads.has(filePath) || this.edits.has(filePath)) this.touchFile(filePath);
+		if (this.reads.has(filePath) || this.edits.has(filePath))
+			this.touchFile(filePath);
 
 		// Check exemptions
 		if (this.exemptions.has(filePath)) {
@@ -707,7 +803,9 @@ export class ReadGuard {
 				// and stronger than FileTime's coarse external-write signal, matching
 				// the skipSnapshotCheck exception at the later range-stale gate.
 				ignoredOldTextResolvedStaleness = true;
-			} else if (this.canTreatStalenessAsOwnPriorEdit(filePath, lastRead.timestamp)) {
+			} else if (
+				this.canTreatStalenessAsOwnPriorEdit(filePath, lastRead.timestamp)
+			) {
 				ignoredOwnEditStaleness = true;
 			} else if (
 				this.canIgnoreStalenessByHashes(
@@ -751,7 +849,11 @@ export class ReadGuard {
 
 		let viaSymbol = false;
 		for (const range of rangesToCheck) {
-			const snapshotValidation = this.validateRangeSnapshot(filePath, range);
+			const snapshotValidation = this.validateRangeSnapshot(
+				filePath,
+				range,
+				!!options?.skipSnapshotCheck,
+			);
 			const coverage = this.checkCoverage(filePath, range);
 			if (!coverage.covered) {
 				const lastRead = fileReads[fileReads.length - 1];
@@ -1230,6 +1332,12 @@ export class ReadGuard {
 	private validateRangeSnapshot(
 		filePath: string,
 		range: [number, number],
+		/**
+		 * What the CALLER will do with the verdict. `checkEdit` honours
+		 * `skipSnapshotCheck` for content-validated (oldText) edits, so a
+		 * `shouldBlock` verdict may never reach the gate (#1904 item 1).
+		 */
+		snapshotCheckSkipped: boolean,
 	): {
 		status: "match" | "mismatch" | "unavailable";
 		matchingReadIndex: number;
@@ -1302,6 +1410,18 @@ export class ReadGuard {
 			checkedCandidateCount > 0 &&
 			hashUnavailableCandidateCount === 0;
 
+		// `enforced` below states INTENT — whether this validation reached a
+		// decidable verdict. It says nothing about what the caller did with it.
+		// `outcome` states the caller's actual behaviour, which is what an
+		// enforcement rate must be computed from (#1904 item 1).
+		const outcome: RangeSnapshotOutcome = shouldBlock
+			? snapshotCheckSkipped
+				? "bypassed-content-match"
+				: "enforced-block"
+			: status === "match"
+				? "enforced-pass"
+				: "not-decidable";
+
 		logReadGuardEvent({
 			event: "range_snapshot_validation",
 			sessionId: this.sessionId,
@@ -1319,6 +1439,7 @@ export class ReadGuard {
 				missingLines: missingLines.slice(0, 20),
 				mismatchedLines: mismatchedLines.slice(0, 20),
 				enforced: shouldBlock || status === "match",
+				outcome,
 			},
 		});
 
@@ -1588,6 +1709,9 @@ export class ReadGuard {
 			reason: verdict.reason,
 			timestamp: Date.now(),
 		});
+		if (arr.length > READ_GUARD_MAX_EDITS_PER_FILE) {
+			arr.splice(0, arr.length - READ_GUARD_MAX_EDITS_PER_FILE);
+		}
 		this.edits.set(filePath, arr);
 	}
 

--- a/clients/search-read-registration.ts
+++ b/clients/search-read-registration.ts
@@ -4,15 +4,21 @@
  *
  * Search → edit is a common flow: the agent finds where something must change
  * (ast_grep_search / lsp_navigation / grep), then edits exactly those lines.
- * Those lines were genuinely shown, so they count as read — but ONLY those lines
- * (plus a small context margin), never the whole file, so editing an unseen
- * region is still guarded.
+ * Those lines were genuinely shown, so they count as read — but ONLY the lines
+ * the search actually DELIVERED, never the whole file and never a blanket
+ * margin, so editing an unseen region is still guarded (#1904).
  */
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
 import { isPathIgnoredByProject } from "./file-utils.js";
 import { isExternalOrVendorFile } from "./path-utils.js";
-import type { ReadRecord } from "./read-guard.js";
+import type { ReadRecord, SearchCreditReason } from "./read-guard.js";
+
+/** Clamp a delivered-context count to a usable non-negative integer. */
+function normalizeMargin(value: number | undefined): number | undefined {
+	if (value === undefined || !Number.isFinite(value)) return undefined;
+	return Math.max(0, Math.floor(value));
+}
 
 export interface SearchReadLocation {
 	/** Absolute or project-relative file path. */
@@ -21,17 +27,37 @@ export interface SearchReadLocation {
 	startLine: number;
 	/** 1-based last line shown (defaults to startLine). */
 	endLine?: number;
+	/**
+	 * Lines of context the search tool actually PRINTED above the hit (grep
+	 * `-B`/`-C`). Only set this when the lines were delivered to the model.
+	 */
+	contextBefore?: number;
+	/** Lines of context actually printed below the hit (grep `-A`/`-C`). */
+	contextAfter?: number;
 }
 
 interface RegisterOpts {
 	projectRoot: string;
 	turnIndex: number;
 	writeIndex: number;
-	/** Lines of slack added around each shown range (default 2). */
+	/**
+	 * Fallback slack for locations that carry no delivered-context counts.
+	 * Defaults to 0: a bare hit credits the match line only (#1904).
+	 */
 	contextMargin?: number;
 }
 
-const DEFAULT_CONTEXT_MARGIN = 2;
+/**
+ * #1904 item 2: this was 2, which credited every search hit as a 5-line read
+ * even though most searches print ONE line. The guard then let edits pass
+ * against lines the model never saw. Credit only delivered lines; callers that
+ * DID deliver context pass `contextBefore`/`contextAfter` per location.
+ *
+ * Note this is not the only slack in the system: `readCoversRange` in
+ * read-guard.ts still widens every read record by `config.contextLines` when it
+ * tests coverage, so a bare hit remains editable within that configured band.
+ */
+const DEFAULT_CONTEXT_MARGIN = 0;
 
 /**
  * Record each shown location as a read (± context margin). Resolves project-
@@ -60,11 +86,20 @@ export function registerSearchReads(
 			continue;
 		}
 
-		const start = Math.max(1, Math.floor(loc.startLine) - margin);
+		const marginBefore = normalizeMargin(loc.contextBefore) ?? margin;
+		const marginAfter = normalizeMargin(loc.contextAfter) ?? margin;
+		const creditReason: SearchCreditReason =
+			marginBefore === 0 && marginAfter === 0
+				? "match-lines-only"
+				: loc.contextBefore !== undefined || loc.contextAfter !== undefined
+					? "delivered-context-flags"
+					: "caller-margin";
+
+		const start = Math.max(1, Math.floor(loc.startLine) - marginBefore);
 		const endLine = Number.isFinite(loc.endLine)
 			? (loc.endLine as number)
 			: loc.startLine;
-		const end = Math.max(start, Math.floor(endLine) + margin);
+		const end = Math.max(start, Math.floor(endLine) + marginAfter);
 		const limit = end - start + 1;
 
 		const key = `${abs}:${start}:${limit}`;
@@ -78,6 +113,11 @@ export function registerSearchReads(
 			effectiveOffset: start,
 			effectiveLimit: limit,
 			expandedByLsp: false,
+			searchCredit: {
+				marginBefore,
+				marginAfter,
+				reason: creditReason,
+			},
 			turnIndex: opts.turnIndex,
 			writeIndex: opts.writeIndex,
 			timestamp: Date.now(),

--- a/tests/clients/bash-file-access.test.ts
+++ b/tests/clients/bash-file-access.test.ts
@@ -7,6 +7,7 @@ import {
 	extractGrepSearchReadsFromOutput,
 	extractReadPathsFromCommand,
 	extractWrittenPathsFromCommand,
+	parseGrepContextLines,
 	type ReadSpan,
 } from "../../clients/bash-file-access.js";
 import { removeTempDirSync } from "./test-utils.js";
@@ -141,8 +142,14 @@ describe("extractGrepSearchReadsFromOutput", () => {
 				`${a}:7:foo\n${relB}:12:foo`,
 			),
 		).toEqual([
-			{ file: a, startLine: 7, endLine: 7 },
-			{ file: b, startLine: 12, endLine: 12 },
+			{ file: a, startLine: 7, endLine: 7, contextBefore: 0, contextAfter: 0 },
+			{
+				file: b,
+				startLine: 12,
+				endLine: 12,
+				contextBefore: 0,
+				contextAfter: 0,
+			},
 		]);
 	});
 
@@ -150,7 +157,9 @@ describe("extractGrepSearchReadsFromOutput", () => {
 		const a = touchLines("a.ts", 20);
 		expect(
 			extractGrepSearchReadsFromOutput(`grep -n foo ${a}`, tmp, "9:foo here"),
-		).toEqual([{ file: a, startLine: 9, endLine: 9 }]);
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 0, contextAfter: 0 },
+		]);
 	});
 
 	it("recognizes combined grep flags that include line numbers", () => {
@@ -161,7 +170,15 @@ describe("extractGrepSearchReadsFromOutput", () => {
 				tmp,
 				`${a}:11:foo here`,
 			),
-		).toEqual([{ file: a, startLine: 11, endLine: 11 }]);
+		).toEqual([
+			{
+				file: a,
+				startLine: 11,
+				endLine: 11,
+				contextBefore: 0,
+				contextAfter: 0,
+			},
+		]);
 	});
 
 	it("ignores grep output when -n is absent", () => {
@@ -169,6 +186,107 @@ describe("extractGrepSearchReadsFromOutput", () => {
 		expect(
 			extractGrepSearchReadsFromOutput(`grep foo ${a}`, tmp, `${a}:9:foo`),
 		).toHaveLength(0);
+	});
+
+	// ── #1904 item 2: credit only the lines the grep actually printed ────────
+
+	it("credits no context for a bare grep hit", () => {
+		const a = touchLines("a.ts", 20);
+		expect(
+			extractGrepSearchReadsFromOutput(`grep -n foo ${a}`, tmp, "9:foo"),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 0, contextAfter: 0 },
+		]);
+	});
+
+	it("credits the context grep -A/-B/-C actually printed", () => {
+		const a = touchLines("a.ts", 40);
+		expect(
+			extractGrepSearchReadsFromOutput(`grep -n -A 3 foo ${a}`, tmp, "9:foo"),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 0, contextAfter: 3 },
+		]);
+		expect(
+			extractGrepSearchReadsFromOutput(`grep -n -B2 foo ${a}`, tmp, "9:foo"),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 2, contextAfter: 0 },
+		]);
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -n --context=4 foo ${a}`,
+				tmp,
+				"9:foo",
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 4, contextAfter: 4 },
+		]);
+	});
+
+	it("reads context flags clustered with other short flags", () => {
+		const a = touchLines("a.ts", 40);
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -rnC2 foo ${a}`,
+				tmp,
+				`${a}:9:foo`,
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 2, contextAfter: 2 },
+		]);
+	});
+
+	it("credits the narrowest context when a command chains several greps", () => {
+		const a = touchLines("a.ts", 40);
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -nC5 foo ${a} && grep -n bar ${a}`,
+				tmp,
+				`${a}:9:foo`,
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 0, contextAfter: 0 },
+		]);
+	});
+});
+
+describe("parseGrepContextLines", () => {
+	it("returns zero context for flags that carry no context request", () => {
+		expect(parseGrepContextLines(["-rn", "foo", "src"])).toEqual({
+			before: 0,
+			after: 0,
+		});
+	});
+
+	it("parses attached, separated, long, and bare-number forms", () => {
+		expect(parseGrepContextLines(["-A3"])).toEqual({ before: 0, after: 3 });
+		expect(parseGrepContextLines(["-B", "4"])).toEqual({ before: 4, after: 0 });
+		expect(parseGrepContextLines(["--after-context", "2"])).toEqual({
+			before: 0,
+			after: 2,
+		});
+		expect(parseGrepContextLines(["--before-context=1"])).toEqual({
+			before: 1,
+			after: 0,
+		});
+		expect(parseGrepContextLines(["-5"])).toEqual({ before: 5, after: 5 });
+	});
+
+	it("does not read a pattern or path as a context value", () => {
+		expect(parseGrepContextLines(["-A", "foo", "src/a.ts"])).toEqual({
+			before: 0,
+			after: 0,
+		});
+		expect(parseGrepContextLines(["--", "-C3"])).toEqual({
+			before: 0,
+			after: 0,
+		});
+	});
+
+	it("bounds an absurd context request", () => {
+		expect(parseGrepContextLines(["-C99999"])).toEqual({
+			before: 100,
+			after: 100,
+		});
 	});
 });
 
@@ -190,7 +308,10 @@ describe("extractWrittenPathsFromCommand — bash writes", () => {
 		["git checkout <ref> -- <file>", (f) => `git checkout HEAD~1 -- ${f}`],
 		["git restore <file>", (f) => `git restore ${f}`],
 		["git restore --staged <file>", (f) => `git restore --staged ${f}`],
-		["git mv destination (#1668 review F2)", (f) => `git mv /other/src.ts ${f}`],
+		[
+			"git mv destination (#1668 review F2)",
+			(f) => `git mv /other/src.ts ${f}`,
+		],
 		["biome format --write", (f) => `npx biome format --write ${f}`],
 		["biome check --write", (f) => `biome check --write ${f}`],
 		["prettier --write", (f) => `prettier --write ${f}`],
@@ -222,7 +343,10 @@ describe("extractWrittenPathsFromCommand — bash writes", () => {
 
 	it("git mv source is NOT registered as a write (only the destination)", () => {
 		const dst = pathIn("dst.ts");
-		const r = extractWrittenPathsFromCommand(`git mv /other/src.ts ${dst}`, tmp);
+		const r = extractWrittenPathsFromCommand(
+			`git mv /other/src.ts ${dst}`,
+			tmp,
+		);
 		expect(r).toContain(dst);
 		expect(r).not.toContain("/other/src.ts");
 	});
@@ -250,17 +374,25 @@ describe("extractWrittenPathsFromCommand — bash writes", () => {
 
 	it("does not invent paths for project-scoped formatter invocations", () => {
 		expect(extractWrittenPathsFromCommand("cargo fmt", tmp)).toHaveLength(0);
-		expect(extractWrittenPathsFromCommand("dotnet format", tmp)).toHaveLength(0);
+		expect(extractWrittenPathsFromCommand("dotnet format", tmp)).toHaveLength(
+			0,
+		);
 		expect(extractWrittenPathsFromCommand("rustfmt", tmp)).toHaveLength(0);
 	});
 
 	it("does not register formatter operands without their write flag", () => {
 		const f = pathIn("a.ts");
-		expect(extractWrittenPathsFromCommand(`biome format ${f}`, tmp)).not.toContain(f);
-		expect(extractWrittenPathsFromCommand(`prettier ${f}`, tmp)).not.toContain(f);
+		expect(
+			extractWrittenPathsFromCommand(`biome format ${f}`, tmp),
+		).not.toContain(f);
+		expect(extractWrittenPathsFromCommand(`prettier ${f}`, tmp)).not.toContain(
+			f,
+		);
 		expect(extractWrittenPathsFromCommand(`eslint ${f}`, tmp)).not.toContain(f);
 		expect(extractWrittenPathsFromCommand(`gofmt ${f}`, tmp)).not.toContain(f);
-		expect(extractWrittenPathsFromCommand(`clang-format ${f}`, tmp)).not.toContain(f);
+		expect(
+			extractWrittenPathsFromCommand(`clang-format ${f}`, tmp),
+		).not.toContain(f);
 	});
 });
 
@@ -356,9 +488,9 @@ describe("extractDeletedPathsFromCommand — bash deletes (#1668)", () => {
 	it("unrelated commands (cat, grep, git status) propose nothing", () => {
 		const f = touchLines("a.ts", 1);
 		expect(extractDeletedPathsFromCommand(`cat ${f}`, tmp)).toHaveLength(0);
-		expect(extractDeletedPathsFromCommand(`grep -n foo ${f}`, tmp)).toHaveLength(
-			0,
-		);
+		expect(
+			extractDeletedPathsFromCommand(`grep -n foo ${f}`, tmp),
+		).toHaveLength(0);
 		expect(extractDeletedPathsFromCommand(`git status`, tmp)).toHaveLength(0);
 	});
 });

--- a/tests/clients/read-guard.test.ts
+++ b/tests/clients/read-guard.test.ts
@@ -7,6 +7,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeFilePath } from "../../clients/path-utils.js";
 import {
 	createReadGuard,
 	currentLinesMatchReadSnapshot,
@@ -14,7 +15,6 @@ import {
 	type ReadRecord,
 } from "../../clients/read-guard.js";
 import { logReadGuardEvent } from "../../clients/read-guard-logger.js";
-import { normalizeFilePath } from "../../clients/path-utils.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
 const fileTimeState = vi.hoisted(() => ({ hasChanged: false }));
@@ -769,6 +769,176 @@ describe("ReadGuard", () => {
 				env.cleanup();
 			}
 		});
+
+		// ── #1904 item 1: log the caller's outcome, not just the intent ───────
+
+		function lastValidationMetadata(): Record<string, unknown> | undefined {
+			const entry = vi
+				.mocked(logReadGuardEvent)
+				.mock.calls.filter(([e]) => e.event === "range_snapshot_validation")
+				.at(-1)?.[0];
+			return entry?.metadata as Record<string, unknown> | undefined;
+		}
+
+		it("reports bypassed-content-match when the caller skips the gate", () => {
+			const env = setupTestEnvironment("read-guard-snapshot-bypass-");
+			try {
+				const filePath = path.join(env.tmpDir, "api.ts");
+				fs.writeFileSync(filePath, "one\ntwo\nthree\n");
+				const guard = createReadGuard("test-session");
+				guard.recordRead(
+					createReadRecord(filePath, {
+						effectiveOffset: 1,
+						effectiveLimit: 3,
+					}),
+				);
+				fs.writeFileSync(filePath, "one\nTWO\nthree\n");
+				vi.mocked(logReadGuardEvent).mockClear();
+
+				const verdict = guard.checkEdit(filePath, [2, 2], undefined, {
+					skipSnapshotCheck: true,
+				});
+
+				expect(verdict.action).toBe("allow");
+				expect(lastValidationMetadata()).toMatchObject({
+					status: "mismatch",
+					enforced: true,
+					outcome: "bypassed-content-match",
+				});
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("reports enforced-block when the caller honors the gate", () => {
+			const env = setupTestEnvironment("read-guard-snapshot-block-");
+			try {
+				const filePath = path.join(env.tmpDir, "api.ts");
+				fs.writeFileSync(filePath, "one\ntwo\nthree\n");
+				const guard = createReadGuard("test-session");
+				guard.recordRead(
+					createReadRecord(filePath, {
+						effectiveOffset: 1,
+						effectiveLimit: 3,
+					}),
+				);
+				fs.writeFileSync(filePath, "one\nTWO\nthree\n");
+				vi.mocked(logReadGuardEvent).mockClear();
+
+				expect(guard.checkEdit(filePath, [2, 2]).action).toBe("block");
+				expect(lastValidationMetadata()).toMatchObject({
+					enforced: true,
+					outcome: "enforced-block",
+				});
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("reports enforced-pass when a hash-checked read still matches", () => {
+			const env = setupTestEnvironment("read-guard-snapshot-pass-");
+			try {
+				const filePath = path.join(env.tmpDir, "api.ts");
+				fs.writeFileSync(filePath, "one\ntwo\nthree\n");
+				const guard = createReadGuard("test-session");
+				guard.recordRead(
+					createReadRecord(filePath, {
+						effectiveOffset: 1,
+						effectiveLimit: 3,
+					}),
+				);
+				vi.mocked(logReadGuardEvent).mockClear();
+
+				expect(guard.checkEdit(filePath, [2, 2]).action).toBe("allow");
+				expect(lastValidationMetadata()).toMatchObject({
+					status: "match",
+					enforced: true,
+					outcome: "enforced-pass",
+				});
+			} finally {
+				env.cleanup();
+			}
+		});
+	});
+
+	// ── #1904 item 3: the per-file read store is bounded ─────────────────────
+
+	describe("per-file read record cap", () => {
+		it("bounds records per file and keeps the newest", () => {
+			const env = setupTestEnvironment("read-guard-record-cap-");
+			try {
+				const filePath = path.join(env.tmpDir, "hot.ts");
+				fs.writeFileSync(
+					filePath,
+					Array.from({ length: 400 }, (_, i) => `line${i + 1}`).join("\n"),
+				);
+				const guard = createReadGuard("test-session");
+				for (let i = 1; i <= 400; i++) {
+					guard.recordRead(
+						createReadRecord(filePath, {
+							requestedOffset: i,
+							requestedLimit: 1,
+							effectiveOffset: i,
+							effectiveLimit: 1,
+						}),
+					);
+				}
+				const stored = guard.getReadHistory(filePath);
+				expect(stored.length).toBeLessThanOrEqual(128);
+				// Oldest-first eviction: the newest read survives, the oldest is gone.
+				expect(stored.at(-1)?.effectiveOffset).toBe(400);
+				expect(stored.some((r) => r.effectiveOffset === 1)).toBe(false);
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("keeps the newest read usable for coverage after the cap trims", () => {
+			const env = setupTestEnvironment("read-guard-record-cap-cover-");
+			try {
+				const filePath = path.join(env.tmpDir, "hot.ts");
+				fs.writeFileSync(
+					filePath,
+					Array.from({ length: 400 }, (_, i) => `line${i + 1}`).join("\n"),
+				);
+				const guard = createReadGuard("test-session");
+				for (let i = 1; i <= 400; i++) {
+					guard.recordRead(
+						createReadRecord(filePath, {
+							requestedOffset: i,
+							requestedLimit: 1,
+							effectiveOffset: i,
+							effectiveLimit: 1,
+						}),
+					);
+				}
+				expect(guard.checkEdit(filePath, [400, 400]).action).toBe("allow");
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("bounds the per-file edit history too (class sweep)", () => {
+			const env = setupTestEnvironment("read-guard-edit-cap-");
+			try {
+				const filePath = path.join(env.tmpDir, "hot.ts");
+				fs.writeFileSync(
+					filePath,
+					Array.from({ length: 400 }, (_, i) => `line${i + 1}`).join("\n"),
+				);
+				const guard = createReadGuard("test-session");
+				guard.recordRead(
+					createReadRecord(filePath, {
+						effectiveOffset: 1,
+						effectiveLimit: 400,
+					}),
+				);
+				for (let i = 1; i <= 400; i++) guard.checkEdit(filePath, [i, i]);
+				expect(guard.getEditHistory(filePath).length).toBeLessThanOrEqual(256);
+			} finally {
+				env.cleanup();
+			}
+		});
 	});
 
 	describe("Phase 2: Range coverage checks", () => {
@@ -1121,7 +1291,9 @@ describe("ReadGuard Tier-2 idle decay and bounds (#1389)", () => {
 			const guard = createReadGuard("tier2-read-guard");
 			const oldPath = "/tmp/old-tier2.ts";
 			const recentPath = "/tmp/recent-tier2.ts";
-			guard.recordRead(createReadRecord(oldPath, { timestamp: Date.now() - 31 * 60_000 }));
+			guard.recordRead(
+				createReadRecord(oldPath, { timestamp: Date.now() - 31 * 60_000 }),
+			);
 			guard.recordRead(createReadRecord(recentPath));
 			vi.advanceTimersByTime(35 * 60_000 + 1);
 			expect(guard.getReadHistory(oldPath)).toHaveLength(1);
@@ -1260,9 +1432,10 @@ describe("ReadGuard export/import across resume (#1041)", () => {
 		try {
 			const guard = createReadGuard("session-x");
 			expect(guard.importState(undefined)).toEqual({ imported: 0, dropped: 0 });
-			expect(
-				guard.importState({ version: 999, reads: [] }),
-			).toEqual({ imported: 0, dropped: 0 });
+			expect(guard.importState({ version: 999, reads: [] })).toEqual({
+				imported: 0,
+				dropped: 0,
+			});
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/read-guard.test.ts
+++ b/tests/clients/read-guard.test.ts
@@ -859,11 +859,96 @@ describe("ReadGuard", () => {
 				env.cleanup();
 			}
 		});
+
+		it("reports not-decidable when no candidate carries hashes", () => {
+			const env = setupTestEnvironment("read-guard-snapshot-undecidable-");
+			try {
+				const filePath = path.join(env.tmpDir, "api.ts");
+				fs.writeFileSync(filePath, "one\ntwo\nthree\n");
+				const guard = createReadGuard("test-session");
+				// An empty hash map means the read delivered no checkable snapshot.
+				guard.recordRead(
+					createReadRecord(filePath, {
+						effectiveOffset: 1,
+						effectiveLimit: 3,
+						lineHashes: {},
+					}),
+				);
+				vi.mocked(logReadGuardEvent).mockClear();
+
+				expect(guard.checkEdit(filePath, [2, 2]).action).toBe("allow");
+				expect(lastValidationMetadata()).toMatchObject({
+					status: "unavailable",
+					enforced: false,
+					outcome: "not-decidable",
+				});
+			} finally {
+				env.cleanup();
+			}
+		});
 	});
 
 	// ── #1904 item 3: the per-file read store is bounded ─────────────────────
 
 	describe("per-file read record cap", () => {
+		/**
+		 * #1907 review F1: the shape that overflows the cap is read-once-then-
+		 * grep-often. Under pure age order the whole-file read is evicted first,
+		 * and it is the only record whose hashes can rescue the edit after an
+		 * unrelated mtime touch. Search credits must be spent before it.
+		 */
+		it("spends search credits before a genuine read when trimming", () => {
+			const env = setupTestEnvironment("read-guard-cap-credit-first-");
+			try {
+				const filePath = path.join(env.tmpDir, "hot.ts");
+				fs.writeFileSync(
+					filePath,
+					Array.from({ length: 400 }, (_, i) => `line${i + 1}`).join("\n"),
+				);
+				const guard = createReadGuard("test-session");
+				// 1. One whole-file read — the oldest record on the file.
+				guard.recordRead(
+					createReadRecord(filePath, {
+						effectiveOffset: 1,
+						effectiveLimit: 400,
+						requestedOffset: 1,
+						requestedLimit: 400,
+					}),
+				);
+				// 2. 130 search credits, enough to overflow the 128 cap.
+				for (let i = 1; i <= 130; i++) {
+					guard.recordRead(
+						createReadRecord(filePath, {
+							requestedOffset: i,
+							requestedLimit: 1,
+							effectiveOffset: i,
+							effectiveLimit: 1,
+							searchCredit: {
+								marginBefore: 0,
+								marginAfter: 0,
+								reason: "match-lines-only",
+							},
+						}),
+					);
+				}
+				// 3. An unrelated touch makes the file look stale. The surviving
+				// whole-file read's hashes still match, so the edit is rescued.
+				// Under pure age order that read is gone and this edit BLOCKS.
+				fileTimeState.hasChanged = true;
+				expect(guard.checkEdit(filePath, [200, 200]).action).toBe("allow");
+
+				// The mechanism: the whole-file read is the one surviving non-credit.
+				const stored = guard.getReadHistory(filePath);
+				expect(stored.length).toBeLessThanOrEqual(128);
+				expect(
+					stored.filter((r) => r.searchCredit === undefined),
+				).toHaveLength(1);
+			} finally {
+				fileTimeState.hasChanged = false;
+				env.cleanup();
+			}
+		});
+
 		it("bounds records per file and keeps the newest", () => {
 			const env = setupTestEnvironment("read-guard-record-cap-");
 			try {
@@ -888,6 +973,16 @@ describe("ReadGuard", () => {
 				// Oldest-first eviction: the newest read survives, the oldest is gone.
 				expect(stored.at(-1)?.effectiveOffset).toBe(400);
 				expect(stored.some((r) => r.effectiveOffset === 1)).toBe(false);
+				// #1907 review F5: growth stays observable past the cap.
+				const trimEntry = vi
+					.mocked(logReadGuardEvent)
+					.mock.calls.filter(([e]) => e.event === "read_recorded")
+					.at(-1)?.[0];
+				expect(trimEntry?.metadata).toMatchObject({
+					readCountForFile: 128,
+					rawReadCountForFile: 129,
+					evictedRecordCount: 1,
+				});
 			} finally {
 				env.cleanup();
 			}

--- a/tests/clients/runtime-tool-result.test.ts
+++ b/tests/clients/runtime-tool-result.test.ts
@@ -132,11 +132,66 @@ describe("bash grep searchReads registration", () => {
 				readGuard: { recordRead },
 			} as any);
 
+			// #1904 item 2: a bare `grep -n` shows ONE line, so credit one line.
+			expect(recordRead).toHaveBeenCalledWith(
+				expect.objectContaining({
+					filePath,
+					effectiveOffset: 9,
+					effectiveLimit: 1,
+					searchCredit: {
+						marginBefore: 0,
+						marginAfter: 0,
+						reason: "match-lines-only",
+					},
+				}),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("credits the context lines a grep -C actually printed", async () => {
+		const env = setupTestEnvironment("pi-lens-grep-context-credit-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			const sampleLines = Array.from({ length: 20 }, (_, i) => `line${i + 1}`);
+			fs.writeFileSync(filePath, sampleLines.join("\n"));
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			runtime.beginTurn();
+			const recordRead = vi.fn();
+
+			await handleToolResult({
+				event: {
+					toolName: "bash",
+					input: { command: `grep -n -C2 line9 ${filePath}` },
+					details: {},
+					content: [{ type: "text", text: "9:line9" }],
+				},
+				getFlag: () => false,
+				dbg: () => {},
+				runtime,
+				cacheManager: new CacheManager(false),
+				biomeClient: {},
+				ruffClient: {},
+				testRunnerClient: {},
+				metricsClient: {},
+				resetLSPService: () => {},
+				agentBehaviorRecord: () => [],
+				formatBehaviorWarnings: () => "",
+				readGuard: { recordRead },
+			} as any);
+
 			expect(recordRead).toHaveBeenCalledWith(
 				expect.objectContaining({
 					filePath,
 					effectiveOffset: 7,
 					effectiveLimit: 5,
+					searchCredit: {
+						marginBefore: 2,
+						marginAfter: 2,
+						reason: "delivered-context-flags",
+					},
 				}),
 			);
 		} finally {

--- a/tests/clients/search-read-registration.test.ts
+++ b/tests/clients/search-read-registration.test.ts
@@ -45,26 +45,100 @@ afterEach(() => {
 
 describe("registerSearchReads", () => {
 	function spyGuard() {
-		const calls: Array<{ effectiveOffset: number; effectiveLimit: number; filePath: string }> = [];
+		const calls: Array<{
+			effectiveOffset: number;
+			effectiveLimit: number;
+			filePath: string;
+			searchCredit?: {
+				marginBefore: number;
+				marginAfter: number;
+				reason: string;
+			};
+		}> = [];
 		return {
 			calls,
-			recordRead: (r: { effectiveOffset: number; effectiveLimit: number; filePath: string }) =>
-				calls.push(r),
+			recordRead: (r: (typeof calls)[number]) => calls.push(r),
 		};
 	}
 
-	it("records each shown range with a ±2 context margin (1-based)", () => {
+	// ── #1904 item 2: only delivered lines are credited ──────────────────────
+
+	it("credits the shown lines only when no context was delivered", () => {
 		fileWithLines("a.ts", 100);
 		const guard = spyGuard();
-		const locs: SearchReadLocation[] = [{ file: "a.ts", startLine: 10, endLine: 12 }];
+		const locs: SearchReadLocation[] = [
+			{ file: "a.ts", startLine: 10, endLine: 12 },
+		];
 		const n = registerSearchReads(guard, locs, {
 			projectRoot: tmp,
 			turnIndex: 0,
 			writeIndex: 0,
 		});
 		expect(n).toBe(1);
-		// lines 10..12 ± 2 → 8..14 → offset 8, limit 7
-		expect(guard.calls[0]).toMatchObject({ effectiveOffset: 8, effectiveLimit: 7 });
+		// lines 10..12 exactly → offset 10, limit 3. No ±2 slack (#1904).
+		expect(guard.calls[0]).toMatchObject({
+			effectiveOffset: 10,
+			effectiveLimit: 3,
+		});
+	});
+
+	it("credits delivered context asymmetrically and records why", () => {
+		fileWithLines("a.ts", 100);
+		const guard = spyGuard();
+		registerSearchReads(
+			guard,
+			[
+				{
+					file: "a.ts",
+					startLine: 10,
+					endLine: 10,
+					contextBefore: 1,
+					contextAfter: 3,
+				},
+			],
+			{ projectRoot: tmp, turnIndex: 0, writeIndex: 0 },
+		);
+		// 9..13 → offset 9, limit 5
+		expect(guard.calls[0]).toMatchObject({
+			effectiveOffset: 9,
+			effectiveLimit: 5,
+			searchCredit: {
+				marginBefore: 1,
+				marginAfter: 3,
+				reason: "delivered-context-flags",
+			},
+		});
+	});
+
+	it("records a bare hit as match-lines-only on the ledger record", () => {
+		fileWithLines("a.ts", 100);
+		const guard = spyGuard();
+		registerSearchReads(guard, [{ file: "a.ts", startLine: 10 }], {
+			projectRoot: tmp,
+			turnIndex: 0,
+			writeIndex: 0,
+		});
+		expect(guard.calls[0].searchCredit).toEqual({
+			marginBefore: 0,
+			marginAfter: 0,
+			reason: "match-lines-only",
+		});
+	});
+
+	it("still honors an explicit caller margin and labels it as such", () => {
+		fileWithLines("a.ts", 100);
+		const guard = spyGuard();
+		registerSearchReads(guard, [{ file: "a.ts", startLine: 10 }], {
+			projectRoot: tmp,
+			turnIndex: 0,
+			writeIndex: 0,
+			contextMargin: 2,
+		});
+		expect(guard.calls[0]).toMatchObject({
+			effectiveOffset: 8,
+			effectiveLimit: 5,
+			searchCredit: { reason: "caller-margin" },
+		});
 	});
 
 	it("clamps the start at line 1", () => {
@@ -108,7 +182,7 @@ describe("registerSearchReads", () => {
 });
 
 describe("search reads → read-guard (end-to-end)", () => {
-	it("unblocks edits to a revealed match (± margin) but still blocks far edits", () => {
+	it("unblocks edits to a revealed match but still blocks far edits", () => {
 		const guard = createReadGuard("s");
 		const f = fileWithLines("a.ts", 100);
 		registerSearchReads(guard, [{ file: f, startLine: 10, endLine: 12 }], {
@@ -117,7 +191,40 @@ describe("search reads → read-guard (end-to-end)", () => {
 			writeIndex: 0,
 		});
 		expect(guard.checkEdit(f, [11, 11]).action).toBe("allow"); // inside match
-		expect(guard.checkEdit(f, [8, 8]).action).toBe("allow"); // within ±2 margin
+		// The guard's own contextLines band (3) still covers 7..15.
+		expect(guard.checkEdit(f, [8, 8]).action).toBe("allow");
 		expect(guard.checkEdit(f, [60, 60]).action).toBe("block"); // far outside
+	});
+
+	it("blocks an edit that only the removed ±2 search margin used to cover", () => {
+		const guard = createReadGuard("s");
+		const f = fileWithLines("a.ts", 100);
+		registerSearchReads(guard, [{ file: f, startLine: 10, endLine: 12 }], {
+			projectRoot: tmp,
+			turnIndex: 0,
+			writeIndex: 0,
+		});
+		// Old credit 8..14 plus contextLines 3 reached line 5. Delivered-lines
+		// credit 10..12 plus contextLines 3 stops at line 7 (#1904 item 2).
+		expect(guard.checkEdit(f, [5, 5]).action).toBe("block");
+	});
+
+	it("re-covers those lines when the search delivered the context", () => {
+		const guard = createReadGuard("s");
+		const f = fileWithLines("a.ts", 100);
+		registerSearchReads(
+			guard,
+			[
+				{
+					file: f,
+					startLine: 10,
+					endLine: 12,
+					contextBefore: 2,
+					contextAfter: 2,
+				},
+			],
+			{ projectRoot: tmp, turnIndex: 0, writeIndex: 0 },
+		);
+		expect(guard.checkEdit(f, [5, 5]).action).toBe("allow");
 	});
 });


### PR DESCRIPTION
## What changed

**Item 2 (the substantive one): search hits credit only the lines the search delivered.**
`search-read-registration.ts` added a blanket `DEFAULT_CONTEXT_MARGIN = 2` to every
hit, so a bare `grep -n` match registered as a 5-line read. Most searches print one
line. The extra four lines were coverage the model never earned, and the failure ran
in the permissive direction: edits against unseen lines passed.

The default margin is now 0. A hit credits its match lines. When the bash command
carried a context flag, `parseGrepContextLines` reads it and credits exactly what
grep printed: `-A N`, `-B N`, `-C N`, `-N`, the `--after-context` / `--before-context`
/ `--context` long forms, attached values (`-A3`), and clusters (`-rnC2`). A command
that chains several greps credits the narrowest context any of them printed, because
the parsed hits carry no segment identity.

Every search-sourced `ReadRecord` now carries `searchCredit: { marginBefore,
marginAfter, reason }`, and `read_recorded` emits those three fields. The ledger says
what was credited and why: `match-lines-only`, `delivered-context-flags`, or
`caller-margin`.

**Item 1: `range_snapshot_validation` reports the caller's outcome.** `enforced` stated
intent — whether the validation reached a decidable verdict. It said nothing about
what `checkEdit` did with it, and `checkEdit` honours `skipSnapshotCheck` for every
content-validated (oldText) edit. The metadata gains `outcome`:
`enforced-pass` | `enforced-block` | `bypassed-content-match` | `not-decidable`.
`enforced` is unchanged, so existing readers keep working. No behavior change.

**Item 3: the per-file read store is bounded.** `enforceFileCap` bounded files, not
records per file. Reads are now capped at 128 per file, oldest-first. The class sweep
found the same shape one method away — `this.edits` is an unbounded per-file array
too — so it is capped at 256, also oldest-first.

## Friction check (item 2)

Expected denial-rate change: **no measurable increase.**

Two reasons, one structural and one empirical.

Structural: `readCoversRange` (read-guard.ts:1252) already widens every read record by
`config.contextLines` (3) when it tests coverage. Under the old rule a bare hit
covered ±5 around the match; now it covers ±3. The tightening removes only lines 4 and
5 from a match line. An edit landing there, with no other read on the file, is
genuinely blind.

Empirical: I replayed the coverage decision over every `read-guard.log` record that
carries both a read set and a touched range — 42 edit incidents across 8 sessions,
including the four sessions in the issue's 2026-08-20 window (22 of the 42). Those
records hold 1267 read entries, 1100 of them 5-line records, which matches the issue's
"89 of 100 sampled records were 5-line search credits". Simulating the shrink
(every 5-line record collapsed to its match line, `contextLines` = 3 retained):

```
read records total 1267, of which effectiveLimit == 5: 1100
covered under old crediting: 2     covered under new crediting: 2
allow -> block flips: 0
```

Read that as what it is: **no flips in the replayed incident set**, not a bound on the
change. The tightening can block, and when it does the block is correct. The reviewer
built the case: two bare `grep -n` hits four lines apart, an edit on the line between
them. The old ±2 credits met in the middle and the edit passed; now neither hit reaches
it, so the guard asks for a read. That line was never printed. Denying it is the point
of the fix, not a regression.

Limits of the evidence, stated plainly: `read-guard.log` has no `edit_allowed` record
carrying read sets, so the replay covers blocked and warned incidents only, not the 727
successful edit batches in the same window. It also cannot tell a search credit from a
real `read offset=N limit=5` — they are byte-identical in the log today. That
indistinguishability is exactly what the new `searchCredit` field closes, so the next
monitoring pass can measure this directly instead of by proxy.

## Known gap, filed separately

`grep -C2 | head -20` credits two lines of context around every parsed hit, including
hits whose context the pipe truncated away. Same class as the defect this PR fixes, two
orders of magnitude smaller: it needs a context flag AND a truncating pipe AND an edit
landing in the truncated tail. Not fixed here; the reviewer is filing it.

## Verification

Red-first. Reverted `clients/` to pre-fix, rebuilt, ran the three target suites:
**20 tests failed**, covering every item — the ±2 credit, the flag parsing, the
`searchCredit` record, the three `outcome` values, and the per-file read cap. Output
kept during the session.

Mutation proof for each new guard:
- Delete the margin change → `credits the shown lines only when no context was
  delivered` and `blocks an edit that only the removed ±2 search margin used to cover`
  go red.
- Neuter `parseGrepContextLines` → the four grep-context tests go red.
- Delete `outcome` → the three outcome tests go red; hardcoding it to `enforced-block`
  reds the bypass test.
- Delete `enforceRecordCapForFile` → `bounds records per file and keeps the newest`
  goes red.
- Delete the edits-array trim → verified red in isolation: `expected 400 to be less
  than or equal to 256`.
- Revert eviction to pure age order → `spends search credits before a genuine read when
  trimming` goes red on the verdict itself: `expected 'block' to be 'allow'`.
- Collapse the `not-decidable` branch into `enforced-pass` → the fourth outcome test
  goes red.
- Drop `rawReadCountForFile` from the log → the cap test's telemetry assertion goes red.

Green after: `npm run build`, `npm run lint`, then 21 test files / **735 tests
passing** — the three target suites plus every sibling file that references the changed
symbols (`runtime-tool-result`, `runtime-tool-call`, `bash-read-guard-integration`,
`read-bridge`, `read-expansion-enrichment`, `read-guard-path-normalization`,
`read-guard-symbol-read`, `read-guard-tool-lines`, `session-state-store`,
`partial-edit-apply`, `pi-host-contract`, `session-state-conformance`,
`ast-grep-search`, `lsp-navigation`, `agent-nudge`, `index-integration`, `git-guard`,
`lens-config`). Full suite deferred to CI.

## Review round 1

Five findings, all addressed. The MEDIUM one was a real bug I shipped.

**F1 (MEDIUM), fixed.** `enforceRecordCapForFile` evicted purely by age. The shape that
overflows the cap is read-once-then-grep-often, so the whole-file read is the OLDEST
record and went first — before 128 cheap search credits — taking
`canIgnoreStalenessByHashes`'s only rescue with it. The reviewer's real-path probe:
full read + 130 search credits + mtime touch + edit → BLOCK on this branch, allow on
master. Eviction now spends search-credit records first, oldest among them first, and
falls through to genuine reads only when the credits run out. Trimming stays in place,
because `EditRecord.precedingReads` holds a reference to the same array. The probe
shape is pinned as a regression test and mutation-proofed.

**F2 (LOW), fixed.** The friction claim above now reads as a replay result with its
limits, not a bound, and names the reviewer's legitimate flip.

**F3 (LOW), noted not fixed.** The `grep -C2 | head -N` truncation gap is called out
under "Known gap, filed separately"; the reviewer is filing the issue.

**F4 (LOW), fixed.** Added the missing fourth outcome test: `not-decidable`, reached
through a real `checkEdit` with an empty `lineHashes` map.

**F5 (INFO), fixed.** `readCountForFile` is logged post-trim, so it saturates at the
cap. `read_recorded` now also carries `rawReadCountForFile`, the pre-trim arrival count,
next to `evictedRecordCount`.

Re-verified after the round: `npm run build`, `npm run lint`, 18 files / **580 tests
green**. After merging the branch head (which had picked up master and #1901), re-ran
the governance suites: 10 files / **389 tests green**, `session-state-conformance`
included.

`tests/clients/runtime-tool-result.test.ts` had one sibling assertion encoding the old
±2 behavior (`effectiveOffset: 7, effectiveLimit: 5` for a bare `grep -n`). It now
asserts the delivered line, and a companion case covers `grep -n -C2`.

## Blast radius

- `SearchReadLocation` gains two optional fields. Producers: `bash-file-access.ts`
  (sets them), `tools/ast-grep-search.ts` and `tools/lsp-navigation.ts` (do not — their
  locations are exact match spans, which is correct). Their suites pass unchanged.
- `ReadRecord` gains one optional field. It rides `PersistedReadGuardState`, so a
  resumed session carries it; `session-state-store` and `session-state-conformance`
  pass.
- `validateRangeSnapshot` is private with one caller (`checkEdit`), which now passes
  its own `skipSnapshotCheck`.
- Hot path: registration adds one small regex scan per grep segment, run once per bash
  `tool_result`, not per hit. `recordRead` adds a length compare; the splice fires only
  past 128 records on a single file.
- Capping `this.edits` is inert for behavior: `canTreatStalenessAsOwnPriorEdit` reads
  only the last record, and `findRelocation`'s window saturates at
  `RELOCATION_WINDOW_MAX / RELOCATION_WINDOW_PER_EDIT` = 20 applied edits, far below
  256. `getStats`, a debug surface, undercounts past the cap.

## Class sweep

**Pattern sweep** across `clients/ tools/ mcp/ scripts/ index.ts`:
- Blanket slack added to a credited range (`grep -niE "MARGIN|contextMargin|slack"`):
  one site, `search-read-registration.ts:34`, fixed. Every other hit is CSS, spawn
  grace, or cascade-cost prose.
- Outer cap without per-key bound (`grep -nE "MAX_[A-Z_]+ *="`, then read each
  Map-of-arrays): `read-guard.ts` `this.edits` was the one sibling — fixed here.
  `metrics-history.ts:46` (`MAX_HISTORY_PER_FILE`) and
  `lsp-mutation.ts:84` (`MAX_SUMMARIES_PER_CONTEXT`) already bound per key;
  `lsp/spawn-history.ts:3` stores a scalar per key.

**Population sweep** — every read-credit producer in the tree
(`recordRead` / `recordSymbolRead` call sites), with a verdict each:

| Site | Verdict |
| --- | --- |
| `clients/search-read-registration.ts:109` | defective, fixed |
| `clients/read-bridge.ts:194` | correct: credits the consumer's reported delivered range |
| `clients/runtime-tool-call.ts:827` | correct: credits `deliveredLimit` |
| `clients/runtime-tool-call.ts:1017`, `:1113` | correct: content-verified oldText match range |
| `clients/runtime-tool-call.ts:1274` | correct: content-verified relocation target |
| `clients/runtime-tool-result.ts:576` | correct: exact span shown by cat/head/tail/sed -n |
| `clients/read-guard.ts:1233` | correct: full file the agent authored |
| `tools/module-report.ts:210`, `index.ts:1482`, `:1492` | correct: `recordSymbolRead` delivers the body; outlines deliberately excluded |

## Observability

Production proof lives in `~/.pi-lens/read-guard.log`:
- `read_recorded` metadata now carries `searchCreditReason`,
  `searchCreditMarginBefore`, `searchCreditMarginAfter`. A session where search credits
  dominate is now visible as `match-lines-only` records with `effectiveLimit: 1`
  instead of an indistinguishable run of 5-line reads.
- `range_snapshot_validation` metadata carries `outcome`. The enforcement rate the
  issue could not compute is now a group-by on that field.
- The read cap emits `evictedRecordCount` and `rawReadCountForFile` on the
  `read_recorded` record that triggered the trim, so a trim is visible, attributable to
  its file, and still shows arrival growth after `readCountForFile` saturates.

## Merge order

No conflict with the open PRs. #1902, #1901, #1896, and #1880 touch none of
`read-guard.ts`, `search-read-registration.ts`, `bash-file-access.ts`, or
`runtime-tool-result.ts` (verified with `gh pr diff --name-only` on each). Any order
works.

