### PR TITLE
fix(cascade): bound the tier-3 reconcile backlog and remove the dead neighbour-touch cache (closes #1899)

### DIFF
--- a/.changelog/1899-cascade-tier3-backlog.md
+++ b/.changelog/1899-cascade-tier3-backlog.md
@@ -1,0 +1,12 @@
+---
+section: Fixed
+---
+
+- **Bound the cascade tier-3 reconcile backlog and drop the dead neighbour-touch
+  cache ([closes #1899](https://github.com/apmantza/pi-lens/issues/1899))** —
+  the outstanding-touch registry now caps its entry count and its entry age
+  instead of growing until a quiet window arrives, every sweep writes a backlog
+  gauge to `cascade.log`, and an unresolved touch says which of the five causes
+  kept it unresolved. The same-write neighbour-touch cache is removed: its read
+  gate could only pass inside a single write, so it measured 0 hits across 236
+  cold touches.

--- a/.changelog/1899-cascade-tier3-backlog.md
+++ b/.changelog/1899-cascade-tier3-backlog.md
@@ -2,8 +2,7 @@
 section: Fixed
 ---
 
-- **Bound the cascade tier-3 reconcile backlog and drop the dead neighbour-touch
-  cache ([closes #1899](https://github.com/apmantza/pi-lens/issues/1899))** —
+- **Bound the cascade tier-3 reconcile backlog and drop the dead neighbour-touch cache ([closes #1899](https://github.com/apmantza/pi-lens/issues/1899))** —
   the outstanding-touch registry now caps its entry count and its entry age
   instead of growing until a quiet window arrives, every sweep writes a backlog
   gauge to `cascade.log`, and an unresolved touch says which of the five causes

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -223,7 +223,16 @@ export type DegradationKind =
 	 * carries the rule name so a specific stuck rule (vs. a whole-binary
 	 * mismatch) is diagnosable from the ledger alone.
 	 */
-	| "biome-explain-unavailable";
+	| "biome-explain-unavailable"
+	/**
+	 * The tier-3 cascade's outstanding-touch registry
+	 * (`clients/lsp/cascade-tier.ts`) reached its cap before a quiet-window
+	 * reconcile drained it, so the oldest touch was dropped unanswered (#1899).
+	 * The registry is drained in full by every sweep, but the sweep runs on
+	 * pi's `agent_settled` window and dogfood logs show gaps up to 52 minutes;
+	 * this kind means a session out-touched that cadence.
+	 */
+	| "cascade-tier3-backlog-evicted";
 
 export interface DegradationRecord {
 	kind: unknown;

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -441,7 +441,6 @@ export function resetDispatchBaselines(cwd?: string): void {
 	clearReviewGraphWorkspaceCache();
 	clearReverseDepsIndexCache();
 	clearModuleGraphCache();
-	neighborTouchCache.clear();
 	recentlyCleanNeighborCache.clear();
 	primaryFilesThisTurn.clear();
 	cascadeDiagnosticBaselines.clear();
@@ -468,15 +467,21 @@ export function getCascadeSessionStats(): {
 	return { ...cascadeSessionStats };
 }
 
-// A5: per-turn neighbor-touch cache keyed by normalized path.
-// Avoids re-touching the same neighbor on every write in a multi-file refactor.
-// Invalidated when writeSeq advances (i.e. a new write starts a new pipeline run).
-type NeighborCacheEntry = {
-	turnSeq: number;
-	writeSeq: number;
-	diagnostics: import("./types.js").Diagnostic[];
-};
-const neighborTouchCache = new Map<string, NeighborCacheEntry>();
+// #1899: the A5 per-write `neighborTouchCache` used to live here. It was
+// removed as dead BY CONSTRUCTION, not merely unused. Its read gate required
+// `cached.turnSeq === turnSeq && cached.writeSeq === writeSeq`, and `writeSeq`
+// is pi's per-write index (`ctx.telemetry.writeIndex`, clients/pipeline.ts),
+// which advances on every write. One write starts one cascade, so a hit needed
+// two cascade computations inside a SINGLE write — a shape the pipeline never
+// produces. Dogfooding measured 0 hits across 236 cold touches.
+//
+// Broadening it was considered and rejected. Dropping the `writeSeq` equality
+// to make it turn-scoped would serve a neighbour's diagnostics from BEFORE a
+// later write in the same turn, which is the stale-answer trap #1092/#1095
+// closed. The two caches that remain already cover the safe reuse: the
+// passive-snapshot path (TTL plus content binding) and
+// `recentlyCleanNeighborCache` (clean answers only, with a fresh-passive-error
+// override).
 
 // Cross-turn clean cache: neighbor touches that recently returned no errors can
 // be skipped for a few turns. LSP servers push diagnostics proactively when a
@@ -487,14 +492,12 @@ const recentlyCleanNeighborCache = new Map<
 	RecentlyCleanNeighborEntry
 >();
 
-/** O(1) entry counts of this module's turn-bounded caches (#1123 item 2
- *  memory attribution) — both are `Map.size` reads, never iterated. */
+/** O(1) entry count of this module's turn-bounded cache (#1123 item 2
+ *  memory attribution) — a `Map.size` read, never iterated. */
 export function getDispatchCascadeCacheStats(): {
-	neighborTouchCacheSize: number;
 	recentlyCleanNeighborCacheSize: number;
 } {
 	return {
-		neighborTouchCacheSize: neighborTouchCache.size,
 		recentlyCleanNeighborCacheSize: recentlyCleanNeighborCache.size,
 	};
 }
@@ -510,7 +513,6 @@ function ensureCascadeTurnScope(turnSeq: number): void {
 	if (turnSeq === cascadeTurnScope) return;
 	cascadeTurnScope = turnSeq;
 	primaryFilesThisTurn.clear();
-	neighborTouchCache.clear();
 	for (const [key, entry] of recentlyCleanNeighborCache) {
 		if (turnSeq - entry.turnSeq > RECENTLY_CLEAN_TTL_TURNS) {
 			recentlyCleanNeighborCache.delete(key);
@@ -1550,12 +1552,12 @@ export async function computeCascadeForFile(
 	// deferred EVERY neighbour is distinguishable from a genuine leaf (both are
 	// `neighborCount: 0` with no output otherwise).
 	let collectLaterSkipped = 0;
-	// #1446 item 5: `recentlyCleanNeighborCache` and `neighborTouchCache` hits
-	// are the whole point of both caches, but neither was ever counted — the
-	// only visible signal was 267s/day of touch wall time with no way to tell
-	// whether the caches were absorbing repeat work or every touch was cold.
+	// #1446 item 5: `recentlyCleanNeighborCache` hits are the whole point of the
+	// cache, but they were never counted — the only visible signal was 267s/day
+	// of touch wall time with no way to tell whether the cache was absorbing
+	// repeat work or every touch was cold. (#1899 removed the sibling
+	// `cacheHits` counter along with the dead `neighborTouchCache`.)
 	let recentlyCleanHits = 0;
-	let cacheHits = 0;
 	// F1 (#1446 follow-up): `coldTouches` must be counted at the point each
 	// neighbour's OUTCOME is actually known, not derived from `coldSnapshotPaths`
 	// (finalized earlier, before the cache-hit checks below run against it). Using
@@ -1742,32 +1744,9 @@ export async function computeCascadeForFile(
 					} satisfies CascadeResult["neighbors"][number];
 				}
 
-				// A5: skip re-touch if this neighbor was already diagnosed at the current
-				// write sequence. A new write (higher writeSeq) invalidates the cache entry.
-				const cached =
-					writeSeq != null ? neighborTouchCache.get(cacheKey) : undefined;
-				if (cached?.turnSeq === turnSeq && cached?.writeSeq === writeSeq) {
-					producedLspData = true;
-					cacheHits++;
-					const durationMs = Date.now() - neighborStart;
-					logCascade({
-						phase: "neighbor_snapshot",
-						filePath,
-						neighborFile: neighborPath,
-						diagnosticCount: cached.diagnostics.length,
-						durationMs,
-						autoPropagate: false,
-						snapshotMissing: false,
-						metadata: { cachedWriteSeq: writeSeq },
-					});
-					return {
-						filePath: neighborPath,
-						reason: neighborReason(importerSet, callerSet, neighborPath),
-						diagnostics: cached.diagnostics,
-						lspTouched: false,
-						durationMs,
-					} satisfies CascadeResult["neighbors"][number];
-				}
+				// #1899: the A5 same-write cache read stood here. See the removal note
+				// at the module's cache declarations — the gate could only pass inside
+				// a single write, which never runs two cascades.
 
 				const configuredServerCount =
 					getServersForFileWithConfig(neighborPath).length;
@@ -1851,8 +1830,8 @@ export async function computeCascadeForFile(
 									},
 								});
 								// Deliberately NOT cached as clean/diagnosed — the wait was
-								// skipped, not resolved, so neither neighborTouchCache nor
-								// recentlyCleanNeighborCache may treat this as a real answer
+								// skipped, not resolved, so recentlyCleanNeighborCache must
+								// not treat this as a real answer
 								// (#240 doctrine). Return undefined: the degraded-fallback
 								// path below still has a chance to surface a passive/stale
 								// snapshot, same as any other "no fresh data this touch" case.
@@ -1935,15 +1914,7 @@ export async function computeCascadeForFile(
 				);
 				const durationMs = Date.now() - neighborStart;
 
-				// Cache only a confirmed answer. An inconclusive or binding-rejected
-				// result must not become a confirmed cache hit on the next cascade.
-				if (writeSeq != null && confirmed) {
-					neighborTouchCache.set(cacheKey, {
-						turnSeq,
-						writeSeq,
-						diagnostics: diags,
-					});
-				}
+				// #1899: the A5 same-write cache write stood here.
 				if (diags.length === 0) {
 					// Only a CONFIRMED clean touch may seed the recently-clean cache
 					// (#1095: a bound-false touch is unconfirmed, exactly like inconclusive).
@@ -2159,7 +2130,6 @@ export async function computeCascadeForFile(
 	).length;
 		const selectedOutcomeCount =
 			passiveSnapshotHits +
-			cacheHits +
 			recentlyCleanHits +
 			deferredTouches +
 			coldTouches +
@@ -2197,11 +2167,10 @@ export async function computeCascadeForFile(
 			// #1446 item 5: cache effectiveness as a number instead of an inference
 			// from `coldSnapshot`/`snapshotMissing` flags scattered across
 			// per-neighbor `neighbor_touch`/`neighbor_snapshot` rows.
-			// F1: cacheHits + recentlyCleanHits + deferredTouches + coldTouches
+			// F1: recentlyCleanHits + deferredTouches + coldTouches
 				// retain their outcome semantics. Passive snapshots and no-server selections
 				// complete the selected-neighbor denominator; touchFailures is a bounded
 				// subtype of coldTouches, not an additional outcome.
-			cacheHits,
 			recentlyCleanHits,
 			deferredTouches,
 			coldTouches,

--- a/clients/lsp/cascade-tier.ts
+++ b/clients/lsp/cascade-tier.ts
@@ -63,6 +63,7 @@
  */
 
 import { logCascade } from "../cascade-logger.js";
+import { incrementDegradationCount } from "../degradation-ledger.js";
 import { logLatency } from "../latency-logger.js";
 import { normalizeMapKey } from "../path-utils.js";
 import { registerQuietWindowTask } from "../quiet-window.js";
@@ -154,7 +155,47 @@ interface OutstandingTouch {
 // replaces the earlier entry (only the most recent touch matters — an
 // older touch's diagnostics, if they ever arrive, are still a strict superset
 // concern the newer touch already re-supersedes via didOpen/didChange).
+//
+// #1899: the registry is drained in full by every reconcile sweep, but nothing
+// bounded it BETWEEN sweeps. The sweep runs on pi's `agent_settled` quiet
+// window, and a session can go a long time without one — dogfood logs show
+// sweeps up to 52 minutes apart. So the two bounds below are the registry's
+// own, independent of when a sweep arrives:
+//
+//   - `MAX_OUTSTANDING_TOUCHES` caps the entry count. Entries are held in
+//     touch order (see `recordOutstandingCascadeTouch`), so eviction takes the
+//     oldest touch at O(1).
+//   - `OUTSTANDING_TOUCH_MAX_AGE_MS` caps how long a touch stays reconcilable.
+//     Past it, the touch is discarded rather than answered: re-injecting a
+//     neighbour error, or clearing a footer entry, from a touch fired that
+//     long ago reports a state the agent has already moved past.
+//
+// Both constants are sized from the 2026-08-09..20 dogfood window (cascade.log,
+// 67 sweeps / 756 entries): the largest single sweep held 53 entries, and a
+// 15-minute age bound retains 72 of the 80 outcomes that ever resolved (90%)
+// while discarding the tail that resolved after ~26-52 minutes.
+const MAX_OUTSTANDING_TOUCHES = 256;
+const OUTSTANDING_TOUCH_MAX_AGE_MS = 15 * 60_000;
+
 const _outstandingTouches = new Map<string, OutstandingTouch>();
+
+/** Entries dropped by the age bound since the last sweep reported. */
+let _expiredSinceLastSweep = 0;
+/** Entries dropped by the size cap since the last sweep reported. */
+let _evictedSinceLastSweep = 0;
+
+/**
+ * Drop every entry older than `OUTSTANDING_TOUCH_MAX_AGE_MS`. The map is held
+ * in touch order, so the expired entries are a prefix and the walk stops at
+ * the first live one.
+ */
+function pruneExpiredOutstandingTouches(now: number): void {
+	for (const [key, touch] of _outstandingTouches) {
+		if (now - touch.touchedAt <= OUTSTANDING_TOUCH_MAX_AGE_MS) break;
+		_outstandingTouches.delete(key);
+		_expiredSinceLastSweep++;
+	}
+}
 
 /**
  * Record a Tier-3 cascade touch that skipped its in-lane wait. Called right
@@ -162,14 +203,44 @@ const _outstandingTouches = new Map<string, OutstandingTouch>();
  * without waiting. `touchedAt` must be sampled BEFORE the notify (see the
  * field doc) so the reconcile comparison can never misread a publish that
  * raced the record as pre-touch.
+ *
+ * #1899: also enforces the registry's two bounds. The `delete` before the
+ * `set` is load-bearing — `Map.set` on an existing key keeps the key's
+ * ORIGINAL insertion position, so without it a re-touched file would keep a
+ * stale position and both the age prefix walk and the oldest-first eviction
+ * would pick the wrong entry.
  */
 export function recordOutstandingCascadeTouch(entry: OutstandingTouch): void {
-	_outstandingTouches.set(normalizeMapKey(entry.filePath), entry);
+	const key = normalizeMapKey(entry.filePath);
+	_outstandingTouches.delete(key);
+	// `Date.now()`, not `entry.touchedAt`: the caller samples `touchedAt` before
+	// its notify, so it trails real time, and the age bound is a statement about
+	// the clock rather than about the newest touch's own stamp.
+	pruneExpiredOutstandingTouches(Date.now());
+	_outstandingTouches.set(key, entry);
+	while (_outstandingTouches.size > MAX_OUTSTANDING_TOUCHES) {
+		const oldest = _outstandingTouches.keys().next();
+		if (oldest.done) break;
+		_outstandingTouches.delete(oldest.value);
+		_evictedSinceLastSweep++;
+		// Bounded by construction: one ledger tally per session, not per
+		// eviction event. The subject is the cap itself rather than the evicted
+		// path — the discriminating fact is "this session overflowed the tier-3
+		// backlog", and per-path subjects would unbound the ledger group.
+		incrementDegradationCount({
+			kind: "cascade-tier3-backlog-evicted",
+			subject: `cap=${MAX_OUTSTANDING_TOUCHES}`,
+			reason:
+				"tier-3 outstanding-touch registry hit its cap before a quiet-window reconcile drained it; the oldest touch was dropped unanswered",
+		});
+	}
 }
 
 /** Test-only: clear the outstanding-touch registry between test cases. */
 export function _resetOutstandingCascadeTouchesForTests(): void {
 	_outstandingTouches.clear();
+	_expiredSinceLastSweep = 0;
+	_evictedSinceLastSweep = 0;
 }
 
 /** Test-only: peek at the registry without mutating it. */
@@ -177,10 +248,33 @@ export function _getOutstandingCascadeTouchesForTests(): OutstandingTouch[] {
 	return [...(_outstandingTouches.values() as Iterable<OutstandingTouch>)];
 }
 
+/**
+ * #1899: WHY a touch stayed unresolved. Five distinct causes used to collapse
+ * into the single word `unresolved`, which is what made the dogfood backlog
+ * unreadable: 676 of 756 outcomes were `unresolved` with no way to tell the
+ * EXPECTED case (a `silentOnClean` server has nothing to say about a clean
+ * neighbour) from a real degradation (the server went cold, or the lookup
+ * threw). Same doctrine as the repo's empty-result rule — an absent answer
+ * must still say which kind of absence it is.
+ */
+export type UnresolvedReason =
+	/** No warm client for the file — the server was idle-reaped since the touch. */
+	| "warm-miss"
+	/** A warm client exists, but it is a different server than the one touched. */
+	| "server-mismatch"
+	/** The client holds no diagnostics entry for this file at all. */
+	| "no-publish"
+	/** An entry exists, but its publish predates the touch — nothing new landed. */
+	| "no-publish-since-touch"
+	/** The client lookup threw. */
+	| "error";
+
 export interface ReconcileOutcome {
 	filePath: string;
 	serverId: string;
 	outcome: "resolved-found" | "resolved-clean" | "unresolved";
+	/** Present only for `unresolved`. */
+	unresolvedReason?: UnresolvedReason;
 	ageMs: number;
 	diagnosticCount?: number;
 	/**
@@ -226,6 +320,10 @@ export async function reconcileOutstandingCascadeTouches(
 	lspService: Pick<LSPService, "getWarmClientForFile">,
 ): Promise<ReconcileOutcome[]> {
 	const outcomes: ReconcileOutcome[] = [];
+	// #1899: the age bound applies at sweep time too, not only at record time —
+	// a registry that received no further touches would otherwise hand the sweep
+	// entries of unbounded age.
+	pruneExpiredOutstandingTouches(Date.now());
 	const entries = [..._outstandingTouches.entries()];
 	_outstandingTouches.clear();
 
@@ -238,6 +336,7 @@ export async function reconcileOutstandingCascadeTouches(
 					filePath: touch.filePath,
 					serverId: touch.serverId,
 					outcome: "unresolved",
+					unresolvedReason: spawned ? "server-mismatch" : "warm-miss",
 					ageMs,
 				});
 				continue;
@@ -252,6 +351,7 @@ export async function reconcileOutstandingCascadeTouches(
 					filePath: touch.filePath,
 					serverId: touch.serverId,
 					outcome: "unresolved",
+					unresolvedReason: entry ? "no-publish-since-touch" : "no-publish",
 					ageMs,
 				});
 				continue;
@@ -272,6 +372,7 @@ export async function reconcileOutstandingCascadeTouches(
 				filePath: touch.filePath,
 				serverId: touch.serverId,
 				outcome: "unresolved",
+				unresolvedReason: "error",
 				ageMs,
 			});
 			logLatency({
@@ -334,9 +435,7 @@ export function registerCascadeTierReconcileTask(
 
 	registerQuietWindowTask("cascade_tier3_reconcile", async () => {
 		if (!isTierAwareCascadeEnabled()) return;
-		if (_outstandingTouches.size === 0) return;
 		const outcomes = await reconcileOutstandingCascadeTouches(getLspService());
-		if (outcomes.length === 0) return;
 
 		// #1023: re-inject each resolved-found neighbor error so it reaches the
 		// agent (previously logs-only). #1444: hand each resolved-CLEAN outcome to
@@ -369,14 +468,29 @@ export function registerCascadeTierReconcileTask(
 		let resolvedClean = 0;
 		let unresolved = 0;
 		let ageSumMs = 0;
+		let maxAgeMs = 0;
+		const unresolvedByReason: Partial<Record<UnresolvedReason, number>> = {};
 		for (const o of outcomes) {
 			if (o.outcome === "resolved-found") resolvedFound++;
 			else if (o.outcome === "resolved-clean") resolvedClean++;
-			else unresolved++;
+			else {
+				unresolved++;
+				const reason = o.unresolvedReason ?? "no-publish";
+				unresolvedByReason[reason] = (unresolvedByReason[reason] ?? 0) + 1;
+			}
 			ageSumMs += o.ageMs;
+			if (o.ageMs > maxAgeMs) maxAgeMs = o.ageMs;
 		}
-		const avgAgeMs = Math.round(ageSumMs / outcomes.length);
+		const avgAgeMs = outcomes.length
+			? Math.round(ageSumMs / outcomes.length)
+			: 0;
 
+		// #1899: emitted on EVERY sweep, including the empty one. The backlog's
+		// size was previously observable only when it was non-empty, so "the
+		// queue is drained" and "the sweep never ran" read identically in
+		// cascade.log. This record is the backlog gauge: what the sweep drained,
+		// what the two bounds dropped since the last sweep, and what the bounds
+		// are, so a reader never has to know the constants to judge the numbers.
 		logCascade({
 			phase: "cascade_tier3_reconcile",
 			filePath: "<quiet-window>",
@@ -385,10 +499,18 @@ export function registerCascadeTierReconcileTask(
 				resolvedFound,
 				resolvedClean,
 				unresolved,
+				unresolvedByReason,
 				avgAgeMs,
+				maxAgeMs,
+				expired: _expiredSinceLastSweep,
+				evicted: _evictedSinceLastSweep,
+				capacity: MAX_OUTSTANDING_TOUCHES,
+				maxAgeCapMs: OUTSTANDING_TOUCH_MAX_AGE_MS,
 				outcomes,
 			},
 		});
+		_expiredSinceLastSweep = 0;
+		_evictedSinceLastSweep = 0;
 	});
 }
 

--- a/clients/memory-sampler.ts
+++ b/clients/memory-sampler.ts
@@ -89,7 +89,6 @@ export interface MemorySampleSubsystems {
 		treeCacheTotalBytes: number;
 	} | null;
 	dispatchCaches: {
-		neighborTouchCacheSize: number;
 		recentlyCleanNeighborCacheSize: number;
 	};
 }

--- a/tests/clients/cascade-compute.test.ts
+++ b/tests/clients/cascade-compute.test.ts
@@ -1037,7 +1037,6 @@ describe("computeCascadeForFile", () => {
 					phase: "cascade_result",
 					metadata: expect.objectContaining({
 						recentlyCleanHits: 1,
-						cacheHits: 0,
 					}),
 				}),
 			);
@@ -1046,7 +1045,13 @@ describe("computeCascadeForFile", () => {
 		}
 	});
 
-	it("#1446 item 5: cascade_result records cacheHits when the same-write neighbor cache short-circuits a re-touch", async () => {
+	// #1899: this used to assert the same-write `neighborTouchCache` short-
+	// circuited the re-touch. That cache is gone. It could only hit when two
+	// cascades ran inside ONE write, and `writeSeq` (pi's per-write index)
+	// advances on every write, so live sessions measured 0 hits across 236 cold
+	// touches. The test now pins the behavior that replaced it: a repeat cascade
+	// re-touches, and `cacheHits` is no longer part of the result record.
+	it("#1899: a repeat cascade in the same write re-touches (no same-write neighbor cache)", async () => {
 		const env = setupTestEnvironment("cascade-cache-hits-");
 		try {
 			const primary = path.join(env.tmpDir, "model.py");
@@ -1067,8 +1072,6 @@ describe("computeCascadeForFile", () => {
 				"../../clients/dispatch/integration.js"
 			);
 
-			// First cascade at turnSeq/writeSeq 1 performs the real touch and
-			// populates neighborTouchCache.
 			await computeCascadeForFile(primary, env.tmpDir, {
 				turnSeq: 1,
 				writeSeq: 1,
@@ -1076,23 +1079,19 @@ describe("computeCascadeForFile", () => {
 			expect(touchFile).toHaveBeenCalledTimes(1);
 			mocks.logCascade.mockClear();
 
-			// A second cascade run for the SAME turn/write (a second primary edited
-			// in the same pipeline pass touching the same neighbor) must reuse the
-			// cached diagnostics rather than re-touch, and the reuse must be counted.
 			await computeCascadeForFile(primary, env.tmpDir, {
 				turnSeq: 1,
 				writeSeq: 1,
 			});
-			expect(touchFile).toHaveBeenCalledTimes(1);
-			expect(mocks.logCascade).toHaveBeenCalledWith(
-				expect.objectContaining({
-					phase: "cascade_result",
-					metadata: expect.objectContaining({
-						cacheHits: 1,
-						recentlyCleanHits: 0,
-					}),
-				}),
+			expect(touchFile).toHaveBeenCalledTimes(2);
+
+			const resultCall = mocks.logCascade.mock.calls.find(
+				(call) => (call[0] as { phase?: string }).phase === "cascade_result",
 			);
+			const metadata = (resultCall![0] as { metadata: Record<string, unknown> })
+				.metadata;
+			expect(metadata).toMatchObject({ coldTouches: 1, recentlyCleanHits: 0 });
+			expect(metadata).not.toHaveProperty("cacheHits");
 		} finally {
 			env.cleanup();
 		}
@@ -1101,28 +1100,30 @@ describe("computeCascadeForFile", () => {
 	// F1 (adversarial review of #1446): `coldTouches` used to be derived from
 	// `coldSnapshotPaths.length`, a list finalized BEFORE the cache-hit checks
 	// inside the touch pool run — so a coldSnapshotPaths neighbour that then hit
-	// neighborTouchCache/recentlyCleanNeighborCache was double-counted (cold AND
+	// recentlyCleanNeighborCache was double-counted (cold AND
 	// cache/clean), while a non-autopropagate (activePaths) neighbour that missed
 	// both caches and took a genuine touch was counted in neither bucket. This
-	// exercises all four touch-pool outcomes in ONE run, with BOTH failure modes
-	// live at once: `neighborCache` (.ts, autoPropagate) sits in
-	// `coldSnapshotPaths` on every run (its snapshot is never valid) yet resolves
-	// via `neighborTouchCache` on this run — the double-count case — while
-	// `neighborCold` (.py, activePaths) takes a genuine cold touch and would be
-	// invisible to the old `coldSnapshotPaths.length` derivation entirely — the
-	// silent-drop case. The four counters must still partition the touched-
-	// neighbour count exactly.
-	it("F1: cacheHits/recentlyCleanHits/coldTouches/deferredTouches partition the touched-neighbour set", async () => {
+	// exercises the touch-pool outcomes in ONE run: `neighborColdTs` (.ts,
+	// autoPropagate) sits in `coldSnapshotPaths` on every run (its snapshot is
+	// never valid) and takes a genuine cold touch — the double-count case —
+	// while `neighborCold` (.py, activePaths) takes a genuine cold touch too and
+	// would be invisible to the old `coldSnapshotPaths.length` derivation
+	// entirely — the silent-drop case. The counters must still partition the
+	// touched-neighbour count exactly.
+	//
+	// #1899 dropped the `cacheHits` bucket with the dead `neighborTouchCache`;
+	// the partition invariant is unchanged and now spans three buckets.
+	it("F1: recentlyCleanHits/coldTouches/deferredTouches partition the touched-neighbour set", async () => {
 		const env = setupTestEnvironment("cascade-f1-partition-");
 		try {
 			const primary = path.join(env.tmpDir, "hub.py");
-			const neighborCache = path.join(env.tmpDir, "src", "cache_hit.ts");
+			const neighborColdTs = path.join(env.tmpDir, "src", "cache_hit.ts");
 			const neighborClean = path.join(env.tmpDir, "recently_clean.py");
 			const neighborCold = path.join(env.tmpDir, "genuinely_cold.py");
 			const neighborDeferred = path.join(env.tmpDir, "src", "deferred.ts");
 			fs.writeFileSync(primary, "class Hub: pass\n");
-			fs.mkdirSync(path.dirname(neighborCache), { recursive: true });
-			fs.writeFileSync(neighborCache, "export const cacheHit = 1;\n");
+			fs.mkdirSync(path.dirname(neighborColdTs), { recursive: true });
+			fs.writeFileSync(neighborColdTs, "export const cacheHit = 1;\n");
 			fs.writeFileSync(neighborClean, "from hub import Hub  # clean\n");
 			fs.writeFileSync(neighborCold, "from hub import Hub  # cold\n");
 			fs.writeFileSync(
@@ -1131,7 +1132,7 @@ describe("computeCascadeForFile", () => {
 			);
 
 			const touchFile = vi.fn().mockImplementation(async (p: string) => {
-				if (p === neighborCache) return { diags: [lspError("cache seed")] };
+				if (p === neighborColdTs) return { diags: [lspError("cache seed")] };
 				if (p === neighborClean) return { diags: [] };
 				if (p === neighborCold) return { diags: [lspError("genuinely cold")] };
 				return undefined; // neighborDeferred's notify-only touch
@@ -1164,11 +1165,10 @@ describe("computeCascadeForFile", () => {
 				"../../clients/dispatch/integration.js"
 			);
 
-			// Setup run: seeds neighborTouchCache (neighborCache, a real error)
-			// and recentlyCleanNeighborCache (neighborClean, a confirmed clean
-			// touch) at turnSeq=1/writeSeq=1.
+			// Setup run: seeds recentlyCleanNeighborCache (neighborClean, a
+			// confirmed clean touch) at turnSeq=1/writeSeq=1.
 			mocks.computeImpactCascade.mockReturnValueOnce(
-				impact(primary, [neighborCache, neighborClean]),
+				impact(primary, [neighborColdTs, neighborClean]),
 			);
 			await computeCascadeForFile(primary, env.tmpDir, {
 				turnSeq: 1,
@@ -1177,11 +1177,11 @@ describe("computeCascadeForFile", () => {
 			expect(touchFile).toHaveBeenCalledTimes(2);
 			mocks.logCascade.mockClear();
 
-			// Main run, SAME turnSeq/writeSeq (so neighborCache's cache entry
-			// matches exactly) plus two new neighbours neither cache has seen.
+			// Main run, SAME turnSeq/writeSeq, plus two new neighbours the
+			// recently-clean cache has not seen.
 			mocks.computeImpactCascade.mockReturnValueOnce(
 				impact(primary, [
-					neighborCache,
+					neighborColdTs,
 					neighborClean,
 					neighborCold,
 					neighborDeferred,
@@ -1199,7 +1199,6 @@ describe("computeCascadeForFile", () => {
 			const metadata = (
 				resultCall![0] as {
 					metadata: {
-						cacheHits: number;
 						recentlyCleanHits: number;
 						coldTouches: number;
 						deferredTouches: number;
@@ -1207,9 +1206,8 @@ describe("computeCascadeForFile", () => {
 				}
 			).metadata;
 			expect(metadata).toMatchObject({
-				cacheHits: 1,
 				recentlyCleanHits: 1,
-				coldTouches: 1,
+				coldTouches: 2,
 				deferredTouches: 1,
 			});
 			// The partition invariant: every touched neighbour (the 4 in this
@@ -1218,8 +1216,7 @@ describe("computeCascadeForFile", () => {
 			// undercounting bug).
 			const touchedNeighbourCount = 4;
 			expect(
-				metadata.cacheHits +
-					metadata.recentlyCleanHits +
+				metadata.recentlyCleanHits +
 					metadata.coldTouches +
 					metadata.deferredTouches,
 			).toBe(touchedNeighbourCount);
@@ -2426,7 +2423,9 @@ describe("computeCascadeForFile", () => {
 				expect(neighborTouchEntry?.metadata).toMatchObject({
 					inconclusive: true,
 				});
-				expect(getDispatchCascadeCacheStats().neighborTouchCacheSize).toBe(0);
+				expect(
+					getDispatchCascadeCacheStats().recentlyCleanNeighborCacheSize,
+				).toBe(0);
 				expect(run.result?.neighbors[0]).toMatchObject({
 					inconclusive: true,
 				});
@@ -2540,7 +2539,9 @@ describe("computeCascadeForFile", () => {
 				expect(diags).toHaveLength(1);
 				expect(diags?.[0]?.message).toBe("live cross-file error");
 				// Not cached as a confirmed neighbor result either.
-				expect(getDispatchCascadeCacheStats().neighborTouchCacheSize).toBe(0);
+				expect(
+					getDispatchCascadeCacheStats().recentlyCleanNeighborCacheSize,
+				).toBe(0);
 				// The third unconfirmed-touch cause is named in cascade.log, so it is
 				// distinguishable from the inconclusive and bound-false causes.
 				const neighborTouchEntry = mocks.logCascade.mock.calls

--- a/tests/clients/lsp/cascade-tier-backlog.test.ts
+++ b/tests/clients/lsp/cascade-tier-backlog.test.ts
@@ -1,0 +1,319 @@
+/**
+ * #1899: the tier-3 outstanding-touch registry's own bounds, and the backlog
+ * gauge the reconcile sweep writes.
+ *
+ * The registry is drained in full by every reconcile sweep, but the sweep runs
+ * on pi's `agent_settled` quiet window. Dogfooding measured sweeps up to 52
+ * minutes apart (cascade.log, 2026-08-09..20, 67 sweeps / 756 outcomes), so
+ * between sweeps the registry had no size bound and no age bound at all. These
+ * tests pin both bounds, and pin the gauge that makes backlog health readable
+ * from cascade.log alone.
+ *
+ * The classifier, the reconcile verdicts, and the kill switch live in
+ * cascade-tier.test.ts; this file covers only the bounds and the observability.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { normalizeMapKey } from "../../../clients/path-utils.js";
+
+const getServersForFileWithConfig = vi.fn();
+const registerQuietWindowTask = vi.fn();
+// Module scope so the spy identity survives `vi.resetModules()` — a
+// factory-local `vi.fn()` is rebuilt with the module, and the assertions would
+// then read a different spy than the code under test called.
+const logCascade = vi.fn();
+
+vi.mock("../../../clients/lsp/config.js", () => ({
+	getServersForFileWithConfig,
+}));
+
+vi.mock("../../../clients/quiet-window.js", () => ({
+	registerQuietWindowTask,
+}));
+
+vi.mock("../../../clients/cascade-logger.js", () => ({
+	logCascade,
+}));
+
+vi.mock("../../../clients/latency-logger.js", () => ({
+	logLatency: vi.fn(),
+}));
+
+const FILE = "C:/repo/neighbor.ts";
+
+/** Mirrors `MAX_OUTSTANDING_TOUCHES` in clients/lsp/cascade-tier.ts. */
+const CAP = 256;
+/** Mirrors `OUTSTANDING_TOUCH_MAX_AGE_MS` in clients/lsp/cascade-tier.ts. */
+const MAX_AGE_MS = 15 * 60_000;
+
+type Mod = typeof import("../../../clients/lsp/cascade-tier.js");
+type Ledger = typeof import("../../../clients/degradation-ledger.js");
+
+let mod: Mod;
+let ledger: Ledger;
+
+beforeEach(async () => {
+	vi.resetModules();
+	getServersForFileWithConfig.mockReset();
+	registerQuietWindowTask.mockReset();
+	logCascade.mockClear();
+	mod = await import("../../../clients/lsp/cascade-tier.js");
+	ledger = await import("../../../clients/degradation-ledger.js");
+	ledger.resetDegradationLedger();
+	mod._resetOutstandingCascadeTouchesForTests();
+	mod._resetCascadeTierReconcileRegistrationForTests();
+});
+
+function record(filePath: string, touchedAt: number): void {
+	mod.recordOutstandingCascadeTouch({
+		filePath,
+		serverId: "typescript",
+		touchedAt,
+	});
+}
+
+function heldPaths(): string[] {
+	return mod._getOutstandingCascadeTouchesForTests().map((t) => t.filePath);
+}
+
+function warm(serverId: string, rows: [string, unknown[], number][]) {
+	return {
+		client: {
+			serverId,
+			getAllDiagnostics: vi
+				.fn()
+				.mockReturnValue(
+					new Map(
+						rows.map(([p, diags, ts]) => [normalizeMapKey(p), { diags, ts }]),
+					),
+				),
+		},
+	};
+}
+
+function sweepGauge(): { phase: string; metadata: Record<string, unknown> } {
+	const row = logCascade.mock.calls
+		.map((call) => call[0])
+		.find((candidate) => candidate?.phase === "cascade_tier3_reconcile");
+	if (!row) throw new Error("no cascade_tier3_reconcile record was written");
+	return row;
+}
+
+describe("registry size bound", () => {
+	it("caps the registry and evicts the OLDEST touch first", () => {
+		const base = Date.now();
+		for (let i = 0; i < CAP; i++) record(`C:/repo/f${i}.ts`, base - CAP + i);
+		expect(heldPaths()).toHaveLength(CAP);
+
+		record("C:/repo/overflow.ts", base);
+
+		const paths = heldPaths();
+		expect(paths).toHaveLength(CAP);
+		// f0 held the oldest touch, so it is the one that goes.
+		expect(paths).not.toContain("C:/repo/f0.ts");
+		expect(paths).toContain("C:/repo/f1.ts");
+		expect(paths).toContain("C:/repo/overflow.ts");
+	});
+
+	it("records the eviction in the degradation ledger", () => {
+		const base = Date.now();
+		for (let i = 0; i <= CAP; i++) record(`C:/repo/f${i}.ts`, base - CAP + i);
+
+		const group = ledger
+			.getDegradationSummary()
+			.find((g) => g.kind === "cascade-tier3-backlog-evicted");
+		expect(group?.count).toBe(1);
+	});
+
+	it("does not evict while the registry is inside the cap", () => {
+		const base = Date.now();
+		for (let i = 0; i < CAP; i++) record(`C:/repo/f${i}.ts`, base - CAP + i);
+
+		expect(
+			ledger
+				.getDegradationSummary()
+				.find((g) => g.kind === "cascade-tier3-backlog-evicted"),
+		).toBeUndefined();
+	});
+
+	// The `delete` before the `set` in `recordOutstandingCascadeTouch` is what
+	// keeps the map in TOUCH order. Without it, `Map.set` on an existing key
+	// keeps that key's ORIGINAL position, so a re-touched file would still be
+	// evicted as "oldest" even though its touch is the newest in the registry.
+	it("re-touching a file moves it to the newest position", () => {
+		const base = Date.now();
+		for (let i = 0; i < CAP; i++) record(`C:/repo/f${i}.ts`, base - CAP + i);
+		record("C:/repo/f0.ts", base + 1);
+
+		record("C:/repo/overflow.ts", base + 2);
+
+		const paths = heldPaths();
+		expect(paths).toContain("C:/repo/f0.ts");
+		// f1 is now the oldest surviving touch, so it is the one evicted.
+		expect(paths).not.toContain("C:/repo/f1.ts");
+	});
+});
+
+describe("registry age bound", () => {
+	it("drops a touch older than the bound when a new touch is recorded", () => {
+		const now = Date.now();
+		record("C:/repo/ancient.ts", now - MAX_AGE_MS - 1);
+		record("C:/repo/fresh.ts", now);
+
+		expect(heldPaths()).toEqual(["C:/repo/fresh.ts"]);
+	});
+
+	it("keeps a touch that is still inside the bound", () => {
+		const now = Date.now();
+		record("C:/repo/old-but-ok.ts", now - MAX_AGE_MS + 60_000);
+		record("C:/repo/fresh.ts", now);
+
+		expect(heldPaths()).toContain("C:/repo/old-but-ok.ts");
+	});
+
+	// The bound must hold when no further touch arrives to trigger the
+	// record-time prune. That is the dogfood shape exactly: a burst of touches,
+	// a long busy stretch with no cascade, then one very late quiet window.
+	it("never reconciles a touch that aged past the bound while waiting for a sweep", async () => {
+		const getWarmClientForFile = vi.fn();
+		record("C:/repo/ancient.ts", Date.now() - MAX_AGE_MS - 1);
+
+		const outcomes = await mod.reconcileOutstandingCascadeTouches({
+			getWarmClientForFile,
+		} as never);
+
+		expect(outcomes).toEqual([]);
+		expect(getWarmClientForFile).not.toHaveBeenCalled();
+	});
+
+	it("still reconciles a touch that is inside the bound", async () => {
+		const touchedAt = Date.now() - 1_000;
+		record(FILE, touchedAt);
+
+		const outcomes = await mod.reconcileOutstandingCascadeTouches({
+			getWarmClientForFile: vi
+				.fn()
+				.mockResolvedValue(warm("typescript", [[FILE, [], touchedAt + 500]])),
+		} as never);
+
+		expect(outcomes[0]?.outcome).toBe("resolved-clean");
+	});
+});
+
+describe("backlog gauge", () => {
+	it("reports expired and evicted counts on the next sweep, then resets them", async () => {
+		const base = Date.now();
+		record("C:/repo/ancient.ts", base - MAX_AGE_MS - 1);
+		for (let i = 0; i <= CAP; i++) record(`C:/repo/f${i}.ts`, base - CAP + i);
+
+		mod.registerCascadeTierReconcileTask(
+			() =>
+				({
+					getWarmClientForFile: vi.fn().mockResolvedValue(undefined),
+				}) as never,
+		);
+		const task = registerQuietWindowTask.mock.calls[0][1] as () => Promise<void>;
+		await task();
+
+		expect(sweepGauge().metadata).toMatchObject({
+			count: CAP,
+			expired: 1,
+			evicted: 1,
+			capacity: CAP,
+			maxAgeCapMs: MAX_AGE_MS,
+		});
+
+		// The two counters are since-last-sweep, not cumulative.
+		logCascade.mockClear();
+		await task();
+		expect(sweepGauge().metadata).toMatchObject({ expired: 0, evicted: 0 });
+	});
+
+	it("breaks the unresolved count down by reason", async () => {
+		const touchedAt = Date.now() - 1_000;
+		mod.registerCascadeTierReconcileTask(
+			() =>
+				({
+					getWarmClientForFile: vi
+						.fn()
+						.mockImplementation(async (filePath: string) =>
+							filePath.endsWith("a.ts")
+								? undefined
+								: warm("typescript", []),
+						),
+				}) as never,
+		);
+		record("C:/repo/a.ts", touchedAt);
+		record("C:/repo/b.ts", touchedAt);
+
+		const task = registerQuietWindowTask.mock.calls[0][1] as () => Promise<void>;
+		await task();
+
+		const metadata = sweepGauge().metadata;
+		expect(metadata.unresolved).toBe(2);
+		expect(metadata.unresolvedByReason).toEqual({
+			"warm-miss": 1,
+			"no-publish": 1,
+		});
+		expect(metadata.maxAgeMs as number).toBeGreaterThan(0);
+	});
+});
+
+/**
+ * `unresolved` used to be one undifferentiated word covering five distinct
+ * causes, which is what made the dogfood backlog unreadable: 676 of 756
+ * outcomes were unresolved, and an EXPECTED silence from a `silentOnClean`
+ * server looked exactly like a server that had gone cold.
+ */
+describe("unresolved reason discrimination", () => {
+	async function reasonFor(
+		getWarmClientForFile: ReturnType<typeof vi.fn>,
+	): Promise<string | undefined> {
+		const touchedAt = Date.now() - 1_000;
+		record(FILE, touchedAt);
+		const outcomes = await mod.reconcileOutstandingCascadeTouches({
+			getWarmClientForFile,
+		} as never);
+		expect(outcomes[0]?.outcome).toBe("unresolved");
+		return outcomes[0]?.unresolvedReason;
+	}
+
+	it("warm-miss: the server was idle-reaped since the touch", async () => {
+		expect(await reasonFor(vi.fn().mockResolvedValue(undefined))).toBe(
+			"warm-miss",
+		);
+	});
+
+	it("server-mismatch: a different server is warm for the file now", async () => {
+		expect(
+			await reasonFor(
+				vi.fn().mockResolvedValue(warm("deno", [[FILE, [], Date.now()]])),
+			),
+		).toBe("server-mismatch");
+	});
+
+	it("no-publish: the client holds no entry for the file at all", async () => {
+		expect(
+			await reasonFor(vi.fn().mockResolvedValue(warm("typescript", []))),
+		).toBe("no-publish");
+	});
+
+	it("no-publish-since-touch: the only entry predates the touch", async () => {
+		expect(
+			await reasonFor(
+				vi
+					.fn()
+					.mockResolvedValue(
+						warm("typescript", [[FILE, [], Date.now() - 60_000]]),
+					),
+			),
+		).toBe("no-publish-since-touch");
+	});
+
+	it("error: the client lookup threw", async () => {
+		expect(await reasonFor(vi.fn().mockRejectedValue(new Error("boom")))).toBe(
+			"error",
+		);
+	});
+});

--- a/tests/clients/lsp/cascade-tier.test.ts
+++ b/tests/clients/lsp/cascade-tier.test.ts
@@ -12,6 +12,10 @@ import { normalizeMapKey } from "../../../clients/path-utils.js";
 
 const getServersForFileWithConfig = vi.fn();
 const registerQuietWindowTask = vi.fn();
+// Module-scope so the identity survives `vi.resetModules()` — a factory-local
+// `vi.fn()` is rebuilt with the module and the assertions would read a
+// different spy than the code under test called.
+const logCascade = vi.fn();
 
 vi.mock("../../../clients/lsp/config.js", () => ({
 	getServersForFileWithConfig,
@@ -22,7 +26,7 @@ vi.mock("../../../clients/quiet-window.js", () => ({
 }));
 
 vi.mock("../../../clients/cascade-logger.js", () => ({
-	logCascade: vi.fn(),
+	logCascade,
 }));
 
 vi.mock("../../../clients/latency-logger.js", () => ({
@@ -30,6 +34,19 @@ vi.mock("../../../clients/latency-logger.js", () => ({
 }));
 
 const FILE = "C:/repo/neighbor.ts";
+
+// #1899: the registry now bounds how OLD an outstanding touch may be
+// (`OUTSTANDING_TOUCH_MAX_AGE_MS`, 15 minutes), so a touch stamped at an
+// absolute `1_000` would read as ~56 years old and be discarded before any
+// reconcile saw it. These constants keep a touch inside the age bound while
+// staying EXPLICIT relative to one sampled base — the production comparison is
+// a strict `entry.ts > touchedAt`, so the ordering must never depend on two
+// wall-clock reads landing in different milliseconds.
+const NOW_BASE = Date.now();
+/** A touch fired 1s ago — well inside the age bound. */
+const TOUCH_TS = NOW_BASE - 1_000;
+/** A publish that landed after `TOUCH_TS`. */
+const PUBLISH_TS = NOW_BASE;
 
 function server(id: string, role?: "language" | "auxiliary") {
 	return { id, name: id, extensions: [".ts"], root: async () => "C:/repo", role };
@@ -262,9 +279,9 @@ describe("outstanding touch registry + reconcile", () => {
 	// the SAME millisecond, and the production comparison is deliberately a
 	// strict `entry.ts > touchedAt` (ties fail safe to unresolved), so
 	// real-clock sampling makes these tests non-deterministic.
-	const TOUCHED_AT = 1_000;
-	const AFTER_TOUCH = 2_000;
-	const BEFORE_TOUCH = 500;
+	const TOUCHED_AT = TOUCH_TS;
+	const AFTER_TOUCH = PUBLISH_TS;
+	const BEFORE_TOUCH = TOUCH_TS - 500;
 
 	it("resolves an outstanding touch as resolved-found when THAT FILE's diagnostics published after the touch", async () => {
 		mod.recordOutstandingCascadeTouch({
@@ -529,12 +546,29 @@ describe("registerCascadeTierReconcileTask", () => {
 		);
 	});
 
-	it("the registered task is a no-op when the registry is empty", async () => {
+	// #1899: an empty registry used to return before the log line, so "the
+	// backlog is drained" and "the sweep never ran" read identically in
+	// cascade.log. The sweep now always emits its gauge.
+	it("the registered task emits a zero gauge when the registry is empty", async () => {
+		logCascade.mockClear();
 		mod.registerCascadeTierReconcileTask(() => ({
 			getWarmClientForFile: vi.fn(),
 		}) as any);
 		const task = registerQuietWindowTask.mock.calls[0][1] as () => Promise<void>;
 		await expect(task()).resolves.toBeUndefined();
+
+		expect(logCascade).toHaveBeenCalledWith(
+			expect.objectContaining({
+				phase: "cascade_tier3_reconcile",
+				metadata: expect.objectContaining({
+					count: 0,
+					unresolved: 0,
+					avgAgeMs: 0,
+					expired: 0,
+					evicted: 0,
+				}),
+			}),
+		);
 	});
 
 	// #1023: a resolved-found neighbor error must be RE-INJECTED to the agent
@@ -549,7 +583,7 @@ describe("registerCascadeTierReconcileTask", () => {
 					new Map([
 						[
 							normalizeMapKey("C:/repo/neighbor.ts"),
-							{ diags: [{ message: "cold neighbor err", severity: 1 }], ts: 2_000 },
+							{ diags: [{ message: "cold neighbor err", severity: 1 }], ts: PUBLISH_TS },
 						],
 					]),
 				),
@@ -562,7 +596,7 @@ describe("registerCascadeTierReconcileTask", () => {
 		mod.recordOutstandingCascadeTouch({
 			filePath: "C:/repo/neighbor.ts",
 			serverId: "typescript",
-			touchedAt: 1_000,
+			touchedAt: TOUCH_TS,
 		});
 		const task = registerQuietWindowTask.mock.calls[0][1] as () => Promise<void>;
 		await task();
@@ -587,7 +621,7 @@ describe("registerCascadeTierReconcileTask", () => {
 				serverId: "typescript",
 				getAllDiagnostics: vi.fn().mockReturnValue(
 					new Map([
-						[normalizeMapKey("C:/repo/neighbor.ts"), { diags: [], ts: 2_000 }],
+						[normalizeMapKey("C:/repo/neighbor.ts"), { diags: [], ts: PUBLISH_TS }],
 					]),
 				),
 			},
@@ -599,7 +633,7 @@ describe("registerCascadeTierReconcileTask", () => {
 		mod.recordOutstandingCascadeTouch({
 			filePath: "C:/repo/neighbor.ts",
 			serverId: "typescript",
-			touchedAt: 1_000,
+			touchedAt: TOUCH_TS,
 		});
 		const task = registerQuietWindowTask.mock.calls[0][1] as () => Promise<void>;
 		await task();
@@ -620,7 +654,7 @@ describe("registerCascadeTierReconcileTask", () => {
 				serverId: "typescript",
 				getAllDiagnostics: vi.fn().mockReturnValue(
 					new Map([
-						[normalizeMapKey("C:/repo/neighbor.ts"), { diags: [], ts: 2_000 }],
+						[normalizeMapKey("C:/repo/neighbor.ts"), { diags: [], ts: PUBLISH_TS }],
 					]),
 				),
 			},
@@ -632,7 +666,7 @@ describe("registerCascadeTierReconcileTask", () => {
 		mod.recordOutstandingCascadeTouch({
 			filePath: "C:/repo/neighbor.ts",
 			serverId: "typescript",
-			touchedAt: 1_000,
+			touchedAt: TOUCH_TS,
 		});
 		const task = registerQuietWindowTask.mock.calls[0][1] as () => Promise<void>;
 		await task();
@@ -642,7 +676,7 @@ describe("registerCascadeTierReconcileTask", () => {
 		expect(onResolvedClean).toHaveBeenCalledWith({
 			filePath: "C:/repo/neighbor.ts",
 			serverId: "typescript",
-			publishedAt: 2_000,
+			publishedAt: PUBLISH_TS,
 		});
 	});
 
@@ -664,7 +698,7 @@ describe("registerCascadeTierReconcileTask", () => {
 		mod.recordOutstandingCascadeTouch({
 			filePath: "C:/repo/neighbor.ts",
 			serverId: "typescript",
-			touchedAt: 1_000,
+			touchedAt: TOUCH_TS,
 		});
 		const task = registerQuietWindowTask.mock.calls[0][1] as () => Promise<void>;
 		await task();

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -1715,7 +1715,7 @@ describe("#1533 — silent auxiliary honesty on clientScope \"all\"", () => {
 	// BLAST-RADIUS PINS (#1533 review). The highest-frequency `"all"` caller is the
 	// cascade per-edit neighbour fan-out, which caps the touch at 1000/2000ms and
 	// does NOT exclude opengrep. The concern raised was that newly-`silent` verdicts
-	// there would block `neighborTouchCache`/`recentlyCleanNeighborCache` seeding via
+	// there would block `recentlyCleanNeighborCache` seeding via
 	// `isConfirmedTouch`.
 	//
 	// The answer has TWO cases, and stating only the first would be the same

--- a/tests/clients/memory-sampler.test.ts
+++ b/tests/clients/memory-sampler.test.ts
@@ -112,7 +112,6 @@ describe("collectMemorySampleSubsystems (O(1)/O(bounded-cache-size) live reads)"
 		expect(subsystems.reviewGraph.cacheEntries).toBeGreaterThanOrEqual(0);
 		expect(subsystems.reviewGraph.totalNodes).toBeGreaterThanOrEqual(0);
 		expect(subsystems.reviewGraph.totalEdges).toBeGreaterThanOrEqual(0);
-		expect(subsystems.dispatchCaches.neighborTouchCacheSize).toBeGreaterThanOrEqual(0);
 		expect(subsystems.dispatchCaches.recentlyCleanNeighborCacheSize).toBeGreaterThanOrEqual(0);
 		if (subsystems.treeSitter) {
 			expect(subsystems.treeSitter.languagesLoaded).toBeGreaterThanOrEqual(0);

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -319,7 +319,7 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 		id: "dispatch-integration:sessionCaches",
 		module: "dispatch/integration.ts",
 		state:
-			"cascadeDiagnosticBaselines, neighborTouchCache, recentlyCleanNeighborCache, primaryFilesThisTurn, sessionSlopRuleCounts, sessionFacts",
+			"cascadeDiagnosticBaselines, recentlyCleanNeighborCache, primaryFilesThisTurn, sessionSlopRuleCounts, sessionFacts",
 		policy: "session_start",
 		resetName: "resetDispatchBaselines",
 		reason:
@@ -697,7 +697,8 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	"diagnostic-line-freshness.ts": 1,
 	"diagnostics-publish.ts": 1,
 	"dispatch/dispatcher.ts": 1,
-	"dispatch/integration.ts": 10,
+	// #1899 removed the dead `neighborTouchCache` (10 → 9).
+	"dispatch/integration.ts": 9,
 	"dispatch/lazy.ts": 0,
 	"dispatch/runners/ast-grep-napi.ts": 5,
 	"dispatch/runners/biome-check.ts": 1,


### PR DESCRIPTION
## What this changes  Two cascade findings from the 2026-08-20 long-session monitoring.  **Part 1 — the tier-3 reconcile backlog is now bounded and readable.** The outstanding-touch registry (`clients/lsp/cascade-tier.ts`) caps its entry count and its entry age. Every reconcile sweep writes a backlog gauge, including the empty sweep. An unresolved touch now names its cause.  **Part 2 — the same-write neighbour-touch cache is removed.** It was dead by construction, not merely unused.  ## Investigation first, because the issue asked for a verdict  I read the implementation and measured the live logs before changing anything (`~/.pi-lens/cascade.log`, 2026-08-09..20: 67 sweeps, 756 outcomes, 1492 `cascade_result` runs).  **(a) Why entries do not conclude.** The reconcile pass is not starved. It drains the whole registry on every run, and resolutions do happen: 47 `resolved-found` and 33 `resolved-clean` across the window. The 676 unresolved outcomes are the designed answer to a question a tier-3 server cannot answer. A `tier3-silent` server is `push-only` AND `silentOnClean`, so it publishes nothing at all when a neighbour is clean. There is no publish for the reconcile to compare against, and per the #240 doctrine a missing answer is never recorded as clean. For a clean codebase, `unresolved` is the correct steady state.  That is exactly why the single word `unresolved` was the real defect: it collapsed five distinct causes, so an expected silence and a server that had gone cold read identically.  **(b) Whether the queue is bounded.** Partly, and not where it matters. `reconcileOutstandingCascadeTouches` clears the map in full (`clients/lsp/cascade-tier.ts:229-230` before this change), so the registry cannot leak across sweeps. Between sweeps it had no bound of any kind. The sweep runs on pi's `agent_settled` quiet window, and the live log shows sweeps up to 52 minutes apart, with entry ages up to 3,176,437 ms. So the registry could grow to the number of distinct neighbour files a session touches, and could hand the sweep touches of unbounded age.  ## What I changed  ### Registry bounds (`clients/lsp/cascade-tier.ts`)  - `MAX_OUTSTANDING_TOUCHES = 256`, oldest-first eviction. The largest single   sweep in the live window held 53 entries, so the cap is roughly 5x the   observed peak. - `OUTSTANDING_TOUCH_MAX_AGE_MS = 15 * 60_000`. Applied at record time and at   sweep start, so the bound holds even when no further touch arrives to trigger   the prune — which is the dogfood shape exactly. - The age constant is measured, not guessed. Resolved and unresolved outcomes   have nearly identical age distributions (p50 258s vs 312s), so no threshold   separates them cleanly. A 15-minute bound retains 72 of the 80 outcomes that   ever resolved (90%) and discards the tail that resolved after 26 to 52   minutes. Re-injecting a neighbour error from a touch fired that long ago   reports a state the agent has moved past. - Eviction records `cascade-tier3-backlog-evicted` through   `incrementDegradationCount`, keyed on the cap rather than the path, so the   ledger group stays bounded.  The `delete` before the `set` in `recordOutstandingCascadeTouch` is load-bearing: `Map.set` on an existing key keeps that key's original position, so without it a re-touched file would still be evicted as "oldest". A test pins that specifically.  ### Observability (`cascade_tier3_reconcile` in `cascade.log`)  The sweep record gains `unresolvedByReason`, `maxAgeMs`, `expired`, `evicted`, `capacity`, and `maxAgeCapMs`, and is now written on EVERY sweep. Previously the task returned before logging when the queue was empty, so "the backlog is drained" and "the sweep never ran" were the same silence. `expired` and `evicted` are since-last-sweep counters, not cumulative.  `unresolvedReason` discriminates `warm-miss`, `server-mismatch`, `no-publish`, `no-publish-since-touch`, and `error`.  ### Part 2: the neighbour-touch cache is removed  The read gate required `cached.turnSeq === turnSeq && cached.writeSeq === writeSeq`. `writeSeq` is pi's per-write index (`ctx.telemetry.writeIndex`, `clients/pipeline.ts:1547`) and advances on every write, and one write starts one cascade. A hit therefore needed two cascade computations inside a single write, which the pipeline never produces. The only construction that ever made it hit was a test calling `computeCascadeForFile` twice with the same `turnSeq`/`writeSeq`.  I evaluated broadening and rejected it. Dropping the `writeSeq` equality to make the cache turn-scoped would serve a neighbour's diagnostics from BEFORE a later write in the same turn, which is the stale-answer trap #1092/#1095 closed. No lifetime makes it both safe and useful, because the safe reuse is already covered twice: the passive-snapshot path (TTL plus content binding) and `recentlyCleanNeighborCache`.  The live log settles the comparison between the two sibling caches over the same 1492 cascade runs: `cacheHits: 0`, `recentlyCleanHits: 128` against 689 cold touches. One cache is dead; its sibling works.  The removal drops the `cacheHits` field from `cascade_result` and `neighborTouchCacheSize` from the memory sampler, updates the session-state registry entry, and lowers `dispatch/integration.ts`'s stateful-symbol pin from 10 to 9.  ## Verification  **Red-proof, on pre-fix source (reverted `cascade-tier.ts` and `degradation-ledger.ts`, rebuilt, ran):**  ``` tests/clients/lsp/cascade-tier-backlog.test.ts  12 failed | 3 passed (15) tests/clients/lsp/cascade-tier.test.ts           1 failed | 29 passed (30) ```  The 3 that passed pre-fix are deliberate negative controls: no eviction inside the cap, a touch inside the age bound is kept, a touch inside the age bound is still reconciled. They pin unchanged behavior, so they must be green on both sides.  Every new guard is mutation-proof:  - Delete the cap loop, and "caps the registry and evicts the OLDEST touch   first" plus the ledger test go red. - Delete the `delete` before the `set`, and "re-touching a file moves it to the   newest position" goes red. - Delete either prune call, and the corresponding age-bound test goes red. - Delete the `unresolvedReason` assignment, and five reason tests go red.  **Green, after the fix (`npm run build` before each run):**  ``` tests/clients/lsp/cascade-tier-backlog.test.ts   15 passed tests/clients/lsp/cascade-tier.test.ts           30 passed tests/clients/cascade-compute.test.ts            + tests/clients/memory-sampler.test.ts                                                  112 passed total (4 files) tests/clients/session-state-conformance.test.ts  + tests/clients/cascade-turn-merge.test.ts                                                  82 passed tests/clients/dispatch/integration.test.ts tests/clients/runtime-session-dispatch-reset.test.ts tests/clients/lsp/service-aux-grace.test.ts      61 passed tests/clients/bounded-telemetry.test.ts tests/clients/degradation-ledger.test.ts         passed ```  `npm run lint` (tsc over the full project, tests included) passes. The full suite is CI's job and has not run locally.  **Composition with the open PRs.** #1902 touches `tests/support/session-state-registry.ts`, the same file. I merged its branch (`fix/1897-remaining-store-resets`) into mine locally, rebuilt, and ran ITS test files plus mine on the merged tree: `session-state-conformance`, `runtime-session-dispatch-reset`, `index-integration`, and `cascade-tier-backlog` — 122 passed, no conflict. The two edits sit in different regions (their registry entries at ~line 460, my state string at ~322 and my pin at ~700). #1901 touches `clients/lsp/index.ts` and the diagnostics tools; no overlap with these files. No merge order is required.  ## Blast radius  - `getDispatchCascadeCacheStats()` loses a field. Callers:   `clients/memory-sampler.ts:91` (updated) and two assertions in   `cascade-compute.test.ts` (updated to the surviving field). Grepped the whole   tree; no other caller. - `cascade_result` loses `cacheHits`. Any external log reader keyed on that   field sees it disappear. It has been constantly 0 across 1492 runs, so no   signal is lost. - Cascade neighbours that previously could have hit the removed cache now take   a real touch. Measured cost: zero, because the cache never hit. - Hot path cost of the new bounds: one `Map.delete` plus one `Date.now()` per   recorded touch, and a prefix walk that stops at the first live entry. The   eviction scan is O(1) — insertion order is now touch order. - No new process spawns. No behavior widening. Sweep log volume rises by the   empty-sweep gauge: 67 quiet windows over 11 days in the live log.  ## Observability  The record that proves this in production is `cascade_tier3_reconcile` in `~/.pi-lens/cascade.log`. Read `count`, `unresolvedByReason`, `maxAgeMs`, `expired`, and `evicted` per sweep. A healthy backlog reads as a small `count` with `unresolvedByReason` dominated by `no-publish` (the expected silence). A `warm-miss`-dominated sweep means servers are being reaped under the backlog, and a non-zero `evicted` means the session out-touched the quiet-window cadence. Eviction also lands in the degradation ledger as `cascade-tier3-backlog-evicted`.  Known gap, stated rather than hidden: `_expiredSinceLastSweep` and Tracked as #1910. `_evictedSinceLastSweep` are sweep-scoped counters and are not cleared at `session_start`. Neither is the registry itself, which predates this change. A session boundary that lands between an eviction and a sweep attributes those counts to the next session's first gauge. The counts are small and bounded, and wiring cascade-tier into `handleSessionStart` is outside this issue's scope.  ## Class sweep  **PATTERN sweep** (whole source tree: `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`) for the defect shape "a registry that only an external event drains, with no size or age bound of its own":  - `clients/lsp/cascade-tier.ts` `_outstandingTouches` — the defect. Fixed here.  **POPULATION sweep** — the enumerable family is quiet-window task registrations (`registerQuietWindowTask` call sites), because every member is state that accumulates between two window firings:  | Member | File:line | Verdict | | --- | --- | --- | | `cascade_tier3_reconcile` | `clients/lsp/cascade-tier.ts:436` | Fixed here | | `turn_summary_emit` | `index.ts:2615` | Already correct — holds a single mutable ctx object (`_turnSummaryEmitCtx`), replaced on each activation, so it cannot accumulate |  The family has two members; both are checked.  **Second population — the cascade neighbour caches**, because a cache whose gate can never be satisfied is invisible to any grep and only a live hit count finds it. Both members checked against the same 1492 live cascade runs: `neighborTouchCache` 0 hits (removed), `recentlyCleanNeighborCache` 128 hits against 689 cold touches (alive, left as is).  Closes #1899.  *This PR is AI-generated, with the maintainer supervising the process.* 