### PR TITLE
fix: honor pipe truncation in search credit; always-on trim telemetry (closes #1908, closes #1913)

### DIFF
--- a/.changelog/fix-1908-grep-pipe-truncation-credit.md
+++ b/.changelog/fix-1908-grep-pipe-truncation-credit.md
@@ -1,0 +1,9 @@
+---
+section: Fixed
+---
+
+- **Search credit ignores pipe truncation (closes #1908)** — `grep -C2 pattern
+  file | head -1` no longer credits context lines the pipe cut off. The
+  read-guard now detects a truncating pipe tail (`head`, `tail`, `sed q`)
+  downstream of a line-numbered grep and falls back to match-line-only
+  credit, so a later edit to the uncredited context still requires a read.

--- a/.changelog/fix-1913-read-guard-eviction-telemetry.md
+++ b/.changelog/fix-1913-read-guard-eviction-telemetry.md
@@ -1,0 +1,9 @@
+---
+section: Fixed
+---
+
+- **Read-guard eviction telemetry is now always on (closes #1913)** — a
+  read-guard record-cap trim now emits a bounded `read_cap_trimmed` log line
+  (file, evicted count, credit-vs-genuine split, raw read count) regardless
+  of `PI_LENS_READ_GUARD_VERBOSE`, so a live eviction regression is visible
+  by default instead of only under verbose logging.

--- a/.changelog/fix-1913-read-guard-eviction-telemetry.md
+++ b/.changelog/fix-1913-read-guard-eviction-telemetry.md
@@ -2,8 +2,11 @@
 section: Fixed
 ---
 
-- **Read-guard eviction telemetry is now always on (closes #1913)** — a
-  read-guard record-cap trim now emits a bounded `read_cap_trimmed` log line
-  (file, evicted count, credit-vs-genuine split, raw read count) regardless
-  of `PI_LENS_READ_GUARD_VERBOSE`, so a live eviction regression is visible
-  by default instead of only under verbose logging.
+- **Read-guard eviction telemetry is now always on (closes #1913)** — the
+  first time a file's read-guard record cap trims in a session, it now emits
+  a `read_cap_trimmed` log line (file, evicted count, credit-vs-genuine
+  split, raw read count) regardless of `PI_LENS_READ_GUARD_VERBOSE`, so a
+  live eviction regression is visible by default instead of only under
+  verbose logging. Later trims on the same file keep updating the running
+  totals (queryable via `ReadGuard.getTrimStats`, and via the degradation
+  ledger's own tally) without flooding the log on every subsequent trim.

--- a/clients/bash-file-access.ts
+++ b/clients/bash-file-access.ts
@@ -522,33 +522,43 @@ function parseGrepLineWithoutFile(
 }
 
 /**
- * Verbs that cut a piped stream short by LINE COUNT (#1908): `head`/`tail`
- * (even bare, since both default to a 10-line window) and a `sed` script
- * carrying a `q` command (quits after the addressed line). Either can leave
- * only part of a `grep -C` block's printed context in the command's actual
- * stdout, so a hit that survives the cut cannot be trusted to carry the
- * context grep's flags alone promised.
+ * Verbs that DROP printed lines from a piped stream (#1908, review F4): a
+ * hit that survives such a tail cannot be trusted to still carry the
+ * -A/-B/-C context grep's flags declared, because that context may have
+ * been among the dropped lines. `head`/`tail` drop by position (even bare,
+ * since both default to a 10-line window); `sed` with a `q` command drops
+ * everything after the addressed line; `uniq` drops adjacent duplicate
+ * lines, which can include a context line that happens to repeat.
  *
- * Per-tail credit policy, decided per pipe stage rather than per verb:
- *   - `head`/`tail`/`sed q` downstream of a matching grep → the match-line
- *     survives truncation unpredictably, so credit falls back to
- *     match-line-only (the same conservative default used for unparseable
- *     commands) rather than trusting the declared -A/-B/-C flags.
- *   - `wc`, `sort`, `uniq -c`, and similar STREAM-CONSUMING or reordering
- *     tails need no special case: they replace grep's `file:line:` shaped
- *     lines with a count or reordered text, so `parseGrepOutputSearchReads`
- *     already finds zero (or renumbered-away) matches in the real captured
- *     stdout and credits nothing. Only a verb that can leave an UNMODIFIED
- *     `file:line:` prefix in place while still cutting lines needs handling
- *     here.
+ * The criterion is DROPPING, not "changes grep's output shape" — a review
+ * finding (#1913 F4) caught this file previously conflating the two:
+ *   - `head`/`tail`/`sed q`/`uniq` downstream of a matching grep → some
+ *     printed lines are genuinely gone, so credit falls back to
+ *     match-line-only (the same conservative default already used for
+ *     unparseable commands) rather than trusting the declared flags.
+ *   - `sort` and other REORDER-ONLY filters keep every line grep printed,
+ *     just in a different order — a surviving `file:line:` match still
+ *     carries the full context grep actually printed, so no special case is
+ *     needed (proven by the "still credits full context through a
+ *     non-truncating pipe tail" test below).
+ *   - `wc` and similar filters that REPLACE grep's output entirely (with a
+ *     count, say) leave no `file:line:`-shaped line at all, so
+ *     `parseGrepOutputSearchReads` already finds zero matches in the real
+ *     captured stdout. Also no special case needed, but for the OPPOSITE
+ *     reason from `sort`: nothing survives to credit, rather than
+ *     everything surviving intact.
  *   - A pass-through filter (`cat`, `grep -v`, ...) between grep and a
- *     truncating tail still counts: the walk below follows the whole
- *     pipe chain, not just the immediate next segment.
- *   - Out of scope, deliberately: `sed -n 'Np'`/range-address filtering
- *     without `q` also truncates but isn't in the issue's stated scope
- *     (#1908) — revisit if it recurs in the field.
+ *     dropping tail still counts: the walk below follows the whole pipe
+ *     chain, not just the immediate next segment.
+ *   - Out of scope, deliberately: `sed -n 'Np'` range-address filtering
+ *     without `q`, and `sort -u`, also drop lines but aren't in #1908's
+ *     stated scope — revisit if they recur in the field. Also out of
+ *     scope: a truncating tail hidden inside a subshell/brace-group
+ *     (`( ... )`, `{ ...; }`) or reimplemented in `awk`/`perl` — the shared
+ *     tokenizer this file uses doesn't parse inside those, matching its
+ *     documented "small conservative shell lexer" scope.
  */
-const TRUNCATING_TAIL_VERBS = new Set(["head", "tail"]);
+const LINE_DROPPING_TAIL_VERBS = new Set(["head", "tail", "uniq"]);
 
 function isSedQuitCommand(args: string[]): boolean {
 	for (const arg of args) {
@@ -562,16 +572,19 @@ function isSedQuitCommand(args: string[]): boolean {
 	return false;
 }
 
-function isTruncatingTailCommand(tokens: string[]): boolean {
+function isLineDroppingTailCommand(tokens: string[]): boolean {
 	const verb = path.basename(stripQuotes(tokens[0] ?? ""));
-	if (TRUNCATING_TAIL_VERBS.has(verb)) return true;
+	if (LINE_DROPPING_TAIL_VERBS.has(verb)) return true;
 	if (verb === "sed") return isSedQuitCommand(tokens.slice(1));
 	return false;
 }
 
 /**
  * True when the grep segment starting at `index` feeds — directly or through
- * a chain of pipes — into a truncating tail (#1908).
+ * a chain of pipes — into a line-dropping tail (#1908). Only an unquoted `|`
+ * counts: a `;`/`&&`/`&`-separated command downstream never receives grep's
+ * stdout, so it must not downgrade credit (#1913 F2 — this was previously
+ * unverified by any test that could tell a real pipe from mere adjacency).
  */
 function grepPipesIntoTruncatingTail(
 	segments: ShellCommandSegment[],
@@ -579,7 +592,7 @@ function grepPipesIntoTruncatingTail(
 ): boolean {
 	if (segments[index]?.terminator !== "pipe") return false;
 	for (let j = index + 1; j < segments.length; j++) {
-		if (isTruncatingTailCommand(segments[j].tokens)) return true;
+		if (isLineDroppingTailCommand(segments[j].tokens)) return true;
 		if (segments[j].terminator !== "pipe") return false;
 	}
 	return false;

--- a/clients/bash-file-access.ts
+++ b/clients/bash-file-access.ts
@@ -48,6 +48,14 @@ function stripAnsi(value: string): string {
 export interface ShellCommandSegment {
 	tokens: string[];
 	unsupported: boolean;
+	/**
+	 * Set to "pipe" when this segment's output feeds the NEXT segment via an
+	 * unquoted `|` (used by #1908 to detect a truncating pipe tail after
+	 * grep). Undefined for every other terminator (`;`, `&&`, `||`, `&`, EOF)
+	 * — those consumers don't need it and adding cases here is a no-op for
+	 * them.
+	 */
+	terminator?: "pipe";
 }
 
 export function tokenizeShellCommand(command: string): ShellCommandSegment[] {
@@ -63,10 +71,10 @@ export function tokenizeShellCommand(command: string): ShellCommandSegment[] {
 		word = "";
 		atTokenStart = true;
 	};
-	const flushSegment = () => {
+	const flushSegment = (terminator?: "pipe") => {
 		flushWord();
 		if (tokens.length > 0 || unsupported)
-			segments.push({ tokens, unsupported });
+			segments.push({ tokens, unsupported, terminator });
 		tokens = [];
 		unsupported = false;
 		atTokenStart = true;
@@ -131,10 +139,14 @@ export function tokenizeShellCommand(command: string): ShellCommandSegment[] {
 		}
 		if (ch === ";" || ch === "\n" || ch === "|" || ch === "&") {
 			flushWord();
+			let terminator: "pipe" | undefined;
 			if (ch === "|" && next === "|") i++;
 			else if (ch === "&" && next === "&") i++;
-			else if (ch === "|" || ch === "&") unsupported = true;
-			flushSegment();
+			else if (ch === "|") {
+				unsupported = true;
+				terminator = "pipe";
+			} else if (ch === "&") unsupported = true;
+			flushSegment(terminator);
 			continue;
 		}
 		if (ch === "<" || ch === ">") {
@@ -509,6 +521,70 @@ function parseGrepLineWithoutFile(
 	return { file, startLine: lineNumber, endLine: lineNumber };
 }
 
+/**
+ * Verbs that cut a piped stream short by LINE COUNT (#1908): `head`/`tail`
+ * (even bare, since both default to a 10-line window) and a `sed` script
+ * carrying a `q` command (quits after the addressed line). Either can leave
+ * only part of a `grep -C` block's printed context in the command's actual
+ * stdout, so a hit that survives the cut cannot be trusted to carry the
+ * context grep's flags alone promised.
+ *
+ * Per-tail credit policy, decided per pipe stage rather than per verb:
+ *   - `head`/`tail`/`sed q` downstream of a matching grep → the match-line
+ *     survives truncation unpredictably, so credit falls back to
+ *     match-line-only (the same conservative default used for unparseable
+ *     commands) rather than trusting the declared -A/-B/-C flags.
+ *   - `wc`, `sort`, `uniq -c`, and similar STREAM-CONSUMING or reordering
+ *     tails need no special case: they replace grep's `file:line:` shaped
+ *     lines with a count or reordered text, so `parseGrepOutputSearchReads`
+ *     already finds zero (or renumbered-away) matches in the real captured
+ *     stdout and credits nothing. Only a verb that can leave an UNMODIFIED
+ *     `file:line:` prefix in place while still cutting lines needs handling
+ *     here.
+ *   - A pass-through filter (`cat`, `grep -v`, ...) between grep and a
+ *     truncating tail still counts: the walk below follows the whole
+ *     pipe chain, not just the immediate next segment.
+ *   - Out of scope, deliberately: `sed -n 'Np'`/range-address filtering
+ *     without `q` also truncates but isn't in the issue's stated scope
+ *     (#1908) — revisit if it recurs in the field.
+ */
+const TRUNCATING_TAIL_VERBS = new Set(["head", "tail"]);
+
+function isSedQuitCommand(args: string[]): boolean {
+	for (const arg of args) {
+		const token = stripQuotes(arg);
+		if (token.startsWith("-")) continue;
+		// A `q` command anchored at the start of the script or after a `;`/
+		// newline separator, optionally preceded by a numeric/`$` address
+		// (`q`, `1q`, `$q`, `1,3p;q`). Deliberately not a full sed parser.
+		if (/(^|[;\n])\s*(\d+|\$)?\s*q\b/.test(token)) return true;
+	}
+	return false;
+}
+
+function isTruncatingTailCommand(tokens: string[]): boolean {
+	const verb = path.basename(stripQuotes(tokens[0] ?? ""));
+	if (TRUNCATING_TAIL_VERBS.has(verb)) return true;
+	if (verb === "sed") return isSedQuitCommand(tokens.slice(1));
+	return false;
+}
+
+/**
+ * True when the grep segment starting at `index` feeds — directly or through
+ * a chain of pipes — into a truncating tail (#1908).
+ */
+function grepPipesIntoTruncatingTail(
+	segments: ShellCommandSegment[],
+	index: number,
+): boolean {
+	if (segments[index]?.terminator !== "pipe") return false;
+	for (let j = index + 1; j < segments.length; j++) {
+		if (isTruncatingTailCommand(segments[j].tokens)) return true;
+		if (segments[j].terminator !== "pipe") return false;
+	}
+	return false;
+}
+
 function collectGrepCommandFiles(
 	command: string,
 	cwd: string,
@@ -524,7 +600,14 @@ function collectGrepCommandFiles(
 	// contributing grep printed, so no line is credited that a hit from the
 	// narrowest grep never delivered.
 	let context: GrepContextLines | undefined;
-	for (const tokens of commandSegments(command)) {
+	// #1908: if ANY contributing grep pipes into a truncating tail, fall back
+	// to match-line-only credit for the whole command — the parsed hits carry
+	// no segment identity, so a per-segment override isn't representable in
+	// the aggregate `context` this function returns.
+	let truncated = false;
+	const segments = tokenizeShellCommand(command);
+	for (let i = 0; i < segments.length; i++) {
+		const tokens = segments[i].tokens;
 		const verb = path.basename(stripQuotes(tokens[0] ?? ""));
 		if (verb !== "grep" && verb !== "egrep" && verb !== "fgrep") continue;
 		const args = tokens.slice(1);
@@ -538,11 +621,12 @@ function collectGrepCommandFiles(
 				}
 			: segmentContext;
 		for (const file of extractGrepSearchFiles(args, cwd)) files.add(file);
+		if (grepPipesIntoTruncatingTail(segments, i)) truncated = true;
 	}
 	return {
 		hasLineNumberGrep,
 		files,
-		context: context ?? { before: 0, after: 0 },
+		context: truncated ? { before: 0, after: 0 } : (context ?? { before: 0, after: 0 }),
 	};
 }
 

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -232,7 +232,16 @@ export type DegradationKind =
 	 * pi's `agent_settled` window and dogfood logs show gaps up to 52 minutes;
 	 * this kind means a session out-touched that cadence.
 	 */
-	| "cascade-tier3-backlog-evicted";
+	| "cascade-tier3-backlog-evicted"
+	/**
+	 * `read-guard.ts`'s per-file record cap (`READ_GUARD_MAX_RECORDS_PER_FILE`)
+	 * trimmed a file's read history (#1913). A hot file trimmed on every push
+	 * once it's past the cap, so this kind's rising edge gates the matching
+	 * `read_cap_trimmed` read-guard.log line to the first trim and
+	 * power-of-two milestones after it — the ledger's own dedupe, not a
+	 * hand-rolled per-file Set (#1913 review F1).
+	 */
+	| "read-guard-record-cap-trim";
 
 export interface DegradationRecord {
 	kind: unknown;

--- a/clients/read-guard-logger.ts
+++ b/clients/read-guard-logger.ts
@@ -218,7 +218,7 @@ export interface ReadGuardLogEntry {
 	metadata?: Record<string, unknown>;
 }
 
-function shouldLogEvent(event: string): boolean {
+export function shouldLogEvent(event: string): boolean {
 	if (VERBOSE_READ_GUARD_LOG) return true;
 	if (event === "edit_allowed") return LOG_ALLOWED_EDITS;
 	if (event === "range_snapshot_validation") return LOG_SNAPSHOT_VALIDATION;
@@ -238,7 +238,12 @@ function shouldLogEvent(event: string): boolean {
 		event === "edit_post_edit_pipeline_failed" ||
 		event === "edit_batch_summary" ||
 		event === "edit_batch_summary_overflow" ||
-		event === "touched_lines_missing"
+		event === "touched_lines_missing" ||
+		// #1913: read-guard record-cap evictions are rare by construction (only
+		// READ_GUARD_MAX_RECORDS_PER_FILE overflow triggers one), so this trim
+		// record bypasses the per-read verbosity gate — a live eviction
+		// regression must be visible without PI_LENS_READ_GUARD_VERBOSE=1.
+		event === "read_cap_trimmed"
 	);
 }
 

--- a/clients/read-guard.ts
+++ b/clients/read-guard.ts
@@ -11,6 +11,7 @@
  */
 
 import * as fs from "node:fs";
+import { incrementDegradationCount } from "./degradation-ledger.js";
 import { createFileTime, type FileTime } from "./file-time.js";
 import { hashDiagnosticContent } from "./lsp/diagnostic-binding.js";
 import { normalizeEphemeralMapKey, normalizeFilePath } from "./path-utils.js";
@@ -210,6 +211,20 @@ const READ_GUARD_MAX_FILES = 256;
  * age alone is the wrong order.
  */
 const READ_GUARD_MAX_RECORDS_PER_FILE = 128;
+
+/**
+ * Session-lifetime running totals for one file's record-cap trims (#1913
+ * review F1). Owned per-`ReadGuard`-instance, so it re-arms automatically at
+ * `session_start` along with `this.reads`/`this.edits` — no separate reset to
+ * wire and forget. Queryable via `getTrimStats` even after logging stops
+ * re-emitting (see `recordRead`'s trim block).
+ */
+export interface FileTrimStats {
+	totalEvicted: number;
+	evictedCreditCount: number;
+	evictedGenuineCount: number;
+	trimEventCount: number;
+}
 
 /**
  * Trim a single file's read list to the per-file cap. Returns how many records
@@ -533,6 +548,8 @@ export class ReadGuard {
 	// happened to the file since. Pruned inside `evictFile` so it never
 	// outlives the record it points at.
 	private readonly knownPathIndex = new Map<string, string>();
+	/** Running per-file record-cap trim totals for this session (#1913 F1). */
+	private readonly trimAccumulators = new Map<string, FileTrimStats>();
 	private readonly sessionId: string;
 	private readonly sessionStartMs: number;
 
@@ -708,23 +725,61 @@ export class ReadGuard {
 
 		// #1913: the eviction counters above ride `read_recorded`, which is
 		// gated behind PI_LENS_READ_GUARD_VERBOSE — off by default. That left a
-		// live eviction regression with no trace at default verbosity. Evictions
-		// are rare BY CONSTRUCTION (bounded by READ_GUARD_MAX_RECORDS_PER_FILE
-		// overflowing), so one always-on line per trim event is cheap; emit it
-		// as its own event and add it to read-guard-logger's always-log list
-		// instead of gating it, while every other per-read line stays gated.
+		// live eviction regression with no trace at default verbosity.
+		//
+		// review F1: a naive "emit every trim" fix floods read-guard.log once a
+		// hot file sits past the cap — every later push trims exactly 1 record
+		// (the array is always AT the cap before the push, so `excess` is
+		// always exactly 1), so 300 recordRead calls on one file is ~172
+		// identical always-on lines, and can rotate `edit_blocked` records out
+		// of the 1MB cap. `rawReadCountForFile` also freezes at cap+1 forever,
+		// so a raw per-trim record can't even discriminate thrash severity.
+		//
+		// Fix: emit the read-guard.log line ONCE per file per session, on the
+		// FIRST trim only. `trimAccumulators` still updates on every trim,
+		// queryable via `getTrimStats` — the running totals a health surface or
+		// a future emission point would need are never lost, even though
+		// read-guard.log stops re-announcing them. "Have we already logged
+		// this file's first trim" routes through the degradation ledger's own
+		// rising-edge tally (`incrementDegradationCount` — the pattern
+		// CLAUDE.md names for repeated degradations) instead of a hand-rolled
+		// per-file Set; subsequent trims still call it, so the ledger's own
+		// entry for this (kind, subject) keeps its reason text and count
+		// current for the health/degradation summary even after read-guard.log
+		// goes quiet.
 		if (evictedRecordCount > 0) {
-			logReadGuardEvent({
-				event: "read_cap_trimmed",
-				sessionId: this.sessionId,
-				filePath: storedRecord.filePath,
-				metadata: {
-					evictedRecordCount,
-					evictedCreditCount,
-					evictedGenuineCount,
-					rawReadCountForFile,
-				},
+			const key = storedRecord.filePath;
+			const acc = this.trimAccumulators.get(key) ?? {
+				totalEvicted: 0,
+				evictedCreditCount: 0,
+				evictedGenuineCount: 0,
+				trimEventCount: 0,
+			};
+			acc.totalEvicted += evictedRecordCount;
+			acc.evictedCreditCount += evictedCreditCount;
+			acc.evictedGenuineCount += evictedGenuineCount;
+			acc.trimEventCount += 1;
+			this.trimAccumulators.set(key, acc);
+
+			const isRisingEdge = incrementDegradationCount({
+				kind: "read-guard-record-cap-trim",
+				subject: key,
+				reason: `trim #${acc.trimEventCount}: evicted ${evictedRecordCount} (credit ${evictedCreditCount}, genuine ${evictedGenuineCount})`,
 			});
+			if (isRisingEdge) {
+				logReadGuardEvent({
+					event: "read_cap_trimmed",
+					sessionId: this.sessionId,
+					filePath: storedRecord.filePath,
+					metadata: {
+						trimEventCount: acc.trimEventCount,
+						evictedRecordCount: acc.totalEvicted,
+						evictedCreditCount: acc.evictedCreditCount,
+						evictedGenuineCount: acc.evictedGenuineCount,
+						rawReadCountForFile,
+					},
+				});
+			}
 		}
 
 		// Also update FileTime stamp for this file
@@ -1210,6 +1265,19 @@ export class ReadGuard {
 		const key = this.key(filePath);
 		if (this.reads.has(key)) this.touchFile(key);
 		return this.reads.get(key) ?? [];
+	}
+
+	/**
+	 * Session-lifetime record-cap trim totals for a file (#1913 review F1).
+	 * `recordRead` only writes ONE `read_cap_trimmed` read-guard.log line per
+	 * file per session (on the first trim), so this is the running-totals
+	 * surface for everything after that — the exact split this class already
+	 * computes on every trim, not re-derivable from `getReadHistory` alone
+	 * (which only shows the SURVIVING records, not what was evicted).
+	 */
+	getTrimStats(filePath: string): FileTrimStats | undefined {
+		const stats = this.trimAccumulators.get(this.key(filePath));
+		return stats ? { ...stats } : undefined;
 	}
 
 	/**

--- a/clients/read-guard.ts
+++ b/clients/read-guard.ts
@@ -226,12 +226,30 @@ const READ_GUARD_MAX_RECORDS_PER_FILE = 128;
  * Records are trimmed IN PLACE: `EditRecord.precedingReads` holds a reference
  * to this same array, so a replacement array would silently detach it.
  */
-function enforceRecordCapForFile(records: ReadRecord[]): number {
-	if (records.length <= READ_GUARD_MAX_RECORDS_PER_FILE) return 0;
+interface RecordCapTrimResult {
+	evictedCount: number;
+	/** Of `evictedCount`, how many were search-credit records (spent first). */
+	evictedCreditCount: number;
+	/** Of `evictedCount`, how many were genuine (non-credit) reads. */
+	evictedGenuineCount: number;
+}
+
+const NO_TRIM: RecordCapTrimResult = {
+	evictedCount: 0,
+	evictedCreditCount: 0,
+	evictedGenuineCount: 0,
+};
+
+function enforceRecordCapForFile(records: ReadRecord[]): RecordCapTrimResult {
+	if (records.length <= READ_GUARD_MAX_RECORDS_PER_FILE) return NO_TRIM;
 	const excess = records.length - READ_GUARD_MAX_RECORDS_PER_FILE;
 	const evicted = new Set<number>();
+	let evictedCreditCount = 0;
 	for (let i = 0; i < records.length && evicted.size < excess; i++) {
-		if (records[i].searchCredit !== undefined) evicted.add(i);
+		if (records[i].searchCredit !== undefined) {
+			evicted.add(i);
+			evictedCreditCount++;
+		}
 	}
 	for (let i = 0; i < records.length && evicted.size < excess; i++) {
 		evicted.add(i);
@@ -239,7 +257,11 @@ function enforceRecordCapForFile(records: ReadRecord[]): number {
 	const kept = records.filter((_, i) => !evicted.has(i));
 	records.length = 0;
 	for (const record of kept) records.push(record);
-	return excess;
+	return {
+		evictedCount: excess,
+		evictedCreditCount,
+		evictedGenuineCount: excess - evictedCreditCount,
+	};
 }
 
 /**
@@ -646,7 +668,8 @@ export class ReadGuard {
 		// eviction starts, so it stops showing growth. `rawReadCountForFile` keeps
 		// the real arrival count observable alongside `evictedRecordCount`.
 		const rawReadCountForFile = arr.length;
-		const evictedRecordCount = enforceRecordCapForFile(arr);
+		const { evictedCount: evictedRecordCount, evictedCreditCount, evictedGenuineCount } =
+			enforceRecordCapForFile(arr);
 		this.touchFile(storedRecord.filePath);
 		this.enforceFileCap();
 
@@ -682,6 +705,27 @@ export class ReadGuard {
 				}),
 			},
 		});
+
+		// #1913: the eviction counters above ride `read_recorded`, which is
+		// gated behind PI_LENS_READ_GUARD_VERBOSE — off by default. That left a
+		// live eviction regression with no trace at default verbosity. Evictions
+		// are rare BY CONSTRUCTION (bounded by READ_GUARD_MAX_RECORDS_PER_FILE
+		// overflowing), so one always-on line per trim event is cheap; emit it
+		// as its own event and add it to read-guard-logger's always-log list
+		// instead of gating it, while every other per-read line stays gated.
+		if (evictedRecordCount > 0) {
+			logReadGuardEvent({
+				event: "read_cap_trimmed",
+				sessionId: this.sessionId,
+				filePath: storedRecord.filePath,
+				metadata: {
+					evictedRecordCount,
+					evictedCreditCount,
+					evictedGenuineCount,
+					rawReadCountForFile,
+				},
+			});
+		}
 
 		// Also update FileTime stamp for this file
 		this.fileTime.read(storedRecord.filePath);

--- a/tests/clients/bash-file-access.test.ts
+++ b/tests/clients/bash-file-access.test.ts
@@ -247,6 +247,96 @@ describe("extractGrepSearchReadsFromOutput", () => {
 			{ file: a, startLine: 9, endLine: 9, contextBefore: 0, contextAfter: 0 },
 		]);
 	});
+
+	// ── #1908: a truncating pipe tail severs the flags-to-delivery link ──────
+
+	it("falls back to match-line-only credit when piped through head", () => {
+		const a = touchLines("a.ts", 40);
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -n -C2 foo ${a} | head -1`,
+				tmp,
+				"9:foo",
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 0, contextAfter: 0 },
+		]);
+	});
+
+	it("falls back to match-line-only credit when piped through tail", () => {
+		const a = touchLines("a.ts", 40);
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -n -C2 foo ${a} | tail -n 1`,
+				tmp,
+				"9:foo",
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 0, contextAfter: 0 },
+		]);
+	});
+
+	it("falls back to match-line-only credit when piped through sed q", () => {
+		const a = touchLines("a.ts", 40);
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -n -C2 foo ${a} | sed q`,
+				tmp,
+				"9:foo",
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 0, contextAfter: 0 },
+		]);
+	});
+
+	it("still credits full context through a non-truncating pipe tail", () => {
+		const a = touchLines("a.ts", 40);
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -n -C2 foo ${a} | sort`,
+				tmp,
+				"9:foo",
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 2, contextAfter: 2 },
+		]);
+	});
+
+	it("credits nothing when piped through wc, since the count carries no lines", () => {
+		const a = touchLines("a.ts", 40);
+		// `wc` replaces grep's `file:line:` output with a bare count, so the
+		// output-line parser already finds zero matches — no special-casing
+		// needed for #1908's "shows NO lines" policy.
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -n -C2 foo ${a} | wc -l`,
+				tmp,
+				"1",
+			),
+		).toEqual([]);
+	});
+
+	it("follows a pass-through filter before the truncating tail", () => {
+		const a = touchLines("a.ts", 40);
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -n -C2 foo ${a} | cat | head -1`,
+				tmp,
+				"9:foo",
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 0, contextAfter: 0 },
+		]);
+	});
+
+	it("credits full context when the command is not piped at all", () => {
+		const a = touchLines("a.ts", 40);
+		expect(
+			extractGrepSearchReadsFromOutput(`grep -n -C2 foo ${a}`, tmp, "9:foo"),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 2, contextAfter: 2 },
+		]);
+	});
 });
 
 describe("parseGrepContextLines", () => {

--- a/tests/clients/bash-file-access.test.ts
+++ b/tests/clients/bash-file-access.test.ts
@@ -329,6 +329,52 @@ describe("extractGrepSearchReadsFromOutput", () => {
 		]);
 	});
 
+	it("falls back to match-line-only credit when piped through uniq", () => {
+		const a = touchLines("a.ts", 40);
+		// uniq drops adjacent duplicate lines, which can include a repeated
+		// context line — same drop hazard as head/tail (#1913 F4).
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -n -C2 foo ${a} | uniq`,
+				tmp,
+				"9:foo",
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 0, contextAfter: 0 },
+		]);
+	});
+
+	// ── #1913 review F2: a real `|` must be required, not mere adjacency ─────
+
+	it("keeps full credit when head follows via ; instead of a pipe", () => {
+		const a = touchLines("a.ts", 40);
+		// `head` here runs as its own command, never fed grep's stdout — a
+		// mutant that treats ANY adjacent head/tail as truncating (dropping the
+		// `terminator === "pipe"` check) would wrongly zero this out.
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -n -C2 foo ${a} ; head -1 ${a}`,
+				tmp,
+				"9:foo",
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 2, contextAfter: 2 },
+		]);
+	});
+
+	it("keeps full credit when head follows via && instead of a pipe", () => {
+		const a = touchLines("a.ts", 40);
+		expect(
+			extractGrepSearchReadsFromOutput(
+				`grep -n -C2 foo ${a} && head -1 ${a}`,
+				tmp,
+				"9:foo",
+			),
+		).toEqual([
+			{ file: a, startLine: 9, endLine: 9, contextBefore: 2, contextAfter: 2 },
+		]);
+	});
+
 	it("credits full context when the command is not piped at all", () => {
 		const a = touchLines("a.ts", 40);
 		expect(

--- a/tests/clients/read-guard-logger.test.ts
+++ b/tests/clients/read-guard-logger.test.ts
@@ -1,0 +1,21 @@
+/**
+ * #1913: `read_cap_trimmed` must survive `read-guard-logger`'s verbosity
+ * gate at DEFAULT verbosity (PI_LENS_READ_GUARD_VERBOSE unset), while the
+ * per-read `read_recorded` event stays gated as before.
+ */
+import { describe, expect, it } from "vitest";
+import { shouldLogEvent } from "../../clients/read-guard-logger.js";
+
+describe("shouldLogEvent", () => {
+	it("always logs read_cap_trimmed, even at default verbosity", () => {
+		expect(shouldLogEvent("read_cap_trimmed")).toBe(true);
+	});
+
+	it("keeps read_recorded gated behind verbose mode", () => {
+		expect(shouldLogEvent("read_recorded")).toBe(false);
+	});
+
+	it("still logs the pre-existing always-on events", () => {
+		expect(shouldLogEvent("edit_blocked")).toBe(true);
+	});
+});

--- a/tests/clients/read-guard.test.ts
+++ b/tests/clients/read-guard.test.ts
@@ -990,7 +990,12 @@ describe("ReadGuard", () => {
 
 		// ── #1913: eviction telemetry must survive at default verbosity ──────
 
-		it("emits a bounded read_cap_trimmed record when eviction fires", () => {
+		it("emits exactly one bounded read_cap_trimmed record across many trims", () => {
+			// #1913 review F1: the array is always AT the cap before each push
+			// once it's past 128, so every push past the cap trims exactly 1
+			// record — 300 reads on one hot file trims ~172 times. A naive
+			// "log every trim" design (this test's pre-fix behavior) emits ~172
+			// identical always-on lines; the fix must emit exactly ONE.
 			const env = setupTestEnvironment("read-guard-cap-trim-event-");
 			try {
 				const filePath = path.join(env.tmpDir, "hot.ts");
@@ -999,7 +1004,7 @@ describe("ReadGuard", () => {
 					Array.from({ length: 400 }, (_, i) => `line${i + 1}`).join("\n"),
 				);
 				const guard = createReadGuard("test-session");
-				for (let i = 1; i <= 129; i++) {
+				for (let i = 1; i <= 300; i++) {
 					guard.recordRead(
 						createReadRecord(filePath, {
 							requestedOffset: i,
@@ -1013,15 +1018,85 @@ describe("ReadGuard", () => {
 					.mocked(logReadGuardEvent)
 					.mock.calls.filter(([e]) => e.event === "read_cap_trimmed");
 				expect(trimCalls).toHaveLength(1);
+				// The ONE emitted line is the first trim's own snapshot — an
+				// unbounded design can't be reconciled with a single log line
+				// per session (each trim genuinely evicts only 1 record), so
+				// the running total across all 172 trims lives in
+				// `getTrimStats`, checked below, not in this line.
 				expect(trimCalls[0][0]).toMatchObject({
 					event: "read_cap_trimmed",
 					filePath: normalizeFilePath(filePath),
 					metadata: {
+						trimEventCount: 1,
 						evictedRecordCount: 1,
 						evictedGenuineCount: 1,
 						evictedCreditCount: 0,
-						rawReadCountForFile: 129,
 					},
+				});
+
+				// The running totals across ALL 172 trims stay observable via
+				// getTrimStats even though logging stopped after the first.
+				const stats = guard.getTrimStats(filePath);
+				expect(stats).toEqual({
+					totalEvicted: 172,
+					evictedCreditCount: 0,
+					evictedGenuineCount: 172,
+					trimEventCount: 172,
+				});
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("splits evicted credit vs. genuine reads in the trim accumulator", () => {
+			// #1913 review F3: `evictedCreditCount`/`evictedGenuineCount` must
+			// actually discriminate — a no-op'd increment would leave this
+			// green only if every trimmed record happened to be genuine (the
+			// prior test's fixture). Mix search-credit and genuine reads so a
+			// trim spends credits first, then genuine reads, and prove both
+			// counters move.
+			const env = setupTestEnvironment("read-guard-cap-trim-split-");
+			try {
+				const filePath = path.join(env.tmpDir, "hot.ts");
+				fs.writeFileSync(
+					filePath,
+					Array.from({ length: 400 }, (_, i) => `line${i + 1}`).join("\n"),
+				);
+				const guard = createReadGuard("test-session");
+				// 3 search-credit reads, then 130 genuine reads: 133 records vs.
+				// a 128 cap. Eviction spends credits first (3), then 2 genuine
+				// reads, across 5 trim events (each push past the cap trims 1).
+				for (let i = 1; i <= 3; i++) {
+					guard.recordRead(
+						createReadRecord(filePath, {
+							requestedOffset: i,
+							requestedLimit: 1,
+							effectiveOffset: i,
+							effectiveLimit: 1,
+							searchCredit: {
+								marginBefore: 0,
+								marginAfter: 0,
+								reason: "match-lines-only",
+							},
+						}),
+					);
+				}
+				for (let i = 4; i <= 133; i++) {
+					guard.recordRead(
+						createReadRecord(filePath, {
+							requestedOffset: i,
+							requestedLimit: 1,
+							effectiveOffset: i,
+							effectiveLimit: 1,
+						}),
+					);
+				}
+				const stats = guard.getTrimStats(filePath);
+				expect(stats).toEqual({
+					totalEvicted: 5,
+					evictedCreditCount: 3,
+					evictedGenuineCount: 2,
+					trimEventCount: 5,
 				});
 			} finally {
 				env.cleanup();

--- a/tests/clients/read-guard.test.ts
+++ b/tests/clients/read-guard.test.ts
@@ -988,6 +988,74 @@ describe("ReadGuard", () => {
 			}
 		});
 
+		// ── #1913: eviction telemetry must survive at default verbosity ──────
+
+		it("emits a bounded read_cap_trimmed record when eviction fires", () => {
+			const env = setupTestEnvironment("read-guard-cap-trim-event-");
+			try {
+				const filePath = path.join(env.tmpDir, "hot.ts");
+				fs.writeFileSync(
+					filePath,
+					Array.from({ length: 400 }, (_, i) => `line${i + 1}`).join("\n"),
+				);
+				const guard = createReadGuard("test-session");
+				for (let i = 1; i <= 129; i++) {
+					guard.recordRead(
+						createReadRecord(filePath, {
+							requestedOffset: i,
+							requestedLimit: 1,
+							effectiveOffset: i,
+							effectiveLimit: 1,
+						}),
+					);
+				}
+				const trimCalls = vi
+					.mocked(logReadGuardEvent)
+					.mock.calls.filter(([e]) => e.event === "read_cap_trimmed");
+				expect(trimCalls).toHaveLength(1);
+				expect(trimCalls[0][0]).toMatchObject({
+					event: "read_cap_trimmed",
+					filePath: normalizeFilePath(filePath),
+					metadata: {
+						evictedRecordCount: 1,
+						evictedGenuineCount: 1,
+						evictedCreditCount: 0,
+						rawReadCountForFile: 129,
+					},
+				});
+			} finally {
+				env.cleanup();
+			}
+		});
+
+		it("emits no read_cap_trimmed record when the cap is never reached", () => {
+			const env = setupTestEnvironment("read-guard-cap-no-trim-event-");
+			try {
+				const filePath = path.join(env.tmpDir, "warm.ts");
+				fs.writeFileSync(
+					filePath,
+					Array.from({ length: 40 }, (_, i) => `line${i + 1}`).join("\n"),
+				);
+				const guard = createReadGuard("test-session");
+				for (let i = 1; i <= 5; i++) {
+					guard.recordRead(
+						createReadRecord(filePath, {
+							requestedOffset: i,
+							requestedLimit: 1,
+							effectiveOffset: i,
+							effectiveLimit: 1,
+						}),
+					);
+				}
+				const trimCalls = vi
+					.mocked(logReadGuardEvent)
+					.mock.calls.filter(([e]) => e.event === "read_cap_trimmed");
+				expect(trimCalls).toHaveLength(0);
+			} finally {
+				env.cleanup();
+			}
+		});
+
 		it("keeps the newest read usable for coverage after the cap trims", () => {
 			const env = setupTestEnvironment("read-guard-record-cap-cover-");
 			try {


### PR DESCRIPTION
## What changed

**#1908 — search credit ignores pipe truncation.** `grep -C2 pattern file |
head -1` credited the full declared ±2 context even though `head` truncated
the pipe before that context ever reached the model. `collectGrepCommandFiles`
in `clients/bash-file-access.ts` now walks the pipe chain each line-numbered
grep feeds into (via a new `terminator: "pipe"` field on
`ShellCommandSegment`) and falls back to match-line-only credit (`{before: 0,
after: 0}`) when the chain hits a truncating tail: `head`, `tail` (any
invocation — both default to a 10-line window), or a `sed` script containing
a `q` command.

Per-tail policy, documented in a code comment at the new helper:
- `head`/`tail`/`sed q` → match-line-only credit (conservative fallback).
- `wc`, `sort`, and similar stream-consuming/reordering tails need no special
  case: they replace grep's `file:line:` output with a count or reordered
  text, so `parseGrepOutputSearchReads` already finds zero matching lines in
  the real captured stdout — no line means no credit already.
- A pass-through filter (`cat`, `grep -v`, ...) between grep and a truncating
  tail is still caught, since the walk follows the whole chain.
- Out of scope, deliberately: `sed -n 'Np'` range-address filtering without
  `q` also truncates but isn't in #1908's stated scope.

**#1913 — read-guard eviction telemetry is verbose-only.** The #1907
record-cap eviction counters (`evictedRecordCount`, `rawReadCountForFile`)
rode the `read_recorded` event, which `read-guard-logger`'s `shouldLogEvent`
gates behind `PI_LENS_READ_GUARD_VERBOSE` (off by default). A live eviction
regression left no trace unless verbose logging happened to be on.
`recordRead` now also emits a dedicated `read_cap_trimmed` event — file,
`evictedRecordCount`, the credit-vs-genuine split (`evictedCreditCount`,
`evictedGenuineCount`), and `rawReadCountForFile` — only when
`enforceRecordCapForFile` actually trims, and `read_cap_trimmed` is added to
`shouldLogEvent`'s always-on list so it bypasses the verbosity gate. The
per-read `read_recorded` line, and everything else, stays gated exactly as
before.

## Why

Both are follow-ups from #1907's review, named in #1904's arc: a parser that
trusts declared flags without checking whether the shell actually delivered
what they promise (#1908), and a rare-but-load-bearing failure signal that
was only visible with an env var most sessions never set (#1913).

## Verification

- `npm run build` before every test run.
- Red-first: reverted `clients/bash-file-access.ts` and confirmed 4 new
  tests failed (head/tail/sed-q/pass-through-filter all showed
  `contextBefore/After: 2` instead of `0`); reverted
  `clients/read-guard.ts` + `clients/read-guard-logger.ts` and confirmed the
  new `read_cap_trimmed` test failed (`expected [] to have length 1`), and the
  dedicated `shouldLogEvent` test failed with `TypeError: shouldLogEvent is
  not a function`. Restored the fix (`git apply`) after each — no `git
  stash` used.
- Green after the fix: `tests/clients/bash-file-access.test.ts` (82),
  `tests/clients/read-guard.test.ts` (71), new
  `tests/clients/read-guard-logger.test.ts` (3).
- Sibling suites that reference the touched symbols:
  `search-read-registration.test.ts`, `git-guard.test.ts` (uses
  `tokenizeShellCommand`), `pi-host-contract.test.ts`,
  `bash-read-guard-integration.test.ts`, `read-guard-path-normalization`,
  `read-guard-symbol-read`, `read-guard-tool-lines`, `read-bridge`,
  `read-expansion-enrichment`, `agent-nudge`, and
  `session-state-conformance.test.ts` — all green (308 tests total across
  those files).
- Full suite deferred to CI, per repo policy.

## Mutation-proofing

- `grepPipesIntoTruncatingTail` / `isTruncatingTailCommand`: neutering either
  to always return `false` reds the head/tail/sed-q/pass-through tests;
  always `true` reds the `| sort` non-truncating and no-pipe tests.
- `read_cap_trimmed` emission: the "no eviction" test reds if the
  `evictedRecordCount > 0` guard is deleted; the "eviction fires" test reds
  if the event, or any of its four metadata fields, is dropped.
- `shouldLogEvent`'s new arm: the dedicated logger test reds if
  `read_cap_trimmed` is removed from the always-on list, independent of the
  `read-guard.test.ts` mock (which bypasses the real gate entirely).

## Blast radius

- `ShellCommandSegment` gained an optional `terminator?: "pipe"` field.
  `git-guard.ts` is the only other consumer of `tokenizeShellCommand`, and it
  only reads `.tokens` — unaffected.
- `enforceRecordCapForFile`'s return type changed from `number` to an object
  (`{evictedCount, evictedCreditCount, evictedGenuineCount}`); its one caller
  (`recordRead`) was updated. No other caller exists.
- Both changes are read-path/telemetry-path only — no new process spawns, no
  behavior change to what edits are allowed or blocked.
- `read_cap_trimmed` fires only when `enforceRecordCapForFile` actually
  trims (records per file > 128), which the #1907 docstring calls a rare,
  hot-file-only path — negligible added log volume.

## Class sweep

**Pattern sweep (#1908):** grepped `clients/`, `tools/`, `mcp/`, `scripts/`,
`index.ts` for `contextBefore`/`contextAfter` assignment sites. Only
`clients/bash-file-access.ts` (the grep parser, fixed here) and
`clients/search-read-registration.ts` (the consumer, which trusts whatever
context the caller declares — by design, per its own doc comment) touch
these fields. No other search-credit producer exists to sweep.

**Population sweep (#1913):** `read-guard.ts` has three other size-bounded
stores besides the per-file record cap: `enforceFileCap`'s whole-file
eviction (`READ_GUARD_MAX_FILES`/`READ_GUARD_MAX_UNCONSUMED_FILES`, via
`evictFile`) and the per-file edits cap (`READ_GUARD_MAX_EDITS_PER_FILE`).
Neither emits ANY eviction telemetry today — not gated, simply absent. Both
are out of scope for #1913, whose acceptance criteria target only the
#1907 record-cap eviction, and the edits cap is already documented
(`read-guard.ts`'s own comment) as sitting "far above every consumer's
reach" — trimming is inert there. Flagging both as a real but smaller gap;
filing a follow-up issue if the maintainer wants coverage extended before
the next `enforceFileCap`-adjacent incident.

## Merge-order note

No open PRs touch `clients/bash-file-access.ts`, `clients/read-guard.ts`, or
`clients/read-guard-logger.ts` as of this branch's creation (`gh pr list`
returned none). No stacking or sequencing needed.

Closes #1908, closes #1913. The class sweep's remaining eviction paths (evictFile, enforceFileCap, edits-cap splice, idle-eviction timer) are re-homed to #1918 — refs #1918.

