### PR TITLE
feat: adopt husky for local git hooks (closes #1804)

### DIFF
--- a/.changelog/feat-1804-husky.md
+++ b/.changelog/feat-1804-husky.md
@@ -1,0 +1,10 @@
+---
+section: Added
+---
+
+- **Husky-managed local git hooks (closes #1804)** — `npm install` now wires
+  a pre-commit hook (changelog fragment validation + `npm run lint`) and a
+  pre-push hook (build + targeted `vitest` for changed files, never the full
+  suite). Both are skippable with `PI_LENS_SKIP_HOOKS=1`, which agents and CI
+  set; humans leave hooks on. Hook install itself is skipped for CI and
+  production/consumer installs, and never fails `npm install` on error.

--- a/.changelog/feat-1804-husky.md
+++ b/.changelog/feat-1804-husky.md
@@ -4,7 +4,10 @@ section: Added
 
 - **Husky-managed local git hooks (closes #1804)** — `npm install` now wires
   a pre-commit hook (changelog fragment validation + `npm run lint`) and a
-  pre-push hook (build + targeted `vitest` for changed files, never the full
-  suite). Both are skippable with `PI_LENS_SKIP_HOOKS=1`, which agents and CI
-  set; humans leave hooks on. Hook install itself is skipped for CI and
-  production/consumer installs, and never fails `npm install` on error.
+  pre-push hook (build + a capped, full-path-resolved targeted `vitest`
+  selection for changed files, never the full suite; degrades to build-only
+  past 25 matched test files or a 2-minute shared test-lock wait). Both are
+  skippable with `PI_LENS_SKIP_HOOKS` set to any non-empty value, which
+  agents and CI should set; humans leave hooks on. Hook install itself is
+  skipped for CI and production/consumer installs, and never fails
+  `npm install` on error.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+if [ "$PI_LENS_SKIP_HOOKS" = "1" ]; then
+  echo "[pre-commit] skipped (PI_LENS_SKIP_HOOKS=1)."
+  exit 0
+fi
+
+npm run changelog:check && npm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
-if [ "$PI_LENS_SKIP_HOOKS" = "1" ]; then
-  echo "[pre-commit] skipped (PI_LENS_SKIP_HOOKS=1)."
+if [ -n "$PI_LENS_SKIP_HOOKS" ]; then
+  echo "[pre-commit] skipped (PI_LENS_SKIP_HOOKS is set)."
   exit 0
 fi
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,6 @@
+if [ "$PI_LENS_SKIP_HOOKS" = "1" ]; then
+  echo "[pre-push] skipped (PI_LENS_SKIP_HOOKS=1)."
+  exit 0
+fi
+
+node scripts/pre-push-targeted-tests.mjs

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,11 @@
-if [ "$PI_LENS_SKIP_HOOKS" = "1" ]; then
-  echo "[pre-push] skipped (PI_LENS_SKIP_HOOKS=1)."
+if [ -n "$PI_LENS_SKIP_HOOKS" ]; then
+  echo "[pre-push] skipped (PI_LENS_SKIP_HOOKS is set)."
   exit 0
 fi
 
+# Bounds how long a push waits on the shared machine-wide test-suite lock
+# (#1101, ~10 agents can share one dev machine). pre-push-targeted-tests.mjs
+# treats a lock timeout as "let the push proceed, CI is authoritative" —
+# never as a hard failure.
+export PI_LENS_TEST_LOCK_TIMEOUT_MS=120000
 node scripts/pre-push-targeted-tests.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,22 @@ npm test
 
 Pull requests must pass `npm run lint` and `npm test`. CI also runs `npm run check:lockfile` and a production `--omit=dev` build (`npm run build:dist`), so keep `package-lock.json` in sync with `package.json`.
 
+## Local git hooks
+
+`npm install` wires Husky-managed hooks into `.git/config`'s `core.hooksPath`,
+scoped to your clone (each worktree wires its own):
+
+- **pre-commit** — changelog fragment validation (`npm run changelog:check`)
+  plus `npm run lint`. Measured around 4s on this repo.
+- **pre-push** — a build, then targeted `vitest` runs for the changed `.ts`
+  files (never the full suite; see `scripts/pre-push-targeted-tests.mjs`).
+
+Skip either with `PI_LENS_SKIP_HOOKS=1 git commit ...` / `git push ...`.
+Agents and CI set this — their commit cadence is too high for a lint pass on
+every commit, and CI runs the real gates anyway. Humans should leave hooks on;
+they catch the exact class of failure (unused vars, changelog-format
+violations) that used to slip through to CI.
+
 ## What belongs here?
 
 pi-lens is a pi extension that runs automated checks on every file write/edit. Contributions that fit are:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,19 +24,33 @@ Pull requests must pass `npm run lint` and `npm test`. CI also runs `npm run che
 
 ## Local git hooks
 
-`npm install` wires Husky-managed hooks into `.git/config`'s `core.hooksPath`,
-scoped to your clone (each worktree wires its own):
+`npm install` wires Husky-managed hooks:
 
 - **pre-commit** — changelog fragment validation (`npm run changelog:check`)
-  plus `npm run lint`. Measured around 4s on this repo.
+  plus `npm run lint`. Measured around 5.5s on this repo.
 - **pre-push** — a build, then targeted `vitest` runs for the changed `.ts`
   files (never the full suite; see `scripts/pre-push-targeted-tests.mjs`).
+  Waits at most 2 minutes on the shared machine-wide test-suite lock
+  (#1101); if that times out, the push proceeds anyway with a warning —
+  CI runs the real gate either way.
 
-Skip either with `PI_LENS_SKIP_HOOKS=1 git commit ...` / `git push ...`.
-Agents and CI set this — their commit cadence is too high for a lint pass on
-every commit, and CI runs the real gates anyway. Humans should leave hooks on;
-they catch the exact class of failure (unused vars, changelog-format
-violations) that used to slip through to CI.
+`core.hooksPath` is `git config` — shared by every worktree of the same
+clone, not scoped per worktree. What IS per-worktree is `.husky/_` (the
+directory husky installs at that path), which is git-ignored and only
+created by running `npm install` in that specific worktree. A worktree
+where nobody has run `npm install` yet has the hook FILES checked out but
+nothing wired to `core.hooksPath` there, so `git commit`/`git push` silently
+run no hooks. This is accepted behavior, not a bug to route around: hooks
+serve human checkouts, where `npm install` has run; agent worktrees are
+covered by `PI_LENS_SKIP_HOOKS` below regardless, and CI is authoritative
+either way.
+
+Skip either hook with `PI_LENS_SKIP_HOOKS=<anything> git commit ...` /
+`git push ...` (any non-empty value works). Agents and CI should set this —
+their commit cadence across concurrent worktrees is too high for a lint pass
+on every commit, and CI runs the real gates anyway. Humans committing
+directly should leave hooks on; they catch the exact class of failure
+(unused vars, changelog-format violations) that used to slip through to CI.
 
 ## What belongs here?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,9 @@ created by running `npm install` in that specific worktree. A worktree
 where nobody has run `npm install` yet has the hook FILES checked out but
 nothing wired to `core.hooksPath` there, so `git commit`/`git push` silently
 run no hooks. This is accepted behavior, not a bug to route around: hooks
-serve human checkouts, where `npm install` has run; agent worktrees are
-covered by `PI_LENS_SKIP_HOOKS` below regardless, and CI is authoritative
-either way.
+serve human checkouts, where `npm install` has run; agent worktrees can opt
+out with `PI_LENS_SKIP_HOOKS` (see below), and CI is authoritative either
+way.
 
 Skip either hook with `PI_LENS_SKIP_HOOKS=<anything> git commit ...` /
 `git push ...` (any non-empty value works). Agents and CI should set this —

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/node": "^26.0.0",
         "@types/pidusage": "^2.0.5",
         "@vitest/coverage-v8": "^4.1.5",
+        "husky": "^9.1.7",
         "typescript": "^7.0.2",
         "typescript-language-server": "^5.1.3",
         "vitest": "^4.1.1"
@@ -3634,6 +3635,22 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "tsc --project tsconfig.build.json",
     "build:dist": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && npx --yes -p typescript@7.0.2 tsc --project tsconfig.dist.json --noCheck && npm run bundle:dist",
     "bundle:dist": "node scripts/bundle-dist.mjs",
-    "prepare": "npm run build:dist && node scripts/download-grammars.js --core --dest grammars",
+    "prepare": "npm run build:dist && node scripts/download-grammars.js --core --dest grammars && node scripts/setup-git-hooks.mjs",
     "lint": "tsc --project tsconfig.json",
     "watch": "tsc --watch",
     "test": "node scripts/with-test-lock.mjs -- vitest run",
@@ -113,6 +113,7 @@
     "@types/node": "^26.0.0",
     "@types/pidusage": "^2.0.5",
     "@vitest/coverage-v8": "^4.1.5",
+    "husky": "^9.1.7",
     "typescript": "^7.0.2",
     "typescript-language-server": "^5.1.3",
     "vitest": "^4.1.1"

--- a/scripts/lib/suite-lock.mjs
+++ b/scripts/lib/suite-lock.mjs
@@ -310,6 +310,12 @@ export async function acquireTestLock(options = {}) {
 
 			const now = Date.now();
 			if (timeoutMs > 0 && now - start > timeoutMs) {
+				// Message shape is pinned: tests/scripts/suite-lock.test.ts:233
+				// asserts against it directly, and scripts/pre-push-targeted-tests.mjs
+				// greps a caller's stderr for "timed out after \d+ms waiting for
+				// test-suite lock" to tell a lock timeout (push proceeds, #1804 F2)
+				// apart from a real test failure (push blocks). Reword both call
+				// sites together with this string.
 				throw new Error(
 					`timed out after ${timeoutMs}ms waiting for test-suite lock held by ${describeOwner(owner)}`,
 				);

--- a/scripts/pre-push-targeted-tests.d.mts
+++ b/scripts/pre-push-targeted-tests.d.mts
@@ -1,0 +1,21 @@
+// Type declarations for pre-push-targeted-tests.mjs (untyped .mjs imported
+// from .ts tests, so the selection logic can be pinned down directly). #1804.
+
+export const MAX_SELECTED_TESTS: number;
+
+export function resolveDiffRange(): string;
+
+export function changedTsFiles(range: string): string[] | null;
+
+export function collectTestFiles(dir: string, out?: string[]): string[];
+
+export interface TargetedTestSelection {
+	selected: string[];
+	unmatched: string[];
+	capped: boolean;
+	totalBeforeCap: number;
+}
+
+export function selectTargetedTests(changed: string[], allTests: string[]): TargetedTestSelection;
+
+export function main(): Promise<number>;

--- a/scripts/pre-push-targeted-tests.mjs
+++ b/scripts/pre-push-targeted-tests.mjs
@@ -5,23 +5,46 @@
 // files that plausibly cover the changed .ts files. Never the full suite —
 // the suite is machine-wide-locked (#1101) and CI is authoritative.
 //
-// Selection is two passes over `tests/**/*.test.ts`:
-//   1. Path mirror: a changed `clients/foo/bar.ts` selects a test file whose
-//      basename is `bar.test.ts` (the repo's dominant tests/ layout mirrors
-//      clients/).
-//   2. Content grep: a changed file's basename appears in a test file's own
-//      import specifiers — catches shared-seam siblings the path mirror
-//      misses (tests/index-*-wiring.test.ts import shared modules by name,
-//      not by mirrored path; see AGENTS.md's "sibling test files encode the
-//      same behavior" note).
+// Selection is two passes over `tests/**/*.test.ts`, per changed file:
+//   1. Path mirror: a changed `clients/foo/bar.ts` selects
+//      `tests/clients/foo/bar.test.ts` if it exists — an exact mirrored
+//      path, not a basename-only guess.
+//   2. Import resolution: every test file's own relative import specifiers
+//      are resolved to absolute, extension-stripped paths (exactly the way
+//      Node/vitest would resolve them) and compared against the changed
+//      file's own absolute, extension-stripped path. This is what catches
+//      shared-seam siblings the path mirror misses (tests/index-*-wiring
+//      test files import shared modules by name, not by mirrored path; see
+//      AGENTS.md's "sibling test files encode the same behavior" note) —
+//      WITHOUT the false-positive blow-up a substring/basename match causes
+//      (multiple `index.ts` files across the tree all share one basename;
+//      a prior basename-suffix version of this script selected 282 test
+//      files for a 43-file commit, ~10 minutes, because of exactly that).
 // A changed test file is always included directly.
 //
-// If nothing matches (docs-only / non-.ts changes), this builds only and
-// skips the test run — never silently skips the build too.
-import { execFileSync } from "node:child_process";
+// Selection is capped at MAX_SELECTED_TESTS: past that, "targeted" has
+// stopped meaning anything cheaper than the full suite, so this degrades to
+// build-only and says so — the "never the full suite" claim holds by
+// construction, not by hoping the heuristic stays narrow.
+//
+// If nothing matches (docs-only / non-.ts changes, or a changed file with no
+// covering test), this builds only and skips the test run — never silently
+// skips the build too.
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { quoteForWindowsCmd } from "./with-test-lock.mjs";
+
+export const MAX_SELECTED_TESTS = 25;
+
+// Matches `from "…"`, `import("…")`, and `require("…")` — the three ways a
+// vitest file (or a module it imports) pulls in another module.
+const IMPORT_SPECIFIER_RE = /(?:from\s+|import\(|require\()\s*["']([^"']+)["']/g;
+
+function toPosix(file) {
+	return file.split(path.sep).join("/");
+}
 
 function readStdin() {
 	try {
@@ -31,7 +54,7 @@ function readStdin() {
 	}
 }
 
-function resolveDiffRange() {
+export function resolveDiffRange() {
 	const stdin = readStdin().trim();
 	if (stdin) {
 		const firstLine = stdin.split("\n")[0]?.trim();
@@ -46,7 +69,7 @@ function resolveDiffRange() {
 	return "origin/master...HEAD";
 }
 
-function changedTsFiles(range) {
+export function changedTsFiles(range) {
 	try {
 		const out = execFileSync("git", ["diff", "--name-only", range], { encoding: "utf8" });
 		return out
@@ -61,46 +84,97 @@ function changedTsFiles(range) {
 	}
 }
 
-function collectTestFiles(dir, out) {
+export function collectTestFiles(dir, out = []) {
 	if (!existsSync(dir)) return out;
 	for (const entry of readdirSync(dir, { withFileTypes: true })) {
 		const full = path.join(dir, entry.name);
 		if (entry.isDirectory()) collectTestFiles(full, out);
-		else if (entry.name.endsWith(".test.ts")) out.push(full.split(path.sep).join("/"));
+		else if (entry.name.endsWith(".test.ts")) out.push(toPosix(full));
 	}
 	return out;
 }
 
-function selectTargetedTests(changed, allTests) {
-	const selected = new Set();
+// `clients/foo/bar.ts` -> absolute path to `clients/foo/bar`, extension
+// stripped, so a .ts source and the .js/.mjs it compiles to (or a test's
+// import of either spelling) compare equal.
+function toAbsNoExt(file) {
+	return path.resolve(file).replace(/\.(ts|tsx|js|mjs|cjs)$/i, "");
+}
+
+function extractRelativeSpecifiers(content) {
+	const specifiers = [];
+	IMPORT_SPECIFIER_RE.lastIndex = 0;
+	let match = IMPORT_SPECIFIER_RE.exec(content);
+	while (match) {
+		const specifier = match[1];
+		if (specifier.startsWith(".")) specifiers.push(specifier);
+		match = IMPORT_SPECIFIER_RE.exec(content);
+	}
+	return specifiers;
+}
+
+function readFileSafe(file) {
+	try {
+		return readFileSync(file, "utf8");
+	} catch {
+		return null;
+	}
+}
+
+// One pass over every test file: read it once, resolve every relative
+// import specifier it contains to an absolute extension-stripped path (the
+// same resolution Node's own module loader would do), and index the result.
+// Built once and reused across every changed file, instead of re-reading
+// every test file per changed file.
+function buildTestImportIndex(allTests) {
+	const index = new Map();
+	for (const test of allTests) {
+		const content = readFileSafe(test);
+		if (content === null) continue;
+		const abs = new Set();
+		for (const specifier of extractRelativeSpecifiers(content)) {
+			abs.add(toAbsNoExt(path.resolve(path.dirname(test), specifier)));
+		}
+		index.set(test, abs);
+	}
+	return index;
+}
+
+/**
+ * @param {string[]} changed
+ * @param {string[]} allTests
+ * @returns {{ selected: string[], unmatched: string[], capped: boolean, totalBeforeCap: number }}
+ */
+export function selectTargetedTests(changed, allTests) {
+	const testImportIndex = buildTestImportIndex(allTests);
+	const perFile = new Map();
+
 	for (const file of changed) {
+		const matches = new Set();
 		if (file.endsWith(".test.ts")) {
-			if (existsSync(file)) selected.add(file.split(path.sep).join("/"));
-			continue;
-		}
-		const base = path.basename(file, ".ts");
-		for (const test of allTests) {
-			if (path.basename(test, ".test.ts") === base) selected.add(test);
-		}
-	}
-	for (const file of changed) {
-		if (file.endsWith(".test.ts")) continue;
-		const base = path.basename(file, ".ts");
-		const marker = `/${base}`;
-		for (const test of allTests) {
-			if (selected.has(test)) continue;
-			let content;
-			try {
-				content = readFileSync(test, "utf8");
-			} catch {
-				continue;
-			}
-			if (content.includes(`${marker}"`) || content.includes(`${marker}'`) || content.includes(`${marker}.js`)) {
-				selected.add(test);
+			if (existsSync(file)) matches.add(toPosix(file));
+		} else {
+			const mirror = `tests/${toPosix(file).replace(/\.ts$/, "")}.test.ts`;
+			if (existsSync(mirror)) matches.add(toPosix(mirror));
+
+			const changedAbsNoExt = toAbsNoExt(file);
+			for (const [test, importedAbs] of testImportIndex) {
+				if (importedAbs.has(changedAbsNoExt)) matches.add(test);
 			}
 		}
+		perFile.set(file, matches);
 	}
-	return [...selected];
+
+	const selected = new Set();
+	for (const matches of perFile.values()) {
+		for (const test of matches) selected.add(test);
+	}
+
+	const unmatched = changed.filter((file) => !file.endsWith(".test.ts") && perFile.get(file).size === 0);
+	const totalBeforeCap = selected.size;
+	const capped = totalBeforeCap > MAX_SELECTED_TESTS;
+
+	return { selected: capped ? [] : [...selected], unmatched, capped, totalBeforeCap };
 }
 
 // Windows CreateProcess can't exec .cmd shims (npm) directly, so those need
@@ -117,7 +191,37 @@ function runInherit(command, args, { needsShimShell = false } = {}) {
 	}
 }
 
-function main() {
+const LOCK_TIMEOUT_RE = /timed out after \d+ms waiting for test-suite lock/;
+
+// Runs the targeted vitest selection through with-test-lock.mjs, streaming
+// stdout live and mirroring stderr live while also buffering it — the
+// buffer is only needed to tell "the shared machine-wide lock timed out"
+// (with-test-lock.mjs's own message, PI_LENS_TEST_LOCK_TIMEOUT_MS in
+// .husky/pre-push) apart from "the tests actually failed". A lock timeout
+// must let the push proceed (the hook is a convenience layer, CI is
+// authoritative, and a blocked push queue on a shared machine is worse than
+// a skipped local run); a real test failure must still block the push.
+function runTargetedTests(selected) {
+	return new Promise((resolve) => {
+		const child = spawn(process.execPath, ["scripts/with-test-lock.mjs", "--", "vitest", "run", ...selected], {
+			stdio: ["ignore", "inherit", "pipe"],
+		});
+		let stderrBuffer = "";
+		child.stderr.on("data", (chunk) => {
+			process.stderr.write(chunk);
+			stderrBuffer += chunk.toString();
+		});
+		child.on("error", (error) => {
+			resolve({ code: 1, timedOut: false, error });
+		});
+		child.on("close", (code) => {
+			const timedOut = code !== 0 && LOCK_TIMEOUT_RE.test(stderrBuffer);
+			resolve({ code: code ?? 1, timedOut });
+		});
+	});
+}
+
+export async function main() {
 	const range = resolveDiffRange();
 	const changed = changedTsFiles(range);
 
@@ -126,24 +230,66 @@ function main() {
 
 	if (changed === null || changed.length === 0) {
 		console.log("[pre-push] no TypeScript changes to target; build-only pass complete.");
-		return;
+		return 0;
 	}
 
-	const allTests = collectTestFiles("tests", []);
-	const selected = selectTargetedTests(changed, allTests);
+	const allTests = collectTestFiles("tests");
+	const { selected, unmatched, capped, totalBeforeCap } = selectTargetedTests(changed, allTests);
+
+	for (const file of unmatched) console.log(`[pre-push] no tests matched ${file}`);
+
+	if (capped) {
+		console.warn(
+			`[pre-push] selection too broad (${totalBeforeCap} test files matched ${changed.length} changed file(s), over the ${MAX_SELECTED_TESTS}-file cap); rely on CI.`,
+		);
+		return 0;
+	}
 
 	if (selected.length === 0) {
-		console.log(
-			`[pre-push] no test files matched ${changed.length} changed .ts file(s); build-only pass complete.`,
-		);
-		return;
+		console.log(`[pre-push] no test files matched ${changed.length} changed .ts file(s); build-only pass complete.`);
+		return 0;
 	}
 
 	console.log(
 		`[pre-push] running ${selected.length} targeted test file(s) for ${changed.length} changed .ts file(s):`,
 	);
 	for (const test of selected) console.log(`  - ${test}`);
-	runInherit(process.execPath, ["scripts/with-test-lock.mjs", "--", "vitest", "run", ...selected]);
+
+	const { code, timedOut, error } = await runTargetedTests(selected);
+	if (timedOut) {
+		console.warn(
+			"[pre-push] the shared machine-wide test-suite lock (#1101) timed out; letting the push proceed without the targeted run. CI runs the real gate.",
+		);
+		return 0;
+	}
+	if (error) {
+		console.warn(`[pre-push] could not run targeted tests (${error.message}); letting the push proceed. CI runs the real gate.`);
+		return 0;
+	}
+	return code;
 }
 
-main();
+// Only run the CLI when this file is the entry point — not when a test
+// imports it to exercise selectTargetedTests/etc. directly. Mirrors
+// with-test-lock.mjs's own isEntryPoint (win32 case-insensitive fallback
+// included for the same reason: a differently-cased invocation path still
+// resolves to this file on Windows's default case-insensitive filesystem).
+function isEntryPoint() {
+	if (!process.argv[1]) return false;
+	const invoked = path.resolve(process.argv[1]);
+	const self = fileURLToPath(import.meta.url);
+	if (invoked === self) return true;
+	if (process.platform !== "win32") return false;
+	return invoked.toLowerCase() === self.toLowerCase();
+}
+
+if (isEntryPoint()) {
+	main()
+		.then((code) => {
+			process.exitCode = code;
+		})
+		.catch((error) => {
+			console.error(`[pre-push] ${error instanceof Error ? error.stack || error.message : error}`);
+			process.exitCode = 1;
+		});
+}

--- a/scripts/pre-push-targeted-tests.mjs
+++ b/scripts/pre-push-targeted-tests.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// scripts/pre-push-targeted-tests.mjs (#1804)
+//
+// Runs a targeted vitest selection before a push: a build, then the test
+// files that plausibly cover the changed .ts files. Never the full suite —
+// the suite is machine-wide-locked (#1101) and CI is authoritative.
+//
+// Selection is two passes over `tests/**/*.test.ts`:
+//   1. Path mirror: a changed `clients/foo/bar.ts` selects a test file whose
+//      basename is `bar.test.ts` (the repo's dominant tests/ layout mirrors
+//      clients/).
+//   2. Content grep: a changed file's basename appears in a test file's own
+//      import specifiers — catches shared-seam siblings the path mirror
+//      misses (tests/index-*-wiring.test.ts import shared modules by name,
+//      not by mirrored path; see AGENTS.md's "sibling test files encode the
+//      same behavior" note).
+// A changed test file is always included directly.
+//
+// If nothing matches (docs-only / non-.ts changes), this builds only and
+// skips the test run — never silently skips the build too.
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+function readStdin() {
+	try {
+		return readFileSync(0, "utf8");
+	} catch {
+		return "";
+	}
+}
+
+function resolveDiffRange() {
+	const stdin = readStdin().trim();
+	if (stdin) {
+		const firstLine = stdin.split("\n")[0]?.trim();
+		const parts = firstLine ? firstLine.split(/\s+/) : [];
+		const [, localSha, , remoteSha] = parts;
+		if (localSha && remoteSha && !/^0+$/.test(remoteSha)) {
+			return `${remoteSha}...${localSha}`;
+		}
+	}
+	// New branch (no remote tracking ref yet) or unreadable stdin: diff
+	// against origin/master, same baseline CI compares PRs against.
+	return "origin/master...HEAD";
+}
+
+function changedTsFiles(range) {
+	try {
+		const out = execFileSync("git", ["diff", "--name-only", range], { encoding: "utf8" });
+		return out
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.endsWith(".ts") && !line.startsWith("dist/"));
+	} catch (error) {
+		console.warn(
+			`[pre-push] could not compute diff range "${range}", falling back to a build-only pass: ${error instanceof Error ? error.message : error}`,
+		);
+		return null;
+	}
+}
+
+function collectTestFiles(dir, out) {
+	if (!existsSync(dir)) return out;
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) collectTestFiles(full, out);
+		else if (entry.name.endsWith(".test.ts")) out.push(full.split(path.sep).join("/"));
+	}
+	return out;
+}
+
+function selectTargetedTests(changed, allTests) {
+	const selected = new Set();
+	for (const file of changed) {
+		if (file.endsWith(".test.ts")) {
+			if (existsSync(file)) selected.add(file.split(path.sep).join("/"));
+			continue;
+		}
+		const base = path.basename(file, ".ts");
+		for (const test of allTests) {
+			if (path.basename(test, ".test.ts") === base) selected.add(test);
+		}
+	}
+	for (const file of changed) {
+		if (file.endsWith(".test.ts")) continue;
+		const base = path.basename(file, ".ts");
+		const marker = `/${base}`;
+		for (const test of allTests) {
+			if (selected.has(test)) continue;
+			let content;
+			try {
+				content = readFileSync(test, "utf8");
+			} catch {
+				continue;
+			}
+			if (content.includes(`${marker}"`) || content.includes(`${marker}'`) || content.includes(`${marker}.js`)) {
+				selected.add(test);
+			}
+		}
+	}
+	return [...selected];
+}
+
+function runInherit(command, args) {
+	execFileSync(command, args, { stdio: "inherit", shell: process.platform === "win32" });
+}
+
+function main() {
+	const range = resolveDiffRange();
+	const changed = changedTsFiles(range);
+
+	console.log("[pre-push] building...");
+	runInherit("npm", ["run", "build"]);
+
+	if (changed === null || changed.length === 0) {
+		console.log("[pre-push] no TypeScript changes to target; build-only pass complete.");
+		return;
+	}
+
+	const allTests = collectTestFiles("tests", []);
+	const selected = selectTargetedTests(changed, allTests);
+
+	if (selected.length === 0) {
+		console.log(
+			`[pre-push] no test files matched ${changed.length} changed .ts file(s); build-only pass complete.`,
+		);
+		return;
+	}
+
+	console.log(
+		`[pre-push] running ${selected.length} targeted test file(s) for ${changed.length} changed .ts file(s):`,
+	);
+	for (const test of selected) console.log(`  - ${test}`);
+	runInherit(process.execPath, ["scripts/with-test-lock.mjs", "--", "vitest", "run", ...selected]);
+}
+
+main();

--- a/scripts/pre-push-targeted-tests.mjs
+++ b/scripts/pre-push-targeted-tests.mjs
@@ -21,6 +21,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
+import { quoteForWindowsCmd } from "./with-test-lock.mjs";
 
 function readStdin() {
 	try {
@@ -102,8 +103,18 @@ function selectTargetedTests(changed, allTests) {
 	return [...selected];
 }
 
-function runInherit(command, args) {
-	execFileSync(command, args, { stdio: "inherit", shell: process.platform === "win32" });
+// Windows CreateProcess can't exec .cmd shims (npm) directly, so those need
+// `shell: true`; a real executable (node.exe) never does. Passing a separate
+// `args` array alongside `shell: true` is deprecated (DEP0190) because Node
+// just space-joins argv without quoting, so a shimmed command gets one
+// CRT-quoted string instead — mirrors scripts/with-test-lock.mjs's own
+// runCommand fallback.
+function runInherit(command, args, { needsShimShell = false } = {}) {
+	if (needsShimShell && process.platform === "win32") {
+		execFileSync([command, ...args].map(quoteForWindowsCmd).join(" "), { stdio: "inherit", shell: true });
+	} else {
+		execFileSync(command, args, { stdio: "inherit", shell: false });
+	}
 }
 
 function main() {
@@ -111,7 +122,7 @@ function main() {
 	const changed = changedTsFiles(range);
 
 	console.log("[pre-push] building...");
-	runInherit("npm", ["run", "build"]);
+	runInherit("npm", ["run", "build"], { needsShimShell: true });
 
 	if (changed === null || changed.length === 0) {
 		console.log("[pre-push] no TypeScript changes to target; build-only pass complete.");

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// scripts/setup-git-hooks.mjs (#1804)
+//
+// Wires Husky-managed hooks (.husky/pre-commit, .husky/pre-push) into this
+// clone's `core.hooksPath`, as a step inside the `prepare` npm lifecycle
+// script. `prepare` also runs `build:dist` + grammar download — steps that
+// consumers who install pi-lens as a dependency (`npm install --omit=dev`,
+// no .git present, no devDependencies) depend on and that MUST fail loudly
+// on error. Hook wiring must never share that failure path with them: it is
+// dev-only and best-effort, so it lives in its own script, invoked last, and
+// swallows its own errors instead of `|| true`-ing the whole `prepare` chain
+// (which would also mask a real build failure).
+//
+// Skipped, not attempted, when:
+//   - PI_LENS_SKIP_HOOKS=1        explicit opt-out (agents/CI set this)
+//   - CI=true                     GitHub Actions sets this automatically;
+//                                  CI never commits, hooks buy nothing
+//   - no .git here                consumer install (dependency, tarball) —
+//                                  there is no repo to attach hooks to
+//   - no node_modules/husky       devDependencies weren't installed
+//                                  (production/consumer install)
+import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+function skipReason() {
+	if (process.env.PI_LENS_SKIP_HOOKS === "1") return "PI_LENS_SKIP_HOOKS=1";
+	if (process.env.CI === "true") return "CI=true";
+	if (!existsSync(".git")) return "no .git (not a clone)";
+	if (!existsSync("node_modules/husky/bin.js")) return "husky not installed (production install)";
+	return null;
+}
+
+const reason = skipReason();
+if (reason) {
+	console.log(`[setup-git-hooks] skipped (${reason}).`);
+	process.exit(0);
+}
+
+try {
+	execFileSync(process.execPath, ["node_modules/husky/bin.js"], { stdio: "inherit" });
+} catch (error) {
+	// Best-effort: a broken git-hooks install must never fail `npm install`.
+	console.warn(
+		`[setup-git-hooks] husky install failed, continuing without local hooks: ${error instanceof Error ? error.message : error}`,
+	);
+}

--- a/scripts/setup-git-hooks.mjs
+++ b/scripts/setup-git-hooks.mjs
@@ -12,9 +12,14 @@
 // (which would also mask a real build failure).
 //
 // Skipped, not attempted, when:
-//   - PI_LENS_SKIP_HOOKS=1        explicit opt-out (agents/CI set this)
-//   - CI=true                     GitHub Actions sets this automatically;
-//                                  CI never commits, hooks buy nothing
+//   - PI_LENS_SKIP_HOOKS is set   explicit opt-out (agents/CI set this) —
+//                                  any non-empty value, same rule the
+//                                  hooks themselves use (.husky/pre-commit,
+//                                  .husky/pre-push)
+//   - CI is set (not "false")     GitHub Actions sets CI=true, but other CI
+//                                  runners set other truthy spellings; treat
+//                                  any non-empty value other than "false" as
+//                                  CI. CI never commits, hooks buy nothing.
 //   - no .git here                consumer install (dependency, tarball) —
 //                                  there is no repo to attach hooks to
 //   - no node_modules/husky       devDependencies weren't installed
@@ -22,9 +27,18 @@
 import { existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 
+function isSet(value) {
+	return typeof value === "string" && value.length > 0;
+}
+
+function isCi() {
+	const value = process.env.CI;
+	return isSet(value) && value.trim().toLowerCase() !== "false";
+}
+
 function skipReason() {
-	if (process.env.PI_LENS_SKIP_HOOKS === "1") return "PI_LENS_SKIP_HOOKS=1";
-	if (process.env.CI === "true") return "CI=true";
+	if (isSet(process.env.PI_LENS_SKIP_HOOKS)) return "PI_LENS_SKIP_HOOKS is set";
+	if (isCi()) return "CI is set";
 	if (!existsSync(".git")) return "no .git (not a clone)";
 	if (!existsSync("node_modules/husky/bin.js")) return "husky not installed (production install)";
 	return null;

--- a/tests/scripts/pre-push-targeted-tests.test.ts
+++ b/tests/scripts/pre-push-targeted-tests.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for scripts/pre-push-targeted-tests.mjs's selection logic (#1804
+ * review round 1, findings F1/F6/F7).
+ *
+ * The pre-push hook's whole safety claim ("never the full suite") rests on
+ * this selection staying narrow. A prior basename-substring version of the
+ * content-grep pass matched any import ending in `/<basename>` regardless of
+ * directory — `index.ts` alone selected 176 test files, and a real 43-file
+ * commit selected 282 (~10 minutes). These tests pin the fix: full-path
+ * import resolution (not a basename/substring guess) plus a hard cap that
+ * degrades to build-only instead of ever approaching "the whole suite" by
+ * accident.
+ *
+ * `selectTargetedTests` resolves paths relative to `process.cwd()` (mirrors
+ * a real repo checkout: `clients/x.ts` <-> `tests/clients/x.test.ts`), so
+ * each test builds an isolated fixture tree under a temp dir and chdirs into
+ * it for the duration of the test, restoring the real cwd in `afterEach` —
+ * never touches the real `tests/`/`clients/` trees.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { collectTestFiles, MAX_SELECTED_TESTS, selectTargetedTests } from "../../scripts/pre-push-targeted-tests.mjs";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+let fixtureDir: string | undefined;
+const originalCwd = process.cwd();
+
+function write(relPath: string, content: string) {
+  const full = path.join(fixtureDir as string, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, "utf8");
+}
+
+function enterFixture() {
+  fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-pre-push-test-"));
+  process.chdir(fixtureDir);
+}
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (fixtureDir) {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fixtureDir = undefined;
+  }
+});
+
+describe("selectTargetedTests — path-mirror pass", () => {
+  it("selects the exact mirrored test path for a changed source file", () => {
+    enterFixture();
+    write("clients/foo/bar.ts", "export const x = 1;\n");
+    write("tests/clients/foo/bar.test.ts", "import { x } from '../../../clients/foo/bar.js';\n");
+
+    const allTests = collectTestFiles("tests");
+    const result = selectTargetedTests(["clients/foo/bar.ts"], allTests);
+
+    expect(result.selected).toEqual(["tests/clients/foo/bar.test.ts"]);
+    expect(result.unmatched).toEqual([]);
+    expect(result.capped).toBe(false);
+  });
+
+  it("always includes a changed test file itself", () => {
+    enterFixture();
+    write("tests/clients/foo/bar.test.ts", "it('x', () => {});\n");
+
+    const allTests = collectTestFiles("tests");
+    const result = selectTargetedTests(["tests/clients/foo/bar.test.ts"], allTests);
+
+    expect(result.selected).toEqual(["tests/clients/foo/bar.test.ts"]);
+  });
+});
+
+describe("selectTargetedTests — import-resolution pass (full path, not basename)", () => {
+  it("selects a sibling test file that imports the changed module by its real path", () => {
+    enterFixture();
+    write("clients/foo/bar.ts", "export const x = 1;\n");
+    // No mirrored tests/clients/foo/bar.test.ts — only a differently-named
+    // sibling that imports it, the shared-seam-wiring-test shape.
+    write("tests/wiring-suite.test.ts", "import { x } from '../clients/foo/bar.js';\n");
+
+    const allTests = collectTestFiles("tests");
+    const result = selectTargetedTests(["clients/foo/bar.ts"], allTests);
+
+    expect(result.selected).toEqual(["tests/wiring-suite.test.ts"]);
+  });
+
+  it("does NOT select a test file that merely shares the changed file's basename in a different directory (the #1804 review regression)", () => {
+    enterFixture();
+    // Two files named `bar.ts` in different directories — the exact shape
+    // that broke the old basename-substring matcher: `/${base}` matched
+    // both `clients/foo/bar` and `clients/other/bar` imports alike.
+    write("clients/foo/bar.ts", "export const x = 1;\n");
+    write("clients/other/bar.ts", "export const y = 2;\n");
+    write("tests/clients/foo/bar.test.ts", "import { x } from '../../../clients/foo/bar.js';\n");
+
+    const allTests = collectTestFiles("tests");
+    // Changing clients/other/bar.ts must NOT pull in
+    // tests/clients/foo/bar.test.ts — that test never imports
+    // clients/other/bar at all, it only shares the basename "bar".
+    const result = selectTargetedTests(["clients/other/bar.ts"], allTests);
+
+    expect(result.selected).toEqual([]);
+    expect(result.unmatched).toEqual(["clients/other/bar.ts"]);
+  });
+
+  it("resolves .js import specifiers against a .ts changed file (compiled-output convention)", () => {
+    enterFixture();
+    write("clients/foo/bar.ts", "export const x = 1;\n");
+    write("tests/clients/foo/other-name.test.ts", "import { x } from '../../../clients/foo/bar.js';\n");
+
+    const allTests = collectTestFiles("tests");
+    const result = selectTargetedTests(["clients/foo/bar.ts"], allTests);
+
+    expect(result.selected).toEqual(["tests/clients/foo/other-name.test.ts"]);
+  });
+});
+
+describe("selectTargetedTests — the >25-file cap (F1)", () => {
+  it("degrades to build-only (empty selection, capped=true) once matches exceed MAX_SELECTED_TESTS", () => {
+    enterFixture();
+    write("clients/shared.ts", "export const shared = 1;\n");
+
+    const testCount = MAX_SELECTED_TESTS + 1;
+    for (let i = 0; i < testCount; i++) {
+      write(`tests/generated-${i}.test.ts`, `import { shared } from '../clients/shared.js';\n`);
+    }
+
+    const allTests = collectTestFiles("tests");
+    expect(allTests.length).toBe(testCount);
+
+    const result = selectTargetedTests(["clients/shared.ts"], allTests);
+
+    // Mutation-proof: if the cap check were removed or off-by-one'd the
+    // wrong way, `selected` would contain all `testCount` entries and
+    // `capped` would read false — this assertion goes red on either.
+    expect(result.capped).toBe(true);
+    expect(result.selected).toEqual([]);
+    expect(result.totalBeforeCap).toBe(testCount);
+  });
+
+  it("does not cap when the match count is exactly at the limit", () => {
+    enterFixture();
+    write("clients/shared.ts", "export const shared = 1;\n");
+
+    for (let i = 0; i < MAX_SELECTED_TESTS; i++) {
+      write(`tests/generated-${i}.test.ts`, `import { shared } from '../clients/shared.js';\n`);
+    }
+
+    const allTests = collectTestFiles("tests");
+    const result = selectTargetedTests(["clients/shared.ts"], allTests);
+
+    expect(result.capped).toBe(false);
+    expect(result.selected.length).toBe(MAX_SELECTED_TESTS);
+  });
+});
+
+describe("selectTargetedTests — no-match fallback (F7)", () => {
+  it("reports a changed file with no covering test as unmatched, selects nothing for it", () => {
+    enterFixture();
+    write("clients/orphan.ts", "export const o = 1;\n");
+    write("tests/clients/unrelated.test.ts", "it('x', () => {});\n");
+
+    const allTests = collectTestFiles("tests");
+    const result = selectTargetedTests(["clients/orphan.ts"], allTests);
+
+    expect(result.selected).toEqual([]);
+    expect(result.unmatched).toEqual(["clients/orphan.ts"]);
+    expect(result.capped).toBe(false);
+  });
+});
+
+describe(".husky hooks — PI_LENS_SKIP_HOOKS accepts any non-empty value (F8)", () => {
+  it.each(["1", "true"])("pre-commit exits 0 and skips without running checks when PI_LENS_SKIP_HOOKS=%s", (value) => {
+    const result = spawnSync("sh", [".husky/pre-commit"], {
+      cwd: repoRoot,
+      env: { ...process.env, PI_LENS_SKIP_HOOKS: value },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("[pre-commit] skipped");
+  });
+
+  it.each(["1", "true"])("pre-push exits 0 and skips without running the targeted-test script when PI_LENS_SKIP_HOOKS=%s", (value) => {
+    const result = spawnSync("sh", [".husky/pre-push"], {
+      cwd: repoRoot,
+      env: { ...process.env, PI_LENS_SKIP_HOOKS: value },
+      encoding: "utf8",
+      input: "",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("[pre-push] skipped");
+  });
+
+});


### PR DESCRIPTION
## What

Adds Husky-managed local git hooks (v9), wired via `prepare`:

- **pre-commit** — `npm run changelog:check` (reuses the existing sub-second
  fragment validator, already proven in CI's release-bump lane) then
  `npm run lint` (tsc, the same command CI's `lint-and-typecheck` job runs).
- **pre-push** — `npm run build`, then targeted `vitest` for the changed
  `.ts` files (`scripts/pre-push-targeted-tests.mjs`), never the full suite.

Both hooks exit early when `PI_LENS_SKIP_HOOKS=1` is set. Agents and CI should set
it; humans leave hooks on.

## Why

Several fix rounds this release cycle shipped heads with lint failures
(unused variable, changelog-format violations) that CI caught one lap later.
A local hook that runs in seconds catches the same failure before the push,
saving a full CI round trip.

## Design notes

- **No self-lint biome.** The issue's suggested shape mentioned "biome check
  on staged files," but this repo has no `biome.json` and doesn't use biome
  to lint itself — `biome-client.ts` runs biome against *user* codebases pi-lens
  analyzes, a different surface entirely. Adding an unconfigured linter to
  pre-commit would produce noise from day one. `npm run lint` (tsc) is the
  repo's actual self-lint mechanism and the one CI already runs.
- **Whole-project lint, not staged-files-only.** tsc type-checks the whole
  project graph; a partial staged-file check isn't meaningful for it. At
  ~3.5s the full `npm run lint` is cheap enough to run every commit and
  reuses the exact CI command — no parallel staged-file lint config to drift
  from it.
- **`prepare` had to stay split.** The existing `prepare` script
  (`build:dist` + grammar download) is load-bearing for consumers who
  install pi-lens as a dependency (`npm install --omit=dev`, no `.git`, no
  devDependencies — see `ci.yml`'s `prod-install-build` job) and must fail
  loudly on error. Hook wiring is dev-only and best-effort, so it's a
  separate script (`scripts/setup-git-hooks.mjs`) appended last, which
  always exits 0 — it never shares a failure path with the build step, so a
  broken hook install can't get masked by (or mask) a real build failure.
- **Targeted-test selection** (`scripts/pre-push-targeted-tests.mjs`) does a
  two-pass match against `tests/**/*.test.ts`: a path-mirror pass (changed
  `clients/foo/bar.ts` → `tests/.../bar.test.ts`) plus a content-grep pass
  that catches shared-seam siblings the path mirror misses (a changed
  module's basename appearing in another test file's own imports). Verified
  against `clients/agent-nudge.ts`: correctly selected both
  `tests/clients/agent-nudge.test.ts` (mirror) and
  `tests/clients/write-autofix-nudge-suppression.test.ts` (content-grep
  sibling). Falls back to build-only when nothing matches — never silently
  skips the build too.
- **`with-test-lock.mjs` reused**, not reimplemented, for the actual vitest
  invocation (respects the existing machine-wide suite lock and its
  cross-platform spawn handling).

## Measured cost

Real `git commit` on this branch, hook included: **~5.5s**
(`changelog:check` ~0.75s + `npm run lint` ~3.5s + npm/git process
overhead). Slightly over the issue's "under a few seconds" framing but the
two checks it runs are the exact ones that caused the CI round-trips this
issue cites — I judged the coverage worth the extra ~1.5-2s over a bare
changelog-only check. `PI_LENS_SKIP_HOOKS=1` is the intended escape hatch
for anyone (or any automation) where that cost matters more than the local
catch.

## Worktree verification

Git worktrees of the same clone **share** `core.hooksPath` (it's repo-level
config, not worktree-level) — but `.husky/_` (the machinery husky installs
at that path) is generated fresh per working directory and is git-ignored,
so each worktree needs its own `npm install`/`prepare` before hooks actually
fire there. Verified directly:

1. Created a second worktree off this branch — `.husky/pre-commit` is
   checked out (tracked file) but `.husky/_` doesn't exist yet.
2. Committed a deliberately invalid changelog fragment there: **succeeded**
   (hooks silently no-op — nothing installed at `core.hooksPath` in that
   worktree yet). Reverted.
3. Ran `npm install` in that worktree (real install, not a junction —
   proves the full `prepare` chain: build:dist → grammar download → hook
   wiring).
4. Same invalid fragment: **failed** pre-commit with the expected
   `changelog:check` error.
5. Same invalid fragment with `PI_LENS_SKIP_HOOKS=1`: **succeeded**.

## Red-proof (this branch's own worktree)

- Bad changelog fragment (`this is not valid front matter`, no YAML front
  matter) → `git commit` failed: `Invalid changelog entry ...: expected YAML
  front matter` / `husky - pre-commit script failed (code 1)`.
- Same commit with `PI_LENS_SKIP_HOOKS=1` → succeeded.
- Real commit with a valid changelog entry → `changelog:check` + `lint` both
  ran and passed, commit succeeded.
- `pre-push` with only non-`.ts` changes staged → build-only pass, no test
  run (correct: nothing to target).
- `pre-push` with a `.ts` change → build, then 2 targeted test files
  selected and run (39 tests passed), matching the design notes above.

## Verification run

- `npm run build`, `npm run lint`: clean.
- `tests/packaging.test.ts` (asserts `prepare` still contains `build:dist`
  and `download-grammars`): 10 passed, 4 skipped (unrelated pre-existing
  skips).
- `tests/scripts/{with-test-lock,rollup-changelog,changelog-entries,changelog}.test.ts`:
  44 passed — nothing in the reused seams broke.
- Full suite: not run locally (machine-wide lock, CI is authoritative per
  AGENTS.md).

## Blast radius

- `package.json`'s `prepare` script changed shape but keeps both existing
  steps (`build:dist`, grammar download) verbatim, just appends a third,
  fail-safe step. `tests/packaging.test.ts` already pins the first two by
  substring match and still passes.
- New `devDependency`: `husky@^9.1.7`. No production dependency change —
  `.husky/`, `scripts/setup-git-hooks.mjs`, and
  `scripts/pre-push-targeted-tests.mjs` are dev-only, not in `package.json`'s
  `files` allowlist, so they don't ship in the published tarball.
- New process spawns: `npm install`/`prepare` now also spawns
  `node_modules/husky/bin.js` (skipped for CI/production installs — see
  Design notes). Every local `git commit`/`git push` now spawns the
  hook chain described above, unless `PI_LENS_SKIP_HOOKS=1`.
- No runtime/extension code touched — LSP, dispatch, and client surfaces are
  unaffected.

## Observability

Every hook run prints what it did (`[pre-commit] skipped (...)`, `[pre-push]
building...`, `[pre-push] running N targeted test file(s)...`) directly to
the commit/push output — this is local, synchronous, terminal-visible
tooling, not a background process, so there's no separate log file to name.
`scripts/setup-git-hooks.mjs` logs its skip reason or a warning (never a
silent failure) on every `npm install`.

Closes #1804.


## Review round 1 (9 findings, fixed on this branch)

- **F1 (high, selection blow-up)** — the content-grep pass matched imports
  by basename suffix; `index.ts` alone matched 176 test files, and a real
  43-file commit selected 282 (~10 minutes). Fixed two ways: selection now
  resolves every test file's relative import specifiers to absolute,
  extension-stripped paths and compares real paths, not substrings; a hard
  25-file cap degrades to build-only regardless, so "never the full suite"
  holds by construction. Test:
  `tests/scripts/pre-push-targeted-tests.test.ts` includes a same-basename-
  different-directory case that must NOT match, and an over-the-cap case.
  Both verified red against the pre-fix logic (see PR discussion).
- **F2 (high, unbounded hang)** — pre-push now sets
  `PI_LENS_TEST_LOCK_TIMEOUT_MS=120000`; a lock timeout is detected from
  `with-test-lock.mjs`'s own stderr and lets the push proceed (exit 0) with
  a warning instead of blocking it. Verified end-to-end with a fabricated
  live lock holder and a 2s timeout: push proceeded in ~6.6s with the
  expected warning.
- **F3 (high, wire PI_LENS_SKIP_HOOKS via `.claude/settings.json`)** — NOT
  done. Every edit path to `.claude/settings.json` (Edit tool, Bash
  heredoc/append) was blocked outright by this session's own permission
  system, independent of PR content. Per this agent's standing contract, no
  instruction — including a reviewer's — can authorize a change to
  permission/settings configuration, so the block stands rather than being
  routed around. `PI_LENS_SKIP_HOOKS` still works exactly as documented; it
  just isn't auto-set for Claude Code sessions in this repo. Left to the
  maintainer to wire manually if wanted — CONTRIBUTING.md and the changelog
  fragment were corrected to not claim this exists.
- **F4/F5 (medium, doc accuracy)** — CONTRIBUTING.md previously claimed
  hooks are "scoped to your clone (each worktree wires its own)".
  Corrected: `core.hooksPath` is repo-level git config shared by every
  worktree; only `.husky/_` (gitignored, per-worktree) is not. A worktree
  where `npm install` hasn't run yet silently runs no hooks — documented as
  accepted behavior (agent worktrees are covered by `PI_LENS_SKIP_HOOKS`
  regardless; CI is authoritative either way).
- **F6 (medium, zero tests on the selection logic)** — added
  `tests/scripts/pre-push-targeted-tests.test.ts`: path-mirror pass,
  full-path import-resolution pass (plus the false-basename-match negative
  case), the >25-file cap (both over and exactly at the limit), the
  no-match fallback, and `PI_LENS_SKIP_HOOKS` accepting `"1"` and `"true"`
  via a real `sh .husky/pre-commit`/`pre-push` spawn. 12 tests, all
  mutation-verified: disabling the cap check and reverting to
  basename-substring matching both turned the relevant test red before the
  fix and green after (verified locally, not committed — see PR
  discussion for the exact mutation and output).
- **F7 (low, no-match reporting)** — pre-push now prints one
  `[pre-push] no tests matched <file>` line per changed file with zero
  covering tests.
- **F8 (low, skip-value strictness)** — both hooks and
  `scripts/setup-git-hooks.mjs` now treat any non-empty
  `PI_LENS_SKIP_HOOKS` value as skip, not only `"1"`.
- **F9 (low, CI env-var strictness)** — `scripts/setup-git-hooks.mjs` now
  treats any non-empty `CI` value other than `"false"` as CI, not only
  `"true"`.

Rebased onto `origin/master` (`73716d8c`, #1914 merged) before this round;
no conflicts. New head: `3e1248d4`.


