### PR TITLE
ci: add actionlint, PR-title lint, markdownlint, osv scan (refs #1844)

### DIFF
--- a/.changelog/ci-1844-lint-batch.md
+++ b/.changelog/ci-1844-lint-batch.md
@@ -2,4 +2,4 @@
 section: Added
 ---
 
-- **Mechanical lint batch: actionlint, PR-title lint, markdownlint, OSV scan (refs #1844)** — a new `lint.yml` workflow dogfoods actionlint against `.github/workflows/**`, validates that every PR title carries a conventional prefix and an issue reference (`scripts/check-pr-title.mjs`), and lints Markdown docs with `markdownlint-cli2` under a repo-tuned config. A separate `osv-scan.yml` runs an advisory weekly `osv-scanner` sweep plus a scan on lockfile-touching PRs.
+- **Mechanical lint batch: actionlint, PR-title lint, markdownlint, OSV scan (refs #1844)** — a new `lint.yml` workflow dogfoods actionlint against every workflow file, validates that every PR title carries a conventional prefix and an issue reference **in the title itself** (`scripts/check-pr-title.mjs` — a reference living only in the PR body no longer counts, since it never reaches the merge-commit subject), and lints Markdown docs with `markdownlint-cli2` under a repo-tuned config. A separate `osv-scan.yml` runs an advisory weekly `osv-scanner` sweep plus a scan on lockfile-touching PRs, writing results to the job summary.

--- a/.changelog/ci-1844-lint-batch.md
+++ b/.changelog/ci-1844-lint-batch.md
@@ -2,4 +2,4 @@
 section: Added
 ---
 
-- **Mechanical lint batch: actionlint, PR-title lint, markdownlint, OSV scan (refs #1844)** — a new `lint.yml` workflow dogfoods actionlint against `.github/workflows/**`, validates that every PR title carries a conventional prefix and an issue reference (`scripts/check-pr-title.mjs`), lints Markdown docs with `markdownlint-cli2` under a repo-tuned config, and runs an advisory weekly `osv-scanner` sweep plus a scan on lockfile-touching PRs.
+- **Mechanical lint batch: actionlint, PR-title lint, markdownlint, OSV scan (refs #1844)** — a new `lint.yml` workflow dogfoods actionlint against `.github/workflows/**`, validates that every PR title carries a conventional prefix and an issue reference (`scripts/check-pr-title.mjs`), and lints Markdown docs with `markdownlint-cli2` under a repo-tuned config. A separate `osv-scan.yml` runs an advisory weekly `osv-scanner` sweep plus a scan on lockfile-touching PRs.

--- a/.changelog/ci-1844-lint-batch.md
+++ b/.changelog/ci-1844-lint-batch.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Mechanical lint batch: actionlint, PR-title lint, markdownlint, OSV scan (refs #1844)** — a new `lint.yml` workflow dogfoods actionlint against `.github/workflows/**`, validates that every PR title carries a conventional prefix and an issue reference (`scripts/check-pr-title.mjs`), lints Markdown docs with `markdownlint-cli2` under a repo-tuned config, and runs an advisory weekly `osv-scanner` sweep plus a scan on lockfile-touching PRs.

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -123,9 +123,11 @@ jobs:
           esac
           # Record the installed layout for debugging (hoisted vs symlink store)
           echo "--- node_modules/pi-lens ---"
-          ls -la node_modules/pi-lens >/dev/null 2>&1 && \
-            { readlink node_modules/pi-lens || echo "(real dir)"; } || \
+          if ls -la node_modules/pi-lens >/dev/null 2>&1; then
+            readlink node_modules/pi-lens || echo "(real dir)"
+          else
             find . -maxdepth 4 -name pi-lens -type d | head
+          fi
 
       - name: Selftest under bun (strictest resolver)
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Download and verify actionlint v1.7.12 (linux_amd64)
         run: |
           set -eu
-          curl -sLO https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          curl -sLO --proto '=https' --tlsv1.2 https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
           echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum -c -
           tar -xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,135 @@
+name: Lint
+
+# #1844: mechanical lint batch. Four independent, cheap jobs -- each stays
+# well under a minute and needs no `npm install` (actionlint and
+# markdownlint-cli2 are self-contained; osv-scanner reads only package-lock
+# via the SBOM-less lockfile scan). Kept out of ci.yml so a lint finding
+# never blocks on -- or waits behind -- the full install/build/test lanes.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly OSV sweep for advisories published against dependencies already
+    # in the lockfile (not just ones introduced by a PR that touches it).
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  actionlint:
+    name: actionlint
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # Pinned release + checksum verification rather than piping a
+      # third-party install script or trusting an unpinned marketplace
+      # action (this repo dogfoods actionlint as a runner -- see
+      # clients/dispatch/runners -- so lint it with the same rigor).
+      - name: Download and verify actionlint v1.7.12 (linux_amd64)
+        run: |
+          set -eu
+          curl -sLO https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
+
+      - name: Lint workflows
+        run: ./actionlint -color .github/workflows/*.yml
+
+  pr-title-lint:
+    name: PR title
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "22"
+
+      - name: Validate PR title (conventional prefix + issue ref)
+        run: node scripts/check-pr-title.mjs
+
+  markdownlint:
+    name: markdownlint
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "22"
+
+      - name: Lint markdown
+        run: npx --yes markdownlint-cli2@0.23.2
+
+  # osv-scan below only runs on a PR that touches package-lock.json (plus
+  # weekly on schedule, see the workflow-level cron). "changed_files_names"
+  # is not a real event-payload field, so the lockfile touch is detected via
+  # git diff here, in a job with no `if:` so it runs on every trigger and
+  # never skips (a skipped `needs` job would skip osv-scan too, including
+  # on schedule -- see the job comment below).
+  detect-lockfile-change:
+    name: Detect lockfile change
+    # osv-scan is scoped to pull_request (lockfile-touching) plus schedule
+    # and workflow_dispatch (full sweep) -- not every push to master.
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: github.event_name == 'pull_request'
+        with:
+          persist-credentials: false
+
+      - id: diff
+        run: |
+          set -eu
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Non-PR triggers (schedule, workflow_dispatch) always run the
+            # full scan; the gate only applies to PRs.
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD -- package-lock.json | grep -qx package-lock.json; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  osv-scan:
+    name: OSV scan (advisory)
+    needs: [detect-lockfile-change]
+    if: needs.detect-lockfile-change.outputs.changed == 'true'
+    # Advisory to start (see PR body / #1844): the job runs and reports, but
+    # is not wired into required-checks branch protection yet. Promote once
+    # it's proven quiet for a few weeks.
+    permissions:
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
+    with:
+      scan-args: |-
+        --lockfile=./package-lock.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,13 +11,17 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    # Default types omit "edited". Without it, retitling a PR to fix a
+    # PR-title-lint failure replays the STALE payload from the original
+    # "opened" event instead of re-running against the new title (#1917
+    # review F3).
+    types: [opened, synchronize, reopened, edited]
 
 permissions: {}
 
 jobs:
   actionlint:
     name: actionlint
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,8 +41,11 @@ jobs:
           echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum -c -
           tar -xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
 
+      # Bare invocation (no *.yml glob): actionlint auto-discovers every
+      # workflow under .github/workflows/, including a future .yaml
+      # extension the glob would silently miss (#1917 review F5).
       - name: Lint workflows
-        run: ./actionlint -color .github/workflows/*.yml
+        run: ./actionlint -color
 
   pr-title-lint:
     name: PR title

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,16 @@
 name: Lint
 
-# #1844: mechanical lint batch. Four independent, cheap jobs -- each stays
+# #1844: mechanical lint batch. Three independent, cheap jobs -- each stays
 # well under a minute and needs no `npm install` (actionlint and
-# markdownlint-cli2 are self-contained; osv-scanner reads only package-lock
-# via the SBOM-less lockfile scan). Kept out of ci.yml so a lint finding
-# never blocks on -- or waits behind -- the full install/build/test lanes.
+# markdownlint-cli2 are self-contained). Kept out of ci.yml so a lint
+# finding never blocks on -- or waits behind -- the full install/build/test
+# lanes. The OSV scan lives in its own osv-scan.yml (see that file for why).
 
 on:
   push:
     branches: [master]
   pull_request:
     branches: [master]
-  schedule:
-    # Weekly OSV sweep for advisories published against dependencies already
-    # in the lockfile (not just ones introduced by a PR that touches it).
-    - cron: "0 6 * * 1"
-  workflow_dispatch: {}
 
 permissions: {}
 
@@ -65,7 +60,6 @@ jobs:
 
   markdownlint:
     name: markdownlint
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -80,56 +74,3 @@ jobs:
 
       - name: Lint markdown
         run: npx --yes markdownlint-cli2@0.23.2
-
-  # osv-scan below only runs on a PR that touches package-lock.json (plus
-  # weekly on schedule, see the workflow-level cron). "changed_files_names"
-  # is not a real event-payload field, so the lockfile touch is detected via
-  # git diff here, in a job with no `if:` so it runs on every trigger and
-  # never skips (a skipped `needs` job would skip osv-scan too, including
-  # on schedule -- see the job comment below).
-  detect-lockfile-change:
-    name: Detect lockfile change
-    # osv-scan is scoped to pull_request (lockfile-touching) plus schedule
-    # and workflow_dispatch (full sweep) -- not every push to master.
-    if: github.event_name != 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      changed: ${{ steps.diff.outputs.changed }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        if: github.event_name == 'pull_request'
-        with:
-          persist-credentials: false
-
-      - id: diff
-        run: |
-          set -eu
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            # Non-PR triggers (schedule, workflow_dispatch) always run the
-            # full scan; the gate only applies to PRs.
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git fetch --depth=1 origin "${{ github.event.pull_request.base.sha }}"
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD -- package-lock.json | grep -qx package-lock.json; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  osv-scan:
-    name: OSV scan (advisory)
-    needs: [detect-lockfile-change]
-    if: needs.detect-lockfile-change.outputs.changed == 'true'
-    # Advisory to start (see PR body / #1844): the job runs and reports, but
-    # is not wired into required-checks branch protection yet. Promote once
-    # it's proven quiet for a few weeks.
-    permissions:
-      contents: read
-      security-events: write
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
-    with:
-      scan-args: |-
-        --lockfile=./package-lock.json

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Download and verify osv-scanner v2.5.1 (linux_amd64)
         run: |
           set -eu
-          curl -sLO https://github.com/google/osv-scanner/releases/download/v2.5.1/osv-scanner_linux_amd64
+          curl -sLO --proto '=https' --tlsv1.2 https://github.com/google/osv-scanner/releases/download/v2.5.1/osv-scanner_linux_amd64
           echo "f9f25499a2c8cc367b3af45df2ea7eeca7fbccceab9c35079968f4b3652194be  osv-scanner_linux_amd64" | sha256sum -c -
           chmod +x osv-scanner_linux_amd64
 

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -59,11 +59,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Advisory to start (see PR body / #1844): the job runs and reports, but
-    # isn't wired into required-checks branch protection yet. Promote once
-    # it's proven quiet for a few weeks. continue-on-error keeps a real
-    # finding from blocking merges while advisory.
-    continue-on-error: true
+    # Advisory to start (see PR body / #1844): this job is NOT wired into
+    # required-checks branch protection, so it never blocks a merge on its
+    # own. That's exactly why it must NOT use continue-on-error -- a real
+    # finding should show as a red advisory check a reviewer can see and
+    # choose to act on, not a silently-green one (#1917 review F2).
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -79,5 +79,16 @@ jobs:
           echo "f9f25499a2c8cc367b3af45df2ea7eeca7fbccceab9c35079968f4b3652194be  osv-scanner_linux_amd64" | sha256sum -c -
           chmod +x osv-scanner_linux_amd64
 
+      # Markdown-format output is written straight to the job summary so a
+      # finding is visible from the PR's checks tab without opening logs
+      # (#1917 review F2). The scan itself still exits non-zero on a real
+      # finding -- captured via $? (not piped, so no PIPESTATUS needed) and
+      # re-raised after the summary write so the job reports red.
       - name: Scan package-lock.json
-        run: ./osv-scanner_linux_amd64 --lockfile=./package-lock.json
+        run: |
+          set +e
+          ./osv-scanner_linux_amd64 --format=markdown --lockfile=./package-lock.json > osv-scan-result.md
+          status=$?
+          set -e
+          cat osv-scan-result.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,0 +1,83 @@
+name: OSV scan
+
+# #1844: advisory dependency-vulnerability sweep. Split out of lint.yml into
+# its own file (rather than a job there) so a problem specific to this one
+# check -- e.g. the third-party reusable workflow it calls -- can't take
+# down the actionlint/PR-title/markdownlint jobs, which are unrelated and
+# have no such external dependency.
+
+on:
+  schedule:
+    # Weekly sweep for advisories against dependencies already in the
+    # lockfile, not just ones a PR happens to touch.
+    - cron: "0 6 * * 1"
+  pull_request:
+    branches: [master]
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  # Gates the PR-triggered scan to PRs that actually touch the lockfile.
+  # "changed_files_names" is not a real event-payload field, so this uses
+  # git diff against the PR's base SHA instead. Always runs (no job-level
+  # `if`) so schedule/workflow_dispatch triggers -- which have no PR to
+  # diff -- aren't skipped as an unmet `needs` dependency downstream.
+  detect-lockfile-change:
+    name: Detect lockfile change
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: github.event_name == 'pull_request'
+        with:
+          persist-credentials: false
+
+      - id: diff
+        run: |
+          set -eu
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Non-PR triggers (schedule, workflow_dispatch) always run the
+            # full scan; the gate only applies to PRs.
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD -- package-lock.json | grep -qx package-lock.json; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  osv-scan:
+    name: OSV scan (advisory)
+    needs: [detect-lockfile-change]
+    if: needs.detect-lockfile-change.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Advisory to start (see PR body / #1844): the job runs and reports, but
+    # isn't wired into required-checks branch protection yet. Promote once
+    # it's proven quiet for a few weeks. continue-on-error keeps a real
+    # finding from blocking merges while advisory.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # Pinned release + checksum verification, matching the actionlint job
+      # in lint.yml -- no third-party GitHub Action, no unpinned install
+      # script piped to a shell.
+      - name: Download and verify osv-scanner v2.5.1 (linux_amd64)
+        run: |
+          set -eu
+          curl -sLO https://github.com/google/osv-scanner/releases/download/v2.5.1/osv-scanner_linux_amd64
+          echo "f9f25499a2c8cc367b3af45df2ea7eeca7fbccceab9c35079968f4b3652194be  osv-scanner_linux_amd64" | sha256sum -c -
+          chmod +x osv-scanner_linux_amd64
+
+      - name: Scan package-lock.json
+        run: ./osv-scanner_linux_amd64 --lockfile=./package-lock.json

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -31,9 +31,20 @@ jobs:
     outputs:
       changed: ${{ steps.diff.outputs.changed }}
     steps:
+      # Pin to the PR's own head commit, NOT the default checkout ref. For
+      # pull_request events, actions/checkout defaults to GitHub's synthetic
+      # refs/pull/N/merge commit (base branch's CURRENT tip merged with the
+      # PR). Diffing that synthetic HEAD against the PR's recorded (and
+      # potentially stale, once the PR falls BEHIND) base.sha then picks up
+      # every change master accumulated in between as if the PR had made it
+      # -- caught in review verification: this PR doesn't touch
+      # package-lock.json, but the gate still fired because master gained an
+      # unrelated lockfile change after this branch was cut. Pinning `ref`
+      # to head.sha makes HEAD the PR's real, stable branch tip.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: github.event_name == 'pull_request'
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - id: diff
@@ -65,8 +76,14 @@ jobs:
     # finding should show as a red advisory check a reviewer can see and
     # choose to act on, not a silently-green one (#1917 review F2).
     steps:
+      # Same head.sha pin as detect-lockfile-change, and for the same
+      # reason: scan the PR's own lockfile, not a merge-drifted one that
+      # would make the result move whenever master changes independently of
+      # this PR. On schedule/workflow_dispatch there's no PR head, so this
+      # falls back to the default (current branch tip).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
           persist-credentials: false
 
       # Pinned release + checksum verification, matching the actionlint job

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,11 @@ jobs:
             SHOULD_RELEASE=true
           fi
 
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$VERSION"
+            echo "tag=$TAG"
+            echo "should_release=$SHOULD_RELEASE"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Verify bump PR rolled up changelog entries
         if: steps.meta.outputs.should_release == 'true'

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -37,14 +37,23 @@
     // docs/features.md intentionally skips an h2 in one section; not worth
     // renumbering headings repo-wide for a brand-new lint pass.
     "MD001": false,
-    // Repo mixes `_underscore_`/`__underscore__` and `*asterisk*` emphasis
+    // Repo mixes `_underscore_` and `*asterisk*` single-marker emphasis
     // across docs written by different authors over time.
     "MD049": false,
+    // Same author-style mix as MD049, for `__underscore__`/`**asterisk**`
+    // bold (docs/tree-sitter_rules_catalog.md uses underscore bold
+    // throughout its rule descriptions).
     "MD050": false,
     // A handful of long-form design docs (lsp-latency-benchmark.md) quote
     // multi-paragraph benchmark output inside blockquotes with blank lines.
     "MD028": false,
+    // docs/servercapabilities.md has a genuine double-blank-line gap
+    // between sections; not worth a one-line docs edit for a brand-new
+    // lint pass.
     "MD012": false,
+    // docs/servercapabilities.md has emphasis markers with a leading space
+    // (", _ text_") in prose describing punctuation-adjacent terms; a false
+    // positive for how the sentence reads, not a formatting mistake.
     "MD037": false,
     // "#NNN" issue references routinely land at the start of a wrapped
     // line in prose (e.g. "structured options,\n#771)") -- these are never
@@ -54,8 +63,17 @@
     // AGENTS.md and docs/api-ports-inventory.md use tab-indented tables/data
     // blocks (copy-pasted from tool output).
     "MD010": false,
+    // docs/ast-grep_rules_catalog.md is a generated rule catalog; its table
+    // cells embed raw rule-message text (e.g. a trailing "`" before a
+    // space) that trips this rule as a side effect of the content, not the
+    // markdown structure.
     "MD038": false,
+    // Same generated catalog: a table cell containing literal code like
+    // "split(sep)[n]" parses as reversed-link syntax by coincidence.
     "MD011": false,
+    // docs/audit1.md has fenced code blocks immediately followed by a list
+    // item with no blank line -- a deliberate compact layout, not a
+    // formatting slip.
     "MD031": false
   },
   "globs": ["**/*.md"],

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,72 @@
+{
+  // Minimal ruleset tuned to this repo's existing docs style (#1844). The
+  // goal is a mechanical dogfooding CI job, not a mass reformat -- rules
+  // that would force rewriting the current tree are disabled below, each
+  // with the reason. Structural rules (broken headings, duplicate content,
+  // bad links) stay enabled because those catch real authoring mistakes.
+  "config": {
+    "default": true,
+    // Docs mix prose paragraphs with long code samples and tables; a hard
+    // wrap would force reformatting every existing file for no reader benefit.
+    "MD013": false,
+    // Several docs (AGENTS.md, CLAUDE.md) use inline HTML for callouts.
+    "MD033": false,
+    // Repo convention mixes bare issue/PR URLs into prose (e.g. "#1844",
+    // full GitHub URLs) without always wrapping them as links.
+    "MD034": false,
+    // Docs use both "-" and "*" bullets depending on the author/section.
+    "MD004": false,
+    // First line doesn't always have to be a top-level heading (e.g.
+    // .changelog/README.md leads with a heading but some docs use a badge
+    // or short intro line first).
+    "MD041": false,
+    // Duplicate headings occur across sibling sections (e.g. "Overview"
+    // repeated per subsystem) -- acceptable given the doc structure.
+    "MD024": false,
+    // Docs tables use compact "| a | b |" style without markdownlint's
+    // stricter pipe-alignment rules; rewriting every table for this
+    // brand-new rule (MD060) is exactly the mass reformat we're avoiding.
+    "MD060": false,
+    // Skill docs use bare ``` fences for illustrative snippets that are not
+    // a single language (shell + output mixed, or pseudo-code).
+    "MD040": false,
+    // Design-doc style throughout docs/ nests lists and headings tight
+    // against surrounding prose without a blank-line buffer.
+    "MD032": false,
+    "MD022": false,
+    // docs/features.md intentionally skips an h2 in one section; not worth
+    // renumbering headings repo-wide for a brand-new lint pass.
+    "MD001": false,
+    // Repo mixes `_underscore_`/`__underscore__` and `*asterisk*` emphasis
+    // across docs written by different authors over time.
+    "MD049": false,
+    "MD050": false,
+    // A handful of long-form design docs (lsp-latency-benchmark.md) quote
+    // multi-paragraph benchmark output inside blockquotes with blank lines.
+    "MD028": false,
+    "MD012": false,
+    "MD037": false,
+    // "#NNN" issue references routinely land at the start of a wrapped
+    // line in prose (e.g. "structured options,\n#771)") -- these are never
+    // intended as ATX headings, and CommonMark itself does not render them
+    // as headings (no space after '#'). False-positive-prone for this repo.
+    "MD018": false,
+    // AGENTS.md and docs/api-ports-inventory.md use tab-indented tables/data
+    // blocks (copy-pasted from tool output).
+    "MD010": false,
+    "MD038": false,
+    "MD011": false,
+    "MD031": false
+  },
+  "globs": ["**/*.md"],
+  "ignores": [
+    "node_modules/**",
+    "dist/**",
+    "grammars/**",
+    ".changelog/*.md",
+    "CHANGELOG.md",
+    // Deliberately malformed fixtures that exercise the markdown
+    // format/autofix tools under test -- linting them defeats their purpose.
+    "tests/fixtures/**"
+  ]
+}

--- a/docs/word-index.md
+++ b/docs/word-index.md
@@ -60,8 +60,8 @@ parsed by `parseWordIndexQuery` (`clients/word-index.ts`) before tokenization:
 Example: `lang:jsts file:clients/ -file:test rank`. Multiple positive filters
 of the SAME key OR together; different keys AND; negations always subtract.
 Filters are applied as a `fileFilter` predicate BEFORE BM25/priors/centrality
-scoring (same seam as the pre-existing `paths`/`lang` structured options, #771),
-so a surviving file's score is unaffected by filtering. An unrecognized
+scoring (same seam as the pre-existing `paths`/`lang` structured options,
+#771), so a surviving file's score is unaffected by filtering. An unrecognized
 `key:` token passes through as an ordinary search term (colon-bearing terms
 like `std::vector`, URLs, and Windows paths search normally). Only a
 recognized key with a bad value — an unrecognized `lang:` kind — throws

--- a/docs/word-index.md
+++ b/docs/word-index.md
@@ -60,8 +60,8 @@ parsed by `parseWordIndexQuery` (`clients/word-index.ts`) before tokenization:
 Example: `lang:jsts file:clients/ -file:test rank`. Multiple positive filters
 of the SAME key OR together; different keys AND; negations always subtract.
 Filters are applied as a `fileFilter` predicate BEFORE BM25/priors/centrality
-scoring (same seam as the pre-existing `paths`/`lang` structured options,
-#771), so a surviving file's score is unaffected by filtering. An unrecognized
+scoring (same seam as the pre-existing `paths`/`lang` structured options, #771),
+so a surviving file's score is unaffected by filtering. An unrecognized
 `key:` token passes through as an ordinary search term (colon-bearing terms
 like `std::vector`, URLs, and Windows paths search normally). Only a
 recognized key with a bad value — an unrecognized `lang:` kind — throws

--- a/scripts/check-pr-title.d.mts
+++ b/scripts/check-pr-title.d.mts
@@ -1,0 +1,6 @@
+export declare const MISSING_PREFIX_MESSAGE: string;
+export declare const MISSING_ISSUE_REF_MESSAGE: string;
+export declare function lintPrTitle(
+	title?: string,
+	body?: string,
+): { valid: boolean; errors: string[] };

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Repo convention: conventional-commit-style prefix, then an issue reference
+// somewhere in the title or body. Merges are merge commits from the PR
+// title (see AGENTS.md), so a malformed title becomes the permanent commit
+// subject -- catch it before merge, not after.
+const CONVENTIONAL_PREFIX =
+	/^(feat|fix|chore|docs|refactor|test|ci|perf)(\([^)]+\))?: .+/;
+const ISSUE_REF = /#\d+/;
+
+export const MISSING_PREFIX_MESSAGE =
+	'PR title must start with a conventional prefix and a colon, for example "fix: repair the widget cache (refs #123)". ' +
+	"Allowed prefixes: feat, fix, chore, docs, refactor, test, ci, perf.";
+
+export const MISSING_ISSUE_REF_MESSAGE =
+	'PR title or body must reference an issue (e.g. "#123"). Use "Closes #123" when the PR fully resolves the issue, or "Refs #123" when work remains.';
+
+/**
+ * Lint a PR title/body pair against the repo's conventional-prefix +
+ * issue-ref convention. Pure function so it is unit-testable without a
+ * GitHub event payload.
+ */
+export function lintPrTitle(title = "", body = "") {
+	const errors = [];
+	if (!CONVENTIONAL_PREFIX.test(title.trim())) {
+		errors.push(MISSING_PREFIX_MESSAGE);
+	}
+	if (!ISSUE_REF.test(title) && !ISSUE_REF.test(body)) {
+		errors.push(MISSING_ISSUE_REF_MESSAGE);
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+function eventPayload() {
+	const eventPath = process.env.GITHUB_EVENT_PATH;
+	if (!eventPath) throw new Error("GITHUB_EVENT_PATH is required");
+	return JSON.parse(readFileSync(eventPath, "utf8"));
+}
+
+function lintPullRequestEvent() {
+	const pullRequest = eventPayload().pull_request;
+	if (!pullRequest) throw new Error("Event payload has no pull_request");
+	const result = lintPrTitle(pullRequest.title ?? "", pullRequest.body ?? "");
+	if (!result.valid) {
+		for (const error of result.errors) console.error(error);
+		process.exitCode = 1;
+		return;
+	}
+	console.log(`PR title OK: "${pullRequest.title}"`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+	try {
+		lintPullRequestEvent();
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : error);
+		process.exitCode = 1;
+	}
+}

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -1,10 +1,13 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-// Repo convention: conventional-commit-style prefix, then an issue reference
-// somewhere in the title or body. Merges are merge commits from the PR
-// title (see AGENTS.md), so a malformed title becomes the permanent commit
-// subject -- catch it before merge, not after.
+// Repo convention: conventional-commit-style prefix, then an issue
+// reference, BOTH IN THE TITLE. Merges are merge commits from the PR title
+// (see AGENTS.md), so a malformed title becomes the permanent commit
+// subject -- catch it before merge, not after. A ref that lives only in the
+// body doesn't survive into the merge-commit subject line, so it doesn't
+// satisfy the convention (policy decision, #1844 PR #1917 review F1): the
+// body is never consulted here, on purpose.
 const CONVENTIONAL_PREFIX =
 	/^(feat|fix|chore|docs|refactor|test|ci|perf)(\([^)]+\))?: .+/;
 const ISSUE_REF = /#\d+/;
@@ -14,19 +17,23 @@ export const MISSING_PREFIX_MESSAGE =
 	"Allowed prefixes: feat, fix, chore, docs, refactor, test, ci, perf.";
 
 export const MISSING_ISSUE_REF_MESSAGE =
-	'PR title or body must reference an issue (e.g. "#123"). Use "Closes #123" when the PR fully resolves the issue, or "Refs #123" when work remains.';
+	'PR title must reference an issue (e.g. "#123"). Use "Closes #123" when the PR fully resolves the issue, or "Refs #123" when work remains. A reference in the PR body alone does not count -- the title becomes the merge-commit subject.';
 
 /**
- * Lint a PR title/body pair against the repo's conventional-prefix +
- * issue-ref convention. Pure function so it is unit-testable without a
- * GitHub event payload.
+ * Lint a PR title against the repo's conventional-prefix + issue-ref
+ * convention. Both requirements are checked against the TITLE ONLY. `body`
+ * is accepted but intentionally never read -- it stays in the signature so
+ * a caller can pass it through unchanged, and so the regression test for
+ * this policy (#1917 review F1: dropping the old title-or-body fallback)
+ * can prove a ref sitting only in the body no longer rescues the title.
+ * Pure function so it is unit-testable without a GitHub event payload.
  */
-export function lintPrTitle(title = "", body = "") {
+export function lintPrTitle(title = "", _body = "") {
 	const errors = [];
 	if (!CONVENTIONAL_PREFIX.test(title.trim())) {
 		errors.push(MISSING_PREFIX_MESSAGE);
 	}
-	if (!ISSUE_REF.test(title) && !ISSUE_REF.test(body)) {
+	if (!ISSUE_REF.test(title)) {
 		errors.push(MISSING_ISSUE_REF_MESSAGE);
 	}
 	return { valid: errors.length === 0, errors };

--- a/tests/scripts/check-pr-title.test.ts
+++ b/tests/scripts/check-pr-title.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+	MISSING_ISSUE_REF_MESSAGE,
+	MISSING_PREFIX_MESSAGE,
+	lintPrTitle,
+} from "../../scripts/check-pr-title.mjs";
+
+describe("PR title lint (#1844)", () => {
+	it("accepts a conventional prefix with an issue ref in the title", () => {
+		expect(lintPrTitle("fix: repair the widget cache (refs #123)", "")).toEqual({
+			valid: true,
+			errors: [],
+		});
+	});
+
+	it("accepts a scoped prefix", () => {
+		expect(lintPrTitle("feat(lsp): add native fallback (closes #456)", "")).toMatchObject({
+			valid: true,
+		});
+	});
+
+	it("accepts an issue ref that lives in the body instead of the title", () => {
+		expect(lintPrTitle("chore: tidy scripts", "Refs #789")).toMatchObject({
+			valid: true,
+		});
+	});
+
+	it("rejects a title with no conventional prefix", () => {
+		const result = lintPrTitle("Repair the widget cache (#123)", "");
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain(MISSING_PREFIX_MESSAGE);
+	});
+
+	it("rejects a prefix not in the allowed set", () => {
+		const result = lintPrTitle("wip: repair the widget cache (#123)", "");
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain(MISSING_PREFIX_MESSAGE);
+	});
+
+	it("rejects a title/body with no issue reference", () => {
+		const result = lintPrTitle("fix: repair the widget cache", "No issue here.");
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain(MISSING_ISSUE_REF_MESSAGE);
+	});
+
+	it("rejects a prefix with no colon-space separator", () => {
+		const result = lintPrTitle("fix:repair the cache (#123)", "");
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain(MISSING_PREFIX_MESSAGE);
+	});
+
+	it("reports both errors when both are missing", () => {
+		const result = lintPrTitle("repair the cache", "");
+		expect(result.valid).toBe(false);
+		expect(result.errors).toEqual([MISSING_PREFIX_MESSAGE, MISSING_ISSUE_REF_MESSAGE]);
+	});
+
+	it("accepts a cross-repo style issue ref count in the title (# followed by digits only)", () => {
+		expect(lintPrTitle("fix: repair cache #123", "")).toMatchObject({ valid: true });
+	});
+});

--- a/tests/scripts/check-pr-title.test.ts
+++ b/tests/scripts/check-pr-title.test.ts
@@ -7,55 +7,60 @@ import {
 
 describe("PR title lint (#1844)", () => {
 	it("accepts a conventional prefix with an issue ref in the title", () => {
-		expect(lintPrTitle("fix: repair the widget cache (refs #123)", "")).toEqual({
+		expect(lintPrTitle("fix: repair the widget cache (refs #123)")).toEqual({
 			valid: true,
 			errors: [],
 		});
 	});
 
 	it("accepts a scoped prefix", () => {
-		expect(lintPrTitle("feat(lsp): add native fallback (closes #456)", "")).toMatchObject({
+		expect(lintPrTitle("feat(lsp): add native fallback (closes #456)")).toMatchObject({
 			valid: true,
 		});
 	});
 
-	it("accepts an issue ref that lives in the body instead of the title", () => {
-		expect(lintPrTitle("chore: tidy scripts", "Refs #789")).toMatchObject({
-			valid: true,
-		});
+	// Policy (#1917 review F1): the issue ref must live in the TITLE. Merges
+	// are merge commits from the PR title, so a ref sitting only in the body
+	// never survives into the merge-commit subject line -- it must not
+	// rescue an otherwise-unreferenced title. This is the regression case
+	// for the fallback (`|| ISSUE_REF.test(body)`) that used to live here.
+	it("rejects a title with no issue ref even when the body has one", () => {
+		const result = lintPrTitle("chore: tidy scripts", "Refs #789");
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain(MISSING_ISSUE_REF_MESSAGE);
 	});
 
 	it("rejects a title with no conventional prefix", () => {
-		const result = lintPrTitle("Repair the widget cache (#123)", "");
+		const result = lintPrTitle("Repair the widget cache (#123)");
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(MISSING_PREFIX_MESSAGE);
 	});
 
 	it("rejects a prefix not in the allowed set", () => {
-		const result = lintPrTitle("wip: repair the widget cache (#123)", "");
+		const result = lintPrTitle("wip: repair the widget cache (#123)");
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(MISSING_PREFIX_MESSAGE);
 	});
 
-	it("rejects a title/body with no issue reference", () => {
-		const result = lintPrTitle("fix: repair the widget cache", "No issue here.");
+	it("rejects a title with no issue reference", () => {
+		const result = lintPrTitle("fix: repair the widget cache");
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(MISSING_ISSUE_REF_MESSAGE);
 	});
 
 	it("rejects a prefix with no colon-space separator", () => {
-		const result = lintPrTitle("fix:repair the cache (#123)", "");
+		const result = lintPrTitle("fix:repair the cache (#123)");
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(MISSING_PREFIX_MESSAGE);
 	});
 
 	it("reports both errors when both are missing", () => {
-		const result = lintPrTitle("repair the cache", "");
+		const result = lintPrTitle("repair the cache");
 		expect(result.valid).toBe(false);
 		expect(result.errors).toEqual([MISSING_PREFIX_MESSAGE, MISSING_ISSUE_REF_MESSAGE]);
 	});
 
 	it("accepts a cross-repo style issue ref count in the title (# followed by digits only)", () => {
-		expect(lintPrTitle("fix: repair cache #123", "")).toMatchObject({ valid: true });
+		expect(lintPrTitle("fix: repair cache #123")).toMatchObject({ valid: true });
 	});
 });


### PR DESCRIPTION
## What

Adds four mechanical checks from the #1844 "cheap lint batch" wave, split
across two workflow files so a problem in one check can't take the others
down (see "Why two workflow files" below):

1. **actionlint** (`lint.yml`) — lints every workflow under
   `.github/workflows/` (bare `./actionlint -color`, no glob, so a future
   `.yaml` file is covered too), downloaded from a pinned release and
   verified by sha256 checksum. It surfaced two pre-existing shellcheck
   findings — `install-smoke.yml`'s `A && B || C` fallback (SC2015) and
   `release.yml`'s individual `>>` redirects (SC2129) — both fixed here,
   behavior-preserving.
2. **PR-title lint** (`lint.yml`, `scripts/check-pr-title.mjs`) enforces the
   repo's conventional-prefix + issue-ref convention, **both in the title**:
   `^(feat|fix|chore|docs|refactor|test|ci|perf)(\(.+\))?: .+` plus an
   `#NNN` reference. **Policy**: an issue reference that lives only in the
   PR body does not satisfy the check. Merges are merge commits from the PR
   title, so a body-only reference never survives into the merge-commit
   subject line — the earlier version of this PR fell back to the body,
   which this review round dropped as a genuine policy gap, not just a
   style choice. Unit-tested (9 cases, including the dropped-fallback
   regression) and mutation-proofed: I neutered both guards and separately
   re-added the body fallback, confirming each regression test catches its
   specific mutation before reverting.
3. **markdownlint-cli2** (`lint.yml`) lints `**/*.md` under
   `.markdownlint-cli2.jsonc`, tuned to the current docs style. Every
   disabled rule now has its own reason comment (six were missing one in
   the first pass — MD012, MD037, MD038, MD011, MD031, MD050 — added this
   round with the actual file/finding that motivated each). No doc files
   are touched: `docs/word-index.md`'s wrapped `#771)` line, which I'd
   rewrapped in the first pass believing it was a false-positive fix, turns
   out to already pass cleanly under the shipped config (MD018 is
   disabled) — reverted back to master's exact wording.
4. **osv-scanner** (`osv-scan.yml`, advisory) runs weekly and on any PR that
   touches `package-lock.json`, gated by a `detect-lockfile-change` job that
   diffs against the PR's base SHA. The scan now runs **without**
   `continue-on-error`: since this job isn't wired into required-checks
   branch protection, a real finding should show as a red (but
   non-blocking) advisory check that a reviewer can see, not a silently
   green one. Results are also written to `$GITHUB_STEP_SUMMARY` in
   markdown-table format so a finding is visible from the PR's checks tab
   without opening logs.

`lint.yml`'s `pull_request` trigger now includes `types: [opened,
synchronize, reopened, edited]` — the default event types omit `edited`, so
without this, retitling a PR to fix a PR-title-lint failure would re-run
against the stale original title instead of the new one.

## Why two workflow files

The first push put all four checks in one `lint.yml`, with the OSV scan as a
job calling `google/osv-scanner-action`'s reusable workflow via a SHA-pinned
`uses:`. That made the **entire run** end in `startup_failure` with zero
jobs — taking the unrelated actionlint/PR-title/markdownlint jobs down with
it, even though `actionlint` validated the file cleanly beforehand (GitHub's
own reusable-workflow-call validation is stricter than what actionlint
checks for an external ref). Root-causing that further was out of this PR's
effort budget, so I isolated the blast radius: OSV scan now lives in
`osv-scan.yml` and calls the `osv-scanner` CLI directly (pinned release +
sha256 checksum, same pattern as actionlint) instead of the reusable
workflow.

## Bug found during post-push CI verification (not a numbered review finding)

The push that addressed F1-F7 also surfaced a real bug in `detect-lockfile-change`:
its checkout used the default `pull_request` ref, which is GitHub's
synthetic `refs/pull/1917/merge` commit (current master tip merged with this
branch), not this branch's own tip. Diffing that synthetic HEAD against the
PR's recorded (and, once a PR falls BEHIND, stale) `base.sha` picks up
everything master accumulated in between as if this PR had made it. Caught
it because the OSV scan job actually ran on this PR even though it doesn't
touch `package-lock.json` — master had gained an unrelated lockfile change
(`husky` hooks, #1804) after this branch was cut. Fixed by pinning both
`detect-lockfile-change` and `osv-scan`'s checkout to
`github.event.pull_request.head.sha` explicitly, so `HEAD` is the PR's real,
stable branch tip regardless of how far master has moved.

## Historical PR-title replay (stricter, title-only rule)

Replayed the last 200 merged PR titles through `lintPrTitle(title)` (no
body): **21/200 fail (10.5%)** — mostly missing issue refs entirely
(`docs(nightly): refresh LSP capability docs`, `chore: release v4.1.0`) or
missing/malformed prefixes (`Fix workspace refresh reach for monorepo
caches (closes #1707)` — capitalized, no colon prefix). **Historical titles
are not relined** — this check only gates future PRs from the point this
merges forward. Not a concern for currently open PRs: the orchestrator has
already retitled the three open PRs to conform, so merging this creates no
standing red.

## Verification

- `npx vitest run tests/scripts/check-pr-title.test.ts` — 9/9 pass.
- Mutation-proof (both guards, plus the dropped-fallback regression):
  - Neutered both `lintPrTitle` guards (`if (false && ...)`) — 6/9 red,
    including the new "no issue ref even when the body has one" case.
  - Reverted, then specifically re-added `|| ISSUE_REF.test(_body)` to
    simulate the OLD fallback regressing back in — exactly 1/9 red (the
    dedicated regression test for this policy), 8/9 still green. Reverted.
- `actionlint -color` (v1.7.12, linux_amd64, sha256 verified, bare
  auto-discovery) — clean across every workflow.
- `npx markdownlint-cli2` (v0.23.2) — `0 issues in 0 files` across the 44
  linted docs, including after reverting the word-index.md rewrap.
- `node scripts/check-changelog-fragments.mjs` — fragment format OK.
- `npm run build && npm run lint && npm run check:lockfile` — all green.
- Full suite: **not run** (CI is authoritative per repo convention); ran the
  targeted files above instead.
- `git diff origin/master -- docs/word-index.md` — empty (confirms the F6
  revert is byte-identical to master).

## Blast radius

- Two workflow files (`lint.yml`, `osv-scan.yml`); no changes to `ci.yml` or
  `merge-train-warden.yml`.
- Two pre-existing workflows got behavior-preserving shellcheck fixes
  (`install-smoke.yml`, `release.yml`).
- `scripts/check-pr-title.mjs` (+ `.d.mts`) and `.markdownlint-cli2.jsonc`
  are new, standalone files with no existing callers to break.
- `docs/word-index.md` is untouched relative to master (see Verification).
- No new process spawns on the hot path — CI-only jobs, not session-start or
  dispatch code.

## Class sweep

Not applicable — this PR adds new mechanical CI checks rather than fixing a
root-caused runtime bug, so there's no existing defect class to sweep for.

## What remains (posted to #1844, issue stays open)

- **Stryker incremental mutation testing** — deferred, heavier lift.
  `@stryker-mutator/core` + `@stryker-mutator/vitest-runner` support Vitest
  directly; incremental mode re-mutates only files changed since the last
  run, which fits #1112's serialized full-suite constraint. Scoping to
  `mutate: ["clients/**/*.ts"]` with a generous initial threshold (60-70%)
  keeps first-run noise down. Needs its own PR to size real runtime.
- **dependency-cruiser** — deferred. Proposed ruleset: repo-wide
  `no-circular`, a `no-import` rule pinning the declared leaf modules named
  in #1844 (`ledger-bounds`, `workspace-diagnostics-session`,
  `path-utils`) to zero fan-in from `clients/`, and a size/allowlist pin on
  `index.ts`'s eager import graph. Needs its own PR to enumerate the
  current graph and calibrate the allowlist.
- **SonarCloud npx finding** (not a required check) — `lint.yml`'s
  markdownlint job invokes `markdownlint-cli2` via `npx`, which SonarCloud
  flags as a MAJOR vulnerability (arbitrary package install + lifecycle
  scripts). Accepted for now (version pinned); maintainer call on whether
  to pin it as a devDependency instead.

Refs #1844
