### PR TITLE
fix: re-arm cascade tier-3 at session_start; log quick-mode skips (closes #1910, closes #1911)

### DIFF
--- a/.changelog/add-1911-quick-mode-skip-record.md
+++ b/.changelog/add-1911-quick-mode-skip-record.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Quick-mode session_start now logs which steps it skipped (closes #1911)** — quick mode silently skipped slow tool probes, language profiling, preinstall, startup scans, and the error-debt baseline, with no record either way. `session_start` now emits one bounded `session_start_skipped_steps` latency record naming the skipped step set, so a reader can tell "quick mode correctly skipped these" from "the probes silently never ran".

--- a/.changelog/fix-1910-cascade-tier-session-reset.md
+++ b/.changelog/fix-1910-cascade-tier-session-reset.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Cascade tier-3 registry now resets at session_start (closes #1910)** — the outstanding-touch registry and its sweep-scoped expired/evicted counters (`clients/lsp/cascade-tier.ts`) used to survive a session replacement, so a new session inherited the prior session's outstanding touches and a stray eviction or expiry landed on the next session's first reconcile gauge. `handleSessionStart` now clears both, primary-only, same as every other per-session latch in that reset block.

--- a/clients/lsp/cascade-tier.ts
+++ b/clients/lsp/cascade-tier.ts
@@ -236,11 +236,27 @@ export function recordOutstandingCascadeTouch(entry: OutstandingTouch): void {
 	}
 }
 
-/** Test-only: clear the outstanding-touch registry between test cases. */
-export function _resetOutstandingCascadeTouchesForTests(): void {
+/**
+ * #1910: session-boundary reset for the outstanding-touch registry and its
+ * sweep-scoped `_expiredSinceLastSweep`/`_evictedSinceLastSweep` counters.
+ * Both predate #1899 and were never wired into `handleSessionStart` — a
+ * session replacement inherited the prior session's outstanding touches, and
+ * a stray eviction/expiry landing between a sweep and the boundary attributed
+ * its count to the NEXT session's first reconcile gauge. Wired primary-only,
+ * same as every other entry in that reset block: a concurrently-live
+ * secondary never reaches `handleSessionStart` at all (the #473 guard in
+ * index.ts), so it can never race this reset against the still-live
+ * primary's outstanding touches.
+ */
+export function resetCascadeTierSessionState(): void {
 	_outstandingTouches.clear();
 	_expiredSinceLastSweep = 0;
 	_evictedSinceLastSweep = 0;
+}
+
+/** Test-only: clear the outstanding-touch registry between test cases. */
+export function _resetOutstandingCascadeTouchesForTests(): void {
+	resetCascadeTierSessionState();
 }
 
 /** Test-only: peek at the registry without mutating it. */

--- a/clients/lsp/cascade-tier.ts
+++ b/clients/lsp/cascade-tier.ts
@@ -265,6 +265,20 @@ export function _getOutstandingCascadeTouchesForTests(): OutstandingTouch[] {
 }
 
 /**
+ * Test-only: peek at the sweep-scoped expired/evicted counters without
+ * mutating them. Exists so a probe of `resetCascadeTierSessionState` can
+ * assert on THESE counters directly, rather than only on the registry map —
+ * a future counter added here and left out of the reset would otherwise
+ * stay invisible to any probe that only checks the map went empty.
+ */
+export function _getCascadeTierSweepCountersForTests(): {
+	expired: number;
+	evicted: number;
+} {
+	return { expired: _expiredSinceLastSweep, evicted: _evictedSinceLastSweep };
+}
+
+/**
  * #1899: WHY a touch stayed unresolved. Five distinct causes used to collapse
  * into the single word `unresolved`, which is what made the dogfood backlog
  * unreadable: 676 of 756 outcomes were `unresolved` with no way to tell the

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -41,6 +41,7 @@ import {
 } from "./language-profile.js";
 import { logLatency } from "./latency-logger.js";
 import { runLogCleanup } from "./log-cleanup.js";
+import { resetCascadeTierSessionState } from "./lsp/cascade-tier.js";
 import type { LSPShutdownOptions } from "./lsp/client.js";
 import { initLSPConfig, loadLSPConfig } from "./lsp/config.js";
 import { resetWorkspaceDiagnosticsCacheSession } from "./lsp/workspace-diagnostics-session.js";
@@ -2179,6 +2180,14 @@ export async function handleSessionStart(
 	// concrete KnipClient. Session reset is an optional lifecycle capability;
 	// its absence must not make session_start fail.
 	knipClient.resetSessionState?.();
+	// #1910: the tier-3 cascade outstanding-touch registry and its
+	// sweep-scoped expired/evicted counters (clients/lsp/cascade-tier.ts) are
+	// a per-SESSION claim about touches THIS session fired. #1899 bounded the
+	// registry between sweeps but, by its own review, left the session
+	// boundary unwired — a session replacement inherited the prior session's
+	// outstanding touches and misattributed a stray expiry/eviction to the
+	// next session's first reconcile gauge.
+	resetCascadeTierSessionState();
 	runtime.resetForSession(sessionStartMs);
 	logLatency({
 		type: "phase",
@@ -2369,6 +2378,29 @@ export async function handleSessionStart(
 		dbg(
 			"session_start: quick mode active - skipping slow tool probes, language profiling, preinstall, scans, and error debt baseline",
 		);
+		// #1911: the debug line above says WHICH steps were skipped, but nothing
+		// bounded or structured said so — quick mode's absence of work and an
+		// absent LOGGER read identically in latency.log. This record is that
+		// line's structured twin: one bounded gauge per quick-mode session_start,
+		// naming exactly the step set skipped, so a reader can tell "quick mode
+		// correctly skipped these" from "the probes silently never ran".
+		logLatency({
+			type: "phase",
+			phase: "session_start_skipped_steps",
+			filePath: cwd,
+			durationMs: 0,
+			metadata: {
+				mode: startupMode,
+				reason: deps.sessionReason,
+				steps: [
+					"slow_tool_probes",
+					"language_profiling",
+					"tool_preinstall",
+					"startup_scans",
+					"error_debt_baseline",
+				],
+			},
+		});
 		const totalDurationMs = Date.now() - sessionStartMs;
 		dbg(`session_start total: ${totalDurationMs}ms (interactive path)`);
 		logLatency({

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -2392,6 +2392,15 @@ export async function handleSessionStart(
 			metadata: {
 				mode: startupMode,
 				reason: deps.sessionReason,
+				// #1911 review F3: this `if (quickMode)` branch is an early return —
+				// the whole quick path — so there is no enumerable list of "steps
+				// run vs. skipped" this array could be derived from mechanically. It
+				// is DESCRIPTIVE documentation of what the early return skips,
+				// matching the `dbg()` line above word for word; keep both in sync by
+				// hand if either changes. It also does NOT narrow under
+				// `getFlag("no-lsp")` — quick mode skips the same five steps either
+				// way; the LSP flag instead affects `quickTools` above, a separate
+				// record.
 				steps: [
 					"slow_tool_probes",
 					"language_profiling",

--- a/tests/clients/runtime-session-cascade-tier-reset.test.ts
+++ b/tests/clients/runtime-session-cascade-tier-reset.test.ts
@@ -1,0 +1,196 @@
+/**
+ * #1910: the tier-3 cascade outstanding-touch registry and its sweep-scoped
+ * `_expiredSinceLastSweep`/`_evictedSinceLastSweep` counters (#1899) were never
+ * wired into `handleSessionStart` — a session replacement inherited the prior
+ * session's outstanding touches, and a stray eviction/expiry landing between a
+ * sweep and the boundary attributed its count to the NEXT session's first
+ * reconcile gauge.
+ *
+ * This drives the REAL handler (never calling `resetCascadeTierSessionState`
+ * directly) so the wiring itself — not just the reset function in isolation —
+ * is under test. `tests/support/session-state-registry.ts`'s probe already
+ * proves the reset function re-arms the state; this file proves
+ * `handleSessionStart` actually reaches it, and that a concurrent secondary
+ * (which never reaches `handleSessionStart` at all — the #473 guard in
+ * index.ts) does not.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { removeTempDirSync, setupTestEnvironment } from "./test-utils.js";
+
+// Dynamically imported below (never a static top-level import): a static
+// `import ... from "../../clients/runtime-session.js"` pulls in
+// clients/lsp/cascade-tier.js as part of the SAME module-graph evaluation
+// that runs BEFORE this file's own top-level `const logCascade = vi.fn()`
+// below executes, which is a TDZ crash the moment the hoisted
+// `vi.mock("../../clients/cascade-logger.js", ...)` factory tries to read it.
+type HandleSessionStart =
+	typeof import("../../clients/runtime-session.js").handleSessionStart;
+
+const registerQuietWindowTask = vi.fn();
+const logCascade = vi.fn();
+
+vi.mock("../../clients/quiet-window.js", () => ({
+	registerQuietWindowTask,
+}));
+vi.mock("../../clients/cascade-logger.js", () => ({
+	logCascade,
+}));
+
+vi.mock("../../clients/safe-spawn.js", () => ({
+	safeSpawn: vi.fn(() => ({ stdout: "", stderr: "", status: 1 })),
+	safeSpawnAsync: vi.fn(async () => ({ stdout: "", stderr: "", status: 1 })),
+	resetSafeSpawnWindowsCommandCache: vi.fn(),
+}));
+
+vi.mock("../../clients/installer/index.js", () => ({
+	ensureTool: vi.fn(async () => undefined),
+	resetResolvedPathCache: vi.fn(),
+	isSpawnableCommand: vi.fn(async () => false),
+	resetPathWalkMemo: vi.fn(),
+}));
+
+vi.mock("../../clients/lsp/config.js", () => ({
+	loadLSPConfig: vi.fn().mockResolvedValue({}),
+	initLSPConfig: vi.fn().mockResolvedValue(undefined),
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../clients/lsp/index.js", () => ({
+	getLSPService: vi.fn(() => ({
+		touchFile: vi.fn().mockResolvedValue(undefined),
+		supportsLSP: () => false,
+	})),
+}));
+
+function makeDefaultRuntime() {
+	return {
+		sessionGeneration: 1,
+		isCurrentSession: () => true,
+		markStartupScanInFlight: () => {},
+		clearStartupScanInFlight: () => {},
+		complexityBaselines: new Map(),
+		resetForSession: () => {},
+		projectRoot: "",
+		projectRulesScan: { hasCustomRules: false, rules: [] },
+		cachedExports: new Map(),
+		errorDebtBaseline: { testsPassed: true, buildPassed: true },
+	};
+}
+
+function makeDeps(ctxCwd: string) {
+	return {
+		ctxCwd,
+		getFlag: () => false,
+		notify: vi.fn(),
+		dbg: () => {},
+		log: () => {},
+		runtime: makeDefaultRuntime(),
+		metricsClient: { reset: () => {} },
+		cacheManager: { writeCache: () => {}, readCache: () => null },
+		todoScanner: { scanDirectory: () => ({ items: [] }) },
+		astGrepClient: {
+			isAvailable: () => false,
+			ensureAvailable: async () => false,
+			scanExports: async () => new Map(),
+		},
+		biomeClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		ruffClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		knipClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		jscpdClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		depChecker: { isAvailable: () => false, ensureAvailable: async () => false },
+		testRunnerClient: {
+			detectRunner: () => ({ runner: "vitest", config: null }),
+			runTestFile: () => ({ failed: 1, error: false }),
+		},
+		goClient: { isGoAvailableAsync: async () => false },
+		rustClient: { isAvailableAsync: async () => false },
+		ensureTool: vi.fn(async () => null),
+		cleanStaleTsBuildInfo: () => [],
+		resetDispatchBaselines: () => {},
+		resetLSPService: () => {},
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	} as any;
+}
+
+/** Mirrors `MAX_OUTSTANDING_TOUCHES` in clients/lsp/cascade-tier.ts. */
+const CAP = 256;
+/** Mirrors `OUTSTANDING_TOUCH_MAX_AGE_MS` in clients/lsp/cascade-tier.ts. */
+const MAX_AGE_MS = 15 * 60_000;
+
+function sweepGauge(): { phase: string; metadata: Record<string, unknown> } {
+	const row = logCascade.mock.calls
+		.map((call) => call[0])
+		.find((candidate) => candidate?.phase === "cascade_tier3_reconcile");
+	if (!row) throw new Error("no cascade_tier3_reconcile record was written");
+	return row;
+}
+
+describe("cascade tier-3 registry is reset at session_start (#1910)", () => {
+	let tmpDir: string;
+	let handleSessionStart: HandleSessionStart;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		tmpDir = setupTestEnvironment("pi-lens-cascade-tier-reset-").tmpDir;
+		const cascadeTier = await import("../../clients/lsp/cascade-tier.js");
+		cascadeTier._resetOutstandingCascadeTouchesForTests();
+		cascadeTier._resetCascadeTierReconcileRegistrationForTests();
+		({ handleSessionStart } = await import("../../clients/runtime-session.js"));
+	});
+
+	afterEach(() => {
+		removeTempDirSync(tmpDir);
+	});
+
+	it("clears outstanding touches and the expired/evicted counters through the real handler", async () => {
+		const cascadeTier = await import("../../clients/lsp/cascade-tier.js");
+		const base = Date.now();
+
+		// Arm the registry, and both since-last-sweep counters: one ancient
+		// touch (pruned by age on the next record) and CAP+1 fresh touches (the
+		// last record trips the size cap and evicts the oldest survivor).
+		cascadeTier.recordOutstandingCascadeTouch({
+			filePath: `${tmpDir}/ancient.ts`,
+			serverId: "typescript",
+			touchedAt: base - MAX_AGE_MS - 1,
+		});
+		for (let i = 0; i <= CAP; i++) {
+			cascadeTier.recordOutstandingCascadeTouch({
+				filePath: `${tmpDir}/f${i}.ts`,
+				serverId: "typescript",
+				touchedAt: base - CAP + i,
+			});
+		}
+		expect(
+			cascadeTier._getOutstandingCascadeTouchesForTests().length,
+		).toBeGreaterThan(0);
+
+		// Never call resetCascadeTierSessionState directly — the whole point is
+		// to prove handleSessionStart itself reaches it.
+		await handleSessionStart(makeDeps(tmpDir));
+
+		expect(cascadeTier._getOutstandingCascadeTouchesForTests()).toEqual([]);
+
+		// Confirm the SWEEP-SCOPED counters were cleared too, not just the map:
+		// register the reconcile task and run one sweep, and read what it wrote.
+		cascadeTier.registerCascadeTierReconcileTask(
+			() =>
+				({
+					getWarmClientForFile: vi.fn().mockResolvedValue(undefined),
+				}) as never,
+		);
+		const task = registerQuietWindowTask.mock.calls[0][1] as () => Promise<void>;
+		await task();
+		expect(sweepGauge().metadata).toMatchObject({
+			count: 0,
+			expired: 0,
+			evicted: 0,
+		});
+	});
+
+	// The "a concurrent secondary must NOT reset" half is proved at the
+	// index.ts layer, where the #473 primary/secondary decision actually lives
+	// — see tests/index-integration.test.ts's "primary session_start clears the
+	// cascade tier-3 registry, a concurrent secondary's does not".
+});

--- a/tests/clients/runtime-session-quick-mode-observability.test.ts
+++ b/tests/clients/runtime-session-quick-mode-observability.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #1911: quick-mode `session_start` skips several slow probes silently — the
+ * `session_start: quick mode active - skipping...` debug line names them, but
+ * nothing bounded or structured said so. In test mode `dbg()` is suppressed
+ * entirely (`clients/env-utils.ts`'s `isTestMode`), so that debug line was
+ * never even a durable record in production either way — absence of the
+ * skipped work and absence of the LOGGING read identically in latency.log.
+ *
+ * This pins the structured twin: one `session_start_skipped_steps` latency
+ * record on the quick path, naming the skipped step set, and its ABSENCE on
+ * the full path (where those steps actually run instead of being skipped).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LatencyEntry } from "../../clients/latency-logger.js";
+
+const latencyEntries = vi.hoisted(() => [] as LatencyEntry[]);
+vi.mock("../../clients/latency-logger.js", () => ({
+	logLatency: (entry: LatencyEntry) => latencyEntries.push(entry),
+}));
+
+vi.mock("../../clients/lsp/config.js", () => ({
+	loadLSPConfig: vi.fn().mockResolvedValue({}),
+	initLSPConfig: vi.fn().mockResolvedValue(undefined),
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../clients/lsp/index.js", () => ({
+	getLSPService: vi.fn(() => ({
+		touchFile: vi.fn().mockResolvedValue(undefined),
+		supportsLSP: () => false,
+	})),
+}));
+
+vi.mock("../../clients/safe-spawn.js", () => ({
+	safeSpawn: vi.fn(() => ({ stdout: "", stderr: "", status: 1 })),
+	safeSpawnAsync: vi.fn(async () => ({ stdout: "", stderr: "", status: 1 })),
+	resetSafeSpawnWindowsCommandCache: vi.fn(),
+}));
+
+vi.mock("../../clients/installer/index.js", () => ({
+	ensureTool: vi.fn(async () => undefined),
+	resetResolvedPathCache: vi.fn(),
+	isSpawnableCommand: vi.fn(async () => false),
+	resetPathWalkMemo: vi.fn(),
+}));
+
+import { handleSessionStart } from "../../clients/runtime-session.js";
+import { removeTempDirSync, setupTestEnvironment } from "./test-utils.js";
+
+function setStartupMode(mode: "full" | "quick"): () => void {
+	const prev = process.env.PI_LENS_STARTUP_MODE;
+	process.env.PI_LENS_STARTUP_MODE = mode;
+	return () => {
+		if (prev === undefined) delete process.env.PI_LENS_STARTUP_MODE;
+		else process.env.PI_LENS_STARTUP_MODE = prev;
+	};
+}
+
+function makeDefaultRuntime() {
+	return {
+		sessionGeneration: 1,
+		isCurrentSession: () => true,
+		markStartupScanInFlight: () => {},
+		clearStartupScanInFlight: () => {},
+		complexityBaselines: new Map(),
+		resetForSession: () => {},
+		projectRoot: "",
+		projectRulesScan: { hasCustomRules: false, rules: [] },
+		cachedExports: new Map(),
+		errorDebtBaseline: { testsPassed: true, buildPassed: true },
+	};
+}
+
+function makeDeps(ctxCwd: string) {
+	return {
+		ctxCwd,
+		getFlag: () => false,
+		notify: vi.fn(),
+		dbg: () => {},
+		log: () => {},
+		runtime: makeDefaultRuntime(),
+		metricsClient: { reset: () => {} },
+		cacheManager: { writeCache: () => {}, readCache: () => null },
+		todoScanner: { scanDirectory: () => ({ items: [] }) },
+		astGrepClient: {
+			isAvailable: () => false,
+			ensureAvailable: async () => false,
+			scanExports: async () => new Map(),
+		},
+		biomeClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		ruffClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		knipClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		jscpdClient: { isAvailable: () => false, ensureAvailable: async () => false },
+		depChecker: { isAvailable: () => false, ensureAvailable: async () => false },
+		testRunnerClient: {
+			detectRunner: () => ({ runner: "vitest", config: null }),
+			runTestFile: () => ({ failed: 1, error: false }),
+		},
+		goClient: { isGoAvailableAsync: async () => false },
+		rustClient: { isAvailableAsync: async () => false },
+		ensureTool: vi.fn(async () => null),
+		cleanStaleTsBuildInfo: () => [],
+		resetDispatchBaselines: () => {},
+		resetLSPService: () => {},
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	} as any;
+}
+
+function skippedStepsRecords(): LatencyEntry[] {
+	return latencyEntries.filter(
+		(entry) => entry.phase === "session_start_skipped_steps",
+	);
+}
+
+describe("quick-mode session_start skip observability (#1911)", () => {
+	let tmpDir: string;
+	let restoreStartupMode: () => void;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		latencyEntries.length = 0;
+		tmpDir = setupTestEnvironment("pi-lens-quick-mode-obs-").tmpDir;
+	});
+
+	afterEach(() => {
+		restoreStartupMode?.();
+		removeTempDirSync(tmpDir);
+	});
+
+	it("emits a bounded session_start_skipped_steps record naming the skipped steps on the quick path", async () => {
+		restoreStartupMode = setStartupMode("quick");
+
+		await handleSessionStart(makeDeps(tmpDir));
+
+		const records = skippedStepsRecords();
+		expect(records).toHaveLength(1);
+		expect(records[0]).toEqual(
+			expect.objectContaining({
+				type: "phase",
+				phase: "session_start_skipped_steps",
+				filePath: tmpDir,
+				durationMs: 0,
+				metadata: expect.objectContaining({
+					mode: "quick",
+					steps: expect.arrayContaining([
+						"slow_tool_probes",
+						"language_profiling",
+						"tool_preinstall",
+						"startup_scans",
+						"error_debt_baseline",
+					]),
+				}),
+			}),
+		);
+	});
+
+	it("never emits the record on the full path, where those steps actually run instead of being skipped", async () => {
+		restoreStartupMode = setStartupMode("full");
+
+		await handleSessionStart(makeDeps(tmpDir));
+
+		expect(skippedStepsRecords()).toEqual([]);
+	});
+});

--- a/tests/clients/runtime-session-quick-mode-observability.test.ts
+++ b/tests/clients/runtime-session-quick-mode-observability.test.ts
@@ -48,6 +48,12 @@ vi.mock("../../clients/installer/index.js", () => ({
 import { handleSessionStart } from "../../clients/runtime-session.js";
 import { removeTempDirSync, setupTestEnvironment } from "./test-utils.js";
 
+// The full path runs a REAL (unmocked) handleSessionStart body, same as
+// tests/index-integration.test.ts's integration cases — vitest's default
+// 5000ms timed out once in six under batch contention. Same constant name and
+// value as that file's INTEGRATION_TIMEOUT_MS.
+const INTEGRATION_TIMEOUT_MS = 45_000;
+
 function setStartupMode(mode: "full" | "quick"): () => void {
 	const prev = process.env.PI_LENS_STARTUP_MODE;
 	process.env.PI_LENS_STARTUP_MODE = mode;
@@ -155,11 +161,15 @@ describe("quick-mode session_start skip observability (#1911)", () => {
 		);
 	});
 
-	it("never emits the record on the full path, where those steps actually run instead of being skipped", async () => {
-		restoreStartupMode = setStartupMode("full");
+	it(
+		"never emits the record on the full path, where those steps actually run instead of being skipped",
+		async () => {
+			restoreStartupMode = setStartupMode("full");
 
-		await handleSessionStart(makeDeps(tmpDir));
+			await handleSessionStart(makeDeps(tmpDir));
 
-		expect(skippedStepsRecords()).toEqual([]);
-	});
+			expect(skippedStepsRecords()).toEqual([]);
+		},
+		INTEGRATION_TIMEOUT_MS,
+	);
 });

--- a/tests/index-integration.test.ts
+++ b/tests/index-integration.test.ts
@@ -363,6 +363,60 @@ describe("index.ts integration", () => {
 		expect(telemetry.getVerifiedPathAttributionGuessCount()).toBe(0);
 	}, INTEGRATION_TIMEOUT_MS);
 
+	// #1910: the tier-3 cascade outstanding-touch registry (clients/lsp/
+	// cascade-tier.ts) is process-shared runtime state, same #473 shape as the
+	// active-tool set and the direct-LSP latch above. A concurrently-live
+	// secondary's session_start must not wipe the still-live primary's
+	// outstanding touches out from under it.
+	it("primary session_start clears the cascade tier-3 registry, a concurrent secondary's does not", async () => {
+		// The earlier "session_start handler passes working ensureTool closure
+		// into handleSessionStart" case in this file `vi.doMock`s
+		// runtime-session.js and never `vi.doUnmock`s it (only line ~1584, in a
+		// different describe block, ever does) — `vi.doMock` registrations
+		// outlive `vi.resetModules()`, so without this explicit unmock this test
+		// would run against that STUBBED handleSessionStart (a no-op) whenever
+		// it happens to execute after that one, and pass for the wrong reason
+		// (nothing ever resets anything). This test needs the REAL handler.
+		// Same leak, second module: the same earlier test also `vi.doMock`s
+		// installer/index.js with a partial export set (missing
+		// `resetPathWalkMemo`, which `resetDispatchAvailabilityState` — reached
+		// from `handleSessionStart` — needs) and never unmocks it either.
+		vi.doUnmock("../clients/runtime-session.js");
+		vi.doUnmock("../clients/installer/index.js");
+		const { default: registerExtension } = await import("../index.js");
+		const cascadeTier = await import("../clients/lsp/cascade-tier.js");
+		cascadeTier._resetOutstandingCascadeTouchesForTests();
+
+		const primary = createMockPi();
+		registerExtension(primary.pi as any);
+		await primary.trigger("session_start", {}, makeCtx({ cwd: tmpDir, sessionId: "primary" }));
+
+		// Seed a touch the still-live primary is tracking.
+		cascadeTier.recordOutstandingCascadeTouch({
+			filePath: `${tmpDir}/neighbor.ts`,
+			serverId: "typescript",
+			touchedAt: Date.now(),
+		});
+		expect(
+			cascadeTier._getOutstandingCascadeTouchesForTests().length,
+		).toBeGreaterThan(0);
+
+		// A concurrently-live secondary binds in the same process (the #473
+		// shape) — its session_start must return at the concurrent-secondary
+		// guard, above the reset block, and leave the primary's touch alone.
+		const secondary = createMockPi();
+		registerExtension(secondary.pi as any);
+		await secondary.trigger("session_start", {}, makeCtx({ cwd: tmpDir, sessionId: "secondary" }));
+		expect(
+			cascadeTier._getOutstandingCascadeTouchesForTests().length,
+		).toBeGreaterThan(0);
+
+		// A genuine primary session replacement, by contrast, DOES clear it —
+		// the whole point of #1910 wiring the reset into handleSessionStart.
+		await primary.trigger("session_start", {}, makeCtx({ cwd: tmpDir, sessionId: "primary" }));
+		expect(cascadeTier._getOutstandingCascadeTouchesForTests()).toEqual([]);
+	}, INTEGRATION_TIMEOUT_MS);
+
 	it("agent_settled dumps active handles AFTER quiet-window work is scheduled (#1123 item 4)", async () => {
 		// #1097's leak (a stray ref'd timer) only surfaces once whatever
 		// agent_settled itself queues is already in flight, so the dump must

--- a/tests/support/bounded-telemetry-scan.ts
+++ b/tests/support/bounded-telemetry-scan.ts
@@ -236,5 +236,5 @@ export const UNBOUNDED_FAILURE_PHASE_REASONS: Record<string, string> = {
 	review_graph_size_skip:
 		"One record per graph build, which is already the coarsest unit of review-graph work.",
 	session_start_skipped_steps:
-		"One record per quick-mode session_start, and quick mode is forced at most once per interactive process (plus once per explicit `-p`/`--print` one-shot) — the same once-per-lifecycle-event cadence as `agent_end_concurrent_secondary_skip` above, pinned by tests/clients/runtime-session-quick-mode-observability.test.ts.",
+		"One record per session_start, and only on the quick-mode path — the same once-per-lifecycle-event cadence as `agent_end_concurrent_secondary_skip` above, pinned by tests/clients/runtime-session-quick-mode-observability.test.ts.",
 };

--- a/tests/support/bounded-telemetry-scan.ts
+++ b/tests/support/bounded-telemetry-scan.ts
@@ -235,4 +235,6 @@ export const UNBOUNDED_FAILURE_PHASE_REASONS: Record<string, string> = {
 		"The site already holds a first-seen-per-cwd set (`_cwdWorktreeCheckedCwds`) and returns early when it admits nothing.",
 	review_graph_size_skip:
 		"One record per graph build, which is already the coarsest unit of review-graph work.",
+	session_start_skipped_steps:
+		"One record per quick-mode session_start, and quick mode is forced at most once per interactive process (plus once per explicit `-p`/`--print` one-shot) — the same once-per-lifecycle-event cadence as `agent_end_concurrent_secondary_skip` above, pinned by tests/clients/runtime-session-quick-mode-observability.test.ts.",
 };

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -50,6 +50,11 @@ import {
 	isWorkspaceSweepActive,
 } from "../../clients/lsp/workspace-sweep-hold.js";
 import {
+	_getOutstandingCascadeTouchesForTests,
+	recordOutstandingCascadeTouch,
+	resetCascadeTierSessionState,
+} from "../../clients/lsp/cascade-tier.js";
+import {
 	_resetDeferredForTests,
 	isDeferredThisSession,
 	markDisposition,
@@ -519,6 +524,26 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 		reason:
 			"#1895: formatter PATH availability is session-scoped, but these module-local latches are not covered by the dispatch availability generation. A formatter installed or removed between sessions must be re-probed. The reset is `clearFormatterCache`, not the latch clear alone: `getFormattersForFile` answers a same-cwd lookup from `detectionCache` before it reaches a `which` probe, so dropping the latches without the selection cache re-arms every directory except the working one (review round on PR #1896).",
 	},
+	{
+		id: "cascade-tier:outstandingTouches",
+		module: "lsp/cascade-tier.ts",
+		state: "_outstandingTouches, _expiredSinceLastSweep, _evictedSinceLastSweep",
+		policy: "session_start",
+		resetName: "resetCascadeTierSessionState",
+		reason:
+			"#1910: the tier-3 cascade outstanding-touch registry and its sweep-scoped expired/evicted counters are a per-SESSION claim about touches THIS session fired. #1899 bounded the registry between sweeps but, by its own review, left the session boundary unwired — a session replacement inherited the prior session's outstanding touches, and a stray eviction/expiry landing between a sweep and the boundary attributed its count to the next session's first reconcile gauge. Previously the whole file was blanket-exempted (#1909 review F4: 'cascade-tier registration and outstanding-touch bookkeeping'); this entry replaces that blanket claim with the real reset now that one exists. `_reconcileTaskRegistered` and the `_enabledCache` kill-switch memo are deliberately still NOT covered by a reset — the former is idempotent quiet-window-task registration (same shape as the other publisher-registration exemptions in this file), and the latter is a memo of the `PI_LENS_TIER_AWARE_CASCADE` env var, unaffected by a session boundary.",
+		probe: {
+			arm: () => {
+				recordOutstandingCascadeTouch({
+					filePath: "/probe/session-state-registry.ts",
+					serverId: "session-state-registry-probe",
+					touchedAt: Date.now(),
+				});
+			},
+			isArmed: () => _getOutstandingCascadeTouchesForTests().length === 0,
+			reset: () => resetCascadeTierSessionState(),
+		},
+	},
 
 	// ── Deliberately not session_start ───────────────────────────────────────
 	{
@@ -645,7 +670,6 @@ export const EXEMPT_SESSION_STATE_FILES: Readonly<Record<string, string>> = {
 	"quiet-window.ts": "quiet-window task registration",
 	"quiet-window-config.ts":
 		"the env-derived quiet-window kill switch and wait budget, split out of quiet-window.ts by #1462; a memo of configuration, not of a session verdict",
-	"lsp/cascade-tier.ts": "cascade-tier registration and outstanding-touch bookkeeping",
 	"dispatch/lazy.ts": "the lazy dispatch-integration import cell",
 	"extension-log.ts": "console-method guard installation",
 	"cache-observability.ts":

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -50,6 +50,7 @@ import {
 	isWorkspaceSweepActive,
 } from "../../clients/lsp/workspace-sweep-hold.js";
 import {
+	_getCascadeTierSweepCountersForTests,
 	_getOutstandingCascadeTouchesForTests,
 	recordOutstandingCascadeTouch,
 	resetCascadeTierSessionState,
@@ -533,14 +534,40 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 		reason:
 			"#1910: the tier-3 cascade outstanding-touch registry and its sweep-scoped expired/evicted counters are a per-SESSION claim about touches THIS session fired. #1899 bounded the registry between sweeps but, by its own review, left the session boundary unwired — a session replacement inherited the prior session's outstanding touches, and a stray eviction/expiry landing between a sweep and the boundary attributed its count to the next session's first reconcile gauge. Previously the whole file was blanket-exempted (#1909 review F4: 'cascade-tier registration and outstanding-touch bookkeeping'); this entry replaces that blanket claim with the real reset now that one exists. `_reconcileTaskRegistered` and the `_enabledCache` kill-switch memo are deliberately still NOT covered by a reset — the former is idempotent quiet-window-task registration (same shape as the other publisher-registration exemptions in this file), and the latter is a memo of the `PI_LENS_TIER_AWARE_CASCADE` env var, unaffected by a session boundary.",
 		probe: {
+			// Arms all THREE pieces of state the reset claims to cover, not just
+			// the map: an ancient touch trips the age prune (bumps `expired` on
+			// the next record), and CAP+1 fresh touches trip the size cap (bumps
+			// `evicted`). A probe that only checked the map would stay green if a
+			// future counter were added and left out of the reset — this one
+			// would not (review round, F2).
 			arm: () => {
+				const base = Date.now();
 				recordOutstandingCascadeTouch({
-					filePath: "/probe/session-state-registry.ts",
+					filePath: "/probe/session-state-registry-ancient.ts",
 					serverId: "session-state-registry-probe",
-					touchedAt: Date.now(),
+					// Mirrors OUTSTANDING_TOUCH_MAX_AGE_MS in clients/lsp/cascade-tier.ts.
+					touchedAt: base - 15 * 60_000 - 1,
 				});
+				// Mirrors MAX_OUTSTANDING_TOUCHES in clients/lsp/cascade-tier.ts; the
+				// (CAP + 1)th record both prunes the ancient entry above and evicts
+				// the oldest surviving one.
+				const CAP = 256;
+				for (let i = 0; i <= CAP; i++) {
+					recordOutstandingCascadeTouch({
+						filePath: `/probe/session-state-registry-f${i}.ts`,
+						serverId: "session-state-registry-probe",
+						touchedAt: base - CAP + i,
+					});
+				}
 			},
-			isArmed: () => _getOutstandingCascadeTouchesForTests().length === 0,
+			isArmed: () => {
+				const counters = _getCascadeTierSweepCountersForTests();
+				return (
+					_getOutstandingCascadeTouchesForTests().length === 0 &&
+					counters.expired === 0 &&
+					counters.evicted === 0
+				);
+			},
 			reset: () => resetCascadeTierSessionState(),
 		},
 	},


### PR DESCRIPTION
## What changed

Two session-start seam gaps, both filed against `handleSessionStart`'s reset block.

**#1910 — cascade tier-3 registry never re-armed.** `clients/lsp/cascade-tier.ts`'s outstanding-touch registry and its sweep-scoped `_expiredSinceLastSweep`/`_evictedSinceLastSweep` counters predate #1899 and were never wired into `handleSessionStart`. A session replacement inherited the prior session's outstanding touches, and a stray eviction or expiry landing between a sweep and the boundary attributed its count to the next session's first reconcile gauge. #1909 named this as an honest gap.

Fix: a new `resetCascadeTierSessionState()` clears the registry and both counters, called primary-only in the same reset block as every other per-session latch (`resetDegradationLedger`, `resetDispatchAvailabilityState`, and so on). The file's blanket `EXEMPT_SESSION_STATE_FILES` entry is replaced with a real `SESSION_STATE_REGISTRY` entry, since a real reset now exists — `_reconcileTaskRegistered` (idempotent task registration) and the `_enabledCache` kill-switch memo stay outside the registry, same as the rest of the file's registration/config-memo state.

**#1911 — quick-mode skip was silent.** Quick-mode `session_start` skips slow tool probes, language profiling, preinstall, startup scans, and the error-debt baseline. The only record of that was a debug line, and `dbg()` is suppressed in test mode (`isTestMode()`), so absence of the work and absence of the logging read identically. `session_start` now emits one bounded `session_start_skipped_steps` latency record naming the skipped step set, at the same seam as the debug line — its structured twin.

## Verification

**Red-proof.** Reverted `clients/lsp/cascade-tier.ts` and `clients/runtime-session.ts` to pre-fix (`git diff > patch`, `git checkout --`, rebuild), kept the new tests:

```
tests/clients/runtime-session-cascade-tier-reset.test.ts    1 failed
tests/index-integration.test.ts (cascade tier-3 test)       1 failed
tests/clients/runtime-session-quick-mode-observability.test.ts  1 failed (positive case), 1 passed (negative control, correctly)
```

Reapplied the patch (`git apply`), rebuilt, all green.

**Mutation-proof.** Trimmed `resetCascadeTierSessionState()` to clear only the map, not the two counters — `runtime-session-cascade-tier-reset.test.ts`'s sweep-gauge assertion (`expired: 0, evicted: 0`) went red, catching the narrower mutation. Restored, green again.

**Green, after the fix** (`npm run build` before every run):

```
tests/clients/runtime-session-cascade-tier-reset.test.ts        1 passed
tests/clients/runtime-session-quick-mode-observability.test.ts  2 passed
tests/clients/session-state-conformance.test.ts                 69 passed
tests/clients/lsp/cascade-tier.test.ts                           30 passed
tests/clients/lsp/cascade-tier-backlog.test.ts                   15 passed
tests/clients/cascade-compute.test.ts
tests/clients/cascade-turn-merge.test.ts
tests/tools/lsp-diagnostics.test.ts
tests/clients/runtime-session-dispatch-reset.test.ts
tests/index-integration.test.ts                                  34 passed
                                                          289 passed total (10 files)
```

Also ran the full `runtime-session-*.test.ts` family (13 files, 64 tests) — all pass in isolation. One unrelated file in that family, `runtime-session-scan-cache.test.ts`, flakes when run alongside a large-enough batch of unrelated test files regardless of whether my changes are present (confirmed by reproducing the same failure with a completely different file set substituted for mine) — a pre-existing worker-contention flake in a real (non-fake) 2-second warmup timer race, not a regression from this PR. Not investigated further here; flagging in case it needs its own issue.

`npm run build` and `npm run lint` (full `tsc` typecheck) both pass. Full suite is CI's job.

## A pre-existing test-isolation gap found along the way

Adding the #1910 integration test to `tests/index-integration.test.ts` surfaced two `vi.doMock` calls (for `../clients/runtime-session.js` and `../clients/installer/index.js`, both in the "session_start handler passes working ensureTool closure" test) that are never `vi.doUnmock`'d in that describe block — only a different, much later describe block unmocks them. `vi.doMock` registrations outlive `vi.resetModules()`, so any later test in the file that dynamically imports those modules silently inherits the stub. My new test worked around it with explicit `vi.doUnmock` calls and a comment naming the cause; the underlying gap in the existing test (nothing currently depends on the real modules there, so it has stayed invisible) is not fixed by this PR.

## Blast radius

- `handleSessionStart` (`clients/runtime-session.ts`) gains two calls: `resetCascadeTierSessionState()` (a `Map.clear()` plus two scalar resets — O(map size), same cost class as the other sixteen resets already in that block) and one `logLatency()` call gated inside the existing `if (quickMode)` branch (already the exit path for every other quick-mode phase record). No new spawns, no behavior widening on the full-mode path.
- `tests/support/session-state-registry.ts`: `lsp/cascade-tier.ts` moves from `EXEMPT_SESSION_STATE_FILES` to `SESSION_STATE_REGISTRY`. `SESSION_STATE_SYMBOL_COUNTS`'s pin for that file is unchanged (still 1 — no new module-level `Map`/`Set` was added, only a reset function).
- `cascade_tier3_reconcile`'s log shape in `cascade.log` is unchanged — the new reset only affects when the counters are AT ZERO, not the record's fields.
- New `session_start_skipped_steps` phase in `latency.log` on every quick-mode `session_start`. Any log reader that enumerates `phase` values gains one new value; nothing consumes it downstream yet (no dashboard/alert wired to it in this PR).

## Class sweep

**Pattern sweep** — grepped `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts` for the same shape (a module-level `Map`/`Set` with a reset function that `handleSessionStart` does not reach): `tests/support/session-state-registry.ts`'s own coverage sweep (`session-state-conformance.test.ts`) is exactly this check, repo-wide, and it is green — no other file currently in `EXEMPT_SESSION_STATE_FILES` claims a reset the way `cascade-tier.ts` did (its blanket-exempt entry was the anomaly `#1909`'s review flagged; everything else in that list is a genuine host-derivation/config-memo/registration exemption).

**Population sweep** — quiet-window task registrations (`registerQuietWindowTask` call sites), because every member accumulates state between two window firings, same shape #1909 already swept:

| Member | File:line | Verdict |
| --- | --- | --- |
| `cascade_tier3_reconcile` | `clients/lsp/cascade-tier.ts` | Fixed here (#1910) |
| `turn_summary_emit` | `index.ts:2615` | Already correct (#1909's sweep: holds a single mutable ctx object, replaced on each activation) |

Two members, both checked; no new ones found.

For #1911, the "silent skip" shape (a debug-only line describing skipped work, no structured record) was searched across `runtime-session.ts`'s other `skipping` lines (`grep -n "skipping"` — see list in the issue investigation). Every other quick-mode/full-mode skip line in that file (`skipping tool preinstall`, `skipping prettier preinstall probe`, `skipping startup background scans`, `skipping heavy scans`, `skipping TODO scan`, `skipping pre-warm` variants) already sits inside a phase whose *absence* is provable another way — either the phase never fires so no `logLatency` for it exists to compare against, or (for the LSP pre-warm skips) a sibling record already exists for the ATTEMPT path. The #1911 issue named this ONE specific line (the quick-mode aggregate skip); no sibling of the same "aggregate skip announced only in a suppressed debug line" shape was found. Deferred sweep, not exhaustive: a full per-skip-line audit of whether each one needs its own bounded record is out of this issue's scope and not filed as a follow-up here — happy to file if wanted.

## Merge order

No open PR touches `clients/lsp/cascade-tier.ts` or this region of `clients/runtime-session.ts` as far as `gh pr list` shows at branch time. No merge-order constraint identified.

## Review round 1

An adversarial review found one blocking finding and two small ones. All fixed on this branch.

- **F1 (blocking, CI-red)** — the new `session_start_skipped_steps` raw `logLatency` call matched the `#1743` bounded-telemetry sweep's failure-shape predicate (its phase name contains `_skipped_`), and had no registered bound or stated reason, so `tests/clients/bounded-telemetry-sweep.test.ts` failed. Fixed by adding it to `UNBOUNDED_FAILURE_PHASE_REASONS` (`tests/support/bounded-telemetry-scan.ts`), following the same pattern as the existing `agent_end_concurrent_secondary_skip` entry: "one record per quick-mode `session_start`, which fires at most once per session_start call," pinned by `tests/clients/runtime-session-quick-mode-observability.test.ts`. Ran the sweep plus the original ten targeted files — all green.
- **F2 (low)** — the session-state-registry probe for `cascade-tier:outstandingTouches` only armed and checked the outstanding-touch MAP, so a reviewer's mutation (trimming `resetCascadeTierSessionState` to clear only the map) stayed invisible to the probe itself, even though a separate dedicated test caught it. Added a test-only `_getCascadeTierSweepCountersForTests()` getter to `clients/lsp/cascade-tier.ts`, and rewrote the probe's `arm()`/`isArmed()` to also trip and check the expired/evicted counters (one ancient touch plus CAP+1 fresh touches). Re-ran the same mutation against the probe directly: it now reds on its own, with no dependence on the dedicated test.
- **F3 (low)** — the five-item `steps` array is a hand-maintained list next to the `dbg()` line naming the same five, with no enumerable source to derive it from (the quick path is a single early return). Added a comment stating that plainly, that it must be kept in sync by hand, and that it does not narrow under `no-lsp` (LSP has its own separate `quickTools` record).
- **F4 (cosmetic)** — the PR body's closing line said "Refs #1910, #1911" while the title said "closes"; both issues' acceptance criteria are fully met, so the body now says "Closes" to match.

The reviewer separately confirmed the timing flake mentioned above is pre-existing across multiple test files (their instance was `startup-overhead.test.ts`, mine was `runtime-session-scan-cache.test.ts`) and is being filed as its own issue — no action needed here.

Closes #1910, Closes #1911

*This PR is AI-generated, with the maintainer supervising the process.*

