### PR TITLE
fix: guard agent_settled ctx access after session replacement (closes #1924)

### DIFF
--- a/.changelog/fix-1924-agent-settled-stale-ctx.md
+++ b/.changelog/fix-1924-agent-settled-stale-ctx.md
@@ -1,0 +1,7 @@
+---
+section: Fixed
+---
+
+- **agent_settled no longer crashes with extension_error when the session is
+  replaced mid-run** — stale extension ctx reads are guarded and the ambient
+  abort signal is cleared (closes #1924; thanks @Pluto-Yt).

--- a/.changelog/fix-1924-agent-settled-stale-ctx.md
+++ b/.changelog/fix-1924-agent-settled-stale-ctx.md
@@ -2,6 +2,6 @@
 section: Fixed
 ---
 
-- **agent_settled no longer crashes with extension_error when the session is
-  replaced mid-run** — stale extension ctx reads are guarded and the ambient
-  abort signal is cleared (closes #1924; thanks @Pluto-Yt).
+- **agent_settled no longer crashes with extension_error when the session is replaced mid-run** —
+  stale extension ctx reads are guarded and the ambient abort signal is
+  cleared (closes #1924; thanks @Pluto-Yt).

--- a/index.ts
+++ b/index.ts
@@ -2710,26 +2710,40 @@ function activateExtension(hostPi: ExtensionAPI) {
 				// gets FORMATTED instead of requeued (an inversion of the #1642
 				// harm this issue exists to fix) and the requeue branches become
 				// production-unreachable.
-				setAmbientAbortSignal(ctx?.signal);
 				try {
-					await runDeferredMutationDrain(ctx);
-				} catch (drainErr) {
-					dbg(`agent_settled deferred_mutation_drain crashed: ${drainErr}`);
-				} finally {
+					setAmbientAbortSignal(ctx?.signal);
+					try {
+						await runDeferredMutationDrain(ctx);
+					} catch (drainErr) {
+						if (isStaleExtensionCtxError(drainErr)) {
+							dbg("agent_settled deferred_mutation_drain skipped: session context is stale");
+							return;
+						}
+						dbg(`agent_settled deferred_mutation_drain crashed: ${drainErr}`);
+					} finally {
+						setAmbientAbortSignal(undefined);
+					}
+					const cwd = ctx?.cwd;
+					void runQuietWindow({
+						runtime,
+						dbg,
+						cwd,
+					}).catch((err) => {
+						dbg(`quiet_window crashed: ${err}`);
+					});
+					// #1123 item 4: dump active handles AFTER the quiet-window work is
+					// scheduled — the #1097-class leak (a stray ref'd timer surviving
+					// past settle) is only visible once whatever settle itself queued is
+					// already in flight. No-op unless PI_LENS_DEBUG_HANDLES=1.
+					dumpActiveHandles("agent_settled");
+				} catch (settledErr) {
 					setAmbientAbortSignal(undefined);
+					if (isStaleExtensionCtxError(settledErr)) {
+						dbg("agent_settled skipped: session context was replaced or reloaded");
+						return;
+					}
+					throw settledErr;
 				}
-				void runQuietWindow({
-					runtime,
-					dbg,
-					cwd: ctx?.cwd,
-				}).catch((err) => {
-					dbg(`quiet_window crashed: ${err}`);
-				});
-				// #1123 item 4: dump active handles AFTER the quiet-window work is
-				// scheduled — the #1097-class leak (a stray ref'd timer surviving
-				// past settle) is only visible once whatever settle itself queued is
-				// already in flight. No-op unless PI_LENS_DEBUG_HANDLES=1.
-				dumpActiveHandles("agent_settled");
 			},
 		);
 	} catch (registerErr) {

--- a/tests/index-integration.test.ts
+++ b/tests/index-integration.test.ts
@@ -534,6 +534,44 @@ describe("index.ts integration", () => {
 			// finally-block clear).
 			expect(getAmbientAbortSignal()).toBeUndefined();
 		}, INTEGRATION_TIMEOUT_MS);
+
+		it("agent_settled resolves (does not crash with extension_error) when the ctx has gone stale after a session replacement (#1924)", async () => {
+			// #1924: a session replace/reload (ctx.newSession/fork/switchSession/
+			// reload) invalidates the captured ctx mid-run. The next
+			// `agent_settled` firing hands the handler a ctx whose every
+			// property getter throws the SDK's stale-ctx signature. Pre-fix,
+			// `setAmbientAbortSignal(ctx?.signal)` ran with no enclosing
+			// try/catch, so that throw propagated straight out of the async
+			// handler and the host logged an `extension_error`. Post-fix, the
+			// whole body is wrapped and `isStaleExtensionCtxError` degrades it
+			// to a no-op.
+			const handleAgentEndMock = vi.fn(async () => undefined);
+			mockDrainDeps(handleAgentEndMock);
+
+			const { default: registerExtension } = await import("../index.js");
+			const { getAmbientAbortSignal } = await import(
+				"../clients/safe-spawn.js"
+			);
+			const { pi, handlers } = createMockPi();
+			registerExtension(pi as any);
+
+			const STALE_MSG =
+				"This extension ctx is stale after session replacement or reload";
+			const staleCtx = {};
+			for (const prop of ["signal", "cwd", "ui", "sessionManager"]) {
+				Object.defineProperty(staleCtx, prop, {
+					enumerable: true,
+					get() {
+						throw new Error(STALE_MSG);
+					},
+				});
+			}
+
+			const settled = handlers.agent_settled?.[0];
+			expect(settled).toBeTypeOf("function");
+			await expect(settled?.({}, staleCtx)).resolves.toBeUndefined();
+			expect(getAmbientAbortSignal()).toBeUndefined();
+		}, INTEGRATION_TIMEOUT_MS);
 	});
 
 	it("idle LSP reset repaints the footer to Inactive (detached 240s timer)", async () => {


### PR DESCRIPTION
## Summary
- guard `agent_settled` context access after session replacement or reload
- safely skip deferred mutation draining and quiet-window scheduling when the callback context is stale
- preserve cleanup of the ambient abort signal

## Verification
- `npm run lint`
- reproduced the original `pi-goal` + `pi-lens` RPC flow; no `extension_error` is emitted
- verified `get_diagnostics` still executes successfully