### PR TITLE
chore: exempt Claude sessions from git hooks via PI_LENS_SKIP_HOOKS (refs #1804)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "PI_LENS_SKIP_HOOKS": "1"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ AGENTS.md
 .claude/*
 !.claude/agents/
 !.claude/agents/*.md
+!.claude/settings.json
 !.claude/skills/
 !.claude/skills/**
 !.claude/skills/**/*.md


### PR DESCRIPTION
## What

Checked-in `.claude/settings.json` with `PI_LENS_SKIP_HOOKS=1` in `env`, plus the `.gitignore` negation to carry it. Every Claude Code session in this repo (orchestrator and subagents inherit the env) now skips the husky pre-commit and pre-push hooks; human checkouts outside Claude keep them.

## Why

Closes the parked F3 from the #1916 review: the hooks PR documented an agent escape hatch that nothing wired. The permission classifier correctly blocked agents from writing settings files, so this lands maintainer-approved. Refs #1804.

## Verification

- `git check-ignore .claude/settings.json` no longer matches after the `.gitignore` negation.
- Hook-skip behavior itself was proven in #1916's review (any non-empty `PI_LENS_SKIP_HOOKS` skips both hooks, tested via real `sh .husky/pre-commit` spawns).
- No changelog fragment: repo-internal tooling config, not user-facing (same call as #1923).

Maintainer-approved settings change (explicit user instruction; classifier gate deliberately overridden by the maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
