### PR TITLE
docs: codify issue body shape and harden the em-dash rule (refs #1844)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2020,13 +2020,13 @@ Short, obvious changes may use a subject only. Non-trivial changes get a body.
 - Define an acronym on first use. Prefer a plain word over jargon when one exists.
 - Avoid gerund or noun pile-ups and ambiguous constructions. Avoid `please`. Use the Oxford comma.
 - Limit em-dashes to one per paragraph, and prefer zero in anything posted to GitHub. Use periods, colons, and commas instead. Do not nest parentheticals. A sentence that wants two dashes wants to be two sentences.
-- These rules are machine-checkable. Pi-lens ships a config-gated Vale runner (`clients/dispatch/runners/vale.js`). A `.vale.ini` with the Google style package would enforce this section automatically; track that separately.
+- These rules are machine-checkable. Pi-lens ships a config-gated Vale runner (`clients/dispatch/runners/vale.js`). A `.vale.ini` with the Google style package would enforce this section automatically; tracked as the Vale lane of #1844's mechanical wave.
 
 **The standard also governs how agents talk to the maintainer.** Chat replies, status updates, and reports follow the same Zinsser frame. Lead with the outcome. Strip words that do no work. Prefer short sentences over dense em-dash chains. Clarity beats brevity when they conflict. Write like a person, not a system emitting a report.
 
 ### Issue bodies
 
-**Every issue follows one shape, in this order.** Each part is one short section or a few sentences, not a form to pad.
+**Every agent- or maintainer-authored issue follows one shape, in this order.** Each part is one short section or a few sentences, not a form to pad. Contributor issues filed through the GitHub UI follow the forms in `.github/ISSUE_TEMPLATE/` instead; triage maps them onto this shape when an agent picks them up.
 
 1. Evidence first. Measured numbers, quoted output, exact paths, and file:line references. The reader must see the defect before any interpretation of it.
 2. Root cause, or a hypothesis labeled as one. Never present a guess as a finding.
@@ -2034,7 +2034,7 @@ Short, obvious changes may use a subject only. Non-trivial changes get a body.
 4. The observability record. Name the log record that proves the behavior after the fix ships, or name the gap (see the observability assessment section).
 5. Cross-links. Name class siblings, the defect shape when it matches the catalog, and any PR or review that produced the evidence.
 
-Label at creation with type and area. Keep the language rules above: short sentences, and no em-dashes outside list markers.
+Label at creation with type and area. Keep the language rules above: short sentences, and no em-dashes except as the label separator in a bullet list.
 
 ## Observability assessment
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2010,7 +2010,7 @@ Short, obvious changes may use a subject only. Non-trivial changes get a body.
 
 ### Documentation and prose style
 
-**Prose in docs, changelog, and PR descriptions follows the [Google developer documentation style guide](https://developers.google.com/style) and [Simplified Technical English (ASD-STE100) principles](https://asd-ste100.org/), framed by Zinsser's four principles from *On Writing Well*: simplicity, brevity, clarity, and humanity.** Zinsser is the spirit; the two guides below are the mechanics. This is a principles-only adoption of ASD-STE100, a proprietary aerospace controlled-language specification; it does not adopt its licensed word list. Apply this standard to `README`, `docs/`, `AGENTS.md`, changelog entries, and PR bodies:
+**Prose in docs, changelog, and PR descriptions follows the [Google developer documentation style guide](https://developers.google.com/style) and [Simplified Technical English (ASD-STE100) principles](https://asd-ste100.org/), framed by Zinsser's four principles from *On Writing Well*: simplicity, brevity, clarity, and humanity.** Zinsser is the spirit; the two guides below are the mechanics. This is a principles-only adoption of ASD-STE100, a proprietary aerospace controlled-language specification; it does not adopt its licensed word list. Apply this standard to `README`, `docs/`, `AGENTS.md`, changelog entries, PR bodies, issue bodies, and issue and PR comments:
 
 - Use active voice and present tense.
 - Use second person (`you`) for instructions. Use the imperative for procedure steps.
@@ -2019,9 +2019,22 @@ Short, obvious changes may use a subject only. Non-trivial changes get a body.
 - Use sentence case for headings.
 - Define an acronym on first use. Prefer a plain word over jargon when one exists.
 - Avoid gerund or noun pile-ups and ambiguous constructions. Avoid `please`. Use the Oxford comma.
+- Limit em-dashes to one per paragraph, and prefer zero in anything posted to GitHub. Use periods, colons, and commas instead. Do not nest parentheticals. A sentence that wants two dashes wants to be two sentences.
 - These rules are machine-checkable. Pi-lens ships a config-gated Vale runner (`clients/dispatch/runners/vale.js`). A `.vale.ini` with the Google style package would enforce this section automatically; track that separately.
 
 **The standard also governs how agents talk to the maintainer.** Chat replies, status updates, and reports follow the same Zinsser frame. Lead with the outcome. Strip words that do no work. Prefer short sentences over dense em-dash chains. Clarity beats brevity when they conflict. Write like a person, not a system emitting a report.
+
+### Issue bodies
+
+**Every issue follows one shape, in this order.** Each part is one short section or a few sentences, not a form to pad.
+
+1. Evidence first. Measured numbers, quoted output, exact paths, and file:line references. The reader must see the defect before any interpretation of it.
+2. Root cause, or a hypothesis labeled as one. Never present a guess as a finding.
+3. Acceptance criteria that a test can decide. "Each handler tolerates a stale ctx, with one probe test per handler, red on pre-fix code" decides; "improve robustness" does not.
+4. The observability record. Name the log record that proves the behavior after the fix ships, or name the gap (see the observability assessment section).
+5. Cross-links. Name class siblings, the defect shape when it matches the catalog, and any PR or review that produced the evidence.
+
+Label at creation with type and area. Keep the language rules above: short sentences, and no em-dashes outside list markers.
 
 ## Observability assessment
 


### PR DESCRIPTION
## What

Three edits to AGENTS.md's writing conventions:

1. The scope line now names issue bodies and issue and PR comments alongside docs, changelog entries, and PR bodies.
2. A hard em-dash rule: one per paragraph at most, zero preferred in posted text, no nested parentheticals.
3. A new "Issue bodies" subsection: five parts in order (evidence, root cause or labeled hypothesis, testable acceptance criteria, observability record, cross-links), plus label-at-creation.

## Why

Two maintainer audits (2026-08-15 and 2026-08-21) found the same drift in posted text: em-dash chains and long sentences. The issue-body shape existed only as practice, so workers could not be held to it. Refs #1844 (the Vale lane in the mechanical wave will machine-check the prose rules; this PR gives it the text to enforce).

## Verification

Docs-only diff. No changelog fragment: repo-internal conventions, same call as #1914. CI must show Lint and Unit tests executing on the head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
