### PR TITLE
fix: skip markdownlint for files outside project root

### DIFF
--- a/clients/cache-observability.ts
+++ b/clients/cache-observability.ts
@@ -65,6 +65,7 @@ export type CacheContextPlacement =
 	| "prepend"
 	| "insert-before-final"
 	| "append"
+	| "steer"
 	| "none";
 export type CachePrefixObservation =
 	| "baseline"
@@ -262,7 +263,7 @@ function prefixLengthForPlacement(
 	if (placement === "insert-before-final") {
 		return Math.max(0, messageCount - 1);
 	}
-	if (placement === "prepend") return 0;
+	if (placement === "prepend" || placement === "steer") return 0;
 	return messageCount;
 }
 
@@ -325,10 +326,7 @@ export function observeCacheContext(args: {
 			placement,
 			existingMessages.length,
 		);
-		const afterPrefixLength = Math.min(
-			beforePrefixLength,
-			resultMessages.length,
-		);
+		const afterPrefixLength = Math.min(beforePrefixLength, resultMessages.length);
 		const beforePrefix = hashMessageSequence(
 			existingMessages.slice(0, beforePrefixLength),
 		);
@@ -382,8 +380,7 @@ export function observeCacheContext(args: {
 					injectedMessages.length,
 					MAX_REPORTED_MESSAGES,
 				),
-				injectedMessageCountCapped:
-					injectedMessages.length > MAX_REPORTED_MESSAGES,
+				injectedMessageCountCapped: injectedMessages.length > MAX_REPORTED_MESSAGES,
 				injectedChars: sizes.chars,
 				injectedBytes: sizes.bytes,
 				injectedCountsCapped: sizes.capped,
@@ -391,10 +388,7 @@ export function observeCacheContext(args: {
 					existingMessages.length,
 					MAX_REPORTED_MESSAGES,
 				),
-				resultMessageCount: Math.min(
-					resultMessages.length,
-					MAX_REPORTED_MESSAGES,
-				),
+				resultMessageCount: Math.min(resultMessages.length, MAX_REPORTED_MESSAGES),
 				messageCountCapped,
 				placement,
 				prefixObservation,

--- a/clients/diagnostic-dispositions.ts
+++ b/clients/diagnostic-dispositions.ts
@@ -1,6 +1,6 @@
 /**
  * Agent+user disposition layer over dispatch diagnostics (#690, unifying #181/
- * #503/#504's discussion). Four dispositions:
+ * #503/#504's discussion). Five dispositions:
  *
  *   false-positive — the rule misfired. Project-persistent, routed nowhere
  *                     special yet (telemetry hookup is a fast-follow).
@@ -17,6 +17,10 @@
  *                     resolved; surfaced through the existing lens_diagnostics
  *                     query (tagged), not a separate file/tool the agent has
  *                     to separately poll.
+ *   info           — real finding, but informational only. Persistent,
+ *                     filters from steering/injection; weak-anchored so it
+ *                     survives incidental edits. Does not write an inline
+ *                     comment; the agent simply won't see it in context.
  *
  * Anchoring: TWO flavors, chosen per-disposition because each one binds to a
  * different thing conceptually:
@@ -30,12 +34,12 @@
  *     anchor, while a semantic edit to the flagged line correctly invalidates
  *     it.
  *   WEAK ("ddw:" prefix) — relativeFile|tool|rule|normalizedMessage, no line
- *     hash at all. Used for defer, flagged, and suppress: these are
+ *     hash at all. Used for defer, flagged, suppress, and info: these are
  *     intent-level judgments ("I'll get to this", "fix this", "policy says
- *     don't") about a finding identity, not about one exact line's bytes —
- *     they must survive incidental edits elsewhere on the flagged line
- *     (reformatting, a nearby rename) without silently dropping the mark.
- *     suppress's real enforcement is the inline comment (see
+ *     don't", "informational only") about a finding identity, not about one
+ *     exact line's bytes — they must survive incidental edits elsewhere on the
+ *     flagged line (reformatting, a nearby rename) without silently dropping
+ *     the mark. suppress's real enforcement is the inline comment (see
  *     suppress-writer.ts) which travels with the code by construction; the
  *     weak-anchored store entry is just an audit mirror plus a second,
  *     belt-and-braces filter.
@@ -74,7 +78,12 @@ export interface DispositionCandidate {
 	line?: number;
 }
 
-export type Disposition = "false-positive" | "suppress" | "defer" | "flagged";
+export type Disposition =
+	| "false-positive"
+	| "suppress"
+	| "defer"
+	| "flagged"
+	| "info";
 export type PersistedDisposition = Exclude<Disposition, "defer">;
 
 export interface DispositionEntry {
@@ -447,16 +456,26 @@ export function markDisposition(
 	const existing = readState(cwd).dispositions?.[anchor];
 	if (disposition === "defer") {
 		deferredThisSession.add(anchor);
-		emitMarkTelemetry(cwd, target, disposition, anchor, reason, existing, identity);
+		emitMarkTelemetry(
+			cwd,
+			target,
+			disposition,
+			anchor,
+			reason,
+			existing,
+			identity,
+		);
 		return anchor;
 	}
 
 	const now = new Date().toISOString();
 	const capturesFixContext = disposition === "flagged";
 	const lineText = capturesFixContext
-		? (target.content?.split(/\r?\n/)[
-				target.line !== undefined ? target.line - 1 : -1
-			] ?? existing?.lineText)?.trim()
+		? (
+				target.content?.split(/\r?\n/)[
+					target.line === undefined ? -1 : target.line - 1
+				] ?? existing?.lineText
+			)?.trim()
 		: existing?.lineText;
 	const entry: DispositionEntry = {
 		disposition,
@@ -467,7 +486,15 @@ export function markDisposition(
 		lineText,
 	};
 	commitDisposition(cwd, anchor, entry);
-	emitMarkTelemetry(cwd, target, disposition, anchor, reason, existing, identity);
+	emitMarkTelemetry(
+		cwd,
+		target,
+		disposition,
+		anchor,
+		reason,
+		existing,
+		identity,
+	);
 	return anchor;
 }
 
@@ -489,13 +516,13 @@ export function _resetDeferredForTests(): void {
 }
 
 /**
- * Drop diagnostics disposed false-positive/suppress, or deferred this session,
+ * Drop diagnostics disposed false-positive/suppress/info, or deferred this session,
  * from `diagnostics`. `flagged` diagnostics are kept as-is — callers that want
  * to surface the flag (e.g. lens_diagnostics' rendering) look it up separately
  * via getDisposition on the WEAK anchor (anchorsForDiagnostic(...).weak).
  *
  * Computes both anchors per diagnostic (cheap — same hash primitive, twice)
- * since false-positive is keyed strict while defer/suppress are keyed weak;
+ * since false-positive is keyed strict while defer/suppress/info are keyed weak;
  * see module doc for why each disposition binds the way it does.
  */
 export function applyDispositions<T extends DispositionCandidate>(
@@ -516,13 +543,14 @@ export function applyDispositions<T extends DispositionCandidate>(
 		// dropped this finding upstream via applyInlineSuppressions. This is a
 		// harmless second cover for the store-only audit trail case.
 		if (dispositions?.[weak]?.disposition === "suppress") return false;
+		if (dispositions?.[weak]?.disposition === "info") return false;
 		return true;
 	});
 }
 
 /**
  * WEAK-anchor-only disposition filter for the "instant" (cache-only)
- * lens_diagnostics modes (delta/all). Drops diagnostics disposed `suppress`
+ * lens_diagnostics modes (delta/all). Drops diagnostics disposed `suppress`/`info`
  * or deferred this session — both WEAK-anchored (`file|tool|rule|message`, no
  * line-content hash; see module doc), so this needs ZERO file I/O: it computes
  * only the weak anchor and never touches the diagnostic's line content.
@@ -533,7 +561,7 @@ export function applyDispositions<T extends DispositionCandidate>(
  * cache-only modes. A false-positive mark still filters at the next per-edit
  * dispatch (`dispatcher.ts`) and in `mode=full`'s merge — both of which already
  * have file content in hand and call `applyDispositions` (the full,
- * content-based filter). suppress/defer, being intent-level and weak-anchored,
+ * content-based filter). suppress/defer/info, being intent-level and weak-anchored,
  * are the marks that must apply the instant a query re-serves cached findings,
  * and they do so here without any read.
  */
@@ -556,6 +584,7 @@ export function applyWeakDispositions<T extends DispositionCandidate>(
 		});
 		if (deferredThisSession.has(weak)) return false;
 		if (dispositions?.[weak]?.disposition === "suppress") return false;
+		if (dispositions?.[weak]?.disposition === "info") return false;
 		return true;
 	});
 }

--- a/clients/dispatch/runners/markdownlint.ts
+++ b/clients/dispatch/runners/markdownlint.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { safeSpawnAsync } from "../../safe-spawn.js";
 import {
 	getLinterPolicyForCwd,
@@ -106,11 +107,19 @@ const markdownlintRunner: RunnerDefinition = {
 	async run(ctx: DispatchContext): Promise<RunnerResult> {
 		const cwd = ctx.cwd || process.cwd();
 		const policy = getLinterPolicyForCwd(ctx.filePath, cwd);
+
+		// Skip files outside the project root to avoid linting random files on the user's Desktop/etc.
+		const resolvedFilePath = path.resolve(ctx.filePath);
+		const resolvedCwd = path.resolve(cwd);
+		const relative = path.relative(resolvedCwd, resolvedFilePath);
+		if (relative.startsWith("..") || path.isAbsolute(relative)) {
+			return { status: "skipped", diagnostics: [], semantic: "none" };
+		}
 		if (policy && !policy.preferredRunners.includes("markdownlint")) {
 			return { status: "skipped", diagnostics: [], semantic: "none" };
 		}
 		let cmd: string | null = null;
-		if (await (markdownlint.isAvailableAsync(cwd))) {
+		if (await markdownlint.isAvailableAsync(cwd)) {
 			cmd = markdownlint.getCommand(cwd);
 		} else {
 			cmd = await resolveToolCommandWithInstallFallback(cwd, "markdownlint");

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -10,6 +10,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
 import { logSessionStart } from "../../../sessionstart-logger.js";
 import { getGlobalPiLensDir } from "../../../file-utils.js";
 import { PathKeyedMap } from "../../../path-keyed-map.js";
@@ -263,7 +264,9 @@ export async function getManagedToolEnvironment(
 }
 
 /** Read-only managed/PATH discovery for spawn-time resolution memos. */
-export async function discoverManagedTool(toolId: string): Promise<string | null> {
+export async function discoverManagedTool(
+	toolId: string,
+): Promise<string | null> {
 	return (await ensureTool(toolId, { allowInstall: false })) ?? null;
 }
 
@@ -388,7 +391,12 @@ export function createAvailabilityChecker(
 
 	function getCache(cwd: string): AvailabilityCache {
 		ensureCurrentGeneration();
-		const key = path.resolve(cwd || process.cwd());
+		const resolvedCwd = path.resolve(cwd || process.cwd());
+		const pathHash = createHash("sha256")
+			.update(process.env.PATH ?? "")
+			.digest("hex")
+			.slice(0, 8);
+		const key = `${resolvedCwd}|${pathHash}`;
 		const existing = cacheByCwd.get(key);
 		if (existing) return existing;
 		const created: AvailabilityCache = {
@@ -429,10 +437,7 @@ export function createAvailabilityChecker(
 			cache.transientAttempts = 0;
 		} else {
 			cache.transientAttempts += 1;
-			retryAfterMs = transientRetryDelayMs(
-				cache.transientAttempts,
-				verdict.cause,
-			);
+			retryAfterMs = transientRetryDelayMs(cache.transientAttempts, verdict.cause);
 			cache.retryAtMs = Date.now() + retryAfterMs;
 		}
 		logAvailabilityDecision(
@@ -834,16 +839,18 @@ export function resolveAvailableOrInstall(
 	if (existing) return existing;
 
 	const generation = availabilityStateGeneration;
-	const promise = resolveAvailableOrInstallUnshared(checker, toolId, cwd).finally(
-		() => {
-			if (generation !== availabilityStateGeneration) return;
-			const current = resolveInstallInFlightByCwd.get(key);
-			if (current?.get(toolId) === promise) {
-				current.delete(toolId);
-				if (current.size === 0) resolveInstallInFlightByCwd.delete(key);
-			}
-		},
-	);
+	const promise = resolveAvailableOrInstallUnshared(
+		checker,
+		toolId,
+		cwd,
+	).finally(() => {
+		if (generation !== availabilityStateGeneration) return;
+		const current = resolveInstallInFlightByCwd.get(key);
+		if (current?.get(toolId) === promise) {
+			current.delete(toolId);
+			if (current.size === 0) resolveInstallInFlightByCwd.delete(key);
+		}
+	});
 	byTool.set(toolId, promise);
 	return promise;
 }
@@ -959,7 +966,9 @@ export async function isSgAvailableAsync(): Promise<boolean> {
 		// 1. Local node_modules/.bin
 		for (const localBin of buildSgLocalBins()) {
 			if (await probeAstGrepCommandAsync(localBin)) {
-				sgCmd = localBin; sgCmdArgs = []; noteSgAvailable(startedAt);
+				sgCmd = localBin;
+				sgCmdArgs = [];
+				noteSgAvailable(startedAt);
 				return true;
 			}
 		}
@@ -967,7 +976,9 @@ export async function isSgAvailableAsync(): Promise<boolean> {
 		// 2. Global PATH
 		for (const cmd of ["ast-grep", "sg"]) {
 			if (await probeAstGrepCommandAsync(cmd)) {
-				sgCmd = cmd; sgCmdArgs = []; noteSgAvailable(startedAt);
+				sgCmd = cmd;
+				sgCmdArgs = [];
+				noteSgAvailable(startedAt);
 				return true;
 			}
 		}
@@ -977,14 +988,18 @@ export async function isSgAvailableAsync(): Promise<boolean> {
 		for (const name of ["ast-grep", "sg"]) {
 			const globalBin = await findGlobalBinary(name);
 			if (globalBin && (await probeAstGrepCommandAsync(globalBin))) {
-				sgCmd = globalBin; sgCmdArgs = []; noteSgAvailable(startedAt);
+				sgCmd = globalBin;
+				sgCmdArgs = [];
+				noteSgAvailable(startedAt);
 				return true;
 			}
 		}
 
 		// 3. npx --no (cache-only, no silent download).
 		if (await probeAstGrepCommandAsync("npx", ["--no", "--", "ast-grep"])) {
-			sgCmd = "npx"; sgCmdArgs = ["--no", "--", "ast-grep"]; noteSgAvailable(startedAt);
+			sgCmd = "npx";
+			sgCmdArgs = ["--no", "--", "ast-grep"];
+			noteSgAvailable(startedAt);
 			return true;
 		}
 

--- a/clients/lens-config.ts
+++ b/clients/lens-config.ts
@@ -98,6 +98,14 @@ export interface PiLensGlobalConfig {
 		 * messages. Findings are still cached for `lens_diagnostics` / `/lens-health`.
 		 */
 		enabled?: boolean;
+		/**
+		 * How findings are delivered when enabled. `"inject"` (default) prepends
+		 * findings into the transcript via the `context` hook. `"steer"` sends
+		 * findings as a steer message via `pi.sendUserMessage` so they land after
+		 * the current assistant turn finishes its tool calls instead of interrupting
+		 * the prompt cache.
+		 */
+		mode?: "inject" | "steer";
 	};
 	turnSummary?: {
 		/**
@@ -238,6 +246,25 @@ export function loadPiLensGlobalConfig(
 					warnInvalid('format.mode must be "immediate" or "deferred"');
 				}
 				formatSection.mode = undefined;
+			}
+		}
+
+		const contextInjection = asConfigObject(raw.contextInjection);
+		if (contextInjection) {
+			config.contextInjection ??= {};
+			const ciSection = config.contextInjection as Record<string, unknown>;
+			if (
+				contextInjection.mode === "inject" ||
+				contextInjection.mode === "steer"
+			) {
+				ciSection.mode = contextInjection.mode;
+			} else {
+				// #533: a present-but-invalid mode warns and falls back; an
+				// absent mode stays silent.
+				if ("mode" in contextInjection) {
+					warnInvalid('contextInjection.mode must be "inject" or "steer"');
+				}
+				ciSection.mode = undefined;
 			}
 		}
 

--- a/clients/mcp/review.ts
+++ b/clients/mcp/review.ts
@@ -55,6 +55,7 @@ export function analyzeFileFresh(
 	return new Promise((resolve) => {
 		const args = [workerPath, `--file=${file}`, `--cwd=${cwd}`];
 		if (options.flags) args.push(`--flags=${JSON.stringify(options.flags)}`);
+		if (options.ownerId) args.push(`--ownerId=${options.ownerId}`);
 
 		let child: ChildProcessByStdio<null, Readable, Readable>;
 		try {

--- a/clients/runtime-context.ts
+++ b/clients/runtime-context.ts
@@ -55,17 +55,37 @@ function historicalPrefix(provenance: AdvisoryProvenance | undefined): string {
 	return `Historical finding; workspace changed since capture; re-run to confirm. (${provenanceStamp(provenance)})`;
 }
 
-function historicalTestContent(content: string, provenance?: AdvisoryProvenance): string {
+function historicalTestContent(
+	content: string,
+	provenance?: AdvisoryProvenance,
+): string {
 	return content.startsWith("[from a prior turn")
 		? content
 		: `${historicalPrefix(provenance)}\n\n${content}`;
+}
+
+/**
+ * Check if content is purely advisory/noise that should be skipped in steer mode.
+ * Returns true if the content is non-actionable operational noise.
+ */
+function isAdvisoryOnlyContent(content: string): boolean {
+	const trimmed = content.trim();
+	return (
+		/^\s*[ℹ️⚠️]?\s*Advisory — no action required/i.test(trimmed) ||
+		/^\s*[ℹ️⚠️]?\s*Cascade could not compute/i.test(trimmed) ||
+		/^\s*pi-lens: \d+ file\(s\) were/i.test(trimmed)
+	);
 }
 
 function turnEndMessage(
 	content: string,
 	current: boolean,
 	provenance?: AdvisoryProvenance,
-): { role: "user"; content: string } {
+): { role: "user"; content: string } | undefined {
+	// Skip purely advisory/noise content — it's not actionable.
+	if (isAdvisoryOnlyContent(content)) {
+		return undefined;
+	}
 	return {
 		role: "user",
 		content: current
@@ -87,15 +107,16 @@ export function peekTurnEndFindings(
 	);
 	if (!findings?.data?.content || findings.data.consumed === true) return;
 	const validation = validateAdvisoryProvenance(findings.data, cwd, runtime);
-	if (logDelivery) logProvenanceDecision(validation, findings.data.provenance, "turn-end", cwd);
+	if (logDelivery)
+		logProvenanceDecision(validation, findings.data.provenance, "turn-end", cwd);
 	if (validation.allFilesDeleted) return;
-	return {
-		messages: [turnEndMessage(
-			findings.data.content,
-			validation.status === "current",
-			findings.data.provenance,
-		)],
-	};
+	const msg = turnEndMessage(
+		findings.data.content,
+		validation.status === "current",
+		findings.data.provenance,
+	);
+	if (!msg) return undefined;
+	return { messages: [msg] };
 }
 
 export function consumeTurnEndFindings(
@@ -127,13 +148,13 @@ export function consumeTurnEndFindings(
 		cacheManager.clearCache("turn-end-findings", cwd);
 	}
 	if (validation.allFilesDeleted) return;
-	return {
-		messages: [turnEndMessage(
-			findings.data.content,
-			validation.status === "current",
-			findings.data.provenance,
-		)],
-	};
+	const msg = turnEndMessage(
+		findings.data.content,
+		validation.status === "current",
+		findings.data.provenance,
+	);
+	if (!msg) return undefined;
+	return { messages: [msg] };
 }
 
 /** Read test findings without consuming them; used by acknowledged IPC delivery. */
@@ -149,7 +170,13 @@ export function peekTestFindings(
 	);
 	if (!findings?.data?.content) return;
 	const validation = validateAdvisoryProvenance(findings.data, cwd, runtime);
-	if (logDelivery) logProvenanceDecision(validation, findings.data.provenance, "test-findings", cwd);
+	if (logDelivery)
+		logProvenanceDecision(
+			validation,
+			findings.data.provenance,
+			"test-findings",
+			cwd,
+		);
 	if (validation.allFilesDeleted) return;
 	const current = validation.status === "current";
 	return {
@@ -169,7 +196,10 @@ export function consumeTestFindings(
 	cwd: string,
 	runtime?: RuntimeCoordinator,
 ): ContextResult | undefined {
-	const record = cacheManager.readCache<TestRunnerFindingsCache>("test-runner-findings", cwd);
+	const record = cacheManager.readCache<TestRunnerFindingsCache>(
+		"test-runner-findings",
+		cwd,
+	);
 	if (!record?.data?.content) return;
 	const findings = peekTestFindings(cacheManager, cwd, runtime, true);
 	if (!findings) return;
@@ -184,25 +214,47 @@ export function consumeTestFindings(
 	)?.data?.testRunGeneration;
 	cacheManager.writeCache(
 		"test-runner-findings",
-		{ content: "", testRunGeneration: priorGeneration } as TestRunnerFindingsCache,
+		{
+			content: "",
+			testRunGeneration: priorGeneration,
+		} as TestRunnerFindingsCache,
 		cwd,
 	);
 	return findings;
 }
 
 /** Complete an acknowledged MCP delivery without re-validating or re-rendering it. */
-export function acknowledgeTurnEndFindings(cacheManager: CacheManager, cwd: string): void {
-	const findings = cacheManager.readCache<Partial<TurnEndFindingsCache>>("turn-end-findings", cwd);
+export function acknowledgeTurnEndFindings(
+	cacheManager: CacheManager,
+	cwd: string,
+): void {
+	const findings = cacheManager.readCache<Partial<TurnEndFindingsCache>>(
+		"turn-end-findings",
+		cwd,
+	);
 	if (!findings?.data?.content || findings.data.consumed === true) return;
-	if (findings.data.hasBlockers === true && typeof findings.data.sessionId === "string") {
-		cacheManager.writeCache("turn-end-findings", { ...findings.data, consumed: true }, cwd);
+	if (
+		findings.data.hasBlockers === true &&
+		typeof findings.data.sessionId === "string"
+	) {
+		cacheManager.writeCache(
+			"turn-end-findings",
+			{ ...findings.data, consumed: true },
+			cwd,
+		);
 	} else {
 		cacheManager.clearCache("turn-end-findings", cwd);
 	}
 }
 
-export function acknowledgeTestFindings(cacheManager: CacheManager, cwd: string): void {
-	const findings = cacheManager.readCache<TestRunnerFindingsCache>("test-runner-findings", cwd);
+export function acknowledgeTestFindings(
+	cacheManager: CacheManager,
+	cwd: string,
+): void {
+	const findings = cacheManager.readCache<TestRunnerFindingsCache>(
+		"test-runner-findings",
+		cwd,
+	);
 	if (!findings?.data?.content) return;
 	// Same high-water-mark preservation as consumeTestFindings.
 	cacheManager.writeCache(

--- a/config/markdownlint/core.json
+++ b/config/markdownlint/core.json
@@ -2,5 +2,10 @@
   "MD013": false,
   "MD024": {
     "siblings_only": true
-  }
+  },
+  "ignore": [
+    "**/Desktop/**",
+    "**/Downloads/**",
+    "**/Documents/**"
+  ]
 }

--- a/index.ts
+++ b/index.ts
@@ -26,7 +26,10 @@ import {
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { createDefaultHostPorts, type HostPorts } from "./clients/host-ports.js";
+import {
+	createDefaultHostPorts,
+	type HostPorts,
+} from "./clients/host-ports.js";
 import { AstGrepClient } from "./clients/ast-grep-client.js";
 import { loadBootstrapClients } from "./clients/bootstrap.js";
 import { CacheManager } from "./clients/cache-manager.js";
@@ -55,13 +58,17 @@ import {
 	sessionStartMode,
 } from "./clients/session-state-store.js";
 import { getDiagnosticTracker } from "./clients/diagnostic-tracker.js";
-import { warmDispatchIntegration, loadDispatchIntegration } from "./clients/dispatch/lazy.js";
+import {
+	warmDispatchIntegration,
+	loadDispatchIntegration,
+} from "./clients/dispatch/lazy.js";
 import {
 	getFormatService,
 	resetFormatService,
 } from "./clients/format-service.js";
 import { getAllToolStatuses } from "./clients/installer/index.js";
 import {
+	getPiLensGlobalConfigPath,
 	loadPiLensGlobalConfig,
 	resolvePiLensFlag,
 	resolvePiLensFlagWithSource,
@@ -203,11 +210,17 @@ type DispatchIntegration = Awaited<ReturnType<typeof loadDispatchIntegration>>;
 let loadedDispatchIntegration: DispatchIntegration | undefined;
 
 function warmDispatchAtSessionStart(): void {
-	void warmDispatchIntegration().then((integration) => {
-		loadedDispatchIntegration = integration;
-	}).catch((err) => {
-		logExtension({ subsystem: "dispatch", level: "warn", message: `dispatch warm failed: ${err}` });
-	});
+	void warmDispatchIntegration()
+		.then((integration) => {
+			loadedDispatchIntegration = integration;
+		})
+		.catch((err) => {
+			logExtension({
+				subsystem: "dispatch",
+				level: "warn",
+				message: `dispatch warm failed: ${err}`,
+			});
+		});
 }
 
 function resetDispatchBaselines(cwd?: string): void {
@@ -357,17 +370,31 @@ export function createHostPorts(
 			// their per-subsystem files, NOT extension.log) is S4 scope; this
 			// placeholder exists so the interface is complete for contract tests.
 			sink: (subsystem) => (entry) =>
-				logExtension({ subsystem, level: "debug", message: "host sink entry", metadata: { entry } }),
+				logExtension({
+					subsystem,
+					level: "debug",
+					message: "host sink entry",
+					metadata: { entry },
+				}),
 		},
 		emit: { bus: emit },
 		status: { set: (name, value) => context()?.ui?.setStatus?.(name, value) },
-		spawn: { abortSignal: () => context()?.signal, isAllowed: assertInstallAllowed },
+		spawn: {
+			abortSignal: () => context()?.signal,
+			isAllowed: assertInstallAllowed,
+		},
 		render: { invalidate: () => options.getRenderInvalidator?.()?.() },
 		session: { id: () => getStableSessionId(context()) },
-		workspace: { cwd: () => context()?.cwd, projectRoot: () => options.getProjectRoot?.() },
+		workspace: {
+			cwd: () => context()?.cwd,
+			projectRoot: () => options.getProjectRoot?.(),
+		},
 		flags: { get: (name) => pi.getFlag(name) },
 		tools: {
-			has: async (name) => typeof (pi as unknown as { getTool?: (tool: string) => unknown }).getTool?.(name) !== "undefined",
+			has: async (name) =>
+				typeof (pi as unknown as { getTool?: (tool: string) => unknown }).getTool?.(
+					name,
+				) !== "undefined",
 			getActive: () => activeTools.getActiveTools?.() ?? [],
 			setActive: (names) => activeTools.setActiveTools?.(names),
 		},
@@ -434,7 +461,9 @@ const runtime = new RuntimeCoordinator();
 // have it read the CURRENT activation's pi/flag closures through this
 // holder, refreshed on every activation — never a stale captured `pi`.
 let _readBridgeRegistered = false;
-let _readBridgeGetFlag: ((name: string) => boolean | string | undefined) | undefined;
+let _readBridgeGetFlag:
+	| ((name: string) => boolean | string | undefined)
+	| undefined;
 let _turnSummaryEmitRegistered = false;
 let _turnSummaryEmitCtx:
 	| {
@@ -497,9 +526,7 @@ function cleanStaleTsBuildInfo(cwd: string): string[] {
 				const data = JSON.parse(nodeFs.readFileSync(infoPath, "utf-8"));
 				const root: string[] = data.root ?? [];
 				const dir = path.dirname(infoPath);
-				const isStale = root.some(
-					(f) => !nodeFs.existsSync(path.resolve(dir, f)),
-				);
+				const isStale = root.some((f) => !nodeFs.existsSync(path.resolve(dir, f)));
 				if (isStale) {
 					nodeFs.unlinkSync(infoPath);
 					cleaned.push(infoPath);
@@ -737,7 +764,8 @@ function activateExtension(hostPi: ExtensionAPI) {
 			peekWriteIndex: () => runtime.peekWriteIndex(),
 			isRecordable(filePath: string): boolean {
 				if (_readBridgeGetFlag?.("no-read-guard")) return false;
-				if (isPathIgnoredByProject(filePath, runtime.projectRoot, false)) return false;
+				if (isPathIgnoredByProject(filePath, runtime.projectRoot, false))
+					return false;
 				if (isExternalOrVendorFile(filePath, runtime.projectRoot)) return false;
 				return true;
 			},
@@ -748,6 +776,13 @@ function activateExtension(hostPi: ExtensionAPI) {
 	// env override → CLI flag → global config, all resolved inside getLensFlag
 	// from the registry's PI_LENS_NO_CONTEXT_INJECTION env binding (#166).
 	let contextInjectionEnabled = !getLensFlag("no-lens-context");
+	// Mode determines HOW findings are delivered when enabled: "inject" prepends
+	// into the transcript via the context hook (default); "steer" sends them as a
+	// steer message so they land after the current assistant turn finishes tool
+	// calls instead of invalidating the prompt cache.
+	type ContextInjectionMode = "inject" | "steer";
+	let contextInjectionMode: ContextInjectionMode =
+		globalConfig?.contextInjection?.mode === "steer" ? "steer" : "inject";
 	let lensWidgetVisible = globalConfig?.widget?.visible !== false;
 	let mountedLensWidgetUi: LensWidgetUi | undefined;
 	let widgetMountFailureLogged = false;
@@ -877,16 +912,103 @@ function activateExtension(hostPi: ExtensionAPI) {
 
 	pi.registerCommand("lens-context-toggle", {
 		description:
-			"Toggle automatic context injection on/off for the current session (tools/LSP/read-guard/formatting stay active). Usage: /lens-context-toggle",
-		handler: async (_args, ctx) => {
-			contextInjectionEnabled = !contextInjectionEnabled;
-			notifyUi(
-				ctx,
-				contextInjectionEnabled
-					? "pi-lens context injection enabled — findings will be added to the next turn."
-					: "pi-lens context injection disabled — findings are still cached (lens_diagnostics, /lens-health) but not added to model context.",
-				contextInjectionEnabled ? "info" : "warning",
-			);
+			"Choose automatic context injection mode for this session (tools/LSP/read-guard/formatting stay active). Usage: /lens-context-toggle [inject|steer|off]",
+		handler: async (args, ctx) => {
+			const arg = args?.trim().toLowerCase() as
+				| "inject"
+				| "steer"
+				| "off"
+				| undefined;
+
+			// If no argument, show submenu explaining options.
+			if (!arg) {
+				const currentState = contextInjectionEnabled
+					? contextInjectionMode === "steer"
+						? "Steer"
+						: "Inject"
+					: "Off";
+
+				const message = [
+					`pi-lens context injection: **${currentState}**`,
+					"",
+					"**Options:**",
+					"• **Inject** — Findings prepended to transcript (default, interrupts prompt cache)",
+					"• **Steer** — Findings sent as steer message after turn finishes (preserves cache)",
+					"• **Off** — No findings injected (still cached for lens_diagnostics, /lens-health)",
+					"",
+					`Current: ${currentState}. Run /lens-context-toggle <option> to change.`,
+				].join("\n");
+
+				notifyUi(ctx, message, "info");
+				return;
+			}
+
+			// Apply selected mode.
+			if (arg === "off") {
+				contextInjectionEnabled = false;
+				notifyUi(
+					ctx,
+					"pi-lens context injection disabled — findings are still cached (lens_diagnostics, /lens-health) but not added to model context.",
+					"warning",
+				);
+			} else if (arg === "inject") {
+				contextInjectionEnabled = true;
+				contextInjectionMode = "inject";
+				notifyUi(
+					ctx,
+					"pi-lens context injection enabled (inject mode) — findings will be prepended to the next turn.",
+					"info",
+				);
+			} else if (arg === "steer") {
+				contextInjectionEnabled = true;
+				contextInjectionMode = "steer";
+				notifyUi(
+					ctx,
+					"pi-lens context injection switched to steer mode — findings will be sent as a steer message after the current turn finishes.",
+					"info",
+				);
+			} else {
+				notifyUi(
+					ctx,
+					`Invalid option "${arg}". Use: inject, steer, or off.`,
+					"error",
+				);
+				return;
+			}
+
+			// Persist the mode choice to global config so it survives across sessions.
+			try {
+				const configPath = getPiLensGlobalConfigPath();
+				let existing: Record<string, unknown> = {};
+				try {
+					const raw = nodeFs.readFileSync(configPath, "utf-8");
+					existing = JSON.parse(raw);
+				} catch {
+					/* fresh config */
+				}
+				const next: Record<string, unknown> = { ...existing };
+				if (contextInjectionEnabled) {
+					next.contextInjection = {
+						...((existing.contextInjection as Record<string, unknown>) ?? {}),
+						mode: contextInjectionMode,
+					};
+				} else {
+					// Remove contextInjection if present.
+					const ci = next.contextInjection as Record<string, unknown> | undefined;
+					if (ci) {
+						const { mode, ...rest } = ci;
+						if (Object.keys(rest).length > 0) {
+							next.contextInjection = rest;
+						} else {
+							delete next.contextInjection;
+						}
+					}
+				}
+				nodeFs.mkdirSync(path.dirname(configPath), { recursive: true });
+				nodeFs.writeFileSync(configPath, JSON.stringify(next, null, 2));
+			} catch {
+				/* best-effort persistence — never throw */
+			}
 		},
 	});
 
@@ -1019,13 +1141,8 @@ function activateExtension(hostPi: ExtensionAPI) {
 		description:
 			"Show pi-lens runtime health: pipeline crashes, slow runners, and last dispatch latency. Usage: /lens-health",
 		handler: async (_args, ctx) => {
-			const crashEntries = runtime
-				.getCrashEntries()
-				.sort((a, b) => b[1] - a[1]);
-			const totalCrashes = crashEntries.reduce(
-				(sum, [, count]) => sum + count,
-				0,
-			);
+			const crashEntries = runtime.getCrashEntries().sort((a, b) => b[1] - a[1]);
+			const totalCrashes = crashEntries.reduce((sum, [, count]) => sum + count, 0);
 
 			const dispatchIntegration =
 				loadedDispatchIntegration ?? (await loadDispatchIntegration());
@@ -1034,9 +1151,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 			const last = reports.length > 0 ? reports[reports.length - 1] : undefined;
 			const diagStats = getDiagnosticTracker().getStats();
 			const slowRunners = last
-				? [...last.runners]
-						.sort((a, b) => b.durationMs - a.durationMs)
-						.slice(0, 3)
+				? [...last.runners].sort((a, b) => b.durationMs - a.durationMs).slice(0, 3)
 				: [];
 
 			// Session duration
@@ -1044,13 +1159,11 @@ function activateExtension(hostPi: ExtensionAPI) {
 			const sessionMins = Math.floor(sessionAge / 60_000);
 			const sessionHrs = Math.floor(sessionMins / 60);
 			const sessionAgeStr =
-				sessionHrs > 0
-					? `${sessionHrs}h ${sessionMins % 60}m`
-					: `${sessionMins}m`;
-			const startedAt = new Date(runtime.sessionStartedAt).toLocaleTimeString(
-				[],
-				{ hour: "2-digit", minute: "2-digit" },
-			);
+				sessionHrs > 0 ? `${sessionHrs}h ${sessionMins % 60}m` : `${sessionMins}m`;
+			const startedAt = new Date(runtime.sessionStartedAt).toLocaleTimeString([], {
+				hour: "2-digit",
+				minute: "2-digit",
+			});
 
 			const lines: string[] = [
 				t("lens.health.title", "🩺 PI-LENS HEALTH"),
@@ -1214,9 +1327,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 					`Cascade diagnostics surfaced: ${cascadeStats.diagnosticsSurfaced}`,
 				);
 				if (cascadeStats.coldSnapshotTouches > 0) {
-					lines.push(
-						`Cold-snapshot touches: ${cascadeStats.coldSnapshotTouches}`,
-					);
+					lines.push(`Cold-snapshot touches: ${cascadeStats.coldSnapshotTouches}`);
 				}
 			}
 
@@ -1306,10 +1417,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 
 			// GitHub releases
 			if (bySource["github-release"].length > 0) {
-				lines.push(
-					"",
-					`⬇️ GitHub releases (${bySource["github-release"].length}):`,
-				);
+				lines.push("", `⬇️ GitHub releases (${bySource["github-release"].length}):`);
 				for (const tool of bySource["github-release"]) {
 					lines.push(`  ✓ ${tool.name}`);
 				}
@@ -1317,10 +1425,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 
 			// pi-lens auto-installed
 			if (bySource["pi-lens-auto"].length > 0) {
-				lines.push(
-					"",
-					`🤖 Auto-installed (${bySource["pi-lens-auto"].length}):`,
-				);
+				lines.push("", `🤖 Auto-installed (${bySource["pi-lens-auto"].length}):`);
 				for (const tool of bySource["pi-lens-auto"]) {
 					lines.push(`  ✓ ${tool.name}`);
 				}
@@ -1451,10 +1556,13 @@ function activateExtension(hostPi: ExtensionAPI) {
 			readGuard: runtime.readGuard,
 			dbg,
 		}),
-		createLensDiagnosticMarkTool(() => runtime.projectRoot, () => ({
-			model: runtime.telemetryModelId,
-			provider: runtime.telemetryProviderId,
-		})),
+		createLensDiagnosticMarkTool(
+			() => runtime.projectRoot,
+			() => ({
+				model: runtime.telemetryModelId,
+				provider: runtime.telemetryProviderId,
+			}),
+		),
 	];
 	const LAZY_TOOL_CATALOG: ActivatableToolInfo[] = [
 		{
@@ -1464,8 +1572,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 		},
 		{
 			name: "ast_grep_replace",
-			summary:
-				"AST-aware structural code rewrite/refactor (ast-grep patterns).",
+			summary: "AST-aware structural code rewrite/refactor (ast-grep patterns).",
 		},
 		{
 			name: "ast_grep_outline",
@@ -1581,10 +1688,18 @@ function activateExtension(hostPi: ExtensionAPI) {
 	pi.on("session_start", async (event, ctx) => {
 		warmDispatchAtSessionStart();
 		void warmLspService().catch((err) =>
-			logExtension({ subsystem: "lsp", level: "warn", message: `LSP warm failed: ${err}` }),
+			logExtension({
+				subsystem: "lsp",
+				level: "warn",
+				message: `LSP warm failed: ${err}`,
+			}),
 		);
 		void warmFormatters().catch((err) =>
-			logExtension({ subsystem: "format", level: "warn", message: `formatter warm failed: ${err}` }),
+			logExtension({
+				subsystem: "format",
+				level: "warn",
+				message: `formatter warm failed: ${err}`,
+			}),
 		);
 		rememberOwnEventCtx(ctx);
 		refreshCtxDerivedPlumbing();
@@ -1703,8 +1818,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 								? "fresh_session_lazy_deactivation"
 								: "session_rebuild_restore",
 							deferralApplies: supportsDeferredTools(
-								(ctx as { model?: Parameters<typeof supportsDeferredTools>[0] })
-									?.model,
+								(ctx as { model?: Parameters<typeof supportsDeferredTools>[0] })?.model,
 							),
 						});
 					}
@@ -1917,10 +2031,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 					if (persisted?.widget) {
 						// #180/#190: drop files changed on disk since the snapshot so a
 						// resume never surfaces stale diagnostics; they re-scan on edit.
-						const fresh = await dropStaleFiles(
-							persisted.widget,
-							persisted.savedAt,
-						);
+						const fresh = await dropStaleFiles(persisted.widget, persisted.savedAt);
 						const dropped = persisted.widget.files.length - fresh.files.length;
 						importWidgetState(fresh);
 						// #1041: rehydrate the read-before-edit guard's read-set on the
@@ -1928,9 +2039,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 						// file isn't falsely zero-read-blocked. importState reconciles
 						// each read against current disk (drops changed/missing files),
 						// so a resume never masks a real staleness.
-						const readImport = runtime.readGuard.importState(
-							persisted.readGuard,
-						);
+						const readImport = runtime.readGuard.importState(persisted.readGuard);
 						dbg(
 							`session_start: ${reasonLabel} ${stableSessionId} — rehydrated ${fresh.files.length} file(s)` +
 								(dropped > 0 ? `, dropped ${dropped} stale` : "") +
@@ -2022,8 +2131,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 				await loadBootstrapClients();
 			return await handleToolResult({
 				event: event as any,
-				getFlag: (name: string, filePath?: string) =>
-					getLensFlag(name, filePath),
+				getFlag: (name: string, filePath?: string) => getLensFlag(name, filePath),
 				getFlagSource: (name: string, filePath?: string) =>
 					getLensFlagSource(name, filePath),
 				dbg,
@@ -2138,16 +2246,14 @@ function activateExtension(hostPi: ExtensionAPI) {
 			await flushDebouncedToolResults();
 			await handleAgentEnd({
 				ctxCwd: ctx.cwd,
-				getFlag: (name: string, filePath?: string) =>
-					getLensFlag(name, filePath),
+				getFlag: (name: string, filePath?: string) => getLensFlag(name, filePath),
 				getFlagSource: (name: string, filePath?: string) =>
 					getLensFlagSource(name, filePath),
 				notify: (msg, level) => notifyUi(ctx, msg, level),
 				dbg,
 				runtime,
 				cacheManager,
-				getFormatService: () =>
-					getFormatService(runtime.telemetrySessionId, true),
+				getFormatService: () => getFormatService(runtime.telemetrySessionId, true),
 				getAutofixClients: async () => {
 					const { biomeClient, ruffClient } = await loadBootstrapClients();
 					return { biomeClient, ruffClient };
@@ -2205,10 +2311,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 					sessionSuspectedStalls += 1;
 				} else {
 					lastLoggedLoopWorstMs = loopMaxMs;
-					sessionWorstRealBlockMs = Math.max(
-						sessionWorstRealBlockMs,
-						loopMaxMs,
-					);
+					sessionWorstRealBlockMs = Math.max(sessionWorstRealBlockMs, loopMaxMs);
 				}
 			}
 			// Start a fresh per-turn occupancy window so the next turn's worst
@@ -2246,7 +2349,9 @@ function activateExtension(hostPi: ExtensionAPI) {
 					// window — turn_end already knows exactly when this session
 					// began, so admitted rows are scoped to it, not to a day-wide
 					// guess that could straddle multiple sessions.
-					for (const note of checkSmellsAndNoteOnce(countRecentSmells(undefined, runtime.sessionStartedAt))) {
+					for (const note of checkSmellsAndNoteOnce(
+						countRecentSmells(undefined, runtime.sessionStartedAt),
+					)) {
 						notifyUi(ctx, note, "warning");
 					}
 				} catch {
@@ -2427,9 +2532,8 @@ function activateExtension(hostPi: ExtensionAPI) {
 				toRunnerDisplayPath(cwd, fp),
 			);
 			const line = formatTurnSummaryLine(details);
-			const sendMessage = (
-				emitCtx.pi as { sendMessage?: (msg: unknown) => void }
-			).sendMessage;
+			const sendMessage = (emitCtx.pi as { sendMessage?: (msg: unknown) => void })
+				.sendMessage;
 			if (typeof sendMessage === "function") {
 				try {
 					sendMessage.call(emitCtx.pi, {
@@ -2448,9 +2552,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 					dbg(`turn-summary sendMessage failed: ${sendErr}`);
 				}
 			} else {
-				dbg(
-					"turn-summary: pi.sendMessage unavailable on this host, skipping emit",
-				);
+				dbg("turn-summary: pi.sendMessage unavailable on this host, skipping emit");
 			}
 			logLatency({
 				type: "phase",
@@ -2468,24 +2570,21 @@ function activateExtension(hostPi: ExtensionAPI) {
 		});
 	}
 	try {
-		(pi as any).on(
-			"agent_settled",
-			(_event: unknown, ctx: { cwd?: string }) => {
-				if (!lensEnabled) return;
-				void runQuietWindow({
-					runtime,
-					dbg,
-					cwd: ctx?.cwd,
-				}).catch((err) => {
-					dbg(`quiet_window crashed: ${err}`);
-				});
-				// #1123 item 4: dump active handles AFTER the quiet-window work is
-				// scheduled — the #1097-class leak (a stray ref'd timer surviving
-				// past settle) is only visible once whatever settle itself queued is
-				// already in flight. No-op unless PI_LENS_DEBUG_HANDLES=1.
-				dumpActiveHandles("agent_settled");
-			},
-		);
+		(pi as any).on("agent_settled", (_event: unknown, ctx: { cwd?: string }) => {
+			if (!lensEnabled) return;
+			void runQuietWindow({
+				runtime,
+				dbg,
+				cwd: ctx?.cwd,
+			}).catch((err) => {
+				dbg(`quiet_window crashed: ${err}`);
+			});
+			// #1123 item 4: dump active handles AFTER the quiet-window work is
+			// scheduled — the #1097-class leak (a stray ref'd timer surviving
+			// past settle) is only visible once whatever settle itself queued is
+			// already in flight. No-op unless PI_LENS_DEBUG_HANDLES=1.
+			dumpActiveHandles("agent_settled");
+		});
 	} catch (registerErr) {
 		dbg(`agent_settled registration failed (older pi host?): ${registerErr}`);
 	}
@@ -2643,7 +2742,7 @@ function activateExtension(hostPi: ExtensionAPI) {
 			let telemetryLogged = false;
 			const logContextObservation = (
 				resultMessages: Array<{ role: string; content: unknown }>,
-				placement: "prepend" | "insert-before-final" | "append" | "none",
+				placement: "prepend" | "insert-before-final" | "append" | "steer" | "none",
 				injectionSources: Array<
 					"session-guidance" | "turn-findings" | "test-findings" | "agent-nudge"
 				>,
@@ -2701,6 +2800,88 @@ function activateExtension(hostPi: ExtensionAPI) {
 				const injectionSources = sourceMessages.map((source) => source.source);
 				if (injectedMessages.length === 0) {
 					logContextObservation(existingMessages, "none", [], []);
+					return;
+				}
+
+				// Steer mode: send findings as a steer message via pi.sendUserMessage
+				// so they land after the current assistant turn finishes its tool calls
+				// instead of interrupting the prompt cache. Clean up content to remove
+				// internal framing, operational noise, and non-actionable advisories.
+				if (contextInjectionMode === "steer") {
+					// Filter out session-guidance (tool list) and agent-nudge (best-effort)
+					// in steer mode — they're not actionable findings.
+					const steerSources = [
+						...sourceMessages.filter(
+							(s) => s.source === "turn-findings" || s.source === "test-findings",
+						),
+					];
+					const steerMessages = steerSources.flatMap((s) => s.messages);
+					if (steerMessages.length === 0) {
+						logContextObservation(existingMessages, "none", [], []);
+						return;
+					}
+
+					// Clean up each message: strip framing, remove operational headers,
+					// filter out non-actionable noise.
+					const cleanedMessages = steerMessages
+						.map((m) => {
+							let content =
+								typeof m.content === "string" ? m.content : String(m.content);
+
+							// Strip AUTOMATION_FRAMING prefix (turn-end findings).
+							content = content.replace(
+								/^\[pi-lens automated check — not a user request\] /,
+								"",
+							);
+
+							// Strip agent-nudge prefix.
+							content = content.replace(
+								/^\[pi-lens automated context — not a user request\] /,
+								"",
+							);
+
+							// Remove the "Address 🔴 blockers" header from turn-end findings.
+							content = content.replace(
+								/^Address 🔴 blockers before continuing; ℹ️ advisories are informational only\.\s*\n\n?/,
+								"",
+							);
+
+							// Remove historical prefix if present.
+							content = content.replace(
+								/^Historical finding; workspace changed since capture; re-run to confirm\.\s*\([^)]+\)\s*\n\n?/,
+								"",
+							);
+
+							// Check if content is purely advisory/noise and skip it entirely.
+							const trimmed = content.trim();
+							if (
+								!trimmed ||
+								/^\s*[ℹ️⚠️]?\s*Advisory — no action required/i.test(trimmed) ||
+								/^\s*[ℹ️⚠️]?\s*Cascade could not compute/i.test(trimmed) ||
+								/^\s*pi-lens: \d+ file\(s\) were/i.test(trimmed)
+							) {
+								return undefined;
+							}
+
+							return trimmed;
+						})
+						.filter((c): c is string => typeof c === "string");
+
+					if (cleanedMessages.length === 0) {
+						logContextObservation(existingMessages, "none", [], []);
+						return;
+					}
+
+					const steerContent = cleanedMessages.join("\n\n");
+					logContextObservation(
+						existingMessages,
+						"steer",
+						injectionSources.filter(
+							(s) => s === "turn-findings" || s === "test-findings",
+						),
+						injectedMessages,
+					);
+					void pi.sendUserMessage(steerContent, { deliverAs: "steer" });
 					return;
 				}
 

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -24,7 +24,10 @@ import * as net from "node:net";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { AstGrepClient } from "../clients/ast-grep-client.js";
-import { CacheManager } from "../clients/cache-manager.js";
+import {
+	CacheManager,
+	MCP_TURN_STATE_OWNER_ID,
+} from "../clients/cache-manager.js";
 import {
 	getDegradationSummary,
 	renderDegradationLines,
@@ -74,6 +77,7 @@ import { createLensDiagnosticsTool } from "../tools/lens-diagnostics.js";
 import { peekMcpSessionRuntime } from "../clients/mcp/session.js";
 import { createLspDiagnosticsTool } from "../tools/lsp-diagnostics.js";
 import { createLspNavigationTool } from "../tools/lsp-navigation.js";
+import { createLensDiagnosticMarkTool } from "../tools/lens-diagnostic-mark.js";
 import {
 	computeBuildStamp,
 	STALE_SERVED_BY_FRESH,
@@ -194,9 +198,7 @@ async function ensureReady(cwd: string): Promise<void> {
 		await ensureLspConfig(normalized);
 		// pi-lens-ignore: missing-error-propagation
 	} catch (err) {
-		console.error(
-			`[pi-lens-mcp] initLSPConfig failed for ${normalized}: ${err}`,
-		);
+		console.error(`[pi-lens-mcp] initLSPConfig failed for ${normalized}: ${err}`);
 	}
 	lspReadyCwds.add(normalized);
 }
@@ -220,12 +222,16 @@ interface AutoSessionState {
 	succeeded: boolean;
 	firedAt: string | null;
 	error: string | null;
+	retryCount: number;
+	nextRetryAt: number;
 }
 let autoSessionState: AutoSessionState = {
 	attempted: false,
 	succeeded: false,
 	firedAt: null,
 	error: null,
+	retryCount: 0,
+	nextRetryAt: 0,
 };
 // Non-null while a run is in flight — guards both the `initialize` call site
 // and the `tools/call` self-heal fallback against double-firing/races.
@@ -233,19 +239,28 @@ let autoSessionInFlight: Promise<void> | null = null;
 
 function maybeAutoSessionStart(): void {
 	if (process.env.PI_LENS_MCP_AUTO_SESSION !== "1") return;
-	// Already running, or already completed successfully — nothing to do. A
-	// prior *failed* attempt is retried (this is the self-heal path).
+	// Already running, or already completed successfully — nothing to do.
 	if (autoSessionInFlight || autoSessionState.succeeded) return;
+	// Backoff for failed attempts: exponential backoff capped at 60s.
+	const now = Date.now();
+	if (now < autoSessionState.nextRetryAt) return;
 	autoSessionState = {
 		attempted: true,
 		succeeded: false,
 		firedAt: new Date().toISOString(),
 		error: null,
+		retryCount: autoSessionState.retryCount + 1,
+		nextRetryAt: now + Math.min(1000 * 2 ** autoSessionState.retryCount, 60_000),
 	};
 	autoSessionInFlight = ensureReady(DEFAULT_CWD)
 		.then(() => runSessionStart(DEFAULT_CWD))
 		.then(() => {
-			autoSessionState = { ...autoSessionState, succeeded: true };
+			autoSessionState = {
+				...autoSessionState,
+				succeeded: true,
+				retryCount: 0,
+				nextRetryAt: 0,
+			};
 			console.error("[pi-lens-mcp] auto session_start complete");
 		})
 		.catch((err) => {
@@ -338,8 +353,7 @@ function startIpcServer(): void {
 						if ((parsed as { route?: string }).route === "turn-end-ack") {
 							if (
 								parsed.version !== WARM_TURN_END_SCHEMA_VERSION ||
-								typeof (parsed as { deliveryId?: unknown }).deliveryId !==
-									"string"
+								typeof (parsed as { deliveryId?: unknown }).deliveryId !== "string"
 							) {
 								socket.end(
 									`${JSON.stringify({ error: `turn-end ack schema ${parsed.version} != ${WARM_TURN_END_SCHEMA_VERSION}` })}\n`,
@@ -570,6 +584,10 @@ const lspNavigationTool = createLspNavigationTool((name, cwd) =>
 	createMcpHost(undefined, cwd ?? DEFAULT_CWD).getFlag(name),
 );
 const lspDiagnosticsTool = createLspDiagnosticsTool();
+const lensDiagnosticMarkTool = createLensDiagnosticMarkTool(
+	() => DEFAULT_CWD,
+	() => ({ model: undefined, provider: undefined }),
+);
 
 // Wrapped pi tools already declare their params as typebox (which IS JSON
 // Schema). Emit that directly as the MCP inputSchema (+ the MCP-only `cwd`)
@@ -605,8 +623,7 @@ const ALL_TOOLS = [
 			properties: {
 				file: {
 					type: "string",
-					description:
-						"Path to the file to analyze (absolute, or relative to cwd).",
+					description: "Path to the file to analyze (absolute, or relative to cwd).",
 				},
 				cwd: {
 					type: "string",
@@ -788,8 +805,7 @@ const ALL_TOOLS = [
 				},
 				maxCallGraphEntries: {
 					type: "number",
-					description:
-						"Per-direction cap for call-graph relations (default 20).",
+					description: "Per-direction cap for call-graph relations (default 20).",
 				},
 			},
 			required: ["file"],
@@ -884,13 +900,11 @@ const ALL_TOOLS = [
 			properties: {
 				file: {
 					type: "string",
-					description:
-						"Absolute or workspace-relative path to the source file.",
+					description: "Absolute or workspace-relative path to the source file.",
 				},
 				line: {
 					type: "number",
-					description:
-						"1-based line number inside the desired symbol/callback.",
+					description: "1-based line number inside the desired symbol/callback.",
 				},
 				cwd: { type: "string" },
 				kinds: {
@@ -996,6 +1010,16 @@ const ALL_TOOLS = [
 		inputSchema: schemaWithCwd(lspNavigationTool.parameters),
 	},
 	{
+		name: "pilens_diagnostic_mark",
+		description:
+			"Record a disposition for a lens_diagnostics finding: false-positive / " +
+			"suppress (inline ignore comment) / defer (this session) / flagged (to fix) / " +
+			"info (informational only, filters from steering/injection). Uses the exact " +
+			"filePath/rule/message/line the finding was reported with. Same schema as " +
+			"the pi tool.",
+		inputSchema: schemaWithCwd(lensDiagnosticMarkTool.parameters),
+	},
+	{
 		name: "pilens_lsp_diagnostics",
 		description:
 			"Pure LSP diagnostics for a file, directory, or batch of files (type " +
@@ -1066,7 +1090,10 @@ async function callTool(
 			// Honest review loop: a forked worker loads the freshly-built code, so
 			// the result reflects the latest commit — not this long-lived server's
 			// in-memory image.
-			const outcome = await analyzeFileFresh(WORKER_PATH, file, cwd, { flags });
+			const outcome = await analyzeFileFresh(WORKER_PATH, file, cwd, {
+				flags,
+				ownerId: MCP_TURN_STATE_OWNER_ID,
+			});
 			if (outcome.error || !outcome.result) {
 				return {
 					...toolText(`fresh analyze failed: ${outcome.error ?? "no result"}`),
@@ -1283,8 +1310,7 @@ async function callTool(
 
 	if (name === "pilens_module_report") {
 		const file = typeof args.file === "string" ? args.file : "";
-		if (!file.trim())
-			return { ...toolText("Provide a `file`."), isError: true };
+		if (!file.trim()) return { ...toolText("Provide a `file`."), isError: true };
 		const cwd = typeof args.cwd === "string" ? args.cwd : DEFAULT_CWD;
 		const maxRefsPerSymbol =
 			typeof args.maxRefsPerSymbol === "number" &&
@@ -1304,9 +1330,7 @@ async function callTool(
 				? Math.max(1, Math.floor(args.maxCallGraphEntries))
 				: undefined;
 		const view =
-			args.view === "summary" || args.view === "compact"
-				? args.view
-				: undefined;
+			args.view === "summary" || args.view === "compact" ? args.view : undefined;
 		const focus = typeof args.focus === "string" ? args.focus : undefined;
 		const report = await moduleReport(file, cwd, {
 			maxRefsPerSymbol,
@@ -1353,9 +1377,7 @@ async function callTool(
 		// agent parses this payload, it doesn't read it formatted.
 		return toolText(
 			summary,
-			graphStaleness
-				? { ...report, graphStalenessNote: graphStaleness }
-				: report,
+			graphStaleness ? { ...report, graphStalenessNote: graphStaleness } : report,
 			true,
 		);
 	}
@@ -1401,9 +1423,7 @@ async function callTool(
 			(graphStaleness ? `\n\n${graphStaleness}` : "");
 		return toolText(
 			summary,
-			graphStaleness
-				? { ...report, graphStalenessNote: graphStaleness }
-				: report,
+			graphStaleness ? { ...report, graphStalenessNote: graphStaleness } : report,
 			true,
 		);
 	}
@@ -1531,10 +1551,12 @@ async function callTool(
 			`LSP: ${aliveClients} alive client(s)`,
 			...servers.flatMap((server) => [
 				`  ${server.connected ? "✓" : "✗"} ${server.serverId} (${server.root})`,
-				...server.pullFailureHistory.slice(-1).map(
-					(failure) =>
-						`    ⚠ diagnostics pull failed: ${failure.method}${failure.code !== undefined ? ` (${failure.code})` : ""} — ${failure.message.length > 200 ? `${failure.message.slice(0, 200)}…` : failure.message}`,
-				),
+				...server.pullFailureHistory
+					.slice(-1)
+					.map(
+						(failure) =>
+							`    ⚠ diagnostics pull failed: ${failure.method}${failure.code !== undefined ? ` (${failure.code})` : ""} — ${failure.message.length > 200 ? `${failure.message.slice(0, 200)}…` : failure.message}`,
+					),
 			]),
 			...renderLspBrokenStatusLines(brokenServers),
 			...renderDegradationLines(degradations),
@@ -1645,12 +1667,22 @@ async function callTool(
 		return toolText(parts.filter(Boolean).join("\n"), outcome);
 	}
 
+	if (name === "pilens_diagnostic_mark") {
+		const cwd = typeof args.cwd === "string" ? args.cwd : DEFAULT_CWD;
+		const out = await lensDiagnosticMarkTool.execute(
+			"mcp",
+			args,
+			undefined,
+			undefined,
+			{ cwd },
+		);
+		return out;
+	}
+
 	if (name === "pilens_ast_grep_search" || name === "pilens_ast_grep_replace") {
 		const cwd = typeof args.cwd === "string" ? args.cwd : DEFAULT_CWD;
 		const tool =
-			name === "pilens_ast_grep_search"
-				? astGrepSearchTool
-				: astGrepReplaceTool;
+			name === "pilens_ast_grep_search" ? astGrepSearchTool : astGrepReplaceTool;
 		const out = (await tool.execute(
 			"mcp",
 			args,
@@ -1822,9 +1854,7 @@ async function handleRequest(request: JsonRpcRequest): Promise<void> {
 				// Surface as a tool error (isError), not a transport error, so the
 				// agent sees the message instead of a dead request.
 				sendResult(id ?? null, {
-					...toolText(
-						`pi-lens tool '${name}' failed: ${(err as Error).message}`,
-					),
+					...toolText(`pi-lens tool '${name}' failed: ${(err as Error).message}`),
 					isError: true,
 				});
 			}

--- a/mcp/worker.ts
+++ b/mcp/worker.ts
@@ -38,7 +38,9 @@ async function main(): Promise<void> {
 		}
 	}
 
-	const result = await analyzeFile(file, cwd, { flags });
+	const ownerId = arg("ownerId");
+
+	const result = await analyzeFile(file, cwd, { flags, ownerId });
 	// Flush before exiting — a bare process.exit can truncate a piped write. The
 	// explicit exit is needed because spawned LSP/runner handles would otherwise
 	// keep the event loop alive.

--- a/tests/index-wiring.test.ts
+++ b/tests/index-wiring.test.ts
@@ -34,7 +34,11 @@ vi.mock("../clients/bootstrap.js", () => ({
 		ruffClient: { isAvailable: () => false },
 		knipClient: {
 			isAvailable: () => false,
-			analyze: async () => ({ success: false, summary: "unavailable", issues: [] }),
+			analyze: async () => ({
+				success: false,
+				summary: "unavailable",
+				issues: [],
+			}),
 		},
 		jscpdClient: { isAvailable: () => false },
 		depChecker: { isAvailable: () => false },
@@ -109,7 +113,9 @@ describe("index.ts extension wiring", () => {
 		try {
 			const parent = createPiMock();
 			const parentApi = parent.asExtensionAPI();
-			(parentApi as unknown as { events: { emit: ReturnType<typeof vi.fn> } }).events = {
+			(
+				parentApi as unknown as { events: { emit: ReturnType<typeof vi.fn> } }
+			).events = {
 				emit: vi.fn(),
 			};
 			extension(parentApi);
@@ -121,7 +127,9 @@ describe("index.ts extension wiring", () => {
 
 			const dbg = vi.fn();
 			wireBusEmitter(() => {
-				throw new Error("This extension ctx is stale after session replacement or reload");
+				throw new Error(
+					"This extension ctx is stale after session replacement or reload",
+				);
 			});
 			publishFilesTouched({
 				reason: "autofix",
@@ -137,14 +145,18 @@ describe("index.ts extension wiring", () => {
 			const recoveredEmit = vi.fn();
 			const subagent = createPiMock();
 			const subagentApi = subagent.asExtensionAPI();
-			(subagentApi as unknown as { events: { emit: typeof recoveredEmit } }).events = {
+			(
+				subagentApi as unknown as { events: { emit: typeof recoveredEmit } }
+			).events = {
 				emit: recoveredEmit,
 			};
 			extension(subagentApi);
 			// Model another activation winning the module singleton after factory
 			// load. The guarded session_start itself must reclaim the wiring.
 			wireBusEmitter(() => {
-				throw new Error("This extension ctx is stale after session replacement or reload");
+				throw new Error(
+					"This extension ctx is stale after session replacement or reload",
+				);
 			});
 			await subagent.emit(
 				"session_start",
@@ -160,7 +172,9 @@ describe("index.ts extension wiring", () => {
 
 			expect(recoveredEmit).toHaveBeenCalledWith(
 				"pilens:files:touched",
-				expect.objectContaining({ paths: [expect.stringContaining("recovered.ts")] }),
+				expect.objectContaining({
+					paths: [expect.stringContaining("recovered.ts")],
+				}),
 			);
 			expect(dbg).toHaveBeenCalledTimes(1);
 		} finally {
@@ -214,11 +228,17 @@ describe("index.ts extension wiring", () => {
 		_resetSessionLifecycleForTests();
 		resetBusPublishForTests();
 		try {
-			const staleOwnerCtx = makeCtx({ cwd: process.cwd(), sessionId: "stale-owner" });
+			const staleOwnerCtx = makeCtx({
+				cwd: process.cwd(),
+				sessionId: "stale-owner",
+			});
 			staleOwnerCtx.isIdle = () => {
 				throw new Error("This extension ctx is stale after session replacement");
 			};
-			const freshGlobalCtx = makeCtx({ cwd: process.cwd(), sessionId: "fresh-sibling" });
+			const freshGlobalCtx = makeCtx({
+				cwd: process.cwd(),
+				sessionId: "fresh-sibling",
+			});
 			const ownerEmit = vi.fn();
 			const owner = createPiMock();
 			const ownerApi = owner.asExtensionAPI();
@@ -265,7 +285,10 @@ describe("index.ts extension wiring", () => {
 		_resetSessionLifecycleForTests();
 		resetBusPublishForTests();
 		try {
-			const staleSiblingCtx = makeCtx({ cwd: process.cwd(), sessionId: "stale-sibling" });
+			const staleSiblingCtx = makeCtx({
+				cwd: process.cwd(),
+				sessionId: "stale-sibling",
+			});
 			staleSiblingCtx.isIdle = () => {
 				throw new Error("This extension ctx is stale after session replacement");
 			};
@@ -393,15 +416,11 @@ describe("index.ts extension wiring", () => {
 
 				for (const t of LAZY_TOOLS) {
 					expect(pi.getTool(t), `tool registered: ${t}`).toBeDefined();
-					expect(pi.activeTools.has(t), `should start inactive: ${t}`).toBe(
-						false,
-					);
+					expect(pi.activeTools.has(t), `should start inactive: ${t}`).toBe(false);
 				}
 				for (const t of ALWAYS_ACTIVE) {
 					expect(pi.getTool(t), `tool registered: ${t}`).toBeDefined();
-					expect(pi.activeTools.has(t), `should start active: ${t}`).toBe(
-						true,
-					);
+					expect(pi.activeTools.has(t), `should start active: ${t}`).toBe(true);
 				}
 			} finally {
 				if (prevDataDir === undefined) delete process.env.PILENS_DATA_DIR;
@@ -432,9 +451,7 @@ describe("index.ts extension wiring", () => {
 					// Every tool — including the normally-lazy 6 — stays active because
 					// index.ts never found getActiveTools/setActiveTools to call, so it
 					// skipped the deactivation step entirely (the graceful fallback).
-					expect(pi.activeTools.has(t), `should stay active: ${t}`).toBe(
-						true,
-					);
+					expect(pi.activeTools.has(t), `should stay active: ${t}`).toBe(true);
 				}
 			} finally {
 				if (prevDataDir === undefined) delete process.env.PILENS_DATA_DIR;
@@ -625,10 +642,14 @@ describe("index.ts extension wiring", () => {
 						| { renderCall?: unknown; renderResult?: unknown }
 						| undefined;
 					expect(tool, `tool: ${t}`).toBeDefined();
-					expect(tool?.renderCall, `${t}.renderCall should be absent when off`).toBeUndefined();
-					expect(tool?.renderResult, `${t}.renderResult should still exist`).toBeTypeOf(
-						"function",
-					);
+					expect(
+						tool?.renderCall,
+						`${t}.renderCall should be absent when off`,
+					).toBeUndefined();
+					expect(
+						tool?.renderResult,
+						`${t}.renderResult should still exist`,
+					).toBeTypeOf("function");
 				}
 			});
 
@@ -664,7 +685,10 @@ describe("index.ts extension wiring", () => {
 				expect(callComponent?.render(80)).toEqual([]);
 
 				const resultComponent = tool.renderResult?.(
-					{ content: [], details: { mode: "all", totalBlocking: 0, filesWithIssues: 0 } },
+					{
+						content: [],
+						details: { mode: "all", totalBlocking: 0, filesWithIssues: 0 },
+					},
 					{ expanded: false, isPartial: false },
 					theme,
 					ctx,
@@ -753,7 +777,11 @@ describe("index.ts extension wiring", () => {
 			removeTempDirSync(tmp);
 		});
 
-		function seedTurnEndFindings(cwd: string, content: string, sessionId: string): void {
+		function seedTurnEndFindings(
+			cwd: string,
+			content: string,
+			sessionId: string,
+		): void {
 			const file = path.join(cwd, "unchanged.ts");
 			fs.writeFileSync(file, "export const unchanged = true;\n");
 			const provenance = snapshotAdvisoryProvenance({
@@ -762,7 +790,11 @@ describe("index.ts extension wiring", () => {
 				generation: 1,
 				files: [{ path: file, role: "affected" }],
 			});
-			new CacheManager().writeCache("turn-end-findings", { content, provenance }, cwd);
+			new CacheManager().writeCache(
+				"turn-end-findings",
+				{ content, provenance },
+				cwd,
+			);
 		}
 
 		it("suppresses injection when --no-lens-context is set, then injects after /lens-context-toggle", async () => {
@@ -770,7 +802,11 @@ describe("index.ts extension wiring", () => {
 			_resetSessionLifecycleForTests();
 			const pi = createPiMock({ "no-lens-context": true });
 			extension(pi.asExtensionAPI());
-			await pi.emit("session_start", { sessionId: "wiring-session" }, makeCtx({ cwd: tmp, sessionId: "wiring-session" }));
+			await pi.emit(
+				"session_start",
+				{ sessionId: "wiring-session" },
+				makeCtx({ cwd: tmp, sessionId: "wiring-session" }),
+			);
 			seedTurnEndFindings(tmp, "TESTFINDINGS_XYZZY", "wiring-session");
 
 			const existing = [{ role: "system", content: "orig" }];
@@ -784,7 +820,7 @@ describe("index.ts extension wiring", () => {
 			expect(off).toBeUndefined();
 
 			// Flip it on through the real command handler.
-			await pi.runCommand("lens-context-toggle", "", makeCtx({ cwd: tmp }));
+			await pi.runCommand("lens-context-toggle", "inject", makeCtx({ cwd: tmp }));
 
 			// Now the same hook injects the cached findings into the transcript.
 			// The lone existing message is a `system` message (not a plain user
@@ -802,6 +838,182 @@ describe("index.ts extension wiring", () => {
 			expect(on?.messages[0]).toEqual({ role: "system", content: "orig" });
 			expect(on?.messages.at(-1)?.content).toMatch(/TESTFINDINGS_XYZZY/);
 			expect(on?.messages.at(-1)?.content).toContain("Address 🔴 blockers");
+		});
+
+		it("shows submenu with options via /lens-context-toggle", async () => {
+			_resetSessionLifecycleForTests();
+			const pi = createPiMock();
+			extension(pi.asExtensionAPI());
+			await pi.emit(
+				"session_start",
+				{ sessionId: "wiring-session" },
+				makeCtx({ cwd: tmp, sessionId: "wiring-session" }),
+			);
+
+			const ctx = makeCtx({ cwd: tmp });
+
+			// No argument: shows submenu explaining options.
+			await pi.runCommand("lens-context-toggle", "", ctx);
+			const notifications = ctx.notifications.map((n) => n.message);
+			expect(notifications.some((n) => n.includes("**Options:**"))).toBe(true);
+			expect(notifications.some((n) => n.includes("**Inject**"))).toBe(true);
+			expect(notifications.some((n) => n.includes("**Steer**"))).toBe(true);
+			expect(notifications.some((n) => n.includes("**Off**"))).toBe(true);
+		});
+
+		it("sets steer mode via /lens-context-toggle steer", async () => {
+			_resetSessionLifecycleForTests();
+			const pi = createPiMock();
+			extension(pi.asExtensionAPI());
+			await pi.emit(
+				"session_start",
+				{ sessionId: "wiring-session" },
+				makeCtx({ cwd: tmp, sessionId: "wiring-session" }),
+			);
+
+			const ctx = makeCtx({ cwd: tmp });
+
+			// Set steer mode explicitly.
+			await pi.runCommand("lens-context-toggle", "steer", ctx);
+			const notifications = ctx.notifications.map((n) => n.message);
+			expect(notifications.some((n) => n.includes("steer mode"))).toBe(true);
+		});
+
+		it("sets off mode via /lens-context-toggle off", async () => {
+			_resetSessionLifecycleForTests();
+			const pi = createPiMock();
+			extension(pi.asExtensionAPI());
+			await pi.emit(
+				"session_start",
+				{ sessionId: "wiring-session" },
+				makeCtx({ cwd: tmp, sessionId: "wiring-session" }),
+			);
+
+			const ctx = makeCtx({ cwd: tmp });
+
+			// Set off mode explicitly.
+			await pi.runCommand("lens-context-toggle", "off", ctx);
+			const notifications = ctx.notifications.map((n) => n.message);
+			expect(notifications.some((n) => n.includes("disabled"))).toBe(true);
+		});
+
+		it("sets inject mode via /lens-context-toggle inject", async () => {
+			_resetSessionLifecycleForTests();
+			const pi = createPiMock();
+			extension(pi.asExtensionAPI());
+			await pi.emit(
+				"session_start",
+				{ sessionId: "wiring-session" },
+				makeCtx({ cwd: tmp, sessionId: "wiring-session" }),
+			);
+
+			const ctx = makeCtx({ cwd: tmp });
+
+			// Set inject mode explicitly.
+			await pi.runCommand("lens-context-toggle", "inject", ctx);
+			const notifications = ctx.notifications.map((n) => n.message);
+			expect(notifications.some((n) => n.includes("enabled (inject mode)"))).toBe(
+				true,
+			);
+		});
+
+		it("sends findings via sendUserMessage in steer mode", async () => {
+			_resetSessionLifecycleForTests();
+			const pi = createPiMock();
+			extension(pi.asExtensionAPI());
+			await pi.emit(
+				"session_start",
+				{ sessionId: "wiring-session" },
+				makeCtx({ cwd: tmp, sessionId: "wiring-session" }),
+			);
+			seedTurnEndFindings(tmp, "STEER_CONTENT_ABC", "wiring-session");
+
+			const ctx = makeCtx({ cwd: tmp });
+
+			// Set steer mode explicitly.
+			await pi.runCommand("lens-context-toggle", "steer", ctx);
+
+			const existing = [{ role: "user", content: "hello" }];
+			// Steer mode: context hook returns undefined (no transcript modification)
+			// and calls sendUserMessage instead.
+			const result = await pi.emit("context", { messages: existing }, ctx);
+			expect(result).toBeUndefined();
+
+			// Verify sendUserMessage was called with steer delivery.
+			expect(pi.sentUserMessages).toHaveLength(1);
+			expect(pi.sentUserMessages[0].options?.deliverAs).toBe("steer");
+			expect(pi.sentUserMessages[0].content).toMatch(/STEER_CONTENT_ABC/);
+		});
+
+		it("persists steer mode in global config across sessions", async () => {
+			const prevConfigPath = process.env.PI_LENS_CONFIG_PATH;
+			const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-config-"));
+			const configPath = path.join(configDir, "config.json");
+			process.env.PI_LENS_CONFIG_PATH = configPath;
+
+			try {
+				_resetSessionLifecycleForTests();
+				const pi = createPiMock();
+				extension(pi.asExtensionAPI());
+				await pi.emit(
+					"session_start",
+					{ sessionId: "persist-session" },
+					makeCtx({ cwd: tmp, sessionId: "persist-session" }),
+				);
+
+				const ctx = makeCtx({ cwd: tmp });
+
+				// Set steer mode explicitly.
+				await pi.runCommand("lens-context-toggle", "steer", ctx);
+
+				// Read back the config file to verify persistence.
+				const rawConfig = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+				expect(rawConfig.contextInjection?.mode).toBe("steer");
+			} finally {
+				if (prevConfigPath === undefined) delete process.env.PI_LENS_CONFIG_PATH;
+				else process.env.PI_LENS_CONFIG_PATH = prevConfigPath;
+				removeTempDirSync(configDir);
+			}
+		});
+
+		it("respects persisted steer mode on fresh session start", async () => {
+			const prevConfigPath = process.env.PI_LENS_CONFIG_PATH;
+			const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-config-"));
+			const configPath = path.join(configDir, "config.json");
+			process.env.PI_LENS_CONFIG_PATH = configPath;
+
+			try {
+				// Pre-write steer mode into config.
+				fs.writeFileSync(
+					configPath,
+					JSON.stringify({ contextInjection: { mode: "steer" } }),
+				);
+
+				_resetSessionLifecycleForTests();
+				const pi = createPiMock();
+				extension(pi.asExtensionAPI());
+				await pi.emit(
+					"session_start",
+					{ sessionId: "fresh-session" },
+					makeCtx({ cwd: tmp, sessionId: "fresh-session" }),
+				);
+				seedTurnEndFindings(tmp, "PERSIST_TEST", "fresh-session");
+
+				const ctx = makeCtx({ cwd: tmp });
+				const existing = [{ role: "user", content: "hello" }];
+
+				// Should use steer mode from config — no transcript modification.
+				const result = await pi.emit("context", { messages: existing }, ctx);
+				expect(result).toBeUndefined();
+
+				// And sendUserMessage should have been called.
+				expect(pi.sentUserMessages).toHaveLength(1);
+				expect(pi.sentUserMessages[0].options?.deliverAs).toBe("steer");
+			} finally {
+				if (prevConfigPath === undefined) delete process.env.PI_LENS_CONFIG_PATH;
+				else process.env.PI_LENS_CONFIG_PATH = prevConfigPath;
+				removeTempDirSync(configDir);
+			}
 		});
 	});
 

--- a/tests/mcp/server.smoke.test.ts
+++ b/tests/mcp/server.smoke.test.ts
@@ -58,6 +58,7 @@ describe("pi-lens MCP server (stdio smoke)", { retry: 2 }, () => {
 		expect(names).toContain("pilens_ast_grep_replace");
 		expect(names).toContain("pilens_lsp_navigation");
 		expect(names).toContain("pilens_lsp_diagnostics");
+		expect(names).toContain("pilens_diagnostic_mark");
 		expect(names).toContain("pilens_symbol_search");
 		// pilens_impact was removed (#304) — its blast radius folded into
 		// pilens_module_report's `blastRadius` option.
@@ -95,9 +96,9 @@ describe("pi-lens MCP server (stdio smoke)", { retry: 2 }, () => {
 		});
 		try {
 			const listed = await installedHarness.request(20, "tools/list");
-			const tools = (
-				listed.result as { tools: { name: string }[] }
-			).tools.map((tool) => tool.name);
+			const tools = (listed.result as { tools: { name: string }[] }).tools.map(
+				(tool) => tool.name,
+			);
 			expect(tools).not.toContain("pilens_rebuild");
 
 			// Defense in depth: a client that calls the hidden tool directly still
@@ -179,7 +180,7 @@ describe("pi-lens MCP server (stdio smoke)", { retry: 2 }, () => {
 		expect(result.content[0].text).toContain("[warm]");
 		expect(result.content[0].text).toContain("host-shim.ts");
 		// The structured JSON payload (fenced) carries the latency record.
-		expect(result.content[0].text).toContain("\"latency\"");
+		expect(result.content[0].text).toContain('"latency"');
 	}, 60_000);
 
 	// pilens_module_report + pilens_read_symbol execute against a tiny project in

--- a/tests/support/pi-mock.ts
+++ b/tests/support/pi-mock.ts
@@ -68,6 +68,15 @@ export interface CapturedMessage {
 	details: unknown;
 }
 
+/** A `pi.sendUserMessage(...)` call captured for assertions. */
+export interface CapturedUserMessage {
+	content: unknown;
+	options?: {
+		deliverAs?: "steer" | "followUp" | "nextTurn";
+		triggerTurn?: boolean;
+	};
+}
+
 export interface PiMock {
 	// ── recordings ───────────────────────────────────────────────────────────
 	readonly flags: Map<string, RecordedFlag>;
@@ -77,6 +86,8 @@ export interface PiMock {
 	readonly flagValues: Map<string, boolean | string>;
 	readonly messageRenderers: Map<string, unknown>;
 	readonly sentMessages: CapturedMessage[];
+	/** Every `pi.sendUserMessage(...)` call, in order. */
+	readonly sentUserMessages: CapturedUserMessage[];
 	/**
 	 * #dynamic-tooling: tools registered via `registerTool` are active by
 	 * default (mirrors the real host — see docs' `getActiveTools`/
@@ -123,7 +134,11 @@ export interface PiMock {
 	/** Run every handler registered for `event`; return the last defined result. */
 	emit(event: string, payload?: unknown, ctx?: unknown): Promise<unknown>;
 	/** Invoke a registered command's handler. */
-	runCommand(name: string, args?: string, ctx?: ExtensionCommandContext): Promise<void>;
+	runCommand(
+		name: string,
+		args?: string,
+		ctx?: ExtensionCommandContext,
+	): Promise<void>;
 	/** Cast to the host type for `extension(pi.asExtensionAPI())`. */
 	asExtensionAPI(): ExtensionAPI;
 }
@@ -153,6 +168,7 @@ export function createPiMock(
 	);
 	const messageRenderers = new Map<string, unknown>();
 	const sentMessages: CapturedMessage[] = [];
+	const sentUserMessages: CapturedUserMessage[] = [];
 	const activeTools = new Set<string>();
 
 	const mock: PiMock = {
@@ -163,6 +179,7 @@ export function createPiMock(
 		flagValues,
 		messageRenderers,
 		sentMessages,
+		sentUserMessages,
 		activeTools,
 
 		registerFlag(name, options) {
@@ -249,6 +266,15 @@ export function createPiMock(
 					for (const name of names) activeTools.add(name);
 				};
 			}
+			api.sendUserMessage = (
+				content: unknown,
+				options?: {
+					deliverAs?: "steer" | "followUp" | "nextTurn";
+					triggerTurn?: boolean;
+				},
+			) => {
+				sentUserMessages.push({ content, options });
+			};
 			return api as unknown as ExtensionAPI;
 		},
 	};

--- a/tools/lens-diagnostic-mark.ts
+++ b/tools/lens-diagnostic-mark.ts
@@ -2,7 +2,7 @@
  * lens_diagnostic_mark — agent-facing disposition operation (#690, unifying
  * #181/#503/#504's discussion into one triage layer).
  *
- * Four dispositions, given the exact filePath/rule/message/line a
+ * Five dispositions, given the exact filePath/rule/message/line a
  * lens_diagnostics finding was reported with (same fields shown in that
  * tool's output):
  *   false-positive — the rule misfired. Persists project-wide.
@@ -50,9 +50,18 @@ import {
 	type Disposition,
 } from "../clients/diagnostic-dispositions.js";
 import { insertSuppressComment } from "../clients/dispatch/suppress-writer.js";
-import { getFileDiagnostics, type WidgetDiagnostic } from "../clients/widget-state.js";
+import {
+	getFileDiagnostics,
+	type WidgetDiagnostic,
+} from "../clients/widget-state.js";
 
-const DISPOSITIONS = ["false-positive", "suppress", "defer", "flagged"] as const;
+const DISPOSITIONS = [
+	"false-positive",
+	"suppress",
+	"defer",
+	"flagged",
+	"info",
+] as const;
 
 // How far ± the caller's line the fuzzy fallback searches for a plausible
 // (non-blank) line when there's no widget-state match to reanchor from.
@@ -99,7 +108,8 @@ function widgetCrossCheck(
 	if (matches.length === 0) return undefined;
 	if (matches.length === 1) return { line: matches[0].line, ambiguous: false };
 	const closest = matches.reduce(
-		(best, d) => (Math.abs(d.line - callerLine) < Math.abs(best.line - callerLine) ? d : best),
+		(best, d) =>
+			Math.abs(d.line - callerLine) < Math.abs(best.line - callerLine) ? d : best,
 		matches[0],
 	);
 	return { line: closest.line, ambiguous: true };
@@ -209,26 +219,29 @@ export function createLensDiagnosticMarkTool(
 		label: "Mark Diagnostic",
 		description:
 			"Record a disposition for a lens_diagnostics finding, using the exact filePath/rule/message/line " +
-			"it was reported with. false-positive/suppress persist across sessions; defer lasts only for the " +
+			"it was reported with. false-positive/suppress/info persist across sessions; defer lasts only for the " +
 			"current session (resurfaces next time); flagged marks it for you to come back and fix, and shows " +
 			"up tagged in a later lens_diagnostics mode=full. suppress additionally writes a `pi-lens-ignore: " +
-			"<rule>` comment into the source above the flagged line — rule is required for suppress. " +
+			"<rule>` comment into the source above the flagged line — rule is required for suppress. info " +
+			"filters from steering/injection without an inline comment. " +
 			"The line is verified/reanchored against current diagnostics before writing (#802): if a live " +
 			"diagnostic for this tool/rule/message is now at a different line, that line is used instead of " +
 			"the one you passed. When suppressing several findings in the SAME file in one turn, work " +
 			"bottom-up (highest line number first) — each inserted comment shifts later lines down by one, " +
 			"and reanchoring can't always disambiguate two nearby findings.",
 		promptSnippet:
-			"Use lens_diagnostic_mark to dismiss a false-positive, suppress a won't-fix, defer, or flag a finding to fix later",
+			"Use lens_diagnostic_mark to dismiss a false-positive, suppress a won\'t-fix, defer, flag a finding to fix later, or mark as info only",
 		parameters: Type.Object({
 			filePath: Type.String({
-				description: "The file the diagnostic was reported on (relative or absolute).",
+				description:
+					"The file the diagnostic was reported on (relative or absolute).",
 			}),
 			line: Type.Number({
 				description: "The 1-based line the diagnostic was reported at.",
 			}),
 			message: Type.String({
-				description: "The diagnostic's message, exactly as lens_diagnostics reported it.",
+				description:
+					"The diagnostic's message, exactly as lens_diagnostics reported it.",
 			}),
 			rule: Type.Optional(
 				Type.String({
@@ -237,15 +250,19 @@ export function createLensDiagnosticMarkTool(
 				}),
 			),
 			tool: Type.Optional(
-				Type.String({ description: "The tool that produced the diagnostic, if known." }),
+				Type.String({
+					description: "The tool that produced the diagnostic, if known.",
+				}),
 			),
 			disposition: Type.String({
 				enum: DISPOSITIONS,
 				description:
-					"false-positive = the rule misfired. suppress = real finding, won't fix (writes an inline ignore comment). defer = fix later, this session only. flagged = mark for you to fix.",
+					"false-positive = the rule misfired. suppress = real finding, won\'t fix (writes an inline ignore comment). defer = fix later, this session only. flagged = mark for you to fix. info = real finding, informational only (filters from steering/injection, no inline comment).",
 			}),
 			reason: Type.Optional(
-				Type.String({ description: "Optional short reason, kept alongside the disposition." }),
+				Type.String({
+					description: "Optional short reason, kept alongside the disposition.",
+				}),
 			),
 		}),
 		async execute(
@@ -286,7 +303,8 @@ export function createLensDiagnosticMarkTool(
 					content: [
 						{
 							type: "text" as const,
-							text: "disposition=suppress requires `rule` — the inline pi-lens-ignore comment names a rule id.",
+							text:
+								"disposition=suppress requires `rule` — the inline pi-lens-ignore comment names a rule id.",
 						},
 					],
 					isError: true,
@@ -323,7 +341,14 @@ export function createLensDiagnosticMarkTool(
 			let verifiedLine = line;
 			let reanchorNote: string | undefined;
 			try {
-				const verification = verifyLine(content, absPath, tool, rule, message, line);
+				const verification = verifyLine(
+					content,
+					absPath,
+					tool,
+					rule,
+					message,
+					line,
+				);
 				if ("error" in verification) {
 					if (disposition === "suppress") {
 						return {
@@ -337,7 +362,7 @@ export function createLensDiagnosticMarkTool(
 							details: {},
 						};
 					}
-					// false-positive/defer/flagged: same worst-case as before #802 — a
+					// false-positive/defer/flagged/info: same worst-case as before #802 — a
 					// stale line produces a rotted (never-matching) anchor rather than a
 					// blocked mark.
 				} else {
@@ -402,7 +427,9 @@ export function createLensDiagnosticMarkTool(
 						? "deferred for this session"
 						: disposition === "flagged"
 							? "flagged to fix"
-							: "marked false-positive";
+							: disposition === "info"
+								? "marked info (filtered from steering/injection)"
+								: "marked false-positive";
 			const reanchorSuffix = reanchorNote ? ` (${reanchorNote})` : "";
 			return {
 				content: [


### PR DESCRIPTION
The markdownlint runner now skips files outside the project root (e.g. files on Desktop, Downloads, Documents) to avoid 'no action required' warnings for files being edited while pi-lens is running.

Config: added ignore patterns for common user directories.
Runner: added path check to skip files outside project root.

This fixes the 'no action required' warnings that appeared when editing markdown files on the Desktop while pi-lens was running.