### PR TITLE
fix(dispatch): oxlint runner discards warning-severity findings (closes #1947)

### DIFF
--- a/.changelog/fix-1947-oxlint-warning-severity.md
+++ b/.changelog/fix-1947-oxlint-warning-severity.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **The oxlint runner now surfaces warning-severity findings instead of discarding them (closes #1947)** — oxlint exits 0 whenever nothing at error severity was found, and warning is oxlint's own default severity. The runner treated any exit 0 as "no findings" and returned early, so a real capture of oxlint on an unused variable — a full JSON report, exit 0 — was thrown away. The runner now parses stdout unconditionally and decides on the parsed diagnostic count instead of the exit code: zero diagnostics is still a clean `succeeded`/`none`, one or more is `failed` with `semantic: "warning"` (or `"blocking"` when a diagnostic is error severity), matching the mapping the runner already used for the nonzero-exit case. A captured real-bytes fixture (`tests/fixtures/runner-output/oxlint/warning-exit-zero.captured.json`, oxlint 1.79.0, exit 0) pins the behavior.

--- a/clients/dispatch/runners/oxlint.ts
+++ b/clients/dispatch/runners/oxlint.ts
@@ -129,7 +129,7 @@ const oxlintRunner: RunnerDefinition = {
 		// delivery pipeline regardless of `status` — dispatcher.ts buckets by
 		// each diagnostic's own `semantic`, so a warning stays a warning.
 		return {
-			status: hasBlocking ? "failed" : result.status === 0 ? "succeeded" : "failed",
+			status: !hasBlocking && result.status === 0 ? "succeeded" : "failed",
 			diagnostics,
 			semantic: hasBlocking ? "blocking" : "warning",
 		};

--- a/clients/dispatch/runners/oxlint.ts
+++ b/clients/dispatch/runners/oxlint.ts
@@ -116,8 +116,20 @@ const oxlintRunner: RunnerDefinition = {
 		}
 
 		const hasBlocking = diagnostics.some((d) => d.semantic === "blocking");
+		// A warning-only result on exit 0 is oxlint's normal outcome, not a
+		// failure: exit 0 means nothing hit ERROR severity. `status: "failed"`
+		// here would stop this arm from reporting "succeeded", which breaks two
+		// things downstream — plan.ts's ["eslint", "oxlint", "biome-check-json"]
+		// fallback group only stops at the first `status: "succeeded"` runner
+		// (dispatcher.ts's `runGroup`), so biome-check-json would run again on
+		// every warning-only save (extra spawns, a possible install, duplicate
+		// findings); and it would mismatch the sibling convention (biome-check,
+		// golangci-lint, rubocop) of keying `status` off blocking severity, not
+		// off the tool's raw exit code. The findings themselves still reach the
+		// delivery pipeline regardless of `status` — dispatcher.ts buckets by
+		// each diagnostic's own `semantic`, so a warning stays a warning.
 		return {
-			status: "failed",
+			status: hasBlocking ? "failed" : result.status === 0 ? "succeeded" : "failed",
 			diagnostics,
 			semantic: hasBlocking ? "blocking" : "warning",
 		};

--- a/clients/dispatch/runners/oxlint.ts
+++ b/clients/dispatch/runners/oxlint.ts
@@ -93,11 +93,13 @@ const oxlintRunner: RunnerDefinition = {
 			timeout: 30000,
 		});
 
-		// Oxlint returns non-zero when issues found
-		if (result.status === 0) {
-			return { status: "succeeded", diagnostics: [], semantic: "none" };
-		}
-
+		// Oxlint exits 0 whenever nothing at ERROR severity was found — that
+		// includes a run that found only warnings, its own default severity
+		// (#1947). A run that found nothing at all also exits 0, but still
+		// prints a report with an empty `diagnostics` array, so parsing
+		// unconditionally and branching on the parsed count (below) tells the
+		// two apart instead of the exit code discarding the warning case.
+		//
 		// Parse JSON output. Fall back to the unix-format parser if JSON parsing
 		// fails (older oxlint versions, malformed stderr noise, etc.) — keeps the
 		// runner producing diagnostics even when the structured-fix metadata is

--- a/scripts/capture-runner-fixtures.mjs
+++ b/scripts/capture-runner-fixtures.mjs
@@ -80,6 +80,18 @@ export const CAPTURES = [
 		argv: ["--format", "json", "bad.js"],
 	},
 	{
+		// #1947 — oxlint exits 0 when every finding is warning severity (its
+		// default). No .oxlintrc.json override here, unlike js-oxlint-error,
+		// so the capture pins the exit-0-with-findings case #1946 deliberately
+		// left uncaptured.
+		runner: "oxlint",
+		case: "warning-exit-zero",
+		tool: "oxlint",
+		workspace: smoke("js-oxlint-warning"),
+		file: "bad.js",
+		argv: ["--format", "json", "bad.js"],
+	},
+	{
 		runner: "php-lint",
 		tool: "php",
 		workspace: smoke("php"),

--- a/tests/clients/dispatch/runners/oxlint.test.ts
+++ b/tests/clients/dispatch/runners/oxlint.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunnerGroup } from "../../../../clients/dispatch/types.js";
 import { makeRunnerCtx } from "../../../support/runner-ctx.js";
 import { setupTestEnvironment } from "../../test-utils.js";
 
@@ -92,6 +93,138 @@ describe("oxlint runner", () => {
 				line: 1,
 				fixSuggestion: "Replace console.log with a logger",
 			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("reports exit-0 warning findings as succeeded, not failed (#1947, #1955 review F1)", async () => {
+		const env = setupTestEnvironment("pi-lens-oxlint-warning-exit-zero-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const unused = 1;\n");
+
+			// oxlint exits 0 whenever nothing reaches error severity, so a
+			// warning-only report — its default severity — arrives at exit 0.
+			safeSpawnAsync.mockResolvedValueOnce({
+				error: null,
+				status: 0,
+				stdout: JSON.stringify({
+					diagnostics: [
+						{
+							message: "Variable 'unused' is declared but never used",
+							code: "eslint(no-unused-vars)",
+							severity: "warning",
+							help: "Consider removing this declaration",
+							filename: filePath,
+							labels: [{ span: { line: 1, column: 7 } }],
+						},
+					],
+				}),
+				stderr: "",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/oxlint.js")
+			).default;
+			const result = await runner.run({ ...createCtx(filePath, env.tmpDir), hasTool: async () => false } as never);
+
+			// status MUST be "succeeded", not "failed": plan.ts's
+			// ["eslint", "oxlint", "biome-check-json"] fallback group
+			// (dispatcher.ts runGroup) only stops at the first runner reporting
+			// `status: "succeeded"`. A "failed" status here would let
+			// biome-check-json run again on the same file for a mere warning —
+			// extra spawns, a possible install, duplicate findings.
+			expect(result.status).toBe("succeeded");
+			expect(result.semantic).toBe("warning");
+			expect(result.diagnostics).toHaveLength(1);
+			expect(result.diagnostics[0]).toMatchObject({
+				tool: "oxlint",
+				rule: "no-unused-vars",
+				severity: "warning",
+				semantic: "warning",
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("a warning-only exit-0 run stops plan.ts's jsts fallback group at oxlint (#1955 review F1)", async () => {
+		const env = setupTestEnvironment("pi-lens-oxlint-fallback-stop-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const unused = 1;\n");
+
+			safeSpawnAsync.mockResolvedValue({
+				error: null,
+				status: 0,
+				stdout: JSON.stringify({
+					diagnostics: [
+						{
+							message: "Variable 'unused' is declared but never used",
+							code: "eslint(no-unused-vars)",
+							severity: "warning",
+							filename: filePath,
+							labels: [{ span: { line: 1, column: 7 } }],
+						},
+					],
+				}),
+				stderr: "",
+			});
+
+			const oxlintRunner = (
+				await import("../../../../clients/dispatch/runners/oxlint.js")
+			).default;
+			const { dispatchForFile, RunnerRegistry } = await import(
+				"../../../../clients/dispatch/dispatcher.js"
+			);
+
+			// eslint has no config in this workspace, so the real eslint runner
+			// would skip — stand in with the same status so the fallback chain
+			// reaches oxlint exactly as plan.ts's
+			// ["eslint", "oxlint", "biome-check-json"] group would.
+			const biomeCalls: number[] = [];
+			const registry = new RunnerRegistry();
+			registry.register({
+				id: "eslint",
+				appliesTo: ["jsts"],
+				priority: 1,
+				enabledByDefault: true,
+				async run() {
+					return { status: "skipped", diagnostics: [], semantic: "none" };
+				},
+			});
+			registry.register({ ...oxlintRunner, priority: 2 });
+			registry.register({
+				id: "biome-check-json",
+				appliesTo: ["jsts"],
+				priority: 3,
+				enabledByDefault: true,
+				async run() {
+					biomeCalls.push(Date.now());
+					return { status: "succeeded", diagnostics: [], semantic: "none" };
+				},
+			});
+
+			const groups: RunnerGroup[] = [
+				{
+					mode: "fallback",
+					runnerIds: ["eslint", "oxlint", "biome-check-json"],
+				},
+			];
+			const ctx = {
+				...createCtx(filePath, env.tmpDir),
+				hasTool: async () => false,
+			};
+
+			const result = await dispatchForFile(ctx as never, groups, registry);
+
+			// The regression this pins: a "failed" status on oxlint's warning-only
+			// exit-0 result would NOT stop a fallback group (dispatcher.ts's
+			// runGroup only stops at "succeeded"), so biome-check-json would run
+			// too — extra spawns, a possible install, duplicate findings.
+			expect(biomeCalls).toHaveLength(0);
+			expect(result.warnings.some((w) => w.tool === "oxlint")).toBe(true);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/fixtures/runner-output/oxlint/warning-exit-zero.captured.json
+++ b/tests/fixtures/runner-output/oxlint/warning-exit-zero.captured.json
@@ -1,0 +1,20 @@
+{
+	"provenance": {
+		"runner": "oxlint",
+		"tool": "oxlint",
+		"version": "1.79.0",
+		"command": "oxlint --format json bad.js",
+		"argv": [
+			"--format",
+			"json",
+			"bad.js"
+		],
+		"workspace": "tests/fixtures/tool-smoke/js-oxlint-warning",
+		"platform": "win32-x64",
+		"capturedAt": "2026-08-21"
+	},
+	"file": "bad.js",
+	"exitCode": 0,
+	"stdout": "{ \"diagnostics\": [{\"message\": \"Variable 'unused' is declared but never used. Unused variables should start with a '_'.\",\"code\": \"eslint(no-unused-vars)\",\"severity\": \"warning\",\"url\": \"https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\",\"help\": \"Consider removing this declaration.\",\"filename\": \"bad.js\",\"labels\": [{\"label\": \"'unused' is declared here\",\"span\": {\"offset\": 188,\"length\": 6,\"line\": 4,\"column\": 8}}]}],\n              \"number_of_files\": 1,\n              \"number_of_rules\": 96,\n              \"threads_count\": 16,\n              \"start_time\": 0.606185\n            }\n            ",
+	"stderr": ""
+}

--- a/tests/fixtures/tool-smoke/js-oxlint-warning/bad.js
+++ b/tests/fixtures/tool-smoke/js-oxlint-warning/bad.js
@@ -1,0 +1,6 @@
+// Tool-smoke fixture (#1947) — no .oxlintrc.json override, so oxlint's default
+// severity for no-unused-vars (warning) applies and the process exits 0.
+export function demo() {
+	const unused = 1;
+	return 2;
+}


### PR DESCRIPTION
## What

oxlint exits 0 whenever nothing reaches error severity, and warning is
its own default severity. `clients/dispatch/runners/oxlint.ts` treated
any exit 0 as "nothing found" and returned early, so a real run that
produced only warning-severity findings — a full JSON report, exit 0
— was discarded. pi-lens saw no oxlint warnings at all, only findings
a project had explicitly raised to error severity.

The runner now parses stdout unconditionally and branches on the
parsed diagnostic count instead of the exit code. Zero diagnostics
still maps to a clean `succeeded`/`none` (a genuinely clean run also
exits 0 but its JSON report carries an empty `diagnostics` array, so
this distinguishes the two cases). A diagnostic at error severity
still maps to `failed`/`blocking`, unchanged. A warning-only result
maps to `succeeded`/`warning` when the exit was 0, and to
`failed`/`warning` when the exit was nonzero — unchanged from the
runner's existing nonzero-exit mapping (see review round 1 below for
why the exit-0 case specifically must report `succeeded`).

## Why

#1946 fixed four parser bugs of the #1933 shape but deliberately left
oxlint's exit-0 case for its own PR: reading output on exit 0 is a
behavior widening on the hottest dispatch path (every JS/TS save), and
needed its own noise assessment. Decision: yes, surface warnings — a
project's oxlint warnings are real signal the agent should see, and
the volume change is bounded to files that already have oxlint
warnings today (previously invisible, now visible).

## Verification

- Fixture: `tests/fixtures/runner-output/oxlint/warning-exit-zero.captured.json`
  — real oxlint 1.79.0 output, exit 0, one `no-unused-vars` warning,
  captured via `scripts/capture-runner-fixtures.mjs oxlint` against a
  new workspace fixture (`tests/fixtures/tool-smoke/js-oxlint-warning`,
  no `.oxlintrc.json` override) with full provenance including
  `provenance.argv`, following #1946's convention.
- Red-first (initial fix): ran `captured-real-output.test.ts -t oxlint`
  against pre-fix code with the fixture added — 1 failed (`oxlint
  parsed 0 diagnostics out of real oxlint 1.79.0 output (exit 0)`), 1
  passed (the pre-existing error-severity fixture).
- Red-first (review round 1, F1/F2): added two unit cases to
  `oxlint.test.ts` and ran them against the round-1 code (status
  unconditionally `"failed"` when diagnostics exist) — both failed:
  `expected 'failed' to be 'succeeded'`, and the fallback-stop probe
  recorded `biome-check-json` invoked once when it should never run.
  Both pass after the F1 fix below.
- Post-fix: `oxlint.test.ts`, `captured-real-output.test.ts -t oxlint`,
  `exit-blind-runners.test.ts`, `run-outcome-ratchet.test.ts`,
  `smoke-fixture-coverage.test.ts`, `capture-runner-output.test.ts`,
  `autofix-policy-consistency.test.ts`, `plan-exposure.test.ts`,
  `runner-helpers.test.ts`, `install-attempt-evidence.test.ts`,
  `tool-policy.test.ts`, `dispatcher-flow.test.ts` — every test file
  referencing `oxlint` outside the installer-lifecycle tool-fetch
  suites (which only use "oxlint" as a package-manager id, not the
  parser), plus the dispatcher's own fallback-semantics suite. All
  green, 270+ tests total across these files.
- `npm run build` before every run; `npm run lint` (tsc typecheck)
  clean.
- Full suite deferred to CI per repo policy.

## Review round 1

Reviewer findings, all fixed on this branch:

- **F1 (high) — status choice broke the fallback group.** The initial
  fix always returned `status: "failed"` whenever any diagnostic
  existed, matching the runner's own nonzero-exit convention but not
  what dispatch needs on exit 0. `plan.ts`'s jsts group is
  `mode: "fallback"` over `["eslint", "oxlint", "biome-check-json"]`,
  and `dispatcher.ts`'s `runGroup` only stops the chain at the first
  `status: "succeeded"` result. A `"failed"` status on a mere warning
  let `biome-check-json` run again on every JS/TS save that has an
  oxlint warning — 2+ extra spawns, a possible install, and duplicate
  findings for the same file. Fixed: exit 0 with only warning-severity
  diagnostics now returns `status: "succeeded"`, `semantic: "warning"`,
  matching the sibling convention on the exit-0 path (`biome-check.ts:352`,
  `golangci-lint.ts:168`, `rubocop.ts:135`, all of which key `status`
  off blocking severity rather than the raw exit code). Findings still
  reach the delivery pipeline regardless of `status` —
  `dispatcher.ts:829-833,993-995` buckets by each diagnostic's own
  `semantic`, so a warning stays a warning either way. The nonzero-exit
  case is untouched (still `status: "failed"` for a warning-only
  result there, matching the pre-existing pinned test) — narrowing the
  fix to exactly the new exit-0 path the reviewer flagged, not
  reworking the runner's older nonzero-exit convention. (SonarCloud's
  new-code gate flagged the first cut of this as a nested ternary,
  S3358; flattened to `!hasBlocking && result.status === 0 ?
  "succeeded" : "failed"`, logically identical and still caught by
  both regression cases below.)
- **F2 (medium) — missing unit case.** Added
  `"reports exit-0 warning findings as succeeded, not failed"` to
  `oxlint.test.ts`, pinning exit 0 + warning-severity JSON → `status:
  "succeeded"`, `semantic: "warning"`, diagnostics present. Also added
  `"a warning-only exit-0 run stops plan.ts's jsts fallback group at
  oxlint"`, an integration-style case that runs the real
  `dispatchForFile` + `RunnerRegistry` over the actual
  `["eslint", "oxlint", "biome-check-json"]` group shape with the real
  oxlint runner and a spy `biome-check-json`, asserting the spy is
  never called. Both reproduce red against the round-1 code (see
  above) and green after the fix.
- **F3 (medium) — golangci-lint claim was wrong.** The original sweep
  called `golangci-lint.ts` ruled out because it "exits nonzero on any
  finding by default." `run.issues-exit-code` is settable to 0 in
  `.golangci.yml`, and the runner only ever runs where that config
  file exists (`hasGolangciConfig` gate, `golangci-lint.ts:136`) — so
  the exact config surface that could reproduce this class is always
  present when the runner runs. Removed from this PR's ruled-out list;
  moved to #1954's scope per the reviewer.

## Class sweep

Pattern: grepped every `clients/dispatch/runners/*.ts` for
`status === 0` early-return shapes (18 hits). Population: every JS/TS
(`appliesTo: ["jsts"]`) and general lint runner using a bare
`status === 0` return with no output check.

- **`eslint.ts:148`** — identical shape. ESLint also exits 0 on
  warnings-only by default. Filed as **#1954** rather than folded in
  here, per the same "own noise assessment" boundary #1947 itself
  drew. `golangci-lint.ts` (F3 above) is now in #1954's scope too, not
  ruled out.
- Checked and ruled out via known CLI semantics (not a live capture):
  `cue-vet.ts`, `fish-indent.ts`, `shfmt.ts` (no severity concept —
  errors-only or diff-based), `php-lint.ts`, `phpstan.ts`,
  `prisma-validate.ts`, `rubocop.ts` (exit nonzero on any finding by
  default, not gated on error-only severity). `psscriptanalyzer.ts`'s
  two `status === 0` sites are availability probes, not result
  parsing — not in scope.

## Blast radius

Every JS/TS file save that runs oxlint and has warning-severity
findings now surfaces them, where before it surfaced nothing. That
surfacing costs nothing extra downstream: exit-0 warnings return
`status: "succeeded"`, so `plan.ts`'s
`["eslint", "oxlint", "biome-check-json"]` fallback group still stops
at oxlint exactly as it did before this PR — **no new spawns** beyond
oxlint's own existing invocation. (Round 1 of this PR briefly made
that claim false — see F1 above — and this fix restores it.) No
change to files with zero findings or with only error-severity
findings (unchanged behavior, already covered by the existing
`real.captured.json` fixture).

## Observability

No new failure path — this is a parse-path widening, not a new error
branch. The existing `run-outcome-ratchet.test.ts` entry for
`oxlint.ts` ("reads its own exit status; #1737 strangler") stays
accurate; the runner still reads `result.status` itself, just no
longer short-circuits on it before parsing.

Known corner, named rather than fixed here: #1948 proposes a shared
`runner-parsed-nothing` ledger row for a runner that receives non-empty
output and parses zero diagnostics — but it is unmerged on master as
of this branch. Once oxlint's exit-0 path parses unconditionally, a
future oxlint output shape that produces real (non-empty) exit-0
output but zero parsed diagnostics — a parser regression on some
future oxlint report shape, say — is invisible to #1948's proposed
rule, because #1948 is scoped to *failing* runs, and this exit-0 path
reports `succeeded` even when it parses nothing (by design: a
genuinely clean file also exits 0 with an empty diagnostics array, and
the two must not be conflated as a failure). Neither this PR nor #1948
as currently scoped closes that gap; worth a line in #1948 if it lands
after this.

Closes #1947

