### PR TITLE
fix(review-graph): grow tree cache for Tier-3 full builds (closes #1941)

### DIFF
--- a/.changelog/fix-1941-tier3-cache-capacity.md
+++ b/.changelog/fix-1941-tier3-cache-capacity.md
@@ -1,0 +1,14 @@
+---
+section: Fixed
+---
+
+- **Review-graph Tier-3 build never grew the tree cache past the 50-entry
+  default (closes #1941)** — `builder.ts`'s full-project rebuild parses every
+  non-jsts file through the shared `TreeSitterClient`'s parse-tree cache but
+  never called `ensureTreeCacheCapacity`, the #1715 fix already wired into
+  the diagnostics scanner. A project with more than 50 non-jsts files evicted
+  and re-parsed files past the 50th on every Tier-3 build. The build now
+  grows the cache to its actual per-parse working set before extraction
+  starts — the full file list on a cold build, or the checkpoint's remaining
+  files on a resumed build, since resumed files are reused from the
+  checkpoint graph and never re-parsed.

--- a/.changelog/fix-1941-tier3-cache-capacity.md
+++ b/.changelog/fix-1941-tier3-cache-capacity.md
@@ -2,11 +2,11 @@
 section: Fixed
 ---
 
-- **Review-graph Tier-3 build never grew the tree cache past the 50-entry
-  default (closes #1941)** — `builder.ts`'s full-project rebuild parses every
-  non-jsts file through the shared `TreeSitterClient`'s parse-tree cache but
-  never called `ensureTreeCacheCapacity`, the #1715 fix already wired into
-  the diagnostics scanner. A project with more than 50 non-jsts files evicted
+- **Review-graph Tier-3 build never grew the tree cache past the 50-entry default (closes #1941)** —
+  `builder.ts`'s full-project rebuild parses every non-jsts file through the
+  shared `TreeSitterClient`'s parse-tree cache but never called
+  `ensureTreeCacheCapacity`, the #1715 fix already wired into the
+  diagnostics scanner. A project with more than 50 non-jsts files evicted
   and re-parsed files past the 50th on every Tier-3 build. The build now
   grows the cache to its actual per-parse working set before extraction
   starts — the full file list on a cold build, or the checkpoint's remaining

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -4803,6 +4803,15 @@ async function _doBuildGraph(
 	const graph = resumed?.graph ?? createEmptyGraph();
 	const filesToExtract = resumed?.remaining ?? filesToBuild;
 	const treeSitterClient = getSharedTreeSitterClient();
+	// #1941: grow the tree cache to span THIS pass's actual per-parse working
+	// set before parsing starts — filesToExtract, not filesToBuild. On a cold
+	// build they're the same array; on a resumed build filesToExtract is only
+	// the checkpoint's remaining (unprocessed) files, since resumed files are
+	// reused from the checkpoint graph and never re-parsed here. Sizing to
+	// filesToBuild on a resume would over-grow the cache for files this pass
+	// never touches. Same #1715 pattern as scanner.ts:147 — monotonic and
+	// ceiling-bounded inside ensureTreeCacheCapacity itself.
+	treeSitterClient?.ensureTreeCacheCapacity(filesToExtract.length);
 	const extractionStartedAt = Date.now();
 	// Seeded with the reused files' hashes on resume so the completed snapshot
 	// still records a hash for every file (needed by #202 incremental next time).

--- a/tests/clients/review-graph/tier3-cache-capacity.test.ts
+++ b/tests/clients/review-graph/tier3-cache-capacity.test.ts
@@ -1,0 +1,154 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import {
+	buildOrUpdateGraph,
+	clearGraphCache,
+	clearReviewGraphWorkspaceCache,
+	resetReviewGraphPersistWorkerForTests,
+} from "../../../clients/review-graph/builder.js";
+import {
+	_resetSharedTreeSitterClientForTests,
+	getSharedTreeSitterClient,
+} from "../../../clients/tree-sitter-shared.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+// #1941: the Tier-3 full review-graph build parses a project's whole
+// non-jsts file set through the shared `TreeSitterClient`'s `TreeCache`
+// (`extractTreeSitterSymbols` -> `withParsedTree` -> `treeCache.get`/`.set`,
+// clients/tree-sitter-client.ts:1490-1509) but never called
+// `ensureTreeCacheCapacity` before doing so — the #1715 fix wired that call
+// into the diagnostics scanner (scanner.ts:147) but review-graph's sibling
+// full-project scan was left at the interactive 50-entry default
+// (`TREE_CACHE_DEFAULT_MAX_SIZE`). A project whose non-jsts file count
+// exceeds 50 evicts and re-parses files past the 50th on every Tier-3 build.
+//
+// Uses python fixtures (kind "python") because the jsts kind never routes
+// through `TreeCache` (`addFileToGraph`, builder.ts:3921 — jsts uses its own
+// extraction path), so a jsts-only fixture could never observe this class of
+// defect.
+
+const roots: string[] = [];
+
+// Varying, non-uniform per-file sizes (#1942 review-round shape) so a
+// content-hash/byte-count assertion can't be trivially satisfied by a
+// uniform fixture; not load-bearing for THIS test's assertions (which check
+// cache capacity and hit/miss counters, not bytes), but keeps the fixture
+// itself honest about what "a real project" looks like.
+function pySource(i: number): string {
+	const bodyLines = 3 + ((i * 17) % 11);
+	const lines = Array.from(
+		{ length: bodyLines },
+		(_, j) => `    value_${j} = ${i * 31 + j}`,
+	);
+	return `def fn_${i}():\n${lines.join("\n")}\n    return value_0\n`;
+}
+
+function writePythonFiles(root: string, count: number): string[] {
+	const dir = path.join(root, "src");
+	fs.mkdirSync(dir, { recursive: true });
+	const files: string[] = [];
+	for (let i = 0; i < count; i++) {
+		const file = path.join(dir, `mod_${i}.py`);
+		fs.writeFileSync(file, pySource(i));
+		files.push(file);
+	}
+	return files;
+}
+
+function makeRoot(prefix: string): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	roots.push(root);
+	return root;
+}
+
+beforeEach(() => {
+	// Keep the debounced disk persist from landing mid-test so a second
+	// `buildOrUpdateGraph` call still takes the Tier-3 full-build path
+	// instead of serving a just-written disk cache.
+	process.env.PI_LENS_GRAPH_PERSIST_DEBOUNCE_MS = "3600000";
+});
+
+afterEach(() => {
+	clearReviewGraphWorkspaceCache();
+	clearGraphCache();
+	resetReviewGraphPersistWorkerForTests();
+	_resetSharedTreeSitterClientForTests();
+	delete process.env.PI_LENS_GRAPH_PERSIST_DEBOUNCE_MS;
+	delete process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER;
+	for (const root of roots.splice(0)) removeTempDirSync(root);
+});
+
+describe("Tier-3 full build grows the tree cache to its file count (#1941)", () => {
+	it("sizes the cache past the 50-entry default so a second Tier-3 build on the same files hits, not re-parses", async () => {
+		const root = makeRoot("pi-lens-t3-cap-");
+		const fileCount = 60; // over TREE_CACHE_DEFAULT_MAX_SIZE (50)
+		writePythonFiles(root, fileCount);
+
+		await buildOrUpdateGraph(root, [], new FactStore());
+
+		const client = getSharedTreeSitterClient();
+		expect(client).not.toBeNull();
+		const afterFirst = client?.getParseCacheStats();
+		// Pinning the fix directly: the cache must have grown to span this
+		// build's working set, not sat at the 50-entry default.
+		expect(afterFirst?.maxSize).toBeGreaterThanOrEqual(fileCount);
+		// Every file is still resident — nothing was evicted mid-build by a
+		// cache that grew too late (or not at all).
+		expect(afterFirst?.size).toBe(fileCount);
+
+		// Force a second Tier-3 build over the identical, unchanged file set
+		// (workspace/build caches cleared; TreeCache itself stays warm, as it
+		// would across two scans in the same live process).
+		clearReviewGraphWorkspaceCache(root);
+		clearGraphCache();
+		await buildOrUpdateGraph(root, [], new FactStore());
+
+		const afterSecond = client?.getParseCacheStats();
+		// The #1715 pattern: a cache sized for the whole working set records
+		// zero capacityMisses across both builds. Deleting the
+		// `ensureTreeCacheCapacity` call (or reverting to the 50-entry
+		// default) makes files 51-60 evict-and-reparse on every build,
+		// which shows up here as capacityMisses > 0.
+		expect(afterSecond?.capacityMisses).toBe(0);
+	}, 30000);
+});
+
+describe("Tier-3 checkpoint resume sizes the cache to the RESUMING pass, not the original target (#1941)", () => {
+	it("grows the cache to the checkpoint's remaining file count, not the full project's filesToBuild count", async () => {
+		const root = makeRoot("pi-lens-t3-cap-resume-");
+		const totalFiles = 90;
+		const stopAfter = 20;
+		const expectedRemaining = totalFiles - stopAfter;
+		writePythonFiles(root, totalFiles);
+
+		// Session A: killed mid-build after `stopAfter` files, having written
+		// a checkpoint (same seam as tests/clients/review-graph/checkpoint-resume.test.ts).
+		process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER = String(stopAfter);
+		await expect(
+			buildOrUpdateGraph(root, [], new FactStore()),
+		).rejects.toThrow(/checkpoint_test_abort/);
+		delete process.env.PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER;
+
+		// Session B: a new process would start with a cold tree cache — reset
+		// the singleton so the capacity we observe below can only have come
+		// from THIS resumed pass, not session A's cold-build call.
+		_resetSharedTreeSitterClientForTests();
+		clearReviewGraphWorkspaceCache(root);
+		clearGraphCache();
+
+		await buildOrUpdateGraph(root, [], new FactStore());
+
+		const client = getSharedTreeSitterClient();
+		// If the fix sized capacity to `filesToBuild.length` (90, the
+		// original full-project target) instead of the resumed pass's actual
+		// per-parse working set (`filesToExtract.length`, the checkpoint's 70
+		// remaining files), this would read 90, not 70. Resumed files are
+		// reused from the checkpoint graph and never re-parsed in this pass,
+		// so sizing to the full target would over-grow the cache for files
+		// this pass never touches.
+		expect(client?.getParseCacheStats().maxSize).toBe(expectedRemaining);
+	}, 30000);
+});


### PR DESCRIPTION
## What

Review-graph's Tier-3 full build (`clients/review-graph/builder.ts`, the
`_doBuildGraph` cold/resumed full-project path around line 4805) parses
every non-jsts file through the shared `TreeSitterClient`'s `TreeCache`
(`extractTreeSitterSymbols` -> `withParsedTree` -> `treeCache.get`/`.set`,
`clients/tree-sitter-client.ts:1490-1509`) but never called
`ensureTreeCacheCapacity` before starting. #1715 wired that call into the
diagnostics scanner (`scanner.ts:147`); this was the one other full-project
file-list consumer left at the interactive 50-entry default
(`TREE_CACHE_DEFAULT_MAX_SIZE`).

The fix calls `treeSitterClient?.ensureTreeCacheCapacity(filesToExtract.length)`
right after `filesToExtract` is computed (builder.ts:4805-4813), before
`extractAndDrainIr` starts.

## Why filesToExtract, not filesToBuild

The issue asked for independent verification against the checkpoint/resume
machinery (`tryResumeFromCheckpoint`). `filesToExtract` is already the
variable the existing code uses as the per-parse working set
(`resumed?.remaining ?? filesToBuild`, builder.ts:4804):

- **Cold build**: `resumed` is `null`, so `filesToExtract === filesToBuild`
  — sizing the cache to either is equivalent.
- **Resumed build**: `resumed.remaining` (`tryResumeFromCheckpoint`,
  builder.ts:2710) is the target file list minus every file whose checkpoint
  hash still matches its current content. Those reused files are seeded
  straight into the graph from the checkpoint (`resumed.graph`) and are
  **never re-parsed** in this pass — only `filesToExtract` calls
  `addFileToGraph` -> `extractTreeSitterSymbols` (the extraction loop at
  builder.ts:4821-4882 iterates `filesToExtract`, not `filesToBuild`).

Sizing to `filesToBuild.length` on a resumed build would grow the cache for
files this pass never touches — correct in the sense that the cache would
still be big enough, but not the actual per-parse working set the issue
asked to verify. `deriveScanTreeCacheCapacity` is already monotonic (never
shrinks a capacity an earlier, larger scan already grew), so sizing to the
resumed remainder is safe: a later cold build sizing to the full project
count still grows it further if needed.

## Tests (red-first)

`tests/clients/review-graph/tier3-cache-capacity.test.ts`, two cases, both
proven red on pre-fix `builder.ts` (reverted via `git checkout --`, `npm run
build`, ran, captured output, then reapplied the fix):

1. **Capacity growth + reuse** (`#1715` test shape) — 60 python files (over
   the 50-entry default; python because jsts never routes through
   `TreeCache`, so a jsts-only fixture can't observe this defect). Asserts
   `maxSize >= 60` and `size === 60` after the first build, then forces a
   second Tier-3 build over the identical unchanged file set and asserts
   cumulative `capacityMisses === 0`.
   - Pre-fix: `expected 50 to be greater than or equal to 60`.
   - Post-fix: passes.
2. **Resume interaction** (mutation-proof against `filesToBuild.length` vs
   `filesToExtract.length`) — 90 files, checkpoint-killed after 20
   (`PI_LENS_GRAPH_CHECKPOINT_TEST_STOP_AFTER`), tree-sitter client reset to
   simulate a fresh process, then resumed. Asserts `maxSize === 70` (the
   remaining count), which only passes if the capacity call uses
   `filesToExtract.length`; using `filesToBuild.length` (90) fails it.
   - Pre-fix: `expected 50 to be 70` (no capacity call at all).
   - Post-fix: passes.

```
tests/clients/review-graph/tier3-cache-capacity.test.ts (2 tests | 2 passed)
```

Also ran, all green (one `import-resolvers.test.ts` timeout on the first
pass reproduced as a pre-existing contention flake — passed in isolation and
on rerun of the full set, unrelated to this change):

```
tests/clients/review-graph/  tests/clients/tree-sitter-cache.test.ts
tests/clients/project-diagnostics/scanner-cache-stats-scope.test.ts
Test Files  18 passed | 2 skipped (20)
     Tests  146 passed | 2 skipped (148)
```

## Memory blast radius

Same accounting #1715/#1935 established: ~330KB of resident WASM heap per
held tree (measured on ~3.6KB synthetic TypeScript sources), capped at
`TREE_CACHE_SCAN_CAPACITY_CEILING` (500 entries, or its
`PI_LENS_TREE_SITTER_CACHE_SCAN_CAP` override) regardless of a project's
real file count. Tier-3 project file counts run from tens to low thousands;
before this fix the cache never exceeded 50 entries (~16MB worst case) for
Tier-3 specifically. After this fix, the same 500-entry ceiling applies:
~165MB worst case, identical to the diagnostics scanner's already-accepted
bound. No new ceiling was introduced — this PR only makes Tier-3 use the
one that already existed for scan-shaped callers.

## Class sweep

**Pattern sweep** — every `getSharedTreeSitterClient()` call site across
`clients/ tools/ mcp/ scripts/ index.ts` (`tools/`, `mcp/`, `scripts/` had no
matches):

| Site | Verdict |
|---|---|
| `clients/project-diagnostics/scanner.ts:142` | Already correct — #1715's fix, has `ensureTreeCacheCapacity` at :147 |
| `clients/review-graph/builder.ts:4805` | Fixed by this PR |
| `clients/review-graph/builder.ts:3369,3401,3478` | Not applicable — per-file extraction helpers (`getExtractor`, `extractTreeSitterSymbols`, `captureReviewGraphStructuralIr`) called *by* the Tier-3 loop; capacity ownership belongs at the loop's call site, now fixed |
| `clients/review-graph/builder.ts` `tryIncrementalFromCache` (4190) | Not applicable — sizes to a diff (`added`+`trulyChanged`), a bounded per-edit delta by design, not a full-project scan |
| `clients/blocker-freshness.ts:160,252` | Not applicable — single-file forward-import resolution, bounded by `MAX_DRIFT_CHECK_IMPORTS` (128), not a full-list scan |
| `clients/dispatch/runners/tree-sitter.ts:390` | Not applicable — per-edit dispatch runner, single `ctx.filePath` |
| `clients/memory-sampler.ts:111` | Not applicable — reads `getParseCacheStats()` only, never parses |
| `clients/module-report.ts:476,518` | Not applicable — `moduleReport`/`readSymbol`/`readEnclosing` are single-target reports (`file: string` parameter), not project-wide scans |
| `clients/tree-sitter-shared.ts:168` | Not applicable — `withTreeSitterRoot`, a single-content helper |

**Population sweep**: the "full project file list through `TreeCache`"
family has exactly two members — the diagnostics scanner (#1715, already
fixed) and review-graph's Tier-3 build (this PR). No third member found.

## Observability

The existing `review_graph_full` `cache_stats` record
(`clients/tree-sitter-logger.ts`, emitted at builder.ts:4897-4905 via
`logTreeSitterCacheStats`) already carries `stats.capacityMisses` per build —
that's the real, non-vacuous record the issue pointed at. This fix makes its
`capacityMisses` field mean something different in production: it should now
read 0 (or near-0) for a Tier-3 build's own working set instead of scaling
with `fileCount - 50`. No new record was needed; the gap was that nothing
acted on what the existing one already showed.

## Verification

- `npm run build` before every test run.
- Lint (`npm run lint` = `tsc --project tsconfig.json`): clean, no errors.
- Full suite deferred to CI per repo policy.
