### PR TITLE
perf(install): warm pi's jiti transform cache at install (refs #1926)

### DIFF
--- a/.changelog/fix-1926-warm-loader-cache.md
+++ b/.changelog/fix-1926-warm-loader-cache.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Updating pi-lens no longer costs a five-second first session (refs #1926)** — pi loads the extension through jiti, which transforms the ~4MB `dist/index.js` bundle and caches the result. Every `git:` install or update produced a new bundle, so the next interactive session paid that transform: 4847ms of `module import`, against a 138ms steady state. The `prepare` chain now runs the transform itself, in `scripts/warm-loader-cache.mjs`, writing the same cache entry pi reads. The first session after an update is warm. The step runs last, is best-effort, and never fails an install; set `PI_LENS_SKIP_WARM_CACHE` to skip it. Each run appends one line to `~/.pi-lens/install.log`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "vitest": "^4.1.1"
       },
       "optionalDependencies": {
+        "jiti": "^2.7.0",
         "web-tree-sitter": "0.25.10"
       },
       "peerDependencies": {
@@ -3699,6 +3700,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "tsc --project tsconfig.build.json",
     "build:dist": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && npx --yes -p typescript@7.0.2 tsc --project tsconfig.dist.json --noCheck && npm run bundle:dist",
     "bundle:dist": "node scripts/bundle-dist.mjs",
-    "prepare": "npm run build:dist && node scripts/download-grammars.js --core --dest grammars && node scripts/setup-git-hooks.mjs",
+    "prepare": "npm run build:dist && node scripts/download-grammars.js --core --dest grammars && node scripts/setup-git-hooks.mjs && node scripts/warm-loader-cache.mjs",
     "lint": "tsc --project tsconfig.json",
     "watch": "tsc --watch",
     "test": "node scripts/with-test-lock.mjs -- vitest run",
@@ -81,6 +81,8 @@
     "scripts/analyze-pi-lens-logs.mjs",
     "scripts/install-selftest.mjs",
     "scripts/lib/host-provided-deps.mjs",
+    "scripts/lib/warm-loader-cache.mjs",
+    "scripts/warm-loader-cache.mjs",
     "scripts/rpc-load-check.mjs",
     "README.md",
     "CHANGELOG.md",
@@ -112,6 +114,7 @@
     }
   },
   "optionalDependencies": {
+    "jiti": "^2.7.0",
     "web-tree-sitter": "0.25.10"
   },
   "devDependencies": {

--- a/scripts/lib/warm-loader-cache.d.mts
+++ b/scripts/lib/warm-loader-cache.d.mts
@@ -1,3 +1,18 @@
+export declare function jitiHash(text: string, length?: number): string;
+
+export declare function expectedCacheFileName(entry: string): string;
+
+export declare function verifyCacheEntry(args: {
+	cacheDir: string;
+	fileName: string;
+	source: string;
+	fsDeps: {
+		existsSync: (p: string) => boolean;
+		readFileSync: (p: string) => string;
+		isWritable: (p: string) => boolean;
+	};
+}): { ok: boolean; reason: string | null; transformVersion: string | null };
+
 export declare function resolveJitiCacheDir(deps: {
 	tmpdir: () => string;
 	env: Record<string, string | undefined>;

--- a/scripts/lib/warm-loader-cache.d.mts
+++ b/scripts/lib/warm-loader-cache.d.mts
@@ -1,0 +1,26 @@
+export declare function resolveJitiCacheDir(deps: {
+	tmpdir: () => string;
+	env: Record<string, string | undefined>;
+	cwd: () => string;
+	join: (a: string, b: string) => string;
+}): string;
+
+export declare function buildStubAliases(
+	hostProvidedPackages: readonly string[],
+): Record<string, string>;
+
+export declare const STUB_TARGET: string;
+
+export declare function warmSkipReason(state: {
+	env: Record<string, string | undefined>;
+	distEntryExists: boolean;
+	jitiResolvable: boolean;
+}): string | null;
+
+export declare function appendBounded(
+	existingLines: string[],
+	line: string,
+	max?: number,
+): string[];
+
+export declare const INSTALL_LOG_MAX_LINES: number;

--- a/scripts/lib/warm-loader-cache.mjs
+++ b/scripts/lib/warm-loader-cache.mjs
@@ -40,6 +40,132 @@
  * nothing; it can never hand pi the wrong code.
  */
 
+import { createHash, getFips } from "node:crypto";
+
+/**
+ * Mirror of jiti's `utils_hash`: md5 truncated to `length` hex characters, or
+ * sha256 where FIPS mode forbids md5. jiti makes the same substitution, so the
+ * two agree on every machine.
+ *
+ * @param {string} text
+ * @param {number} [length]
+ * @returns {string}
+ */
+export function jitiHash(text, length = 8) {
+	let fips = false;
+	try {
+		fips = Boolean(getFips?.());
+	} catch {
+		fips = false;
+	}
+	return createHash(fips ? "sha256" : "md5")
+		.update(text)
+		.digest("hex")
+		.slice(0, length);
+}
+
+/**
+ * The cache file jiti writes for an async import of `entry`.
+ *
+ * Mirror of jiti's `getCache` naming:
+ * `<basename(dirname(file))>-<basename up to the first dot>.<hash(file)>.mjs`.
+ * jiti hashes the POSIX-normalised absolute path, so the separators are
+ * converted here. The drive-letter case is left exactly as the caller resolved
+ * it, because jiti does not touch it either. Verified against pi's own cache
+ * directory: the md5 of the dogfood install's forward-slashed entry path,
+ * truncated to 8 characters, is the `db18768f` in the
+ * `dist-index.db18768f.mjs` pi had already written.
+ *
+ * @param {string} entry absolute path to the extension entry
+ * @returns {string}
+ */
+export function expectedCacheFileName(entry) {
+	const posix = entry.split("\\").join("/");
+	const segments = posix.split("/");
+	const base = segments.pop() ?? posix;
+	const parent = segments.pop() ?? "";
+	const dot = base.indexOf(".");
+	const stem = dot <= 0 ? base : base.slice(0, dot);
+	return `${parent}-${stem}.${jitiHash(posix)}.mjs`;
+}
+
+/**
+ * Did the warm actually leave a cache entry pi can use?
+ *
+ * Elapsed time is not evidence. jiti can return from an import having written
+ * nothing, and every such path exits 0:
+ *
+ *   - the cache directory is not writable. jiti's `prepareCacheDir` catches
+ *     that, sets `fsCache` to false, and transforms in memory from then on.
+ *   - jiti imported the entry natively. `tryNative` skips the transform
+ *     entirely, so nothing is cached. That path is reachable whenever the
+ *     entry's imports resolve, which makes an unverified warm's success
+ *     CONTINGENT on native resolution failing — a condition this script neither
+ *     controls nor observes.
+ *   - a cache entry exists but does not match the source. jiti validates the
+ *     body against a trailing version-and-source-hash marker, so a stale or
+ *     truncated file is a miss for pi and the session pays the transform.
+ *
+ * Checking the file is what turns "the import returned" into "pi will hit".
+ *
+ * @param {object} args
+ * @param {string} args.cacheDir
+ * @param {string} args.fileName
+ * @param {string} args.source contents of the entry, for the marker check
+ * @param {object} args.fsDeps
+ * @param {(p: string) => boolean} args.fsDeps.existsSync
+ * @param {(p: string) => string} args.fsDeps.readFileSync
+ * @param {(p: string) => boolean} args.fsDeps.isWritable
+ * @returns {{ok: boolean, reason: string | null, transformVersion: string | null}}
+ */
+export function verifyCacheEntry({ cacheDir, fileName, source, fsDeps }) {
+	const file = `${cacheDir}/${fileName}`;
+	if (!fsDeps.existsSync(file)) {
+		if (!fsDeps.isWritable(cacheDir)) {
+			return {
+				ok: false,
+				reason: `cache directory is not writable: ${cacheDir}`,
+				transformVersion: null,
+			};
+		}
+		return {
+			ok: false,
+			reason:
+				"jiti wrote no cache entry — it imported the entry natively, so the " +
+				"transform was never cached",
+			transformVersion: null,
+		};
+	}
+	let body;
+	try {
+		body = fsDeps.readFileSync(file);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return {
+			ok: false,
+			reason: `cache entry unreadable: ${message}`,
+			transformVersion: null,
+		};
+	}
+	const marker = /\/\* v([^-\s]+)-([0-9a-f]+) \*\/\s*$/.exec(body);
+	if (!marker) {
+		return {
+			ok: false,
+			reason: "cache entry has no jiti version marker — pi will re-transform",
+			transformVersion: null,
+		};
+	}
+	if (marker[2] !== jitiHash(source, marker[2].length)) {
+		return {
+			ok: false,
+			reason:
+				"cache entry does not match the built entry — pi will re-transform",
+			transformVersion: marker[1],
+		};
+	}
+	return { ok: true, reason: null, transformVersion: marker[1] };
+}
+
 /**
  * Mirror of jiti's `prepareCacheDir` fallback branch.
  *

--- a/scripts/lib/warm-loader-cache.mjs
+++ b/scripts/lib/warm-loader-cache.mjs
@@ -97,16 +97,23 @@ export function expectedCacheFileName(entry) {
  *
  *   - the cache directory is not writable. jiti's `prepareCacheDir` catches
  *     that, sets `fsCache` to false, and transforms in memory from then on.
- *   - jiti imported the entry natively. `tryNative` skips the transform
- *     entirely, so nothing is cached. That path is reachable whenever the
- *     entry's imports resolve, which makes an unverified warm's success
- *     CONTINGENT on native resolution failing — a condition this script neither
- *     controls nor observes.
+ *   - the entry imported natively and nothing needed transforming. For an
+ *     async-imported ESM `.js` file jiti's `evalModule` attempts a native
+ *     import UNCONDITIONALLY, and only falls back to the transform when that
+ *     import rejects. So the cache exists at all because native import fails in
+ *     a real `--omit=dev` install, where the host-provided specifiers do not
+ *     resolve. That is the same reason pi's own load transforms the bundle,
+ *     which is why the warm and pi agree — but it is a property of the
+ *     environment, not of this script.
  *   - a cache entry exists but does not match the source. jiti validates the
  *     body against a trailing version-and-source-hash marker, so a stale or
  *     truncated file is a miss for pi and the session pays the transform.
  *
- * Checking the file is what turns "the import returned" into "pi will hit".
+ * Checking the file is what turns "the import returned" into "the warm's own
+ * jiti cached this entry, with these versions". It is not a promise about pi:
+ * pi-side drift shows up as a version delta between this record and pi's, which
+ * is a thing to read from the log, not something an install can detect.
+ * An absent entry always warrants a look, never a shrug.
  *
  * @param {object} args
  * @param {string} args.cacheDir
@@ -128,11 +135,12 @@ export function verifyCacheEntry({ cacheDir, fileName, source, fsDeps }) {
 				transformVersion: null,
 			};
 		}
+		// Deliberately generic. Several routes end here — a native import that
+		// needed no transform, a transform that threw before the write — and this
+		// check cannot tell them apart, so it does not name one.
 		return {
 			ok: false,
-			reason:
-				"jiti wrote no cache entry — it imported the entry natively, so the " +
-				"transform was never cached",
+			reason: `no cache entry was written: ${fileName}`,
 			transformVersion: null,
 		};
 	}

--- a/scripts/lib/warm-loader-cache.mjs
+++ b/scripts/lib/warm-loader-cache.mjs
@@ -1,0 +1,151 @@
+/**
+ * Pure helpers for `scripts/warm-loader-cache.mjs` (#1926).
+ *
+ * pi loads an extension through jiti (`createJiti(..., { moduleCache: false,
+ * alias: … })` in `@earendil-works/pi-coding-agent`'s
+ * `dist/core/extensions/loader.js`). jiti transforms the entry with Babel and
+ * stores the result in a filesystem cache. pi-lens's `dist/index.js` is a ~4MB
+ * esbuild bundle, so that transform costs seconds: the first session after a
+ * `git:` install or update measured 4847ms of `module import`, against a 138ms
+ * steady state once the cache is warm (#1926 field report).
+ *
+ * The fix is to pay that transform at install time instead of in the first
+ * interactive session. `prepare` already builds `dist/`, so the last step of
+ * the chain runs the same transform through the same jiti, writing the same
+ * cache file pi will later read.
+ *
+ * WHY THE WARM PRODUCES A HIT FOR THE REAL LOADER
+ *
+ * jiti keys a cache entry on the transformed file, not on the jiti instance
+ * (see `getCache` in `jiti/dist/jiti.cjs`):
+ *
+ *   <basename(dirname(file))>-<basename(file) up to the first dot>
+ *   + "+map" if sourceMaps + ".i" if interopDefault
+ *   + "." + md5(file).slice(0, 8)
+ *   + ".mjs" for an async import, ".cjs" otherwise
+ *
+ * and it validates the stored body against a trailing
+ * ` /* v<TRANSFORM_VERSION>-<md5(source).slice(0,16)> *\/` marker. So the warm
+ * has to agree with pi on three things only: the absolute path of the entry,
+ * the cache directory, and the transform itself. Everything else — the alias
+ * map, `moduleCache`, which package the jiti instance was created from — is
+ * outside the key AND outside the transform. Measured, not assumed: running
+ * this warm over the dogfood install's `dist/index.js` produced a cache file
+ * byte-identical to the one pi had written, both with pi's alias map and with
+ * no alias map at all.
+ *
+ * The marker is also the safety net. If pi ships a jiti whose transform version
+ * or Babel output differs, pi recomputes the marker, does not match, and simply
+ * re-transforms. A mismatched warm costs the install a few seconds and buys
+ * nothing; it can never hand pi the wrong code.
+ */
+
+/**
+ * Mirror of jiti's `prepareCacheDir` fallback branch.
+ *
+ * jiti picks `<dir of the file that created the jiti instance>/node_modules/
+ * .cache/jiti` when that `node_modules` exists, and `<tmpdir>/jiti` otherwise.
+ * pi creates its instance from `dist/core/extensions/loader.js` inside the
+ * installed `@earendil-works/pi-coding-agent`, which has no `node_modules`
+ * sibling, so pi always lands on the tmpdir branch. The warm therefore passes
+ * `<tmpdir>/jiti` EXPLICITLY rather than letting jiti derive a directory from
+ * this repo's layout: `scripts/` has no `node_modules` sibling today, but a
+ * script moved one level up would silently start filling a private cache that
+ * pi never reads.
+ *
+ * The TMPDIR dance below is jiti's, kept verbatim so the two agree on machines
+ * where TMPDIR is set to the current directory.
+ *
+ * @param {object} deps
+ * @param {() => string} deps.tmpdir
+ * @param {Record<string, string | undefined>} deps.env
+ * @param {() => string} deps.cwd
+ * @param {(a: string, b: string) => string} deps.join
+ * @returns {string}
+ */
+export function resolveJitiCacheDir({ tmpdir, env, cwd, join }) {
+	let dir = tmpdir();
+	if (env.TMPDIR && dir === cwd() && !env.JITI_RESPECT_TMPDIR_ENV) {
+		const saved = env.TMPDIR;
+		delete env.TMPDIR;
+		dir = tmpdir();
+		env.TMPDIR = saved;
+	}
+	return join(dir, "jiti");
+}
+
+/**
+ * Alias every host-provided specifier to a path that cannot exist.
+ *
+ * The warm only needs the TRANSFORM of `dist/index.js`; jiti writes the cache
+ * entry before it evaluates the module. Evaluation then walks the bundle's
+ * external imports, none of which resolve outside pi. Pointing the
+ * host-provided ones at a stub makes that walk stop at the first one instead of
+ * resolving unrelated packages first, so the warm does the least work it can
+ * and always ends the same way. Derived from the shared host-provided list so
+ * it cannot drift from what `bundle-dist.mjs` keeps external.
+ *
+ * @param {readonly string[]} hostProvidedPackages
+ * @returns {Record<string, string>}
+ */
+export function buildStubAliases(hostProvidedPackages) {
+	/** @type {Record<string, string>} */
+	const alias = {};
+	for (const name of hostProvidedPackages) {
+		alias[name] = STUB_TARGET;
+	}
+	return alias;
+}
+
+/** A path no filesystem resolves, so aliased imports fail immediately. */
+export const STUB_TARGET = "/__pi-lens-warm-cache-stub__";
+
+/**
+ * Decide whether the warm can run, and say why not when it cannot.
+ *
+ * Every reason is a skip, never a failure: `prepare` also builds `dist/` and
+ * downloads grammars, and those steps MUST fail loudly. Cache warming is an
+ * optimisation, so it runs last and reports rather than throws — the same
+ * posture as `scripts/setup-git-hooks.mjs` (#1804).
+ *
+ * @param {object} state
+ * @param {Record<string, string | undefined>} state.env
+ * @param {boolean} state.distEntryExists
+ * @param {boolean} state.jitiResolvable
+ * @returns {string | null} skip reason, or null to proceed
+ */
+export function warmSkipReason({ env, distEntryExists, jitiResolvable }) {
+	const optOut = env.PI_LENS_SKIP_WARM_CACHE;
+	if (typeof optOut === "string" && optOut.length > 0) {
+		return "PI_LENS_SKIP_WARM_CACHE is set";
+	}
+	if (!distEntryExists) {
+		return "dist/index.js is missing — nothing to warm";
+	}
+	if (!jitiResolvable) {
+		// jiti is an optionalDependency, so `--omit=optional` (or a failed
+		// optional install) legitimately leaves it absent.
+		return "jiti is not installed — install ran without optional dependencies";
+	}
+	return null;
+}
+
+/**
+ * Keep the install log bounded: one line per install, newest last.
+ *
+ * @param {string[]} existingLines
+ * @param {string} line
+ * @param {number} [max]
+ * @returns {string[]}
+ */
+export function appendBounded(
+	existingLines,
+	line,
+	max = INSTALL_LOG_MAX_LINES,
+) {
+	const lines = [...existingLines.filter((l) => l.trim().length > 0), line];
+	return lines.slice(Math.max(0, lines.length - max));
+}
+
+/** Cap for `~/.pi-lens/install.log`. */
+export const INSTALL_LOG_MAX_LINES = 100;

--- a/scripts/warm-loader-cache.d.mts
+++ b/scripts/warm-loader-cache.d.mts
@@ -1,0 +1,3 @@
+export declare function main(): Promise<void>;
+
+export declare function run(work?: () => unknown): Promise<void>;

--- a/scripts/warm-loader-cache.mjs
+++ b/scripts/warm-loader-cache.mjs
@@ -30,7 +30,9 @@ import { HOST_PROVIDED_PACKAGES } from "./lib/host-provided-deps.mjs";
 import {
 	appendBounded,
 	buildStubAliases,
+	expectedCacheFileName,
 	resolveJitiCacheDir,
+	verifyCacheEntry,
 	warmSkipReason,
 } from "./lib/warm-loader-cache.mjs";
 
@@ -46,13 +48,17 @@ function log(message) {
  *
  * pi's install output scrolls away, so without this there is no record that the
  * warm ran, was skipped, or failed. One bounded line per install keeps the
- * question answerable after the fact.
+ * question answerable after the fact. `PI_LENS_INSTALL_LOG` redirects the file,
+ * which is how the tests read the record back.
  */
 function record(entry) {
 	try {
-		const dir = path.join(os.homedir(), ".pi-lens");
-		fs.mkdirSync(dir, { recursive: true });
-		const file = path.join(dir, "install.log");
+		const override = process.env.PI_LENS_INSTALL_LOG;
+		const file =
+			typeof override === "string" && override.length > 0
+				? override
+				: path.join(os.homedir(), ".pi-lens", "install.log");
+		fs.mkdirSync(path.dirname(file), { recursive: true });
 		const existing = fs.existsSync(file)
 			? fs.readFileSync(file, "utf8").split("\n")
 			: [];
@@ -97,7 +103,37 @@ async function loadCreateJiti() {
 	return undefined;
 }
 
-async function main() {
+/**
+ * The installed jiti's version, so a host jiti bump — which changes the marker
+ * and silently turns every warm into a cold session — is diagnosable from the
+ * record rather than from a bisect.
+ */
+function jitiVersion() {
+	try {
+		const url = import.meta.resolve
+			? import.meta.resolve("jiti/package.json")
+			: pathToFileURL(require.resolve("jiti/package.json")).href;
+		return JSON.parse(fs.readFileSync(fileURLToPath(url), "utf8")).version;
+	} catch {
+		return null;
+	}
+}
+
+/** Real-filesystem probes for `verifyCacheEntry`. */
+const fsDeps = {
+	existsSync: (p) => fs.existsSync(p),
+	readFileSync: (p) => fs.readFileSync(p, "utf8"),
+	isWritable: (p) => {
+		try {
+			fs.accessSync(p, fs.constants.W_OK);
+			return true;
+		} catch {
+			return false;
+		}
+	},
+};
+
+export async function main() {
 	const entries = extensionEntries();
 	const createJiti = await loadCreateJiti();
 	const skip = warmSkipReason({
@@ -119,9 +155,11 @@ async function main() {
 		join: path.join,
 	});
 	const alias = buildStubAliases(HOST_PROVIDED_PACKAGES);
+	const version = jitiVersion();
 
 	for (const entry of entries) {
 		const started = Date.now();
+		const cacheFile = expectedCacheFileName(entry);
 		const jiti = createJiti(pathToFileURL(entry).href, {
 			// Mirror pi's loader: no in-process module cache, aliases present.
 			// Neither affects the transform or the cache key, but staying close to
@@ -140,15 +178,56 @@ async function main() {
 		}
 		const ms = Date.now() - started;
 		const relative = path.relative(root, entry);
-		log(`warmed ${relative} in ${ms}ms (cache: ${cacheDir})`);
-		record({ status: "warmed", entry: relative, ms, cacheDir });
+
+		// The import returning proves nothing. Three exit-0 paths leave no usable
+		// entry — an unwritable cache directory, a native import that skips the
+		// transform, and a stale file that fails jiti's marker check — so read the
+		// file back before claiming the session is warm.
+		const verdict = verifyCacheEntry({
+			cacheDir,
+			fileName: cacheFile,
+			source: fs.readFileSync(entry, "utf8"),
+			fsDeps,
+		});
+		const common = {
+			entry: relative,
+			ms,
+			cacheDir,
+			cacheFile,
+			jitiVersion: version,
+		};
+		if (verdict.ok) {
+			log(`warmed ${relative} in ${ms}ms (cache: ${cacheDir}/${cacheFile})`);
+			record({
+				status: "warmed",
+				...common,
+				transformVersion: verdict.transformVersion,
+			});
+			continue;
+		}
+		log(`not cached: ${relative} after ${ms}ms — ${verdict.reason}`);
+		record({ status: "not_cached", ...common, reason: verdict.reason });
 	}
 }
 
-try {
-	await main();
-} catch (err) {
-	const message = err instanceof Error ? err.message : String(err);
-	log(`skipped: ${message}`);
-	record({ status: "failed", reason: message });
+/**
+ * Run `work`, absorbing any failure. Exported so a test can inject a throwing
+ * body and assert the process still exits 0 and still leaves a record.
+ */
+export async function run(work = main) {
+	try {
+		await work();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		log(`failed: ${message}`);
+		record({ status: "failed", reason: message });
+	}
+}
+
+const invokedPath = process.argv[1];
+const invokedDirectly =
+	typeof invokedPath === "string" &&
+	pathToFileURL(path.resolve(invokedPath)).href === import.meta.url;
+if (invokedDirectly) {
+	await run();
 }

--- a/scripts/warm-loader-cache.mjs
+++ b/scripts/warm-loader-cache.mjs
@@ -179,10 +179,10 @@ export async function main() {
 		const ms = Date.now() - started;
 		const relative = path.relative(root, entry);
 
-		// The import returning proves nothing. Three exit-0 paths leave no usable
-		// entry — an unwritable cache directory, a native import that skips the
-		// transform, and a stale file that fails jiti's marker check — so read the
-		// file back before claiming the session is warm.
+		// The import returning proves nothing. Several exit-0 paths leave no usable
+		// entry — an unwritable cache directory, an import that never reached the
+		// transform, a stale file that fails jiti's marker check — so read the file
+		// back before claiming anything was cached.
 		const verdict = verifyCacheEntry({
 			cacheDir,
 			fileName: cacheFile,

--- a/scripts/warm-loader-cache.mjs
+++ b/scripts/warm-loader-cache.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// scripts/warm-loader-cache.mjs (#1926)
+//
+// Pay pi's jiti transform of dist/index.js at install time, so no interactive
+// session pays it.
+//
+// pi loads an extension with jiti, which Babel-transforms the entry and caches
+// the result under <tmpdir>/jiti. pi-lens's entry is a ~4MB esbuild bundle, so
+// the transform is the dominant startup cost exactly once per build: the first
+// session after a `git:` install or update measured 4847ms of `module import`,
+// against 138ms once the cache is warm. `prepare` has just built that bundle,
+// so this script transforms it through the same jiti and writes the same cache
+// entry pi will read.
+//
+// See scripts/lib/warm-loader-cache.mjs for why the entry this writes is the
+// entry pi reads — the cache key, the transform-version marker that makes a
+// mismatch a miss instead of a corruption, and the measurement that proved the
+// output byte-identical to pi's own.
+//
+// POSTURE: best-effort, last in the chain, always exit 0. `prepare` also runs
+// `build:dist` and `download-grammars`, which consumers depend on and which
+// MUST fail loudly. A cache warm is an optimisation and must never share their
+// failure path — the same split `scripts/setup-git-hooks.mjs` makes (#1804).
+import * as fs from "node:fs";
+import { createRequire } from "node:module";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { HOST_PROVIDED_PACKAGES } from "./lib/host-provided-deps.mjs";
+import {
+	appendBounded,
+	buildStubAliases,
+	resolveJitiCacheDir,
+	warmSkipReason,
+} from "./lib/warm-loader-cache.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const require = createRequire(import.meta.url);
+
+function log(message) {
+	process.stderr.write(`[warm-loader-cache] ${message}\n`);
+}
+
+/**
+ * Append one JSONL record to ~/.pi-lens/install.log.
+ *
+ * pi's install output scrolls away, so without this there is no record that the
+ * warm ran, was skipped, or failed. One bounded line per install keeps the
+ * question answerable after the fact.
+ */
+function record(entry) {
+	try {
+		const dir = path.join(os.homedir(), ".pi-lens");
+		fs.mkdirSync(dir, { recursive: true });
+		const file = path.join(dir, "install.log");
+		const existing = fs.existsSync(file)
+			? fs.readFileSync(file, "utf8").split("\n")
+			: [];
+		const line = JSON.stringify({
+			ts: new Date().toISOString(),
+			event: "warm_loader_cache",
+			...entry,
+		});
+		fs.writeFileSync(file, `${appendBounded(existing, line).join("\n")}\n`);
+	} catch {
+		// The log is diagnostic. Losing it must not change the install outcome.
+	}
+}
+
+/** Entries pi will load, read from the manifest rather than hardcoded. */
+function extensionEntries() {
+	try {
+		const pkg = JSON.parse(
+			fs.readFileSync(path.join(root, "package.json"), "utf8"),
+		);
+		return (pkg.pi?.extensions ?? []).map((entry) => path.resolve(root, entry));
+	} catch {
+		return [];
+	}
+}
+
+async function loadCreateJiti() {
+	// `jiti/static` is the subpath pi's loader imports, and it is export-mapped
+	// for `import` only — `require.resolve` reports it as not exported. Resolve
+	// it the ESM way, and fall back to the package root for older runtimes.
+	for (const specifier of ["jiti/static", "jiti"]) {
+		try {
+			const url = import.meta.resolve
+				? import.meta.resolve(specifier)
+				: pathToFileURL(require.resolve(specifier)).href;
+			const mod = await import(url);
+			if (typeof mod.createJiti === "function") return mod.createJiti;
+		} catch {
+			// Try the next specifier; absence is a skip, not a failure.
+		}
+	}
+	return undefined;
+}
+
+async function main() {
+	const entries = extensionEntries();
+	const createJiti = await loadCreateJiti();
+	const skip = warmSkipReason({
+		env: process.env,
+		distEntryExists:
+			entries.length > 0 && entries.every((e) => fs.existsSync(e)),
+		jitiResolvable: typeof createJiti === "function",
+	});
+	if (skip) {
+		log(`skipped: ${skip}`);
+		record({ status: "skipped", reason: skip });
+		return;
+	}
+
+	const cacheDir = resolveJitiCacheDir({
+		tmpdir: os.tmpdir,
+		env: process.env,
+		cwd: process.cwd,
+		join: path.join,
+	});
+	const alias = buildStubAliases(HOST_PROVIDED_PACKAGES);
+
+	for (const entry of entries) {
+		const started = Date.now();
+		const jiti = createJiti(pathToFileURL(entry).href, {
+			// Mirror pi's loader: no in-process module cache, aliases present.
+			// Neither affects the transform or the cache key, but staying close to
+			// pi's call keeps the two easy to compare.
+			moduleCache: false,
+			fsCache: cacheDir,
+			alias,
+		});
+		try {
+			// jiti writes the cache entry BEFORE it evaluates the module, so the
+			// warm is complete even though evaluation then fails on the first
+			// host-provided import — those only resolve inside pi.
+			await jiti.import(entry, { default: true });
+		} catch {
+			// Expected. Evaluation is not the goal; the transform is.
+		}
+		const ms = Date.now() - started;
+		const relative = path.relative(root, entry);
+		log(`warmed ${relative} in ${ms}ms (cache: ${cacheDir})`);
+		record({ status: "warmed", entry: relative, ms, cacheDir });
+	}
+}
+
+try {
+	await main();
+} catch (err) {
+	const message = err instanceof Error ? err.message : String(err);
+	log(`skipped: ${message}`);
+	record({ status: "failed", reason: message });
+}

--- a/tests/scripts/warm-loader-cache.test.ts
+++ b/tests/scripts/warm-loader-cache.test.ts
@@ -147,10 +147,13 @@ describe("the warm is verified, not assumed (#1926)", () => {
 		expect(verdict.reason).toContain("not writable");
 	});
 
-	it("reports the native-import bypass, where nothing is cached at all", () => {
-		// jiti's tryNative path skips the transform. An unverified warm's success
-		// is contingent on native resolution FAILING, which this script neither
-		// controls nor observes — so it has to check.
+	it("reports a missing entry without naming a cause it cannot establish", () => {
+		// Several routes end with no file: a native import that needed no
+		// transform, or a transform that threw before the write. This check cannot
+		// tell them apart, so the reason stays generic. It still warrants a look —
+		// jiti attempts the native import for an async ESM `.js` unconditionally,
+		// and the cache exists only because that import fails in a real
+		// --omit=dev install.
 		const verdict = verifyCacheEntry({
 			cacheDir: "/cache",
 			fileName: "dist-index.abc12345.mjs",
@@ -158,7 +161,8 @@ describe("the warm is verified, not assumed (#1926)", () => {
 			fsDeps: { ...writable, existsSync: () => false, readFileSync: () => "" },
 		});
 		expect(verdict.ok).toBe(false);
-		expect(verdict.reason).toContain("natively");
+		expect(verdict.reason).toContain("no cache entry was written");
+		expect(verdict.reason).not.toContain("natively");
 	});
 
 	it("reports an entry whose marker does not match the built source", () => {

--- a/tests/scripts/warm-loader-cache.test.ts
+++ b/tests/scripts/warm-loader-cache.test.ts
@@ -1,0 +1,238 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { HOST_PROVIDED_PACKAGES } from "../../scripts/lib/host-provided-deps.mjs";
+import {
+	appendBounded,
+	buildStubAliases,
+	INSTALL_LOG_MAX_LINES,
+	resolveJitiCacheDir,
+	STUB_TARGET,
+	warmSkipReason,
+} from "../../scripts/lib/warm-loader-cache.mjs";
+
+// #1926 remainder. pi loads pi-lens through jiti, which Babel-transforms the
+// ~4MB dist bundle and caches the result. The first session after a `git:`
+// install paid that transform: 4847ms of `module import`, against 138ms once
+// warm. `prepare` now runs the same transform, writing the same cache entry.
+// These tests pin the three things the warm has to agree with pi about — the
+// cache directory, the entry path, and the best-effort posture — plus the
+// prepare-chain ordering that keeps the load-bearing steps load-bearing.
+
+const root = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"..",
+);
+const pkg = JSON.parse(
+	fs.readFileSync(path.join(root, "package.json"), "utf8"),
+) as {
+	scripts?: Record<string, string>;
+	files?: string[];
+	dependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+	pi?: { extensions?: string[] };
+};
+const warmScript = fs.readFileSync(
+	path.join(root, "scripts", "warm-loader-cache.mjs"),
+	"utf8",
+);
+
+describe("jiti cache directory mirrors pi's loader (#1926)", () => {
+	const join = (a: string, b: string) => `${a}/${b}`;
+
+	it("uses <tmpdir>/jiti, the branch pi's loader always lands on", () => {
+		// pi creates its jiti from dist/core/extensions/loader.js, which has no
+		// node_modules sibling, so jiti falls through to the tmpdir branch. A warm
+		// that wrote anywhere else would build a private cache pi never reads.
+		const dir = resolveJitiCacheDir({
+			tmpdir: () => "/tmp",
+			env: {},
+			cwd: () => "/somewhere/else",
+			join,
+		});
+		expect(dir).toBe("/tmp/jiti");
+	});
+
+	it("re-reads tmpdir with TMPDIR removed when TMPDIR is the cwd", () => {
+		// jiti's own quirk, mirrored verbatim: when TMPDIR points at the current
+		// directory it ignores it. Diverging here would put the warm's cache and
+		// pi's cache in different places on exactly those machines.
+		const env: Record<string, string | undefined> = { TMPDIR: "/work" };
+		let call = 0;
+		const dir = resolveJitiCacheDir({
+			tmpdir: () => (++call === 1 ? "/work" : "/real-tmp"),
+			env,
+			cwd: () => "/work",
+			join,
+		});
+		expect(dir).toBe("/real-tmp/jiti");
+		expect(env.TMPDIR, "TMPDIR must be restored").toBe("/work");
+	});
+
+	it("honours JITI_RESPECT_TMPDIR_ENV, as jiti does", () => {
+		const dir = resolveJitiCacheDir({
+			tmpdir: () => "/work",
+			env: { TMPDIR: "/work", JITI_RESPECT_TMPDIR_ENV: "1" },
+			cwd: () => "/work",
+			join,
+		});
+		expect(dir).toBe("/work/jiti");
+	});
+
+	it("the script passes the mirrored directory explicitly", () => {
+		// Letting jiti derive the directory from this script's location would work
+		// only while the script sits in a directory with no node_modules sibling.
+		expect(warmScript).toContain("resolveJitiCacheDir");
+		expect(warmScript).toContain("fsCache: cacheDir");
+	});
+});
+
+describe("warm skip reasons (#1926)", () => {
+	const ready = {
+		env: {} as Record<string, string | undefined>,
+		distEntryExists: true,
+		jitiResolvable: true,
+	};
+
+	it("proceeds when the entry is built and jiti is installed", () => {
+		expect(warmSkipReason(ready)).toBeNull();
+	});
+
+	it("skips on the PI_LENS_SKIP_WARM_CACHE opt-out", () => {
+		expect(
+			warmSkipReason({ ...ready, env: { PI_LENS_SKIP_WARM_CACHE: "1" } }),
+		).toMatch(/PI_LENS_SKIP_WARM_CACHE/);
+	});
+
+	it("treats an empty opt-out value as not set", () => {
+		expect(
+			warmSkipReason({ ...ready, env: { PI_LENS_SKIP_WARM_CACHE: "" } }),
+		).toBeNull();
+	});
+
+	it("skips when dist/index.js has not been built", () => {
+		expect(warmSkipReason({ ...ready, distEntryExists: false })).toMatch(
+			/dist\/index\.js/,
+		);
+	});
+
+	it("skips when jiti is absent, because it is an optional dependency", () => {
+		// `npm install --omit=optional`, or a failed optional install, leaves jiti
+		// out. That is a skip with a reason, never an install failure.
+		expect(warmSkipReason({ ...ready, jitiResolvable: false })).toMatch(/jiti/);
+	});
+});
+
+describe("stub aliases derive from the host-provided list (#1926)", () => {
+	it("aliases every host-provided package to an unresolvable path", () => {
+		const alias = buildStubAliases(HOST_PROVIDED_PACKAGES);
+		expect(Object.keys(alias).sort()).toEqual(
+			[...HOST_PROVIDED_PACKAGES].sort(),
+		);
+		for (const value of Object.values(alias)) expect(value).toBe(STUB_TARGET);
+	});
+
+	it("keeps no second copy of the package list in the script", () => {
+		// Single source of truth: a hand-written alias map in the script would
+		// drift from what bundle-dist.mjs keeps external.
+		expect(warmScript).toContain("HOST_PROVIDED_PACKAGES");
+		for (const name of HOST_PROVIDED_PACKAGES) {
+			expect(warmScript, `${name} must not be hardcoded`).not.toContain(
+				`"${name}"`,
+			);
+		}
+	});
+});
+
+describe("install log stays bounded (#1926)", () => {
+	it("keeps the newest lines and drops the rest", () => {
+		const existing = Array.from({ length: INSTALL_LOG_MAX_LINES }, (_, i) =>
+			String(i),
+		);
+		const next = appendBounded(existing, "newest");
+		expect(next).toHaveLength(INSTALL_LOG_MAX_LINES);
+		expect(next.at(-1)).toBe("newest");
+		expect(next[0]).toBe("1");
+	});
+
+	it("drops blank lines from a trailing newline", () => {
+		expect(appendBounded(["a", ""], "b")).toEqual(["a", "b"]);
+	});
+});
+
+describe("prepare chain keeps load-bearing steps load-bearing (#1926)", () => {
+	const prepare = pkg.scripts?.prepare ?? "";
+
+	it("runs the warm last, after the steps that must fail loudly", () => {
+		// build:dist and download-grammars are what consumers install for. The
+		// warm is an optimisation, so it runs after them and can never preempt
+		// their failure.
+		const build = prepare.indexOf("build:dist");
+		const grammars = prepare.indexOf("download-grammars");
+		const warm = prepare.indexOf("warm-loader-cache.mjs");
+		expect(build).toBeGreaterThanOrEqual(0);
+		expect(grammars).toBeGreaterThan(build);
+		expect(warm).toBeGreaterThan(grammars);
+		expect(
+			prepare.slice(warm).includes("&&"),
+			"nothing may run after the warm",
+		).toBe(false);
+	});
+
+	it("never masks a real prepare failure with `|| true`", () => {
+		// `|| true` on the chain would swallow a build:dist failure too. The
+		// script owns its own errors instead — the setup-git-hooks split (#1804).
+		expect(prepare).not.toContain("|| true");
+	});
+
+	it("the warm script never exits non-zero", () => {
+		expect(warmScript).not.toMatch(/process\.exit\((?!0\))/);
+		expect(warmScript).toContain("catch");
+	});
+
+	it("ships both warm modules in the tarball", () => {
+		const files = pkg.files ?? [];
+		expect(files).toContain("scripts/warm-loader-cache.mjs");
+		expect(files).toContain("scripts/lib/warm-loader-cache.mjs");
+	});
+});
+
+describe("jiti stays off the session path (#1926)", () => {
+	it("is an optional dependency, never a runtime dependency", () => {
+		// #1926's own lesson: a package vendored into the git install and
+		// evaluated at import costs startup time. jiti is install-time only, so it
+		// must never be reachable from the bundled entry.
+		expect(Object.hasOwn(pkg.dependencies ?? {}, "jiti")).toBe(false);
+		expect(Object.hasOwn(pkg.optionalDependencies ?? {}, "jiti")).toBe(true);
+	});
+
+	it("no extension source imports jiti", () => {
+		const offenders: string[] = [];
+		const walk = (dir: string) => {
+			for (const name of fs.readdirSync(dir, { withFileTypes: true })) {
+				if (name.name === "node_modules" || name.name.startsWith(".")) continue;
+				const full = path.join(dir, name.name);
+				if (name.isDirectory()) {
+					walk(full);
+					continue;
+				}
+				if (!name.name.endsWith(".ts")) continue;
+				const text = fs.readFileSync(full, "utf8");
+				if (/from\s*["']jiti(\/|["'])/.test(text)) offenders.push(full);
+			}
+		};
+		for (const dir of ["clients", "tools", "mcp"]) {
+			const full = path.join(root, dir);
+			if (fs.existsSync(full)) walk(full);
+		}
+		const entry = path.join(root, "index.ts");
+		if (fs.existsSync(entry)) {
+			expect(
+				/from\s*["']jiti(\/|["'])/.test(fs.readFileSync(entry, "utf8")),
+			).toBe(false);
+		}
+		expect(offenders).toEqual([]);
+	});
+});

--- a/tests/scripts/warm-loader-cache.test.ts
+++ b/tests/scripts/warm-loader-cache.test.ts
@@ -1,4 +1,6 @@
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -6,11 +8,15 @@ import { HOST_PROVIDED_PACKAGES } from "../../scripts/lib/host-provided-deps.mjs
 import {
 	appendBounded,
 	buildStubAliases,
+	expectedCacheFileName,
 	INSTALL_LOG_MAX_LINES,
+	jitiHash,
 	resolveJitiCacheDir,
 	STUB_TARGET,
+	verifyCacheEntry,
 	warmSkipReason,
 } from "../../scripts/lib/warm-loader-cache.mjs";
+import { run } from "../../scripts/warm-loader-cache.mjs";
 
 // #1926 remainder. pi loads pi-lens through jiti, which Babel-transforms the
 // ~4MB dist bundle and caches the result. The first session after a `git:`
@@ -86,6 +92,119 @@ describe("jiti cache directory mirrors pi's loader (#1926)", () => {
 		// only while the script sits in a directory with no node_modules sibling.
 		expect(warmScript).toContain("resolveJitiCacheDir");
 		expect(warmScript).toContain("fsCache: cacheDir");
+	});
+});
+
+describe("the warm is verified, not assumed (#1926)", () => {
+	// Elapsed time is not evidence. Three exit-0 paths leave no usable entry, and
+	// an unverified script records "warmed" for all three.
+	const marker = (source: string) => ` /* v9-${jitiHash(source, 16)} */\n`;
+	const writable = { isWritable: () => true };
+
+	it("derives jiti's cache filename from the POSIX path", () => {
+		// Pinned against pi's own cache directory: this exact name is the file pi
+		// had already written for the dogfood install.
+		expect(
+			expectedCacheFileName(
+				"C:\\Users\\apman\\.pi\\agent\\git\\github.com\\apmantza\\pi-lens\\dist\\index.js",
+			),
+		).toBe("dist-index.db18768f.mjs");
+		expect(expectedCacheFileName("/home/u/pi-lens/dist/index.js")).toMatch(
+			/^dist-index\.[0-9a-f]{8}\.mjs$/,
+		);
+	});
+
+	it("accepts an entry whose marker matches the built source", () => {
+		const source = "export default () => {};";
+		expect(
+			verifyCacheEntry({
+				cacheDir: "/cache",
+				fileName: "dist-index.abc12345.mjs",
+				source,
+				fsDeps: {
+					...writable,
+					existsSync: () => true,
+					readFileSync: () => `transformed${marker(source)}`,
+				},
+			}),
+		).toEqual({ ok: true, reason: null, transformVersion: "9" });
+	});
+
+	it("reports an unwritable cache directory", () => {
+		// jiti's prepareCacheDir catches the write failure, sets fsCache to false,
+		// and transforms in memory. The import still returns.
+		const verdict = verifyCacheEntry({
+			cacheDir: "/cache",
+			fileName: "dist-index.abc12345.mjs",
+			source: "x",
+			fsDeps: {
+				existsSync: () => false,
+				readFileSync: () => "",
+				isWritable: () => false,
+			},
+		});
+		expect(verdict.ok).toBe(false);
+		expect(verdict.reason).toContain("not writable");
+	});
+
+	it("reports the native-import bypass, where nothing is cached at all", () => {
+		// jiti's tryNative path skips the transform. An unverified warm's success
+		// is contingent on native resolution FAILING, which this script neither
+		// controls nor observes — so it has to check.
+		const verdict = verifyCacheEntry({
+			cacheDir: "/cache",
+			fileName: "dist-index.abc12345.mjs",
+			source: "x",
+			fsDeps: { ...writable, existsSync: () => false, readFileSync: () => "" },
+		});
+		expect(verdict.ok).toBe(false);
+		expect(verdict.reason).toContain("natively");
+	});
+
+	it("reports an entry whose marker does not match the built source", () => {
+		const verdict = verifyCacheEntry({
+			cacheDir: "/cache",
+			fileName: "dist-index.abc12345.mjs",
+			source: "the new bundle",
+			fsDeps: {
+				...writable,
+				existsSync: () => true,
+				readFileSync: () => `stale${marker("the old bundle")}`,
+			},
+		});
+		expect(verdict.ok).toBe(false);
+		expect(verdict.reason).toContain("re-transform");
+		expect(verdict.transformVersion).toBe("9");
+	});
+
+	it("reports an entry with no marker at all, against the real filesystem", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "warm-corrupt-"));
+		const fileName = "dist-index.abc12345.mjs";
+		fs.writeFileSync(path.join(dir, fileName), "truncated output, no marker");
+		const verdict = verifyCacheEntry({
+			cacheDir: dir.split("\\").join("/"),
+			fileName,
+			source: "x",
+			fsDeps: {
+				existsSync: (p: string) => fs.existsSync(p),
+				readFileSync: (p: string) => fs.readFileSync(p, "utf8"),
+				isWritable: () => true,
+			},
+		});
+		expect(verdict.ok).toBe(false);
+		expect(verdict.reason).toContain("no jiti version marker");
+	});
+
+	it("the script records not_cached rather than warmed when the check fails", () => {
+		expect(warmScript).toContain("verifyCacheEntry");
+		expect(warmScript).toContain('status: "not_cached"');
+	});
+
+	it("the record carries the jiti version and the expected cache filename", () => {
+		// A host jiti bump changes the marker, so every warm silently becomes a
+		// cold session. Both fields make that diagnosable from one log line.
+		expect(warmScript).toContain("jitiVersion: version");
+		expect(warmScript).toContain("cacheFile");
 	});
 });
 
@@ -187,9 +306,58 @@ describe("prepare chain keeps load-bearing steps load-bearing (#1926)", () => {
 		expect(prepare).not.toContain("|| true");
 	});
 
-	it("the warm script never exits non-zero", () => {
-		expect(warmScript).not.toMatch(/process\.exit\((?!0\))/);
-		expect(warmScript).toContain("catch");
+	it("a thrown body leaves the exit code at 0 and still records the failure", async () => {
+		// Behavioural, not a regex over the source. `prepare` chains with `&&`, so
+		// a non-zero exit here would abort the install after a successful build.
+		const logFile = path.join(
+			fs.mkdtempSync(path.join(os.tmpdir(), "warm-run-")),
+			"install.log",
+		);
+		const previousLog = process.env.PI_LENS_INSTALL_LOG;
+		const previousExit = process.exitCode;
+		process.env.PI_LENS_INSTALL_LOG = logFile;
+		process.exitCode = 0;
+		try {
+			await run(() => {
+				throw new Error("injected warm failure");
+			});
+			expect(process.exitCode ?? 0).toBe(0);
+			const written = JSON.parse(
+				fs.readFileSync(logFile, "utf8").trim().split("\n").at(-1) as string,
+			);
+			expect(written.status).toBe("failed");
+			expect(written.reason).toContain("injected warm failure");
+		} finally {
+			process.exitCode = previousExit;
+			if (previousLog === undefined) delete process.env.PI_LENS_INSTALL_LOG;
+			else process.env.PI_LENS_INSTALL_LOG = previousLog;
+		}
+	});
+
+	it("running the script as a command exits 0 and writes a record", () => {
+		// Pins the `invokedDirectly` guard. If it stopped matching, the prepare
+		// step would silently do nothing and every install would stay cold.
+		const logFile = path.join(
+			fs.mkdtempSync(path.join(os.tmpdir(), "warm-cli-")),
+			"install.log",
+		);
+		execFileSync(
+			process.execPath,
+			[path.join(root, "scripts", "warm-loader-cache.mjs")],
+			{
+				env: {
+					...process.env,
+					PI_LENS_INSTALL_LOG: logFile,
+					PI_LENS_SKIP_WARM_CACHE: "1",
+				},
+				stdio: "ignore",
+			},
+		);
+		const written = JSON.parse(
+			fs.readFileSync(logFile, "utf8").trim().split("\n").at(-1) as string,
+		);
+		expect(written.event).toBe("warm_loader_cache");
+		expect(written.status).toBe("skipped");
 	});
 
 	it("ships both warm modules in the tarball", () => {


### PR DESCRIPTION
## What changed

`prepare` now warms pi's jiti transform cache after it builds `dist/`, so the
first session after a `git:` install or update is already warm.

- `scripts/warm-loader-cache.mjs` — runs last in the `prepare` chain,
  best-effort, always exits 0.
- `scripts/lib/warm-loader-cache.mjs` — the pure parts: cache-directory
  resolution, skip decisions, alias derivation, install-log bounding.
- `jiti` becomes an `optionalDependency`. Nothing in the extension imports it,
  so it never enters the session path.
- One JSONL line per install in `~/.pi-lens/install.log`.

## Why

pi loads an extension through jiti (`createJiti(...)` in
`@earendil-works/pi-coding-agent`'s `dist/core/extensions/loader.js`). jiti
Babel-transforms the entry and caches the result under `<tmpdir>/jiti`. pi-lens's
entry is a ~4MB esbuild bundle, so that transform is the dominant startup cost —
exactly once per build. Every update produces a new bundle, so the next
interactive session paid it: 4847ms of `module import` in the #1926 field
report, against a 138ms steady state.

`prepare` has just built the bundle. Running the transform there moves the cost
off the session path entirely.

## How the warm produces a hit for the real loader

jiti keys a cache entry on the transformed file, not on the jiti instance
(`getCache` in `jiti/dist/jiti.cjs`):

```
<basename(dirname(file))>-<basename(file) up to the first dot>
+ "+map" if sourceMaps + ".i" if interopDefault
+ "." + md5(file).slice(0, 8)
+ ".mjs" for an async import, ".cjs" otherwise
```

and it validates the stored body against a trailing
`/* v<TRANSFORM_VERSION>-<md5(source).slice(0,16)> */` marker.

So the warm has to agree with pi on three things: the absolute path of the
entry, the cache directory, and the transform. Everything else — the alias map,
`moduleCache`, which package created the jiti instance — is outside both the key
and the transform.

Measured, not assumed. Running this transform over the dogfood install's
`dist/index.js` produced a cache file **byte-identical** to the one pi had
already written, both with pi's alias map and with none:

```
$ node probe.mjs <scratch-cache-dir>          # pi's alias map
files: [ 'dist-index.db18768f.mjs' ]
$ cmp <scratch>/dist-index.db18768f.mjs %TEMP%/jiti/dist-index.db18768f.mjs
BYTE-IDENTICAL to pi's own cache entry

$ node probe.mjs <scratch2> noalias           # no alias map at all
NOALIAS ALSO IDENTICAL
```

The `db18768f` suffix is `md5("C:/Users/apman/.pi/agent/git/github.com/apmantza/pi-lens/dist/index.js").slice(0,8)`
— confirmed against pi's own file, which pins the path normalisation (forward
slashes, drive-letter case preserved).

The marker is also the safety net. If pi ever ships a jiti whose transform
version or Babel output differs, pi recomputes the marker, does not match, and
re-transforms. A mismatched warm costs the install a few seconds and buys
nothing; it can never hand pi the wrong code.

## Why a dependency, and why `optionalDependencies`

pi's own jiti is not resolvable from an extension's `prepare`: the extension is
installed by `npm install --omit=dev` in its own tree, with no path to pi's
`node_modules`. `devDependencies` are absent under `--omit=dev`. `npx jiti`
would need the network at install time and could drift in version. So jiti has
to be declared.

`optionalDependencies` rather than `dependencies`, because the warm is an
optimisation. `--omit=dev` installs optional dependencies, so pi's git install
resolves it; `--omit=optional`, or a failed optional install, leaves it out and
the script skips with a reason instead of failing the install.

## Verification

The full flow: clean `git clone` of this branch, `npm install --omit=dev` (pi's
own git-install command), a **fresh TEMP** so the jiti cache starts cold, then a
real headless pi session under `PI_TIMING` with stdin closed:

```
pi -p -ne -e <sim>/dist/index.js --no-session "reply with the single word OK" < /dev/null
```

**Negative control** — same flow, `PI_LENS_SKIP_WARM_CACHE=1`, first session on a
cold cache. Two independent fresh-TEMP runs:

```
  ...\dist\index.js module import: 9590ms      TOTAL: 9604ms
  ...\dist\index.js module import: 9472ms      TOTAL: 9488ms
```

**With the warm** — install output, then the FIRST session against that TEMP:

```
[warm-loader-cache] warmed dist\index.js in 12590ms (cache: C:\Users\apman\pi-lens-sim\tempB\jiti)

  ...\dist\index.js module import: 242ms   factory: 7ms   TOTAL: 249ms
```

Four further sessions in the same TEMP: 467ms, 205ms, 288ms, 245ms. The 467ms
reading coincided with a concurrent build on this machine; the median is ~245ms.
The acceptance criterion — first post-update session under 300ms — is met on the
first session, which is the one the issue is about.

This machine reads cold at ~9.5s where the field report read 4847ms, so the
absolute cold figure is machine-dependent. The ratio is not: 9472ms → 242ms on
the same tree, same TEMP, same command.

Functional check on the warmed cache, so the fix is not just fast:

```
$ pi -p -ne -e <sim>/dist/index.js --no-session "Call the lens_diagnostics tool now and paste its exact output."
No issues in the current turn delta.
```

### Tests

`tests/scripts/warm-loader-cache.test.ts`, 19 tests. Targeted sweep:
`tests/scripts/`, `tests/packaging.test.ts`, `tests/build-freshness-guard.test.ts`,
`tests/host-sdk-type-only.test.ts`,
`tests/clients/session-state-conformance.test.ts` — 405 tests, all passing
(`astgrep-self-scan` failed once under parallel execution because ast-grep could
not find `sgconfig.yml` from the shared cwd, and passes standalone; also verified
via `npm run astgrep:self-scan`, 0 findings). `npm run lint` and
`npm run check:lockfile` clean. Full suite deferred to CI.

**Red on pre-fix code.** With `package.json` reverted and the implementation in
place, three guards fail:

```
FAIL  prepare chain keeps load-bearing steps load-bearing (#1926) > runs the warm last
FAIL  prepare chain keeps load-bearing steps load-bearing (#1926) > ships both warm modules in the tarball
FAIL  jiti stays off the session path (#1926) > is an optional dependency, never a runtime dependency
Tests  3 failed | 16 passed (19)
```

**Mutation-proof.** Each new guard reds when neutered, one at a time:

| mutation | test that reds |
| --- | --- |
| drop jiti's TMPDIR quirk from `resolveJitiCacheDir` | `re-reads tmpdir with TMPDIR removed when TMPDIR is the cwd` |
| ignore `jitiResolvable` in `warmSkipReason` | `skips when jiti is absent, because it is an optional dependency` |
| hardcode the alias list instead of deriving it | `aliases every host-provided package to an unresolvable path` |

## Blast radius

- **`prepare`.** Adds ~10-13s to every `git:` install and update, and to the two
  CI jobs that run a from-source `--omit=dev` install. That is the cost being
  moved, not added: the session used to pay it. Ordering is pinned by test —
  `build:dist` and `download-grammars` still run first and still fail loudly,
  and nothing runs after the warm.
- **Install size.** jiti is 1.7MB, flat, no transitive dependencies.
- **Session path.** Nothing. `dist/index.js` never imports jiti, pinned by a
  source scan over `clients/`, `tools/`, `mcp/`, and `index.ts`. No new process
  spawns at session time; the script runs only under `prepare`.
- **`scripts/check-prod-install-shape.mjs`.** Unaffected: it checks
  `HOST_PROVIDED_PACKAGES` for vendoring, and jiti is not one.
- **Callers.** Both new modules are new files. `package.json` gains one script
  invocation, two `files` entries, and one optional dependency.

## Observability

Two records, both already in production paths:

1. `~/.pi-lens/latency.log`, `phase: "extension_loaded"` (`clients/startup-timing.ts`)
   — measures process start to pi-lens load-complete, so it includes the jiti
   transform. A cold first session after an update shows up there as a multi-second
   outlier; a warm one does not. This is the record that proves the fix in the field.
2. `~/.pi-lens/install.log` — one bounded JSONL line per install, capped at 100
   lines, saying `warmed` with the elapsed time and cache directory, `skipped`
   with the reason, or `failed` with the message. pi's install output scrolls
   away; without this there is no record that the warm ran.

## Class sweep

**Pattern.** The shape is "a cost derivable at install time is left to be
produced lazily on the session path". Grepped the whole tree for `jiti`
(`scripts/`, `clients/`, `tools/`, `mcp/`, `index.ts`, workflows, docs): every
other hit is documentation of the #182 dist-vs-source decision. No other site
defers an install-derivable artifact to a session.

**Population.** The enumerable family is the `prepare` chain. Every member
checked for the "a best-effort step must not share the load-bearing failure
path" class:

| step | verdict |
| --- | --- |
| `build:dist` | load-bearing, fails loudly — correct |
| `download-grammars --core` | load-bearing, fails loudly — correct |
| `setup-git-hooks.mjs` | best-effort, self-contained, exits 0 (#1804) — already correct |
| `warm-loader-cache.mjs` | new; best-effort, self-contained, exits 0 — pinned by test |

Second family: jiti-loaded entries. `pi.extensions` has one entry today, and the
warm iterates the manifest rather than hardcoding `dist/index.js`, so a second
entry is covered without a code change. The `bin` entries run under plain node,
not jiti, so they have no transform cost.

## Remainder — why `refs #1926`, not `closes`

The npm install form is not covered. `npm install pi-lens` from the registry does
not run `prepare`, and the only lifecycle hook that would is `postinstall`, which
`tests/packaging.test.ts` deliberately asserts is absent (grammars history). So an
npm-form install still pays one cold transform on its first session. That, plus
the outstanding npm-path `PI_TIMING` capture already recorded on the issue, keeps
#1926 open. Both are named in an issue comment.

## Merge order

No constraint. No open PR touches `package.json`, the `prepare` chain,
`tests/packaging.test.ts`, or `tests/scripts/warm-loader-cache.test.ts`.


---

## Review round 1

Four findings, all fixed on this branch at `23268e5`.

### F1 (medium) — the script recorded "warmed" on elapsed time alone

The reviewer proved three exit-0 outcomes with zero bytes cached: an unwritable
cache directory (jiti's `prepareCacheDir` catches the failure, sets `fsCache` to
false, and transforms in memory), a stale or corrupt entry, and an import that
never reached the transform at all. The last one is the sharp one: an unverified
warm's success was **contingent** on the environment, which the script neither
controls nor observes. See F4 for the mechanism.

`verifyCacheEntry` now derives jiti's own cache filename from the POSIX entry
path, checks the file exists, and validates the trailing
version-and-source-hash marker. What that proves is bounded and worth stating
exactly: the warm's own jiti cached this entry, with these versions. It is not a
promise about pi. pi-side drift shows up as a version delta between the two
records, which is something to read from the log, not something an install can
detect. Anything short of a matching entry records `not_cached` with the reason,
still exit 0.

The absent-entry reason is deliberately generic — `no cache entry was written`.
Several routes end there, and this check cannot tell them apart, so it names
none of them.

Live probe, TEMP pointed at a regular file so the cache directory cannot be
created:

```
[warm-loader-cache] not cached: dist\index.js after 6638ms — cache directory is not writable: ...\blocked-temp\jiti
exit=0
{"status":"not_cached","ms":6638,"cacheFile":"dist-index.e86805c7.mjs","jitiVersion":"2.7.0","reason":"cache directory is not writable: ..."}
```

The pre-fix script recorded that same run as `warmed`.

### F2 (low) — the record could not diagnose a jiti version bump

`jitiVersion` and the expected `cacheFile` are now in every record, alongside
the `transformVersion` read back out of the marker. A host jiti bump changes the
marker and silently turns every warm into a cold session; those three fields
make it readable from one log line.

### F3 (low) — the outer handler logged "skipped" and recorded "failed"

It is a failure. Both now say `failed`.

### F4 (blast radius) — what evaluates inside the install process

jiti writes the cache entry before it evaluates, and evaluation is not the goal,
so the script lets it fail. What runs before it fails is bounded and worth
naming.

`dist/index.js` has module-scope side effects: `installConsoleGuard()` and
`openModuleLoadConsoleWindow()` from the first import (`clients/console-guard-install.ts`),
then `startEventLoopMonitor()` and three `logLatency` writes. The extension
**factory never runs** — the script imports the default export and does not call
it — so there is no `session_start`, no LSP spawn, no dispatch, and no process
spawned by pi-lens. `monitorEventLoopDelay` does not hold the event loop open,
so the install process still exits.

The native attempt is not gated by `tryNative`. jiti's `evalModule` tries a
native import UNCONDITIONALLY for an async-imported ESM `.js`, and falls back to
the transform only when that import rejects. So there is a cache entry at all
only because native import FAILS here: in a real `--omit=dev` install the
host-provided specifiers do not resolve.

That strengthens the parity argument rather than weakening it. The same
condition makes pi's own load transform the bundle — pi is loading the same
entry, with the same unresolvable specifiers, through the same jiti. The warm
and pi agree because they meet the same environment, not because the script
arranged it. Aliasing the host specifiers to an unresolvable stub only makes the
failure immediate and identical every time.

It also sets how to read a `not_cached` record: always as something to look at.
It means the environment was not the one the warm depends on, and the F1 check is
what makes that visible instead of silent.

### Vacuous exit-0 guard replaced

The old test was a regex over the source plus `toContain("catch")`. It is now
behavioural: inject a throwing body into the exported `run()`, assert
`process.exitCode` stays 0 and the record says `failed`. A second test runs the
script as a subprocess and asserts it exits 0 and writes a record, which pins
the direct-invocation guard — if that guard stopped matching, `prepare` would
silently do nothing and every install would stay cold.

### Round-1 verification

28 tests in `tests/scripts/warm-loader-cache.test.ts`. Battery re-run:
`tests/scripts/` plus `tests/packaging.test.ts` — 339 passing. `npm run lint`
and `npm run astgrep:self-scan` clean.

**Red against the unverified version.** Restoring the previous commit's two
script files under the new tests:

```
Failed Tests 10
  the warm is verified, not assumed > derives jiti's cache filename from the POSIX path
  the warm is verified, not assumed > accepts an entry whose marker matches the built source
  the warm is verified, not assumed > reports an unwritable cache directory
  the warm is verified, not assumed > reports a missing entry without naming a cause it cannot establish
  the warm is verified, not assumed > reports an entry whose marker does not match the built source
  the warm is verified, not assumed > reports an entry with no marker at all, against the real filesystem
  the warm is verified, not assumed > the script records not_cached rather than warmed when the check fails
  the warm is verified, not assumed > the record carries the jiti version and the expected cache filename
  ... plus the two behavioural exit-0 tests
```

**Mutation-proof, build-gated.**

| mutation | tests that red |
| --- | --- |
| skip the `existsSync` check in `verifyCacheEntry` | `reports an unwritable cache directory`, `reports a missing entry ...` |
| make `verifyCacheEntry` always return `ok` | those two plus `marker does not match`, `no marker at all` |

**End to end, re-run on the new head.** Same flow, fresh TEMP, real install:

```
[warm-loader-cache] warmed dist\index.js in 7399ms (cache: ...\tempD\jiti/dist-index.e86805c7.mjs)
{"status":"warmed","ms":7399,"cacheFile":"dist-index.e86805c7.mjs","jitiVersion":"2.7.0","transformVersion":"9"}

first session:  module import: 413ms
```

413ms is above the 300ms criterion, and the cause is machine load, not the
change. Paired control, measured back to back afterwards on the same machine:
the round-1 cache (`tempB`) read 182ms and 262ms, the round-2 cache (`tempD`)
read 272ms and 199ms. The two caches are the same file and perform the same.
Round 1's first session read 242ms on a quiet machine. Against a 9472-9590ms
cold baseline, the win is not in doubt; the exact first-session figure moves
with whatever else the machine is doing.


---

## Verify round

Cleared with three wording corrections, committed at `0677e73`. No behaviour
change: the native-import mechanism is now stated as traced (unconditional
attempt, transform on rejection), the absent-entry reason no longer names a
cause it cannot establish, and the verification claim is scoped to what it
proves. Warm tests 28 passing, `tests/packaging.test.ts` 29 passing, lint clean.
