### PR TITLE
fix(session): count stale-ctx skips in session_start and context (closes #1929)

### DIFF
--- a/.changelog/fix-1929-session-start-context-stale-ctx.md
+++ b/.changelog/fix-1929-session-start-context-stale-ctx.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **A session swap that starves `session_start` or `context` is now counted, not misreported as a pi-lens crash (closes #1929)** — both handlers survived a dead extension ctx already, but each logged it as `session_start crashed: …` or `context event error: …` and recorded nothing, so a replacement that kept starving them was invisible in aggregate. Both now run through the shared stale-ctx wrapper and leave one bounded `extension-ctx-stale` record keyed to the event name. `context` uses a new value-returning wrapper variant that states its stale-path answer explicitly: `undefined`, pi's "this extension contributed nothing", so the host keeps its own message list rather than receiving a half-built injection. Seven of twelve `pi.on` registrations are now wrapped, up from five.

--- a/README.md
+++ b/README.md
@@ -36,17 +36,18 @@ pi-lens gives AI coding agents fast, language-aware feedback while they write/ed
 
 ## Architecture
 
-Most lifecycle events enter through one wrapper, which drops events that arrive
-on a replaced session. `tool_call` and `session_start` predate that wrapper and
-still register raw. Events fan out into the edit-time lane and the LSP lane.
-Both lanes write into the findings stores. Nothing reaches the agent from those
-stores until a freshness gate or an explicit age label clears it.
+Most lifecycle events enter through one wrapper, which drops and counts events
+that arrive on a replaced session. `tool_call` registers raw: it delegates
+straight to a handler that owns its own total guard. Events fan out into the
+edit-time lane and the LSP lane. Both lanes write into the findings stores.
+Nothing reaches the agent from those stores until a freshness gate or an
+explicit age label clears it.
 
 ```mermaid
 flowchart TD
     subgraph host["pi host"]
         HOST["Host events<br/>tool_call, tool_result, turn_start/end,<br/>session_start/shutdown, agent_end, context"]
-        WRAP["Stale-ctx wrapper<br/>skips and counts events on a replaced session<br/>tool_result, turn_start, turn_end, agent_end, agent_settled"]
+        WRAP["Stale-ctx wrapper<br/>skips and counts events on a replaced session<br/>tool_result, turn_start, turn_end, agent_end,<br/>agent_settled, session_start, context"]
     end
 
     subgraph guards["Guards"]
@@ -89,7 +90,7 @@ flowchart TD
     HOST --> WRAP
     HOST -->|tool_call, raw| RG
     HOST -->|tool_call, raw| GG
-    HOST -->|session_start, raw| SESSION
+    WRAP -->|session_start| SESSION
     WRAP -->|tool_result| PIPE
     WRAP -->|tool_result, records reads and writes| RG
     SESSION --> POOL

--- a/clients/session-event-guard.ts
+++ b/clients/session-event-guard.ts
@@ -157,12 +157,21 @@ function guardSessionEvent<E, C, R>(
 		// `false` is the only confirmed verdict. `undefined` means the probe
 		// could not tell, and an inconclusive probe must dispatch.
 		if (probeCtxActive(ctx) === false)
+			// SAFETY: `R` is the handler's declared return type, which is either a
+			// plain value or a promise of one. `skip` yields `Awaited<R>`, the
+			// settled form. TypeScript cannot see that a host awaiting an `R` is
+			// equally satisfied by the settled value, but every `pi.on` caller
+			// either awaits the result or ignores it, so both forms behave the
+			// same at the call site. The same reasoning covers the two casts
+			// below.
 			return skip(event, "pre-dispatch") as unknown as R;
 		try {
 			const result = handler(event, ctx);
 			if (isThenable(result)) {
 				// Recover the rejection in place. The host awaits the same promise
 				// it would have awaited anyway; it just resolves instead.
+				// SAFETY: the recovered promise settles to `Awaited<R>`, which the
+				// host consumes exactly as it would an `R` — see the note above.
 				return Promise.resolve(result).catch((err: unknown) => {
 					if (isStaleExtensionCtxError(err)) return skip(event, "mid-handler");
 					throw err;
@@ -171,6 +180,8 @@ function guardSessionEvent<E, C, R>(
 			return result;
 		} catch (err) {
 			if (isStaleExtensionCtxError(err))
+				// SAFETY: a synchronous handler's `R` is already its settled form,
+				// so `Awaited<R>` and `R` coincide here — see the note above.
 				return skip(event, "mid-handler") as unknown as R;
 			throw err;
 		}

--- a/clients/session-event-guard.ts
+++ b/clients/session-event-guard.ts
@@ -21,10 +21,27 @@
  *
  * #1924 fixed that for `agent_settled` with an inline try/catch. #1925 found
  * four more handlers with the same shape. Five inline copies of one policy is
- * the parallel-state defect AGENTS.md names, so the policy lives here instead
- * and every session-event registration in `index.ts` goes through
- * {@link wrapSessionEventHandler}. `agent_settled` is a consumer of this path,
- * not a special case.
+ * the parallel-state defect AGENTS.md names, so the policy lives here instead.
+ * `agent_settled` is a consumer of this path, not a special case.
+ *
+ * ## What this module actually covers
+ *
+ * Not every `pi.on` registration in `index.ts` goes through here, and the doc
+ * used to read as if they all did. Seven do today:
+ *
+ * - {@link wrapSessionEventHandler} — `tool_result`, `turn_start`,
+ *   `agent_end`, `turn_end`, `agent_settled` (#1925) and `session_start`
+ *   (#1929). All six return nothing, so a skipped event resolving to
+ *   `undefined` is exactly their own early-exit value.
+ * - {@link wrapSessionEventHandlerWithResult} — `context` (#1929), which must
+ *   hand the host back a message list on the live path.
+ *
+ * Five registrations stay unwrapped on purpose: `resources_discover`,
+ * `session_before_fork`, `tool_call`, `session_shutdown`, and `message_end`.
+ * `tests/clients/session-event-guard-sweep.test.ts` is the source of truth for
+ * that split. It scans every registration in `index.ts` and reds unless the
+ * handler is wrapped or carries a written reason, so this paragraph can go
+ * stale but the contract cannot.
  *
  * The wrapper does three things and nothing else:
  *
@@ -114,20 +131,17 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
 }
 
 /**
- * Wrap one `pi.on` handler so a stale ctx becomes an observable no-op instead
- * of a throw into the host.
- *
- * The returned function keeps the handler's own signature and its return
- * value, so a wrapped registration is a drop-in for the bare one. A skipped
- * event resolves to `undefined`, which is what every one of pi-lens's session
- * handlers already returns on its early-exit paths.
+ * The one policy. Both public wrappers are this function with a different
+ * stale-path value, so the probe point, the classification, and the record can
+ * never drift apart between a void handler and a value-returning one.
  */
-export function wrapSessionEventHandler<H extends SessionEventHandler>(
+function guardSessionEvent<E, C, R>(
 	eventName: string,
-	handler: H,
-	options: SessionEventGuardOptions = {},
-): H {
-	const skip = (detectedAt: StaleDetectionPoint): undefined => {
+	handler: (event: E, ctx: C) => R,
+	onStaleResult: (event: E) => Awaited<R>,
+	options: SessionEventGuardOptions,
+): (event: E, ctx: C) => R {
+	const skip = (event: E, detectedAt: StaleDetectionPoint): Awaited<R> => {
 		recordStaleSkip(eventName, detectedAt);
 		try {
 			options.dbg?.(
@@ -136,29 +150,87 @@ export function wrapSessionEventHandler<H extends SessionEventHandler>(
 		} catch {
 			// A debug sink must never decide whether an event is handled.
 		}
-		return undefined;
+		return onStaleResult(event);
 	};
 
-	const guarded = (event: never, ctx: never): ReturnType<H> | undefined => {
+	return (event: E, ctx: C): R => {
 		// `false` is the only confirmed verdict. `undefined` means the probe
 		// could not tell, and an inconclusive probe must dispatch.
-		if (probeCtxActive(ctx) === false) return skip("pre-dispatch");
+		if (probeCtxActive(ctx) === false)
+			return skip(event, "pre-dispatch") as unknown as R;
 		try {
-			const result = handler(event, ctx) as ReturnType<H>;
+			const result = handler(event, ctx);
 			if (isThenable(result)) {
 				// Recover the rejection in place. The host awaits the same promise
 				// it would have awaited anyway; it just resolves instead.
 				return Promise.resolve(result).catch((err: unknown) => {
-					if (isStaleExtensionCtxError(err)) return skip("mid-handler");
+					if (isStaleExtensionCtxError(err)) return skip(event, "mid-handler");
 					throw err;
-				}) as ReturnType<H>;
+				}) as unknown as R;
 			}
 			return result;
 		} catch (err) {
-			if (isStaleExtensionCtxError(err)) return skip("mid-handler");
+			if (isStaleExtensionCtxError(err))
+				return skip(event, "mid-handler") as unknown as R;
 			throw err;
 		}
 	};
+}
 
-	return guarded as H;
+/**
+ * Wrap one `pi.on` handler so a stale ctx becomes an observable no-op instead
+ * of a throw into the host.
+ *
+ * The returned function keeps the handler's own signature and its return
+ * value, so a wrapped registration is a drop-in for the bare one. A skipped
+ * event resolves to `undefined`, which is what every handler wrapped this way
+ * already returns on its early-exit paths.
+ *
+ * Use {@link wrapSessionEventHandlerWithResult} when `undefined` is NOT the
+ * handler's own no-op value.
+ */
+export function wrapSessionEventHandler<H extends SessionEventHandler>(
+	eventName: string,
+	handler: H,
+	options: SessionEventGuardOptions = {},
+): H {
+	return guardSessionEvent<never, never, unknown>(
+		eventName,
+		handler,
+		() => undefined,
+		options,
+	) as H;
+}
+
+export interface SessionEventResultGuardOptions<E, R>
+	extends SessionEventGuardOptions {
+	/**
+	 * The value the host receives when the event is skipped. It takes the
+	 * EVENT, never the ctx: the ctx is the thing that just proved dead, and
+	 * reading it here would throw inside the guard that exists to absorb that
+	 * throw.
+	 *
+	 * State the value deliberately per event. `context` returns `undefined`,
+	 * pi's "this extension contributed nothing" answer, so the host keeps its
+	 * own message list untouched — never a partially built injection.
+	 */
+	onStaleResult: (event: E) => Awaited<R>;
+}
+
+/**
+ * {@link wrapSessionEventHandler} for a handler whose return value the host
+ * consumes (#1929).
+ *
+ * The live path returns exactly what the handler returned. The stale path
+ * returns `onStaleResult(event)` instead of assuming `undefined`, so a handler
+ * whose no-op value is something else does not get one silently substituted.
+ * Probe, classification, and the bounded record are identical to the void
+ * wrapper's — they are the same function underneath.
+ */
+export function wrapSessionEventHandlerWithResult<E, C, R>(
+	eventName: string,
+	handler: (event: E, ctx: C) => R,
+	options: SessionEventResultGuardOptions<E, R>,
+): (event: E, ctx: C) => R {
+	return guardSessionEvent(eventName, handler, options.onStaleResult, options);
 }

--- a/index.ts
+++ b/index.ts
@@ -141,6 +141,7 @@ import { handleToolCall } from "./clients/runtime-tool-call.js";
 import {
 	isStaleExtensionCtxError,
 	wrapSessionEventHandler,
+	wrapSessionEventHandlerWithResult,
 } from "./clients/session-event-guard.js";
 import {
 	classifyCurrentSessionEmission,
@@ -1634,410 +1635,436 @@ function activateExtension(hostPi: ExtensionAPI) {
 
 	// --- Events ---
 
-	pi.on("session_start", async (event, ctx) => {
-		const sessionStartMonotonicAt = performance.now();
-		resetVerifiedPathAttributionGuessCount();
-		warmDispatchAtSessionStart();
-		void warmLspService().catch((err) =>
-			logExtension({ subsystem: "lsp", level: "warn", message: `LSP warm failed: ${err}` }),
-		);
-		void warmFormatters().catch((err) =>
-			logExtension({ subsystem: "format", level: "warn", message: `formatter warm failed: ${err}` }),
-		);
-		rememberOwnEventCtx(ctx);
-		refreshCtxDerivedPlumbing();
-		const sessionStartFiredAt = Date.now();
-		try {
-			dbg("session_start fired");
-			const sessionReason = (event as { reason?: string }).reason;
-
-			// #1334 S5: adopt the HOST's project-trust decision before anything
-			// below can auto-install a tool or spawn an LSP server. pi-lens is a
-			// CONSUMER of trust (`ctx.isProjectTrusted()`), never a handler of the
-			// `project_trust` event — answering that question on the user's behalf
-			// is the host's/user's job. Re-read here and on every turn_start because
-			// fork/reload/resume can change cwd and trust can change mid-session.
-			// Feature-detected:
-			// a host without the accessor yields "unknown" and nothing is gated.
-			const trustState = adoptProjectTrustFromPorts(hostPorts);
-			if (trustState !== "unknown") {
-				dbg(`session_start: project trust = ${trustState}`);
-			}
-			if (trustState === "untrusted") {
-				dbg(
-					"session_start: untrusted project — tool auto-install and LSP spawns are disabled for this session",
+	// #1929: wrapped like the other reachable handlers. The ctx delivered here
+	// is USUALLY the announced session's own, built moments earlier, so the
+	// probe answers `true` and nothing changes. It is not always: a session
+	// replacement can land while this event sits in the queue, and then every
+	// ctx read below throws. Before the wrapper that arrived as
+	// `session_start crashed: …`, indistinguishable from a real handler bug,
+	// and it counted nothing. Now it is one bounded `extension-ctx-stale`
+	// record subject-keyed to `session_start`.
+	//
+	// Skipping the whole handler is the right stale-path answer, not a loss:
+	// `rememberOwnEventCtx` would otherwise store the DEAD ctx as pi-lens's
+	// own, and the warms plus per-session resets above all re-run when the
+	// replacement session fires its own live `session_start`.
+	pi.on(
+		"session_start",
+		wrapSessionEventHandler(
+			"session_start",
+			async (event, ctx) => {
+				const sessionStartMonotonicAt = performance.now();
+				resetVerifiedPathAttributionGuessCount();
+				warmDispatchAtSessionStart();
+				void warmLspService().catch((err) =>
+					logExtension({ subsystem: "lsp", level: "warn", message: `LSP warm failed: ${err}` }),
 				);
-			}
-
-			// #190: pi's session lifecycle. `reason` distinguishes new/resume/fork/
-			// reload/startup; the STABLE session id comes from the session manager
-			// (the event carries none), and is what lets a resumed session rehydrate.
-			const stableSessionId = (() => {
+				void warmFormatters().catch((err) =>
+					logExtension({ subsystem: "format", level: "warn", message: `formatter warm failed: ${err}` }),
+				);
+				rememberOwnEventCtx(ctx);
+				refreshCtxDerivedPlumbing();
+				const sessionStartFiredAt = Date.now();
 				try {
-					return (
-						ctx as { sessionManager?: { getSessionId?: () => string } }
-					)?.sessionManager?.getSessionId?.();
-				} catch {
-					return undefined;
-				}
-			})();
+					dbg("session_start fired");
+					const sessionReason = (event as { reason?: string }).reason;
 
-			// #473: distinguish a concurrently-live in-process subagent bind
-			// (tintinweb/pi-subagents-style) from a real sequential session
-			// replacement BEFORE touching any process-shared singleton. A
-			// concurrent secondary must not run handleSessionStart (which resets
-			// the shared LSP fleet + runtime generation out from under the still
-			// -live parent) or updateRuntimeIdentityFromCtx (which would
-			// overwrite the parent's telemetry identity).
-			const sessionStartDecision = decideSessionStart(ctx, stableSessionId);
-			if (!sessionStartDecision.runFullSessionStart) {
-				dbg(
-					`session_start: concurrent secondary detected (count=${sessionStartDecision.secondaryCount}) — skipping handleSessionStart`,
-				);
-				logConcurrentSessionBind({
-					secondaryCount: sessionStartDecision.secondaryCount,
-					sessionReason,
-					sameCwd: (ctx as { cwd?: string })?.cwd === process.cwd(),
-				});
-				return;
-			}
-
-			// #1723 review F4: the in-flight-phase live-bracket map/closed-ring
-			// (clients/latency-logger.ts) is process-shared state, exactly like
-			// the LSP fleet / runtime generation the #473 gate above already
-			// protects — so this reset belongs BEHIND that gate, not before it.
-			// A concurrent secondary's session_start must not wipe brackets a
-			// still-live PARENT activation genuinely has open; only a confirmed
-			// full session start (this line has already returned otherwise) may
-			// assume no sibling activation still owns live brackets in this
-			// process. See `resetCurrentPhaseForSession`'s doc comment for the
-			// accepted cost on the other side (a torn-down secondary's own
-			// bracket goes stale until the next full session start).
-			resetCurrentPhaseForSession();
-
-			// Dynamic tooling (#pi 0.80.x+): put the active tool set back to the
-			// posture this logical conversation had — the always-active baseline
-			// plus exactly the lazy tools (LAZY_TOOL_CATALOG) the model activated
-			// via pi_lens_activate_tools. session_start is the correct lifecycle
-			// point for this call (#643; see the comment left at the old call site
-			// above, right after tool registration, for why it can never succeed
-			// there).
-			//
-			// #1453: this RESTORES, it does not merely shrink. Every session_start
-			// reason arrives with all registered pi-lens tools active, because the
-			// host builds a fresh AgentSession with `includeAllExtensionTools: true`
-			// on fork/reload/resume just as it does on startup, and never persists
-			// an active-tool set per session. Skipping the call on those reasons
-			// would therefore leave every lazy tool active forever AND change the
-			// advertised tool list relative to the parent's cached prompt prefix.
-			// Rebuilding the same set instead keeps the prefix identical and
-			// genuinely preserves the model's activations, because pi-lens's own
-			// closure state (`rememberedLazyTools`) survives the rebuild.
-			//
-			// Deliberately BELOW the #473 concurrent-secondary guard: the active
-			// tool set is shared runtime state (one loader per process), so a
-			// secondary's session_start must never rewrite the still-live
-			// primary's set — last writer would win.
-			//
-			// Feature-detected the same way as elsewhere in this handler:
-			// `pi.getActiveTools`/`setActiveTools` aren't guaranteed present on
-			// every host the broad `@earendil-works/pi-coding-agent` peer
-			// dependency allows, so probe with typeof rather than assuming the
-			// pinned devDependency version's API exists at runtime. Under
-			// `--no-lazy-tools` nothing is touched at all: all-active IS the
-			// requested posture.
-			try {
-				const piWithActiveTools = pi as unknown as {
-					getActiveTools?: () => string[];
-					setActiveTools?: (names: string[]) => void;
-				};
-				if (
-					getLensFlag("no-lazy-tools") !== true &&
-					typeof piWithActiveTools.getActiveTools === "function" &&
-					typeof piWithActiveTools.setActiveTools === "function"
-				) {
-					// A fresh conversation starts with no activation memory; a
-					// rebuild inherits the parent's.
-					if (isFreshSessionStart(sessionReason)) rememberedLazyTools.clear();
-					const lazyNames = new Set(LAZY_TOOL_CATALOG.map((t) => t.name));
-					const plan = planToolSet(
-						piWithActiveTools.getActiveTools(),
-						lazyNames,
-						rememberedLazyTools,
-					);
-					if (plan.changed) {
-						piWithActiveTools.setActiveTools(plan.desired);
-						recordToolSetMutation({
-							addedCount: plan.addedCount,
-							removedCount: plan.removedCount,
-							reason: isFreshSessionStart(sessionReason)
-								? "fresh_session_lazy_deactivation"
-								: "session_rebuild_restore",
-							deferralApplies: supportsDeferredTools(
-								(ctx as { model?: Parameters<typeof supportsDeferredTools>[0] })
-									?.model,
-							),
-						});
+					// #1334 S5: adopt the HOST's project-trust decision before anything
+					// below can auto-install a tool or spawn an LSP server. pi-lens is a
+					// CONSUMER of trust (`ctx.isProjectTrusted()`), never a handler of the
+					// `project_trust` event — answering that question on the user's behalf
+					// is the host's/user's job. Re-read here and on every turn_start because
+					// fork/reload/resume can change cwd and trust can change mid-session.
+					// Feature-detected:
+					// a host without the accessor yields "unknown" and nothing is gated.
+					const trustState = adoptProjectTrustFromPorts(hostPorts);
+					if (trustState !== "unknown") {
+						dbg(`session_start: project trust = ${trustState}`);
 					}
-				}
-			} catch (toolSetErr) {
-				dbg(
-					`dynamic tool set restore failed (older pi host lacking getActiveTools/setActiveTools, or a genuine host error): ${toolSetErr}`,
-				);
-			}
-
-			// #449 slice 1 / #472: register this process in the cross-process
-			// instance registry and fire-and-forget an orphan-LSP sweep. Below the
-			// #473 guard deliberately: a concurrent secondary neither re-registers
-			// (the pid's entry already exists) nor re-sweeps (a fan-out would run
-			// up to maxConcurrent redundant sweeps). Neither call is awaited —
-			// registry I/O and the reaper must never delay session start; both are
-			// internally best-effort (never throw).
-			await configureWarmAttach(ctx.cwd ?? process.cwd());
-			void registerInstance(ctx.cwd ?? process.cwd()).catch(() => {
-				// best-effort observability — never fail session_start over this
-			});
-			// #1123 item 2: log a sessionstart.log marker for any registry entry
-			// whose owning pid is confirmed dead — this instance vanished without
-			// reaching deregisterInstance()'s clean-shutdown removal. MUST read the
-			// registry and log BEFORE sweepOrphans (below) prunes exactly these same
-			// dead-pid entries out from under it, or the vanished set would already
-			// be empty by the time this runs — hence the explicit read here rather
-			// than letting sweepOrphans's own internal read race it.
-			void readInstanceRegistry()
-				.then((registry) => logVanishedInstances(registry))
-				.catch(() => {
-					// best-effort observability — never fail session_start over this
-				})
-				.finally(() => {
-					void sweepOrphans();
-				});
-			// #658: registry-INDEPENDENT backstop sweep, running alongside the
-			// registry-driven one above. `sweepOrphans` can only ever see pids
-			// still listed in some instance's `lspChildren[]`; once that trace is
-			// lost (stale-heartbeat entry removal, or a silently-failed
-			// `killPidTree`), the child becomes permanently invisible to it. This
-			// backstop instead scans the OS process table directly for known
-			// pi-lens-managed binary names and only acts on ones that are BOTH
-			// untracked by the current registry snapshot AND have a
-			// confirmed-dead parent — never on name alone. Fire-and-forget, same
-			// non-blocking/never-throws contract as `sweepOrphans`.
-			//
-			// #1857: SCHEDULED, not called. The sweep's OS-process enumeration was
-			// measured at 9344ms on the session_start critical path, exactly
-			// overlapping and starving `warmup_language_profile`. It now fires on
-			// an unref'd timer well after warmup, under a machine-wide cooldown.
-			scheduleUntrackedOrphanSweep();
-			// #449 slice 2 (prototype): machine-wide LSP budget check. Reads the
-			// same registry, decides locally whether THIS session should skip
-			// spawning auxiliary LSP servers, and caches the decision for
-			// clients/dispatch/auxiliary-lsp.ts to read on later dispatch calls.
-			// Never awaited — a registry read must not delay session start, and
-			// dispatch doesn't happen until later in the turn anyway, so the cache
-			// is populated well before it's first read in practice.
-			void checkCrossProcessLspBudget();
-			// #492: child-at-session_start cross-process nudge consumer. Reads
-			// `recent-touches.json` (clients/recent-touches.ts) for entries from
-			// OTHER pi-lens instances (pid-excluded) within the 15-minute
-			// freshness window whose file still exists, and feeds them into the
-			// same #485 accumulator a bus event would use — the first `context`
-			// call this session makes (clients/agent-nudge.ts, wired below) then
-			// injects one batched provenance message. This is the "child blind to
-			// parent" direction from #492: a subagent asked to `git status` right
-			// after spawn otherwise sees unexplained `M` files with no
-			// explanation. Never awaited-to-block session_start; internally
-			// best-effort (recent-touches.ts never throws).
-			void readCrossProcessTouchesForSessionStart({
-				cwd: ctx.cwd ?? process.cwd(),
-			})
-				.then((entries) => {
-					if (entries.length === 0) return;
-					recordCrossProcessTouches(
-						entries.map((e) => ({ path: e.path, reason: e.reason })),
-					);
-					dbg(
-						`session_start: cross-process nudge — ${entries.length} file(s) from other instance(s)`,
-					);
-				})
-				.catch((err) => {
-					dbg(`session_start: cross-process nudge read failed: ${err}`);
-				});
-			updateRuntimeIdentityFromCtx(ctx);
-			try {
-				await ensureLSPConfigInitialized(ctx.cwd ?? process.cwd());
-			} catch (cfgErr) {
-				dbg(`lsp config init failed: ${cfgErr}`);
-			}
-
-			const bootstrapClientsStartedAt = Date.now();
-			const {
-				metricsClient,
-				todoScanner,
-				biomeClient,
-				ruffClient,
-				knipClient,
-				jscpdClient,
-				govulncheckClient,
-				gitleaksClient,
-				trivyClient,
-				opengrepClient,
-				depChecker,
-				testRunnerClient,
-				goClient,
-				rustClient,
-				deadCodeClients,
-			} = await loadBootstrapClients();
-			const bootstrapClientsDurationMs = Date.now() - bootstrapClientsStartedAt;
-			const handlerEnteredAt = Date.now();
-			// Consume the process-lifetime measurement at the first real session
-			// start. Concurrent secondary starts never reach this handler.
-			const emitHostReadyDelay = consumeHostReadyDelayAnchor();
-			await handleSessionStart({
-				ctxCwd: ctx.cwd,
-				sessionStartFiredAt,
-				sessionStartMonotonicAt,
-				extensionLoadedAt: PI_LENS_LOADED_AT_MS,
-				emitHostReadyDelay,
-				sessionReason,
-				handlerEnteredAt,
-				bootstrapClientsStartedAt,
-				bootstrapClientsDurationMs,
-				getFlag: (name: string) => getLensFlag(name),
-				notify: (msg, level) => notifyUi(ctx, msg, level),
-				dbg,
-				log,
-				runtime,
-				metricsClient,
-				cacheManager,
-				todoScanner,
-				astGrepClient,
-				biomeClient,
-				ruffClient,
-				knipClient,
-				jscpdClient,
-				deadCodeClients,
-				govulncheckClient,
-				gitleaksClient,
-				trivyClient,
-				opengrepClient,
-				depChecker,
-				testRunnerClient,
-				goClient,
-				rustClient,
-				ensureTool: async (name: string) =>
-					(await import("./clients/installer/index.js")).ensureTool(name),
-				cleanStaleTsBuildInfo,
-				resetDispatchBaselines,
-				resetLSPService,
-			});
-			ctx.ui && updateLspStatus(ctx.ui.setStatus, ctx.ui.theme);
-
-			// Pin the stable identity + reason AFTER handleSessionStart (which ran
-			// resetForSession → a fresh random id); the stable id now wins (#190).
-			runtime.setSessionLifecycle({
-				sessionId: stableSessionId,
-				reason: sessionReason,
-			});
-
-			// Lifecycle-aware widget state (#190). The "should I rehydrate" signal is
-			// NOT the reason — it's whether a persisted snapshot exists for this
-			// STABLE session id. A `pi --session <id>` launch fires reason="startup"
-			// (not "resume" — that's only an in-process switchSession), so gating on
-			// "resume" alone missed the common resume path. So: fork branches from
-			// the in-memory stash; reload keeps state; new starts clean; everything
-			// else (resume / startup / default) rehydrates IFF a snapshot exists —
-			// a brand-new session has a fresh id with no file (→ clean), a
-			// resumed/launched one has its prior file (→ rehydrate).
-			const reasonLabel = sessionReason ?? "startup";
-			const startMode = sessionStartMode(sessionReason, !!pendingForkSnapshot);
-			if (startMode === "fork" && pendingForkSnapshot) {
-				// Branch the forked session from the source's in-memory snapshot, then
-				// persist it under the new session id so the fork owns its own copy.
-				clearWidgetState();
-				importWidgetState(pendingForkSnapshot);
-				const forkedFileCount = pendingForkSnapshot.files.length;
-				pendingForkSnapshot = undefined;
-				// #1041: adopt the source session's read history (staleness-reconciled
-				// against current disk) so the fork isn't zero-read-blocked on files
-				// the parent already read.
-				let forkReadImport: { imported: number; dropped: number } | undefined;
-				if (pendingForkReadGuard) {
-					forkReadImport = runtime.readGuard.importState(pendingForkReadGuard);
-					pendingForkReadGuard = undefined;
-				}
-				if (stableSessionId) {
-					void saveSessionState(
-						ctx.cwd ?? process.cwd(),
-						stableSessionId,
-						exportWidgetState(),
-						runtime.readGuard.exportState(),
-					);
-				}
-				dbg(
-					`session_start: fork — branched ${forkedFileCount} file(s) from source` +
-						(forkReadImport
-							? `, read-guard +${forkReadImport.imported} (dropped ${forkReadImport.dropped})`
-							: ""),
-				);
-			} else if (startMode === "keep") {
-				dbg("session_start: reload — keeping widget state");
-			} else if (startMode === "clean") {
-				pendingForkSnapshot = undefined;
-				pendingForkReadGuard = undefined;
-				clearWidgetState();
-				dbg("session_start: new — clean widget");
-			} else {
-				// maybe-rehydrate: covers resume AND startup (e.g. `pi --session <id>`)
-				pendingForkSnapshot = undefined;
-				pendingForkReadGuard = undefined;
-				clearWidgetState();
-				if (stableSessionId) {
-					const persisted = await loadSessionState(
-						ctx.cwd ?? process.cwd(),
-						stableSessionId,
-					);
-					if (persisted?.widget) {
-						// #180/#190: drop files changed on disk since the snapshot so a
-						// resume never surfaces stale diagnostics; they re-scan on edit.
-						const fresh = await dropStaleFiles(
-							persisted.widget,
-							persisted.savedAt,
-						);
-						const dropped = persisted.widget.files.length - fresh.files.length;
-						importWidgetState(fresh);
-						// #1041: rehydrate the read-before-edit guard's read-set on the
-						// SAME path so the first post-resume edit of a previously-read
-						// file isn't falsely zero-read-blocked. importState reconciles
-						// each read against current disk (drops changed/missing files),
-						// so a resume never masks a real staleness.
-						const readImport = runtime.readGuard.importState(
-							persisted.readGuard,
-						);
+					if (trustState === "untrusted") {
 						dbg(
-							`session_start: ${reasonLabel} ${stableSessionId} — rehydrated ${fresh.files.length} file(s)` +
-								(dropped > 0 ? `, dropped ${dropped} stale` : "") +
-								(readImport.imported > 0 || readImport.dropped > 0
-									? `; read-guard +${readImport.imported} read(s) (dropped ${readImport.dropped} stale)`
+							"session_start: untrusted project — tool auto-install and LSP spawns are disabled for this session",
+						);
+					}
+
+					// #190: pi's session lifecycle. `reason` distinguishes new/resume/fork/
+					// reload/startup; the STABLE session id comes from the session manager
+					// (the event carries none), and is what lets a resumed session rehydrate.
+					const stableSessionId = (() => {
+						try {
+							return (
+								ctx as { sessionManager?: { getSessionId?: () => string } }
+							)?.sessionManager?.getSessionId?.();
+						} catch {
+							return undefined;
+						}
+					})();
+
+					// #473: distinguish a concurrently-live in-process subagent bind
+					// (tintinweb/pi-subagents-style) from a real sequential session
+					// replacement BEFORE touching any process-shared singleton. A
+					// concurrent secondary must not run handleSessionStart (which resets
+					// the shared LSP fleet + runtime generation out from under the still
+					// -live parent) or updateRuntimeIdentityFromCtx (which would
+					// overwrite the parent's telemetry identity).
+					const sessionStartDecision = decideSessionStart(ctx, stableSessionId);
+					if (!sessionStartDecision.runFullSessionStart) {
+						dbg(
+							`session_start: concurrent secondary detected (count=${sessionStartDecision.secondaryCount}) — skipping handleSessionStart`,
+						);
+						logConcurrentSessionBind({
+							secondaryCount: sessionStartDecision.secondaryCount,
+							sessionReason,
+							sameCwd: (ctx as { cwd?: string })?.cwd === process.cwd(),
+						});
+						return;
+					}
+
+					// #1723 review F4: the in-flight-phase live-bracket map/closed-ring
+					// (clients/latency-logger.ts) is process-shared state, exactly like
+					// the LSP fleet / runtime generation the #473 gate above already
+					// protects — so this reset belongs BEHIND that gate, not before it.
+					// A concurrent secondary's session_start must not wipe brackets a
+					// still-live PARENT activation genuinely has open; only a confirmed
+					// full session start (this line has already returned otherwise) may
+					// assume no sibling activation still owns live brackets in this
+					// process. See `resetCurrentPhaseForSession`'s doc comment for the
+					// accepted cost on the other side (a torn-down secondary's own
+					// bracket goes stale until the next full session start).
+					resetCurrentPhaseForSession();
+
+					// Dynamic tooling (#pi 0.80.x+): put the active tool set back to the
+					// posture this logical conversation had — the always-active baseline
+					// plus exactly the lazy tools (LAZY_TOOL_CATALOG) the model activated
+					// via pi_lens_activate_tools. session_start is the correct lifecycle
+					// point for this call (#643; see the comment left at the old call site
+					// above, right after tool registration, for why it can never succeed
+					// there).
+					//
+					// #1453: this RESTORES, it does not merely shrink. Every session_start
+					// reason arrives with all registered pi-lens tools active, because the
+					// host builds a fresh AgentSession with `includeAllExtensionTools: true`
+					// on fork/reload/resume just as it does on startup, and never persists
+					// an active-tool set per session. Skipping the call on those reasons
+					// would therefore leave every lazy tool active forever AND change the
+					// advertised tool list relative to the parent's cached prompt prefix.
+					// Rebuilding the same set instead keeps the prefix identical and
+					// genuinely preserves the model's activations, because pi-lens's own
+					// closure state (`rememberedLazyTools`) survives the rebuild.
+					//
+					// Deliberately BELOW the #473 concurrent-secondary guard: the active
+					// tool set is shared runtime state (one loader per process), so a
+					// secondary's session_start must never rewrite the still-live
+					// primary's set — last writer would win.
+					//
+					// Feature-detected the same way as elsewhere in this handler:
+					// `pi.getActiveTools`/`setActiveTools` aren't guaranteed present on
+					// every host the broad `@earendil-works/pi-coding-agent` peer
+					// dependency allows, so probe with typeof rather than assuming the
+					// pinned devDependency version's API exists at runtime. Under
+					// `--no-lazy-tools` nothing is touched at all: all-active IS the
+					// requested posture.
+					try {
+						const piWithActiveTools = pi as unknown as {
+							getActiveTools?: () => string[];
+							setActiveTools?: (names: string[]) => void;
+						};
+						if (
+							getLensFlag("no-lazy-tools") !== true &&
+							typeof piWithActiveTools.getActiveTools === "function" &&
+							typeof piWithActiveTools.setActiveTools === "function"
+						) {
+							// A fresh conversation starts with no activation memory; a
+							// rebuild inherits the parent's.
+							if (isFreshSessionStart(sessionReason)) rememberedLazyTools.clear();
+							const lazyNames = new Set(LAZY_TOOL_CATALOG.map((t) => t.name));
+							const plan = planToolSet(
+								piWithActiveTools.getActiveTools(),
+								lazyNames,
+								rememberedLazyTools,
+							);
+							if (plan.changed) {
+								piWithActiveTools.setActiveTools(plan.desired);
+								recordToolSetMutation({
+									addedCount: plan.addedCount,
+									removedCount: plan.removedCount,
+									reason: isFreshSessionStart(sessionReason)
+										? "fresh_session_lazy_deactivation"
+										: "session_rebuild_restore",
+									deferralApplies: supportsDeferredTools(
+										(ctx as { model?: Parameters<typeof supportsDeferredTools>[0] })
+											?.model,
+									),
+								});
+							}
+						}
+					} catch (toolSetErr) {
+						dbg(
+							`dynamic tool set restore failed (older pi host lacking getActiveTools/setActiveTools, or a genuine host error): ${toolSetErr}`,
+						);
+					}
+
+					// #449 slice 1 / #472: register this process in the cross-process
+					// instance registry and fire-and-forget an orphan-LSP sweep. Below the
+					// #473 guard deliberately: a concurrent secondary neither re-registers
+					// (the pid's entry already exists) nor re-sweeps (a fan-out would run
+					// up to maxConcurrent redundant sweeps). Neither call is awaited —
+					// registry I/O and the reaper must never delay session start; both are
+					// internally best-effort (never throw).
+					await configureWarmAttach(ctx.cwd ?? process.cwd());
+					void registerInstance(ctx.cwd ?? process.cwd()).catch(() => {
+						// best-effort observability — never fail session_start over this
+					});
+					// #1123 item 2: log a sessionstart.log marker for any registry entry
+					// whose owning pid is confirmed dead — this instance vanished without
+					// reaching deregisterInstance()'s clean-shutdown removal. MUST read the
+					// registry and log BEFORE sweepOrphans (below) prunes exactly these same
+					// dead-pid entries out from under it, or the vanished set would already
+					// be empty by the time this runs — hence the explicit read here rather
+					// than letting sweepOrphans's own internal read race it.
+					void readInstanceRegistry()
+						.then((registry) => logVanishedInstances(registry))
+						.catch(() => {
+							// best-effort observability — never fail session_start over this
+						})
+						.finally(() => {
+							void sweepOrphans();
+						});
+					// #658: registry-INDEPENDENT backstop sweep, running alongside the
+					// registry-driven one above. `sweepOrphans` can only ever see pids
+					// still listed in some instance's `lspChildren[]`; once that trace is
+					// lost (stale-heartbeat entry removal, or a silently-failed
+					// `killPidTree`), the child becomes permanently invisible to it. This
+					// backstop instead scans the OS process table directly for known
+					// pi-lens-managed binary names and only acts on ones that are BOTH
+					// untracked by the current registry snapshot AND have a
+					// confirmed-dead parent — never on name alone. Fire-and-forget, same
+					// non-blocking/never-throws contract as `sweepOrphans`.
+					//
+					// #1857: SCHEDULED, not called. The sweep's OS-process enumeration was
+					// measured at 9344ms on the session_start critical path, exactly
+					// overlapping and starving `warmup_language_profile`. It now fires on
+					// an unref'd timer well after warmup, under a machine-wide cooldown.
+					scheduleUntrackedOrphanSweep();
+					// #449 slice 2 (prototype): machine-wide LSP budget check. Reads the
+					// same registry, decides locally whether THIS session should skip
+					// spawning auxiliary LSP servers, and caches the decision for
+					// clients/dispatch/auxiliary-lsp.ts to read on later dispatch calls.
+					// Never awaited — a registry read must not delay session start, and
+					// dispatch doesn't happen until later in the turn anyway, so the cache
+					// is populated well before it's first read in practice.
+					void checkCrossProcessLspBudget();
+					// #492: child-at-session_start cross-process nudge consumer. Reads
+					// `recent-touches.json` (clients/recent-touches.ts) for entries from
+					// OTHER pi-lens instances (pid-excluded) within the 15-minute
+					// freshness window whose file still exists, and feeds them into the
+					// same #485 accumulator a bus event would use — the first `context`
+					// call this session makes (clients/agent-nudge.ts, wired below) then
+					// injects one batched provenance message. This is the "child blind to
+					// parent" direction from #492: a subagent asked to `git status` right
+					// after spawn otherwise sees unexplained `M` files with no
+					// explanation. Never awaited-to-block session_start; internally
+					// best-effort (recent-touches.ts never throws).
+					void readCrossProcessTouchesForSessionStart({
+						cwd: ctx.cwd ?? process.cwd(),
+					})
+						.then((entries) => {
+							if (entries.length === 0) return;
+							recordCrossProcessTouches(
+								entries.map((e) => ({ path: e.path, reason: e.reason })),
+							);
+							dbg(
+								`session_start: cross-process nudge — ${entries.length} file(s) from other instance(s)`,
+							);
+						})
+						.catch((err) => {
+							dbg(`session_start: cross-process nudge read failed: ${err}`);
+						});
+					updateRuntimeIdentityFromCtx(ctx);
+					try {
+						await ensureLSPConfigInitialized(ctx.cwd ?? process.cwd());
+					} catch (cfgErr) {
+						dbg(`lsp config init failed: ${cfgErr}`);
+					}
+
+					const bootstrapClientsStartedAt = Date.now();
+					const {
+						metricsClient,
+						todoScanner,
+						biomeClient,
+						ruffClient,
+						knipClient,
+						jscpdClient,
+						govulncheckClient,
+						gitleaksClient,
+						trivyClient,
+						opengrepClient,
+						depChecker,
+						testRunnerClient,
+						goClient,
+						rustClient,
+						deadCodeClients,
+					} = await loadBootstrapClients();
+					const bootstrapClientsDurationMs = Date.now() - bootstrapClientsStartedAt;
+					const handlerEnteredAt = Date.now();
+					// Consume the process-lifetime measurement at the first real session
+					// start. Concurrent secondary starts never reach this handler.
+					const emitHostReadyDelay = consumeHostReadyDelayAnchor();
+					await handleSessionStart({
+						ctxCwd: ctx.cwd,
+						sessionStartFiredAt,
+						sessionStartMonotonicAt,
+						extensionLoadedAt: PI_LENS_LOADED_AT_MS,
+						emitHostReadyDelay,
+						sessionReason,
+						handlerEnteredAt,
+						bootstrapClientsStartedAt,
+						bootstrapClientsDurationMs,
+						getFlag: (name: string) => getLensFlag(name),
+						notify: (msg, level) => notifyUi(ctx, msg, level),
+						dbg,
+						log,
+						runtime,
+						metricsClient,
+						cacheManager,
+						todoScanner,
+						astGrepClient,
+						biomeClient,
+						ruffClient,
+						knipClient,
+						jscpdClient,
+						deadCodeClients,
+						govulncheckClient,
+						gitleaksClient,
+						trivyClient,
+						opengrepClient,
+						depChecker,
+						testRunnerClient,
+						goClient,
+						rustClient,
+						ensureTool: async (name: string) =>
+							(await import("./clients/installer/index.js")).ensureTool(name),
+						cleanStaleTsBuildInfo,
+						resetDispatchBaselines,
+						resetLSPService,
+					});
+					ctx.ui && updateLspStatus(ctx.ui.setStatus, ctx.ui.theme);
+
+					// Pin the stable identity + reason AFTER handleSessionStart (which ran
+					// resetForSession → a fresh random id); the stable id now wins (#190).
+					runtime.setSessionLifecycle({
+						sessionId: stableSessionId,
+						reason: sessionReason,
+					});
+
+					// Lifecycle-aware widget state (#190). The "should I rehydrate" signal is
+					// NOT the reason — it's whether a persisted snapshot exists for this
+					// STABLE session id. A `pi --session <id>` launch fires reason="startup"
+					// (not "resume" — that's only an in-process switchSession), so gating on
+					// "resume" alone missed the common resume path. So: fork branches from
+					// the in-memory stash; reload keeps state; new starts clean; everything
+					// else (resume / startup / default) rehydrates IFF a snapshot exists —
+					// a brand-new session has a fresh id with no file (→ clean), a
+					// resumed/launched one has its prior file (→ rehydrate).
+					const reasonLabel = sessionReason ?? "startup";
+					const startMode = sessionStartMode(sessionReason, !!pendingForkSnapshot);
+					if (startMode === "fork" && pendingForkSnapshot) {
+						// Branch the forked session from the source's in-memory snapshot, then
+						// persist it under the new session id so the fork owns its own copy.
+						clearWidgetState();
+						importWidgetState(pendingForkSnapshot);
+						const forkedFileCount = pendingForkSnapshot.files.length;
+						pendingForkSnapshot = undefined;
+						// #1041: adopt the source session's read history (staleness-reconciled
+						// against current disk) so the fork isn't zero-read-blocked on files
+						// the parent already read.
+						let forkReadImport: { imported: number; dropped: number } | undefined;
+						if (pendingForkReadGuard) {
+							forkReadImport = runtime.readGuard.importState(pendingForkReadGuard);
+							pendingForkReadGuard = undefined;
+						}
+						if (stableSessionId) {
+							void saveSessionState(
+								ctx.cwd ?? process.cwd(),
+								stableSessionId,
+								exportWidgetState(),
+								runtime.readGuard.exportState(),
+							);
+						}
+						dbg(
+							`session_start: fork — branched ${forkedFileCount} file(s) from source` +
+								(forkReadImport
+									? `, read-guard +${forkReadImport.imported} (dropped ${forkReadImport.dropped})`
 									: ""),
 						);
+					} else if (startMode === "keep") {
+						dbg("session_start: reload — keeping widget state");
+					} else if (startMode === "clean") {
+						pendingForkSnapshot = undefined;
+						pendingForkReadGuard = undefined;
+						clearWidgetState();
+						dbg("session_start: new — clean widget");
 					} else {
-						dbg(
-							`session_start: ${reasonLabel} ${stableSessionId} — no persisted state (clean)`,
-						);
+						// maybe-rehydrate: covers resume AND startup (e.g. `pi --session <id>`)
+						pendingForkSnapshot = undefined;
+						pendingForkReadGuard = undefined;
+						clearWidgetState();
+						if (stableSessionId) {
+							const persisted = await loadSessionState(
+								ctx.cwd ?? process.cwd(),
+								stableSessionId,
+							);
+							if (persisted?.widget) {
+								// #180/#190: drop files changed on disk since the snapshot so a
+								// resume never surfaces stale diagnostics; they re-scan on edit.
+								const fresh = await dropStaleFiles(
+									persisted.widget,
+									persisted.savedAt,
+								);
+								const dropped = persisted.widget.files.length - fresh.files.length;
+								importWidgetState(fresh);
+								// #1041: rehydrate the read-before-edit guard's read-set on the
+								// SAME path so the first post-resume edit of a previously-read
+								// file isn't falsely zero-read-blocked. importState reconciles
+								// each read against current disk (drops changed/missing files),
+								// so a resume never masks a real staleness.
+								const readImport = runtime.readGuard.importState(
+									persisted.readGuard,
+								);
+								dbg(
+									`session_start: ${reasonLabel} ${stableSessionId} — rehydrated ${fresh.files.length} file(s)` +
+										(dropped > 0 ? `, dropped ${dropped} stale` : "") +
+										(readImport.imported > 0 || readImport.dropped > 0
+											? `; read-guard +${readImport.imported} read(s) (dropped ${readImport.dropped} stale)`
+											: ""),
+								);
+							} else {
+								dbg(
+									`session_start: ${reasonLabel} ${stableSessionId} — no persisted state (clean)`,
+								);
+							}
+						} else {
+							dbg(`session_start: ${reasonLabel} — no stable session id (clean)`);
+						}
 					}
-				} else {
-					dbg(`session_start: ${reasonLabel} — no stable session id (clean)`);
-				}
-			}
 
-			if (lensWidgetVisible) {
-				mountLensWidget(ctx.ui, readExtensionMode(ctx));
-			}
-		} catch (sessionErr) {
-			dbg(`session_start crashed: ${sessionErr}`);
-			dbg(`session_start crash stack: ${(sessionErr as Error).stack}`);
-		}
-	});
+					if (lensWidgetVisible) {
+						mountLensWidget(ctx.ui, readExtensionMode(ctx));
+					}
+				} catch (sessionErr) {
+					// The stale-ctx class has ONE classifier and one record, in
+					// clients/session-event-guard.ts. Rethrow so the wrapper around
+					// this registration owns it, instead of this catch logging a
+					// session swap as a pi-lens crash (#1929, same shape as the
+					// agent_end and turn_end catches).
+					if (isStaleExtensionCtxError(sessionErr)) throw sessionErr;
+					dbg(`session_start crashed: ${sessionErr}`);
+					dbg(`session_start crash stack: ${(sessionErr as Error).stack}`);
+				}
+			},
+			{ dbg },
+		),
+	);
 
 	// #190 Phase 2: capture the source session's diagnostics just before a fork,
 	// so the forked session (its `session_start` fires with reason="fork") can
@@ -2901,142 +2928,166 @@ function activateExtension(hostPi: ExtensionAPI) {
 	// biome-ignore lint/suspicious/noExplicitAny: pi.on("context") overload has TS resolution bug
 	(pi as any).on(
 		"context",
-		async (
-			event: { messages?: Array<{ role: string; content: unknown }> } | unknown,
-			ctx: { cwd?: string },
-		) => {
-			// #1018: context telemetry deliberately runs even when the lens or its
-			// injection toggle is off, so an A/B run has a no-injection observation.
-			const existingMessages =
-				(event as { messages?: Array<{ role: string; content: unknown }> })
-					?.messages ?? [];
-			const prefixSessionId = getStableSessionId(ctx);
-			const sessionRole = classifyCurrentSessionEmission(ctx, prefixSessionId);
-			// #1938: `observeCachePrefix` still owns the unbounded, always-accurate
-			// `cache_prefix_break` signal below. Its return value used to be threaded
-			// into `observeCacheContext` as `prefixObservation`, but that field was
-			// removed there (see the cache-observability.ts module doc) — the call
-			// stays for its `cache_prefix_break` side effect only.
-			observeCachePrefix(
-				existingMessages,
-				runtime.turnIndex,
-				prefixSessionId,
-				sessionRole,
-				dbg,
-			);
-			const effectiveInjectionEnabled = lensEnabled && contextInjectionEnabled;
-			let telemetryLogged = false;
-			const logContextObservation = (
-				resultMessages: Array<{ role: string; content: unknown }>,
-				placement: "prepend" | "insert-before-final" | "append" | "none",
-				// #1071: the per-source slices ARE the telemetry input. The source
-				// name list and the flat message list are both derived from them
-				// inside observeCacheContext, so this call site cannot report a
-				// source that contributed nothing.
-				injectionSlices: ReadonlyArray<CacheContextInjectionSlice>,
+		// #1929: `context` is reachable with a ctx the SDK already invalidated,
+		// exactly like the five handlers #1925 wrapped. It could not use the void
+		// wrapper because the host CONSUMES its return value on the live path, so
+		// it uses the value-returning variant and states its own stale-path answer
+		// below. Before this, a stale ctx surfaced as `context event error: …`,
+		// indistinguishable from a real handler bug, and counted nothing.
+		wrapSessionEventHandlerWithResult(
+			"context",
+			async (
+				event: { messages?: Array<{ role: string; content: unknown }> } | unknown,
+				ctx: { cwd?: string },
 			) => {
-				if (telemetryLogged) return;
-				telemetryLogged = true;
-				observeCacheContext({
+				// #1018: context telemetry deliberately runs even when the lens or its
+				// injection toggle is off, so an A/B run has a no-injection observation.
+				const existingMessages =
+					(event as { messages?: Array<{ role: string; content: unknown }> })
+						?.messages ?? [];
+				const prefixSessionId = getStableSessionId(ctx);
+				const sessionRole = classifyCurrentSessionEmission(ctx, prefixSessionId);
+				// #1938: `observeCachePrefix` still owns the unbounded, always-accurate
+				// `cache_prefix_break` signal below. Its return value used to be threaded
+				// into `observeCacheContext` as `prefixObservation`, but that field was
+				// removed there (see the cache-observability.ts module doc) — the call
+				// stays for its `cache_prefix_break` side effect only.
+				observeCachePrefix(
 					existingMessages,
-					resultMessages,
-					sessionId: prefixSessionId,
+					runtime.turnIndex,
+					prefixSessionId,
 					sessionRole,
-					turnIndex: runtime.turnIndex,
-					injectionEnabled: effectiveInjectionEnabled,
-					injectionSlices,
-					placement,
 					dbg,
-				});
-			};
-			try {
-				const cwd = ctx.cwd ?? process.cwd();
-
-				if (!effectiveInjectionEnabled) {
-					logContextObservation(existingMessages, "none", []);
-					return;
-				}
-
-				const turnEndFindings = consumeTurnEndFindings(cacheManager, cwd, runtime);
-				const sessionGuidance = consumeSessionStartGuidance(cacheManager, cwd);
-				const testFindings = consumeTestFindings(cacheManager, cwd, runtime);
-				const agentNudge = consumeAgentNudge(dbg);
-				const sourceMessages = [
-					{
-						source: "session-guidance" as const,
-						messages: sessionGuidance?.messages ?? [],
-					},
-					{
-						source: "turn-findings" as const,
-						messages: turnEndFindings?.messages ?? [],
-					},
-					{
-						source: "test-findings" as const,
-						messages: testFindings?.messages ?? [],
-					},
-					{
-						source: "agent-nudge" as const,
-						messages: agentNudge?.messages ?? [],
-					},
-				].filter((source) => source.messages.length > 0);
-				const injectedMessages = sourceMessages.flatMap(
-					(source) => source.messages,
 				);
-				if (injectedMessages.length === 0) {
-					logContextObservation(existingMessages, "none", []);
-					return;
-				}
+				const effectiveInjectionEnabled = lensEnabled && contextInjectionEnabled;
+				let telemetryLogged = false;
+				const logContextObservation = (
+					resultMessages: Array<{ role: string; content: unknown }>,
+					placement: "prepend" | "insert-before-final" | "append" | "none",
+					// #1071: the per-source slices ARE the telemetry input. The source
+					// name list and the flat message list are both derived from them
+					// inside observeCacheContext, so this call site cannot report a
+					// source that contributed nothing.
+					injectionSlices: ReadonlyArray<CacheContextInjectionSlice>,
+				) => {
+					if (telemetryLogged) return;
+					telemetryLogged = true;
+					observeCacheContext({
+						existingMessages,
+						resultMessages,
+						sessionId: prefixSessionId,
+						sessionRole,
+						turnIndex: runtime.turnIndex,
+						injectionEnabled: effectiveInjectionEnabled,
+						injectionSlices,
+						placement,
+						dbg,
+					});
+				};
+				try {
+					const cwd = ctx.cwd ?? process.cwd();
 
-				// Empty transcript (no turns yet): fall back to prepend semantics —
-				// there is no trailing user message to sit before, and we must never
-				// emit empty input (fe0ed5da: OpenAI Responses fails on empty input).
-				if (existingMessages.length === 0) {
-					const resultMessages = [...injectedMessages];
+					if (!effectiveInjectionEnabled) {
+						logContextObservation(existingMessages, "none", []);
+						return;
+					}
+
+					const turnEndFindings = consumeTurnEndFindings(cacheManager, cwd, runtime);
+					const sessionGuidance = consumeSessionStartGuidance(cacheManager, cwd);
+					const testFindings = consumeTestFindings(cacheManager, cwd, runtime);
+					const agentNudge = consumeAgentNudge(dbg);
+					const sourceMessages = [
+						{
+							source: "session-guidance" as const,
+							messages: sessionGuidance?.messages ?? [],
+						},
+						{
+							source: "turn-findings" as const,
+							messages: turnEndFindings?.messages ?? [],
+						},
+						{
+							source: "test-findings" as const,
+							messages: testFindings?.messages ?? [],
+						},
+						{
+							source: "agent-nudge" as const,
+							messages: agentNudge?.messages ?? [],
+						},
+					].filter((source) => source.messages.length > 0);
+					const injectedMessages = sourceMessages.flatMap(
+						(source) => source.messages,
+					);
+					if (injectedMessages.length === 0) {
+						logContextObservation(existingMessages, "none", []);
+						return;
+					}
+
+					// Empty transcript (no turns yet): fall back to prepend semantics —
+					// there is no trailing user message to sit before, and we must never
+					// emit empty input (fe0ed5da: OpenAI Responses fails on empty input).
+					if (existingMessages.length === 0) {
+						const resultMessages = [...injectedMessages];
+						logContextObservation(
+							resultMessages,
+							"prepend",
+							sourceMessages,
+						);
+						return { messages: resultMessages };
+					}
+
+					const lastMessage = existingMessages[existingMessages.length - 1];
+
+					// Mid-loop the tail can be a tool_result (or assistant/tool) message;
+					// inserting before it would break tool_use↔tool_result adjacency. Only
+					// splice before the last message when it is a plain user prompt.
+					if (!isPlainUserPrompt(lastMessage)) {
+						// Append after the whole transcript — pure append preserves the
+						// adjacency AND leaves the entire prior transcript as an untouched
+						// cache prefix.
+						const resultMessages = [...existingMessages, ...injectedMessages];
+						logContextObservation(
+							resultMessages,
+							"append",
+							sourceMessages,
+						);
+						return { messages: resultMessages };
+					}
+
+					// Insert the injected block just before the final message so
+					// messages[0] stays stable and the real user prompt stays trailing.
+					const resultMessages = [
+						...existingMessages.slice(0, -1),
+						...injectedMessages,
+						lastMessage,
+					];
 					logContextObservation(
 						resultMessages,
-						"prepend",
+						"insert-before-final",
 						sourceMessages,
 					);
 					return { messages: resultMessages };
+				} catch (err) {
+					// The stale-ctx class has ONE classifier and one record, in
+					// clients/session-event-guard.ts. Rethrow BEFORE the fallback
+					// observation (#1929): a session that no longer exists must not
+					// leave a "no injection" cache-context row behind, and the
+					// wrapper's own record is the accurate one.
+					if (isStaleExtensionCtxError(err)) throw err;
+					if (!telemetryLogged)
+						logContextObservation(existingMessages, "none", []);
+					dbg(`context event error: ${err}`);
 				}
-
-				const lastMessage = existingMessages[existingMessages.length - 1];
-
-				// Mid-loop the tail can be a tool_result (or assistant/tool) message;
-				// inserting before it would break tool_use↔tool_result adjacency. Only
-				// splice before the last message when it is a plain user prompt.
-				if (!isPlainUserPrompt(lastMessage)) {
-					// Append after the whole transcript — pure append preserves the
-					// adjacency AND leaves the entire prior transcript as an untouched
-					// cache prefix.
-					const resultMessages = [...existingMessages, ...injectedMessages];
-					logContextObservation(
-						resultMessages,
-						"append",
-						sourceMessages,
-					);
-					return { messages: resultMessages };
-				}
-
-				// Insert the injected block just before the final message so
-				// messages[0] stays stable and the real user prompt stays trailing.
-				const resultMessages = [
-					...existingMessages.slice(0, -1),
-					...injectedMessages,
-					lastMessage,
-				];
-				logContextObservation(
-					resultMessages,
-					"insert-before-final",
-					sourceMessages,
-				);
-				return { messages: resultMessages };
-			} catch (err) {
-				if (!telemetryLogged)
-					logContextObservation(existingMessages, "none", []);
-				dbg(`context event error: ${err}`);
-			}
-		},
+			},
+			{
+				dbg,
+				// #1929: a dead ctx means pi-lens contributes NOTHING to this
+				// request. `undefined` is that answer, and is what the four
+				// non-injecting paths above already return, so the host keeps its
+				// own message list byte-for-byte. Never a half-built injection: the
+				// consume* calls that feed one have side effects and may not have run.
+				onStaleResult: () => undefined,
+			},
+		),
 	);
 }
 

--- a/tests/clients/session-event-guard-sweep.test.ts
+++ b/tests/clients/session-event-guard-sweep.test.ts
@@ -19,6 +19,10 @@
  * registers 12 handlers today. A regex that stops matching one of them, the
  * way the first draft missed the `on?.()` form, drops the count and reds here
  * instead of quietly excusing the handler it can no longer see.
+ *
+ * #1929 moved `session_start` and `context` out of the exemption table and into
+ * the wrapper, so seven registrations are wrapped and five carry a reason. The
+ * registration count is unchanged: neither handler was added or removed.
  */
 
 import * as fs from "node:fs";
@@ -51,14 +55,10 @@ const UNWRAPPED_HANDLER_REASONS: Readonly<Record<string, string>> = {
 		"Registered with no ctx parameter at all; it reads only pi-lens's own in-process state.",
 	tool_call:
 		"Delegates straight to handleToolCall, which already owns a total guard recording `tool-call-handler-throw` (clients/runtime-tool-call.ts); the registration body itself reads no ctx property.",
-	session_start:
-		"The ctx delivered here belongs to the session being announced, built moments earlier, so it cannot be one invalidated before delivery. The two calls that run BEFORE the handler's try (rememberOwnEventCtx, refreshCtxDerivedPlumbing, index.ts:1646-1647) read no ctx property: the first null-checks and stores the reference, the second only captures it in a closure.",
 	session_shutdown:
 		"Every ctx read is already inside a try/catch or behind noteSessionShutdown's probe, and skipping teardown on an inconclusive probe would leak the LSP fleet.",
 	message_end:
-		"The handler body is a total try/catch, and its only ctx readers are getStableSessionId (its own try/catch, index.ts:328) and classifyCurrentSessionEmission (probe-based, reads no ctx property). Nothing throws. The skip is unrecorded, which is the same observability gap as #1929.",
-	context:
-		"This handler must return the host's message list, so a wrapper short-circuiting to `undefined` would change what pi builds context from. Its two pre-try ctx readers (getStableSessionId and classifyCurrentSessionEmission, index.ts:2912-2913) are individually safe rather than covered by the try at :2947. The observability half is tracked in #1929.",
+		"The handler body is a total try/catch, and its only ctx readers are getStableSessionId (its own try/catch, index.ts:328) and classifyCurrentSessionEmission (probe-based, reads no ctx property). Nothing throws and nothing is skipped: a stale ctx degrades the cache_usage row to an unattributed sessionId instead. Wrapping it would DROP a row whose `message` payload is still valid, so the fix is a bounded attribution record, not a skip. Tracked in #1956.",
 };
 
 /** One `pi.on("<event>", ...)` registration found in index.ts. */
@@ -103,7 +103,14 @@ function scanRegistrations(): Registration[] {
 			event,
 			line: source.slice(0, match.index).split("\n").length,
 			// The wrapper must name the SAME event, or the ledger subject lies.
-			wrapped: args.includes(`wrapSessionEventHandler("${event}"`),
+			// Both entry points count (#1929): `wrapSessionEventHandlerWithResult`
+			// is the same policy with a stated stale-path value, for a handler
+			// whose return the host consumes. Matched with a regex rather than a
+			// substring because the formatter puts the event name on its own line
+			// once the call gets long enough.
+			wrapped: new RegExp(
+				`wrapSessionEventHandler(?:WithResult)?\\s*\\(\\s*"${event}"`,
+			).test(args),
 		});
 		match = opener.exec(source);
 	}
@@ -135,14 +142,14 @@ describe("session-event stale-ctx guard sweep (#1925)", () => {
 			scannedCount: registrations.length,
 			minScanned: 12,
 			remediation:
-				"Wrap it with wrapSessionEventHandler(<event>, handler, { dbg }) from clients/session-event-guard.ts, or add the event to UNWRAPPED_HANDLER_REASONS with the mechanism that makes a stale ctx unreachable for it.",
+				"Wrap it with wrapSessionEventHandler(<event>, handler, { dbg }) from clients/session-event-guard.ts — or wrapSessionEventHandlerWithResult(<event>, handler, { dbg, onStaleResult }) when the host consumes the handler's return value — or add the event to UNWRAPPED_HANDLER_REASONS with the mechanism that makes a stale ctx unreachable for it.",
 		});
 		expect(audit.problems).toEqual([]);
 	});
 
-	it("keeps the five known-reachable handlers wrapped", () => {
-		// The population #1925 fixed, pinned by name: an unwrap shows up here
-		// even if someone also adds a reason for it.
+	it("keeps the seven known-reachable handlers wrapped", () => {
+		// The population #1925 fixed plus the two #1929 added, pinned by name: an
+		// unwrap shows up here even if someone also adds a reason for it.
 		const wrapped = new Set(
 			registrations
 				.filter((entry) => entry.wrapped)
@@ -154,6 +161,8 @@ describe("session-event stale-ctx guard sweep (#1925)", () => {
 			"agent_end",
 			"turn_end",
 			"agent_settled",
+			"session_start",
+			"context",
 		]) {
 			expect(wrapped, `${event} lost its stale-ctx wrapper`).toContain(event);
 		}

--- a/tests/clients/session-event-guard.test.ts
+++ b/tests/clients/session-event-guard.test.ts
@@ -16,6 +16,7 @@ import {
 import {
 	isStaleExtensionCtxError,
 	wrapSessionEventHandler,
+	wrapSessionEventHandlerWithResult,
 } from "../../clients/session-event-guard.js";
 import { makeStaleCtx, STALE_CTX_MESSAGE } from "../support/pi-mock.js";
 
@@ -146,6 +147,108 @@ describe("wrapSessionEventHandler (#1925)", () => {
 
 		expect(() => guarded({} as never, makeStaleCtx() as never)).not.toThrow();
 		expect(staleGroup()?.count).toBe(1);
+	});
+});
+
+/**
+ * The value-returning variant (#1929).
+ *
+ * `context` must hand pi a message list on the live path, so it could not use
+ * the void wrapper: a skip resolving to `undefined` was a guess about what
+ * `undefined` means to the host, not a stated decision. This variant makes the
+ * stale-path value an explicit argument. These tests use a SENTINEL fallback,
+ * not `undefined`, so a wrapper that quietly hardcodes `undefined` again reds
+ * here rather than passing by coincidence.
+ */
+describe("wrapSessionEventHandlerWithResult (#1929)", () => {
+	const FALLBACK = { fallback: true } as const;
+
+	beforeEach(() => {
+		resetDegradationLedger();
+	});
+
+	function guard(handler: (event: unknown, ctx: unknown) => unknown) {
+		return wrapSessionEventHandlerWithResult<unknown, unknown, unknown>(
+			"context",
+			handler,
+			{ onStaleResult: () => FALLBACK },
+		);
+	}
+
+	it("returns the handler's own value on a live ctx and calls no fallback", () => {
+		const onStaleResult = vi.fn(() => ({ messages: ["fallback"] }));
+		const guarded = wrapSessionEventHandlerWithResult<
+			unknown,
+			unknown,
+			{ messages: string[] }
+		>("context", () => ({ messages: ["injected"] }), { onStaleResult });
+
+		expect(guarded({}, liveCtx())).toEqual({ messages: ["injected"] });
+		expect(onStaleResult).not.toHaveBeenCalled();
+		expect(staleGroup()).toBeUndefined();
+	});
+
+	it("returns the STATED fallback, not undefined, when the ctx probes stale", () => {
+		const handler = vi.fn();
+		const guarded = guard(handler);
+
+		expect(guarded({}, makeStaleCtx())).toBe(FALLBACK);
+		expect(handler).not.toHaveBeenCalled();
+		expect(staleGroup()?.latestReasons[0]?.reason).toContain("pre-dispatch");
+	});
+
+	it("returns the stated fallback for a stale throw racing in mid-handler", () => {
+		const guarded = guard(() => {
+			throw new Error(STALE_CTX_MESSAGE);
+		});
+
+		expect(guarded({}, liveCtx())).toBe(FALLBACK);
+		expect(staleGroup()?.latestReasons[0]?.reason).toContain("mid-handler");
+	});
+
+	it("resolves an async stale rejection to the stated fallback", async () => {
+		const guarded = guard(async () => {
+			throw new Error(STALE_CTX_MESSAGE);
+		});
+
+		await expect(guarded({}, liveCtx())).resolves.toBe(FALLBACK);
+		expect(staleGroup()?.latestReasons[0]?.reason).toContain("mid-handler");
+	});
+
+	it("gives the fallback the EVENT and never the ctx that just died", () => {
+		// The ctx is the thing that proved dead. Passing it to the fallback would
+		// put a throwing accessor inside the guard that exists to absorb it.
+		const onStaleResult = vi.fn(() => FALLBACK);
+		const guarded = wrapSessionEventHandlerWithResult<unknown, unknown, unknown>(
+			"context",
+			vi.fn(),
+			{ onStaleResult },
+		);
+		const event = { messages: [{ role: "user", content: "keep me" }] };
+
+		expect(guarded(event, makeStaleCtx())).toBe(FALLBACK);
+		expect(onStaleResult).toHaveBeenCalledTimes(1);
+		expect(onStaleResult).toHaveBeenCalledWith(event);
+	});
+
+	it("keeps a NON-stale failure loud and records nothing", async () => {
+		const syncGuarded = guard(() => {
+			throw new Error("boom");
+		});
+		const asyncGuarded = guard(async () => {
+			throw new Error("boom");
+		});
+
+		expect(() => syncGuarded({}, liveCtx())).toThrow("boom");
+		await expect(asyncGuarded({}, liveCtx())).rejects.toThrow("boom");
+		expect(staleGroup()).toBeUndefined();
+	});
+
+	it("records under its own event name, like the void wrapper", () => {
+		guard(vi.fn())({}, makeStaleCtx());
+
+		expect(staleGroup()?.count).toBe(1);
+		expect(staleGroup()?.latestReasons[0]?.subject).toBe("context");
 	});
 });
 

--- a/tests/index-wiring.test.ts
+++ b/tests/index-wiring.test.ts
@@ -935,6 +935,13 @@ describe("stale extension ctx tolerance in event handlers (#1925)", () => {
 		{ event: "agent_end", payload: { messages: [] } },
 		{ event: "turn_end", payload: {} },
 		{ event: "agent_settled", payload: {} },
+		// #1929: both of these already SURVIVED a stale ctx before the fix — each
+		// had a total try/catch — so the "resolves" half passes either way. The
+		// ledger half is the whole test. Without the wrapper the skip is logged as
+		// `session_start crashed: …` / `context event error: …` and counted
+		// nowhere, so `expectStaleSkipRecorded` is what reds on pre-fix code.
+		{ event: "session_start", payload: makeSessionStartEvent() },
+		{ event: "context", payload: { messages: [] } },
 	];
 
 	for (const { event, payload } of CASES) {
@@ -947,6 +954,74 @@ describe("stale extension ctx tolerance in event handlers (#1925)", () => {
 			).resolves.not.toThrow();
 
 			expectStaleSkipRecorded(event);
+		});
+	}
+
+	it("hands the host its own message list back when context gets a stale ctx (#1929)", async () => {
+		// `context` is the one wrapped handler whose return value the host
+		// consumes. The stale path must answer `undefined` — pi's "this extension
+		// contributed nothing" — so the host keeps the transcript it already had.
+		// Any other value (a partial injection, an echoed array) would change what
+		// pi builds the request from at the exact moment pi-lens knows least.
+		const pi = createPiMock();
+		extension(pi.asExtensionAPI());
+		const existing = [{ role: "user", content: "keep me" }];
+
+		const result = await pi.emit(
+			"context",
+			{ messages: existing },
+			makeStaleCtx(),
+		);
+
+		expect(result).toBeUndefined();
+		expect(existing).toEqual([{ role: "user", content: "keep me" }]);
+		expectStaleSkipRecorded("context");
+	});
+
+	/**
+	 * A ctx that PASSES the pre-dispatch probe and dies afterwards (#1929).
+	 *
+	 * `makeStaleCtx` is dead on arrival, so the wrapper's probe catches it and
+	 * the handler never runs. The other half of the race is a swap that lands
+	 * while the handler is already inside its own body. `session_start` and
+	 * `context` each wrap their body in a total catch, so without an explicit
+	 * rethrow that catch eats the stale throw and the wrapper never sees it.
+	 */
+	function makeCtxThatDiesMidHandler() {
+		const ctx = makeCtx({ sessionId: "dies-mid-handler" });
+		ctx.isIdle = () => true;
+		Object.defineProperty(ctx, "cwd", {
+			configurable: true,
+			get() {
+				throw new Error(
+					"This extension ctx is stale after session replacement or reload",
+				);
+			},
+		});
+		return ctx;
+	}
+
+	for (const { event, payload } of [
+		{ event: "session_start", payload: makeSessionStartEvent() },
+		{ event: "context", payload: { messages: [] } },
+	]) {
+		it(`hands a MID-handler stale throw to the wrapper from ${event} (#1929)`, async () => {
+			const pi = createPiMock();
+			extension(pi.asExtensionAPI());
+
+			await expect(
+				pi.emit(event, payload, makeCtxThatDiesMidHandler()),
+			).resolves.not.toThrow();
+
+			// Without the rethrow this passes the "resolves" half and records
+			// nothing: the handler's own catch logs `… crashed` / `… event error`
+			// and the class stays invisible.
+			expectStaleSkipRecorded(event);
+			expect(
+				getDegradationSummary().find(
+					(entry) => entry.kind === "extension-ctx-stale",
+				)?.latestReasons[0]?.reason,
+			).toContain("mid-handler");
 		});
 	}
 


### PR DESCRIPTION
## What changed

`session_start` and `context` now go through the shared stale-ctx guard. Seven of twelve `pi.on` registrations are wrapped, up from five.

Both handlers already survived a dead extension ctx. Each wrapped its ctx reads in a total catch, logged a line, and moved on. The line named the wrong cause: a session swap read as `session_start crashed: …` or `context event error: …`, indistinguishable from a real pi-lens handler bug. And the skip counted nothing, so a replacement that kept starving either handler left no aggregate trace.

Neither could join `wrapSessionEventHandler` as it stood. `context` hands the host back a message list, so a wrapper that assumed `undefined` on the stale path was guessing what `undefined` means to pi rather than stating a decision.

`clients/session-event-guard.ts` therefore grows a second entry point, `wrapSessionEventHandlerWithResult`, which takes the stale-path value as an argument. Both entry points delegate to one private function, so the probe point, the classifier, and the bounded record cannot drift apart between a void handler and a value-returning one.

Per-event stale-path answers, judged from what pi does with each return:

- `context` returns `undefined`. That is pi's "this extension contributed nothing", and it is what the handler's own four non-injecting paths already return, so the host keeps its message list untouched. The alternative, echoing the input array back, is a behavior this repo has never exercised. A partially built injection is worse still, because the `consume*` calls that feed one have side effects that may not have run.
- `session_start` returns nothing on any path, so it uses the void wrapper. No new machinery for a handler that does not need it.

Two more changes fall out:

- **Mid-handler rethrow.** Each handler's total catch now rethrows a stale error, matching `index.ts:2345` (`agent_end`) and `index.ts:2564` (`turn_end`). Without it the catch eats a swap that lands while the handler is already running, and the wrapper never sees it. `context` rethrows before its fallback `logContextObservation` call, so a dead session does not leave a phantom "no injection" cache-context row.
- **Sweep detection.** `tests/clients/session-event-guard-sweep.test.ts` now accepts both entry points, and matches with a regex instead of a substring, because the formatter puts the event name on its own line once the call gets long enough.

`message_end`'s exemption reason no longer points at #1929. Its stale-ctx behavior is an unrecorded attribution degrade, not a skip, and wrapping it would drop a `cache_usage` row whose payload is still valid. Re-homed to #1956.

README's Architecture section and diagram change in the same PR, per the #1952 tripwire: the `session_start, raw` edge becomes a wrapper edge, the wrapper node lists seven events, and the prose no longer claims `session_start` registers raw.

## Verification

Red-first, on pre-fix source. Patch, checkout, apply. No stash.

- `tests/index-wiring.test.ts` — 3 failed, 6 passed. Both new `CASES` entries and the `context` return-value test failed on `… skipped a stale ctx without recording it in the degradation ledger: expected undefined to be defined`. The "resolves" half passed either way, which is the point: these handlers never crashed, they just counted nothing.
- `tests/clients/session-event-guard.test.ts` — 7 failed, 9 passed. `wrapSessionEventHandlerWithResult is not a function`.

Mutation proofs, each run on the built tree with one guard neutered:

| Mutation | Reds |
| --- | --- |
| M1: `skip()` returns `undefined` instead of `onStaleResult(event)` | 4, all the `WithResult` fallback tests |
| M2: `recordStaleSkip` call deleted | 14, every ledger assertion across both wrappers, unit and wiring |
| M3: pre-dispatch probe deleted | 5, six unit reds; the new wiring cases stay green because the handlers' own rethrows route a dead-on-arrival ctx through mid-handler classification (verify round evidence) |
| M4: sweep detection back to the substring form | 2, `session_start` and `context` read as unwrapped |
| M5: both new rethrows deleted | 2, the mid-handler cases |

M3 is the load-bearing one for this issue. `session_start` and `context` each own a total catch, so mid-handler classification alone cannot see their stale throws. The pre-dispatch probe is what makes them observable at all. M5 covers the other half of the race.

Green after the fix:

- `session-event-guard`, `session-event-guard-sweep`, `bounded-telemetry-sweep`, `session-state-conformance`, `index-wiring`, `index-integration`, `session-lifecycle` — 7 files, 214 tests.
- 14 sibling files that emit `session_start`: agent-nudge, dispatch/lazy-liveness, extension-log, formatters-lazy-liveness, lsp-lazy-liveness, lsp/teardown-logging, runtime-session, session-lifecycle, word-index-logger, index-project-trust-wiring, index-vanished-instance-wiring, scripts/compat-contracts, support/host-event-shape-scan, support/pi-mock — 160 tests.
- After merging `origin/master` (which brought #1949): the six governance and targeted files plus `demoted-blocker-render-retirement` — 7 files, 186 tests.
- `tsc --project tsconfig.json` clean. `node scripts/check-changelog-fragments.mjs` clean.

The full suite is CI's job and has not run locally.

One flake seen and dismissed with evidence: `session-lifecycle.test.ts > with PI_LENS_CONCURRENT_SESSION_GUARD=0 …` hit the 5s timeout on the first 14-file batch run. It passes alone, 43 tests in 1.87s, and passed on an identical rerun of the same batch. The failure was a timeout under machine contention, not an assertion.

## Class sweep

**Pattern sweep** over `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts`, not `clients/` alone. Grepped `isStaleExtensionCtxError`, `stale after session replacement`, and the generic catch-and-log shape. Every hit is accounted for below.

**Population sweep.** The family is the twelve `pi.on` registrations in `index.ts`, enumerated by the sweep test rather than by hand:

| Registration | Verdict |
| --- | --- |
| `tool_result`, `turn_start`, `agent_end`, `turn_end`, `agent_settled` | already wrapped (#1925) |
| `session_start` | fixed here: wrapped, plus the rethrow at `index.ts:2060` |
| `context` | fixed here: wrapped with a stated fallback, plus the rethrow at `index.ts:3075` |
| `resources_discover` | exempt, reads no ctx |
| `session_before_fork` | exempt, no ctx parameter |
| `tool_call` | exempt, `handleToolCall` owns a total guard recording `tool-call-handler-throw` |
| `session_shutdown` | exempt, skipping teardown on an inconclusive probe would leak the LSP fleet |
| `message_end` | exempt, degrades rather than skips, filed as #1956 |

Second family checked and cleared: the nine `pi.registerCommand` handlers. A command runs on the ctx the user is typing into, so it cannot be invoked with a ctx that was already invalidated. Not reachable by this defect.

Two sibling sites found, deliberately left, and recorded on #1956 with file and line: the `turn_summary_emit` quiet-window task at `index.ts:2670-2678` and `index.ts:2697-2702`, and `runPipeline`'s catch at `clients/runtime-tool-result.ts:979-983`. The first is a detached task the handler wrapper structurally cannot own. The second runs recovery work a skip would lose, so it needs its own decision rather than a copy of the handler pattern.

## Observability

`clients/degradation-ledger.ts`, kind `extension-ctx-stale`, subject `session_start` or `context`. The bounded record is `session_event_stale_ctx_skip` in `~/.pi-lens/latency.log`, carrying `metadata.event` and `metadata.detectedAt`, which is either `pre-dispatch` or `mid-handler`. `/lens-health` surfaces the ledger group. Bounding is rising-edge per identity, so a replaced session draining a hundred queued events writes one detailed row per event name and an exact count.

## Blast radius

- `wrapSessionEventHandler`'s public signature and behavior are unchanged. Its body moved into the shared `guardSessionEvent`. The five existing call sites are untouched and their tests pass.
- `session_start` gains a pre-dispatch skip that did not exist. On a confirmed-stale ctx the handler no longer runs at all, so `rememberOwnEventCtx` no longer stores a dead ctx as pi-lens's own, and the warms and per-session resets are skipped for that event. That is the correct trade. The probe answers `false` only on the SDK's own stale message, and the replacement session fires its own live `session_start` which re-runs all of it. On a live ctx the probe answers `true` and nothing changes.
- `context` gains the same pre-dispatch skip. On the stale path it now emits no cache-context observation, where before it emitted a `"none"` row attributed to a session that no longer exists.
- Hot-path cost: one `probeCtxActive` call per `session_start` and per `context` event. That is a single `ctx.isIdle()` call inside a try. `context` fires once per provider request, `session_start` once per session. No new spawns, no I/O, no allocation beyond the closure.
- Callers of the changed handlers: none. Both are registered directly with `pi.on` and called only by the host.
- The re-indentation of both handler bodies is mechanical. `git diff -w` shows only the substantive lines.

## Composition with open PRs

- **#1949** merged into master while this branch was in flight. Merged in and re-verified: `tsc` clean, and `tests/clients/demoted-blocker-render-retirement.test.ts` passes on the merged tree along with the governance suites. Its only touch on shared ground was additive, one new `DegradationKind` union member.
- **#1922** touches `docs/servercapabilities.md` only. No overlap.

Closes #1929.

