### PR TITLE
fix(dispatch): eslint runner discards warning-severity findings (closes #1954)

### DIFF
--- a/.changelog/fix-1954-eslint-warning-severity.md
+++ b/.changelog/fix-1954-eslint-warning-severity.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **ESLint warnings are no longer discarded (closes #1954)** — The eslint runner treated every exit 0 as "nothing found". ESLint exits 0 whenever no rule reaches error severity, so a run that produced only warning-severity findings was thrown away silently. The runner now parses stdout unconditionally and surfaces the findings; a clean file still reports clean, and exit 2 stays an unavailable skip.

--- a/clients/dispatch/runners/eslint.ts
+++ b/clients/dispatch/runners/eslint.ts
@@ -138,15 +138,23 @@ const eslintRunner: RunnerDefinition = {
 			{ timeout: 30000, cwd },
 		);
 
-		// ESLint exits 1 when there are lint errors, 2 on fatal/config error
+		// ESLint exits 2 on fatal/config errors — nothing was linted, so this
+		// is an unavailable run, not a clean or failed one.
 		if (result.status === 2) {
 			return { status: "skipped", diagnostics: [], semantic: "none" };
 		}
 
-		const raw = result.stdout || result.stderr || "";
-
-		if (result.status === 0) {
-			return { status: "succeeded", diagnostics: [], semantic: "none" };
+		// ESLint exits 0 whenever nothing reached ERROR severity — that
+		// includes a run that found only warnings (#1954), which also prints a
+		// full JSON report. So parse stdout unconditionally and branch on the
+		// parsed diagnostic count instead of letting the exit code discard the
+		// warning case. Stderr is only a fallback for a failing run whose
+		// stdout went missing; parsing stderr noise on a healthy exit-0 run
+		// would turn deprecation chatter into spurious parse-error findings.
+		const stdout = result.stdout ?? "";
+		let raw = stdout;
+		if (raw.length === 0 && result.status !== 0) {
+			raw = result.stderr || "";
 		}
 
 		const parsed = parseEslintJson(raw, ctx.filePath);
@@ -179,8 +187,16 @@ const eslintRunner: RunnerDefinition = {
 		}
 
 		const hasErrors = diagnostics.some((d) => d.semantic === "blocking");
+		// A warning-only result on exit 0 is ESLint's normal outcome, not a
+		// failure: exit 0 means nothing hit ERROR severity. Keying status off
+		// blocking severity plus exit code (the sibling convention from oxlint,
+		// biome-check, golangci-lint, rubocop) keeps plan.ts's fallback group
+		// ["eslint", "oxlint", "biome-check-json"] stopping at eslint instead
+		// of re-running oxlint and biome-check-json on every warning-only save.
+		// The findings reach delivery regardless of status — dispatcher.ts
+		// buckets by each diagnostic's own `semantic`.
 		return {
-			status: "failed",
+			status: !hasErrors && result.status === 0 ? "succeeded" : "failed",
 			diagnostics,
 			semantic: hasErrors ? "blocking" : "warning",
 		};

--- a/scripts/capture-runner-fixtures.mjs
+++ b/scripts/capture-runner-fixtures.mjs
@@ -92,6 +92,18 @@ export const CAPTURES = [
 		argv: ["--format", "json", "bad.js"],
 	},
 	{
+		// #1954 — ESLint also exits 0 when every finding is warning severity
+		// (--max-warnings unset). No rule in modern @eslint/js recommended
+		// ships at "warn" anymore, so js-eslint-warning's config downgrades
+		// no-unused-vars explicitly — still the exit-0-with-findings shape.
+		runner: "eslint",
+		case: "warning-exit-zero",
+		tool: "eslint",
+		workspace: smoke("js-eslint-warning"),
+		file: "bad.js",
+		argv: ["--format", "json", "--no-error-on-unmatched-pattern", "bad.js"],
+	},
+	{
 		runner: "php-lint",
 		tool: "php",
 		workspace: smoke("php"),

--- a/tests/clients/dispatch/runners/captured-real-output.test.ts
+++ b/tests/clients/dispatch/runners/captured-real-output.test.ts
@@ -50,6 +50,7 @@ vi.mock("../../../../clients/tool-policy.js", async (importOriginal) => ({
 	...(await importOriginal<Record<string, unknown>>()),
 	getLinterPolicyForCwd,
 	markdownlintConfigArgs: () => [],
+	hasEslintConfig: () => true,
 	hasMypyConfig: () => true,
 	hasPhpstanConfig: () => true,
 	// Left real: sqlfluff's config presence CHANGES its argv (an unconfigured
@@ -96,6 +97,7 @@ vi.mock(
  */
 const RUNNER_DESCRIPTORS: Record<string, { module: string; kind: string }> = {
 	actionlint: { module: "actionlint", kind: "yaml" },
+	eslint: { module: "eslint", kind: "jsts" },
 	"biome-check-json": { module: "biome-check", kind: "jsts" },
 	hadolint: { module: "hadolint", kind: "docker" },
 	markdownlint: { module: "markdownlint", kind: "markdown" },

--- a/tests/clients/dispatch/runners/eslint.test.ts
+++ b/tests/clients/dispatch/runners/eslint.test.ts
@@ -1,0 +1,278 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunnerGroup } from "../../../../clients/dispatch/types.js";
+import { makeRunnerCtx } from "../../../support/runner-ctx.js";
+import { setupTestEnvironment } from "../../test-utils.js";
+
+const safeSpawnAsync = vi.fn();
+
+vi.mock(
+	"../../../../clients/safe-spawn.js",
+	async (importOriginal) => ({
+		...(await importOriginal<Record<string, unknown>>()),
+		safeSpawnAsync,
+	}),
+);
+
+// The eslint runner resolves its binary and probes availability through
+// runner-helpers; both are environment, not behavior under test (#448). The
+// probe stub answers available so every case reaches the spawn seam.
+vi.mock("../../../../clients/dispatch/runners/utils/runner-helpers.js", () => ({
+	resolveToolCommand: vi.fn(() => "eslint"),
+	createCwdCachedProbe: vi.fn(() => {
+		const probe = async () => true;
+		(probe as unknown as Record<string, unknown>).getVerdict = () => ({
+			outcome: "available",
+			classification: "probe-success",
+		});
+		(probe as unknown as Record<string, unknown>).reset = () => {};
+		return probe;
+	}),
+}));
+
+// hasEslintConfig walks the real filesystem for config files; the tests plant
+// their own workspaces without one. Force the gate open — config discovery is
+// not what this suite tests.
+vi.mock("../../../../clients/tool-policy.js", async (importOriginal) => ({
+	...(await importOriginal<Record<string, unknown>>()),
+	hasEslintConfig: vi.fn(() => true),
+}));
+
+function createCtx(filePath: string, cwd: string) {
+	return makeRunnerCtx(filePath, cwd);
+}
+
+describe("eslint runner", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		safeSpawnAsync.mockReset();
+	});
+
+	it("reports exit-0 warning findings instead of discarding them (#1954)", async () => {
+		const env = setupTestEnvironment("pi-lens-eslint-warning-exit-zero-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const unused = 1;\n");
+
+			// ESLint exits 0 whenever no rule reaches ERROR severity
+			// (--max-warnings unset), so a warnings-only report arrives at
+			// exit 0 with a full JSON payload on stdout.
+			safeSpawnAsync.mockResolvedValue({
+				error: null,
+				status: 0,
+				stdout: JSON.stringify([
+					{
+						filePath,
+						messages: [
+							{
+								ruleId: "no-unused-vars",
+								severity: 1,
+								message: "'unused' is assigned a value but never used.",
+								line: 1,
+								column: 7,
+								fix: { range: [0, 17], text: "" },
+							},
+						],
+						errorCount: 0,
+						warningCount: 1,
+					},
+				]),
+				stderr: "",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/eslint.js")
+			).default;
+			const result = await runner.run(createCtx(filePath, env.tmpDir) as never);
+
+			expect(result.diagnostics).toHaveLength(1);
+			expect(result.semantic).toBe("warning");
+			expect(result.status).toBe("succeeded");
+			expect(result.diagnostics[0]).toMatchObject({
+				tool: "eslint",
+				rule: "no-unused-vars",
+				severity: "warning",
+				semantic: "warning",
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("a warning-only exit-0 run still stops plan.ts's jsts fallback group at eslint (#1954)", async () => {
+		const env = setupTestEnvironment("pi-lens-eslint-fallback-stop-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const unused = 1;\n");
+
+			safeSpawnAsync.mockResolvedValue({
+				error: null,
+				status: 0,
+				stdout: JSON.stringify([
+					{
+						filePath,
+						messages: [
+							{
+								ruleId: "no-unused-vars",
+								severity: 1,
+								message: "'unused' is assigned a value but never used.",
+								line: 1,
+								column: 7,
+							},
+						],
+						errorCount: 0,
+						warningCount: 1,
+					},
+				]),
+				stderr: "",
+			});
+
+			const eslintRunner = (
+				await import("../../../../clients/dispatch/runners/eslint.js")
+			).default;
+			const { dispatchForFile, RunnerRegistry } = await import(
+				"../../../../clients/dispatch/dispatcher.js"
+			);
+
+			// plan.ts's real jsts lint group is a fallback chain:
+			// ["eslint", "oxlint", "biome-check-json"]. A warning-only exit-0
+			// result must keep status "succeeded" (keyed off blocking severity +
+			// exit code, the sibling convention from #1947's review) so the chain
+			// still stops at eslint — otherwise oxlint and biome-check-json would
+			// re-run on the same file: extra spawns, a possible install,
+			// duplicate findings.
+			let downstreamRuns = 0;
+			const registry = new RunnerRegistry();
+			registry.register({ ...eslintRunner, priority: 1 });
+			for (const id of ["oxlint", "biome-check-json"]) {
+				registry.register({
+					id,
+					appliesTo: ["jsts"],
+					priority: id === "oxlint" ? 2 : 3,
+					enabledByDefault: true,
+					async run() {
+						downstreamRuns++;
+						return { status: "succeeded", diagnostics: [], semantic: "none" };
+					},
+				});
+			}
+
+			const groups: RunnerGroup[] = [
+				{
+					mode: "fallback",
+					runnerIds: ["eslint", "oxlint", "biome-check-json"],
+				},
+			];
+			const result = await dispatchForFile(
+				createCtx(filePath, env.tmpDir) as never,
+				groups,
+				registry,
+			);
+
+			expect(downstreamRuns).toBe(0);
+			expect(result.warnings.some((w) => w.tool === "eslint")).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("keeps reporting exit-1 error findings as blocking", async () => {
+		const env = setupTestEnvironment("pi-lens-eslint-error-exit-one-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "debugger;\n");
+
+			safeSpawnAsync.mockResolvedValue({
+				error: null,
+				status: 1,
+				stdout: JSON.stringify([
+					{
+						filePath,
+						messages: [
+							{
+								ruleId: "no-debugger",
+								severity: 2,
+								message: "Unexpected 'debugger' statement.",
+								line: 1,
+								column: 1,
+							},
+						],
+						errorCount: 1,
+						warningCount: 0,
+					},
+				]),
+				stderr: "",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/eslint.js")
+			).default;
+			const result = await runner.run(createCtx(filePath, env.tmpDir) as never);
+
+			expect(result.status).toBe("failed");
+			expect(result.semantic).toBe("blocking");
+			expect(result.diagnostics[0]).toMatchObject({
+				tool: "eslint",
+				rule: "no-debugger",
+				severity: "error",
+				semantic: "blocking",
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("reports a clean exit-0 run as succeeded with no findings", async () => {
+		const env = setupTestEnvironment("pi-lens-eslint-clean-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "export const ok = 1;\n");
+
+			safeSpawnAsync.mockResolvedValue({
+				error: null,
+				status: 0,
+				stdout: JSON.stringify([
+					{ filePath, messages: [], errorCount: 0, warningCount: 0 },
+				]),
+				stderr: "",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/eslint.js")
+			).default;
+			const result = await runner.run(createCtx(filePath, env.tmpDir) as never);
+
+			expect(result.status).toBe("succeeded");
+			expect(result.semantic).toBe("none");
+			expect(result.diagnostics).toHaveLength(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("skips on exit 2 (fatal/config error) rather than misreporting findings", async () => {
+		const env = setupTestEnvironment("pi-lens-eslint-fatal-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+
+			safeSpawnAsync.mockResolvedValue({
+				error: null,
+				status: 2,
+				stdout: "",
+				stderr: "ESLint configuration error.",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/eslint.js")
+			).default;
+			const result = await runner.run(createCtx(filePath, env.tmpDir) as never);
+
+			expect(result.status).toBe("skipped");
+			expect(result.diagnostics).toHaveLength(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+});

--- a/tests/clients/dispatch/runners/eslint.test.ts
+++ b/tests/clients/dispatch/runners/eslint.test.ts
@@ -7,13 +7,10 @@ import { setupTestEnvironment } from "../../test-utils.js";
 
 const safeSpawnAsync = vi.fn();
 
-vi.mock(
-	"../../../../clients/safe-spawn.js",
-	async (importOriginal) => ({
-		...(await importOriginal<Record<string, unknown>>()),
-		safeSpawnAsync,
-	}),
-);
+vi.mock("../../../../clients/safe-spawn.js", async (importOriginal) => ({
+	...(await importOriginal<Record<string, unknown>>()),
+	safeSpawnAsync,
+}));
 
 // The eslint runner resolves its binary and probes availability through
 // runner-helpers; both are environment, not behavior under test (#448). The
@@ -131,9 +128,8 @@ describe("eslint runner", () => {
 			const eslintRunner = (
 				await import("../../../../clients/dispatch/runners/eslint.js")
 			).default;
-			const { dispatchForFile, RunnerRegistry } = await import(
-				"../../../../clients/dispatch/dispatcher.js"
-			);
+			const { dispatchForFile, RunnerRegistry } =
+				await import("../../../../clients/dispatch/dispatcher.js");
 
 			// plan.ts's real jsts lint group is a fallback chain:
 			// ["eslint", "oxlint", "biome-check-json"]. A warning-only exit-0

--- a/tests/clients/dispatch/runners/eslint.test.ts
+++ b/tests/clients/dispatch/runners/eslint.test.ts
@@ -219,6 +219,37 @@ describe("eslint runner", () => {
 		}
 	});
 
+	it("does not parse stderr noise on a healthy exit-0 run (#1954 review P3)", async () => {
+		const env = setupTestEnvironment("pi-lens-eslint-stderr-gating-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "export const ok = 1;\n");
+
+			// Exit 0 with empty stdout and deprecation-style chatter on stderr.
+			// The old `stdout || stderr` fallback would feed that prose to the
+			// JSON parser and fabricate a parse-error finding on a clean save;
+			// stderr only feeds the parser when a FAILING run's stdout went
+			// missing. Pins clients/dispatch/runners/eslint.ts:157-160.
+			safeSpawnAsync.mockResolvedValue({
+				error: null,
+				status: 0,
+				stdout: "",
+				stderr: "Warning: You are using an unsupported version of Node.js\n",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/eslint.js")
+			).default;
+			const result = await runner.run(createCtx(filePath, env.tmpDir) as never);
+
+			expect(result.status).toBe("succeeded");
+			expect(result.semantic).toBe("none");
+			expect(result.diagnostics).toHaveLength(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("reports a clean exit-0 run as succeeded with no findings", async () => {
 		const env = setupTestEnvironment("pi-lens-eslint-clean-");
 		try {

--- a/tests/clients/dispatch/smoke-fixture-coverage.test.ts
+++ b/tests/clients/dispatch/smoke-fixture-coverage.test.ts
@@ -86,10 +86,6 @@ const EXEMPT = new Map<string, string>([
 		"structural: in-process napi engine; real-engine coverage via ast-grep-rule-tests plus the sonar and utils-block suites",
 	],
 	[
-		"eslint",
-		"alternate: oxlint is the JS/TS lint primary; eslint runs only with an eslint config and is exercised by the --autofix lane",
-	],
-	[
 		"credo",
 		"alternate: elixir-check is the Elixir primary; credo is the config-gated alternate",
 	],

--- a/tests/fixtures/runner-output/eslint/warning-exit-zero.captured.json
+++ b/tests/fixtures/runner-output/eslint/warning-exit-zero.captured.json
@@ -1,0 +1,21 @@
+{
+	"provenance": {
+		"runner": "eslint",
+		"tool": "eslint",
+		"version": "10.9.0",
+		"command": "eslint --format json --no-error-on-unmatched-pattern bad.js",
+		"argv": [
+			"--format",
+			"json",
+			"--no-error-on-unmatched-pattern",
+			"bad.js"
+		],
+		"workspace": "tests/fixtures/tool-smoke/js-eslint-warning",
+		"platform": "win32-x64",
+		"capturedAt": "2026-08-22"
+	},
+	"file": "bad.js",
+	"exitCode": 0,
+	"stdout": "[{\"filePath\":\"__WORKSPACE__\\\\bad.js\",\"messages\":[{\"ruleId\":\"no-unused-vars\",\"severity\":1,\"message\":\"'unused' is assigned a value but never used.\",\"line\":5,\"column\":8,\"messageId\":\"unusedVar\",\"endLine\":5,\"endColumn\":14,\"suggestions\":[{\"messageId\":\"removeVar\",\"data\":{\"varName\":\"unused\"},\"fix\":{\"range\":[205,222],\"text\":\"\"},\"desc\":\"Remove unused variable 'unused'.\"}]}],\"suppressedMessages\":[],\"errorCount\":0,\"fatalErrorCount\":0,\"warningCount\":1,\"fixableErrorCount\":0,\"fixableWarningCount\":0,\"source\":\"// Tool-smoke fixture (#1954) — eslint.config.cjs downgrades no-unused-vars\\n// to \\\"warn\\\", so a real run reports one severity-1 finding and exits 0\\n// (--max-warnings is not set).\\nexport function demo() {\\n\\tconst unused = 1;\\n\\treturn 2;\\n}\\n\",\"usedDeprecatedRules\":[]}]\n",
+	"stderr": ""
+}

--- a/tests/fixtures/tool-smoke/js-eslint-warning/bad.js
+++ b/tests/fixtures/tool-smoke/js-eslint-warning/bad.js
@@ -1,0 +1,7 @@
+// Tool-smoke fixture (#1954) — eslint.config.cjs downgrades no-unused-vars
+// to "warn", so a real run reports one severity-1 finding and exits 0
+// (--max-warnings is not set).
+export function demo() {
+	const unused = 1;
+	return 2;
+}

--- a/tests/fixtures/tool-smoke/js-eslint-warning/eslint.config.cjs
+++ b/tests/fixtures/tool-smoke/js-eslint-warning/eslint.config.cjs
@@ -1,0 +1,11 @@
+// Tool-smoke fixture config (#1954). Modern @eslint/js recommended ships
+// every rule at "error" (no rule defaults to "warn" anymore), so the
+// realistic exit-0-with-findings shape is a project config that downgrades
+// a rule to "warn" — what this file does. languageOptions keeps the ESM
+// sample parseable instead of exiting 2 on a config/parse error.
+module.exports = [
+	{
+		languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+		rules: { "no-unused-vars": "warn" },
+	},
+];


### PR DESCRIPTION
Closes #1954, the named residual of #1947's class sweep.

## What changed

`clients/dispatch/runners/eslint.ts` treated every exit 0 as "nothing found". ESLint exits 0 whenever no rule reaches error severity (`--max-warnings` unset), so a warnings-only run — full JSON report on stdout — was discarded silently.

The runner now parses stdout unconditionally and branches on the parsed diagnostic count, mirroring #1947's oxlint fix:

- **Zero diagnostics** → clean `succeeded`/`none`, unchanged.
- **Error-severity diagnostic** → `failed`/`blocking`, unchanged from the old exit-1 path.
- **Warning-only on exit 0** → `succeeded` with the findings riding along. Status keys off blocking severity plus exit code (#1955 review round 1), so plan.ts's fallback group `["eslint", "oxlint", "biome-check-json"]` still stops at eslint instead of re-running oxlint and biome-check-json on every warning-only save.
- **Exit 2** stays an unavailable skip.
- stderr only feeds the parser when a failing run's stdout went missing, so exit-0 stderr chatter cannot become spurious parse-error findings.

## Behavior decision (issue acceptance criterion 1)

Warnings surface. Expected volume change: JS/TS projects with an eslint config that sets any rule to `"warn"` start seeing advisory findings where saves previously read clean. Note: no rule in modern `@eslint/js` recommended ships at `"warn"` anymore (`no-unused-vars` is `"error"`), so the realistic warnings-only shape is a project downgrade — what the fixture config does.

## Evidence

- **Real-bytes fixture** (acceptance criterion 3): captured live from eslint 10.9.0 (exit 0, one severity-1 finding) into `tests/fixtures/runner-output/eslint/warning-exit-zero.captured.json`, replayed through `captured-real-output.test.ts`. Workspace fixture: `tests/fixtures/tool-smoke/js-eslint-warning/`.
- **Red-first**: both new regression cases fail against pre-fix code — diagnostics length 0 vs 1, and the eslint finding missing from the dispatch result.
- **Mutation proof**: reverting the runner fix reproduces both reds (2 failed | 3 passed).
- The smoke-fixture coverage guard flagged eslint's old exemption as redundant once captured bytes existed; the exemption is deleted.

## Blast radius

`module_report` on `eslint.ts`: single consumer seam (`run(ctx)` via the dispatch registry); no callbacks, no exported internals beyond the default runner definition. Affected dependents: plan.ts's jsts fallback group (covered by the new integration test), dispatcher bucketing (by-diagnostic semantic, unchanged), and the ratchet test's strangler entry (unchanged — the runner still reads its own exit status for exit-2 and succeeded/failed keying).

## Observability

Existing records prove the change: `latency.log` runner rows now carry nonzero `diagnosticCount` on warning-only saves, and findings reach `actionable-warnings.json` through the normal advisory routing. No new telemetry needed — this fixes a producer, not a decision.

Refs #1947, #1937