### PR TITLE
fix(dispatch): classify expected oxlint skips (closes #1998)

### DIFF
--- a/.changelog/fix-1998-oxlint-no-match-telemetry.md
+++ b/.changelog/fix-1998-oxlint-no-match-telemetry.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Classify oxlint no-match results as expected skips (closes #1998)**. Oxlint now carries `no-files-matched` through runner telemetry without emitting an extension error or claiming the file is clean. The skip requires Oxlint's genuine no-files envelope; zero-file JSON carrying errors or stderr retains normal parsed-failure telemetry.
+- **Classify oxlint no-match results as expected skips (closes #1998)**. Oxlint now carries `no-files-matched` through runner telemetry without emitting an extension error or claiming the file is clean. A single fail-closed state machine validates process completion, exit status, stderr, the captured banner, and every JSON summary field's type and range; truncated, malformed, wrong-status, or error-bearing lookalikes retain failure or unconfirmed telemetry.

--- a/.changelog/fix-1998-oxlint-no-match-telemetry.md
+++ b/.changelog/fix-1998-oxlint-no-match-telemetry.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Classify oxlint no-match results as expected skips (closes #1998)**. Oxlint now carries `no-files-matched` through runner telemetry without emitting an extension error or claiming the file is clean. The skip requires Oxlint's genuine no-files envelope; zero-file JSON carrying errors or stderr retains normal parsed-failure telemetry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1589,6 +1589,18 @@ non-light behavior in a detected subagent child, either vocabulary),
 
 ## Runner process model
 
+Expected runner skips must stay distinct from clean success and runner failure.
+Return a bounded machine-readable `skipReason` on `RunnerResult` and carry it
+through the existing runner latency record. Do not emit an extension error for
+an expected policy skip; reserve failure classification and degradation records
+for a tool that did not run or did not produce a usable result. Extend the
+closed `RUNNER_SKIP_REASONS` taxonomy when adding a new expected-skip reason;
+the dispatcher rejects unknown runtime values from latency metadata. Oxlint's
+`no-files-matched` reason requires its captured exit-1 banner plus an empty,
+known-field JSON summary and empty stderr; `number_of_files: 0` alone is not
+evidence of an expected skip, and rejected lookalikes retain shared
+parsed-nothing failure telemetry.
+
 - **Use `safeSpawnAsync()` for all subprocess work** in hook/dispatch/install paths. The sync `safeSpawn()` is deprecated, blocks the Node event loop, and is now reachable only from the cached `TestRunnerClient.detectRunner` `which pytest` probe. Don't add new sync `safeSpawn` callers.
 - **The hot per-edit path is the dispatch runners** (`clients/dispatch/runners/*`), not the legacy per-tool client classes (`biome-client`, `ruff-client`, `rust-client`, `ast-grep-client`, …). Those classes historically carried a *parallel sync surface* (`checkFile`/`fixFile`/`isAvailable`/`findCargoPath`/…) that the async runners superseded; #197 found almost all of it **dead** and deleted ~1600 lines. **Lesson: when you find a sync client method, grep its real callers before "converting" it — the answer is usually "delete," and the live path already has an `*Async` twin** (`fixFileAsync`, `ensureAvailable`, `runTestFileAsync`, `tempScanAsync`, `findGoPathAsync`).
 - **Ambient turn abort signal (#197):** `safeSpawnAsync` defaults its `AbortSignal` to a module-level ambient signal (`setAmbientAbortSignal` in `clients/safe-spawn.ts`). The lifecycle handlers (`tool_result`, `agent_end`, `turn_end`) publish pi's `ctx.signal` at entry and clear it in `finally`, so an Esc/interrupt kills in-flight linter/format/type-check children (process-tree kill on Windows) without threading a signal through every call site. The signal is captured at spawn time, so clearing it only affects future spawns. Pass `ignoreAmbientSignal: true` for **installs** (gem/go/dotnet/rustup) so they run to completion even if the turn is interrupted — matching the old uncancellable sync behaviour; an explicit `options.signal` always wins.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1596,10 +1596,17 @@ an expected policy skip; reserve failure classification and degradation records
 for a tool that did not run or did not produce a usable result. Extend the
 closed `RUNNER_SKIP_REASONS` taxonomy when adding a new expected-skip reason;
 the dispatcher rejects unknown runtime values from latency metadata. Oxlint's
-`no-files-matched` reason requires its captured exit-1 banner plus an empty,
-known-field JSON summary and empty stderr; `number_of_files: 0` alone is not
-evidence of an expected skip, and rejected lookalikes retain shared
-parsed-nothing failure telemetry.
+no-files classification is one fail-closed state machine: process-control
+evidence wins first (spawn/timeout/killed/signal use #1994's runner-empty lane;
+truncation is unconfirmed), and only a normal exit 1 with empty stderr, the
+exact captured banner, and exactly the captured JSON fields may produce
+`no-files-matched`. Every field is schema-checked (`diagnostics` array;
+nonnegative integer file/rule counts; positive integer threads; finite
+nonnegative start time), diagnostics must be empty, and the file count must be
+zero. A no-files lookalike on any other status/banner/stderr/JSON/schema/count
+combination is never clean: nonzero runs retain shared parsed-nothing telemetry,
+while status 0 becomes an explicit `unconfirmed_output` failure. Reports with no
+no-files evidence continue through the ordinary parser.
 
 - **Use `safeSpawnAsync()` for all subprocess work** in hook/dispatch/install paths. The sync `safeSpawn()` is deprecated, blocks the Node event loop, and is now reachable only from the cached `TestRunnerClient.detectRunner` `which pytest` probe. Don't add new sync `safeSpawn` callers.
 - **The hot per-edit path is the dispatch runners** (`clients/dispatch/runners/*`), not the legacy per-tool client classes (`biome-client`, `ruff-client`, `rust-client`, `ast-grep-client`, …). Those classes historically carried a *parallel sync surface* (`checkFile`/`fixFile`/`isAvailable`/`findCargoPath`/…) that the async runners superseded; #197 found almost all of it **dead** and deleted ~1600 lines. **Lesson: when you find a sync client method, grep its real callers before "converting" it — the answer is usually "delete," and the live path already has an `*Async` twin** (`fixFileAsync`, `ensureAvailable`, `runTestFileAsync`, `tempScanAsync`, `findGoPathAsync`).

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -44,6 +44,7 @@ import { getToolPlan } from "./plan.js";
 import { resolveRunnerPath } from "./runner-context.js";
 import { applyRulePolicy, rulePolicyMapFromConfig } from "./rule-policy.js";
 import { getToolProfile } from "./tool-profile.js";
+import { isRunnerSkipReason } from "./types.js";
 import type {
 	Diagnostic,
 	DispatchContext,
@@ -54,6 +55,7 @@ import type {
 	RunnerGroup,
 	RunnerRegistry as RunnerRegistryContract,
 	RunnerResult,
+	RunnerSkipReason,
 } from "./types.js";
 import { formatDiagnostics } from "./utils/format-utils.js";
 
@@ -493,6 +495,7 @@ export interface RunnerLatency {
 	status: "succeeded" | "failed" | "skipped" | "when_skipped";
 	diagnosticCount: number;
 	semantic: string;
+	skipReason?: RunnerSkipReason;
 	unconfirmedServerIds?: readonly string[];
 }
 
@@ -777,6 +780,13 @@ async function runGroup(
 		onRunnerResult?.(runnerId, result);
 		const runnerEnd = Date.now();
 		const duration = runnerEnd - runnerStart;
+		// Runner definitions are a typed API, but embedders/plugins can still
+		// return untyped objects at runtime. Admit only the closed taxonomy and
+		// only on actual skips so free text cannot enter durable latency metadata.
+		const skipReason =
+			result.status === "skipped" && isRunnerSkipReason(result.skipReason)
+				? result.skipReason
+				: undefined;
 
 		latencies.push({
 			runnerId,
@@ -786,6 +796,9 @@ async function runGroup(
 			status: result.status,
 			diagnosticCount: result.diagnostics.length,
 			semantic: result.semantic ?? semantic,
+			...(skipReason !== undefined && {
+				skipReason,
+			}),
 			...(result.unconfirmedServerIds !== undefined && {
 				unconfirmedServerIds: result.unconfirmedServerIds,
 			}),
@@ -814,7 +827,9 @@ async function runGroup(
 							failureKind: result.failureKind,
 							failureMessage: result.failureMessage,
 						}
-					: undefined,
+					: skipReason
+						? { skipReason }
+						: undefined,
 		});
 		recordRunner(
 			ctx.filePath,

--- a/clients/dispatch/runners/oxlint.ts
+++ b/clients/dispatch/runners/oxlint.ts
@@ -26,7 +26,18 @@ import {
 	resolveToolCommand,
 	resolveToolCommandWithInstallFallback,
 } from "./utils/runner-helpers.js";
-import { finishParsedRun } from "./utils/tool-failure.js";
+import { finishParsedRun, parseToolRun } from "./utils/tool-failure.js";
+
+const OXLINT_NO_FILES = Symbol("oxlint-no-files");
+const OXLINT_NO_FILES_BANNER =
+	"No files found to lint. Please check your paths and ignore patterns.";
+const OXLINT_NO_FILES_REPORT_KEYS = new Set([
+	"diagnostics",
+	"number_of_files",
+	"number_of_rules",
+	"threads_count",
+	"start_time",
+]);
 
 function resolveLocalVp(cwd: string): string | null {
 	const isWin = process.platform === "win32";
@@ -107,13 +118,32 @@ const oxlintRunner: RunnerDefinition = {
 		// unavailable.
 		const stdout = result.stdout ?? "";
 		const stderr = result.stderr ?? "";
-		let diagnostics = parseOxlintJson(stdout, ctx.filePath);
-		if (diagnostics.length === 0 && stdout.length > 0) {
-			diagnostics = parseOxlintUnix(stdout + stderr, ctx.filePath);
-		}
+		const parsedOutput = stdout + stderr;
+		// #1994's shared gate classifies invocation and parsed-output failures.
+		// The private marker lets its parser recognize oxlint's one legitimate
+		// nonzero/zero-diagnostic shape without recording a parsed-nothing
+		// degradation. It never escapes this runner. Because parseToolRun checks
+		// the process outcome before invoking the parser, a timed-out or killed
+		// process retaining partial no-files stdout still follows the failure path.
+		const parsedRun = parseToolRun<Diagnostic | typeof OXLINT_NO_FILES>(
+			"oxlint",
+			{ result, output: parsedOutput },
+			() => {
+				let parsed = parseOxlintJson(stdout, ctx.filePath);
+				if (parsed.length === 0 && stdout.length > 0) {
+					parsed = parseOxlintUnix(parsedOutput, ctx.filePath);
+				}
+				return parsed.length === 0 &&
+					isExpectedOxlintNoFiles(result.status, stdout, stderr)
+					? [OXLINT_NO_FILES]
+					: parsed;
+			},
+			{ parseOutput: parsedOutput },
+		);
+		if (parsedRun.skipped) return parsedRun.skipped;
 
-		if (diagnostics.length === 0) {
-			// Read BEFORE anything else — real captured bytes show oxlint exits
+		if (parsedRun.diagnostics.includes(OXLINT_NO_FILES)) {
+			// Real captured bytes show oxlint exits
 			// 1 with "No files found" + number_of_files: 0 when a config excludes
 			// the target, so "nonzero exit" alone cannot mean "unreadable report
 			// of problems" until the no-files shape is ruled out.
@@ -122,27 +152,16 @@ const oxlintRunner: RunnerDefinition = {
 			// file reports the same empty diagnostics array a clean file does.
 			// "succeeded"/"none" would say "we checked, it's clean"; this file
 			// was never checked at all.
-			if (parseOxlintFileCount(stdout) === 0) {
-				ctx.log(
-					"oxlint: 0 files matched (ignorePatterns/nested config excluded this file) — skipping, not reporting clean",
-				);
-				return { status: "skipped", diagnostics: [], semantic: "none" };
-			}
-			// Nonzero exit WITH output that parsed to nothing (and files WERE
-			// matched) is an unreadable report of problems, never clean (#1839).
-			if (
-				(result.status ?? 0) !== 0 &&
-				(stdout.length > 0 || stderr.length > 0)
-			) {
-				return finishParsedRun({
-					tool: "oxlint",
-					ctx,
-					result,
-					diagnostics,
-				});
-			}
-			return { status: "succeeded", diagnostics: [], semantic: "none" };
+			return {
+				status: "skipped",
+				diagnostics: [],
+				semantic: "none",
+				skipReason: "no-files-matched",
+			};
 		}
+		const diagnostics = parsedRun.diagnostics.filter(
+			(diagnostic): diagnostic is Diagnostic => diagnostic !== OXLINT_NO_FILES,
+		);
 
 		// A warning-only result on exit 0 is oxlint's normal outcome, not a
 		// failure: exit 0 means nothing hit ERROR severity. `status: "failed"`
@@ -191,34 +210,50 @@ interface OxlintJsonReport {
 }
 
 /**
- * `number_of_files: 0` is oxlint's own signal that its config (nested
- * discovery walks up from `ctx.filePath` and stops at the NEAREST
- * `.oxlintrc.json`/`ignorePatterns`, not necessarily the repo root's) excluded
- * this file entirely — "No files found to lint." That report has the SAME
- * empty `diagnostics` array a genuinely clean file produces, so without
- * reading this field, config-excluded and clean are indistinguishable (the
- * AGENTS.md empty-result invariant). Returns `undefined` when the field is
- * absent or the JSON did not parse — callers must not treat that as zero.
+ * Recognize only oxlint's captured expected no-files envelope. The numeric
+ * field alone is not a verdict: config errors can also serialize
+ * `number_of_files: 0`, and stderr accompanying an otherwise familiar stdout
+ * means the invocation did not produce the clean expected-policy outcome.
  *
  * Real oxlint 1.79.0 prints "No files found to lint. Please check your paths
- * and ignore patterns." to STDOUT BEFORE the JSON report in this exact case —
- * confirmed against a real capture (#1985 review round 2), not assumed. An
- * earlier version of this function trusted `stdout.trim().startsWith("{")`
- * and bailed on that banner line every time, so the guard this function
- * exists for never actually fired in production. Finding the first `{` and
- * parsing from there survives the banner; a raw string with no `{` at all
- * (a crash, a wholly different error format) still returns `undefined`.
+ * and ignore patterns." to stdout before a JSON summary, exits 1, emits an
+ * empty diagnostics array, and leaves stderr empty. Unknown JSON fields fail
+ * closed so an error/message payload cannot borrow the expected skip merely
+ * by also setting the file count to zero. Rejected lookalikes continue through
+ * `parseToolRun`, preserving #1994 parsed-nothing telemetry.
  */
-function parseOxlintFileCount(raw: string): number | undefined {
-	const jsonStart = raw.indexOf("{");
-	if (jsonStart === -1) return undefined;
+function isExpectedOxlintNoFiles(
+	status: number | null | undefined,
+	stdout: string,
+	stderr: string,
+): boolean {
+	if (status !== 1 || stderr.trim().length > 0) return false;
+	const jsonStart = stdout.indexOf("{");
+	if (jsonStart === -1) return false;
+	if (stdout.slice(0, jsonStart).trim() !== OXLINT_NO_FILES_BANNER)
+		return false;
 	try {
-		const parsed = JSON.parse(raw.slice(jsonStart)) as OxlintJsonReport;
-		return typeof parsed.number_of_files === "number"
-			? parsed.number_of_files
-			: undefined;
+		const parsed = JSON.parse(stdout.slice(jsonStart)) as unknown;
+		if (
+			typeof parsed !== "object" ||
+			parsed === null ||
+			Array.isArray(parsed)
+		) {
+			return false;
+		}
+		const report = parsed as Record<string, unknown>;
+		if (
+			Object.keys(report).some((key) => !OXLINT_NO_FILES_REPORT_KEYS.has(key))
+		) {
+			return false;
+		}
+		return (
+			report.number_of_files === 0 &&
+			Array.isArray(report.diagnostics) &&
+			report.diagnostics.length === 0
+		);
 	} catch {
-		return undefined;
+		return false;
 	}
 }
 

--- a/clients/dispatch/runners/oxlint.ts
+++ b/clients/dispatch/runners/oxlint.ts
@@ -29,6 +29,7 @@ import {
 import { finishParsedRun, parseToolRun } from "./utils/tool-failure.js";
 
 const OXLINT_NO_FILES = Symbol("oxlint-no-files");
+const OXLINT_NO_FILES_UNCONFIRMED = Symbol("oxlint-no-files-unconfirmed");
 const OXLINT_NO_FILES_BANNER =
 	"No files found to lint. Please check your paths and ignore patterns.";
 const OXLINT_NO_FILES_REPORT_KEYS = new Set([
@@ -38,6 +39,33 @@ const OXLINT_NO_FILES_REPORT_KEYS = new Set([
 	"threads_count",
 	"start_time",
 ]);
+
+type OxlintProcessState =
+	| "normal"
+	| "spawn"
+	| "timeout"
+	| "killed"
+	| "signal"
+	| "truncated";
+type OxlintNoFilesUnconfirmedReason =
+	| `process-${Exclude<OxlintProcessState, "normal">}`
+	| "status-zero"
+	| "status-null"
+	| "status-other"
+	| "stderr-nonempty"
+	| "banner-near"
+	| "banner-missing"
+	| "json-malformed"
+	| "json-unknown-key"
+	| "json-missing-key"
+	| "json-known-field-invalid"
+	| "diagnostics-nonempty"
+	| "files-nonzero";
+
+export type OxlintNoFilesDecision =
+	| { kind: "expected-no-files" }
+	| { kind: "ordinary-report" }
+	| { kind: "unconfirmed-no-files"; reason: OxlintNoFilesUnconfirmedReason };
 
 function resolveLocalVp(cwd: string): string | null {
 	const isWin = process.platform === "win32";
@@ -119,24 +147,32 @@ const oxlintRunner: RunnerDefinition = {
 		const stdout = result.stdout ?? "";
 		const stderr = result.stderr ?? "";
 		const parsedOutput = stdout + stderr;
+		const noFilesDecision = decideOxlintNoFiles(result, stdout, stderr);
 		// #1994's shared gate classifies invocation and parsed-output failures.
-		// The private marker lets its parser recognize oxlint's one legitimate
-		// nonzero/zero-diagnostic shape without recording a parsed-nothing
-		// degradation. It never escapes this runner. Because parseToolRun checks
-		// the process outcome before invoking the parser, a timed-out or killed
-		// process retaining partial no-files stdout still follows the failure path.
-		const parsedRun = parseToolRun<Diagnostic | typeof OXLINT_NO_FILES>(
+		// The private markers preserve one legitimate nonzero/empty shape and
+		// force a status-0 lookalike away from clean. Neither escapes this runner.
+		// parseToolRun checks process failures before invoking this parser, so
+		// spawn/timeout/killed/signal precedence remains owned by #1994.
+		const parsedRun = parseToolRun<
+			Diagnostic | typeof OXLINT_NO_FILES | typeof OXLINT_NO_FILES_UNCONFIRMED
+		>(
 			"oxlint",
 			{ result, output: parsedOutput },
 			() => {
+				if (noFilesDecision.kind === "expected-no-files") {
+					return [OXLINT_NO_FILES];
+				}
+				if (
+					noFilesDecision.kind === "unconfirmed-no-files" &&
+					result.status === 0
+				) {
+					return [OXLINT_NO_FILES_UNCONFIRMED];
+				}
 				let parsed = parseOxlintJson(stdout, ctx.filePath);
 				if (parsed.length === 0 && stdout.length > 0) {
 					parsed = parseOxlintUnix(parsedOutput, ctx.filePath);
 				}
-				return parsed.length === 0 &&
-					isExpectedOxlintNoFiles(result.status, stdout, stderr)
-					? [OXLINT_NO_FILES]
-					: parsed;
+				return parsed;
 			},
 			{ parseOutput: parsedOutput },
 		);
@@ -159,8 +195,34 @@ const oxlintRunner: RunnerDefinition = {
 				skipReason: "no-files-matched",
 			};
 		}
+		if (parsedRun.diagnostics.includes(OXLINT_NO_FILES_UNCONFIRMED)) {
+			const reason =
+				noFilesDecision.kind === "unconfirmed-no-files"
+					? noFilesDecision.reason
+					: "status-zero";
+			return {
+				status: "failed",
+				diagnostics: [
+					{
+						id: `oxlint:no-files-unconfirmed:${reason}`,
+						message: `oxlint no-files report was not canonical (${reason})`,
+						filePath: ctx.filePath,
+						line: 1,
+						column: 1,
+						severity: "warning",
+						semantic: "warning",
+						tool: "oxlint",
+					},
+				],
+				semantic: "warning",
+				failureKind: "unconfirmed_output",
+				failureMessage: `no-files-${reason}`,
+			};
+		}
 		const diagnostics = parsedRun.diagnostics.filter(
-			(diagnostic): diagnostic is Diagnostic => diagnostic !== OXLINT_NO_FILES,
+			(diagnostic): diagnostic is Diagnostic =>
+				diagnostic !== OXLINT_NO_FILES &&
+				diagnostic !== OXLINT_NO_FILES_UNCONFIRMED,
 		);
 
 		// A warning-only result on exit 0 is oxlint's normal outcome, not a
@@ -209,52 +271,156 @@ interface OxlintJsonReport {
 	number_of_files?: number;
 }
 
+interface OxlintProcessEvidence {
+	status?: number | null;
+	error?: Error | null;
+	failure?: string;
+	signal?: NodeJS.Signals | null;
+	outputTruncated?: boolean;
+	spawnFailure?: { kind?: string };
+}
+
+function oxlintProcessState(result: OxlintProcessEvidence): OxlintProcessState {
+	const failureKind = result.spawnFailure?.kind;
+	if (result.signal || result.failure === "signal") return "signal";
+	if (result.failure === "timeout" || failureKind === "timeout")
+		return "timeout";
+	if (result.failure === "aborted" || failureKind === "killed") return "killed";
+	if (result.failure === "spawn" || result.error) return "spawn";
+	if (result.outputTruncated) return "truncated";
+	return "normal";
+}
+
+function isNonnegativeInteger(value: unknown): value is number {
+	return Number.isInteger(value) && (value as number) >= 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+	return Number.isInteger(value) && (value as number) >= 1;
+}
+
+function isNonnegativeFinite(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 /**
- * Recognize only oxlint's captured expected no-files envelope. The numeric
- * field alone is not a verdict: config errors can also serialize
- * `number_of_files: 0`, and stderr accompanying an otherwise familiar stdout
- * means the invocation did not produce the clean expected-policy outcome.
+ * One decision seam for every oxlint no-files axis (#1998).
  *
- * Real oxlint 1.79.0 prints "No files found to lint. Please check your paths
- * and ignore patterns." to stdout before a JSON summary, exits 1, emits an
- * empty diagnostics array, and leaves stderr empty. Unknown JSON fields fail
- * closed so an error/message payload cannot borrow the expected skip merely
- * by also setting the file count to zero. Rejected lookalikes continue through
- * `parseToolRun`, preserving #1994 parsed-nothing telemetry.
+ * Real oxlint 1.79.0 establishes the only expected shape: a normal completed
+ * process, exit 1, empty stderr, the exact no-files banner, and a JSON object
+ * containing exactly the five captured summary fields with canonical types
+ * and ranges. Diagnostics must be empty and `number_of_files` must be zero.
+ *
+ * Any process-control evidence wins before report bytes. Any no-files
+ * lookalike that differs on status, stderr, banner, JSON syntax/schema,
+ * diagnostics, or file count is unconfirmed rather than clean. A report with
+ * no no-files evidence remains an ordinary oxlint report for the normal parser.
  */
-function isExpectedOxlintNoFiles(
-	status: number | null | undefined,
+export function decideOxlintNoFiles(
+	result: OxlintProcessEvidence,
 	stdout: string,
 	stderr: string,
-): boolean {
-	if (status !== 1 || stderr.trim().length > 0) return false;
-	const jsonStart = stdout.indexOf("{");
-	if (jsonStart === -1) return false;
-	if (stdout.slice(0, jsonStart).trim() !== OXLINT_NO_FILES_BANNER)
-		return false;
-	try {
-		const parsed = JSON.parse(stdout.slice(jsonStart)) as unknown;
-		if (
-			typeof parsed !== "object" ||
-			parsed === null ||
-			Array.isArray(parsed)
-		) {
-			return false;
-		}
-		const report = parsed as Record<string, unknown>;
-		if (
-			Object.keys(report).some((key) => !OXLINT_NO_FILES_REPORT_KEYS.has(key))
-		) {
-			return false;
-		}
-		return (
-			report.number_of_files === 0 &&
-			Array.isArray(report.diagnostics) &&
-			report.diagnostics.length === 0
-		);
-	} catch {
-		return false;
+): OxlintNoFilesDecision {
+	const processState = oxlintProcessState(result);
+	if (processState !== "normal") {
+		return {
+			kind: "unconfirmed-no-files",
+			reason: `process-${processState}`,
+		};
 	}
+
+	const jsonStart = stdout.indexOf("{");
+	const bannerText = (
+		jsonStart === -1 ? stdout : stdout.slice(0, jsonStart)
+	).trim();
+	const banner =
+		bannerText === OXLINT_NO_FILES_BANNER
+			? "exact"
+			: /no files found.+lint/i.test(bannerText)
+				? "near"
+				: "missing";
+
+	let report: Record<string, unknown> | undefined;
+	let jsonMalformed = jsonStart === -1;
+	if (jsonStart !== -1) {
+		try {
+			const parsed = JSON.parse(stdout.slice(jsonStart)) as unknown;
+			if (
+				typeof parsed === "object" &&
+				parsed !== null &&
+				!Array.isArray(parsed)
+			) {
+				report = parsed as Record<string, unknown>;
+			} else {
+				jsonMalformed = true;
+			}
+		} catch {
+			jsonMalformed = true;
+		}
+	}
+
+	const hasFileCount =
+		report !== undefined &&
+		Object.prototype.hasOwnProperty.call(report, "number_of_files");
+	const fileCount = report?.number_of_files;
+	const hasNoFilesEvidence =
+		banner !== "missing" ||
+		(hasFileCount && (fileCount === 0 || !isNonnegativeInteger(fileCount)));
+	if (!hasNoFilesEvidence) return { kind: "ordinary-report" };
+
+	if (result.status == null) {
+		return { kind: "unconfirmed-no-files", reason: "status-null" };
+	}
+	if (result.status === 0) {
+		return { kind: "unconfirmed-no-files", reason: "status-zero" };
+	}
+	if (result.status !== 1) {
+		return { kind: "unconfirmed-no-files", reason: "status-other" };
+	}
+	if (stderr.trim().length > 0) {
+		return { kind: "unconfirmed-no-files", reason: "stderr-nonempty" };
+	}
+	if (banner === "near") {
+		return { kind: "unconfirmed-no-files", reason: "banner-near" };
+	}
+	if (banner === "missing") {
+		return { kind: "unconfirmed-no-files", reason: "banner-missing" };
+	}
+	if (jsonMalformed || !report) {
+		return { kind: "unconfirmed-no-files", reason: "json-malformed" };
+	}
+
+	const keys = Object.keys(report);
+	if (keys.some((key) => !OXLINT_NO_FILES_REPORT_KEYS.has(key))) {
+		return { kind: "unconfirmed-no-files", reason: "json-unknown-key" };
+	}
+	if (
+		OXLINT_NO_FILES_REPORT_KEYS.size !== keys.length ||
+		[...OXLINT_NO_FILES_REPORT_KEYS].some(
+			(key) => !Object.prototype.hasOwnProperty.call(report, key),
+		)
+	) {
+		return { kind: "unconfirmed-no-files", reason: "json-missing-key" };
+	}
+	if (
+		!Array.isArray(report.diagnostics) ||
+		!isNonnegativeInteger(report.number_of_files) ||
+		!isNonnegativeInteger(report.number_of_rules) ||
+		!isPositiveInteger(report.threads_count) ||
+		!isNonnegativeFinite(report.start_time)
+	) {
+		return {
+			kind: "unconfirmed-no-files",
+			reason: "json-known-field-invalid",
+		};
+	}
+	if (report.diagnostics.length > 0) {
+		return { kind: "unconfirmed-no-files", reason: "diagnostics-nonempty" };
+	}
+	if (report.number_of_files !== 0) {
+		return { kind: "unconfirmed-no-files", reason: "files-nonzero" };
+	}
+	return { kind: "expected-no-files" };
 }
 
 // Oxlint codes look like "eslint(no-debugger)" or "oxc(approx-constant)".
@@ -279,8 +445,9 @@ function parseOxlintJson(raw: string, filePath: string): Diagnostic[] {
 	} catch {
 		return [];
 	}
+	if (!Array.isArray(parsed.diagnostics)) return [];
 	const diagnostics: Diagnostic[] = [];
-	for (const d of parsed.diagnostics ?? []) {
+	for (const d of parsed.diagnostics) {
 		const rule = extractOxlintRule(d.code);
 		const label = d.labels?.[0]?.span;
 		const lineNum = label?.line ?? 1;

--- a/clients/dispatch/types.ts
+++ b/clients/dispatch/types.ts
@@ -141,6 +141,15 @@ export interface RunnerDefinition {
 	run(ctx: DispatchContext): Promise<RunnerResult>;
 }
 
+/** Closed telemetry taxonomy for expected runner skips. */
+export const RUNNER_SKIP_REASONS = ["no-files-matched"] as const;
+export type RunnerSkipReason = (typeof RUNNER_SKIP_REASONS)[number];
+
+/** Runtime guard for untyped/plugin-provided runner results. */
+export function isRunnerSkipReason(value: unknown): value is RunnerSkipReason {
+	return RUNNER_SKIP_REASONS.some((reason) => reason === value);
+}
+
 export interface RunnerResult {
 	status: "succeeded" | "failed" | "skipped";
 	/** Diagnostics found */
@@ -160,6 +169,8 @@ export interface RunnerResult {
 	failureKind?: string;
 	/** Optional short human-readable detail for the failure (truncated). */
 	failureMessage?: string;
+	/** Bounded machine-readable reason when status is an expected skip. */
+	skipReason?: RunnerSkipReason;
 	/** Correlated scanner ids whose findings are absent from this result. */
 	unconfirmedServerIds?: readonly string[];
 }

--- a/tests/clients/dispatch/runners/oxlint.test.ts
+++ b/tests/clients/dispatch/runners/oxlint.test.ts
@@ -14,6 +14,60 @@ const safeSpawnAsync = vi.fn();
 const ensureTool = vi.fn(async (_toolId?: string) => "oxlint");
 const logLatency = vi.hoisted(() => vi.fn());
 
+const OXLINT_NO_FILES_BANNER =
+	"No files found to lint. Please check your paths and ignore patterns.";
+const CANONICAL_NO_FILES_REPORT = {
+	diagnostics: [],
+	number_of_files: 0,
+	number_of_rules: 96,
+	threads_count: 16,
+	start_time: 0.009533,
+};
+const CAPTURED_NO_FILES_STDOUT =
+	`${OXLINT_NO_FILES_BANNER}\n` +
+	'{ "diagnostics": [],\n' +
+	'              "number_of_files": 0,\n' +
+	'              "number_of_rules": 96,\n' +
+	'              "threads_count": 16,\n' +
+	'              "start_time": 0.009533\n' +
+	"            }\n" +
+	"            ";
+
+function noFilesEnvelope(
+	report: Record<string, unknown> | string = CANONICAL_NO_FILES_REPORT,
+	banner = OXLINT_NO_FILES_BANNER,
+): string {
+	return `${banner}\n${typeof report === "string" ? report : JSON.stringify(report)}`;
+}
+
+const MATRIX_UNCONFIRMED_REASONS: Record<string, string> = {
+	"spawn failure with exact envelope": "process-spawn",
+	"timeout with exact envelope": "process-timeout",
+	"killed process with exact envelope": "process-killed",
+	"signal termination with exact envelope": "process-signal",
+	"truncated exact envelope": "process-truncated",
+	"status zero with exact envelope": "status-zero",
+	"other nonzero status with exact envelope": "status-other",
+	"null status with exact envelope": "status-null",
+	"nonempty stderr with exact envelope": "stderr-nonempty",
+	"near banner": "banner-near",
+	"missing banner": "banner-missing",
+	"unknown JSON key": "json-unknown-key",
+	"missing captured JSON key": "json-missing-key",
+	"diagnostics has the wrong type": "json-known-field-invalid",
+	"number_of_files has the wrong type": "json-known-field-invalid",
+	"number_of_files is out of range": "json-known-field-invalid",
+	"number_of_rules has the wrong type": "json-known-field-invalid",
+	"number_of_rules is out of range": "json-known-field-invalid",
+	"threads_count is out of range": "json-known-field-invalid",
+	"threads_count has the wrong type": "json-known-field-invalid",
+	"start_time has the wrong type": "json-known-field-invalid",
+	"start_time is out of range": "json-known-field-invalid",
+	"malformed JSON after exact banner": "json-malformed",
+	"nonempty diagnostics with zero files": "diagnostics-nonempty",
+	"nonzero file count after exact banner": "files-nonzero",
+};
+
 vi.mock("../../../../clients/safe-spawn.js", () => ({
 	safeSpawn,
 	safeSpawnAsync,
@@ -73,6 +127,417 @@ describe("oxlint runner", () => {
 		};
 		expect(invalid.skipReason).toBe("ignored because someone felt like it");
 	});
+
+	it.each([
+		{
+			name: "exact captured envelope",
+			result: {
+				error: null,
+				status: 1,
+				stdout: CAPTURED_NO_FILES_STDOUT,
+				stderr: "",
+			},
+			expectedStatus: "skipped",
+			expectedSkipReason: "no-files-matched",
+		},
+		{
+			name: "spawn failure with exact envelope",
+			result: {
+				error: new Error("spawn failed"),
+				failure: "spawn",
+				status: null,
+				stdout: CAPTURED_NO_FILES_STDOUT,
+				stderr: "",
+			},
+			expectedStatus: "skipped",
+			expectedDegradation: "runner-empty-result",
+		},
+		{
+			name: "timeout with exact envelope",
+			result: {
+				error: new Error("Process timed out after 30000ms"),
+				failure: "timeout",
+				status: null,
+				stdout: CAPTURED_NO_FILES_STDOUT,
+				stderr: "",
+			},
+			expectedStatus: "skipped",
+			expectedDegradation: "runner-empty-result",
+		},
+		{
+			name: "killed process with exact envelope",
+			result: {
+				error: new Error("Spawn aborted"),
+				failure: "aborted",
+				status: null,
+				stdout: CAPTURED_NO_FILES_STDOUT,
+				stderr: "",
+			},
+			expectedStatus: "skipped",
+			expectedDegradation: "runner-empty-result",
+		},
+		{
+			name: "signal termination with exact envelope",
+			result: {
+				error: new Error("Process killed by signal: SIGTERM"),
+				failure: "signal",
+				signal: "SIGTERM" as NodeJS.Signals,
+				status: null,
+				stdout: CAPTURED_NO_FILES_STDOUT,
+				stderr: "",
+			},
+			expectedStatus: "skipped",
+			expectedDegradation: "runner-empty-result",
+		},
+		{
+			name: "truncated exact envelope",
+			result: {
+				error: null,
+				status: 1,
+				stdout: CAPTURED_NO_FILES_STDOUT,
+				stderr: "",
+				outputTruncated: true,
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "status zero with exact envelope",
+			result: {
+				error: null,
+				status: 0,
+				stdout: CAPTURED_NO_FILES_STDOUT,
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedFailureKind: "unconfirmed_output",
+		},
+		{
+			name: "other nonzero status with exact envelope",
+			result: {
+				error: null,
+				status: 2,
+				stdout: CAPTURED_NO_FILES_STDOUT,
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "null status with exact envelope",
+			result: {
+				error: null,
+				status: null,
+				stdout: CAPTURED_NO_FILES_STDOUT,
+				stderr: "",
+			},
+			expectedStatus: "skipped",
+			expectedDegradation: "runner-empty-result",
+		},
+		{
+			name: "nonempty stderr with exact envelope",
+			result: {
+				error: null,
+				status: 1,
+				stdout: CAPTURED_NO_FILES_STDOUT,
+				stderr: "Error: invalid configuration\n",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "near banner",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope(
+					CANONICAL_NO_FILES_REPORT,
+					"No files found to lint. Check paths and ignores.",
+				),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "missing banner",
+			result: {
+				error: null,
+				status: 1,
+				stdout: JSON.stringify(CANONICAL_NO_FILES_REPORT),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "unknown JSON key",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					error: "invalid config",
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "missing captured JSON key",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					diagnostics: [],
+					number_of_files: 0,
+					number_of_rules: 96,
+					threads_count: 16,
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "diagnostics has the wrong type",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					diagnostics: {},
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "number_of_files has the wrong type",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					number_of_files: "0",
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "number_of_files is out of range",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					number_of_files: -1,
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "number_of_rules has the wrong type",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					number_of_rules: "96",
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "number_of_rules is out of range",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					number_of_rules: -1,
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "threads_count is out of range",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					threads_count: 0,
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "threads_count has the wrong type",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					threads_count: "16",
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "start_time has the wrong type",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					start_time: "0.009533",
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "start_time is out of range",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					start_time: -0.1,
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "malformed JSON after exact banner",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope('{ "diagnostics": [], "number_of_files": 0'),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "nonempty diagnostics with zero files",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					diagnostics: [{ message: "invalid config" }],
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "nonzero file count after exact banner",
+			result: {
+				error: null,
+				status: 1,
+				stdout: noFilesEnvelope({
+					...CANONICAL_NO_FILES_REPORT,
+					number_of_files: 1,
+				}),
+				stderr: "",
+			},
+			expectedStatus: "failed",
+			expectedDegradation: "runner-parsed-nothing",
+		},
+		{
+			name: "ordinary matched clean report",
+			result: {
+				error: null,
+				status: 0,
+				stdout: JSON.stringify({ diagnostics: [], number_of_files: 1 }),
+				stderr: "",
+			},
+			expectedStatus: "succeeded",
+		},
+	])(
+		"classifies the no-files state matrix: $name",
+		async ({
+			name,
+			result: spawnResult,
+			expectedStatus,
+			expectedSkipReason,
+			expectedDegradation,
+			expectedFailureKind,
+		}) => {
+			const env = setupTestEnvironment(
+				`pi-lens-oxlint-matrix-${name.replace(/[^a-z0-9]+/gi, "-")}-`,
+			);
+			try {
+				const filePath = path.join(env.tmpDir, "sample.ts");
+				fs.writeFileSync(filePath, "const value = 1;\n");
+				safeSpawnAsync.mockResolvedValueOnce(spawnResult);
+				const runnerModule =
+					await import("../../../../clients/dispatch/runners/oxlint.js");
+				const decision = runnerModule.decideOxlintNoFiles(
+					spawnResult,
+					spawnResult.stdout,
+					spawnResult.stderr,
+				);
+				const expectedDecision = expectedSkipReason
+					? { kind: "expected-no-files" }
+					: expectedStatus === "succeeded"
+						? { kind: "ordinary-report" }
+						: {
+								kind: "unconfirmed-no-files",
+								reason: MATRIX_UNCONFIRMED_REASONS[name],
+							};
+				if (!expectedSkipReason && expectedStatus !== "succeeded") {
+					expect(MATRIX_UNCONFIRMED_REASONS[name]).toBeDefined();
+				}
+				expect(decision).toEqual(expectedDecision);
+
+				const runner = runnerModule.default;
+				const outcome = await runner.run({
+					...createCtx(filePath, env.tmpDir),
+					hasTool: async () => false,
+				} as never);
+
+				expect(outcome.status).toBe(expectedStatus);
+				expect(outcome.skipReason).toBe(expectedSkipReason);
+				expect(outcome.failureKind).toBe(expectedFailureKind);
+				const degradationKinds = logLatency.mock.calls
+					.map(
+						([entry]) =>
+							entry as { phase?: string; metadata?: { kind?: string } },
+					)
+					.filter((entry) => entry.phase === "degradation_ledger")
+					.map((entry) => entry.metadata?.kind);
+				if (expectedDegradation) {
+					expect(degradationKinds).toContain(expectedDegradation);
+				} else {
+					expect(degradationKinds).toEqual([]);
+				}
+			} finally {
+				env.cleanup();
+			}
+		},
+	);
 
 	it("does not skip test files (#576) — real correctness findings matter there too", async () => {
 		const { default: oxlintRunner } =
@@ -582,16 +1047,6 @@ describe("oxlint runner", () => {
 			const filePath = path.join(env.tmpDir, "sample.ts");
 			fs.writeFileSync(filePath, "const unused = 1;\n");
 
-			const CAPTURED_NO_FILES_STDOUT =
-				"No files found to lint. Please check your paths and ignore patterns.\n" +
-				'{ "diagnostics": [],\n' +
-				'              "number_of_files": 0,\n' +
-				'              "number_of_rules": 96,\n' +
-				'              "threads_count": 16,\n' +
-				'              "start_time": 0.009533\n' +
-				"            }\n" +
-				"            ";
-
 			safeSpawnAsync.mockResolvedValueOnce({
 				error: null,
 				status: 1,
@@ -630,8 +1085,7 @@ describe("oxlint runner", () => {
 				error: new Error("Process timed out after 30000ms"),
 				failure: "timeout",
 				status: null,
-				stdout:
-					'No files found to lint.\n{ "diagnostics": [], "number_of_files": 0 }',
+				stdout: CAPTURED_NO_FILES_STDOUT,
 				stderr: "",
 			});
 
@@ -670,9 +1124,7 @@ describe("oxlint runner", () => {
 			safeSpawnAsync.mockResolvedValueOnce({
 				error: null,
 				status: 1,
-				stdout:
-					"No files found to lint. Please check your paths and ignore patterns.\n" +
-					'{ "diagnostics": [], "number_of_files": 0 }',
+				stdout: CAPTURED_NO_FILES_STDOUT,
 				stderr: "",
 			});
 

--- a/tests/clients/dispatch/runners/oxlint.test.ts
+++ b/tests/clients/dispatch/runners/oxlint.test.ts
@@ -1,13 +1,18 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { RunnerGroup } from "../../../../clients/dispatch/types.js";
+import {
+	RUNNER_SKIP_REASONS,
+	type RunnerGroup,
+	type RunnerResult,
+} from "../../../../clients/dispatch/types.js";
 import { makeRunnerCtx } from "../../../support/runner-ctx.js";
 import { setupTestEnvironment } from "../../test-utils.js";
 
 const safeSpawn = vi.fn();
 const safeSpawnAsync = vi.fn();
 const ensureTool = vi.fn(async (_toolId?: string) => "oxlint");
+const logLatency = vi.hoisted(() => vi.fn());
 
 vi.mock("../../../../clients/safe-spawn.js", () => ({
 	safeSpawn,
@@ -16,6 +21,13 @@ vi.mock("../../../../clients/safe-spawn.js", () => ({
 
 vi.mock("../../../../clients/installer/index.js", () => ({
 	ensureTool,
+}));
+
+vi.mock("../../../../clients/latency-logger.js", async (importActual) => ({
+	...(await importActual<
+		typeof import("../../../../clients/latency-logger.js")
+	>()),
+	logLatency,
 }));
 
 vi.mock("../../../../clients/dispatch/runners/utils/runner-helpers.js", () => ({
@@ -36,9 +48,30 @@ describe("oxlint runner", () => {
 		safeSpawn.mockReset();
 		safeSpawnAsync.mockReset();
 		ensureTool.mockReset();
+		logLatency.mockReset();
 		ensureTool.mockResolvedValue("oxlint");
 		// Simulate oxlint not being available on PATH/venv so ensureTool path is used.
 		safeSpawn.mockReturnValue({ error: new Error("not found"), status: 1 });
+	});
+
+	it("keeps expected runner skip reasons on a closed type/runtime taxonomy", () => {
+		expect(RUNNER_SKIP_REASONS).toEqual(["no-files-matched"]);
+		const valid: RunnerResult = {
+			status: "skipped",
+			diagnostics: [],
+			semantic: "none",
+			skipReason: "no-files-matched",
+		};
+		expect(valid.skipReason).toBe("no-files-matched");
+
+		const invalid: RunnerResult = {
+			status: "skipped",
+			diagnostics: [],
+			semantic: "none",
+			// @ts-expect-error free text is not an admitted telemetry reason
+			skipReason: "ignored because someone felt like it",
+		};
+		expect(invalid.skipReason).toBe("ignored because someone felt like it");
 	});
 
 	it("does not skip test files (#576) — real correctness findings matter there too", async () => {
@@ -381,6 +414,151 @@ describe("oxlint runner", () => {
 		}
 	});
 
+	it("keeps a matched clean file distinct from a no-files skip", async () => {
+		const env = setupTestEnvironment("pi-lens-oxlint-clean-match-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const value = 1;\n");
+			safeSpawnAsync.mockResolvedValueOnce({
+				error: null,
+				status: 0,
+				stdout: JSON.stringify({ diagnostics: [], number_of_files: 1 }),
+				stderr: "",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/oxlint.js")
+			).default;
+			const log = vi.fn();
+			const result = await runner.run({
+				...createCtx(filePath, env.tmpDir),
+				hasTool: async () => false,
+				log,
+			} as never);
+
+			expect(result).toMatchObject({
+				status: "succeeded",
+				semantic: "none",
+				diagnostics: [],
+			});
+			expect(result.skipReason).toBeUndefined();
+			expect(log).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("keeps nonzero garbage as a failure, not a no-files skip", async () => {
+		const env = setupTestEnvironment("pi-lens-oxlint-garbage-failure-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const value = 1;\n");
+			safeSpawnAsync.mockResolvedValueOnce({
+				error: null,
+				status: 1,
+				stdout: "oxlint: internal failure, report unavailable\n",
+				stderr: "",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/oxlint.js")
+			).default;
+			const result = await runner.run({
+				...createCtx(filePath, env.tmpDir),
+				hasTool: async () => false,
+			} as never);
+
+			expect(result.status).toBe("failed");
+			expect(result.skipReason).toBeUndefined();
+			expect(result.diagnostics[0]).toMatchObject({
+				semantic: "warning",
+				message: expect.stringContaining("could not be parsed"),
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("does not trust number_of_files=0 inside an error report", async () => {
+		const env = setupTestEnvironment("pi-lens-oxlint-zero-files-error-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const value = 1;\n");
+			safeSpawnAsync.mockResolvedValueOnce({
+				error: null,
+				status: 1,
+				stdout: JSON.stringify({
+					diagnostics: [],
+					number_of_files: 0,
+					error: "invalid config",
+				}),
+				stderr: "",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/oxlint.js")
+			).default;
+			const result = await runner.run({
+				...createCtx(filePath, env.tmpDir),
+				hasTool: async () => false,
+			} as never);
+
+			expect(result.status).toBe("failed");
+			expect(result.skipReason).toBeUndefined();
+			expect(result.diagnostics[0]?.message).toContain("could not be parsed");
+			expect(logLatency).toHaveBeenCalledWith(
+				expect.objectContaining({
+					phase: "degradation_ledger",
+					metadata: expect.objectContaining({
+						kind: "runner-parsed-nothing",
+						subject: "oxlint",
+					}),
+				}),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("does not suppress stderr accompanying an otherwise expected no-files report", async () => {
+		const env = setupTestEnvironment("pi-lens-oxlint-zero-files-stderr-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const value = 1;\n");
+			safeSpawnAsync.mockResolvedValueOnce({
+				error: null,
+				status: 1,
+				stdout:
+					"No files found to lint. Please check your paths and ignore patterns.\n" +
+					'{ "diagnostics": [], "number_of_files": 0 }',
+				stderr: "Error: invalid configuration\n",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/oxlint.js")
+			).default;
+			const result = await runner.run({
+				...createCtx(filePath, env.tmpDir),
+				hasTool: async () => false,
+			} as never);
+
+			expect(result.status).toBe("failed");
+			expect(result.skipReason).toBeUndefined();
+			expect(result.diagnostics[0]?.message).toContain("could not be parsed");
+			expect(logLatency).toHaveBeenCalledWith(
+				expect.objectContaining({
+					phase: "degradation_ledger",
+					metadata: expect.objectContaining({
+						kind: "runner-parsed-nothing",
+						subject: "oxlint",
+					}),
+				}),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("reports a config-excluded file as skipped, not succeeded (dogfood #1985 review F2b/R2)", async () => {
 		// Nested-config discovery means a file under a directory with its own
 		// `.oxlintrc.json` ignorePatterns — or covered by a parent config's
@@ -432,9 +610,172 @@ describe("oxlint runner", () => {
 			} as never);
 
 			expect(result.status).toBe("skipped");
+			expect(result.skipReason).toBe("no-files-matched");
 			expect(result.semantic).toBe("none");
 			expect(result.diagnostics).toHaveLength(0);
-			expect(log).toHaveBeenCalledWith(expect.stringContaining("oxlint"));
+			// The existing latency runner record carries the structured skip reason.
+			// This expected policy outcome must not enter the extension error log.
+			expect(log).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("does not let a timed-out partial report masquerade as a no-files skip", async () => {
+		const env = setupTestEnvironment("pi-lens-oxlint-timeout-partial-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const value = 1;\n");
+			safeSpawnAsync.mockResolvedValueOnce({
+				error: new Error("Process timed out after 30000ms"),
+				failure: "timeout",
+				status: null,
+				stdout:
+					'No files found to lint.\n{ "diagnostics": [], "number_of_files": 0 }',
+				stderr: "",
+			});
+
+			const runner = (
+				await import("../../../../clients/dispatch/runners/oxlint.js")
+			).default;
+			const result = await runner.run({
+				...createCtx(filePath, env.tmpDir),
+				hasTool: async () => false,
+			} as never);
+
+			// The shared #1994 outcome gate owns process failures. It records the
+			// degradation and returns an unconfirmed skip, never the expected-policy
+			// reason that would suppress failure accounting.
+			expect(result.status).toBe("skipped");
+			expect(result.skipReason).toBeUndefined();
+			expect(logLatency).toHaveBeenCalledWith(
+				expect.objectContaining({
+					phase: "degradation_ledger",
+					metadata: expect.objectContaining({
+						kind: "runner-empty-result",
+						subject: "oxlint",
+					}),
+				}),
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("carries the no-files reason through existing runner telemetry", async () => {
+		const env = setupTestEnvironment("pi-lens-oxlint-skip-telemetry-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const value = 1;\n");
+			safeSpawnAsync.mockResolvedValueOnce({
+				error: null,
+				status: 1,
+				stdout:
+					"No files found to lint. Please check your paths and ignore patterns.\n" +
+					'{ "diagnostics": [], "number_of_files": 0 }',
+				stderr: "",
+			});
+
+			const oxlintRunner = (
+				await import("../../../../clients/dispatch/runners/oxlint.js")
+			).default;
+			const {
+				clearLatencyReports,
+				dispatchForFile,
+				getLatencyReports,
+				RunnerRegistry,
+			} = await import("../../../../clients/dispatch/dispatcher.js");
+			clearLatencyReports();
+			const registry = new RunnerRegistry();
+			registry.register(oxlintRunner);
+			const extensionLog = vi.fn();
+
+			await dispatchForFile(
+				{
+					...createCtx(filePath, env.tmpDir),
+					hasTool: async () => false,
+					log: extensionLog,
+				} as never,
+				[{ mode: "all", runnerIds: ["oxlint"] }],
+				registry,
+			);
+
+			const report = getLatencyReports().at(-1);
+			expect(report?.runners).toContainEqual(
+				expect.objectContaining({
+					runnerId: "oxlint",
+					status: "skipped",
+					skipReason: "no-files-matched",
+				}),
+			);
+			const runnerRow = logLatency.mock.calls
+				.map(([entry]) => entry as Record<string, unknown>)
+				.find(
+					(entry) => entry.type === "runner" && entry.runnerId === "oxlint",
+				);
+			expect(runnerRow).toMatchObject({
+				status: "skipped",
+				metadata: { skipReason: "no-files-matched" },
+			});
+			expect(
+				logLatency.mock.calls.some(
+					([entry]) =>
+						(entry as { phase?: string }).phase === "degradation_ledger",
+				),
+			).toBe(false);
+			expect(extensionLog).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("rejects untyped free-text skip reasons at the latency boundary", async () => {
+		const env = setupTestEnvironment("pi-lens-runner-skip-reason-boundary-");
+		try {
+			const filePath = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(filePath, "const value = 1;\n");
+			const {
+				clearLatencyReports,
+				dispatchForFile,
+				getLatencyReports,
+				RunnerRegistry,
+			} = await import("../../../../clients/dispatch/dispatcher.js");
+			clearLatencyReports();
+			const registry = new RunnerRegistry();
+			registry.register({
+				id: "malformed-skip",
+				appliesTo: ["jsts"],
+				priority: 1,
+				enabledByDefault: true,
+				async run() {
+					return {
+						status: "skipped",
+						diagnostics: [],
+						semantic: "none",
+						skipReason: "free text from an untyped plugin",
+					} as never;
+				},
+			});
+
+			await dispatchForFile(
+				createCtx(filePath, env.tmpDir) as never,
+				[{ mode: "all", runnerIds: ["malformed-skip"] }],
+				registry,
+			);
+
+			const latency = getLatencyReports().at(-1)?.runners.at(-1);
+			expect(latency).toMatchObject({
+				runnerId: "malformed-skip",
+				status: "skipped",
+			});
+			expect(latency).not.toHaveProperty("skipReason");
+			const runnerRow = logLatency.mock.calls
+				.map(([entry]) => entry as Record<string, unknown>)
+				.find(
+					(entry) =>
+						entry.type === "runner" && entry.runnerId === "malformed-skip",
+				);
+			expect(runnerRow).not.toHaveProperty("metadata.skipReason");
 		} finally {
 			env.cleanup();
 		}


### PR DESCRIPTION
Closes #1998. Work produced by the codex session; verified and promoted by maintainer agent.

## What changed

Oxlint's expected policy outcomes (config-excluded file → no files matched) were surfacing as extension *errors* in telemetry instead of closed runner skips. This carries **no-files-matched** as a typed, closed skip reason on the runner result (`types.ts`), classifies it in the dispatcher, and keeps malformed / timed-out / genuinely failed runs on the shared failure path. The oxlint runner's skip paths are restructured around the classification (+345 lines of new oxlint tests pinning each shape).

Built on top of #1994's merged oxlint state (finishParsedRun tail included).

## Verification

- oxlint + run-outcome-ratchet suites: 50/50 green in the branch worktree.
- fmt clean; lint clean.

## Observability

Expected skips now close as runner skips in latency rows instead of error-class records — the exact confusion #1998 reports is gone from logs post-merge.

Refs #1998