### PR TITLE
feat(freshness): kernel comparator + verdict type; migrate six stores (closes #1739)

### DIFF
--- a/.changelog/refactor-1739-freshness-kernel.md
+++ b/.changelog/refactor-1739-freshness-kernel.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Freshness kernel: one comparator, one verdict type for staleness gates (closes #1739)** — `clients/freshness.ts` owns the mtime-vs-reference comparison and shared drift tolerance that six stores had independently reimplemented (three copies carried the identical #1710/#1711 tolerance defect). `freshnessFromMtime` returns an explicit verdict (`fresh` / `stale: modified-after-reference` / `indeterminate: no-mtime-evidence`) so each caller keeps its own no-evidence policy while sharing the comparison. A registered-or-fail sweep fails on any new out-of-kernel mtime-vs-reference comparison in `clients/`.

--- a/clients/advisory-provenance.ts
+++ b/clients/advisory-provenance.ts
@@ -5,7 +5,7 @@ import type { RuntimeCoordinator } from "./runtime-coordinator.js";
 import { logLatency } from "./latency-logger.js";
 import { normalizeMapKey, toProjectRelativePath } from "./path-utils.js";
 import { resolveRunnerPath } from "./dispatch/runner-context.js";
-import { MTIME_DRIFT_TOLERANCE_MS } from "./blocker-freshness.js";
+import { freshnessFromMtime } from "./freshness.js";
 
 export type AdvisoryFileRole = "source" | "test" | "affected";
 
@@ -365,13 +365,14 @@ export function findingPathFreshness(
 ): FindingPathFreshness {
 	try {
 		const stat = fs.statSync(resolvedPath);
-		if (
-			scannedAtMs !== undefined &&
-			stat.mtimeMs > scannedAtMs + MTIME_DRIFT_TOLERANCE_MS
-		) {
-			return "stale";
-		}
-		return "live";
+		// No scan timestamp recorded: the pre-kernel behavior treated the
+		// path as live (no reference to be stale against) - preserved.
+		if (scannedAtMs === undefined) return "live";
+		const verdict = freshnessFromMtime({
+			mtimeMs: stat.mtimeMs,
+			referenceMs: scannedAtMs,
+		});
+		return verdict.verdict === "stale" ? "stale" : "live";
 	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code ?? "unknown";
 		// ENOTDIR: an ancestor component is no longer a directory — the cited

--- a/clients/blocker-freshness.ts
+++ b/clients/blocker-freshness.ts
@@ -372,7 +372,10 @@ export async function collectForwardImportMtimes(
  * +50ms). +50ms comfortably clears the measured skew while staying far below the
  * gap between genuinely distinct edits.
  */
-export const MTIME_DRIFT_TOLERANCE_MS = 50;
+// Single implementation lives in the freshness kernel (#1739); this
+// re-export preserves every existing importer's path.
+export { MTIME_DRIFT_TOLERANCE_MS } from "./freshness.js";
+import { freshnessFromMtime } from "./freshness.js";
 
 interface DriftResult {
 	drifted: string[];
@@ -387,21 +390,23 @@ async function detectDrift(
 	turnIndex: number | undefined,
 ): Promise<DriftResult> {
 	const drifted: string[] = [];
-	const ownMtimeMs = await statMtimeMs(filePath);
-	if (
-		ownMtimeMs !== undefined &&
-		ownMtimeMs > recordedAtMs + MTIME_DRIFT_TOLERANCE_MS
-	) {
-		drifted.push(filePath);
-	}
+	const ownFreshness = freshnessFromMtime({
+		mtimeMs: await statMtimeMs(filePath),
+		referenceMs: recordedAtMs,
+	});
+	if (ownFreshness.verdict === "stale") drifted.push(filePath);
 	const { mtimes, truncated } = await collectForwardImportMtimes(
 		cwd,
 		filePath,
 		resolveForwardImports,
 		turnIndex,
 	);
-	for (const { path, mtimeMs } of mtimes) {
-		if (mtimeMs > recordedAtMs + MTIME_DRIFT_TOLERANCE_MS) drifted.push(path);
+	for (const { mtimeMs } of mtimes) {
+		if (
+			freshnessFromMtime({ mtimeMs, referenceMs: recordedAtMs }).verdict ===
+			"stale"
+		)
+			drifted.push(filePath);
 	}
 	return { drifted, truncated };
 }

--- a/clients/blocker-freshness.ts
+++ b/clients/blocker-freshness.ts
@@ -401,12 +401,12 @@ async function detectDrift(
 		resolveForwardImports,
 		turnIndex,
 	);
-	for (const { mtimeMs } of mtimes) {
-		if (
-			freshnessFromMtime({ mtimeMs, referenceMs: recordedAtMs }).verdict ===
-			"stale"
-		)
-			drifted.push(filePath);
+	for (const { path: depPath, mtimeMs } of mtimes) {
+		const verdict = freshnessFromMtime({
+			mtimeMs,
+			referenceMs: recordedAtMs,
+		});
+		if (verdict.verdict === "stale") drifted.push(depPath);
 	}
 	return { drifted, truncated };
 }

--- a/clients/freshness.ts
+++ b/clients/freshness.ts
@@ -1,0 +1,55 @@
+/**
+ * Freshness kernel (#1739): ONE comparator and ONE verdict type for every
+ * "was this file modified after my reference timestamp?" gate.
+ *
+ * The same staleness comparison was independently reimplemented in at least
+ * six stores (advisory-provenance, blocker-freshness,
+ * project-diagnostics/cache [#1711], widget-state ×3, lsp/workspace-
+ * diagnostics-cache), and three of those copies carried the identical
+ * mtime-tolerance defect fixed separately in #1710/#1711/#1664. This module
+ * is the single implementation going forward; the registered-or-fail sweep
+ * (`tests/clients/freshness-sweep.test.ts`) fails on new out-of-kernel
+ * comparisons so the population cannot silently regrow.
+ *
+ * Deliberately NOT here: age-based checks (`Date.now() - mtime > TTL` — that
+ * is expiry, not freshness against a reference event) and max-selection
+ * comparisons (`mtime > best.mtimeMs`) — neither compares against a scan or
+ * record timestamp, which is what this kernel's verdict means.
+ */
+
+/** Shared drift tolerance: raised from 0 to 50ms after measured Windows mtime skew produced 42 false demotions in 50 runs (#1710 evidence). */
+export const MTIME_DRIFT_TOLERANCE_MS = 50;
+
+export type FreshnessVerdict =
+	| { verdict: "fresh" }
+	| {
+			verdict: "stale";
+			reason: "modified-after-reference";
+	  }
+	| {
+			verdict: "indeterminate";
+			reason: "no-mtime-evidence";
+	  };
+
+/**
+ * Compare an observed mtime against a reference timestamp (the scan, record,
+ * or touch instant whose validity depends on the file not having moved).
+ *
+ * `mtimeMs === undefined` means the caller had no readable mtime (stat
+ * failed, file gone). The kernel does NOT choose a policy for that case -
+ * callers differ legitimately (a diagnostics cache drops, a drift detector
+ * skips) - so it reports `indeterminate` and the caller maps it.
+ */
+export function freshnessFromMtime(input: {
+	mtimeMs: number | undefined;
+	referenceMs: number;
+	toleranceMs?: number;
+}): FreshnessVerdict {
+	const tolerance = input.toleranceMs ?? MTIME_DRIFT_TOLERANCE_MS;
+	if (input.mtimeMs === undefined) {
+		return { verdict: "indeterminate", reason: "no-mtime-evidence" };
+	}
+	return input.mtimeMs > input.referenceMs + tolerance
+		? { verdict: "stale", reason: "modified-after-reference" }
+		: { verdict: "fresh" };
+}

--- a/clients/lsp/workspace-diagnostics-cache.ts
+++ b/clients/lsp/workspace-diagnostics-cache.ts
@@ -6,7 +6,7 @@ import { readJsonCache } from "../json-cache-read.js";
 import { createGenerationMap } from "../generation-guard.js";
 import { normalizeMapKey } from "../path-utils.js";
 import { loadReverseDependencyIndexFromSnapshot } from "../reverse-deps.js";
-import { MTIME_DRIFT_TOLERANCE_MS } from "../blocker-freshness.js";
+import { freshnessFromMtime } from "../freshness.js";
 import { logLatency } from "../latency-logger.js";
 import { workspaceDiagnosticsCacheSessionStart } from "./workspace-diagnostics-session.js";
 import type { LSPDiagnostic } from "./client.js";
@@ -443,16 +443,17 @@ export function isEntryFresh(
 		return entry.depIndexAtScan !== true;
 	}
 	for (const dep of imports) {
+		let mtimeMs: number | undefined;
 		try {
-			if (
-				fs.statSync(dep).mtimeMs >
-				entry.scannedAt + MTIME_DRIFT_TOLERANCE_MS
-			) {
-				return false;
-			}
+			mtimeMs = fs.statSync(dep).mtimeMs;
 		} catch {
 			return false; // dependency deleted/unreadable: fail closed
 		}
+		const verdict = freshnessFromMtime({
+			mtimeMs,
+			referenceMs: entry.scannedAt,
+		});
+		if (verdict.verdict === "stale") return false;
 	}
 	return true;
 }

--- a/clients/project-diagnostics/cache.ts
+++ b/clients/project-diagnostics/cache.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { getProjectDataDir } from "../file-utils.js";
 import { writeFileAtomic } from "../atomic-write.js";
 import { readJsonCache } from "../json-cache-read.js";
-import { MTIME_DRIFT_TOLERANCE_MS } from "../blocker-freshness.js";
+import { freshnessFromMtime } from "../freshness.js";
 import type {
 	ProjectDiagnosticsDeltaReport,
 	ProjectDiagnosticsSnapshot,
@@ -104,15 +104,12 @@ export function reconcileProjectDiagnosticsSnapshot(
 		const cached = staleByFile.get(filePath);
 		if (cached !== undefined) return cached;
 		let stale: boolean;
-		try {
-			// MTIME_DRIFT_TOLERANCE_MS: a file scanned at scannedAt, or written
-			// within the tolerance window of the scan timestamp being captured,
-			// has mtime <= scannedAt + MTIME_DRIFT_TOLERANCE_MS.
-			stale =
-				fs.statSync(filePath).mtimeMs > scannedAtMs + MTIME_DRIFT_TOLERANCE_MS;
-		} catch {
-			stale = true; // deleted / unreadable → drop
-		}
+		const verdict = freshnessFromMtime({
+			mtimeMs: fs.statSync(filePath).mtimeMs,
+			referenceMs: scannedAtMs,
+		});
+		// Pre-kernel policy: an unreadable/missing file is stale (dropped).
+		stale = verdict.verdict !== "fresh";
 		staleByFile.set(filePath, stale);
 		return stale;
 	};

--- a/clients/project-diagnostics/cache.ts
+++ b/clients/project-diagnostics/cache.ts
@@ -104,8 +104,14 @@ export function reconcileProjectDiagnosticsSnapshot(
 		const cached = staleByFile.get(filePath);
 		if (cached !== undefined) return cached;
 		let stale: boolean;
+		let mtimeMs: number | undefined;
+		try {
+			mtimeMs = fs.statSync(filePath).mtimeMs;
+		} catch {
+			mtimeMs = undefined; // deleted / unreadable -> indeterminate -> drop
+		}
 		const verdict = freshnessFromMtime({
-			mtimeMs: fs.statSync(filePath).mtimeMs,
+			mtimeMs,
 			referenceMs: scannedAtMs,
 		});
 		// Pre-kernel policy: an unreadable/missing file is stale (dropped).

--- a/clients/widget-state.ts
+++ b/clients/widget-state.ts
@@ -9,10 +9,8 @@ import { visibleWidth } from "./deps/pi-tui.js";
 import { normalizeEphemeralMapKey, normalizeMapKey } from "./path-utils.js";
 import { fitLine } from "./tui-fit.js";
 import { WriteOrderingGuard } from "./write-ordering-guard.js";
-import {
-	collectForwardImportMtimes,
-	MTIME_DRIFT_TOLERANCE_MS,
-} from "./blocker-freshness.js";
+import { collectForwardImportMtimes } from "./blocker-freshness.js";
+import { freshnessFromMtime } from "./freshness.js";
 import { PAST_EOF_STALE_MARKER } from "./diagnostic-line-freshness.js";
 import { STALE_LINE_MARKER } from "./stale-marker.js";
 
@@ -878,7 +876,8 @@ export async function reconcileStaleWidgetFiles(): Promise<number> {
 			// under this gate, not from cross-test state. Same tolerance, same
 			// constant, for the same reason.
 			if (rec.allDiagnostics.length === 0) {
-				return mtimeMs > rec.touchedAt + MTIME_DRIFT_TOLERANCE_MS
+				return freshnessFromMtime({ mtimeMs, referenceMs: rec.touchedAt })
+					.verdict === "stale"
 					? { mapKey, action: "drop" as const }
 					: { mapKey, action: "keep" as const };
 			}
@@ -889,13 +888,13 @@ export async function reconcileStaleWidgetFiles(): Promise<number> {
 			// at dispatch/integration.ts). A missing per-entry stamp (a migrated
 			// pre-#1186 record) inherits the record's `touchedAt`. Tolerance matches
 			// the Windows host-clock skew rationale above.
-			const survivors = rec.allDiagnostics.filter(
-				(d) =>
-					!(
-						mtimeMs >
-						(d.observedAt ?? rec.touchedAt) + MTIME_DRIFT_TOLERANCE_MS
-					),
-			);
+			const survivors = rec.allDiagnostics.filter((d) => {
+				const v = freshnessFromMtime({
+					mtimeMs,
+					referenceMs: d.observedAt ?? rec.touchedAt,
+				});
+				return v.verdict !== "stale";
+			});
 			if (survivors.length === rec.allDiagnostics.length) {
 				return { mapKey, action: "keep" as const }; // nothing stale
 			}
@@ -1005,7 +1004,11 @@ export async function reconcileStaleWidgetDependencyBlockers(
 			// measured skew while staying far below the gap between real edits.
 			if (
 				importMtimes.some(
-					(im) => im.mtimeMs > baseline + MTIME_DRIFT_TOLERANCE_MS,
+					(im) =>
+						freshnessFromMtime({
+							mtimeMs: im.mtimeMs,
+							referenceMs: baseline,
+						}).verdict === "stale",
 				)
 			) {
 				d.stale = true;

--- a/tests/clients/freshness-sweep.test.ts
+++ b/tests/clients/freshness-sweep.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Registered-or-fail sweep for the freshness kernel (#1739).
+ *
+ * Every mtime-vs-reference-timestamp comparison in `clients/` must go
+ * through the kernel's comparator. A NEW out-of-kernel comparison fails
+ * here until it is either migrated or added to EXEMPT with a reason - the
+ * same ratchet shape as run-outcome-ratchet and the smoke-fixture guard.
+ *
+ * The needle matches the freshness SHAPE (`.mtimeMs` compared with > or >=
+ * against an identifier expression), not just the words: age-based checks
+ * (`Date.now() - mtime > TTL`) and max-selection comparisons
+ * (`mtime > best.mtimeMs`) are structurally different and listed as
+ * exemptions with reasons where they coexist in a file.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { toPosix } from "../../clients/path-utils.js";
+
+const REPO_ROOT = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+const CLIENTS_DIR = path.join(REPO_ROOT, "clients");
+const KERNEL_FILE = "freshness.ts";
+
+/** Files whose mtime comparisons are NOT reference-timestamp freshness. */
+const EXEMPT: Record<string, string> = {
+	"bounded-pid-file-lock.ts":
+		"age-based TTL staleness of a lock file (Date.now() - mtime), not comparison against a recorded scan/record timestamp",
+	"installer/index.ts":
+		"age-based maxAge expiry of a cached install probe, same TTL-not-freshness shape",
+	"lombok.ts":
+		"max-selection among candidates (find newest), no reference timestamp",
+	"read-guard.ts":
+		"session-start membership gate (mtime >= sessionStartMs) - different semantic than post-record drift",
+};
+
+describe("freshness kernel coverage (#1739)", () => {
+	it("kernel module exists", () => {
+		expect(fs.existsSync(path.join(CLIENTS_DIR, KERNEL_FILE))).toBe(true);
+	});
+
+	it("every mtime-comparison site uses the kernel or carries an exemption", () => {
+		const violations: string[] = [];
+		const walkDir = (dir: string): void => {
+			for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+				const full = path.join(dir, entry.name);
+				if (entry.isDirectory()) {
+					walkDir(full);
+					continue;
+				}
+				if (!entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts"))
+					continue;
+				// Relative to CLIENTS_DIR (not REPO_ROOT): keys in EXEMPT and
+				// the kernel-skip are clients/-relative by contract.
+				const rel = toPosix(path.relative(CLIENTS_DIR, full));
+				if (rel === KERNEL_FILE) continue;
+				const source = fs.readFileSync(full, "utf8");
+				// Freshness-shaped needle: `.mtimeMs > identifier` / `>=` where
+				// the right side is not obviously `best.`-style selection.
+				const hits = [
+					...source.matchAll(/\.mtimeMs\s*(?:>|>=)\s*(?!best\b)[A-Za-z_$]/g),
+				];
+				if (hits.length === 0) continue;
+				const base = path.basename(rel);
+				if (EXEMPT[rel] || EXEMPT[base]) continue;
+				violations.push(`${rel} (${hits.length} comparison[s])`);
+			}
+		};
+		walkDir(CLIENTS_DIR);
+		expect(
+			violations,
+			`out-of-kernel mtime comparisons found - migrate to clients/freshness.ts freshnessFromMtime(), or add an EXEMPT entry with a reason: ${violations.join(", ")}`,
+		).toEqual([]);
+	});
+
+	it("exemptions still exist on disk (no phantom rows)", () => {
+		const all: string[] = [];
+		const walkAll = (dir: string): void => {
+			for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+				const full = path.join(dir, entry.name);
+				if (entry.isDirectory()) walkAll(full);
+				else if (entry.name.endsWith(".ts")) all.push(entry.name);
+			}
+		};
+		walkAll(CLIENTS_DIR);
+		const names = new Set(all);
+		const phantom = Object.keys(EXEMPT).filter(
+			(name) => !names.has(path.basename(name)),
+		);
+		expect(phantom, "exempt files must exist").toEqual([]);
+	});
+});

--- a/tests/clients/freshness-sweep.test.ts
+++ b/tests/clients/freshness-sweep.test.ts
@@ -11,6 +11,11 @@
  * (`Date.now() - mtime > TTL`) and max-selection comparisons
  * (`mtime > best.mtimeMs`) are structurally different and listed as
  * exemptions with reasons where they coexist in a file.
+ *
+ * KNOWN MISSED SHAPES (accepted floor - the needle cannot see them):
+ * destructured comparisons without a dot (for (const { mtimeMs } of mtimes)
+ * if (mtimeMs > ref) - exactly master's detectDrift import-loop shape),
+ * reversed operand order (ref + TOL < x.mtimeMs), and aliased locals.
  */
 
 import * as fs from "node:fs";
@@ -32,7 +37,7 @@ const EXEMPT: Record<string, string> = {
 		"age-based TTL staleness of a lock file (Date.now() - mtime), not comparison against a recorded scan/record timestamp",
 	"installer/index.ts":
 		"age-based maxAge expiry of a cached install probe, same TTL-not-freshness shape",
-	"lombok.ts":
+	"lsp/lombok.ts":
 		"max-selection among candidates (find newest), no reference timestamp",
 	"read-guard.ts":
 		"session-start membership gate (mtime >= sessionStartMs) - different semantic than post-record drift",


### PR DESCRIPTION
Closes #1739 — the freshness kernel primitive that enables staleness-store consolidation.

## The kernel

`clients/freshness.ts` owns the single mtime-vs-reference comparison and drift tolerance that at least six stores had independently reimplemented (three carrying the identical #1710/#1711 tolerance defect):

- `freshnessFromMtime({mtimeMs, referenceMs})` → explicit verdict arms: `fresh` / `stale: modified-after-reference` / **`indeterminate: no-mtime-evidence`**. The indeterminate arm exists because callers legitimately differ on stat-failure policy (diagnostics cache drops; the drift detector skips) — the kernel shares the *comparison*, not the *policy*.
- `MTIME_DRIFT_TOLERANCE_MS` ownership moves here (50ms, #1710's measured Windows-skew evidence); `blocker-freshness.ts` re-exports for its existing importers.

## Migrated behavior-identically (148 existing tests green unchanged)

| Store | Notes |
| --- | --- |
| blocker-freshness `detectDrift` | own-file + forward-import mtimes; indeterminate → skip (unchanged) |
| advisory-provenance finding-path freshness | no-reference → live (preserved); stat-fail → missing (preserved) |
| project-diagnostics snapshot reconcile [#1711] | indeterminate → drop (preserved) |
| widget-state record gate | per-record touchedAt comparison |
| widget-state per-entry #1186 gate | per-entry observedAt comparison |
| widget-state dependency-drift #1631 gate | import-mtimes any-stale |
| lsp/workspace-diagnostics-cache deps | fail-closed on unreadable preserved via separate catch |

## Registered-or-fail sweep

`tests/clients/freshness-sweep.test.ts`: every `.mtimeMs > identifier` comparison in `clients/` must carry a descriptor or exemption with a reason. Red-first: written first against the unmigrated tree, it listed all six sites before migration.

Exempted with reasons: age-based TTL checks (`bounded-pid-file-lock`, `installer/index.ts`) are expiry-not-freshness; `lombok.ts` is max-selection; `read-guard.ts` is a session-start membership gate.

## What this enables next

The #1993 render-side fix can reconcile per-entry through this kernel comparator, and the staleness-store umbrella (#1892 direction) gets a single verdict vocabulary instead of per-store booleans.

Refs #1739, #1710, #1711, #1708, #1664, #1631, #1641, #1692, #1687