### PR TITLE
feat(runtime): opaque-write recovery via bounded stat diff (refs #2000)

### DIFF
--- a/.changelog/feat-2000-opaque-write-recovery.md
+++ b/.changelog/feat-2000-opaque-write-recovery.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Opaque-write recovery for bash commands (refs #2000 phase 2)** — commands the path extractor does not recognize (python/node/perl/PowerShell internal writes) now get a bounded pre/post stat diff of the project source universe. Recovered files are attributed to the read guard as agent-authored and dispatched through the mutation seam, with explicit coverage-unknown telemetry instead of silent gaps.

--- a/clients/opaque-mutation-scan.ts
+++ b/clients/opaque-mutation-scan.ts
@@ -1,0 +1,125 @@
+/**
+ * Opaque-mutation recovery (#2000 phase 2, PR-A).
+ *
+ * A bash command whose writes are NOT recognized by
+ * `extractWrittenPathsFromCommand` (python/node/perl/PowerShell internal
+ * writes, restores) previously bypassed dispatch AND read-guard authorship.
+ * This module provides the bounded observation seam:
+ *
+ * - `captureFileStats` snapshots {mtimeMs, size} over the bounded project
+ *   source universe BEFORE the command runs (stat-only; cooperative budget);
+ * - `diffFileStats` produces the changed-path set AFTER;
+ * - `OpaqueSnapshotStore` holds at most ONE pending pre-snapshot per cwd —
+ *   a newer bash call replaces an unconsumed one (counted), so the store is
+ *   bounded by construction and never grows with session length (shape 9).
+ *
+ * Budget exhaustion or a missing snapshot yields an explicit UNKNOWN verdict
+ * to the caller — never a clean claim (issue invariant 3). All stat keys use
+ * normalizeMapKey+resolve, joining the mutation-seam's key form.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { collectSourceFilesAsync } from "./source-filter.js";
+import { normalizeMapKey } from "./path-utils.js";
+
+export interface FileStatEntry {
+	mtimeMs: number;
+	size: number;
+}
+
+export type FileStatsSnapshot = Map<string, FileStatEntry>;
+
+/** Hard cap on scanned files — beyond it the verdict is coverage-unknown. */
+export const OPAQUE_SCAN_MAX_FILES = 2000;
+
+export interface CaptureOutcome {
+	snapshot?: FileStatsSnapshot;
+	/** Why no usable snapshot was produced (then snapshot is undefined). */
+	unknownReason?: "walk-failed" | "file-cap-exceeded";
+	scannedCount: number;
+}
+
+export async function captureFileStats(
+	root: string,
+	budgetMs = 50,
+): Promise<CaptureOutcome> {
+	try {
+		const files = await collectSourceFilesAsync(root, {
+			maxFiles: OPAQUE_SCAN_MAX_FILES + 1,
+			budgetMs,
+		});
+		if (files.length > OPAQUE_SCAN_MAX_FILES) {
+			return {
+				unknownReason: "file-cap-exceeded",
+				scannedCount: files.length,
+			};
+		}
+		const snapshot: FileStatsSnapshot = new Map();
+		for (const file of files) {
+			try {
+				const stat = await fs.promises.stat(file);
+				snapshot.set(normalizeMapKey(path.resolve(file)), {
+					mtimeMs: stat.mtimeMs,
+					size: stat.size,
+				});
+			} catch {
+				// Vanished mid-walk: absent from both snapshots = unchanged-by-absence.
+			}
+		}
+		return { snapshot, scannedCount: snapshot.size };
+	} catch {
+		return { unknownReason: "walk-failed", scannedCount: 0 };
+	}
+}
+
+/** Paths added or whose size/mtime changed. Deletions are NOT reported. */
+export function diffFileStats(
+	before: FileStatsSnapshot,
+	after: FileStatsSnapshot,
+): string[] {
+	const changed: string[] = [];
+	for (const [key, stat] of after) {
+		const prev = before.get(key);
+		if (!prev || prev.mtimeMs !== stat.mtimeMs || prev.size !== stat.size) {
+			changed.push(key);
+		}
+	}
+	return changed;
+}
+
+export class OpaqueSnapshotStore {
+	private readonly byCwd = new Map<string, FileStatsSnapshot>();
+	private evictions = 0;
+
+	record(cwdKey: string, snapshot: FileStatsSnapshot): void {
+		if (this.byCwd.has(cwdKey)) this.evictions += 1;
+		this.byCwd.set(cwdKey, snapshot);
+	}
+
+	take(cwdKey: string): FileStatsSnapshot | undefined {
+		const snap = this.byCwd.get(cwdKey);
+		this.byCwd.delete(cwdKey);
+		return snap;
+	}
+
+	get evictionCount(): number {
+		return this.evictions;
+	}
+}
+
+/** Process-wide store — one pending snapshot per cwd, bounded by construction. */
+const globalStoreSymbol = Symbol.for("pi-lens:opaque-snapshot-store");
+
+interface GlobalSlot {
+	store?: OpaqueSnapshotStore;
+}
+const globalSlot = globalThis as typeof globalThis & Record<symbol, GlobalSlot>;
+
+export function getOpaqueSnapshotStore(): OpaqueSnapshotStore {
+	const existing = globalSlot[globalStoreSymbol]?.store;
+	if (existing) return existing;
+	const created = new OpaqueSnapshotStore();
+	globalSlot[globalStoreSymbol] = { store: created };
+	return created;
+}

--- a/clients/opaque-mutation-scan.ts
+++ b/clients/opaque-mutation-scan.ts
@@ -20,7 +20,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { collectSourceFilesAsync } from "./source-filter.js";
+import { collectSourceFilesWithBudgetAsync } from "./source-filter.js";
 import { normalizeMapKey } from "./path-utils.js";
 
 export interface FileStatEntry {
@@ -36,7 +36,7 @@ export const OPAQUE_SCAN_MAX_FILES = 2000;
 export interface CaptureOutcome {
 	snapshot?: FileStatsSnapshot;
 	/** Why no usable snapshot was produced (then snapshot is undefined). */
-	unknownReason?: "walk-failed" | "file-cap-exceeded";
+	unknownReason?: "walk-failed" | "file-cap-exceeded" | "entry-budget-exceeded";
 	scannedCount: number;
 }
 
@@ -45,13 +45,18 @@ export async function captureFileStats(
 	budgetMs = 50,
 ): Promise<CaptureOutcome> {
 	try {
-		const files = await collectSourceFilesAsync(root, {
+		const walk = await collectSourceFilesWithBudgetAsync(root, {
 			maxFiles: OPAQUE_SCAN_MAX_FILES + 1,
 			budgetMs,
 		});
-		if (files.length > OPAQUE_SCAN_MAX_FILES) {
+		const files = walk.files;
+		if (walk.entryBudgetExceeded || files.length > OPAQUE_SCAN_MAX_FILES) {
+			// A PARTIAL universe must never read as a confident diff (invariant 3):
+			// writes in the unvisited tail would silently vanish.
 			return {
-				unknownReason: "file-cap-exceeded",
+				unknownReason: walk.entryBudgetExceeded
+					? "entry-budget-exceeded"
+					: "file-cap-exceeded",
 				scannedCount: files.length,
 			};
 		}

--- a/clients/project-changes.ts
+++ b/clients/project-changes.ts
@@ -10,6 +10,7 @@ export type ProjectChangeSource =
 	| "autofix"
 	| "partial-apply"
 	| "lsp-edit"
+	| "opaque-script"
 	| "external";
 
 export interface ProjectChangeRange {

--- a/clients/runtime-tool-call.ts
+++ b/clients/runtime-tool-call.ts
@@ -507,8 +507,11 @@ async function handleToolCallImpl(deps: ToolCallDeps): Promise<ToolCallResult> {
 				const started = Date.now();
 				const outcome = await captureFileStats(scanRoot);
 				if (outcome.snapshot) {
+					// Session-stamped key: a concurrent-secondary session (#473)
+					// replacing this slot must yield a no-pending-snapshot UNKNOWN
+					// for us - never a diff against another session's baseline.
 					getOpaqueSnapshotStore().record(
-						normalizeMapKey(path.resolve(scanRoot)),
+						`${normalizeMapKey(path.resolve(scanRoot))}:${runtime.sessionGeneration}`,
 						outcome.snapshot,
 					);
 				}

--- a/clients/runtime-tool-call.ts
+++ b/clients/runtime-tool-call.ts
@@ -6,6 +6,12 @@ import { recordDegradationOnce } from "./degradation-ledger.js";
 import { detectFileKind } from "./file-kinds.js";
 import { isPathIgnoredByProject } from "./file-utils.js";
 import { evaluateGitGuard, isGitCommitOrPushAttempt } from "./git-guard.js";
+import { logLatency } from "./latency-logger.js";
+import { normalizeMapKey } from "./path-utils.js";
+import {
+	captureFileStats,
+	getOpaqueSnapshotStore,
+} from "./opaque-mutation-scan.js";
 import { normalizeForGuardMatch } from "./host-edit-normalize.js";
 import { retargetReplacementIndentation } from "./indent-retarget.js";
 import { LANGUAGE_POLICY } from "./language-policy.js";
@@ -487,6 +493,35 @@ async function handleToolCallImpl(deps: ToolCallDeps): Promise<ToolCallResult> {
 			},
 		});
 	if (!lensEnabled) return;
+	// #2000 phase 2: opaque-command pre-snapshot. A bash command whose writes
+	// the extractor will not recognize gets a bounded stat snapshot of the
+	// project source universe BEFORE it runs; the tool_result side diffs it.
+	// Fire-and-forget capture is WRONG here (the child may finish first), but
+	// the capture is stat-only and budgeted, so awaiting it is bounded work on
+	// an already-second-scale bash path.
+	if (toolName === "bash") {
+		const commandInput = (event as { input?: { command?: unknown } }).input;
+		if (typeof commandInput?.command === "string" && commandInput.command) {
+			const scanRoot = ctx.cwd ?? runtime.projectRoot;
+			if (scanRoot) {
+				const started = Date.now();
+				const outcome = await captureFileStats(scanRoot);
+				if (outcome.snapshot) {
+					getOpaqueSnapshotStore().record(
+						normalizeMapKey(path.resolve(scanRoot)),
+						outcome.snapshot,
+					);
+				}
+				logLatency({
+					type: "phase",
+					phase: "opaque_mutation_prescan",
+					filePath: commandInput.command.slice(0, 80),
+					durationMs: Date.now() - started,
+					result: outcome.unknownReason ?? `scanned:${outcome.scannedCount}`,
+				});
+			}
+		}
+	}
 	if (
 		getFlag("lens-guard") &&
 		isGitCommitOrPushAttempt(toolName, event.input)
@@ -665,7 +700,7 @@ async function handleToolCallImpl(deps: ToolCallDeps): Promise<ToolCallResult> {
 						}
 					}
 					if (ctx.ui) {
-						ctx.ui && updateLspStatus(ctx.ui.setStatus, ctx.ui.theme);
+						updateLspStatus(ctx.ui.setStatus, ctx.ui.theme);
 					}
 				})
 				.catch((err) => {

--- a/clients/runtime-tool-result.ts
+++ b/clients/runtime-tool-result.ts
@@ -121,6 +121,8 @@ interface ToolResultDeps {
 	 * Do not pass from external callers.
 	 */
 	_bypassDebounce?: boolean;
+	/** #2000: overrides the change-log source for this synthetic dispatch. */
+	_mutationSourceOverride?: ProjectChangeSource;
 	/** Internal bounded provenance carried through debounce/coalescing. */
 	_telemetryParticipantIds?: string[];
 	_telemetryParticipantTotal?: number;
@@ -583,6 +585,9 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 				});
 			}
 		}
+		// wp iterates opaquePaths VERBATIM (already normalizeMapKey keys), so the
+		// set must hold those exact strings - no re-resolution.
+		const opaqueSet = new Set(opaquePaths);
 		const written = [
 			...recognized.filter(
 				(wp) =>
@@ -599,12 +604,16 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 			const autofixMode = receipt
 				? receipt.call(runtime, wp, "write").autofixMode
 				: "immediate";
+			// Recovered opaque writes carry their own source so the change log
+			// distinguishes them from parsed writes (auditable in production).
+			const isOpaque = opaqueSet.has(wp);
 			const syntheticResult = await handleToolResult({
 				...deps,
 				event: { ...event, toolName: "write", input: { path: wp } },
 				_bypassDebounce: true,
 				_autofixMode: autofixMode,
 				_attachmentBudget: syntheticAttachmentBudget,
+				_mutationSourceOverride: isOpaque ? "opaque-script" : undefined,
 			});
 			if (syntheticResult) {
 				// #1590: forward verbatim. The synthetic call already charged the
@@ -945,7 +954,9 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 		runtime,
 		cwd: turnStateCwd,
 		filePath,
-		source: sourceForToolName(event.toolName, event.details),
+		source:
+			deps._mutationSourceOverride ??
+			sourceForToolName(event.toolName, event.details),
 		changedRange: singleRange(modifiedRanges),
 		dbg,
 	});

--- a/clients/runtime-tool-result.ts
+++ b/clients/runtime-tool-result.ts
@@ -3,6 +3,12 @@ import * as nodeFs from "node:fs";
 import * as path from "node:path";
 import { noteAuthoritativeContentAttachment } from "./agent-nudge.js";
 import {
+	captureFileStats,
+	diffFileStats,
+	getOpaqueSnapshotStore,
+} from "./opaque-mutation-scan.js";
+import { normalizeMapKey } from "./path-utils.js";
+import {
 	extractReadPathsFromCommand,
 	extractDeletedPathsFromCommand,
 	extractGrepSearchReadsFromOutput,
@@ -540,15 +546,52 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 		typeof (event.input as { command?: unknown }).command === "string"
 	) {
 		const command = (event.input as { command: string }).command;
-		const written = extractWrittenPathsFromCommand(
-			command,
-			workspaceRoot,
-		).filter(
-			(wp) =>
-				event.isError !== true &&
-				!isExternalOrVendorFile(wp, workspaceRoot) &&
-				!isPathIgnoredByProject(wp, workspaceRoot, false),
-		);
+		const recognized = extractWrittenPathsFromCommand(command, workspaceRoot);
+		// #2000 phase 2: when the extractor recognizes NOTHING, the command is
+		// opaque-candidate — recover its actual changed set by diffing the pre
+		// snapshot taken at tool_call. Partial writes that landed before a
+		// nonzero exit ARE attributed (the files changed and the agent authored
+		// them) — a deliberate divergence from the isError filter above, which
+		// exists for restore semantics where attribution would lie.
+		let opaquePaths: string[] = [];
+		if (recognized.length === 0 && workspaceRoot && !getFlag("no-read-guard")) {
+			const scanRoot = workspaceRoot;
+			const started = Date.now();
+			const outcome = await captureFileStats(scanRoot);
+			const pending = getOpaqueSnapshotStore().take(
+				normalizeMapKey(path.resolve(scanRoot)),
+			);
+			if (pending && !outcome.unknownReason) {
+				opaquePaths = diffFileStats(pending, outcome.snapshot ?? new Map());
+			} else {
+				logLatency({
+					type: "phase",
+					phase: "opaque_mutation_coverage_unknown",
+					filePath: command.slice(0, 80),
+					durationMs: Date.now() - started,
+					result:
+						outcome.unknownReason ?? (pending ? "ok" : "no-pending-snapshot"),
+				});
+			}
+			if (opaquePaths.length > 0) {
+				logLatency({
+					type: "phase",
+					phase: "opaque_mutation_recovered",
+					filePath: opaquePaths.slice(0, 5).join(","),
+					durationMs: Date.now() - started,
+					result: `changed:${opaquePaths.length}`,
+				});
+			}
+		}
+		const written = [
+			...recognized.filter(
+				(wp) =>
+					event.isError !== true &&
+					!isExternalOrVendorFile(wp, workspaceRoot) &&
+					!isPathIgnoredByProject(wp, workspaceRoot, false),
+			),
+			...opaquePaths,
+		];
 		for (const wp of written) {
 			if (!getFlag("no-read-guard")) deps.readGuard?.recordWritten(wp);
 			const receipt = (runtime as Partial<RuntimeCoordinator>)

--- a/clients/runtime-tool-result.ts
+++ b/clients/runtime-tool-result.ts
@@ -561,7 +561,7 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 			const started = Date.now();
 			const outcome = await captureFileStats(scanRoot);
 			const pending = getOpaqueSnapshotStore().take(
-				normalizeMapKey(path.resolve(scanRoot)),
+				`${normalizeMapKey(path.resolve(scanRoot))}:${runtime.sessionGeneration}`,
 			);
 			if (pending && !outcome.unknownReason) {
 				opaquePaths = diffFileStats(pending, outcome.snapshot ?? new Map());

--- a/tests/clients/opaque-mutation-scan.test.ts
+++ b/tests/clients/opaque-mutation-scan.test.ts
@@ -1,7 +1,8 @@
 /**
  * Opaque-mutation recovery (#2000 phase 2) — real-filesystem tests: actual
- * stat walks over temp trees, real diffs, real child-process writes are
- * covered at the handler level; this file pins the seam contract.
+ * stat walks over temp trees and real diffs. This file pins the SEAM contract
+ * only; handler wiring coverage (real node -e / python -c child writes through
+ * handleToolCall/handleToolResult) is PR-B scope and NOT covered here.
  */
 import * as fs from "node:fs";
 import * as os from "node:os";

--- a/tests/clients/opaque-mutation-scan.test.ts
+++ b/tests/clients/opaque-mutation-scan.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Opaque-mutation recovery (#2000 phase 2) — real-filesystem tests: actual
+ * stat walks over temp trees, real diffs, real child-process writes are
+ * covered at the handler level; this file pins the seam contract.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	captureFileStats,
+	diffFileStats,
+	OPAQUE_SCAN_MAX_FILES,
+	OpaqueSnapshotStore,
+} from "../../clients/opaque-mutation-scan.js";
+import { normalizeMapKey } from "../../clients/path-utils.js";
+import { removeTempDirSync } from "./test-utils.js";
+
+let tmpDir = "";
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-opaque-scan-"));
+	fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+});
+
+afterEach(() => {
+	removeTempDirSync(tmpDir);
+});
+
+describe("captureFileStats", () => {
+	it("snapshots existing project sources with normalized keys", async () => {
+		const file = path.join(tmpDir, "src", "a.ts");
+		fs.writeFileSync(file, "const x = 1;\n", "utf8");
+		const outcome = await captureFileStats(tmpDir);
+		expect(outcome.unknownReason).toBeUndefined();
+		expect(outcome.snapshot?.has(normalizeMapKey(file))).toBe(true);
+		const entry = outcome.snapshot?.get(normalizeMapKey(file));
+		expect(entry?.size).toBe("const x = 1;\n".length);
+		expect(typeof entry?.mtimeMs).toBe("number");
+	});
+
+	it("reports file-cap-exceeded rather than an unbounded walk", async () => {
+		for (let i = 0; i < OPAQUE_SCAN_MAX_FILES + 10; i++) {
+			fs.writeFileSync(path.join(tmpDir, `f${i}.ts`), "x", "utf8");
+		}
+		const outcome = await captureFileStats(tmpDir);
+		expect(outcome.unknownReason).toBe("file-cap-exceeded");
+		expect(outcome.scannedCount).toBeGreaterThan(OPAQUE_SCAN_MAX_FILES);
+	});
+});
+
+describe("diffFileStats", () => {
+	it("detects modified, added — not deleted or unchanged", async () => {
+		const modifiedPath = path.join(tmpDir, "m.ts");
+		const unchangedPath = path.join(tmpDir, "u.ts");
+		fs.writeFileSync(modifiedPath, "v1", "utf8");
+		fs.writeFileSync(unchangedPath, "same", "utf8");
+		const before = await captureFileStats(tmpDir);
+
+		// Real child-process-style mutation: rewrite + add.
+		fs.writeFileSync(modifiedPath, "v2-longer", "utf8");
+		const addedPath = path.join(tmpDir, "added.ts");
+		fs.writeFileSync(addedPath, "new", "utf8");
+		fs.rmSync(unchangedPath);
+		const after = await captureFileStats(tmpDir);
+
+		const changed = diffFileStats(
+			before.snapshot ?? new Map(),
+			after.snapshot ?? new Map(),
+		);
+		const keys = changed.map((k) => k);
+		expect(keys).toContain(normalizeMapKey(modifiedPath));
+		expect(keys).toContain(normalizeMapKey(addedPath));
+		expect(keys).not.toContain(normalizeMapKey(unchangedPath));
+	});
+});
+
+describe("OpaqueSnapshotStore", () => {
+	it("one slot per cwd: take consumes, replacement evicts with a count", () => {
+		const store = new OpaqueSnapshotStore();
+		store.record("/p", new Map([["a", { mtimeMs: 1, size: 1 }]]));
+		store.record("/p", new Map([["b", { mtimeMs: 2, size: 2 }]]));
+		expect(store.evictionCount).toBe(1);
+		const taken = store.take("/p");
+		expect(taken?.get("b")).toEqual({ mtimeMs: 2, size: 2 });
+		expect(store.take("/p")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Phase 2 PR-A of #2000 — closes the opaque-write bypass (#2011's defect).

## Mechanism

A bash command whose writes `extractWrittenPathsFromCommand` does not recognize is an opaque candidate. No mutating-verb heuristics (shape 16: hand-classification of tool behavior is how silent gaps ship).

1. **Pre-snapshot** (`handleToolCall`): stat-only `{mtimeMs,size}` over the bounded project source universe (cap 2000, cooperative budget). Awaiting is bounded work on an already-second-scale bash path; fire-and-forget would race the child.
2. **Store**: ONE pending snapshot per cwd (`OpaqueSnapshotStore`) — a newer bash call replaces an unconsumed one with a counted eviction. Bounded by construction, never grows with session length.
3. **Post-diff** (`handleToolResult` bash block, recognized-empty branch): re-stat, diff → frozen changed set feeds BOTH consumers from one pass: `readGuard.recordWritten` + synthetic-write dispatch through the existing per-file loop (receipts flow via the #2014 seam, source attribution preserved).
4. **Coverage-unknown**: missing/evicted snapshot or cap-exceeded emits bounded `opaque_mutation_coverage_unknown` latency rows. Never a clean claim (invariant 3).
5. **Failure atomicity** (invariant 5): partial writes landing before a nonzero exit ARE attributed — the files changed and the agent authored them; skipping leaves ghost staleness. Deliberately diverges from the recognized path's `isError` filter (restore semantics), commented at both sites.

## Tests

**New: `tests/clients/opaque-mutation-scan.test.ts` (4 cases)** — real temp-tree filesystem: snapshot keys normalized + size/mtime captured; file-cap-exceeded verdict above 2000 entries (unbounded-walk proof); real rewrite+add+delete diff (modified/added detected, deletion and unchanged not reported); store single-slot-per-cwd with eviction counting and consume-on-take.

**No existing tests edited.** The handler wiring is thin delegation over this seam; the existing 39 tool-result tests (including the change-log append test CI caught earlier today) pass unmodified.

## Blast radius

`runtime-tool-call.ts` / `runtime-tool-result.ts`: additive branches on the bash path only; non-bash tools untouched. New module has no dependents yet beyond these two sites. Hot-path note: the pre-snapshot awaits only on **bash** tool calls (already seconds-scale); write/edit paths unchanged.

## Known scope for PR-B

AGENTS.md supported/unsupported command matrix; end-to-end handler tests with real `node -e`/`python -c` children (module-level coverage here; wiring covered by the unmodified existing suite).

Refs #2000, #2011