### PR TITLE
feat(runtime): git-first opaque recovery, no universe cap (refs #2000)

### DIFF
--- a/.changelog/feat-2000-opaque-git-recovery.md
+++ b/.changelog/feat-2000-opaque-git-recovery.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Opaque-write recovery goes git-first (refs #2000)** — inside a git worktree the pre side records only a timestamp and `git status --porcelain` plus an mtime window answers what changed, with no file-universe cap: recovery now works on any repo size, including large monorepos where the stat-walk previously degraded every command to coverage-unknown. The bounded stat-diff path remains for small non-git trees.

--- a/clients/opaque-mutation-scan.ts
+++ b/clients/opaque-mutation-scan.ts
@@ -21,10 +21,16 @@
  * never a clean claim (issue invariant 3). All path keys use
  * normalizeMapKey+resolve, joining the mutation-seam's key form.
  *
- * KNOWN LIMITATION (shape 6): identity is mtime-window (+size for the
- * stat-diff path). A rewrite landing in the same mtime tick AND the same
- * byte length is undetected on the stat path; the git path detects any
- * content change regardless. A content-hash confirm is future scope.
+ * KNOWN LIMITATIONS:
+ * - shape 6: stat-diff identity is size+mtimeMs - a rewrite landing in the
+ *   same mtime tick AND the same byte length is undetected there. A content
+ *   hash confirm is future scope.
+ * - INVARIANT 4 (per issue): ignored/vendor paths are EXCLUDED. Under the
+ *   git strategy this means writes landing ONLY in .gitignore'd locations
+ *   are never reported - an all-ignored write set reads as an empty (clean)
+ *   recovery BY SPEC, not by oversight. Codegen targeting dist/build-style
+ *   outputs should use explicit redirect destinations so the extractor
+ *   recognizes them.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -239,7 +245,7 @@ export async function recoverOpaqueChangesViaGit(
 		if (token.length < 4 || token[2] !== " ") continue;
 		const status = token.slice(0, 2);
 		const relPath = token.slice(3);
-		if (status.includes("R")) skipNext = true;
+		if (status.includes("R") || status.includes("C")) skipNext = true;
 		const abs = path.resolve(root, relPath);
 		try {
 			const stat = await fs.promises.stat(abs);

--- a/clients/opaque-mutation-scan.ts
+++ b/clients/opaque-mutation-scan.ts
@@ -31,6 +31,7 @@ import * as path from "node:path";
 
 import { collectSourceFilesWithBudgetAsync } from "./source-filter.js";
 import { normalizeMapKey } from "./path-utils.js";
+import { freshnessFromMtime } from "./freshness.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
 
 export interface FileStatEntry {
@@ -139,6 +140,11 @@ export class OpaqueBaselineStore {
 	get evictionCount(): number {
 		return this.evictions;
 	}
+
+	/** Session-boundary clear - unconsumed baselines are unreachable after reset. */
+	takeAllForTest(): void {
+		this.byCwd.clear();
+	}
 }
 
 const globalStoreSymbol = Symbol.for("pi-lens:opaque-snapshot-store");
@@ -157,6 +163,17 @@ export function getOpaqueBaselineStore(): OpaqueBaselineStore {
 }
 
 const gitRepoMemo = new Map<string, boolean>();
+
+/**
+ * Session-boundary clear (#1635): unconsumed pending baselines are keyed by
+ * cwd:generation, so entries from a finished session are unreachable; and a
+ * directory that was not a worktree last session may be one now. Without this
+ * reset both leak and mis-answer forever.
+ */
+export function resetOpaqueMutationState(): void {
+	getOpaqueBaselineStore().takeAllForTest();
+	gitRepoMemo.clear();
+}
 
 /** Cached git-worktree probe (repos don't stop being git mid-session). */
 export async function isGitWorktree(root: string): Promise<boolean> {
@@ -226,7 +243,13 @@ export async function recoverOpaqueChangesViaGit(
 		const abs = path.resolve(root, relPath);
 		try {
 			const stat = await fs.promises.stat(abs);
-			if (stat.isFile() && stat.mtimeMs >= floorMs) {
+			if (
+				stat.isFile() &&
+				freshnessFromMtime({ mtimeMs: stat.mtimeMs, referenceMs: floorMs })
+					.verdict === "stale"
+			) {
+				// Kernel "stale" = modified AFTER the window floor - exactly the
+				// writes this command may have authored.
 				paths.push(normalizeMapKey(abs));
 			}
 		} catch {

--- a/clients/opaque-mutation-scan.ts
+++ b/clients/opaque-mutation-scan.ts
@@ -1,27 +1,37 @@
 /**
- * Opaque-mutation recovery (#2000 phase 2, PR-A).
+ * Opaque-mutation recovery (#2000 phase 2).
  *
  * A bash command whose writes are NOT recognized by
  * `extractWrittenPathsFromCommand` (python/node/perl/PowerShell internal
  * writes, restores) previously bypassed dispatch AND read-guard authorship.
- * This module provides the bounded observation seam:
+ * This module observes what such a command actually changed.
  *
- * - `captureFileStats` snapshots {mtimeMs, size} over the bounded project
- *   source universe BEFORE the command runs (stat-only; cooperative budget);
- * - `diffFileStats` produces the changed-path set AFTER;
- * - `OpaqueSnapshotStore` holds at most ONE pending pre-snapshot per cwd —
- *   a newer bash call replaces an unconsumed one (counted), so the store is
- *   bounded by construction and never grows with session length (shape 9).
+ * GIT-FIRST STRATEGY: inside a git worktree the pre side records only a
+ * TIMESTAMP; the post side asks `git status --porcelain` which files are
+ * dirty and keeps those whose mtime falls inside the command's window.
+ * This has NO file-universe bound — it works identically on a 10-file site
+ * and a 5000-file monorepo, and content-identical rewrites are correctly
+ * NOT reported (a false positive the pure stat-diff design produced).
  *
- * Budget exhaustion or a missing snapshot yields an explicit UNKNOWN verdict
- * to the caller — never a clean claim (issue invariant 3). All stat keys use
+ * NON-GIT FALLBACK: outside git the pre side takes a bounded stat snapshot
+ * (cap enforced, cooperative budget) and the post side diffs it — the
+ * original design, kept honestly scoped to small non-git trees.
+ *
+ * Every failure mode yields an explicit UNKNOWN verdict to the caller —
+ * never a clean claim (issue invariant 3). All path keys use
  * normalizeMapKey+resolve, joining the mutation-seam's key form.
+ *
+ * KNOWN LIMITATION (shape 6): identity is mtime-window (+size for the
+ * stat-diff path). A rewrite landing in the same mtime tick AND the same
+ * byte length is undetected on the stat path; the git path detects any
+ * content change regardless. A content-hash confirm is future scope.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { collectSourceFilesWithBudgetAsync } from "./source-filter.js";
 import { normalizeMapKey } from "./path-utils.js";
+import { safeSpawnAsync } from "./safe-spawn.js";
 
 export interface FileStatEntry {
 	mtimeMs: number;
@@ -33,11 +43,29 @@ export type FileStatsSnapshot = Map<string, FileStatEntry>;
 /** Hard cap on scanned files — beyond it the verdict is coverage-unknown. */
 export const OPAQUE_SCAN_MAX_FILES = 2000;
 
+/** How far before recorded start an earlier write may still be attributed. */
+export const OPAQUE_MTIME_TOLERANCE_MS = 150;
+
+export type OpaqueUnknownReason =
+	| "walk-failed"
+	| "file-cap-exceeded"
+	| "entry-budget-exceeded"
+	| "no-git"
+	| "git-failed"
+	| "no-pending-snapshot";
+
 export interface CaptureOutcome {
 	snapshot?: FileStatsSnapshot;
-	/** Why no usable snapshot was produced (then snapshot is undefined). */
-	unknownReason?: "walk-failed" | "file-cap-exceeded" | "entry-budget-exceeded";
+	unknownReason?: OpaqueUnknownReason;
 	scannedCount: number;
+}
+
+/** The pending pre-side state: either a timestamp (git) or stats (fallback). */
+export interface PendingOpaqueBaseline {
+	startedAt: number;
+	strategy: "git" | "stat-diff";
+	stats?: FileStatsSnapshot;
+	statsUnknownReason?: OpaqueUnknownReason;
 }
 
 export async function captureFileStats(
@@ -51,8 +79,8 @@ export async function captureFileStats(
 		});
 		const files = walk.files;
 		if (walk.entryBudgetExceeded || files.length > OPAQUE_SCAN_MAX_FILES) {
-			// A PARTIAL universe must never read as a confident diff (invariant 3):
-			// writes in the unvisited tail would silently vanish.
+			// A PARTIAL universe must never read as a confident diff (invariant
+			// 3): writes in the unvisited tail would silently vanish.
 			return {
 				unknownReason: walk.entryBudgetExceeded
 					? "entry-budget-exceeded"
@@ -93,19 +121,19 @@ export function diffFileStats(
 	return changed;
 }
 
-export class OpaqueSnapshotStore {
-	private readonly byCwd = new Map<string, FileStatsSnapshot>();
+export class OpaqueBaselineStore {
+	private readonly byCwd = new Map<string, PendingOpaqueBaseline>();
 	private evictions = 0;
 
-	record(cwdKey: string, snapshot: FileStatsSnapshot): void {
+	record(cwdKey: string, baseline: PendingOpaqueBaseline): void {
 		if (this.byCwd.has(cwdKey)) this.evictions += 1;
-		this.byCwd.set(cwdKey, snapshot);
+		this.byCwd.set(cwdKey, baseline);
 	}
 
-	take(cwdKey: string): FileStatsSnapshot | undefined {
-		const snap = this.byCwd.get(cwdKey);
+	take(cwdKey: string): PendingOpaqueBaseline | undefined {
+		const baseline = this.byCwd.get(cwdKey);
 		this.byCwd.delete(cwdKey);
-		return snap;
+		return baseline;
 	}
 
 	get evictionCount(): number {
@@ -113,18 +141,97 @@ export class OpaqueSnapshotStore {
 	}
 }
 
-/** Process-wide store — one pending snapshot per cwd, bounded by construction. */
 const globalStoreSymbol = Symbol.for("pi-lens:opaque-snapshot-store");
 
 interface GlobalSlot {
-	store?: OpaqueSnapshotStore;
+	store?: OpaqueBaselineStore;
 }
 const globalSlot = globalThis as typeof globalThis & Record<symbol, GlobalSlot>;
 
-export function getOpaqueSnapshotStore(): OpaqueSnapshotStore {
+export function getOpaqueBaselineStore(): OpaqueBaselineStore {
 	const existing = globalSlot[globalStoreSymbol]?.store;
 	if (existing) return existing;
-	const created = new OpaqueSnapshotStore();
+	const created = new OpaqueBaselineStore();
 	globalSlot[globalStoreSymbol] = { store: created };
 	return created;
+}
+
+const gitRepoMemo = new Map<string, boolean>();
+
+/** Cached git-worktree probe (repos don't stop being git mid-session). */
+export async function isGitWorktree(root: string): Promise<boolean> {
+	const key = normalizeMapKey(path.resolve(root));
+	const memo = gitRepoMemo.get(key);
+	if (memo !== undefined) return memo;
+	const result = await safeSpawnAsync(
+		"git",
+		["rev-parse", "--is-inside-work-tree"],
+		{ cwd: root, timeout: 3000 },
+	);
+	const isRepo =
+		!result.error && result.status === 0 && result.stdout?.trim() === "true";
+	gitRepoMemo.set(key, isRepo === true);
+	return isRepo === true;
+}
+
+export function _resetGitWorktreeMemoForTests(): void {
+	gitRepoMemo.clear();
+}
+
+export interface GitRecoveryOutcome {
+	verdict: "recovered" | "unknown";
+	paths: string[];
+	unknownReason?: OpaqueUnknownReason;
+	scannedCount: number;
+}
+
+/**
+ * Files dirty in the working tree whose mtime falls inside
+ * [startedAt - tolerance, now]. Porcelain -z parsing handles renames
+ * (the NEW path is reported; the old path token is skipped).
+ */
+export async function recoverOpaqueChangesViaGit(
+	root: string,
+	startedAt: number,
+): Promise<GitRecoveryOutcome> {
+	const result = await safeSpawnAsync(
+		"git",
+		["status", "--porcelain", "-z", "--untracked-files=all"],
+		{ cwd: root, timeout: 5000 },
+	);
+	if (result.error || (result.status !== 0 && result.status !== null)) {
+		return {
+			verdict: "unknown",
+			paths: [],
+			unknownReason: "git-failed",
+			scannedCount: 0,
+		};
+	}
+	const floorMs = startedAt - OPAQUE_MTIME_TOLERANCE_MS;
+	const raw = result.stdout ?? "";
+	const tokens = raw.split("\0");
+	const paths: string[] = [];
+	let skipNext = false; // rename's OLD path follows its NEW path
+	for (const token of tokens) {
+		if (!token) continue;
+		if (skipNext) {
+			skipNext = false;
+			continue;
+		}
+		// Each entry: two status chars, one space, then the path.
+		if (token.length < 4 || token[2] !== " ") continue;
+		const status = token.slice(0, 2);
+		const relPath = token.slice(3);
+		if (status.includes("R")) skipNext = true;
+		const abs = path.resolve(root, relPath);
+		try {
+			const stat = await fs.promises.stat(abs);
+			if (stat.isFile() && stat.mtimeMs >= floorMs) {
+				paths.push(normalizeMapKey(abs));
+			}
+		} catch {
+			// Deleted or vanished: deletions are deliberately unreported.
+		}
+	}
+	return { verdict: "recovered", paths, scannedCount: paths.length };
 }

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -110,6 +110,7 @@ import { TrivyClient, type TrivyResult } from "./trivy-client.js";
 import { isWarmAttached } from "./warm-attach.js";
 import { setSessionLanguages } from "./widget-state.js";
 import { logWordIndex } from "./word-index-logger.js";
+import { resetOpaqueMutationState } from "./opaque-mutation-scan.js";
 import { resetWorkspaceTopology } from "./workspace-topology.js";
 import { resetZizmorTokenAvailability } from "./zizmor-config.js";
 import { resetSpawnTimeoutCooldowns } from "./spawn-timeout-cooldown.js";
@@ -2107,6 +2108,10 @@ export async function handleSessionStart(
 	// previously session-lived with no reset hook at all).
 	resetWorkspaceTopology();
 	clearTsconfigPathsCache();
+	// #2000: opaque-recovery baselines are keyed cwd:generation (unreachable
+	// after reset) and the git-worktree memo must re-probe after a session
+	// that may have seen a non-git dir become one.
+	resetOpaqueMutationState();
 	// #817/#1199: Windows command resolution is cached per (command, canonical
 	// effective child PATH/PATHEXT/cwd/per-drive provenance); drop it each
 	// session so environment changes (e.g.

--- a/clients/runtime-tool-call.ts
+++ b/clients/runtime-tool-call.ts
@@ -10,7 +10,9 @@ import { logLatency } from "./latency-logger.js";
 import { normalizeMapKey } from "./path-utils.js";
 import {
 	captureFileStats,
-	getOpaqueSnapshotStore,
+	getOpaqueBaselineStore,
+	isGitWorktree,
+	type PendingOpaqueBaseline,
 } from "./opaque-mutation-scan.js";
 import { normalizeForGuardMatch } from "./host-edit-normalize.js";
 import { retargetReplacementIndentation } from "./indent-retarget.js";
@@ -505,22 +507,40 @@ async function handleToolCallImpl(deps: ToolCallDeps): Promise<ToolCallResult> {
 			const scanRoot = ctx.cwd ?? runtime.projectRoot;
 			if (scanRoot) {
 				const started = Date.now();
-				const outcome = await captureFileStats(scanRoot);
-				if (outcome.snapshot) {
-					// Session-stamped key: a concurrent-secondary session (#473)
-					// replacing this slot must yield a no-pending-snapshot UNKNOWN
-					// for us - never a diff against another session's baseline.
-					getOpaqueSnapshotStore().record(
-						`${normalizeMapKey(path.resolve(scanRoot))}:${runtime.sessionGeneration}`,
-						outcome.snapshot,
-					);
+				const rootKey = `${normalizeMapKey(path.resolve(scanRoot))}:${runtime.sessionGeneration}`;
+				let baseline: PendingOpaqueBaseline;
+				let resultNote: string;
+				if (await isGitWorktree(scanRoot)) {
+					// Git-first: the timestamp IS the baseline; git answers what
+					// changed, at any repo size, with no file-universe cap.
+					baseline = { startedAt: started, strategy: "git" };
+					resultNote = "git";
+				} else {
+					const outcome = await captureFileStats(scanRoot);
+					baseline = outcome.snapshot
+						? {
+								startedAt: started,
+								strategy: "stat-diff",
+								stats: outcome.snapshot,
+							}
+						: {
+								startedAt: started,
+								strategy: "stat-diff",
+								statsUnknownReason: outcome.unknownReason ?? "walk-failed",
+							};
+					resultNote =
+						outcome.unknownReason ?? `scanned:${outcome.scannedCount}`;
 				}
+				// Session-stamped key: a concurrent-secondary session (#473)
+				// replacing this slot must yield a no-pending-snapshot UNKNOWN
+				// for us - never a diff against another session's baseline.
+				getOpaqueBaselineStore().record(rootKey, baseline);
 				logLatency({
 					type: "phase",
 					phase: "opaque_mutation_prescan",
 					filePath: commandInput.command.slice(0, 80),
 					durationMs: Date.now() - started,
-					result: outcome.unknownReason ?? `scanned:${outcome.scannedCount}`,
+					result: resultNote,
 				});
 			}
 		}

--- a/clients/runtime-tool-result.ts
+++ b/clients/runtime-tool-result.ts
@@ -5,7 +5,8 @@ import { noteAuthoritativeContentAttachment } from "./agent-nudge.js";
 import {
 	captureFileStats,
 	diffFileStats,
-	getOpaqueSnapshotStore,
+	getOpaqueBaselineStore,
+	recoverOpaqueChangesViaGit,
 } from "./opaque-mutation-scan.js";
 import { normalizeMapKey } from "./path-utils.js";
 import {
@@ -559,20 +560,47 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 		if (recognized.length === 0 && workspaceRoot && !getFlag("no-read-guard")) {
 			const scanRoot = workspaceRoot;
 			const started = Date.now();
-			const outcome = await captureFileStats(scanRoot);
-			const pending = getOpaqueSnapshotStore().take(
+			const pending = getOpaqueBaselineStore().take(
 				`${normalizeMapKey(path.resolve(scanRoot))}:${runtime.sessionGeneration}`,
 			);
-			if (pending && !outcome.unknownReason) {
-				opaquePaths = diffFileStats(pending, outcome.snapshot ?? new Map());
+			let unknownReason: string | undefined;
+			if (!pending) {
+				unknownReason = "no-pending-snapshot";
+			} else if (pending.strategy === "git") {
+				// Git-first: no universe cap - works on any repo size.
+				const recovery = await recoverOpaqueChangesViaGit(
+					scanRoot,
+					pending.startedAt,
+				);
+				if (recovery.verdict === "recovered") {
+					opaquePaths = recovery.paths.filter(
+						(p) =>
+							!isExternalOrVendorFile(p, scanRoot) &&
+							!isPathIgnoredByProject(p, scanRoot, false),
+					);
+				} else {
+					unknownReason = recovery.unknownReason;
+				}
+			} else if (pending.stats) {
+				const outcome = await captureFileStats(scanRoot);
+				if (outcome.snapshot && !outcome.unknownReason) {
+					opaquePaths = diffFileStats(pending.stats, outcome.snapshot);
+				} else {
+					unknownReason =
+						outcome.unknownReason ??
+						pending.statsUnknownReason ??
+						"walk-failed";
+				}
 			} else {
+				unknownReason = pending.statsUnknownReason ?? "walk-failed";
+			}
+			if (unknownReason) {
 				logLatency({
 					type: "phase",
 					phase: "opaque_mutation_coverage_unknown",
 					filePath: command.slice(0, 80),
 					durationMs: Date.now() - started,
-					result:
-						outcome.unknownReason ?? (pending ? "ok" : "no-pending-snapshot"),
+					result: unknownReason,
 				});
 			}
 			if (opaquePaths.length > 0) {

--- a/tests/clients/opaque-mutation-scan.test.ts
+++ b/tests/clients/opaque-mutation-scan.test.ts
@@ -8,13 +8,34 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The synthetic-write dispatch runs the full per-edit pipeline; point it at
+// a resolved verdict instead of spawning real linters over a bare temp repo
+// (same seam the runtime-tool-result suite mocks).
+vi.mock("../../clients/pipeline.js", () => ({
+	runPipeline: vi.fn().mockResolvedValue({
+		output: "✓ no blockers",
+		hasBlockers: false,
+		isError: false,
+		fileModified: false,
+	}),
+}));
+
+import { handleToolCall } from "../../clients/runtime-tool-call.js";
+import { handleToolResult } from "../../clients/runtime-tool-result.js";
+import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
+import { CacheManager } from "../../clients/cache-manager.js";
+import { getProjectChangeLogPath } from "../../clients/project-changes.js";
+import type { ProjectChangeEntry } from "../../clients/project-changes.js";
 
 import {
 	captureFileStats,
 	diffFileStats,
+	OpaqueBaselineStore,
 	OPAQUE_SCAN_MAX_FILES,
-	OpaqueSnapshotStore,
+	recoverOpaqueChangesViaGit,
 } from "../../clients/opaque-mutation-scan.js";
 import { normalizeMapKey } from "../../clients/path-utils.js";
 import { removeTempDirSync } from "./test-utils.js";
@@ -78,14 +99,142 @@ describe("diffFileStats", () => {
 	});
 });
 
-describe("OpaqueSnapshotStore", () => {
+describe("OpaqueBaselineStore", () => {
 	it("one slot per cwd: take consumes, replacement evicts with a count", () => {
-		const store = new OpaqueSnapshotStore();
-		store.record("/p", new Map([["a", { mtimeMs: 1, size: 1 }]]));
-		store.record("/p", new Map([["b", { mtimeMs: 2, size: 2 }]]));
+		const store = new OpaqueBaselineStore();
+		store.record("/p", { startedAt: 1, strategy: "git" });
+		store.record("/p", { startedAt: 2, strategy: "git" });
 		expect(store.evictionCount).toBe(1);
 		const taken = store.take("/p");
-		expect(taken?.get("b")).toEqual({ mtimeMs: 2, size: 2 });
+		expect(taken?.startedAt).toBe(2);
 		expect(store.take("/p")).toBeUndefined();
 	});
+});
+
+describe("recoverOpaqueChangesViaGit (real git repo)", () => {
+	let repoDir = "";
+
+	beforeEach(() => {
+		repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-opaque-git-"));
+		execSync("git init -q", { cwd: repoDir });
+		execSync("git config user.email t@t.local", { cwd: repoDir });
+		execSync("git config user.name t", { cwd: repoDir });
+		fs.mkdirSync(path.join(repoDir, "src"), { recursive: true });
+		fs.writeFileSync(path.join(repoDir, "src", "base.ts"), "base\n", "utf8");
+		execSync("git add -A && git commit -qm base", { cwd: repoDir });
+	});
+
+	afterEach(() => {
+		removeTempDirSync(repoDir);
+	});
+
+	function nodeScriptFile(script: string): string {
+		const file = path.join(repoDir, `.opaque-child-${Date.now()}.cjs`);
+		fs.writeFileSync(file, script, "utf8");
+		return file;
+	}
+
+	function writeViaNodeChild(target: string, content: string): void {
+		const scriptFile = nodeScriptFile(
+			`require('fs').writeFileSync(${JSON.stringify(target)}, ${JSON.stringify(content)});`,
+		);
+		try {
+			execSync(`node "${scriptFile}"`, { cwd: repoDir });
+		} finally {
+			fs.rmSync(scriptFile, { force: true });
+		}
+	}
+
+	it("reports modified and added files inside the mtime window", async () => {
+		const startedAt = Date.now();
+		writeViaNodeChild(path.join(repoDir, "src", "base.ts"), "modified\n");
+		writeViaNodeChild(path.join(repoDir, "src", "new.ts"), "added\n");
+		const outcome = await recoverOpaqueChangesViaGit(repoDir, startedAt);
+		expect(outcome.verdict).toBe("recovered");
+		expect(outcome.paths).toContain(
+			normalizeMapKey(path.join(repoDir, "src", "base.ts")),
+		);
+		expect(outcome.paths).toContain(
+			normalizeMapKey(path.join(repoDir, "src", "new.ts")),
+		);
+	});
+
+	it("excludes files last written BEFORE the window floor", async () => {
+		// A pre-existing dirty file from long before the command started.
+		fs.writeFileSync(path.join(repoDir, "src", "base.ts"), "early\n", "utf8");
+		// A window that opens far in the future excludes everything on disk.
+		const outcome = await recoverOpaqueChangesViaGit(
+			repoDir,
+			Date.now() + 10_000,
+		);
+		expect(outcome.verdict).toBe("recovered");
+		expect(outcome.paths).toEqual([]);
+	});
+
+	it(
+		"end-to-end: node child write is recovered as opaque-script in the change log",
+		{ timeout: 15_000 },
+		async () => {
+			const previousDataDir = process.env.PILENS_DATA_DIR;
+			process.env.PILENS_DATA_DIR = path.join(repoDir, "data");
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = repoDir;
+			runtime.setTelemetryIdentity({ sessionId: "opaque-e2e" });
+			try {
+				const target = path.join(repoDir, "src", "generated.ts");
+				const command = nodeScriptFile(
+					`require('fs').writeFileSync(${JSON.stringify(target)}, 'generated by child\\n');`,
+				);
+				await handleToolCall({
+					event: { toolName: "bash", input: { command } },
+					ctx: { cwd: repoDir },
+					lensEnabled: true,
+					getFlag: () => false,
+					dbg: () => {},
+					runtime,
+					cacheManager: new CacheManager(false),
+					ensureLSPConfigInitialized: async () => {},
+					updateLspStatus: () => {},
+					resetLSPService: () => {},
+				} as Parameters<typeof handleToolCall>[0]);
+				try {
+					execSync(`node "${command}"`, { cwd: repoDir });
+				} finally {
+					fs.rmSync(command, { force: true });
+				}
+				await handleToolResult({
+					event: {
+						toolName: "bash",
+						input: { command },
+						content: [{ type: "text", text: "done" }],
+					},
+					getFlag: () => false,
+					dbg: () => {},
+					runtime,
+					cacheManager: new CacheManager(false),
+					biomeClient: {},
+					ruffClient: {},
+					testRunnerClient: {},
+					metricsClient: {},
+					resetLSPService: () => {},
+					agentBehaviorRecord: () => [],
+					formatBehaviorWarnings: () => "",
+				} as unknown as Parameters<typeof handleToolResult>[0]);
+
+				const lines = fs
+					.readFileSync(getProjectChangeLogPath(repoDir), "utf8")
+					.split("\n")
+					.filter((l) => l.trim());
+				const entries = lines.map((l) => JSON.parse(l) as ProjectChangeEntry);
+				const recovered = entries.filter((e) => e.source === "opaque-script");
+				expect(recovered.length).toBeGreaterThanOrEqual(1);
+				expect(recovered.some((e) => e.filePath.endsWith("generated.ts"))).toBe(
+					true,
+				);
+			} finally {
+				if (previousDataDir === undefined) delete process.env.PILENS_DATA_DIR;
+				else process.env.PILENS_DATA_DIR = previousDataDir;
+			}
+		},
+	);
 });

--- a/tests/clients/opaque-mutation-scan.test.ts
+++ b/tests/clients/opaque-mutation-scan.test.ts
@@ -231,6 +231,17 @@ describe("recoverOpaqueChangesViaGit (real git repo)", () => {
 				expect(recovered.some((e) => e.filePath.endsWith("generated.ts"))).toBe(
 					true,
 				);
+
+				// Dispatch really ran for the recovered file - the synthetic write
+				// re-enters the full per-edit pipeline (runPipeline), same as any
+				// native or recognized write. Assert it, don't assume it.
+				const { runPipeline } = await import("../../clients/pipeline.js");
+				const dispatchedPaths = vi
+					.mocked(runPipeline)
+					.mock.calls.map((call) => String(call[0]?.filePath));
+				expect(dispatchedPaths.some((p) => p.endsWith("generated.ts"))).toBe(
+					true,
+				);
 			} finally {
 				if (previousDataDir === undefined) delete process.env.PILENS_DATA_DIR;
 				else process.env.PILENS_DATA_DIR = previousDataDir;

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -902,6 +902,9 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	"lsp/client.ts": 2,
 	"lsp/config.ts": 1,
 	"lsp/index.ts": 2,
+	// #2000 phase 2: the pending-baseline store (one slot per cwd:generation)
+	// plus the process-global Symbol.for slot; cleared via resetOpaqueMutationState.
+	"opaque-mutation-scan.ts": 1,
 	"lsp/jvm-runtime.ts": 0,
 	"lsp/spawn-history.ts": 1,
 	"lsp/server.ts": 5,

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -179,6 +179,16 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 			reset: () => resetBoundedTelemetry(),
 		},
 	},
+	// ── #2000 phase 2 opaque-recovery baselines ─────────────────────────
+	{
+		id: "opaque-mutation-scan:baselineStore+gitMemo",
+		module: "opaque-mutation-scan.ts",
+		state: "OpaqueBaselineStore byCwd map, gitRepoMemo",
+		policy: "session_start",
+		resetName: "resetOpaqueMutationState",
+		reason:
+			"#2000 phase 2: pending pre-command baselines are keyed cwd:generation and become unreachable when the session generation advances; and the git-worktree memo must re-probe after a session that may have seen a directory become a worktree. Without the reset both leak per session and the memo mis-answers forever.",
+	},
 	// ── The named population from #1635 ──────────────────────────────────────
 	{
 		id: "degradation-ledger:onceKeys",


### PR DESCRIPTION
Phase 2 follow-up to #2018, driven by live dogfooding.

## The finding

On pi-lens itself (>2000 sources), **every** prescan degraded to `file-cap-exceeded` (15/15 telemetry rows in one session) — recovery never fired on its own repo. The cap existed only because the design required a full-universe pre-snapshot.

## Redesign: timestamp + git window

- **Pre side records only `startedAt`** when inside a git worktree (cached `rev-parse` probe). No walk.
- **Post side**: `git status --porcelain -z` → keep paths with mtime in `[startedAt − 150ms, now]` → same ignore/vendor filters as recognized writes. Handles renames; spawn failures yield explicit `git-failed`; content-identical rewrites correctly unreported.
- **No file-universe bound anywhere on this path** — works at 10 files or 5000.
- Non-git trees keep the bounded stat-diff fallback unchanged.
- Store slot is now `{startedAt, strategy, stats?}`; session-stamped keys unchanged.

## Tests (real git repo, real child processes)

- modified+added detection inside the mtime window
- exclusion of writes older than the window floor
- **end-to-end**: `handleToolCall` → real `node <script>` child writes → `handleToolResult` asserts BOTH that the durable change log records source `opaque-script` for the recovered file AND that `runPipeline` was invoked with `ctx.filePath` = that file — dispatch participation is pinned by assertion, not claimed
- Child scripts execute via temp `.cjs` invoked as `node "<file>"` — invoking the bare path went through the Windows file association and opened the maintainer's IDE instead of executing (found live; fixed and documented)

7/7 suite green; build/lint/fmt clean.

Refs #2000, #2011