### PR TITLE
fix(diagnostics): authoritative LSP sweep retires stale widget state (refs #1993)

### DIFF
--- a/.changelog/fix-1993-full-mode-stale-blockers.md
+++ b/.changelog/fix-1993-full-mode-stale-blockers.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **mode=full no longer replays stale mid-edit blockers (refs #1993)** — a confirmed, fully-covered LSP sweep is now authoritative for its files: widget-store diagnostics captured from a since-fixed broken intermediate state are retired instead of rendering as current 🔴 blockers beside a clean sweep. Unconfirmed or timed-out sweeps keep the fail-open behavior.

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -2094,9 +2094,89 @@ describe("lens_diagnostics mode=full", () => {
 
 		const result = await run(makeTool({}, lspService), { mode: "full" });
 		const text = String(result.content[0].text);
-		expect(text).toContain("cached dispatch message");
-		expect(text).not.toContain("same diagnostic from workspace scan");
+		// #1993: a CONFIRMED, fully-covered sweep is AUTHORITATIVE for the file -
+		// the fresh workspace-scan copy renders and the cached dispatch-time
+		// copy is retired instead of the reverse. Still exactly ONE row (the
+		// dedup-by-file/line/rule guarantee is unchanged).
+		expect(text).toContain("same diagnostic from workspace scan");
+		expect(text).not.toContain("cached dispatch message");
 		expect(result.details).toMatchObject({ totalBlocking: 1, totalErrors: 1 });
+	});
+
+	it("a clean fully-covered sweep RETIRES stale widget blockers for the file (#1993)", async () => {
+		// The #1993 defect: mid-edit broken-state diagnostics captured in the
+		// widget store rendered as current blocking findings forever, because
+		// mode=full's merge was additive-only - a clean authoritative sweep
+		// never retired them.
+		mockSummaries.length = 0;
+		mockSummaries.push(
+			sum(
+				"/proj/src/stale.ts",
+				{ blocking: 1, errors: 1 },
+				{
+					diagnostics: [
+						{
+							severity: "error",
+							semantic: "blocking",
+							message:
+								"Duplicate function implementation (stale mid-edit state)",
+							line: 400,
+							rule: "ts:2393",
+							tool: "lsp",
+						},
+					],
+				},
+			),
+		);
+		const lspService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([
+				{
+					filePath: "/proj/src/stale.ts",
+					diagnostics: [],
+					count: 0,
+				},
+			]),
+		};
+
+		const result = await run(makeTool({}, lspService), { mode: "full" });
+		const text = String(result.content[0].text);
+		expect(text).not.toContain("stale mid-edit state");
+		// details omits totalBlocking entirely when zero.
+		expect(
+			(result.details as { totalBlocking?: number }).totalBlocking ?? 0,
+		).toBe(0);
+
+		// Fail-open guard: WITHOUT a sweep result for the file (unconfirmed /
+		// not re-checked), the stored finding must stay visible.
+		mockSummaries.length = 0;
+		mockSummaries.push(
+			sum(
+				"/proj/src/stale.ts",
+				{ blocking: 1, errors: 1 },
+				{
+					diagnostics: [
+						{
+							severity: "error",
+							semantic: "blocking",
+							message:
+								"Duplicate function implementation (stale mid-edit state)",
+							line: 400,
+							rule: "ts:2393",
+							tool: "lsp",
+						},
+					],
+				},
+			),
+		);
+		const noSweepService = {
+			runWorkspaceDiagnostics: vi.fn().mockResolvedValue([]),
+		};
+		const keepResult = await run(makeTool({}, noSweepService), {
+			mode: "full",
+		});
+		expect(String(keepResult.content[0].text)).toContain(
+			"stale mid-edit state",
+		);
 	});
 
 	it("dedups the napi project scan against ast-grep LSP findings despite the source prefix (#308)", async () => {

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -1327,17 +1327,28 @@ function tallyLspPrimaryVsAuxiliary(results: WorkspaceLspDiagnosticResult[]): {
 	return { primary, auxiliary };
 }
 
-function mergeDiagnosticsWithWidgetSummaries(
+export function mergeDiagnosticsWithWidgetSummaries(
 	widgetSummaries: FileDiagnosticSummary[],
 	lspResults: WorkspaceLspDiagnosticResult[],
 	projectSnapshot?: ProjectDiagnosticsSnapshot,
 	projectDelta?: ProjectDiagnosticsDeltaReport,
+	/**
+	 * #1993: resolved paths covered by a CONFIRMED, fully-covered LSP result
+	 * in `lspResults`. The fresh sweep is AUTHORITATIVE for these files - any
+	 * widget-store diagnostics seeded for them predate the sweep and must not
+	 * survive it (an additive-only merge let mid-edit stale 🔴 entries render
+	 * forever beside a clean sweep). Files absent from this set keep today's
+	 * additive behavior (fail-open: unconfirmed/timed-out sweeps never retire
+	 * widget state they did not actually re-check).
+	 */
+	authoritativeLspFiles?: ReadonlySet<string>,
 ): FileDiagnosticSummary[] {
 	const byFile = new Map<string, FileDiagnosticSummary>();
 	const seen = new Set<string>();
 
 	for (const summary of widgetSummaries) {
 		const filePath = path.resolve(summary.filePath);
+		if (authoritativeLspFiles?.has(filePath)) continue;
 		const diagnostics = (summary.diagnostics ?? []).map((d) => ({ ...d }));
 		byFile.set(filePath, { ...summary, filePath, diagnostics });
 		for (const diagnostic of diagnostics) {
@@ -1795,6 +1806,12 @@ async function formatFullMode(
 	// read as "0 issues, clean" via its LSP contribution. It can still
 	// legitimately show diagnostics from widgetSummaries/project-runner state
 	// below if those independently have entries for it.
+	// #1993: files with a CONFIRMED, fully-covered LSP result are authoritative
+	// - the fresh sweep replaces their widget-store state instead of merging
+	// additively beside it.
+	const authoritativeLspFiles = new Set(
+		fullyCoveredLspResults.map((result) => path.resolve(result.filePath)),
+	);
 	const summaries = await applyInlineSuppressionsToSummaries(
 		mergeDiagnosticsWithWidgetSummaries(
 			getFileDiagnosticSummaries().filter((summary) =>
@@ -1803,6 +1820,7 @@ async function formatFullMode(
 			confirmedLspResults,
 			projectSnapshot,
 			projectDelta,
+			authoritativeLspFiles,
 		),
 		cwd,
 		policyMap,

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -1348,6 +1348,12 @@ export function mergeDiagnosticsWithWidgetSummaries(
 
 	for (const summary of widgetSummaries) {
 		const filePath = path.resolve(summary.filePath);
+		// NOTE (#1993 review): dispositions recorded against a CACHED copy's
+		// message text may not match this file's fresh sweep copy (weak
+		// anchors key on message). Both copies derive from the same LSP
+		// diagnostic via convertLspDiagnostics, so identity is stable in
+		// practice; inline pi-lens-ignore comments are the primary
+		// suppression mechanism.
 		if (authoritativeLspFiles?.has(filePath)) continue;
 		const diagnostics = (summary.diagnostics ?? []).map((d) => ({ ...d }));
 		byFile.set(filePath, { ...summary, filePath, diagnostics });
@@ -1812,6 +1818,23 @@ async function formatFullMode(
 	const authoritativeLspFiles = new Set(
 		fullyCoveredLspResults.map((result) => path.resolve(result.filePath)),
 	);
+	// #1993 review: retirement must be observable - if a future regression
+	// makes the set falsely authoritative, findings would vanish silently.
+	const authoritativeRetiredCount = getFileDiagnosticSummaries().filter(
+		(summary) =>
+			includeFile(summary.filePath) &&
+			authoritativeLspFiles.has(path.resolve(summary.filePath)) &&
+			(summary.diagnostics?.length ?? 0) > 0,
+	).length;
+	if (authoritativeRetiredCount > 0) {
+		logLatency({
+			type: "phase",
+			phase: "lsp_authoritative_widget_retire",
+			filePath: "",
+			durationMs: 0,
+			metadata: { files: authoritativeRetiredCount },
+		});
+	}
 	const summaries = await applyInlineSuppressionsToSummaries(
 		mergeDiagnosticsWithWidgetSummaries(
 			getFileDiagnosticSummaries().filter((summary) =>


### PR DESCRIPTION
Fixes the #1993 defect class: mode=full replaying stale mid-edit blockers as current 🔴 beside a clean sweep.

## Root cause

`mergeDiagnosticsWithWidgetSummaries` was additive-only: widget-store diagnostics seeded `byFile` first, fresh LSP findings merely dedup-merged beside them. A **confirmed, fully-covered clean sweep therefore never retired** the file's stale entries. Observed originally on `clients/dispatch/runners/oxlint.ts`: ts:2393/ts:2528 ghost blockers with past-EOF positions persisting across repeated mode=full calls while tsc, rg, and the sweep itself all reported clean — and re-running didn't reconcile them, because nothing in the merge ever removed anything.

## Fix

`mergeDiagnosticsWithWidgetSummaries` gains an `authoritativeLspFiles` set (resolved paths with a confirmed, fully-covered result, computed in `formatFullMode`). Widget state for those files is not seeded; the fresh sweep's own diagnostics stand. Files without full coverage keep today's additive behavior — fail-open by design: an unconfirmed or timed-out sweep must never retire widget state it did not actually re-check.

## Tests (red-first verified by stashing the production change)

1. **Updated** dedup test pins the inversion: fresh workspace-scan copy renders, cached dispatch-time copy retired — still exactly one row (dedup-by-file/line/rule guarantee unchanged).
2. **New #1993 test**: a clean fully-covered sweep retires the stale blocker (`totalBlocking` absent-at-zero; text clean), AND the fail-open guard — with no sweep result for the file, the stored finding stays visible.

104/104 in the suite; 177 green across touched suites; build/lint/fmt clean.

## Blast radius

Single call site (`formatFullMode`); new optional parameter — additive signature. Non-bash/diagnostic surfaces untouched. The footer-reconcile loop already full-replaced per fully-covered result (#571); this brings the rendered summary to the same semantics.

## Tests section (template)

- New test "a clean fully-covered sweep RETIRES stale widget blockers" — regression proof for #1993 + fail-open guard assertion.
- Edited test "deduplicates LSP diagnostics..." — survivor flipped to the fresh sweep copy per authoritative semantics; duplicate-row guarantee still pinned.

Refs #1993