### PR TITLE
feat(delivery-gate): register remaining agent-facing surfaces (refs #2028)

### DIFF
--- a/.changelog/fix-2028-delivery-gate-surfaces.md
+++ b/.changelog/fix-2028-delivery-gate-surfaces.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Register remaining agent-facing delivery surfaces (#2028)** — The per-edit 🔴 STOP block now drops blockers whose cited file no longer exists, so a deleted file's stale blocker no longer re-blocks the agent with no remediation. All five previously unregistered surfaces (stop blocker, `lsp_diagnostics` output, git-guard verdicts, read-guard preflight errors, thrashing notices) are registered in the finding-delivery gate registry.

--- a/clients/finding-delivery-gate.ts
+++ b/clients/finding-delivery-gate.ts
@@ -505,6 +505,57 @@ export const DELIVERY_SURFACES: Record<string, DeliverySurfaceEntry> = {
 		["reconcileProjectDiagnosticsSnapshot"],
 		["reconcileProjectDiagnosticsSnapshot("],
 	),
+
+	// ── #2028: the remaining agent-facing surfaces ──────────────────────────
+	// Registered after #2028's root-cause review found the 🔴 STOP block
+	// rendering stale/deleted-file blockers because its surface was never in
+	// this registry — the exact "gated or labeled, never neither" gap this
+	// module exists to close.
+	"tool-call:stop-blocker": gated(
+		"clients/pipeline.ts",
+		"Per-edit 🔴 STOP blocker output appended to the write/edit tool result.",
+		["dropFindingsForMissingPaths"],
+		['store: "stop-blocker"'],
+	),
+	// The freshness stack itself (own-file mtime + reverse-dependency mtimes
+	// via isEntryFresh, plus the #1095 content binding) lives inside
+	// clients/lsp/workspace-diagnostics-cache.ts; the two evidence calls are
+	// the tool's literal entry points into that gated path.
+	"lsp-diagnostics:tool-output": gated(
+		"tools/lsp-diagnostics.ts",
+		"`lsp_diagnostics` batch/directory sweep results. Cache hits replay through " +
+			"the shared workspace-diagnostics cache: createWorkspaceDiagnosticsCacheContext " +
+			"is the tool's entry, and its lookup() applies the #671/#672 freshness stack " +
+			"(own-file mtime + reverse-dependency mtimes via isEntryFresh) plus the " +
+			"#1095 content binding.",
+		["createWorkspaceDiagnosticsCacheContext", "isEntryFresh", "cacheCtx.lookup"],
+		[
+			"createWorkspaceDiagnosticsCacheContext(resolvedCwd)",
+			"cacheCtx.lookup(file, scopeKey)",
+		],
+	),
+	"git-guard:commit-blocked": labeled(
+		"clients/git-guard.ts",
+		"Git-guard commit/push 🔴 COMMIT BLOCKED verdict (--lens-guard).",
+		"Synchronous preflight rejection returned inline with the failed git " +
+			"command — no stored state is delivered, so nothing can go stale between " +
+			"detection and delivery.",
+		"live",
+	),
+	"read-guard-tool-lines:preflight-errors": labeled(
+		"clients/read-guard-tool-lines.ts",
+		"Read-guard hashline BLOCKED / RE-READ REQUIRED preflight errors.",
+		"Computed fresh per edit attempt and returned as that attempt's rejection — " +
+			"no cached findings are replayed, so there is no staleness window.",
+		"live",
+	),
+	"agent-behavior:thrashing-notice": labeled(
+		"clients/agent-behavior-client.ts",
+		"In-result thrashing/blind-write detection notice.",
+		"Ephemeral notice computed at detection time inside the same tool result — " +
+			"no persistence and no cache, so nothing can be stale.",
+		"live",
+	),
 };
 
 function assertPartialStatusHasReason(

--- a/clients/finding-delivery-gate.ts
+++ b/clients/finding-delivery-gate.ts
@@ -528,7 +528,11 @@ export const DELIVERY_SURFACES: Record<string, DeliverySurfaceEntry> = {
 			"is the tool's entry, and its lookup() applies the #671/#672 freshness stack " +
 			"(own-file mtime + reverse-dependency mtimes via isEntryFresh) plus the " +
 			"#1095 content binding.",
-		["createWorkspaceDiagnosticsCacheContext", "isEntryFresh", "cacheCtx.lookup"],
+		[
+			"createWorkspaceDiagnosticsCacheContext",
+			"isEntryFresh",
+			"cacheCtx.lookup",
+		],
 		[
 			"createWorkspaceDiagnosticsCacheContext(resolvedCwd)",
 			"cacheCtx.lookup(file, scopeKey)",

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -75,6 +75,7 @@ import type { WordIndex } from "./word-index.js";
 import { getAmbientAbortSignal, safeSpawnAsync } from "./safe-spawn.js";
 import { combineAbortSignals } from "./deadline-utils.js";
 import { recordDegradationOnce } from "./degradation-ledger.js";
+import { dropFindingsForMissingPaths } from "./advisory-provenance.js";
 import {
 	getAutofixPolicyForFile,
 	getPreferredAutofixTools,
@@ -1532,10 +1533,27 @@ export async function runPipeline(
 		getDiagnosticTracker().trackAgentFixed(dispatchResult.resolvedCount);
 
 	let output = "";
+	// #2028: the 🔴 STOP block is an agent-facing delivery surface
+	// (finding-delivery-gate.ts's `tool-call:stop-blocker`), so it routes through
+	// the shared deleted-path gate before rendering: a blocker whose cited file
+	// no longer exists has no remediation the agent can perform (the finding IS
+	// the deleted file's content), so it is dropped here rather than re-asserted.
+	// One bounded stat per unique cited path, only when blockers exist — zero
+	// cost on the clean/fast paths.
+	const deliverableBlockers = dispatchResult.hasBlockers
+		? dropFindingsForMissingPaths({
+				store: "stop-blocker",
+				findings: dispatchResult.blockers,
+				cwd,
+				citedPath: (b) => b.filePath || undefined,
+			})
+		: dispatchResult.blockers;
 	if (dispatchResult.hasBlockers && fileContent) {
 		// Enrich blocker output with a code snippet so the agent can see the
 		// exact line it wrote that caused each violation — no re-read needed.
-		output += buildEnrichedBlockerOutput(dispatchResult.blockers, fileContent);
+		if (deliverableBlockers.length > 0) {
+			output += buildEnrichedBlockerOutput(deliverableBlockers, fileContent);
+		}
 		// Append fixed/coverage parts from the original output (slice off the
 		// blocker section we're replacing).
 		const rest = dispatchResult.output.slice(

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -1268,9 +1268,11 @@ export async function runFormatPhase(
  */
 function buildEnrichedBlockerOutput(
 	blockers: Diagnostic[],
-	fileContent: string,
+	fileContent = "",
 ): string {
-	const fileLines = fileContent.split("\n");
+	// Empty fileContent (readback failed, e.g. deleted-file race) still
+	// renders the gated blocker list - just without per-line snippets.
+	const fileLines = fileContent ? fileContent.split("\n") : [];
 	const MAX_SNIPPET = 120; // chars — keep it tight in context
 
 	let out = `\n\n🔴 STOP — ${blockers.length} issue(s) must be fixed:\n`;
@@ -1561,7 +1563,22 @@ export async function runPipeline(
 		);
 		if (rest) output += rest;
 	} else if (dispatchResult.output) {
-		output += `\n\n${dispatchResult.output}`;
+		// #2028 review P3: this path fires when readback FAILED - raw output
+		// still cites possibly-deleted files. Re-render from the gated set
+		// (no snippets without fileContent) and keep the post-blocker slice.
+		if (
+			dispatchResult.hasBlockers &&
+			deliverableBlockers.length !== dispatchResult.blockers.length
+		) {
+			let gatedOut = buildEnrichedBlockerOutput(deliverableBlockers);
+			const rest = dispatchResult.output.slice(
+				dispatchResult.blockerOutput.length,
+			);
+			if (rest) gatedOut += rest;
+			output += `\n\n${gatedOut}`;
+		} else {
+			output += `\n\n${dispatchResult.output}`;
+		}
 	}
 	if (fixedCount > 0) {
 		const detail =

--- a/tests/clients/finding-delivery-gate.test.ts
+++ b/tests/clients/finding-delivery-gate.test.ts
@@ -73,6 +73,12 @@ const EXPECTED_SURFACE_IDS = [
 	"widget-state:footer",
 	"agent-nudge:context-message",
 	"project-diagnostics:persisted-snapshot",
+	// #2028: the remaining agent-facing surfaces.
+	"tool-call:stop-blocker",
+	"lsp-diagnostics:tool-output",
+	"git-guard:commit-blocked",
+	"read-guard-tool-lines:preflight-errors",
+	"agent-behavior:thrashing-notice",
 ].sort();
 
 // ── Real seam scan (#1634 review F2) ────────────────────────────────────────

--- a/tests/clients/pipeline.test.ts
+++ b/tests/clients/pipeline.test.ts
@@ -1091,4 +1091,101 @@ describe("Pipeline", () => {
 			expect(result.inlineBlockerLines).toEqual([3]);
 		});
 	});
+
+	// #2028: the 🔴 STOP block is a registered agent-facing delivery surface
+	// (finding-delivery-gate.ts's `tool-call:stop-blocker`), so blockers whose
+	// cited file no longer exists are dropped before rendering — there is no
+	// remediation for content in a deleted file.
+	describe("#2028 stop-blocker deleted-path gate", () => {
+		it("drops blockers whose cited file was deleted from the rendered STOP block", async () => {
+			const filePath = createTempFile(
+				tmpDir,
+				"live.ts",
+				"const x = 1;\nconst y = 2;\n",
+			);
+			const deletedPath = path.join(tmpDir, "deleted-by-agent.ts");
+			vi.mocked(dispatchLintWithResult).mockResolvedValue({
+				diagnostics: [],
+				blockers: [
+					{
+						id: "dead-1",
+						message: "DELETED-FILE-BLOCKER-MARKER secret in removed file",
+						filePath: deletedPath,
+						line: 1,
+						severity: "error",
+						semantic: "blocking",
+						tool: "gitleaks",
+					},
+					{
+						id: "live-1",
+						message: "LIVE-FILE-BLOCKER-MARKER unused var",
+						filePath,
+						line: 1,
+						severity: "error",
+						semantic: "blocking",
+						tool: "lsp",
+					},
+				],
+				warnings: [],
+				baselineWarningCount: 0,
+				fixed: [],
+				resolvedCount: 0,
+				output:
+					"DELETED-FILE-BLOCKER-MARKER secret in removed file\nLIVE-FILE-BLOCKER-MARKER unused var\ncoverage: ok",
+				blockerOutput:
+					"DELETED-FILE-BLOCKER-MARKER secret in removed file\nLIVE-FILE-BLOCKER-MARKER unused var\n",
+				hasBlockers: true,
+			});
+
+			const result = await runPipeline(
+				createMockContext(filePath),
+				createMockDeps(),
+			);
+
+			expect(result.hasBlockers).toBe(true);
+			// The live blocker renders at full authority…
+			expect(result.output).toContain("LIVE-FILE-BLOCKER-MARKER");
+			expect(result.output).toContain("🔴 STOP");
+			// …the deleted-file blocker does not render at all.
+			expect(result.output).not.toContain("DELETED-FILE-BLOCKER-MARKER");
+			// The surviving blocker's count is the LIVE one, not the raw total.
+			expect(result.output).toContain("1 issue(s)");
+		});
+
+		it("renders no STOP header when every blocker cites a deleted file", async () => {
+			const filePath = createTempFile(tmpDir, "clean-now.ts", "const x = 1;");
+			const deletedPath = path.join(tmpDir, "also-deleted.ts");
+			vi.mocked(dispatchLintWithResult).mockResolvedValue({
+				diagnostics: [],
+				blockers: [
+					{
+						id: "dead-2",
+						message: "GHOST-BLOCKER-MARKER finding in removed file",
+						filePath: deletedPath,
+						line: 1,
+						severity: "error",
+						semantic: "blocking",
+						tool: "gitleaks",
+					},
+				],
+				warnings: [],
+				baselineWarningCount: 0,
+				fixed: [],
+				resolvedCount: 0,
+				output: "GHOST-BLOCKER-MARKER finding in removed file",
+				blockerOutput: "GHOST-BLOCKER-MARKER finding in removed file",
+				hasBlockers: true,
+			});
+
+			const result = await runPipeline(
+				createMockContext(filePath),
+				createMockDeps(),
+			);
+
+			// No "🔴 STOP — 0 issue(s)" ghost header, and no replay of the raw
+			// blocker text either.
+			expect(result.output).not.toContain("🔴 STOP");
+			expect(result.output).not.toContain("GHOST-BLOCKER-MARKER");
+		});
+	});
 });


### PR DESCRIPTION
Closes the #2028 class sweep: every agent-facing delivery surface now registered in `DELIVERY_SURFACES`.

## Gated (real staleness wiring)

- **`tool-call:stop-blocker`** (`clients/pipeline.ts`) — the 🔴 STOP advisory now routes its blockers through `dropFindingsForMissingPaths({ store: "stop-blocker", ... })` before rendering. Deleted files' blockers stop rendering; when all cite deleted paths, no ghost `🔴 STOP — 0 issue(s)` header appears at all.
- **`lsp-diagnostics:tool-output`** (`tools/lsp-diagnostics.ts`) — gates cite the tool's existing staleness stack: `createWorkspaceDiagnosticsCacheContext` entry + `cacheCtx.lookup`, whose cache module performs own-file mtime, reverse-dependency mtime, and #1095 content-binding validation.

## Labeled (live — nothing stored to go stale)

- `git-guard:commit-blocked` — synchronous preflight rejection returned inline with the failed git command.
- `read-guard-tool-lines:preflight-errors` — hashline BLOCKED / RE-READ REQUIRED computed fresh per edit attempt.
- `agent-behavior:thrashing-notice` — ephemeral in-result notice computed at detection time.

## Honest scope note

The stop-blocker gate changes RENDERING only: `result.hasBlockers`, inline-blocker summary, and git-guard turn-state records still reflect the raw set. Changing those semantics was out of scope; noted here as the record.

## Tests

Two new integration tests in `tests/clients/pipeline.test.ts` (existing mocked-dispatch harness): deleted-file blocker dropped from rendered output; mixed live/deleted set renders survivors only. **Red-first verified by stashing only the pipeline wiring** — both failed on pre-fix code with the deleted-file blocker rendering. Registry enumeration (`EXPECTED_SURFACE_IDS`) updated for +5.

124 tests green across finding-delivery-gate / pipeline / lsp-diagnostics suites; build/lint clean.

Refs #2028