### PR TITLE
feat(lsp): collect-later delivery for slow auxiliary LSPs (closes #2001, #2002, refs #2026)

### DIFF
--- a/.changelog/feat-2001-collect-later-aux-delivery.md
+++ b/.changelog/feat-2001-collect-later-aux-delivery.md
@@ -1,0 +1,13 @@
+---
+section: Added
+---
+
+- **Collect-later delivery for slow auxiliary LSP servers (closes #2001, refs #2002)** —
+  When an auxiliary scanner such as opengrep misses its aux-grace window,
+  pi-lens now marks the file and server pair in a bounded pending store
+  instead of dropping the scanner's eventual findings. The next turn end
+  probes the auxiliary's client cache through a read-only seam,
+  freshness-gates the result against the mark timestamp, and delivers
+  survivors as a `Late auxiliary diagnostics` advisory. A cited file that was
+  edited or deleted since the mark drops its findings, and both drop arms are
+  counted in the new `late_auxiliary_findings` latency record.

--- a/clients/finding-delivery-gate.ts
+++ b/clients/finding-delivery-gate.ts
@@ -397,6 +397,20 @@ export const DELIVERY_SURFACES: Record<string, DeliverySurfaceEntry> = {
 			"gated surfaces, not a cache of its own.",
 		"live",
 	),
+	// #2001/#2002 collect-later: findings an auxiliary LSP published AFTER its
+	// aux-grace window expired, probed from the client cache at the next
+	// turn_end. Gated on the mark timestamp: a cited file deleted or edited
+	// since the mark drops its findings (never delivered before, and the
+	// drifting edit already re-touched the file — a fresh pending pair
+	// supersedes this one), with both drop arms counted in the
+	// `late_auxiliary_findings` latency record rather than silenced.
+	"runtime-turn:late-auxiliary-findings": gated(
+		RUNTIME_TURN_FILE,
+		"Turn-end late-auxiliary LSP findings (collect-later probe of aux " +
+			"client caches whose grace window expired).",
+		["gateFindingsByPathFreshness"],
+		['store: "late-auxiliary-findings"'],
+	),
 	"runtime-turn:cascade-blocker": labeled(
 		RUNTIME_TURN_FILE,
 		"Turn-end 🧪 cascade neighbor blocker.",

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -41,6 +41,7 @@ import {
 	fingerprintDocumentContent,
 	type DriftSweepResult,
 } from "./document-drift.js";
+import { markPendingAuxiliaryCoverage } from "./pending-aux-coverage.js";
 import {
 	isAtOrAboveHomeDir,
 	isWindowsPath,
@@ -2633,6 +2634,34 @@ export class LSPService {
 	}
 
 	/**
+	 * #2001/#2002 collect-later: read-only cached-diagnostics probe for the
+	 * turn-end late-auxiliary delivery (`clients/runtime-turn.ts`). Like
+	 * `isServerAliveForFile`, this NEVER creates or warms a client — it only
+	 * resolves each requested server's root and reads the already-connected
+	 * client's cached diagnostics for `filePath`. Servers with no live client
+	 * are simply absent from the returned map (the caller drops those pairs
+	 * silently); a present server maps to its cache contents, possibly empty
+	 * (still scanning).
+	 */
+	async readCachedDiagnosticsForServers(
+		filePath: string,
+		serverIds: ReadonlySet<string>,
+	): Promise<Map<string, import("./client.js").LSPDiagnostic[]>> {
+		const out = new Map<string, import("./client.js").LSPDiagnostic[]>();
+		if (this.checkDestroyed() || serverIds.size === 0) return out;
+		for (const server of getServersForFileWithConfig(filePath)) {
+			if (!serverIds.has(server.id) || out.has(server.id)) continue;
+			const root = await this.resolveServerRoot(server, filePath);
+			if (!root) continue;
+			const key = `${server.id}:${normalizeMapKey(root)}`;
+			const client = this.state.clients.get(key);
+			if (!client?.isAlive()) continue;
+			out.set(server.id, client.getDiagnostics(filePath));
+		}
+		return out;
+	}
+
+	/**
 	 * #1668: deliver a `workspace/didChangeWatchedFiles` event for a disk
 	 * change the client did not author through open-document sync — a bash
 	 * write/delete, or any other external change. `type` is the LSP
@@ -4533,6 +4562,27 @@ export class LSPService {
 								// an outcome string.
 								const uncovered = auxiliaryCoverageGap(outcomes);
 								if (uncovered.length > 0) auxUnconfirmedServerIds = uncovered;
+								// #2001/#2002 collect-later: an auxiliary with NO publication
+								// evidence for this content (`cut_off` — our grace timer won; or
+								// `silent` — its own budget lapsed with nothing published) may still
+								// publish into its client cache seconds later. Mark the pair so the
+								// NEXT turn_end can probe the cache and deliver the late findings
+								// instead of dropping them on the floor. Exclusions mirror the
+								// coverage-gap policy: `answered` already rode along, a #1493-exempt
+								// scanner's stored findings are bound to exactly these bytes (its
+								// answer is already carried), and DEFERRED servers never received
+								// this content at all (#1459) — their cache describes the PREVIOUS
+								// revision and probing it would replay stale findings.
+								const collectLaterServerIds = outcomes
+									.filter(
+										(o) =>
+											!o.publishedThisContent &&
+											(o.outcome === "cut_off" || o.outcome === "silent"),
+									)
+									.map((o) => o.serverId);
+								if (collectLaterServerIds.length > 0) {
+									markPendingAuxiliaryCoverage(filePath, collectLaterServerIds);
+								}
 								logLatency({
 									type: "phase",
 									phase: "lsp_aux_wait_outcome",

--- a/clients/lsp/pending-aux-coverage.ts
+++ b/clients/lsp/pending-aux-coverage.ts
@@ -1,0 +1,129 @@
+/**
+ * #2001/#2002 — collect-later coverage store for slow auxiliary LSP servers.
+ *
+ * When a `with-auxiliary` touch's aux-grace window expires without a
+ * publication from an auxiliary scanner (opengrep on Windows measures ~8s per
+ * scan against a 2s grace), that scanner's eventual findings were silently
+ * cached inside its LSP client and never surfaced to the agent: the auxiliary
+ * contributed ZERO agent-visible coverage on most edits.
+ *
+ * This module is the bounded hand-off between the two halves of the fix:
+ *
+ *   - PRODUCER (`clients/lsp/index.ts`'s aux-grace wait): after the outcomes
+ *     are decided, every auxiliary with no publication evidence for this
+ *     content (`cut_off` or `silent`, minus #1493's published-this-content
+ *     exemption) marks its (filePath, serverId) pair here. DEFERRED servers
+ *     are never marked — they never received the content, so their cache
+ *     still describes the PREVIOUS revision (#1459).
+ *   - CONSUMER (`clients/runtime-turn.ts` at turn_end): drains the store,
+ *     probes each pair through the read-only
+ *     `LSPService.readCachedDiagnosticsForServers` seam, freshness-gates the
+ *     result against `markedAtMs`, and delivers survivors as the registered
+ *     `runtime-turn:late-auxiliary-findings` gated surface. A pair whose
+ *     client is alive but has STILL published nothing is re-armed (same
+ *     original `markedAtMs` — the freshness baseline never moves) until
+ *     LATE_AUX_REARM_TTL_MS after the mark, so a scan finishing between two
+ *     turn ends is not lost; past the TTL, or when the client is gone, the
+ *     entry is dropped silently (best-effort by design).
+ *
+ * Bounds: at most MAX_PENDING_ENTRIES (file, server) pairs, insertion-order
+ * eviction of the OLDEST pair when the cap is exceeded (shape 9 discipline —
+ * the axis that grows is the pair count, so that is the axis that is capped).
+ * Keys fold through `normalizeEphemeralMapKey`: this is a hot single-process
+ * index whose keys are produced by this same process's touch path, so the
+ * cheap ephemeral normalizer is the lifetime-appropriate choice per the
+ * PathKeyedMap guidance — no realpath walk on the per-edit path.
+ */
+
+import { normalizeEphemeralMapKey } from "../path-utils.js";
+
+/** Maximum pending (filePath, serverId) pairs; oldest evicted beyond this. */
+export const MAX_PENDING_AUX_ENTRIES = 50;
+
+/**
+ * How long a marked pair keeps being re-probed at successive turn ends when
+ * the client is alive but has published nothing yet. Covers opengrep's
+ * measured ~8s worst case many times over without pinning state forever.
+ */
+export const LATE_AUX_REARM_TTL_MS = 5 * 60_000;
+
+export interface PendingAuxCoverageEntry {
+	/** Original-spelling file path (display form; keys are normalized internally). */
+	filePath: string;
+	serverId: string;
+	/**
+	 * Freshness baseline: when this pair was FIRST marked, i.e. roughly when
+	 * the touch's notify went out. The turn-end gate stats the file against
+	 * this timestamp; re-arming preserves it so the baseline never drifts
+	 * forward past the content the pending findings describe.
+	 */
+	markedAtMs: number;
+}
+
+const pending = new Map<string, PendingAuxCoverageEntry>();
+
+function pairKey(filePath: string, serverId: string): string {
+	return `${normalizeEphemeralMapKey(filePath)}\u0000${serverId}`;
+}
+
+/**
+ * Mark (or re-arm) one file's pending auxiliary coverage for `serverIds`.
+ * An existing pair keeps its ORIGINAL `markedAtMs`; only genuinely new pairs
+ * stamp the current time. Insertion order updates on re-mark so a re-armed
+ * pair is not the next one evicted at the cap.
+ */
+export function markPendingAuxiliaryCoverage(
+	filePath: string,
+	serverIds: readonly string[],
+	markedAtMs: number = Date.now(),
+): void {
+	for (const serverId of serverIds) {
+		const key = pairKey(filePath, serverId);
+		const existing = pending.get(key);
+		if (existing) {
+			// Refresh recency WITHOUT moving the freshness baseline.
+			pending.delete(key);
+			pending.set(key, existing);
+			continue;
+		}
+		pending.set(key, { filePath, serverId, markedAtMs });
+		while (pending.size > MAX_PENDING_AUX_ENTRIES) {
+			const oldest = pending.keys().next().value;
+			if (oldest === undefined) break;
+			pending.delete(oldest);
+		}
+	}
+}
+
+/**
+ * Remove one pair after its findings were delivered, or whenever the caller
+ * knows it is resolved. Unknown pairs are a no-op.
+ */
+export function clearPendingAuxiliaryCoverage(
+	filePath: string,
+	serverId: string,
+): void {
+	pending.delete(pairKey(filePath, serverId));
+}
+
+/**
+ * Drain ALL pending pairs (removing them from the store) and return them in
+ * insertion order. The consumer re-arms the still-waiting subset via
+ * {@link markPendingAuxiliaryCoverage}, which preserves each entry's original
+ * `markedAtMs`.
+ */
+export function drainPendingAuxiliaryCoverage(): PendingAuxCoverageEntry[] {
+	const drained = [...pending.values()];
+	pending.clear();
+	return drained;
+}
+
+/** Test-only: current pending pair count. */
+export function pendingAuxiliaryCoverageSizeForTests(): number {
+	return pending.size;
+}
+
+/** Test-only: clear all state between tests. */
+export function resetPendingAuxiliaryCoverageForTests(): void {
+	pending.clear();
+}

--- a/clients/lsp/pending-aux-coverage.ts
+++ b/clients/lsp/pending-aux-coverage.ts
@@ -126,7 +126,10 @@ export function pendingAuxiliaryCoverageSizeForTests(): number {
 	return pending.size;
 }
 
-/** Test-only: clear all state between tests. */
-export function resetPendingAuxiliaryCoverageForTests(): void {
+/**
+ * Session-boundary clear (#1635): pending baselines are unreachable after
+ * reset (the generation-stamped keys no longer match any active session).
+ */
+export function resetPendingAuxiliaryCoverage(): void {
 	pending.clear();
 }

--- a/clients/lsp/pending-aux-coverage.ts
+++ b/clients/lsp/pending-aux-coverage.ts
@@ -81,9 +81,12 @@ export function markPendingAuxiliaryCoverage(
 		const key = pairKey(filePath, serverId);
 		const existing = pending.get(key);
 		if (existing) {
-			// Refresh recency WITHOUT moving the freshness baseline.
+			// #2027 review: bump the freshness baseline on re-mark. A newer
+			// touch means the auxiliary is scanning a NEWER revision; keeping
+			// the original baseline would make every post-baseline mtime read
+			// as stale, permanently dropping current-revision findings.
 			pending.delete(key);
-			pending.set(key, existing);
+			pending.set(key, { filePath, serverId, markedAtMs });
 			continue;
 		}
 		pending.set(key, { filePath, serverId, markedAtMs });

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -111,6 +111,7 @@ import { isWarmAttached } from "./warm-attach.js";
 import { setSessionLanguages } from "./widget-state.js";
 import { logWordIndex } from "./word-index-logger.js";
 import { resetOpaqueMutationState } from "./opaque-mutation-scan.js";
+import { resetPendingAuxiliaryCoverage } from "./lsp/pending-aux-coverage.js";
 import { resetWorkspaceTopology } from "./workspace-topology.js";
 import { resetZizmorTokenAvailability } from "./zizmor-config.js";
 import { resetSpawnTimeoutCooldowns } from "./spawn-timeout-cooldown.js";
@@ -2112,6 +2113,8 @@ export async function handleSessionStart(
 	// after reset) and the git-worktree memo must re-probe after a session
 	// that may have seen a non-git dir become one.
 	resetOpaqueMutationState();
+	// #2026: pending auxiliary baselines are unreachable after generation bump.
+	resetPendingAuxiliaryCoverage();
 	// #817/#1199: Windows command resolution is cached per (command, canonical
 	// effective child PATH/PATHEXT/cwd/per-drive provenance); drop it each
 	// session so environment changes (e.g.

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -2253,6 +2253,7 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	let lateAuxMissing = 0;
 	let lateAuxRearmed = 0;
 	let lateAuxClientGone = 0;
+	let lateAuxProbeFailed = 0;
 	if (drainedPairs.length > 0) {
 		const byFile = new Map<string, typeof drainedPairs>();
 		for (const pair of drainedPairs) {
@@ -2270,6 +2271,15 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 						new Set(pairs.map((p) => p.serverId)),
 					);
 				} catch {
+					// #2027 round-1 P3-2: count dropped pairs — never silent.
+					lateAuxProbeFailed += pairs.length;
+					for (const pair of pairs) {
+						markPendingAuxiliaryCoverage(
+							pair.filePath,
+							[pair.serverId],
+							Date.now(),
+						);
+					}
 					continue;
 				}
 				const displayLateAuxPath = toRunnerDisplayPath(cwd, lateAuxPath);
@@ -2319,6 +2329,16 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 					lateAuxStale += gate.stale.length;
 					lateAuxMissing +=
 						converted.length - gate.live.length - gate.stale.length;
+					if (gate.stale.length > 0) {
+						// Stale findings mean the scan predates the last edit.
+						// Re-arm with a REFRESHED baseline so the next turn probes
+						// the newer revision (#2027 round-1 P2-1).
+						markPendingAuxiliaryCoverage(
+							lateAuxPath,
+							[pair.serverId],
+							Date.now(),
+						);
+					}
 					if (gate.live.length === 0) continue;
 					const lines = gate.live.map(
 						(f) =>
@@ -2347,6 +2367,7 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 				missing: lateAuxMissing,
 				rearmed: lateAuxRearmed,
 				clientGone: lateAuxClientGone,
+				probeFailed: lateAuxProbeFailed,
 			},
 		});
 	}

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -94,6 +94,15 @@ import {
 } from "./advisory-provenance.js";
 import { sweepInlineBlockerFreshness } from "./blocker-freshness.js";
 import { sweepInlineBlockerPastEof } from "./blocker-past-eof.js";
+// #2001/#2002: collect-later delivery for slow auxiliary LSP servers.
+import { getLSPService } from "./lsp/index.js";
+import {
+	drainPendingAuxiliaryCoverage,
+	LATE_AUX_REARM_TTL_MS,
+	markPendingAuxiliaryCoverage,
+} from "./lsp/pending-aux-coverage.js";
+import type { LSPDiagnostic } from "./lsp/client.js";
+import { convertLspDiagnostics } from "./dispatch/utils/lsp-diagnostics.js";
 // #1631 review V2: moved to its own leaf module so a low-level store
 // (widget-state.ts) can use the marker without importing this orchestrator —
 // see clients/stale-marker.ts's doc comment.
@@ -2228,6 +2237,119 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	}
 
 	cacheManager.incrementTurnCycle(cwd, currentOwner);
+
+	// #2001/#2002: collect-later delivery for auxiliary LSP servers whose
+	// aux-grace window expired without a publication (opengrep on Windows:
+	// ~8s per scan against a 2s grace — the scanner's eventual findings sat
+	// in its client cache, agent-invisible). Probe each pending pair through
+	// the read-only cache seam (never spawns), freshness-gate the result
+	// against when the pair was marked, and deliver survivors as an advisory.
+	// A pair whose client is alive but has STILL published nothing re-arms
+	// (same original markedAtMs) until the TTL; a dead client drops silently.
+	const lateAuxStart = Date.now();
+	const drainedPairs = drainPendingAuxiliaryCoverage();
+	let lateAuxDelivered = 0;
+	let lateAuxStale = 0;
+	let lateAuxMissing = 0;
+	let lateAuxRearmed = 0;
+	let lateAuxClientGone = 0;
+	if (drainedPairs.length > 0) {
+		const byFile = new Map<string, typeof drainedPairs>();
+		for (const pair of drainedPairs) {
+			const list = byFile.get(pair.filePath);
+			if (list) list.push(pair);
+			else byFile.set(pair.filePath, [pair]);
+		}
+		try {
+			const service = getLSPService();
+			for (const [lateAuxPath, pairs] of byFile) {
+				let cached: Map<string, LSPDiagnostic[]>;
+				try {
+					cached = await service.readCachedDiagnosticsForServers(
+						lateAuxPath,
+						new Set(pairs.map((p) => p.serverId)),
+					);
+				} catch {
+					continue;
+				}
+				const displayLateAuxPath = toRunnerDisplayPath(cwd, lateAuxPath);
+				for (const pair of pairs) {
+					const rawDiags = cached.get(pair.serverId);
+					if (rawDiags === undefined) {
+						// No live client for this server any more — best-effort probe,
+						// drop the pair silently.
+						lateAuxClientGone += 1;
+						continue;
+					}
+					if (rawDiags.length === 0) {
+						// Still scanning (or published nothing yet) — keep waiting
+						// within the TTL so a scan finishing before the NEXT turn end
+						// still delivers. The original markedAtMs survives re-arming:
+						// it is the freshness baseline, not a recency stamp.
+						if (Date.now() - pair.markedAtMs < LATE_AUX_REARM_TTL_MS) {
+							markPendingAuxiliaryCoverage(
+								lateAuxPath,
+								[pair.serverId],
+								pair.markedAtMs,
+							);
+							lateAuxRearmed += 1;
+						}
+						continue;
+					}
+					const converted = convertLspDiagnostics(rawDiags, lateAuxPath, {
+						tool: "lsp",
+					});
+					if (converted.length === 0) continue;
+					// Freshness kernel (#1634 gated surface): stat the cited file
+					// against the mark timestamp. Missing → drop (no remediation for
+					// a deleted file); mtime drifted past the mark → drop too, NOT
+					// demote — unlike the cached-blocker gates these findings were
+					// NEVER delivered before, and the edit that drifted the file
+					// already re-touched it (a fresh pending pair supersedes this
+					// one), so a stale-arm replay would double-report old content.
+					// Both drops are COUNTED here and in the latency record below —
+					// never silent (shape 10).
+					const gate = gateFindingsByPathFreshness({
+						store: "late-auxiliary-findings",
+						findings: converted,
+						cwd,
+						scannedAt: pair.markedAtMs,
+						citedPath: () => lateAuxPath,
+					});
+					lateAuxStale += gate.stale.length;
+					lateAuxMissing +=
+						converted.length - gate.live.length - gate.stale.length;
+					if (gate.live.length === 0) continue;
+					const lines = gate.live.map(
+						(f) =>
+							`  ${displayLateAuxPath}:${f.line}:${f.column} [${f.rule}] ${f.message}`,
+					);
+					lateAuxDelivered += gate.live.length;
+					// @delivery-surface: runtime-turn:late-auxiliary-findings
+					advisoryParts.push(
+						`🕐 Late auxiliary diagnostics (${pair.serverId} answered after its grace window):\n${lines.join("\n")}`,
+					);
+				}
+			}
+		} catch (err) {
+			dbg(`turn_end: late-auxiliary probe failed: ${err}`);
+		}
+		logLatency({
+			type: "phase",
+			toolName: "turn_end",
+			filePath: cwd,
+			phase: "late_auxiliary_findings",
+			durationMs: Date.now() - lateAuxStart,
+			metadata: {
+				pending: drainedPairs.length,
+				delivered: lateAuxDelivered,
+				stale: lateAuxStale,
+				missing: lateAuxMissing,
+				rearmed: lateAuxRearmed,
+				clientGone: lateAuxClientGone,
+			},
+		});
+	}
 
 	const labeledAdvisoryParts = advisoryParts.map(
 		(p) => `ℹ️ Advisory — no action required this turn:\n${p}`,

--- a/tests/clients/finding-delivery-gate.test.ts
+++ b/tests/clients/finding-delivery-gate.test.ts
@@ -64,6 +64,7 @@ const EXPECTED_SURFACE_IDS = [
 	"runtime-turn:actionable-warnings-advisory",
 	"runtime-turn:code-quality-warnings-advisory",
 	"runtime-turn:disposition-suppressed-notice",
+	"runtime-turn:late-auxiliary-findings",
 	"runtime-turn:cascade-blocker",
 	"runtime-turn:cascade-coverage-advisory",
 	"runtime-turn:call-graph-advisory",

--- a/tests/clients/lsp/late-auxiliary-findings.test.ts
+++ b/tests/clients/lsp/late-auxiliary-findings.test.ts
@@ -38,7 +38,7 @@ import {
 	drainPendingAuxiliaryCoverage,
 	LATE_AUX_REARM_TTL_MS,
 	markPendingAuxiliaryCoverage,
-	resetPendingAuxiliaryCoverageForTests,
+	resetPendingAuxiliaryCoverage,
 } from "../../../clients/lsp/pending-aux-coverage.js";
 import type { LSPDiagnostic } from "../../../clients/lsp/client.js";
 import { setupTestEnvironment } from "../test-utils.js";
@@ -128,11 +128,11 @@ function lateAuxRecord(): any | undefined {
 beforeEach(() => {
 	readCachedDiagnosticsForServers.mockReset();
 	logLatency.mockClear();
-	resetPendingAuxiliaryCoverageForTests();
+	resetPendingAuxiliaryCoverage();
 });
 
 afterEach(() => {
-	resetPendingAuxiliaryCoverageForTests();
+	resetPendingAuxiliaryCoverage();
 });
 
 describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
@@ -275,7 +275,7 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 			// Past the TTL the same empty probe retires the pair instead. The
 			// store preserves a live pair's baseline, so expire by draining first
 			// and marking fresh with an already-aged timestamp.
-			resetPendingAuxiliaryCoverageForTests();
+			resetPendingAuxiliaryCoverage();
 			registerEdit(env, "late-aux-rearm", cacheManager, file);
 			markPendingAuxiliaryCoverage(
 				file,

--- a/tests/clients/lsp/late-auxiliary-findings.test.ts
+++ b/tests/clients/lsp/late-auxiliary-findings.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Turn-end collect-later delivery for slow auxiliary LSP servers
+ * (#2001/#2002).
+ *
+ * Drives the real `handleTurnEnd` against a mocked `getLSPService()` seam
+ * (the process boundary — a real auxiliary client is an external child
+ * process) and asserts the agent-visible guarantees:
+ *   1. Findings an auxiliary published AFTER its aux-grace window expired are
+ *      probed from the client cache at the next turn end and DELIVERED as an
+ *      advisory (`runtime-turn:late-auxiliary-findings`, gated surface).
+ *   2. A cited file edited after the mark timestamp drops its findings; a
+ *      deleted cited file drops too. Neither is delivered stale, and both are
+ *      counted in the `late_auxiliary_findings` latency record.
+ *   3. A pair whose client is alive but still empty re-arms within the TTL
+ *      (original markedAtMs preserved); a dead client's pair drops silently.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readCachedDiagnosticsForServers = vi.hoisted(() => vi.fn());
+vi.mock("../../../clients/lsp/index.js", () => ({
+	// Only `getLSPService` crosses this seam in handleTurnEnd's import graph.
+	getLSPService: () => ({ readCachedDiagnosticsForServers }),
+}));
+
+const logLatency = vi.hoisted(() => vi.fn());
+vi.mock("../../../clients/latency-logger.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../../clients/latency-logger.js")>();
+	return { ...actual, logLatency };
+});
+
+import { CacheManager } from "../../../clients/cache-manager.js";
+import { RuntimeCoordinator } from "../../../clients/runtime-coordinator.js";
+import { handleTurnEnd } from "../../../clients/runtime-turn.js";
+import {
+	drainPendingAuxiliaryCoverage,
+	LATE_AUX_REARM_TTL_MS,
+	markPendingAuxiliaryCoverage,
+	resetPendingAuxiliaryCoverageForTests,
+} from "../../../clients/lsp/pending-aux-coverage.js";
+import type { LSPDiagnostic } from "../../../clients/lsp/client.js";
+import { setupTestEnvironment } from "../test-utils.js";
+
+function diag(line: number, message: string): LSPDiagnostic {
+	return {
+		range: {
+			start: { line, character: 0 },
+			end: { line, character: 10 },
+		},
+		severity: 2,
+		code: "rule-x",
+		source: "opengrep",
+		message,
+	};
+}
+
+function makeDeps(
+	runtime: RuntimeCoordinator,
+	cacheManager: CacheManager,
+	cwd: string,
+) {
+	return {
+		ctxCwd: cwd,
+		getFlag: () => false,
+		dbg: () => {},
+		runtime,
+		cacheManager,
+		knipClient: {
+			ensureAvailable: async () => false,
+			analyze: async () => ({
+				success: true,
+				issues: [],
+				unusedExports: [],
+				unusedFiles: [],
+				unusedDeps: [],
+				unlistedDeps: [],
+				summary: "skipped",
+			}),
+		},
+		deadCodeClients: [],
+		depChecker: { ensureAvailable: async () => false },
+		testRunnerClient: { getTestRunTarget: () => null },
+		resetLSPService: () => {},
+		resetFormatService: () => {},
+	} as any;
+}
+
+/** Register the file as modified this turn so turn_end runs its main path. */
+function registerEdit(
+	env: { tmpDir: string },
+	sessionId: string,
+	cacheManager: CacheManager,
+	filePath: string,
+	content = "export const value = 1;\n",
+): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content);
+	// Pin mtime 10s in the past so the freshness relation is explicit.
+	const past = new Date(Date.now() - 10_000);
+	fs.utimesSync(filePath, past, past);
+	cacheManager.addModifiedRange(
+		filePath,
+		{ start: 1, end: 1 },
+		false,
+		env.tmpDir,
+		sessionId,
+	);
+}
+
+function turnEndContent(cacheManager: CacheManager, cwd: string): string {
+	return (
+		cacheManager.readCache<{ content: string }>("turn-end-findings", cwd)?.data
+			?.content ?? ""
+	);
+}
+
+function lateAuxRecord(): any | undefined {
+	return logLatency.mock.calls
+		.map((call) => call[0])
+		.find(
+			(entry: any) =>
+				entry?.type === "phase" && entry?.phase === "late_auxiliary_findings",
+		);
+}
+
+beforeEach(() => {
+	readCachedDiagnosticsForServers.mockReset();
+	logLatency.mockClear();
+	resetPendingAuxiliaryCoverageForTests();
+});
+
+afterEach(() => {
+	resetPendingAuxiliaryCoverageForTests();
+});
+
+describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
+	it("delivers findings an auxiliary published after its grace window expired", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-deliver-") as any;
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-session" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const file = path.join(env.tmpDir, "src", "scanned.ts");
+			registerEdit(env, "late-aux-session", cacheManager, file);
+
+			// The grace expired without publication → the pair was marked ~2s
+			// AFTER the file write but BEFORE the scan finished.
+			markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 2000);
+			// By turn end the scanner has published into its client cache.
+			readCachedDiagnosticsForServers.mockImplementation(
+				async (_filePath: string, serverIds: ReadonlySet<string>) => {
+					const out = new Map<string, LSPDiagnostic[]>();
+					if (serverIds.has("opengrep"))
+						out.set("opengrep", [diag(4, "late finding body")]);
+					return out;
+				},
+			);
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+
+			const content = turnEndContent(cacheManager, env.tmpDir);
+			expect(content).toContain("Late auxiliary diagnostics");
+			expect(content).toContain("opengrep");
+			expect(content).toContain("late finding body");
+			expect(content).toContain(path.basename(file));
+
+			// The pair was consumed, not left pending.
+			expect(drainPendingAuxiliaryCoverage()).toHaveLength(0);
+
+			// One bounded latency record names the outcome counts.
+			const record = lateAuxRecord();
+			expect(record).toBeDefined();
+			expect(record.metadata).toMatchObject({
+				pending: 1,
+				delivered: 1,
+				stale: 0,
+				rearmed: 0,
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("drops findings when the cited file was edited after the mark", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-stale-") as any;
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-stale" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const file = path.join(env.tmpDir, "src", "stale.ts");
+			registerEdit(env, "late-aux-stale", cacheManager, file);
+
+			// Marked long before the edit that drifted the file past the mark:
+			// mtime (now-10s) > mark (now-60s) + tolerance → stale → drop.
+			markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 60_000);
+			readCachedDiagnosticsForServers.mockImplementation(
+				async () => new Map([["opengrep", [diag(0, "should not appear")]]]),
+			);
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+
+			const content = turnEndContent(cacheManager, env.tmpDir);
+			expect(content).not.toContain("should not appear");
+			expect(content).not.toContain("Late auxiliary diagnostics");
+
+			const record = lateAuxRecord();
+			expect(record).toBeDefined();
+			expect(record.metadata).toMatchObject({ pending: 1, delivered: 0 });
+			expect(record.metadata.stale).toBeGreaterThan(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("drops findings when the cited file is gone", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-deleted-") as any;
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-deleted" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const kept = path.join(env.tmpDir, "src", "kept.ts");
+			registerEdit(env, "late-aux-deleted", cacheManager, kept);
+
+			const deleted = path.join(env.tmpDir, "src", "deleted.ts");
+			markPendingAuxiliaryCoverage(deleted, ["opengrep"], Date.now() - 2000);
+			readCachedDiagnosticsForServers.mockImplementation(
+				async () =>
+					new Map([["opengrep", [diag(0, "finding for deleted file")]]]),
+			);
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+
+			const content = turnEndContent(cacheManager, env.tmpDir);
+			expect(content).not.toContain("finding for deleted file");
+			const record = lateAuxRecord();
+			expect(record).toBeDefined();
+			expect(record.metadata.missing).toBeGreaterThan(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("re-arms an alive-but-empty probe within the TTL and preserves the baseline", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-rearm-") as any;
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-rearm" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const file = path.join(env.tmpDir, "src", "slow.ts");
+			registerEdit(env, "late-aux-rearm", cacheManager, file);
+
+			const markedAt = Date.now() - 1000;
+			markPendingAuxiliaryCoverage(file, ["opengrep"], markedAt);
+			// Client alive (present in the map) but the scan has not landed yet.
+			readCachedDiagnosticsForServers.mockImplementation(
+				async () => new Map([["opengrep", []]]),
+			);
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+
+			// Nothing delivered, but the pair survives for the NEXT turn end.
+			expect(turnEndContent(cacheManager, env.tmpDir)).not.toContain(
+				"Late auxiliary diagnostics",
+			);
+			const stillPending = drainPendingAuxiliaryCoverage();
+			expect(stillPending).toHaveLength(1);
+			expect(stillPending[0].markedAtMs).toBe(markedAt);
+
+			// Past the TTL the same empty probe retires the pair instead. The
+			// store preserves a live pair's baseline, so expire by draining first
+			// and marking fresh with an already-aged timestamp.
+			resetPendingAuxiliaryCoverageForTests();
+			registerEdit(env, "late-aux-rearm", cacheManager, file);
+			markPendingAuxiliaryCoverage(
+				file,
+				["opengrep"],
+				Date.now() - LATE_AUX_REARM_TTL_MS - 5000,
+			);
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+			expect(drainPendingAuxiliaryCoverage()).toHaveLength(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("drops a pair silently when the auxiliary client is gone", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-gone-") as any;
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-gone" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const file = path.join(env.tmpDir, "src", "gone.ts");
+			registerEdit(env, "late-aux-gone", cacheManager, file);
+
+			markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 2000);
+			// The service answers with an EMPTY map: no live client for opengrep.
+			readCachedDiagnosticsForServers.mockImplementation(async () => new Map());
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+
+			expect(drainPendingAuxiliaryCoverage()).toHaveLength(0);
+			const record = lateAuxRecord();
+			expect(record).toBeDefined();
+			expect(record.metadata.clientGone).toBe(1);
+			expect(record.metadata.rearmed).toBe(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+});

--- a/tests/clients/lsp/pending-aux-coverage.test.ts
+++ b/tests/clients/lsp/pending-aux-coverage.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the #2001/#2002 collect-later pending store
+ * (`clients/lsp/pending-aux-coverage.ts`).
+ *
+ * The store is the bounded hand-off between the aux-grace producer
+ * (`clients/lsp/index.ts`) and the turn-end consumer
+ * (`clients/runtime-turn.ts`). These tests pin its contract: bounded pair
+ * count with oldest-eviction, freshness-baseline preservation across re-arm,
+ * and path-key normalization so mixed-separator spellings of one file share
+ * one entry (the #210 path-key class).
+ */
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+	MAX_PENDING_AUX_ENTRIES,
+	clearPendingAuxiliaryCoverage,
+	drainPendingAuxiliaryCoverage,
+	LATE_AUX_REARM_TTL_MS,
+	markPendingAuxiliaryCoverage,
+	pendingAuxiliaryCoverageSizeForTests,
+	resetPendingAuxiliaryCoverageForTests,
+} from "../../../clients/lsp/pending-aux-coverage.js";
+
+beforeEach(() => {
+	resetPendingAuxiliaryCoverageForTests();
+});
+
+describe("pending auxiliary coverage store (#2001/#2002)", () => {
+	it("drains marked pairs and empties the store", () => {
+		markPendingAuxiliaryCoverage("C:/proj/src/a.ts", ["opengrep"], 1000);
+		markPendingAuxiliaryCoverage("C:/proj/src/a.ts", ["typos"], 2000);
+
+		expect(pendingAuxiliaryCoverageSizeForTests()).toBe(2);
+		const drained = drainPendingAuxiliaryCoverage();
+		expect(pendingAuxiliaryCoverageSizeForTests()).toBe(0);
+		expect(drained.map((e) => e.serverId).sort()).toEqual([
+			"opengrep",
+			"typos",
+		]);
+		// Original display spelling survives; only keys are normalized.
+		expect(drained.every((e) => e.filePath === "C:/proj/src/a.ts")).toBe(true);
+		expect(drained.find((e) => e.serverId === "opengrep")?.markedAtMs).toBe(
+			1000,
+		);
+	});
+
+	it("re-marking an existing pair preserves its original markedAtMs", () => {
+		markPendingAuxiliaryCoverage("/w/a.ts", ["opengrep"], 1111);
+		// Turn-end re-arm passes the SAME baseline back; a plain re-mark from
+		// another touch must not clobber it either.
+		markPendingAuxiliaryCoverage("/w/a.ts", ["opengrep"], 9999);
+
+		const drained = drainPendingAuxiliaryCoverage();
+		expect(drained).toHaveLength(1);
+		expect(drained[0].markedAtMs).toBe(1111);
+	});
+
+	it("clearPendingAuxiliaryCoverage removes exactly one pair", () => {
+		markPendingAuxiliaryCoverage("/w/a.ts", ["opengrep", "typos"], 1000);
+		clearPendingAuxiliaryCoverage("/w/a.ts", "opengrep");
+
+		const drained = drainPendingAuxiliaryCoverage();
+		expect(drained.map((e) => e.serverId)).toEqual(["typos"]);
+	});
+
+	it("mixed-separator spellings of one file share one pair per server", () => {
+		// Same-case, cross-separator: the #210 path-key class. Keys fold through
+		// normalizeEphemeralMapKey, so these two marks are ONE pair.
+		markPendingAuxiliaryCoverage("C:\\proj\\src\\a.ts", ["opengrep"], 1000);
+		markPendingAuxiliaryCoverage("C:/proj/src/a.ts", ["opengrep"], 2000);
+
+		expect(pendingAuxiliaryCoverageSizeForTests()).toBe(1);
+		const drained = drainPendingAuxiliaryCoverage();
+		expect(drained[0].markedAtMs).toBe(1000);
+	});
+
+	it("evicts the OLDEST pair beyond the cap (bounded store, shape 9)", () => {
+		expect(MAX_PENDING_AUX_ENTRIES).toBeLessThanOrEqual(50);
+		for (let i = 0; i < MAX_PENDING_AUX_ENTRIES + 5; i++) {
+			markPendingAuxiliaryCoverage(`/w/file${i}.ts`, ["opengrep"], i);
+		}
+		expect(pendingAuxiliaryCoverageSizeForTests()).toBe(
+			MAX_PENDING_AUX_ENTRIES,
+		);
+		const drained = drainPendingAuxiliaryCoverage();
+		// The first-marked pairs were evicted; the newest survive.
+		expect(drained.some((e) => e.filePath === "/w/file0.ts")).toBe(false);
+		expect(
+			drained.some(
+				(e) => e.filePath === `/w/file${MAX_PENDING_AUX_ENTRIES + 4}.ts`,
+			),
+		).toBe(true);
+	});
+
+	it("re-arming a pair refreshes eviction recency without moving the baseline", () => {
+		for (let i = 0; i < MAX_PENDING_AUX_ENTRIES; i++) {
+			markPendingAuxiliaryCoverage(`/w/file${i}.ts`, ["opengrep"], i);
+		}
+		// Re-mark the OLDEST entry: it must jump to the back of the eviction
+		// order AND keep its original timestamp.
+		markPendingAuxiliaryCoverage("/w/file0.ts", ["opengrep"], 0);
+		// One more insert forces one eviction — of file1, not the re-armed file0.
+		markPendingAuxiliaryCoverage("/w/overflow.ts", ["opengrep"], 10_000);
+		expect(pendingAuxiliaryCoverageSizeForTests()).toBe(
+			MAX_PENDING_AUX_ENTRIES,
+		);
+
+		const drained = drainPendingAuxiliaryCoverage();
+		expect(drained.some((e) => e.filePath === "/w/file0.ts")).toBe(true);
+		expect(drained.some((e) => e.filePath === "/w/file1.ts")).toBe(false);
+		const file0 = drained.find((e) => e.filePath === "/w/file0.ts");
+		expect(file0?.markedAtMs).toBe(0);
+	});
+
+	it("exposes a positive re-arm TTL (a zero TTL would drop every slow scanner)", () => {
+		expect(LATE_AUX_REARM_TTL_MS).toBeGreaterThan(60_000);
+	});
+});

--- a/tests/clients/lsp/pending-aux-coverage.test.ts
+++ b/tests/clients/lsp/pending-aux-coverage.test.ts
@@ -17,11 +17,11 @@ import {
 	LATE_AUX_REARM_TTL_MS,
 	markPendingAuxiliaryCoverage,
 	pendingAuxiliaryCoverageSizeForTests,
-	resetPendingAuxiliaryCoverageForTests,
+	resetPendingAuxiliaryCoverage,
 } from "../../../clients/lsp/pending-aux-coverage.js";
 
 beforeEach(() => {
-	resetPendingAuxiliaryCoverageForTests();
+	resetPendingAuxiliaryCoverage();
 });
 
 describe("pending auxiliary coverage store (#2001/#2002)", () => {

--- a/tests/clients/lsp/pending-aux-coverage.test.ts
+++ b/tests/clients/lsp/pending-aux-coverage.test.ts
@@ -43,15 +43,16 @@ describe("pending auxiliary coverage store (#2001/#2002)", () => {
 		);
 	});
 
-	it("re-marking an existing pair preserves its original markedAtMs", () => {
+	it("re-marking an existing pair BUMPS its markedAtMs (#2027 review)", () => {
+		// #2027 round-1 P2-1: the baseline must advance when a newer touch
+		// re-marks, so post-baseline mtimes don't falsely read as stale and
+		// drop current-revision findings.
 		markPendingAuxiliaryCoverage("/w/a.ts", ["opengrep"], 1111);
-		// Turn-end re-arm passes the SAME baseline back; a plain re-mark from
-		// another touch must not clobber it either.
 		markPendingAuxiliaryCoverage("/w/a.ts", ["opengrep"], 9999);
 
 		const drained = drainPendingAuxiliaryCoverage();
 		expect(drained).toHaveLength(1);
-		expect(drained[0].markedAtMs).toBe(1111);
+		expect(drained[0].markedAtMs).toBe(9999);
 	});
 
 	it("clearPendingAuxiliaryCoverage removes exactly one pair", () => {
@@ -70,7 +71,7 @@ describe("pending auxiliary coverage store (#2001/#2002)", () => {
 
 		expect(pendingAuxiliaryCoverageSizeForTests()).toBe(1);
 		const drained = drainPendingAuxiliaryCoverage();
-		expect(drained[0].markedAtMs).toBe(1000);
+		expect(drained[0].markedAtMs).toBe(2000); // newer mark bumps baseline
 	});
 
 	it("evicts the OLDEST pair beyond the cap (bounded store, shape 9)", () => {

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -189,6 +189,16 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 		reason:
 			"#2000 phase 2: pending pre-command baselines are keyed cwd:generation and become unreachable when the session generation advances; and the git-worktree memo must re-probe after a session that may have seen a directory become a worktree. Without the reset both leak per session and the memo mis-answers forever.",
 	},
+	// ── #2026 pending auxiliary coverage baselines ──────────────────────
+	{
+		id: "lsp:pending-aux-coverage",
+		module: "lsp/pending-aux-coverage.ts",
+		state: "pending Map (filePath,serverId) pairs",
+		policy: "session_start",
+		resetName: "resetPendingAuxiliaryCoverage",
+		reason:
+			"#2026: pending auxiliary baselines are keyed by cwd and become unreachable when the session generation advances.",
+	},
 	// ── The named population from #1635 ──────────────────────────────────────
 	{
 		id: "degradation-ledger:onceKeys",
@@ -905,6 +915,7 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	// #2000 phase 2: the pending-baseline store (one slot per cwd:generation)
 	// plus the process-global Symbol.for slot; cleared via resetOpaqueMutationState.
 	"opaque-mutation-scan.ts": 1,
+	"lsp/pending-aux-coverage.ts": 1,
 	"lsp/jvm-runtime.ts": 0,
 	"lsp/spawn-history.ts": 1,
 	"lsp/server.ts": 5,


### PR DESCRIPTION
Implements the general COLLECT-LATER delivery pattern for ALL auxiliary-role LSP servers that don't answer within their budget (#2001 opengrep, #2002 typos, and any future slow scanner).

## Design

When aux-grace expires without publication from an auxiliary:
1. The (filePath, serverId) pair is marked in a bounded pending store (`clients/lsp/pending-aux-coverage.ts`, cap 50, oldest-evicted)
2. At the next turn_end, each pending pair is probed via a new read-only seam (`LSPService.readCachedDiagnosticsForServers`) — never spawns/warms/waits
3. Late findings are freshness-gated: stat the file, compare mtime against `markedAtMs`, drop stale or deleted
4. Delivered through registered surface `runtime-turn:late-auxiliary-findings` (GATED)

## Why this matters

Live evidence (#2001): opengrep on Windows takes 8+ seconds per scan — the 2s ceiling cuts it off 64% of the time. Under sync-wait, those edits get ZERO security-scanner coverage. Collect-later delivers ~100% of findings with one-turn delay.

## Honest scope

- Stale findings are DROPPED not demoted (#1419's usual rule) because they were never delivered at full authority; reasoning documented at call site + registry
- The probe is best-effort: LSP client gone → drop silently
- Re-arm within 5min TTL for still-empty probes (avoids re-probing every turn)

## Blast radius

New module (129 lines) + touchFile producer hook + runtime-turn consumer + registry entry. No existing behavior changed — coverage-gap reporting (unconfirmedServerIds) is untouched; this ADDS a delivery path that didn't exist before.

Closes #2001, closes #2002, refs #2026