### PR TITLE
fix(spawn): pin chcp via absolute path (closes #2023)

### DIFF
--- a/.changelog/fix-2023-pin-chcp-absolute-path.md
+++ b/.changelog/fix-2023-pin-chcp-absolute-path.md
@@ -1,0 +1,10 @@
+---
+section: Fixed
+---
+
+- **Windows `.cmd`/`.bat` spawns no longer fail when System32 is absent from the child PATH (closes #2023)** — The cmd.exe wrapper prefixed every spawn
+  with a bare `chcp 65001 &&`. When the child environment's PATH could not
+  resolve `chcp.com`, the lookup failed and `&&` short-circuited, so the whole
+  spawn exited 1 with empty output. chcp is now invoked via its pinned
+  `%SystemRoot%\System32\chcp.com` absolute path and chained with `&`, so a
+  code-page failure can never suppress the real command.

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -475,13 +475,19 @@ function cmdEscapeArg(arg: string): string {
  * that already worked. The `chcp 65001` prefix forces the UTF-8 code page (so
  * tool output isn't mangled by the system code page) and, as a side benefit,
  * keeps the (possibly quoted) command off the front of the line, avoiding
- * cmd.exe's `/s` outer-quote-stripping quirk.
+ * cmd.exe's `/s` outer-quote-stripping quirk. #2023: chcp is invoked via its
+ * absolute `%SystemRoot%\System32\chcp.com` path and chained with `&`, not
+ * `&&` — a child environment whose PATH cannot resolve System32 used to fail
+ * the bare `chcp` lookup, and `&&` then short-circuited EVERY .cmd/.bat spawn
+ * into exit 1 with empty output. With the pin plus `&`, even a chcp failure
+ * can never suppress the real command.
  */
 export function buildWindowsShellCommand(
 	command: string,
 	args: string[],
 ): string {
-	return `chcp 65001 >nul 2>&1 && ${[command, ...args].map(cmdEscapeArg).join(" ")}`;
+	const chcp = `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\chcp.com`;
+	return `${chcp} 65001 >nul 2>&1 & ${[command, ...args].map(cmdEscapeArg).join(" ")}`;
 }
 
 // ============================================================================

--- a/tests/clients/installer/installer-lifecycle.integration.test.ts
+++ b/tests/clients/installer/installer-lifecycle.integration.test.ts
@@ -90,10 +90,11 @@ function testEnv(
 ): NodeJS.ProcessEnv {
 	const nodeDir = path.dirname(process.execPath);
 	// #2015: verifyToolBinary routes through safeSpawnAsync, whose Windows
-	// .cmd/.bat wrapper runs `chcp 65001 && <shim>` (clients/safe-spawn.ts).
-	// chcp.com lives in System32, so System32 must stay on PATH or every
-	// .cmd shim probe exits 1 with no output. Node's dir stays first so the
-	// restricted PATH still cannot collide with a real oxlint.
+	// .cmd/.bat wrapper runs `chcp ... & <shim>` (clients/safe-spawn.ts).
+	// Since #2023 chcp is invoked via its pinned System32 absolute path, so
+	// System32 no longer HAS to be on PATH; keeping it here exercises the
+	// restricted-PATH scenario without depending on the pin. Node's dir stays
+	// first so the restricted PATH still cannot collide with a real oxlint.
 	const toolPath =
 		process.platform === "win32"
 			? `${nodeDir};${process.env.SystemRoot ?? "C:\\Windows"}\\System32`

--- a/tests/clients/safe-spawn-windows-command.test.ts
+++ b/tests/clients/safe-spawn-windows-command.test.ts
@@ -30,8 +30,9 @@ describe("buildWindowsShellCommand (Windows cmd.exe quoting — #214)", () => {
 	});
 
 	it("leaves a space-free command unquoted (no regression for npm/.pi-lens paths)", () => {
+		const chcp = `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\chcp.com`;
 		expect(buildWindowsShellCommand("ruff", ["check", "x.py"])).toBe(
-			"chcp 65001 >nul 2>&1 && ruff check x.py",
+			`${chcp} 65001 >nul 2>&1 & ruff check x.py`,
 		);
 	});
 
@@ -40,10 +41,12 @@ describe("buildWindowsShellCommand (Windows cmd.exe quoting — #214)", () => {
 		expect(s).toContain('"C:\\a b\\c.txt"');
 	});
 
-	it("always prefixes the UTF-8 code-page switch", () => {
-		expect(buildWindowsShellCommand("go", ["version"])).toMatch(
-			/^chcp 65001 >nul 2>&1 && /,
-		);
+	it("always prefixes the UTF-8 code-page switch, pinned via System32 (#2023)", () => {
+		const s = buildWindowsShellCommand("go", ["version"]);
+		// Absolute chcp path (independent of the child PATH) chained with `&`,
+		// so a chcp failure can never short-circuit the real command.
+		const chcp = `${process.env.SystemRoot ?? "C:\\Windows"}\\System32\\chcp.com`;
+		expect(s.startsWith(`${chcp} 65001 >nul 2>&1 & `)).toBe(true);
 	});
 
 	it("keeps shell metacharacters inside one argument", () => {
@@ -176,6 +179,24 @@ describe.runIf(process.platform === "win32")(
 			expect(JSON.parse(result.stdout)).toEqual(["hello world", "plain"]);
 		});
 
+		it("(b2) #2023: a .cmd shim still runs when the child PATH cannot resolve System32 (chcp is pinned)", async () => {
+			// Pre-fix, the cmd.exe wrapper prefixed every spawn with bare
+			// `chcp 65001 &&`. With System32 absent from the CHILD's PATH the
+			// chcp lookup failed inside cmd.exe and `&&` short-circuited, so the
+			// shim exited 1 with empty output. chcp is now invoked via its
+			// SystemRoot-pinned absolute path, independent of the child PATH.
+			const result = await safeSpawnAsync(echoArgsCmd, ["no-system32"], {
+				env: {
+					PATH: fixtureDir,
+					Path: fixtureDir,
+					PATHEXT: ".COM;.EXE;.BAT;.CMD",
+				},
+			});
+			expect(result.error).toBeUndefined();
+			expect(result.status).toBe(0);
+			expect(JSON.parse(result.stdout)).toEqual(["no-system32"]);
+		});
+
 		it('(c) an arg containing "%" targeting a .cmd shim is rejected loudly, nothing spawned', async () => {
 			const result = await safeSpawnAsync(echoArgsCmd, ["%APPDATA%.md"]);
 			expect(result.error).toBeDefined();
@@ -295,15 +316,14 @@ describe.runIf(process.platform === "win32")(
 			expect(JSON.parse(result.stdout)).toEqual(["hello world", "plain"]);
 		});
 
-		it("sync safeSpawn resolves a command from its overridden PATH", () => {
-			// Keep the ambient system directory after the fixture so the pinned
-			// cmd.exe can still find its `chcp` helper; the fixture remains first
-			// and is the only source of the command under test.
-			const overriddenPath = `${fixtureDir};${process.env.Path ?? process.env.PATH ?? ""}`;
+		it("sync safeSpawn resolves a command from its overridden PATH (#2023: System32 may be absent)", () => {
+			// The fixture is the ONLY entry — System32 is deliberately absent.
+			// chcp runs via its SystemRoot-pinned absolute path, so the wrapper
+			// no longer depends on the child environment resolving it.
 			const result = safeSpawn("echo-args", ["from-overridden-path"], {
 				env: {
-					PATH: overriddenPath,
-					Path: overriddenPath,
+					PATH: fixtureDir,
+					Path: fixtureDir,
 					PATHEXT: ".COM;.CMD",
 				},
 			});


### PR DESCRIPTION
Closes #2023 — safe-spawn's Windows `.cmd/.bat` wrapper no longer depends on the child environment's PATH for `chcp.com`.

## Root cause

`buildWindowsShellCommand` prefixed every cmd.exe spawn with `chcp 65001 && …`. When PATH couldn't resolve `chcp.com` (System32), the `&&` short-circuited and **every** `.cmd/.bat` spawn exited 1 with empty output — silently, since wrapper output is swallowed.

## Fix

Pin chcp via its absolute path (`%SystemRoot%\System32\chcp.com`) and chain with `&` instead of `&&` — so even if chcp fails, the actual command still runs.

## Tests (red-first proven)

- New `(b2)` test: safeSpawnAsync of a `.cmd` shim with child env PATH set to *only* the fixture dir. Failed pre-fix with status 1 / empty output.
- Sync-path overridden-PATH test tightened: removed the keep-System32 workaround; now red pre-fix too.
- 22/22 green on the suite; installer-lifecycle integration stays green.

Closes #2023