### PR TITLE
fix(test-runner): retire stale targets (closes #2044)

### DIFF
--- a/.changelog/fix-2044-retire-stale-test-targets.md
+++ b/.changelog/fix-2044-retire-stale-test-targets.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Retire deleted failed-first test targets (closes #2044)** — Test selection removes missing failed paths before choosing a target, then continues with valid failures or normal discovery.
+- **Retire deleted failed-first test targets (closes #2044)** — Test selection retires only confirmed-missing canonical paths with bounded work, then continues with valid failures or normal discovery.

--- a/.changelog/fix-2044-retire-stale-test-targets.md
+++ b/.changelog/fix-2044-retire-stale-test-targets.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Retire deleted failed-first test targets (closes #2044)** — Test selection removes missing failed paths before choosing a target, then continues with valid failures or normal discovery.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1607,7 +1607,7 @@ non-light behavior in a detected subagent child, either vocabulary),
 
 ## Runner process model
 
-Test-runner failed-first state is path-canonical at both the project-root and target boundaries. It retains at most 32 recent targets per runner and validates at most 8 candidates per selection. A probe retires state only on `ENOENT`/`ENOTDIR`; permission and transient errors retain the target. Remaining unchecked candidates carry into the next turn. Missing, indeterminate, and capacity-eviction outcomes use the bounded `test_runner_failed_target_state` telemetry phase, with exact ledger counts and at most eight detailed rows per turn. (#2044)
+Test-runner failed-first state is path-canonical at both the project-root and target boundaries while retaining the caller's path spelling for execution. It retains the globally newest 32 targets per runner and validates at most 8 candidates per selection. A probe retires state only on `ENOENT`/`ENOTDIR`; permission and transient errors retain the target. Remaining unchecked candidates carry into the next turn. Missing, indeterminate, and capacity-eviction outcomes use the bounded `test_runner_failed_target_state` telemetry phase, with exact ledger counts and at most eight detailed rows per originating turn. Per-turn telemetry counters retain 64 interleavable turn buckets; a result older than that bounded window fails closed rather than reopening its budget. (#2044)
 
 Expected runner skips must stay distinct from clean success and runner failure.
 Return a bounded machine-readable `skipReason` on `RunnerResult` and carry it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1607,6 +1607,8 @@ non-light behavior in a detected subagent child, either vocabulary),
 
 ## Runner process model
 
+Test-runner failed-first state is path-canonical at both the project-root and target boundaries. It retains at most 32 recent targets per runner and validates at most 8 candidates per selection. A probe retires state only on `ENOENT`/`ENOTDIR`; permission and transient errors retain the target. Remaining unchecked candidates carry into the next turn. Missing, indeterminate, and capacity-eviction outcomes use the bounded `test_runner_failed_target_state` telemetry phase, with exact ledger counts and at most eight detailed rows per turn. (#2044)
+
 Expected runner skips must stay distinct from clean success and runner failure.
 Return a bounded machine-readable `skipReason` on `RunnerResult` and carry it
 through the existing runner latency record. Do not emit an extension error for

--- a/clients/bounded-telemetry.ts
+++ b/clients/bounded-telemetry.ts
@@ -24,10 +24,9 @@
  *    that must re-arm at `session_start` and will eventually be forgotten
  *    (the #1266–#1625 defect class).
  * 2. **A per-turn cap names its turn.** `capPerTurn` carries the caller's
- *    `turnIndex` in the same object as the limit, so there is no separate
- *    reset to wire and forget: the counters clear when the observed turn
- *    changes. This is the same lazy clear-on-transition shape as
- *    `noteImportResolutionMemoTurn` (`clients/blocker-freshness.ts`).
+ *    `turnIndex` in the same object as the limit. A bounded 64-turn window
+ *    keeps overlapping async turns independent; results older than that window
+ *    fail closed. Session start clears the window when numbering restarts.
  * 3. **Identity always survives.** Every emitted record carries the
  *    discriminating identity in `filePath` and in `metadata.identity`, so
  *    aggregation can still answer "which file, which method, which record is
@@ -189,14 +188,15 @@ export type BoundedTelemetryPayload = Omit<
 };
 
 /**
- * Per-turn admission counters, keyed by phase. Cleared lazily when a call
- * observes a turn index different from the one the counters were built for,
- * and eagerly by `resetBoundedTelemetry` at `session_start` (a new session
- * restarts turn numbering at 0, so the lazy check alone could carry a stale
- * count across a session boundary that happened to land on the same index).
+ * Per-turn admission counters, keyed by turn and phase. Multiple turns remain
+ * live because async work can finish T1 after T2 has already emitted. The map
+ * retains a bounded recent window; work older than that window fails closed
+ * rather than reopening an exhausted budget. Session start clears all state.
  */
-let turnCounts = new Map<string, number>();
-let countedTurnIndex: number | undefined;
+const MAX_TRACKED_TURN_CAPS = 64;
+let turnCounts = new Map<number, Map<string, number>>();
+let latestCountedTurnIndex: number | undefined;
+let retiredThroughTurnIndex = Number.NEGATIVE_INFINITY;
 
 /**
  * Decide whether this occurrence earns a detailed record, and count it in the
@@ -275,13 +275,29 @@ function admitAgainstTurnCap(
 	cap: BoundedTelemetryOptions["capPerTurn"],
 ): boolean {
 	if (cap === undefined) return true;
-	if (countedTurnIndex !== cap.turnIndex) {
-		turnCounts = new Map();
-		countedTurnIndex = cap.turnIndex;
+	if (cap.turnIndex <= retiredThroughTurnIndex) return false;
+
+	let counts = turnCounts.get(cap.turnIndex);
+	if (!counts) {
+		if (turnCounts.size >= MAX_TRACKED_TURN_CAPS) {
+			const oldestTrackedTurn = Math.min(...turnCounts.keys());
+			if (cap.turnIndex < oldestTrackedTurn) return false;
+			turnCounts.delete(oldestTrackedTurn);
+			retiredThroughTurnIndex = Math.max(
+				retiredThroughTurnIndex,
+				oldestTrackedTurn,
+			);
+		}
+		counts = new Map();
+		turnCounts.set(cap.turnIndex, counts);
 	}
-	const used = turnCounts.get(phase) ?? 0;
+	latestCountedTurnIndex = Math.max(
+		latestCountedTurnIndex ?? cap.turnIndex,
+		cap.turnIndex,
+	);
+	const used = counts.get(phase) ?? 0;
 	if (used >= cap.limit) return false;
-	turnCounts.set(phase, used + 1);
+	counts.set(phase, used + 1);
 	return true;
 }
 
@@ -293,10 +309,20 @@ function admitAgainstTurnCap(
  */
 export function resetBoundedTelemetry(): void {
 	turnCounts = new Map();
-	countedTurnIndex = undefined;
+	latestCountedTurnIndex = undefined;
+	retiredThroughTurnIndex = Number.NEGATIVE_INFINITY;
 }
 
-/** Test-only: the live per-turn admission count for a phase. */
-export function _boundedTurnCountForTest(phase: string): number {
-	return turnCounts.get(phase) ?? 0;
+/** Test-only: one turn's live admission count for a phase. */
+export function _boundedTurnCountForTest(
+	phase: string,
+	turnIndex = latestCountedTurnIndex,
+): number {
+	if (turnIndex === undefined) return 0;
+	return turnCounts.get(turnIndex)?.get(phase) ?? 0;
+}
+
+/** Test-only: number of turn buckets retained by the bounded counter. */
+export function _boundedTrackedTurnsForTest(): number {
+	return turnCounts.size;
 }

--- a/clients/bounded-telemetry.ts
+++ b/clients/bounded-telemetry.ts
@@ -89,6 +89,12 @@ export const BOUNDED_TELEMETRY_PHASES = [
 	 */
 	"lsp_warm_client_missing",
 	/**
+	 * #2044: failed-first test state was retired after a confirmed missing path,
+	 * retained because the filesystem verdict was indeterminate, or evicted at
+	 * the state cap. Selection checks and detailed rows are both capped per turn.
+	 */
+	"test_runner_failed_target_state",
+	/**
 	 * #1723: an event-loop block at or above the floor. Not a degradation, so
 	 * no ledger kind; bounded by call cadence (one `turn_end` runs it once per
 	 * turn) rather than by an option here.

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -64,6 +64,13 @@ export type DegradationKind =
 	 * is the exact number of detections this session.
 	 */
 	| "snapshot-integrity"
+	/**
+	 * Failed-first test state was retired only after ENOENT/ENOTDIR evidence,
+	 * retained when the filesystem probe was indeterminate, or evicted at the
+	 * state cap (#2044). Subject is outcome + runner + bounded path, so repeated
+	 * checks stay attributable.
+	 */
+	| "test-runner-failed-target-state"
 	| "formatter-failure"
 	| "wasm-abort"
 	| "lsp-diagnostics-timeout"

--- a/clients/latency-logger.ts
+++ b/clients/latency-logger.ts
@@ -117,6 +117,10 @@ let recentPhases: Array<{ phase: string; ts: string }> = [];
  * #1996: `cache_usage_summary` is a zero-duration session rollup over earlier
  * usage records. It reports no new work and therefore cannot own last-phase
  * stall attribution.
+ *
+ * #2044: `test_runner_failed_target_state` is a zero-duration decision after a
+ * bounded filesystem probe. The surrounding turn-end test-selection phase owns
+ * any real work, so this row must not replace it in stall attribution.
  */
 const LAST_PHASE_EXCLUDED = new Set([
 	"loop_block",
@@ -127,6 +131,7 @@ const LAST_PHASE_EXCLUDED = new Set([
 	"agent_end_deferred_mutation_requeue",
 	"session_end_bus_rollup",
 	"cache_usage_summary",
+	"test_runner_failed_target_state",
 	"lsp_aux_wait_outcome",
 	"tool_set_mutation",
 	"availability_decision",

--- a/clients/path-keyed-map.ts
+++ b/clients/path-keyed-map.ts
@@ -51,7 +51,18 @@ export class PathKeyedMap<V> {
 	}
 
 	delete(path: string): boolean {
-		return this.store.delete(this.normalize(path));
+		if (this.store.delete(this.normalize(path))) return true;
+		// A filesystem-aware normalizer can change after the keyed file is
+		// deleted (for example, real on-disk casing becomes a lowercased missing
+		// tail on Windows). The caller may still hold the exact display key it
+		// received from this map. Honor that captured identity without deriving a
+		// second path form, so deletion remains possible across existence changes.
+		for (const [key, entry] of this.store) {
+			if (entry.displayPath !== path) continue;
+			this.store.delete(key);
+			return true;
+		}
+		return false;
 	}
 
 	clear(): void {

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -1753,7 +1753,11 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 		}
 
 		for (const { display, abs, isNeighbor } of candidates) {
-			const target = testRunnerClient.getTestRunTarget(abs, cwd);
+			const target = testRunnerClient.getTestRunTarget(
+				abs,
+				cwd,
+				runtime.turnIndex,
+			);
 			if (target && !seen.has(target.testFile)) {
 				seen.add(target.testFile);
 				targets.push(target);
@@ -1800,12 +1804,11 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 			);
 			Promise.allSettled(
 				targets.map((t) =>
-					testRunnerClient.runTestFileAsync(
-						t.testFile,
-						cwd,
-						t.runner,
-						t.config,
-					),
+					testRunnerClient.runTestFileAsync(t.testFile, cwd, {
+						runner: t.runner,
+						config: t.config,
+						turnIndex: firedAtTurn,
+					}),
 				),
 			)
 				.then((results) => {

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -11,12 +11,16 @@
  * specific file being edited, not the entire suite.
  */
 
-import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { emitBounded } from "./bounded-telemetry.js";
+import { truncateForLedger } from "./degradation-ledger.js";
 import { minimatch } from "./deps/minimatch.js";
+import { createSubsystemLogger } from "./extension-log.js";
 import { detectFileRole } from "./file-role.js";
 import { findGlobalBinary } from "./package-manager.js";
+import { PathKeyedMap } from "./path-keyed-map.js";
+import { normalizeMapKey } from "./path-utils.js";
 import { isMeasuredDuration, toMeasuredDurationMs } from "./run-duration.js";
 import { safeSpawn, safeSpawnAsync } from "./safe-spawn.js";
 
@@ -260,11 +264,81 @@ export function stripWrapperArgs(binName: string, args: string[]): string[] {
 
 // --- Client ---
 
+const MAX_FAILED_TARGETS_PER_RUNNER = 32;
+const MAX_FAILED_TARGET_CHECKS_PER_SELECTION = 8;
+const FAILED_TARGET_DETAIL_CAP_PER_TURN = 8;
+
+interface TestRunnerClientOptions {
+	statFailedTarget?: (filePath: string) => void;
+}
+
+interface TestRunRequest {
+	runner: string;
+	config: RunnerConfig;
+	turnIndex?: number;
+}
+
+interface FailedTargetStateRecord {
+	outcome:
+		| "retired-missing"
+		| "retained-indeterminate"
+		| "capacity-evicted";
+	runner: string;
+	candidate: string;
+	errorCode?: string;
+	turnIndex?: number;
+}
+
+interface FailedTargetSelection {
+	cwd: string;
+	runner: string;
+	failedTargets: PathKeyedMap<string>;
+	relatedAbs?: string;
+	selfAbs?: string;
+	turnIndex?: number;
+}
+
+interface TestResultRecord {
+	cwd: string;
+	runner: string;
+	testFile: string;
+	result: TestResult;
+	turnIndex?: number;
+}
+
+function canonicalFailedDisplayPath(filePath: string): string {
+	const absolute = path.resolve(filePath);
+	try {
+		return fs.realpathSync.native(absolute);
+	} catch {
+		return absolute;
+	}
+}
+
+function canonicalFailedPath(filePath: string): string {
+	return normalizeMapKey(canonicalFailedDisplayPath(filePath));
+}
+
+function filesystemErrorCode(error: unknown): string | undefined {
+	if (
+		error !== null &&
+		typeof error === "object" &&
+		"code" in error &&
+		typeof error.code === "string"
+	) {
+		return error.code;
+	}
+	return undefined;
+}
+
 export class TestRunnerClient {
 	private log: (msg: string) => void;
-	private retirementLog: (msg: string) => void;
 	private availableRunners: Map<string, boolean> = new Map();
-	private failedTestsByRunner: Map<string, Set<string>> = new Map();
+	private failedTestsByRunner = new Map<
+		string,
+		PathKeyedMap<PathKeyedMap<string>>
+	>();
+	private readonly statFailedTarget: (filePath: string) => void;
 	// Best-effort vitest config `test.include`/`test.exclude` globs, scraped as
 	// plain text (never executed) and cached per cwd so the config file is
 	// only read/parsed once, not on every edit. `null` means "no config found
@@ -276,14 +350,12 @@ export class TestRunnerClient {
 		{ include?: string[]; exclude?: string[] } | null
 	> = new Map();
 
-	constructor(verbose = false) {
+	constructor(verbose = false, options: TestRunnerClientOptions = {}) {
 		this.log = verbose
 			? createSubsystemLogger("test-runner")
 			: () => {};
-		// Retirement is a correctness decision, not optional verbose chatter.
-		// Keep it on the existing subsystem sink so production can prove that a
-		// stale failed-first target was removed without logging every run.
-		this.retirementLog = createSubsystemLogger("test-runner");
+		this.statFailedTarget =
+			options.statFailedTarget ?? ((filePath) => void fs.statSync(filePath));
 	}
 
 	/**
@@ -850,6 +922,7 @@ export class TestRunnerClient {
 	getTestRunTarget(
 		sourceFilePath: string,
 		cwd: string,
+		turnIndex?: number,
 	): {
 		testFile: string;
 		runner: string;
@@ -859,8 +932,7 @@ export class TestRunnerClient {
 		const detected = this.detectRunner(cwd, sourceFilePath);
 		if (!detected) return null;
 
-		const key = this.failedKey(cwd, detected.runner);
-		const failedSet = this.failedTestsByRunner.get(key);
+		const failedSet = this.getFailedTargets(cwd, detected.runner);
 
 		// If the edited file is itself a test file, there's no "related test"
 		// to discover — running findTestFile on it would strip its own
@@ -872,13 +944,14 @@ export class TestRunnerClient {
 			: this.findTestFile(sourceFilePath, cwd, detected.runner);
 
 		if (failedSet && failedSet.size > 0) {
-			const failedFirst = this.retireMissingFailedTargets(
-				key,
-				detected.runner,
-				failedSet,
-				related ? path.resolve(related.testFile) : undefined,
-				selfIsTest ? path.resolve(sourceFilePath) : undefined,
-			);
+			const failedFirst = this.retireMissingFailedTargets({
+				cwd,
+				runner: detected.runner,
+				failedTargets: failedSet,
+				relatedAbs: related ? path.resolve(related.testFile) : undefined,
+				selfAbs: selfIsTest ? path.resolve(sourceFilePath) : undefined,
+				turnIndex,
+			});
 			if (failedFirst) {
 				return {
 					testFile: failedFirst,
@@ -918,8 +991,34 @@ export class TestRunnerClient {
 		cwd: string,
 		runner: string,
 		config: RunnerConfig,
+	): Promise<TestResult>;
+	async runTestFileAsync(
+		testFile: string,
+		cwd: string,
+		request: TestRunRequest,
+	): Promise<TestResult>;
+	async runTestFileAsync(
+		testFile: string,
+		cwd: string,
+		runnerOrRequest: string | TestRunRequest,
+		legacyConfig?: RunnerConfig,
 	): Promise<TestResult> {
 		const absoluteTestFile = path.resolve(testFile);
+		let request: TestRunRequest;
+		if (typeof runnerOrRequest === "string") {
+			if (!legacyConfig) {
+				return this.emptyResult(
+					absoluteTestFile,
+					"",
+					runnerOrRequest,
+					"Runner configuration missing",
+				);
+			}
+			request = { runner: runnerOrRequest, config: legacyConfig };
+		} else {
+			request = runnerOrRequest;
+		}
+		const { runner, config, turnIndex } = request;
 		if (!fs.existsSync(absoluteTestFile)) {
 			return this.emptyResult(
 				absoluteTestFile,
@@ -1015,7 +1114,13 @@ export class TestRunnerClient {
 					break;
 			}
 
-			this.recordResult(cwd, runner, absoluteTestFile, parsed);
+			this.recordResult({
+				cwd,
+				runner,
+				testFile: absoluteTestFile,
+				result: parsed,
+				turnIndex,
+			});
 			return parsed;
 		} catch (err: any) {
 			this.log(`Run error: ${err.message}`);
@@ -1023,48 +1128,171 @@ export class TestRunnerClient {
 		}
 	}
 
+	private getFailedTargets(
+		cwd: string,
+		runner: string,
+		create = false,
+	): PathKeyedMap<string> | undefined {
+		let roots = this.failedTestsByRunner.get(runner);
+		if (!roots && create) {
+			roots = new PathKeyedMap<PathKeyedMap<string>>(canonicalFailedPath);
+			this.failedTestsByRunner.set(runner, roots);
+		}
+		if (!roots) return undefined;
+
+		const root = canonicalFailedPath(cwd);
+		let targets = roots.get(root);
+		if (!targets && create) {
+			targets = new PathKeyedMap<string>(canonicalFailedPath);
+			roots.set(root, targets);
+		}
+		return targets;
+	}
+
+	private deleteFailedRoot(cwd: string, runner: string): void {
+		const roots = this.failedTestsByRunner.get(runner);
+		if (!roots) return;
+		roots.delete(canonicalFailedPath(cwd));
+		if (roots.size === 0) this.failedTestsByRunner.delete(runner);
+	}
+
+	private failedTargetCount(runner: string): number {
+		const roots = this.failedTestsByRunner.get(runner);
+		if (!roots) return 0;
+		let count = 0;
+		for (const targets of roots.values()) count += targets.size;
+		return count;
+	}
+
+	private evictOldestFailedTarget(runner: string): string | undefined {
+		const roots = this.failedTestsByRunner.get(runner);
+		if (!roots) return undefined;
+		for (const [root, targets] of roots) {
+			const oldest = targets.keys().next();
+			if (oldest.done) continue;
+			targets.delete(oldest.value);
+			if (targets.size === 0) roots.delete(root);
+			if (roots.size === 0) this.failedTestsByRunner.delete(runner);
+			return oldest.value;
+		}
+		return undefined;
+	}
+
+	private classifyFailedTarget(candidate: string): {
+		status: "present" | "missing" | "indeterminate";
+		errorCode?: string;
+	} {
+		try {
+			this.statFailedTarget(candidate);
+			return { status: "present" };
+		} catch (error) {
+			const errorCode = filesystemErrorCode(error);
+			if (errorCode === "ENOENT" || errorCode === "ENOTDIR") {
+				return { status: "missing", errorCode };
+			}
+			return { status: "indeterminate", errorCode };
+		}
+	}
+
+	private recordFailedTargetState(record: FailedTargetStateRecord): void {
+		const { outcome, runner, candidate, errorCode, turnIndex } = record;
+		const boundedTarget = truncateForLedger(candidate);
+		const identity = truncateForLedger(`${outcome}:${runner}:${candidate}`);
+		const payload = {
+			durationMs: 0,
+			filePath: boundedTarget,
+			metadata: {
+				outcome,
+				runner,
+				errorCode: errorCode ?? "unknown",
+			},
+		};
+		const options = {
+			ledgerKind: "test-runner-failed-target-state" as const,
+			risingEdgePer: "identity" as const,
+			reason: `${outcome}: ${boundedTarget}`,
+		};
+		emitBounded(
+			"test_runner_failed_target_state",
+			identity,
+			payload,
+			turnIndex === undefined
+				? options
+				: {
+						...options,
+						capPerTurn: {
+							limit: FAILED_TARGET_DETAIL_CAP_PER_TURN,
+							turnIndex,
+						},
+					},
+		);
+	}
+
 	/**
-	 * Remove failed-first paths that disappeared since their failed run, then
-	 * return the first surviving target. Related/self targets keep their
-	 * existing priority over an unrelated failed target.
+	 * Retire only confirmed-missing failed-first paths, then return one usable
+	 * target. A bounded prefix is checked per selection; remaining candidates
+	 * carry over to the next selection instead of adding unbounded synchronous
+	 * filesystem work to turn_end. Related/self targets keep priority.
 	 */
 	private retireMissingFailedTargets(
-		key: string,
-		runner: string,
-		failedSet: Set<string>,
-		relatedAbs?: string,
-		selfAbs?: string,
+		selection: FailedTargetSelection,
 	): string | undefined {
-		let firstValid: string | undefined;
-		let preferredValid: string | undefined;
-
-		// Failed-first is a process-local hint, so validate it at the point of
-		// use. Missing paths can survive indefinitely because the missing-file
-		// result returns before recordResult() gets a chance to retire them.
-		for (const candidate of failedSet) {
-			const candidateAbs = path.resolve(candidate);
-			if (!fs.existsSync(candidateAbs)) {
-				failedSet.delete(candidate);
-				const boundedTarget =
-					candidateAbs.length > 200
-						? `…${candidateAbs.slice(-199)}`
-						: candidateAbs;
-				this.retirementLog(
-					`failed-first-retired runner=${runner} target=${boundedTarget}`,
-				);
-				continue;
+		const {
+			cwd,
+			runner,
+			failedTargets,
+			relatedAbs,
+			selfAbs,
+			turnIndex,
+		} = selection;
+		let checked = 0;
+		const inspected = new Set<string>();
+		const inspect = (identity: string, candidate: string): string | undefined => {
+			if (checked >= MAX_FAILED_TARGET_CHECKS_PER_SELECTION) return undefined;
+			checked += 1;
+			inspected.add(identity);
+			const verdict = this.classifyFailedTarget(candidate);
+			if (verdict.status === "missing") {
+				failedTargets.delete(identity);
+				this.recordFailedTargetState({
+					outcome: "retired-missing",
+					runner,
+					candidate,
+					errorCode: verdict.errorCode,
+					turnIndex,
+				});
+				return undefined;
 			}
-
-			firstValid ??= candidateAbs;
-			if (candidateAbs === relatedAbs || candidateAbs === selfAbs) {
-				preferredValid = candidateAbs;
+			if (verdict.status === "indeterminate") {
+				this.recordFailedTargetState({
+					outcome: "retained-indeterminate",
+					runner,
+					candidate,
+					errorCode: verdict.errorCode,
+					turnIndex,
+				});
 			}
+			return candidate;
+		};
+
+		for (const preferred of [relatedAbs, selfAbs]) {
+			if (!preferred) continue;
+			const identity = canonicalFailedPath(preferred);
+			const candidate = failedTargets.get(identity);
+			if (!candidate) continue;
+			const selected = inspect(identity, candidate);
+			if (selected) return selected;
 		}
 
-		if (failedSet.size === 0) this.failedTestsByRunner.delete(key);
-		else this.failedTestsByRunner.set(key, failedSet);
+		for (const [identity, candidate] of failedTargets) {
+			if (inspected.has(identity)) continue;
+			if (checked >= MAX_FAILED_TARGET_CHECKS_PER_SELECTION) break;
+			const selected = inspect(identity, candidate);
+			if (selected) return selected;
+		}
 
-		return preferredValid ?? firstValid;
+		if (failedTargets.size === 0) this.deleteFailedRoot(cwd, runner);
+		return undefined;
 	}
 
 	/**
@@ -2306,30 +2534,46 @@ export class TestRunnerClient {
 		return lines.join("\n").slice(0, 500);
 	}
 
-	private failedKey(cwd: string, runner: string): string {
-		return `${path.resolve(cwd)}:${runner}`;
-	}
-
-	private recordResult(
-		cwd: string,
-		runner: string,
-		testFile: string,
-		result: TestResult,
-	): void {
-		const key = this.failedKey(cwd, runner);
-		const abs = path.resolve(testFile);
-		const set = this.failedTestsByRunner.get(key) ?? new Set<string>();
+	private recordResult(record: TestResultRecord): void {
+		const { cwd, runner, testFile, result, turnIndex } = record;
+		const targetPath = canonicalFailedDisplayPath(testFile);
+		const target = canonicalFailedPath(targetPath);
+		let failedTargets = this.getFailedTargets(
+			cwd,
+			runner,
+			result.failed > 0,
+		);
+		if (!failedTargets) return;
 
 		if (result.failed > 0) {
-			set.add(abs);
-			this.failedTestsByRunner.set(key, set);
+			const alreadyRecorded = failedTargets.has(target);
+			if (
+				!alreadyRecorded &&
+				this.failedTargetCount(runner) >= MAX_FAILED_TARGETS_PER_RUNNER
+			) {
+				const evicted = this.evictOldestFailedTarget(runner);
+				if (evicted) {
+					this.recordFailedTargetState({
+						outcome: "capacity-evicted",
+						runner,
+						candidate: evicted,
+						turnIndex,
+					});
+				}
+				// Eviction can remove this root's final prior target. Reacquire the
+				// root map before inserting so the newest failure never lands in a
+				// detached PathKeyedMap.
+				failedTargets = this.getFailedTargets(cwd, runner, true);
+				if (!failedTargets) return;
+			}
+			// Refresh insertion order so the cap retains the latest failures.
+			if (alreadyRecorded) failedTargets.delete(target);
+			failedTargets.set(target, targetPath);
 			return;
 		}
 
-		if (set.has(abs)) {
-			set.delete(abs);
-			if (set.size === 0) this.failedTestsByRunner.delete(key);
-			else this.failedTestsByRunner.set(key, set);
+		if (failedTargets.delete(target) && failedTargets.size === 0) {
+			this.deleteFailedRoot(cwd, runner);
 		}
 	}
 }

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -262,6 +262,7 @@ export function stripWrapperArgs(binName: string, args: string[]): string[] {
 
 export class TestRunnerClient {
 	private log: (msg: string) => void;
+	private retirementLog: (msg: string) => void;
 	private availableRunners: Map<string, boolean> = new Map();
 	private failedTestsByRunner: Map<string, Set<string>> = new Map();
 	// Best-effort vitest config `test.include`/`test.exclude` globs, scraped as
@@ -279,6 +280,10 @@ export class TestRunnerClient {
 		this.log = verbose
 			? createSubsystemLogger("test-runner")
 			: () => {};
+		// Retirement is a correctness decision, not optional verbose chatter.
+		// Keep it on the existing subsystem sink so production can prove that a
+		// stale failed-first target was removed without logging every run.
+		this.retirementLog = createSubsystemLogger("test-runner");
 	}
 
 	/**
@@ -867,36 +872,21 @@ export class TestRunnerClient {
 			: this.findTestFile(sourceFilePath, cwd, detected.runner);
 
 		if (failedSet && failedSet.size > 0) {
-			if (related) {
-				const relatedAbs = path.resolve(related.testFile);
-				if (failedSet.has(relatedAbs)) {
-					return {
-						testFile: relatedAbs,
-						runner: detected.runner,
-						config: detected.config,
-						strategy: "failed-first",
-					};
-				}
+			const failedFirst = this.retireMissingFailedTargets(
+				key,
+				detected.runner,
+				failedSet,
+				related ? path.resolve(related.testFile) : undefined,
+				selfIsTest ? path.resolve(sourceFilePath) : undefined,
+			);
+			if (failedFirst) {
+				return {
+					testFile: failedFirst,
+					runner: detected.runner,
+					config: detected.config,
+					strategy: "failed-first",
+				};
 			}
-
-			if (selfIsTest) {
-				const selfAbs = path.resolve(sourceFilePath);
-				if (failedSet.has(selfAbs)) {
-					return {
-						testFile: selfAbs,
-						runner: detected.runner,
-						config: detected.config,
-						strategy: "failed-first",
-					};
-				}
-			}
-
-			return {
-				testFile: [...failedSet][0],
-				runner: detected.runner,
-				config: detected.config,
-				strategy: "failed-first",
-			};
 		}
 
 		if (selfIsTest) {
@@ -1031,6 +1021,50 @@ export class TestRunnerClient {
 			this.log(`Run error: ${err.message}`);
 			return this.emptyResult(absoluteTestFile, "", runner, err.message);
 		}
+	}
+
+	/**
+	 * Remove failed-first paths that disappeared since their failed run, then
+	 * return the first surviving target. Related/self targets keep their
+	 * existing priority over an unrelated failed target.
+	 */
+	private retireMissingFailedTargets(
+		key: string,
+		runner: string,
+		failedSet: Set<string>,
+		relatedAbs?: string,
+		selfAbs?: string,
+	): string | undefined {
+		let firstValid: string | undefined;
+		let preferredValid: string | undefined;
+
+		// Failed-first is a process-local hint, so validate it at the point of
+		// use. Missing paths can survive indefinitely because the missing-file
+		// result returns before recordResult() gets a chance to retire them.
+		for (const candidate of failedSet) {
+			const candidateAbs = path.resolve(candidate);
+			if (!fs.existsSync(candidateAbs)) {
+				failedSet.delete(candidate);
+				const boundedTarget =
+					candidateAbs.length > 200
+						? `…${candidateAbs.slice(-199)}`
+						: candidateAbs;
+				this.retirementLog(
+					`failed-first-retired runner=${runner} target=${boundedTarget}`,
+				);
+				continue;
+			}
+
+			firstValid ??= candidateAbs;
+			if (candidateAbs === relatedAbs || candidateAbs === selfAbs) {
+				preferredValid = candidateAbs;
+			}
+		}
+
+		if (failedSet.size === 0) this.failedTestsByRunner.delete(key);
+		else this.failedTestsByRunner.set(key, failedSet);
+
+		return preferredValid ?? firstValid;
 	}
 
 	/**

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -11,10 +11,11 @@
  * specific file being edited, not the entire suite.
  */
 
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { emitBounded } from "./bounded-telemetry.js";
-import { truncateForLedger } from "./degradation-ledger.js";
+import { LEDGER_FIELD_MAX } from "./degradation-ledger.js";
 import { minimatch } from "./deps/minimatch.js";
 import { createSubsystemLogger } from "./extension-log.js";
 import { detectFileRole } from "./file-role.js";
@@ -279,10 +280,7 @@ interface TestRunRequest {
 }
 
 interface FailedTargetStateRecord {
-	outcome:
-		| "retired-missing"
-		| "retained-indeterminate"
-		| "capacity-evicted";
+	outcome: "retired-missing" | "retained-indeterminate" | "capacity-evicted";
 	runner: string;
 	candidate: string;
 	errorCode?: string;
@@ -353,9 +351,7 @@ export class TestRunnerClient {
 	> = new Map();
 
 	constructor(verbose = false, options: TestRunnerClientOptions = {}) {
-		this.log = verbose
-			? createSubsystemLogger("test-runner")
-			: () => {};
+		this.log = verbose ? createSubsystemLogger("test-runner") : () => {};
 		this.statFailedTarget =
 			options.statFailedTarget ?? ((filePath) => void fs.statSync(filePath));
 	}
@@ -595,10 +591,18 @@ export class TestRunnerClient {
 	 * `clients/knip-client.ts`, so `tests/clients/knip-client.test.ts` is
 	 * checked alongside the flat `tests/knip-client.test.ts` candidate).
 	 */
-	private relativeSourceDir(sourceFilePath: string, cwd: string): string | null {
+	private relativeSourceDir(
+		sourceFilePath: string,
+		cwd: string,
+	): string | null {
 		const dir = path.dirname(sourceFilePath);
 		const relDir = path.relative(cwd, path.resolve(cwd, dir));
-		if (!relDir || relDir === "." || relDir.startsWith("..") || path.isAbsolute(relDir)) {
+		if (
+			!relDir ||
+			relDir === "." ||
+			relDir.startsWith("..") ||
+			path.isAbsolute(relDir)
+		) {
 			return null;
 		}
 		return relDir;
@@ -1212,8 +1216,16 @@ export class TestRunnerClient {
 
 	private recordFailedTargetState(record: FailedTargetStateRecord): void {
 		const { outcome, runner, candidate, errorCode, turnIndex } = record;
-		const boundedTarget = truncateForLedger(candidate);
-		const identity = truncateForLedger(`${outcome}:${runner}:${candidate}`);
+		const boundedTarget =
+			candidate.length <= LEDGER_FIELD_MAX
+				? candidate
+				: `…${candidate.slice(1 - LEDGER_FIELD_MAX)}`;
+		const targetIdentity = createHash("sha256")
+			.update(runner)
+			.update("\0")
+			.update(candidate)
+			.digest("hex");
+		const identity = `${outcome}:${targetIdentity}`;
 		const payload = {
 			durationMs: 0,
 			filePath: boundedTarget,
@@ -1253,14 +1265,8 @@ export class TestRunnerClient {
 	private retireMissingFailedTargets(
 		selection: FailedTargetSelection,
 	): string | undefined {
-		const {
-			cwd,
-			runner,
-			failedTargets,
-			relatedAbs,
-			selfAbs,
-			turnIndex,
-		} = selection;
+		const { cwd, runner, failedTargets, relatedAbs, selfAbs, turnIndex } =
+			selection;
 		let checked = 0;
 		const inspected = new Set<string>();
 		const inspect = (
@@ -1632,7 +1638,9 @@ export class TestRunnerClient {
 		let skipped = 0;
 
 		// Success (or success-with-incomplete/skipped): "OK (12 tests, 34 assertions)"
-		const okMatch = output.match(/OK\s*\((\d+)\s+tests?,\s*\d+\s+assertions?\)/i);
+		const okMatch = output.match(
+			/OK\s*\((\d+)\s+tests?,\s*\d+\s+assertions?\)/i,
+		);
 		if (okMatch) {
 			passed = Number.parseInt(okMatch[1], 10);
 		} else {
@@ -1643,7 +1651,9 @@ export class TestRunnerClient {
 			const skippedMatch = output.match(/Skipped:\s*(\d+)/i);
 
 			const total = testsMatch ? Number.parseInt(testsMatch[1], 10) : 0;
-			const failures = failuresMatch ? Number.parseInt(failuresMatch[1], 10) : 0;
+			const failures = failuresMatch
+				? Number.parseInt(failuresMatch[1], 10)
+				: 0;
 			const errors = errorsMatch ? Number.parseInt(errorsMatch[1], 10) : 0;
 			skipped = skippedMatch ? Number.parseInt(skippedMatch[1], 10) : 0;
 			failed = failures + errors;
@@ -1691,11 +1701,12 @@ export class TestRunnerClient {
 			if (legacyMatch) {
 				const value = Number.parseFloat(legacyMatch[1]);
 				const unit = legacyMatch[2].toLowerCase();
-				const scale = unit.startsWith("ms") || unit.startsWith("milli")
-					? 1
-					: unit.startsWith("min")
-						? 60_000
-						: 1000;
+				const scale =
+					unit.startsWith("ms") || unit.startsWith("milli")
+						? 1
+						: unit.startsWith("min")
+							? 60_000
+							: 1000;
 				if (Number.isFinite(value) && value > 0) {
 					duration = Math.round(value * scale);
 				}
@@ -1741,7 +1752,9 @@ export class TestRunnerClient {
 		if (summaryMatch) {
 			const total = Number.parseInt(summaryMatch[1], 10);
 			failed = Number.parseInt(summaryMatch[2], 10);
-			const excluded = summaryMatch[3] ? Number.parseInt(summaryMatch[3], 10) : 0;
+			const excluded = summaryMatch[3]
+				? Number.parseInt(summaryMatch[3], 10)
+				: 0;
 			const skippedCount = summaryMatch[4]
 				? Number.parseInt(summaryMatch[4], 10)
 				: 0;
@@ -2163,9 +2176,7 @@ export class TestRunnerClient {
 		// Package-line counts, like the go duration probe above, take the
 		// FIRST package summary only — the same known limit already
 		// documented on `parseGenericRunnerDuration`.
-		const goFailNames = [
-			...output.matchAll(/--- FAIL:[^\S\n]+([^\s(]+)/g),
-		];
+		const goFailNames = [...output.matchAll(/--- FAIL:[^\S\n]+([^\s(]+)/g)];
 		// #1524-r4: only COUNT unparented failures. go prints a `--- FAIL:`
 		// line for every level of a failing subtest tree — `TestA` AND
 		// `TestA/sub` each get their own line for what is really one
@@ -2192,9 +2203,7 @@ export class TestRunnerClient {
 			// were rendering as `✗ 1/1 failed ✗ go failure` instead of the
 			// runner error they are.
 			const goFailPackage =
-				/^FAIL(?![^\n]*\[(?:build|setup) failed\])[^\S\n]+\S+/m.test(
-					output,
-				);
+				/^FAIL(?![^\n]*\[(?:build|setup) failed\])[^\S\n]+\S+/m.test(output);
 			const goOkPackages = [
 				...output.matchAll(/^ok[^\S\n]+\S+[^\S\n]+[\d.]+s/gm),
 			];
@@ -2264,7 +2273,10 @@ export class TestRunnerClient {
 		// `failures` above when `matched` or `goFailNames` already settled
 		// the question some other way, but they no longer settle it alone.
 		const runnerError =
-			exitCode !== 0 && !matched && goFailNames.length === 0 && lower.includes("error")
+			exitCode !== 0 &&
+			!matched &&
+			goFailNames.length === 0 &&
+			lower.includes("error")
 				? `Runner ${runner} exited with ${exitCode}`
 				: undefined;
 
@@ -2416,9 +2428,7 @@ export class TestRunnerClient {
 		const relDir = path.relative(cwd, dir);
 		const segments = relDir.split(path.sep).filter(Boolean);
 		if (segments.length > 1 && knownSourceRoots.has(segments[0])) {
-			return [
-				path.join(cwd, testDir, ...segments.slice(1), testFilename),
-			];
+			return [path.join(cwd, testDir, ...segments.slice(1), testFilename)];
 		}
 		return [];
 	}
@@ -2515,13 +2525,19 @@ export class TestRunnerClient {
 		// itself, so the leading wrapper-name arg(s) that named it (e.g. "vitest",
 		// or "-m pytest") are stripped from args() — see stripWrapperArgs.
 		if (fs.existsSync(localBin)) {
-			return { command: localBin, args: stripWrapperArgs(binName, config.args(testFile, cwd)) };
+			return {
+				command: localBin,
+				args: stripWrapperArgs(binName, config.args(testFile, cwd)),
+			};
 		}
 
 		// Any package manager's global bin dir (npm/pnpm/yarn/bun) before npx (#375).
 		const globalBin = await findGlobalBinary(binName);
 		if (globalBin) {
-			return { command: globalBin, args: stripWrapperArgs(binName, config.args(testFile, cwd)) };
+			return {
+				command: globalBin,
+				args: stripWrapperArgs(binName, config.args(testFile, cwd)),
+			};
 		}
 
 		return { command: config.command, args: config.args(testFile, cwd) };
@@ -2558,11 +2574,7 @@ export class TestRunnerClient {
 		const { cwd, runner, testFile, result, turnIndex } = record;
 		const targetPath = path.resolve(testFile);
 		const target = canonicalFailedPath(targetPath);
-		let failedTargets = this.getFailedTargets(
-			cwd,
-			runner,
-			result.failed > 0,
-		);
+		let failedTargets = this.getFailedTargets(cwd, runner, result.failed > 0);
 		if (!failedTargets) return;
 
 		if (result.failed > 0) {

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -289,10 +289,15 @@ interface FailedTargetStateRecord {
 	turnIndex?: number;
 }
 
+interface FailedTargetEntry {
+	displayPath: string;
+	sequence: number;
+}
+
 interface FailedTargetSelection {
 	cwd: string;
 	runner: string;
-	failedTargets: PathKeyedMap<string>;
+	failedTargets: PathKeyedMap<FailedTargetEntry>;
 	relatedAbs?: string;
 	selfAbs?: string;
 	turnIndex?: number;
@@ -306,17 +311,13 @@ interface TestResultRecord {
 	turnIndex?: number;
 }
 
-function canonicalFailedDisplayPath(filePath: string): string {
+function canonicalFailedPath(filePath: string): string {
 	const absolute = path.resolve(filePath);
 	try {
-		return fs.realpathSync.native(absolute);
+		return normalizeMapKey(fs.realpathSync.native(absolute));
 	} catch {
-		return absolute;
+		return normalizeMapKey(absolute);
 	}
-}
-
-function canonicalFailedPath(filePath: string): string {
-	return normalizeMapKey(canonicalFailedDisplayPath(filePath));
 }
 
 function filesystemErrorCode(error: unknown): string | undefined {
@@ -336,8 +337,9 @@ export class TestRunnerClient {
 	private availableRunners: Map<string, boolean> = new Map();
 	private failedTestsByRunner = new Map<
 		string,
-		PathKeyedMap<PathKeyedMap<string>>
+		PathKeyedMap<PathKeyedMap<FailedTargetEntry>>
 	>();
+	private failedTargetSequence = 0;
 	private readonly statFailedTarget: (filePath: string) => void;
 	// Best-effort vitest config `test.include`/`test.exclude` globs, scraped as
 	// plain text (never executed) and cached per cwd so the config file is
@@ -1132,10 +1134,12 @@ export class TestRunnerClient {
 		cwd: string,
 		runner: string,
 		create = false,
-	): PathKeyedMap<string> | undefined {
+	): PathKeyedMap<FailedTargetEntry> | undefined {
 		let roots = this.failedTestsByRunner.get(runner);
 		if (!roots && create) {
-			roots = new PathKeyedMap<PathKeyedMap<string>>(canonicalFailedPath);
+			roots = new PathKeyedMap<PathKeyedMap<FailedTargetEntry>>(
+				canonicalFailedPath,
+			);
 			this.failedTestsByRunner.set(runner, roots);
 		}
 		if (!roots) return undefined;
@@ -1143,7 +1147,7 @@ export class TestRunnerClient {
 		const root = canonicalFailedPath(cwd);
 		let targets = roots.get(root);
 		if (!targets && create) {
-			targets = new PathKeyedMap<string>(canonicalFailedPath);
+			targets = new PathKeyedMap<FailedTargetEntry>(canonicalFailedPath);
 			roots.set(root, targets);
 		}
 		return targets;
@@ -1167,15 +1171,27 @@ export class TestRunnerClient {
 	private evictOldestFailedTarget(runner: string): string | undefined {
 		const roots = this.failedTestsByRunner.get(runner);
 		if (!roots) return undefined;
+		let oldest:
+			| {
+					root: string;
+					identity: string;
+					entry: FailedTargetEntry;
+			  }
+			| undefined;
 		for (const [root, targets] of roots) {
-			const oldest = targets.keys().next();
-			if (oldest.done) continue;
-			targets.delete(oldest.value);
-			if (targets.size === 0) roots.delete(root);
-			if (roots.size === 0) this.failedTestsByRunner.delete(runner);
-			return oldest.value;
+			for (const [identity, entry] of targets) {
+				if (!oldest || entry.sequence < oldest.entry.sequence) {
+					oldest = { root, identity, entry };
+				}
+			}
 		}
-		return undefined;
+		if (!oldest) return undefined;
+
+		const targets = roots.get(oldest.root);
+		targets?.delete(oldest.identity);
+		if (targets?.size === 0) roots.delete(oldest.root);
+		if (roots.size === 0) this.failedTestsByRunner.delete(runner);
+		return oldest.entry.displayPath;
 	}
 
 	private classifyFailedTarget(candidate: string): {
@@ -1247,10 +1263,14 @@ export class TestRunnerClient {
 		} = selection;
 		let checked = 0;
 		const inspected = new Set<string>();
-		const inspect = (identity: string, candidate: string): string | undefined => {
+		const inspect = (
+			identity: string,
+			entry: FailedTargetEntry,
+		): string | undefined => {
 			if (checked >= MAX_FAILED_TARGET_CHECKS_PER_SELECTION) return undefined;
 			checked += 1;
 			inspected.add(identity);
+			const candidate = entry.displayPath;
 			const verdict = this.classifyFailedTarget(candidate);
 			if (verdict.status === "missing") {
 				failedTargets.delete(identity);
@@ -1278,16 +1298,16 @@ export class TestRunnerClient {
 		for (const preferred of [relatedAbs, selfAbs]) {
 			if (!preferred) continue;
 			const identity = canonicalFailedPath(preferred);
-			const candidate = failedTargets.get(identity);
-			if (!candidate) continue;
-			const selected = inspect(identity, candidate);
+			const entry = failedTargets.get(identity);
+			if (!entry) continue;
+			const selected = inspect(identity, entry);
 			if (selected) return selected;
 		}
 
-		for (const [identity, candidate] of failedTargets) {
+		for (const [identity, entry] of failedTargets) {
 			if (inspected.has(identity)) continue;
 			if (checked >= MAX_FAILED_TARGET_CHECKS_PER_SELECTION) break;
-			const selected = inspect(identity, candidate);
+			const selected = inspect(identity, entry);
 			if (selected) return selected;
 		}
 
@@ -2536,7 +2556,7 @@ export class TestRunnerClient {
 
 	private recordResult(record: TestResultRecord): void {
 		const { cwd, runner, testFile, result, turnIndex } = record;
-		const targetPath = canonicalFailedDisplayPath(testFile);
+		const targetPath = path.resolve(testFile);
 		const target = canonicalFailedPath(targetPath);
 		let failedTargets = this.getFailedTargets(
 			cwd,
@@ -2566,9 +2586,12 @@ export class TestRunnerClient {
 				failedTargets = this.getFailedTargets(cwd, runner, true);
 				if (!failedTargets) return;
 			}
-			// Refresh insertion order so the cap retains the latest failures.
-			if (alreadyRecorded) failedTargets.delete(target);
-			failedTargets.set(target, targetPath);
+			// Sequence is global across roots, so a refreshed target becomes the
+			// newest failure without relying on one root map's insertion order.
+			failedTargets.set(target, {
+				displayPath: targetPath,
+				sequence: ++this.failedTargetSequence,
+			});
 			return;
 		}
 

--- a/tests/clients/bounded-telemetry.test.ts
+++ b/tests/clients/bounded-telemetry.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../clients/latency-logger.js", async (importActual) => {
 });
 
 import {
+	_boundedTrackedTurnsForTest,
 	_boundedTurnCountForTest,
 	admitBounded,
 	BOUNDED_TELEMETRY_PHASES,
@@ -165,6 +166,47 @@ describe("emitBounded (#1743)", () => {
 			// which is exactly the "state that must re-arm hiding behind a
 			// process-lifetime latch" shape.
 			expect([sameTurn, nextTurn]).toEqual([false, true]);
+		});
+
+		it("does not reopen an older turn when its async result arrives late", () => {
+			const emit = (turnIndex: number) =>
+				emitBounded(
+					"loop_block",
+					`turn-${turnIndex}`,
+					{ durationMs: 1 },
+					{ capPerTurn: { limit: 2, turnIndex } },
+				);
+
+			expect([emit(7), emit(7), emit(8), emit(7)]).toEqual([
+				true,
+				true,
+				true,
+				false,
+			]);
+			expect(_boundedTurnCountForTest("loop_block", 7)).toBe(2);
+			expect(_boundedTurnCountForTest("loop_block", 8)).toBe(1);
+		});
+
+		it("bounds retained turn buckets and fails closed for retired turns", () => {
+			for (let turnIndex = 0; turnIndex < 80; turnIndex++) {
+				expect(
+					emitBounded(
+						"loop_block",
+						`turn-${turnIndex}`,
+						{ durationMs: 1 },
+						{ capPerTurn: { limit: 1, turnIndex } },
+					),
+				).toBe(true);
+			}
+			expect(_boundedTrackedTurnsForTest()).toBeLessThanOrEqual(64);
+			expect(
+				emitBounded(
+					"loop_block",
+					"late-turn-0",
+					{ durationMs: 1 },
+					{ capPerTurn: { limit: 1, turnIndex: 0 } },
+				),
+			).toBe(false);
 		});
 
 		it("counts each phase against its own budget", () => {

--- a/tests/clients/latency-logger.test.ts
+++ b/tests/clients/latency-logger.test.ts
@@ -174,6 +174,22 @@ describe("getLastLoggedPhase (loop_block attribution, #1122/#1123)", () => {
 		});
 		expect(getLastLoggedPhase()?.phase).toBe("provider_request");
 	});
+
+	it("does not let failed-target decision telemetry own stall attribution (#2044)", () => {
+		logLatency({
+			type: "phase",
+			phase: "turn_end_tests",
+			filePath: "<pi-lens>",
+			durationMs: 5,
+		});
+		logLatency({
+			type: "phase",
+			phase: "test_runner_failed_target_state",
+			filePath: "/repo/stale.test.ts",
+			durationMs: 0,
+		});
+		expect(getLastLoggedPhase()?.phase).toBe("turn_end_tests");
+	});
 });
 
 describe("getRecentLoggedPhases (#1723: bounded attribution ring)", () => {

--- a/tests/clients/path-keyed-map.test.ts
+++ b/tests/clients/path-keyed-map.test.ts
@@ -43,6 +43,18 @@ describe("PathKeyedMap", () => {
 		expect(map.size).toBe(0);
 	});
 
+	it("deletes a captured display key when normalization changes after file removal", () => {
+		let exists = true;
+		const map = new PathKeyedMap<number>((p) =>
+			exists ? p.toUpperCase() : p.toLowerCase(),
+		);
+		map.set("MixedCase_Test.go", 7);
+		exists = false;
+
+		expect(map.delete("MixedCase_Test.go")).toBe(true);
+		expect(map.size).toBe(0);
+	});
+
 	it("two differently-formed keys for the same path collapse to ONE entry", () => {
 		const map = new PathKeyedMap<number>(fold);
 		map.set("SUB\\a.ts", 1);

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -2372,16 +2372,22 @@ describe("turn_end test runner — cascade neighbors get their own test companio
 				}
 				return null;
 			});
-			const runTestFileAsync = vi.fn(async (testFile: string) => ({
-				file: testFile,
-				sourceFile: "",
-				runner: "vitest",
-				passed: 1,
-				failed: 0,
-				skipped: 0,
-				failures: [],
-				duration: 1,
-			}));
+			const runTestFileAsync = vi.fn(
+				async (
+					testFile: string,
+					_cwd?: string,
+					_request?: { turnIndex?: number },
+				) => ({
+					file: testFile,
+					sourceFile: "",
+					runner: "vitest",
+					passed: 1,
+					failed: 0,
+					skipped: 0,
+					failures: [],
+					duration: 1,
+				}),
+			);
 
 			await handleTurnEnd(
 				makeTurnEndDeps(runtime, cacheManager, {
@@ -2398,6 +2404,9 @@ describe("turn_end test runner — cascade neighbors get their own test companio
 			const firedTestFiles = runTestFileAsync.mock.calls.map((c) => c[0]);
 			expect(firedTestFiles).toContain(fooTestFile);
 			expect(firedTestFiles).toContain(barTestFile);
+			for (const call of runTestFileAsync.mock.calls) {
+				expect(call[2]).toMatchObject({ turnIndex: runtime.turnIndex });
+			}
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -1,8 +1,13 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { CacheManager } from "../../clients/cache-manager.js";
 import { snapshotAdvisoryProvenance } from "../../clients/advisory-provenance.js";
+import {
+	_boundedTurnCountForTest,
+	resetBoundedTelemetry,
+} from "../../clients/bounded-telemetry.js";
+import { CacheManager } from "../../clients/cache-manager.js";
+import { resetDegradationLedger } from "../../clients/degradation-ledger.js";
 import {
 	evaluateGitGuard,
 	mergeGitGuardTestFailure,
@@ -13,6 +18,11 @@ import {
 	consumeTurnEndFindings,
 } from "../../clients/runtime-context.js";
 import { loadProjectDiagnosticsDeltaReport } from "../../clients/project-diagnostics/cache.js";
+import {
+	clearLatencyLog,
+	flushLatencyLog,
+	getLatencyLogPath,
+} from "../../clients/latency-logger.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { SESSION_START_GUIDANCE } from "../../clients/runtime-session.js";
 import {
@@ -24,6 +34,7 @@ import {
 	checkCrossProcessLspBudget,
 	_resetLspBudgetDecisionForTests,
 } from "../../clients/lsp-budget.js";
+import { RUNNERS, TestRunnerClient } from "../../clients/test-runner-client.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
 const EMPTY_KNIP_RESULT = {
@@ -2408,6 +2419,84 @@ describe("turn_end test runner — cascade neighbors get their own test companio
 				expect(call[2]).toMatchObject({ turnIndex: runtime.turnIndex });
 			}
 		} finally {
+			env.cleanup();
+		}
+	});
+
+	// #2044 review: the hand-written doubles above cannot prove originating-turn
+	// propagation through REAL selection, REAL recording, and the REAL sink.
+	// This test wires the actual TestRunnerClient into handleTurnEnd.
+	it("retires a deleted failed target through the real client and records real telemetry", async () => {
+		const env = setupTestEnvironment("pi-lens-test-real-2044-");
+		const previousTestMode = process.env.PI_LENS_TEST_MODE;
+		process.env.PI_LENS_TEST_MODE = "0";
+		try {
+			resetDegradationLedger();
+			resetBoundedTelemetry();
+			clearLatencyLog();
+			await flushLatencyLog();
+
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "real-2044-session" });
+			const cacheManager = new CacheManager(false);
+
+			fs.writeFileSync(
+				path.join(env.tmpDir, "go.mod"),
+				"module example.com/tmp\n",
+			);
+			const editedFile = path.join(env.tmpDir, "widget.go");
+			const staleTest = path.join(env.tmpDir, "stale_test.go");
+			fs.writeFileSync(editedFile, "package widget\n");
+			fs.writeFileSync(staleTest, "package widget\n");
+			cacheManager.addModifiedRange(
+				editedFile,
+				{ start: 1, end: 1 },
+				false,
+				env.tmpDir,
+				"real-2044-session",
+			);
+
+			const testRunnerClient = new TestRunnerClient(false);
+			const seeded = await testRunnerClient.runTestFileAsync(
+				staleTest,
+				env.tmpDir,
+				{
+					runner: "go",
+					config: {
+						...RUNNERS.go,
+						command: process.execPath,
+						binName: "pi-lens-real-2044-runner",
+						args: (testFile: string) => [
+							"-e",
+							"console.log('--- FAIL: fixture'); process.exitCode = 1;",
+							testFile,
+						],
+					},
+					turnIndex: runtime.turnIndex,
+				},
+			);
+			expect(seeded.failed).toBe(1);
+			fs.rmSync(staleTest);
+
+			await handleTurnEnd(
+				makeTurnEndDeps(runtime, cacheManager, {
+					ctxCwd: env.tmpDir,
+					testRunnerClient,
+				}),
+			);
+			await flushLatencyLog();
+
+			// Real selection retired the missing path and the real sink recorded it.
+			const log = fs.readFileSync(getLatencyLogPath(), "utf8");
+			expect(log).toContain('"phase":"test_runner_failed_target_state"');
+			expect(log).toContain('"outcome":"retired-missing"');
+			expect(log).toContain('"runner":"go"');
+		} finally {
+			if (previousTestMode === undefined) {
+				delete process.env.PI_LENS_TEST_MODE;
+			} else {
+				process.env.PI_LENS_TEST_MODE = previousTestMode;
+			}
 			env.cleanup();
 		}
 	});

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -949,6 +949,142 @@ describe("test-runner-client", () => {
 		expect(target?.testFile).toBe(path.resolve(testFile));
 	});
 
+	describe("failed-first target retirement (#2044)", () => {
+		const failingNodeConfig = {
+			...RUNNERS.go,
+			command: process.execPath,
+			binName: "pi-lens-2044-fixture-runner",
+			args: (testFile: string) => [
+				"-e",
+				"console.log('--- FAIL: fixture'); process.exitCode = 1;",
+				testFile,
+			],
+		};
+
+		it("retires one deleted failed target and falls back to normal discovery", async () => {
+			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-2044-");
+			cleanups.push(cleanup);
+
+			fs.writeFileSync(path.join(tmpDir, "go.mod"), "module example.com/tmp\n");
+			const sourceFile = path.join(tmpDir, "widget.go");
+			const staleTest = path.join(tmpDir, "stale_test.go");
+			const relatedTest = path.join(tmpDir, "widget_test.go");
+			fs.writeFileSync(sourceFile, "package widget\n");
+			fs.writeFileSync(staleTest, "package widget\n");
+			fs.writeFileSync(relatedTest, "package widget\n");
+
+			const client = new TestRunnerClient(false);
+			const seeded = await client.runTestFileAsync(
+				staleTest,
+				tmpDir,
+				"go",
+				failingNodeConfig,
+			);
+			expect(seeded.failed).toBe(1);
+			fs.rmSync(staleTest);
+
+			const target = client.getTestRunTarget(sourceFile, tmpDir);
+			expect(target).toMatchObject({
+				testFile: path.resolve(relatedTest),
+				runner: "go",
+				strategy: "related",
+			});
+		});
+
+		it("keeps the next valid failed target after missing execution", async () => {
+			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-2044-");
+			cleanups.push(cleanup);
+
+			fs.writeFileSync(path.join(tmpDir, "go.mod"), "module example.com/tmp\n");
+			const sourceFile = path.join(tmpDir, "widget.go");
+			const staleTest = path.join(tmpDir, "stale_test.go");
+			const validFailedTest = path.join(tmpDir, "other_test.go");
+			fs.writeFileSync(sourceFile, "package widget\n");
+			fs.writeFileSync(staleTest, "package widget\n");
+			fs.writeFileSync(validFailedTest, "package widget\n");
+
+			const client = new TestRunnerClient(false);
+			for (const testFile of [staleTest, validFailedTest]) {
+				const seeded = await client.runTestFileAsync(
+					testFile,
+					tmpDir,
+					"go",
+					failingNodeConfig,
+				);
+				expect(seeded.failed).toBe(1);
+			}
+			fs.rmSync(staleTest);
+
+			const missing = await client.runTestFileAsync(
+				staleTest,
+				tmpDir,
+				"go",
+				failingNodeConfig,
+			);
+			expect(missing.error).toBe("Test file not found");
+
+			const target = client.getTestRunTarget(sourceFile, tmpDir);
+			expect(target).toMatchObject({
+				testFile: path.resolve(validFailedTest),
+				runner: "go",
+				strategy: "failed-first",
+			});
+		});
+
+		it("keeps failed-first state isolated between runners", async () => {
+			const go = setupTestEnvironment("pi-lens-tests-2044-go-");
+			const cargo = setupTestEnvironment("pi-lens-tests-2044-cargo-");
+			cleanups.push(go.cleanup, cargo.cleanup);
+
+			const client = new TestRunnerClient(false);
+			const projects = [
+				{
+					root: go.tmpDir,
+					manifest: "go.mod",
+					runner: "go",
+					testName: "go_test.go",
+					sourceName: "go.go",
+					config: failingNodeConfig,
+				},
+				{
+					root: cargo.tmpDir,
+					manifest: "Cargo.toml",
+					runner: "cargo",
+					testName: "cargo_test.rs",
+					sourceName: "cargo.rs",
+					config: {
+						...RUNNERS.cargo,
+						command: process.execPath,
+						binName: "pi-lens-2044-cargo-runner",
+						args: (testFile: string) => [
+							"-e",
+							"console.log('test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out'); process.exitCode = 1;",
+							testFile,
+						],
+					},
+				},
+			];
+
+			for (const project of projects) {
+				fs.writeFileSync(path.join(project.root, project.manifest), "manifest\n");
+				const sourceFile = path.join(project.root, project.sourceName);
+				const testFile = path.join(project.root, project.testName);
+				fs.writeFileSync(sourceFile, "fixture\n");
+				fs.writeFileSync(testFile, "fixture\n");
+				const seeded = await client.runTestFileAsync(
+					testFile,
+					project.root,
+					project.runner,
+					project.config,
+				);
+				expect(seeded.failed).toBe(1);
+				expect(client.getTestRunTarget(sourceFile, project.root)?.testFile).toBe(
+					path.resolve(testFile),
+				);
+			}
+		});
+	});
+
 	it("does not infer pytest from pyproject without pytest section", () => {
 		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 		cleanups.push(cleanup);

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -1064,8 +1064,8 @@ describe("test-runner-client", () => {
 			fs.writeFileSync(path.join(tmpDir, "Cargo.toml"), "[package]\nname='tmp'\n");
 			const goSource = path.join(tmpDir, "widget.go");
 			const staleGoTest = path.join(tmpDir, "stale_test.go");
-			const cargoSource = path.join(aliasRoot, "widget.rs");
-			const cargoTest = path.join(tmpDir, "widget_test.rs");
+			const cargoSource = path.join(tmpDir, "widget.rs");
+			const cargoTest = path.join(aliasRoot, "widget_test.rs");
 			for (const file of [goSource, staleGoTest, cargoSource, cargoTest]) {
 				fs.writeFileSync(file, "fixture\n");
 			}
@@ -1099,15 +1099,15 @@ describe("test-runner-client", () => {
 			fs.rmSync(staleGoTest);
 			expect(client.getTestRunTarget(goSource, tmpDir)).toBeNull();
 
-			// Re-probe through the symlink spelling after removing Go's marker. The
-			// root must collapse to the same project, while the cargo state survives
-			// retirement of the missing Go target.
+			// Seed the target through its symlink spelling, then consume the project
+			// through the aliased root. Keys collapse while the returned target keeps
+			// caller spelling and Cargo survives retirement of the missing Go target.
 			fs.rmSync(path.join(tmpDir, "go.mod"));
 			const cargoTarget = client.getTestRunTarget(cargoSource, aliasRoot);
 			expect(cargoTarget).toMatchObject({
 				runner: "cargo",
 				strategy: "failed-first",
-				testFile: fs.realpathSync.native(cargoTest),
+				testFile: path.resolve(cargoTest),
 			});
 		});
 
@@ -1260,6 +1260,53 @@ describe("test-runner-client", () => {
 					process.env.PI_LENS_TEST_MODE = previousTestMode;
 				}
 			}
+		});
+
+		it("evicts the globally oldest target after a cross-root refresh", async () => {
+			const first = setupTestEnvironment("pi-lens-tests-2044-hot-");
+			const second = setupTestEnvironment("pi-lens-tests-2044-cold-");
+			cleanups.push(first.cleanup, second.cleanup);
+			for (const root of [first.tmpDir, second.tmpDir]) {
+				fs.writeFileSync(path.join(root, "go.mod"), "module example.com/tmp\n");
+				fs.writeFileSync(path.join(root, "widget.go"), "package widget\n");
+			}
+			const hot = path.join(first.tmpDir, "hot_test.go");
+			const cold = Array.from({ length: 31 }, (_, index) =>
+				path.join(second.tmpDir, `cold-${index}_test.go`),
+			);
+			const newest = path.join(second.tmpDir, "newest_test.go");
+			const client = new TestRunnerClient(false);
+			const recordFailure = async (root: string, testFile: string) => {
+				fs.writeFileSync(testFile, "package widget\n");
+				const result = await client.runTestFileAsync(
+					testFile,
+					root,
+					"go",
+					failingNodeConfig,
+				);
+				expect(result.failed).toBe(1);
+			};
+
+			await recordFailure(first.tmpDir, hot);
+			for (const testFile of cold) {
+				await recordFailure(second.tmpDir, testFile);
+			}
+			// Refresh A after every original B entry, then force one eviction in B.
+			await recordFailure(first.tmpDir, hot);
+			await recordFailure(second.tmpDir, newest);
+
+			expect(
+				client.getTestRunTarget(
+					path.join(first.tmpDir, "widget.go"),
+					first.tmpDir,
+				)?.testFile,
+			).toBe(path.resolve(hot));
+			expect(
+				client.getTestRunTarget(
+					path.join(second.tmpDir, "widget.go"),
+					second.tmpDir,
+				)?.testFile,
+			).toBe(path.resolve(cold[1]));
 		});
 	});
 

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -1,6 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetBoundedTelemetry } from "../../clients/bounded-telemetry.js";
+import {
+	clearLatencyLog,
+	flushLatencyLog,
+	getLatencyLogPath,
+} from "../../clients/latency-logger.js";
 import { RUNNERS, TestRunnerClient } from "../../clients/test-runner-client.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
@@ -931,7 +937,7 @@ describe("test-runner-client", () => {
 		});
 	});
 
-	it("prefers failed-first target when failure cache exists", () => {
+	it("prefers failed-first target when failure cache exists", async () => {
 		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 		cleanups.push(cleanup);
 
@@ -941,8 +947,18 @@ describe("test-runner-client", () => {
 		fs.writeFileSync(src, "package main\n");
 		fs.writeFileSync(testFile, "package main\n");
 
-		const client = new TestRunnerClient(false) as any;
-		client.failedTestsByRunner.set(`${path.resolve(tmpDir)}:go`, new Set([testFile]));
+		const client = new TestRunnerClient(false);
+		const seeded = await client.runTestFileAsync(testFile, tmpDir, "go", {
+			...RUNNERS.go,
+			command: process.execPath,
+			binName: "pi-lens-failed-first-fixture",
+			args: (target) => [
+				"-e",
+				"console.log('--- FAIL: fixture'); process.exitCode = 1;",
+				target,
+			],
+		});
+		expect(seeded.failed).toBe(1);
 
 		const target = client.getTestRunTarget(src, tmpDir);
 		expect(target?.strategy).toBe("failed-first");
@@ -1031,56 +1047,218 @@ describe("test-runner-client", () => {
 			});
 		});
 
-		it("keeps failed-first state isolated between runners", async () => {
-			const go = setupTestEnvironment("pi-lens-tests-2044-go-");
-			const cargo = setupTestEnvironment("pi-lens-tests-2044-cargo-");
-			cleanups.push(go.cleanup, cargo.cleanup);
+		it("retires one runner without clearing another in the same project", async () => {
+			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-2044-");
+			const aliasRoot = `${tmpDir}-alias`;
+			fs.symlinkSync(
+				tmpDir,
+				aliasRoot,
+				process.platform === "win32" ? "junction" : "dir",
+			);
+			cleanups.push(
+				() => fs.rmSync(aliasRoot, { recursive: true, force: true }),
+				cleanup,
+			);
 
+			fs.writeFileSync(path.join(tmpDir, "go.mod"), "module example.com/tmp\n");
+			fs.writeFileSync(path.join(tmpDir, "Cargo.toml"), "[package]\nname='tmp'\n");
+			const goSource = path.join(tmpDir, "widget.go");
+			const staleGoTest = path.join(tmpDir, "stale_test.go");
+			const cargoSource = path.join(aliasRoot, "widget.rs");
+			const cargoTest = path.join(tmpDir, "widget_test.rs");
+			for (const file of [goSource, staleGoTest, cargoSource, cargoTest]) {
+				fs.writeFileSync(file, "fixture\n");
+			}
+
+			const cargoConfig = {
+				...RUNNERS.cargo,
+				command: process.execPath,
+				binName: "pi-lens-2044-cargo-runner",
+				args: (testFile: string) => [
+					"-e",
+					"console.log('test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out'); process.exitCode = 1;",
+					testFile,
+				],
+			};
 			const client = new TestRunnerClient(false);
-			const projects = [
-				{
-					root: go.tmpDir,
-					manifest: "go.mod",
-					runner: "go",
-					testName: "go_test.go",
-					sourceName: "go.go",
-					config: failingNodeConfig,
-				},
-				{
-					root: cargo.tmpDir,
-					manifest: "Cargo.toml",
-					runner: "cargo",
-					testName: "cargo_test.rs",
-					sourceName: "cargo.rs",
-					config: {
-						...RUNNERS.cargo,
-						command: process.execPath,
-						binName: "pi-lens-2044-cargo-runner",
-						args: (testFile: string) => [
-							"-e",
-							"console.log('test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out'); process.exitCode = 1;",
-							testFile,
-						],
-					},
-				},
-			];
+			const goFailure = await client.runTestFileAsync(
+				staleGoTest,
+				tmpDir,
+				"go",
+				failingNodeConfig,
+			);
+			const cargoFailure = await client.runTestFileAsync(
+				cargoTest,
+				tmpDir,
+				"cargo",
+				cargoConfig,
+			);
+			expect(goFailure.failed).toBe(1);
+			expect(cargoFailure.failed).toBe(1);
 
-			for (const project of projects) {
-				fs.writeFileSync(path.join(project.root, project.manifest), "manifest\n");
-				const sourceFile = path.join(project.root, project.sourceName);
-				const testFile = path.join(project.root, project.testName);
-				fs.writeFileSync(sourceFile, "fixture\n");
-				fs.writeFileSync(testFile, "fixture\n");
+			fs.rmSync(staleGoTest);
+			expect(client.getTestRunTarget(goSource, tmpDir)).toBeNull();
+
+			// Re-probe through the symlink spelling after removing Go's marker. The
+			// root must collapse to the same project, while the cargo state survives
+			// retirement of the missing Go target.
+			fs.rmSync(path.join(tmpDir, "go.mod"));
+			const cargoTarget = client.getTestRunTarget(cargoSource, aliasRoot);
+			expect(cargoTarget).toMatchObject({
+				runner: "cargo",
+				strategy: "failed-first",
+				testFile: fs.realpathSync.native(cargoTest),
+			});
+		});
+
+		it("retains indeterminate paths and writes bounded real telemetry", async () => {
+			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-2044-");
+			cleanups.push(cleanup);
+			fs.writeFileSync(path.join(tmpDir, "go.mod"), "module example.com/tmp\n");
+			const sourceFile = path.join(tmpDir, "widget.go");
+			const failedTest = path.join(tmpDir, "widget_test.go");
+			fs.writeFileSync(sourceFile, "package widget\n");
+			fs.writeFileSync(failedTest, "package widget\n");
+
+			const denied = Object.assign(new Error("access denied"), { code: "EACCES" });
+			const client = new TestRunnerClient(false, {
+				statFailedTarget: () => {
+					throw denied;
+				},
+			});
+			const seeded = await client.runTestFileAsync(
+				failedTest,
+				tmpDir,
+				"go",
+				failingNodeConfig,
+			);
+			expect(seeded.failed).toBe(1);
+
+			const previousTestMode = process.env.PI_LENS_TEST_MODE;
+			process.env.PI_LENS_TEST_MODE = "0";
+			try {
+				resetBoundedTelemetry();
+				clearLatencyLog();
+				await flushLatencyLog();
+				const target = client.getTestRunTarget(sourceFile, tmpDir, 2044);
+				expect(target).toMatchObject({
+					strategy: "failed-first",
+					testFile: fs.realpathSync.native(failedTest),
+				});
+				await flushLatencyLog();
+				const records = fs
+					.readFileSync(getLatencyLogPath(), "utf8")
+					.trim()
+					.split("\n")
+					.map((line) => JSON.parse(line));
+				expect(records).toContainEqual(
+					expect.objectContaining({
+						phase: "test_runner_failed_target_state",
+						metadata: expect.objectContaining({
+							outcome: "retained-indeterminate",
+							runner: "go",
+							errorCode: "EACCES",
+						}),
+					}),
+				);
+			} finally {
+				if (previousTestMode === undefined) {
+					delete process.env.PI_LENS_TEST_MODE;
+				} else {
+					process.env.PI_LENS_TEST_MODE = previousTestMode;
+				}
+			}
+		});
+
+		it("bounds missing-target probes and carries the remainder forward", async () => {
+			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-2044-");
+			cleanups.push(cleanup);
+			fs.writeFileSync(path.join(tmpDir, "go.mod"), "module example.com/tmp\n");
+			const sourceFile = path.join(tmpDir, "widget.go");
+			const relatedTest = path.join(tmpDir, "widget_test.go");
+			fs.writeFileSync(sourceFile, "package widget\n");
+			fs.writeFileSync(relatedTest, "package widget\n");
+
+			let statCalls = 0;
+			const client = new TestRunnerClient(false, {
+				statFailedTarget: (filePath) => {
+					statCalls += 1;
+					void fs.statSync(filePath);
+				},
+			});
+			const staleTests = Array.from({ length: 12 }, (_, index) =>
+				path.join(tmpDir, `stale-${index}_test.go`),
+			);
+			for (const testFile of staleTests) {
+				fs.writeFileSync(testFile, "package widget\n");
 				const seeded = await client.runTestFileAsync(
 					testFile,
-					project.root,
-					project.runner,
-					project.config,
+					tmpDir,
+					"go",
+					failingNodeConfig,
 				);
 				expect(seeded.failed).toBe(1);
-				expect(client.getTestRunTarget(sourceFile, project.root)?.testFile).toBe(
-					path.resolve(testFile),
-				);
+				fs.rmSync(testFile);
+			}
+
+			expect(client.getTestRunTarget(sourceFile, tmpDir, 88)?.testFile).toBe(
+				path.resolve(relatedTest),
+			);
+			expect(statCalls).toBe(8);
+			expect(client.getTestRunTarget(sourceFile, tmpDir, 88)?.testFile).toBe(
+				path.resolve(relatedTest),
+			);
+			expect(statCalls).toBe(12);
+		});
+
+		it("caps each runner at the newest 32 failed targets", async () => {
+			const first = setupTestEnvironment("pi-lens-tests-2044-first-");
+			const second = setupTestEnvironment("pi-lens-tests-2044-second-");
+			cleanups.push(first.cleanup, second.cleanup);
+			for (const root of [first.tmpDir, second.tmpDir]) {
+				fs.writeFileSync(path.join(root, "go.mod"), "module example.com/tmp\n");
+			}
+			const sourceFile = path.join(first.tmpDir, "widget.go");
+			const oldest = path.join(first.tmpDir, "oldest_test.go");
+			const newest = path.join(first.tmpDir, "newest_test.go");
+			fs.writeFileSync(sourceFile, "package widget\n");
+			const middle = Array.from({ length: 31 }, (_, index) =>
+				path.join(second.tmpDir, `failure-${index}_test.go`),
+			);
+			const client = new TestRunnerClient(false);
+			const previousTestMode = process.env.PI_LENS_TEST_MODE;
+			process.env.PI_LENS_TEST_MODE = "0";
+			try {
+				resetBoundedTelemetry();
+				clearLatencyLog();
+				await flushLatencyLog();
+				for (const [root, testFile] of [
+					[first.tmpDir, oldest],
+					...middle.map((testFile) => [second.tmpDir, testFile]),
+					[first.tmpDir, newest],
+				]) {
+					fs.writeFileSync(testFile, "package widget\n");
+					const seeded = await client.runTestFileAsync(testFile, root, {
+						runner: "go",
+						config: failingNodeConfig,
+						turnIndex: 2045,
+					});
+					expect(seeded.failed).toBe(1);
+				}
+
+				expect(
+					client.getTestRunTarget(sourceFile, first.tmpDir)?.testFile,
+				).toBe(fs.realpathSync.native(newest));
+				await flushLatencyLog();
+				const log = fs.readFileSync(getLatencyLogPath(), "utf8");
+				expect(log).toContain('"outcome":"capacity-evicted"');
+				expect(log).toContain('"phase":"test_runner_failed_target_state"');
+			} finally {
+				if (previousTestMode === undefined) {
+					delete process.env.PI_LENS_TEST_MODE;
+				} else {
+					process.env.PI_LENS_TEST_MODE = previousTestMode;
+				}
 			}
 		});
 	});
@@ -1440,19 +1618,31 @@ describe("test-runner-client", () => {
 			expect(target?.strategy).toBe("related");
 		});
 
-		it("prefers failed-first over self when the edited test file is itself in the failed set", () => {
+		it("prefers failed-first over self when the edited test file is itself in the failed set", async () => {
 			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 			cleanups.push(cleanup);
 
 			fs.writeFileSync(path.join(tmpDir, "vitest.config.ts"), "export default {}\n");
 			const src = path.join(tmpDir, "flaky.test.ts");
 			fs.writeFileSync(src, "// test\n");
+			const vitestFailureConfig = {
+				...RUNNERS.vitest,
+				command: process.execPath,
+				binName: "pi-lens-failed-vitest-fixture",
+				args: (testFile: string) => [
+					"-e",
+					`console.log(JSON.stringify({ numPassedTests: 0, numFailedTests: 1, numPendingTests: 0, testResults: [{ name: ${JSON.stringify(testFile)}, assertionResults: [{ status: "failed", title: "fixture", failureMessages: ["boom"] }] }] })); process.exitCode = 1;`,
+				],
+			};
 
-			const client = new TestRunnerClient(false) as any;
-			client.failedTestsByRunner.set(
-				`${path.resolve(tmpDir)}:vitest`,
-				new Set([path.resolve(src)]),
+			const client = new TestRunnerClient(false);
+			const seeded = await client.runTestFileAsync(
+				src,
+				tmpDir,
+				"vitest",
+				vitestFailureConfig,
 			);
+			expect(seeded.failed).toBe(1);
 
 			const target = client.getTestRunTarget(src, tmpDir);
 			expect(target?.strategy).toBe("failed-first");

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -3,6 +3,10 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetBoundedTelemetry } from "../../clients/bounded-telemetry.js";
 import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
+import {
 	clearLatencyLog,
 	flushLatencyLog,
 	getLatencyLogPath,
@@ -12,7 +16,8 @@ import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
 // Only the resolveExec matrix below (#1098) needs this mocked; every other
 // test in this file never reaches a `findGlobalBinary` call.
-const findGlobalBinary = vi.fn<(command: string) => Promise<string | undefined>>();
+const findGlobalBinary =
+	vi.fn<(command: string) => Promise<string | undefined>>();
 vi.mock("../../clients/package-manager.js", () => ({
 	findGlobalBinary: (command: string) => findGlobalBinary(command),
 }));
@@ -28,7 +33,10 @@ describe("test-runner-client", () => {
 		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 		cleanups.push(cleanup);
 
-		fs.writeFileSync(path.join(tmpDir, "vite.config.ts"), "export default {}\n");
+		fs.writeFileSync(
+			path.join(tmpDir, "vite.config.ts"),
+			"export default {}\n",
+		);
 		fs.writeFileSync(
 			path.join(tmpDir, "package.json"),
 			JSON.stringify({ name: "tmp", version: "1.0.0" }),
@@ -678,7 +686,9 @@ describe("test-runner-client", () => {
 			expect(result.error).toBeUndefined();
 			expect(result.failed).toBeGreaterThan(0);
 			expect(result.failures).toEqual(
-				expect.arrayContaining([expect.objectContaining({ name: "TestParse" })]),
+				expect.arrayContaining([
+					expect.objectContaining({ name: "TestParse" }),
+				]),
 			);
 		});
 
@@ -717,7 +727,10 @@ describe("test-runner-client", () => {
 		});
 
 		it("still reports a genuine runner-start failure as an error (no failure names, #1487 stays green)", () => {
-			const result = parse("go: cannot find main module; error initializing", 1);
+			const result = parse(
+				"go: cannot find main module; error initializing",
+				1,
+			);
 
 			expect(result.error).toBe("Runner go exited with 1");
 			expect(result.failed).toBe(0);
@@ -814,7 +827,9 @@ describe("test-runner-client", () => {
 			const result = parse("FAILED\n\nsome trailing note\n", 1, "cargo");
 
 			expect(
-				result.failures.some((f: { name: string }) => f.name === "some trailing note"),
+				result.failures.some(
+					(f: { name: string }) => f.name === "some trailing note",
+				),
 			).toBe(false);
 		});
 	});
@@ -894,7 +909,9 @@ describe("test-runner-client", () => {
 	// exclusive, so a `TestResult` claiming both is self-contradictory.
 	describe("a runner-error result has no leftover failure names (#1524-r4 tidy)", () => {
 		it("clears failures when the rspec load-error text also matches a same-line Failure: name", () => {
-			const result = (new TestRunnerClient(false) as any).parseGenericRunnerOutput(
+			const result = (
+				new TestRunnerClient(false) as any
+			).parseGenericRunnerOutput(
 				"",
 				"An error occurred while loading ./spec/foo_spec.rb.\nFailure: cannot load such file -- foo\n",
 				1,
@@ -983,7 +1000,7 @@ describe("test-runner-client", () => {
 
 			fs.writeFileSync(path.join(tmpDir, "go.mod"), "module example.com/tmp\n");
 			const sourceFile = path.join(tmpDir, "widget.go");
-			const staleTest = path.join(tmpDir, "stale_test.go");
+			const staleTest = path.join(tmpDir, "MixedCase_Test.go");
 			const relatedTest = path.join(tmpDir, "widget_test.go");
 			fs.writeFileSync(sourceFile, "package widget\n");
 			fs.writeFileSync(staleTest, "package widget\n");
@@ -1003,6 +1020,15 @@ describe("test-runner-client", () => {
 			expect(target).toMatchObject({
 				testFile: path.resolve(relatedTest),
 				runner: "go",
+				strategy: "related",
+			});
+
+			// Recreating the same mixed-case path must not resurrect a stale entry.
+			// On Windows this also proves deletion survives the normalizer changing
+			// from real on-disk casing to a lowercased missing-path tail.
+			fs.writeFileSync(staleTest, "package widget\n");
+			expect(client.getTestRunTarget(sourceFile, tmpDir)).toMatchObject({
+				testFile: path.resolve(relatedTest),
 				strategy: "related",
 			});
 		});
@@ -1061,7 +1087,10 @@ describe("test-runner-client", () => {
 			);
 
 			fs.writeFileSync(path.join(tmpDir, "go.mod"), "module example.com/tmp\n");
-			fs.writeFileSync(path.join(tmpDir, "Cargo.toml"), "[package]\nname='tmp'\n");
+			fs.writeFileSync(
+				path.join(tmpDir, "Cargo.toml"),
+				"[package]\nname='tmp'\n",
+			);
 			const goSource = path.join(tmpDir, "widget.go");
 			const staleGoTest = path.join(tmpDir, "stale_test.go");
 			const cargoSource = path.join(tmpDir, "widget.rs");
@@ -1120,7 +1149,9 @@ describe("test-runner-client", () => {
 			fs.writeFileSync(sourceFile, "package widget\n");
 			fs.writeFileSync(failedTest, "package widget\n");
 
-			const denied = Object.assign(new Error("access denied"), { code: "EACCES" });
+			const denied = Object.assign(new Error("access denied"), {
+				code: "EACCES",
+			});
 			const client = new TestRunnerClient(false, {
 				statFailedTarget: () => {
 					throw denied;
@@ -1168,6 +1199,47 @@ describe("test-runner-client", () => {
 					process.env.PI_LENS_TEST_MODE = previousTestMode;
 				}
 			}
+		});
+
+		it("keeps long target identities distinct in the degradation ledger", () => {
+			resetDegradationLedger();
+			resetBoundedTelemetry();
+			const client = new TestRunnerClient(false);
+			const record = (
+				client as unknown as {
+					recordFailedTargetState(value: {
+						outcome: "retired-missing";
+						runner: string;
+						candidate: string;
+						errorCode: string;
+						turnIndex: number;
+					}): void;
+				}
+			).recordFailedTargetState.bind(client);
+			const sharedPrefix = `C:/${"a".repeat(260)}`;
+			record({
+				outcome: "retired-missing",
+				runner: "vitest",
+				candidate: `${sharedPrefix}/one.test.ts`,
+				errorCode: "ENOENT",
+				turnIndex: 9,
+			});
+			record({
+				outcome: "retired-missing",
+				runner: "vitest",
+				candidate: `${sharedPrefix}/two.test.ts`,
+				errorCode: "ENOENT",
+				turnIndex: 9,
+			});
+
+			const group = getDegradationSummary().find(
+				(entry) => entry.kind === "test-runner-failed-target-state",
+			);
+			expect(group?.count).toBe(2);
+			expect(group?.droppedCount).toBe(0);
+			expect(
+				new Set(group?.latestReasons.map((entry) => entry.subject)).size,
+			).toBe(2);
 		});
 
 		it("bounds missing-target probes and carries the remainder forward", async () => {
@@ -1352,7 +1424,10 @@ describe("test-runner-client", () => {
 			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 			cleanups.push(cleanup);
 
-			fs.writeFileSync(path.join(tmpDir, "vitest.config.ts"), "export default {}\n");
+			fs.writeFileSync(
+				path.join(tmpDir, "vitest.config.ts"),
+				"export default {}\n",
+			);
 			const srcDir = path.join(tmpDir, "clients");
 			fs.mkdirSync(srcDir, { recursive: true });
 			const src = path.join(srcDir, "knip-client.ts");
@@ -1372,7 +1447,10 @@ describe("test-runner-client", () => {
 			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 			cleanups.push(cleanup);
 
-			fs.writeFileSync(path.join(tmpDir, "vitest.config.ts"), "export default {}\n");
+			fs.writeFileSync(
+				path.join(tmpDir, "vitest.config.ts"),
+				"export default {}\n",
+			);
 			const srcDir = path.join(tmpDir, "lib", "utils");
 			fs.mkdirSync(srcDir, { recursive: true });
 			const src = path.join(srcDir, "format.ts");
@@ -1412,7 +1490,10 @@ describe("test-runner-client", () => {
 			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 			cleanups.push(cleanup);
 
-			fs.writeFileSync(path.join(tmpDir, "vitest.config.ts"), "export default {}\n");
+			fs.writeFileSync(
+				path.join(tmpDir, "vitest.config.ts"),
+				"export default {}\n",
+			);
 			const srcDir = path.join(tmpDir, "clients");
 			fs.mkdirSync(srcDir, { recursive: true });
 			const src = path.join(srcDir, "widget.ts");
@@ -1429,7 +1510,10 @@ describe("test-runner-client", () => {
 			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 			cleanups.push(cleanup);
 
-			fs.writeFileSync(path.join(tmpDir, "vitest.config.ts"), "export default {}\n");
+			fs.writeFileSync(
+				path.join(tmpDir, "vitest.config.ts"),
+				"export default {}\n",
+			);
 			const srcDir = path.join(tmpDir, "clients");
 			fs.mkdirSync(srcDir, { recursive: true });
 			const src = path.join(srcDir, "gadget.ts");
@@ -1449,7 +1533,10 @@ describe("test-runner-client", () => {
 			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 			cleanups.push(cleanup);
 
-			fs.writeFileSync(path.join(tmpDir, "vitest.config.ts"), "export default {}\n");
+			fs.writeFileSync(
+				path.join(tmpDir, "vitest.config.ts"),
+				"export default {}\n",
+			);
 			const srcDir = path.join(tmpDir, "clients");
 			fs.mkdirSync(srcDir, { recursive: true });
 			const src = path.join(srcDir, "dual.ts");
@@ -1611,7 +1698,10 @@ describe("test-runner-client", () => {
 			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 			cleanups.push(cleanup);
 
-			fs.writeFileSync(path.join(tmpDir, "vitest.config.ts"), "export default {}\n");
+			fs.writeFileSync(
+				path.join(tmpDir, "vitest.config.ts"),
+				"export default {}\n",
+			);
 			const src = path.join(tmpDir, "foo.test.ts");
 			fs.writeFileSync(src, "// test\n");
 
@@ -1625,7 +1715,10 @@ describe("test-runner-client", () => {
 			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 			cleanups.push(cleanup);
 
-			fs.writeFileSync(path.join(tmpDir, "vitest.config.ts"), "export default {}\n");
+			fs.writeFileSync(
+				path.join(tmpDir, "vitest.config.ts"),
+				"export default {}\n",
+			);
 			const src = path.join(tmpDir, "bar.spec.ts");
 			fs.writeFileSync(src, "// test\n");
 
@@ -1653,7 +1746,10 @@ describe("test-runner-client", () => {
 			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 			cleanups.push(cleanup);
 
-			fs.writeFileSync(path.join(tmpDir, "vitest.config.ts"), "export default {}\n");
+			fs.writeFileSync(
+				path.join(tmpDir, "vitest.config.ts"),
+				"export default {}\n",
+			);
 			const src = path.join(tmpDir, "widget.ts");
 			fs.writeFileSync(src, "export const x = 1;\n");
 			const testFile = path.join(tmpDir, "widget.test.ts");
@@ -1669,7 +1765,10 @@ describe("test-runner-client", () => {
 			const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 			cleanups.push(cleanup);
 
-			fs.writeFileSync(path.join(tmpDir, "vitest.config.ts"), "export default {}\n");
+			fs.writeFileSync(
+				path.join(tmpDir, "vitest.config.ts"),
+				"export default {}\n",
+			);
 			const src = path.join(tmpDir, "flaky.test.ts");
 			fs.writeFileSync(src, "// test\n");
 			const vitestFailureConfig = {
@@ -1886,7 +1985,10 @@ describe("test-runner-client", () => {
 		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 		cleanups.push(cleanup);
 
-		fs.writeFileSync(path.join(tmpDir, "phpunit.xml.dist"), "<phpunit></phpunit>\n");
+		fs.writeFileSync(
+			path.join(tmpDir, "phpunit.xml.dist"),
+			"<phpunit></phpunit>\n",
+		);
 
 		const client = new TestRunnerClient(false);
 		const detected = client.detectRunner(tmpDir);
@@ -1929,7 +2031,11 @@ describe("test-runner-client", () => {
 		cleanups.push(cleanup);
 
 		fs.writeFileSync(path.join(tmpDir, "phpunit.xml"), "<phpunit></phpunit>\n");
-		const src = createTempFile(tmpDir, "src/Foo/Bar.php", "<?php\nclass Bar {}\n");
+		const src = createTempFile(
+			tmpDir,
+			"src/Foo/Bar.php",
+			"<?php\nclass Bar {}\n",
+		);
 		const testFile = createTempFile(
 			tmpDir,
 			"tests/Foo/BarTest.php",
@@ -2090,7 +2196,11 @@ describe("test-runner-client", () => {
 				startTime: 1786866554330,
 				endTime: 1786866554461.674,
 				assertionResults: [
-					{ status: "passed", title: "slow pass", duration: 122.60340400000001 },
+					{
+						status: "passed",
+						title: "slow pass",
+						duration: 122.60340400000001,
+					},
 					{ status: "failed", title: "quick fail", duration: 8.674104 },
 					{ status: "skipped", title: "skipped" },
 				],
@@ -2275,8 +2385,18 @@ describe("test-runner-client", () => {
 				numPassedTests: 2,
 				numFailedTests: 0,
 				testResults: [
-					{ name: "/tmp/a.test.js", status: "passed", startTime: 1000, endTime: 1500 },
-					{ name: "/tmp/b.test.js", status: "passed", startTime: 1100, endTime: 1900 },
+					{
+						name: "/tmp/a.test.js",
+						status: "passed",
+						startTime: 1000,
+						endTime: 1500,
+					},
+					{
+						name: "/tmp/b.test.js",
+						status: "passed",
+						startTime: 1100,
+						endTime: 1900,
+					},
 				],
 			}),
 			"",
@@ -2302,7 +2422,9 @@ describe("test-runner-client", () => {
 						status: "passed",
 						startTime: 2000,
 						endTime: 1000,
-						assertionResults: [{ status: "passed", title: "a", duration: null }],
+						assertionResults: [
+							{ status: "passed", title: "a", duration: null },
+						],
 					},
 				],
 			}),
@@ -2336,7 +2458,9 @@ describe("test-runner-client", () => {
 						status: "passed",
 						startTime: 1_760_000_000_000,
 						endTime: 1_760_000_000_000,
-						assertionResults: [{ status: "passed", title: "a", duration: null }],
+						assertionResults: [
+							{ status: "passed", title: "a", duration: null },
+						],
 					},
 				],
 			}),
@@ -2361,7 +2485,9 @@ describe("test-runner-client", () => {
 					{
 						name: "/tmp/a.test.js",
 						status: "passed",
-						assertionResults: [{ status: "passed", title: "a", duration: null }],
+						assertionResults: [
+							{ status: "passed", title: "a", duration: null },
+						],
 					},
 				],
 			}),
@@ -2463,7 +2589,10 @@ describe("test-runner-client", () => {
 		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 		cleanups.push(cleanup);
 
-		fs.writeFileSync(path.join(tmpDir, "mix.exs"), "defmodule Demo.MixProject do\nend\n");
+		fs.writeFileSync(
+			path.join(tmpDir, "mix.exs"),
+			"defmodule Demo.MixProject do\nend\n",
+		);
 
 		const client = new TestRunnerClient(false);
 		const detected = client.detectRunner(tmpDir);
@@ -2474,7 +2603,10 @@ describe("test-runner-client", () => {
 		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-tests-");
 		cleanups.push(cleanup);
 
-		fs.writeFileSync(path.join(tmpDir, "mix.exs"), "defmodule Demo.MixProject do\nend\n");
+		fs.writeFileSync(
+			path.join(tmpDir, "mix.exs"),
+			"defmodule Demo.MixProject do\nend\n",
+		);
 		const src = createTempFile(
 			tmpDir,
 			"lib/accounts/user.ex",
@@ -2592,14 +2724,21 @@ describe("resolveExec argv preservation matrix (#1098)", () => {
 
 		describe(`runner: ${runnerKey}`, () => {
 			it("preserves argv on local-bin resolution", () => {
-				const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-resolve-exec-");
+				const { tmpDir, cleanup } = setupTestEnvironment(
+					"pi-lens-resolve-exec-",
+				);
 				resolveCleanups.push(cleanup);
 				const client = new TestRunnerClient(false) as any;
 
 				let localBinPath: string;
 				if (runnerKey === "phpunit") {
 					const phpSuffix = process.platform === "win32" ? ".bat" : "";
-					localBinPath = path.join(tmpDir, "vendor", "bin", `phpunit${phpSuffix}`);
+					localBinPath = path.join(
+						tmpDir,
+						"vendor",
+						"bin",
+						`phpunit${phpSuffix}`,
+					);
 				} else {
 					localBinPath = path.join(
 						tmpDir,
@@ -2624,7 +2763,9 @@ describe("resolveExec argv preservation matrix (#1098)", () => {
 						// phpunit's local (vendor/bin) resolution never strips —
 						// see the dedicated branch in resolveExec.
 						const expected =
-							runnerKey === "phpunit" ? rawArgs : expectedStrippedArgs(binName, rawArgs);
+							runnerKey === "phpunit"
+								? rawArgs
+								: expectedStrippedArgs(binName, rawArgs);
 						expect(resolved.args).toEqual(expected);
 					});
 			});
@@ -2635,7 +2776,9 @@ describe("resolveExec argv preservation matrix (#1098)", () => {
 				// (`command: "phpunit"`), so it's covered by the fallback case
 				// below instead of duplicated here.
 				it("preserves argv on global-bin resolution", () => {
-					const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-resolve-exec-");
+					const { tmpDir, cleanup } = setupTestEnvironment(
+						"pi-lens-resolve-exec-",
+					);
 					resolveCleanups.push(cleanup);
 					const client = new TestRunnerClient(false) as any;
 
@@ -2654,13 +2797,17 @@ describe("resolveExec argv preservation matrix (#1098)", () => {
 						.resolveExec(runnerKey, config, testFile, tmpDir)
 						.then((resolved: { command: string; args: string[] }) => {
 							expect(resolved.command).toBe(globalBinPath);
-							expect(resolved.args).toEqual(expectedStrippedArgs(binName, rawArgs));
+							expect(resolved.args).toEqual(
+								expectedStrippedArgs(binName, rawArgs),
+							);
 						});
 				});
 			}
 
 			it("preserves argv verbatim on fallback (no local/global bin)", () => {
-				const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-resolve-exec-");
+				const { tmpDir, cleanup } = setupTestEnvironment(
+					"pi-lens-resolve-exec-",
+				);
 				resolveCleanups.push(cleanup);
 				const client = new TestRunnerClient(false) as any;
 
@@ -2689,7 +2836,12 @@ describe("resolveExec argv preservation matrix (#1098)", () => {
 		resolveCleanups.push(cleanup);
 		const client = new TestRunnerClient(false) as any;
 
-		const localBinPath = path.join(tmpDir, "node_modules", ".bin", `cargo${binSuffix()}`);
+		const localBinPath = path.join(
+			tmpDir,
+			"node_modules",
+			".bin",
+			`cargo${binSuffix()}`,
+		);
 		fs.mkdirSync(path.dirname(localBinPath), { recursive: true });
 		fs.writeFileSync(localBinPath, "");
 


### PR DESCRIPTION
## Outcome

Retire only confirmed-missing failed-first test targets. Test discovery continues to another valid failure or normal related-test discovery instead of retrying a deleted path forever.

Closes #2044.

## State model

- Canonical project-root and target keys collapse symlink, separator, and case aliases. Values preserve caller path spelling for execution.
- A runner retains its globally newest 32 failed targets across all roots.
- Each selection probes at most 8 candidates. Unchecked candidates carry into the next selection.
- `ENOENT` and `ENOTDIR` retire state. Permission and transient failures retain it.
- Runner and project-root buckets remain isolated. Capacity eviction reattaches a removed destination root before inserting the newest failure.
- Telemetry retains 64 interleavable turn buckets. Results older than that bounded window fail closed instead of reopening a spent budget.

## Changes

- Replace raw failed-path sets with nested `PathKeyedMap` state plus global recency sequences.
- Preserve related/self priority among validated failures.
- Carry the originating turn into asynchronous result recording.
- Emit missing, indeterminate, and capacity outcomes through `emitBounded`, with exact ledger counts and at most eight detailed rows per originating turn.
- Exclude the zero-duration decision row from last-phase stall attribution.

## Tests

`tests/clients/test-runner-client.test.ts` uses the real client, filesystem, and runner process boundary. Cases cover deleted-target fallback, next valid failure, same-project runner isolation, symlink root and target spelling, indeterminate stat failures, real latency-log bytes, eight-probe carry-over, the 32-target cap, post-eviction root reattachment, and global cross-root recency after refresh.

`tests/clients/bounded-telemetry.test.ts` covers late T1 completion after T2, independent per-turn counts, the 64-turn storage cap, and fail-closed retired turns.

`tests/clients/runtime-turn-session.test.ts` proves the originating turn reaches asynchronous test recording. `tests/clients/latency-logger.test.ts` pins last-phase exclusion.

Independent mutants cover runner isolation, filesystem classification, path canonicalization, caller spelling, probe cap, state cap, global LRU order, post-eviction reattachment, interleaved-turn accounting, telemetry phase, and last-phase exclusion. Every mutant makes its regression test fail.

Verification passed: build, lint, format, changelog validation, ast-grep self-scan, clean LSP diagnostics, and 369 targeted tests across seven files.

## Blast radius and cost

`module_report(..., blastRadius:true)` was attempted before and after for all five changed production modules: `test-runner-client.ts`, `runtime-turn.ts`, `bounded-telemetry.ts`, `degradation-ledger.ts`, and `latency-logger.ts`. The cached graph was identity-stale and had no nodes for these files, so transitive graph evidence remains unavailable. Direct imports identify `runtime-turn.ts` as the production selection and asynchronous execution entry point. The initial review mapped 12 base dependents.

A 50-sample turn-level benchmark measured four selections at p95 0.753 ms without failed state and 13.215 ms while draining the maximum 32 missing targets. The bounded worst-case delta was 12.462 ms.

## Observability

`test_runner_failed_target_state` records the outcome, runner, bounded path identity, and filesystem code in the real latency sink. The degradation ledger retains exact counts when detailed rows hit their cap.

## Class sweep

The sweep found raw cwd-keyed runner-detection and Vitest-glob caches in the same module. They are separate from failed-first state and are tracked in #2048.

## Review status

The first review requested changes for a vacuous isolation test, filesystem semantics, raw path keys, unbounded work/state, raw telemetry, and missing blast evidence. The first follow-up found cross-root recency, late-turn cap, caller-spelling, and turn-level evidence gaps. Commits `75eca2f2` and `cab51f08` address every finding. A final scoped adversarial review is pending before this draft becomes ready.
