### PR TITLE
docs(dead-code): correct vulture exit-code comment (#1765)

### DIFF
--- a/.changelog/fix-1765-vulture-exit-comment.md
+++ b/.changelog/fix-1765-vulture-exit-comment.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Correct the vulture exit-code comment (closes #1765)** — The comment in `clients/dead-code-client.ts` now states the verified vulture 2.16 exit codes: 0 on a clean run, 3 with findings on stdout when dead code is found, and 1 with an error on stderr for invalid input or parse errors.

--- a/clients/dead-code-client.ts
+++ b/clients/dead-code-client.ts
@@ -163,9 +163,9 @@ export function parseVultureOutput(
  *
  * vulture finds unused functions, classes, methods, imports, variables and
  * attributes by static analysis of the whole tree. It has no JSON reporter, so
- * we parse its stable one-line-per-finding text output. It exits 1 when it
- * FINDS dead code (linter convention), so a non-zero exit with parseable
- * output is success, not failure.
+ * we parse its stable one-line-per-finding text output. A clean run exits 0;
+ * found dead code exits 3 with findings on stdout. A non-zero exit with
+ * parseable output is success, not failure (see runAnalyze for the table).
  */
 export class PythonDeadCodeClient implements DeadCodeClient {
 	readonly id = "python";
@@ -458,14 +458,16 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 				durationMs,
 			};
 		}
-		// vulture writes parse/usage errors to stderr and exits 1 with no
-		// stdout findings; distinguish that from "found dead code" (exit 1 WITH
-		// findings on stdout). #1736 sweep: the ORIGINAL guard here required
-		// non-empty stderr to call it an error, so a nonzero exit with BOTH
-		// empty stdout and empty stderr (a silent crash) still fell through to
-		// "No dead code found" -- the same empty-distinguishes-clean-from-errored
-		// gap the knip fix closes. A nonzero exit with no findings on stdout is
-		// never clean now, regardless of whether stderr said anything.
+		// Verified exit-code table (vulture 2.16, probed live during the #1758
+		// review): a clean run exits 0 with empty stdout; dead code found exits
+		// 3 with findings on stdout; invalid input or a parse error exits 1
+		// with empty stdout and the error on stderr. #1736 sweep: the ORIGINAL
+		// guard here required non-empty stderr to call it an error, so a
+		// nonzero exit with BOTH empty stdout and empty stderr (a silent crash)
+		// still fell through to "No dead code found" -- the same
+		// empty-distinguishes-clean-from-errored gap the knip fix closes. A
+		// nonzero exit with no findings on stdout is never clean now,
+		// regardless of whether stderr said anything.
 		const output = result.stdout || "";
 		if (!output.trim()) {
 			const stderr = (result.stderr || "").trim();


### PR DESCRIPTION
Closes #1765.

## What changed

Rewrote the vulture exit-code comment in `clients/dead-code-client.ts` (the `runAnalyze` guard) to state the verified behavior, and corrected the same stale claim in the `PythonDeadCodeClient` class docstring. Added a changelog fragment.

## Why

The old comment claimed vulture exits 1 with no stdout findings, and framed dead-code-found as "exit 1 WITH findings". Both claims are wrong. Live probing of vulture 2.16 during the PR #1758 review verified the real table:

- Clean run: exit 0, empty stdout.
- Dead code found: exit 3, findings on stdout.
- Invalid input or parse error: exit 1, empty stdout, error on stderr.

## How verified

This is a comment-only change with no runtime impact. The guard logic is already correct: the #1736 check uses a generic `status !== 0` plus an empty-output test, so it handles every row of the verified table. No code or test changes were needed. `npm run fmt:check` passes.