### PR TITLE
fix(ci): unify pinned npm version across workflows (closes #2051)

### DIFF
--- a/.changelog/fix-2051-unify-npm-pin.md
+++ b/.changelog/fix-2051-unify-npm-pin.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Unify the pinned npm version across workflows (#2051)** — ci.yml and release.yml both pin npm 11.18.0 so a single lockfile-writer version governs CI and release installs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,11 @@ jobs:
 
       # npm 11.11 restored libc descriptors in lockfile v3 (#9025). Older npm
       # silently removes them and installs both glibc and musl optional binaries.
+      # Keep this version in sync with the pin in release.yml (publish-npm job).
       - name: Pin npm with libc-aware lockfile metadata
         run: |
-          npm install --ignore-scripts --global npm@11.17.0
-          test "$(npm --version)" = "11.17.0"
+          npm install --ignore-scripts --global npm@11.18.0
+          test "$(npm --version)" = "11.18.0"
 
       # #437: typescript is a devDependency (#402), so --omit=dev omits it. pi builds
       # the GitHub install from source under --omit=dev, so `build:dist` must resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,10 @@ jobs:
       # deliberately not npm 12.x, whose engines requirement
       # (node ^22.22.2 || ^24.15.0 || >=26.0.0) is stricter than what the
       # `node-version: 22` pin above guarantees.
+      # npm 11.11 restored libc descriptors in lockfile v3 (#9025), so a
+      # release-time install keeps glibc/musl optional-binary metadata intact.
+      # Keep this version in sync with the pin in ci.yml
+      # (production-install-build job).
       - name: Pin npm to a version with OIDC trusted-publishing support
         run: npm install -g npm@11.18.0 --ignore-scripts
 


### PR DESCRIPTION
## What changed

ci.yml pinned npm 11.17.0; release.yml pinned npm 11.18.0. This PR unifies both to 11.18.0 and adds a cross-reference at each pin naming the sibling workflow.

## Why

Both pins already satisfy the >=11.11 floor that preserves libc descriptors in lockfile v3 (npm/cli#9025), so there is no correctness gap today. Two pins can still drift on lockfile-writer behavior over time, so one consistent version is safer.

## Verification

No lockfile semantic change results. The production-install CI jobs are the proof surface: the `prod-install-build` job in ci.yml and the `publish-npm` job in release.yml both install with the same 11.18.0 pin, and the `Lockfile in sync with package.json` check in the `lint-and-typecheck` job guards lockfile stability.

A changelog fragment is included in `.changelog/`.