### PR TITLE
fix(test-runner): canonicalize roots #2048

### DIFF
--- a/.changelog/fix-2048-canonical-cache-roots.md
+++ b/.changelog/fix-2048-canonical-cache-roots.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Canonicalize test-runner cache roots (refs #2048)** — Test-runner availability and Vitest glob caches now share project identity across path aliases.
+- **Canonicalize test-runner cache roots (refs #2048)** — Test-runner availability and Vitest glob caches now share project identity across path aliases, while positive runner verdicts expire when their supporting config disappears.

--- a/.changelog/fix-2048-canonical-cache-roots.md
+++ b/.changelog/fix-2048-canonical-cache-roots.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Canonicalize test-runner cache roots (refs #2048)** — Test-runner availability and Vitest glob caches now share project identity across path aliases.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,6 +438,11 @@ decision point re-reads live clients because `inFlight` cleanup is asynchronous.
 **Path-keyed Tier-3 caches normalize at both boundaries.** Widget LSP server
 roots, startup-scan context keys, and Ruby drive-root memo keys use
 `normalizeMapKey`; equivalent separator/case spellings must share one entry.
+Test-runner project-root caches additionally canonicalize through guarded
+`realpathSync.native` on every platform. Canonical aliases share availability
+verdicts, so cached positive verdicts retain their config evidence path and
+must be discarded when that file disappears; canonicalize once per public
+hot-path call, not once per runner lookup.
 Widget file-record cardinality eviction is render-aware: only idle records with
 no live diagnostic may be evicted. Formatter detection signatures include
 formatter config metadata, and tsconfig-path signatures include recursive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2254,3 +2254,9 @@ Process-table resource samples preserve query outcome. `clients/child-unref.ts`
 those failures, so consumers leave usage unknown rather than fabricating zero
 samples, and records one bounded `resource-sampler-query-failed` degradation
 per query subject. (#1863)
+
+Test-runner availability and Vitest-glob caches canonicalize each public cwd
+once, then use `normalizeEphemeralMapKey` because their keys are already
+canonical and process-local. `detectRunner` hoists the outer availability-map
+lookup before the runner loop and uses the nested plain `Map`; glob-cache
+lookups use one `get`, not `has` plus `get`. (#2048)

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -21,7 +21,7 @@ import { createSubsystemLogger } from "./extension-log.js";
 import { detectFileRole } from "./file-role.js";
 import { findGlobalBinary } from "./package-manager.js";
 import { PathKeyedMap } from "./path-keyed-map.js";
-import { normalizeMapKey } from "./path-utils.js";
+import { normalizeEphemeralMapKey, normalizeMapKey } from "./path-utils.js";
 import { isMeasuredDuration, toMeasuredDurationMs } from "./run-duration.js";
 import { safeSpawn, safeSpawnAsync } from "./safe-spawn.js";
 
@@ -321,9 +321,9 @@ function canonicalFailedPath(filePath: string): string {
 function canonicalProjectRoot(cwd: string): string {
 	const absolute = path.resolve(cwd);
 	try {
-		return normalizeMapKey(fs.realpathSync.native(absolute));
+		return normalizeEphemeralMapKey(fs.realpathSync.native(absolute));
 	} catch {
-		return normalizeMapKey(absolute);
+		return normalizeEphemeralMapKey(absolute);
 	}
 }
 
@@ -347,7 +347,7 @@ function filesystemErrorCode(error: unknown): string | undefined {
 export class TestRunnerClient {
 	private log: (msg: string) => void;
 	private availableRunners = new PathKeyedMap<Map<string, RunnerAvailability>>(
-		normalizeMapKey,
+		normalizeEphemeralMapKey,
 	);
 	private failedTestsByRunner = new Map<
 		string,
@@ -364,7 +364,7 @@ export class TestRunnerClient {
 	private vitestTestGlobsCache = new PathKeyedMap<{
 		include?: string[];
 		exclude?: string[];
-	} | null>(normalizeMapKey);
+	} | null>(normalizeEphemeralMapKey);
 
 	constructor(verbose = false, options: TestRunnerClientOptions = {}) {
 		this.log = verbose ? createSubsystemLogger("test-runner") : () => {};
@@ -373,10 +373,9 @@ export class TestRunnerClient {
 	}
 
 	private getRunnerAvailability(
-		rootKey: string,
+		byRunner: Map<string, RunnerAvailability> | undefined,
 		runner: string,
 	): boolean | undefined {
-		const byRunner = this.availableRunners.get(rootKey);
 		const cached = byRunner?.get(runner);
 		if (!cached) return undefined;
 		if (
@@ -391,16 +390,11 @@ export class TestRunnerClient {
 	}
 
 	private setRunnerAvailability(
-		rootKey: string,
+		byRunner: Map<string, RunnerAvailability>,
 		runner: string,
 		available: boolean,
 		evidencePath?: string,
 	): void {
-		let byRunner = this.availableRunners.get(rootKey);
-		if (!byRunner) {
-			byRunner = new Map();
-			this.availableRunners.set(rootKey, byRunner);
-		}
 		byRunner.set(runner, { available, evidencePath });
 	}
 
@@ -416,9 +410,14 @@ export class TestRunnerClient {
 		sourceFilePath?: string,
 	): { runner: string; config: RunnerConfig } | null {
 		const rootKey = canonicalProjectRoot(cwd);
+		let byRunner = this.availableRunners.get(rootKey);
+		if (!byRunner) {
+			byRunner = new Map();
+			this.availableRunners.set(rootKey, byRunner);
+		}
 		// Priority 1: Config files
 		for (const [name, config] of Object.entries(RUNNERS)) {
-			const cached = this.getRunnerAvailability(rootKey, name);
+			const cached = this.getRunnerAvailability(byRunner, name);
 			if (cached !== undefined) {
 				if (cached) {
 					return { runner: name, config };
@@ -462,7 +461,7 @@ export class TestRunnerClient {
 				return matches;
 			});
 
-			this.setRunnerAvailability(rootKey, name, found, configEvidencePath);
+			this.setRunnerAvailability(byRunner, name, found, configEvidencePath);
 			if (found) {
 				this.log(`Detected runner via config: ${name}`);
 				return { runner: name, config };
@@ -480,17 +479,17 @@ export class TestRunnerClient {
 			// Check for vitest first (more specific than jest)
 			if (allDeps.vitest) {
 				this.log("Detected vitest in package.json");
-				this.setRunnerAvailability(rootKey, "vitest", true, packageJsonPath);
+				this.setRunnerAvailability(byRunner, "vitest", true, packageJsonPath);
 				return { runner: "vitest", config: RUNNERS.vitest };
 			}
 			if (allDeps.jest) {
 				this.log("Detected jest in package.json");
-				this.setRunnerAvailability(rootKey, "jest", true, packageJsonPath);
+				this.setRunnerAvailability(byRunner, "jest", true, packageJsonPath);
 				return { runner: "jest", config: RUNNERS.jest };
 			}
 			if (allDeps.pytest || allDeps["pytest-cov"]) {
 				this.log("Detected pytest in package.json (unusual)");
-				this.setRunnerAvailability(rootKey, "pytest", true, packageJsonPath);
+				this.setRunnerAvailability(byRunner, "pytest", true, packageJsonPath);
 				return { runner: "pytest", config: RUNNERS.pytest };
 			}
 		} catch (err) {
@@ -686,8 +685,9 @@ export class TestRunnerClient {
 		cwd: string,
 	): { include?: string[]; exclude?: string[] } | null {
 		const rootKey = canonicalProjectRoot(cwd);
-		if (this.vitestTestGlobsCache.has(rootKey)) {
-			return this.vitestTestGlobsCache.get(rootKey) ?? null;
+		const cached = this.vitestTestGlobsCache.get(rootKey);
+		if (cached !== undefined) {
+			return cached;
 		}
 
 		// .mts isn't in RUNNERS.vitest.configFiles (that list drives runner

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -318,6 +318,20 @@ function canonicalFailedPath(filePath: string): string {
 	}
 }
 
+function canonicalProjectRoot(cwd: string): string {
+	const absolute = path.resolve(cwd);
+	try {
+		return normalizeMapKey(fs.realpathSync.native(absolute));
+	} catch {
+		return normalizeMapKey(absolute);
+	}
+}
+
+interface RunnerAvailability {
+	available: boolean;
+	evidencePath?: string;
+}
+
 function filesystemErrorCode(error: unknown): string | undefined {
 	if (
 		error !== null &&
@@ -332,7 +346,7 @@ function filesystemErrorCode(error: unknown): string | undefined {
 
 export class TestRunnerClient {
 	private log: (msg: string) => void;
-	private availableRunners = new PathKeyedMap<Map<string, boolean>>(
+	private availableRunners = new PathKeyedMap<Map<string, RunnerAvailability>>(
 		normalizeMapKey,
 	);
 	private failedTestsByRunner = new Map<
@@ -359,23 +373,35 @@ export class TestRunnerClient {
 	}
 
 	private getRunnerAvailability(
-		cwd: string,
+		rootKey: string,
 		runner: string,
 	): boolean | undefined {
-		return this.availableRunners.get(cwd)?.get(runner);
+		const byRunner = this.availableRunners.get(rootKey);
+		const cached = byRunner?.get(runner);
+		if (!cached) return undefined;
+		if (
+			cached.available &&
+			cached.evidencePath !== undefined &&
+			!fs.existsSync(cached.evidencePath)
+		) {
+			byRunner?.delete(runner);
+			return undefined;
+		}
+		return cached.available;
 	}
 
 	private setRunnerAvailability(
-		cwd: string,
+		rootKey: string,
 		runner: string,
 		available: boolean,
+		evidencePath?: string,
 	): void {
-		let byRunner = this.availableRunners.get(cwd);
+		let byRunner = this.availableRunners.get(rootKey);
 		if (!byRunner) {
 			byRunner = new Map();
-			this.availableRunners.set(cwd, byRunner);
+			this.availableRunners.set(rootKey, byRunner);
 		}
-		byRunner.set(runner, available);
+		byRunner.set(runner, { available, evidencePath });
 	}
 
 	/**
@@ -389,9 +415,10 @@ export class TestRunnerClient {
 		cwd: string,
 		sourceFilePath?: string,
 	): { runner: string; config: RunnerConfig } | null {
+		const rootKey = canonicalProjectRoot(cwd);
 		// Priority 1: Config files
 		for (const [name, config] of Object.entries(RUNNERS)) {
-			const cached = this.getRunnerAvailability(cwd, name);
+			const cached = this.getRunnerAvailability(rootKey, name);
 			if (cached !== undefined) {
 				if (cached) {
 					return { runner: name, config };
@@ -399,13 +426,16 @@ export class TestRunnerClient {
 				continue;
 			}
 
+			let configEvidencePath: string | undefined;
 			const found = config.configFiles.some((cf) => {
 				if (name === "pytest" && cf === "pyproject.toml") {
 					const pyprojectPath = path.join(cwd, cf);
 					if (!fs.existsSync(pyprojectPath)) return false;
 					try {
 						const pyproject = fs.readFileSync(pyprojectPath, "utf-8");
-						return pyproject.includes("[tool.pytest.ini_options]");
+						const matches = pyproject.includes("[tool.pytest.ini_options]");
+						if (matches) configEvidencePath = pyprojectPath;
+						return matches;
 					} catch {
 						return false;
 					}
@@ -419,15 +449,20 @@ export class TestRunnerClient {
 							...composer.require,
 							...composer["require-dev"],
 						};
-						return Boolean(allDeps["phpunit/phpunit"]);
+						const matches = Boolean(allDeps["phpunit/phpunit"]);
+						if (matches) configEvidencePath = composerPath;
+						return matches;
 					} catch {
 						return false;
 					}
 				}
-				return fs.existsSync(path.join(cwd, cf));
+				const candidate = path.join(cwd, cf);
+				const matches = fs.existsSync(candidate);
+				if (matches) configEvidencePath = candidate;
+				return matches;
 			});
 
-			this.setRunnerAvailability(cwd, name, found);
+			this.setRunnerAvailability(rootKey, name, found, configEvidencePath);
 			if (found) {
 				this.log(`Detected runner via config: ${name}`);
 				return { runner: name, config };
@@ -445,17 +480,17 @@ export class TestRunnerClient {
 			// Check for vitest first (more specific than jest)
 			if (allDeps.vitest) {
 				this.log("Detected vitest in package.json");
-				this.setRunnerAvailability(cwd, "vitest", true);
+				this.setRunnerAvailability(rootKey, "vitest", true, packageJsonPath);
 				return { runner: "vitest", config: RUNNERS.vitest };
 			}
 			if (allDeps.jest) {
 				this.log("Detected jest in package.json");
-				this.setRunnerAvailability(cwd, "jest", true);
+				this.setRunnerAvailability(rootKey, "jest", true, packageJsonPath);
 				return { runner: "jest", config: RUNNERS.jest };
 			}
 			if (allDeps.pytest || allDeps["pytest-cov"]) {
 				this.log("Detected pytest in package.json (unusual)");
-				this.setRunnerAvailability(cwd, "pytest", true);
+				this.setRunnerAvailability(rootKey, "pytest", true, packageJsonPath);
 				return { runner: "pytest", config: RUNNERS.pytest };
 			}
 		} catch (err) {
@@ -650,8 +685,9 @@ export class TestRunnerClient {
 	parseVitestTestGlobs(
 		cwd: string,
 	): { include?: string[]; exclude?: string[] } | null {
-		if (this.vitestTestGlobsCache.has(cwd)) {
-			return this.vitestTestGlobsCache.get(cwd) ?? null;
+		const rootKey = canonicalProjectRoot(cwd);
+		if (this.vitestTestGlobsCache.has(rootKey)) {
+			return this.vitestTestGlobsCache.get(rootKey) ?? null;
 		}
 
 		// .mts isn't in RUNNERS.vitest.configFiles (that list drives runner
@@ -680,7 +716,7 @@ export class TestRunnerClient {
 			}
 		}
 
-		this.vitestTestGlobsCache.set(cwd, result);
+		this.vitestTestGlobsCache.set(rootKey, result);
 		return result;
 	}
 

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -327,6 +327,8 @@ function canonicalProjectRoot(cwd: string): string {
 	}
 }
 
+const MAX_CANONICAL_ROOT_MEMO_ENTRIES = 512;
+
 interface RunnerAvailability {
 	available: boolean;
 	evidencePath?: string;
@@ -346,6 +348,12 @@ function filesystemErrorCode(error: unknown): string | undefined {
 
 export class TestRunnerClient {
 	private log: (msg: string) => void;
+	// This is an instance-lifetime memo: a symlink retargeted mid-session keeps
+	// its old resolution until a new client instance. That is acceptable because
+	// round 2's evidence re-validation already handles verdict-level staleness
+	// (positive verdicts re-stat their config file). Keep the memo bounded so
+	// pathological spelling churn cannot grow it without limit.
+	private canonicalRootMemo = new Map<string, string>();
 	private availableRunners = new PathKeyedMap<Map<string, RunnerAvailability>>(
 		normalizeEphemeralMapKey,
 	);
@@ -370,6 +378,19 @@ export class TestRunnerClient {
 		this.log = verbose ? createSubsystemLogger("test-runner") : () => {};
 		this.statFailedTarget =
 			options.statFailedTarget ?? ((filePath) => void fs.statSync(filePath));
+	}
+
+	private getCanonicalProjectRoot(cwd: string): string {
+		const cached = this.canonicalRootMemo.get(cwd);
+		if (cached !== undefined) return cached;
+
+		const canonical = canonicalProjectRoot(cwd);
+		if (this.canonicalRootMemo.size >= MAX_CANONICAL_ROOT_MEMO_ENTRIES) {
+			const oldest = this.canonicalRootMemo.keys().next().value;
+			if (oldest !== undefined) this.canonicalRootMemo.delete(oldest);
+		}
+		this.canonicalRootMemo.set(cwd, canonical);
+		return canonical;
 	}
 
 	private getRunnerAvailability(
@@ -409,7 +430,7 @@ export class TestRunnerClient {
 		cwd: string,
 		sourceFilePath?: string,
 	): { runner: string; config: RunnerConfig } | null {
-		const rootKey = canonicalProjectRoot(cwd);
+		const rootKey = this.getCanonicalProjectRoot(cwd);
 		let byRunner = this.availableRunners.get(rootKey);
 		if (!byRunner) {
 			byRunner = new Map();
@@ -684,7 +705,7 @@ export class TestRunnerClient {
 	parseVitestTestGlobs(
 		cwd: string,
 	): { include?: string[]; exclude?: string[] } | null {
-		const rootKey = canonicalProjectRoot(cwd);
+		const rootKey = this.getCanonicalProjectRoot(cwd);
 		const cached = this.vitestTestGlobsCache.get(rootKey);
 		if (cached !== undefined) {
 			return cached;

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -332,7 +332,9 @@ function filesystemErrorCode(error: unknown): string | undefined {
 
 export class TestRunnerClient {
 	private log: (msg: string) => void;
-	private availableRunners: Map<string, boolean> = new Map();
+	private availableRunners = new PathKeyedMap<Map<string, boolean>>(
+		normalizeMapKey,
+	);
 	private failedTestsByRunner = new Map<
 		string,
 		PathKeyedMap<PathKeyedMap<FailedTargetEntry>>
@@ -345,15 +347,35 @@ export class TestRunnerClient {
 	// or it couldn't be parsed in the simple shape we look for" — callers
 	// treat that as "no additional signal" and fall back to naming-convention
 	// detection only.
-	private vitestTestGlobsCache: Map<
-		string,
-		{ include?: string[]; exclude?: string[] } | null
-	> = new Map();
+	private vitestTestGlobsCache = new PathKeyedMap<{
+		include?: string[];
+		exclude?: string[];
+	} | null>(normalizeMapKey);
 
 	constructor(verbose = false, options: TestRunnerClientOptions = {}) {
 		this.log = verbose ? createSubsystemLogger("test-runner") : () => {};
 		this.statFailedTarget =
 			options.statFailedTarget ?? ((filePath) => void fs.statSync(filePath));
+	}
+
+	private getRunnerAvailability(
+		cwd: string,
+		runner: string,
+	): boolean | undefined {
+		return this.availableRunners.get(cwd)?.get(runner);
+	}
+
+	private setRunnerAvailability(
+		cwd: string,
+		runner: string,
+		available: boolean,
+	): void {
+		let byRunner = this.availableRunners.get(cwd);
+		if (!byRunner) {
+			byRunner = new Map();
+			this.availableRunners.set(cwd, byRunner);
+		}
+		byRunner.set(runner, available);
 	}
 
 	/**
@@ -369,9 +391,9 @@ export class TestRunnerClient {
 	): { runner: string; config: RunnerConfig } | null {
 		// Priority 1: Config files
 		for (const [name, config] of Object.entries(RUNNERS)) {
-			const cacheKey = `${cwd}:${name}:config`;
-			if (this.availableRunners.has(cacheKey)) {
-				if (this.availableRunners.get(cacheKey)) {
+			const cached = this.getRunnerAvailability(cwd, name);
+			if (cached !== undefined) {
+				if (cached) {
 					return { runner: name, config };
 				}
 				continue;
@@ -405,7 +427,7 @@ export class TestRunnerClient {
 				return fs.existsSync(path.join(cwd, cf));
 			});
 
-			this.availableRunners.set(cacheKey, found);
+			this.setRunnerAvailability(cwd, name, found);
 			if (found) {
 				this.log(`Detected runner via config: ${name}`);
 				return { runner: name, config };
@@ -423,17 +445,17 @@ export class TestRunnerClient {
 			// Check for vitest first (more specific than jest)
 			if (allDeps.vitest) {
 				this.log("Detected vitest in package.json");
-				this.availableRunners.set(`${cwd}:vitest:config`, true);
+				this.setRunnerAvailability(cwd, "vitest", true);
 				return { runner: "vitest", config: RUNNERS.vitest };
 			}
 			if (allDeps.jest) {
 				this.log("Detected jest in package.json");
-				this.availableRunners.set(`${cwd}:jest:config`, true);
+				this.setRunnerAvailability(cwd, "jest", true);
 				return { runner: "jest", config: RUNNERS.jest };
 			}
 			if (allDeps.pytest || allDeps["pytest-cov"]) {
 				this.log("Detected pytest in package.json (unusual)");
-				this.availableRunners.set(`${cwd}:pytest:config`, true);
+				this.setRunnerAvailability(cwd, "pytest", true);
 				return { runner: "pytest", config: RUNNERS.pytest };
 			}
 		} catch (err) {

--- a/tests/clients/test-runner-cache-roots.test.ts
+++ b/tests/clients/test-runner-cache-roots.test.ts
@@ -1,0 +1,80 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { TestRunnerClient } from "../../clients/test-runner-client.js";
+
+const tempRoots: string[] = [];
+
+function makeProject(): { root: string; alias: string } {
+	const parent = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-2048-"));
+	const root = path.join(parent, "project");
+	const alias = path.join(parent, "project-alias");
+	fs.mkdirSync(root);
+	try {
+		fs.symlinkSync(root, alias, "junction");
+	} catch {
+		fs.symlinkSync(root, alias, "dir");
+	}
+	tempRoots.push(parent);
+	return { root, alias };
+}
+
+function existingWindowsAlias(root: string): string | undefined {
+	const alias = root
+		.replace(/[A-Za-z]/g, (letter) =>
+			letter === letter.toLowerCase()
+				? letter.toUpperCase()
+				: letter.toLowerCase(),
+		)
+		.replace(/[\\/]/g, "\\");
+	return alias !== root && fs.existsSync(alias) ? alias : undefined;
+}
+
+afterEach(() => {
+	while (tempRoots.length > 0) {
+		const root = tempRoots.pop();
+		if (root) fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe("TestRunnerClient project-root caches (#2048)", () => {
+	it("shares availability and Vitest glob state across a real symlink", () => {
+		const { root, alias } = makeProject();
+		const client = new TestRunnerClient();
+
+		// Cache the negative verdict through one spelling, then change the
+		// project. A raw-root cache would probe the alias again and return true.
+		expect(client.detectRunner(alias)).toBeNull();
+		fs.writeFileSync(
+			path.join(root, "vitest.config.ts"),
+			"export default { test: { include: ['tests/**/*.test.ts'] } }\n",
+		);
+		expect(client.detectRunner(root)).toBeNull();
+
+		const firstGlobs = client.parseVitestTestGlobs(alias);
+		fs.writeFileSync(
+			path.join(root, "vitest.config.ts"),
+			"export default { test: { include: ['changed/**/*.test.ts'] } }\n",
+		);
+		expect(client.parseVitestTestGlobs(root)).toEqual(firstGlobs);
+	});
+
+	it("shares caches across a confirmed Windows separator and case alias", () => {
+		const { root } = makeProject();
+		const alias = existingWindowsAlias(root);
+		if (!alias) return;
+
+		const client = new TestRunnerClient();
+		expect(client.detectRunner(alias)).toBeNull();
+		fs.writeFileSync(path.join(root, "vitest.config.ts"), "export default {}\n");
+		expect(client.detectRunner(root)).toBeNull();
+
+		const firstGlobs = client.parseVitestTestGlobs(alias);
+		fs.writeFileSync(
+			path.join(root, "vitest.config.ts"),
+			"export default { test: { exclude: ['changed/**'] } }\n",
+		);
+		expect(client.parseVitestTestGlobs(root)).toEqual(firstGlobs);
+	});
+});

--- a/tests/clients/test-runner-cache-roots.test.ts
+++ b/tests/clients/test-runner-cache-roots.test.ts
@@ -60,10 +60,13 @@ describe("TestRunnerClient project-root caches (#2048)", () => {
 		expect(client.parseVitestTestGlobs(root)).toEqual(firstGlobs);
 	});
 
-	it("shares caches across a confirmed Windows separator and case alias", () => {
+	it("shares caches across a confirmed Windows separator and case alias", (ctx) => {
 		const { root } = makeProject();
 		const alias = existingWindowsAlias(root);
-		if (!alias) return;
+		if (!alias) {
+			ctx.skip();
+			return;
+		}
 
 		const client = new TestRunnerClient();
 		expect(client.detectRunner(alias)).toBeNull();


### PR DESCRIPTION
## What changed

`TestRunnerClient` now stores project roots in `PathKeyedMap` instances.
Project roots are explicitly canonicalized with guarded `realpathSync.native` on both POSIX and Windows, followed by `normalizeMapKey`.
Runner names stay in a nested plain map.
Availability and Vitest glob caches now use the same canonical root.

The tests use a real filesystem symlink.
They also test a Windows separator and case alias when the filesystem confirms it exists.
The changelog has one fragment.

## Why

Raw root strings allowed one project to keep separate cache entries for aliases.
A stale false verdict or stale Vitest glob result could depend on path spelling.

## Verification

Ran `npm run build` before the targeted tests.

Ran `npx vitest run tests/clients/test-runner-cache-roots.test.ts tests/clients/test-runner-client.test.ts`.
Result: 2 test files passed and 162 tests passed on Windows.

The original mutation proof reverted canonical cache keying, rebuilt, and made both cache-root tests fail as expected. Adversarial execution additionally proved the POSIX symlink cell red on PR head `12b6337` and the merged #2044 alias regression red on Windows before this fix round. Both are green after the fix.

I skipped the full test suite. CI owns the normal full matrix, including Linux symlink behavior.

## Observability

This fix adds no per-edit logging.
The issue identifies an observability gap for cache-key convergence.
The real-filesystem regression tests provide the acceptance proof.

## Fix round 1

- F1: added a guarded `fs.realpathSync.native` project-root canonicalizer on both platforms without changing `path-utils.ts` semantics. Both project-root caches consume that canonical key.
- F2: availability entries now retain the exact config or `package.json` evidence for cached positive verdicts. A missing evidence file discards that member and resumes the existing ordered probes, so deleting `go.mod` permits Cargo detection through an alias while cached negative verdicts still converge.
- F3: `detectRunner` and `parseVitestTestGlobs` canonicalize once at entry and reuse the key. A 2,000-iteration Windows measurement over seven samples measured a median cached positive `detectRunner` call of **197 ?s** (samples: 250.6, 202.8, 191.4, 196.9, 182.9, 183.5, 240.6 ?s), down from the reviewed PR-head measurement of 1,628 ?s and below the 594 ?s pre-PR reference.
- F4: every #2048 acceptance criterion is now met. The PR continues to say `refs #2048`; the merger can decide whether to close it.
- F5: the unavailable Windows alias cell now calls Vitest's `ctx.skip()`, so non-Windows CI reports a skip instead of a vacuous pass.

### Red/green evidence

Pre-fix red evidence is the original raw-key mutation (both #2048 cells failed), the Linux CI symlink failure at line 53 on `12b6337`, and the Windows #2044 regression at `test-runner-client.test.ts:1136`. After the fix, the targeted Windows run is green: 2 files, 162 tests. Build completed before the run.

### Class sweep

Population: pattern-grep of raw path-keyed `Map`/`Set` caches and cwd/root/path lookup sites across `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts`, followed by a per-hit boundary check. Representative raw hits outside this class either normalize/resolve at both boundaries (`index.ts` LSP-config cwd set, `mcp/server.ts` ready-cwd set, formatter and language-profile caches), deliberately distinguish package cwd (`BiomeClient.localBinaryByCwd`), key non-path identities, or are request-local grouping maps. No sibling requiring this PR's project-identity change was found.

Every cache member in `TestRunnerClient` was reviewed:

- `availableRunners`: project-root keyed; fixed with one explicit canonical key per call, nested runner identity, and positive evidence invalidation.
- `vitestTestGlobsCache`: project-root keyed; fixed with the same one-per-call canonical key. Existing sticky parsed/null semantics are unchanged.
- `failedTestsByRunner`: outer map is runner-name keyed, not path keyed. Its project-root and failed-target inner maps already use `canonicalFailedPath`, so no change.

### Blast radius

Direct external caller: `clients/runtime-session.ts` calls `detectRunner`. Internal test-runner flows call `detectRunner` from target selection and execution, and call `parseVitestTestGlobs` from Vitest test-file discovery. Alias spellings now share negative availability and parsed-glob state on Linux and Windows. Cached positive availability is the only freshness behavior change: if its supporting config/package file disappears, that runner member is re-probed in the existing order. The cached positive hot path pays one guarded realpath plus one evidence-existence check per call, measured at 197 ?s median on Windows.




## Fix round 2

- Hoisted the canonical-root availability lookup out of the 12-runner loop, used plain nested `Map` lookups, collapsed the Vitest glob cache `has`+`get` pair to one `get`, and switched both project-root caches to the cheap `normalizeEphemeralMapKey` normalizer. `canonicalProjectRoot` remains the sole realpath seam.
- Like-for-like benchmark: 7 samples ? 2,000 warm `detectRunner` calls, with `npm run build` between file checkouts.

| Shape | master-first: master | master-first: new head | PR-first: master | PR-first: new head |
| --- | ---: | ---: | ---: | ---: |
| Positive cache hit (`vitest.config.ts`) | 1.47 ?s | 0.73 ?s | 2.52 ?s | 0.55 ?s |
| All-negative (empty project) | 1,417.93 ?s | 2,065.21 ?s | 3,466.98 ?s | 2,142.76 ?s |

The round-1 197 ?s claim compared mismatched shapes and is superseded by this like-for-like measurement. Round 2 leaves nothing remaining for close except CI green on Linux.


### Final benchmark correction

After the final duplicate-realpath removal in `canonicalProjectRoot`, the corrected new-head rerun measured medians of 565.72 ?s for the positive shape and 4,379.66 ?s for the all-negative shape on this Windows host. The earlier table above was captured before that final correction and is superseded; the implementation and targeted tests are the authoritative result.
## Fix round 3

- Added a bounded (512-entry, evict-oldest) plain `Map` on each `TestRunnerClient`, keyed by the exact cwd spelling and storing its canonical project-root key. Each distinct spelling pays `realpathSync.native` once per client instance; repeated calls are string-map hits.
- Semantics: the spelling-to-canonical mapping is instance-lifetime. If a symlink is retargeted mid-session, its old resolution remains until a new client instance. This is acceptable because round 2's verdict-level staleness protection re-validates positive verdict evidence by re-statting the config file; the memo only avoids repeated root canonicalization.
- The memo lives on the instance, dies with it, and is bounded so pathological spelling churn cannot grow it without limit. Alias convergence remains covered by the real-filesystem tests.

Like-for-like benchmark: 7 samples Ã— 2,000 warm `detectRunner` calls per shape, with `npm run build` before every benchmark run and between file swaps. Values are median microseconds per call.

| Shape | master-first: master | master-first: head | PR-first: master | PR-first: head |
| --- | ---: | ---: | ---: | ---: |
| Warm positive (`vitest.config.ts`) | 1.16 Âµs | 23.00 Âµs | 1.45 Âµs | 30.75 Âµs |
| All-negative (empty project) | 900.96 Âµs | 886.63 Âµs | 1,159.45 Âµs | 1,034.16 Âµs |

The positive head result is materially below round 2's 565.72 Âµs; this Windows host's 20â€“31 Âµs result is dominated by the existing positive evidence check. The all-negative shape is dominated by the existing ordered filesystem probes and is effectively unchanged.

Suite-lock report: checked the machine-wide lock path `%USERPROFILE%\\.pi-lens\\test-suite.lock` from the #1112 mechanism. No lock file existed, so there was no stale holder to clean and no process was killed. The normal pre-push hook will be used for this round.
