### PR TITLE
perf: memoize ignore compilation #1976

### DIFF
--- a/.changelog/perf-1976-memoize-ignore-compile.md
+++ b/.changelog/perf-1976-memoize-ignore-compile.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Memoize compiled gitignore globs (closes #1976)** — Reuse compiled ignore patterns for each matcher instance, reducing the measured compile count from 500 to ≤6.

--- a/clients/deps/minimatch.ts
+++ b/clients/deps/minimatch.ts
@@ -1,5 +1,5 @@
 /**
  * Centralized accessor for `minimatch`. See ./typescript.ts for the rationale.
  */
-export { minimatch } from "minimatch";
+export { minimatch, Minimatch } from "minimatch";
 export type { MinimatchOptions } from "minimatch";

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -405,6 +405,11 @@ function buildProjectIgnoreMatcher(
 	// function), and — critically — it's only ever paid for paths a pattern
 	// already flagged as ignored, so it doesn't reintroduce the per-file cost
 	// this memo exists to avoid for the common (not-ignored) case.
+	const patternMemo = new Map<
+		string,
+		{ ignored: boolean; layer: GitignorePatternLayer | undefined }
+	>();
+
 	// Compile expanded gitignore globs once per matcher instance. Relative-path
 	// resolution remains outside this cache, so nested ignore scopes cannot leak
 	// verdicts between sibling trees. The instance lifetime bounds this map.
@@ -421,11 +426,6 @@ function buildProjectIgnoreMatcher(
 		}
 		return compiled.match(value);
 	};
-
-	const patternMemo = new Map<
-		string,
-		{ ignored: boolean; layer: GitignorePatternLayer | undefined }
-	>();
 
 	// #703 perf follow-up: `normalizeEphemeralMapKey` (cheap slash-fold +
 	// Windows-lowercase, zero fs I/O), NOT `normalizeMapKey` (realpath-backed).

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -5,7 +5,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { minimatch } from "./deps/minimatch.js";
+import { Minimatch, type MinimatchOptions } from "./deps/minimatch.js";
 import {
 	isInSpawnTimeoutCooldown,
 	noteSpawnTimeout,
@@ -283,18 +283,18 @@ function matchesGitignorePattern(
 	pattern: GitignorePattern,
 	relativePath: string,
 	isDirectory: boolean,
+	matchExpanded: (value: string, expanded: string) => boolean,
 ): boolean {
 	const candidate = stripLeadingSlashes(normalizeIgnorePath(relativePath));
 	if (!candidate) return false;
 	const candidates = isDirectory ? [candidate, `${candidate}/`] : [candidate];
-	const options = { dot: true, nocase: process.platform === "win32" };
 	return expandGitignorePattern(pattern).some((expanded) => {
 		if (isDirectory && expanded.endsWith("/**")) {
 			const prefix = expanded.slice(0, -3);
 			if (candidate === prefix || candidate.startsWith(`${prefix}/`))
 				return true;
 		}
-		return candidates.some((value) => minimatch(value, expanded, options));
+		return candidates.some((value) => matchExpanded(value, expanded));
 	});
 }
 
@@ -405,6 +405,23 @@ function buildProjectIgnoreMatcher(
 	// function), and — critically — it's only ever paid for paths a pattern
 	// already flagged as ignored, so it doesn't reintroduce the per-file cost
 	// this memo exists to avoid for the common (not-ignored) case.
+	// Compile expanded gitignore globs once per matcher instance. Relative-path
+	// resolution remains outside this cache, so nested ignore scopes cannot leak
+	// verdicts between sibling trees. The instance lifetime bounds this map.
+	const gitignoreGlobOptions: MinimatchOptions = {
+		dot: true,
+		nocase: process.platform === "win32",
+	};
+	const compiledGlobs = new Map<string, Minimatch>();
+	const matchExpanded = (value: string, expanded: string): boolean => {
+		let compiled = compiledGlobs.get(expanded);
+		if (compiled === undefined) {
+			compiled = new Minimatch(expanded, gitignoreGlobOptions);
+			compiledGlobs.set(expanded, compiled);
+		}
+		return compiled.match(value);
+	};
+
 	const patternMemo = new Map<
 		string,
 		{ ignored: boolean; layer: GitignorePatternLayer | undefined }
@@ -466,7 +483,14 @@ function buildProjectIgnoreMatcher(
 						const relative = path.relative(dir, resolved);
 						const normalized = normalizeIgnorePath(relative);
 						for (const pattern of dirPatterns) {
-							if (!matchesGitignorePattern(pattern, normalized, isDirectory))
+							if (
+								!matchesGitignorePattern(
+									pattern,
+									normalized,
+									isDirectory,
+									matchExpanded,
+								)
+							)
 								continue;
 							ignored = !pattern.negated;
 							layer = pattern.layer;

--- a/tests/clients/ignore-compile-memo.test.ts
+++ b/tests/clients/ignore-compile-memo.test.ts
@@ -1,0 +1,258 @@
+/**
+ * #1976: the project ignore matcher must compile each gitignore glob once
+ * per (pattern, flags) per matcher instance. The pre-fix code called the
+ * plain `minimatch()` helper per (file × ancestor dir × pattern ×
+ * candidate) — a fresh `Minimatch` construction (full glob parse plus
+ * regex compile) on every call. In a walk over unique paths the per-path
+ * verdict memo never hits, so #1974's profiling measured ~60% of a
+ * 45,378-file warmup walk's CPU inside minimatch compilation alone.
+ *
+ * The correctness trap the issue states up front: gitignore patterns are
+ * directory-relative. A nested .gitignore scopes its patterns to its
+ * subtree, so a cache that stored per-PATTERN VERDICTS would leak a
+ * subtree's answers to sibling trees. These tests pin that the memo holds
+ * only compiled matchers (context-free — the subject path is resolved
+ * relative to each pattern's owning directory by the caller, never
+ * cached), so identical pattern text in two subtrees shares one compiled
+ * glob while keeping independent verdicts.
+ *
+ * Counts are asserted on Minimatch.prototype.make invocations (one per
+ * real compilation), never wall time (#1920).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+// Direct package import: resolves to the SAME module instance
+// clients/deps/minimatch.js re-exports, so a prototype spy counts every
+// construction the matcher performs. Deliberately not the deps accessor —
+// the pre-fix tree (#1976 red run) does not re-export the class yet, and a
+// red proof must fail on the bug, not on a missing import.
+import { Minimatch } from "minimatch";
+import {
+	createProjectIgnoreMatcher,
+	getProjectIgnoreMatcher,
+} from "../../clients/file-utils.js";
+import { collectSourceFilesForWarmup } from "../../clients/language-profile.js";
+import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+
+/** Counts real minimatch compilations: `make()` runs once per `new
+ * Minimatch(...)`, which is exactly the work #1976 memoizes. Spying the
+ * prototype of the shared package instance counts every construction in
+ * the process, so each test only runs its own walks inside the window. */
+function compileCounter() {
+	const spy = vi.spyOn(Minimatch.prototype, "make");
+	return {
+		get count(): number {
+			return spy.mock.calls.length;
+		},
+	};
+}
+
+// A failed assertion must not leak an installed spy into the next test
+// (observed in the pre-fix red run: a failing test's count carried over
+// and redened an unrelated sibling for the wrong reason).
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("#1976 compiled-glob memo", () => {
+	it("compiles each expanded pattern once per matcher instance across a walk over unique paths", () => {
+		const env = setupTestEnvironment("pi-lens-1976-compile-");
+		try {
+			fs.writeFileSync(path.join(env.tmpDir, ".gitignore"), "*.log\ntemp/\n");
+			for (let i = 0; i < 60; i++) {
+				createTempFile(env.tmpDir, `f${i}.log`, "");
+			}
+			for (let i = 0; i < 20; i++) {
+				createTempFile(env.tmpDir, `temp/f${i}.ts`, "");
+			}
+			for (let i = 0; i < 20; i++) {
+				createTempFile(env.tmpDir, `s${i}.ts`, "");
+			}
+			const matcher = createProjectIgnoreMatcher(env.tmpDir);
+			const counter = compileCounter();
+			// 100 unique paths — the per-path verdict memo never hits, exactly
+			// like a first walk over the tree.
+			for (let i = 0; i < 60; i++) {
+				matcher.isIgnored(path.join(env.tmpDir, `f${i}.log`));
+			}
+			for (let i = 0; i < 20; i++) {
+				matcher.isIgnored(path.join(env.tmpDir, `temp`, `f${i}.ts`));
+			}
+			for (let i = 0; i < 20; i++) {
+				matcher.isIgnored(path.join(env.tmpDir, `s${i}.ts`));
+			}
+			// `*.log` expands to [*.log, **/*.log]; `temp/` (directory-only,
+			// no slash, not rooted) expands to
+			// [temp, temp/**, **/temp, **/temp/**] — 6 distinct compiled globs
+			// total. Pre-fix this is 100 files × 6 = 600 compilations.
+			expect(counter.count).toBeGreaterThanOrEqual(1);
+			expect(counter.count).toBeLessThanOrEqual(6);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("repeated isIgnored calls on the same path add zero compilations", () => {
+		const env = setupTestEnvironment("pi-lens-1976-repeat-");
+		try {
+			fs.writeFileSync(path.join(env.tmpDir, ".gitignore"), "*.log\n");
+			createTempFile(env.tmpDir, "a.log", "");
+			const matcher = createProjectIgnoreMatcher(env.tmpDir);
+			const counter = compileCounter();
+			expect(matcher.isIgnored(path.join(env.tmpDir, "a.log"))).toBe(true);
+			const firstPass = counter.count;
+			for (let i = 0; i < 25; i++) {
+				expect(matcher.isIgnored(path.join(env.tmpDir, "a.log"))).toBe(true);
+			}
+			expect(counter.count).toBe(firstPass);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("a nested .gitignore pattern does not leak to sibling subtrees through the memo (the #1976 trap)", () => {
+		const env = setupTestEnvironment("pi-lens-1976-leak-");
+		try {
+			fs.writeFileSync(path.join(env.tmpDir, ".gitignore"), "*.log\n");
+			const sub1 = path.join(env.tmpDir, "sub1");
+			const sub2 = path.join(env.tmpDir, "sub2");
+			fs.mkdirSync(sub1);
+			fs.mkdirSync(sub2);
+			fs.writeFileSync(path.join(sub1, ".gitignore"), "profiles/\n*.snap\n");
+
+			const matcher = createProjectIgnoreMatcher(env.tmpDir);
+			// Poisoning order: warm sub1 first. A verdict cache keyed by
+			// pattern text alone would return sub1's answers for every query
+			// below.
+			expect(matcher.isIgnored(path.join(sub1, "a.snap"))).toBe(true);
+			expect(matcher.isIgnored(path.join(sub1, "profiles"), true)).toBe(true);
+			expect(matcher.isIgnored(path.join(sub1, "profiles", "x.ts"))).toBe(
+				true,
+			);
+			// Sibling subtree: sub1's patterns must NOT apply there.
+			expect(matcher.isIgnored(path.join(sub2, "a.snap"))).toBe(false);
+			expect(matcher.isIgnored(path.join(sub2, "profiles"), true)).toBe(
+				false,
+			);
+			expect(matcher.isIgnored(path.join(sub2, "profiles", "x.ts"))).toBe(
+				false,
+			);
+			// Outside both subtrees.
+			expect(matcher.isIgnored(path.join(env.tmpDir, "a.snap"))).toBe(false);
+			// The root pattern still applies inside the sibling subtree.
+			expect(matcher.isIgnored(path.join(sub2, "b.log"))).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("two subtrees sharing a pattern text keep independent verdicts (negation in one subtree only)", () => {
+		const env = setupTestEnvironment("pi-lens-1976-shared-");
+		try {
+			const sub1 = path.join(env.tmpDir, "sub1");
+			const sub2 = path.join(env.tmpDir, "sub2");
+			fs.mkdirSync(sub1);
+			fs.mkdirSync(sub2);
+			fs.writeFileSync(path.join(sub1, ".gitignore"), "*.gen.ts\n");
+			fs.writeFileSync(path.join(sub2, ".gitignore"), "*.gen.ts\n!keep.gen.ts\n");
+
+			// sub1 first: the compiled `*.gen.ts` / `**/*.gen.ts` globs are
+			// now warm and shared across subtrees — the VERDICT must not be.
+			const matcherA = createProjectIgnoreMatcher(env.tmpDir);
+			expect(matcherA.isIgnored(path.join(sub1, "keep.gen.ts"))).toBe(true);
+			expect(matcherA.isIgnored(path.join(sub2, "keep.gen.ts"))).toBe(false);
+			expect(matcherA.isIgnored(path.join(sub2, "drop.gen.ts"))).toBe(true);
+
+			// Reverse order on a fresh matcher: same answers.
+			const matcherB = createProjectIgnoreMatcher(env.tmpDir);
+			expect(matcherB.isIgnored(path.join(sub2, "keep.gen.ts"))).toBe(false);
+			expect(matcherB.isIgnored(path.join(sub1, "keep.gen.ts"))).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("the compile cache is per matcher instance, not process-lifetime (catalog shape 17)", () => {
+		const envA = setupTestEnvironment("pi-lens-1976-inst-a-");
+		const envB = setupTestEnvironment("pi-lens-1976-inst-b-");
+		try {
+			fs.writeFileSync(path.join(envA.tmpDir, ".gitignore"), "*.log\n");
+			fs.writeFileSync(path.join(envB.tmpDir, ".gitignore"), "*.log\n");
+			const a = createProjectIgnoreMatcher(envA.tmpDir);
+			const b = createProjectIgnoreMatcher(envB.tmpDir);
+			const counter = compileCounter();
+			// A NON-matching file exercises every expansion: `*.log` expands
+			// to exactly [*.log, **/*.log] (a matching file short-circuits
+			// after the first).
+			a.isIgnored(path.join(envA.tmpDir, "x.ts"));
+			expect(counter.count).toBe(2);
+			// A second matcher instance must compile its own: a module-level
+			// cache shared across instances would keep the count at 2.
+			b.isIgnored(path.join(envB.tmpDir, "x.ts"));
+			expect(counter.count).toBe(4);
+			// And within one instance the count stays flat no matter how many
+			// unique paths are checked.
+			for (let i = 0; i < 30; i++) {
+				a.isIgnored(path.join(envA.tmpDir, `f${i}.ts`));
+			}
+			expect(counter.count).toBe(4);
+		} finally {
+			envA.cleanup();
+			envB.cleanup();
+		}
+	});
+
+	it("rebuilding the matcher (root .gitignore change) drops the compile cache with the instance", () => {
+		const env = setupTestEnvironment("pi-lens-1976-inval-");
+		try {
+			fs.writeFileSync(path.join(env.tmpDir, ".gitignore"), "*.log\n");
+			const first = getProjectIgnoreMatcher(env.tmpDir);
+			const counter = compileCounter();
+			// Non-matching file: compiles both expansions of `*.log`.
+			first.isIgnored(path.join(env.tmpDir, "x.ts"));
+			expect(counter.count).toBe(2);
+			// Different content (size+mtime signature, #1105) rebuilds the
+			// matcher; the old instance's compile cache dies with it.
+			fs.writeFileSync(path.join(env.tmpDir, ".gitignore"), "*.log\n*.tmp\n");
+			const second = getProjectIgnoreMatcher(env.tmpDir);
+			expect(second).not.toBe(first);
+			second.isIgnored(path.join(env.tmpDir, "x.ts"));
+			expect(counter.count).toBeGreaterThan(2);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	// The measured acceptance criterion, in #1974's fixture shape with its
+	// order swap already in place: source-extension files ignored only by a
+	// FILE-LEVEL pattern, so the extension gate stays open and every file
+	// still consults isIgnored — the residue #1974's swap cannot remove and
+	// this memo exists to make cheap. Counts, never wall time (#1920).
+	it("warmup walk over a file-level-ignored source pile compiles O(patterns), not O(files)", async () => {
+		const env = setupTestEnvironment("pi-lens-1976-walk-");
+		try {
+			const PILE = 200;
+			for (let i = 0; i < PILE; i++) {
+				createTempFile(env.tmpDir, `wal/gen${i}.gen.ts`, "");
+			}
+			createTempFile(env.tmpDir, "src/a.ts", "export const a = 1;\n");
+			fs.writeFileSync(path.join(env.tmpDir, ".gitignore"), "*.gen.ts\n");
+
+			const counter = compileCounter();
+			const files = await collectSourceFilesForWarmup(env.tmpDir);
+			const compiles = counter.count;
+
+			expect(
+				files.some((f) => f.replace(/\\/g, "/").endsWith("/src/a.ts")),
+			).toBe(true);
+			expect(files.some((f) => f.endsWith(".gen.ts"))).toBe(false);
+			// `*.gen.ts` expands to two globs; the walk's directory queries
+			// reuse them. Pre-fix: 200 files × 2 expansions = 400+ compilations.
+			expect(compiles).toBeLessThanOrEqual(8);
+		} finally {
+			env.cleanup();
+		}
+	});
+});

--- a/tests/clients/ignore-compile-memo.test.ts
+++ b/tests/clients/ignore-compile-memo.test.ts
@@ -128,14 +128,10 @@ describe("#1976 compiled-glob memo", () => {
 			// below.
 			expect(matcher.isIgnored(path.join(sub1, "a.snap"))).toBe(true);
 			expect(matcher.isIgnored(path.join(sub1, "profiles"), true)).toBe(true);
-			expect(matcher.isIgnored(path.join(sub1, "profiles", "x.ts"))).toBe(
-				true,
-			);
+			expect(matcher.isIgnored(path.join(sub1, "profiles", "x.ts"))).toBe(true);
 			// Sibling subtree: sub1's patterns must NOT apply there.
 			expect(matcher.isIgnored(path.join(sub2, "a.snap"))).toBe(false);
-			expect(matcher.isIgnored(path.join(sub2, "profiles"), true)).toBe(
-				false,
-			);
+			expect(matcher.isIgnored(path.join(sub2, "profiles"), true)).toBe(false);
 			expect(matcher.isIgnored(path.join(sub2, "profiles", "x.ts"))).toBe(
 				false,
 			);
@@ -156,7 +152,10 @@ describe("#1976 compiled-glob memo", () => {
 			fs.mkdirSync(sub1);
 			fs.mkdirSync(sub2);
 			fs.writeFileSync(path.join(sub1, ".gitignore"), "*.gen.ts\n");
-			fs.writeFileSync(path.join(sub2, ".gitignore"), "*.gen.ts\n!keep.gen.ts\n");
+			fs.writeFileSync(
+				path.join(sub2, ".gitignore"),
+				"*.gen.ts\n!keep.gen.ts\n",
+			);
 
 			// sub1 first: the compiled `*.gen.ts` / `**/*.gen.ts` globs are
 			// now warm and shared across subtrees — the VERDICT must not be.


### PR DESCRIPTION
## what changed
- Exported `Minimatch` through the centralized dependency seam.
- Added a matcher-instance compiled-glob memo in `clients/file-utils.ts`, keyed by expanded pattern text with the shared `dot`/platform `nocase` flags. Relative paths remain computed per owning ignore directory, so nested scopes do not share verdicts.
- Kept the existing per-path memo because dispatch/integration, project-ignore helper, and repeated per-event/snapshot callers benefit from cached `{ignored, layer}` verdicts; it is complementary to the new unique-path compilation memo.
- Added compile-count regression coverage, matcher-lifetime coverage, nested sibling leakage coverage, and warmup-walk coverage.

## why
#1976 found that `minimatch()` rebuilt a parser/regex for every file ? ancestor ? pattern check, while walks mostly visit unique paths. The repeating axis is the compiled pattern. The compiled matcher is context-free after the caller supplies the directory-relative subject, while verdicts remain path-scoped. Both maps live inside one matcher instance and are discarded when the matcher is rebuilt, satisfying catalog shape 17.

## verification
- `npm run build` ? passed.
- `npm exec vitest run tests/clients/ignore-compile-memo.test.ts tests/clients/global-ignore.test.ts tests/clients/project-lens-ignore.test.ts tests/clients/source-filter-gitignore.test.ts tests/clients/tracked-aware-ignore-matcher.test.ts tests/monorepo/nested-ignore-config.test.ts tests/clients/ext-gate-before-ignore.test.ts` ? 7 files, 63 tests passed.
- `npm exec vitest run tests/clients/startup-scan-entry-budget.test.ts` ? 10 tests passed.
- Commit hooks passed lockfile check, changelog check, and TypeScript lint. Pre-push build passed; its changed-file selector deferred the broad 41-file set to CI. Full suite skipped locally; CI-deferred.
- Fresh red-first proof was run after saving `fix.patch`, checking out both source files, rebuilding, and running the new test. Quoted red output: `Tests 7 | 3 failed`; `expected 500 to be less than or equal to 6`, `expected 64 to be 4`, and `expected 410 to be less than or equal to 8`. After applying the saved diff, the same test passed: `Tests 7 | 7 passed`.

## FIX ROUND
CodeQL raised `js/regex-injection` on the `Minimatch` constructor at `clients/file-utils.ts:422`. The analysis is a modeling artifact: identical pattern text already reached minimatch pre-fix via the function call, the data flow is unchanged, and a differential probe made 2320 comparisons with 0 divergences. This records the dismissal rationale on the PR without dismissing the alert.

## CLASS SWEEP
Pattern sweep across `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts` found the changed gitignore matcher as the only per-file compilation defect in scope. Remaining direct `minimatch` calls are separate pattern domains: ast-grep/tree-sitter rule filters, lens-engine/test-runner/path filters, LSP client filter globs, and log-analysis globs; their inputs/options and lifetimes differ, so they are unaffected by this gitignore fix. No `mcp/` or `index.ts` invariant-input matcher recompilation site was found.

Population sweep of the fourteen isIgnored call-site families:

- `language-profile.ts:375`, `jscpd-client.ts:169`, `source-filter.ts:681`, `startup-scan.ts:274`: unique-path source/warmup walks ? benefit directly from compiled-glob reuse.
- `pipeline.ts:151,158`, `source-walker.ts:125`, `review-graph/workspace-modules.ts:144,572,583`, `tree-sitter-client.ts:4513,4516`, and `tools/lsp-diagnostics.ts:376,379`: directory/file walk members ? benefit directly; each keeps its own directory-relative verdict semantics.
- `clients/lsp/index.ts:1071,1081`: workspace diagnostic directory/file sweep ? benefit directly; extension/server gating remains unchanged.
- `clients/dispatch/integration.ts:797`, `clients/project-scan-policy.ts:43`, `tools/lens-diagnostics.ts:959`, and `clients/file-utils.ts:659` (`isPathIgnoredByProject`): repeated per-event/display/helper checks - benefit from both compiled globs and the retained per-path verdict memo.
- The `tools/lsp-diagnostics.ts:334` predicate adapter is a forwarding member and is unaffected beyond the matcher it invokes. No caller needs a new invalidation or ownership mechanism.

## BLAST RADIUS
Changed paths are limited to the minimatch accessor and `buildProjectIgnoreMatcher`; all callers retain the `isIgnored(filePath, isDirectory)` contract. The new map is matcher-instance-owned, bounded by distinct expanded patterns (including directory expansions), and dies with matcher invalidation. The old per-path memo remains bounded by the same matcher lifetime and is justified for repeated paths and its retained `layer` data.

Compile-count evidence uses `Minimatch.prototype.make`, not wall time: pre-fix counts were 500 (100-file mixed walk), 64 (two matcher instances plus repeated paths), and 410 (200-file warmup walk). Post-fix assertions are <=6, exactly 4 for the two-instance lifetime test, and <=8 respectively; the observed warmup count is 2. Repeated calls add zero compilations, nested subtree patterns do not leak to siblings, and a rebuilt matcher recompiles independently.

## OBSERVABILITY
The field record for the performance effect remains the warmup and scan phase durations in `sessionstart.log` and `latency.log`, as required by #1976/#1974. This change adds deterministic compile-count evidence so wall-clock variance is not used as the correctness/performance gate.

Initial implementation by an opencode glm-5.3 worker; salvaged, verified, and completed by a codex worker.

