### PR TITLE
fix(format): add hit-rate outcome to formatter_selected (#1940)

### DIFF
--- a/.changelog/fix-1940-formatter-selected-hit-rate.md
+++ b/.changelog/fix-1940-formatter-selected-hit-rate.md
@@ -1,0 +1,5 @@
+﻿---
+section: Fixed
+---
+
+- **Record formatter cache hits (closes #1940)** — Emit `formatter_selected` with `outcome: "hit"`, `reason: "cache"`, and `cached: true` on formatter detection cache hits, providing hit-rate observability with a single denominator in `latency.log`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,9 @@ session guards must continue to skip both resets. Re-arm through
 `clearFormatterCache`, never the which-latch clear alone: `getFormattersForFile`
 answers a same-cwd lookup from `detectionCache` before it reaches a probe, so
 dropping the latches without the selection cache leaves the previous session's
-verdict standing in the working directory. (#1895)
+verdict standing in the working directory. Formatter selection emits
+`formatter_selected` with `outcome: "hit" | "miss"` on both cache hits and
+re-detections so hit rate is computable from `latency.log`. (#1895, #1940)
 
 Per-edit LSP dispatch preserves the touch's correlated `unconfirmedServerIds`
 through `RunnerResult` and runner latency assembly. The agent coverage notice

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -100,6 +100,16 @@ export async function tryLazyInstallFormatterTool(
 export const SKIP_FORMATTING = "skip-formatting" as const;
 export type ResolvedFormatterCommand = string[] | null | typeof SKIP_FORMATTING;
 
+/**
+ * #1940: what formatter selection actually did to answer one file.
+ *
+ * `formatter_selected` fired only on a detection-cache miss, so cache hit rate
+ * was invisible and a cache-churning regression had no baseline. Emitting on
+ * both hit and miss with an explicit `outcome` discriminator gives hit rate
+ * from one record family with one denominator (`hit / (hit + miss)`).
+ */
+export type FormatterSelectionOutcome = "hit" | "miss";
+
 export interface FormatterInfo {
 	name: string;
 	command: string[]; // Command with $FILE placeholder — used as fallback
@@ -1674,6 +1684,21 @@ export async function getFormattersForFile(
 
 	if (cached.entries.has(cacheKey)) {
 		const enabledNames = cached.entries.get(cacheKey);
+		const selectedFormatterName =
+			enabledNames && enabledNames.length > 0 ? enabledNames[0] : null;
+		logLatency({
+			type: "phase",
+			phase: "formatter_selected",
+			filePath: filePath,
+			durationMs: 0,
+			metadata: {
+				formatter: selectedFormatterName,
+				reason: "cache",
+				cached: true,
+				outcome: "hit" satisfies FormatterSelectionOutcome,
+				cwd,
+			},
+		});
 		if (!enabledNames || enabledNames.length === 0) return [];
 		// Return cached formatters by name (preserves priority order)
 		return ALL_FORMATTERS.filter((f) => enabledNames.includes(f.name));
@@ -1833,6 +1858,7 @@ export async function getFormattersForFile(
 		metadata: {
 			formatter: selected?.name ?? null,
 			reason: selectionReason,
+			outcome: "miss" satisfies FormatterSelectionOutcome,
 			cwd,
 			...(provisional && {
 				cached: false,

--- a/tests/clients/formatter-degraded-selection.test.ts
+++ b/tests/clients/formatter-degraded-selection.test.ts
@@ -261,10 +261,16 @@ describe("the poison guard sees every binary a detect probed (#1539)", () => {
 		expect(selections()[0]?.metadata?.cached).toBeUndefined();
 		expect(selections()[0]?.metadata?.stalledProbes).toBeUndefined();
 
-		// And it is genuinely cached: a second pass is served from the cache, so it
-		// logs no new selection at all.
+		// And it is genuinely cached: a second pass is served from the cache, so
+		// it logs a cache-hit selection record (#1940).
 		expect(await names(dirB, bareFile)).toEqual([]);
-		expect(selections()).toHaveLength(1);
+		expect(selections()).toHaveLength(2);
+		expect(selections()[1]?.metadata).toMatchObject({
+			formatter: null,
+			reason: "cache",
+			cached: true,
+			outcome: "hit",
+		});
 	});
 });
 

--- a/tests/clients/formatter-selection-outcome.test.ts
+++ b/tests/clients/formatter-selection-outcome.test.ts
@@ -1,0 +1,173 @@
+﻿// #1940: `formatter_selected` fired only on a detection-cache miss, so cache hit
+// rate was invisible and a cache-churning regression had no baseline.
+// These tests pin the outcome discriminator ("hit" vs "miss") and cache-hit
+// record emission in `getFormattersForFile`.
+//
+// MUTATION PROOFS:
+//   - delete `outcome` from either `formatter_selected` metadata block and
+//     the reachable outcome tests red;
+//   - delete the `formatter_selected` log in the cache-hit branch and the hit
+//     test reds;
+//   - set `outcome: "miss"` on cache hit and the hit test reds;
+//   - set `outcome: "hit"` on miss and the cold miss test reds.
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { safeSpawnAsync, logLatencySpy } = vi.hoisted(() => ({
+	safeSpawnAsync: vi.fn(),
+	logLatencySpy: vi.fn(),
+}));
+
+vi.mock("../../clients/safe-spawn.js", () => ({
+	safeSpawnAsync,
+	safeSpawn: vi.fn(),
+	getAmbientAbortSignal: () => undefined,
+	isCommandAvailableAsync: async () => false,
+}));
+vi.mock("../../clients/latency-logger.js", () => ({
+	logLatency: logLatencySpy,
+	getLastLoggedPhase: () => undefined,
+}));
+
+import {
+	clearFormatterCache,
+	getFormattersForFile,
+} from "../../clients/formatters.js";
+
+const notFoundResult = { stdout: "", stderr: "", status: 1 };
+const foundResult = (binary: string) => ({
+	stdout: `/usr/bin/${binary}\n`,
+	stderr: "",
+	status: 0,
+});
+
+const finder = () => (process.platform === "win32" ? "where" : "which");
+
+function pathLookups(verdicts: Record<string, "found" | "missing">) {
+	return async (cmd: string, args: string[]) => {
+		if (cmd !== finder()) return notFoundResult;
+		const command = args[0] ?? "";
+		const verdict = verdicts[command] ?? "missing";
+		if (verdict === "found") return foundResult(command);
+		return notFoundResult;
+	};
+}
+
+const selections = () =>
+	logLatencySpy.mock.calls
+		.map((call) => call[0])
+		.filter((entry) => entry?.phase === "formatter_selected");
+
+function rubyProject(): { cwd: string; filePath: string } {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-outcome-rb-"));
+	fs.writeFileSync(
+		path.join(cwd, ".rubocop.yml"),
+		"AllCops:\n  NewCops: enable\n",
+	);
+	fs.writeFileSync(path.join(cwd, "Gemfile"), "gem 'rubocop'\n");
+	const filePath = path.join(cwd, "app.rb");
+	fs.writeFileSync(filePath, "puts 1\n");
+	return { cwd, filePath };
+}
+
+function emptyRubyProject(): { cwd: string; filePath: string } {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-outcome-bare-"));
+	const filePath = path.join(cwd, "bare.rb");
+	fs.writeFileSync(filePath, "puts 1\n");
+	return { cwd, filePath };
+}
+
+beforeEach(() => {
+	safeSpawnAsync.mockReset();
+	logLatencySpy.mockReset();
+	clearFormatterCache();
+});
+
+describe("formatter_selected outcome discriminator (#1940)", () => {
+	it("records outcome 'miss' on cold detection and 'hit' on cache hit", async () => {
+		const { cwd, filePath } = rubyProject();
+		safeSpawnAsync.mockImplementation(pathLookups({ rubocop: "found" }));
+
+		// Cold detection pass: misses cache, runs detection, logs outcome "miss"
+		const first = await getFormattersForFile(filePath, cwd);
+		expect(first.map((f) => f.name)).toEqual(["rubocop"]);
+		expect(selections()).toHaveLength(1);
+		expect(selections()[0]?.metadata).toMatchObject({
+			formatter: "rubocop",
+			reason: "detect",
+			outcome: "miss",
+			cwd,
+		});
+		expect(selections()[0]?.metadata?.cached).toBeUndefined();
+
+		// Second pass on same file: answers from cache, logs outcome "hit"
+		safeSpawnAsync.mockClear();
+		const second = await getFormattersForFile(filePath, cwd);
+		expect(second.map((f) => f.name)).toEqual(["rubocop"]);
+		expect(safeSpawnAsync).not.toHaveBeenCalled();
+		expect(selections()).toHaveLength(2);
+		expect(selections()[1]?.metadata).toMatchObject({
+			formatter: "rubocop",
+			reason: "cache",
+			outcome: "hit",
+			cached: true,
+			cwd,
+		});
+	});
+
+	it("records outcome 'miss' then 'hit' for empty (no formatter) selections", async () => {
+		const { cwd, filePath } = emptyRubyProject();
+		safeSpawnAsync.mockImplementation(pathLookups({ rubocop: "missing" }));
+
+		// Cold pass finding no formatter
+		const first = await getFormattersForFile(filePath, cwd);
+		expect(first).toEqual([]);
+		expect(selections()).toHaveLength(1);
+		expect(selections()[0]?.metadata).toMatchObject({
+			formatter: null,
+			reason: "none",
+			outcome: "miss",
+			cwd,
+		});
+		expect(selections()[0]?.metadata?.cached).toBeUndefined();
+
+		// Warm pass finding no formatter from cache
+		safeSpawnAsync.mockClear();
+		const second = await getFormattersForFile(filePath, cwd);
+		expect(second).toEqual([]);
+		expect(safeSpawnAsync).not.toHaveBeenCalled();
+		expect(selections()).toHaveLength(2);
+		expect(selections()[1]?.metadata).toMatchObject({
+			formatter: null,
+			reason: "cache",
+			outcome: "hit",
+			cached: true,
+			cwd,
+		});
+	});
+
+	it("allows calculating detection cache hit rate with a single denominator", async () => {
+		const { cwd, filePath } = rubyProject();
+		safeSpawnAsync.mockImplementation(pathLookups({ rubocop: "found" }));
+
+		// 1 miss + 3 hits
+		await getFormattersForFile(filePath, cwd);
+		await getFormattersForFile(filePath, cwd);
+		await getFormattersForFile(filePath, cwd);
+		await getFormattersForFile(filePath, cwd);
+
+		const allSelections = selections();
+		expect(allSelections).toHaveLength(4);
+
+		const hits = allSelections.filter((s) => s.metadata?.outcome === "hit");
+		const misses = allSelections.filter((s) => s.metadata?.outcome === "miss");
+		expect(hits).toHaveLength(3);
+		expect(misses).toHaveLength(1);
+
+		const hitRate = hits.length / allSelections.length;
+		expect(hitRate).toBe(0.75);
+	});
+});


### PR DESCRIPTION
﻿## What changed / why / verification

### What changed
- Exported `FormatterSelectionOutcome` (`"hit" | "miss"`) from `clients/formatters.ts`.
- Emitted `formatter_selected` on `detectionCache` hits with `outcome: "hit"`, `reason: "cache"`, and `cached: true`.
- Added `outcome: "miss"` to `formatter_selected` on detection misses while preserving existing `reason` and `cached` metadata semantics.
- Updated `tests/clients/formatter-degraded-selection.test.ts` to assert the cache-hit selection record on repeated passes.
- Added regression test suite `tests/clients/formatter-selection-outcome.test.ts` verifying hit, miss, and hit-rate calculation over a shared denominator.

### Why
- `formatter_selected` previously fired only on detection cache misses. Cache hits returned early without emitting a record.
- Cache hit rate and field distribution of formatters under cache reuse were completely invisible in `latency.log`.

### Verification
- Ran targeted test suites: `tests/clients/formatter-selection-outcome.test.ts`, `tests/clients/formatter-degraded-selection.test.ts`, `tests/clients/formatters-which-latch.test.ts`, `tests/clients/formatters.test.ts`, `tests/clients/format-service.test.ts`.
- Ran `npm run fmt:check`, `npm run changelog:check`, and `npm run astgrep:self-scan`.
- Skipped full suite per repository non-negotiables; CI must confirm full test suite.
- Quoted red-first output on pre-fix code:
```
 FAIL  |default| tests/clients/formatter-selection-outcome.test.ts > formatter_selected outcome discriminator (#1940) > records outcome 'miss' on cold detection and 'hit' on cache hit
AssertionError: expected { formatter: 'rubocop', …(2) } to match object { formatter: 'rubocop', …(3) }

- Expected
+ Received

  {
    "cwd": "C:\\Users\\apman\\AppData\\Local\\Temp\\pi-lens-outcome-rb-tvtm2Y",
    "formatter": "rubocop",
-   "outcome": "miss",
    "reason": "detect",
  }

 ❯ tests/clients/formatter-selection-outcome.test.ts:101:37

 FAIL  |default| tests/clients/formatter-selection-outcome.test.ts > formatter_selected outcome discriminator (#1940) > records outcome 'miss' then 'hit' for empty (no formatter) selections
AssertionError: expected { formatter: null, …(2) } to match object { formatter: null, …(3) }

- Expected
+ Received

  {
    "cwd": "C:\\Users\\apman\\AppData\\Local\\Temp\\pi-lens-outcome-bare-VkiDVr",
    "formatter": null,
-   "outcome": "miss",
    "reason": "none",
  }

 ❯ tests/clients/formatter-selection-outcome.test.ts:132:37

 FAIL  |default| tests/clients/formatter-selection-outcome.test.ts > formatter_selected outcome discriminator (#1940) > allows calculating detection cache hit rate with a single denominator
AssertionError: expected [ { type: 'phase', …(4) } ] to have a length of 4 but got 1

- Expected
+ Received

- 4
+ 1 

 ❯ tests/clients/formatter-selection-outcome.test.ts:166:25
```

## CLASS SWEEP

### Pattern sweep
- `lsp_client_selected` (`clients/lsp/index.ts:2348`, `clients/lsp/index.ts:2376`): has hit/miss visibility via `outcome: "warm-reuse" | "cold-spawn" | "spawn-failure"` (#1934).
- `linter_selected` (`clients/tool-policy.ts:1673`): stateless directory config evaluation on every call, no cache.
- `formatter_selected` (`clients/formatters.ts:1688`, `clients/formatters.ts:1855`): fixed in this PR (#1940).
- `knip` (`clients/runtime-turn.ts:1166`): emits `cacheHit: boolean`.
- `tree_sitter` (`clients/tree-sitter-logger.ts:95`): emits `cache_stats` with hit/miss counters.
- `word_index` (`clients/word-index.ts:1683`, `clients/word-index.ts:1787`): logs distinct cold build and resume events.

### Population sweep (cache lanes named by sibling issue #1936)
- Formatter detection memo (`clients/formatters.ts:1658-1854`): fixed in this PR (`file:line` `clients/formatters.ts:1688`, `clients/formatters.ts:1855`, closes #1940, refs #1936).
- Startup-scan context cache (`clients/startup-scan.ts:326`): out of scope, tracked in #1936.
- Project-snapshot parse cache (`clients/project-snapshot.ts:261`): out of scope, tracked in #1936.
- Dependency-checker memo (`clients/dependency-checker.ts:849-880`): out of scope, tracked in #1936.
- Reverse deps cache (`clients/reverse-deps.ts` / cascade): out of scope, tracked in #1936.

## BLAST RADIUS
- Callers of changed selection path: `FormatService.formatFile` (`clients/format-service.ts:97`) during formatting, and smoke tests (`scripts/smoke-tools.mjs`).
- Hot-path cost of new counting: zero per-call I/O beyond appending one NDJSON row via `logLatency` (`durationMs: 0`).
- Cache hits read in-memory Map entries and emit one phase record synchronously.
- Bound: exactly one `formatter_selected` phase record per `getFormattersForFile` invocation.

## OBSERVABILITY
- Exact record: `phase: "formatter_selected"` with `outcome: "hit" | "miss"`, `reason`, `cached`, `formatter`, and `cwd` in metadata.
- File: `latency.log`.
- Hit rate formula: `hit_rate = count(outcome == "hit") / count(phase == "formatter_selected")`.
