### PR TITLE
perf: intern word-index posting file identities (refs #2067)

### DIFF
--- a/.changelog/fix-2067-intern-word-index-files.md
+++ b/.changelog/fix-2067-intern-word-index-files.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Intern word-index posting files (refs #2067)** — Per-edit document replacement now compares shared file identities instead of re-normalizing every posting element; build/refresh telemetry records posting-entry counts and per-edit replacement cost. This is the declared prerequisite for #2069's posting representation work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2260,3 +2260,10 @@ Process-table resource samples preserve query outcome. `clients/child-unref.ts`
 those failures, so consumers leave usage unknown rather than fabricating zero
 samples, and records one bounded `resource-sampler-query-failed` degradation
 per query subject. (#1863)
+
+Interned word-index replacements share one commit tail. The synchronous and
+cooperative document-update paths call one helper for append, forward and
+freshness metadata, aggregate counters, and replacement telemetry. Keep the
+bulk `indexWordLine` loop direct: routing each token through the batch append
+helper allocates a map and one-element array per token and is not needed for
+the interning invariant.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,6 +443,16 @@ no live diagnostic may be evicted. Formatter detection signatures include
 formatter config metadata, and tsconfig-path signatures include recursive
 `extends`/project-reference configs. (#1389)
 
+**Word-index postings intern their document identity (#2067).** The in-memory
+posting entry keeps the index-owned shared file string, while `fileTable` maps
+the canonical `wordIndexKey` to that string. Removal and async refresh compare
+posting identities; they must never call `wordIndexKey(hit.file)`. Snapshot wire
+format v2 remains `[fileIdx, line]`; load rebuilds the table and shared refs.
+The cascade per-edit seam deliberately uses the cooperative async replacement
+variant so its synchronous occupancy remains within the 8 ms budget.
+When touching this seam, keep posting-entry counts and replacement-cost scalars
+in word-index telemetry. #2069 intentionally builds on this prerequisite.
+
 **Spawn repair decisions use the typed safe-spawn taxonomy.** A raw OS
 `ENOENT` can mean either a missing executable or an invalid child cwd. Consume
 `SpawnResult.spawnFailure.kind` / `SpawnFailureError.kind`, never errno or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,8 +448,9 @@ posting entry keeps the index-owned shared file string, while `fileTable` maps
 the canonical `wordIndexKey` to that string. Removal and async refresh compare
 posting identities; they must never call `wordIndexKey(hit.file)`. Snapshot wire
 format v2 remains `[fileIdx, line]`; load rebuilds the table and shared refs.
-The cascade per-edit seam deliberately uses the cooperative async replacement
-variant so its synchronous occupancy remains within the 8 ms budget.
+The cascade per-edit seam deliberately uses the synchronous replacement variant:
+unawaited concurrent cascades must not yield across a wholesale posting snapshot.
+Cooperative async variants are serialized per index and remain for bulk refresh.
 When touching this seam, keep posting-entry counts and replacement-cost scalars
 in word-index telemetry. #2069 intentionally builds on this prerequisite.
 

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -831,15 +831,15 @@ function isIgnoredCascadeNeighbor(filePath: string, cwd: string): boolean {
  *
  * Race safety against a build-in-progress: this function body is entirely
  * synchronous (no `await` anywhere in it) and is called synchronously at
- * `computeCascadeForFile`'s entry, before its own `await buildOrUpdateGraph`.
+ * `computeCascadeForFile`'s entry, before its own `await buildOrUpdateGraph`;
+ * the seam body is synchronous, although the caller awaits it.
  * Node is single-threaded, so two overlapping cascades (#450's unawaited
  * concurrency) can never interleave mid-mutation here — each call runs to
  * completion in one turn. The async variants exist for cooperative bulk
  * refreshes, but must not be used from unawaited concurrent callers: the
  * reviewer's 300-document probe lost 1,719 postings during an 8 ms yield
  * before the async path was serialized. The only cross-build hazard is a full
- * session-start
- * rebuild REPLACING `runtime.wordIndex` with a new object between the caller
+ * session-start rebuild REPLACING `runtime.wordIndex` with a new object between the caller
  * reading `runtime.wordIndex` (in runtime-tool-result.ts, also synchronous)
  * and this function receiving it — in that case this call simply mutates
  * whichever index object it was handed (old or new), and the other one is

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -107,8 +107,8 @@ import {
 	hasJavaBuildDescriptor,
 } from "../tool-policy.js";
 import {
-	removeWordIndexDocumentAsync,
-	updateWordIndexDocumentAsync,
+	removeWordIndexDocument,
+	updateWordIndexDocument,
 	WORD_INDEX_MAX_BYTES,
 	type WordIndex,
 } from "../word-index.js";
@@ -834,7 +834,11 @@ function isIgnoredCascadeNeighbor(filePath: string, cwd: string): boolean {
  * `computeCascadeForFile`'s entry, before its own `await buildOrUpdateGraph`.
  * Node is single-threaded, so two overlapping cascades (#450's unawaited
  * concurrency) can never interleave mid-mutation here — each call runs to
- * completion in one turn. The only cross-build hazard is a full session-start
+ * completion in one turn. The async variants exist for cooperative bulk
+ * refreshes, but must not be used from unawaited concurrent callers: the
+ * reviewer's 300-document probe lost 1,719 postings during an 8 ms yield
+ * before the async path was serialized. The only cross-build hazard is a full
+ * session-start
  * rebuild REPLACING `runtime.wordIndex` with a new object between the caller
  * reading `runtime.wordIndex` (in runtime-tool-result.ts, also synchronous)
  * and this function receiving it — in that case this call simply mutates
@@ -855,10 +859,10 @@ async function updateWordIndexForCascade(args: {
 
 	const byteLength = Buffer.byteLength(content, "utf-8");
 	if (byteLength > WORD_INDEX_MAX_BYTES) {
-		await removeWordIndexDocumentAsync(wordIndex, filePath);
+		removeWordIndexDocument(wordIndex, filePath);
 		dbg?.(`word-index per-edit: dropped ${filePath} (over size cap)`);
 	} else {
-		await updateWordIndexDocumentAsync(wordIndex, { path: filePath, content });
+		updateWordIndexDocument(wordIndex, { path: filePath, content });
 		dbg?.(`word-index per-edit: updated ${filePath}`);
 	}
 	onUpdated?.(wordIndex);

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -107,8 +107,8 @@ import {
 	hasJavaBuildDescriptor,
 } from "../tool-policy.js";
 import {
-	removeWordIndexDocument,
-	updateWordIndexDocument,
+	removeWordIndexDocumentAsync,
+	updateWordIndexDocumentAsync,
 	WORD_INDEX_MAX_BYTES,
 	type WordIndex,
 } from "../word-index.js";
@@ -842,23 +842,23 @@ function isIgnoredCascadeNeighbor(filePath: string, cwd: string): boolean {
  * abandoned/superseded, never corrupted. No queue, no lock: the simplest rule
  * that is still provably correct.
  */
-function updateWordIndexForCascade(args: {
+async function updateWordIndexForCascade(args: {
 	wordIndex?: WordIndex | null;
 	filePath: string;
 	content?: string;
 	onUpdated?: (index: WordIndex) => void;
 	dbg?: (msg: string) => void;
-}): void {
+}): Promise<void> {
 	const { wordIndex, filePath, content, onUpdated, dbg } = args;
 	if (!wordIndex || !wordIndex.forward) return;
 	if (content === undefined) return;
 
 	const byteLength = Buffer.byteLength(content, "utf-8");
 	if (byteLength > WORD_INDEX_MAX_BYTES) {
-		removeWordIndexDocument(wordIndex, filePath);
+		await removeWordIndexDocumentAsync(wordIndex, filePath);
 		dbg?.(`word-index per-edit: dropped ${filePath} (over size cap)`);
 	} else {
-		updateWordIndexDocument(wordIndex, { path: filePath, content });
+		await updateWordIndexDocumentAsync(wordIndex, { path: filePath, content });
 		dbg?.(`word-index per-edit: updated ${filePath}`);
 	}
 	onUpdated?.(wordIndex);
@@ -977,7 +977,7 @@ export async function computeCascadeForFile(
 		// The old hazard — this update silently orphaning a SECOND entry next to the
 		// walker's original-cased one — is now structurally impossible at the map
 		// layer, so this seam no longer has to hand-match the build path's key shape.
-		updateWordIndexForCascade({
+		await updateWordIndexForCascade({
 			wordIndex,
 			filePath: nodePath.resolve(filePath),
 			content: fileContent,

--- a/clients/memory-sampler.ts
+++ b/clients/memory-sampler.ts
@@ -154,6 +154,7 @@ export interface MemorySampleSubsystems {
 	/** `null` when no word index has been built yet this session. */
 	wordIndex: {
 		docs: number;
+		fileTable: number;
 		postings: number;
 		forwardEntries: number;
 	} | null;
@@ -219,6 +220,7 @@ export function collectMemorySampleSubsystems(
 		wordIndex: wordIndex
 			? {
 					docs: wordIndex.docLengths.size,
+					fileTable: wordIndex.fileTable.size,
 					postings: wordIndex.postings.size,
 					forwardEntries: wordIndex.forward?.size ?? 0,
 				}

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -926,8 +926,11 @@ async function buildOrRefreshWordIndex(args: {
 	const snapshot = loadProjectSnapshot(snapshotRoot);
 	const snapshotLoadMs = Date.now() - snapshotLoadStartMs;
 	if (snapshot?.wordIndex) {
-		const { deserializeWordIndex, refreshWordIndexIncrementally } =
-			await import("./word-index.js");
+		const {
+			deserializeWordIndex,
+			refreshWordIndexIncrementally,
+			countWordIndexPostingEntries,
+		} = await import("./word-index.js");
 		const deserializeStartMs = Date.now();
 		const index = deserializeWordIndex(snapshot.wordIndex);
 		const deserializeMs = Date.now() - deserializeStartMs;
@@ -988,6 +991,7 @@ async function buildOrRefreshWordIndex(args: {
 						durationMs: Date.now() - startMs,
 						indexedFileCount: index.docCount,
 						tokens: index.postings.size,
+						postingEntries: countWordIndexPostingEntries(index),
 						truncated: index.truncated,
 						phaseDurationsMs: {
 							snapshotLoadMs,
@@ -1029,8 +1033,11 @@ async function buildOrRefreshWordIndex(args: {
 	// implementation backs this task, the quick-mode warmup call below, AND the
 	// stateless cold-query background trigger in word-index.ts — a bound/skip
 	// -rule change lands once, not in three copies.
-	const { buildWordIndexAsync, collectWordIndexDocs } =
-		await import("./word-index.js");
+	const {
+		buildWordIndexAsync,
+		collectWordIndexDocs,
+		countWordIndexPostingEntries,
+	} = await import("./word-index.js");
 	const docs = await collectWordIndexDocs(
 		analysisRoot,
 		() => runtime.isCurrentSession(sessionGeneration),
@@ -1072,6 +1079,7 @@ async function buildOrRefreshWordIndex(args: {
 		durationMs: Date.now() - startMs,
 		indexedFileCount: runtime.wordIndex.docCount,
 		tokens: runtime.wordIndex.postings.size,
+		postingEntries: countWordIndexPostingEntries(runtime.wordIndex),
 		truncated: runtime.wordIndex.truncated,
 		skipped: docs.skipped,
 	});

--- a/clients/word-index-logger.ts
+++ b/clients/word-index-logger.ts
@@ -74,6 +74,12 @@ export interface WordIndexLogEntry {
 	truncated?: boolean;
 	/** Distinct token count (postings.size) — index breadth at a glance. */
 	tokens?: number;
+	/** Total in-memory posting entries (sum of posting-array lengths). */
+	postingEntries?: number;
+	/** Aggregate per-edit replacement cost for the pending turn/burst. */
+	replacementCount?: number;
+	totalReplacementMs?: number;
+	maxReplacementMs?: number;
 	/** Incremental: docs re-tokenized because their mtime changed. */
 	refreshed?: number;
 	/** Incremental: docs removed because they left the current file set. */

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -96,7 +96,7 @@ export interface WordIndex {
 	 * discipline forbids.
 	 */
 	fileSizes: PathKeyedMap<number>;
-	/** Bounded scalar aggregate for per-edit replacement observability. */
+	/** Bounded scalar aggregate for the current persist window. */
 	replacementStats?: { count: number; totalMs: number; maxMs: number };
 }
 
@@ -312,6 +312,23 @@ function internWordIndexFile(index: WordIndex, filePath: string): string {
 	return filePath;
 }
 
+function appendWordIndexPostings(
+	index: WordIndex,
+	filePath: string,
+	perTokenHits: Map<string, number[]>,
+): Map<string, number> {
+	const internedFile = internWordIndexFile(index, filePath);
+	const tokenLineCounts = new Map<string, number>();
+	for (const [token, lineNumbers] of perTokenHits) {
+		tokenLineCounts.set(token, lineNumbers.length);
+		const hits = lineNumbers.map((line) => ({ file: internedFile, line }));
+		const arr = index.postings.get(token);
+		if (arr) arr.push(...hits);
+		else index.postings.set(token, hits);
+	}
+	return tokenLineCounts;
+}
+
 function indexWordLine(
 	index: WordIndex,
 	filePath: string,
@@ -319,16 +336,20 @@ function indexWordLine(
 	lineNumber: number,
 	tokenLineCounts: Map<string, number>,
 ): number {
-	const internedFile = internWordIndexFile(index, filePath);
 	const lineTokens = tokenizeLine(line);
 	const seenOnLine = new Set<string>();
+	const perTokenHits = new Map<string, number[]>();
 	for (const token of lineTokens) {
 		if (seenOnLine.has(token)) continue;
 		seenOnLine.add(token);
-		const arr = index.postings.get(token);
-		if (arr) arr.push({ file: internedFile, line: lineNumber });
-		else index.postings.set(token, [{ file: internedFile, line: lineNumber }]);
-		tokenLineCounts.set(token, (tokenLineCounts.get(token) ?? 0) + 1);
+		perTokenHits.set(token, [lineNumber]);
+	}
+	for (const [token, count] of appendWordIndexPostings(
+		index,
+		filePath,
+		perTokenHits,
+	)) {
+		tokenLineCounts.set(token, (tokenLineCounts.get(token) ?? 0) + count);
 	}
 	return lineTokens.length;
 }
@@ -499,15 +520,11 @@ export function updateWordIndexDocument(
 		}
 	}
 
-	const internedFile = internWordIndexFile(index, doc.path);
-	const tokenLineCounts = new Map<string, number>();
-	for (const [token, lineNumbers] of perTokenHits) {
-		tokenLineCounts.set(token, lineNumbers.length);
-		const hits = lineNumbers.map((line) => ({ file: internedFile, line }));
-		const arr = index.postings.get(token);
-		if (arr) arr.push(...hits);
-		else index.postings.set(token, hits);
-	}
+	const tokenLineCounts = appendWordIndexPostings(
+		index,
+		doc.path,
+		perTokenHits,
+	);
 
 	index.docLengths.set(doc.path, docLength);
 	index.forward.set(doc.path, tokenLineCounts);
@@ -533,6 +550,26 @@ type StagedWordIndexRemoval = {
 	postings: Map<string, WordHit[] | undefined>;
 	docLength: number;
 };
+
+const asyncWordIndexOperations = new WeakMap<WordIndex, Promise<void>>();
+
+function enqueueAsyncWordIndexOperation<T>(
+	index: WordIndex,
+	operation: () => Promise<T>,
+): Promise<T> {
+	const previous = asyncWordIndexOperations.get(index) ?? Promise.resolve();
+	const run = previous.catch(() => undefined).then(operation);
+	const settled = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	asyncWordIndexOperations.set(index, settled);
+	return run.finally(() => {
+		if (asyncWordIndexOperations.get(index) === settled) {
+			asyncWordIndexOperations.delete(index);
+		}
+	});
+}
 
 async function stageWordIndexDocumentRemoval(
 	index: WordIndex,
@@ -587,15 +624,17 @@ export async function removeWordIndexDocumentAsync(
 	filePath: string,
 	shouldContinue: () => boolean = () => true,
 ): Promise<boolean> {
-	const staged = await stageWordIndexDocumentRemoval(
-		index,
-		filePath,
-		shouldContinue,
-	);
-	if (!staged) return false;
-	if (!shouldContinue()) throw new Error("word index refresh superseded");
-	commitWordIndexDocumentRemoval(index, filePath, staged);
-	return true;
+	return enqueueAsyncWordIndexOperation(index, async () => {
+		const staged = await stageWordIndexDocumentRemoval(
+			index,
+			filePath,
+			shouldContinue,
+		);
+		if (!staged) return false;
+		if (!shouldContinue()) throw new Error("word index refresh superseded");
+		commitWordIndexDocumentRemoval(index, filePath, staged);
+		return true;
+	});
 }
 
 /** Cooperative replacement whose old/new state is committed without an await. */
@@ -603,6 +642,16 @@ export async function updateWordIndexDocumentAsync(
 	index: WordIndex,
 	doc: { path: string; content: string },
 	shouldContinue: () => boolean = () => true,
+): Promise<boolean> {
+	return enqueueAsyncWordIndexOperation(index, () =>
+		updateWordIndexDocumentAsyncUnsafe(index, doc, shouldContinue),
+	);
+}
+
+async function updateWordIndexDocumentAsyncUnsafe(
+	index: WordIndex,
+	doc: { path: string; content: string },
+	shouldContinue: () => boolean,
 ): Promise<boolean> {
 	if (!index.forward) return false;
 	const startedAt = Date.now();
@@ -635,15 +684,11 @@ export async function updateWordIndexDocumentAsync(
 	);
 	if (!shouldContinue()) throw new Error("word index refresh superseded");
 	if (removal) commitWordIndexDocumentRemoval(index, doc.path, removal);
-	const internedFile = internWordIndexFile(index, doc.path);
-	const tokenLineCounts = new Map<string, number>();
-	for (const [token, lineNumbers] of perTokenHits) {
-		tokenLineCounts.set(token, lineNumbers.length);
-		const hits = lineNumbers.map((line) => ({ file: internedFile, line }));
-		const arr = index.postings.get(token);
-		if (arr) arr.push(...hits);
-		else index.postings.set(token, hits);
-	}
+	const tokenLineCounts = appendWordIndexPostings(
+		index,
+		doc.path,
+		perTokenHits,
+	);
 	index.docLengths.set(doc.path, docLength);
 	index.forward.set(doc.path, tokenLineCounts);
 	index.fileMtimes.set(doc.path, -1);
@@ -1511,8 +1556,8 @@ export function serializeWordIndex(index: WordIndex): SerializedWordIndex {
 	const files = [...index.docLengths.keys()];
 	const fileIndex = new Map<string, number>();
 	files.forEach((file, i) => {
-		const interned = index.fileTable.get(wordIndexKey(file));
-		if (interned !== undefined) fileIndex.set(interned, i);
+		const interned = index.fileTable.get(wordIndexKey(file)) ?? file;
+		fileIndex.set(interned, i);
 	});
 
 	const postings: Array<[string, number[]]> = [];
@@ -1849,6 +1894,7 @@ async function writeWordIndexSnapshot(
 			totalReplacementMs: index.replacementStats?.totalMs ?? 0,
 			maxReplacementMs: index.replacementStats?.maxMs ?? 0,
 		});
+		index.replacementStats = { count: 0, totalMs: 0, maxMs: 0 };
 	} catch (err) {
 		dbg?.(`word-index persist: failed: ${err}`);
 		// M3, #958: a swallowed persist means every LATER symbol_search reads a

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -329,6 +329,27 @@ function appendWordIndexPostings(
 	return tokenLineCounts;
 }
 
+function commitWordIndexDocumentReplacement(
+	index: WordIndex,
+	doc: { path: string; content: string },
+	perTokenHits: Map<string, number[]>,
+	docLength: number,
+	startedAt: number,
+): void {
+	const tokenLineCounts = appendWordIndexPostings(
+		index,
+		doc.path,
+		perTokenHits,
+	);
+	index.docLengths.set(doc.path, docLength);
+	index.forward!.set(doc.path, tokenLineCounts);
+	index.fileMtimes.set(doc.path, -1);
+	index.fileSizes.set(doc.path, Buffer.byteLength(doc.content, "utf-8"));
+	index.totalTokens += docLength;
+	index.docCount += 1;
+	recordWordIndexReplacement(index, startedAt);
+}
+
 function indexWordLine(
 	index: WordIndex,
 	filePath: string,
@@ -338,18 +359,13 @@ function indexWordLine(
 ): number {
 	const lineTokens = tokenizeLine(line);
 	const seenOnLine = new Set<string>();
-	const perTokenHits = new Map<string, number[]>();
 	for (const token of lineTokens) {
 		if (seenOnLine.has(token)) continue;
 		seenOnLine.add(token);
-		perTokenHits.set(token, [lineNumber]);
-	}
-	for (const [token, count] of appendWordIndexPostings(
-		index,
-		filePath,
-		perTokenHits,
-	)) {
-		tokenLineCounts.set(token, (tokenLineCounts.get(token) ?? 0) + count);
+		const arr = index.postings.get(token);
+		if (arr) arr.push({ file: filePath, line: lineNumber });
+		else index.postings.set(token, [{ file: filePath, line: lineNumber }]);
+		tokenLineCounts.set(token, (tokenLineCounts.get(token) ?? 0) + 1);
 	}
 	return lineTokens.length;
 }
@@ -375,13 +391,14 @@ function indexWordDocument(
 	index: WordIndex,
 	doc: WordIndexInputDocument,
 ): void {
+	const internedFile = internWordIndexFile(index, doc.path);
 	const lines = doc.content.split(/\r?\n/);
 	const tokenLineCounts = new Map<string, number>();
 	let docLength = 0;
 	for (let i = 0; i < lines.length; i += 1) {
 		docLength += indexWordLine(
 			index,
-			doc.path,
+			internedFile,
 			lines[i],
 			i + 1,
 			tokenLineCounts,
@@ -411,12 +428,19 @@ export async function buildWordIndexAsync(
 	const deadline = createDeadline(WORD_INDEX_BUILD_YIELD_BUDGET_MS);
 	for (const doc of files) {
 		if (!shouldContinue()) throw new Error("word index build superseded");
+		const internedFile = internWordIndexFile(index, doc.path);
 		const lines = doc.content.split(/\r?\n/);
 		const tokenLineCounts = new Map<string, number>();
 		let docLength = 0;
 		for (let i = 0; i < lines.length; i += 1) {
 			const line = lines[i];
-			docLength += indexWordLine(index, doc.path, line, i + 1, tokenLineCounts);
+			docLength += indexWordLine(
+				index,
+				internedFile,
+				line,
+				i + 1,
+				tokenLineCounts,
+			);
 			if (
 				line.length >= WORD_INDEX_LONG_LINE_YIELD_CHARS ||
 				deadline.expired()
@@ -520,29 +544,18 @@ export function updateWordIndexDocument(
 		}
 	}
 
-	const tokenLineCounts = appendWordIndexPostings(
-		index,
-		doc.path,
-		perTokenHits,
-	);
-
-	index.docLengths.set(doc.path, docLength);
-	index.forward.set(doc.path, tokenLineCounts);
 	// Per-edit callers generally already have content but not a stat. -1 is an
 	// impossible real mtime, so it deliberately makes the document stale at the
 	// next startup refresh (`-1 !== realMtime` always) — unlike 0, which is a
 	// legal on-disk mtime (SOURCE_DATE_EPOCH=0, archive extraction) and would
 	// collide, leaving such a file never re-tokenized (#958 review F2).
-	index.fileMtimes.set(doc.path, -1);
-	// Size is likewise recorded for the #1105 mtime+size refresh gate. The -1
-	// mtime already forces a re-read next session, so this value only keeps the
-	// map dense (parallel to fileMtimes); store the real byte length so a
-	// deserialize→reserialize round-trip before any refresh carries a truthful
-	// size rather than a placeholder.
-	index.fileSizes.set(doc.path, Buffer.byteLength(doc.content, "utf-8"));
-	index.totalTokens += docLength;
-	index.docCount += 1;
-	recordWordIndexReplacement(index, startedAt);
+	commitWordIndexDocumentReplacement(
+		index,
+		doc,
+		perTokenHits,
+		docLength,
+		startedAt,
+	);
 	return true;
 }
 
@@ -684,18 +697,13 @@ async function updateWordIndexDocumentAsyncUnsafe(
 	);
 	if (!shouldContinue()) throw new Error("word index refresh superseded");
 	if (removal) commitWordIndexDocumentRemoval(index, doc.path, removal);
-	const tokenLineCounts = appendWordIndexPostings(
+	commitWordIndexDocumentReplacement(
 		index,
-		doc.path,
+		doc,
 		perTokenHits,
+		docLength,
+		startedAt,
 	);
-	index.docLengths.set(doc.path, docLength);
-	index.forward.set(doc.path, tokenLineCounts);
-	index.fileMtimes.set(doc.path, -1);
-	index.fileSizes.set(doc.path, Buffer.byteLength(doc.content, "utf-8"));
-	index.totalTokens += docLength;
-	index.docCount += 1;
-	recordWordIndexReplacement(index, startedAt);
 	return true;
 }
 

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -53,6 +53,8 @@ export const wordIndexKey = normalizeEphemeralMapKey;
 export interface WordIndex {
 	/** token → postings (one entry per (file,line) the token appears on). */
 	postings: Map<string, WordHit[]>;
+	/** Canonical file key → one shared display string used by every posting. */
+	fileTable: Map<string, string>;
 	/**
 	 * file → number of indexed tokens (document length, for BM25 normalization).
 	 * Path-keyed via {@link wordIndexKey} ({@link PathKeyedMap}) so build-form and
@@ -94,6 +96,8 @@ export interface WordIndex {
 	 * discipline forbids.
 	 */
 	fileSizes: PathKeyedMap<number>;
+	/** Bounded scalar aggregate for per-edit replacement observability. */
+	replacementStats?: { count: number; totalMs: number; maxMs: number };
 }
 
 export interface RankedFile {
@@ -272,6 +276,7 @@ const WORD_INDEX_LONG_LINE_YIELD_CHARS = 4096;
 function createEmptyWordIndex(truncated: boolean): WordIndex {
 	return {
 		postings: new Map<string, WordHit[]>(),
+		fileTable: new Map<string, string>(),
 		docLengths: new PathKeyedMap<number>(wordIndexKey),
 		totalTokens: 0,
 		docCount: 0,
@@ -279,7 +284,32 @@ function createEmptyWordIndex(truncated: boolean): WordIndex {
 		forward: new PathKeyedMap<Map<string, number>>(wordIndexKey),
 		fileMtimes: new PathKeyedMap<number>(wordIndexKey),
 		fileSizes: new PathKeyedMap<number>(wordIndexKey),
+		replacementStats: { count: 0, totalMs: 0, maxMs: 0 },
 	};
+}
+
+export function countWordIndexPostingEntries(index: WordIndex): number {
+	let count = 0;
+	for (const hits of index.postings.values()) count += hits.length;
+	return count;
+}
+
+function recordWordIndexReplacement(index: WordIndex, startedAt: number): void {
+	const stats = index.replacementStats ?? { count: 0, totalMs: 0, maxMs: 0 };
+	const durationMs = Math.max(0, Date.now() - startedAt);
+	stats.count += 1;
+	stats.totalMs += durationMs;
+	stats.maxMs = Math.max(stats.maxMs, durationMs);
+	index.replacementStats = stats;
+}
+
+/** Intern a document path once per index; posting removal compares this identity. */
+function internWordIndexFile(index: WordIndex, filePath: string): string {
+	const key = wordIndexKey(filePath);
+	const existing = index.fileTable.get(key);
+	if (existing !== undefined) return existing;
+	index.fileTable.set(key, filePath);
+	return filePath;
 }
 
 function indexWordLine(
@@ -289,14 +319,15 @@ function indexWordLine(
 	lineNumber: number,
 	tokenLineCounts: Map<string, number>,
 ): number {
+	const internedFile = internWordIndexFile(index, filePath);
 	const lineTokens = tokenizeLine(line);
 	const seenOnLine = new Set<string>();
 	for (const token of lineTokens) {
 		if (seenOnLine.has(token)) continue;
 		seenOnLine.add(token);
 		const arr = index.postings.get(token);
-		if (arr) arr.push({ file: filePath, line: lineNumber });
-		else index.postings.set(token, [{ file: filePath, line: lineNumber }]);
+		if (arr) arr.push({ file: internedFile, line: lineNumber });
+		else index.postings.set(token, [{ file: internedFile, line: lineNumber }]);
 		tokenLineCounts.set(token, (tokenLineCounts.get(token) ?? 0) + 1);
 	}
 	return lineTokens.length;
@@ -403,10 +434,12 @@ export function removeWordIndexDocument(
 	// (`sub/a.ts`) on a case-insensitive FS and lingers as a stale posting
 	// (the #1025 item #2 bug this fix closes).
 	const removedKey = wordIndexKey(filePath);
+	const removedFile = index.fileTable.get(removedKey);
+	if (removedFile === undefined) return false;
 	for (const token of tokenLineCounts.keys()) {
 		const arr = index.postings.get(token);
 		if (!arr) continue;
-		const next = arr.filter((hit) => wordIndexKey(hit.file) !== removedKey);
+		const next = arr.filter((hit) => hit.file !== removedFile);
 		if (next.length > 0) index.postings.set(token, next);
 		else index.postings.delete(token);
 	}
@@ -416,6 +449,7 @@ export function removeWordIndexDocument(
 	index.forward.delete(filePath);
 	index.fileMtimes.delete(filePath);
 	index.fileSizes.delete(filePath);
+	index.fileTable.delete(removedKey);
 	index.totalTokens -= docLength;
 	index.docCount = Math.max(0, index.docCount - 1);
 	return true;
@@ -439,6 +473,7 @@ export function updateWordIndexDocument(
 	doc: { path: string; content: string },
 ): boolean {
 	if (!index.forward) return false;
+	const startedAt = Date.now();
 
 	// Remove the old contribution first (no-op if this is a brand new doc).
 	if (index.forward.has(doc.path)) {
@@ -464,10 +499,11 @@ export function updateWordIndexDocument(
 		}
 	}
 
+	const internedFile = internWordIndexFile(index, doc.path);
 	const tokenLineCounts = new Map<string, number>();
 	for (const [token, lineNumbers] of perTokenHits) {
 		tokenLineCounts.set(token, lineNumbers.length);
-		const hits = lineNumbers.map((line) => ({ file: doc.path, line }));
+		const hits = lineNumbers.map((line) => ({ file: internedFile, line }));
 		const arr = index.postings.get(token);
 		if (arr) arr.push(...hits);
 		else index.postings.set(token, hits);
@@ -489,6 +525,7 @@ export function updateWordIndexDocument(
 	index.fileSizes.set(doc.path, Buffer.byteLength(doc.content, "utf-8"));
 	index.totalTokens += docLength;
 	index.docCount += 1;
+	recordWordIndexReplacement(index, startedAt);
 	return true;
 }
 
@@ -506,6 +543,8 @@ async function stageWordIndexDocumentRemoval(
 	const tokenLineCounts = index.forward.get(filePath);
 	if (!tokenLineCounts) return undefined;
 	const removedKey = wordIndexKey(filePath);
+	const removedFile = index.fileTable.get(removedKey);
+	if (removedFile === undefined) return undefined;
 	const postings = new Map<string, WordHit[] | undefined>();
 	const deadline = createDeadline(WORD_INDEX_BUILD_YIELD_BUDGET_MS);
 	for (const token of tokenLineCounts.keys()) {
@@ -514,7 +553,7 @@ async function stageWordIndexDocumentRemoval(
 		if (!arr) continue;
 		const next: WordHit[] = [];
 		for (const hit of arr) {
-			if (wordIndexKey(hit.file) !== removedKey) next.push(hit);
+			if (hit.file !== removedFile) next.push(hit);
 			if (deadline.expired() && (await yieldIfOverBudget(deadline))) {
 				if (!shouldContinue()) throw new Error("word index refresh superseded");
 			}
@@ -537,6 +576,7 @@ function commitWordIndexDocumentRemoval(
 	index.forward?.delete(filePath);
 	index.fileMtimes.delete(filePath);
 	index.fileSizes.delete(filePath);
+	index.fileTable.delete(wordIndexKey(filePath));
 	index.totalTokens -= staged.docLength;
 	index.docCount = Math.max(0, index.docCount - 1);
 }
@@ -565,6 +605,7 @@ export async function updateWordIndexDocumentAsync(
 	shouldContinue: () => boolean = () => true,
 ): Promise<boolean> {
 	if (!index.forward) return false;
+	const startedAt = Date.now();
 	const removal = index.forward.has(doc.path)
 		? await stageWordIndexDocumentRemoval(index, doc.path, shouldContinue)
 		: undefined;
@@ -594,10 +635,11 @@ export async function updateWordIndexDocumentAsync(
 	);
 	if (!shouldContinue()) throw new Error("word index refresh superseded");
 	if (removal) commitWordIndexDocumentRemoval(index, doc.path, removal);
+	const internedFile = internWordIndexFile(index, doc.path);
 	const tokenLineCounts = new Map<string, number>();
 	for (const [token, lineNumbers] of perTokenHits) {
 		tokenLineCounts.set(token, lineNumbers.length);
-		const hits = lineNumbers.map((line) => ({ file: doc.path, line }));
+		const hits = lineNumbers.map((line) => ({ file: internedFile, line }));
 		const arr = index.postings.get(token);
 		if (arr) arr.push(...hits);
 		else index.postings.set(token, hits);
@@ -608,6 +650,7 @@ export async function updateWordIndexDocumentAsync(
 	index.fileSizes.set(doc.path, Buffer.byteLength(doc.content, "utf-8"));
 	index.totalTokens += docLength;
 	index.docCount += 1;
+	recordWordIndexReplacement(index, startedAt);
 	return true;
 }
 
@@ -1467,7 +1510,10 @@ export const WORD_INDEX_FORMAT_VERSION = 2;
 export function serializeWordIndex(index: WordIndex): SerializedWordIndex {
 	const files = [...index.docLengths.keys()];
 	const fileIndex = new Map<string, number>();
-	files.forEach((file, i) => fileIndex.set(file, i));
+	files.forEach((file, i) => {
+		const interned = index.fileTable.get(wordIndexKey(file));
+		if (interned !== undefined) fileIndex.set(interned, i);
+	});
 
 	const postings: Array<[string, number[]]> = [];
 	for (const [token, hits] of index.postings) {
@@ -1517,6 +1563,11 @@ export function deserializeWordIndex(
 		return null;
 	}
 	const docLengths = new PathKeyedMap<number>(wordIndexKey);
+	const fileTable = new Map<string, string>();
+	data.files.forEach((file) => fileTable.set(wordIndexKey(file), file));
+	const internedFiles = data.files.map(
+		(file) => fileTable.get(wordIndexKey(file)) ?? file,
+	);
 	const fileMtimes = new PathKeyedMap<number>(wordIndexKey);
 	const fileSizes = new PathKeyedMap<number>(wordIndexKey);
 	data.files.forEach((file, i) =>
@@ -1543,7 +1594,7 @@ export function deserializeWordIndex(
 		if (typeof token !== "string" || !Array.isArray(flat)) continue;
 		const hits: WordHit[] = [];
 		for (let i = 0; i + 1 < flat.length; i += 2) {
-			const file = data.files[flat[i]];
+			const file = internedFiles[flat[i]];
 			const line = flat[i + 1];
 			if (typeof file === "string" && typeof line === "number") {
 				hits.push({ file, line });
@@ -1574,6 +1625,7 @@ export function deserializeWordIndex(
 
 	return {
 		postings,
+		fileTable,
 		docLengths,
 		totalTokens: typeof data.totalTokens === "number" ? data.totalTokens : 0,
 		docCount: data.files.length,
@@ -1686,6 +1738,7 @@ export function triggerBackgroundWordIndexBuild(
 				durationMs: Date.now() - startMs,
 				indexedFileCount: index.docCount,
 				tokens: index.postings.size,
+				postingEntries: countWordIndexPostingEntries(index),
 				truncated: index.truncated,
 				skipped: docs.skipped,
 			});
@@ -1756,6 +1809,7 @@ async function writeWordIndexSnapshot(
 	index: WordIndex,
 	dbg?: (msg: string) => void,
 ): Promise<void> {
+	const persistStartedAt = Date.now();
 	try {
 		const {
 			loadProjectSnapshot,
@@ -1787,8 +1841,13 @@ async function writeWordIndexSnapshot(
 			phase: "persist_succeeded",
 			cwd: path.resolve(cwd),
 			trigger: "per_edit",
+			durationMs: Date.now() - persistStartedAt,
 			indexedFileCount: index.docCount,
 			tokens: index.postings.size,
+			postingEntries: countWordIndexPostingEntries(index),
+			replacementCount: index.replacementStats?.count ?? 0,
+			totalReplacementMs: index.replacementStats?.totalMs ?? 0,
+			maxReplacementMs: index.replacementStats?.maxMs ?? 0,
 		});
 	} catch (err) {
 		dbg?.(`word-index persist: failed: ${err}`);

--- a/tests/clients/memory-sampler.test.ts
+++ b/tests/clients/memory-sampler.test.ts
@@ -176,7 +176,7 @@ describe("collectMemorySampleSubsystems (O(1)/O(bounded-cache-size) live reads)"
 	});
 
 	it("reports word-index doc/posting/forward counts when a word index is supplied", () => {
-		const wordIndex = {
+		const wordIndex: WordIndex = {
 			postings: new Map([["foo", [{ file: "a.ts", line: 1 }]]]),
 			fileTable: new Map([[normalizeEphemeralMapKey("a.ts"), "a.ts"]]),
 			docLengths: (() => {
@@ -195,10 +195,11 @@ describe("collectMemorySampleSubsystems (O(1)/O(bounded-cache-size) live reads)"
 			docCount: 1,
 			fileMtimes: new PathKeyedMap<number>(normalizeEphemeralMapKey),
 			fileSizes: new PathKeyedMap<number>(normalizeEphemeralMapKey),
-		} as WordIndex;
+		};
 		const subsystems = collectMemorySampleSubsystems(wordIndex);
 		expect(subsystems.wordIndex).toEqual({
 			docs: 1,
+			fileTable: 1,
 			postings: 1,
 			forwardEntries: 1,
 		});

--- a/tests/clients/memory-sampler.test.ts
+++ b/tests/clients/memory-sampler.test.ts
@@ -176,8 +176,9 @@ describe("collectMemorySampleSubsystems (O(1)/O(bounded-cache-size) live reads)"
 	});
 
 	it("reports word-index doc/posting/forward counts when a word index is supplied", () => {
-		const wordIndex: WordIndex = {
+		const wordIndex = {
 			postings: new Map([["foo", [{ file: "a.ts", line: 1 }]]]),
+			fileTable: new Map([[normalizeEphemeralMapKey("a.ts"), "a.ts"]]),
 			docLengths: (() => {
 				const m = new PathKeyedMap<number>(normalizeEphemeralMapKey);
 				m.set("a.ts", 5);
@@ -194,7 +195,7 @@ describe("collectMemorySampleSubsystems (O(1)/O(bounded-cache-size) live reads)"
 			docCount: 1,
 			fileMtimes: new PathKeyedMap<number>(normalizeEphemeralMapKey),
 			fileSizes: new PathKeyedMap<number>(normalizeEphemeralMapKey),
-		};
+		} as WordIndex;
 		const subsystems = collectMemorySampleSubsystems(wordIndex);
 		expect(subsystems.wordIndex).toEqual({
 			docs: 1,

--- a/tests/clients/word-index-2067-interning.test.ts
+++ b/tests/clients/word-index-2067-interning.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { normalizeCalls } = vi.hoisted(() => ({ normalizeCalls: { value: 0 } }));
+vi.mock("../../clients/path-utils.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../clients/path-utils.js")>();
+	return {
+		...actual,
+		normalizeEphemeralMapKey: (file: string) => {
+			normalizeCalls.value += 1;
+			return actual.normalizeEphemeralMapKey(file);
+		},
+	};
+});
+
+describe("word-index posting file interning (#2067)", () => {
+	it("keeps removal normalization proportional to distinct files, not hits", async () => {
+		const { buildWordIndex, removeWordIndexDocument, searchWordIndex } =
+			await import("../../clients/word-index.js");
+		const files = Array.from({ length: 40 }, (_, i) => ({
+			path: `doc-${i}.ts`,
+			content: Array.from({ length: 40 }, () => "sharedToken").join("\n"),
+		}));
+		const index = buildWordIndex(files);
+
+		normalizeCalls.value = 0;
+		expect(removeWordIndexDocument(index, "doc-0.ts")).toBe(true);
+
+		// The old filter normalized all 1,600 posting elements. A small fixed
+		// bound allows map housekeeping while proving the hot loop is gone.
+		expect(normalizeCalls.value).toBeLessThan(100);
+		expect(searchWordIndex(index, "sharedToken")).toHaveLength(20);
+	});
+});

--- a/tests/clients/word-index-2067-interning.test.ts
+++ b/tests/clients/word-index-2067-interning.test.ts
@@ -31,4 +31,21 @@ describe("word-index posting file interning (#2067)", () => {
 		expect(normalizeCalls.value).toBeLessThan(100);
 		expect(searchWordIndex(index, "sharedToken")).toHaveLength(20);
 	});
+
+	it("keeps async removal normalization proportional to distinct files, not hits", async () => {
+		const { buildWordIndex, removeWordIndexDocumentAsync, searchWordIndex } =
+			await import("../../clients/word-index.js");
+		const files = Array.from({ length: 40 }, (_, i) => ({
+			path: `async-doc-${i}.ts`,
+			content: Array.from({ length: 40 }, () => "asyncShared").join("\n"),
+		}));
+		const index = buildWordIndex(files);
+
+		normalizeCalls.value = 0;
+		expect(await removeWordIndexDocumentAsync(index, "async-doc-0.ts")).toBe(
+			true,
+		);
+		expect(normalizeCalls.value).toBeLessThan(100);
+		expect(searchWordIndex(index, "asyncShared")).toHaveLength(20);
+	});
 });

--- a/tests/clients/word-index-cooperative-occupancy.test.ts
+++ b/tests/clients/word-index-cooperative-occupancy.test.ts
@@ -121,4 +121,40 @@ describe("cooperative word-index refresh occupancy (#1215/#1224/#1225)", () => {
 			searchWordIndex(index, "novel").some((hit) => hit.file === path),
 		).toBe(true);
 	});
+
+	it(
+		"serializes concurrent async replacements and preserves postings/forward consistency",
+		{ timeout: 30_000 },
+		async () => {
+			const docs = Object.assign(
+				Array.from({ length: 300 }, (_, file) => ({
+					path: `src/f${file}.ts`,
+					content: sharedBody(file, "original", 20),
+				})),
+				{ truncated: false },
+			);
+			const index = buildWordIndex(docs);
+			const expected = buildWordIndex(docs);
+			const updates = [0, 1].map((file) => ({
+				path: docs[file].path,
+				content: sharedBody(file, "updated", 20),
+			}));
+			for (const update of updates) updateWordIndexDocument(expected, update);
+
+			await Promise.all(
+				updates.map((update) => updateWordIndexDocumentAsync(index, update)),
+			);
+
+			expect(serializeWordIndex(index)).toEqual(serializeWordIndex(expected));
+			for (const [file, tokenCounts] of index.forward!) {
+				for (const [token, count] of tokenCounts) {
+					expect(
+						(index.postings.get(token) ?? []).filter(
+							(hit) => hit.file === file,
+						),
+					).toHaveLength(count);
+				}
+			}
+		},
+	);
 });

--- a/tests/clients/word-index-observability.test.ts
+++ b/tests/clients/word-index-observability.test.ts
@@ -149,6 +149,10 @@ describe("word-index observability (#958)", () => {
 					trigger: "per_edit",
 					indexedFileCount: 1,
 					tokens: expect.any(Number),
+					postingEntries: expect.any(Number),
+					replacementCount: 0,
+					totalReplacementMs: 0,
+					maxReplacementMs: 0,
 				}),
 			);
 			// And no persist_failed on the success path.

--- a/tests/clients/word-index-observability.test.ts
+++ b/tests/clients/word-index-observability.test.ts
@@ -145,7 +145,7 @@ describe("word-index observability (#958)", () => {
 			await flushMicrotasks();
 
 			const ok = logSpy.mock.calls.find(
-				(c) => c[0]?.phase === "persist_succeeded",
+				(c) => c[0]?.phase === "persist_succeeded" && c[0]?.cwd === env.tmpDir,
 			);
 			expect(ok).toBeDefined();
 			expect(ok?.[0]).toEqual(
@@ -164,6 +164,38 @@ describe("word-index observability (#958)", () => {
 			expect(
 				logSpy.mock.calls.find((c) => c[0]?.phase === "persist_failed"),
 			).toBeUndefined();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("resets replacementCount between successful persist records", async () => {
+		const env = setupTestEnvironment("pi-lens-word-replacement-reset-");
+		try {
+			const {
+				buildWordIndex,
+				updateWordIndexDocument,
+				scheduleWordIndexPersist,
+				flushWordIndexPersistsForTests,
+			} = await import("../../clients/word-index.js");
+			const index = buildWordIndex([{ path: "a.ts", content: "alpha" }]);
+			updateWordIndexDocument(index, { path: "a.ts", content: "beta" });
+			scheduleWordIndexPersist(env.tmpDir, index);
+			flushWordIndexPersistsForTests();
+			await flushMicrotasks();
+			scheduleWordIndexPersist(env.tmpDir, index);
+			flushWordIndexPersistsForTests();
+			await flushMicrotasks();
+			const records = logSpy.mock.calls
+				.map((call) => call[0])
+				.filter(
+					(record) =>
+						record?.phase === "persist_succeeded" && record?.cwd === env.tmpDir,
+				);
+			expect(records).toHaveLength(2);
+			expect(records[1]).toEqual(
+				expect.objectContaining({ replacementCount: 0 }),
+			);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/word-index-observability.test.ts
+++ b/tests/clients/word-index-observability.test.ts
@@ -128,12 +128,17 @@ describe("word-index observability (#958)", () => {
 		try {
 			const {
 				buildWordIndex,
+				updateWordIndexDocument,
 				scheduleWordIndexPersist,
 				flushWordIndexPersistsForTests,
 			} = await import("../../clients/word-index.js");
 			const index = buildWordIndex([
 				{ path: "a.ts", content: "export const alpha = 1;" },
 			]);
+			updateWordIndexDocument(index, {
+				path: "a.ts",
+				content: "export const alpha = 2;",
+			});
 
 			scheduleWordIndexPersist(env.tmpDir, index);
 			flushWordIndexPersistsForTests();
@@ -150,9 +155,9 @@ describe("word-index observability (#958)", () => {
 					indexedFileCount: 1,
 					tokens: expect.any(Number),
 					postingEntries: expect.any(Number),
-					replacementCount: 0,
-					totalReplacementMs: 0,
-					maxReplacementMs: 0,
+					replacementCount: 1,
+					totalReplacementMs: expect.any(Number),
+					maxReplacementMs: expect.any(Number),
 				}),
 			);
 			// And no persist_failed on the success path.

--- a/tests/clients/word-index-path-divergence.test.ts
+++ b/tests/clients/word-index-path-divergence.test.ts
@@ -25,7 +25,9 @@ import * as fs from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
 	buildWordIndex,
+	countWordIndexPostingEntries,
 	refreshWordIndexIncrementally,
+	serializeWordIndex,
 	updateWordIndexDocument,
 	wordIndexKey,
 } from "../../clients/word-index.js";
@@ -35,6 +37,24 @@ import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 const NORMALIZER_FOLDS_CASE = wordIndexKey("A.ts") === wordIndexKey("a.ts");
 
 describe("word-index build/update key convergence (#1025 item #2)", () => {
+	it("serializes folded walk spellings without dropping postings", () => {
+		const index = buildWordIndex([
+			{ path: "walk\\alpha.ts", content: "foldedToken" },
+			{ path: "walk/alpha.ts", content: "foldedToken" },
+		]);
+		// Two walk spellings fold to one path key. Simulate the older producer's
+		// missing table row while retaining the folded walk entry.
+		index.fileTable.clear();
+		index.docLengths.clear();
+		index.docLengths.set("walk\\alpha.ts", 1);
+		// The serializer's spelling fallback must retain both in-memory entries.
+		const serializedEntries = serializeWordIndex(index).postings.reduce(
+			(total, [, flat]) => total + flat.length / 2,
+			0,
+		);
+		expect(serializedEntries).toBe(countWordIndexPostingEntries(index));
+	});
+
 	it("separator-divergent build vs edit forms collapse to one entry (all platforms)", () => {
 		// BUILD keys the doc with a backslash separator (as a Windows walk would).
 		const index = buildWordIndex([

--- a/tests/clients/word-index-path-divergence.test.ts
+++ b/tests/clients/word-index-path-divergence.test.ts
@@ -55,6 +55,20 @@ describe("word-index build/update key convergence (#1025 item #2)", () => {
 		expect(serializedEntries).toBe(countWordIndexPostingEntries(index));
 	});
 
+	it("serializes folded walk spellings with the live file table intact", () => {
+		const index = buildWordIndex([
+			{ path: "walk\\alpha.ts", content: "firstWalkToken" },
+			{ path: "walk/alpha.ts", content: "secondWalkToken" },
+		]);
+		const serialized = serializeWordIndex(index);
+		const tokens = new Set(serialized.postings.map(([token]) => token));
+		expect(tokens.has("firstwalktoken")).toBe(true);
+		expect(tokens.has("secondwalktoken")).toBe(true);
+		expect(
+			serialized.postings.reduce((n, [, flat]) => n + flat.length / 2, 0),
+		).toBe(countWordIndexPostingEntries(index));
+	});
+
 	it("separator-divergent build vs edit forms collapse to one entry (all platforms)", () => {
 		// BUILD keys the doc with a backslash separator (as a Windows walk would).
 		const index = buildWordIndex([

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -826,7 +826,8 @@ export const EXEMPT_SESSION_STATE_FILES: Readonly<Record<string, string>> = {
 		"the recent-touch cursor, consumed and advanced per read",
 	"widget-state.ts":
 		"widget render state, rebuilt from the sources it displays",
-	"word-index.ts": "word-index build guard, per build",
+	"word-index.ts":
+		"word-index build guard, per build; asyncWordIndexOperations queue is keyed by WordIndex and self-deletes in finally, so it needs no reset",
 	"mcp/analyze.ts":
 		"warm word-index cache keyed by path with its own freshness check",
 	"mcp/session.ts":
@@ -954,7 +955,7 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	"tui-fit.ts": 0,
 	"warm-attach.ts": 0,
 	"widget-state.ts": 2,
-	"word-index.ts": 2,
+	"word-index.ts": 3,
 	"workspace-topology.ts": 2,
 	"zizmor-config.ts": 0,
 };


### PR DESCRIPTION
## what changed

- Intern each document's canonical `wordIndexKey` once in an index-owned `fileTable`; postings retain the shared file string and removal compares identity.
- Apply the same identity seam to synchronous/async update and removal, and migrate the cascade seam to the cooperative async variant to preserve the 8 ms occupancy budget.
- Keep snapshot v2 unchanged: serialize still emits `[fileIdx, line]`, and deserialization rebuilds the table/shared references, including old v2 snapshots.
- Add count-based regression coverage, posting-entry telemetry, and bounded replacement count/total/max timing. Persist-success records now also carry duration.
- This PR is intentionally first; #2069's compact posting-entry representation builds on this interning seam.

## why

The old removal filter called `wordIndexKey(hit.file)` for every posting element. On the measured 2,500-document high-posting corpus that repeated normalization of the same document paths thousands of times per edit. Identity comparison removes that repeated work without changing search inputs or BM25 calculation.

## verification

- Build before tests: `npm run build` passed.
- Targeted suite: 117 passed, 2 skipped across 10 word-index/dispatch files.
- Focused post-amend rerun: 6 passed across the regression and observability files.
- `npm run fmt:check`, changelog validation, and commit lint/lockfile hooks passed.
- Red-first output on pre-fix code:

  > AssertionError: expected 4807 to be less than 100

  The RED test counted normalizer calls while removing 1,600 posting elements; the fixed test passes with fewer than 100 calls.
- Edit-loop benchmark, n=100, 2,500 documents, 20 KB shared-posting target: before mean 169.99 ms/edit; after mean 33.61 ms/edit (after max 49.18 ms). The cascade seam uses the async cooperative path.
- Search/BM25 equivalence remains covered by the existing incremental random-edit and snapshot round-trip tests; the targeted suite passed.

## CLASS SWEEP

Pattern swept: per-element re-derivation of an invariant path key inside a filter/map over a large collection.

- `clients/`: the reported word-index removal and async refresh were the only confirmed members; fixed. Posting readers in dispatch integration, lens-engine, and module-report use the shared string directly or normalize once per result. `tools/symbol-search.ts` only renders the string. Other client normalizer/filter hits were unrelated diagnostic/cache domains.
- `tools/`: no word-index posting-key re-derivation found; symbol-search readers are display-only.
- `mcp/`: no word-index posting-key re-derivation or direct posting reader found.
- `scripts/`: no word-index posting-key re-derivation found; matches are unrelated report/file fields.
- `index.ts`: no word-index posting-key re-derivation found; matches are unrelated extension/tool entries.

## BLAST RADIUS

Every `WordHit.file` reader was checked: `clients/word-index.ts` query grouping and serialization, `clients/dispatch/integration.ts` cascade neighbor mapping, `clients/lens-engine.ts` centrality lookup, `clients/module-report.ts` aggregation, and `tools/symbol-search.ts` display. All accept a shared string reference; no reader depends on per-hit string identity or mutation. Snapshot load/save compatibility is preserved with wire format v2 and the new table rebuilt on load. The regression also covers the async removal path through the existing cooperative-update tests.

## OBSERVABILITY

`full_rebuild`, `incremental_refresh`, and `cold_build` records now include `postingEntries`. Per-edit `persist_succeeded` records include `durationMs`, `postingEntries`, `replacementCount`, `totalReplacementMs`, and `maxReplacementMs`. The RED evidence and benchmark are retained in the worktree scratch files for review.

Refs #2067. Declared order: this PR lands before #2069.


## Fix round 1

- F1: restored the cascade per-edit seam to synchronous `updateWordIndexDocument`/`removeWordIndexDocument`. The reviewer probe showed the unawaited cascade callers could overlap async wholesale posting snapshots and lose 1,719 postings across 300 documents during the 8 ms yield. Cooperative async callers are now protected by a per-index in-flight promise chain; the concurrency regression asserts postings remain consistent with `forward`. Residual per-edit wall cost remains tracked by #2068/#1740 for main-thread offload.
- F2: added count-instrumented coverage for async removal; the normalizer count remains bounded by distinct files rather than posting entries.
- F3: added folded-spelling serializer coverage; serialized posting entries equal the in-memory posting count through the fallback bridge.
- F4: replacement statistics are documented and reset per persist window immediately after each `persist_succeeded` emission; the observability suite pins a non-zero replacement case.
- F5: extracted the shared interning-plus-append helper used by all three posting construction paths. PR title corrected. Benchmark evidence remains scratch-only.
- F8: restored explicit `const wordIndex: WordIndex` test annotations.
- F9: memory samples now include `fileTable` accounting.

### Corrected blast radius

The behavioral risk is limited to unawaited concurrent callers of the cooperative async word-index APIs and the restored synchronous cascade invariant. Bulk refresh remains cooperative and async, now serialized per index; snapshot wire format v2, search/BM25 inputs, and all posting readers remain unchanged.

Criteria 2 (CPU profile under 2% normalizer evidence) and 5 (search/BM25 equivalence evidence) remain open on #2067; benchmark evidence currently lives only in scratch.


### Red-first snippets

- F2 guard: pre-fix async removal produced `AssertionError: expected 4807 to be less than 100` from the normalizer call counter.
- F3 serialize bridge: pre-fix folded-spelling serialization produced `AssertionError: expected 0 to be 6` posting entries (in-memory count 6).


## Fix round 3

- 1: registered the third stateful symbol count for `word-index.ts`; the `asyncWordIndexOperations` WeakMap remains correctly exempt because it is keyed by `WordIndex` and self-deletes in `finally`.
- 2: extracted the complete append-through-replacement-telemetry tail into one shared helper used by synchronous and cooperative async updates. Sonar duplicate-block scope is reduced to the requested shared seam.
- 3: added live-`fileTable` folded-walk serialization coverage; red proof with the master `files.forEach((file, i) => fileIndex.set(file, i))` bridge dropped postings and failed the new test.
- 4: added a second schedule/flush assertion requiring `replacementCount: 0`; red proof with the reset assignment deleted reported `replacementCount: 1` on the second record.
- 5: corrected the cascade comment to describe the synchronous body and fixed the session-start line wrap.
- 6: kept direct `indexWordLine` hot-loop posting writes. Interning now occurs once per document and passes the shared display string into the loop, avoiding per-token map/array allocation; no benchmark is needed for the removed round-2 overhead.
- 7: criteria 2 (CPU profile under 2% evidence) and 5 (BM25 equivalence on a fixed query set) remain open on #2067.

### Fix round 3 red snippets

- Item 3: with the master serializer bridge, `AssertionError: expected false to be true` (`firstwalktoken` missing; the existing fallback also reported `expected 3 to be 6`).
- Item 4: with the reset line deleted, `AssertionError: expected ... replacementCount: 0`, received `replacementCount: 1`.
