### PR TITLE
fix: validate live PR titles (closes #2083)

### DIFF
--- a/.changelog/fix-2083-live-pr-title.md
+++ b/.changelog/fix-2083-live-pr-title.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **PR-title checks now validate the live pull-request title (refs #2083)** — rerunning a failed check can recover after the title is fixed without requiring a new pull-request event.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,7 @@ jobs:
     name: PR title
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,6 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -63,6 +64,8 @@ jobs:
           node-version: "22"
 
       - name: Validate PR title (conventional prefix + issue ref)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/check-pr-title.mjs
 
   oxfmt:

--- a/scripts/check-pr-title.d.mts
+++ b/scripts/check-pr-title.d.mts
@@ -4,3 +4,7 @@ export declare function lintPrTitle(
 	title?: string,
 	body?: string,
 ): { valid: boolean; errors: string[] };
+export declare function resolveLivePrTitle(
+	payloadPr: { number: number; title?: string },
+	fetchImpl?: typeof fetch,
+): Promise<string>;

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -47,11 +47,10 @@ export async function resolveLivePrTitle(
 	const token = process.env.GITHUB_TOKEN;
 	if (!token) {
 		console.warn(
-			"PR title live fetch failed: GITHUB_TOKEN is missing; using event payload title",
+			"::warning::PR title live fetch failed: GITHUB_TOKEN is missing; using event payload title",
 		);
 		return fallbackTitle;
 	}
-
 	try {
 		const apiUrl = process.env.GITHUB_API_URL;
 		const repository = process.env.GITHUB_REPOSITORY;
@@ -61,6 +60,7 @@ export async function resolveLivePrTitle(
 		const response = await fetchImpl(
 			`${apiUrl}/repos/${repository}/pulls/${payloadPr.number}`,
 			{
+				signal: AbortSignal.timeout(10_000),
 				headers: {
 					Authorization: `Bearer ${token}`,
 					Accept: "application/vnd.github+json",
@@ -78,7 +78,7 @@ export async function resolveLivePrTitle(
 	} catch (error) {
 		const reason = error instanceof Error ? error.message : String(error);
 		console.warn(
-			`PR title live fetch failed: ${reason}; using event payload title`,
+			`::warning::PR title live fetch failed: ${reason}; using event payload title`,
 		);
 		return fallbackTitle;
 	}

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -39,29 +39,73 @@ export function lintPrTitle(title = "", _body = "") {
 	return { valid: errors.length === 0, errors };
 }
 
+export async function resolveLivePrTitle(
+	payloadPr,
+	fetchImpl = globalThis.fetch,
+) {
+	const fallbackTitle = payloadPr.title ?? "";
+	const token = process.env.GITHUB_TOKEN;
+	if (!token) {
+		console.warn(
+			"PR title live fetch failed: GITHUB_TOKEN is missing; using event payload title",
+		);
+		return fallbackTitle;
+	}
+
+	try {
+		const apiUrl = process.env.GITHUB_API_URL;
+		const repository = process.env.GITHUB_REPOSITORY;
+		if (!apiUrl || !repository) {
+			throw new Error("GITHUB_API_URL or GITHUB_REPOSITORY is missing");
+		}
+		const response = await fetchImpl(
+			`${apiUrl}/repos/${repository}/pulls/${payloadPr.number}`,
+			{
+				headers: {
+					Authorization: `Bearer ${token}`,
+					Accept: "application/vnd.github+json",
+				},
+			},
+		);
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}`);
+		}
+		const livePr = await response.json();
+		if (typeof livePr?.title !== "string") {
+			throw new Error("response has no title");
+		}
+		return livePr.title;
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		console.warn(
+			`PR title live fetch failed: ${reason}; using event payload title`,
+		);
+		return fallbackTitle;
+	}
+}
+
 function eventPayload() {
 	const eventPath = process.env.GITHUB_EVENT_PATH;
 	if (!eventPath) throw new Error("GITHUB_EVENT_PATH is required");
 	return JSON.parse(readFileSync(eventPath, "utf8"));
 }
 
-function lintPullRequestEvent() {
+async function lintPullRequestEvent() {
 	const pullRequest = eventPayload().pull_request;
 	if (!pullRequest) throw new Error("Event payload has no pull_request");
-	const result = lintPrTitle(pullRequest.title ?? "", pullRequest.body ?? "");
+	const title = await resolveLivePrTitle(pullRequest);
+	const result = lintPrTitle(title, pullRequest.body ?? "");
 	if (!result.valid) {
 		for (const error of result.errors) console.error(error);
 		process.exitCode = 1;
 		return;
 	}
-	console.log(`PR title OK: "${pullRequest.title}"`);
+	console.log(`PR title OK: "${title}"`);
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-	try {
-		lintPullRequestEvent();
-	} catch (error) {
+	lintPullRequestEvent().catch((error) => {
 		console.error(error instanceof Error ? error.message : error);
 		process.exitCode = 1;
-	}
+	});
 }

--- a/tests/scripts/check-pr-title.test.ts
+++ b/tests/scripts/check-pr-title.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	MISSING_ISSUE_REF_MESSAGE,
 	MISSING_PREFIX_MESSAGE,
 	lintPrTitle,
+	resolveLivePrTitle,
 } from "../../scripts/check-pr-title.mjs";
+
+const payloadPr = {
+	number: 2083,
+	title: "fix: stale payload title",
+	body: "Refs #2083",
+};
 
 describe("PR title lint (#1844)", () => {
 	it("accepts a conventional prefix with an issue ref in the title", () => {
@@ -69,5 +76,63 @@ describe("PR title lint (#1844)", () => {
 		expect(lintPrTitle("fix: repair cache #123")).toMatchObject({
 			valid: true,
 		});
+	});
+});
+
+describe("live PR title resolution (#2083)", () => {
+	it("uses the live title when it differs from the event payload", async () => {
+		process.env.GITHUB_API_URL = "https://api.github.test";
+		process.env.GITHUB_REPOSITORY = "apmantza/pi-lens";
+		process.env.GITHUB_TOKEN = "test-token";
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({ title: "fix: current title (refs #2083)" }),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			),
+		);
+
+		const title = await resolveLivePrTitle(payloadPr, fetchImpl);
+		expect(title).toBe("fix: current title (refs #2083)");
+		expect(lintPrTitle(title).valid).toBe(true);
+		expect(fetchImpl).toHaveBeenCalledWith(
+			"https://api.github.test/repos/apmantza/pi-lens/pulls/2083",
+			expect.objectContaining({
+				headers: {
+					Authorization: "Bearer test-token",
+					Accept: "application/vnd.github+json",
+				},
+			}),
+		);
+	});
+
+	it("uses the live invalid title instead of a compliant payload title", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ title: "needs a prefix (#2083)" }), {
+				status: 200,
+			}),
+		);
+
+		const title = await resolveLivePrTitle(
+			{ ...payloadPr, title: "fix: payload title (refs #2083)" },
+			fetchImpl,
+		);
+		expect(title).toBe("needs a prefix (#2083)");
+		expect(lintPrTitle(title).valid).toBe(false);
+	});
+
+	it("falls back to the payload title and warns when fetching fails", async () => {
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+
+		await expect(resolveLivePrTitle(payloadPr, fetchImpl)).resolves.toBe(
+			payloadPr.title,
+		);
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining("network down"),
+		);
+		warning.mockRestore();
 	});
 });

--- a/tests/scripts/check-pr-title.test.ts
+++ b/tests/scripts/check-pr-title.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	MISSING_ISSUE_REF_MESSAGE,
 	MISSING_PREFIX_MESSAGE,
@@ -11,6 +11,10 @@ const payloadPr = {
 	title: "fix: stale payload title",
 	body: "Refs #2083",
 };
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
 
 describe("PR title lint (#1844)", () => {
 	it("accepts a conventional prefix with an issue ref in the title", () => {
@@ -81,9 +85,9 @@ describe("PR title lint (#1844)", () => {
 
 describe("live PR title resolution (#2083)", () => {
 	it("uses the live title when it differs from the event payload", async () => {
-		process.env.GITHUB_API_URL = "https://api.github.test";
-		process.env.GITHUB_REPOSITORY = "apmantza/pi-lens";
-		process.env.GITHUB_TOKEN = "test-token";
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
 		const fetchImpl = vi.fn().mockResolvedValue(
 			new Response(
 				JSON.stringify({ title: "fix: current title (refs #2083)" }),
@@ -109,6 +113,9 @@ describe("live PR title resolution (#2083)", () => {
 	});
 
 	it("uses the live invalid title instead of a compliant payload title", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
 		const fetchImpl = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ title: "needs a prefix (#2083)" }), {
 				status: 200,
@@ -124,6 +131,9 @@ describe("live PR title resolution (#2083)", () => {
 	});
 
 	it("falls back to the payload title and warns when fetching fails", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
 		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
 
@@ -134,5 +144,62 @@ describe("live PR title resolution (#2083)", () => {
 			expect.stringContaining("network down"),
 		);
 		warning.mockRestore();
+	});
+
+	it("falls back with an annotation when GitHub returns a non-2xx response", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValue(new Response("forbidden", { status: 403 }));
+
+		await expect(resolveLivePrTitle(payloadPr, fetchImpl)).resolves.toBe(
+			payloadPr.title,
+		);
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining("::warning::"),
+		);
+		expect(warning).toHaveBeenCalledWith(expect.stringContaining("HTTP 403"));
+	});
+
+	it("falls back with an annotation when the response has no string title", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify({ title: 2083 }), { status: 200 }),
+			);
+
+		await expect(resolveLivePrTitle(payloadPr, fetchImpl)).resolves.toBe(
+			payloadPr.title,
+		);
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining("::warning::"),
+		);
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining("response has no title"),
+		);
+	});
+
+	it("falls back with an annotation when GITHUB_TOKEN is unset", async () => {
+		vi.stubEnv("GITHUB_TOKEN", "");
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = vi.fn();
+
+		await expect(resolveLivePrTitle(payloadPr, fetchImpl)).resolves.toBe(
+			payloadPr.title,
+		);
+		expect(fetchImpl).not.toHaveBeenCalled();
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining("::warning::"),
+		);
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining("GITHUB_TOKEN is missing"),
+		);
 	});
 });


### PR DESCRIPTION
## What changed / why

The PR-title entry point now uses the event payload only for the pull-request number, fetches the live title from GitHub with `globalThis.fetch`, and lints that title. Fetch failures (including non-2xx, network errors, missing token, or malformed responses) emit one warning and fall back to the payload title. The existing `lintPrTitle(title, _body)` rules are unchanged.

This fixes reruns replaying an old title snapshot after the PR title has been corrected.

## Verification

- `npm run build`
- `npm test -- --run tests/scripts/check-pr-title.test.ts` — 12 passed
- `npm run lint`
- `npm run fmt:check`
- `git diff --check`
- Pre-push build and targeted test — 12 passed
- `actionlint` was not installed locally.

Red-first output from the pre-fix run:

> TypeError: resolveLivePrTitle is not a function
>
> Test Files 1 failed (1)
> Tests 3 failed | 9 passed (12)

A real rerun-heal can only be proven on a live PR; that is the CI-confirm step and remains to be observed after this PR is opened.

## Class sweep

- `scripts/check-pr-title.mjs`: fixed here; it no longer validates the stale payload title and fetches the live title.
- `scripts/check-close-keywords.mjs` / `.github/workflows/close-keyword-verification.yml`: the script reads `pull_request.body` from the closed-event payload. A post-merge rerun after body edits could replay stale close-keyword syntax; this is a separate follow-up because the workflow also verifies issue state and this change is scoped to the title check.
- `.github/workflows/osv-scan.yml`: `pull_request.base.sha` and `pull_request.head.sha` are commit identities used for checkout/diff, not mutable PR title/body/labels/base metadata; no rerun-replay defect found.
- No other `pull_request.title`, `pull_request.labels`, or mutable PR-body readers were found under `.github/workflows/` and `scripts/`.

## Blast radius

The new job permission is read-only: `pull-requests: read`, alongside its existing `contents: read`. For fork PRs, `github.token` is read-only, which is sufficient for this GET and does not grant write access.

## Observability

When live resolution degrades, the one-line `PR title live fetch failed: ...; using event payload title` warning is the record. The resolver tests cover a live compliant title replacing an invalid payload, a live invalid title replacing a compliant payload, and fetch-failure fallback.
## Fix round 1

- F2 — resolved: added injected-fetcher unit coverage for 403/non-2xx, 2xx JSON without a string title, and an unset `GITHUB_TOKEN`; each asserts annotated fallback behavior.
- F3 — resolved: replaced direct environment mutation with `vi.stubEnv` and added `afterEach(() => vi.unstubAllEnvs())`; the inverse live-title test passes in isolation.
- F4 — resolved: added `AbortSignal.timeout(10_000)` to the live fetch and `timeout-minutes: 5` to the `pr-title-lint` job.
- F5 — resolved: fallback warnings now use the Actions `::warning::` annotation while retaining the plain message text.

Mutation-red snippets (each test failed when its guard was neutered):

```text
F2 non-2xx guard removed: expected warning containing HTTP 403; received JSON parse fallback.
F2 response-title guard removed: expected payload fallback; received numeric title 2083.
F2 missing-token guard removed: expected GITHUB_TOKEN is missing; reached the later URL guard.
```

The refs #2083 live rerun-heal proof remains the named remainder for CI/live verification.