### PR TITLE
perf(word-index): move snapshot serialization off the main thread (refs #2068)

### DIFF
--- a/.changelog/fix-2068-offthread-index-serialize.md
+++ b/.changelog/fix-2068-offthread-index-serialize.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Move word-index snapshot serialization off the main thread (refs #2068)** — Per-edit persistence now structured-clones the live index and derives its wire snapshot in the existing snapshot worker.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2288,3 +2288,11 @@ once, then use `normalizeEphemeralMapKey` because their keys are already
 canonical and process-local. `detectRunner` hoists the outer availability-map
 lookup before the runner loop and uses the nested plain `Map`; glob-cache
 lookups use one `get`, not `has` plus `get`. (#2048)
+
+**Word-index persistence serializes in the snapshot worker (#2068).** The
+per-edit writer passes the live index as `wordIndexForWorker`; it must not call
+`serializeWordIndex` before `saveProjectSnapshot`. The worker's structured
+clone is the capture boundary, so edits after scheduling cannot affect the
+captured wire form. Keep the posting-entry shape and #2082 serializer bridge
+composable; the parent-thread serialize counter is a regression guard, not
+production telemetry.

--- a/clients/gzip-stage-write.ts
+++ b/clients/gzip-stage-write.ts
@@ -158,6 +158,7 @@ export function serveGzipStageWorker<
 >(
 	buildBaseResult: (request: Req) => Base,
 	options?: {
+		prepareData?: (request: Req) => unknown;
 		semanticFingerprint?: (request: Req, json: string) => string;
 		skipIfFingerprints?: (request: Req) => readonly string[] | undefined;
 	},
@@ -174,7 +175,7 @@ export function serveGzipStageWorker<
 			try {
 				const fingerprint = options?.semanticFingerprint;
 				const metrics = await writeGzipStageFile(
-					request.data,
+					options?.prepareData?.(request) ?? request.data,
 					request.stagePath,
 					request.testDelayMs,
 					{

--- a/clients/project-snapshot-persist-worker.ts
+++ b/clients/project-snapshot-persist-worker.ts
@@ -4,6 +4,7 @@ import {
 	serveGzipStageWorker,
 } from "./gzip-stage-write.js";
 import { fingerprintProjectSnapshotJson } from "./project-snapshot-fingerprint.js";
+import { serializeWordIndex, type WordIndex } from "./word-index.js";
 
 /**
  * Worker-thread persist for the project snapshot BODY (#958 item 2). The parent
@@ -19,6 +20,8 @@ import { fingerprintProjectSnapshotJson } from "./project-snapshot-fingerprint.j
 export interface ProjectSnapshotPersistWorkerRequest extends GzipStageWorkerRequest {
 	/** Last body digest known to have reached canonical storage. */
 	priorFingerprints?: string[];
+	/** Live index captured by postMessage; serialized only inside this worker. */
+	wordIndexForWorker?: WordIndex;
 }
 
 export type ProjectSnapshotPersistWorkerResult = GzipStageWorkerResult;
@@ -50,6 +53,15 @@ serveGzipStageWorker<
 		stagePath: request.stagePath,
 	}),
 	{
+		prepareData: (request) => {
+			const snapshotRequest = request as ProjectSnapshotPersistWorkerRequest;
+			return snapshotRequest.wordIndexForWorker
+				? {
+						...(snapshotRequest.data as Record<string, unknown>),
+						wordIndex: serializeWordIndex(snapshotRequest.wordIndexForWorker),
+					}
+				: snapshotRequest.data;
+		},
 		semanticFingerprint: semanticSnapshotFingerprint,
 		skipIfFingerprints: (request) => request.priorFingerprints,
 	},

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -25,6 +25,7 @@ import type { StartupScanContext } from "./startup-scan.js";
 import {
 	deserializeWordIndex,
 	serializeWordIndex,
+	type WordIndex,
 	type SerializedWordIndex,
 } from "./word-index.js";
 
@@ -893,6 +894,7 @@ interface PendingSnapshotBody {
 	generation: number;
 	durablePersist?: SnapshotPersistRecord;
 	dedupeFingerprints: string[];
+	wordIndexForWorker?: WordIndex;
 }
 
 interface SnapshotPersistRecord {
@@ -1263,7 +1265,7 @@ function reconcileAuthoritativeAfterWrite(
 	// shared reference is unsafe: ProjectSnapshot stores serialized arrays while
 	// WordIndex owns mutable Map/PathKeyedMap state. Drop the authoritative copy
 	// after publication; later merge-writers rehydrate the canonical disk body.
-	if (pending.snapshot.wordIndex) {
+	if (pending.snapshot.wordIndex || pending.wordIndexForWorker) {
 		try {
 			const stat = fs.statSync(pending.gzPath);
 			cacheParsedSnapshot(pending.gzPath, {
@@ -1368,7 +1370,13 @@ function writeSnapshotBodyOnMainThread(
 	}
 	try {
 		const serializeStarted = performance.now();
-		const json = JSON.stringify(pending.snapshot);
+		const snapshotForWrite = pending.wordIndexForWorker
+			? {
+					...pending.snapshot,
+					wordIndex: serializeWordIndex(pending.wordIndexForWorker),
+				}
+			: pending.snapshot;
+		const json = JSON.stringify(snapshotForWrite);
 		const serializeMs = performance.now() - serializeStarted;
 		const rawBytes = Buffer.byteLength(json);
 		const fingerprint = fingerprintProjectSnapshotJson(
@@ -1593,6 +1601,7 @@ function dispatchSnapshotPersist(pending: PendingSnapshotBody): void {
 		stagePath: pending.stagePath,
 		data: pending.snapshot,
 		priorFingerprints: pending.dedupeFingerprints,
+		wordIndexForWorker: pending.wordIndexForWorker,
 		testDelayMs:
 			process.env.NODE_ENV === "test"
 				? Number(process.env.PI_LENS_TEST_SNAPSHOT_PERSIST_WORKER_DELAY_MS) ||
@@ -1759,6 +1768,7 @@ function ensureSnapshotPersistExitHook(): void {
 export function saveProjectSnapshot(
 	cwd: string,
 	snapshot: ProjectSnapshot,
+	options?: { wordIndexForWorker?: WordIndex },
 ): void {
 	const gzPath = getProjectSnapshotPath(cwd);
 	const legacyPath = getProjectSnapshotLegacyPath(cwd);
@@ -1841,6 +1851,7 @@ export function saveProjectSnapshot(
 		generation,
 		durablePersist: priorPersist,
 		dedupeFingerprints: baselines.fingerprints,
+		wordIndexForWorker: options?.wordIndexForWorker,
 	};
 	sweepStaleSnapshotStageFiles(cacheDir);
 	ensureSnapshotPersistExitHook();

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -1464,8 +1464,41 @@ export interface SerializedWordIndex {
 /** Persisted word-index serialization format version. Bump on breaking format changes. */
 export const WORD_INDEX_FORMAT_VERSION = 2;
 
+let serializeWordIndexCallCount = 0;
+
+type PathMapLike<V> = {
+	keys?: () => IterableIterator<string>;
+	get?: (key: string) => V | undefined;
+};
+
+function pathMapEntries<V>(map: PathMapLike<V>): Array<[string, V]> {
+	const cloned = map as PathMapLike<V> & {
+		store?: Map<string, { displayPath: string; value: V }>;
+	};
+	if (cloned.store instanceof Map)
+		return [...cloned.store.values()].map((entry) => [
+			entry.displayPath,
+			entry.value,
+		]);
+	if (!map.keys || !map.get) return [];
+	return [...map.keys()].map((key) => [key, map.get!(key)!]);
+}
+
+function pathMapGet<V>(map: PathMapLike<V>, key: string): V | undefined {
+	const cloned = map as PathMapLike<V> & {
+		store?: Map<string, { displayPath: string; value: V }>;
+	};
+	if (cloned.store instanceof Map) {
+		for (const entry of cloned.store.values())
+			if (entry.displayPath === key) return entry.value;
+		return undefined;
+	}
+	return map.get?.(key);
+}
+
 export function serializeWordIndex(index: WordIndex): SerializedWordIndex {
-	const files = [...index.docLengths.keys()];
+	serializeWordIndexCallCount++;
+	const files = pathMapEntries(index.docLengths).map(([file]) => file);
 	const fileIndex = new Map<string, number>();
 	files.forEach((file, i) => fileIndex.set(file, i));
 
@@ -1484,7 +1517,7 @@ export function serializeWordIndex(index: WordIndex): SerializedWordIndex {
 		index.forward
 			? files.map((file, i) => [
 					i,
-					[...(index.forward!.get(file) ?? new Map()).entries()],
+					[...(pathMapGet(index.forward!, file) ?? new Map()).entries()],
 				])
 			: undefined;
 
@@ -1499,6 +1532,36 @@ export function serializeWordIndex(index: WordIndex): SerializedWordIndex {
 		fileMtimes: files.map((file) => index.fileMtimes.get(file) ?? 0),
 		fileSizes: files.map((file) => index.fileSizes.get(file) ?? 0),
 		forward,
+	};
+}
+
+export function getWordIndexSerializeCountForTests(): number {
+	return serializeWordIndexCallCount;
+}
+
+export function resetWordIndexSerializeCountForTests(): void {
+	serializeWordIndexCallCount = 0;
+}
+
+/**
+ * Make the small path-index structures cloneable for the snapshot worker.
+ * `postings` is intentionally left as its native Map so worker_threads clones
+ * its entries without a JavaScript posting walk on the caller thread.
+ */
+export function prepareWordIndexForWorker(index: WordIndex): WordIndex {
+	return {
+		...index,
+		docLengths: new Map(index.docLengths) as unknown as WordIndex["docLengths"],
+		fileMtimes: new Map(index.fileMtimes) as unknown as WordIndex["fileMtimes"],
+		fileSizes: new Map(index.fileSizes) as unknown as WordIndex["fileSizes"],
+		forward: index.forward
+			? (new Map(
+					[...index.forward.entries()].map(([file, counts]) => [
+						file,
+						new Map(counts),
+					]),
+				) as unknown as WordIndex["forward"])
+			: undefined,
 	};
 }
 
@@ -1774,8 +1837,9 @@ async function writeWordIndexSnapshot(
 			cachedExports: [],
 		};
 		snapshot.generatedAt = new Date().toISOString();
-		snapshot.wordIndex = serializeWordIndex(index);
-		saveProjectSnapshot(cwd, snapshot);
+		saveProjectSnapshot(cwd, snapshot, {
+			wordIndexForWorker: prepareWordIndexForWorker(index),
+		});
 		dbg?.(
 			`word-index persist: ${index.docCount} files, ${index.postings.size} tokens`,
 		);

--- a/tests/clients/word-index-persist-offthread.test.ts
+++ b/tests/clients/word-index-persist-offthread.test.ts
@@ -1,0 +1,49 @@
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	_resetProjectSnapshotParseCacheForTests,
+	resetProjectSnapshotPersistWorkerForTests,
+	waitForProjectSnapshotPersistsForTests,
+} from "../../clients/project-snapshot.js";
+import {
+	buildWordIndex,
+	flushWordIndexPersistsForTests,
+	getWordIndexSerializeCountForTests,
+	resetWordIndexSerializeCountForTests,
+	scheduleWordIndexPersist,
+	serializeWordIndex,
+} from "../../clients/word-index.js";
+import { deserializeWordIndex } from "../../clients/word-index.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+describe("word-index persist serialization", () => {
+	afterEach(() => {
+		delete process.env.PI_LENS_WORD_INDEX_PERSIST_DEBOUNCE_MS;
+		delete process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC;
+		resetWordIndexSerializeCountForTests();
+		resetProjectSnapshotPersistWorkerForTests();
+	});
+
+	it("does not iterate postings on the persist caller and remains byte-stable", async () => {
+		const env = setupTestEnvironment("word-index-persist-");
+		const cwd = path.join(env.tmpDir, "project");
+		try {
+			process.env.PI_LENS_WORD_INDEX_PERSIST_DEBOUNCE_MS = "0";
+			const index = buildWordIndex([
+				{ path: path.join(cwd, "a.ts"), content: "alpha beta\n" },
+				{ path: path.join(cwd, "b.ts"), content: "beta gamma\n" },
+			]);
+			resetWordIndexSerializeCountForTests();
+			scheduleWordIndexPersist(cwd, index);
+			flushWordIndexPersistsForTests();
+			expect(getWordIndexSerializeCountForTests()).toBe(0);
+			await waitForProjectSnapshotPersistsForTests();
+			const first = serializeWordIndex(index);
+			const loaded = deserializeWordIndex(first);
+			expect(loaded).not.toBeNull();
+			expect(serializeWordIndex(loaded!)).toEqual(first);
+		} finally {
+			env.cleanup();
+		}
+	});
+});

--- a/tests/clients/word-index-persist-offthread.test.ts
+++ b/tests/clients/word-index-persist-offthread.test.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-	_resetProjectSnapshotParseCacheForTests,
+	loadProjectSnapshot,
 	resetProjectSnapshotPersistWorkerForTests,
 	waitForProjectSnapshotPersistsForTests,
 } from "../../clients/project-snapshot.js";
@@ -12,6 +12,7 @@ import {
 	resetWordIndexSerializeCountForTests,
 	scheduleWordIndexPersist,
 	serializeWordIndex,
+	updateWordIndexDocument,
 } from "../../clients/word-index.js";
 import { deserializeWordIndex } from "../../clients/word-index.js";
 import { setupTestEnvironment } from "./test-utils.js";
@@ -36,13 +37,42 @@ describe("word-index persist serialization", () => {
 			resetWordIndexSerializeCountForTests();
 			scheduleWordIndexPersist(cwd, index);
 			flushWordIndexPersistsForTests();
+			await new Promise((resolve) => setTimeout(resolve, 100));
 			expect(getWordIndexSerializeCountForTests()).toBe(0);
 			await waitForProjectSnapshotPersistsForTests();
-			const first = serializeWordIndex(index);
+			const saved = loadProjectSnapshot(cwd);
+			const first = saved?.wordIndex;
 			const loaded = deserializeWordIndex(first);
 			expect(loaded).not.toBeNull();
 			expect(serializeWordIndex(loaded!)).toEqual(first);
 		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("captures the index before a concurrent edit mutates it", async () => {
+		const env = setupTestEnvironment("word-index-persist-race-");
+		const cwd = path.join(env.tmpDir, "project");
+		try {
+			process.env.PI_LENS_WORD_INDEX_PERSIST_DEBOUNCE_MS = "0";
+			process.env.PI_LENS_TEST_SNAPSHOT_PERSIST_WORKER_DELAY_MS = "100";
+			const filePath = path.join(cwd, "a.ts");
+			const index = buildWordIndex([
+				{ path: filePath, content: "alpha beta\n" },
+			]);
+			scheduleWordIndexPersist(cwd, index);
+			flushWordIndexPersistsForTests();
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			updateWordIndexDocument(index, {
+				path: filePath,
+				content: "alpha delta\n",
+			});
+			await waitForProjectSnapshotPersistsForTests();
+			const saved = deserializeWordIndex(loadProjectSnapshot(cwd)?.wordIndex);
+			expect(saved?.postings.get("beta")).toHaveLength(1);
+			expect(saved?.postings.get("delta")).toBeUndefined();
+		} finally {
+			delete process.env.PI_LENS_TEST_SNAPSHOT_PERSIST_WORKER_DELAY_MS;
 			env.cleanup();
 		}
 	});


### PR DESCRIPTION
## Summary

Move per-edit word-index snapshot serialization into the existing project-snapshot worker. The caller performs only a bounded document/metadata clone; native posting Maps are structured-cloned and `serializeWordIndex` runs in the worker. This PR references #2068 and is intended to merge after PR #2082.

Refs #2068

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:perf
- [x] area:project-intelligence
- [x] area:tests

## Checklist

- [x] Read CONTRIBUTING.md and AGENTS.md
- [x] Added regression coverage
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] Targeted `npm test` passes (75/75)
- [x] `npm run build:dist` passes
- [x] `npm run fmt:check` passes
- [x] AGENTS.md updated
- [x] Changelog fragment added

## What changed and why

Option (a) was selected. Incremental wire caching (option (b)) is unnecessary: the existing worker already owns stringify/gzip and can receive a cloneable capture of the live index. `PathKeyedMap` metadata is converted to Maps at the boundary; postings are not re-derived or iterated by parent-thread JavaScript. A fallback still serializes synchronously only when the worker is unavailable, preserving the existing degraded-path contract.

The worker capture is made before the persist returns, so an edit during worker serialization cannot mutate the captured index. Round-trip wire bytes remain stable.

## Tests

- `tests/clients/word-index-persist-offthread.test.ts`: count-based parent-thread serialization guard, persisted serialize/load/serialize byte stability, and concurrent-edit capture safety.
- Existing project-snapshot, MCP word-index eviction, MCP symbol-search, and tool symbol-search tests: 75/75 passed.

Measured test seam: before = 1 parent-thread `serializeWordIndex` invocation per forced word-index persist; after = 0. The after path records worker serialization, while the parent counter remains zero.

## Blast radius

`clients/word-index.ts` per-edit persistence and `clients/project-snapshot.ts` worker request plumbing are affected. `clients/gzip-stage-write.ts` gains an optional worker-side data preparation callback; existing review-graph callers remain unchanged. Consumer coverage includes project snapshot load/hydration and MCP/tool symbol search. No per-posting parent-thread loop remains on the normal persist path.

## Class sweep

Defect shape: main-thread serialization hidden before an already-offloaded snapshot stringify; analogous to #1976's one-changed-document-triggering-full-re-derivation and governed by #1740 event-loop discipline. Searched `serializeWordIndex`, `JSON.stringify`, and persist call sites under `clients/`; the review-graph `persistGraph` serializer is explicitly #2072/#2074 territory and is not claimed here.

## Observability

This PR does not add a second `persist_succeeded.durationMs` field. PR #2082 already adds that field along with `postingEntries` and replacement telemetry; after #2082 lands, its version remains the single observability seam. The existing worker persist metrics continue to report offloaded serialization timing.

## Composition with PR #2082

Merge order is **#2082 first, then this PR**. This change does not alter the posting-entry shape. Its worker serializer accepts the interned posting representation supplied by #2082, and its clone adapter preserves the file-table/shared-identity data. Resolve any overlapping serializer-bridge hunks by retaining #2082's bridge and this PR's worker-side invocation. Run #2082's test files on the locally merged tree.
