### PR TITLE
fix(ci): budget test forks against real memory (refs #2042)

### DIFF
--- a/.changelog/fix-2042-ci-memory-budget.md
+++ b/.changelog/fix-2042-ci-memory-budget.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Budget CI test workers against real memory, and name an OOM kill (refs #2042)** — Fork concurrency and the per-fork heap ceiling now come from one resolver that sizes them against the host's memory instead of two constants tuned on a dev host, and the CI suite runs under a memory watch that reports the low-water mark so exit 137 no longer reads as unattributable infrastructure noise.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,15 @@ jobs:
       - name: Ast-grep self-scan
         run: npm run astgrep:self-scan
 
+      # #2042: the size of the box the fork pool is budgeted against. The suite
+      # was OOM-killed here repeatedly and no log line said how much memory the
+      # runner actually had, so every diagnosis started from a guess.
+      - name: Runner capacity
+        run: |
+          echo "nproc=$(nproc)"
+          free -m
+          cat /sys/fs/cgroup/memory.max 2>/dev/null || true
+
       - name: Run tests
         env:
           # Spawn-heavy MCP smokes retain a 20s local deadline but need room
@@ -136,7 +145,12 @@ jobs:
           # never contention to serialize — skip it explicitly rather than
           # relying on it being harmless.
           PI_LENS_TEST_NO_LOCK: '1'
-        run: npm test
+        # #2042: the wrapper changes nothing about what runs and forwards the
+        # child's exit code unchanged. It prints the host's memory low-water
+        # mark and a verdict line, so the next `Killed npm test` / exit 137 —
+        # which carries no failing assertion and reads as infrastructure noise —
+        # arrives with a number attached.
+        run: node scripts/with-memory-watch.mjs -- npm test
 
   # Simulates pi's real install path: a `git:` install runs `npm install
   # --omit=dev`, which triggers `prepare` → `build:dist` FROM SOURCE with the

--- a/scripts/lib/memory-watch.d.mts
+++ b/scripts/lib/memory-watch.d.mts
@@ -1,0 +1,27 @@
+export interface MemorySample {
+	totalMb: number;
+	availableMb: number;
+	source: "meminfo" | "os";
+}
+
+export declare function readMemory(meminfoPath?: string): MemorySample;
+
+export declare function parseMeminfo(text: string): {
+	totalMb: number;
+	availableMb: number;
+	source: "meminfo";
+};
+
+export declare function shouldPrint(
+	sample: { availableMb: number },
+	state: {
+		lastPrintedMb: number | null;
+		thresholdMb: number;
+		stepMb: number;
+	},
+): boolean;
+
+export declare function formatVerdict(
+	exit: { code: number | null; signal: string | null },
+	watch: { totalMb: number; lowWaterMb: number; lowWaterAt: string | null },
+): string;

--- a/scripts/lib/memory-watch.mjs
+++ b/scripts/lib/memory-watch.mjs
@@ -1,0 +1,92 @@
+// Sampling and formatting for `scripts/with-memory-watch.mjs` (#2042).
+//
+// Kept separate from the wrapper so the parsing and the print policy are unit
+// testable without spawning a child process.
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+
+const MB = 1024 * 1024;
+
+/**
+ * Available memory, in MB, as the OS reports it.
+ *
+ * `/proc/meminfo`'s MemAvailable is the number the Linux OOM killer's pressure
+ * actually tracks: `os.freemem()` excludes reclaimable page cache and reads
+ * alarmingly low on a healthy runner, which would make every sample look like
+ * an emergency. Fall back to `os.freemem()` off Linux, where this wrapper is
+ * only ever a no-op passthrough anyway.
+ *
+ * @param {string} [meminfoPath]
+ * @returns {{ totalMb: number, availableMb: number, source: "meminfo" | "os" }}
+ */
+export function readMemory(meminfoPath = "/proc/meminfo") {
+	try {
+		return parseMeminfo(fs.readFileSync(meminfoPath, "utf8"));
+	} catch {
+		return {
+			totalMb: Math.round(os.totalmem() / MB),
+			availableMb: Math.round(os.freemem() / MB),
+			source: "os",
+		};
+	}
+}
+
+/**
+ * @param {string} text
+ * @returns {{ totalMb: number, availableMb: number, source: "meminfo" }}
+ */
+export function parseMeminfo(text) {
+	const field = (name) => {
+		const match = new RegExp(`^${name}:\\s+(\\d+) kB$`, "m").exec(text);
+		if (!match) throw new Error(`meminfo has no ${name}`);
+		return Math.round(Number(match[1]) / 1024);
+	};
+	return {
+		totalMb: field("MemTotal"),
+		availableMb: field("MemAvailable"),
+		source: "meminfo",
+	};
+}
+
+/**
+ * Print policy. A sample every few seconds for a five-minute suite would bury
+ * the test output, so a sample is only worth a line when it says something new:
+ * the first one, a fall past the low-water threshold, or a big step down from
+ * the last line printed.
+ *
+ * @param {{ availableMb: number }} sample
+ * @param {{ lastPrintedMb: number | null, thresholdMb: number, stepMb: number }} state
+ * @returns {boolean}
+ */
+export function shouldPrint(sample, state) {
+	if (state.lastPrintedMb === null) return true;
+	if (sample.availableMb <= state.thresholdMb) return true;
+	return state.lastPrintedMb - sample.availableMb >= state.stepMb;
+}
+
+/**
+ * The verdict line. Exit 137 with no failing assertion is the whole problem
+ * this wrapper exists for: on its own it reads as infrastructure noise and
+ * costs a judged rerun. Naming the low-water mark turns it into a claim about
+ * memory that the next reader can act on.
+ *
+ * @param {{ code: number | null, signal: string | null }} exit
+ * @param {{ totalMb: number, lowWaterMb: number, lowWaterAt: string | null }} watch
+ * @returns {string}
+ */
+export function formatVerdict(exit, watch) {
+	const status =
+		exit.signal !== null
+			? `signal=${exit.signal}`
+			: `exitCode=${exit.code ?? "null"}`;
+	const oomShaped = exit.signal === "SIGKILL" || exit.code === 137;
+	const head = oomShaped
+		? "[mem-watch] KILLED — no failing assertion means the OS reclaimed memory, not a test failure."
+		: "[mem-watch] done.";
+	return (
+		`${head} ${status} totalMb=${watch.totalMb} ` +
+		`lowWaterAvailableMb=${watch.lowWaterMb}` +
+		(watch.lowWaterAt ? ` lowWaterAt=${watch.lowWaterAt}` : "")
+	);
+}

--- a/scripts/lib/worker-budget.d.mts
+++ b/scripts/lib/worker-budget.d.mts
@@ -1,0 +1,30 @@
+export declare const WORKER_PEAK_RSS_BUDGET_MB: number;
+export declare const NON_WORKER_RESERVE_MB: number;
+export declare const LOCAL_MAX_WORKERS: string;
+export declare const MAX_WORKER_HEAP_MB: number;
+export declare const MIN_WORKER_HEAP_MB: number;
+
+export interface TestWorkerHost {
+	totalMemMb: number;
+	cpus: number;
+	ci: boolean;
+	workerOverride?: number;
+	heapOverride?: number;
+}
+
+export interface TestWorkerBudget {
+	maxWorkers: number | string;
+	heavyMaxWorkers: number;
+	heapMb: number;
+	cpuCap: number;
+	memCap: number;
+}
+
+export declare function resolveTestWorkerBudget(
+	host: TestWorkerHost,
+): TestWorkerBudget;
+
+export declare function formatTestWorkerBudget(
+	host: { totalMemMb: number; cpus: number },
+	budget: TestWorkerBudget,
+): string;

--- a/scripts/lib/worker-budget.mjs
+++ b/scripts/lib/worker-budget.mjs
@@ -1,0 +1,121 @@
+// Single source of truth for how many Vitest forks may run at once, and how
+// much V8 heap each one gets. `vitest.config.ts` calls this; nothing else
+// computes those numbers.
+//
+// #2042. The suite was OOM-killed on ubuntu-latest (exit 137, SIGKILL, zero
+// failing assertions). Two host-specific constants were applied unconditionally
+// to CI:
+//
+//   - `maxWorkers` was left undefined on CI, so Vitest resolved it to
+//     `availableParallelism() - 1`. That bounds worker COUNT, which is not the
+//     axis that grows.
+//   - `--max-old-space-size=4096` was tuned on a 32-core / 68 GB dev host, with
+//     the comment "4 GB x workers << host RAM". On a shared CI runner that
+//     inequality does not hold.
+//
+// Measured on 2026-08-25 with a per-file `process.resourceUsage().maxRSS` probe
+// over all 740 files of the default project. Peak RSS per file: p50 93 MB, p90
+// 389 MB, p99 1405 MB, max 2267 MB, and 42 files above 1 GB. That tail is
+// NATIVE memory, not V8 heap -- `tree-sitter-imports.test.ts` peaked at 1601 MB
+// RSS while reporting 33 MB heapUsed, because tree-sitter wasm grammar compiles
+// and @ast-grep/napi arenas live outside V8's accounting. So
+// `--max-old-space-size` cannot bound the growing axis, and `maxWorkers` bounds
+// the wrong one. Dividing the host's real memory by a measured per-worker peak
+// is the lever that fits.
+
+/**
+ * Per-worker peak-RSS budget, in MB: the measured p99 (1405 MB) rounded up to
+ * the next power of two. A worker that exceeds it is a tail file, and the point
+ * of the budget is that the host can still hold `maxWorkers` of them at once.
+ */
+export const WORKER_PEAK_RSS_BUDGET_MB = 2048;
+
+/**
+ * Memory the run needs OUTSIDE the forks: Vitest's own main process (it holds
+ * the module graph and per-file reporter state for 740 files, measured above
+ * 1 GB), npm, and the real tool and LSP child processes the suite spawns, plus
+ * OS headroom.
+ */
+export const NON_WORKER_RESERVE_MB = 3072;
+
+/** Local default, unchanged from the pre-#2042 measured posture. */
+export const LOCAL_MAX_WORKERS = "50%";
+
+/** Per-fork V8 heap ceiling on a host with room for it (pre-#2042 value). */
+export const MAX_WORKER_HEAP_MB = 4096;
+
+/**
+ * Floor for the per-fork V8 heap ceiling. NOT a memory-budget number -- it is a
+ * correctness constraint: the heaviest file measured 2067 MB of live V8 heap
+ * (`tests/monorepo/cross-package-graph.test.ts`), so a ceiling near or below
+ * that turns a green suite red. The budget below may never go under it.
+ */
+export const MIN_WORKER_HEAP_MB = 3072;
+
+/**
+ * @param {{ totalMemMb: number, cpus: number, ci: boolean, workerOverride?: number, heapOverride?: number }} host
+ * @returns {{ maxWorkers: number | string, heavyMaxWorkers: number, heapMb: number, cpuCap: number, memCap: number }}
+ */
+export function resolveTestWorkerBudget(host) {
+	const { totalMemMb, cpus, ci, workerOverride, heapOverride } = host;
+
+	// Vitest's own default for a non-watch run, reproduced here so the memory
+	// budget can only ever LOWER the concurrency, never raise it.
+	const cpuCap = Math.max(1, cpus - 1);
+	const memCap = Math.max(
+		1,
+		Math.floor(
+			(totalMemMb - NON_WORKER_RESERVE_MB) / WORKER_PEAK_RSS_BUDGET_MB,
+		),
+	);
+
+	const ciWorkers = Math.min(cpuCap, memCap);
+	const maxWorkers = ci ? ciWorkers : workerOverride || LOCAL_MAX_WORKERS;
+
+	// The heavy phase's files each peaked at 1.4-3.9 GB, above the general
+	// budget, so it runs at half the general concurrency (floor 1). Locally that
+	// still lands on the pre-#2042 cap of 2 on any host with >= 6 cores.
+	const heavyMaxWorkers = ci
+		? Math.max(1, Math.floor(ciWorkers / 2))
+		: Math.max(1, Math.min(2, Math.floor(cpus / 2)));
+
+	// Per-fork V8 heap ceiling: aim at half the host's memory shared between the
+	// concurrent forks, then clamp. The clamp usually wins, and that is the
+	// honest picture — one real file holds 2067 MB of live heap, so the floor
+	// cannot go much lower without turning a green suite red. What the aim buys
+	// is the CI case: a 16 GB runner resolves to 3072 instead of the flat 4096
+	// tuned on a 68 GB dev host, which is a quarter off the permitted aggregate
+	// and, more usefully, makes a runaway fork die on its OWN heap limit — with
+	// Node's report naming the file — before the OS kills the whole run.
+	//
+	// CI only. A local run keeps the pre-#2042 4096 outright: the dev host it
+	// was measured on is the one host where the original reasoning holds, and
+	// #2042 is a CI failure that has no business changing what a developer runs.
+	const heapMb =
+		heapOverride ||
+		(ci
+			? Math.max(
+					MIN_WORKER_HEAP_MB,
+					Math.min(MAX_WORKER_HEAP_MB, Math.floor(totalMemMb / 2 / ciWorkers)),
+				)
+			: MAX_WORKER_HEAP_MB);
+
+	return { maxWorkers, heavyMaxWorkers, heapMb, cpuCap, memCap };
+}
+
+/**
+ * One line, on CI only, naming the host and the decision. Without it an exit
+ * 137 says nothing about what the run was allowed to use.
+ *
+ * @param {{ totalMemMb: number, cpus: number }} host
+ * @param {{ maxWorkers: number | string, heavyMaxWorkers: number, heapMb: number, cpuCap: number, memCap: number }} budget
+ * @returns {string}
+ */
+export function formatTestWorkerBudget(host, budget) {
+	return (
+		`[test-budget] cpus=${host.cpus} totalMemMb=${host.totalMemMb} ` +
+		`cpuCap=${budget.cpuCap} memCap=${budget.memCap} ` +
+		`maxWorkers=${budget.maxWorkers} heavyMaxWorkers=${budget.heavyMaxWorkers} ` +
+		`workerHeapMb=${budget.heapMb}`
+	);
+}

--- a/scripts/lib/worker-budget.mjs
+++ b/scripts/lib/worker-budget.mjs
@@ -22,6 +22,17 @@
 // `--max-old-space-size` cannot bound the growing axis, and `maxWorkers` bounds
 // the wrong one. Dividing the host's real memory by a measured per-worker peak
 // is the lever that fits.
+//
+// PROVENANCE OF THOSE NUMBERS, because it matters for how much to trust them:
+// they were measured on the DEV host (Windows, 16 cores, 15.6 GB), not on the
+// runner. The first `[mem-file]` lines from CI show Linux running roughly three
+// times leaner on the same files -- `tree-sitter-imports.test.ts` peaks at
+// 580 MB there against 1601 MB here, and 7 files clear 512 MB on CI against 42
+// clearing 1 GB on the dev host. So WORKER_PEAK_RSS_BUDGET_MB is conservative
+// against the profile it actually governs: it reserves more per worker than a
+// CI fork needs, which errs toward fewer workers. That is the safe direction,
+// but it is an unvalidated constant on Linux, and it should be re-derived from
+// accumulated `[mem-file]` data rather than treated as settled.
 
 /**
  * Per-worker peak-RSS budget, in MB: the measured p99 (1405 MB) rounded up to
@@ -73,11 +84,10 @@ export function resolveTestWorkerBudget(host) {
 	const maxWorkers = ci ? ciWorkers : workerOverride || LOCAL_MAX_WORKERS;
 
 	// The heavy phase's files each peaked at 1.4-3.9 GB, above the general
-	// budget, so it runs at half the general concurrency (floor 1). Locally that
-	// still lands on the pre-#2042 cap of 2 on any host with >= 6 cores.
-	const heavyMaxWorkers = ci
-		? Math.max(1, Math.floor(ciWorkers / 2))
-		: Math.max(1, Math.min(2, Math.floor(cpus / 2)));
+	// budget, so on CI it runs at half the general concurrency (floor 1). Locally
+	// it stays the plain pre-#2042 literal 2: deriving it from core count bought
+	// nothing and silently changed the local posture to 1 on a 1-3 core box.
+	const heavyMaxWorkers = ci ? Math.max(1, Math.floor(ciWorkers / 2)) : 2;
 
 	// Per-fork V8 heap ceiling: aim at half the host's memory shared between the
 	// concurrent forks, then clamp. The clamp usually wins, and that is the

--- a/scripts/with-memory-watch.mjs
+++ b/scripts/with-memory-watch.mjs
@@ -27,8 +27,29 @@
  */
 
 import { spawn } from "node:child_process";
+import * as fs from "node:fs";
 import * as os from "node:os";
 import { formatVerdict, readMemory, shouldPrint } from "./lib/memory-watch.mjs";
+
+/**
+ * Every line this wrapper emits goes through a BLOCKING write to fd 1, never
+ * `process.stdout.write`.
+ *
+ * When stdout is a pipe, Node buffers writes and flushes them asynchronously,
+ * and `process.exit()` discards whatever is still queued. A reader that has
+ * fallen behind — a log collector under memory pressure, which is precisely the
+ * scenario this file exists for — fills the pipe, so the verdict line is queued
+ * rather than written, and then thrown away microseconds later. The #2093
+ * review reproduced that 3/3 on Linux with a slow reader: correct exit code, no
+ * verdict line. `fs.writeSync` blocks until the bytes reach the OS, so the
+ * record survives.
+ *
+ * Node writes to pipes synchronously on Windows and asynchronously on Linux, so
+ * this only ever went wrong on the platform CI runs on.
+ */
+function emit(line) {
+	fs.writeSync(1, line);
+}
 
 const separator = process.argv.indexOf("--");
 const command = separator === -1 ? [] : process.argv.slice(separator + 1);
@@ -44,7 +65,7 @@ const thresholdMb = Number(process.env.PI_LENS_MEM_WATCH_LOW_MB) || 1024;
 const stepMb = Number(process.env.PI_LENS_MEM_WATCH_STEP_MB) || 1024;
 
 const first = readMemory();
-process.stdout.write(
+emit(
 	`[mem-watch] host cpus=${os.availableParallelism?.() ?? os.cpus().length} ` +
 		`totalMb=${first.totalMb} availableMb=${first.availableMb} ` +
 		`source=${first.source} intervalMs=${intervalMs}\n`,
@@ -66,7 +87,7 @@ const timer = setInterval(() => {
 	}
 	if (shouldPrint(sample, state)) {
 		state.lastPrintedMb = sample.availableMb;
-		process.stdout.write(
+		emit(
 			`[mem-watch] ${at} availableMb=${sample.availableMb} of ${sample.totalMb}\n`,
 		);
 	}
@@ -74,6 +95,11 @@ const timer = setInterval(() => {
 // The watcher must never be the reason the process stays alive.
 timer.unref?.();
 
+// CI-only, and CI is Linux. The win32 branch is a courtesy for running the
+// wrapper by hand on a dev box: Windows cannot exec `npm` without a shell, and
+// `shell: true` concatenates rather than escapes the arguments, so a path with
+// a space or a shell metacharacter would be mis-parsed. Do not build a Windows
+// job on this.
 const child = spawn(command[0], command.slice(1), {
 	stdio: "inherit",
 	shell: process.platform === "win32",
@@ -87,7 +113,7 @@ child.on("error", (error) => {
 
 child.on("exit", (code, signal) => {
 	clearInterval(timer);
-	process.stdout.write(`${formatVerdict({ code, signal }, watch)}\n`);
+	emit(`${formatVerdict({ code, signal }, watch)}\n`);
 	// Re-raising the signal would make this wrapper's own death the story. Map
 	// it to the shell's 128+n instead, which is the code CI already reports.
 	if (signal) process.exit(128 + (os.constants.signals[signal] ?? 0));

--- a/scripts/with-memory-watch.mjs
+++ b/scripts/with-memory-watch.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * scripts/with-memory-watch.mjs (#2042)
+ *
+ * Runs a command while sampling host memory, so an OOM kill leaves evidence.
+ *
+ * The problem it solves is not memory use, it is memory ATTRIBUTION. The CI
+ * Unit-tests job was SIGKILLed repeatedly with `Killed npm test` and exit 137
+ * and zero failing assertions. That output names no file, no process, and no
+ * number, so every occurrence reads as infrastructure noise and costs a judged
+ * rerun. This wrapper prints the host's memory low-water mark and a verdict
+ * line, so the next exit 137 is a claim about memory that a reader can check.
+ *
+ * It never changes what runs, and it forwards the child's exit code and signal
+ * unchanged -- a killed run still fails the job.
+ *
+ * Usage:
+ *   node scripts/with-memory-watch.mjs -- <command> [args...]
+ *
+ * Env:
+ *   PI_LENS_MEM_WATCH_INTERVAL_MS   Sampling period (default 2000).
+ *   PI_LENS_MEM_WATCH_LOW_MB        Print every sample at or below this many
+ *                                   MB available (default 1024).
+ *   PI_LENS_MEM_WATCH_STEP_MB       Print when available memory has fallen this
+ *                                   far since the last printed line
+ *                                   (default 1024).
+ */
+
+import { spawn } from "node:child_process";
+import * as os from "node:os";
+import { formatVerdict, readMemory, shouldPrint } from "./lib/memory-watch.mjs";
+
+const separator = process.argv.indexOf("--");
+const command = separator === -1 ? [] : process.argv.slice(separator + 1);
+if (command.length === 0) {
+	process.stderr.write(
+		"usage: node scripts/with-memory-watch.mjs -- <command> [args...]\n",
+	);
+	process.exit(2);
+}
+
+const intervalMs = Number(process.env.PI_LENS_MEM_WATCH_INTERVAL_MS) || 2000;
+const thresholdMb = Number(process.env.PI_LENS_MEM_WATCH_LOW_MB) || 1024;
+const stepMb = Number(process.env.PI_LENS_MEM_WATCH_STEP_MB) || 1024;
+
+const first = readMemory();
+process.stdout.write(
+	`[mem-watch] host cpus=${os.availableParallelism?.() ?? os.cpus().length} ` +
+		`totalMb=${first.totalMb} availableMb=${first.availableMb} ` +
+		`source=${first.source} intervalMs=${intervalMs}\n`,
+);
+
+const watch = {
+	totalMb: first.totalMb,
+	lowWaterMb: first.availableMb,
+	lowWaterAt: null,
+};
+const state = { lastPrintedMb: null, thresholdMb, stepMb };
+
+const timer = setInterval(() => {
+	const sample = readMemory();
+	const at = new Date().toISOString().slice(11, 19);
+	if (sample.availableMb < watch.lowWaterMb) {
+		watch.lowWaterMb = sample.availableMb;
+		watch.lowWaterAt = at;
+	}
+	if (shouldPrint(sample, state)) {
+		state.lastPrintedMb = sample.availableMb;
+		process.stdout.write(
+			`[mem-watch] ${at} availableMb=${sample.availableMb} of ${sample.totalMb}\n`,
+		);
+	}
+}, intervalMs);
+// The watcher must never be the reason the process stays alive.
+timer.unref?.();
+
+const child = spawn(command[0], command.slice(1), {
+	stdio: "inherit",
+	shell: process.platform === "win32",
+});
+
+child.on("error", (error) => {
+	clearInterval(timer);
+	process.stderr.write(`[mem-watch] failed to spawn: ${error.message}\n`);
+	process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+	clearInterval(timer);
+	process.stdout.write(`${formatVerdict({ code, signal }, watch)}\n`);
+	// Re-raising the signal would make this wrapper's own death the story. Map
+	// it to the shell's 128+n instead, which is the code CI already reports.
+	if (signal) process.exit(128 + (os.constants.signals[signal] ?? 0));
+	process.exit(code ?? 1);
+});

--- a/scripts/with-memory-watch.mjs
+++ b/scripts/with-memory-watch.mjs
@@ -32,31 +32,32 @@ import * as os from "node:os";
 import { formatVerdict, readMemory, shouldPrint } from "./lib/memory-watch.mjs";
 
 /**
- * Every line this wrapper emits goes through a BLOCKING write to fd 1, never
- * `process.stdout.write`.
+ * Every line this wrapper emits goes through a BLOCKING write, never
+ * `process.stdout.write` or `process.stderr.write`.
  *
  * When stdout is a pipe, Node buffers writes and flushes them asynchronously,
  * and `process.exit()` discards whatever is still queued. A reader that has
  * fallen behind — a log collector under memory pressure, which is precisely the
  * scenario this file exists for — fills the pipe, so the verdict line is queued
  * rather than written, and then thrown away microseconds later. The #2093
- * review reproduced that 3/3 on Linux with a slow reader: correct exit code, no
- * verdict line. `fs.writeSync` blocks until the bytes reach the OS, so the
+ * review reproduced that 3/3 with a slow reader: correct exit code, no verdict
+ * line. On Linux, `fs.writeSync` blocks until the bytes reach the OS, so the
  * record survives.
  *
- * Node writes to pipes synchronously on Windows and asynchronously on Linux, so
- * this only ever went wrong on the platform CI runs on.
+ * On Windows this is NOT sufficient: pipe-buffered bytes can be discarded at
+ * process teardown even after `fs.writeSync` reports a complete write (the
+ * #2093 verify reproduced the loss post-fix, `ok bytes=86 of 86` and no line at
+ * the reader). That is a separate OS teardown behavior no write mechanism here
+ * closes. The wrapper's durability guarantee is CI-grade (Linux) only.
  */
-function emit(line) {
-	fs.writeSync(1, line);
+function emit(line, fd = 1) {
+	fs.writeSync(fd, line);
 }
 
 const separator = process.argv.indexOf("--");
 const command = separator === -1 ? [] : process.argv.slice(separator + 1);
 if (command.length === 0) {
-	process.stderr.write(
-		"usage: node scripts/with-memory-watch.mjs -- <command> [args...]\n",
-	);
+	emit("usage: node scripts/with-memory-watch.mjs -- <command> [args...]\n", 2);
 	process.exit(2);
 }
 
@@ -107,7 +108,7 @@ const child = spawn(command[0], command.slice(1), {
 
 child.on("error", (error) => {
 	clearInterval(timer);
-	process.stderr.write(`[mem-watch] failed to spawn: ${error.message}\n`);
+	emit(`[mem-watch] failed to spawn: ${error.message}\n`, 2);
 	process.exit(1);
 });
 

--- a/tests/config/module-instance-coverage.test.ts
+++ b/tests/config/module-instance-coverage.test.ts
@@ -38,6 +38,10 @@ const reviewedExceptions = new Map<string, string>([
 		"tests/config/timing-sensitive-coverage.test.ts -> vitest.config.ts",
 		"reads the live config source, not the stale compiled vitest.config.js",
 	],
+	[
+		"tests/config/worker-budget.test.ts -> vitest.config.ts",
+		"reads the live config source, not the stale compiled vitest.config.js",
+	],
 ]);
 
 describe("test imports bind the compiled module instance (#1565)", () => {

--- a/tests/config/worker-budget.test.ts
+++ b/tests/config/worker-budget.test.ts
@@ -282,8 +282,13 @@ describe("vitest.config.ts wiring (#2042)", () => {
 		}
 	});
 
-	it("leaves a local run on the pre-#2042 posture", () => {
-		const budget = resolveTestWorkerBudget({ ...currentHost(), ci: false });
+	it("matches the resolver on whatever host is running it", () => {
+		// The ambient resolution, CI or not. Deliberately NOT forced to `ci: false`
+		// — the config reads the real `process.env.CI`, so pinning the expectation
+		// to the local branch asserts a posture the config was never asked for and
+		// fails on CI (it did, run 32899910007: expected 3 to equal "50%"). The
+		// local posture itself is asserted against the resolver directly, above.
+		const budget = resolveTestWorkerBudget(currentHost());
 		expect(project("default").maxWorkers).toEqual(budget.maxWorkers);
 		expect(project("default").execArgv).toEqual([
 			`--max-old-space-size=${budget.heapMb}`,

--- a/tests/config/worker-budget.test.ts
+++ b/tests/config/worker-budget.test.ts
@@ -1,0 +1,311 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import {
+	MAX_WORKER_HEAP_MB,
+	MIN_WORKER_HEAP_MB,
+	NON_WORKER_RESERVE_MB,
+	WORKER_PEAK_RSS_BUDGET_MB,
+	formatTestWorkerBudget,
+	resolveTestWorkerBudget,
+} from "../../scripts/lib/worker-budget.mjs";
+// The REAL config object, not its source text — same reasoning as
+// tests/config/timing-sensitive-coverage.test.ts, including the explicit `.ts`:
+// the `.js` spelling resolves to the gitignored COMPILED vitest.config.js that
+// `npm run build` emits, so this guard would read a stale config.
+import vitestConfig from "../../vitest.config.ts";
+
+const repoRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+
+/** The same host object vitest.config.ts builds, so the resolution matches. */
+function currentHost() {
+	return {
+		totalMemMb: Math.round(os.totalmem() / (1024 * 1024)),
+		cpus: os.availableParallelism?.() ?? os.cpus().length,
+		ci: Boolean(process.env.CI),
+		workerOverride: Number(process.env.PI_LENS_TEST_MAX_WORKERS) || undefined,
+		heapOverride: Number(process.env.PI_LENS_TEST_WORKER_HEAP_MB) || undefined,
+	};
+}
+
+function project(name: string) {
+	const projects: unknown = vitestConfig.test?.projects;
+	if (!Array.isArray(projects)) {
+		throw new Error("vitest.config.ts default export has no test.projects");
+	}
+	const found = projects
+		.map(
+			(entry) =>
+				(
+					entry as {
+						test?: {
+							name?: unknown;
+							maxWorkers?: unknown;
+							execArgv?: unknown;
+						};
+					}
+				)?.test,
+		)
+		.find((test) => test?.name === name);
+	if (!found) throw new Error(`vitest.config.ts has no project "${name}"`);
+	return found;
+}
+
+describe("test worker budget (#2042)", () => {
+	it("lets the memory budget bind when a host has more cores than RAM", () => {
+		// 8 GB, 16 cores. Vitest's own default would hand this host 15 forks; the
+		// suite's measured p99 peak is 1405 MB per fork, so 15 of them is a
+		// SIGKILL. Memory, not core count, has to win.
+		const budget = resolveTestWorkerBudget({
+			totalMemMb: 8192,
+			cpus: 16,
+			ci: true,
+		});
+		expect(budget.cpuCap).toBe(15);
+		expect(budget.memCap).toBe(
+			Math.floor((8192 - NON_WORKER_RESERVE_MB) / WORKER_PEAK_RSS_BUDGET_MB),
+		);
+		expect(budget.maxWorkers).toBe(budget.memCap);
+		expect(budget.maxWorkers).toBeLessThan(budget.cpuCap);
+	});
+
+	it("never raises concurrency above vitest's own core-derived default", () => {
+		// 256 GB, 4 cores. Plenty of memory must not buy extra forks: the cap is
+		// the MINIMUM of the two, never the memory figure alone.
+		const budget = resolveTestWorkerBudget({
+			totalMemMb: 262_144,
+			cpus: 4,
+			ci: true,
+		});
+		expect(budget.memCap).toBeGreaterThan(budget.cpuCap);
+		expect(budget.maxWorkers).toBe(budget.cpuCap);
+		expect(budget.maxWorkers).toBe(3);
+	});
+
+	it("resolves a CI number, never undefined (the #2042 regression)", () => {
+		// Pre-fix, vitest.config.ts set `maxWorkers: undefined` under CI and let
+		// vitest fall back to `availableParallelism() - 1`, so nothing in the repo
+		// expressed a memory budget at all. Any host must now produce a number.
+		for (const [totalMemMb, cpus] of [
+			[7168, 2],
+			[16_384, 4],
+			[65_536, 32],
+		]) {
+			const budget = resolveTestWorkerBudget({ totalMemMb, cpus, ci: true });
+			expect(typeof budget.maxWorkers, `${totalMemMb}MB/${cpus}cpu`).toBe(
+				"number",
+			);
+			expect(budget.maxWorkers).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("keeps at least one worker on a host too small for the budget", () => {
+		const budget = resolveTestWorkerBudget({
+			totalMemMb: 2048,
+			cpus: 1,
+			ci: true,
+		});
+		expect(budget.maxWorkers).toBe(1);
+		expect(budget.heavyMaxWorkers).toBe(1);
+	});
+
+	it("runs the heavy phase at or below the general concurrency", () => {
+		for (const [totalMemMb, cpus] of [
+			[7168, 2],
+			[16_384, 4],
+			[32_768, 8],
+		]) {
+			const budget = resolveTestWorkerBudget({ totalMemMb, cpus, ci: true });
+			expect(
+				budget.heavyMaxWorkers,
+				`${totalMemMb}MB/${cpus}cpu`,
+			).toBeLessThanOrEqual(budget.maxWorkers as number);
+			expect(budget.heavyMaxWorkers).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("holds the per-fork heap ceiling between its correctness floor and cap", () => {
+		for (const [totalMemMb, cpus] of [
+			[2048, 1],
+			[7168, 2],
+			[16_384, 4],
+			[65_536, 32],
+			[262_144, 64],
+		]) {
+			const budget = resolveTestWorkerBudget({ totalMemMb, cpus, ci: true });
+			const where = `${totalMemMb}MB/${cpus}cpu`;
+			// The floor is not a budget number: one real file holds 2067 MB of live
+			// V8 heap, so a smaller ceiling turns a green suite red.
+			expect(budget.heapMb, where).toBeGreaterThanOrEqual(MIN_WORKER_HEAP_MB);
+			expect(budget.heapMb, where).toBeLessThanOrEqual(MAX_WORKER_HEAP_MB);
+		}
+	});
+
+	it("drops the heap ceiling below its cap on a memory-tight CI host", () => {
+		// The pre-#2042 value was a flat 4096 MB per fork on every host, with the
+		// comment "4 GB x workers << host RAM" — true on the 68 GB dev host it was
+		// measured on, false on a CI runner. A 16 GB / 4-core runner must now come
+		// out lower.
+		const budget = resolveTestWorkerBudget({
+			totalMemMb: 16_384,
+			cpus: 4,
+			ci: true,
+		});
+		expect(budget.heapMb).toBeLessThan(MAX_WORKER_HEAP_MB);
+	});
+
+	it("keeps the full ceiling when the host has room for it", () => {
+		// >= 2 x MAX_WORKER_HEAP_MB of memory per concurrent fork.
+		const budget = resolveTestWorkerBudget({
+			totalMemMb: 65_536,
+			cpus: 5,
+			ci: true,
+		});
+		expect(budget.maxWorkers).toBe(4);
+		expect(budget.heapMb).toBe(MAX_WORKER_HEAP_MB);
+	});
+
+	it("leaves the local posture unchanged", () => {
+		// The measured 2026-07-29 local settings, which #2042 must not disturb:
+		// "50%" forks, 4096 MB heap, heavy phase capped at 2.
+		const budget = resolveTestWorkerBudget({
+			totalMemMb: 65_536,
+			cpus: 16,
+			ci: false,
+		});
+		expect(budget.maxWorkers).toBe("50%");
+		expect(budget.heapMb).toBe(4096);
+		expect(budget.heavyMaxWorkers).toBe(2);
+	});
+
+	it("honours the explicit local overrides", () => {
+		const budget = resolveTestWorkerBudget({
+			totalMemMb: 65_536,
+			cpus: 16,
+			ci: false,
+			workerOverride: 6,
+			heapOverride: 3500,
+		});
+		expect(budget.maxWorkers).toBe(6);
+		expect(budget.heapMb).toBe(3500);
+	});
+
+	it("names the host and the decision in one line", () => {
+		const host = { totalMemMb: 16_384, cpus: 4 };
+		const line = formatTestWorkerBudget(
+			host,
+			resolveTestWorkerBudget({ ...host, ci: true }),
+		);
+		expect(line).toMatch(/^\[test-budget\] /);
+		for (const field of [
+			"cpus=",
+			"totalMemMb=",
+			"maxWorkers=",
+			"heavyMaxWorkers=",
+			"workerHeapMb=",
+		]) {
+			expect(line, `line must carry ${field}`).toContain(field);
+		}
+	});
+});
+
+describe("vitest.config.ts wiring (#2042)", () => {
+	// Asserting the ambient resolution would be vacuous on a developer's machine:
+	// off CI the resolver returns exactly the pre-#2042 values ("50%", 4096, 2),
+	// so a config that never called it would still pass. Re-import the config
+	// with CI forced on, where the pre-fix and post-fix values differ.
+	async function ciConfig() {
+		vi.stubEnv("CI", "1");
+		vi.resetModules();
+		try {
+			const loaded = await import("../../vitest.config.ts");
+			return loaded.default;
+		} finally {
+			vi.unstubAllEnvs();
+			vi.resetModules();
+		}
+	}
+
+	function ciProject(config: unknown, name: string) {
+		const projects = (config as { test?: { projects?: unknown[] } })?.test
+			?.projects;
+		if (!Array.isArray(projects)) throw new Error("no test.projects");
+		const found = projects
+			.map(
+				(entry) =>
+					(
+						entry as {
+							test?: {
+								name?: unknown;
+								maxWorkers?: unknown;
+								execArgv?: unknown;
+							};
+						}
+					)?.test,
+			)
+			.find((test) => test?.name === name);
+		if (!found) throw new Error(`no project "${name}"`);
+		return found;
+	}
+
+	it("takes both worker caps from the resolver under CI", async () => {
+		const host = { ...currentHost(), ci: true };
+		const budget = resolveTestWorkerBudget(host);
+		const config = await ciConfig();
+		// Pre-fix this was `undefined` — vitest's own core-derived fallback, with
+		// no memory budget expressed anywhere.
+		expect(ciProject(config, "default").maxWorkers).toEqual(budget.maxWorkers);
+		expect(typeof ciProject(config, "default").maxWorkers).toBe("number");
+		// Pre-fix this was a hardcoded 2 on every host.
+		expect(ciProject(config, "grammar-heavy").maxWorkers).toEqual(
+			budget.heavyMaxWorkers,
+		);
+	});
+
+	it("gives every project the derived heap ceiling under CI", async () => {
+		const budget = resolveTestWorkerBudget({ ...currentHost(), ci: true });
+		const config = await ciConfig();
+		const expected = [`--max-old-space-size=${budget.heapMb}`];
+		for (const name of [
+			"default",
+			"grammar-heavy",
+			"timing-sensitive",
+			"lsp-spawn-heavy",
+			"wall-clock-budget",
+		]) {
+			expect(ciProject(config, name).execArgv, name).toEqual(expected);
+		}
+	});
+
+	it("leaves a local run on the pre-#2042 posture", () => {
+		const budget = resolveTestWorkerBudget({ ...currentHost(), ci: false });
+		expect(project("default").maxWorkers).toEqual(budget.maxWorkers);
+		expect(project("default").execArgv).toEqual([
+			`--max-old-space-size=${budget.heapMb}`,
+		]);
+	});
+});
+
+describe("CI memory attribution (#2042)", () => {
+	const ci = fs.readFileSync(
+		path.join(repoRoot, ".github/workflows/ci.yml"),
+		"utf8",
+	);
+
+	it("runs the Unit-tests suite under the memory watch", () => {
+		// Without the wrapper an OOM kill prints `Killed` and exit 137 and names
+		// nothing, which is what made this class read as infrastructure noise.
+		expect(ci).toContain("node scripts/with-memory-watch.mjs -- npm test");
+	});
+
+	it("records the runner's capacity before the suite runs", () => {
+		expect(ci).toContain("Runner capacity");
+		expect(ci).toContain("free -m");
+		expect(ci).toContain("nproc");
+	});
+});

--- a/tests/config/worker-budget.test.ts
+++ b/tests/config/worker-budget.test.ts
@@ -129,6 +129,38 @@ describe("test worker budget (#2042)", () => {
 		}
 	});
 
+	it("runs the heavy phase STRICTLY below the general cap when it can", () => {
+		// The ordering test above accepts equality, so it passes for a resolver
+		// that never halves anything. This one pins the halving itself: wherever
+		// the general cap is 2 or more, the heavy phase must be strictly smaller.
+		// Mutating `Math.floor(ciWorkers / 2)` to `ciWorkers` reds exactly here.
+		for (const [totalMemMb, cpus] of [
+			[16_384, 4],
+			[16_384, 3],
+			[32_768, 8],
+			[65_536, 32],
+		]) {
+			const budget = resolveTestWorkerBudget({ totalMemMb, cpus, ci: true });
+			const where = `${totalMemMb}MB/${cpus}cpu`;
+			expect(budget.maxWorkers, where).toBeGreaterThanOrEqual(2);
+			expect(budget.heavyMaxWorkers, where).toBeLessThan(
+				budget.maxWorkers as number,
+			);
+		}
+	});
+
+	it("keeps the local heavy phase at 2 on any core count", () => {
+		// Deriving this from core count silently moved a 1-3 core dev box to 1.
+		// The local posture is the pre-#2042 literal, and it does not vary.
+		for (const cpus of [1, 2, 3, 4, 8, 16]) {
+			expect(
+				resolveTestWorkerBudget({ totalMemMb: 65_536, cpus, ci: false })
+					.heavyMaxWorkers,
+				`${cpus}cpu`,
+			).toBe(2);
+		}
+	});
+
 	it("holds the per-fork heap ceiling between its correctness floor and cap", () => {
 		for (const [totalMemMb, cpus] of [
 			[2048, 1],

--- a/tests/scripts/memory-watch.test.ts
+++ b/tests/scripts/memory-watch.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatVerdict,
+	parseMeminfo,
+	shouldPrint,
+} from "../../scripts/lib/memory-watch.mjs";
+
+const MEMINFO = [
+	"MemTotal:       16376464 kB",
+	"MemFree:          204908 kB",
+	"MemAvailable:    9481512 kB",
+	"Buffers:          151876 kB",
+	"Cached:          8724180 kB",
+].join("\n");
+
+describe("memory watch sampling (#2042)", () => {
+	it("reads MemAvailable, not MemFree", () => {
+		// MemFree excludes reclaimable page cache and reads alarmingly low on a
+		// healthy runner. MemAvailable is the number that tracks real pressure, so
+		// reading the wrong field would make every sample look like an emergency.
+		const sample = parseMeminfo(MEMINFO);
+		expect(sample.totalMb).toBe(Math.round(16_376_464 / 1024));
+		expect(sample.availableMb).toBe(Math.round(9_481_512 / 1024));
+		expect(sample.availableMb).not.toBe(Math.round(204_908 / 1024));
+	});
+
+	it("refuses to invent numbers from an unparseable meminfo", () => {
+		expect(() => parseMeminfo("MemTotal: not-a-number\n")).toThrow();
+	});
+});
+
+describe("memory watch print policy (#2042)", () => {
+	const state = (lastPrintedMb: number | null) => ({
+		lastPrintedMb,
+		thresholdMb: 1024,
+		stepMb: 1024,
+	});
+
+	it("always prints the first sample", () => {
+		expect(shouldPrint({ availableMb: 12_000 }, state(null))).toBe(true);
+	});
+
+	it("stays quiet while memory is plentiful and steady", () => {
+		// A line every two seconds for a five-minute suite would bury the test
+		// output it is meant to annotate.
+		expect(shouldPrint({ availableMb: 11_800 }, state(12_000))).toBe(false);
+	});
+
+	it("prints once memory falls a full step", () => {
+		expect(shouldPrint({ availableMb: 10_900 }, state(12_000))).toBe(true);
+	});
+
+	it("prints every sample below the low-water threshold", () => {
+		// Past the threshold each sample is evidence: the last one before a kill
+		// is the whole point of the watch.
+		expect(shouldPrint({ availableMb: 900 }, state(1000))).toBe(true);
+	});
+});
+
+describe("memory watch verdict (#2042)", () => {
+	const watch = { totalMb: 15_992, lowWaterMb: 143, lowWaterAt: "20:09:27" };
+
+	it("calls a SIGKILL what it is, with the low-water mark", () => {
+		const line = formatVerdict({ code: null, signal: "SIGKILL" }, watch);
+		expect(line).toContain("KILLED");
+		expect(line).toContain("no failing assertion");
+		expect(line).toContain("lowWaterAvailableMb=143");
+		expect(line).toContain("lowWaterAt=20:09:27");
+	});
+
+	it("treats a bare exit 137 as the same shape", () => {
+		// A shell between the wrapper and the killed process reports 137 rather
+		// than forwarding the signal; both must reach the same verdict.
+		expect(formatVerdict({ code: 137, signal: null }, watch)).toContain(
+			"KILLED",
+		);
+	});
+
+	it("does not cry OOM over an ordinary test failure", () => {
+		const line = formatVerdict({ code: 1, signal: null }, watch);
+		expect(line).not.toContain("KILLED");
+		expect(line).toContain("exitCode=1");
+	});
+
+	it("reports the low-water mark on success too", () => {
+		// The headroom on a passing run is what says whether the next one is safe.
+		const line = formatVerdict({ code: 0, signal: null }, watch);
+		expect(line).toContain("lowWaterAvailableMb=143");
+	});
+});

--- a/tests/scripts/with-memory-watch.test.ts
+++ b/tests/scripts/with-memory-watch.test.ts
@@ -98,25 +98,26 @@ describe("with-memory-watch exit forwarding (#2042)", () => {
 });
 
 describe("with-memory-watch verdict durability (#2042)", () => {
-	it("routes every record through a blocking write to fd 1", () => {
+	it("routes every record through a blocking write", () => {
 		// The behavioural case below is the real proof, but it can only FAIL on
-		// Linux: Node documents `process.stdout` as synchronous for pipes on
-		// Windows and asynchronous for pipes on Linux, so a Windows dev box cannot
-		// reproduce the loss no matter how badly the reader is starved (confirmed
-		// on this host — the pre-fix write passed 5/5). CI is Linux, which is
-		// exactly where it bites and where nobody is watching.
+		// Linux. Windows discards pipe-buffered bytes at process teardown even
+		// after `fs.writeSync` reports a complete write (#2093 verify: `ok
+		// bytes=86 of 86`, nothing at the reader), so no write mechanism makes
+		// the loss reproducible-then-fixed there. CI is Linux, which is exactly
+		// where the fix holds and where nobody is watching.
 		//
 		// So pin the mechanism too, on every platform: no record may go out
-		// through `process.stdout.write`, whose queued bytes `process.exit`
-		// discards. Reverting any `emit(...)` call to `process.stdout.write` reds
-		// here regardless of OS.
+		// through `process.stdout.write` or `process.stderr.write`, whose queued
+		// bytes `process.exit` discards on Linux. Reverting any `emit(...)` call
+		// to a stream write reds here regardless of OS. On a dev box this text
+		// pin is the only thing holding the ratchet.
 		const source = fs.readFileSync(wrapper, "utf8");
 		const offending = source
 			.split("\n")
 			.map((line, index) => ({ line: line.trim(), number: index + 1 }))
 			.filter(
 				(entry) =>
-					entry.line.includes("process.stdout.write") &&
+					/process\.std(out|err)\.write/.test(entry.line) &&
 					!entry.line.startsWith("*") &&
 					!entry.line.startsWith("//"),
 			);
@@ -133,8 +134,11 @@ describe("with-memory-watch verdict durability (#2042)", () => {
 		// discards it. The #2093 review reproduced that 3/3 on Linux — correct
 		// exit code, no verdict line — losing the record in exactly the
 		// memory-pressured run this wrapper exists to explain. A blocking
-		// `fs.writeSync(1, ...)` survives. This case cannot fail on Windows; see
-		// the mechanism guard above for why, and for the cross-platform ratchet.
+		// `fs.writeSync(1, ...)` survives on Linux. This case cannot fail on
+		// Windows at these parameters, and a heavier probe (18 MB, 4 KB reads)
+		// fails there even WITH the fix (teardown discard, see the mechanism
+		// guard) — if a Windows unit-test leg is ever added, expect this case to
+		// flake for reasons unrelated to the code.
 		const run = await runWrapper(
 			["--", nodeCmd, "-e", "process.stdout.write('x'.repeat(4194304))"],
 			20,

--- a/tests/scripts/with-memory-watch.test.ts
+++ b/tests/scripts/with-memory-watch.test.ts
@@ -1,0 +1,146 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+const wrapper = path.join(repoRoot, "scripts/with-memory-watch.mjs");
+
+interface Run {
+	code: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+/**
+ * Run the wrapper and collect everything it wrote.
+ *
+ * `throttleMs` starves the stdout reader: each chunk pauses the stream and
+ * resumes it after the delay, so the OS pipe backs up while the wrapped command
+ * is still producing output. That is the state the wrapper is in when a CI log
+ * collector falls behind, and it is where an asynchronously queued write is
+ * lost to `process.exit`.
+ */
+function runWrapper(args: string[], throttleMs = 0): Promise<Run> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [wrapper, ...args], {
+			cwd: repoRoot,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => {
+			stdout += chunk;
+			if (throttleMs > 0) {
+				child.stdout.pause();
+				setTimeout(() => child.stdout.resume(), throttleMs);
+			}
+		});
+		child.stderr.on("data", (chunk: string) => {
+			stderr += chunk;
+		});
+		child.on("error", reject);
+		child.on("close", (code) => resolve({ code, stdout, stderr }));
+	});
+}
+
+// The wrapper spawns through a shell on Windows (it has to: `npm` is not
+// executable there), and `shell: true` concatenates arguments without escaping
+// them. `process.execPath` is `C:\Program Files\nodejs\node.exe` on a default
+// install, so the space would split the command. Use the bare name off PATH
+// there, and keep every `-e` script free of spaces for the same reason. This is
+// the limitation the wrapper's own comment warns about, met first-hand.
+const nodeCmd = process.platform === "win32" ? "node" : process.execPath;
+
+/** A child that exits with `code` after writing nothing. */
+const exitWith = (code: number) => [
+	"--",
+	nodeCmd,
+	"-e",
+	`process.exitCode=${code}`,
+];
+
+describe("with-memory-watch exit forwarding (#2042)", () => {
+	it("forwards a non-zero child exit code", async () => {
+		// The wrapper must never soften a failure into a pass. A killed suite has
+		// to keep failing the job.
+		const run = await runWrapper(exitWith(3));
+		expect(run.code).toBe(3);
+	});
+
+	it("forwards a clean child exit", async () => {
+		const run = await runWrapper(exitWith(0));
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("[mem-watch] done.");
+	});
+
+	it("rejects a usage error with 2", async () => {
+		// No `--` separator: nothing to run.
+		const run = await runWrapper([]);
+		expect(run.code).toBe(2);
+		expect(run.stderr).toContain("usage:");
+	});
+
+	it("reports a command it cannot spawn with 1", async () => {
+		const run = await runWrapper([
+			"--",
+			"pi-lens-no-such-binary-2042",
+			"--version",
+		]);
+		expect(run.code).toBe(1);
+	});
+});
+
+describe("with-memory-watch verdict durability (#2042)", () => {
+	it("routes every record through a blocking write to fd 1", () => {
+		// The behavioural case below is the real proof, but it can only FAIL on
+		// Linux: Node documents `process.stdout` as synchronous for pipes on
+		// Windows and asynchronous for pipes on Linux, so a Windows dev box cannot
+		// reproduce the loss no matter how badly the reader is starved (confirmed
+		// on this host — the pre-fix write passed 5/5). CI is Linux, which is
+		// exactly where it bites and where nobody is watching.
+		//
+		// So pin the mechanism too, on every platform: no record may go out
+		// through `process.stdout.write`, whose queued bytes `process.exit`
+		// discards. Reverting any `emit(...)` call to `process.stdout.write` reds
+		// here regardless of OS.
+		const source = fs.readFileSync(wrapper, "utf8");
+		const offending = source
+			.split("\n")
+			.map((line, index) => ({ line: line.trim(), number: index + 1 }))
+			.filter(
+				(entry) =>
+					entry.line.includes("process.stdout.write") &&
+					!entry.line.startsWith("*") &&
+					!entry.line.startsWith("//"),
+			);
+		expect(
+			offending,
+			"use emit() (fs.writeSync) so process.exit cannot discard the record",
+		).toEqual([]);
+	});
+
+	it("writes the verdict even when the log reader has fallen behind", async () => {
+		// 4 MB through a 64 KB pipe against a reader that stalls 20ms per chunk:
+		// by the time the child exits, the pipe is full, so an asynchronously
+		// queued `process.stdout.write` is still pending when `process.exit`
+		// discards it. The #2093 review reproduced that 3/3 on Linux — correct
+		// exit code, no verdict line — losing the record in exactly the
+		// memory-pressured run this wrapper exists to explain. A blocking
+		// `fs.writeSync(1, ...)` survives. This case cannot fail on Windows; see
+		// the mechanism guard above for why, and for the cross-platform ratchet.
+		const run = await runWrapper(
+			["--", nodeCmd, "-e", "process.stdout.write('x'.repeat(4194304))"],
+			20,
+		);
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("[mem-watch] done.");
+		expect(run.stdout).toContain("lowWaterAvailableMb=");
+	}, 60_000);
+});

--- a/tests/support/vitest-setup.ts
+++ b/tests/support/vitest-setup.ts
@@ -76,8 +76,14 @@ if (toolTemplate) {
 // 2267 MB. The heavy tail is NATIVE memory — tree-sitter wasm grammar compiles
 // and @ast-grep/napi arenas — which no V8 flag bounds and no reporter shows.
 //
-// Without this line an OOM-killed CI run names nothing at all. With it, the
-// last lines before the kill name the files that were resident.
+// What this record can and cannot say. It is an `afterAll` hook, so it only
+// fires for a file that FINISHED. The file that was mid-run when the OS killed
+// the job never reports its own peak. What the last lines before a kill name is
+// the completed co-residents -- the memory profile of the phase the run died
+// in, not the culprit. That is still far better than the nothing there was
+// before, but it is circumstantial evidence, not attribution, and the
+// `[mem-watch]` low-water mark is the record that says how close the run
+// actually came.
 //
 // `maxRSS` is kilobytes on every platform: libuv normalizes the Win32 peak
 // working set for `uv_getrusage`, so no per-platform scaling is needed.

--- a/tests/support/vitest-setup.ts
+++ b/tests/support/vitest-setup.ts
@@ -2,6 +2,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { afterAll, expect } from "vitest";
 
 // The review-graph persist is debounced in production (#260 circuit-breaker) so
 // a burst of edits collapses to one write. In tests that would race disk-snapshot
@@ -63,4 +64,43 @@ if (toolTemplate) {
 	} catch {
 		// missing template file — worker simply runs cold, as before
 	}
+}
+
+// #2042: per-file peak memory, for the files big enough to matter.
+//
+// Vitest's forks pool with `isolate: true` gives every test FILE its own child
+// process (verified 2026-08-25: 20 files at `maxWorkers: 1` produced 20 distinct
+// pids), so `process.resourceUsage().maxRSS` at the end of a file is that
+// file's own peak, uncontaminated by its neighbours. Measured over all 740
+// files of the default project: p50 93 MB, p90 389 MB, p99 1405 MB, max
+// 2267 MB. The heavy tail is NATIVE memory — tree-sitter wasm grammar compiles
+// and @ast-grep/napi arenas — which no V8 flag bounds and no reporter shows.
+//
+// Without this line an OOM-killed CI run names nothing at all. With it, the
+// last lines before the kill name the files that were resident.
+//
+// `maxRSS` is kilobytes on every platform: libuv normalizes the Win32 peak
+// working set for `uv_getrusage`, so no per-platform scaling is needed.
+const memReportThresholdMb = Number(
+	process.env.PI_LENS_TEST_MEM_REPORT_MB ?? (process.env.CI ? "512" : "0"),
+);
+if (memReportThresholdMb > 0) {
+	afterAll(() => {
+		const usage = process.memoryUsage();
+		const peakMb = Math.round(process.resourceUsage().maxRSS / 1024);
+		if (peakMb < memReportThresholdMb) return;
+		const file = String(expect.getState().testPath ?? "unknown")
+			.replace(/\\/g, "/")
+			.split("/tests/")
+			.pop();
+		// Straight to the fork's stderr, not `console.log`: vitest intercepts
+		// worker console output and routes it through the reporter, which
+		// attributes it to a task and can drop it entirely for a hook that runs
+		// after the last test (verified 2026-08-25 — the console form printed
+		// nothing). A raw write lands in the job log unconditionally, which is the
+		// whole point of a line whose only reader is a post-mortem.
+		process.stderr.write(
+			`[mem-file] peakRssMb=${peakMb} heapUsedMb=${Math.round(usage.heapUsed / 1048576)} externalMb=${Math.round(usage.external / 1048576)} tests/${file}\n`,
+		);
+	});
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,9 @@
+import * as os from "node:os";
 import { defineConfig } from "vitest/config";
+import {
+	formatTestWorkerBudget,
+	resolveTestWorkerBudget,
+} from "./scripts/lib/worker-budget.mjs";
 
 // Applies to globalSetup as well as workers: ordinary tests never install tools.
 process.env.PI_LENS_DISABLE_TOOL_INSTALL ??= "1";
@@ -48,35 +53,59 @@ const sharedGlobalSetup = [
 
 const sharedSetupFiles = ["./tests/support/vitest-setup.ts"];
 
-// Local runs: cap forks at half the cores (measured 2026-07-29 on a
-// 16-core host, post dead-wait removal: 8 forks ≈ 40s / 9-11 GB peak
-// RSS; 6 forks ≈ 44s / 8 GB; the old uncapped 15 forks gave the same
-// memory for a slower wall). CI keeps vitest's default — its 4-core
-// runner has no worker headroom to give back. Memory-constrained runs:
-// PI_LENS_TEST_MAX_WORKERS=6.
-const sharedMaxWorkers = process.env.CI
-	? undefined
-	: Number(process.env.PI_LENS_TEST_MAX_WORKERS) || "50%";
+// Fork concurrency and per-fork heap ceiling both come from ONE resolver
+// (scripts/lib/worker-budget.mjs), which sizes them against the host's
+// real memory. Before #2042 they were two constants tuned on a 32-core / 68 GB
+// dev host and applied verbatim to CI, where `maxWorkers` fell back to
+// vitest's `availableParallelism() - 1` and bounded worker COUNT while per-fork
+// peak RSS — the axis that actually grows, and native rather than V8 heap — was
+// bounded by nothing. That is how the Unit-tests job got SIGKILLed (exit 137)
+// with no failing assertion. Local runs keep the measured 2026-07-29 posture
+// (8 forks ≈ 40s / 9-11 GB peak RSS; 6 forks ≈ 44s / 8 GB); memory-constrained
+// local runs still use PI_LENS_TEST_MAX_WORKERS=6.
+const testHost = {
+	totalMemMb: Math.round(os.totalmem() / (1024 * 1024)),
+	cpus: os.availableParallelism?.() ?? os.cpus().length,
+	ci: Boolean(process.env.CI),
+	workerOverride: Number(process.env.PI_LENS_TEST_MAX_WORKERS) || undefined,
+	heapOverride: Number(process.env.PI_LENS_TEST_WORKER_HEAP_MB) || undefined,
+};
+const testBudget = resolveTestWorkerBudget(testHost);
+if (testHost.ci) {
+	// One line naming the host and the decision. Without it an exit 137 says
+	// nothing about what the run was allowed to use.
+	console.log(formatTestWorkerBudget(testHost, testBudget));
+}
 
-// Worker heap headroom: the full suite occasionally died with a "Worker
+const sharedMaxWorkers = testBudget.maxWorkers;
+
+// Worker heap headroom (#2042 note first: this ceiling is now DERIVED from the
+// host by the budget resolver above, not the flat 4096 that the paragraph below
+// describes — on a 68 GB dev host it still resolves to 4096, so the reasoning
+// stands unchanged there; on a small CI runner it shrinks, and a fork that
+// blows the smaller ceiling dies with Node's own heap-limit report naming the
+// FILE, which is a far better failure than the OS killing the whole run).
+//
+// The full suite occasionally died with a "Worker
 // exited unexpectedly" + a `node::GetNodeReport` dump. That report is emitted
 // by Node's OWN fatal-error handler (V8 heap-limit reached) — an external OS
 // OOM-kill SIGKILLs with no dump — so the crash is a single long-lived worker
 // hitting its own V8 heap ceiling, not system memory exhaustion (32-core /
 // 68 GB host). With `isolate: true` (vitest's default) each worker's module
 // registry is reset per file, so the native addons (the many tree-sitter
-// grammars + @ast-grep/napi) are re-loaded file-after-file and their off- and
-// on-heap buffers accumulate in the reused worker until a heavy worker tips
-// over. `execArgv` passes --max-old-space-size to every spawned worker,
-// giving that headroom WITHOUT capping worker count (no CI slowdown);
-// aggregate risk is negligible (workers never all peak at once, and 4 GB ×
-// workers ≪ host RAM). Tune via PI_LENS_TEST_WORKER_HEAP_MB. NOTE: Vitest 4
+// grammars + @ast-grep/napi) are re-loaded and re-compiled file after file.
+// CORRECTION (#2042, measured 2026-08-25): this paragraph used to say those
+// buffers "accumulate in the reused worker". They do not — Vitest 4's forks
+// pool with `isolate: true` spawns a FRESH child process per test file (20
+// files at `maxWorkers: 1` produced 20 distinct pids), so a fork's peak is its
+// own file's peak and nothing carries over. The cost is per-file, not
+// cumulative; it is simply large for the tail (p99 1405 MB, max 2267 MB).
+// `execArgv` passes --max-old-space-size to every spawned worker.
+// Tune via PI_LENS_TEST_WORKER_HEAP_MB. NOTE: Vitest 4
 // flattened the config — `execArgv` is a direct `test` field (the v3
 // `poolOptions.forks.execArgv` nesting no longer exists and is silently
 // ignored).
-const sharedExecArgv = [
-	`--max-old-space-size=${process.env.PI_LENS_TEST_WORKER_HEAP_MB || 4096}`,
-];
+const sharedExecArgv = [`--max-old-space-size=${testBudget.heapMb}`];
 
 // Tier 1 fix (#902): these files all transitively drive real tree-sitter
 // grammar parses (via clients/review-graph/builder.js or the project-diagnostics
@@ -272,7 +301,11 @@ export default defineConfig({
 					// concurrency knobs were unified into the top-level
 					// `maxWorkers` (applies to whichever pool is active; this repo
 					// uses the default `forks` pool everywhere).
-					maxWorkers: 2,
+					// #2042: 2 locally, but derived on CI — these files carry the
+					// suite's largest native footprints (measured 3345 MB and 3853 MB
+					// peak RSS), so two at once is a bigger bite than a small runner
+					// has to give.
+					maxWorkers: testBudget.heavyMaxWorkers,
 					// Distinct groupOrder is required whenever projects have
 					// different `maxWorkers` (Vitest 4 throws otherwise). Side
 					// effect: scheduling groups run as sequential PHASES (group 0


### PR DESCRIPTION
﻿## Summary

The Unit-tests job was SIGKILLed on `ubuntu-latest` with exit 137 and no failing assertion, five times in one evening. Two constants tuned on a dev host were applied unconditionally to CI:

- `maxWorkers` was left `undefined` under CI, so Vitest resolved it to `availableParallelism() - 1`. That bounds worker COUNT.
- every fork got `--max-old-space-size=4096`, on the reasoning "4 GB x workers << host RAM". That bounds V8 heap.

Neither bounds the axis that grows.

**Measurement.** A per-file `process.resourceUsage().maxRSS` probe over all 740 files of the default project gives peak RSS per file: p50 93 MB, p90 389 MB, p99 1405 MB, max 2267 MB, with 42 files above 1 GB. The tail is NATIVE memory, not V8 heap. `tests/clients/tree-sitter-imports.test.ts` peaks at 1601 MB while holding 33 MB of heap, because tree-sitter wasm grammar compiles and `@ast-grep/napi` arenas sit outside V8's accounting. Three concurrent tail files is several GB that no setting caps, which is why the kill is a scheduling coin flip: reruns pass, master passes, three PRs die in one window.

**What changed.**

1. `scripts/lib/worker-budget.mjs` resolves fork concurrency and the per-fork heap ceiling from the host's real memory. Concurrency is `min(cpus - 1, (totalMem - reserve) / 2048)`, so the memory budget can lower it but never raise it. The heavy phase runs at half the general concurrency. A local run keeps its pre-existing posture exactly: `"50%"`, 4096 MB, heavy phase at 2.
2. The kill is now attributable. CI records the runner's `nproc` and `free -m`; the suite runs under `scripts/with-memory-watch.mjs`, which prints the memory low-water mark and states plainly that a SIGKILL with no failing assertion is the OS reclaiming memory; and each fork over 512 MB reports its own peak, so the last lines before a kill name the files that were resident.
3. The config comment claiming buffers "accumulate in the reused worker" is corrected. Vitest 4's forks pool with `isolate: true` spawns a fresh process per test file: 20 files at `maxWorkers: 1` produced 20 distinct pids. Nothing accumulates across files. The cost is per-file and simply large for the tail.

Nothing changes about which tests run.

## Tests

New: `tests/config/worker-budget.test.ts` and `tests/scripts/memory-watch.test.ts`, 26 cases together.

Red on pre-fix code, with the fix's tracked files reverted via `git diff > patch` / `git checkout --`:

```
FAIL tests/config/worker-budget.test.ts > vitest.config.ts wiring (#2042) > takes both worker caps from the resolver under CI
FAIL tests/config/worker-budget.test.ts > vitest.config.ts wiring (#2042) > gives every project the derived heap ceiling under CI
FAIL tests/config/worker-budget.test.ts > CI memory attribution (#2042) > runs the Unit-tests suite under the memory watch
FAIL tests/config/worker-budget.test.ts > CI memory attribution (#2042) > records the runner's capacity before the suite runs
 Test Files  1 failed | 1 passed (2)
      Tests  4 failed | 22 passed (26)
```

The wiring assertions re-import `vitest.config.ts` with `CI` stubbed on. Asserting the ambient resolution would be vacuous on a developer's machine, where the resolver returns exactly the pre-fix values, so a config that never called it would still pass.

Green after: 26 passed. Wider targeted battery, run because they read `vitest.config.ts` or the same guards: `worker-budget`, `memory-watch`, `module-instance-coverage`, `timing-sensitive-coverage`, `module-instance-binding`, `changelog-entries`, `zizmor-config` — 7 files, 49 tests, all passing. `npm run lint`, `npm run fmt:check`, and `npm run build` clean.

Live check of the observability, threshold lowered to 150 MB:

```
[mem-file] peakRssMb=1328 heapUsedMb=34 externalMb=60 tests/clients/tree-sitter-symbols.test.ts
```

That is the file that was executing when run 32893530546 was killed. Its sibling in the same run, peak 90 MB, correctly stayed silent.

The resolver's own decision, from a forced-CI run on a 16-core / 15.6 GB host:

```
[test-budget] cpus=16 totalMemMb=15639 cpuCap=15 memCap=6 maxWorkers=6 heavyMaxWorkers=3 workerHeapMb=3072
```

Memory binds at 6 where core count would have given 15.

The full suite is CI's job.

## Blast radius

Every PR's CI runs through this, so the failure semantics matter.

- **What changes.** On a 16 GB / 4-core runner: fork count stays at 3, the heavy phase drops from 2 to 1, and the per-fork heap ceiling drops from 4096 MB to 3072 MB. On a smaller runner the fork count drops too. A fork that now blows the lower ceiling dies with Node's own heap-limit report naming the file, which is a real assertion surface, instead of the OS killing the whole run.
- **The heap floor is a correctness constraint, not a budget number.** `tests/monorepo/cross-package-graph.test.ts` holds 2067 MB of live V8 heap. `MIN_WORKER_HEAP_MB` is 3072 so the ceiling can never be lowered into that file. If CI reports a runner small enough that 3072 is still too generous, the honest fix is fewer forks, not a lower ceiling.
- **Wall-clock cost.** Serializing the heavy phase costs roughly a minute; the six files take 59s at two workers locally. If the runner turns out smaller than 16 GB, the fork-count drop costs more. The suite ran 263s before, so the issue's 10-minute bound has room.
- **Local runs are untouched by construction**, and a test asserts it: off CI the resolver returns `"50%"`, 4096 MB, heavy phase 2, exactly as before. `PI_LENS_TEST_MAX_WORKERS` and `PI_LENS_TEST_WORKER_HEAP_MB` still override.
- **The wrapper forwards the child's exit code and signal unchanged** (verified: exit 3 forwards as 3, a usage error exits 2), so a killed run still fails the job. It adds one Node process holding an unref'd interval timer.
- **New callers.** `vitest.config.ts` is the only caller of the resolver; `ci.yml`'s Unit-tests step is the only caller of the wrapper.
- **No open PR collides.** #2080 is the only open PR touching `tests/config/`, and it adds a different file plus `AGENTS.md`. No merge-order constraint.

## Class sweep

The defect shape is AGENTS.md shape 9: **a resource bounded on one axis while it grows on another** — here, a fork pool capped by worker count while per-fork RSS is what grows. Second axis: **a constant measured on one host applied verbatim to another**.

**Pattern sweep**, run over `.github/workflows/`, `scripts/`, `clients/`, `mcp/`, `tools/`, `index.ts`, and `vitest.config.ts` for `max-old-space-size`, `maxWorkers`, `availableParallelism`, `cpus()`, and `--max-workers`. No other site in the tree sets a heap flag or sizes a worker pool. The remaining numeric `maxWorkers` literals are the three later phases — `timing-sensitive: 2`, `lsp-spawn-heavy: 1`, `wall-clock-budget: 1`. Those exist for CPU contention, not memory, and 2 and 1 are already at or below anything the memory budget would resolve to on any runner, so they are safe unchanged. `grep "npm test" .github/workflows/` confirms the Unit-tests job is the only workflow that runs the suite.

**Population sweep** over the enumerable family of CI jobs that run memory-hungry work:

| Job | Verdict |
| --- | --- |
| `ci.yml` Unit tests | fixed here |
| `ci.yml` Lint & type-check | already correct — one `tsc` process, no pool |
| `ci.yml` Production install build | already correct — `npm install` plus one `tsc`, no pool |
| `ci.yml` Close-keyword / Changelog fast-fail | already correct — one short Node process each |
| `tool-smoke.yml` (nightly, MCP and LSP smokes) | left deliberately. It spawns real servers serially through `scripts/smoke-tools.mjs` rather than a fork pool, so it has no concurrency knob to budget. It has not been OOM-killed. Worth revisiting only if it starts to be; noted on the issue rather than pre-emptively changed. |

The `with-test-lock.mjs` header still describes the pre-fix "4GB/fork" posture. It is a comment about why the lock exists, and its argument is unaffected, so it is left alone.

## Observability

Three records prove this from the CI log alone, all in the Unit-tests job:

1. `Runner capacity` step — `nproc` and `free -m`. The runner's actual size, which no previous log line carried. Every past diagnosis of this issue started from a guess about it.
2. `[test-budget] cpus=… totalMemMb=… cpuCap=… memCap=… maxWorkers=… heavyMaxWorkers=… workerHeapMb=…` — one line naming the host and the decision, so the budget is auditable rather than inferred.
3. `[mem-watch] …` — the memory low-water mark during the run, plus a verdict line. On a kill it reads `KILLED — no failing assertion means the OS reclaimed memory, not a test failure` with the low-water mark and the time it happened.
4. `[mem-file] peakRssMb=… heapUsedMb=… externalMb=… tests/…` — per-file peak for any fork over 512 MB, written straight to the fork's stderr. Vitest intercepts worker `console` output and drops it for a hook that runs after the last test, verified 2026-08-25, so the raw write is deliberate.

**Gap, named:** none of this proves the kill mode is gone. Only CI can, and only over repeated runs. See the acceptance note below.

## Why `refs`, not `closes`

The issue's acceptance criteria include "no OOM kills in 10 consecutive master CI runs". That cannot be proved from this branch. The expected CI evidence is recorded in an issue comment: the first run on this PR reports the runner's real memory and the resolved budget, which either confirms a 16 GB runner (making the heap ceiling and the attribution the operative mitigation) or reveals a smaller one (where the fork-count drop is the fix). The issue stays open until the 10-run window is observed.

Refs #2042


---

## Round 1: first CI run on this branch

Run 32899910007, job 97971052378. Everything below is new signal this PR added.

```
nproc=4
Mem:           15989        1538       11555          44        3287       14451
Swap:           3071           0        3071
[mem-watch] host cpus=4 totalMb=15990 availableMb=14452 source=meminfo intervalMs=2000
[test-budget] cpus=4 totalMemMb=15990 cpuCap=3 memCap=6 maxWorkers=3 heavyMaxWorkers=1 workerHeapMb=3072
[mem-watch] 21:15:03 availableMb=13065 of 15990
[mem-watch] done. exitCode=1 totalMb=15990 lowWaterAvailableMb=12840 lowWaterAt=21:15:05
```

Two things this settles, both worth recording plainly.

**The runner is 4-core with 16 GB, not the ~7 GB the issue assumed.** Every earlier diagnosis of #2042 had to guess at this number, because no log line carried it.

**On this run the suite's low-water mark was 12,840 MB available**, so peak usage was around 3.1 GB against 16 GB. The 2-second sampling interval can miss a fast spike, but this is a long way from exhaustion. The fork pool's steady-state footprint is therefore not, on its own, what kills these jobs. The honest reading is that the memory budget here is a headroom improvement and a correctness fix to two mis-scoped constants, while the attribution is the part that will diagnose the next kill. The full reasoning and the three remaining candidates are on the issue.

Job wall time was 4m40s, so serializing the heavy phase cost nothing measurable.

**One test failed, and it was mine.** `leaves a local run on the pre-#2042 posture` pinned the config against a `ci: false` resolution, but the config reads the real `process.env.CI`, so on CI it asserted a posture the config was never asked for: `expected 3 to deeply equal '50%'`. Fixed in 3940f8f8 by asserting the ambient resolution instead. The local posture is still asserted against the resolver directly, and the two forced-CI wiring cases are unchanged. Verified both ways locally: 16 passed with `CI` unset, 16 passed with `CI=1`. The other 767 test files passed.

**Known cosmetic issue:** `[test-budget]` prints once per project phase rather than once per run, because Vitest re-evaluates the config for each project. Five lines in the log. Left as is: the repetition is harmless and the line is load-bearing.



---

## Fix round 1

Head `ace3ea01`. All six findings applied on the same branch, plus a merge of `origin/master`.

### F1 (medium) â€” verdict line lost on a backed-up pipe. Fixed.

Reproduced by the review 3/3 on Linux: correct exit code, no verdict line. `process.stdout.write` queues asynchronously when stdout is a pipe, and `process.exit` discards whatever is still queued, so the record vanished in exactly the memory-pressured run the wrapper exists to explain. Every record now goes through a blocking `fs.writeSync(1, â€¦)` via one `emit()` helper: the host line, the samples, and the verdict.

I could not reproduce it on this host, and the reason is worth recording: **Node writes to pipes synchronously on Windows and asynchronously on Linux.** The pre-fix write passed 5/5 here even with a 4 MB payload through a 20 ms-per-chunk throttled reader. The defect is Linux-only, which is to say CI-only, which is to say unwatched.

So the fix ships with two guards. Red proof is from the mechanism guard, which binds on every platform:

```
FAIL tests/scripts/with-memory-watch.test.ts > with-memory-watch verdict durability (#2042)
     > routes every record through a blocking write to fd 1
AssertionError: use emit() (fs.writeSync) so process.exit cannot discard the record:
  expected [ { â€¦(2) } ] to deeply equal []
 Tests  1 failed | 5 passed (6)
```

That is the reviewer's own mutation â€” reverting the verdict `emit(...)` to `process.stdout.write`.

### F2 (medium) â€” vacuous heavy-phase halving. Fixed.

The ordering test accepted equality and the wiring test was tautological against the resolver, so the halving could be mutated away and stay green. New case pins it: wherever the general cap is 2 or more, the heavy phase must be strictly smaller. Red under the reviewer's mutation (`Math.max(1, ciWorkers)`):

```
FAIL tests/config/worker-budget.test.ts > test worker budget (#2042)
     > runs the heavy phase STRICTLY below the general cap when it can
AssertionError: 16384MB/4cpu: expected 3 to be less than 3
 Tests  1 failed | 17 passed (18)
```

### F3 (low) â€” no coverage for the wrapper. Fixed.

`tests/scripts/with-memory-watch.test.ts`, six cases: non-zero exit forwards, clean exit forwards, usage error (no `--`) exits 2, unspawnable command exits 1, the mechanism guard, and the slow-reader case.

**The PR body was wrong** and is corrected above: a *usage error* exits 2; a *missing command* exits 1. Verified by the new tests.

Writing them surfaced the F7 limitation first-hand: `process.execPath` is `C:\Program Files\nodejs\node.exe`, and `shell: true` split it on the space. The tests now use the bare name off PATH on win32 and keep every `-e` script free of spaces.

### F4 (low) â€” local heavy posture changed for 1-3 cores. Fixed.

Restored the plain literal `2` for the local branch; the core-count derivation bought nothing and silently moved a small dev box to 1. Pin extended to cpus 1, 2, 3, 4, 8, 16. Red under the previous derivation:

```
FAIL tests/config/worker-budget.test.ts > keeps the local heavy phase at 2 on any core count
AssertionError: 1cpu: expected 1 to be 2
```

### F5 (body honesty) â€” the RSS constants are dev-host numbers. Stated.

The p50/p90/p99/max figures, and therefore `WORKER_PEAK_RSS_BUDGET_MB`, were measured on the dev host: Windows, 16 cores, 15.6 GB. **They are unvalidated on Linux, and the first CI `[mem-file]` lines show Linux running roughly three times leaner on the same files** â€” `tree-sitter-imports.test.ts` peaks at 580 MB there against 1601 MB here, and 7 files clear 512 MB on CI against 42 clearing 1 GB locally.

The budget is therefore conservative against the profile it actually governs: it reserves more per worker than a CI fork needs, which errs toward fewer workers. That is the safe direction, but it is a constant that should be re-derived from accumulated `[mem-file]` data rather than treated as settled. Now recorded in `scripts/lib/worker-budget.mjs` where the next reader will meet it.

### F6 (body honesty) â€” `[mem-file]` framing softened.

`[mem-file]` is an `afterAll` hook, so it fires only for a file that FINISHED. **The file that was mid-run when the OS killed the job never reports its own peak.** What the last lines before a kill name is the completed co-residents: the memory profile of the phase the run died in, not the culprit. Circumstantial evidence, not attribution. The `[mem-watch]` low-water mark remains the record that says how close the run actually came. Corrected in the code comment and in a follow-up comment on #2042.

### F7 (note) â€” Windows `shell: true`. Documented.

A comment on the `spawn` call states that the wrapper is CI-only, CI is Linux, and the win32 branch is a hand-run courtesy whose unescaped argument concatenation must not be built on.

### Verification

`npm run build` before every run. Targeted files plus everything reading the same seams: `worker-budget`, `memory-watch`, `with-memory-watch`, `module-instance-coverage`, `timing-sensitive-coverage`, `module-instance-binding`, `session-state-conformance` â€” 7 files, 117 tests, all passing after the `origin/master` merge. Also green with `CI=1` forced (24 tests), since the resolver branches on it. `npm run lint` and `npm run fmt:check` clean.

`origin/master` merged at `f4861bbc`; its only change to a file of mine was 3 lines elsewhere in `ci.yml`, and the Unit-tests step is intact. Full suite is CI's job.
