### PR TITLE
fix(dispatch): fail closed on truncated git ls-files output (refs #2075)

### DIFF
--- a/.changelog/fix-2075-git-ls-files-truncation.md
+++ b/.changelog/fix-2075-git-ls-files-truncation.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Fail closed on truncated Git file lists.** Truncated `git ls-files` output now reports unavailable tracked and ignored sets instead of presenting partial sets as complete.

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -16,6 +16,8 @@ export type DegradationKind =
 	| "mode-suppression"
 	| "ts-idle-eviction"
 	| "spawn-failure"
+	/** A git ls-files collection was truncated before parsing completed (#2075). */
+	| "git-tracked-ignore-truncated"
 	| "formatter-skip"
 	| "grammar-blocked"
 	| "lsp-breaker"

--- a/clients/git-tracked-ignore.ts
+++ b/clients/git-tracked-ignore.ts
@@ -48,8 +48,13 @@ function recordTruncatedLsFiles(
 	});
 }
 
-// A real listing in this repository is about 133 KiB. Cap pathological
-// repositories at 16 MiB so safeSpawnAsync cannot retain unbounded stdout.
+// The binding listing is the untracked-ignored one: a mid-size project's
+// node_modules alone yields a ~66k-line ignored list (roughly 4-6 MiB), and
+// a monorepo with several dependency trees can multiply that. 16 MiB leaves
+// that headroom while stopping safeSpawnAsync from retaining unbounded
+// stdout (an uncapped probe held 20 MiB in full). The tracked listing is
+// far smaller (~133 KiB in this repository). A capped read fails closed to
+// unavailable with one bounded ledger record per site.
 const MAX_LS_FILES_OUTPUT_BYTES = 16 * 1024 * 1024;
 
 /**

--- a/clients/git-tracked-ignore.ts
+++ b/clients/git-tracked-ignore.ts
@@ -34,8 +34,19 @@
 
 import * as path from "node:path";
 import { isExcludedDirName } from "./file-utils.js";
+import { recordDegradationOnce } from "./degradation-ledger.js";
 import { normalizeEphemeralMapKey, normalizeMapKey } from "./path-utils.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
+
+function recordTruncatedLsFiles(
+	parseSite: "untracked-ignored" | "tracked",
+): void {
+	recordDegradationOnce({
+		kind: "git-tracked-ignore-truncated",
+		subject: `git-ls-files:${parseSite}`,
+		reason: "safeSpawnAsync capped git ls-files stdout",
+	});
+}
 
 /**
  * Parses `git ls-files --others --ignored --exclude-standard` output
@@ -74,6 +85,10 @@ async function fetchUntrackedIgnoredIds(
 			{ cwd, timeout: 10_000, resourceLabel: "git-tracked-ignore" },
 		);
 		if (result.error || result.status !== 0) return undefined;
+		if (result.outputTruncated === true) {
+			recordTruncatedLsFiles("untracked-ignored");
+			return undefined;
+		}
 		return parseUntrackedIgnoredOutput(result.stdout, cwd);
 	} catch {
 		return undefined;
@@ -166,6 +181,10 @@ async function fetchTrackedFiles(
 			resourceLabel: "git-tracked-ignore",
 		});
 		if (result.error || result.status !== 0) return undefined;
+		if (result.outputTruncated === true) {
+			recordTruncatedLsFiles("tracked");
+			return undefined;
+		}
 		return parseTrackedFilesOutput(result.stdout, cwd);
 	} catch {
 		return undefined;

--- a/clients/git-tracked-ignore.ts
+++ b/clients/git-tracked-ignore.ts
@@ -48,6 +48,10 @@ function recordTruncatedLsFiles(
 	});
 }
 
+// A real listing in this repository is about 133 KiB. Cap pathological
+// repositories at 16 MiB so safeSpawnAsync cannot retain unbounded stdout.
+const MAX_LS_FILES_OUTPUT_BYTES = 16 * 1024 * 1024;
+
 /**
  * Parses `git ls-files --others --ignored --exclude-standard` output
  * (repo-relative paths, one per line) into normalized map-key file ids.
@@ -82,13 +86,18 @@ async function fetchUntrackedIgnoredIds(
 		const result = await safeSpawnAsync(
 			"git",
 			["ls-files", "--others", "--ignored", "--exclude-standard"],
-			{ cwd, timeout: 10_000, resourceLabel: "git-tracked-ignore" },
+			{
+				cwd,
+				timeout: 10_000,
+				maxOutputBytes: MAX_LS_FILES_OUTPUT_BYTES,
+				resourceLabel: "git-tracked-ignore",
+			},
 		);
-		if (result.error || result.status !== 0) return undefined;
 		if (result.outputTruncated === true) {
 			recordTruncatedLsFiles("untracked-ignored");
 			return undefined;
 		}
+		if (result.error || result.status !== 0) return undefined;
 		return parseUntrackedIgnoredOutput(result.stdout, cwd);
 	} catch {
 		return undefined;
@@ -178,13 +187,14 @@ async function fetchTrackedFiles(
 		const result = await safeSpawnAsync("git", ["ls-files"], {
 			cwd,
 			timeout: 10_000,
+			maxOutputBytes: MAX_LS_FILES_OUTPUT_BYTES,
 			resourceLabel: "git-tracked-ignore",
 		});
-		if (result.error || result.status !== 0) return undefined;
 		if (result.outputTruncated === true) {
 			recordTruncatedLsFiles("tracked");
 			return undefined;
 		}
+		if (result.error || result.status !== 0) return undefined;
 		return parseTrackedFilesOutput(result.stdout, cwd);
 	} catch {
 		return undefined;

--- a/tests/clients/git-tracked-ignore.test.ts
+++ b/tests/clients/git-tracked-ignore.test.ts
@@ -82,7 +82,7 @@ describe("collectUntrackedIgnoredIds (#694)", () => {
 			vi.spyOn(safeSpawn, "safeSpawnAsync").mockResolvedValue({
 				stdout: "partial/path.ts\n",
 				stderr: "",
-				status: 0,
+				status: 1,
 				outputTruncated: true,
 			});
 
@@ -102,6 +102,25 @@ describe("collectUntrackedIgnoredIds (#694)", () => {
 			]);
 		},
 	);
+
+	it.each([
+		["untracked-ignored", collectUntrackedIgnoredIds],
+		["tracked", collectTrackedFiles],
+	] as const)("caps %s git ls-files stdout", async (_site, collect) => {
+		const spawn = vi.spyOn(safeSpawn, "safeSpawnAsync").mockResolvedValue({
+			stdout: "tracked/path.ts\n",
+			stderr: "",
+			status: 0,
+		});
+
+		await collect(process.cwd());
+
+		expect(spawn).toHaveBeenCalledWith(
+			"git",
+			expect.any(Array),
+			expect.objectContaining({ maxOutputBytes: 16 * 1024 * 1024 }),
+		);
+	});
 
 	it("degrades to undefined (no throw) outside a git repo", async () => {
 		const env = setupTestEnvironment("pi-lens-git-tracked-ignore-nogit-");

--- a/tests/clients/git-tracked-ignore.test.ts
+++ b/tests/clients/git-tracked-ignore.test.ts
@@ -1,11 +1,18 @@
 import { execFileSync } from "node:child_process";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	_resetTrackedFilesCacheForTests,
 	_resetUntrackedIgnoredCacheForTests,
+	collectTrackedFiles,
 	collectUntrackedIgnoredIds,
 	parseUntrackedIgnoredOutput,
 } from "../../clients/git-tracked-ignore.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
 import { normalizeMapKey } from "../../clients/path-utils.js";
+import * as safeSpawn from "../../clients/safe-spawn.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
 describe("parseUntrackedIgnoredOutput", () => {
@@ -22,9 +29,13 @@ describe("parseUntrackedIgnoredOutput", () => {
 describe("collectUntrackedIgnoredIds (#694)", () => {
 	beforeEach(() => {
 		_resetUntrackedIgnoredCacheForTests();
+		_resetTrackedFilesCacheForTests();
+		resetDegradationLedger();
 	});
 	afterEach(() => {
 		_resetUntrackedIgnoredCacheForTests();
+		_resetTrackedFilesCacheForTests();
+		vi.restoreAllMocks();
 	});
 
 	function initGitRepo(cwd: string): void {
@@ -61,6 +72,36 @@ describe("collectUntrackedIgnoredIds (#694)", () => {
 			env.cleanup();
 		}
 	});
+
+	it.each([
+		["untracked-ignored", collectUntrackedIgnoredIds],
+		["tracked", collectTrackedFiles],
+	] as const)(
+		"fails closed when %s git ls-files output is truncated",
+		async (site, collect) => {
+			vi.spyOn(safeSpawn, "safeSpawnAsync").mockResolvedValue({
+				stdout: "partial/path.ts\n",
+				stderr: "",
+				status: 0,
+				outputTruncated: true,
+			});
+
+			expect(await collect(process.cwd())).toBeUndefined();
+			expect(getDegradationSummary()).toEqual([
+				{
+					kind: "git-tracked-ignore-truncated",
+					count: 1,
+					droppedCount: 0,
+					latestReasons: [
+						{
+							subject: `git-ls-files:${site}`,
+							reason: "safeSpawnAsync capped git ls-files stdout",
+						},
+					],
+				},
+			]);
+		},
+	);
 
 	it("degrades to undefined (no throw) outside a git repo", async () => {
 		const env = setupTestEnvironment("pi-lens-git-tracked-ignore-nogit-");


### PR DESCRIPTION
## Summary

Fixes defect shape 10, “silencing counted as fixing,” at both `git ls-files` parse sites. A capped stdout result now returns unavailable instead of an under-populated tracked or ignored set. Each parse site emits one bounded `git-tracked-ignore-truncated` degradation record.

The change is intentionally fail closed at the producer boundary. Existing consumers keep their unavailable behavior and cannot treat a partial set as complete.

## Tests

- Red-first mocked `SpawnResult` with `outputTruncated: true` for both `collectUntrackedIgnoredIds` and `collectTrackedFiles`; pre-fix received a partial `Set`, post-fix receives `undefined`.
- Real degradation-ledger assertion proves the parse-site subject and bounded record.
- Mutation proof: replacing either `outputTruncated` guard with `false &&` made its regression case fail with the partial `Set`.
- `npm run build`
- `npm run lint`
- `npm run fmt:check`
- Targeted consumers: `git-tracked-ignore`, `gitleaks-scratch-exclusion`, and `graph-cache`: 42 tests passed.
- Governance: session-state conformance, changelog entries, and delivery-surface ratchet: 80 tests passed.

The ast-grep self-scan scanned 1,236 files with 0 findings.

## Blast radius

| Consumer | Behavior when a set is unavailable | Fail-closed direction |
| --- | --- | --- |
| `clients/file-utils.ts` `ProjectIgnoreMatcher` | Uses pattern-only ignore behavior; it does not claim tracked status. | Keep tracked rescue disabled until a complete set is available. |
| `clients/gitleaks-client.ts` `classifyAndFilterFindings` | Leaves `pathStatus` unset when both git-backed sets are unavailable. | Do not label a finding tracked, ignored, or untracked from partial data. |
| `clients/lens-map.ts` | Does not apply the untracked-ignored exclusion set. | Keep files visible rather than silently dropping paths from a partial set. |
| `clients/review-graph/builder.ts` | Does not apply untracked-ignored node exclusion, and fingerprints unavailable separately. | Preserve graph completeness and prevent checkpoint reuse across unavailable state. |

The touched production modules are `git-tracked-ignore.ts` and `degradation-ledger.ts`. The entry points are the two fetchers, `ensureTrackedIndex`, gitleaks classification, lens-map generation, and review-graph generation. The change adds one boolean read and one bounded ledger admission per truncated spawn, with no new spawn or filesystem work.

## Class sweep

Population census of production `safeSpawnAsync` consumers that parse stdout into a collection or collection-shaped report:

| Site | Verdict |
| --- | --- |
| `clients/opaque-mutation-scan.ts` `git status --porcelain -z` | Guard present but DORMANT (no cap at the spawn site). |
| `clients/git-tracked-ignore.ts` untracked/ignored `git ls-files` | Fixed here; returns `undefined` and records `git-tracked-ignore:untracked-ignored`. |
| `clients/git-tracked-ignore.ts` tracked `git ls-files` | Fixed here; returns `undefined` and records `git-tracked-ignore:tracked`. |
| `clients/ast-grep-client.ts` validation outline via `execRaw` | Live cap and truncation failure. |
| `clients/dispatch/runners/helm-lint.ts` report | Guard present but DORMANT (no cap at the spawn site). |
| `clients/dispatch/runners/helm-render.ts` scan report (`:750`/`:798`) | Live cap and truncation failure. |
| `clients/dispatch/runners/helm-render.ts` render report (`:953`) | Guard present but DORMANT (no cap at the spawn site). |
| `clients/dispatch/runners/oxlint.ts` JSON and Unix diagnostics | Guard present but DORMANT (no cap at the spawn site). |
| `clients/sg-runner.ts` lint and file-lint matches | Live cap and truncation failure before JSON parsing. |
| `clients/dependency-checker.ts` Madge file and workspace collections | JSON parse errors enter the existing failed/empty path; no partial JSON collection is accepted. |
| `clients/test-runner-client.ts` Vitest/Jest failure collection | JSON parse errors enter the existing unreadable-result path; no partial JSON collection is accepted. |
| `clients/dispatch/runners/actionlint.ts`, `biome-check.ts`, `credo.ts`, `cpp-check.ts`, `cue-vet.ts`, `dart-analyze.ts`, `detekt.ts`, `dotnet-build.ts`, `elixir-check.ts`, `eslint.ts`, `gleam-check.ts`, `golangci-lint.ts`, `hadolint.ts`, `htmlhint.ts`, `javac.ts`, `ktlint.ts`, `markdownlint.ts`, `mypy.ts`, `php-lint.ts`, `phpstan.ts`, `prisma-validate.ts`, `psscriptanalyzer.ts`, `pyright.ts`, `rubocop.ts`, `ruff.ts`, `rust-clippy.ts`, `shellcheck.ts`, `shfmt.ts`, `spellcheck.ts`, `spotbugs.ts`, `sqlfluff.ts`, `stylelint.ts`, `swiftlint.ts`, `taplo.ts`, `terragrunt.ts`, `tflint.ts`, `trivy-config.ts`, `vale.ts`, `yamllint.ts`, `zig-check.ts` | Diagnostic collections use parser failure/empty-output semantics and, where applicable, `parseToolRun`/`finishParsedRun`; none is a complete tracked/ignored universe. No additional complete-set consumer was found. |
| `clients/gitleaks-client.ts`, `opengrep-client.ts` | `safeSpawnAsync` writes a report file; the collection is parsed from that file, not safe-spawn stdout. Out of scope. |
| `clients/resource-sampler.ts`, `instance-reaper.ts` | Use `spawnCollectStdoutResult`, not `safeSpawnAsync`. Out of scope. |

The sweep covered `clients/` imports and every stdout parse site, including the edited module itself. The #2055 opaque-mutation member is already correct; #2075 fixes both remaining complete-set git members.

## Observability

Truncation emits one bounded degradation-ledger record per parse site:

- kind: `git-tracked-ignore-truncated`
- subjects: `git-ls-files:untracked-ignored` and `git-ls-files:tracked`
- reason: `safeSpawnAsync capped git ls-files stdout`

The ledger retains the parse-site identity and bounds repeated records through `recordDegradationOnce`.

Consulted AGENTS.md: Issue and PR design contract, Standing invariants: Dispatch, runners, formatters, and installer, Recurring defect shapes: Shape 10, Test requirements, Real-runner rule/dispatch tests, and the commit conventions.
## Fix round 1

- F1 fixed: both `git ls-files` spawns now cap stdout at 16 MiB. The real listing is about 133 KiB, so the cap bounds pathological repositories without affecting sane ones.
- F2 fixed: `outputTruncated` is checked before status, so a cap-kill with status 1 returns unavailable and records the bounded degradation.
- F3 fixed: the regression uses the production-faithful cap-kill shape.

Red proof before F2:

```ts
{ status: 1, outputTruncated: true }
```

The pre-round ordering returned `undefined` before recording truncation because the status check swallowed this real cap-kill. The corrected test asserts the unavailable verdict and degradation record.

- F4 fixed: the census distinguishes live guards from dormant guards. The dormant family is noted on issue #2075 for follow-up.
- F5 fixed: the self-scan result is 1,236 files, 0 findings.
- F6 disposition: the refreshed Unit tests job still died with exit 137 after passing tests, confirming runner OOM infrastructure failure; Analyze(ruby) now passes.

Test edits: `tests/clients/git-tracked-ignore.test.ts` now uses the status-1 cap-kill regression for both parse sites and adds both max-output routing assertions.
