### PR TITLE
ci: report missing priority labels in the weekly sweep (refs #1676)

### DIFF
--- a/.changelog/ci-1676-priority-label-coverage.md
+++ b/.changelog/ci-1676-priority-label-coverage.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Weekly stale-issue report now flags missing priority labels (refs #1676)** — the scheduled detector's report on #1323 adds a Priority label coverage section, listing open issues with zero `priority:*` labels and open issues with more than one. Advisory only; the job still never edits an issue.

--- a/scripts/detect-stale-open-issues.mjs
+++ b/scripts/detect-stale-open-issues.mjs
@@ -15,15 +15,22 @@ const runUrl =
 	process.env.GITHUB_SERVER_URL && process.env.GITHUB_RUN_ID
 		? `${process.env.GITHUB_SERVER_URL}/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}`
 		: undefined;
-const { candidates, truncatedCommits } = await detectStaleOpenIssues({
-	fetcher: defaultFetcher(token),
-	repository,
+const { candidates, truncatedCommits, priorityCoverage } =
+	await detectStaleOpenIssues({
+		fetcher: defaultFetcher(token),
+		repository,
+	});
+const summary = formatSummary(candidates, {
+	runUrl,
+	truncatedCommits,
+	priorityCoverage,
 });
-const summary = formatSummary(candidates, { runUrl, truncatedCommits });
 console.log(summary);
 if (process.env.GITHUB_STEP_SUMMARY)
 	appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
-if (candidates.length > 0) {
+const hasPriorityGaps =
+	priorityCoverage.zero.length > 0 || priorityCoverage.multiple.length > 0;
+if (candidates.length > 0 || hasPriorityGaps) {
 	const headers = {
 		accept: "application/vnd.github+json",
 		authorization: `Bearer ${token}`,

--- a/scripts/detect-stale-open-issues.mjs
+++ b/scripts/detect-stale-open-issues.mjs
@@ -5,6 +5,7 @@ import {
 	defaultFetcher,
 	detectStaleOpenIssues,
 	formatSummary,
+	shouldPost,
 } from "./lib/stale-open-issues.mjs";
 
 const repository = process.env.GITHUB_REPOSITORY;
@@ -28,9 +29,7 @@ const summary = formatSummary(candidates, {
 console.log(summary);
 if (process.env.GITHUB_STEP_SUMMARY)
 	appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
-const hasPriorityGaps =
-	priorityCoverage.zero.length > 0 || priorityCoverage.multiple.length > 0;
-if (candidates.length > 0 || hasPriorityGaps) {
+if (shouldPost({ candidates, priorityCoverage })) {
 	const headers = {
 		accept: "application/vnd.github+json",
 		authorization: `Bearer ${token}`,

--- a/scripts/lib/stale-open-issues.d.mts
+++ b/scripts/lib/stale-open-issues.d.mts
@@ -25,6 +25,10 @@ export interface PriorityCoverage {
 export function checkPriorityCoverage(
 	issues: PriorityLabeledIssue[],
 ): PriorityCoverage;
+export function shouldPost(options: {
+	candidates: StaleIssueCandidate[];
+	priorityCoverage: PriorityCoverage;
+}): boolean;
 export function detectStaleOpenIssues(options: {
 	fetcher: (
 		url: string,

--- a/scripts/lib/stale-open-issues.d.mts
+++ b/scripts/lib/stale-open-issues.d.mts
@@ -11,6 +11,20 @@ export interface StaleIssueCandidate {
 	};
 	evidence: string[];
 }
+export interface PriorityLabeledIssue {
+	number: number;
+	title: string;
+	html_url?: string;
+	pull_request?: unknown;
+	labels?: Array<string | { name?: string }>;
+}
+export interface PriorityCoverage {
+	zero: PriorityLabeledIssue[];
+	multiple: PriorityLabeledIssue[];
+}
+export function checkPriorityCoverage(
+	issues: PriorityLabeledIssue[],
+): PriorityCoverage;
 export function detectStaleOpenIssues(options: {
 	fetcher: (
 		url: string,
@@ -18,10 +32,18 @@ export function detectStaleOpenIssues(options: {
 	) => Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
 	repository: string;
 	branch?: string;
-}): Promise<{ candidates: StaleIssueCandidate[]; truncatedCommits: number }>;
+}): Promise<{
+	candidates: StaleIssueCandidate[];
+	truncatedCommits: number;
+	priorityCoverage: PriorityCoverage;
+}>;
 export function formatSummary(
 	candidates: StaleIssueCandidate[],
-	options?: { runUrl?: string; truncatedCommits?: number },
+	options?: {
+		runUrl?: string;
+		truncatedCommits?: number;
+		priorityCoverage?: PriorityCoverage;
+	},
 ): string;
 export function defaultFetcher(
 	token: string,

--- a/scripts/lib/stale-open-issues.mjs
+++ b/scripts/lib/stale-open-issues.mjs
@@ -201,6 +201,17 @@ export function formatSummary(
 	return lines.join("\n");
 }
 
+// #1676 fix round: the comment-posting decision was inline and untested --
+// reverting it to the old candidates-only gate left the suite green. Naming
+// it lets a mutation on either half of the OR fail a test.
+export function shouldPost({ candidates, priorityCoverage }) {
+	return (
+		candidates.length > 0 ||
+		priorityCoverage.zero.length > 0 ||
+		priorityCoverage.multiple.length > 0
+	);
+}
+
 export function defaultFetcher(token) {
 	return (url, init) =>
 		fetch(url, {

--- a/scripts/lib/stale-open-issues.mjs
+++ b/scripts/lib/stale-open-issues.mjs
@@ -7,6 +7,29 @@ export const DETECTOR_ISSUE = 1323;
 
 const CLOSING_REFERENCE = /\b(?:closes|fixes|resolves)\s+#(\d+)\b/gi;
 const ISSUE_NUMBER = /(?:^|[^\d])#?(\d+)(?!\d)/g;
+const PRIORITY_LABEL = /^priority:/;
+
+function labelName(label) {
+	return typeof label === "string" ? label : (label?.name ?? "");
+}
+
+// #1676: exactly one priority:* label is the standing triage rule. Advisory
+// only -- this never edits an issue, it just names the gap for a human.
+export function checkPriorityCoverage(issues) {
+	const zero = [];
+	const multiple = [];
+	for (const issue of issues) {
+		if (issue.pull_request) continue;
+		const labels = Array.isArray(issue.labels) ? issue.labels : [];
+		const priorityCount = labels.filter((label) =>
+			PRIORITY_LABEL.test(labelName(label)),
+		).length;
+		if (priorityCount === 0) zero.push(issue);
+		else if (priorityCount > 1) multiple.push(issue);
+	}
+	const byNumber = (a, b) => a.number - b.number;
+	return { zero: zero.sort(byNumber), multiple: multiple.sort(byNumber) };
+}
 
 function numbersFromClosingText(text) {
 	const numbers = new Set();
@@ -115,12 +138,20 @@ export async function detectStaleOpenIssues({
 	return {
 		candidates,
 		truncatedCommits: Math.max(0, commits.length - MAX_COMMIT_DETAILS),
+		priorityCoverage: checkPriorityCoverage(openIssues),
 	};
+}
+
+function formatIssueLine(issue) {
+	const link = issue.html_url
+		? `[#${issue.number}](${issue.html_url})`
+		: `#${issue.number}`;
+	return `- ${link} **${issue.title}**`;
 }
 
 export function formatSummary(
 	candidates,
-	{ runUrl, truncatedCommits = 0 } = {},
+	{ runUrl, truncatedCommits = 0, priorityCoverage } = {},
 ) {
 	const lines = [
 		"<!-- pi-lens-stale-open-issue-detector -->",
@@ -141,6 +172,32 @@ export function formatSummary(
 			`Note: ${truncatedCommits} commit(s) beyond the ${MAX_COMMIT_DETAILS}-detail cap were NOT examined this run.`,
 		);
 	if (runUrl) lines.push("", `Workflow run: ${runUrl}`);
+	if (priorityCoverage) {
+		lines.push(
+			"",
+			"## Priority label coverage",
+			"",
+			"Advisory only: every open issue should carry exactly one priority:* label (#1676). This job never edits labels.",
+			"",
+		);
+		lines.push(
+			`### Zero priority:* labels (${priorityCoverage.zero.length})`,
+			"",
+		);
+		if (priorityCoverage.zero.length === 0) lines.push("None.");
+		else
+			for (const issue of priorityCoverage.zero)
+				lines.push(formatIssueLine(issue));
+		lines.push(
+			"",
+			`### More than one priority:* label (${priorityCoverage.multiple.length})`,
+			"",
+		);
+		if (priorityCoverage.multiple.length === 0) lines.push("None.");
+		else
+			for (const issue of priorityCoverage.multiple)
+				lines.push(formatIssueLine(issue));
+	}
 	return lines.join("\n");
 }
 

--- a/tests/scripts/stale-open-issues.test.ts
+++ b/tests/scripts/stale-open-issues.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	checkPriorityCoverage,
 	detectStaleOpenIssues,
 	formatSummary,
 	MAX_COMMIT_DETAILS,
@@ -146,5 +147,129 @@ describe("stale open-issue detector (#1323)", () => {
 		expect(formatSummary([], { runUrl: "https://example/run" })).toContain(
 			"never closes issues",
 		);
+	});
+});
+
+describe("priority label coverage (#1676)", () => {
+	it("flags an open issue with zero priority:* labels", () => {
+		const issues = [
+			{
+				number: 1,
+				title: "no priority",
+				html_url: "https://github.com/acme/repo/issues/1",
+				labels: [{ name: "bug" }],
+			},
+		];
+		const { zero, multiple } = checkPriorityCoverage(issues);
+		expect(zero).toEqual([expect.objectContaining({ number: 1 })]);
+		expect(multiple).toEqual([]);
+	});
+
+	it("does not flag an open issue with exactly one priority:* label", () => {
+		const issues = [
+			{
+				number: 2,
+				title: "one priority",
+				html_url: "https://github.com/acme/repo/issues/2",
+				labels: [{ name: "bug" }, { name: "priority:p2" }],
+			},
+		];
+		const { zero, multiple } = checkPriorityCoverage(issues);
+		expect(zero).toEqual([]);
+		expect(multiple).toEqual([]);
+	});
+
+	it("flags an open issue with more than one priority:* label", () => {
+		const issues = [
+			{
+				number: 3,
+				title: "two priorities",
+				html_url: "https://github.com/acme/repo/issues/3",
+				labels: [{ name: "priority:p1" }, { name: "priority:p2" }],
+			},
+		];
+		const { zero, multiple } = checkPriorityCoverage(issues);
+		expect(zero).toEqual([]);
+		expect(multiple).toEqual([expect.objectContaining({ number: 3 })]);
+	});
+
+	it("treats labels that merely contain 'priority' but aren't priority:* as zero coverage", () => {
+		const issues = [
+			{
+				number: 4,
+				title: "decoy label",
+				html_url: "https://github.com/acme/repo/issues/4",
+				labels: [{ name: "high-priority" }, { name: "not-priority:p1" }],
+			},
+		];
+		const { zero, multiple } = checkPriorityCoverage(issues);
+		expect(zero).toEqual([expect.objectContaining({ number: 4 })]);
+		expect(multiple).toEqual([]);
+	});
+
+	it("ignores pull requests when checking priority coverage", () => {
+		const issues = [
+			{
+				number: 5,
+				title: "a pull request",
+				html_url: "https://github.com/acme/repo/pull/5",
+				pull_request: {},
+				labels: [],
+			},
+		];
+		const { zero, multiple } = checkPriorityCoverage(issues);
+		expect(zero).toEqual([]);
+		expect(multiple).toEqual([]);
+	});
+
+	it("accepts plain-string labels, not only label objects", () => {
+		const issues = [
+			{ number: 6, title: "string label", labels: ["priority:p3"] },
+		];
+		const { zero, multiple } = checkPriorityCoverage(issues);
+		expect(zero).toEqual([]);
+		expect(multiple).toEqual([]);
+	});
+
+	it("sorts both lists by issue number", () => {
+		const issues = [
+			{ number: 20, title: "b", labels: [] },
+			{ number: 7, title: "a", labels: [] },
+		];
+		const { zero } = checkPriorityCoverage(issues);
+		expect(zero.map((issue) => issue.number)).toEqual([7, 20]);
+	});
+});
+
+describe("formatSummary priority coverage section", () => {
+	it("lists zero- and multiple-priority issues by number and title", () => {
+		const summary = formatSummary([], {
+			priorityCoverage: {
+				zero: [
+					{
+						number: 8,
+						title: "missing priority",
+						html_url: "https://github.com/acme/repo/issues/8",
+					},
+				],
+				multiple: [
+					{
+						number: 9,
+						title: "double priority",
+						html_url: "https://github.com/acme/repo/issues/9",
+					},
+				],
+			},
+		});
+		expect(summary).toContain("Priority label coverage");
+		expect(summary).toContain("#8");
+		expect(summary).toContain("missing priority");
+		expect(summary).toContain("#9");
+		expect(summary).toContain("double priority");
+	});
+
+	it("omits the priority coverage section when not provided (byte-identical for existing callers)", () => {
+		const before = formatSummary([], { runUrl: "https://example/run" });
+		expect(before).not.toContain("Priority label coverage");
 	});
 });

--- a/tests/scripts/stale-open-issues.test.ts
+++ b/tests/scripts/stale-open-issues.test.ts
@@ -6,6 +6,7 @@ import {
 	MAX_COMMIT_DETAILS,
 	MAX_PAGES,
 	PAGE_SIZE,
+	shouldPost,
 } from "../../scripts/lib/stale-open-issues.mjs";
 
 function fakeGithub(data: Record<string, unknown>) {
@@ -271,5 +272,25 @@ describe("formatSummary priority coverage section", () => {
 	it("omits the priority coverage section when not provided (byte-identical for existing callers)", () => {
 		const before = formatSummary([], { runUrl: "https://example/run" });
 		expect(before).not.toContain("Priority label coverage");
+	});
+});
+
+describe("shouldPost (#1676 fix round)", () => {
+	it("posts when priority gaps exist even with zero stale candidates", () => {
+		expect(
+			shouldPost({
+				candidates: [],
+				priorityCoverage: { zero: [{ number: 1, title: "x" }], multiple: [] },
+			}),
+		).toBe(true);
+	});
+
+	it("stays silent when there are neither stale candidates nor priority gaps", () => {
+		expect(
+			shouldPost({
+				candidates: [],
+				priorityCoverage: { zero: [], multiple: [] },
+			}),
+		).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

Extends the weekly stale-open-issue detector (`scripts/detect-stale-open-issues.mjs`, run by `.github/workflows/stale-open-issues.yml`) to also flag priority-label gaps, per the standing triage rule added in AGENTS.md (#1676): every open issue should carry exactly one `priority:*` label.

- Added `checkPriorityCoverage(issues)` to `scripts/lib/stale-open-issues.mjs`. A pure function over the issue list the detector already fetches (labels are already in that payload — no new API call). It sorts open, non-PR issues into two buckets: zero `priority:*` labels, and more than one.
- Wired the result into `detectStaleOpenIssues` and into `formatSummary`, which now appends a "Priority label coverage" section listing each flagged issue by number and title.
- The workflow now posts or updates its #1323 comment when either stale candidates or priority gaps exist, so a week with zero stale candidates but open priority gaps still gets a report.
- Detection only. The script never edits a label or closes an issue.

## Tests

- `tests/scripts/stale-open-issues.test.ts`: 7 new cases for `checkPriorityCoverage` (zero, one, two, non-priority-labels-only decoy, PR exclusion, string-shaped labels, sort order) plus 2 for the new `formatSummary` section (present, and absent when not passed) — 9 new tests total.
- Red-first: ran the new tests against the pre-fix tree. 7 `checkPriorityCoverage` tests failed with `TypeError: checkPriorityCoverage is not a function`; 1 `formatSummary` test failed on the missing heading (`AssertionError`) — 8 failures. The 9th new test ("omits the section when not provided") passed even pre-fix, since an unrecognized option was already harmless. Output kept.
- Mutation-proofed the "exactly one" predicate: commented out the `priorityCount > 1` branch and reran — the "flags more than one" test failed as expected, confirming the guard is load-bearing. Reverted before committing.
- All 14 tests green after the fix, including the 5 pre-existing stale-detection tests, unmodified.
- `npm run build` run before testing (repo convention; `scripts/*.mjs` are outside tsc so the build itself didn't touch these files).
- `npx oxfmt --check` clean on the four changed files.
- `node scripts/check-changelog-fragments.mjs`: OK.
- Full suite and CI lint/type-check: left to CI, per repo policy.

## Blast radius

- `detectStaleOpenIssues`'s return shape gains a `priorityCoverage` field; its only caller is `scripts/detect-stale-open-issues.mjs`, updated in this PR.
- `formatSummary`'s new `priorityCoverage` option is optional and additive — omitted, the output is byte-identical to before (covered by the "omits section when not provided" test).
- No new process spawns, no behavior widening beyond the new advisory section. Workflow cadence (weekly, `workflow_dispatch`) is unchanged.
- The posting gate in `detect-stale-open-issues.mjs` is now the exported, tested `shouldPost({ candidates, priorityCoverage })`, so a week with a clean stale-candidate list but open priority gaps still updates the #1323 comment. See the fix-round section below.

## Class sweep

Other label-coverage checks that could ride the same weekly report: type-label coverage and area-label coverage, per AGENTS.md's issue-labeling taxonomy. Not implemented here — re-homed as a comment on #1676 so it has a place to land instead of only living in this PR body.

## Observability

The weekly #1323 comment and the workflow's `GITHUB_STEP_SUMMARY` output are the record: a human reads the Priority label coverage section during the same triage pass that already reviews stale candidates. No separate log or ledger needed for an advisory-only, weekly-cadence check.

Known inherited limit: `paged()` caps every GitHub list fetch at `MAX_PAGES * PAGE_SIZE` (300 items). `checkPriorityCoverage` runs over whatever `paged()` returns for open issues, so once open-issue count exceeds 300 the coverage check silently misses the overflow, same as the pre-existing stale-candidate detection. Not fixed here per review guidance; flagging in case it needs its own issue.

Refs #1676

## Review round 1

The reviewer's mutation sweep found the posting-gate change was the PR's only untested behavioral change: reverting `scripts/detect-stale-open-issues.mjs`'s inline gate back to `if (candidates.length > 0)` left all 339 tests green. Six other library-level mutations were caught (all reds), and the "labels already in the payload" claim was proven live.

Fixes in this round:

- **F1 (posting gate untested).** Extracted `shouldPost({ candidates, priorityCoverage })` as a pure, exported function in `scripts/lib/stale-open-issues.mjs`, called from the entrypoint instead of an inline boolean. Added two direction tests: priority gaps with zero stale candidates still posts, and neither condition stays silent. Red-first: added the two tests before `shouldPost` existed (`TypeError: shouldPost is not a function`); after implementing it, reproduced the reviewer's exact mutation (revert to `candidates.length > 0` only) and confirmed the "gaps with no stale candidates" test fails (`expected false to be true`) — see snippet below. Reverted the mutation before committing.
- **F5 (class-sweep follow-up unfiled).** Re-homed the type-label/area-label coverage follow-up as a comment on #1676 (closed, so the comment stands as the record instead of the issue reopening): https://github.com/apmantza/pi-lens/issues/1676#issuecomment-5417742208.
- **F3 (test tally wrong).** Corrected the Tests section: 7 `checkPriorityCoverage` cases plus 2 `formatSummary` cases (9 new tests, not 8), with the red run broken out as 7 `TypeError` plus 1 `AssertionError` (8 failures; the 9th new test passed even pre-fix because an unrecognized `formatSummary` option was already harmless).
- **F2 (inherited page cap).** Not fixed, per review guidance — noted as a known inherited limit in the Observability section above (`paged()`'s 300-item cap applies to `checkPriorityCoverage` the same way it already applies to stale-candidate detection).

### F1 red snippet

```
FAIL  |default| tests/scripts/stale-open-issues.test.ts > shouldPost (#1676 fix round) > posts when priority gaps exist even with zero stale candidates
AssertionError: expected false to be true // Object.is equality

- Expected
+ Received

- true
+ false

 ❯ tests/scripts/stale-open-issues.test.ts:285:5
```

Full suite after the fix round: 16/16 green in `tests/scripts/stale-open-issues.test.ts` (14 from round 1 plus 2 new `shouldPost` cases).

