### PR TITLE
fix(observability): guard metrics-history git probe stderr (closes #2095)

### DIFF
--- a/.changelog/fix-2095-metrics-history-stderr.md
+++ b/.changelog/fix-2095-metrics-history-stderr.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Stop metrics-history's git probe from leaking stderr into the TUI (#2095)** — `getCurrentCommit()` now pipes `git rev-parse` stderr instead of inheriting it, so a failing probe reports "unknown" quietly instead of printing a raw `fatal:` line. The same fix applies to the LSP launcher's Windows registry PATH probe, the only other unguarded `execSync`/`execFileSync` call in the runtime.

--- a/clients/lsp/launch.ts
+++ b/clients/lsp/launch.ts
@@ -131,34 +131,42 @@ function resolvePathValue(env: NodeJS.ProcessEnv): string {
 	return combinePathValuesForPlatform([env.PATH, env.Path, env.path]);
 }
 
-/** Read live system+user PATH from Windows registry (bypasses stale process.env.PATH). */
-function readWindowsRegistryPath(): string {
+/**
+ * Run an `execFileSync` probe with the #2095 stderr guard applied, returning
+ * `""` on any failure. Exported as a small test seam: production always calls
+ * it with the fixed `powershell.exe` command/args below, but a test can pass
+ * a command guaranteed to fail with real stderr output (no real Windows or
+ * powershell.exe required) to prove the guard is actually reached and not
+ * vacuous.
+ */
+export function runStderrGuardedProbe(command: string, args: string[]): string {
 	try {
 		const { execFileSync } =
 			require("node:child_process") as typeof import("node:child_process");
-		const out = execFileSync(
-			"powershell.exe",
-			[
-				"-NoProfile",
-				"-NonInteractive",
-				"-Command",
-				"[System.Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path','User')",
-			],
-			{
-				timeout: 3000,
-				encoding: "utf8",
-				// #2095 sibling: execFileSync inherits stderr to the parent by
-				// default (only stdout is captured into `out`), so a failed
-				// powershell.exe launch would print raw diagnostics into the pi
-				// TUI even though the surrounding catch already reports "unknown"
-				// PATH. Pipe stderr instead of inheriting it.
-				stdio: ["ignore", "pipe", "ignore"],
-			},
-		);
+		const out = execFileSync(command, args, {
+			timeout: 3000,
+			encoding: "utf8",
+			// #2095 sibling: execFileSync inherits stderr to the parent by
+			// default (only stdout is captured into `out`), so a failed
+			// powershell.exe launch would print raw diagnostics into the pi
+			// TUI even though the surrounding catch already returns "" (read as
+			// "unknown" PATH by every caller). Pipe stderr instead of inheriting it.
+			stdio: ["ignore", "pipe", "ignore"],
+		});
 		return out.trim();
 	} catch {
 		return "";
 	}
+}
+
+/** Read live system+user PATH from Windows registry (bypasses stale process.env.PATH). */
+function readWindowsRegistryPath(): string {
+	return runStderrGuardedProbe("powershell.exe", [
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		"[System.Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path','User')",
+	]);
 }
 
 let _liveWindowsPath: string | null = null;

--- a/clients/lsp/launch.ts
+++ b/clients/lsp/launch.ts
@@ -144,7 +144,16 @@ function readWindowsRegistryPath(): string {
 				"-Command",
 				"[System.Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path','User')",
 			],
-			{ timeout: 3000, encoding: "utf8" },
+			{
+				timeout: 3000,
+				encoding: "utf8",
+				// #2095 sibling: execFileSync inherits stderr to the parent by
+				// default (only stdout is captured into `out`), so a failed
+				// powershell.exe launch would print raw diagnostics into the pi
+				// TUI even though the surrounding catch already reports "unknown"
+				// PATH. Pipe stderr instead of inheriting it.
+				stdio: ["ignore", "pipe", "ignore"],
+			},
 		);
 		return out.trim();
 	} catch {

--- a/clients/metrics-history.ts
+++ b/clients/metrics-history.ts
@@ -72,9 +72,17 @@ function getCurrentCommit(): string {
 	}
 
 	try {
+		// #2095: execSync inherits the child's stderr to THIS process by
+		// default (only stdout is captured for the return value), so a
+		// failing `git rev-parse` prints its raw "fatal: ..." line straight
+		// into the pi TUI — the catch below only ever sees the thrown
+		// non-zero-exit error, never the already-inherited stream. The
+		// explicit stdio array pipes stderr instead, so a failure is fully
+		// contained: silent here, same as the "unknown" fallback it feeds.
 		return execSync("git rev-parse --short HEAD", {
 			encoding: "utf-8",
 			timeout: 5000,
+			stdio: ["ignore", "pipe", "ignore"],
 		}).trim();
 	} catch {
 		return "unknown";

--- a/tests/clients/lsp/launch-stderr-guard.test.ts
+++ b/tests/clients/lsp/launch-stderr-guard.test.ts
@@ -1,0 +1,58 @@
+/**
+ * #2095 fix-round F1 — the launch.ts sibling guard was reviewed as vacuous:
+ * no test actually drove `readWindowsRegistryPath`'s failure path, so
+ * reverting the `stdio` override there redded nothing.
+ *
+ * `runStderrGuardedProbe` (the extracted seam `readWindowsRegistryPath` calls
+ * with the fixed `powershell.exe` command) is exported so a test can pass a
+ * command guaranteed to fail with real stderr output, with no real Windows or
+ * powershell.exe required. This spawns a REAL child Node process (no mocking
+ * of `node:child_process`) that requires the compiled `clients/lsp/launch.js`
+ * and calls `runStderrGuardedProbe("git", ["not-a-real-subcommand"])`, which
+ * genuinely fails and genuinely writes to stderr. The child's own stderr is
+ * inherited straight from the grandchild `git` process pre-fix, so this test
+ * observes the real leak rather than asserting on mocked call arguments.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const LAUNCH_JS = path.resolve(__dirname, "../../../clients/lsp/launch.js");
+
+function hasGit(): boolean {
+	try {
+		execFileSync("git", ["--version"], { stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+describe("launch.ts runStderrGuardedProbe stderr suppression (#2095)", () => {
+	it.skipIf(!hasGit())(
+		"does not leak the probed command's stderr when it fails",
+		() => {
+			const script = [
+				`const { runStderrGuardedProbe } = require(${JSON.stringify(LAUNCH_JS)});`,
+				'const result = runStderrGuardedProbe("git", ["not-a-real-subcommand"]);',
+				// Print the resolved value so the test can prove the failure path
+				// was actually taken (the empty-string fallback), not skipped.
+				'process.stdout.write("RESULT:" + JSON.stringify(result));',
+			].join("\n");
+
+			const result = spawnSync(process.execPath, ["-e", script], {
+				encoding: "utf-8",
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.status).toBe(0);
+			// Proves the probe actually ran its failure path — not that the
+			// child silently crashed or the require target was missing.
+			expect(result.stdout).toContain('RESULT:""');
+			// The bug: git's raw "not a git command" line lands on the child's
+			// own stderr, unfiltered by any try/catch inside the probe.
+			expect(result.stderr).not.toMatch(/not a git command/i);
+		},
+	);
+});

--- a/tests/clients/metrics-history-stderr.test.ts
+++ b/tests/clients/metrics-history-stderr.test.ts
@@ -1,0 +1,86 @@
+/**
+ * #2095 — `getCurrentCommit()` in `clients/metrics-history.ts` ran
+ * `execSync("git rev-parse --short HEAD")` without an explicit `stdio`
+ * override. Node's `execSync`/`execFileSync` inherit the child's stderr to
+ * the PARENT process by default (only stdout is piped into the return
+ * value), so a failing `git rev-parse` prints its raw "fatal: ..." line
+ * straight into the pi TUI, bypassing the surrounding try/catch entirely —
+ * the catch only sees the thrown (non-zero exit) error, never the
+ * already-inherited stderr stream.
+ *
+ * This spawns a REAL child Node process (not a mock) that requires the
+ * compiled runtime module and calls `captureSnapshot()` with its cwd set to
+ * a real git repo that has zero commits, so `git rev-parse --short HEAD`
+ * genuinely fails and genuinely writes to stderr. The child's own stderr is
+ * inherited straight from the grandchild `git` process pre-fix, so this
+ * test observes the real leak rather than asserting on mocked call
+ * arguments.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const METRICS_HISTORY_JS = path.resolve(
+	__dirname,
+	"../../clients/metrics-history.js",
+);
+
+function hasGit(): boolean {
+	try {
+		execFileSync("git", ["--version"], { stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+describe("metrics-history getCurrentCommit stderr suppression (#2095)", () => {
+	it.skipIf(!hasGit())(
+		"does not leak git's stderr when rev-parse fails in a commit-less repo",
+		() => {
+			const tmp = fs.mkdtempSync(
+				path.join(os.tmpdir(), "pi-lens-metrics-history-"),
+			);
+			try {
+				// A real repo with zero commits: `git rev-parse --short HEAD`
+				// genuinely fails with "fatal: ambiguous argument 'HEAD': unknown
+				// revision or path not in the working tree." on real stderr.
+				execFileSync("git", ["init", "-q"], { cwd: tmp });
+
+				const dataDir = path.join(tmp, ".pilens-data");
+				const filePath = path.join(tmp, "file.ts");
+				const script = [
+					`process.chdir(${JSON.stringify(tmp)});`,
+					`const { captureSnapshot } = require(${JSON.stringify(METRICS_HISTORY_JS)});`,
+					"captureSnapshot(",
+					`  ${JSON.stringify(filePath)},`,
+					"  {",
+					"    maintainabilityIndex: 90,",
+					"    cognitiveComplexity: 1,",
+					"    maxNestingDepth: 1,",
+					"    linesOfCode: 10,",
+					"    maxCyclomatic: 1,",
+					"    entropy: 1,",
+					"  },",
+					");",
+				].join("\n");
+
+				const result = spawnSync(process.execPath, ["-e", script], {
+					cwd: tmp,
+					encoding: "utf-8",
+					env: { ...process.env, PILENS_DATA_DIR: dataDir },
+				});
+
+				expect(result.error).toBeUndefined();
+				// The bug: git's raw "fatal: ..." line lands on the child's own
+				// stderr, unfiltered by any try/catch inside getCurrentCommit().
+				expect(result.stderr).not.toMatch(/fatal:/i);
+			} finally {
+				fs.rmSync(tmp, { recursive: true, force: true });
+			}
+		},
+	);
+});

--- a/tests/clients/metrics-history-stderr.test.ts
+++ b/tests/clients/metrics-history-stderr.test.ts
@@ -48,16 +48,23 @@ describe("metrics-history getCurrentCommit stderr suppression (#2095)", () => {
 				// A real repo with zero commits: `git rev-parse --short HEAD`
 				// genuinely fails with "fatal: ambiguous argument 'HEAD': unknown
 				// revision or path not in the working tree." on real stderr.
-				execFileSync("git", ["init", "-q"], { cwd: tmp });
+				// `stdio: "ignore"` here is the exact guard this PR is about —
+				// this setup call must not itself leak `git init`'s stderr.
+				execFileSync("git", ["init", "-q"], { cwd: tmp, stdio: "ignore" });
 
 				const dataDir = path.join(tmp, ".pilens-data");
 				const filePath = path.join(tmp, "file.ts");
+				// Use the synchronous, immediate-save `captureSnapshots` (not the
+				// debounced `captureSnapshot`) so the resolved commit is available
+				// to print without waiting on the 5s save timer.
 				const script = [
+					`const path = require("path");`,
 					`process.chdir(${JSON.stringify(tmp)});`,
-					`const { captureSnapshot } = require(${JSON.stringify(METRICS_HISTORY_JS)});`,
-					"captureSnapshot(",
-					`  ${JSON.stringify(filePath)},`,
-					"  {",
+					`const { captureSnapshots } = require(${JSON.stringify(METRICS_HISTORY_JS)});`,
+					`const filePath = ${JSON.stringify(filePath)};`,
+					"const history = captureSnapshots([{",
+					"  filePath,",
+					"  metrics: {",
 					"    maintainabilityIndex: 90,",
 					"    cognitiveComplexity: 1,",
 					"    maxNestingDepth: 1,",
@@ -65,7 +72,12 @@ describe("metrics-history getCurrentCommit stderr suppression (#2095)", () => {
 					"    maxCyclomatic: 1,",
 					"    entropy: 1,",
 					"  },",
-					");",
+					"}]);",
+					"const relativePath = path.relative(process.cwd(), filePath);",
+					// Print the resolved commit so the test can prove the failure
+					// path was actually taken — not that the require target was
+					// missing or the child silently crashed before reaching it.
+					'process.stdout.write("COMMIT:" + JSON.stringify(history.files[relativePath].latest.commit));',
 				].join("\n");
 
 				const result = spawnSync(process.execPath, ["-e", script], {
@@ -75,6 +87,11 @@ describe("metrics-history getCurrentCommit stderr suppression (#2095)", () => {
 				});
 
 				expect(result.error).toBeUndefined();
+				expect(result.status).toBe(0);
+				// Proves getCurrentCommit() actually took its catch/fallback
+				// branch, so the stderr assertion below is checking a genuinely
+				// exercised failure path, not a script that silently no-opped.
+				expect(result.stdout).toContain('COMMIT:"unknown"');
 				// The bug: git's raw "fatal: ..." line lands on the child's own
 				// stderr, unfiltered by any try/catch inside getCurrentCommit().
 				expect(result.stderr).not.toMatch(/fatal:/i);


### PR DESCRIPTION
## Summary

`getCurrentCommit()` in `clients/metrics-history.ts` ran `git rev-parse --short HEAD` through `execSync` without an explicit `stdio` override. `execSync`/`execFileSync` pipe stdout into the return value but inherit stderr to the parent process by default. When the probe failed (a `.git` directory present but not a valid repo state, or a cwd mismatch around subagent/tool contexts), git's raw `fatal: ...` line printed straight into the pi TUI, bypassing the surrounding `try/catch` — the catch only ever sees the thrown non-zero-exit error, never the already-inherited stderr stream.

The fix pipes stderr instead of inheriting it, so a failure stays contained and the function falls through to its existing `"unknown"` fallback silently.

## Tests

New test: `tests/clients/metrics-history-stderr.test.ts`. It spawns a real child Node process (no mocking of `node:child_process`) with its cwd set to a real git repo with zero commits, so `git rev-parse --short HEAD` genuinely fails and genuinely writes to stderr. The child requires the compiled `clients/metrics-history.js` and calls `captureSnapshot()`, then the test asserts the child's own stderr never carries git's `fatal:` line.

Red run against pre-fix code:

```
 ❯ |default| tests/clients/metrics-history-stderr.test.ts (1 test | 1 failed) 241ms
     × does not leak git's stderr when rev-parse fails in a commit-less repo 239ms

AssertionError: expected 'fatal: Needed a single revision\n' not to match /fatal:/i

- Expected:
/fatal:/i

+ Received:
"fatal: Needed a single revision
"
```

Green after the fix:

```
 ✓ |default| tests/clients/metrics-history-stderr.test.ts > metrics-history getCurrentCommit stderr suppression (#2095) > does not leak git's stderr when rev-parse fails in a commit-less repo 238ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Also ran the LSP launcher's sibling suites (unaffected behaviorally, confirming no regression from the `readWindowsRegistryPath` change):

```
tests/clients/lsp/launch.test.ts
tests/clients/lsp/launch-path.test.ts
tests/clients/lsp/resolve-and-launch-fallback.test.ts
tests/clients/delivery-surface-ratchet.test.ts (references metrics-history.ts by name)

 Test Files  4 passed (4)
      Tests  18 passed | 1 skipped (19)
```

The one skip is pre-existing and unrelated to this change (a platform-gated case in an untouched test).

`npm run build` and `npm run lint` (both `tsc`) are clean. `oxfmt --check` on the three touched source/test files reports correct formatting.

## Blast radius

Behavior change is scoped to the failure path only: when `git rev-parse` succeeds, output is identical. When it fails, the only observable difference is that git's stderr no longer prints to the terminal — `getCurrentCommit()` still returns `"unknown"` exactly as before, so every caller (`captureSnapshot`, `captureSnapshots`) sees no functional change. No new process spawns, no timing change, no widened behavior. Same reasoning applies to the `readWindowsRegistryPath` sibling in `clients/lsp/launch.ts`: its catch already returns `""` on failure, and pipes rather than inherits stderr now.

## Class sweep

Pattern sweep: `grep -rn "execSync(\|execFileSync(\|spawnSync(" --include=*.ts` across `clients/`, `scripts/`, `tools/`, `mcp/` (the latter two don't exist in this repo), plus `tests/` for context.

| site | verdict | action |
|---|---|---|
| `clients/metrics-history.ts:75` `execSync` | defective | fixed — added `stdio: ["ignore","pipe","ignore"]` |
| `clients/lsp/launch.ts:139` `execFileSync` (`readWindowsRegistryPath`) | defective (same shape) | fixed — added `stdio: ["ignore","pipe","ignore"]` |
| `clients/lsp/launch.ts:293` `execFileSync` (`which`/`where` resolution) | already correct | none — already sets `stdio: ["ignore","pipe","ignore"]` |
| `clients/safe-spawn.ts:380` `spawnSync` (Windows `taskkill`) | already correct | none — `spawnSync`'s default stdio pipes all three streams (captures, doesn't inherit); this site also sets explicit `stdio: "ignore"` |
| `clients/safe-spawn.ts:1055` `spawnSync` (one-shot `chcp 65001`) | already correct | none — `spawnSync` default captures stderr, never inherits it |
| `clients/safe-spawn.ts:2009`, `:2031` `spawnSync` (the shared spawn path) | already correct | none — same `spawnSync` default; `result.stderr` is returned to the caller, never printed |
| `scripts/*.mjs` (~25 sites: `execFileSync`/`execSync`/`spawnSync` in build, release, and smoke-test tooling) | out of scope | no action — these are developer-invoked CLI scripts, not runtime code reachable during ordinary agent tool use; inherited stderr there is the intended, expected behavior for a script run directly in a terminal |

**Consolidation verdict:** stay on two call sites, not fold onto one seam. `execSync`/`execFileSync` are the only Node APIs in `clients/` with this stderr-inherits-by-default quirk, and there are now exactly two of them, both already fixed with the same one-line `stdio` override. `spawnSync` (used everywhere else, including inside `safe-spawn.ts`) does not share the defect — its default already pipes stderr — so there is no shared helper to extract; adding one for two call sites that need an identical three-element literal would be indirection without a behavior difference to unify.

## Observability

No new failure path is introduced — this changes what a browser sees on stderr, not what pi-lens records. The existing behavior already logs nothing when `getCurrentCommit()` falls back to `"unknown"` (silent-by-design, matching every other transient git-probe fallback in this file). That is an existing gap, not one this fix widens: a repeated failure to resolve the current commit is invisible in `latency.log`/`cascade.log` today. Filing this as a follow-up is out of scope for a P1 stderr-leak fix, but noting it here for visibility — `captureSnapshot`'s commit field silently reads `"unknown"` for every snapshot in a broken-git-state session, with no degradation record to distinguish "clean, no commit info needed" from "git probe kept failing."

## Review round 1

An adversarial review confirmed the production fix correct under attack and found four test-quality defects, all fixed in this round:

- **F1 (medium) — the launch.ts sibling guard was vacuous.** No test exercised `readWindowsRegistryPath`'s failure path, so reverting only that `stdio` hunk redded nothing. Fixed by extracting the guarded `execFileSync` call into an exported seam, `runStderrGuardedProbe(command, args)`, so a test can drive it with a real failing command (`git` with a bad subcommand) instead of needing real Windows/`powershell.exe`. New test: `tests/clients/lsp/launch-stderr-guard.test.ts`.

  Red run with the guard hunk reverted:
  ```
  × |default| tests/clients/lsp/launch-stderr-guard.test.ts > launch.ts runStderrGuardedProbe stderr suppression (#2095) > does not leak the probed command's stderr when it fails 181ms
    → expected 'git: \'not-a-real-subcommand\' is not…' not to match /not a git command/i

  AssertionError: expected 'git: \'not-a-real-subcommand\' is not…' not to match /not a git command/i
  + Received:
  "git: 'not-a-real-subcommand' is not a git command. See 'git --help'.
  "
  ```
  Green with the guard restored:
  ```
  ✓ |default| tests/clients/lsp/launch-stderr-guard.test.ts > launch.ts runStderrGuardedProbe stderr suppression (#2095) > does not leak the probed command's stderr when it fails 291ms
  ```

- **F2 (medium) — `metrics-history-stderr.test.ts` passed vacuously.** The reviewer pointed the `require()` at a nonexistent module and it still passed, because the test only checked stderr content and never confirmed the child actually ran the code under test. Fixed by switching from `captureSnapshot` (debounced, no return value) to `captureSnapshots` (synchronous, returns the history), asserting `result.status === 0`, and having the child print the resolved commit. The test now asserts `result.stdout` contains `COMMIT:"unknown"`, proving `getCurrentCommit()`'s catch branch was genuinely reached rather than the child silently no-oping.

- **F3 (low) — the test's own setup call leaked stderr.** `execFileSync("git", ["init", "-q"], { cwd: tmp })` at test line 51 had no `stdio` override — the exact defect this PR fixes, inside the test guarding against it. Added `stdio: "ignore"`.

- **F4 (nit) — stale comment.** `clients/lsp/launch.ts`'s guard comment said the catch "already reports 'unknown' PATH"; the catch actually returns `""` (callers read the empty string as "unknown" PATH, they don't receive the literal word). Corrected the wording.

All four landed in one commit (`bd8c2e49`) on this branch. Targeted re-run after the fixes, all green:
```
tests/clients/metrics-history-stderr.test.ts
tests/clients/lsp/launch-stderr-guard.test.ts
tests/clients/lsp/launch.test.ts
tests/clients/lsp/launch-path.test.ts
tests/clients/lsp/resolve-and-launch-fallback.test.ts
tests/clients/delivery-surface-ratchet.test.ts

Test Files  6 passed (6)
     Tests  22 passed | 1 skipped (23)
```
`npm run build` and `npm run lint` clean; `oxfmt --check` clean on all touched files. No new changelog fragment — this round is test hygiene only, no user-facing behavior changed since round 1.

Closes #2095 — every acceptance criterion (stderr suppressed, existing `"unknown"` fallback preserved, class sweep of sibling call sites, regression tests that are provably non-vacuous) is met.

