### PR TITLE
fix(lsp): make spawn records count truthfully (closes #2064)

### DIFF
--- a/.changelog/fix-2064-lsp-spawn-records.md
+++ b/.changelog/fix-2064-lsp-spawn-records.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Make LSP spawn records count truthfully (closes #2064)** — `lsp_client_selected` reported `cold-spawn` for every caller that merely joined another caller's in-flight spawn, so the one metric that looked like a spawn count over-counted 3.0x in a 21.8 h field window, and one 29.3 s TypeScript spawn read as 39 spawns in 2 ms. The record now names the starter (`cold-spawn`, `spawn-failure`) apart from the joiners (`cold-spawn-joined`, `spawn-failure-joined`), on the same record with the same denominator. A new `lsp_server_spawned` latency record fires once per language-server process start for every server, so `latency.log` finally counts TypeScript spawns, which `lsp_launch_candidate_success` never covered.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,10 +533,16 @@ carries `cold-spawn`/`spawn-failure` for the starter and
 `cold-spawn-joined`/`spawn-failure-joined` for every joiner, and the
 starter/joiner bit is captured before `await spawnPromise` — after that await
 the two are indistinguishable, which is how one 29.3 s TypeScript spawn read as
-39 spawns in 2 ms. `lsp_server_spawned` is the process-start record for every
-server, emitted once at `spawnClient`'s success path, so a spawn count never
-depends on a per-server launcher record such as
-`lsp_launch_candidate_success`, which the TypeScript path does not reach.
+39 spawns in 2 ms. The AUTHORITATIVE spawn count is `lsp_server_spawned`, the
+process-start record emitted once at `spawnClient`'s success path for every
+server. It does not depend on a per-server launcher record such as
+`lsp_launch_candidate_success`, which the TypeScript path never reaches. The
+two records relate as `count(lsp_server_spawned) >=
+count(outcome="cold-spawn")`, never as equality: `getClientsForFile` and
+`getAuxiliaryClientsForFile` call `ensureClientForServer` without `onOutcome`,
+so a multi-client or auxiliary spawn writes a spawn record and no selection
+record. The starter-outcome count therefore under-counts real process starts,
+and only `lsp_server_spawned` answers "how many servers did we start".
 (#1934, #2064)
 
 ### Dispatch, runners, formatters, and installer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -527,6 +527,18 @@ remain ordinary project directories. The positive `.gitignore` glob precheck is
 cached per resolved project root and `size:mtimeMs`, including the absent-file
 empty result, while the project ignore matcher remains authoritative.
 
+LSP acquisition records name the caller that STARTED a language-server process
+apart from the callers that joined its in-flight spawn. `lsp_client_selected`
+carries `cold-spawn`/`spawn-failure` for the starter and
+`cold-spawn-joined`/`spawn-failure-joined` for every joiner, and the
+starter/joiner bit is captured before `await spawnPromise` — after that await
+the two are indistinguishable, which is how one 29.3 s TypeScript spawn read as
+39 spawns in 2 ms. `lsp_server_spawned` is the process-start record for every
+server, emitted once at `spawnClient`'s success path, so a spawn count never
+depends on a per-server launcher record such as
+`lsp_launch_candidate_success`, which the TypeScript path does not reach.
+(#1934, #2064)
+
 ### Dispatch, runners, formatters, and installer
 
 Knip's dispatch memo is instance-owned and keyed by canonical project root plus

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -539,10 +539,17 @@ export interface SpawnedServer {
  * records inside 2ms against a measured 29.3s TypeScript spawn. The `-joined`
  * values split the two readings apart without splitting the record:
  *
- * - process starts = count(`cold-spawn`) + count(`spawn-failure`);
- * - selections that paid a spawn wait = those two plus their `-joined` twins;
+ * - selections that paid a spawn wait = every cold/failure value;
+ * - selections served from the pool = `warm-reuse`;
  * - reuse rate = `warm-reuse / (warm-reuse + every cold/failure value)`, the
  *   same single denominator #1934 defined.
+ *
+ * These values are NOT the spawn count. `lsp_server_spawned` is, and it is
+ * authoritative: `getClientsForFile` and `getAuxiliaryClientsForFile` pass no
+ * `onOutcome`, so a multi-client or auxiliary spawn writes a spawn record and
+ * no selection record at all. Read the relation as
+ * `count(lsp_server_spawned) >= count(outcome="cold-spawn")`, never as
+ * equality (#2064 review F1).
  */
 export type LSPClientAcquisitionOutcome =
 	| "warm-reuse"
@@ -551,10 +558,6 @@ export type LSPClientAcquisitionOutcome =
 	| "spawn-failure"
 	| "spawn-failure-joined"
 	| "declined";
-
-/** The outcomes whose caller STARTED a language-server process. */
-export const SPAWN_STARTING_OUTCOMES: ReadonlySet<LSPClientAcquisitionOutcome> =
-	new Set<LSPClientAcquisitionOutcome>(["cold-spawn", "spawn-failure"]);
 
 // #1621: a rename-propagation notify failure now records WHY it failed —
 // `timedOut` (the notify write never settled inside its budget) is distinct
@@ -3321,10 +3324,21 @@ export class LSPService {
 			return spawned;
 		} catch (err) {
 			// A throwing spawn promise is an errored acquisition by definition.
-			// #2064: the joiners of a failing spawn are counted apart from its
-			// starter for the same reason the success path splits them — one
-			// failed process start must not read as N.
-			onOutcome?.(startedSpawn ? "spawn-failure" : "spawn-failure-joined");
+			//
+			// #2064 review F2: deliberately NOT split into a starter/joiner pair
+			// like the resolve path above, because nothing could observe the
+			// split. `spawnClient` never rethrows; it catches its own spawn and
+			// initialize failures and resolves `undefined`. This catch is
+			// therefore reachable only when `spawnClient` throws BEFORE its own
+			// `try` (the trust probe, `logSessionStart`, `recordLsp`), and two
+			// facts follow. The published promise is already rejected when it
+			// enters `inFlight`, so no joiner can attach to it. And the rethrow
+			// below unwinds past every `lsp_client_selected` emit site, so this
+			// value is written to no record: a probe drove a throwing trust
+			// check through two concurrent callers and got two rejections and
+			// zero selection records. An unobservable discriminator is a
+			// vacuous guard, so this path keeps the single #1934 value.
+			onOutcome?.("spawn-failure");
 			throw err;
 		} finally {
 			if (this.state.inFlight.get(key) === spawnPromise) {
@@ -3503,6 +3517,13 @@ export class LSPService {
 			// `latency.log` alone. Volume is bounded by process starts: one
 			// record per spawn, and a spawn is single-flighted per
 			// `serverId:root` by `state.inFlight`.
+			//
+			// The two path fields are deliberate and are not duplicates.
+			// `filePath` carries the ROOT, because the root plus `serverId` is
+			// the client's identity and the unit a spawn is single-flighted on.
+			// `triggerFilePath` carries the file whose touch paid for the
+			// spawn, which answers a different question and is the one that
+			// varies across records for the same client.
 			logLatency({
 				type: "phase",
 				phase: "lsp_server_spawned",

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -531,12 +531,30 @@ export interface SpawnedServer {
  * `declined` never reaches `lsp_client_selected` — those paths already have
  * their own records (`lsp_client_unavailable`, `lsp_client_skipped_broken`,
  * `lsp_client_skipped_unavailable_command`).
+ *
+ * #2064: `cold-spawn` alone conflated two different facts. Every caller that
+ * awaited one spawn reported `cold-spawn`, so the value read as a spawn count
+ * and was not one. In a 21.8h field window 62 `cold-spawn` records clustered
+ * into 21 real spawn events, a 3.0x over-count, and one cluster held 39
+ * records inside 2ms against a measured 29.3s TypeScript spawn. The `-joined`
+ * values split the two readings apart without splitting the record:
+ *
+ * - process starts = count(`cold-spawn`) + count(`spawn-failure`);
+ * - selections that paid a spawn wait = those two plus their `-joined` twins;
+ * - reuse rate = `warm-reuse / (warm-reuse + every cold/failure value)`, the
+ *   same single denominator #1934 defined.
  */
 export type LSPClientAcquisitionOutcome =
 	| "warm-reuse"
 	| "cold-spawn"
+	| "cold-spawn-joined"
 	| "spawn-failure"
+	| "spawn-failure-joined"
 	| "declined";
+
+/** The outcomes whose caller STARTED a language-server process. */
+export const SPAWN_STARTING_OUTCOMES: ReadonlySet<LSPClientAcquisitionOutcome> =
+	new Set<LSPClientAcquisitionOutcome>(["cold-spawn", "spawn-failure"]);
 
 // #1621: a rename-propagation notify failure now records WHY it failed —
 // `timedOut` (the notify write never settled inside its budget) is distinct
@@ -2347,7 +2365,11 @@ export class LSPService {
 			// #1934: the first server whose acquisition ERRORED, as opposed to
 			// cleanly declining. Kept so a selection that served nobody still
 			// says which server the pool actually tried and failed to spawn.
+			// #2064 carries the errored outcome VALUE with it, so the record
+			// below reports whether this caller started the failed spawn or
+			// joined it, instead of pinning a starter label on every joiner.
 			let erroredServerId: string | undefined;
+			let erroredOutcome: LSPClientAcquisitionOutcome | undefined;
 
 			// Try each matching server
 			for (const server of servers) {
@@ -2383,8 +2405,14 @@ export class LSPService {
 					});
 					return spawned;
 				}
-				if (acquisition.outcome === "spawn-failure") {
-					erroredServerId ??= server.id;
+				if (
+					acquisition.outcome === "spawn-failure" ||
+					acquisition.outcome === "spawn-failure-joined"
+				) {
+					if (erroredServerId === undefined) {
+						erroredServerId = server.id;
+						erroredOutcome = acquisition.outcome;
+					}
 				}
 			}
 
@@ -2402,7 +2430,8 @@ export class LSPService {
 					metadata: {
 						serverId: erroredServerId,
 						candidateCount: servers.length,
-						outcome: "spawn-failure" satisfies LSPClientAcquisitionOutcome,
+						outcome: (erroredOutcome ??
+							"spawn-failure") satisfies LSPClientAcquisitionOutcome,
 					},
 				});
 			}
@@ -3220,11 +3249,20 @@ export class LSPService {
 			if (isOptionalServer) this.optionalDisabled.delete(key);
 		}
 
+		// #2064: did THIS caller start the language-server process, or did it
+		// join a spawn another caller already had in flight? The answer is only
+		// knowable here, before the await — downstream of `await spawnPromise`
+		// the two are indistinguishable, which is exactly how the 3.0x
+		// over-count happened. There are two join sites and both count as
+		// joins: the unguarded read below, and the `raced` re-read inside the
+		// spawn gate, which catches a caller that reached the gate before the
+		// starter published its promise.
+		let startedSpawn = false;
 		let spawnPromise = this.state.inFlight.get(key);
 		if (!spawnPromise) {
 			const started = await this.withClientSpawnGate(async () => {
 				const raced = this.state.inFlight.get(key);
-				if (raced) return { promise: raced };
+				if (raced) return { promise: raced, startedSpawn: false };
 				// `server.root()` and dead-client cleanup above are async. A reset during
 				// either gap must not let this retired generation start a late spawn.
 				if (this.checkDestroyed()) return undefined;
@@ -3237,10 +3275,11 @@ export class LSPService {
 					allowInstall,
 				);
 				this.state.inFlight.set(key, promise);
-				return { promise };
+				return { promise, startedSpawn: true };
 			});
 			if (!started) return undefined;
 			spawnPromise = started.promise;
+			startedSpawn = started.startedSpawn;
 		}
 		// Announce the in-flight spawn so the caller can skip a doomed touch
 		// wait. The announcement never returns a client and never
@@ -3261,20 +3300,31 @@ export class LSPService {
 			// #1934: a client here cost a process WAIT, whether this caller
 			// started the spawn or joined another caller's in-flight promise.
 			// Either way the selection was not served from the warm pool.
+			// #2064: which of the two it was is now named, so the record can
+			// answer "how many processes started" as well as "how many
+			// selections paid a wait". `startedSpawn` is captured before the
+			// await, because after it the two are indistinguishable.
 			//
 			// The verdict read is synchronous and sits in the same microtask as
 			// the await above, so it can only see the attempt just settled.
 			onOutcome?.(
 				spawned
-					? "cold-spawn"
+					? startedSpawn
+						? "cold-spawn"
+						: "cold-spawn-joined"
 					: this.lastSpawnVerdict.get(key) === "failed"
-						? "spawn-failure"
+						? startedSpawn
+							? "spawn-failure"
+							: "spawn-failure-joined"
 						: "declined",
 			);
 			return spawned;
 		} catch (err) {
 			// A throwing spawn promise is an errored acquisition by definition.
-			onOutcome?.("spawn-failure");
+			// #2064: the joiners of a failing spawn are counted apart from its
+			// starter for the same reason the success path splits them — one
+			// failed process start must not read as N.
+			onOutcome?.(startedSpawn ? "spawn-failure" : "spawn-failure-joined");
 			throw err;
 		} finally {
 			if (this.state.inFlight.get(key) === spawnPromise) {
@@ -3442,6 +3492,29 @@ export class LSPService {
 			const spawnDurationMs = Date.now() - startedAt;
 			recordLsp(server.id, root, "spawn_success", spawnDurationMs);
 			recordSuccessfulLspSpawn(server.id, spawnDurationMs);
+			// #2064: the only latency record that a language-server PROCESS
+			// started. `lsp_launch_candidate_success` covers the servers that
+			// launch through `resolveAndLaunch` and never fired for TypeScript,
+			// which served 913 of 941 selections in the field window — so
+			// nothing in `latency.log` counted the 29.3s TypeScript spawn at
+			// all. This sits at `spawnClient`'s single success path, so every
+			// server reports through one record instead of a per-server
+			// launcher, and `count(serverId=typescript)` is answerable from
+			// `latency.log` alone. Volume is bounded by process starts: one
+			// record per spawn, and a spawn is single-flighted per
+			// `serverId:root` by `state.inFlight`.
+			logLatency({
+				type: "phase",
+				phase: "lsp_server_spawned",
+				filePath: root,
+				durationMs: spawnDurationMs,
+				metadata: {
+					serverId: server.id,
+					source: spawned.source ?? "unknown",
+					launchVariant: spawned.launchVariant ?? "default",
+					triggerFilePath: filePath,
+				},
+			});
 			if (!this.workspaceProbeLogged.has(key)) {
 				logSessionStart(
 					`lsp workspace-diag probe ${server.id}: advertised=${wsDiag.advertised} mode=${wsDiag.mode} provider=${wsDiag.diagnosticProviderKind}`,

--- a/tests/clients/lsp/spawn-record-truth.test.ts
+++ b/tests/clients/lsp/spawn-record-truth.test.ts
@@ -15,10 +15,17 @@
 //   - make `startedSpawn` unconditionally `true` in `ensureClientForServer` and
 //     the concurrency, burst-replay, and failure-join tests red;
 //   - make it unconditionally `false` and the same three red;
-//   - delete the `lsp_server_spawned` emit in `spawnClient` and the two
-//     spawn-record tests red;
+//   - delete the `lsp_server_spawned` emit in `spawnClient` and three tests
+//     red, including the `getClientsForFile` one;
 //   - move the `startedSpawn` capture to AFTER `await spawnPromise` (which is
-//     the pre-fix shape) and the burst replay reports 39 spawns again.
+//     the pre-fix shape) and the burst replay reports 39 spawns again;
+//   - make `spawnClient` rethrow from its own catch and the
+//     "emits no selection record when the acquisition throws" test reds,
+//     which is the signal that the un-split catch below it needs revisiting.
+//
+// NOT claimed as mutation-proven: the catch around `await spawnPromise` keeps
+// a single `spawn-failure` value on purpose. See the comment at that catch and
+// the last test in this file for the reachability analysis.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const logLatency = vi.hoisted(() => vi.fn());
@@ -33,6 +40,24 @@ vi.mock("../../../clients/lsp/config.js", () => ({
 }));
 
 vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
+
+/**
+ * Drives the one route into `ensureClientForServer`'s catch: a throw from
+ * `spawnClient` BEFORE its own `try`. Defaults to off, so every other test in
+ * this file runs against the real trust module's behavior.
+ */
+const trustProbeThrows = { value: false };
+vi.mock("../../../clients/project-trust.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../../clients/project-trust.js")>();
+	return {
+		...actual,
+		isLspSpawnAllowedByTrust: () => {
+			if (trustProbeThrows.value) throw new Error("trust probe threw");
+			return actual.isLspSpawnAllowedByTrust();
+		},
+	};
+});
 
 function fakeClient(alive: { value: boolean }) {
 	return {
@@ -180,22 +205,17 @@ describe("LSP spawn records count truthfully (#2064)", () => {
 			expect(countOutcome("cold-spawn")).toBe(1);
 			expect(countOutcome("cold-spawn-joined")).toBe(38);
 
-			// The process-start record agrees with the starter count. That
-			// cross-check is the whole claim: one denominator, two readings.
+			// One process start, and on THIS path the spawn record and the
+			// starter outcome agree. They do not agree in general — see the
+			// `getClientsForFile` test below, which is why the recipe is an
+			// inequality.
 			expect(spawnRecords()).toHaveLength(1);
 
-			// The same count, derived the way a log reader derives it — through
-			// the exported classification rather than a literal in this test, so
-			// a future outcome value cannot be added without classifying it.
-			const { SPAWN_STARTING_OUTCOMES } =
-				await import("../../../clients/lsp/index.js");
-			const starters = selectionOutcomes().filter((outcome) =>
-				SPAWN_STARTING_OUTCOMES.has(
-					outcome as Parameters<typeof SPAWN_STARTING_OUTCOMES.has>[0],
-				),
+			// Nothing else reached the record, so the denominator is unchanged
+			// and no third value slipped in.
+			expect(new Set(selectionOutcomes())).toEqual(
+				new Set(["cold-spawn", "cold-spawn-joined"]),
 			);
-			expect(starters).toHaveLength(1);
-			// Every other record is a joiner, so the denominator is unchanged.
 			expect(selectionOutcomes()).toHaveLength(39);
 		} finally {
 			release?.();
@@ -253,6 +273,64 @@ describe("LSP spawn records count truthfully (#2064)", () => {
 			expect(spawnRecords()).toEqual([]);
 		} finally {
 			release?.();
+			await service.shutdown({ processExiting: true });
+		}
+	});
+
+	// #2064 review F1. `getClientsForFile` and `getAuxiliaryClientsForFile`
+	// call `ensureClientForServer` with no `onOutcome`, so a spawn on those
+	// paths writes a process-start record and NO selection record. This test
+	// exists because the first version of this PR documented the two counts as
+	// equal, which is false in production and would have sent a log reader
+	// hunting a phantom leak. The relation is
+	// `count(lsp_server_spawned) >= count(outcome="cold-spawn")`, and
+	// `lsp_server_spawned` is the authoritative spawn count.
+	it("counts a getClientsForFile spawn with no selection record", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		try {
+			const result = await service.getClientsForFile("/repo/a.ts");
+			expect(result.clients).toHaveLength(1);
+
+			// The process started, and only the spawn record says so.
+			expect(spawnRecords()).toHaveLength(1);
+			expect(selectionOutcomes()).toEqual([]);
+		} finally {
+			await service.shutdown({ processExiting: true });
+		}
+	});
+
+	// #2064 review F2. The catch around `await spawnPromise` deliberately keeps
+	// one `spawn-failure` value rather than splitting starter from joiner, and
+	// this test pins the reachability analysis that justifies it. `spawnClient`
+	// never rethrows, so the catch is reachable only when `spawnClient` throws
+	// before its own `try` — here, a throwing trust probe. Two facts follow,
+	// and both are asserted: the acquisition REJECTS rather than resolving, and
+	// the rethrow unwinds past every `lsp_client_selected` emit site, so the
+	// catch's outcome value reaches no record. A discriminator nothing can
+	// observe is a vacuous guard.
+	//
+	// Honest framing: this is a claim pin, not a red-first regression test. It
+	// passes before and after the fix. Its job is to fail if someone later
+	// makes `spawnClient` rethrow, because that would make the catch reachable
+	// with a live joiner and the single value would start over-counting again.
+	it("emits no selection record when the acquisition throws", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		try {
+			trustProbeThrows.value = true;
+			const settled = await Promise.allSettled([
+				service.getClientForFile("/repo/x1.ts"),
+				service.getClientForFile("/repo/x2.ts"),
+			]);
+			expect(settled.map((entry) => entry.status)).toEqual([
+				"rejected",
+				"rejected",
+			]);
+			expect(selectionOutcomes()).toEqual([]);
+			expect(spawnRecords()).toEqual([]);
+		} finally {
+			trustProbeThrows.value = false;
 			await service.shutdown({ processExiting: true });
 		}
 	});

--- a/tests/clients/lsp/spawn-record-truth.test.ts
+++ b/tests/clients/lsp/spawn-record-truth.test.ts
@@ -1,0 +1,259 @@
+// #2064: the LSP records could not count spawns.
+//
+// `lsp_client_selected` reported `cold-spawn` after `await spawnPromise`, so
+// every caller that merely JOINED another caller's in-flight spawn reported it
+// too. A 21.8h field window held 62 `cold-spawn` records that clustered into 21
+// real spawn events — a 3.0x over-count — and one cluster held 39 records
+// inside 2ms against a measured 29.3s TypeScript spawn. Separately, no latency
+// record proved a TypeScript language-server process ever started:
+// `lsp_launch_candidate_success` covers only servers that launch through
+// `resolveAndLaunch`, and fired 0 times for `typescript` in that window.
+//
+// These tests pin both halves.
+//
+// MUTATION PROOFS, stated so a later reader can re-run them:
+//   - make `startedSpawn` unconditionally `true` in `ensureClientForServer` and
+//     the concurrency, burst-replay, and failure-join tests red;
+//   - make it unconditionally `false` and the same three red;
+//   - delete the `lsp_server_spawned` emit in `spawnClient` and the two
+//     spawn-record tests red;
+//   - move the `startedSpawn` capture to AFTER `await spawnPromise` (which is
+//     the pre-fix shape) and the burst replay reports 39 spawns again.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const logLatency = vi.hoisted(() => vi.fn());
+vi.mock("../../../clients/latency-logger.js", () => ({ logLatency }));
+
+const getServersForFileWithConfig = vi.fn();
+const createLSPClient = vi.fn();
+
+vi.mock("../../../clients/lsp/config.js", () => ({
+	getServersForFileWithConfig,
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
+
+function fakeClient(alive: { value: boolean }) {
+	return {
+		root: "/repo",
+		isAlive: vi.fn(() => alive.value),
+		isBusy: vi.fn(() => false),
+		shutdown: vi.fn(async () => undefined),
+		wasShutdownIntentional: vi.fn(() => false),
+		getExitedAt: vi.fn(() => undefined),
+		notify: {
+			open: vi.fn(async () => undefined),
+			change: vi.fn(async () => undefined),
+		},
+		diagnosticsVersion: 0,
+		getWorkspaceDiagnosticsSupport: vi.fn(() => ({
+			advertised: false,
+			mode: "push-only",
+			diagnosticProviderKind: "unavailable",
+		})),
+	};
+}
+
+const liveSpawn = {
+	process: {
+		process: { killed: false },
+		stdin: {},
+		stdout: {},
+		stderr: {},
+		pid: 4242,
+	},
+};
+
+/** Every `lsp_client_selected` record's outcome, in emission order. */
+function selectionOutcomes(): unknown[] {
+	return logLatency.mock.calls
+		.filter(([entry]) => entry?.phase === "lsp_client_selected")
+		.map(([entry]) => entry.metadata?.outcome);
+}
+
+function countOutcome(outcome: string): number {
+	return selectionOutcomes().filter((value) => value === outcome).length;
+}
+
+function spawnRecords(): Array<Record<string, unknown>> {
+	return logLatency.mock.calls
+		.filter(([entry]) => entry?.phase === "lsp_server_spawned")
+		.map(([entry]) => entry);
+}
+
+/**
+ * Drain enough macrotask turns that every concurrent caller has reached its
+ * `await spawnPromise`. Real timers on purpose: a fake-timer drain would not
+ * flush the microtask chain the acquisition path walks through.
+ */
+async function settleConcurrentCallers(): Promise<void> {
+	for (let i = 0; i < 12; i++) {
+		await new Promise((resolve) => setImmediate(resolve));
+	}
+}
+
+describe("LSP spawn records count truthfully (#2064)", () => {
+	let spawnBehavior: () => Promise<unknown>;
+	const alive = { value: true };
+
+	beforeEach(async () => {
+		vi.resetModules();
+		logLatency.mockClear();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+		alive.value = true;
+		spawnBehavior = async () => liveSpawn;
+		getServersForFileWithConfig.mockReturnValue([
+			{
+				id: "typescript",
+				name: "TypeScript",
+				extensions: [".ts"],
+				root: async () => "/repo",
+				spawn: vi.fn(() => spawnBehavior()),
+			},
+		]);
+		createLSPClient.mockImplementation(() => fakeClient(alive));
+		const ledger = await import("../../../clients/degradation-ledger.js");
+		ledger.resetDegradationLedger();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("marks exactly one starter and N-1 joiners for one slow spawn", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		let release: (() => void) | undefined;
+		const held = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		try {
+			spawnBehavior = async () => {
+				await held;
+				return liveSpawn;
+			};
+			const callers = 5;
+			const pending = Array.from({ length: callers }, (_, index) =>
+				service.getClientForFile(`/repo/f${index}.ts`),
+			);
+			// Every caller is now parked behind the SAME in-flight spawn.
+			await settleConcurrentCallers();
+			release?.();
+			const served = await Promise.all(pending);
+			expect(served.every(Boolean)).toBe(true);
+
+			// The point of the issue: one process started, four callers joined it.
+			expect(countOutcome("cold-spawn")).toBe(1);
+			expect(countOutcome("cold-spawn-joined")).toBe(callers - 1);
+			// One record per selection, so the reuse-rate denominator is unchanged.
+			expect(selectionOutcomes()).toHaveLength(callers);
+		} finally {
+			release?.();
+			await service.shutdown({ processExiting: true });
+		}
+	});
+
+	// The 2026-08-25T07:18:48.303Z field cluster: 39 records in 2ms against a
+	// measured 29.3s spawn. Pre-fix that reads as 39 spawns, which is not
+	// physically possible.
+	it("replays the 39-record burst as 1 spawn and 38 joins", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		let release: (() => void) | undefined;
+		const held = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		try {
+			spawnBehavior = async () => {
+				await held;
+				return liveSpawn;
+			};
+			const pending = Array.from({ length: 39 }, (_, index) =>
+				service.getClientForFile(`/repo/burst${index}.ts`),
+			);
+			await settleConcurrentCallers();
+			release?.();
+			await Promise.all(pending);
+
+			expect(countOutcome("cold-spawn")).toBe(1);
+			expect(countOutcome("cold-spawn-joined")).toBe(38);
+
+			// The process-start record agrees with the starter count. That
+			// cross-check is the whole claim: one denominator, two readings.
+			expect(spawnRecords()).toHaveLength(1);
+
+			// The same count, derived the way a log reader derives it — through
+			// the exported classification rather than a literal in this test, so
+			// a future outcome value cannot be added without classifying it.
+			const { SPAWN_STARTING_OUTCOMES } =
+				await import("../../../clients/lsp/index.js");
+			const starters = selectionOutcomes().filter((outcome) =>
+				SPAWN_STARTING_OUTCOMES.has(
+					outcome as Parameters<typeof SPAWN_STARTING_OUTCOMES.has>[0],
+				),
+			);
+			expect(starters).toHaveLength(1);
+			// Every other record is a joiner, so the denominator is unchanged.
+			expect(selectionOutcomes()).toHaveLength(39);
+		} finally {
+			release?.();
+			await service.shutdown({ processExiting: true });
+		}
+	});
+
+	it("records a TypeScript process start in latency.log", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		try {
+			expect(await service.getClientForFile("/repo/a.ts")).toBeTruthy();
+			const records = spawnRecords();
+			expect(records).toHaveLength(1);
+			expect(records[0].metadata).toMatchObject({
+				serverId: "typescript",
+				triggerFilePath: "/repo/a.ts",
+			});
+			expect(typeof records[0].durationMs).toBe("number");
+
+			// A warm reuse is not a process start, so the count must not move.
+			expect(await service.getClientForFile("/repo/b.ts")).toBeTruthy();
+			expect(selectionOutcomes()).toEqual(["cold-spawn", "warm-reuse"]);
+			expect(spawnRecords()).toHaveLength(1);
+		} finally {
+			await service.shutdown({ processExiting: true });
+		}
+	});
+
+	it("splits the starter from the joiners when the spawn fails", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		let release: (() => void) | undefined;
+		const held = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		try {
+			spawnBehavior = async () => {
+				await held;
+				throw new Error("spawn refused");
+			};
+			const callers = 5;
+			const pending = Array.from({ length: callers }, (_, index) =>
+				service.getClientForFile(`/repo/bad${index}.ts`),
+			);
+			await settleConcurrentCallers();
+			release?.();
+			const served = await Promise.all(pending);
+			expect(served.every((entry) => entry === undefined)).toBe(true);
+
+			// One failed process start, not five.
+			expect(countOutcome("spawn-failure")).toBe(1);
+			expect(countOutcome("spawn-failure-joined")).toBe(callers - 1);
+			// A failed spawn started a process attempt but produced no server.
+			expect(spawnRecords()).toEqual([]);
+		} finally {
+			release?.();
+			await service.shutdown({ processExiting: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

`lsp_client_selected` could not count spawns. It reported `cold-spawn` after
`await spawnPromise`, which sits downstream of the `state.inFlight` join, so
every caller that merely joined another caller's spawn reported a spawn of its
own. In the issue's 21.8 h field window 62 `cold-spawn` records clustered into
21 real spawn events, a 3.0x over-count, and one cluster held 39 records inside
2 ms against a measured 29.3 s TypeScript spawn.

Two changes, both observability:

1. `ensureClientForServer` now captures whether THIS caller created the
   in-flight promise, before the await, where the starter and the joiner are
   still distinguishable. Joiners report `cold-spawn-joined`, and the failure
   path gets the same split as `spawn-failure-joined`. Both readings stay
   derivable from one record with one denominator: process starts are the
   starter values, selections that paid a spawn wait are all four, and the
   reuse rate #1934 defined is unchanged in shape.
2. A new `lsp_server_spawned` latency record fires once at `spawnClient`'s
   success path. `lsp_launch_candidate_success` only covers servers that launch
   through `resolveAndLaunch`, and fired 0 times for `typescript` in the field
   window while TypeScript served 913 of 941 selections. One record at the
   shared choke point covers every server, so `count(serverId=typescript)` is
   answerable from `latency.log` alone.

No spawn-cost optimization is included. The records come first.

Acceptance criteria, per the issue:

- [x] A record distinguishes the spawn-starting caller from spawn-joining
      callers, on the existing record, with one denominator.
- [x] A test drives N concurrent `getClientForFile` calls for one key against a
      single slow spawn and asserts exactly 1 starter and N-1 joiners.
      Neutering the discriminator reds it (proof below).
- [x] A record proves a TypeScript language-server process started.
- [x] The 2026-08-25T07:18:48.303Z burst shape replays as 1 spawn and 38 joins.

## Tests

New file `tests/clients/lsp/spawn-record-truth.test.ts`, 4 tests.

Red on pre-fix code. Source reverted with `git checkout --`, rebuilt, then run:

```
 FAIL  tests/clients/lsp/spawn-record-truth.test.ts > replays the 39-record burst as 1 spawn and 38 joins
AssertionError: expected 39 to be 1 // Object.is equality
- Expected
+ Received
- 1
+ 39
 ❯ tests/clients/lsp/spawn-record-truth.test.ts:180:39
    180|    expect(countOutcome("cold-spawn")).toBe(1);

 FAIL  tests/clients/lsp/spawn-record-truth.test.ts > records a TypeScript process start in latency.log
AssertionError: expected [] to have a length of 1 but got +0
 ❯ tests/clients/lsp/spawn-record-truth.test.ts:198:20

 FAIL  tests/clients/lsp/spawn-record-truth.test.ts > splits the starter from the joiners when the spawn fails
AssertionError: expected 5 to be 1 // Object.is equality
 ❯ tests/clients/lsp/spawn-record-truth.test.ts:236:42

 Test Files  1 failed (1)
      Tests  4 failed (4)
```

The pre-fix run reproduces the field number exactly: one spawn, 39 `cold-spawn`
records.

Mutation proof for the new discriminator. Forcing `startedSpawn` to `true` at
both assignment sites, rebuilt:

```
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

The fourth test is the `lsp_server_spawned` test, which that mutation does not
touch. Deleting the `lsp_server_spawned` emit reds it and the burst-replay
cross-check.

Green after the fix:

- targeted: `spawn-record-truth`, `client-selection-outcome` (the #1934 sibling
  that pins the same record), `client-ceiling`, `lifecycle` — all pass.
- canaries for the two seams that landed just before this branch:
  `refresh-and-sync-kind`, `workspace-diagnostics-outside-root`,
  `silent-clean-confirm` — all pass.
- governance: `bounded-telemetry-sweep`, `session-state-conformance`,
  `module-instance-coverage` — all pass.
- 10 files, 163 tests, 0 failures.
- whole `tests/clients/lsp` directory, 116 files: 1157 passed, 1 failed.
  The failure is `server-policy.test.ts > skips standalone csharp files without
  a project marker (#201)`, a 5 s timeout on a `CSharpServer.root()` filesystem
  walk under 116-file parallel load. It passes on its own on this branch
  (76/76) and touches nothing this PR changes. Reported, not claimed clean.
- `npm run lint` (tsc) clean, `oxfmt --check` clean.
- The full suite is CI's job.

## Blast radius

`LSPClientAcquisitionOutcome` gains two values. Every consumer:

- `clients/lsp/index.ts` is the only producer and the only non-test consumer.
  A repo-wide grep for `cold-spawn`, `warm-reuse`, and
  `LSPClientAcquisitionOutcome` across `clients/`, `tools/`, `mcp/`,
  `scripts/`, and `index.ts` returns this file plus one doc comment in
  `clients/degradation-ledger.ts` that names the record but does not read it.
- `tests/clients/lsp/client-selection-outcome.test.ts` asserts the outcome
  vocabulary. Its cases are all single-caller, so they still see the starter
  values and pass unchanged.
- The `erroredServerId` branch in `getClientForFile` now also admits
  `spawn-failure-joined`, and the record it emits carries the acquisition's own
  outcome instead of a hardcoded `"spawn-failure"`. Without that, a joined
  failure would still have been reported as a starter.

Hot path: the discriminator is one boolean assignment on the LSP acquisition
path, already an `await`-heavy path around a process spawn. `lsp_server_spawned`
is one `logLatency` call per language-server process start, next to two existing
per-spawn record calls (`recordLsp`, `recordSuccessfulLspSpawn`). Spawns are
single-flighted per `serverId:root`, so this adds no per-touch or per-file cost.

No new process spawns, no behavior widening, no change to what gets spawned or
when. Only what is written down changes.

Merge order: no conflict expected. The two other open PRs (#2105, #1986) touch
`clients/lsp/launch.ts`, `clients/metrics-history.ts`, and
`docs/servercapabilities.md`. Neither touches `clients/lsp/index.ts` or this
test file.

## Class sweep

Defect shape: a per-caller observability record emitted downstream of a
single-flight join, so N joiners each report the one unit of work as their own.

PATTERN sweep, whole source tree (`clients/`, `tools/`, `mcp/`, `scripts/`,
`index.ts`): grep for single-flight promise maps and for record emission after
the join. 14 sites.

POPULATION sweep, the single-flight family, one verdict each:

| site | verdict |
|---|---|
| `clients/lsp/index.ts:3263` (LSP spawn) | FIXED here |
| `clients/lsp/server.ts:1133` (root walk) | already correct — joiners `return flying` at :1134, no post-join code |
| `clients/dead-code-client.ts:398` | already correct — `if (existing) return existing` |
| `clients/jscpd-client.ts:255` | already correct — same early return |
| `clients/knip-client.ts:467` | already correct — same early return |
| `clients/security-scan-client.ts:354` | already correct — same early return |
| `clients/dispatch/runners/utils/lazy-installer.ts:192` | already correct — records live inside `performInstall`, which runs once |
| `clients/dispatch/runners/utils/runner-helpers.ts:965` | already correct — same early return |
| `clients/dispatch/runners/utils/runner-helpers.ts:1256` | already correct — same early return |
| `clients/dispatch/runners/helm-lint.ts:198` | already correct — same early return |
| `clients/dispatch/runners/helm-render.ts:1085` | already correct — same early return |
| `clients/package-manager.ts:219` | already correct — joiner returns the shared probe |
| `clients/mcp/session.ts:419` | already correct — `if (inFlight) return inFlight` |
| `clients/runtime-tool-result.ts:994` | already correct, and the positive control for the shape: a duplicate concurrent pipeline is attributed as a `participantIds` entry on the one pipeline, never as a second pipeline |

Consolidation verdict: no shared helper is warranted, and the sweep explains
why. Every other family member returns the joined promise at the join site, so
joiners execute no post-join code and cannot over-count. The LSP acquisition
path is the only member that must keep running after the join — it announces
`onSpawnInFlight`, owns the `inFlight` `finally`, and reports a per-selection
outcome — which is precisely why it was the only member that could count a
joiner as an originator. A helper would have one caller.

Under-count half of the class, checked separately: the LSP lifecycle phases in
`latency.log`. Terminations were already recorded (`lsp_client_shutdown`,
`lsp_server_unexpected_exit`, `lsp_server_respawn`); starts were not, for any
server that does not launch through `resolveAndLaunch`. With
`lsp_server_spawned` the lifecycle is balanced, so live-client count is now
derivable from the log.

Cross-link, not absorbed: #2070 (writer-attribution gap) is the named sibling in
the same "the record does not identify who did it" family. It is a different
seam with a different writer set and stays its own issue.

## Observability

The record that proves this in production, both halves in
`~/.pi-lens/latency.log`:

- `lsp_client_selected`, `metadata.outcome`. Clustering `cold-spawn` records by
  `serverId` within a 2 s window must now agree with the raw `cold-spawn` count
  instead of exceeding it 3.0x. On the issue's window that predicts 21
  `cold-spawn` and 41 `cold-spawn-joined` where 62 `cold-spawn` were written,
  and a reuse rate of 97.7% rather than 93.5%. That is a prediction from the
  issue's own clustering, not a replay: the field log was written by the old
  code and cannot be re-emitted. The burst shape itself IS replayed, in the
  test below.
- `lsp_server_spawned`, one record per language-server process start, carrying
  `serverId`, `source`, `launchVariant`, and the spawn-plus-initialize
  `durationMs`. `count(phase=lsp_server_spawned, serverId=typescript)` is the
  spawn count the issue said no record could answer, and it is the
  AUTHORITATIVE spawn count.

  The two records relate as `count(lsp_server_spawned) >=
  count(outcome=cold-spawn)`, never as equality. An earlier version of this
  body claimed equality and was wrong: `getClientsForFile` and
  `getAuxiliaryClientsForFile` call `ensureClientForServer` without
  `onOutcome`, so a multi-client or auxiliary spawn writes a spawn record and
  no selection record at all. The starter-outcome count therefore under-counts
  real process starts. See review round F1 below.

Bounds. Neither record is new volume. `lsp_client_selected` fires once per
selection as before; only its `outcome` vocabulary widened, and no exact-key
pin was loosened. `lsp_server_spawned` fires once per process start, and starts
are single-flighted per `serverId:root` by `state.inFlight`, so its cadence is
the spawn cadence — 21 records in the issue's 21.8 h window. It is not a
failure-shaped phase, so the `bounded-telemetry-sweep` registered-or-fail rule
does not govern it; that suite passes on this branch.

A standing invariant recording the starter/joiner rule is added to AGENTS.md's
LSP group, so the next author cannot re-derive the outcome after the await.

## Review round 1

Four findings, all applied on this branch in commit `ca529c9`. Each was
reproduced with a probe before it was fixed.

**F1 (medium) — the observability recipe was false in production.** This body
and the AGENTS.md invariant both claimed
`count(lsp_server_spawned) == count(outcome=cold-spawn)`.
`getClientsForFile` (`clients/lsp/index.ts:2586`) and
`getAuxiliaryClientsForFile` (`:2612`) call `ensureClientForServer` with no
`onOutcome`, so a spawn on those paths emits a spawn record and zero selection
records. A log reader following the equality would have chased a phantom leak.
Probe output:

```
F1 spawn records: 1
F1 selection records: []
```

Corrected in three places: the AGENTS.md invariant, this body, and the
`LSPClientAcquisitionOutcome` doc comment. All three now state
`count(lsp_server_spawned) >= count(outcome="cold-spawn")` and name
`lsp_server_spawned` authoritative. Pinned by a new test,
"counts a getClientsForFile spawn with no selection record", which reds on
pre-fix source (`expected [] to have a length of 1 but got +0`).

**F2 (low) — the catch-path split was unproven, and is now removed.** The
reviewer found that reverting
`startedSpawn ? "spawn-failure" : "spawn-failure-joined"` at the catch left all
four tests green. Investigating why produced a stronger answer than a new test.
`spawnClient` never rethrows: it catches its own spawn and initialize failures
and resolves `undefined`. So that catch is reachable only when `spawnClient`
throws BEFORE its own `try` (the trust probe, `logSessionStart`, `recordLsp`),
and two things follow. The published promise is already rejected when it enters
`inFlight`, so no joiner can attach. And the rethrow unwinds past every
`lsp_client_selected` emit site, so the value is written to no record. A probe
drove a throwing trust check through two concurrent callers:

```
F2 settled: [ 'rejected', 'rejected' ]
F2 selection records: []
```

An unobservable discriminator is a vacuous guard, so the split is reverted to
the single `#1934` value and the reachability analysis is recorded at the site.
A new test, "emits no selection record when the acquisition throws", pins that
analysis. It is labeled honestly in the file as a claim pin, not a red-first
regression test: it passes before and after. Its job is to fail if someone
later makes `spawnClient` rethrow, which would make the catch reachable with a
live joiner and reopen the over-count. The test file's mutation-proof list now
names this branch as NOT mutation-proven, with the reason.

The resolve-path split is unaffected and stays mutation-proven: forcing
`startedSpawn` true reds 3 of 6 tests.

**F3 (nit) — `SPAWN_STARTING_OUTCOMES` removed.** It was a production export
with only a test consumer. The burst test now asserts the observed outcome set
directly, which gives the same "no third value slipped in" guarantee without a
dead export.

**F4 (nit) — the two path fields are deliberate, and the record now says so.**
`filePath` carries the root, because root plus `serverId` is the client's
identity and the unit a spawn is single-flighted on. `triggerFilePath` carries
the file whose touch paid for the spawn. They answer different questions and
`triggerFilePath` is the one that varies across records for the same client.

### Verification for the round

Red proof on pre-fix source (`git checkout origin/master -- clients/lsp/index.ts`,
rebuilt), 5 of 6 red:

```
 × marks exactly one starter and N-1 joiners for one slow spawn
   → expected 5 to be 1
 × replays the 39-record burst as 1 spawn and 38 joins
   → expected 39 to be 1
 × records a TypeScript process start in latency.log
   → expected [] to have a length of 1 but got +0
 × splits the starter from the joiners when the spawn fails
   → expected 5 to be 1
 × counts a getClientsForFile spawn with no selection record
   → expected [] to have a length of 1 but got +0
 ✓ emits no selection record when the acquisition throws
      Tests  5 failed | 1 passed (6)
```

The sixth passing on pre-fix source is the F2 claim pin, exactly as its comment
states.

Green after: `spawn-record-truth` 6/6, run three times for stability. Canaries
`refresh-and-sync-kind` (32), `workspace-diagnostics-outside-root` (2),
`silent-clean-confirm` (11) pass. Governance `bounded-telemetry-sweep` (15),
`session-state-conformance` + `module-instance-coverage` (81) pass.
`client-selection-outcome`, `client-ceiling`, `lifecycle` pass.

`origin/master` moved to `e4e7895` (#2105) during the round, so this branch
merged it. Semantic screen of the merge, not just a textual one: #2105 changes
only the `stdio` piping on a Windows PATH-resolution probe in
`clients/lsp/launch.ts`. It does not touch spawn success or failure
classification, the `inFlight` seam, or any record, so it cannot recombine with
the starter/joiner bit or the spawn record. Its own test file
(`tests/clients/lsp/launch-stderr-guard.test.ts`) passes on the merged tree.

One honest note on local runs: the machine was under heavy concurrent test load
during this round. A four-file canary run took 62 minutes and reported one
failure with no attributable output. Re-running each of those four files
individually afterward passed, 60/60. Treated as load flake, not a regression,
and CI is authoritative.

