### PR TITLE
fix(session): guard shared-checkout WIP against branch switches (refs #2007)

### DIFF
--- a/.changelog/fix-2007-shared-checkout-wip.md
+++ b/.changelog/fix-2007-shared-checkout-wip.md
@@ -1,0 +1,7 @@
+---
+section: Added
+---
+
+- **Guard a shared checkout against branch switches that destroy another session's work (refs #2007)** — a new opt-in `--lens-checkout-guard` (`guard.sharedCheckout=true`) declines `git checkout`, `switch`, `restore`, `reset --hard`, `stash`, `clean`, `merge`, `rebase`, `pull`, `cherry-pick`, and `revert` when the checkout has uncommitted work and another live pi-lens session is registered on the same root. The refusal names the peer pids and tells you to commit or take a dedicated worktree, rather than moving anyone's work behind their back. Command classification reuses the existing git-guard shell analysis; peer liveness reuses the instance registry.
+
+> Refs #2007

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -930,6 +930,30 @@ unrecognized leading launcher with `-c`/`--run`/`/c`/`-Command` is inspected
 recursively and fails closed only when its command string contains an actual
 guarded git verb (literal mentions such as `echo git push` remain allowed).
 
+Git command classification has ONE implementation. `detectGuardedGitVerb`
+takes a `GitVerbMatcher` and owns the wrapper, `$IFS`, substitution, PATHEXT,
+and text-consumer analysis; a guard that needs "is this really a git
+invocation of verb V" supplies only the verb question. Do not add a second
+lexer. The two matchers differ on exactly one axis, `indirectAlwaysMatches`:
+the commit gate is a policy an agent may want to evade, so any non-leading
+`git` fails closed there, while the shared-checkout guard protects an agent
+from its own accident and arms the indirect path only when the argv also
+carries a governed verb.
+
+The shared-checkout guard (`clients/shared-checkout-guard.ts`,
+`--lens-checkout-guard`) declines a worktree-mutating git command when three
+facts all hold, checked cheapest first: the command really mutates the
+working tree, `selectLivePeerInstances` reports another live session on this
+root, and `git status` reports uncommitted work. Refusal is the whole design
+— never auto-stash, because `git stash` is repo-global across worktrees and
+would reproduce the defect it is rescuing from. An unanswerable `git status`
+declines on its own UNKNOWN reason and records a counted degradation; it is
+never read as clean. A registry that cannot be read allows, so an
+observability outage cannot start refusing branch switches machine-wide.
+`selectLivePeerInstances` (`clients/instance-registry.ts`) is the single
+source of truth for "another session is here"; `selectWarmAttachIncumbent`
+picks the oldest entry it returns, so the two cannot drift.
+
 ### Host integration and repo automation
 
 The weekly stale-open-issue detector is detection-only: `.github/workflows/stale-open-issues.yml`

--- a/clients/bounded-telemetry.ts
+++ b/clients/bounded-telemetry.ts
@@ -107,6 +107,17 @@ export const BOUNDED_TELEMETRY_PHASES = [
 	 * queue of them, so it is rising-edge per event name.
 	 */
 	"session_event_stale_ctx_skip",
+	/**
+	 * #2007: a worktree-mutating git command declined because another live
+	 * session shares this dirty checkout. Rising edge per checkout root; the
+	 * ledger keeps the exact repeat count.
+	 */
+	"shared_checkout_switch_blocked",
+	/**
+	 * #2007: `git status` could not report the working-tree state, so the same
+	 * command was declined on an UNKNOWN rather than assumed clean.
+	 */
+	"shared_checkout_probe_failed",
 ] as const;
 
 export type BoundedPhase = (typeof BOUNDED_TELEMETRY_PHASES)[number];

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -48,6 +48,14 @@ export type DegradationKind =
 	| "lsp-warm-client-missing"
 	| "lsp-capability-skip"
 	/**
+	 * #2007: a worktree-mutating git command was declined because a live peer
+	 * session shares this dirty checkout. The subject is the checkout root, so
+	 * the ledger says WHICH shared directory is contended.
+	 */
+	| "shared-checkout-wip"
+	/** #2007: `git status` could not answer for that same decision. */
+	| "shared-checkout-probe"
+	/**
 	 * The blind review-graph read (`getCachedReviewGraph`) either DROPPED a
 	 * persisted snapshot because its git stamp names a different worktree, or
 	 * SERVED one whose stamp names a different HEAD (#1961). Subject is

--- a/clients/finding-delivery-gate.ts
+++ b/clients/finding-delivery-gate.ts
@@ -560,6 +560,15 @@ export const DELIVERY_SURFACES: Record<string, DeliverySurfaceEntry> = {
 			"detection and delivery.",
 		"live",
 	),
+	"shared-checkout-guard:worktree-mutation-blocked": labeled(
+		"clients/shared-checkout-guard.ts",
+		"Shared-checkout 🔴 WORKING-TREE CHANGE BLOCKED verdict (--lens-checkout-guard).",
+		"Synchronous preflight rejection returned inline with the failed git " +
+			"command. Both inputs are read at decision time — the instance registry " +
+			"and `git status` — so no stored finding is replayed and nothing can go " +
+			"stale between detection and delivery.",
+		"live",
+	),
 	"read-guard-tool-lines:preflight-errors": labeled(
 		"clients/read-guard-tool-lines.ts",
 		"Read-guard hashline BLOCKED / RE-READ REQUIRED preflight errors.",

--- a/clients/git-guard.ts
+++ b/clients/git-guard.ts
@@ -273,7 +273,48 @@ function delimitedSubstitutionBody(
 	return undefined;
 }
 
-function containsGuardedSubstitution(command: string, depth: number): boolean {
+/**
+ * Which git verbs a guard cares about (#2007).
+ *
+ * The wrapper, substitution, `$IFS`, PATHEXT, and text-consumer analysis
+ * below took several review rounds to get right. A second guard that needs
+ * the same "is this an actual git invocation, and which verb" answer must
+ * reuse that analysis rather than grow a parallel lexer, so the classifier
+ * takes the verb question as a parameter and keeps everything else shared.
+ */
+export interface GitVerbMatcher {
+	/** Stable id for telemetry and tests. */
+	readonly id: string;
+	/**
+	 * True when `verb` in git command position, with `argsAfterVerb`
+	 * following it, is an operation this guard governs.
+	 */
+	readonly matchesVerb: (
+		verb: string,
+		argsAfterVerb: readonly string[],
+	) => boolean;
+	/**
+	 * True when ANY non-leading (indirect) `git` token matches unconditionally.
+	 * The commit/push guard is a policy gate an agent may want to evade, so
+	 * unknown launchers fail closed there. A guard that protects the agent
+	 * from its own accident sets this false and falls back to "an indirect
+	 * git whose argv also carries a governed verb" — see
+	 * `clients/shared-checkout-guard.ts`.
+	 */
+	readonly indirectAlwaysMatches: boolean;
+}
+
+const COMMIT_PUSH_MATCHER: GitVerbMatcher = {
+	id: "commit-push",
+	matchesVerb: (verb) => verb === "commit" || verb === "push",
+	indirectAlwaysMatches: true,
+};
+
+function containsGuardedSubstitution(
+	command: string,
+	depth: number,
+	matcher: GitVerbMatcher,
+): boolean {
 	if (depth > 3) return false;
 	let quote: "single" | "double" | undefined;
 	let escaped = false;
@@ -314,9 +355,9 @@ function containsGuardedSubstitution(command: string, depth: number): boolean {
 		if (substitution && substitution.end >= 0) {
 			const nested = canonicalizeGuardCommand(substitution.body);
 			if (
-				containsGuardedSubstitution(nested, depth + 1) ||
+				containsGuardedSubstitution(nested, depth + 1, matcher) ||
 				tokenizeShellCommand(nested).some((segment) =>
-					containsCommitOrPush(segment.tokens, depth + 1),
+					containsGuardedGitVerb(segment.tokens, depth + 1, matcher),
 				)
 			) {
 				return true;
@@ -327,7 +368,11 @@ function containsGuardedSubstitution(command: string, depth: number): boolean {
 	return false;
 }
 
-function containsCommitOrPush(tokens: string[], depth: number): boolean {
+function containsGuardedGitVerb(
+	tokens: string[],
+	depth: number,
+	matcher: GitVerbMatcher,
+): boolean {
 	if (depth > 3 || tokens.length === 0) return false;
 	let commandTokens = tokens;
 	while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(commandTokens[0] ?? "")) {
@@ -344,7 +389,7 @@ function containsCommitOrPush(tokens: string[], depth: number): boolean {
 		if (runIndex >= 0 && runIndex + 1 < commandTokens.length) {
 			const nestedCommand = commandTokens.slice(runIndex + 2).join(" ");
 			return tokenizeShellCommand(canonicalizeGuardCommand(nestedCommand)).some(
-				(segment) => containsCommitOrPush(segment.tokens, depth + 1),
+				(segment) => containsGuardedGitVerb(segment.tokens, depth + 1, matcher),
 			);
 		}
 	}
@@ -361,7 +406,20 @@ function containsCommitOrPush(tokens: string[], depth: number): boolean {
 	if (gitIndex >= 0) {
 		// Any non-leading git invocation is indirect. Do not maintain a wrapper
 		// or flag allowlist: unknown launchers are the security boundary here.
-		if (gitIndex > 0) return true;
+		if (gitIndex > 0) {
+			if (matcher.indirectAlwaysMatches) return true;
+			// #2007: a guard that protects the agent from its own accident must
+			// not decline `xargs git status`. Keep the indirect path armed only
+			// when the argv also carries a governed verb, so the evasion surface
+			// stays narrow without blocking every read-only indirect git.
+			const indirectTokens = commandTokens.slice(gitIndex + 1);
+			return indirectTokens.some((token, offset) =>
+				matcher.matchesVerb(
+					normalizeGuardVerbToken(token),
+					indirectTokens.slice(offset + 1),
+				),
+			);
+		}
 		const gitTokens = commandTokens.slice(gitIndex);
 		let i = 1;
 		const takesValue = new Set([
@@ -378,7 +436,10 @@ function containsCommitOrPush(tokens: string[], depth: number): boolean {
 			if (["--help", "-h", "--version", "-v", "-V"].includes(option))
 				return false;
 			if (option === "--")
-				return gitTokens[i + 1] === "commit" || gitTokens[i + 1] === "push";
+				return matcher.matchesVerb(
+					gitTokens[i + 1] ?? "",
+					gitTokens.slice(i + 2),
+				);
 			if (
 				["-C", "-c"].some(
 					(prefix) =>
@@ -403,7 +464,10 @@ function containsCommitOrPush(tokens: string[], depth: number): boolean {
 			i += takesValue.has(option) ? 2 : 1;
 		}
 		const verbs = expandGuardVerbToken(gitTokens[i] ?? "");
-		return verbs.length === 1 && (verbs[0] === "commit" || verbs[0] === "push");
+		return (
+			verbs.length === 1 &&
+			matcher.matchesVerb(verbs[0], gitTokens.slice(i + 1))
+		);
 	}
 	const leadingExecutable = commandTokens[0] ?? "";
 	const knownCommandStringWrapper =
@@ -424,7 +488,7 @@ function containsCommitOrPush(tokens: string[], depth: number): boolean {
 		if (commandIndex >= commandTokens.length) return false;
 		const nestedCommand = commandTokens.slice(commandIndex).join(" ");
 		return tokenizeShellCommand(canonicalizeGuardCommand(nestedCommand)).some(
-			(segment) => containsCommitOrPush(segment.tokens, depth + 1),
+			(segment) => containsGuardedGitVerb(segment.tokens, depth + 1, matcher),
 		);
 	}
 	const lower = commandTokens.slice(1).map((token) => token.toLowerCase());
@@ -451,23 +515,39 @@ function containsCommitOrPush(tokens: string[], depth: number): boolean {
 	if (commandTokens[commandIndex] === "--") commandIndex += 1;
 	const nestedCommand = commandTokens.slice(commandIndex).join(" ");
 	return tokenizeShellCommand(canonicalizeGuardCommand(nestedCommand)).some(
-		(segment) => containsCommitOrPush(segment.tokens, depth + 1),
+		(segment) => containsGuardedGitVerb(segment.tokens, depth + 1, matcher),
 	);
 }
 
-/** Analyze actual executable invocations, not substrings in shell text. */
-export function isGitCommitOrPushAttempt(
+/**
+ * Analyze actual executable invocations, not substrings in shell text.
+ *
+ * Shared entry point for every guard that needs "is this bash input really a
+ * git invocation of a verb I govern" (#2007). The verb question is the only
+ * parameter; wrapper, substitution, and text-consumer analysis are identical
+ * for all callers by construction.
+ */
+export function detectGuardedGitVerb(
 	toolName: string,
 	input: unknown,
+	matcher: GitVerbMatcher,
 ): boolean {
 	if (toolName !== "bash") return false;
 	const command = getShellCommand(input);
 	if (!command) return false;
 	const canonical = canonicalizeGuardCommand(command);
-	if (containsGuardedSubstitution(canonical, 0)) return true;
+	if (containsGuardedSubstitution(canonical, 0, matcher)) return true;
 	return tokenizeShellCommand(canonical).some((segment) =>
-		containsCommitOrPush(segment.tokens, 0),
+		containsGuardedGitVerb(segment.tokens, 0, matcher),
 	);
+}
+
+/** The #1063 commit gate's own question. */
+export function isGitCommitOrPushAttempt(
+	toolName: string,
+	input: unknown,
+): boolean {
+	return detectGuardedGitVerb(toolName, input, COMMIT_PUSH_MATCHER);
 }
 
 function isTurnEndFindingsCache(value: unknown): value is TurnEndFindingsCache {

--- a/clients/git-guard.ts
+++ b/clients/git-guard.ts
@@ -302,12 +302,26 @@ export interface GitVerbMatcher {
 	 * `clients/shared-checkout-guard.ts`.
 	 */
 	readonly indirectAlwaysMatches: boolean;
+	/**
+	 * True when a LEADING post-verb `--help`/`-h` means "print documentation"
+	 * and the invocation should not match (#2007).
+	 *
+	 * FALSE for the commit gate, and that is a contract, not a tuning knob.
+	 * `-h` is a legal option VALUE: `git commit -m -h` creates a commit whose
+	 * message is `-h` (verified against git 2.55 — it exits 0 and the log
+	 * subject reads `-h`), and `git push --repo -h` really pushes. A gate that
+	 * fails closed must not be talked out of a match by a token that might be
+	 * a value. `git commit --help` therefore still classifies as an attempt,
+	 * exactly as it did before this seam existed.
+	 */
+	readonly suppressPostVerbHelp: boolean;
 }
 
 const COMMIT_PUSH_MATCHER: GitVerbMatcher = {
 	id: "commit-push",
 	matchesVerb: (verb) => verb === "commit" || verb === "push",
 	indirectAlwaysMatches: true,
+	suppressPostVerbHelp: false,
 };
 
 function containsGuardedSubstitution(
@@ -436,9 +450,22 @@ export function matchGitVerbAtCommandPosition(
 	const index = gitVerbIndex(gitTokens);
 	if (index === undefined) return false;
 	const argsAfterVerb = gitTokens.slice(index + 1);
-	// `git checkout --help` prints documentation and touches nothing. The
+	// `git checkout --help` prints documentation and touches nothing, and the
 	// global-option walk above cannot see it, because it sits AFTER the verb.
-	if (argsAfterVerb.some((arg) => arg === "--help" || arg === "-h")) {
+	//
+	// Only the FIRST argument counts, and only for matchers that opt in. `-h`
+	// deeper in the argv may be an option VALUE rather than a help request —
+	// `git commit -m -h` commits with the message `-h`, `git clean -e -h`
+	// excludes a pattern named `-h`. Reading any position would need a
+	// per-verb table of value-taking options for every governed verb, which is
+	// exactly the hand-maintained parallel list this repo forbids, and every
+	// gap in it would silently UNDER-block. Leading-position-only needs no
+	// table, covers how help is actually invoked, and every other spelling
+	// falls through to a match, which is the safe direction for a guard.
+	if (
+		matcher.suppressPostVerbHelp &&
+		(argsAfterVerb[0] === "--help" || argsAfterVerb[0] === "-h")
+	) {
 		return false;
 	}
 	const verbs = expandGuardVerbToken(gitTokens[index] ?? "");

--- a/clients/git-guard.ts
+++ b/clients/git-guard.ts
@@ -368,6 +368,184 @@ function containsGuardedSubstitution(
 	return false;
 }
 
+/** Git global options that consume the following token as their value. */
+const GIT_GLOBAL_OPTIONS_WITH_VALUE = new Set([
+	"-C",
+	"-c",
+	"--config-env",
+	"--git-dir",
+	"--work-tree",
+	"--exec-path",
+	"--namespace",
+]);
+
+const GIT_GLOBAL_OPTIONS_WITH_INLINE_VALUE = [
+	"--config-env",
+	"--git-dir",
+	"--work-tree",
+	"--exec-path",
+	"--namespace",
+];
+
+/**
+ * Index of git's subcommand token in `gitTokens` (which starts at the `git`
+ * executable), after skipping global options and their values. Returns
+ * `undefined` when the invocation has no subcommand at all — `git --help`,
+ * `git --version`, or a trailing option with no verb behind it.
+ *
+ * Shared by the direct and indirect paths so both ask the same question about
+ * the same position (#2007).
+ */
+function gitVerbIndex(gitTokens: string[]): number | undefined {
+	let i = 1;
+	while (i < gitTokens.length && gitTokens[i].startsWith("-")) {
+		const option = gitTokens[i];
+		if (["--help", "-h", "--version", "-v", "-V"].includes(option)) {
+			return undefined;
+		}
+		if (option === "--") return i + 1 < gitTokens.length ? i + 1 : undefined;
+		if (
+			["-C", "-c"].some(
+				(prefix) => option.startsWith(prefix) && option.length > prefix.length,
+			)
+		) {
+			i += 1;
+			continue;
+		}
+		if (
+			GIT_GLOBAL_OPTIONS_WITH_INLINE_VALUE.some((prefix) =>
+				option.startsWith(`${prefix}=`),
+			)
+		) {
+			i += 1;
+			continue;
+		}
+		i += GIT_GLOBAL_OPTIONS_WITH_VALUE.has(option) ? 2 : 1;
+	}
+	return i < gitTokens.length ? i : undefined;
+}
+
+/**
+ * True when the subcommand in git's command position is one the matcher
+ * governs. `gitTokens[0]` is the `git` executable token.
+ */
+export function matchGitVerbAtCommandPosition(
+	gitTokens: string[],
+	matcher: GitVerbMatcher,
+): boolean {
+	const index = gitVerbIndex(gitTokens);
+	if (index === undefined) return false;
+	const argsAfterVerb = gitTokens.slice(index + 1);
+	// `git checkout --help` prints documentation and touches nothing. The
+	// global-option walk above cannot see it, because it sits AFTER the verb.
+	if (argsAfterVerb.some((arg) => arg === "--help" || arg === "-h")) {
+		return false;
+	}
+	const verbs = expandGuardVerbToken(gitTokens[index] ?? "");
+	return verbs.length === 1 && matcher.matchesVerb(verbs[0], argsAfterVerb);
+}
+
+/** Strip one layer of shell quoting the lexer preserved on a value token. */
+function unquoteGuardValue(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.length >= 2) {
+		const first = trimmed[0];
+		const last = trimmed[trimmed.length - 1];
+		if ((first === '"' || first === "'") && first === last) {
+			return trimmed.slice(1, -1);
+		}
+	}
+	return trimmed;
+}
+
+/**
+ * The directory a git invocation actually targets (#2007).
+ *
+ * `git -C <dir>` and `--work-tree` retarget the command at a DIFFERENT
+ * directory, so a guard that evaluates the caller's cwd would inspect the
+ * wrong working tree and allow a destructive command against a shared one.
+ * `-C` composes cumulatively, exactly as git applies it; `--work-tree` names
+ * the working tree directly and therefore wins.
+ *
+ * Returns the resolved absolute directory, or `cwd` when the invocation
+ * carries no retargeting option.
+ */
+export function resolveGitTargetDirectory(
+	gitTokens: string[],
+	cwd: string,
+): string {
+	let base = cwd;
+	let workTree: string | undefined;
+	let i = 1;
+	while (i < gitTokens.length && gitTokens[i].startsWith("-")) {
+		const option = gitTokens[i];
+		if (["--help", "-h", "--version", "-v", "-V"].includes(option)) break;
+		if (option === "--") break;
+		if (option === "-C" && i + 1 < gitTokens.length) {
+			base = path.resolve(base, unquoteGuardValue(gitTokens[i + 1]));
+			i += 2;
+			continue;
+		}
+		if (option.startsWith("-C") && option.length > 2) {
+			base = path.resolve(base, unquoteGuardValue(option.slice(2)));
+			i += 1;
+			continue;
+		}
+		if (option === "--work-tree" && i + 1 < gitTokens.length) {
+			workTree = unquoteGuardValue(gitTokens[i + 1]);
+			i += 2;
+			continue;
+		}
+		if (option.startsWith("--work-tree=")) {
+			workTree = unquoteGuardValue(option.slice("--work-tree=".length));
+			i += 1;
+			continue;
+		}
+		if (
+			option.startsWith("-c") &&
+			option.length > 2 &&
+			!option.startsWith("--")
+		) {
+			i += 1;
+			continue;
+		}
+		if (
+			GIT_GLOBAL_OPTIONS_WITH_INLINE_VALUE.some((prefix) =>
+				option.startsWith(`${prefix}=`),
+			)
+		) {
+			i += 1;
+			continue;
+		}
+		i += GIT_GLOBAL_OPTIONS_WITH_VALUE.has(option) ? 2 : 1;
+	}
+	return workTree === undefined ? base : path.resolve(base, workTree);
+}
+
+/**
+ * Every git invocation the command contains, as token arrays starting at the
+ * `git` executable. Used by callers that must know WHICH directory a matched
+ * command targets, not merely that it matched (#2007).
+ */
+export function collectGitInvocations(
+	toolName: string,
+	input: unknown,
+): string[][] {
+	if (toolName !== "bash") return [];
+	const command = getShellCommand(input);
+	if (!command) return [];
+	const invocations: string[][] = [];
+	for (const segment of tokenizeShellCommand(
+		canonicalizeGuardCommand(command),
+	)) {
+		const gitIndex = segment.tokens.findIndex((token) =>
+			isGitExecutable(token),
+		);
+		if (gitIndex >= 0) invocations.push(segment.tokens.slice(gitIndex));
+	}
+	return invocations;
+}
+
 function containsGuardedGitVerb(
 	tokens: string[],
 	depth: number,
@@ -406,67 +584,15 @@ function containsGuardedGitVerb(
 	if (gitIndex >= 0) {
 		// Any non-leading git invocation is indirect. Do not maintain a wrapper
 		// or flag allowlist: unknown launchers are the security boundary here.
-		if (gitIndex > 0) {
-			if (matcher.indirectAlwaysMatches) return true;
-			// #2007: a guard that protects the agent from its own accident must
-			// not decline `xargs git status`. Keep the indirect path armed only
-			// when the argv also carries a governed verb, so the evasion surface
-			// stays narrow without blocking every read-only indirect git.
-			const indirectTokens = commandTokens.slice(gitIndex + 1);
-			return indirectTokens.some((token, offset) =>
-				matcher.matchesVerb(
-					normalizeGuardVerbToken(token),
-					indirectTokens.slice(offset + 1),
-				),
-			);
-		}
-		const gitTokens = commandTokens.slice(gitIndex);
-		let i = 1;
-		const takesValue = new Set([
-			"-C",
-			"-c",
-			"--config-env",
-			"--git-dir",
-			"--work-tree",
-			"--exec-path",
-			"--namespace",
-		]);
-		while (i < gitTokens.length && gitTokens[i].startsWith("-")) {
-			const option = gitTokens[i];
-			if (["--help", "-h", "--version", "-v", "-V"].includes(option))
-				return false;
-			if (option === "--")
-				return matcher.matchesVerb(
-					gitTokens[i + 1] ?? "",
-					gitTokens.slice(i + 2),
-				);
-			if (
-				["-C", "-c"].some(
-					(prefix) =>
-						option.startsWith(prefix) && option.length > prefix.length,
-				)
-			) {
-				i += 1;
-				continue;
-			}
-			if (
-				[
-					"--config-env",
-					"--git-dir",
-					"--work-tree",
-					"--exec-path",
-					"--namespace",
-				].some((prefix) => option.startsWith(`${prefix}=`))
-			) {
-				i += 1;
-				continue;
-			}
-			i += takesValue.has(option) ? 2 : 1;
-		}
-		const verbs = expandGuardVerbToken(gitTokens[i] ?? "");
-		return (
-			verbs.length === 1 &&
-			matcher.matchesVerb(verbs[0], gitTokens.slice(i + 1))
+		if (gitIndex > 0 && matcher.indirectAlwaysMatches) return true;
+		// #2007: a guard that protects the agent from its own accident must not
+		// decline `xargs git status`, so the indirect path stays armed only when
+		// a governed verb sits in git's real COMMAND POSITION. Scanning every
+		// token instead would fire on `find . -name checkout | xargs git add`,
+		// where `checkout` is a positional value and not a subcommand at all.
+		return matchGitVerbAtCommandPosition(
+			commandTokens.slice(gitIndex),
+			matcher,
 		);
 	}
 	const leadingExecutable = commandTokens[0] ?? "";

--- a/clients/instance-registry.ts
+++ b/clients/instance-registry.ts
@@ -35,7 +35,7 @@ import { getGlobalPiLensDir } from "./file-utils.js";
 // use on both sides happens inside function bodies, never at module-
 // evaluation time, so both modules are fully initialized before either
 // import is actually invoked.
-import { realIsPidAlive } from "./instance-reaper.js";
+import { realIsPidAlive, STALE_HEARTBEAT_MS } from "./instance-reaper.js";
 import { normalizeFilePath } from "./path-utils.js";
 import { getSubagentIdentity, isSubagentSession } from "./subagent-mode.js";
 
@@ -428,6 +428,43 @@ export function deregisterInstance(): void {
 	const remaining = file.instances.filter((entry) => entry.pid !== pid);
 	if (remaining.length === file.instances.length) return; // nothing to remove
 	writeRegistrySync({ instances: remaining });
+}
+
+/**
+ * Every OTHER live pi-lens process registered against the same project root,
+ * oldest first (#2007).
+ *
+ * "Live" is the registry's own three-part answer, not a guess: a different
+ * pid, an OS-confirmed alive pid, and a parseable heartbeat inside
+ * `STALE_HEARTBEAT_MS`. This is the single predicate for "am I sharing this
+ * directory with someone" — `selectWarmAttachIncumbent` picks the oldest
+ * entry it returns, and the shared-checkout guard asks whether it returns
+ * anything at all. Both must move together if the liveness rule changes.
+ *
+ * Roots are compared after `normalizeFilePath`, the same form
+ * `registerInstance` writes, so drive-letter case and separators cannot make
+ * a peer invisible (catalog shape 1).
+ *
+ * Best-effort by construction: the caller supplies the entries, so a failed
+ * registry read is the caller's empty list, which reads as "no known peer".
+ */
+export function selectLivePeerInstances(
+	entries: readonly InstanceEntry[],
+	root: string,
+	now: number = Date.now(),
+	isPidAlive: (pid: number) => boolean = realIsPidAlive,
+): InstanceEntry[] {
+	const normalizedRoot = normalizeFilePath(root);
+	return entries
+		.filter(
+			(entry) =>
+				entry.pid !== process.pid &&
+				entry.projectRoot === normalizedRoot &&
+				isPidAlive(entry.pid) &&
+				Number.isFinite(Date.parse(entry.heartbeatAt)) &&
+				now - Date.parse(entry.heartbeatAt) <= STALE_HEARTBEAT_MS,
+		)
+		.sort((a, b) => Date.parse(a.startedAt) - Date.parse(b.startedAt));
 }
 
 // --- Resource footprint aggregation (#620) ----------------------------------

--- a/clients/instance-registry.ts
+++ b/clients/instance-registry.ts
@@ -445,21 +445,44 @@ export function deregisterInstance(): void {
  * `registerInstance` writes, so drive-letter case and separators cannot make
  * a peer invisible (catalog shape 1).
  *
+ * `match` picks what "same directory" means, and the two callers genuinely
+ * differ. Warm attach needs `"exact"`: it shares one LSP service, which is
+ * bound to a specific project root. The shared-checkout guard needs
+ * `"containment"`: a peer registered at the repo root and a command run from
+ * `repo/clients` share one working tree, and an exact compare would report no
+ * peer and allow the destructive command. Containment compares on segment
+ * boundaries, so `/repo-backup` never matches `/repo`.
+ *
  * Best-effort by construction: the caller supplies the entries, so a failed
  * registry read is the caller's empty list, which reads as "no known peer".
  */
+export type PeerRootMatch = "exact" | "containment";
+
+/**
+ * True when `a` and `b` are the same directory, or one contains the other.
+ * Compared on SEGMENT boundaries, so `/repo-backup` never matches `/repo`.
+ */
+function rootsOverlap(a: string, b: string): boolean {
+	if (a === b) return true;
+	const [shorter, longer] = a.length < b.length ? [a, b] : [b, a];
+	return longer.startsWith(shorter.endsWith("/") ? shorter : `${shorter}/`);
+}
+
 export function selectLivePeerInstances(
 	entries: readonly InstanceEntry[],
 	root: string,
 	now: number = Date.now(),
 	isPidAlive: (pid: number) => boolean = realIsPidAlive,
+	match: PeerRootMatch = "exact",
 ): InstanceEntry[] {
 	const normalizedRoot = normalizeFilePath(root);
 	return entries
 		.filter(
 			(entry) =>
 				entry.pid !== process.pid &&
-				entry.projectRoot === normalizedRoot &&
+				(match === "exact"
+					? entry.projectRoot === normalizedRoot
+					: rootsOverlap(entry.projectRoot, normalizedRoot)) &&
 				isPidAlive(entry.pid) &&
 				Number.isFinite(Date.parse(entry.heartbeatAt)) &&
 				now - Date.parse(entry.heartbeatAt) <= STALE_HEARTBEAT_MS,

--- a/clients/lens-flag-registry.ts
+++ b/clients/lens-flag-registry.ts
@@ -132,6 +132,15 @@ export const LENS_FLAGS: readonly LensFlagSpec[] = [
 		scope: "global",
 	},
 	{
+		name: "lens-checkout-guard",
+		description:
+			"Experimental: decline git commands that rewrite the working tree when another live pi-lens session shares this dirty checkout. Also via guard.sharedCheckout=true in ~/.pi-lens/config.json.",
+		configKey: "guard.sharedCheckout",
+		negated: false,
+		default: false,
+		scope: "global",
+	},
+	{
 		name: "no-opengrep",
 		description:
 			"Disable the Opengrep security scanner (a default-on auxiliary LSP; auto-installs, uses repo rules if present else the login-free 'auto' ruleset). Also via opengrep.enabled=false in ~/.pi-lens/config.json.",

--- a/clients/opaque-mutation-scan.ts
+++ b/clients/opaque-mutation-scan.ts
@@ -228,6 +228,7 @@ const gitRepoMemo = new Map<string, boolean>();
 export function resetOpaqueMutationState(): void {
 	getOpaqueBaselineStore().takeAllForTest();
 	gitRepoMemo.clear();
+	gitToplevelMemo.clear();
 }
 
 /** Cached git-worktree probe (repos don't stop being git mid-session). */
@@ -248,6 +249,42 @@ export async function isGitWorktree(root: string): Promise<boolean> {
 
 export function _resetGitWorktreeMemoForTests(): void {
 	gitRepoMemo.clear();
+	gitToplevelMemo.clear();
+}
+
+const gitToplevelMemo = new Map<string, string | undefined>();
+
+/**
+ * The root of the working tree `root` belongs to, or `undefined` when it is
+ * not inside one (#2007).
+ *
+ * This is WORKTREE IDENTITY, which path containment cannot supply. A linked
+ * worktree lives at a path nested under the main checkout — this repo keeps
+ * agent worktrees under `.claude/worktrees/` — yet shares no working files
+ * with it. `--show-toplevel` answers which tree a directory really belongs
+ * to, so two directories are the same checkout when, and only when, their
+ * toplevels match.
+ *
+ * Memoized beside `isGitWorktree`, and cleared by the same
+ * `resetOpaqueMutationState` session boundary, so it cannot become a
+ * process-lifetime latch (catalog shape 17). `undefined` is a real cached
+ * answer, so the memo is probed with `has`, never by truthiness.
+ */
+export async function resolveGitToplevel(
+	root: string,
+): Promise<string | undefined> {
+	const key = normalizeMapKey(path.resolve(root));
+	if (gitToplevelMemo.has(key)) return gitToplevelMemo.get(key);
+	const result = await safeSpawnAsync("git", ["rev-parse", "--show-toplevel"], {
+		cwd: root,
+		timeout: 3000,
+	});
+	const toplevel =
+		!result.error && result.status === 0 && result.stdout?.trim()
+			? result.stdout.trim()
+			: undefined;
+	gitToplevelMemo.set(key, toplevel);
+	return toplevel;
 }
 
 export interface GitRecoveryOutcome {

--- a/clients/runtime-tool-call.ts
+++ b/clients/runtime-tool-call.ts
@@ -6,6 +6,7 @@ import { recordDegradationOnce } from "./degradation-ledger.js";
 import { detectFileKind } from "./file-kinds.js";
 import { isPathIgnoredByProject } from "./file-utils.js";
 import { evaluateGitGuard, isGitCommitOrPushAttempt } from "./git-guard.js";
+import { evaluateSharedCheckoutGuard } from "./shared-checkout-guard.js";
 import { logLatency } from "./latency-logger.js";
 import { normalizeMapKey } from "./path-utils.js";
 import {
@@ -560,6 +561,25 @@ async function handleToolCallImpl(deps: ToolCallDeps): Promise<ToolCallResult> {
 			return {
 				block: true,
 				reason: guard.reason,
+			};
+		}
+	}
+
+	// #2007: a sibling session's branch switch destroys uncommitted work in a
+	// shared checkout. Independent of `lens-guard`: that gate is about blocker
+	// hygiene before a commit, this one is about not deleting a peer's WIP.
+	// The evaluator short-circuits on a pure string classification, so a
+	// non-git bash command pays no I/O here.
+	if (getFlag("lens-checkout-guard")) {
+		const sharedCheckout = await evaluateSharedCheckoutGuard(
+			toolName,
+			event.input,
+			ctx.cwd ?? runtime.projectRoot ?? process.cwd(),
+		);
+		if (sharedCheckout.block) {
+			return {
+				block: true,
+				reason: sharedCheckout.reason,
 			};
 		}
 	}

--- a/clients/shared-checkout-guard.ts
+++ b/clients/shared-checkout-guard.ts
@@ -1,0 +1,281 @@
+/**
+ * Shared-checkout WIP guard (#2007).
+ *
+ * THE HAZARD. Several agent sessions can run against ONE checkout. Nothing
+ * in git binds a session to a directory, so when one session runs
+ * `git checkout <branch>`, git overwrites the tracked files another live
+ * session was editing. The work is not recoverable: it was never committed
+ * and never stashed. The reported incident lost uncommitted edits to three
+ * files between two observations minutes apart.
+ *
+ * THE ANSWER IS REFUSAL, NOT RESCUE. An auto-stash would be invisible
+ * machinery that moves another session's work somewhere it did not ask for,
+ * and `git stash` is repo-global across worktrees, so the rescue would be a
+ * second instance of the same defect. This guard instead DECLINES the
+ * command and says who else is here. The operator resolves it the way the
+ * design contract already says to: commit, or take a dedicated
+ * `git worktree`.
+ *
+ * THREE FACTS MUST ALL HOLD BEFORE ANYTHING IS DECLINED, cheapest first:
+ *
+ *   1. The bash input really invokes a git verb that rewrites the working
+ *      tree. Pure string work, no I/O — see `WORKTREE_MUTATING_GIT_MATCHER`.
+ *   2. Another live pi-lens session is registered on this same root.
+ *      `selectLivePeerInstances` (clients/instance-registry.ts) is the single
+ *      source of truth for that question; warm-attach reads the same
+ *      predicate. No peer means no shared checkout and nothing to protect.
+ *   3. The working tree actually carries uncommitted work. A clean tree can
+ *      be switched freely.
+ *
+ * That ordering is the cost story: the two `git` probes run only after a
+ * genuine worktree-mutating command in a genuinely shared checkout, which is
+ * rare. Ordinary bash traffic pays one string classification.
+ *
+ * UNKNOWN IS NOT CLEAN (catalog shape 10). When `git status` cannot answer,
+ * the guard declines with its OWN reason rather than assuming the tree is
+ * clean, and records a counted degradation so a repeatedly broken probe is
+ * visible instead of silently permissive.
+ *
+ * NO LATCHES HERE (catalog shape 17). Every decision is recomputed from the
+ * registry and the tree. Repeat-suppression for telemetry lives in the
+ * degradation ledger, which already re-arms at `session_start`.
+ */
+
+import { emitBounded } from "./bounded-telemetry.js";
+import { detectGuardedGitVerb, type GitVerbMatcher } from "./git-guard.js";
+import {
+	type InstanceEntry,
+	readInstanceRegistry,
+	selectLivePeerInstances,
+} from "./instance-registry.js";
+import { realIsPidAlive } from "./instance-reaper.js";
+import { logLatency } from "./latency-logger.js";
+import { isGitWorktree } from "./opaque-mutation-scan.js";
+import { normalizeFilePath } from "./path-utils.js";
+import { safeSpawnAsync } from "./safe-spawn.js";
+
+/** Verbs that rewrite tracked files unconditionally. */
+const ALWAYS_MUTATING_VERBS: ReadonlySet<string> = new Set([
+	"checkout",
+	"switch",
+	"restore",
+	"merge",
+	"rebase",
+	"pull",
+	"cherry-pick",
+	"revert",
+]);
+
+/** `git reset` touches the working tree only in these modes. */
+const RESET_WORKTREE_MODES: ReadonlySet<string> = new Set([
+	"--hard",
+	"--merge",
+	"--keep",
+]);
+
+/** `git stash` subcommands that only read. Everything else moves files. */
+const READ_ONLY_STASH_SUBCOMMANDS: ReadonlySet<string> = new Set([
+	"list",
+	"show",
+]);
+
+const CLEAN_DRY_RUN_FLAGS: ReadonlySet<string> = new Set(["-n", "--dry-run"]);
+
+/**
+ * The verb question for the shared-checkout guard. Every other part of the
+ * classification (wrappers, `$IFS`, substitutions, PATHEXT, text consumers)
+ * is the #1063 git-guard machinery, reused rather than re-implemented.
+ *
+ * `indirectAlwaysMatches` is FALSE here on purpose. The commit gate is a
+ * policy an agent may want to evade, so it fails closed on any indirect
+ * `git`. This guard protects an agent from its own accident, so failing
+ * closed on `xargs git status` would cost far more than it saves; the
+ * indirect path stays armed only when the argv also carries a governed verb.
+ *
+ * DELIBERATELY OUT OF SCOPE: `git apply` and `git am`. They add the caller's
+ * own patch on top of the tree and fail loudly into `.rej` files rather than
+ * discarding tracked content wholesale, and `git apply` is the sanctioned
+ * replacement for the forbidden `git stash`. Blocking it would push
+ * operators back toward stash.
+ */
+export const WORKTREE_MUTATING_GIT_MATCHER: GitVerbMatcher = {
+	id: "worktree-mutating",
+	indirectAlwaysMatches: false,
+	matchesVerb(verb, argsAfterVerb) {
+		if (ALWAYS_MUTATING_VERBS.has(verb)) return true;
+		if (verb === "reset") {
+			return argsAfterVerb.some((arg) => RESET_WORKTREE_MODES.has(arg));
+		}
+		if (verb === "stash") {
+			const subcommand = argsAfterVerb.find((arg) => !arg.startsWith("-"));
+			return (
+				subcommand === undefined || !READ_ONLY_STASH_SUBCOMMANDS.has(subcommand)
+			);
+		}
+		if (verb === "clean") {
+			return !argsAfterVerb.some((arg) => CLEAN_DRY_RUN_FLAGS.has(arg));
+		}
+		return false;
+	},
+};
+
+/** True when this bash input runs a git verb that rewrites tracked files. */
+export function isWorktreeMutatingGitAttempt(
+	toolName: string,
+	input: unknown,
+): boolean {
+	return detectGuardedGitVerb(toolName, input, WORKTREE_MUTATING_GIT_MATCHER);
+}
+
+/**
+ * `dirty` and `clean` are answers. `unknown` means git could not tell us,
+ * which is NOT the same as clean and must never be collapsed into it.
+ */
+export type WorkingTreeState = "dirty" | "clean" | "unknown";
+
+/**
+ * Ask git whether the working tree carries uncommitted work.
+ *
+ * Deliberately narrower than `recoverOpaqueChangesViaGit`: that function
+ * answers WHICH files changed inside a time window and stats each one, which
+ * drops deletions and costs one stat per entry. Here the only question is
+ * whether ANY entry exists, so a truncated listing is still a definite
+ * `dirty` — a prefix of dirt is dirt.
+ */
+export async function probeWorkingTreeState(
+	root: string,
+): Promise<WorkingTreeState> {
+	const result = await safeSpawnAsync(
+		"git",
+		["status", "--porcelain", "--untracked-files=all"],
+		{ cwd: root, timeout: 5000 },
+	);
+	if (result.error || (result.status !== 0 && result.status !== null)) {
+		return "unknown";
+	}
+	if (result.outputTruncated === true) return "dirty";
+	return (result.stdout ?? "").trim().length > 0 ? "dirty" : "clean";
+}
+
+export interface SharedCheckoutDecision {
+	block: boolean;
+	/** True when the refusal comes from an unanswerable probe, not from WIP. */
+	unknown?: boolean;
+	reason?: string;
+}
+
+/** Seams the tests replace. Production uses every default. */
+export interface SharedCheckoutGuardDeps {
+	readRegistry?: () => Promise<InstanceEntry[]>;
+	isPidAlive?: (pid: number) => boolean;
+	now?: number;
+	isGitRepo?: (root: string) => Promise<boolean>;
+	probeWorkingTree?: (root: string) => Promise<WorkingTreeState>;
+}
+
+function logAllow(root: string, reasonCategory: string): void {
+	logLatency({
+		type: "phase",
+		toolName: "shared-checkout-guard",
+		phase: "shared_checkout_guard_allow",
+		filePath: root,
+		durationMs: 0,
+		metadata: { decision: "allowed", reasonCategory },
+	});
+}
+
+function describePeers(peers: readonly InstanceEntry[]): string {
+	const pids = peers.slice(0, 4).map((peer) => peer.pid);
+	const suffix = peers.length > pids.length ? ", …" : "";
+	return `${peers.length} other live pi-lens session${
+		peers.length === 1 ? "" : "s"
+	} (pid ${pids.join(", ")}${suffix})`;
+}
+
+/**
+ * Decide whether one worktree-mutating git command may run here.
+ *
+ * Never throws: a registry read that fails yields an empty peer list, which
+ * reads as "no shared checkout" and allows. That direction is deliberate —
+ * the registry is observability substrate and an outage of it must not
+ * start refusing every branch switch on every machine.
+ */
+export async function evaluateSharedCheckoutGuard(
+	toolName: string,
+	input: unknown,
+	cwd: string,
+	deps: SharedCheckoutGuardDeps = {},
+): Promise<SharedCheckoutDecision> {
+	if (!isWorktreeMutatingGitAttempt(toolName, input)) return { block: false };
+	const root = normalizeFilePath(cwd);
+	let peers: InstanceEntry[];
+	try {
+		const entries = await (deps.readRegistry ?? readInstanceRegistry)();
+		peers = selectLivePeerInstances(
+			entries,
+			cwd,
+			deps.now ?? Date.now(),
+			deps.isPidAlive ?? realIsPidAlive,
+		);
+	} catch {
+		logAllow(root, "registry_unreadable");
+		return { block: false };
+	}
+	if (peers.length === 0) {
+		logAllow(root, "no_peer_session");
+		return { block: false };
+	}
+	if (!(await (deps.isGitRepo ?? isGitWorktree)(cwd))) {
+		logAllow(root, "not_a_git_worktree");
+		return { block: false };
+	}
+	const state = await (deps.probeWorkingTree ?? probeWorkingTreeState)(cwd);
+	if (state === "clean") {
+		logAllow(root, "working_tree_clean");
+		return { block: false };
+	}
+	if (state === "unknown") {
+		emitBounded(
+			"shared_checkout_probe_failed",
+			root,
+			{
+				toolName: "shared-checkout-guard",
+				durationMs: 0,
+				metadata: { decision: "blocked", peerCount: peers.length },
+			},
+			{
+				ledgerKind: "shared-checkout-probe",
+				risingEdgePer: "identity",
+				reason: "git status could not report working-tree state",
+			},
+		);
+		return {
+			block: true,
+			unknown: true,
+			reason:
+				"🔴 WORKING-TREE CHANGE BLOCKED (--lens-checkout-guard): git could not report whether this checkout has uncommitted work, and it is shared with " +
+				`${describePeers(peers)}. Re-run the command once git answers, or take a dedicated git worktree.`,
+		};
+	}
+	emitBounded(
+		"shared_checkout_switch_blocked",
+		root,
+		{
+			toolName: "shared-checkout-guard",
+			durationMs: 0,
+			metadata: { decision: "blocked", peerCount: peers.length },
+		},
+		{
+			ledgerKind: "shared-checkout-wip",
+			risingEdgePer: "identity",
+			reason: "worktree-mutating git command declined on a shared checkout",
+		},
+	);
+	return {
+		block: true,
+		reason:
+			"🔴 WORKING-TREE CHANGE BLOCKED (--lens-checkout-guard): this checkout has uncommitted changes and is shared with " +
+			`${describePeers(peers)}. The command would discard work that may not be yours. ` +
+			"Commit the changes first, or run this in a dedicated git worktree.",
+	};
+}

--- a/clients/shared-checkout-guard.ts
+++ b/clients/shared-checkout-guard.ts
@@ -19,11 +19,16 @@
  * THREE FACTS MUST ALL HOLD BEFORE ANYTHING IS DECLINED, cheapest first:
  *
  *   1. The bash input really invokes a git verb that rewrites the working
- *      tree. Pure string work, no I/O — see `WORKTREE_MUTATING_GIT_MATCHER`.
- *   2. Another live pi-lens session is registered on this same root.
+ *      tree, read from git's own COMMAND POSITION. Pure string work, no I/O —
+ *      see `WORKTREE_MUTATING_GIT_MATCHER`. The directory judged is the one
+ *      the invocation TARGETS, which `-C` and `--work-tree` can move away
+ *      from the caller's cwd.
+ *   2. Another live pi-lens session shares that directory.
  *      `selectLivePeerInstances` (clients/instance-registry.ts) is the single
  *      source of truth for that question; warm-attach reads the same
- *      predicate. No peer means no shared checkout and nothing to protect.
+ *      predicate in `"exact"` mode. This guard asks in `"containment"` mode,
+ *      because a peer at the repo root and a command run from a subdirectory
+ *      share ONE working tree. No peer means nothing to protect.
  *   3. The working tree actually carries uncommitted work. A clean tree can
  *      be switched freely.
  *
@@ -42,7 +47,13 @@
  */
 
 import { emitBounded } from "./bounded-telemetry.js";
-import { detectGuardedGitVerb, type GitVerbMatcher } from "./git-guard.js";
+import {
+	collectGitInvocations,
+	detectGuardedGitVerb,
+	type GitVerbMatcher,
+	matchGitVerbAtCommandPosition,
+	resolveGitTargetDirectory,
+} from "./git-guard.js";
 import {
 	type InstanceEntry,
 	readInstanceRegistry,
@@ -79,7 +90,20 @@ const READ_ONLY_STASH_SUBCOMMANDS: ReadonlySet<string> = new Set([
 	"show",
 ]);
 
-const CLEAN_DRY_RUN_FLAGS: ReadonlySet<string> = new Set(["-n", "--dry-run"]);
+/**
+ * `git clean` in dry-run mode reports and deletes nothing.
+ *
+ * Short flags CLUSTER (`git clean -nfd` is `-n -f -d`), so an exact-token set
+ * would read `-nfd` as mutating and decline a command that touches nothing.
+ * Match the letter inside any short cluster, and `--dry-run` exactly.
+ */
+function isCleanDryRun(argsAfterVerb: readonly string[]): boolean {
+	return argsAfterVerb.some(
+		(arg) =>
+			arg === "--dry-run" ||
+			(arg.startsWith("-") && !arg.startsWith("--") && arg.includes("n")),
+	);
+}
 
 /**
  * The verb question for the shared-checkout guard. Every other part of the
@@ -112,12 +136,18 @@ export const WORKTREE_MUTATING_GIT_MATCHER: GitVerbMatcher = {
 				subcommand === undefined || !READ_ONLY_STASH_SUBCOMMANDS.has(subcommand)
 			);
 		}
-		if (verb === "clean") {
-			return !argsAfterVerb.some((arg) => CLEAN_DRY_RUN_FLAGS.has(arg));
-		}
+		if (verb === "clean") return !isCleanDryRun(argsAfterVerb);
 		return false;
 	},
 };
+
+/** True when this one git invocation's subcommand rewrites tracked files. */
+function matchesWorktreeMutatingVerb(gitTokens: string[]): boolean {
+	return matchGitVerbAtCommandPosition(
+		gitTokens,
+		WORKTREE_MUTATING_GIT_MATCHER,
+	);
+}
 
 /** True when this bash input runs a git verb that rewrites tracked files. */
 export function isWorktreeMutatingGitAttempt(
@@ -207,20 +237,58 @@ export async function evaluateSharedCheckoutGuard(
 	deps: SharedCheckoutGuardDeps = {},
 ): Promise<SharedCheckoutDecision> {
 	if (!isWorktreeMutatingGitAttempt(toolName, input)) return { block: false };
-	const root = normalizeFilePath(cwd);
-	let peers: InstanceEntry[];
+	// #2007: `git -C <dir>` and `--work-tree` retarget the command at a
+	// DIFFERENT directory. Evaluating the caller's cwd would inspect the wrong
+	// working tree and allow the destructive command against a shared one, so
+	// every targeted directory is evaluated and the first contended one wins.
+	const targets = resolveGuardTargets(toolName, input, cwd);
+	let entries: InstanceEntry[];
 	try {
-		const entries = await (deps.readRegistry ?? readInstanceRegistry)();
-		peers = selectLivePeerInstances(
-			entries,
-			cwd,
-			deps.now ?? Date.now(),
-			deps.isPidAlive ?? realIsPidAlive,
-		);
+		entries = await (deps.readRegistry ?? readInstanceRegistry)();
 	} catch {
-		logAllow(root, "registry_unreadable");
+		logAllow(normalizeFilePath(cwd), "registry_unreadable");
 		return { block: false };
 	}
+	for (const target of targets) {
+		const decision = await evaluateOneTarget(target, entries, deps);
+		if (decision.block) return decision;
+	}
+	return { block: false };
+}
+
+/** Distinct directories the command's git invocations actually target. */
+function resolveGuardTargets(
+	toolName: string,
+	input: unknown,
+	cwd: string,
+): string[] {
+	const targets = new Set<string>();
+	for (const gitTokens of collectGitInvocations(toolName, input)) {
+		if (!matchesWorktreeMutatingVerb(gitTokens)) continue;
+		targets.add(resolveGitTargetDirectory(gitTokens, cwd));
+	}
+	// A wrapper or substitution form the token scan cannot attribute to a
+	// directory still matched the classifier, so fall back to the cwd rather
+	// than evaluating nothing.
+	if (targets.size === 0) targets.add(cwd);
+	return [...targets];
+}
+
+async function evaluateOneTarget(
+	cwd: string,
+	entries: InstanceEntry[],
+	deps: SharedCheckoutGuardDeps,
+): Promise<SharedCheckoutDecision> {
+	const root = normalizeFilePath(cwd);
+	const peers = selectLivePeerInstances(
+		entries,
+		cwd,
+		deps.now ?? Date.now(),
+		deps.isPidAlive ?? realIsPidAlive,
+		// A peer registered at the repo root and a command run from a
+		// subdirectory share ONE working tree; an exact compare would miss it.
+		"containment",
+	);
 	if (peers.length === 0) {
 		logAllow(root, "no_peer_session");
 		return { block: false };

--- a/clients/shared-checkout-guard.ts
+++ b/clients/shared-checkout-guard.ts
@@ -23,12 +23,15 @@
  *      see `WORKTREE_MUTATING_GIT_MATCHER`. The directory judged is the one
  *      the invocation TARGETS, which `-C` and `--work-tree` can move away
  *      from the caller's cwd.
- *   2. Another live pi-lens session shares that directory.
- *      `selectLivePeerInstances` (clients/instance-registry.ts) is the single
- *      source of truth for that question; warm-attach reads the same
- *      predicate in `"exact"` mode. This guard asks in `"containment"` mode,
- *      because a peer at the repo root and a command run from a subdirectory
- *      share ONE working tree. No peer means nothing to protect.
+ *   2. Another live pi-lens session is in the SAME WORKING TREE.
+ *      `selectLivePeerInstances` (clients/instance-registry.ts) owns liveness
+ *      and is the single source of truth for it; warm-attach reads the same
+ *      predicate in `"exact"` mode. Path containment alone is not identity
+ *      here, in either direction: a peer at the repo root and a command run
+ *      from a subdirectory DO share one tree, while a linked worktree nested
+ *      under the main checkout shares nothing with it. Containment against
+ *      the toplevel is the pre-filter; `git rev-parse --show-toplevel` is the
+ *      decision. No peer means nothing to protect.
  *   3. The working tree actually carries uncommitted work. A clean tree can
  *      be switched freely.
  *
@@ -61,7 +64,7 @@ import {
 } from "./instance-registry.js";
 import { realIsPidAlive } from "./instance-reaper.js";
 import { logLatency } from "./latency-logger.js";
-import { isGitWorktree } from "./opaque-mutation-scan.js";
+import { resolveGitToplevel } from "./opaque-mutation-scan.js";
 import { normalizeFilePath } from "./path-utils.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
 
@@ -125,6 +128,10 @@ function isCleanDryRun(argsAfterVerb: readonly string[]): boolean {
 export const WORKTREE_MUTATING_GIT_MATCHER: GitVerbMatcher = {
 	id: "worktree-mutating",
 	indirectAlwaysMatches: false,
+	// `git checkout --help` opens documentation and changes nothing. This
+	// guard can afford to read a leading help flag as documentation; the
+	// commit gate cannot — see `suppressPostVerbHelp`'s own docstring.
+	suppressPostVerbHelp: true,
 	matchesVerb(verb, argsAfterVerb) {
 		if (ALWAYS_MUTATING_VERBS.has(verb)) return true;
 		if (verb === "reset") {
@@ -199,7 +206,8 @@ export interface SharedCheckoutGuardDeps {
 	readRegistry?: () => Promise<InstanceEntry[]>;
 	isPidAlive?: (pid: number) => boolean;
 	now?: number;
-	isGitRepo?: (root: string) => Promise<boolean>;
+	/** Resolves a directory to its working-tree root, or undefined. */
+	resolveToplevel?: (root: string) => Promise<string | undefined>;
 	probeWorkingTree?: (root: string) => Promise<WorkingTreeState>;
 }
 
@@ -280,21 +288,43 @@ async function evaluateOneTarget(
 	deps: SharedCheckoutGuardDeps,
 ): Promise<SharedCheckoutDecision> {
 	const root = normalizeFilePath(cwd);
-	const peers = selectLivePeerInstances(
-		entries,
-		cwd,
-		deps.now ?? Date.now(),
-		deps.isPidAlive ?? realIsPidAlive,
-		// A peer registered at the repo root and a command run from a
-		// subdirectory share ONE working tree; an exact compare would miss it.
-		"containment",
-	);
-	if (peers.length === 0) {
-		logAllow(root, "no_peer_session");
+	const resolveToplevel = deps.resolveToplevel ?? resolveGitToplevel;
+	const toplevel = await resolveToplevel(cwd);
+	if (toplevel === undefined) {
+		logAllow(root, "not_a_git_worktree");
 		return { block: false };
 	}
-	if (!(await (deps.isGitRepo ?? isGitWorktree)(cwd))) {
-		logAllow(root, "not_a_git_worktree");
+	const normalizedToplevel = normalizeFilePath(toplevel);
+	// Containment against the TOPLEVEL, not against the caller's directory:
+	// two sessions in sibling subdirectories of one checkout share it, and
+	// comparing them to each other would miss that. Every directory in a
+	// working tree is under its own toplevel, so this pre-filter can only
+	// admit candidates, never drop a real peer.
+	const candidates = selectLivePeerInstances(
+		entries,
+		normalizedToplevel,
+		deps.now ?? Date.now(),
+		deps.isPidAlive ?? realIsPidAlive,
+		"containment",
+	);
+	// Path containment is NOT shared-checkout identity. A linked worktree sits
+	// at a path nested under the main checkout — this repo puts agent
+	// worktrees under `.claude/worktrees/` — and shares no working files with
+	// it. Confirm each candidate belongs to the SAME working tree before
+	// declining anything, or the guard tells an operator already inside a
+	// dedicated worktree to go get a dedicated worktree.
+	const peers: InstanceEntry[] = [];
+	for (const candidate of candidates) {
+		const peerToplevel = await resolveToplevel(candidate.projectRoot);
+		if (
+			peerToplevel !== undefined &&
+			normalizeFilePath(peerToplevel) === normalizedToplevel
+		) {
+			peers.push(candidate);
+		}
+	}
+	if (peers.length === 0) {
+		logAllow(root, "no_peer_session");
 		return { block: false };
 	}
 	const state = await (deps.probeWorkingTree ?? probeWorkingTreeState)(cwd);

--- a/clients/warm-attach.ts
+++ b/clients/warm-attach.ts
@@ -4,8 +4,9 @@ import * as path from "node:path";
 import {
 	type InstanceEntry,
 	readInstanceRegistry,
+	selectLivePeerInstances,
 } from "./instance-registry.js";
-import { realIsPidAlive, STALE_HEARTBEAT_MS } from "./instance-reaper.js";
+import { realIsPidAlive } from "./instance-reaper.js";
 import { logLatency } from "./latency-logger.js";
 import { touchCoverageGap } from "./lsp/diagnostic-binding.js";
 import { loadLspService } from "./lsp-lazy.js";
@@ -52,23 +53,18 @@ function record(
 	});
 }
 
+/**
+ * The oldest live peer on this root, if any. The liveness rule itself lives
+ * in `selectLivePeerInstances` (#2007) so warm-attach and the shared-checkout
+ * guard cannot drift apart about what "another session is here" means.
+ */
 export function selectWarmAttachIncumbent(
 	entries: readonly InstanceEntry[],
 	cwd: string,
 	now = Date.now(),
 	isPidAlive: (pid: number) => boolean = realIsPidAlive,
 ): InstanceEntry | undefined {
-	const root = normalizeFilePath(cwd);
-	return entries
-		.filter(
-			(entry) =>
-				entry.pid !== process.pid &&
-				entry.projectRoot === root &&
-				isPidAlive(entry.pid) &&
-				Number.isFinite(Date.parse(entry.heartbeatAt)) &&
-				now - Date.parse(entry.heartbeatAt) <= STALE_HEARTBEAT_MS,
-		)
-		.sort((a, b) => Date.parse(a.startedAt) - Date.parse(b.startedAt))[0];
+	return selectLivePeerInstances(entries, cwd, now, isPidAlive)[0];
 }
 
 async function serveRequest(

--- a/tests/clients/finding-delivery-gate.test.ts
+++ b/tests/clients/finding-delivery-gate.test.ts
@@ -81,6 +81,9 @@ const EXPECTED_SURFACE_IDS = [
 	"read-guard-tool-lines:preflight-errors",
 	"agent-behavior:thrashing-notice",
 	"tool-call:duplicate-export-blocker",
+	// #2007: the shared-checkout refusal, the same live-preflight shape as
+	// `git-guard:commit-blocked`.
+	"shared-checkout-guard:worktree-mutation-blocked",
 ].sort();
 
 // ── Real seam scan (#1634 review F2) ────────────────────────────────────────

--- a/tests/clients/git-guard.test.ts
+++ b/tests/clients/git-guard.test.ts
@@ -185,6 +185,43 @@ describe("git-guard", () => {
 		).toBe(false);
 	});
 
+	// #2007 R1 (regression, caught in review): the shared-checkout guard added
+	// a post-verb `--help`/`-h` suppression to the classifier both gates now
+	// share. Applied to THIS gate it was a hole, because `-h` is a legal
+	// option VALUE. Verified against real git 2.55 in a scratch repo:
+	// `git commit -m -h` exits 0 and the log subject reads `-h`, and
+	// `git push --repo -h` reaches the push path rather than printing help.
+	// A gate that fails closed must never be talked out of a match by a token
+	// that might be a value.
+	it("still matches when -h is an option VALUE, not a help request", () => {
+		for (const command of [
+			"git commit -m -h",
+			"git commit -F -h",
+			"git commit --file -h",
+			"git commit -c -h",
+			"git commit --reuse-message -h",
+			"git push --repo -h",
+			"git push --receive-pack -h",
+			"git push --exec -h",
+		]) {
+			expect(isGitCommitOrPushAttempt("bash", { command }), command).toBe(true);
+		}
+	});
+
+	it("keeps failing closed on an explicit post-verb help flag", () => {
+		// Not a value here, but this gate does not get to decide that: the
+		// pre-#2007 classifier matched these, and a commit gate that can be
+		// switched off by appending a flag is not a gate.
+		for (const command of [
+			"git commit --help",
+			"git commit -h",
+			"git push --help",
+			"git push -h",
+		]) {
+			expect(isGitCommitOrPushAttempt("bash", { command }), command).toBe(true);
+		}
+	});
+
 	it("does not treat literal git text as an indirect operation", () => {
 		for (const command of [
 			'echo "remember to git push later"',

--- a/tests/clients/shared-checkout-guard-wiring.test.ts
+++ b/tests/clients/shared-checkout-guard-wiring.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `handleToolCall` wiring for the shared-checkout guard (#2007).
+ *
+ * The evaluator can be perfectly correct and still protect nobody if the
+ * tool_call seam never asks it. These three cases pin the seam itself: the
+ * flag gate, the refusal reaching pi, and the allow path staying silent.
+ *
+ * The guard module is mocked so the seam is tested without a registry, a git
+ * repo, or a peer process. Its own behavior is covered by
+ * `shared-checkout-guard.test.ts` against the real git binary.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const evaluate = vi.fn();
+vi.mock("../../clients/shared-checkout-guard.js", () => ({
+	evaluateSharedCheckoutGuard: (...args: unknown[]) => evaluate(...args),
+}));
+
+vi.mock("../../clients/lsp/index.js", () => ({
+	getLSPService: () => ({
+		touchFile: vi.fn().mockResolvedValue(undefined),
+		getWarmClientForFile: vi.fn().mockResolvedValue(undefined),
+	}),
+	resetLSPService: () => {},
+}));
+
+import { CacheManager } from "../../clients/cache-manager.js";
+import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
+import { handleToolCall } from "../../clients/runtime-tool-call.js";
+
+function deps(
+	command: string,
+	getFlag: (flag: string) => boolean,
+): Parameters<typeof handleToolCall>[0] {
+	return {
+		event: { toolName: "bash", input: { command } },
+		ctx: { cwd: process.cwd() },
+		lensEnabled: true,
+		getFlag,
+		dbg: () => {},
+		runtime: new RuntimeCoordinator(),
+		cacheManager: new CacheManager(false),
+		ensureLSPConfigInitialized: async () => {},
+		updateLspStatus: () => {},
+		resetLSPService: () => {},
+	} as Parameters<typeof handleToolCall>[0];
+}
+
+describe("shared-checkout guard wiring (#2007)", () => {
+	beforeEach(() => {
+		evaluate.mockReset();
+		evaluate.mockResolvedValue({ block: false });
+	});
+
+	it("does not consult the guard while the flag is off", async () => {
+		await handleToolCall(deps("git checkout main", () => false));
+		// MUTATION PROOF: drop the `getFlag("lens-checkout-guard")` gate and
+		// this reds — an opt-in experiment would be on for everyone.
+		expect(evaluate).not.toHaveBeenCalled();
+	});
+
+	it("blocks the tool with the guard's own reason", async () => {
+		evaluate.mockResolvedValue({
+			block: true,
+			reason: "🔴 WORKING-TREE CHANGE BLOCKED (--lens-checkout-guard): …",
+		});
+		const result = await handleToolCall(
+			deps("git checkout main", (flag) => flag === "lens-checkout-guard"),
+		);
+		// MUTATION PROOF: delete the wiring block in runtime-tool-call.ts and
+		// this reds — the evaluator's verdict would never reach pi.
+		expect(result).toMatchObject({ block: true });
+		expect((result as { reason: string }).reason).toContain(
+			"WORKING-TREE CHANGE BLOCKED",
+		);
+		expect(evaluate).toHaveBeenCalledWith(
+			"bash",
+			{ command: "git checkout main" },
+			process.cwd(),
+		);
+	});
+
+	it("lets an allowed command through without an opinion", async () => {
+		const result = await handleToolCall(
+			deps("git checkout main", (flag) => flag === "lens-checkout-guard"),
+		);
+		expect(evaluate).toHaveBeenCalledTimes(1);
+		expect(result).toBeUndefined();
+	});
+});

--- a/tests/clients/shared-checkout-guard.test.ts
+++ b/tests/clients/shared-checkout-guard.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Shared-checkout WIP guard (#2007).
+ *
+ * The incident: several agent sessions shared one checkout, one ran
+ * `git checkout <branch>`, and three files of another session's uncommitted
+ * work vanished unrecoverably.
+ *
+ * Every guard the fix adds is pinned INDEPENDENTLY, with the mutation that
+ * reds it named in a comment. The four are: the command classification, the
+ * live-peer requirement, the dirty-tree requirement, and the unknown-is-not-
+ * clean rule. A compensating pair would let one deletion pass unnoticed
+ * (#1733's lesson), so no test stands in for another.
+ *
+ * `probeWorkingTreeState` is exercised against the REAL `git` binary in a
+ * real temp repo (catalog shape 16): a hand-written porcelain fixture would
+ * only pin our guess about git's output.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const latencyCalls: Array<Record<string, unknown>> = [];
+vi.mock("../../clients/latency-logger.js", async (importActual) => {
+	const actual =
+		await importActual<typeof import("../../clients/latency-logger.js")>();
+	return {
+		...actual,
+		logLatency: (entry: Record<string, unknown>) => {
+			latencyCalls.push(entry);
+		},
+	};
+});
+
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
+import { isGitCommitOrPushAttempt } from "../../clients/git-guard.js";
+import type { InstanceEntry } from "../../clients/instance-registry.js";
+import { selectLivePeerInstances } from "../../clients/instance-registry.js";
+import {
+	evaluateSharedCheckoutGuard,
+	isWorktreeMutatingGitAttempt,
+	probeWorkingTreeState,
+	type SharedCheckoutGuardDeps,
+	type WorkingTreeState,
+} from "../../clients/shared-checkout-guard.js";
+import { normalizeFilePath } from "../../clients/path-utils.js";
+import { safeSpawnAsync } from "../../clients/safe-spawn.js";
+
+const ROOT = "/shared/checkout";
+
+function bash(command: string): { command: string } {
+	return { command };
+}
+
+function phaseCalls(phase: string): Array<Record<string, unknown>> {
+	return latencyCalls.filter((entry) => entry.phase === phase);
+}
+
+function summaryFor(kind: string) {
+	return getDegradationSummary().find((group) => group.kind === kind);
+}
+
+function peer(overrides: Partial<InstanceEntry> = {}): InstanceEntry {
+	return {
+		pid: process.pid + 1,
+		startedAt: new Date(1_000).toISOString(),
+		projectRoot: normalizeFilePath(ROOT),
+		lspChildren: [],
+		lspChildCount: 0,
+		rssBytes: 0,
+		heartbeatAt: new Date(2_000).toISOString(),
+		...overrides,
+	};
+}
+
+/** All seams stubbed: a live peer, a real repo, and a dirty tree. */
+function deps(
+	overrides: Partial<SharedCheckoutGuardDeps> = {},
+	probeSpy?: { calls: number },
+): SharedCheckoutGuardDeps {
+	return {
+		readRegistry: async () => [peer()],
+		isPidAlive: () => true,
+		now: 3_000,
+		isGitRepo: async () => true,
+		probeWorkingTree: async (): Promise<WorkingTreeState> => {
+			if (probeSpy) probeSpy.calls += 1;
+			return "dirty";
+		},
+		...overrides,
+	};
+}
+
+describe("worktree-mutating git classification (#2007)", () => {
+	it("recognizes every verb that rewrites tracked files", () => {
+		for (const command of [
+			"git checkout main",
+			"git checkout -b feature",
+			"git checkout -- clients/dispatcher.ts",
+			"git switch master",
+			"git restore .",
+			"git reset --hard HEAD",
+			"git reset --merge",
+			"git reset --keep origin/master",
+			"git stash",
+			"git stash push -m wip",
+			"git stash pop",
+			"git clean -fd",
+			"git merge origin/master",
+			"git rebase master",
+			"git pull",
+			"git cherry-pick abc123",
+			"git revert abc123",
+		]) {
+			expect(isWorktreeMutatingGitAttempt("bash", bash(command)), command).toBe(
+				true,
+			);
+		}
+	});
+
+	it("leaves read-only and index-only git alone", () => {
+		for (const command of [
+			"git status",
+			"git log --oneline",
+			"git diff",
+			"git add .",
+			"git commit -m x",
+			"git push origin master",
+			// Soft/mixed reset moves HEAD and the index, never the worktree.
+			"git reset HEAD~1",
+			"git reset --soft HEAD~1",
+			"git stash list",
+			"git stash show",
+			"git clean -n",
+			"git clean --dry-run",
+			"git --help checkout",
+			'echo "git checkout main"',
+			"npm run build",
+		]) {
+			expect(isWorktreeMutatingGitAttempt("bash", bash(command)), command).toBe(
+				false,
+			);
+		}
+	});
+
+	it("inherits the #1063 wrapper and substitution analysis instead of re-parsing", () => {
+		// MUTATION PROOF for the reuse decision: a hand-rolled `startsWith("git ")`
+		// classifier passes the plain cases above and reds on every line here.
+		for (const command of [
+			"sh -c 'git checkout main'",
+			'bash -lc "git switch master"',
+			"cmd /c git reset --hard",
+			"pwsh -Command git clean -fd",
+			"echo $(git checkout main)",
+			"git${IFS}checkout${IFS}main",
+			"GIT_DIR=.git git checkout main",
+			"git -C /elsewhere checkout main",
+		]) {
+			expect(isWorktreeMutatingGitAttempt("bash", bash(command)), command).toBe(
+				true,
+			);
+		}
+	});
+
+	it("narrows the indirect-git fail-closed rule to governed verbs only", () => {
+		// The commit gate is a policy an agent may evade, so ANY indirect git
+		// fails closed there. This guard protects the agent from an accident,
+		// so a read-only indirect git must stay usable.
+		expect(isGitCommitOrPushAttempt("bash", bash("xargs git status"))).toBe(
+			true,
+		);
+		expect(isWorktreeMutatingGitAttempt("bash", bash("xargs git status"))).toBe(
+			false,
+		);
+		// MUTATION PROOF: make `indirectAlwaysMatches` irrelevant by returning
+		// false for every indirect git and this line reds.
+		expect(
+			isWorktreeMutatingGitAttempt("bash", bash("xargs git checkout main")),
+		).toBe(true);
+	});
+
+	it("only classifies bash tool input", () => {
+		expect(
+			isWorktreeMutatingGitAttempt("write", bash("git checkout main")),
+		).toBe(false);
+		expect(isWorktreeMutatingGitAttempt("bash", {})).toBe(false);
+	});
+
+	it("keeps the commit/push gate's own answers unchanged after the refactor", () => {
+		expect(isGitCommitOrPushAttempt("bash", bash('git commit -m "x"'))).toBe(
+			true,
+		);
+		expect(isGitCommitOrPushAttempt("bash", bash("git push origin main"))).toBe(
+			true,
+		);
+		expect(isGitCommitOrPushAttempt("bash", bash("git checkout main"))).toBe(
+			false,
+		);
+		expect(isGitCommitOrPushAttempt("bash", bash('echo "git push"'))).toBe(
+			false,
+		);
+	});
+});
+
+describe("live-peer selection (#2007)", () => {
+	it("counts only another pid, alive, on this root, with a fresh heartbeat", () => {
+		const entries = [
+			peer(),
+			peer({ pid: process.pid }), // this process is not its own peer
+			peer({ pid: process.pid + 2, projectRoot: normalizeFilePath("/other") }),
+			peer({ pid: process.pid + 3, heartbeatAt: "not-a-date" }),
+		];
+		const live = selectLivePeerInstances(entries, ROOT, 3_000, () => true);
+		expect(live.map((entry) => entry.pid)).toEqual([process.pid + 1]);
+	});
+
+	it("drops a dead pid and a stale heartbeat", () => {
+		expect(
+			selectLivePeerInstances([peer()], ROOT, 3_000, () => false),
+		).toHaveLength(0);
+		expect(
+			selectLivePeerInstances(
+				[peer()],
+				ROOT,
+				Date.parse("2100-01-01T00:00:00Z"),
+				() => true,
+			),
+		).toHaveLength(0);
+	});
+});
+
+describe("evaluateSharedCheckoutGuard (#2007)", () => {
+	beforeEach(() => {
+		latencyCalls.length = 0;
+		resetDegradationLedger();
+	});
+
+	it("declines a branch switch when a live peer shares this dirty checkout", async () => {
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			ROOT,
+			deps(),
+		);
+		// MUTATION PROOF: return `{ block: false }` from the dirty branch and
+		// this is the only test that reds — the incident ships again.
+		expect(decision.block).toBe(true);
+		expect(decision.unknown).toBeUndefined();
+		expect(decision.reason).toContain(`pid ${process.pid + 1}`);
+		expect(decision.reason).toContain("uncommitted changes");
+	});
+
+	it("allows the same command when no other session is here", async () => {
+		const probeSpy = { calls: 0 };
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			ROOT,
+			deps({ readRegistry: async () => [] }, probeSpy),
+		);
+		// MUTATION PROOF: delete the peer check and this reds — every solo
+		// session's branch switch would be declined.
+		expect(decision.block).toBe(false);
+		// The probe is the expensive part; a peerless checkout must not pay it.
+		expect(probeSpy.calls).toBe(0);
+		expect(
+			phaseCalls("shared_checkout_guard_allow")[0]?.metadata,
+		).toMatchObject({ reasonCategory: "no_peer_session" });
+	});
+
+	it("allows the same command when the shared checkout is clean", async () => {
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			ROOT,
+			deps({ probeWorkingTree: async () => "clean" }),
+		);
+		// MUTATION PROOF: drop the `clean` branch and every shared checkout
+		// becomes unswitchable, which would get the flag turned off.
+		expect(decision.block).toBe(false);
+		expect(
+			phaseCalls("shared_checkout_guard_allow")[0]?.metadata,
+		).toMatchObject({ reasonCategory: "working_tree_clean" });
+	});
+
+	it("declines on an UNKNOWN probe rather than assuming clean", async () => {
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git reset --hard"),
+			ROOT,
+			deps({ probeWorkingTree: async () => "unknown" }),
+		);
+		// MUTATION PROOF (catalog shape 10): collapse `unknown` into `clean`
+		// and this reds while every other test stays green.
+		expect(decision.block).toBe(true);
+		expect(decision.unknown).toBe(true);
+		expect(decision.reason).toContain("could not report");
+		expect(summaryFor("shared-checkout-probe")?.count).toBe(1);
+		expect(phaseCalls("shared_checkout_probe_failed")).toHaveLength(1);
+	});
+
+	it("never touches the registry for a command that cannot rewrite the tree", async () => {
+		let registryReads = 0;
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git status"),
+			ROOT,
+			deps({
+				readRegistry: async () => {
+					registryReads += 1;
+					return [peer()];
+				},
+			}),
+		);
+		expect(decision.block).toBe(false);
+		// MUTATION PROOF for the cost story: move the classification below the
+		// registry read and this reds. Every bash command would pay file I/O.
+		expect(registryReads).toBe(0);
+		expect(latencyCalls).toHaveLength(0);
+	});
+
+	it("allows when the shared directory is not a git worktree", async () => {
+		const probeSpy = { calls: 0 };
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			ROOT,
+			deps({ isGitRepo: async () => false }, probeSpy),
+		);
+		expect(decision.block).toBe(false);
+		expect(probeSpy.calls).toBe(0);
+	});
+
+	it("allows when the registry itself cannot be read", async () => {
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			ROOT,
+			deps({
+				readRegistry: async () => {
+					throw new Error("registry unreadable");
+				},
+			}),
+		);
+		// A registry outage must not start refusing branch switches machine-wide.
+		expect(decision.block).toBe(false);
+		expect(
+			phaseCalls("shared_checkout_guard_allow")[0]?.metadata,
+		).toMatchObject({ reasonCategory: "registry_unreadable" });
+	});
+
+	it("counts every repeat while logging one detailed record per checkout", async () => {
+		for (let i = 0; i < 4; i++) {
+			await evaluateSharedCheckoutGuard(
+				"bash",
+				bash("git switch other"),
+				ROOT,
+				deps(),
+			);
+		}
+		expect(phaseCalls("shared_checkout_switch_blocked")).toHaveLength(1);
+		// The ledger keeps the exact total, and its subject says WHICH checkout
+		// is contended — aggregation that lost that identity would be the
+		// failure AGENTS.md names.
+		expect(summaryFor("shared-checkout-wip")?.count).toBe(4);
+		expect(
+			summaryFor("shared-checkout-wip")?.latestReasons.at(-1)?.subject,
+		).toBe(normalizeFilePath(ROOT));
+	});
+
+	it("re-arms at the session boundary rather than latching for the process", async () => {
+		await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			ROOT,
+			deps(),
+		);
+		expect(phaseCalls("shared_checkout_switch_blocked")).toHaveLength(1);
+		// MUTATION PROOF (catalog shape 17): replace the ledger's rising edge
+		// with a module-level `Set` and this stays at 1 after the reset.
+		resetDegradationLedger();
+		await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			ROOT,
+			deps(),
+		);
+		expect(phaseCalls("shared_checkout_switch_blocked")).toHaveLength(2);
+	});
+});
+
+describe("probeWorkingTreeState against the real git binary (#2007)", () => {
+	const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-2007-"));
+
+	afterAll(() => {
+		fs.rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("reports clean, then dirty, then unknown outside a repo", async () => {
+		const repo = path.join(tmpRoot, "repo");
+		fs.mkdirSync(repo, { recursive: true });
+		const init = await safeSpawnAsync("git", ["init", "-q"], {
+			cwd: repo,
+			timeout: 20000,
+		});
+		if (init.error || init.status !== 0) {
+			throw new Error(`git init unavailable: ${init.error ?? init.status}`);
+		}
+		expect(await probeWorkingTreeState(repo)).toBe("clean");
+
+		fs.writeFileSync(path.join(repo, "wip.ts"), "export const a = 1;\n");
+		// An UNTRACKED file is work too — this is exactly what the incident lost.
+		expect(await probeWorkingTreeState(repo)).toBe("dirty");
+
+		const outside = path.join(tmpRoot, "not-a-repo");
+		fs.mkdirSync(outside, { recursive: true });
+		// git exits non-zero outside a repo. That is UNKNOWN, not clean.
+		expect(await probeWorkingTreeState(outside)).toBe("unknown");
+	});
+});

--- a/tests/clients/shared-checkout-guard.test.ts
+++ b/tests/clients/shared-checkout-guard.test.ts
@@ -37,7 +37,11 @@ import {
 	getDegradationSummary,
 	resetDegradationLedger,
 } from "../../clients/degradation-ledger.js";
-import { isGitCommitOrPushAttempt } from "../../clients/git-guard.js";
+import {
+	collectGitInvocations,
+	isGitCommitOrPushAttempt,
+	resolveGitTargetDirectory,
+} from "../../clients/git-guard.js";
 import type { InstanceEntry } from "../../clients/instance-registry.js";
 import { selectLivePeerInstances } from "../../clients/instance-registry.js";
 import {
@@ -50,7 +54,7 @@ import {
 import { normalizeFilePath } from "../../clients/path-utils.js";
 import { safeSpawnAsync } from "../../clients/safe-spawn.js";
 
-const ROOT = "/shared/checkout";
+const ROOT = path.resolve("/shared/checkout");
 
 function bash(command: string): { command: string } {
 	return { command };
@@ -183,6 +187,52 @@ describe("worktree-mutating git classification (#2007)", () => {
 		).toBe(true);
 	});
 
+	it("reads the verb from git's COMMAND POSITION, not from any token", () => {
+		// F5: scanning every token after `git` fires on a positional value that
+		// happens to spell a subcommand. `checkout` here is a -name argument.
+		for (const command of [
+			"find . -name checkout | xargs git add",
+			"git log --format=checkout",
+			"git config alias.co checkout",
+			"git add restore.ts",
+			"xargs git add -- clean",
+		]) {
+			expect(isWorktreeMutatingGitAttempt("bash", bash(command)), command).toBe(
+				false,
+			);
+		}
+	});
+
+	it("treats a post-verb --help as documentation, not a mutation", () => {
+		// F4: the global-option walk cannot see `--help` after the verb, so
+		// `git checkout --help` classified as a branch switch.
+		for (const command of [
+			"git checkout --help",
+			"git stash -h",
+			"git clean --help",
+		]) {
+			expect(isWorktreeMutatingGitAttempt("bash", bash(command)), command).toBe(
+				false,
+			);
+		}
+	});
+
+	it("reads a clustered -n as `git clean` dry-run", () => {
+		// F4: short flags cluster. An exact-token set read `-nfd` as mutating.
+		for (const command of [
+			"git clean -nfd",
+			"git clean -ndx",
+			"git clean -n -f",
+		]) {
+			expect(isWorktreeMutatingGitAttempt("bash", bash(command)), command).toBe(
+				false,
+			);
+		}
+		expect(isWorktreeMutatingGitAttempt("bash", bash("git clean -fdx"))).toBe(
+			true,
+		);
+	});
+
 	it("only classifies bash tool input", () => {
 		expect(
 			isWorktreeMutatingGitAttempt("write", bash("git checkout main")),
@@ -206,6 +256,36 @@ describe("worktree-mutating git classification (#2007)", () => {
 	});
 });
 
+describe("git target-directory resolution (#2007)", () => {
+	function targetOf(command: string, cwd: string): string {
+		const [gitTokens] = collectGitInvocations("bash", bash(command));
+		return resolveGitTargetDirectory(gitTokens ?? [], cwd);
+	}
+
+	it("composes cumulative -C the way git does, and lets --work-tree win", () => {
+		const cwd = path.resolve("/cwd");
+		expect(targetOf("git checkout main", cwd)).toBe(cwd);
+		expect(targetOf("git -C sub checkout main", cwd)).toBe(
+			path.resolve(cwd, "sub"),
+		);
+		expect(targetOf("git -C /a -C b checkout main", cwd)).toBe(
+			path.resolve("/a/b"),
+		);
+		expect(targetOf("git -Csub checkout main", cwd)).toBe(
+			path.resolve(cwd, "sub"),
+		);
+		expect(targetOf("git -C /a --work-tree=/w checkout main", cwd)).toBe(
+			path.resolve("/w"),
+		);
+		expect(targetOf("git --work-tree /w checkout main", cwd)).toBe(
+			path.resolve("/w"),
+		);
+		// `-c key=value` is config, not a directory, and must not be consumed
+		// as one.
+		expect(targetOf("git -c core.autocrlf=false checkout main", cwd)).toBe(cwd);
+	});
+});
+
 describe("live-peer selection (#2007)", () => {
 	it("counts only another pid, alive, on this root, with a fresh heartbeat", () => {
 		const entries = [
@@ -216,6 +296,40 @@ describe("live-peer selection (#2007)", () => {
 		];
 		const live = selectLivePeerInstances(entries, ROOT, 3_000, () => true);
 		expect(live.map((entry) => entry.pid)).toEqual([process.pid + 1]);
+	});
+
+	it("matches a peer at the repo root from a subdirectory, in both directions", () => {
+		// F3: an exact compare reported no peer whenever the agent ran the
+		// command from a subdirectory of the shared checkout, which allowed the
+		// exact destructive command this guard exists to decline.
+		const sub = `${ROOT}/clients`;
+		expect(
+			selectLivePeerInstances([peer()], sub, 3_000, () => true, "containment"),
+		).toHaveLength(1);
+		expect(
+			selectLivePeerInstances(
+				[peer({ projectRoot: normalizeFilePath(sub) })],
+				ROOT,
+				3_000,
+				() => true,
+				"containment",
+			),
+		).toHaveLength(1);
+		// Segment boundaries: a sibling directory sharing a name PREFIX is not
+		// the same checkout.
+		expect(
+			selectLivePeerInstances(
+				[peer({ projectRoot: normalizeFilePath(`${ROOT}-backup`) })],
+				ROOT,
+				3_000,
+				() => true,
+				"containment",
+			),
+		).toHaveLength(0);
+		// Warm attach keeps the exact rule, because it shares one LSP service.
+		expect(
+			selectLivePeerInstances([peer()], sub, 3_000, () => true),
+		).toHaveLength(0);
 	});
 
 	it("drops a dead pid and a stale heartbeat", () => {
@@ -252,6 +366,28 @@ describe("evaluateSharedCheckoutGuard (#2007)", () => {
 		expect(decision.unknown).toBeUndefined();
 		expect(decision.reason).toContain(`pid ${process.pid + 1}`);
 		expect(decision.reason).toContain("uncommitted changes");
+	});
+
+	it("evaluates the directory `-C` retargets at, not the caller's cwd", async () => {
+		// F2: `git -C <shared> checkout main` run from a private worktree
+		// destroys the SHARED tree. Evaluating cwd found no peer and allowed it.
+		const probed: string[] = [];
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash(`git -C ${ROOT} checkout main`),
+			"/private/worktree",
+			deps({
+				probeWorkingTree: async (root) => {
+					probed.push(root);
+					return "dirty";
+				},
+			}),
+		);
+		expect(decision.block).toBe(true);
+		// MUTATION PROOF: pass `cwd` to `evaluateOneTarget` instead of the
+		// resolved target and this reds — the probe would name /private/worktree
+		// and the peer on ROOT would never be found.
+		expect(probed).toEqual([path.resolve(ROOT)]);
 	});
 
 	it("allows the same command when no other session is here", async () => {

--- a/tests/clients/shared-checkout-guard.test.ts
+++ b/tests/clients/shared-checkout-guard.test.ts
@@ -51,6 +51,7 @@ import {
 	type SharedCheckoutGuardDeps,
 	type WorkingTreeState,
 } from "../../clients/shared-checkout-guard.js";
+import { resolveGitToplevel } from "../../clients/opaque-mutation-scan.js";
 import { normalizeFilePath } from "../../clients/path-utils.js";
 import { safeSpawnAsync } from "../../clients/safe-spawn.js";
 
@@ -90,7 +91,7 @@ function deps(
 		readRegistry: async () => [peer()],
 		isPidAlive: () => true,
 		now: 3_000,
-		isGitRepo: async () => true,
+		resolveToplevel: async () => ROOT,
 		probeWorkingTree: async (): Promise<WorkingTreeState> => {
 			if (probeSpy) probeSpy.calls += 1;
 			return "dirty";
@@ -390,6 +391,71 @@ describe("evaluateSharedCheckoutGuard (#2007)", () => {
 		expect(probed).toEqual([path.resolve(ROOT)]);
 	});
 
+	it("declines from a SUBDIRECTORY of the shared checkout, end to end", async () => {
+		// R2: round 2 proved containment only by calling
+		// `selectLivePeerInstances` directly, so swapping the call site back to
+		// "exact" left every test green. This drives the real evaluator.
+		const sub = path.join(ROOT, "clients");
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			sub,
+			deps({
+				// Both the subdirectory and the peer's root belong to one tree.
+				resolveToplevel: async () => ROOT,
+			}),
+		);
+		// MUTATION PROOF: change the call site's "containment" back to "exact"
+		// and this reds — a command run from any subdirectory would be allowed.
+		expect(decision.block).toBe(true);
+		expect(decision.reason).toContain(`pid ${process.pid + 1}`);
+	});
+
+	it("allows inside a NESTED worktree, which shares no files with its parent", async () => {
+		// R3: a linked worktree lives at a path under the main checkout but is
+		// a separate working tree. Lexical containment declined it, and the
+		// refusal told the operator to go use a dedicated worktree — which is
+		// exactly where they already were.
+		const nested = path.join(ROOT, ".claude", "worktrees", "agent-x");
+		const probed: string[] = [];
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			nested,
+			deps({
+				// The peer's root resolves to the MAIN tree, the cwd to its own.
+				resolveToplevel: async (root) =>
+					normalizeFilePath(root) === normalizeFilePath(nested) ? nested : ROOT,
+				probeWorkingTree: async (root) => {
+					probed.push(root);
+					return "dirty";
+				},
+			}),
+		);
+		// MUTATION PROOF: drop the toplevel comparison and keep containment
+		// alone, and this reds — every agent worktree under `.claude/` would be
+		// declined on the main checkout's peers.
+		expect(decision.block).toBe(false);
+		// It never even reaches the working-tree probe: there is no peer.
+		expect(probed).toEqual([]);
+		expect(
+			phaseCalls("shared_checkout_guard_allow")[0]?.metadata,
+		).toMatchObject({ reasonCategory: "no_peer_session" });
+	});
+
+	it("allows when the target is not inside any working tree", async () => {
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			ROOT,
+			deps({ resolveToplevel: async () => undefined }),
+		);
+		expect(decision.block).toBe(false);
+		expect(
+			phaseCalls("shared_checkout_guard_allow")[0]?.metadata,
+		).toMatchObject({ reasonCategory: "not_a_git_worktree" });
+	});
+
 	it("allows the same command when no other session is here", async () => {
 		const probeSpy = { calls: 0 };
 		const decision = await evaluateSharedCheckoutGuard(
@@ -459,18 +525,6 @@ describe("evaluateSharedCheckoutGuard (#2007)", () => {
 		expect(latencyCalls).toHaveLength(0);
 	});
 
-	it("allows when the shared directory is not a git worktree", async () => {
-		const probeSpy = { calls: 0 };
-		const decision = await evaluateSharedCheckoutGuard(
-			"bash",
-			bash("git checkout main"),
-			ROOT,
-			deps({ isGitRepo: async () => false }, probeSpy),
-		);
-		expect(decision.block).toBe(false);
-		expect(probeSpy.calls).toBe(0);
-	});
-
 	it("allows when the registry itself cannot be read", async () => {
 		const decision = await evaluateSharedCheckoutGuard(
 			"bash",
@@ -534,6 +588,55 @@ describe("probeWorkingTreeState against the real git binary (#2007)", () => {
 
 	afterAll(() => {
 		fs.rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("gives a nested linked worktree its OWN toplevel (R3's premise)", async () => {
+		// The whole R3 fix rests on a claim about git: that a worktree created
+		// UNDER the main checkout reports itself, not the parent. Verified
+		// against the real binary rather than assumed (catalog shape 16) — this
+		// mirrors how this repo stores agent worktrees under `.claude/`.
+		const main = path.join(tmpRoot, "main-repo");
+		fs.mkdirSync(main, { recursive: true });
+		const run = async (args: string[], cwd: string) =>
+			safeSpawnAsync("git", args, { cwd, timeout: 20000 });
+		const init = await run(["init", "-q", "-b", "master"], main);
+		if (init.error || init.status !== 0) {
+			throw new Error(`git init unavailable: ${init.error ?? init.status}`);
+		}
+		await run(["config", "user.email", "t@t.t"], main);
+		await run(["config", "user.name", "t"], main);
+		fs.writeFileSync(path.join(main, "base.txt"), "base\n");
+		await run(["add", "-A"], main);
+		await run(["commit", "-qm", "init"], main);
+
+		const nested = path.join(main, ".claude", "worktrees", "agent-x");
+		const added = await run(
+			["worktree", "add", "-q", "-b", "agent-x", nested],
+			main,
+		);
+		if (added.error || added.status !== 0) {
+			throw new Error(
+				`git worktree add failed: ${added.error ?? added.status}`,
+			);
+		}
+
+		const mainTop = await resolveGitToplevel(main);
+		const nestedTop = await resolveGitToplevel(nested);
+		expect(mainTop).toBeDefined();
+		expect(nestedTop).toBeDefined();
+		// The nested tree is lexically INSIDE the main one and is still a
+		// different working tree. Containment alone cannot tell them apart.
+		expect(
+			normalizeFilePath(nestedTop!).startsWith(normalizeFilePath(mainTop!)),
+		).toBe(true);
+		expect(normalizeFilePath(nestedTop!)).not.toBe(normalizeFilePath(mainTop!));
+
+		// A plain subdirectory of the main tree DOES resolve back to it.
+		const plainSub = path.join(main, "sub");
+		fs.mkdirSync(plainSub, { recursive: true });
+		expect(normalizeFilePath((await resolveGitToplevel(plainSub))!)).toBe(
+			normalizeFilePath(mainTop!),
+		);
 	});
 
 	it("reports clean, then dirty, then unknown outside a repo", async () => {

--- a/tests/clients/shared-checkout-guard.test.ts
+++ b/tests/clients/shared-checkout-guard.test.ts
@@ -411,6 +411,28 @@ describe("evaluateSharedCheckoutGuard (#2007)", () => {
 		expect(decision.reason).toContain(`pid ${process.pid + 1}`);
 	});
 
+	it("finds a peer REGISTERED on a subdirectory of the shared checkout", async () => {
+		// R2, second direction. The first subdirectory test moves the CWD, which
+		// the toplevel lookup alone already handles — so it does not prove the
+		// call site's "containment" argument. This one moves the PEER: pi-lens
+		// registers a session at whatever project root it opened, which can be
+		// a package inside the repo. Only containment admits that candidate.
+		const decision = await evaluateSharedCheckoutGuard(
+			"bash",
+			bash("git checkout main"),
+			ROOT,
+			deps({
+				readRegistry: async () => [
+					peer({ projectRoot: normalizeFilePath(path.join(ROOT, "clients")) }),
+				],
+				resolveToplevel: async () => ROOT,
+			}),
+		);
+		// MUTATION PROOF: swap the call site's "containment" for "exact" and
+		// this reds — a peer registered one directory down is invisible.
+		expect(decision.block).toBe(true);
+	});
+
 	it("allows inside a NESTED worktree, which shares no files with its parent", async () => {
 		// R3: a linked worktree lives at a path under the main checkout but is
 		// a separate working tree. Lexical containment declined it, and the

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -956,7 +956,10 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	"format-events-publish.ts": 0,
 	"formatters.ts": 5,
 	"generated-artifacts.ts": 2,
-	"git-guard.ts": 1,
+	// #2007 hoisted git's global-option table to a module-level `new Set`
+	// (1 → 2). It is an import-time frozen lookup with no session lifetime —
+	// SWEEP_HEURISTIC_LIMITS item 5, not state that must re-arm.
+	"git-guard.ts": 2,
 	"git-tracked-ignore.ts": 3,
 	"installer/index.ts": 12,
 	"instance-registry.ts": 0,

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -217,11 +217,11 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 	{
 		id: "opaque-mutation-scan:baselineStore+gitMemo",
 		module: "opaque-mutation-scan.ts",
-		state: "OpaqueBaselineStore byCwd map, gitRepoMemo",
+		state: "OpaqueBaselineStore byCwd map, gitRepoMemo, gitToplevelMemo",
 		policy: "session_start",
 		resetName: "resetOpaqueMutationState",
 		reason:
-			"#2000 phase 2: pending pre-command baselines are keyed cwd:generation and become unreachable when the session generation advances; and the git-worktree memo must re-probe after a session that may have seen a directory become a worktree. Without the reset both leak per session and the memo mis-answers forever.",
+			"#2000 phase 2: pending pre-command baselines are keyed cwd:generation and become unreachable when the session generation advances; and the git-worktree and toplevel memos must re-probe after a session that may have seen a directory become a worktree, or become a LINKED worktree of another (#2007). Without the reset the baselines leak per session and the memos mis-answer forever.",
 	},
 	// ── #2026 pending auxiliary coverage baselines ──────────────────────
 	{
@@ -978,7 +978,9 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	// LEGAL_ORDINARY_PORCELAIN_STATUSES. Both are frozen-by-convention lookup
 	// tables of Git's documented porcelain matrix — import-time constants with
 	// no session identity, so they need no reset (SWEEP_HEURISTIC_LIMITS item 5).
-	"opaque-mutation-scan.ts": 3,
+	// #2007 added `gitToplevelMemo`, the worktree-identity cache (3 → 4). It
+	// is registered above and cleared by the same `resetOpaqueMutationState`.
+	"opaque-mutation-scan.ts": 4,
 	"lsp/pending-aux-coverage.ts": 1,
 	"lsp/jvm-runtime.ts": 0,
 	"lsp/session-roots.ts": 1,


### PR DESCRIPTION
## Summary

Several agent sessions can share one checkout. Nothing in git binds a session to a directory, so one session's `git checkout <branch>` overwrites the tracked files another live session is editing, and the work is unrecoverable because it was never committed. #2007 records the incident: three files of uncommitted work vanished between two observations minutes apart.

This adds an opt-in guard, `--lens-checkout-guard` (`guard.sharedCheckout=true`), that DECLINES a worktree-mutating git command when three facts all hold, checked cheapest first:

1. The command really rewrites the working tree: `checkout`, `switch`, `restore`, `reset --hard|--merge|--keep`, `stash` (any mutating subcommand), `clean` without `--dry-run`, `merge`, `rebase`, `pull`, `cherry-pick`, `revert`.
2. `selectLivePeerInstances` reports another live pi-lens session registered on this root.
3. `git status` reports uncommitted work.

Refusal, not rescue. An auto-stash would move a peer's work behind their back, and `git stash` is repo-global across worktrees, so the rescue would repeat the defect it is fixing. The refusal names the peer pids and points at the two correct exits: commit, or take a dedicated `git worktree`.

Two reuse decisions, both to avoid parallel state:

- Command classification goes through the existing #1063 git-guard shell analysis. `containsCommitOrPush` became `containsGuardedGitVerb(tokens, depth, matcher)` and the public entry point is now `detectGuardedGitVerb(toolName, input, matcher)`. There is no second lexer. The two matchers differ on one axis: `indirectAlwaysMatches`. The commit gate is a policy an agent may want to evade, so any non-leading `git` fails closed there. This guard protects an agent from its own accident, so its indirect path arms only when the argv also carries a governed verb — `xargs git status` stays usable, `xargs git checkout main` does not.
- Peer liveness goes through `selectLivePeerInstances` in `clients/instance-registry.ts`, hoisted out of `selectWarmAttachIncumbent` (`clients/warm-attach.ts:55`), which now delegates to it. The two cannot drift about what "another session is here" means.

Catalog screens applied: shape 10 (an unanswerable `git status` declines on its own UNKNOWN reason and is never read as clean), shape 17 (no process-lifetime latch; repeat suppression is the degradation ledger's own rising edge, which re-arms at `session_start`), shape 14 (tests import `.js`), shape 7 (every branch carries a named mutation proof). AGENTS.md sections consulted: "Recurring defect shapes", "Git guard", "Experimental git guard (#1063)", "Session lifecycle, telemetry, and observability", "Maintaining this file".

## Tests

Two new files, 21 tests. `npm run build` before every run.

**Baseline red on pre-fix code.** `git checkout e0ef5a3f -- clients/`, delete the new module, rebuild, run both files:

```
 ❯ tests/clients/shared-checkout-guard-wiring.test.ts (3 tests | 2 failed)
     × blocks the tool with the guard's own reason 6ms
     × lets an allowed command through without an opinion 1ms
 FAIL  tests/clients/shared-checkout-guard.test.ts
Error: Cannot find module '/clients/shared-checkout-guard.js' imported from .../tests/clients/shared-checkout-guard.test.ts
 FAIL  shared-checkout guard wiring (#2007) > blocks the tool with the guard's own reason
AssertionError: expected undefined to match object { block: true }
 FAIL  shared-checkout guard wiring (#2007) > lets an allowed command through without an opinion
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 Test Files  2 failed (2)
      Tests  2 failed | 1 passed (3)
```

**Mutation proofs.** Five guards, each neutered independently on the fixed tree, rebuilt, and re-run. No compensating pairs.

M1, the dirty branch returns `{ block: false }`:

```
 ❯ tests/clients/shared-checkout-guard.test.ts (18 tests | 1 failed)
     × declines a branch switch when a live peer shares this dirty checkout 6ms
      Tests  1 failed | 17 passed (18)
```

M2, the `peers.length === 0` early return is disabled:

```
 ❯ tests/clients/shared-checkout-guard.test.ts (18 tests | 1 failed)
     × allows the same command when no other session is here 7ms
      Tests  1 failed | 17 passed (18)
```

M3, `unknown` collapsed into `clean` (shape 10):

```
 ❯ tests/clients/shared-checkout-guard.test.ts (18 tests | 1 failed)
     × declines on an UNKNOWN probe rather than assuming clean 9ms
      Tests  1 failed | 17 passed (18)
```

M4, the `getFlag("lens-checkout-guard")` gate removed in `runtime-tool-call.ts`:

```
 ❯ tests/clients/shared-checkout-guard-wiring.test.ts (3 tests | 1 failed)
     × does not consult the guard while the flag is off 143ms
      Tests  1 failed | 2 passed (3)
```

M5, the indirect-git narrowing replaced by `return matcher.indirectAlwaysMatches`:

```
 ❯ tests/clients/shared-checkout-guard.test.ts (18 tests | 2 failed)
     × inherits the #1063 wrapper and substitution analysis instead of re-parsing 11ms
     × narrows the indirect-git fail-closed rule to governed verbs only 2ms
      Tests  2 failed | 16 passed (18)
```

**Green on the fixed tree.** New files plus every suite that references a changed symbol:

- `shared-checkout-guard`, `shared-checkout-guard-wiring`, `git-guard`, `warm-attach`, `bounded-telemetry-sweep`, `index-wiring` — 104 passed (6 files).
- `git-guard`, `warm-attach`, `instance-registry`, `bounded-telemetry-sweep`, `bounded-telemetry`, `degradation-ledger`, `lens-config`, `index-wiring`, `mcp/host-shim`, `config/module-instance-coverage` — 272 passed (10 files).
- `runtime-turn-session`, `opaque-mutation-scan`, `pi-host-contract`, `session-state-conformance`, `lsp-budget`, `quiet-window`, `instance-reaper` — 249 passed (7 files).

`npm run build`, `npm run lint`, `npm run fmt:check`, `npm run changelog:check`, and `npm run astgrep:self-scan` all clean. The full suite is deferred to CI.

`probeWorkingTreeState` is exercised against the REAL `git` binary in a temp repo — clean, then dirty after one untracked file, then unknown outside a repo — rather than against a hand-written porcelain fixture (shape 16).

## Blast radius

**`clients/git-guard.ts` — the refactor is the widest surface.** `containsCommitOrPush` and `containsGuardedSubstitution` gained a `matcher` parameter. `isGitCommitOrPushAttempt` keeps its exact signature and now delegates with `COMMIT_PUSH_MATCHER`, whose `indirectAlwaysMatches: true` reproduces the old unconditional indirect-git fail-closed behavior. Its only caller is `clients/runtime-tool-call.ts:552`. The 60-assertion `tests/clients/git-guard.test.ts` passes unchanged, and the new suite re-pins four commit-gate answers directly, including `xargs git status` still returning `true`. One deliberate non-change: the verb comparison stays case-sensitive, because git's own verbs are.

**`clients/warm-attach.ts` — behavior preserved by delegation.** `selectWarmAttachIncumbent`'s filter moved verbatim into `selectLivePeerInstances`; the function now returns element `[0]` of the same sorted list. Callers are `configureWarmAttach` and `tryWarmAttachedDiagnostics` in that file. `tests/clients/warm-attach.test.ts` passes unchanged.

**Hot path cost.** The guard runs inside `handleToolCall` for bash only, and only with the flag on. Ordinary bash traffic pays one `detectGuardedGitVerb` call, the same string classification `lens-guard` already performs, with no I/O — the `registryReads === 0` and `latencyCalls.length === 0` assertions in the "never touches the registry" test pin that ordering. A worktree-mutating command pays one registry file read. A worktree-mutating command WITH a live peer additionally pays `git rev-parse` (memoized per root by `isGitWorktree`) and one `git status`, both capped at 3s and 5s. No new process spawns on any other path, and no new long-lived handles.

**Behavior widening.** One: with the flag on, a bash command can now be blocked that previously ran. The flag defaults false and is not on in any test fixture, so no existing behavior changes for anyone who does not opt in. A registry that cannot be read ALLOWS, so an observability outage cannot start refusing branch switches machine-wide.

**Registries touched.** `LENS_FLAGS` gains one entry, which `index.ts` registration, `lens-config` resolution, and `tests/index-wiring.test.ts` all derive from — no second list to update. `BOUNDED_TELEMETRY_PHASES` gains two phases and `DegradationKind` gains two kinds; the registered-or-fail sweep passes.

## Class sweep

The defect shape: **one session's git command mutating a working tree another live session owns.**

**PATTERN sweep** — `grep -rn '"git"'` across `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts` for every git invocation, not `clients/` alone. Every production git call pi-lens makes is READ-ONLY, so pi-lens itself is not a member of the class:

- `clients/git-tracked-ignore.ts:92` `ls-files --others --ignored --exclude-standard`, `:192` `ls-files` — read-only, correct as-is.
- `clients/opaque-mutation-scan.ts:239` `rev-parse --is-inside-work-tree`, `:379` `status --porcelain -z` — read-only, correct as-is.
- `clients/shared-checkout-guard.ts:149` `status --porcelain` — read-only, added here.
- `scripts/bench-lsp.mjs:92`, `characterize-lsp.mjs:53`, `compat-smoke-behavioral.mjs:112-116`, `probe-clean-signal.mjs:234`, `server-capabilities.mjs:72`, `smoke-gitleaks-scratch-exclusion.mjs:69`, `smoke-tools.mjs:1565` and `:2026` — all `git init`/`add`/`commit` into a freshly created temp workspace, never the user's tree. Correct as-is.
- `scripts/pre-push-targeted-tests.mjs:75` `diff --name-only`, `scripts/backfill-release-thanks.mjs:105` tag read — read-only. Correct as-is.

So the destructive actor is always the AGENT's own bash command, which is exactly what this guard intercepts.

**POPULATION sweep** — the family is "code that classifies git subcommands by what they do to the working tree". Two members:

- `clients/shared-checkout-guard.ts` `WORKTREE_MUTATING_GIT_MATCHER` — added here.
- `clients/runtime-tool-result.ts:85-91` `GIT_INTEGRATION_SUBCOMMANDS` (`merge`, `rebase`, `cherry-pick`, `pull`, `revert`, `am`) — already correct at that line, for a different question.

**Consolidation verdict: NOT consolidated, deliberately.** The two lists overlap but answer different questions. `GIT_INTEGRATION_SUBCOMMANDS` asks "on FAILURE, does this command leave the other branch's content in the index", which is why it includes `am` and excludes `checkout`, `switch`, `restore`, `reset`, `stash`, and `clean`. The new matcher asks "can this rewrite tracked files at all". Merging them would force one list to answer a question it was not built for. What IS consolidated is the expensive part — the shell tokenization and wrapper analysis — which now has a single implementation behind `detectGuardedGitVerb`.

**Second axis, non-git cross-session damage in a shared root.** The opaque-mutation baseline store already session-stamps its key (`clients/runtime-tool-call.ts`, the #473 note) so a concurrent secondary yields UNKNOWN rather than diffing another session's baseline — already correct. Durable stores use tmp+rename atomic writes. The instance registry's last-writer-wins race is documented and accepted in its module docstring, and only costs an observability entry. No new member found.

**Deliberately left:** `git apply` and `git am` are NOT governed. They add the caller's own patch on top of the tree and fail loudly into `.rej` files rather than discarding tracked content, and `git apply` is this repo's sanctioned replacement for the forbidden `git stash`. Governing it would push operators back toward stash. Recorded in the matcher's docstring so the omission is a decision, not an oversight.

## Observability

Three records prove the guard in production, all in `~/.pi-lens/latency.log`, all carrying the checkout root as the discriminating identity:

- `shared_checkout_switch_blocked` — a refusal on real WIP. Emitted through `emitBounded` with ledger kind `shared-checkout-wip`, rising edge per checkout root, so one contended directory cannot flood the log while the ledger keeps the exact repeat count. `metadata.identity` is the normalized root, `metadata.peerCount` the number of live peers.
- `shared_checkout_probe_failed` — a refusal because `git status` could not answer. Ledger kind `shared-checkout-probe`. This is the record that makes a broken probe visible instead of silently permissive.
- `shared_checkout_guard_allow` — every allow, with `metadata.reasonCategory` naming which of the four exits fired: `no_peer_session`, `registry_unreadable`, `not_a_git_worktree`, or `working_tree_clean`. This is what answers "the guard is on but never fires — is it working, or is the registry empty?".

Both bounded phases join `BOUNDED_TELEMETRY_PHASES`; `tests/clients/bounded-telemetry-sweep.test.ts` passes, so neither is a raw unbounded failure record. The allow record is intentionally raw: it is not a failure path and its volume is bounded by how often a worktree-mutating git command runs.

**Named gap:** the guard's decision is visible in `latency.log` but not in any session-facing surface. An operator who has never seen the refusal text will not know the flag exists. That is inherent to an opt-in experiment and matches how `--lens-guard` shipped; no separate issue filed.

## Merge order

No conflict. The only other open PR is #1986 (`bot/lsp-docs-refresh`), which touches docs only.

Refs #2007


## Review round 1 — five findings, head `50b36a08`

### F1 — the module bypassed the delivery-surface ratchet

CI red on `ae4d8868`. Reproduced locally before changing anything:

```
 ❯ tests/clients/delivery-surface-ratchet.test.ts (3 tests | 1 failed)
     × every advisory-marker file is registered or exempted 102ms
AssertionError: expected [ 'shared-checkout-guard.ts' ] to deeply equal []
      Tests  1 failed | 46 passed (47)
```

**Resolution: REGISTERED, not exempted.** The refusal text is a real agent-facing finding, so an exemption would have claimed the module delivers nothing. `shared-checkout-guard:worktree-mutation-blocked` joins `DELIVERY_SURFACES` as a `labeled` entry with `ageSource: "live"`, modeled on the adjacent `git-guard:commit-blocked` — the identical shape, a synchronous preflight rejection returned inline with the failed git command. The stated reason is stronger than "no cache": BOTH inputs, the instance registry and `git status`, are read at decision time, so no stored finding is replayed and there is no staleness window to label. The id also joins `EXPECTED_SURFACE_IDS`, the registry's own registered-or-fail pin. Deleting the entry reproduces the red above.

### F2 — the guard judged the caller's cwd, not the directory git targets

`git -C <shared> checkout main` run from a private worktree destroys the SHARED tree. The guard looked for peers in the private worktree, found none, and allowed exactly the command it exists to decline. `--work-tree` has the same effect.

`resolveGitTargetDirectory` now resolves each invocation's real target: `-C` composes cumulatively, the way git composes it, and `--work-tree` names the working tree directly and wins. Every distinct target is evaluated and the first contended one blocks.

### F3 — peer matching missed every subdirectory

Roots were compared for exact equality, so a command run from `repo/clients` never matched a peer registered at `repo`, and the guard allowed the destructive command. `selectLivePeerInstances` gained a `match` parameter. This guard asks in `"containment"` mode, because a peer at the repo root and a command in a subdirectory share ONE working tree. Warm attach keeps `"exact"`, which is what a root-bound LSP service needs. Containment compares on segment boundaries, so `/repo-backup` never matches `/repo`.

### F4 — `--help` after the verb, and clustered `clean` flags

`git checkout --help` classified as a branch switch: the global-option walk runs BEFORE the verb and cannot see a post-verb `--help`. And `git clean -nfd` classified as a deletion, because short flags cluster and an exact-token set does not see the `n`.

### F5 — the indirect path read a verb from any token

The indirect-git branch scanned every token after `git`, so a positional value that happens to spell a subcommand matched: `find . -name checkout | xargs git add` read as a branch switch. Both the direct and the indirect path now call one `matchGitVerbAtCommandPosition` helper, which walks git's global options and reads the single token in real command position.

### Red proof for F2–F5

The five fixes were written, then `clients/` was reverted to `958ebecc`, rebuilt, and the tests re-run. All six new tests red on pre-fix code, no other test disturbed:

```
 ❯ tests/clients/shared-checkout-guard.test.ts (24 tests | 6 failed)
     × reads the verb from git's COMMAND POSITION, not from any token 5ms
     × treats a post-verb --help as documentation, not a mutation 1ms
     × reads a clustered -n as `git clean` dry-run 1ms
     × composes cumulative -C the way git does, and lets --work-tree win 1ms
     × matches a peer at the repo root from a subdirectory, in both directions 2ms
     × evaluates the directory `-C` retargets at, not the caller's cwd 2ms
AssertionError: xargs git add -- clean: expected true to be false
AssertionError: git checkout --help: expected true to be false
AssertionError: git clean -nfd: expected true to be false
AssertionError: expected [] to have a length of 1 but got +0
AssertionError: expected false to be true
 Test Files  1 failed (1)
      Tests  6 failed | 18 passed (24)
```

### A second governance sweep fired on the fix

Hoisting git's global-option table to a module-level `new Set` moved `git-guard.ts` from 1 stateful symbol to 2, which the #1817 session-state pin caught:

```
AssertionError: session-state symbol-count pin: 1 flagged item(s) are neither registered nor exempted:
  git-guard.ts@2
```

Resolved by updating the pin to 2 with the reason stated inline: it is an import-time frozen lookup with no session lifetime, `SWEEP_HEURISTIC_LIMITS` item 5, not state that must re-arm at `session_start`.

### Why round 0's targeted run missed F1 and the pin

I selected test files by grepping for the symbols I changed. Neither sweep references any of them — both walk a directory and fire on ANY new or edited file. A symbol grep structurally cannot find that class. The correct rule is "symbol grep PLUS every directory-scanning governance suite", and round 0 ran only one of the latter.

### Verification on `50b36a08`

Green (21 files, 457 passed): `shared-checkout-guard`, `shared-checkout-guard-wiring`, `git-guard`, `warm-attach`, `instance-registry`, `lsp-budget`, `quiet-window`, `instance-reaper`, `runtime-turn-session`, `pi-host-contract`, `delivery-surface-ratchet`, `finding-delivery-gate`, `bounded-telemetry-sweep`, `index-wiring`, `session-state-conformance`, `config/module-instance-coverage`, `bus-producer-coverage`, `deps-centralization`, `freshness-sweep`, `managed-tool-seam-coverage`, `profiling-coverage`. `npm run build`, `npm run lint`, and `npm run fmt` all clean.

**Reported honestly, not as green:** in that 22-file parallel run, `opaque-mutation-scan.test.ts > reports file-cap-exceeded rather than an unbounded walk` failed at 5637ms. Re-run in isolation it passes 35/35 in 25s. It exercises `captureFileStats`, the non-git stat-diff walk under a cooperative budget, which this PR adds no code to — the failure is load contention from running 22 files at once, not a regression. CI runs it on its own schedule and is authoritative.

### Provenance note

F1 came from CI. F2 through F5 reached me only as a one-line summary in an orchestrator resume message, with no originating review text. Rather than take that on trust or dismiss it, I verified each claim against the code myself, confirmed all four were real, and fixed them on their merits. Each carries its own red-proven regression test above.

### Blast radius of this round

`clients/git-guard.ts` gained `matchGitVerbAtCommandPosition`, `resolveGitTargetDirectory`, and `collectGitInvocations`, and the direct/indirect verb lookup collapsed into the shared helper. `isGitCommitOrPushAttempt` keeps its signature and its `indirectAlwaysMatches: true` behavior; the 60-assertion `git-guard.test.ts` passes unchanged. `selectLivePeerInstances` gained a fifth parameter defaulting to `"exact"`, so `selectWarmAttachIncumbent` and `warm-attach.test.ts` are unaffected.

One behavior widening beyond round 0: with the flag on, a `git -C <dir>` command is now judged against `<dir>`. That is the fix. Three narrowings: `git checkout --help`, `git clean -nfd`, and an indirect git whose argv merely contains a verb-shaped positional are no longer declined.


## Review round 2 — three findings, head `4c447758`

### R1 (BLOCKER, a regression my round 1 introduced)

Round 1 added a post-verb `--help`/`-h` suppression to the classifier both gates now share. Applied to the #1063 commit gate it was a hole, because `-h` is a legal option VALUE. I verified the reviewer's probe against the real binary before changing anything, in a scratch repo on git 2.55:

```
$ git commit -m -h -q ; echo "exit:$?"
exit:0
$ git log --oneline -1 --format='SUBJECT=[%s]'
SUBJECT=[-h]
```

It commits. `git push --repo -h` likewise reaches the push path, not a help screen.

**Fix, both parts.** Suppression is now opt-in per matcher via `suppressPostVerbHelp`, and it is `false` for `COMMIT_PUSH_MATCHER` — that gate fails closed by contract and does not get to be argued out of a match by a token that might be a value. `git commit --help` therefore classifies as an attempt again, exactly as before this seam existed.

For the checkout guard, suppression fires only on the FIRST post-verb argument. I did not take the suggested per-verb table of value-taking options: that is a hand-maintained parallel list, this repo's single-source-of-truth rule forbids it, and every gap in it would silently UNDER-block. Leading-position-only needs no table, matches how help is actually invoked, and every other spelling falls through to a match — the safe direction for a guard.

### R2 — the containment fix was vacuous at the call site

Correct, and worse than reported. My first attempt at a fix was ALSO vacuous: I added an end-to-end test with a subdirectory cwd, flipped the call site to `"exact"`, and it stayed green. The R3 toplevel lookup resolves a subdirectory cwd back to the repo root on its own, so the cwd direction never exercises containment at all.

The case containment uniquely answers is a peer **registered** on a subdirectory. pi-lens registers whatever project root it opened, which can be a package inside the repo, and an exact compare cannot see it. Both directions are now pinned, and the registered-on-a-subdirectory one reds under `"exact"`:

```
 ❯ tests/clients/shared-checkout-guard.test.ts (28 tests | 1 failed)
     × finds a peer REGISTERED on a subdirectory of the shared checkout 6ms
AssertionError: expected false to be true
      Tests  1 failed | 27 passed (28)
```

### R3 — lexical containment swallowed nested worktrees

Also correct, and the failure mode was self-refuting: an agent working in `.claude/worktrees/agent-x` was declined on the MAIN checkout's peers, and told to go use a dedicated worktree, which is where it already was.

Path containment is not checkout identity. `resolveGitToplevel` now resolves both the target and each candidate peer with `git rev-parse --show-toplevel`, and only equal toplevels count as shared. It is memoized beside the existing `isGitWorktree` probe and cleared by the same `resetOpaqueMutationState` session boundary, so it is not a process-lifetime latch (catalog shape 17). `undefined` is a real cached answer, so the memo is probed with `has`, never by truthiness.

The premise is verified against the real binary with an actual `git worktree add` fixture, not assumed: the nested tree's toplevel starts with the main tree's path and is not equal to it.

### Red proofs on round-2 code (`50b36a08`)

```
 ❯ tests/clients/git-guard.test.ts (28 tests | 2 failed)
     × still matches when -h is an option VALUE, not a help request 6ms
     × keeps failing closed on an explicit post-verb help flag 1ms
 ❯ tests/clients/shared-checkout-guard.test.ts (27 tests | 9 failed)
     × declines from a SUBDIRECTORY of the shared checkout, end to end 21ms
     × allows inside a NESTED worktree, which shares no files with its parent 23ms
     × gives a nested linked worktree its OWN toplevel (R3's premise) 720ms
     ...
AssertionError: git commit -m -h: expected false to be true
AssertionError: git commit --help: expected false to be true
 Test Files  2 failed (2)
      Tests  11 failed | 44 passed (55)
```

Reported precisely: the two `git-guard.test.ts` reds are pure R1 — that suite's harness is untouched by this round. Among the nine guard-suite reds, the three named above are the targeted R2/R3 proofs; the other six are collateral from renaming the `isGitRepo` dep to `resolveToplevel`, and I am not claiming them as evidence.

### Differential: 128 commands, master vs branch, 0 divergences

I built the probe as a corpus of 128 commit-gate commands — plain verbs, seven help spellings, 30 `-h`/`--help`-as-option-value forms across every value-taking `commit` and `push` option, global options before the verb, wrappers, substitutions, `$IFS` escapes, and negatives — and ran it on three trees, isolating `clients/git-guard.ts` so nothing else moved.

```
commands compared: 128
commit-gate divergences: 0
master-true count: 95
```

Zero, not "zero minus two benign rows": scoping suppression away from `COMMIT_PUSH_MATCHER` entirely means even `git commit --help` matches exactly as master does. 95 of 128 commands are true on master, so the corpus exercises both outcomes rather than trivially agreeing.

**The probe is not vacuous.** Run against round-2 code it finds the regression, at larger scale than the review reported:

```
round-2 vs master divergences on the commit gate: 58
  git commit --help  master=true branch=false
  git commit -m -h  master=true branch=false
  git commit -F -h  master=true branch=false
  git commit --author -h  master=true branch=false
  git push --repo -h  master=true branch=false
  git push --force-with-lease -h  master=true branch=false
  ... 52 more, every one true→false
```

### A third governance sweep fired

Adding `gitToplevelMemo` moved `opaque-mutation-scan.ts` from 3 stateful symbols to 4. **Registered, not exempted:** it is real session state, and the module's existing `session-state-registry` entry already names `resetOpaqueMutationState` as its boundary, so the entry's `state` and `reason` now name the new memo and the pin moves to 4.

### Verification on `4c447758`

Batch 1, targeted (8 files, 217 passed): `shared-checkout-guard`, `shared-checkout-guard-wiring`, `git-guard`, `warm-attach`, `instance-registry`, `opaque-mutation-scan`, `runtime-turn-session`, `pi-host-contract`.

Batch 2, governance (14 files, 247 passed): `session-state-conformance`, `delivery-surface-ratchet`, `finding-delivery-gate`, `bounded-telemetry-sweep`, `module-instance-coverage`, `index-wiring`, `bus-producer-coverage`, `deps-centralization`, `freshness-sweep`, `managed-tool-seam-coverage`, `profiling-coverage`, `lsp-budget`, `quiet-window`, `instance-reaper`.

`npm run build`, `npm run lint`, and `npm run fmt` clean. `opaque-mutation-scan` passed in this round's batch, so round 2's isolated-only note no longer applies.

### Blast radius of this round

`GitVerbMatcher` gained a third required field, so both matchers had to answer it — a new matcher cannot forget. `SharedCheckoutGuardDeps.isGitRepo` became `resolveToplevel`; the only callers are this module and its tests. `resolveGitToplevel` is new in `opaque-mutation-scan.ts` and spawns `git rev-parse --show-toplevel`, memoized per root, on the same path that already spawns `isGitWorktree` — one extra bounded 3s spawn per distinct root, per session, reached only after a worktree-mutating command matched.

Two narrowings and one widening. Narrowed: nested linked worktrees are no longer declined, and a peer whose toplevel cannot be resolved no longer counts. Widened: a peer registered on a subdirectory of the shared checkout is now seen. The commit gate is restored to master's exact behavior on all 128 probed commands.
