### PR TITLE
perf(lsp): fold the two didChange document walks into one (refs #2066)

### DIFF
--- a/.changelog/fix-2066-single-pass-document-sync.md
+++ b/.changelog/fix-2066-single-pass-document-sync.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Per-send LSP document sync makes one JavaScript pass over the previous document instead of two, on `didChange` (refs #2066)** — the newline count behind `lsp_document_send`'s `contentLineCount` and the last-line position behind an Incremental `didChange` range now come from a single scan whose result rides on the existing per-path content-binding entry, so a change no longer splits the previous document into one substring per line to read one of them. Line-count semantics are unchanged: `contentLineCount` still counts `\n` only, while the range still treats `\r\n`, lone `\r`, and `\n` as terminators. The remainder of #2066 is its "one pass total" target: the #1095 sha256 content binding is a second, native full-document pass and still runs on every send.

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -912,10 +912,21 @@ export interface LSPClientState {
 	 *  ONLY when `syncKind` is Incremental — the one case that needs it, to
 	 *  compute the NEXT change's full-range replace against the document as the
 	 *  server last saw it (see `buildContentChanges`). Full/None servers never
-	 *  populate it, so the common case pays no extra retained memory. */
+	 *  populate it, so the common case pays no extra retained memory.
+	 *
+	 *  #2066: `lastLine` is where that same send's `scanSentContent` pass left
+	 *  the end of `text`, so the next change reads two numbers instead of
+	 *  re-walking (and re-splitting) the whole document for them. It travels
+	 *  with `text` and only with `text`: the eviction rewrite below drops both
+	 *  together, and a position describing text that is gone would be a lie. */
 	readonly documentContentHashes: Map<
 		string,
-		{ version: number; hash: string; text?: string }
+		{
+			version: number;
+			hash: string;
+			text?: string;
+			lastLine?: LastLinePosition;
+		}
 	>;
 	/** #2065: full Incremental-sync text is an LRU-like bounded subset of the
 	 * per-path content-binding map. The binding remains after text eviction. */
@@ -1769,6 +1780,63 @@ function logTypeScriptPullSettle(
 	});
 }
 
+/** Where a document's last LSP-addressable line begins (#2066). */
+interface LastLinePosition {
+	/** Its 0-based line index. */
+	index: number;
+	/** Its first character's offset into the document. */
+	start: number;
+}
+
+interface SentContentScan {
+	/** `\n` count — `contentLineCount` is this + 1. */
+	lfNewlineCount: number;
+	lastLine: LastLinePosition;
+}
+
+/**
+ * #2066: the ONE full-document walk a send needs, replacing the two that used
+ * to run independently — a `charCodeAt` loop counting `\n` for the
+ * `lsp_document_send` line count, and a `.split(/\r\n|\r|\n/)` in
+ * `buildContentChanges` that materialized one substring per line to read the
+ * last one. The #1095 sha256 is a third walk and stays; it is native, and it
+ * is load-bearing.
+ *
+ * The two counts here are deliberately NOT the same number and must not be
+ * collapsed into one. `lfNewlineCount` counts `\n` only, because its consumer
+ * pairs against `diagnostic_past_eof`, whose gate counts LF BYTES
+ * (`clients/diagnostic-line-freshness.ts`); merging the conventions would put
+ * the two records one apart on exactly the mixed-ending documents the pairing
+ * exists to debug. `lastLine` uses the full LSP terminator set (`\r\n`, lone
+ * `\r`, `\n` — #1669 review F6), because a CRLF or classic-Mac document whose
+ * terminators went uncounted computes a range ending mid-document.
+ */
+function scanSentContent(content: string): SentContentScan {
+	let lfNewlineCount = 0;
+	let index = 0;
+	let start = 0;
+	// `charCodeAt`, not `codePointAt` (typescript:S7758, accepted): both are
+	// compared against 10/13, which no surrogate unit or astral code point can
+	// equal, so they are interchangeable here — but `codePointAt` measured 8%
+	// slower on a 400 KiB LF document (0.716 vs 0.663 ms/scan), because every
+	// ordinary character pays a surrogate-pair check this loop never uses.
+	for (let i = 0; i < content.length; i++) {
+		const code = content.charCodeAt(i);
+		if (code !== 10 && code !== 13) continue;
+		if (code === 10) {
+			lfNewlineCount++;
+		} else if (content.charCodeAt(i + 1) === 10) {
+			// `\r\n` is ONE line terminator, and still carries the `\n` the
+			// LF-only count wants.
+			lfNewlineCount++;
+			i++;
+		}
+		index++;
+		start = i + 1;
+	}
+	return { lfNewlineCount, lastLine: { index, start } };
+}
+
 /**
  * #1095: fingerprint the EXACT didOpen/didChange payload text at SEND time and
  * tag it with the document version it was sent as, so a later
@@ -1783,6 +1851,7 @@ function recordSentContent(
 	version: number,
 	content: string,
 ): void {
+	const scan = scanSentContent(content);
 	const previous = state.documentContentHashes.get(normalizedPath);
 	if (previous?.text !== undefined) {
 		state.incrementalTextRetainedEntries = Math.max(
@@ -1814,8 +1883,11 @@ function recordSentContent(
 		// #1669: retain the full text only for Incremental — the sole reader
 		// (`buildContentChanges`) needs it to compute the NEXT change against
 		// what the server last saw; Full/None never read this field.
+		// #2066: `lastLine` is that reader's answer, already computed by the
+		// scan above — it rides along with the text it describes.
 		...(state.syncKind === TEXT_DOCUMENT_SYNC_KIND_INCREMENTAL && {
 			text: content,
+			lastLine: scan.lastLine,
 		}),
 	});
 	if (state.syncKind === TEXT_DOCUMENT_SYNC_KIND_INCREMENTAL) {
@@ -1845,6 +1917,8 @@ function recordSentContent(
 			const binding = state.documentContentHashes.get(oldestPath);
 			state.incrementalTextBearingPaths.delete(oldestPath);
 			if (!binding || binding.text === undefined) continue;
+			// #2066: `lastLine` is dropped here with the text it describes. The
+			// #1095 version/hash binding is what must survive the strip.
 			state.documentContentHashes.set(oldestPath, {
 				version: binding.version,
 				hash: binding.hash,
@@ -1870,13 +1944,9 @@ function recordSentContent(
 	// convention as the gate itself (newline count + 1 — a trailing `\n` adds
 	// one more, empty, addressable line; an empty document is still 1 line),
 	// or the two records disagree by one at exactly the boundary this counter
-	// exists to help debug. Counted directly (no `.split("\n")`, which
-	// allocates one substring per line — measured at 13.3ms/200k allocations
-	// on a 7MB send) since only the COUNT is needed here, not the lines.
-	let newlineCount = 0;
-	for (let i = 0; i < content.length; i++) {
-		if (content.charCodeAt(i) === 10) newlineCount++;
-	}
+	// exists to help debug. #2066: the count comes from `scanSentContent`
+	// above, which folded this loop into the walk `buildContentChanges` was
+	// already paying for; the LF-only convention is unchanged.
 	logLatency({
 		type: "phase",
 		phase: "lsp_document_send",
@@ -1885,7 +1955,7 @@ function recordSentContent(
 		metadata: {
 			version,
 			contentLength: content.length,
-			contentLineCount: newlineCount + 1,
+			contentLineCount: scan.lfNewlineCount + 1,
 		},
 	});
 }
@@ -1926,23 +1996,24 @@ function buildContentChanges(
 	if (state.syncKind !== TEXT_DOCUMENT_SYNC_KIND_INCREMENTAL) {
 		return [{ text: content }];
 	}
-	const previousText = state.documentContentHashes.get(normalizedPath)?.text;
-	if (previousText === undefined) {
+	const previous = state.documentContentHashes.get(normalizedPath);
+	if (previous?.text === undefined) {
 		return [{ text: content }];
 	}
-	// #1669 review F6: split on every LSP line terminator (\r\n, lone \r, or
-	// \n), not just \n — a document using CRLF or lone-CR line endings would
-	// otherwise be undercounted, computing a range that ends mid-document
-	// instead of at the real last line.
-	const previousLines = previousText.split(/\r\n|\r|\n/);
-	const lastLine = previousLines.length - 1;
-	const lastLineText = previousLines[lastLine] ?? "";
+	const previousText = previous.text;
+	// #2066: `recordSentContent` scanned this exact text when it sent it, so
+	// read where it left the last line instead of walking (and splitting) the
+	// document a second time. An entry carrying text without that position was
+	// written by something else — resolve it through the SAME scanner, never a
+	// second convention that can drift from it.
+	const lastLine = previous.lastLine ?? scanSentContent(previousText).lastLine;
+	const lastLineText = previousText.slice(lastLine.start);
 	return [
 		{
 			range: {
 				start: { line: 0, character: 0 },
 				end: {
-					line: lastLine,
+					line: lastLine.index,
 					character: convertCharacterOffset(
 						state.positionEncoding,
 						lastLineText,

--- a/tests/clients/lsp/client-internals.test.ts
+++ b/tests/clients/lsp/client-internals.test.ts
@@ -681,6 +681,52 @@ describe("handleNotifyOpen", () => {
 		expect(sendCall?.[0].metadata.contentLineCount).toBe(1);
 	});
 
+	it("#2066: a CRLF document counts its LF terminators, so two CRLFs are 3 lines", async () => {
+		logLatencyMock.mockClear();
+		const state = createMockState();
+		await handleNotifyOpen(state, TEST_FILE, "a\r\nb\r\n", "typescript");
+
+		const sendCall = logLatencyMock.mock.calls.find(
+			(c) => c[0]?.phase === "lsp_document_send",
+		);
+		expect(sendCall?.[0].metadata.contentLineCount).toBe(3);
+		expect(sendCall?.[0].metadata.contentLength).toBe(6);
+	});
+
+	it("#2066: a lone-CR document is 1 line to contentLineCount and 3 to the didChange range", async () => {
+		logLatencyMock.mockClear();
+		const state = createMockState({ syncKind: 2 });
+		await handleNotifyOpen(state, TEST_FILE, "a\rb\rc", "typescript");
+
+		const sendCall = logLatencyMock.mock.calls.find(
+			(c) => c[0]?.phase === "lsp_document_send",
+		);
+		// `contentLineCount` exists to pair with `diagnostic_past_eof`, whose gate
+		// counts `\n` BYTES (clients/diagnostic-line-freshness.ts). A lone-CR
+		// document has none, so it is one addressable line to BOTH records.
+		expect(sendCall?.[0].metadata.contentLineCount).toBe(1);
+
+		await handleNotifyChange(state, TEST_FILE, "a\rb\rd");
+
+		const didChange = [
+			...vi.mocked(state.connection.sendNotification).mock.calls,
+		]
+			.reverse()
+			.find((c) => c[0] === "textDocument/didChange");
+		const params = didChange?.[1] as {
+			contentChanges: Array<{
+				range?: { end: { line: number; character: number } };
+			}>;
+		};
+		// LSP line addressing treats a lone `\r` as a terminator, so the SAME
+		// document is 3 addressable lines here. The two numbers diverge on
+		// purpose; folding them into one would break one consumer or the other.
+		expect(params.contentChanges[0].range?.end).toEqual({
+			line: 2,
+			character: 1,
+		});
+	});
+
 	it("detaches the classic TypeScript projectInfo probe after didOpen", async () => {
 		const state = createMockState({
 			serverId: "typescript",

--- a/tests/clients/lsp/refresh-and-sync-kind.test.ts
+++ b/tests/clients/lsp/refresh-and-sync-kind.test.ts
@@ -27,6 +27,7 @@ import {
 	loadWorkspaceDiagnosticsCache,
 } from "../../../clients/lsp/workspace-diagnostics-cache.js";
 import { negotiateSyncKind } from "../../../clients/lsp/sync-kind.js";
+import type { PositionEncoding } from "../../../clients/lsp/position-encoding.js";
 // #1669 review F8/rebase: #1682 landed the shared factory this file's local
 // copy was anticipating — use it instead of hand-maintaining a parallel one
 // (single-source-of-truth). `createMockState` there now also carries the F8
@@ -122,23 +123,20 @@ describe("negotiateSyncKind (#1669)", () => {
 	});
 });
 
-describe("outgoing didChange honors the negotiated sync kind (#1669)", () => {
-	function lastDidChangeParams(state: LSPClientState): {
+function lastDidChangeParams(state: LSPClientState): {
+	contentChanges: Array<{ range?: unknown; text: string }>;
+} {
+	const calls = vi.mocked(state.connection.sendNotification).mock.calls;
+	const call = [...calls]
+		.reverse()
+		.find((c) => c[0] === "textDocument/didChange");
+	expect(call, "a textDocument/didChange notification was sent").toBeDefined();
+	return call![1] as {
 		contentChanges: Array<{ range?: unknown; text: string }>;
-	} {
-		const calls = vi.mocked(state.connection.sendNotification).mock.calls;
-		const call = [...calls]
-			.reverse()
-			.find((c) => c[0] === "textDocument/didChange");
-		expect(
-			call,
-			"a textDocument/didChange notification was sent",
-		).toBeDefined();
-		return call![1] as {
-			contentChanges: Array<{ range?: unknown; text: string }>;
-		};
-	}
+	};
+}
 
+describe("outgoing didChange honors the negotiated sync kind (#1669)", () => {
 	it("Full sync kind: unchanged whole-document event", async () => {
 		const state = createMockState({ syncKind: 1 });
 		state.openDocuments.add(TEST_KEY);
@@ -413,6 +411,248 @@ describe("outgoing didChange honors the negotiated sync kind (#1669)", () => {
 		const previous = "before\ncontent";
 		const applied = `${previous.slice(0, 0)}${edit.text}`;
 		expect(applied).toBe("after\ncontent");
+	});
+});
+
+interface DocumentScanProbe {
+	charCodeAtVisits: number;
+	splitReceiverChars: number;
+	maxSplitResultLength: number;
+}
+
+/**
+ * #2066: count the JS full-document work one call performs — every
+ * `charCodeAt` visit, plus the receiver length and result size of every
+ * `split` over a string at least `minReceiverLength` long (shorter splits are
+ * path/URI plumbing, not document passes). Patched onto `String.prototype`
+ * because the code under test walks a plain string: there is no seam to
+ * inject, and a count is the only instrument that distinguishes one pass from
+ * three without measuring wall time.
+ */
+async function measureDocumentScans(
+	minReceiverLength: number,
+	run: () => Promise<void>,
+): Promise<DocumentScanProbe> {
+	const realCharCodeAt = String.prototype.charCodeAt;
+	// Pinned to the string/RegExp overload; `.call` on the raw method resolves
+	// to the `Symbol.split` one instead.
+	const realSplit: (
+		this: string,
+		separator: string | RegExp,
+		limit?: number,
+	) => string[] = String.prototype.split;
+	const probe: DocumentScanProbe = {
+		charCodeAtVisits: 0,
+		splitReceiverChars: 0,
+		maxSplitResultLength: 0,
+	};
+	const install = (name: string, value: unknown) => {
+		Object.defineProperty(String.prototype, name, {
+			value,
+			configurable: true,
+			writable: true,
+		});
+	};
+	install("charCodeAt", function (this: string, index: number): number {
+		probe.charCodeAtVisits++;
+		return realCharCodeAt.call(this, index);
+	});
+	install(
+		"split",
+		function (
+			this: string,
+			separator: string | RegExp,
+			limit?: number,
+		): string[] {
+			const result = realSplit.call(this, separator, limit);
+			if (this.length >= minReceiverLength) {
+				probe.splitReceiverChars += this.length;
+				probe.maxSplitResultLength = Math.max(
+					probe.maxSplitResultLength,
+					result.length,
+				);
+			}
+			return result;
+		},
+	);
+	try {
+		await run();
+	} finally {
+		install("charCodeAt", realCharCodeAt);
+		install("split", realSplit);
+	}
+	return probe;
+}
+
+// #2066: a send used to walk the whole document three times — the #1095
+// sha256 (kept), a `charCodeAt` loop counting `\n` for `contentLineCount`,
+// and a `.split(/\r\n|\r|\n/)` that materialized every line to read the last
+// one. The last two folded into a single scan whose result rides on the
+// `documentContentHashes` entry. These pin what must not move: the range on
+// the wire, and the number of JS passes that produce it.
+describe("#2066 one JS document pass per send", () => {
+	interface RangeCase {
+		name: string;
+		previous: string;
+		encoding: PositionEncoding;
+		end: { line: number; character: number };
+	}
+
+	// Every case's expectation is the value the pre-fix `.split` produced for
+	// the same input, so the table is a parity contract, not a re-derivation.
+	const RANGE_CASES: RangeCase[] = [
+		{
+			name: "LF terminators",
+			previous: "const x = 1;\nconst y = 1;",
+			encoding: "utf-16",
+			end: { line: 1, character: 12 },
+		},
+		{
+			name: "CRLF terminators (one terminator, not two)",
+			previous: "const x = 1;\r\nconst y = 1;",
+			encoding: "utf-16",
+			end: { line: 1, character: 12 },
+		},
+		{
+			name: "lone-CR terminators",
+			previous: "const x = 1;\rconst y = 1;",
+			encoding: "utf-16",
+			end: { line: 1, character: 12 },
+		},
+		{
+			name: "mixed terminators ending in one",
+			previous: "a\r\nb\rc\n",
+			encoding: "utf-16",
+			end: { line: 3, character: 0 },
+		},
+		{
+			name: "a single unterminated line",
+			previous: "const x = 1;",
+			encoding: "utf-16",
+			end: { line: 0, character: 12 },
+		},
+		{
+			name: "an empty previous document",
+			previous: "",
+			encoding: "utf-16",
+			end: { line: 0, character: 0 },
+		},
+		{
+			name: "utf-8 encoding with a 2-byte glyph on the last line",
+			previous: "a\nconst é = 1;",
+			encoding: "utf-8",
+			end: { line: 1, character: 13 },
+		},
+		{
+			name: "utf-8 encoding with an astral glyph after a CRLF",
+			previous: 'a\r\nx = "🙂";',
+			encoding: "utf-8",
+			end: { line: 1, character: 11 },
+		},
+		{
+			name: "utf-32 encoding with an astral glyph after a lone CR",
+			previous: 'a\rx = "🙂";',
+			encoding: "utf-32",
+			end: { line: 1, character: 8 },
+		},
+	];
+
+	const NEXT_CONTENT = "replacement";
+
+	/** The entry hand-seeded by a test double: text, no carried scan. */
+	async function rangeFromSeededEntry(
+		testCase: RangeCase,
+	): Promise<unknown | undefined> {
+		const state = createMockState({
+			syncKind: 2,
+			positionEncoding: testCase.encoding,
+		});
+		state.openDocuments.add(TEST_KEY);
+		state.documentVersions.set(TEST_KEY, 0);
+		state.documentContentHashes.set(TEST_KEY, {
+			version: 0,
+			hash: "irrelevant",
+			text: testCase.previous,
+		});
+		await handleNotifyChange(state, TEST_FILE, NEXT_CONTENT);
+		return lastDidChangeParams(state).contentChanges[0].range;
+	}
+
+	/** The entry a REAL previous send wrote, carrying its own scan. */
+	async function rangeFromPreviousSend(
+		testCase: RangeCase,
+	): Promise<unknown | undefined> {
+		const state = createMockState({
+			syncKind: 2,
+			positionEncoding: testCase.encoding,
+		});
+		// First call takes the not-yet-open fallback didOpen, which records the
+		// content exactly as production's own first send does.
+		await handleNotifyChange(state, TEST_FILE, testCase.previous);
+		await handleNotifyChange(state, TEST_FILE, NEXT_CONTENT);
+		return lastDidChangeParams(state).contentChanges[0].range;
+	}
+
+	for (const testCase of RANGE_CASES) {
+		it(`sends the same range for ${testCase.name}, carried or recomputed`, async () => {
+			const seeded = await rangeFromSeededEntry(testCase);
+			expect(seeded).toEqual({
+				start: { line: 0, character: 0 },
+				end: testCase.end,
+			});
+			// An entry with text but no carried scan (any test double, and any
+			// future writer that isn't `recordSentContent`) must resolve through
+			// the SAME scanner, not a second convention that drifts from it.
+			expect(await rangeFromPreviousSend(testCase)).toEqual(seeded);
+		});
+	}
+
+	it("carries the last-line position only for as long as it carries the text", async () => {
+		const state = createMockState({ syncKind: 2 });
+		const paths = Array.from(
+			{ length: MAX_INCREMENTAL_TEXT_RETAINED_ENTRIES + 1 },
+			(_, index) => `/project/carried-${index}.ts`,
+		);
+		for (const filePath of paths) {
+			state.openDocuments.add(normalizeMapKey(filePath));
+			await handleNotifyChange(state, filePath, "a\r\nb\n");
+		}
+
+		const newest = state.documentContentHashes.get(
+			normalizeMapKey(paths[paths.length - 1]),
+		);
+		expect(newest?.text).toBe("a\r\nb\n");
+		expect(newest?.lastLine).toEqual({ index: 2, start: 5 });
+		// The oldest path is one past the entry cap, so its text was stripped.
+		// The position describes text that is gone — it must go with it, or the
+		// next send for that path would compute a range against nothing.
+		const evicted = state.documentContentHashes.get(normalizeMapKey(paths[0]));
+		expect(evicted?.text).toBeUndefined();
+		expect(evicted?.lastLine).toBeUndefined();
+	});
+
+	it("walks the document once per didChange, not twice, and builds no per-line array", async () => {
+		const previous =
+			"const value = 1; // padding for a realistic line\n".repeat(4000);
+		const next = `${previous}const tail = 2;\n`;
+		const state = createMockState({ syncKind: 2 });
+		await handleNotifyChange(state, TEST_FILE, previous);
+
+		const probe = await measureDocumentScans(1024, async () => {
+			await handleNotifyChange(state, TEST_FILE, next);
+		});
+
+		// Positive control: the instrument really did observe the one scan.
+		// Without it every bound below passes for free on a no-op.
+		expect(probe.charCodeAtVisits).toBeGreaterThanOrEqual(next.length);
+		// Characters visited by JS, in units of the document. The sha256 (#1095)
+		// is native and outside this count by design. Pre-fix: 2 (newline loop +
+		// regex split). Post-fix: 1.
+		const documentPasses =
+			(probe.charCodeAtVisits + probe.splitReceiverChars) / next.length;
+		expect(documentPasses).toBeLessThan(1.5);
+		// Pre-fix this was one substring per line to read a single line's text.
+		expect(probe.maxSplitResultLength).toBeLessThanOrEqual(1);
 	});
 });
 


### PR DESCRIPTION
## Summary

Per-send LSP document sync made two full-document JavaScript walks that one pass can serve: `recordSentContent`'s LF newline count (a telemetry field) and `buildContentChanges`'s `/\r\n|\r|\n/` split allocated per line to read only the last one. A new `scanSentContent()` makes one `charCodeAt` walk producing both derived values, carried on the existing `documentContentHashes` entry beside `text`; `buildContentChanges` uses the carried last-line index+start plus a slice, with a recompute path through the same scanner for entries that carry text without a position. Eviction drops the position with the text it describes.

Non-obvious constraints kept: `contentLineCount` stays LF-only (it pairs with `diagnostic_past_eof`'s LF-byte gate), while the change range counts all three terminators; the two conventions diverge by design on lone-CR documents and a test now pins that. The `text` ⟺ `lastLine` invariant is enforced by the eviction test rather than a discriminated union: making it structural forces `lastLine` into the hand-seeded test entries that exist precisely to prove the recompute fallback matches the carried path.

Refs #2066 — AC1, AC3, and AC4 are met. The remainder is AC2's literal "one pass total": the #1095 sha256 content binding is a second, native full-document pass and still runs on every send; folding the scan into it means touching the content-binding contract, deliberately out of scope. Issue comment naming the remainder to follow.

## Type of change

- [x] Enhancement (improvement to existing capability)

## Area

- [x] area:lsp
- [x] area:perf

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds
- [x] `package-lock.json` is in sync with `package.json`
- [ ] `AGENTS.md` — no documented behavior, command, convention, or invariant changes
- [x] `.changelog/fix-2066-single-pass-document-sync.md` has one valid entry
- [x] Commit subject includes the issue number: `(refs #2066)`

## Tests

New, in `tests/clients/lsp/refresh-and-sync-kind.test.ts`:
- 9-case range-parity table (`\n`, `\r\n`, lone `\r`, mixed, single-line, empty, utf-8 2-byte, utf-8 astral after CRLF, utf-32 astral after lone CR), each asserted through the carried path AND the recompute path, pinning that both agree with the old split's ranges including the encoding-converted end character. Deliberately green pre-fix (AC1: reverting to `.split` must keep it green).
- Pass-count test (loose-bound screen, bounded tight): instruments `String.prototype.charCodeAt` visits and asserts < 1.5 full-document JS passes per didChange plus zero per-line arrays. Red pre-fix:

```
AssertionError: expected 1.9999183740102848 to be less than 1.5
AssertionError: expected 4001 to be less than or equal to 1
```

- Carried-field lifetime test (eviction strips `lastLine` with `text`; next send re-arms). Red pre-fix: `expected undefined to deeply equal { index: 2, start: 5 }`.

Edited, `tests/clients/lsp/client-internals.test.ts`: adds the previously missing CRLF `contentLineCount` case and a lone-CR pin of the LF-count vs range-line-count divergence.

Mutation proofs (all red): revert to `.split`; reintroduce a separate LF loop; drop the CRLF lookahead (4 tests); make eviction retain `lastLine`; neuter the recompute fallback (9 tests). Independent review additionally brute-forced all 364 strings over `{a, \r, \n}` up to length 5 plus 120 random mixed/astral docs through both paths against the pre-fix algorithm: zero divergence.

Totals: `tests/clients/lsp/` whole directory 1124 passed / 10 skipped (110 files), integration suite with real servers 37 passed, `tests/config` 30 passed.

## Blast radius

One production module: `clients/lsp/client.ts` (`recordSentContent`, `buildContentChanges`, the `documentContentHashes` entry shape). Consumers are the didOpen/didChange notify paths only; the #1095 hash pass and its consumers (`read-guard.ts`, `tools/lens-diagnostics.ts`, `tools/lsp-diagnostics.ts`) are untouched. Hot-path cost, measured through the compiled runtime: JS full-document passes per didChange 1.9999 → 1.0000; per-send median on a 400 KiB / ~8,500-line document −9% (0.751 → 0.686 ms), 200 KiB −7%, CRLF 400 KiB −2%; substring allocations 8,501 → 0 per didChange. didOpen never built ranged changes: 1 pass before and after, wall time within run-to-run spread (0.776-0.781 vs 0.790-0.825 ms min-of-5). Measurement note: a single-process multi-size benchmark shows a phantom 22% regression from heap/JIT contamination; per-process runs and `--cpu-prof` both dispel it.

## Observability

`lsp_document_send` in `~/.pi-lens/latency.log` carries `contentLength` and `contentLineCount` and proves the field stays correct in production; `loop_block` in the same file catches any regression large enough to stall the loop. No per-send CPU record exists or is added; the pass-count assertions are the durable guard (per the issue's own observability section).

## Class sweep

Defect class: O(document) work per edit where O(delta) or a single pass suffices (#1740 / #2016 family; this issue is the #2066 member). Tree-wide sweep of full-document `.split(/\r\n|\r|\n/)` and per-send scan sites across `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`: the two members fixed here were the only ones on the per-send path. One remaining family member found and left deliberately: `lineTextAt` in `clients/lsp/position-encoding.ts:64-70` full-splits to read one line, on diagnostic-conversion call sites, not the per-send path; needs its own issue rather than a ride-along. Consolidation verdict: terminator semantics now live in exactly one function (`scanSentContent`), which is the seam the family folds onto for this path.