### PR TITLE
perf(review-graph): incremental rebuild (refs #2074)

### DIFF
--- a/.changelog/perf-2074-incremental-graph-rebuild.md
+++ b/.changelog/perf-2074-incremental-graph-rebuild.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Review-graph one-file rebuild (refs #2074)** — the incremental rebuild now reads the graph's own adjacency indexes instead of rescanning every edge. Restoring preserved incoming edges and reading a changed file's import targets both became bucket lookups, and the derived indexes stay live through the update instead of being rebuilt at the end. On a 1,600-file fixture a one-file rebuild drops from 48.0 ms to 33.6 ms median, with edge-metadata comparisons down from 9,600 to 4 and edge visits down from 19,200 to 8. The same fix makes `existedBefore` report the truth, which unblocks reverse-dependency index reuse on every incremental build.

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -1375,20 +1375,55 @@ export async function getGraphSourceFiles(
 }
 
 function addNode(graph: ReviewGraph, node: ReviewGraphNode): void {
+	// #2074: keep symbolNodesByFile live here, not only in rebuildIndexes, so the
+	// incremental path can drop its terminal O(graph) reindex. Re-adding an id
+	// already in the map must not push a duplicate — rebuildIndexes starts from
+	// empty maps, so the two producers stay consistent.
+	const isNew = !graph.nodes.has(node.id);
 	graph.nodes.set(node.id, node);
 	if (node.kind === "file" && node.filePath) {
 		graph.fileNodes.set(node.filePath, node.id);
+		return;
+	}
+	if (isNew && node.kind === "symbol" && node.filePath) {
+		const ids = graph.symbolNodesByFile.get(node.filePath) ?? [];
+		ids.push(node.id);
+		graph.symbolNodesByFile.set(node.filePath, ids);
 	}
 }
 
-function addEdge(graph: ReviewGraph, edge: ReviewGraphEdge): void {
-	graph.edges.push(edge);
+function indexEdge(graph: ReviewGraph, edge: ReviewGraphEdge): void {
 	const from = graph.edgesByFrom.get(edge.from) ?? [];
 	from.push(edge);
 	graph.edgesByFrom.set(edge.from, from);
 	const to = graph.edgesByTo.get(edge.to) ?? [];
 	to.push(edge);
 	graph.edgesByTo.set(edge.to, to);
+}
+
+/**
+ * Drop `edge` from both adjacency buckets (#2074). Costs one scan of the two
+ * buckets the edge belongs to, never a scan of `graph.edges`, so removing a
+ * changed file's edges stays proportional to that file's fan-in/fan-out.
+ */
+function unindexEdge(graph: ReviewGraph, edge: ReviewGraphEdge): void {
+	const from = graph.edgesByFrom.get(edge.from);
+	if (from) {
+		const at = from.indexOf(edge);
+		if (at >= 0) from.splice(at, 1);
+		if (from.length === 0) graph.edgesByFrom.delete(edge.from);
+	}
+	const to = graph.edgesByTo.get(edge.to);
+	if (to) {
+		const at = to.indexOf(edge);
+		if (at >= 0) to.splice(at, 1);
+		if (to.length === 0) graph.edgesByTo.delete(edge.to);
+	}
+}
+
+function addEdge(graph: ReviewGraph, edge: ReviewGraphEdge): void {
+	graph.edges.push(edge);
+	indexEdge(graph, edge);
 }
 
 function rebuildIndexes(graph: ReviewGraph): void {
@@ -4157,19 +4192,44 @@ function removeFileOwnedGraphData(
 	if (graph.nodes.has(fileNodeId)) removedIds.add(fileNodeId);
 
 	const preservedIncomingSymbolEdges: ReviewGraphEdge[] = [];
+	const droppedEdges: ReviewGraphEdge[] = [];
 	graph.edges = graph.edges.filter((edge) => {
 		const fromRemoved = removedIds.has(edge.from);
 		const toRemoved = removedIds.has(edge.to);
-		if (fromRemoved) return false;
+		if (fromRemoved) {
+			droppedEdges.push(edge);
+			return false;
+		}
 		if (removedSymbolIds.has(edge.to)) {
 			preservedIncomingSymbolEdges.push({ ...edge });
+			droppedEdges.push(edge);
 			return false;
 		}
 		// Preserve importer edges to the stable file node id; the node is re-added below.
 		if (toRemoved && edge.to === fileNodeId) return true;
+		if (toRemoved) droppedEdges.push(edge);
 		return !toRemoved;
 	});
-	for (const id of removedIds) graph.nodes.delete(id);
+	// #2074: keep the adjacency indexes live instead of rebuilding them over the
+	// whole graph afterwards. Only the dropped edges' own buckets are touched.
+	// Unconditional: on an unindexed graph every bucket lookup simply misses.
+	for (const edge of droppedEdges) unindexEdge(graph, edge);
+	for (const id of removedIds) {
+		const node = graph.nodes.get(id);
+		graph.nodes.delete(id);
+		if (!node?.filePath) continue;
+		if (node.kind === "file") {
+			if (graph.fileNodes.get(node.filePath) === id) {
+				graph.fileNodes.delete(node.filePath);
+			}
+		} else if (node.kind === "symbol") {
+			const ids = graph.symbolNodesByFile.get(node.filePath);
+			if (!ids) continue;
+			const at = ids.indexOf(id);
+			if (at >= 0) ids.splice(at, 1);
+			if (ids.length === 0) graph.symbolNodesByFile.delete(node.filePath);
+		}
+	}
 	return preservedIncomingSymbolEdges;
 }
 
@@ -4272,22 +4332,63 @@ async function addFileToGraph(
 	}
 }
 
+/**
+ * #2074 acceptance instrumentation. `restoreComparisons` counts edge-metadata
+ * stringifications inside `restoreValidIncomingEdges`; `importTargetEdgeScans`
+ * counts edges visited by `importTargetsForFile`. Before this change both grew
+ * with the whole graph on every one-file rebuild. They are the count-based
+ * signal the issue asks for, because wall time on this hardware is IO-noisy
+ * (#1920).
+ */
+const _rebuildCounters = { restoreComparisons: 0, importTargetEdgeScans: 0 };
+
+export function _getReviewGraphRebuildCountersForTests(): {
+	restoreComparisons: number;
+	importTargetEdgeScans: number;
+} {
+	return { ..._rebuildCounters };
+}
+
+export function _resetReviewGraphRebuildCountersForTests(): void {
+	_rebuildCounters.restoreComparisons = 0;
+	_rebuildCounters.importTargetEdgeScans = 0;
+}
+
+/**
+ * Identity of an edge for dedupe purposes, WITHIN one target bucket: the array
+ * form needs no separator sentinel and cannot collide across fields.
+ */
+function edgeIdentityKey(edge: ReviewGraphEdge): string {
+	_rebuildCounters.restoreComparisons++;
+	return JSON.stringify([edge.from, edge.kind, edge.metadata ?? {}]);
+}
+
 function restoreValidIncomingEdges(
 	graph: ReviewGraph,
 	edges: ReviewGraphEdge[],
 ): void {
-	const existing = new Set(
-		graph.edges.map(
-			(edge) =>
-				`${edge.from}\u0000${edge.to}\u0000${edge.kind}\u0000${JSON.stringify(edge.metadata ?? {})}`,
-		),
-	);
+	// #2074: dedupe per TARGET, using `edgesByTo`, instead of building a key set
+	// over every edge in the graph. Preserved incoming edges point at symbols of
+	// the files just re-extracted, and `removeFileOwnedGraphData` has already
+	// dropped those symbols' incoming edges, so each bucket read here is tiny.
+	// The per-target `Set` keeps the restore linear even when one changed file is
+	// a hub with thousands of preserved incoming edges — scanning the bucket per
+	// edge instead would be quadratic in that fan-in.
+	const seenByTarget = new Map<string, Set<string>>();
 	for (const edge of edges) {
 		if (!graph.nodes.has(edge.from) || !graph.nodes.has(edge.to)) continue;
-		const key = `${edge.from}\u0000${edge.to}\u0000${edge.kind}\u0000${JSON.stringify(edge.metadata ?? {})}`;
-		if (existing.has(key)) continue;
-		graph.edges.push(edge);
-		existing.add(key);
+		let seen = seenByTarget.get(edge.to);
+		if (!seen) {
+			seen = new Set<string>();
+			for (const candidate of graph.edgesByTo.get(edge.to) ?? []) {
+				seen.add(edgeIdentityKey(candidate));
+			}
+			seenByTarget.set(edge.to, seen);
+		}
+		const key = edgeIdentityKey(edge);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		addEdge(graph, edge);
 	}
 }
 
@@ -4322,10 +4423,12 @@ function importTargetsForFile(graph: ReviewGraph, filePath: string): string[] {
 	const normalized = normalizeMapKey(filePath);
 	const fileNodeId = graph.fileNodes.get(normalized) ?? `file:${normalized}`;
 	const targets = new Set<string>();
-	// Cached graph snapshots intentionally omit derived indexes; read the
-	// canonical edge collection so the delta is correct before the first rebuild.
-	for (const edge of graph.edges) {
-		if (edge.from !== fileNodeId) continue;
+	// #2074: read this file's own out-edges from `edgesByFrom` rather than
+	// scanning every edge in the graph. The only caller, `updateGraphFiles`,
+	// indexes the graph before its first call and keeps the indexes live for the
+	// rest of the update, so the bucket is always authoritative here.
+	for (const edge of graph.edgesByFrom.get(fileNodeId) ?? []) {
+		_rebuildCounters.importTargetEdgeScans++;
 		if (edge.kind !== "imports") continue;
 		const target = graph.nodes.get(edge.to)?.filePath;
 		if (target) targets.add(normalizeMapKey(target));
@@ -4340,6 +4443,17 @@ async function updateGraphFiles(
 	facts: FactStore,
 	ignoredIds?: ReadonlySet<string>,
 ): Promise<GraphFileImportChange[]> {
+	// #2074: index ONCE, up front, then keep the indexes live through the update.
+	// This is the same single O(graph) pass the terminal `rebuildIndexes` used to
+	// cost, moved to the front, and it buys three things: the two
+	// `importTargetsForFile` calls per changed file become bucket lookups,
+	// `restoreValidIncomingEdges` dedupes against a fan-in bucket instead of the
+	// whole edge list, and `existedBefore` finally reads a POPULATED `fileNodes`.
+	// `cloneGraph` returns empty indexes, so before this the first file's
+	// `existedBefore` was always false on every update path — which forced
+	// `importsChanged` true in `clients/dispatch/integration.ts:1077` and blocked
+	// reverse-dependency index reuse on every incremental build.
+	rebuildIndexes(graph);
 	const prior = files.map((file) => ({
 		filePath: normalizeMapKey(file),
 		existedBefore: graph.fileNodes.has(normalizeMapKey(file)),
@@ -4352,7 +4466,6 @@ async function updateGraphFiles(
 	}
 	restoreValidIncomingEdges(graph, preservedIncoming);
 	resolveDeferredSymbolEdges(graph, false);
-	rebuildIndexes(graph);
 	graph.changedSymbolsByFile.clear();
 	for (const file of files) {
 		upsertChangedSymbols(graph, facts, file);
@@ -4376,6 +4489,12 @@ function resolveDeferredSymbolEdges(graph: ReviewGraph, rebuild = true): void {
 		symbolNameToIds.set(node.symbolName, ids);
 	}
 
+	// #2074: this pass REPLACES edge objects, so the adjacency buckets that hold
+	// the old objects go stale. Callers that keep the indexes live (the
+	// incremental path, which no longer reindexes afterwards) need each
+	// replacement patched into the buckets; collect them here rather than paying
+	// a whole-graph reindex for a handful of newly resolved edges.
+	const replacements: Array<[ReviewGraphEdge, ReviewGraphEdge]> = [];
 	graph.edges = graph.edges.map((edge) => {
 		const targetNode = graph.nodes.get(edge.to);
 		if (!targetNode?.metadata?.unresolvedName) return edge;
@@ -4391,13 +4510,25 @@ function resolveDeferredSymbolEdges(graph: ReviewGraph, rebuild = true): void {
 				(id) => graph.nodes.get(id)?.filePath === importHintFile,
 			);
 			if (scoped.length === 1) {
-				return { ...edge, to: scoped[0], resolution: "import" };
+				const resolved: ReviewGraphEdge = {
+					...edge,
+					to: scoped[0],
+					resolution: "import",
+				};
+				replacements.push([edge, resolved]);
+				return resolved;
 			}
 		}
 		if (candidates.length === 1) {
 			// Exactly one same-named real symbol exists graph-wide: the bare-name
 			// match is provably unambiguous (refs #655 — resolution confidence).
-			return { ...edge, to: candidates[0], resolution: "exact" };
+			const resolved: ReviewGraphEdge = {
+				...edge,
+				to: candidates[0],
+				resolution: "exact",
+			};
+			replacements.push([edge, resolved]);
+			return resolved;
 		}
 		// 0 or 2+ candidates (and no import hint narrowed it): stays on the
 		// unresolved placeholder, resolution stays "name-only" (set at edge
@@ -4405,7 +4536,14 @@ function resolveDeferredSymbolEdges(graph: ReviewGraph, rebuild = true): void {
 		// confirmed graph node.
 		return edge;
 	});
-	if (rebuild) rebuildIndexes(graph);
+	if (rebuild) {
+		rebuildIndexes(graph);
+		return;
+	}
+	for (const [before, after] of replacements) {
+		unindexEdge(graph, before);
+		indexEdge(graph, after);
+	}
 }
 
 interface CachedGraphEntry {

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -4540,9 +4540,37 @@ function resolveDeferredSymbolEdges(graph: ReviewGraph, rebuild = true): void {
 		rebuildIndexes(graph);
 		return;
 	}
+	if (replacements.length === 0) return;
+	// Bucket ORDER is part of the contract, not just bucket membership:
+	// `resolveUsedBy` in module-report walks `edgesByTo` and truncates at a cap,
+	// so the order decides which callers a reader sees. `rebuildIndexes` orders
+	// every bucket by position in `graph.edges`, and the incremental path must
+	// match it exactly.
+	//
+	// `from` is unchanged by a resolution, so the from-bucket only needs the new
+	// object swapped in at the OLD object's position — order is preserved for
+	// free. `to` moves from the placeholder's bucket to the resolved symbol's,
+	// and appending there would put an early edge behind later ones. Rebuild
+	// exactly the affected to-buckets from `graph.edges`, which restores
+	// canonical order without touching the rest of the index.
+	const affectedTargets = new Set<string>();
 	for (const [before, after] of replacements) {
-		unindexEdge(graph, before);
-		indexEdge(graph, after);
+		const fromBucket = graph.edgesByFrom.get(before.from);
+		if (fromBucket) {
+			const at = fromBucket.indexOf(before);
+			if (at >= 0) fromBucket[at] = after;
+		}
+		affectedTargets.add(before.to);
+		affectedTargets.add(after.to);
+	}
+	for (const target of affectedTargets) graph.edgesByTo.set(target, []);
+	for (const edge of graph.edges) {
+		if (affectedTargets.has(edge.to)) graph.edgesByTo.get(edge.to)?.push(edge);
+	}
+	for (const target of affectedTargets) {
+		if (graph.edgesByTo.get(target)?.length === 0) {
+			graph.edgesByTo.delete(target);
+		}
 	}
 }
 

--- a/tests/clients/review-graph/rebuild-cost.test.ts
+++ b/tests/clients/review-graph/rebuild-cost.test.ts
@@ -333,7 +333,8 @@ describe("review-graph one-file rebuild cost (#2074)", () => {
 			// incoming edge already points at the real symbol, while the freshly
 			// extracted one points at a placeholder that resolveDeferredSymbolEdges
 			// rewrites onto that same symbol AFTER the restore has run. That
-			// duplicate is pre-existing behavior and reproduces on master.
+			// duplicate is pre-existing behavior, reproduces on master, and is
+			// tracked as #2127.
 			//
 			// The next single-file rebuild is where the dedupe branch earns its
 			// place: both copies come back as preserved incoming edges, and the
@@ -376,9 +377,9 @@ describe("review-graph one-file rebuild cost (#2074)", () => {
 				seqHint,
 			);
 			// Precondition, stated loudly on purpose: this guard's proof rests on
-			// the same-batch duplicate existing. If that pre-existing defect is
-			// fixed, this fails here rather than passing vacuously, and whoever
-			// fixes it must re-home the dedupe branch's proof.
+			// the same-batch duplicate existing. When #2127 fixes that defect, this
+			// fails here rather than passing vacuously, and whoever fixes it must
+			// re-home the dedupe branch's proof.
 			expect(duplicateEdgeCount(batched)).toBe(1);
 			expect(batched.edges.length).toBe(coldEdges + 1);
 

--- a/tests/clients/review-graph/rebuild-cost.test.ts
+++ b/tests/clients/review-graph/rebuild-cost.test.ts
@@ -146,8 +146,12 @@ describe("review-graph one-file rebuild cost (#2074)", () => {
 		"keeps rebuild work proportional to the changed file, not the graph",
 		{ timeout: 240_000 },
 		async () => {
-			const small = await warmThenRebuildOneFile(makeRing(40));
-			const large = await warmThenRebuildOneFile(makeRing(160));
+			// Ring sizes are kept as small as the 4x ratio allows: this file's peak
+			// RSS sits in the unit suite's heavy tail (tree-sitter and TS-compiler
+			// arenas, ~1.4 GB at 40/160 files), and the CI runner has been killed
+			// at exit 137 for less.
+			const small = await warmThenRebuildOneFile(makeRing(16));
+			const large = await warmThenRebuildOneFile(makeRing(64));
 
 			// Sanity: the fixture really did scale, so an O(graph) cost would show.
 			expect(large.nodes).toBeGreaterThan(small.nodes * 3);
@@ -173,11 +177,10 @@ describe("review-graph one-file rebuild cost (#2074)", () => {
 	);
 
 	it(
-		"reports existedBefore for a file already in the graph",
+		"reports existedBefore and leaves every derived index intact",
 		{ timeout: 120_000 },
 		async () => {
-			const root = makeRing(12);
-			const probe = await warmThenRebuildOneFile(root);
+			const probe = await warmThenRebuildOneFile(makeRing(10));
 			const delta = getGraphImportChanges(probe.graph);
 			expect(delta).toBeDefined();
 			const change = delta?.changes.find((entry) =>
@@ -191,14 +194,7 @@ describe("review-graph one-file rebuild cost (#2074)", () => {
 			// full reverse-deps rebuild on every incremental build.
 			expect(change?.existedBefore).toBe(true);
 			expect(change?.existsAfter).toBe(true);
-		},
-	);
 
-	it(
-		"leaves every derived index identical to a full reindex",
-		{ timeout: 120_000 },
-		async () => {
-			const probe = await warmThenRebuildOneFile(makeRing(24));
 			// Mutation guard for the incremental index maintenance that replaced the
 			// terminal rebuildIndexes: dropping unindexEdge, addNode's
 			// symbolNodesByFile upkeep, or resolveDeferredSymbolEdges' replacement
@@ -212,7 +208,7 @@ describe("review-graph one-file rebuild cost (#2074)", () => {
 		"does not duplicate preserved incoming edges across repeated rebuilds",
 		{ timeout: 120_000 },
 		async () => {
-			const root = makeRing(16);
+			const root = makeRing(10);
 			const changed = path.join(root, "src", "file0.ts");
 			let seq = 0;
 			const seqHint = {

--- a/tests/clients/review-graph/rebuild-cost.test.ts
+++ b/tests/clients/review-graph/rebuild-cost.test.ts
@@ -1,0 +1,249 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import {
+	_getReviewGraphRebuildCountersForTests,
+	_resetReviewGraphRebuildCountersForTests,
+	buildOrUpdateGraph,
+	clearGraphCache,
+	clearReviewGraphWorkspaceCache,
+	getGraphImportChanges,
+} from "../../../clients/review-graph/builder.js";
+import type { ReviewGraph } from "../../../clients/review-graph/types.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	clearReviewGraphWorkspaceCache();
+	for (const root of roots.splice(0)) removeTempDirSync(root);
+});
+
+/**
+ * A ring of `count` modules where every module imports and calls two others.
+ * Node and edge counts therefore scale linearly with `count`, while the fan-in
+ * of any single file stays at 2 — exactly the shape the #2074 acceptance
+ * criteria need to separate per-graph cost from per-changed-file cost.
+ */
+function makeRing(count: number): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-2074-"));
+	roots.push(root);
+	fs.writeFileSync(path.join(root, ".gitignore"), "node_modules/\n");
+	fs.writeFileSync(path.join(root, ".git"), "");
+	const src = path.join(root, "src");
+	fs.mkdirSync(src, { recursive: true });
+	for (let i = 0; i < count; i++) {
+		const a = (i + 1) % count;
+		const b = (i + 2) % count;
+		fs.writeFileSync(
+			path.join(src, `file${i}.ts`),
+			`import { fn${a} } from "./file${a}.js";\n` +
+				`import { fn${b} } from "./file${b}.js";\n` +
+				`export function fn${i}(): number {\n` +
+				`\treturn fn${a}() + fn${b}();\n` +
+				`}\n`,
+		);
+	}
+	return root;
+}
+
+interface RebuildProbe {
+	graph: ReviewGraph;
+	counters: { restoreComparisons: number; importTargetEdgeScans: number };
+	nodes: number;
+	edges: number;
+}
+
+/**
+ * Warm the graph, then edit ONE file and rebuild through the #451 seq fast
+ * path, counting only the rebuild's work.
+ */
+async function warmThenRebuildOneFile(root: string): Promise<RebuildProbe> {
+	const changed = path.join(root, "src", "file0.ts");
+	let seq = 0;
+	const seqHint = {
+		projectSeq: () => seq,
+		getFilesChangedSince: () => [changed],
+	};
+	await buildOrUpdateGraph(root, [changed], new FactStore(), seqHint);
+	seq++;
+	fs.appendFileSync(changed, "\nexport const marker0 = 1;\n");
+	clearGraphCache();
+	_resetReviewGraphRebuildCountersForTests();
+	const graph = await buildOrUpdateGraph(
+		root,
+		[changed],
+		new FactStore(),
+		seqHint,
+	);
+	return {
+		graph,
+		counters: _getReviewGraphRebuildCountersForTests(),
+		nodes: graph.nodes.size,
+		edges: graph.edges.length,
+	};
+}
+
+/** The indexes `rebuildIndexes` would produce for `graph`, as plain data. */
+function referenceIndexes(graph: ReviewGraph): {
+	edgesByFrom: Array<[string, number]>;
+	edgesByTo: Array<[string, number]>;
+	fileNodes: Array<[string, string]>;
+	symbolNodesByFile: Array<[string, string[]]>;
+} {
+	const edgesByFrom = new Map<string, number>();
+	const edgesByTo = new Map<string, number>();
+	const fileNodes = new Map<string, string>();
+	const symbolNodesByFile = new Map<string, string[]>();
+	for (const node of graph.nodes.values()) {
+		if (node.kind === "file" && node.filePath) {
+			fileNodes.set(node.filePath, node.id);
+		}
+		if (node.kind === "symbol" && node.filePath) {
+			const ids = symbolNodesByFile.get(node.filePath) ?? [];
+			ids.push(node.id);
+			symbolNodesByFile.set(node.filePath, ids);
+		}
+	}
+	for (const edge of graph.edges) {
+		edgesByFrom.set(edge.from, (edgesByFrom.get(edge.from) ?? 0) + 1);
+		edgesByTo.set(edge.to, (edgesByTo.get(edge.to) ?? 0) + 1);
+	}
+	const sortNum = (map: Map<string, number>): Array<[string, number]> =>
+		[...map].sort(([a], [b]) => a.localeCompare(b));
+	return {
+		edgesByFrom: sortNum(edgesByFrom),
+		edgesByTo: sortNum(edgesByTo),
+		fileNodes: [...fileNodes].sort(([a], [b]) => a.localeCompare(b)),
+		symbolNodesByFile: [...symbolNodesByFile]
+			.map(([key, ids]) => [key, [...ids].sort()] as [string, string[]])
+			.sort(([a], [b]) => a.localeCompare(b)),
+	};
+}
+
+/** The indexes actually carried by `graph`, in the same plain-data shape. */
+function liveIndexes(graph: ReviewGraph): ReturnType<typeof referenceIndexes> {
+	const counts = (map: Map<string, unknown[]>): Array<[string, number]> =>
+		[...map]
+			.filter(([, values]) => values.length > 0)
+			.map(([key, values]) => [key, values.length] as [string, number])
+			.sort(([a], [b]) => a.localeCompare(b));
+	return {
+		edgesByFrom: counts(graph.edgesByFrom),
+		edgesByTo: counts(graph.edgesByTo),
+		fileNodes: [...graph.fileNodes].sort(([a], [b]) => a.localeCompare(b)),
+		symbolNodesByFile: [...graph.symbolNodesByFile]
+			.filter(([, ids]) => ids.length > 0)
+			.map(([key, ids]) => [key, [...ids].sort()] as [string, string[]])
+			.sort(([a], [b]) => a.localeCompare(b)),
+	};
+}
+
+describe("review-graph one-file rebuild cost (#2074)", () => {
+	it(
+		"keeps rebuild work proportional to the changed file, not the graph",
+		{ timeout: 240_000 },
+		async () => {
+			const small = await warmThenRebuildOneFile(makeRing(40));
+			const large = await warmThenRebuildOneFile(makeRing(160));
+
+			// Sanity: the fixture really did scale, so an O(graph) cost would show.
+			expect(large.nodes).toBeGreaterThan(small.nodes * 3);
+			expect(large.edges).toBeGreaterThan(small.edges * 3);
+
+			// AC1a: metadata comparisons in restoreValidIncomingEdges are bounded by
+			// the preserved-incoming set of the ONE changed file, so they do not
+			// move when the graph quadruples. Before #2074 this counted one
+			// JSON.stringify per edge in the whole graph.
+			expect(large.counters.restoreComparisons).toBe(
+				small.counters.restoreComparisons,
+			);
+
+			// AC1b: importTargetsForFile reads the changed file's own edgesByFrom
+			// bucket. Before #2074 it scanned graph.edges twice per changed file.
+			expect(large.counters.importTargetEdgeScans).toBe(
+				small.counters.importTargetEdgeScans,
+			);
+			expect(large.counters.importTargetEdgeScans).toBeLessThan(
+				small.edges / 2,
+			);
+		},
+	);
+
+	it(
+		"reports existedBefore for a file already in the graph",
+		{ timeout: 120_000 },
+		async () => {
+			const root = makeRing(12);
+			const probe = await warmThenRebuildOneFile(root);
+			const delta = getGraphImportChanges(probe.graph);
+			expect(delta).toBeDefined();
+			const change = delta?.changes.find((entry) =>
+				entry.filePath.endsWith("file0.ts"),
+			);
+			expect(change).toBeDefined();
+			// updateGraphFiles used to read existedBefore off the EMPTY fileNodes map
+			// a fresh cloneGraph hands it, so a long-standing file always looked new.
+			// clients/dispatch/integration.ts:1077 reads this to decide whether the
+			// reverse-dependency index can be reused; a false negative here forces a
+			// full reverse-deps rebuild on every incremental build.
+			expect(change?.existedBefore).toBe(true);
+			expect(change?.existsAfter).toBe(true);
+		},
+	);
+
+	it(
+		"leaves every derived index identical to a full reindex",
+		{ timeout: 120_000 },
+		async () => {
+			const probe = await warmThenRebuildOneFile(makeRing(24));
+			// Mutation guard for the incremental index maintenance that replaced the
+			// terminal rebuildIndexes: dropping unindexEdge, addNode's
+			// symbolNodesByFile upkeep, or resolveDeferredSymbolEdges' replacement
+			// patching all leave the live indexes disagreeing with this reference.
+			expect(liveIndexes(probe.graph)).toEqual(referenceIndexes(probe.graph));
+			expect(probe.graph.edgesByFrom.size).toBeGreaterThan(0);
+		},
+	);
+
+	it(
+		"does not duplicate preserved incoming edges across repeated rebuilds",
+		{ timeout: 120_000 },
+		async () => {
+			const root = makeRing(16);
+			const changed = path.join(root, "src", "file0.ts");
+			let seq = 0;
+			const seqHint = {
+				projectSeq: () => seq,
+				getFilesChangedSince: () => [changed],
+			};
+			await buildOrUpdateGraph(root, [changed], new FactStore(), seqHint);
+			let previousEdges = -1;
+			for (let round = 0; round < 3; round++) {
+				seq++;
+				fs.appendFileSync(
+					changed,
+					`\nexport const marker${round} = ${round};\n`,
+				);
+				clearGraphCache();
+				const graph = await buildOrUpdateGraph(
+					root,
+					[changed],
+					new FactStore(),
+					seqHint,
+				);
+				// Mutation guard for the dedupe branch in restoreValidIncomingEdges:
+				// dropping it re-appends the preserved incoming edges every round, so
+				// the edge count climbs instead of holding steady.
+				const keys = graph.edges.map((edge) =>
+					JSON.stringify([edge.from, edge.to, edge.kind, edge.metadata ?? {}]),
+				);
+				expect(new Set(keys).size).toBe(keys.length);
+				if (previousEdges >= 0) expect(graph.edges.length).toBe(previousEdges);
+				previousEdges = graph.edges.length;
+			}
+		},
+	);
+});

--- a/tests/clients/review-graph/rebuild-cost.test.ts
+++ b/tests/clients/review-graph/rebuild-cost.test.ts
@@ -11,7 +11,10 @@ import {
 	clearReviewGraphWorkspaceCache,
 	getGraphImportChanges,
 } from "../../../clients/review-graph/builder.js";
-import type { ReviewGraph } from "../../../clients/review-graph/types.js";
+import type {
+	ReviewGraph,
+	ReviewGraphEdge,
+} from "../../../clients/review-graph/types.js";
 import { removeTempDirSync } from "../test-utils.js";
 
 const roots: string[] = [];
@@ -47,6 +50,34 @@ function makeRing(count: number): string {
 		);
 	}
 	return root;
+}
+
+/** A project with exactly the given files, ready for a seq-fast-path rebuild. */
+function makeProject(files: Record<string, string>): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-2074-"));
+	roots.push(root);
+	fs.writeFileSync(path.join(root, ".gitignore"), "node_modules/\n");
+	fs.writeFileSync(path.join(root, ".git"), "");
+	for (const [relative, body] of Object.entries(files)) {
+		const file = path.join(root, relative);
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+		fs.writeFileSync(file, body);
+	}
+	return root;
+}
+
+/** Full edge identity, including target — the dedupe key plus `to`. */
+function fullEdgeKey(edge: ReviewGraphEdge): string {
+	return JSON.stringify([edge.from, edge.to, edge.kind, edge.metadata ?? {}]);
+}
+
+function duplicateEdgeCount(graph: ReviewGraph): number {
+	const counts = new Map<string, number>();
+	for (const edge of graph.edges) {
+		const key = fullEdgeKey(edge);
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+	}
+	return [...counts.values()].filter((count) => count > 1).length;
 }
 
 interface RebuildProbe {
@@ -86,15 +117,43 @@ async function warmThenRebuildOneFile(root: string): Promise<RebuildProbe> {
 	};
 }
 
-/** The indexes `rebuildIndexes` would produce for `graph`, as plain data. */
-function referenceIndexes(graph: ReviewGraph): {
-	edgesByFrom: Array<[string, number]>;
-	edgesByTo: Array<[string, number]>;
+/**
+ * Snapshot of the four derived indexes, preserving BUCKET ORDER.
+ *
+ * Order matters, not just membership: `resolveUsedBy` in `clients/module-report.ts`
+ * walks `edgesByTo` and truncates at a cap, so bucket order decides which callers
+ * a reader is shown. `rebuildIndexes` orders every bucket by position in
+ * `graph.edges`; the incremental path must match that exactly. Comparing bucket
+ * LENGTHS only would pass on a graph whose buckets hold the right edges in the
+ * wrong order, which is the divergence this snapshot exists to catch.
+ *
+ * Edges are identified by content, not object identity, so a reference built
+ * from `graph.edges` and the live index compare equal when they agree.
+ */
+type IndexSnapshot = {
+	edgesByFrom: Array<[string, string[]]>;
+	edgesByTo: Array<[string, string[]]>;
 	fileNodes: Array<[string, string]>;
 	symbolNodesByFile: Array<[string, string[]]>;
-} {
-	const edgesByFrom = new Map<string, number>();
-	const edgesByTo = new Map<string, number>();
+};
+
+function edgeIdentity(edge: ReviewGraphEdge): string {
+	return JSON.stringify([
+		edge.from,
+		edge.to,
+		edge.kind,
+		edge.resolution ?? null,
+		edge.metadata ?? {},
+	]);
+}
+
+const byKey = <T>(entries: Array<[string, T]>): Array<[string, T]> =>
+	[...entries].sort(([a], [b]) => a.localeCompare(b));
+
+/** What `rebuildIndexes` would produce for `graph`, in `graph.edges` order. */
+function referenceIndexes(graph: ReviewGraph): IndexSnapshot {
+	const edgesByFrom = new Map<string, string[]>();
+	const edgesByTo = new Map<string, string[]>();
 	const fileNodes = new Map<string, string>();
 	const symbolNodesByFile = new Map<string, string[]>();
 	for (const node of graph.nodes.values()) {
@@ -108,36 +167,39 @@ function referenceIndexes(graph: ReviewGraph): {
 		}
 	}
 	for (const edge of graph.edges) {
-		edgesByFrom.set(edge.from, (edgesByFrom.get(edge.from) ?? 0) + 1);
-		edgesByTo.set(edge.to, (edgesByTo.get(edge.to) ?? 0) + 1);
+		const identity = edgeIdentity(edge);
+		const from = edgesByFrom.get(edge.from) ?? [];
+		from.push(identity);
+		edgesByFrom.set(edge.from, from);
+		const to = edgesByTo.get(edge.to) ?? [];
+		to.push(identity);
+		edgesByTo.set(edge.to, to);
 	}
-	const sortNum = (map: Map<string, number>): Array<[string, number]> =>
-		[...map].sort(([a], [b]) => a.localeCompare(b));
 	return {
-		edgesByFrom: sortNum(edgesByFrom),
-		edgesByTo: sortNum(edgesByTo),
-		fileNodes: [...fileNodes].sort(([a], [b]) => a.localeCompare(b)),
-		symbolNodesByFile: [...symbolNodesByFile]
-			.map(([key, ids]) => [key, [...ids].sort()] as [string, string[]])
-			.sort(([a], [b]) => a.localeCompare(b)),
+		edgesByFrom: byKey([...edgesByFrom]),
+		edgesByTo: byKey([...edgesByTo]),
+		fileNodes: byKey([...fileNodes]),
+		symbolNodesByFile: byKey([...symbolNodesByFile]),
 	};
 }
 
-/** The indexes actually carried by `graph`, in the same plain-data shape. */
-function liveIndexes(graph: ReviewGraph): ReturnType<typeof referenceIndexes> {
-	const counts = (map: Map<string, unknown[]>): Array<[string, number]> =>
-		[...map]
-			.filter(([, values]) => values.length > 0)
-			.map(([key, values]) => [key, values.length] as [string, number])
-			.sort(([a], [b]) => a.localeCompare(b));
+/** The indexes `graph` actually carries, in the same shape. */
+function liveIndexes(graph: ReviewGraph): IndexSnapshot {
+	const identities = (
+		map: Map<string, ReviewGraphEdge[]>,
+	): Array<[string, string[]]> =>
+		byKey(
+			[...map]
+				.filter(([, edges]) => edges.length > 0)
+				.map(([key, edges]) => [key, edges.map(edgeIdentity)]),
+		);
 	return {
-		edgesByFrom: counts(graph.edgesByFrom),
-		edgesByTo: counts(graph.edgesByTo),
-		fileNodes: [...graph.fileNodes].sort(([a], [b]) => a.localeCompare(b)),
-		symbolNodesByFile: [...graph.symbolNodesByFile]
-			.filter(([, ids]) => ids.length > 0)
-			.map(([key, ids]) => [key, [...ids].sort()] as [string, string[]])
-			.sort(([a], [b]) => a.localeCompare(b)),
+		edgesByFrom: identities(graph.edgesByFrom),
+		edgesByTo: identities(graph.edgesByTo),
+		fileNodes: byKey([...graph.fileNodes]),
+		symbolNodesByFile: byKey(
+			[...graph.symbolNodesByFile].filter(([, ids]) => ids.length > 0),
+		),
 	};
 }
 
@@ -201,6 +263,139 @@ describe("review-graph one-file rebuild cost (#2074)", () => {
 			// patching all leave the live indexes disagreeing with this reference.
 			expect(liveIndexes(probe.graph)).toEqual(referenceIndexes(probe.graph));
 			expect(probe.graph.edgesByFrom.size).toBeGreaterThan(0);
+		},
+	);
+
+	it(
+		"orders resolved-edge buckets the way a full reindex would",
+		{ timeout: 120_000 },
+		async () => {
+			// `aaa-caller` and `bbb-caller` call `shared()` by bare name. Two files
+			// define `shared`, so both calls stay on the unresolved placeholder and
+			// their edges sit EARLY in graph.edges. Renaming one definer makes the
+			// name unique, so resolveDeferredSymbolEdges moves those long-standing
+			// early edges into `zzz-def`'s symbol bucket, which already holds a
+			// LATER `contains` edge.
+			//
+			// Appending to the bucket puts them in the wrong order. That is
+			// observable: `resolveUsedBy` in clients/module-report.ts walks
+			// `edgesByTo` and truncates at a cap, so bucket order decides which
+			// callers a reader is shown. This assertion reds if the patch in
+			// resolveDeferredSymbolEdges goes back to unindex-then-append.
+			const root = makeProject({
+				"src/aaa-caller.ts":
+					"export function callsIt(): number {\n\treturn shared();\n}\n",
+				"src/bbb-caller.ts":
+					"export function callsItToo(): number {\n\treturn shared();\n}\n",
+				"src/mmm-dup.ts":
+					"export function shared(): number {\n\treturn 2;\n}\n",
+				"src/zzz-def.ts":
+					"export function shared(): number {\n\treturn 1;\n}\n",
+			});
+			const changed = path.join(root, "src", "mmm-dup.ts");
+			let seq = 0;
+			const seqHint = {
+				projectSeq: () => seq,
+				getFilesChangedSince: () => [changed],
+			};
+			await buildOrUpdateGraph(root, [changed], new FactStore(), seqHint);
+			seq++;
+			fs.writeFileSync(
+				changed,
+				"export function renamedAway(): number {\n\treturn 2;\n}\n",
+			);
+			clearGraphCache();
+			const graph = await buildOrUpdateGraph(
+				root,
+				[changed],
+				new FactStore(),
+				seqHint,
+			);
+
+			// Precondition: the rename really did resolve previously-ambiguous
+			// edges, so the ordering path under test actually ran.
+			const resolved = graph.edges.filter(
+				(edge) => edge.kind === "calls" && edge.resolution === "exact",
+			);
+			expect(resolved.length).toBeGreaterThan(0);
+
+			expect(liveIndexes(graph)).toEqual(referenceIndexes(graph));
+		},
+	);
+
+	it(
+		"collapses a duplicate incoming edge left by a same-batch rebuild",
+		{ timeout: 120_000 },
+		async () => {
+			// This is the fixture that actually reaches the dedupe branch in
+			// restoreValidIncomingEdges. Re-extracting two mutually-referencing
+			// files in ONE batch leaves a duplicate `calls` edge: the preserved
+			// incoming edge already points at the real symbol, while the freshly
+			// extracted one points at a placeholder that resolveDeferredSymbolEdges
+			// rewrites onto that same symbol AFTER the restore has run. That
+			// duplicate is pre-existing behavior and reproduces on master.
+			//
+			// The next single-file rebuild is where the dedupe branch earns its
+			// place: both copies come back as preserved incoming edges, and the
+			// branch collapses them. Delete `if (seen.has(key)) continue;` and this
+			// rebuild leaves the duplicate in place instead of repairing it.
+			const root = makeProject({
+				"src/a.ts":
+					'import { fnB } from "./b.js";\nexport function fnA(): number {\n\treturn fnB();\n}\n',
+				"src/b.ts":
+					'import { fnA } from "./a.js";\nexport function fnB(): number {\n\treturn fnA();\n}\n',
+			});
+			const fileA = path.join(root, "src", "a.ts");
+			const fileB = path.join(root, "src", "b.ts");
+			let seq = 0;
+			let changedNow: string[] = [fileA];
+			const seqHint = {
+				projectSeq: () => seq,
+				getFilesChangedSince: () => changedNow,
+			};
+			const cold = await buildOrUpdateGraph(
+				root,
+				changedNow,
+				new FactStore(),
+				seqHint,
+			);
+			expect(duplicateEdgeCount(cold)).toBe(0);
+			const coldEdges = cold.edges.length;
+
+			// Same-batch re-extraction of both files creates the duplicate.
+			seq++;
+			changedNow = [fileA, fileB];
+			for (const file of changedNow) {
+				fs.appendFileSync(file, "\nexport const batchMarker = 1;\n");
+			}
+			clearGraphCache();
+			const batched = await buildOrUpdateGraph(
+				root,
+				changedNow,
+				new FactStore(),
+				seqHint,
+			);
+			// Precondition, stated loudly on purpose: this guard's proof rests on
+			// the same-batch duplicate existing. If that pre-existing defect is
+			// fixed, this fails here rather than passing vacuously, and whoever
+			// fixes it must re-home the dedupe branch's proof.
+			expect(duplicateEdgeCount(batched)).toBe(1);
+			expect(batched.edges.length).toBe(coldEdges + 1);
+
+			// The single-file rebuild repairs it. This is the assertion that reds
+			// when the dedupe branch is deleted.
+			seq++;
+			changedNow = [fileA];
+			fs.appendFileSync(fileA, "\nexport const singleMarker = 2;\n");
+			clearGraphCache();
+			const repaired = await buildOrUpdateGraph(
+				root,
+				changedNow,
+				new FactStore(),
+				seqHint,
+			);
+			expect(duplicateEdgeCount(repaired)).toBe(0);
+			expect(repaired.edges.length).toBe(coldEdges);
 		},
 	);
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -133,6 +133,12 @@ const grammarHeavyInclude = [
 	// the exact #255/#902 contention shape this project exists to bound.
 	"tests/clients/tree-sitter-call-graph.test.ts",
 	"tests/clients/module-report-call-graph.test.ts",
+	// #2074: builds several synthetic TypeScript projects end-to-end through the
+	// review-graph extractor. Measured peak RSS 1,417 MB — the same class as its
+	// review-graph siblings above (1,394-1,396 MB) — and the CI unit job was
+	// killed at exit 137 the first time this file ran as a default-project
+	// co-resident.
+	"tests/clients/review-graph/rebuild-cost.test.ts",
 ];
 
 // Tier 2 fix (#902): event-loop *occupancy* guards (measureMaxSyncBlockMs —


### PR DESCRIPTION
## Summary

A one-file review-graph rebuild walked the whole graph three times before this
change. `restoreValidIncomingEdges` built a key set over every edge and called
`JSON.stringify` on every edge's metadata. `importTargetsForFile` scanned
`graph.edges` linearly, twice per changed file. `updateGraphFiles` then rebuilt
every derived index over the whole graph. The `edgesByFrom` / `edgesByTo`
adjacency indexes the graph already carries were never consulted.

The fix indexes once, at the top of `updateGraphFiles`, and keeps the indexes
live for the rest of the update:

- `restoreValidIncomingEdges` dedupes per target through `edgesByTo`, with a
  per-target `Set` so a hub file with thousands of preserved incoming edges
  stays linear instead of quadratic.
- `importTargetsForFile` reads the changed file's own `edgesByFrom` bucket.
- `removeFileOwnedGraphData` unindexes only the edges it drops and maintains
  `fileNodes` / `symbolNodesByFile`.
- `addNode` maintains `symbolNodesByFile`, which previously only
  `rebuildIndexes` produced.
- `resolveDeferredSymbolEdges` patches the buckets for the edge objects it
  replaces, instead of forcing a whole-graph reindex.
- The terminal `rebuildIndexes` in `updateGraphFiles` is gone. The single
  O(graph) index pass moved to the front of the function, so the cost is not
  duplicated.

Indexing up front also fixes a latent correctness bug. `existedBefore` read the
`fileNodes` map that `cloneGraph` deliberately hands out empty, so a file that
had been in the graph for hours always reported `existedBefore: false`. That
forces `importsChanged` true at `clients/dispatch/integration.ts:1077`, which
blocked reverse-dependency index reuse on every incremental build.

This is a constant-factor reduction, not a complexity change. It does not close
#2074 — see "What remains".

## Tests

New file: `tests/clients/review-graph/rebuild-cost.test.ts` (3 tests, after the round-2 trim below).

Two are red-first. To measure the pre-fix algorithm rather than fail on a
missing import, the pre-fix red run used `origin/master`'s `builder.ts` with
only the two counters added to the old code paths (one metadata stringification
per graph edge, one visit per graph edge). Verbatim red output:

```
 FAIL  tests/clients/review-graph/rebuild-cost.test.ts > review-graph one-file rebuild cost (#2074) > keeps rebuild work proportional to the changed file, not the graph
AssertionError: expected 960 to be 240 // Object.is equality
- Expected
+ Received
- 240
+ 960
 > tests/clients/review-graph/rebuild-cost.test.ts:164:46

 FAIL  tests/clients/review-graph/rebuild-cost.test.ts > review-graph one-file rebuild cost (#2074) > reports existedBefore for a file already in the graph
AssertionError: expected false to be true // Object.is equality
- Expected
+ Received
- true
+ false
 > tests/clients/review-graph/rebuild-cost.test.ts:196:34

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

960 vs 240 is the point: quadrupling the graph quadrupled the metadata
comparisons for the same single changed file.

Two assertions pass on pre-fix code by construction. They are mutation guards
for the new maintenance code, and I state that rather than claim them as
red-first:

- the index-identity assertion reds if
  `unindexEdge`, `addNode`'s `symbolNodesByFile` upkeep, or
  `resolveDeferredSymbolEdges`' replacement patching is removed.
- "does not duplicate preserved incoming edges across repeated rebuilds" reds if
  the dedupe branch in `restoreValidIncomingEdges` is removed.

The red run above was taken at the pre-trim shape of the file (4 tests), which
is why its counts read 960/240 and its summary reads 2 failed / 2 passed.

### Before and after

Controlled harness, same process, ring fixture where every module imports and
calls two others, median of 9 consecutive one-file rebuilds through the #451 seq
fast path, `PI_LENS_REVIEW_GRAPH_MAX_FILES=20000`.

| | files | nodes / edges | median | min-max | metadata comparisons | edge visits |
|---|---|---|---|---|---|---|
| before | 400 | 1,200 / 2,400 | 24.1 ms | 22.1-43.5 | 2,400 | 4,800 |
| before | 1,600 | 4,800 / 9,600 | 48.0 ms | 42.0-61.0 | 9,600 | 19,200 |
| after | 400 | 1,200 / 2,400 | 17.1 ms | 15.1-40.1 | 4 | 8 |
| after | 1,600 | 4,800 / 9,600 | 33.6 ms | 30.2-49.9 | 4 | 8 |

Median rebuild is 29-30% faster at both sizes. Both counters are flat across a
4x graph, which is the count-based acceptance signal the issue asks for.

Growth ratio for a 4x graph: 1.99x before, 1.96x after. The remaining growth is
the O(graph) work listed below, so the ratio barely moves. The issue's 5.4x
figure was measured before #2092 removed the realpath tax and on a different
fixture; I do not claim these numbers refute it.

### Suites run

Green: `tests/clients/review-graph/` (all 19 files), `review-graph-persist`,
`review-graph.service`, `review-graph-seq-fastpath`,
`review-graph-superseded-persist`, `review-graph-git-stamp`, `graph-cache`,
`lens-map`, `module-report`, `module-report-call-graph`,
`module-report-call-graph-identity-missing`, `module-report-revision-drift`,
`project-report`, `reverse-deps`, `reverse-deps-cache`,
`cascade-graph-occupancy`, plus the governance suites
(`bounded-telemetry-sweep`, `bus-producer-coverage`, `deps-centralization`,
`freshness-sweep`, `managed-tool-seam-coverage`, `profiling-coverage`,
`module-instance-coverage`, `sweep-floor-coverage`). Build, `oxfmt`, and
`tsc --project tsconfig.json` are clean.

`tests/clients/review-graph/incremental-equivalence.test.ts` is the strongest
canary here: it compares the live `edgesByFrom` / `edgesByTo` / `fileNodes` /
`symbolNodesByFile` of an incrementally built graph against a full rebuild over
three randomized edit sequences including adds and deletes. It passes.

One flake, disclosed: `cascade-graph-occupancy`'s "main-thread
reverse-dependency delta patch stays under the sync-block budget" failed all
three retries (420.9 ms against a 300 ms budget) inside a 10-file parallel batch
on a machine running several concurrent agents, then passed in isolation on this
branch. The assertion covers `patchReverseDependencyIndex` over a synthetic
200-entry index that never enters the review-graph builder, so this change
cannot reach it. CI is the authority.

The full suite is CI's job.

## Test assessment

One test file is touched: `tests/clients/review-graph/rebuild-cost.test.ts`
(new, 5 cases). Nothing else under `tests/` changes. `vitest.config.ts` changes
too, but it is configuration, not a test file.

What each case uniquely pins:

- "keeps rebuild work proportional to the changed file, not the graph" — the
  only count-based pin that a one-file rebuild's edge work does not scale with
  graph size. Nothing else in the corpus asserts a cost count.
- "reports existedBefore and leaves every derived index intact" — the only pin
  on `existedBefore` being true for a known file, and the only contents-and-order
  comparison of the live indexes against a full reindex.
- "orders resolved-edge buckets the way a full reindex would" — the only pin on
  `edgesByTo` bucket ORDER after a deferred-symbol resolution. This is the
  behavior `resolveUsedBy` truncates on.
- "collapses a duplicate incoming edge left by a same-batch rebuild" — the only
  pin on the dedupe branch in `restoreValidIncomingEdges`, and the only fixture
  in the corpus that reaches it.
- "does not duplicate preserved incoming edges across repeated rebuilds" — pins
  edge-count stability across successive one-file rebuilds.

Made redundant by this PR: nothing, and I checked the nearest candidate rather
than assuming. `tests/clients/review-graph/incremental-equivalence.test.ts`
compares the same four indexes, so it looks like a duplicate of the
index-identity case. It is not: its `sortedIndex` helper sorts every bucket
before comparing, so it is structurally blind to the ordering bug this PR
fixes. It also compares an incremental graph against a full rebuild over
randomized edit sequences, which the new file does not do. Both survive.

Value action already taken: round 2 merged two cases into one shared probe and
shrank the ring fixtures, cutting this file from four synthetic projects to
three, after it measured at 1,417 MB peak RSS and the CI job was OOM-killed.
The file is now in the capped `grammar-heavy` project.

## Blast radius

`updateGraphFiles` is reached from both incremental paths
(`builder.ts:4677` signature-diff, `builder.ts:4869` seq fast path). Everything
below is downstream of those.

- **Reverse-dependency reuse turns on.** This is the widening to watch. With
  `existedBefore` now true for known files, `importsChanged` at
  `clients/dispatch/integration.ts:1077` is no longer forced true, so the
  `canReuse` branch below it can fire. Reuse is still gated on delta
  contiguity and generation equality (#939), which this change does not touch.
  `reverse-deps.test.ts` and `reverse-deps-cache.test.ts` pass.
- **Every `ReviewGraph` index consumer** now reads maps maintained
  incrementally rather than rebuilt wholesale: `module-report.ts:629/687/824`,
  `project-report.ts:396/401/680`, `review-graph/query.ts:35/88/100/246/297/307`,
  `lens-engine.ts:438`, `dispatch/integration.ts:1284`, `reverse-deps.ts:115`.
  The equivalence suite is what proves those maps identical; the new
  index-identity test is the direct assertion.
- **Hot path cost.** Measured above: 24.1 to 17.1 ms and 48.0 to 33.6 ms
  median. No new allocation on the full-build path — `addNode`'s
  `symbolNodesByFile` upkeep is one array push per new symbol node, and
  `rebuildIndexes` still starts from empty maps so the two producers cannot
  double-count.
- **No new process spawns, no new IO, no new log volume.**
- The two exported `_*ForTests` counters are test-only accessors, in the same
  style as `_getReviewGraphSourcePathNormalizeCallsForTests` from #2092.

Composition with #2092 (merged, in this base): #2092 owns
`countRetainedSourceFiles` and the source-path spelling memo, both on the
persist side. This change owns the adjacency indexes on the update side. No
shared line. #2092's tests in `review-graph-persist.test.ts` and
`review-graph.service.test.ts` pass on this branch. Nothing else open touches
`clients/review-graph/`.

## Class sweep

Defect shape: **per-changed-file work implemented as a whole-graph scan while a
derived index for exactly that lookup already exists.**

Pattern sweep, whole source tree (`clients/ tools/ mcp/ index.ts`), for full
`graph.edges` traversals:

| site | verdict |
|---|---|
| `clients/review-graph/builder.ts:4196` (`removeFileOwnedGraphData` filter) | still O(graph), left deliberately — filtering an array is one pass, and the alternative is changing `edges` from an array to an adjacency-first store. Re-homed to #2074. |
| `clients/review-graph/builder.ts:4498` (`resolveDeferredSymbolEdges` map) | still O(graph), left deliberately — a newly added symbol can resolve a placeholder anywhere, and scoping it needs a name-to-placeholder index that does not exist. Re-homed to #2074. |
| `clients/review-graph/builder.ts:1444` (`rebuildIndexes`) | correct by construction. |
| `clients/review-graph/builder.ts:2918` (`pruneOrphanNonFileNodes`) | correct: one pass to build a referenced-id set, on the checkpoint-resume path only. |
| `clients/review-graph/builder.ts:5673` (call-graph projection) | whole-graph projection by design. |
| `clients/call-graph.ts:160` | different graph type, whole-graph weight aggregation by design. |
| `clients/lens-map.ts:340` | whole-graph aggregation is the job of `/lens-map`. |
| `clients/project-report.ts:267`, `:311`, `:590` | whole-project report aggregation by design. |

Second shape, from the `existedBefore` bug: **reading a field off a map that
`cloneGraph` deliberately leaves empty, before any reindex.** Every `cloneGraph`
call site checked. `builder.ts:4640`, `:4835`, `:5122`, `:5173`, `:5395` all
call `rebuildIndexes` on the next line. `builder.ts:4652` and `:5189` store the
clone into the workspace cache, where `getCachedReviewGraph`'s `ensureIndexed`
covers the read. `builder.ts:4677` and `:4869` are the two that fed
`updateGraphFiles`; both are fixed by the single up-front `rebuildIndexes`. Two
instances existed, both fixed.

Population sweep — the `ReviewGraph` derived-index family, every mutation site:

| member | site | verdict |
|---|---|---|
| `nodes`, `fileNodes`, `symbolNodesByFile` | `addNode` (`builder.ts:1377`) | fixed — now maintains `symbolNodesByFile` |
| `edges`, `edgesByFrom`, `edgesByTo` | `addEdge` (`builder.ts:1424`) | already correct |
| all | `rebuildIndexes` (`builder.ts:1430`) | correct by construction |
| `nodes` | `pruneOrphanNonFileNodes` (`builder.ts:2923`) | already correct — deletes only `filePath`-less, edge-less nodes, which appear in no index |
| `edges`, `nodes`, all indexes | `removeFileOwnedGraphData` (`builder.ts:4196`) | fixed |
| `edges`, adjacency | `resolveDeferredSymbolEdges` (`builder.ts:4498`) | fixed |
| `changedSymbolsByFile` | `upsertChangedSymbols` (`builder.ts:3312`) | already correct — direct map write, no derived index |
| all | `capGraphForPersist` | already correct — `rebuildIndexes(capped)` |

Consolidation verdict: the two remaining whole-graph scans are one seam, not
eight scattered sites. Both live in the incremental update path and both need
the same structural move (an adjacency-first edge store) to fix. Consolidating
them now would mean rewriting `ReviewGraph.edges`, which is persisted,
snapshotted, and read by nine consumer files. That is its own PR. No
consolidation in this one.

## Observability

**The record that proves this in production:** `~/.pi-lens/review-graph.log`,
phase `build_succeeded`, filtered to `mode=seq-fastpath`. The issue measured
that population at n=432, p50 213 ms and p90 6,955 ms over the last 7 days. The
same query after this ships is the field check. `~/.pi-lens/cascade.log`'s
`graph_build` phase carries the same duration on the per-edit path.

**The gap, unclosed:** that record still carries one `durationMs` and no phase
breakdown, so it cannot attribute a slow build to clone, extract, reindex, or
persist. `persist_scheduled` and `persist_succeeded` carry no `durationMs` at
all — 0 of 4,224 records. A reviewer cannot tell from logs which of the six
phases this PR moved. The issue names the fix (`build_succeeded` gains
`phases` with `walkMs` / `signatureMs` / `extractMs` / `indexMs` / `persistMs`
plus `changedFiles` and `sourceFiles`; `persist_succeeded` gains `durationMs`
and `bytes`). It is not in this PR and stays open on #2074.

The counters this PR adds (`_getReviewGraphRebuildCountersForTests`) are
test-only. They do not reach the log.

## What remains on #2074

`refs`, not `closes`. Per-criterion:

- AC1, O(changed) edges on a one-file rebuild — **met.** Metadata comparisons
  are bounded by the preserved-incoming set, and `importTargetsForFile` performs
  no full-`edges` scan.
- AC2, at most `2 x changedFiles` realpath calls from source enumeration —
  **met before this PR**, by #2092. Not re-litigated here.
- AC3, delta persist — **not started.** `persistGraph` still re-serializes and
  re-gzips the whole graph after a one-file change.
- AC4, one-file rebuild within 2x between 8,000 and 32,000 nodes — **not met.**
  Measured 1.96x for a 4x graph at 1,200 to 4,800 nodes, but the trend is still
  O(graph) and comes from work this PR did not remove.

I will comment on #2074 naming AC3, AC4, the two remaining whole-graph scans,
and the observability gap, so none of it is silently carried by another PR.
Sibling issues #2073 (idle-evict family) and #2114 (node/edge heap cost) are
separate and untouched here. #2127 (pre-existing same-batch duplicate edge) was
found during this PR's review round and is likewise separate.

*This PR is AI-generated, with the maintainer supervising the process.*

## Round 2 — CI memory kill

The first head (`2db6edc`) failed Unit tests with exit code 137: the runner
SIGKILLed `node scripts/with-memory-watch.mjs -- npm test`. No assertion failed.
`Lint & type-check` passed on the same head.

Cause, measured locally with `PI_LENS_TEST_MEM_REPORT_MB=1`: the new
`rebuild-cost.test.ts` peaks at 1,417 MB RSS. That is not an outlier for its
family — `review-graph-seq-fastpath.test.ts` peaks at 1,396 MB and
`review-graph/incremental-equivalence.test.ts` at 1,394 MB — but it adds one
more file of that class to the `default` project, which runs three workers on a
16 GB runner.

Fix on the same branch (`f52de76`):

- Added the file to `grammarHeavyInclude` in `vitest.config.ts`, the project
  that exists for exactly this (capped at `heavyMaxWorkers`, one heavy file at a
  time). This is the repo's own mechanism, not a new one.
- Shrank the fixtures: ring sizes 16/64 instead of 40/160, and the
  `existedBefore` and index-identity assertions now share one probe instead of
  building two more synthetic projects. Four tests became three; every
  assertion is retained.

`tests/config/worker-budget.test.ts` and
`tests/config/timing-sensitive-coverage.test.ts` pass with the config change.

## Round 3 — adversarial review findings

Verdict was: behavior correct under every attack, CI green, two test-strength
findings blocking under the mutation-proof rule. Both are fixed on this branch
(`cff0770`). Chasing the second one turned up a real ordering bug.

### F1 (HIGH) — the dedupe branch was reported vacuous

It is not vacuous. It was unreached by the fixtures, which is a different thing,
and I found what reaches it.

Re-extracting two mutually-referencing files in ONE batch leaves a duplicate
`calls` edge. The preserved incoming edge already points at the real symbol,
while the freshly extracted one points at a placeholder that
`resolveDeferredSymbolEdges` rewrites onto that same symbol AFTER the restore
has run. Nothing dedupes after that rewrite. This duplicate is pre-existing and
reproduces on master.

The dedupe branch earns its place on the NEXT single-file rebuild: both copies
come back as preserved incoming edges and the branch collapses them. Probe
output, instrumented build, `a.ts` and `b.ts` mutually referencing:

```
B1 mutual same-batch then single: cold edges=8 dups=0
  batch0 [src/a.ts,src/b.ts] edges=9 dups=1 dedupeHits=0
  batch1 [src/a.ts]          edges=8 dups=0 dedupeHits=1
```

With `if (seen.has(key)) continue;` deleted:

```
  batch0 [src/a.ts,src/b.ts] edges=9 dups=1 dedupeHits=0
  batch1 [src/a.ts]          edges=9 dups=1 dedupeHits=0
  batch2 [src/a.ts]          edges=9 dups=1 dedupeHits=0
```

New test "collapses a duplicate incoming edge left by a same-batch rebuild".
Red under the deletion, verbatim:

```
 FAIL  tests/clients/review-graph/rebuild-cost.test.ts > review-graph one-file rebuild cost (#2074) > collapses a duplicate incoming edge left by a same-batch rebuild
AssertionError: expected 1 to be +0 // Object.is equality
- Expected
+ Received
- 0
+ 1
 > tests/clients/review-graph/rebuild-cost.test.ts:397:41
 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

The test asserts the same-batch duplicate exists as an explicit precondition, so
if that pre-existing defect is fixed this test fails loudly there instead of
passing vacuously, and whoever fixes it must re-home this guard's proof.

### F2 (LOW as filed, HIGH once probed) — a real ordering bug

The finding was that the index-identity test compared bucket LENGTHS. Probing
the consequence showed the divergence is real, not hypothetical.

`resolveDeferredSymbolEdges` patched the index by unindexing the old edge object
and appending the new one. Appending is correct only when the resolved edge is
already last in `graph.edges`. A long-standing edge that resolves onto a symbol
whose bucket holds later edges lands behind them, where `rebuildIndexes` would
have put it first. `resolveUsedBy` in `clients/module-report.ts` walks
`edgesByTo` and truncates at a cap, so bucket order decides which callers a
reader is shown.

Reproducer: `aaa-caller.ts` and `bbb-caller.ts` call `shared()` by bare name;
two files define `shared`, so both calls stay unresolved and sit early in
`graph.edges`; renaming one definer makes the name unique. Probe under the old
append:

```
O1 ambiguity resolved by rename: edges=10 divergentBuckets=1
   key=.../src/zzz-def.ts:shared:function:1 sameSet=true
```

`sameSet=true` is the point: right contents, wrong order.

Fix: swap the new object into the from-bucket at the old object's position
(`from` never changes, so order is preserved for free), and rebuild only the
affected to-buckets from `graph.edges`. Cost is one `Set` membership test per
edge, and only when a resolution happened.

`liveIndexes` / `referenceIndexes` in the test now compare bucket CONTENTS in
order, not lengths. New test "orders resolved-edge buckets the way a full
reindex would". Red under the old append, verbatim excerpt:

```
-   ".../aaa-caller.ts:callsIt:function:1", ... "calls","exact"
-   ".../bbb-caller.ts:callsItToo:function:1", ... "calls","exact"
     "file:.../zzz-def.ts", ... "contains"
     "file:.../zzz-def.ts", ... "defines"
+   ".../aaa-caller.ts:callsIt:function:1", ... "calls","exact"
+   ".../bbb-caller.ts:callsItToo:function:1", ... "calls","exact"
 > tests/clients/review-graph/rebuild-cost.test.ts:322:31
 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

### F3 — pre-existing duplicate edge, not introduced here

The same-batch duplicate described under F1 reproduces on master and is bounded
(one extra edge, flat across repeated rebuilds). It is not a regression from
this PR, and this PR's dedupe branch is what repairs it on the next single-file
rebuild. Filed as #2127.

### Round 3 measurements

Same harness, after the F2 fix:

| | files | nodes / edges | median | metadata comparisons | edge visits |
|---|---|---|---|---|---|
| after round 3 | 400 | 1,200 / 2,400 | 13.8 ms | 4 | 8 |
| after round 3 | 1,600 | 4,800 / 9,600 | 26.3 ms | 4 | 8 |

Faster than round 1's 17.1 / 33.6 ms, but the machine was less loaded, so read
this as "the ordering fix did not regress the numbers", not as a further win.
Counters are unchanged. Growth ratio 1.91x.

### Round 3 suites

Green, run serially: all 20 `tests/clients/review-graph/` files,
`review-graph-persist`, `review-graph.service`, `review-graph-seq-fastpath`,
`review-graph-superseded-persist`, `review-graph-git-stamp`, `graph-cache`,
`module-report` (4 files), `project-report`, `reverse-deps`,
`reverse-deps-cache`, `lens-map`, `session-state-conformance`,
`worker-budget`, `timing-sensitive-coverage`. Build, `oxfmt`, `tsc` clean.

`cascade-graph-occupancy`'s reverse-dependency sync-block guard breached its
300 ms budget again under machine load. Controlled A/B, three isolated runs
each, same machine, back to back:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| this branch | pass | 393.8 / 440.9 ms, recovered on retry | pass |
| `origin/master` | pass | 359.8 / 379.0 ms, recovered on retry | pass |

Master breaches the same budget in the same run slot with the same recovery, so
this is machine contention, not a regression from this PR. The assertion covers
`patchReverseDependencyIndex` over a synthetic 200-entry index that never enters
the review-graph builder.
