### PR TITLE
fix(observability): fail loudly when the stale-open-issues scan is truncated (closes #2104)

### DIFF
--- a/.changelog/fix-2104-stale-open-issues-pagination.md
+++ b/.changelog/fix-2104-stale-open-issues-pagination.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Paginate the stale open-issue detector to exhaustion (closes #2104)** — the weekly detector scans every proven GitHub page, fails loudly when its safety bound is reached, and reports the scanned population in its comment.
+- **Fail loudly when the stale open-issues scan is truncated (closes #2104)** — the weekly detector proves exhaustion for the open-issue population, fails loudly when its safety bound is reached, and reports the scanned population. The master commit read remains a deliberately bounded recent window and reports commits beyond its detail cap.

--- a/.changelog/fix-2104-stale-open-issues-pagination.md
+++ b/.changelog/fix-2104-stale-open-issues-pagination.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Paginate the stale open-issue detector to exhaustion (closes #2104)** — the weekly detector scans every proven GitHub page, fails loudly when its safety bound is reached, and reports the scanned population in its comment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1007,8 +1007,10 @@ picks the oldest entry it returns, so the two cannot drift.
 The weekly stale-open-issue detector is detection-only: `.github/workflows/stale-open-issues.yml`
 calls `scripts/detect-stale-open-issues.mjs`, which uses the bounded GitHub REST
 fetcher seam in `scripts/lib/stale-open-issues.mjs` to inspect open issues and
-bounded `master` commit details. It comments one candidate summary on #1323 and
-writes the workflow summary; it must never close or edit detected issues.
+bounded `master` commit details. It paginates each response until an empty page
+proves exhaustion and fails loudly at the safety bound instead of interpreting a
+partial response. It comments one candidate summary on #1323 and writes the
+workflow summary; it must never close or edit detected issues.
 
 CI validates GitHub close-keyword syntax through `scripts/check-close-keywords.mjs`:
 PR bodies may not use a comma-separated close list because GitHub applies only

--- a/scripts/detect-stale-open-issues.mjs
+++ b/scripts/detect-stale-open-issues.mjs
@@ -16,7 +16,7 @@ const runUrl =
 	process.env.GITHUB_SERVER_URL && process.env.GITHUB_RUN_ID
 		? `${process.env.GITHUB_SERVER_URL}/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}`
 		: undefined;
-const { candidates, truncatedCommits, priorityCoverage } =
+const { candidates, truncatedCommits, scannedOpenItems, priorityCoverage } =
 	await detectStaleOpenIssues({
 		fetcher: defaultFetcher(token),
 		repository,
@@ -24,6 +24,7 @@ const { candidates, truncatedCommits, priorityCoverage } =
 const summary = formatSummary(candidates, {
 	runUrl,
 	truncatedCommits,
+	scannedOpenItems,
 	priorityCoverage,
 });
 console.log(summary);

--- a/scripts/lib/stale-open-issues.d.mts
+++ b/scripts/lib/stale-open-issues.d.mts
@@ -39,6 +39,7 @@ export function detectStaleOpenIssues(options: {
 }): Promise<{
 	candidates: StaleIssueCandidate[];
 	truncatedCommits: number;
+	scannedOpenItems: number;
 	priorityCoverage: PriorityCoverage;
 }>;
 export function formatSummary(
@@ -46,6 +47,7 @@ export function formatSummary(
 	options?: {
 		runUrl?: string;
 		truncatedCommits?: number;
+		scannedOpenItems?: number;
 		priorityCoverage?: PriorityCoverage;
 	},
 ): string;

--- a/scripts/lib/stale-open-issues.mjs
+++ b/scripts/lib/stale-open-issues.mjs
@@ -84,6 +84,10 @@ async function paged(fetcher, baseUrl, params = {}) {
 			throw new Error(`GitHub API returned a non-array for ${baseUrl}`);
 		values.push(...batch);
 		if (batch.length < PAGE_SIZE) break;
+		if (page === MAX_PAGES)
+			throw new Error(
+				`GitHub API pagination bound reached for ${baseUrl}; refusing to use a partial response`,
+			);
 	}
 	return values;
 }
@@ -138,6 +142,7 @@ export async function detectStaleOpenIssues({
 	return {
 		candidates,
 		truncatedCommits: Math.max(0, commits.length - MAX_COMMIT_DETAILS),
+		scannedOpenItems: openIssues.length,
 		priorityCoverage: checkPriorityCoverage(openIssues),
 	};
 }
@@ -151,7 +156,7 @@ function formatIssueLine(issue) {
 
 export function formatSummary(
 	candidates,
-	{ runUrl, truncatedCommits = 0, priorityCoverage } = {},
+	{ runUrl, truncatedCommits = 0, scannedOpenItems, priorityCoverage } = {},
 ) {
 	const lines = [
 		"<!-- pi-lens-stale-open-issue-detector -->",
@@ -160,6 +165,8 @@ export function formatSummary(
 		"Detection only: a human must verify the evidence and close or update an issue. This job never closes issues.",
 		"",
 	];
+	if (scannedOpenItems !== undefined)
+		lines.push(`Scanned population: ${scannedOpenItems} open item(s).`);
 	if (candidates.length === 0) lines.push("No candidates found.");
 	else
 		for (const { issue, evidence } of candidates)

--- a/scripts/lib/stale-open-issues.mjs
+++ b/scripts/lib/stale-open-issues.mjs
@@ -71,7 +71,12 @@ async function getJson(fetcher, url) {
 	return response.json();
 }
 
-async function paged(fetcher, baseUrl, params = {}) {
+async function paged(
+	fetcher,
+	baseUrl,
+	params = {},
+	{ exhaustive = false } = {},
+) {
 	const values = [];
 	for (let page = 1; page <= MAX_PAGES; page++) {
 		const query = new URLSearchParams({
@@ -84,7 +89,9 @@ async function paged(fetcher, baseUrl, params = {}) {
 			throw new Error(`GitHub API returned a non-array for ${baseUrl}`);
 		values.push(...batch);
 		if (batch.length < PAGE_SIZE) break;
-		if (page === MAX_PAGES)
+		// A full final page does not prove another page exists, so exhaustive
+		// callers fail conservatively at the bound instead of using partial data.
+		if (exhaustive && page === MAX_PAGES)
 			throw new Error(
 				`GitHub API pagination bound reached for ${baseUrl}; refusing to use a partial response`,
 			);
@@ -101,6 +108,7 @@ export async function detectStaleOpenIssues({
 		fetcher,
 		`https://api.github.com/repos/${repository}/issues`,
 		{ state: "open" },
+		{ exhaustive: true },
 	);
 	const issueNumbers = new Set(
 		openIssues

--- a/tests/scripts/stale-open-issues.test.ts
+++ b/tests/scripts/stale-open-issues.test.ts
@@ -61,6 +61,48 @@ describe("stale open-issue detector (#1323)", () => {
 		expect(truncatedCommits).toBe(0);
 	});
 
+	it("fails loudly instead of returning a population beyond the page bound", async () => {
+		const { fetcher } = fakeGithub({
+			"/repos/acme/repo/issues": Array.from({ length: PAGE_SIZE }, (_, i) => ({
+				number: i + 1,
+				labels: [{ name: "priority:p3" }],
+			})),
+			"/repos/acme/repo/commits": [],
+		});
+		await expect(
+			detectStaleOpenIssues({ fetcher, repository: "acme/repo" }),
+		).rejects.toThrow("refusing to use a partial response");
+	});
+
+	it("paginates the open population until GitHub returns an empty page", async () => {
+		const pages = [
+			Array.from({ length: PAGE_SIZE }, (_, i) => ({
+				number: i + 1,
+				labels: [{ name: "priority:p3" }],
+			})),
+			[{ number: PAGE_SIZE + 1, labels: [{ name: "priority:p3" }] }],
+			[],
+		];
+		const fetcher = async (url: string) => {
+			const parsed = new URL(url);
+			const page = Number(parsed.searchParams.get("page"));
+			return {
+				ok: true,
+				status: 200,
+				json: async () =>
+					parsed.pathname.endsWith("/issues") ? pages[page - 1] : [],
+			};
+		};
+		const result = await detectStaleOpenIssues({
+			fetcher,
+			repository: "acme/repo",
+		});
+		expect(result.scannedOpenItems).toBe(PAGE_SIZE + 1);
+		expect(
+			formatSummary([], { scannedOpenItems: result.scannedOpenItems }),
+		).toContain("Scanned population: 101 open item(s).");
+	});
+
 	it("ignores issues absent from the open-issue response and non-test filenames", async () => {
 		const { fetcher } = fakeGithub({
 			"/repos/acme/repo/issues": [
@@ -292,5 +334,14 @@ describe("shouldPost (#1676 fix round)", () => {
 				priorityCoverage: { zero: [], multiple: [] },
 			}),
 		).toBe(false);
+	});
+
+	it("posts when multiple priority labels exist even without zero-label gaps", () => {
+		expect(
+			shouldPost({
+				candidates: [],
+				priorityCoverage: { zero: [], multiple: [{ number: 2, title: "x" }] },
+			}),
+		).toBe(true);
 	});
 });

--- a/tests/scripts/stale-open-issues.test.ts
+++ b/tests/scripts/stale-open-issues.test.ts
@@ -174,6 +174,35 @@ describe("stale open-issue detector (#1323)", () => {
 		);
 	});
 
+	it("keeps the bounded commit window and reports truncation", async () => {
+		const pages = Array.from({ length: MAX_PAGES }, (_, pageIndex) =>
+			Array.from({ length: PAGE_SIZE }, (_, itemIndex) => ({
+				sha: `page${pageIndex}-sha${itemIndex}`,
+				commit: { message: "chore: routine" },
+			})),
+		);
+		const commits = pages.flat();
+		const fetcher = async (url: string) => {
+			const parsed = new URL(url);
+			if (parsed.pathname.endsWith("/issues"))
+				return { ok: true, status: 200, json: async () => [] };
+			if (parsed.pathname.endsWith("/commits"))
+				return {
+					ok: true,
+					status: 200,
+					json: async () => pages[Number(parsed.searchParams.get("page")) - 1],
+				};
+			return { ok: true, status: 200, json: async () => ({ files: [] }) };
+		};
+
+		const result = await detectStaleOpenIssues({
+			fetcher,
+			repository: "acme/repo",
+		});
+		expect(result.candidates).toEqual([]);
+		expect(result.truncatedCommits).toBe(commits.length - MAX_COMMIT_DETAILS);
+	});
+
 	it("keeps API work bounded and formats one detection-only summary", async () => {
 		const { fetcher, calls } = fakeGithub({
 			"/repos/acme/repo/issues": [],


### PR DESCRIPTION
## Summary

Fixes #2104 by making the stale-open-issues detector prove exhaustion for the open-issue population. If the safety bound is reached while a full page remains, the detector throws instead of interpreting a partial population. The master commit read remains a deliberately bounded recent window and reports commits beyond its detail cap.

## Tests

- `tests/scripts/stale-open-issues.test.ts`: added a page-aware regression proving three full commit pages still resolve with `truncatedCommits > 0`; retained the loud open-issue bound failure, exhaustion pagination, scanned-population, priority coverage, and `shouldPost` branch tests.
- F1 mutation red after dropping the exhaustive flag from the issues call:

  ```text
  AssertionError: promise resolved "{ candidates: [], ?(3) }" instead of rejecting

  - Expected
  + Received

  - Error {
  -   "message": "rejected promise",
  + {
  +   "candidates": [],
  +   "priorityCoverage": {
  +     "multiple": [],
  +     "zero": [],
  +   },
  +   "scannedOpenItems": 300,
  +   "truncatedCommits": 0,
  + }
  ```

- F2 mutation red after making the shared helper throw unconditionally:

  ```text
  FAIL  tests/scripts/stale-open-issues.test.ts > stale open-issue detector (#1323) > keeps the bounded commit window and reports truncation
  Error: GitHub API pagination bound reached for https://api.github.com/repos/acme/repo/commits; refusing to use a partial response
  ```

- Green targeted run: `Test Files 1 passed (1)`, `Tests 20 passed (20)`.
- `npm run build`: passed.
- `npm run lint`: passed.
- `npm run fmt -- --check`: passed on 1,348 files.
- `npm run changelog:check`: passed, 41 entries validated.
- Pre-push build and targeted test: passed.

## Test assessment

- `tests/scripts/stale-open-issues.test.ts`: uniquely pins exhaustive issue pagination, bounded commit pagination, truncation disclosure, scanned-population observability, priority coverage rendering, and both `shouldPost` OR branches. No test became redundant.

## Blast radius

- `scripts/lib/stale-open-issues.mjs`: the scheduled detector now applies exhaustive bound failure only to open issues. The master commit read keeps its bounded three-page window and disclosure.
- `scripts/detect-stale-open-issues.mjs`: consumes the existing scanned-population and truncation fields. No new network call or hot per-file path exists.
- Direct caller sweep found only the scheduled detector entry point and its test import. `module_report` with `blastRadius: true` is unavailable for these script modules in this session.

## Class sweep

This sweep covers the #2096 silent-partial shape: bounded API reads must classify truncation before interpreting results. It searched `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`, and tests for page bounds, `per_page`, `hasNextPage`, and paginated collection reads.

| Bounded read | Verdict |
| --- | --- |
| `scripts/lib/stale-open-issues.mjs` REST issue pages | Fixed here: the exhaustive issue read throws at the bound before interpreting a partial population. |
| `scripts/lib/stale-open-issues.mjs` REST master commit pages | Intentional window: stays bounded by design, limits detail inspection, and reports `truncatedCommits`. |
| `scripts/lib/merge-train-warden.mjs` GraphQL open-PR pages | Follow-up filed as #2134: `hasNextPage` at `MAX_PAGES` is not surfaced before action classification. |
| `scripts/check-pr-body.mjs` pull-request file listing | No complete-set interpretation; outside this detector family. |
| `scripts/lib/ci-failure-classifier.mjs` comment reads | Marker/idempotence support, not a complete population used for classification. |

The F1 and F2 mutations above prove the exhaustive flag and bounded-window branch are mutation-proof. At exactly 300 items, a full final REST page cannot prove exhaustion, so the exhaustive issue read fails conservatively.

## Observability

Every successful weekly comment includes `Scanned population: N open item(s)?`, making population caps visible. A bound hit fails the workflow with the pagination error in the job log, so it cannot publish a quiet partial comment. Commit truncation remains visible through the existing summary disclosure.

Consulted AGENTS.md: Issue and PR design contract, Recurring defect shapes 7 and 10, Standing invariants dispatch group, Test requirements and all ten test-authoring screens, Real-runner rule/dispatch tests, Release notes per-entry files, and commit conventions.