### PR TITLE
fix(tests): await the snapshot persist in word-index lifecycle (closes #2108)

### DIFF
--- a/tests/clients/word-index-lifecycle.test.ts
+++ b/tests/clients/word-index-lifecycle.test.ts
@@ -8,10 +8,12 @@
  * (decision 2: fold into the existing warmup, not a new mechanism).
  */
 
+import * as fs from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	loadProjectSnapshot,
 	PROJECT_SNAPSHOT_VERSION,
+	getProjectSnapshotPath,
 	saveProjectSnapshot,
 } from "../../clients/project-snapshot.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
@@ -41,6 +43,13 @@ function setStartupMode(mode: "full" | "quick"): () => void {
 		if (prev === undefined) delete process.env.PI_LENS_STARTUP_MODE;
 		else process.env.PI_LENS_STARTUP_MODE = prev;
 	};
+}
+
+async function waitForPersistedSnapshot(cwd: string): Promise<void> {
+	await vi.waitFor(
+		() => expect(fs.existsSync(getProjectSnapshotPath(cwd))).toBe(true),
+		{ timeout: 5000 },
+	);
 }
 
 function makeDeps(tmpDir: string, runtime: RuntimeCoordinator, dbg = vi.fn()) {
@@ -241,6 +250,7 @@ describe("word-index lifecycle — full mode (#348)", () => {
 			await vi.waitFor(() => expect(runtime1.wordIndex).not.toBeNull(), {
 				timeout: 5000,
 			});
+			await waitForPersistedSnapshot(env.tmpDir);
 
 			// Second run against the same cwd/seq should reuse, not rebuild.
 			const runtime2 = new RuntimeCoordinator();

--- a/tests/clients/word-index-observability.test.ts
+++ b/tests/clients/word-index-observability.test.ts
@@ -40,10 +40,6 @@ vi.mock("../../clients/project-snapshot.js", async (importOriginal) => {
 	};
 });
 
-async function flushMicrotasks(): Promise<void> {
-	for (let i = 0; i < 25; i++) await new Promise((r) => setTimeout(r, 5));
-}
-
 beforeEach(() => {
 	logSpy.mockClear();
 	failPersist.value = false;
@@ -104,7 +100,11 @@ describe("word-index observability (#958)", () => {
 			failPersist.value = true;
 			scheduleWordIndexPersist(env.tmpDir, index);
 			flushWordIndexPersistsForTests();
-			await flushMicrotasks();
+			await vi.waitFor(() =>
+				expect(
+					logSpy.mock.calls.some((c) => c[0]?.phase === "persist_failed"),
+				).toBe(true),
+			);
 
 			const persistFailed = logSpy.mock.calls.find(
 				(c) => c[0]?.phase === "persist_failed",
@@ -142,7 +142,14 @@ describe("word-index observability (#958)", () => {
 
 			scheduleWordIndexPersist(env.tmpDir, index);
 			flushWordIndexPersistsForTests();
-			await flushMicrotasks();
+			await vi.waitFor(() =>
+				expect(
+					logSpy.mock.calls.some(
+						(c) =>
+							c[0]?.phase === "persist_succeeded" && c[0]?.cwd === env.tmpDir,
+					),
+				).toBe(true),
+			);
 
 			const ok = logSpy.mock.calls.find(
 				(c) => c[0]?.phase === "persist_succeeded" && c[0]?.cwd === env.tmpDir,
@@ -182,10 +189,24 @@ describe("word-index observability (#958)", () => {
 			updateWordIndexDocument(index, { path: "a.ts", content: "beta" });
 			scheduleWordIndexPersist(env.tmpDir, index);
 			flushWordIndexPersistsForTests();
-			await flushMicrotasks();
+			await vi.waitFor(() =>
+				expect(
+					logSpy.mock.calls.filter(
+						(c) =>
+							c[0]?.phase === "persist_succeeded" && c[0]?.cwd === env.tmpDir,
+					).length,
+				).toBe(1),
+			);
 			scheduleWordIndexPersist(env.tmpDir, index);
 			flushWordIndexPersistsForTests();
-			await flushMicrotasks();
+			await vi.waitFor(() =>
+				expect(
+					logSpy.mock.calls.filter(
+						(c) =>
+							c[0]?.phase === "persist_succeeded" && c[0]?.cwd === env.tmpDir,
+					).length,
+				).toBe(2),
+			);
 			const records = logSpy.mock.calls
 				.map((call) => call[0])
 				.filter(
@@ -213,7 +234,11 @@ describe("word-index observability (#958)", () => {
 				await import("../../clients/word-index.js");
 
 			triggerBackgroundWordIndexBuild(env.tmpDir);
-			await flushMicrotasks();
+			await vi.waitFor(() =>
+				expect(
+					logSpy.mock.calls.some((c) => c[0]?.phase === "cold_build"),
+				).toBe(true),
+			);
 
 			const coldBuild = logSpy.mock.calls.find(
 				(c) => c[0]?.phase === "cold_build",


### PR DESCRIPTION
## Summary

Await the first lifecycle run's persisted snapshot before starting the fresh-snapshot reuse run. The synchronization polls the real `project-snapshot.json.gz` path, so the test no longer treats `runtime.wordIndex` construction as persistence completion.

The sibling `word-index-observability.test.ts` had the same missing-await shape: it flushed a scheduler, then slept for a fixed interval before reading persist records. Its tests now wait for the emitted `persist_failed`, `persist_succeeded`, or `cold_build` record. Production files are unchanged.

## Tests

- Controlled pre-fix evidence from issue #2108: `AssertionError: expected false to be true` on the missing `word-index: incremental` debug message after run 1. The full pre-fix family also reproduced load-sensitive assertion failures, including `AssertionError: expected false to be true`; a neighboring legacy-refresh case was selected before the low-rate snapshot-reuse case.
- Fixed snapshot-reuse test: 10 consecutive loaded runs passed. Each run co-scheduled the 22-file word-index/memory-sampler family; the target reported `1 passed`, with 21 sibling files loaded and filtered.
- Targeted lifecycle, observability, and persist suites: 14/14 passed in the focused run.
- Pre-push targeted files: 11/11 passed on the successful retry.
- `npm run build`: passed.
- `npm run lint`: passed.
- Governance suites: session-state conformance, delivery-surface ratchet, changelog guard, module-instance coverage, and timing-sensitive coverage passed. One combined run also exposed the known pre-existing neighboring lifecycle timeout; all other governance files passed.
- `npm run astgrep:self-scan`: 1,260 files, 13 rules, 0 findings.

### Test assessment

- `tests/clients/word-index-lifecycle.test.ts`: uniquely pins that a fresh-snapshot reuse assertion cannot start until the first snapshot body is persisted.
- `tests/clients/word-index-observability.test.ts`: uniquely pins durable word-index outcomes and now waits on their real emitted records; no test is removed.

## Blast radius

This is test-only. `git diff origin/master...HEAD --name-only` contains only:

- `tests/clients/word-index-lifecycle.test.ts`
- `tests/clients/word-index-observability.test.ts`

No production file, runtime path, or persistence implementation changes. The runtime and snapshot modules are exercised as real implementations; only the existing LSP host seam remains mocked for throwaway test directories.

## Class sweep

Defect class: tests waiting for an intermediate readiness signal instead of the state required by the assertion.

| Word-index test family member | Verdict |
| --- | --- |
| `word-index-lifecycle.test.ts` | Fixed: run 1 now waits for the persisted snapshot file before run 2. |
| `word-index-observability.test.ts` | Fixed: persist assertions wait for emitted outcome records instead of a fixed sleep. |
| `word-index-persist.test.ts` | Already pins the persisted file and reads its body after existence polling. |
| `word-index-incremental.test.ts`, `word-index-mtime-preserved-freshness.test.ts`, `word-index-per-edit.test.ts`, `word-index-session-refresh.test.ts`, `word-index-stat-concurrency.test.ts`, and remaining `word-index-*.test.ts` files | No matching lifecycle persist wait found; they assert index transformation, freshness, dispatch, concurrency, or direct serialization rather than a run-then-reuse persistence transition. |

The sweep covers the complete `tests/clients/word-index-*.test.ts` family plus `memory-sampler.test.ts`. The only matching missing-await shapes were the two edited files.

## Observability

The lifecycle regression is observed through the existing `word-index: incremental` debug message and the persisted snapshot body. The observability sibling is observed through the existing `persist_failed`, `persist_succeeded`, and `cold_build` records. No production telemetry or logger behavior changes.

No changelog fragment is included because this is an internal test synchronization fix with no shipped behavior change.

Closes #2108
