### PR TITLE
fix(observability): resolve metrics commit against the target file's repo (closes #2099)

### DIFF
--- a/.changelog/fix-2099-metrics-commit-repo.md
+++ b/.changelog/fix-2099-metrics-commit-repo.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- Resolve metrics commit attribution against each target file's Git repository. (closes #2099)

--- a/clients/metrics-history.ts
+++ b/clients/metrics-history.ts
@@ -71,6 +71,12 @@ function getCurrentCommit(startDir: string): string {
 	if (!isInsideGitRepo(repoStartDir)) {
 		return "unknown";
 	}
+	let spawnDir = repoStartDir;
+	while (!fs.existsSync(spawnDir)) {
+		const parent = path.dirname(spawnDir);
+		if (parent === spawnDir) return "unknown";
+		spawnDir = parent;
+	}
 
 	try {
 		// #2095: execSync inherits the child's stderr to THIS process by
@@ -84,7 +90,7 @@ function getCurrentCommit(startDir: string): string {
 			encoding: "utf-8",
 			timeout: 5000,
 			stdio: ["ignore", "pipe", "ignore"],
-			cwd: repoStartDir,
+			cwd: spawnDir,
 		}).trim();
 	} catch {
 		return "unknown";

--- a/clients/metrics-history.ts
+++ b/clients/metrics-history.ts
@@ -66,8 +66,9 @@ function isInsideGitRepo(startDir: string): boolean {
 /**
  * Get current git commit hash (short)
  */
-function getCurrentCommit(): string {
-	if (!isInsideGitRepo(process.cwd())) {
+function getCurrentCommit(startDir: string): string {
+	const repoStartDir = path.resolve(startDir);
+	if (!isInsideGitRepo(repoStartDir)) {
 		return "unknown";
 	}
 
@@ -83,6 +84,7 @@ function getCurrentCommit(): string {
 			encoding: "utf-8",
 			timeout: 5000,
 			stdio: ["ignore", "pipe", "ignore"],
+			cwd: repoStartDir,
 		}).trim();
 	} catch {
 		return "unknown";
@@ -157,7 +159,7 @@ export function captureSnapshot(
 	}
 
 	const relativePath = path.relative(process.cwd(), filePath);
-	const commit = getCurrentCommit();
+	const commit = getCurrentCommit(path.dirname(filePath));
 
 	const snapshot: MetricSnapshot = {
 		commit,
@@ -226,7 +228,7 @@ export function captureSnapshots(
 
 	for (const file of files) {
 		const relativePath = path.relative(process.cwd(), file.filePath);
-		const commit = getCurrentCommit();
+		const commit = getCurrentCommit(path.dirname(file.filePath));
 
 		const snapshot: MetricSnapshot = {
 			commit,

--- a/tests/clients/metrics-history-stderr.test.ts
+++ b/tests/clients/metrics-history-stderr.test.ts
@@ -226,6 +226,17 @@ describe("metrics-history repository guard (#2099)", () => {
 				),
 			);
 			fixtureEnv.PI_LENS_SKIP_HOOKS = "1";
+			for (const variable of [
+				"GIT_DIR",
+				"GIT_WORK_TREE",
+				"GIT_INDEX_FILE",
+				"GIT_OBJECT_DIRECTORY",
+				"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+				"GIT_COMMON_DIR",
+				"GIT_PREFIX",
+			]) {
+				delete fixtureEnv[variable];
+			}
 			fixtureEnv.GIT_CONFIG_GLOBAL = path.join(tmp, "gitconfig");
 			fixtureEnv.GIT_CONFIG_NOSYSTEM = "1";
 			const repo = path.join(tmp, "nested-repo");
@@ -291,6 +302,17 @@ describe("metrics-history missing target directory (#2099)", () => {
 				),
 			);
 			fixtureEnv.PI_LENS_SKIP_HOOKS = "1";
+			for (const variable of [
+				"GIT_DIR",
+				"GIT_WORK_TREE",
+				"GIT_INDEX_FILE",
+				"GIT_OBJECT_DIRECTORY",
+				"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+				"GIT_COMMON_DIR",
+				"GIT_PREFIX",
+			]) {
+				delete fixtureEnv[variable];
+			}
 			fixtureEnv.GIT_CONFIG_GLOBAL = path.join(tmp, "gitconfig");
 			fixtureEnv.GIT_CONFIG_NOSYSTEM = "1";
 			const runGit = (args: string[]) =>

--- a/tests/clients/metrics-history-stderr.test.ts
+++ b/tests/clients/metrics-history-stderr.test.ts
@@ -101,3 +101,101 @@ describe("metrics-history getCurrentCommit stderr suppression (#2095)", () => {
 		},
 	);
 });
+
+describe("metrics-history per-file commit resolution (#2099)", () => {
+	it.skipIf(!hasGit())(
+		"records each target file's repository commit when cwd has another HEAD",
+		() => {
+			const tmp = fs.mkdtempSync(
+				path.join(os.tmpdir(), "pi-lens-metrics-history-repos-"),
+			);
+			const fixtureEnv: Record<string, string> = Object.fromEntries(
+				Object.entries(process.env).filter(
+					(entry): entry is [string, string] => entry[1] !== undefined,
+				),
+			);
+			fixtureEnv.PI_LENS_SKIP_HOOKS = "1";
+			for (const variable of [
+				"GIT_DIR",
+				"GIT_WORK_TREE",
+				"GIT_INDEX_FILE",
+				"GIT_OBJECT_DIRECTORY",
+				"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+				"GIT_COMMON_DIR",
+				"GIT_PREFIX",
+			]) {
+				delete fixtureEnv[variable];
+			}
+			const runGit = (cwd: string, args: string[]) =>
+				execFileSync("git", args, {
+					cwd,
+					stdio: "ignore",
+					env: fixtureEnv,
+				});
+			try {
+				const umbrella = tmp;
+				const repoA = path.join(umbrella, "service-a");
+				const repoB = path.join(umbrella, "service-b");
+				fs.mkdirSync(repoA);
+				fs.mkdirSync(repoB);
+
+				for (const repo of [umbrella, repoA, repoB]) {
+					runGit(repo, ["init", "-q"]);
+					runGit(repo, ["config", "user.email", "test@example.com"]);
+					runGit(repo, ["config", "user.name", "pi-lens test"]);
+				}
+				fs.writeFileSync(path.join(umbrella, "README.md"), "umbrella\n");
+				runGit(umbrella, ["add", "README.md"]);
+				runGit(umbrella, ["commit", "-qm", "umbrella"]);
+				fs.writeFileSync(path.join(repoA, "a.ts"), "const a = 1;\n");
+				runGit(repoA, ["add", "a.ts"]);
+				runGit(repoA, ["commit", "-qm", "service-a"]);
+				fs.writeFileSync(path.join(repoB, "b.ts"), "const b = 1;\n");
+				runGit(repoB, ["add", "b.ts"]);
+				runGit(repoB, ["commit", "-qm", "service-b"]);
+
+				const expectedA = execFileSync(
+					"git",
+					["rev-parse", "--short", "HEAD"],
+					{ cwd: repoA, encoding: "utf-8", env: fixtureEnv },
+				).trim();
+				const expectedB = execFileSync(
+					"git",
+					["rev-parse", "--short", "HEAD"],
+					{ cwd: repoB, encoding: "utf-8", env: fixtureEnv },
+				).trim();
+				const umbrellaHead = execFileSync(
+					"git",
+					["rev-parse", "--short", "HEAD"],
+					{ cwd: umbrella, encoding: "utf-8", env: fixtureEnv },
+				).trim();
+
+				const dataDir = path.join(umbrella, ".pilens-data");
+				const script = [
+					`process.chdir(${JSON.stringify(umbrella)});`,
+					`const { captureSnapshots } = require(${JSON.stringify(METRICS_HISTORY_JS)});`,
+					`const files = ${JSON.stringify([path.join(repoA, "a.ts"), path.join(repoB, "b.ts")])};`,
+					"const history = captureSnapshots(files.map((filePath) => ({ filePath, metrics: {",
+					"  maintainabilityIndex: 90, cognitiveComplexity: 1, maxNestingDepth: 1,",
+					"  linesOfCode: 10, maxCyclomatic: 1, entropy: 1,",
+					"} })));",
+					"process.stdout.write(JSON.stringify(files.map((filePath) => history.files[require('node:path').relative(process.cwd(), filePath)].latest.commit)));",
+				].join("\n");
+				const result = spawnSync(process.execPath, ["-e", script], {
+					cwd: umbrella,
+					encoding: "utf-8",
+					env: { ...fixtureEnv, PILENS_DATA_DIR: dataDir },
+				});
+
+				expect(result.error).toBeUndefined();
+				expect(result.status).toBe(0);
+				expect(JSON.parse(result.stdout)).toEqual([expectedA, expectedB]);
+				expect(expectedA).not.toBe(umbrellaHead);
+				expect(expectedB).not.toBe(umbrellaHead);
+			} finally {
+				fs.rmSync(tmp, { recursive: true, force: true });
+			}
+		},
+		30_000,
+	);
+});

--- a/tests/clients/metrics-history-stderr.test.ts
+++ b/tests/clients/metrics-history-stderr.test.ts
@@ -44,13 +44,24 @@ describe("metrics-history getCurrentCommit stderr suppression (#2095)", () => {
 			const tmp = fs.mkdtempSync(
 				path.join(os.tmpdir(), "pi-lens-metrics-history-"),
 			);
+			const fixtureEnv: Record<string, string> = Object.fromEntries(
+				Object.entries(process.env).filter(
+					(entry): entry is [string, string] => entry[1] !== undefined,
+				),
+			);
+			fixtureEnv.GIT_CONFIG_GLOBAL = path.join(tmp, "gitconfig");
+			fixtureEnv.GIT_CONFIG_NOSYSTEM = "1";
 			try {
 				// A real repo with zero commits: `git rev-parse --short HEAD`
 				// genuinely fails with "fatal: ambiguous argument 'HEAD': unknown
 				// revision or path not in the working tree." on real stderr.
 				// `stdio: "ignore"` here is the exact guard this PR is about —
 				// this setup call must not itself leak `git init`'s stderr.
-				execFileSync("git", ["init", "-q"], { cwd: tmp, stdio: "ignore" });
+				execFileSync("git", ["init", "-q"], {
+					cwd: tmp,
+					stdio: "ignore",
+					env: fixtureEnv,
+				});
 
 				const dataDir = path.join(tmp, ".pilens-data");
 				const filePath = path.join(tmp, "file.ts");
@@ -83,7 +94,7 @@ describe("metrics-history getCurrentCommit stderr suppression (#2095)", () => {
 				const result = spawnSync(process.execPath, ["-e", script], {
 					cwd: tmp,
 					encoding: "utf-8",
-					env: { ...process.env, PILENS_DATA_DIR: dataDir },
+					env: { ...fixtureEnv, PILENS_DATA_DIR: dataDir },
 				});
 
 				expect(result.error).toBeUndefined();
@@ -126,6 +137,8 @@ describe("metrics-history per-file commit resolution (#2099)", () => {
 			]) {
 				delete fixtureEnv[variable];
 			}
+			fixtureEnv.GIT_CONFIG_GLOBAL = path.join(tmp, "gitconfig");
+			fixtureEnv.GIT_CONFIG_NOSYSTEM = "1";
 			const runGit = (cwd: string, args: string[]) =>
 				execFileSync("git", args, {
 					cwd,
@@ -192,6 +205,134 @@ describe("metrics-history per-file commit resolution (#2099)", () => {
 				expect(JSON.parse(result.stdout)).toEqual([expectedA, expectedB]);
 				expect(expectedA).not.toBe(umbrellaHead);
 				expect(expectedB).not.toBe(umbrellaHead);
+			} finally {
+				fs.rmSync(tmp, { recursive: true, force: true });
+			}
+		},
+		30_000,
+	);
+});
+
+describe("metrics-history repository guard (#2099)", () => {
+	it.skipIf(!hasGit())(
+		"resolves a nested repository under a non-repository umbrella",
+		() => {
+			const tmp = fs.mkdtempSync(
+				path.join(os.tmpdir(), "pi-lens-metrics-history-nonrepo-"),
+			);
+			const fixtureEnv: Record<string, string> = Object.fromEntries(
+				Object.entries(process.env).filter(
+					(entry): entry is [string, string] => entry[1] !== undefined,
+				),
+			);
+			fixtureEnv.PI_LENS_SKIP_HOOKS = "1";
+			fixtureEnv.GIT_CONFIG_GLOBAL = path.join(tmp, "gitconfig");
+			fixtureEnv.GIT_CONFIG_NOSYSTEM = "1";
+			const repo = path.join(tmp, "nested-repo");
+			const filePath = path.join(repo, "nested.ts");
+			const runGit = (args: string[]) =>
+				execFileSync("git", args, {
+					cwd: repo,
+					stdio: "ignore",
+					env: fixtureEnv,
+				});
+			try {
+				fs.mkdirSync(repo);
+				runGit(["init", "-q"]);
+				runGit(["config", "user.email", "test@example.com"]);
+				runGit(["config", "user.name", "pi-lens test"]);
+				fs.writeFileSync(filePath, "const nested = 1;\n");
+				runGit(["add", "nested.ts"]);
+				runGit(["commit", "-qm", "nested-repo"]);
+				const expected = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+					cwd: repo,
+					encoding: "utf-8",
+					env: fixtureEnv,
+				}).trim();
+				const dataDir = path.join(tmp, ".pilens-data");
+				const script = [
+					`process.chdir(${JSON.stringify(tmp)});`,
+					`const { captureSnapshots } = require(${JSON.stringify(METRICS_HISTORY_JS)});`,
+					`const filePath = ${JSON.stringify(filePath)};`,
+					"const history = captureSnapshots([{ filePath, metrics: {",
+					"  maintainabilityIndex: 90, cognitiveComplexity: 1, maxNestingDepth: 1,",
+					"  linesOfCode: 10, maxCyclomatic: 1, entropy: 1,",
+					"} }]);",
+					"process.stdout.write(history.files[require('node:path').relative(process.cwd(), filePath)].latest.commit);",
+				].join("\n");
+				const result = spawnSync(process.execPath, ["-e", script], {
+					cwd: tmp,
+					encoding: "utf-8",
+					env: { ...fixtureEnv, PILENS_DATA_DIR: dataDir },
+				});
+
+				expect(result.error).toBeUndefined();
+				expect(result.status).toBe(0);
+				expect(result.stdout).toBe(expected);
+				expect(result.stdout).not.toBe("unknown");
+			} finally {
+				fs.rmSync(tmp, { recursive: true, force: true });
+			}
+		},
+		30_000,
+	);
+});
+
+describe("metrics-history missing target directory (#2099)", () => {
+	it.skipIf(!hasGit())(
+		"resolves a file whose directory does not exist yet",
+		() => {
+			const tmp = fs.mkdtempSync(
+				path.join(os.tmpdir(), "pi-lens-metrics-history-missing-"),
+			);
+			const fixtureEnv: Record<string, string> = Object.fromEntries(
+				Object.entries(process.env).filter(
+					(entry): entry is [string, string] => entry[1] !== undefined,
+				),
+			);
+			fixtureEnv.PI_LENS_SKIP_HOOKS = "1";
+			fixtureEnv.GIT_CONFIG_GLOBAL = path.join(tmp, "gitconfig");
+			fixtureEnv.GIT_CONFIG_NOSYSTEM = "1";
+			const runGit = (args: string[]) =>
+				execFileSync("git", args, {
+					cwd: tmp,
+					stdio: "ignore",
+					env: fixtureEnv,
+				});
+			try {
+				runGit(["init", "-q"]);
+				runGit(["config", "user.email", "test@example.com"]);
+				runGit(["config", "user.name", "pi-lens test"]);
+				fs.writeFileSync(path.join(tmp, "README.md"), "umbrella\n");
+				runGit(["add", "README.md"]);
+				runGit(["commit", "-qm", "fixture"]);
+				const expected = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+					cwd: tmp,
+					encoding: "utf-8",
+					env: fixtureEnv,
+				}).trim();
+				const filePath = path.join(tmp, "sub", "gone.ts");
+				const dataDir = path.join(tmp, ".pilens-data");
+				const script = [
+					`process.chdir(${JSON.stringify(tmp)});`,
+					`const { captureSnapshots } = require(${JSON.stringify(METRICS_HISTORY_JS)});`,
+					`const filePath = ${JSON.stringify(filePath)};`,
+					"const history = captureSnapshots([{ filePath, metrics: {",
+					"  maintainabilityIndex: 90, cognitiveComplexity: 1, maxNestingDepth: 1,",
+					"  linesOfCode: 10, maxCyclomatic: 1, entropy: 1,",
+					"} }]);",
+					"process.stdout.write(history.files[require('node:path').relative(process.cwd(), filePath)].latest.commit);",
+				].join("\n");
+				const result = spawnSync(process.execPath, ["-e", script], {
+					cwd: tmp,
+					encoding: "utf-8",
+					env: { ...fixtureEnv, PILENS_DATA_DIR: dataDir },
+				});
+
+				expect(result.error).toBeUndefined();
+				expect(result.status).toBe(0);
+				expect(result.stdout).toBe(expected);
+				expect(result.stdout).not.toBe("unknown");
 			} finally {
 				fs.rmSync(tmp, { recursive: true, force: true });
 			}


### PR DESCRIPTION
## Summary

Resolve each metrics snapshot commit from the target file's repository, including nested repositories under non-repository umbrellas and missing target directories.

The resolver keeps the original target path for repository detection, then walks to the nearest existing ancestor for the Git process cwd. Fixture Git commands use isolated global and system configuration.

## Tests

- Red-first F1 mutation: reverting `isInsideGitRepo(repoStartDir)` to `isInsideGitRepo(process.cwd())` fails the non-repository-umbrella fixture.

  ```text
  AssertionError: expected 'unknown' to be '828671e' // Object.is equality

  Expected: 828671e
  Received: unknown

   ❯ tests/clients/metrics-history-stderr.test.ts:271:27
  ```

- Red-first F2 mutation: reverting `cwd: spawnDir` to `cwd: repoStartDir` fails the missing-directory fixture.

  ```text
  AssertionError: expected 'unknown' to be '1396c83' // Object.is equality

  Expected: 1396c83
  Received: unknown

   ❯ tests/clients/metrics-history-stderr.test.ts:334:27
  ```

- Fixed targeted suite: `Test Files 1 passed (1); Tests 4 passed (4)`.
- `npm run build`: passed.
- `npm run fmt:check`: passed.

### Test assessment

- `tests/clients/metrics-history-stderr.test.ts`: preserves the real-child stderr regression for #2095, the adjacent-repository regression for #2099, and adds independent guard and missing-directory regressions. The fixtures execute real Git commands and assert real short `HEAD` values.

## Blast radius

- `clients/runtime-tool-call.ts` remains the only production consumer of `captureSnapshot()`; it calls the function once per recorded file write.
- `captureSnapshots()` serves the batch `/lens-metrics` path.
- `getCurrentCommit()` adds an `fs.existsSync` ancestor walk before its existing bounded Git spawn. The walk runs once per commit lookup and stops at the first existing ancestor.

## Class sweep

The issue identifies process-cwd-anchored Git and repository resolution as the defect class. The sweep covered `clients/`, `scripts/`, and `tests/`.

| Surface | Result | Disposition |
| --- | --- | --- |
| `clients/metrics-history.ts` | Found and fixed | Detect from the target path and spawn from its nearest existing ancestor. |
| `clients/git-tracked-ignore.ts` | Uses explicit caller/project cwd for `git ls-files` | No change. |
| `clients/opaque-mutation-scan.ts` | Uses explicit target cwd for `git rev-parse --show-toplevel` | No change. Its asynchronous contract differs from this synchronous caller. |
| Other Git command resolutions | No process-cwd-anchored target resolution found | No consolidation required. |

The guard mutation is load-bearing because the non-repository umbrella fixture reds. The cwd mutation is load-bearing because the missing-directory fixture reds.

Consolidation verdict: no shared resolver deletion is justified. The existing candidates serve different async and caching contracts, while this path requires a synchronous, bounded lookup.

## Observability

Metrics history persists the resolved commit in `metrics-history.json`. Failures retain the existing bounded `unknown` value. The stored `commit` field can be compared with the target repository's short `HEAD`.