### PR TITLE
fix(tests): await the snapshot promotion in the full-rebuilds lifecycle test (closes #2142)

### DIFF
--- a/tests/clients/word-index-lifecycle.test.ts
+++ b/tests/clients/word-index-lifecycle.test.ts
@@ -15,6 +15,7 @@ import {
 	PROJECT_SNAPSHOT_VERSION,
 	getProjectSnapshotPath,
 	saveProjectSnapshot,
+	waitForProjectSnapshotPersistsForTests,
 } from "../../clients/project-snapshot.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { handleSessionStart } from "../../clients/runtime-session.js";
@@ -35,6 +36,34 @@ vi.mock("../../clients/lsp/index.js", async (importOriginal) => ({
 		touchFile: mockTouchFile,
 	})),
 }));
+
+const deferredRuntimeSnapshotSave = vi.hoisted(() => ({
+	delayCall: undefined as number | undefined,
+	calls: 0,
+	delayMs: 1200,
+}));
+vi.mock("../../clients/project-snapshot.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../clients/project-snapshot.js")>();
+	return {
+		...actual,
+		saveRuntimeProjectSnapshot: vi.fn((args) => {
+			deferredRuntimeSnapshotSave.calls += 1;
+			if (
+				deferredRuntimeSnapshotSave.calls !==
+				deferredRuntimeSnapshotSave.delayCall
+			) {
+				actual.saveRuntimeProjectSnapshot(args);
+				return;
+			}
+			deferredRuntimeSnapshotSave.delayCall = undefined;
+			setTimeout(
+				() => actual.saveRuntimeProjectSnapshot(args),
+				deferredRuntimeSnapshotSave.delayMs,
+			).unref();
+		}),
+	};
+});
 
 function setStartupMode(mode: "full" | "quick"): () => void {
 	const prev = process.env.PI_LENS_STARTUP_MODE;
@@ -136,6 +165,8 @@ afterEach(() => {
 		__piLensFirstSessionDone?: boolean;
 		__piLensWarmupScheduled?: boolean;
 	};
+	deferredRuntimeSnapshotSave.delayCall = undefined;
+	deferredRuntimeSnapshotSave.calls = 0;
 	globals.__piLensFirstSessionDone = false;
 	globals.__piLensWarmupScheduled = false;
 });
@@ -322,6 +353,7 @@ describe("word-index lifecycle — full mode (#348)", () => {
 			const legacyRuntime = new RuntimeCoordinator();
 			legacyRuntime.resetForSession();
 			const legacyDbg = vi.fn();
+			deferredRuntimeSnapshotSave.delayCall = 2;
 			await handleSessionStart(makeDeps(env.tmpDir, legacyRuntime, legacyDbg));
 			await vi.waitFor(
 				() =>
@@ -332,6 +364,16 @@ describe("word-index lifecycle — full mode (#348)", () => {
 					).toBe(true),
 				{ timeout: 5000 },
 			);
+			await vi.waitFor(
+				() =>
+					expect(
+						legacyDbg.mock.calls.filter(([m]) =>
+							String(m).includes("project_snapshot: saved"),
+						).length,
+					).toBeGreaterThanOrEqual(2),
+				{ timeout: 5000 },
+			);
+			await waitForProjectSnapshotPersistsForTests();
 			expect(legacyRuntime.wordIndex?.docLengths.has("ghost-a.ts")).toBe(false);
 
 			// Seed a current-format index whose file set is mostly gone. The

--- a/tests/clients/word-index-lifecycle.test.ts
+++ b/tests/clients/word-index-lifecycle.test.ts
@@ -40,6 +40,7 @@ vi.mock("../../clients/lsp/index.js", async (importOriginal) => ({
 const deferredRuntimeSnapshotSave = vi.hoisted(() => ({
 	delayCall: undefined as number | undefined,
 	calls: 0,
+	wordIndexSaveCompleted: false,
 	delayMs: 1200,
 }));
 vi.mock("../../clients/project-snapshot.js", async (importOriginal) => {
@@ -48,19 +49,28 @@ vi.mock("../../clients/project-snapshot.js", async (importOriginal) => {
 	return {
 		...actual,
 		saveRuntimeProjectSnapshot: vi.fn((args) => {
+			// Replace the old ordinal assumption ("the second save is the
+			// promotion") with the free content discriminator: only a save carrying
+			// the runtime word index belongs to this forcing/barrier.
 			deferredRuntimeSnapshotSave.calls += 1;
+			const carriesWordIndex = args.runtime.wordIndex !== null;
+			if (!carriesWordIndex) {
+				actual.saveRuntimeProjectSnapshot(args);
+				return;
+			}
 			if (
 				deferredRuntimeSnapshotSave.calls !==
 				deferredRuntimeSnapshotSave.delayCall
 			) {
 				actual.saveRuntimeProjectSnapshot(args);
+				deferredRuntimeSnapshotSave.wordIndexSaveCompleted = true;
 				return;
 			}
 			deferredRuntimeSnapshotSave.delayCall = undefined;
-			setTimeout(
-				() => actual.saveRuntimeProjectSnapshot(args),
-				deferredRuntimeSnapshotSave.delayMs,
-			).unref();
+			setTimeout(() => {
+				actual.saveRuntimeProjectSnapshot(args);
+				deferredRuntimeSnapshotSave.wordIndexSaveCompleted = true;
+			}, deferredRuntimeSnapshotSave.delayMs).unref();
 		}),
 	};
 });
@@ -167,6 +177,7 @@ afterEach(() => {
 	};
 	deferredRuntimeSnapshotSave.delayCall = undefined;
 	deferredRuntimeSnapshotSave.calls = 0;
+	deferredRuntimeSnapshotSave.wordIndexSaveCompleted = false;
 	globals.__piLensFirstSessionDone = false;
 	globals.__piLensWarmupScheduled = false;
 });
@@ -365,12 +376,14 @@ describe("word-index lifecycle — full mode (#348)", () => {
 				{ timeout: 5000 },
 			);
 			await vi.waitFor(
-				() =>
+				() => {
 					expect(
 						legacyDbg.mock.calls.filter(([m]) =>
 							String(m).includes("project_snapshot: saved"),
 						).length,
-					).toBeGreaterThanOrEqual(2),
+					).toBeGreaterThanOrEqual(2);
+					expect(deferredRuntimeSnapshotSave.wordIndexSaveCompleted).toBe(true);
+				},
 				{ timeout: 5000 },
 			);
 			await waitForProjectSnapshotPersistsForTests();


### PR DESCRIPTION
## Summary

Await the first lifecycle run's asynchronous word-index snapshot promotion before reseeding the current-format snapshot for the fallback run.  The test mock defers the real `saveRuntimeProjectSnapshot` call for 1,200 ms on the word-index save. The test waits for two runtime snapshot save records and the real persist queue to drain before starting run 2.  This is test-only. Production code is unchanged.  

## Tests

- Native master flake justification for the count barrier: 2/10 forced runs reproduced the promotion race. Removing the count barrier with forcing produced 0/16 mutation reds, so the barrier is not claimed as independently mutation-proven.
- Proven guard: deleting only the persist-drain await reproduced the fallback rebuild assertion red in 2/9 forced runs: `AssertionError: expected false to be true // Object.is equality`. The content-gated forcing still targets `delayCall = 2`, and the barrier requires at least two save records plus completion of the save carrying `runtime.wordIndex`. - Fixed lifecycle test: 5/5 tests passed. - Unloaded target repetitions: 10/10 passed. - Loaded target repetitions: 5/5 passed with 21 word-index sibling files and `memory-sampler.test.ts` co-scheduled and filtered; each run reported 1 passed and 21 skipped files. - Governance suites: 6 files, 118 tests passed, including session-state conformance, delivery-surface ratchet, module-instance coverage, timing-sensitive coverage, and changelog checks. - `npm run astgrep:self-scan`: 1,264 files, 13 rules, 0 findings. - `npm run build`: passed. - `npm run lint`: passed. - `npm run fmt:check`: passed. - `npm test`: 10,050 passed, 37 skipped, 16 unrelated contention/environment failures. The changed lifecycle test passed in focused and loaded runs.  

### Test assessment

- `tests/clients/word-index-lifecycle.test.ts`: uniquely pins that a full-rebuild lifecycle test waits for the real snapshot promotion before replacing the persisted snapshot used by the next run. No test is removed.  

## Blast radius

This change is test-only. `git diff origin/master...HEAD --name-only` contains only `tests/clients/word-index-lifecycle.test.ts`. No production module, runtime path, persistence implementation, or shipped behavior changes.  The test uses the real `RuntimeCoordinator`, real `handleSessionStart`, real snapshot serialization, real snapshot persistence, and real persist queue. The existing LSP host seam remains mocked for throwaway test directories. The test-only mock wraps the real `saveRuntimeProjectSnapshot` and delays one call to make the ordering defect deterministic.  

## Class sweep

Defect class: a lifecycle test starts a reuse or fallback run before asynchronous persistence reaches the state required by the next run.  | Lifecycle test in `tests/clients/word-index-lifecycle.test.ts` | Verdict | | --- | --- | | Builds and persists when no snapshot exists yet | No run-2 reuse transition; no matching race. | | Rebuilds when the persisted snapshot's sequence is stale | Seeds before the run; no prior asynchronous save is reused. | | Reuses a fresh persisted snapshot without rebuilding | Fixed by the sibling #2138 artifact wait. | | Full-rebuilds legacy serialization and falls back after refresh refusal | Fixed here: waits for the real persist queue after the first run's save records. | | Cold-start warmup pass builds and persists the index | Quick-mode warmup path; no run-2 reseed or reuse transition. |  I reviewed every lifecycle test in this file line by line. The remaining tests do not start a second run after an asynchronous persist, so no matching member remains in this file. The broader word-index family was co-scheduled in loaded verification; this in-file member was missed by #2138's sweep.  Verdict: the file's matching async-persist lifecycle race is fully covered; no remaining in-scope member is deferred.  

## Observability

The test observes the existing `project_snapshot: saved` debug records and waits on the real project snapshot persistence queue. No production telemetry changes. The test-only delay exists solely to prove the ordering guard red-first.  Changelog: test-only; no changelog fragment is required because no shipped behavior changes.  Closes #2142
