### PR TITLE
fix(observability): classify merge-train pagination truncation loudly (closes #2134)

### DIFF
--- a/.changelog/2134-warden-pagination.md
+++ b/.changelog/2134-warden-pagination.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Classify merge-train pagination truncation (closes #2134)** — the warden reports GraphQL pull-request pagination truncation instead of treating a partial population as complete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1011,6 +1011,13 @@ bounded `master` commit details. It paginates each response until an empty page
 proves exhaustion and fails loudly at the safety bound instead of interpreting a
 partial response. It comments one candidate summary on #1323 and writes the
 workflow summary; it must never close or edit detected issues.
+The shared `paged` helper demands exhaustion by default; the intentionally
+bounded commit-detail population opts out explicitly.
+
+The merge-train warden's GraphQL PR reader follows the same bounded-read contract:
+`fetchOpenPullRequests` preserves collected pages but records a fatal list error
+when `hasNextPage` remains true at `MAX_PAGES`. Its consumer prints that error and
+sets a nonzero exit code, while deliberately bounded sibling reads remain scoped.
 
 CI validates GitHub close-keyword syntax through `scripts/check-close-keywords.mjs`:
 PR bodies may not use a comma-separated close list because GitHub applies only

--- a/scripts/lib/merge-train-warden.mjs
+++ b/scripts/lib/merge-train-warden.mjs
@@ -157,6 +157,12 @@ export async function fetchOpenPullRequests(fetcher, owner, name) {
 		if (!connection || !Array.isArray(connection.nodes)) break;
 		for (const node of connection.nodes) prs.push(normalizePr(node));
 		if (!connection.pageInfo?.hasNextPage) break;
+		if (page === MAX_PAGES - 1) {
+			errors.push(
+				`GraphQL pagination truncated after ${MAX_PAGES} pages while hasNextPage=true`,
+			);
+			break;
+		}
 		after = connection.pageInfo.endCursor;
 	}
 	return { prs, errors };

--- a/scripts/lib/stale-open-issues.mjs
+++ b/scripts/lib/stale-open-issues.mjs
@@ -75,7 +75,7 @@ async function paged(
 	fetcher,
 	baseUrl,
 	params = {},
-	{ exhaustive = false } = {},
+	{ exhaustive = true } = {},
 ) {
 	const values = [];
 	for (let page = 1; page <= MAX_PAGES; page++) {
@@ -120,6 +120,7 @@ export async function detectStaleOpenIssues({
 		fetcher,
 		`https://api.github.com/repos/${repository}/commits`,
 		{ sha: branch },
+		{ exhaustive: false },
 	);
 	for (const commit of commits.slice(0, MAX_COMMIT_DETAILS)) {
 		const commitText = commit.commit?.message ?? commit.message ?? "";

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -6,6 +6,7 @@ import {
 	decideActions,
 	fetchOpenPullRequests,
 	MAX_PAGES,
+	PAGE_SIZE,
 	RED_CI_LABEL,
 	runWarden,
 } from "../../scripts/lib/merge-train-warden.mjs";
@@ -521,15 +522,33 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 		expect(errors[0]).toContain("network down");
 	});
 
-	// Review round 1, F8: pin MAX_PAGES with a fixture that counts calls
-	// against an always-hasNextPage response, so lowering/raising the loop
-	// bound independently of the exported constant turns this red.
-	it("stops paginating at exactly MAX_PAGES calls when every page claims hasNextPage", async () => {
-		const { fetcher, calls } = fakeGithub({
-			"POST /graphql": graphqlPage([], true, "cursor"),
-		});
-		await fetchOpenPullRequests(fetcher, "acme", "repo");
+	// #2134: a full final page with hasNextPage is not an exhausted result.
+	// The page-aware fixture makes a cursor bug visible instead of returning
+	// the same page for every request.
+	it("records truncation when MAX_PAGES pages still claim another page", async () => {
+		const pages = Array.from({ length: MAX_PAGES }, (_, pageIndex) =>
+			graphqlPage(
+				Array.from({ length: PAGE_SIZE }, (_, itemIndex) =>
+					prNode({ number: pageIndex * PAGE_SIZE + itemIndex + 1 }),
+				),
+				true,
+				`cursor-${pageIndex}`,
+			),
+		);
+		const calls: unknown[] = [];
+		const fetcher = async (_url: string, init?: { body?: string }) => {
+			const body = JSON.parse(init?.body ?? "{}");
+			calls.push(body);
+			const after = body.variables?.after;
+			const pageIndex = after ? Number(after.replace("cursor-", "")) + 1 : 0;
+			return { ok: true, status: 200, json: async () => pages[pageIndex] };
+		};
+		const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
 		expect(calls).toHaveLength(MAX_PAGES);
+		expect(result.prs).toHaveLength(MAX_PAGES * PAGE_SIZE);
+		expect(result.errors).toEqual([
+			`GraphQL pagination truncated after ${MAX_PAGES} pages while hasNextPage=true`,
+		]);
 	});
 
 	it("applyAction issues the exact REST call for each action type", async () => {

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -551,6 +551,33 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 		]);
 	});
 
+	// The page limit is healthy when the final page exhausts the connection.
+	// Hoisting the truncation guard above the hasNextPage break must make this
+	// complete population report a false error.
+	it("accepts MAX_PAGES full pages when the last page is exhausted", async () => {
+		const pages = Array.from({ length: MAX_PAGES }, (_, pageIndex) =>
+			graphqlPage(
+				Array.from({ length: PAGE_SIZE }, (_, itemIndex) =>
+					prNode({ number: pageIndex * PAGE_SIZE + itemIndex + 1 }),
+				),
+				pageIndex < MAX_PAGES - 1,
+				`cursor-${pageIndex}`,
+			),
+		);
+		const calls: unknown[] = [];
+		const fetcher = async (_url: string, init?: { body?: string }) => {
+			const body = JSON.parse(init?.body ?? "{}");
+			calls.push(body);
+			const after = body.variables?.after;
+			const pageIndex = after ? Number(after.replace("cursor-", "")) + 1 : 0;
+			return { ok: true, status: 200, json: async () => pages[pageIndex] };
+		};
+		const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(calls).toHaveLength(MAX_PAGES);
+		expect(result.prs).toHaveLength(MAX_PAGES * PAGE_SIZE);
+		expect(result.errors).toEqual([]);
+	});
+
 	it("applyAction issues the exact REST call for each action type", async () => {
 		const { fetcher, calls } = fakeGithub({});
 		const record = pr({ number: 5, headSha: "abc123" });


### PR DESCRIPTION
### Summary

The merge-train warden records a fatal list error when GraphQL reaches `MAX_PAGES` while `hasNextPage` remains true. It preserves collected pages. `runWarden` still applies labels and comments to all collected PRs before exiting nonzero.

### Tests

- `npx vitest run tests/scripts/merge-train-warden.test.ts tests/scripts/stale-open-issues.test.ts --reporter=dot` — 53 passed.
- `npm run build` — passed.
- `npm run lint` — passed.
- `npm run fmt:check` — passed.
- `npm run astgrep:self-scan` — passed with 0 findings.
- `npm run changelog:check` — passed.
- The red-first hoist mutation failed the healthy-boundary test with `AssertionError: expected [ Array(1) ] to deeply equal []`; it received `GraphQL pagination truncated after 4 pages while hasNextPage=true`.
- The healthy-boundary test serves `MAX_PAGES` full cursor pages, sets `hasNextPage:false` on the last page, and asserts 200 collected PRs with no errors.
- The truncation regression serves four distinct cursor pages, each with 50 nodes, and asserts four calls, 200 collected PRs, and the fatal error.

### Blast radius

The production change is limited to `fetchOpenPullRequests` in `scripts/lib/merge-train-warden.mjs`. Its only consumer is `runWarden`, which routes list errors into the visible list-fetch record while continuing through every collected PR. The CLI sets a nonzero exit code for the fatal record. `module_report` is unavailable for `.mjs` script modules, so the direct consumer trace is documented here.

### Class sweep

| Member | Behavior | Disposition |
| --- | --- | --- |
| ls-files (#2096) | REST bounded read reports unprovable exhaustion | Existing fix |
| stale-open-issues (#2135) | REST pager demands exhaustion by default; commit details opt out explicitly | Preserved and default flipped here |
| merge-train warden (#2134) | GraphQL `hasNextPage` is explicit; the final bounded page records fatal truncation | Fixed here |

Consolidation verdict: the three members share the bounded-read contract but retain separate protocol-specific readers. The shared REST `paged()` helper now defaults to exhaustive: true, making bounded behavior opt out explicitly. The deliberately bounded commit-history read passes `{ exhaustive: false }`, so its contract does not change. The GraphQL reader stays local because its explicit `hasNextPage` signal makes the exact final-page condition clearer than adapting the REST helper.

### Observability

The existing warden summary records `ERROR: GraphQL pagination truncated after 4 pages while hasNextPage=true` under `(list fetch)`, and the CLI sets `process.exitCode = 1`. No new telemetry sink is needed.

### Test assessment

- `tests/scripts/merge-train-warden.test.ts`: the added pagination case uniquely pins a complete `MAX_PAGES` population with an exhausted final page, and red-proves the guard ordering. The edited truncation case pins page-aware cursor traversal, collected-page preservation, and fatal truncation classification.
- `scripts/lib/stale-open-issues.mjs`: the edited helper default and explicit commit-reader opt-out preserve the bounded sibling contract; existing tests cover both exhaustive open-issue reads and bounded commit details.
- No test was removed or made redundant.
