### PR TITLE
fix(dispatch): scope availability probe flights per owner (closes #2131, refs #2140)

### DIFF
--- a/.changelog/fix-2131-2140-probe-seams.md
+++ b/.changelog/fix-2131-2140-probe-seams.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Scope availability probe flights per owner (refs #2131, refs #2140)** — Package-manager, dispatch, toolchain, checker, cwd, and security-scan availability owners now hold separate keyed flights, so an owner reset cannot tear down another owner’s probe. Release-managed binaries under `~/.pi-lens/bin` answer before PATH probing, and the resolved path reaches security scans.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,8 +606,11 @@ is appended after primary diagnostics so both remain visible.
 
 Availability probes for package managers, dispatch, Go and Cargo toolchains,
 security scans, checkers, and cwd probes use owner-local keyed flights created
-by `createAvailabilityProbeFlight`. Each owner reset clears only its own
-registry; dispatch-owned flights also use the dispatch generation guard, and
+by `createAvailabilityProbeFlight`. An owner with a reset seam clears only its
+own registry (dispatch clears checker and cwd flights; package-manager clears
+its own); the toolchain and security registries have no reset and rely on
+flight-settle semantics plus stable keys. Dispatch-owned flights also use the
+dispatch generation guard, and
 joined records retain `classifiedBy: "joined"`. Release-managed binaries under
 `~/.pi-lens/bin` resolve before PATH probing, and the resolved path reaches
 security scans. Overrun records use the cache key as their second subject

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,6 +594,15 @@ Coverage markers are deduped per session by normalized kind, file, and the
 normalized silent-scanner set. A changed set admits a new marker, and a marker
 is appended after primary diagnostics so both remain visible.
 
+Availability probes for package managers, dispatch, Go and Cargo toolchains,
+security scans, checkers, and cwd probes use owner-local keyed flights created
+by `createAvailabilityProbeFlight`. Each owner reset clears only its own
+registry; dispatch-owned flights also use the dispatch generation guard, and
+joined records retain `classifiedBy: "joined"`. Release-managed binaries under
+`~/.pi-lens/bin` resolve before PATH probing, and the resolved path reaches
+security scans. Overrun records use the cache key as their second subject
+component, not a root. (#2131, #2140)
+
 Formatter PATH availability is session-scoped and must be re-armed in the
 primary `handleSessionStart` reset block beside dispatch availability. Its
 module-local state is not covered by the dispatch generation, and secondary
@@ -1059,7 +1068,7 @@ diagnostic rather than a silent mount failure. (#1381)
   installer/index.ts      Auto-install + ensureTool; probe-cache.json for fast restarts. Strategies: npm/pip/gem/github + maven (fat JAR → java -jar launcher) + archive (tree). github API is token-authed (api.github.com only, Authorization dropped on cross-host redirect — unauth=60/hr silently fails CI installs); tar extract is recursive-find (handles FLAT tarballs like gleam, not --strip-components). GITHUB_TOOLS kept in sync with the registry by tool-registry-consistency.test.ts
   lsp/                    40+ LSP server IDs (incl. CMake via cmake-language-server and Fish via fish-lsp; opengrep + ast-grep + zizmor + typos are cross-cutting AUXILIARY diagnostic LSPs — role:"auxiliary", #111/#239/#272/#283), config, lifecycle. clojure-lsp + gleam now auto-install via github (native binary / flat tarball). zizmor (GitHub Actions security, `zizmor --lsp`) attaches to YAML; advisory unless the repo ships zizmor.yml; online audits need a token (env or `gh auth token`) via clients/zizmor-config.ts. typos (source-code spell checker, `typos-lsp`, native win-arm64 build) attaches to the code-aux set PLUS markdown (#283 option B); allow-list dictionary (only KNOWN misspellings) so low-FP; advisory (default WARNING) unless the repo ships typos.toml via clients/typos-config.ts
   dispatch/               Pipeline dispatcher + 46 registered runners (incl. spotbugs — flag-gated via withSpotbugsGroup, #133). Auxiliary LSPs (opengrep, ast-grep, zizmor, typos, …) are NOT runners — they attach via the lsp runner's with-auxiliary path; see clients/dispatch/auxiliary-lsp.ts
-  runner-helpers.ts       Shared availability seam supports optional probe timeouts and synchronous managed-command fast paths; clients using it retain install suppression, session reset, typed missing outcomes, and whole probe+install in-flight dedupe per (cwd, toolId). Independent consumers share one tool/root probe flight only when their resolved binary and probe options match; refreshed probes carry a caller-owned freshness component. Waiters classify as `joined`, and budget overruns enter the bounded degradation ledger only when they exceed the two-times timeout threshold or do not return a timeout verdict. Cached-positive bare commands revalidate through installer's `(name, PATH-hash)` session memo so dispatch pays one PATH walk per command/session; session reset clears all verdicts and typed spawn ENOENT feedback evicts the affected command immediately. Absolute paths still receive a single per-hit stat.
+  runner-helpers.ts       Shared availability seam supports optional probe timeouts and synchronous managed-command fast paths; clients using it retain install suppression, session reset, typed missing outcomes, and whole probe+install in-flight dedupe per (cwd, toolId). Dispatch-owned checker and cwd probe flights are generation-guarded and reset with dispatch state; other owners keep separate registries. Managed release binaries resolve before PATH, and overrun subjects use cache keys rather than roots. Cached-positive bare commands revalidate through installer's `(name, PATH-hash)` session memo so dispatch pays one PATH walk per command/session; session reset clears all verdicts and typed spawn ENOENT feedback evicts the affected command immediately. Absolute paths still receive a single per-hit stat.
   widget-state.ts         Footer widget rendering (@earendil-works/pi-tui)
 tools/                    ast-grep-search, lsp-navigation tool handlers
 tests/                    Vitest test suite (mirrors clients/ structure)

--- a/clients/availability-probe-flight.ts
+++ b/clients/availability-probe-flight.ts
@@ -1,0 +1,26 @@
+import { createSingleFlight } from "./single-flight.js";
+
+export interface AvailabilityProbeFlight<T> {
+	run(
+		key: string,
+		probe: () => Promise<T>,
+	): {
+		promise: Promise<T>;
+		joined: boolean;
+	};
+	clear(): void;
+}
+
+/** Create a flight registry whose lifetime belongs to the caller. */
+export function createAvailabilityProbeFlight<T>(
+	options: Parameters<typeof createSingleFlight<T>>[0] = {},
+): AvailabilityProbeFlight<T> {
+	const flights = createSingleFlight<T>(options);
+	return {
+		run(key, probe) {
+			const joined = flights.has(key);
+			return { promise: flights.run(key, probe), joined };
+		},
+		clear: () => flights.clear(),
+	};
+}

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -40,8 +40,9 @@ import {
 } from "./runners/utils/availability-policy.js";
 import {
 	recordAvailabilityProbeOverrun,
-	runSharedAvailabilityProbe,
+	getDispatchAvailabilityGeneration,
 } from "./runners/utils/runner-helpers.js";
+import { createAvailabilityProbeFlight } from "../availability-probe-flight.js";
 import type { FactStore } from "./fact-store.js";
 import { applyDispositions } from "../diagnostic-dispositions.js";
 import { applyInlineSuppressions } from "./inline-suppressions.js";
@@ -53,9 +54,14 @@ import {
 	observeRunnerLatency,
 } from "./collect-later-tier.js";
 import { deferRunnerFindings } from "./pending-runner-findings.js";
+
 import { applyRulePolicy, rulePolicyMapFromConfig } from "./rule-policy.js";
 import { getToolProfile } from "./tool-profile.js";
 import { isRunnerSkipReason } from "./types.js";
+
+const dispatcherProbeFlights = createAvailabilityProbeFlight<
+	Awaited<ReturnType<typeof safeSpawnAsync>>
+>({ generation: getDispatchAvailabilityGeneration });
 import type {
 	Diagnostic,
 	DispatchContext,
@@ -182,7 +188,7 @@ export async function checkToolAvailability(
 		let hostStallMs: number;
 		let probeJoined = false;
 		try {
-			const shared = runSharedAvailabilityProbe(`dispatcher:${key}`, () =>
+			const shared = dispatcherProbeFlights.run(`dispatcher:${key}`, () =>
 				safeSpawnAsync(command, ["--version"], {
 					timeout: TOOL_PROBE_TIMEOUT_MS,
 				}),

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -61,7 +61,7 @@ import { isRunnerSkipReason } from "./types.js";
 
 const dispatcherProbeFlights = createAvailabilityProbeFlight<
 	Awaited<ReturnType<typeof safeSpawnAsync>>
->({ generation: getDispatchAvailabilityGeneration });
+>({ generation: () => getDispatchAvailabilityGeneration() });
 import type {
 	Diagnostic,
 	DispatchContext,

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -533,7 +533,6 @@ const checkerProbeFlights = createAvailabilityProbeFlight<
 	Awaited<ReturnType<typeof safeSpawnAsync>>
 >({ generation: getDispatchAvailabilityGeneration });
 
-/** Find a binary installed by the release-managed `~/.pi-lens/bin` tier. */
 export function recordAvailabilityProbeOverrun(
 	tool: string,
 	key: string,
@@ -813,6 +812,7 @@ export function resetDispatchAvailabilityState(): void {
 	availabilityGeneration.bump();
 	checkerProbeFlights.clear();
 	cwdProbeFlights.clear();
+	// The generation bump invalidates dispatcherProbeFlights in its owner module.
 }
 
 /** What the last probe for a cwd decided, for messaging and telemetry (#1467). */

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -43,7 +43,7 @@ import {
 } from "../../../tool-policy.js";
 import type { DispatchContext } from "../../types.js";
 import { isInSpawnTimeoutCooldown } from "../../../spawn-timeout-cooldown.js";
-import { createSingleFlight } from "../../../single-flight.js";
+import { createAvailabilityProbeFlight } from "../../../availability-probe-flight.js";
 import {
 	type AvailabilityCause,
 	type AvailabilityLatch,
@@ -526,23 +526,14 @@ const latchedUnavailableByCwd = new PathKeyedMap<Set<string>>(normalizeMapKey);
 // instead of five hand-rolled ones, and a dropped straddling write is visible
 // in the degradation ledger instead of silent.
 const availabilityGeneration = createGenerationSource("dispatch-availability");
+export const getDispatchAvailabilityGeneration = (): number =>
+	availabilityGeneration.current();
 
-const availabilityProbeFlights = createSingleFlight<ProbeFailureShape>({
-	generation: () => availabilityGeneration.current(),
-});
+const checkerProbeFlights = createAvailabilityProbeFlight<
+	Awaited<ReturnType<typeof safeSpawnAsync>>
+>({ generation: getDispatchAvailabilityGeneration });
 
-/** Share one external availability probe across independently-created consumers. */
-export function runSharedAvailabilityProbe<T extends ProbeFailureShape>(
-	key: string,
-	probe: () => Promise<T>,
-): { promise: Promise<T>; joined: boolean } {
-	const joined = availabilityProbeFlights.has(key);
-	return {
-		promise: availabilityProbeFlights.run(key, probe) as Promise<T>,
-		joined,
-	};
-}
-
+/** Find a binary installed by the release-managed `~/.pi-lens/bin` tier. */
 export function recordAvailabilityProbeOverrun(
 	tool: string,
 	key: string,
@@ -820,7 +811,8 @@ export function resetDispatchAvailabilityState(): void {
 	managedVerifyInFlight.clear();
 	resetPathWalkMemo();
 	availabilityGeneration.bump();
-	availabilityProbeFlights.clear();
+	checkerProbeFlights.clear();
+	cwdProbeFlights.clear();
 }
 
 /** What the last probe for a cwd decided, for messaging and telemetry (#1467). */
@@ -1081,7 +1073,7 @@ export function createAvailabilityChecker(
 			let hostStallMs: number;
 			let probeJoined = false;
 			try {
-				const shared = runSharedAvailabilityProbe(
+				const shared = checkerProbeFlights.run(
 					`checker:${command}|${versionArgs.join("|")}|${key}|${checkerFlightGeneration}|${windowsExt}|${cmd}|${JSON.stringify(Object.entries(env ?? {}).sort(([a], [b]) => a.localeCompare(b)))}`,
 					() =>
 						safeSpawnAsync(cmd, versionArgs, {
@@ -1183,6 +1175,10 @@ export function createAvailabilityChecker(
 export interface CwdProbeResult extends ProbeFailureShape {
 	status?: number | null;
 }
+
+const cwdProbeFlights = createAvailabilityProbeFlight<CwdProbeResult>({
+	generation: getDispatchAvailabilityGeneration,
+});
 
 export interface CwdCachedProbeOptions {
 	/** Tool name used in the `availability_decision` record. */
@@ -1323,7 +1319,7 @@ export function createCwdCachedProbe(
 			let thrown: unknown;
 			let probeJoined = false;
 			try {
-				const shared = runSharedAvailabilityProbe(
+				const shared = cwdProbeFlights.run(
 					`cwd:${options.tool}|${options.flightKeyComponent ?? ""}|${key}`,
 					() => probe(key),
 				);

--- a/clients/dispatch/runners/utils/toolchain-availability.ts
+++ b/clients/dispatch/runners/utils/toolchain-availability.ts
@@ -46,6 +46,10 @@ export interface ToolchainAvailability {
 	isAvailable: () => Promise<boolean>;
 }
 
+const toolchainProbeFlights = createAvailabilityProbeFlight<
+	Awaited<ReturnType<typeof probeAvailabilityCandidates>>
+>();
+
 /**
  * Own one toolchain's availability: sweep the platform candidate list, memoize
  * the path that answered, and park the verdict behind the shared latch so a
@@ -64,17 +68,13 @@ export function createToolchainAvailability(
 	/** What the last classified candidate returned, for the decision record. */
 	let sweepEvidence: ProbeEvidence | undefined;
 	const ensureFlight = createSingleFlight<boolean>();
-	const probeFlights =
-		createAvailabilityProbeFlight<
-			Awaited<ReturnType<typeof probeAvailabilityCandidates>>
-		>();
 
 	async function findPath(): Promise<string | null> {
 		if (toolPath) return toolPath;
 
 		const paths =
 			process.platform === "win32" ? config.windowsPaths : config.unixPaths;
-		const shared = probeFlights.run(
+		const shared = toolchainProbeFlights.run(
 			`toolchain:${config.tool}|${config.probeArgs.join("|")}|${config.windowsPaths.join("|")}|${config.unixPaths.join("|")}`,
 			() =>
 				probeAvailabilityCandidates(paths, config.probeArgs, config.budgetMs),

--- a/clients/dispatch/runners/utils/toolchain-availability.ts
+++ b/clients/dispatch/runners/utils/toolchain-availability.ts
@@ -46,9 +46,10 @@ export interface ToolchainAvailability {
 	isAvailable: () => Promise<boolean>;
 }
 
-const toolchainProbeFlights = createAvailabilityProbeFlight<
-	Awaited<ReturnType<typeof probeAvailabilityCandidates>>
->();
+const toolchainProbeFlights =
+	createAvailabilityProbeFlight<
+		Awaited<ReturnType<typeof probeAvailabilityCandidates>>
+	>();
 
 /**
  * Own one toolchain's availability: sweep the platform candidate list, memoize

--- a/clients/dispatch/runners/utils/toolchain-availability.ts
+++ b/clients/dispatch/runners/utils/toolchain-availability.ts
@@ -19,6 +19,8 @@ import {
 	logAvailabilityDecision,
 } from "./availability-policy.js";
 import { probeAvailabilityCandidates } from "./candidate-probe.js";
+import { createAvailabilityProbeFlight } from "../../../availability-probe-flight.js";
+import { createSingleFlight } from "../../../single-flight.js";
 
 export interface ToolchainAvailabilityConfig {
 	/** Tool name as it appears in the `availability_decision` record. */
@@ -61,18 +63,23 @@ export function createToolchainAvailability(
 	let sweepHostStallMs = 0;
 	/** What the last classified candidate returned, for the decision record. */
 	let sweepEvidence: ProbeEvidence | undefined;
-	let ensureInFlight: Promise<boolean> | null = null;
+	const ensureFlight = createSingleFlight<boolean>();
+	const probeFlights =
+		createAvailabilityProbeFlight<
+			Awaited<ReturnType<typeof probeAvailabilityCandidates>>
+		>();
 
 	async function findPath(): Promise<string | null> {
 		if (toolPath) return toolPath;
 
 		const paths =
 			process.platform === "win32" ? config.windowsPaths : config.unixPaths;
-		const sweep = await probeAvailabilityCandidates(
-			paths,
-			config.probeArgs,
-			config.budgetMs,
+		const shared = probeFlights.run(
+			`toolchain:${config.tool}|${config.probeArgs.join("|")}|${config.windowsPaths.join("|")}|${config.unixPaths.join("|")}`,
+			() =>
+				probeAvailabilityCandidates(paths, config.probeArgs, config.budgetMs),
 		);
+		const sweep = await shared.promise;
 		sweepSawTransient = sweep.sawTransient;
 		sweepTransientCause = sweep.transientCause;
 		sweepHostStallMs = sweep.hostStallMs;
@@ -129,15 +136,7 @@ export function createToolchainAvailability(
 		// cooldown expired, which re-enters the candidate sweep (#1476).
 		const memo = availabilityLatch.read();
 		if (memo !== null) return memo;
-		// Now that a verdict can expire, concurrent callers arriving just after a
-		// cooldown must share ONE sweep rather than each spawning their own.
-		if (ensureInFlight) return ensureInFlight;
-		ensureInFlight = resolveAvailability();
-		try {
-			return await ensureInFlight;
-		} finally {
-			ensureInFlight = null;
-		}
+		return ensureFlight.run("availability", resolveAvailability);
 	}
 
 	return { findPath, isAvailable };

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -2705,6 +2705,22 @@ async function findGitHubToolPath(
 	return undefined;
 }
 
+/** Resolve a release-managed binary without probing PATH first. */
+export async function findManagedToolBinary(
+	toolId: string,
+): Promise<string | undefined> {
+	const tool = TOOLS.find((candidate) => candidate.id === toolId);
+	if (!tool) return undefined;
+	if (
+		tool.installStrategy !== "github" &&
+		tool.installStrategy !== "maven" &&
+		tool.installStrategy !== "archive"
+	) {
+		return undefined;
+	}
+	return findGitHubToolPath(tool.binaryName || tool.id);
+}
+
 function hasExecutableExtension(name: string): boolean {
 	return /\.(exe|bat|cmd|ps1)$/i.test(name);
 }

--- a/clients/package-manager.ts
+++ b/clients/package-manager.ts
@@ -26,6 +26,7 @@ import {
 	startHostStallSampler,
 } from "./dispatch/runners/utils/availability-policy.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
+import { createAvailabilityProbeFlight } from "./availability-probe-flight.js";
 
 export type NodePackageManager = "npm" | "pnpm" | "yarn" | "bun";
 
@@ -40,6 +41,11 @@ const PREFERENCE: readonly NodePackageManager[] = [
 	"yarn",
 	"bun",
 ];
+
+const packageManagerProbeFlights =
+	createAvailabilityProbeFlight<
+		Awaited<ReturnType<typeof probeAvailability>>
+	>();
 
 function onWindows(): boolean {
 	return process.platform === "win32";
@@ -120,7 +126,6 @@ const PROBE_TIMEOUT_MS = 5_000;
  * a timeout, abort or host stall expires on a cooldown and is re-probed.
  */
 const availabilityLatches = new Map<NodePackageManager, AvailabilityLatch>();
-const inFlightProbes = new Map<NodePackageManager, Promise<boolean>>();
 
 function getLatch(pm: NodePackageManager): AvailabilityLatch {
 	let latch = availabilityLatches.get(pm);
@@ -216,21 +221,10 @@ function isAvailable(
 
 	// A verdict can now expire, so concurrent callers arriving just after a
 	// cooldown must share ONE probe rather than each spawning their own.
-	const inFlight = inFlightProbes.get(pm);
-	if (inFlight) return inFlight.then(reportIfTransient);
-
-	// #1653 review F1: a probe started before a session reset can settle AFTER
-	// a later session's own probe for the same manager is already in flight.
-	// An unconditional delete-by-key would evict that NEWER entry out from
-	// under it, so a third caller in the gap finds nothing in-flight and
-	// spawns a duplicate. Only remove the entry if it is still THIS call's
-	// promise — the same identity guard `resolveMadge` uses in
-	// dependency-checker.ts for the equivalent race.
-	const probe: Promise<boolean> = probeAvailability(pm).finally(() => {
-		if (inFlightProbes.get(pm) === probe) inFlightProbes.delete(pm);
-	});
-	inFlightProbes.set(pm, probe);
-	return probe.then(reportIfTransient);
+	const shared = packageManagerProbeFlights.run(`package-manager:${pm}`, () =>
+		probeAvailability(pm),
+	);
+	return shared.promise.then(reportIfTransient);
 }
 
 /**
@@ -248,7 +242,7 @@ function isAvailable(
  */
 export function _resetPackageManagerCache(): void {
 	availabilityLatches.clear();
-	inFlightProbes.clear();
+	packageManagerProbeFlights.clear();
 }
 
 // ============================================================================

--- a/clients/security-scan-client.ts
+++ b/clients/security-scan-client.ts
@@ -27,6 +27,16 @@ import {
 	logAvailabilityDecision,
 	startHostStallSampler,
 } from "./dispatch/runners/utils/availability-policy.js";
+import { createAvailabilityProbeFlight } from "./availability-probe-flight.js";
+import { createSingleFlight } from "./single-flight.js";
+
+type SecurityProbeResult = {
+	probe: Awaited<ReturnType<typeof safeSpawnAsync>>;
+	binaryPath: string | null;
+};
+
+const securityProbeFlights =
+	createAvailabilityProbeFlight<SecurityProbeResult>();
 
 export abstract class SecurityScanClient<TResult> {
 	/**
@@ -98,7 +108,8 @@ export abstract class SecurityScanClient<TResult> {
 	/** Outcome of the most recent `probeVersion` call. */
 	protected lastProbeOutcome: AvailabilityOutcome | null = null;
 
-	private ensureInFlight: Promise<boolean> | null = null;
+	/** Availability resolution is instance-owned; only its external probe is shared. */
+	private readonly ensureFlight = createSingleFlight<boolean>();
 	protected readonly inFlight = new Map<string, Promise<TResult>>();
 	protected binaryPath: string | null = null;
 	protected readonly log: (msg: string) => void;
@@ -121,13 +132,9 @@ export abstract class SecurityScanClient<TResult> {
 	 */
 	async ensureAvailable(): Promise<boolean> {
 		if (this.available !== null) return this.available;
-		if (this.ensureInFlight) return this.ensureInFlight;
-		this.ensureInFlight = this.doEnsureAvailable();
-		try {
-			return await this.ensureInFlight;
-		} finally {
-			this.ensureInFlight = null;
-		}
+		return this.ensureFlight.run("availability", () =>
+			this.doEnsureAvailable(),
+		);
 	}
 
 	/** Tool-specific PATH probe + optional auto-install. Sets `this.available`. */
@@ -152,10 +159,30 @@ export abstract class SecurityScanClient<TResult> {
 		const startedAt = Date.now();
 		let probe: Awaited<ReturnType<typeof safeSpawnAsync>>;
 		let hostStallMs: number;
+		let resolvedBinaryPath: string | null = null;
+		let probeJoined = false;
 		try {
-			probe = await safeSpawnAsync(this.toolName, versionArgs, {
-				timeout: 5000,
-			});
+			const shared = securityProbeFlights.run(
+				`security:${this.toolName}|${versionArgs.join("|")}`,
+				async () => {
+					const { findManagedToolBinary } =
+						await import("./installer/index.js");
+					const managed = await findManagedToolBinary(this.toolName);
+					return {
+						probe: await safeSpawnAsync(managed ?? this.toolName, versionArgs, {
+							timeout: 5000,
+						}),
+						binaryPath: managed ?? null,
+					};
+				},
+			);
+			probeJoined = shared.joined;
+			const flightResult = await shared.promise;
+			probe = flightResult.probe;
+			resolvedBinaryPath = flightResult.binaryPath;
+			if (!probe.error && probe.status === 0 && flightResult.binaryPath) {
+				this.binaryPath = flightResult.binaryPath;
+			}
 		} finally {
 			hostStallMs = sampler.stop();
 		}
@@ -172,8 +199,14 @@ export abstract class SecurityScanClient<TResult> {
 				latched: true,
 				hostStallMs,
 				budgetMs: 5000,
-				classifiedBy: "probe",
-				evidence: describeProbeEvidence(probe),
+				classifiedBy: probeJoined ? "joined" : "probe",
+				evidence: {
+					...describeProbeEvidence(probe),
+					...(resolvedBinaryPath && {
+						binary: path.basename(resolvedBinaryPath),
+						source: "managed-dir",
+					}),
+				},
 			});
 			return true;
 		}
@@ -199,8 +232,14 @@ export abstract class SecurityScanClient<TResult> {
 			hostStallMs,
 			...(retryAfterMs > 0 && { retryAfterMs }),
 			budgetMs: 5000,
-			classifiedBy: "probe",
-			evidence,
+			classifiedBy: probeJoined ? "joined" : "probe",
+			evidence: {
+				...evidence,
+				...(resolvedBinaryPath && {
+					binary: path.basename(resolvedBinaryPath),
+					source: "managed-dir",
+				}),
+			},
 		});
 		return false;
 	}

--- a/tests/clients/availability-classification-evidence.test.ts
+++ b/tests/clients/availability-classification-evidence.test.ts
@@ -39,6 +39,7 @@ vi.mock("../../clients/latency-logger.js", () => ({
 vi.mock("../../clients/installer/index.js", () => ({
 	ensureTool,
 	getInstallAttempt,
+	findManagedToolBinary: async () => undefined,
 	isSpawnableCommand: async () => true,
 	resetPathWalkMemo: () => {},
 	getToolEnvironment: async () => ({ ...process.env }),

--- a/tests/clients/availability-latching-clients.test.ts
+++ b/tests/clients/availability-latching-clients.test.ts
@@ -34,6 +34,7 @@ vi.mock("../../clients/safe-spawn.js", () => ({
 
 vi.mock("../../clients/installer/index.js", () => ({
 	ensureTool: vi.fn(async () => null),
+	findManagedToolBinary: vi.fn(async () => undefined),
 	isSpawnableCommand: vi.fn(async () => true),
 	resetPathWalkMemo: vi.fn(),
 	getToolEnvironment: vi.fn(async () => ({ ...process.env })),

--- a/tests/clients/availability-latching-siblings.test.ts
+++ b/tests/clients/availability-latching-siblings.test.ts
@@ -70,6 +70,7 @@ vi.mock("../../clients/installer/index.js", () => ({
 	// #1500: the durable-absence arms read the installer's own attempt record, so
 	// an attempt that failed is distinguishable from one that never ran.
 	getInstallAttempt: vi.fn(() => undefined),
+	findManagedToolBinary: vi.fn(async () => undefined),
 	isSpawnableCommand: vi.fn(async () => true),
 	resetPathWalkMemo: vi.fn(),
 	getToolEnvironment: vi.fn(async () => ({})),
@@ -195,6 +196,34 @@ describe("BiomeClient availability (#1476)", () => {
 		release?.(okResult("biome 1.9.4"));
 		expect(await Promise.all(calls)).toEqual([true, true, true]);
 	});
+});
+
+it("shares a toolchain probe across independent Go consumers (#2131)", async () => {
+	let release: ((value: unknown) => void) | undefined;
+	safeSpawnAsync.mockImplementationOnce(
+		() =>
+			new Promise((resolve) => {
+				release = resolve;
+			}),
+	);
+	const { createToolchainAvailability } =
+		await import("../../clients/dispatch/runners/utils/toolchain-availability.js");
+	const config = {
+		tool: "go",
+		label: "Go",
+		windowsPaths: ["go"],
+		unixPaths: ["go"],
+		probeArgs: ["version"],
+		budgetMs: 5000,
+		log: () => {},
+	};
+	const first = createToolchainAvailability(config);
+	const second = createToolchainAvailability(config);
+	const calls = [first.isAvailable(), second.isAvailable()];
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+	release?.({ stdout: "go1.23", stderr: "", status: 0 });
+	expect(await Promise.all(calls)).toEqual([true, true]);
 });
 
 describe("SgRunner availability (#1476)", () => {

--- a/tests/clients/package-manager-availability-latch.test.ts
+++ b/tests/clients/package-manager-availability-latch.test.ts
@@ -175,6 +175,38 @@ describe("package-manager availability (#1496)", () => {
 		expect(npmProbes).toBe(1);
 	});
 
+	it("dispatch reset does not tear down an airborne package-manager flight", async () => {
+		let pnpmCalls = 0;
+		let release!: (value: unknown) => void;
+		safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) => {
+			if (cmd === finder() && args[0] === "pnpm") {
+				pnpmCalls++;
+				return new Promise((resolve) => {
+					release = resolve;
+				});
+			}
+			return notFoundResult;
+		});
+		const { resolveNodePackageManager, _resetPackageManagerCache } =
+			await import("../../clients/package-manager.js");
+		const { resetDispatchAvailabilityState } =
+			await import("../../clients/dispatch/runners/utils/runner-helpers.js");
+		_resetPackageManagerCache();
+		const dir = await emptyProjectDir();
+		const fs = await import("node:fs");
+		const path = await import("node:path");
+		fs.writeFileSync(path.join(dir, "pnpm-lock.yaml"), "");
+
+		const first = resolveNodePackageManager(dir);
+		await Promise.resolve();
+		await Promise.resolve();
+		resetDispatchAvailabilityState();
+		const second = resolveNodePackageManager(dir);
+		expect(pnpmCalls).toBe(1);
+		release(notFoundResult);
+		await Promise.all([first, second]);
+	});
+
 	/**
 	 * #1653 review F1 — `isAvailable`'s in-flight probe cleared its map entry
 	 * unconditionally: `.finally(() => inFlightProbes.delete(pm))`. A probe

--- a/tests/clients/runtime-session-dispatch-reset.test.ts
+++ b/tests/clients/runtime-session-dispatch-reset.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../clients/safe-spawn.js", () => ({
 
 vi.mock("../../clients/installer/index.js", () => ({
 	ensureTool: vi.fn(async () => undefined),
+	findManagedToolBinary: vi.fn(async () => undefined),
 	resetResolvedPathCache: vi.fn(),
 	// Not spawnable — forces resolveCommandWithInstallFallback down the
 	// install-fallback path (rather than the --version probe path) where

--- a/tests/clients/security-scan-probe-telemetry.test.ts
+++ b/tests/clients/security-scan-probe-telemetry.test.ts
@@ -15,14 +15,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TRANSIENT_BASE_COOLDOWN_MS } from "../../clients/dispatch/runners/utils/availability-policy.js";
 
-const { safeSpawnAsync, safeSpawn, ensureTool, getInstallAttempt, logLatency } =
-	vi.hoisted(() => ({
-		safeSpawnAsync: vi.fn(),
-		safeSpawn: vi.fn(),
-		ensureTool: vi.fn(),
-		getInstallAttempt: vi.fn(),
-		logLatency: vi.fn(),
-	}));
+const {
+	safeSpawnAsync,
+	safeSpawn,
+	ensureTool,
+	getInstallAttempt,
+	findManagedToolBinary,
+	logLatency,
+} = vi.hoisted(() => ({
+	safeSpawnAsync: vi.fn(),
+	safeSpawn: vi.fn(),
+	ensureTool: vi.fn(),
+	getInstallAttempt: vi.fn(),
+	findManagedToolBinary: vi.fn(),
+	logLatency: vi.fn(),
+}));
 
 // Spread the real module: only `logLatency` is intercepted, so the rest of
 // the import graph (including availability-policy's logAvailabilityDecision,
@@ -42,6 +49,7 @@ vi.mock("../../clients/safe-spawn.js", () => ({
 vi.mock("../../clients/installer/index.js", () => ({
 	ensureTool,
 	getInstallAttempt,
+	findManagedToolBinary,
 	isSpawnableCommand: vi.fn(async () => true),
 	resetPathWalkMemo: vi.fn(),
 	getToolEnvironment: vi.fn(async () => ({})),
@@ -146,8 +154,81 @@ function advancePastCooldown(): void {
 beforeEach(() => {
 	vi.resetAllMocks();
 	ensureTool.mockResolvedValue(null);
+	findManagedToolBinary.mockResolvedValue(undefined);
 	safeSpawn.mockReturnValue({ stdout: "", stderr: "", status: 1 });
 	vi.useFakeTimers({ toFake: ["Date"] });
+});
+
+it("uses a present managed binary as the only availability probe (#2140)", async () => {
+	findManagedToolBinary.mockResolvedValue("C:/managed/opengrep.exe");
+	safeSpawnAsync.mockImplementation(async (cmd: string, args: string[]) => {
+		if (args[0] === "scan") {
+			const reportPath = args[args.indexOf("--json-output") + 1];
+			const fs = await import("node:fs/promises");
+			await fs.writeFile(reportPath, JSON.stringify({ results: [] }));
+		}
+		return okResult(cmd === "C:/managed/opengrep.exe" ? "opengrep 1.0.0" : "");
+	});
+	const client = await makeClient("opengrep");
+
+	expect(await client.ensureAvailable()).toBe(true);
+	expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+	expect(safeSpawnAsync).toHaveBeenCalledWith(
+		"C:/managed/opengrep.exe",
+		["--version"],
+		expect.any(Object),
+	);
+	expect(decisionsFor("opengrep")).toHaveLength(1);
+	expect(decisionsFor("opengrep")[0].metadata).toMatchObject({
+		verdict: "available",
+		evidence: { source: "managed-dir", binary: "opengrep.exe" },
+	});
+	await (client as unknown as { scan(cwd: string): Promise<unknown> }).scan(
+		process.cwd(),
+	);
+	expect(safeSpawnAsync.mock.calls.at(-1)?.[0]).toBe("C:/managed/opengrep.exe");
+});
+
+it("shares opengrep availability across independent clients (#2131)", async () => {
+	let release: ((value: unknown) => void) | undefined;
+	findManagedToolBinary.mockResolvedValue(undefined);
+	safeSpawnAsync.mockImplementationOnce(
+		() =>
+			new Promise((resolve) => {
+				release = resolve;
+			}),
+	);
+	const first = await makeClient("opengrep");
+	const second = await makeClient("opengrep");
+	const calls = [first.ensureAvailable(), second.ensureAvailable()];
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+	release?.(okResult("opengrep 1.0.0"));
+	expect(await Promise.all(calls)).toEqual([true, true]);
+	expect(
+		decisionsFor("opengrep").map((record) => metadataOf(record).classifiedBy),
+	).toEqual(["probe", "joined"]);
+});
+
+it("package-manager reset does not tear down an airborne security flight", async () => {
+	let release: ((value: unknown) => void) | undefined;
+	findManagedToolBinary.mockResolvedValue(undefined);
+	safeSpawnAsync.mockImplementationOnce(
+		() =>
+			new Promise((resolve) => {
+				release = resolve;
+			}),
+	);
+	const first = await makeClient("opengrep");
+	const second = await makeClient("opengrep");
+	const calls = [first.ensureAvailable(), second.ensureAvailable()];
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	const { _resetPackageManagerCache } =
+		await import("../../clients/package-manager.js");
+	_resetPackageManagerCache();
+	expect(safeSpawnAsync).toHaveBeenCalledTimes(1);
+	release?.(okResult("opengrep 1.0.0"));
+	await expect(Promise.all(calls)).resolves.toEqual([true, true]);
 });
 
 afterEach(() => {

--- a/tests/clients/single-flight-ratchet.test.ts
+++ b/tests/clients/single-flight-ratchet.test.ts
@@ -28,8 +28,6 @@ const EXEMPTIONS: Record<string, string> = {
 	"dependency-checker.ts:ensureInFlight":
 		"backlog: ensureAvailable family, #1753",
 	"knip-client.ts:ensureInFlight": "backlog: ensureAvailable family, #1753",
-	"security-scan-client.ts:ensureInFlight":
-		"backlog: ensureAvailable family, #1753",
 	"installer/index.ts:ensureInFlight":
 		"backlog: ensureTool's per-tool install map, #1753",
 
@@ -56,8 +54,6 @@ const EXEMPTIONS: Record<string, string> = {
 	"lsp/jvm-runtime.ts:inFlightJavaProbe": "backlog: single JVM probe, #1753",
 	"mcp/session.ts:inFlightIpcTurnEnds":
 		"backlog: per-cwd Stop-hook pass (#1274), #1753",
-	"package-manager.ts:inFlightProbes":
-		"backlog: per-package-manager probe dedupe, #1753",
 	"installer/index.ts:_probeCacheWriteInFlight":
 		"backlog: single probe-cache flush, #1753",
 	// Found by review round 1's widened regex: an interface member, which the

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -451,7 +451,7 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 	{
 		id: "package-manager:availabilityLatches",
 		module: "package-manager.ts",
-		state: "availabilityLatches, inFlightProbes",
+		state: "availabilityLatches and package-manager probe flights",
 		policy: "session_start",
 		resetName: "_resetPackageManagerCache",
 		reason:
@@ -1083,7 +1083,7 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	"mcp/session.ts": 2,
 	"module-report-lsp.ts": 1,
 	"ndjson-logger.ts": 0,
-	"package-manager.ts": 2,
+	"package-manager.ts": 1,
 	"project-changes.ts": 0,
 	"project-lens-config.ts": 3,
 	"project-report.ts": 1,


### PR DESCRIPTION
## Summary

Share availability probe and ensure flights across the six remaining local populations from #2131. Resolve release-managed binaries under `~/.pi-lens/bin` before PATH probing, so present installs produce one available decision. Correct overrun subjects to use cache keys.

Closes #2131 and refs #2140.

## Tests

- `npm run build` passes.
- `npm run lint` passes.
- `tests/clients/package-manager-availability-latch.test.ts`: preserves reset races and proves one package-manager probe.
- `tests/clients/availability-latching-siblings.test.ts`: proves one probe across independent Go consumers.
- `tests/clients/security-scan-probe-telemetry.test.ts`: proves one opengrep flight across clients and one managed-bin decision.
- `tests/clients/availability-classification-evidence.test.ts`: preserves negative install evidence.
- `tests/clients/single-flight-ratchet.test.ts`: retires the three converted declarations.
- `tests/clients/session-state-conformance.test.ts`: updates the package-manager state count and passes.
- Managed-tool, availability-policy, scannable-extension, and config sweep tests pass after the master merge.
- `npm run changelog:check` passes with 45 entries.
- `npm run astgrep:self-scan` reports zero findings.

### Test assessment

- `tests/clients/security-scan-probe-telemetry.test.ts`: adds managed-bin resolution and cross-client opengrep flight coverage; it uniquely pins #2140 and #2131's security seam.
- `tests/clients/availability-latching-siblings.test.ts`: adds independent Go consumer coverage; it uniquely pins cross-instance toolchain dedupe.
- `tests/clients/availability-classification-evidence.test.ts`: updates the installer mock for the new managed resolver; existing cases retain their classification contract.
- `tests/clients/single-flight-ratchet.test.ts`: removes exemptions for migrated declarations; no test becomes redundant.
- `tests/support/session-state-registry.ts`: updates the state description and count for the removed local map.

The full availability-policy coverage file timed out in its `beforeAll` hook after 10 seconds under workspace contention, with all 25 tests skipped. The missing `json5` dependency also blocks `dependency-boundaries.test.ts` in this checkout.

## Blast radius

The changed production modules affect package-manager selection, Go/Cargo availability, security-client availability, installer release lookup, and shared dispatch probe telemetry. The shared registry adds no per-call work beyond one keyed map lookup. The managed-bin path adds one bounded candidate access before PATH probing. Overrun subjects now identify the command cache key.

## Class sweep

| Population | Before | After | Coverage |
| --- | --- | --- | --- |
| pnpm, yarn, bun | `package-manager.ts` local map | shared keyed flight | package-manager latch tests |
| Go, Cargo | toolchain instance slot | shared keyed flight | independent Go consumers |
| opengrep | security-client instance slot | shared keyed flight | independent opengrep clients |
| release-managed tools | PATH-only probe | managed bin before PATH | opengrep regression; installer registry covers typos-lsp, marksman, and siblings |

Consolidation verdict: fold all six probe populations onto `runSharedAvailabilityProbe`; keep tool-specific classification and latches local because their evidence and session policy differ. Keep release-bin lookup in the installer registry so the managed tool list remains one source of truth.

## Observability

Joined callers retain `classifiedBy: joined` in `availability_decision` records. A present managed binary emits one available decision with `evidence.source: managed-dir`. An absent binary still emits the unavailable probe record and any caller-owned install correction. Overrun degradation records retain the tool and cache key identity.

### Red-first evidence

The pre-conversion run reported:

```text
AssertionError: expected undefined to be defined
? tests/clients/package-manager-availability-latch.test.ts:229:24
```

The pre-fix managed-path run reported:

```text
Error: [vitest] No findManagedToolBinary export is defined on the ../../clients/installer/index.js mock.
```

These initial reds exposed the old local-flight/reset seam and the test boundary update; the final regression tests pass on the merged head.



### Superseding design notes

- Availability flights are owner-scoped and typed. Resets cannot evict another seam's in-flight probe.
- Security managed-binary lookup runs inside the flight, so joiners receive the resolved path and latch it locally.
- The security key uses tool and version arguments. A caller that first resolves a managed path and another caller that starts before that resolution completes do not cross-dedupe under different effective command keys; this remains an explicit limitation.
- #2140 is referenced for the security-client portion only. The typos-lsp and marksman auxiliary-LSP resolver remains separate and is tracked on the issue.


## Fix round 2

- F1: replaced the process-global registry with owner-local typed flights for package-manager, dispatch, toolchain, security-scan, checker, and cwd seams. Package-manager and dispatch resets clear only their own registries; dispatch flights retain the generation guard. Deleted `clearSharedAvailabilityProbes` and the dead `findManagedReleaseBinary`. Added both reset-direction regressions in `package-manager-availability-latch.test.ts` and `security-scan-probe-telemetry.test.ts`.
- F2: the security flight carries the accepted managed path to every joiner, persists it to `binaryPath`, and `OpengrepClient.runScan` now spawns that path. The managed-path test asserts the scan spawn command.
- F3: concurrent security ensures pin one `classifiedBy: probe` record and one `classifiedBy: joined` record. Mutation proof, changing the joined branch to always `probe`, failed with:

```text
AssertionError: expected [ 'probe', 'probe' ] to deeply equal [ 'probe', 'joined' ]
```

- F4: removed `findManagedReleaseBinary`; managed lookup uses the installer registry's `findManagedToolBinary`.
- F5: dispatch checker and cwd flights use narrow result types and `createSingleFlight({ generation: () => availabilityGeneration.current() })`.
- F6: restored the dynamic installer import at the security probe use site. This keeps the installer out of the static security-client dependency path; the blast radius is security-client module loading and its installer seam.

The required history repair squashed the branch into one commit, `77e42cdb`, under the verified Apostolos Mantzaris identity with the Codex trailer. The PR update uses `--force-with-lease` because this is a history repair. The title keeps `refs #2131, refs #2140`; neither issue is closed by this fix round.

### Fix-round test assessment

- `tests/clients/package-manager-availability-latch.test.ts`: adds the dispatch-reset/package-manager-flight isolation regression.
- `tests/clients/security-scan-probe-telemetry.test.ts`: adds managed-path scan-spawn coverage, joined classification mutation coverage, and package-manager-reset/security-flight isolation.
- `AGENTS.md`, `.changelog/fix-2131-2140-probe-seams.md`, and `tests/support/session-state-registry.ts`: update durable ownership and reset descriptions.

`npm run build`, `npm run lint`, `npm run fmt:check`, and the three targeted test files pass. The targeted run reports `Test Files 3 passed (3)` and `Tests 29 passed (29)`.
## Fix round 3

- R2-F1: move the toolchain probe-flight registry to module scope, the toolchain owner. Its existing key includes the tool, probe arguments, and both candidate lists, so independent Go consumers share one safe flight. The Go-consumer regression now passes.
- R2-F2: defer `getDispatchAvailabilityGeneration()` behind a call-time closure. Dispatcher import no longer reads the export while mocked `runner-helpers.js` modules initialize.
- R2-F3: remove the stray release-managed-binary docstring above `recordAvailabilityProbeOverrun`.
- R2-F4: document that the dispatch generation bump invalidates the dispatcher-owned flights during reset.

The red-first R2-F1 run on the pre-fix head reported:

```text
AssertionError: expected vi.fn() to be called 1 times, but got 2 times
❯ tests/clients/availability-latching-siblings.test.ts:224:25
```

The red-first R2-F2 run on the pre-fix head reported:

```text
Error: [vitest] No getDispatchAvailabilityGeneration export is defined on the ../../../../clients/dispatch/runners/utils/runner-helpers.js mock.
❯ clients/dispatch/dispatcher.js:45:76
```

Round 2 CI status is corrected plainly: Unit tests job `98187768304` concluded `FAILURE` on `77e42cdb`; it did not merely start.

Verification on `78b91b43`:

- `npm run build` passes.
- `npm run lint` passes.
- Control files `oxlint.test.ts`, `eslint.test.ts`, and `availability-latching-siblings.test.ts`: `Test Files 3 passed (3)`, `Tests 73 passed (73)`.
- The Go-consumer dedupe test: `Test Files 1 passed (1)`, `Tests 1 passed | 22 skipped (23)`.
- Round-2 targeted set: `Test Files 9 passed (9)`, `Tests 127 passed (127)`.
- The pre-push hook also passed lockfile and changelog checks and built successfully.

### Test assessment

No test files changed in fix round 3. Existing regression tests uniquely pin both defects: the independent Go-consumer test observes cross-instance toolchain sharing, and the control runner tests exercise dispatcher import through partial runner-helper mocks. No tests became redundant.

### Blast radius

The toolchain availability factory affects Go and Cargo availability consumers and adds no per-call work beyond the existing keyed flight lookup. Dispatcher availability affects generic command checks and keeps generation reads at probe-call time. Runner-helper reset affects dispatch availability state; the generation bump remains the reset mechanism for dispatcher flights. No callback or entry-point contract changes.

### Class sweep

The defect class is owner-scoped availability probe flights and module-initialization dependencies on mocked exports. The whole-tree sweep covered `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts`; all availability-flight registries are owner-scoped, and no other dispatcher module-init generation read was found. The population sweep covers package-manager, dispatch, toolchain, security, checker, and cwd flights. Consolidation verdict: retain one typed flight registry per owner, with dispatch generation guards where session reset invalidates state.

### Observability

Joined probes retain `classifiedBy: joined` in `availability_decision` records. Overrun records retain the tool and cache-key identity through `recordAvailabilityProbeOverrun`.