### PR TITLE
feat(ci): auto-repair flattened PR bodies in the body lint (refs #2145)

### DIFF
--- a/.changelog/ci-body-lint-autorepair.md
+++ b/.changelog/ci-body-lint-autorepair.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- Auto-repair clearly flattened pull request bodies before advisory lint validation. Repair only splits inline headings; bodies containing backticks refuse repair and preserve the original lint errors.
+- Auto-repair clearly flattened pull request bodies before advisory lint validation. Repair only splits inline headings; duplicate or otherwise structurally inconsistent template headings refuse repair and preserve the original lint errors.

--- a/.changelog/ci-body-lint-autorepair.md
+++ b/.changelog/ci-body-lint-autorepair.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- Auto-repair clearly flattened pull request bodies before advisory lint validation.

--- a/.changelog/ci-body-lint-autorepair.md
+++ b/.changelog/ci-body-lint-autorepair.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- Auto-repair clearly flattened pull request bodies before advisory lint validation.
+- Auto-repair clearly flattened pull request bodies before advisory lint validation. Repair only splits inline headings; bodies containing backticks refuse repair and preserve the original lint errors.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
     timeout-minutes: 5
     # Advisory to start: this job is not in required-checks branch protection.
     # A finding stays visible as a red check without blocking a merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -805,11 +805,11 @@ labeled. (#1432)
 
 The PR body advisory lint may auto-repair only clearly flattened bodies: two or
 more inline template headings, at most two physical newlines, and a minimum
-body length. Detection refuses bodies with escape-loss markers, and repair only
-splits inline headings. `repairFlattenedBody` is idempotent via its detection
-short-circuit and must pass `lintPrBody` before `patchLivePrBody` writes through
-the GitHub API; failed or stale repairs report the original errors and never
-write. The workflow grants
+body length. Detection refuses bodies with escape-loss markers or any backtick,
+and repair only splits inline headings. `repairFlattenedBody` is idempotent via
+its detection short-circuit and must pass `lintPrBody` before `patchLivePrBody`
+writes through the GitHub API; failed, stale, or uncheckable repairs report the
+original errors and never write. The workflow grants
 `pull-requests: write` only to the PR body lint job. (#2145)
 
 Message-end attribution uses a bounded two-slot session anchor. A primary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -805,9 +805,11 @@ labeled. (#1432)
 
 The PR body advisory lint may auto-repair only clearly flattened bodies: two or
 more inline template headings, at most two physical newlines, and a minimum
-body length. `repairFlattenedBody` must remain idempotent and must pass
-`lintPrBody` before `patchLivePrBody` writes through the GitHub API; failed
-repairs report the original errors and never write. The workflow grants
+body length. Detection refuses bodies with escape-loss markers, and repair only
+splits inline headings. `repairFlattenedBody` is idempotent via its detection
+short-circuit and must pass `lintPrBody` before `patchLivePrBody` writes through
+the GitHub API; failed or stale repairs report the original errors and never
+write. The workflow grants
 `pull-requests: write` only to the PR body lint job. (#2145)
 
 Message-end attribution uses a bounded two-slot session anchor. A primary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -803,6 +803,13 @@ smell warnings count only the current session, or a 24-hour fallback window
 when no session boundary is available; explicit health remains separately
 labeled. (#1432)
 
+The PR body advisory lint may auto-repair only clearly flattened bodies: two or
+more inline template headings, at most two physical newlines, and a minimum
+body length. `repairFlattenedBody` must remain idempotent and must pass
+`lintPrBody` before `patchLivePrBody` writes through the GitHub API; failed
+repairs report the original errors and never write. The workflow grants
+`pull-requests: write` only to the PR body lint job. (#2145)
+
 Message-end attribution uses a bounded two-slot session anchor. A primary
 `session_start` rotates `lastStableSessionId` into `previousSessionId` because
 queued stale events from the replaced session can drain after the boundary;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -816,8 +816,10 @@ labeled. (#1432)
 The PR body advisory lint may auto-repair only clearly flattened bodies: two or
 more inline template headings, at most two physical newlines, and a minimum
 body length. Detection refuses bodies with escape-loss markers, while the
-post-split structural guard refuses duplicate template headings or more
-headings than distinct template sections. Repair only splits inline headings.
+post-split structural guard compares repaired heading count with distinct
+template-section count and refuses inconsistent structures. Repair only splits
+inline headings
+whose preceding text ends at body start or sentence-ending punctuation.
 `repairFlattenedBody` is idempotent via its detection short-circuit and must
 pass `lintPrBody` before `patchLivePrBody` writes through the GitHub API; failed,
 stale, or uncheckable repairs report the original errors and never write. The workflow grants

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -815,11 +815,12 @@ labeled. (#1432)
 
 The PR body advisory lint may auto-repair only clearly flattened bodies: two or
 more inline template headings, at most two physical newlines, and a minimum
-body length. Detection refuses bodies with escape-loss markers or any backtick,
-and repair only splits inline headings. `repairFlattenedBody` is idempotent via
-its detection short-circuit and must pass `lintPrBody` before `patchLivePrBody`
-writes through the GitHub API; failed, stale, or uncheckable repairs report the
-original errors and never write. The workflow grants
+body length. Detection refuses bodies with escape-loss markers, while the
+post-split structural guard refuses duplicate template headings or more
+headings than distinct template sections. Repair only splits inline headings.
+`repairFlattenedBody` is idempotent via its detection short-circuit and must
+pass `lintPrBody` before `patchLivePrBody` writes through the GitHub API; failed,
+stale, or uncheckable repairs report the original errors and never write. The workflow grants
 `pull-requests: write` only to the PR body lint job. (#2145)
 
 Message-end attribution uses a bounded two-slot session anchor. A primary

--- a/scripts/check-pr-body.d.mts
+++ b/scripts/check-pr-body.d.mts
@@ -1,3 +1,5 @@
+export declare function detectFlattenedBody(body?: string): boolean;
+export declare function repairFlattenedBody(body?: string): string;
 export declare function lintPrBody(
 	body?: string,
 	options?: { requireTestAssessment?: boolean },
@@ -9,6 +11,11 @@ export declare function resolveLivePrBody(
 	payloadPr: { number: number; body?: string | null },
 	fetchImpl?: typeof fetch,
 ): Promise<string>;
+export declare function patchLivePrBody(
+	payloadPr: { number: number },
+	body: string,
+	fetchImpl?: typeof fetch,
+): Promise<void>;
 export declare function resolveTouchesTests(
 	payloadPr: { number: number },
 	fetchImpl?: typeof fetch,
@@ -17,3 +24,7 @@ export declare function lintLivePrBody(
 	payloadPr: { number: number; body?: string | null },
 	fetchImpl?: typeof fetch,
 ): Promise<{ valid: boolean; errors: string[] }>;
+export declare function lintPullRequestEvent(
+	fetchImpl?: typeof fetch,
+	event?: { pull_request?: { number: number; body?: string | null } },
+): Promise<{ valid: boolean; repaired: boolean }>;

--- a/scripts/check-pr-body.d.mts
+++ b/scripts/check-pr-body.d.mts
@@ -20,10 +20,6 @@ export declare function resolveTouchesTests(
 	payloadPr: { number: number },
 	fetchImpl?: typeof fetch,
 ): Promise<boolean | null>;
-export declare function lintLivePrBody(
-	payloadPr: { number: number; body?: string | null },
-	fetchImpl?: typeof fetch,
-): Promise<{ valid: boolean; errors: string[] }>;
 export declare function lintPullRequestEvent(
 	fetchImpl?: typeof fetch,
 	event?: { pull_request?: { number: number; body?: string | null } },

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -130,7 +130,7 @@ export function detectFlattenedBody(body = "") {
 	// A flattened body containing these markers has already lost data. It is
 	// safer to report the original lint errors than to write a guessed repair.
 	if (
-		/[\f\t]|\r(?!\n)|\\[ftr]/.test(source) ||
+		/[`\f\t]|\r(?!\n)|\\[ftr]/.test(source) ||
 		/\\n/.test(source) ||
 		new RegExp(
 			`(?:^|[\\s])(?:${CORRUPTED_HEADING_TAILS.join("|")})(?=\\s|$)`,
@@ -241,39 +241,42 @@ export function lintPrBody(body = "", options = {}) {
 	return { valid: errors.length === 0, errors };
 }
 
+async function fetchLivePrBody(payloadPr, fetchImpl) {
+	const token = process.env.GITHUB_TOKEN;
+	if (!token) throw new Error("GITHUB_TOKEN is not set");
+	const apiUrl = process.env.GITHUB_API_URL;
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!apiUrl || !repository)
+		throw new Error("GITHUB_API_URL or GITHUB_REPOSITORY is missing");
+	const response = await fetchImpl(
+		`${apiUrl}/repos/${repository}/pulls/${payloadPr.number}`,
+		{
+			signal: AbortSignal.timeout(10_000),
+			headers: {
+				Accept: "application/vnd.github+json",
+				Authorization: `Bearer ${token}`,
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+		},
+	);
+	if (!response.ok) throw new Error(`GitHub API returned ${response.status}`);
+	const data = await response.json();
+	if (typeof data.body !== "string")
+		throw new Error("GitHub API returned no body");
+	return data.body;
+}
+
 export async function resolveLivePrBody(
 	payloadPr,
 	fetchImpl = globalThis.fetch,
 ) {
-	const fallback = payloadPr.body ?? "";
 	try {
-		const token = process.env.GITHUB_TOKEN;
-		if (!token) throw new Error("GITHUB_TOKEN is not set");
-		const apiUrl = process.env.GITHUB_API_URL;
-		const repository = process.env.GITHUB_REPOSITORY;
-		if (!apiUrl || !repository)
-			throw new Error("GITHUB_API_URL or GITHUB_REPOSITORY is missing");
-		const response = await fetchImpl(
-			`${apiUrl}/repos/${repository}/pulls/${payloadPr.number}`,
-			{
-				signal: AbortSignal.timeout(10_000),
-				headers: {
-					Accept: "application/vnd.github+json",
-					Authorization: `Bearer ${token}`,
-					"X-GitHub-Api-Version": "2022-11-28",
-				},
-			},
-		);
-		if (!response.ok) throw new Error(`GitHub API returned ${response.status}`);
-		const data = await response.json();
-		if (typeof data.body !== "string")
-			throw new Error("GitHub API returned no body");
-		return data.body;
+		return await fetchLivePrBody(payloadPr, fetchImpl);
 	} catch (error) {
 		console.warn(
 			`::warning::Could not fetch the live PR body; using the event payload instead (${error instanceof Error ? error.message : error}).`,
 		);
-		return fallback;
+		return payloadPr.body ?? "";
 	}
 }
 
@@ -364,13 +367,6 @@ export async function resolveTouchesTests(
  * (no tests/ files) both skip it, so a flaky fetch can never misfire the
  * check (#2124 review F2 pinned this consumption).
  */
-export async function lintLivePrBody(payloadPr, fetchImpl = globalThis.fetch) {
-	return lintPrBody(await resolveLivePrBody(payloadPr, fetchImpl), {
-		requireTestAssessment:
-			(await resolveTouchesTests(payloadPr, fetchImpl)) === true,
-	});
-}
-
 function eventPayload() {
 	const eventPath = process.env.GITHUB_EVENT_PATH;
 	if (!eventPath) throw new Error("GITHUB_EVENT_PATH is required");
@@ -397,7 +393,7 @@ export async function lintPullRequestEvent(
 		const repairedResult = lintPrBody(repairedBody, { requireTestAssessment });
 		if (repairedResult.valid) {
 			try {
-				const latestBody = await resolveLivePrBody(pullRequest, fetchImpl);
+				const latestBody = await fetchLivePrBody(pullRequest, fetchImpl);
 				if (latestBody !== body) {
 					console.log(
 						`::notice::Skipped flattened PR body repair for #${pullRequest.number}; the body changed during linting.`,
@@ -411,8 +407,8 @@ export async function lintPullRequestEvent(
 				);
 				return { valid: true, repaired: true };
 			} catch (error) {
-				console.error(
-					`::warning::Could not write the repaired PR body; preserving original lint errors (${error instanceof Error ? error.message : error}).`,
+				console.warn(
+					`::warning::Skipped flattened PR body repair for #${pullRequest.number}; freshness check failed, preserving original lint errors (${error instanceof Error ? error.message : error}).`,
 				);
 			}
 		}

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -27,6 +27,17 @@ const REPAIR_HEADINGS = [
 	"Review round \\d+",
 ];
 const REPAIR_HEADING_PATTERN = REPAIR_HEADINGS.join("|");
+const CORRUPTED_HEADING_TAILS = [
+	"ummary",
+	"ests",
+	"est assessment",
+	"last radius",
+	"lass sweep",
+	"bservability",
+	"ix round \\d+",
+	"eview round \\d+",
+];
+const CORRUPTED_IDENTIFIER_TAILS = ["etchOpenPullRequests", "px"];
 
 // Fleet census from the review of 11 bodies: ## OBSERVABILITY x5,
 // ## what changed x6, ## verification x7, and ## Summary x1. “What changed”
@@ -116,6 +127,24 @@ export function detectFlattenedBody(body = "") {
 	const newlineCount = (source.match(/\r?\n/g) ?? []).length;
 	if (newlineCount > FLATTENED_BODY_MAX_NEWLINES || source.length < 200)
 		return false;
+	// A flattened body containing these markers has already lost data. It is
+	// safer to report the original lint errors than to write a guessed repair.
+	if (
+		/[\f\t]|\r(?!\n)|\\[ftr]/.test(source) ||
+		/\\n/.test(source) ||
+		new RegExp(
+			`(?:^|[\\s])(?:${CORRUPTED_HEADING_TAILS.join("|")})(?=\\s|$)`,
+			"i",
+		).test(source) ||
+		new RegExp(
+			`(?:^|[\\s` +
+				"\\\"'" +
+				`])(?:${CORRUPTED_IDENTIFIER_TAILS.join("|")})(?=$|[\\s` +
+				"\\\"',.)" +
+				`])`,
+		).test(source)
+	)
+		return false;
 	const inlineHeadings = source.match(
 		new RegExp(
 			`(?<!^)\\s#{2,4}\\s+(?:${REPAIR_HEADING_PATTERN})(?=\\s|$)`,
@@ -129,7 +158,7 @@ export function detectFlattenedBody(body = "") {
 export function repairFlattenedBody(body = "") {
 	const source = String(body ?? "");
 	if (!detectFlattenedBody(source)) return source;
-	let repaired = source.replace(/\r\n?/g, "\n").replace(/\\r\\n|\\n/g, "\n");
+	let repaired = source.replace(/\r\n?/g, "\n");
 	repaired = repaired.replace(
 		new RegExp(`(#{2,4}\\s+(?:${REPAIR_HEADING_PATTERN}))(?=\\s)`, "g"),
 		"$1\n",
@@ -141,11 +170,6 @@ export function repairFlattenedBody(body = "") {
 		),
 		"\n\n",
 	);
-	repaired = repaired
-		.replace(/\s*```/g, "\n```")
-		.replace(/```\s*/g, "```\n")
-		.replace(/\s+(?=(?:[-*+] |\d+[.)] )\S)/g, "\n")
-		.replace(/\n{3,}/g, "\n\n");
 	return repaired;
 }
 
@@ -373,6 +397,14 @@ export async function lintPullRequestEvent(
 		const repairedResult = lintPrBody(repairedBody, { requireTestAssessment });
 		if (repairedResult.valid) {
 			try {
+				const latestBody = await resolveLivePrBody(pullRequest, fetchImpl);
+				if (latestBody !== body) {
+					console.log(
+						`::notice::Skipped flattened PR body repair for #${pullRequest.number}; the body changed during linting.`,
+					);
+					for (const error of result.errors) console.error(error);
+					return { valid: false, repaired: false };
+				}
 				await patchLivePrBody(pullRequest, repairedBody, fetchImpl);
 				console.log(
 					`::notice::Repaired flattened PR body for #${pullRequest.number} before validation passed.`,

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -130,7 +130,7 @@ export function detectFlattenedBody(body = "") {
 	// A flattened body containing these markers has already lost data. It is
 	// safer to report the original lint errors than to write a guessed repair.
 	if (
-		/[`\f\t]|\r(?!\n)|\\[ftr]/.test(source) ||
+		/[\f\t]|\r(?!\n)|\\[ftr]/.test(source) ||
 		/\\n/.test(source) ||
 		new RegExp(
 			`(?:^|[\\s])(?:${CORRUPTED_HEADING_TAILS.join("|")})(?=\\s|$)`,
@@ -170,6 +170,21 @@ export function repairFlattenedBody(body = "") {
 		),
 		"\n\n",
 	);
+	const repairedHeadings = repaired
+		.split("\n")
+		.map((line) => HEADING.exec(line)?.[1].trim().toLowerCase())
+		.filter(Boolean);
+	const templateHeadings = repairedHeadings.filter((heading) =>
+		new RegExp(`^(?:${REPAIR_HEADING_PATTERN})$`, "i").test(heading),
+	);
+	const distinctTemplateHeadings = new Set(
+		templateHeadings.map((heading) => heading.replace(/ \d+$/, "")),
+	);
+	if (
+		templateHeadings.length !== distinctTemplateHeadings.size ||
+		repairedHeadings.length > distinctTemplateHeadings.size
+	)
+		return source;
 	return repaired;
 }
 
@@ -360,6 +375,12 @@ export async function resolveTouchesTests(
 	}
 }
 
+function eventPayload() {
+	const eventPath = process.env.GITHUB_EVENT_PATH;
+	if (!eventPath) throw new Error("GITHUB_EVENT_PATH is required");
+	return JSON.parse(readFileSync(eventPath, "utf8"));
+}
+
 /**
  * The full live lint: resolve body and file list, then lint. The tri-state
  * from resolveTouchesTests is consumed HERE: only an affirmative true
@@ -367,12 +388,6 @@ export async function resolveTouchesTests(
  * (no tests/ files) both skip it, so a flaky fetch can never misfire the
  * check (#2124 review F2 pinned this consumption).
  */
-function eventPayload() {
-	const eventPath = process.env.GITHUB_EVENT_PATH;
-	if (!eventPath) throw new Error("GITHUB_EVENT_PATH is required");
-	return JSON.parse(readFileSync(eventPath, "utf8"));
-}
-
 export async function lintPullRequestEvent(
 	fetchImpl = globalThis.fetch,
 	event = eventPayload(),

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -15,6 +15,18 @@ const REQUIRED_SECTIONS = [
 	"Observability",
 ];
 const HEADING = /^#{2,4}\s+(.+?)\s*$/;
+const FLATTENED_BODY_MAX_NEWLINES = 2;
+const REPAIR_HEADINGS = [
+	"Summary",
+	"Tests",
+	"Test assessment",
+	"Blast radius",
+	"Class sweep",
+	"Observability",
+	"Fix round \\d+",
+	"Review round \\d+",
+];
+const REPAIR_HEADING_PATTERN = REPAIR_HEADINGS.join("|");
 
 // Fleet census from the review of 11 bodies: ## OBSERVABILITY x5,
 // ## what changed x6, ## verification x7, and ## Summary x1. “What changed”
@@ -96,6 +108,45 @@ function hasRealContent(lines, section, placeholders) {
 			!templateLines.has(value)
 		);
 	});
+}
+
+/** Detect the high-confidence shape produced when a worker flattens a body. */
+export function detectFlattenedBody(body = "") {
+	const source = String(body ?? "");
+	const newlineCount = (source.match(/\r?\n/g) ?? []).length;
+	if (newlineCount > FLATTENED_BODY_MAX_NEWLINES || source.length < 200)
+		return false;
+	const inlineHeadings = source.match(
+		new RegExp(
+			`(?<!^)\\s#{2,4}\\s+(?:${REPAIR_HEADING_PATTERN})(?=\\s|$)`,
+			"g",
+		),
+	);
+	return (inlineHeadings?.length ?? 0) >= 2;
+}
+
+/** Repair only a body already proven to have the flattened shape. */
+export function repairFlattenedBody(body = "") {
+	const source = String(body ?? "");
+	if (!detectFlattenedBody(source)) return source;
+	let repaired = source.replace(/\r\n?/g, "\n").replace(/\\r\\n|\\n/g, "\n");
+	repaired = repaired.replace(
+		new RegExp(`(#{2,4}\\s+(?:${REPAIR_HEADING_PATTERN}))(?=\\s)`, "g"),
+		"$1\n",
+	);
+	repaired = repaired.replace(
+		new RegExp(
+			`(?<!^)[ \\t]+(?=#{2,4}\\s+(?:${REPAIR_HEADING_PATTERN})(?=\\s|$))`,
+			"gm",
+		),
+		"\n\n",
+	);
+	repaired = repaired
+		.replace(/\s*```/g, "\n```")
+		.replace(/```\s*/g, "```\n")
+		.replace(/\s+(?=(?:[-*+] |\d+[.)] )\S)/g, "\n")
+		.replace(/\n{3,}/g, "\n\n");
+	return repaired;
 }
 
 /** Check the structural PR-body contract, including answered sections. */
@@ -202,6 +253,34 @@ export async function resolveLivePrBody(
 	}
 }
 
+export async function patchLivePrBody(
+	payloadPr,
+	body,
+	fetchImpl = globalThis.fetch,
+) {
+	const token = process.env.GITHUB_TOKEN;
+	if (!token) throw new Error("GITHUB_TOKEN is not set");
+	const apiUrl = process.env.GITHUB_API_URL;
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!apiUrl || !repository)
+		throw new Error("GITHUB_API_URL or GITHUB_REPOSITORY is missing");
+	const response = await fetchImpl(
+		`${apiUrl}/repos/${repository}/pulls/${payloadPr.number}`,
+		{
+			method: "PATCH",
+			signal: AbortSignal.timeout(10_000),
+			headers: {
+				Accept: "application/vnd.github+json",
+				Authorization: `Bearer ${token}`,
+				"X-GitHub-Api-Version": "2022-11-28",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ body }),
+		},
+	);
+	if (!response.ok) throw new Error(`GitHub API returned ${response.status}`);
+}
+
 /**
  * True when the PR touches any file under tests/. Advisory best-effort: one
  * page of 100 files covers this repo's PR sizes; on any failure (including a
@@ -274,22 +353,49 @@ function eventPayload() {
 	return JSON.parse(readFileSync(eventPath, "utf8"));
 }
 
-async function lintPullRequestEvent() {
-	const pullRequest = eventPayload().pull_request;
+export async function lintPullRequestEvent(
+	fetchImpl = globalThis.fetch,
+	event = eventPayload(),
+) {
+	const pullRequest = event.pull_request;
 	if (!pullRequest || !process.env.GITHUB_REPOSITORY)
 		throw new Error("Pull request event and GITHUB_REPOSITORY are required");
-	const result = await lintLivePrBody(pullRequest);
-	if (!result.valid) {
-		for (const error of result.errors) console.error(error);
-		process.exitCode = 1;
-		return;
+	const body = await resolveLivePrBody(pullRequest, fetchImpl);
+	const requireTestAssessment =
+		(await resolveTouchesTests(pullRequest, fetchImpl)) === true;
+	const result = lintPrBody(body, { requireTestAssessment });
+	if (result.valid) {
+		console.log(`PR body OK: ${pullRequest.number}`);
+		return { valid: true, repaired: false };
 	}
-	console.log(`PR body OK: ${pullRequest.number}`);
+	if (detectFlattenedBody(body)) {
+		const repairedBody = repairFlattenedBody(body);
+		const repairedResult = lintPrBody(repairedBody, { requireTestAssessment });
+		if (repairedResult.valid) {
+			try {
+				await patchLivePrBody(pullRequest, repairedBody, fetchImpl);
+				console.log(
+					`::notice::Repaired flattened PR body for #${pullRequest.number} before validation passed.`,
+				);
+				return { valid: true, repaired: true };
+			} catch (error) {
+				console.error(
+					`::warning::Could not write the repaired PR body; preserving original lint errors (${error instanceof Error ? error.message : error}).`,
+				);
+			}
+		}
+	}
+	for (const error of result.errors) console.error(error);
+	return { valid: false, repaired: false };
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-	lintPullRequestEvent().catch((error) => {
-		console.error(error instanceof Error ? error.message : error);
-		process.exitCode = 1;
-	});
+	lintPullRequestEvent()
+		.then((result) => {
+			if (!result.valid) process.exitCode = 1;
+		})
+		.catch((error) => {
+			console.error(error instanceof Error ? error.message : error);
+			process.exitCode = 1;
+		});
 }

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -160,16 +160,20 @@ export function repairFlattenedBody(body = "") {
 	if (!detectFlattenedBody(source)) return source;
 	let repaired = source.replace(/\r\n?/g, "\n");
 	repaired = repaired.replace(
-		new RegExp(`(#{2,4}\\s+(?:${REPAIR_HEADING_PATTERN}))(?=\\s)`, "g"),
-		"$1\n",
-	);
-	repaired = repaired.replace(
 		new RegExp(
-			`(?<!^)[ \\t]+(?=#{2,4}\\s+(?:${REPAIR_HEADING_PATTERN})(?=\\s|$))`,
-			"gm",
+			`(^|[.!?])[ \\t]*(#{2,4}\\s+(?:${REPAIR_HEADING_PATTERN}))(?=\\s|$)`,
+			"g",
 		),
-		"\n\n",
+		(_match, sentenceEnd, heading) =>
+			sentenceEnd ? `${sentenceEnd}\n\n${heading}\n` : `${heading}\n`,
 	);
+	const residualInlineHeadings = repaired.match(
+		new RegExp(
+			`(?<!^)[ \\t]#{2,4}\\s+(?:${REPAIR_HEADING_PATTERN})(?=\\s|$)`,
+			"g",
+		),
+	);
+	if (residualInlineHeadings?.length) return source;
 	const repairedHeadings = repaired
 		.split("\n")
 		.map((line) => HEADING.exec(line)?.[1].trim().toLowerCase())
@@ -180,11 +184,7 @@ export function repairFlattenedBody(body = "") {
 	const distinctTemplateHeadings = new Set(
 		templateHeadings.map((heading) => heading.replace(/ \d+$/, "")),
 	);
-	if (
-		templateHeadings.length !== distinctTemplateHeadings.size ||
-		repairedHeadings.length > distinctTemplateHeadings.size
-	)
-		return source;
+	if (repairedHeadings.length !== distinctTemplateHeadings.size) return source;
 	return repaired;
 }
 

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, afterEach, vi } from "vitest";
 import {
 	detectFlattenedBody,
 	lintPullRequestEvent,
-	lintLivePrBody,
 	lintPrBody,
 	repairFlattenedBody,
 	resolveLivePrBody,
@@ -40,14 +39,20 @@ describe("flattened PR body repair", () => {
 	});
 
 	it("rejects the minimum-length boundary", () => {
-		const boundary = "## Summary x ## Tests x".padEnd(199, "x");
+		const boundary = "x ## Summary x ## Tests x".padEnd(199, "x");
 		expect(boundary).toHaveLength(199);
+		expect(
+			boundary.match(/(?<!^)\s#{2,4}\s+(?:Summary|Tests)(?=\s|$)/g),
+		).toHaveLength(2);
 		expect(detectFlattenedBody(boundary)).toBe(false);
 	});
 
 	it("requires at least two inline headings", () => {
-		const oneHeading = `## Summary ${"x".repeat(220)}`;
+		const oneHeading = `x ## Summary ${"x".repeat(220)}`;
 		expect(oneHeading).not.toMatch(/\r?\n/);
+		expect(
+			oneHeading.match(/(?<!^)\s#{2,4}\s+(?:Summary|Tests)(?=\s|$)/g),
+		).toHaveLength(1);
 		expect(detectFlattenedBody(oneHeading)).toBe(false);
 	});
 
@@ -75,14 +80,13 @@ describe("flattened PR body repair", () => {
 		expect(repairFlattenedBody(candidate)).toBe(candidate);
 	});
 
-	it("leaves fenced code and prose hyphens unchanged", () => {
+	it("refuses bodies containing backticks", () => {
 		const candidate = flattenedBody.replace(
 			"word-index",
 			"word-index ```bash echo hi``` The well - known race",
 		);
-		const repaired = repairFlattenedBody(candidate);
-		expect(repaired).toContain("```bash echo hi```");
-		expect(repaired).toContain("The well - known race");
+		expect(detectFlattenedBody(candidate)).toBe(false);
+		expect(repairFlattenedBody(candidate)).toBe(candidate);
 	});
 
 	it("is idempotent", () => {
@@ -133,6 +137,66 @@ describe("flattened body CI entrypoint", () => {
 			expect.stringContaining("::notice::Repaired flattened PR body"),
 		);
 		log.mockRestore();
+	});
+
+	it("refuses a flattened fenced template and preserves lint errors", async () => {
+		stubApi();
+		const fencedBody =
+			flattenedBody + " ```text ## Summary one ## Tests two ```";
+		const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+		const fetchImpl = vi
+			.fn()
+			.mockImplementation(async (url: string) =>
+				String(url).includes("/files")
+					? new Response(JSON.stringify([]), { status: 200 })
+					: new Response(JSON.stringify({ body: fencedBody }), { status: 200 }),
+			);
+		expect(
+			await lintPullRequestEvent(fetchImpl, {
+				pull_request: { number: 2144, body: fencedBody },
+			}),
+		).toEqual({ valid: false, repaired: false });
+		expect(fetchImpl).not.toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ method: "PATCH" }),
+		);
+		expect(errors).toHaveBeenCalled();
+		errors.mockRestore();
+	});
+
+	it("skips the patch when freshness GET fails", async () => {
+		stubApi();
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+		let bodyGets = 0;
+		const fetchImpl = vi
+			.fn()
+			.mockImplementation(async (url: string, init?: RequestInit) => {
+				if (String(url).includes("/files"))
+					return new Response(JSON.stringify([]), { status: 200 });
+				if (init?.method === "PATCH")
+					return new Response("{}", { status: 200 });
+				bodyGets += 1;
+				if (bodyGets === 2) throw new Error("transient GET failure");
+				return new Response(JSON.stringify({ body: flattenedBody }), {
+					status: 200,
+				});
+			});
+		expect(
+			await lintPullRequestEvent(fetchImpl, {
+				pull_request: { number: 2144, body: flattenedBody },
+			}),
+		).toEqual({ valid: false, repaired: false });
+		expect(fetchImpl).not.toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ method: "PATCH" }),
+		);
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining("freshness check failed"),
+		);
+		expect(errors).toHaveBeenCalled();
+		warning.mockRestore();
+		errors.mockRestore();
 	});
 
 	it("skips the patch when the live body changes after linting", async () => {
@@ -548,69 +612,5 @@ describe("renames out of tests/ still require the assessment (#2124 F3)", () => 
 		);
 		expect(await resolveTouchesTests({ number: 7 }, fetchImpl)).toBe(true);
 		vi.unstubAllEnvs();
-	});
-});
-
-describe("the entrypoint consumes the tri-state (#2124 F2)", () => {
-	const assessedBody = `${body}
-
-### Test assessment
-foo.test.ts uniquely pins the retry ladder.`;
-
-	afterEach(() => vi.unstubAllEnvs());
-
-	function fetchFor(bodyText: string, files: unknown) {
-		return vi.fn().mockImplementation(async (url: string | URL | Request) => {
-			if (String(url).includes("/files"))
-				return files instanceof Error
-					? Promise.reject(files)
-					: new Response(JSON.stringify(files), { status: 200 });
-			return new Response(JSON.stringify({ body: bodyText }), { status: 200 });
-		});
-	}
-
-	function stubApi() {
-		vi.stubEnv("GITHUB_TOKEN", "t");
-		vi.stubEnv("GITHUB_API_URL", "https://api.example");
-		vi.stubEnv("GITHUB_REPOSITORY", "o/r");
-	}
-
-	it("requires the section when the live file list touches tests/", async () => {
-		stubApi();
-		const result = await lintLivePrBody(
-			{ number: 7, body },
-			fetchFor(body, [{ filename: "tests/clients/foo.test.ts" }]),
-		);
-		expect(result.valid).toBe(false);
-		expect(result.errors.join(" ")).toContain("Test assessment");
-	});
-
-	it("accepts the assessed body when required", async () => {
-		stubApi();
-		const result = await lintLivePrBody(
-			{ number: 7, body: assessedBody },
-			fetchFor(assessedBody, [{ filename: "tests/clients/foo.test.ts" }]),
-		);
-		expect(result).toMatchObject({ valid: true });
-	});
-
-	it("skips the section for production-only PRs", async () => {
-		stubApi();
-		const result = await lintLivePrBody(
-			{ number: 7, body },
-			fetchFor(body, [{ filename: "clients/foo.ts" }]),
-		);
-		expect(result).toMatchObject({ valid: true });
-	});
-
-	it("skips the section on file-list fetch trouble (null never enforces)", async () => {
-		stubApi();
-		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
-		const result = await lintLivePrBody(
-			{ number: 7, body },
-			fetchFor(body, new Error("boom")),
-		);
-		expect(result).toMatchObject({ valid: true });
-		warning.mockRestore();
 	});
 });

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -12,6 +12,11 @@ import {
 const body = `Summary\nOpening context.\n\n## Tests\nTargeted tests pass.\n\n## Blast radius\nNo runtime module touched.\n\n## Class sweep\nWhole-tree grep completed.\n\n## Observability\nThe advisory check run is the record.`;
 const flattenedBody =
 	"## Summary Await the first lifecycle run's asynchronous word-index snapshot promotion before reseeding the current-format snapshot for the fallback run. ## Tests - Native master flake justification for the count barrier: 2/10 forced runs reproduced the promotion race. - Fixed lifecycle test: 5/5 tests passed. ### Test assessment - tests/clients/word-index-lifecycle.test.ts uniquely pins the ordering guard. ## Blast radius This change is test-only. ## Class sweep The async-persist lifecycle race is fully covered. ## Observability The test observes existing project snapshot records.";
+const motivatingFlattenedBodies = [
+	"## Summary Fix #2052 R1 by making MCP LSP readiness consult the authoritative session-root registry. When the 128-root registry evicts a root, a later request re-registers it instead of returning from the stale lspReadyCwds memo. Add the remainder matrix cells: one mixed inside/outside batch, and an explicit /Users/... case-boundary fixture whose expected result follows the actual filesystem. ## Tests - Red-first mutation proof against the old memo-only guard: firstRootStillServed=false - npm run lint: passed. - npm run build: passed before every test run. - tests/clients/lsp/root-coalescing.test.ts: 12/12 focused tests passed. ### Test assessment - root-coalescing.test.ts uniquely pins the session-root registry and eviction transition. ## Blast radius MCP server readiness and the LSP session-root registry. ## Class sweep The memo-versus-registry readiness pair is fixed here. ## Observability Evicted roots recover; foreign roots retain the existing bounded decline record.",
+	"## Summary Fixes #2104 by making the stale-open-issues detector prove exhaustion for the open-issue population. If the safety bound is reached while a full page remains, the detector throws instead of interpreting a partial population. ## Tests - tests/scripts/stale-open-issues.test.ts adds a page-aware regression. - F1 mutation red after dropping the exhaustive flag. - Green targeted run: 20 tests passed. ### Test assessment - stale-open-issues.test.ts uniquely pins exhaustive pagination and truncation disclosure. ## Blast radius The scheduled stale-open-issues detector and its pagination helper. ## Class sweep Bounded API reads classify truncation before interpreting results. ## Observability Successful comments include the scanned population; a bound hit fails the workflow.",
+	flattenedBody,
+].map((candidate) => candidate.replaceAll("\\n", " "));
 
 describe("flattened PR body repair", () => {
 	it("detects the clearly flattened real-world shape and repairs it", () => {
@@ -80,12 +85,29 @@ describe("flattened PR body repair", () => {
 		expect(repairFlattenedBody(candidate)).toBe(candidate);
 	});
 
-	it("refuses bodies containing backticks", () => {
-		const candidate = flattenedBody.replace(
-			"word-index",
-			"word-index ```bash echo hi``` The well - known race",
-		);
-		expect(detectFlattenedBody(candidate)).toBe(false);
+	it.each(motivatingFlattenedBodies)(
+		"repairs a flattened motivating body shape",
+		(candidate) => {
+			expect(detectFlattenedBody(candidate)).toBe(true);
+			expect(
+				lintPrBody(repairFlattenedBody(candidate), {
+					requireTestAssessment: true,
+				}),
+			).toMatchObject({ valid: true });
+		},
+	);
+
+	it.each([
+		[
+			"plain quoted headings",
+			`${flattenedBody} \"## Summary one ## Tests two\"`,
+		],
+		[
+			"fenced quoted headings",
+			`${flattenedBody} \`\`\`text ## Summary one ## Tests two \`\`\``,
+		],
+	])("refuses structurally corrupted headings: %s", (_name, candidate) => {
+		expect(detectFlattenedBody(candidate)).toBe(true);
 		expect(repairFlattenedBody(candidate)).toBe(candidate);
 	});
 
@@ -612,5 +634,68 @@ describe("renames out of tests/ still require the assessment (#2124 F3)", () => 
 		);
 		expect(await resolveTouchesTests({ number: 7 }, fetchImpl)).toBe(true);
 		vi.unstubAllEnvs();
+	});
+});
+
+describe("the event entrypoint consumes the tri-state (#2124 F2)", () => {
+	const assessedBody = `${body}
+
+### Test assessment
+foo.test.ts uniquely pins the retry ladder.`;
+
+	afterEach(() => vi.unstubAllEnvs());
+
+	function stubApi() {
+		vi.stubEnv("GITHUB_TOKEN", "t");
+		vi.stubEnv("GITHUB_API_URL", "https://api.example");
+		vi.stubEnv("GITHUB_REPOSITORY", "o/r");
+	}
+
+	function fetchFor(bodyText: string, files: unknown) {
+		return vi.fn().mockImplementation(async (url: string | URL | Request) => {
+			if (String(url).includes("/files")) {
+				if (files instanceof Error) throw files;
+				return new Response(JSON.stringify(files), { status: 200 });
+			}
+			return new Response(JSON.stringify({ body: bodyText }), { status: 200 });
+		});
+	}
+
+	it("requires the section when the live file list touches tests/", async () => {
+		stubApi();
+		const result = await lintPullRequestEvent(
+			fetchFor(body, [{ filename: "tests/clients/foo.test.ts" }]),
+			{ pull_request: { number: 7, body } },
+		);
+		expect(result.valid).toBe(false);
+	});
+
+	it("accepts the assessed body when required", async () => {
+		stubApi();
+		const result = await lintPullRequestEvent(
+			fetchFor(assessedBody, [{ filename: "tests/clients/foo.test.ts" }]),
+			{ pull_request: { number: 7, body: assessedBody } },
+		);
+		expect(result).toMatchObject({ valid: true });
+	});
+
+	it("skips the section for production-only PRs", async () => {
+		stubApi();
+		const result = await lintPullRequestEvent(
+			fetchFor(body, [{ filename: "clients/foo.ts" }]),
+			{ pull_request: { number: 7, body } },
+		);
+		expect(result).toMatchObject({ valid: true });
+	});
+
+	it("skips the section on file-list fetch trouble", async () => {
+		stubApi();
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const result = await lintPullRequestEvent(
+			fetchFor(body, new Error("boom")),
+			{ pull_request: { number: 7, body } },
+		);
+		expect(result).toMatchObject({ valid: true });
+		warning.mockRestore();
 	});
 });

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -111,6 +111,42 @@ describe("flattened PR body repair", () => {
 		expect(repairFlattenedBody(candidate)).toBe(candidate);
 	});
 
+	it.each(
+		[
+			[
+				"quoted Test assessment mid-sentence",
+				"## Summary Opening context. Workers keep writing the ## Test assessment heading inline inside the Tests prose. ## Tests Targeted coverage. ## Blast radius Runtime impact. ## Class sweep Covered. ## Observability Recorded.",
+			],
+			[
+				"quoted Fix round mid-sentence",
+				"## Summary Opening context. Workers carried a ## Fix round 1 heading inline in the evidence. ## Tests Targeted coverage. ## Blast radius Runtime impact. ## Class sweep Covered. ## Observability Recorded.",
+			],
+		].map(([name, candidate]) => [name, candidate.padEnd(220, " ")]),
+	)("refuses a mid-sentence quoted heading: %s", (_name, candidate) => {
+		expect(detectFlattenedBody(candidate)).toBe(true);
+		expect(repairFlattenedBody(candidate)).toBe(candidate);
+	});
+
+	it("refuses duplicate template headings through the count check", () => {
+		const duplicate =
+			"## Summary Opening context. ## Tests First report. ## Tests Second report. ## Blast radius Runtime impact. ## Class sweep Covered. ## Observability Recorded.".padEnd(
+				220,
+				" ",
+			);
+		expect(detectFlattenedBody(duplicate)).toBe(true);
+		expect(repairFlattenedBody(duplicate)).toBe(duplicate);
+	});
+
+	it("refuses an extra repaired heading through the count check", () => {
+		const extraHeading =
+			"## Summary Opening context. ## Tests Targeted coverage.\n### Existing nested heading\n## Blast radius Runtime impact. ## Class sweep Covered. ## Observability Recorded.".padEnd(
+				220,
+				" ",
+			);
+		expect(detectFlattenedBody(extraHeading)).toBe(true);
+		expect(repairFlattenedBody(extraHeading)).toBe(extraHeading);
+	});
+
 	it("is idempotent", () => {
 		const repaired = repairFlattenedBody(flattenedBody);
 		expect(repairFlattenedBody(repaired)).toBe(repaired);

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -39,6 +39,52 @@ describe("flattened PR body repair", () => {
 		expect(detectFlattenedBody(incidental)).toBe(false);
 	});
 
+	it("rejects the minimum-length boundary", () => {
+		const boundary = "## Summary x ## Tests x".padEnd(199, "x");
+		expect(boundary).toHaveLength(199);
+		expect(detectFlattenedBody(boundary)).toBe(false);
+	});
+
+	it("requires at least two inline headings", () => {
+		const oneHeading = `## Summary ${"x".repeat(220)}`;
+		expect(oneHeading).not.toMatch(/\r?\n/);
+		expect(detectFlattenedBody(oneHeading)).toBe(false);
+	});
+
+	it.each([
+		[
+			"form feed",
+			flattenedBody.replace("word-index", "\fetchOpenPullRequests"),
+		],
+		["tab", flattenedBody.replace("word-index", "\tpx")],
+		["lone carriage return", flattenedBody.replace("word-index", "\retch")],
+		["escaped form feed", `${flattenedBody} \\fetchOpenPullRequests`],
+		["escaped tab", `${flattenedBody} \\tpx`],
+		["escaped carriage return", `${flattenedBody} \\retch`],
+		[
+			"escaped newline",
+			flattenedBody.replace("word-index", "`fetch\\nOpenPullRequests`"),
+		],
+		[
+			"missing heading letter",
+			flattenedBody.replace("## Summary", "## ummary"),
+		],
+		["missing identifier letter", `${flattenedBody} etchOpenPullRequests`],
+	])("refuses data-loss marker: %s", (_name, candidate) => {
+		expect(detectFlattenedBody(candidate)).toBe(false);
+		expect(repairFlattenedBody(candidate)).toBe(candidate);
+	});
+
+	it("leaves fenced code and prose hyphens unchanged", () => {
+		const candidate = flattenedBody.replace(
+			"word-index",
+			"word-index ```bash echo hi``` The well - known race",
+		);
+		const repaired = repairFlattenedBody(candidate);
+		expect(repaired).toContain("```bash echo hi```");
+		expect(repaired).toContain("The well - known race");
+	});
+
 	it("is idempotent", () => {
 		const repaired = repairFlattenedBody(flattenedBody);
 		expect(repairFlattenedBody(repaired)).toBe(repaired);
@@ -85,6 +131,43 @@ describe("flattened body CI entrypoint", () => {
 		);
 		expect(log).toHaveBeenCalledWith(
 			expect.stringContaining("::notice::Repaired flattened PR body"),
+		);
+		log.mockRestore();
+	});
+
+	it("skips the patch when the live body changes after linting", async () => {
+		stubApi();
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		let bodyGets = 0;
+		const changedBody = `${flattenedBody} changed`;
+		const fetchImpl = vi
+			.fn()
+			.mockImplementation(async (url: string, init?: RequestInit) => {
+				if (String(url).includes("/files"))
+					return new Response(JSON.stringify([]), { status: 200 });
+				if (init?.method === "PATCH")
+					return new Response("{}", { status: 200 });
+				bodyGets += 1;
+				return new Response(
+					JSON.stringify({
+						body: bodyGets === 1 ? flattenedBody : changedBody,
+					}),
+					{
+						status: 200,
+					},
+				);
+			});
+		expect(
+			await lintPullRequestEvent(fetchImpl, {
+				pull_request: { number: 2144, body: flattenedBody },
+			}),
+		).toEqual({ valid: false, repaired: false });
+		expect(fetchImpl).not.toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ method: "PATCH" }),
+		);
+		expect(log).toHaveBeenCalledWith(
+			expect.stringContaining("body changed during linting"),
 		);
 		log.mockRestore();
 	});

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -1,13 +1,122 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it, afterEach, vi } from "vitest";
 import {
+	detectFlattenedBody,
+	lintPullRequestEvent,
 	lintLivePrBody,
 	lintPrBody,
+	repairFlattenedBody,
 	resolveLivePrBody,
 	resolveTouchesTests,
 } from "../../scripts/check-pr-body.mjs";
 
 const body = `Summary\nOpening context.\n\n## Tests\nTargeted tests pass.\n\n## Blast radius\nNo runtime module touched.\n\n## Class sweep\nWhole-tree grep completed.\n\n## Observability\nThe advisory check run is the record.`;
+const flattenedBody =
+	"## Summary Await the first lifecycle run's asynchronous word-index snapshot promotion before reseeding the current-format snapshot for the fallback run. ## Tests - Native master flake justification for the count barrier: 2/10 forced runs reproduced the promotion race. - Fixed lifecycle test: 5/5 tests passed. ### Test assessment - tests/clients/word-index-lifecycle.test.ts uniquely pins the ordering guard. ## Blast radius This change is test-only. ## Class sweep The async-persist lifecycle race is fully covered. ## Observability The test observes existing project snapshot records.";
+
+describe("flattened PR body repair", () => {
+	it("detects the clearly flattened real-world shape and repairs it", () => {
+		expect(lintPrBody(flattenedBody)).toMatchObject({ valid: false });
+		expect(detectFlattenedBody(flattenedBody)).toBe(true);
+		const repaired = repairFlattenedBody(flattenedBody);
+		expect(lintPrBody(repaired, { requireTestAssessment: true })).toEqual({
+			valid: true,
+			errors: [],
+		});
+	});
+
+	it.each([
+		body,
+		"Summary\nShort body.\n\n## Tests\nDone.\n\n## Blast radius\nNone.\n\n## Class sweep\nDone.\n\n## Observability\nRecorded.",
+	])("does not detect a normal or short valid body", (candidate) => {
+		expect(detectFlattenedBody(candidate)).toBe(false);
+		expect(repairFlattenedBody(candidate)).toBe(candidate);
+	});
+
+	it("does not classify a long valid body with incidental inline headings", () => {
+		const incidental = `${body}\n\nExtra context.\n\n\nThe text mentions ## Tests and ## Blast radius as examples.`;
+		expect(lintPrBody(incidental)).toMatchObject({ valid: true });
+		expect(detectFlattenedBody(incidental)).toBe(false);
+	});
+
+	it("is idempotent", () => {
+		const repaired = repairFlattenedBody(flattenedBody);
+		expect(repairFlattenedBody(repaired)).toBe(repaired);
+	});
+});
+
+describe("flattened body CI entrypoint", () => {
+	afterEach(() => vi.unstubAllEnvs());
+
+	function stubApi() {
+		vi.stubEnv("GITHUB_TOKEN", "t");
+		vi.stubEnv("GITHUB_API_URL", "https://api.example");
+		vi.stubEnv("GITHUB_REPOSITORY", "o/r");
+	}
+
+	it("patches only the repaired body and reports a notice", async () => {
+		stubApi();
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchImpl = vi
+			.fn()
+			.mockImplementation(async (url: string, init?: RequestInit) => {
+				if (String(url).includes("/files"))
+					return new Response(
+						JSON.stringify([{ filename: "tests/foo.test.ts" }]),
+						{ status: 200 },
+					);
+				if (init?.method === "PATCH")
+					return new Response("{}", { status: 200 });
+				return new Response(JSON.stringify({ body: flattenedBody }), {
+					status: 200,
+				});
+			});
+		expect(
+			await lintPullRequestEvent(fetchImpl, {
+				pull_request: { number: 2144, body: flattenedBody },
+			}),
+		).toEqual({ valid: true, repaired: true });
+		expect(fetchImpl).toHaveBeenCalledWith(
+			"https://api.example/repos/o/r/pulls/2144",
+			expect.objectContaining({
+				method: "PATCH",
+				body: expect.stringContaining("## Tests\\n"),
+			}),
+		);
+		expect(log).toHaveBeenCalledWith(
+			expect.stringContaining("::notice::Repaired flattened PR body"),
+		);
+		log.mockRestore();
+	});
+
+	it("reports original errors and does not write when repair remains invalid", async () => {
+		stubApi();
+		const invalidFlattenedBody = flattenedBody.replace(
+			"## Blast radius This change is test-only.",
+			"## Blast radius",
+		);
+		const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+		const fetchImpl = vi.fn().mockImplementation(async (url: string) =>
+			String(url).includes("/files")
+				? new Response("[]", { status: 200 })
+				: new Response(JSON.stringify({ body: invalidFlattenedBody }), {
+						status: 200,
+					}),
+		);
+		const result = await lintPullRequestEvent(fetchImpl, {
+			pull_request: { number: 2144, body: invalidFlattenedBody },
+		});
+		expect(result).toMatchObject({ valid: false, repaired: false });
+		expect(errors).toHaveBeenCalledWith(
+			expect.stringContaining("PR body is missing a Summary section"),
+		);
+		expect(fetchImpl).not.toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ method: "PATCH" }),
+		);
+		errors.mockRestore();
+	});
+});
 
 describe("PR body lint (#1844)", () => {
 	it("accepts the required sections", () => {


### PR DESCRIPTION
## Summary

Detect clearly flattened pull request bodies and repair known headings before advisory lint validation. Persist a repaired body only after the existing lint contract passes. Refs #2145.

## Tests

The focused body-lint suite covers the #2119, #2135, and #2144 flattened shapes, conservative detection, structural refusal, idempotence, freshness failure, and original-error no-write behavior. Build, TypeScript lint, formatting, and changelog validation pass locally.

## Test assessment

`tests/scripts/check-pr-body.test.ts` adds real-shape flattened fixtures, plain and fenced quoted-heading corruption probes, two count-guard failure-shape fixtures, and restores four tri-state consumption cases on `lintPullRequestEvent`. No production test coverage is removed. The duplicate-template and extra-heading fixtures each reach the repair path and pin a distinct count-guard refusal.

## Blast radius

Production changes are limited to `scripts/check-pr-body.mjs`. The live body resolver remains the read seam; freshness validation still prevents concurrent overwrites, and PATCH writes only a body that re-validates. No module-report tool is available for these script modules, so dependent-module mapping is unavailable.

## Class sweep

Repair covers the known Summary, Tests, Test assessment, Blast radius, Class sweep, Observability, Fix round, and Review round headings. Repair remains headings-only. Escape-loss markers still refuse repair. The post-split count comparison refuses repeated template sections and extra heading lines.

## Observability

Successful writes emit the bounded repaired-body notice with the PR number; failed, stale, or structurally unsafe repairs preserve the original lint errors and never write.

## Fix round 2

- F1: Added a backtick refusal marker.
- F2: Added a propagating freshness GET.
- F3: Proved the length and inline-heading count boundaries with mutation tests.
- F4: Removed the production-dead `lintLivePrBody` export, declaration, and tests.
- F5: Corrected the class-sweep claim to heading-splitting only.

## Fix round 3

- N1/N2: Removed the backtick refusal marker and added the post-split structural guard. Mutation `if (false)` produced this verbatim result: `Tests 69 passed | 3 failed`, with both structural corruption probes and the fenced end-to-end refusal red. The reviewer probe now returns the original body and sends no PATCH.
- N3: Restored the four #2124 F2 tests against `lintPullRequestEvent`, covering true, assessed true, false, and null file-list outcomes. Mutation `=== true` to `!== false` produced this verbatim red: `the event entrypoint consumes the tri-state (#2124 F2) > skips the section on file-list fetch trouble`; `expected { valid: false, repaired: false } to match object { valid: true }`.
- N4: Moved the tri-state consumption JSDoc directly onto `lintPullRequestEvent`.
- N5: Fence preservation and list-item repair remain deferred because this repair is headings-only by design. Issue #2145 records the remainder.
- N6: Commit `a462945e` uses `fix(ci): make body repair refusal structural (refs #2145)`.

The targeted suite passed with `Test Files 1 passed (1)` and `Tests 69 passed (69)`. `npm run build`, `npm run lint`, `npm run fmt:check`, and `npm run changelog:check` passed.

## Fix round 4

- R1: The sentence-boundary repair restriction remains mutation-proof. Removing that restriction makes both mid-sentence quoted-heading probes red: `2 failed | 71 passed`.
- R2: Resolved by simplification. The reviewer required independent protection, so the honest fix deletes the dependent clause and keeps the count clause. The duplicate-template and extra-heading fixtures each reach the surviving guard; dropping it produces `2 failed | 71 passed`.
- R3: Corrected the body claim to describe one post-split count comparison, with one fixture per distinct failure shape.

The updated targeted suite passed with `Test Files 1 passed (1)` and `Tests 73 passed (73)`. `npm run build`, `npm run lint`, `npm run fmt:check`, and `npm run changelog:check` pass.