### PR TITLE
fix(dispatch): rebuild the ignore matcher when a nested .gitignore changes (refs #2071)

### DIFF
--- a/.changelog/fix-2071-nested-gitignore.md
+++ b/.changelog/fix-2071-nested-gitignore.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Nested `.gitignore` edits now refresh ignore verdicts (closes #2071)** —
+  agent writes invalidate the affected matcher subtree, so its per-path memo
+  cannot serve a verdict from an older ignore file. Root edits rebuild the
+  matcher, while nested edits preserve compiled-glob reuse for sibling trees.

--- a/.changelog/fix-2071-nested-gitignore.md
+++ b/.changelog/fix-2071-nested-gitignore.md
@@ -3,6 +3,7 @@ section: Fixed
 ---
 
 - **Nested `.gitignore` edits now refresh ignore verdicts (closes #2071)** —
-  agent writes invalidate the affected matcher subtree, so its per-path memo
-  cannot serve a verdict from an older ignore file. Root edits rebuild the
-  matcher, while nested edits preserve compiled-glob reuse for sibling trees.
+  agent writes invalidate every cached project matcher containing the edited
+  path, so its per-path memo cannot serve a verdict from an older ignore file.
+  Root edits rebuild each affected matcher, while nested edits preserve
+  compiled-glob reuse for sibling trees.

--- a/.changelog/fix-2071-nested-gitignore.md
+++ b/.changelog/fix-2071-nested-gitignore.md
@@ -1,4 +1,6 @@
-### Fixed
+---
+section: Fixed
+---
 
 - **Nested `.gitignore` edits now refresh ignore verdicts (closes #2071)** —
   agent writes invalidate the affected matcher subtree, so its per-path memo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,9 +579,13 @@ and only `lsp_server_spawned` answers "how many servers did we start".
 
 The project ignore matcher keeps its per-path verdict memo hot between edits.
 The write-result seam calls `invalidateProjectIgnoreMatcherForPath` for a
-`.gitignore` mutation: root changes rebuild the matcher, while nested changes
-evict only that directory's subtree. This preserves compiled-glob reuse and
-avoids a nested-file stat on every `isIgnored` verdict. (#2071)
+`.gitignore` mutation: it scans every cached root containing the edited path,
+rebuilds a root matcher, and evicts only the changed subtree for nested files.
+This handles non-git trees and nested git roots, preserves compiled-glob reuse,
+and avoids a nested-file stat on every `isIgnored` verdict. IDE edits, checkout
+or merge restoration, and writes under already-ignored directories remain
+outside the tool-result producer and are tracked by the freshness-probe issue.
+(#2071)
 
 Knip's dispatch memo is instance-owned and keyed by canonical project root plus
 the runtime's monotonic project sequence. Only callers that supply that content

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,6 +577,12 @@ and only `lsp_server_spawned` answers "how many servers did we start".
 
 ### Dispatch, runners, formatters, and installer
 
+The project ignore matcher keeps its per-path verdict memo hot between edits.
+The write-result seam calls `invalidateProjectIgnoreMatcherForPath` for a
+`.gitignore` mutation: root changes rebuild the matcher, while nested changes
+evict only that directory's subtree. This preserves compiled-glob reuse and
+avoids a nested-file stat on every `isIgnored` verdict. (#2071)
+
 Knip's dispatch memo is instance-owned and keyed by canonical project root plus
 the runtime's monotonic project sequence. Only callers that supply that content
 generation may reuse a successful result; explicit fresh-analysis callers omit

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -18,7 +18,11 @@ import {
 	getGlobalIgnorePatterns,
 	getPiLensGlobalConfigPath,
 } from "./lens-config.js";
-import { normalizeEphemeralMapKey, normalizeFilePath } from "./path-utils.js";
+import {
+	isUnderDir,
+	normalizeEphemeralMapKey,
+	normalizeFilePath,
+} from "./path-utils.js";
 import {
 	findPiLensConfigInDir,
 	findPiLensProjectConfig,
@@ -677,15 +681,18 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
  */
 export function invalidateProjectIgnoreMatcherForPath(filePath: string): void {
 	const resolvedPath = path.resolve(filePath);
-	if (path.basename(resolvedPath) !== ".gitignore") return;
-	const resolvedRoot = resolveGitIgnoreRoot(path.dirname(resolvedPath));
-	const cached = projectIgnoreMatcherCache.get(resolvedRoot);
-	if (!cached) return;
-	if (resolvedPath === path.join(resolvedRoot, ".gitignore")) {
-		projectIgnoreMatcherCache.delete(resolvedRoot);
-		return;
+	if (path.basename(resolvedPath).toLowerCase() !== ".gitignore") return;
+	for (const [cachedRoot, cached] of projectIgnoreMatcherCache) {
+		if (!isUnderDir(resolvedPath, cachedRoot)) continue;
+		if (
+			normalizeFilePath(resolvedPath) ===
+			normalizeFilePath(path.join(cachedRoot, ".gitignore"))
+		) {
+			projectIgnoreMatcherCache.delete(cachedRoot);
+			continue;
+		}
+		cached.matcher.invalidateSubtree(path.dirname(resolvedPath));
 	}
-	cached.matcher.invalidateSubtree(path.dirname(resolvedPath));
 }
 
 export function isPathIgnoredByProject(

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -416,7 +416,10 @@ function buildProjectIgnoreMatcher(
 		for (const key of patternMemo.keys()) {
 			const memoPath = key.slice(2);
 			const relative = path.relative(resolvedSubtree, memoPath);
-			if (!relative || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+			if (
+				!relative ||
+				(!relative.startsWith("..") && !path.isAbsolute(relative))
+			) {
 				patternMemo.delete(key);
 			}
 		}

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -167,6 +167,8 @@ export interface GitignorePattern {
 export interface ProjectIgnoreMatcher {
 	rootDir: string;
 	patterns: GitignorePattern[];
+	/** Drops path verdicts below a changed nested `.gitignore`. */
+	invalidateSubtree(subtree: string): void;
 	isIgnored(filePath: string, isDirectory?: boolean): boolean;
 	/**
 	 * Primes the tracked-files set for `rootDir` (async `git ls-files`,
@@ -409,6 +411,17 @@ function buildProjectIgnoreMatcher(
 		string,
 		{ ignored: boolean; layer: GitignorePatternLayer | undefined }
 	>();
+	const invalidateSubtree = (subtree: string): void => {
+		const resolvedSubtree = path.resolve(subtree);
+		for (const key of patternMemo.keys()) {
+			const memoPath = key.slice(2);
+			const relative = path.relative(resolvedSubtree, memoPath);
+			if (!relative || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+				patternMemo.delete(key);
+			}
+		}
+		nestedCache.delete(resolvedSubtree);
+	};
 
 	// Compile expanded gitignore globs once per matcher instance. Relative-path
 	// resolution remains outside this cache, so nested ignore scopes cannot leak
@@ -453,6 +466,7 @@ function buildProjectIgnoreMatcher(
 	return {
 		rootDir: resolvedRoot,
 		patterns,
+		invalidateSubtree,
 		ensureTrackedIndex(): Promise<void> {
 			return collectTrackedFiles(resolvedRoot).then(() => undefined);
 		},
@@ -649,6 +663,26 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 		matcher,
 	});
 	return matcher;
+}
+
+/**
+ * Invalidate the cached matcher state affected by a written `.gitignore`.
+ *
+ * Root changes discard the whole matcher because they change its base pattern
+ * set. Nested changes evict only verdicts in that directory's subtree; the
+ * matcher and compiled-glob memo remain reusable for unrelated trees.
+ */
+export function invalidateProjectIgnoreMatcherForPath(filePath: string): void {
+	const resolvedPath = path.resolve(filePath);
+	if (path.basename(resolvedPath) !== ".gitignore") return;
+	const resolvedRoot = resolveGitIgnoreRoot(path.dirname(resolvedPath));
+	const cached = projectIgnoreMatcherCache.get(resolvedRoot);
+	if (!cached) return;
+	if (resolvedPath === path.join(resolvedRoot, ".gitignore")) {
+		projectIgnoreMatcherCache.delete(resolvedRoot);
+		return;
+	}
+	cached.matcher.invalidateSubtree(path.dirname(resolvedPath));
 }
 
 export function isPathIgnoredByProject(

--- a/clients/runtime-tool-result.ts
+++ b/clients/runtime-tool-result.ts
@@ -24,7 +24,10 @@ import {
 import type { CacheManager } from "./cache-manager.js";
 import { createFileTime } from "./file-time.js";
 import { publishFormatQueued } from "./format-events-publish.js";
-import { isPathIgnoredByProject } from "./file-utils.js";
+import {
+	invalidateProjectIgnoreMatcherForPath,
+	isPathIgnoredByProject,
+} from "./file-utils.js";
 import type { ReadGuard } from "./read-guard.js";
 import { getFormatService } from "./format-service.js";
 import {
@@ -565,6 +568,7 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 			? rawFilePath
 			: path.resolve(resolutionBasis, rawFilePath)
 		: rawFilePath;
+	if (filePath) invalidateProjectIgnoreMatcherForPath(filePath);
 
 	// Purely diagnostic: tool_call's call-time verdict (computed on ITS OWN
 	// resolved path, which may since have been superseded) disagreed with

--- a/tests/clients/ignore-compile-memo.test.ts
+++ b/tests/clients/ignore-compile-memo.test.ts
@@ -127,6 +127,45 @@ describe("#1976 compiled-glob memo", () => {
 		}
 	});
 
+	it("refreshes a nested .gitignore in a non-git tree", () => {
+		const env = setupTestEnvironment("pi-lens-2071-no-git-");
+		try {
+			const nested = path.join(env.tmpDir, "packages", "app");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignoredPath = path.join(nested, "generated.ts");
+			const ignorePath = path.join(nested, ".gitignore");
+			fs.writeFileSync(ignorePath, "generated.ts\n");
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			expect(matcher.isIgnored(ignoredPath)).toBe(true);
+
+			fs.writeFileSync(ignorePath, "!generated.ts\n");
+			invalidateProjectIgnoreMatcherForPath(ignorePath);
+			expect(matcher.isIgnored(ignoredPath)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("refreshes an outer matcher when a nested git root changes", () => {
+		const env = setupTestEnvironment("pi-lens-2071-nested-git-");
+		try {
+			fs.mkdirSync(path.join(env.tmpDir, ".git"));
+			const nested = path.join(env.tmpDir, "submodule");
+			fs.mkdirSync(path.join(nested, ".git"), { recursive: true });
+			const ignoredPath = path.join(nested, "generated.ts");
+			const ignorePath = path.join(nested, ".gitignore");
+			fs.writeFileSync(ignorePath, "generated.ts\n");
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			expect(matcher.isIgnored(ignoredPath)).toBe(true);
+
+			fs.writeFileSync(ignorePath, "!generated.ts\n");
+			invalidateProjectIgnoreMatcherForPath(ignorePath);
+			expect(matcher.isIgnored(ignoredPath)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("compiles each expanded pattern once per matcher instance across a walk over unique paths", () => {
 		const env = setupTestEnvironment("pi-lens-1976-compile-");
 		try {

--- a/tests/clients/ignore-compile-memo.test.ts
+++ b/tests/clients/ignore-compile-memo.test.ts
@@ -32,6 +32,7 @@ import { Minimatch } from "minimatch";
 import {
 	createProjectIgnoreMatcher,
 	getProjectIgnoreMatcher,
+	invalidateProjectIgnoreMatcherForPath,
 } from "../../clients/file-utils.js";
 import { collectSourceFilesForWarmup } from "../../clients/language-profile.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
@@ -57,6 +58,75 @@ afterEach(() => {
 });
 
 describe("#1976 compiled-glob memo", () => {
+	it("refreshes a previously ignored path after a nested .gitignore edit", () => {
+		const env = setupTestEnvironment("pi-lens-2071-ignore-");
+		try {
+			fs.mkdirSync(path.join(env.tmpDir, ".git"));
+			const nested = path.join(env.tmpDir, "packages", "app");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignoredPath = path.join(nested, "generated.ts");
+			fs.writeFileSync(path.join(nested, ".gitignore"), "generated.ts\n");
+			const first = getProjectIgnoreMatcher(env.tmpDir);
+			expect(first.isIgnored(ignoredPath)).toBe(true);
+
+			fs.writeFileSync(path.join(nested, ".gitignore"), "!generated.ts\n");
+			invalidateProjectIgnoreMatcherForPath(path.join(nested, ".gitignore"));
+			const second = getProjectIgnoreMatcher(env.tmpDir);
+			expect(second.isIgnored(ignoredPath)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("refreshes a previously allowed path after a nested .gitignore edit", () => {
+		const env = setupTestEnvironment("pi-lens-2071-allow-");
+		try {
+			fs.mkdirSync(path.join(env.tmpDir, ".git"));
+			const nested = path.join(env.tmpDir, "packages", "app");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignoredPath = path.join(nested, "generated.ts");
+			fs.writeFileSync(path.join(nested, ".gitignore"), "!generated.ts\n");
+			const first = getProjectIgnoreMatcher(env.tmpDir);
+			expect(first.isIgnored(ignoredPath)).toBe(false);
+
+			fs.writeFileSync(path.join(nested, ".gitignore"), "generated.ts\n");
+			invalidateProjectIgnoreMatcherForPath(path.join(nested, ".gitignore"));
+			const second = getProjectIgnoreMatcher(env.tmpDir);
+			expect(second.isIgnored(ignoredPath)).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("handles nested .gitignore creation and deletion without flushing siblings", () => {
+		const env = setupTestEnvironment("pi-lens-2071-lifecycle-");
+		try {
+			fs.mkdirSync(path.join(env.tmpDir, ".git"));
+			const changedDir = path.join(env.tmpDir, "packages", "changed");
+			const siblingDir = path.join(env.tmpDir, "packages", "sibling");
+			fs.mkdirSync(changedDir, { recursive: true });
+			fs.mkdirSync(siblingDir, { recursive: true });
+			const changedPath = path.join(changedDir, "generated.ts");
+			const siblingPath = path.join(siblingDir, "generated.ts");
+			const ignorePath = path.join(changedDir, ".gitignore");
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			expect(matcher.isIgnored(changedPath)).toBe(false);
+			expect(matcher.isIgnored(siblingPath)).toBe(false);
+
+			fs.writeFileSync(ignorePath, "generated.ts\n");
+			invalidateProjectIgnoreMatcherForPath(ignorePath);
+			expect(getProjectIgnoreMatcher(env.tmpDir)).toBe(matcher);
+			expect(matcher.isIgnored(changedPath)).toBe(true);
+			expect(matcher.isIgnored(siblingPath)).toBe(false);
+
+			fs.unlinkSync(ignorePath);
+			invalidateProjectIgnoreMatcherForPath(ignorePath);
+			expect(matcher.isIgnored(changedPath)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("compiles each expanded pattern once per matcher instance across a walk over unique paths", () => {
 		const env = setupTestEnvironment("pi-lens-1976-compile-");
 		try {

--- a/tests/clients/runtime-tool-result.test.ts
+++ b/tests/clients/runtime-tool-result.test.ts
@@ -6,6 +6,7 @@ import { readChangesSince } from "../../clients/project-changes.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { handleToolCall } from "../../clients/runtime-tool-call.js";
 import { handleToolResult } from "../../clients/runtime-tool-result.js";
+import { getProjectIgnoreMatcher } from "../../clients/file-utils.js";
 import {
 	getVerifiedPathAttributionGuessCount,
 	resetVerifiedPathAttributionGuessCount,
@@ -23,6 +24,51 @@ const notifyExternalFileChange = vi.hoisted(() => vi.fn(async () => undefined));
 vi.mock("../../clients/lsp/index.js", () => ({ notifyExternalFileChange }));
 
 describe("bash grep searchReads registration", () => {
+	it("invalidates the ignore matcher through handleToolResult", async () => {
+		const { runPipeline } = await import("../../clients/pipeline.js");
+		vi.mocked(runPipeline).mockResolvedValue({
+			output: "",
+			hasBlockers: false,
+			isError: false,
+			fileModified: false,
+		});
+		const env = setupTestEnvironment("pi-lens-2071-tool-result-");
+		try {
+			const nested = path.join(env.tmpDir, "packages", "app");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignoredPath = path.join(nested, "generated.ts");
+			const ignorePath = path.join(nested, ".gitignore");
+			fs.writeFileSync(ignorePath, "generated.ts\n");
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			expect(matcher.isIgnored(ignoredPath)).toBe(true);
+
+			fs.writeFileSync(ignorePath, "!generated.ts\n");
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			await handleToolResult({
+				event: {
+					toolName: "write",
+					input: { path: ignorePath },
+					content: [{ type: "text", text: "written" }],
+				},
+				getFlag: () => false,
+				dbg: () => {},
+				runtime,
+				cacheManager: { addModifiedRange: () => {}, readTurnState: () => ({}) },
+				biomeClient: {},
+				ruffClient: {},
+				metricsClient: {},
+				resetLSPService: () => {},
+				agentBehaviorRecord: () => [],
+				formatBehaviorWarnings: () => "",
+			} as any);
+
+			expect(matcher.isIgnored(ignoredPath)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("registers bash reads only from a successful tool result", async () => {
 		const env = setupTestEnvironment("pi-lens-bash-read-result-");
 		try {


### PR DESCRIPTION
## Summary

Nested `.gitignore` edits invalidate every cached project matcher containing the edited path. Root edits rebuild the matcher. Nested edits evict only the changed subtree, so the per-path memo cannot serve a verdict from older ignore content.

The write-result seam calls `invalidateProjectIgnoreMatcherForPath` for agent, formatter, and recovered opaque writes. The fix preserves compiled-glob reuse, tracked-file rescue, and the existing #2096 `git ls-files` truncation classification.

## Tests

- `npx vitest run tests/clients/ignore-compile-memo.test.ts tests/clients/project-lens-ignore.test.ts tests/clients/freshness-sweep.test.ts`: 3 files, 25 tests passed before this fix round.
- `npm run build`: passed during this fix round.
- `npm run lint`: deferred to CI after the final push.
- `npm run astgrep:self-scan`: deferred to CI after the final push.
- The full suite was not run, per the targeted-test constraint.

## Blast radius

The touched production modules are `clients/file-utils.ts` and `clients/runtime-tool-result.ts`. The write boundary adds one case-insensitive basename check and one cached-root scan only when a `.gitignore` is written. The hot `isIgnored` verdict path has 0 added filesystem calls and 0 added freshness checks. Unrelated subtrees retain their matcher and compiled-glob state. Root `.gitignore` changes keep full matcher rebuild semantics.

The invalidation scan remains O(memo entries) per `.gitignore` mutation. A local run measured `55.6 ms for one invalidateSubtree scan over 10,000 memo entries` after the ancestor-walk redesign. This is accepted as a rare mutation cost.

## Class sweep

Defect shape: a per-path memo outlives an edited source file or cross-file dependency.

| Surface | Source dependency | Freshness disposition |
|---|---|---|
| Project ignore matcher | Root and nested `.gitignore`, project config, global config | Fixed here. Nested writes scan every cached ancestor root and evict only the changed subtree; root writes rebuild each affected matcher. |
| Nested project config memo | Nested `.pi-lens.json` | Existing `size:mtimeMs` gate in `patternsForDir`, rechecked because #1171 warns that a sweep can miss a sibling in its own file. |
| Compiled ignore-glob memo | Parsed pattern text | Instance-scoped and context-free. Preserved across nested subtree invalidation. |
| Tracked-file memo | `git ls-files` output | Existing bounded fetch and #2096 16MiB truncation classification unchanged. |

Residual producers are documented on #2071 and tracked by sibling issue #2159: IDE edits, git checkout or merge restoration, and writes under already-ignored directories can bypass the tool-result producer and remain stale.

## Observability

The existing dispatch and latency records remain unchanged. Correctness is observable through the refreshed matcher verdict and existing scan results. No new failure path is introduced, so no new degradation record is needed.

### Test assessment

- `tests/clients/ignore-compile-memo.test.ts`: adds non-git-tree and nested-git-root regressions. They uniquely pin ancestor-root discovery, both verdict directions, and subtree invalidation.
- `tests/clients/runtime-tool-result.test.ts`: adds a real `handleToolResult` integration regression. It uniquely pins that the production write-result boundary invokes invalidation and changes the real matcher verdict.
- Existing tests were not removed or made redundant.

## Fix round 2

- F1 and F2: `invalidateProjectIgnoreMatcherForPath` now walks `projectIgnoreMatcherCache` and processes every cached root that contains the edited `.gitignore`. It deletes the root entry when the edited file is that root's `.gitignore`, and otherwise calls `invalidateSubtree` for the edited directory. This removes dependence on `resolveGitIgnoreRoot`, covering non-git trees and nested `.git` roots.
- F3: the new test calls `handleToolResult` with a write result for a nested `.gitignore`, then asserts the real matcher flips. Mutation: I deleted `if (filePath) invalidateProjectIgnoreMatcherForPath(filePath);` from `clients/runtime-tool-result.ts`. After `npm run build`, the test red output was:

  > AssertionError: expected true to be false // Object.is equality
  >
  > - Expected
  > + Received
  >
  > - false
  > + true
  >
  > ❯ tests/clients/runtime-tool-result.test.ts:66:43

- F1 red proof mutation: I ran the new non-git-tree test against the pre-fix invalidator. The output was:

  > AssertionError: expected true to be false // Object.is equality
  >
  > ❯ tests/clients/ignore-compile-memo.test.ts:143:43

- F2 red proof mutation: I ran the new nested-git-root test against the pre-fix invalidator. The output was:

  > AssertionError: expected true to be false // Object.is equality
  >
  > ❯ tests/clients/ignore-compile-memo.test.ts:163:43

  These red proofs mutate only the invalidation behavior on the current PR branch. Reverting to master removes the function and produces a `TypeError: ... is not a function`, which is not the claimed regression proof.
- F4: the PR title is `fix(dispatch): rebuild the ignore matcher when a nested .gitignore changes (refs #2071)`. I commented on #2071 with the residual IDE, checkout/merge, and already-ignored-directory producers. I filed #2159, labeled `bug`, `area:dispatch`, and `priority:p2`, proposing a cadence-bounded mtime/size freshness probe at matcher lookup, and cross-linked #2071 and #2153.
- F5: the `.gitignore` filename identity check now lowercases the basename before comparison.
- F6: the quoted assertion outputs above are verbatim from the named mutations and local runs. No master-revert output is presented as a red regression proof.
- F7: the redesigned scan measured `55.6 ms for one invalidateSubtree scan over 10,000 memo entries`, compared with the review's 62.6 ms measurement. The synchronous rare-event cost is accepted.

Targeted tests run after builds: the two new `ignore-compile-memo` probes passed, and the `handleToolResult` wiring test passed. Mutation testing for F3 produced the assertion red quoted above. The broader affected suites, lint, ast-grep self-scan, and full suite remain CI-deferred or intentionally skipped.
