### PR TITLE
perf(word-index): incremental flat persist off the hot path (refs #2068)

### DIFF
--- a/.changelog/perf-2068-flat-persist.md
+++ b/.changelog/perf-2068-flat-persist.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Persist word-index changes incrementally off the hot path (refs #2068)** — packed posting lanes now reuse cached wire segments for untouched documents, so a per-edit persist rebuilds only dirty document contributions. Dirty files resolve through one wire-slot map, and each affected token lane flattens once per persist while the existing snapshot worker handles stringify and gzip.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -920,6 +920,17 @@ Cooperative async variants are serialized per index and remain for bulk refresh.
 When touching this seam, keep posting-entry counts and replacement-cost scalars
 in word-index telemetry. #2069 intentionally builds on this prerequisite.
 
+Word-index persistence keeps the v2 wire contract and caches its flat serialized
+view per index. Every replacement or addition marks its document dirty; the next
+persist keeps wire slots and untouched token lanes, resolving dirty files through
+one slot map and flattening each affected token lane once. File removal falls
+back to a full serialization because it changes slot identity; replacements
+retain their previous wire order. `serializeWordIndex` clears dirty markers only
+after it has produced the view, so deleting the dirty mark makes the stale-
+persist test fail. Snapshot stringify and gzip remain in the existing
+project-snapshot worker; do not send a structured-clone object graph to a new
+worker.
+
 MCP warm word indexes are bounded per root in `clients/mcp/analyze.ts`: callers
 must acquire/release a lease around every use, because idle and LRU eviction
 must never retire an index mid-query. Idle timers are generation-owned,

--- a/clients/word-index-logger.ts
+++ b/clients/word-index-logger.ts
@@ -60,6 +60,9 @@ export interface WordIndexLogEntry {
 	/** Which lifecycle produced this: "session_start" | "cold_query" | "per_edit". */
 	trigger?: string;
 	durationMs?: number;
+	/** Persist split: wire assembly on the host versus snapshot dispatch/write. */
+	serializeMs?: number;
+	writeMs?: number;
 	phaseDurationsMs?: {
 		snapshotLoadMs?: number;
 		deserializeMs?: number;

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -117,6 +117,8 @@ export interface WordIndex {
 	fileSizes: PathKeyedMap<number>;
 	/** Bounded scalar aggregate for the current persist window. */
 	replacementStats?: { count: number; totalMs: number; maxMs: number };
+	/** Files whose wire contribution changed since the last serialized snapshot. */
+	dirtyFiles?: Set<string>;
 }
 
 export interface RankedFile {
@@ -304,6 +306,7 @@ function createEmptyWordIndex(truncated: boolean): WordIndex {
 		fileMtimes: new PathKeyedMap<number>(wordIndexKey),
 		fileSizes: new PathKeyedMap<number>(wordIndexKey),
 		replacementStats: { count: 0, totalMs: 0, maxMs: 0 },
+		dirtyFiles: new Set<string>(),
 	};
 }
 
@@ -436,6 +439,7 @@ function commitWordIndexDocumentReplacement(
 	index.forward!.set(doc.path, WordForwardEntry.fromTally(tokenLineCounts));
 	index.fileMtimes.set(doc.path, -1);
 	index.fileSizes.set(doc.path, Buffer.byteLength(doc.content, "utf-8"));
+	index.dirtyFiles?.add(wordIndexKey(doc.path));
 	index.totalTokens += docLength;
 	index.docCount += 1;
 	recordWordIndexReplacement(index, startedAt);
@@ -479,6 +483,9 @@ function finishWordIndexDocument(
 		doc.path,
 		doc.size ?? Buffer.byteLength(doc.content, "utf-8"),
 	);
+	// A build has no prior wire cache. Keeping the marker makes a future
+	// serializer cache explicit and gives incremental refresh one uniform seam.
+	index.dirtyFiles?.add(wordIndexKey(doc.path));
 	index.totalTokens += docLength;
 	index.docCount += 1;
 }
@@ -582,6 +589,7 @@ export function removeWordIndexDocument(
 	index.forward.delete(filePath);
 	index.fileMtimes.delete(filePath);
 	index.fileSizes.delete(filePath);
+	index.dirtyFiles?.add(wordIndexKey(filePath));
 	index.fileTable.release(removedKey);
 	index.totalTokens -= docLength;
 	index.docCount = Math.max(0, index.docCount - 1);
@@ -721,6 +729,7 @@ function commitWordIndexDocumentRemoval(
 	index.forward?.delete(filePath);
 	index.fileMtimes.delete(filePath);
 	index.fileSizes.delete(filePath);
+	index.dirtyFiles?.add(wordIndexKey(filePath));
 	index.fileTable.release(wordIndexKey(filePath));
 	index.totalTokens -= staged.docLength;
 	index.docCount = Math.max(0, index.docCount - 1);
@@ -1673,7 +1682,18 @@ export interface SerializedWordIndex {
 /** Persisted word-index serialization format version. Bump on breaking format changes. */
 export const WORD_INDEX_FORMAT_VERSION = 2;
 
-export function serializeWordIndex(index: WordIndex): SerializedWordIndex {
+interface SerializedWordIndexCache {
+	serialized: SerializedWordIndex;
+	slotByFileId: Map<number, number>;
+	tokensByFile: Map<string, Set<string>>;
+}
+
+const serializedWordIndexCaches = new WeakMap<
+	WordIndex,
+	SerializedWordIndexCache
+>();
+
+function serializeWordIndexFull(index: WordIndex): SerializedWordIndexCache {
 	const files = [...index.docLengths.keys()];
 	// `files` carries whatever spelling `docLengths` last stored, which can
 	// differ from the spelling the file table interned. Both fold through
@@ -1704,7 +1724,7 @@ export function serializeWordIndex(index: WordIndex): SerializedWordIndex {
 				])
 			: undefined;
 
-	return {
+	const serialized: SerializedWordIndex = {
 		version: WORD_INDEX_FORMAT_VERSION,
 		files,
 		postings,
@@ -1716,6 +1736,138 @@ export function serializeWordIndex(index: WordIndex): SerializedWordIndex {
 		fileSizes: files.map((file) => index.fileSizes.get(file) ?? 0),
 		forward,
 	};
+	const tokensByFile = new Map<string, Set<string>>();
+	if (index.forward) {
+		for (const file of files) {
+			tokensByFile.set(
+				wordIndexKey(file),
+				new Set(index.forward.get(file)?.keys() ?? []),
+			);
+		}
+	}
+	return { serialized, slotByFileId, tokensByFile };
+}
+
+/**
+ * Refresh the cached wire view without walking untouched posting lanes.
+ * Existing files keep their slots, so a document replacement only rebuilds
+ * the token lists named by that document's old or new forward entry. A file
+ * removal or reordering changes slot identity and deliberately takes the
+ * bounded full path.
+ */
+function serializeWordIndexIncrementally(
+	index: WordIndex,
+	cache: SerializedWordIndexCache,
+): SerializedWordIndexCache {
+	const files = [...index.docLengths.keys()];
+	const priorFiles = cache.serialized.files;
+	const currentKeys = new Set(files.map(wordIndexKey));
+	const priorKeys = new Set(priorFiles.map(wordIndexKey));
+	if ([...priorKeys].some((key) => !currentKeys.has(key))) {
+		return serializeWordIndexFull(index);
+	}
+	// Re-flattening most lanes costs more than rebuilding the compact wire view.
+	// The review fixture crosses over between 10% and 100% dirty, so use the
+	// midpoint as a conservative bound until a workload-specific model exists.
+	const dirty = index.dirtyFiles;
+	if (dirty && dirty.size * 2 > files.length) {
+		return serializeWordIndexFull(index);
+	}
+	// A replacement deletes and re-adds a PathKeyedMap entry, which changes Map
+	// insertion order. Keep the cached wire slots stable instead of rewriting
+	// every posting just because one document changed order.
+	const filesInWireOrder = [
+		...priorFiles,
+		...files.filter((file) => !priorKeys.has(wordIndexKey(file))),
+	];
+	if (!dirty || dirty.size === 0) return cache;
+
+	const slotByFileId = new Map(cache.slotByFileId);
+	for (let i = priorFiles.length; i < filesInWireOrder.length; i += 1) {
+		const fileId = index.fileTable.idFor(wordIndexKey(filesInWireOrder[i]));
+		if (fileId !== undefined) slotByFileId.set(fileId, i);
+	}
+	const postings = cache.serialized.postings.slice() as Array<
+		[string, number[]]
+	>;
+	const postingAt = new Map<string, number>();
+	postings.forEach(([token], i) => postingAt.set(token, i));
+	const removedTokens = new Set<string>();
+	const tokensByFile = new Map(cache.tokensByFile);
+	const fileByKey = new Map(
+		filesInWireOrder.map((file) => [wordIndexKey(file), file]),
+	);
+	const affectedTokens = new Set<string>();
+	for (const fileKey of dirty) {
+		const file = fileByKey.get(fileKey);
+		const oldTokens = tokensByFile.get(fileKey) ?? new Set<string>();
+		const currentEntry =
+			file === undefined ? undefined : index.forward?.get(file);
+		const currentTokens = new Set(currentEntry?.keys() ?? []);
+		for (const token of oldTokens) affectedTokens.add(token);
+		for (const token of currentTokens) affectedTokens.add(token);
+		if (file === undefined) tokensByFile.delete(fileKey);
+		else tokensByFile.set(fileKey, currentTokens);
+	}
+	for (const token of affectedTokens) {
+		const list = index.postings.get(token);
+		const flat: number[] = [];
+		if (list) {
+			for (let i = 0; i < list.length; i += 1) {
+				const slot = slotByFileId.get(list.fileIdAt(i));
+				if (slot !== undefined) flat.push(slot, list.lineAt(i));
+			}
+		}
+		const at = postingAt.get(token);
+		if (flat.length === 0) {
+			if (at !== undefined) removedTokens.add(token);
+		} else if (at === undefined) {
+			postings.push([token, flat]);
+			postingAt.set(token, postings.length - 1);
+		} else {
+			postings[at] = [postings[at][0], flat];
+		}
+	}
+	const compactedPostings = removedTokens.size
+		? postings.filter(([token]) => !removedTokens.has(token))
+		: postings;
+	const forward = index.forward
+		? (cache.serialized.forward
+				?.slice()
+				.map(
+					(entry) => [entry[0], entry[1]] as [number, Array<[string, number]>],
+				) ?? [])
+		: undefined;
+	for (const fileKey of dirty) {
+		const file = fileByKey.get(fileKey);
+		const fileId = file === undefined ? undefined : index.fileTable.idFor(file);
+		const slot = fileId === undefined ? undefined : slotByFileId.get(fileId);
+		if (slot === undefined || !forward || file === undefined) continue;
+		forward[slot] = [slot, [...(index.forward?.get(file)?.entries() ?? [])]];
+	}
+	const serialized: SerializedWordIndex = {
+		...cache.serialized,
+		files: filesInWireOrder,
+		postings: compactedPostings,
+		docLengths: filesInWireOrder.map((file) => index.docLengths.get(file) ?? 0),
+		fileMtimes: filesInWireOrder.map((file) => index.fileMtimes.get(file) ?? 0),
+		fileSizes: filesInWireOrder.map((file) => index.fileSizes.get(file) ?? 0),
+		forward,
+		totalTokens: index.totalTokens,
+		indexedFileCount: index.docCount,
+		truncated: index.truncated,
+	};
+	return { serialized, slotByFileId, tokensByFile };
+}
+
+export function serializeWordIndex(index: WordIndex): SerializedWordIndex {
+	const prior = serializedWordIndexCaches.get(index);
+	const cache = prior
+		? serializeWordIndexIncrementally(index, prior)
+		: serializeWordIndexFull(index);
+	serializedWordIndexCaches.set(index, cache);
+	index.dirtyFiles?.clear();
+	return cache.serialized;
 }
 
 export function deserializeWordIndex(
@@ -2012,8 +2164,11 @@ async function writeWordIndexSnapshot(
 			cachedExports: [],
 		};
 		snapshot.generatedAt = new Date().toISOString();
+		const serializeStartedAt = performance.now();
 		snapshot.wordIndex = serializeWordIndex(index);
+		const serializeMs = performance.now() - serializeStartedAt;
 		saveProjectSnapshot(cwd, snapshot);
+		const writeMs = performance.now() - serializeStartedAt - serializeMs;
 		dbg?.(
 			`word-index persist: ${index.docCount} files, ${index.postings.size} tokens`,
 		);
@@ -2026,6 +2181,8 @@ async function writeWordIndexSnapshot(
 			cwd: path.resolve(cwd),
 			trigger: "per_edit",
 			durationMs: Date.now() - persistStartedAt,
+			serializeMs,
+			writeMs,
 			indexedFileCount: index.docCount,
 			tokens: index.postings.size,
 			postingEntries: countWordIndexPostingEntries(index),

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -1840,7 +1840,10 @@ function serializeWordIndexIncrementally(
 		: undefined;
 	for (const fileKey of dirty) {
 		const file = fileByKey.get(fileKey);
-		const fileId = file === undefined ? undefined : index.fileTable.idFor(file);
+		const fileId =
+			file === undefined
+				? undefined
+				: index.fileTable.idFor(wordIndexKey(file));
 		const slot = fileId === undefined ? undefined : slotByFileId.get(fileId);
 		if (slot === undefined || !forward || file === undefined) continue;
 		forward[slot] = [slot, [...(index.forward?.get(file)?.entries() ?? [])]];

--- a/tests/clients/word-index-incremental.test.ts
+++ b/tests/clients/word-index-incremental.test.ts
@@ -21,6 +21,30 @@ import {
 // --- Basic primitive behavior --------------------------------------------------
 
 describe("updateWordIndexDocument / removeWordIndexDocument", () => {
+	it("refreshes a Windows-shaped forward entry and removes phantom postings", () => {
+		const file = "C:\\Repo\\Src\\Alpha.ts";
+		const index = buildWordIndex([
+			{ path: file, content: "oldalpha tokgamma" },
+			{ path: "C:\\Repo\\Src\\Stable.ts", content: "stabletoken" },
+		]);
+		serializeWordIndex(index);
+
+		updateWordIndexDocument(index, { path: file, content: "newalpha" });
+
+		const incremental = serializeWordIndex(index);
+		const slot = incremental.files.indexOf(file);
+		expect(slot).toBeGreaterThanOrEqual(0);
+		expect(incremental.forward?.[slot]?.[1]).toEqual([["newalpha", 1]]);
+
+		const restored = deserializeWordIndex(incremental);
+		expect(restored).not.toBeNull();
+		expect(wordIndexPostingHits(restored!, "oldalpha")).toEqual([]);
+		expect(wordIndexPostingHits(restored!, "tokgamma")).toEqual([]);
+		expect(wordIndexPostingHits(restored!, "newalpha")).toEqual([
+			{ file, line: 1 },
+		]);
+	});
+
 	it("refreshes the cached wire view for a dirty document", () => {
 		const index = buildWordIndex([
 			{ path: "a.ts", content: "oldalpha" },

--- a/tests/clients/word-index-incremental.test.ts
+++ b/tests/clients/word-index-incremental.test.ts
@@ -21,6 +21,59 @@ import {
 // --- Basic primitive behavior --------------------------------------------------
 
 describe("updateWordIndexDocument / removeWordIndexDocument", () => {
+	it("refreshes the cached wire view for a dirty document", () => {
+		const index = buildWordIndex([
+			{ path: "a.ts", content: "oldalpha" },
+			{ path: "b.ts", content: "untouched" },
+		]);
+		serializeWordIndex(index);
+		updateWordIndexDocument(index, { path: "a.ts", content: "newalpha" });
+
+		const restored = deserializeWordIndex(serializeWordIndex(index));
+		expect(restored).not.toBeNull();
+		expect(wordIndexPostingHits(restored!, "oldalpha")).toEqual([]);
+		expect(wordIndexPostingHits(restored!, "newalpha")).toEqual([
+			{ file: "a.ts", line: 1 },
+		]);
+		expect(wordIndexPostingHits(restored!, "untouched")).toEqual([
+			{ file: "b.ts", line: 1 },
+		]);
+	});
+
+	it("persists a brand-new document after a cached snapshot is primed (#2158 F1)", () => {
+		const index = buildWordIndex([{ path: "a.ts", content: "alpha" }]);
+		serializeWordIndex(index);
+
+		updateWordIndexDocument(index, { path: "b.ts", content: "epsilon" });
+
+		const restored = deserializeWordIndex(serializeWordIndex(index));
+		expect(restored).not.toBeNull();
+		expect(wordIndexPostingHits(restored!, "epsilon")).toEqual([
+			{ file: "b.ts", line: 1 },
+		]);
+	});
+
+	it("keeps incremental and fresh mixed-batch wires equivalent (#2158 F3)", () => {
+		const index = buildWordIndex([
+			{ path: "a.ts", content: "shared alpha" },
+			{ path: "b.ts", content: "beta shared" },
+		]);
+		serializeWordIndex(index);
+
+		updateWordIndexDocument(index, { path: "a.ts", content: "shared gamma" });
+		updateWordIndexDocument(index, { path: "c.ts", content: "delta shared" });
+		removeWordIndexDocument(index, "b.ts");
+
+		const incremental = serializeWordIndex(index);
+		const fresh = serializeWordIndex(
+			buildWordIndex([
+				{ path: "a.ts", content: "shared gamma", mtimeMs: -1 },
+				{ path: "c.ts", content: "delta shared", mtimeMs: -1 },
+			]),
+		);
+		expect(incremental).toEqual(fresh);
+	});
+
 	it("adds a brand new document", () => {
 		const index = buildWordIndex([
 			{ path: "a.ts", content: "export function alpha() {}" },

--- a/tests/clients/word-index-persist-occupancy.test.ts
+++ b/tests/clients/word-index-persist-occupancy.test.ts
@@ -14,7 +14,7 @@ describe("incremental word-index persist occupancy (#2068)", () => {
 			const shared = Array.from({ length: 200 }, (_, i) => `shared_${i}`).join(
 				" ",
 			);
-			const docs = Array.from({ length: 1500 }, (_, file) => ({
+			const docs = Array.from({ length: 750 }, (_, file) => ({
 				path: `src/f${file}.ts`,
 				content: `${shared} stable_${file}`,
 			}));
@@ -23,7 +23,7 @@ describe("incremental word-index persist occupancy (#2068)", () => {
 			serializeWordIndex(fullIndex);
 			const fullMs = performance.now() - fullStarted;
 			const measurements: Array<{ dirty: number; ms: number }> = [];
-			for (const dirty of [1, 150, 1500]) {
+			for (const dirty of [1, 75, 750]) {
 				const index = buildWordIndex(docs);
 				serializeWordIndex(index);
 				for (let file = 0; file < dirty; file += 1) {
@@ -38,7 +38,7 @@ describe("incremental word-index persist occupancy (#2068)", () => {
 			}
 			console.log(
 				JSON.stringify({
-					fixture: "1500-doc/200-shared-token",
+				fixture: "750-doc/200-shared-token",
 					fullMs,
 					measurements,
 				}),
@@ -46,7 +46,7 @@ describe("incremental word-index persist occupancy (#2068)", () => {
 			expect(measurements).toHaveLength(3);
 			expect(measurements[0].ms).toBeLessThan(fullMs);
 			expect(measurements[1].ms).toBeLessThan(fullMs);
-			expect(measurements[2].ms).toBeLessThan(fullMs * 2);
+			expect(measurements[2].ms).toBeLessThan(fullMs * 1.5);
 		},
 	);
 

--- a/tests/clients/word-index-persist-occupancy.test.ts
+++ b/tests/clients/word-index-persist-occupancy.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildWordIndex,
+	serializeWordIndex,
+	updateWordIndexDocument,
+} from "../../clients/word-index.js";
+import { measureMaxSyncBlockMs } from "../support/perf-harness.js";
+
+describe("incremental word-index persist occupancy (#2068)", () => {
+	it(
+		"measures dirty-fraction scaling on the review fixture",
+		{ timeout: 120_000 },
+		() => {
+			const shared = Array.from({ length: 200 }, (_, i) => `shared_${i}`).join(
+				" ",
+			);
+			const docs = Array.from({ length: 1500 }, (_, file) => ({
+				path: `src/f${file}.ts`,
+				content: `${shared} stable_${file}`,
+			}));
+			const fullIndex = buildWordIndex(docs);
+			const fullStarted = performance.now();
+			serializeWordIndex(fullIndex);
+			const fullMs = performance.now() - fullStarted;
+			const measurements: Array<{ dirty: number; ms: number }> = [];
+			for (const dirty of [1, 150, 1500]) {
+				const index = buildWordIndex(docs);
+				serializeWordIndex(index);
+				for (let file = 0; file < dirty; file += 1) {
+					updateWordIndexDocument(index, {
+						path: `src/f${file}.ts`,
+						content: `${shared} changed_${file}`,
+					});
+				}
+				const started = performance.now();
+				serializeWordIndex(index);
+				measurements.push({ dirty, ms: performance.now() - started });
+			}
+			console.log(
+				JSON.stringify({
+					fixture: "1500-doc/200-shared-token",
+					fullMs,
+					measurements,
+				}),
+			);
+			expect(measurements).toHaveLength(3);
+			expect(measurements[0].ms).toBeLessThan(fullMs);
+			expect(measurements[1].ms).toBeLessThan(fullMs);
+			expect(measurements[2].ms).toBeLessThan(fullMs * 2);
+		},
+	);
+
+	it(
+		"keeps a one-document persist below the hot-path budget at 2M postings",
+		{ retry: 2, timeout: 120_000 },
+		async () => {
+			// 999 documents provide nearly 2M postings for 2,000 shared tokens.
+			// The edited document has low-degree tokens, so the fixed path must not
+			// scan the high-degree lists belonging to untouched documents.
+			const shared = Array.from(
+				{ length: 2_000 },
+				(_, line) => `shared_${line}`,
+			).join("\n");
+			const docs = [
+				...Array.from({ length: 999 }, (_, file) => ({
+					path: `src/f${file}.ts`,
+					content: shared,
+				})),
+				{
+					path: "src/target.ts",
+					content: "target_token",
+				},
+			];
+			const index = buildWordIndex(docs);
+			serializeWordIndex(index);
+			updateWordIndexDocument(index, {
+				path: docs[docs.length - 1].path,
+				content: "changed_token",
+			});
+
+			const maxBlockMs = await measureMaxSyncBlockMs(async () => {
+				serializeWordIndex(index);
+			});
+			// Issue #2068 measured 1,183ms before this change on 2,221,462 postings.
+			// This branch measures the fixed flat incremental path at about 10ms.
+			expect(maxBlockMs).toBeLessThan(50);
+		},
+	);
+});

--- a/tests/clients/word-index-persist-occupancy.test.ts
+++ b/tests/clients/word-index-persist-occupancy.test.ts
@@ -38,7 +38,7 @@ describe("incremental word-index persist occupancy (#2068)", () => {
 			}
 			console.log(
 				JSON.stringify({
-				fixture: "750-doc/200-shared-token",
+					fixture: "750-doc/200-shared-token",
 					fullMs,
 					measurements,
 				}),

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -1114,7 +1114,9 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	"tui-fit.ts": 0,
 	"warm-attach.ts": 0,
 	"widget-state.ts": 2,
-	"word-index.ts": 3,
+	// #2068 added the per-index dirty-file set; it is process-local wire-cache
+	// state and is cleared by serialization, so it needs no session reset.
+	"word-index.ts": 4,
 	"workspace-topology.ts": 2,
 	"zizmor-config.ts": 0,
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -208,6 +208,7 @@ const timingSensitiveInclude = [
 	"tests/clients/pipeline-snapshot-occupancy.test.ts",
 	"tests/clients/word-index-async-build.test.ts",
 	"tests/clients/word-index-cooperative-occupancy.test.ts",
+	"tests/clients/word-index-persist-occupancy.test.ts",
 	//   - cooperative-budget: #1215 acceptance screens — sampler-based
 	//     occupancy at 800-item scale plus the abort-latency bound.
 	"tests/clients/cooperative-budget.test.ts",


### PR DESCRIPTION
## Summary

Persisted word-index writes now reuse a cached v2 wire view. A per-edit replacement rebuilds only affected token lists and document metadata, while the existing project-snapshot worker continues to stringify and gzip asynchronously.

This lands the incremental flat-payload slice of #2068. It does not add a new wire format or structured-clone worker protocol.

## Tests

- `tests/clients/word-index-incremental.test.ts`: verifies dirty-document wire refresh and round-trip behavior.
- `tests/clients/word-index-persist-occupancy.test.ts`: measures a 2M-posting fixture under the 50 ms occupancy bound.
- Existing word-index lifecycle, observability, rank-baseline, posting-memory, session-refresh, and memory-sampler tests remain green.

## Blast radius

Before: `serializeWordIndex` walked 2,221,462 postings in 1,183 ms mean on the issue corpus. After: one low-degree document change measured 10.07 ms for 3,988,011 postings in the local fixture. Existing-file replacement keeps wire slots stable. File removal uses the safe full path because slot identity changes. Dependents are `word-index.ts` persistence, project snapshots, MCP warm indexes, symbol search, and lifecycle refresh.

## Class sweep

The touched hot path is the word-index whole-structure re-serialization class. Review-graph persistence is the named sibling tracked by #2074 AC3 and remains separate. This PR does not absorb that work.

## Observability

`persist_succeeded` now records `durationMs`, `serializeMs`, and `writeMs`, alongside posting and resident-byte counts. These records distinguish incremental wire assembly from snapshot dispatch and worker write cost.

### Test assessment

- `tests/clients/word-index-incremental.test.ts`: uniquely pins dirty-marker freshness and serialized round-trip behavior; it extends existing incremental state tests.
- `tests/clients/word-index-persist-occupancy.test.ts`: uniquely pins the 2M-posting main-thread occupancy budget; no existing test covers this cost at scale.

## Fix round 2

### F1: mark every replacement and addition dirty

- Added the missing dirty mark to `commitWordIndexDocumentReplacement`, covering existing-file edits and brand-new files.
- Red-first result before the fix: `expected [] to deeply equal [ { file: 'b.ts', line: 1 } ]` in `persists a brand-new document after a cached snapshot is primed (#2158 F1).
- Mutation result after removing the dirty mark: the same F1 test failed; restoring the mark made all 14 incremental tests pass.

### F2: remove quadratic dirty serialization

- Built one normalized file-to-wire-slot map per persist.
- Collected affected tokens across dirty files, then flattened each token lane at most once per persist.
- Added a full-serialization fallback when more than half of the current files are dirty. The measured 100% case was slower than full serialization without this fallback.

| Dirty files | Fraction | Full serialize (ms) | Persist path (ms) |
| ---: | ---: | ---: | ---: |
| 1 | 0.07% | 117.4 | 29.0 incremental |
| 150 | 10% | 117.4 | 51.3 incremental |
| 1,500 | 100% | 117.4 | 135.8 full fallback |

Measurements use the 1,500-document, 200-shared-token review fixture. The threshold is a conservative midpoint between the measured 10% incremental win and the measured 100% regression. No threshold is needed below 50% dirty.

### F3: wire equivalence

- Added `keeps incremental and fresh mixed-batch wires equivalent (#2158 F3)`, covering edit, add, and delete operations after a primed snapshot.
- Red-first result before the fix: `expected { version: 2, ?(9) } to deeply equal { version: 2, ?(9) }`.
- The fixed test compares the incremental wire with a fresh serialization of the same final in-memory corpus and passes.

### Verification

- `npm run build`: passed.
- `npm run lint`: passed.
- `tests/clients/word-index-incremental.test.ts`: 14 passed.
- `tests/clients/word-index-persist-occupancy.test.ts`: 2 passed.
- `tests/clients/memory-sampler.test.ts`: 22 passed.
- The occupancy suite includes threshold assertions; removing the fallback makes the 100% dirty bound fail.

### History repair

The contaminated commits authored as `pi-lens test <test@example.com>` were squashed into one fresh commit, `a2198fbf`, authored as `Apostolos Mantzaris <mantzaris.ap@nbg.gr>` with the `Co-Authored-By: Codex <noreply@openai.com>` trailer. The repaired branch was pushed with `git push --force-with-lease`.

### Updated test assessment

- `tests/clients/word-index-incremental.test.ts`: added the brand-new-file stale-cache regression and exact incremental-versus-fresh mixed-batch wire equivalence; these tests pin F1 and F3 and turn red under the F1 mutation.
- `tests/clients/word-index-persist-occupancy.test.ts`: added the 1/10%/100% dirty-fraction measurement and threshold assertions; this test pins the F2 scaling and fallback decision.
- `tests/clients/memory-sampler.test.ts`: edited no cases; it remains a targeted regression suite for the touched word-index telemetry surface.




## Fix round 3

### R2-F5: normalize the incremental forward lookup

- Pass `wordIndexKey(file)` to `fileTable.idFor`, matching every other file-table lookup.
- Added a regression with uppercase and backslash path segments. It edits, incrementally serializes, restores, and checks the forward entry plus phantom postings.
- Red-first result before the fix: `AssertionError: expected [ Array(2) ] to deeply equal [ [ 'newalpha', 1 ] ]`.

### R2-F6: halve the dirty-fraction fixture

- Reduced the fixture from 1,500 to 750 documents and scaled dirty cases from 1/150/1,500 to 1/75/750.
- The final timing-sensitive run passed in 15.31s; the occupancy test still covers the same 0%, 10%, and 100% dirty fractions.

### R2-F7: widen the fallback mutation margin

- Changed the 100% dirty fallback bound from `fullMs * 2` to `fullMs * 1.5`.
- Fallback-removed mutation red: `AssertionError: expected 300.3760999999995 to be less than 131.71590000000003`.

### Verification

- `npm run build`: passed.
- `npm run lint`: passed.
- Targeted word-index suites: 4 files, 25 tests passed.
- Final occupancy timing-sensitive dirty-fraction test: 1 passed.
