### PR TITLE
fix(lsp): distinguish clean from absent in late-aux harvest (closes #2151)

### DIFF
--- a/.changelog/fix-2151-aux-clean-vs-absent.md
+++ b/.changelog/fix-2151-aux-clean-vs-absent.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Distinguish clean from absent auxiliary LSP results (closes #2151)** — Turn-end late-auxiliary harvesting now recognizes published clean results and retires stuck coverage pairs with bounded, reconciled telemetry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,14 @@ client cache. Carry them into that read only when their stored SHA-256 content
 binding matches the touch content exactly. Unknown or changed-content bindings
 never replay. (#1458)
 
+Turn-end late-auxiliary cache probes return per-file diagnostics with the
+publication timestamp. A newer timestamp with zero diagnostics is a confirmed
+clean result; an absent or older entry is still unavailable. Keep re-arms
+bounded by both the TTL and a hard count carried across each drain, and expose
+bounded stuck-pair identity in the phase record. Pair-level retirements and
+finding-level counts use separate fields and reconcile each drained pair to
+one retirement or a pending-after count. (#2151)
+
 Every auxiliary touch emits one bounded `lsp_aux_wait_outcome` latency row, on
 both producers: the `with-auxiliary` grace wait (`waitShape: "aux_grace"`) and,
 since #1533, the `clientScope: "all"` aggregate wait (`waitShape: "aggregate"`),

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -2694,15 +2694,23 @@ export class LSPService {
 	 * `isServerAliveForFile`, this NEVER creates or warms a client — it only
 	 * resolves each requested server's root and reads the already-connected
 	 * client's cached diagnostics for `filePath`. Servers with no live client
-	 * are simply absent from the returned map (the caller drops those pairs
-	 * silently); a present server maps to its cache contents, possibly empty
-	 * (still scanning).
+	 * are simply absent from the returned map. A live client is present only
+	 * when its per-file cache entry exists; its timestamp distinguishes a
+	 * published clean result from no publication.
 	 */
 	async readCachedDiagnosticsForServers(
 		filePath: string,
 		serverIds: ReadonlySet<string>,
-	): Promise<Map<string, import("./client.js").LSPDiagnostic[]>> {
-		const out = new Map<string, import("./client.js").LSPDiagnostic[]>();
+	): Promise<
+		Map<
+			string,
+			{ diags: import("./client.js").LSPDiagnostic[]; publishedAt?: number }
+		>
+	> {
+		const out = new Map<
+			string,
+			{ diags: import("./client.js").LSPDiagnostic[]; publishedAt?: number }
+		>();
 		if (this.checkDestroyed() || serverIds.size === 0) return out;
 		for (const server of getServersForFileWithConfig(filePath)) {
 			if (!serverIds.has(server.id) || out.has(server.id)) continue;
@@ -2711,7 +2719,11 @@ export class LSPService {
 			const key = `${server.id}:${normalizeMapKey(root)}`;
 			const client = this.state.clients.get(key);
 			if (!client?.isAlive()) continue;
-			out.set(server.id, client.getDiagnostics(filePath));
+			const entry = client.getAllDiagnostics().get(normalizeMapKey(filePath));
+			out.set(server.id, {
+				diags: entry?.diags ?? [],
+				publishedAt: entry?.ts,
+			});
 		}
 		return out;
 	}

--- a/clients/lsp/pending-aux-coverage.ts
+++ b/clients/lsp/pending-aux-coverage.ts
@@ -50,6 +50,7 @@ export const MAX_PENDING_AUX_ENTRIES = 50;
  * forever. Overridable via `PI_LENS_LATE_AUX_REARM_TTL_MS`.
  */
 export const DEFAULT_LATE_AUX_REARM_TTL_MS = 5 * 60_000;
+export const MAX_LATE_AUX_REARMS = 8;
 
 /**
  * Read the `PI_LENS_LATE_AUX_REARM_TTL_MS` env override at call time (not
@@ -89,6 +90,7 @@ export interface PendingAuxCoverageEntry {
 	 * gate's freshness comparison.
 	 */
 	lastRearmedAtMs?: number;
+	rearmCount?: number;
 }
 
 /**
@@ -129,6 +131,7 @@ export function markPendingAuxiliaryCoverage(
 	serverIds: readonly string[],
 	markedAtMs: number = Date.now(),
 	rearmedAtMs?: number,
+	rearmCount?: number,
 ): void {
 	for (const serverId of serverIds) {
 		const key = pairKey(filePath, serverId);
@@ -149,6 +152,7 @@ export function markPendingAuxiliaryCoverage(
 							serverId,
 							markedAtMs: existing.markedAtMs,
 							lastRearmedAtMs: rearmedAtMs,
+							rearmCount: rearmCount ?? (existing.rearmCount ?? 0) + 1,
 						},
 			);
 			continue;
@@ -157,7 +161,13 @@ export function markPendingAuxiliaryCoverage(
 			key,
 			rearmedAtMs === undefined
 				? { filePath, serverId, markedAtMs }
-				: { filePath, serverId, markedAtMs, lastRearmedAtMs: rearmedAtMs },
+				: {
+						filePath,
+						serverId,
+						markedAtMs,
+						lastRearmedAtMs: rearmedAtMs,
+						rearmCount: rearmCount ?? 1,
+					},
 		);
 		while (pending.size > MAX_PENDING_AUX_ENTRIES) {
 			const oldest = pending.keys().next().value;
@@ -165,6 +175,22 @@ export function markPendingAuxiliaryCoverage(
 			pending.delete(oldest);
 		}
 	}
+}
+
+/** Re-arm a drained pair while carrying its ceiling count across the drain. */
+export function rearmPendingAuxiliaryCoverage(
+	pair: PendingAuxCoverageEntry,
+	rearmedAtMs: number = Date.now(),
+	refreshBaseline = false,
+): void {
+	const nextCount = (pair.rearmCount ?? 0) + 1;
+	markPendingAuxiliaryCoverage(
+		pair.filePath,
+		[pair.serverId],
+		refreshBaseline ? rearmedAtMs : pair.markedAtMs,
+		rearmedAtMs,
+		nextCount,
+	);
 }
 
 /**
@@ -190,10 +216,14 @@ export function drainPendingAuxiliaryCoverage(): PendingAuxCoverageEntry[] {
 	return drained;
 }
 
-/** Test-only: current pending pair count. */
-export function pendingAuxiliaryCoverageSizeForTests(): number {
+/** Current pending pair count for bounded reconciliation telemetry. */
+export function pendingAuxiliaryCoverageSize(): number {
 	return pending.size;
 }
+
+/** Test-only alias for the store-size assertion seam. */
+export const pendingAuxiliaryCoverageSizeForTests =
+	pendingAuxiliaryCoverageSize;
 
 /**
  * Session-boundary clear (#1635): pending baselines are unreachable after

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -99,7 +99,9 @@ import { getLSPService } from "./lsp/index.js";
 import {
 	drainPendingAuxiliaryCoverage,
 	isPendingAuxiliaryPastRearmTtl,
-	markPendingAuxiliaryCoverage,
+	rearmPendingAuxiliaryCoverage,
+	MAX_LATE_AUX_REARMS,
+	pendingAuxiliaryCoverageSize,
 } from "./lsp/pending-aux-coverage.js";
 import type { LSPDiagnostic } from "./lsp/client.js";
 import { convertLspDiagnostics } from "./dispatch/utils/lsp-diagnostics.js";
@@ -2353,6 +2355,11 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	let lateAuxRearmed = 0;
 	let lateAuxClientGone = 0;
 	let lateAuxProbeFailed = 0;
+	let lateAuxCleanConfirmed = 0;
+	let lateAuxExpired = 0;
+	let lateAuxCeilingExhausted = 0;
+	let lateAuxAnswered = 0;
+	const lateAuxStuckPairs: Array<{ filePath: string; serverId: string }> = [];
 	if (drainedPairs.length > 0) {
 		const byFile = new Map<string, typeof drainedPairs>();
 		for (const pair of drainedPairs) {
@@ -2363,7 +2370,10 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 		try {
 			const service = getLSPService();
 			for (const [lateAuxPath, pairs] of byFile) {
-				let cached: Map<string, LSPDiagnostic[]>;
+				let cached: Map<
+					string,
+					{ diags: LSPDiagnostic[]; publishedAt?: number }
+				>;
 				try {
 					cached = await service.readCachedDiagnosticsForServers(
 						lateAuxPath,
@@ -2372,25 +2382,22 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 				} catch {
 					// #2027 round-1 P3-2: count dropped pairs — never silent.
 					lateAuxProbeFailed += pairs.length;
-					for (const pair of pairs) {
-						markPendingAuxiliaryCoverage(
-							pair.filePath,
-							[pair.serverId],
-							Date.now(),
-						);
-					}
 					continue;
 				}
 				const displayLateAuxPath = toRunnerDisplayPath(cwd, lateAuxPath);
 				for (const pair of pairs) {
-					const rawDiags = cached.get(pair.serverId);
-					if (rawDiags === undefined) {
+					const cachedEntry = cached.get(pair.serverId);
+					if (cachedEntry === undefined) {
 						// No live client for this server any more — best-effort probe,
 						// drop the pair silently.
 						lateAuxClientGone += 1;
 						continue;
 					}
-					if (rawDiags.length === 0) {
+					const rawDiags = cachedEntry.diags;
+					if (
+						cachedEntry.publishedAt === undefined ||
+						cachedEntry.publishedAt <= pair.markedAtMs
+					) {
 						// Still scanning (or published nothing yet) — keep waiting
 						// so a scan finishing before the NEXT turn end still
 						// delivers. Two clocks, deliberately decoupled: the
@@ -2398,21 +2405,35 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 						// the delivery gate stats against — while the re-arm TTL is
 						// anchored on `lastRearmedAtMs`, advanced by every successful
 						// empty probe: the scanner is demonstrably alive, just slow.
-						if (!isPendingAuxiliaryPastRearmTtl(pair)) {
-							markPendingAuxiliaryCoverage(
-								lateAuxPath,
-								[pair.serverId],
-								pair.markedAtMs,
-								Date.now(),
-							);
+						if (
+							!isPendingAuxiliaryPastRearmTtl(pair) &&
+							(pair.rearmCount ?? 0) < MAX_LATE_AUX_REARMS
+						) {
+							rearmPendingAuxiliaryCoverage(pair);
 							lateAuxRearmed += 1;
+							if (lateAuxStuckPairs.length < 20)
+								lateAuxStuckPairs.push({
+									filePath: pair.filePath,
+									serverId: pair.serverId,
+								});
+						} else {
+							if (isPendingAuxiliaryPastRearmTtl(pair)) lateAuxExpired += 1;
+							else lateAuxCeilingExhausted += 1;
 						}
+						continue;
+					}
+					if (rawDiags.length === 0) {
+						lateAuxCleanConfirmed += 1;
 						continue;
 					}
 					const converted = convertLspDiagnostics(rawDiags, lateAuxPath, {
 						tool: "lsp",
 					});
-					if (converted.length === 0) continue;
+					if (converted.length === 0) {
+						lateAuxMissing += rawDiags.length;
+						lateAuxAnswered += 1;
+						continue;
+					}
 					// Freshness kernel (#1634 gated surface): stat the cited file
 					// against the mark timestamp. Missing → drop (no remediation for
 					// a deleted file); mtime drifted past the mark → drop too, NOT
@@ -2432,22 +2453,32 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 					lateAuxStale += gate.stale.length;
 					lateAuxMissing +=
 						converted.length - gate.live.length - gate.stale.length;
-					if (gate.stale.length > 0) {
-						// Stale findings mean the scan predates the last edit.
-						// Re-arm with a REFRESHED baseline so the next turn probes
-						// the newer revision (#2027 round-1 P2-1).
-						markPendingAuxiliaryCoverage(
-							lateAuxPath,
-							[pair.serverId],
-							Date.now(),
-						);
+					if (gate.live.length === 0) {
+						if (gate.stale.length > 0) {
+							// Stale findings mean the scan predates the last edit. Re-arm
+							// with a refreshed baseline and carry the ceiling count.
+							if (
+								!isPendingAuxiliaryPastRearmTtl(pair) &&
+								(pair.rearmCount ?? 0) < MAX_LATE_AUX_REARMS
+							) {
+								rearmPendingAuxiliaryCoverage(pair, Date.now(), true);
+								lateAuxRearmed += 1;
+							} else if (isPendingAuxiliaryPastRearmTtl(pair)) {
+								lateAuxExpired += 1;
+							} else {
+								lateAuxCeilingExhausted += 1;
+							}
+						} else {
+							lateAuxAnswered += 1;
+						}
+						continue;
 					}
-					if (gate.live.length === 0) continue;
 					const lines = gate.live.map(
 						(f) =>
 							`  ${displayLateAuxPath}:${f.line}:${f.column} [${f.rule}] ${f.message}`,
 					);
 					lateAuxDelivered += gate.live.length;
+					lateAuxAnswered += 1;
 					// @delivery-surface: runtime-turn:late-auxiliary-findings
 					advisoryParts.push(
 						`🕐 Late auxiliary diagnostics (${pair.serverId} answered after its grace window):\n${lines.join("\n")}`,
@@ -2465,12 +2496,19 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 			durationMs: Date.now() - lateAuxStart,
 			metadata: {
 				pending: drainedPairs.length,
+				pairCreated: drainedPairs.length,
+				pendingAfter: pendingAuxiliaryCoverageSize(),
 				delivered: lateAuxDelivered,
 				stale: lateAuxStale,
 				missing: lateAuxMissing,
 				rearmed: lateAuxRearmed,
 				clientGone: lateAuxClientGone,
 				probeFailed: lateAuxProbeFailed,
+				cleanConfirmed: lateAuxCleanConfirmed,
+				expired: lateAuxExpired,
+				ceilingExhausted: lateAuxCeilingExhausted,
+				answered: lateAuxAnswered,
+				stuckPairs: lateAuxStuckPairs,
 			},
 		});
 	}

--- a/tests/clients/lsp/late-auxiliary-findings.test.ts
+++ b/tests/clients/lsp/late-auxiliary-findings.test.ts
@@ -39,6 +39,7 @@ import { handleTurnEnd } from "../../../clients/runtime-turn.js";
 import {
 	drainPendingAuxiliaryCoverage,
 	markPendingAuxiliaryCoverage,
+	MAX_LATE_AUX_REARMS,
 	readLateAuxRearmTtlMs,
 	resetPendingAuxiliaryCoverage,
 } from "../../../clients/lsp/pending-aux-coverage.js";
@@ -155,9 +156,15 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 			// By turn end the scanner has published into its client cache.
 			readCachedDiagnosticsForServers.mockImplementation(
 				async (_filePath: string, serverIds: ReadonlySet<string>) => {
-					const out = new Map<string, LSPDiagnostic[]>();
+					const out = new Map<
+						string,
+						{ diags: LSPDiagnostic[]; publishedAt: number }
+					>();
 					if (serverIds.has("opengrep"))
-						out.set("opengrep", [diag(4, "late finding body")]);
+						out.set("opengrep", {
+							diags: [diag(4, "late finding body")],
+							publishedAt: Date.now(),
+						});
 					return out;
 				},
 			);
@@ -201,7 +208,16 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 			// mtime (now-10s) > mark (now-60s) + tolerance → stale → drop.
 			markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 60_000);
 			readCachedDiagnosticsForServers.mockImplementation(
-				async () => new Map([["opengrep", [diag(0, "should not appear")]]]),
+				async () =>
+					new Map([
+						[
+							"opengrep",
+							{
+								diags: [diag(0, "should not appear")],
+								publishedAt: Date.now(),
+							},
+						],
+					]),
 			);
 
 			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
@@ -214,6 +230,184 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 			expect(record).toBeDefined();
 			expect(record.metadata).toMatchObject({ pending: 1, delivered: 0 });
 			expect(record.metadata.stale).toBeGreaterThan(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("retires a newer empty publication as cleanConfirmed", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-clean-") as any;
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-clean" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const file = path.join(env.tmpDir, "src", "clean.ts");
+			registerEdit(env, "late-aux-clean", cacheManager, file);
+			markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 2_000);
+			const clean: {
+				diags: LSPDiagnostic[];
+				publishedAt: number;
+			} = { diags: [], publishedAt: Date.now() };
+			readCachedDiagnosticsForServers.mockResolvedValue(
+				new Map([["opengrep", clean]]),
+			);
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+			expect(drainPendingAuxiliaryCoverage()).toHaveLength(0);
+			expect(lateAuxRecord()?.metadata).toMatchObject({
+				pending: 1,
+				cleanConfirmed: 1,
+				rearmed: 0,
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("retires a never-published pair at the re-arm ceiling", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-ceiling-") as any;
+		try {
+			process.env.PI_LENS_LATE_AUX_REARM_TTL_MS = "600000";
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-ceiling" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const file = path.join(env.tmpDir, "src", "ceiling.ts");
+			registerEdit(env, "late-aux-ceiling", cacheManager, file);
+			markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 1000);
+			readCachedDiagnosticsForServers.mockResolvedValue(
+				new Map([["opengrep", { diags: [], publishedAt: undefined }]]),
+			);
+
+			for (let turn = 0; turn <= MAX_LATE_AUX_REARMS; turn += 1) {
+				registerEdit(env, "late-aux-ceiling", cacheManager, file);
+				await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+			}
+
+			const ceilingRemaining = drainPendingAuxiliaryCoverage();
+			expect(ceilingRemaining).toHaveLength(0);
+			const records = logLatency.mock.calls
+				.map((call) => call[0])
+				.filter((entry: any) => entry?.phase === "late_auxiliary_findings");
+			expect(records.at(-1)?.metadata).toMatchObject({
+				pairCreated: 1,
+				ceilingExhausted: 1,
+				pendingAfter: 0,
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("reconciles pair units across clean, stale, absent, and eviction paths", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-pair-reconcile-") as any;
+		try {
+			process.env.PI_LENS_LATE_AUX_REARM_TTL_MS = "5000";
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-pair-reconcile" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const clean = path.join(env.tmpDir, "src", "clean.ts");
+			const stale = path.join(env.tmpDir, "src", "stale.ts");
+			registerEdit(env, "late-aux-pair-reconcile", cacheManager, stale);
+			registerEdit(env, "late-aux-pair-reconcile", cacheManager, clean);
+			markPendingAuxiliaryCoverage(
+				path.join(env.tmpDir, "src", "evicted.ts"),
+				["opengrep"],
+				Date.now() - 1000,
+			);
+			markPendingAuxiliaryCoverage(clean, ["opengrep"], Date.now() - 1000);
+			markPendingAuxiliaryCoverage(
+				stale,
+				["opengrep"],
+				Date.now() - 60_000,
+				Date.now() - 1000,
+			);
+			const absent = path.join(env.tmpDir, "src", "absent.ts");
+			markPendingAuxiliaryCoverage(absent, ["opengrep"], Date.now() - 1000);
+			const expired = path.join(env.tmpDir, "src", "expired.ts");
+			markPendingAuxiliaryCoverage(expired, ["opengrep"], Date.now() - 10_000);
+			for (let index = 0; index < 47; index += 1) {
+				markPendingAuxiliaryCoverage(
+					path.join(env.tmpDir, "src", `clean-${index}.ts`),
+					["opengrep"],
+					Date.now() - 1000,
+				);
+			}
+			readCachedDiagnosticsForServers.mockImplementation(
+				async (filePath: string) => {
+					if (filePath === absent) return new Map();
+					if (filePath === stale)
+						return new Map([
+							[
+								"opengrep",
+								{ diags: [diag(0, "old")], publishedAt: Date.now() },
+							],
+						]);
+					if (filePath === expired)
+						return new Map([
+							["opengrep", { diags: [], publishedAt: Date.now() - 20_000 }],
+						]);
+					return new Map([
+						["opengrep", { diags: [], publishedAt: Date.now() }],
+					]);
+				},
+			);
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+
+			const metadata = lateAuxRecord()?.metadata;
+			expect(metadata).toMatchObject({
+				pairCreated: 50,
+				cleanConfirmed: 47,
+				clientGone: 1,
+				expired: 1,
+				rearmed: 1,
+				pendingAfter: 1,
+			});
+			expect(
+				metadata.cleanConfirmed +
+					metadata.clientGone +
+					metadata.expired +
+					metadata.pendingAfter,
+			).toBe(metadata.pairCreated);
+			expect(metadata.stale).toBe(1);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("reconciles expired and conversion-empty retirements", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-reconcile-") as any;
+		try {
+			process.env.PI_LENS_LATE_AUX_REARM_TTL_MS = "5000";
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-reconcile" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const expired = path.join(env.tmpDir, "src", "expired.ts");
+			const empty = path.join(env.tmpDir, "src", "empty.ts");
+			registerEdit(env, "late-aux-reconcile", cacheManager, expired);
+			registerEdit(env, "late-aux-reconcile", cacheManager, empty);
+			markPendingAuxiliaryCoverage(expired, ["opengrep"], Date.now() - 10_000);
+			markPendingAuxiliaryCoverage(empty, ["opengrep"], Date.now() - 2_000);
+			readCachedDiagnosticsForServers.mockImplementation(
+				async (filePath: string) =>
+					filePath === expired
+						? new Map([
+								["opengrep", { diags: [], publishedAt: Date.now() - 20_000 }],
+							])
+						: new Map([
+								[
+									"opengrep",
+									{ diags: [{ message: "bad" }], publishedAt: Date.now() },
+								],
+							]),
+			);
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+			const metadata = lateAuxRecord()?.metadata;
+			expect(metadata).toMatchObject({ pending: 2, expired: 1, missing: 1 });
+			expect(metadata.expired + metadata.missing).toBe(metadata.pending);
 		} finally {
 			env.cleanup();
 		}
@@ -233,7 +427,15 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 			markPendingAuxiliaryCoverage(deleted, ["opengrep"], Date.now() - 2000);
 			readCachedDiagnosticsForServers.mockImplementation(
 				async () =>
-					new Map([["opengrep", [diag(0, "finding for deleted file")]]]),
+					new Map([
+						[
+							"opengrep",
+							{
+								diags: [diag(0, "finding for deleted file")],
+								publishedAt: Date.now(),
+							},
+						],
+					]),
 			);
 
 			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
@@ -262,7 +464,7 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 			markPendingAuxiliaryCoverage(file, ["opengrep"], markedAt);
 			// Client alive (present in the map) but the scan has not landed yet.
 			readCachedDiagnosticsForServers.mockImplementation(
-				async () => new Map([["opengrep", []]]),
+				async () => new Map([["opengrep", { diags: [] }]]),
 			);
 
 			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
@@ -318,7 +520,7 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 				Date.now() - 1_000,
 			);
 			readCachedDiagnosticsForServers.mockImplementation(
-				async () => new Map([["opengrep", []]]),
+				async () => new Map([["opengrep", { diags: [] }]]),
 			);
 
 			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
@@ -350,7 +552,7 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 
 			markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 10_000);
 			readCachedDiagnosticsForServers.mockImplementation(
-				async () => new Map([["opengrep", []]]),
+				async () => new Map([["opengrep", { diags: [] }]]),
 			);
 
 			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));


### PR DESCRIPTION
## Summary

Fixes #2151. The late-auxiliary cache probe now returns `{ diags, publishedAt }` from the per-file cache entry. A publication newer than `markedAtMs` with zero diagnostics retires as `cleanConfirmed`; absent or older publication evidence remains pending. Re-arms have a hard count ceiling, and stuck pairs are bounded in telemetry.

The new clean-publication regression was red on the pre-fix runtime:

> AssertionError: expected [ { ?(4) } ] to have a length of +0 but got 1
>
> ? tests/clients/lsp/late-auxiliary-findings.test.ts:237:44

All five acceptance criteria are complete. The full suite was skipped locally; CI is deferred because the pre-push selection exceeded its 25-file cap.

## Tests

- `tests/clients/lsp/late-auxiliary-findings.test.ts` ? edits existing cache-shape fixtures and adds a clean-publication regression that pins timestamp-based retirement, plus an expiry/conversion-empty reconciliation test that pins one outcome counter per pending pair. The clean guard mutation failed with `cleanConfirmed: 0` where `1` was expected.
- `tests/clients/lsp/pending-aux-coverage.test.ts` ? unchanged; it uniquely pins pending-store reset, TTL, and baseline preservation. No test became redundant.

### Test assessment

- `tests/clients/lsp/late-auxiliary-findings.test.ts` uniquely covers the production turn-end consumer, clean confirmation, stale/deleted findings, expiry, bounded re-arm, client disappearance, and telemetry reconciliation. No tests are redundant; no removal candidates.
- `tests/clients/lsp/pending-aux-coverage.test.ts` uniquely covers the store?s insertion, reset, TTL, and baseline contract. It was run as a targeted compatibility suite and is not redundant.

## Blast radius

- `clients/lsp/index.ts` ? affects the `LSPService.readCachedDiagnosticsForServers` turn-end probe. Caller grep found one production caller, `clients/runtime-turn.ts:2372`; the probe remains read-only and warm-client-only. The per-file hot path adds one `getAllDiagnostics()` lookup per live server probe, followed by the existing per-file fallback. No separate `module_report` capability was available in this session; caller grep is the authoritative dependent map recorded here.
- `clients/runtime-turn.ts` ? affects the `handleTurnEnd` collect-later callback and its `late_auxiliary_findings` phase record. It adds constant-time timestamp/count classification per pending pair and caps stuck identity at 20 pairs.
- `clients/lsp/pending-aux-coverage.ts` ? affects producer and turn-end re-arm state. It adds one bounded integer field per pending pair; the existing 50-pair store cap remains unchanged.

## Class sweep

This is AGENTS.md shape 10, ?silencing counted as fixing,? with the related availability/probe screens in shapes 13, 17, and 18. I swept `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts` for `getDiagnostics`, `getAllDiagnostics`, `readCachedDiagnosticsForServers`, diagnostics-length, and availability probes.

- `clients/lsp/index.ts:2701` ? fixed here: cached empty diagnostics now require a newer per-file publication timestamp.
- `clients/runtime-turn.ts:2372` ? fixed here: consumer distinguishes absent/old, clean, findings, stale, and conversion-empty results.
- `clients/lsp/cascade-tier.ts:384` ? already correct: checks per-file entry presence and timestamp; retained as the precedent.
- `clients/lsp/index.ts:5086` ? already correct: checks per-file cache entry presence.
- `clients/lsp/index.ts:4774` ? real sibling candidate: primary sync racer still uses non-empty diagnostics as evidence; filed as issue #2161 for separate scope.
- `scripts/smoke-tools.mjs:1672` ? intentional availability gate: it distinguishes unavailable tools before interpreting an empty auxiliary result and is not a cached publication probe.
- `tools/lsp-diagnostics.ts`, `tools/lsp-navigation.ts`, `clients/actionable-warnings.ts`, `clients/dispatch/integration.ts`, and remaining `getDiagnostics` consumers ? verdict: deliver or aggregate diagnostics, with no empty-as-unanswered branch.

Consolidation verdict: cached publication evidence stays centralized in the LSP client?s per-file `{ diags, ts }` entry; the separate primary sync-racer issue is tracked in #2161.

## Observability

The bounded `late_auxiliary_findings` phase record in `clients/runtime-turn.ts` now carries `cleanConfirmed`, `expired`, `rearmed`, `clientGone`, `probeFailed`, and bounded `stuckPairs`. Production proof is `cleanConfirmed > 0` with `pending` reaching zero after a clean publication; the reconciliation test proves expiry and conversion-empty counts sum to the pending pair count.




## Fix round 2

Round 2 is complete in squashed commit `96fc52a9`. The branch history was repaired from the contaminated `843a1ce8` commit and force-pushed with `--force-with-lease` to the existing PR branch.

### F1 ? re-arm ceiling

The consumer now carries `rearmCount + 1` across every drain, including stale re-arms. A real `handleTurnEnd` regression runs through the ceiling and retires the never-published pair exactly at `MAX_LATE_AUX_REARMS`.

Red-first result before the fix:

> AssertionError: expected [ { ?(5) } ] to have a length of +0 but got 1
>
> ? tests/clients/lsp/late-auxiliary-findings.test.ts:291:29

Mutation result with the ceiling clause replaced by `true`:

> AssertionError: expected [ { ?(5) } ] to have a length of +0 but got 1
>
> ? tests/clients/lsp/late-auxiliary-findings.test.ts:291:29

### F2 ? telemetry reconciliation

Pair-level fields now include `pairCreated`, `cleanConfirmed`, `expired`, `ceilingExhausted`, `clientGone`, `probeFailed`, `answered`, and `pendingAfter`. Finding-level `delivered`, `stale`, and `missing` remain separate. Probe failures retire pairs instead of silently re-inserting fresh entries. The reconciliation regression covers clean, stale, absent-client, TTL, and 50-pair eviction paths.

Mutation result after forcing `pendingAfter` to `0`:

> AssertionError: expected { pending: 50, pairCreated: 50, ?(12) } to match object { pairCreated: 50, ?(5) }
>
> - Expected `pendingAfter: 1`
> > Received `pendingAfter: 0`
> 
> > ? tests/clients/lsp/late-auxiliary-findings.test.ts:359:21

The passing reconciliation run reports 50 created pairs, 47 clean retirements, one absent-client retirement, one TTL retirement, and one pending re-arm; the sum is 50.

### F4 ? diagnostics fallback

Removed the dead `entry?.diags ?? client.getDiagnostics(filePath)` fallback. `getAllDiagnostics()` is the sole source for the cached per-file result, so legacy diagnostics cannot fabricate an un-timestamped answer.

### F5 ? cost claim

The blast radius now states that `getAllDiagnostics()` materializes a `Map` over all tracked paths for each live `(file, server)` probe. Turn-end processing can probe up to 50 pairs per turn; this follows the accepted `cascade-tier.ts:384` precedent.

### F6 ? clean fixture shape

The clean test fixture now uses the production-shaped `{ diags, publishedAt }` object rather than an array cast with attached properties.

### Verification

- `npm run build` ? passed.
- `npm run lint` ? passed.
- `npm run fmt:check` ? passed.
- Targeted and sibling suites ? 6 files passed, 217 tests passed, 3 skipped.
- Required CI verification is pending on the new head `96fc52a9`.
