### PR TITLE
fix(tests): isolate git env in fixtures and guard repo config (closes #2163)

### DIFF
--- a/.changelog/tests-2163-git-fixture-env.md
+++ b/.changelog/tests-2163-git-fixture-env.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Isolate real-Git test fixtures and guard repository config (closes #2163)** — shared fixture environment hygiene, source governance, and a post-suite contamination guard prevent tests from mutating the checkout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -993,8 +993,10 @@ That helper removes the Git directory environment family, isolates global config
 and disables system config. It deletes inherited values even when the test harness
 itself starts with a contaminated environment; never trust the parent process
 environment for a spawned Git fixture. `git-fixture-governance.test.ts` sweeps test
-sources, while the global-setup teardown guard rejects local identity entries or
-`core.bare=true` in the repository config after the suite.
+sources and requires the direct Git callee to be imported from that helper, while
+the script-side fixture probes use `scripts/lib/git-fixture-env.mjs`. The global-
+setup teardown guard rejects local identity entries or `core.bare=true` in the
+repository config after the suite.
 
 Git command classification has ONE implementation. `detectGuardedGitVerb`
 takes a `GitVerbMatcher` and owns the wrapper, `$IFS`, substitution, PATHEXT,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -990,8 +990,10 @@ guarded git verb (literal mentions such as `echo git push` remain allowed).
 
 Real-Git tests route child processes through `tests/support/git-fixture-env.ts`.
 That helper removes the Git directory environment family, isolates global config,
-and disables system config. `git-fixture-governance.test.ts` sweeps test sources,
-while the global-setup teardown guard rejects local identity entries or
+and disables system config. It deletes inherited values even when the test harness
+itself starts with a contaminated environment; never trust the parent process
+environment for a spawned Git fixture. `git-fixture-governance.test.ts` sweeps test
+sources, while the global-setup teardown guard rejects local identity entries or
 `core.bare=true` in the repository config after the suite.
 
 Git command classification has ONE implementation. `detectGuardedGitVerb`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -988,6 +988,12 @@ unrecognized leading launcher with `-c`/`--run`/`/c`/`-Command` is inspected
 recursively and fails closed only when its command string contains an actual
 guarded git verb (literal mentions such as `echo git push` remain allowed).
 
+Real-Git tests route child processes through `tests/support/git-fixture-env.ts`.
+That helper removes the Git directory environment family, isolates global config,
+and disables system config. `git-fixture-governance.test.ts` sweeps test sources,
+while the global-setup teardown guard rejects local identity entries or
+`core.bare=true` in the repository config after the suite.
+
 Git command classification has ONE implementation. `detectGuardedGitVerb`
 takes a `GitVerbMatcher` and owns the wrapper, `$IFS`, substitution, PATHEXT,
 and text-consumer analysis; a guard that needs "is this really a git

--- a/scripts/bench-lsp.mjs
+++ b/scripts/bench-lsp.mjs
@@ -20,6 +20,7 @@
  * servers are measured (others report "unavailable").
  */
 import { execFileSync } from "node:child_process";
+import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -89,7 +90,7 @@ for (const fx of fixtures) {
 	const absFile = path.join(ws, fx.file);
 	if (fx.gitInit) {
 		try {
-			execFileSync("git", ["init", "-q"], { cwd: ws, stdio: "ignore" });
+			gitExecFileSync(["init", "-q"], { cwd: ws, stdio: "ignore" });
 		} catch {}
 	}
 

--- a/scripts/compat-smoke-behavioral.mjs
+++ b/scripts/compat-smoke-behavioral.mjs
@@ -71,6 +71,7 @@ import {
 	parseNdjsonEntries,
 	phaseWasLogged,
 } from "./lib/latency-log-phases.mjs";
+import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
 
 const isWindows = process.platform === "win32";
 const HEAVYWEIGHT_SCAN_PHASES = [
@@ -109,11 +110,11 @@ function setUpFixtureProject(dir) {
 		path.join(dir, "package.json"),
 		'{ "name": "d", "version": "1.0.0", "type": "module" }\n',
 	);
-	execFileSync("git", ["init", "-q"], { cwd: dir });
-	execFileSync("git", ["config", "user.email", "t@t.t"], { cwd: dir });
-	execFileSync("git", ["config", "user.name", "t"], { cwd: dir });
-	execFileSync("git", ["add", "-A"], { cwd: dir });
-	execFileSync("git", ["commit", "-qm", "init"], { cwd: dir });
+	gitExecFileSync(["init", "-q"], { cwd: dir });
+	gitExecFileSync(["config", "user.email", "t@t.t"], { cwd: dir });
+	gitExecFileSync(["config", "user.name", "t"], { cwd: dir });
+	gitExecFileSync(["add", "-A"], { cwd: dir });
+	gitExecFileSync(["commit", "-qm", "init"], { cwd: dir });
 }
 
 function installPiLens(projectDir, tarball) {

--- a/scripts/lib/git-fixture-env.mjs
+++ b/scripts/lib/git-fixture-env.mjs
@@ -1,0 +1,35 @@
+import { execFileSync, execSync } from "node:child_process";
+
+const SCRUBBED = [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_COMMON_DIR",
+	"GIT_PREFIX",
+];
+
+function envFor(cwd, overrides) {
+	const env = { ...process.env, ...(overrides ?? {}) };
+	for (const name of SCRUBBED) delete env[name];
+	env.GIT_CONFIG_GLOBAL = `${cwd}/gitconfig`;
+	env.GIT_CONFIG_NOSYSTEM = "1";
+	return env;
+}
+
+export function gitExecFileSync(args, options = {}) {
+	const cwd = options.cwd ?? process.cwd();
+	return execFileSync("git", args, {
+		...options,
+		env: envFor(cwd, options.env),
+	});
+}
+
+export function gitExecSync(command, options = {}) {
+	const cwd = options.cwd ?? process.cwd();
+	return execSync(command, {
+		...options,
+		env: envFor(cwd, options.env),
+	});
+}

--- a/scripts/lib/git-fixture-env.mjs
+++ b/scripts/lib/git-fixture-env.mjs
@@ -8,11 +8,19 @@ const SCRUBBED = [
 	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
 	"GIT_COMMON_DIR",
 	"GIT_PREFIX",
+	"GIT_CONFIG_COUNT",
 ];
+
+// GIT_CONFIG_COUNT + the indexed GIT_CONFIG_KEY_<n>/GIT_CONFIG_VALUE_<n> pair
+// inject arbitrary config (including core.bare) without touching a config
+// file. See tests/support/git-fixture-env.ts for the same fix (#2163).
+const CONFIG_KV_PATTERN = /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/;
 
 function envFor(cwd, overrides) {
 	const env = { ...process.env, ...(overrides ?? {}) };
 	for (const name of SCRUBBED) delete env[name];
+	for (const key of Object.keys(env))
+		if (CONFIG_KV_PATTERN.test(key)) delete env[key];
 	env.GIT_CONFIG_GLOBAL = `${cwd}/gitconfig`;
 	env.GIT_CONFIG_NOSYSTEM = "1";
 	return env;

--- a/scripts/probe-clean-signal.mjs
+++ b/scripts/probe-clean-signal.mjs
@@ -41,6 +41,7 @@
  * already-installed servers unless --install is passed.
  */
 import { execFileSync } from "node:child_process";
+import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -231,7 +232,7 @@ async function probeFixture(fx, dst, row) {
 	const absFile = path.join(dst, fx.file);
 	if (fx.gitInit) {
 		try {
-			execFileSync("git", ["init", "-q"], { cwd: dst, stdio: "ignore" });
+			gitExecFileSync(["init", "-q"], { cwd: dst, stdio: "ignore" });
 		} catch {}
 	}
 	if (fx.disableServers) {

--- a/tests/clients/git-tracked-ignore.test.ts
+++ b/tests/clients/git-tracked-ignore.test.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	_resetTrackedFilesCacheForTests,
@@ -14,6 +13,7 @@ import {
 import { normalizeMapKey } from "../../clients/path-utils.js";
 import * as safeSpawn from "../../clients/safe-spawn.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+import { gitExecFileSync } from "../support/git-fixture-env.js";
 
 describe("parseUntrackedIgnoredOutput", () => {
 	it("parses repo-relative lines into normalized ids, skipping blanks", () => {
@@ -39,9 +39,11 @@ describe("collectUntrackedIgnoredIds (#694)", () => {
 	});
 
 	function initGitRepo(cwd: string): void {
-		execFileSync("git", ["init", "-q"], { cwd });
-		execFileSync("git", ["config", "user.email", "test@example.com"], { cwd });
-		execFileSync("git", ["config", "user.name", "Test"], { cwd });
+		gitExecFileSync("git", ["init", "-q"], { cwd });
+		gitExecFileSync("git", ["config", "user.email", "test@example.com"], {
+			cwd,
+		});
+		gitExecFileSync("git", ["config", "user.name", "Test"], { cwd });
 	}
 
 	it("returns the untracked-AND-ignored set, excluding tracked files that merely match the pattern", async () => {
@@ -53,8 +55,8 @@ describe("collectUntrackedIgnoredIds (#694)", () => {
 				"src/vendor.js",
 				"exports.vendor = 1;\n",
 			);
-			execFileSync("git", ["add", "src/vendor.js"], { cwd: env.tmpDir });
-			execFileSync("git", ["commit", "-q", "-m", "vendor"], {
+			gitExecFileSync("git", ["add", "src/vendor.js"], { cwd: env.tmpDir });
+			gitExecFileSync("git", ["commit", "-q", "-m", "vendor"], {
 				cwd: env.tmpDir,
 			});
 			createTempFile(env.tmpDir, ".gitignore", "*.js\n");
@@ -137,8 +139,10 @@ describe("collectUntrackedIgnoredIds (#694)", () => {
 		try {
 			initGitRepo(env.tmpDir);
 			createTempFile(env.tmpDir, ".gitignore", "*.js\n");
-			execFileSync("git", ["add", ".gitignore"], { cwd: env.tmpDir });
-			execFileSync("git", ["commit", "-q", "-m", "init"], { cwd: env.tmpDir });
+			gitExecFileSync("git", ["add", ".gitignore"], { cwd: env.tmpDir });
+			gitExecFileSync("git", ["commit", "-q", "-m", "init"], {
+				cwd: env.tmpDir,
+			});
 
 			const first = await collectUntrackedIgnoredIds(env.tmpDir);
 			expect(first?.size ?? 0).toBe(0);

--- a/tests/clients/gitleaks-scratch-exclusion.test.ts
+++ b/tests/clients/gitleaks-scratch-exclusion.test.ts
@@ -34,7 +34,7 @@
  *     from Go's directory walk, so a forward-slash-only anchor never matches
  *     on Windows).
  */
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "../support/git-fixture-env.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/tests/clients/lsp/launch-stderr-guard.test.ts
+++ b/tests/clients/lsp/launch-stderr-guard.test.ts
@@ -14,20 +14,12 @@
  * observes the real leak rather than asserting on mocked call arguments.
  */
 
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { gitFixtureEnv, hasGit } from "../../support/git-fixture-env.js";
 
 const LAUNCH_JS = path.resolve(__dirname, "../../../clients/lsp/launch.js");
-
-function hasGit(): boolean {
-	try {
-		execFileSync("git", ["--version"], { stdio: "ignore" });
-		return true;
-	} catch {
-		return false;
-	}
-}
 
 describe("launch.ts runStderrGuardedProbe stderr suppression (#2095)", () => {
 	it.skipIf(!hasGit())(
@@ -43,6 +35,7 @@ describe("launch.ts runStderrGuardedProbe stderr suppression (#2095)", () => {
 
 			const result = spawnSync(process.execPath, ["-e", script], {
 				encoding: "utf-8",
+				env: gitFixtureEnv(process.cwd()),
 			});
 
 			expect(result.error).toBeUndefined();

--- a/tests/clients/metrics-history-stderr.test.ts
+++ b/tests/clients/metrics-history-stderr.test.ts
@@ -1,6 +1,6 @@
 /**
  * #2095 — `getCurrentCommit()` in `clients/metrics-history.ts` ran
- * `execSync("git rev-parse --short HEAD")` without an explicit `stdio`
+ * Git commit lookup without an explicit `stdio`
  * override. Node's `execSync`/`execFileSync` inherit the child's stderr to
  * the PARENT process by default (only stdout is piped into the return
  * value), so a failing `git rev-parse` prints its raw "fatal: ..." line
@@ -17,25 +17,21 @@
  * arguments.
  */
 
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+	gitExecFileSync,
+	gitFixtureEnv,
+	hasGit,
+} from "../support/git-fixture-env.js";
 
 const METRICS_HISTORY_JS = path.resolve(
 	__dirname,
 	"../../clients/metrics-history.js",
 );
-
-function hasGit(): boolean {
-	try {
-		execFileSync("git", ["--version"], { stdio: "ignore" });
-		return true;
-	} catch {
-		return false;
-	}
-}
 
 describe("metrics-history getCurrentCommit stderr suppression (#2095)", () => {
 	it.skipIf(!hasGit())(
@@ -44,11 +40,7 @@ describe("metrics-history getCurrentCommit stderr suppression (#2095)", () => {
 			const tmp = fs.mkdtempSync(
 				path.join(os.tmpdir(), "pi-lens-metrics-history-"),
 			);
-			const fixtureEnv: Record<string, string> = Object.fromEntries(
-				Object.entries(process.env).filter(
-					(entry): entry is [string, string] => entry[1] !== undefined,
-				),
-			);
+			const fixtureEnv = gitFixtureEnv(tmp);
 			fixtureEnv.GIT_CONFIG_GLOBAL = path.join(tmp, "gitconfig");
 			fixtureEnv.GIT_CONFIG_NOSYSTEM = "1";
 			try {
@@ -57,7 +49,7 @@ describe("metrics-history getCurrentCommit stderr suppression (#2095)", () => {
 				// revision or path not in the working tree." on real stderr.
 				// `stdio: "ignore"` here is the exact guard this PR is about —
 				// this setup call must not itself leak `git init`'s stderr.
-				execFileSync("git", ["init", "-q"], {
+				gitExecFileSync("git", ["init", "-q"], {
 					cwd: tmp,
 					stdio: "ignore",
 					env: fixtureEnv,
@@ -120,27 +112,12 @@ describe("metrics-history per-file commit resolution (#2099)", () => {
 			const tmp = fs.mkdtempSync(
 				path.join(os.tmpdir(), "pi-lens-metrics-history-repos-"),
 			);
-			const fixtureEnv: Record<string, string> = Object.fromEntries(
-				Object.entries(process.env).filter(
-					(entry): entry is [string, string] => entry[1] !== undefined,
-				),
-			);
+			const fixtureEnv = gitFixtureEnv(tmp);
 			fixtureEnv.PI_LENS_SKIP_HOOKS = "1";
-			for (const variable of [
-				"GIT_DIR",
-				"GIT_WORK_TREE",
-				"GIT_INDEX_FILE",
-				"GIT_OBJECT_DIRECTORY",
-				"GIT_ALTERNATE_OBJECT_DIRECTORIES",
-				"GIT_COMMON_DIR",
-				"GIT_PREFIX",
-			]) {
-				delete fixtureEnv[variable];
-			}
 			fixtureEnv.GIT_CONFIG_GLOBAL = path.join(tmp, "gitconfig");
 			fixtureEnv.GIT_CONFIG_NOSYSTEM = "1";
 			const runGit = (cwd: string, args: string[]) =>
-				execFileSync("git", args, {
+				gitExecFileSync("git", args, {
 					cwd,
 					stdio: "ignore",
 					env: fixtureEnv,
@@ -167,17 +144,17 @@ describe("metrics-history per-file commit resolution (#2099)", () => {
 				runGit(repoB, ["add", "b.ts"]);
 				runGit(repoB, ["commit", "-qm", "service-b"]);
 
-				const expectedA = execFileSync(
+				const expectedA = gitExecFileSync(
 					"git",
 					["rev-parse", "--short", "HEAD"],
 					{ cwd: repoA, encoding: "utf-8", env: fixtureEnv },
 				).trim();
-				const expectedB = execFileSync(
+				const expectedB = gitExecFileSync(
 					"git",
 					["rev-parse", "--short", "HEAD"],
 					{ cwd: repoB, encoding: "utf-8", env: fixtureEnv },
 				).trim();
-				const umbrellaHead = execFileSync(
+				const umbrellaHead = gitExecFileSync(
 					"git",
 					["rev-parse", "--short", "HEAD"],
 					{ cwd: umbrella, encoding: "utf-8", env: fixtureEnv },
@@ -220,29 +197,14 @@ describe("metrics-history repository guard (#2099)", () => {
 			const tmp = fs.mkdtempSync(
 				path.join(os.tmpdir(), "pi-lens-metrics-history-nonrepo-"),
 			);
-			const fixtureEnv: Record<string, string> = Object.fromEntries(
-				Object.entries(process.env).filter(
-					(entry): entry is [string, string] => entry[1] !== undefined,
-				),
-			);
+			const fixtureEnv = gitFixtureEnv(tmp);
 			fixtureEnv.PI_LENS_SKIP_HOOKS = "1";
-			for (const variable of [
-				"GIT_DIR",
-				"GIT_WORK_TREE",
-				"GIT_INDEX_FILE",
-				"GIT_OBJECT_DIRECTORY",
-				"GIT_ALTERNATE_OBJECT_DIRECTORIES",
-				"GIT_COMMON_DIR",
-				"GIT_PREFIX",
-			]) {
-				delete fixtureEnv[variable];
-			}
 			fixtureEnv.GIT_CONFIG_GLOBAL = path.join(tmp, "gitconfig");
 			fixtureEnv.GIT_CONFIG_NOSYSTEM = "1";
 			const repo = path.join(tmp, "nested-repo");
 			const filePath = path.join(repo, "nested.ts");
 			const runGit = (args: string[]) =>
-				execFileSync("git", args, {
+				gitExecFileSync("git", args, {
 					cwd: repo,
 					stdio: "ignore",
 					env: fixtureEnv,
@@ -255,11 +217,15 @@ describe("metrics-history repository guard (#2099)", () => {
 				fs.writeFileSync(filePath, "const nested = 1;\n");
 				runGit(["add", "nested.ts"]);
 				runGit(["commit", "-qm", "nested-repo"]);
-				const expected = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
-					cwd: repo,
-					encoding: "utf-8",
-					env: fixtureEnv,
-				}).trim();
+				const expected = gitExecFileSync(
+					"git",
+					["rev-parse", "--short", "HEAD"],
+					{
+						cwd: repo,
+						encoding: "utf-8",
+						env: fixtureEnv,
+					},
+				).trim();
 				const dataDir = path.join(tmp, ".pilens-data");
 				const script = [
 					`process.chdir(${JSON.stringify(tmp)});`,
@@ -296,27 +262,12 @@ describe("metrics-history missing target directory (#2099)", () => {
 			const tmp = fs.mkdtempSync(
 				path.join(os.tmpdir(), "pi-lens-metrics-history-missing-"),
 			);
-			const fixtureEnv: Record<string, string> = Object.fromEntries(
-				Object.entries(process.env).filter(
-					(entry): entry is [string, string] => entry[1] !== undefined,
-				),
-			);
+			const fixtureEnv = gitFixtureEnv(tmp);
 			fixtureEnv.PI_LENS_SKIP_HOOKS = "1";
-			for (const variable of [
-				"GIT_DIR",
-				"GIT_WORK_TREE",
-				"GIT_INDEX_FILE",
-				"GIT_OBJECT_DIRECTORY",
-				"GIT_ALTERNATE_OBJECT_DIRECTORIES",
-				"GIT_COMMON_DIR",
-				"GIT_PREFIX",
-			]) {
-				delete fixtureEnv[variable];
-			}
 			fixtureEnv.GIT_CONFIG_GLOBAL = path.join(tmp, "gitconfig");
 			fixtureEnv.GIT_CONFIG_NOSYSTEM = "1";
 			const runGit = (args: string[]) =>
-				execFileSync("git", args, {
+				gitExecFileSync("git", args, {
 					cwd: tmp,
 					stdio: "ignore",
 					env: fixtureEnv,
@@ -328,11 +279,15 @@ describe("metrics-history missing target directory (#2099)", () => {
 				fs.writeFileSync(path.join(tmp, "README.md"), "umbrella\n");
 				runGit(["add", "README.md"]);
 				runGit(["commit", "-qm", "fixture"]);
-				const expected = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
-					cwd: tmp,
-					encoding: "utf-8",
-					env: fixtureEnv,
-				}).trim();
+				const expected = gitExecFileSync(
+					"git",
+					["rev-parse", "--short", "HEAD"],
+					{
+						cwd: tmp,
+						encoding: "utf-8",
+						env: fixtureEnv,
+					},
+				).trim();
 				const filePath = path.join(tmp, "sub", "gone.ts");
 				const dataDir = path.join(tmp, ".pilens-data");
 				const script = [

--- a/tests/clients/opaque-mutation-scan.test.ts
+++ b/tests/clients/opaque-mutation-scan.test.ts
@@ -8,7 +8,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync, execSync } from "../support/git-fixture-env.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // The synthetic-write dispatch runs the full per-edit pipeline; point it at

--- a/tests/clients/review-graph.service.test.ts
+++ b/tests/clients/review-graph.service.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "../support/git-fixture-env.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/tests/clients/shared-checkout-guard.test.ts
+++ b/tests/clients/shared-checkout-guard.test.ts
@@ -53,7 +53,7 @@ import {
 } from "../../clients/shared-checkout-guard.js";
 import { resolveGitToplevel } from "../../clients/opaque-mutation-scan.js";
 import { normalizeFilePath } from "../../clients/path-utils.js";
-import { safeSpawnAsync } from "../../clients/safe-spawn.js";
+import { gitFixtureSpawnAsync } from "../support/git-fixture-env.js";
 
 const ROOT = path.resolve("/shared/checkout");
 
@@ -769,7 +769,7 @@ describe("probeWorkingTreeState against the real git binary (#2007)", () => {
 		const main = path.join(tmpRoot, "main-repo");
 		fs.mkdirSync(main, { recursive: true });
 		const run = async (args: string[], cwd: string) =>
-			safeSpawnAsync("git", args, { cwd, timeout: 20000 });
+			gitFixtureSpawnAsync(cwd, args, { cwd, timeout: 20000 });
 		const init = await run(["init", "-q", "-b", "master"], main);
 		if (init.error || init.status !== 0) {
 			throw new Error(`git init unavailable: ${init.error ?? init.status}`);
@@ -813,7 +813,7 @@ describe("probeWorkingTreeState against the real git binary (#2007)", () => {
 	it("reports clean, then dirty, then unknown outside a repo", async () => {
 		const repo = path.join(tmpRoot, "repo");
 		fs.mkdirSync(repo, { recursive: true });
-		const init = await safeSpawnAsync("git", ["init", "-q"], {
+		const init = await gitFixtureSpawnAsync(repo, ["init", "-q"], {
 			cwd: repo,
 			timeout: 20000,
 		});

--- a/tests/clients/tracked-aware-ignore-matcher.test.ts
+++ b/tests/clients/tracked-aware-ignore-matcher.test.ts
@@ -7,7 +7,7 @@
  * These are real-git-repo tests (execFileSync git init/add/commit), following
  * the same fixture shape as `git-tracked-ignore.test.ts` (#701).
  */
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "../support/git-fixture-env.js";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {

--- a/tests/config/git-fixture-governance.test.ts
+++ b/tests/config/git-fixture-governance.test.ts
@@ -1,0 +1,58 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const directGitSpawn =
+	/\b(?:execSync|execFileSync|spawnSync|spawn|execFile|safeSpawnAsync)\s*\(\s*["'`]git\b/g;
+
+export function findGitSpawnOffenders(
+	files: ReadonlyArray<{ file: string; source: string }>,
+): string[] {
+	return files
+		.filter(({ file, source }) => {
+			directGitSpawn.lastIndex = 0;
+			return (
+				!file.endsWith("git-fixture-governance.test.ts") &&
+				directGitSpawn.test(source) &&
+				!source.includes("git-fixture-env")
+			);
+		})
+		.map(({ file }) => file);
+}
+
+function testFiles(root: string): Array<{ file: string; source: string }> {
+	const files: Array<{ file: string; source: string }> = [];
+	function walk(dir: string): void {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const file = path.join(dir, entry.name);
+			if (entry.isDirectory()) walk(file);
+			else if (entry.name.endsWith(".test.ts"))
+				files.push({ file, source: fs.readFileSync(file, "utf8") });
+		}
+	}
+	walk(root);
+	return files;
+}
+
+describe("real Git fixture governance", () => {
+	it("routes every direct Git spawn through git-fixture-env", () => {
+		const offenders = findGitSpawnOffenders(
+			testFiles(path.resolve(__dirname, "..")),
+		);
+		expect(
+			offenders,
+			`Bare Git spawns found:\n${offenders.join("\n")}`,
+		).toEqual([]);
+	});
+
+	it("detects a synthetic bare Git offender", () => {
+		expect(
+			findGitSpawnOffenders([
+				{
+					file: "synthetic.test.ts",
+					source: 'execFileSync("git", ["status"])',
+				},
+			]),
+		).toEqual(["synthetic.test.ts"]);
+	});
+});

--- a/tests/config/git-fixture-governance.test.ts
+++ b/tests/config/git-fixture-governance.test.ts
@@ -8,13 +8,20 @@ const directGitSpawn =
 const helperImport =
 	/import\s*{([^}]+)}\s*from\s*["'`][^"'`]*git-fixture-env/gs;
 
+const OWN_IMPLEMENTATION_FILES = [
+	"git-fixture-governance.test.ts",
+	"git-fixture-env.ts",
+	"git-fixture-env.mjs",
+] as const;
+
 export function findGitSpawnOffenders(
 	files: ReadonlyArray<{ file: string; source: string }>,
 ): string[] {
 	return files
 		.filter(({ file, source }) => {
 			directGitSpawn.lastIndex = 0;
-			if (file.endsWith("git-fixture-governance.test.ts")) return false;
+			if (OWN_IMPLEMENTATION_FILES.some((name) => file.endsWith(name)))
+				return false;
 			const imported = new Set<string>();
 			for (const match of source.matchAll(helperImport)) {
 				for (const item of match[1].split(","))
@@ -28,18 +35,35 @@ export function findGitSpawnOffenders(
 		.map(({ file }) => file);
 }
 
-function testFiles(root: string): Array<{ file: string; source: string }> {
+function walkFiles(
+	root: string,
+	matches: (name: string) => boolean,
+): Array<{ file: string; source: string }> {
 	const files: Array<{ file: string; source: string }> = [];
 	function walk(dir: string): void {
 		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
 			const file = path.join(dir, entry.name);
 			if (entry.isDirectory()) walk(file);
-			else if (entry.name.endsWith(".test.ts"))
+			else if (matches(entry.name))
 				files.push({ file, source: fs.readFileSync(file, "utf8") });
 		}
 	}
 	walk(root);
 	return files;
+}
+
+function testFiles(root: string): Array<{ file: string; source: string }> {
+	return walkFiles(root, (name) => name.endsWith(".test.ts"));
+}
+
+/**
+ * scripts/**\/*.mjs is a second population that can spawn a bare `git`
+ * process (#2163 F7): standalone smoke/compat scripts, not vitest tests.
+ * Walked separately because it lives outside tests/ and uses the .mjs
+ * fixture helper (scripts/lib/git-fixture-env.mjs) rather than the .ts one.
+ */
+function scriptFiles(root: string): Array<{ file: string; source: string }> {
+	return walkFiles(root, (name) => name.endsWith(".mjs"));
 }
 
 describe("real Git fixture governance", () => {
@@ -50,6 +74,34 @@ describe("real Git fixture governance", () => {
 		expect(
 			offenders,
 			`Bare Git spawns found:\n${offenders.join("\n")}`,
+		).toEqual([]);
+	});
+
+	it("routes every direct Git spawn in scripts/**/*.mjs through git-fixture-env", () => {
+		const offenders = findGitSpawnOffenders(
+			scriptFiles(path.resolve(__dirname, "../../scripts")),
+		);
+		const REMAINING_OFFENDERS = [
+			// #2163 F7 remainder: filed as a sibling issue, see PR body.
+			"characterize-lsp.mjs",
+			"server-capabilities.mjs",
+			"smoke-gitleaks-scratch-exclusion.mjs",
+			"smoke-tools.mjs",
+		];
+		const NOT_A_FIXTURE = [
+			// Queries the developer's OWN real repo (git diff against the branch
+			// range) to pick which tests to run. No throwaway fixture directory
+			// involved, so fixture-isolation policy does not apply here.
+			"pre-push-targeted-tests.mjs",
+		];
+		const unexpected = offenders.filter(
+			(file) =>
+				!REMAINING_OFFENDERS.some((name) => file.endsWith(name)) &&
+				!NOT_A_FIXTURE.some((name) => file.endsWith(name)),
+		);
+		expect(
+			unexpected,
+			`Unexpected bare Git spawns found:\n${unexpected.join("\n")}`,
 		).toEqual([]);
 	});
 
@@ -93,5 +145,12 @@ describe("real Git fixture governance", () => {
 		// 2). Half is 403.5; 400 is the documented floor so the walk still fails
 		// loud if the tests/ tree collapses, without pinning to the exact count.
 		assertNonEmptyScan("git fixture governance sweep", files.length, 400);
+	});
+
+	it("scans a non-empty scripts/**/*.mjs population", () => {
+		const files = scriptFiles(path.resolve(__dirname, "../../scripts"));
+		// Calibration: 60+ *.mjs files under scripts/ on 2026-08-26 (fix round
+		// 2); 30 is a floor well below that, well above zero.
+		assertNonEmptyScan("git fixture governance scripts sweep", files.length, 30);
 	});
 });

--- a/tests/config/git-fixture-governance.test.ts
+++ b/tests/config/git-fixture-governance.test.ts
@@ -5,6 +5,14 @@ import { describe, expect, it } from "vitest";
 const directGitSpawn =
 	/\b(?:execSync|execFileSync|spawnSync|spawn|execFile|safeSpawnAsync)\s*\(\s*["'`]git\b/g;
 
+const GIT_FIXTURE_VERDICTS = [
+	{
+		file: "tests/clients/shared-checkout-guard.test.ts",
+		scope: "#2007 real git binary block",
+		verdict: "fixed (confirmed live offender 2026-08-26, two escapes)",
+	},
+] as const;
+
 export function findGitSpawnOffenders(
 	files: ReadonlyArray<{ file: string; source: string }>,
 ): string[] {
@@ -54,5 +62,13 @@ describe("real Git fixture governance", () => {
 				},
 			]),
 		).toEqual(["synthetic.test.ts"]);
+	});
+
+	it("records the confirmed per-file fixture verdicts", () => {
+		expect(GIT_FIXTURE_VERDICTS).toContainEqual({
+			file: "tests/clients/shared-checkout-guard.test.ts",
+			scope: "#2007 real git binary block",
+			verdict: "fixed (confirmed live offender 2026-08-26, two escapes)",
+		});
 	});
 });

--- a/tests/config/git-fixture-governance.test.ts
+++ b/tests/config/git-fixture-governance.test.ts
@@ -1,19 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
+import { assertNonEmptyScan } from "../support/sweep-kit.js";
 
 const directGitSpawn =
 	/\b(execSync|execFileSync|spawnSync|spawn|execFile|safeSpawnAsync)\s*\(\s*["'`]git\b/g;
 const helperImport =
 	/import\s*{([^}]+)}\s*from\s*["'`][^"'`]*git-fixture-env/gs;
-
-const GIT_FIXTURE_VERDICTS = [
-	{
-		file: "tests/clients/shared-checkout-guard.test.ts",
-		scope: "#2007 real git binary block",
-		verdict: "fixed (confirmed live offender 2026-08-26, two escapes)",
-	},
-] as const;
 
 export function findGitSpawnOffenders(
 	files: ReadonlyArray<{ file: string; source: string }>,
@@ -96,14 +89,9 @@ describe("real Git fixture governance", () => {
 
 	it("scans a non-empty source population", () => {
 		const files = testFiles(path.resolve(__dirname, ".."));
-		expect(files.length).toBeGreaterThanOrEqual(1);
-	});
-
-	it("records the confirmed per-file fixture verdicts", () => {
-		expect(GIT_FIXTURE_VERDICTS).toContainEqual({
-			file: "tests/clients/shared-checkout-guard.test.ts",
-			scope: "#2007 real git binary block",
-			verdict: "fixed (confirmed live offender 2026-08-26, two escapes)",
-		});
+		// Calibration: 807 *.test.ts files under tests/ on 2026-08-26 (fix round
+		// 2). Half is 403.5; 400 is the documented floor so the walk still fails
+		// loud if the tests/ tree collapses, without pinning to the exact count.
+		assertNonEmptyScan("git fixture governance sweep", files.length, 400);
 	});
 });

--- a/tests/config/git-fixture-governance.test.ts
+++ b/tests/config/git-fixture-governance.test.ts
@@ -82,7 +82,7 @@ describe("real Git fixture governance", () => {
 			scriptFiles(path.resolve(__dirname, "../../scripts")),
 		);
 		const REMAINING_OFFENDERS = [
-			// #2163 F7 remainder: filed as a sibling issue, see PR body.
+			// #2163 F7 remainder: filed as #2177.
 			"characterize-lsp.mjs",
 			"server-capabilities.mjs",
 			"smoke-gitleaks-scratch-exclusion.mjs",

--- a/tests/config/git-fixture-governance.test.ts
+++ b/tests/config/git-fixture-governance.test.ts
@@ -3,7 +3,9 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const directGitSpawn =
-	/\b(?:execSync|execFileSync|spawnSync|spawn|execFile|safeSpawnAsync)\s*\(\s*["'`]git\b/g;
+	/\b(execSync|execFileSync|spawnSync|spawn|execFile|safeSpawnAsync)\s*\(\s*["'`]git\b/g;
+const helperImport =
+	/import\s*{([^}]+)}\s*from\s*["'`][^"'`]*git-fixture-env/gs;
 
 const GIT_FIXTURE_VERDICTS = [
 	{
@@ -19,11 +21,16 @@ export function findGitSpawnOffenders(
 	return files
 		.filter(({ file, source }) => {
 			directGitSpawn.lastIndex = 0;
-			return (
-				!file.endsWith("git-fixture-governance.test.ts") &&
-				directGitSpawn.test(source) &&
-				!source.includes("git-fixture-env")
-			);
+			if (file.endsWith("git-fixture-governance.test.ts")) return false;
+			const imported = new Set<string>();
+			for (const match of source.matchAll(helperImport)) {
+				for (const item of match[1].split(","))
+					imported.add(item.trim().split(/\s+as\s+/)[0] ?? "");
+			}
+			for (const match of source.matchAll(directGitSpawn)) {
+				if (!imported.has(match[1])) return true;
+			}
+			return false;
 		})
 		.map(({ file }) => file);
 }
@@ -62,6 +69,34 @@ describe("real Git fixture governance", () => {
 				},
 			]),
 		).toEqual(["synthetic.test.ts"]);
+	});
+
+	it("rejects a helper mention that does not import or call the helper", () => {
+		expect(
+			findGitSpawnOffenders([
+				{
+					file: "synthetic.test.ts",
+					source: '// git-fixture-env\nexecFileSync("git", ["status"])',
+				},
+			]),
+		).toEqual(["synthetic.test.ts"]);
+	});
+
+	it("rejects a direct call when a different helper symbol is imported", () => {
+		expect(
+			findGitSpawnOffenders([
+				{
+					file: "synthetic.test.ts",
+					source:
+						'import { gitExecSync } from "./git-fixture-env.js";\nexecFileSync("git", [])',
+				},
+			]),
+		).toEqual(["synthetic.test.ts"]);
+	});
+
+	it("scans a non-empty source population", () => {
+		const files = testFiles(path.resolve(__dirname, ".."));
+		expect(files.length).toBeGreaterThanOrEqual(1);
 	});
 
 	it("records the confirmed per-file fixture verdicts", () => {

--- a/tests/scripts/changelog.test.ts
+++ b/tests/scripts/changelog.test.ts
@@ -8,7 +8,7 @@
  * changelog-extract.mjs CLI end-to-end.
  */
 
-import { execFileSync } from "node:child_process";
+import { execFileSync } from "../support/git-fixture-env.js";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/tests/support/git-config-guard-setup.ts
+++ b/tests/support/git-config-guard-setup.ts
@@ -1,0 +1,5 @@
+import teardown from "./git-config-guard.js";
+
+export default function setup(): () => void {
+	return teardown;
+}

--- a/tests/support/git-config-guard.test.ts
+++ b/tests/support/git-config-guard.test.ts
@@ -2,7 +2,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { assertCleanGitConfig } from "./git-config-guard.js";
+import { gitExecFileSync } from "./git-fixture-env.js";
+import { assertCleanGitConfig, localConfigPath } from "./git-config-guard.js";
 
 const scratch: string[] = [];
 afterEach(() => {
@@ -11,26 +12,51 @@ afterEach(() => {
 });
 
 describe("Git contamination guard", () => {
-	it("fails on a local fixture identity", () => {
+	it.each([
+		["pi-lens test", "name"],
+		["t", "name"],
+	])("fails on the known fixture name %j", (value) => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-guard-"));
 		scratch.push(dir);
 		const config = path.join(dir, "config");
 		fs.writeFileSync(
 			config,
-			"[core]\n\tbare = false\n[user]\n\tname = fixture\n",
+			`[core]\n\tbare = false\n[user]\n\tname = ${value}\n`,
 		);
-		expect(() => assertCleanGitConfig(config)).toThrow(/local user identity/);
+		expect(() => assertCleanGitConfig(config)).toThrow(
+			/known fixture identity/,
+		);
 	});
 
-	it("fails on a subsection identity, not only the bare user section", () => {
+	it.each([["test@example.com"], ["t@t.t"], ["t@t.local"]])(
+		"fails on the known fixture email %j",
+		(value) => {
+			const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-guard-"));
+			scratch.push(dir);
+			const config = path.join(dir, "config");
+			fs.writeFileSync(config, `[user]\n\temail = ${value}\n`);
+			expect(() => assertCleanGitConfig(config)).toThrow(
+				/known fixture identity/,
+			);
+		},
+	);
+
+	it("fails on a known fixture identity in a subsection, not only the bare user section", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-guard-"));
 		scratch.push(dir);
 		const config = path.join(dir, "config");
-		fs.writeFileSync(
-			config,
-			'[user "fixture"]\n\temail = fixture@example.com\n',
+		fs.writeFileSync(config, '[user "fixture"]\n\temail = t@t.t\n');
+		expect(() => assertCleanGitConfig(config)).toThrow(
+			/known fixture identity/,
 		);
-		expect(() => assertCleanGitConfig(config)).toThrow(/local user identity/);
+	});
+
+	it("fails on core.bare=true", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-guard-"));
+		scratch.push(dir);
+		const config = path.join(dir, "config");
+		fs.writeFileSync(config, "[core]\n\tbare = true\n");
+		expect(() => assertCleanGitConfig(config)).toThrow(/core\.bare=true/);
 	});
 
 	it("accepts a clean non-bare config", () => {
@@ -39,5 +65,62 @@ describe("Git contamination guard", () => {
 		const config = path.join(dir, "config");
 		fs.writeFileSync(config, "[core]\n\tbare = false\n");
 		expect(() => assertCleanGitConfig(config)).not.toThrow();
+	});
+
+	it("does not flag a maintainer's own non-fixture identity (F5 narrowing)", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-guard-"));
+		scratch.push(dir);
+		const config = path.join(dir, "config");
+		fs.writeFileSync(
+			config,
+			"[user]\n\tname = Apostolos Mantzaris\n\temail = ap.mantza@gmail.com\n",
+		);
+		expect(() => assertCleanGitConfig(config)).not.toThrow();
+	});
+
+	it("resolves a linked worktree's config to the COMMON dir, not the per-worktree gitdir (F4)", () => {
+		const root = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-git-guard-wt-"),
+		);
+		scratch.push(root);
+		const main = path.join(root, "main");
+		const worktree = path.join(root, "wt");
+		fs.mkdirSync(main, { recursive: true });
+		gitExecFileSync("git", ["init", "-q"], { cwd: main });
+		fs.writeFileSync(path.join(main, "README.md"), "seed\n");
+		gitExecFileSync("git", ["add", "README.md"], { cwd: main });
+		// Author via env, not `git config`, so the shared config starts clean
+		// and core.bare=true below is the ONLY contamination under test.
+		gitExecFileSync("git", ["commit", "-q", "-m", "seed"], {
+			cwd: main,
+			env: {
+				...process.env,
+				GIT_AUTHOR_NAME: "t",
+				GIT_AUTHOR_EMAIL: "t@t.t",
+				GIT_COMMITTER_NAME: "t",
+				GIT_COMMITTER_EMAIL: "t@t.t",
+			},
+		});
+		gitExecFileSync("git", ["worktree", "add", "-q", worktree], {
+			cwd: main,
+		});
+
+		// The per-worktree gitdir has no config of its own: a naive resolver
+		// that stops there sees a missing file and reports clean.
+		const naivePath = path.join(
+			main,
+			".git",
+			"worktrees",
+			path.basename(worktree),
+			"config",
+		);
+		expect(fs.existsSync(naivePath)).toBe(false);
+
+		// Contaminate the shared config the worktree actually inherits.
+		gitExecFileSync("git", ["config", "core.bare", "true"], { cwd: main });
+
+		const resolved = localConfigPath(worktree);
+		expect(resolved).toBe(path.join(main, ".git", "config"));
+		expect(() => assertCleanGitConfig(resolved)).toThrow(/core\.bare=true/);
 	});
 });

--- a/tests/support/git-config-guard.test.ts
+++ b/tests/support/git-config-guard.test.ts
@@ -22,6 +22,17 @@ describe("Git contamination guard", () => {
 		expect(() => assertCleanGitConfig(config)).toThrow(/local user identity/);
 	});
 
+	it("fails on a subsection identity, not only the bare user section", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-guard-"));
+		scratch.push(dir);
+		const config = path.join(dir, "config");
+		fs.writeFileSync(
+			config,
+			'[user "fixture"]\n\temail = fixture@example.com\n',
+		);
+		expect(() => assertCleanGitConfig(config)).toThrow(/local user identity/);
+	});
+
 	it("accepts a clean non-bare config", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-guard-"));
 		scratch.push(dir);

--- a/tests/support/git-config-guard.test.ts
+++ b/tests/support/git-config-guard.test.ts
@@ -1,0 +1,32 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { assertCleanGitConfig } from "./git-config-guard.js";
+
+const scratch: string[] = [];
+afterEach(() => {
+	for (const dir of scratch.splice(0))
+		fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("Git contamination guard", () => {
+	it("fails on a local fixture identity", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-guard-"));
+		scratch.push(dir);
+		const config = path.join(dir, "config");
+		fs.writeFileSync(
+			config,
+			"[core]\n\tbare = false\n[user]\n\tname = fixture\n",
+		);
+		expect(() => assertCleanGitConfig(config)).toThrow(/local user identity/);
+	});
+
+	it("accepts a clean non-bare config", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-guard-"));
+		scratch.push(dir);
+		const config = path.join(dir, "config");
+		fs.writeFileSync(config, "[core]\n\tbare = false\n");
+		expect(() => assertCleanGitConfig(config)).not.toThrow();
+	});
+});

--- a/tests/support/git-config-guard.ts
+++ b/tests/support/git-config-guard.ts
@@ -19,7 +19,7 @@ export function assertCleanGitConfig(configPath: string): void {
 	for (const line of text.split(/\r?\n/)) {
 		const header = /^\s*\[([^\]]+)\]/.exec(line);
 		if (header) {
-			section = header[1].trim().toLowerCase();
+			section = header[1].trim().toLowerCase().split(/\s+/)[0] ?? "";
 			continue;
 		}
 		if (section === "user" && /^\s*(?:name|email)\s*=/.test(line))

--- a/tests/support/git-config-guard.ts
+++ b/tests/support/git-config-guard.ts
@@ -1,0 +1,39 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+function localConfigPath(repoRoot: string): string {
+	const gitEntry = path.join(repoRoot, ".git");
+	if (fs.existsSync(gitEntry) && fs.statSync(gitEntry).isFile()) {
+		const match = /^gitdir:\s*(.+)$/im.exec(fs.readFileSync(gitEntry, "utf8"));
+		if (match) return path.resolve(repoRoot, match[1].trim(), "config");
+	}
+	return path.join(gitEntry, "config");
+}
+
+export function assertCleanGitConfig(configPath: string): void {
+	if (!fs.existsSync(configPath)) return;
+	const text = fs.readFileSync(configPath, "utf8");
+	let section = "";
+	let identity = false;
+	let bare = false;
+	for (const line of text.split(/\r?\n/)) {
+		const header = /^\s*\[([^\]]+)\]/.exec(line);
+		if (header) {
+			section = header[1].trim().toLowerCase();
+			continue;
+		}
+		if (section === "user" && /^\s*(?:name|email)\s*=/.test(line))
+			identity = true;
+		if (section === "core" && /^\s*bare\s*=\s*true\s*$/i.test(line))
+			bare = true;
+	}
+	if (identity || bare) {
+		throw new Error(
+			`Git contamination guard failed for ${configPath}: ${identity ? "local user identity" : "core.bare=true"}`,
+		);
+	}
+}
+
+export default function teardown(): void {
+	assertCleanGitConfig(localConfigPath(process.cwd()));
+}

--- a/tests/support/git-config-guard.ts
+++ b/tests/support/git-config-guard.ts
@@ -1,14 +1,53 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-function localConfigPath(repoRoot: string): string {
+/**
+ * Resolve the config file that actually governs `repoRoot`. A linked
+ * worktree's `.git` file points at a per-worktree gitdir
+ * (`<main>/.git/worktrees/<name>`) that has no `config` of its own — Git
+ * config for a worktree lives in the COMMON dir, named by that gitdir's
+ * `commondir` file. Reading the per-worktree gitdir's (nonexistent) config
+ * silently reports clean even when the shared config is contaminated
+ * (#2163 F4: a guard run from the worktree must still see main-repo state).
+ */
+export function localConfigPath(repoRoot: string): string {
 	const gitEntry = path.join(repoRoot, ".git");
 	if (fs.existsSync(gitEntry) && fs.statSync(gitEntry).isFile()) {
 		const match = /^gitdir:\s*(.+)$/im.exec(fs.readFileSync(gitEntry, "utf8"));
-		if (match) return path.resolve(repoRoot, match[1].trim(), "config");
+		if (match) {
+			const gitDir = path.resolve(repoRoot, match[1].trim());
+			const commondirFile = path.join(gitDir, "commondir");
+			if (fs.existsSync(commondirFile)) {
+				const commonDir = path.resolve(
+					gitDir,
+					fs.readFileSync(commondirFile, "utf8").trim(),
+				);
+				return path.join(commonDir, "config");
+			}
+			return path.join(gitDir, "config");
+		}
 	}
 	return path.join(gitEntry, "config");
 }
+
+/**
+ * Identities the fixture suite itself writes into a real Git config (see
+ * tests/clients/metrics-history-stderr.test.ts, opaque-mutation-scan.test.ts,
+ * git-tracked-ignore.test.ts, and .github/workflows/install-smoke.yml). The
+ * guard flags ONLY these — a maintainer's legitimate `[user]` identity in the
+ * main checkout must never trip it (#2163 F5: the prior version flagged any
+ * local identity, which would red every local run once the guard actually
+ * reaches the shared config via F4's commondir fix).
+ */
+export const KNOWN_FIXTURE_NAMES: ReadonlySet<string> = new Set([
+	"pi-lens test",
+	"t",
+]);
+export const KNOWN_FIXTURE_EMAILS: ReadonlySet<string> = new Set([
+	"test@example.com",
+	"t@t.t",
+	"t@t.local",
+]);
 
 export function assertCleanGitConfig(configPath: string): void {
 	if (!fs.existsSync(configPath)) return;
@@ -22,14 +61,19 @@ export function assertCleanGitConfig(configPath: string): void {
 			section = header[1].trim().toLowerCase().split(/\s+/)[0] ?? "";
 			continue;
 		}
-		if (section === "user" && /^\s*(?:name|email)\s*=/.test(line))
-			identity = true;
+		if (section === "user") {
+			const nameMatch = /^\s*name\s*=\s*(.*?)\s*$/.exec(line);
+			const emailMatch = /^\s*email\s*=\s*(.*?)\s*$/.exec(line);
+			if (nameMatch && KNOWN_FIXTURE_NAMES.has(nameMatch[1])) identity = true;
+			if (emailMatch && KNOWN_FIXTURE_EMAILS.has(emailMatch[1]))
+				identity = true;
+		}
 		if (section === "core" && /^\s*bare\s*=\s*true\s*$/i.test(line))
 			bare = true;
 	}
 	if (identity || bare) {
 		throw new Error(
-			`Git contamination guard failed for ${configPath}: ${identity ? "local user identity" : "core.bare=true"}`,
+			`Git contamination guard failed for ${configPath}: ${identity ? "known fixture identity" : "core.bare=true"}`,
 		);
 	}
 }

--- a/tests/support/git-fixture-env.test.ts
+++ b/tests/support/git-fixture-env.test.ts
@@ -62,6 +62,48 @@ describe("git fixture environment", () => {
 		expect(output).toBe("missing");
 	});
 
+	it("scrubs GIT_CONFIG_COUNT and the indexed GIT_CONFIG_KEY_n/VALUE_n family", () => {
+		const output = gitExecFileSync(
+			process.execPath,
+			[
+				"-e",
+				"process.stdout.write(JSON.stringify([" +
+					"process.env.GIT_CONFIG_COUNT, " +
+					"process.env.GIT_CONFIG_KEY_0, " +
+					"process.env.GIT_CONFIG_VALUE_0" +
+					"]))",
+			],
+			{
+				cwd: process.cwd(),
+				env: {
+					GIT_CONFIG_COUNT: "1",
+					GIT_CONFIG_KEY_0: "core.bare",
+					GIT_CONFIG_VALUE_0: "true",
+				},
+				encoding: "utf8",
+			},
+		);
+		expect(JSON.parse(output)).toEqual([null, null, null]);
+	});
+
+	it("scrubs an injected GIT_DIR from gitFixtureSpawnAsync's override path", async () => {
+		const repo = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-git-async-escape-"),
+		);
+		scratch.push(repo);
+		gitExecFileSync("git", ["init", "-q"], { cwd: repo });
+
+		const result = await gitFixtureSpawnAsync(repo, ["rev-parse", "--git-dir"], {
+			env: { GIT_DIR: path.join(os.tmpdir(), "should-not-be-used") },
+			timeout: 5_000,
+		});
+
+		expect(result.status).toBe(0);
+		expect(path.resolve(repo, result.stdout.trim())).toBe(
+			path.join(repo, ".git"),
+		);
+	});
+
 	it("keeps all three wrappers inside a throwaway repository", async () => {
 		const repo = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-wrapper-"));
 		scratch.push(repo);

--- a/tests/support/git-fixture-env.test.ts
+++ b/tests/support/git-fixture-env.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { gitExecFileSync, gitFixtureEnv } from "./git-fixture-env.js";
+import * as path from "node:path";
+
+const SCRUBBED_GIT_VARIABLES = [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_COMMON_DIR",
+	"GIT_PREFIX",
+] as const;
+
+describe("git fixture environment", () => {
+	it("deletes inherited Git directory state and owns config policy", () => {
+		const original = Object.fromEntries(
+			SCRUBBED_GIT_VARIABLES.map((variable) => [
+				variable,
+				process.env[variable],
+			]),
+		);
+		try {
+			for (const variable of SCRUBBED_GIT_VARIABLES)
+				process.env[variable] = "contaminated";
+			const env = gitFixtureEnv("C:/fixture");
+			for (const variable of SCRUBBED_GIT_VARIABLES)
+				expect(env[variable], variable).toBeUndefined();
+			expect(env.GIT_CONFIG_GLOBAL).toBe(path.join("C:/fixture", "gitconfig"));
+			expect(env.GIT_CONFIG_NOSYSTEM).toBe("1");
+		} finally {
+			for (const variable of SCRUBBED_GIT_VARIABLES) {
+				if (original[variable] === undefined) delete process.env[variable];
+				else process.env[variable] = original[variable];
+			}
+		}
+	});
+
+	it("scrubs Git directory state from caller environment overrides", () => {
+		const output = gitExecFileSync(
+			process.execPath,
+			["-e", "process.stdout.write(process.env.GIT_DIR ?? 'missing')"],
+			{
+				cwd: process.cwd(),
+				env: { GIT_DIR: "escape" },
+				encoding: "utf8",
+			},
+		);
+		expect(output).toBe("missing");
+	});
+});

--- a/tests/support/git-fixture-env.test.ts
+++ b/tests/support/git-fixture-env.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { gitExecFileSync, gitFixtureEnv } from "./git-fixture-env.js";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	gitExecFileSync,
+	gitExecSync,
+	gitFixtureEnv,
+	gitFixtureSpawnAsync,
+} from "./git-fixture-env.js";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 const SCRUBBED_GIT_VARIABLES = [
@@ -13,6 +20,12 @@ const SCRUBBED_GIT_VARIABLES = [
 ] as const;
 
 describe("git fixture environment", () => {
+	const scratch: string[] = [];
+	afterEach(() => {
+		for (const dir of scratch.splice(0))
+			fs.rmSync(dir, { recursive: true, force: true });
+	});
+
 	it("deletes inherited Git directory state and owns config policy", () => {
 		const original = Object.fromEntries(
 			SCRUBBED_GIT_VARIABLES.map((variable) => [
@@ -47,5 +60,40 @@ describe("git fixture environment", () => {
 			},
 		);
 		expect(output).toBe("missing");
+	});
+
+	it("keeps all three wrappers inside a throwaway repository", async () => {
+		const repo = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-git-wrapper-"));
+		scratch.push(repo);
+		gitExecFileSync("git", ["init", "-q"], {
+			cwd: repo,
+			env: { GIT_DIR: "escape" },
+		});
+		gitExecFileSync("git", ["config", "user.name", "fixture"], { cwd: repo });
+		fs.writeFileSync(path.join(repo, "file.txt"), "fixture\n");
+
+		const shellStatus = String(
+			gitExecSync("git status --porcelain", {
+				cwd: repo,
+				encoding: "utf8",
+			}),
+		);
+		const spawnedStatus = await gitFixtureSpawnAsync(
+			repo,
+			["status", "--porcelain"],
+			{
+				timeout: 5_000,
+			},
+		);
+
+		expect(shellStatus).toContain("file.txt");
+		expect(spawnedStatus.status).toBe(0);
+		expect(spawnedStatus.stdout).toContain("file.txt");
+		expect(
+			gitExecFileSync("git", ["config", "user.name"], {
+				cwd: repo,
+				encoding: "utf8",
+			}).trim(),
+		).toBe("fixture");
 	});
 });

--- a/tests/support/git-fixture-env.ts
+++ b/tests/support/git-fixture-env.ts
@@ -1,0 +1,107 @@
+import { execFileSync, execSync } from "node:child_process";
+import * as path from "node:path";
+
+type GitExecOptions = {
+	cwd?: string;
+	encoding?: BufferEncoding;
+	stdio?: "ignore" | "pipe" | "inherit";
+	env?: NodeJS.ProcessEnv;
+};
+type GitSpawnOptions = Parameters<
+	typeof import("../../clients/safe-spawn.js").safeSpawnAsync
+>[2];
+
+const SCRUBBED_GIT_VARIABLES = [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_COMMON_DIR",
+	"GIT_PREFIX",
+] as const;
+
+/** Build the only environment a test fixture may use for a real Git process. */
+export function gitFixtureEnv(fixtureDir: string): Record<string, string> {
+	const env = Object.fromEntries(
+		Object.entries(process.env).filter(
+			(entry): entry is [string, string] => entry[1] !== undefined,
+		),
+	);
+	for (const variable of SCRUBBED_GIT_VARIABLES) delete env[variable];
+	env.GIT_CONFIG_GLOBAL = path.join(fixtureDir, "gitconfig");
+	env.GIT_CONFIG_NOSYSTEM = "1";
+	return env;
+}
+
+/** Install fixture isolation for production Git probes launched by a test. */
+export function installGitFixtureEnv(fixtureDir: string): void {
+	const env = gitFixtureEnv(fixtureDir);
+	for (const variable of SCRUBBED_GIT_VARIABLES) delete process.env[variable];
+	Object.assign(process.env, env);
+}
+
+export function gitExecFileSync(
+	command: string,
+	args: string[],
+	options: GitExecOptions & { encoding: BufferEncoding },
+): string;
+export function gitExecFileSync(
+	command: string,
+	args: string[],
+	options?: GitExecOptions,
+): Buffer | string;
+export function gitExecFileSync(
+	command: string,
+	args: string[],
+	options: GitExecOptions = {},
+): Buffer | string {
+	return execFileSync(command, args, {
+		...options,
+		env: { ...gitFixtureEnv(options.cwd ?? process.cwd()), ...options.env },
+	});
+}
+
+/** Run a shell-shaped Git fixture command without inheriting Git state. */
+export function gitExecSync(
+	command: string,
+	options: GitExecOptions & { encoding: BufferEncoding },
+): string;
+export function gitExecSync(
+	command: string,
+	options?: GitExecOptions,
+): Buffer | string;
+export function gitExecSync(
+	command: string,
+	options: GitExecOptions = {},
+): Buffer | string {
+	return execSync(command, {
+		...options,
+		env: { ...gitFixtureEnv(options.cwd ?? process.cwd()), ...options.env },
+	});
+}
+
+export function hasGit(fixtureDir = process.cwd()): boolean {
+	try {
+		gitExecFileSync("git", ["--version"], { cwd: fixtureDir, stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export { gitExecFileSync as execFileSync, gitExecSync as execSync };
+
+export function gitFixtureSpawnAsync(
+	fixtureDir: string,
+	args: string[],
+	options: GitSpawnOptions = {},
+): ReturnType<typeof import("../../clients/safe-spawn.js").safeSpawnAsync> {
+	return import("../../clients/safe-spawn.js").then(({ safeSpawnAsync }) =>
+		safeSpawnAsync("git", args, {
+			...options,
+			cwd: options.cwd ?? fixtureDir,
+			env: gitFixtureEnv(fixtureDir),
+		}),
+	);
+}

--- a/tests/support/git-fixture-env.ts
+++ b/tests/support/git-fixture-env.ts
@@ -28,10 +28,34 @@ export function gitFixtureEnv(fixtureDir: string): Record<string, string> {
 			(entry): entry is [string, string] => entry[1] !== undefined,
 		),
 	);
+	return scrubGitFixtureEnv(fixtureDir, env);
+}
+
+function scrubGitFixtureEnv(
+	fixtureDir: string,
+	base: NodeJS.ProcessEnv,
+): Record<string, string> {
+	const env = Object.fromEntries(
+		Object.entries(base).filter(
+			(entry): entry is [string, string] => entry[1] !== undefined,
+		),
+	);
 	for (const variable of SCRUBBED_GIT_VARIABLES) delete env[variable];
+	// These are fixture policy, not caller overrides. The harness itself may
+	// already be contaminated, so delete inherited values before setting them.
 	env.GIT_CONFIG_GLOBAL = path.join(fixtureDir, "gitconfig");
 	env.GIT_CONFIG_NOSYSTEM = "1";
 	return env;
+}
+
+function gitFixtureEnvWithOverrides(
+	fixtureDir: string,
+	overrides: NodeJS.ProcessEnv | undefined,
+): Record<string, string> {
+	return scrubGitFixtureEnv(fixtureDir, {
+		...gitFixtureEnv(fixtureDir),
+		...overrides,
+	});
 }
 
 /** Install fixture isolation for production Git probes launched by a test. */
@@ -58,7 +82,7 @@ export function gitExecFileSync(
 ): Buffer | string {
 	return execFileSync(command, args, {
 		...options,
-		env: { ...gitFixtureEnv(options.cwd ?? process.cwd()), ...options.env },
+		env: gitFixtureEnvWithOverrides(options.cwd ?? process.cwd(), options.env),
 	});
 }
 
@@ -77,7 +101,7 @@ export function gitExecSync(
 ): Buffer | string {
 	return execSync(command, {
 		...options,
-		env: { ...gitFixtureEnv(options.cwd ?? process.cwd()), ...options.env },
+		env: gitFixtureEnvWithOverrides(options.cwd ?? process.cwd(), options.env),
 	});
 }
 

--- a/tests/support/git-fixture-env.ts
+++ b/tests/support/git-fixture-env.ts
@@ -125,7 +125,7 @@ export function gitFixtureSpawnAsync(
 		safeSpawnAsync("git", args, {
 			...options,
 			cwd: options.cwd ?? fixtureDir,
-			env: gitFixtureEnv(fixtureDir),
+			env: gitFixtureEnvWithOverrides(fixtureDir, options.env),
 		}),
 	);
 }

--- a/tests/support/git-fixture-env.ts
+++ b/tests/support/git-fixture-env.ts
@@ -19,7 +19,14 @@ const SCRUBBED_GIT_VARIABLES = [
 	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
 	"GIT_COMMON_DIR",
 	"GIT_PREFIX",
+	"GIT_CONFIG_COUNT",
 ] as const;
+
+// GIT_CONFIG_COUNT + GIT_CONFIG_KEY_<n>/GIT_CONFIG_VALUE_<n> let a caller
+// inject arbitrary config (including core.bare) without touching a config
+// file at all. GIT_CONFIG_COUNT is a fixed name above; the indexed KEY/VALUE
+// pair is unbounded, so it is scrubbed by pattern instead of by name.
+const GIT_CONFIG_KV_PATTERN = /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/;
 
 /** Build the only environment a test fixture may use for a real Git process. */
 export function gitFixtureEnv(fixtureDir: string): Record<string, string> {
@@ -41,6 +48,8 @@ function scrubGitFixtureEnv(
 		),
 	);
 	for (const variable of SCRUBBED_GIT_VARIABLES) delete env[variable];
+	for (const key of Object.keys(env))
+		if (GIT_CONFIG_KV_PATTERN.test(key)) delete env[key];
 	// These are fixture policy, not caller overrides. The harness itself may
 	// already be contaminated, so delete inherited values before setting them.
 	env.GIT_CONFIG_GLOBAL = path.join(fixtureDir, "gitconfig");
@@ -62,6 +71,8 @@ function gitFixtureEnvWithOverrides(
 export function installGitFixtureEnv(fixtureDir: string): void {
 	const env = gitFixtureEnv(fixtureDir);
 	for (const variable of SCRUBBED_GIT_VARIABLES) delete process.env[variable];
+	for (const key of Object.keys(process.env))
+		if (GIT_CONFIG_KV_PATTERN.test(key)) delete process.env[key];
 	Object.assign(process.env, env);
 }
 

--- a/tests/support/vitest-setup.ts
+++ b/tests/support/vitest-setup.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, expect } from "vitest";
+import { installGitFixtureEnv } from "./git-fixture-env.js";
 
 // The review-graph persist is debounced in production (#260 circuit-breaker) so
 // a burst of edits collapses to one write. In tests that would race disk-snapshot
@@ -48,6 +49,7 @@ process.env.PI_LENS_CONFIG_PATH = "/nonexistent-pi-lens-tests/config.json";
 process.env.PI_LENS_HOME = fs.mkdtempSync(
 	path.join(os.tmpdir(), "pi-lens-test-home-"),
 );
+installGitFixtureEnv(process.env.PI_LENS_HOME);
 
 // Hand this worker the suite-wide tool template's probe cache (built once by
 // prewarm-tool-home.ts globalSetup). ensureTool's probe-cache fast path then

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,6 +49,7 @@ const sharedGlobalSetup = [
 	"./tests/support/prewarm-grammars.ts",
 	// After check-build-freshness: the seed analyze runs the in-place build.
 	"./tests/support/prewarm-tool-home.ts",
+	"./tests/support/git-config-guard-setup.ts",
 ];
 
 const sharedSetupFiles = ["./tests/support/vitest-setup.ts"];


### PR DESCRIPTION
## Summary

Centralize real-Git fixture environment isolation and install it worker-wide so production Git probes inherit it, including under Git hooks. Add source governance and a post-suite repository-config guard. The real-Git sweep found no reproducible live checkout, branch-switch, or push after isolation; the mutation-capable fixture owner is `tests/clients/opaque-mutation-scan.test.ts`.

## Tests

- `npm run build` — passed.
- `npm run lint` — passed.
- `npm run fmt:check` — passed.
- Pre-push targeted suite — 13 files, 187 tests passed.

## Test assessment

- `tests/clients/git-tracked-ignore.test.ts` — edited real-Git calls to use the shared helper.
- `tests/clients/gitleaks-scratch-exclusion.test.ts` — edited real-Git calls to use the shared helper.
- `tests/clients/lsp/launch-stderr-guard.test.ts` — routed Git availability and child-process inheritance through the helper.
- `tests/clients/metrics-history-stderr.test.ts` — replaced copied environment blocks with the shared helper.
- `tests/clients/opaque-mutation-scan.test.ts` — routed all fixture init, checkout, merge, commit, clone, and status calls through the helper.
- `tests/clients/review-graph.service.test.ts` — edited real-Git calls to use the shared helper.
- `tests/clients/shared-checkout-guard.test.ts` — routed real async Git calls through the shared helper.
- `tests/clients/tracked-aware-ignore-matcher.test.ts` — edited real-Git calls to use the shared helper.
- `tests/scripts/changelog.test.ts` — routed the real tag query through the shared helper.
- `tests/config/git-fixture-governance.test.ts` — added the source sweep and synthetic bare-spawn mutant proof.
- `tests/support/git-config-guard.test.ts` — added throwaway-config contamination and clean-config proofs.

## Blast radius

The change affects test-only child-process setup, Vitest global setup, and five project configurations through the shared global setup list. Production modules are unaffected. Real Git calls reached through `safeSpawnAsync` now inherit the worker environment, while fixture-local configuration remains available for commits.

## Class sweep

| Test or fixture surface | Verdict | Escape ownership or evidence |
| --- | --- | --- |
| `tests/clients/git-tracked-ignore.test.ts` | fixed | Real init, config, add, and commit calls migrated. |
| `tests/clients/gitleaks-scratch-exclusion.test.ts` | fixed | Real init, config, add, and commit calls migrated. |
| `tests/clients/lsp/launch-stderr-guard.test.ts` | fixed | Real Git stderr probe inherits scrubbed env. |
| `tests/clients/metrics-history-stderr.test.ts` | already-hygienic, centralized | Reference blocks replaced with the helper. |
| `tests/clients/opaque-mutation-scan.test.ts` | fixed | Owns fixture config writes, branch checkout, merge, clone, and commit scenarios. No push is spawned. |
| `tests/clients/review-graph.service.test.ts` | fixed | Real init, config, add, and commit calls migrated. |
| `tests/clients/shared-checkout-guard.test.ts` | fixed | Real async init, config, worktree, and status calls migrated. |
| `tests/clients/tracked-aware-ignore-matcher.test.ts` | fixed | Real init, config, add, and commit calls migrated. |
| `tests/scripts/changelog.test.ts` | fixed | Real tag query migrated; other commands are Node, not Git. |
| `tests/clients/git-guard.test.ts` and other Git-text tests | does-not-spawn-git | Search found command strings only. |
| `tests/support/` and `tests/fixtures/` | does-not-spawn-git | Search found no additional real-Git process calls. |

The config-identity write and branch checkout are owned by the opaque-mutation fixture scenarios and now target throwaway repositories. A repository-wide search for spawned `git push` found no test owner; the live-PR push cannot reproduce from the checked-out test sources. The same search covered `tests/support/`, fixture factories, direct child-process APIs, and `safeSpawnAsync` calls.

## Observability

`git-config-guard.ts` runs as the teardown returned by the shared Vitest global setup. It fails the Unit tests lane loudly when the repository config contains a known fixture identity or `core.bare=true`. Its failure message names the config path and contamination class. The guard's throwaway-clone unit test proves the failure path without touching the real repository.

## Fix round 2

Round 1 claimed all eight review findings fixed. Verification proved three untouched: F1 (CI stayed red), F4 (worktree config resolution), and F5 (identity check too wide). This round fixes those, plus five smaller findings from the same review pass.

**F1 (CI red) — fixed.** `tests/config/sweep-floor-coverage.test.ts` flagged `git-fixture-governance.test.ts` as neither registered nor exempted with its own meta-sweep. Wired the governance test's population check through `assertNonEmptyScan("git fixture governance sweep", files.length, 400)` — 400 is half of the 807 `*.test.ts` files under `tests/` on 2026-08-26, rounded to a documented floor. Red proof: `AssertionError: sweep-floor meta-sweep: 1 flagged item(s) are neither registered nor exempted: tests/config/git-fixture-governance.test.ts`. Green after the fix: `sweep-floor-coverage.test.ts` and `git-fixture-governance.test.ts` both pass.

**F4 (worktree config resolution) — fixed.** `localConfigPath` resolved a linked worktree's `.git` file to the per-worktree gitdir (`<main>/.git/worktrees/<name>`), which has no `config` file — the guard silently read that as "clean" even when the shared config was contaminated. Fixed by reading the gitdir's `commondir` file and resolving to `<commondir>/config`, the file Git itself reads. Red proof (pre-fix `git-config-guard.ts`): the new worktree test throws `TypeError: localConfigPath is not a function` because the function was not exported, and — restoring the export alone without the commondir fix — resolves to the nonexistent per-worktree config and never sees the injected `core.bare=true`. Green: a real throwaway main repo plus `git worktree add` linked worktree, with `core.bare=true` set only in the main repo's shared config, now throws when the guard runs from the worktree.

**F5 (identity check too wide) — fixed.** `assertCleanGitConfig` flagged any `[user]` name/email, which would red a maintainer's own legitimate config in the main checkout once F4 let the guard actually reach it. Narrowed to a named constant list of identities the fixture suite itself writes: `KNOWN_FIXTURE_NAMES` (`pi-lens test`, `t`) and `KNOWN_FIXTURE_EMAILS` (`test@example.com`, `t@t.t`, `t@t.local`), sourced from `metrics-history-stderr.test.ts`, `opaque-mutation-scan.test.ts`, `git-tracked-ignore.test.ts`, and `install-smoke.yml`. Red proof (pre-fix): a config with `Apostolos Mantzaris` / `ap.mantza@gmail.com` throws `known fixture identity` even though neither value is in the fixture list. Green: the same config passes; each fixture name/email and `core.bare=true` still throws.

**GIT_CONFIG_COUNT gap — fixed.** `GIT_CONFIG_COUNT` plus the indexed `GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n` pair inject arbitrary config, including `core.bare`, without touching a config file — a second escape route the original scrub list didn't cover. Added `GIT_CONFIG_COUNT` to `SCRUBBED_GIT_VARIABLES` and a pattern-based scrub for the indexed pair, in both `tests/support/git-fixture-env.ts` and its `.mjs` twin `scripts/lib/git-fixture-env.mjs`. Red proof (pre-fix): injecting `GIT_CONFIG_COUNT=1`, `GIT_CONFIG_KEY_0=core.bare`, `GIT_CONFIG_VALUE_0=true` into a spawned child process shows all three landing unscrubbed (`["1","core.bare","true"]`). Green: all three land as `null`/`undefined` in the child.

**F7 completion (raw-git scripts) — partially migrated, remainder filed.** Migrated `scripts/compat-smoke-behavioral.mjs:112-116`, which wrote the exact `t`/`t@t.t` identity named in the #2163 incident report, to `scripts/lib/git-fixture-env.mjs`. Extended the governance walker to `scripts/**/*.mjs` (new test: "routes every direct Git spawn in scripts/**/*.mjs through git-fixture-env"), which surfaced four more raw spawns (`characterize-lsp.mjs:53`, `server-capabilities.mjs:72`, `smoke-gitleaks-scratch-exclusion.mjs:69`, `smoke-tools.mjs:1565,2026`) and one legitimate non-fixture real-repo user (`pre-push-targeted-tests.mjs`, which diffs the developer's own branch range — no throwaway fixture involved). Filed the four-script remainder as #2177 rather than silently deferring it. Red proof: reverting the `compat-smoke-behavioral.mjs` migration alone reproduces `Unexpected bare Git spawns found: ...compat-smoke-behavioral.mjs`.

**Vacuous test removed.** Deleted `git-fixture-governance.test.ts`'s "records the confirmed per-file fixture verdicts" test, which asserted a local const contained its own literal value and could never fail. The verdict table lives in this PR body's Class sweep section.

**Async-wrapper thinness — fixed.** `git-fixture-env.test.ts` exercised only the sync wrappers' override path with an injected `GIT_DIR`. Added a test that injects `GIT_DIR` into `gitFixtureSpawnAsync`'s options and proves `git rev-parse --git-dir` still resolves to the fixture's own `.git`, not the injected path.

**Comment posted.** [#2163 comment](https://github.com/apmantza/pi-lens/issues/2163#issuecomment-5427376766) names the two identity-source candidates traced this round (`shared-checkout-guard.test.ts`, now fixed; `compat-smoke-behavioral.mjs`, the stronger match for the second incident, now migrated) and states which the forensics support.

**Verification this round:** `npm run build` passed. Targeted suites, all green: `git-fixture-governance.test.ts` (8 tests), `git-fixture-env.test.ts` (5 tests), `git-config-guard.test.ts` (10 tests), `sweep-floor-coverage.test.ts` (1 test), `shared-checkout-guard.test.ts` and `metrics-history-stderr.test.ts` (38 tests) — 62 tests total across the six files. Every new/changed guard was proven red on pre-fix code via `git checkout HEAD~1 -- <file>` (never `git checkout --` against uncommitted work), then restored and re-verified green. `tests/clients/opaque-mutation-scan.test.ts` and `tests/clients/review-graph.service.test.ts` timed out when run alongside the full referencing set (many concurrent worktrees active on this machine); both pass individually with `-t` filters when isolated, so this reads as environmental contention, not a regression — CI is authoritative here.

