### PR TITLE
fix(ci): keep distinct fix-round headings distinct in body repair (closes #2170)

### DIFF
--- a/.changelog/fix-2170-multi-round-count-gate.md
+++ b/.changelog/fix-2170-multi-round-count-gate.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- PR body repair keeps distinct numbered fix-round headings distinct, so legitimate multi-round bodies can be repaired while duplicate and corrupted headings remain protected.

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -181,9 +181,7 @@ export function repairFlattenedBody(body = "") {
 	const templateHeadings = repairedHeadings.filter((heading) =>
 		new RegExp(`^(?:${REPAIR_HEADING_PATTERN})$`, "i").test(heading),
 	);
-	const distinctTemplateHeadings = new Set(
-		templateHeadings.map((heading) => heading.replace(/ \d+$/, "")),
-	);
+	const distinctTemplateHeadings = new Set(templateHeadings);
 	if (repairedHeadings.length !== distinctTemplateHeadings.size) return source;
 	return repaired;
 }

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -12,6 +12,8 @@ import {
 const body = `Summary\nOpening context.\n\n## Tests\nTargeted tests pass.\n\n## Blast radius\nNo runtime module touched.\n\n## Class sweep\nWhole-tree grep completed.\n\n## Observability\nThe advisory check run is the record.`;
 const flattenedBody =
 	"## Summary Await the first lifecycle run's asynchronous word-index snapshot promotion before reseeding the current-format snapshot for the fallback run. ## Tests - Native master flake justification for the count barrier: 2/10 forced runs reproduced the promotion race. - Fixed lifecycle test: 5/5 tests passed. ### Test assessment - tests/clients/word-index-lifecycle.test.ts uniquely pins the ordering guard. ## Blast radius This change is test-only. ## Class sweep The async-persist lifecycle race is fully covered. ## Observability The test observes existing project snapshot records.";
+const multiRoundFlattenedBody =
+	"## Summary Preserve the repair context across multiple review rounds. ## Tests - The repair fixture exercises distinct numbered fix rounds. ### Test assessment - tests/scripts/check-pr-body.test.ts uniquely pins numbered fix-round repair. ## Fix round 1 The first review round records the initial correction. ## Fix round 2 The second review round records the follow-up correction. ## Blast radius This change is test-only. ## Class sweep Numbered fix rounds remain distinct during repair. ## Observability The repaired body is validated by the existing body lint.";
 const motivatingFlattenedBodies = [
 	"## Summary Fix #2052 R1 by making MCP LSP readiness consult the authoritative session-root registry. When the 128-root registry evicts a root, a later request re-registers it instead of returning from the stale lspReadyCwds memo. Add the remainder matrix cells: one mixed inside/outside batch, and an explicit /Users/... case-boundary fixture whose expected result follows the actual filesystem. ## Tests - Red-first mutation proof against the old memo-only guard: firstRootStillServed=false - npm run lint: passed. - npm run build: passed before every test run. - tests/clients/lsp/root-coalescing.test.ts: 12/12 focused tests passed. ### Test assessment - root-coalescing.test.ts uniquely pins the session-root registry and eviction transition. ## Blast radius MCP server readiness and the LSP session-root registry. ## Class sweep The memo-versus-registry readiness pair is fixed here. ## Observability Evicted roots recover; foreign roots retain the existing bounded decline record.",
 	"## Summary Fixes #2104 by making the stale-open-issues detector prove exhaustion for the open-issue population. If the safety bound is reached while a full page remains, the detector throws instead of interpreting a partial population. ## Tests - tests/scripts/stale-open-issues.test.ts adds a page-aware regression. - F1 mutation red after dropping the exhaustive flag. - Green targeted run: 20 tests passed. ### Test assessment - stale-open-issues.test.ts uniquely pins exhaustive pagination and truncation disclosure. ## Blast radius The scheduled stale-open-issues detector and its pagination helper. ## Class sweep Bounded API reads classify truncation before interpreting results. ## Observability Successful comments include the scanned population; a bound hit fails the workflow.",
@@ -23,6 +25,16 @@ describe("flattened PR body repair", () => {
 		expect(lintPrBody(flattenedBody)).toMatchObject({ valid: false });
 		expect(detectFlattenedBody(flattenedBody)).toBe(true);
 		const repaired = repairFlattenedBody(flattenedBody);
+		expect(lintPrBody(repaired, { requireTestAssessment: true })).toEqual({
+			valid: true,
+			errors: [],
+		});
+	});
+
+	it("repairs flattened bodies with distinct numbered fix rounds", () => {
+		expect(detectFlattenedBody(multiRoundFlattenedBody)).toBe(true);
+		const repaired = repairFlattenedBody(multiRoundFlattenedBody);
+		expect(repaired).not.toBe(multiRoundFlattenedBody);
 		expect(lintPrBody(repaired, { requireTestAssessment: true })).toEqual({
 			valid: true,
 			errors: [],


### PR DESCRIPTION
## Summary

Closes #2170. Keep distinct numbered fix-round headings distinct during flattened PR-body repair. The count gate now accepts legitimate multi-round bodies, while duplicate and corrupted headings still refuse repair.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (run `npm install` after dep changes)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there
- [x] `.changelog/<branch-or-slug>-<short-desc>.md` has one valid entry **in this PR** for any user-facing change (Added/Changed/Deprecated/Removed/Fixed/Security) - see [.changelog/README.md](../.changelog/README.md)
- [x] Commit subject includes the issue number: `(closes #NNN)` or `(refs #NNN)`

## Tests

- `tests/scripts/check-pr-body.test.ts`: added a flattened-body fixture with `## Fix round 1` and `## Fix round 2`; it proves both rounds repair and the result passes body lint.
- The four corruption probes still refuse repair: two mid-sentence quoted headings, one plain-text quoted example, and one fenced example.
- The count-gate mutation still reds both shape fixtures: duplicate template headings and an extra repaired heading.
- Pre-fix red-first result: `Tests 74 passed (74)` was not the failure summary; the multi-round assertion failed with this exact output:

  `AssertionError: expected '## Summary Preserve the repair contex…' not to be '## Summary Preserve the repair contex…' // Object.is equality`

- Final targeted result: `Test Files 1 passed (1)` and `Tests 74 passed (74)`.
- Additional checks: `npm run build`, `npm run lint`, `npm run fmt:check`, `npm run changelog:check`, and `git diff --check` pass.

### Test assessment

- `tests/scripts/check-pr-body.test.ts`: uniquely pins flattened PR-body repair, corruption refusal, duplicate detection, count-gate mutation resistance, and the new numbered multi-round regression. No existing test became redundant.

## Blast radius

- `scripts/check-pr-body.mjs`: the flattened PR-body repair entry point and its count gate are affected. No callbacks or runtime entry points change; the verification plan covers the targeted script suite and build.
- The change removes one normalization from a repair-only path. It adds no hot-path cost beyond preserving the existing `Set` construction.

## Observability

The existing body-lint refusal diagnostics remain the production record. No new observability gap exists.

## Class sweep

The defect class is repair count normalization that merges distinct numbered headings. A whole-tree search across `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts` found this normalization only in `scripts/check-pr-body.mjs`; the related tests cover all count-gate members. The family stays on this single repair seam.