### PR TITLE
fix(lsp): bound stale re-arm and count cap eviction (closes #2167, closes #2168)

### DIFF
--- a/.changelog/fix-2167-2168-late-aux-telemetry.md
+++ b/.changelog/fix-2167-2168-late-aux-telemetry.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Bound the stale-findings re-arm loop and count cap-evicted pairs (closes #2167, closes #2168)** — Late-auxiliary turn-end harvesting now caps a pair that keeps returning stale findings at `MAX_LATE_AUX_REARMS` re-arms, re-arms (instead of dropping) a pair after a transient probe-cache read failure, and counts a pending-coverage cap eviction with a dedicated `capEvicted` counter folded into the turn's reconciliation sum.

--- a/clients/lsp/pending-aux-coverage.ts
+++ b/clients/lsp/pending-aux-coverage.ts
@@ -109,6 +109,15 @@ export function isPendingAuxiliaryPastRearmTtl(
 
 const pending = new Map<string, PendingAuxCoverageEntry>();
 
+/**
+ * #2168: pairs evicted at the cap have no other retirement record — the
+ * drain-time reconciliation in `runtime-turn.ts` never sees them because
+ * they are gone before a drain can observe them. Counted here so the
+ * consumer can fold them into its per-turn `pairCreated`/retirement sum
+ * instead of the pair vanishing uncounted.
+ */
+let capEvictedCount = 0;
+
 function pairKey(filePath: string, serverId: string): string {
 	return `${normalizeEphemeralMapKey(filePath)}\u0000${serverId}`;
 }
@@ -173,6 +182,7 @@ export function markPendingAuxiliaryCoverage(
 			const oldest = pending.keys().next().value;
 			if (oldest === undefined) break;
 			pending.delete(oldest);
+			capEvictedCount += 1;
 		}
 	}
 }
@@ -226,9 +236,23 @@ export const pendingAuxiliaryCoverageSizeForTests =
 	pendingAuxiliaryCoverageSize;
 
 /**
+ * Drain (read and reset) the cap-eviction count accumulated since the last
+ * drain. Mirrors {@link drainPendingAuxiliaryCoverage}'s consume-once shape
+ * so the turn-end consumer can fold evictions that happened between two
+ * turn ends into its reconciliation sum exactly once, never accumulating
+ * across turns.
+ */
+export function drainPendingAuxCapEvictedCount(): number {
+	const count = capEvictedCount;
+	capEvictedCount = 0;
+	return count;
+}
+
+/**
  * Session-boundary clear (#1635): pending baselines are unreachable after
  * reset (the generation-stamped keys no longer match any active session).
  */
 export function resetPendingAuxiliaryCoverage(): void {
 	pending.clear();
+	capEvictedCount = 0;
 }

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -2365,7 +2365,7 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	let lateAuxCeilingExhausted = 0;
 	let lateAuxAnswered = 0;
 	const lateAuxStuckPairs: Array<{ filePath: string; serverId: string }> = [];
-	if (drainedPairs.length > 0 || lateAuxCapEvicted > 0) {
+	if (drainedPairs.length > 0) {
 		const byFile = new Map<string, typeof drainedPairs>();
 		for (const pair of drainedPairs) {
 			const list = byFile.get(pair.filePath);

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -97,6 +97,7 @@ import { sweepInlineBlockerPastEof } from "./blocker-past-eof.js";
 // #2001/#2002: collect-later delivery for slow auxiliary LSP servers.
 import { getLSPService } from "./lsp/index.js";
 import {
+	drainPendingAuxCapEvictedCount,
 	drainPendingAuxiliaryCoverage,
 	isPendingAuxiliaryPastRearmTtl,
 	rearmPendingAuxiliaryCoverage,
@@ -2349,6 +2350,10 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	// client drops silently.
 	const lateAuxStart = Date.now();
 	const drainedPairs = drainPendingAuxiliaryCoverage();
+	// #2168: cap evictions retire a pair before any drain can observe it — read
+	// and reset that count here so it folds into this turn's reconciliation
+	// sum instead of the pair vanishing uncounted.
+	const lateAuxCapEvicted = drainPendingAuxCapEvictedCount();
 	let lateAuxDelivered = 0;
 	let lateAuxStale = 0;
 	let lateAuxMissing = 0;
@@ -2360,7 +2365,7 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	let lateAuxCeilingExhausted = 0;
 	let lateAuxAnswered = 0;
 	const lateAuxStuckPairs: Array<{ filePath: string; serverId: string }> = [];
-	if (drainedPairs.length > 0) {
+	if (drainedPairs.length > 0 || lateAuxCapEvicted > 0) {
 		const byFile = new Map<string, typeof drainedPairs>();
 		for (const pair of drainedPairs) {
 			const list = byFile.get(pair.filePath);
@@ -2380,8 +2385,28 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 						new Set(pairs.map((p) => p.serverId)),
 					);
 				} catch {
-					// #2027 round-1 P3-2: count dropped pairs — never silent.
+					// #2027 round-1 P3-2 / #2167 R2-2: a transient probe rejection
+					// tells us nothing about the pair's content, so treat it like the
+					// "still scanning" branch below — re-arm under the SAME
+					// ceiling/TTL bound rather than dropping the coverage outright.
+					// `probeFailed` stays an honest per-turn failure count; it is
+					// informational (like `stale`/`missing`), not a terminal bucket,
+					// since the pair itself still resolves through rearmed/
+					// ceilingExhausted/expired below.
 					lateAuxProbeFailed += pairs.length;
+					for (const pair of pairs) {
+						if (
+							!isPendingAuxiliaryPastRearmTtl(pair) &&
+							(pair.rearmCount ?? 0) < MAX_LATE_AUX_REARMS
+						) {
+							rearmPendingAuxiliaryCoverage(pair);
+							lateAuxRearmed += 1;
+						} else if (isPendingAuxiliaryPastRearmTtl(pair)) {
+							lateAuxExpired += 1;
+						} else {
+							lateAuxCeilingExhausted += 1;
+						}
+					}
 					continue;
 				}
 				const displayLateAuxPath = toRunnerDisplayPath(cwd, lateAuxPath);
@@ -2496,7 +2521,7 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 			durationMs: Date.now() - lateAuxStart,
 			metadata: {
 				pending: drainedPairs.length,
-				pairCreated: drainedPairs.length,
+				pairCreated: drainedPairs.length + lateAuxCapEvicted,
 				pendingAfter: pendingAuxiliaryCoverageSize(),
 				delivered: lateAuxDelivered,
 				stale: lateAuxStale,
@@ -2508,6 +2533,7 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 				expired: lateAuxExpired,
 				ceilingExhausted: lateAuxCeilingExhausted,
 				answered: lateAuxAnswered,
+				capEvicted: lateAuxCapEvicted,
 				stuckPairs: lateAuxStuckPairs,
 			},
 		});

--- a/tests/clients/lsp/late-auxiliary-findings.test.ts
+++ b/tests/clients/lsp/late-auxiliary-findings.test.ts
@@ -40,6 +40,7 @@ import {
 	drainPendingAuxiliaryCoverage,
 	markPendingAuxiliaryCoverage,
 	MAX_LATE_AUX_REARMS,
+	pendingAuxiliaryCoverageSizeForTests,
 	readLateAuxRearmTtlMs,
 	resetPendingAuxiliaryCoverage,
 } from "../../../clients/lsp/pending-aux-coverage.js";
@@ -299,6 +300,145 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 		}
 	});
 
+	it("retires a stale-looping pair at the re-arm ceiling with a distinct outcome (#2167)", async () => {
+		// The no-publication ceiling above bounds the "still scanning" branch.
+		// A pair that DOES get answered every turn, but whose findings are
+		// always stale (the cited file keeps looking edited-after-the-scan),
+		// re-arms through the SEPARATE clause at the stale-findings site. That
+		// clause carries its own `(pair.rearmCount ?? 0) < MAX_LATE_AUX_REARMS`
+		// check; deleting it would let this loop re-arm forever instead of
+		// ever reaching `ceilingExhausted`.
+		const env = setupTestEnvironment("pi-lens-late-aux-stale-ceiling-") as any;
+		try {
+			process.env.PI_LENS_LATE_AUX_REARM_TTL_MS = "600000";
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-stale-ceiling" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const sessionId = "late-aux-stale-ceiling";
+			const file = path.join(env.tmpDir, "src", "stale-ceiling.ts");
+
+			// Write the file ONCE and pin its mtime far in the future so every
+			// turn's freshness gate sees it as edited-after-the-scan (stale),
+			// independent of how many times the pair's baseline gets refreshed
+			// by the stale-path re-arm (which stamps a fresh `markedAtMs`).
+			fs.mkdirSync(path.dirname(file), { recursive: true });
+			fs.writeFileSync(file, "export const value = 1;\n");
+			const future = new Date(Date.now() + 600_000);
+			fs.utimesSync(file, future, future);
+			cacheManager.addModifiedRange(
+				file,
+				{ start: 1, end: 1 },
+				false,
+				env.tmpDir,
+				sessionId,
+			);
+
+			markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 1000);
+			const farPublishedAt = Date.now() + 500_000;
+			readCachedDiagnosticsForServers.mockImplementation(
+				async () =>
+					new Map([
+						[
+							"opengrep",
+							{
+								diags: [diag(0, "stale finding body")],
+								publishedAt: farPublishedAt,
+							},
+						],
+					]),
+			);
+
+			for (let turn = 0; turn <= MAX_LATE_AUX_REARMS; turn += 1) {
+				// Keep this turn's modified-file worklist non-empty WITHOUT
+				// touching the pinned future mtime the freshness gate reads.
+				cacheManager.addModifiedRange(
+					file,
+					{ start: 1, end: 1 },
+					false,
+					env.tmpDir,
+					sessionId,
+				);
+				await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+			}
+
+			expect(drainPendingAuxiliaryCoverage()).toHaveLength(0);
+			const content = turnEndContent(cacheManager, env.tmpDir);
+			expect(content).not.toContain("stale finding body");
+
+			const records = logLatency.mock.calls
+				.map((call) => call[0])
+				.filter((entry: any) => entry?.phase === "late_auxiliary_findings");
+			const rearmedTotal = records.reduce(
+				(sum: number, r: any) => sum + (r.metadata.rearmed ?? 0),
+				0,
+			);
+			expect(rearmedTotal).toBe(MAX_LATE_AUX_REARMS);
+			// The ceiling turn retires the pair as `ceilingExhausted` — a
+			// DISTINCT outcome from `expired` (TTL) or `answered` (delivered).
+			expect(records.at(-1)?.metadata).toMatchObject({
+				pairCreated: 1,
+				ceilingExhausted: 1,
+				expired: 0,
+				pendingAfter: 0,
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("bounds a transient probe throw to a re-arm instead of dropping coverage (#2167 R2-2)", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-probe-throw-") as any;
+		try {
+			process.env.PI_LENS_LATE_AUX_REARM_TTL_MS = "600000";
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-probe-throw" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const sessionId = "late-aux-probe-throw";
+			const file = path.join(env.tmpDir, "src", "probe-throw.ts");
+			registerEdit(env, sessionId, cacheManager, file);
+			markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 1000);
+			readCachedDiagnosticsForServers.mockRejectedValue(
+				new Error("transient cache read failure"),
+			);
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+
+			// One transient throw counts the failure AND keeps the pair
+			// pending — the coverage must not vanish uncounted.
+			expect(pendingAuxiliaryCoverageSizeForTests()).toBe(1);
+			expect(lateAuxRecord()?.metadata).toMatchObject({
+				probeFailed: 1,
+				rearmed: 1,
+				pendingAfter: 1,
+			});
+
+			// The re-arm is still bounded: repeated throws eventually retire
+			// the pair instead of looping forever.
+			for (let turn = 0; turn < MAX_LATE_AUX_REARMS; turn += 1) {
+				cacheManager.addModifiedRange(
+					file,
+					{ start: 1, end: 1 },
+					false,
+					env.tmpDir,
+					sessionId,
+				);
+				await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+			}
+			expect(pendingAuxiliaryCoverageSizeForTests()).toBe(0);
+			const records = logLatency.mock.calls
+				.map((call) => call[0])
+				.filter((entry: any) => entry?.phase === "late_auxiliary_findings");
+			expect(records.at(-1)?.metadata).toMatchObject({
+				ceilingExhausted: 1,
+				pendingAfter: 0,
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("reconciles pair units across clean, stale, absent, and eviction paths", async () => {
 		const env = setupTestEnvironment("pi-lens-late-aux-pair-reconcile-") as any;
 		try {
@@ -357,8 +497,16 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
 
 			const metadata = lateAuxRecord()?.metadata;
+			// 52 pairs were marked above (evicted.ts, clean, stale, absent,
+			// expired, clean-0..46) against a 50-pair cap: "evicted.ts" and
+			// "clean" are the two OLDEST pairs, so both are cap-evicted before
+			// this drain ever sees them (#2168). `capEvicted` folds them back
+			// into the reconciliation sum instead of letting them vanish
+			// uncounted — `pairCreated` (52) now reflects every pair actually
+			// marked, not just what survived to be drained (50).
 			expect(metadata).toMatchObject({
-				pairCreated: 50,
+				pairCreated: 52,
+				capEvicted: 2,
 				cleanConfirmed: 47,
 				clientGone: 1,
 				expired: 1,
@@ -369,7 +517,8 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 				metadata.cleanConfirmed +
 					metadata.clientGone +
 					metadata.expired +
-					metadata.pendingAfter,
+					metadata.pendingAfter +
+					metadata.capEvicted,
 			).toBe(metadata.pairCreated);
 			expect(metadata.stale).toBe(1);
 		} finally {

--- a/tests/clients/lsp/pending-aux-coverage.test.ts
+++ b/tests/clients/lsp/pending-aux-coverage.test.ts
@@ -14,6 +14,7 @@ import {
 	DEFAULT_LATE_AUX_REARM_TTL_MS,
 	MAX_PENDING_AUX_ENTRIES,
 	clearPendingAuxiliaryCoverage,
+	drainPendingAuxCapEvictedCount,
 	drainPendingAuxiliaryCoverage,
 	isPendingAuxiliaryPastRearmTtl,
 	markPendingAuxiliaryCoverage,
@@ -96,6 +97,46 @@ describe("pending auxiliary coverage store (#2001/#2002)", () => {
 				(e) => e.filePath === `/w/file${MAX_PENDING_AUX_ENTRIES + 4}.ts`,
 			),
 		).toBe(true);
+	});
+
+	it("counts a cap eviction (#2168) and drains it exactly once", () => {
+		// Mark 51 pairs against the 50-pair cap: the 51st mark evicts the
+		// single oldest pair, which retires with no other telemetry — the
+		// dedicated counter is the only record of it.
+		for (let i = 0; i < MAX_PENDING_AUX_ENTRIES + 1; i++) {
+			markPendingAuxiliaryCoverage(`/w/file${i}.ts`, ["opengrep"], i);
+		}
+		expect(pendingAuxiliaryCoverageSizeForTests()).toBe(
+			MAX_PENDING_AUX_ENTRIES,
+		);
+		expect(drainPendingAuxCapEvictedCount()).toBe(1);
+		// Draining resets the count so a later drain never double-counts it.
+		expect(drainPendingAuxCapEvictedCount()).toBe(0);
+	});
+
+	it("counts one eviction per pair beyond the cap in a single mark call", () => {
+		for (let i = 0; i < MAX_PENDING_AUX_ENTRIES; i++) {
+			markPendingAuxiliaryCoverage(`/w/file${i}.ts`, ["opengrep"], i);
+		}
+		// One call marking three NEW server ids for one file pushes the store
+		// three pairs over the cap in one shot.
+		markPendingAuxiliaryCoverage(
+			"/w/overflow.ts",
+			["opengrep", "typos", "biome"],
+			10_000,
+		);
+		expect(pendingAuxiliaryCoverageSizeForTests()).toBe(
+			MAX_PENDING_AUX_ENTRIES,
+		);
+		expect(drainPendingAuxCapEvictedCount()).toBe(3);
+	});
+
+	it("resetPendingAuxiliaryCoverage also clears the cap-eviction count", () => {
+		for (let i = 0; i < MAX_PENDING_AUX_ENTRIES + 1; i++) {
+			markPendingAuxiliaryCoverage(`/w/file${i}.ts`, ["opengrep"], i);
+		}
+		resetPendingAuxiliaryCoverage();
+		expect(drainPendingAuxCapEvictedCount()).toBe(0);
 	});
 
 	it("re-arming a pair refreshes eviction recency without moving the baseline", () => {


### PR DESCRIPTION
## What

Two P3 residuals from PR #2162's round-2 verification, both on the late-auxiliary
turn-end path.

**#2167** — `clients/runtime-turn.ts`:
1. The stale-findings re-arm ceiling clause (`~2461-2464`) had no test. Deleting
   `(pair.rearmCount ?? 0) < MAX_LATE_AUX_REARMS` from that branch left the whole
   suite green, so a pair looping on stale findings could re-arm forever. The
   clause itself was already correct; only the coverage was missing.
2. A transient `readCachedDiagnosticsForServers` rejection dropped its pairs
   outright (`probeFailed` counted, coverage lost). Changed to re-arm each pair
   through the same ceiling/TTL bound every other branch uses, so one transient
   throw no longer costs the pair its place in the queue.

**#2168** — `clients/lsp/pending-aux-coverage.ts`: marking a pair past the
50-pair cap evicted the oldest pair with zero telemetry. Added a `capEvicted`
counter, drained once per turn end and folded into `pairCreated` so the
reconciliation sum accounts for it instead of the pair vanishing uncounted.

## Why

Both are "retire without a record" — the same class #2151 was filed to
eliminate. A pair that loops forever or disappears silently defeats the whole
point of the reconciliation invariant: every pair created retires through
exactly one pair-level counter, or is still pending.

## Verification

Build: `npm run build` (tsc, clean) before every test run below.

Targeted suites, all green:
- `tests/clients/lsp/late-auxiliary-findings.test.ts` — 13 tests
- `tests/clients/lsp/pending-aux-coverage.test.ts` — 14 tests
- `tests/clients/runtime-turn-dead-code.test.ts`, `runtime-turn-finding-freshness.test.ts`, `runtime-turn-secrets-disposition.test.ts`, `runtime-turn-session.test.ts` — 76 tests
- All 11 governance sweeps (`delivery-surface-ratchet`, `finding-delivery-gate`, `session-state-conformance`, `bounded-telemetry-sweep`, `bus-producer-coverage`, `deps-centralization`, `freshness-sweep`, `managed-tool-seam-coverage`, `profiling-coverage`, `module-instance-coverage`, `sweep-floor-coverage`) — 162 tests

Full suite deferred to CI.

### Test assessment per touched test file

- `tests/clients/lsp/late-auxiliary-findings.test.ts`: added
  `retires a stale-looping pair at the re-arm ceiling with a distinct outcome (#2167)`
  and `bounds a transient probe throw to a re-arm instead of dropping coverage (#2167 R2-2)`.
  Extended `reconciles pair units across clean, stale, absent, and eviction paths`
  to assert `capEvicted: 2` and `pairCreated: 52` (that test already marks 52
  pairs against the 50-pair cap — the two oldest were already being silently
  evicted; the extension makes the existing setup prove #2168 too).
- `tests/clients/lsp/pending-aux-coverage.test.ts`: added three unit tests —
  single eviction counted and drained exactly once, three evictions from one
  over-cap `markPendingAuxiliaryCoverage` call, and `resetPendingAuxiliaryCoverage`
  clearing the count.

**Red-first proof** (commit `29cdc668` made first, then source reverted via
`git checkout HEAD~1 -- clients/lsp/pending-aux-coverage.ts clients/runtime-turn.ts`
with tests held at the fixed commit):

```
FAIL tests/clients/lsp/late-auxiliary-findings.test.ts > bounds a transient probe throw to a re-arm instead of dropping coverage (#2167 R2-2)
AssertionError: expected +0 to be 1 // Object.is equality

FAIL tests/clients/lsp/late-auxiliary-findings.test.ts > reconciles pair units across clean, stale, absent, and eviction paths
- "capEvicted": 2,        (missing)
- "pairCreated": 52,      + "pairCreated": 50,

FAIL tests/clients/lsp/pending-aux-coverage.test.ts > counts a cap eviction (#2168) and drains it exactly once
TypeError: drainPendingAuxCapEvictedCount is not a function

FAIL tests/clients/lsp/pending-aux-coverage.test.ts > counts one eviction per pair beyond the cap in a single mark call
TypeError: drainPendingAuxCapEvictedCount is not a function

Test Files  2 failed (2)
     Tests  5 failed | 22 passed (27)
```

The new stale-ceiling test passes on pre-fix code too, by design: the AC1
clause itself was never broken, only untested. Its mutation proof (below) is
what pins it.

**Mutation proof**, each reverted after confirming red:
- Deleting `(pair.rearmCount ?? 0) < MAX_LATE_AUX_REARMS` from the stale-findings
  branch → `retires a stale-looping pair...` fails (`expected [...] to have a
  length of +0 but got 1` — the pair never retires).
- Reverting the probe-throw catch block to `lateAuxProbeFailed += pairs.length; continue;`
  → `bounds a transient probe throw...` fails (`expected +0 to be 1`).
- Removing `capEvictedCount += 1` from the eviction loop → both new
  `pending-aux-coverage.test.ts` eviction tests fail (`expected +0 to be 1` / `to be 3`).

### Blast radius

- `readCachedDiagnosticsForServers` catch block: only behavior change is that a
  transient probe failure now re-arms instead of drops. No new spawns, no new
  I/O — `rearmPendingAuxiliaryCoverage` is the existing in-memory re-arm path.
  Cost: identical shape to the existing "still scanning" branch, one loop over
  `pairs` (at most `MAX_PENDING_AUX_ENTRIES` = 50) per probe failure.
- `pending-aux-coverage.ts`: `capEvictedCount` is a single module-scope `number`,
  incremented inside the existing eviction `while` loop (no new loop, no new
  allocation). `drainPendingAuxCapEvictedCount()` is a new read-and-reset
  function, called once per `handleTurnEnd` invocation.
- `pairCreated` in the `late_auxiliary_findings` latency metadata changes value
  (now includes `capEvicted`) whenever an eviction happened between two turn
  ends. Any downstream consumer of that field that assumed `pairCreated ===
  drainedPairs.length` would need updating — grepped `pairCreated` and
  `late_auxiliary_findings` across `clients/`, `tools/`, `scripts/`: no other
  producer or consumer reads that field besides this one write site and the
  two test files above.

### Class sweep

**Defect shape**: "retire without a record" — a pair-level lifecycle event that
skips the reconciliation counters entirely (same class as #2151).

**Pattern sweep** (grep `\.delete\(` and eviction/retirement sites across
`clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts` for other bounded stores
that drop an entry without an accompanying counter increment): the other
bounded caches in `clients/` (`cache-manager.ts`'s various caches, the handle
tracker at `clients/observability/handle-tracker.ts`) already have their own
counters from #1141/#1123 (pin-earliest-N) and #417/#418; none showed a
silent-eviction gap. `pending-aux-coverage.ts` was the one member with a bare
`pending.delete(oldest)` and no telemetry.

**Population sweep**: the late-auxiliary pipeline has exactly one bounded
producer-side store (`pending-aux-coverage.ts`) and one consumer/reconciler
(`runtime-turn.ts`'s late-aux block) — this is the full family for #2151's
class in this subsystem. No sibling store found.

### Observability

The `late_auxiliary_findings` phase record in `latency.log` now carries
`capEvicted` alongside `rearmed`/`ceilingExhausted`/`expired`/`clientGone`/
`probeFailed`/`cleanConfirmed`/`answered`, and `pairCreated` includes cap
evictions. This closes the exact gap #2168 named: a probe that previously
counted `pairCreated=50` while actually having marked more pairs now reports
the true total, with the delta accounted for by `capEvicted`.

## Merge order

No overlap with the one other open PR touching LSP files (#2174, `fix(lsp):
share one LSP service across module evaluations`) — it only touches
`clients/lsp/index.ts` and `clients/process-singletons.ts`. No merge-order
dependency.

Closes #2167
Closes #2168
