### PR TITLE
fix(dispatch): use ordinal comparators in cache keys (closes #2155, closes #2165)

### DIFF
--- a/.changelog/fix-2155-2165-ordinal-keys.md
+++ b/.changelog/fix-2155-2165-ordinal-keys.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Identity-feeding sorts now use a code-unit comparator, not `localeCompare` (closes #2155, closes #2165)** — the availability-probe cache key in `runner-helpers.ts` sorted env entries with `localeCompare`, a locale-dependent comparator. Two processes (or one process under a changed locale) could order the same env set differently and mint different keys for identical state, causing a silent probe-dedupe miss. Fixed via a new shared `compareOrdinal` helper (`clients/string-utils.ts`), applied to every identity-feeding sort found in the class sweep: dependency-cycle and madge dedupe keys, review-graph signature/hash/cache keys, the Windows spawn cache key, the bounded-hash object-key order, the rule-cache content hash, the workspace-diagnostics scope key, the turn-end-findings signature, and the formatter-config signature. `localeCompare` sorts kept for user-facing display are left untouched.

--- a/clients/cache-observability.ts
+++ b/clients/cache-observability.ts
@@ -50,6 +50,7 @@
 import { createHash } from "node:crypto";
 import { lazyEnvNumber } from "./env-utils.js";
 import { logLatency } from "./latency-logger.js";
+import { compareOrdinal } from "./string-utils.js";
 
 interface AssistantMessageLike {
 	role?: unknown;
@@ -729,7 +730,7 @@ function boundedHashObject(
 	state: BoundedHashState,
 ): string {
 	const keys = Object.keys(value).sort((left, right) =>
-		left.localeCompare(right),
+		compareOrdinal(left, right),
 	);
 	if (keys.length > 24) state.contentTruncated = true;
 	const fields = keys

--- a/clients/cache/rule-cache.ts
+++ b/clients/cache/rule-cache.ts
@@ -12,6 +12,7 @@ import { getProjectDataDir } from "../file-utils.js";
 import { readJsonCache } from "../json-cache-read.js";
 import { resolvePackagePath } from "../package-root.js";
 import { writeFileAtomic } from "../atomic-write.js";
+import { compareOrdinal } from "../string-utils.js";
 
 // v4: cache skip_test_files + fix_action — v3 entries silently dropped them,
 // and ruleHash (rule-file mtimes) never invalidates on a code-only fix.
@@ -109,7 +110,7 @@ export class RuleCache {
 
 	private computeRuleHash(ruleFiles: string[]): string {
 		const hash = crypto.createHash("sha256");
-		for (const file of ruleFiles.sort((a, b) => a.localeCompare(b))) {
+		for (const file of ruleFiles.sort(compareOrdinal)) {
 			const resolved = path.resolve(file);
 			if (!fs.existsSync(resolved)) continue;
 			const stat = fs.statSync(resolved);

--- a/clients/dependency-checker.ts
+++ b/clients/dependency-checker.ts
@@ -1124,7 +1124,11 @@ export class DependencyChecker {
 		let output = `[Circular Deps] ${circular.length} cycle(s) found:\n`;
 
 		for (const dep of circular) {
-			const cycleKey = dep.path.sort(compareOrdinal).join("→");
+			// Copy before sorting: `dep.path` is rendered verbatim below (and by
+			// other CircularDep consumers, e.g. madge.ts's diagnostic renderer),
+			// so the dedupe key must not reorder — let alone mutate in place —
+			// the path a user reads.
+			const cycleKey = [...dep.path].sort(compareOrdinal).join("→");
 			if (seen.has(cycleKey)) continue;
 			seen.add(cycleKey);
 

--- a/clients/dependency-checker.ts
+++ b/clients/dependency-checker.ts
@@ -15,6 +15,7 @@ import * as path from "node:path";
 import { findNodeToolBinary } from "./package-manager.js";
 import { isFullyQualified } from "./path-utils.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
+import { compareOrdinal } from "./string-utils.js";
 import {
 	createAvailabilityChecker,
 	discoverManagedTool,
@@ -1123,7 +1124,7 @@ export class DependencyChecker {
 		let output = `[Circular Deps] ${circular.length} cycle(s) found:\n`;
 
 		for (const dep of circular) {
-			const cycleKey = dep.path.sort((a, b) => a.localeCompare(b)).join("→");
+			const cycleKey = dep.path.sort(compareOrdinal).join("→");
 			if (seen.has(cycleKey)) continue;
 			seen.add(cycleKey);
 

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -37,6 +37,7 @@ import {
 } from "../../../lsp/config.js";
 import { findGlobalBinary } from "../../../package-manager.js";
 import { safeSpawnAsync } from "../../../safe-spawn.js";
+import { compareOrdinal } from "../../../string-utils.js";
 import {
 	getToolCommandSpec,
 	shouldAutoInstallTool,
@@ -1080,7 +1081,7 @@ export function createAvailabilityChecker(
 			let probeJoined = false;
 			try {
 				const shared = checkerProbeFlights.run(
-					`checker:${command}|${versionArgs.join("|")}|${key}|${checkerFlightGeneration}|${windowsExt}|${cmd}|${JSON.stringify(Object.entries(env ?? {}).sort(([a], [b]) => a.localeCompare(b)))}`,
+					`checker:${command}|${versionArgs.join("|")}|${key}|${checkerFlightGeneration}|${windowsExt}|${cmd}|${JSON.stringify(Object.entries(env ?? {}).sort(([a], [b]) => compareOrdinal(a, b)))}`,
 					() =>
 						safeSpawnAsync(cmd, versionArgs, {
 							timeout: options.probeTimeout ?? 5000,

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -1632,16 +1632,14 @@ const FORMATTER_CONFIG_FILES = [
 async function formatterConfigSignature(cwd: string): Promise<string> {
 	const paths = await findUp(FORMATTER_CONFIG_FILES, cwd);
 	const parts = await Promise.all(
-		paths
-			.sort(compareOrdinal)
-			.map(async (filePath) => {
-				try {
-					const stat = await fs.stat(filePath);
-					return `${filePath}:${stat.mtimeMs}:${stat.size}`;
-				} catch {
-					return `${filePath}:missing`;
-				}
-			}),
+		paths.sort(compareOrdinal).map(async (filePath) => {
+			try {
+				const stat = await fs.stat(filePath);
+				return `${filePath}:${stat.mtimeMs}:${stat.size}`;
+			} catch {
+				return `${filePath}:missing`;
+			}
+		}),
 	);
 	return parts.join("|");
 }

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -21,6 +21,7 @@ import {
 	hasDetectableIndentation,
 } from "./dispatch/indent-detect.js";
 import { logLatency } from "./latency-logger.js";
+import { compareOrdinal } from "./string-utils.js";
 import {
 	type AvailabilityLatch,
 	classifyProbeFailure,
@@ -1632,7 +1633,7 @@ async function formatterConfigSignature(cwd: string): Promise<string> {
 	const paths = await findUp(FORMATTER_CONFIG_FILES, cwd);
 	const parts = await Promise.all(
 		paths
-			.sort((a, b) => a.localeCompare(b))
+			.sort(compareOrdinal)
 			.map(async (filePath) => {
 				try {
 					const stat = await fs.stat(filePath);

--- a/clients/lsp/workspace-diagnostics-cache.ts
+++ b/clients/lsp/workspace-diagnostics-cache.ts
@@ -8,6 +8,7 @@ import { normalizeMapKey } from "../path-utils.js";
 import { loadReverseDependencyIndexFromSnapshot } from "../reverse-deps.js";
 import { freshnessFromMtime } from "../freshness.js";
 import { logLatency } from "../latency-logger.js";
+import { compareOrdinal } from "../string-utils.js";
 import { workspaceDiagnosticsCacheSessionStart } from "./workspace-diagnostics-session.js";
 import type { LSPDiagnostic } from "./client.js";
 import {
@@ -478,7 +479,7 @@ export function buildScopeKey(
 	excludeServerIds?: readonly string[],
 ): string {
 	const excluded = excludeServerIds
-		? [...excludeServerIds].sort((a, b) => a.localeCompare(b))
+		? [...excludeServerIds].sort(compareOrdinal)
 		: [];
 	return `${clientScope}|${excluded.join(",")}`;
 }

--- a/clients/project-diagnostics/runner-adapters/madge.ts
+++ b/clients/project-diagnostics/runner-adapters/madge.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import type { CircularDep } from "../../dependency-checker.js";
+import { compareOrdinal } from "../../string-utils.js";
 import type { ProjectDiagnostic } from "../types.js";
 
 function resolveCyclePath(cwd: string, file: string): string {
@@ -48,7 +49,7 @@ export function circularDepsToProjectDiagnostics(
 	for (const dep of circular) {
 		const key = cycleMembers(dep)
 			.map((f) => resolveCyclePath(cwd, f))
-			.sort((a, b) => a.localeCompare(b))
+			.sort(compareOrdinal)
 			.join("|");
 		if (seen.has(key)) continue;
 		seen.add(key);

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -36,6 +36,7 @@ import {
 } from "../path-utils.js";
 import { collectProjectSourceFilesWithBudgetAsync } from "../project-scan-policy.js";
 import { getReviewGraphMaxFilesDerived } from "../project-scale.js";
+import { compareOrdinal } from "../string-utils.js";
 import { BoundedLruCache } from "../bounded-cache.js";
 import {
 	jsTsCandidatePaths,
@@ -956,7 +957,7 @@ async function sourceSignatureMapAsync(
 
 function sourceSignatureFromMap(signatures: Map<string, string>): string {
 	return [...signatures.entries()]
-		.sort(([a], [b]) => a.localeCompare(b))
+		.sort(([a], [b]) => compareOrdinal(a, b))
 		.map(([file, signature]) => `${file}:${signature}`)
 		.join("|");
 }
@@ -2650,7 +2651,7 @@ function reviewGraphCheckpointPath(cwd: string): string {
 function hashIgnoredIds(ignoredIds: ReadonlySet<string> | undefined): string {
 	if (ignoredIds === undefined) return "unavailable";
 	const joined = [...ignoredIds]
-		.sort((a, b) => a.localeCompare(b))
+		.sort((a, b) => compareOrdinal(a, b))
 		.join("\u0000");
 	return createHash("sha256").update(joined).digest("hex");
 }
@@ -4433,7 +4434,7 @@ function importTargetsForFile(graph: ReviewGraph, filePath: string): string[] {
 		const target = graph.nodes.get(edge.to)?.filePath;
 		if (target) targets.add(normalizeMapKey(target));
 	}
-	return [...targets].sort((a, b) => a.localeCompare(b));
+	return [...targets].sort((a, b) => compareOrdinal(a, b));
 }
 
 async function updateGraphFiles(
@@ -5486,7 +5487,7 @@ async function _doBuildGraph(
  * rather than by coincidence.
  */
 function buildCacheKey(cwd: string, changedFiles: string[]): string {
-	return `${buildCacheWorkspaceKey(cwd)}|${[...changedFiles].sort((a, b) => a.localeCompare(b)).join(",")}`;
+	return `${buildCacheWorkspaceKey(cwd)}|${[...changedFiles].sort((a, b) => compareOrdinal(a, b)).join(",")}`;
 }
 
 /**

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -23,6 +23,7 @@ import {
 import { cascadeSettleWaitMs } from "./cascade-budget.js";
 import { logCascade } from "./cascade-logger.js";
 import { normalizeMapKey } from "./path-utils.js";
+import { compareOrdinal } from "./string-utils.js";
 import type {
 	DependencyChecker,
 	MadgeBatchStats,
@@ -2530,7 +2531,7 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 		const content = capTurnEndMessage(findingParts.join("\n\n"));
 		const signature = `${files
 			.slice()
-			.sort((a, b) => a.localeCompare(b))
+			.sort((a, b) => compareOrdinal(a, b))
 			.join("|")}::${content}`;
 		const last = cacheManager.readCache<{
 			signature: string;

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -27,6 +27,7 @@ import { recordDegradation } from "./degradation-ledger.js";
 import { logExtension } from "./extension-log.js";
 import { isFullyQualifiedWin32 } from "./path-utils.js";
 import { startSpawnUsageSampler } from "./resource-sampler.js";
+import { compareOrdinal } from "./string-utils.js";
 
 export interface SpawnResourceUsage {
 	sampleCount: number;
@@ -948,7 +949,7 @@ export function resolveWindowsCommandForEnvironment(
 				? ([[key.toLowerCase(), value] as const] as const)
 				: [],
 		)
-		.sort(([left], [right]) => left.localeCompare(right));
+		.sort(([left], [right]) => compareOrdinal(left, right));
 	// Keep presence separate from value: absent PATHEXT means the Windows
 	// default extension list, while PATHEXT="" means no implicit extensions.
 	// The per-drive snapshot is equally important: it is provenance for

--- a/clients/string-utils.ts
+++ b/clients/string-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Ordinal (code-unit) string comparator for identity-feeding sorts — cache
+ * keys, dedupe keys, hashes, and signatures. Refs #2155, #2165.
+ *
+ * `Array.prototype.sort` with no comparator, and `localeCompare`, both order
+ * strings by locale-dependent collation. That is fine for a list a human
+ * reads. It is a bug (SonarCloud S2871) when the sorted result feeds an
+ * identity: two processes — or one process whose locale changes — can order
+ * the same input differently and mint different keys for equivalent state,
+ * producing a silent cache or dedupe miss.
+ *
+ * Use this comparator whenever a sort's output becomes a key, a hash input,
+ * or a signature compared for equality later. Keep `localeCompare` for
+ * sorting that only affects what a person reads.
+ */
+export function compareOrdinal(a: string, b: string): number {
+	return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/clients/string-utils.ts
+++ b/clients/string-utils.ts
@@ -2,12 +2,14 @@
  * Ordinal (code-unit) string comparator for identity-feeding sorts — cache
  * keys, dedupe keys, hashes, and signatures. Refs #2155, #2165.
  *
- * `Array.prototype.sort` with no comparator, and `localeCompare`, both order
- * strings by locale-dependent collation. That is fine for a list a human
- * reads. It is a bug (SonarCloud S2871) when the sorted result feeds an
- * identity: two processes — or one process whose locale changes — can order
- * the same input differently and mint different keys for equivalent state,
- * producing a silent cache or dedupe miss.
+ * `localeCompare` orders strings by locale-dependent collation (the DEFAULT
+ * `Array.prototype.sort`, with no comparator, does not — it compares UTF-16
+ * code units, which is already ordinal). Locale-dependent order is fine for
+ * a list a human reads. It is a bug (SonarCloud S2871) when the sorted
+ * result feeds an identity: two processes — or one process whose locale
+ * changes — can order the same input differently under `localeCompare` and
+ * mint different keys for equivalent state, producing a silent cache or
+ * dedupe miss.
  *
  * Use this comparator whenever a sort's output becomes a key, a hash input,
  * or a signature compared for equality later. Keep `localeCompare` for

--- a/tests/clients/dependency-checker-cycle-key-ordinal.test.ts
+++ b/tests/clients/dependency-checker-cycle-key-ordinal.test.ts
@@ -24,10 +24,7 @@ describe("DependencyChecker.formatScanResult cycle-key comparator (#2155, #2165 
 			// exactly what two OS locales (or a locale change mid-session) can
 			// do to real `localeCompare`. A comparator this unstable must not
 			// affect the dedupe key at all.
-			String.prototype.localeCompare = function (
-				this: string,
-				that: string,
-			) {
+			String.prototype.localeCompare = function (this: string, that: string) {
 				call++;
 				if (this === "a.ts" && that === "b.ts") return call <= 1 ? -1 : 1;
 				if (this === "b.ts" && that === "a.ts") return call <= 1 ? 1 : -1;

--- a/tests/clients/dependency-checker-cycle-key-ordinal.test.ts
+++ b/tests/clients/dependency-checker-cycle-key-ordinal.test.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	DependencyChecker,
@@ -41,5 +42,27 @@ describe("DependencyChecker.formatScanResult cycle-key comparator (#2155, #2165 
 		} finally {
 			String.prototype.localeCompare = realLocaleCompare;
 		}
+	});
+
+	it("renders the original discovery path order and does not mutate the shared CircularDep (review F2)", () => {
+		const checker = new DependencyChecker();
+		// Discovery order is the actual a→b→c→a traversal — meaningful, and
+		// distinct from both the localeCompare and the code-unit sort order of
+		// these three names. The dedupe key's sort must never leak into what a
+		// user reads, and must not mutate `dep.path` in place: other CircularDep
+		// consumers (e.g. madge.ts's diagnostic renderer) read the same object.
+		const dep: CircularDep = {
+			file: "middle.ts",
+			path: ["middle.ts", "alpha.ts", "Zeta.ts"],
+		};
+		const originalPath = [...dep.path];
+
+		const output = checker.formatScanResult([dep]);
+
+		const expectedNames = originalPath
+			.map((p) => path.relative(process.cwd(), p))
+			.join(" → ");
+		expect(output).toContain(`  • ${expectedNames}\n`);
+		expect(dep.path).toEqual(originalPath);
 	});
 });

--- a/tests/clients/dependency-checker-cycle-key-ordinal.test.ts
+++ b/tests/clients/dependency-checker-cycle-key-ordinal.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+	DependencyChecker,
+	type CircularDep,
+} from "../../clients/dependency-checker.js";
+
+describe("DependencyChecker.formatScanResult cycle-key comparator (#2155, #2165 class)", () => {
+	it("dedupes the same cycle reported from two anchors by a code-unit key, immune to a comparator that answers inconsistently across calls", () => {
+		const checker = new DependencyChecker();
+		// The same two-file cycle, reported once per anchor file — the exact
+		// "same member set, different anchor" shape `formatScanResult`'s dedupe
+		// exists for.
+		const circular: CircularDep[] = [
+			{ file: "a.ts", path: ["a.ts", "b.ts"] },
+			{ file: "b.ts", path: ["b.ts", "a.ts"] },
+		];
+
+		const realLocaleCompare = String.prototype.localeCompare;
+		let call = 0;
+		try {
+			// Simulate a locale-dependent comparator that answers the SAME
+			// question differently across the two cycles' key computations —
+			// exactly what two OS locales (or a locale change mid-session) can
+			// do to real `localeCompare`. A comparator this unstable must not
+			// affect the dedupe key at all.
+			String.prototype.localeCompare = function (
+				this: string,
+				that: string,
+			) {
+				call++;
+				if (this === "a.ts" && that === "b.ts") return call <= 1 ? -1 : 1;
+				if (this === "b.ts" && that === "a.ts") return call <= 1 ? 1 : -1;
+				return realLocaleCompare.call(this, that);
+			};
+
+			const output = checker.formatScanResult(circular);
+			const cycleLines = output
+				.split("\n")
+				.filter((line) => line.includes("→"));
+			expect(cycleLines).toHaveLength(1);
+		} finally {
+			String.prototype.localeCompare = realLocaleCompare;
+		}
+	});
+});

--- a/tests/clients/dispatch/runners/runner-helpers.test.ts
+++ b/tests/clients/dispatch/runners/runner-helpers.test.ts
@@ -330,20 +330,23 @@ describe("runner-helpers availability checker", () => {
 		// carry identical entries, so a locale-independent key must join them
 		// into one physical probe regardless of what `localeCompare` says.
 		const env = { AAA: "1", BBB: "2" };
-		const checkerA = createAvailabilityChecker("dupe-locale-tool", "", [
-			"--version",
-		], { environment: async () => ({ ...env }) });
-		const checkerB = createAvailabilityChecker("dupe-locale-tool", "", [
-			"--version",
-		], { environment: async () => ({ ...env }) });
+		const checkerA = createAvailabilityChecker(
+			"dupe-locale-tool",
+			"",
+			["--version"],
+			{ environment: async () => ({ ...env }) },
+		);
+		const checkerB = createAvailabilityChecker(
+			"dupe-locale-tool",
+			"",
+			["--version"],
+			{ environment: async () => ({ ...env }) },
+		);
 
 		const realLocaleCompare = String.prototype.localeCompare;
 		try {
 			// Simulate "locale 1": AAA sorts before BBB.
-			String.prototype.localeCompare = function (
-				this: string,
-				that: string,
-			) {
+			String.prototype.localeCompare = function (this: string, that: string) {
 				if (this === "AAA" && that === "BBB") return -1;
 				if (this === "BBB" && that === "AAA") return 1;
 				return realLocaleCompare.call(this, that);
@@ -356,10 +359,7 @@ describe("runner-helpers availability checker", () => {
 			// Simulate "locale 2": the same two keys sort in the OPPOSITE order.
 			// A real second process under a different OS locale can see exactly
 			// this. `env` itself is untouched — only the comparator "moved".
-			String.prototype.localeCompare = function (
-				this: string,
-				that: string,
-			) {
+			String.prototype.localeCompare = function (this: string, that: string) {
 				if (this === "AAA" && that === "BBB") return 1;
 				if (this === "BBB" && that === "AAA") return -1;
 				return realLocaleCompare.call(this, that);

--- a/tests/clients/dispatch/runners/runner-helpers.test.ts
+++ b/tests/clients/dispatch/runners/runner-helpers.test.ts
@@ -314,6 +314,71 @@ describe("runner-helpers availability checker", () => {
 		}
 	});
 
+	it("keys the checker flight by code-unit order, not locale (#2155, #2165)", async () => {
+		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
+		let releaseProbe!: (value: unknown) => void;
+		const pendingProbe = new Promise((resolve) => {
+			releaseProbe = resolve;
+		});
+		vi.mocked(safeSpawnMod.safeSpawnAsync).mockReturnValue(
+			pendingProbe as never,
+		);
+
+		// Two independent checker instances probing the SAME command in the
+		// SAME cwd with the SAME env content share one flight-registry key
+		// space (module-scoped `checkerProbeFlights`). Their env objects here
+		// carry identical entries, so a locale-independent key must join them
+		// into one physical probe regardless of what `localeCompare` says.
+		const env = { AAA: "1", BBB: "2" };
+		const checkerA = createAvailabilityChecker("dupe-locale-tool", "", [
+			"--version",
+		], { environment: async () => ({ ...env }) });
+		const checkerB = createAvailabilityChecker("dupe-locale-tool", "", [
+			"--version",
+		], { environment: async () => ({ ...env }) });
+
+		const realLocaleCompare = String.prototype.localeCompare;
+		try {
+			// Simulate "locale 1": AAA sorts before BBB.
+			String.prototype.localeCompare = function (
+				this: string,
+				that: string,
+			) {
+				if (this === "AAA" && that === "BBB") return -1;
+				if (this === "BBB" && that === "AAA") return 1;
+				return realLocaleCompare.call(this, that);
+			};
+			const first = checkerA.isAvailableAsync(process.cwd());
+			await vi.waitFor(() =>
+				expect(safeSpawnMod.safeSpawnAsync).toHaveBeenCalledTimes(1),
+			);
+
+			// Simulate "locale 2": the same two keys sort in the OPPOSITE order.
+			// A real second process under a different OS locale can see exactly
+			// this. `env` itself is untouched — only the comparator "moved".
+			String.prototype.localeCompare = function (
+				this: string,
+				that: string,
+			) {
+				if (this === "AAA" && that === "BBB") return 1;
+				if (this === "BBB" && that === "AAA") return -1;
+				return realLocaleCompare.call(this, that);
+			};
+			const second = checkerB.isAvailableAsync(process.cwd());
+			// Let the second call's async prefix (findCommand's fs walk) settle
+			// before asserting it did or didn't start a second physical probe.
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			expect(safeSpawnMod.safeSpawnAsync).toHaveBeenCalledTimes(1);
+
+			releaseProbe({ stdout: "1.0.0", stderr: "", status: 0 });
+			expect(await first).toBe(true);
+			expect(await second).toBe(true);
+		} finally {
+			String.prototype.localeCompare = realLocaleCompare;
+		}
+	});
+
 	it("does not let an old in-flight probe delete a newer generation", async () => {
 		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
 		let releaseOld!: (value: unknown) => void;

--- a/tests/clients/string-utils.test.ts
+++ b/tests/clients/string-utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { compareOrdinal } from "../../clients/string-utils.js";
+
+describe("compareOrdinal", () => {
+	it("orders by code unit, not locale collation", () => {
+		// Code-unit order: "B" (0x42) sorts before "a" (0x61). A locale-aware
+		// comparator commonly reverses this (case-insensitive alphabetic
+		// collation puts "a" first), which is exactly the divergence this
+		// comparator exists to avoid for identity-feeding sorts (#2155, #2165).
+		expect(["a", "B"].sort(compareOrdinal)).toEqual(["B", "a"]);
+	});
+
+	it("is a stable, symmetric total order", () => {
+		expect(compareOrdinal("a", "a")).toBe(0);
+		expect(compareOrdinal("a", "b")).toBeLessThan(0);
+		expect(compareOrdinal("b", "a")).toBeGreaterThan(0);
+	});
+
+	it("produces the same key regardless of input insertion order", () => {
+		const left = ["zeta", "Alpha", "_beta"].sort(compareOrdinal).join(",");
+		const right = ["_beta", "zeta", "Alpha"].sort(compareOrdinal).join(",");
+		expect(left).toBe(right);
+	});
+});


### PR DESCRIPTION
## Summary

The availability-probe checker's cache key sorted env entries with
`localeCompare`, a locale-dependent comparator (SonarCloud S2871). Two
processes, or one process whose OS locale changes, can order the same
env set differently and mint different keys for identical state — a
silent probe-dedupe miss, not a correctness break.

Adds `compareOrdinal` (`clients/string-utils.ts`), a code-unit
comparator, and uses it everywhere a sort's output feeds a cache key,
dedupe key, hash, or signature compared for equality later.

## Why

Sorting with `localeCompare` (or bare `.sort()`) is fine when a human
reads the result. It is a bug when the sorted string becomes an
identity: collation depends on the runtime's default locale, so the
same content can produce different key strings on different machines,
or on the same machine after a locale change.

## Class sweep

**Pattern sweep**: grepped `localeCompare` across `clients/`, `tools/`,
`mcp/`, `scripts/`, and `index.ts` (not `clients/`-only). 90+ hits.

**Population sweep** — every hit, classified by whether its sorted
output feeds an identity (cache key / dedupe key / hash / signature
compared for equality) versus only display order:

| Site | Verdict |
|---|---|
| `clients/dispatch/runners/utils/runner-helpers.ts:1083` — checker flight key | **Fixed** (#2155, #2165) |
| `clients/dependency-checker.ts:1126` — `cycleKey` dedupe (`seen.has`) | **Fixed** |
| `clients/project-diagnostics/runner-adapters/madge.ts:51` — cycle dedupe key | **Fixed** |
| `clients/review-graph/builder.ts:958` — `sourceSignatureFromMap`, compared for cache-fastpath equality | **Fixed** |
| `clients/review-graph/builder.ts:2654` — `hashIgnoredIds`, sha256 input | **Fixed** |
| `clients/review-graph/builder.ts:4437` — `importTargetsForFile`, positionally diffed against a prior sorted array in `clients/dispatch/integration.ts:1078-1080` | **Fixed** |
| `clients/review-graph/builder.ts:5490` — `buildCacheKey` | **Fixed** |
| `clients/safe-spawn.ts:951` — `perDriveCwds`, folded into the Windows command `cacheKey` | **Fixed** |
| `clients/cache-observability.ts:732` — `boundedHashObject` key order (feeds a content hash) | **Fixed** |
| `clients/cache/rule-cache.ts:112` — `computeRuleHash` sha256 input | **Fixed** |
| `clients/lsp/workspace-diagnostics-cache.ts:481` — `buildScopeKey` | **Fixed** |
| `clients/runtime-turn.ts:2533` — turn-end-findings `signature`, compared against `cacheManager.readCache` | **Fixed** |
| `clients/formatters.ts:1635` — `formatterConfigSignature`, compared as `cached.signature !== configSignature` | **Fixed** |
| `clients/dispatch/dispatcher.ts:567`, `clients/lsp/index.ts:8109` | Already correct — inline `Number(a>b)-Number(a<b)` ordinal comparator, a dedupe-key precedent this PR generalizes into `compareOrdinal` |
| `tools/lens-diagnostics.ts:2059` | Already correct — comment states `localeCompare` is deliberately avoided |
| `clients/fact-scheduler.ts`, `clients/installer/managed-tool-refresh.ts` | Left — execution/refresh *order*, not an identity key; a locale flip changes which item runs first, never what a key equals |
| `clients/dispatch/integration.ts` (slop-score `ruleCounts`), `clients/module-report.ts`, `clients/project-report.ts`, `clients/diagnostic-tracker.ts`, `clients/generation-guard.ts`, `clients/lens-map.ts`, `clients/call-graph.ts`, `clients/project-snapshot.ts`, `scripts/*.mjs` | Left — user-facing report/display sorting, never compared for equality |
| `clients/reverse-deps.ts` (`normalizeIndex`, `sortedUnique`) | Left, but not for display: the sorted order feeds a persisted reverse-deps snapshot's `imports`/`importedBy` maps. Every consumer reads those as maps (key lookup), never compares the array order or a serialized form for equality, so a locale-driven reorder changes nothing observable — order-insensitive by construction, not display-only. |

Every fixed site now imports the same `compareOrdinal` from
`clients/string-utils.ts` — single source of truth, no per-file
hand-rolled comparator.

## Tests

### Test assessment

Red-first, proven on pre-fix source by reverting only the two files
under proof (`git checkout 727ddd27 -- <file>`, never `git checkout --`
against uncommitted work) after committing tests + fix:

```
FAIL tests/clients/dispatch/runners/runner-helpers.test.ts > ... keys the checker flight by code-unit order, not locale (#2155, #2165)
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times

FAIL tests/clients/dependency-checker-cycle-key-ordinal.test.ts > ... dedupes the same cycle reported from two anchors...
AssertionError: expected [ Array(2) ] to have a length of 1 but got 2

FAIL tests/clients/dependency-checker-cycle-key-ordinal.test.ts > ... renders the original discovery path order and does not mutate the shared CircularDep (review F2)
AssertionError: expected '[Circular Deps] 1 cycle(s) found:\n  …' to contain '  • middle.ts → alpha.ts → Zeta.ts\n'
  Received: '  • Zeta.ts → alpha.ts → middle.ts\n'
```

Both tests mock `String.prototype.localeCompare` to answer the same
question differently across two calls in the SAME process — simulating
two OS locales (or a mid-session locale change) without depending on
real ICU collation data being present in CI. Post-fix, both are green
(the mock has no effect, since `compareOrdinal` never calls
`localeCompare`). Added `tests/clients/string-utils.test.ts` as a
direct unit test of the new comparator.

Targeted suites run green post-fix: `runner-helpers.test.ts`,
`dependency-checker-cycle-key-ordinal.test.ts`, `string-utils.test.ts`,
every `dependency-checker-*.test.ts`, `safe-spawn-windows-*.test.ts`,
`cache-observability.test.ts`, `cache/rule-cache.test.ts`,
`review-graph/rebuild-cost.test.ts`,
`review-graph/checkpoint-resume.test.ts`, `runtime-turn-*.test.ts`,
`lsp/workspace-diagnostics-cache*.test.ts`,
`lsp/workspace-diagnostics-clean-reanswer.test.ts`,
`project-diagnostics.test.ts`, `formatters*.test.ts`.

Governance sweeps run green:
`delivery-surface-ratchet`, `finding-delivery-gate`,
`session-state-conformance`, `bounded-telemetry-sweep`,
`bus-producer-coverage`, `deps-centralization`, `freshness-sweep`,
`managed-tool-seam-coverage`, `profiling-coverage`,
`module-instance-coverage`, `sweep-floor-coverage`.

Two directory-scanning suites (`sweep-floor-coverage`,
`module-instance-coverage`) and a handful of formatter/project-diagnostics
tests timed out at the default 5000ms when run in a large concurrent
batch on this machine; each passes individually (and with a raised
`--testTimeout`), confirming machine-load contention, not a
regression — consistent with the repo's documented test-contention
policy. Full suite deferred to CI, which is authoritative.

`npm run build` and `npm run lint` (tsc project + type-check) both
clean.

## Blast radius

`compareOrdinal` is a new pure function; every call site is a drop-in
replacement of one comparator with another inside an existing `.sort()`
call — no signature or call-shape changes anywhere. The only
behavioral change is comparator OUTPUT: sort order for these specific
identity strings now follows code-unit order instead of locale
collation. This changes on-disk cache-key strings and sha256 hash
inputs for: the review-graph checkpoint/cache-key, the rule-cache hash,
the Windows spawn command cache, and the workspace-diagnostics scope
key. Existing persisted cache entries keyed under the old
`localeCompare` order simply miss once and get rebuilt under the new
key — no corruption, no crash, matching every one of these caches'
existing fail-open-on-miss design. No new process spawns; no hot-path
cost (a code-unit comparison is cheaper than `localeCompare`, not more
expensive).

## Observability

No new log record needed: a locale-driven cache miss was never
distinguishable in the ledger from any other miss, and after this fix
there is nothing left to distinguish — the miss cause this issue named
no longer exists. The one-time rebuild on upgrade (old-keyed entries
missing) is invisible in aggregate exactly like the routine RuleCache
`CACHE_VERSION` bumps already documented in `clients/cache/rule-cache.ts`.

## Acceptance

- #2155: code-unit comparator in place; test pins key/dedupe stability
  independent of locale, red under the `localeCompare` revert. **Closes.**
- #2165: same fix, same file. **Closes.**

Refs #2137, #2131 (PR #2148 review, F9 — the original finding this class
descends from).

## Review round 1

Adversarial review returned four findings, all probe-proven. Fixed on
the same branch, head `55e1a607`:

- **F2 (substantive)** — `clients/dependency-checker.ts`'s cycle dedupe
  key sorted `dep.path` IN PLACE. `dep.path` is also rendered verbatim
  in the same function, and read by other `CircularDep` consumers
  (madge.ts's diagnostic renderer), so the key sort silently reordered
  what a user reads (probe: "alpha → Zeta" flipped to "Zeta → alpha").
  Fixed by sorting a copy: `[...dep.path].sort(compareOrdinal)`. Added
  a red-first regression pinning that the rendered path preserves
  discovery order and `dep.path` is left unmutated — proven red against
  the in-place version, green against the fix.
- **F3** — the `string-utils.ts` comment claimed the DEFAULT
  `Array.prototype.sort` is locale-dependent. It isn't: only
  `localeCompare` is; unadorned `.sort()` already compares UTF-16 code
  units. Corrected the comment.
- **F4** — the sweep table's "display-only" verdict for
  `clients/reverse-deps.ts` was right but reasoned wrong: its sorted
  output is a *persisted* reverse-deps snapshot, not a report. It's
  still "leave", because every consumer reads it as a map (key lookup),
  never compares array order or a serialized form for equality — order
  doesn't reach any identity check. Row corrected above.
- **F1 (gate)** — CI produced no run on the pre-review-round head: a
  dropped webhook event (the Lint workflow's jobs all showed
  `cancelled`; sibling branches fired normally in the same window).
  Merged `origin/master` (clean, no conflicts, no overlap with files
  this PR touches) to re-trigger both workflows and pushed. New head:
  `55e1a607`.

Closes #2155. Closes #2165.

