### PR TITLE
fix(dispatch): probe consumed gitignore freshness at matcher lookup (closes #2159)

### DIFF
--- a/.changelog/fix-2159-gitignore-freshness.md
+++ b/.changelog/fix-2159-gitignore-freshness.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Consumed `.gitignore` files refresh at matcher lookup (closes #2159)** — pi-lens detects external edits, git restores, and changes under ignored directories with a cadence-bounded freshness probe.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -597,6 +597,12 @@ or merge restoration, and writes under already-ignored directories remain
 outside the tool-result producer and are tracked by the freshness-probe issue.
 (#2071)
 
+Consumed nested `.gitignore` sources carry their build-time `mtimeMs` and size
+in the project matcher cache. `getProjectIgnoreMatcher` sweeps those sources
+at most once per root per two-second cadence and routes drift, including
+deletion, through `invalidateProjectIgnoreMatcherForPath`; it never stats on
+`isIgnored` verdicts. (#2159)
+
 Knip's dispatch memo is instance-owned and keyed by canonical project root plus
 the runtime's monotonic project sequence. Only callers that supply that content
 generation may reuse a successful result; explicit fresh-analysis callers omit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -600,8 +600,9 @@ outside the tool-result producer and are tracked by the freshness-probe issue.
 Consumed nested `.gitignore` sources carry their build-time `mtimeMs` and size
 in the project matcher cache. `getProjectIgnoreMatcher` sweeps those sources
 at most once per root per two-second cadence and routes drift, including
-deletion, through `invalidateProjectIgnoreMatcherForPath`; it never stats on
-`isIgnored` verdicts. (#2159)
+deletion, through `invalidateProjectIgnoreMatcherForPath`; newly discovered
+sources append to the baseline without replacing existing signatures, and it
+never stats on `isIgnored` verdicts. (#2159)
 
 Knip's dispatch memo is instance-owned and keyed by canonical project root plus
 the runtime's monotonic project sequence. Only callers that supply that content

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -568,7 +568,7 @@ export function createProjectIgnoreMatcher(
 	rootDir: string,
 	extraPatterns: string[] = [],
 	globalPatterns: string[] = [],
-): ProjectIgnoreMatcher {
+): ProjectIgnoreMatcherWithFreshness {
 	const resolvedRoot = resolveGitIgnoreRoot(rootDir);
 	// Precedence is gitignore order: LATER patterns override earlier ones. So
 	// global (lowest) → project .gitignore → project .pi-lens.json (highest),
@@ -680,8 +680,17 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 		if (hasIgnoreSourceDrift(cached.ignoreSources)) {
 			for (const source of cached.ignoreSources) {
 				if (hasIgnoreSourceDrift([source])) {
+					const sourceIndex = cached.ignoreSources.findIndex(
+						(cachedSource) => cachedSource.path === source.path,
+					);
 					invalidateProjectIgnoreMatcherForPath(source.path);
 					cached.matcher.refreshConsumedIgnoreSource(source.path);
+					const refreshedSource = cached.matcher
+						.getConsumedIgnoreSources()
+						.find((current) => current.path === source.path);
+					if (sourceIndex !== -1 && refreshedSource !== undefined) {
+						cached.ignoreSources.splice(sourceIndex, 1, refreshedSource);
+					}
 				}
 			}
 		}
@@ -716,7 +725,7 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 		resolvedRoot,
 		projectConfig.ignore,
 		getGlobalIgnorePatterns(),
-	) as ProjectIgnoreMatcherWithFreshness;
+	);
 	projectIgnoreMatcherCache.set(resolvedRoot, {
 		ignoreSources: [...matcher.getConsumedIgnoreSources()],
 		lastIgnoreFreshnessCheckMs: Date.now(),

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -186,6 +186,16 @@ export interface ProjectIgnoreMatcher {
 	 * degrade-to-pattern-only is intended, not a bug.
 	 */
 	ensureTrackedIndex(): Promise<void>;
+	/** Sources read by this matcher, with their build-time signatures. */
+	getConsumedIgnoreSources(): readonly IgnoreSource[];
+	/** Refresh the baseline after the existing write-result invalidation seam. */
+	refreshConsumedIgnoreSource(filePath: string): void;
+}
+
+export interface IgnoreSource {
+	path: string;
+	mtimeMs: number;
+	size: number;
 }
 
 function resolveGitIgnoreRoot(startDir: string): string {
@@ -336,6 +346,12 @@ function buildProjectIgnoreMatcher(
 	resolvedRoot: string,
 	patterns: GitignorePattern[],
 ): ProjectIgnoreMatcher {
+	const consumedIgnoreSources = new Map<string, IgnoreSource>();
+	const rememberIgnoreSource = (filePath: string): void => {
+		const signature = fileFreshnessSignature(filePath);
+		consumedIgnoreSources.set(filePath, { path: filePath, ...signature });
+	};
+	rememberIgnoreSource(path.join(resolvedRoot, ".gitignore"));
 	const nestedCache = new Map<
 		string,
 		{
@@ -359,6 +375,7 @@ function buildProjectIgnoreMatcher(
 	const patternsForDir = (dir: string): GitignorePattern[] => {
 		if (dir === resolvedRoot) return patterns;
 		const gitignoreSig = gitignoreSignature(dir);
+		rememberIgnoreSource(path.join(dir, ".gitignore"));
 		// #1105: gate on size too. `findPiLensConfigInDir` returns `size` alongside
 		// `mtimeMs` (both from one stat), and `gitignoreSignature` reads both for
 		// the nested `.gitignore`, so an mtime-preserving, length-changing edit to
@@ -473,6 +490,10 @@ function buildProjectIgnoreMatcher(
 	return {
 		rootDir: resolvedRoot,
 		patterns,
+		getConsumedIgnoreSources: () => [...consumedIgnoreSources.values()],
+		refreshConsumedIgnoreSource(filePath: string): void {
+			if (consumedIgnoreSources.has(filePath)) rememberIgnoreSource(filePath);
+		},
 		invalidateSubtree,
 		ensureTrackedIndex(): Promise<void> {
 			return collectTrackedFiles(resolvedRoot).then(() => undefined);
@@ -564,6 +585,8 @@ export function createProjectIgnoreMatcher(
 const projectIgnoreMatcherCache = new Map<
 	string,
 	{
+		ignoreSources: IgnoreSource[];
+		lastIgnoreFreshnessCheckMs: number;
 		gitignoreMtimeMs: number;
 		/** #1105 second axis for the root `.gitignore` (see FreshnessSignature). */
 		gitignoreSize: number;
@@ -580,6 +603,9 @@ const projectIgnoreMatcherCache = new Map<
 		matcher: ProjectIgnoreMatcher;
 	}
 >();
+
+/** Nested ignore sources are checked at most once per root per cadence window. */
+export const PROJECT_IGNORE_FRESHNESS_CADENCE_MS = 2_000;
 
 /**
  * `size:mtimeMs` freshness signature for a single file (#1105). mtime alone
@@ -612,6 +638,13 @@ function gitignoreSignature(rootDir: string): FreshnessSignature {
 	return fileFreshnessSignature(path.join(rootDir, ".gitignore"));
 }
 
+function hasIgnoreSourceDrift(sources: readonly IgnoreSource[]): boolean {
+	return sources.some((source) => {
+		const current = fileFreshnessSignature(source.path);
+		return current.mtimeMs !== source.mtimeMs || current.size !== source.size;
+	});
+}
+
 /**
  * The project config file found by the same upward walk as the loader. Cache
  * invalidation must track the actual file found, not only a file directly under
@@ -637,6 +670,24 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 	const globalSig = globalConfigSignature();
 	const cached = projectIgnoreMatcherCache.get(resolvedRoot);
 	if (
+		cached &&
+		Date.now() - cached.lastIgnoreFreshnessCheckMs >=
+			PROJECT_IGNORE_FRESHNESS_CADENCE_MS
+	) {
+		cached.lastIgnoreFreshnessCheckMs = Date.now();
+		if (hasIgnoreSourceDrift(cached.ignoreSources)) {
+			for (const source of cached.ignoreSources) {
+				if (hasIgnoreSourceDrift([source])) {
+					invalidateProjectIgnoreMatcherForPath(source.path);
+					cached.matcher.refreshConsumedIgnoreSource(source.path);
+				}
+			}
+		}
+	}
+	// A path can be discovered during the previous matcher lookup. Preserve
+	// that expanded source set in the cache before the next cadence check.
+	if (cached) cached.ignoreSources = [...cached.matcher.getConsumedIgnoreSources()];
+	if (
 		cached?.gitignoreMtimeMs === gitignoreSig.mtimeMs &&
 		cached?.gitignoreSize === gitignoreSig.size &&
 		cached?.lensConfigPath === lensConfig.path &&
@@ -660,6 +711,8 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 		getGlobalIgnorePatterns(),
 	);
 	projectIgnoreMatcherCache.set(resolvedRoot, {
+		ignoreSources: [...matcher.getConsumedIgnoreSources()],
+		lastIgnoreFreshnessCheckMs: Date.now(),
 		gitignoreMtimeMs: gitignoreSig.mtimeMs,
 		gitignoreSize: gitignoreSig.size,
 		lensConfigPath: lensConfig.path,

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -186,17 +186,18 @@ export interface ProjectIgnoreMatcher {
 	 * degrade-to-pattern-only is intended, not a bug.
 	 */
 	ensureTrackedIndex(): Promise<void>;
-	/** Sources read by this matcher, with their build-time signatures. */
-	getConsumedIgnoreSources(): readonly IgnoreSource[];
-	/** Refresh the baseline after the existing write-result invalidation seam. */
-	refreshConsumedIgnoreSource(filePath: string): void;
 }
 
-export interface IgnoreSource {
+interface IgnoreSource {
 	path: string;
 	mtimeMs: number;
 	size: number;
 }
+
+type ProjectIgnoreMatcherWithFreshness = ProjectIgnoreMatcher & {
+	getConsumedIgnoreSources(): readonly IgnoreSource[];
+	refreshConsumedIgnoreSource(filePath: string): void;
+};
 
 function resolveGitIgnoreRoot(startDir: string): string {
 	const fallback = path.resolve(startDir);
@@ -345,7 +346,7 @@ function ancestorDirsBetween(rootDir: string, targetDir: string): string[] {
 function buildProjectIgnoreMatcher(
 	resolvedRoot: string,
 	patterns: GitignorePattern[],
-): ProjectIgnoreMatcher {
+): ProjectIgnoreMatcherWithFreshness {
 	const consumedIgnoreSources = new Map<string, IgnoreSource>();
 	const rememberIgnoreSource = (filePath: string): void => {
 		const signature = fileFreshnessSignature(filePath);
@@ -492,6 +493,7 @@ function buildProjectIgnoreMatcher(
 		patterns,
 		getConsumedIgnoreSources: () => [...consumedIgnoreSources.values()],
 		refreshConsumedIgnoreSource(filePath: string): void {
+			// The freshness sweep refreshes this baseline after invalidation.
 			if (consumedIgnoreSources.has(filePath)) rememberIgnoreSource(filePath);
 		},
 		invalidateSubtree,
@@ -600,7 +602,7 @@ const projectIgnoreMatcherCache = new Map<
 		globalConfigMtimeMs: number;
 		/** #1105 second axis for the global `~/.pi-lens/config.json`. */
 		globalConfigSize: number;
-		matcher: ProjectIgnoreMatcher;
+		matcher: ProjectIgnoreMatcherWithFreshness;
 	}
 >();
 
@@ -684,9 +686,14 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 			}
 		}
 	}
-	// A path can be discovered during the previous matcher lookup. Preserve
-	// that expanded source set in the cache before the next cadence check.
-	if (cached) cached.ignoreSources = [...cached.matcher.getConsumedIgnoreSources()];
+	// A path can be discovered during the previous matcher lookup. Publish only
+	// previously unseen sources so a walk cannot replace a pre-edit baseline.
+	if (cached) {
+		const known = new Set(cached.ignoreSources.map((source) => source.path));
+		for (const source of cached.matcher.getConsumedIgnoreSources()) {
+			if (!known.has(source.path)) cached.ignoreSources.push(source);
+		}
+	}
 	if (
 		cached?.gitignoreMtimeMs === gitignoreSig.mtimeMs &&
 		cached?.gitignoreSize === gitignoreSig.size &&
@@ -709,7 +716,7 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 		resolvedRoot,
 		projectConfig.ignore,
 		getGlobalIgnorePatterns(),
-	);
+	) as ProjectIgnoreMatcherWithFreshness;
 	projectIgnoreMatcherCache.set(resolvedRoot, {
 		ignoreSources: [...matcher.getConsumedIgnoreSources()],
 		lastIgnoreFreshnessCheckMs: Date.now(),

--- a/tests/clients/project-ignore-freshness.test.ts
+++ b/tests/clients/project-ignore-freshness.test.ts
@@ -1,6 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return { ...actual, statSync: vi.fn(actual.statSync) };
+});
+
 import {
 	getProjectIgnoreMatcher,
 	PROJECT_IGNORE_FRESHNESS_CADENCE_MS,
@@ -59,6 +65,70 @@ describe("project ignore freshness probe (#2159)", () => {
 		}
 	});
 
+	it("refreshes a pre-memoized path after other paths walk an edited source", () => {
+		const env = setupTestEnvironment("pi-lens-2159-ordering-");
+		try {
+			const nested = path.join(env.tmpDir, "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			const memoizedTarget = path.join(nested, "a.ts");
+			const walkerTarget = path.join(nested, "b.ts");
+			fs.writeFileSync(ignorePath, "a.ts\n");
+			vi.useFakeTimers();
+			const start = Date.now();
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			expect(matcher.isIgnored(memoizedTarget)).toBe(true);
+			getProjectIgnoreMatcher(env.tmpDir);
+
+			fs.writeFileSync(ignorePath, "!a.ts\n");
+			// This ordinary walker lookup must not replace the pre-edit baseline.
+			getProjectIgnoreMatcher(env.tmpDir).isIgnored(walkerTarget);
+			getProjectIgnoreMatcher(env.tmpDir);
+			for (let window = 1; window <= 5; window++) {
+				vi.setSystemTime(start + window * PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
+				getProjectIgnoreMatcher(env.tmpDir).isIgnored(walkerTarget);
+			}
+
+			expect(getProjectIgnoreMatcher(env.tmpDir).isIgnored(memoizedTarget)).toBe(
+				false,
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("refreshes a pre-memoized path after other paths walk a deleted source", () => {
+		const env = setupTestEnvironment("pi-lens-2159-delete-ordering-");
+		try {
+			const nested = path.join(env.tmpDir, "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			const memoizedTarget = path.join(nested, "a.ts");
+			const walkerTarget = path.join(nested, "b.ts");
+			fs.writeFileSync(ignorePath, "a.ts\n");
+			vi.useFakeTimers();
+			const start = Date.now();
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			expect(matcher.isIgnored(memoizedTarget)).toBe(true);
+			getProjectIgnoreMatcher(env.tmpDir);
+
+			fs.unlinkSync(ignorePath);
+			// This ordinary walker lookup must not replace the pre-delete baseline.
+			getProjectIgnoreMatcher(env.tmpDir).isIgnored(walkerTarget);
+			getProjectIgnoreMatcher(env.tmpDir);
+			for (let window = 1; window <= 5; window++) {
+				vi.setSystemTime(start + window * PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
+				getProjectIgnoreMatcher(env.tmpDir).isIgnored(walkerTarget);
+			}
+
+			expect(getProjectIgnoreMatcher(env.tmpDir).isIgnored(memoizedTarget)).toBe(
+				false,
+			);
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("keeps the unchanged matcher hot inside the cadence window", () => {
 		const env = setupTestEnvironment("pi-lens-2159-cadence-");
 		try {
@@ -69,7 +139,20 @@ describe("project ignore freshness probe (#2159)", () => {
 			getProjectIgnoreMatcher(env.tmpDir).isIgnored(target);
 
 			const first = getProjectIgnoreMatcher(env.tmpDir);
+			const statSpy = vi.spyOn(fs, "statSync");
+			const sourceStats = () =>
+				statSpy.mock.calls.filter(
+					([filePath]) => filePath === path.join(nested, ".gitignore"),
+				);
+			statSpy.mockClear();
+
 			expect(getProjectIgnoreMatcher(env.tmpDir)).toBe(first);
+			expect(sourceStats()).toHaveLength(0);
+
+			vi.useFakeTimers();
+			vi.setSystemTime(Date.now() + PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
+			getProjectIgnoreMatcher(env.tmpDir);
+			expect(sourceStats().length).toBeGreaterThan(0);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/project-ignore-freshness.test.ts
+++ b/tests/clients/project-ignore-freshness.test.ts
@@ -157,4 +157,41 @@ describe("project ignore freshness probe (#2159)", () => {
 			env.cleanup();
 		}
 	});
+
+	it("settles to one source stat per cadence window after external edit", () => {
+		const env = setupTestEnvironment("pi-lens-2159-settled-");
+		try {
+			const nested = path.join(env.tmpDir, "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			const target = path.join(nested, "generated.ts");
+			fs.writeFileSync(ignorePath, "generated.ts\n");
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			matcher.isIgnored(target);
+			getProjectIgnoreMatcher(env.tmpDir);
+
+			const statSpy = vi.spyOn(fs, "statSync");
+			const sourceStats = () =>
+				statSpy.mock.calls.filter(
+					([filePath]) => filePath === ignorePath,
+				);
+			statSpy.mockClear();
+			fs.writeFileSync(ignorePath, "!generated.ts\n");
+			vi.useFakeTimers();
+			const start = Date.now();
+			const perWindow: number[] = [];
+			for (let window = 1; window <= 6; window++) {
+				vi.setSystemTime(
+					start + window * PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1,
+				);
+				const before = sourceStats().length;
+				getProjectIgnoreMatcher(env.tmpDir).isIgnored(target);
+				perWindow.push(sourceStats().length - before);
+			}
+
+			expect(perWindow.slice(1)).toEqual([1, 1, 1, 1, 1]);
+		} finally {
+			env.cleanup();
+		}
+	});
 });

--- a/tests/clients/project-ignore-freshness.test.ts
+++ b/tests/clients/project-ignore-freshness.test.ts
@@ -1,0 +1,77 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	getProjectIgnoreMatcher,
+	PROJECT_IGNORE_FRESHNESS_CADENCE_MS,
+} from "../../clients/file-utils.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+describe("project ignore freshness probe (#2159)", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("refreshes a consumed nested ignore file after an external edit", () => {
+		const env = setupTestEnvironment("pi-lens-2159-external-");
+		try {
+			const nested = path.join(env.tmpDir, "ignored", "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			const target = path.join(nested, "generated.ts");
+			fs.writeFileSync(path.join(env.tmpDir, ".gitignore"), "ignored/\n");
+			fs.writeFileSync(ignorePath, "generated.ts\n");
+			const first = getProjectIgnoreMatcher(env.tmpDir);
+			expect(first.isIgnored(target)).toBe(true);
+			// The next lookup publishes the nested source discovered by the verdict.
+			expect(getProjectIgnoreMatcher(env.tmpDir)).toBe(first);
+
+			// This bypasses the tool_result write boundary that #2153 covers.
+			fs.writeFileSync(ignorePath, "!generated.ts\n");
+			vi.useFakeTimers();
+			vi.setSystemTime(Date.now() + PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
+
+			expect(getProjectIgnoreMatcher(env.tmpDir).isIgnored(target)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("drops a consumed nested source when an external delete removes it", () => {
+		const env = setupTestEnvironment("pi-lens-2159-delete-");
+		try {
+			const nested = path.join(env.tmpDir, "ignored", "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			const target = path.join(nested, "generated.ts");
+			fs.writeFileSync(ignorePath, "generated.ts\n");
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			expect(matcher.isIgnored(target)).toBe(true);
+			getProjectIgnoreMatcher(env.tmpDir);
+			fs.unlinkSync(ignorePath);
+			vi.useFakeTimers();
+			vi.setSystemTime(Date.now() + PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
+
+			expect(getProjectIgnoreMatcher(env.tmpDir).isIgnored(target)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("keeps the unchanged matcher hot inside the cadence window", () => {
+		const env = setupTestEnvironment("pi-lens-2159-cadence-");
+		try {
+			const nested = path.join(env.tmpDir, "package");
+			fs.mkdirSync(nested, { recursive: true });
+			fs.writeFileSync(path.join(nested, ".gitignore"), "generated.ts\n");
+			const target = path.join(nested, "generated.ts");
+			getProjectIgnoreMatcher(env.tmpDir).isIgnored(target);
+
+			const first = getProjectIgnoreMatcher(env.tmpDir);
+			expect(getProjectIgnoreMatcher(env.tmpDir)).toBe(first);
+		} finally {
+			env.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Closes #2159. Track every `.gitignore` consumed by a project matcher with its build-time `mtimeMs` and size. At matcher lookup, sweep those sources once per root per 2,000 ms and route drift or deletion through `invalidateProjectIgnoreMatcherForPath`. The `isIgnored` verdict path performs no freshness checks. This covers IDE edits, git checkout/merge/rebase restoration, and nested files under ignored directories.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:dispatch
- [ ] area:lsp
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files pass locally after `npm run build`
- [x] The new regression tests are proven RED on pre-fix code
- [x] The new freshness guard is mutation-proof
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds
- [x] `package-lock.json` is in sync with `package.json`
- [x] `AGENTS.md` is updated
- [x] `.changelog/fix-2159-gitignore-freshness.md` is included
- [x] Commit subject includes the issue number

## Tests

- `tests/clients/project-ignore-freshness.test.ts`: direct external edit flips a consumed nested verdict, external deletion removes the verdict, and unchanged lookup stays hot. The test enters through `getProjectIgnoreMatcher`, the production lookup path, and uses real filesystem state.
- Pre-fix red: with the freshness sweep disabled, `refreshes a consumed nested ignore file after an external edit` and `drops a consumed nested source when an external delete removes it` both failed with `AssertionError: expected true to be false`.
- Mutation red: replacing the drift action with an impossible predicate produced the same two assertion reds.
- Targeted result: `Test Files 14 passed (14)`, `Tests 279 passed (279)`.
- The test uses fake time only for cadence control and restores timers after each case. It satisfies screens 1, 5, 7, and 9.

### Test assessment

- `tests/clients/project-ignore-freshness.test.ts`: uniquely pins external edit, deletion, lazy nested-source registration, and the unchanged cadence fast path. No existing test became redundant; no removal candidate.

## Blast radius

`clients/file-utils.ts` affects project ignore lookup and all source walkers that call `isPathIgnoredByProject`; the entry point is `getProjectIgnoreMatcher`. The existing write-result invalidation callback remains the nested subtree seam. `module_report` was unavailable in this agent context, so dependent inspection used the repository-wide `isPathIgnoredByProject` and `getProjectIgnoreMatcher` search. Hot-path measurements were:

- Before: `{beforeMsPerIsIgnored:0.0021744645}`
- After: `{afterMsPerIsIgnored:0.0020987285000000004,deltaMsPerIsIgnored:-0.00007573599999999943}`
- Warm `isIgnored` cost stays about 0.002 ms per call because freshness runs at matcher lookup, never per verdict.
- A sweep over 11 consumed files measured `{warmCallMs:0.0017248530000000001,statSweepMs:0.12246539999999999,consumedSources:11}`. The stat cost was 0.122 ms per sweep on this Windows workspace.

## Observability

There is no dedicated latency or degradation record for a normal matcher invalidation. The gap is bounded and documented here: the only production evidence is the changed matcher verdict. Add a dedicated bounded `project_ignore_freshness_sweep` record in a follow-up if invalidation-rate diagnosis becomes necessary.

## Class sweep

The defect class is consumed configuration without lookup-time freshness. A repository-wide search covered `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts` for `mtimeMs`, `statSync`, `stat`, `getProjectIgnoreMatcher`, and configuration caches. Per-member verdicts: project `.gitignore` nested sources were the confirmed missing member and are fixed here; root `.gitignore` already has size/mtime lookup validation; global ignore configuration already has size/mtime lookup validation; nested `.pi-lens.json` files already have size/mtime validation while their matcher is used; LSP configuration files use their own configuration freshness seams and are not consumed by this matcher cache. No other consumed-config cache shares this exact missing lookup probe. Consolidation verdict: keep freshness on the existing project matcher cache and invalidation seam; no second cache or watcher is needed.
## Fix round 1

- F1 BLOCKER: Published consumed sources are now add-only. Existing signatures remain the pre-edit baseline when ordinary walker lookups discover an already-known path. Added edit and deletion ordering regressions memoize `a.ts`, edit or delete `.gitignore`, walk `b.ts`, cross five cadence windows, and assert that `a.ts` flips. Both passed after the fix. `Closes #2159` remains because AC3 is now proven through the ordinary walker path.
- F2 MINOR: The cadence test now counts `statSync` calls for the nested `.gitignore`. It asserts zero source stats inside the cadence window and more than zero after expiry. Disabling the drift branch failed all five freshness tests, including the positive post-expiry stat assertion.
- F3 MINOR: Corrected the refresh comment to identify the freshness sweep as the caller.
- F4 MINOR: Kept freshness helpers and `IgnoreSource` module-private; the exported `ProjectIgnoreMatcher` interface is unchanged.
- F5 MINOR: The fix-round commit uses a 72-column body with `Refs #2159` and the requested `Co-Authored-By` trailer.

Fix-round tests: `npm run build`, `npm run lint`, and the ten reviewer test files pass with 10 files and 120 tests.

Red-first evidence: before the fix, both ordering tests failed verbatim with `AssertionError: expected true to be false`; the failures occurred at the final `a.ts` verdict assertions on lines 92 and 124.
## Fix round 2

- R2-1: Replace each refreshed drifted source in `cached.ignoreSources` so the post-edit baseline settles. The new regression expects `[1, 1, 1, 1, 1]` source stats across subsequent cadence windows; the pre-fix red was `AssertionError: expected [ 5, 5, 5, 5, 5 ] to deeply equal [ 1, 1, 1, 1, 1 ]`. Removing the splice reproduces that red.
- R2-2: Widen `createProjectIgnoreMatcher` to return `ProjectIgnoreMatcherWithFreshness`, removing the unchecked cast at the cache construction site.