### PR TITLE
fix(lsp): adapt late-aux grace to observed spawn cost (closes #2152)

### DIFF
--- a/.changelog/fix-2152-adaptive-aux-grace.md
+++ b/.changelog/fix-2152-adaptive-aux-grace.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Adapt the first cold auxiliary wait to observed spawn cost (closes #2152)** — a cold auxiliary touch derives its grace ceiling from the server's last successful spawn duration, adds a bounded 500ms margin, and caps the result at 8s. Warm touches retain the 2s fast path, and `PI_LENS_AUX_GRACE_MS` remains an explicit override.

--- a/.changelog/fix-2152-adaptive-aux-grace.md
+++ b/.changelog/fix-2152-adaptive-aux-grace.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Adapt the first cold auxiliary wait to observed spawn cost (closes #2152)** — a cold auxiliary touch derives its grace ceiling from the server's last successful spawn duration, adds a bounded 500ms margin, and caps the result at 8s. Warm touches retain the 2s fast path, and `PI_LENS_AUX_GRACE_MS` remains an explicit override.
+- **Adapt the first cold auxiliary wait to observed spawn cost (closes #2152)** — a cold auxiliary touch uses the larger of its declared wait and the server's last successful spawn duration plus a 500ms margin, capped at 8s. Warm touches retain the declared wait capped at 2s, and `PI_LENS_AUX_GRACE_MS` remains an explicit override.

--- a/.changelog/fix-2152-adaptive-aux-grace.md
+++ b/.changelog/fix-2152-adaptive-aux-grace.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Adapt the first cold auxiliary wait to observed spawn cost (closes #2152)** — a cold auxiliary touch uses the larger of its declared wait and the server's last successful spawn duration plus a 500ms margin, capped at 8s. Warm touches retain the declared wait capped at 2s, and `PI_LENS_AUX_GRACE_MS` remains an explicit override.
+- **Adapt the first cold auxiliary wait to observed spawn cost (closes #2152)** — a cold auxiliary touch uses the larger of its declared wait and the server's last successful spawn duration plus a 500ms margin, capped at 8s. Warm touches retain the declared wait capped at 2s, and `PI_LENS_AUX_GRACE_MS` caps the budget (it never raises it).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,7 @@ group (see the placement rules in "Maintaining this file").
 
 Auxiliary diagnostic waits preserve a warm-turn fast path: on a cold
 acquisition, the budget is `max(declared wait, observed spawn + 500ms)` clamped
-to 8s; on a warm acquisition, it remains `min(declared wait, 2000ms)`. An
+to an 8s ceiling; on a warm acquisition, it remains `min(declared wait, 2000ms)`. An
 explicit `PI_LENS_AUX_GRACE_MS` value overrides both formulas. (#2152)
 
 Pull-diagnostics request deadlines send `$/cancelRequest`, but cancellation is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,11 @@ turn-end delivery, and stale completed findings must re-arm a refreshed
 freshness baseline. Turn-end drains use a zero wait budget and requeue unsettled
 promises, so deferred work never adds a repeated per-turn stall (#2122).
 
+Auxiliary diagnostics waits preserve a warm-turn fast path: the default 2s
+ceiling applies to reused clients, while a cold acquisition may use the
+server's last successful spawn duration plus a bounded margin, never exceeding
+8s. An explicit `PI_LENS_AUX_GRACE_MS` value overrides this adaptation. (#2152)
+
 Live contracts, grouped by subsystem. Consult the group for the seam you
 touch; each paragraph carries its evidence issue. New entries join their
 group (see the placement rules in "Maintaining this file").

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,16 +267,16 @@ turn-end delivery, and stale completed findings must re-arm a refreshed
 freshness baseline. Turn-end drains use a zero wait budget and requeue unsettled
 promises, so deferred work never adds a repeated per-turn stall (#2122).
 
-Auxiliary diagnostics waits preserve a warm-turn fast path: the default 2s
-ceiling applies to reused clients, while a cold acquisition may use the
-server's last successful spawn duration plus a bounded margin, never exceeding
-8s. An explicit `PI_LENS_AUX_GRACE_MS` value overrides this adaptation. (#2152)
-
 Live contracts, grouped by subsystem. Consult the group for the seam you
 touch; each paragraph carries its evidence issue. New entries join their
 group (see the placement rules in "Maintaining this file").
 
 ### LSP: acquisition, touches, waits, and diagnostics
+
+Auxiliary diagnostic waits preserve a warm-turn fast path: on a cold
+acquisition, the budget is `max(declared wait, observed spawn + 500ms)` clamped
+to 8s; on a warm acquisition, it remains `min(declared wait, 2000ms)`. An
+explicit `PI_LENS_AUX_GRACE_MS` value overrides both formulas. (#2152)
 
 Pull-diagnostics request deadlines send `$/cancelRequest`, but cancellation is
 advisory. While a cancelled request remains unsettled, admission blocks another

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,7 +276,9 @@ group (see the placement rules in "Maintaining this file").
 Auxiliary diagnostic waits preserve a warm-turn fast path: on a cold
 acquisition, the budget is `max(declared wait, observed spawn + 500ms)` clamped
 to an 8s ceiling; on a warm acquisition, it remains `min(declared wait, 2000ms)`. An
-explicit `PI_LENS_AUX_GRACE_MS` value overrides both formulas. (#2152)
+explicit `PI_LENS_AUX_GRACE_MS` value caps the budget on both paths;
+it never raises it. On a cold auxiliary it also caps the request's own
+wait, so a low value cancels the request earlier than master did. (#2152)
 
 Pull-diagnostics request deadlines send `$/cancelRequest`, but cancellation is
 advisory. While a cancelled request remains unsettled, admission blocks another

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -507,10 +507,7 @@ export function auxWaitBudgetMs(
 	}
 	return Math.min(
 		MAX_ADAPTIVE_AUX_GRACE_CEILING_MS,
-		Math.max(
-			declaredWaitMs,
-			(observedSpawnMs ?? 0) + ADAPTIVE_AUX_GRACE_MARGIN_MS,
-		),
+		Math.max(declaredWaitMs, observedSpawnMs + ADAPTIVE_AUX_GRACE_MARGIN_MS),
 	);
 }
 const DIAGNOSTICS_SEMANTIC_SETTLE_THRESHOLD_MS = Math.max(

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -489,25 +489,6 @@ const DEFAULT_AUX_GRACE_CEILING_MS = 2000;
 const MAX_ADAPTIVE_AUX_GRACE_CEILING_MS = 8000;
 const ADAPTIVE_AUX_GRACE_MARGIN_MS = 500;
 
-function auxGraceCeilingMs(
-	serverId: string,
-	isCold: boolean,
-	configuredCeilingMs: number | undefined,
-): number {
-	if (configuredCeilingMs !== undefined || !isCold) {
-		return configuredCeilingMs ?? DEFAULT_AUX_GRACE_CEILING_MS;
-	}
-	const observedSpawnMs = getSuccessfulLspSpawnDurationMs(serverId);
-	if (observedSpawnMs === undefined) return DEFAULT_AUX_GRACE_CEILING_MS;
-	return Math.min(
-		MAX_ADAPTIVE_AUX_GRACE_CEILING_MS,
-		Math.max(
-			DEFAULT_AUX_GRACE_CEILING_MS,
-			observedSpawnMs + ADAPTIVE_AUX_GRACE_MARGIN_MS,
-		),
-	);
-}
-
 export function auxWaitBudgetMs(
 	serverId: string,
 	isCold: boolean,
@@ -517,7 +498,7 @@ export function auxWaitBudgetMs(
 	if (configuredCeilingMs !== undefined || !isCold) {
 		return Math.min(
 			declaredWaitMs,
-			auxGraceCeilingMs(serverId, isCold, configuredCeilingMs),
+			configuredCeilingMs ?? DEFAULT_AUX_GRACE_CEILING_MS,
 		);
 	}
 	const observedSpawnMs = getSuccessfulLspSpawnDurationMs(serverId);
@@ -526,7 +507,10 @@ export function auxWaitBudgetMs(
 	}
 	return Math.min(
 		MAX_ADAPTIVE_AUX_GRACE_CEILING_MS,
-		Math.max(declaredWaitMs, observedSpawnMs + ADAPTIVE_AUX_GRACE_MARGIN_MS),
+		Math.max(
+			declaredWaitMs,
+			(observedSpawnMs ?? 0) + ADAPTIVE_AUX_GRACE_MARGIN_MS,
+		),
 	);
 }
 const DIAGNOSTICS_SEMANTIC_SETTLE_THRESHOLD_MS = Math.max(
@@ -4565,7 +4549,39 @@ export class LSPService {
 						// Fail-open: missing capability state keeps today's push fallback.
 					}
 				}
-				const perServerWaits = spawned.map((entry) => {
+				const configuredAuxCeilingMs = readEnvAuxGraceMs();
+				const perServerDeclaredTimeouts = spawned.map((entry) =>
+					timeoutFor(entry.client.serverId),
+				);
+				const perServerWaitTimeouts = spawned.map((entry, entryIndex) => {
+					const declaredServerTimeout = perServerDeclaredTimeouts[entryIndex];
+					const observedSpawnMs = getSuccessfulLspSpawnDurationMs(
+						entry.client.serverId,
+					);
+					return hasTouchAuxiliaries &&
+						entry.info.role === "auxiliary" &&
+						coldAuxiliaryServerIds.has(entry.client.serverId) &&
+						(configuredAuxCeilingMs !== undefined ||
+							(observedSpawnMs !== undefined && observedSpawnMs > 0))
+						? auxWaitBudgetMs(
+								entry.client.serverId,
+								true,
+								configuredAuxCeilingMs,
+								declaredServerTimeout,
+							)
+						: perServerDeclaredTimeouts[entryIndex];
+				});
+				const perServerRaceBudgets = spawned.map((entry, entryIndex) => {
+					return hasTouchAuxiliaries && entry.info.role === "auxiliary"
+						? auxWaitBudgetMs(
+								entry.client.serverId,
+								coldAuxiliaryServerIds.has(entry.client.serverId),
+								configuredAuxCeilingMs,
+								perServerDeclaredTimeouts[entryIndex],
+							)
+						: perServerDeclaredTimeouts[entryIndex];
+				});
+				const perServerWaits = spawned.map((entry, entryIndex) => {
 					// #1459: a DEFERRED server never received this content, so its version
 					// can never advance past the baseline — waiting on it burns its whole
 					// budget and would flip the touch to `inconclusive`, discarding a
@@ -4574,7 +4590,7 @@ export class LSPService {
 					if (deferredResyncServerIds.has(entry.info.id)) {
 						return Promise.resolve(undefined);
 					}
-					const serverTimeout = timeoutFor(entry.client.serverId);
+					const serverTimeout = perServerWaitTimeouts[entryIndex];
 					// #1531: a per-path baseline. `clientWaitForDiagnostics` compares it
 					// against this path's own publication stamp, so a sibling file's
 					// publication on a shared client can no longer end this wait before the
@@ -4644,6 +4660,7 @@ export class LSPService {
 												serverId: spawned[i].info.id,
 												client: spawned[i].client,
 												baseline: diagnosticBaselines.get(spawned[i].client),
+												budgetMs: perServerRaceBudgets[i],
 											}
 										: null,
 								)
@@ -4655,13 +4672,12 @@ export class LSPService {
 										serverId: string;
 										client: (typeof spawned)[number]["client"];
 										baseline: number | undefined;
+										budgetMs: number;
 									} => x !== null,
 								);
-							const configuredAuxCeilingMs = readEnvAuxGraceMs();
-							// After all primaries settle, give each auxiliary the smaller of
-							// its declared wait budget and the global auxiliary ceiling. The
-							// 2000ms default admits measured ~1.3s warm scanner runs without
-							// making every edit pay opengrep's 3500ms cold-start allowance.
+							// After all primaries settle, use the same per-auxiliary budget
+							// that bounded its own diagnostic wait. Warm acquisitions retain
+							// the 2000ms ceiling; cold acquisitions include observed startup.
 							// Late aux results are dropped from this wait. A later unchanged-
 							// content read may carry a SHA-256-bound cache publication before its
 							// resync clears the cache; changed or unknown content never replays.
@@ -4674,12 +4690,7 @@ export class LSPService {
 								const auxWaitStartedAt = Date.now();
 								const outcomes = await Promise.all(
 									auxWaits.map(async (aux) => {
-										const budgetMs = auxWaitBudgetMs(
-											aux.serverId,
-											coldAuxiliaryServerIds.has(aux.serverId),
-											configuredAuxCeilingMs,
-											timeoutFor(aux.serverId),
-										);
+										const { budgetMs } = aux;
 										let timer: ReturnType<typeof setTimeout> | undefined;
 										const timeout = new Promise<false>((resolve) => {
 											timer = setTimeout(() => resolve(false), budgetMs);

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -507,6 +507,28 @@ function auxGraceCeilingMs(
 		),
 	);
 }
+
+export function auxWaitBudgetMs(
+	serverId: string,
+	isCold: boolean,
+	configuredCeilingMs: number | undefined,
+	declaredWaitMs: number,
+): number {
+	if (configuredCeilingMs !== undefined || !isCold) {
+		return Math.min(
+			declaredWaitMs,
+			auxGraceCeilingMs(serverId, isCold, configuredCeilingMs),
+		);
+	}
+	const observedSpawnMs = getSuccessfulLspSpawnDurationMs(serverId);
+	if (observedSpawnMs === undefined || observedSpawnMs <= 0) {
+		return Math.min(declaredWaitMs, DEFAULT_AUX_GRACE_CEILING_MS);
+	}
+	return Math.min(
+		MAX_ADAPTIVE_AUX_GRACE_CEILING_MS,
+		Math.max(declaredWaitMs, observedSpawnMs + ADAPTIVE_AUX_GRACE_MARGIN_MS),
+	);
+}
 const DIAGNOSTICS_SEMANTIC_SETTLE_THRESHOLD_MS = Math.max(
 	0,
 	Number.parseInt(
@@ -2342,10 +2364,6 @@ export class LSPService {
 		hardCapMs?: number,
 		resolvedRoots?: Map<string, string>,
 		waitSkipReasons?: Set<string>,
-		onOutcome?: (
-			serverId: string,
-			outcome: LSPClientAcquisitionOutcome,
-		) => void,
 	): Promise<SpawnedServer | undefined> {
 		if (this.checkDestroyed()) return undefined;
 		// Primary selection considers language servers only — auxiliary servers
@@ -2414,7 +2432,6 @@ export class LSPService {
 					noteSpawnInFlight,
 					(reported) => {
 						acquisition.outcome = reported;
-						onOutcome?.(server.id, reported);
 					},
 				);
 				if (spawned) {
@@ -4657,13 +4674,11 @@ export class LSPService {
 								const auxWaitStartedAt = Date.now();
 								const outcomes = await Promise.all(
 									auxWaits.map(async (aux) => {
-										const budgetMs = Math.min(
+										const budgetMs = auxWaitBudgetMs(
+											aux.serverId,
+											coldAuxiliaryServerIds.has(aux.serverId),
+											configuredAuxCeilingMs,
 											timeoutFor(aux.serverId),
-											auxGraceCeilingMs(
-												aux.serverId,
-												coldAuxiliaryServerIds.has(aux.serverId),
-												configuredAuxCeilingMs,
-											),
 										);
 										let timer: ReturnType<typeof setTimeout> | undefined;
 										const timeout = new Promise<false>((resolve) => {

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -485,6 +485,28 @@ function readEnvAuxGraceMs(): number | undefined {
 	if (!Number.isFinite(parsed) || parsed < 0) return undefined;
 	return parsed;
 }
+const DEFAULT_AUX_GRACE_CEILING_MS = 2000;
+const MAX_ADAPTIVE_AUX_GRACE_CEILING_MS = 8000;
+const ADAPTIVE_AUX_GRACE_MARGIN_MS = 500;
+
+function auxGraceCeilingMs(
+	serverId: string,
+	isCold: boolean,
+	configuredCeilingMs: number | undefined,
+): number {
+	if (configuredCeilingMs !== undefined || !isCold) {
+		return configuredCeilingMs ?? DEFAULT_AUX_GRACE_CEILING_MS;
+	}
+	const observedSpawnMs = getSuccessfulLspSpawnDurationMs(serverId);
+	if (observedSpawnMs === undefined) return DEFAULT_AUX_GRACE_CEILING_MS;
+	return Math.min(
+		MAX_ADAPTIVE_AUX_GRACE_CEILING_MS,
+		Math.max(
+			DEFAULT_AUX_GRACE_CEILING_MS,
+			observedSpawnMs + ADAPTIVE_AUX_GRACE_MARGIN_MS,
+		),
+	);
+}
 const DIAGNOSTICS_SEMANTIC_SETTLE_THRESHOLD_MS = Math.max(
 	0,
 	Number.parseInt(
@@ -2320,6 +2342,10 @@ export class LSPService {
 		hardCapMs?: number,
 		resolvedRoots?: Map<string, string>,
 		waitSkipReasons?: Set<string>,
+		onOutcome?: (
+			serverId: string,
+			outcome: LSPClientAcquisitionOutcome,
+		) => void,
 	): Promise<SpawnedServer | undefined> {
 		if (this.checkDestroyed()) return undefined;
 		// Primary selection considers language servers only — auxiliary servers
@@ -2388,6 +2414,7 @@ export class LSPService {
 					noteSpawnInFlight,
 					(reported) => {
 						acquisition.outcome = reported;
+						onOutcome?.(server.id, reported);
 					},
 				);
 				if (spawned) {
@@ -2605,6 +2632,10 @@ export class LSPService {
 	async getAuxiliaryClientsForFile(
 		filePath: string,
 		enabledIds: ReadonlySet<string>,
+		onOutcome?: (
+			serverId: string,
+			outcome: LSPClientAcquisitionOutcome,
+		) => void,
 	): Promise<SpawnedServer[]> {
 		if (this.checkDestroyed() || enabledIds.size === 0) return [];
 		const servers = getServersForFileWithConfig(filePath).filter(
@@ -2612,7 +2643,15 @@ export class LSPService {
 		);
 		if (servers.length === 0) return [];
 		const spawned = await Promise.all(
-			servers.map((server) => this.ensureClientForServer(filePath, server)),
+			servers.map((server) =>
+				this.ensureClientForServer(
+					filePath,
+					server,
+					undefined,
+					undefined,
+					(reported) => onOutcome?.(server.id, reported),
+				),
+			),
 		);
 		return spawned.filter((entry): entry is SpawnedServer => Boolean(entry));
 	}
@@ -3717,6 +3756,15 @@ export class LSPService {
 		const useAllClients = clientScope === "all";
 		const resolvedPrimaryRoots = new Map<string, string>();
 		const waitSkipReasons = new Set<string>();
+		const coldAuxiliaryServerIds = new Set<string>();
+		const noteColdAuxiliary = (
+			serverId: string,
+			outcome: LSPClientAcquisitionOutcome,
+		): void => {
+			if (outcome === "cold-spawn" || outcome === "cold-spawn-joined") {
+				coldAuxiliaryServerIds.add(serverId);
+			}
+		};
 		let spawned: SpawnedServer[];
 		let serverCountAttempted: number;
 		if (useAllClients) {
@@ -3741,6 +3789,7 @@ export class LSPService {
 				this.getAuxiliaryClientsForFile(
 					filePath,
 					new Set(options.auxiliaryServerIds ?? []),
+					noteColdAuxiliary,
 				),
 			]);
 			spawned = entry ? [entry, ...aux] : aux;
@@ -4591,7 +4640,7 @@ export class LSPService {
 										baseline: number | undefined;
 									} => x !== null,
 								);
-							const auxCeilingMs = readEnvAuxGraceMs() ?? 2000;
+							const configuredAuxCeilingMs = readEnvAuxGraceMs();
 							// After all primaries settle, give each auxiliary the smaller of
 							// its declared wait budget and the global auxiliary ceiling. The
 							// 2000ms default admits measured ~1.3s warm scanner runs without
@@ -4610,7 +4659,11 @@ export class LSPService {
 									auxWaits.map(async (aux) => {
 										const budgetMs = Math.min(
 											timeoutFor(aux.serverId),
-											auxCeilingMs,
+											auxGraceCeilingMs(
+												aux.serverId,
+												coldAuxiliaryServerIds.has(aux.serverId),
+												configuredAuxCeilingMs,
+											),
 										);
 										let timer: ReturnType<typeof setTimeout> | undefined;
 										const timeout = new Promise<false>((resolve) => {

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -446,46 +446,73 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 		);
 	});
 
-	it("extends a cold auxiliary grace from its observed spawn cost", async () => {
-		const { LSPService } = await import("../../../clients/lsp/index.js");
-		const service = new LSPService();
-		// A cold start measures 2.5s. The adaptive ceiling should give this
-		// first touch enough room for a 3s auxiliary wait, while the old static
-		// 2s ceiling cuts it off.
-		const auxServer = makeAuxServer("opengrep");
-		auxServer.spawn.mockImplementation(
-			async () =>
-				new Promise((resolve) =>
-					setTimeout(
-						() => resolve({ process: makeFakeProcess(), source: "test" }),
-						2500,
-					),
-				),
-		);
-		getServersForFileWithConfig.mockReturnValue([
-			makePrimaryServer("ts-primary"),
-			auxServer,
-		]);
-		createLSPClient
-			.mockResolvedValueOnce(makeClient(100, [], { serverId: "ts-primary" }))
-			.mockResolvedValueOnce(
-				makeClient(3000, [makeDiagnostic("cold aux finding")], {
-					serverId: "opengrep",
-				}),
+	it.each([
+		{ observedMs: 1000, expectedFinding: false },
+		{ observedMs: 2500, expectedFinding: true },
+	])(
+		"tracks a cold typos spawn of $observedMs ms instead of using a flat grace",
+		async ({ observedMs, expectedFinding }) => {
+			const { LSPService, auxWaitBudgetMs } =
+				await import("../../../clients/lsp/index.js");
+			const {
+				recordSuccessfulLspSpawn,
+				_clearSuccessfulLspSpawnHistoryForTests,
+			} = await import("../../../clients/lsp/spawn-history.js");
+			_clearSuccessfulLspSpawnHistoryForTests();
+			recordSuccessfulLspSpawn("typos", observedMs);
+			expect(auxWaitBudgetMs("typos", true, undefined, 1500)).toBe(
+				observedMs === 1000 ? 1500 : 3000,
 			);
+			const service = new LSPService();
+			const auxServer = makeAuxServer("typos");
+			auxServer.spawn.mockImplementation(
+				async () =>
+					new Promise((resolve) =>
+						setTimeout(
+							() => resolve({ process: makeFakeProcess(), source: "test" }),
+							observedMs,
+						),
+					),
+			);
+			getServersForFileWithConfig.mockReturnValue([
+				makePrimaryServer("ts-primary"),
+				auxServer,
+			]);
+			createLSPClient
+				.mockResolvedValueOnce(
+					makeClient(100, [makeDiagnostic("primary-only sentinel")], {
+						serverId: "ts-primary",
+					}),
+				)
+				.mockResolvedValueOnce(
+					makeClient(2500, [makeDiagnostic("cold aux finding")], {
+						serverId: "typos",
+					}),
+				);
 
-		const touch = service.touchFile(FILE, "cold-adaptive", {
-			clientScope: "with-auxiliary",
-			auxiliaryServerIds: ["opengrep"],
-			collectDiagnostics: true,
-			diagnostics: "document",
-		});
-		await vi.advanceTimersByTimeAsync(2500);
-		await vi.advanceTimersByTimeAsync(3010);
-		const result = await touch;
-		expect(result?.diags.map((diagnostic) => diagnostic.message)).toContain(
-			"cold aux finding",
-		);
+			const touch = service.touchFile(FILE, "cold-adaptive", {
+				clientScope: "with-auxiliary",
+				auxiliaryServerIds: ["typos"],
+				collectDiagnostics: true,
+				diagnostics: "document",
+			});
+			await vi.advanceTimersByTimeAsync(observedMs + 2600);
+			const result = await touch;
+			expect(result?.diags.map((diagnostic) => diagnostic.message)).toContain(
+				expectedFinding ? "cold aux finding" : "primary-only sentinel",
+			);
+		},
+	);
+
+	it("clamps a cold auxiliary budget at 8000 ms", async () => {
+		const { auxWaitBudgetMs } = await import("../../../clients/lsp/index.js");
+		const {
+			recordSuccessfulLspSpawn,
+			_clearSuccessfulLspSpawnHistoryForTests,
+		} = await import("../../../clients/lsp/spawn-history.js");
+		_clearSuccessfulLspSpawnHistoryForTests();
+		recordSuccessfulLspSpawn("typos", 9000);
+		expect(auxWaitBudgetMs("typos", true, undefined, 1500)).toBe(8000);
 	});
 
 	it("still waits for slow primary even if aux settles early", async () => {

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -157,22 +157,29 @@ function makeClient(
 			close: vi.fn(async () => {}),
 		},
 		waitForDiagnostics: vi.fn(
-			(filePath: string) =>
+			(filePath: string, timeoutMs: number) =>
 				new Promise<void>((resolve) =>
-					setTimeout(() => {
-						waitSettled = true;
-						// A genuine publish is what advances the version on a real
-						// client; a settle with NOTHING published must not, or the
-						// evidence-based outcome check below can't tell the two apart.
-						// #1493: an empty publish is still a publish — opt into it with
-						// `publishesWhenClean` to model a scanner that ran and found
-						// nothing.
-						if (diags.length > 0 || options.publishesWhenClean) {
-							version += 1;
-							stampsByPath.set(filePath, version);
-						}
-						resolve();
-					}, delayMs),
+					setTimeout(
+						() => {
+							const fitWithinBudget = delayMs <= timeoutMs;
+							if (fitWithinBudget) waitSettled = true;
+							// A genuine publish is what advances the version on a real
+							// client; a settle with NOTHING published must not, or the
+							// evidence-based outcome check below can't tell the two apart.
+							// #1493: an empty publish is still a publish — opt into it with
+							// `publishesWhenClean` to model a scanner that ran and found
+							// nothing.
+							if (
+								fitWithinBudget &&
+								(diags.length > 0 || options.publishesWhenClean)
+							) {
+								version += 1;
+								stampsByPath.set(filePath, version);
+							}
+							resolve();
+						},
+						Math.min(delayMs, timeoutMs),
+					),
 				),
 		),
 	};
@@ -478,17 +485,16 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 				makePrimaryServer("ts-primary"),
 				auxServer,
 			]);
+			const auxClient = makeClient(2500, [makeDiagnostic("cold aux finding")], {
+				serverId: "typos",
+			});
 			createLSPClient
 				.mockResolvedValueOnce(
 					makeClient(100, [makeDiagnostic("primary-only sentinel")], {
 						serverId: "ts-primary",
 					}),
 				)
-				.mockResolvedValueOnce(
-					makeClient(2500, [makeDiagnostic("cold aux finding")], {
-						serverId: "typos",
-					}),
-				);
+				.mockResolvedValueOnce(auxClient);
 
 			const touch = service.touchFile(FILE, "cold-adaptive", {
 				clientScope: "with-auxiliary",
@@ -498,6 +504,11 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 			});
 			await vi.advanceTimersByTimeAsync(observedMs + 2600);
 			const result = await touch;
+			expect(auxClient.waitForDiagnostics).toHaveBeenCalledWith(
+				FILE,
+				expectedFinding ? 3000 : 1500,
+				expect.objectContaining({ minVersion: 0 }),
+			);
 			expect(result?.diags.map((diagnostic) => diagnostic.message)).toContain(
 				expectedFinding ? "cold aux finding" : "primary-only sentinel",
 			);

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -446,6 +446,48 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 		);
 	});
 
+	it("extends a cold auxiliary grace from its observed spawn cost", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		// A cold start measures 2.5s. The adaptive ceiling should give this
+		// first touch enough room for a 3s auxiliary wait, while the old static
+		// 2s ceiling cuts it off.
+		const auxServer = makeAuxServer("opengrep");
+		auxServer.spawn.mockImplementation(
+			async () =>
+				new Promise((resolve) =>
+					setTimeout(
+						() => resolve({ process: makeFakeProcess(), source: "test" }),
+						2500,
+					),
+				),
+		);
+		getServersForFileWithConfig.mockReturnValue([
+			makePrimaryServer("ts-primary"),
+			auxServer,
+		]);
+		createLSPClient
+			.mockResolvedValueOnce(makeClient(100, [], { serverId: "ts-primary" }))
+			.mockResolvedValueOnce(
+				makeClient(3000, [makeDiagnostic("cold aux finding")], {
+					serverId: "opengrep",
+				}),
+			);
+
+		const touch = service.touchFile(FILE, "cold-adaptive", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep"],
+			collectDiagnostics: true,
+			diagnostics: "document",
+		});
+		await vi.advanceTimersByTimeAsync(2500);
+		await vi.advanceTimersByTimeAsync(3010);
+		const result = await touch;
+		expect(result?.diags.map((diagnostic) => diagnostic.message)).toContain(
+			"cold aux finding",
+		);
+	});
+
 	it("still waits for slow primary even if aux settles early", async () => {
 		process.env.PI_LENS_AUX_GRACE_MS = String(AUX_GRACE_MS);
 

--- a/tests/clients/lsp/service-scanner-coverage-gap.test.ts
+++ b/tests/clients/lsp/service-scanner-coverage-gap.test.ts
@@ -230,12 +230,9 @@ async function touchAll(
 }
 
 describe("#1459 — sweep fan-out must not black out a scanner silently", () => {
-	beforeEach(async () => {
+	beforeEach(() => {
 		vi.useFakeTimers();
 		vi.resetModules();
-		(
-			await import("../../../clients/lsp/spawn-history.js")
-		)._clearSuccessfulLspSpawnHistoryForTests();
 		getServersForFileWithConfig.mockReset();
 		createLSPClient.mockReset();
 		logLatency.mockReset();
@@ -645,10 +642,6 @@ describe("#1459 — sweep fan-out must not black out a scanner silently", () => 
 		const { LSPService } = await import("../../../clients/lsp/index.js");
 		const service = new LSPService();
 
-		// The with-auxiliary path, i.e. the `waitShape: "aux_grace"` producer. Since
-		// #1533 the `"all"` scope emits `lsp_aux_wait_outcome` too, so this probe pins
-		// the grace producer specifically; the aggregate producer's deferral row is
-		// pinned by its own test below.
 		const aux = makeClient("opengrep", NOTIFY_BUDGET_MS * 50, [], "never");
 		const primary = makeClient("typescript", 0, [
 			makeDiagnostic("primary finding"),
@@ -675,19 +668,13 @@ describe("#1459 — sweep fan-out must not black out a scanner silently", () => 
 		await vi.advanceTimersByTimeAsync(NOTIFY_BUDGET_MS * 200);
 		await Promise.all([first, second]);
 
-		const outcomes = rowsFor("lsp_aux_wait_outcome").flatMap((row) =>
-			(
-				row.metadata as {
-					waitShape?: string;
-					outcomes?: Array<{ serverId: string; outcome: string }>;
-				}
-			)?.waitShape === "aux_grace"
-				? ((
-						row.metadata as {
-							outcomes?: Array<{ serverId: string; outcome: string }>;
-						}
-					)?.outcomes ?? [])
-				: [],
+		const outcomes = rowsFor("lsp_aux_wait_outcome").flatMap(
+			(row) =>
+				(
+					row.metadata as {
+						outcomes?: Array<{ serverId: string; outcome: string }>;
+					}
+				)?.outcomes ?? [],
 		);
 		const opengrepOutcomes = outcomes
 			.filter((entry) => entry.serverId === "opengrep")
@@ -838,9 +825,12 @@ describe("#1586 — deferred-door coverage is judged at merge time", () => {
 	const POST_MERGE_FINDING = "post-merge scanner finding";
 	const PRIMARY_PUBLISH_MS = 700;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		vi.useFakeTimers();
 		vi.resetModules();
+		(
+			await import("../../../clients/lsp/spawn-history.js")
+		)._clearSuccessfulLspSpawnHistoryForTests();
 		getServersForFileWithConfig.mockReset();
 		createLSPClient.mockReset();
 		logLatency.mockReset();

--- a/tests/clients/lsp/service-scanner-coverage-gap.test.ts
+++ b/tests/clients/lsp/service-scanner-coverage-gap.test.ts
@@ -230,9 +230,12 @@ async function touchAll(
 }
 
 describe("#1459 — sweep fan-out must not black out a scanner silently", () => {
-	beforeEach(() => {
+	beforeEach(async () => {
 		vi.useFakeTimers();
 		vi.resetModules();
+		(
+			await import("../../../clients/lsp/spawn-history.js")
+		)._clearSuccessfulLspSpawnHistoryForTests();
 		getServersForFileWithConfig.mockReset();
 		createLSPClient.mockReset();
 		logLatency.mockReset();
@@ -672,13 +675,19 @@ describe("#1459 — sweep fan-out must not black out a scanner silently", () => 
 		await vi.advanceTimersByTimeAsync(NOTIFY_BUDGET_MS * 200);
 		await Promise.all([first, second]);
 
-		const outcomes = rowsFor("lsp_aux_wait_outcome").flatMap(
-			(row) =>
-				(
-					row.metadata as {
-						outcomes?: Array<{ serverId: string; outcome: string }>;
-					}
-				)?.outcomes ?? [],
+		const outcomes = rowsFor("lsp_aux_wait_outcome").flatMap((row) =>
+			(
+				row.metadata as {
+					waitShape?: string;
+					outcomes?: Array<{ serverId: string; outcome: string }>;
+				}
+			)?.waitShape === "aux_grace"
+				? ((
+						row.metadata as {
+							outcomes?: Array<{ serverId: string; outcome: string }>;
+						}
+					)?.outcomes ?? [])
+				: [],
 		);
 		const opengrepOutcomes = outcomes
 			.filter((entry) => entry.serverId === "opengrep")


### PR DESCRIPTION
## Summary

Make cold auxiliary diagnostics waits adaptive to recorded startup cost.

For a cold auxiliary with a positive observation, the effective budget is
`min(8000, max(declaredWaitMs, observedSpawnMs + 500))`. The same budget now
reaches that auxiliary's `waitForDiagnostics` `serverTimeout` and the outer
race. Without a positive observation, the own wait keeps its declared timeout,
while the race keeps the 2,000 ms default ceiling. Warm acquisitions retain
the declared own timeout and a race ceiling of `min(declaredWaitMs, 2000)`.

`PI_LENS_AUX_GRACE_MS` remains an explicit ceiling override. Closes #2152.

## Tests

- `tests/clients/lsp/service-aux-grace.test.ts`: edits the shared client double to resolve at `min(delayMs, timeoutMs)` and publish only when the delay fits. The cold regression proves a 2,500 ms observed typos startup uses a 3,000 ms own timeout and delivers its finding. The 1,000 ms case proves the declared 1,500 ms budget remains sufficient. The 8,000 ms cap and warm behavior remain covered.
- `tests/clients/lsp/late-auxiliary-findings.test.ts`: retains late publication, clean confirmation, ceiling exhaustion, stale-content, and pair-reconciliation coverage.
- `tests/clients/lsp/pending-aux-coverage.test.ts`: retains pending-pair storage and bounded re-arm coverage.
- `tests/clients/lsp/service-race.test.ts`: retains service acquisition and race lifecycle coverage.
- `tests/clients/lsp/spawn-record-truth.test.ts`: retains spawn-record classification coverage.
- `tests/clients/lsp/service-scanner-coverage-gap.test.ts`: restores the full outcome population assertion and retains deferred-versus-silent coverage.
- `tests/clients/session-state-conformance.test.ts`: retains session-state registry conformance coverage.

The required seven-suite run passes with 192 tests.

Red-first and mutation evidence:

- Faithful-double regression on the pre-fix production path: `AssertionError: expected [ 'primary-only sentinel' ] to include 'cold aux finding'`.
- Flat-constant mutation: `AssertionError: expected 2500 to be 1500 // Object.is equality` and `AssertionError: expected 2500 to be 3000 // Object.is equality`.
- Cap mutation: `AssertionError: expected 9500 to be 8000 // Object.is equality`.

`npm run build`, `npm run lint`, `npm run fmt:check`, and
`npm run astgrep:self-scan` pass.

### Test assessment

- `tests/clients/lsp/service-aux-grace.test.ts`: uniquely pins adaptive cold arithmetic, own server timeout propagation, faithful timeout settlement, warm preservation, and cap enforcement. No test became redundant.
- `tests/clients/lsp/late-auxiliary-findings.test.ts`: uniquely pins late auxiliary delivery and bounded reconciliation. No test became redundant.
- `tests/clients/lsp/pending-aux-coverage.test.ts`: uniquely pins pending auxiliary pair lifecycle. No test became redundant.
- `tests/clients/lsp/service-race.test.ts`: uniquely pins LSP acquisition races. No test became redundant.
- `tests/clients/lsp/spawn-record-truth.test.ts`: uniquely pins spawn evidence classification. No test became redundant.
- `tests/clients/lsp/service-scanner-coverage-gap.test.ts`: uniquely pins deferred scanner coverage gaps and the complete outcome population. No test became redundant.
- `tests/clients/session-state-conformance.test.ts`: uniquely pins session-state registry conformance. No test became redundant.

## Blast radius

The change affects `LSPService.touchFile` with-auxiliary touches, auxiliary
client acquisition outcome tracking, per-server diagnostic wait setup, and the
auxiliary race timer. The production module's structural blast-radius report is
unavailable in this environment; the seven-suite run covers the affected entry
points and dependents.

Cold auxiliaries with recorded startup use `min(8000, max(declaredWaitMs,
observedSpawnMs + 500))` for both waits. Multiple cold auxiliaries run through
`Promise.all`, so their added wall-clock cost is the maximum effective budget,
not the sum: `min(8000, max(observedSpawnMs) + 500)` when observations dominate.
Warm auxiliaries retain the previous 2,000 ms race ceiling and declared own
wait. The 2,000 ms fallback race remains when no positive cold observation
exists.

## Observability

Each auxiliary still emits one bounded `lsp_aux_wait_outcome` record with its
effective race budget, elapsed time, publication evidence, and outcome. The
record distinguishes answered, silent, cut-off, and deferred auxiliaries.

The warm path is pinned by the existing warm-preservation test. This change
does not claim a measured warm p50.

## Class sweep

The defect class is a measured-startup budget that widens an outer race without
widening the promise it races. A repository search covered the touch path,
auxiliary acquisition callback, aggregation race, spawn-history readers, and
all `PI_LENS_AUX_GRACE_MS` references. The aggregation path has a separate
result-aggregation contract and no cold-acquisition callback, so it remains
unchanged.



## Review round 3 corrections

- Observability: on the new cold path the own timeout equals the race budget, so a cold-path `cut_off` count is structurally zero; the record that proves the fix in production is `lsp_aux_wait_outcome` with `waitShape=aux_grace` and `budgetMs > declared` (warm turns still produce `cut_off`).
- Blast radius, measured: a cold turn with opengrep's observed 6,342 ms spawn measures ~13.2 s touch duration (spawn + 6,842 ms aux wait) vs ~8.3 s on master; at the measured max spawn of 18,301 ms the 8 s cap puts a cold turn near 26 s worst case. Multiple cold auxes cost max, not sum.
- `PI_LENS_AUX_GRACE_MS` caps the budget on both paths and never raises it; on a cold auxiliary it now also caps the request's own wait (earlier `$/cancelRequest` than master for low values).
