### PR TITLE
fix(ci): stop duplicate merge-train warden actions (closes #2150)

### DIFF
--- a/.changelog/2150-warden-dedupe.md
+++ b/.changelog/2150-warden-dedupe.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Stop duplicate merge-train warden actions (closes #2150)** — the warden stops on a non-advancing GraphQL cursor and deduplicates PR records before applying actions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1073,8 +1073,10 @@ bounded commit-detail population opts out explicitly.
 
 The merge-train warden's GraphQL PR reader follows the same bounded-read contract:
 `fetchOpenPullRequests` preserves collected pages but records a fatal list error
-when `hasNextPage` remains true at `MAX_PAGES`. Its consumer prints that error and
-sets a nonzero exit code, while deliberately bounded sibling reads remain scoped.
+when `hasNextPage` remains true at `MAX_PAGES` or the cursor does not advance.
+It deduplicates PR numbers before `runWarden` decides or applies actions. Its
+consumer prints that error and sets a nonzero exit code, while deliberately
+bounded sibling reads remain scoped.
 
 CI validates GitHub close-keyword syntax through `scripts/check-close-keywords.mjs`:
 PR bodies may not use a comma-separated close list because GitHub applies only

--- a/scripts/lib/merge-train-warden.mjs
+++ b/scripts/lib/merge-train-warden.mjs
@@ -138,6 +138,7 @@ function normalizePr(node) {
 export async function fetchOpenPullRequests(fetcher, owner, name) {
 	const prs = [];
 	const errors = [];
+	const seenNumbers = new Set();
 	let after;
 	for (let page = 0; page < MAX_PAGES; page++) {
 		let payload;
@@ -155,15 +156,26 @@ export async function fetchOpenPullRequests(fetcher, owner, name) {
 			);
 		const connection = payload?.data?.repository?.pullRequests;
 		if (!connection || !Array.isArray(connection.nodes)) break;
-		for (const node of connection.nodes) prs.push(normalizePr(node));
+		for (const node of connection.nodes) {
+			if (seenNumbers.has(node.number)) continue;
+			seenNumbers.add(node.number);
+			prs.push(normalizePr(node));
+		}
 		if (!connection.pageInfo?.hasNextPage) break;
+		const nextCursor = connection.pageInfo.endCursor;
+		if (nextCursor == null || nextCursor === after) {
+			errors.push(
+				"GraphQL pagination truncated because cursor did not advance",
+			);
+			break;
+		}
 		if (page === MAX_PAGES - 1) {
 			errors.push(
 				`GraphQL pagination truncated after ${MAX_PAGES} pages while hasNextPage=true`,
 			);
 			break;
 		}
-		after = connection.pageInfo.endCursor;
+		after = nextCursor;
 	}
 	return { prs, errors };
 }

--- a/scripts/lib/merge-train-warden.mjs
+++ b/scripts/lib/merge-train-warden.mjs
@@ -157,7 +157,12 @@ export async function fetchOpenPullRequests(fetcher, owner, name) {
 		const connection = payload?.data?.repository?.pullRequests;
 		if (!connection || !Array.isArray(connection.nodes)) break;
 		for (const node of connection.nodes) {
-			if (seenNumbers.has(node.number)) continue;
+			if (seenNumbers.has(node.number)) {
+				errors.push(
+					`GraphQL pagination repeated PR #${node.number} across pages; collection may be incomplete`,
+				);
+				continue;
+			}
 			seenNumbers.add(node.number);
 			prs.push(normalizePr(node));
 		}

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -594,8 +594,16 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 
 	it("does not return or process the same PR twice across distinct pages", async () => {
 		const pages = [
-			graphqlPage([prNode({ number: 7 })], true, "cursor-1"),
-			graphqlPage([prNode({ number: 7 })], false, "cursor-2"),
+			graphqlPage(
+				[prNode({ number: 7 }), prNode({ number: 8 })],
+				true,
+				"cursor-1",
+			),
+			graphqlPage(
+				[prNode({ number: 8 }), prNode({ number: 9 })],
+				false,
+				"cursor-2",
+			),
 		];
 		const calls: unknown[] = [];
 		const fetcher = async (_url: string, init?: { body?: string }) => {
@@ -608,8 +616,11 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 			};
 		};
 		const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
-		expect(result.prs).toHaveLength(1);
-		expect(result.prs[0].number).toBe(7);
+		expect(result.prs).toHaveLength(3);
+		expect(result.prs.map(({ number }) => number)).toEqual([7, 8, 9]);
+		expect(result.errors).toEqual([
+			"GraphQL pagination repeated PR #8 across pages; collection may be incomplete",
+		]);
 	});
 
 	it("decides actions once when pagination repeats a PR", async () => {

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -578,6 +578,59 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 		expect(result.errors).toEqual([]);
 	});
 
+	// #2150: a repeating/null endCursor must not make the collector replay a
+	// page. The error keeps the partial result visibly truncated.
+	it("stops on a non-advancing cursor and keeps one copy of the PR", async () => {
+		const { fetcher, calls } = fakeGithub({
+			"POST /graphql": graphqlPage([prNode()], true, null),
+		});
+		const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(calls).toHaveLength(1);
+		expect(result.prs).toHaveLength(1);
+		expect(result.errors).toEqual([
+			"GraphQL pagination truncated because cursor did not advance",
+		]);
+	});
+
+	it("does not return or process the same PR twice across distinct pages", async () => {
+		const pages = [
+			graphqlPage([prNode({ number: 7 })], true, "cursor-1"),
+			graphqlPage([prNode({ number: 7 })], false, "cursor-2"),
+		];
+		const calls: unknown[] = [];
+		const fetcher = async (_url: string, init?: { body?: string }) => {
+			const body = JSON.parse(init?.body ?? "{}");
+			calls.push(body);
+			return {
+				ok: true,
+				status: 200,
+				json: async () => pages[calls.length - 1],
+			};
+		};
+		const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
+		expect(result.prs).toHaveLength(1);
+		expect(result.prs[0].number).toBe(7);
+	});
+
+	it("decides actions once when pagination repeats a PR", async () => {
+		const { fetcher, calls } = fakeGithub({
+			"POST /graphql": graphqlPage([prNode()], true, null),
+		});
+		await runWarden({ fetcher, owner: "acme", repo: "repo" });
+		expect(
+			calls.filter(
+				({ method, url }) =>
+					method === "POST" && url.endsWith("/issues/7/labels"),
+			),
+		).toHaveLength(1);
+		expect(
+			calls.filter(
+				({ method, url }) =>
+					method === "POST" && url.endsWith("/issues/7/comments"),
+			),
+		).toHaveLength(1);
+	});
+
 	it("applyAction issues the exact REST call for each action type", async () => {
 		const { fetcher, calls } = fakeGithub({});
 		const record = pr({ number: 5, headSha: "abc123" });


### PR DESCRIPTION
﻿### Summary

Fixes #2150 by stopping GraphQL pagination when `hasNextPage` is true but `endCursor` is null or unchanged. The collector also deduplicates PR numbers before action decisions. Every acceptance criterion is complete.

The ambiguity in the first acceptance criterion is resolved using the existing warden pagination convention: a non-advancing cursor is classified as truncation, preserves collected records, and makes the sweep nonzero. The implementation also deduplicates numbers across distinct pages.

### Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

### Area

- [ ] area:lsp
- [x] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

### Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (run `npm install` after dep changes)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there
- [x] `.changelog/2150-warden-dedupe.md` has one valid entry in this PR
- [x] Commit subject includes the issue number: `(closes #NNN)` or `(refs #NNN)`

### Tests

- `tests/scripts/merge-train-warden.test.ts`: added a null-cursor regression test. It pins one fetch, one retained PR, and the truncation classification.
- `tests/scripts/merge-train-warden.test.ts`: added a distinct-page duplicate test. It pins number-based collector deduplication.
- `tests/scripts/merge-train-warden.test.ts`: added a repeated-page action test. It pins one label and one comment action per PR.
- Pre-fix red: `AssertionError: expected [ { method: 'POST', …(2) }, …(3) ] to have a length of 1 but got 4` at `tests/scripts/merge-train-warden.test.ts:588:17`.
- Pre-fix red: `AssertionError: expected [ { number: 7, …(9) }, …(1) ] to have a length of 1 but got 2` at `tests/scripts/merge-train-warden.test.ts:611:22`.
- Pre-fix red: `AssertionError: expected [ { method: 'POST', …(2) }, …(3) ] to have a length of 1 but got 4` at `tests/scripts/merge-train-warden.test.ts:625:5`.
- Mutation red for cursor guard: the fetch-count assertion reported `expected [ { method: 'POST', …(2) }, …(3) ] to have a length of 1 but got 4`.
- Mutation red for number guard: `AssertionError: expected [ { number: 7, …(9) }, …(1) ] to have a length of 1 but got 2` at line 611.
- The tests enter through `fetchOpenPullRequests` and `runWarden`, use independent GraphQL fixtures, and assert counts and error classification. They avoid invisible skips, implementation mirrors, and snapshots.

### Test assessment

- `tests/scripts/merge-train-warden.test.ts`: uniquely pins pagination safety and one-action-per-PR behavior. No existing test became redundant; the prior MAX_PAGES tests cover exhaustion bounds, not cursor progress or deduplication.

### Blast radius

- `scripts/lib/merge-train-warden.mjs`: affects the scheduled and manually dispatched `.github/workflows/merge-train-warden.yml` entry point through `runWarden`, specifically GraphQL collection and downstream REST annotations. `module_report` with `blastRadius: true` is unavailable in this environment, so the callback and dependent map was verified by direct search. The change is sweep-bounded, not a per-file or per-spawn hot path.
- `AGENTS.md`, `.changelog/2150-warden-dedupe.md`, and the existing test file have no production callback blast radius.

### Observability

The existing fatal list-error result records `GraphQL pagination truncated because cursor did not advance`; the CLI prints it and exits nonzero. The per-PR result records each applied label/comment, so duplicate actions remain visible. Cross-page duplicate detection is recorded in Fix round 1 because the previous implementation dropped it silently.

### Class sweep

This fix covers AGENTS.md defect shape 10, silencing counted as fixing, and the bounded-read pagination contract in the Host integration and repo automation section. A whole-tree pattern sweep searched `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts` for pagination loops, `hasNextPage`, `endCursor`, and page collectors. The only matching production GraphQL PR collector is `scripts/lib/merge-train-warden.mjs`; REST pagination uses the separate shared bounded helper and remains covered by its own tests. The population sweep therefore has one member: warden GraphQL collection, fixed here. The consolidation verdict is to keep GraphQL collection local because its fatal truncation result and PR normalization contract differ from the REST helper.

## Fix round 1

### Summary

Record cross-page duplicate PR numbers as a possible incomplete collection. A repeated number can mean GitHub's page window slid while pagination was in progress, allowing another PR to fall out of the collected results.

### Tests

- `tests/scripts/merge-train-warden.test.ts`: changed the duplicate-page fixture to pages `[7, 8]` then `[8, 9]`; it asserts PRs `[7, 8, 9]` and the bounded error record.
- Pre-fix red: `AssertionError: expected [] to deeply equal [ Array(1) ]` at `tests/scripts/merge-train-warden.test.ts:621:25`.
- Mutation red after removing the new error record: `AssertionError: expected [] to deeply equal [ Array(1) ]` at `tests/scripts/merge-train-warden.test.ts:621:25`.
- Final targeted result: `tests/scripts/merge-train-warden.test.ts` passed with 36 tests.

### Blast radius

The change is limited to duplicate detection in `fetchOpenPullRequests`; downstream PR normalization and action decisions remain unchanged.

### Class sweep

The existing pagination sweep still has one production GraphQL PR collector. Its sibling safeguards for maximum pages and non-advancing cursors already record errors; this round brings cross-page duplicate detection into the same visible failure contract.

### Observability

The previous “No new telemetry gap is introduced” claim is superseded. Duplicate page-window detection now emits the bounded collector error `GraphQL pagination repeated PR #N across pages; collection may be incomplete`, preserving the PR number and possible incompleteness for the CLI summary and nonzero result.

### Test assessment

- `tests/scripts/merge-train-warden.test.ts`: the edited case uniquely pins duplicate-window observability and partial collection; no test became redundant.

