### PR TITLE
fix(lsp): use publication timestamps for primary sync racer (closes #2161)

### DIFF
--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -4859,7 +4859,7 @@ export class LSPService {
 						// its wait is about to settle on) — nothing to confirm, no sync
 						// request goes out.
 						const publishedAt = primaryClient
-							.getAllDiagnostics()
+							.getAllDiagnostics?.()
 							.get(normalizedPath)?.ts;
 						if (
 							pushWaitSettled ||

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -4858,18 +4858,9 @@ export class LSPService {
 						// Push already answered (settled, or published diagnostics that
 						// its wait is about to settle on) — nothing to confirm, no sync
 						// request goes out.
-						let publishedAt: number | undefined;
-						try {
-							publishedAt = primaryClient
-								.getAllDiagnostics()
-								.get(normalizedPath)?.ts;
-						} catch {
-							recordDegradationOnce({
-								kind: "lsp-diagnostics-timeout",
-								subject: `${primaryClient.serverId}:${normalizedPath}`,
-								reason: "primary sync publication probe unavailable",
-							});
-						}
+						const publishedAt = primaryClient
+							.getAllDiagnostics()
+							.get(normalizedPath)?.ts;
 						if (
 							pushWaitSettled ||
 							(publishedAt !== undefined && publishedAt > markedAtMs)

--- a/tests/clients/lsp/service-tsserver-sync-confirm.test.ts
+++ b/tests/clients/lsp/service-tsserver-sync-confirm.test.ts
@@ -425,6 +425,36 @@ describe("#707 per-edit tsserver sync clean-confirm in touchFile", () => {
 			expect(result?.diags).toEqual([]);
 		});
 
+		it("stale empty publication before grace: launches the sync racer", async () => {
+			process.env.PI_LENS_TSSERVER_SYNC_GRACE_MS = "10";
+			const executeCommand = vi.fn();
+			const stalePublishedAt = Date.now() - 1_000;
+			const client = makeClient({
+				executeCommand: executeCommand.mockImplementation(makeSyncResponse({})),
+				waitForDiagnostics: vi.fn(() => new Promise(() => {})), // push pinned
+				getAllDiagnostics: () =>
+					new Map([
+						[normalizeMapKey(FILE), { diags: [], ts: stalePublishedAt }],
+					]),
+			});
+			createLSPClient.mockResolvedValue(client);
+			getServersForFileWithConfig.mockReturnValue([makeServer("typescript")]);
+
+			const { LSPService } = await import("../../../clients/lsp/index.js");
+			const service = new LSPService();
+
+			const result = await service.touchFile(FILE, "missingSymbol();\n", {
+				clientScope: "primary",
+				diagnostics: "document",
+				collectDiagnostics: true,
+				maxDiagnosticsWaitMs: 5000,
+				source: "test-2161-stale-clean-publication",
+			});
+
+			expect(executeCommand).toHaveBeenCalled();
+			expect(result?.diags).toEqual([]);
+		});
+
 		it("dirty file: racing sync winner surfaces the diagnostics, not discarded", async () => {
 			process.env.PI_LENS_TSSERVER_SYNC_GRACE_MS = "25";
 			const syncDiag = {


### PR DESCRIPTION
## Summary

Fixes #2161. The primary tsserver sync racer now treats a result as answered only when its per-file diagnostic publication timestamp is newer than the touch mark. A fresh empty publication therefore confirms clean, while absent or older publication evidence still allows the sync confirmation path to run.

The guard mutation was red: changing `publishedAt > markedAtMs` to `publishedAt <= markedAtMs` produced two unwanted `typescript.tsserverRequest` calls in the regression test.

## Tests

- `tests/clients/lsp/service-tsserver-sync-confirm.test.ts` adds a real `touchFile` regression for a fresh empty primary publication and asserts that the sync racer is not launched.
- `npm run build` passes.
- `npm run lint` passes.
- `npm run fmt:check` passes.
- Targeted LSP, cascade, session-state conformance, and index-wiring suites pass: 8 files, 215 tests.

### Test assessment

- `tests/clients/lsp/service-tsserver-sync-confirm.test.ts` uniquely pins primary sync-racer publication evidence, including the clean empty-publication case. Existing racing, fallback, dirty, and capability cases remain non-redundant.

## Blast radius

- `clients/lsp/index.ts` affects the primary-only `touchFile` tsserver sync racer. It reads the existing per-file `{ diags, ts }` cache entry once after the grace delay and uses the optional-call convention for fail-closed test doubles.
- A stale non-empty publication now lets the racer fire where the old `length > 0` read suppressed it. This is the documented post-write debounce path, so some touches gain sync requests they previously skipped; the #707 zero-new-requests-on-push-answers contract is narrowed accordingly.
- The branch was re-merged with `origin/master` before verification and push.

## Class sweep

This is AGENTS.md defect shape 10, with related screens from shapes 13, 17, and 18. I swept `clients/` for cached `getDiagnostics(...).length > 0` and empty-as-answered branches.

- `clients/lsp/index.ts` primary sync racer: fixed with per-file publication timestamp evidence.
- `clients/lsp/index.ts` late-auxiliary probe: already uses `{ diags, publishedAt }` and remains correct.
- `clients/lsp/cascade-tier.ts`: already checks per-file entry presence and timestamp and remains the precedent.
- Other `clients/` length checks operate on already-derived findings, output formatting, or collection filters; none use zero length as proof that an LSP producer answered.

## Observability

Existing timeout latency records retain the unanswered-server identity. Production proof is a fresh per-file publication timestamp greater than the touch mark, including when the published diagnostics array is empty.

## Fix round 1

- F2: Deleted the vacuous `getAllDiagnostics()` try/catch and degradation branch. The required interface method reads in-memory state and cannot throw in production.
- F3: Documented the narrowed #707 contract in Blast radius.
- F4: This fix-round commit uses the requested subject, wrapping, and trailers.

## Fix round 2

- N1: Added the reviewer-specified stale empty-publication regression. The presence-only timestamp mutation reds with `Test timed out in 5000ms (the suppressed racer leaves the pinned push wait unsettled, so touchFile hangs past the budget — the mutation reds by hang, not by assertion)`.
- N2: Made the racer’s `getAllDiagnostics` read optional so older test doubles fail closed.
- N3: Updated the Blast-radius wording to describe the optional-call convention.

