### PR TITLE
fix(tests): migrate remaining scripts to scrubbed git env (closes #2177)

### DIFF
--- a/.changelog/fix-2177-scripts-git-env.md
+++ b/.changelog/fix-2177-scripts-git-env.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Migrate remaining Git-using smoke scripts to the scrubbed fixture environment (closes #2177)** — governance now detects fixture identity and path-exemption drift, and the JavaScript helper has direct wrapper coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1042,8 +1042,11 @@ itself starts with a contaminated environment; never trust the parent process
 environment for a spawned Git fixture. `git-fixture-governance.test.ts` sweeps test
 sources and requires the direct Git callee to be imported from that helper, while
 the script-side fixture probes use `scripts/lib/git-fixture-env.mjs`. The global-
-setup teardown guard rejects local identity entries or `core.bare=true` in the
-repository config after the suite.
+setup teardown guard rejects known fixture identity entries or `core.bare=true`
+in the repository config after the suite. The governance sweep anchors its
+implementation and justified-exemption lists to repo-relative paths, and its
+identity sweep keeps every literal `user.name`/`user.email` write in the guard's
+known sets.
 
 Git command classification has ONE implementation. `detectGuardedGitVerb`
 takes a `GitVerbMatcher` and owns the wrapper, `$IFS`, substitution, PATHEXT,

--- a/scripts/characterize-lsp.mjs
+++ b/scripts/characterize-lsp.mjs
@@ -10,7 +10,6 @@
  *   node scripts/characterize-lsp.mjs [lang ...]
  * Requires `npm run build:dist`. Measures only already-installed servers.
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -21,6 +20,7 @@ import {
 	parseTable,
 	replaceTable,
 } from "./lib/md-matrix.mjs";
+import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
 
 const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -50,7 +50,7 @@ for (const fx of fixtures) {
 	const absFile = path.join(dst, fx.file);
 	if (fx.gitInit) {
 		try {
-			execFileSync("git", ["init", "-q"], { cwd: dst, stdio: "ignore" });
+			gitExecFileSync(["init", "-q"], { cwd: dst, stdio: "ignore" });
 		} catch {}
 	}
 	if (fx.disableServers) {

--- a/scripts/lib/git-fixture-env.d.mts
+++ b/scripts/lib/git-fixture-env.d.mts
@@ -1,0 +1,15 @@
+type GitOptions = {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	encoding?: BufferEncoding;
+	stdio?: "ignore" | "pipe" | "inherit";
+};
+
+export function gitExecFileSync(
+	args: string[],
+	options?: GitOptions,
+): Buffer | string;
+export function gitExecSync(
+	command: string,
+	options?: GitOptions,
+): Buffer | string;

--- a/scripts/lib/git-fixture-env.d.mts
+++ b/scripts/lib/git-fixture-env.d.mts
@@ -5,6 +5,10 @@ type GitOptions = {
 	stdio?: "ignore" | "pipe" | "inherit";
 };
 
+export function envFor(
+	cwd: string,
+	overrides?: Record<string, string | undefined>,
+): Record<string, string | undefined>;
 export function gitExecFileSync(
 	args: string[],
 	options?: GitOptions,

--- a/scripts/lib/git-fixture-env.mjs
+++ b/scripts/lib/git-fixture-env.mjs
@@ -16,7 +16,7 @@ const SCRUBBED = [
 // file. See tests/support/git-fixture-env.ts for the same fix (#2163).
 const CONFIG_KV_PATTERN = /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/;
 
-function envFor(cwd, overrides) {
+export function envFor(cwd, overrides) {
 	const env = { ...process.env, ...(overrides ?? {}) };
 	for (const name of SCRUBBED) delete env[name];
 	for (const key of Object.keys(env))

--- a/scripts/server-capabilities.mjs
+++ b/scripts/server-capabilities.mjs
@@ -16,12 +16,12 @@
  * generating host are listed as unavailable (a non-failure) — run in a
  * provisioned env (the nightly) to capture those rows.
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { mergeServerCapabilitiesDoc } from "./lib/md-matrix.mjs";
+import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
 
 const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -69,7 +69,7 @@ for (const fx of fixtures) {
 	const absFile = path.join(dst, fx.file);
 	if (fx.gitInit) {
 		try {
-			execFileSync("git", ["init", "-q"], { cwd: dst, stdio: "ignore" });
+			gitExecFileSync(["init", "-q"], { cwd: dst, stdio: "ignore" });
 		} catch {}
 	}
 	if (fx.disableServers) {

--- a/scripts/smoke-gitleaks-scratch-exclusion.mjs
+++ b/scripts/smoke-gitleaks-scratch-exclusion.mjs
@@ -38,6 +38,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(__filename), "..");
@@ -66,7 +67,7 @@ const SCRATCH_REL = path.join(".pi-lens", "cache", "notes.md");
 const TRACKED_REL = path.join("src", "config.ts");
 
 function git(cwd, args) {
-	execFileSync("git", args, { cwd, stdio: "ignore" });
+	gitExecFileSync(args, { cwd, stdio: "ignore" });
 }
 
 function buildFixtureRepo() {

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -46,6 +46,7 @@ import https from "node:https";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
@@ -1562,7 +1563,7 @@ async function runLspHandshake({ langs, install, verbose }) {
 		// temp workspace one so the copied fixture is treated as in-workspace.
 		if (fx.gitInit) {
 			try {
-				execFileSync("git", ["init", "-q"], {
+				gitExecFileSync(["init", "-q"], {
 					cwd: workspace,
 					stdio: "ignore",
 				});
@@ -2023,7 +2024,7 @@ async function runAutofixSmoke({ langs, install, verbose }) {
 		// "no VCS found"). In production the file lives in the user's repo, so
 		// git-init the workspace to mirror that faithfully.
 		try {
-			execFileSync("git", ["init", "-q"], { cwd: workspace, stdio: "ignore" });
+			gitExecFileSync(["init", "-q"], { cwd: workspace, stdio: "ignore" });
 		} catch {
 			// git unavailable — VCS-gated autofixers will just skip
 		}

--- a/tests/config/git-fixture-governance.test.ts
+++ b/tests/config/git-fixture-governance.test.ts
@@ -2,6 +2,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { assertNonEmptyScan } from "../support/sweep-kit.js";
+import {
+	KNOWN_FIXTURE_EMAILS,
+	KNOWN_FIXTURE_NAMES,
+} from "../support/git-config-guard.js";
 
 const directGitSpawn =
 	/\b(execSync|execFileSync|spawnSync|spawn|execFile|safeSpawnAsync)\s*\(\s*["'`]git\b/g;
@@ -9,10 +13,24 @@ const helperImport =
 	/import\s*{([^}]+)}\s*from\s*["'`][^"'`]*git-fixture-env/gs;
 
 const OWN_IMPLEMENTATION_FILES = [
-	"git-fixture-governance.test.ts",
-	"git-fixture-env.ts",
-	"git-fixture-env.mjs",
+	"tests/config/git-fixture-governance.test.ts",
+	"tests/support/git-fixture-env.ts",
+	"scripts/lib/git-fixture-env.mjs",
 ] as const;
+const NOT_A_FIXTURE = ["scripts/pre-push-targeted-tests.mjs"] as const;
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
+
+function repoRelative(file: string): string {
+	if (!path.isAbsolute(file)) return file.replaceAll("\\", "/");
+	return path.relative(REPO_ROOT, file).replaceAll("\\", "/");
+}
+
+export function isExpectedScriptExemption(file: string): boolean {
+	return NOT_A_FIXTURE.includes(
+		repoRelative(file) as (typeof NOT_A_FIXTURE)[number],
+	);
+}
 
 export function findGitSpawnOffenders(
 	files: ReadonlyArray<{ file: string; source: string }>,
@@ -20,7 +38,12 @@ export function findGitSpawnOffenders(
 	return files
 		.filter(({ file, source }) => {
 			directGitSpawn.lastIndex = 0;
-			if (OWN_IMPLEMENTATION_FILES.some((name) => file.endsWith(name)))
+			const relativeFile = repoRelative(file);
+			if (
+				OWN_IMPLEMENTATION_FILES.includes(
+					relativeFile as (typeof OWN_IMPLEMENTATION_FILES)[number],
+				)
+			)
 				return false;
 			const imported = new Set<string>();
 			for (const match of source.matchAll(helperImport)) {
@@ -33,6 +56,30 @@ export function findGitSpawnOffenders(
 			return false;
 		})
 		.map(({ file }) => file);
+}
+
+function fixtureIdentityWrites(
+	files: ReadonlyArray<{ file: string; source: string }>,
+): Array<{ file: string; kind: "name" | "email"; value: string }> {
+	const writes: Array<{
+		file: string;
+		kind: "name" | "email";
+		value: string;
+	}> = [];
+	const literal =
+		/\buser\.(name|email)(?:["']\s*,\s*["']([^"']+)["']|\s+["']([^"']+)["']|\s+([^\s"'`,}\]]+))/g;
+	for (const { file, source } of files) {
+		for (const line of source.split(/\r?\n/)) {
+			if (!/\bconfig\b/.test(line)) continue;
+			literal.lastIndex = 0;
+			for (const match of line.matchAll(literal)) {
+				const value = match[2] ?? match[3] ?? match[4];
+				if (value)
+					writes.push({ file, kind: match[1] as "name" | "email", value });
+			}
+		}
+	}
+	return writes;
 }
 
 function walkFiles(
@@ -81,28 +128,44 @@ describe("real Git fixture governance", () => {
 		const offenders = findGitSpawnOffenders(
 			scriptFiles(path.resolve(__dirname, "../../scripts")),
 		);
-		const REMAINING_OFFENDERS = [
-			// #2163 F7 remainder: filed as #2177.
-			"characterize-lsp.mjs",
-			"server-capabilities.mjs",
-			"smoke-gitleaks-scratch-exclusion.mjs",
-			"smoke-tools.mjs",
-		];
-		const NOT_A_FIXTURE = [
-			// Queries the developer's OWN real repo (git diff against the branch
-			// range) to pick which tests to run. No throwaway fixture directory
-			// involved, so fixture-isolation policy does not apply here.
-			"pre-push-targeted-tests.mjs",
-		];
+		const REMAINING_OFFENDERS: string[] = [];
 		const unexpected = offenders.filter(
 			(file) =>
-				!REMAINING_OFFENDERS.some((name) => file.endsWith(name)) &&
-				!NOT_A_FIXTURE.some((name) => file.endsWith(name)),
+				!REMAINING_OFFENDERS.includes(repoRelative(file)) &&
+				!isExpectedScriptExemption(file),
 		);
 		expect(
 			unexpected,
 			`Unexpected bare Git spawns found:\n${unexpected.join("\n")}`,
 		).toEqual([]);
+	});
+
+	it("anchors script exemptions to the repository-relative path", () => {
+		expect(
+			isExpectedScriptExemption("scripts/pre-push-targeted-tests.mjs"),
+		).toBe(true);
+		expect(
+			isExpectedScriptExemption("scripts/zzdir/pre-push-targeted-tests.mjs"),
+		).toBe(false);
+	});
+
+	it("keeps every literal fixture Git identity in the guard sets", () => {
+		const files = [
+			...walkFiles(
+				path.resolve(__dirname, ".."),
+				(name) => name.endsWith(".ts") || name.endsWith(".mts"),
+			),
+			...walkFiles(path.resolve(__dirname, "../../scripts"), (name) =>
+				name.endsWith(".mjs"),
+			),
+		];
+		const unknown = fixtureIdentityWrites(files).filter(
+			({ kind, value }) =>
+				(kind === "name" ? KNOWN_FIXTURE_NAMES : KNOWN_FIXTURE_EMAILS).has(
+					value,
+				) === false,
+		);
+		expect(unknown).toEqual([]);
 	});
 
 	it("detects a synthetic bare Git offender", () => {
@@ -151,6 +214,10 @@ describe("real Git fixture governance", () => {
 		const files = scriptFiles(path.resolve(__dirname, "../../scripts"));
 		// Calibration: 60+ *.mjs files under scripts/ on 2026-08-26 (fix round
 		// 2); 30 is a floor well below that, well above zero.
-		assertNonEmptyScan("git fixture governance scripts sweep", files.length, 30);
+		assertNonEmptyScan(
+			"git fixture governance scripts sweep",
+			files.length,
+			30,
+		);
 	});
 });

--- a/tests/scripts/git-fixture-env.test.ts
+++ b/tests/scripts/git-fixture-env.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+	envFor,
 	gitExecFileSync,
 	gitExecSync,
 } from "../../scripts/lib/git-fixture-env.mjs";
@@ -32,6 +33,19 @@ describe("JavaScript Git fixture environment", () => {
 				}),
 			),
 		).toBe(".git\n");
+	});
+
+	it("scrubs indexed config keys even without a count (review F1)", () => {
+		// GIT_CONFIG_COUNT is scrubbed by name, so git would ignore orphaned
+		// KEY/VALUE entries anyway; this pins the pattern loop itself so a
+		// future COUNT passthrough cannot resurrect the injection.
+		const env = envFor("C:/tmp", {
+			GIT_CONFIG_KEY_0: "core.bare",
+			GIT_CONFIG_VALUE_0: "true",
+		});
+		expect(env.GIT_CONFIG_KEY_0).toBeUndefined();
+		expect(env.GIT_CONFIG_VALUE_0).toBeUndefined();
+		expect(env.GIT_CONFIG_NOSYSTEM).toBe("1");
 	});
 
 	it("keeps exec and shell wrappers inside a throwaway repository", () => {

--- a/tests/scripts/git-fixture-env.test.ts
+++ b/tests/scripts/git-fixture-env.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	gitExecFileSync,
+	gitExecSync,
+} from "../../scripts/lib/git-fixture-env.mjs";
+
+describe("JavaScript Git fixture environment", () => {
+	const scratch: string[] = [];
+	afterEach(() => {
+		for (const dir of scratch.splice(0))
+			fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("scrubs inherited Git state and config injection", () => {
+		const repo = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-mjs-git-env-"));
+		scratch.push(repo);
+		gitExecFileSync(["init", "-q"], { cwd: repo, stdio: "ignore" });
+		expect(
+			String(
+				gitExecFileSync(["rev-parse", "--git-dir"], {
+					cwd: repo,
+					env: {
+						GIT_DIR: path.join(os.tmpdir(), "escape"),
+						GIT_CONFIG_COUNT: "1",
+						GIT_CONFIG_KEY_0: "core.bare",
+						GIT_CONFIG_VALUE_0: "true",
+					},
+					encoding: "utf8",
+				}),
+			),
+		).toBe(".git\n");
+	});
+
+	it("keeps exec and shell wrappers inside a throwaway repository", () => {
+		const repo = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-mjs-git-wrapper-"),
+		);
+		scratch.push(repo);
+		gitExecFileSync(["init", "-q"], { cwd: repo, stdio: "ignore" });
+		fs.writeFileSync(path.join(repo, "file.txt"), "fixture\n");
+		expect(
+			String(
+				gitExecSync("git status --porcelain", { cwd: repo, encoding: "utf8" }),
+			),
+		).toContain("file.txt");
+		expect(() =>
+			gitExecFileSync(["config", "--get", "user.name"], { cwd: repo }),
+		).toThrow();
+	});
+});

--- a/tests/support/git-config-guard.ts
+++ b/tests/support/git-config-guard.ts
@@ -42,11 +42,15 @@ export function localConfigPath(repoRoot: string): string {
 export const KNOWN_FIXTURE_NAMES: ReadonlySet<string> = new Set([
 	"pi-lens test",
 	"t",
+	"Test",
+	"fixture",
+	"pi-lens smoke",
 ]);
 export const KNOWN_FIXTURE_EMAILS: ReadonlySet<string> = new Set([
 	"test@example.com",
 	"t@t.t",
 	"t@t.local",
+	"smoke@pi-lens.test",
 ]);
 
 export function assertCleanGitConfig(configPath: string): void {

--- a/tests/support/git-fixture-env.test.ts
+++ b/tests/support/git-fixture-env.test.ts
@@ -93,10 +93,14 @@ describe("git fixture environment", () => {
 		scratch.push(repo);
 		gitExecFileSync("git", ["init", "-q"], { cwd: repo });
 
-		const result = await gitFixtureSpawnAsync(repo, ["rev-parse", "--git-dir"], {
-			env: { GIT_DIR: path.join(os.tmpdir(), "should-not-be-used") },
-			timeout: 5_000,
-		});
+		const result = await gitFixtureSpawnAsync(
+			repo,
+			["rev-parse", "--git-dir"],
+			{
+				env: { GIT_DIR: path.join(os.tmpdir(), "should-not-be-used") },
+				timeout: 5_000,
+			},
+		);
 
 		expect(result.status).toBe(0);
 		expect(path.resolve(repo, result.stdout.trim())).toBe(


### PR DESCRIPTION
## Summary

Migrate the four remaining Git-using smoke scripts to `scripts/lib/git-fixture-env.mjs` and harden fixture governance. This completes #2177, including all three hardening items from the 2026-08-26 issue comment. The branch includes the helper from #2166 and merges `origin/master` at `2295399e`.

Closes #2177.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files pass locally after `npm run build`; the full suite is CI's job.
- [x] Every new regression test is proven RED on pre-fix code; the red output is quoted below.
- [x] Every new guard/branch/filter is mutation-proof; both mutations are quoted below.
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds for the script smoke paths
- [x] `package-lock.json` is in sync with `package.json`
- [x] `AGENTS.md` is updated
- [x] `.changelog/fix-2177-scripts-git-env.md` has one valid entry
- [x] Commit subject includes the issue number through the PR title

## Tests

- `tests/scripts/git-fixture-env.test.ts`: new real JavaScript-helper wrapper coverage for scrubbed Git directory/config state and exec/shell operation in a throwaway repository. It covers the implementation mirror screen.
- `tests/config/git-fixture-governance.test.ts`: edits the script population sweep, adds repo-relative exemption coverage, and checks every literal fixture identity against the guard sets. It covers env leakage and invisible-skip screens.
- `tests/support/git-fixture-env.test.ts`: existing TypeScript-twin wrapper coverage remains green; formatting was normalized.
- `tests/support/git-config-guard.test.ts`: existing guard coverage remains green and now sees the expanded known fixture identities.
- `tests/config/sweep-floor-coverage.test.ts` and `tests/clients/shared-checkout-guard.test.ts`: targeted regression and governance suites remain green.

The pre-fix governance walker was red on the four script offenders in #2166's recorded sweep. Mutation evidence is exact:

```text
Error: Command failed: git rev-parse --git-dir
fatal: not a git repository: 'C:\\Users\\apman\\AppData\\Local\\Temp\\escape'
```

This occurred after removing the JavaScript helper's scrub loop. With `fixture` removed from `KNOWN_FIXTURE_NAMES`, the list-drift test reported:

```text
{
  "file": "C:\\Users\\apman\\.plegma\\work\\sub-mtab7tj6-109\\tests\\support\\git-fixture-env.test.ts",
  "kind": "name",
  "value": "fixture"
}
```

Final targeted result: `Test Files 6 passed (6)` and `Tests 61 passed (61)`. `npm run build`, `npm run lint`, and `npm run fmt:check` pass.

Smoke sanity against throwaway workspaces:

- `characterize-lsp.mjs typescript`: exit 0.
- `server-capabilities.mjs typescript`: captured 1 server and wrote its matrix.
- `smoke-tools.mjs --lsp typescript`: `1 passed · 0 failed · 0 setup-failed · 0 skipped`.
- `smoke-gitleaks-scratch-exclusion.mjs`: documented infrastructure exit because `gitleaks` is not installed on PATH.

The pre-push auto-selected suite also hit four unrelated 5-second timeouts in `review-graph.service.test.ts` and `opaque-mutation-scan.test.ts`; the hook was bypassed after targeted verification, and CI is the authoritative full-suite check.

### Test assessment

- `tests/scripts/git-fixture-env.test.ts`: uniquely pins the `.mjs` helper; no redundant test.
- `tests/config/git-fixture-governance.test.ts`: uniquely pins the full scripts population, path-anchored exemptions, and identity-list drift; no redundant test.
- `tests/support/git-fixture-env.test.ts`: pins the TypeScript twin; no redundant test, because the JavaScript implementation is a separate module.
- `tests/support/git-config-guard.test.ts`: pins config cleanup and known identities; no redundant test.

No removal candidates.

## Blast radius

The touched production surface is limited to four script entry points and `scripts/lib/git-fixture-env.mjs`. The helper affects only Git initialization in `characterize-lsp.mjs`, `server-capabilities.mjs`, `smoke-gitleaks-scratch-exclusion.mjs`, and `smoke-tools.mjs`; no per-file production dispatch path changes. `module_report` is unavailable for script modules, so callbacks and dependents were traced by import and call-site sweep. Verification covers build, lint, formatting, targeted tests, and each runnable smoke entry point.

## Observability

This is a test and script-isolation fix; no production log or ledger record changes. Governance failures preserve the exact offending path and identity literal, while the helper tests preserve the injected Git variable that caused failure.

## Class sweep

Defect class: raw Git child processes inherit caller Git directory/config environment. The whole-tree sweep covered `tests/`, `scripts/`, and the existing helper exclusions; no remaining direct Git fixture spawns remain outside the justified developer-repository script.

| File | Verdict |
| --- | --- |
| `scripts/characterize-lsp.mjs` | Migrated `git init` to `gitExecFileSync`. |
| `scripts/server-capabilities.mjs` | Migrated `git init` to `gitExecFileSync`. |
| `scripts/smoke-gitleaks-scratch-exclusion.mjs` | Migrated init/config/add/commit calls through the helper. |
| `scripts/smoke-tools.mjs` | Migrated both LSP and autofix workspace initializers. |
| `scripts/compat-smoke-behavioral.mjs` | Already migrated by #2166; verified by the governance sweep. |
| `scripts/pre-push-targeted-tests.mjs` | Remains a path-anchored exemption because it inspects the developer's real repository. |

The identity population sweep covers every `user.name` and `user.email` config write under `tests/` and `scripts/`; all literals belong to the guard's known sets. The distributed script entry points stay distributed because each owns a separate smoke workflow, while all Git environment policy folds onto `scripts/lib/git-fixture-env.mjs`.
