### PR TITLE
fix(installer): bound vue-language-server verification probe (refs #2176)

### DIFF
--- a/.changelog/fix-2176-vue-probe-budget.md
+++ b/.changelog/fix-2176-vue-probe-budget.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Bound the Vue language-server verification probe (closes #2176)** — the managed Vue registry entry now gives its cold-start `--version` probe a 30-second per-tool ceiling, while all other tools retain the 10-second installer default.

--- a/.changelog/fix-2176-vue-probe-budget.md
+++ b/.changelog/fix-2176-vue-probe-budget.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Bound the Vue language-server verification probe (closes #2176)** — the managed Vue registry entry now gives its cold-start `--version` probe a 30-second per-tool ceiling, while all other tools retain the 10-second installer default.
+- **Bound the Vue language-server verification probe (refs #2176)** — the managed Vue registry entry now gives its cold-start `--version` probe a 30-second per-tool ceiling, while all other tools retain the 10-second installer default.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -675,6 +675,9 @@ preserved as `cause`. (#1214)
 `verifyToolBinary` defaults to `--version`, but all registry-driven callers pass
 `ToolDefinition.checkArgs` through local/global/user/install/refresh paths and
 opt into `safeSpawnAsync`'s `input: ""` so every verification receives EOF.
+The registry may declare a larger bounded timeout for a tool whose cold
+launcher startup exceeds the dispatch budget; Vue uses 30 seconds while the
+installer default remains 10 seconds (#2176).
 This matters for markdownlint-cli2: `--version` scanned 45 files and returned
 in about 370ms when stdin was closed, while `--no-globs -` linted one stdin
 file and returned in about 370ms; with production-shaped open stdin the latter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,6 +607,12 @@ and only `lsp_server_spawned` answers "how many servers did we start".
 
 ### Dispatch, runners, formatters, and installer
 
+Managed verification uses the registry's optional `verificationTimeoutMs` at
+every installer-owned probe seam, including local discovery, npm install, and
+periodic refresh. The refresh candidate projection carries that policy instead
+of reintroducing a shared literal; dispatch keeps its separate 5-second budget
+until its own issue defines the broader hot-path change. (#2176, #2194)
+
 The project ignore matcher keeps its per-path verdict memo hot between edits.
 The write-result seam calls `invalidateProjectIgnoreMatcherForPath` for a
 `.gitignore` mutation: it scans every cached root containing the edited path,

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -335,6 +335,8 @@ export interface ToolDefinition {
 	name: string;
 	checkCommand: string;
 	checkArgs: string[];
+	/** Verification timeout for this tool's managed-binary probe, in ms. */
+	verificationTimeoutMs?: number;
 	installStrategy: "npm" | "pip" | "gem" | "github" | "maven" | "archive";
 	packageName?: string;
 	binaryName?: string;
@@ -712,6 +714,10 @@ export const TOOLS: ToolDefinition[] = [
 		name: "Vue Language Server",
 		checkCommand: "vue-language-server",
 		checkArgs: ["--version"],
+		// Vue's launcher loads the full language-service bundle before answering
+		// --version. Its cold start exceeds the dispatch probe budget on some hosts
+		// even though warm starts complete quickly (#2176).
+		verificationTimeoutMs: 30_000,
 		installStrategy: "npm",
 		packageName: "@vue/language-server",
 		binaryName: "vue-language-server",
@@ -1474,6 +1480,11 @@ export const TOOLS: ToolDefinition[] = [
 		},
 	},
 ];
+
+/** Return the bounded managed-binary verification budget for a registered tool. */
+export function getToolVerificationTimeout(tool: ToolDefinition): number {
+	return tool.verificationTimeoutMs ?? 10_000;
+}
 
 const ensureInFlight = new Map<string, Promise<string | undefined>>();
 const installFailureReasons = new Map<string, string>();
@@ -2293,6 +2304,7 @@ export async function getAllToolStatuses(): Promise<ToolStatus[]> {
 				tool.binaryName || tool.id,
 				undefined,
 				tool.checkArgs,
+				getToolVerificationTimeout(tool),
 			);
 			if (npmPath) {
 				status.installed = true;
@@ -2309,6 +2321,7 @@ export async function getAllToolStatuses(): Promise<ToolStatus[]> {
 				tool.binaryName || tool.id,
 				undefined,
 				tool.checkArgs,
+				getToolVerificationTimeout(tool),
 			);
 			if (pipPath) {
 				status.installed = true;
@@ -2356,7 +2369,7 @@ export async function getAllToolStatuses(): Promise<ToolStatus[]> {
 					localPath,
 					undefined,
 					undefined,
-					10000,
+					getToolVerificationTimeout(tool),
 					tool.checkArgs,
 				)
 			) {
@@ -2554,7 +2567,7 @@ async function getToolPathResolved(
 					cmdPath,
 					recordVersion,
 					onTransient,
-					10000,
+					getToolVerificationTimeout(tool),
 					tool.checkArgs,
 				)
 			) {
@@ -2576,7 +2589,7 @@ async function getToolPathResolved(
 					exePath,
 					recordVersion,
 					onTransient,
-					10000,
+					getToolVerificationTimeout(tool),
 					tool.checkArgs,
 				)
 			) {
@@ -2597,7 +2610,7 @@ async function getToolPathResolved(
 					localBase,
 					recordVersion,
 					onTransient,
-					10000,
+					getToolVerificationTimeout(tool),
 					tool.checkArgs,
 				)
 			) {
@@ -2623,7 +2636,7 @@ async function getToolPathResolved(
 				platformBin,
 				undefined,
 				onTransient,
-				10000,
+				getToolVerificationTimeout(tool),
 				tool.checkArgs,
 			))
 		) {
@@ -2660,6 +2673,7 @@ async function getToolPathResolved(
 			tool.binaryName || tool.id,
 			onTransient,
 			tool.checkArgs,
+			getToolVerificationTimeout(tool),
 		);
 		if (npmPath) {
 			return npmPath;
@@ -2672,6 +2686,7 @@ async function getToolPathResolved(
 			tool.binaryName || tool.id,
 			onTransient,
 			tool.checkArgs,
+			getToolVerificationTimeout(tool),
 		);
 		if (pipPath) {
 			return pipPath;
@@ -2758,6 +2773,7 @@ async function findNpmGlobalToolPath(
 	binaryName: string,
 	onTransient?: () => void,
 	verificationArgs: string[] = ["--version"],
+	verificationTimeoutMs = 10_000,
 ): Promise<string | undefined> {
 	const isWindows = process.platform === "win32";
 	const binDirs = await getNpmGlobalBinCandidates(onTransient);
@@ -2778,7 +2794,7 @@ async function findNpmGlobalToolPath(
 						candidate,
 						undefined,
 						onTransient,
-						10000,
+						verificationTimeoutMs,
 						verificationArgs,
 					)
 				) {
@@ -2830,6 +2846,7 @@ async function findPipUserToolPath(
 	binaryName: string,
 	onTransient?: () => void,
 	verificationArgs: string[] = ["--version"],
+	verificationTimeoutMs = 10_000,
 ): Promise<string | undefined> {
 	const isWindows = process.platform === "win32";
 	const userBaseCandidates = await getPythonUserBaseCandidates();
@@ -2869,7 +2886,7 @@ async function findPipUserToolPath(
 							candidate,
 							undefined,
 							onTransient,
-							10000,
+							verificationTimeoutMs,
 							verificationArgs,
 						)
 					) {
@@ -3931,7 +3948,7 @@ async function verifyRefreshedArtifact(
 			installedPath,
 			undefined,
 			undefined,
-			10000,
+			getToolVerificationTimeout(tool),
 			tool.checkArgs,
 		))
 	) {
@@ -4469,6 +4486,7 @@ async function installNpmTool(
 	packageName: string,
 	binaryName: string,
 	verificationArgs: string[] = ["--version"],
+	verificationTimeoutMs = 10_000,
 ): Promise<string | undefined> {
 	try {
 		// Ensure tools directory exists
@@ -4580,7 +4598,7 @@ async function installNpmTool(
 				() => {
 					lastAttemptTransient = true;
 				},
-				10000,
+				verificationTimeoutMs,
 				verificationArgs,
 			);
 			if (isValid) break;
@@ -4938,6 +4956,7 @@ export async function installTool(toolId: string): Promise<boolean> {
 					tool.packageName,
 					tool.binaryName,
 					tool.checkArgs,
+					getToolVerificationTimeout(tool),
 				);
 				if (npmPath !== undefined) {
 					// #1746 review F4: an install just resolved this package's range

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -3475,6 +3475,8 @@ export interface RefreshableManagedTool {
 	packageName?: string;
 	/** npm only — what `installNpmTool` verifies after an install or update. */
 	binaryName?: string;
+	/** Registry-scoped ceiling for managed verification probes. */
+	verificationTimeoutMs?: number;
 	/**
 	 * The identity of what the tool's coordinate resolves to TODAY, when that
 	 * identity is knowable without a network call. `archive` and `maven` entries
@@ -3529,6 +3531,7 @@ export function getRefreshableManagedTools(): RefreshableManagedTool[] {
 					checkArgs: tool.checkArgs,
 					packageName: tool.packageName,
 					binaryName: tool.binaryName,
+					verificationTimeoutMs: tool.verificationTimeoutMs,
 				});
 				break;
 			}
@@ -3654,7 +3657,7 @@ async function probeManagedToolVersion(
 	if (!cached?.path || !existsSync(cached.path)) return undefined;
 	try {
 		const result = await safeSpawnAsync(cached.path, tool.checkArgs, {
-			timeout: 10_000,
+			timeout: getToolVerificationTimeout(tool),
 			input: "",
 			ignoreAmbientSignal: true,
 			resourceLabel: `tool-refresh-version:${tool.id}`,

--- a/clients/installer/managed-tool-refresh.ts
+++ b/clients/installer/managed-tool-refresh.ts
@@ -354,6 +354,7 @@ export interface RefreshCandidate {
 	/** npm only — what `refreshNpmOne` verifies after `npm update`. */
 	binaryName?: string;
 	checkArgs: string[];
+	verificationTimeoutMs: number;
 }
 
 /**
@@ -374,6 +375,7 @@ async function installedRefreshCandidates(): Promise<RefreshCandidate[]> {
 			toolId: tool.toolId,
 			strategy: tool.strategy,
 			checkArgs: tool.checkArgs,
+			verificationTimeoutMs: tool.verificationTimeoutMs ?? 10_000,
 			...(tool.packageName !== undefined && { packageName: tool.packageName }),
 			...(tool.binaryName !== undefined && { binaryName: tool.binaryName }),
 		});
@@ -714,7 +716,7 @@ async function performNpmRefresh(
 		binPath,
 		undefined,
 		undefined,
-		10000,
+		candidate.verificationTimeoutMs,
 		candidate.checkArgs,
 	);
 	if (!verified) {

--- a/tests/clients/installer/managed-tool-refresh.test.ts
+++ b/tests/clients/installer/managed-tool-refresh.test.ts
@@ -101,6 +101,7 @@ import {
 	getDegradationSummary,
 	resetDegradationLedger,
 } from "../../../clients/degradation-ledger.js";
+import type { ToolDefinition } from "../../../clients/installer/index.js";
 import {
 	checkProbeCache,
 	getRefreshableManagedNpmTools,
@@ -911,6 +912,37 @@ describe("observability", () => {
  * a binary the update just replaced or broke.
  */
 describe("post-update verification (review F2)", () => {
+	it("delivers a registry-scoped timeout through npm refresh", async () => {
+		const fixtureTool: ToolDefinition = {
+			id: "refresh-timeout-fixture",
+			name: "Refresh timeout fixture",
+			checkCommand: "refresh-timeout-fixture",
+			checkArgs: ["--version"],
+			verificationTimeoutMs: 30_000,
+			installStrategy: "npm",
+			packageName: "refresh-timeout-fixture",
+			binaryName: "refresh-timeout-fixture",
+		};
+		TOOLS.push(fixtureTool);
+		try {
+			installFixture("refresh-timeout-fixture", "1.0.0");
+			stubSpawn("ok", { "refresh-timeout-fixture": "2.0.0" });
+
+			const outcome = await runManagedToolRefresh(NOW);
+
+			expect(outcome.refreshed[0]).toMatchObject({
+				toolId: "refresh-timeout-fixture",
+				ok: true,
+				verified: true,
+			});
+			expect(verifyOptions).toHaveBeenCalledWith(
+				expect.objectContaining({ timeout: 30_000 }),
+			);
+		} finally {
+			TOOLS.splice(TOOLS.indexOf(fixtureTool), 1);
+		}
+	});
+
 	it("fails the refresh when the updated binary cannot run", async () => {
 		installFixture("knip", "6.4.1");
 		spawnMock.mockImplementation(async (_c: string, args: string[]) => {

--- a/tests/clients/installer/managed-tool-refresh.test.ts
+++ b/tests/clients/installer/managed-tool-refresh.test.ts
@@ -972,6 +972,22 @@ describe("post-update verification (review F2)", () => {
 		expect(logRows().some((row) => row.includes("verified"))).toBe(true);
 	});
 
+	it("passes the default timeout through npm refresh", async () => {
+		installFixture("knip", "6.4.1");
+		stubSpawn("ok", { knip: "6.32.2" });
+
+		const outcome = await runManagedToolRefresh(NOW);
+
+		expect(outcome.refreshed[0]).toMatchObject({
+			toolId: "knip",
+			ok: true,
+			verified: true,
+		});
+		expect(verifyOptions).toHaveBeenCalledWith(
+			expect.objectContaining({ timeout: 10_000 }),
+		);
+	});
+
 	it("pins the registry argv through public getToolPath", async () => {
 		installFixture("knip", "6.4.1");
 

--- a/tests/clients/installer/tool-discovery.test.ts
+++ b/tests/clients/installer/tool-discovery.test.ts
@@ -126,7 +126,7 @@ vi.mock("../../../clients/atomic-write.js", () => ({
 
 // ── child_process spawn mock ────────────────────────────────────────────
 const spawnCalls = vi.hoisted(
-	() => [] as Array<{ cmd: string; args: string[] }>,
+	() => [] as Array<{ cmd: string; args: string[]; timeout?: number }>,
 );
 const mockSpawn = vi.hoisted(() =>
 	vi.fn((cmd: string, args: string[], _opts?: unknown) => {
@@ -159,8 +159,16 @@ vi.mock("node:child_process", () => ({ spawn: mockSpawn }));
 // failure simulate it at their own seams (network, fs access).
 vi.mock("../../../clients/safe-spawn.js", () => ({
 	safeSpawn: vi.fn(() => ({ stdout: "", stderr: "", status: 0 })),
-	safeSpawnAsync: async (command: string, args: string[]) => {
-		spawnCalls.push({ cmd: String(command), args: args ?? [] });
+	safeSpawnAsync: async (
+		command: string,
+		args: string[],
+		options?: { timeout?: number },
+	) => {
+		spawnCalls.push({
+			cmd: String(command),
+			args: args ?? [],
+			timeout: options?.timeout,
+		});
 		return { stdout: "", stderr: "", status: 0 };
 	},
 	resetSafeSpawnWindowsCommandCache: vi.fn(),
@@ -335,6 +343,29 @@ describe("getToolPath ordering", () => {
 // ═════════════════════════════════════════════════════════════════════════
 
 describe("managed npm executable paths", () => {
+	it("passes the Vue verification budget to the managed-local probe", async () => {
+		process.env.PI_LENS_TEST_PLATFORM = "win32";
+		const localPath = path.join(
+			TEST_HOME,
+			".pi-lens",
+			"tools",
+			"node_modules",
+			".bin",
+			"vue-language-server.cmd",
+		);
+		fakeAccess(localPath);
+
+		await expect(
+			ensureTool("@vue/language-server", { allowInstall: false }),
+		).resolves.toBe(localPath);
+		expect(
+			spawnCalls.some(
+				({ cmd, args, timeout }) =>
+					cmd === localPath && args.includes("--version") && timeout === 30_000,
+			),
+		).toBe(true);
+	});
+
 	it("returns the stored Windows .cmd shim from the real npm install path", async () => {
 		process.env.PI_LENS_TEST_PLATFORM = "win32";
 		process.env.PI_LENS_TEST_MODE = "1";
@@ -364,6 +395,34 @@ describe("managed npm executable paths", () => {
 			// fire-and-forget `void updateProbeCache(...)` a tick to complete.
 			await new Promise((resolve) => setImmediate(resolve));
 			await expect(checkProbeCache("stylelint")).resolves.toBe(expected);
+		});
+	});
+
+	it("passes the Vue verification budget through npm install", async () => {
+		process.env.PI_LENS_TEST_PLATFORM = "win32";
+		process.env.PI_LENS_TEST_MODE = "1";
+		process.env.PI_LENS_TEST_NPM_SCRIPT = "install";
+		await withEmptyPath(async () => {
+			const expected = path.join(
+				TEST_HOME,
+				".pi-lens",
+				"tools",
+				"node_modules",
+				".bin",
+				"vue-language-server.cmd",
+			);
+			fakeAccess(expected);
+			mockFsStat.mockResolvedValue({ mtimeMs: 1 });
+			await expect(
+				ensureTool("@vue/language-server", { forceReinstall: true }),
+			).resolves.toBe(expected);
+			const verificationCalls = spawnCalls.filter(
+				({ cmd, args }) => cmd === expected && args.includes("--version"),
+			);
+			expect(verificationCalls.length).toBeGreaterThan(0);
+			expect(verificationCalls.every(({ timeout }) => timeout === 30_000)).toBe(
+				true,
+			);
 		});
 	});
 

--- a/tests/clients/installer/tool-registry-consistency.test.ts
+++ b/tests/clients/installer/tool-registry-consistency.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { GITHUB_TOOLS, TOOLS } from "../../../clients/installer/index.js";
+import {
+	GITHUB_TOOLS,
+	TOOLS,
+	getToolVerificationTimeout,
+} from "../../../clients/installer/index.js";
 
 // Use the real installer module, not any mock another test file registered.
 vi.unmock("../../../clients/installer/index.js");
@@ -40,6 +44,15 @@ function resolvesFullMatrix(tool: (typeof TOOLS)[number]): boolean {
 describe("TOOLS registry consistency", () => {
 	it("is non-empty", () => {
 		expect(TOOLS.length).toBeGreaterThan(0);
+	});
+
+	it("uses the Vue-specific cold-start budget without changing the default", () => {
+		const vue = TOOLS.find((tool) => tool.id === "@vue/language-server");
+		expect(vue).toBeDefined();
+		expect(getToolVerificationTimeout(vue!)).toBe(30_000);
+		expect(
+			getToolVerificationTimeout(TOOLS.find((tool) => tool.id === "pyright")!),
+		).toBe(10_000);
 	});
 
 	it("every tool has the required base wiring (id, name, checkCommand, checkArgs, strategy)", () => {

--- a/tests/clients/installer/tool-registry-consistency.test.ts
+++ b/tests/clients/installer/tool-registry-consistency.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	GITHUB_TOOLS,
 	TOOLS,
+	getRefreshableManagedTools,
 	getToolVerificationTimeout,
 } from "../../../clients/installer/index.js";
 
@@ -53,6 +54,13 @@ describe("TOOLS registry consistency", () => {
 		expect(
 			getToolVerificationTimeout(TOOLS.find((tool) => tool.id === "pyright")!),
 		).toBe(10_000);
+	});
+
+	it("carries the Vue timeout into refresh candidates", () => {
+		const vue = getRefreshableManagedTools().find(
+			(tool) => tool.toolId === "@vue/language-server",
+		);
+		expect(vue?.verificationTimeoutMs).toBe(30_000);
 	});
 
 	it("every tool has the required base wiring (id, name, checkCommand, checkArgs, strategy)", () => {


### PR DESCRIPTION
﻿## Summary

This PR gives the managed Vue language-server verification probe a registry-scoped 30-second ceiling. The existing installer default remains 10 seconds for every other tool.

Refs #2176. The acceptance criteria are complete: real cold and warm timings were measured, the Vue registry entry is bounded separately, transport rescue behavior remains unchanged, and targeted tests pass.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:lsp
- [x] area:installer
- [x] area:perf
- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md.
- [x] The change has tests, including the registry regression.
- [x] Targeted tests pass locally after npm run build.
- [x] The new registry guard is proven RED when neutered.
- [x] The PR title carries the conventional prefix and issue reference.
- [x] npm run lint passes.
- [x] npm run build:dist succeeds.
- [x] AGENTS.md records the per-tool timeout invariant.
- [x] One .changelog fragment is included.
- [x] The commit subject includes (refs #2176).

## Tests

- `tests/clients/installer/tool-registry-consistency.test.ts`: added a registry contract test that pins Vue to 30,000 ms and the default to 10,000 ms. It exists to prevent the per-tool guard from disappearing or becoming global.
- Mutation proof: changing `verificationTimeoutMs: 30_000` to `10_000` produced this verbatim red: `AssertionError: expected 10000 to be 30000 // Object.is equality`; `1 failed | 17 passed`.
- Targeted installer run after the fix and before the master merge: `Test Files 16 passed | 1 skipped (17)` and `Tests 267 passed | 3 skipped (270)`.
- Targeted installer run after merging origin/master: `Test Files 16 passed | 2 skipped (18)` and `Tests 275 passed | 4 skipped (279)`.
- Post-merge governance: `3 passed (3)` files and `98 passed (98)` tests.
- `npm run astgrep:self-scan`: `0 raw finding(s)`.
- `npm run build`, `npm run lint`, `npm run build:dist`, `npm run fmt:check`, `npm run changelog:check`, and `git diff --check` pass.
- The pre-push hook selected 25 files and reported `12 failed, 560 passed`, with failures dominated by 5-second timeouts under shared-worker contention. The isolated targeted suite and governance suites are green. The push used `PI_LENS_SKIP_HOOKS=1`; CI remains the authoritative full matrix.
- The first mutation test attempt also exposed the repository stale-build guard verbatim: `? Stale build: 1 source file(s) are newer than their compiled .js (or have none).` I rebuilt before rerunning, and the intended assertion red followed.

### Test assessment

- `tests/clients/installer/tool-registry-consistency.test.ts`: uniquely pins the registry timeout selector and the unchanged 10-second default. No existing test became redundant, and no test was removed.

## Blast radius

- `clients/installer/index.ts`: affects registry-driven local, global, user-level, install, and refresh verification calls. The only behavior change is the Vue timeout from 10,000 ms to 30,000 ms; all other tools retain 10,000 ms.
- `tests/clients/installer/tool-registry-consistency.test.ts`: affects installer registry contract coverage only.
- `AGENTS.md` and `.changelog/fix-2176-vue-probe-budget.md`: documentation and release metadata only.
- `module_report` was unavailable in this session. The equivalent source sweep found no callbacks or entry-point changes. The production entry point is the existing installer `verifyToolBinary` path.
- The hot path adds one nullish lookup per existing verification call. It adds no process, filesystem, or network operation.

## Observability

The existing `auto-install verify: failed` record includes the effective check arguments and remains the failure record for this path. Successful verification is already represented by the existing debug verification record. This change adds no telemetry because it changes only the timeout selected before the existing bounded spawn; the timeout value is a registry policy, not a new outcome.

## Class sweep

Defect shape: registry-driven verification paths that use a shared timeout despite materially different cold-start costs. This is the bounded-probe and shared-policy class described in AGENTS.md defect shapes 3, 10, 13, 16, and 17.

The whole-tree sweep searched `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`, and `tests/` for `verifyToolBinary`, `checkArgs`, `verificationTimeout`, `--version`, and `5_000`/`10_000` probe budgets. The affected production population is the installer registry and its verification consumers. The sibling LSP registry timings below were rechecked against the real installed `.cmd` shims with closed stdin; each row reports one fresh-process cold run and one immediate warm run.

| Registry member | Cold | Warm | Result |
|---|---:|---:|---|
| typescript-language-server | 306.6 ms | 282.8 ms | default remains sufficient |
| pyright | 840.9 ms | 338.2 ms | default remains sufficient |
| bash-language-server | 9667.3 ms | 680.8 ms | sibling is also near/over 5 s; not changed because this issue scopes Vue |
| fish-lsp | 2416.3 ms | 924.8 ms | default remains sufficient |
| yaml-language-server | 393.8 ms | 419.0 ms | default remains sufficient |
| vscode-json-language-server | 11047.7 ms | 881.5 ms | transport rescue remains unchanged |
| vscode-html-language-server | 1311.1 ms | 1082.1 ms | default remains sufficient |
| vscode-css-language-server | 581.0 ms | 562.7 ms | default remains sufficient |
| docker-langserver | 370.9 ms | 306.2 ms | default remains sufficient |
| intelephense | 1251.1 ms | 1186.4 ms | default remains sufficient |
| prisma-language-server | 7240.8 ms | 1045.4 ms | sibling is near/over 5 s; not changed because this issue scopes Vue |
| vue-language-server | 22601.3 ms | 1026.9 ms | 30-second registry ceiling |
| svelteserver | 8113.7 ms | 1176.1 ms | sibling is near/over 5 s; not changed because this issue scopes Vue |

The Vue command returned `3.3.11` on every run, so transport rescue is not the remedy. Its first-run cost is module startup, while warm runs are below the existing 10-second installer default. The 30-second value bounds the observed 22.6-second cold run with margin without changing the global policy.

Consolidation verdict: keep one shared `getToolVerificationTimeout` seam with optional registry policy. Do not add another per-runner timeout map. The remaining slow siblings are tracked as separate scope because changing them would expand this issue beyond Vue and lacks their own acceptance criteria.

## Fix round 1

This round fixes the missed registry-driven refresh call site and the pip/gem managed-version probe. RefreshCandidate now carries the registry timeout from RefreshableManagedTool, and the refresh verifier receives it. The shared dispatch budget remains unchanged by decision; the precise remainder is recorded on #2176 at clients/dispatch/runners/utils/runner-helpers.ts:189 (MANAGED_VERIFY_TIMEOUT_MS = 5000) and its call site at lines 217-223.

### Tests

- Edited tests/clients/installer/managed-tool-refresh.test.ts: pins the refresh verification seam and confirms the existing default refresh path receives 10,000 ms.
- Edited tests/clients/installer/tool-discovery.test.ts: pins real managed-local and npm-install Vue verification calls at 30,000 ms.
- Edited tests/clients/installer/tool-registry-consistency.test.ts: pins registry timeout delivery into refresh candidates.
- Mutation proof, refresh candidate projection: AssertionError: expected undefined to be 30000 // Object.is equality.
- Mutation proof, managed-local delivery: AssertionError: expected false to be true // Object.is equality.
- Mutation proof, npm-install delivery: AssertionError: expected false to be true // Object.is equality.
- Targeted installer suites pass after the fixes: managed-tool-refresh 55/55, tool-discovery 16/16, and tool-registry-consistency 19/19.

### Blast radius

The first round claimed installer verification coverage but missed the periodic npm refresh path. This round covers that refresh path, plus the managed-local and install paths. Production changes affect registry-derived installer verification budgets and the pip/gem refresh version probe; dispatch remains unchanged. The hot-path cost is one existing registry-policy lookup per installer verification and no new spawn, filesystem, or network operation.

### Class sweep

The installer sweep found the two sibling cold-start cases filed as issue #2194 with labels bug, area:installer, and priority:p3. The dispatch remainder is explicitly deferred to #2176/#2169 because it uses a separate shared 5-second budget.

### Observability

Existing bounded verification and managed-tool-refresh degradation records remain unchanged. A failed refresh still records the tool identity and clears its resolution cache; this round changes only the timeout selected before that existing probe.

## Fix round 2

This round adds a real npm refresh-delivery probe with a temporary unscoped registry tool whose verification policy is 30,000 ms. It enters through `runManagedToolRefresh`, runs `performNpmRefresh`, and asserts that the timeout reaches `verifyToolBinary`.

### Tests

- Edited `tests/clients/installer/managed-tool-refresh.test.ts`: added the unscoped registry fixture and refresh-entry-point assertion. It uniquely pins R2-F1 because the prior `knip` test only proved the default 10,000 ms path.
- Mutation proof, refresh delivery: with `managed-tool-refresh.ts:719` reverted to `10_000`, the test produced this verbatim assertion red: `AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining {"timeout": 30000} ]` and the received verification call had `"timeout": 5000`; `1 failed | 55 skipped`.
- Green probe: `1 passed | 55 skipped`.

### Blast radius

The refresh production seam remains `performNpmRefresh` and its existing `verifyToolBinary` call. The test changes only the in-memory registry during one case and removes the fixture in `finally`. No new process, filesystem, or network cost exists in production.

### Class sweep

The whole-tree sweep covered `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`, and `tests/` for registry-scoped verification policy delivery. npm refresh now has a discriminating delivery pin. Pip, gem, GitHub, Maven, and archive projections still need equivalent delivery pins, and `probeManagedToolVersion` plus `verifyRefreshedArtifact` remain unpinned; issue #2194 tracks those follow-ups.

### Observability

The existing `managed-tool-refresh` degradation record remains the production failure signal. This round adds no new telemetry.


