### PR TITLE
perf(word-index): prove 2067 residuals (refs #2067)

### DIFF
--- a/.changelog/perf-2066-2067-residuals.md
+++ b/.changelog/perf-2066-2067-residuals.md
@@ -1,5 +1,0 @@
----
-section: Fixed
----
-
-- **Close the #2066 and #2067 performance residuals** — retain the single JavaScript document scan and packed word-index file identities, add a reproducible replacement CPU-profile command, and pin fixed-corpus BM25 results against the pre-packing baseline.

--- a/.changelog/perf-2066-2067-residuals.md
+++ b/.changelog/perf-2066-2067-residuals.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Close the #2066 and #2067 performance residuals** — retain the single JavaScript document scan and packed word-index file identities, add a reproducible replacement CPU-profile command, and pin fixed-corpus BM25 results against the pre-packing baseline.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -985,6 +985,8 @@ in word-index telemetry. #2069 intentionally builds on this prerequisite.
 The reproducible synchronous replacement profile is
 `npm run build && npm run bench:word-index-replacement`; it reports latency
 percentiles and inspector samples attributed to `normalizeEphemeralMapKey`.
+The relative smoke check's restored run reports 0.226% attribution (3,092
+samples); the pre-interning comparison reports 32.303% (5,727 samples).
 
 Word-index persistence keeps the v2 wire contract and caches its flat serialized
 view per index. Every replacement or addition marks its document dirty; the next

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -975,6 +975,9 @@ unawaited concurrent cascades must not yield across a wholesale posting snapshot
 Cooperative async variants are serialized per index and remain for bulk refresh.
 When touching this seam, keep posting-entry counts and replacement-cost scalars
 in word-index telemetry. #2069 intentionally builds on this prerequisite.
+The reproducible synchronous replacement profile is
+`npm run build && npm run bench:word-index-replacement`; it reports latency
+percentiles and inspector samples attributed to `normalizeEphemeralMapKey`.
 
 Word-index persistence keeps the v2 wire contract and caches its flat serialized
 view per index. Every replacement or addition marks its document dirty; the next

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"astgrep:self-scan:update-baseline": "node scripts/run-astgrep-pi-lens.mjs --update-baseline",
 		"audit:playground": "node scripts/playground-verify-rule.mjs",
 		"bench:cascade-budget": "node scripts/bench-cascade-budget.mjs",
+		"bench:word-index-replacement": "node scripts/bench-word-index-replacement.mjs",
 		"logs:smells": "node scripts/analyze-pi-lens-logs.mjs",
 		"changelog:check": "node scripts/rollup-changelog.mjs --check",
 		"changelog:release": "node scripts/changelog-release.mjs",

--- a/scripts/bench-word-index-replacement.mjs
+++ b/scripts/bench-word-index-replacement.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Profile the synchronous per-edit word-index replacement seam (#2067).
+ *
+ * The workload deliberately keeps the corpus large and makes the edited
+ * document appear in a shared posting list. This is the shape that used to
+ * normalize every posting element. Run after `npm run build`:
+ *
+ *   node scripts/bench-word-index-replacement.mjs
+ *
+ * The inspector profile is self-sample based. It reports the replacement
+ * latency distribution and the share attributed to normalizeEphemeralMapKey,
+ * so the acceptance numbers can be reproduced without a machine-specific
+ * `--prof-process` installation.
+ */
+import * as inspector from "node:inspector";
+import * as path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const wordIndexUrl = pathToFileURL(
+	path.join(root, "clients", "word-index.js"),
+).href;
+const { buildWordIndex, updateWordIndexDocument } = await import(wordIndexUrl);
+
+const corpusSize = 2600;
+const lineCount = 1600;
+const targetPath = "src/bench-target.ts";
+const corpus = Array.from({ length: corpusSize }, (_, file) => ({
+	path: file === 0 ? targetPath : `src/bench-${file}.ts`,
+	content: Array.from(
+		{ length: file === 0 ? lineCount : 8 },
+		(_, line) => `export function sharedPostingHandler${line}() {}`,
+	).join("\n"),
+}));
+const index = buildWordIndex(corpus);
+const session = new inspector.Session();
+session.connect();
+
+function post(method, params = {}) {
+	return new Promise((resolve, reject) => {
+		session.post(method, params, (error, result) =>
+			error ? reject(error) : resolve(result),
+		);
+	});
+}
+
+await post("Profiler.enable");
+await post("Profiler.start");
+const durations = [];
+for (let edit = 0; edit < 60; edit += 1) {
+	const content = `${corpus[0].content}\nexport const edit${edit} = sharedPostingHandler0;`;
+	const started = performance.now();
+	if (!updateWordIndexDocument(index, { path: targetPath, content })) {
+		throw new Error("word-index replacement was not available");
+	}
+	durations.push(performance.now() - started);
+}
+const { profile } = await post("Profiler.stop");
+session.disconnect();
+
+const samples = profile.samples ?? [];
+const nodes = new Map((profile.nodes ?? []).map((node) => [node.id, node]));
+const selfSamples = samples.length;
+const normalizerSamples = samples.filter((sample) => {
+	let node = nodes.get(sample.nodeId);
+	while (node) {
+		if (node.callFrame?.functionName === "normalizeEphemeralMapKey")
+			return true;
+		node = nodes.get(node.parent);
+	}
+	return false;
+}).length;
+const sorted = [...durations].sort((a, b) => a - b);
+const percentile = (p) => sorted[Math.floor((sorted.length - 1) * p)];
+const mean =
+	durations.reduce((sum, value) => sum + value, 0) / durations.length;
+
+console.log(`corpus documents: ${corpusSize}`);
+console.log(`target bytes: ${Buffer.byteLength(corpus[0].content, "utf8")}`);
+console.log(`replacement mean: ${mean.toFixed(3)} ms`);
+console.log(`replacement p50: ${percentile(0.5).toFixed(3)} ms`);
+console.log(`replacement p95: ${percentile(0.95).toFixed(3)} ms`);
+console.log(`replacement max: ${Math.max(...durations).toFixed(3)} ms`);
+console.log(
+	`normalizeEphemeralMapKey: ${((100 * normalizerSamples) / Math.max(1, selfSamples)).toFixed(3)}% of samples`,
+);
+console.log(`profile samples: ${selfSamples}`);

--- a/scripts/bench-word-index-replacement.mjs
+++ b/scripts/bench-word-index-replacement.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 /**
- * Profile the synchronous per-edit word-index replacement seam (#2067).
+ * Relative attribution smoke check for the synchronous per-edit word-index
+ * replacement seam (#2067).
  *
- * The workload deliberately keeps the corpus large and makes the edited
- * document appear in a shared posting list. This is the shape that used to
- * normalize every posting element. Run after `npm run build`:
+ * The workload deliberately makes the edited document appear in a shared
+ * posting list. It is not a reproduction of the issue's 2.2M-posting corpus
+ * and its latency is not a cross-machine performance claim. Run after build:
  *
  *   node scripts/bench-word-index-replacement.mjs
  *
@@ -49,7 +50,7 @@ function post(method, params = {}) {
 await post("Profiler.enable");
 await post("Profiler.start");
 const durations = [];
-for (let edit = 0; edit < 60; edit += 1) {
+for (let edit = 0; edit < 300; edit += 1) {
 	const content = `${corpus[0].content}\nexport const edit${edit} = sharedPostingHandler0;`;
 	const started = performance.now();
 	if (!updateWordIndexDocument(index, { path: targetPath, content })) {
@@ -62,13 +63,19 @@ session.disconnect();
 
 const samples = profile.samples ?? [];
 const nodes = new Map((profile.nodes ?? []).map((node) => [node.id, node]));
+const parents = new Map();
+for (const node of nodes.values()) {
+	for (const childId of node.children ?? []) parents.set(childId, node.id);
+}
 const selfSamples = samples.length;
 const normalizerSamples = samples.filter((sample) => {
-	let node = nodes.get(sample.nodeId);
-	while (node) {
+	let nodeId = sample;
+	while (nodeId !== undefined) {
+		const node = nodes.get(nodeId);
+		if (!node) break;
 		if (node.callFrame?.functionName === "normalizeEphemeralMapKey")
 			return true;
-		node = nodes.get(node.parent);
+		nodeId = parents.get(nodeId);
 	}
 	return false;
 }).length;

--- a/tests/clients/word-index-2067-interning.test.ts
+++ b/tests/clients/word-index-2067-interning.test.ts
@@ -48,4 +48,28 @@ describe("word-index posting file interning (#2067)", () => {
 		expect(normalizeCalls.value).toBeLessThan(100);
 		expect(searchWordIndex(index, "asyncShared")).toHaveLength(20);
 	});
+
+	it("preserves BM25 results and scores across a document replacement", async () => {
+		const { buildWordIndex, searchWordIndex, updateWordIndexDocument } =
+			await import("../../clients/word-index.js");
+		const files = [
+			{ path: "src/a.ts", content: "export function sharedHandler() {}" },
+			{
+				path: "src/b.ts",
+				content: "export function sharedHandler() { return sharedHandler(); }",
+			},
+			{ path: "src/c.ts", content: "export function unrelated() {}" },
+		];
+		const index = buildWordIndex(files);
+		const before = searchWordIndex(index, "shared handler");
+
+		expect(
+			updateWordIndexDocument(index, {
+				path: "src/a.ts",
+				content: files[0].content,
+			}),
+		).toBe(true);
+
+		expect(searchWordIndex(index, "shared handler")).toEqual(before);
+	});
 });

--- a/tests/clients/word-index-rank-baseline.test.ts
+++ b/tests/clients/word-index-rank-baseline.test.ts
@@ -1,5 +1,5 @@
 /**
- * #2069 acceptance criterion 3 — `searchWordIndex` output is unchanged by the
+ * #2067 criterion 5 / #2069 acceptance criterion 3 — `searchWordIndex` output is unchanged by the
  * packed posting store.
  *
  * This is a characterization test, not a red-first regression test: the
@@ -99,7 +99,7 @@ const baselinePath = path.join(
 	"word-index-rank-baseline.json",
 );
 
-describe("word-index ranking is unchanged by the packed store (#2069)", () => {
+describe("word-index ranking is unchanged by replacement and packing (#2067/#2069)", () => {
 	it("reproduces the boxed representation's output for a fixed 20-query set", () => {
 		const baseline = JSON.parse(
 			fs.readFileSync(baselinePath, "utf-8"),

--- a/tests/clients/word-index-rank-baseline.test.ts
+++ b/tests/clients/word-index-rank-baseline.test.ts
@@ -19,7 +19,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { buildWordIndex, searchWordIndex } from "../../clients/word-index.js";
+import {
+	buildWordIndex,
+	searchWordIndex,
+	updateWordIndexDocument,
+} from "../../clients/word-index.js";
 
 const WORDS = [
 	"renderWidget",
@@ -111,7 +115,8 @@ describe("word-index ranking is unchanged by replacement and packing (#2067/#206
 			QUERIES.length - 1,
 		);
 
-		const index = buildWordIndex(makeCorpus());
+		const corpus = makeCorpus();
+		const index = buildWordIndex(corpus);
 		const actual: RecordedQuery[] = QUERIES.map((query) => [
 			query,
 			searchWordIndex(index, query, { limit: 5 }).map(
@@ -125,5 +130,23 @@ describe("word-index ranking is unchanged by replacement and packing (#2067/#206
 		]);
 
 		expect(actual).toEqual(baseline);
+		expect(
+			updateWordIndexDocument(index, {
+				path: corpus[0].path,
+				content: corpus[0].content,
+			}),
+		).toBe(true);
+		const afterReplacement: RecordedQuery[] = QUERIES.map((query) => [
+			query,
+			searchWordIndex(index, query, { limit: 5 }).map(
+				(result): RecordedResult => [
+					result.file,
+					Number(result.score.toFixed(6)),
+					result.hits,
+					result.lines,
+				],
+			),
+		]);
+		expect(afterReplacement).toEqual(actual);
 	});
 });


### PR DESCRIPTION
## Summary

This PR adds durable benchmark and parity evidence for the remaining #2067 performance criterion.

Refs #2066 — the issue's hash-folding, `lineTextAt`, and AC4 async migration remain out of scope.
Refs #2067 — the CPU attribution and fixed-query-set criteria are supplied here.

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [x] area:project-intelligence
- [x] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] The characterization test preserves before/after equivalence. The quoted red belongs to the pre-existing interning test under mutation, not to a new regression test.
- [x] Every new guard/branch/filter is mutation-proof: no production guard or branch changed in this PR.
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes via the commit hook
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json`
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there
- [x] No changelog fragment: this test/benchmark-only PR changes no user-facing behavior.
- [x] Commit body includes `Refs #2066` and `Refs #2067`

## Tests

- `tests/clients/word-index-2067-interning.test.ts`: adds a three-file replacement round-trip that compares result files, hits, lines, and BM25 scores.
- `tests/clients/word-index-rank-baseline.test.ts`: edits the characterization test to run the existing boxed-store 20-query list before and after replacement.
- `scripts/bench-word-index-replacement.mjs`: adds the compiled-runtime inspector profile for 300 replacements across 2,600 documents.

The replacement test uses the real index and search implementation. It avoids an ambient mock except for the existing normalizer-count seam.

The interning test's mutation red is verbatim:

`expected 4808 to be less than 100`

That red comes from temporarily restoring one normalization call per posting element in the pre-existing interning test. The restored implementation passes.

## Test assessment

- `tests/clients/word-index-2067-interning.test.ts` uniquely pins removal normalization and three-file replacement ranking parity.
- `tests/clients/word-index-rank-baseline.test.ts` uniquely pins the fixed 20-query boxed-store output and replacement parity across all 20 queries.

## Blast radius

No production module changed. `module_report` with `blastRadius: true` is unavailable in this checkout, so there are no production dependents, callbacks, or entry points to report. The touched entry points are the npm benchmark command and two word-index test files.

The benchmark is a relative attribution smoke check, not an issue-scale latency benchmark. It uses 2,600 documents and a 72,489-byte target, with approximately 22,400 posting entries. Its final restored run reported:

```text
replacement mean: 16.479 ms
replacement p50: 16.052 ms
replacement p95: 23.295 ms
replacement max: 29.111 ms
normalizeEphemeralMapKey: 0.226% of samples
profile samples: 3092
```

The same corrected harness against the pre-#2067 `clients/word-index.ts` reported:

```text
replacement mean: 30.528 ms
replacement p50: 30.684 ms
replacement p95: 39.561 ms
replacement max: 47.742 ms
normalizeEphemeralMapKey: 32.303% of samples
profile samples: 5727
```

The profile decoder treats `Profile.samples` as numeric node IDs and derives parent links by walking each node's `children` list. The CPU percentage is the load-bearing acceptance evidence; latency is reported only for context.

## Observability

The existing `persist_succeeded` word-index record carries `replacementCount`, `totalReplacementMs`, and `maxReplacementMs` for production per-edit evidence. The benchmark adds no runtime telemetry.

The durable command is `npm run build && npm run bench:word-index-replacement`.

AC4 remains open: `integration.ts` still calls synchronous `updateWordIndexDocument` at the cascade seam, and the existing measurements show 14–54 ms. The async migration is a separate PR. This PR makes no 8 ms budget assertion.

## Class sweep

The defect class is repeated work over posting elements and re-derivation of per-edit document state. I swept `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`, and `tests/` for `wordIndexKey`, `normalizeEphemeralMapKey`, posting removal, document sync scans, and fixed ranking baselines.

The word-index population has one removal implementation and one cooperative bulk sibling; both compare integer file identities and have normalization count coverage. The LSP population has the existing `scanSentContent` seam; `lineTextAt` remains a separate diagnostic-conversion member documented in #2066. Consolidation verdict: keep the word-index identity in `WordIndexFileTable`; defer the unrelated `lineTextAt` conversion and AC4 async migration to separate work.

## Fix round 1

- F1: fixed the CDP profile decoder. A final restored run reports `normalizeEphemeralMapKey: 0.226% of samples`; the pre-#2067 proof reports `normalizeEphemeralMapKey: 32.303% of samples`.
- F2: chose the relative attribution smoke check. The script header and this body state that its approximately 22,400-posting corpus is below the issue's 2.2M target and that latency is not comparable across machines. CPU attribution carries the acceptance claim.
- F3: narrowed the PR to references, removed any budget assertion claim, and left AC4 as an explicit async-migration remainder on #2067.
- F4: extended replacement parity to the existing 20-query boxed-store set.
- F5: corrected the red-first description. The replacement test is a characterization test; `expected 4808 to be less than 100` is the pre-existing interning test's mutation red.
- F6: removed the changelog fragment because this PR changes no production behavior or user-facing output.
- F7: the #2066 issue comment records that no single-pass coverage was added by this PR; the remainder stays open.
