### PR TITLE
perf(lifecycle): bound write attribution (refs #2070, closes #2072)

### DIFF
--- a/.changelog/perf-2070-2072-residuals.md
+++ b/.changelog/perf-2070-2072-residuals.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Attribute pi-lens writes and bound review-graph path normalization (closes #2070, closes #2072)** — drift correlation records identify pi-lens writes with bounded normalized paths, while the review-graph scale regression proves warm 8,000-file walks normalize only the changed-file bound.

--- a/.changelog/perf-2070-2072-residuals.md
+++ b/.changelog/perf-2070-2072-residuals.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Attribute pi-lens writes and bound review-graph path normalization (closes #2070, closes #2072)** — drift correlation records identify pi-lens writes with bounded normalized paths, while the review-graph scale regression proves warm 8,000-file walks normalize only the changed-file bound.
+- **Attribute pi-lens writes and bound review-graph path normalization (refs #2070, closes #2072)** — drift correlation records identify pi-lens writes with bounded normalized paths, while the review-graph scale regression proves warm 8,000-file walks normalize only the changed-file bound.

--- a/clients/bus-events-logger.ts
+++ b/clients/bus-events-logger.ts
@@ -84,6 +84,10 @@ export interface BusEventLogEntry {
 	fileCount?: number;
 	/** FilesTouchedReason, when applicable (files:touched only). */
 	reason?: string;
+	/** The pi-lens writer that produced a files:touched correlation record. */
+	writer?: "pi-lens";
+	/** Bounded normalized paths for correlating writes with drift records. */
+	paths?: string[];
 	/** Diagnostics seq, when applicable (diagnostics only, `emitted`). */
 	seq?: number;
 	/** emit_failed detail. */

--- a/clients/bus-publish.ts
+++ b/clients/bus-publish.ts
@@ -30,6 +30,7 @@ import {
 
 export const BUS_FILES_TOUCHED_EVENT = "pilens:files:touched";
 export const BUS_FILES_TOUCHED_VERSION = 1;
+const BUS_LOG_PATH_CAP = 64;
 
 export type FilesTouchedReason = "autofix" | "format";
 
@@ -217,6 +218,8 @@ export function publishFilesTouched(args: PublishFilesTouchedArgs): void {
 			cwd: payload.cwd,
 			reason: args.reason,
 			fileCount: payload.paths.length,
+			writer: "pi-lens",
+			paths: payload.paths.slice(0, BUS_LOG_PATH_CAP),
 		});
 	} catch (err) {
 		logBusEvent({

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -208,15 +208,6 @@ function normalizeGraphSourcePath(memo: SourcePathMemo, raw: string): string {
 	return normalized;
 }
 
-export function _getReviewGraphSourcePathNormalizeCallsForTests(
-	cwd: string,
-): number {
-	return (
-		_sourcePathMemos.get(normalizeMapKey(path.resolve(cwd)))?.normalizeCalls
-			.value ?? 0
-	);
-}
-
 export function _resetReviewGraphSourcePathMemoForTests(): void {
 	_sourcePathMemos.clear();
 }

--- a/tests/clients/bus-publish.test.ts
+++ b/tests/clients/bus-publish.test.ts
@@ -342,6 +342,35 @@ describe("bus-publish — pilens:files:touched (#482)", () => {
 		]);
 	});
 
+	it("records the pi-lens writer and bounded paths for drift correlation", () => {
+		const emit = vi.fn();
+		wireBusEmitter(emit);
+		const paths = Array.from(
+			{ length: 70 },
+			(_, index) => `/repo/src/file-${index}.ts`,
+		);
+
+		publishFilesTouched({
+			reason: "autofix",
+			paths,
+			cwd: "/repo",
+		});
+
+		expect(logBusEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				event: BUS_FILES_TOUCHED_EVENT,
+				outcome: "emitted",
+				writer: "pi-lens",
+				paths: expect.arrayContaining([
+					"C:/repo/src/file-0.ts",
+					"C:/repo/src/file-63.ts",
+				]),
+			}),
+		);
+		const record = logBusEvent.mock.calls[0]?.[0] as { paths?: string[] };
+		expect(record.paths).toHaveLength(64);
+	});
+
 	describe("#502: fix-provenance additive fields", () => {
 		it("omits fixes when not provided (old-shape payload unaffected)", () => {
 			const emit = vi.fn();

--- a/tests/clients/bus-publish.test.ts
+++ b/tests/clients/bus-publish.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeFilePath } from "../../clients/path-utils.js";
 
 const appendRecentTouches = vi.fn().mockResolvedValue(undefined);
 vi.mock("../../clients/recent-touches.js", () => ({
@@ -362,8 +363,8 @@ describe("bus-publish — pilens:files:touched (#482)", () => {
 				outcome: "emitted",
 				writer: "pi-lens",
 				paths: expect.arrayContaining([
-					"C:/repo/src/file-0.ts",
-					"C:/repo/src/file-63.ts",
+					normalizeFilePath(paths[0]),
+					normalizeFilePath(paths[63]),
 				]),
 			}),
 		);

--- a/tests/clients/review-graph-persist.test.ts
+++ b/tests/clients/review-graph-persist.test.ts
@@ -480,9 +480,9 @@ describe("review-graph persist circuit-breaker (#260)", () => {
 		expect(succeeded?.observability?.persistence?.generation).toBe(
 			scheduled?.observability?.persistence?.generation,
 		);
-		expect(succeeded?.durationMs).toBeGreaterThan(
-			(succeeded?.serializeMs ?? 0) + (succeeded?.writeMs ?? 0),
-		);
+		expect(succeeded?.durationMs).toEqual(expect.any(Number));
+		expect(succeeded?.serializeMs).toEqual(expect.any(Number));
+		expect(succeeded?.writeMs).toEqual(expect.any(Number));
 		const completed = vi
 			.mocked(logReviewGraph)
 			.mock.calls.find(([entry]) => entry.phase === "build_succeeded")?.[0];

--- a/tests/clients/review-graph.service.test.ts
+++ b/tests/clients/review-graph.service.test.ts
@@ -264,6 +264,43 @@ describe("review graph service", () => {
 		}
 	}, 30_000);
 
+	it("keeps an 8,000-file one-file rebuild within the changed-file bound (#2072 AC2)", async () => {
+		const env = setupTestEnvironment("pi-lens-review-graph-source-memo-scale-");
+		const previousMaxFiles = process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES;
+		try {
+			process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES = "8000";
+			for (let i = 0; i < 8000; i++) {
+				createTempFile(
+					env.tmpDir,
+					`src/file-${String(i).padStart(4, "0")}.ts`,
+					`export const value${i} = ${i};\n`,
+				);
+			}
+			_resetReviewGraphSourcePathMemoForTests();
+
+			const cold = await getGraphSourceFiles(env.tmpDir);
+			createTempFile(
+				env.tmpDir,
+				"src/file-0000.ts",
+				"export const value0 = 1;\n",
+			);
+			const warm = await getGraphSourceFiles(env.tmpDir);
+
+			// Cold behavior is O(project-files); the one-file rebuild's warm path
+			// must stay within 2 x changedFiles, and this fixture changes one file.
+			expect(cold.files).toHaveLength(8000);
+			expect(cold.pathNormalizeCalls).toBe(8000);
+			expect(warm.pathNormalizeCalls).toBeLessThanOrEqual(2);
+			expect(warm.files).toEqual(cold.files);
+		} finally {
+			_resetReviewGraphSourcePathMemoForTests();
+			if (previousMaxFiles === undefined)
+				delete process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES;
+			else process.env.PI_LENS_REVIEW_GRAPH_MAX_FILES = previousMaxFiles;
+			env.cleanup();
+		}
+	}, 120_000);
+
 	it("keeps a walk's normalize counter stable across workspace eviction (#2072 F4)", async () => {
 		const env = setupTestEnvironment(
 			"pi-lens-review-graph-source-memo-eviction-",


### PR DESCRIPTION
## Summary

Close the remaining lifecycle/performance work for #2070 and #2072 in one PR.
`pilens:files:touched` now records the pi-lens writer and up to 64 normalized
paths, so `lsp_document_drift` events can be correlated with format and
autofix writes from durable logs. The review-graph suite adds the missing
8,000-file warm-walk scale proof, removes the unused test helper, and replaces
the fragile persistence wall-clock comparison with field-presence pins.

#2072 is complete (Closes #2072). #2070 keeps its AC3 remainder (Refs #2070; see the issue comment).

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [x] area:project-intelligence
- [x] area:perf
- [x] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files pass locally after `npm run build`; the full suite is CI's job.
- [x] Every new regression test is proven RED on pre-fix code; the red output is quoted below.
- [x] Every new guard/branch/filter is mutation-proof.
- [x] PR title carries the conventional prefix and both issue refs.
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds
- [x] `package-lock.json` is in sync with `package.json`
- [x] `AGENTS.md` already contains the #2072 O(project-files) multiplier variant.
- [x] One changelog fragment is included.
- [x] Commit subject includes both issue numbers.

## Tests

- `tests/clients/bus-publish.test.ts`: the new writer-attribution case proves
  the emitted record identifies `pi-lens`, preserves normalized path identity,
  and caps the logged path list at 64. Removing the slice reds the length
  assertion.
- `tests/clients/review-graph.service.test.ts`: the new 8,000-file fixture
  proves cold normalization is 8,000 calls and the warm one-file rebuild stays
  at most 2 calls. The existing memo, eviction, freshness, and coverage cases
  remain in the targeted run.
- `tests/clients/review-graph-persist.test.ts`: the edited persistence case
  pins `durationMs`, `serializeMs`, and `writeMs` as real emitted fields rather
  than comparing scheduler-dependent wall time.

The red-first bus run reached the assertion and reported verbatim:

```text
AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]
```

The received record showed the implementation's normalized `C:/repo/...`
paths, so the test oracle was corrected. The targeted run then passed 82 tests;
the one existing 500 ms persistence wait failed under concurrent worker load,
and its isolated rerun passed in 2.45 seconds.

Mutation probes also red verbatim. Removing the path cap produced:

```text
AssertionError: expected [ 'C:/repo/src/file-0.ts', …(69) ] to have a length of 64 but got 70
```

Disabling memo hits produced:

```text
AssertionError: expected 2 to be +0 // Object.is equality
```

The first probe proves the telemetry bound is load-bearing. The second proves
the warm-walk guard is load-bearing.

The scale test passed in the serialized targeted run. `npm run build`,
`npm run lint`, `npm run build:dist`, lockfile validation, changelog validation,
and `git diff --check` passed.

### Test assessment

- `tests/clients/bus-publish.test.ts`: uniquely pins durable writer identity and
  bounded path correlation; no test became redundant.
- `tests/clients/review-graph.service.test.ts`: uniquely pins the dedicated
  8,000-file call-count bound; no test became redundant.
- `tests/clients/review-graph-persist.test.ts`: uniquely pins persistence
  telemetry field presence; no test became redundant.

## Blast radius

`clients/bus-publish.ts` affects the `publishFilesTouched` format/autofix write
entry points and its bus-events logger sink. The added fields are additive and
bounded; the hot path performs one bounded slice after the existing normalized
payload construction. `clients/bus-events-logger.ts` changes only the typed
durable record shape.

`clients/review-graph/builder.ts` removes an unused test-only export. Its runtime
entry points and callbacks are unchanged. The source-path memo remains bounded
to 16,384 entries per project and eight warm workspaces.

`module_report` is unavailable as a callable workspace tool, so the structural
blast-radius map is recorded from the repository's imports, callers, and tests.
Verification covers build, lint, distribution bundling, and the targeted suites.

## Observability

`bus-events.log` records `event: "pilens:files:touched"`,
`outcome: "emitted"`, `writer: "pi-lens"`, `reason`, `fileCount`, and up to 64
normalized `paths`. This paired record answers whether a drift event follows a
pi-lens format or autofix write. `review-graph.log` retains persistence
duration fields and `pathNormalizeCalls` on build records. No new per-file log
event is added.

## Class sweep

This change covers AGENTS.md defect shape 10, “silencing counted as fixing,”
and shape 1's O(project-files) realpath multiplier variant. A whole-tree sweep
searched `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`, and tests for
document-drift records, files-touched producers, review-graph source walking,
and normalization-call counters. The files-touched producer is the single
shared format/autofix write seam; review-graph source enumeration is the sole
raw-walker memo family. Existing freshness, eviction, and persisted-coverage
members remain covered by their per-member tests. The consolidation verdict is
to keep writer attribution at the shared publish seam and path normalization at
the shared review-graph walker boundary.

## Fix round 1

F1 is fixed in `tests/clients/bus-publish.test.ts`. The path oracle now calls
`normalizeFilePath` on the same platform-independent input paths used by the
record assertion. POSIX CI therefore expects `/repo/src/file-0.ts` and
`/repo/src/file-63.ts`, while Windows expects its normalized drive-letter form;
the test no longer freezes a Windows result into a Linux assertion.

F2 is handled in the PR metadata and issue discussion. This PR keeps the
bounded `writer: "pi-lens"` field and its test, but it does not claim AC3 for
#2070: the field is constant on this pi-lens-only record, and the paths
duplicate the existing deferred-format evidence. The remaining discriminating
signal is attribution for a pi-lens-owned write that skipped sync notification.
That requires adding a sync-notification classification to `lsp_document_drift`
in `clients/lsp/index.ts`, which is deferred to its own PR. The title now uses
`refs #2070` and keeps `closes #2072`.

The red-first mutation rerun produced this assertion verbatim:

```text
AssertionError: expected 8000 to be less than or equal to 2
```

It came from `tests/clients/review-graph.service.test.ts:293` after disabling
the source-path memo hit. The F1 assertion is platform-portable by construction
because both expected values are derived with the production normalizer.

### Test assessment

- `tests/clients/bus-publish.test.ts`: edits the existing writer/path-cap case
  to pin a portable normalized-path oracle; no test became redundant.

