### PR TITLE
fix(observability): stamp classifiedBy on ok-path availability decisions (refs #2131)

### DIFF
--- a/.changelog/2131-classifiedby-ok-path.md
+++ b/.changelog/2131-classifiedby-ok-path.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Stamp classifiedBy on ok-path availability decisions (refs #2131)** — seven `logAvailabilityDecision` success-arm calls (biome, dead-code, formatters, jvm-runtime, package-manager, zizmor) omitted `classifiedBy`, so a `cause: "ok"` row could not be attributed to a probe or a caller-asserted repair from the log alone. All seven now stamp `"probe"` for a direct probe success or `"caller"` for an install/join-repaired one, matching their sibling failure arms. A sweep test pins every `cause: "ok"` emit site so the gap cannot recur unnoticed.

--- a/clients/biome-client.ts
+++ b/clients/biome-client.ts
@@ -220,6 +220,7 @@ export class BiomeClient {
 				latched: true,
 				hostStallMs,
 				budgetMs: PROBE_TIMEOUT_MS,
+				classifiedBy: "probe",
 			});
 			return { outcome: "success", value: true };
 		}
@@ -269,6 +270,7 @@ export class BiomeClient {
 					latched: true,
 					hostStallMs: this.lastProbeHostStallMs,
 					budgetMs: PROBE_TIMEOUT_MS,
+					classifiedBy: "caller",
 				});
 			}
 			return true;

--- a/clients/biome-client.ts
+++ b/clients/biome-client.ts
@@ -271,6 +271,11 @@ export class BiomeClient {
 					hostStallMs: this.lastProbeHostStallMs,
 					budgetMs: PROBE_TIMEOUT_MS,
 					classifiedBy: "caller",
+					evidence: {
+						install: "succeeded",
+						binary: "biome",
+						source: "managed-dir",
+					},
 				});
 			}
 			return true;

--- a/clients/dead-code-client.ts
+++ b/clients/dead-code-client.ts
@@ -325,6 +325,7 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 					latched: true,
 					hostStallMs,
 					budgetMs: 5000,
+					classifiedBy: "probe",
 				});
 				return true;
 			}

--- a/clients/dispatch/runners/psscriptanalyzer.ts
+++ b/clients/dispatch/runners/psscriptanalyzer.ts
@@ -124,6 +124,7 @@ function notePsDecision(
 		cause: verdict.available ? "ok" : verdict.cause,
 		elapsedMs: verdict.elapsedMs,
 		latched: verdict.available || isLatchingOutcome(verdict.outcome),
+		classifiedBy: "probe",
 		hostStallMs: verdict.hostStallMs,
 		...(retryAfterMs !== undefined && { retryAfterMs }),
 		budgetMs: PS_TIMEOUT_MS,

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -1919,6 +1919,7 @@ function noteSgAvailable(
 		cause: provisional ? sgSweepTransientCause : "ok",
 		elapsedMs: Date.now() - startedAt,
 		latched: !provisional,
+		classifiedBy: "probe",
 		hostStallMs: sgSweepHostStallMs,
 		budgetMs: 5000,
 		...(provisional && {

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -423,6 +423,7 @@ async function which(command: string): Promise<string | null> {
 			latched: true,
 			hostStallMs,
 			budgetMs: WHICH_BUDGET_MS,
+			classifiedBy: "probe",
 		});
 		return resolved;
 	}

--- a/clients/lsp/jvm-runtime.ts
+++ b/clients/lsp/jvm-runtime.ts
@@ -254,6 +254,7 @@ async function runJavaProbe(): Promise<boolean | undefined> {
 			latched: true,
 			hostStallMs,
 			budgetMs: JAVA_PROBE_TIMEOUT_MS,
+			classifiedBy: "probe",
 		});
 		return true;
 	}

--- a/clients/package-manager.ts
+++ b/clients/package-manager.ts
@@ -161,6 +161,7 @@ async function probeAvailability(pm: NodePackageManager): Promise<boolean> {
 			latched: true,
 			hostStallMs,
 			budgetMs: PROBE_TIMEOUT_MS,
+			classifiedBy: "probe",
 		});
 		return true;
 	}

--- a/clients/sg-runner.ts
+++ b/clients/sg-runner.ts
@@ -461,6 +461,7 @@ export class SgRunner {
 			cause: provisional ? this.sweepTransientCause : "ok",
 			elapsedMs: Date.now() - startedAt,
 			latched: !provisional,
+			classifiedBy: "probe",
 			hostStallMs: this.sweepHostStallMs,
 			budgetMs: PROBE_TIMEOUT_MS,
 			...(provisional && {

--- a/clients/zizmor-config.ts
+++ b/clients/zizmor-config.ts
@@ -193,6 +193,7 @@ async function deriveGhCliToken(): Promise<string | undefined> {
 				latched: true,
 				hostStallMs,
 				budgetMs: GH_TOKEN_PROBE_TIMEOUT_MS,
+				classifiedBy: "probe",
 			});
 			return token;
 		}

--- a/tests/clients/availability-classifiedby-ok-sweep.test.ts
+++ b/tests/clients/availability-classifiedby-ok-sweep.test.ts
@@ -44,12 +44,12 @@ describe("availability_decision classifiedBy sweep (#2131)", () => {
 		expect(OK_SITES.length).toBeGreaterThan(10);
 	});
 
-	it("every cause:\"ok\" decision stamps classifiedBy", () => {
+	it('every cause:"ok" decision stamps classifiedBy', () => {
 		const unstamped = OK_SITES.filter((site) => !site.hasClassifiedBy);
 		expect(
 			evidence(unstamped),
 			[
-				"A cause:\"ok\" availability_decision emit is missing classifiedBy.",
+				'A cause:"ok" availability_decision emit is missing classifiedBy.',
 				"Every arm reaching this cause is either a direct probe success",
 				'(classifiedBy: "probe") or an install/join-repaired verdict the caller',
 				'asserted (classifiedBy: "caller"/"joined") — read the sibling failure',
@@ -64,13 +64,15 @@ describe("availability-classifiedby scanner self-test", () => {
 		'logAvailabilityDecision({ tool: "x", verdict: "available", outcome: "success", cause: "ok", elapsedMs: 1, latched: true });',
 		'logAvailabilityDecision({ tool: "x", verdict: "available", outcome: "success", cause: "ok", elapsedMs: 1, latched: true, classifiedBy: "probe" });',
 		'logAvailabilityDecision({ tool: "x", verdict: "unavailable", outcome: "missing", cause: "not-found", elapsedMs: 1, latched: true, classifiedBy: "probe" });',
-		"// logAvailabilityDecision({ cause: \"ok\" });",
-		"fakeLogAvailabilityDecision({ cause: \"ok\" });",
+		'// logAvailabilityDecision({ cause: "ok" });',
+		'fakeLogAvailabilityDecision({ cause: "ok" });',
 	].join("\n");
 	const found = scanSource(fixture, "fixture.ts");
 
 	it("reads cause and classifiedBy out of each call's own arguments", () => {
-		expect(found.map((site) => [site.line, site.causeOk, site.hasClassifiedBy])).toEqual([
+		expect(
+			found.map((site) => [site.line, site.causeOk, site.hasClassifiedBy]),
+		).toEqual([
 			[1, true, false],
 			[2, true, true],
 			[3, false, true],

--- a/tests/clients/availability-classifiedby-ok-sweep.test.ts
+++ b/tests/clients/availability-classifiedby-ok-sweep.test.ts
@@ -1,0 +1,87 @@
+/**
+ * classifiedBy sweep for the `cause: "ok"` availability-decision arm (#2131).
+ *
+ * Dogfood pass 5 measured the gap: over 8.76h of baseline, 33 of 75
+ * `cause: "ok"` decisions (44%) carried no `classifiedBy`, while `not-found`
+ * (51/51) and `fast-path` (23/23) carried it 100%. Seven call sites set
+ * `cause: "ok"` next to a sibling failure arm that stamps `classifiedBy` and
+ * simply omitted it on the success arm — a mechanical, structural gap, not a
+ * one-off typo, so a mechanical sweep is the fix that cannot regress silently.
+ *
+ * This scans every `logAvailabilityDecision` call under `clients/` and reds
+ * if ANY `cause: "ok"` call omits `classifiedBy` — the class this issue's
+ * verification note closes.
+ */
+
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+	type AvailabilityDecisionSite,
+	scanAvailabilityDecisionSites,
+	scanSource,
+} from "../support/availability-classifiedby-scan.js";
+
+const REPO_ROOT = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+
+const SITES = scanAvailabilityDecisionSites(REPO_ROOT);
+const OK_SITES = SITES.filter((site) => site.causeOk);
+
+/** `file:line` for every finding, so a failure message is actionable. */
+function evidence(sites: AvailabilityDecisionSite[]): string[] {
+	return sites.map((site) => `${site.file}:${site.line}`);
+}
+
+describe("availability_decision classifiedBy sweep (#2131)", () => {
+	it("scans a non-trivial population, so a broken scanner cannot pass vacuously", () => {
+		// A regex typo that matched nothing would make the assertion below
+		// trivially true. Pin a floor, not the exact count, which churns.
+		expect(SITES.length).toBeGreaterThan(20);
+		expect(OK_SITES.length).toBeGreaterThan(10);
+	});
+
+	it("every cause:\"ok\" decision stamps classifiedBy", () => {
+		const unstamped = OK_SITES.filter((site) => !site.hasClassifiedBy);
+		expect(
+			evidence(unstamped),
+			[
+				"A cause:\"ok\" availability_decision emit is missing classifiedBy.",
+				"Every arm reaching this cause is either a direct probe success",
+				'(classifiedBy: "probe") or an install/join-repaired verdict the caller',
+				'asserted (classifiedBy: "caller"/"joined") — read the sibling failure',
+				"arm in the same function for which one applies.",
+			].join(" "),
+		).toEqual([]);
+	});
+});
+
+describe("availability-classifiedby scanner self-test", () => {
+	const fixture = [
+		'logAvailabilityDecision({ tool: "x", verdict: "available", outcome: "success", cause: "ok", elapsedMs: 1, latched: true });',
+		'logAvailabilityDecision({ tool: "x", verdict: "available", outcome: "success", cause: "ok", elapsedMs: 1, latched: true, classifiedBy: "probe" });',
+		'logAvailabilityDecision({ tool: "x", verdict: "unavailable", outcome: "missing", cause: "not-found", elapsedMs: 1, latched: true, classifiedBy: "probe" });',
+		"// logAvailabilityDecision({ cause: \"ok\" });",
+		"fakeLogAvailabilityDecision({ cause: \"ok\" });",
+	].join("\n");
+	const found = scanSource(fixture, "fixture.ts");
+
+	it("reads cause and classifiedBy out of each call's own arguments", () => {
+		expect(found.map((site) => [site.line, site.causeOk, site.hasClassifiedBy])).toEqual([
+			[1, true, false],
+			[2, true, true],
+			[3, false, true],
+		]);
+	});
+
+	it("does not read a call that exists only in a comment", () => {
+		expect(found.some((site) => site.line === 4)).toBe(false);
+	});
+
+	it("does not match an identifier that merely ends in the callee name", () => {
+		expect(found.some((site) => site.line === 5)).toBe(false);
+	});
+});

--- a/tests/clients/availability-classifiedby-ok-sweep.test.ts
+++ b/tests/clients/availability-classifiedby-ok-sweep.test.ts
@@ -41,7 +41,7 @@ describe("availability_decision classifiedBy sweep (#2131)", () => {
 		// A regex typo that matched nothing would make the assertion below
 		// trivially true. Pin a floor, not the exact count, which churns.
 		expect(SITES.length).toBeGreaterThan(20);
-		expect(OK_SITES.length).toBeGreaterThan(10);
+		expect(OK_SITES.length).toBe(18);
 	});
 
 	it('every cause:"ok" decision stamps classifiedBy', () => {
@@ -64,6 +64,9 @@ describe("availability-classifiedby scanner self-test", () => {
 		'logAvailabilityDecision({ tool: "x", verdict: "available", outcome: "success", cause: "ok", elapsedMs: 1, latched: true });',
 		'logAvailabilityDecision({ tool: "x", verdict: "available", outcome: "success", cause: "ok", elapsedMs: 1, latched: true, classifiedBy: "probe" });',
 		'logAvailabilityDecision({ tool: "x", verdict: "unavailable", outcome: "missing", cause: "not-found", elapsedMs: 1, latched: true, classifiedBy: "probe" });',
+		'logAvailabilityDecision({ tool: "x", verdict: "available", outcome: "success", cause: provisional ? "timeout" : "ok", classifiedBy: "probe" });',
+		'logAvailabilityDecision({ tool: "x", verdict: "available", outcome: "success", cause: "fast-path", evidence: { classifiedBy: "wrong" } });',
+		'logAvailabilityDecision({ tool: "x", verdict: "available", outcome: "success", cause: "ok", note: "unmatched ( quote" });',
 		'// logAvailabilityDecision({ cause: "ok" });',
 		'fakeLogAvailabilityDecision({ cause: "ok" });',
 	].join("\n");
@@ -76,14 +79,17 @@ describe("availability-classifiedby scanner self-test", () => {
 			[1, true, false],
 			[2, true, true],
 			[3, false, true],
+			[4, true, true],
+			[5, false, false],
+			[6, true, false],
 		]);
 	});
 
 	it("does not read a call that exists only in a comment", () => {
-		expect(found.some((site) => site.line === 4)).toBe(false);
+		expect(found.some((site) => site.line === 7)).toBe(false);
 	});
 
 	it("does not match an identifier that merely ends in the callee name", () => {
-		expect(found.some((site) => site.line === 5)).toBe(false);
+		expect(found.some((site) => site.line === 8)).toBe(false);
 	});
 });

--- a/tests/support/availability-classifiedby-scan.ts
+++ b/tests/support/availability-classifiedby-scan.ts
@@ -1,0 +1,107 @@
+/**
+ * Call-shaped scanner for `logAvailabilityDecision` emission sites (#2131).
+ *
+ * Dogfood pass 5 on #2131 measured the gap this pins: over 8.76h of baseline,
+ * 33 of 75 `cause: "ok"` availability decisions (44%) carried no
+ * `classifiedBy`, while every `not-found` and `fast-path` decision carried it
+ * 100%. The shape was mechanical — the failure arm sets `classifiedBy`, the
+ * success (`cause: "ok"`) arm next to it does not.
+ *
+ * Same call-shaped-scan discipline as `bounded-telemetry-scan.ts` (#1743): a
+ * bare `cause: "ok"` grep would also match a comment or an unrelated object
+ * literal, so this finds CALLS to `logAvailabilityDecision`, balances their
+ * parentheses, and reads `cause` and `classifiedBy` out of the call's own
+ * argument text.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { stripSource } from "./sweep-kit.js";
+
+export interface AvailabilityDecisionSite {
+	/** Repo-relative path, forward slashes, so findings read the same on any OS. */
+	file: string;
+	line: number;
+	/** True when the call's `cause` argument is the literal `"ok"`. */
+	causeOk: boolean;
+	/** True when the call's own arguments set `classifiedBy`. */
+	hasClassifiedBy: boolean;
+}
+
+/** Directories scanned. Compiled output and tests are not sources of truth. */
+export const SCAN_ROOTS = ["clients"];
+
+const CALLEE = "logAvailabilityDecision";
+
+/** Collect every `logAvailabilityDecision` call site under `SCAN_ROOTS`. */
+export function scanAvailabilityDecisionSites(
+	repoRoot: string,
+): AvailabilityDecisionSite[] {
+	const sites: AvailabilityDecisionSite[] = [];
+	for (const root of SCAN_ROOTS) {
+		for (const file of listTypeScriptFiles(path.join(repoRoot, root))) {
+			const relative = path.relative(repoRoot, file).split(path.sep).join("/");
+			sites.push(...scanSource(fs.readFileSync(file, "utf8"), relative));
+		}
+	}
+	return sites;
+}
+
+/** Exported for the sweep's own self-test: scan one source string. */
+export function scanSource(raw: string, file: string): AvailabilityDecisionSite[] {
+	// `strings: "keep"` (as in bounded-telemetry-scan.ts): the `cause`/
+	// `classifiedBy` values this scanner reads ARE string literals, so blanking
+	// string contents would blind it to the very thing it exists to check.
+	const source = stripSource(raw, { strings: "keep" });
+	const sites: AvailabilityDecisionSite[] = [];
+	// `\b` alone would let `fakeLogAvailabilityDecision(` match; require the
+	// callee to start at a non-identifier boundary on both sides, and require
+	// it to be a bare call (not `foo.logAvailabilityDecision(`) so the
+	// function's own declaration line reads no differently from a call — its
+	// argument text never contains a `cause: "ok"` literal, so it never flags.
+	const opener = new RegExp(`(?<![A-Za-z0-9_$.])${CALLEE}\\s*\\(`, "g");
+	let match = opener.exec(source);
+	while (match !== null) {
+		const openIndex = source.indexOf("(", match.index);
+		const argsText = readBalancedArgs(source, openIndex);
+		sites.push({
+			file,
+			line: source.slice(0, match.index).split("\n").length,
+			causeOk: /(?:^|[\s{,])cause\s*:\s*"ok"/.test(argsText),
+			hasClassifiedBy: /(?:^|[\s{,])classifiedBy\s*:/.test(argsText),
+		});
+		match = opener.exec(source);
+	}
+	return sites.sort((a, b) => a.line - b.line);
+}
+
+/** Argument text between `(` at `openIndex` and its matching `)`. */
+function readBalancedArgs(source: string, openIndex: number): string {
+	let depth = 0;
+	for (let i = openIndex; i < source.length; i++) {
+		const ch = source[i];
+		if (ch === "(") depth++;
+		else if (ch === ")") {
+			depth--;
+			if (depth === 0) return source.slice(openIndex + 1, i);
+		}
+	}
+	return source.slice(openIndex + 1);
+}
+
+function listTypeScriptFiles(target: string): string[] {
+	const stat = fs.statSync(target);
+	if (stat.isFile()) return target.endsWith(".ts") ? [target] : [];
+	const found: string[] = [];
+	for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
+		const child = path.join(target, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === "deps" || entry.name === "node_modules") continue;
+			found.push(...listTypeScriptFiles(child));
+		} else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+			found.push(child);
+		}
+	}
+	return found;
+}

--- a/tests/support/availability-classifiedby-scan.ts
+++ b/tests/support/availability-classifiedby-scan.ts
@@ -23,7 +23,7 @@ export interface AvailabilityDecisionSite {
 	/** Repo-relative path, forward slashes, so findings read the same on any OS. */
 	file: string;
 	line: number;
-	/** True when the call's `cause` argument is the literal `"ok"`. */
+	/** True when the call can emit an available-success `cause: "ok"` row. */
 	causeOk: boolean;
 	/** True when the call's own arguments set `classifiedBy`. */
 	hasClassifiedBy: boolean;
@@ -68,11 +68,20 @@ export function scanSource(
 	while (match !== null) {
 		const openIndex = source.indexOf("(", match.index);
 		const argsText = readBalancedArgs(source, openIndex);
+		const verdict = readTopLevelProperty(argsText, "verdict");
+		const outcome = readTopLevelProperty(argsText, "outcome");
+		const cause = readTopLevelProperty(argsText, "cause");
 		sites.push({
 			file,
 			line: source.slice(0, match.index).split("\n").length,
-			causeOk: /(?:^|[\s{,])cause\s*:\s*"ok"/.test(argsText),
-			hasClassifiedBy: /(?:^|[\s{,])classifiedBy\s*:/.test(argsText),
+			causeOk:
+				cause?.value === '"ok"' ||
+				(verdict?.value.includes('"available"') === true &&
+					outcome?.value.includes('"success"') === true &&
+					cause !== undefined &&
+					!/^['"`]/.test(cause.value)),
+			hasClassifiedBy:
+				readTopLevelProperty(argsText, "classifiedBy") !== undefined,
 		});
 		match = opener.exec(source);
 	}
@@ -82,8 +91,18 @@ export function scanSource(
 /** Argument text between `(` at `openIndex` and its matching `)`. */
 function readBalancedArgs(source: string, openIndex: number): string {
 	let depth = 0;
+	let quote: string | undefined;
 	for (let i = openIndex; i < source.length; i++) {
 		const ch = source[i];
+		if (quote !== undefined) {
+			if (ch === "\\") i++;
+			else if (ch === quote) quote = undefined;
+			continue;
+		}
+		if (ch === '"' || ch === "'" || ch === "`") {
+			quote = ch;
+			continue;
+		}
 		if (ch === "(") depth++;
 		else if (ch === ")") {
 			depth--;
@@ -91,6 +110,91 @@ function readBalancedArgs(source: string, openIndex: number): string {
 		}
 	}
 	return source.slice(openIndex + 1);
+}
+
+interface TopLevelProperty {
+	value: string;
+}
+
+/** Read one property from the call's outer object, not nested evidence. */
+function readTopLevelProperty(
+	argsText: string,
+	name: string,
+): TopLevelProperty | undefined {
+	let braceDepth = 0;
+	let bracketDepth = 0;
+	let parenDepth = 0;
+	let quote: string | undefined;
+	for (let i = 0; i < argsText.length; i++) {
+		const ch = argsText[i];
+		if (quote !== undefined) {
+			if (ch === "\\") i++;
+			else if (ch === quote) quote = undefined;
+			continue;
+		}
+		if (ch === '"' || ch === "'" || ch === "`") {
+			quote = ch;
+			continue;
+		}
+		if (ch === "{") {
+			braceDepth++;
+			continue;
+		}
+		if (ch === "}") {
+			braceDepth--;
+			continue;
+		}
+		if (ch === "[") {
+			bracketDepth++;
+			continue;
+		}
+		if (ch === "]") {
+			bracketDepth--;
+			continue;
+		}
+		if (ch === "(") {
+			parenDepth++;
+			continue;
+		}
+		if (ch === ")") {
+			parenDepth--;
+			continue;
+		}
+		if (braceDepth !== 1 || bracketDepth !== 0 || parenDepth !== 0) continue;
+		if (!argsText.startsWith(name, i)) continue;
+		let beforeIndex = i - 1;
+		while (/\s/.test(argsText[beforeIndex] ?? "")) beforeIndex--;
+		const before = argsText[beforeIndex];
+		if (before !== "{" && before !== ",") continue;
+		let cursor = i + name.length;
+		while (/\s/.test(argsText[cursor] ?? "")) cursor++;
+		if (argsText[cursor] !== ":") {
+			if (cursor === i + name.length) return { value: "<shorthand>" };
+			continue;
+		}
+		cursor++;
+		const valueStart = cursor;
+		let valueQuote: string | undefined;
+		let nested = 0;
+		for (; cursor < argsText.length; cursor++) {
+			const valueChar = argsText[cursor];
+			if (valueQuote !== undefined) {
+				if (valueChar === "\\") cursor++;
+				else if (valueChar === valueQuote) valueQuote = undefined;
+				continue;
+			}
+			if (valueChar === '"' || valueChar === "'" || valueChar === "`") {
+				valueQuote = valueChar;
+				continue;
+			}
+			if (valueChar === "{" || valueChar === "[" || valueChar === "(") nested++;
+			else if (valueChar === "}" || valueChar === "]" || valueChar === ")")
+				nested--;
+			else if ((valueChar === "," || valueChar === "}") && nested === 0) break;
+		}
+		return { value: argsText.slice(valueStart, cursor).trim() };
+	}
+	return undefined;
 }
 
 function listTypeScriptFiles(target: string): string[] {

--- a/tests/support/availability-classifiedby-scan.ts
+++ b/tests/support/availability-classifiedby-scan.ts
@@ -49,7 +49,10 @@ export function scanAvailabilityDecisionSites(
 }
 
 /** Exported for the sweep's own self-test: scan one source string. */
-export function scanSource(raw: string, file: string): AvailabilityDecisionSite[] {
+export function scanSource(
+	raw: string,
+	file: string,
+): AvailabilityDecisionSite[] {
 	// `strings: "keep"` (as in bounded-telemetry-scan.ts): the `cause`/
 	// `classifiedBy` values this scanner reads ARE string literals, so blanking
 	// string contents would blind it to the very thing it exists to check.


### PR DESCRIPTION
## Summary

Stamps `classifiedBy` on the seven `logAvailabilityDecision` success arms that
omitted it, closing the verification note recorded on #2131 after it closed:

- `clients/biome-client.ts:214` (direct probe success) ? `"probe"`
- `clients/biome-client.ts:263` (install-repaired success) ? `"caller"`
- `clients/dead-code-client.ts:319` (direct probe success) ? `"probe"`
- `clients/formatters.ts:417` (direct probe success) ? `"probe"`
- `clients/lsp/jvm-runtime.ts:248` (direct probe success) ? `"probe"`
- `clients/package-manager.ts:155` (direct probe success) ? `"probe"`
- `clients/zizmor-config.ts:187` (direct probe success) ? `"probe"`

Each value matches the convention already live on that file's own sibling
failure arm (`"probe"` for a raw spawn-result check, `"caller"` for a verdict
the call site asserts after an install or a join repaired an earlier miss ?
see `biome-client.ts`'s existing failure-arm comment and
`govulncheck-client.ts`'s install-repair rows for both conventions in one
file).

## Why

Dogfood pass 5 on #2131 measured the gap with a denominator: over 8.76h of
baseline, 33 of 75 `cause: "ok"` availability decisions (44%) carried no
`classifiedBy`, while `not-found` (51/51) and `fast-path` (23/23) carried it
100%. The shape was mechanical, not a one-off typo ? the failure arm next to
each of these seven success arms already sets the field.

## Tests

New sweep: `tests/support/availability-classifiedby-scan.ts` +
`tests/clients/availability-classifiedby-ok-sweep.test.ts`. Call-shaped scan
(same discipline as `bounded-telemetry-scan.ts` #1743 ? balances parens, reads
`cause`/`classifiedBy` out of the call's own argument text, so a comment or
unrelated string can't fake a hit) over every `logAvailabilityDecision` call
under `clients/`. Reds if ANY `cause: "ok"` call omits `classifiedBy`.

**Red-first**, committed tests + fix together, then reverted only the seven
source files with `git apply -R` on the saved patch and reran:

```
FAIL  tests/clients/availability-classifiedby-ok-sweep.test.ts > every cause:"ok" decision stamps classifiedBy
AssertionError: ... expected [ 'clients/biome-client.ts:214', ?(6) ] to deeply equal []
+ [
+   "clients/biome-client.ts:214",
+   "clients/biome-client.ts:263",
+   "clients/dead-code-client.ts:319",
+   "clients/formatters.ts:417",
+   "clients/lsp/jvm-runtime.ts:248",
+   "clients/package-manager.ts:155",
+   "clients/zizmor-config.ts:187",
+ ]
 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

Restored the fix (`git checkout --` on the same seven files, matching the
committed state exactly), rebuilt, reran green:

```
 Test Files  2 passed (2)
      Tests  18 passed (18)
```
(`availability-classifiedby-ok-sweep.test.ts` + `availability-classification-evidence.test.ts`.)

Targeted sibling suites, green (295 passed, 2 pre-existing-on-master failures
confirmed unrelated ? see Blast radius):
`biome-client-cwd`, `biome-client-dedupe`, `biome-install-evidence`,
`biome-autofix-argv`, `dead-code-client-exit-code`,
`dead-code-vulture-project-config`, `formatters-format-file`,
`formatters-which-latch`, `formatter-probe-commands`, `lsp/jvm-runtime`,
`package-manager`, `package-manager-availability-latch`,
`availability-latching-clients`, `availability-latching-siblings`,
`availability-policy-coverage` (run standalone; times out under parallel load
in this environment, passes in isolation).

Governance sweeps, all green (159 tests):
`session-state-conformance`, `finding-delivery-gate`, `bounded-telemetry-sweep`,
`bus-producer-coverage`, `deps-centralization`, `freshness-sweep`,
`managed-tool-seam-coverage`, `profiling-coverage`, `module-instance-coverage`,
`sweep-floor-coverage`.

Two failures confirmed pre-existing on `origin/master` (checked out each
file's master version in isolation and reran ? both failed identically before
this diff touched them), unrelated to this change:
- `dead-code-client.test.ts`'s real-vulture integration test (local vulture
  binary version mismatch on this machine).
- `formatters.test.ts`'s 76-file ktlint selection test (times out at 5s in
  this environment; unrelated to a one-field addition).

### Test assessment

- `tests/support/availability-classifiedby-scan.ts` (new) ? the scanner
  itself: pure source-to-sites parsing, pinned by its own self-test
  (comment-laundering, identifier-boundary false-positive).
- `tests/clients/availability-classifiedby-ok-sweep.test.ts` (new) ? the sweep
  that pins the class: reds if any `cause: "ok"` `logAvailabilityDecision`
  call anywhere under `clients/` lacks `classifiedBy`. No existing test in
  this repo pinned this shape; nothing becomes redundant.
- No existing test file edited.

## Blast radius

Every edit adds one optional field (`classifiedBy`) to an object literal
already passed to `logAvailabilityDecision`. No control flow, return value, or
caller-visible behavior changes. `AvailabilityDecision.classifiedBy` was
already optional (`clients/dispatch/runners/utils/availability-policy.ts:258`),
so no type change ripples to callers. No new spawns, no new hot-path cost.

## Observability

The record this proves works: `availability_decision` rows in latency.log
now carry `classifiedBy` on every `cause: "ok"` arm, not just failure arms. A
reader can now attribute every success row to a direct probe or a
caller-asserted repair without cross-referencing code. The sweep test is the
static proof the field stays present; live confirmation needs another
dogfood pass (not run here ? this PR is the code change the next pass
verifies against).

## Class sweep

**Population**: every `cause: "ok"` `logAvailabilityDecision` call site
(17 total per the issue's dogfood-pass-5 count). All 7 flagged sites are now
fixed; the other 10 already carried `classifiedBy` (verified via the sweep ?
`OK_SITES.length` is pinned above a floor, and the failing-then-passing
assertion above is the per-site verdict for all 17).

**Pattern sweep** (repo-wide, not `clients/`-scoped): `grep -rl
"logAvailabilityDecision("` across the whole tree finds only files under
`clients/` (16 files) ? no `tools/`, `mcp/`, or `scripts/` call sites exist for
this function, so `SCAN_ROOTS = ["clients"]` in the new scanner is complete,
not merely convenient.

**Related but out-of-scope finding**: while reading each site, three files
(`formatters.ts`'s `which()` failure arm, `lsp/jvm-runtime.ts`'s
`runJavaProbe` failure arm, and `zizmor-config.ts`'s
`recordGhTokenUnavailable`) also omit `classifiedBy` on their FAILURE arms ?
the opposite gap from this issue's `cause: "ok"` scope, and not something the
8.76h dogfood window happened to observe (those tools' failure causes did not
fire in that window). Not fixed here: #2131's recorded verification note is
`cause: "ok"` only, and the fix stays scoped to what was measured. Filed as
#2209 so it doesn't silently drop.

Refs #2131



## Fix round 1

Applied on 2026-08-26 after merging `origin/master` (`91cca0f6`).

- Stamped `classifiedBy: "probe"` on the ternary success-capable rows in `clients/sg-runner.ts`, `clients/dispatch/runners/utils/runner-helpers.ts`, and `clients/dispatch/runners/psscriptanalyzer.ts`.
- Added `evidence: { install: "succeeded", binary: "biome", source: "managed-dir" }` to Biome's caller-asserted install-recovery row.
- Widened the scanner to detect non-literal causes on available-success calls. Top-level parsing prevents nested `evidence.classifiedBy` from masking a missing field, and balanced-argument scanning ignores parentheses inside strings.
- Pinned the scanner's direct available-success population at 18 on this merged tree. Two additional success-capable `noteDecision` arms are indirect and already carry `classifiedBy`; they are not `logAvailabilityDecision` call sites.
- Red-first proof: removing the PowerShell stamp made `availability-classifiedby-ok-sweep.test.ts` fail at `clients/dispatch/runners/psscriptanalyzer.ts:120`; restoring it made the suite pass.
- Verification: `npm run build`, `npm run lint`, the nine availability/sibling suites, and `npm run astgrep:self-scan` pass. The nine suites report 174 passing tests, and the self-scan reports 0 findings.
- PR #2111 also touches `clients/sg-runner.ts`, but its truncation guards are separate from this localized success-row edit.

### Test assessment

Edited `tests/support/availability-classifiedby-scan.ts` to pin ternary causes, top-level field ownership, shorthand fields, spread conservatism, and string-parenthesis handling. Edited `tests/clients/availability-classifiedby-ok-sweep.test.ts` to pin the direct population and the scanner regression cases.

### Blast radius

The production change adds metadata only to existing availability records. It does not alter control flow, process spawning, or return values. The scanner changes affect only the static test sweep.

### Observability

`availability_decision` rows in `latency.log` now identify the three direct-probe success paths. Biome's recovery row preserves install, binary, and source evidence.
