### PR TITLE
fix(installer): bound JSON and Bash language-server probes (closes #2194)

### DIFF
--- a/.changelog/fix-2194-ls-probe-budgets.md
+++ b/.changelog/fix-2194-ls-probe-budgets.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Bound the JSON and Bash language-server verification probes (closes #2194)** — `bash-language-server` and `vscode-json-language-server` measured 9,667ms and 11,047ms cold `--version` starts with closed stdin, close enough to the 10-second installer default that host contention alone could trip a false verification degradation. Both now carry a 20-second `verificationTimeoutMs`, delivered through the managed-local, install, and refresh paths. The refresh delivery for the other five install strategies (pip, gem, github, maven, archive) is now covered by tests too, closing the gap the issue's follow-up comment flagged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -703,7 +703,15 @@ preserved as `cause`. (#1214)
 opt into `safeSpawnAsync`'s `input: ""` so every verification receives EOF.
 The registry may declare a larger bounded timeout for a tool whose cold
 launcher startup exceeds the dispatch budget; Vue uses 30 seconds while the
-installer default remains 10 seconds (#2176).
+installer default remains 10 seconds (#2176). bash-language-server and
+vscode-json-language-server measured 9,667ms and 11,047ms cold with closed
+stdin — both close enough to the 10s default that host contention alone can
+trip a false verification degradation — and use a 20-second bound (#2194).
+Delivery is proven per strategy, not just for npm: `probeManagedToolVersion`
+(pip/gem) and `verifyRefreshedArtifact` (github/maven/archive) both resolve
+the timeout through `getToolVerificationTimeout` on every call, and each of
+the six strategies has a test that raises a tool's `verificationTimeoutMs`
+and asserts the exact value reaches the post-refresh `--version` spawn (#2194).
 This matters for markdownlint-cli2: `--version` scanned 45 files and returned
 in about 370ms when stdin was closed, while `--no-globs -` linted one stdin
 file and returned in about 370ms; with production-shaped open stdin the latter

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -549,6 +549,12 @@ export const TOOLS: ToolDefinition[] = [
 		name: "Bash Language Server",
 		checkCommand: "bash-language-server",
 		checkArgs: ["--version"],
+		// The #2188 sweep measured a 9,667ms cold `--version` start with closed
+		// stdin — close enough to the 10s installer default that modest host
+		// contention pushes it over and emits a false verification degradation.
+		// 20s gives the same kind of headroom Vue's 30s bound gives its own
+		// slower cold start (#2176), without inventing a shared literal (#2194).
+		verificationTimeoutMs: 20_000,
 		installStrategy: "npm",
 		packageName: "bash-language-server",
 		binaryName: "bash-language-server",
@@ -585,6 +591,11 @@ export const TOOLS: ToolDefinition[] = [
 		name: "VSCode JSON Language Server",
 		checkCommand: "vscode-json-language-server",
 		checkArgs: ["--version"],
+		// The #2188 sweep measured an 11,047ms cold `--version` start with closed
+		// stdin — over the 10s installer default, so a cold or contended host can
+		// see a false verification degradation before the binary ever answers.
+		// 20s mirrors the bash-language-server bound above (#2194).
+		verificationTimeoutMs: 20_000,
 		installStrategy: "npm",
 		packageName: "vscode-langservers-extracted",
 		binaryName: "vscode-json-language-server",

--- a/tests/clients/installer/managed-tool-refresh-strategies.test.ts
+++ b/tests/clients/installer/managed-tool-refresh-strategies.test.ts
@@ -1011,7 +1011,10 @@ describe("verification-budget delivery across non-npm strategies", () => {
 		const suffix = isWindows ? ".bat" : "";
 		spawnMock.mockImplementation(async (command: string, args: string[]) => {
 			const argv = args ?? [];
-			if (/tar(\.exe)?$/i.test(command) && argv.some((a) => a.startsWith("-x"))) {
+			if (
+				/tar(\.exe)?$/i.test(command) &&
+				argv.some((a) => a.startsWith("-x"))
+			) {
 				const destIndex = argv.indexOf("-C");
 				const destRel = destIndex >= 0 ? argv[destIndex + 1] : undefined;
 				if (destRel) {
@@ -1117,7 +1120,10 @@ describe("verification-budget delivery across non-npm strategies", () => {
 		await withVerificationTimeout("ktfmt", 45_000, async () => {
 			installManagedBin("ktfmt");
 			freshenAllExcept("ktfmt", {
-				ktfmt: { checkedAt: NOW - 8 * DAY_MS, resolutionId: `${KTFMT_PIN}-old` },
+				ktfmt: {
+					checkedAt: NOW - 8 * DAY_MS,
+					resolutionId: `${KTFMT_PIN}-old`,
+				},
 			});
 			httpsRoutes.push({
 				match: (url) => url.startsWith("https://repo1.maven.org/"),

--- a/tests/clients/installer/managed-tool-refresh-strategies.test.ts
+++ b/tests/clients/installer/managed-tool-refresh-strategies.test.ts
@@ -958,6 +958,183 @@ describe("archive and maven strategies compare the registry pin", () => {
 	});
 });
 
+// --- verification-budget delivery, all five non-npm strategies (#2194) ----
+
+/**
+ * The #2194 comment flagged that the per-strategy refresh candidate carries
+ * `verificationTimeoutMs` for npm only, and that `probeManagedToolVersion`
+ * (pip/gem) and `verifyRefreshedArtifact` (github/maven/archive) had no red
+ * test proving a registry-scoped budget actually reaches the post-refresh
+ * spawn instead of silently falling back to the shared 10s default. Each
+ * case here temporarily raises an already-fixtured tool's
+ * `verificationTimeoutMs` and asserts the exact value lands in the
+ * `--version` probe's spawn options.
+ */
+describe("verification-budget delivery across non-npm strategies", () => {
+	async function withVerificationTimeout<T>(
+		toolId: string,
+		timeoutMs: number,
+		fn: () => Promise<T>,
+	): Promise<T> {
+		const tool = TOOLS.find((t) => t.id === toolId);
+		if (!tool) throw new Error(`unknown tool ${toolId}`);
+		const original = tool.verificationTimeoutMs;
+		tool.verificationTimeoutMs = timeoutMs;
+		try {
+			// Awaited, not returned bare — a bare `return fn()` would run this
+			// `finally` synchronously right after the promise is created, restoring
+			// the original timeout before the awaited refresh ever reaches its
+			// spawn, and every assertion below would silently see the default.
+			return await fn();
+		} finally {
+			tool.verificationTimeoutMs = original;
+		}
+	}
+
+	/** Every `--version` spawn's `timeout` option, across all calls. */
+	function versionProbeTimeouts(): Array<number | undefined> {
+		return spawnMock.mock.calls
+			.filter(([, args]) => (args ?? []).includes("--version"))
+			.map(([, , options]) => (options as { timeout?: number })?.timeout);
+	}
+
+	/**
+	 * `installArchiveTool` verifies its launcher on real disk after a MOCKED
+	 * `tar` spawn, so the mock has to actually materialize the launcher file
+	 * (into the `-C` destination it was asked to extract to) or the install
+	 * fails before verification is ever reached. Every other spawn — the
+	 * `--version` post-refresh probe included — falls through to the default
+	 * success stub.
+	 */
+	function stubArchiveExtraction(launcherRelPath: string): void {
+		const isWindows = process.platform === "win32";
+		const suffix = isWindows ? ".bat" : "";
+		spawnMock.mockImplementation(async (command: string, args: string[]) => {
+			const argv = args ?? [];
+			if (/tar(\.exe)?$/i.test(command) && argv.some((a) => a.startsWith("-x"))) {
+				const destIndex = argv.indexOf("-C");
+				const destRel = destIndex >= 0 ? argv[destIndex + 1] : undefined;
+				if (destRel) {
+					const destAbs = path.join(
+						TOOLS_DIR,
+						destRel,
+						...`${launcherRelPath}${suffix}`.split("/"),
+					);
+					fs.mkdirSync(path.dirname(destAbs), { recursive: true });
+					fs.writeFileSync(destAbs, "#!/bin/sh\necho 1.2.3\nexit 0\n");
+				}
+				return { stdout: "", stderr: "", status: 0 };
+			}
+			return { stdout: "1.2.3", stderr: "", status: 0 };
+		});
+	}
+
+	it("delivers a github tool's custom budget to the post-refresh verify (#2194)", async () => {
+		await withVerificationTimeout("shfmt", 45_000, async () => {
+			installManagedBin("shfmt");
+			freshenAllExcept("shfmt", {
+				shfmt: { checkedAt: NOW - 8 * DAY_MS, resolutionId: "v3.7.0" },
+			});
+			routeGitHubRelease("v3.12.0", { etag: 'W/"abc"' });
+
+			const outcome = await runManagedToolRefresh(NOW);
+
+			expect(outcome.refreshed[0]).toMatchObject({
+				toolId: "shfmt",
+				ok: true,
+			});
+			expect(versionProbeTimeouts()).toContain(45_000);
+		});
+	});
+
+	it("delivers a pip tool's custom budget to both version probes (#2194)", async () => {
+		await withVerificationTimeout("ruff", 45_000, async () => {
+			installProbeCached("ruff");
+			freshenAllExcept("ruff", {
+				ruff: { checkedAt: NOW - 8 * DAY_MS, version: "0.5.0" },
+			});
+
+			const outcome = await runManagedToolRefresh(NOW);
+
+			expect(outcome.refreshed[0]).toMatchObject({
+				toolId: "ruff",
+				ok: true,
+			});
+			const timeouts = versionProbeTimeouts();
+			expect(timeouts.length).toBeGreaterThan(0);
+			expect(timeouts.every((t) => t === 45_000)).toBe(true);
+		});
+	});
+
+	it("delivers a gem tool's custom budget to both version probes (#2194)", async () => {
+		await withVerificationTimeout("rubocop", 45_000, async () => {
+			installProbeCached("rubocop");
+			freshenAllExcept("rubocop", {
+				rubocop: { checkedAt: NOW - 8 * DAY_MS, version: "1.60.0" },
+			});
+
+			const outcome = await runManagedToolRefresh(NOW);
+
+			expect(outcome.refreshed[0]).toMatchObject({
+				toolId: "rubocop",
+				ok: true,
+			});
+			const timeouts = versionProbeTimeouts();
+			expect(timeouts.length).toBeGreaterThan(0);
+			expect(timeouts.every((t) => t === 45_000)).toBe(true);
+		});
+	});
+
+	it("delivers an archive tool's custom budget to the post-refresh verify (#2194)", async () => {
+		await withVerificationTimeout("spotbugs", 45_000, async () => {
+			installManagedBin("spotbugs");
+			freshenAllExcept("spotbugs", {
+				spotbugs: {
+					checkedAt: NOW - 8 * DAY_MS,
+					resolutionId: `${SPOTBUGS_PIN}-old`,
+				},
+			});
+			httpsRoutes.push({
+				match: (url) => url.includes("spotbugs"),
+				respond: () => ({
+					statusCode: 200,
+					body: Buffer.from("archive-bytes"),
+				}),
+			});
+			stubArchiveExtraction("bin/spotbugs");
+
+			const outcome = await runManagedToolRefresh(NOW);
+
+			expect(outcome.refreshed[0]).toMatchObject({
+				toolId: "spotbugs",
+				ok: true,
+			});
+			expect(versionProbeTimeouts()).toContain(45_000);
+		});
+	});
+
+	it("delivers a maven tool's custom budget to the post-refresh verify (#2194)", async () => {
+		await withVerificationTimeout("ktfmt", 45_000, async () => {
+			installManagedBin("ktfmt");
+			freshenAllExcept("ktfmt", {
+				ktfmt: { checkedAt: NOW - 8 * DAY_MS, resolutionId: `${KTFMT_PIN}-old` },
+			});
+			httpsRoutes.push({
+				match: (url) => url.startsWith("https://repo1.maven.org/"),
+				respond: () => ({ statusCode: 200, body: Buffer.from("jar-bytes") }),
+			});
+
+			const outcome = await runManagedToolRefresh(NOW);
+
+			expect(outcome.refreshed[0]).toMatchObject({
+				toolId: "ktfmt",
+				ok: true,
+			});
+			expect(versionProbeTimeouts()).toContain(45_000);
+		});
+	});
+});
+
 // --- archive refresh never destroys a working install (#1759 review F1) --
 //
 // The reviewer's exact probe: a working extracted tree, a refresh whose

--- a/tests/clients/installer/managed-tool-refresh.test.ts
+++ b/tests/clients/installer/managed-tool-refresh.test.ts
@@ -943,6 +943,40 @@ describe("post-update verification (review F2)", () => {
 		}
 	});
 
+	it("delivers bash-language-server's 20s budget through npm refresh (#2194)", async () => {
+		installFixture("bash-language-server", "4.0.0");
+		stubSpawn("ok", { "bash-language-server": "5.0.0" });
+
+		const outcome = await runManagedToolRefresh(NOW);
+
+		expect(outcome.refreshed[0]).toMatchObject({
+			toolId: "bash-language-server",
+			ok: true,
+			verified: true,
+		});
+		expect(verifyOptions).toHaveBeenCalledWith(
+			expect.objectContaining({ timeout: 20_000 }),
+		);
+	});
+
+	it("delivers vscode-json-language-server's 20s budget through npm refresh (#2194)", async () => {
+		installFixture("vscode-langservers-extracted", "4.0.0", {
+			binaryName: "vscode-json-language-server",
+		});
+		stubSpawn("ok", { "vscode-langservers-extracted": "5.0.0" });
+
+		const outcome = await runManagedToolRefresh(NOW);
+
+		expect(outcome.refreshed[0]).toMatchObject({
+			toolId: "vscode-json-language-server",
+			ok: true,
+			verified: true,
+		});
+		expect(verifyOptions).toHaveBeenCalledWith(
+			expect.objectContaining({ timeout: 20_000 }),
+		);
+	});
+
 	it("fails the refresh when the updated binary cannot run", async () => {
 		installFixture("knip", "6.4.1");
 		spawnMock.mockImplementation(async (_c: string, args: string[]) => {

--- a/tests/clients/installer/tool-discovery.test.ts
+++ b/tests/clients/installer/tool-discovery.test.ts
@@ -443,9 +443,9 @@ describe("managed npm executable paths", () => {
 			);
 			fakeAccess(localPath);
 
-			await expect(
-				ensureTool(toolId, { allowInstall: false }),
-			).resolves.toBe(localPath);
+			await expect(ensureTool(toolId, { allowInstall: false })).resolves.toBe(
+				localPath,
+			);
 			expect(
 				spawnCalls.some(
 					({ cmd, args, timeout }) =>

--- a/tests/clients/installer/tool-discovery.test.ts
+++ b/tests/clients/installer/tool-discovery.test.ts
@@ -426,6 +426,71 @@ describe("managed npm executable paths", () => {
 		});
 	});
 
+	it.each([
+		["bash-language-server", "bash-language-server"],
+		["vscode-json-language-server", "vscode-json-language-server"],
+	])(
+		"passes the %s verification budget to the managed-local probe (#2194)",
+		async (toolId, binaryName) => {
+			process.env.PI_LENS_TEST_PLATFORM = "win32";
+			const localPath = path.join(
+				TEST_HOME,
+				".pi-lens",
+				"tools",
+				"node_modules",
+				".bin",
+				`${binaryName}.cmd`,
+			);
+			fakeAccess(localPath);
+
+			await expect(
+				ensureTool(toolId, { allowInstall: false }),
+			).resolves.toBe(localPath);
+			expect(
+				spawnCalls.some(
+					({ cmd, args, timeout }) =>
+						cmd === localPath &&
+						args.includes("--version") &&
+						timeout === 20_000,
+				),
+			).toBe(true);
+		},
+	);
+
+	it.each([
+		["bash-language-server", "bash-language-server"],
+		["vscode-json-language-server", "vscode-json-language-server"],
+	])(
+		"passes the %s verification budget through npm install (#2194)",
+		async (toolId, binaryName) => {
+			process.env.PI_LENS_TEST_PLATFORM = "win32";
+			process.env.PI_LENS_TEST_MODE = "1";
+			process.env.PI_LENS_TEST_NPM_SCRIPT = "install";
+			await withEmptyPath(async () => {
+				const expected = path.join(
+					TEST_HOME,
+					".pi-lens",
+					"tools",
+					"node_modules",
+					".bin",
+					`${binaryName}.cmd`,
+				);
+				fakeAccess(expected);
+				mockFsStat.mockResolvedValue({ mtimeMs: 1 });
+				await expect(
+					ensureTool(toolId, { forceReinstall: true }),
+				).resolves.toBe(expected);
+				const verificationCalls = spawnCalls.filter(
+					({ cmd, args }) => cmd === expected && args.includes("--version"),
+				);
+				expect(verificationCalls.length).toBeGreaterThan(0);
+				expect(
+					verificationCalls.every(({ timeout }) => timeout === 20_000),
+				).toBe(true);
+			});
+		},
+	);
+
 	it("clears the madge managed-path memo when a managed install succeeds (#1276)", async () => {
 		process.env.PI_LENS_TEST_PLATFORM = "win32";
 		process.env.PI_LENS_TEST_MODE = "1";

--- a/tests/clients/installer/tool-registry-consistency.test.ts
+++ b/tests/clients/installer/tool-registry-consistency.test.ts
@@ -63,6 +63,17 @@ describe("TOOLS registry consistency", () => {
 		expect(vue?.verificationTimeoutMs).toBe(30_000);
 	});
 
+	it("uses the bash/JSON language-server cold-start budgets (#2194)", () => {
+		const bash = TOOLS.find((tool) => tool.id === "bash-language-server");
+		const json = TOOLS.find(
+			(tool) => tool.id === "vscode-json-language-server",
+		);
+		expect(bash).toBeDefined();
+		expect(json).toBeDefined();
+		expect(getToolVerificationTimeout(bash!)).toBe(20_000);
+		expect(getToolVerificationTimeout(json!)).toBe(20_000);
+	});
+
 	it("every tool has the required base wiring (id, name, checkCommand, checkArgs, strategy)", () => {
 		for (const t of TOOLS) {
 			expect(typeof t.id, `id on ${JSON.stringify(t.name)}`).toBe("string");


### PR DESCRIPTION
## Summary

Bound cold-start verification for `bash-language-server` and
`vscode-json-language-server` at 20 seconds. Add delivery tests proving that
all non-npm refresh strategies pass a custom verification timeout to the
post-refresh `--version` probe. This completes #2194.

The 20-second budget is derived from cold measurements: Bash takes 20s for
9.67s of observed work, or 2.07x; JSON takes 20s for 11.05s, or 1.81x.
Both budgets remain bounded and safe. Vue's existing 30s budget is 1.33x its
22.6s measurement.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation

## Area

- [x] area:installer
- [x] area:lsp
- [x] area:tests

## Changes

- Set `verificationTimeoutMs: 20_000` for both language-server registry entries.
- Add discovery, refresh, and registry consistency coverage for the budgets.
- Add delivery coverage for pip, gem, GitHub, Maven, and archive refreshes.

## Tests

- `tests/clients/installer/tool-discovery.test.ts`: verifies managed-local and
  npm-install delivery for both language servers.
- `tests/clients/installer/managed-tool-refresh.test.ts`: verifies npm-refresh
  delivery for both language servers.
- `tests/clients/installer/tool-registry-consistency.test.ts`: verifies both
  registry entries resolve to 20 seconds.
- `tests/clients/installer/managed-tool-refresh-strategies.test.ts`: verifies
  custom timeout delivery through each non-npm refresh strategy.

The new regression tests were red on pre-fix code because they observed
`10000` instead of `20000`. The targeted suites pass after the fix.

## Test assessment

- `tool-discovery.test.ts` uniquely pins timeout delivery through managed-local
  discovery and npm installation; no touched test is redundant.
- `managed-tool-refresh.test.ts` uniquely pins npm-refresh delivery; no
  touched test is redundant.
- `tool-registry-consistency.test.ts` uniquely pins registry configuration;
  no touched test is redundant.
- `managed-tool-refresh-strategies.test.ts` uniquely pins delivery through
  each non-npm strategy; no touched test is redundant.

## Blast radius

The affected dependents are managed-local discovery, npm installation, and
all managed refresh strategies that await verification through
`clients/lsp/server.ts:636`. `installNpmTool` retries verification three times
with 1s and 2s backoff, so a broken Bash or JSON install can now cost up to
approximately 63 seconds, versus approximately 33 seconds before this
change. Healthy binaries answer well below the budget. Dispatch's separate
5-second budget is unchanged. No callbacks or entry points change, and the
production hot-path cost is limited to the existing bounded retry path.

## Class sweep

The pattern sweep covers `clients/`, `tools/`, `mcp/`, `scripts/`, and
`index.ts` for installer verification defaults. The population sweep covers
npm, pip, gem, GitHub, Maven, and archive strategies. Each strategy uses the
shared timeout seam, and each non-npm strategy has delivery coverage. The
family stays distributed because each strategy owns a distinct refresh
protocol while verification uses one shared policy.

## Observability

Verification failures use the existing bounded
`auto-install verify: failed for <path> (check=..., kind=...)` record. The
budget is a threshold change, so no additional telemetry is required.

## Fix round 1

- Ran `npm run fmt` after the advisory oxfmt check reported two test files.
- Removed the unfiled pip-flake claim after four clean reproductions.
- Added the install-retry multiplication and timeout derivation to this body.
- Merged `origin/master` before verification.

## Verification

- `npm run build`
- `npm run fmt:check`
- `tests/clients/installer/tool-discovery.test.ts`
- `tests/clients/installer/tool-registry-consistency.test.ts`
- `tests/clients/installer/managed-tool-refresh.test.ts`
- `tests/clients/installer/managed-tool-refresh-strategies.test.ts`

Full-suite execution remains delegated to CI.

Refs #2194
