### PR TITLE
test: fix flaky/hygiene residuals (refs #2090, closes #2139, refs #2182)

### DIFF
--- a/.changelog/test-2090-2139-2182-flake-hygiene.md
+++ b/.changelog/test-2090-2139-2182-flake-hygiene.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Test-flakiness and hygiene residuals (refs #2090, closes #2139, refs #2182)** — `project-snapshot.test.ts` now restores its stubbed idle-evict env var so it cannot leak into later tests, and `project-report.test.ts`'s graph-cold assertion checks the cache stayed cold instead of a 22x-loose wall-clock bound. `session-lifecycle.test.ts`'s guard=0 reset test gets a 15s timeout, sized off a measured 5.4-7.2s honest cost under load instead of vitest's tight 5s default. `managed-tool-refresh-strategies.test.ts`'s cross-session re-arm test gets the same budget correction after reproducing its combined-run flake against the degradation-ledger suites.

--- a/tests/clients/installer/managed-tool-refresh-strategies.test.ts
+++ b/tests/clients/installer/managed-tool-refresh-strategies.test.ts
@@ -1253,34 +1253,30 @@ describe("one budget across all strategies", () => {
 		expect(apiCalls().length + installSpawns().length).toBeLessThanOrEqual(1);
 	});
 
-	it(
-		"re-arms across sessions rather than latching for the process",
-		async () => {
-			installProbeCached("ruff");
-			installProbeCached("rubocop");
+	// #2182: the two `runManagedToolRefresh` calls below resolve on queued
+	// microtasks (fast on a quiet host), but under the same real
+	// parallel-worker contention #2139 measured, this test's default 5000ms
+	// testTimeout starves and fires — reproduced locally by running this file
+	// combined with tests/clients/degradation-ledger*.test.ts under synthetic
+	// CPU load. The timeout does not stop the underlying refresh promise, so
+	// the straggler resolves later and mutates the shared spawn/degradation
+	// mocks mid-way through an UNRELATED later test (the "declines and
+	// touches nothing when PI_LENS_DISABLE_TOOL_INSTALL=1" case a few tests
+	// down failed the same combined run with degradationCount() 1 instead of
+	// 0 — a side effect of this straggler, not its own bug). Giving this
+	// test enough budget to finish normally removes the straggler at the
+	// source.
+	it("re-arms across sessions rather than latching for the process", async () => {
+		installProbeCached("ruff");
+		installProbeCached("rubocop");
 
-			await runManagedToolRefresh(NOW);
-			const first = installSpawns().length;
-			resetManagedToolRefreshSession();
-			await runManagedToolRefresh(NOW);
+		await runManagedToolRefresh(NOW);
+		const first = installSpawns().length;
+		resetManagedToolRefreshSession();
+		await runManagedToolRefresh(NOW);
 
-			expect(installSpawns().length).toBe(first + 1);
-		},
-		// #2182: the two `runManagedToolRefresh` calls resolve on queued
-		// microtasks (fast on a quiet host), but under the same real
-		// parallel-worker contention #2139 measured, this test's default 5000ms
-		// testTimeout starves and fires — reproduced locally by running this
-		// file combined with tests/clients/degradation-ledger*.test.ts under
-		// synthetic CPU load. The timeout does not stop the underlying refresh
-		// promise, so the straggler resolves later and mutates the shared
-		// spawn/degradation mocks mid-way through an UNRELATED later test (the
-		// "declines and touches nothing when PI_LENS_DISABLE_TOOL_INSTALL=1"
-		// case a few tests down failed the same combined run with
-		// degradationCount() 1 instead of 0 — a side effect of this straggler,
-		// not its own bug). Giving this test enough budget to finish normally
-		// removes the straggler at the source.
-		15_000,
-	);
+		expect(installSpawns().length).toBe(first + 1);
+	}, 15_000);
 });
 
 // --- install kill-switch, trust gate, and install lock (#1759 review F2) --

--- a/tests/clients/installer/managed-tool-refresh-strategies.test.ts
+++ b/tests/clients/installer/managed-tool-refresh-strategies.test.ts
@@ -22,6 +22,22 @@
  * `node:https` and `safeSpawnAsync` are mocked so network calls and spawns can
  * be counted exactly. Everything else — the stamp file, the presence checks,
  * the cadence arithmetic — runs for real against a temp `PI_LENS_HOME`.
+ *
+ * #2182: this file flaked when run combined with the two
+ * `tests/clients/degradation-ledger*.test.ts` files under real machine
+ * contention. Root cause: "re-arms across sessions rather than latching for
+ * the process" awaits two refresh calls that resolve on queued microtasks
+ * (fast on a quiet host) but starved past the default 5000ms testTimeout
+ * under load; the timeout does not cancel the underlying promise, so the
+ * straggler resolved later and mutated the shared spawn/degradation mocks
+ * mid-test in an unrelated later case. Fix: budget correction — that one
+ * test now carries an explicit 15_000ms timeout (see the test body) sized
+ * off a local repro under synthetic CPU load, instead of a phased vitest
+ * project (the existing "timing-sensitive" lane is reserved for
+ * measureMaxSyncBlockMs sampler tests — see
+ * tests/config/timing-sensitive-coverage.test.ts — and this file uses
+ * neither the sampler nor a real process spawn, so it does not fit that or
+ * the "lsp-spawn-heavy" lane).
  */
 
 import { EventEmitter } from "node:events";
@@ -1237,17 +1253,34 @@ describe("one budget across all strategies", () => {
 		expect(apiCalls().length + installSpawns().length).toBeLessThanOrEqual(1);
 	});
 
-	it("re-arms across sessions rather than latching for the process", async () => {
-		installProbeCached("ruff");
-		installProbeCached("rubocop");
+	it(
+		"re-arms across sessions rather than latching for the process",
+		async () => {
+			installProbeCached("ruff");
+			installProbeCached("rubocop");
 
-		await runManagedToolRefresh(NOW);
-		const first = installSpawns().length;
-		resetManagedToolRefreshSession();
-		await runManagedToolRefresh(NOW);
+			await runManagedToolRefresh(NOW);
+			const first = installSpawns().length;
+			resetManagedToolRefreshSession();
+			await runManagedToolRefresh(NOW);
 
-		expect(installSpawns().length).toBe(first + 1);
-	});
+			expect(installSpawns().length).toBe(first + 1);
+		},
+		// #2182: the two `runManagedToolRefresh` calls resolve on queued
+		// microtasks (fast on a quiet host), but under the same real
+		// parallel-worker contention #2139 measured, this test's default 5000ms
+		// testTimeout starves and fires — reproduced locally by running this
+		// file combined with tests/clients/degradation-ledger*.test.ts under
+		// synthetic CPU load. The timeout does not stop the underlying refresh
+		// promise, so the straggler resolves later and mutates the shared
+		// spawn/degradation mocks mid-way through an UNRELATED later test (the
+		// "declines and touches nothing when PI_LENS_DISABLE_TOOL_INSTALL=1"
+		// case a few tests down failed the same combined run with
+		// degradationCount() 1 instead of 0 — a side effect of this straggler,
+		// not its own bug). Giving this test enough budget to finish normally
+		// removes the straggler at the source.
+		15_000,
+	);
 });
 
 // --- install kill-switch, trust gate, and install lock (#1759 review F2) --

--- a/tests/clients/project-report.test.ts
+++ b/tests/clients/project-report.test.ts
@@ -38,17 +38,20 @@ describe("projectReport — cold path (#773)", () => {
 		const env = makeEnv();
 		createTempFile(env.tmpDir, "src/a.ts", "export const a = 1;\n");
 
-		const startedAt = Date.now();
 		const report = await projectReport(env.tmpDir);
-		const elapsedMs = Date.now() - startedAt;
 
 		expect(report.available).toBe(false);
 		expect(report.hint).toBeTruthy();
 		expect(report.trust).toBeUndefined();
 		expect(report.hubs).toBeUndefined();
-		// The call must return immediately — it must never synchronously run a
-		// full graph build on this path (#773's graph-cold contract).
-		expect(elapsedMs).toBeLessThan(2000);
+		// #2090: the actual claim is "never synchronously run a full graph
+		// build on this path" (#773's graph-cold contract) - a wall-clock bound
+		// only approximates that, and passed at 88ms against a 2000ms ceiling
+		// (a 22.7x margin), loose enough to hide a synchronous build on a small
+		// fixture. Assert the claim directly: the cache must still be cold the
+		// instant the call returns, because the build is only kicked off
+		// (fire-and-forget), never awaited.
+		expect(getCachedReviewGraph(env.tmpDir)).toBeUndefined();
 
 		// The background build was kicked off (deduped, fire-and-forget) — assert
 		// it eventually populates the cache, proving it actually ran rather than

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -117,6 +117,11 @@ describe("project snapshot", () => {
 	});
 	afterEach(() => {
 		delete process.env.PI_LENS_SNAPSHOT_PERSIST_SYNC;
+		// #2090: three tests below stub PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS
+		// via vi.stubEnv and never restored it, so the value leaked into every
+		// later test in this file (~50 tests, including the idle-eviction
+		// suite whose authors chose their own window).
+		vi.unstubAllEnvs();
 	});
 
 	it("fingerprints only the top-level generatedAt field as volatile", () => {

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -570,6 +570,14 @@ describe("project snapshot", () => {
 			}
 		}));
 
+	// #2090: the three idle-eviction tests above stub
+	// PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS via vi.stubEnv. Without the
+	// afterEach unstub, the last stub value ("100000") survives into every
+	// later test in this file.
+	it("does not leak PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS to later tests (#2090)", () => {
+		expect(process.env.PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS).toBeUndefined();
+	});
+
 	it("embeds the derived sequence index in BOTH the body and the meta sidecar (#1019)", () =>
 		withProjectDataDir((cwd) => {
 			// A runtime with a real per-file sequence state at seq=3.

--- a/tests/clients/session-lifecycle.test.ts
+++ b/tests/clients/session-lifecycle.test.ts
@@ -443,41 +443,50 @@ describe("concurrent session_start guard — behavioral (index.ts wiring seam)",
 		delete process.env.PI_LENS_CONCURRENT_SESSION_GUARD;
 	});
 
-	it("a concurrent secondary session_start leaves runtime.sessionGeneration unchanged and never calls resetLSPService", async () => {
-		const env = setupTestEnvironment("pi-lens-concurrent-secondary-");
-		try {
-			const runtime = new RuntimeCoordinator();
-			const resetLSPService = vi.fn();
+	it(
+		"a concurrent secondary session_start leaves runtime.sessionGeneration unchanged and never calls resetLSPService",
+		async () => {
+			const env = setupTestEnvironment("pi-lens-concurrent-secondary-");
+			try {
+				const runtime = new RuntimeCoordinator();
+				const resetLSPService = vi.fn();
 
-			// Primary session_start (the parent).
-			await runGuardedSessionStart(
-				runtime,
-				resetLSPService,
-				activeCtx(),
-				"parent-session",
-				env.tmpDir,
-			);
-			const generationAfterPrimary = runtime.sessionGeneration;
-			expect(resetLSPService).toHaveBeenCalledTimes(1);
+				// Primary session_start (the parent).
+				await runGuardedSessionStart(
+					runtime,
+					resetLSPService,
+					activeCtx(),
+					"parent-session",
+					env.tmpDir,
+				);
+				const generationAfterPrimary = runtime.sessionGeneration;
+				expect(resetLSPService).toHaveBeenCalledTimes(1);
 
-			// Concurrent in-process subagent bind — the parent's ctx is still
-			// active (activeCtx() never throws), and the session id differs.
-			const decision = await runGuardedSessionStart(
-				runtime,
-				resetLSPService,
-				activeCtx(),
-				"subagent-session",
-				env.tmpDir,
-			);
+				// Concurrent in-process subagent bind — the parent's ctx is still
+				// active (activeCtx() never throws), and the session id differs.
+				const decision = await runGuardedSessionStart(
+					runtime,
+					resetLSPService,
+					activeCtx(),
+					"subagent-session",
+					env.tmpDir,
+				);
 
-			expect(decision.classification).toBe("concurrent-secondary");
-			expect(runtime.sessionGeneration).toBe(generationAfterPrimary);
-			// Still only the one call from the primary's session_start.
-			expect(resetLSPService).toHaveBeenCalledTimes(1);
-		} finally {
-			env.cleanup();
-		}
-	});
+				expect(decision.classification).toBe("concurrent-secondary");
+				expect(runtime.sessionGeneration).toBe(generationAfterPrimary);
+				// Still only the one call from the primary's session_start.
+				expect(resetLSPService).toHaveBeenCalledTimes(1);
+			} finally {
+				env.cleanup();
+			}
+		},
+		// #2139 class sweep: this sibling shares the guard=0 test's shape (one
+		// real handleSessionStart call through the same seam) and was seen
+		// timing out at vitest's 5000ms default in a combined 4-file run
+		// locally, even though it measures ~320ms solo. Same budget-correction
+		// fix as the guard=0 test below.
+		15_000,
+	);
 
 	it(
 		"with PI_LENS_CONCURRENT_SESSION_GUARD=0, the same sequence resets as today (behavior unchanged)",

--- a/tests/clients/session-lifecycle.test.ts
+++ b/tests/clients/session-lifecycle.test.ts
@@ -479,38 +479,51 @@ describe("concurrent session_start guard — behavioral (index.ts wiring seam)",
 		}
 	});
 
-	it("with PI_LENS_CONCURRENT_SESSION_GUARD=0, the same sequence resets as today (behavior unchanged)", async () => {
-		const env = setupTestEnvironment("pi-lens-guard-disabled-");
-		try {
-			const runtime = new RuntimeCoordinator();
-			const resetLSPService = vi.fn();
+	it(
+		"with PI_LENS_CONCURRENT_SESSION_GUARD=0, the same sequence resets as today (behavior unchanged)",
+		async () => {
+			const env = setupTestEnvironment("pi-lens-guard-disabled-");
+			try {
+				const runtime = new RuntimeCoordinator();
+				const resetLSPService = vi.fn();
 
-			await runGuardedSessionStart(
-				runtime,
-				resetLSPService,
-				activeCtx(),
-				"parent-session",
-				env.tmpDir,
-			);
-			const generationAfterPrimary = runtime.sessionGeneration;
-			expect(resetLSPService).toHaveBeenCalledTimes(1);
+				await runGuardedSessionStart(
+					runtime,
+					resetLSPService,
+					activeCtx(),
+					"parent-session",
+					env.tmpDir,
+				);
+				const generationAfterPrimary = runtime.sessionGeneration;
+				expect(resetLSPService).toHaveBeenCalledTimes(1);
 
-			process.env.PI_LENS_CONCURRENT_SESSION_GUARD = "0";
-			const decision = await runGuardedSessionStart(
-				runtime,
-				resetLSPService,
-				activeCtx(),
-				"subagent-session",
-				env.tmpDir,
-			);
+				process.env.PI_LENS_CONCURRENT_SESSION_GUARD = "0";
+				const decision = await runGuardedSessionStart(
+					runtime,
+					resetLSPService,
+					activeCtx(),
+					"subagent-session",
+					env.tmpDir,
+				);
 
-			expect(decision.classification).toBe("sequential-replacement");
-			expect(decision.runFullSessionStart).toBe(true);
-			// Kill switch: today's behavior — reset runs again, generation bumps.
-			expect(resetLSPService).toHaveBeenCalledTimes(2);
-			expect(runtime.sessionGeneration).toBeGreaterThan(generationAfterPrimary);
-		} finally {
-			env.cleanup();
-		}
-	});
+				expect(decision.classification).toBe("sequential-replacement");
+				expect(decision.runFullSessionStart).toBe(true);
+				// Kill switch: today's behavior — reset runs again, generation bumps.
+				expect(resetLSPService).toHaveBeenCalledTimes(2);
+				expect(runtime.sessionGeneration).toBeGreaterThan(
+					generationAfterPrimary,
+				);
+			} finally {
+				env.cleanup();
+			}
+		},
+		// #2139: this test runs handleSessionStart TWICE for real (only
+		// resetLSPService is stubbed), and vitest's default 5000ms testTimeout
+		// is tighter than that honest cost — measured 7221ms/6.76s/5.96s locally
+		// on a cold module cache, and 6.24s / 5.4-5.9s under load in the #2133
+		// verify run that surfaced this. The work itself is fine (600-900ms
+		// once the module cache is warm); only the bound was too tight. 15s
+		// gives ~2x headroom over the worst measured run.
+		15_000,
+	);
 });

--- a/tests/clients/session-lifecycle.test.ts
+++ b/tests/clients/session-lifecycle.test.ts
@@ -443,96 +443,85 @@ describe("concurrent session_start guard — behavioral (index.ts wiring seam)",
 		delete process.env.PI_LENS_CONCURRENT_SESSION_GUARD;
 	});
 
-	it(
-		"a concurrent secondary session_start leaves runtime.sessionGeneration unchanged and never calls resetLSPService",
-		async () => {
-			const env = setupTestEnvironment("pi-lens-concurrent-secondary-");
-			try {
-				const runtime = new RuntimeCoordinator();
-				const resetLSPService = vi.fn();
+	// #2139 class sweep: this sibling shares the guard=0 test's shape below
+	// (one real handleSessionStart call through the same seam) and was seen
+	// timing out at vitest's 5000ms default in a combined 4-file run locally,
+	// even though it measures ~320ms solo. Same budget-correction fix.
+	it("a concurrent secondary session_start leaves runtime.sessionGeneration unchanged and never calls resetLSPService", async () => {
+		const env = setupTestEnvironment("pi-lens-concurrent-secondary-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const resetLSPService = vi.fn();
 
-				// Primary session_start (the parent).
-				await runGuardedSessionStart(
-					runtime,
-					resetLSPService,
-					activeCtx(),
-					"parent-session",
-					env.tmpDir,
-				);
-				const generationAfterPrimary = runtime.sessionGeneration;
-				expect(resetLSPService).toHaveBeenCalledTimes(1);
+			// Primary session_start (the parent).
+			await runGuardedSessionStart(
+				runtime,
+				resetLSPService,
+				activeCtx(),
+				"parent-session",
+				env.tmpDir,
+			);
+			const generationAfterPrimary = runtime.sessionGeneration;
+			expect(resetLSPService).toHaveBeenCalledTimes(1);
 
-				// Concurrent in-process subagent bind — the parent's ctx is still
-				// active (activeCtx() never throws), and the session id differs.
-				const decision = await runGuardedSessionStart(
-					runtime,
-					resetLSPService,
-					activeCtx(),
-					"subagent-session",
-					env.tmpDir,
-				);
+			// Concurrent in-process subagent bind — the parent's ctx is still
+			// active (activeCtx() never throws), and the session id differs.
+			const decision = await runGuardedSessionStart(
+				runtime,
+				resetLSPService,
+				activeCtx(),
+				"subagent-session",
+				env.tmpDir,
+			);
 
-				expect(decision.classification).toBe("concurrent-secondary");
-				expect(runtime.sessionGeneration).toBe(generationAfterPrimary);
-				// Still only the one call from the primary's session_start.
-				expect(resetLSPService).toHaveBeenCalledTimes(1);
-			} finally {
-				env.cleanup();
-			}
-		},
-		// #2139 class sweep: this sibling shares the guard=0 test's shape (one
-		// real handleSessionStart call through the same seam) and was seen
-		// timing out at vitest's 5000ms default in a combined 4-file run
-		// locally, even though it measures ~320ms solo. Same budget-correction
-		// fix as the guard=0 test below.
-		15_000,
-	);
+			expect(decision.classification).toBe("concurrent-secondary");
+			expect(runtime.sessionGeneration).toBe(generationAfterPrimary);
+			// Still only the one call from the primary's session_start.
+			expect(resetLSPService).toHaveBeenCalledTimes(1);
+		} finally {
+			env.cleanup();
+		}
+	}, 15_000);
 
-	it(
-		"with PI_LENS_CONCURRENT_SESSION_GUARD=0, the same sequence resets as today (behavior unchanged)",
-		async () => {
-			const env = setupTestEnvironment("pi-lens-guard-disabled-");
-			try {
-				const runtime = new RuntimeCoordinator();
-				const resetLSPService = vi.fn();
+	// #2139: this test runs handleSessionStart TWICE for real (only
+	// resetLSPService is stubbed), and vitest's default 5000ms testTimeout is
+	// tighter than that honest cost — measured 7221ms/6.76s/5.96s locally on
+	// a cold module cache, and 6.24s / 5.4-5.9s under load in the #2133
+	// verify run that surfaced this. The work itself is fine (600-900ms once
+	// the module cache is warm); only the bound was too tight. 15s gives
+	// ~2x headroom over the worst measured run.
+	it("with PI_LENS_CONCURRENT_SESSION_GUARD=0, the same sequence resets as today (behavior unchanged)", async () => {
+		const env = setupTestEnvironment("pi-lens-guard-disabled-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const resetLSPService = vi.fn();
 
-				await runGuardedSessionStart(
-					runtime,
-					resetLSPService,
-					activeCtx(),
-					"parent-session",
-					env.tmpDir,
-				);
-				const generationAfterPrimary = runtime.sessionGeneration;
-				expect(resetLSPService).toHaveBeenCalledTimes(1);
+			await runGuardedSessionStart(
+				runtime,
+				resetLSPService,
+				activeCtx(),
+				"parent-session",
+				env.tmpDir,
+			);
+			const generationAfterPrimary = runtime.sessionGeneration;
+			expect(resetLSPService).toHaveBeenCalledTimes(1);
 
-				process.env.PI_LENS_CONCURRENT_SESSION_GUARD = "0";
-				const decision = await runGuardedSessionStart(
-					runtime,
-					resetLSPService,
-					activeCtx(),
-					"subagent-session",
-					env.tmpDir,
-				);
+			process.env.PI_LENS_CONCURRENT_SESSION_GUARD = "0";
+			const decision = await runGuardedSessionStart(
+				runtime,
+				resetLSPService,
+				activeCtx(),
+				"subagent-session",
+				env.tmpDir,
+			);
 
-				expect(decision.classification).toBe("sequential-replacement");
-				expect(decision.runFullSessionStart).toBe(true);
-				// Kill switch: today's behavior — reset runs again, generation bumps.
-				expect(resetLSPService).toHaveBeenCalledTimes(2);
-				expect(runtime.sessionGeneration).toBeGreaterThan(
-					generationAfterPrimary,
-				);
-			} finally {
-				env.cleanup();
-			}
-		},
-		// #2139: this test runs handleSessionStart TWICE for real (only
-		// resetLSPService is stubbed), and vitest's default 5000ms testTimeout
-		// is tighter than that honest cost — measured 7221ms/6.76s/5.96s locally
-		// on a cold module cache, and 6.24s / 5.4-5.9s under load in the #2133
-		// verify run that surfaced this. The work itself is fine (600-900ms
-		// once the module cache is warm); only the bound was too tight. 15s
-		// gives ~2x headroom over the worst measured run.
-		15_000,
-	);
+			expect(decision.classification).toBe("sequential-replacement");
+			expect(decision.runFullSessionStart).toBe(true);
+			// Kill switch: today's behavior — reset runs again, generation bumps.
+			expect(resetLSPService).toHaveBeenCalledTimes(2);
+			expect(runtime.sessionGeneration).toBeGreaterThan(generationAfterPrimary);
+		} finally {
+			env.cleanup();
+		}
+	}, 15_000);
 });


### PR DESCRIPTION
## Summary

Three test-flakiness/hygiene fixes from the same family.

**#2090 — leaking env stub + loose timing bound.**
`project-snapshot.test.ts` stubbed `PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS`
in three tests and never unstubbed it, so the value leaked into every later
test in the file. Added `vi.unstubAllEnvs()` to the describe's `afterEach`,
plus a regression test asserting the env var reads back unset.

`project-report.test.ts`'s graph-cold guard asserted `elapsedMs < 2000`
against a measured 88ms — a 22.7x margin, loose enough to hide a synchronous
graph build on a small fixture. Replaced it with the actual claim: the
review-graph cache must still be cold the instant `projectReport` returns,
because the build is fire-and-forget, never awaited.

**#2139 — session-lifecycle guard=0 test breaches its 5s timeout under load.**
The guard=0 reset test runs `handleSessionStart` twice for real. Measured
locally: 7221ms / 6.76s / 5.96s on a cold module cache — all over vitest's
5000ms default. Gave it an explicit 15s timeout with the measured numbers
recorded in a comment. Class sweep found a sibling test in the same describe
block with the identical shape (one real `handleSessionStart` call through
the same seam); it surfaced the same timeout in a local combined run despite
measuring ~320ms solo, so it got the same fix.

**#2182 — installer suite flakes under combined parallel load.**
Reproduced the two named failures in `managed-tool-refresh-strategies.test.ts`
by running it combined with `tests/clients/degradation-ledger*.test.ts`
under synthetic CPU load (24-28 busy-loop workers on a 16-core host).
Root cause: "re-arms across sessions rather than latching for the process"
awaits two refresh calls that resolve on queued microtasks — fast on a quiet
host, but the default 5000ms timeout doesn't cancel the underlying promise,
so a straggler resolved later and mutated the shared spawn/degradation mocks
mid an unrelated later test ("declines and touches nothing when
PI_LENS_DISABLE_TOOL_INSTALL=1", which failed with `degradationCount()`
returning 1 instead of 0 — a side effect, not its own bug). Fix: the same
budget correction as #2139, recorded in the file's header comment.

## Why budget correction, not a phased vitest project

`tests/config/timing-sensitive-coverage.test.ts` asserts the "timing-sensitive"
project's `include` list only ever contains files that import
`measureMaxSyncBlockMs` — adding a non-sampler file there fails that
governance test. None of the touched files fit "lsp-spawn-heavy" either (no
real process spawn). Raising the specific tests' timeouts, with the measured
cost recorded beside the new value, is the mechanism the #2139 issue itself
names as acceptable.

## What's NOT fully closed

**#2182 residual risk.** Six of seven post-fix combined runs (installer dir +
both degradation-ledger files, under synthetic load) passed clean. One run
showed 3 failures, including one at a different assertion
(`degradationCount()` in the pip/gem degrade case around line 818) that does
not match either originally-reported failure and did not reproduce again
across 4 further heavy-load attempts. This suggests the dangling-promise
contamination pattern may have more than the two named instances in this
file. Filing this as a follow-up rather than claiming full closure — see the
issue comment.

**#2015 timeout-kill test** (`verify-binary-semantics.test.ts`) — the issue
also names this test as flaking in a master combined run. I could not
reproduce a failure there across two attempts (one with 12 busy-loop
workers, one clean). It already carries a 25s timeout, so if it does flake
under real contention, the cause is a genuine process-timing race (a
1.5s kill timeout vs. a grandchild's 6s delayed write), not a test-timeout
gap — likely out of test-side-only scope. Left unreproduced and unfixed;
noted on the issue.

## Verification

- `npm run build` before every run.
- Red-first proof, `project-snapshot.test.ts` leak: reverted only the
  `afterEach` fix, ran the new regression test — `FAIL ... does not leak
  PI_LENS_PROJECT_SNAPSHOT_IDLE_EVICT_MS to later tests (#2090)`. Restored
  the fix, file green (53/53).
- Red-first proof, `project-report.test.ts` timing bound: mutated
  `triggerBackgroundGraphBuild` to `await` the build before returning
  (simulating a synchronous-build regression). New assertion failed:
  `expect(getCachedReviewGraph(env.tmpDir)).toBeUndefined()` — proving it
  catches what the old 2000ms bound would have missed. Reverted the mutation.
- Red-first proof, `session-lifecycle.test.ts` guard=0 test: first isolated
  run on unmodified code failed — `Test timed out in 5000ms` at 7221ms
  measured. Fixed file green, 43/43, run 3x.
- Red-first proof, `managed-tool-refresh-strategies.test.ts`: reproduced
  both named failures running the file combined with
  `tests/clients/degradation-ledger.test.ts` and
  `tests/clients/degradation-ledger-count-suffix.test.ts` under synthetic
  CPU load — `Test timed out in 5000ms` on "re-arms across sessions..." and
  `AssertionError: expected 1 to be +0` on "declines and touches nothing...".
  Fixed, then 6 of 7 combined re-runs under load passed clean (residual
  noted above).
- Governance suites run green: `session-state-conformance.test.ts`,
  `timing-sensitive-coverage.test.ts`, `changelog.test.ts`,
  `delivery-surface-ratchet.test.ts`, `finding-delivery-gate.test.ts`,
  `bounded-telemetry-sweep.test.ts`, `bus-producer-coverage.test.ts`,
  `deps-centralization.test.ts`, `freshness-sweep.test.ts`,
  `managed-tool-seam-coverage.test.ts`, `profiling-coverage.test.ts`,
  `module-instance-coverage.test.ts`, `sweep-floor-coverage.test.ts`.
- Full suite deferred to CI (repo convention).

## Test assessment

- `tests/clients/project-snapshot.test.ts` — pins the idle-eviction cache's
  save/load/timer semantics. This PR adds one test (the leak regression) and
  fixes an `afterEach`; nothing becomes redundant.
- `tests/clients/project-report.test.ts` — pins the graph-cold, never-blocks
  contract for `projectReport`. One assertion changed (timing bound to
  cache-cold check) in place; no test removed, none made redundant.
- `tests/clients/session-lifecycle.test.ts` — pins the session_start guard
  classification and the real wiring seam. Two `it()` calls gained explicit
  timeouts; no assertions changed, nothing redundant.
- `tests/clients/installer/managed-tool-refresh-strategies.test.ts` — pins
  per-strategy refresh policy. One `it()` call gained an explicit timeout;
  nothing redundant.

No removal candidates identified.

## Observability

Test-only PR — not applicable. No production log or ledger record changes.

## Blast radius

Test-only changes; no production code ships different behavior (the
`project-report.ts` async-signature edit used for the mutation proof was
reverted before commit). Two `it()` calls gained explicit timeouts (no
behavior change on a quiet host); one `afterEach` now also calls
`vi.unstubAllEnvs()` (only affects env vars other tests in the file stub,
none currently do besides the fixed one).

## Class sweep

Pattern: `vi.stubEnv` without a matching `vi.unstubAllEnvs` — grepped all of
`tests/` (not just `tests/clients/`): 18 files call `vi.stubEnv`;
`project-snapshot.test.ts` was the only one missing the restore, now fixed.

Pattern: a real async seam call wrapped in `it(...)` with no explicit
timeout, whose cost was measured to exceed vitest's 5000ms default under
load — swept `session-lifecycle.test.ts`'s two callers of
`runGuardedSessionStart` (both fixed) and confirmed
`managed-tool-refresh-strategies.test.ts`'s single instance (fixed). Did not
attempt a repo-wide sweep for every `it()` lacking an explicit timeout — that
population is much larger than this issue's evidence covers, and a blind
timeout bump everywhere would violate the "no blanket timeout raises"
instruction. Flagging the pattern for a follow-up issue if the orchestrator
wants a full sweep.

Refs #2090, closes #2139, refs #2182

