### PR TITLE
fix(ci): escalate workflow runs stuck queued (closes #2203)

### DIFF
--- a/.changelog/fix-2203-stuck-queued-escalation.md
+++ b/.changelog/fix-2203-stuck-queued-escalation.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Escalate workflow runs stuck queued (closes #2203)** — the merge-train warden classified a run that GitHub queued and never scheduled as `runs-in-progress` on every cycle forever, which read as healthy waiting. A tracked run that has executed zero steps for 60 minutes now classifies `stalled-run`: the warden names it in a PR comment, cancels it on the next cycle, and re-runs it once, bounded by GitHub's own `run_attempt`. A run with executed steps stays in progress however long it takes, and a cancellation the warden did not make is left alone.

--- a/.github/workflows/merge-train-warden.yml
+++ b/.github/workflows/merge-train-warden.yml
@@ -5,15 +5,19 @@ name: Merge-train warden
 # armed auto-merge PRs falling BEHIND with no automatic nudge, and red CI on
 # an armed PR discovered only by manual polling (#1844). This workflow
 # OBSERVES AND ANNOTATES ONLY -- it never resolves a conflict, never merges,
-# and never pushes to a PR branch. Two exceptions, both GitHub-sanctioned
+# and never pushes to a PR branch. Three exceptions, all GitHub-sanctioned
 # buttons a human clicks in the PR UI: the "update branch" call for a PR that
-# already has auto-merge armed, and the "re-run workflow" call for a run this
-# sweep classified as STARVED (#2184), at most once per run.
+# already has auto-merge armed, the "re-run workflow" call for a run this
+# sweep classified as STARVED (#2184), at most once per run, and the
+# "cancel workflow" call for a run classified as STALLED (#2203), also at
+# most once per run and only after the sweep has announced it in a comment.
 #
 # The sweep also names a run-health classification for EVERY open PR head:
-# runs-concluded-normally, starved-run, absent-run, runs-in-progress, or
-# run-health-unknown. The 2026-08-26 Actions degradation stalled the train for
-# hours precisely because a starved head looked like "nothing to report".
+# runs-concluded-normally, starved-run, stalled-run, absent-run,
+# runs-in-progress, or run-health-unknown. The 2026-08-26 Actions degradation
+# stalled the train for hours precisely because a starved head looked like
+# "nothing to report", and a run stuck in `queued` looked the same way for as
+# long as it stayed there (#2203).
 #
 # workflow_dispatch is included so this can be smoke-run on demand after
 # merge -- a scheduled trigger cannot be exercised pre-merge (see the PR body
@@ -45,7 +49,7 @@ jobs:
     permissions:
       contents: write # checkout, and the update-branch merge-commit kick
       pull-requests: write # label + comment on PRs
-      actions: write # read runs/jobs, and re-run a starved run once (#2184)
+      actions: write # read runs/jobs, re-run a starved run once (#2184), cancel a stalled one (#2203)
       checks: read # check-run conclusions on the head commit (statusCheckRollup)
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -59,5 +63,5 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Sweep open PRs for DIRTY / BEHIND / red-CI / starved / absent runs
+      - name: Sweep open PRs for DIRTY / BEHIND / red-CI / starved / stalled / absent runs
         run: node scripts/merge-train-warden.mjs

--- a/scripts/lib/github-paging.d.mts
+++ b/scripts/lib/github-paging.d.mts
@@ -4,6 +4,13 @@ export const REST_PAGE_SIZE: number;
 export const MAX_REST_PAGES: number;
 
 export function paginate(fetcher: FetchFn, url: string): Promise<unknown[]>;
+export function presentCommentMarkers(
+	fetcher: FetchFn,
+	owner: string,
+	repo: string,
+	number: number,
+	markers: string[] | null | undefined,
+): Promise<Set<string>>;
 export function commentMarkerExists(
 	fetcher: FetchFn,
 	owner: string,

--- a/scripts/lib/github-paging.mjs
+++ b/scripts/lib/github-paging.mjs
@@ -51,6 +51,30 @@ export async function paginate(fetcher, url) {
 }
 
 /**
+ * Which of these markers already appear in the issue's comments? One paged
+ * read answers for every marker, so a head carrying several stuck runs
+ * (#2203) costs the same single read as one carrying none.
+ */
+export async function presentCommentMarkers(
+	fetcher,
+	owner,
+	repo,
+	number,
+	markers,
+) {
+	const comments = await paginate(
+		fetcher,
+		`https://api.github.com/repos/${owner}/${repo}/issues/${number}/comments`,
+	);
+	const bodies = comments.map((c) => String(c?.body ?? ""));
+	return new Set(
+		(markers ?? []).filter((marker) =>
+			bodies.some((body) => body.includes(marker)),
+		),
+	);
+}
+
+/**
  * Does any comment on this issue carry the marker? Shared by both modules so
  * the per-head dedupe has one implementation, not two that can drift.
  */
@@ -61,9 +85,8 @@ export async function commentMarkerExists(
 	number,
 	marker,
 ) {
-	const comments = await paginate(
-		fetcher,
-		`https://api.github.com/repos/${owner}/${repo}/issues/${number}/comments`,
-	);
-	return comments.some((c) => String(c?.body ?? "").includes(marker));
+	const present = await presentCommentMarkers(fetcher, owner, repo, number, [
+		marker,
+	]);
+	return present.has(marker);
 }

--- a/scripts/lib/merge-train-lane.mjs
+++ b/scripts/lib/merge-train-lane.mjs
@@ -167,8 +167,10 @@ export function evaluateMergeGate(pr, health, { approvedBy } = {}) {
 			);
 	}
 
-	// Starved and absent runs read as not-green even when a stale check run
-	// from an earlier attempt looks settled (#2184).
+	// Starved, stalled, and absent runs read as not-green even when a stale
+	// check run from an earlier attempt looks settled (#2184, #2203). The test
+	// is "not NORMAL", so a new classification is gated the day it is added,
+	// not the day someone remembers to list it here.
 	if (health.classification !== RUN_HEALTH.NORMAL)
 		return deny(
 			MERGE_GATE_REASON.RUN_HEALTH,

--- a/scripts/lib/merge-train-warden.d.mts
+++ b/scripts/lib/merge-train-warden.d.mts
@@ -42,6 +42,7 @@ export type WardenAction =
 	| { type: "comment"; body: string }
 	| { type: "update-branch" }
 	| { type: "rerun-run"; runId: number | string; workflowPath: string }
+	| { type: "cancel-run"; runId: number | string; workflowPath: string }
 	| { type: "note"; benign: boolean; message: string };
 
 export interface WardenError {
@@ -87,9 +88,31 @@ export function hasAbsentRunComment(
 	repo: string,
 	pr: WardenPr,
 ): Promise<boolean>;
+export function readStalledRunMarkers(
+	fetcher: FetchFn,
+	owner: string,
+	repo: string,
+	pr: WardenPr,
+	health: {
+		stalledRuns?: Array<{ id: number | string }>;
+		cancelledStalledRuns?: Array<{ id: number | string }>;
+	},
+): Promise<Set<string>>;
 export function summarizeRunHealth(health: {
 	classification: string;
 	starvedRuns: Array<{
+		id: number | string;
+		path: string;
+		runAttempt?: number;
+	}>;
+	stalledRuns?: Array<{
+		id: number | string;
+		path: string;
+		status?: string;
+		runAttempt?: number;
+		stalledForMinutes?: number | null;
+	}>;
+	cancelledStalledRuns?: Array<{
 		id: number | string;
 		path: string;
 		runAttempt?: number;
@@ -101,6 +124,7 @@ export function summarizeRunHealth(health: {
 export const RUN_HEALTH: {
 	NORMAL: string;
 	STARVED: string;
+	STALLED: string;
 	ABSENT: string;
 	PENDING: string;
 	UNKNOWN: string;

--- a/scripts/lib/merge-train-warden.mjs
+++ b/scripts/lib/merge-train-warden.mjs
@@ -17,12 +17,16 @@
  * permissions (#2185).
  */
 
-import { commentMarkerExists } from "./github-paging.mjs";
+import {
+	commentMarkerExists,
+	presentCommentMarkers,
+} from "./github-paging.mjs";
 import {
 	absentRunCommentMarker,
 	decideRunHealthActions,
 	fetchHeadRunHealth,
 	RUN_HEALTH,
+	stalledRunCommentMarker,
 } from "./warden-run-health.mjs";
 
 export const CONFLICT_LABEL = "conflict";
@@ -407,6 +411,16 @@ export async function applyAction(fetcher, owner, repo, pr, action) {
 				"POST",
 				`${base}/actions/runs/${action.runId}/rerun`,
 			);
+		case "cancel-run":
+			// #2203. GitHub refuses `rerun` on a run that has not completed, so a
+			// zombie stuck in `queued` must be cancelled before it can be re-run.
+			// A second cancel of the same run returns 409, which is already
+			// classified benign.
+			return restJson(
+				fetcher,
+				"POST",
+				`${base}/actions/runs/${action.runId}/cancel`,
+			);
 		default:
 			throw new Error(`unknown warden action type: ${action.type}`);
 	}
@@ -442,9 +456,33 @@ export async function hasAbsentRunComment(fetcher, owner, repo, pr) {
 	);
 }
 
+/**
+ * Which stalled runs on this head already carry the warden's marker comment?
+ * One paged comment read per head, and ONLY for a head that already has a
+ * stalled run, so the healthy sweep pays nothing (#2203).
+ *
+ * Returns null when the read failed: the caller must not treat "we could not
+ * look" as "no marker", which would repost the notice and, worse, re-attribute
+ * a person's cancellation to the warden.
+ */
+export async function readStalledRunMarkers(fetcher, owner, repo, pr, health) {
+	const runs = [
+		...(health.stalledRuns ?? []),
+		...(health.cancelledStalledRuns ?? []),
+	];
+	if (runs.length === 0) return new Set();
+	return presentCommentMarkers(
+		fetcher,
+		owner,
+		repo,
+		pr.number,
+		runs.map((run) => stalledRunCommentMarker(run.id)),
+	);
+}
+
 function describeApplied(action) {
-	if (action.type === "rerun-run")
-		return `rerun-run:${action.workflowPath}#${action.runId}`;
+	if (action.type === "rerun-run" || action.type === "cancel-run")
+		return `${action.type}:${action.workflowPath}#${action.runId}`;
 	return action.type + (action.label ? `:${action.label}` : "");
 }
 
@@ -504,9 +542,31 @@ export async function runWarden({ fetcher, owner, repo, now = Date.now() }) {
 			}
 		}
 
+		let stalledRunMarkers = new Set();
+		try {
+			stalledRunMarkers = await readStalledRunMarkers(
+				fetcher,
+				owner,
+				repo,
+				pr,
+				health,
+			);
+		} catch (error) {
+			// null, not an empty Set: the ladder must stand still for a cycle
+			// rather than act on a guess (#2203).
+			stalledRunMarkers = null;
+			errors.push({
+				message: `PR #${pr.number}: ${error instanceof Error ? error.message : String(error)}; stalled-run markers unreadable this run`,
+				benign: true,
+			});
+		}
+
 		const actions = [
 			...decideActions(pr),
-			...decideRunHealthActions(pr, health, { absentCommentExists }),
+			...decideRunHealthActions(pr, health, {
+				absentCommentExists,
+				stalledRunMarkers,
+			}),
 		];
 		for (const action of actions) {
 			if (action.type === "note") {
@@ -558,6 +618,16 @@ export function summarizeRunHealth(health) {
 	for (const run of health.starvedRuns)
 		detail.push(
 			`starved ${run.path} run ${run.id} (attempt ${run.runAttempt})`,
+		);
+	// #2203 AC4: the sweep record must name the stuck run and how long it has
+	// been stuck, so a stalled train is one grep away in the warden run log.
+	for (const run of health.stalledRuns ?? [])
+		detail.push(
+			`stalled ${run.path} run ${run.id} ${run.status} ${Math.round(run.stalledForMinutes ?? 0)}m with zero executed steps (attempt ${run.runAttempt})`,
+		);
+	for (const run of health.cancelledStalledRuns ?? [])
+		detail.push(
+			`cancelled zero-step ${run.path} run ${run.id} (attempt ${run.runAttempt})`,
 		);
 	if (health.absentWorkflows.length > 0)
 		detail.push(`no run for ${health.absentWorkflows.join(", ")}`);

--- a/scripts/lib/warden-run-health.d.mts
+++ b/scripts/lib/warden-run-health.d.mts
@@ -7,9 +7,11 @@ import type {
 export const TRACKED_WORKFLOW_PATHS: string[];
 export const ABSENT_RUN_GRACE_MINUTES: number;
 export const STARVED_RUN_CONCLUSIONS: Set<string>;
+export const STALLED_RUN_MINUTES: number;
 export const RUN_HEALTH: {
 	NORMAL: string;
 	STARVED: string;
+	STALLED: string;
 	ABSENT: string;
 	PENDING: string;
 	UNKNOWN: string;
@@ -39,9 +41,16 @@ export interface HeadRun {
 	jobs: WorkflowJob[] | null;
 }
 
+/** A stalled run carries how long it has been stuck (#2203). */
+export interface StalledHeadRun extends HeadRun {
+	stalledForMinutes?: number | null;
+}
+
 export interface HeadRunHealth {
 	classification: string;
 	starvedRuns: HeadRun[];
+	stalledRuns: StalledHeadRun[];
+	cancelledStalledRuns: HeadRun[];
 	absentWorkflows: string[];
 	unknownWorkflows: string[];
 	pendingWorkflows: string[];
@@ -50,6 +59,16 @@ export interface HeadRunHealth {
 
 export function countExecutedSteps(jobs: WorkflowJob[] | null): number;
 export function isStarvedRun(run: HeadRun | null | undefined): boolean;
+export function runAgeMinutes(
+	run: HeadRun | null | undefined,
+	now: number,
+): number | null;
+export function isStalledRun(
+	run: HeadRun | null | undefined,
+	now: number,
+	thresholdMinutes?: number,
+): boolean;
+export function isCancelledStalledRun(run: HeadRun | null | undefined): boolean;
 export function latestRunPerWorkflowPath(
 	runs: HeadRun[] | null | undefined,
 ): Map<string, HeadRun>;
@@ -58,6 +77,7 @@ export function classifyHeadRun(options: {
 	headCommittedDate: string | null | undefined;
 	now: number;
 	graceMinutes?: number;
+	stalledMinutes?: number;
 	trackedPaths?: string[];
 }): HeadRunHealth;
 export function fetchHeadRunHealth(
@@ -74,8 +94,16 @@ export function absentRunCommentBody(
 	workflows: string[],
 	ageMinutes: number | null,
 ): string;
+export function stalledRunCommentMarker(runId: number | string): string;
+export function stalledRunCommentBody(
+	run: HeadRun,
+	minutes: number | null,
+): string;
 export function decideRunHealthActions(
 	pr: WardenPr,
 	health: HeadRunHealth,
-	options?: { absentCommentExists?: boolean },
+	options?: {
+		absentCommentExists?: boolean;
+		stalledRunMarkers?: Set<string> | null;
+	},
 ): WardenAction[];

--- a/scripts/lib/warden-run-health.mjs
+++ b/scripts/lib/warden-run-health.mjs
@@ -17,6 +17,14 @@
  * - ABSENT RUN: no run for a tracked workflow exists on the head at all,
  *   minutes after the commit. GitHub dropped the `pull_request` dispatch.
  *
+ * - STALLED RUN (#2203): the run EXISTS and never leaves `queued`. Nothing in
+ *   the two signatures above bounds how long a non-`completed` run may sit,
+ *   so a head with a zombie run classified `runs-in-progress` on every cycle
+ *   forever, which reads as healthy waiting. The discriminator is again ZERO
+ *   EXECUTED STEPS: a long matrix job is genuinely in progress no matter how
+ *   old it is, but a run that has executed nothing after an hour was never
+ *   picked up by a runner.
+ *
  * Both are shape 11 in AGENTS.md wearing a new coat: an absent or starved
  * required check is not a passing one. The classifier therefore also emits
  * PENDING and UNKNOWN rather than collapsing "nothing yet" and "we could not
@@ -40,9 +48,21 @@ export const ABSENT_RUN_GRACE_MINUTES = 12;
 // executed steps, and re-running it would fight the person who cancelled it.
 export const STARVED_RUN_CONCLUSIONS = new Set(["failure", "startup_failure"]);
 
+// #2203, AC2: measured, not guessed. Over the 60 most recent COMPLETED
+// `ci.yml` runs (read 2026-08-26 from `actions/workflows/ci.yml/runs`), wall
+// time from `run_started_at` to `updated_at` was median 9 minutes, p95 14,
+// max 17. This threshold applies only to a run that has executed ZERO steps,
+// so the yardstick is queue delay rather than workflow duration, and GitHub
+// normally queues a `pull_request` run onto a runner within seconds. 60
+// minutes is over three times the whole workflow's worst case, and six
+// warden cycles, so an ordinary backlog gets six chances to clear before the
+// warden escalates.
+export const STALLED_RUN_MINUTES = 60;
+
 export const RUN_HEALTH = {
 	NORMAL: "runs-concluded-normally",
 	STARVED: "starved-run",
+	STALLED: "stalled-run",
 	ABSENT: "absent-run",
 	PENDING: "runs-in-progress",
 	UNKNOWN: "run-health-unknown",
@@ -72,6 +92,45 @@ export function countExecutedSteps(jobs) {
 export function isStarvedRun(run) {
 	if (!run || run.status !== "completed") return false;
 	if (!STARVED_RUN_CONCLUSIONS.has(run.conclusion)) return false;
+	if (!Array.isArray(run.jobs)) return false;
+	return countExecutedSteps(run.jobs) === 0;
+}
+
+/** Minutes since GitHub created this run, or null when the date is unreadable. */
+export function runAgeMinutes(run, now) {
+	const createdMs = Date.parse(run?.createdAt ?? "");
+	return Number.isNaN(createdMs) ? null : (now - createdMs) / 60000;
+}
+
+/**
+ * The stalled-run predicate (#2203). Three conditions, each load-bearing:
+ *
+ * - the run has NOT completed, so this never re-judges a concluded run;
+ * - its jobs are a KNOWN array with ZERO executed steps, so a genuinely
+ *   running job is never cancelled out from under itself, however long it
+ *   runs, and an unreadable jobs list stays UNKNOWN rather than becoming
+ *   evidence (shape 10);
+ * - it has been that way for at least `thresholdMinutes`.
+ */
+export function isStalledRun(run, now, thresholdMinutes = STALLED_RUN_MINUTES) {
+	if (!run || run.status === "completed") return false;
+	if (!Array.isArray(run.jobs)) return false;
+	if (countExecutedSteps(run.jobs) > 0) return false;
+	const age = runAgeMinutes(run, now);
+	return age !== null && age >= thresholdMinutes;
+}
+
+/**
+ * The second rung of the stalled ladder: a run the warden cancelled is now
+ * `completed`/`cancelled` with zero executed steps. It is still not a passing
+ * check and still resolves on its own never, so it keeps the STALLED
+ * classification. Only the ACTION differs, and the caller gates that on the
+ * warden's own per-run comment marker: without the marker this is a human's
+ * cancellation and the warden must not fight it.
+ */
+export function isCancelledStalledRun(run) {
+	if (!run || run.status !== "completed") return false;
+	if (run.conclusion !== "cancelled") return false;
 	if (!Array.isArray(run.jobs)) return false;
 	return countExecutedSteps(run.jobs) === 0;
 }
@@ -106,21 +165,25 @@ function runIsNewer(candidate, incumbent) {
  * carrying its jobs, or `jobs: null` when the jobs read failed), the head's
  * commit date, and the clock.
  *
- * Precedence is STARVED > ABSENT > UNKNOWN > PENDING > NORMAL, because it
- * orders by how actionable the finding is: a starved run has a rerun lever,
- * an absent run has a push lever a bot cannot pull, and the rest are waits.
- * The returned record carries EVERY populated bucket, so one head can both
- * rerun a starved `ci.yml` and be told its `lint.yml` never dispatched.
+ * Precedence is STARVED > STALLED > ABSENT > UNKNOWN > PENDING > NORMAL,
+ * because it orders by how actionable the finding is: a starved run has a
+ * rerun lever, a stalled run has a cancel-then-rerun lever, an absent run has
+ * a push lever a bot cannot pull, and the rest are waits. The returned record
+ * carries EVERY populated bucket, so one head can both rerun a starved
+ * `ci.yml` and be told its `lint.yml` never dispatched.
  */
 export function classifyHeadRun({
 	runs,
 	headCommittedDate,
 	now,
 	graceMinutes = ABSENT_RUN_GRACE_MINUTES,
+	stalledMinutes = STALLED_RUN_MINUTES,
 	trackedPaths = TRACKED_WORKFLOW_PATHS,
 }) {
 	const latest = latestRunPerWorkflowPath(runs);
 	const starvedRuns = [];
+	const stalledRuns = [];
+	const cancelledStalledRuns = [];
 	const absentWorkflows = [];
 	const unknownWorkflows = [];
 	const pendingWorkflows = [];
@@ -141,7 +204,26 @@ export function classifyHeadRun({
 			continue;
 		}
 		if (run.status !== "completed") {
-			pendingWorkflows.push(path);
+			// #2203: an in-flight run needs an age dimension. Only a run past the
+			// threshold is even a candidate, and only one that has executed nothing.
+			const runAge = runAgeMinutes(run, now);
+			if (runAge === null || runAge < stalledMinutes) {
+				pendingWorkflows.push(path);
+				continue;
+			}
+			if (!Array.isArray(run.jobs)) {
+				// Aged, but we could not read its jobs, so "stuck" and "working" are
+				// indistinguishable. Say so rather than cancel a live run.
+				unknownWorkflows.push(path);
+				continue;
+			}
+			if (isStalledRun(run, now, stalledMinutes))
+				stalledRuns.push({ ...run, stalledForMinutes: runAge });
+			else pendingWorkflows.push(path);
+			continue;
+		}
+		if (isCancelledStalledRun(run)) {
+			cancelledStalledRuns.push(run);
 			continue;
 		}
 		if (!Array.isArray(run.jobs)) {
@@ -156,6 +238,8 @@ export function classifyHeadRun({
 
 	let classification = RUN_HEALTH.NORMAL;
 	if (starvedRuns.length > 0) classification = RUN_HEALTH.STARVED;
+	else if (stalledRuns.length > 0 || cancelledStalledRuns.length > 0)
+		classification = RUN_HEALTH.STALLED;
 	else if (absentWorkflows.length > 0) classification = RUN_HEALTH.ABSENT;
 	else if (unknownWorkflows.length > 0) classification = RUN_HEALTH.UNKNOWN;
 	else if (pendingWorkflows.length > 0) classification = RUN_HEALTH.PENDING;
@@ -163,6 +247,8 @@ export function classifyHeadRun({
 	return {
 		classification,
 		starvedRuns,
+		stalledRuns,
+		cancelledStalledRuns,
 		absentWorkflows,
 		unknownWorkflows,
 		pendingWorkflows,
@@ -185,9 +271,29 @@ function normalizeRun(run) {
 }
 
 /**
+ * Which runs need a jobs read? Only the anomalous minority, so the healthy
+ * sweep still costs one runs call per head and nothing else:
+ *
+ * - a run that concluded failure/startup_failure (starved candidate, #2184);
+ * - a run that concluded cancelled with the warden's ladder possibly behind
+ *   it (#2203);
+ * - a run still in flight PAST the stalled threshold. A run younger than the
+ *   threshold cannot be stalled, so it is never read: every ordinary in-flight
+ *   run on an open PR is younger than an hour.
+ */
+function needsJobsRead(run, now) {
+	if (run.status !== "completed") {
+		const age = runAgeMinutes(run, now);
+		return age !== null && age >= STALLED_RUN_MINUTES;
+	}
+	if (run.conclusion === "cancelled") return true;
+	return STARVED_RUN_CONCLUSIONS.has(run.conclusion);
+}
+
+/**
  * Read the head's runs, then the jobs of any run that concluded failed.
  * Bounded by construction: one runs call per PR head, plus one jobs call per
- * FAILED tracked run (the anomalous minority), never per healthy run.
+ * anomalous tracked run (see `needsJobsRead`), never per healthy run.
  *
  * Never throws: every failure is recorded and leaves the affected run's
  * `jobs` at null, which the classifier reads as UNKNOWN rather than as
@@ -207,6 +313,8 @@ export async function fetchHeadRunHealth(
 			health: {
 				classification: RUN_HEALTH.UNKNOWN,
 				starvedRuns: [],
+				stalledRuns: [],
+				cancelledStalledRuns: [],
 				absentWorkflows: [],
 				unknownWorkflows: [...TRACKED_WORKFLOW_PATHS],
 				pendingWorkflows: [],
@@ -245,6 +353,8 @@ export async function fetchHeadRunHealth(
 			health: {
 				classification: RUN_HEALTH.UNKNOWN,
 				starvedRuns: [],
+				stalledRuns: [],
+				cancelledStalledRuns: [],
 				absentWorkflows: [],
 				unknownWorkflows: [...TRACKED_WORKFLOW_PATHS],
 				pendingWorkflows: [],
@@ -256,8 +366,7 @@ export async function fetchHeadRunHealth(
 
 	for (const run of runs) {
 		if (!TRACKED_WORKFLOW_PATHS.includes(run.path)) continue;
-		if (run.status !== "completed") continue;
-		if (!STARVED_RUN_CONCLUSIONS.has(run.conclusion)) continue;
+		if (!needsJobsRead(run, now)) continue;
 		try {
 			const response = await fetcher(
 				`${base}/actions/runs/${run.id}/jobs?per_page=100`,
@@ -308,6 +417,113 @@ export function absentRunCommentBody(headSha, workflows, ageMinutes) {
 }
 
 /**
+ * The stalled-run ladder (#2203). Three rungs, each gated on state GitHub
+ * itself reports, so the warden keeps no ledger of its own:
+ *
+ * 1. NO MARKER YET -> post the loud comment naming the stuck run. Nothing is
+ *    cancelled in this cycle: the marker has to exist FIRST, because it is
+ *    what tells the next cycle that the cancellation was the warden's.
+ * 2. MARKER, RUN STILL QUEUED -> cancel it. A cancel is idempotent by
+ *    construction: it moves the run out of the non-completed state, so the
+ *    run can never be selected for a second cancel.
+ * 3. MARKER, RUN CANCELLED WITH ZERO STEPS -> re-run it once. `rerun` is the
+ *    lever a starved run gets, bounded by the same GitHub-owned counter,
+ *    `run_attempt`. It is applied here rather than at rung 2 because GitHub
+ *    refuses `rerun` on a run that has not completed.
+ *
+ * A cancelled zero-step run with NO marker is a person's cancellation. The
+ * warden leaves it alone: it stays STALLED, so nothing reads it as green, but
+ * no lever fires against the human who pulled it.
+ */
+function decideStalledRunActions(pr, health, stalledRunMarkers) {
+	const stalled = health.stalledRuns ?? [];
+	const cancelled = health.cancelledStalledRuns ?? [];
+	if (stalled.length === 0 && cancelled.length === 0) return [];
+	// Fail CLOSED on an unreadable comment list: without the markers the
+	// warden cannot tell its own cancellation from a person's, and guessing
+	// either way is worse than waiting one cycle.
+	if (!(stalledRunMarkers instanceof Set))
+		return [
+			{
+				type: "note",
+				benign: true,
+				message: `PR #${pr.number}: stalled runs found but the comment markers were unreadable; no stalled-run action this cycle`,
+			},
+		];
+
+	const actions = [];
+	const attemptSpent = (run) =>
+		(run.runAttempt ?? 1) > 1
+			? {
+					type: "note",
+					benign: false,
+					message: `PR #${pr.number}: ${run.path} run ${run.id} is STALLED again on attempt ${run.runAttempt}; the warden already recovered it once for this head`,
+				}
+			: null;
+
+	for (const run of stalled) {
+		if (!stalledRunMarkers.has(stalledRunCommentMarker(run.id))) {
+			actions.push({
+				type: "comment",
+				body: stalledRunCommentBody(run, run.stalledForMinutes ?? null),
+			});
+			continue;
+		}
+		const spent = attemptSpent(run);
+		if (spent) {
+			actions.push(spent);
+			continue;
+		}
+		actions.push({
+			type: "cancel-run",
+			runId: run.id,
+			workflowPath: run.path,
+		});
+	}
+
+	for (const run of cancelled) {
+		if (!stalledRunMarkers.has(stalledRunCommentMarker(run.id))) continue;
+		const spent = attemptSpent(run);
+		if (spent) {
+			actions.push(spent);
+			continue;
+		}
+		actions.push({
+			type: "rerun-run",
+			runId: run.id,
+			workflowPath: run.path,
+		});
+	}
+	return actions;
+}
+
+/**
+ * Per-RUN dedupe key for the stalled-run escalation (#2203). Per-run, not
+ * per-head, because the ladder needs it for two jobs at once: it deduplicates
+ * the loud comment, and it is the only GitHub-owned evidence that the
+ * cancellation of this run was the warden's and not a person's. A per-head
+ * key could not distinguish two stuck runs on the same head.
+ */
+export function stalledRunCommentMarker(runId) {
+	return `<!-- warden:stalled-run:${runId} -->`;
+}
+
+export function stalledRunCommentBody(run, minutes) {
+	const age = minutes === null ? "an unknown time" : `${Math.round(minutes)}`;
+	return [
+		"**Merge-train warden: this run has been queued for hours and has executed nothing.**",
+		"",
+		`\`${run.path}\` run [${run.id}](${run.url}) is \`${run.status}\` ${age} minutes after GitHub created it, with zero executed steps across every job. GitHub queued it and never scheduled it.`,
+		"",
+		`A run that never concludes is not a run that is fine. The required checks on this head are UNRESOLVED, not passing, so nothing may read this PR as green.`,
+		"",
+		"The warden cancels this run on its next cycle, then re-runs it once. If the re-run stalls too, the warden stops and marks its own run red.",
+		"",
+		stalledRunCommentMarker(run.id),
+	].join("\n");
+}
+
+/**
  * Decide the recovery actions for one head's run health. Pure, like
  * `decideActions`: the caller resolves whether the absent-run comment already
  * exists and hands in the boolean.
@@ -322,9 +538,10 @@ export function absentRunCommentBody(headSha, workflows, ageMinutes) {
 export function decideRunHealthActions(
 	pr,
 	health,
-	{ absentCommentExists } = {},
+	{ absentCommentExists, stalledRunMarkers } = {},
 ) {
 	const actions = [];
+	actions.push(...decideStalledRunActions(pr, health, stalledRunMarkers));
 	for (const run of health.starvedRuns ?? []) {
 		if ((run.runAttempt ?? 1) > 1) {
 			actions.push({

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -16,8 +16,8 @@ import {
 } from "../../scripts/lib/merge-train-lane.mjs";
 import {
 	applyAction,
-	classifyActionFailure,
 	CONFLICT_LABEL,
+	classifyActionFailure,
 	decideActions,
 	fetchOpenPullRequests,
 	MAX_PAGES,
@@ -32,8 +32,12 @@ import {
 	countExecutedSteps,
 	decideRunHealthActions,
 	fetchHeadRunHealth,
+	isCancelledStalledRun,
+	isStalledRun,
 	isStarvedRun,
 	RUN_HEALTH,
+	STALLED_RUN_MINUTES,
+	stalledRunCommentMarker,
 } from "../../scripts/lib/warden-run-health.mjs";
 
 function pr(overrides: Record<string, unknown> = {}) {
@@ -1134,6 +1138,8 @@ describe("run-health recovery actions (#2184)", () => {
 	const starvedHealth = () => ({
 		classification: RUN_HEALTH.STARVED,
 		starvedRuns: [headRun()],
+		stalledRuns: [],
+		cancelledStalledRuns: [],
 		absentWorkflows: [],
 		unknownWorkflows: [],
 		pendingWorkflows: [],
@@ -1173,6 +1179,8 @@ describe("run-health recovery actions (#2184)", () => {
 			{
 				classification: RUN_HEALTH.ABSENT,
 				starvedRuns: [],
+				stalledRuns: [],
+				cancelledStalledRuns: [],
 				absentWorkflows: [".github/workflows/ci.yml"],
 				unknownWorkflows: [],
 				pendingWorkflows: [],
@@ -1196,6 +1204,8 @@ describe("run-health recovery actions (#2184)", () => {
 			{
 				classification: RUN_HEALTH.ABSENT,
 				starvedRuns: [],
+				stalledRuns: [],
+				cancelledStalledRuns: [],
 				absentWorkflows: [".github/workflows/ci.yml"],
 				unknownWorkflows: [],
 				pendingWorkflows: [],
@@ -1219,6 +1229,8 @@ describe("run-health recovery actions (#2184)", () => {
 				{
 					classification: RUN_HEALTH.NORMAL,
 					starvedRuns: [],
+					stalledRuns: [],
+					cancelledStalledRuns: [],
 					absentWorkflows: [],
 					unknownWorkflows: [],
 					pendingWorkflows: [],
@@ -1505,12 +1517,463 @@ describe("warden sweep with run health (#2184)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// #2203: the third degradation signature -- a run stuck `queued`
+// ---------------------------------------------------------------------------
+
+/** A run GitHub queued and never scheduled: no jobs, no steps, no progress. */
+function queuedRun(overrides: Record<string, unknown> = {}) {
+	return headRun({
+		id: 32993037596,
+		status: "queued",
+		conclusion: null,
+		createdAt: "2026-08-26T15:00:00Z", // 90 minutes before NOW
+		jobs: [],
+		...overrides,
+	});
+}
+
+/** A head whose lint.yml is healthy, so only the ci.yml run is under test. */
+function healthyLintRun() {
+	return headRun({
+		id: 999,
+		path: ".github/workflows/lint.yml",
+		conclusion: "success",
+		jobs: executedJobs(),
+	});
+}
+
+type StalledFixture = ReturnType<typeof queuedRun> & {
+	stalledForMinutes?: number;
+};
+
+function stalledHealthOf(
+	runs: StalledFixture[],
+	cancelled: ReturnType<typeof queuedRun>[] = [],
+) {
+	return {
+		classification: RUN_HEALTH.STALLED,
+		starvedRuns: [],
+		stalledRuns: runs,
+		cancelledStalledRuns: cancelled,
+		absentWorkflows: [],
+		unknownWorkflows: [],
+		pendingWorkflows: [],
+		ageMinutes: 90,
+	};
+}
+
+describe("stalled-run detection (#2203)", () => {
+	// The red-first anchor. Before #2203 a queued run classified PENDING
+	// forever, however old, and the sweep printed "runs-in-progress" every
+	// cycle -- which reads as healthy waiting.
+	it("classifies a run queued past the threshold with zero steps as stalled", () => {
+		expect(isStalledRun(queuedRun(), NOW)).toBe(true);
+		const health = classifyHeadRun({
+			runs: [queuedRun(), healthyLintRun()],
+			headCommittedDate: "2026-08-26T15:00:00Z",
+			now: NOW,
+		});
+		expect(health.classification).toBe(RUN_HEALTH.STALLED);
+		expect(
+			health.stalledRuns.map((r: { id: number | string }) => r.id),
+		).toEqual([32993037596]);
+		expect(health.pendingWorkflows).toEqual([]);
+	});
+
+	// Mutation screen for the threshold: delete the age test and every run in
+	// the seconds between dispatch and pickup is "stalled", so the warden
+	// cancels healthy CI on every open PR.
+	it("classifies a freshly queued run as in progress, not stalled", () => {
+		const young = queuedRun({ createdAt: "2026-08-26T16:25:00Z" });
+		expect(isStalledRun(young, NOW)).toBe(false);
+		const health = classifyHeadRun({
+			runs: [young, healthyLintRun()],
+			headCommittedDate: "2026-08-26T16:25:00Z",
+			now: NOW,
+		});
+		expect(health.classification).toBe(RUN_HEALTH.PENDING);
+		expect(health.stalledRuns).toEqual([]);
+	});
+
+	// Mutation screen for the zero-executed-steps guard: a long matrix job is
+	// genuinely in progress no matter how old the run is. Widening the
+	// predicate to "old and not completed" would cancel live CI.
+	it("does NOT call a long-running run with executed steps stalled", () => {
+		const working = queuedRun({
+			status: "in_progress",
+			createdAt: "2026-08-26T10:00:00Z", // six and a half hours old
+			jobs: executedJobs(),
+		});
+		expect(isStalledRun(working, NOW)).toBe(false);
+		const health = classifyHeadRun({
+			runs: [working, healthyLintRun()],
+			headCommittedDate: "2026-08-26T10:00:00Z",
+			now: NOW,
+		});
+		expect(health.classification).toBe(RUN_HEALTH.PENDING);
+	});
+
+	it("treats the threshold as inclusive at exactly the boundary", () => {
+		const atBoundary = queuedRun({ createdAt: "2026-08-26T15:30:00Z" });
+		expect(STALLED_RUN_MINUTES).toBe(60);
+		expect(isStalledRun(atBoundary, NOW)).toBe(true);
+		expect(
+			isStalledRun(queuedRun({ createdAt: "2026-08-26T15:30:30Z" }), NOW),
+		).toBe(false);
+	});
+
+	// Shape 10: "we could not read the jobs" is not evidence of a zombie, and
+	// cancelling on a guess would kill a live run.
+	it("classifies an aged queued run whose jobs are unreadable as unknown", () => {
+		expect(isStalledRun(queuedRun({ jobs: null }), NOW)).toBe(false);
+		const health = classifyHeadRun({
+			runs: [queuedRun({ jobs: null }), healthyLintRun()],
+			headCommittedDate: "2026-08-26T15:00:00Z",
+			now: NOW,
+		});
+		expect(health.classification).toBe(RUN_HEALTH.UNKNOWN);
+		expect(health.unknownWorkflows).toEqual([".github/workflows/ci.yml"]);
+		expect(health.stalledRuns).toEqual([]);
+	});
+
+	// The second rung's input: the run the warden cancelled is completed, but a
+	// cancelled required check is not a passing one and it resolves on its own
+	// never. Before #2203 this classified NORMAL.
+	it("classifies a cancelled zero-step run as stalled, not normal", () => {
+		const cancelled = queuedRun({
+			status: "completed",
+			conclusion: "cancelled",
+			jobs: starvedJobs(),
+		});
+		expect(isCancelledStalledRun(cancelled)).toBe(true);
+		const health = classifyHeadRun({
+			runs: [cancelled, healthyLintRun()],
+			headCommittedDate: "2026-08-26T15:00:00Z",
+			now: NOW,
+		});
+		expect(health.classification).toBe(RUN_HEALTH.STALLED);
+		expect(
+			health.cancelledStalledRuns.map((r: { id: number | string }) => r.id),
+		).toEqual([32993037596]);
+	});
+
+	it("does NOT call a cancelled run that executed steps stalled", () => {
+		expect(
+			isCancelledStalledRun(
+				queuedRun({
+					status: "completed",
+					conclusion: "cancelled",
+					jobs: executedJobs(),
+				}),
+			),
+		).toBe(false);
+	});
+
+	it("reads jobs for an aged in-flight run, and never for a young one", async () => {
+		const routes = (createdAt: string) => ({
+			"GET /repos/acme/repo/actions/runs": runsRoute([
+				{
+					id: 1,
+					path: ".github/workflows/ci.yml",
+					status: "queued",
+					conclusion: null,
+					run_attempt: 1,
+					created_at: createdAt,
+				},
+			]),
+			"GET /repos/acme/repo/actions/runs/1/jobs": { jobs: [] },
+		});
+		const aged = fakeGithub(routes("2026-08-26T15:00:00Z"));
+		const agedHealth = await fetchHeadRunHealth(
+			aged.fetcher,
+			"acme",
+			"repo",
+			"8e32f127",
+			"2026-08-26T15:00:00Z",
+			NOW,
+		);
+		expect(agedHealth.health.classification).toBe(RUN_HEALTH.STALLED);
+		expect(aged.calls.filter((c) => c.url.includes("/jobs"))).toHaveLength(1);
+
+		const young = fakeGithub(routes("2026-08-26T16:25:00Z"));
+		await fetchHeadRunHealth(
+			young.fetcher,
+			"acme",
+			"repo",
+			"8e32f127",
+			"2026-08-26T16:25:00Z",
+			NOW,
+		);
+		expect(young.calls.filter((c) => c.url.includes("/jobs"))).toHaveLength(0);
+	});
+});
+
+describe("stalled-run recovery ladder (#2203)", () => {
+	it("announces the stuck run first, and cancels nothing in that cycle", () => {
+		const actions = decideRunHealthActions(
+			pr(),
+			stalledHealthOf([{ ...queuedRun(), stalledForMinutes: 90 }]),
+			{ stalledRunMarkers: new Set<string>() },
+		);
+		expect(actions).toEqual([
+			{
+				type: "comment",
+				body: expect.stringContaining(stalledRunCommentMarker(32993037596)),
+			},
+		]);
+		expect((actions[0] as { body: string }).body).toContain("32993037596");
+		expect((actions[0] as { body: string }).body).toContain("90 minutes");
+		expect(actions.some((a) => a.type === "cancel-run")).toBe(false);
+	});
+
+	// Mutation screen for the comment dedupe: without it the ladder reposts the
+	// notice every 10 minutes and never advances to the cancel.
+	it("cancels the stuck run once its marker exists, without repeating the comment", () => {
+		const actions = decideRunHealthActions(
+			pr(),
+			stalledHealthOf([{ ...queuedRun(), stalledForMinutes: 90 }]),
+			{
+				stalledRunMarkers: new Set([stalledRunCommentMarker(32993037596)]),
+			},
+		);
+		expect(actions).toEqual([
+			{
+				type: "cancel-run",
+				runId: 32993037596,
+				workflowPath: ".github/workflows/ci.yml",
+			},
+		]);
+	});
+
+	it("re-runs a run the warden itself cancelled", () => {
+		const cancelled = queuedRun({
+			status: "completed",
+			conclusion: "cancelled",
+			jobs: starvedJobs(),
+		});
+		const actions = decideRunHealthActions(
+			pr(),
+			stalledHealthOf([], [cancelled]),
+			{
+				stalledRunMarkers: new Set([stalledRunCommentMarker(32993037596)]),
+			},
+		);
+		expect(actions).toEqual([
+			{
+				type: "rerun-run",
+				runId: 32993037596,
+				workflowPath: ".github/workflows/ci.yml",
+			},
+		]);
+	});
+
+	// Mutation screen for the marker gate: drop it and the warden re-runs work
+	// a person deliberately cancelled.
+	it("does NOT re-run a cancelled run the warden did not cancel", () => {
+		const cancelled = queuedRun({
+			status: "completed",
+			conclusion: "cancelled",
+			jobs: starvedJobs(),
+		});
+		expect(
+			decideRunHealthActions(pr(), stalledHealthOf([], [cancelled]), {
+				stalledRunMarkers: new Set<string>(),
+			}),
+		).toEqual([]);
+	});
+
+	// Mutation screen for the run_attempt bound: delete it and the ladder
+	// cancels and re-runs the same run every cycle for the whole outage.
+	it("stops after one recovery, and marks the warden run red", () => {
+		const actions = decideRunHealthActions(
+			pr(),
+			stalledHealthOf([
+				{ ...queuedRun({ runAttempt: 2 }), stalledForMinutes: 90 },
+			]),
+			{
+				stalledRunMarkers: new Set([stalledRunCommentMarker(32993037596)]),
+			},
+		);
+		expect(actions).toEqual([
+			{
+				type: "note",
+				benign: false,
+				message: expect.stringContaining("STALLED again on attempt 2"),
+			},
+		]);
+		expect(actions.some((a) => a.type === "cancel-run")).toBe(false);
+	});
+
+	// Fail closed: without the markers the warden cannot tell its own
+	// cancellation from a person's.
+	it("takes no stalled action when the marker read failed", () => {
+		const actions = decideRunHealthActions(
+			pr(),
+			stalledHealthOf([{ ...queuedRun(), stalledForMinutes: 90 }]),
+			{ stalledRunMarkers: null },
+		);
+		expect(actions).toEqual([
+			{
+				type: "note",
+				benign: true,
+				message: expect.stringContaining("markers were unreadable"),
+			},
+		]);
+	});
+});
+
+describe("warden sweep over a stalled run (#2203)", () => {
+	const stalledPayload = {
+		id: 77,
+		path: ".github/workflows/ci.yml",
+		status: "queued",
+		conclusion: null,
+		run_attempt: 1,
+		created_at: "2026-08-26T15:00:00Z",
+	};
+	// The head's OTHER tracked workflow ran normally, so the sweep is testing
+	// the stalled ladder and not the absent-dispatch comment.
+	const healthyLintPayload = {
+		id: 78,
+		path: ".github/workflows/lint.yml",
+		status: "completed",
+		conclusion: "success",
+		run_attempt: 1,
+		created_at: "2026-08-26T15:00:00Z",
+	};
+
+	function sweepPage() {
+		return graphqlPage([
+			prNode({
+				number: 7,
+				mergeStateStatus: "CLEAN",
+				commits: {
+					nodes: [
+						{
+							commit: {
+								oid: "deadbeef",
+								committedDate: "2026-08-26T15:00:00Z",
+								statusCheckRollup: { contexts: { nodes: [] } },
+							},
+						},
+					],
+				},
+			}),
+		]);
+	}
+
+	it("comments, then cancels on the next cycle, and names the run in the sweep", async () => {
+		const first = fakeGithub({
+			"POST /graphql": sweepPage(),
+			"GET /repos/acme/repo/actions/runs": runsRoute([
+				stalledPayload,
+				healthyLintPayload,
+			]),
+			"GET /repos/acme/repo/actions/runs/77/jobs": { jobs: [] },
+		});
+		const firstResults = await runWarden({
+			fetcher: first.fetcher,
+			owner: "acme",
+			repo: "repo",
+			now: NOW,
+		});
+		const posted = first.calls.filter(
+			(c) => c.method === "POST" && c.url.endsWith("/issues/7/comments"),
+		);
+		expect(posted).toHaveLength(1);
+		expect(String((posted[0].body as { body: string }).body)).toContain(
+			stalledRunCommentMarker(77),
+		);
+		expect(first.calls.some((c) => c.url.includes("/cancel"))).toBe(false);
+		expect(firstResults[0].runHealth).toEqual({
+			classification: RUN_HEALTH.STALLED,
+			detail: expect.stringContaining(
+				"stalled .github/workflows/ci.yml run 77 queued 90m with zero executed steps",
+			),
+		});
+
+		const second = fakeGithub({
+			"POST /graphql": sweepPage(),
+			"GET /repos/acme/repo/actions/runs": runsRoute([
+				stalledPayload,
+				healthyLintPayload,
+			]),
+			"GET /repos/acme/repo/actions/runs/77/jobs": { jobs: [] },
+			"GET /repos/acme/repo/issues/7/comments": [
+				{ body: (posted[0].body as { body: string }).body },
+			],
+		});
+		const secondResults = await runWarden({
+			fetcher: second.fetcher,
+			owner: "acme",
+			repo: "repo",
+			now: NOW,
+		});
+		expect(
+			second.calls.filter(
+				(c) => c.method === "POST" && c.url.endsWith("/actions/runs/77/cancel"),
+			),
+		).toHaveLength(1);
+		expect(
+			second.calls.filter(
+				(c) => c.method === "POST" && c.url.endsWith("/issues/7/comments"),
+			),
+		).toHaveLength(0);
+		expect(secondResults[0].applied).toContain(
+			"cancel-run:.github/workflows/ci.yml#77",
+		);
+	});
+
+	it("re-runs the run it cancelled once the cancellation lands", async () => {
+		const marker = stalledRunCommentMarker(77);
+		const { fetcher, calls } = fakeGithub({
+			"POST /graphql": sweepPage(),
+			"GET /repos/acme/repo/actions/runs": runsRoute([
+				{ ...stalledPayload, status: "completed", conclusion: "cancelled" },
+				healthyLintPayload,
+			]),
+			"GET /repos/acme/repo/actions/runs/77/jobs": { jobs: starvedJobs() },
+			"GET /repos/acme/repo/issues/7/comments": [{ body: `x ${marker}` }],
+		});
+		const results = await runWarden({
+			fetcher,
+			owner: "acme",
+			repo: "repo",
+			now: NOW,
+		});
+		expect(
+			calls.filter(
+				(c) => c.method === "POST" && c.url.endsWith("/actions/runs/77/rerun"),
+			),
+		).toHaveLength(1);
+		expect(results[0].applied).toContain(
+			"rerun-run:.github/workflows/ci.yml#77",
+		);
+	});
+
+	it("issues the cancel against the runs cancel endpoint", async () => {
+		const { fetcher, calls } = fakeGithub({});
+		await applyAction(fetcher, "acme", "repo", pr({ number: 7 }), {
+			type: "cancel-run",
+			runId: 77,
+			workflowPath: ".github/workflows/ci.yml",
+		});
+		expect(calls[0].method).toBe("POST");
+		expect(calls[0].url).toBe(
+			"https://api.github.com/repos/acme/repo/actions/runs/77/cancel",
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // #2185: the label-gated merge lane
 // ---------------------------------------------------------------------------
 
 const HEALTHY = {
 	classification: RUN_HEALTH.NORMAL,
 	starvedRuns: [],
+	stalledRuns: [],
+	cancelledStalledRuns: [],
 	absentWorkflows: [],
 	unknownWorkflows: [],
 	pendingWorkflows: [],
@@ -1677,6 +2140,19 @@ describe("merge-lane gate (#2185)", () => {
 			merge: false,
 			reason: MERGE_GATE_REASON.RUN_HEALTH,
 		});
+	});
+
+	// #2203 AC4: the lane reads the new classification as not-green.
+	it("treats a stalled run health as not-green even with green required checks", () => {
+		const gate = gateOf(approved(), {
+			...HEALTHY,
+			classification: RUN_HEALTH.STALLED,
+		});
+		expect(gate).toMatchObject({
+			merge: false,
+			reason: MERGE_GATE_REASON.RUN_HEALTH,
+		});
+		expect(gate.detail).toContain("stalled-run");
 	});
 
 	it("blocks on a failing non-advisory check and allows a failing advisory one", () => {


### PR DESCRIPTION
## What changed

The merge-train warden now recognises a third degradation signature: a workflow run GitHub queued and never scheduled.

Before this, `classifyHeadRun` had no age dimension for a run that exists. Any tracked run reporting a status other than `completed` classified `runs-in-progress`, with no upper bound. A zombie run printed `runs: runs-in-progress` on every 10-minute cycle forever, which reads as healthy waiting, and no lever ever fired.

A tracked run that has executed **zero steps** for 60 minutes now classifies `stalled-run`. Zero executed steps is the discriminator, the same one the starved signature uses. A long matrix job is genuinely in progress no matter how old the run is, so it stays `runs-in-progress`.

### The threshold, and why 60 minutes

Measured, not guessed. Over the 60 most recent completed `ci.yml` runs, read on 2026-08-26 from `actions/workflows/ci.yml/runs`, wall time from `run_started_at` to `updated_at` was:

| statistic | minutes |
| --- | --- |
| median | 9 |
| p95 | 14 |
| max | 17 |

The threshold applies only to a run that has executed nothing, so the yardstick is queue delay, not workflow duration, and GitHub normally puts a `pull_request` run on a runner within seconds. 60 minutes is over three times the whole workflow's worst case, and it is six warden cycles, so an ordinary backlog gets six chances to clear first. `STALLED_RUN_MINUTES` carries that reasoning in a comment.

### The recovery ladder

Three rungs, each gated on state GitHub itself reports, so the warden keeps no ledger of its own:

1. **No marker yet** — post a comment naming the stuck run, carrying a per-run HTML marker. Nothing is cancelled in this cycle; the marker has to exist first.
2. **Marker, run still queued** — `POST /actions/runs/{id}/cancel`. Idempotent by construction: the cancel moves the run out of the non-completed state, so it can never be selected for a second cancel.
3. **Marker, run cancelled with zero steps** — `POST /actions/runs/{id}/rerun`, once, bounded by GitHub's own `run_attempt` counter exactly as the starved lever is.

`rerun` lands at rung 3 rather than rung 2 because GitHub refuses `rerun` on a run that has not completed. The marker is the only GitHub-owned evidence that a cancellation was the warden's: a cancelled zero-step run **without** the marker is a person's decision, so the warden classifies it `stalled-run` (a cancelled required check is not a passing one) but pulls no lever against it.

Every escalation is named in the sweep record, for example `stalled .github/workflows/ci.yml run 77 queued 90m with zero executed steps (attempt 1)`.

## Merge order

This branch was cut from PR #2191's head. **#2191 merged first** (commit `5c9b0069`), and `origin/master` is merged into this branch, so it is already sequenced correctly. No further ordering constraint.

## Files

- `scripts/lib/warden-run-health.mjs` — `STALLED_RUN_MINUTES`, `RUN_HEALTH.STALLED`, `runAgeMinutes`, `isStalledRun`, `isCancelledStalledRun`, the two new classifier buckets, the ladder, and the escalation comment.
- `scripts/lib/merge-train-warden.mjs` — the `cancel-run` action, `readStalledRunMarkers`, and the new sweep-summary lines.
- `scripts/lib/github-paging.mjs` — `presentCommentMarkers`, one paged comment read answering many markers. `commentMarkerExists` now delegates to it, so there is still one implementation.
- `scripts/lib/merge-train-lane.mjs` — comment only. The gate already denies on any classification that is not `NORMAL`.
- `.github/workflows/merge-train-warden.yml` — comments and the step name; the `actions: write` grant it already had now covers the cancel.
- `scripts/lib/*.d.mts` — declarations for the new exports.

## Verification

`npm run build` before every test run.

### Red-first, on pre-fix source

Tests and fix committed at `626371dd`, then the four changed `.mjs` files reverted to the branch point `85d2b141` with `git checkout`, leaving the tests in place:

```
 Test Files  1 failed (1)
      Tests  17 failed | 98 passed (115)
```

The 17 reds are every new test: the classifier signatures, the ladder, the sweep, the `cancel` endpoint, and the lane gate.

### Mutation proofs

Each guard was deleted in turn, on top of the fix, and at least one test went red for it.

| mutation | result |
| --- | --- |
| M1 threshold removed (`isStalledRun` returns true regardless of age; classifier age branch neutered) | `Tests  3 failed \| 112 passed` — "classifies a freshly queued run as in progress, not stalled", "treats the threshold as inclusive at exactly the boundary", "classifies an in-flight run as pending, never as concluded normally" |
| M2 zero-executed-steps guard removed | `Tests  1 failed \| 114 passed` — "does NOT call a long-running run with executed steps stalled" |
| M3 comment-marker dedupe and gate removed | `Tests  3 failed \| 112 passed` — "announces the stuck run first, and cancels nothing in that cycle", "does NOT re-run a cancelled run the warden did not cancel", "comments, then cancels on the next cycle, and names the run in the sweep" |
| M4 `run_attempt` bound removed | `Tests  1 failed \| 114 passed` — "stops after one recovery, and marks the warden run red" |
| M5 unreadable-markers fail-closed removed | `Tests  1 failed \| 114 passed` — "takes no stalled action when the marker read failed" |

### Green

```
 Test Files  1 passed (1)
      Tests  115 passed (115)
```

`tests/scripts/merge-train-warden.test.ts`, after the `origin/master` merge. 16 tests are new.

Wider run, after the merge: `tests/scripts` plus `tests/config/git-fixture-governance.test.ts`, `tests/packaging.test.ts`, `tests/clients/zizmor-config.test.ts` and the named governance sweeps:

```
 Test Files  1 failed | 36 passed (37)
      Tests  4 failed | 687 passed | 4 skipped (695)
```

The 4 reds are `tests/scripts/pre-push-targeted-tests.test.ts`, and they are **pre-existing and environmental**: the same 4 fail on the untouched branch point `85d2b141` in this worktree, because `PI_LENS_SKIP_HOOKS` is set in the session environment. Not caused by this change.

`npm run lint` (tsc) clean. `biome check` on the changed files reports only findings that already existed on master (`noUnsafeOptionalChaining` at test line 2507, `noTemplateCurlyInString` at 927, `useOptionalChain` on the pre-existing `isStarvedRun` shape).

### Not verified locally

- **actionlint.** Not installed in this environment; `yaml-lint` passes. The workflow edit is comments, a step name, and a trailing comment on an existing permission line, with no expression or structural change. CI's actionlint job is authoritative.
- **The live ladder.** A scheduled workflow cannot be exercised before merge, same limit #2191 recorded. Every rung is covered by injected-fetcher tests, including the two-cycle comment-then-cancel sequence and the cancel-then-rerun sequence.
- **Full suite.** Deferred to CI.

## Test assessment

New coverage, all in `tests/scripts/merge-train-warden.test.ts`:

- **Classification.** Aged queued run with zero steps is stalled; freshly queued is in progress; a six-hour run with executed steps is in progress; the threshold is inclusive at exactly 60 minutes and excludes 59.5; an aged queued run with an unreadable jobs list is `run-health-unknown`, never stalled; a cancelled zero-step run is stalled; a cancelled run that executed steps is not.
- **Read bounding.** `fetchHeadRunHealth` issues a jobs read for an aged in-flight run and none for a young one, which is the claim that the healthy sweep costs nothing extra.
- **Ladder.** Comment-then-cancel-then-rerun, the marker gate against a human's cancellation, the `run_attempt` stop, and the fail-closed path when the comment read throws.
- **Endpoint.** `applyAction` posts `cancel-run` to `/actions/runs/{id}/cancel`.
- **Lane.** A `stalled-run` classification holds a `train:approved` PR with green required checks, reason `run-health`.

The doubles stay production-faithful on the axis under test: `fakeGithub` records the real URLs and methods, and the two-cycle sweep test feeds the first cycle's actual posted comment body into the second cycle's comments route, so the dedupe is proved against the marker the code really wrote.

## Blast radius

- **`classifyHeadRun` result shape.** Two new buckets, `stalledRuns` and `cancelledStalledRuns`. Both consumers (`merge-train-warden.mjs`, `merge-train-lane.mjs`) are in this diff; there are no others (`grep -rn "classifyHeadRun\|fetchHeadRunHealth"` over the whole tree returns those two plus the test file).
- **Behaviour widening, one case.** A run that concluded `cancelled` with zero executed steps used to classify `runs-concluded-normally`. It now classifies `stalled-run`. No merge decision changes: the lane already denied such a head at `required-check-not-success`, because a cancelled check run is not `SUCCESS`. Only the denial reason string and the sweep detail change.
- **New API calls.** One `POST .../cancel` per stalled run, at most once per run. One paged `GET issues/{n}/comments` per head that already has a stalled or cancelled-zero-step run; a healthy head pays nothing, because `readStalledRunMarkers` returns an empty set without a request when both buckets are empty. Jobs reads widen to non-completed runs past 60 minutes and to cancelled runs, both anomalous minorities; every ordinary in-flight run on an open PR is younger than an hour.
- **Permissions.** No new grant. `actions: write` already covered `rerun`, and it covers `cancel`.
- **`commentMarkerExists`.** Refactored to call `presentCommentMarkers`. Same paging, same throw-on-failure contract, same call sites; its existing tests pass unchanged.

## Observability

The warden run log is the record, as in #2184. `summarizeRunHealth` writes the classification and a detail line per head, so a stuck run appears as `stalled-run` with the workflow path, the run id, its status, its age in minutes, and its attempt number. The escalation itself is recorded twice: `applied` carries `cancel-run:<path>#<id>` or `rerun-run:<path>#<id>`, and the PR comment carries the marker.

Bounded by construction, and the discriminating identity is preserved: the comment marker is per run id, so two stuck runs on one head are two records, not one aggregate. The exhausted-ladder case is a non-benign note, which turns the warden's own scheduled run red, so a run still stalled after one recovery is visible within one cycle instead of never.

## Class sweep

**Pattern sweep.** The defect shape is a state machine with a terminal-looking non-terminal state and no age bound: a branch that classifies "still waiting" from a status field with no upper bound on how long the wait may last. Searched the whole tree, not `clients/` alone.

- `scripts/lib/warden-run-health.mjs:206` — the site fixed here.
- `scripts/lib/warden-run-health.mjs:197` — the absent-run branch. Already bounded by `ABSENT_RUN_GRACE_MINUTES` (#2184).
- `scripts/lib/merge-train-lane.mjs:158` — `run.status !== CONCLUDED_STATUS` denies the merge. Correct with no age bound: it withholds a pass rather than granting one, and the run-health gate above it now supplies the age dimension.
- `scripts/lib/ci-failure-classifier.mjs` — operates on a completed run's log; no pending state exists.
- `scripts/lib/stale-open-issues.mjs`, `scripts/lib/drift-issue.mjs` — both are age-driven already; that is their whole purpose.

**Population sweep.** The enumerable family is the run-health signatures, which the issue names as the "CI signal that never resolves" family. Per-member verdict:

| signature | verdict |
| --- | --- |
| `runs-concluded-normally` | terminal; no wait to bound |
| `starved-run` | bounded and levered (#2184); rerun once per `run_attempt` |
| `absent-run` | bounded by `ABSENT_RUN_GRACE_MINUTES`; comment lever, deduped per head |
| `runs-in-progress` | **the defect.** Unbounded. Fixed here |
| `run-health-unknown` | not a wait: it is a read failure, re-read every cycle, and it already denies the merge |

The second sweep axis is the warden's levers, checked for the idempotence rule the catalog demands: `add-label` and `remove-label` are keyed on label presence, `update-branch` on `expected_head_sha`, `comment` on a per-head or per-run marker, `rerun-run` on `run_attempt`, and the new `cancel-run` on the run leaving the non-completed state. Every lever is bounded by state GitHub owns; none uses a warden-side ledger.

Closes #2203.
