### PR TITLE
fix(lsp): serialize per-path didChange sends (closes #2113)

### DIFF
--- a/.changelog/fix-2113-didchange-overlap-serialize.md
+++ b/.changelog/fix-2113-didchange-overlap-serialize.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- Serialize overlapping per-path LSP `didChange` sends so Incremental payloads use the latest confirmed document content (closes #2113).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,12 @@ Pipeline-crash teardown is destructive only for the registered primary session;
 when no primary registration exists, the legacy reset remains the fail-safe.
 (#2157, #2174)
 
+Per-path `didChange` sends serialize their read/build/send/record transaction
+through `LSPClientState.notifyChangeQueues`; different paths remain parallel.
+`recordSentContent` rejects a lower-version mirror update and records an
+`lsp-document-send-order` degradation with the server and normalized path.
+(#2113)
+
 Auxiliary diagnostic waits preserve a warm-turn fast path: on a cold
 acquisition, the budget is `max(declared wait, observed spawn + 500ms)` clamped
 to an 8s ceiling; on a warm acquisition, it remains `min(declared wait, 2000ms)`. An

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -98,6 +98,8 @@ export type DegradationKind =
 	| "lsp-diagnostics-timeout"
 	| "lsp-scanner-coverage-gap"
 	| "lsp-notify-inflight-stall"
+	/** A didChange content mirror was recorded behind a newer document version. */
+	| "lsp-document-send-order"
 	| "bus-stale"
 	| "query-predicates-invalid"
 	| "install-retry-exhausted"

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -900,6 +900,8 @@ export interface LSPClientState {
 	 *  above; readers fold their input through `normalizeMapKey`. */
 	readonly diagnosticsVersionsByPath: Map<string, number>;
 	readonly documentVersions: Map<string, number>;
+	/** #2113: tails for same-path didChange sends; different paths stay parallel. */
+	readonly notifyChangeQueues: Map<string, Promise<void>>;
 	/** The LSP document version (`publishDiagnostics.version`) the cached
 	 *  diagnostics for a path were computed against. Only set when the server
 	 *  reports a version; absent entries mean "version unknown" and are treated
@@ -1873,6 +1875,14 @@ function recordSentContent(
 ): void {
 	const scan = scanSentContent(content);
 	const previous = state.documentContentHashes.get(normalizedPath);
+	if (previous && previous.version > version) {
+		incrementDegradationCount({
+			kind: "lsp-document-send-order",
+			subject: `${state.serverId}:${normalizedPath}`,
+			reason: `recorded version ${version} after newer version ${previous.version}`,
+		});
+		return;
+	}
 	if (previous?.text !== undefined) {
 		state.incrementalTextRetainedEntries = Math.max(
 			0,
@@ -3857,13 +3867,13 @@ export async function handleNotifyOpen(
 	});
 }
 
-export async function handleNotifyChange(
+async function handleNotifyChangeOnce(
 	state: LSPClientState,
 	filePath: string,
 	content: string,
+	normalizedPath: string,
 ): Promise<void> {
 	if (!isClientAlive(state)) return;
-	const normalizedPath = normalizeMapKey(filePath);
 	const uri =
 		state.openDocumentUris?.get(normalizedPath) ?? pathToFileURL(filePath).href;
 
@@ -3905,6 +3915,34 @@ export async function handleNotifyChange(
 		},
 	);
 	if (changeSent) recordSentContent(state, normalizedPath, version, content);
+}
+
+/**
+ * #2113: serialize the read/build/send/record transaction per document. The
+ * content-change payload must be built against the content recorded by the
+ * preceding send for this path; unrelated paths retain parallel sends.
+ */
+export function handleNotifyChange(
+	state: LSPClientState,
+	filePath: string,
+	content: string,
+): Promise<void> {
+	if (!isClientAlive(state)) return Promise.resolve();
+	const normalizedPath = normalizeMapKey(filePath);
+	const previous =
+		state.notifyChangeQueues.get(normalizedPath) ?? Promise.resolve();
+	const queued = previous
+		.catch(() => undefined)
+		.then(() =>
+			handleNotifyChangeOnce(state, filePath, content, normalizedPath),
+		);
+	const settled = queued.finally(() => {
+		if (state.notifyChangeQueues.get(normalizedPath) === settled) {
+			state.notifyChangeQueues.delete(normalizedPath);
+		}
+	});
+	state.notifyChangeQueues.set(normalizedPath, settled);
+	return settled;
 }
 
 /** Close a document through the same lifecycle path exposed by the client. */
@@ -5000,6 +5038,7 @@ export async function createLSPClient(options: {
 		diagnosticsVersion: 0,
 		diagnosticsVersionsByPath: new Map(),
 		documentVersions: new Map(),
+		notifyChangeQueues: new Map(),
 		diagnosticDocVersions: new Map(),
 		documentContentHashes: new Map(),
 		incrementalTextRetainedEntries: 0,

--- a/tests/clients/lsp/mock-client-state.ts
+++ b/tests/clients/lsp/mock-client-state.ts
@@ -74,6 +74,7 @@ export function createMockState(
 		diagnosticsVersion: 0,
 		diagnosticsVersionsByPath: new Map(),
 		documentVersions: new Map(),
+		notifyChangeQueues: new Map(),
 		diagnosticDocVersions: new Map(),
 		documentContentHashes: new Map(),
 		incrementalTextRetainedEntries: 0,

--- a/tests/clients/lsp/refresh-and-sync-kind.test.ts
+++ b/tests/clients/lsp/refresh-and-sync-kind.test.ts
@@ -137,6 +137,79 @@ function lastDidChangeParams(state: LSPClientState): {
 }
 
 describe("outgoing didChange honors the negotiated sync kind (#1669)", () => {
+	it("serializes overlapping Incremental changes per path (#2113)", async () => {
+		const state = createMockState({ syncKind: 2 });
+		state.openDocuments.add(TEST_KEY);
+		state.documentVersions.set(TEST_KEY, 0);
+		state.documentContentHashes.set(TEST_KEY, {
+			version: 0,
+			hash: "irrelevant",
+			text: "before",
+		});
+
+		let releaseFirstSend!: () => void;
+		const firstSend = new Promise<void>((resolve) => {
+			releaseFirstSend = resolve;
+		});
+		let didChangeSends = 0;
+		vi.mocked(state.connection.sendNotification).mockImplementation(
+			async (method) => {
+				if (method === "textDocument/didChange" && didChangeSends++ === 0)
+					await firstSend;
+			},
+		);
+
+		const first = handleNotifyChange(state, TEST_FILE, "first");
+		const second = handleNotifyChange(state, TEST_FILE, "second");
+		releaseFirstSend();
+		await Promise.all([first, second]);
+
+		const changes = vi
+			.mocked(state.connection.sendNotification)
+			.mock.calls.filter((call) => call[0] === "textDocument/didChange")
+			.map(
+				(call) =>
+					(
+						call[1] as {
+							contentChanges: Array<{ range?: unknown; text: string }>;
+						}
+					).contentChanges[0],
+			);
+		expect(changes).toHaveLength(2);
+		expect(changes[0]).toEqual({
+			range: {
+				start: { line: 0, character: 0 },
+				end: { line: 0, character: "before".length },
+			},
+			text: "first",
+		});
+		expect(changes[1]).toEqual({
+			range: {
+				start: { line: 0, character: 0 },
+				end: { line: 0, character: "first".length },
+			},
+			text: "second",
+		});
+	});
+
+	it("does not overwrite a newer mirror when a lower version is recorded (#2113)", async () => {
+		const state = createMockState({ syncKind: 2 });
+		state.openDocuments.add(TEST_KEY);
+		state.documentVersions.set(TEST_KEY, 0);
+		state.documentContentHashes.set(TEST_KEY, {
+			version: 2,
+			hash: "newer",
+			text: "newer content",
+		});
+
+		await handleNotifyChange(state, TEST_FILE, "stale content");
+
+		expect(state.documentContentHashes.get(TEST_KEY)).toMatchObject({
+			version: 2,
+			text: "newer content",
+		});
+	});
+
 	it("Full sync kind: unchanged whole-document event", async () => {
 		const state = createMockState({ syncKind: 1 });
 		state.openDocuments.add(TEST_KEY);


### PR DESCRIPTION
## Summary

Fix overlapping Incremental `didChange` sends for one normalized path. Each
path now queues its read/build/send/record transaction, while different paths
remain parallel. A lower-version `recordSentContent` update is rejected and
counted as `lsp-document-send-order` with the server and normalized path.

The touched production seam is `clients/lsp/client.ts`. Its dependents are
the LSP client factory and `notify.change`; the public notification contract
is unchanged. The per-path queue adds one normalized map lookup and promise
tail per change, with no work on unrelated paths beyond their own queue.

## Tests

- Added `tests/clients/lsp/refresh-and-sync-kind.test.ts` coverage that pauses
  the first send, overlaps a second call, and verifies sequential Incremental
  ranges. It also proves a lower-version mirror cannot overwrite newer state.
- The red-first run failed on the pre-fix code because the second payload used
  `end.character: 6` from `"before"`; the serialized expectation is `5` from
  `"first"`.
- Ran `npm run build` successfully.
- Ran `npm run lint` successfully.
- Ran all four files found by `rg` for `handleNotifyChange`,
  `recordSentContent`, or `notify.change`: 202 tests passed in three files;
  the fourth had one unrelated 5-second `willRenameFiles` timeout.
- Reran that exact integration case in isolation: 1 passed, 36 skipped.

## Test assessment

The new regression test uses the real `handleNotifyChange` implementation and
the real in-process content mirror. It mocks only the JSON-RPC send boundary
to create deterministic backpressure.

## Blast radius

The change affects per-client document synchronization through
`handleNotifyChange` and the `notify.change` adapter. `didOpen`, `didClose`,
and `willSave` were swept: `didOpen` sends direct full-text payloads without
`buildContentChanges`, `didClose` has no content mirror, and `willSave` has no
outgoing notification path. None matches the stale Incremental-range shape.

## Class sweep

The `clients/` sweep found the same send sites in `handleNotifyOpen` and
`handleNotifyChange`. `handleNotifyOpen` records direct full-text `didOpen`
payloads and does not build a range from the prior mirror; `closeDocument`
sends `didClose` without recording content; and `willSave` is capability data
only. Verdict: only Incremental `handleNotifyChange` is in scope for this
defect shape, and it is serialized per normalized path.

## Observability

The runtime net is the bounded `lsp-document-send-order` degradation ledger
entry, keyed by server and normalized path, when a lower-version mirror update
is detected. The test proves the prevention path; the ledger proves any
unexpected out-of-order record in production.
