### PR TITLE
test(#2223): fix reverse-deps-cache env-stub leak, sweep miss

### DIFF
--- a/.changelog/test-2223-reverse-deps-env-stub.md
+++ b/.changelog/test-2223-reverse-deps-env-stub.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **`vi.stubEnv` leak sweep undercount (refs #2090, closes #2223)** — `reverse-deps-cache.test.ts` now unstubs `PI_LENS_REVERSE_DEPS_IDLE_EVICT_MS` in its `afterEach`, the second live instance of the #2090 leak class that the original sweep missed. `check-pr-body.test.ts`'s "renames out of tests/" test unstubbed its GitHub env stubs only after its assertion, so a failing assertion would have left them stubbed for later tests; it now unstubs in `afterEach` like every other describe block in the file.

--- a/tests/clients/dispatch/reverse-deps-cache.test.ts
+++ b/tests/clients/dispatch/reverse-deps-cache.test.ts
@@ -53,8 +53,6 @@ describe("reverse-dependency Tier-2 cache bounds (#1389)", () => {
 	});
 
 	it("does not leak PI_LENS_REVERSE_DEPS_IDLE_EVICT_MS to later tests (#2223)", () => {
-		expect(
-			process.env.PI_LENS_REVERSE_DEPS_IDLE_EVICT_MS,
-		).toBeUndefined();
+		expect(process.env.PI_LENS_REVERSE_DEPS_IDLE_EVICT_MS).toBeUndefined();
 	});
 });

--- a/tests/clients/dispatch/reverse-deps-cache.test.ts
+++ b/tests/clients/dispatch/reverse-deps-cache.test.ts
@@ -16,6 +16,11 @@ const index = {
 afterEach(() => {
 	clearReverseDepsIndexCache();
 	vi.useRealTimers();
+	// #2223: the idle-eviction timer test below stubs
+	// PI_LENS_REVERSE_DEPS_IDLE_EVICT_MS via vi.stubEnv. Without the
+	// unstub, the last stub value ("100000") survives into every later
+	// test in this file (refs #2090).
+	vi.unstubAllEnvs();
 });
 
 describe("reverse-dependency Tier-2 cache bounds (#1389)", () => {
@@ -45,5 +50,11 @@ describe("reverse-dependency Tier-2 cache bounds (#1389)", () => {
 			_seedReverseDepsIndexCacheForTests("root-a", index, 1);
 		expect(vi.getTimerCount() - before).toBe(1);
 		vi.useRealTimers();
+	});
+
+	it("does not leak PI_LENS_REVERSE_DEPS_IDLE_EVICT_MS to later tests (#2223)", () => {
+		expect(
+			process.env.PI_LENS_REVERSE_DEPS_IDLE_EVICT_MS,
+		).toBeUndefined();
 	});
 });

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -665,6 +665,11 @@ describe("nested headings are structure, not content (#2124 F1)", () => {
 });
 
 describe("renames out of tests/ still require the assessment (#2124 F3)", () => {
+	// #2223: the unstub used to run only after the assertion below, so a
+	// failing assertion left GITHUB_TOKEN/GITHUB_API_URL/GITHUB_REPOSITORY
+	// stubbed for every later test in this file.
+	afterEach(() => vi.unstubAllEnvs());
+
 	it("counts previous_filename", async () => {
 		vi.stubEnv("GITHUB_TOKEN", "t");
 		vi.stubEnv("GITHUB_API_URL", "https://api.example");
@@ -681,7 +686,6 @@ describe("renames out of tests/ still require the assessment (#2124 F3)", () => 
 			),
 		);
 		expect(await resolveTouchesTests({ number: 7 }, fetchImpl)).toBe(true);
-		vi.unstubAllEnvs();
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes #2223. `reverse-deps-cache.test.ts` stubbed `PI_LENS_REVERSE_DEPS_IDLE_EVICT_MS`
via `vi.stubEnv` and never unstubbed it. It is harmless today because it is
the terminal test in the file, but it is a live instance of the leak class
#2090 fixed, and #2216's sweep for that class missed it.

## Fix

Add `vi.unstubAllEnvs()` to the file's `afterEach`, matching the pattern
`project-snapshot.test.ts` uses for the same class. Add a regression test
asserting the env var reads back unset.

## Class sweep

Re-ran the sweep across all 14 files in the repo that call `vi.stubEnv`,
checking each for a guaranteed `vi.unstubAllEnvs()` in `afterEach`/`afterAll`
or an inline `try/finally`. Per-file verdicts:

- `tests/clients/dispatch/reverse-deps-cache.test.ts` — fixed (this PR).
- `tests/scripts/check-pr-body.test.ts` — fixed (this PR). The "renames out
  of tests/" describe called `vi.unstubAllEnvs()` only after its assertion,
  so a failing assertion would skip cleanup and leak `GITHUB_TOKEN`,
  `GITHUB_API_URL`, and `GITHUB_REPOSITORY` into later tests. Moved to
  `afterEach`, matching the file's other describes.
- `tests/scripts/check-pr-title.test.ts` — already correct: module-level
  `afterEach` at line 15.
- `tests/index-lsp-idle-reset.test.ts` — already correct: `afterEach` at
  line 74.
- `tests/config/worker-budget.test.ts` — already correct: `try/finally` at
  line 261.
- `tests/clients/workspace-topology-eviction.test.ts` — already correct:
  module-level `afterEach` at line 17.
- `tests/clients/session-lifecycle-multi-root.test.ts` — already correct:
  describe-level `afterEach` at line 191 covers its stub site.
- `tests/clients/review-graph-superseded-persist.test.ts` — already
  correct: module-level `afterEach` at line 29.
- `tests/clients/project-snapshot.test.ts` — already correct (the #2090
  fix).
- `tests/clients/instance-registry.test.ts` — already correct:
  describe-level `afterEach` at line 33 covers the whole file (single
  top-level describe).
- `tests/clients/installer/managed-tool-refresh.test.ts` — already correct:
  module-level `afterEach` at line 294.
- `tests/clients/graph-cache.test.ts` — already correct: describe-level
  `afterEach` at line 39.
- `tests/clients/dispatch/runners/terraform-kotlin-runners.test.ts` —
  already correct in effect: resets via `beforeEach` instead of `afterEach`.
  This repo runs each test file in its own forked process
  (`isolate: true`), so a stub can only leak to later tests within the same
  file, and `beforeEach` clears it before each test runs, same net effect.
- `tests/clients/dispatch/runners/runner-helpers.test.ts` — already
  correct: `try/finally` at line 312.

No further misses found by this grep. This sweep is shaped around the
`vi.stubEnv` spelling, so it cannot see the same call arrive through an
indirection. `tests/support/fault-injection.ts:191` wraps `vi.stubEnv` in a
`starveBudget()` helper; checked its three call sites separately, since a
grep for `vi.stubEnv` misses them:
`tests/clients/pipeline-lsp-sync.test.ts:39` restores via an explicit
`delete process.env.PI_LENS_LSP_SYNC_BUDGET_MS` in `afterEach`, and
`tests/clients/lsp/service-runtime-exit-breaker.test.ts:327` restores via an
inline `try/finally` that saves and reinstates the original value. All three
are safe; no defect there. Deliberately did not widen the sweep to
`process.env.X = ...` direct assignment (a different, pre-existing pattern
already handled by manual try/finally save/restore, as seen in this same
file's first test) — that is a separate defect shape, not this one.

## Test assessment

- `tests/clients/dispatch/reverse-deps-cache.test.ts` — the new
  "does not leak PI_LENS_REVERSE_DEPS_IDLE_EVICT_MS to later tests" test
  uniquely pins the `afterEach` unstub; nothing else in the file checks
  this. No test becomes redundant.
- `tests/scripts/check-pr-body.test.ts` — no new test added here (the
  fragile inline unstub was moved into `afterEach`; a `GITHUB_TOKEN`-leak
  regression test was rejected because `GITHUB_REPOSITORY`/`GITHUB_API_URL`
  are ambient GitHub Actions env vars in CI, so asserting `toBeUndefined()`
  after restore would be flaky). No test becomes redundant.

## Tests

- Targeted: `npx vitest run tests/clients/dispatch/reverse-deps-cache.test.ts
  tests/scripts/check-pr-body.test.ts` — 77 passed.
- Governance sweeps: `bounded-telemetry-sweep`, `bus-producer-coverage`,
  `delivery-surface-ratchet`, `deps-centralization`, `finding-delivery-gate`,
  `freshness-sweep`, `managed-tool-seam-coverage`, `profiling-coverage`,
  `session-state-conformance`, `module-instance-coverage`,
  `sweep-floor-coverage` — 162 passed.
- Full suite deferred to CI.

Red-first proof (both fixes), quoted from this session's own runs:

`reverse-deps-cache.test.ts`, `afterEach`'s unstub line removed, regression
test kept:

```
FAIL  |default| tests/clients/dispatch/reverse-deps-cache.test.ts > reverse-dependency Tier-2 cache bounds (#1389) > does not leak PI_LENS_REVERSE_DEPS_IDLE_EVICT_MS to later tests (#2223)
AssertionError: expected '100000' to be undefined
```

`check-pr-body.test.ts`, forced the "counts previous_filename" assertion to
fail (pre-fix inline-unstub-after-assert code), added a probe test right
after:

```
FAIL  |default| tests/scripts/check-pr-body.test.ts > renames out of tests/ still require the assessment (#2124 F3) > counts previous_filename
AssertionError: expected true to be false

FAIL  |default| tests/scripts/check-pr-body.test.ts > PROBE: leak check after forced failure > sees leaked GITHUB_TOKEN if unstub never ran
AssertionError: expected 't' to be undefined
```

Both probes and forced failures were reverted before committing; the
committed diff carries only the real fix and its permanent regression test.

## Blast radius

Test-only change, two files. No production code touched. No new process
spawns, no behavior widening.

## Observability

N/A — test-hygiene fix. The permanent regression test in
`reverse-deps-cache.test.ts` is the record that proves the leak stays fixed.

