### PR TITLE
fix(read-guard): telemetry for other eviction paths (closes #1918)

### DIFF
--- a/.changelog/fix-1918-read-guard-eviction-telemetry.md
+++ b/.changelog/fix-1918-read-guard-eviction-telemetry.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Read-guard eviction paths now leave a trace (#1918)** — Whole-file eviction (file cap, idle timeout, external-delete cleanup) and the per-file edits-cap trim each emit a bounded, always-on `read-guard.log` record naming the file and which path evicted it, closing the gap #1915 left after fixing the record-cap path.

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -381,6 +381,24 @@ export type DegradationKind =
 	 */
 	| "read-guard-record-cap-trim"
 	/**
+	 * `read-guard.ts`'s whole-file evictor (`evictFile`) dropped a file's
+	 * tracked read/edit state (#1918, the #1913 class sibling). Fires from
+	 * three call sites — the consumed-file cap, the unconsumed-file cap, and
+	 * the idle-eviction timer — the `reason` text in the matching
+	 * `read_file_evicted` read-guard.log line says which. Rising edge gates
+	 * that log line per file per session, same as `read-guard-record-cap-trim`.
+	 */
+	| "read-guard-file-evicted"
+	/**
+	 * `read-guard.ts`'s per-file edits-cap splice (`READ_GUARD_MAX_EDITS_PER_FILE`)
+	 * trimmed a file's edit history (#1918). The in-repo doc comment on that
+	 * cap argues the trim is inert in practice, but this kind gives it a
+	 * record instead of resting only on that argument. Rising edge gates the
+	 * matching `edits_cap_trimmed` read-guard.log line, same shape as
+	 * `read-guard-record-cap-trim`.
+	 */
+	| "read-guard-edits-cap-trim"
+	/**
 	 * A demoted finding was RETIRED from a delivery store instead of being
 	 * re-served (#1944). Raised when the cited file shrank past the
 	 * coordinates the finding is pinned to, so no re-run can ever confirm it.

--- a/clients/read-guard-logger.ts
+++ b/clients/read-guard-logger.ts
@@ -246,9 +246,14 @@ export function shouldLogEvent(event: string): boolean {
 		// regression must be visible without PI_LENS_READ_GUARD_VERBOSE=1.
 		event === "read_cap_trimmed" ||
 		// #1918: the record-cap trim's population siblings — whole-file
-		// eviction (file cap or idle timer) and the per-file edits-cap trim.
-		// Same rarity argument as #1913: each fires once per file per
-		// session (rising-edge gated), so always-on visibility costs nothing.
+		// eviction under real pressure (file cap or an external delete) and
+		// the per-file edits-cap trim. Idle-timeout eviction is deliberately
+		// EXCLUDED from this event (see read-guard.ts's evictFile doc
+		// comment) — it's routine housekeeping, not a fault, and its
+		// per-file cardinality is unbounded in a healthy session. Same
+		// rarity argument as #1913 for the reasons that DO fire: each is
+		// rising-edge gated once per file per session, so always-on
+		// visibility costs nothing.
 		event === "read_file_evicted" ||
 		event === "edits_cap_trimmed"
 	);

--- a/clients/read-guard-logger.ts
+++ b/clients/read-guard-logger.ts
@@ -244,7 +244,13 @@ export function shouldLogEvent(event: string): boolean {
 		// READ_GUARD_MAX_RECORDS_PER_FILE overflow triggers one), so this trim
 		// record bypasses the per-read verbosity gate — a live eviction
 		// regression must be visible without PI_LENS_READ_GUARD_VERBOSE=1.
-		event === "read_cap_trimmed"
+		event === "read_cap_trimmed" ||
+		// #1918: the record-cap trim's population siblings — whole-file
+		// eviction (file cap or idle timer) and the per-file edits-cap trim.
+		// Same rarity argument as #1913: each fires once per file per
+		// session (rising-edge gated), so always-on visibility costs nothing.
+		event === "read_file_evicted" ||
+		event === "edits_cap_trimmed"
 	);
 }
 

--- a/clients/read-guard.ts
+++ b/clients/read-guard.ts
@@ -256,9 +256,11 @@ const NO_TRIM: RecordCapTrimResult = {
 };
 
 /**
- * Which of `evictFile`'s three call sites (#1918) dropped a file's tracked
+ * Which of `evictFile`'s four call sites (#1918) dropped a file's tracked
  * state. Carried in the `read_file_evicted` metadata so a live regression
  * names not just which file was evicted but which cap/timer fired.
+ * `idle-timeout` never reaches that metadata (#1918 review F2) — designed
+ * housekeeping stays silent by construction; see `evictFile`'s doc comment.
  */
 type FileEvictionReason =
 	| "file-cap-consumed"
@@ -607,15 +609,25 @@ export class ReadGuard {
 	 * evictor has four call sites — `enforceFileCap`'s consumed-file cap, its
 	 * unconsumed-file cap, `touchFile`'s idle timer, and `forgetPath`'s
 	 * external-delete cleanup — and none of them left any trace. A live
-	 * regression in any of the four (e.g. an idle timer
-	 * firing early, or a cap set too low) dropped a file's read/edit history
-	 * with nothing in `~/.pi-lens/read-guard.log` to show it happened.
+	 * regression in any of the four (e.g. a cap set too low) dropped a file's
+	 * read/edit history with nothing in `~/.pi-lens/read-guard.log` to show it
+	 * happened.
 	 *
-	 * Follows #1913's aggregate-after-first pattern: `incrementDegradationCount`
+	 * Follows #1913's aggregate-after-first pattern for the three PRESSURE
+	 * reasons (cap exhaustion, external delete): `incrementDegradationCount`
 	 * keeps the exact per-file eviction tally (and its own power-of-two
 	 * milestone rows in latency.log) while the read-guard.log line fires only
 	 * on the rising edge, so a file evicted repeatedly across a session can't
 	 * flood the log.
+	 *
+	 * `idle-timeout` is deliberately excluded from both the ledger tally and
+	 * the log line (#1918 review F2): idle eviction is designed housekeeping,
+	 * not a fault signal — a read-only session that idles out N files is
+	 * healthy, ordinary behavior, and N is unbounded (every distinct file path
+	 * touched that session is its own ledger subject). Recording it here would
+	 * grow the ledger's tally map without bound and spam `pilens_health` in
+	 * every healthy session, unlike the other three reasons, which are rare by
+	 * construction (only real pressure or an explicit delete reaches them).
 	 */
 	private evictFile(filePath: string, reason: FileEvictionReason): void {
 		this.clearFileTimer(filePath);
@@ -629,6 +641,7 @@ export class ReadGuard {
 		for (const [syntacticKey, stored] of this.knownPathIndex) {
 			if (stored === filePath) this.knownPathIndex.delete(syntacticKey);
 		}
+		if (reason === "idle-timeout") return;
 		const isRisingEdge = incrementDegradationCount({
 			kind: "read-guard-file-evicted",
 			subject: filePath,
@@ -659,6 +672,11 @@ export class ReadGuard {
 			// eviction. Only consumed reads and rebuildable edit history may expire.
 			if (this.reads.has(filePath) && !this.consumedReadFiles.has(filePath))
 				return;
+			// #1918 review F2: this reason is intentionally silent inside
+			// evictFile — idle eviction is routine housekeeping, not a fault, and
+			// every distinct file idling out this session is its own ledger
+			// subject, so recording it would grow unbounded and flood
+			// pilens_health on every healthy session. See evictFile's doc comment.
 			this.evictFile(filePath, "idle-timeout");
 		}, this.idleEvictMs());
 		timer.unref?.();

--- a/clients/read-guard.ts
+++ b/clients/read-guard.ts
@@ -255,6 +255,17 @@ const NO_TRIM: RecordCapTrimResult = {
 	evictedGenuineCount: 0,
 };
 
+/**
+ * Which of `evictFile`'s three call sites (#1918) dropped a file's tracked
+ * state. Carried in the `read_file_evicted` metadata so a live regression
+ * names not just which file was evicted but which cap/timer fired.
+ */
+type FileEvictionReason =
+	| "file-cap-consumed"
+	| "file-cap-unconsumed"
+	| "idle-timeout"
+	| "external-delete";
+
 function enforceRecordCapForFile(records: ReadRecord[]): RecordCapTrimResult {
 	if (records.length <= READ_GUARD_MAX_RECORDS_PER_FILE) return NO_TRIM;
 	const excess = records.length - READ_GUARD_MAX_RECORDS_PER_FILE;
@@ -590,7 +601,23 @@ export class ReadGuard {
 		this.fileIdleTimers.delete(filePath);
 	}
 
-	private evictFile(filePath: string): void {
+	/**
+	 * #1918: `enforceRecordCapForFile` (the per-file record cap) is the only
+	 * `read-guard.ts` eviction path #1913 gave a bounded record. This whole-file
+	 * evictor has four call sites — `enforceFileCap`'s consumed-file cap, its
+	 * unconsumed-file cap, `touchFile`'s idle timer, and `forgetPath`'s
+	 * external-delete cleanup — and none of them left any trace. A live
+	 * regression in any of the four (e.g. an idle timer
+	 * firing early, or a cap set too low) dropped a file's read/edit history
+	 * with nothing in `~/.pi-lens/read-guard.log` to show it happened.
+	 *
+	 * Follows #1913's aggregate-after-first pattern: `incrementDegradationCount`
+	 * keeps the exact per-file eviction tally (and its own power-of-two
+	 * milestone rows in latency.log) while the read-guard.log line fires only
+	 * on the rising edge, so a file evicted repeatedly across a session can't
+	 * flood the log.
+	 */
+	private evictFile(filePath: string, reason: FileEvictionReason): void {
 		this.clearFileTimer(filePath);
 		this.reads.delete(filePath);
 		this.edits.delete(filePath);
@@ -601,6 +628,19 @@ export class ReadGuard {
 		// too, so it never outlives the record it points at.
 		for (const [syntacticKey, stored] of this.knownPathIndex) {
 			if (stored === filePath) this.knownPathIndex.delete(syntacticKey);
+		}
+		const isRisingEdge = incrementDegradationCount({
+			kind: "read-guard-file-evicted",
+			subject: filePath,
+			reason: `evicted (${reason})`,
+		});
+		if (isRisingEdge) {
+			logReadGuardEvent({
+				event: "read_file_evicted",
+				sessionId: this.sessionId,
+				filePath,
+				metadata: { reason },
+			});
 		}
 	}
 
@@ -619,7 +659,7 @@ export class ReadGuard {
 			// eviction. Only consumed reads and rebuildable edit history may expire.
 			if (this.reads.has(filePath) && !this.consumedReadFiles.has(filePath))
 				return;
-			this.evictFile(filePath);
+			this.evictFile(filePath, "idle-timeout");
 		}, this.idleEvictMs());
 		timer.unref?.();
 		this.fileIdleTimers.set(filePath, timer);
@@ -634,7 +674,7 @@ export class ReadGuard {
 						(this.fileLastUsed.get(a) ?? 0) - (this.fileLastUsed.get(b) ?? 0),
 				)[0];
 			if (!victim) break;
-			this.evictFile(victim);
+			this.evictFile(victim, "file-cap-consumed");
 		}
 		while (this.reads.size > READ_GUARD_MAX_UNCONSUMED_FILES) {
 			const victim = [...this.reads.keys()]
@@ -646,7 +686,7 @@ export class ReadGuard {
 			if (!victim) break;
 			// This is a normal read miss: a later edit must require a fresh read,
 			// never silently allow and never become a permanent hard-block.
-			this.evictFile(victim);
+			this.evictFile(victim, "file-cap-unconsumed");
 		}
 	}
 
@@ -1151,7 +1191,7 @@ export class ReadGuard {
 	 */
 	forgetPath(filePath: string): void {
 		const stored = this.knownPathIndex.get(normalizeEphemeralMapKey(filePath));
-		this.evictFile(stored ?? this.key(filePath));
+		this.evictFile(stored ?? this.key(filePath), "external-delete");
 	}
 
 	/**
@@ -1851,7 +1891,28 @@ export class ReadGuard {
 			timestamp: Date.now(),
 		});
 		if (arr.length > READ_GUARD_MAX_EDITS_PER_FILE) {
-			arr.splice(0, arr.length - READ_GUARD_MAX_EDITS_PER_FILE);
+			const trimmedCount = arr.length - READ_GUARD_MAX_EDITS_PER_FILE;
+			arr.splice(0, trimmedCount);
+			// #1918: the #282-289 doc comment argues this trim is inert in
+			// practice (every consumer reads only the last record or a
+			// bounded relocation window), but an argument is not a record —
+			// if that assumption ever breaks, this is the only signal. Same
+			// aggregate-after-first shape as `read_cap_trimmed` (#1913):
+			// `incrementDegradationCount` keeps the exact per-file tally,
+			// the read-guard.log line fires once on the rising edge.
+			const isRisingEdge = incrementDegradationCount({
+				kind: "read-guard-edits-cap-trim",
+				subject: filePath,
+				reason: `trimmed ${trimmedCount} edit record(s) past cap`,
+			});
+			if (isRisingEdge) {
+				logReadGuardEvent({
+					event: "edits_cap_trimmed",
+					sessionId: this.sessionId,
+					filePath,
+					metadata: { trimmedCount, cappedLength: arr.length },
+				});
+			}
 		}
 		this.edits.set(filePath, arr);
 	}

--- a/tests/clients/read-guard-logger.test.ts
+++ b/tests/clients/read-guard-logger.test.ts
@@ -11,6 +11,17 @@ describe("shouldLogEvent", () => {
 		expect(shouldLogEvent("read_cap_trimmed")).toBe(true);
 	});
 
+	// #1918: read_cap_trimmed's population siblings. read-guard.test.ts mocks
+	// read-guard-logger.js wholesale, so it can't see this gate at all — this
+	// file is the only place a dropped always-on arm reds.
+	it("always logs read_file_evicted, even at default verbosity", () => {
+		expect(shouldLogEvent("read_file_evicted")).toBe(true);
+	});
+
+	it("always logs edits_cap_trimmed, even at default verbosity", () => {
+		expect(shouldLogEvent("edits_cap_trimmed")).toBe(true);
+	});
+
 	it("keeps read_recorded gated behind verbose mode", () => {
 		expect(shouldLogEvent("read_recorded")).toBe(false);
 	});

--- a/tests/clients/read-guard.test.ts
+++ b/tests/clients/read-guard.test.ts
@@ -1555,6 +1555,138 @@ describe("ReadGuard Tier-2 idle decay and bounds (#1389)", () => {
 	});
 });
 
+// #1918: the record-cap trim's population siblings. `evictFile` (whole-file
+// eviction, three internal call sites plus `forgetPath`) and the per-file
+// edits-cap splice evicted state with zero telemetry before this fix.
+describe("ReadGuard eviction-path telemetry (#1918)", () => {
+	function evictionEvents(event: string) {
+		return vi
+			.mocked(logReadGuardEvent)
+			.mock.calls.filter(([entry]) => entry.event === event);
+	}
+
+	it("emits read_file_evicted with reason idle-timeout when a consumed read idles out", () => {
+		vi.useFakeTimers();
+		try {
+			const guard = createReadGuard("1918-idle-evict-session");
+			const filePath = "/tmp/1918-idle-evict.ts";
+			guard.recordRead(createReadRecord(filePath));
+			guard.recordWritten(filePath); // marks consumed; arms the idle timer
+			vi.mocked(logReadGuardEvent).mockClear();
+
+			vi.advanceTimersByTime(31 * 60_000);
+
+			const evictions = evictionEvents("read_file_evicted");
+			expect(evictions).toHaveLength(1);
+			expect(evictions[0][0]).toMatchObject({
+				event: "read_file_evicted",
+				filePath: normalizeFilePath(filePath),
+				metadata: { reason: "idle-timeout" },
+			});
+			expect(guard.getReadHistory(filePath)).toHaveLength(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("emits read_file_evicted with reason file-cap-consumed at the consumed-file cap", () => {
+		const guard = createReadGuard("1918-file-cap-consumed-session");
+		const victimPath = "/tmp/1918-file-cap-consumed-victim.ts";
+		guard.recordRead(createReadRecord(victimPath));
+		guard.recordWritten(victimPath);
+		vi.mocked(logReadGuardEvent).mockClear();
+
+		for (let i = 0; i < 256; i += 1) {
+			const filePath = `/tmp/1918-file-cap-consumed-${i}.ts`;
+			guard.recordRead(createReadRecord(filePath));
+			guard.recordWritten(filePath);
+		}
+
+		const evictions = evictionEvents("read_file_evicted");
+		expect(evictions).toHaveLength(1);
+		expect(evictions[0][0]).toMatchObject({
+			event: "read_file_evicted",
+			filePath: normalizeFilePath(victimPath),
+			metadata: { reason: "file-cap-consumed" },
+		});
+		expect(guard.getReadHistory(victimPath)).toHaveLength(0);
+	});
+
+	it("emits read_file_evicted with reason file-cap-unconsumed at the unconsumed-file cap", () => {
+		const guard = createReadGuard("1918-file-cap-unconsumed-session");
+		const victimPath = "/tmp/1918-file-cap-unconsumed-victim.ts";
+		guard.recordRead(createReadRecord(victimPath));
+		vi.mocked(logReadGuardEvent).mockClear();
+
+		for (let i = 0; i < 4096; i += 1) {
+			guard.recordRead(
+				createReadRecord(`/tmp/1918-file-cap-unconsumed-${i}.ts`),
+			);
+		}
+
+		const evictions = evictionEvents("read_file_evicted");
+		expect(evictions).toHaveLength(1);
+		expect(evictions[0][0]).toMatchObject({
+			event: "read_file_evicted",
+			filePath: normalizeFilePath(victimPath),
+			metadata: { reason: "file-cap-unconsumed" },
+		});
+		expect(guard.getReadHistory(victimPath)).toHaveLength(0);
+	});
+
+	it("emits read_file_evicted with reason external-delete via forgetPath", () => {
+		const guard = createReadGuard("1918-forget-path-session");
+		const filePath = "/tmp/1918-forget-path.ts";
+		guard.recordRead(createReadRecord(filePath));
+		vi.mocked(logReadGuardEvent).mockClear();
+
+		guard.forgetPath(filePath);
+
+		const evictions = evictionEvents("read_file_evicted");
+		expect(evictions).toHaveLength(1);
+		expect(evictions[0][0]).toMatchObject({
+			event: "read_file_evicted",
+			filePath: normalizeFilePath(filePath),
+			metadata: { reason: "external-delete" },
+		});
+	});
+
+	it("emits exactly one edits_cap_trimmed record when the per-file edit history overflows", () => {
+		const guard = createReadGuard("1918-edits-cap-session");
+		const filePath = "/tmp/1918-edits-cap.ts";
+		guard.recordRead(
+			createReadRecord(filePath, { requestedLimit: 500, effectiveLimit: 500 }),
+		);
+		vi.mocked(logReadGuardEvent).mockClear();
+
+		for (let i = 0; i < 257; i += 1) {
+			guard.checkEdit(filePath, [1, 1]);
+		}
+
+		const trims = evictionEvents("edits_cap_trimmed");
+		expect(trims).toHaveLength(1);
+		expect(trims[0][0]).toMatchObject({
+			event: "edits_cap_trimmed",
+			filePath: normalizeFilePath(filePath),
+			metadata: { trimmedCount: 1, cappedLength: 256 },
+		});
+		expect(guard.getEditHistory(filePath)).toHaveLength(256);
+	});
+
+	it("emits no edits_cap_trimmed record while the edit history stays within the cap", () => {
+		const guard = createReadGuard("1918-edits-cap-no-trim-session");
+		const filePath = "/tmp/1918-edits-cap-no-trim.ts";
+		guard.recordRead(createReadRecord(filePath));
+		vi.mocked(logReadGuardEvent).mockClear();
+
+		for (let i = 0; i < 10; i += 1) {
+			guard.checkEdit(filePath, [1, 1]);
+		}
+
+		expect(evictionEvents("edits_cap_trimmed")).toHaveLength(0);
+	});
+});
+
 // #1041: export/import of the read-set across a session resume.
 describe("ReadGuard export/import across resume (#1041)", () => {
 	// Write, then backdate mtime to BEFORE any guard's session start so the file

--- a/tests/clients/read-guard.test.ts
+++ b/tests/clients/read-guard.test.ts
@@ -7,6 +7,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resetDegradationLedger } from "../../clients/degradation-ledger.js";
 import { normalizeFilePath } from "../../clients/path-utils.js";
 import {
 	createReadGuard,
@@ -1565,7 +1566,12 @@ describe("ReadGuard eviction-path telemetry (#1918)", () => {
 			.mock.calls.filter(([entry]) => entry.event === event);
 	}
 
-	it("emits read_file_evicted with reason idle-timeout when a consumed read idles out", () => {
+	// #1918 review F2: idle-timeout is routine housekeeping, not a fault — a
+	// read-only session idling out N files is healthy behavior, and N is
+	// unbounded, so it takes an in-code justification (evictFile's doc
+	// comment) instead of an always-on record. The eviction itself still
+	// happens; only the telemetry is intentionally silent.
+	it("evicts on idle timeout without any read_file_evicted record", () => {
 		vi.useFakeTimers();
 		try {
 			const guard = createReadGuard("1918-idle-evict-session");
@@ -1576,14 +1582,8 @@ describe("ReadGuard eviction-path telemetry (#1918)", () => {
 
 			vi.advanceTimersByTime(31 * 60_000);
 
-			const evictions = evictionEvents("read_file_evicted");
-			expect(evictions).toHaveLength(1);
-			expect(evictions[0][0]).toMatchObject({
-				event: "read_file_evicted",
-				filePath: normalizeFilePath(filePath),
-				metadata: { reason: "idle-timeout" },
-			});
 			expect(guard.getReadHistory(filePath)).toHaveLength(0);
+			expect(evictionEvents("read_file_evicted")).toHaveLength(0);
 		} finally {
 			vi.useRealTimers();
 		}
@@ -1684,6 +1684,53 @@ describe("ReadGuard eviction-path telemetry (#1918)", () => {
 		}
 
 		expect(evictionEvents("edits_cap_trimmed")).toHaveLength(0);
+	});
+
+	// #1918 review F3: pin the (kind, subject) key the rising edge is keyed
+	// on — two DISTINCT files evicted via forgetPath must each get their own
+	// line, not share one rising edge because they hit the same `kind`.
+	it("emits one read_file_evicted line per distinct file, not one per session", () => {
+		const guard = createReadGuard("1918-distinct-files-session");
+		const firstPath = "/tmp/1918-distinct-first.ts";
+		const secondPath = "/tmp/1918-distinct-second.ts";
+		guard.recordRead(createReadRecord(firstPath));
+		guard.recordRead(createReadRecord(secondPath));
+		vi.mocked(logReadGuardEvent).mockClear();
+
+		guard.forgetPath(firstPath);
+		guard.forgetPath(secondPath);
+
+		const evictions = evictionEvents("read_file_evicted");
+		expect(evictions).toHaveLength(2);
+		expect(evictions.map(([entry]) => entry.filePath).sort()).toEqual(
+			[normalizeFilePath(firstPath), normalizeFilePath(secondPath)].sort(),
+		);
+	});
+
+	// #1918 review F3: pin session re-arm — the SAME file evicted twice within
+	// one session logs once (rising edge), but a fresh session (which is what
+	// resetDegradationLedger models: the ledger's own generation bump, wired
+	// into session start) re-arms the edge so the next eviction of that same
+	// path logs again.
+	it("re-emits for the same file after resetDegradationLedger (fresh session)", () => {
+		const guard = createReadGuard("1918-rearm-session");
+		const filePath = "/tmp/1918-rearm.ts";
+		guard.recordRead(createReadRecord(filePath));
+		vi.mocked(logReadGuardEvent).mockClear();
+
+		guard.forgetPath(filePath);
+		expect(evictionEvents("read_file_evicted")).toHaveLength(1);
+
+		// Second eviction of the SAME path in the SAME session: rising edge
+		// already tripped, so no second line.
+		guard.recordRead(createReadRecord(filePath));
+		guard.forgetPath(filePath);
+		expect(evictionEvents("read_file_evicted")).toHaveLength(1);
+
+		resetDegradationLedger();
+		guard.recordRead(createReadRecord(filePath));
+		guard.forgetPath(filePath);
+		expect(evictionEvents("read_file_evicted")).toHaveLength(2);
 	});
 });
 


### PR DESCRIPTION
## Summary

`read-guard.log` only ever recorded the per-file record-cap trim (#1913,
`read_cap_trimmed`). #1915's own review named the family and re-homed the
rest to this issue: `evictFile`'s whole-file eviction and the per-file
edits-cap splice had no telemetry at any verbosity. A live regression on any
of them left no trace.

- `evictFile` now takes a `reason` (`"file-cap-consumed"`,
  `"file-cap-unconsumed"`, `"idle-timeout"`, `"external-delete"`).
- Three of the four reasons — the two file caps and external delete — emit an
  always-on `read_file_evicted` line (file path plus reason) the first time
  each fires for a given file in a session.
- `idle-timeout` stays silent by design (review round F2, see Class sweep):
  idle eviction is routine housekeeping in every healthy session, not a
  fault, so it takes the in-code-justification branch #1918's acceptance
  criteria allow instead of a record.
- `recordEdit`'s edits-cap splice gets the same shape: `edits_cap_trimmed`,
  first-trim-only.
- All emissions use `incrementDegradationCount`'s rising-edge return, exactly
  like `read_cap_trimmed` — the ledger keeps the exact per-file tally and its
  own power-of-two milestone rows, `read-guard.log` stays quiet after the
  first line so a hot file can't flood it.
- `read_file_evicted` and `edits_cap_trimmed` are added to
  `shouldLogEvent`'s always-on list, bypassing `PI_LENS_READ_GUARD_VERBOSE`.
- Two new `DegradationKind` entries (`read-guard-file-evicted`,
  `read-guard-edits-cap-trim`) document the vocabulary next to
  `read-guard-record-cap-trim`.

#1913 fixed the record-cap path's silence but its review flagged the rest of
the family as a real gap and re-homed it here. The edits-cap trim's own
in-repo comment argues the trim is inert in practice — that argument is not a
record, so this closes the gap regardless of whether the argument holds.

Merge order: no open PR touches `clients/read-guard.ts` (checked `gh pr list`
+ `gh pr diff --name-only` against all open PRs, both before this round and
after merging master). PR #2229 touches `clients/read-guard-logger.ts` but
only normalizes `filePath` at the `logReadGuardEvent` emit seam — it does not
touch `shouldLogEvent` or any line this PR changes.

Closes #1918.

## Type of change

- [x] Bug fix

## Area

- [x] area:read-guard
- [x] area:observability

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted below
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [ ] `npm run lint` — not run locally this round; CI's Lint & type-check job is authoritative
- [x] `npm run build:dist` not required — no `dist`-affecting change
- [x] `package-lock.json` unchanged
- [x] AGENTS.md unchanged — no new convention or invariant introduced
- [x] `.changelog/fix-1918-read-guard-eviction-telemetry.md` added
- [x] Commit subjects reference #1918

## Tests

- `tests/clients/read-guard.test.ts`, new describe block "ReadGuard
  eviction-path telemetry (#1918)" — 9 cases pinning: `read_file_evicted` for
  each of `file-cap-consumed`, `file-cap-unconsumed`, `external-delete`;
  idle-timeout eviction happens but emits nothing; `edits_cap_trimmed` fires
  once on overflow and never under the cap; two distinct files each get their
  own line (subject discrimination); the same file evicted twice in one
  session logs once, then `resetDegradationLedger()` re-arms it (session
  discrimination).
- `tests/clients/read-guard-logger.test.ts` — 2 new cases: `read_file_evicted`
  and `edits_cap_trimmed` are always-on in `shouldLogEvent`. Added in this
  review round after F1 found the original PR body's coverage claim about
  this file was false (see below).

Red-first, quoted from this round's runs:

```
✕ evicts on idle timeout without any read_file_evicted record
AssertionError: expected [ [ { …(4) } ] ] to have a length of +0 but got 1
```
(pre-F2-fix `read-guard.ts` restored via `git checkout HEAD~1 -- clients/read-guard.ts`, idle-timeout still emitted)

```
✕ emits one read_file_evicted line per distinct file, not one per session
AssertionError: expected [ [ { …(4) } ] ] to have a length of 2 but got 1
```
(mutation: `subject: filePath` → constant string in `evictFile`)

```
✕ re-emits for the same file after resetDegradationLedger (fresh session)
AssertionError: expected [ [ { …(4) } ] ] to have a length of 2 but got 1
```
(mutation: `resetDegradationLedger()` call removed from the test)

From the original PR (unchanged this round, still valid): the 5 emission
tests all failed with `expected [] to have a length of 1 but got +0` against
`clients/read-guard.ts`/`read-guard-logger.ts`/`degradation-ledger.ts`
reverted to pre-fix.

### Test assessment

- `tests/clients/read-guard.test.ts` — uniquely pins that `evictFile`'s four
  reasons and `recordEdit`'s edits-cap splice each produce the correct
  `read_file_evicted`/`edits_cap_trimmed` shape, that idle-timeout is silent,
  and that the rising edge discriminates on both file identity and session
  boundary. No removal candidates — this is new coverage of a previously
  untested surface.
- `tests/clients/read-guard-logger.test.ts` — uniquely pins `shouldLogEvent`'s
  real always-on gate, which `read-guard.test.ts` cannot see because it mocks
  the logger module wholesale. F1 (below) found this file was the only one
  that could catch a dropped always-on arm, and the original PR body claimed
  coverage here that did not exist. No removal candidates.

## Blast radius

- `evictFile`'s signature gained a required `reason` parameter — every call
  site was updated (5 total, see Class sweep). No external callers exist; it
  is a private method.
- `DegradationKind` gained two new string-literal members — additive, no
  existing kind changed.
- Both new events are read-path/telemetry-path only: no behavior change to
  what edits are allowed or blocked, no new process spawns.
- Log volume: the three pressure/delete reasons are rising-edge gated per
  file per session, same bound as `read_cap_trimmed` — negligible added log
  volume even under heavy file churn. `idle-timeout` was deliberately kept
  OUT of that budget (see Class sweep) rather than included and then
  rate-limited, since its natural cardinality in a healthy session is every
  file the session ever touched.

## Observability

`~/.pi-lens/read-guard.log`'s `read_file_evicted` and `edits_cap_trimmed`
events, always-on regardless of `PI_LENS_READ_GUARD_VERBOSE`. Each line names
the file and (for `read_file_evicted`) which of the three pressure/delete
reasons fired. The degradation ledger's `read-guard-file-evicted` and
`read-guard-edits-cap-trim` kinds carry the exact per-file tally in
`pilens_health` even after `read-guard.log` goes quiet past the first line.
Idle-timeout eviction is the one path this PR leaves without a record,
explicitly: see Class sweep for why.

## Class sweep

Defect shape: an eviction/trim path that drops tracked state with no bounded
record at any verbosity (the #1913 shape, AGENTS.md's silent-degradation
family).

**Population sweep** — every `evictFile` call site in `clients/read-guard.ts`:

| Site | Verdict |
|---|---|
| `enforceRecordCapForFile` (per-file record cap) | Already fixed in #1913/#1915 — `read_cap_trimmed` |
| `enforceFileCap`'s consumed-file cap | Fixed here — `read_file_evicted`, reason `file-cap-consumed` |
| `enforceFileCap`'s unconsumed-file cap | Fixed here — `read_file_evicted`, reason `file-cap-unconsumed` |
| `touchFile`'s idle-eviction timer | Reviewed and DECIDED silent (F2): idle eviction is designed housekeeping in every healthy session, not a fault — recording it would grow the ledger's tally map unbounded (one entry per distinct file touched) and flood `pilens_health` on every session. In-code justification at `evictFile`'s doc comment and the `touchFile` call site stands in for a record, as #1918's AC allows |
| `recordEdit`'s per-file edits-cap splice | Fixed here — `edits_cap_trimmed` |
| `forgetPath` (external-delete cleanup) | Not named in the issue's own sweep — found while giving `evictFile` a required `reason` parameter, since every call site needed one. Fixed here — `read_file_evicted`, reason `external-delete` |

Consolidation verdict: all four non-idle reasons fold onto the single
`read_file_evicted` event and the single `read-guard-file-evicted`
degradation kind — one seam, not four. The edits-cap trim stays a separate
event (`edits_cap_trimmed`) because it doesn't drop a file, only a bounded
slice of one file's edit history, so conflating it with whole-file eviction
would make `read_file_evicted`'s `reason` field lie about what happened.

`forgetPath` is a fifth `evictFile` call site the issue's own sweep missed:
it runs after pi-lens confirms an external `rm` already landed, dropping the
same read/edit state as the other four. Instrumenting it cost nothing extra
once `evictFile` took a `reason` parameter, so it is covered rather than left
as a sixth gap.

## Review round (2026-08-27)

First review returned FIX-ROUND: emits real and mutation-proof, sweep table
accurate, four findings.

- **F1 (blocking, false coverage claim)** — the original body claimed
  `read-guard-logger.test.ts` would red if the always-on arm were dropped. It
  would not: that file only asserted the three pre-existing always-on events,
  and `read-guard.test.ts` mocks the logger module wholesale so it can't see
  the real gate. Added the two missing assertions and proved them red by
  neutering `shouldLogEvent`'s new arms (both new tests failed
  `expected false to be true`), then restored.
- **F2 (orchestrator decision, implemented)** — idle-timeout eviction is
  routine housekeeping with unbounded per-session cardinality, unlike the
  other three reasons. Dropped its always-on emit and the ledger call
  entirely; added the in-code justification at `evictFile` and at the
  `touchFile` call site. Proved red by restoring the pre-decision code (idle
  still emitted) against the new "no record" test.
- **F3** — added two tests the reviewer probed by hand and confirmed no
  existing test pinned: two distinct files evicted produce two lines (pins
  the `(kind, subject)` key), and the same file evicted twice logs once, then
  `resetDegradationLedger()` re-arms it (pins session re-arm). Both
  mutation-proofed (see Tests).
- **F4** — this body now uses the PR template's exact section names
  (`Summary`, `Tests` / `Test assessment`, `Blast radius`, `Observability`,
  `Class sweep`) instead of the ad hoc `Population sweep`/`Verification`/
  `Mutation-proofing`/`Merge-order note` headings from the first draft.

Also merged `origin/master` (branch was `BEHIND`; #2226/#2229/#2230 landed
since branch creation). Merge was clean — no conflicts, and `git diff
--name-only <merge-base> origin/master` confirmed none of master's new
commits touched `read-guard.ts`, `read-guard-logger.ts`, or
`degradation-ledger.ts`. Rebuilt and reran all targeted suites and governance
sweeps post-merge (see Tests / Blast radius); all green.
