### PR TITLE
fix(registry): report every root in pilens_health's footprint (refs #2130)

### DIFF
--- a/.changelog/2130-health-footprint-roots.md
+++ b/.changelog/2130-health-footprint-roots.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Report every root a host serves in `pilens_health` (refs #2130)** — the resource footprint projected one scalar `projectRoot` per instance, so a host also serving a subagent's temp worktree read as single-rooted there while `instances.json` listed both. Each `resourceFootprint.perInstance` entry now carries `projectRoots`, resolved through `getInstanceRoots` (the single reader the shared-checkout guard already uses), with the pinned primary still in `projectRoot` for existing consumers.

--- a/clients/instance-registry.ts
+++ b/clients/instance-registry.ts
@@ -857,7 +857,20 @@ export function selectLivePeerInstances(
 
 export interface InstanceFootprint {
 	pid: number;
+	/** The host's pinned primary root. Kept for wire compatibility — every
+	 *  pre-#2130 consumer of `pilens_health`'s `resourceFootprint` reads it. */
 	projectRoot: string;
+	/**
+	 * Every root this host serves (#2130), through {@link getInstanceRoots} —
+	 * the same single reader the shared-checkout guard uses.
+	 *
+	 * Without it a multi-root host reported as if it worked in one directory:
+	 * the scalar above is only the FIRST root, so `pilens_health` showed a
+	 * subagent's temp worktree nowhere at all while `instances.json` listed it.
+	 * Always present and always non-empty for a well-formed entry, so a
+	 * consumer never has to branch on the pre-#2130 shape.
+	 */
+	projectRoots: string[];
 	rssBytes: number;
 	cpuPercent: number;
 	lspChildCount: number;
@@ -928,9 +941,11 @@ export function computeResourceFootprint(
 			(sum, child) => sum + (child.cpuPercent ?? 0),
 			0,
 		);
+		const roots = getInstanceRoots(instance);
 		return {
 			pid: instance.pid,
-			projectRoot: instance.projectRoot,
+			projectRoot: roots[0] ?? instance.projectRoot,
+			projectRoots: roots,
 			rssBytes: instance.rssBytes ?? 0,
 			cpuPercent: instance.cpuPercent ?? 0,
 			lspChildCount: instance.lspChildren.length,

--- a/tests/clients/instance-registry-multi-root.test.ts
+++ b/tests/clients/instance-registry-multi-root.test.ts
@@ -255,6 +255,73 @@ describe("instance-registry multi-root (#2130)", () => {
 		});
 	});
 
+	describe("the resource footprint reports every root (#2130)", () => {
+		function entry(roots: { projectRoot?: string; projectRoots?: string[] }) {
+			return {
+				pid: 1,
+				startedAt: "2026-08-26T00:00:00.000Z",
+				heartbeatAt: "2026-08-26T00:00:00.000Z",
+				rssBytes: 0,
+				lspChildCount: 0,
+				lspChildren: [],
+				projectRoot: "",
+				...roots,
+			};
+		}
+
+		it("carries the whole set for a multi-root host", async () => {
+			// The under-report: `pilens_health` projected ONE root per instance, so
+			// a host serving a subagent's temp worktree looked single-rooted there
+			// while `instances.json` listed both.
+			const { computeResourceFootprint } =
+				await import("../../clients/instance-registry.js");
+			const footprint = computeResourceFootprint([
+				entry({
+					projectRoot: "/primary",
+					projectRoots: ["/primary", "/tmp/worktree-a"],
+				}),
+			]);
+			expect(footprint.perInstance[0].projectRoots).toEqual([
+				"/primary",
+				"/tmp/worktree-a",
+			]);
+			expect(footprint.perInstance[0].projectRoot).toBe("/primary");
+		});
+
+		it("folds a pre-#2130 entry to a one-element set, never undefined", async () => {
+			const { computeResourceFootprint } =
+				await import("../../clients/instance-registry.js");
+			const footprint = computeResourceFootprint([
+				entry({ projectRoot: "/legacy" }),
+			]);
+			expect(footprint.perInstance[0].projectRoots).toEqual(["/legacy"]);
+		});
+
+		it("resolves the scalar from the set when a torn entry lost it", async () => {
+			// `getInstanceRoots` is the single reader precisely so a projection
+			// cannot disagree with the set. Reading `entry.projectRoot` directly
+			// reported the empty scalar for a shape the set answers cleanly.
+			const { computeResourceFootprint } =
+				await import("../../clients/instance-registry.js");
+			const footprint = computeResourceFootprint([
+				entry({ projectRoots: ["/a", "/b"] }),
+			]);
+			expect(footprint.perInstance[0].projectRoot).toBe("/a");
+		});
+
+		it("getResourceFootprint reports both roots this pid registered", async () => {
+			const { registerInstance, registerInstanceRoot, getResourceFootprint } =
+				await import("../../clients/instance-registry.js");
+			await registerInstance(realRoot);
+			await registerInstanceRoot(tempRoot);
+
+			const footprint = await getResourceFootprint(() => true);
+			const mine = footprint.perInstance.find((i) => i.pid === process.pid);
+			expect(mine?.projectRoots).toHaveLength(2);
+			expect(mine?.projectRoots[1]).toContain(path.basename(tempRoot));
+		});
+	});
+
 	describe("selectLivePeerInstances sees SECONDARY roots (#2007 / #2107)", () => {
 		function peerEntry(roots: string[]) {
 			return {


### PR DESCRIPTION
## Summary

`pilens_health` reported one project root per instance, so a host also serving a subagent's temp worktree read as single-rooted while `instances.json` listed both. Each `resourceFootprint.perInstance` entry now carries `projectRoots`, resolved through `getInstanceRoots` — the single reader the shared-checkout guard already uses. This closes the item #2228 named as the only one keeping #2130 open.

`computeResourceFootprint` read `instance.projectRoot` directly — the last direct read of that field outside the registry's own writers, which `InstanceEntry.projectRoot`'s docstring forbids. `projectRoot` stays for wire compatibility but now resolves as `roots[0] ?? instance.projectRoot`, the same idiom `registerInstanceRootNow` uses, so a torn entry cannot make the projection disagree with the set it is derived from. `projectRoots` is always present and non-empty for a well-formed entry, so no consumer branches on the pre-#2130 shape.

Refs #2130, not closes: the parked decline rollup from the issue thread is still absent and deliberately not folded in — `concurrent_session_bind` fires in the extension host while `pilens_health` runs in the MCP server, and a correct counter needs `getProcessSingleton` plus a session-boundary reset (defect shape 25), not the module-scope `let` the existing rollups use. Filed as #2249.

## Type of change

- [x] Bug fix

## Area

- [x] area:session
- [x] area:observability

## Tests

`tests/clients/instance-registry-multi-root.test.ts` — four new cases: multi-root host carries the whole set; pre-#2130 entry folds to a one-element set, never undefined; torn entry recovers the scalar from the set; end-to-end `getResourceFootprint` over a pid that registered two roots. All four red on pre-fix code:

```
× carries the whole set for a multi-root host
  AssertionError: expected undefined to deeply equal [ '/primary', '/tmp/worktree-a' ]
× folds a pre-#2130 entry to a one-element set, never undefined
  AssertionError: expected undefined to deeply equal [ '/legacy' ]
× resolves the scalar from the set when a torn entry lost it
  AssertionError: expected '' to be '/a'
× getResourceFootprint reports both roots this pid registered
  AssertionError: Target cannot be null or undefined.
Tests  4 failed | 20 passed (24)
```

Screens: parallel path (footprint vs guard resolve through one reader), wrong-layer pin (asserted on the public footprint, not the private field).

### Test assessment

`instance-registry-multi-root.test.ts` uniquely pins multi-root registry behavior end to end; the new cases extend it and make nothing redundant. No removals.

## Blast radius

`computeResourceFootprint` has two consumers: `pilens_health` (MCP server) and `getResourceFootprint`. The change is additive (`projectRoots` field) plus a derivation change for the existing scalar that only differs on a torn entry. No hot path — the footprint is computed on a health poll, not per edit or per spawn. Targeted verification: 14 test files / 208 tests via pre-push hook, plus `tests/mcp/server.smoke.test.ts` for the wire shape.

## Observability

`pilens_health`'s `resourceFootprint.perInstance[].projectRoots` is itself the record: the multi-root truth is now directly visible where the clobber used to be. `instances.json` remains the on-disk source.

## Class sweep

Defect class: direct `entry.projectRoot` reads outside the registry's writers (the scalar-projection residue of #2130). Sweep across every `InstanceEntry` consumer — `instance-reaper.ts`, `vanished-instance-marker.ts`, `shared-checkout-guard.ts`, `mcp/server.ts` — found this the sole remaining member; the guard already routes through `getInstanceRoots`, the reaper and marker never read roots. Every other `.projectRoot` hit in the tree is `runtime.projectRoot`/`ctx.projectRoot`, an unrelated type. Class of size 1, grep-proven. Consolidation: already folded onto `getInstanceRoots`.

Refs #2130

BLUF