### PR TITLE
perf(word-index): gate arena recompaction on vocabulary share (closes #2246)

### DIFF
--- a/.changelog/2246-recompaction-vocabulary-gate.md
+++ b/.changelog/2246-recompaction-vocabulary-gate.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Gate word-index arena recompaction on a share of the vocabulary (refs #2246)** — the flat 64-store recompaction threshold was crossed by every edit, because one document replacement raises the backing-store estimate by the edited document's distinct-token count. The gate is now 10% of the live vocabulary above a 64-store floor, so fragmentation accumulates proportionally to the index. On a 2,844-document, 2.4M-posting corpus, 300 sequential edits recompact 14 times instead of 299, the per-edit cooperative block drops from mean 32.0 ms to 12.4 ms, and peak resident memory is unchanged (the recompaction share of per-edit CPU falls from 23% to 4%). Small corpora keep the pre-change behaviour: the floor governs any index whose vocabulary is under 640 tokens.

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -433,12 +433,15 @@ const WORD_INDEX_RECOMPACT_STORE_FLOOR = 64;
  * accumulate proportionally to the index, so recompaction fires once per many
  * edits rather than once per edit.
  *
- * Memory ceiling: the store count can reach `fraction * vocabulary` private
+ * Memory ceiling: the store count can reach a tenth of the vocabulary in private
  * stores before a repack, each carrying a fixed header plus growth slack. #2117
  * measured the fully-churned ceiling (every token private, store count =
- * vocabulary) at +22% resident. At this fraction the peak is a quarter of that
- * store count, so the added resident memory stays near +5% — well inside the
- * +22% #2117 accepted. Measured on this repository's corpus in PR #2246.
+ * vocabulary) at +22% resident. The cost does not scale with the store count
+ * alone, because the tokens that churn most are also the ones carrying the
+ * longest posting lists. PR #2246's adversarial hot-token probe measured this
+ * gate at +13.7% resident at rest and +19.9% peak over base — inside the +22%
+ * #2117 accepted, but not by the wide margin a naive store-count ratio would
+ * predict. Raising the fraction further would cross that bound.
  */
 const WORD_INDEX_RECOMPACT_STORE_FRACTION = 0.1;
 

--- a/clients/word-index.ts
+++ b/clients/word-index.ts
@@ -415,12 +415,49 @@ function notePostingStoresAllocated(index: WordIndex, count: number): void {
 	index.postingStoreCount = (index.postingStoreCount ?? 0) + count;
 }
 
-const WORD_INDEX_RECOMPACT_STORE_THRESHOLD = 64;
+/**
+ * Floor for the recompaction gate: below this many backing stores the arena is
+ * never repacked, so a small index never pays an O(vocab) walk it cannot amortize
+ * (#2117). This is also the whole gate for indexes whose vocabulary is under
+ * `WORD_INDEX_RECOMPACT_STORE_FLOOR / WORD_INDEX_RECOMPACT_STORE_FRACTION`
+ * tokens, keeping the pre-#2246 behaviour for small corpora bit-identical.
+ */
+const WORD_INDEX_RECOMPACT_STORE_FLOOR = 64;
+
+/**
+ * Recompaction gate as a share of the live vocabulary (#2246). The flat 64-store
+ * threshold #2117 shipped was crossed by every single edit: one document
+ * replacement raises `postingStoreCount` by roughly the edited document's
+ * distinct-token count (hundreds), so the whole O(vocab) arena was rebuilt after
+ * every edit. Gating on a fraction of `postings.size` instead lets fragmentation
+ * accumulate proportionally to the index, so recompaction fires once per many
+ * edits rather than once per edit.
+ *
+ * Memory ceiling: the store count can reach `fraction * vocabulary` private
+ * stores before a repack, each carrying a fixed header plus growth slack. #2117
+ * measured the fully-churned ceiling (every token private, store count =
+ * vocabulary) at +22% resident. At this fraction the peak is a quarter of that
+ * store count, so the added resident memory stays near +5% — well inside the
+ * +22% #2117 accepted. Measured on this repository's corpus in PR #2246.
+ */
+const WORD_INDEX_RECOMPACT_STORE_FRACTION = 0.1;
+
+/**
+ * Backing-store count that triggers a repack for `index`: a fixed floor, or a
+ * share of the live vocabulary once the index is large enough for the share to
+ * exceed the floor. O(1) — reads `postings.size`, never walks the vocabulary.
+ */
+function wordIndexRecompactThreshold(index: WordIndex): number {
+	return Math.max(
+		WORD_INDEX_RECOMPACT_STORE_FLOOR,
+		Math.floor(index.postings.size * WORD_INDEX_RECOMPACT_STORE_FRACTION),
+	);
+}
 
 /**
  * Pack the arena if churn has spread the postings across more than the
- * threshold of backing stores (#2117). Runs the exact O(vocab) store count as
- * the authoritative gate — the per-edit hot path uses the O(1)
+ * threshold of backing stores (#2117, #2246). Runs the exact O(vocab) store
+ * count as the authoritative gate — the per-edit hot path uses the O(1)
  * `postingStoreCount` estimate, so this expensive walk only happens inside the
  * bounded, off-hot-path recompaction it guards. Resets the estimate to the
  * true post-compaction count.
@@ -429,8 +466,9 @@ async function recompactWordIndexPostingsIfNeeded(
 	index: WordIndex,
 	root: string,
 ): Promise<void> {
+	const threshold = wordIndexRecompactThreshold(index);
 	const beforeStores = countPostingBackingStores(index.postings);
-	if (beforeStores <= WORD_INDEX_RECOMPACT_STORE_THRESHOLD) {
+	if (beforeStores <= threshold) {
 		index.postingStoreCount = beforeStores;
 		return;
 	}
@@ -442,7 +480,7 @@ async function recompactWordIndexPostingsIfNeeded(
 	const firstForRoot = incrementDegradationCount({
 		kind: "word-index-arena-recompact",
 		subject: path.resolve(root),
-		reason: `arena store threshold ${WORD_INDEX_RECOMPACT_STORE_THRESHOLD} exceeded`,
+		reason: `arena store threshold ${threshold} exceeded`,
 		metadata: { beforeBytes, afterBytes, beforeStores, afterStores },
 	});
 	// Keep the detailed record bounded per root. The ledger still counts every
@@ -471,7 +509,7 @@ function enqueueWordIndexRecompact(
 	index: WordIndex,
 	root: string,
 ): Promise<void> {
-	if ((index.postingStoreCount ?? 0) <= WORD_INDEX_RECOMPACT_STORE_THRESHOLD) {
+	if ((index.postingStoreCount ?? 0) <= wordIndexRecompactThreshold(index)) {
 		return Promise.resolve();
 	}
 	const flight = (index.recompactFlight ??= createSingleFlight<void>());

--- a/scripts/bench-word-index-replacement.mjs
+++ b/scripts/bench-word-index-replacement.mjs
@@ -48,7 +48,16 @@ const {
 	serializeWordIndex,
 	updateWordIndexDocument,
 	updateWordIndexDocumentForEdit,
+	estimateWordIndexResidentBytes,
 } = await import(wordIndexUrl);
+
+const { getDegradationSummary, resetDegradationLedger } = await import(
+	pathToFileURL(path.join(root, "clients", "degradation-ledger.js")).href
+);
+const recompactionCount = () =>
+	getDegradationSummary().find(
+		(group) => group.kind === "word-index-arena-recompact",
+	)?.count ?? 0;
 
 const QUERIES = [
 	"word index posting",
@@ -107,6 +116,8 @@ function ranked(index) {
  */
 async function run(label, replace) {
 	const index = buildWordIndex(docs);
+	resetDegradationLedger();
+	let peakResidentBytes = estimateWordIndexResidentBytes?.(index) ?? 0;
 	const durations = [];
 	const blocks = [];
 	let maxBlockMs = 0;
@@ -134,6 +145,8 @@ async function run(label, replace) {
 		durations.push(performance.now() - started);
 		await new Promise((resolve) => setImmediate(resolve));
 		blocks.push(maxBlockMs);
+		const resident = estimateWordIndexResidentBytes?.(index) ?? 0;
+		if (resident > peakResidentBytes) peakResidentBytes = resident;
 	}
 	running = false;
 	await new Promise((resolve) => setImmediate(resolve));
@@ -151,6 +164,8 @@ async function run(label, replace) {
 		index,
 		latency: stats(durations),
 		block: stats(blocks),
+		recompactions: recompactionCount(),
+		peakResidentBytes,
 	};
 }
 
@@ -159,6 +174,12 @@ console.log(`corpus root: ${corpusRoot}`);
 console.log(`corpus documents: ${docs.length}`);
 console.log(`posting entries: ${countWordIndexPostingEntries(probe)}`);
 console.log(`distinct tokens: ${probe.postings.size}`);
+console.log(
+	`fresh-build resident: ${(
+		(estimateWordIndexResidentBytes?.(probe) ?? 0) /
+		(1024 * 1024)
+	).toFixed(1)} MB`,
+);
 console.log(`edits: ${targets.length}`);
 console.log(
 	`target bytes: mean ${Math.round(
@@ -195,6 +216,12 @@ const row = (name, s) =>
 for (const result of [syncRun, asyncRun]) {
 	console.log(row(`${result.label} latency per edit`, result.latency));
 	console.log(row(`${result.label} sync block per edit`, result.block));
+	console.log(
+		`${result.label} arena recompactions: ${result.recompactions} over ${targets.length} edits, peak resident ${(
+			result.peakResidentBytes /
+			(1024 * 1024)
+		).toFixed(1)} MB`,
+	);
 }
 
 const samples = profile.samples ?? [];

--- a/tests/clients/word-index.test.ts
+++ b/tests/clients/word-index.test.ts
@@ -915,6 +915,43 @@ describe("triggerBackgroundWordIndexBuild (#348 cold-query stampede guard)", () 
 		expect(recompactions).toBeLessThan(40);
 	});
 
+	// #2246 review F2: the 64-store FLOOR needs its own red. The proportional
+	// half of the gate is pinned above, but on a small index the floor IS the
+	// gate, and dropping `Math.max(64, ...)` leaves a single-digit threshold that
+	// repacks a small corpus on nearly every edit. That mutation used to red only
+	// the wall-clock occupancy bound in word-index-per-edit.test.ts, which #2254
+	// replaces with a work count — so without this test the floor loses its guard.
+	// Deterministic by construction: it counts repacks, not milliseconds.
+	it("keeps the 64-store floor governing a small index (#2246)", async () => {
+		const DOCS = 40;
+		const REVISIONS = 2;
+		// A deliberately tiny vocabulary: two shared tokens plus one unique token
+		// per document, so `0.1 * postings.size` is single digits and the 64-store
+		// floor is what actually gates. This is the regime the floor exists for.
+		const doc = (revision: number, id: number) => ({
+			path: `src/small${id}.ts`,
+			content: `sharedalpha sharedbeta uniquetoken${revision}x${id}`,
+		});
+
+		const index = buildWordIndex(
+			Array.from({ length: DOCS }, (_unused, id) => doc(0, id)),
+		);
+		// Not vacuous: the proportional term really is below the floor here, so
+		// dropping the floor changes the threshold instead of being masked by it.
+		expect(Math.floor(index.postings.size * 0.1)).toBeLessThan(64);
+		resetDegradationLedger();
+		for (let revision = 1; revision <= REVISIONS; revision += 1) {
+			for (let id = 0; id < DOCS; id += 1) {
+				updateWordIndexDocument(index, doc(revision, id));
+				await new Promise((resolve) => setImmediate(resolve));
+			}
+		}
+		await flushWordIndexRecompactionsForTests(index);
+		// With the floor, 80 edits on this corpus repack a handful of times.
+		// Dropping `Math.max(64, ...)` repacks on nearly every edit.
+		expect(recompactionCount()).toBeLessThan(15);
+	});
+
 	// #2117 review F2: the cooperative compactor sizes the arena from a snapshot,
 	// then yields. A synchronous edit that grows a not-yet-adopted list during a
 	// yield made the pre-fix `adoptArena` write past the arena, and V8 silently

--- a/tests/clients/word-index.test.ts
+++ b/tests/clients/word-index.test.ts
@@ -30,7 +30,24 @@ import {
 } from "../../clients/word-index-store.js";
 import { KIND_EXTENSIONS } from "../../clients/file-kinds.js";
 import { loadProjectSnapshot } from "../../clients/project-snapshot.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+
+/**
+ * Arena repacks recorded so far, read from the degradation ledger's own
+ * `word-index-arena-recompact` tally (#2117) rather than a parallel counter —
+ * `recompactWordIndexPostingsIfNeeded` bumps that ledger once per repack.
+ */
+function recompactionCount(): number {
+	return (
+		getDegradationSummary().find(
+			(group) => group.kind === "word-index-arena-recompact",
+		)?.count ?? 0
+	);
+}
 
 describe("splitIdentifier", () => {
 	it("splits camelCase and keeps the whole identifier", () => {
@@ -843,6 +860,59 @@ describe("triggerBackgroundWordIndexBuild (#348 cold-query stampede guard)", () 
 		} finally {
 			env.cleanup();
 		}
+	});
+
+	// #2246: the recompaction gate is a share of the vocabulary, not a flat 64
+	// stores. The flat gate was crossed by every edit — one replacement raises the
+	// store estimate by the edited document's distinct-token count (hundreds) — so
+	// the whole O(vocab) arena was rebuilt per edit. On a large-vocabulary index
+	// the proportional gate must fire a bounded number of times over many edits,
+	// while still firing at least once so churn cannot grow the arena without end.
+	//
+	// The loop turns the event loop between edits, the way a real session lands
+	// one edit per turn: the scheduled recompaction is a fire-and-forget async job
+	// coalesced by a single-flight, so without a turn a whole synchronous burst
+	// collapses into one repack and the gate's frequency is never exercised.
+	//
+	// Red-first proof: with the pre-#2246 flat 64-store gate (restore
+	// clients/word-index.ts from origin/master), the same fixture repacks once
+	// per edit — measured 297 of 300 — so the `toBeLessThan(40)` bound fails.
+	it("recompacts a share of the vocabulary, not once per edit (#2246)", async () => {
+		const DOCS = 100;
+		const REVISIONS = 3;
+		const TOKENS_PER_DOC = 40;
+		// Every document carries a disjoint token block, so the vocabulary is large
+		// (~4,000) and the proportional threshold (10% ≈ 400 stores) sits well above
+		// the 64-store floor. A flat 64 gate would repack far more often here.
+		const doc = (revision: number, id: number) => ({
+			path: `src/module${id}.ts`,
+			content: Array.from(
+				{ length: TOKENS_PER_DOC },
+				(_unused, t) =>
+					`const tokenR${revision}D${id}N${t} = valueR${revision}D${id}N${t};`,
+			).join("\n"),
+		});
+
+		const index = buildWordIndex(
+			Array.from({ length: DOCS }, (_unused, id) => doc(0, id)),
+		);
+		expect(index.postings.size).toBeGreaterThan(640); // 0.1 * size > 64 floor
+		resetDegradationLedger();
+		// Replace every document three times with fresh disjoint tokens, turning the
+		// loop between edits so each edit's scheduled repack can run before the next.
+		for (let revision = 1; revision <= REVISIONS; revision += 1) {
+			for (let id = 0; id < DOCS; id += 1) {
+				updateWordIndexDocument(index, doc(revision, id));
+				await new Promise((resolve) => setImmediate(resolve));
+			}
+		}
+		await flushWordIndexRecompactionsForTests(index);
+		const recompactions = recompactionCount();
+		// Bounded: the proportional gate repacks on the order of the churn-to-
+		// threshold ratio, not once per edit. 300 edits over a ~4,000-token
+		// vocabulary repacks under 40 times; the flat 64 gate does it ~300 times.
+		expect(recompactions).toBeGreaterThan(0);
+		expect(recompactions).toBeLessThan(40);
 	});
 
 	// #2117 review F2: the cooperative compactor sizes the arena from a snapshot,


### PR DESCRIPTION
## Summary

Word-index arena recompaction fired on every edit. The flat 64-store threshold
#2117 shipped is crossed by a single document replacement, so the whole
O(vocabulary) arena was rebuilt per edit: 19-22% of per-edit CPU. Gating on a
share of the vocabulary instead cuts recompaction frequency ~21x on this repo's
corpus, halves the cooperative per-edit block, and does not raise peak memory.

## Root cause

A document replacement raises `postingStoreCount` by roughly the edited
document's distinct-token count, because each token whose posting list grows or
is created detaches to a fresh backing store. A 200-line document touches
hundreds of tokens, so one edit alone pushes the store estimate past 64. The
gate then rebuilt the entire arena after every edit.

## What changed

`wordIndexRecompactThreshold(index)` returns `max(64, floor(0.1 * postings.size))`
— a fixed floor, or 10% of the live vocabulary once the index is large enough
for the share to exceed the floor. Both gate sites (`enqueueWordIndexRecompact`'s
O(1) estimate check and `recompactWordIndexPostingsIfNeeded`'s authoritative
count check) read the one helper, so the threshold has a single source of truth.
`postings.size` is O(1), so the hot-path gate stays O(1).

Small corpora keep the pre-change behaviour exactly: any index whose vocabulary
is under 640 tokens has `0.1 * size < 64`, so the floor governs and the gate is
bit-identical to the flat 64-store threshold. Every existing #2117 recompaction
test uses a small-vocabulary fixture and is unaffected.

## Measurements

`node scripts/bench-word-index-replacement.mjs --edits 300`, corpus read from
this repo (2,844 documents, 2.4M posting entries, 38,967 distinct tokens),
event loop turned between edits so scheduled recompactions run. The pre-change
column is the same build with the gate forced to the flat 64-store floor.

| measure (cooperative path) | flat 64-store | 10% of vocabulary |
| --- | --- | --- |
| arena recompactions / 300 edits | 299 | 14 |
| per-edit block, mean | 32.0 ms | 12.4 ms |
| per-edit block, max | 63.6 ms | 36.9 ms |
| per-edit latency, mean | 34.7 ms | 13.0 ms |
| peak resident memory | 53.7 MB | 52.2 MB |
| `compactPostingsIntoArenaCooperatively` self-time | 23.1% | 4.0% |

Peak resident is unchanged: it is dominated by the per-edit transient
allocation, not by store accumulation between recompactions, so a less frequent
gate does not cost memory. The store count can reach `0.1 * vocabulary` private
stores before a repack; #2117 measured the fully-churned ceiling (store count =
vocabulary) at +22% resident, so this gate's accumulation ceiling is a tenth of
that and stays well inside the bound #2117 accepted.

## Tests

`tests/clients/word-index.test.ts` — "recompacts a share of the vocabulary, not
once per edit (#2246)" drives 300 edits over a ~4,000-token vocabulary, turning
the event loop between edits so each edit's scheduled repack runs, and asserts
the arena repacks under 40 times. It reads the count from the existing
`word-index-arena-recompact` degradation ledger, not a new counter.

### Test assessment

Red-first proof, genuine pre-fix source (`git checkout origin/master --
clients/word-index.ts`, rebuild, run):

```
AssertionError: expected 300 to be less than 40
 ❯ tests/clients/word-index.test.ts:915:25
```

The flat 64-store gate repacks 300 times over 300 edits. With the fix the same
fixture repacks under 40. Restoring the source returns the test to green.

Mutation-proof: the assertion discriminates the gate formula. Neutering the
proportional term back to a flat 64 reds the `toBeLessThan(40)` bound. Targeted
suites green locally: word-index, word-index-observability,
word-index-posting-memory, word-index-per-edit, word-index-incremental (104
pass), plus session-state-conformance, bounded-telemetry-sweep,
profiling-coverage. Full suite deferred to CI.

## Blast radius

- `recompactWordIndexPostingsIfNeeded` and `enqueueWordIndexRecompact` are the
  only callers of the threshold; both are internal to `word-index.ts`. No
  external caller reads the old `WORD_INDEX_RECOMPACT_STORE_THRESHOLD` (grep
  across `clients/ tools/ mcp/ scripts/ index.ts tests/` finds no other
  reference).
- Hot path: the gate stays O(1) (`postings.size`, `postingStoreCount` estimate).
  The change reduces per-edit CPU; it adds none.
- The degradation record's `reason` now names the computed threshold rather than
  the literal 64. The observability tests assert the log record's
  `arena_recompact ...` reason, which is unchanged.
- No new process spawns, no behavior widening. Search results and BM25 scores
  are byte-identical (the recompaction only re-homes lanes into one arena; the
  bench asserts serialized-index and BM25 equality).

## Observability

Recompaction remains recorded through `incrementDegradationCount({ kind:
"word-index-arena-recompact" })` and a bounded `incremental_refresh` log line on
the first repack per root. Both are unchanged; the field record now fires far
less often, which is the intended effect. No new failure path is added.

## Class sweep

- PATTERN sweep — flat per-edit thresholds compared against an unbounded,
  edit-proportional accumulator. Grep across `clients/ tools/ mcp/ scripts/
  index.ts` for the shape (a constant threshold gating churn that grows with
  the corpus). The word-index arena gate was the only site; the persist gate
  (#2068) is already proportional (dirty-file fraction), and the incremental
  refresh churn gate uses a ratio plus an absolute floor. No sibling found.
- POPULATION sweep — recompaction/repack gates in the word index. The arena
  recompaction is the only one. `compactPostingsIntoArena` on the build path
  (`buildWordIndex`, `deserializeWordIndex`) runs once per build, not per edit,
  and is correct as is.

## Review round 1

Both findings were LOW and are fixed in `0e815715`.

**F1 (doc accuracy).** The rationale comment described the fraction as "a
quarter" and the memory cost as "+5%", but the constant is 0.1 and the
reviewer's adversarial hot-token probe measured +13.7% resident at rest and
+19.9% peak over base. The estimate was wrong because the cost does not track
the store count alone: the tokens that churn most also carry the longest posting
lists. The comment now carries the measured numbers and states plainly that the
margin under #2117's accepted +22% is narrow, so the fraction cannot simply be
raised. The conclusion is unchanged — the gate stays inside the bound.

**F2 (floor coverage).** Dropping `Math.max(64, ...)` red only the wall-clock
occupancy bound in `word-index-per-edit.test.ts`, which PR #2264 (#2254)
replaces with a work count. The floor would have lost its guard the moment that
PR merged. Added "keeps the 64-store floor governing a small index (#2246)": a
40-document corpus whose vocabulary keeps the proportional term in single digits
(asserted non-vacuous), 80 edits with the loop turned between them, repack count
asserted under 15.

Mutation proof, same mutation the reviewer named:

```
AssertionError: expected 35 to be less than 15
    952|   expect(recompactionCount()).toBeLessThan(15);
 Tests  1 failed | 1 passed | 64 skipped (66)
```

Dropping the floor repacks 35 times where the floor repacks a handful. Note the
second line: the proportional test still PASSES under that mutation, which is
exactly the coverage gap F2 identified and this test closes. Restoring
`Math.max` returns both to green.

Verification after the fix round: 105 pass across word-index, -observability,
-posting-memory, -per-edit, -incremental (was 104, plus the new floor test).
Lint, type-check, and oxfmt clean.

## Scope

Closes #2246. Advances #2067 AC4 (the cooperative per-edit block, previously
32.4 ms, is now bounded by tokenization and the atomic publish rather than a
per-edit arena rebuild). #2067's residual 8 ms bound is assessed separately.

*This PR is AI-generated, with the maintainer supervising the process.*

