### PR TITLE
fix(dispatch): one freshness clock for nested ignore rules and path verdicts (closes #2071, closes #1976)

### DIFF
--- a/.changelog/fix-2071-nested-ignore-clock.md
+++ b/.changelog/fix-2071-nested-ignore-clock.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Give nested ignore rules and path verdicts one freshness clock (closes #2071, closes #1976)** — a nested `.gitignore` edit no longer leaves two paths under the same rule disagreeing, and the ignore matcher stats a nested source once per cadence window instead of once per file. A 2000-file walk drops from 18,064 `statSync` calls (9.03 per file) to 192 (0.10 per file), and from 1,886 ms to 96 ms.
+- **Give nested ignore rules and path verdicts one freshness clock (closes #2071, closes #1976)** — a nested `.gitignore` edit no longer leaves two paths under the same rule disagreeing, and the ignore matcher stats a nested source once per cadence window instead of once per file. A 2000-file walk drops from 18,064 `statSync` calls (9.03 per file) to 192 (0.10 per file), and from 1,886 ms to 85-92 ms across runs. An externally edited nested ignore file is honored within one cadence window (2 s).

--- a/.changelog/fix-2071-nested-ignore-clock.md
+++ b/.changelog/fix-2071-nested-ignore-clock.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Give nested ignore rules and path verdicts one freshness clock (closes #2071, closes #1976)** — a nested `.gitignore` edit no longer leaves two paths under the same rule disagreeing, and the ignore matcher stats a nested source once per cadence window instead of once per file. A 2000-file walk drops from 18,064 `statSync` calls (9.03 per file) to 192 (0.10 per file), and from 1,886 ms to 96 ms.

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -348,14 +348,25 @@ function buildProjectIgnoreMatcher(
 	patterns: GitignorePattern[],
 ): ProjectIgnoreMatcherWithFreshness {
 	const consumedIgnoreSources = new Map<string, IgnoreSource>();
-	const rememberIgnoreSource = (filePath: string): void => {
-		const signature = fileFreshnessSignature(filePath);
+	// `signature` lets a caller that already statted the file reuse that one
+	// stat (#2016's class on this seam: never re-derive a value you just
+	// computed). Callers with no signature in hand still pay their own stat.
+	const rememberIgnoreSource = (
+		filePath: string,
+		signature: FreshnessSignature = fileFreshnessSignature(filePath),
+	): void => {
 		consumedIgnoreSources.set(filePath, { path: filePath, ...signature });
 	};
 	rememberIgnoreSource(path.join(resolvedRoot, ".gitignore"));
 	const nestedCache = new Map<
 		string,
 		{
+			/**
+			 * #2071: the ONE clock this directory's ignore rules and every path
+			 * verdict derived from them share. Inside the window neither is
+			 * re-checked, so two paths under the same rule cannot disagree.
+			 */
+			checkedAtMs: number;
 			gitignoreMtimeMs: number;
 			gitignoreSize: number;
 			pilensMtimeMs: number;
@@ -375,8 +386,28 @@ function buildProjectIgnoreMatcher(
 	// caller (or the root-config lookup above) already loaded.
 	const patternsForDir = (dir: string): GitignorePattern[] => {
 		if (dir === resolvedRoot) return patterns;
+		const cached = nestedCache.get(dir);
+		const now = Date.now();
+		// #2071: inside the cadence window this directory's rules are frozen, so
+		// no stat runs and every verdict already memoized under `dir` stays
+		// derivable from exactly these patterns. Before this gate the freshness
+		// check ran per call while `patternMemo` did not, which is what let a
+		// fresh path and a memoized path in the same directory return opposite
+		// verdicts for the same rule. Externally edited nested sources are
+		// therefore picked up within PROJECT_IGNORE_FRESHNESS_CADENCE_MS, the
+		// same bound #2159 already accepted for the root sources.
+		// pi-authored `.gitignore` writes keep their instant path through
+		// `invalidateProjectIgnoreMatcherForPath`.
+		if (
+			cached !== undefined &&
+			now - cached.checkedAtMs < PROJECT_IGNORE_FRESHNESS_CADENCE_MS
+		) {
+			return cached.patterns;
+		}
 		const gitignoreSig = gitignoreSignature(dir);
-		rememberIgnoreSource(path.join(dir, ".gitignore"));
+		// One stat, two consumers. `rememberIgnoreSource` used to stat the same
+		// file a second time on the line below this one.
+		rememberIgnoreSource(path.join(dir, ".gitignore"), gitignoreSig);
 		// #1105: gate on size too. `findPiLensConfigInDir` returns `size` alongside
 		// `mtimeMs` (both from one stat), and `gitignoreSignature` reads both for
 		// the nested `.gitignore`, so an mtime-preserving, length-changing edit to
@@ -384,13 +415,15 @@ function buildProjectIgnoreMatcher(
 		const pilensInfo = findPiLensConfigInDir(dir);
 		const pilensMtime = pilensInfo?.mtimeMs ?? -1;
 		const pilensSize = pilensInfo?.size ?? -1;
-		const cached = nestedCache.get(dir);
 		if (
 			cached?.gitignoreMtimeMs === gitignoreSig.mtimeMs &&
 			cached?.gitignoreSize === gitignoreSig.size &&
 			cached?.pilensMtimeMs === pilensMtime &&
 			cached?.pilensSize === pilensSize
 		) {
+			// Unchanged: re-arm the shared clock so the next window is measured
+			// from this check, not from the build that first populated the entry.
+			cached.checkedAtMs = now;
 			return cached.patterns;
 		}
 		const nestedConfig = loadPiLensConfigInDir(dir);
@@ -399,12 +432,18 @@ function buildProjectIgnoreMatcher(
 			...parseGitignoreContent(nestedConfig.ignore.join("\n"), "pilens"),
 		];
 		nestedCache.set(dir, {
+			checkedAtMs: now,
 			gitignoreMtimeMs: gitignoreSig.mtimeMs,
 			gitignoreSize: gitignoreSig.size,
 			pilensMtimeMs: pilensMtime,
 			pilensSize: pilensSize,
 			patterns: nextPatterns,
 		});
+		// #2071: drift is the SINGLE trigger. The rules under `dir` just changed,
+		// so every verdict computed under the superseded rules dies in the same
+		// step that supersedes them. `cached === undefined` is a first build, not
+		// a change, and has no verdicts to drop.
+		if (cached !== undefined) dropVerdictsUnder(dir);
 		return nextPatterns;
 	};
 
@@ -433,7 +472,14 @@ function buildProjectIgnoreMatcher(
 		string,
 		{ ignored: boolean; layer: GitignorePatternLayer | undefined }
 	>();
-	const invalidateSubtree = (subtree: string): void => {
+	/**
+	 * Drop every memoized verdict at or below `subtree`, leaving `nestedCache`
+	 * alone. `patternsForDir` calls this the moment it rebuilds a directory's
+	 * patterns, which is why it must NOT evict the entry that rebuild just
+	 * wrote. `invalidateSubtree` layers the eviction on top for the write-hook
+	 * path, where the caller knows the source changed but has not re-read it.
+	 */
+	function dropVerdictsUnder(subtree: string): void {
 		const resolvedSubtree = path.resolve(subtree);
 		for (const key of patternMemo.keys()) {
 			const memoPath = key.slice(2);
@@ -445,7 +491,10 @@ function buildProjectIgnoreMatcher(
 				patternMemo.delete(key);
 			}
 		}
-		nestedCache.delete(resolvedSubtree);
+	}
+	const invalidateSubtree = (subtree: string): void => {
+		dropVerdictsUnder(subtree);
+		nestedCache.delete(path.resolve(subtree));
 	};
 
 	// Compile expanded gitignore globs once per matcher instance. Relative-path

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -720,6 +720,23 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 	const lensConfig = lensConfigInfo(resolvedRoot);
 	const globalSig = globalConfigSignature();
 	const cached = projectIgnoreMatcherCache.get(resolvedRoot);
+	// A path can be discovered during the previous matcher lookup. Publish only
+	// previously unseen sources so a walk cannot replace a pre-edit baseline.
+	//
+	// This runs BEFORE the sweep below, and the order is load-bearing. A nested
+	// source can only be published on a call AFTER the one that consumed it.
+	// With the publish second, the sweep never saw a source during the window in
+	// which it was discovered, yet still reset `lastIgnoreFreshnessCheckMs`, so
+	// the first sweep that could see it ran a FULL cadence later. Pickup was up
+	// to 2x cadence, not 1x: measured stale at 2 s and 3 s, fresh at 4 s. The
+	// baseline is protected by the `known` set, not by the ordering, so moving
+	// the publish earlier cannot let a walk overwrite a pre-edit baseline.
+	if (cached) {
+		const known = new Set(cached.ignoreSources.map((source) => source.path));
+		for (const source of cached.matcher.getConsumedIgnoreSources()) {
+			if (!known.has(source.path)) cached.ignoreSources.push(source);
+		}
+	}
 	if (
 		cached &&
 		Date.now() - cached.lastIgnoreFreshnessCheckMs >=
@@ -742,14 +759,6 @@ export function getProjectIgnoreMatcher(rootDir: string): ProjectIgnoreMatcher {
 					}
 				}
 			}
-		}
-	}
-	// A path can be discovered during the previous matcher lookup. Publish only
-	// previously unseen sources so a walk cannot replace a pre-edit baseline.
-	if (cached) {
-		const known = new Set(cached.ignoreSources.map((source) => source.path));
-		for (const source of cached.matcher.getConsumedIgnoreSources()) {
-			if (!known.has(source.path)) cached.ignoreSources.push(source);
 		}
 	}
 	if (

--- a/tests/clients/nested-ignore-freshness-clock.test.ts
+++ b/tests/clients/nested-ignore-freshness-clock.test.ts
@@ -1,0 +1,131 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return { ...actual, statSync: vi.fn(actual.statSync) };
+});
+
+import {
+	getProjectIgnoreMatcher,
+	PROJECT_IGNORE_FRESHNESS_CADENCE_MS,
+} from "../../clients/file-utils.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+describe("nested ignore freshness clock (#2071)", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("keeps two paths under one nested rule in agreement after an external edit", () => {
+		const env = setupTestEnvironment("pi-lens-2071-divergence-");
+		try {
+			const nested = path.join(env.tmpDir, "sub");
+			fs.mkdirSync(nested, { recursive: true });
+			fs.writeFileSync(path.join(env.tmpDir, ".gitignore"), "node_modules\n");
+			fs.writeFileSync(path.join(nested, ".gitignore"), "placeholder-keep\n");
+			const memoized = path.join(nested, "x.ts");
+			const fresh = path.join(nested, "y.ts");
+
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			expect(matcher.isIgnored(memoized)).toBe(false);
+
+			// External edit, no pi-lens write hook: the IDE-edit shape.
+			fs.writeFileSync(path.join(nested, ".gitignore"), "*.ts\n");
+
+			// Same matcher, same directory, same rule. Before the shared clock the
+			// fresh path re-read the nested rules while the memoized path replayed
+			// its pre-edit verdict, so these two disagreed.
+			expect(matcher.isIgnored(fresh)).toBe(matcher.isIgnored(memoized));
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("drops subtree verdicts when a walk rebuilds drifted nested patterns", () => {
+		const env = setupTestEnvironment("pi-lens-2071-drift-drop-");
+		try {
+			const nested = path.join(env.tmpDir, "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			fs.writeFileSync(ignorePath, "a.ts\n");
+			const memoized = path.join(nested, "a.ts");
+			const walked = path.join(nested, "b.ts");
+
+			vi.useFakeTimers();
+			const start = Date.now();
+			// Held once, as a walk loop holds it. No further getProjectIgnoreMatcher
+			// lookups, so the #2159 sweep cannot be what fixes this.
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			expect(matcher.isIgnored(memoized)).toBe(true);
+
+			fs.writeFileSync(ignorePath, "!a.ts\n");
+			vi.setSystemTime(start + PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
+
+			// This fresh path rebuilds the drifted directory. That rebuild must take
+			// the superseded verdicts with it.
+			matcher.isIgnored(walked);
+
+			expect(matcher.isIgnored(memoized)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("stats a nested ignore source once per cadence window, not once per file", () => {
+		const env = setupTestEnvironment("pi-lens-2071-bounded-cost-");
+		try {
+			const nested = path.join(env.tmpDir, "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			fs.writeFileSync(ignorePath, "generated.ts\n");
+
+			vi.useFakeTimers();
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			// First lookup builds the entry and arms the clock.
+			matcher.isIgnored(path.join(nested, "seed.ts"));
+
+			const statSpy = vi.spyOn(fs, "statSync");
+			const sourceStats = () =>
+				statSpy.mock.calls.filter(([filePath]) => filePath === ignorePath)
+					.length;
+			statSpy.mockClear();
+
+			// Fifty distinct paths in one directory, all inside one window.
+			for (let index = 0; index < 50; index++) {
+				matcher.isIgnored(path.join(nested, `f${index}.ts`));
+			}
+
+			expect(sourceStats()).toBe(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("reads the nested ignore source once per check instead of twice", () => {
+		const env = setupTestEnvironment("pi-lens-2071-single-stat-");
+		try {
+			const nested = path.join(env.tmpDir, "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			fs.writeFileSync(ignorePath, "generated.ts\n");
+
+			const statSpy = vi.spyOn(fs, "statSync");
+			const sourceStats = () =>
+				statSpy.mock.calls.filter(([filePath]) => filePath === ignorePath)
+					.length;
+			statSpy.mockClear();
+
+			// One cold lookup: one freshness check of this one nested source.
+			getProjectIgnoreMatcher(env.tmpDir).isIgnored(
+				path.join(nested, "generated.ts"),
+			);
+
+			expect(sourceStats()).toBe(1);
+		} finally {
+			env.cleanup();
+		}
+	});
+});

--- a/tests/clients/nested-ignore-freshness-clock.test.ts
+++ b/tests/clients/nested-ignore-freshness-clock.test.ts
@@ -189,6 +189,17 @@ describe("nested ignore freshness clock (#2071)", () => {
 
 			fs.writeFileSync(ignorePath, "bbb.ts\n");
 			expect(fs.statSync(ignorePath).size).toBe(7);
+			// PIN the mtime rather than trusting the clock to tick. Size is held
+			// constant here on purpose, so mtime is the ONLY axis that can carry
+			// the edit — and two same-size writes land in one coarse mtime bucket
+			// most of the time (measured 181/200 back to back on Windows). The
+			// real test does enough work between the writes to usually escape the
+			// bucket, which is worse than always failing: it failed 1 of 15
+			// unmutated runs here, and Linux CI would never show it. This is the
+			// mirror of the #1105 cases, which pin mtime with `utimesSync` to
+			// isolate the size axis; this pins it to isolate the mtime axis.
+			const bumped = new Date(fs.statSync(ignorePath).mtimeMs + 5_000);
+			fs.utimesSync(ignorePath, bumped, bumped);
 			vi.setSystemTime(start + PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
 			// A fresh path in the same directory rebuilds the drifted entry and
 			// drops the subtree's verdicts with it.

--- a/tests/clients/nested-ignore-freshness-clock.test.ts
+++ b/tests/clients/nested-ignore-freshness-clock.test.ts
@@ -9,6 +9,7 @@ vi.mock("node:fs", async (importOriginal) => {
 
 import {
 	getProjectIgnoreMatcher,
+	isPathIgnoredByProject,
 	PROJECT_IGNORE_FRESHNESS_CADENCE_MS,
 } from "../../clients/file-utils.js";
 import { setupTestEnvironment } from "./test-utils.js";
@@ -124,6 +125,107 @@ describe("nested ignore freshness clock (#2071)", () => {
 			);
 
 			expect(sourceStats()).toBe(1);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("re-arms the shared clock after an unchanged check crosses a window", () => {
+		const env = setupTestEnvironment("pi-lens-2071-rearm-");
+		try {
+			const nested = path.join(env.tmpDir, "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			fs.writeFileSync(ignorePath, "generated.ts\n");
+
+			vi.useFakeTimers();
+			const start = Date.now();
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			matcher.isIgnored(path.join(nested, "seed.ts"));
+
+			// Cross the boundary. This check finds no drift, so it must stamp the
+			// entry with the CURRENT time. Without the re-arm the entry keeps its
+			// build time, every later call still reads as expired, and the
+			// per-file stat storm this PR removed comes straight back. The
+			// existing bounded-cost case never crosses a window, so it cannot see
+			// the difference.
+			vi.setSystemTime(start + PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
+
+			const statSpy = vi.spyOn(fs, "statSync");
+			const sourceStats = () =>
+				statSpy.mock.calls.filter(([filePath]) => filePath === ignorePath)
+					.length;
+			statSpy.mockClear();
+
+			// The first of these pays the one boundary-crossing stat. The other
+			// forty-nine are inside the window the re-arm just opened.
+			for (let index = 0; index < 50; index++) {
+				matcher.isIgnored(path.join(nested, `f${index}.ts`));
+			}
+
+			expect(sourceStats()).toBe(1);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("catches a same-size nested edit through the mtime axis", () => {
+		const env = setupTestEnvironment("pi-lens-2071-mtime-axis-");
+		try {
+			const nested = path.join(env.tmpDir, "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			// "aaa.ts" and "bbb.ts" are the same length, so only mtime separates
+			// these two rule sets. The #1105 cases pin the size axis by holding
+			// mtime fixed; this is the mirror, and without it the mtime comparison
+			// is removable with every test still green.
+			fs.writeFileSync(ignorePath, "aaa.ts\n");
+			const target = path.join(nested, "bbb.ts");
+
+			vi.useFakeTimers();
+			const start = Date.now();
+			const matcher = getProjectIgnoreMatcher(env.tmpDir);
+			expect(matcher.isIgnored(target)).toBe(false);
+
+			fs.writeFileSync(ignorePath, "bbb.ts\n");
+			expect(fs.statSync(ignorePath).size).toBe(7);
+			vi.setSystemTime(start + PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
+			// A fresh path in the same directory rebuilds the drifted entry and
+			// drops the subtree's verdicts with it.
+			matcher.isIgnored(path.join(nested, "other.ts"));
+
+			expect(matcher.isIgnored(target)).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("publishes a newly discovered nested source before the sweep that must see it", () => {
+		const env = setupTestEnvironment("pi-lens-2071-publish-order-");
+		try {
+			const nested = path.join(env.tmpDir, "package");
+			fs.mkdirSync(nested, { recursive: true });
+			const ignorePath = path.join(nested, ".gitignore");
+			fs.writeFileSync(ignorePath, "placeholder-keep\n");
+			const target = path.join(nested, "x.ts");
+
+			vi.useFakeTimers();
+			const start = Date.now();
+			// Lookup one consumes the nested source for the first time. There is
+			// no cache entry yet, so the source cannot be published until a later
+			// call.
+			expect(isPathIgnoredByProject(target, env.tmpDir)).toBe(false);
+
+			fs.writeFileSync(ignorePath, "*.ts\n");
+
+			// Lookup two lands one cadence later. Its sweep must see the source
+			// discovered by lookup one. With the publish AFTER the sweep, this
+			// sweep ran against a source list that did not yet contain the nested
+			// file, found no drift, and still reset the clock — so pickup took a
+			// second full window (measured: stale at 2 s and 3 s, fresh at 4 s).
+			vi.setSystemTime(start + PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
+
+			expect(isPathIgnoredByProject(target, env.tmpDir)).toBe(true);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/project-lens-ignore.test.ts
+++ b/tests/clients/project-lens-ignore.test.ts
@@ -1,10 +1,11 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createProjectIgnoreMatcher,
 	getProjectIgnoreMatcher,
+	PROJECT_IGNORE_FRESHNESS_CADENCE_MS,
 } from "../../clients/file-utils.js";
 import { resetProjectLensConfigCache } from "../../clients/project-lens-config.js";
 import {
@@ -21,6 +22,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	vi.useRealTimers();
 	removeTempDirSync(tmpDir);
 	resetProjectLensConfigCache();
 });
@@ -271,6 +273,12 @@ describe("ignore-matcher cache freshness (#1105 mtime+size)", () => {
 		fs.writeFileSync(nestedConfig, JSON.stringify({ ignore: ["skip-new/**"] }));
 		fs.utimesSync(nestedConfig, pinned, pinned);
 
+		// #2071: the nested rules and the verdicts derived from them now share one
+		// clock, so the gate re-checks at window expiry rather than per call. The
+		// size axis under test is unchanged; only when it is consulted moved.
+		vi.useFakeTimers();
+		vi.setSystemTime(Date.now() + PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
+
 		// Fresh paths → bypass patternMemo → hit the nested cache gate.
 		expect(matcher.isIgnored(path.join(subDir, "skip-new/y.ts"), false)).toBe(
 			true,
@@ -298,6 +306,10 @@ describe("ignore-matcher cache freshness (#1105 mtime+size)", () => {
 		// Shorter, different .gitignore; restore the SAME mtime.
 		fs.writeFileSync(nestedGitignore, "new-dir/\n");
 		fs.utimesSync(nestedGitignore, pinned, pinned);
+
+		// #2071: same shared clock as the .pi-lens.json case above.
+		vi.useFakeTimers();
+		vi.setSystemTime(Date.now() + PROJECT_IGNORE_FRESHNESS_CADENCE_MS + 1);
 
 		// Fresh paths → bypass patternMemo → hit the nested cache gate.
 		expect(matcher.isIgnored(path.join(subDir, "new-dir/y.ts"), false)).toBe(


### PR DESCRIPTION
## Summary

The project ignore matcher held two caches over the same nested ignore files, on
two different freshness disciplines. They now share one.

- `nestedCache` (`clients/file-utils.ts:361`) maps a directory to its nested
  `.gitignore` and `.pi-lens.json` patterns, gated on mtime and size. It
  re-checked on **every** `patternsForDir` call.
- `patternMemo` (`clients/file-utils.ts:471`) maps a path to its verdict. It was
  invalidated only by the write hook or by #2159's cadence sweep.

So after an external nested `.gitignore` edit, a path never queried before read
the new rules while an already memoized path replayed its old verdict. Two files
in one directory, governed by one rule, returned opposite answers from the same
matcher instance. That is #2071.

`patternsForDir` now works on one clock:

1. Inside `PROJECT_IGNORE_FRESHNESS_CADENCE_MS` the directory's rules are frozen
   and no stat runs. Every verdict computed **within one window** is derived
   from exactly those patterns, so two paths queried in the same window cannot
   disagree. This is within-window consistency, not a global guarantee: a walk
   long enough to cross a cadence flip still sees the old rules before the flip
   and the new ones after it, which is true on master too and is not something
   this PR changes.
2. At window expiry one stat decides. That single signature feeds both the cache
   gate and `rememberIgnoreSource`, which used to stat the same file again one
   line later.
3. On drift the directory's patterns are rebuilt and the verdicts under it are
   dropped in the same step. `invalidateSubtree` is split into
   `dropVerdictsUnder` plus the nested-entry eviction, so the rebuild can drop
   verdicts without evicting the entry it just wrote.

pi-authored `.gitignore` writes keep their instant path through
`invalidateProjectIgnoreMatcherForPath`. The cadence governs only edits pi-lens
did not make.

### Why this shape

The constant is the existing `PROJECT_IGNORE_FRESHNESS_CADENCE_MS`
(`clients/file-utils.ts:659`), not a new one. #2159 already established 2 s as
the accepted staleness bound for externally edited ignore sources at the root.
This extends that bound to nested sources rather than inventing a second policy.

The tradeoff, stated plainly: a path never queried before used to see a nested
edit immediately and now sees it within one cadence window. That buys verdicts
that agree with each other inside a window, and it removes a per-file stat
storm. The full reasoning and the alternative I rejected are in the plan comment
on [#2071](https://github.com/apmantza/pi-lens/issues/2071#issuecomment-5438483668).

"Within 2 s" is true only after the review-round fix below. As first pushed, the
bound at the `isPathIgnoredByProject` seam was up to **2x** cadence, because the
sweep ran before the block that publishes newly consumed nested sources. See
review round 1, S1.

### Measured

Synthetic fixture: 2000 files, 40 directories, depth 4, one root `.gitignore`
and one nested `.gitignore`. `statSync` is wrapped by a CJS preload before the
ESM namespace for `node:fs` is materialized, so the count is exact rather than
sampled. Run on Windows, both sides built from source.

| | statSync calls | per file | cold walk |
|---|---|---|---|
| `origin/master` 9640ac05 | 18,064 | 9.03 | 1,886.4 ms |
| this branch | 192 | 0.10 | 85-92 ms |

The stat count is deterministic across runs; the wall time is not, so it is
given as a range over three runs on an unloaded machine. A run taken during a
concurrent build measured 329 ms, which is machine contention rather than a
property of the change. Trust the stat count.

Warm walk is 0 stats on both sides, which answers #1976's open question about the
per-path memo: it is what makes the second visit free, so it is kept and
justified rather than deleted.

A CPU profile of the same fixture on master shows why the target moved. #1976's
compile memo (PR #2063) worked, and the freshness stats took minimatch's place at
the top of the profile:

```
  323.7ms  stat @ :-1
  114.0ms  rememberIgnoreSource @ clients/file-utils.js:254
  109.7ms  gitignoreSignature  @ clients/file-utils.js:470
    7.9ms  #matchGlobstar @ minimatch/index.js:660
```

Closes #2071. Closes #1976.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [x] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [x] area:project-intelligence
- [x] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (no dependency change)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there (no documented invariant changes; the cadence bound is #2159's, already recorded)
- [x] `.changelog/fix-2071-nested-ignore-clock.md` has one valid entry in this PR
- [x] Commit subject includes the issue number

## Tests

New file `tests/clients/nested-ignore-freshness-clock.test.ts`, four cases:

- *keeps two paths under one nested rule in agreement after an external edit* —
  the #2071 regression proof. It pins mutual consistency, not a fixed verdict,
  so it cannot be satisfied by freezing an answer.
- *drops subtree verdicts when a walk rebuilds drifted nested patterns* — pins
  the drift-to-invalidate wiring. It holds the matcher once, as a walk loop
  does, so the #2159 cadence sweep in `getProjectIgnoreMatcher` cannot be what
  makes it pass.
- *stats a nested ignore source once per cadence window, not once per file* —
  pins the bounded-cost criterion as a test, not only as a measurement.
- *reads the nested ignore source once per check instead of twice* — pins the
  duplicate-stat removal.

Edited `tests/clients/project-lens-ignore.test.ts`: the two #1105 cases
(*rebuilds nested .pi-lens.json patterns* and *rebuilds nested .gitignore
patterns on an mtime-preserving, length-changing edit*) now advance fake timers
past the cadence before their post-edit assertions. The invariant under test is
unchanged; only when the gate is consulted moved. M4 below proves the adaptation
did not weaken it.

AGENTS.md test-authoring screens: the consistency case avoids *wrong-layer pin*
by asserting through the public `isIgnored` seam rather than cache internals;
the two stat-count cases avoid *loose bound* by asserting exact counts (0 and 1)
rather than "fewer than before"; the drift case avoids *parallel path* by
holding the matcher instead of re-entering `getProjectIgnoreMatcher`, which
would have let a different mechanism satisfy it.

Red-first. All four proven red against `clients/file-utils.ts` at 9640ac05 with
the tests in place, rebuilt in between:

```
FAIL > keeps two paths under one nested rule in agreement after an external edit
AssertionError: expected true to be false
FAIL > drops subtree verdicts when a walk rebuilds drifted nested patterns
AssertionError: expected true to be false
FAIL > stats a nested ignore source once per cadence window, not once per file
AssertionError: expected 100 to be +0
FAIL > reads the nested ignore source once per check instead of twice
AssertionError: expected 2 to be 1
```

Mutation proof. Each new guard was neutered one at a time, rebuilt, and the
suite re-run:

| Mutation | Result |
|---|---|
| M1 remove `dropVerdictsUnder(dir)` on drift | RED: drops subtree verdicts when a walk rebuilds drifted nested patterns |
| M2 remove the cadence gate | RED: stats a nested ignore source once per cadence window, not once per file |
| M3 neuter the one-stat signature reuse | RED: reads the nested ignore source once per check instead of twice |
| M4 remove the #1105 nested size axis | RED: rebuilds nested .gitignore patterns on an mtime-preserving, length-changing edit |

Ran locally after `npm run build`: 11 targeted files, 127 tests passing (the new
file plus `project-ignore-freshness`, `project-lens-ignore`,
`nested-ignore-config`, `ignore-compile-memo`, `global-ignore`,
`ext-gate-before-ignore`, `source-filter-gitignore`,
`tracked-aware-ignore-matcher`, `scan-exclusion-stack`, `runtime-tool-result`).
9 governance files, 157 tests passing (`bounded-telemetry-sweep`,
`bus-producer-coverage`, `delivery-surface-ratchet`, `deps-centralization`,
`finding-delivery-gate`, `freshness-sweep`, `managed-tool-seam-coverage`,
`profiling-coverage`, `session-state-conformance`). `npm run lint`,
`npm run fmt:check`, `npm run changelog:check`, and `npm run depcruise:check`
all clean. The full suite is CI's job and has not run locally.

### Test assessment

- `tests/clients/nested-ignore-freshness-clock.test.ts` (new) — uniquely pins
  that the nested pattern cache and the path verdict memo share one clock. No
  existing file covers mutual consistency between two paths, and none asserts
  nested-source stat counts on a multi-path walk. Makes nothing redundant.
- `tests/clients/project-lens-ignore.test.ts` (edited) — uniquely pins the
  #1105 size axis on nested sources, plus the broader
  `createProjectIgnoreMatcher` and `collectSourceFiles` contracts. Its two
  edited cases remain the only coverage of the size axis: M4 above reds them and
  reds nothing in the new file, so they are not redundant with it.
- No removal candidates. I checked whether the new file's drift case subsumes
  `project-ignore-freshness.test.ts`'s ordering cases. It does not: those two
  exercise the `getProjectIgnoreMatcher` sweep path, mine deliberately avoids
  it, and M1 reds mine while leaving theirs green.

## Blast radius

`isIgnored` is the hot seam. Call sites reach it through
`isPathIgnoredByProject` or a held matcher: the source-file walk, the snapshot
walk at `clients/pipeline.ts:152`, the comment scan, knip, jscpd, the call
graph, the source filter, and `clients/dispatch/integration.ts`'s per-edit
cascade check. All of them get strictly fewer stats and the same verdicts,
except within a 2 s window after an external nested edit, where they now get a
consistent answer instead of two contradictory ones.

Hot-path cost delta, measured: cold walk 18,064 stats and 1,886 ms down to 192
stats and 85 ms over 2000 files. Warm walk unchanged at 0 stats. The cost moves
down, not up.

`buildProjectIgnoreMatcher` is internal to `clients/file-utils.ts`. The exported
surface is unchanged: `ProjectIgnoreMatcher.invalidateSubtree` keeps its
signature and its documented behavior, since `dropVerdictsUnder` is a private
split of its body and the public method still evicts the nested entry too.

No behavior widening. No new process spawn. No new failure path, so no new
degradation record. The one change a caller could notice is the 2 s pickup delay
for externally edited nested ignore files. `getProjectIgnoreMatcher`'s
root-level signature check is untouched and still runs per lookup, so root
`.gitignore` edits stay immediate.

## Observability

`~/.pi-lens/sessionstart.log` warmup phase duration and
`~/.pi-lens/word-index.log`'s `phaseDurationsMs.sourceWalkMs` on
`incremental_refresh` are the records that carry this change in production. The
source walk is the walk that paid this tax, so `sourceWalkMs` is the sharp one:
#1976's field evidence measured 1,048 to 3,025 ms on the 2,614-document pi-lens
corpus.

Named gap, honestly: I did not run a fresh field session, so I am not claiming a
field number. The numbers above are local fixture measurements. There is also no
record that would surface the *correctness* half. Neither log emits anything when
an ignore verdict changes, so a future recurrence of the divergence would be
silent in the logs. I am not adding a record for it in this PR, because a
per-verdict event on this path is exactly the kind of unbounded telemetry
AGENTS.md forbids on a hot seam, and a bounded one would need its own design.

## Class sweep

**Shape.** Catalog shape 6, freshness stamp missing a cross-file dependency, in
its two-caches form: a module holds a derived-data cache gated on a file
freshness signature, plus a second memo of results computed from that derived
data whose invalidation is not wired to the same gate. When the source changes,
one refreshes and the other serves a stale answer, and the two disagree.
Sub-shape, from #2016's family: a stable value derived twice on a hot path,
here `gitignoreSignature(dir)` followed one line later by
`rememberIgnoreSource` statting the same file again.

**Pattern sweep.** Swept the whole tree, `index.ts`, `clients/`, `tools/`,
`mcp/`, `scripts/`, for modules that hold an mtime or size freshness signature.
46 files qualify. The safe idiom, and the majority verdict, is *the signature is
part of the cache key*, so a drifted signature is a miss rather than a stale
hit. `clients/project-lens-config.ts:208-236` is the reference example:
`configCache` is keyed by config path and re-checked against
`configInfo.mtimeMs` and `.size` on every read, and no second memo derives from
it without re-keying. `clients/file-utils.ts`'s matcher could not use that idiom
because a path verdict depends on the signatures of N ancestor directories, not
one, which is precisely why it grew a second, unsynchronized discipline.

**Population sweep.** The family is the derived cache that sits downstream of a
freshness-gated cache. Three correct idioms exist in the tree. **A: put the
signature in the read check**, so a drifted source is a miss. **B: carry every
consumed signature** and revalidate all of them on read. **C: one shared clock
plus drift-triggered invalidation**, which this PR adds, for the case where B's
per-read revalidation is itself the hot-path cost.

| Member | file:line | Idiom | Verdict |
|---|---|---|---|
| `patternMemo` | `clients/file-utils.ts:471` | none, then C | **DEFECT, fixed here.** Verdicts derived from `nestedCache` with no shared invalidation. B was the obvious fix and is what caused the storm: revalidating N ancestor signatures per read costs 9 stats per file. |
| `nestedCache` | `clients/file-utils.ts:361` | A, now C | Was correct in isolation and wrong in company. Now on the same clock as `patternMemo`. |
| `rulesCache` / `blockingRulesCache` | `clients/dispatch/runners/yaml-rule-parser.ts:113-114` | broken A | **DEFECT, filed as #2262.** Gates on `statSync(ruleDir).mtimeMs` (`:225`) while its content-signature siblings at `:115-116` hash every rule file (`:205`). A content edit never bumps the directory mtime, and `findYamlRuleFiles` recurses (`:150`) while only the top directory is stat'ed. `clearRulesCache` (`:123`) has no production caller. |
| `startupScanContextCache` / `languageProfileCache` | `clients/startup-scan.ts:329`, `clients/language-profile.ts:129` | none | **DEFECT, filed as #2263.** Both derive from the topology index, both are process-lifetime with no freshness key, and `clients/runtime-session.ts:2132-2133` resets `resetWorkspaceTopology()` and `clearTsconfigPathsCache()` but not these. The `#806` comment at `:2126-2129` claims it covers "any consumer cache layered on top". |
| `compiledGlobs` | `clients/file-utils.ts:507` | n/a | Already correct at file:line. Context-free by construction, bounded by matcher lifetime, no source file behind it. |
| `projectIgnoreMatcherCache` | `clients/file-utils.ts:636` | A + #2159 sweep | Already correct at file:line. |
| `projectIgnoreGlobsCache` | `clients/file-utils.ts:833` | A | Already correct at file:line. |
| `configCache` | `clients/project-lens-config.ts:208` | A | Already correct at `:226` and `:324`. |
| `discoveryCache` | `clients/project-lens-config.ts:209` | B | Already correct at `:372`; revalidates every walked directory mtime. |
| `dirMarkerCache` | `clients/workspace-topology.ts:94` | A | Already correct at `:200`. |
| `walkCache` | `clients/workspace-topology.ts:103` | B | Already correct at `:292`. The closest sibling to the defect: same two-cache layering, but the outer result carries its sources' signatures. It can afford B because upward walks are rare; `isIgnored` cannot, because it runs per file. |
| `snapshotParseCache` | `clients/project-snapshot.ts:284` | A | Already correct at `:835`, mtime and size both. |
| `TreeSitterCache.cache` | `clients/tree-sitter-cache.ts:140` | A | Already correct at `:338`, `:342`. |
| `_cache` / `_trackedCache` / `_trackedSnapshot` | `clients/git-tracked-ignore.ts:125`, `:210`, `:219` | shared TTL | Already correct. All three on one 30 s TTL, evicted in lockstep at `:240-243`. |
| `cache` / `referencesCache` | `clients/review-graph/tsconfig-paths.ts:36-37` | A, signature in key | Already correct. A stale entry is unreachable, only evictable. |
| `_moduleSourceFilesMemo` | `clients/review-graph/workspace-modules.ts:507` | B + identity | Already correct at `:512-513`; bridges to the matcher's own discipline by object identity. |
| `headerVerdictMemo` | `clients/generated-artifacts.ts:207` | A, signature in key | Already correct. |
| `detectionCache` | `clients/formatters.ts:1547` | A | Already correct; signature recomputed per call, inner map dropped with it. |
| `ArtifactProbeCache` | `clients/source-filter.ts:70` | per-walk | Already correct. Explicitly forbidden from becoming module-global at `:38-68`. |

Filed: #2262 and #2263. I read both in source before filing; the quoted lines
above are from this checkout, not from the sweep's report.

Three further leads came out of the sweep that I did **not** verify in source
and am therefore not claiming as defects: `authoritativeSnapshots`
(`clients/project-snapshot.ts:336`, mtime-only `<=` test beside a sibling that
needs size too), `recentlyCleanNeighborCache`
(`clients/dispatch/integration.ts:490`, turn-count TTL over a
generation-invalidated index), and `_sizeSkipVerdicts`
(`clients/review-graph/builder.ts:1223`, 15-minute wall-clock TTL overriding a
signature-fresh graph, documented as intentional at `:1103-1106`). Recording
them here so they are not lost. They need reading before anyone files them.

**Sub-shape, the adjacent duplicate derivation.** `gitignoreSignature(dir)`
followed by `rememberIgnoreSource` re-statting the same file is fixed here. The
rest belongs to #2016 and is enumerated in the Remainder section below. The
sweep also surfaced two non-#2016 instances worth naming:
`clients/review-graph/tsconfig-paths.ts:182,185` takes two `statSync` calls on
one path for `isDirectory()` then `isFile()`, and `:276,287` parses the whole
extends chain for `dependencySignature` then re-reads and re-parses the same
files on the next line. Neither is on a per-file hot path, so neither is fixed
here.

**Consolidation verdict.** The family stays distributed. The safe members are
safe by idioms A and B, which cost nothing extra where they are used; folding
them onto a clock-bearing primitive would add a timer where a key suffices.
#2102 already proposes the timer-bearing-cache consolidation for the idle-evict
family, which is a different axis. The two filed defects are both cases of a
member using the wrong idiom for its seam, not evidence that the idioms should
merge.

## Merge order

There are 20 open PRs, not one as this section previously said. I re-checked
by listing every open PR's changed files: none of them touches
`clients/file-utils.ts` except this one. The conclusion is unchanged, only the
count was wrong. No merge-order constraint.

## Remainder

This PR closes #2071 and #1976. It does not touch #2016, whose remaining members
live in `clients/dispatch/dispatcher.ts`, `clients/lsp-mutation.ts`, and
`clients/cache-manager.ts`. Those are a separate PR on separate files. The
duplicate `rememberIgnoreSource` stat fixed here is a member of #2016's class on
this seam, and is recorded as such rather than counted against that issue's own
acceptance criteria.

## Review round 1

The reviewer reproduced the parent-edit repro on master and on this branch and
re-measured the walk at roughly 77x fewer stats. No behavior change was asked
for beyond S1. Dispositions:

| Finding | Disposition |
|---|---|
| T1 MED: `cached.checkedAtMs = now` was load-bearing but unpinned | Fixed with a test. Reproduced first: deleting the line left all tests green while the stat storm returned. No existing case crossed a cadence boundary, so none could see it. The new case does, and deleting the re-arm now reds it. |
| S1 MED: the stated pickup bound was 2x off | Fixed in code, which the reviewer preferred over rewording. The publish block moved above the sweep. |
| T2 LOW: the mtime axis of the nested gate was removable with all green | Fixed with a test. The #1105 cases pin the size axis by holding mtime fixed; the new case is the mirror, a same-size edit that only mtime separates. |
| T3/T4 LOW: body said one other open PR, and cited master-relative line numbers | Fixed above. 20 open PRs; I listed each one's changed files and none but this touches `clients/file-utils.ts`. Line numbers are now branch-relative. |
| S2 not blocking: "two paths cannot disagree" is false across a cadence flip | Narrowed to within-window consistency in the Summary. |
| FILE: the `authoritativeSnapshots` lead was real | Filed as #2285 after reading it in source. |

## Review round 2

One finding, on my own test rather than on the fix.

| Finding | Disposition |
|---|---|
| F1 MED: the T2 case is flaky on Windows and invisible on Linux CI | Fixed. Reproduced first, then applied the reviewer's exact remedy. |

The T2 case holds size constant so that mtime is the only axis able to carry the
edit, then trusted the clock to tick between the two writes. Two same-size
writes land in one coarse mtime bucket **181 of 200 times** back to back on this
Windows box. The real case does enough work between the writes to usually escape
the bucket, which is worse than always failing: it failed **1 of 15** unmutated
runs here, matching the reviewer's 2 of 15 and 4 of 12. Linux CI would never
show it.

The fix pins the mtime with `utimesSync` rather than trusting the clock, which
mirrors the #1105 cases: they pin mtime to isolate the size axis, this pins it
to isolate the mtime axis.

```
before the pin   unmutated T2 over 15 runs: pass=14 fail=1
after the pin    unmutated T2 over 12 runs: pass=12 fail=0
mutation (mtime axis removed), after the pin: RED in 5/5 runs
```

The mutation now reds deterministically instead of probabilistically, so the
guard is stronger than before the flake was found, not merely quieter.

Re-ran after this round: 21 files, 288 tests passing. `npm run lint`,
`npm run fmt:check`, and `npm run changelog:check` clean. Unit tests passed on
the previous head `479ed66a` (job 98547925592) and are re-running on this one.

### S1 in detail

A nested source is consumed while a previous lookup computes a verdict, and it
can only be published into `cached.ignoreSources` on a **later** call. With the
publish after the sweep, the sweep never saw a source during the window in which
it was discovered, yet still reset `lastIgnoreFreshnessCheckMs`. The first sweep
that could see it therefore ran a full cadence later.

Measured at the `isPathIgnoredByProject` seam, edit after the discovery lookup:

```
before the move   t=2s ignored=false   t=3s ignored=false   t=4s ignored=true
after the move    t=2s ignored=true    t=3s ignored=true    t=4s ignored=true
```

Moving the publish earlier cannot let a walk overwrite a pre-edit baseline: that
guard is the `known` set, which pushes only previously unseen sources, and it
does not depend on the ordering. The four #2159 ordering tests that exist to
protect that baseline stay green.

### Review-round mutation proof

| Mutation | Result |
|---|---|
| T1 delete `cached.checkedAtMs = now` | RED: re-arms the shared clock after an unchanged check crosses a window |
| T2 remove the mtime axis from the nested gate | RED: catches a same-size nested edit through the mtime axis |
| S1 move the publish block back below the sweep | RED: publishes a newly discovered nested source before the sweep that must see it |

Each mutation reds exactly one case, so the three new tests do not overlap.

Re-ran after the round: 21 files, 288 tests passing (the 11 targeted ignore
files plus the sweep-floor meta-sweep and the nine governance suites).
`npm run lint`, `npm run fmt:check`, and `npm run changelog:check` clean.

*This pull request is AI-generated, with the maintainer supervising the process.*
