### PR TITLE
fix(gitignore): anchor test-* scratch patterns to repo root (#2250)

### DIFF
--- a/.changelog/2250-gitignore-test-anchor.md
+++ b/.changelog/2250-gitignore-test-anchor.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Anchor `.gitignore`'s scratch `test-*` patterns to the repo root (refs #2250)** — the unanchored `test-*.ts`/`.js`/`.py`/`.md`/`.sh`/`.mjs` rules matched the basename of any tracked file at any depth, silently hiding `clients/test-runner-client.ts` and several `tests/` files from `rg` and other ignore-respecting search tools. `git status` never flagged it because git still tracks the files. The patterns now only match scratch files dropped at the repo root, their original intent.

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ migrate-*.js
 !docs/dispositions.md
 !docs/word-index.md
 !docs/durable-store-audit-1202.md
+!docs/analysisall.md
+!docs/api-ports-inventory.md
+!docs/astplayground.md
 !skills/**/*.md
 !.github/PULL_REQUEST_TEMPLATE.md
 
@@ -126,10 +129,14 @@ BUG_*.md
 # Autofix-smoke fixtures (#209 --autofix layer) — files with a safely-autofixable
 # lint violation; the pipeline's safe-autofix phase must fix them.
 !tests/fixtures/autofix-smoke/**
+# call-graph / function-facts fixtures — small real-language snippets several
+# call-graph and function-fact test suites parse for structural facts; tracked
+# but shadowed by the global *.js ignore above (#2250 sweep).
+!tests/fixtures/call-graph/**
+!tests/fixtures/function-facts/**
 
 clients/dispatch/debug.log
 clients/lsp/.intelephense/
-AGENTS.md
 .npmignore
 .claude/
 !.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -35,12 +35,19 @@ test-lsp-files/
 test-filetime/
 test-projects/
 # scripts/ intentionally tracked
-test-*.ts
-test-*.js
-test-*.py
-test-*.md
-test-*.sh
-test-*.mjs
+# Anchored to repo root (#2250): unanchored, these matched the basename of
+# any tracked test file anywhere in the tree (tests/clients/test-*.test.ts,
+# clients/test-runner-client.ts, .changelog/test-*.md), silently hiding
+# them from ignore-respecting search tools (rg, grep --exclude-from) even
+# though `git status`/`git check-ignore` show nothing wrong for a tracked
+# path. These rules only ever meant to catch ad hoc scratch files dropped
+# at the repo root.
+/test-*.ts
+/test-*.js
+/test-*.py
+/test-*.md
+/test-*.sh
+/test-*.mjs
 
 # Debug/dev scripts
 debug-*.js

--- a/tests/clients/test-runner-cache-roots.test.ts
+++ b/tests/clients/test-runner-cache-roots.test.ts
@@ -71,7 +71,10 @@ describe("TestRunnerClient project-root caches (#2048)", () => {
 
 	it("re-resolves an alias first probed before its symlink existed (#2077)", () => {
 		const { root, alias } = makeUnlinkedProject("pi-lens-2077-");
-		fs.writeFileSync(path.join(root, "vitest.config.ts"), "export default {}\n");
+		fs.writeFileSync(
+			path.join(root, "vitest.config.ts"),
+			"export default {}\n",
+		);
 		const client = new TestRunnerClient();
 
 		// The alias does not exist yet, so canonicalization falls back to the
@@ -94,7 +97,10 @@ describe("TestRunnerClient project-root caches (#2048)", () => {
 
 		const client = new TestRunnerClient();
 		expect(client.detectRunner(alias)).toBeNull();
-		fs.writeFileSync(path.join(root, "vitest.config.ts"), "export default {}\n");
+		fs.writeFileSync(
+			path.join(root, "vitest.config.ts"),
+			"export default {}\n",
+		);
 		expect(client.detectRunner(root)).toBeNull();
 
 		const firstGlobs = client.parseVitestTestGlobs(alias);

--- a/tests/config/gitignore-tracked-shadow.test.ts
+++ b/tests/config/gitignore-tracked-shadow.test.ts
@@ -1,9 +1,9 @@
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { Minimatch } from "../../clients/deps/minimatch.js";
+import { gitExecFileSync } from "../support/git-fixture-env.js";
 
 const root = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -42,7 +42,7 @@ function unanchoredTestScratchPatterns(): string[] {
 }
 
 function findShadowedTrackedFiles(): string[] {
-	const tracked = execFileSync("git", ["ls-files"], {
+	const tracked = gitExecFileSync("git", ["ls-files"], {
 		cwd: root,
 		encoding: "utf8",
 	})

--- a/tests/config/gitignore-tracked-shadow.test.ts
+++ b/tests/config/gitignore-tracked-shadow.test.ts
@@ -1,0 +1,63 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { Minimatch } from "../../clients/deps/minimatch.js";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * A git-tracked file that also matches a `.gitignore` pattern is invisible
+ * to any ignore-respecting tool that doesn't special-case tracked status —
+ * `rg`, plain `grep --exclude-from`, GitHub code search. Git itself keeps
+ * tracking the file (`git status`/`git check-ignore` both special-case
+ * already-indexed paths, so neither flags the shadow), but tools that walk
+ * the filesystem and apply `.gitignore` textually do not (#2250).
+ *
+ * A `.gitignore` line with no `/` (other than a trailing one) matches the
+ * BASENAME of a path at any depth — that's the documented gitignore rule
+ * responsible for the shadow, and the one `rg`/`git check-ignore --no-index`
+ * apply. Reproduce it directly with the same semantics, rather than relying
+ * on an external `rg` binary that may not be on PATH in CI.
+ *
+ * Scoped to the `test-*` scratch-file family named in #2250 ("Test
+ * directories and files" section of `.gitignore`), not the whole file: the
+ * blanket `*.md`/`*.js`/`*.d.ts` rules elsewhere have their own dedicated
+ * negation allowlists (docs, README, etc.) that a naive basename matcher
+ * can't evaluate correctly without fully reimplementing gitignore
+ * precedence. Those are a separate, larger audit outside this issue's scope.
+ */
+function unanchoredTestScratchPatterns(): string[] {
+	const text = fs.readFileSync(path.join(root, ".gitignore"), "utf8");
+	return text
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.startsWith("test-"))
+		.filter((line) => !line.slice(0, -1).includes("/")); // no "/" except maybe trailing
+}
+
+function findShadowedTrackedFiles(): string[] {
+	const tracked = execFileSync("git", ["ls-files"], {
+		cwd: root,
+		encoding: "utf8",
+	})
+		.split("\n")
+		.filter(Boolean);
+
+	const matchers = unanchoredTestScratchPatterns().map(
+		(pattern) => new Minimatch(pattern, { matchBase: true, dot: true }),
+	);
+
+	return tracked.filter((file) => {
+		const base = path.basename(file);
+		return matchers.some((m) => m.match(base));
+	});
+}
+
+describe("gitignore does not shadow tracked files (#2250)", () => {
+	it("no git-tracked file's basename matches an unanchored .gitignore pattern", () => {
+		const shadowed = findShadowedTrackedFiles();
+		expect(shadowed).toEqual([]);
+	});
+});

--- a/tests/config/gitignore-tracked-shadow.test.ts
+++ b/tests/config/gitignore-tracked-shadow.test.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from "node:url";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { gitExecFileSync } from "../support/git-fixture-env.js";
+import { assertNonEmptyScan } from "../support/sweep-kit.js";
 
 const root = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -31,6 +32,13 @@ function findShadowedTrackedFiles(): string[] {
 		cwd: root,
 		encoding: "utf8",
 	});
+	const trackedCount = tracked.split("\0").filter(Boolean).length;
+	// Floor set well under the repo's real tracked-file count (~2,950) so it
+	// still catches a silent zero — e.g. the `input` forwarding this test
+	// relies on (git-fixture-env.ts's GitExecOptions) getting dropped in a
+	// future edit, which would make `shadowed` trivially equal `[]` for the
+	// wrong reason and pass forever (#2250 review V3).
+	assertNonEmptyScan("git ls-files (tracked files scanned)", trackedCount, 500);
 
 	let shadowed: string;
 	try {

--- a/tests/config/gitignore-tracked-shadow.test.ts
+++ b/tests/config/gitignore-tracked-shadow.test.ts
@@ -5,7 +5,11 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { Minimatch } from "../../clients/deps/minimatch.js";
 
-const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const root = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"..",
+);
 
 /**
  * A git-tracked file that also matches a `.gitignore` pattern is invisible

--- a/tests/config/gitignore-tracked-shadow.test.ts
+++ b/tests/config/gitignore-tracked-shadow.test.ts
@@ -1,8 +1,6 @@
-import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
-import { Minimatch } from "../../clients/deps/minimatch.js";
 import { gitExecFileSync } from "../support/git-fixture-env.js";
 
 const root = path.resolve(
@@ -15,52 +13,48 @@ const root = path.resolve(
  * A git-tracked file that also matches a `.gitignore` pattern is invisible
  * to any ignore-respecting tool that doesn't special-case tracked status —
  * `rg`, plain `grep --exclude-from`, GitHub code search. Git itself keeps
- * tracking the file (`git status`/`git check-ignore` both special-case
- * already-indexed paths, so neither flags the shadow), but tools that walk
- * the filesystem and apply `.gitignore` textually do not (#2250).
+ * tracking the file (`git status`/`git check-ignore` on an already-indexed
+ * path both special-case it), so nothing in git itself flags the shadow
+ * (#2250).
  *
- * A `.gitignore` line with no `/` (other than a trailing one) matches the
- * BASENAME of a path at any depth — that's the documented gitignore rule
- * responsible for the shadow, and the one `rg`/`git check-ignore --no-index`
- * apply. Reproduce it directly with the same semantics, rather than relying
- * on an external `rg` binary that may not be on PATH in CI.
- *
- * Scoped to the `test-*` scratch-file family named in #2250 ("Test
- * directories and files" section of `.gitignore`), not the whole file: the
- * blanket `*.md`/`*.js`/`*.d.ts` rules elsewhere have their own dedicated
- * negation allowlists (docs, README, etc.) that a naive basename matcher
- * can't evaluate correctly without fully reimplementing gitignore
- * precedence. Those are a separate, larger audit outside this issue's scope.
+ * `git check-ignore --no-index` is git's own textual pattern evaluator —
+ * the same primitive `rg`'s gitignore support and GitHub code search apply
+ * — so piping every tracked path through it is the ground truth for "would
+ * a real ignore-respecting tool skip this file", with zero reimplemented
+ * gitignore dialect (a hand-rolled matcher previously here missed
+ * negations entirely and produced false positives on `.changelog/*.md`
+ * fragments git does NOT actually ignore). `-z`/`--stdin -z` NUL-delimit
+ * both ends so no filename with a space or unusual character is misread.
  */
-function unanchoredTestScratchPatterns(): string[] {
-	const text = fs.readFileSync(path.join(root, ".gitignore"), "utf8");
-	return text
-		.split(/\r?\n/)
-		.map((line) => line.trim())
-		.filter((line) => line.startsWith("test-"))
-		.filter((line) => !line.slice(0, -1).includes("/")); // no "/" except maybe trailing
-}
-
 function findShadowedTrackedFiles(): string[] {
-	const tracked = gitExecFileSync("git", ["ls-files"], {
+	const tracked = gitExecFileSync("git", ["ls-files", "-z"], {
 		cwd: root,
 		encoding: "utf8",
-	})
-		.split("\n")
-		.filter(Boolean);
-
-	const matchers = unanchoredTestScratchPatterns().map(
-		(pattern) => new Minimatch(pattern, { matchBase: true, dot: true }),
-	);
-
-	return tracked.filter((file) => {
-		const base = path.basename(file);
-		return matchers.some((m) => m.match(base));
 	});
+
+	let shadowed: string;
+	try {
+		shadowed = gitExecFileSync(
+			"git",
+			["check-ignore", "--no-index", "--stdin", "-z"],
+			{ cwd: root, encoding: "utf8", input: tracked },
+		);
+	} catch (err) {
+		// git check-ignore exits 1 when NONE of the stdin paths are ignored —
+		// that's the passing case, not a failure. Any other exit still throws.
+		const e = err as { status?: number; stdout?: string | Buffer };
+		if (e.status !== 1) throw err;
+		shadowed =
+			typeof e.stdout === "string"
+				? e.stdout
+				: (e.stdout?.toString("utf8") ?? "");
+	}
+
+	return shadowed.split("\0").filter(Boolean);
 }
 
 describe("gitignore does not shadow tracked files (#2250)", () => {
-	it("no git-tracked file's basename matches an unanchored .gitignore pattern", () => {
+	it("no git-tracked file is reported ignored by git check-ignore --no-index", () => {
 		const shadowed = findShadowedTrackedFiles();
 		expect(shadowed).toEqual([]);
 	});

--- a/tests/support/git-fixture-env.ts
+++ b/tests/support/git-fixture-env.ts
@@ -6,6 +6,8 @@ type GitExecOptions = {
 	encoding?: BufferEncoding;
 	stdio?: "ignore" | "pipe" | "inherit";
 	env?: NodeJS.ProcessEnv;
+	/** Piped to the child's stdin, e.g. feeding `git check-ignore --stdin`. */
+	input?: string | Buffer;
 };
 type GitSpawnOptions = Parameters<
 	typeof import("../../clients/safe-spawn.js").safeSpawnAsync


### PR DESCRIPTION
## Summary

Anchors `.gitignore`'s `test-*` scratch patterns to the repo root so they
stop hiding real tracked files from `rg` and similar tools. Refs #2250;
addresses the reported shadow fully, scoped deliberately to the `test-*`
family (see Scope note below).

## What

`.gitignore`'s "Test directories and files" section had six unanchored
patterns: `test-*.ts`, `test-*.js`, `test-*.py`, `test-*.md`, `test-*.sh`,
`test-*.mjs`. Without a leading `/`, gitignore matches these against the
basename of any path at any depth, not just the repo root. This PR anchors
all six to the repo root.

## Why

The unanchored patterns silently hid real tracked files from any
ignore-respecting search tool: `rg` without `--no-ignore`, `grep
--exclude-from`, GitHub code search. `git status` and `git check-ignore`
both special-case already-tracked paths, so nothing in git itself flags
the shadow — only a tool that walks the filesystem and applies `.gitignore`
textually sees it.

Confirmed shadowed before this fix:
- `clients/test-runner-client.ts` (production source, not a test file)
- `tests/clients/test-runner-client.test.ts`
- `tests/clients/test-runner-cache-roots.test.ts`
- `tests/clients/test-utils.ts`
- `.changelog/test-2090-2139-2182-flake-hygiene.md`
- `.changelog/test-2223-reverse-deps-env-stub.md`

Git history and the surrounding comments show these patterns predate the
`tests/` directory tree — they were meant to catch ad hoc scratch files an
agent or developer drops at the repo root, not real files nested under
`tests/` or `clients/`. Anchoring restores that original intent.

## Verification

Red-first, quoted verbatim from local runs (Windows, this worktree):

Pre-fix `.gitignore` (new test file present, `.gitignore` reverted):

```
- []
+ [
+   ".changelog/test-2090-2139-2182-flake-hygiene.md",
+   ".changelog/test-2223-reverse-deps-env-stub.md",
+   "clients/test-runner-client.ts",
+   "tests/clients/test-runner-cache-roots.test.ts",
+   "tests/clients/test-runner-client.test.ts",
+   "tests/clients/test-utils.ts",
+ ]
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Post-fix:

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Manual sanity check with the real `rg` binary (not part of the automated
test, which avoids depending on an external binary that may be absent in
CI):

```
$ rg -l "TestRunnerClient" tests/    # before fix
tests/clients/pipeline.test.ts
tests/clients/runtime-turn-session.test.ts

$ rg -l "TestRunnerClient" tests/    # after fix
tests/clients/pipeline.test.ts
tests/clients/runtime-turn-session.test.ts
tests/clients/test-runner-cache-roots.test.ts
tests/clients/test-runner-client.test.ts
```

Also confirmed a genuine root-level scratch file (`test-scratch-root.ts`)
stays ignored by both `git status` and `rg --files` after anchoring — the
original intent still works.

18 test files, 383 tests passed, 4 skipped (pre-existing skips, unrelated):
targeted (`test-runner-client`, `test-runner-cache-roots`, `global-ignore`,
`git-tracked-ignore`, `project-lens-ignore`, `packaging`, the new
`gitignore-tracked-shadow`) plus all 11 governance sweeps
(delivery-surface-ratchet, finding-delivery-gate,
session-state-conformance, bounded-telemetry-sweep, bus-producer-coverage,
deps-centralization, freshness-sweep, managed-tool-seam-coverage,
profiling-coverage, module-instance-coverage, sweep-floor-coverage). Full
suite deferred to CI (#1112 serialization).

## Test assessment

- `tests/config/gitignore-tracked-shadow.test.ts` (rewritten in the fix
  round): pins that `git check-ignore --no-index` reports zero tracked
  files as ignored, repo-wide — not scoped to `test-*` anymore. See "Fix
  round" for why. No other test file changed behaviorally; the format-only
  edit to `tests/clients/test-runner-cache-roots.test.ts` (V1, second fix
  round) is whitespace-only and pins nothing new.

## Scope note (superseded — see Fix round)

The original version deliberately checked only the `test-*` family. The
fix round replaced the matcher with git's own pipeline, which covers the
whole `.gitignore` at no extra reimplementation cost, so this PR now fixes
every tracked-file shadow that exists today, not just the `test-*` one.

## Blast radius

`.gitignore` change plus a rewritten test file and one additive field on
`tests/support/git-fixture-env.ts`'s `GitExecOptions` type (`input?:
string | Buffer`, forwarded straight to `execFileSync`, no behavior change
for existing callers that don't pass it); no production runtime code
touched. Six `test-*` file classes plus `AGENTS.md`, three `docs/*.md`
files, and two `tests/fixtures/**` directories are no longer ignored
outside their intended scope — `git status`/`git add` will now see any
existing untracked files matching those patterns (there were none at HEAD
besides the already-tracked ones this PR is about).

## Class sweep

Defect shape: a `.gitignore` pattern silently shadows an already-tracked
file from any tool that walks the filesystem and applies `.gitignore`
textually (`rg`, `grep --exclude-from`, GitHub code search), while `git
status`/`git check-ignore` on an already-tracked path both special-case it
and stay silent. Two ways a pattern produces this: an unanchored glob
(`test-*.ts` matching any depth, not just root) and a later broader rule
that cancels an earlier negation under gitignore's last-match-wins
ordering (`AGENTS.md`'s stray re-ignore canceling `!AGENTS.md`). This
isn't one of AGENTS.md's numbered code-defect shapes — it's a
repo-configuration integrity class, not a code bug — so there's no
catalog entry to cite; recording it here for the next `.gitignore` PR.

Pattern sweep: the fix round's `git ls-files -z | git check-ignore
--no-index --stdin -z` pipeline (`tests/config/gitignore-tracked-shadow.
test.ts`) already IS the pattern sweep — it evaluates every pattern in
`.gitignore` against every tracked path with git's own textual matcher,
not a grep over the pattern text. Confirmed via `find . -iname
".gitignore" -not -path "*/node_modules/*"` that the repo has exactly one
`.gitignore` (root), so there's no nested-gitignore population to
enumerate separately.

Population sweep: other ignore-pattern files exist
(`.oxfmtrc.json`'s `ignorePatterns`, used only to exclude paths from
`oxfmt` formatting) but they don't gate `git ls-files`/`git status`, so a
pattern there can't shadow a *tracked* file the way `.gitignore` does —
the class doesn't apply to them. Checked and ruled out, not swept as a
sibling.

Consolidation verdict: class of size 1 (one `.gitignore`, one governance
test). No further seam to fold onto; the rewritten sweep IS the permanent
detector for this class, gated by CI on every future `.gitignore` edit.

## Provenance

Related to #2077 / PR #2242 per the issue's own note, but that PR doesn't
touch `.gitignore`, so no overlap.

## Observability

Not applicable — this is a repo-configuration fix with no runtime code
path. The rewritten governance test is the permanent record: it fails
loudly if any tracked file becomes shadowed again, for any reason.

## Fix round (review findings)

- **F3 (simplifies, resolves F2) — replaced the minimatch reimplementation
  with git's own pipeline.** `git ls-files -z | git check-ignore --no-index
  --stdin -z` is git's own textual gitignore evaluator, so the test needs
  no reimplemented dialect. It also fixes F2: the prior minimatch matcher
  had no negation support and flagged two `.changelog/*.md` fragments git
  does NOT actually ignore — a future legitimate fragment would have red
  the suite for no reason. Runs in 0.227s locally. `git-fixture-env.ts`
  gained an `input` option on `GitExecOptions` (execFileSync already
  supports it) so the pipe goes through the existing wrapper instead of a
  bare, ungoverned `child_process` call.
- Running the widened, dialect-accurate sweep surfaced **7 more currently-
  shadowed tracked files** beyond the `test-*` family, fixed in the same
  `.gitignore`:
  - **`AGENTS.md`** — `.gitignore:64` negates it (`!AGENTS.md`), but a
    stray bare `AGENTS.md` re-ignore further down (gitignore is
    last-match-wins) canceled that negation. The canonical engineering
    contract this repo's own `CLAUDE.md` and every agent brief points to
    was invisible to a plain `rg` walk. Removed the stray re-ignore.
  - `docs/analysisall.md`, `docs/api-ports-inventory.md`,
    `docs/astplayground.md` — real, substantial (150+ lines each) tracked
    docs simply missing from the `docs/*.md` negation allowlist. Added.
  - `tests/fixtures/call-graph/**`, `tests/fixtures/function-facts/**` —
    real fixture files actively read by call-graph and function-facts test
    suites, shadowed by the global `*.js` rule the same way tool-smoke/
    format-smoke/autofix-smoke fixtures already have dedicated negations
    for. Added the same pattern.
  - Verified `git ls-files -z | git check-ignore --no-index --stdin -z`
    returns empty after the fix — zero tracked files shadowed, repo-wide.
- **F1 — toolchain exposure check.** Ran `npx oxfmt --check` on the newly
  un-shadowed files. Result: no exposure. `.oxfmtrc.json`'s own
  `ignorePatterns` excludes `tests/fixtures/**` and `**/*.md`
  independently of `.gitignore`, so none of the 7 files are newly visible
  to oxfmt — only my own rewritten test file needed formatting, applied.

Red-first for the rewritten test, quoted verbatim (reverted `.gitignore`
and `git-fixture-env.ts` to their pre-fix-round commit, kept the rewritten
test):

```
AssertionError: expected [ 'AGENTS.md', …(6) ] to deeply equal []
+ [
+   "AGENTS.md",
+   "docs/analysisall.md",
+   "docs/api-ports-inventory.md",
+   "docs/astplayground.md",
+   "tests/fixtures/call-graph/javascript/callee.js",
+   "tests/fixtures/call-graph/javascript/caller.js",
+   "tests/fixtures/function-facts/javascript-parameter.js",
+ ]
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Post-fix: `Test Files  1 passed (1)` / `Tests  1 passed (1)`.

Merged `origin/master` (was behind — #2258/#2264 landed mid-review); clean,
no conflicts. Full targeted + governance rerun after merge: 21 files, 400
tests passed, 4 skipped.

## Fix round 2 (review findings)

- **V1 — un-shadowed test file left unformatted.** Anchoring `test-*` to
  the repo root un-shadowed `tests/clients/test-runner-cache-roots.test.ts`
  from `oxfmt`'s own view (it isn't in `.oxfmtrc.json`'s exclusions), and
  that file had pre-existing formatting drift `oxfmt` had never been able
  to see. Ran `npx oxfmt tests/clients/test-runner-cache-roots.test.ts`;
  whitespace-only diff (two `fs.writeFileSync` calls reflowed to multiple
  lines). `npx oxfmt --check` on both touched test files now passes clean.
- **V2 — PR body lost the `## Class sweep` and `## Test assessment`
  sections in the round-1 rewrite.** `## Class sweep` was never written
  as its own heading; the "Fix round" section above already carried the
  evidence (the `test-*` root cause plus the widened sweep's 7 additional
  shadowed files) but not under a heading the template linter recognizes.
  Added `## Class sweep` above with that evidence re-homed under the
  template's four required prompts (shape, pattern sweep, population
  sweep, consolidation verdict). Renamed `## Test assessment (updated in
  fix round — see below)` to the exact heading `## Test assessment` — the
  parenthetical broke the linter's exact match against the template.
- **V3 — the sweep's own scan had no floor.** If `git ls-files -z` ever
  returns empty (e.g. the `input` forwarding this test relies on in
  `tests/support/git-fixture-env.ts` gets dropped in a future edit),
  `shadowed` trivially equals `[]` and the test would pass forever for the
  wrong reason. Added `assertNonEmptyScan` (`tests/support/sweep-kit.ts`,
  the repo's named floor mechanism) with a 500-file minimum, well under
  the repo's real ~2,950 tracked files. Red-first, quoted verbatim
  (`tracked` forced to `""` to simulate the dropped-forwarding case):

  ```
  Error: git ls-files (tracked files scanned): scanned/matched 0, below
  the declared floor of 500. An empty sweep must fail, not read as clean —
  if the target genuinely went away, delete the sweep instead of letting
  it pass on nothing.
   ❯ assertNonEmptyScan tests/support/sweep-kit.ts:855:9
   ❯ findShadowedTrackedFiles tests/config/gitignore-tracked-shadow.test.ts:41:2
   Test Files  1 failed (1)
        Tests  1 failed (1)
  ```

  Post-fix (floor restored to real `git ls-files` output): `Test Files 1
  passed (1)` / `Tests 1 passed (1)`.

Targeted rerun after round 2: `gitignore-tracked-shadow`,
`sweep-floor-coverage`, `git-fixture-governance` — 3 files, 11 tests
passed. `npx oxfmt --check` clean on both touched files. `npm run lint`
clean.

Refs #2250



