### PR TITLE
test(word-index): work-count occupancy guard, restore lane cap (closes #2254)

### DIFF
--- a/.changelog/2254-occupancy-work-count.md
+++ b/.changelog/2254-occupancy-work-count.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Convert the word-index per-edit occupancy guard to a load-invariant work count (refs #2254)** — the per-edit seam's occupancy bound was a wall-clock max-block over a 401-document fixture with `retry: 2`, so it was both flaky and a noisy neighbour in the timing-sensitive test lane. It now asserts the seam's cooperative replacement reads the clock a number of times bounded by the old document's distinct tokens, not by the posting elements it walks, which is deterministic and invariant to runner load. The guard leaves the timing-sensitive lane, and that lane returns to `maxWorkers: 2` now that its one heavy neighbour is gone. The shared `countClockReads` helper moves to `tests/support/perf-harness.ts` so the incremental test and the seam test read one implementation.

--- a/tests/clients/word-index-incremental.test.ts
+++ b/tests/clients/word-index-incremental.test.ts
@@ -6,7 +6,7 @@
  * from-scratch `buildWordIndex` over the same final corpus.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
 	buildWordIndex,
 	deserializeWordIndex,
@@ -19,6 +19,7 @@ import {
 	type WordIndex,
 	wordIndexPostingHits,
 } from "../../clients/word-index.js";
+import { countClockReads } from "../support/perf-harness.js";
 
 // --- Basic primitive behavior --------------------------------------------------
 
@@ -482,18 +483,6 @@ describe("cooperative removal staging counts the clock per token (#2067)", () =>
 			total += index.postings.get(token)?.length ?? 0;
 		}
 		return total;
-	}
-
-	async function countClockReads(
-		work: () => Promise<unknown>,
-	): Promise<number> {
-		const spy = vi.spyOn(performance, "now");
-		try {
-			await work();
-			return spy.mock.calls.length;
-		} finally {
-			spy.mockRestore();
-		}
 	}
 
 	it("stages a removal with clock reads bounded by tokens, not postings", async () => {

--- a/tests/clients/word-index-per-edit.test.ts
+++ b/tests/clients/word-index-per-edit.test.ts
@@ -15,7 +15,7 @@ import {
 	WORD_INDEX_MAX_BYTES,
 	wordIndexPostingHits,
 } from "../../clients/word-index.js";
-import { measureMaxSyncBlockMs } from "../support/perf-harness.js";
+import { countClockReads } from "../support/perf-harness.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
 const mocks = vi.hoisted(() => ({
@@ -214,76 +214,80 @@ describe("computeCascadeForFile — word-index per-edit seam (#348 phase 2)", ()
 		}
 	});
 
-	it(
-		"never holds the event loop for the whole replacement (#2067 AC4)",
-		{ retry: 2, timeout: 120_000 },
-		async () => {
-			const env = setupTestEnvironment("word-index-per-edit-occupancy-");
-			try {
-				// Few distinct tokens, many characters: the yieldable halves (posting
-				// scan, tokenization) dominate, and the atomic publish — which cannot
-				// yield and never could — stays small, so the measurement is about the
-				// occupancy this change owns.
-				const body = (tag: string, lines: number) =>
-					Array.from(
-						{ length: lines },
-						() =>
-							`export const ${tag}Handler = ${tag}ProjectSnapshotStore.${tag}ResolveDocumentEntry(${tag}RequestContext, ${tag}IndexShard, ${tag}WordPosting);`,
-					).join("\n");
+	// #2254: the seam's cooperative replacement must read the clock O(distinct
+	// tokens the old document carried), not O(posting elements it walks). That is
+	// what keeps the per-edit block bounded — a deadline check per posting element
+	// cost one `performance.now()` per entry (the #2067 tax). A clock-read count
+	// is a deterministic WORK COUNT, invariant to machine speed and runner load,
+	// so it replaces the earlier wall-clock max-block bound (#2202 class): that
+	// bound needed a 401-document fixture and `retry: 2`, and was both flaky and a
+	// noisy neighbour in the timing-sensitive lane.
+	//
+	// Red-first: restoring the per-element deadline check reds this — the fixture
+	// walks two orders of magnitude more posting elements than it has tokens.
+	it("replaces through the seam with clock reads bounded by tokens, not postings (#2254)", async () => {
+		const env = setupTestEnvironment("word-index-per-edit-occupancy-");
+		try {
+			// A few distinct tokens repeated across a high-document-frequency corpus:
+			// each token's posting list is long, so a per-element deadline check would
+			// read the clock tens of thousands of times while a per-token check reads
+			// it a handful. No large single document and no retry are needed — the
+			// clock-read count does not depend on wall-clock timing.
+			const shared = Array.from({ length: 6 }, (_, i) => `sharedtoken${i}`).join(
+				" ",
+			);
+			const filePath = path.join(env.tmpDir, "src", "target.ts");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			const content = Array(20).fill("replacementtoken here").join("\n");
+			fs.writeFileSync(filePath, content);
 
-				const filePath = path.join(env.tmpDir, "src", "target.ts");
-				fs.mkdirSync(path.dirname(filePath), { recursive: true });
-				// Just under the shared size cap, so the seam replaces rather than drops.
-				const content = body("updated", 3_000);
-				expect(Buffer.byteLength(content, "utf-8")).toBeLessThan(
-					WORD_INDEX_MAX_BYTES,
-				);
-				fs.writeFileSync(filePath, content);
+			const wordIndex = buildWordIndex([
+				{ path: filePath, content: Array(20).fill(shared).join("\n") },
+				...Array.from({ length: 60 }, (_, doc) => ({
+					path: path.join(env.tmpDir, "src", `peer${doc}.ts`),
+					content: Array(200).fill(shared).join("\n"),
+				})),
+			]);
 
-				// High-document-frequency corpus: the removal half has to walk the
-				// posting list of every token the old document carried.
-				const wordIndex = buildWordIndex([
-					{ path: filePath, content: body("original", 3_000) },
-					...Array.from({ length: 400 }, (_, doc) => ({
-						path: path.join(env.tmpDir, "src", `peer${doc}.ts`),
-						content: body("original", 200),
-					})),
-				]);
-
-				const { computeCascadeForFile } =
-					await import("../../clients/dispatch/integration.js");
-				const maxBlockMs = await measureMaxSyncBlockMs(() =>
-					computeCascadeForFile(filePath, env.tmpDir, {
-						turnSeq: 1,
-						writeSeq: 1,
-						fileContent: content,
-						wordIndex,
-					}),
-				);
-
-				// The synchronous variant this seam used to call held the loop for the
-				// whole replacement: 40-42 ms on this fixture, against 9-16 ms for the
-				// cooperative one, which gives the loop back on its 8 ms budget. The
-				// bound sits between them with room for the non-yieldable atomic
-				// publish and a loaded CI box.
-				expect(maxBlockMs).toBeLessThan(30);
-				// Not vacuous: the replacement really happened.
-				expect(
-					wordIndexPostingHits(wordIndex, "updatedhandler").some(
-						(hit) => hit.file === filePath,
-					),
-				).toBe(true);
-				expect(wordIndex.postings.has("originalhandler")).toBe(true);
-				expect(
-					wordIndexPostingHits(wordIndex, "originalhandler").some(
-						(hit) => hit.file === filePath,
-					),
-				).toBe(false);
-			} finally {
-				env.cleanup();
+			// Not vacuous: the old document's tokens really do span a large posting
+			// population the staging pass has to walk.
+			let postingElements = 0;
+			for (const token of wordIndex.forward?.get(filePath)?.keys() ?? []) {
+				postingElements += wordIndex.postings.get(token)?.length ?? 0;
 			}
-		},
-	);
+			expect(postingElements).toBeGreaterThan(20_000);
+
+			const { computeCascadeForFile } = await import(
+				"../../clients/dispatch/integration.js"
+			);
+			const clockReads = await countClockReads(() =>
+				computeCascadeForFile(filePath, env.tmpDir, {
+					turnSeq: 1,
+					writeSeq: 1,
+					fileContent: content,
+					wordIndex,
+				}),
+			);
+
+			// One read per token the old document carried, plus tokenization of the
+			// new content and a handful of yields — never one per posting element.
+			// The per-element form reds this by two orders of magnitude.
+			expect(clockReads).toBeLessThan(2_000);
+			// Not vacuous: the replacement really happened.
+			expect(
+				wordIndexPostingHits(wordIndex, "replacementtoken").some(
+					(hit) => hit.file === filePath,
+				),
+			).toBe(true);
+			expect(
+				wordIndexPostingHits(wordIndex, "sharedtoken0").some(
+					(hit) => hit.file === filePath,
+				),
+			).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
 
 	it("removes (not partially indexes) a file over the shared size cap", async () => {
 		const env = setupTestEnvironment("word-index-per-edit-oversize-");

--- a/tests/clients/word-index-per-edit.test.ts
+++ b/tests/clients/word-index-per-edit.test.ts
@@ -233,9 +233,10 @@ describe("computeCascadeForFile — word-index per-edit seam (#348 phase 2)", ()
 			// read the clock tens of thousands of times while a per-token check reads
 			// it a handful. No large single document and no retry are needed — the
 			// clock-read count does not depend on wall-clock timing.
-			const shared = Array.from({ length: 6 }, (_, i) => `sharedtoken${i}`).join(
-				" ",
-			);
+			const shared = Array.from(
+				{ length: 6 },
+				(_, i) => `sharedtoken${i}`,
+			).join(" ");
 			const filePath = path.join(env.tmpDir, "src", "target.ts");
 			fs.mkdirSync(path.dirname(filePath), { recursive: true });
 			const content = Array(20).fill("replacementtoken here").join("\n");
@@ -252,14 +253,16 @@ describe("computeCascadeForFile — word-index per-edit seam (#348 phase 2)", ()
 			// Not vacuous: the old document's tokens really do span a large posting
 			// population the staging pass has to walk.
 			let postingElements = 0;
+			let oldDistinctTokens = 0;
 			for (const token of wordIndex.forward?.get(filePath)?.keys() ?? []) {
 				postingElements += wordIndex.postings.get(token)?.length ?? 0;
+				oldDistinctTokens += 1;
 			}
 			expect(postingElements).toBeGreaterThan(20_000);
+			expect(oldDistinctTokens).toBeGreaterThan(0);
 
-			const { computeCascadeForFile } = await import(
-				"../../clients/dispatch/integration.js"
-			);
+			const { computeCascadeForFile } =
+				await import("../../clients/dispatch/integration.js");
 			const clockReads = await countClockReads(() =>
 				computeCascadeForFile(filePath, env.tmpDir, {
 					turnSeq: 1,
@@ -269,9 +272,16 @@ describe("computeCascadeForFile — word-index per-edit seam (#348 phase 2)", ()
 				}),
 			);
 
-			// One read per token the old document carried, plus tokenization of the
-			// new content and a handful of yields — never one per posting element.
-			// The per-element form reds this by two orders of magnitude.
+			// TWO-SIDED. The upper bound catches the per-element regression: one read
+			// per posting element instead of per token reds it by two orders of
+			// magnitude. The lower bound catches the opposite regression, and it is
+			// the one the deleted wall-clock assertion used to own — if the seam stops
+			// calling the cooperative primitive and goes back to the synchronous
+			// `updateWordIndexDocument`, there is no deadline at all, so the count
+			// COLLAPSES to zero and an upper bound alone stays green. The floor is the
+			// old document's distinct-token count, because cooperative staging checks
+			// its deadline once per token it retires.
+			expect(clockReads).toBeGreaterThanOrEqual(oldDistinctTokens);
 			expect(clockReads).toBeLessThan(2_000);
 			// Not vacuous: the replacement really happened.
 			expect(

--- a/tests/support/perf-harness.ts
+++ b/tests/support/perf-harness.ts
@@ -17,6 +17,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { vi } from "vitest";
 
 /**
  * Build a nested tree of ~`target` source files under `root`, plus ignored
@@ -94,4 +95,27 @@ export async function measureMaxSyncBlockMs(
 	// Let the final gap (the stretch after the work's last yield) register.
 	await new Promise<void>((resolve) => setImmediate(resolve));
 	return maxLagMs;
+}
+
+/**
+ * Run `work` and return how many times it read the clock (`performance.now`).
+ *
+ * A deterministic WORK COUNT, not a wall-clock measurement, so it is invariant
+ * to machine speed and event-loop load (#2202, #2254). A cooperative loop that
+ * checks its deadline per bounded work unit reads the clock O(work units) times;
+ * a loop that checks per posting element reads it O(elements) times. The gap
+ * between those two is what a clock-read guard pins, and it does not move when a
+ * shared runner lane is under contention, so this belongs outside the
+ * timing-sensitive lane.
+ */
+export async function countClockReads(
+	work: () => Promise<unknown>,
+): Promise<number> {
+	const spy = vi.spyOn(performance, "now");
+	try {
+		await work();
+		return spy.mock.calls.length;
+	} finally {
+		spy.mockRestore();
+	}
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -214,9 +214,6 @@ const timingSensitiveInclude = [
 	"tests/clients/pipeline-snapshot-occupancy.test.ts",
 	"tests/clients/word-index-async-build.test.ts",
 	"tests/clients/word-index-cooperative-occupancy.test.ts",
-	//   - word-index-per-edit: the per-edit seam's longest-sync-stretch bound
-	//     (#2067 AC4), sampler-based like its cooperative-occupancy sibling.
-	"tests/clients/word-index-per-edit.test.ts",
 	"tests/clients/word-index-persist-occupancy.test.ts",
 	//   - cooperative-budget: #1215 acceptance screens — sampler-based
 	//     occupancy at 800-item scale plus the abort-latency bound.
@@ -350,16 +347,17 @@ export default defineConfig({
 					globalSetup: sharedGlobalSetup,
 					setupFiles: sharedSetupFiles,
 					execArgv: sharedExecArgv,
-					// Fully serial so the event-loop-occupancy sampler in each
-					// (measureMaxSyncBlockMs, see perf-harness.ts) never competes
-					// with a sibling fork for CPU turns while it's mid-measurement.
-					// Dropped from 2 to 1 when word-index-per-edit joined the lane:
-					// that file rebuilds a 401-document index (~1.2s, retry: 2), and
-					// at cap 2 it starved performance-report-occupancy's sampler on a
-					// loaded runner (107ms against a 75ms budget, 3/3 retries). Return
-					// to 2 once #2254 converts the occupancy guards to load-invariant
-					// work counts, which lets them leave this lane.
-					maxWorkers: 1,
+					// At most two at a time so the event-loop-occupancy sampler in each
+					// (measureMaxSyncBlockMs, see perf-harness.ts) contends with at most
+					// one sibling fork for CPU turns while it's mid-measurement, not the
+					// full-suite fork storm. This lane briefly ran at 1 while
+					// word-index-per-edit lived here: that file rebuilt a 401-document
+					// index (~1.2s, retry: 2) and at cap 2 starved
+					// performance-report-occupancy's sampler on a loaded runner (107ms
+					// against a 75ms budget, 3/3 retries). #2254 converted that guard to
+					// a load-invariant clock-read count and moved it out of this lane, so
+					// the heavy neighbour is gone and the cap returns to 2.
+					maxWorkers: 2,
 					// Its own phase, after both "default" and "grammar-heavy" drain
 					// (required anyway once maxWorkers differs from "default" — see
 					// the grammar-heavy project above). By running last and alone,


### PR DESCRIPTION
## Summary

The word-index per-edit occupancy guard was a wall-clock max-block over a
401-document fixture with `retry: 2`. It was load-sensitive and a heavy
neighbour in the timing-sensitive test lane: adding it forced the lane's cap
from 2 to 1 (#2245 interim), because on a loaded runner the fixture rebuild
starved `performance-report-occupancy`'s sampler. This converts the guard to a
deterministic work count, removes it from the lane, and restores the cap to 2.

## What changed

- `tests/clients/word-index-per-edit.test.ts` — the occupancy test now asserts
  the seam's cooperative replacement reads the clock a number of times bounded
  by the old document's distinct tokens, not by the posting elements it walks.
  It drives the replacement through `computeCascadeForFile` (the real seam), on a
  60-document high-frequency corpus (no 3,000-line document, no 401 peers, no
  `retry`). The clock-read count is invariant to machine speed and runner load.
- `tests/support/perf-harness.ts` — `countClockReads` moves here as the single
  implementation. `word-index-incremental.test.ts` had a private copy; it now
  imports the shared one, so the two clock-read guards read one helper.
- `vitest.config.ts` — `word-index-per-edit.test.ts` leaves
  `timingSensitiveInclude`, and the `timing-sensitive` lane returns to
  `maxWorkers: 2`. The lane's one heavy neighbour is gone, so the interim cap of
  1 is no longer needed.

## Why a work count

A cooperative loop that checks its deadline per bounded work unit reads the
clock O(work units) times. A loop that checks per posting element reads it
O(elements) times. That gap is the #2067 tax the seam removed, and it is what
the guard pins. The count does not move under contention, so unlike a wall-clock
max-block it is neither flaky nor a reason to keep the file in a serialized
lane. This is the same reshape #2202 applied and the one #2245's review finding
F2 applied to the removal-staging guard.

## Tests

`tests/clients/word-index-per-edit.test.ts` — "replaces through the seam with
clock reads bounded by tokens, not postings (#2254)": the fixture walks over
20,000 posting elements (asserted non-vacuous), and the per-token replacement
reads the clock under 2,000 times.

### Test assessment

Red-first proof: reintroducing the per-element deadline check in
`stageWordIndexDocumentRemoval` (the #2067 tax) reds the guard.

```
AssertionError: expected 84184 to be less than 2000
 ❯ tests/clients/word-index-per-edit.test.ts:275:23
```

84,184 clock reads with the per-element check versus under 2,000 with the
per-token form — a 42x separation, invariant to load. Restoring the source
returns the test to green.

Targeted suites green locally: `word-index-per-edit`, `word-index-incremental`,
`timing-sensitive-coverage` (the governance test that derives lane membership
from the sampler import — it confirms the file correctly leaves the lane), and
the lane neighbours `performance-report-occupancy` and
`word-index-persist-occupancy`. Full suite deferred to CI, which runs the whole
timing-sensitive lane at the restored `maxWorkers: 2`.

## Blast radius

- `tests/support/perf-harness.ts` gains an export and a `vitest` import; it is a
  test-support module, imported only by tests. `word-index-incremental.test.ts`
  now imports `countClockReads` from it instead of defining its own; behaviour is
  identical (same spy on `performance.now`).
- `vitest.config.ts` lane change affects only the `timing-sensitive` project's
  worker cap and membership. The `timing-sensitive-coverage` governance test
  enforces that only sampler-importing files stay in the lane; it passes.
- No production code changes. `clients/word-index.ts` is untouched.

## Observability

Test-only change. The guard's signal is the `performance.now` call count during
one replacement, read through a `vi.spyOn` in the test. No runtime record
changes.

## Class sweep

- PATTERN sweep — wall-clock max-block occupancy assertions living in the shared
  timing-sensitive lane, the #2202 class. Grep for `measureMaxSyncBlockMs` across
  `tests/`. The other lane members (source-walk, cascade-graph, lsp edits,
  diagnostics, report and snapshot occupancy) each measure a genuinely different
  surface and their fixtures are not heavy neighbours; `timing-sensitive-coverage`
  keeps them correctly phased. word-index-per-edit was the one member that both
  measured a work-countable property and carried a heavy fixture, so it is the
  only conversion here.
- POPULATION sweep — clock-read work-count guards over the word index. Two exist
  now (removal staging and the per-edit seam), both reading the shared
  `countClockReads`. No third site walks postings under a cooperative deadline.

## Review round 1

Two findings, both fixed in `0631a398`.

**F1 (HIGH, coverage regression).** The clock-read count bounded work only
UPWARD. It caught the per-element regression but not its opposite: the reviewer
reverted the seam at `clients/dispatch/integration.ts:874` from
`await updateWordIndexDocumentForEdit(...)` to the synchronous
`updateWordIndexDocument(...)` — the exact regression the deleted
`maxBlockMs < 30` assertion owned — and the whole family stayed green. The
synchronous path has no cooperative deadline, so the count COLLAPSES to zero
and a ceiling alone cannot see it.

Fixed with the tighter of the two forms the reviewer offered: a floor tied to
the old document's distinct-token count, because cooperative staging checks its
deadline once per token it retires. Deterministic and load-invariant like the
ceiling. The guard is now two-sided.

Mutation proof, the reviewer's exact mutation:

```
AssertionError: expected 0 to be greater than or equal to 7
    284|   expect(clockReads).toBeGreaterThanOrEqual(oldDistinctTokens);
 Tests  1 failed | 5 passed (6)
```

Zero clock reads against a floor of 7, matching the reviewer's instrumented
"0 vs 29 real". Restoring the seam returns the file to 6/6.

Scope note, confirmed by the reviewer: this guard covers only "the seam stops
calling the cooperative path". The cooperative PRIMITIVE's own yielding stays
covered by `word-index-cooperative-occupancy.test.ts:44`, which is unchanged
and still in the timing-sensitive lane.

**F2 (MED, format).** `oxfmt` failed on
`tests/clients/word-index-per-edit.test.ts`. Ran the formatter; `oxfmt --check`
over `tests/` and `vitest.config.ts` is clean (865 files).

Verification after the fix round: 32 pass across word-index-per-edit,
-incremental, timing-sensitive-coverage, word-index-cooperative-occupancy, and
the two lane neighbours performance-report-occupancy and
word-index-persist-occupancy. Lint, type-check, and oxfmt clean.

Composition after #2258 merged: master was merged into this branch at
`2111f680` (clean, no conflicts). #2258 changed how often the arena recompacts,
and recompaction also reads the clock, so the interaction was verified rather
than reasoned about: 97 pass across word-index-per-edit, word-index,
-incremental, timing-sensitive-coverage, cooperative-occupancy, and the two lane
neighbours. The floor holds because staging reads the clock once per retired
token regardless of recompaction, and the ceiling has ample headroom. Governance
suites re-run on the merged tree: session-state-conformance,
bounded-telemetry-sweep, profiling-coverage, worker-budget — 121 pass.

## Verification level for the lane restore

Stated honestly, because the "lane green under load" criterion was not
independently satisfied. The reviewer's host was saturated by concurrent agents,
so a controlled-load comparison was not possible there. Their ambient cap-2 runs
were 5/6 green, with the single failure being the known
`cascade-graph-occupancy` flake rather than anything this PR touches, and
`performance-report-occupancy` — the test whose starvation forced the interim
cap of 1 — held its 75ms budget in all six runs. CI's own run of the lane at
`maxWorkers: 2` passed. That is the evidence for the restore: consistent, but
short of a controlled under-load proof.

## Scope

Closes #2254. The interim `maxWorkers: 1` #2245 shipped is reverted here, which
was that PR's stated hand-off. Composes with #2258 (the #2246 recompaction gate)
— disjoint files, either merge order is safe.

*This PR is AI-generated, with the maintainer supervising the process.*



