### PR TITLE
fix(ci): read live PR body in close-keyword verification (refs #2086)

### DIFF
--- a/.changelog/fix-2086-close-keyword-live-body.md
+++ b/.changelog/fix-2086-close-keyword-live-body.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Read the live PR body in close-keyword verification (refs #2086)** — a post-merge rerun of `--verify-merged` used to relint the closed-event payload's stale body; it now fetches the live body, so an edit that fixes or introduces a comma-separated close list is seen on rerun.
+- **Read the live PR body in close-keyword verification (refs #2086)** — a post-merge rerun of `--verify-merged` used to relint the closed-event payload's stale body and, in production, silently kept doing so because the workflow step never carried the `GITHUB_TOKEN` env var the live fetch needs. It now sets that var and fails the check loud on any fetch problem instead of falling back to stale data, so an edit that fixes or introduces a comma-separated close list is reliably seen on rerun.

--- a/.changelog/fix-2086-close-keyword-live-body.md
+++ b/.changelog/fix-2086-close-keyword-live-body.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Read the live PR body in close-keyword verification (refs #2086)** — a post-merge rerun of `--verify-merged` used to relint the closed-event payload's stale body; it now fetches the live body, so an edit that fixes or introduces a comma-separated close list is seen on rerun.

--- a/.github/workflows/close-keyword-verification.yml
+++ b/.github/workflows/close-keyword-verification.yml
@@ -21,5 +21,14 @@ jobs:
 
       - name: Verify referenced issues closed
         env:
+          # GH_TOKEN: the gh CLI calls in check-close-keywords.mjs (issue
+          # state lookups, the PR comment). GITHUB_TOKEN: the live-body
+          # fetch this step exists for (#2267 F1) -- check-pr-body.mjs's
+          # resolveLivePrBody/fetchLivePrBody read process.env.GITHUB_TOKEN
+          # specifically, not GH_TOKEN, so without this the live fetch
+          # always throws "GITHUB_TOKEN is not set" and every run silently
+          # falls back to the stale closed-event body -- the exact bug
+          # #2086 was filed to fix, still present under a different name.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/check-close-keywords.mjs --verify-merged

--- a/scripts/check-close-keywords.d.mts
+++ b/scripts/check-close-keywords.d.mts
@@ -11,3 +11,8 @@ export declare function lintCloseKeywords(body?: string): {
 	offendingLines: string[];
 	valid: boolean;
 };
+export declare function verifyMergedPullRequest(
+	fetchImpl?: typeof fetch,
+	event?: { pull_request?: { number: number; body?: string | null } },
+	getIssueState?: (repository: string, number: number) => string,
+): Promise<void>;

--- a/scripts/check-close-keywords.mjs
+++ b/scripts/check-close-keywords.mjs
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { resolveLivePrBody } from "./check-pr-body.mjs";
+import { fetchLivePrBody } from "./check-pr-body.mjs";
 
 const CLOSE_KEYWORD = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b/gi;
 const CLOSE_ISSUE = /\s*:?[ \t]*#(\d+)/y;
@@ -127,11 +127,30 @@ export async function verifyMergedPullRequest(
 	// #2086: the closed-event payload's body is a snapshot from when the PR
 	// closed. A rerun of this check after the body was edited post-merge must
 	// see the edit, not replay the stale snapshot. Reuses check-pr-body.mjs's
-	// resolveLivePrBody (PR #2085/#2086's own root-cause sibling) rather than
-	// hand-rolling a second live-body fetch -- same env vars, same
-	// fall-back-with-::warning:: behavior, already covered by that file's own
-	// tests for a missing token, a non-2xx response, and a malformed body.
-	const liveBody = await resolveLivePrBody(pullRequest, fetchImpl);
+	// fetchLivePrBody (PR #2085/#2086's own root-cause sibling) rather than
+	// hand-rolling a second live-body fetch -- same env vars, same request
+	// shape.
+	//
+	// #2267 F2: uses the STRICT fetchLivePrBody here, not resolveLivePrBody's
+	// warn-and-fall-back-to-stale-payload wrapper. That wrapper is right for
+	// the advisory body LINTER (check-pr-body.mjs), where degrading to the
+	// stale body on a fetch hiccup is an acceptable trade. It is wrong for
+	// this post-merge verification GATE: a gate that silently falls back and
+	// reports "OK" on a fetch failure is indistinguishable from a gate that
+	// actually checked and found nothing wrong -- the exact "fails open"
+	// shape #2086 was filed to close, just moved one level up. A fetch
+	// failure here fails the check LOUD instead.
+	let liveBody;
+	try {
+		liveBody = await fetchLivePrBody(pullRequest, fetchImpl);
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		console.error(
+			`::error::Post-merge close verification could not fetch the live PR body, so it did not run: ${reason}`,
+		);
+		process.exitCode = 1;
+		return;
+	}
 	const { issues } = parseCloseKeywords(liveBody);
 	const unresolved = issues
 		.map((number) => ({ number, state: getIssueState(repository, number) }))

--- a/scripts/check-close-keywords.mjs
+++ b/scripts/check-close-keywords.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { resolveLivePrBody } from "./check-pr-body.mjs";
 
 const CLOSE_KEYWORD = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b/gi;
 const CLOSE_ISSUE = /\s*:?[ \t]*#(\d+)/y;
@@ -105,16 +106,35 @@ function issueState(repository, number) {
 	}
 }
 
-function verifyMergedPullRequest() {
-	const event = eventPayload();
+/**
+ * @param {typeof fetch} [fetchImpl]
+ * @param {object} [event] injectable event payload (tests only; defaults to
+ *   the real GITHUB_EVENT_PATH payload)
+ * @param {(repository: string, number: number) => string} [getIssueState]
+ *   injectable issue-state lookup (tests only; defaults to the real `gh api`
+ *   call)
+ */
+export async function verifyMergedPullRequest(
+	fetchImpl = globalThis.fetch,
+	event = eventPayload(),
+	getIssueState = issueState,
+) {
 	const pullRequest = event.pull_request;
 	const repository = process.env.GITHUB_REPOSITORY;
 	if (!pullRequest || !repository)
 		throw new Error("Pull request event and GITHUB_REPOSITORY are required");
 
-	const { issues } = parseCloseKeywords(pullRequest.body ?? "");
+	// #2086: the closed-event payload's body is a snapshot from when the PR
+	// closed. A rerun of this check after the body was edited post-merge must
+	// see the edit, not replay the stale snapshot. Reuses check-pr-body.mjs's
+	// resolveLivePrBody (PR #2085/#2086's own root-cause sibling) rather than
+	// hand-rolling a second live-body fetch -- same env vars, same
+	// fall-back-with-::warning:: behavior, already covered by that file's own
+	// tests for a missing token, a non-2xx response, and a malformed body.
+	const liveBody = await resolveLivePrBody(pullRequest, fetchImpl);
+	const { issues } = parseCloseKeywords(liveBody);
 	const unresolved = issues
-		.map((number) => ({ number, state: issueState(repository, number) }))
+		.map((number) => ({ number, state: getIssueState(repository, number) }))
 		.filter(({ state }) => state !== "closed");
 	if (unresolved.length === 0) {
 		console.log(
@@ -173,15 +193,16 @@ Post-merge close verification found issue(s) that were not closed: ${details}. G
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-	try {
+	(async () => {
 		if (process.argv[2] === "--lint-pr") lintPullRequest();
-		else if (process.argv[2] === "--verify-merged") verifyMergedPullRequest();
+		else if (process.argv[2] === "--verify-merged")
+			await verifyMergedPullRequest();
 		else
 			throw new Error(
 				"Usage: node scripts/check-close-keywords.mjs --lint-pr|--verify-merged",
 			);
-	} catch (error) {
+	})().catch((error) => {
 		console.error(error instanceof Error ? error.message : error);
 		process.exitCode = 1;
-	}
+	});
 }

--- a/scripts/check-pr-body.d.mts
+++ b/scripts/check-pr-body.d.mts
@@ -9,6 +9,10 @@ export declare function lintPrBody(
 	valid: boolean;
 	errors: string[];
 };
+export declare function fetchLivePrBody(
+	payloadPr: { number: number; body?: string | null },
+	fetchImpl: typeof fetch,
+): Promise<string>;
 export declare function resolveLivePrBody(
 	payloadPr: { number: number; body?: string | null },
 	fetchImpl?: typeof fetch,

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -307,7 +307,21 @@ export function lintPrBody(body = "", options = {}) {
 	return { valid: errors.length === 0, errors };
 }
 
-async function fetchLivePrBody(payloadPr, fetchImpl) {
+/**
+ * Strict live-body fetch: throws instead of swallowing, on a missing token,
+ * a non-2xx response, or a malformed body. `resolveLivePrBody` below wraps
+ * this for the advisory body LINTER, where degrading to the stale payload
+ * on any hiccup is the right posture. It is the wrong posture for a
+ * post-merge verification GATE (#2267 F2): a gate that silently passes on
+ * a fetch failure is indistinguishable from a gate that actually checked
+ * and found nothing wrong. check-close-keywords.mjs's --verify-merged path
+ * calls this directly and fails closed (exitCode=1, ::error::) instead.
+ *
+ * @param {{ number: number, body?: string | null }} payloadPr
+ * @param {typeof fetch} fetchImpl
+ * @returns {Promise<string>}
+ */
+export async function fetchLivePrBody(payloadPr, fetchImpl) {
 	const token = process.env.GITHUB_TOKEN;
 	if (!token) throw new Error("GITHUB_TOKEN is not set");
 	const apiUrl = process.env.GITHUB_API_URL;

--- a/tests/scripts/check-close-keywords.test.ts
+++ b/tests/scripts/check-close-keywords.test.ts
@@ -1,3 +1,7 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as yaml from "js-yaml";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	INVALID_CLOSE_KEYWORD_MESSAGE,
@@ -6,11 +10,21 @@ import {
 	verifyMergedPullRequest,
 } from "../../scripts/check-close-keywords.mjs";
 // Reused, not reimplemented (#2086): check-close-keywords.mjs imports this
-// straight from check-pr-body.mjs. Its own edge cases (missing token,
-// non-2xx, malformed body) are already covered by
-// tests/scripts/check-pr-body.test.ts's "live PR body resolution (#2085)"
-// suite -- no need to duplicate them here.
-import { resolveLivePrBody } from "../../scripts/check-pr-body.mjs";
+// straight from check-pr-body.mjs. Deliberately the STRICT fetchLivePrBody,
+// not the advisory resolveLivePrBody wrapper (#2267 F2) -- see the comment
+// at its call site in check-close-keywords.mjs for why a post-merge GATE
+// must fail closed on a fetch problem instead of falling back to stale
+// data. resolveLivePrBody's own fallback paths (missing token, non-2xx,
+// malformed body) are covered by check-pr-body.test.ts's "live PR body
+// resolution (#2085)" suite; this file exercises fetchLivePrBody's THROWING
+// behavior directly, since that's the behavior check-close-keywords.mjs
+// actually depends on.
+import { fetchLivePrBody } from "../../scripts/check-pr-body.mjs";
+
+const REPO_ROOT = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
 
 afterEach(() => {
 	vi.unstubAllEnvs();
@@ -122,7 +136,7 @@ describe("live PR body resolution (#2086)", () => {
 			}),
 		);
 
-		const body = await resolveLivePrBody(payloadPr, fetchImpl);
+		const body = await fetchLivePrBody(payloadPr, fetchImpl);
 		expect(body).toBe("Closes #123. Closes #456.");
 		expect(lintCloseKeywords(body).valid).toBe(true);
 		expect(fetchImpl).toHaveBeenCalledWith(
@@ -144,7 +158,7 @@ describe("live PR body resolution (#2086)", () => {
 			}),
 		);
 
-		const body = await resolveLivePrBody(payloadPr, fetchImpl);
+		const body = await fetchLivePrBody(payloadPr, fetchImpl);
 		expect(lintCloseKeywords(payloadPr.body).valid).toBe(false);
 		expect(lintCloseKeywords(body).valid).toBe(true);
 	});
@@ -162,14 +176,14 @@ describe("live PR body resolution (#2086)", () => {
 			}),
 		);
 
-		const body = await resolveLivePrBody(cleanPayloadPr, fetchImpl);
+		const body = await fetchLivePrBody(cleanPayloadPr, fetchImpl);
 		expect(lintCloseKeywords(cleanPayloadPr.body).valid).toBe(true);
 		expect(lintCloseKeywords(body).valid).toBe(false);
 	});
 });
 
 // The actual regression this issue is about, exercised end to end through
-// verifyMergedPullRequest itself (not just resolveLivePrBody in isolation):
+// verifyMergedPullRequest itself (not just fetchLivePrBody in isolation):
 // a rerun of --verify-merged must lint the LIVE body's issue references, not
 // the ones frozen into the closed-event payload. Both fixture bodies name
 // issues getIssueState reports as already closed, so the run always takes
@@ -204,5 +218,100 @@ describe("verifyMergedPullRequest reads the live body, not the stale payload (#2
 		expect(getIssueState).toHaveBeenCalledWith("apmantza/pi-lens", 1);
 		expect(getIssueState).toHaveBeenCalledWith("apmantza/pi-lens", 2);
 		log.mockRestore();
+	});
+});
+
+// #2267 F2 (fix round): a post-merge verification GATE must fail LOUD on a
+// fetch problem, not warn-and-fall-back like the advisory body linter does.
+// Reproduces the reviewer's exact production scenario: GITHUB_TOKEN unset
+// (F1's shape) or the API returning non-2xx -- either way, the check used
+// to log a ::warning:: and report "OK" on the stale payload. It must now
+// set exitCode=1 with an ::error:: annotation and never reach the
+// success-path console.log or the gh-CLI comment path.
+describe("verifyMergedPullRequest fails closed on a live-fetch problem (#2267 F2)", () => {
+	afterEach(() => {
+		process.exitCode = undefined;
+	});
+
+	it("fails closed when GITHUB_TOKEN is unset (the F1 production shape)", async () => {
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "");
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchImpl = vi.fn();
+		const event = { pull_request: { number: 2267, body: "Closes #1, #2" } };
+		const getIssueState = vi.fn().mockReturnValue("open");
+
+		await verifyMergedPullRequest(fetchImpl, event, getIssueState);
+
+		expect(process.exitCode).toBe(1);
+		expect(fetchImpl).not.toHaveBeenCalled();
+		// Mutation-proof: reverting to resolveLivePrBody's swallow-and-warn
+		// behavior would call console.warn (not console.error) and go on to
+		// log a success/failure message from the STALE payload instead of
+		// short-circuiting here -- this asserts neither happened.
+		expect(log).not.toHaveBeenCalled();
+		expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("::error::"));
+		expect(errorLog).toHaveBeenCalledWith(
+			expect.stringContaining("GITHUB_TOKEN is not set"),
+		);
+		expect(getIssueState).not.toHaveBeenCalled();
+		errorLog.mockRestore();
+		log.mockRestore();
+	});
+
+	it("fails closed when the GitHub API returns a non-2xx response", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValue(new Response("service unavailable", { status: 503 }));
+		const event = { pull_request: { number: 2267, body: "Closes #1" } };
+		const getIssueState = vi.fn();
+
+		await verifyMergedPullRequest(fetchImpl, event, getIssueState);
+
+		expect(process.exitCode).toBe(1);
+		expect(getIssueState).not.toHaveBeenCalled();
+		expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("503"));
+		errorLog.mockRestore();
+	});
+});
+
+// #2267 F1 (fix round, BLOCKING): the fix never fired in production because
+// the workflow step set GH_TOKEN (for the gh CLI calls) but not
+// GITHUB_TOKEN (which fetchLivePrBody/resolveLivePrBody read specifically)
+// -- every real run threw "GITHUB_TOKEN is not set" before any fetch and
+// silently used the stale payload, the exact bug #2086 exists to fix, under
+// a different name. A source-level unit test can prove the function reads
+// process.env.GITHUB_TOKEN, but nothing short of reading the workflow YAML
+// itself proves the WIRING is correct in the one place it actually runs.
+describe("close-keyword-verification.yml carries GITHUB_TOKEN (#2267 F1)", () => {
+	it("sets both GH_TOKEN and GITHUB_TOKEN on the verify step", () => {
+		const workflowPath = path.join(
+			REPO_ROOT,
+			".github/workflows/close-keyword-verification.yml",
+		);
+		type WorkflowStep = { run?: string; env?: Record<string, string> };
+		type Workflow = { jobs: { verify: { steps: WorkflowStep[] } } };
+		const workflow = yaml.load(
+			fs.readFileSync(workflowPath, "utf8"),
+		) as Workflow;
+		const step = workflow.jobs.verify.steps.find((s) =>
+			(s.run ?? "").includes("check-close-keywords.mjs"),
+		);
+		if (!step)
+			throw new Error(
+				"verify step not found in close-keyword-verification.yml",
+			);
+		// Mutation-proof: removing either line reds this. GH_TOKEN feeds the
+		// `gh` CLI calls (issue-state lookups, the PR comment); GITHUB_TOKEN
+		// feeds fetchLivePrBody -- check-pr-body.mjs reads that exact name,
+		// not GH_TOKEN, so the two are NOT interchangeable here even though
+		// they carry the same secret value.
+		expect(step.env?.GH_TOKEN).toBeTruthy();
+		expect(step.env?.GITHUB_TOKEN).toBeTruthy();
 	});
 });

--- a/tests/scripts/check-close-keywords.test.ts
+++ b/tests/scripts/check-close-keywords.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	INVALID_CLOSE_KEYWORD_MESSAGE,
 	lintCloseKeywords,
 	parseCloseKeywords,
+	verifyMergedPullRequest,
 } from "../../scripts/check-close-keywords.mjs";
+// Reused, not reimplemented (#2086): check-close-keywords.mjs imports this
+// straight from check-pr-body.mjs. Its own edge cases (missing token,
+// non-2xx, malformed body) are already covered by
+// tests/scripts/check-pr-body.test.ts's "live PR body resolution (#2085)"
+// suite -- no need to duplicate them here.
+import { resolveLivePrBody } from "../../scripts/check-pr-body.mjs";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
 
 describe("close-keyword parser (#1320)", () => {
 	it("parses one close keyword", () => {
@@ -86,5 +97,112 @@ describe("close-keyword parser (#1320)", () => {
 		const result = lintCloseKeywords("Intro.\nCloses #12, #13\nOutro.");
 		expect(result.valid).toBe(false);
 		expect(result.offendingLines).toEqual(["Closes #12, #13"]);
+	});
+});
+
+// #2086: verifyMergedPullRequest read pullRequest.body straight off the
+// closed-event payload, so a rerun after the body was edited post-merge
+// always relinted the STALE body. It now reuses check-pr-body.mjs's
+// resolveLivePrBody (shipped for #2085) instead of a second implementation;
+// that file's own "live PR body resolution (#2085)" suite already
+// mutation-proves the fallback paths (missing token, non-2xx, malformed
+// body), so this file only proves the regression case parseCloseKeywords
+// actually cares about: an edited body changes the lint verdict.
+describe("live PR body resolution (#2086)", () => {
+	const payloadPr = { number: 2086, body: "Closes #123, #456" };
+
+	it("uses the live body when it differs from the event payload", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ body: "Closes #123. Closes #456." }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		const body = await resolveLivePrBody(payloadPr, fetchImpl);
+		expect(body).toBe("Closes #123. Closes #456.");
+		expect(lintCloseKeywords(body).valid).toBe(true);
+		expect(fetchImpl).toHaveBeenCalledWith(
+			"https://api.github.test/repos/apmantza/pi-lens/pulls/2086",
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+	});
+
+	// The regression case this issue exists for: an edit that FIXES the
+	// comma-list problem must be seen on rerun, not masked by the stale
+	// payload the closed event carried.
+	it("sees a post-merge edit that fixes an invalid comma list", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ body: "Closes #123. Closes #456." }), {
+				status: 200,
+			}),
+		);
+
+		const body = await resolveLivePrBody(payloadPr, fetchImpl);
+		expect(lintCloseKeywords(payloadPr.body).valid).toBe(false);
+		expect(lintCloseKeywords(body).valid).toBe(true);
+	});
+
+	// The mirror case: an edit that INTRODUCES a comma list must be seen too,
+	// not masked by a stale payload that looked clean at close time.
+	it("sees a post-merge edit that introduces an invalid comma list", async () => {
+		const cleanPayloadPr = { number: 2086, body: "Closes #123" };
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ body: "Closes #123, #456" }), {
+				status: 200,
+			}),
+		);
+
+		const body = await resolveLivePrBody(cleanPayloadPr, fetchImpl);
+		expect(lintCloseKeywords(cleanPayloadPr.body).valid).toBe(true);
+		expect(lintCloseKeywords(body).valid).toBe(false);
+	});
+});
+
+// The actual regression this issue is about, exercised end to end through
+// verifyMergedPullRequest itself (not just resolveLivePrBody in isolation):
+// a rerun of --verify-merged must lint the LIVE body's issue references, not
+// the ones frozen into the closed-event payload. Both fixture bodies name
+// issues getIssueState reports as already closed, so the run always takes
+// the "OK" branch and never touches the real `gh pr comment` side effects --
+// the only difference under test is WHICH body's issue count gets logged.
+describe("verifyMergedPullRequest reads the live body, not the stale payload (#2086)", () => {
+	it("logs the live body's issue count, proving it did not use the stale payload's", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({ body: "Closes #1. Closes #2." }), // live: 2 issues
+				{ status: 200 },
+			),
+		);
+		const event = {
+			pull_request: { number: 2086, body: "Closes #1" }, // stale: 1 issue
+		};
+		const getIssueState = vi.fn().mockReturnValue("closed");
+
+		await verifyMergedPullRequest(fetchImpl, event, getIssueState);
+
+		// Mutation-proof: if verifyMergedPullRequest reverted to reading
+		// pullRequest.body directly, this would report "1 issue" (the stale
+		// payload) instead -- this exact assertion is what pins the fix, and
+		// it needs no `gh` CLI, no comment-posting side effect.
+		expect(log).toHaveBeenCalledWith(
+			expect.stringContaining("2 issues closed"),
+		);
+		expect(getIssueState).toHaveBeenCalledWith("apmantza/pi-lens", 1);
+		expect(getIssueState).toHaveBeenCalledWith("apmantza/pi-lens", 2);
+		log.mockRestore();
 	});
 });


### PR DESCRIPTION
## Summary

`check-close-keywords.mjs --verify-merged` now reads the PR's live body instead of the closed-event payload's snapshot, and the fetch path actually runs in production. Refs #2086.

`verifyMergedPullRequest` read `pull_request.body` straight off the GitHub Actions closed-event payload — a snapshot frozen at close time. `close-keyword-verification.yml` only triggers on `types: [closed]`, with no `edited` refresh and no live fetch. A rerun of this check after the body was edited post-merge always relinted that stale snapshot: an edit that fixed a comma-separated close list never cleared the false-positive comment, and an edit that introduced one would go unseen.

## Fix round 1 (adversarial review)

Two blocking/high findings against the initial fix, both closed in this round.

**F1 (BLOCKING — the fix never fired in production).** `close-keyword-verification.yml` set `GH_TOKEN` for the `gh` CLI calls but not `GITHUB_TOKEN`, which `fetchLivePrBody`/`resolveLivePrBody` read specifically. Every real run threw `GITHUB_TOKEN is not set` before any fetch and silently used the stale payload — the exact bug #2086 exists to fix, wearing a different name. The sibling `lint.yml:83` workflow already carries `GITHUB_TOKEN` for the same seam; the initial fix reused the function without its env contract. Fixed by adding `GITHUB_TOKEN` alongside `GH_TOKEN` to the workflow step, plus a new test that parses the actual workflow YAML and asserts both env vars are present — pinning the WIRING, not just the function's env-var name.

**F2 (HIGH — verification failed open on any fetch failure).** A 503, `ECONNRESET`, or a malformed 200 all logged a `::warning::` and reported "OK" on the stale body — the original bug with a warning attached. That posture is right for the advisory PR body linter (`check-pr-body.mjs`), which `resolveLivePrBody` serves; it's wrong for a post-merge verification GATE, where silently passing on an unmeasured fetch failure is indistinguishable from a gate that actually checked and found nothing wrong. Exported `check-pr-body.mjs`'s previously module-private `fetchLivePrBody` (the strict, throwing version) and switched `verifyMergedPullRequest` to call it directly: any fetch problem now sets `exitCode=1` with an `::error::` annotation instead of falling back.

Also fixed: the changelog fragment claimed "it now fetches the live body," which was false until F1's wiring landed in the same rollup — reworded to describe the actual working behavior.

## Tests

- `tests/scripts/check-close-keywords.test.ts`: switched the "live PR body resolution" suite to exercise `fetchLivePrBody` directly (the function `check-close-keywords.mjs` actually calls now), added `verifyMergedPullRequest fails closed on a live-fetch problem (#2267 F2)` (missing token, non-2xx — both must set `exitCode=1`, log `::error::`, and never reach the success path or the `gh` comment side effect), and added `close-keyword-verification.yml carries GITHUB_TOKEN (#2267 F1)`, which parses the real workflow YAML and asserts the verify step's `env` carries both `GH_TOKEN` and `GITHUB_TOKEN`.
- `tests/scripts/check-pr-body.test.ts`: unchanged; `fetchLivePrBody`'s behavior was already covered there through `resolveLivePrBody`'s wrapping tests, and is now also directly reachable via the new export.

### Test assessment

- `check-close-keywords.test.ts`'s new workflow-YAML test is the only thing in this PR that can catch a REGRESSION of F1 specifically — a source-level assertion that the function reads `process.env.GITHUB_TOKEN` proves the function's contract, but nothing short of reading the deployed YAML proves the workflow actually satisfies it. This is exactly the class of bug that shipped in the first place: correct code, wrong wiring.
- The two `verifyMergedPullRequest` fail-closed tests replace nothing; they pin new behavior (F2) that had no prior test coverage.

Red-first, both rounds. Fix round 1 (#2086, `verifyMergedPullRequest` not exported):

```
TypeError: verifyMergedPullRequest is not a function
 Test Files  1 failed (1)
      Tests  1 failed | 15 passed (16)
```

Fix round 2 (#2267 F1/F2, reverted the workflow YAML and both `.mjs` source files, kept tests):

```
FAIL  ... live PR body resolution (#2086) > uses the live body ...  (fetchLivePrBody is not a function, x3)
FAIL  ... verifyMergedPullRequest fails closed ... GITHUB_TOKEN is unset ...
  expected "error" to be called with ::error::, got the STALE-BODY success comment instead
FAIL  ... verifyMergedPullRequest fails closed ... non-2xx response ... (crashed reaching the real `gh` CLI, because pre-fix code never short-circuits on a fetch failure)
FAIL  ... close-keyword-verification.yml carries GITHUB_TOKEN ... expected undefined to be truthy
 Test Files  1 failed (1)
      Tests  6 failed | 13 passed (19)
```

Restored both fixes, rebuilt, reran: `Test Files 2 passed (2)`, `Tests 104 passed (104)` (`check-close-keywords.test.ts` + `check-pr-body.test.ts` combined). Also ran `tests/clients/session-state-conformance.test.ts` (83 passed). Full suite deferred to CI.

## Blast radius

- `check-pr-body.mjs`'s `fetchLivePrBody` export is new surface; its only other caller remains `resolveLivePrBody` inside the same file, unchanged. No other script imports it.
- The workflow env change (`GITHUB_TOKEN` added to `close-keyword-verification.yml`) only affects that one step; it does not touch `lint.yml` or any other workflow.
- `verifyMergedPullRequest`'s new fail-closed behavior means a live-fetch outage now BLOCKS the post-merge check (exit 1) where it previously passed silently. That is the intended behavior change (F2), but it means a transient GitHub API blip on a merge now produces a visible failing check where none showed before — acceptable for a verification gate, and no automatic rerun is wired for this workflow (unlike #2103's classifier), so a real outage requires a manual rerun.

## Observability

The `::error::` annotation on a fetch failure is the record: it shows up in the Actions log and, because `console.error` writes to the job's own output, in `gh run view --log` for that job. There is no PR comment on a fetch-failure path (deliberately — the failure is about verification not running, not about an issue being unresolved, so the close-keyword-verifier marker/comment machinery is not the right channel for it). F2 is exactly the gap this PR's own missing Observability section let through the first time: writing this section for the initial fix would have surfaced the fail-open behavior before review did.

## Class sweep

Pattern grep across the whole tree (not just `clients/`) for `.pull_request` payload reads: `scripts/check-close-keywords.mjs` (this fix), `scripts/check-pr-body.mjs` (already fixed, #2085), `scripts/check-pr-title.mjs` (already fixed, #2083/PR #2084), `scripts/lib/stale-open-issues.mjs` (reads `issue`, not PR body — different shape), `.github/workflows/close-keyword-verification.yml` and `.github/workflows/osv-scan.yml` (workflow YAML, not script-level payload reads). No further siblings found. Filed #2268 for a related, out-of-scope finding in `fetchLivePrBody`'s null-body handling; corrected #2268's impact framing in a follow-up comment once F2 changed which caller is affected (`verifyMergedPullRequest` now fails closed on that same null-body shape, where it used to silently degrade through `resolveLivePrBody`).

## Scope not covered here

Out of scope, tracked separately: #2268 (`fetchLivePrBody`'s `body: null` handling — a legitimate empty PR description currently throws and, after this PR, fails the check closed rather than degrading silently).

Refs #2086.
