### PR TITLE
fix(tests): fail loud on stale compiled .js beside tests source (#2232)

### DIFF
--- a/.changelog/2232-stale-test-residue-guard.md
+++ b/.changelog/2232-stale-test-residue-guard.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Make a stale compiled `.js` beside a `tests/**/*.ts` file fail loudly (refs #2232)** — `tests/` is excluded from `npm run build`, so any `.js` sibling of a test-support `.ts` file is leftover residue from an earlier, differently configured local compile. Vitest's import specifiers end in `.js`, so that residue silently wins module resolution over the real source, running stale code with no warning. The build-freshness `globalSetup` now also flags this residue and aborts the run naming the file.

--- a/tests/build-freshness-guard.test.ts
+++ b/tests/build-freshness-guard.test.ts
@@ -130,10 +130,7 @@ describe("check-build-freshness setup() end-to-end (#2232)", () => {
 	// The real repo root, exactly as the globalSetup module computes it —
 	// proves the guard fires against the ACTUAL tests/ tree the whole suite
 	// runs from, not just an isolated fixture.
-	const repoRoot = join(
-		dirname(fileURLToPath(import.meta.url)),
-		"..",
-	);
+	const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 	const probeTs = join(repoRoot, "tests", "support", "__2232-residue-probe.ts");
 	const probeJs = join(repoRoot, "tests", "support", "__2232-residue-probe.js");
 

--- a/tests/build-freshness-guard.test.ts
+++ b/tests/build-freshness-guard.test.ts
@@ -10,13 +10,18 @@ import {
 	mkdirSync,
 	mkdtempSync,
 	rmSync,
+	unlinkSync,
 	utimesSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { findStaleCompiledSources } from "./support/check-build-freshness.js";
+import checkBuildFreshness, {
+	findResidueCompiledTestSources,
+	findStaleCompiledSources,
+} from "./support/check-build-freshness.js";
 
 let root: string;
 const older = new Date("2020-01-01T00:00:00Z");
@@ -77,5 +82,74 @@ describe("findStaleCompiledSources (#198 build-freshness guard)", () => {
 		const r = run();
 		expect(r.some((p) => p.includes("thing.test.ts"))).toBe(false);
 		expect(r.some((p) => p.includes("thing.d.ts"))).toBe(false);
+	});
+});
+
+describe("findResidueCompiledTestSources (#2232 stale test-support residue guard)", () => {
+	let residueRoot: string;
+
+	beforeAll(() => {
+		residueRoot = mkdtempSync(join(tmpdir(), "pi-lens-test-residue-"));
+		const support = join(residueRoot, "tests", "support");
+		mkdirSync(support, { recursive: true });
+		const write = (rel: string) => writeFileSync(join(residueRoot, rel), "");
+
+		// tests/ is never built, so ANY .js sibling of a tests/**/*.ts is residue,
+		// regardless of mtime — unlike findStaleCompiledSources above.
+		write("tests/support/shadowed.ts");
+		write("tests/support/shadowed.js");
+		// no sibling .js: clean, must not be flagged.
+		write("tests/support/clean.ts");
+		// .d.ts is never a real test-support module: must not be flagged even
+		// with a .js sibling.
+		write("tests/support/types.d.ts");
+		write("tests/support/types.js");
+	});
+
+	afterAll(() => rmSync(residueRoot, { recursive: true, force: true }));
+
+	it("flags a .ts file that has a compiled .js sibling", () => {
+		const r = findResidueCompiledTestSources({ root: residueRoot }).map((p) =>
+			p.replace(/\\/g, "/"),
+		);
+		expect(r.some((p) => p.endsWith("tests/support/shadowed.js"))).toBe(true);
+	});
+
+	it("does not flag a .ts file with no compiled sibling", () => {
+		const r = findResidueCompiledTestSources({ root: residueRoot });
+		expect(r.some((p) => p.includes("clean"))).toBe(false);
+	});
+
+	it("ignores .d.ts even when a same-stem .js sits beside it", () => {
+		const r = findResidueCompiledTestSources({ root: residueRoot });
+		expect(r.some((p) => p.includes("types.js"))).toBe(false);
+	});
+});
+
+describe("check-build-freshness setup() end-to-end (#2232)", () => {
+	// The real repo root, exactly as the globalSetup module computes it —
+	// proves the guard fires against the ACTUAL tests/ tree the whole suite
+	// runs from, not just an isolated fixture.
+	const repoRoot = join(
+		dirname(fileURLToPath(import.meta.url)),
+		"..",
+	);
+	const probeTs = join(repoRoot, "tests", "support", "__2232-residue-probe.ts");
+	const probeJs = join(repoRoot, "tests", "support", "__2232-residue-probe.js");
+
+	afterAll(() => {
+		for (const p of [probeTs, probeJs]) {
+			try {
+				unlinkSync(p);
+			} catch {
+				// already absent
+			}
+		}
+	});
+
+	it("throws a loud error naming a planted stale-residue file", () => {
+		writeFileSync(probeTs, "");
+		writeFileSync(probeJs, "");
+		expect(() => checkBuildFreshness()).toThrow(/__2232-residue-probe\.js/);
 	});
 });

--- a/tests/build-freshness-guard.test.ts
+++ b/tests/build-freshness-guard.test.ts
@@ -10,17 +10,16 @@ import {
 	mkdirSync,
 	mkdtempSync,
 	rmSync,
-	unlinkSync,
 	utimesSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import checkBuildFreshness, {
+import {
 	findResidueCompiledTestSources,
 	findStaleCompiledSources,
+	runFreshnessChecks,
 } from "./support/check-build-freshness.js";
 
 let root: string;
@@ -126,27 +125,25 @@ describe("findResidueCompiledTestSources (#2232 stale test-support residue guard
 	});
 });
 
-describe("check-build-freshness setup() end-to-end (#2232)", () => {
-	// The real repo root, exactly as the globalSetup module computes it —
-	// proves the guard fires against the ACTUAL tests/ tree the whole suite
-	// runs from, not just an isolated fixture.
-	const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-	const probeTs = join(repoRoot, "tests", "support", "__2232-residue-probe.ts");
-	const probeJs = join(repoRoot, "tests", "support", "__2232-residue-probe.js");
+describe("runFreshnessChecks() end-to-end (#2232)", () => {
+	// An isolated temp tree, NOT the live repo tests/ directory: planting a
+	// file under the real tests/support/ raced a concurrent
+	// module-instance-scan.ts walk of that same live tree under parallel
+	// test workers (ENOENT observed in review — CI green beforehand was
+	// scheduling luck, not correctness). runFreshnessChecks() takes an
+	// injectable root precisely so this proof never touches the live tree.
+	let e2eRoot: string;
 
-	afterAll(() => {
-		for (const p of [probeTs, probeJs]) {
-			try {
-				unlinkSync(p);
-			} catch {
-				// already absent
-			}
-		}
+	beforeAll(() => {
+		e2eRoot = mkdtempSync(join(tmpdir(), "pi-lens-freshness-e2e-"));
+		mkdirSync(join(e2eRoot, "tests", "support"), { recursive: true });
 	});
 
+	afterAll(() => rmSync(e2eRoot, { recursive: true, force: true }));
+
 	it("throws a loud error naming a planted stale-residue file", () => {
-		writeFileSync(probeTs, "");
-		writeFileSync(probeJs, "");
-		expect(() => checkBuildFreshness()).toThrow(/__2232-residue-probe\.js/);
+		writeFileSync(join(e2eRoot, "tests", "support", "probe.ts"), "");
+		writeFileSync(join(e2eRoot, "tests", "support", "probe.js"), "");
+		expect(() => runFreshnessChecks(e2eRoot)).toThrow(/probe\.js/);
 	});
 });

--- a/tests/support/check-build-freshness.ts
+++ b/tests/support/check-build-freshness.ts
@@ -89,17 +89,70 @@ export function findStaleCompiledSources(opts: {
 	return stale;
 }
 
+/**
+ * `tests/` is excluded from `tsconfig.build.json` (#2232), so `npm run
+ * build` NEVER writes a `.js` sibling there. Any `.js` sibling of a
+ * `tests/**\/*.ts` therefore isn't "stale" in the mtime sense above — it's
+ * pure residue from an earlier local `tsc` invocation that DID include
+ * tests/ (a different tsconfig, an editor auto-compile-on-save, a manual
+ * `npx tsc`). Import specifiers in tests end in `.js`, so that residue
+ * silently wins module resolution over the real `.ts` source and every
+ * later test run in the worktree quietly exercises stale code — this is
+ * exactly what fooled a PR #2226 reviewer into a false "fix doesn't work"
+ * finding. Presence alone is the defect; there's no mtime check to make
+ * because a legitimately fresh compiled `.js` under tests/ can never exist.
+ */
+function* walkTestsTs(dir: string): Generator<string> {
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === "node_modules") continue;
+			yield* walkTestsTs(full);
+		} else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+			yield full;
+		}
+	}
+}
+
+export function findResidueCompiledTestSources(opts: { root: string }): string[] {
+	const residue: string[] = [];
+	for (const ts of walkTestsTs(join(opts.root, "tests"))) {
+		const js = `${ts.slice(0, -3)}.js`;
+		if (existsSync(js)) residue.push(js);
+	}
+	return residue;
+}
+
 export default function setup(): void {
 	const stale = findStaleCompiledSources({ root: repoRoot });
-	if (stale.length === 0) return;
+	if (stale.length > 0) {
+		const rel = (p: string) => p.slice(repoRoot.length + 1).replace(/\\/g, "/");
+		const shown = stale.slice(0, 10).map(rel);
+		const more = stale.length > 10 ? `\n  …and ${stale.length - 10} more` : "";
+		throw new Error(
+			`\n⛔ Stale build: ${stale.length} source file(s) are newer than their compiled .js (or have none).\n` +
+				`Vitest loads the compiled .js next to each .ts (\`npm run build\` emits in place),\n` +
+				`so these edits are NOT under test. Run \`npm run build\` before testing.\n` +
+				`Stale:\n  ${shown.join("\n  ")}${more}\n`,
+		);
+	}
 
-	const rel = (p: string) => p.slice(repoRoot.length + 1).replace(/\\/g, "/");
-	const shown = stale.slice(0, 10).map(rel);
-	const more = stale.length > 10 ? `\n  …and ${stale.length - 10} more` : "";
-	throw new Error(
-		`\n⛔ Stale build: ${stale.length} source file(s) are newer than their compiled .js (or have none).\n` +
-			`Vitest loads the compiled .js next to each .ts (\`npm run build\` emits in place),\n` +
-			`so these edits are NOT under test. Run \`npm run build\` before testing.\n` +
-			`Stale:\n  ${shown.join("\n  ")}${more}\n`,
-	);
+	const residue = findResidueCompiledTestSources({ root: repoRoot });
+	if (residue.length > 0) {
+		const rel = (p: string) => p.slice(repoRoot.length + 1).replace(/\\/g, "/");
+		const shown = residue.slice(0, 10).map(rel);
+		const more = residue.length > 10 ? `\n  …and ${residue.length - 10} more` : "";
+		throw new Error(
+			`\n⛔ Stale test residue: ${residue.length} compiled .js file(s) sit beside tests/**/*.ts source.\n` +
+				`tests/ is excluded from \`npm run build\`, so these were never freshly built — an\n` +
+				`import ending in ".js" resolves to this STALE file instead of the real .ts source,\n` +
+				`silently running old code (#2232). Delete them:\n  ${shown.join("\n  ")}${more}\n`,
+		);
+	}
 }

--- a/tests/support/check-build-freshness.ts
+++ b/tests/support/check-build-freshness.ts
@@ -114,13 +114,19 @@ function* walkTestsTs(dir: string): Generator<string> {
 		if (entry.isDirectory()) {
 			if (entry.name === "node_modules") continue;
 			yield* walkTestsTs(full);
-		} else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+		} else if (
+			entry.isFile() &&
+			entry.name.endsWith(".ts") &&
+			!entry.name.endsWith(".d.ts")
+		) {
 			yield full;
 		}
 	}
 }
 
-export function findResidueCompiledTestSources(opts: { root: string }): string[] {
+export function findResidueCompiledTestSources(opts: {
+	root: string;
+}): string[] {
 	const residue: string[] = [];
 	for (const ts of walkTestsTs(join(opts.root, "tests"))) {
 		const js = `${ts.slice(0, -3)}.js`;
@@ -147,7 +153,8 @@ export default function setup(): void {
 	if (residue.length > 0) {
 		const rel = (p: string) => p.slice(repoRoot.length + 1).replace(/\\/g, "/");
 		const shown = residue.slice(0, 10).map(rel);
-		const more = residue.length > 10 ? `\n  …and ${residue.length - 10} more` : "";
+		const more =
+			residue.length > 10 ? `\n  …and ${residue.length - 10} more` : "";
 		throw new Error(
 			`\n⛔ Stale test residue: ${residue.length} compiled .js file(s) sit beside tests/**/*.ts source.\n` +
 				`tests/ is excluded from \`npm run build\`, so these were never freshly built — an\n` +

--- a/tests/support/check-build-freshness.ts
+++ b/tests/support/check-build-freshness.ts
@@ -20,6 +20,7 @@
 import { type Dirent, existsSync, readdirSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { testSourceFiles } from "./module-instance-scan.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -101,44 +102,40 @@ export function findStaleCompiledSources(opts: {
  * exactly what fooled a PR #2226 reviewer into a false "fix doesn't work"
  * finding. Presence alone is the defect; there's no mtime check to make
  * because a legitimately fresh compiled `.js` under tests/ can never exist.
+ *
+ * Reuses `testSourceFiles` (module-instance-scan.ts, #1565) rather than a
+ * second hand-rolled `tests/` walker: it already excludes `tests/fixtures`
+ * (inputs the fixture's own toolchain owns, not repo tests — e.g. the
+ * native-TS7/Vitest fixture the live integration suite copies out and
+ * type-checks) and `tests/native-ts7-live-*` (that suite's copied-out temp
+ * projects), both proven live false-positive classes for a naive walk. A
+ * duplicate walker that didn't exclude them would abort every run at
+ * `globalSetup`, before a single test executes.
  */
-function* walkTestsTs(dir: string): Generator<string> {
-	let entries: Dirent[];
-	try {
-		entries = readdirSync(dir, { withFileTypes: true });
-	} catch {
-		return;
-	}
-	for (const entry of entries) {
-		const full = join(dir, entry.name);
-		if (entry.isDirectory()) {
-			if (entry.name === "node_modules") continue;
-			yield* walkTestsTs(full);
-		} else if (
-			entry.isFile() &&
-			entry.name.endsWith(".ts") &&
-			!entry.name.endsWith(".d.ts")
-		) {
-			yield full;
-		}
-	}
-}
-
 export function findResidueCompiledTestSources(opts: {
 	root: string;
 }): string[] {
 	const residue: string[] = [];
-	for (const ts of walkTestsTs(join(opts.root, "tests"))) {
+	for (const ts of testSourceFiles(join(opts.root, "tests"))) {
+		if (ts.endsWith(".d.ts")) continue;
 		const js = `${ts.slice(0, -3)}.js`;
 		if (existsSync(js)) residue.push(js);
 	}
 	return residue;
 }
 
-export default function setup(): void {
-	const stale = findStaleCompiledSources({ root: repoRoot });
+/**
+ * The checks vitest's `globalSetup` runs, against an injectable `root` so
+ * tests can point it at an isolated temp tree instead of racing the live
+ * repo (#2270 review: the previous end-to-end test planted files directly
+ * under the real `tests/support/`, which a concurrent `module-instance-scan`
+ * walk of the same live tree could observe mid-write — `ENOENT` under
+ * parallel test workers, not a `.gitignore`/build-freshness violation).
+ */
+export function runFreshnessChecks(root: string): void {
+	const stale = findStaleCompiledSources({ root });
 	if (stale.length > 0) {
-		const rel = (p: string) => p.slice(repoRoot.length + 1).replace(/\\/g, "/");
+		const rel = (p: string) => p.slice(root.length + 1).replace(/\\/g, "/");
 		const shown = stale.slice(0, 10).map(rel);
 		const more = stale.length > 10 ? `\n  …and ${stale.length - 10} more` : "";
 		throw new Error(
@@ -149,9 +146,9 @@ export default function setup(): void {
 		);
 	}
 
-	const residue = findResidueCompiledTestSources({ root: repoRoot });
+	const residue = findResidueCompiledTestSources({ root });
 	if (residue.length > 0) {
-		const rel = (p: string) => p.slice(repoRoot.length + 1).replace(/\\/g, "/");
+		const rel = (p: string) => p.slice(root.length + 1).replace(/\\/g, "/");
 		const shown = residue.slice(0, 10).map(rel);
 		const more =
 			residue.length > 10 ? `\n  …and ${residue.length - 10} more` : "";
@@ -162,4 +159,8 @@ export default function setup(): void {
 				`silently running old code (#2232). Delete them:\n  ${shown.join("\n  ")}${more}\n`,
 		);
 	}
+}
+
+export default function setup(): void {
+	runFreshnessChecks(repoRoot);
 }


### PR DESCRIPTION
## Summary

Makes a stale compiled `.js` beside a `tests/**/*.ts` source file fail
loudly at vitest startup, instead of silently shadowing the real source.
Refs #2232; the acceptance criteria for a loud, proven guard are met.

## What

Extends the existing build-freshness `globalSetup` (`tests/support/check-build-freshness.ts`, #198) to also fail loudly when a compiled `.js` file sits beside a `tests/**/*.ts` source file.

## Why

`tsconfig.build.json` excludes `tests/`, so `npm run build` never writes a `.js` sibling there. Any `.js` next to a `tests/**/*.ts` file is therefore pure residue from an earlier, differently configured local compile — a stray `tsc` invocation, an editor's compile-on-save. Test import specifiers end in `.js`, so that residue silently wins module resolution over the real source, and every later test run in the worktree quietly exercises stale code. `.gitignore` hides the `.js` from `git status`, so nothing flags it.

This isn't hypothetical: during the PR #2226 verify round, a reviewer's probe of `tests/support/availability-classifiedby-scan.ts` falsely reproduced pre-fix behavior because a stale `.js` sibling shadowed it. The contradiction between the probe result and the diff just read was the only tell.

The existing `#198` guard already solves this exact class of bug for `clients/commands/tools` (comparing `.ts` mtime against `.js` mtime), but its own comment explicitly assumed `tests/` was "not at risk" since build never touches it — which is precisely backward: build never touching it means any `.js` there is unconditionally residue, not conditionally stale.

## Fix

- `findResidueCompiledTestSources(root)`: walks `tests/`, flags every `.ts` (excluding `.d.ts`) that has a `.js` sibling, no mtime comparison needed (presence alone is the defect, since a fresh one can never legitimately exist).
- `setup()` now checks this after the existing stale-build check and throws with the specific file path(s).

## Verification

Red-first, quoted verbatim from local runs (Windows, this worktree):

Pre-fix source (`git show 9640ac05:tests/support/check-build-freshness.ts`, keeping the new tests):

```
TypeError: findResidueCompiledTestSources is not a function
 ...
 FAIL  tests/build-freshness-guard.test.ts > check-build-freshness setup() end-to-end (#2232) > throws a loud error naming a planted stale-residue file
AssertionError: expected [Function] to throw an error
 Test Files  1 failed (1)
      Tests  4 failed | 4 passed (8)
```

Post-fix:

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

The acceptance criterion "planting a synthetic stale `.js` sibling must produce a loud failure naming the file" is proven end-to-end, not just via the pure function: the new `"throws a loud error naming a planted stale-residue file"` test plants `tests/support/__2232-residue-probe.ts` + `.js` in the REAL repo tree and calls the actual `setup()` export (the literal globalSetup vitest runs), asserting the thrown message names the planted file. Cleaned up in `afterAll`.

Sibling file `tests/clients/atomic-write.test.ts` (references `check-build-freshness.ts` in a comment, not code) — unaffected, still green.

Governance sweeps, all green after a resource-contention retry (running all 11 in one batch caused spurious timeouts unrelated to this change — confirmed by re-running failed ones individually/in smaller batches):
delivery-surface-ratchet, finding-delivery-gate, session-state-conformance, bounded-telemetry-sweep, bus-producer-coverage, deps-centralization, freshness-sweep, managed-tool-seam-coverage, profiling-coverage, module-instance-coverage, sweep-floor-coverage — 11 files, 162 tests, all passed across two batches.

Full suite deferred to CI (#1112 serialization).

## Test assessment

- `tests/build-freshness-guard.test.ts`: three new `describe` blocks pin
  the new behavior — the pure `findResidueCompiledTestSources` detection
  logic (isolated fixture, three cases), and an end-to-end case that plants
  a real file beside `tests/support/` and calls the actual `setup()`
  export. No existing case becomes redundant; the pre-existing `#198`
  cases still pin the separate mtime-staleness contract for
  `clients/commands/tools`, which this PR doesn't touch.

## AGENTS.md note

Per the acceptance criteria, no AGENTS.md worktree-hygiene update is included — the fix is a loud in-process guard, not a documented manual sweep step, so there's no new procedure for a human/agent to remember.

## Class sweep

Pattern: this is the second `.ts`/`.js` shadow site in the repo (the first being the exact #198 mtime-based one this PR extends). Grepped `clients/ tools/ mcp/ scripts/ index.ts` for other directories excluded from `tsconfig.build.json` that also load `.ts` sources directly at runtime (not compiled) — only `tests/` fits that shape (`scripts/*.mjs` files aren't compiled from `.ts`, and `commands/`/`tools/` ARE in the build). No sibling site needs the same fix.

## Blast radius

Adds one more filesystem walk to `globalSetup`, run once per vitest process launch (not per test). `tests/` currently contains ~1400 `.ts` files; the walk is a plain `readdirSync` recursion with no I/O beyond `existsSync` per file, comparable in cost to the existing `clients/tools/commands` walk it sits beside. No production code path is touched — `tests/support/check-build-freshness.ts` only runs under vitest.

## Observability

The guard's thrown error IS the record — it aborts the vitest process with the specific residue file path(s) named, so the failure can never silently pass. No separate log/ledger applies; this is local-dev-only test infrastructure, never reached by CI (CI always runs a clean checkout).

## Fix round (review findings)

- **F1 (blocking) — end-to-end proof raced the live tree.** The prior
  `"throws a loud error naming a planted stale-residue file"` test planted
  files directly under the real `tests/support/`. A concurrent
  `module-instance-scan.ts` walk of that same live tree could observe the
  plant mid-write under parallel workers (reviewer reproduced `ENOENT`) —
  CI green before this fix round was scheduling luck, not correctness.
  `setup()` is now split: `runFreshnessChecks(root: string)` does the real
  work against an injectable root; `setup()` (the actual zero-arg
  `globalSetup` vitest calls) delegates to it with the real `repoRoot`. The
  end-to-end test now plants its probe in an isolated `mkdtempSync` tree and
  calls `runFreshnessChecks` directly, never touching the live repo.
- **F2 (high, reuse) — hand-rolled walker only excluded `node_modules`.**
  Replaced `findResidueCompiledTestSources`'s own `walkTestsTs` with
  `testSourceFiles()` (`tests/support/module-instance-scan.ts:103-118`,
  #1565), which already excludes `tests/fixtures/**` and
  `tests/native-ts7-live-*/**` — both proven-live false-positive classes.
  Either one would have aborted the whole suite at `globalSetup`, before a
  single test ran, the first time this repo grew a fixture or live-copy
  file with an accidental `.js` sibling.

Red-first for both, quoted verbatim (reverted only `check-build-freshness.ts`
to its pre-fix-round commit, kept the rewritten test):

```
TypeError: expected [Function] to throw error matching /probe\.js/ but got
'(0 , __vite_ssr_import_4__.runFreshnessChecks) is not a function'
 Test Files  1 failed (1)
      Tests  1 failed | 7 passed (8)
```

Post-fix: `Test Files  1 passed (1)` / `Tests  8 passed (8)`.

Merged `origin/master` (was behind — #2258/#2264 landed mid-review); clean,
no conflicts. Targeted + governance suites rerun after merge: 13 files, 192
tests passed, 3 skipped.

Refs #2232


