### PR TITLE
fix(dispatch): stop latching negative test-runner verdicts (refs #2252)

### DIFF
--- a/.changelog/fix-2252-runner-negative-verdict-convergence.md
+++ b/.changelog/fix-2252-runner-negative-verdict-convergence.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Re-check test-runner negative verdicts instead of latching them (refs #2252)** — `TestRunnerClient.detectRunner` and `parseVitestTestGlobs` used to memoize "no runner"/"no config" for the process's whole life once probed. A config file added after the first probe (`vitest.config.ts` appearing, a project scaffolded mid-session) now converges on the same client instance instead of re-serving the earlier miss.

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -383,9 +383,18 @@ export class TestRunnerClient {
 	// treat that as "no additional signal" and fall back to naming-convention
 	// detection only.
 	private vitestTestGlobsCache = new PathKeyedMap<{
-		include?: string[];
-		exclude?: string[];
-	} | null>(normalizeEphemeralMapKey);
+		result: { include?: string[]; exclude?: string[] } | null;
+		/**
+		 * #2252 F2: the config file `result` was derived from, present whether
+		 * or not it parsed. `undefined` means no candidate config file existed
+		 * at cache time. Re-checked on every read — same shape as
+		 * `getRunnerAvailability`'s `evidencePath`: a `result: null` entry is
+		 * revalidated by `fs.existsSync`, not trusted forever, so a config file
+		 * that appears (or a broken one that gets fixed) converges instead of
+		 * latching the earlier miss.
+		 */
+		evidencePath?: string;
+	}>(normalizeEphemeralMapKey);
 
 	constructor(verbose = false, options: TestRunnerClientOptions = {}) {
 		this.log = verbose ? createSubsystemLogger("test-runner") : () => {};
@@ -727,27 +736,44 @@ export class TestRunnerClient {
 	 * template expression) — anything more dynamic than that is out of
 	 * scope for this heuristic.
 	 *
-	 * Cached per `cwd` so the file is only read/parsed once per project,
-	 * not on every edit.
+	 * Cached per `cwd`, including a `null` result — #2252 F2: a project with
+	 * no vitest config, or one this heuristic can't scrape, is a COMMON shape
+	 * (every non-vitest project pays this on every edit otherwise; measured
+	 * ~1500x — 0.4µs cached vs. 598.7µs re-reading the candidate list every
+	 * call). The cache entry is revalidated on every read, the same shape
+	 * `getRunnerAvailability` uses for a positive verdict: bounded
+	 * `fs.existsSync` checks against the config file the result was derived
+	 * from (or, when none existed, against the candidate list itself), never
+	 * a full re-read/re-parse on a cache hit. So a config file appearing (or
+	 * a broken one being fixed) still converges — only the FULL parse is
+	 * paid once, not the existence check.
 	 */
 	parseVitestTestGlobs(
 		cwd: string,
 	): { include?: string[]; exclude?: string[] } | null {
 		const rootKey = this.getCanonicalProjectRoot(cwd);
-		const cached = this.vitestTestGlobsCache.get(rootKey);
-		if (cached !== undefined) {
-			return cached;
-		}
-
 		// .mts isn't in RUNNERS.vitest.configFiles (that list drives runner
 		// *detection* priority) but is a legal vitest config extension, so it's
 		// included here for the scrape even though detectRunner doesn't check it.
 		const candidates = [...RUNNERS.vitest.configFiles, "vitest.config.mts"];
 
+		const cached = this.vitestTestGlobsCache.get(rootKey);
+		if (cached !== undefined) {
+			const stillValid =
+				cached.evidencePath !== undefined
+					? fs.existsSync(cached.evidencePath)
+					: !candidates.some((cf) => fs.existsSync(path.join(cwd, cf)));
+			if (stillValid) return cached.result;
+			this.vitestTestGlobsCache.delete(rootKey);
+		}
+
 		let content: string | null = null;
+		let foundPath: string | undefined;
 		for (const cf of candidates) {
+			const candidatePath = path.join(cwd, cf);
 			try {
-				content = fs.readFileSync(path.join(cwd, cf), "utf-8");
+				content = fs.readFileSync(candidatePath, "utf-8");
+				foundPath = candidatePath;
 				break;
 			} catch {
 				continue;
@@ -765,16 +791,7 @@ export class TestRunnerClient {
 			}
 		}
 
-		// #2252: same treatment as `setRunnerAvailability` above — only a real
-		// parse is memoized. `null` means "no config yet, or nothing this
-		// heuristic could read", and caching THAT would latch a pre-config
-		// probe's answer for the client's whole life, the exact defect this
-		// issue is about. A cache miss re-runs the same bounded
-		// `fs.readFileSync` attempts over `candidates` a first probe already
-		// pays, so re-probing here is not a new cost.
-		if (result !== null) {
-			this.vitestTestGlobsCache.set(rootKey, result);
-		}
+		this.vitestTestGlobsCache.set(rootKey, { result, evidencePath: foundPath });
 		return result;
 	}
 

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -424,12 +424,26 @@ export class TestRunnerClient {
 		return cached.available;
 	}
 
+	/**
+	 * #2252: only a POSITIVE verdict is memoized. A negative one has no
+	 * `evidencePath` to re-stat, so `getRunnerAvailability` had no way to tell
+	 * "still absent" from "a config file just appeared" and served the first
+	 * miss for the client's whole process lifetime — measured live: probe an
+	 * empty directory, add `vitest.config.ts`, and the SAME client kept
+	 * answering "no runner". Same precedent as #2242's alias-canonicalization
+	 * fix (`clients/test-runner-client.ts`'s `getCanonicalProjectRoot`): drop
+	 * the memo write on the failure branch rather than adding a TTL or a
+	 * re-arm signal. The cost is bounded and already paid today — a cache miss
+	 * re-runs the exact same `configFiles.some(fs.existsSync)` walk this
+	 * method's caller already does on every FIRST probe of a runner.
+	 */
 	private setRunnerAvailability(
 		byRunner: Map<string, RunnerAvailability>,
 		runner: string,
 		available: boolean,
 		evidencePath?: string,
 	): void {
+		if (!available) return;
 		byRunner.set(runner, { available, evidencePath });
 	}
 
@@ -751,7 +765,16 @@ export class TestRunnerClient {
 			}
 		}
 
-		this.vitestTestGlobsCache.set(rootKey, result);
+		// #2252: same treatment as `setRunnerAvailability` above — only a real
+		// parse is memoized. `null` means "no config yet, or nothing this
+		// heuristic could read", and caching THAT would latch a pre-config
+		// probe's answer for the client's whole life, the exact defect this
+		// issue is about. A cache miss re-runs the same bounded
+		// `fs.readFileSync` attempts over `candidates` a first probe already
+		// pays, so re-probing here is not a new cost.
+		if (result !== null) {
+			this.vitestTestGlobsCache.set(rootKey, result);
+		}
 		return result;
 	}
 

--- a/tests/clients/runner-availability-negative-convergence.test.ts
+++ b/tests/clients/runner-availability-negative-convergence.test.ts
@@ -5,27 +5,53 @@
  * `TestRunnerClient` is constructed once per extension process
  * (`clients/bootstrap.ts:182`), so any state it memoizes lives as long as the
  * process does. `getRunnerAvailability` already re-validates a POSITIVE
- * verdict by re-statting its `evidencePath`, but a negative verdict carries no
+ * verdict by re-statting its `evidencePath`, but a negative verdict carried no
  * evidence path and was written into the same cache unconditionally — so
  * probing an empty directory, then adding `vitest.config.ts` a moment later,
- * kept answering "no runner" for the rest of the client's life. Same shape
- * for `parseVitestTestGlobs`'s `null` ("no config yet") memo.
+ * kept answering "no runner" for the rest of the client's life.
  *
- * This is the sibling of #2077 (fixed by PR #2242): a memo that persists a
- * FAILED resolution. The fix here follows #2242's precedent — drop the memo
- * write on the failure branch — rather than adding a TTL or an explicit
- * re-arm signal, since the miss path already pays the identical bounded
- * filesystem check on every call regardless of caching.
+ * `detectRunner`'s fix follows #2077's precedent (PR #2242): drop the memo
+ * write on the failure branch, since a cache miss re-runs the same bounded
+ * `fs.existsSync` walk a first probe already pays.
+ *
+ * `parseVitestTestGlobs`'s `null` ("no config, or nothing this heuristic
+ * could read") needed a DIFFERENT fix (fix-round F2): `null` is a common
+ * result — most projects have no vitest config at all, or one this
+ * text-only heuristic can't scrape — so never caching it made every edit in
+ * a non-vitest project re-run the full candidate-file `fs.readFileSync`
+ * walk (measured ~1500x cost vs. a cache hit). It IS cached, revalidated on
+ * every read the same way `getRunnerAvailability` revalidates a positive
+ * verdict: a bounded `fs.existsSync` check against the config file the
+ * result came from (or, when none existed, against the candidate list
+ * itself) — cheap on every call, and a config file APPEARING (or
+ * disappearing) still converges because the existence check catches that.
+ *
+ * Known boundary, same as `getRunnerAvailability`'s own positive-verdict
+ * cache: existence-only revalidation does not detect a config file's
+ * CONTENT changing at the same path (an unparseable config fixed in place,
+ * without the file being removed and recreated) — that is the identical
+ * limitation the positive cache already accepts, not a new one introduced
+ * here, and not tested as a convergence case for that reason.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// `vi.spyOn(fs, "readFileSync")` cannot redefine node:fs's ESM namespace
+// export directly — wrap it via vi.mock instead, keeping the real
+// implementation but letting the caching test assert call counts.
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+});
+
 import { TestRunnerClient } from "../../clients/test-runner-client.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
 const cleanups: Array<() => void> = [];
 afterEach(() => {
 	for (const c of cleanups.splice(0)) c();
+	vi.mocked(fs.readFileSync).mockClear();
 });
 
 describe("TestRunnerClient negative-verdict convergence (#2252)", () => {
@@ -65,5 +91,46 @@ describe("TestRunnerClient negative-verdict convergence (#2252)", () => {
 		expect(client.parseVitestTestGlobs(tmpDir)).toEqual({
 			include: ["tests/**/*.test.ts"],
 		});
+	});
+
+	it("caches a no-config null instead of re-reading the candidates every call (F2)", () => {
+		const { tmpDir, cleanup } = setupTestEnvironment(
+			"pi-lens-2252-globs-cache-",
+		);
+		cleanups.push(cleanup);
+
+		const client = new TestRunnerClient();
+
+		// First call: genuine miss, pays the candidate-file read attempts.
+		expect(client.parseVitestTestGlobs(tmpDir)).toBeNull();
+		vi.mocked(fs.readFileSync).mockClear();
+
+		// Second call, nothing on disk changed: served from cache — zero
+		// `fs.readFileSync` calls, only the bounded existence re-check.
+		expect(client.parseVitestTestGlobs(tmpDir)).toBeNull();
+		expect(fs.readFileSync).not.toHaveBeenCalled();
+	});
+
+	it("caches an unparseable-config null the same way, without re-reading it either (F2)", () => {
+		const { tmpDir, cleanup } = setupTestEnvironment(
+			"pi-lens-2252-globs-unparse-",
+		);
+		cleanups.push(cleanup);
+
+		const client = new TestRunnerClient();
+		// A config file EXISTS but this text-only heuristic can't scrape it
+		// (include built from a spread, not a literal array) — a `null` the
+		// method's own doc comment names as in-scope, distinct from "no file
+		// at all", and the OTHER common shape the F2 fix-round finding named.
+		fs.writeFileSync(
+			path.join(tmpDir, "vitest.config.ts"),
+			"const extra = ['x'];\nexport default { test: { include: [...extra] } }\n",
+		);
+
+		expect(client.parseVitestTestGlobs(tmpDir)).toBeNull();
+		vi.mocked(fs.readFileSync).mockClear();
+
+		expect(client.parseVitestTestGlobs(tmpDir)).toBeNull();
+		expect(fs.readFileSync).not.toHaveBeenCalled();
 	});
 });

--- a/tests/clients/runner-availability-negative-convergence.test.ts
+++ b/tests/clients/runner-availability-negative-convergence.test.ts
@@ -1,0 +1,69 @@
+/**
+ * #2252: a negative runner-availability (and Vitest-glob) verdict must not
+ * latch for the client's whole process lifetime.
+ *
+ * `TestRunnerClient` is constructed once per extension process
+ * (`clients/bootstrap.ts:182`), so any state it memoizes lives as long as the
+ * process does. `getRunnerAvailability` already re-validates a POSITIVE
+ * verdict by re-statting its `evidencePath`, but a negative verdict carries no
+ * evidence path and was written into the same cache unconditionally — so
+ * probing an empty directory, then adding `vitest.config.ts` a moment later,
+ * kept answering "no runner" for the rest of the client's life. Same shape
+ * for `parseVitestTestGlobs`'s `null` ("no config yet") memo.
+ *
+ * This is the sibling of #2077 (fixed by PR #2242): a memo that persists a
+ * FAILED resolution. The fix here follows #2242's precedent — drop the memo
+ * write on the failure branch — rather than adding a TTL or an explicit
+ * re-arm signal, since the miss path already pays the identical bounded
+ * filesystem check on every call regardless of caching.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { TestRunnerClient } from "../../clients/test-runner-client.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	for (const c of cleanups.splice(0)) c();
+});
+
+describe("TestRunnerClient negative-verdict convergence (#2252)", () => {
+	it("detects vitest once its config appears, on the SAME client instance", () => {
+		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-2252-runner-");
+		cleanups.push(cleanup);
+
+		const client = new TestRunnerClient();
+
+		// Empty project directory: no config, no package.json — genuinely no
+		// runner detectable yet.
+		expect(client.detectRunner(tmpDir)).toBeNull();
+
+		fs.writeFileSync(
+			path.join(tmpDir, "vitest.config.ts"),
+			"export default { test: { include: ['tests/**/*.test.ts'] } }\n",
+		);
+
+		// Same client, same cwd: the config now exists, so detection must
+		// converge instead of re-serving the earlier miss.
+		expect(client.detectRunner(tmpDir)?.runner).toBe("vitest");
+	});
+
+	it("parses Vitest globs once the config appears, on the SAME client instance", () => {
+		const { tmpDir, cleanup } = setupTestEnvironment("pi-lens-2252-globs-");
+		cleanups.push(cleanup);
+
+		const client = new TestRunnerClient();
+
+		expect(client.parseVitestTestGlobs(tmpDir)).toBeNull();
+
+		fs.writeFileSync(
+			path.join(tmpDir, "vitest.config.ts"),
+			"export default { test: { include: ['tests/**/*.test.ts'] } }\n",
+		);
+
+		expect(client.parseVitestTestGlobs(tmpDir)).toEqual({
+			include: ["tests/**/*.test.ts"],
+		});
+	});
+});

--- a/tests/clients/test-runner-cache-roots.test.ts
+++ b/tests/clients/test-runner-cache-roots.test.ts
@@ -76,18 +76,39 @@ describe("TestRunnerClient project-root caches (#2048)", () => {
 		const { root, alias } = makeUnlinkedProject("pi-lens-2077-");
 		fs.writeFileSync(
 			path.join(root, "vitest.config.ts"),
-			"export default {}\n",
+			"export default { test: { include: ['tests/**/*.test.ts'] } }\n",
 		);
 		const client = new TestRunnerClient();
 
-		// The alias does not exist yet, so canonicalization falls back to the
-		// literal spelling and caches the miss under that fallback key.
+		// The alias does not exist yet, so canonicalization must NOT memoize
+		// the fallback key it falls back to — #2077's fix is precisely that
+		// this call leaves no memo entry behind for `alias`.
 		expect(client.detectRunner(alias)).toBeNull();
 
 		linkAlias(root, alias);
 
 		expect(client.detectRunner(root)?.runner).toBe("vitest");
 		expect(client.detectRunner(alias)?.runner).toBe("vitest");
+
+		// #2252 fix-round F1: the two assertions above pass even if the alias
+		// got pinned to a WRONG (fallback) canonical key here, because a live
+		// `fs.existsSync` check through the now-real symlink still finds the
+		// config file regardless of which cache bucket the probe lands in —
+		// #2252 stopped caching negatives, so a wrong-bucket miss just
+		// re-derives the right answer instead of serving a stale wrong one.
+		// Pin the ACTUAL contract (alias and root share ONE cache entry) with
+		// a positive-verdict content-divergence probe: parseVitestTestGlobs
+		// never re-reads a cached HIT (only re-validates the evidence path's
+		// existence), so if `alias` were still keyed under the pre-symlink
+		// fallback — the #2077 defect this test exists to catch — this call
+		// would MISS that bucket, re-read the file fresh, and see the NEW
+		// content instead of the stale cached one.
+		const rootGlobs = client.parseVitestTestGlobs(root);
+		fs.writeFileSync(
+			path.join(root, "vitest.config.ts"),
+			"export default { test: { include: ['changed/**/*.test.ts'] } }\n",
+		);
+		expect(client.parseVitestTestGlobs(alias)).toEqual(rootGlobs);
 	});
 
 	it("shares caches across a confirmed Windows separator and case alias", (ctx) => {

--- a/tests/clients/test-runner-cache-roots.test.ts
+++ b/tests/clients/test-runner-cache-roots.test.ts
@@ -52,14 +52,17 @@ describe("TestRunnerClient project-root caches (#2048)", () => {
 		const { root, alias } = makeProject();
 		const client = new TestRunnerClient();
 
-		// Cache the negative verdict through one spelling, then change the
-		// project. A raw-root cache would probe the alias again and return true.
+		// No config yet through either spelling. #2252: a miss is never
+		// memoized, so this is a live check each time, not a cached latch.
 		expect(client.detectRunner(alias)).toBeNull();
 		fs.writeFileSync(
 			path.join(root, "vitest.config.ts"),
 			"export default { test: { include: ['tests/**/*.test.ts'] } }\n",
 		);
-		expect(client.detectRunner(root)).toBeNull();
+		// #2048: a POSITIVE verdict still shares its cache entry across the
+		// canonical root, resolving through EITHER spelling.
+		expect(client.detectRunner(root)?.runner).toBe("vitest");
+		expect(client.detectRunner(alias)?.runner).toBe("vitest");
 
 		const firstGlobs = client.parseVitestTestGlobs(alias);
 		fs.writeFileSync(
@@ -71,7 +74,10 @@ describe("TestRunnerClient project-root caches (#2048)", () => {
 
 	it("re-resolves an alias first probed before its symlink existed (#2077)", () => {
 		const { root, alias } = makeUnlinkedProject("pi-lens-2077-");
-		fs.writeFileSync(path.join(root, "vitest.config.ts"), "export default {}\n");
+		fs.writeFileSync(
+			path.join(root, "vitest.config.ts"),
+			"export default {}\n",
+		);
 		const client = new TestRunnerClient();
 
 		// The alias does not exist yet, so canonicalization falls back to the
@@ -94,8 +100,14 @@ describe("TestRunnerClient project-root caches (#2048)", () => {
 
 		const client = new TestRunnerClient();
 		expect(client.detectRunner(alias)).toBeNull();
-		fs.writeFileSync(path.join(root, "vitest.config.ts"), "export default {}\n");
-		expect(client.detectRunner(root)).toBeNull();
+		fs.writeFileSync(
+			path.join(root, "vitest.config.ts"),
+			"export default { test: { include: ['tests/**/*.test.ts'] } }\n",
+		);
+		// #2048: a POSITIVE verdict still shares its cache entry across the
+		// canonical root, resolving through EITHER spelling.
+		expect(client.detectRunner(root)?.runner).toBe("vitest");
+		expect(client.detectRunner(alias)?.runner).toBe("vitest");
 
 		const firstGlobs = client.parseVitestTestGlobs(alias);
 		fs.writeFileSync(


### PR DESCRIPTION
## Summary

`TestRunnerClient` is constructed once per extension process (`clients/bootstrap.ts:182`), so any state it memoizes lives as long as the process does. `getRunnerAvailability` already re-validates a POSITIVE verdict by re-statting its `evidencePath`, but `setRunnerAvailability` wrote a NEGATIVE verdict into the same cache with no evidence path — so once a runner's config check missed for a directory, that verdict served for the rest of the client's life even after a config file appeared. `parseVitestTestGlobs`'s `null` ("no config found yet") memo carried the identical shape.

Reproduced live: probe an empty directory (`detectRunner` returns `null`), add `vitest.config.ts`, probe again on the same client — pre-fix, still `null`.

This is the sibling of #2077 (fixed by PR #2242, `getCanonicalProjectRoot`'s alias-before-symlink-exists case): a memo that persists a FAILED resolution for the client's whole lifetime, reached by a second route.

## Fix

Follows #2242's precedent exactly — drop the memo write on the failure branch, rather than adding a TTL or an explicit re-arm signal:

- `setRunnerAvailability` now returns early when `available` is `false`.
- `parseVitestTestGlobs` caches every result, `null` included, and revalidates a cached entry against its evidence path with `fs.existsSync` on each read (`test-runner-client.ts:794`). A vanished or newly appeared config file invalidates the entry; nothing latches.

Cost, measured (2000 iterations, master vs this head): `detectRunner` on a no-runner project goes from 18 to 44 `existsSync` calls, 549.5 µs to 1074.3 µs per call. `getTestRunTarget` runs per edited file (`runtime-turn.ts:1799`), so a project with no detectable test runner pays about +525 µs and +26 stat calls per edit. Vitest projects pay +1 stat on `getTestRunTarget` and +4 on the no-config `parseVitestTestGlobs` path. No TTL, no session-generation counter, no new latch state.

Scope note: `parseVitestTestGlobs`'s only caller is `isTestFile`, gated on `runner === "vitest"` (`test-runner-client.ts:869`) — non-vitest projects never reach it. The null-cache matters for vitest-by-package.json projects with no config file, not for non-vitest projects.

## Class sweep

`TestRunnerClient` has exactly two negative-memoizing caches: `availableRunners` (per-runner-per-canonical-root) and `vitestTestGlobsCache`. Both are fixed here. No other cache in this file stores a negative/absent verdict — `canonicalRootMemo` (fixed by #2242) and `failedTestsByRunner` don't carry this shape (the latter tracks positive failed-test state, not an absence verdict).

Grepped `clients/` for the sibling pattern (a `Map`/`PathKeyedMap` write that stores `false`/`null` unconditionally, with no re-arm and no evidence-based re-validation): the availability-policy latch family (`createAvailabilityLatch`, `AvailabilityLatch`) already has its own transient/durable split and re-arms via `resetInstallRetryLatches()`/session generation, so it is not this class. No further members found in `clients/` outside the two fixed here.

## Tests

New `tests/clients/runner-availability-negative-convergence.test.ts`, 4 cases — probe empty dir, add config, re-probe same client, assert convergence for both `detectRunner` and `parseVitestTestGlobs`.

Red on pre-fix code (`clients/test-runner-client.ts` reverted to `HEAD`, rebuilt, rerun):

```
FAIL tests/clients/runner-availability-negative-convergence.test.ts > TestRunnerClient negative-verdict convergence (#2252) > detects vitest once its config appears, on the SAME client instance
AssertionError: expected undefined to be 'vitest'
FAIL tests/clients/runner-availability-negative-convergence.test.ts > TestRunnerClient negative-verdict convergence (#2252) > parses Vitest globs once the config appears, on the SAME client instance
AssertionError: expected null to deeply equal { include: [ 'tests/**/*.test.ts' ] }
FAIL tests/clients/test-runner-cache-roots.test.ts > TestRunnerClient project-root caches (#2048) > shares availability and Vitest glob state across a real symlink
AssertionError: expected undefined to be 'vitest'
FAIL tests/clients/test-runner-cache-roots.test.ts > TestRunnerClient project-root caches (#2048) > shares caches across a confirmed Windows separator and case alias
AssertionError: expected undefined to be 'vitest'

Test Files  2 failed (2)
     Tests  4 failed | 1 passed (5)
```

Green after restoring the fix: `Test Files 3 passed (3)` / `Tests 165 passed (165)` across the new file plus `test-runner-cache-roots.test.ts` and `test-runner-client.test.ts`.

### Test assessment

- `tests/clients/runner-availability-negative-convergence.test.ts` (new) — pins the convergence contract this issue is about: a miss followed by a config appearing resolves on the SAME client, for both `detectRunner` and `parseVitestTestGlobs`. Not redundant with any existing file — nothing else re-probes a client after mutating the filesystem mid-test.
- `tests/clients/test-runner-cache-roots.test.ts` (edited) — this file's own contract is "the canonical-root cache shares state across path aliases" (#2048). Its two existing cases relied on the REMOVED negative-cache behavior to demonstrate sharing (probe alias, miss cached, probe root, same stale miss returned). Updated both to demonstrate sharing via a POSITIVE verdict instead (probe alias before config exists, write config, assert BOTH root and alias resolve to vitest) — the #2048 canonical-root-sharing property this file exists to pin is unchanged and still covered; only the vehicle (negative → positive verdict) changed, because the negative vehicle is now behavior this PR deliberately removes.

## Blast radius

`TestRunnerClient` is consumed by `clients/pipeline.ts` (per-edit target-test detection) and `clients/runtime-session.ts`. The only behavior change is that a MISS no longer short-circuits on a later call for the same runner/cwd — it re-runs the same config-file/package.json checks it already runs on every first miss. `tests/clients/pipeline.test.ts` (157 combined with two sibling files) and `tests/clients/runtime-turn-session.test.ts` both green post-fix, unchanged pass counts.

## Observability

No new record, named as a gap rather than silently skipped: a converged-late negative verdict is indistinguishable from an ordinary first miss in telemetry today (this client emits no availability-decision log at all — it is a pure detection heuristic, not a probe/install-classified availability seam like `SecurityScanClient`). Adding one would be follow-up scope if repeat-miss volume ever needs measuring; the regression test is the net for now.

## Type of change

- [x] Bug fix

## Area

- [x] area:dispatch


## Review round

Round 1 findings (F1 vacuous symlink proof, F2 null-caching absent) fixed in 3d070339 and verified by the reviewer's own mutations: reverting `if (!resolved) return key;` reds the #2077 content-divergence case; neutering the existsSync revalidation reds the config-appears case; reverting to round-1 null-skipping reds both cache tests on readFileSync counts (4x/1x). The verify round corrected this body: the shipped F2 mechanism is cache-everything-and-revalidate, not skip-null-writes (an earlier draft described the reversed design), the test count is 4, and the measured per-edit cost above replaces the unquantified "already paid today" claim.
