### PR TITLE
fix(obs): split loop_block into compute vs non-CPU stall and name the sweep (refs #1980, refs #1723)

### DIFF
--- a/.changelog/1723-1980-loop-block-stall-class.md
+++ b/.changelog/1723-1980-loop-block-stall-class.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Split `loop_block` into compute and non-CPU stalls, and name the sweep that caused one (refs #1980, #1723)** — every `loop_block` record now carries `stallClass` (`below-floor`, `cpu-accounted`, `non-cpu-stall`, `system-stall`) and `cpuCoverageRatio`, derived from the `windowCpuMs` that has sat unread beside `durationMs` since #1122. Nine of sixteen genuine 5s+ blocks in a 23h window burned less CPU than the block lasted; those now read as parked, not as work. `suspectSystemStall` is unchanged. The LSP workspace-diagnostics sweep's per-file touch is also bracketed now, so a block inside it names `lsp_workspace_diagnostics_touch` instead of arriving anonymous.

--- a/clients/event-loop-monitor.ts
+++ b/clients/event-loop-monitor.ts
@@ -234,7 +234,9 @@ export function classifyLoopBlock(
 	const cpuCoverageRatio =
 		maxMs > 0 ? Math.round((windowCpuMs / maxMs) * 100) / 100 : undefined;
 	if (maxMs < floorMs) return { stallClass: "below-floor", cpuCoverageRatio };
-	if (isSuspendSuspectedBlock(maxMs, windowCpuMs, suspendFloorMs, suspendSlopMs))
+	if (
+		isSuspendSuspectedBlock(maxMs, windowCpuMs, suspendFloorMs, suspendSlopMs)
+	)
 		return { stallClass: "system-stall", cpuCoverageRatio };
 	if (windowCpuMs + slopMs < maxMs)
 		return { stallClass: "non-cpu-stall", cpuCoverageRatio };

--- a/clients/event-loop-monitor.ts
+++ b/clients/event-loop-monitor.ts
@@ -116,6 +116,129 @@ export interface EventLoopStats {
 	 * commit-charge paging thrash — rather than genuine CPU work (#1122).
 	 */
 	suspectSystemStall: boolean;
+	/**
+	 * Which stall class `maxMs` falls in, read from `windowCpuMs` (#1980). See
+	 * {@link classifyLoopBlock}. `suspectSystemStall` above is unchanged and
+	 * still means exactly what it meant; `stallClass === "system-stall"` is the
+	 * same predicate surfaced in the ladder.
+	 */
+	stallClass: LoopBlockStallClass;
+	/**
+	 * `windowCpuMs / maxMs`, rounded to two decimals — the ratio #1980 had to
+	 * compute by hand over 1221 records. Undefined when `maxMs` is 0 (no block,
+	 * nothing to cover). Values above 1 are normal and not an error:
+	 * `windowCpuMs` is process-wide over the WHOLE window, so it routinely
+	 * exceeds one block inside that window.
+	 */
+	cpuCoverageRatio: number | undefined;
+}
+
+/**
+ * How a `loop_block` sample splits on the CPU axis (#1980).
+ *
+ * - `below-floor` — shorter than {@link STALL_CLASSIFY_FLOOR_MS}. Not
+ *   classified: at this scale timer slop and CPU-accounting granularity are
+ *   the same order as the signal, so any verdict would be noise. Said out
+ *   loud rather than defaulted to the compute label.
+ * - `cpu-accounted` — the window burned enough CPU to account for the block.
+ *   Deliberately NOT named "compute": `windowCpuMs` is process-wide over the
+ *   whole window, so covering the block is consistent with compute but does
+ *   not prove it. Only one direction of this test is sound (see below).
+ * - `non-cpu-stall` — the window's TOTAL CPU cannot cover the block, so the
+ *   block provably was not computing. The loop was parked: synchronous fs on
+ *   a cloud-backed tree, a blocking native call, `spawnSync`, a lock. This is
+ *   the class #1980 found nine of sixteen 5 s+ blocks in.
+ * - `system-stall` — `non-cpu-stall` AND over the suspend floor, i.e. the
+ *   pre-existing {@link isSuspendSuspectedBlock} verdict: machine sleep,
+ *   Modern Standby, or commit-charge paging.
+ */
+export type LoopBlockStallClass =
+	| "below-floor"
+	| "cpu-accounted"
+	| "non-cpu-stall"
+	| "system-stall";
+
+/**
+ * Below this, a block is not classified at all (`below-floor`). #1980 mined
+ * the 5 s+ tier; 1 s is a deliberately conservative floor that still covers
+ * every block that tier cares about while keeping sub-second jitter — where
+ * measurement slop rivals the signal — out of the verdict.
+ */
+export const STALL_CLASSIFY_FLOOR_MS = 1000;
+
+/**
+ * Slack allowed to the CPU budget before a block counts as unaccounted.
+ * `process.cpuUsage()` and the histogram are sampled at slightly different
+ * instants and the histogram quantizes, so a block whose CPU coverage is
+ * within this much of exact is called `cpu-accounted`, not a stall.
+ */
+export const STALL_CLASSIFY_SLOP_MS = 250;
+
+/** What {@link classifyLoopBlock} decides about one sample. */
+export interface LoopBlockClassification {
+	stallClass: LoopBlockStallClass;
+	cpuCoverageRatio: number | undefined;
+}
+
+/**
+ * Split a block into compute-vs-stall from the CPU it could possibly have
+ * burned (#1980). Pure, so the discrimination is testable without the native
+ * histogram or a real machine stall — the same reason
+ * {@link isSuspendSuspectedBlock} is pure.
+ *
+ * ## Why this is sound in exactly one direction
+ *
+ * `windowCpuMs` is the CPU the WHOLE process consumed across the WHOLE window
+ * — every thread, every phase, not just this block. So it is an UPPER BOUND on
+ * the CPU this one block could have burned. A synchronous compute block of D ms
+ * needs ≈ D ms of main-thread CPU. Therefore:
+ *
+ * - `windowCpuMs + slop < maxMs` PROVES the block was not compute. Even if the
+ *   block had been the only thing running, there was not enough CPU in the
+ *   whole window to cover it. This is the `non-cpu-stall` verdict and it is a
+ *   real inference, not a heuristic.
+ * - The converse proves nothing. A window can burn 30 s of CPU in other phases
+ *   and still contain a 5 s I/O park. That is why the label is
+ *   `cpu-accounted` ("the budget covers it") rather than "compute": it reports
+ *   the absence of proof, not the presence of compute.
+ *
+ * The existing 20 s suspend verdict is not re-derived here; this delegates to
+ * {@link isSuspendSuspectedBlock} so there is one definition of a suspend, and
+ * `system-stall` is checked BEFORE `non-cpu-stall` because a suspend is the
+ * strictly more specific case of the same evidence.
+ *
+ * ## Known ambiguity, carried forward not silenced
+ *
+ * `isSuspendSuspectedBlock`'s own doc records that a >20 s synchronous syscall
+ * stall is CPU-indistinguishable from a suspend. Nothing here fixes that. What
+ * this adds is the tier BELOW that floor: a 5-20 s non-CPU block, which used
+ * to read as ordinary compute and now reads as `non-cpu-stall` with the
+ * `inFlightPhase` attribution beside it.
+ */
+export function classifyLoopBlock(
+	maxMs: number,
+	windowCpuMs: number,
+	options: {
+		floorMs?: number;
+		slopMs?: number;
+		suspendFloorMs?: number;
+		suspendSlopMs?: number;
+	} = {},
+): LoopBlockClassification {
+	const {
+		floorMs = STALL_CLASSIFY_FLOOR_MS,
+		slopMs = STALL_CLASSIFY_SLOP_MS,
+		suspendFloorMs,
+		suspendSlopMs,
+	} = options;
+	const cpuCoverageRatio =
+		maxMs > 0 ? Math.round((windowCpuMs / maxMs) * 100) / 100 : undefined;
+	if (maxMs < floorMs) return { stallClass: "below-floor", cpuCoverageRatio };
+	if (isSuspendSuspectedBlock(maxMs, windowCpuMs, suspendFloorMs, suspendSlopMs))
+		return { stallClass: "system-stall", cpuCoverageRatio };
+	if (windowCpuMs + slopMs < maxMs)
+		return { stallClass: "non-cpu-stall", cpuCoverageRatio };
+	return { stallClass: "cpu-accounted", cpuCoverageRatio };
 }
 
 const safeMs = (ns: number): number =>
@@ -165,13 +288,18 @@ export function getEventLoopStats(): EventLoopStats | undefined {
 	const maxMs = safeMs(histogram.max);
 	const windowWallMs = Math.max(0, Date.now() - windowStartWallMs);
 	const windowCpuMs = Math.max(0, cpuTotalMs() - windowStartCpuMs);
+	// One classification pass feeds both fields, so `suspectSystemStall` and
+	// `stallClass` can never disagree about the same sample (#1980).
+	const classification = classifyLoopBlock(maxMs, windowCpuMs);
 	return {
 		maxMs,
 		p99Ms: safeMs(histogram.percentile(99)),
 		meanMs: safeMs(histogram.mean),
 		windowWallMs: Math.round(windowWallMs),
 		windowCpuMs: Math.round(windowCpuMs),
-		suspectSystemStall: isSuspendSuspectedBlock(maxMs, windowCpuMs),
+		suspectSystemStall: classification.stallClass === "system-stall",
+		stallClass: classification.stallClass,
+		cpuCoverageRatio: classification.cpuCoverageRatio,
 	};
 }
 

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -18,7 +18,11 @@ import { recordLsp } from "../widget-state.js";
 import { applyAuxiliarySuppressions } from "../dispatch/auxiliary-lsp.js";
 import { detectFileRole } from "../file-role.js";
 import { emitBounded } from "../bounded-telemetry.js";
-import { logLatency } from "../latency-logger.js";
+import {
+	logLatency,
+	phaseFinished,
+	phaseStarted,
+} from "../latency-logger.js";
 import { logSessionStart } from "../sessionstart-logger.js";
 import {
 	incrementDegradationCount,
@@ -7819,6 +7823,23 @@ export class LSPService {
 		};
 
 		const processFile = async (filePath: string): Promise<void> => {
+			// #1723 residual (named as a deferred gap on PR #1805, closed here).
+			// This closure is the SCAN-side twin of the runner chokepoint #1805
+			// wired in `dispatcher.ts`'s `runRunner`. It is the site whose
+			// COMPLETION (`lsp_workspace_diagnostics`) is the `lastPhase` on this
+			// issue's own 18 270 ms reproduction — so until this bracket existed,
+			// the motivating record could only ever name the phase that finished
+			// BEFORE the block, never the one burning the time during it.
+			//
+			// Cost: one object allocation, one `Date.now()`/`toISOString()`, one
+			// `Map.set` per file — see `phaseStarted`'s own doc. That matters here
+			// because this loop must keep its opens inside `WatchedFilesQueue`'s
+			// 100ms debounce window (see the `statSync` note below), so the PR
+			// body carries a measured per-call number rather than an assurance.
+			//
+			// Paired in `finally`, per `phaseFinished`'s contract: an abandoned
+			// bracket would misattribute every LATER loop_block to this sweep.
+			const sweepPhase = phaseStarted("lsp_workspace_diagnostics_touch");
 			try {
 				const content =
 					contentCache.get(filePath) ??
@@ -7998,6 +8019,11 @@ export class LSPService {
 					unconfirmedReason: "error",
 					writeIndex: writeIndexByPath.get(normalizeMapKey(filePath)),
 				});
+			} finally {
+				// Closes on EVERY exit — success, error, or an abort that unwinds
+				// through here — so a torn-down sweep cannot leave a phantom bracket
+				// attributing later blocks to work that already stopped.
+				phaseFinished(sweepPhase);
 			}
 			completed += 1;
 			// User-facing progress (streamed to the tool's onUpdate). Per-file so the

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -18,11 +18,7 @@ import { recordLsp } from "../widget-state.js";
 import { applyAuxiliarySuppressions } from "../dispatch/auxiliary-lsp.js";
 import { detectFileRole } from "../file-role.js";
 import { emitBounded } from "../bounded-telemetry.js";
-import {
-	logLatency,
-	phaseFinished,
-	phaseStarted,
-} from "../latency-logger.js";
+import { logLatency, phaseFinished, phaseStarted } from "../latency-logger.js";
 import { logSessionStart } from "../sessionstart-logger.js";
 import {
 	incrementDegradationCount,

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -7819,23 +7819,6 @@ export class LSPService {
 		};
 
 		const processFile = async (filePath: string): Promise<void> => {
-			// #1723 residual (named as a deferred gap on PR #1805, closed here).
-			// This closure is the SCAN-side twin of the runner chokepoint #1805
-			// wired in `dispatcher.ts`'s `runRunner`. It is the site whose
-			// COMPLETION (`lsp_workspace_diagnostics`) is the `lastPhase` on this
-			// issue's own 18 270 ms reproduction — so until this bracket existed,
-			// the motivating record could only ever name the phase that finished
-			// BEFORE the block, never the one burning the time during it.
-			//
-			// Cost: one object allocation, one `Date.now()`/`toISOString()`, one
-			// `Map.set` per file — see `phaseStarted`'s own doc. That matters here
-			// because this loop must keep its opens inside `WatchedFilesQueue`'s
-			// 100ms debounce window (see the `statSync` note below), so the PR
-			// body carries a measured per-call number rather than an assurance.
-			//
-			// Paired in `finally`, per `phaseFinished`'s contract: an abandoned
-			// bracket would misattribute every LATER loop_block to this sweep.
-			const sweepPhase = phaseStarted("lsp_workspace_diagnostics_touch");
 			try {
 				const content =
 					contentCache.get(filePath) ??
@@ -8015,11 +7998,6 @@ export class LSPService {
 					unconfirmedReason: "error",
 					writeIndex: writeIndexByPath.get(normalizeMapKey(filePath)),
 				});
-			} finally {
-				// Closes on EVERY exit — success, error, or an abort that unwinds
-				// through here — so a torn-down sweep cannot leave a phantom bracket
-				// attributing later blocks to work that already stopped.
-				phaseFinished(sweepPhase);
 			}
 			completed += 1;
 			// User-facing progress (streamed to the tool's onUpdate). Per-file so the
@@ -8052,157 +8030,188 @@ export class LSPService {
 			WORKSPACE_DIAGNOSTICS_CONCURRENCY,
 			groups.length,
 		);
-		await runPerServerGroups(
-			groups,
-			groupWorkers,
-			async (group) => {
-				if (signal?.aborted) return;
-				// #1618: checked before any per-group work (pull attempt, warm-up,
-				// per-file loop) so a service already destroyed when this group
-				// starts never pays for a language-server round trip it cannot get.
-				if (this.checkDestroyed()) {
-					markServiceDestroyed(group.files);
-					return;
-				}
-				// Fast path: one project-wide pull for the whole group (opt-in).
-				if (!isWarmAttached() && workspacePullEnabled && !group.multiServer) {
-					const pulled = await this.tryWorkspacePull(
-						group.files,
-						perFileMs,
-						cacheServedKeys,
-					);
-					if (pulled) {
-						// #1782: an explicit zero-diagnostic answer for a file this
-						// sweep served from cache SUPERSEDES that cached replay. Route
-						// it through the same result list every other answer uses, so
-						// the cache write below overwrites the stale entry and the
-						// footer reconcile in `tools/lens-diagnostics.ts` clears the
-						// widget rows — no second eviction path to keep in step.
-						for (const clean of pulled.extraClean) {
-							supersededCacheKeys.add(normalizeMapKey(clean.filePath));
-						}
-						for (const result of [...pulled.results, ...pulled.extraClean]) {
-							results.push({
-								...result,
-								writeIndex: writeIndexByPath.get(
-									normalizeMapKey(result.filePath),
-								),
-							});
-							// #671: a pull result is always confirmed (see
-							// `tryWorkspacePull`'s doc comment), so it's cache-eligible
-							// too — best-effort stat since the pull already resolved the
-							// diagnostics for this file some time ago.
-							try {
-								scannedMtimeByFile.set(
-									result.filePath,
-									nodeFs.statSync(result.filePath).mtimeMs,
-								);
-							} catch {
-								// Not cache-eligible without a confirmed mtime.
-							}
-						}
-						completed += group.files.length;
-						options.onProgress?.(completed, files.length);
-						return;
-					}
-				}
-				// #667: warm-check before this group's own per-file loop starts —
-				// cheap/no-op when the group's primary server already demonstrated
-				// readiness (from an earlier sweep, or an earlier group sharing the
-				// same server root, this session); pays one deliberate warm-up round
-				// trip against the group's first file only when genuinely cold. Not
-				// needed above the pull fast path: a `workspace/diagnostic` pull
-				// already covers the WHOLE group with its own generous per-server
-				// budget in one shot — the per-file "first N files eat individual
-				// timeouts" failure mode this fixes doesn't apply there.
-				const first = group.files[0];
-				if (first && !isWarmAttached()) {
-					const warmup = await this.ensureWarmForSweep(first, { signal });
+		// #1723 residual, named as a deferred gap on PR #1805 and closed here:
+		// the SCAN-side twin of the runner chokepoint #1805 wired in
+		// `dispatcher.ts`'s `runRunner`. This sweep is the site whose COMPLETION
+		// (`lsp_workspace_diagnostics`) is the `lastPhase` on #1723's own
+		// 18 270 ms reproduction, so until this bracket existed the record could
+		// only ever name the phase that finished BEFORE the block, never the one
+		// burning the time during it.
+		//
+		// ONE bracket for the whole fan-out, not one per file (#2272 review F1).
+		// Per-file bracketing was the first shape and it was inert for exactly
+		// the case above: `phaseFinished` pushes onto a ring capped at
+		// `CLOSED_BRACKET_CAP` (5, clients/latency-logger.ts), while `turn_end`
+		// reads `getPhaseForWindow` AFTER the sweep returns. A 225-file sweep
+		// therefore evicted the blocking file's own bracket unless the block
+		// landed in the last five files, and the survivors were then rejected by
+		// `MIN_PLAUSIBLE_ELAPSED_FRACTION` for being far shorter than the block
+		// window. The phase string is a constant carrying no per-file identity,
+		// so 225 brackets never held more information than one — they only cost
+		// 225 map inserts and destroyed the ring. One bracket keeps the same
+		// discriminating identity, survives to the read point, and spans the
+		// block by construction.
+		//
+		// Paired in `finally`, per `phaseFinished`'s contract: an abandoned
+		// bracket would misattribute every LATER loop_block to this sweep. An
+		// abort or a destroyed service returns out of the worker callback, which
+		// a trailing statement would miss and a `finally` does not.
+		const sweepPhase = phaseStarted("lsp_workspace_diagnostics_touch");
+		try {
+			await runPerServerGroups(
+				groups,
+				groupWorkers,
+				async (group) => {
 					if (signal?.aborted) return;
-					// #744: the group's primary server failed warm-up (initial round
-					// trip + one retry both left it cold). Every per-file touch to it
-					// would re-pay its full timeout and time out again, dragging the
-					// whole sweep — the exact wedged-marksman failure mode this closes.
-					// So skip this group's files and record each as UNCONFIRMED
-					// (timedOut + skippedWarmupFailure), never as confirmed-clean `[]`:
-					// the group is keyed by its primary server, so a non-empty
-					// `failedServerIds` means that primary is the one that couldn't warm.
-					if (warmup.failedServerIds.length > 0) {
-						logLatency({
-							type: "phase",
-							phase: "lsp_sweep_group_skipped_warmup",
-							filePath: first,
-							durationMs: 0,
-							metadata: {
-								failedServerIds: warmup.failedServerIds,
-								// #799: distinguishes a fresh warm-up failure from a
-								// negative-cache hit (this sweep never re-attempted warm-up
-								// at all — it was already known cold from earlier this
-								// session).
-								skippedFromCache: warmup.skippedFromCache ?? false,
-								skippedFiles: group.files.length,
-							},
-						});
-						for (const filePath of group.files) {
-							results.push({
-								filePath,
-								diagnostics: [],
-								count: 0,
-								timedOut: true,
-								unconfirmedReason: "inconclusive",
-								skippedWarmupFailure: true,
-							});
-							timedOutFiles += 1;
-							completed += 1;
-						}
-						options.onProgress?.(completed, files.length);
-						return;
-					}
-					if (warmup.performedWarmup) options.onServerReady?.();
-				}
-				// #608/#621: batch-open a CHUNK of this group's files before
-				// waiting on diagnostics for any of them individually — see
-				// `preOpenGroupFiles` above. Chunking (rather than the whole
-				// group at once) bounds how much a single burst can dump on
-				// the server's request queue at real project scale, while each
-				// chunk's opens still land inside the debounce window and
-				// coalesce into one flush — see `WORKSPACE_SWEEP_PREOPEN_CHUNK_SIZE`.
-				for (
-					let chunkStart = 0;
-					chunkStart < group.files.length;
-					chunkStart += WORKSPACE_SWEEP_PREOPEN_CHUNK_SIZE
-				) {
-					if (signal?.aborted) return;
-					// #1618: a service destroyed WHILE this group's chunk loop was
-					// already running (the group-start check above can't see a
-					// destruction that lands mid-loop) — stop here and mark every
-					// file from this chunk onward, rather than letting the remaining
-					// chunks pay for pre-opens/touches against a torn-down service.
+					// #1618: checked before any per-group work (pull attempt, warm-up,
+					// per-file loop) so a service already destroyed when this group
+					// starts never pays for a language-server round trip it cannot get.
 					if (this.checkDestroyed()) {
-						markServiceDestroyed(group.files.slice(chunkStart));
+						markServiceDestroyed(group.files);
 						return;
 					}
-					const chunk = group.files.slice(
-						chunkStart,
-						chunkStart + WORKSPACE_SWEEP_PREOPEN_CHUNK_SIZE,
-					);
-					await preOpenGroupFiles(chunk);
-					for (const filePath of chunk) {
-						// Honor cancellation between files (#341); already-collected
-						// results are returned as a partial.
-						if (signal?.aborted) return;
-						if (this.checkDestroyed()) {
-							markServiceDestroyed(
-								group.files.slice(group.files.indexOf(filePath)),
-							);
+					// Fast path: one project-wide pull for the whole group (opt-in).
+					if (!isWarmAttached() && workspacePullEnabled && !group.multiServer) {
+						const pulled = await this.tryWorkspacePull(
+							group.files,
+							perFileMs,
+							cacheServedKeys,
+						);
+						if (pulled) {
+							// #1782: an explicit zero-diagnostic answer for a file this
+							// sweep served from cache SUPERSEDES that cached replay. Route
+							// it through the same result list every other answer uses, so
+							// the cache write below overwrites the stale entry and the
+							// footer reconcile in `tools/lens-diagnostics.ts` clears the
+							// widget rows — no second eviction path to keep in step.
+							for (const clean of pulled.extraClean) {
+								supersededCacheKeys.add(normalizeMapKey(clean.filePath));
+							}
+							for (const result of [...pulled.results, ...pulled.extraClean]) {
+								results.push({
+									...result,
+									writeIndex: writeIndexByPath.get(
+										normalizeMapKey(result.filePath),
+									),
+								});
+								// #671: a pull result is always confirmed (see
+								// `tryWorkspacePull`'s doc comment), so it's cache-eligible
+								// too — best-effort stat since the pull already resolved the
+								// diagnostics for this file some time ago.
+								try {
+									scannedMtimeByFile.set(
+										result.filePath,
+										nodeFs.statSync(result.filePath).mtimeMs,
+									);
+								} catch {
+									// Not cache-eligible without a confirmed mtime.
+								}
+							}
+							completed += group.files.length;
+							options.onProgress?.(completed, files.length);
 							return;
 						}
-						await processFile(filePath);
 					}
-				}
-			},
-			signal,
-		);
+					// #667: warm-check before this group's own per-file loop starts —
+					// cheap/no-op when the group's primary server already demonstrated
+					// readiness (from an earlier sweep, or an earlier group sharing the
+					// same server root, this session); pays one deliberate warm-up round
+					// trip against the group's first file only when genuinely cold. Not
+					// needed above the pull fast path: a `workspace/diagnostic` pull
+					// already covers the WHOLE group with its own generous per-server
+					// budget in one shot — the per-file "first N files eat individual
+					// timeouts" failure mode this fixes doesn't apply there.
+					const first = group.files[0];
+					if (first && !isWarmAttached()) {
+						const warmup = await this.ensureWarmForSweep(first, { signal });
+						if (signal?.aborted) return;
+						// #744: the group's primary server failed warm-up (initial round
+						// trip + one retry both left it cold). Every per-file touch to it
+						// would re-pay its full timeout and time out again, dragging the
+						// whole sweep — the exact wedged-marksman failure mode this closes.
+						// So skip this group's files and record each as UNCONFIRMED
+						// (timedOut + skippedWarmupFailure), never as confirmed-clean `[]`:
+						// the group is keyed by its primary server, so a non-empty
+						// `failedServerIds` means that primary is the one that couldn't warm.
+						if (warmup.failedServerIds.length > 0) {
+							logLatency({
+								type: "phase",
+								phase: "lsp_sweep_group_skipped_warmup",
+								filePath: first,
+								durationMs: 0,
+								metadata: {
+									failedServerIds: warmup.failedServerIds,
+									// #799: distinguishes a fresh warm-up failure from a
+									// negative-cache hit (this sweep never re-attempted warm-up
+									// at all — it was already known cold from earlier this
+									// session).
+									skippedFromCache: warmup.skippedFromCache ?? false,
+									skippedFiles: group.files.length,
+								},
+							});
+							for (const filePath of group.files) {
+								results.push({
+									filePath,
+									diagnostics: [],
+									count: 0,
+									timedOut: true,
+									unconfirmedReason: "inconclusive",
+									skippedWarmupFailure: true,
+								});
+								timedOutFiles += 1;
+								completed += 1;
+							}
+							options.onProgress?.(completed, files.length);
+							return;
+						}
+						if (warmup.performedWarmup) options.onServerReady?.();
+					}
+					// #608/#621: batch-open a CHUNK of this group's files before
+					// waiting on diagnostics for any of them individually — see
+					// `preOpenGroupFiles` above. Chunking (rather than the whole
+					// group at once) bounds how much a single burst can dump on
+					// the server's request queue at real project scale, while each
+					// chunk's opens still land inside the debounce window and
+					// coalesce into one flush — see `WORKSPACE_SWEEP_PREOPEN_CHUNK_SIZE`.
+					for (
+						let chunkStart = 0;
+						chunkStart < group.files.length;
+						chunkStart += WORKSPACE_SWEEP_PREOPEN_CHUNK_SIZE
+					) {
+						if (signal?.aborted) return;
+						// #1618: a service destroyed WHILE this group's chunk loop was
+						// already running (the group-start check above can't see a
+						// destruction that lands mid-loop) — stop here and mark every
+						// file from this chunk onward, rather than letting the remaining
+						// chunks pay for pre-opens/touches against a torn-down service.
+						if (this.checkDestroyed()) {
+							markServiceDestroyed(group.files.slice(chunkStart));
+							return;
+						}
+						const chunk = group.files.slice(
+							chunkStart,
+							chunkStart + WORKSPACE_SWEEP_PREOPEN_CHUNK_SIZE,
+						);
+						await preOpenGroupFiles(chunk);
+						for (const filePath of chunk) {
+							// Honor cancellation between files (#341); already-collected
+							// results are returned as a partial.
+							if (signal?.aborted) return;
+							if (this.checkDestroyed()) {
+								markServiceDestroyed(
+									group.files.slice(group.files.indexOf(filePath)),
+								);
+								return;
+							}
+							await processFile(filePath);
+						}
+					}
+				},
+				signal,
+			);
+		} finally {
+			phaseFinished(sweepPhase);
+		}
 
 		// #1618: per-reason tally alongside the flat `timedOutFiles` count (kept
 		// for the existing `scripts/analyze-pi-lens-logs.mjs` consumer) — a

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -8053,9 +8053,12 @@ export class LSPService {
 		// block by construction.
 		//
 		// Paired in `finally`, per `phaseFinished`'s contract: an abandoned
-		// bracket would misattribute every LATER loop_block to this sweep. An
-		// abort or a destroyed service returns out of the worker callback, which
-		// a trailing statement would miss and a `finally` does not.
+		// bracket would misattribute every LATER loop_block to this sweep. The
+		// leak guard is what the tests pin: emptying this `finally` reds three
+		// of them. `finally` rather than a trailing call covers a throw that
+		// escapes the fan-out; abort and service-destroyed both RETURN from the
+		// worker callback rather than throwing, so those two paths alone would
+		// not distinguish the two spellings.
 		const sweepPhase = phaseStarted("lsp_workspace_diagnostics_touch");
 		try {
 			await runPerServerGroups(

--- a/clients/lsp/launch.ts
+++ b/clients/lsp/launch.ts
@@ -311,6 +311,14 @@ function findBinaryOnPath(
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "ignore"],
 			env,
+			// #1980 population sweep: this was the one synchronous
+			// child-process site in the repo with no bound at all. It runs on
+			// the LSP server spawn path, so an unresponsive `where`/`which` — a
+			// stale network PATH entry is the classic cause — parked the event
+			// loop with no ceiling, and read as ordinary compute in
+			// `loop_block`. 5s matches `isCommandAvailable`/`findCommand` in
+			// clients/safe-spawn.ts, which run these same two binaries.
+			timeout: 5000,
 		})
 			.split(/\r?\n/)
 			.map((line) => line.trim())

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -1062,6 +1062,13 @@ function ensureUtf8ConsoleCodePageOnce(): void {
 		spawnSync(cmdExe, ["/d", "/s", "/c", "chcp 65001 >nul 2>&1"], {
 			shell: false,
 			windowsHide: true,
+			// #1980 population sweep: a synchronous spawn with no timeout parks
+			// the event loop for as long as the child takes, and nothing here
+			// bounds that. `chcp` is normally instant, but this runs before the
+			// FIRST real spawn of the process, which is exactly when a cold or
+			// antivirus-throttled cmd.exe is slowest. Matches the 5s bound every
+			// other synchronous child-process site in this repo already carries.
+			timeout: 5000,
 		});
 	} catch {
 		// Best-effort: worst case is non-ASCII tool output decoded incorrectly, not a

--- a/index.ts
+++ b/index.ts
@@ -2562,10 +2562,12 @@ function activateExtension(hostPi: ExtensionAPI) {
 				// scheduled as a macrotask, and microtasks always drain first, so a
 				// genuinely synchronous phase has typically ALREADY closed by the
 				// time this line runs. Checking live brackets alone would read
-				// empty for exactly the case this exists to catch. NOT wired into
-				// the LSP workspace-diagnostics sweep's own touch loop
-				// (clients/lsp/index.ts) — that remains a named, deferred gap (see
-				// the PR body / issue comment), not a silent one.
+				// empty for exactly the case this exists to catch. Both bracket
+				// sites are wired now: the runner chokepoint (`runRunner` in
+				// dispatcher.ts, #1805) and the LSP workspace-diagnostics sweep
+				// (clients/lsp/index.ts), the latter as ONE bracket around the
+				// whole per-file loop so it survives the closed-bracket ring to
+				// reach this read point.
 				//
 				// #1723 review round 3: this window — [now - loopMaxMs, now] —
 				// assumes the block ENDED right at this sample, which is a

--- a/index.ts
+++ b/index.ts
@@ -2600,6 +2600,16 @@ function activateExtension(hostPi: ExtensionAPI) {
 						worstSoFar: isNewSessionWorst,
 						turnIndex: runtime.turnIndex,
 						suspectSystemStall,
+						// #1980: the CPU-vs-wall split, read from the record alone.
+						// `windowCpuMs` has sat beside every block since #1122 and
+						// was never read together with `durationMs`; nine of sixteen
+						// genuine 5s+ blocks in a 23h window burned less CPU than the
+						// block lasted, which makes them parked, not computing. The
+						// monitor owns the verdict (clients/event-loop-monitor.ts's
+						// `classifyLoopBlock`) so `suspectSystemStall` and
+						// `stallClass` cannot disagree about one sample.
+						stallClass: elStats?.stallClass,
+						cpuCoverageRatio: elStats?.cpuCoverageRatio,
 						windowCpuMs: elStats?.windowCpuMs,
 						windowWallMs: elStats?.windowWallMs,
 						lastPhase: lastPhase?.phase,

--- a/tests/clients/event-loop-monitor.test.ts
+++ b/tests/clients/event-loop-monitor.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	_stopEventLoopMonitorForTest,
+	classifyLoopBlock,
 	getEventLoopStats,
 	isSuspendSuspectedBlock,
 	resetEventLoopMonitor,
@@ -146,5 +147,84 @@ describe("resetEventLoopMonitor window re-baselining (#1122)", () => {
 		// inflate the fresh window on a loaded CI box, so assert only that reset
 		// cut it well below the pre-reset elapsed span.
 		expect(after).toBeLessThan(before / 2);
+	});
+});
+
+/**
+ * #1980: `windowCpuMs` has sat beside every `loop_block` since #1122 and was
+ * never read together with `durationMs`. Over a 23h window (1221 records),
+ * nine of the sixteen genuine 5s+ blocks burned LESS CPU than the block
+ * lasted — they were parked in a syscall, not computing — and every one of
+ * them read as ordinary work because `suspectSystemStall` only fires above
+ * 20s. These pin the ladder that splits them. Every case is a real row from
+ * the issue's evidence where one exists.
+ */
+describe("classifyLoopBlock: CPU-vs-wall stall discrimination (#1980)", () => {
+	it("declines to classify a sub-floor block instead of defaulting it to compute", () => {
+		// Under STALL_CLASSIFY_FLOOR_MS the CPU accounting is the same order as
+		// its own measurement slop, so the honest answer is "not classified".
+		expect(classifyLoopBlock(900, 0).stallClass).toBe("below-floor");
+	});
+
+	it("classes a block the window's whole CPU budget cannot cover as a non-CPU stall", () => {
+		// #1980's top row: d=19780ms cpu=7907ms at 13:59:03. 7.9s of CPU cannot
+		// produce a 19.8s synchronous burst, so the loop was waiting.
+		expect(classifyLoopBlock(19780, 7907).stallClass).toBe("non-cpu-stall");
+		// Two more from the same evidence block.
+		expect(classifyLoopBlock(16895, 4078).stallClass).toBe("non-cpu-stall");
+		expect(classifyLoopBlock(10435, 1688).stallClass).toBe("non-cpu-stall");
+	});
+
+	it("classes a block the window's CPU covers as cpu-accounted, not a stall", () => {
+		expect(classifyLoopBlock(5000, 5500).stallClass).toBe("cpu-accounted");
+	});
+
+	it("keeps the suspend verdict distinct from an ordinary non-CPU stall", () => {
+		// At or above the 20s suspend floor with ~no CPU: sleep/standby/paging.
+		expect(classifyLoopBlock(300000, 200).stallClass).toBe("system-stall");
+		// The SAME evidence shape below that floor is the narrower class — this
+		// is the whole 5-20s tier #1980 found and #1122's flag could not see.
+		expect(classifyLoopBlock(15435, 3985).stallClass).toBe("non-cpu-stall");
+	});
+
+	it("agrees with the pre-existing suspend predicate on every classified sample", () => {
+		// One definition of a suspend, not two: the class delegates.
+		for (const [maxMs, cpuMs] of [
+			[300000, 200],
+			[25000, 20000],
+			[30000, 30000],
+			[19780, 7907],
+			[5000, 5500],
+		] as const) {
+			expect(classifyLoopBlock(maxMs, cpuMs).stallClass === "system-stall").toBe(
+				isSuspendSuspectedBlock(maxMs, cpuMs),
+			);
+		}
+	});
+
+	it("honours the CPU slop so a near-exact match is not called a stall", () => {
+		expect(classifyLoopBlock(5000, 4800).stallClass).toBe("cpu-accounted");
+		expect(classifyLoopBlock(5000, 4700).stallClass).toBe("non-cpu-stall");
+	});
+
+	it("reports the CPU coverage ratio the issue had to compute by hand", () => {
+		expect(classifyLoopBlock(19780, 7907).cpuCoverageRatio).toBe(0.4);
+		expect(classifyLoopBlock(5000, 5500).cpuCoverageRatio).toBe(1.1);
+		// No block means nothing to cover — not a ratio of zero.
+		expect(classifyLoopBlock(0, 0).cpuCoverageRatio).toBeUndefined();
+	});
+
+	it("getEventLoopStats carries the class and the ratio onto every sample", async () => {
+		startEventLoopMonitor(10);
+		await settle(40);
+		const s = getEventLoopStats();
+		// A live loop's own jitter is far under the floor, so the honest class is
+		// below-floor — and it must be PRESENT, which is what the loop_block
+		// record reads.
+		expect(s?.stallClass).toBe("below-floor");
+		expect(s?.suspectSystemStall).toBe(false);
+		expect(
+			s?.cpuCoverageRatio === undefined || Number.isFinite(s.cpuCoverageRatio),
+		).toBe(true);
 	});
 });

--- a/tests/clients/event-loop-monitor.test.ts
+++ b/tests/clients/event-loop-monitor.test.ts
@@ -196,9 +196,9 @@ describe("classifyLoopBlock: CPU-vs-wall stall discrimination (#1980)", () => {
 			[19780, 7907],
 			[5000, 5500],
 		] as const) {
-			expect(classifyLoopBlock(maxMs, cpuMs).stallClass === "system-stall").toBe(
-				isSuspendSuspectedBlock(maxMs, cpuMs),
-			);
+			expect(
+				classifyLoopBlock(maxMs, cpuMs).stallClass === "system-stall",
+			).toBe(isSuspendSuspectedBlock(maxMs, cpuMs));
 		}
 	});
 

--- a/tests/clients/loop-block-stall-discrimination.test.ts
+++ b/tests/clients/loop-block-stall-discrimination.test.ts
@@ -1,0 +1,136 @@
+/**
+ * #1980 AC4, end to end on the REAL monitor: an injected synchronous stall
+ * must classify as a stall, not as compute.
+ *
+ * The sibling cases in `event-loop-monitor.test.ts` drive the pure classifier
+ * with numbers copied out of `latency.log`. That proves the ladder, but not
+ * that the ladder is fed the right numbers: `getEventLoopStats` reads its
+ * `windowCpuMs` from `process.cpuUsage()` and its `maxMs` from the native
+ * histogram, and a fix that classifies correctly on paper is worthless if
+ * those two are measured over spans that do not line up.
+ *
+ * So this file blocks the loop for real, twice, with the ONLY difference
+ * being the CPU axis under test:
+ *
+ * - `Atomics.wait` on a `SharedArrayBuffer` parks the thread in a futex wait.
+ *   The loop is genuinely blocked (nothing can be serviced) and ~no CPU is
+ *   burned. That is the exact shape of #1980's nine records: sync fs on a
+ *   cloud-backed tree, a blocking native call, `spawnSync`.
+ * - A busy loop of the SAME duration blocks the loop for the same wall time
+ *   while burning that time as CPU.
+ *
+ * Same monitor, same code path, same duration. If the classifier were fed a
+ * CPU number that does not correspond to its window, both would land in the
+ * same class and one of these two cases would fail.
+ *
+ * Lane: this file measures real CPU-vs-wall, so it runs in vitest.config.ts's
+ * serialized "wall-clock-budget" project. Under the default fork storm a busy
+ * spin can be descheduled — it would then burn far less CPU than the wall time
+ * it held, and the compute case would read as a stall. That is contention, not
+ * a regression, and the cure is a quiet host, not a looser assertion.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	_stopEventLoopMonitorForTest,
+	getEventLoopStats,
+	resetEventLoopMonitor,
+	startEventLoopMonitor,
+} from "../../clients/event-loop-monitor.js";
+
+afterEach(() => {
+	_stopEventLoopMonitorForTest();
+});
+
+const settle = (ms: number) =>
+	new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Comfortably over `STALL_CLASSIFY_FLOOR_MS` (1000), so both cases are
+ * actually classified rather than landing in `below-floor`, and long enough
+ * that the 250ms slop cannot swallow the difference between the two.
+ */
+const BLOCK_MS = 1600;
+
+/**
+ * Block the event loop WITHOUT burning CPU — a futex wait that no one ever
+ * wakes, so it runs out its timeout. This is the production-faithful stand-in
+ * for a blocking syscall: the thread is parked, the loop is dead, the CPU
+ * counter does not move.
+ */
+function blockWithoutCpu(ms: number): void {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/** Block the event loop by burning CPU for the same wall time. */
+function blockWithCpu(ms: number): void {
+	const until = Date.now() + ms;
+	// Non-trivial arithmetic so the JIT cannot elide the loop body.
+	let sink = 0;
+	while (Date.now() < until) sink = (sink + 1) % 1_000_003;
+	if (sink === -1) throw new Error("unreachable");
+}
+
+/**
+ * Start a fresh window, run `block`, then read the sample it produced.
+ *
+ * The `settle` AFTER `resetEventLoopMonitor` is load-bearing, not padding.
+ * Measured on Node v24.19.0: `IntervalHistogram.reset()` followed by a
+ * synchronous block in the SAME tick records ~32ms for a 1600ms block, while
+ * the identical block one tick later records 1601ms. Production is always the
+ * second shape — `resetEventLoopMonitor` runs at `turn_end` and the next
+ * turn's block is many ticks later — so blocking in the reset's own tick would
+ * be the unfaithful harness, not the faithful one.
+ */
+async function sampleOneBlock(block: () => void) {
+	startEventLoopMonitor(10);
+	await settle(30); // let the histogram take a few clean baseline samples
+	resetEventLoopMonitor(); // window starts HERE: wall, CPU, and histogram together
+	await settle(30); // see above: the reset needs a tick before the block
+	block();
+	await settle(60); // let the delayed timer fire so the histogram records it
+	const stats = getEventLoopStats();
+	expect(stats).toBeDefined();
+	return stats as NonNullable<typeof stats>;
+}
+
+describe("#1980 injected stalls classify by CPU, not by duration", () => {
+	it("a real non-CPU block (parked thread) reads as non-cpu-stall", async () => {
+		const stats = await sampleOneBlock(() => blockWithoutCpu(BLOCK_MS));
+
+		// The block really happened and really was over the classify floor.
+		expect(stats.maxMs).toBeGreaterThan(1000);
+		// And it really burned no CPU — this is the axis under test, so assert it
+		// rather than trust it.
+		expect(stats.windowCpuMs).toBeLessThan(stats.maxMs / 2);
+		// Pre-fix there is no such field at all; with only #1122's flag this
+		// sample reads `suspectSystemStall: false`, i.e. indistinguishable from
+		// ordinary work, which is the whole complaint in #1980.
+		expect(stats.stallClass).toBe("non-cpu-stall");
+		// Not a suspend: well under the 20s floor, and the old flag is unchanged.
+		expect(stats.suspectSystemStall).toBe(false);
+		expect(stats.cpuCoverageRatio).toBeLessThan(0.5);
+	});
+
+	it("a CPU spin of the same duration reads as cpu-accounted", async () => {
+		const stats = await sampleOneBlock(() => blockWithCpu(BLOCK_MS));
+
+		expect(stats.maxMs).toBeGreaterThan(1000);
+		// The discriminator: this window's CPU covers its own block.
+		expect(stats.windowCpuMs).toBeGreaterThan(stats.maxMs * 0.8);
+		expect(stats.stallClass).toBe("cpu-accounted");
+		expect(stats.suspectSystemStall).toBe(false);
+	});
+
+	it("the two blocks are the same length and differ only on the CPU axis", async () => {
+		// Guards against a future change that "passes" both cases above by
+		// keying on duration: if the classifier ever read `maxMs` alone, these
+		// two comparable durations could not land in different classes.
+		const stalled = await sampleOneBlock(() => blockWithoutCpu(BLOCK_MS));
+		_stopEventLoopMonitorForTest();
+		const spun = await sampleOneBlock(() => blockWithCpu(BLOCK_MS));
+
+		expect(Math.abs(stalled.maxMs - spun.maxMs)).toBeLessThan(BLOCK_MS / 2);
+		expect(stalled.stallClass).not.toBe(spun.stallClass);
+	});
+});

--- a/tests/clients/lsp/service-notify-inflight-throttle.test.ts
+++ b/tests/clients/lsp/service-notify-inflight-throttle.test.ts
@@ -27,7 +27,17 @@ const getServersForFileWithConfig = vi.fn();
 const createLSPClient = vi.fn();
 const logLatency = vi.fn();
 
-vi.mock("../../../clients/latency-logger.js", () => ({ logLatency }));
+// Partial mock, not a whole-module replacement (#1723): `() => ({ logLatency })`
+// replaces the ENTIRE module, so the day `clients/lsp/index.ts` imports one
+// more thing from latency-logger — as it now does, for the sweep's phase
+// bracket — this file dies with "No <name> export is defined on the mock".
+// Spreading the actual module overrides only what this test needs to observe.
+vi.mock("../../../clients/latency-logger.js", async (importActual) => ({
+	...(await importActual<
+		typeof import("../../../clients/latency-logger.js")
+	>()),
+	logLatency,
+}));
 
 vi.mock("../../../clients/lsp/config.js", () => ({
 	getServersForFileWithConfig,

--- a/tests/clients/lsp/sweep-warmup.test.ts
+++ b/tests/clients/lsp/sweep-warmup.test.ts
@@ -32,7 +32,17 @@ vi.mock("../../../clients/lsp/config.js", () => ({
 	getServerInitOverride: vi.fn().mockReturnValue(undefined),
 }));
 vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
-vi.mock("../../../clients/latency-logger.js", () => ({ logLatency }));
+// Partial mock, not a whole-module replacement (#1723): `() => ({ logLatency })`
+// replaces the ENTIRE module, so the day `clients/lsp/index.ts` imports one
+// more thing from latency-logger — as it now does, for the sweep's phase
+// bracket — this file dies with "No <name> export is defined on the mock".
+// Spreading the actual module overrides only what this test needs to observe.
+vi.mock("../../../clients/latency-logger.js", async (importActual) => ({
+	...(await importActual<
+		typeof import("../../../clients/latency-logger.js")
+	>()),
+	logLatency,
+}));
 
 function makeTsServer(root: string) {
 	return {

--- a/tests/clients/lsp/workspace-diagnostics-sweep-attribution.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-sweep-attribution.test.ts
@@ -36,130 +36,159 @@ vi.mock("../../../clients/lsp/config.js", () => ({
 }));
 vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
 
-describe("#1723 sweep per-file touch is attributable", () => {
-	let sessionDir: string;
-	let fileA: string;
-	let fileB: string;
-	/** Runs INSIDE the sweep's touch, where a synchronous block would land. */
-	let duringTouch: (() => void) | undefined;
+/**
+ * Cold `import("clients/lsp/index.js")` after `vi.resetModules()` is heavy —
+ * the same cost tests/index-loop-block-wiring.test.ts documents and budgets
+ * for. 30s matches that file's convention.
+ */
+const SWEEP_ATTRIBUTION_TIMEOUT_MS = 30_000;
 
-	beforeEach(() => {
-		vi.resetModules();
-		getServersForFileWithConfig.mockReset();
-		createLSPClient.mockReset();
-		duringTouch = undefined;
-
-		sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), "wsd-1723-"));
-		fs.mkdirSync(path.join(sessionDir, ".pi-lens"));
-		fileA = path.join(sessionDir, "a.ts");
-		fileB = path.join(sessionDir, "b.ts");
-		fs.writeFileSync(fileA, "export const a = 1;\n");
-		fs.writeFileSync(fileB, "export const b = 2;\n");
-
-		const tsServer = {
-			id: "typescript",
-			name: "typescript",
-			extensions: [".ts"],
-			root: async () => sessionDir,
-			spawn: vi.fn(async () => ({ process: {}, source: "test" })),
-		};
-		getServersForFileWithConfig.mockImplementation((fp: string) =>
-			fp.endsWith(".ts") ? [tsServer] : [],
-		);
-		createLSPClient.mockResolvedValue({
-			isAlive: () => true,
-			shutdown: async () => {},
-			serverId: "typescript",
-			root: sessionDir,
-			getWorkspaceDiagnosticsSupport: () => ({ advertised: false }),
-			getOperationSupport: () => ({}),
-			notify: { open: vi.fn(async () => {}) },
-			waitForDiagnostics: vi.fn(async () => {
-				duringTouch?.();
-			}),
-			getDiagnostics: vi.fn(() => []),
-		});
-	});
-
-	afterEach(async () => {
-		const roots = await import("../../../clients/lsp/session-roots.js");
-		roots.resetSessionRootsForTests();
-		removeTempDirSync(sessionDir);
-		resetWorkspaceDiagnosticsCacheSession();
-	});
-
-	/**
-	 * Build the module graph for ONE test, then register the session root
-	 * through the SAME graph `index.js` closes over — the pattern
-	 * workspace-diagnostics-outside-root.test.ts establishes and explains.
-	 * `latency-logger` is imported here too so the observations below read the
-	 * instance the service actually writes to.
-	 */
-	async function loadService() {
-		const { LSPService } = await import("../../../clients/lsp/index.js");
-		const roots = await import("../../../clients/lsp/session-roots.js");
-		const latency = await import("../../../clients/latency-logger.js");
-		roots.resetSessionRootsForTests();
-		roots.registerSessionRoot(sessionDir);
-		latency.resetCurrentPhaseForSession();
-		return { service: new LSPService(), latency };
+/**
+ * Hold the loop synchronously for `ms`. This is the SHAPE the feature exists
+ * for — a block inside the sweep — and it also makes the read below
+ * deterministic: `getPhaseForWindow` rejects a bracket whose elapsed time is
+ * under 5% of the window length (MIN_PLAUSIBLE_ELAPSED_FRACTION), and a
+ * bracket read microseconds after it opened trips that floor on a fast host.
+ */
+function blockFor(ms: number): void {
+	const until = Date.now() + ms;
+	while (Date.now() < until) {
+		// deliberately empty: a real synchronous block
 	}
+}
 
-	it("names the sweep as the in-flight phase while a file's touch is running", async () => {
-		const { service, latency } = await loadService();
-		let observed: string | undefined;
-		duringTouch = () => {
-			observed = latency.getCurrentPhase()?.phase;
-		};
+describe(
+	"#1723 sweep per-file touch is attributable",
+	{
+		timeout: SWEEP_ATTRIBUTION_TIMEOUT_MS,
+	},
+	() => {
+		let sessionDir: string;
+		let fileA: string;
+		let fileB: string;
+		/** Runs INSIDE the sweep's touch, where a synchronous block would land. */
+		let duringTouch: (() => void) | undefined;
 
-		await service.runWorkspaceDiagnostics(sessionDir, { files: [fileA] });
+		beforeEach(() => {
+			vi.resetModules();
+			getServersForFileWithConfig.mockReset();
+			createLSPClient.mockReset();
+			duringTouch = undefined;
 
-		// Pre-fix: undefined. Nothing brackets the sweep's touch, so a block
-		// during it overlaps no live bracket and the loop_block record is
-		// anonymous — exactly #1723's 18 270 ms reproduction.
-		expect(observed).toBe("lsp_workspace_diagnostics_touch");
-	});
+			sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), "wsd-1723-"));
+			fs.mkdirSync(path.join(sessionDir, ".pi-lens"));
+			fileA = path.join(sessionDir, "a.ts");
+			fileB = path.join(sessionDir, "b.ts");
+			fs.writeFileSync(fileA, "export const a = 1;\n");
+			fs.writeFileSync(fileB, "export const b = 2;\n");
 
-	it("a block whose window lands inside the sweep is attributed to it", async () => {
-		const { service, latency } = await loadService();
-		let attribution: ReturnType<typeof latency.getPhaseForWindow>;
-		duringTouch = () => {
-			// The production read: overlap the block's own time window against
-			// live and recently-closed brackets (index.ts's turn_end).
-			const now = Date.now();
-			attribution = latency.getPhaseForWindow(now - 50, now);
-		};
-
-		await service.runWorkspaceDiagnostics(sessionDir, { files: [fileA] });
-
-		expect(attribution?.phase).toBe("lsp_workspace_diagnostics_touch");
-		expect(attribution?.stillRunning).toBe(true);
-	});
-
-	it("closes every bracket, so a later block is not blamed on a finished sweep", async () => {
-		const { service, latency } = await loadService();
-
-		await service.runWorkspaceDiagnostics(sessionDir, {
-			files: [fileA, fileB],
+			const tsServer = {
+				id: "typescript",
+				name: "typescript",
+				extensions: [".ts"],
+				root: async () => sessionDir,
+				spawn: vi.fn(async () => ({ process: {}, source: "test" })),
+			};
+			getServersForFileWithConfig.mockImplementation((fp: string) =>
+				fp.endsWith(".ts") ? [tsServer] : [],
+			);
+			createLSPClient.mockResolvedValue({
+				isAlive: () => true,
+				shutdown: async () => {},
+				serverId: "typescript",
+				root: sessionDir,
+				getWorkspaceDiagnosticsSupport: () => ({ advertised: false }),
+				getOperationSupport: () => ({}),
+				notify: { open: vi.fn(async () => {}) },
+				waitForDiagnostics: vi.fn(async () => {
+					duringTouch?.();
+				}),
+				getDiagnostics: vi.fn(() => []),
+			});
 		});
 
-		// Mutation guard for the `finally`: drop it and each file leaks a live
-		// bracket that misattributes every later loop_block to a sweep that
-		// already ended — `phaseFinished`'s own documented failure mode.
-		expect(latency.getCurrentPhase()).toBeUndefined();
-	});
+		afterEach(async () => {
+			const roots = await import("../../../clients/lsp/session-roots.js");
+			roots.resetSessionRootsForTests();
+			removeTempDirSync(sessionDir);
+			resetWorkspaceDiagnosticsCacheSession();
+		});
 
-	it("closes the bracket even when the file's touch throws", async () => {
-		const { service, latency } = await loadService();
-		duringTouch = () => {
-			throw new Error("server died mid-touch");
-		};
+		/**
+		 * Build the module graph for ONE test, then register the session root
+		 * through the SAME graph `index.js` closes over — the pattern
+		 * workspace-diagnostics-outside-root.test.ts establishes and explains.
+		 * `latency-logger` is imported here too so the observations below read the
+		 * instance the service actually writes to.
+		 */
+		async function loadService() {
+			const { LSPService } = await import("../../../clients/lsp/index.js");
+			const roots = await import("../../../clients/lsp/session-roots.js");
+			const latency = await import("../../../clients/latency-logger.js");
+			roots.resetSessionRootsForTests();
+			roots.registerSessionRoot(sessionDir);
+			latency.resetCurrentPhaseForSession();
+			return { service: new LSPService(), latency };
+		}
 
-		await service.runWorkspaceDiagnostics(sessionDir, { files: [fileA] });
+		it("names the sweep as the in-flight phase while a file's touch is running", async () => {
+			const { service, latency } = await loadService();
+			let observed: string | undefined;
+			duringTouch = () => {
+				observed = latency.getCurrentPhase()?.phase;
+			};
 
-		// The error path is the one a bare `phaseFinished` after the try/catch
-		// would still cover, but an early `return` inside the try would not —
-		// hence `finally`, and hence this case.
-		expect(latency.getCurrentPhase()).toBeUndefined();
-	});
-});
+			await service.runWorkspaceDiagnostics(sessionDir, { files: [fileA] });
+
+			// Pre-fix: undefined. Nothing brackets the sweep's touch, so a block
+			// during it overlaps no live bracket and the loop_block record is
+			// anonymous — exactly #1723's 18 270 ms reproduction.
+			expect(observed).toBe("lsp_workspace_diagnostics_touch");
+		});
+
+		it("a block whose window lands inside the sweep is attributed to it", async () => {
+			const { service, latency } = await loadService();
+			let attribution: ReturnType<typeof latency.getPhaseForWindow>;
+			duringTouch = () => {
+				// Block for real, then read exactly as turn_end does: overlap the
+				// block's own time window against live and recently-closed brackets.
+				const blockMs = 30;
+				blockFor(blockMs);
+				const now = Date.now();
+				attribution = latency.getPhaseForWindow(now - blockMs, now);
+			};
+
+			await service.runWorkspaceDiagnostics(sessionDir, { files: [fileA] });
+
+			expect(attribution?.phase).toBe("lsp_workspace_diagnostics_touch");
+			expect(attribution?.stillRunning).toBe(true);
+		});
+
+		it("closes every bracket, so a later block is not blamed on a finished sweep", async () => {
+			const { service, latency } = await loadService();
+
+			await service.runWorkspaceDiagnostics(sessionDir, {
+				files: [fileA, fileB],
+			});
+
+			// Mutation guard for the `finally`: drop it and each file leaks a live
+			// bracket that misattributes every later loop_block to a sweep that
+			// already ended — `phaseFinished`'s own documented failure mode.
+			expect(latency.getCurrentPhase()).toBeUndefined();
+		});
+
+		it("closes the bracket even when the file's touch throws", async () => {
+			const { service, latency } = await loadService();
+			duringTouch = () => {
+				throw new Error("server died mid-touch");
+			};
+
+			await service.runWorkspaceDiagnostics(sessionDir, { files: [fileA] });
+
+			// The error path is the one a bare `phaseFinished` after the try/catch
+			// would still cover, but an early `return` inside the try would not —
+			// hence `finally`, and hence this case.
+			expect(latency.getCurrentPhase()).toBeUndefined();
+		});
+	},
+);

--- a/tests/clients/lsp/workspace-diagnostics-sweep-attribution.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-sweep-attribution.test.ts
@@ -44,6 +44,13 @@ vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
 const SWEEP_ATTRIBUTION_TIMEOUT_MS = 30_000;
 
 /**
+ * The scale #1723's own reproduction ran at (225 files, 224 cache hits). It
+ * matters that this is far above `CLOSED_BRACKET_CAP` (5): the review finding
+ * these cases pin is that a per-file bracket cannot survive the ring.
+ */
+const SWEEP_FILE_COUNT = 225;
+
+/**
  * Hold the loop synchronously for `ms`. This is the SHAPE the feature exists
  * for — a block inside the sweep — and it also makes the read below
  * deterministic: `getPhaseForWindow` rejects a bracket whose elapsed time is
@@ -66,14 +73,21 @@ describe(
 		let sessionDir: string;
 		let fileA: string;
 		let fileB: string;
-		/** Runs INSIDE the sweep's touch, where a synchronous block would land. */
-		let duringTouch: (() => void) | undefined;
+		/**
+		 * Runs INSIDE the sweep's touch, where a synchronous block would land.
+		 * Receives the 1-based index of the file being touched, so a test can
+		 * put the block at a chosen point in a long sweep rather than only on
+		 * the first file.
+		 */
+		let duringTouch: ((fileIndex: number) => void) | undefined;
+		let touchedCount = 0;
 
 		beforeEach(() => {
 			vi.resetModules();
 			getServersForFileWithConfig.mockReset();
 			createLSPClient.mockReset();
 			duringTouch = undefined;
+			touchedCount = 0;
 
 			sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), "wsd-1723-"));
 			fs.mkdirSync(path.join(sessionDir, ".pi-lens"));
@@ -101,7 +115,8 @@ describe(
 				getOperationSupport: () => ({}),
 				notify: { open: vi.fn(async () => {}) },
 				waitForDiagnostics: vi.fn(async () => {
-					duringTouch?.();
+					touchedCount += 1;
+					duringTouch?.(touchedCount);
 				}),
 				getDiagnostics: vi.fn(() => []),
 			});
@@ -177,7 +192,7 @@ describe(
 			expect(latency.getCurrentPhase()).toBeUndefined();
 		});
 
-		it("closes the bracket even when the file's touch throws", async () => {
+		it("closes the bracket even when a file's touch throws", async () => {
 			const { service, latency } = await loadService();
 			duringTouch = () => {
 				throw new Error("server died mid-touch");
@@ -185,9 +200,92 @@ describe(
 
 			await service.runWorkspaceDiagnostics(sessionDir, { files: [fileA] });
 
-			// The error path is the one a bare `phaseFinished` after the try/catch
-			// would still cover, but an early `return` inside the try would not —
-			// hence `finally`, and hence this case.
+			// `finally`, not a call after the try/catch: an early `return` inside
+			// the fan-out (abort, service destroyed) skips a trailing statement
+			// but never skips a `finally`.
+			expect(latency.getCurrentPhase()).toBeUndefined();
+		});
+
+		/**
+		 * #2272 review F1 — the headline case, and the one the four above could
+		 * not see.
+		 *
+		 * All of them read attribution from INSIDE the touch, on a one or two
+		 * file fixture. Production reads it somewhere else entirely: `turn_end`
+		 * in index.ts calls `getPhaseForWindow` AFTER the sweep has finished,
+		 * and a real sweep is hundreds of files.
+		 *
+		 * That gap hid a defect that made the whole feature inert for its own
+		 * motivating case. With one bracket PER FILE, a 225-file sweep pushes
+		 * 225 entries through a closed-bracket ring capped at
+		 * CLOSED_BRACKET_CAP = 5 (latency-logger.ts). The bracket belonging to
+		 * the file that actually blocked is evicted unless the block lands in
+		 * the last five files — roughly 2% of a sweep. The five survivors are
+		 * then rejected by MIN_PLAUSIBLE_ELAPSED_FRACTION, because a fast
+		 * trailing file's bracket is far shorter than the block window. Net
+		 * result: silence, which is exactly what #1723 opened about.
+		 *
+		 * One bracket around the whole per-file loop fixes it and is also the
+		 * simpler shape. The phase string is a constant carrying no per-file
+		 * identity, so 225 brackets never held more information than one; they
+		 * only cost 225 map inserts and destroyed the ring.
+		 */
+		it("F1: a mid-sweep block is still attributed when read AFTER a 225-file sweep", async () => {
+			const { service, latency } = await loadService();
+			const files = Array.from({ length: SWEEP_FILE_COUNT }, (_, i) => {
+				const p = path.join(sessionDir, `f${i}.ts`);
+				fs.writeFileSync(p, `export const f${i} = ${i};\n`);
+				return p;
+			});
+
+			// Block mid-sweep, far enough from the end that a 5-entry ring
+			// cannot still be holding this file's bracket when the sweep ends.
+			const blockAtFile = Math.floor(SWEEP_FILE_COUNT / 2);
+			const blockMs = 40;
+			let blockStart = 0;
+			let blockEnd = 0;
+			duringTouch = (fileIndex) => {
+				if (fileIndex !== blockAtFile) return;
+				blockStart = Date.now();
+				blockFor(blockMs);
+				blockEnd = Date.now();
+			};
+
+			await service.runWorkspaceDiagnostics(sessionDir, { files });
+
+			expect(blockEnd).toBeGreaterThan(blockStart);
+			// THE PRODUCTION READ POINT: after the sweep returned, exactly as
+			// turn_end does, against the block's own window.
+			const attribution = latency.getPhaseForWindow(blockStart, blockEnd);
+
+			// Pre-fix this is undefined: the blocking file's bracket was evicted
+			// from the ring by the ~112 files that closed after it.
+			expect(attribution?.phase).toBe("lsp_workspace_diagnostics_touch");
+			// And it must be a real bracket that CONTAINS the block, not a
+			// trailing sliver that happens to survive.
+			expect(attribution?.elapsedMs).toBeGreaterThanOrEqual(blockMs);
+		});
+
+		it("F1: one bracket for the whole sweep, not one per file", async () => {
+			// The structural claim behind the case above, asserted directly so a
+			// future change back to per-file brackets reds here too, not only
+			// through the ring-eviction symptom. Every file is touched, and the
+			// ring still holds exactly one sweep bracket afterwards.
+			const { service, latency } = await loadService();
+			const files = Array.from({ length: SWEEP_FILE_COUNT }, (_, i) => {
+				const p = path.join(sessionDir, `g${i}.ts`);
+				fs.writeFileSync(p, `export const g${i} = ${i};\n`);
+				return p;
+			});
+
+			await service.runWorkspaceDiagnostics(sessionDir, { files });
+
+			// At least one touch per file. Not exactly one: a cold group also
+			// pays `ensureWarmForSweep`'s single warm-up round trip (#667),
+			// which drives the same `waitForDiagnostics` stub.
+			expect(touchedCount).toBeGreaterThanOrEqual(SWEEP_FILE_COUNT);
+			// Pre-fix: 5, the ring saturated by 225 per-file brackets.
+			expect(latency._closedBracketsStorageLengthForTest()).toBe(1);
 			expect(latency.getCurrentPhase()).toBeUndefined();
 		});
 	},

--- a/tests/clients/lsp/workspace-diagnostics-sweep-attribution.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-sweep-attribution.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #1723 residual: the workspace-diagnostics sweep's per-file touch is
+ * bracketed, so a block that fires DURING it has a name.
+ *
+ * PR #1805 wired in-flight phase attribution at the dispatcher's `runRunner`
+ * chokepoint and named this second site as a deferred gap. It is not a
+ * hypothetical one: the 18 270 ms block in #1723's own reproduction carries
+ * `lastPhase: lsp_workspace_diagnostics`, i.e. the sweep's own COMPLETION
+ * record. `lastPhase` names a phase that already finished, so the sweep could
+ * only ever appear in a loop_block record AFTER it stopped being the culprit.
+ *
+ * `getPhaseForWindow` (clients/latency-logger.ts) reads live and
+ * recently-closed brackets. Without a bracket around `processFile`, a block
+ * inside the sweep overlaps nothing and the record is anonymous.
+ *
+ * These drive the REAL `runWorkspaceDiagnostics` and observe the bracket from
+ * inside the touch — the instant a synchronous block would fire — rather than
+ * calling `phaseStarted` directly, which would pin nothing about the wiring.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetWorkspaceDiagnosticsCacheSession } from "../../../clients/lsp/workspace-diagnostics-session.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+const getServersForFileWithConfig = vi.fn();
+const createLSPClient = vi.fn();
+
+// Only server selection and client creation are stubbed, so no language server
+// is spawned. Everything the sweep itself does is the real code path.
+vi.mock("../../../clients/lsp/config.js", () => ({
+	getServersForFileWithConfig,
+	getServerInitOverride: () => undefined,
+}));
+vi.mock("../../../clients/lsp/client.js", () => ({ createLSPClient }));
+
+describe("#1723 sweep per-file touch is attributable", () => {
+	let sessionDir: string;
+	let fileA: string;
+	let fileB: string;
+	/** Runs INSIDE the sweep's touch, where a synchronous block would land. */
+	let duringTouch: (() => void) | undefined;
+
+	beforeEach(() => {
+		vi.resetModules();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+		duringTouch = undefined;
+
+		sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), "wsd-1723-"));
+		fs.mkdirSync(path.join(sessionDir, ".pi-lens"));
+		fileA = path.join(sessionDir, "a.ts");
+		fileB = path.join(sessionDir, "b.ts");
+		fs.writeFileSync(fileA, "export const a = 1;\n");
+		fs.writeFileSync(fileB, "export const b = 2;\n");
+
+		const tsServer = {
+			id: "typescript",
+			name: "typescript",
+			extensions: [".ts"],
+			root: async () => sessionDir,
+			spawn: vi.fn(async () => ({ process: {}, source: "test" })),
+		};
+		getServersForFileWithConfig.mockImplementation((fp: string) =>
+			fp.endsWith(".ts") ? [tsServer] : [],
+		);
+		createLSPClient.mockResolvedValue({
+			isAlive: () => true,
+			shutdown: async () => {},
+			serverId: "typescript",
+			root: sessionDir,
+			getWorkspaceDiagnosticsSupport: () => ({ advertised: false }),
+			getOperationSupport: () => ({}),
+			notify: { open: vi.fn(async () => {}) },
+			waitForDiagnostics: vi.fn(async () => {
+				duringTouch?.();
+			}),
+			getDiagnostics: vi.fn(() => []),
+		});
+	});
+
+	afterEach(async () => {
+		const roots = await import("../../../clients/lsp/session-roots.js");
+		roots.resetSessionRootsForTests();
+		removeTempDirSync(sessionDir);
+		resetWorkspaceDiagnosticsCacheSession();
+	});
+
+	/**
+	 * Build the module graph for ONE test, then register the session root
+	 * through the SAME graph `index.js` closes over — the pattern
+	 * workspace-diagnostics-outside-root.test.ts establishes and explains.
+	 * `latency-logger` is imported here too so the observations below read the
+	 * instance the service actually writes to.
+	 */
+	async function loadService() {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const roots = await import("../../../clients/lsp/session-roots.js");
+		const latency = await import("../../../clients/latency-logger.js");
+		roots.resetSessionRootsForTests();
+		roots.registerSessionRoot(sessionDir);
+		latency.resetCurrentPhaseForSession();
+		return { service: new LSPService(), latency };
+	}
+
+	it("names the sweep as the in-flight phase while a file's touch is running", async () => {
+		const { service, latency } = await loadService();
+		let observed: string | undefined;
+		duringTouch = () => {
+			observed = latency.getCurrentPhase()?.phase;
+		};
+
+		await service.runWorkspaceDiagnostics(sessionDir, { files: [fileA] });
+
+		// Pre-fix: undefined. Nothing brackets the sweep's touch, so a block
+		// during it overlaps no live bracket and the loop_block record is
+		// anonymous — exactly #1723's 18 270 ms reproduction.
+		expect(observed).toBe("lsp_workspace_diagnostics_touch");
+	});
+
+	it("a block whose window lands inside the sweep is attributed to it", async () => {
+		const { service, latency } = await loadService();
+		let attribution: ReturnType<typeof latency.getPhaseForWindow>;
+		duringTouch = () => {
+			// The production read: overlap the block's own time window against
+			// live and recently-closed brackets (index.ts's turn_end).
+			const now = Date.now();
+			attribution = latency.getPhaseForWindow(now - 50, now);
+		};
+
+		await service.runWorkspaceDiagnostics(sessionDir, { files: [fileA] });
+
+		expect(attribution?.phase).toBe("lsp_workspace_diagnostics_touch");
+		expect(attribution?.stillRunning).toBe(true);
+	});
+
+	it("closes every bracket, so a later block is not blamed on a finished sweep", async () => {
+		const { service, latency } = await loadService();
+
+		await service.runWorkspaceDiagnostics(sessionDir, {
+			files: [fileA, fileB],
+		});
+
+		// Mutation guard for the `finally`: drop it and each file leaks a live
+		// bracket that misattributes every later loop_block to a sweep that
+		// already ended — `phaseFinished`'s own documented failure mode.
+		expect(latency.getCurrentPhase()).toBeUndefined();
+	});
+
+	it("closes the bracket even when the file's touch throws", async () => {
+		const { service, latency } = await loadService();
+		duringTouch = () => {
+			throw new Error("server died mid-touch");
+		};
+
+		await service.runWorkspaceDiagnostics(sessionDir, { files: [fileA] });
+
+		// The error path is the one a bare `phaseFinished` after the try/catch
+		// would still cover, but an early `return` inside the try would not —
+		// hence `finally`, and hence this case.
+		expect(latency.getCurrentPhase()).toBeUndefined();
+	});
+});

--- a/tests/config/sync-child-process-timeout.test.ts
+++ b/tests/config/sync-child-process-timeout.test.ts
@@ -2,91 +2,68 @@
  * #1980 AC3, as a recurrence guard rather than a one-off census.
  *
  * A synchronous child-process call parks the event loop for exactly as long
- * as the child takes. With no `timeout`, that is unbounded — and #1980's
+ * as the child takes. With no `timeout`, that park is unbounded — and #1980's
  * whole finding is that such a park used to read as ordinary compute in
- * `loop_block`, because `windowCpuMs` was recorded and never read.
+ * `loop_block`, because `windowCpuMs` was recorded beside every block and
+ * never read.
  *
- * The one-off sweep found two unbounded sites (`findBinaryOnPath` in
- * clients/lsp/launch.ts, on the LSP spawn path, and
- * `ensureUtf8ConsoleCodePageOnce` in clients/safe-spawn.ts, on the first
- * spawn of the process). Both are fixed. This walks the family so the next
- * one cannot land silently: a hand-written list of "the sync spawn sites"
- * would go stale the first time someone adds one, which is the
- * single-source-of-truth rule this repo already applies to language and
- * runner registries.
+ * The one-off sweep found three real call sites with no bound. Two are fixed
+ * (`findBinaryOnPath` in clients/lsp/launch.ts, on the LSP spawn path;
+ * `ensureUtf8ConsoleCodePageOnce` in clients/safe-spawn.ts, on the first spawn
+ * of the process); the third is exempted below with its reason. This walks the
+ * family so the next one cannot land silently: a hand-written list of "the
+ * sync spawn sites" goes stale the first time someone adds one, which is the
+ * single-source-of-truth rule this repo already applies to language and runner
+ * registries.
  *
- * Scope: `spawnSync` / `execSync` / `execFileSync` CALL sites in the shipped
- * source tree (clients/, index.ts, tools/, mcp/). Tests and scripts are out —
- * neither runs on pi's event loop.
+ * Built on tests/support/sweep-kit.ts — `listSourceFiles` for the walk,
+ * `stripSource` for comment/string masking, `auditRegistry` for
+ * exempted-with-a-reason plus stale-exemption and dead-scan floors. Those
+ * floors are the point: this repo's catalog shape 10 is a sweep that matches
+ * nothing and reads as clean.
+ *
+ * Scope: the shipped source tree (clients/, index.ts, tools/, mcp/). Tests and
+ * scripts are out — neither runs on pi's event loop.
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import {
+	auditRegistry,
+	listSourceFiles,
+	relativePosix,
+	stripSource,
+} from "../support/sweep-kit.js";
 
-const repoRoot = path.resolve(
+const REPO_ROOT = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
-	"..",
-	"..",
+	"../..",
 );
 
-/** The family. Each is a synchronous child-process launcher. */
+/** The family: every synchronous child-process launcher Node offers. */
 const SYNC_SPAWN_CALLS = ["spawnSync", "execSync", "execFileSync"];
 
 /**
  * Sites that legitimately carry no literal `timeout:` in their own options,
- * with the reason. Keyed by `file::enclosingSnippet` so a move is visible but
- * a rename of the surrounding function is not a false failure.
+ * each with the reason `auditRegistry` requires. Keyed `file:snippet`, where
+ * the snippet appears in the call's arguments or just above it, so a moved
+ * call is still recognised but a genuinely new one is not.
  *
- * Keep this SHORT and reasoned. "It is probably fast" is not a reason — the
- * two bugs this test exists for were both probably fast.
+ * Keep this SHORT and reasoned. "It is probably fast" is not a reason — both
+ * bugs this guard exists for were probably fast.
  */
-const ALLOWED_WITHOUT_TIMEOUT: ReadonlyArray<{
-	file: string;
-	contains: string;
-	reason: string;
-}> = [
-	{
-		file: "clients/safe-spawn.ts",
-		contains: "taskkill.exe",
-		reason:
-			"killPidTreeSync runs from process exit/signal handlers. The process is already tearing down, so there is no event loop left to protect and a timeout would only orphan the kill.",
-	},
-	{
-		file: "clients/safe-spawn.ts",
-		contains: "...(options as SpawnOptions)",
-		reason:
-			"safeSpawn's own two spawnSync calls spread the CALLER's options, which is where the timeout comes from; its only in-repo callers (isCommandAvailable, findCommand) both pass timeout: 5000.",
-	},
-];
-
-function sourceFiles(): string[] {
-	const roots = ["clients", "tools", "mcp"];
-	const found: string[] = [];
-	const walk = (dir: string): void => {
-		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-			const full = path.join(dir, entry.name);
-			if (entry.isDirectory()) {
-				if (entry.name === "node_modules" || entry.name === "dist") continue;
-				walk(full);
-			} else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
-				found.push(full);
-			}
-		}
-	};
-	for (const root of roots) {
-		const abs = path.join(repoRoot, root);
-		if (fs.existsSync(abs)) walk(abs);
-	}
-	const indexTs = path.join(repoRoot, "index.ts");
-	if (fs.existsSync(indexTs)) found.push(indexTs);
-	return found;
-}
+const EXEMPT_SITES: Readonly<Record<string, string>> = {
+	"clients/safe-spawn.ts:taskkill.exe":
+		"killPidTreeSync runs from process exit and signal handlers. The process is already tearing down, so there is no event loop left to protect, and a timeout would only orphan the kill it was asked to perform.",
+	"clients/safe-spawn.ts:...(options as SpawnOptions)":
+		"safeSpawn's own spawnSync calls spread the CALLER's options, which is where the timeout comes from; its only in-repo callers, isCommandAvailable and findCommand, both pass timeout: 5000.",
+};
 
 /**
- * Slice from `(` to its matching `)`, so the options object is read whole
- * rather than by a line-bounded regex that a multi-line call defeats.
+ * Slice from `(` to its matching `)`, so a multi-line options object is read
+ * whole rather than by a line-bounded regex that a formatted call defeats.
  */
 function callArguments(source: string, openParenIndex: number): string {
 	let depth = 0;
@@ -101,126 +78,111 @@ function callArguments(source: string, openParenIndex: number): string {
 	return source.slice(openParenIndex + 1);
 }
 
-/**
- * Which byte offsets are real code, as opposed to comment or string body.
- *
- * Necessary, not fussy: this repo documents its own migrations in prose, so
- * `clients/lsp/server.ts` and `clients/safe-spawn.ts` both contain the text
- * `spawnSync(` inside doc comments explaining that the call USED to be
- * synchronous. A plain regex reports those as unbounded call sites, which is
- * a false failure that would push a maintainer to weaken this test. Stripping
- * comments with a regex has the opposite risk — it can swallow real code and
- * hide a genuine site — so this walks the file once and tracks state instead.
- */
-function codeMask(source: string): Uint8Array {
-	const mask = new Uint8Array(source.length).fill(1);
-	let i = 0;
-	const blank = (from: number, to: number): void => {
-		for (let k = from; k < to && k < source.length; k++) mask[k] = 0;
-	};
-	while (i < source.length) {
-		const two = source.slice(i, i + 2);
-		if (two === "//") {
-			const end = source.indexOf("\n", i);
-			const stop = end === -1 ? source.length : end;
-			blank(i, stop);
-			i = stop;
-		} else if (two === "/*") {
-			const end = source.indexOf("*/", i + 2);
-			const stop = end === -1 ? source.length : end + 2;
-			blank(i, stop);
-			i = stop;
-		} else if (source[i] === '"' || source[i] === "'" || source[i] === "`") {
-			const quote = source[i];
-			let j = i + 1;
-			while (j < source.length) {
-				if (source[j] === "\\") j += 2;
-				else if (source[j] === quote) break;
-				else j++;
-			}
-			blank(i, Math.min(j + 1, source.length));
-			i = j + 1;
-		} else {
-			i++;
-		}
-	}
-	return mask;
-}
-
 interface CallSite {
+	/** `file:line fn` — the id the audit reports. */
+	id: string;
 	file: string;
-	line: number;
-	fn: string;
-	args: string;
-	/** Source just before the call, so an allowlist entry can key on the
-	 * enclosing function rather than on the argument list alone. */
-	context: string;
+	/** Argument list plus a little preceding source, for exemption matching. */
+	haystack: string;
+	bounded: boolean;
 }
 
-function findCallSites(): CallSite[] {
+function shippedSourceFiles(): string[] {
+	const files = ["clients", "tools", "mcp"].flatMap((dir) => {
+		const abs = path.join(REPO_ROOT, dir);
+		return fs.existsSync(abs)
+			? listSourceFiles(abs, { extensions: [".ts"], skipTests: true })
+			: [];
+	});
+	const indexTs = path.join(REPO_ROOT, "index.ts");
+	if (fs.existsSync(indexTs)) files.push(indexTs);
+	return files;
+}
+
+function findCallSites(): { sites: CallSite[]; scanned: number } {
+	const files = shippedSourceFiles();
 	const sites: CallSite[] = [];
-	for (const abs of sourceFiles()) {
-		const source = fs.readFileSync(abs, "utf-8");
-		const mask = codeMask(source);
-		const rel = path.relative(repoRoot, abs).split(path.sep).join("/");
+	for (const abs of files) {
+		const raw = fs.readFileSync(abs, "utf8");
+		// Comment/string masking is necessary, not fussy: this repo documents
+		// its own sync-to-async migrations in prose, so clients/lsp/server.ts
+		// and clients/safe-spawn.ts both contain `spawnSync(` inside doc
+		// comments explaining that the call USED to be synchronous. A raw regex
+		// reports those as unbounded sites, which is a false failure that would
+		// push a maintainer to weaken this guard. `stripSource` blanks comments
+		// and string bodies while preserving every offset.
+		const masked = stripSource(raw);
+		const rel = relativePosix(REPO_ROOT, abs);
 		for (const fn of SYNC_SPAWN_CALLS) {
-			// A CALL, not an import/type/prose mention: the name must be
-			// followed by `(`, and must not be preceded by an identifier char
-			// (so `safeSpawnSync(` never matches `spawnSync`).
+			// A CALL, not an import, type, or prose mention: the name must be
+			// followed by `(` and must not be preceded by an identifier
+			// character, so `safeSpawnSync(` never matches `spawnSync`.
 			const pattern = new RegExp(`(?<![\\w$.])${fn}\\s*\\(`, "g");
-			for (const match of source.matchAll(pattern)) {
-				if (mask[match.index] !== 1) continue; // comment or string body
-				const openParen = source.indexOf("(", match.index);
+			for (const match of masked.matchAll(pattern)) {
+				const openParen = masked.indexOf("(", match.index);
+				const args = callArguments(raw, openParen);
 				sites.push({
+					id: `${rel}:${raw.slice(0, match.index).split("\n").length} ${fn}`,
 					file: rel,
-					line: source.slice(0, match.index).split("\n").length,
-					fn,
-					args: callArguments(source, openParen),
-					context: source.slice(Math.max(0, match.index - 600), match.index),
+					haystack:
+						raw.slice(Math.max(0, match.index - 600), match.index) + args,
+					bounded: /\btimeout\s*:/.test(args),
 				});
 			}
 		}
 	}
-	return sites;
+	return { sites, scanned: files.length };
 }
 
-const matchesEntry = (
-	site: CallSite,
-	entry: (typeof ALLOWED_WITHOUT_TIMEOUT)[number],
-): boolean =>
-	entry.file === site.file &&
-	(site.args.includes(entry.contains) || site.context.includes(entry.contains));
-
-const isAllowed = (site: CallSite): boolean =>
-	ALLOWED_WITHOUT_TIMEOUT.some((entry) => matchesEntry(site, entry));
+/** The exemption key a site matches, if any. */
+function exemptionKey(site: CallSite): string | undefined {
+	return Object.keys(EXEMPT_SITES).find((key) => {
+		const [file, ...rest] = key.split(":");
+		return file === site.file && site.haystack.includes(rest.join(":"));
+	});
+}
 
 describe("#1980 every synchronous child-process call bounds the event-loop park", () => {
-	const sites = findCallSites();
+	const { sites, scanned } = findCallSites();
+	const unbounded = sites.filter((site) => !site.bounded);
 
-	it("finds the family at all (guards against a regex that matches nothing)", () => {
-		// Vacuity guard: if the detection breaks, every assertion below passes
-		// for free. The repo had 7 such sites when this landed.
+	const audit = auditRegistry({
+		sweepName: "sync child-process timeout sweep",
+		// Flagged = the unbounded sites, reported under their exemption key when
+		// they have one, so a stale exemption is detectable by the kit itself.
+		flagged: unbounded.map((site) => exemptionKey(site) ?? site.id),
+		registered: [],
+		exemptions: EXEMPT_SITES,
+		scannedCount: scanned,
+		// Floors, not decoration (catalog shape 10): a walk that finds no
+		// source files, or a detector that flags nothing, must fail rather than
+		// read as clean. 200 is well under the ~450 shipped .ts files; 1 is the
+		// single exempt site that will always be flagged.
+		minScanned: 200,
+		minFlagged: 1,
+		remediation:
+			"Pass an explicit `timeout` (5000 matches every other sync child-process site), or add an entry to EXEMPT_SITES with a real reason.",
+	});
+
+	it("actually finds the family (a dead scan must not read as clean)", () => {
+		// Vacuity guard on the DETECTOR, separate from the audit's floors: if
+		// the call-site regex breaks, every assertion below passes for free.
+		// There were 7 sites across 3 files when this landed.
 		expect(sites.length).toBeGreaterThanOrEqual(5);
 		expect(new Set(sites.map((s) => s.file)).size).toBeGreaterThanOrEqual(3);
 	});
 
-	it("passes an explicit timeout, or is allowlisted with a reason", () => {
-		const unbounded = sites
-			.filter((site) => !/\btimeout\s*:/.test(site.args))
-			.filter((site) => !isAllowed(site))
-			.map((site) => `${site.file}:${site.line} ${site.fn}`);
-		// Pre-fix this reads:
+	it("bounds every site, or exempts it with a reason", () => {
+		// Pre-fix, `audit.unaccounted` reads:
 		//   clients/lsp/launch.ts:310 execFileSync
 		//   clients/safe-spawn.ts:1062 spawnSync
-		expect(unbounded).toEqual([]);
+		expect(audit.problems).toEqual([]);
 	});
 
-	it("keeps the allowlist live, so a stale exemption cannot hide a new site", () => {
-		// An allowlist entry whose site no longer exists must be deleted, not
-		// left to silently cover some future call it was never reasoned about.
-		const stale = ALLOWED_WITHOUT_TIMEOUT.filter(
-			(entry) => !sites.some((site) => matchesEntry(site, entry)),
-		).map((entry) => `${entry.file} :: ${entry.contains}`);
-		expect(stale).toEqual([]);
+	it("keeps the exemption list live and reasoned", () => {
+		// An exemption whose site no longer exists must be deleted, not left to
+		// silently cover some future call it was never reasoned about.
+		expect(audit.staleExemptions).toEqual([]);
+		expect(audit.reasonlessExemptions).toEqual([]);
 	});
 });

--- a/tests/config/sync-child-process-timeout.test.ts
+++ b/tests/config/sync-child-process-timeout.test.ts
@@ -1,0 +1,226 @@
+/**
+ * #1980 AC3, as a recurrence guard rather than a one-off census.
+ *
+ * A synchronous child-process call parks the event loop for exactly as long
+ * as the child takes. With no `timeout`, that is unbounded — and #1980's
+ * whole finding is that such a park used to read as ordinary compute in
+ * `loop_block`, because `windowCpuMs` was recorded and never read.
+ *
+ * The one-off sweep found two unbounded sites (`findBinaryOnPath` in
+ * clients/lsp/launch.ts, on the LSP spawn path, and
+ * `ensureUtf8ConsoleCodePageOnce` in clients/safe-spawn.ts, on the first
+ * spawn of the process). Both are fixed. This walks the family so the next
+ * one cannot land silently: a hand-written list of "the sync spawn sites"
+ * would go stale the first time someone adds one, which is the
+ * single-source-of-truth rule this repo already applies to language and
+ * runner registries.
+ *
+ * Scope: `spawnSync` / `execSync` / `execFileSync` CALL sites in the shipped
+ * source tree (clients/, index.ts, tools/, mcp/). Tests and scripts are out —
+ * neither runs on pi's event loop.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"..",
+);
+
+/** The family. Each is a synchronous child-process launcher. */
+const SYNC_SPAWN_CALLS = ["spawnSync", "execSync", "execFileSync"];
+
+/**
+ * Sites that legitimately carry no literal `timeout:` in their own options,
+ * with the reason. Keyed by `file::enclosingSnippet` so a move is visible but
+ * a rename of the surrounding function is not a false failure.
+ *
+ * Keep this SHORT and reasoned. "It is probably fast" is not a reason — the
+ * two bugs this test exists for were both probably fast.
+ */
+const ALLOWED_WITHOUT_TIMEOUT: ReadonlyArray<{
+	file: string;
+	contains: string;
+	reason: string;
+}> = [
+	{
+		file: "clients/safe-spawn.ts",
+		contains: "taskkill.exe",
+		reason:
+			"killPidTreeSync runs from process exit/signal handlers. The process is already tearing down, so there is no event loop left to protect and a timeout would only orphan the kill.",
+	},
+	{
+		file: "clients/safe-spawn.ts",
+		contains: "...(options as SpawnOptions)",
+		reason:
+			"safeSpawn's own two spawnSync calls spread the CALLER's options, which is where the timeout comes from; its only in-repo callers (isCommandAvailable, findCommand) both pass timeout: 5000.",
+	},
+];
+
+function sourceFiles(): string[] {
+	const roots = ["clients", "tools", "mcp"];
+	const found: string[] = [];
+	const walk = (dir: string): void => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				if (entry.name === "node_modules" || entry.name === "dist") continue;
+				walk(full);
+			} else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+				found.push(full);
+			}
+		}
+	};
+	for (const root of roots) {
+		const abs = path.join(repoRoot, root);
+		if (fs.existsSync(abs)) walk(abs);
+	}
+	const indexTs = path.join(repoRoot, "index.ts");
+	if (fs.existsSync(indexTs)) found.push(indexTs);
+	return found;
+}
+
+/**
+ * Slice from `(` to its matching `)`, so the options object is read whole
+ * rather than by a line-bounded regex that a multi-line call defeats.
+ */
+function callArguments(source: string, openParenIndex: number): string {
+	let depth = 0;
+	for (let i = openParenIndex; i < source.length; i++) {
+		const ch = source[i];
+		if (ch === "(") depth++;
+		else if (ch === ")") {
+			depth--;
+			if (depth === 0) return source.slice(openParenIndex + 1, i);
+		}
+	}
+	return source.slice(openParenIndex + 1);
+}
+
+/**
+ * Which byte offsets are real code, as opposed to comment or string body.
+ *
+ * Necessary, not fussy: this repo documents its own migrations in prose, so
+ * `clients/lsp/server.ts` and `clients/safe-spawn.ts` both contain the text
+ * `spawnSync(` inside doc comments explaining that the call USED to be
+ * synchronous. A plain regex reports those as unbounded call sites, which is
+ * a false failure that would push a maintainer to weaken this test. Stripping
+ * comments with a regex has the opposite risk — it can swallow real code and
+ * hide a genuine site — so this walks the file once and tracks state instead.
+ */
+function codeMask(source: string): Uint8Array {
+	const mask = new Uint8Array(source.length).fill(1);
+	let i = 0;
+	const blank = (from: number, to: number): void => {
+		for (let k = from; k < to && k < source.length; k++) mask[k] = 0;
+	};
+	while (i < source.length) {
+		const two = source.slice(i, i + 2);
+		if (two === "//") {
+			const end = source.indexOf("\n", i);
+			const stop = end === -1 ? source.length : end;
+			blank(i, stop);
+			i = stop;
+		} else if (two === "/*") {
+			const end = source.indexOf("*/", i + 2);
+			const stop = end === -1 ? source.length : end + 2;
+			blank(i, stop);
+			i = stop;
+		} else if (source[i] === '"' || source[i] === "'" || source[i] === "`") {
+			const quote = source[i];
+			let j = i + 1;
+			while (j < source.length) {
+				if (source[j] === "\\") j += 2;
+				else if (source[j] === quote) break;
+				else j++;
+			}
+			blank(i, Math.min(j + 1, source.length));
+			i = j + 1;
+		} else {
+			i++;
+		}
+	}
+	return mask;
+}
+
+interface CallSite {
+	file: string;
+	line: number;
+	fn: string;
+	args: string;
+	/** Source just before the call, so an allowlist entry can key on the
+	 * enclosing function rather than on the argument list alone. */
+	context: string;
+}
+
+function findCallSites(): CallSite[] {
+	const sites: CallSite[] = [];
+	for (const abs of sourceFiles()) {
+		const source = fs.readFileSync(abs, "utf-8");
+		const mask = codeMask(source);
+		const rel = path.relative(repoRoot, abs).split(path.sep).join("/");
+		for (const fn of SYNC_SPAWN_CALLS) {
+			// A CALL, not an import/type/prose mention: the name must be
+			// followed by `(`, and must not be preceded by an identifier char
+			// (so `safeSpawnSync(` never matches `spawnSync`).
+			const pattern = new RegExp(`(?<![\\w$.])${fn}\\s*\\(`, "g");
+			for (const match of source.matchAll(pattern)) {
+				if (mask[match.index] !== 1) continue; // comment or string body
+				const openParen = source.indexOf("(", match.index);
+				sites.push({
+					file: rel,
+					line: source.slice(0, match.index).split("\n").length,
+					fn,
+					args: callArguments(source, openParen),
+					context: source.slice(Math.max(0, match.index - 600), match.index),
+				});
+			}
+		}
+	}
+	return sites;
+}
+
+const matchesEntry = (
+	site: CallSite,
+	entry: (typeof ALLOWED_WITHOUT_TIMEOUT)[number],
+): boolean =>
+	entry.file === site.file &&
+	(site.args.includes(entry.contains) || site.context.includes(entry.contains));
+
+const isAllowed = (site: CallSite): boolean =>
+	ALLOWED_WITHOUT_TIMEOUT.some((entry) => matchesEntry(site, entry));
+
+describe("#1980 every synchronous child-process call bounds the event-loop park", () => {
+	const sites = findCallSites();
+
+	it("finds the family at all (guards against a regex that matches nothing)", () => {
+		// Vacuity guard: if the detection breaks, every assertion below passes
+		// for free. The repo had 7 such sites when this landed.
+		expect(sites.length).toBeGreaterThanOrEqual(5);
+		expect(new Set(sites.map((s) => s.file)).size).toBeGreaterThanOrEqual(3);
+	});
+
+	it("passes an explicit timeout, or is allowlisted with a reason", () => {
+		const unbounded = sites
+			.filter((site) => !/\btimeout\s*:/.test(site.args))
+			.filter((site) => !isAllowed(site))
+			.map((site) => `${site.file}:${site.line} ${site.fn}`);
+		// Pre-fix this reads:
+		//   clients/lsp/launch.ts:310 execFileSync
+		//   clients/safe-spawn.ts:1062 spawnSync
+		expect(unbounded).toEqual([]);
+	});
+
+	it("keeps the allowlist live, so a stale exemption cannot hide a new site", () => {
+		// An allowlist entry whose site no longer exists must be deleted, not
+		// left to silently cover some future call it was never reasoned about.
+		const stale = ALLOWED_WITHOUT_TIMEOUT.filter(
+			(entry) => !sites.some((site) => matchesEntry(site, entry)),
+		).map((entry) => `${entry.file} :: ${entry.contains}`);
+		expect(stale).toEqual([]);
+	});
+});

--- a/tests/index-loop-block-wiring.test.ts
+++ b/tests/index-loop-block-wiring.test.ts
@@ -303,6 +303,37 @@ describe(
 			expect(metadata.inFlightPhaseElapsedMs).toBeUndefined();
 		});
 
+		// #1980: the stall class and its CPU-coverage ratio have to reach the
+		// PERSISTED record, or the split exists only in memory and a reader
+		// mining latency.log is back to computing the ratio by hand over 1221
+		// records. The monitor owns the verdict; this pins that turn_end stamps
+		// what the monitor decided instead of dropping it or re-deriving it.
+		it("(g) #1980: the loop_block record carries the stall class and CPU coverage ratio", async () => {
+			statsToReturn = {
+				// #1980's own top row: d=19780ms cpu=7907ms wall=41295ms.
+				maxMs: 19780,
+				p99Ms: 0,
+				meanMs: 0,
+				windowWallMs: 41295,
+				windowCpuMs: 7907,
+				suspectSystemStall: false,
+				stallClass: "non-cpu-stall",
+				cpuCoverageRatio: 0.4,
+			};
+
+			await fireTurnEnd();
+
+			const logged = loopBlocks();
+			expect(logged).toHaveLength(1);
+			const metadata = logged[0].metadata as Record<string, unknown>;
+			// Pre-fix both fields are absent from the record entirely.
+			expect(metadata.stallClass).toBe("non-cpu-stall");
+			expect(metadata.cpuCoverageRatio).toBe(0.4);
+			// The #1122 flag is untouched beside them, not replaced.
+			expect(metadata.suspectSystemStall).toBe(false);
+			expect(metadata.windowCpuMs).toBe(7907);
+		});
+
 		// #1723 review round 7, S3: `resetCurrentPhaseForSession()`'s call site
 		// (index.ts's `session_start` handler, behind the #473 gate) is exactly
 		// the kind of wiring `SESSION_STATE_REGISTRY`'s reachability derivation

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -231,6 +231,15 @@ const timingSensitiveInclude = [
 	// a stall — contention, not a regression, so the cure is a quiet host, not
 	// a looser assertion. timing-sensitive-coverage.test.ts derives this
 	// membership from the process.cpuUsage marker and fails if it is absent.
+	//
+	// Read the `maxWorkers: 2` note below together with this entry. That note
+	// says the lane's heavy neighbour is gone; this file is a NEW one — three
+	// cases that busy-spin a core for ~4.8s in total, which is exactly the
+	// shape that starved a sibling's sampler at cap 2 before. Measured rather
+	// than assumed when this landed: the full lane ran clean 4/4 at cap 2 with
+	// this file in it (19 files, 118 tests, ~49s). If a sampler-based sibling
+	// starts flaking here, this file is the first suspect and the cap is the
+	// first lever.
 	"tests/clients/loop-block-stall-discrimination.test.ts",
 ];
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -226,6 +226,15 @@ const timingSensitiveInclude = [
 	// sampler, and its fail-then-pass pair injects a busy-wait stall, so it
 	// must not compete with a fork storm for CPU turns.
 	"tests/clients/source-walker-io-occupancy.test.ts",
+	// #1980: blocks the real event loop twice (a parked-thread futex wait, then
+	// a busy spin of the same length) and asserts the two classify differently
+	// on the CPU axis, reading process.cpuUsage through getEventLoopStats.
+	// Under the default fork storm a busy spin gets descheduled and burns less
+	// CPU than the wall time it held, which would make the compute case read as
+	// a stall — contention, not a regression, so the cure is a quiet host, not
+	// a looser assertion. timing-sensitive-coverage.test.ts derives this
+	// membership from the process.cpuUsage marker and fails if it is absent.
+	"tests/clients/loop-block-stall-discrimination.test.ts",
 ];
 
 // #1022 fix: the "workspace LSP winner" case in this file spawns a REAL
@@ -266,13 +275,6 @@ const lspSpawnHeavyInclude = [
 // host. Sweep coverage for other members lives in this list; new entries must
 // carry a wall-clock budget assertion, not just slowness.
 const wallClockBudgetInclude = [
-	// #1980: blocks the real event loop twice (a parked-thread futex wait, then
-	// a busy spin of the same length) and asserts the two classify differently
-	// on the CPU axis. Under the default fork storm a busy spin gets
-	// descheduled and burns less CPU than the wall time it held, which would
-	// make the compute case read as a stall — contention, not a regression, so
-	// the cure is a quiet host, not a looser assertion.
-	"tests/clients/loop-block-stall-discrimination.test.ts",
 	"tests/clients/startup-overhead.test.ts",
 	"tests/clients/runtime-session-scan-cache.test.ts",
 	"tests/clients/cascade-turn-merge.test.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -266,6 +266,13 @@ const lspSpawnHeavyInclude = [
 // host. Sweep coverage for other members lives in this list; new entries must
 // carry a wall-clock budget assertion, not just slowness.
 const wallClockBudgetInclude = [
+	// #1980: blocks the real event loop twice (a parked-thread futex wait, then
+	// a busy spin of the same length) and asserts the two classify differently
+	// on the CPU axis. Under the default fork storm a busy spin gets
+	// descheduled and burns less CPU than the wall time it held, which would
+	// make the compute case read as a stall — contention, not a regression, so
+	// the cure is a quiet host, not a looser assertion.
+	"tests/clients/loop-block-stall-discrimination.test.ts",
 	"tests/clients/startup-overhead.test.ts",
 	"tests/clients/runtime-session-scan-cache.test.ts",
 	"tests/clients/cascade-turn-merge.test.ts",


### PR DESCRIPTION
## What changed

Every `loop_block` record now says whether the block was computing or parked.

`windowCpuMs` has sat beside `durationMs` on every `loop_block` since #1122 and
was never read together with it. #1980's log mining did read them together, by
hand, and found that nine of the sixteen genuine 5 s+ blocks in a 23 h window
burned less CPU than the block lasted. Those are synchronous waits, not work,
and every one of them read as ordinary compute because `suspectSystemStall`
only fires above a 20 s floor.

Three pieces:

1. **`classifyLoopBlock`** (`clients/event-loop-monitor.ts`) stamps `stallClass`
   and `cpuCoverageRatio` on every sample. `getEventLoopStats` computes it once,
   so `suspectSystemStall` and `stallClass` cannot disagree about the same
   block, and `turn_end` (`index.ts`) copies both onto the record.
2. **The sweep gets a name** (`clients/lsp/index.ts`). #1723's remaining AC2 gap
   was the workspace-diagnostics sweep's per-file touch, named as deferred on
   PR #1805. It now opens a `phaseStarted`/`phaseFinished` bracket paired in
   `finally`, so `getPhaseForWindow` can attribute a block that fires inside it.
3. **Two unbounded synchronous spawns**, found by #1980's population sweep, now
   pass a timeout.

## The classifier is one-sided, and says so

`windowCpuMs` is process-wide CPU across the whole window, so it is an upper
bound on the CPU any single block inside it could have burned. That makes one
direction a real inference and the other not:

- `windowCpuMs + slop < maxMs` **proves** the block was not compute. Even if
  the block had been the only thing running, the window did not contain enough
  CPU to produce it. That is `non-cpu-stall`.
- The converse proves nothing: a window can burn 30 s of CPU elsewhere and
  still contain a 5 s I/O park. So the other label is `cpu-accounted` ("the
  budget covers it"), not `compute`.

The ladder is `below-floor` → `system-stall` → `non-cpu-stall` →
`cpu-accounted`. `system-stall` delegates to the existing
`isSuspendSuspectedBlock`, so there is one definition of a suspend rather than
two, and a test asserts the two agree on every classified sample.

## Tests

Red-first, on pre-fix source with a rebuild between:

```
     × declines to classify a sub-floor block instead of defaulting it to compute 3ms
     × classes a block the window's whole CPU budget cannot cover as a non-CPU stall 0ms
     × classes a block the window's CPU covers as cpu-accounted, not a stall 0ms
     × keeps the suspend verdict distinct from an ordinary non-CPU stall 0ms
     × agrees with the pre-existing suspend predicate on every classified sample 0ms
     × honours the CPU slop so a near-exact match is not called a stall 0ms
     × reports the CPU coverage ratio the issue had to compute by hand 0ms
     × getEventLoopStats carries the class and the ratio onto every sample 45ms
     × names the sweep as the in-flight phase while a file's touch is running 1179ms
     × a block whose window lands inside the sweep is attributed to it 50ms
     × (g) #1980: the loop_block record carries the stall class and CPU coverage ratio 105ms
     × a real non-CPU block (parked thread) reads as non-cpu-stall 1746ms
     × a CPU spin of the same duration reads as cpu-accounted 1737ms
     × the two blocks are the same length and differ only on the CPU axis 3474ms
      Tests  14 failed | 27 passed (41)
```

And for the spawn sweep, reverting only `clients/lsp/launch.ts` and
`clients/safe-spawn.ts`:

```
     × passes an explicit timeout, or is allowlisted with a reason 13ms
+ [
+   "clients/lsp/launch.ts:310 execFileSync",
+   "clients/safe-spawn.ts:1062 spawnSync",
+ ]
      Tests  1 failed | 2 passed (3)
```

### #1980 AC4: a real injected stall, on the real monitor

The pure cases prove the ladder but not that the ladder is fed numbers measured
over spans that line up. `tests/clients/loop-block-stall-discrimination.test.ts`
blocks the real loop twice for the same duration, differing only on the CPU
axis: `Atomics.wait` on a `SharedArrayBuffer` parks the thread in a futex wait
(loop dead, no CPU), and a busy loop holds it for the same wall time as CPU.
The first classifies `non-cpu-stall`, the second `cpu-accounted`.

One thing that fell out of building it, worth knowing: on Node v24.19.0,
`IntervalHistogram.reset()` followed by a synchronous block **in the same tick**
records ~32 ms for a 1600 ms block; the identical block one tick later records
1601 ms. Production is always the second shape (`resetEventLoopMonitor` runs at
`turn_end`, the next turn's block is many ticks later), so this is a harness
constraint, not a production bug. The test yields a tick after the reset and
documents why.

### Mutation proofs

Every new branch reds a test when removed:

| mutation | result |
| --- | --- |
| delete the `below-floor` branch | 2 failed |
| delete the `system-stall` branch | 2 failed |
| `slopMs` default to 0 | 1 failed |
| delete `processFile`'s `finally` | 3 failed |

### Governance suites

Two fired on the new files, both correctly, and both are fixed rather than
worked around:

- `sweep-floor-coverage` — the sync-spawn census is sweep-shaped, so it must use
  `tests/support/sweep-kit.ts`. Rebuilt on `listSourceFiles` + `stripSource` +
  `auditRegistry`, which replaced a hand-rolled walk and a bespoke comment
  scanner and gave it the dead-scan and stale-exemption floors for free.
- `timing-sensitive-coverage` — the discrimination test reads process CPU time,
  so it belongs in the serialized `timing-sensitive` project, not
  `wall-clock-budget`. That suite derives membership from the marker, so the
  misplacement was caught mechanically.

All 15 governance suites green:
`bounded-telemetry-sweep`, `bus-producer-coverage`, `delivery-surface-ratchet`,
`deps-centralization`, `finding-delivery-gate`, `freshness-sweep`,
`managed-tool-seam-coverage`, `profiling-coverage`, `session-state-conformance`,
`module-instance-coverage`, `sweep-floor-coverage`, `timing-sensitive-coverage`,
`vacuous-skip-coverage`, `dependency-boundaries`, `sync-child-process-timeout`
— 175 passed.

Targeted files green: 114 passed across the 8 files that reference the changed
symbols, plus the whole `tests/clients/lsp/` tree (1174 passed, 8 skipped)
since review round 1 moved a bracket inside that seam. `npm run lint`, `npm run fmt:check`, `npm run changelog:check` clean.
Full suite is CI's job.

## Class sweep

**Pattern sweep.** The defect shape is "a field is recorded and never read
together with the field that makes it meaningful". Grepped the whole shipped
tree, not just `clients/`. `windowCpuMs`/`windowWallMs` were the instance; no
sibling pair turned up.

**Population sweep (#1980 AC3): synchronous child-process calls.** This is the
enumerable family whose members can park the loop for seconds. Seven call sites
across three files, comment-masked so the repo's own prose about past
migrations does not count:

| site | verdict |
| --- | --- |
| `clients/lsp/launch.ts:310` `execFileSync` (`findBinaryOnPath`) | **FIXED** — no bound at all, on the LSP server spawn path. A stale network PATH entry parks the loop with no ceiling. Now `timeout: 5000`. |
| `clients/safe-spawn.ts:1062` `spawnSync` (`ensureUtf8ConsoleCodePageOnce`) | **FIXED** — no bound, runs before the first real spawn of the process, when cmd.exe is coldest. Now `timeout: 5000`. |
| `clients/safe-spawn.ts:387` `spawnSync` (`killPidTreeSync`) | **EXEMPT, reasoned** — runs from exit/signal handlers. No event loop left to protect; a timeout would orphan the kill. |
| `clients/safe-spawn.ts` `spawnSync` x2 (`safeSpawn` Windows and POSIX branches) | **EXEMPT, reasoned** — spread the caller's options; both in-repo callers pass `timeout: 5000`. |
| `clients/lsp/launch.ts:146` `execFileSync` (`runStderrGuardedProbe`) | **already correct** — `timeout: 3000`. |
| `clients/metrics-history.ts:89` `execSync` (`git rev-parse`) | **already correct** — `timeout: 5000`. |

The guard walks the family rather than pinning a list, so the next unbounded
site reds instead of landing silently.

**Population sweep: synchronous fs.** 777 `*Sync` fs call sites across 148
files. Not per-site verdicted here, and I am not going to claim otherwise — a
census that size needs its own pass, and the repo already has the measured
answer to the class in `clients/slow-fs.ts`, which classifies the workspace by
probe and routes sync walks to reduced caps. Named as the remainder in an issue
comment on #1980 rather than folded in silently.

## Test assessment

Per touched test file, what it uniquely pins and what became redundant.

| file | pins | redundancy |
| --- | --- | --- |
| `tests/clients/event-loop-monitor.test.ts` (7 new cases in one new `describe`) | each branch of `classifyLoopBlock`, on real rows from #1980's evidence, plus the agreement with `isSuspendSuspectedBlock` and the ratio field. Every branch is mutation-proofed above. | none. The existing `isSuspendSuspectedBlock` cases stay: they pin the 20s suspend predicate directly, and the new agreement case would pass vacuously if that predicate were deleted. |
| `tests/clients/loop-block-stall-discrimination.test.ts` (new) | that the classifier is fed CPU and duration measured over spans that line up, using the real monitor and a real blocked loop. The pure cases cannot see this. | none. It is the only end-to-end case on this seam. |
| `tests/clients/lsp/workspace-diagnostics-sweep-attribution.test.ts` (new, 6 cases) | the sweep bracket through the REAL `runWorkspaceDiagnostics`. Four cases read from inside the touch (phase named, window attributed, bracket closed on the success and throw paths). Two cases added in review round 1 read at the PRODUCTION read point — after a 225-file sweep — which is the only place the F1 defect was visible. | none. No existing sweep test observes phase state. The four in-touch cases are NOT redundant with the two production-read ones: they localise a failure to the bracket itself rather than to the ring, which is what made F1 diagnosable in one run. |
| `tests/config/sync-child-process-timeout.test.ts` (new) | that no synchronous child-process call is unbounded, as a walk rather than a list. | none, and it deliberately replaced a hand-rolled walk with `sweep-kit` rather than adding a second one. |
| `tests/index-loop-block-wiring.test.ts` (1 case added) | that the class and ratio reach the PERSISTED record, not just `getEventLoopStats`. | none. Cases (a)-(f) pin different wiring facts. |
| `tests/clients/lsp/sweep-warmup.test.ts`, `tests/clients/lsp/service-notify-inflight-throttle.test.ts` | unchanged assertions. Only the `vi.mock` factory changed, from a whole-module replacement to an `importActual` spread. | none removed. |

No test was deleted or weakened. The five existing `loop_block` wiring cases and
every `isSuspendSuspectedBlock` case still assert exactly what they did.

## Blast radius

- **`EventLoopStats` gained two required fields.** Consumers:
  `index.ts` `turn_end` (updated), `clients/memory-sampler.ts` and the health
  surfaces read `maxMs`/`suspectSystemStall` only and are untouched. Additive;
  `suspectSystemStall` keeps its exact prior value, asserted by a test that
  compares the class against `isSuspendSuspectedBlock` on five samples.
- **`loop_block` record gained two metadata fields.** Additive. Nothing parses
  the record positionally.
- **The LSP sweep's fan-out gained one bracket** (review round 1, F1 — it was
  one per file in the first shape). Measured: **2.13 µs** per
  `phaseStarted`/`phaseFinished` pair over 200 000 warmed iterations. At one
  pair per SWEEP that is 2.13 µs total, against the 100 ms
  `WatchedFilesQueue` debounce window the per-file loop must stay inside.
  Nothing measurable.
- **Two spawn sites gained a 5 s timeout.** Behavior widens only in the failure
  direction: a child that used to hang forever now returns an error after 5 s,
  and both call sites already treat failure as "not found" / best-effort.
- **No new process spawns.** No new persisted state.
- **Concurrency:** the sweep runs `processFile` across concurrent workers. The
  bracket map is keyed by token, which is the design PR #1805's review round
  arrived at precisely so overlapping brackets are the normal case.

## Observability

The record that proves this in production is `~/.pi-lens/latency.log`,
`phase: "loop_block"`, fields `metadata.stallClass` and
`metadata.cpuCoverageRatio`. Both ride the existing bounded-telemetry helper
(`emitBounded`, identity `<pi-lens>`), so the volume bound is unchanged: one
record per turn, set by call cadence.

For the attribution half, the same record's `metadata.inFlightPhase` should now
read `lsp_workspace_diagnostics_touch` for a block inside a full scan, where it
previously read empty with `lastPhase: lsp_workspace_diagnostics` beside it.

The spawn timeouts have no record of their own. That is the honest gap: a
`where`/`which` that now times out at 5 s returns "not found" through the same
path a genuine miss takes, so it is indistinguishable in logs. Named in the
issue comment on #1980 rather than left implied.

## Merge order

No collision with the two open PRs (#2256 review-graph builder, #2243 FactStore
and degradation ledger). Disjoint files; no ordering requirement either way.

## Review round 1

Two findings, both real, both reproduced before I touched anything.

### F1 (blocker): the headline was inert for its own motivating case

The reviewer's probe: `CLOSED_BRACKET_CAP` is 5 (`clients/latency-logger.ts:214`), the first shape opened and closed a bracket PER SWEPT FILE, and `turn_end` reads `getPhaseForWindow` AFTER the sweep returns. So a 225-file sweep pushes 225 entries through a 5-entry ring, and the blocking file's own bracket is evicted unless the block lands in the last five files — about 2% of a scan. The five survivors are then rejected by `MIN_PLAUSIBLE_ELAPSED_FRACTION` for being far shorter than the block window. Net result: silence, which is what #1723 opened about.

My four original cases could not see this. Every one of them read attribution from INSIDE the touch, on a one or two file fixture. The production read point was untested.

Reproduced first, on my own head `5b7d83c4`, with a new case that reads where production reads:

```
     × F1: a mid-sweep block is still attributed when read AFTER a 225-file sweep 1991ms
     × F1: one bracket for the whole sweep, not one per file 1704ms
AssertionError: expected undefined to be 'lsp_workspace_diagnostics_touch' // Object.is equality
AssertionError: expected 5 to be 1 // Object.is equality
      Tests  2 failed | 4 passed (6)
```

`expected 5 to be 1` is the ring saturation itself: 225 per-file brackets left exactly `CLOSED_BRACKET_CAP` entries behind.

Fixed by adopting the reviewer's simpler shape: ONE bracket around the whole per-file fan-out (`clients/lsp/index.ts`, wrapping `runPerServerGroups`). The phase string is a constant carrying no per-file identity, so 225 brackets never held more information than one — they only cost 225 map inserts and destroyed the ring. One bracket keeps the same discriminating identity, survives to the read point, and spans the block by construction. All 6 cases green after.

This also retires the per-call cost number from the Blast radius section below: the sweep now pays ONE `phaseStarted`/`phaseFinished` pair per sweep, not 225. At 2.13 µs per pair that is 2.13 µs total against a 100 ms debounce window, rather than the 0.48 ms the first shape cost.

Mutation proof for the new shape: emptying the `finally` reds 3 cases.

### F2: a comment that this PR made false

`index.ts` still claimed the sweep was "a named, deferred gap" and "NOT wired". This PR wires it. Deleted, replaced with what is actually true.

While checking F2 I found a second false claim in my own new comment: it asserted that abort and service-destroyed would defeat a trailing `phaseFinished` call. They do not — both RETURN from the worker callback, so `runPerServerGroups` still resolves. `finally` is still the right spelling (it covers a throw escaping the fan-out), but the justification now matches what the tests actually prove.

### Master merge, screened semantically

Merged `origin/master` while resolving BEHIND. The only file overlap is
`vitest.config.ts`, and the merge is textually clean but the reasoning behind
master's change is now stale, which is the recombination case worth naming.

#2254 returned the timing-sensitive lane from `maxWorkers: 1` to `2`, on the
stated grounds that its heavy neighbour (`word-index-per-edit`) had moved out.
In the meantime this PR added a NEW heavy neighbour to that lane: the #1980
discrimination test busy-spins a core for roughly 4.8 s across its three cases,
which is the same shape that starved a sibling's sampler at cap 2 before.

Measured rather than assumed. The full lane at cap 2 with this file in it:

```
 Test Files  19 passed (19)
      Tests  118 passed (118)
   Duration  49.43s
```

4/4 clean runs, so master's cap stands unchanged and the resolution is purely
additive. A comment next to the lane entry records the interaction so a future
flake there has a first suspect and a first lever.

Governance suites re-run after the merge (15 files, 194 passed), plus the
spawn-related tests master touched (`safe-spawn-ambient-signal`,
`safe-spawn-cap-race`, `spawn-timeout-cooldown`,
`managed-tool-refresh-strategies`) since this PR edits `clients/safe-spawn.ts`
— 147 passed across that set.

### Related

The latent whole-module mock class described below is filed as #2281.

## Review round 0 (CI on the first head)

`Unit tests` went red on head `4c010142` with 5 failures, all one cause:
`tests/clients/lsp/sweep-warmup.test.ts` and
`tests/clients/lsp/service-notify-inflight-throttle.test.ts` replace the WHOLE
latency-logger module with `() => ({ logLatency })`, so the new
`phaseStarted` import in `clients/lsp/index.ts` made them die with
`No "phaseStarted" export is defined on the mock`.

```
      Tests  5 failed | 10548 passed | 61 skipped (10614)
```

Fixed on head `5b7d83c4` by spreading `importActual` in both factories, which
overrides only what each test observes. Both files green locally (24 passed),
assertions unchanged.

Worth naming, because it is a grep lesson: neither file mentions
`phaseStarted`, so grepping the test tree for the CHANGED SYMBOLS could not
find them. When a change adds an import to a module, the grep that finds the
breakage is for tests that MOCK that module.

I then enumerated the class: 22 test files carry a whole-module
latency-logger mock and also load `LSPService`. All 22 run green (231 passed) —
the other 20 never reach `processFile`, so they never touch the new bracket.
They stay latent for the same reason, and I have deliberately not rewritten
them here: 20 files of unrelated churn in a fix PR is noise, and each spread
changes what module state those tests load. Named rather than silently left.

## Remaining

Refs, not closes, both issues:

- **#1980** — AC1, AC2, AC4 met. AC3 met for the child-process family; the
  777-site synchronous fs population is not per-site verdicted. Commented on the
  issue with exactly what remains.
- **#1723** — AC1 was closed by PR #1733, AC2 is now closed on both sides
  (runner via #1805, scan side here). AC3 asks whether scan-window
  `lsp_diagnostics_timeout` records correlate with blocks. That is a question
  answered from log data after this ships, not a code change, so the issue stays
  open for it.

One residual carried forward unchanged from PR #1805's review: `getEventLoopStats`
reports the window's max delay, not the instant the block ended, so the
attribution window `[now - durationMs, now]` remains an approximation. Any
automated correlation must allow the same slack.




