### PR TITLE
fix(dispatch): normalize dispatch paths once per dispatch (refs #2016)

### DIFF
--- a/.changelog/fix-2016-normalize-once.md
+++ b/.changelog/fix-2016-normalize-once.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Stop re-canonicalizing already-normalized dispatch paths (refs #2016)** — the dispatch context's `filePath`, `cwd`, and `projectRoot` are normalized once at construction, and seven downstream sites no longer pay a redundant `realpathSync` per dispatch. Scanner ids and the relative baseline key move to the cheap syntactic normalizer, which also fixes a key that resolved against the process working directory on Windows and stayed relative on Linux.

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -27,7 +27,10 @@ import { getPrimaryDispatchGroup } from "../language-policy.js";
 import { resolveLanguageRootForFile } from "../language-profile.js";
 import { logLatency, phaseFinished, phaseStarted } from "../latency-logger.js";
 import { isSpawnableCommand } from "../installer/index.js";
-import { normalizeMapKey } from "../path-utils.js";
+import {
+	normalizeEphemeralMapKey,
+	normalizeMapKey,
+} from "../path-utils.js";
 import { loadPiLensProjectConfig } from "../project-lens-config.js";
 import { RUNTIME_CONFIG, getRunnerTimeoutFloorMs } from "../runtime-config.js";
 import { safeSpawnAsync } from "../safe-spawn.js";
@@ -566,13 +569,19 @@ function buildCoverageNotice(
 		// The marker describes this exact silent-scanner set. A scanner can
 		// recover while another goes dark on the same file, so the set belongs
 		// in the session dedupe identity rather than only kind and path.
+		// #2016: these are SCANNER IDS, not filesystem paths. `normalizeMapKey`
+		// would realpath each one; on Windows that fails, falls through to
+		// `resolveNonExisting`, and resolves the id against the CURRENT process
+		// cwd, so the dedupe key differed by platform and by cwd (the #2219
+		// non-path-sentinel class). The cheap syntactic fold is what this
+		// session-scoped dedupe key actually needs.
 		const silentScannerSet = [...new Set(unconfirmedServerIds)]
-			.map(normalizeMapKey)
+			.map(normalizeEphemeralMapKey)
 			// Code-unit comparator: the sorted set is a dedupe KEY, so ordering
 			// must be deterministic across locales — localeCompare is not.
 			.sort((a, b) => Number(a > b) - Number(a < b))
 			.join(",");
-		const onceKey = `${ctx.kind}:${normalizeMapKey(ctx.filePath)}:${silentScannerSet}`;
+		const onceKey = `${ctx.kind}:${ctx.filePath}:${silentScannerSet}`;
 		if (coverageNoticeSeen.has(onceKey)) return undefined;
 		coverageNoticeSeen.add(onceKey);
 		const shown = unconfirmedServerIds.slice(0, 4);
@@ -629,7 +638,7 @@ function buildCoverageNotice(
 	);
 	if (anyLinterHasCoverage) return undefined;
 
-	const onceKey = `${ctx.kind}:${normalizeMapKey(ctx.filePath)}`;
+	const onceKey = `${ctx.kind}:${ctx.filePath}`;
 	if (coverageNoticeSeen.has(onceKey)) return undefined;
 	coverageNoticeSeen.add(onceKey);
 
@@ -833,14 +842,14 @@ async function runGroup(
 							runnerId: runner.id,
 							from: observedTier,
 							to: tier,
-							projectRoot: normalizeMapKey(projectRoot),
+							projectRoot,
 						},
 					});
 				}
 				if (tier === "collect-later") {
 					incrementDegradationCount({
 						kind: "runner-collect-later",
-						subject: `${normalizeMapKey(projectRoot)}:${runner.id}`,
+						subject: `${projectRoot}:${runner.id}`,
 						reason: `observed ${durationMs}ms, threshold ${COLLECT_LATER_THRESHOLD_MS}ms`,
 					});
 				}
@@ -915,14 +924,14 @@ async function runGroup(
 					runnerId: runner.id,
 					from: observedTier,
 					to: tier,
-					projectRoot: normalizeMapKey(projectRoot),
+					projectRoot,
 				},
 			});
 		}
 		if (tier === "collect-later") {
 			incrementDegradationCount({
 				kind: "runner-collect-later",
-				subject: `${normalizeMapKey(projectRoot)}:${runner.id}`,
+				subject: `${projectRoot}:${runner.id}`,
 				reason: `observed ${duration}ms, threshold ${COLLECT_LATER_THRESHOLD_MS}ms`,
 			});
 		}
@@ -1055,8 +1064,13 @@ export async function dispatchForFile(
 
 	// Count baseline warnings before filtering (for delta count display)
 	const relativeKey = path.relative(ctx.cwd, ctx.filePath).replace(/\\/g, "/");
-	const baselineAbsKey = `session.baseline.${normalizeMapKey(ctx.filePath)}`;
-	const baselineRelKey = `session.baseline.${normalizeMapKey(relativeKey)}`;
+	const baselineAbsKey = `session.baseline.${ctx.filePath}`;
+	// #2016: `relativeKey` is relative to `ctx.cwd`. `normalizeMapKey` resolved
+	// it against the process cwd instead, so on Windows this "relative" key
+	// became an absolute path anchored on the wrong root while POSIX left it
+	// relative. Both the read here and the write below use this const, so the
+	// key stays self-consistent within a session.
+	const baselineRelKey = `session.baseline.${normalizeEphemeralMapKey(relativeKey)}`;
 	const previousBaseline = ctx.deltaMode
 		? (ctx.facts.getSessionFact<Diagnostic[]>(baselineAbsKey) ??
 			ctx.facts.getSessionFact<Diagnostic[]>(baselineRelKey))

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -27,10 +27,7 @@ import { getPrimaryDispatchGroup } from "../language-policy.js";
 import { resolveLanguageRootForFile } from "../language-profile.js";
 import { logLatency, phaseFinished, phaseStarted } from "../latency-logger.js";
 import { isSpawnableCommand } from "../installer/index.js";
-import {
-	normalizeEphemeralMapKey,
-	normalizeMapKey,
-} from "../path-utils.js";
+import { normalizeEphemeralMapKey, normalizeMapKey } from "../path-utils.js";
 import { loadPiLensProjectConfig } from "../project-lens-config.js";
 import { RUNTIME_CONFIG, getRunnerTimeoutFloorMs } from "../runtime-config.js";
 import { safeSpawnAsync } from "../safe-spawn.js";

--- a/clients/dispatch/types.ts
+++ b/clients/dispatch/types.ts
@@ -177,10 +177,28 @@ export interface RunnerResult {
 
 // --- Dispatch Context ---
 
+/**
+ * #2016 invariant: `filePath`, `projectRoot`, and `cwd` are ALREADY
+ * `normalizeMapKey`-normalized. `createDispatchContext` is the only constructor
+ * and it normalizes all three before building the object.
+ *
+ * So `normalizeMapKey(ctx.filePath)` is a pure `realpathSync.native` syscall
+ * that returns its own input. On Windows that measures ~200 microseconds per
+ * call, and POSIX short-circuits it, which is why CI timing gates cannot see
+ * the waste. Use these three fields directly as map keys, fact keys, once-keys,
+ * and degradation subjects. `tests/clients/dispatch-context-normalized.test.ts`
+ * pins both halves: that the constructor normalizes, and that no call site
+ * re-normalizes.
+ */
 export interface DispatchContext {
+	/** Normalized. See the #2016 invariant above. */
 	readonly filePath: string;
-	/** Workspace/project root before language-specific root resolution. */
+	/**
+	 * Workspace/project root before language-specific root resolution.
+	 * Normalized. See the #2016 invariant above.
+	 */
 	readonly projectRoot?: string;
+	/** Normalized. See the #2016 invariant above. */
 	readonly cwd: string;
 	readonly kind: FileKind | undefined;
 	readonly fileRole: FileRole;

--- a/clients/lsp-mutation.ts
+++ b/clients/lsp-mutation.ts
@@ -159,8 +159,22 @@ function uniqueDetails(
 	fileDetails: AppliedWorkspaceEdit["fileDetails"],
 ): AppliedWorkspaceEdit["fileDetails"] {
 	const byPath = new Map<string, AppliedWorkspaceEdit["fileDetails"][number]>();
+	// #2016: `files` and `fileDetails` name the same paths, so without this the
+	// map-build loop and the lookup below each pay `realpathSync.native` for the
+	// same path (~200 microseconds per call on Windows; POSIX short-circuits, so
+	// CI cannot see it). The memo lives for one call, so it has no staleness
+	// window at all and needs no freshness design.
+	const keyMemo = new Map<string, string>();
+	const keyFor = (filePath: string): string => {
+		let key = keyMemo.get(filePath);
+		if (key === undefined) {
+			key = normalizeMapKey(path.resolve(filePath));
+			keyMemo.set(filePath, key);
+		}
+		return key;
+	};
 	for (const detail of fileDetails) {
-		const key = normalizeMapKey(path.resolve(detail.filePath));
+		const key = keyFor(detail.filePath);
 		const previous = byPath.get(key);
 		if (!previous) {
 			byPath.set(key, detail);
@@ -180,7 +194,7 @@ function uniqueDetails(
 	}
 	return files.map(
 		(filePath) =>
-			byPath.get(normalizeMapKey(path.resolve(filePath))) ?? {
+			byPath.get(keyFor(filePath)) ?? {
 				filePath,
 				// Resource operations have no already-computed text range. A small
 				// range is still enough to invalidate the touched-file turn state;

--- a/tests/clients/dispatch-context-normalized.test.ts
+++ b/tests/clients/dispatch-context-normalized.test.ts
@@ -47,7 +47,10 @@ describe("dispatch context normalization invariant (#2016)", () => {
 		} finally {
 			env.cleanup();
 		}
-	});
+		// Generous budget: this drives the real constructor, which loads project
+		// config and reads a file prefix. Under a loaded parallel run the default
+		// 5s budget is a flake, not a signal.
+	}, 30_000);
 
 	it("has no call site that re-normalizes an already-normalized context field", () => {
 		const repoRoot = path.resolve(import.meta.dirname, "..", "..");
@@ -67,7 +70,8 @@ describe("dispatch context normalization invariant (#2016)", () => {
 					walk(full);
 					continue;
 				}
-				if (!entry.name.endsWith(".ts") || entry.name.endsWith(".d.ts")) continue;
+				if (!entry.name.endsWith(".ts") || entry.name.endsWith(".d.ts"))
+					continue;
 				const lines = fs.readFileSync(full, "utf-8").split(/\r?\n/);
 				lines.forEach((line, index) => {
 					// Comments name the forbidden form in order to forbid it.
@@ -93,7 +97,8 @@ describe("dispatch context normalization invariant (#2016)", () => {
 			const full = path.join(repoRoot, root);
 			if (!fs.existsSync(full)) continue;
 			if (fs.statSync(full).isDirectory()) walk(full);
-			else if (pattern.test(fs.readFileSync(full, "utf-8"))) offenders.push(root);
+			else if (pattern.test(fs.readFileSync(full, "utf-8")))
+				offenders.push(root);
 		}
 
 		expect(offenders).toEqual([]);

--- a/tests/clients/dispatch-context-normalized.test.ts
+++ b/tests/clients/dispatch-context-normalized.test.ts
@@ -1,0 +1,101 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createDispatchContext } from "../../clients/dispatch/dispatcher.js";
+import { FactStore } from "../../clients/dispatch/fact-store.js";
+import { normalizeMapKey } from "../../clients/path-utils.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+/**
+ * #2016. Two halves of one invariant.
+ *
+ * Half one: `createDispatchContext` normalizes `filePath`, `cwd`, and
+ * `projectRoot`, so re-normalizing them downstream is a pure syscall.
+ *
+ * Half two: no call site re-normalizes them. That half is a source scan,
+ * because the waste is invisible to a behavioral assertion: on POSIX the
+ * redundant call short-circuits and returns the same string, so a value test
+ * passes either way. Only the source can tell the difference on CI.
+ */
+describe("dispatch context normalization invariant (#2016)", () => {
+	it("normalizes filePath, cwd, and projectRoot at construction", () => {
+		const env = setupTestEnvironment("pi-lens-2016-ctx-");
+		try {
+			const target = path.join(env.tmpDir, "sample.ts");
+			fs.writeFileSync(target, "export const a = 1;\n");
+			const pi = {
+				getFlag: () => undefined,
+			} as unknown as Parameters<typeof createDispatchContext>[2];
+
+			const ctx = createDispatchContext(
+				target,
+				env.tmpDir,
+				pi,
+				new FactStore(),
+				false,
+				undefined,
+				env.tmpDir,
+			);
+
+			// Idempotence is the property the call sites rely on: normalizing an
+			// already-normalized value must be a no-op, or dropping the redundant
+			// call would change a key.
+			expect(normalizeMapKey(ctx.filePath)).toBe(ctx.filePath);
+			expect(normalizeMapKey(ctx.cwd)).toBe(ctx.cwd);
+			expect(ctx.projectRoot).toBeDefined();
+			expect(normalizeMapKey(ctx.projectRoot as string)).toBe(ctx.projectRoot);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("has no call site that re-normalizes an already-normalized context field", () => {
+		const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+		const roots = ["clients", "tools", "mcp", "index.ts"];
+		const offenders: string[] = [];
+		// `ctx`, `context`, and `dispatchContext` are the spellings the dispatch
+		// seam uses for a DispatchContext. Matching the receiver rather than a
+		// bare field name keeps this from firing on unrelated `filePath` locals.
+		const pattern =
+			/normalizeMapKey\(\s*(?:ctx|context|dispatchContext)\.(?:filePath|cwd|projectRoot)\b/;
+
+		const walk = (dir: string): void => {
+			for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+				const full = path.join(dir, entry.name);
+				if (entry.isDirectory()) {
+					if (entry.name === "node_modules" || entry.name === "deps") continue;
+					walk(full);
+					continue;
+				}
+				if (!entry.name.endsWith(".ts") || entry.name.endsWith(".d.ts")) continue;
+				const lines = fs.readFileSync(full, "utf-8").split(/\r?\n/);
+				lines.forEach((line, index) => {
+					// Comments name the forbidden form in order to forbid it.
+					const trimmed = line.trim();
+					if (
+						trimmed.startsWith("*") ||
+						trimmed.startsWith("//") ||
+						trimmed.startsWith("/*")
+					)
+						return;
+					if (pattern.test(line)) {
+						const relative = path
+							.relative(repoRoot, full)
+							.split(path.sep)
+							.join("/");
+						offenders.push(`${relative}:${index + 1}`);
+					}
+				});
+			}
+		};
+
+		for (const root of roots) {
+			const full = path.join(repoRoot, root);
+			if (!fs.existsSync(full)) continue;
+			if (fs.statSync(full).isDirectory()) walk(full);
+			else if (pattern.test(fs.readFileSync(full, "utf-8"))) offenders.push(root);
+		}
+
+		expect(offenders).toEqual([]);
+	});
+});

--- a/tests/clients/dispatch-context-normalized.test.ts
+++ b/tests/clients/dispatch-context-normalized.test.ts
@@ -4,6 +4,11 @@ import { describe, expect, it } from "vitest";
 import { createDispatchContext } from "../../clients/dispatch/dispatcher.js";
 import { FactStore } from "../../clients/dispatch/fact-store.js";
 import { normalizeMapKey } from "../../clients/path-utils.js";
+import {
+	assertNonEmptyScan,
+	listSourceFiles,
+	stripSource,
+} from "../support/sweep-kit.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
 /**
@@ -55,52 +60,89 @@ describe("dispatch context normalization invariant (#2016)", () => {
 	it("has no call site that re-normalizes an already-normalized context field", () => {
 		const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 		const roots = ["clients", "tools", "mcp", "index.ts"];
-		const offenders: string[] = [];
-		// `ctx`, `context`, and `dispatchContext` are the spellings the dispatch
-		// seam uses for a DispatchContext. Matching the receiver rather than a
-		// bare field name keeps this from firing on unrelated `filePath` locals.
-		const pattern =
-			/normalizeMapKey\(\s*(?:ctx|context|dispatchContext)\.(?:filePath|cwd|projectRoot)\b/;
 
-		const walk = (dir: string): void => {
-			for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-				const full = path.join(dir, entry.name);
-				if (entry.isDirectory()) {
-					if (entry.name === "node_modules" || entry.name === "deps") continue;
-					walk(full);
-					continue;
-				}
-				if (!entry.name.endsWith(".ts") || entry.name.endsWith(".d.ts"))
-					continue;
-				const lines = fs.readFileSync(full, "utf-8").split(/\r?\n/);
-				lines.forEach((line, index) => {
-					// Comments name the forbidden form in order to forbid it.
-					const trimmed = line.trim();
-					if (
-						trimmed.startsWith("*") ||
-						trimmed.startsWith("//") ||
-						trimmed.startsWith("/*")
-					)
-						return;
-					if (pattern.test(line)) {
-						const relative = path
-							.relative(repoRoot, full)
-							.split(path.sep)
-							.join("/");
-						offenders.push(`${relative}:${index + 1}`);
-					}
-				});
-			}
-		};
+		// A DispatchContext arrives under one of these receiver names.
+		const RECEIVERS = "ctx|context|dispatchContext";
+		const FIELDS = "filePath|cwd|projectRoot";
+		const receiverCall = new RegExp(
+			`normalizeMapKey\\(\\s*(?:${RECEIVERS})\\.(?:${FIELDS})\\b`,
+		);
+		// A local bound to a context field INHERITS the invariant, and the four
+		// `projectRoot` sites this PR fixed read exactly such a local
+		// (`const projectRoot = ctx.projectRoot ?? ctx.cwd`, dispatcher.ts:815).
+		// A receiver-only pattern cannot see them: the fix-round reviewer restored
+		// the call on that local and all 61 tests stayed green. Resolve the
+		// aliases per file and forbid the call on them too.
+		const aliasDeclaration = new RegExp(
+			`\\b(?:const|let)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*[^;]*?` +
+				`\\b(?:${RECEIVERS})\\.(?:${FIELDS})\\b`,
+			"g",
+		);
 
-		for (const root of roots) {
+		const sourceFiles = roots.flatMap((root) => {
 			const full = path.join(repoRoot, root);
-			if (!fs.existsSync(full)) continue;
-			if (fs.statSync(full).isDirectory()) walk(full);
-			else if (pattern.test(fs.readFileSync(full, "utf-8")))
-				offenders.push(root);
+			if (!fs.existsSync(full)) return [];
+			return fs.statSync(full).isDirectory()
+				? listSourceFiles(full, { extensions: [".ts"] })
+				: [full];
+		});
+
+		const offenders: string[] = [];
+		let aliasesResolved = 0;
+		for (const file of sourceFiles) {
+			// Strip first. This test names the forbidden form in its own comments
+			// and so does the DispatchContext doc block, which is the kit's
+			// comment-laundering attack in miniature. `stripSource` replaces the
+			// hand-rolled comment skip this test used to carry.
+			//
+			// `strings: "keep"` is REQUIRED here, not a default worth inheriting.
+			// Five of the seven sites this PR fixed are interpolations inside
+			// template literals (`` `${ctx.kind}:${ctx.filePath}` ``), and the
+			// kit's default `"blank"` policy blanks template CONTENTS — the known
+			// limit documented at the top of sweep-kit.ts. Under the default this
+			// scan went silently blind: the reviewer's own F2 probe, plus a
+			// restored `normalizeMapKey(ctx.filePath)`, both stayed green. Keeping
+			// strings means a call named inside a plain string would read as code;
+			// that is the safe direction for a guard, and the empty offender list
+			// below shows no such string exists in this tree.
+			const stripped = stripSource(fs.readFileSync(file, "utf-8"), {
+				strings: "keep",
+			});
+			const aliases = new Set<string>();
+			for (const match of stripped.matchAll(aliasDeclaration)) {
+				if (match[1]) aliases.add(match[1]);
+			}
+			aliasesResolved += aliases.size;
+			const aliasCall =
+				aliases.size > 0
+					? new RegExp(
+							`normalizeMapKey\\(\\s*(?:${[...aliases].join("|")})\\s*[),]`,
+						)
+					: undefined;
+			const relative = path.relative(repoRoot, file).split(path.sep).join("/");
+			const lines = stripped.split("\n");
+			lines.forEach((line, index) => {
+				if (receiverCall.test(line) || aliasCall?.test(line)) {
+					offenders.push(`${relative}:${index + 1}`);
+				}
+			});
 		}
 
-		expect(offenders).toEqual([]);
+		// Floors, per AGENTS.md defect shape 10. A scan that walked nothing, or
+		// that resolved no aliases, reports clean while seeing nothing. The alias
+		// half is the half the reviewer proved was missing, so it carries its own
+		// floor rather than sharing the file floor.
+		assertNonEmptyScan(
+			"dispatch-context normalization scan (files walked)",
+			sourceFiles.length,
+			200,
+		);
+		assertNonEmptyScan(
+			"dispatch-context normalization scan (context aliases resolved)",
+			aliasesResolved,
+			5,
+		);
+
+		expect(offenders, offenders.join("\n")).toEqual([]);
 	});
 });

--- a/tests/clients/lsp-mutation-normalize-once.test.ts
+++ b/tests/clients/lsp-mutation-normalize-once.test.ts
@@ -1,0 +1,87 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const normalizeCalls: string[] = [];
+
+vi.mock("../../clients/path-utils.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../clients/path-utils.js")>();
+	return {
+		...actual,
+		normalizeMapKey: (filePath: string) => {
+			normalizeCalls.push(filePath);
+			return actual.normalizeMapKey(filePath);
+		},
+	};
+});
+
+import {
+	type LspMutationContext,
+	recordLspMutation,
+} from "../../clients/lsp-mutation.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+/**
+ * #2016. `uniqueDetails` normalized every path twice: once building the dedupe
+ * map, once looking the result back up. Both loops walk the same paths, so the
+ * second pass was a pure `realpathSync.native` per file, measured at ~200
+ * microseconds each on Windows and short-circuited on POSIX.
+ *
+ * Driven through the public `recordLspMutation` seam rather than the private
+ * helper, so the test cannot pass by way of a shape the production callers do
+ * not use.
+ */
+describe("lsp-mutation normalizes each path once (#2016)", () => {
+	it("does not re-canonicalize a path it already resolved", () => {
+		const env = setupTestEnvironment("pi-lens-2016-lsp-mutation-");
+		try {
+			const files = ["a.ts", "b.ts", "c.ts"].map((name) => {
+				const full = path.join(env.tmpDir, name);
+				fs.writeFileSync(full, "export const x = 1;\n");
+				return full;
+			});
+			const context: LspMutationContext = {
+				cwd: env.tmpDir,
+				correlationId: "normalize-once-1",
+				tool: "workspace/applyEdit",
+				source: "lsp-edit",
+				emitSummary: false,
+			};
+
+			normalizeCalls.length = 0;
+			recordLspMutation(context, {
+				results: [
+					{
+						descriptions: [],
+						files,
+						operationTotal: files.length,
+						appliedOperationTotal: files.length,
+						appliedOperationIndexes: files.map((_, index) => index),
+						operationCounts: {
+							textEdits: files.length,
+							create: 0,
+							rename: 0,
+							delete: 0,
+						},
+						fileDetails: files.map((filePath) => ({
+							filePath,
+							range: { start: 1, end: 2 },
+							importsChanged: false,
+						})),
+					},
+				],
+			});
+
+			const perFile = files.map(
+				(filePath) =>
+					normalizeCalls.filter(
+						(seen) => path.resolve(seen) === path.resolve(filePath),
+					).length,
+			);
+			expect(perFile).toEqual([1, 1, 1]);
+		} finally {
+			env.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

`createDispatchContext` normalizes `filePath`, `cwd`, and `projectRoot` before
it builds the context (`clients/dispatch/dispatcher.ts:307-316`). It is the only
constructor. So `normalizeMapKey(ctx.filePath)` downstream is a
`realpathSync.native` syscall that returns its own input. Seven sites paid it on
every dispatch.

The invariant is now stated on the type
(`clients/dispatch/types.ts`, above `DispatchContext`) and the seven sites use
the fields directly:

| Site | Was |
|---|---|
| `dispatcher.ts:575` coverage-notice once-key | `normalizeMapKey(ctx.filePath)` |
| `dispatcher.ts:632` coverage-unavailable once-key | `normalizeMapKey(ctx.filePath)` |
| `dispatcher.ts:1058` absolute baseline fact key | `normalizeMapKey(ctx.filePath)` |
| `dispatcher.ts:836`, `:918` tier-flip latency metadata | `normalizeMapKey(projectRoot)` |
| `dispatcher.ts:843`, `:925` collect-later degradation subject | `normalizeMapKey(projectRoot)` |

`projectRoot` at those four sites is `ctx.projectRoot ?? ctx.cwd`
(`dispatcher.ts:809`), so both branches were already normalized.

### Two values that are not filesystem paths

Two more sites fed the realpath-backed normalizer something that is not a path.
`normalizeFilePath` resolves a relative-looking string against the **current
process working directory** on Windows and returns it untouched on POSIX
(`clients/path-utils.ts:95-119`), which is the non-path-sentinel class
`path-utils.ts` already warns about for #2219.

- `dispatcher.ts:570` folded **scanner ids** through it to build the
  coverage-notice dedupe key. On Windows `realpathSync.native("biome")` throws,
  falls through to `resolveNonExisting`, and produces an absolute lowercased
  path anchored on the process cwd. On Linux it stays `biome`. The dedupe key
  therefore differed by platform and by cwd.
- `dispatcher.ts:1059` folded `relativeKey`, which is
  `path.relative(ctx.cwd, ctx.filePath)`, through it. On Windows the "relative"
  key became an absolute path anchored on the wrong root.

Both move to `normalizeEphemeralMapKey`, the cheap syntactic fold documented for
exactly this case at `clients/path-utils.ts:284-304`. This is remediation
direction 3 in the issue. The baseline key is read at `:1058-1059` and written at
`:1151-1152` from the same two consts, so it stays self-consistent within a
session.

### One duplicate per call

`uniqueDetails` in `clients/lsp-mutation.ts:157` normalized every path twice:
once building the dedupe map at `:163`, once looking the result back up at
`:183`. `files` and `fileDetails` name the same paths. A per-call memo makes it
once. The memo lives for one call, so it has no staleness window and needs no
freshness design, which is what separates it from the memo #2193 rejected.

Refs #2016. Not `closes`: two acceptance criteria remain, named in the Remainder
section.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [x] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [x] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (no dependency change)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there (the new invariant is stated on `DispatchContext` itself and pinned by a test, which is where a per-type contract belongs; #2016's third criterion asks for the AGENTS.md catalog entry and is deferred, see Remainder)
- [x] `.changelog/fix-2016-normalize-once.md` has one valid entry in this PR
- [x] Commit subject includes the issue number

## Tests

New file `tests/clients/dispatch-context-normalized.test.ts`, two cases for the
two halves of one invariant:

- *normalizes filePath, cwd, and projectRoot at construction* — pins the
  property the removals rely on. It asserts idempotence, not equality to a
  literal, so it fails if the constructor ever stops normalizing. This case
  passes on pre-fix code by design: it pins existing behavior that the change
  depends on, and it exists so a future edit to the constructor reds here rather
  than silently corrupting seven keys.
- *has no call site that re-normalizes an already-normalized context field* —
  a source scan over `clients/`, `tools/`, `mcp/`, and `index.ts`, built on
  `tests/support/sweep-kit.ts` and declaring two floors. It forbids two
  spellings: the receiver form
  `normalizeMapKey(ctx|context|dispatchContext).(filePath|cwd|projectRoot)`,
  and the **local-alias** form, where a `const`/`let` is bound to a context
  field and inherits the invariant. Four of the seven sites fixed here read
  exactly such a local (`const projectRoot = ctx.projectRoot ?? ctx.cwd`,
  `dispatcher.ts:815`). This half cannot be pinned behaviorally: on POSIX the
  redundant call short-circuits and returns the same string, so a value
  assertion passes either way and CI would never see a regression. The scan is
  what closes the class.

New file `tests/clients/lsp-mutation-normalize-once.test.ts`, one case. It
counts `normalizeMapKey` calls per path through a module mock and drives the
public `recordLspMutation` seam rather than the private `uniqueDetails`, so it
cannot pass through a shape production callers do not use.

AGENTS.md test-authoring screens: the source scan is a deliberate
*implementation mirror*, and it is the right form here because the defect is
invisible at runtime on the CI platform. It is scoped to the `ctx.` receiver so
it does not fire on the many legitimate `normalizeMapKey(filePath)` call sites
elsewhere (23 of them across `clients/`, all outside the dispatch context). The
lsp-mutation case avoids *wrong-layer pin* by driving the exported seam.

Red-first, against `clients/dispatch/dispatcher.ts`,
`clients/dispatch/types.ts`, and `clients/lsp-mutation.ts` restored to 9640ac05
with the tests in place, rebuilt in between:

```
FAIL > has no call site that re-normalizes an already-normalized context field
AssertionError: expected [ …(3) ] to deeply equal []
FAIL > does not re-canonicalize a path it already resolved
AssertionError: expected [ 2, 2, 2 ] to deeply equal [ 1, 1, 1 ]
```

Mutation proof:

| Mutation | Result |
|---|---|
| F2 restore `normalizeMapKey(projectRoot)` at the degradation subject (the reviewer's own probe, 2 sites) | RED: has no call site that re-normalizes an already-normalized context field |
| F2b restore `normalizeMapKey(projectRoot)` in the tier-flip metadata (4 sites) | RED: same case |
| P1 restore `normalizeMapKey(ctx.filePath)` at the once-key | RED: same case |
| P1b restore `normalizeMapKey(ctx.filePath)` at the baseline key | RED: same case |
| P2 revert the lsp-mutation per-call key memo | RED: does not re-canonicalize a path it already resolved |
| F1a empty the scan roots | RED: `scan (files walked): scanned/matched 0, below the declared floor of 200` |
| F1b break alias resolution | RED: `scan (context aliases resolved): scanned/matched 0, below the declared floor of 5` |

Two further mutations neuter the guard itself rather than the source, so the
proof runs the other way: with the reviewer's probe restored so a real offender
exists, the intact guard reds, and each of these makes that same offender
invisible. Dropping the alias half goes green, and reverting to sweep-kit's
default string policy goes green.

**Honest gap.** The two non-path changes, scanner ids at `:570` and
`relativeKey` at `:1059`, are **not** guarded by a behavioral test. The
divergence they fix is Windows-only: on Linux both normalizers return the input
unchanged, so any assertion I could write would pass on CI whether or not the
fix is present. Writing a green-on-CI test for it would be a vacuous guard, and
a `runIf(win32)` test would be an invisible skip on every CI run. I am naming the
gap rather than papering it. Both changes are argued from
`clients/path-utils.ts:95-119` and `:284-304`, and both are visible in the diff.
A reviewer who wants them guarded should say so and I will add a
Windows-gated case with the skip declared.

Ran locally after `npm run build`: 12 files, 214 tests passing (the two new
files, `lsp/edits`, and the nine directory-scanning governance suites). Sibling
files for the changed symbols, 7 files, 196 tests passing: `cascade-compute`,
`dispatch/dispatcher-flow`, `dispatch/rule-policy-dispatcher`,
`dispatch/runners/runner-status-semantics`, `lsp/service-scanner-coverage-gap`,
`lsp/service-aux-grace`, `lsp/service-touch-collect`. `npm run lint` and
`npm run fmt:check` clean. Full suite deferred to CI.

### Test assessment

- `tests/clients/dispatch-context-normalized.test.ts` (new) — uniquely pins the
  normalization invariant on `DispatchContext` and its absence of violators. No
  existing file asserts either half. Makes nothing redundant.
- `tests/clients/lsp-mutation-normalize-once.test.ts` (new) — uniquely pins the
  per-path call count through `recordLspMutation`.
  `tests/clients/lsp/edits.test.ts` drives the same seam but asserts telemetry
  shape, not normalization cost, so neither subsumes the other: P2 reds mine and
  leaves `edits.test.ts` green.
- No test files edited. No removal candidates.

## Blast radius

Every changed expression is a key derivation, so the question for each is
whether the key changes.

- The five `ctx.filePath` and `projectRoot` sites: keys are byte-identical,
  because the removed call is idempotent on its own output and the construction
  test pins that. Callers affected: the coverage-notice and coverage-unavailable
  session dedupe sets, the `runner_collect_later_tier_flip` latency metadata,
  the `runner-collect-later` degradation subject, and the absolute baseline
  session fact. All read and write through the same expressions.
- The scanner-id key at `:570` and the relative baseline key at `:1059`: keys
  **do** change on Windows, deliberately. Both are session-scoped and
  in-memory. The dedupe set starts empty each session, and the baseline key is
  written and read from the same const in the same function, so nothing
  persisted survives across the change.
- `uniqueDetails`: same keys, computed once instead of twice.

Hot path. Per-call cost, two independent Windows runs reported separately
rather than averaged:

| Call | Fix-round reviewer | My run |
|---|---|---|
| `normalizeMapKey`, existing path | 88.5 µs | 71.7 µs |
| `normalizeMapKey`, non-existing path | 132.5 µs | 160.9 µs |
| `normalizeEphemeralMapKey` | 0.16 µs | 0.54 µs |

The absolute figures differ by run; the ratio is the load-bearing part, roughly
130x to 300x.

Whole-dispatch count, from the reviewer's count-probe: **8 realpath calls remain
per dispatch on this branch, of which 3 are the accepted one-per-session-stable-
value normalization** in `createDispatchContext`. So the issue's criterion of 2
or fewer is **not** met, which is why this PR says `refs`. The largest single
remaining source is not in this diff at all — see the Remainder section.

No behavior widening. No new process spawn. No new failure path.

## Observability

`~/.pi-lens/latency.log` carries the effect: the `runner` and `phase` records
for a dispatch include `durationMs`, and the redundant syscalls sat inside those
spans. The `runner_collect_later_tier_flip` phase record is the one whose
`projectRoot` metadata field this PR changed, so it also proves the key is still
the canonical root.

Named gap: nothing counts `realpathSync` calls in production, so the reduction
itself is not directly observable. That is the whole shape of #2016, a tax with
no record. Measuring it needs the instrumented count the issue describes, run
Windows-locally. I did not run it here.

## Class sweep

**Shape.** #2016's own class: repeated realpath-canonicalizing normalization of
a stable value on the per-edit pipeline, invisible on Linux CI because
`normalizeFilePath` short-circuits for clean POSIX paths. Two sub-shapes appear
here: re-normalizing a value already normalized by its constructor, and
normalizing a value that is not a filesystem path at all.

**Pattern sweep.** Grepped `index.ts`, `clients/`, `tools/`, and `mcp/` for
`normalizeMapKey` applied to a dispatch-context field and to bare
`filePath`/`cwd`/`projectRoot` aliases. The `ctx.` receiver form is now zero and
a test keeps it there. The bare-alias form has 23 hits and most are legitimate:
they normalize a value arriving from outside, which is the function's purpose.

**Population sweep.** The family is #2016's own member list.

| Member | Verdict |
|---|---|
| `clients/dispatch/dispatcher.ts:307-316` `createDispatchContext` | **Left deliberately.** These are the one normalization per session-stable value. Removing them needs a cross-dispatch memo of realpath results, which is exactly what the #2193 review rejected for the LSP path: a stale canonical key after a case rename, silent and lifetime-long. Recorded, not fixed. |
| `clients/dispatch/dispatcher.ts:575`, `:632`, `:1058` | **Fixed here.** |
| `clients/dispatch/dispatcher.ts:836`, `:843`, `:918`, `:925` | **Fixed here.** |
| `clients/dispatch/dispatcher.ts:570` scanner ids | **Fixed here**, and it was a correctness defect, not only a tax. |
| `clients/dispatch/dispatcher.ts:1059` relative baseline key | **Fixed here**, same reason. |
| `clients/lsp-mutation.ts:163`, `:183` | **Fixed here.** |
| `clients/lsp/client.ts:3629` `handleNotifyChange` | **Already decided.** PR #2193 was closed without merging; the memo is rejected and the reasoning is recorded on #2016. Out of scope here. |
| `clients/cache-manager.ts:114-115` `addModifiedRange` | **Not fixed, recorded.** `cwdNorm` is session-stable and re-derived per call, but the fix needs the same cross-call memo #2193 rejected. `fileNorm` on the next line is a genuinely different path each call and is correct as written. Named in the Remainder so it is not lost. |
| `clients/dispatch/collect-later-tier.ts:18` | **Already correct at file:line.** It normalizes at a shared seam with a second caller, `clients/lsp/cascade-tier.ts:85`, whose `projectRoot` is not known to be normalized. The defensive normalization is load-bearing there. Changing a shared seam on the strength of one caller is the shape this sweep is supposed to prevent. |

**Consolidation verdict.** The family folds onto one seam already: the
`DispatchContext` invariant plus the source scan means a new dispatch call site
cannot reintroduce the sub-shape without reddening a test. The remaining members
are not the same defect, they are the accepted single normalization and one
shared-seam defensive call, so there is nothing further to consolidate.

## Merge order

Independent of PR #2260 (#2071 and #1976, `clients/file-utils.ts` only) and of
PR #2243 (FactStore bounds). No shared file with either. No merge-order
constraint.

## Remainder

Two of #2016's acceptance criteria are not met, so this is `refs`:

- The Windows-local measurement of one full edit's dispatch showing the
  redundant-realpath count at 2 or fewer. I removed the redundancies but did not
  run the instrumented count.
- The AGENTS.md catalog entry for the Windows-only invisible-tax variant.

`clients/cache-manager.ts:114-115` also remains, for the reason in the sweep
table.

The fix round added a fourth, and it is the **largest remaining member**:
`clients/latency-logger.ts:651` runs `normalizeLoggedPath` on every latency
record, and `dispatcher.ts` feeds it `ctx.filePath` from nine call sites. The
reviewer counted 3 realpath calls per single-runner dispatch and 7 per
five-runner dispatch, scaling with record count. My call-site grep could not see
it: the cost lives inside the logger, not at the call site.

It needs its own PR. Deleting the normalization is wrong, because
`clients/latency-logger.ts:640-646` documents that this field deliberately mixes
normalized dispatch values, raw `path.resolve`/`cwd` values, and non-path labels,
and `normalizeLoggedPath` is what gives that mixed field one spelling under
#2229. The real fix is normalize-once at the producer plus a logger that trusts
a pre-normalized value, which means auditing every `logLatency` producer.

All four remainders are recorded on the issue:
[first comment](https://github.com/apmantza/pi-lens/issues/2016#issuecomment-5439191680),
[fix-round comment](https://github.com/apmantza/pi-lens/issues/2016#issuecomment-5440248193).

## Review round 1

| Finding | Disposition |
|---|---|
| F1 BLOCKING, CI red: the scan was an unregistered sweep | Fixed. Rebuilt on `tests/support/sweep-kit.ts` with two declared floors. Reproduced first: `sweep-floor meta-sweep: 1 flagged item(s) are neither registered nor exempted`. |
| F2 MED: the guard missed the local-alias spelling | Fixed. Reproduced the reviewer's exact probe (restoring `normalizeMapKey(projectRoot)` left every test green), added alias resolution, and that same probe now reds. |
| F3 MED: `latency-logger.ts:651` is a bigger class member, re-home | Re-homed, not fixed here. Verified in source, measured the per-call costs myself, and commented on #2016 with both runs and the seam tension against #2229. |
| F4 waived: no test for the two Windows-only divergences | No change. The disclosure in the Tests section stands. |

Adopting sweep-kit introduced a defect of its own, which the mutation battery
caught before the push. The kit's default string policy blanks template
**contents**, and five of the seven fixed sites are interpolations inside
template literals, so the scan went silently blind under the default: the
reviewer's F2 probe AND a restored `normalizeMapKey(ctx.filePath)` both stayed
green. `strings: "keep"` is required here, the reason is written at the call
site, and reverting to the default is one of the mutations recorded above.

*This pull request is AI-generated, with the maintainer supervising the process.*
