### PR TITLE
fix(warden): classify a paging duplicate by cursor, not fatally (closes #2192)

### DIFF
--- a/.changelog/2192-warden-duplicate-page.md
+++ b/.changelog/2192-warden-duplicate-page.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Stop a routine paging repeat from reddening the merge-train warden (refs #2192)** — the warden's PR reader orders by `UPDATED_AT`, so a PR updated mid-pagination lands on the next page too. That boundary repeat was recorded as a fatal error, once per repeated node, so a fully shifted window could emit up to 200 identical red lines in one 10-minute run. It is now one record per page naming the count, classified by cursor: a repeat with an advancing cursor is benign, a repeat with a stalled cursor stays fatal because it is real truncation. `fetchOpenPullRequests` returns `{ message, benign }` records, so the warden and the merge lane read one classification instead of each deciding for itself.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1206,6 +1206,18 @@ It deduplicates PR numbers before `runWarden` decides or applies actions. Its
 consumer prints that error and sets a nonzero exit code, while deliberately
 bounded sibling reads remain scoped.
 
+A repeated PR number is recorded, but it is NOT automatically fatal (#2192).
+The query orders by `UPDATED_AT` descending, so a PR updated mid-pagination
+shifts the window and lands on the next page too. That is a routine boundary
+repeat, and the same rule that keeps benign HTTP races out of the fatal channel
+applies to it. The reader classifies by CURSOR: a duplicate on a page whose
+cursor advanced (or on the last page) is `benign: true`; a duplicate on a page
+whose cursor did not advance is real truncation and stays fatal. The record is
+one per page, naming the count and the first `DUPLICATE_REPORT_CAP` numbers,
+not one per repeated node. `fetchOpenPullRequests` returns
+`{ message, benign }` records, so both consumers read one classification rather
+than each deciding for itself.
+
 The warden also classifies what Actions did with each open PR head
 (`scripts/lib/warden-run-health.mjs`, #2184). A run that concluded
 `failure`/`startup_failure` with ZERO executed steps across every job is

--- a/scripts/lib/merge-train-lane.mjs
+++ b/scripts/lib/merge-train-lane.mjs
@@ -364,7 +364,12 @@ export async function runMergeLane({
 			number: null,
 			reason: "list-error",
 			merged: false,
-			errors: listErrors.map((message) => ({ message, benign: false })),
+			// #2192: `fetchOpenPullRequests` classifies its own errors now, so
+			// this consumer passes them through instead of re-deciding. The two
+			// consumers used to carry the same blanket `benign: false` mapping,
+			// which is the shape that let a routine boundary duplicate read as
+			// fatal in both of them.
+			errors: listErrors,
 		});
 	}
 

--- a/scripts/lib/merge-train-warden.d.mts
+++ b/scripts/lib/merge-train-warden.d.mts
@@ -64,11 +64,22 @@ export interface WardenResult {
 	runHealth: WardenRunHealthSummary | null;
 }
 
+/**
+ * #2192: `errors` are `WardenError` records, not strings. Both consumers used
+ * to map every list error to `benign: false`; classification now happens once,
+ * at the source, so a routine UPDATED_AT window slide cannot redden the run.
+ */
 export function fetchOpenPullRequests(
 	fetcher: FetchFn,
 	owner: string,
 	name: string,
-): Promise<{ prs: WardenPr[]; errors: string[] }>;
+): Promise<{ prs: WardenPr[]; errors: WardenError[] }>;
+
+/**
+ * How many repeated PR numbers one cross-page duplicate record names before it
+ * reports a remainder count instead (#2192).
+ */
+export const DUPLICATE_REPORT_CAP: number;
 export function decideActions(pr: WardenPr): WardenAction[];
 export function classifyActionFailure(
 	action: WardenAction,

--- a/scripts/lib/merge-train-warden.mjs
+++ b/scripts/lib/merge-train-warden.mjs
@@ -213,15 +213,34 @@ function normalizePr(node) {
 }
 
 /**
+ * How many repeated PR numbers one duplicate record names before it stops
+ * listing them and reports a remainder count (#2192). The record has to stay
+ * one line in a workflow summary; the COUNT is the signal, the first few
+ * numbers are the breadcrumb.
+ */
+export const DUPLICATE_REPORT_CAP = 5;
+
+/**
  * Single paginated list call (per PR, bounded by MAX_PAGES): rate-limit
  * conscious by construction. If GitHub returns a non-array/malformed page,
  * a request throws, or a page comes back with partial `errors`, bail
  * gracefully with whatever PRs were already collected plus a recorded error
  * -- never throw out of this function (review round 1, F6).
+ *
+ * Returns `errors` as `{ message, benign }` RECORDS, not strings (#2192).
+ * Both consumers -- `runWarden` below and the merge lane -- used to map every
+ * list error to `benign: false` on the way in, which is exactly the bug: a
+ * cross-page duplicate is routine, not fatal. The query orders by UPDATED_AT
+ * desc, so any open PR touched mid-pagination shifts the window and pushes a
+ * PR from page N onto page N+1. On a 10-minute cadence that is expected noise,
+ * and this file's own design note (BENIGN_HTTP_STATUSES above) says such races
+ * must not mark the scheduled run red. Classifying at the SOURCE also means
+ * the two consumers stop carrying identical mapping code that can drift apart.
  */
 export async function fetchOpenPullRequests(fetcher, owner, name) {
 	const prs = [];
 	const errors = [];
+	const record = (message, benign = false) => errors.push({ message, benign });
 	const seenNumbers = new Set();
 	let after;
 	for (let page = 0; page < MAX_PAGES; page++) {
@@ -229,37 +248,62 @@ export async function fetchOpenPullRequests(fetcher, owner, name) {
 		try {
 			payload = await graphql(fetcher, PR_QUERY, { owner, name, after });
 		} catch (error) {
-			errors.push(
+			record(
 				`GraphQL request failed: ${error instanceof Error ? error.message : String(error)}`,
 			);
 			break;
 		}
 		if (payload?.errors?.length)
-			errors.push(
+			record(
 				`GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`,
 			);
 		const connection = payload?.data?.repository?.pullRequests;
 		if (!connection || !Array.isArray(connection.nodes)) break;
+		// Collected, not recorded per node (#2192): the old code pushed one
+		// FATAL error per repeated node, so a fully shifted window emitted up
+		// to MAX_PAGES x PAGE_SIZE = 200 identical lines into one summary. One
+		// record per page, naming the count, is the same information at 1/50th
+		// the volume.
+		const duplicates = [];
 		for (const node of connection.nodes) {
 			if (seenNumbers.has(node.number)) {
-				errors.push(
-					`GraphQL pagination repeated PR #${node.number} across pages; collection may be incomplete`,
-				);
+				duplicates.push(node.number);
 				continue;
 			}
 			seenNumbers.add(node.number);
 			prs.push(normalizePr(node));
 		}
-		if (!connection.pageInfo?.hasNextPage) break;
-		const nextCursor = connection.pageInfo.endCursor;
-		if (nextCursor == null || nextCursor === after) {
-			errors.push(
-				"GraphQL pagination truncated because cursor did not advance",
+
+		const hasNextPage = Boolean(connection.pageInfo?.hasNextPage);
+		const nextCursor = connection.pageInfo?.endCursor;
+		// Read BEFORE the breaks below, because it decides how the duplicate
+		// record is classified. A duplicate on a page whose cursor advanced (or
+		// on the last page, where there is no next cursor to advance) is the
+		// UPDATED_AT window sliding under us: routine. A duplicate on a page
+		// whose cursor did NOT advance means the collector was about to replay
+		// the same page, i.e. real truncation, and stays fatal.
+		const cursorAdvanced =
+			!hasNextPage || (nextCursor != null && nextCursor !== after);
+		if (duplicates.length > 0) {
+			const shown = duplicates.slice(0, DUPLICATE_REPORT_CAP);
+			const remainder = duplicates.length - shown.length;
+			record(
+				`GraphQL pagination repeated ${duplicates.length} PR number(s) on page ${page + 1} ` +
+					`(${shown.map((n) => `#${n}`).join(", ")}${remainder > 0 ? `, +${remainder} more` : ""}); ` +
+					(cursorAdvanced
+						? "the open-PR window shifted during pagination, so this is a routine boundary repeat"
+						: "the cursor did not advance, so the collection is truncated"),
+				cursorAdvanced,
 			);
+		}
+
+		if (!hasNextPage) break;
+		if (!cursorAdvanced) {
+			record("GraphQL pagination truncated because cursor did not advance");
 			break;
 		}
 		if (page === MAX_PAGES - 1) {
-			errors.push(
+			record(
 				`GraphQL pagination truncated after ${MAX_PAGES} pages while hasNextPage=true`,
 			);
 			break;
@@ -499,7 +543,11 @@ export async function runWarden({ fetcher, owner, repo, now = Date.now() }) {
 			url: null,
 			mergeStateStatus: null,
 			applied: [],
-			errors: listErrors.map((message) => ({ message, benign: false })),
+			// #2192: the classification is the READER's, not this caller's --
+			// `fetchOpenPullRequests` already returns `{ message, benign }`. The
+			// old blanket `benign: false` here is what made a routine
+			// window-slide duplicate mark the 10-minute run red.
+			errors: listErrors,
 			runHealth: null,
 		});
 	}

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -19,6 +19,7 @@ import {
 	CONFLICT_LABEL,
 	classifyActionFailure,
 	decideActions,
+	DUPLICATE_REPORT_CAP,
 	fetchOpenPullRequests,
 	MAX_PAGES,
 	PAGE_SIZE,
@@ -570,7 +571,10 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 			"repo",
 		);
 		expect(prs).toHaveLength(1);
-		expect(errors[0]).toContain("some field errored");
+		// #2192: list errors are { message, benign } records now, so the
+		// classification lives at the source instead of at each consumer.
+		expect(errors[0].message).toContain("some field errored");
+		expect(errors[0].benign).toBe(false);
 	});
 
 	it("records a thrown GraphQL request failure instead of propagating", async () => {
@@ -583,7 +587,8 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 			"repo",
 		);
 		expect(prs).toEqual([]);
-		expect(errors[0]).toContain("network down");
+		expect(errors[0].message).toContain("network down");
+		expect(errors[0].benign).toBe(false);
 	});
 
 	// #2134: a full final page with hasNextPage is not an exhausted result.
@@ -611,7 +616,10 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 		expect(calls).toHaveLength(MAX_PAGES);
 		expect(result.prs).toHaveLength(MAX_PAGES * PAGE_SIZE);
 		expect(result.errors).toEqual([
-			`GraphQL pagination truncated after ${MAX_PAGES} pages while hasNextPage=true`,
+			{
+				message: `GraphQL pagination truncated after ${MAX_PAGES} pages while hasNextPage=true`,
+				benign: false,
+			},
 		]);
 	});
 
@@ -652,7 +660,10 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 		expect(calls).toHaveLength(1);
 		expect(result.prs).toHaveLength(1);
 		expect(result.errors).toEqual([
-			"GraphQL pagination truncated because cursor did not advance",
+			{
+				message: "GraphQL pagination truncated because cursor did not advance",
+				benign: false,
+			},
 		]);
 	});
 
@@ -682,9 +693,135 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 		const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
 		expect(result.prs).toHaveLength(3);
 		expect(result.prs.map(({ number }) => number)).toEqual([7, 8, 9]);
+		// #2192: ONE record for the page, and benign -- the second page
+		// exhausted the connection, so a repeat there is the UPDATED_AT window
+		// sliding, not truncation.
 		expect(result.errors).toEqual([
-			"GraphQL pagination repeated PR #8 across pages; collection may be incomplete",
+			{
+				message: expect.stringContaining(
+					"repeated 1 PR number(s) on page 2 (#8)",
+				),
+				benign: true,
+			},
 		]);
+	});
+
+	/**
+	 * #2192: the duplicate record was FATAL-channel and PER-NODE. Both halves
+	 * are wrong once pagination actually arms (today's 8 open PRs never reach
+	 * page 2 at PAGE_SIZE 50, so this is latent, not live).
+	 *
+	 * The query orders by UPDATED_AT desc. Any open PR updated while the
+	 * warden pages shifts the window and pushes PRs from page N onto page
+	 * N+1 -- routine on a 10-minute cadence, and this file's own design note
+	 * says such races must not mark the run red.
+	 */
+	describe("#2192 cross-page duplicates", () => {
+		/** Serve a fixed list of pages in request order. */
+		function servePages(pages: unknown[]) {
+			const calls: unknown[] = [];
+			const fetcher = async (_url: string, init?: { body?: string }) => {
+				calls.push(JSON.parse(init?.body ?? "{}"));
+				return {
+					ok: true,
+					status: 200,
+					json: async () => pages[calls.length - 1],
+				};
+			};
+			return { fetcher, calls };
+		}
+
+		it("classifies a boundary duplicate as benign when the cursor advanced", async () => {
+			const pages = [
+				graphqlPage([prNode({ number: 7 }), prNode({ number: 8 })], true, "c1"),
+				graphqlPage([prNode({ number: 8 }), prNode({ number: 9 })], true, "c2"),
+				graphqlPage([prNode({ number: 10 })], false, "c3"),
+			];
+			const { fetcher } = servePages(pages);
+			const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
+
+			expect(result.prs.map(({ number }) => number)).toEqual([7, 8, 9, 10]);
+			expect(result.errors).toHaveLength(1);
+			// Pre-fix: benign is false, so a routine window slide reddens the
+			// scheduled run every ten minutes.
+			expect(result.errors[0].benign).toBe(true);
+			expect(result.errors[0].message).toContain("window shifted");
+		});
+
+		it("keeps a duplicate fatal when the cursor did not advance (real truncation)", async () => {
+			// Page 2 repeats page 1 AND hands back the same cursor: the
+			// collector was about to replay, which is genuine truncation.
+			const pages = [
+				graphqlPage([prNode({ number: 7 })], true, "c1"),
+				graphqlPage([prNode({ number: 7 })], true, "c1"),
+			];
+			const { fetcher } = servePages(pages);
+			const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
+
+			const duplicate = result.errors.find((e) =>
+				e.message.includes("repeated"),
+			);
+			expect(duplicate?.benign).toBe(false);
+			expect(duplicate?.message).toContain("cursor did not advance");
+		});
+
+		it("emits ONE record per page naming the count, not one per repeated node", async () => {
+			// A fully shifted window: every node on page 2 was already seen.
+			const first = Array.from({ length: PAGE_SIZE }, (_, i) =>
+				prNode({ number: i + 1 }),
+			);
+			const pages = [
+				graphqlPage(first, true, "c1"),
+				graphqlPage(first, false, "c2"),
+			];
+			const { fetcher } = servePages(pages);
+			const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
+
+			// Pre-fix: PAGE_SIZE (50) identical fatal lines in one summary, and
+			// up to MAX_PAGES x PAGE_SIZE = 200 across a whole run.
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0].message).toContain(
+				`repeated ${PAGE_SIZE} PR number(s) on page 2`,
+			);
+			expect(result.errors[0].benign).toBe(true);
+			// Still one copy of each PR: the dedupe itself is untouched.
+			expect(result.prs).toHaveLength(PAGE_SIZE);
+		});
+
+		it("caps how many numbers the record lists and says how many it dropped", async () => {
+			const first = Array.from({ length: PAGE_SIZE }, (_, i) =>
+				prNode({ number: i + 1 }),
+			);
+			const pages = [
+				graphqlPage(first, true, "c1"),
+				graphqlPage(first, false, "c2"),
+			];
+			const { fetcher } = servePages(pages);
+			const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
+
+			const message = result.errors[0].message;
+			// Mutation guard on the cap itself: remove the slice and every one
+			// of the 50 numbers lands in the line.
+			const listed = message.match(/#\d+/g) ?? [];
+			expect(listed).toHaveLength(DUPLICATE_REPORT_CAP);
+			expect(message).toContain(`+${PAGE_SIZE - DUPLICATE_REPORT_CAP} more`);
+		});
+
+		it("does not redden a warden run over a routine boundary duplicate", async () => {
+			// The end-to-end claim: benign must survive the trip through
+			// runWarden into the summary the workflow reads for its exit code.
+			const pages = [
+				graphqlPage([prNode({ number: 7 })], true, "c1"),
+				graphqlPage([prNode({ number: 7 })], false, "c2"),
+			];
+			const { fetcher } = servePages(pages);
+			const results = await runWarden({ fetcher, owner: "acme", repo: "repo" });
+
+			const listErrors = results.find(({ number }) => number === null)?.errors;
+			expect(listErrors).toHaveLength(1);
+			expect(listErrors?.[0].benign).toBe(true);
+			expect(results.some((r) => r.errors.some((e) => !e.benign))).toBe(false);
+		});
 	});
 
 	it("decides actions once when pagination repeats a PR", async () => {


### PR DESCRIPTION
## What changed

A routine paging repeat no longer reddens the merge-train warden, and it emits
one record instead of up to two hundred.

The warden's PR reader orders by `UPDATED_AT` descending. Any open PR updated
while the warden pages shifts the window, so a PR from page N reappears on page
N+1. `fetchOpenPullRequests` pushed that into the fatal channel, once per
repeated node, and `runWarden` mapped every list error to `benign: false`. A
fully shifted window would therefore emit up to `MAX_PAGES x PAGE_SIZE` = 200
identical red lines in one ten-minute run. This file's own design note, the one
that keeps benign HTTP races out of the fatal channel, says such races must not
mark the run red.

Three changes, one per acceptance criterion:

1. **Classified by cursor.** A duplicate on a page whose cursor advanced, or on
   the last page where there is no next cursor, is the window sliding:
   `benign: true`. A duplicate on a page whose cursor did NOT advance means the
   collector was about to replay the same page, which is real truncation, and
   stays fatal.
2. **Bounded per page.** Duplicates are collected across the page and recorded
   once, naming the count and the first `DUPLICATE_REPORT_CAP` (5) numbers plus
   a remainder count.
3. **AGENTS.md updated** to describe the classification instead of "records a
   fatal list error".

## Reuse, not a parallel channel

`fetchOpenPullRequests` now returns `errors` as `{ message, benign }` records.
That is not extra structure for its own sake: both consumers, `runWarden` and
`scripts/lib/merge-train-lane.mjs`, carried the identical line

```js
errors: listErrors.map((message) => ({ message, benign: false })),
```

which is exactly the shape that made this bug live in two places at once and
free to drift apart. Classification now happens once, at the reader, and both
consumers pass it through. The `{ message, benign }` record is the warden's
existing `WardenError` type, not a new one, and both CLI entry points already
read `e.benign` for their summary line and exit code, so nothing downstream
changed.

## Tests

Red-first. The five new cases on pre-fix `scripts/lib/*.mjs`:

```
 × #2192 cross-page duplicates > classifies a boundary duplicate as benign when the cursor advanced 22ms
   → expected undefined to be true // Object.is equality
 × #2192 cross-page duplicates > keeps a duplicate fatal when the cursor did not advance (real truncation) 3ms
   → Cannot read properties of undefined (reading 'includes')
 × #2192 cross-page duplicates > emits ONE record per page naming the count, not one per repeated node 6ms
   → expected [ …(50) ] to have a length of 1 but got 50
 × #2192 cross-page duplicates > caps how many numbers the record lists and says how many it dropped 1ms
   → Cannot read properties of undefined (reading 'match')
 × #2192 cross-page duplicates > does not redden a warden run over a routine boundary duplicate 5ms
   → expected false to be true // Object.is equality
      Tests  5 failed | 115 skipped (120)
```

The third line is the issue's own probe reproduced: 50 duplicates produced 50
errors.

### Mutation proofs

Each new guard reds a test when removed:

| mutation | result |
| --- | --- |
| drop the `DUPLICATE_REPORT_CAP` slice | 1 failed — `caps how many numbers the record lists` |
| force `cursorAdvanced = true` (always benign) | 2 failed — including the real-truncation case |
| drop the `benign` argument so it defaults to false | 4 failed |

So the classification cannot collapse in either direction: a mutation that
makes everything benign reds the truncation case, and a mutation that makes
everything fatal reds the routine ones.

### Suites

`tests/scripts/merge-train-warden.test.ts` — 120 passed. Five new, five
existing assertions updated for the record shape (`errors[0].message` rather
than `errors[0]`), which is mechanical collateral of the return-type change and
not a weakening: each kept its original claim and gained a `benign` assertion.

15 governance suites green (197 passed, 4 skipped): `bounded-telemetry-sweep`,
`bus-producer-coverage`, `delivery-surface-ratchet`, `deps-centralization`,
`finding-delivery-gate`, `freshness-sweep`, `managed-tool-seam-coverage`,
`profiling-coverage`, `session-state-conformance`, `module-instance-coverage`,
`sweep-floor-coverage`, `timing-sensitive-coverage`, `vacuous-skip-coverage`,
`dependency-boundaries`, `packaging`.

`npm run lint`, `npm run fmt:check`, `npm run changelog:check` clean. Full suite
is CI's job.

## Class sweep

**Pattern sweep.** The shape is "a routine race recorded in the fatal channel,
unbounded per item". Grepped every `errors.push` and `benign` site across
`scripts/`, `clients/`, `tools/`, `mcp/`, and `index.ts`.

| site | verdict |
| --- | --- |
| `fetchOpenPullRequests` cross-page duplicate | **FIXED** — this issue. |
| `runWarden` list-error mapping | **FIXED** — blanket `benign: false` removed. |
| `runMergeLane` list-error mapping | **FIXED** — same line, same defect, second copy. |
| `fetchOpenPullRequests` cursor-did-not-advance | already correct — genuinely fatal, and bounded (it breaks the loop). |
| `fetchOpenPullRequests` MAX_PAGES truncation | already correct — fatal and bounded, one per run. |
| `fetchOpenPullRequests` GraphQL request failure / partial errors | already correct — fatal, bounded, one per page. |
| `runWarden` REST failures via `BENIGN_HTTP_STATUSES` | already correct at `merge-train-warden.mjs:43` — this is the precedent the fix follows. |
| `runWarden` health-read errors | already correct at `merge-train-warden.mjs:570` — recorded `benign: true`. |
| `runWarden` unreadable-comment-list fallback | already correct at `merge-train-warden.mjs:588` and `:608` — recorded `benign: true`, fails closed. |

**Population sweep: every recorded error in the warden and lane.** The family is
the nine sites above. Two were wrong, both fixed. The rest already carry the
right classification and a bound.

## Test assessment

One touched test file, `tests/scripts/merge-train-warden.test.ts`.

| what | pins | redundancy |
| --- | --- | --- |
| 5 new cases in a `#2192 cross-page duplicates` block | the classification in both directions (benign on an advanced cursor, fatal on a stalled one), the per-page bound, the `DUPLICATE_REPORT_CAP` list cap, and that `benign` survives into `runWarden`'s summary. All four guards mutation-proofed above. | none. No existing case asserted anything about a duplicate's classification; the nearest, `does not return or process the same PR twice across distinct pages`, asserted the dedupe and the old message. |
| 5 existing assertions updated | the same claims as before, now against `{ message, benign }` records, each gaining a `benign` assertion it did not have. | none. This is mechanical collateral of the return-type change. |

Nothing deleted, nothing weakened. `does not return or process the same PR
twice across distinct pages` keeps its dedupe assertion and now also pins that
the boundary case is benign, which is strictly more than it checked before.

## Blast radius

- **`fetchOpenPullRequests`'s return type changed** from `errors: string[]` to
  `errors: WardenError[]`. Two callers, both in this PR. `scripts/lib/merge-train-warden.d.mts`
  updated so `npm run lint` (tsc over the test tree) type-checks it.
- **Both CLI entry points already read `{ message, benign }`**
  (`scripts/merge-train-warden.mjs:44,58`, `scripts/merge-train-lane.mjs:54,66`),
  so the summary line and the exit code need no change.
- **The dedupe itself is untouched.** A repeated PR is still collected once and
  still decided on once; the test asserting one label POST per repeat is
  unchanged and green.
- **Behavior widening:** a boundary duplicate stops setting a nonzero exit code.
  That is the fix, and it is narrow: only a duplicate whose cursor advanced.
  Every other list error keeps its exit code.
- **No new network calls, no new spawns, no new state.**

## Observability

The record is the warden workflow summary line, written by
`scripts/merge-train-warden.mjs`, which renders each error as
`note: <message>` when benign and `ERROR: <message>` when not. After this, a
window slide reads as one `note:` line naming the count; real truncation still
reads `ERROR:` and still exits nonzero.

Honest limit: this is latent. At `PAGE_SIZE` 50 with 8 open PRs, page 2 is
never fetched, so no production run can exercise it until open PRs cross 50.
The five tests are the evidence available today, and the issue says the same.

## Merge order

No collision. Disjoint from PR #2272 (this arc's `loop_block` work), #2256
(review-graph builder), and #2243 (FactStore). Independent in either order.

## Review round 1

One finding, accepted and FILED rather than fixed here, as instructed.

**The classifier keys on `cursorAdvanced` alone**
(`scripts/lib/merge-train-warden.mjs:285-286`), and `seenNumbers`
(`:267-273`) accumulates across the whole read. So a duplicate WITHIN one page
— impossible from a window slide, and a genuine server or query fault — is also
labeled benign, with a message asserting a boundary repeat that cannot have
occurred. Reproduced with my own probe against this head:

```
pages served:      1 (hasNextPage=false, so pagination never continued)
prs collected:     7, 8
errors: [
  {
    "message": "GraphQL pagination repeated 1 PR number(s) on page 1 (#7); the open-PR window shifted during pagination, so this is a routine boundary repeat",
    "benign": true
  }
]
run goes red?      false
```

Filed as #2289 (bug / area:observability / priority:p3) rather than folded in,
so this PR stays scoped to #2192's four acceptance criteria. Worth noting the
severity honestly: at `PAGE_SIZE` 50 with ~8 open PRs the warden fetches one
page per run, so a malformed page is the only duplicate shape reachable today.
That makes #2289 the more live half of the two.

Merged `origin/master` in this round to clear BEHIND. Zero file overlap with
master's changes, and the governance suites plus the warden tests were re-run
on the merged tree: 9 files, 258 passed, 4 skipped.

No production code change in this round. The PR body's earlier claim that a duplicate is
classified "by cursor" remains accurate for the cross-page case this PR is
about; #2289 is the intra-page case it does not distinguish.

## Remaining

All four acceptance criteria are met, so this closes the issue:

1. Boundary duplicates classify `benign: true`; a duplicate with a
   non-advancing cursor stays non-benign. Both tested, both mutation-proofed.
2. One record per page naming the count and the numbers, capped at
   `DUPLICATE_REPORT_CAP`.
3. The AGENTS.md paragraph now describes the classification.
4. Red-first for both the classification and the bound, quoted above.



