### PR TITLE
fix(diagnostics): cap dependency-drift blocker re-serves (closes #1950)

### DIFF
--- a/.changelog/fix-1950-dependency-drift-delivery-cap.md
+++ b/.changelog/fix-1950-dependency-drift-delivery-cap.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Cap dependency-drift blocker re-serves (refs #1950)** — A demoted-but-confirmable inline blocker (`clients/blocker-freshness.ts`) now retires after 3 degraded deliveries with no re-run, instead of re-serving indefinitely. The retirement note says the record can still be confirmed by a fresh dispatch, distinct from #1944's past-EOF retirement, which means the finding is provably unconfirmable.

--- a/clients/blocker-freshness.ts
+++ b/clients/blocker-freshness.ts
@@ -62,7 +62,6 @@
  * COULD still resolve a fresh dispatch; it just stopped being handed one for
  * free.
  */
-export const DEPENDENCY_DRIFT_MAX_DELIVERIES = 3;
 import * as fs from "node:fs";
 import { normalizeEphemeralMapKey } from "./path-utils.js";
 import { resolveImportToFiles } from "./review-graph/import-resolvers.js";
@@ -72,6 +71,9 @@ import {
 	resolveTreeSitterLanguage,
 } from "./tree-sitter-shared.js";
 import { TreeSitterSymbolExtractor } from "./tree-sitter-symbol-extractor.js";
+
+/** See the module doc's "Delivery cap (#1950)" section above. */
+export const DEPENDENCY_DRIFT_MAX_DELIVERIES = 3;
 
 /**
  * Per-turn result of the freshness sweep over the cached inline blockers.

--- a/clients/blocker-freshness.ts
+++ b/clients/blocker-freshness.ts
@@ -43,7 +43,26 @@
  * runtime condition — that edge is invisible to this gate, so a blocker whose only
  * stale dependency arrives that way survives a replay. This is an honest boundary,
  * not a silently-closed one.
+ *
+ * Delivery cap (#1950). A demoted-but-confirmable entry (`alreadyStale` above)
+ * is deliberately NOT retired after its past-EOF sibling's one-delivery rule
+ * (#1944, `blocker-past-eof.ts`) — its coordinates are still in bounds, so a
+ * fresh dispatch can genuinely confirm or clear it, and retiring on delivery
+ * one would discard a recoverable finding. But nothing capped how many times
+ * the SAME demoted record re-serves: incident data (#1944's lane sweep) showed
+ * 18 `alreadyStale` re-serves in one window, with repeat deliveries carrying
+ * near-zero information after the first. `runtime-turn.ts` counts each
+ * delivery (`InlineBlockerRecord.staleDeliveryCount`) and retires the record
+ * via `RuntimeCoordinator.retireDemotedDependencyDriftBlocker` once it reaches
+ * `DEPENDENCY_DRIFT_MAX_DELIVERIES` — a count, not a TTL or a session
+ * boundary, because "how many times has the agent already been told" is the
+ * quantity that actually went to zero information, not "how much time has
+ * passed". The ledger reason says "capped, re-run can still confirm" so it
+ * reads distinctly from #1944's "retired, unrecoverable" — a capped record
+ * COULD still resolve a fresh dispatch; it just stopped being handed one for
+ * free.
  */
+export const DEPENDENCY_DRIFT_MAX_DELIVERIES = 3;
 import * as fs from "node:fs";
 import { normalizeEphemeralMapKey } from "./path-utils.js";
 import { resolveImportToFiles } from "./review-graph/import-resolvers.js";

--- a/clients/demoted-finding-render.ts
+++ b/clients/demoted-finding-render.ts
@@ -181,3 +181,20 @@ export function formatRetirementNote(deadLines: readonly number[]): string {
 		"so this finding cannot be re-confirmed and will not be served again."
 	);
 }
+
+/**
+ * The one-line note a surface appends when it RETIRES a dependency-drift
+ * demotion at its delivery cap (#1950). Deliberately worded differently from
+ * {@link formatRetirementNote}: that one means the finding is provably
+ * unrecoverable (the cited lines are gone), while THIS retirement is a
+ * bounded-noise cap on a record that is still recoverable — a fresh dispatch
+ * of the file could still confirm or clear it. Saying "cannot be re-confirmed"
+ * here would be false.
+ */
+export function formatDeliveryCapNote(deliveryCount: number): string {
+	return (
+		`Not shown again after ${deliveryCount} deliveries with no re-run: ` +
+		"this finding may still be accurate, but re-serving it further adds no " +
+		"new information. A fresh dispatch of this file will re-confirm or clear it."
+	);
+}

--- a/clients/runtime-coordinator.ts
+++ b/clients/runtime-coordinator.ts
@@ -190,6 +190,16 @@ export interface InlineBlockerRecord {
 	 * when no blocker in this record cited a line.
 	 */
 	lines?: readonly number[];
+	/**
+	 * #1950: how many turn ends have re-served this record while `stale`.
+	 * Only incremented for the `"dependency-drift"` reason — `"past-eof"`
+	 * retires after its own single delivery (#1944) and never needs a count.
+	 * Caps a recoverable-but-unconfirmed demotion at
+	 * `DEPENDENCY_DRIFT_MAX_DELIVERIES` deliveries
+	 * (`clients/blocker-freshness.ts`) instead of re-serving it for the rest
+	 * of the session.
+	 */
+	staleDeliveryCount?: number;
 }
 
 /**
@@ -1054,6 +1064,53 @@ export class RuntimeCoordinator {
 		// in the store until a fresh verdict clears it.
 		if (!existing.stale) return false;
 		if ((existing.staleReason ?? "past-eof") !== "past-eof") return false;
+		this._pendingInlineBlockers.delete(key);
+		return true;
+	}
+
+	/**
+	 * #1950: count one more turn end that re-served this record while `stale`.
+	 * The caller (`runtime-turn.ts`) only calls this for a `"dependency-drift"`
+	 * demotion — a `"past-eof"` demotion retires after its own single
+	 * delivery (#1944, `retireDemotedPastEofBlocker`) and never accumulates a
+	 * count. Returns the new count, or 0 when there is no entry to count
+	 * against (already retired, or never recorded).
+	 */
+	incrementInlineBlockerStaleDelivery(filePath: string): number {
+		const key = path.resolve(filePath);
+		const existing = this._pendingInlineBlockers.get(key);
+		if (!existing) return 0;
+		const next = (existing.staleDeliveryCount ?? 0) + 1;
+		this._pendingInlineBlockers.set(key, {
+			...existing,
+			staleDeliveryCount: next,
+		});
+		return next;
+	}
+
+	/**
+	 * #1950: retire a dependency-drift demotion once it has been delivered
+	 * `DEPENDENCY_DRIFT_MAX_DELIVERIES` times with no re-run confirming or
+	 * clearing it. Unlike {@link retireDemotedPastEofBlocker}, the record is
+	 * NOT provably unrecoverable — its coordinates are still in bounds, and a
+	 * fresh dispatch of the file could still confirm or clear it. This is a
+	 * bounded-noise cap, not a "this can never resolve" verdict, and the
+	 * caller's ledger reason must say so (`demoted-finding-retired`'s "capped,
+	 * re-run can still confirm" vs. past-EOF's "retired, unrecoverable").
+	 *
+	 * Only ever touches this gate's OWN demotion (`staleReason ===
+	 * "dependency-drift"`) — a past-EOF demotion on the same file is that
+	 * gate's own record to retire, not this one's.
+	 *
+	 * @returns true when an entry was retired — the caller records it, so the
+	 * suppression is never silent (#1432 Gap 1).
+	 */
+	retireDemotedDependencyDriftBlocker(filePath: string): boolean {
+		const key = path.resolve(filePath);
+		const existing = this._pendingInlineBlockers.get(key);
+		if (!existing) return false;
+		if (!existing.stale) return false;
+		if (existing.staleReason !== "dependency-drift") return false;
 		this._pendingInlineBlockers.delete(key);
 		return true;
 	}

--- a/clients/runtime-coordinator.ts
+++ b/clients/runtime-coordinator.ts
@@ -1069,12 +1069,32 @@ export class RuntimeCoordinator {
 	}
 
 	/**
-	 * #1950: count one more turn end that re-served this record while `stale`.
-	 * The caller (`runtime-turn.ts`) only calls this for a `"dependency-drift"`
-	 * demotion — a `"past-eof"` demotion retires after its own single
-	 * delivery (#1944, `retireDemotedPastEofBlocker`) and never accumulates a
-	 * count. Returns the new count, or 0 when there is no entry to count
-	 * against (already retired, or never recorded).
+	 * #1950 fix-round F1: read the current delivery count WITHOUT committing
+	 * an increment. `runtime-turn.ts` needs the count a delivery would reach
+	 * BEFORE it knows whether that delivery will actually reach the agent —
+	 * the turn-end signature dedupe (`turn-end-findings-last`) can suppress a
+	 * turn whose rendered content is identical to the last one, and a
+	 * suppressed turn must not advance the counter (the agent never saw it).
+	 * The caller peeks, renders the tentative body, and only calls
+	 * {@link incrementInlineBlockerStaleDelivery} once it knows the turn's
+	 * content is NOT being suppressed.
+	 */
+	peekInlineBlockerStaleDeliveryCount(filePath: string): number {
+		const key = path.resolve(filePath);
+		return this._pendingInlineBlockers.get(key)?.staleDeliveryCount ?? 0;
+	}
+
+	/**
+	 * #1950: commit one more turn end that re-served this record while
+	 * `stale`. The caller (`runtime-turn.ts`) only calls this for a
+	 * `"dependency-drift"` demotion — a `"past-eof"` demotion retires after
+	 * its own single delivery (#1944, `retireDemotedPastEofBlocker`) and
+	 * never accumulates a count — and only AFTER confirming the turn's
+	 * content will not be suppressed by the signature dedupe (see
+	 * {@link peekInlineBlockerStaleDeliveryCount}), so this counts ACTUAL
+	 * deliveries the agent saw, not turn-end loop iterations. Returns the new
+	 * count, or 0 when there is no entry to count against (already retired,
+	 * or never recorded).
 	 */
 	incrementInlineBlockerStaleDelivery(filePath: string): number {
 		const key = path.resolve(filePath);

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -93,7 +93,10 @@ import {
 	gateFindingsByPathFreshness,
 	snapshotAdvisoryProvenance,
 } from "./advisory-provenance.js";
-import { sweepInlineBlockerFreshness } from "./blocker-freshness.js";
+import {
+	DEPENDENCY_DRIFT_MAX_DELIVERIES,
+	sweepInlineBlockerFreshness,
+} from "./blocker-freshness.js";
 import { sweepInlineBlockerPastEof } from "./blocker-past-eof.js";
 // #2001/#2002: collect-later delivery for slow auxiliary LSP servers.
 import { getLSPService } from "./lsp/index.js";
@@ -118,6 +121,7 @@ import {
 import { incrementDegradationCount } from "./degradation-ledger.js";
 import {
 	degradeDemotedFindingBody,
+	formatDeliveryCapNote,
 	formatRetirementNote,
 } from "./demoted-finding-render.js";
 import { STALE_LINE_MARKER } from "./stale-marker.js";
@@ -614,9 +618,14 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	// Re-surface inline blockers from this turn that the agent didn't fix.
 	// These were shown inline during write/edit but the agent moved on without resolving them.
 	const unresolvedBlockers = runtime.getInlineBlockersSnapshot();
-	/** #1944: past-EOF demotions retired after their single degraded delivery. */
+	/** #1944/#1950: demotions retired after their delivery limit. */
 	let demotedFindingsRetired = 0;
-	for (const { filePath: bPath, summary, stale } of unresolvedBlockers) {
+	for (const {
+		filePath: bPath,
+		summary,
+		stale,
+		staleReason,
+	} of unresolvedBlockers) {
 		const displayPath = toRunnerDisplayPath(cwd, bPath);
 		if (stale) {
 			// #1631: demoted — out of the authoritative blocker channel and into the
@@ -632,7 +641,8 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 			// session.
 			const deadLines = blockerPastEof.deadLinesByPath.get(bPath) ?? [];
 			const degraded = degradeDemotedFindingBody(summary, { deadLines });
-			const retired = runtime.retireDemotedPastEofBlocker(bPath, deadLines);
+			let retired = runtime.retireDemotedPastEofBlocker(bPath, deadLines);
+			let retirementNote: string | undefined;
 			if (retired) {
 				demotedFindingsRetired += 1;
 				// Bounded by the ledger's own per-kind/subject tally, and the subject
@@ -642,11 +652,33 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 					subject: `inline-blocker:${displayPath}`,
 					reason: `file shrank past cited line(s) ${deadLines.join(", ")}; retired after one degraded delivery`,
 				});
+				retirementNote = formatRetirementNote(deadLines);
+			} else if (staleReason === "dependency-drift") {
+				// #1950: a dependency-drift demotion is recoverable (its coordinates
+				// are still in bounds), so it does NOT retire after one delivery like
+				// the past-EOF case above — but nothing capped how many times the
+				// SAME demoted-but-unconfirmed record re-serves, and incident data
+				// showed repeat deliveries carrying near-zero information after the
+				// first. Cap it at DEPENDENCY_DRIFT_MAX_DELIVERIES instead.
+				const deliveryCount =
+					runtime.incrementInlineBlockerStaleDelivery(bPath);
+				if (deliveryCount >= DEPENDENCY_DRIFT_MAX_DELIVERIES) {
+					retired = runtime.retireDemotedDependencyDriftBlocker(bPath);
+					if (retired) {
+						demotedFindingsRetired += 1;
+						incrementDegradationCount({
+							kind: "demoted-finding-retired",
+							subject: `inline-blocker:${displayPath}`,
+							reason: `capped after ${deliveryCount} deliveries with no re-run; re-run can still confirm`,
+						});
+						retirementNote = formatDeliveryCapNote(deliveryCount);
+					}
+				}
 			}
 			// @delivery-surface: runtime-turn:unresolved-inline-blocker
 			advisoryParts.push(
 				`${STALE_LINE_MARKER} ${displayPath}:\n${degraded.body}` +
-					(retired ? `\n${formatRetirementNote(deadLines)}` : ""),
+					(retirementNote ? `\n${retirementNote}` : ""),
 			);
 		} else {
 			// @delivery-surface: runtime-turn:unresolved-inline-blocker

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -620,6 +620,17 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	const unresolvedBlockers = runtime.getInlineBlockersSnapshot();
 	/** #1944/#1950: demotions retired after their delivery limit. */
 	let demotedFindingsRetired = 0;
+	/**
+	 * #1950 fix-round F1: dependency-drift delivery-count commits, deferred
+	 * until this turn's content is confirmed NOT suppressed by the
+	 * `turn-end-findings-last` signature dedupe further down. That dedupe
+	 * silences a turn whose rendered content is byte-identical to the last
+	 * one actually delivered — the agent never sees a suppressed turn, so
+	 * committing the counter for it would count a delivery that didn't
+	 * happen. Each entry here is invoked only from the "not suppressed"
+	 * branch below.
+	 */
+	const pendingDependencyDriftDeliveries: Array<() => void> = [];
 	for (const {
 		filePath: bPath,
 		summary,
@@ -641,7 +652,7 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 			// session.
 			const deadLines = blockerPastEof.deadLinesByPath.get(bPath) ?? [];
 			const degraded = degradeDemotedFindingBody(summary, { deadLines });
-			let retired = runtime.retireDemotedPastEofBlocker(bPath, deadLines);
+			const retired = runtime.retireDemotedPastEofBlocker(bPath, deadLines);
 			let retirementNote: string | undefined;
 			if (retired) {
 				demotedFindingsRetired += 1;
@@ -660,20 +671,33 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 				// SAME demoted-but-unconfirmed record re-serves, and incident data
 				// showed repeat deliveries carrying near-zero information after the
 				// first. Cap it at DEPENDENCY_DRIFT_MAX_DELIVERIES instead.
-				const deliveryCount =
-					runtime.incrementInlineBlockerStaleDelivery(bPath);
-				if (deliveryCount >= DEPENDENCY_DRIFT_MAX_DELIVERIES) {
-					retired = runtime.retireDemotedDependencyDriftBlocker(bPath);
-					if (retired) {
-						demotedFindingsRetired += 1;
-						incrementDegradationCount({
-							kind: "demoted-finding-retired",
-							subject: `inline-blocker:${displayPath}`,
-							reason: `capped after ${deliveryCount} deliveries with no re-run; re-run can still confirm`,
-						});
-						retirementNote = formatDeliveryCapNote(deliveryCount);
-					}
+				//
+				// The count driving THIS render is a peek (fix-round F1): the actual
+				// increment is deferred to `pendingDependencyDriftDeliveries` below,
+				// committed only once this turn's content is known to reach the
+				// agent, so a suppressed turn's tentative render never advances the
+				// stored count.
+				const tentativeCount =
+					runtime.peekInlineBlockerStaleDeliveryCount(bPath) + 1;
+				if (tentativeCount >= DEPENDENCY_DRIFT_MAX_DELIVERIES) {
+					retirementNote = formatDeliveryCapNote(tentativeCount);
 				}
+				pendingDependencyDriftDeliveries.push(() => {
+					const deliveryCount =
+						runtime.incrementInlineBlockerStaleDelivery(bPath);
+					if (deliveryCount >= DEPENDENCY_DRIFT_MAX_DELIVERIES) {
+						const capRetired =
+							runtime.retireDemotedDependencyDriftBlocker(bPath);
+						if (capRetired) {
+							demotedFindingsRetired += 1;
+							incrementDegradationCount({
+								kind: "demoted-finding-retired",
+								subject: `inline-blocker:${displayPath}`,
+								reason: `capped after ${deliveryCount} deliveries with no re-run; re-run can still confirm`,
+							});
+						}
+					}
+				});
 			}
 			// @delivery-surface: runtime-turn:unresolved-inline-blocker
 			advisoryParts.push(
@@ -2666,6 +2690,10 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 			resetFormatService();
 			return;
 		}
+		// #1950 fix-round F1: this turn's content is confirmed NOT suppressed —
+		// it is about to reach the agent — so NOW commit the delivery-count
+		// increments the per-blocker loop above only tentatively computed.
+		for (const commit of pendingDependencyDriftDeliveries) commit();
 		const fileSeqByPath: Record<string, number> = {};
 		for (const [filePath, seq] of runtime.getFileSeqEntries()) {
 			fileSeqByPath[normalizeMapKey(path.resolve(filePath))] = seq;

--- a/tests/clients/blocker-freshness-delivery-cap.test.ts
+++ b/tests/clients/blocker-freshness-delivery-cap.test.ts
@@ -82,21 +82,45 @@ function readTurnEndContent(cacheManager: CacheManager, cwd: string): string {
 	);
 }
 
-/** Drive one more turn with activity so `handleTurnEnd` doesn't early-return
+/**
+ * Drive one more turn with activity so `handleTurnEnd` doesn't early-return
  * on "no modified files this turn" (same requirement blocker-past-eof-turn-end
- * uses for its multi-turn case). */
+ * uses for its multi-turn case).
+ *
+ * Also touches a per-turn NOISE file (`noise-<turn>.ts`) alongside `consumer`.
+ * Fix-round F1: `handleTurnEnd`'s `turn-end-findings-last` signature dedupe
+ * suppresses a turn whose rendered content is byte-identical to the last one
+ * DELIVERED — and the demoted blocker's own body renders identically turn to
+ * turn until the cap note appears, so without something else varying in the
+ * signature (the touched-file set, here), every turn after the first would
+ * suppress forever and the cap would never be reached. A stable, single-file,
+ * single-finding turn is exactly the shape #1950's own incident data showed
+ * causing repeat SILENT suppression in production — this noise file stands
+ * in for "something else about the turn differs", which is the common case.
+ */
 function driveTurn(
 	runtime: RuntimeCoordinator,
 	cacheManager: CacheManager,
 	consumer: string,
 	cwd: string,
 	sessionId: string,
+	turn: number,
 ): Promise<void> {
 	runtime.beginTurn();
 	runtime.bumpFileSeq(consumer);
 	cacheManager.addModifiedRange(
 		consumer,
 		{ start: 1, end: 2 },
+		false,
+		cwd,
+		sessionId,
+	);
+	const noise = path.join(cwd, `noise-${turn}.ts`);
+	fs.writeFileSync(noise, `export const noise${turn} = ${turn};\n`);
+	runtime.bumpFileSeq(noise);
+	cacheManager.addModifiedRange(
+		noise,
+		{ start: 1, end: 1 },
 		false,
 		cwd,
 		sessionId,
@@ -150,23 +174,47 @@ describe("dependency-drift delivery cap (#1950)", () => {
 			let content = readTurnEndContent(cacheManager, env.tmpDir);
 			expect(content).toContain("[stale — re-run to confirm]");
 			expect(content).not.toContain("Not shown again after");
-			expect(runtime.getInlineBlockersSnapshot()).toHaveLength(1);
+			// Fix-round F1: assert the ACTUAL delivery count directly off the
+			// store, not off `turn-end-findings`'s cached content — a turn whose
+			// content the signature dedupe suppresses leaves that cache holding
+			// the PREVIOUS turn's content, which would make a content-only
+			// assertion pass even for a turn that never reached the agent.
+			let snapshot = runtime.getInlineBlockersSnapshot();
+			expect(snapshot).toHaveLength(1);
+			expect(snapshot[0]?.staleDeliveryCount).toBe(1);
 
-			// Turns 2..cap-1: re-served, still not retired.
+			// Turns 2..cap-1: re-served, still not retired, count advancing by
+			// exactly one PER DELIVERED turn.
 			for (
 				let delivery = 2;
 				delivery < DEPENDENCY_DRIFT_MAX_DELIVERIES;
 				delivery++
 			) {
-				await driveTurn(runtime, cacheManager, consumer, env.tmpDir, sessionId);
+				await driveTurn(
+					runtime,
+					cacheManager,
+					consumer,
+					env.tmpDir,
+					sessionId,
+					delivery,
+				);
 				content = readTurnEndContent(cacheManager, env.tmpDir);
 				expect(content).toContain("[stale — re-run to confirm]");
 				expect(content).not.toContain("Not shown again after");
-				expect(runtime.getInlineBlockersSnapshot()).toHaveLength(1);
+				snapshot = runtime.getInlineBlockersSnapshot();
+				expect(snapshot).toHaveLength(1);
+				expect(snapshot[0]?.staleDeliveryCount).toBe(delivery);
 			}
 
 			// The delivery that reaches the cap retires the record.
-			await driveTurn(runtime, cacheManager, consumer, env.tmpDir, sessionId);
+			await driveTurn(
+				runtime,
+				cacheManager,
+				consumer,
+				env.tmpDir,
+				sessionId,
+				DEPENDENCY_DRIFT_MAX_DELIVERIES,
+			);
 			content = readTurnEndContent(cacheManager, env.tmpDir);
 			expect(content).toContain("[stale — re-run to confirm]");
 			expect(content).toContain(
@@ -194,8 +242,79 @@ describe("dependency-drift delivery cap (#1950)", () => {
 			// resurfaces once retired (proven directly against the store rather
 			// than the cache, since an empty turn-end result may leave the prior
 			// cache entry untouched — a caching detail orthogonal to this fix).
-			await driveTurn(runtime, cacheManager, consumer, env.tmpDir, sessionId);
+			await driveTurn(
+				runtime,
+				cacheManager,
+				consumer,
+				env.tmpDir,
+				sessionId,
+				DEPENDENCY_DRIFT_MAX_DELIVERIES + 1,
+			);
 			expect(runtime.getInlineBlockersSnapshot()).toHaveLength(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("does not advance the delivery count on a turn the signature dedupe suppresses (F1)", async () => {
+		const env = setupTestEnvironment("pi-lens-1950-suppressed-");
+		try {
+			const sessionId = "suppressed-session";
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+
+			const consumer = path.join(env.tmpDir, "consumer.ts");
+			const dep = path.join(env.tmpDir, "dep.ts");
+			fs.writeFileSync(dep, "export const other = 1;\n");
+			fs.writeFileSync(
+				consumer,
+				'import { other } from "./dep.js";\nexport const t = other;\n',
+			);
+
+			runtime.bumpFileSeq(consumer);
+			cacheManager.addModifiedRange(
+				consumer,
+				{ start: 1, end: 2 },
+				false,
+				env.tmpDir,
+				sessionId,
+			);
+			runtime.recordInlineBlockers(consumer, "🔴 L1 a real blocker", 1, [
+				"lsp",
+			]);
+			const future = new Date(Date.now() + 60_000);
+			fs.utimesSync(dep, future, future);
+
+			// Turn 1: demoted and delivered — count becomes 1.
+			await handleTurnEnd(makeTurnEndDeps(runtime, cacheManager, env.tmpDir));
+			expect(runtime.getInlineBlockersSnapshot()[0]?.staleDeliveryCount).toBe(
+				1,
+			);
+			const turn1Content = readTurnEndContent(cacheManager, env.tmpDir);
+
+			// Turn 2: re-touch the SAME consumer with no other change — the
+			// rendered advisory is byte-identical to turn 1's (the count driving
+			// it hasn't moved and stays below the cap note threshold), so
+			// `turn-end-findings-last`'s signature dedupe suppresses it. The
+			// cached content therefore stays turn 1's, unchanged.
+			runtime.beginTurn();
+			runtime.bumpFileSeq(consumer);
+			cacheManager.addModifiedRange(
+				consumer,
+				{ start: 1, end: 2 },
+				false,
+				env.tmpDir,
+				sessionId,
+			);
+			await handleTurnEnd(makeTurnEndDeps(runtime, cacheManager, env.tmpDir));
+
+			// The count must NOT have advanced: this turn was never delivered.
+			expect(runtime.getInlineBlockersSnapshot()[0]?.staleDeliveryCount).toBe(
+				1,
+			);
+			expect(readTurnEndContent(cacheManager, env.tmpDir)).toBe(turn1Content);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/blocker-freshness-delivery-cap.test.ts
+++ b/tests/clients/blocker-freshness-delivery-cap.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Turn-end integration for the dependency-drift delivery cap (#1950).
+ *
+ * #1631's freshness gate demotes a blocker whose dependency drifted to a
+ * `[stale — re-run to confirm]` advisory (demote, not drop — #1419), and
+ * #1949 gave that demotion the shared degradation-ledger body, but
+ * deliberately did NOT retire it: the cited coordinates are still in bounds,
+ * so a fresh dispatch can genuinely confirm or clear it. Nothing capped how
+ * many times the SAME demoted record kept re-serving, though — incident data
+ * showed 18 `alreadyStale` re-serves in one window with near-zero
+ * information after the first delivery.
+ *
+ * This drives the real `handleTurnEnd` across several turns and asserts:
+ *   1. The demotion re-serves, unretired, below the delivery cap.
+ *   2. At the cap (`DEPENDENCY_DRIFT_MAX_DELIVERIES`), the record retires
+ *      with a note that says the OPPOSITE of #1944's past-EOF retirement —
+ *      "re-run can still confirm", not "cannot be re-confirmed".
+ *   3. After retirement, the record is gone from the store and never
+ *      resurfaces.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const logLatency = vi.hoisted(() => vi.fn());
+vi.mock("../../clients/latency-logger.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../clients/latency-logger.js")>();
+	return { ...actual, logLatency };
+});
+
+import { CacheManager } from "../../clients/cache-manager.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
+import { DEPENDENCY_DRIFT_MAX_DELIVERIES } from "../../clients/blocker-freshness.js";
+import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
+import {
+	cancelLSPIdleReset,
+	handleTurnEnd,
+} from "../../clients/runtime-turn.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+const EMPTY_KNIP_RESULT = {
+	success: true,
+	issues: [],
+	unusedExports: [],
+	unusedFiles: [],
+	unusedDeps: [],
+	unlistedDeps: [],
+	summary: "skipped",
+};
+
+function makeTurnEndDeps(
+	runtime: RuntimeCoordinator,
+	cacheManager: CacheManager,
+	cwd: string,
+) {
+	return {
+		ctxCwd: cwd,
+		getFlag: () => false,
+		dbg: () => {},
+		runtime,
+		cacheManager,
+		knipClient: {
+			ensureAvailable: async () => false,
+			analyze: async () => EMPTY_KNIP_RESULT,
+		},
+		deadCodeClients: [],
+		depChecker: { ensureAvailable: async () => false },
+		testRunnerClient: { getTestRunTarget: () => null },
+		resetLSPService: () => {},
+		resetFormatService: () => {},
+	} as any;
+}
+
+function readTurnEndContent(cacheManager: CacheManager, cwd: string): string {
+	return (
+		cacheManager.readCache<{ content: string }>("turn-end-findings", cwd)?.data
+			?.content ?? ""
+	);
+}
+
+/** Drive one more turn with activity so `handleTurnEnd` doesn't early-return
+ * on "no modified files this turn" (same requirement blocker-past-eof-turn-end
+ * uses for its multi-turn case). */
+function driveTurn(
+	runtime: RuntimeCoordinator,
+	cacheManager: CacheManager,
+	consumer: string,
+	cwd: string,
+	sessionId: string,
+): Promise<void> {
+	runtime.beginTurn();
+	runtime.bumpFileSeq(consumer);
+	cacheManager.addModifiedRange(
+		consumer,
+		{ start: 1, end: 2 },
+		false,
+		cwd,
+		sessionId,
+	);
+	return handleTurnEnd(makeTurnEndDeps(runtime, cacheManager, cwd));
+}
+
+afterEach(() => {
+	cancelLSPIdleReset();
+	resetDegradationLedger();
+	logLatency.mockClear();
+});
+
+describe("dependency-drift delivery cap (#1950)", () => {
+	it(`retires after ${DEPENDENCY_DRIFT_MAX_DELIVERIES} deliveries, with a "still confirmable" note, not #1944's "unrecoverable" one`, async () => {
+		const env = setupTestEnvironment("pi-lens-1950-cap-");
+		try {
+			const sessionId = "cap-session";
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+
+			const consumer = path.join(env.tmpDir, "consumer.ts");
+			const dep = path.join(env.tmpDir, "dep.ts");
+			fs.writeFileSync(dep, "export const other = 1;\n");
+			fs.writeFileSync(
+				consumer,
+				'import { other } from "./dep.js";\nexport const t = other;\n',
+			);
+
+			runtime.bumpFileSeq(consumer);
+			cacheManager.addModifiedRange(
+				consumer,
+				{ start: 1, end: 2 },
+				false,
+				env.tmpDir,
+				sessionId,
+			);
+			runtime.recordInlineBlockers(consumer, "🔴 L1 a real blocker", 1, [
+				"lsp",
+			]);
+
+			// The dependency drifts out-of-band after the verdict.
+			const future = new Date(Date.now() + 60_000);
+			fs.utimesSync(dep, future, future);
+
+			// Turn 1: the sweep detects drift and demotes; the SAME turn's
+			// delivery loop serves the fresh demotion (delivery 1 of the cap).
+			await handleTurnEnd(makeTurnEndDeps(runtime, cacheManager, env.tmpDir));
+			let content = readTurnEndContent(cacheManager, env.tmpDir);
+			expect(content).toContain("[stale — re-run to confirm]");
+			expect(content).not.toContain("Not shown again after");
+			expect(runtime.getInlineBlockersSnapshot()).toHaveLength(1);
+
+			// Turns 2..cap-1: re-served, still not retired.
+			for (
+				let delivery = 2;
+				delivery < DEPENDENCY_DRIFT_MAX_DELIVERIES;
+				delivery++
+			) {
+				await driveTurn(runtime, cacheManager, consumer, env.tmpDir, sessionId);
+				content = readTurnEndContent(cacheManager, env.tmpDir);
+				expect(content).toContain("[stale — re-run to confirm]");
+				expect(content).not.toContain("Not shown again after");
+				expect(runtime.getInlineBlockersSnapshot()).toHaveLength(1);
+			}
+
+			// The delivery that reaches the cap retires the record.
+			await driveTurn(runtime, cacheManager, consumer, env.tmpDir, sessionId);
+			content = readTurnEndContent(cacheManager, env.tmpDir);
+			expect(content).toContain("[stale — re-run to confirm]");
+			expect(content).toContain(
+				`Not shown again after ${DEPENDENCY_DRIFT_MAX_DELIVERIES} deliveries`,
+			);
+			// #1950 vs #1944: the wording must NOT claim the finding is
+			// unconfirmable — it may still be accurate.
+			expect(content).not.toContain("cannot be re-confirmed");
+			expect(runtime.getInlineBlockersSnapshot()).toHaveLength(0);
+
+			expect(getDegradationSummary()).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						kind: "demoted-finding-retired",
+						latestReasons: expect.arrayContaining([
+							expect.objectContaining({
+								reason: expect.stringContaining("re-run can still confirm"),
+							}),
+						]),
+					}),
+				]),
+			);
+
+			// A further turn has nothing left to re-serve: the record never
+			// resurfaces once retired (proven directly against the store rather
+			// than the cache, since an empty turn-end result may leave the prior
+			// cache entry untouched — a caching detail orthogonal to this fix).
+			await driveTurn(runtime, cacheManager, consumer, env.tmpDir, sessionId);
+			expect(runtime.getInlineBlockersSnapshot()).toHaveLength(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+});

--- a/tests/clients/runtime-coordinator-dependency-drift-cap.test.ts
+++ b/tests/clients/runtime-coordinator-dependency-drift-cap.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Direct unit coverage for `RuntimeCoordinator`'s #1950 delivery-cap methods
+ * (`peekInlineBlockerStaleDeliveryCount`, `incrementInlineBlockerStaleDelivery`,
+ * `retireDemotedDependencyDriftBlocker`).
+ *
+ * Fix-round F2: adversarial review found `retireDemotedDependencyDriftBlocker`'s
+ * own guards (`!existing.stale`, `staleReason !== "dependency-drift"`)
+ * unreachable through `runtime-turn.ts`'s only call site, which already
+ * pre-filters on `staleReason === "dependency-drift"` before calling. Rather
+ * than drop the guards — this is a PUBLIC coordinator method, and a future
+ * caller that does not pre-filter would silently retire the wrong record
+ * without them — this file exercises them directly, the same way
+ * `retireDemotedPastEofBlocker`'s own guards are proven through its
+ * `staleReason` argument at the turn-end integration layer
+ * (`blocker-past-eof-turn-end.test.ts`'s "does not fight a blocker already
+ * demoted by the dependency-drift gate" case).
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+describe("RuntimeCoordinator dependency-drift delivery-cap methods (#1950)", () => {
+	it("peek and increment are independent: peek never mutates, increment always advances by one", () => {
+		const env = setupTestEnvironment("pi-lens-1950-peek-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const target = path.join(env.tmpDir, "target.ts");
+			fs.writeFileSync(target, "export const a = 1;\n");
+			runtime.recordInlineBlockers(target, "🔴 a blocker", 1, ["lsp"]);
+			runtime.markInlineBlockerStale(target, "dependency-drift");
+
+			expect(runtime.peekInlineBlockerStaleDeliveryCount(target)).toBe(0);
+			// Repeated peeks must not advance the count.
+			expect(runtime.peekInlineBlockerStaleDeliveryCount(target)).toBe(0);
+
+			expect(runtime.incrementInlineBlockerStaleDelivery(target)).toBe(1);
+			expect(runtime.peekInlineBlockerStaleDeliveryCount(target)).toBe(1);
+			expect(runtime.incrementInlineBlockerStaleDelivery(target)).toBe(2);
+			expect(runtime.peekInlineBlockerStaleDeliveryCount(target)).toBe(2);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("peek and increment return 0 for a file with no recorded blocker", () => {
+		const env = setupTestEnvironment("pi-lens-1950-missing-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const target = path.join(env.tmpDir, "never-recorded.ts");
+			expect(runtime.peekInlineBlockerStaleDeliveryCount(target)).toBe(0);
+			expect(runtime.incrementInlineBlockerStaleDelivery(target)).toBe(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("retireDemotedDependencyDriftBlocker refuses a record that is not stale", () => {
+		const env = setupTestEnvironment("pi-lens-1950-notstale-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const target = path.join(env.tmpDir, "target.ts");
+			fs.writeFileSync(target, "export const a = 1;\n");
+			runtime.recordInlineBlockers(target, "🔴 a blocker", 1, ["lsp"]);
+			// Never demoted — `stale` is falsy.
+
+			expect(runtime.retireDemotedDependencyDriftBlocker(target)).toBe(false);
+			expect(runtime.getInlineBlockersSnapshot()).toHaveLength(1);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("retireDemotedDependencyDriftBlocker refuses a past-EOF demotion on the same file", () => {
+		const env = setupTestEnvironment("pi-lens-1950-wrongreason-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const target = path.join(env.tmpDir, "target.ts");
+			fs.writeFileSync(target, "export const a = 1;\n");
+			runtime.recordInlineBlockers(target, "🔴 a blocker", 1, ["lsp"]);
+			runtime.markInlineBlockerStale(target, "past-eof");
+
+			// Must not retire a demotion that belongs to the OTHER gate — that
+			// gate's own retirement (`retireDemotedPastEofBlocker`) owns it.
+			expect(runtime.retireDemotedDependencyDriftBlocker(target)).toBe(false);
+			const snapshot = runtime.getInlineBlockersSnapshot();
+			expect(snapshot).toHaveLength(1);
+			expect(snapshot[0]?.staleReason).toBe("past-eof");
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("retireDemotedDependencyDriftBlocker retires a genuine dependency-drift demotion", () => {
+		const env = setupTestEnvironment("pi-lens-1950-retire-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			const target = path.join(env.tmpDir, "target.ts");
+			fs.writeFileSync(target, "export const a = 1;\n");
+			runtime.recordInlineBlockers(target, "🔴 a blocker", 1, ["lsp"]);
+			runtime.markInlineBlockerStale(target, "dependency-drift");
+
+			expect(runtime.retireDemotedDependencyDriftBlocker(target)).toBe(true);
+			expect(runtime.getInlineBlockersSnapshot()).toHaveLength(0);
+		} finally {
+			env.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up from #1944's lane sweep (PR #1949). The dependency-drift gate demotes a cached inline blocker to a `[stale — re-run to confirm]` advisory when a dependency drifts on disk (`clients/blocker-freshness.ts:573` demotes a record whose cited line is still in bounds — the drift could genuinely be confirmed or cleared by a re-run). #1949 gave that demotion the shared degradation-ledger body but deliberately did NOT retire it, since retiring after one delivery would discard a recoverable finding.

The remaining defect: nothing capped how many times the SAME demoted-but-confirmable record re-serves. The incident data showed 18 `alreadyStale` re-serves in one window, with repeat deliveries carrying near-zero information after the first.

## Design

Per the plan comment on #1950: a **delivery count**, not a TTL or session boundary. "How many times has the agent already been told" is the quantity that went to zero information, not "how much time has passed" — a dependency-drift demotion stays live and re-servable for the WHOLE session by design (unlike #1944's past-EOF case, which retires because it is provably unconfirmable).

- `N = 3`: delivery 1 is the fresh drift signal; delivery 2 covers the case the agent's first pass didn't act; delivery 3 is the last chance before the incident data's "near-zero information" observation applies.
- `InlineBlockerRecord.staleDeliveryCount` tracks deliveries, incremented only for `staleReason === "dependency-drift"` (`"past-eof"` already retires after its own single delivery and never needs a count).
- `RuntimeCoordinator.retireDemotedDependencyDriftBlocker` retires the record at the cap, mirroring `retireDemotedPastEofBlocker`'s shape but with a distinct guard (`staleReason === "dependency-drift"` only) and a distinct ledger reason.
- The retirement note (`formatDeliveryCapNote`) says "re-run can still confirm", the deliberate opposite of #1944's "cannot be re-confirmed" — the record is not provably dead, it just stopped being handed out for free.

No new latch machinery: this reuses `RuntimeCoordinator`'s existing inline-blocker store and `degradation-ledger.ts`'s existing `incrementDegradationCount`, following the same shape #1944 already established for the sibling gate.

## Tests

New `tests/clients/blocker-freshness-delivery-cap.test.ts` drives the real `handleTurnEnd` across 4 turns: demote → re-serve (below cap) → retire (at cap, with the distinguishing note) → gone (never resurfaces).

Red on pre-fix code (`clients/blocker-freshness.ts`, `runtime-coordinator.ts`, `runtime-turn.ts`, `demoted-finding-render.ts` reverted to `HEAD`, rebuilt, rerun):

```
FAIL tests/clients/blocker-freshness-delivery-cap.test.ts > dependency-drift delivery cap (#1950) > retires after undefined deliveries, with a "still confirmable" note, not #1944's "unrecoverable" one
AssertionError: expected 'ℹ️ Advisory — no action required this…' to contain 'Not shown again after undefined deliv…'
- Not shown again after undefined deliveries
+ ℹ️ Advisory — no action required this turn:
+ [stale — re-run to confirm] consumer.ts:
+ 🔴 L1 a real blocker
Test Files  1 failed (1)
     Tests  1 failed (1)
```

(Red for the right reason: pre-fix, the record never retires — it re-serves the same body forever, which is exactly the bug.)

Green after restoring the fix: `Test Files 1 passed (1)` / `Tests 1 passed (1)`.

### Test assessment

- `tests/clients/blocker-freshness-delivery-cap.test.ts` (new, extended in the review round) — pins the delivery-cap contract end to end: below-cap re-serve, at-cap retirement with the distinguishing wording, non-resurfacing, and (review round) that a suppressed turn does not advance the counter. Nothing else drives multiple `handleTurnEnd` cycles against the SAME dependency-drift demotion, so this is not redundant with `blocker-freshness-turn-end.test.ts` (single-turn demotion) or `blocker-past-eof-turn-end.test.ts` (the other gate's own multi-turn re-arm case).
- `tests/clients/runtime-coordinator-dependency-drift-cap.test.ts` (new, review round) — direct unit coverage of `peekInlineBlockerStaleDeliveryCount`, `incrementInlineBlockerStaleDelivery`, and `retireDemotedDependencyDriftBlocker`'s guards, below the integration layer. Not redundant with the turn-end test above, which only exercises these methods through `handleTurnEnd`'s specific call pattern and never a wrong-state call.

Full local run of every sibling file referencing the touched symbols (`InlineBlockerRecord`, `markInlineBlockerStale`, `retireDemotedPastEofBlocker`, `degradeDemotedFindingBody`, `formatRetirementNote`) plus the governance sweeps: `blocker-freshness-delivery-cap.test.ts`, `blocker-freshness-turn-end.test.ts`, `blocker-freshness.test.ts`, `blocker-freshness-widget-population.test.ts`, `blocker-past-eof-turn-end.test.ts`, `demoted-blocker-render-retirement.test.ts`, `runtime-turn-finding-freshness.test.ts`, `runtime-turn-session.test.ts`, `session-state-conformance.test.ts`, `finding-delivery-gate.test.ts`, `bounded-telemetry-sweep.test.ts` (file is `bounded-telemetry-sweep`), `delivery-surface-ratchet.test.ts`, `freshness-sweep.test.ts`, `bus-producer-coverage.test.ts`, `profiling-coverage.test.ts`, `tests/config/module-instance-coverage.test.ts`, `tests/config/sweep-floor-coverage.test.ts` — all green, no regressions.

## Class sweep

Pattern: a demoted (not dropped) advisory record re-served turn after turn with no bound on delivery count. Swept `clients/` for every `stale`/demoted-finding delivery surface:

| Surface | Cap today | Verdict |
|---|---|---|
| Inline blockers, dependency-drift (`runtime-coordinator.ts`) | none | fixed here |
| Inline blockers, past-EOF (`runtime-coordinator.ts`) | 1 delivery | already correct (#1944) — provably unconfirmable, retiring immediately is right |
| Widget-store blockers, dependency-drift (`widget-state.ts`, per `markWidgetFileBlockersStale`) | none | out of scope — different store, same class; filed as a sibling below |
| Test-runner failed-target state (`test-runner-client.ts`) | evicted at state cap (#2044) | different shape (LRU cap, not delivery cap) — not this class |

The widget-store sibling (dependency-drift demotions delivered through `markWidgetFileBlockersStale`/`getWidgetBlockingFilesForSweep` rather than `RuntimeCoordinator`'s inline-blocker map) has the identical unbounded-delivery shape and is NOT fixed by this PR — it is a distinct store with its own render path (`widget-state.ts`) and its own re-derive-not-latch design, and folding it in here would widen this PR past "small". Filed as #2275.

## Blast radius

`clients/runtime-turn.ts`'s unresolved-inline-blocker delivery loop is the only caller of the new coordinator methods, on the same `handleTurnEnd` code path #1944 already touches. No change to the freshness gate's own sweep (`sweepInlineBlockerFreshness`) — the cap fires in the delivery loop, one turn-end call after the sweep already ran, so `blocker_freshness_sweep`'s existing counts (`alreadyStale`, `revalidated`, `kept`) are unaffected.

## Observability

`demoted-finding-retired` (existing kind, `degradation-ledger.ts`) now fires for two distinct reasons distinguishable by the reason string: past-EOF's "retired after one degraded delivery" (unchanged) and this fix's "capped after N deliveries with no re-run; re-run can still confirm". `cache_context` injections (the advisory body) carry the same distinction via `formatDeliveryCapNote` vs. `formatRetirementNote`.

## Review round

Adversarial review returned three findings:

- **F1 (counter measured loop iterations, not deliveries)**: `handleTurnEnd`'s own `turn-end-findings-last` signature dedupe suppresses a turn whose rendered content matches the last DELIVERED turn byte-for-byte — and the demoted body renders identically until the cap note appears, so a stable file set (the common shape the incident data showed) suppressed every middle turn while the counter kept climbing underneath it. Fixed by splitting peek from commit: `RuntimeCoordinator.peekInlineBlockerStaleDeliveryCount` drives the render (does the cap note show?), and the actual `incrementInlineBlockerStaleDelivery` + retirement + ledger write are deferred into a closure invoked only once `handleTurnEnd` confirms this turn is NOT suppressed. New dedicated test proves it (a suppressed turn advances the count from 1 to 2 on pre-fix-round code; stays at 1 post-fix). The existing multi-turn cap test's middle-turn assertions now read `runtime.getInlineBlockersSnapshot()` directly — the cache read the reviewer flagged (`turn-end-findings`) is exactly what a suppressed turn leaves stale.
- **F2 (unreachable guard)**: `retireDemotedDependencyDriftBlocker`'s own `stale`/`staleReason` guards were dead code through the only current call site (which pre-filters). Kept them — it is a public method, and a future caller skipping the pre-filter would silently retire the wrong record — and added `tests/clients/runtime-coordinator-dependency-drift-cap.test.ts` with direct unit coverage of each guard, so they are no longer untested dead code either way.
- **F3 (refs vs closes)**: agreed — flipped to `closes #1950`. All three of #1950's stated acceptance criteria (delivery cap, distinct ledger reason, red-first + mutation-proof test, observability record) are met by this PR alone. #2275 is a disjoint sibling (a different store, `widget-state.ts`, with its own render path), not unfinished remainder of this issue.

Style: `DEPENDENCY_DRIFT_MAX_DELIVERIES` moved below the import block in `blocker-freshness.ts`.

## Type of change

- [x] Bug fix

## Area

- [x] area:diagnostics

Refs #1944, #1634. Closes #1950.
