### PR TITLE
test: fix flaky-under-load family (refs #2225, refs #2235, refs #2182)

### DIFF
--- a/.changelog/2225-2235-2182-flaky-under-load.md
+++ b/.changelog/2225-2235-2182-flaky-under-load.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Remove three real-timer races from tests that only pass under CPU contention (refs #2225, #2235, #2182)** — `safe-spawn.ts`'s cap-then-timeout/cap-then-abort tests raced a real child's stdout against a real 300ms timer (5/8 failures under 8 concurrent runs); they now mock the child so the cap trips before the timeout by construction, in a new `safe-spawn-cap-race.test.ts`. `spawn-timeout-cooldown.test.ts`'s markdownlint-fix guard paired real filesystem I/O with a heavy dynamic import inside vitest's 5000ms default, reproduced as a hard timeout under synthetic load; it now carries a 20s budget. `managed-tool-refresh-strategies.test.ts` had more instances of the dangling-promise-contamination shape #2216 first fixed for one test — a file-wide `vi.setConfig({ testTimeout: 20_000 })` replaces per-test patching. A residual shared-mutable-state race in the same file, independent of any timeout, is left open on #2182.

--- a/tests/clients/installer/managed-tool-refresh-strategies.test.ts
+++ b/tests/clients/installer/managed-tool-refresh-strategies.test.ts
@@ -43,16 +43,24 @@
  * both version probes" (timed out at 5000ms, then corrupted the very next
  * gem-budget test's result the same way #2216 first diagnosed).
  *
+ * The 8932ms/15086ms figures above are LOAD-INDUCED, not this file's normal
+ * cost: on a quiet host the same two tests measure 552ms and 348ms (this
+ * file's full 43-test run completes in 3.3-4.0s of test time). They're the
+ * genuine work observed under sustained 14-16 concurrent CPU-load workers,
+ * which is the scenario this fix has to survive.
+ *
  * Rather than keep annotating individual tests as each one gets caught by a
  * heavier load sample, `vi.setConfig` below raises the DEFAULT test timeout
  * for the WHOLE file once — the single mechanism the next flake report
  * should point at (#2182 acceptance criterion 2), sized with real margin
- * over the slowest genuine-work measurement observed (15086ms). This isn't a
- * phased vitest project: the existing "timing-sensitive" lane is reserved
- * for `measureMaxSyncBlockMs` sampler tests (see
- * tests/config/timing-sensitive-coverage.test.ts), and this file uses
- * neither the sampler nor a real process spawn, so it fits neither that lane
- * nor "lsp-spawn-heavy".
+ * over the slowest genuine-work measurement observed (15086ms). No test in
+ * this file carries its own `it(..., N)` override alongside it — a test
+ * that needs more than the file default gets a bigger default, not a second
+ * mechanism. This isn't a phased vitest project: the existing
+ * "timing-sensitive" lane is reserved for `measureMaxSyncBlockMs` sampler
+ * tests (see tests/config/timing-sensitive-coverage.test.ts), and this file
+ * uses neither the sampler nor a real process spawn, so it fits neither that
+ * lane nor "lsp-spawn-heavy".
  *
  * One residual symptom did NOT fit this budget-correction shape: "gem
  * strategy > re-runs the install command" lost a recorded spawn under the
@@ -79,10 +87,14 @@ import {
 import { withEnv } from "../../support/with-env.js";
 
 // #2182: raises this FILE's default test timeout from vitest's 5000ms to
-// 20_000ms — see the file header for the measurements this margin is sized
-// against. `resetConfig` in `afterAll` scopes the change back to this file
-// alone so it can't leak into a later file reusing the same worker.
-vi.setConfig({ testTimeout: 20_000 });
+// 25_000ms — see the file header for the measurements this margin is sized
+// against (25000/15086 = 1.66x over the slowest genuine-work run observed).
+// This is the ONLY timeout override in the file — no per-test `it(..., N)`
+// coexists with it; a test that needs a bigger number than this raises the
+// default, it doesn't add a second mechanism next to it (#2182 AC2).
+// `resetConfig` in `afterAll` scopes the change back to this file alone so
+// it can't leak into a later file reusing the same worker.
+vi.setConfig({ testTimeout: 25_000 });
 afterAll(() => {
 	vi.resetConfig();
 });
@@ -853,7 +865,7 @@ describe("pip strategy", () => {
 			failed: true,
 			version: "0.5.0",
 		});
-	}, 25_000);
+	});
 
 	it("degrades once and keeps the recorded version when pip fails", async () => {
 		installProbeCached("ruff");

--- a/tests/clients/installer/managed-tool-refresh-strategies.test.ts
+++ b/tests/clients/installer/managed-tool-refresh-strategies.test.ts
@@ -827,39 +827,33 @@ describe("pip strategy", () => {
 		expect(installSpawns()).toEqual([]);
 	});
 
-	it(
-		"degrades when the upgrade leaves a binary that cannot report a version",
-		async () => {
-			installProbeCached("ruff");
-			freshenAllExcept("ruff", {
-				ruff: { checkedAt: NOW - 8 * DAY_MS, version: "0.5.0" },
-			});
-			// The version probe answers before the upgrade and fails after it: the
-			// upgrade replaced a working copy with one that cannot run.
-			let probes = 0;
-			spawnMock.mockImplementation(
-				async (_command: string, args: string[]) => {
-					if ((args ?? []).includes("install")) {
-						return { stdout: "", stderr: "", status: 0 };
-					}
-					probes += 1;
-					return probes === 1
-						? { stdout: "0.5.0", stderr: "", status: 0 }
-						: { stdout: "", stderr: "cannot execute", status: 126 };
-				},
-			);
+	it("degrades when the upgrade leaves a binary that cannot report a version", async () => {
+		installProbeCached("ruff");
+		freshenAllExcept("ruff", {
+			ruff: { checkedAt: NOW - 8 * DAY_MS, version: "0.5.0" },
+		});
+		// The version probe answers before the upgrade and fails after it: the
+		// upgrade replaced a working copy with one that cannot run.
+		let probes = 0;
+		spawnMock.mockImplementation(async (_command: string, args: string[]) => {
+			if ((args ?? []).includes("install")) {
+				return { stdout: "", stderr: "", status: 0 };
+			}
+			probes += 1;
+			return probes === 1
+				? { stdout: "0.5.0", stderr: "", status: 0 }
+				: { stdout: "", stderr: "cannot execute", status: 126 };
+		});
 
-			const outcome = await runManagedToolRefresh(NOW);
+		const outcome = await runManagedToolRefresh(NOW);
 
-			expect(outcome.refreshed[0]).toMatchObject({ ok: false });
-			expect(degradationCount()).toBe(1);
-			expect(readState().ruff).toMatchObject({
-				failed: true,
-				version: "0.5.0",
-			});
-		},
-		25_000,
-	);
+		expect(outcome.refreshed[0]).toMatchObject({ ok: false });
+		expect(degradationCount()).toBe(1);
+		expect(readState().ruff).toMatchObject({
+			failed: true,
+			version: "0.5.0",
+		});
+	}, 25_000);
 
 	it("degrades once and keeps the recorded version when pip fails", async () => {
 		installProbeCached("ruff");

--- a/tests/clients/installer/managed-tool-refresh-strategies.test.ts
+++ b/tests/clients/installer/managed-tool-refresh-strategies.test.ts
@@ -25,19 +25,42 @@
  *
  * #2182: this file flaked when run combined with the two
  * `tests/clients/degradation-ledger*.test.ts` files under real machine
- * contention. Root cause: "re-arms across sessions rather than latching for
- * the process" awaits two refresh calls that resolve on queued microtasks
- * (fast on a quiet host) but starved past the default 5000ms testTimeout
- * under load; the timeout does not cancel the underlying promise, so the
- * straggler resolved later and mutated the shared spawn/degradation mocks
- * mid-test in an unrelated later case. Fix: budget correction — that one
- * test now carries an explicit 15_000ms timeout (see the test body) sized
- * off a local repro under synthetic CPU load, instead of a phased vitest
- * project (the existing "timing-sensitive" lane is reserved for
- * measureMaxSyncBlockMs sampler tests — see
- * tests/config/timing-sensitive-coverage.test.ts — and this file uses
- * neither the sampler nor a real process spawn, so it does not fit that or
- * the "lsp-spawn-heavy" lane).
+ * contention. Root cause: several tests here await real-shaped async work
+ * (multiple sequential mocked spawns, real filesystem I/O against a temp
+ * `PI_LENS_HOME`) that stays well under vitest's default 5000ms testTimeout
+ * on a quiet host but starves past it under load — and a timed-out test's
+ * promise chain keeps running (vitest doesn't cancel it), so the straggler
+ * resolves later and mutates the shared spawn/degradation mocks mid a LATER,
+ * unrelated test. First diagnosed and fixed for one test ("re-arms across
+ * sessions...") in #2216 with a per-test timeout override; verifying that
+ * fix under heavier synthetic load (14-16 concurrent CPU-load workers,
+ * several rounds) turned up more instances of the same shape — "pip
+ * strategy > upgrades a stale package with -U" (genuine work measured at
+ * 8932ms with the budget temporarily raised to 30s), "pip strategy >
+ * degrades when the upgrade leaves a binary that cannot report a version"
+ * (15086ms — two sequential mocked spawns instead of one), and
+ * "verification-budget delivery ... delivers a pip tool's custom budget to
+ * both version probes" (timed out at 5000ms, then corrupted the very next
+ * gem-budget test's result the same way #2216 first diagnosed).
+ *
+ * Rather than keep annotating individual tests as each one gets caught by a
+ * heavier load sample, `vi.setConfig` below raises the DEFAULT test timeout
+ * for the WHOLE file once — the single mechanism the next flake report
+ * should point at (#2182 acceptance criterion 2), sized with real margin
+ * over the slowest genuine-work measurement observed (15086ms). This isn't a
+ * phased vitest project: the existing "timing-sensitive" lane is reserved
+ * for `measureMaxSyncBlockMs` sampler tests (see
+ * tests/config/timing-sensitive-coverage.test.ts), and this file uses
+ * neither the sampler nor a real process spawn, so it fits neither that lane
+ * nor "lsp-spawn-heavy".
+ *
+ * One residual symptom did NOT fit this budget-correction shape: "gem
+ * strategy > re-runs the install command" lost a recorded spawn under the
+ * 16-worker run while finishing in ~3s itself — never near any timeout. That
+ * points at a genuinely shared `installSpawns()`/`TEST_HOME` mutable-state
+ * race between concurrent-in-time promise settlement, not a starved budget.
+ * Left uninvestigated and named on the #2182 issue thread as a remaining
+ * item; it needs its own root-cause pass, not a bigger number here.
  */
 
 import { EventEmitter } from "node:events";
@@ -54,6 +77,15 @@ import {
 	vi,
 } from "vitest";
 import { withEnv } from "../../support/with-env.js";
+
+// #2182: raises this FILE's default test timeout from vitest's 5000ms to
+// 20_000ms — see the file header for the measurements this margin is sized
+// against. `resetConfig` in `afterAll` scopes the change back to this file
+// alone so it can't leak into a later file reusing the same worker.
+vi.setConfig({ testTimeout: 20_000 });
+afterAll(() => {
+	vi.resetConfig();
+});
 
 vi.unmock("../../../clients/installer/index.js");
 
@@ -795,30 +827,39 @@ describe("pip strategy", () => {
 		expect(installSpawns()).toEqual([]);
 	});
 
-	it("degrades when the upgrade leaves a binary that cannot report a version", async () => {
-		installProbeCached("ruff");
-		freshenAllExcept("ruff", {
-			ruff: { checkedAt: NOW - 8 * DAY_MS, version: "0.5.0" },
-		});
-		// The version probe answers before the upgrade and fails after it: the
-		// upgrade replaced a working copy with one that cannot run.
-		let probes = 0;
-		spawnMock.mockImplementation(async (_command: string, args: string[]) => {
-			if ((args ?? []).includes("install")) {
-				return { stdout: "", stderr: "", status: 0 };
-			}
-			probes += 1;
-			return probes === 1
-				? { stdout: "0.5.0", stderr: "", status: 0 }
-				: { stdout: "", stderr: "cannot execute", status: 126 };
-		});
+	it(
+		"degrades when the upgrade leaves a binary that cannot report a version",
+		async () => {
+			installProbeCached("ruff");
+			freshenAllExcept("ruff", {
+				ruff: { checkedAt: NOW - 8 * DAY_MS, version: "0.5.0" },
+			});
+			// The version probe answers before the upgrade and fails after it: the
+			// upgrade replaced a working copy with one that cannot run.
+			let probes = 0;
+			spawnMock.mockImplementation(
+				async (_command: string, args: string[]) => {
+					if ((args ?? []).includes("install")) {
+						return { stdout: "", stderr: "", status: 0 };
+					}
+					probes += 1;
+					return probes === 1
+						? { stdout: "0.5.0", stderr: "", status: 0 }
+						: { stdout: "", stderr: "cannot execute", status: 126 };
+				},
+			);
 
-		const outcome = await runManagedToolRefresh(NOW);
+			const outcome = await runManagedToolRefresh(NOW);
 
-		expect(outcome.refreshed[0]).toMatchObject({ ok: false });
-		expect(degradationCount()).toBe(1);
-		expect(readState().ruff).toMatchObject({ failed: true, version: "0.5.0" });
-	});
+			expect(outcome.refreshed[0]).toMatchObject({ ok: false });
+			expect(degradationCount()).toBe(1);
+			expect(readState().ruff).toMatchObject({
+				failed: true,
+				version: "0.5.0",
+			});
+		},
+		25_000,
+	);
 
 	it("degrades once and keeps the recorded version when pip fails", async () => {
 		installProbeCached("ruff");
@@ -1459,7 +1500,7 @@ describe("one budget across all strategies", () => {
 		await runManagedToolRefresh(NOW);
 
 		expect(installSpawns().length).toBe(first + 1);
-	}, 15_000);
+	});
 });
 
 // --- install kill-switch, trust gate, and install lock (#1759 review F2) --

--- a/tests/clients/safe-spawn-ambient-signal.test.ts
+++ b/tests/clients/safe-spawn-ambient-signal.test.ts
@@ -116,11 +116,20 @@ describe("safeSpawnAsync ambient abort signal (#197)", () => {
 	// to live here raced a real child's stdout against a real 300ms timer —
 	// flaky under CPU load (5/8 concurrent runs failing). They now live in
 	// safe-spawn-cap-race.test.ts, mocked so the cap trips before the
-	// timeout/abort by construction instead of by timing.
+	// timeout/abort by construction instead of by timing. That move drops
+	// real-process coverage for THOSE two interleavings specifically (cap
+	// racing a timeout, cap racing an abort) — the mock never spawns an OS
+	// process at all. The rest of this file's real-child coverage is
+	// unaffected: "kills a noisy child..." above (line 82) and "retains late
+	// output..." below (line 129) still spawn real children and assert
+	// against their real completion, with no competing timer to race — that's
+	// the #2100/#2197-class flush/late-output behavior this file still pins
+	// end to end against a real process.
 
-	// The child ignores SIGTERM for the same reason the two moved tests above did: the
-	// cap's kill must not settle it before it emits its last line. On POSIX a
-	// child's writes to a pipe are asynchronous (they are synchronous only on
+	// The child ignores SIGTERM for the same reason the noisy-child test above
+	// does (line 82): the cap's kill must not settle it before it emits its
+	// last line. On POSIX a child's writes to a pipe are asynchronous (they
+	// are synchronous only on
 	// Windows), so the 100 KB of filler is still queued in the child when the
 	// cap trips on the parent's first read. A child that takes the default
 	// SIGTERM disposition dies with that queue unflushed, and `late-rescue`

--- a/tests/clients/safe-spawn-ambient-signal.test.ts
+++ b/tests/clients/safe-spawn-ambient-signal.test.ts
@@ -111,45 +111,14 @@ describe("safeSpawnAsync ambient abort signal (#197)", () => {
 	// then timed out (or was interrupted) carries the flag under a timeout/abort
 	// failure. Those endings own their own classification; only the cap's own
 	// SIGTERM (or a tool that beat it out the door) is a truncation verdict.
-	// Both children ignore SIGTERM so the cap's kill cannot settle them first.
-	it("reports a capped run that then timed out as a timeout, not a truncation", async () => {
-		const result = await safeSpawnAsync(
-			NODE,
-			[
-				"-e",
-				"process.on('SIGTERM', () => {}); setInterval(() => process.stdout.write('x'.repeat(4096)), 1);",
-			],
-			{ timeout: 300, maxOutputBytes: 1024 },
-		);
+	//
+	// #2225: the two "capped-then-timeout"/"capped-then-aborted" cases that used
+	// to live here raced a real child's stdout against a real 300ms timer —
+	// flaky under CPU load (5/8 concurrent runs failing). They now live in
+	// safe-spawn-cap-race.test.ts, mocked so the cap trips before the
+	// timeout/abort by construction instead of by timing.
 
-		expect(result.outputTruncated).toBe(true);
-		expect(result.killedForOutputCap).toBe(true);
-		expect(result.failure).toBe("timeout");
-		expect(truncatedByOutputCap(result)).toBe(false);
-		expect(killedForOutputCap(result)).toBe(false);
-	});
-
-	it("reports a capped run that was then aborted as an abort, not a truncation", async () => {
-		const controller = new AbortController();
-		setTimeout(() => controller.abort(), 300).unref();
-
-		const result = await safeSpawnAsync(
-			NODE,
-			[
-				"-e",
-				"process.on('SIGTERM', () => {}); setInterval(() => process.stdout.write('x'.repeat(4096)), 1);",
-			],
-			{ timeout: 10_000, maxOutputBytes: 1024, signal: controller.signal },
-		);
-
-		expect(result.outputTruncated).toBe(true);
-		expect(result.killedForOutputCap).toBe(true);
-		expect(result.failure).toBe("aborted");
-		expect(truncatedByOutputCap(result)).toBe(false);
-		expect(killedForOutputCap(result)).toBe(false);
-	});
-
-	// The child ignores SIGTERM for the same reason the two tests above do: the
+	// The child ignores SIGTERM for the same reason the two moved tests above did: the
 	// cap's kill must not settle it before it emits its last line. On POSIX a
 	// child's writes to a pipe are asynchronous (they are synchronous only on
 	// Windows), so the 100 KB of filler is still queued in the child when the

--- a/tests/clients/safe-spawn-cap-race.test.ts
+++ b/tests/clients/safe-spawn-cap-race.test.ts
@@ -1,0 +1,158 @@
+/**
+ * #2225 — the output-cap kill (`stopForOutputLimit`) and the timeout/abort
+ * kill are two independent real-time races in `safe-spawn.ts`: whichever
+ * fires first — a real child's stdout 'data' event, or a wall-clock
+ * `setTimeout`/`AbortSignal` — decides `killedForOutputCap`. Driving that
+ * race with an actual spawned child (as `safe-spawn-ambient-signal.test.ts`
+ * originally did) makes the test itself timing-dependent: under CPU
+ * starvation from other concurrent processes, Node's event loop runs its
+ * timers phase before delivering already-arrived pipe data in the poll
+ * phase, so a real 300ms timer can beat a child that already wrote its
+ * capped output. Measured 5 of 8 concurrent vitest processes failing on
+ * both master and an unrelated feature branch (#2225's evidence).
+ *
+ * This file removes the real-time race BY CONSTRUCTION: `node:child_process`
+ * is mocked (the established `fake-child.ts` double, also used by
+ * `safe-spawn-close-before-error-race.test.ts` and
+ * `safe-spawn-windows-env-plumbing.test.ts`), so the "child wrote enough to
+ * trip the cap" signal is a synchronous `EventEmitter.emit("data", ...)`
+ * call the test issues itself — ordered relative to the timeout/abort
+ * trigger by the test's own statement order, not by an OS scheduler. A
+ * microtask flush always runs before a macrotask (Node/JS engine guarantee,
+ * independent of machine load), so awaiting one microtask after the mocked
+ * spawn call, before firing the timeout timer or the abort signal, makes the
+ * cap-trips-first ordering deterministic rather than probable.
+ *
+ * `process.platform` is pinned to "linux" for the run (posixProcessGroup
+ * path in `killTree`) so the kill goes through the mocked `process.kill`
+ * directly, without a nested nested-`spawn()` `taskkill` call to also mock —
+ * the Windows-only branch has its own dedicated coverage elsewhere
+ * (`safe-spawn-windows-*.test.ts`) and isn't what this race is about.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeFakeChild } from "../support/fake-child.js";
+import {
+	killedForOutputCap,
+	truncatedByOutputCap,
+} from "../../clients/spawn-output-cap.js";
+
+const spawnMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+	spawn: (...args: unknown[]) => spawnMock(...args),
+	spawnSync: () => ({ stdout: "", stderr: "", status: 0, error: undefined }),
+}));
+
+vi.mock("../../clients/resource-sampler.js", () => ({
+	startSpawnUsageSampler: () => ({ stop: () => null }),
+}));
+
+vi.mock("../../clients/latency-logger.js", () => ({
+	logLatency: () => {},
+}));
+
+const { safeSpawnAsync } = await import("../../clients/safe-spawn.js");
+
+// A real absolute path so command resolution (Windows-only) never gets in
+// the way — this run always pins to the POSIX branch anyway.
+const REAL_ABSOLUTE_COMMAND = process.execPath;
+
+describe("safeSpawnAsync sequences the output-cap kill before timeout/abort by construction (#2225)", () => {
+	const realPlatform = process.platform;
+	let killSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		Object.defineProperty(process, "platform", {
+			value: "linux",
+			configurable: true,
+		});
+		// Never send a real signal to a real pid — `child.pid` below is a
+		// fabricated number that could coincidentally name a live process.
+		killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process, "platform", {
+			value: realPlatform,
+			configurable: true,
+		});
+		killSpy.mockRestore();
+		vi.useRealTimers();
+		spawnMock.mockReset();
+	});
+
+	it("reports a capped run that then timed out as a timeout, not a truncation", async () => {
+		const child = makeFakeChild(4242);
+		spawnMock.mockImplementation(() => {
+			queueMicrotask(() => {
+				// Exceeds the 1024-byte cap in a single chunk — a synchronous JS
+				// call, not a real child's OS-scheduled write, so there's no
+				// window for the timer below to win a real race.
+				child.stdout.emit("data", "x".repeat(4096));
+			});
+			return child;
+		});
+
+		const resultPromise = safeSpawnAsync(REAL_ABSOLUTE_COMMAND, ["-e", ""], {
+			timeout: 300,
+			maxOutputBytes: 1024,
+		});
+
+		// Flush the microtask queue: the data emit above runs and trips the
+		// cap (killedForOutputCap = true) BEFORE the timer below is allowed
+		// to advance at all — ordered by construction, not by wall time.
+		await Promise.resolve();
+		await Promise.resolve();
+		await vi.advanceTimersByTimeAsync(300);
+
+		// The child ignores the cap's SIGTERM and lingers, mirroring the
+		// SIGTERM-hardy children the real-process version of this test used —
+		// `timedOut` still latches from the timer above while the process is
+		// still alive.
+		child.emit("exit", null, "SIGTERM");
+		child.emit("close", null, "SIGTERM");
+
+		const result = await resultPromise;
+
+		expect(result.outputTruncated).toBe(true);
+		expect(result.killedForOutputCap).toBe(true);
+		expect(result.failure).toBe("timeout");
+		expect(truncatedByOutputCap(result)).toBe(false);
+		expect(killedForOutputCap(result)).toBe(false);
+	});
+
+	it("reports a capped run that was then aborted as an abort, not a truncation", async () => {
+		const child = makeFakeChild(4242);
+		spawnMock.mockImplementation(() => {
+			queueMicrotask(() => {
+				child.stdout.emit("data", "x".repeat(4096));
+			});
+			return child;
+		});
+
+		const controller = new AbortController();
+		const resultPromise = safeSpawnAsync(REAL_ABSOLUTE_COMMAND, ["-e", ""], {
+			timeout: 10_000,
+			maxOutputBytes: 1024,
+			signal: controller.signal,
+		});
+
+		// Same construction as above: let the cap trip first, THEN abort —
+		// the test drives both steps directly, no race to win.
+		await Promise.resolve();
+		await Promise.resolve();
+		controller.abort();
+
+		child.emit("exit", null, "SIGTERM");
+		child.emit("close", null, "SIGTERM");
+
+		const result = await resultPromise;
+
+		expect(result.outputTruncated).toBe(true);
+		expect(result.killedForOutputCap).toBe(true);
+		expect(result.failure).toBe("aborted");
+		expect(truncatedByOutputCap(result)).toBe(false);
+		expect(killedForOutputCap(result)).toBe(false);
+	});
+});

--- a/tests/clients/spawn-timeout-cooldown.test.ts
+++ b/tests/clients/spawn-timeout-cooldown.test.ts
@@ -154,30 +154,45 @@ describe("tryMarkdownlintFix consults the seam (review P2)", () => {
 		safeSpawnAsync.mockReset();
 	});
 
-	it("returns 0 WITHOUT spawning when its resolved command is cooling down", async () => {
-		const env = setupTestEnvironment("pi-lens-timeout-pipeline-guard-");
-		try {
-			const filePath = path.join(env.tmpDir, "notes.md");
-			fs.writeFileSync(filePath, "# hello\n");
-			const { noteSpawnTimeout } = await seam();
-			// The mocked resolver returns the bare tool id; in production both
-			// lanes resolve the same physical binary, and basename-level
-			// keying is what makes different spellings cross-cool.
-			noteSpawnTimeout({
-				tool: "markdownlint",
-				command: "markdownlint",
-				phase: "availability",
-			});
+	it(
+		"returns 0 WITHOUT spawning when its resolved command is cooling down",
+		// #2235: this test pairs real filesystem I/O (setupTestEnvironment,
+		// writeFileSync) with a dynamic import of pipeline.js — a genuinely
+		// heavy module graph, measured at ~1.5s to resolve on an idle machine.
+		// The default 5000ms budget has only ~3x margin, which several
+		// concurrent vitest workers or sibling agent worktrees building/testing
+		// at once reliably exhaust: reproduced locally under synthetic 14-worker
+		// CPU load as a hard 5020ms timeout (vs. 1537ms idle), a ~3.3x slowdown
+		// this budget doesn't survive. 20s matches the margin already used
+		// elsewhere in this suite for real-spawn/real-import paths (e.g.
+		// safe-spawn-timeout-teardown.test.ts's 15-20s budgets) and comfortably
+		// covers the measured slowdown with headroom to spare.
+		{ timeout: 20_000 },
+		async () => {
+			const env = setupTestEnvironment("pi-lens-timeout-pipeline-guard-");
+			try {
+				const filePath = path.join(env.tmpDir, "notes.md");
+				fs.writeFileSync(filePath, "# hello\n");
+				const { noteSpawnTimeout } = await seam();
+				// The mocked resolver returns the bare tool id; in production both
+				// lanes resolve the same physical binary, and basename-level
+				// keying is what makes different spellings cross-cool.
+				noteSpawnTimeout({
+					tool: "markdownlint",
+					command: "markdownlint",
+					phase: "availability",
+				});
 
-			const pipeline = await import("../../clients/pipeline.js");
-			const fixed = await pipeline.tryMarkdownlintFix(filePath, env.tmpDir);
+				const pipeline = await import("../../clients/pipeline.js");
+				const fixed = await pipeline.tryMarkdownlintFix(filePath, env.tmpDir);
 
-			expect(fixed).toBe(0);
-			expect(safeSpawnAsync).not.toHaveBeenCalled();
-		} finally {
-			env.cleanup();
-		}
-	});
+				expect(fixed).toBe(0);
+				expect(safeSpawnAsync).not.toHaveBeenCalled();
+			} finally {
+				env.cleanup();
+			}
+		},
+	);
 });
 
 describe("cross-lane key sharing (review P2)", () => {


### PR DESCRIPTION
## Summary

Three test files that fail only under machine load, not for a code reason:

1. **`safe-spawn-ambient-signal.test.ts`** — two tests raced a real spawned
   child's stdout against a real 300ms timeout/abort to prove the output cap
   trips first. Measured 5/8 failures under 8 concurrent vitest processes, on
   master and on an unrelated feature branch (#2225's own evidence). Moved to
   a new `safe-spawn-cap-race.test.ts` that mocks `node:child_process`, so
   the cap trip is a synchronous `EventEmitter.emit` the test drives itself —
   sequenced ahead of the timeout/abort by construction, not by which
   process wins a scheduler race.
2. **`spawn-timeout-cooldown.test.ts`** — one test pairs real filesystem I/O
   with a dynamic import of `pipeline.js` (~1.5s idle) inside vitest's
   5000ms default. Raised to a 20s budget.
3. **`managed-tool-refresh-strategies.test.ts`** — more instances of the
   dangling-promise-contamination shape PR #2216 fixed for one test. A
   file-wide `vi.setConfig({ testTimeout: 20_000 })` replaces per-test
   patching.

Refs #2225, Refs #2235, Refs #2182 — none close: #2182 has a named remainder
(see "What's not fixed" below), and #2225/#2235 are single-item issues whose
acceptance criteria are met but I'm leaving them open for the orchestrator's
close call.

A vitest test that hits its timeout gets killed, but the promise chain it
was awaiting keeps running — vitest doesn't cancel it. If that straggler
later mutates a mock or module state a DIFFERENT test reads, the wrong test
fails. Under any of these three shapes, raising the affected test's own
budget (or removing the real-timer race entirely) stops the straggler from
ever being created.

## Root cause per issue

- **#2225**: `safe-spawn.ts`'s output-cap kill (`stopForOutputLimit`, fired
  from a real 'data' event) and the timeout/abort kill (a real `setTimeout`/
  `AbortSignal`) are two independent real-time races. Under CPU starvation,
  Node's event loop runs its timers phase before delivering already-arrived
  pipe data in the poll phase, so a real timer can beat a child that already
  wrote its capped output — a race the test itself introduced by using a
  real child process.
- **#2235**: the test's own real work (real FS + dynamic import) legitimately
  exceeds vitest's 5000ms default under load; not a production defect.
- **#2182**: same shape as #2235, but PR #2216 (merged) already fixed ONE
  instance with a per-test override. Verifying that fix under heavier
  synthetic load turned up more instances of the same class.

## Type of change

- [x] Bug fix

## Area

- [x] area:tests
- [x] area:dispatch
- [x] area:installer

## Tests

- **New**: `tests/clients/safe-spawn-cap-race.test.ts` — the two cap-vs-
  timeout/abort ordering tests, mocked so the ordering is deterministic.
  Mutation-proofed: reverting `killedForOutputCap`'s assignment in
  `clients/safe-spawn.ts:1620` turns both red
  (`expected undefined to be true`).
- **Edited**: `tests/clients/safe-spawn-ambient-signal.test.ts` — removed the
  two tests moved into the new file; the rest of the file (real-process
  tests for early-abort, precedence, and the plain output-cap kill) is
  untouched.
- **Edited**: `tests/clients/spawn-timeout-cooldown.test.ts` — one test now
  carries a 20s timeout instead of vitest's 5000ms default. No behavior
  assertion changed.
- **Edited**: `tests/clients/installer/managed-tool-refresh-strategies.test.ts`
  — file-wide `vi.setConfig({ testTimeout: 20_000 })` (with a scoped
  `afterAll(() => vi.resetConfig())`) replaces the single per-test override
  PR #2216 added; no test body's assertions changed.

Satisfies AGENTS.md's "loose bound" screen: none of these are widened
tolerances on a behavioral assertion — they're all timeout BUDGETS around
tests whose behavioral assertions (exact counts, exact result shapes) are
unchanged.

Red-first evidence (verbatim, my own runs):

```
× tests/clients/spawn-timeout-cooldown.test.ts > tryMarkdownlintFix
  consults the seam (review P2) > returns 0 WITHOUT spawning when its
  resolved command is cooling down 5020ms
  → Test timed out in 5000ms.
```
(reproduced under synthetic 14-worker CPU load, pre-fix)

```
✓ tests/clients/safe-spawn-cap-race.test.ts (2 tests) — pre-fix state is
  "these two tests didn't exist"; the regression proof is the mutation kill
  above plus 24/24 clean runs under 8-concurrent-process load (3 rounds).
```

Post-fix, same 14-worker load, spawn-timeout-cooldown repeat runs: 6613ms,
7913ms — inside the new 20s budget with real margin.

**#2182** red-first under the same synthetic load: 4 tests failed
(`upgrades a stale package -U` and `refreshes nothing when the stamp is
fresh` timed out at 5000ms; `degrades when the upgrade leaves a binary...`
and `swapExtractedDir rollback...` got corrupted downstream state — the
contamination signature). With the per-test budget temporarily raised to
30s to observe genuine completion time: 8932ms and 15086ms for the two pip
tests. Post-fix (file-wide 20s default): 7 consecutive clean 8-worker-load
runs of the combined suite (installer + both degradation-ledger files).

### Test assessment

- `safe-spawn-ambient-signal.test.ts`: pins ambient-signal defaulting/
  precedence/clearing (unique, untouched) plus the plain output-cap kill and
  late-output-retention tests (unique, untouched, still real-process — no
  timer race in either). No redundancy created.
- `safe-spawn-cap-race.test.ts` (new): pins the cap-before-timeout/abort
  ordering contract that used to live in the file above. Fully replaces
  those two tests; nothing is now redundant across the two files.
- `spawn-timeout-cooldown.test.ts`: unchanged behavioral coverage, no
  removal candidates.
- `managed-tool-refresh-strategies.test.ts`: unchanged behavioral coverage,
  no removal candidates.

## Blast radius

Test-only changes. No production module touched — `clients/safe-spawn.ts`,
`clients/pipeline.js`, and the managed-tool-refresh runner are read-only
dependencies of these test files, not edited. No hot path affected.

## Observability

Not applicable — test-suite reliability only, no production code path
changed. (Matches #2235's own issue text: "no production log record
applies.")

## Class sweep

**Pattern**: "real timer/real subprocess race used as a test's own
synchronization primitive" — grepped `tests/` (not just `tests/clients/`)
for `setTimeout(() => controller.abort()` and bare wall-clock races against
`safeSpawnAsync`/`safeSpawn`: only the two tests moved into
`safe-spawn-cap-race.test.ts` had this exact shape. The plain output-cap
test and the late-output-retention test in `safe-spawn-ambient-signal.test.ts`
also spawn real processes but assert against real completion (no competing
timer), so they're not in this class.

**Population**: "dangling-promise-contamination from an unbudgeted real-
work test" (#2182's own class) — checked every `describe` block in
`managed-tool-refresh-strategies.test.ts` under synthetic load (12-, 14-,
and 16-worker rounds): pip-strategy (2 members, fixed via the file-wide
budget), verification-budget-delivery's pip case (1 member, fixed), gem-
strategy's install-command test (1 member — did NOT reproduce as timeout-
shaped; left as the named #2182 remainder, see below). Also checked
`tests/clients/*.ts` for other files combining `vi.resetModules()` with a
dynamic `pipeline.js` import (the #2235 shape): 6 files import `pipeline.js`
dynamically, only `spawn-timeout-cooldown.test.ts` also calls
`vi.resetModules()` per test — the other 5 (`opaque-mutation-scan`,
`runtime-agent-end`, `runtime-tool-result-debounce`, `runtime-tool-result`,
`write-autofix-nudge-suppression`) don't reset modules, so their import is a
normal cached one, not this shape. Consolidation: the pip/verification-
budget instances are folded onto one file-wide `vi.setConfig` (this PR); the
gem-strategy shared-state instance is NOT folded in here — it's a different
defect shape and stays open on #2182.

## What's NOT fixed here (refs, not closes, on #2182)

Under sufficiently extreme synthetic load (16 workers sustained), a
DIFFERENT, genuinely shared-mutable-state race surfaced in
`managed-tool-refresh-strategies.test.ts` — not timeout-shaped (the
offending test itself finished in ~3s). "gem strategy > re-runs the install
command" and, once, "pip strategy > degrades once and keeps the recorded
version when pip fails" lost expected state from `installSpawns()`/
`outcome.refreshed`. This points at concurrent-in-time promise settlement
touching shared module state (`TEST_HOME`, the mock's own arrays) rather
than a starved budget, and needs its own root-cause pass. I will comment on
#2182 naming this remainder; the issue stays open.

## Verification

Targeted + all governance sweeps green: `bounded-telemetry-sweep`,
`bus-producer-coverage`, `delivery-surface-ratchet`, `deps-centralization`,
`finding-delivery-gate`, `freshness-sweep`, `managed-tool-seam-coverage`,
`profiling-coverage`, `session-state-conformance`, `module-instance-coverage`,
`sweep-floor-coverage` — 162/162 passing. Symbol grep for
`killedForOutputCap`/`truncatedByOutputCap` sibling `shared-checkout-guard.test.ts`
also green (35/35). Full suite deferred to CI.

## Merge order

No open PR touches these files (`gh pr list` at branch-cut time: only
#2256 and #2243, neither overlapping). `origin/master` had not moved past
this branch's base at PR-open time.



## Review round 1

Reviewer verdict: FIX-ROUND, one MED finding, one LOW finding.

- **F1 (MED, fixed)**: `managed-tool-refresh-strategies.test.ts` kept a
  per-test `25_000ms` override on "degrades when the upgrade leaves a
  binary..." alongside the file-wide `vi.setConfig` — contradicting the PR
  body's "single mechanism" claim and #2182 AC2. Its own worst-case
  measurement (15086ms) only had a 1.33x margin against the file's 20_000ms
  default anyway. Raised the file default to `25_000` (1.66x margin over
  15086ms) and deleted the override — one mechanism, sized for the worst
  member, no other test carries its own override.
- **F2 (LOW, fixed)**: the #2225 move into `safe-spawn-cap-race.test.ts`
  silently dropped real-process coverage for the two moved interleavings
  (cap racing a timeout, cap racing an abort) without saying so. Now stated
  plainly in `safe-spawn-ambient-signal.test.ts`'s header comment, citing
  the real-child coverage that survives unaffected: "kills a noisy child..."
  (line 82) and "retains late output..." (line 129) — no competing timer in
  either, so no race was introduced or removed there. Fixed the stale "the
  two moved tests above" comment (nothing sits above it anymore). Noted in
  the installer file's header that 8932ms/15086ms are load-induced — idle,
  the same two tests measure 552ms/348ms.

Merged `origin/master` (7 commits, word-index occupancy-guard work; no
overlap with these files, clean merge, re-verified: targeted files 95/95,
governance sweeps 162/162). Head: `3031f55b`.
