### PR TITLE
fix(tests): close #2088 sweep-floor remainders R1/R2 (refs #2088)

### DIFF
--- a/.changelog/fix-2088-floor-remainders-r3.md
+++ b/.changelog/fix-2088-floor-remainders-r3.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Close two named remainders from the #2088 sweep-floor fix (refs #2088)** — the sweep-floor meta-sweep now recognizes the `expect(x.length).toBe(0)` emptiness spelling (14 test files use it, previously invisible to the census), and `managed-tool-seam-coverage` gained a positive control on its `safeSpawnAsync(` detector so a regex that stops matching fails loud instead of reading as zero violations.

--- a/tests/clients/managed-tool-seam-coverage.test.ts
+++ b/tests/clients/managed-tool-seam-coverage.test.ts
@@ -58,6 +58,7 @@ describe("managed-tool client seam coverage (#1290)", () => {
 
 		const violations: string[] = [];
 		let ensureToolSignal = 0;
+		let safeSpawnAsyncSignal = 0;
 		for (const file of files) {
 			const relative = path.relative(CLIENTS, file).split(path.sep).join("/");
 			const source = fs
@@ -72,6 +73,11 @@ describe("managed-tool client seam coverage (#1290)", () => {
 			for (const match of source.matchAll(
 				/\bsafeSpawnAsync\s*\(\s*["']([^"']+)["']/g,
 			)) {
+				// #2088 fix round 3, R2: counted for EVERY match, not just the
+				// managed-command subset filtered below -- a positive control on
+				// the regex itself, not on the (already-controlled) violation
+				// path it feeds.
+				safeSpawnAsyncSignal++;
 				if (
 					MANAGED_COMMANDS.has(match[1]) &&
 					relative !== "dispatch/runners/utils/runner-helpers.ts"
@@ -88,6 +94,18 @@ describe("managed-tool client seam coverage (#1290)", () => {
 		assertNonEmptyScan(
 			"managed-tool-seam-coverage: ensureTool( detector signal",
 			ensureToolSignal,
+			13,
+		);
+		// #2088 fix round 3, R2: the review found this detector had NO positive
+		// control at all -- a `safeSpawnAsync(` call shape that stopped
+		// matching (a refactor to a wrapper function, a rename, a different
+		// call convention) would leave `violations` empty forever, which reads
+		// identical to "no bare managed spawns exist" with zero evidence
+		// behind it. 26 literal safeSpawnAsync(<string>) sites measured
+		// 2026-08-27; half rounded up is 13.
+		assertNonEmptyScan(
+			"managed-tool-seam-coverage: safeSpawnAsync( detector signal",
+			safeSpawnAsyncSignal,
 			13,
 		);
 		expect(violations).toEqual([]);

--- a/tests/config/sweep-floor-coverage.test.ts
+++ b/tests/config/sweep-floor-coverage.test.ts
@@ -21,28 +21,35 @@ const SELF = "tests/config/sweep-floor-coverage.test.ts";
  * production-symbol list remains an intent exception for registries whose
  * walk is not syntactically obvious. Static detection is evadable by
  * construction; this catches natural shapes, while the exception list catches
- * intent.
+ * intent. Exported as a pure function (source in, boolean out) so the
+ * emptiness alternation can be unit-tested against literal snippets, not
+ * only inferred from a whole-tree census.
  */
+export function looksSweepShaped(source: string): boolean {
+	const enumerates =
+		/(?:fs\.readdirSync|(?<![A-Za-z0-9_$])readdirSync|fs\.promises\.readdir|(?<![A-Za-z0-9_$.])readdir(?!Sync)|globSync|listSourceFiles|clientSourceFiles)/.test(
+			source,
+		) ||
+		/(?:assertNonEmptyScan|auditRegistry|scanDualInstanceImports|LSP_SERVERS|LSP_FIXTURES|ALL_FORMATTERS|DYNAMIC_OR_EXEMPT|isTimingSensitive|scanHostEventShapeViolations)/.test(
+			source,
+		);
+	// #2088 fix round 3, R1: the mainstream `expect(x.length).toBe(0)`
+	// spelling (14 existing test files use it) was missing from this
+	// alternation, so a sweep written that way never registered as
+	// sweep-shaped at all -- invisible to the meta-sweep, not merely
+	// unfloored.
+	const empties =
+		/\.toEqual\(\s*\[\s*\]\s*\)|\.toHaveLength\(\s*0\s*\)|\.toStrictEqual\(\s*\[\s*\]\s*\)|\.length\s*\)\s*\.toBe\(\s*0\s*\)/.test(
+			source,
+		);
+	return enumerates && empties;
+}
+
 function sweepShapeFiles(): string[] {
 	return listSourceFiles(TESTS_ROOT, { extensions: [".ts"] })
 		.filter((file) => file.endsWith(".test.ts"))
 		.filter((file) => relativePosix(REPO_ROOT, file) !== SELF)
-		.filter((file) => {
-			const raw = fs.readFileSync(file, "utf8");
-			const source = stripSource(raw);
-			const enumerates =
-				/(?:fs\.readdirSync|(?<![A-Za-z0-9_$])readdirSync|fs\.promises\.readdir|(?<![A-Za-z0-9_$.])readdir(?!Sync)|globSync|listSourceFiles|clientSourceFiles)/.test(
-					source,
-				) ||
-				/(?:assertNonEmptyScan|auditRegistry|scanDualInstanceImports|LSP_SERVERS|LSP_FIXTURES|ALL_FORMATTERS|DYNAMIC_OR_EXEMPT|isTimingSensitive|scanHostEventShapeViolations)/.test(
-					source,
-				);
-			const empties =
-				/\.toEqual\(\s*\[\s*\]\s*\)|\.toHaveLength\(\s*0\s*\)|\.toStrictEqual\(\s*\[\s*\]\s*\)/.test(
-					source,
-				);
-			return enumerates && empties;
-		});
+		.filter((file) => looksSweepShaped(stripSource(fs.readFileSync(file, "utf8"))));
 }
 
 const DECLARED_EXCEPTIONS: Readonly<Record<string, string>> = {
@@ -160,20 +167,59 @@ describe("registered-or-fail sweep floors", () => {
 			flagged: files,
 			registered,
 			exemptions: DECLARED_EXCEPTIONS,
-			// Calibration: 781 test files walked on 2026-08-26 (fix round 2, post
-			// master-merge); half is 391, rounded up to the documented 400 floor.
+			// Calibration: 831 test files walked on 2026-08-27 (fix round 3, #2088
+			// R1: the `.length).toBe(0)` alternation added above pulled 3 more
+			// already-registered sweep files into the census); half is 416,
+			// rounded up to the documented 420 floor.
 			scannedCount,
-			minScanned: 400,
-			// Calibration: this census flags 55 sweep-shaped files on 2026-08-26
-			// (fix round 2) -- 10 registered via assertNonEmptyScan/minScanned, 45
-			// declared exceptions. Half of 55 rounded up is 28. Earlier figures
-			// (13 in this comment, 40 in the PR body table) were both stale by the
-			// time the exception list finished growing to 46 entries in round 1.
+			minScanned: 420,
+			// Calibration: this census flags 58 sweep-shaped files on 2026-08-27
+			// (fix round 3) -- 13 registered via assertNonEmptyScan/minScanned, 45
+			// declared exceptions. Half of 58 rounded up is 29. Earlier figures (28
+			// for a census of 55) were accurate as of round 2 but went stale the
+			// moment the R1 regex fix changed what counts as sweep-shaped.
 			// Recalibrate by reading this test's OWN measured numbers, not by
 			// copying a figure from a comment or a PR body.
-			minFlagged: 28,
+			minFlagged: 29,
 			minReasonLength: 20,
 		});
 		expect(audit.problems, audit.problems.join("\n")).toEqual([]);
+	});
+});
+
+describe("looksSweepShaped emptiness detection (#2088 fix round 3, R1)", () => {
+	const enumerateLine = "for (const f of fs.readdirSync(dir)) { use(f); }";
+
+	// Mutation-proof: the R1 fix from a census of 55 to 58 pulled in files
+	// spelled exactly this way (grep confirms 14 existing test files use
+	// `expect(x.length).toBe(0)`). Deleting the new alternative from the
+	// `empties` regex above must red this exact case.
+	it("recognizes the expect(x.length).toBe(0) spelling", () => {
+		const source = `${enumerateLine}\nexpect(violations.length).toBe(0);`;
+		expect(looksSweepShaped(source)).toBe(true);
+	});
+
+	it("still recognizes the three previously-supported spellings", () => {
+		expect(
+			looksSweepShaped(`${enumerateLine}\nexpect(violations).toEqual([]);`),
+		).toBe(true);
+		expect(
+			looksSweepShaped(`${enumerateLine}\nexpect(violations).toHaveLength(0);`),
+		).toBe(true);
+		expect(
+			looksSweepShaped(
+				`${enumerateLine}\nexpect(violations).toStrictEqual([]);`,
+			),
+		).toBe(true);
+	});
+
+	it("does not flag an enumeration with no emptiness assertion at all", () => {
+		expect(
+			looksSweepShaped(`${enumerateLine}\nexpect(violations.length).toBe(3);`),
+		).toBe(false);
+	});
+
+	it("does not flag an emptiness assertion with no enumeration", () => {
+		expect(looksSweepShaped("expect(x.length).toBe(0);")).toBe(false);
 	});
 });

--- a/tests/config/sweep-floor-coverage.test.ts
+++ b/tests/config/sweep-floor-coverage.test.ts
@@ -49,7 +49,9 @@ function sweepShapeFiles(): string[] {
 	return listSourceFiles(TESTS_ROOT, { extensions: [".ts"] })
 		.filter((file) => file.endsWith(".test.ts"))
 		.filter((file) => relativePosix(REPO_ROOT, file) !== SELF)
-		.filter((file) => looksSweepShaped(stripSource(fs.readFileSync(file, "utf8"))));
+		.filter((file) =>
+			looksSweepShaped(stripSource(fs.readFileSync(file, "utf8"))),
+		);
 }
 
 const DECLARED_EXCEPTIONS: Readonly<Record<string, string>> = {


### PR DESCRIPTION
## Summary

Closes two named remainders from #2088's fix-round-2 review (PR #2094): the meta-sweep's missing `expect(x.length).toBe(0)` emptiness spelling (R1), and `managed-tool-seam-coverage`'s missing positive control on its `safeSpawnAsync(` detector (R2). Refs #2088.

PR #2094 shipped population floors for the six hand-rolled sweeps #2088 named, plus a meta-sweep that registers or exempts every sweep-shaped test file in the tree. The round-2 review found two residuals in that work, quoted from the issue thread:

> R1: the meta-sweep's emptiness detection matches `.toEqual([])` / `.toHaveLength(0)` / `.toStrictEqual([])` but NOT `expect(x.length).toBe(0)` — a mainstream spelling appearing in 14 existing test files.
>
> R2: `managed-tool-seam-coverage`'s second detector (the `safeSpawnAsync` managed-command regex) has no positive control — a never-matching regex stays green; the control must count the 24 literal `safeSpawnAsync` sites.

R1 is the more serious of the two: a sweep written with the missing spelling was invisible to the census entirely, not merely unfloored — a stronger failure mode than the one #2088 itself was filed against.

## Fix round 1 (adversarial review)

**F7.** `npm run fmt` reformatted a line in `sweep-floor-coverage.test.ts` oxfmt wanted wrapped differently. No behavior change.

## Changes

- **R1**: extracted `sweepShapeFiles`'s inline shape check into a pure, exported `looksSweepShaped(source)` function, and added the missing `.length).toBe(0)` alternation to its emptiness regex. This pulled 3 more already-registered sweep files into the flagged set (55 -> 58, all three already register via `assertNonEmptyScan`, so no new exemption entries were needed). Recalibrated `minScanned`/`minFlagged` to the freshly measured population (831 test files walked, 58 flagged) instead of carrying the round-2 figures forward.
- **R2**: added a `safeSpawnAsyncSignal` counter incremented for every regex match (not just the managed-command subset that feeds violations), floored via `assertNonEmptyScan` at 13 (26 literal `safeSpawnAsync(<string>)` sites measured 2026-08-27 — the issue's "24" was accurate as of 2026-08-26; the tree moved). Mirrors the existing `ensureTool(` positive control immediately above it.

Both extend `sweep-kit`'s `assertNonEmptyScan`, per the #2088 root cause: hand-rolled sweeps skip the kit that already solves this. No second floor mechanism was built.

## Tests

- `tests/config/sweep-floor-coverage.test.ts`: extracted and exported `looksSweepShaped`; added `looksSweepShaped emptiness detection (#2088 fix round 3, R1)` (4 unit cases: the new spelling, the three prior spellings, an enumeration with no matching assertion, an assertion with no enumeration). Recalibrated the meta-sweep's own `minScanned`/`minFlagged`.
- `tests/clients/managed-tool-seam-coverage.test.ts`: added the `safeSpawnAsyncSignal` positive-control floor (R2), same test file, no new `it()` block — folded into the existing single-assertion sweep test, matching that file's existing shape for the `ensureTool(` control right above it.

### Test assessment

- `looksSweepShaped`'s 4 new unit cases are the only tests in this repo that pin the meta-sweep's OWN detection logic directly, independent of the whole-tree census. Before this PR, the only way to notice a detection-regex regression was the meta-sweep's aggregate pass/fail against the live tree — informative that something broke, uninformative about which spelling broke. These tests are file-specific: red on the exact broken alternation, green otherwise.
- The R2 floor has no dedicated new test file/case; it's inline in the existing sweep assertion, matching the pattern the R2 finding itself pointed at (the `ensureTool(` control right above it, also inline, also with no separate test).

## Verification

Red-first for both R1 and R2 (initial fix).

R1 (extracted `looksSweepShaped`, mutated to remove the new alternation, kept the new unit tests):

```
FAIL tests/config/sweep-floor-coverage.test.ts > looksSweepShaped emptiness detection (#2088 fix round 3, R1) > recognizes the expect(x.length).toBe(0) spelling
AssertionError: expected false to be true
 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

R2 (renamed the detector regex to a never-matching pattern):

```
FAIL tests/clients/managed-tool-seam-coverage.test.ts > managed-tool client seam coverage (#1290) > keeps ensureTool and bare managed-tool spawns behind shared wrappers
Error: managed-tool-seam-coverage: safeSpawnAsync( detector signal: scanned/matched 0, below the declared floor of 13.
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Restored both fixes, rebuilt, reran: `Test Files 2 passed (2)`, `Tests 6 passed (6)`.

Fix round 1 (F7, fmt-only) is non-behavioral; reran the same two files plus `npm run lint`/`npm run build` after the reformat — unchanged, still green.

Also ran individually (avoiding the concurrent-suite resource contention that produced one environmental timeout on an unrelated file during an earlier combined run — confirmed by rerunning that file alone, which passed in 2.1s): `session-state-conformance` (83), `module-instance-coverage` (4), `freshness-sweep` + `formatter-policy-consistency` (14), `host-event-shape-scan` (6), `dispatch-coverage` + `timing-sensitive-coverage` + `lsp-fixture-coverage` (8). All green. Full suite deferred to CI.

## Blast radius

`looksSweepShaped`'s widened emptiness regex is a RATCHET WIDENING, not a narrowing: any in-flight or future PR that adds a new test file matching BOTH the enumeration shape (a `readdirSync`/`assertNonEmptyScan`/etc. call) AND the `expect(x.length).toBe(0)` emptiness shape newly trips the sweep-floor meta-sweep the moment it lands on top of this branch, and needs a registration line (either `assertNonEmptyScan`/`auditRegistry` in that file, or a declared exception here) to stay green. `master` is green today (this PR's own recalibration accounts for every file already on `master`), but the NEXT PR to add a file in that shape — one that doesn't yet know this regex exists — will hit a red meta-sweep it didn't cause and won't immediately understand. That is the intended enforcement (a previously-invisible sweep shape is now visible), but it is a real surprise cost for the next author, flagged here so it isn't mistaken for this PR's own breakage.

Beyond that: `looksSweepShaped` and the `safeSpawnAsyncSignal` counter are both read-only static analysis over the test tree and `clients/`; neither touches runtime code paths, so there is no production blast radius.

## Observability

The proof lives in CI output, same as the rest of this sweep family: with the floor in place, a broken detector (R1's regex, R2's `safeSpawnAsync` matcher) fails the sweep BY NAME with a specific "below the declared floor" message naming the exact count and the declared minimum, instead of reporting zero findings as if the tree were clean. No new log/ledger record — this is test-time enforcement, not a runtime record.

## Class sweep

This PR is itself the class sweep for #2088's two named residuals — no further siblings found within R1/R2's specific shapes (the emptiness-alternation gap and the missing-positive-control gap are each specific to one file). Comment posted on #2088 naming R3/R4 as remaining, unaddressed by this round.

## Scope not covered here (named remainders, staying on #2088)

- **R3** (deliberate-misuse tier, the review's own priority call): a decorative `assertNonEmptyScan` call on a hardcoded literal registers as floored without actually flooring the walk. Not addressed — lower priority than the accidental shapes R1/R2 close.
- **R4**: the ~44 bulk exemption reasons from fix round 1 remain individually unaudited against their files. A manual per-file audit, out of scope for a "small PR."

Refs #2088.
