### PR TITLE
fix(rules): honor test-file exclusions via ignores (closes #2280)

### DIFF
--- a/.changelog/2280-java-rule-ignores.md
+++ b/.changelog/2280-java-rule-ignores.md
@@ -1,1 +1,5 @@
-Fix Java ast-grep rules so test-file exclusions use the supported `ignores:` key.
+---
+section: Fixed
+---
+
+- **Move three Java rules off an inert `files:` negation glob (fixes #2280)** — `no-raw-types`, `no-string-concat-in-loop`, and `no-system-out-println` used `files: ["**/*.java", "!**/test/**"]` to carve out test files, but ast-grep 0.45.1's `files:` field has no negation support, so the exclusion silently did nothing. All three now use the real `ignores:` field ast-grep's engine honors natively, restoring the test-file carve-out.

--- a/.changelog/2280-java-rule-ignores.md
+++ b/.changelog/2280-java-rule-ignores.md
@@ -1,0 +1,1 @@
+Fix Java ast-grep rules so test-file exclusions use the supported `ignores:` key.

--- a/rules/ast-grep-rules/rules/no-raw-types.yml
+++ b/rules/ast-grep-rules/rules/no-raw-types.yml
@@ -29,4 +29,5 @@ rule:
           kind: class_literal
 files:
   - "**/*.java"
-  - "!**/test/**"
+ignores:
+  - "**/test/**"

--- a/rules/ast-grep-rules/rules/no-string-concat-in-loop.yml
+++ b/rules/ast-grep-rules/rules/no-string-concat-in-loop.yml
@@ -86,4 +86,5 @@ rule:
                       pattern: $VAR
 files:
   - "**/*.java"
-  - "!**/test/**"
+ignores:
+  - "**/test/**"

--- a/rules/ast-grep-rules/rules/no-system-out-println.yml
+++ b/rules/ast-grep-rules/rules/no-system-out-println.yml
@@ -11,5 +11,6 @@ rule:
     - pattern: System.err.print($$$)
 files:
   - "**/*.java"
-  - "!**/test/**"
-  - "!**/*Test.java"
+ignores:
+  - "**/test/**"
+  - "**/*Test.java"

--- a/tests/clients/dispatch/runners/ast-grep-rule-ignores.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-rule-ignores.test.ts
@@ -9,6 +9,10 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import * as path from "node:path";
 import astGrepNapiRunner from "../../../../clients/dispatch/runners/ast-grep-napi.js";
 import { loadYamlRules } from "../../../../clients/dispatch/runners/yaml-rule-parser.js";
+import { resolveAstGrepNativeExe } from "../../../../clients/lsp/wait-policy/strategies.js";
+import { resolveBaselineSgconfig } from "../../../../clients/sgconfig.js";
+import { safeSpawnAsync } from "../../../../clients/safe-spawn.js";
+import { createTempFile, setupTestEnvironment } from "../../test-utils.js";
 import {
 	linesFor,
 	makeRealRunnerEnv,
@@ -32,18 +36,9 @@ describe("no-console-except-error ignores CLI scripts and logger sinks (#965)", 
 			path.join(process.cwd(), "rules", "ast-grep-rules", "rules"),
 		);
 		const expected = new Map([
-			[
-				"no-raw-types",
-				["**/test/**"],
-			],
-			[
-				"no-string-concat-in-loop",
-				["**/test/**"],
-			],
-			[
-				"no-system-out-println",
-				["**/test/**", "**/*Test.java"],
-			],
+			["no-raw-types", ["**/test/**"]],
+			["no-string-concat-in-loop", ["**/test/**"]],
+			["no-system-out-println", ["**/test/**", "**/*Test.java"]],
 			[
 				"go-no-fmt-println",
 				["**/*_test.go", "**/examples/**", "tests/fixtures/**", "cases/**"],
@@ -86,31 +81,135 @@ describe("no-console-except-error ignores CLI scripts and logger sinks (#965)", 
 		const result = await astGrepNapiRunner.run(ctx);
 		expect(linesFor(result.diagnostics, "no-console-except-error")).toEqual([]);
 	});
+});
 
-	it("does not flag Java test files excluded by rule intent (#2280)", async () => {
-		const { ctx } = env.addFile(
-			"src/ExampleTest.java",
-			[
-				"import java.util.List;",
-				"class ExampleTest {",
-				"  void run() {",
-				"    List values = null;",
-				"    String text = \"\";",
-				"    for (;;) { text += values; }",
-				"    System.out.println(text);",
-				"  }",
-				"}",
-			].join("\\n"),
+/**
+ * #2280's three Java rules deliver ONLY through the real ast-grep CLI/LSP
+ * engine, never the in-process napi runner: `java` is in
+ * `AST_GREP_LSP_ONLY_RULE_LANGUAGES` (ast-grep-napi.ts), so
+ * `astGrepNapiRunner.canHandle()` returns false for a `.java` path and
+ * `run()` short-circuits to `{status: "skipped"}` before touching a rule.
+ * Driving these fixtures through `astGrepNapiRunner.run()` (the original
+ * shape of this suite) therefore always produced zero diagnostics — the
+ * assertion passed whether or not the fix worked. `matchesRuleIgnores`
+ * (ast-grep-napi.ts:471) is a pi-lens-only re-implementation of `ignores:`
+ * for the six napi grammars; it never runs for Java. `ignores:` itself is a
+ * real ast-grep rule-schema field the native binary honors on its own
+ * (issue #2280's evidence), so the only faithful probe is the real CLI
+ * against real files — exactly what the issue's acceptance criteria ask
+ * for ("Real-file probe ... not just the `ast-grep test` fixture harness").
+ *
+ * Reuses the production config-assembly seam (`resolveBaselineSgconfig`)
+ * so the merged rule set under test is byte-identical to what a live
+ * `ast-grep scan`/LSP session would load — no hand-rolled YAML.
+ */
+describe("Java rule ignores deliver through the real ast-grep CLI (#2280)", () => {
+	const astGrepExe = resolveAstGrepNativeExe();
+	const skip = !astGrepExe
+		? "no native ast-grep binary resolvable for this platform/arch"
+		: false;
+
+	interface ScanFinding {
+		file: string;
+		ruleId: string;
+	}
+
+	async function scan(cwd: string): Promise<ScanFinding[]> {
+		const configPath = resolveBaselineSgconfig(cwd);
+		if (!configPath) throw new Error("no ast-grep rule sources found");
+		const result = await safeSpawnAsync(
+			astGrepExe as string,
+			["scan", "--config", configPath, "--json", cwd],
+			{ timeout: 60_000, cwd },
 		);
-		const result = await astGrepNapiRunner.run(ctx);
-		expect(
-			result.diagnostics.filter((diagnostic) =>
-				[
+		if (result.error) throw result.error;
+		try {
+			const parsed: ScanFinding[] = JSON.parse(result.stdout || "[]");
+			// ast-grep's `--json` output mixes separators on Windows (a
+			// forward-slashed drive root, backslashed path segments below
+			// it), so normalize before the suffix checks below compare paths.
+			return parsed.map((finding) => ({
+				...finding,
+				file: finding.file.split("\\").join("/"),
+			}));
+		} catch {
+			throw new Error(
+				`failed to parse ast-grep --json output: stdout=${result.stdout.slice(0, 300)} stderr=${result.stderr.slice(0, 300)}`,
+			);
+		}
+	}
+
+	// A body that trips all three rules when unfiltered: a raw `List` (no
+	// generic parameter), a `+=` string concatenation inside a `for` loop,
+	// and a `System.out.println` call.
+	const OFFENDING_BODY = [
+		"import java.util.List;",
+		"class Example {",
+		"  void run() {",
+		"    List values = null;",
+		'    String text = "";',
+		"    for (;;) { text += values; }",
+		"    System.out.println(text);",
+		"  }",
+		"}",
+		"",
+	].join("\n");
+
+	(skip ? describe.skip : describe)("with the real binary", () => {
+		let env: { tmpDir: string; cleanup: () => void };
+
+		beforeAll(() => {
+			env = setupTestEnvironment("pi-lens-java-ignores-");
+			// Non-test file: every rule should fire.
+			createTempFile(env.tmpDir, "src/Example.java", OFFENDING_BODY);
+			// `**/test/**` carve-out: fully excluded, all three rules.
+			createTempFile(env.tmpDir, "src/test/Example.java", OFFENDING_BODY);
+			// `**/*Test.java` carve-out: no-system-out-println names this glob
+			// too, but no-raw-types/no-string-concat-in-loop only ignore
+			// `**/test/**`, which an `ExampleTest.java` under `src/` does not
+			// match — so this file still fires those two.
+			createTempFile(
+				env.tmpDir,
+				"src/ExampleTest.java",
+				OFFENDING_BODY.replace(/Example/g, "ExampleTest"),
+			);
+		});
+		afterAll(() => env.cleanup());
+
+		it("fires all three rules on an ordinary Java file", async () => {
+			const findings = await scan(env.tmpDir);
+			const ids = new Set(
+				findings
+					.filter((f) => f.file.endsWith("src/Example.java"))
+					.map((f) => f.ruleId),
+			);
+			expect(ids).toEqual(
+				new Set([
 					"no-raw-types",
 					"no-string-concat-in-loop",
 					"no-system-out-println",
-				].includes(diagnostic.ruleId),
-			),
-		).toEqual([]);
+				]),
+			);
+		});
+
+		it("excludes every rule under **/test/**", async () => {
+			const findings = await scan(env.tmpDir);
+			const hits = findings.filter((f) =>
+				f.file.endsWith("src/test/Example.java"),
+			);
+			expect(hits).toEqual([]);
+		});
+
+		it("excludes only no-system-out-println on an *Test.java file", async () => {
+			const findings = await scan(env.tmpDir);
+			const ids = new Set(
+				findings
+					.filter((f) => f.file.endsWith("src/ExampleTest.java"))
+					.map((f) => f.ruleId),
+			);
+			expect(ids).toEqual(
+				new Set(["no-raw-types", "no-string-concat-in-loop"]),
+			);
+		});
 	});
 });

--- a/tests/clients/dispatch/runners/ast-grep-rule-ignores.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-rule-ignores.test.ts
@@ -33,6 +33,18 @@ describe("no-console-except-error ignores CLI scripts and logger sinks (#965)", 
 		);
 		const expected = new Map([
 			[
+				"no-raw-types",
+				["**/test/**"],
+			],
+			[
+				"no-string-concat-in-loop",
+				["**/test/**"],
+			],
+			[
+				"no-system-out-println",
+				["**/test/**", "**/*Test.java"],
+			],
+			[
 				"go-no-fmt-println",
 				["**/*_test.go", "**/examples/**", "tests/fixtures/**", "cases/**"],
 			],
@@ -73,5 +85,32 @@ describe("no-console-except-error ignores CLI scripts and logger sinks (#965)", 
 		);
 		const result = await astGrepNapiRunner.run(ctx);
 		expect(linesFor(result.diagnostics, "no-console-except-error")).toEqual([]);
+	});
+
+	it("does not flag Java test files excluded by rule intent (#2280)", async () => {
+		const { ctx } = env.addFile(
+			"src/ExampleTest.java",
+			[
+				"import java.util.List;",
+				"class ExampleTest {",
+				"  void run() {",
+				"    List values = null;",
+				"    String text = \"\";",
+				"    for (;;) { text += values; }",
+				"    System.out.println(text);",
+				"  }",
+				"}",
+			].join("\\n"),
+		);
+		const result = await astGrepNapiRunner.run(ctx);
+		expect(
+			result.diagnostics.filter((diagnostic) =>
+				[
+					"no-raw-types",
+					"no-string-concat-in-loop",
+					"no-system-out-println",
+				].includes(diagnostic.ruleId),
+			),
+		).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

Move the inert `!`-negation globs from `files:` to `ignores:` on the three
Java rules #2280 names (`no-raw-types`, `no-string-concat-in-loop`,
`no-system-out-println`). ast-grep 0.45.1's `files:` field has no negation
support, so `!**/test/**` parsed without error and silently excluded
nothing. `ignores:` is a real field the native ast-grep engine honors on
its own — the fix restores the intended test-file carve-out with no runner
code change.

Implemented by a plegma codex worker (branch pushed from its isolated
worktree); PR opened by the maintainer. Commit 5f060c8d for the rule-YAML
change; this fix round (695e6d98) rebuilds the regression test and repairs
the changelog fragment.

## Fix round (review findings)

The initial PR shipped with four review-blocking gaps. Each is fixed on
this branch:

- **F2 — changelog fragment missing front matter.** `.changelog/2280-java-rule-ignores.md`
  had no `---\nsection: Fixed\n---` header, so
  `check-changelog-fragments.mjs` exited 1. Added the header, matching
  every other fragment in `.changelog/`.
- **F3 — TS2551 in the test file.** `diagnostic.ruleId` doesn't exist on
  the `Diagnostic` type; the field is `rule`. Moot now — see F4, the whole
  block that line lived in was rebuilt.
- **F4 — the #2280 regression test could not fail.** Three compounding
  bugs:
  1. `[...].includes(undefined)` (the F3 typo) made the filter always
     return `[]`.
  2. The fixture joined lines with the literal two characters `\n`
     (`join("\\n")`), not a real newline, so the Java source was one
     malformed line.
  3. The deeper bug: the test drove the fixture through
     `astGrepNapiRunner.run()`. Java is in
     `AST_GREP_LSP_ONLY_RULE_LANGUAGES` (`ast-grep-napi.ts`) — the napi
     addon bundles six grammars (ts/tsx/js/css/html) and Java isn't one of
     them, so `canHandle()` returns false for any `.java` path and `run()`
     short-circuits to `{status: "skipped", diagnostics: []}` before a
     single rule runs. Java rules deliver exclusively through the real
     `ast-grep` CLI/LSP binary. The test's own probe against a plain
     `src/Example.java` confirmed this: `{"status":"skipped","diagnostics":[],"semantic":"none"}`.

  Rebuilt the suite to spawn the real ast-grep binary (`resolveAstGrepNativeExe`)
  against the production-assembled config (`resolveBaselineSgconfig` —
  the same seam a live `ast-grep scan`/LSP session uses, no hand-rolled
  YAML) over three real fixture files. This matches issue #2280's own
  acceptance criterion: "Real-file probe (not just the `ast-grep test`
  fixture harness, which ... never exercises `files:`/`ignores:` glob
  matching at all)."

- **F5 — this section and the red/green claims below.**

## Tests

Red-first, on this branch's own test file, with only the three rule YAMLs
reverted to `origin/master` (`git checkout origin/master -- rules/ast-grep-rules/rules/{no-raw-types,no-string-concat-in-loop,no-system-out-println}.yml`):

```
FAIL  ... > uses ignores for every VTCode Go rule and covers fixture paths (#2207)
FAIL  ... > Java rule ignores deliver through the real ast-grep CLI (#2280) > with the real binary > excludes every rule under **/test/**
FAIL  ... > Java rule ignores deliver through the real ast-grep CLI (#2280) > with the real binary > excludes only no-system-out-println on an *Test.java file

 Test Files  1 failed (1)
      Tests  3 failed | 4 passed (7)
```

Restored the fix (`git checkout HEAD -- <same three files>`) and reran the
identical command:

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Targeted + sibling suites, this session, all green: `ast-grep-rule-ignores`
(7/7), `ast-grep-rule-precedence-followups`, `ast-grep-catalog-rules`,
`sgconfig`, `ast-grep-rule-validity`, `ast-grep-rule-tests` (88/88
combined). Governance sweeps (`bounded-telemetry-sweep`,
`bus-producer-coverage`, `delivery-surface-ratchet`, `deps-centralization`,
`finding-delivery-gate`, `freshness-sweep`, `managed-tool-seam-coverage`,
`profiling-coverage`, `session-state-conformance`,
`module-instance-coverage`, `sweep-floor-coverage`): 162/162. `npm run
build` and `npm run lint` (tsc) both clean. `npm run fmt:check` (oxfmt)
clean. `node scripts/check-changelog-fragments.mjs`: `changelog fragments
OK (105 entries)`. Full suite deferred to CI, per repo policy.

### Test assessment

The rebuilt suite exercises the real delivery path (ast-grep CLI/LSP) that
Java rules actually use in production, not the napi in-process runner that
never touches `.java` files. Three fixtures cover the three exclusion
shapes that matter: an ordinary file (all three rules fire), a file under
`**/test/**` (fully excluded), and an `*Test.java` file under `src/` that
is `**/test/**`-shaped but not `**/*Test.java`-shaped for the two rules
that don't carry that second glob — see Blast radius below for why that
file only loses one of its three findings.

## Blast radius

The three rules stop firing on files under `**/test/**`; `no-system-out-println`
additionally stops firing on any `**/*Test.java` file regardless of
directory. No other file class changes. Corrected claim from the original
PR body: `no-raw-types` and `no-string-concat-in-loop` ignore only
`**/test/**` — an `ExampleTest.java` living directly under `src/` (not
under a `test/` directory) is NOT excluded from those two rules, only from
`no-system-out-println`. Verified with a real CLI probe: `src/ExampleTest.java`
containing all three trigger patterns produced `no-raw-types` and
`no-string-concat-in-loop` findings but no `no-system-out-println` finding.
Rule YAML only; no runner code touched.

Corrected attribution: the original PR body credited the napi runner's
`matchesRuleIgnores` (`ast-grep-napi.ts:471`) with honoring `ignores:` for
these rules. That function only runs in the in-process napi fallback for
the six napi-bundled languages (ts/tsx/js/css/html) — it never executes
for `.java` files. For Java, `ignores:` is honored natively by the real
`ast-grep` binary itself (CLI/LSP delivery route), independent of any
pi-lens runner code.

## Observability

No new failure path; rule matching surfaces through the existing dispatch
telemetry. Unchanged from the original PR body.

## Class sweep

Exhaustive YAML sweep across `rules/` (including `coderabbit/`): no
remaining `files:` entries starting with `!` anywhere in the tree
(re-verified this session with the same grep the issue used). Population:
the three named rules were the only members carrying the inert shape.
