### PR TITLE
fix(ci): treat a null PR body as empty, not a fetch failure (closes #2268)

### DIFF
--- a/.changelog/fix-2268-null-pr-body.md
+++ b/.changelog/fix-2268-null-pr-body.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Treat a null PR body as empty (closes #2268)** — Let PR-body and close-keyword checks report their actual validation results instead of treating an empty GitHub body as a fetch failure.

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -327,9 +327,9 @@ async function fetchLivePrBody(payloadPr, fetchImpl) {
 	);
 	if (!response.ok) throw new Error(`GitHub API returned ${response.status}`);
 	const data = await response.json();
-	if (typeof data.body !== "string")
+	if (data.body !== null && typeof data.body !== "string")
 		throw new Error("GitHub API returned no body");
-	return data.body;
+	return data.body ?? "";
 }
 
 export async function resolveLivePrBody(

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -623,9 +623,11 @@ describe("live PR body resolution (#2085)", () => {
 		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
 		vi.stubEnv("GITHUB_TOKEN", "test-token");
 		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
-		const fetchImpl = vi.fn().mockResolvedValue(
-			new Response(JSON.stringify({ body: null }), { status: 200 }),
-		);
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify({ body: null }), { status: 200 }),
+			);
 
 		try {
 			expect(await resolveLivePrBody(payloadPr, fetchImpl)).toBe("");

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -618,6 +618,23 @@ describe("live PR body resolution (#2085)", () => {
 		);
 	});
 
+	it("treats a null live body as an empty body", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ body: null }), { status: 200 }),
+		);
+
+		try {
+			expect(await resolveLivePrBody(payloadPr, fetchImpl)).toBe("");
+			expect(warning).not.toHaveBeenCalled();
+		} finally {
+			warning.mockRestore();
+		}
+	});
+
 	it.each([
 		[
 			"non-2xx",


### PR DESCRIPTION
## Summary

`resolveLivePrBody` rejected a non-string API body, and the fallback warning labeled that as a fetch failure — but `body: null` is how the API represents a genuinely empty PR body. Normalize null to "" so the section checks report the real problem (missing sections) instead of "could not fetch". Closes #2268 (filed from PR #2267's review).

Implemented by a plegma codex worker (branch pushed from its isolated worktree); PR opened by the maintainer. Commit a7b9a9e8.

## Tests

Red (pre-fix): new test with a fetch double returning body:null fails `expected 'fallback' to be ''` — the misreport path. Green after the narrow normalization. Mutation-proof: reverting the null handling reproduces the identical red. Full check-pr-body suite: 86/86. `npm run build`, `npm run lint`, changelog validation (105 entries) all pass.

### Test assessment

The null-body case is pinned directly at the seam both consumers share; malformed-shape rejections are preserved and still covered by the existing suite.

## Blast radius

Two consumers: the PR-body lint and close-keyword verification (via #2267's reuse). Both now treat an empty body as empty; neither behavior changes for real fetch failures or malformed payloads.

## Observability

The fallback warning now fires only on genuine fetch failures, making it a trustworthy signal.

## Class sweep

Swept scripts/ for other `.body` reads conflating null with failure: none. The close-keyword and title consumers already coalesce null to empty.
