### PR TITLE
fix(rules): detect edited and nested rule files in the rules cache (closes #2262)

### DIFF
--- a/.changelog/2262-rules-cache-freshness.md
+++ b/.changelog/2262-rules-cache-freshness.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Ast-grep YAML rule caches detect edited and nested files (closes #2262)** — the in-memory rules cache snapshots every YAML file with `mtimeMs` and size, then confirms content when metadata agrees. Editing an existing rule or adding a nested rule therefore invalidates the cache even when the rule directory mtime stays unchanged.
+- **Ast-grep YAML rule caches detect edited and nested files (closes #2262)** — the in-memory rules cache snapshots every YAML file with `mtimeMs` and size, re-checked at most once per 2-second cadence window. Editing an existing rule or adding a nested rule invalidates the cache even when the rule directory mtime stays unchanged; pickup lag is bounded by one cadence window.

--- a/.changelog/2262-rules-cache-freshness.md
+++ b/.changelog/2262-rules-cache-freshness.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Ast-grep YAML rule caches detect edited and nested files (closes #2262)** — the in-memory rules cache snapshots every YAML file with `mtimeMs` and size, then confirms content when metadata agrees. Editing an existing rule or adding a nested rule therefore invalidates the cache even when the rule directory mtime stays unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -803,10 +803,15 @@ guarded by `isWindowsPath` or `isFullyQualifiedWin32`; host-default path calls
 elsewhere, including the valid fallback arm of a ternary, remain allowed.
 
 The YAML ast-grep rules cache snapshots every discovered rule file with
-`mtimeMs` and size, then confirms file contents when those metadata values
-agree. It must detect edits to existing files and additions below nested rule
-directories; directory mtime alone is insufficient on supported filesystems.
-(#2262)
+`mtimeMs` and size, metadata only — no content hashing. `getCachedRules`
+serves the bundled tier, which is immutable per install, so it inherits
+`clients/cache/rule-cache.ts`'s documented content-confirm exemption; adding
+a content hash here cost a measured 8000x on a per-file hot path (#2292).
+A 2 s freshness cadence bounds re-stat work; rule-edit pickup lag is bounded
+by one cadence. It must detect edits to existing files and additions below
+nested rule directories; directory mtime alone is insufficient on supported
+filesystems. A same-size, same-mtime edit is invisible by design on this
+tier. (#2262)
 
 ### Caches, durable stores, and path keys
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -802,6 +802,12 @@ The shipped ast-grep catalog includes `no-bare-host-path-in-win32-branch`
 guarded by `isWindowsPath` or `isFullyQualifiedWin32`; host-default path calls
 elsewhere, including the valid fallback arm of a ternary, remain allowed.
 
+The YAML ast-grep rules cache snapshots every discovered rule file with
+`mtimeMs` and size, then confirms file contents when those metadata values
+agree. It must detect edits to existing files and additions below nested rule
+directories; directory mtime alone is insufficient on supported filesystems.
+(#2262)
+
 ### Caches, durable stores, and path keys
 
 Advisory caches must carry immutable capture provenance and validate it again

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
-- **Ast-grep YAML rule caches detect edited and nested files (closes #2262)** — the in-memory rules cache snapshots every YAML file with `mtimeMs` and size, then confirms content when metadata agrees. Editing an existing rule or adding a nested rule therefore invalidates the cache even when the rule directory mtime stays unchanged.
-
 ### Security
 
 ## [4.1.2] - 2026-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Ast-grep YAML rule caches detect edited and nested files (closes #2262)** — the in-memory rules cache snapshots every YAML file with `mtimeMs` and size, then confirms content when metadata agrees. Editing an existing rule or adding a nested rule therefore invalidates the cache even when the rule directory mtime stays unchanged.
+
 ### Security
 
 ## [4.1.2] - 2026-08-24

--- a/clients/dispatch/runners/yaml-rule-parser.ts
+++ b/clients/dispatch/runners/yaml-rule-parser.ts
@@ -17,6 +17,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import yaml from "../../deps/js-yaml.js";
 import { BoundedLruCache } from "../../bounded-cache.js";
+import { compareOrdinal } from "../../string-utils.js";
 
 // --- Types ---
 
@@ -78,7 +79,8 @@ export interface YamlRule {
 interface CachedRules {
 	rules: YamlRule[];
 	files: RuleFileStamp[];
-	contentSignature: string;
+	/** `Date.now()` at the last metadata stat sweep (#2262 round 2). */
+	checkedAtMs: number;
 }
 
 interface RuleFileStamp {
@@ -115,6 +117,17 @@ export const OVERLY_BROAD_PATTERNS = [
 /** Maximum complexity score for rules in blockingOnly mode */
 export const MAX_BLOCKING_RULE_COMPLEXITY = 8;
 
+/**
+ * `getCachedRules` re-stats a rule directory's files at most once per this
+ * window (#2262 round 2). `scanner.ts:235` calls `loadYamlRules` per file
+ * scanned; a full metadata sweep (readdir + stat every rule file) on every
+ * warmed call measured 250x master's per-call cost on a mid-size catalog.
+ * Same value and same shape as `file-utils.ts`'s
+ * `PROJECT_IGNORE_FRESHNESS_CADENCE_MS` (#2159/#2071): 2s is the accepted
+ * staleness bound for a rule tree pi-lens itself did not just write.
+ */
+export const RULES_CACHE_FRESHNESS_CADENCE_MS = 2_000;
+
 // --- Caches ---
 
 const rulesCache = new BoundedLruCache<string, CachedRules>(64);
@@ -139,7 +152,14 @@ function findYamlRuleFiles(ruleDir: string): string[] {
 	try {
 		entries = fs
 			.readdirSync(ruleDir, { withFileTypes: true })
-			.sort((a, b) => a.name.localeCompare(b.name));
+			// Ordinal (code-unit), not locale, comparison: this order feeds the
+			// index-aligned file-stamp identity compared in `getCachedRules` and
+			// the hash input order in `loadYamlRulesFresh`. `localeCompare` can
+			// order the same file set differently across locales/processes,
+			// which would desync the two and mint spurious cache misses or
+			// (worse) content-hash collisions across differently-ordered runs.
+			// Same reasoning as `rule-cache.ts`'s `computeRuleHash` (#2155/#2165).
+			.sort((a, b) => compareOrdinal(a.name, b.name));
 	} catch {
 		return [];
 	}
@@ -221,6 +241,21 @@ export function getCachedRules(
 	}
 
 	const cache = severityFilter === "error" ? blockingRulesCache : rulesCache;
+	const cached = cache.get(ruleDir);
+	const now = Date.now();
+	if (
+		cached &&
+		now - cached.checkedAtMs < RULES_CACHE_FRESHNESS_CADENCE_MS
+	) {
+		// Inside the cadence window: no stat sweep at all. `getCachedRules` is
+		// the bundled-catalog path only (project rules route through
+		// `loadYamlRulesFresh` — see `ast-grep-napi.ts`'s route split), and
+		// `scanner.ts:235` calls it once per scanned file, so a per-call
+		// `readdirSync`+`statSync*N` sweep is the hot-path cost this window
+		// exists to remove.
+		return cached.rules;
+	}
+
 	const files = findYamlRuleFiles(ruleDir);
 	const fileStamps = files.flatMap((file): RuleFileStamp[] => {
 		try {
@@ -230,7 +265,6 @@ export function getCachedRules(
 			return [];
 		}
 	});
-	const cached = cache.get(ruleDir);
 	const metadataMatches =
 		cached?.files.length === fileStamps.length &&
 		cached.files.every(
@@ -240,35 +274,17 @@ export function getCachedRules(
 				file.size === fileStamps[index].size,
 		);
 	if (cached && metadataMatches) {
-		// Metadata is the cheap first tier. Confirm bytes when it agrees because
-		// same-mtime, same-size edits are valid on supported filesystems.
-		if (cached.contentSignature === ruleContentSignature(ruleDir, files)) {
-			return cached.rules;
-		}
+		// Nothing drifted. Re-arm the window from *now* regardless — otherwise
+		// the next call re-stats immediately instead of waiting a full cadence
+		// (the #2260/#2071 "checkedAtMs must re-arm on every check, not only on
+		// a miss" lesson).
+		cached.checkedAtMs = now;
+		return cached.rules;
 	}
 
 	const rules = loadYamlRuleFiles(files, severityFilter);
-	cache.set(ruleDir, {
-		rules,
-		files: fileStamps,
-		contentSignature: ruleContentSignature(ruleDir, files),
-	});
+	cache.set(ruleDir, { rules, files: fileStamps, checkedAtMs: now });
 	return rules;
-}
-
-function ruleContentSignature(ruleDir: string, files: string[]): string {
-	const hash = createHash("sha256");
-	for (const file of files) {
-		hash.update(path.relative(ruleDir, file));
-		hash.update("\0");
-		try {
-			hash.update(fs.readFileSync(file));
-		} catch {
-			hash.update("missing");
-		}
-		hash.update("\0");
-	}
-	return hash.digest("hex");
 }
 
 export function isOverlyBroadPattern(

--- a/clients/dispatch/runners/yaml-rule-parser.ts
+++ b/clients/dispatch/runners/yaml-rule-parser.ts
@@ -243,10 +243,7 @@ export function getCachedRules(
 	const cache = severityFilter === "error" ? blockingRulesCache : rulesCache;
 	const cached = cache.get(ruleDir);
 	const now = Date.now();
-	if (
-		cached &&
-		now - cached.checkedAtMs < RULES_CACHE_FRESHNESS_CADENCE_MS
-	) {
+	if (cached && now - cached.checkedAtMs < RULES_CACHE_FRESHNESS_CADENCE_MS) {
 		// Inside the cadence window: no stat sweep at all. `getCachedRules` is
 		// the bundled-catalog path only (project rules route through
 		// `loadYamlRulesFresh` — see `ast-grep-napi.ts`'s route split), and

--- a/clients/dispatch/runners/yaml-rule-parser.ts
+++ b/clients/dispatch/runners/yaml-rule-parser.ts
@@ -77,7 +77,14 @@ export interface YamlRule {
 
 interface CachedRules {
 	rules: YamlRule[];
-	mtime: number;
+	files: RuleFileStamp[];
+	contentSignature: string;
+}
+
+interface RuleFileStamp {
+	path: string;
+	mtimeMs: number;
+	size: number;
 }
 
 interface ContentCachedRules {
@@ -119,13 +126,6 @@ const contentBlockingRulesCache = new BoundedLruCache<
 >(64);
 
 // --- Public API ---
-
-export function clearRulesCache(): void {
-	rulesCache.clear();
-	blockingRulesCache.clear();
-	contentRulesCache.clear();
-	contentBlockingRulesCache.clear();
-}
 
 export function loadYamlRules(
 	ruleDir: string,
@@ -220,22 +220,55 @@ export function getCachedRules(
 		return [];
 	}
 
-	let currentMtime = 0;
-	try {
-		currentMtime = fs.statSync(ruleDir).mtimeMs;
-	} catch {
-		return [];
-	}
-
 	const cache = severityFilter === "error" ? blockingRulesCache : rulesCache;
+	const files = findYamlRuleFiles(ruleDir);
+	const fileStamps = files.flatMap((file): RuleFileStamp[] => {
+		try {
+			const stat = fs.statSync(file);
+			return [{ path: file, mtimeMs: stat.mtimeMs, size: stat.size }];
+		} catch {
+			return [];
+		}
+	});
 	const cached = cache.get(ruleDir);
-	if (cached && cached.mtime === currentMtime) {
-		return cached.rules;
+	const metadataMatches =
+		cached?.files.length === fileStamps.length &&
+		cached.files.every(
+			(file, index) =>
+				file.path === fileStamps[index].path &&
+				file.mtimeMs === fileStamps[index].mtimeMs &&
+				file.size === fileStamps[index].size,
+		);
+	if (cached && metadataMatches) {
+		// Metadata is the cheap first tier. Confirm bytes when it agrees because
+		// same-mtime, same-size edits are valid on supported filesystems.
+		if (cached.contentSignature === ruleContentSignature(ruleDir, files)) {
+			return cached.rules;
+		}
 	}
 
-	const rules = loadYamlRulesUncached(ruleDir, severityFilter);
-	cache.set(ruleDir, { rules, mtime: currentMtime });
+	const rules = loadYamlRuleFiles(files, severityFilter);
+	cache.set(ruleDir, {
+		rules,
+		files: fileStamps,
+		contentSignature: ruleContentSignature(ruleDir, files),
+	});
 	return rules;
+}
+
+function ruleContentSignature(ruleDir: string, files: string[]): string {
+	const hash = createHash("sha256");
+	for (const file of files) {
+		hash.update(path.relative(ruleDir, file));
+		hash.update("\0");
+		try {
+			hash.update(fs.readFileSync(file));
+		} catch {
+			hash.update("missing");
+		}
+		hash.update("\0");
+	}
+	return hash.digest("hex");
 }
 
 export function isOverlyBroadPattern(

--- a/tests/clients/ast-grep-rule-precedence-followups.test.ts
+++ b/tests/clients/ast-grep-rule-precedence-followups.test.ts
@@ -9,7 +9,6 @@ import {
 	evaluateAstGrepRules,
 	type AstGrepEvaluateOptions,
 } from "../../clients/dispatch/runners/ast-grep-napi.js";
-import { clearRulesCache } from "../../clients/dispatch/runners/yaml-rule-parser.js";
 import { createLSPClient } from "../../clients/lsp/client.js";
 import { getServerById } from "../../clients/lsp/server.js";
 import {
@@ -194,7 +193,6 @@ function runCli(configPath: string, filePath: string) {
 
 afterEach(() => {
 	_resetBaselineSgconfigForTests();
-	clearRulesCache();
 	for (const root of tempRoots.splice(0)) {
 		// Windows: the raw ast-grep LSP child spawned by the cliIt case can still
 		// hold a handle on the temp dir when teardown runs, making rmSync throw

--- a/tests/clients/ast-grep-rule-precedence-followups.test.ts
+++ b/tests/clients/ast-grep-rule-precedence-followups.test.ts
@@ -191,6 +191,15 @@ function runCli(configPath: string, filePath: string) {
 	};
 }
 
+// No `clearRulesCache()` call here (removed with the function in #2262 round
+// 2 — it had no remaining production caller). Isolation does not depend on
+// it: every case builds its project rule tree under a fresh
+// `fs.mkdtempSync` root via `makeProject()`, so each test's `getCachedRules`/
+// `loadYamlRulesFresh` cache key (the directory path) is unique across the
+// whole run and a prior test's entry can never be read back. The bundled
+// catalog tier (the real `rules/ast-grep-rules/...` directories) DOES share
+// one cache entry across every test in this file — that's the caching
+// working as designed, since no case here mutates bundled files on disk.
 afterEach(() => {
 	_resetBaselineSgconfigForTests();
 	for (const root of tempRoots.splice(0)) {

--- a/tests/clients/dispatch/runners/yaml-rule-parser.test.ts
+++ b/tests/clients/dispatch/runners/yaml-rule-parser.test.ts
@@ -1,9 +1,73 @@
-import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+	loadYamlRules,
 	parseSimpleYaml,
 	isOverlyBroadPattern,
 	isStructuredRule,
 } from "../../../../clients/dispatch/runners/yaml-rule-parser.js";
+
+const ruleCacheTempDirs: string[] = [];
+
+function writeRule(filePath: string, id: string, message: string): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(
+		filePath,
+		[
+			`id: ${id}`,
+			"severity: warning",
+			`message: ${message}`,
+			"rule:",
+			"  pattern: $X",
+			"",
+		].join("\n"),
+	);
+}
+
+function messages(rules: ReturnType<typeof loadYamlRules>): string[] {
+	return rules.map((rule) => rule.message ?? "").sort();
+}
+
+const FIXED_DIRECTORY_MTIME = new Date("2000-01-01T00:00:00.000Z");
+
+afterEach(() => {
+	for (const dir of ruleCacheTempDirs.splice(0))
+		fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("yaml-rule-parser cache freshness (#2262)", () => {
+	it("reloads an edited existing rule when the directory mtime is unchanged", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pilens-rules-cache-"));
+		ruleCacheTempDirs.push(root);
+		const file = path.join(root, "existing.yml");
+		writeRule(file, "existing", "old");
+		fs.utimesSync(root, FIXED_DIRECTORY_MTIME, FIXED_DIRECTORY_MTIME);
+		const first = loadYamlRules(root);
+
+		writeRule(file, "existing", "new");
+		fs.utimesSync(root, FIXED_DIRECTORY_MTIME, FIXED_DIRECTORY_MTIME);
+
+		expect(messages(loadYamlRules(root))).toEqual(["new"]);
+		expect(messages(first)).toEqual(["old"]);
+	});
+
+	it("discovers a nested rule file when the root directory mtime is unchanged", () => {
+		const root = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pilens-rules-cache-nested-"),
+		);
+		ruleCacheTempDirs.push(root);
+		writeRule(path.join(root, "root.yml"), "root", "root");
+		fs.utimesSync(root, FIXED_DIRECTORY_MTIME, FIXED_DIRECTORY_MTIME);
+		loadYamlRules(root);
+
+		writeRule(path.join(root, "nested", "child.yml"), "child", "child");
+		fs.utimesSync(root, FIXED_DIRECTORY_MTIME, FIXED_DIRECTORY_MTIME);
+
+		expect(messages(loadYamlRules(root))).toEqual(["child", "root"]);
+	});
+});
 
 describe("yaml-rule-parser fix metadata", () => {
 	it("parses note and fix fields (including multiline) from ast-grep YAML", () => {

--- a/tests/clients/dispatch/runners/yaml-rule-parser.test.ts
+++ b/tests/clients/dispatch/runners/yaml-rule-parser.test.ts
@@ -1,12 +1,24 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ESM can't redefine an unmocked module's exports (vi.spyOn on a bare `fs`
+// import throws "Module namespace is not configurable"). Wrapping `statSync`
+// through `vi.mock` — same shape as `nested-ignore-freshness-clock.test.ts`'s
+// mock for the sibling cadence — makes it spy-able.
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return { ...actual, statSync: vi.fn(actual.statSync) };
+});
+
 import {
 	loadYamlRules,
+	loadYamlRulesUncached,
 	parseSimpleYaml,
 	isOverlyBroadPattern,
 	isStructuredRule,
+	RULES_CACHE_FRESHNESS_CADENCE_MS,
 } from "../../../../clients/dispatch/runners/yaml-rule-parser.js";
 
 const ruleCacheTempDirs: string[] = [];
@@ -33,10 +45,20 @@ function messages(rules: ReturnType<typeof loadYamlRules>): string[] {
 const FIXED_DIRECTORY_MTIME = new Date("2000-01-01T00:00:00.000Z");
 
 afterEach(() => {
+	vi.useRealTimers();
 	for (const dir of ruleCacheTempDirs.splice(0))
 		fs.rmSync(dir, { recursive: true, force: true });
 });
 
+/**
+ * `getCachedRules` now skips its stat sweep entirely inside
+ * `RULES_CACHE_FRESHNESS_CADENCE_MS` (round 2 of #2262 — see
+ * `yaml-rule-parser.ts`). An edit made and re-read within the same window is
+ * invisible until the window elapses, mirroring `file-utils.ts`'s
+ * `PROJECT_IGNORE_FRESHNESS_CADENCE_MS` contract. These two cases advance a
+ * fake clock past the window before the second read, exactly as
+ * `nested-ignore-freshness-clock.test.ts` does for the sibling cadence.
+ */
 describe("yaml-rule-parser cache freshness (#2262)", () => {
 	it("reloads an edited existing rule when the directory mtime is unchanged", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pilens-rules-cache-"));
@@ -44,10 +66,13 @@ describe("yaml-rule-parser cache freshness (#2262)", () => {
 		const file = path.join(root, "existing.yml");
 		writeRule(file, "existing", "old");
 		fs.utimesSync(root, FIXED_DIRECTORY_MTIME, FIXED_DIRECTORY_MTIME);
+		vi.useFakeTimers();
+		const start = Date.now();
 		const first = loadYamlRules(root);
 
 		writeRule(file, "existing", "new");
 		fs.utimesSync(root, FIXED_DIRECTORY_MTIME, FIXED_DIRECTORY_MTIME);
+		vi.setSystemTime(start + RULES_CACHE_FRESHNESS_CADENCE_MS + 1);
 
 		expect(messages(loadYamlRules(root))).toEqual(["new"]);
 		expect(messages(first)).toEqual(["old"]);
@@ -60,12 +85,51 @@ describe("yaml-rule-parser cache freshness (#2262)", () => {
 		ruleCacheTempDirs.push(root);
 		writeRule(path.join(root, "root.yml"), "root", "root");
 		fs.utimesSync(root, FIXED_DIRECTORY_MTIME, FIXED_DIRECTORY_MTIME);
+		vi.useFakeTimers();
+		const start = Date.now();
 		loadYamlRules(root);
 
 		writeRule(path.join(root, "nested", "child.yml"), "child", "child");
 		fs.utimesSync(root, FIXED_DIRECTORY_MTIME, FIXED_DIRECTORY_MTIME);
+		vi.setSystemTime(start + RULES_CACHE_FRESHNESS_CADENCE_MS + 1);
 
 		expect(messages(loadYamlRules(root))).toEqual(["child", "root"]);
+	});
+
+	it("re-stats a rule directory at most once per cadence window, not once per call", () => {
+		const root = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pilens-rules-cache-bounded-"),
+		);
+		ruleCacheTempDirs.push(root);
+		writeRule(path.join(root, "a.yml"), "a", "a");
+		vi.useFakeTimers();
+		const start = Date.now();
+		loadYamlRules(root); // primes the cache: one sweep
+
+		const statSpy = vi.mocked(fs.statSync);
+		statSpy.mockClear();
+		for (let i = 0; i < 25; i++) loadYamlRules(root);
+		expect(statSpy).not.toHaveBeenCalled();
+
+		vi.setSystemTime(start + RULES_CACHE_FRESHNESS_CADENCE_MS + 1);
+		loadYamlRules(root);
+		expect(statSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("orders discovered rule files by code unit, not by locale collation", () => {
+		const root = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pilens-rules-cache-order-"),
+		);
+		ruleCacheTempDirs.push(root);
+		// Ordinal order puts 'B' (0x42) before 'a' (0x61); default locale
+		// collation orders case-insensitively and would put 'a' first. This
+		// pins the array order `loadYamlRulesFresh` hashes and `getCachedRules`
+		// compares index-by-index (#2262 F4).
+		writeRule(path.join(root, "B.yml"), "upper", "upper");
+		writeRule(path.join(root, "a.yml"), "lower", "lower");
+
+		const rules = loadYamlRulesUncached(root);
+		expect(rules.map((rule) => rule.message)).toEqual(["upper", "lower"]);
 	});
 });
 

--- a/tests/clients/dispatch/runners/yaml-rule-parser.test.ts
+++ b/tests/clients/dispatch/runners/yaml-rule-parser.test.ts
@@ -70,11 +70,15 @@ describe("yaml-rule-parser cache freshness (#2262)", () => {
 		const start = Date.now();
 		const first = loadYamlRules(root);
 
-		writeRule(file, "existing", "new");
+		// The replacement message must differ in LENGTH from "old": the metadata
+		// tier is mtimeMs+size only, and NTFS mtime granularity makes a same-size
+		// rewrite collide with the original stamp ~90% of the time (flaked 3/24
+		// on Windows). A size change is what the mechanism actually detects.
+		writeRule(file, "existing", "renewed");
 		fs.utimesSync(root, FIXED_DIRECTORY_MTIME, FIXED_DIRECTORY_MTIME);
 		vi.setSystemTime(start + RULES_CACHE_FRESHNESS_CADENCE_MS + 1);
 
-		expect(messages(loadYamlRules(root))).toEqual(["new"]);
+		expect(messages(loadYamlRules(root))).toEqual(["renewed"]);
 		expect(messages(first)).toEqual(["old"]);
 	});
 


### PR DESCRIPTION
## Summary

`getCachedRules` gated freshness on the top-level directory's mtime only, so edits to existing rule files and nested rule files were invisible (directory mtime does not change for in-place edits on Windows). The cache now snapshots every rule file with `mtimeMs` + size, and re-arms that snapshot on a cadence instead of every call. `clearRulesCache` deleted (no production caller; dead export). Closes #2262.

Implemented by a plegma codex worker (branch pushed from its isolated worktree); PR opened by the maintainer. First pass at commit 67e58ffb.

## Review round 1

One finding, on the first pass's fix, not on the bug or its two regression tests: both remain genuine.

| Finding | Disposition |
|---|---|
| MED: the fix's content-hash confirm (sha256 over every rule file's bytes, every call) was an ~8000x warmed-path regression — 0.02ms to 161-186ms per call. `scanner.ts:235` calls `getCachedRules` once per scanned file, so a 500-file scan paid ~80s | Fixed below |

### What changed

1. **Dropped the content-hash confirm entirely.** `getCachedRules` is the bundled-catalog path only — `ast-grep-napi.ts:718` routes project rules to `loadYamlRulesFresh`, not here — and bundled files are immutable within a process. `rule-cache.ts:110-127`'s `computeRuleHash` already draws this exact line and its comment states it explicitly: content-confirm only the mutable, project-local subset; bundled files stay metadata-cheap. Both #2262 regression tests still red without the content confirm reintroduced any other way, which is the direct proof it was never load-bearing.
2. **Added a cadence window.** Metadata-only (readdir + stat every file, every call) still measured 4.98ms warmed — 250x master. `getCachedRules` now skips the stat sweep entirely inside a 2s window and re-arms `checkedAtMs` on every check (not only on a cache miss) — the `file-utils.ts` `PROJECT_IGNORE_FRESHNESS_CADENCE_MS` pattern from #2260/#2071, including that PR's "checkedAtMs must re-arm on every check" lesson (its own T1 finding). Warmed calls inside the window are a single map lookup.
3. **F4: `findYamlRuleFiles` now sorts with `compareOrdinal`, not `localeCompare`.** That order feeds the index-aligned file-stamp identity `getCachedRules` compares and the hash input order `loadYamlRulesFresh` hashes — `localeCompare` can order the same file set differently across locales/processes, desyncing the two. Same reasoning as `rule-cache.ts`'s `computeRuleHash` (#2155/#2165).
4. **F5: the `CHANGELOG.md` hand-edit is reverted.** Fragment lives in `.changelog/2262-rules-cache-freshness.md`.
5. **F6: `ast-grep-rule-precedence-followups.test.ts`'s `afterEach` documents why it doesn't need `clearRulesCache`.** Every case builds its project rule tree under a fresh `mkdtempSync` root, so each test's cache key (the directory path) is unique across the run — isolation already holds by construction, not by the deleted reset. Ran the file standalone to confirm: 11/11 green.

### Measured

Synthetic fixture: 500 rule files, one flat directory, warmed calls (cache primed, well inside the cadence window), `process.hrtime.bigint()`, Windows, built from source.

| | ms/call (warmed) |
|---|---|
| master (no freshness fix) | ~0.02 |
| round 1 (content-hash confirm) | 161-186 |
| round 1, content-confirm removed only | 4.98 |
| this round (cadence-gated metadata) | 0.018 |

### Mutation proof

Removed the cadence early-return (`if (cached && now - cached.checkedAtMs < RULES_CACHE_FRESHNESS_CADENCE_MS) return cached.rules;`), rebuilt, reran. The new bounded-cost test reds exactly as expected — 25 calls where it expects 0:

```
FAIL > re-stats a rule directory at most once per cadence window, not once per call
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 25 times
```

Restored, rebuilt, green again (10/10 in the file).

## Tests

Red-first against `origin/master`'s pre-fix `yaml-rule-parser.ts` (mtime-only cache, the original bug), rebuilt in between, kept output:

```
FAIL > reloads an edited existing rule when the directory mtime is unchanged
AssertionError: expected [ 'old' ] to deeply equal [ 'new' ]

FAIL > discovers a nested rule file when the root directory mtime is unchanged
AssertionError: expected [ 'root' ] to deeply equal [ 'child', 'root' ]

FAIL > re-stats a rule directory at most once per cadence window, not once per call
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 25 times

FAIL > orders discovered rule files by code unit, not by locale collation
AssertionError: expected [ 'lower', 'upper' ] to deeply equal [ 'upper', 'lower' ]
```

All four green after restoring the fix and rebuilding. The two original #2262 cases now advance a fake clock past the cadence window before their post-edit read (`vi.useFakeTimers()` + `vi.setSystemTime`), mirroring `nested-ignore-freshness-clock.test.ts`'s pattern for the sibling cadence — otherwise the cadence gate itself would hide the edit from a same-tick re-read.

Ran locally after `npm run build`:
- `tests/clients/dispatch/runners/yaml-rule-parser.test.ts` — 10/10
- `tests/clients/ast-grep-rule-precedence-followups.test.ts` — 11/11 (F6 isolation check)
- Every other test file referencing `loadYamlRules`/`getCachedRules`/`yaml-rule-parser` (`redos-nested-quantifier`, `ast-grep-napi-language-coverage`, `ast-grep-napi`, `ast-grep-rule-ignores`, `ast-grep-utils-block`, `run-outcome-ratchet`) — 68/68 across the 8 files
- Governance suites (`delivery-surface-ratchet`, `finding-delivery-gate`, `session-state-conformance`, `bounded-telemetry-sweep`, `bus-producer-coverage`, `deps-centralization`, `freshness-sweep`, `managed-tool-seam-coverage`, `profiling-coverage`, `module-instance-coverage`, `sweep-floor-coverage`) — 162/162 across 11 files
- `npm run lint`, `npm run fmt:check`, `npm run changelog:check` — clean

Full suite is CI's job and has not run locally.

### Test assessment

Both staleness axes (in-place edit, nested discovery) are pinned directly through the public `loadYamlRules` seam. The bounded-cost case pins the perf fix as a test, not only as a measurement, and the mutation proof shows it is load-bearing. The order case pins F4 by exploiting a real locale-vs-ordinal divergence (`'B'` 0x42 sorts before `'a'` 0x61 ordinally; default locale collation is case-insensitive and would put `'a'` first), not a fixed platform assumption.

## Blast radius

One production caller path, unchanged from round 1: `ast-grep-napi.ts` selects `loadYamlRules` for bundled rules on dispatch, called once per scanned file (`scanner.ts:235`). Warmed-call cost is now back to master's baseline (0.018ms vs master's ~0.02ms), so the regression this round exists to fix is closed. `clearRulesCache` removal: still zero callers.

## Observability

No new failure path; stale-rule serving simply stops. The cadence window trades "sees an external edit immediately" for "sees it within 2s", same tradeoff #2260 already accepted and documented for the sibling ignore-matcher cache — bundled rule files are never edited at runtime, so this bound applies to a case that doesn't occur in production; it only governs the synthetic project-rule scenario the regression tests exercise directly against `getCachedRules`.

## Class sweep

Unchanged from round 1: directory-mtime-gated cache sweep found only intentional topology/config discovery caches remaining (sibling issue #2263 covers the topology pair, deliberately out of scope here). This round's fix (content-confirm removal, cadence gate) is scoped to the one cache this issue's regression covers and does not introduce a new instance of the swept class.
