### PR TITLE
fix(session): re-arm topology-derived caches at session start (closes #2263)

### DIFF
--- a/.changelog/2263-topology-cache-rearm.md
+++ b/.changelog/2263-topology-cache-rearm.md
@@ -1,4 +1,4 @@
 ---
 section: Fixed
 ---
-- **Topology-derived startup scan and language-profile memos now re-arm with the workspace marker index at session start (closes #2263)** — `resetWorkspaceTopology()` now walks one registered downstream-cache reset list, clearing `startupScanContextCache` and `languageProfileCache` with the source index. A new session therefore re-derives project-root and configured-language answers after marker changes; mid-session edits remain governed by each consumer's existing freshness policy.
+- **Topology-derived startup scan and language-profile memos re-arm with the workspace marker index at session start (closes #2263)** — `resetWorkspaceTopology()` walks one registered downstream-cache reset list, clearing `startupScanContextCache`, `languageProfileCache`, and tsconfig-path caches with the source index. Caches are cleared only at session start via the topology-reset registry; mid-session edits are not detected.

--- a/.changelog/2263-topology-cache-rearm.md
+++ b/.changelog/2263-topology-cache-rearm.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- **Topology-derived startup scan and language-profile memos now re-arm with the workspace marker index at session start (closes #2263)** — `resetWorkspaceTopology()` now walks one registered downstream-cache reset list, clearing `startupScanContextCache` and `languageProfileCache` with the source index. A new session therefore re-derives project-root and configured-language answers after marker changes; mid-session edits remain governed by each consumer's existing freshness policy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Topology-derived startup scan and language-profile memos now re-arm with the workspace marker index at session start (closes #2263)** — `resetWorkspaceTopology()` now walks one registered downstream-cache reset list, clearing `startupScanContextCache` and `languageProfileCache` with the source index. A new session therefore re-derives project-root and configured-language answers after marker changes; mid-session edits remain governed by each consumer's existing freshness policy.
+
 ### Security
 
 ## [4.1.2] - 2026-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
-- **Topology-derived startup scan and language-profile memos now re-arm with the workspace marker index at session start (closes #2263)** — `resetWorkspaceTopology()` now walks one registered downstream-cache reset list, clearing `startupScanContextCache` and `languageProfileCache` with the source index. A new session therefore re-derives project-root and configured-language answers after marker changes; mid-session edits remain governed by each consumer's existing freshness policy.
-
 ### Security
 
 ## [4.1.2] - 2026-08-24

--- a/clients/language-profile.ts
+++ b/clients/language-profile.ts
@@ -17,7 +17,10 @@ import {
 } from "./language-policy.js";
 import { getSourceFiles } from "./scan-utils.js";
 import { readDirEntriesSafe, shouldRecurseIntoDir } from "./source-walker.js";
-import { findNearestDirWithAnyBasename } from "./workspace-topology.js";
+import {
+	findNearestDirWithAnyBasename,
+	registerWorkspaceTopologyReset,
+} from "./workspace-topology.js";
 import { BoundedLruCache } from "./bounded-cache.js";
 
 /** Every registered kind participates in project-language detection (#894). */
@@ -130,6 +133,7 @@ const languageProfileCache = new BoundedLruCache<
 	string,
 	ProjectLanguageProfile
 >(32);
+registerWorkspaceTopologyReset(() => languageProfileCache.clear());
 
 export function detectProjectLanguageProfile(
 	projectRoot: string,

--- a/clients/language-profile.ts
+++ b/clients/language-profile.ts
@@ -123,7 +123,8 @@ function hasProjectMarker(projectRoot: string, marker: string): boolean {
 	}
 }
 
-// Process-lifetime memo keyed on projectRoot. Only populated when the
+// Session-lifetime memo keyed on projectRoot. The topology-reset registry
+// clears it at session start. Only populated when the
 // caller did not pass an explicit `sourceFiles` array — the explicit-array
 // case is used by the warmup pipeline to inject pre-collected files and
 // must not pollute the no-arg cache. The synchronous getSourceFiles() call

--- a/clients/review-graph/tsconfig-paths.ts
+++ b/clients/review-graph/tsconfig-paths.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import {
 	findGoverningTsconfigDir,
 	getDirectoryMarkers,
+	registerWorkspaceTopologyReset,
 } from "../workspace-topology.js";
 
 export interface TsconfigPathMatcher {
@@ -35,6 +36,10 @@ interface ParsedConfig {
 
 const cache = new BoundedLruCache<string, TsconfigPathMatcher[]>(64);
 const referencesCache = new BoundedLruCache<string, Map<string, string>>(64);
+registerWorkspaceTopologyReset(() => {
+	cache.clear();
+	referencesCache.clear();
+});
 
 /** Strip JSONC comments and trailing commas without touching string contents. */
 function parseJsonc(content: string): TsconfigJson {

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -2123,12 +2123,10 @@ export async function handleSessionStart(
 	clearFileTimeSessions();
 	runtime.complexityBaselines.clear();
 	resetDispatchBaselines(ctxCwd);
-	// #806: drop the shared per-directory marker index (and any consumer
-	// cache layered on top, e.g. tsconfig-paths' matcher cache) so a
-	// `.pi-lens.json`/`tsconfig.json`/workspace-manifest edit made between
-	// sessions is picked up fresh instead of only on process restart — this
-	// also fixes #805's mid-session tsconfig staleness (the matcher cache was
-	// previously session-lived with no reset hook at all).
+	// #806: drop the shared per-directory marker index and its registered
+	// topology-derived consumer caches so marker edits between sessions are
+	// picked up fresh instead of only on process restart. Mid-session edits
+	// remain governed by each consumer's own freshness policy.
 	resetWorkspaceTopology();
 	clearTsconfigPathsCache();
 	// #2000: opaque-recovery baselines are keyed cwd:generation (unreachable

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -82,7 +82,6 @@ import {
 	readProjectSnapshotMeta,
 	saveRuntimeProjectSnapshot,
 } from "./project-snapshot.js";
-import { clearTsconfigPathsCache } from "./review-graph/tsconfig-paths.js";
 import type { RuffClient } from "./ruff-client.js";
 import { scanProjectRules } from "./rules-scanner.js";
 import type { RuntimeCoordinator } from "./runtime-coordinator.js";
@@ -2123,12 +2122,10 @@ export async function handleSessionStart(
 	clearFileTimeSessions();
 	runtime.complexityBaselines.clear();
 	resetDispatchBaselines(ctxCwd);
-	// #806: drop the shared per-directory marker index and its registered
-	// topology-derived consumer caches so marker edits between sessions are
-	// picked up fresh instead of only on process restart. Mid-session edits
-	// remain governed by each consumer's own freshness policy.
+	// #806: clear the shared per-directory marker index and registered
+	// topology-derived caches only at session start. Mid-session edits are NOT
+	// detected; #805's tsconfig matcher cache follows the same registry reset.
 	resetWorkspaceTopology();
-	clearTsconfigPathsCache();
 	// #2000: opaque-recovery baselines are keyed cwd:generation (unreachable
 	// after reset) and the git-worktree memo must re-probe after a session
 	// that may have seen a non-git dir become one.

--- a/clients/startup-scan.ts
+++ b/clients/startup-scan.ts
@@ -321,14 +321,12 @@ export function countSourceFilesWithinLimit(
 	return walkSourceCount(dir, limit, Number.POSITIVE_INFINITY).count;
 }
 
-// Process-lifetime memo for the (cwd, homeDir, maxSourceFiles) tuple. The
+// Session-lifetime memo for the (cwd, homeDir, maxSourceFiles) tuple. The
 // underlying computation walks the entire project root counting source
 // files and is dominated by ignoreMatcher.isIgnored() calls; on a 2k-file
-// project it costs ~2-3s the first time. Every `session_start` invocation
-// (boot, /new, --print) recomputes this otherwise. Since the answer
-// depends only on the file tree shape and ignore rules — both of which
-// are also captured by the project snapshot freshness check upstream —
-// in-process memoisation is safe for the duration of a single pi process.
+// project it costs ~2-3s the first time. The topology-reset registry clears
+// this memo at session start, so each session re-derives its answer. The memo
+// remains valid until the next session-start reset.
 const startupScanContextCache = new BoundedLruCache<string, StartupScanContext>(
 	32,
 );

--- a/clients/startup-scan.ts
+++ b/clients/startup-scan.ts
@@ -24,7 +24,10 @@ import {
 	walkTreeStackSync,
 	type WalkVisitor,
 } from "./source-walker.js";
-import { getDirectoryMarkers } from "./workspace-topology.js";
+import {
+	getDirectoryMarkers,
+	registerWorkspaceTopologyReset,
+} from "./workspace-topology.js";
 
 export const PROJECT_ROOT_MARKERS = [
 	".git",
@@ -329,6 +332,7 @@ export function countSourceFilesWithinLimit(
 const startupScanContextCache = new BoundedLruCache<string, StartupScanContext>(
 	32,
 );
+registerWorkspaceTopologyReset(() => startupScanContextCache.clear());
 
 function startupScanCacheKey(cwd: string, options: StartupScanOptions): string {
 	return [

--- a/clients/workspace-topology.ts
+++ b/clients/workspace-topology.ts
@@ -93,6 +93,13 @@ interface DirCacheEntry {
 /** Per-directory marker cache — the shared seam every consumer reads through. */
 const dirMarkerCache = new Map<string, DirCacheEntry>();
 
+/** Downstream memo clears that must follow the topology index reset. */
+const topologyDerivedCacheResets: Array<() => void> = [];
+
+export function registerWorkspaceTopologyReset(reset: () => void): void {
+	topologyDerivedCacheResets.push(reset);
+}
+
 /** Cache for upward marker-walk results, keyed by `${startDir}\0${markerKey}`. */
 type WalkCacheEntry = {
 	dir: string | undefined;
@@ -152,6 +159,7 @@ function touchWalk(key: string, entry: WalkCacheEntry): void {
 export function resetWorkspaceTopology(): void {
 	for (const key of dirMarkerCache.keys()) deleteDirMarker(key);
 	for (const key of walkCache.keys()) deleteWalk(key);
+	for (const reset of topologyDerivedCacheResets) reset();
 }
 
 /**

--- a/tests/clients/topology-derived-cache-rearm.test.ts
+++ b/tests/clients/topology-derived-cache-rearm.test.ts
@@ -1,0 +1,45 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	detectProjectLanguageProfile,
+} from "../../clients/language-profile.js";
+import { resolveStartupScanContext } from "../../clients/startup-scan.js";
+import { resetWorkspaceTopology } from "../../clients/workspace-topology.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+describe("topology-derived cache re-arm (#2263)", () => {
+	it("re-derives startup scan context after topology reset", () => {
+		const env = setupTestEnvironment("pi-lens-topology-startup-");
+		try {
+			const homeDir = path.join(env.tmpDir, "home");
+			const before = resolveStartupScanContext(env.tmpDir, { homeDir });
+			expect(before.projectRoot).toBeNull();
+
+			fs.mkdirSync(path.join(env.tmpDir, ".git"));
+			resetWorkspaceTopology();
+
+			const after = resolveStartupScanContext(env.tmpDir, { homeDir });
+			expect(after.projectRoot).toBe(path.resolve(env.tmpDir));
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("re-derives language profile after topology reset", () => {
+		const env = setupTestEnvironment("pi-lens-topology-language-");
+		try {
+			fs.writeFileSync(path.join(env.tmpDir, "index.ts"), "export {}\n");
+			const before = detectProjectLanguageProfile(env.tmpDir);
+			expect(before.configured.jsts).toBeUndefined();
+
+			fs.writeFileSync(path.join(env.tmpDir, "package.json"), "{}\n");
+			resetWorkspaceTopology();
+
+			const after = detectProjectLanguageProfile(env.tmpDir);
+			expect(after.configured.jsts).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+});

--- a/tests/clients/topology-derived-cache-rearm.test.ts
+++ b/tests/clients/topology-derived-cache-rearm.test.ts
@@ -60,7 +60,7 @@ describe("topology-derived cache re-arm (#2263)", () => {
 				expect.objectContaining({ pattern: "@old/*" }),
 			]);
 			expect(aliasedImportTargets("@old/value", sourceDir)).toEqual([
-				path.join(env.tmpDir, "old/*").replace("*", "value"),
+				path.join(env.tmpDir, "old", "value"),
 			]);
 
 			const originalStat = fs.statSync(configPath);

--- a/tests/clients/topology-derived-cache-rearm.test.ts
+++ b/tests/clients/topology-derived-cache-rearm.test.ts
@@ -2,6 +2,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { detectProjectLanguageProfile } from "../../clients/language-profile.js";
+import {
+	aliasedImportTargets,
+	parseTsconfigPaths,
+} from "../../clients/review-graph/tsconfig-paths.js";
 import { resolveStartupScanContext } from "../../clients/startup-scan.js";
 import { resetWorkspaceTopology } from "../../clients/workspace-topology.js";
 import { setupTestEnvironment } from "./test-utils.js";
@@ -36,6 +40,48 @@ describe("topology-derived cache re-arm (#2263)", () => {
 
 			const after = detectProjectLanguageProfile(env.tmpDir);
 			expect(after.configured.jsts).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("re-derives tsconfig paths after topology reset", () => {
+		const env = setupTestEnvironment("pi-lens-topology-tsconfig-");
+		try {
+			const configPath = path.join(env.tmpDir, "tsconfig.json");
+			const sourceDir = path.join(env.tmpDir, "src");
+			fs.mkdirSync(sourceDir);
+			const initialConfig = JSON.stringify({
+				compilerOptions: { baseUrl: ".", paths: { "@old/*": ["old/*"] } },
+			});
+			fs.writeFileSync(configPath, initialConfig);
+			fs.utimesSync(configPath, 946684800, 946684800);
+			expect(parseTsconfigPaths(sourceDir)).toEqual([
+				expect.objectContaining({ pattern: "@old/*" }),
+			]);
+			expect(aliasedImportTargets("@old/value", sourceDir)).toEqual([
+				path.join(env.tmpDir, "old/*").replace("*", "value"),
+			]);
+
+			const originalStat = fs.statSync(configPath);
+			const replacementConfig = JSON.stringify({
+				compilerOptions: { baseUrl: ".", paths: { "@new/*": ["new/*"] } },
+			});
+			expect(replacementConfig.length).toBe(initialConfig.length);
+			fs.writeFileSync(configPath, replacementConfig);
+			fs.utimesSync(configPath, originalStat.atime, originalStat.mtime);
+			const replacementStat = fs.statSync(configPath);
+			expect(replacementStat.size).toBe(originalStat.size);
+			expect(replacementStat.mtimeMs).toBe(originalStat.mtimeMs);
+
+			resetWorkspaceTopology();
+
+			expect(parseTsconfigPaths(sourceDir)).toEqual([
+				expect.objectContaining({ pattern: "@new/*" }),
+			]);
+			expect(aliasedImportTargets("@new/value", sourceDir)).toEqual([
+				path.join(env.tmpDir, "new/value"),
+			]);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/topology-derived-cache-rearm.test.ts
+++ b/tests/clients/topology-derived-cache-rearm.test.ts
@@ -1,9 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
-import {
-	detectProjectLanguageProfile,
-} from "../../clients/language-profile.js";
+import { detectProjectLanguageProfile } from "../../clients/language-profile.js";
 import { resolveStartupScanContext } from "../../clients/startup-scan.js";
 import { resetWorkspaceTopology } from "../../clients/workspace-topology.js";
 import { setupTestEnvironment } from "./test-utils.js";

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -545,6 +545,15 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 			"Language profiles derive configured markers from workspace topology, so the memo must re-arm with that index.",
 	},
 	{
+		id: "tsconfig-paths:topology-derived-caches",
+		module: "review-graph/tsconfig-paths.ts",
+		state: "cache, referencesCache",
+		policy: "session_start",
+		resetName: "resetWorkspaceTopology",
+		reason:
+			"Tsconfig path and project-reference resolutions derive from workspace topology, so both memos must re-arm with that index.",
+	},
+	{
 		id: "workspace-modules:moduleSourceFilesMemo",
 		module: "review-graph/workspace-modules.ts",
 		state: "_moduleSourceFilesMemo",

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -527,6 +527,24 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 			"Workspace layout is re-derived per session; a new session can open a tree whose markers moved.",
 	},
 	{
+		id: "startup-scan:topology-derived-cache",
+		module: "startup-scan.ts",
+		state: "startupScanContextCache",
+		policy: "session_start",
+		resetName: "resetWorkspaceTopology",
+		reason:
+			"Startup scan context derives its project-root verdict from workspace marker topology, so the memo must re-arm with that index.",
+	},
+	{
+		id: "language-profile:topology-derived-cache",
+		module: "language-profile.ts",
+		state: "languageProfileCache",
+		policy: "session_start",
+		resetName: "resetWorkspaceTopology",
+		reason:
+			"Language profiles derive configured markers from workspace topology, so the memo must re-arm with that index.",
+	},
+	{
 		id: "workspace-modules:moduleSourceFilesMemo",
 		module: "review-graph/workspace-modules.ts",
 		state: "_moduleSourceFilesMemo",


### PR DESCRIPTION
## Summary

Fixes #2263 by making `resetWorkspaceTopology()` the single reset seam for topology-derived process-lifetime caches. It walks a registered downstream-reset list, clearing `startupScanContextCache` and `languageProfileCache` before the next session derives marker-based answers.

Mid-session marker edits remain out of scope. The existing topology directory and walk caches use mtime freshness, while these derived memos re-arm at `session_start`; extending freshness to every derived profile would add a different policy and is not needed for the reported session boundary.

## Tests

- `tests/clients/topology-derived-cache-rearm.test.ts`: primes each memo, changes marker state, resets topology, and proves the answer is re-derived.
- Edited `tests/support/session-state-registry.ts`: registers both module-scope caches.
- Red-first baseline: both assertions failed with stale `null` project root and `undefined` configured JSTS.
- Mutation proof: removing either callback red its own assertion.
- Reference suite: 22 files, 281 passed, 4 skipped.
- `npm run build`, `npm run lint`: passed.

## Blast radius

`handleSessionStart` now clears two bounded 32-entry memos. The next use pays the existing cold startup-scan or language-profile walk once; warmup and synchronous paths share the re-armed caches.

## Class sweep

The tsconfig matcher cache now resets through the topology registry (moved in the fix round); the module-graph caches reset through their existing seams. Other topology consumers use mtime freshness or direct marker reads. No third process-lifetime per-site verdict cache survives the reset.

## Observability

The existing session-start phase record does not name downstream cache clears. This PR adds no telemetry claim.

## Test assessment

The new regression file uses real filesystem state. The registry edit makes both module-scope caches visible to conformance coverage.

## Fix round (review)

Applied in 36961646: CHANGELOG.md hand-edit replaced with a `.changelog/` fragment; `clearTsconfigPathsCache` moved onto the topology-reset registry at its owner module; the runtime-session comment now states the true lifetime (cleared only at session start via the registry, mid-session edits not detected); stale process-lifetime comments in startup-scan.ts and language-profile.ts corrected; test import formatted.

Measured cost (reviewer, ~3k-file tree): cold derive 6338 ms, warm hit 0.3 ms, post-reset re-derive ~230 ms. Each `/new` pays ~230 ms on the first consumer of either memo, against 0.3 ms before this PR; the ignore-matcher and source-walk caches stay warm, which is why this is far below startup-scan's ~2-3 s cold figure.

Follow-up: #2294 tracks the registered-or-fail sweep that makes registry membership structural.

