### PR TITLE
fix(warden): reject intra-page duplicates (closes #2289)

### DIFF
--- a/.changelog/2289-warden-intra-page-duplicate.md
+++ b/.changelog/2289-warden-intra-page-duplicate.md
@@ -1,1 +1,5 @@
+---
+section: Fixed
+---
+
 - **Merge-train duplicate classification (#2289)** — The warden now treats a PR number repeated within one GraphQL page as malformed data and a fatal error. Genuine cross-page window slides remain benign notes.

--- a/.changelog/2289-warden-intra-page-duplicate.md
+++ b/.changelog/2289-warden-intra-page-duplicate.md
@@ -1,0 +1,1 @@
+- **Merge-train duplicate classification (#2289)** — The warden now treats a PR number repeated within one GraphQL page as malformed data and a fatal error. Genuine cross-page window slides remain benign notes.

--- a/scripts/lib/merge-train-warden.mjs
+++ b/scripts/lib/merge-train-warden.mjs
@@ -265,7 +265,6 @@ export async function fetchOpenPullRequests(fetcher, owner, name) {
 		// to MAX_PAGES x PAGE_SIZE = 200 identical lines into one summary. One
 		// record per page, naming the count, is the same information at 1/50th
 		// the volume.
-		const seenBeforePage = new Set(seenNumbers);
 		const seenOnPage = new Set();
 		const boundaryDuplicates = [];
 		const intraPageDuplicates = [];
@@ -275,7 +274,7 @@ export async function fetchOpenPullRequests(fetcher, owner, name) {
 				continue;
 			}
 			seenOnPage.add(node.number);
-			if (seenBeforePage.has(node.number)) {
+			if (seenNumbers.has(node.number)) {
 				boundaryDuplicates.push(node.number);
 				continue;
 			}

--- a/scripts/lib/merge-train-warden.mjs
+++ b/scripts/lib/merge-train-warden.mjs
@@ -234,8 +234,9 @@ export const DUPLICATE_REPORT_CAP = 5;
  * desc, so any open PR touched mid-pagination shifts the window and pushes a
  * PR from page N onto page N+1. On a 10-minute cadence that is expected noise,
  * and this file's own design note (BENIGN_HTTP_STATUSES above) says such races
- * must not mark the scheduled run red. Classifying at the SOURCE also means
- * the two consumers stop carrying identical mapping code that can drift apart.
+ * must not mark the scheduled run red. An intra-page duplicate is malformed
+ * API data and stays fatal (#2289). Classifying at the SOURCE also means the
+ * two consumers stop carrying identical mapping code that can drift apart.
  */
 export async function fetchOpenPullRequests(fetcher, owner, name) {
 	const prs = [];
@@ -264,10 +265,18 @@ export async function fetchOpenPullRequests(fetcher, owner, name) {
 		// to MAX_PAGES x PAGE_SIZE = 200 identical lines into one summary. One
 		// record per page, naming the count, is the same information at 1/50th
 		// the volume.
-		const duplicates = [];
+		const seenBeforePage = new Set(seenNumbers);
+		const seenOnPage = new Set();
+		const boundaryDuplicates = [];
+		const intraPageDuplicates = [];
 		for (const node of connection.nodes) {
-			if (seenNumbers.has(node.number)) {
-				duplicates.push(node.number);
+			if (seenOnPage.has(node.number)) {
+				intraPageDuplicates.push(node.number);
+				continue;
+			}
+			seenOnPage.add(node.number);
+			if (seenBeforePage.has(node.number)) {
+				boundaryDuplicates.push(node.number);
 				continue;
 			}
 			seenNumbers.add(node.number);
@@ -276,24 +285,29 @@ export async function fetchOpenPullRequests(fetcher, owner, name) {
 
 		const hasNextPage = Boolean(connection.pageInfo?.hasNextPage);
 		const nextCursor = connection.pageInfo?.endCursor;
-		// Read BEFORE the breaks below, because it decides how the duplicate
-		// record is classified. A duplicate on a page whose cursor advanced (or
-		// on the last page, where there is no next cursor to advance) is the
-		// UPDATED_AT window sliding under us: routine. A duplicate on a page
-		// whose cursor did NOT advance means the collector was about to replay
-		// the same page, i.e. real truncation, and stays fatal.
+		// Read BEFORE the breaks below, because it decides how a cross-page
+		// duplicate is classified. An intra-page duplicate cannot be a boundary
+		// slide, regardless of cursor state, and is recorded separately above.
 		const cursorAdvanced =
 			!hasNextPage || (nextCursor != null && nextCursor !== after);
-		if (duplicates.length > 0) {
-			const shown = duplicates.slice(0, DUPLICATE_REPORT_CAP);
-			const remainder = duplicates.length - shown.length;
+		if (boundaryDuplicates.length > 0) {
+			const shown = boundaryDuplicates.slice(0, DUPLICATE_REPORT_CAP);
+			const remainder = boundaryDuplicates.length - shown.length;
 			record(
-				`GraphQL pagination repeated ${duplicates.length} PR number(s) on page ${page + 1} ` +
+				`GraphQL pagination repeated ${boundaryDuplicates.length} PR number(s) on page ${page + 1} ` +
 					`(${shown.map((n) => `#${n}`).join(", ")}${remainder > 0 ? `, +${remainder} more` : ""}); ` +
 					(cursorAdvanced
 						? "the open-PR window shifted during pagination, so this is a routine boundary repeat"
 						: "the cursor did not advance, so the collection is truncated"),
 				cursorAdvanced,
+			);
+		}
+		if (intraPageDuplicates.length > 0) {
+			const shown = intraPageDuplicates.slice(0, DUPLICATE_REPORT_CAP);
+			const remainder = intraPageDuplicates.length - shown.length;
+			record(
+				`GraphQL returned malformed page ${page + 1}: repeated ${intraPageDuplicates.length} PR number(s) within the page ` +
+					`(${shown.map((n) => `#${n}`).join(", ")}${remainder > 0 ? `, +${remainder} more` : ""})`,
 			);
 		}
 

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -748,6 +748,56 @@ describe("merge-train warden GraphQL fetch + REST apply (#1844)", () => {
 			expect(result.errors[0].message).toContain("window shifted");
 		});
 
+		it("keeps an intra-page duplicate fatal and names the malformed page", async () => {
+			const pages = [
+				graphqlPage(
+					[prNode({ number: 7 }), prNode({ number: 7 }), prNode({ number: 8 })],
+					false,
+					"c1",
+				),
+			];
+			const { fetcher } = servePages(pages);
+			const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
+
+			expect(result.prs.map(({ number }) => number)).toEqual([7, 8]);
+			expect(result.errors).toEqual([
+				{
+					message: expect.stringContaining(
+						"malformed page 1: repeated 1 PR number(s) within the page (#7)",
+					),
+					benign: false,
+				},
+			]);
+			expect(result.errors[0].message).not.toContain("window shifted");
+		});
+
+		it("reports intra-page and cross-page duplicates separately", async () => {
+			const pages = [
+				graphqlPage([prNode({ number: 7 })], true, "c1"),
+				graphqlPage(
+					[prNode({ number: 7 }), prNode({ number: 8 }), prNode({ number: 8 })],
+					false,
+					"c2",
+				),
+			];
+			const { fetcher } = servePages(pages);
+			const result = await fetchOpenPullRequests(fetcher, "acme", "repo");
+
+			expect(result.errors).toHaveLength(2);
+			expect(result.errors).toEqual(
+				expect.arrayContaining([
+					{
+						message: expect.stringContaining("routine boundary repeat"),
+						benign: true,
+					},
+					{
+						message: expect.stringContaining("malformed page 2"),
+						benign: false,
+					},
+				]),
+			);
+		});
+
 		it("keeps a duplicate fatal when the cursor did not advance (real truncation)", async () => {
 			// Page 2 repeats page 1 AND hands back the same cursor: the
 			// collector was about to replay, which is genuine truncation.


### PR DESCRIPTION
## Summary

Fixes the live failure inversion in #2289. `fetchOpenPullRequests` now snapshots PR numbers seen before each page and distinguishes them from repeats first seen within that page. Cross-page window slides remain benign. Intra-page duplicates produce a fatal record that truthfully names malformed page data. Pages containing both shapes emit separate records.

Closes #2289.

## Tests

- `keeps an intra-page duplicate fatal and names the malformed page` pins the production-reachable one-page case, its fatal classification, its deduplicated PR output, and the absence of the false window-slide message.
- `reports intra-page and cross-page duplicates separately` pins the mixed-page discriminator and prevents collapsing both shapes back into the cursor-only classification.
- Red-first proof on master `52b8a4ab`: the targeted file reported 2 failures and 120 passes. The one-page case received `benign: true` with `the open-PR window shifted`; the mixed case emitted one record instead of two.
- Targeted green: `npm test -- --run tests/scripts/merge-train-warden.test.ts` (122 passed).
- Type-check: `npm run lint`.
- Format: `npm run fmt` and `npm run fmt:check`.
- Final-head broader suite: `npm test -- --run tests/scripts` (34 files, 601 tests passed).
- Final-head governance: `npm run build`, `npm run lint`, `npm run fmt:check`, `npm run changelog:check` (116 entries), and `npm run astgrep:self-scan` (0 findings).
- The environment-wide `npm test` attempt on superseded SHA `6889fd15` was red outside this seam: the installed git guard rejected intentional temp-directory `git init` calls, and independent five-second/timing tests exceeded budgets under full fork load. That run also caught the fragment's missing YAML front matter; final SHA `47c29a25` fixes it and passes the broader automation and governance suites above.

### Test assessment

The two new cases belong in `tests/scripts/merge-train-warden.test.ts` because they exercise the real shared GraphQL collector used by both CLI entry points. The first is the regression and mutation guard: restoring classification from `cursorAdvanced` alone makes it fail. The second covers the required cross-product cell where one page contains both duplicate classes. Existing #2274 tests continue to pin benign advancing-cursor repeats, fatal stalled-cursor repeats, bounded record cardinality, and end-to-end propagation through `runWarden`.

## Blast radius

The production change is confined to `fetchOpenPullRequests` in `scripts/lib/merge-train-warden.mjs`. Caller grep finds two library consumers: `runWarden` in the same module and `runMergeLane` in `scripts/lib/merge-train-lane.mjs`. Their CLI entry points, `scripts/merge-train-warden.mjs` and `scripts/merge-train-lane.mjs`, both render `e.benign` as `note` or `ERROR` and set a failing exit code when any record is non-benign. No callback, closure, or additional entry-point consumer was found. The structural `module_report` facility was unavailable in this session, so caller grep supplied the dependency map. The collector is scheduled workflow code, not a per-file or per-spawn hot path; the change adds two page-local sets over at most 50 nodes and requires no hot-path benchmark.

## Class sweep

Defect class: empty-result/failure inversion, specifically using page-exhaustion state as proof of a duplicate's provenance. `merge-train-lane.mjs` has no separate pagination implementation; it delegates to the corrected collector. `scripts/lib/github-paging.mjs` and `scripts/lib/stale-open-issues.mjs` are the other pagination consumers found under `scripts/`. They classify exhaustion by page length or bounds and do not classify duplicate identities, so neither has the last-page blind spot. Existing #2274 cross-page cases remain green.

## Observability

The existing bounded page-level record remains the production proof. Intra-page duplicates render as `ERROR: GraphQL returned malformed page ...` in both CLI summaries and make either process exit non-zero. Genuine advancing-cursor boundary repeats retain the `note:` record and zero-exit behavior. Number lists remain capped by `DUPLICATE_REPORT_CAP`; no new unbounded record was added.

## AGENTS.md screens consulted

- `Recurring defect shapes - screen against these BEFORE you write code`, especially shape 10, where errored data must not become a clean or benign result.
- `Standing invariants` ? `Host integration and repo automation`, including the merge-train bounded-read and label-gated lane contracts.
- `Test requirements` and `Test-authoring screens`, including red-first and mutation-proof guards.
- `Issue and PR design contract`, including blast radius, class sweep, observability, test assessment, and prose requirements.

## Review round

The verify round confirmed the classifier's behavior across all five duplicate shapes (intra-page fatal with a true message, cross-page slide still benign, stalled cursor fatal, mixed page two records, 50-duplicate page one capped record) and both CLI exit paths. Two deltas landed after review: the fragment gained its required front matter (47c29a25), and the redundant per-page snapshot set was removed (a559d2e0) — `seenOnPage` short-circuits same-page repeats before the snapshot check, so `seenNumbers` alone carries the classification; the reviewer proved equivalence by mutation across all five shapes. Correction to the Tests section above: the original push did not run the changelog fragment check locally, and Unit tests failed on head 6889fd15 for exactly that omission; both pass after 47c29a25. 122/122 warden tests green on the final head.
