### PR TITLE
fix(dispatch): route napi css/html (closes #2248)

### DIFF
--- a/.changelog/2248.md
+++ b/.changelog/2248.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+Route CSS and HTML files to the napi ast-grep runner when its bundled grammars support them.

--- a/.changelog/2248.md
+++ b/.changelog/2248.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-Route CSS and HTML files to the napi ast-grep runner when its bundled grammars support them.
+- **Napi runner css/html admission (#2248)** — Route CSS and HTML files to the napi ast-grep runner when its bundled grammars support them.

--- a/clients/dispatch/runners/ast-grep-napi.ts
+++ b/clients/dispatch/runners/ast-grep-napi.ts
@@ -905,7 +905,7 @@ export function evaluateAstGrepRules(
 
 const astGrepNapiRunner: RunnerDefinition = {
 	id: "ast-grep-napi",
-	appliesTo: ["jsts"],
+	appliesTo: ["jsts", "css", "html"],
 	priority: PRIORITY.SPECIALIZED_ANALYSIS,
 	enabledByDefault: true,
 	skipTestFiles: true,

--- a/tests/clients/dispatch/runners/ast-grep-css-rules.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-css-rules.test.ts
@@ -5,6 +5,10 @@
  * run on CSS roots and that they do not run on HTML roots.
  */
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+	dispatchForFile,
+	RunnerRegistry,
+} from "../../../../clients/dispatch/dispatcher.js";
 import astGrepNapiRunner from "../../../../clients/dispatch/runners/ast-grep-napi.js";
 import {
 	firedRuleIds,
@@ -24,6 +28,26 @@ beforeAll(() => {
 afterAll(() => env.cleanup());
 
 describe("ast-grep CSS rules (integration via napi fallback)", () => {
+	it("dispatches CSS files to napi and reports a real rule finding", async () => {
+		const { ctx } = env.addFile(
+			"dispatch.css",
+			[".modal {", "  z-index: 9999 !important;", "}", ""].join("\n"),
+		);
+		const registry = new RunnerRegistry();
+		registry.register(astGrepNapiRunner);
+		expect(ctx.kind).toBe("css");
+		const selected = registry.getForKind("css", ctx.filePath);
+		const result = await dispatchForFile(
+			ctx,
+			[{ mode: "all", runnerIds: selected.map((runner) => runner.id) }],
+			registry,
+		);
+
+		expect(result.diagnostics.map((diagnostic) => diagnostic.rule)).toContain(
+			"no-important",
+		);
+	});
+
 	it("fires no-important on a real !important declaration", async () => {
 		const { ctx } = env.addFile(
 			"sample.css",

--- a/tests/clients/dispatch/runners/ast-grep-napi-language-coverage.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi-language-coverage.test.ts
@@ -10,7 +10,8 @@
  * addon has no grammar for were skipped with nothing saying so. This file is
  * the net for both halves:
  *
- * - Every extension routed to this runner (`KIND_EXTENSIONS` jsts/css/html) is
+ * - Every extension routed to this runner (`KIND_EXTENSIONS` jsts/css/html,
+ *   all three reaching it through dispatch `appliesTo` since #2248) is
  *   either served or carries a recorded reason.
  * - Every extension `canHandle` admits resolves a real grammar on the addon
  *   that actually loaded — the "admitted then silently skipped" shape.
@@ -323,5 +324,22 @@ describe("admitted-but-unparseable language is recorded (#2215)", () => {
 	it("records nothing for an extension the matrix never admitted", () => {
 		expect(napi.getLang("main.go", sgModule)).toBeUndefined();
 		expect(languageGap()).toBeUndefined();
+	});
+
+	// #2248 acceptance criterion 2: the kinds `appliesTo` declares must equal the
+	// kinds the napi matrix actually serves, derived from `canHandle` over the
+	// registered extensions -- not a hand-written list. Dropping a served kind
+	// from `appliesTo` (the pre-#2248 defect) or declaring an unserved one reds
+	// this without any per-kind fixture.
+	it("appliesTo matches the kinds the napi matrix serves (#2248)", async () => {
+		const runner = (
+			await import("../../../../clients/dispatch/runners/ast-grep-napi.js")
+		).default;
+		const byCodeUnit = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+		const servedKinds = Object.entries(KIND_EXTENSIONS)
+			.filter(([, exts]) => exts.some((ext) => napi.canHandle("probe" + ext)))
+			.map(([kind]) => kind)
+			.sort(byCodeUnit);
+		expect([...runner.appliesTo].sort(byCodeUnit)).toEqual(servedKinds);
 	});
 });


### PR DESCRIPTION
## Summary

- Expand `ast-grep-napi.appliesTo` from `jsts` to `jsts`, `css`, and `html`, matching the runner's bundled napi language matrix.
- Add a real CSS dispatch regression that enters through `RunnerRegistry.getForKind`, runs the real napi parser and rule loader, and observes the shipped `no-important` finding.
- Add a `Fixed` changelog fragment.

Closes #2248.

## Tests

- `npm run build`
- `npx vitest run tests/clients/dispatch/runners/ast-grep-css-rules.test.ts tests/clients/dispatch/runners/ast-grep-napi-language-coverage.test.ts tests/clients/dispatch/runners/ast-grep-napi.test.ts` (28 passed)
- `npm run lint`
- `npx oxfmt --check clients/dispatch/runners/ast-grep-napi.ts tests/clients/dispatch/runners/ast-grep-css-rules.test.ts .changelog/2248.md`

Red proof: with `appliesTo` restored to `["jsts"]`, after `npm run build`, the dispatch regression failed at its behavioral assertion:

```text
AssertionError: expected [] to include 'no-important'
Test Files  1 failed (1)
Tests  1 failed | 3 passed (4)
```

## Class sweep

Defect class: fixes inert where they ship / dead admission. `RunnerRegistry.getForKind` filters by `appliesTo` before a selected runner can execute its internal admission check.

Sweep commands:

```text
rg -l "appliesTo:" clients/dispatch/runners -g "*.ts"
rg -n "canHandle|path\.extname|unsupported_extension|isGitHubWorkflowFile|supportsLSP" clients/dispatch/runners -g "*.ts"
```

Per-member verdicts:

- `ast-grep-napi`: divergent. `canHandle` admits the `jsts`, `css`, and `html` matrix, while `appliesTo` admitted only `jsts`. Fixed.
- `tree-sitter`: aligned. Its extension lookup narrows the declared `jsts`, `python`, `go`, `rust`, `ruby`, and `cxx` kinds; it admits no extra kind.
- `actionlint`: aligned narrowing. `appliesTo: ["yaml"]` admits the containing kind, and `isGitHubWorkflowFile` intentionally restricts execution to workflow YAML.
- `lsp`: aligned and derived. `appliesTo` comes from `getLspCapableKinds`; `supportsLSP` checks the same language-policy/config surface at runtime.
- `cpp-check`: aligned. Its compiler/parser extension choice stays within `cxx` and admits no extra kind.
- `shellcheck`: aligned. Its extension logic selects a shell dialect within the declared `shell` kind.
- `biome-check-json`, `credo`, `cue-vet`, `dart-analyze`, `detekt`, `dotnet-build`, `elixir-check`, `eslint`, `fact-rules`, `fish-indent`, `gleam-check`, `go-vet`, `golangci-lint`, `hadolint`, `helm-lint`, `helm-render`, `htmlhint`, `javac`, `ktlint`, `markdownlint`, `mypy`, `oxlint`, `php-lint`, `phpstan`, `prisma-validate`, `psscriptanalyzer`, `pyright`, `rubocop`, `ruff-lint`, `rust-clippy`, `shfmt`, `spellcheck`, `spotbugs`, `sqlfluff`, `stylelint`, `swiftlint`, `taplo`, `terragrunt`, `tflint`, `trivy-config`, `vale`, `yamllint`, and `zig-check`: aligned. Each uses `appliesTo` as its file-kind admission boundary; any internal gates narrow configuration, project role, or tool availability and do not admit another kind.

No sibling divergence remains.

## Blast radius

Caller grep:

```text
rg -n "getForKind\(" clients tests
```

- `clients/dispatch/dispatcher.ts:93` owns the changed selection seam.
- `clients/dispatch/dispatcher.ts:1397` uses it in the low-level dispatch entry point covered by the regression's registry-to-`dispatchForFile` path.
- `clients/dispatch/integration.ts:2695` uses it for `getAvailableRunners`, so CSS and HTML availability now reports napi coverage.
- `tests/clients/dispatch/dispatcher-flow.test.ts:40` is the generic registry caller.

The production module has no callback registration or mutable state. The change adds two constant-time `includes` candidates only when registry consumers enumerate runners. The project file-major scanner already calls the napi language matrix directly and is unchanged.

## Test assessment

- `tests/clients/dispatch/runners/ast-grep-css-rules.test.ts`: the added case uniquely pins dispatch selection before real CSS napi rule execution. The existing cases call `runner.run` directly and cannot detect a dead `appliesTo` declaration. No test becomes redundant.

## Observability

No failure path changes. Existing runner results and dispatch latency records identify `ast-grep-napi`; the new paths use the same bounded records. No new telemetry is needed.

## AGENTS.md sections consulted

- Recurring defect shapes — screen against these BEFORE you write code
- Standing invariants — dispatch
- Test requirements, including Testing dispatch runners and Real-runner rule/dispatch tests
- Issue and PR design contract


## Review round

Corrections and deltas from the adversarial review (commit 678c8933):

- The changelog fragment gains its required top-level bullet; it previously redded both the fragment check and Unit tests on head cbd8cd1e (the original body did not report that CI state).
- The coverage file now carries the derived pin #2248's second criterion asks for: `appliesTo` must equal the kind set `canHandle` serves, computed from `KIND_EXTENSIONS` — dropping `html` was previously silent; the pin reds on that mutation (`expected ['css','jsts'] to equal ['css','html','jsts']`).
- Class-sweep correction: tree-sitter's `appliesTo` declares nine kinds (jsts, python, go, rust, ruby, cxx, csharp, php, css), not the six quoted above. The "aligned" verdict stands — `EXT_TO_LANG` maps no extension outside those families.
- Blast radius, measured by the reviewer: css/html files now pay a real per-edit runner execution — ~37 ms warm per css file, plus a one-time ~347 ms native addon load a css-only project never paid before. The catalog serves one css rule and one html rule today, so steady-state cost is small. Unserved `.scss`/`.less` return skipped in 7-11 ms.
- The reviewer confirmed #2217's blast radius does not grow here, but the same css file is now evaluated under `kind: "css"` on the per-edit path and `kind: "jsts"` on the scanner path — recorded on #2217.
