### PR TITLE
fix(snapshot): validate authoritative body size (closes #2285)

### DIFF
--- a/.changelog/2285-authoritative-snapshot-size.md
+++ b/.changelog/2285-authoritative-snapshot-size.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Detect different-size project-snapshot rewrites inside one mtime bucket (closes #2285)** — The authoritative in-process cache now validates both body mtime and size before serving its snapshot, so a hot project root cannot mask a different-length external write indefinitely. Same-size, same-mtime rewrites remain outside this metadata-only hot-path guarantee.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -821,7 +821,10 @@ at save and after promotion. Both `loadProjectSnapshot` and
 disk mtime is `<=` the stamp and size still matches. Keep `<=` for the
 in-flight-write case; size detects different-length writes in a coarse mtime
 bucket. Same-size, same-mtime external rewrites remain invisible by design,
-and this hot read path does not content-hash. (#2285)
+and this hot read path does not content-hash. Only `loadProjectSnapshot`
+re-arms the idle-eviction timer on a cache hit (`touchAuthoritativeSnapshot`),
+so a bucket the narrow loader alone keeps hitting rides an indefinite mask,
+not one bounded by the 20-minute idle window. (#2285)
 
 Advisory caches must carry immutable capture provenance and validate it again
 at every delivery surface. A finding is current only when session/turn state

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -815,6 +815,14 @@ tier. (#2262)
 
 ### Caches, durable stores, and path keys
 
+The project-snapshot authoritative-write cache stamps both `mtimeMs` and size
+at save and after promotion. Both `loadProjectSnapshot` and
+`loadProjectSnapshotExportsAndRules` serve the in-process object only while
+disk mtime is `<=` the stamp and size still matches. Keep `<=` for the
+in-flight-write case; size detects different-length writes in a coarse mtime
+bucket. Same-size, same-mtime external rewrites remain invisible by design,
+and this hot read path does not content-hash. (#2285)
+
 Advisory caches must carry immutable capture provenance and validate it again
 at every delivery surface. A finding is current only when session/turn state
 matches and every affected file is SHA-256-confirmed (size+mtime is only the

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -327,9 +327,12 @@ interface AuthoritativeSnapshotEntry {
 	 * pre-write file's mtime at save time (or -Infinity when no file exists
 	 * yet), then updated to the promoted file's mtime once the worker (or the
 	 * sync fallback) lands the write. Load prefers this entry while the on-disk
-	 * mtime is `<=` this value.
+	 * mtime is `<=` this value and its size still matches `knownSize`. The size
+	 * axis detects coarse-mtime collisions without hashing this hot read path;
+	 * a same-size, same-mtime external rewrite remains invisible by design.
 	 */
 	knownMtime: number;
+	knownSize: number;
 	lastUsedAt: number;
 	idleTimer?: ReturnType<typeof setTimeout>;
 }
@@ -792,7 +795,11 @@ export function loadProjectSnapshotExportsAndRules(
 	const authoritative = authoritativeSnapshots.get(key);
 	if (authoritative) {
 		const diskMtime = body ? body.mtimeMs : Number.NEGATIVE_INFINITY;
-		if (diskMtime <= authoritative.knownMtime) {
+		const diskSize = body ? body.size : Number.NEGATIVE_INFINITY;
+		if (
+			diskMtime <= authoritative.knownMtime &&
+			diskSize === authoritative.knownSize
+		) {
 			const { version, seq, cachedExports, projectRulesScan } =
 				authoritative.snapshot;
 			return { version, seq, cachedExports, projectRulesScan };
@@ -809,18 +816,23 @@ function loadProjectSnapshotInternal(
 	const key = normalizeMapKey(cwd);
 	const body = resolveSnapshotBodyPath(cwd);
 	// Authoritative in-process write wins while our own (possibly still
-	// in-flight) write has not been superseded on disk by a newer external
-	// mtime. `body === null` means nothing is on disk yet — our just-scheduled
-	// write is the only truth, so serve it.
+	// in-flight) write has not been superseded on disk by a newer external mtime
+	// or a different-size body in the same/coarser bucket. `body === null` means
+	// nothing is on disk yet — our just-scheduled write is the only truth, so
+	// serve it. Keep `<=`: the pre-promotion body can be older than our baseline.
 	const authoritative = authoritativeSnapshots.get(key);
 	if (authoritative) {
 		const diskMtime = body ? body.mtimeMs : Number.NEGATIVE_INFINITY;
-		if (diskMtime <= authoritative.knownMtime) {
+		const diskSize = body ? body.size : Number.NEGATIVE_INFINITY;
+		if (
+			diskMtime <= authoritative.knownMtime &&
+			diskSize === authoritative.knownSize
+		) {
 			touchAuthoritativeSnapshot(key, authoritative);
 			return authoritative.snapshot;
 		}
-		// An external writer moved past our write — honor disk and stop
-		// serving the now-stale in-memory object.
+		// An external writer changed the body beyond our metadata stamp — honor
+		// disk and stop serving the now-stale in-memory object.
 		deleteAuthoritativeSnapshot(key);
 	}
 	if (!body) {
@@ -1298,9 +1310,11 @@ function reconcileAuthoritativeAfterWrite(
 		return;
 	}
 	try {
-		entry.knownMtime = fs.statSync(pending.gzPath).mtimeMs;
+		const stat = fs.statSync(pending.gzPath);
+		entry.knownMtime = stat.mtimeMs;
+		entry.knownSize = stat.size;
 	} catch {
-		// If we can't stat our own write, leave knownMtime as-is; the worst case
+		// If we can't stat our own write, leave the metadata as-is; the worst case
 		// is one extra disk re-parse on the next load.
 	}
 }
@@ -1812,9 +1826,11 @@ export function saveProjectSnapshot(
 	// legacy body to a merge-consumer, silently dropping this snapshot's fields.
 	const priorBody = resolveSnapshotBodyPath(cwd);
 	const knownMtime = priorBody ? priorBody.mtimeMs : Number.NEGATIVE_INFINITY;
+	const knownSize = priorBody ? priorBody.size : Number.NEGATIVE_INFINITY;
 	const authoritativeEntry: AuthoritativeSnapshotEntry = {
 		snapshot,
 		knownMtime,
+		knownSize,
 		lastUsedAt: Date.now(),
 	};
 	const previousAuthoritativeEntry = authoritativeSnapshots.get(key);

--- a/clients/project-snapshot.ts
+++ b/clients/project-snapshot.ts
@@ -794,16 +794,24 @@ export function loadProjectSnapshotExportsAndRules(
 	const body = resolveSnapshotBodyPath(cwd);
 	const authoritative = authoritativeSnapshots.get(key);
 	if (authoritative) {
-		const diskMtime = body ? body.mtimeMs : Number.NEGATIVE_INFINITY;
-		const diskSize = body ? body.size : Number.NEGATIVE_INFINITY;
-		if (
-			diskMtime <= authoritative.knownMtime &&
-			diskSize === authoritative.knownSize
-		) {
+		// `body === null` means nothing is on disk — that is never "the body
+		// changed size", so it must not be read as superseding our own write.
+		// See the matching comment in loadProjectSnapshotInternal.
+		const notSuperseded =
+			body === null ||
+			(body.mtimeMs <= authoritative.knownMtime &&
+				body.size === authoritative.knownSize);
+		if (notSuperseded) {
 			const { version, seq, cachedExports, projectRulesScan } =
 				authoritative.snapshot;
 			return { version, seq, cachedExports, projectRulesScan };
 		}
+		// On mismatch, unlike the full loader, this narrow loader neither
+		// deletes the entry nor touches its idle timer (it never calls
+		// touchAuthoritativeSnapshot even on a hit). The stale entry is safe to
+		// leave in place: nothing here re-arms its eviction, so it is still
+		// bounded by whatever idle window the full loader (or the original
+		// write) last set, not left to live indefinitely.
 	}
 	if (!body) return null;
 	return readSnapshotExportsAndRulesBody(body.path, body.gz);
@@ -818,16 +826,16 @@ function loadProjectSnapshotInternal(
 	// Authoritative in-process write wins while our own (possibly still
 	// in-flight) write has not been superseded on disk by a newer external mtime
 	// or a different-size body in the same/coarser bucket. `body === null` means
-	// nothing is on disk yet — our just-scheduled write is the only truth, so
-	// serve it. Keep `<=`: the pre-promotion body can be older than our baseline.
+	// nothing is on disk — either our just-scheduled write hasn't landed yet, or
+	// something removed the body after we wrote it (e.g. a cleared cache dir).
+	// Neither case is "the body changed size", so serve the in-process object.
 	const authoritative = authoritativeSnapshots.get(key);
 	if (authoritative) {
-		const diskMtime = body ? body.mtimeMs : Number.NEGATIVE_INFINITY;
-		const diskSize = body ? body.size : Number.NEGATIVE_INFINITY;
-		if (
-			diskMtime <= authoritative.knownMtime &&
-			diskSize === authoritative.knownSize
-		) {
+		const notSuperseded =
+			body === null ||
+			(body.mtimeMs <= authoritative.knownMtime &&
+				body.size === authoritative.knownSize);
+		if (notSuperseded) {
 			touchAuthoritativeSnapshot(key, authoritative);
 			return authoritative.snapshot;
 		}

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -1415,6 +1415,49 @@ describe("project snapshot", () => {
 			fs.unlinkSync(gzPath);
 			expect(loadProjectSnapshot(cwd)).toBeNull();
 		}));
+
+	it.each([
+		["full loader", (cwd: string) => loadProjectSnapshot(cwd)],
+		[
+			"exports-and-rules loader",
+			(cwd: string) => loadProjectSnapshotExportsAndRules(cwd),
+		],
+	])(
+		"%s detects a different-size external rewrite in the same mtime bucket (#2285)",
+		(_name, load) =>
+			withProjectDataDir((cwd) => {
+				const runtime = new RuntimeCoordinator();
+				runtime.seedProjectSequence(7);
+				const saved = buildProjectSnapshotFromRuntime({ cwd, runtime });
+				saveProjectSnapshot(cwd, saved);
+
+				const gzPath = getProjectSnapshotPath(cwd);
+				const savedStat = fs.statSync(gzPath);
+				const external = new RuntimeCoordinator();
+				external.seedProjectSequence(9);
+				for (let i = 0; i < 40; i++) {
+					external.cachedExports.set(
+						`external_${i}_${"x".repeat(i)}`,
+						path.join(cwd, "external", `${i}.ts`),
+					);
+				}
+				fs.writeFileSync(
+					gzPath,
+					gzipSync(
+						JSON.stringify(
+							buildProjectSnapshotFromRuntime({ cwd, runtime: external }),
+						),
+					),
+				);
+				const bucketMtime = Math.floor(savedStat.mtimeMs / 2000) * 2000;
+				fs.utimesSync(gzPath, new Date(bucketMtime), new Date(bucketMtime));
+				const externalStat = fs.statSync(gzPath);
+				expect(externalStat.size).not.toBe(savedStat.size);
+				expect(externalStat.mtimeMs).toBeLessThanOrEqual(savedStat.mtimeMs);
+
+				expect(load(cwd)?.seq).toBe(9);
+			}),
+	);
 });
 
 describe("project snapshot worker persist (#958)", () => {

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -1392,6 +1392,18 @@ describe("project snapshot", () => {
 			expect(first).toBe(saved);
 			expect(loadProjectSnapshot(cwd)).toBe(saved);
 
+			// A newer mtime with IDENTICAL bytes must supersede on its own —
+			// this pins the mtime clause specifically, because the size axis
+			// added for #2285 satisfies the different-size case below by
+			// itself and silently absorbed this guard's old coverage.
+			const gzPathEarly = getProjectSnapshotPath(cwd);
+			const sameBytes = fs.readFileSync(gzPathEarly);
+			fs.writeFileSync(gzPathEarly, sameBytes);
+			const bumpedSame = new Date(Date.now() + 6000);
+			fs.utimesSync(gzPathEarly, bumpedSame, bumpedSame);
+			expect(fs.statSync(gzPathEarly).size).toBe(sameBytes.length);
+			expect(loadProjectSnapshot(cwd)).not.toBe(saved);
+
 			// An external writer moves the gz body past our own write (newer
 			// mtime) → the authoritative entry is abandoned and disk wins.
 			const other = new RuntimeCoordinator();
@@ -1466,7 +1478,7 @@ describe("project snapshot", () => {
 			(cwd: string) => loadProjectSnapshotExportsAndRules(cwd),
 		],
 	])(
-		"%s carries forward the authoritative in-process write when the body disappears from disk (#2296)",
+		"%s carries forward the authoritative in-process write when the body disappears from disk (#2285)",
 		(_name, load) =>
 			withProjectDataDir((cwd) => {
 				const runtime = new RuntimeCoordinator();

--- a/tests/clients/project-snapshot.test.ts
+++ b/tests/clients/project-snapshot.test.ts
@@ -1458,6 +1458,37 @@ describe("project snapshot", () => {
 				expect(load(cwd)?.seq).toBe(9);
 			}),
 	);
+
+	it.each([
+		["full loader", (cwd: string) => loadProjectSnapshot(cwd)],
+		[
+			"exports-and-rules loader",
+			(cwd: string) => loadProjectSnapshotExportsAndRules(cwd),
+		],
+	])(
+		"%s carries forward the authoritative in-process write when the body disappears from disk (#2296)",
+		(_name, load) =>
+			withProjectDataDir((cwd) => {
+				const runtime = new RuntimeCoordinator();
+				runtime.seedProjectSequence(7);
+				const saved = buildProjectSnapshotFromRuntime({ cwd, runtime });
+				saveProjectSnapshot(cwd, saved);
+
+				// Our own write is authoritative and has been reconciled against the
+				// body it just wrote (knownMtime/knownSize are real numbers now).
+				const gzPath = getProjectSnapshotPath(cwd);
+				expect(fs.existsSync(gzPath)).toBe(true);
+
+				// External deletion — e.g. a user clearing the cache dir mid-session.
+				// `body === null` means nothing is on disk, which per the documented
+				// contract at loadProjectSnapshotInternal must NOT be read as "the
+				// body changed size"; our own in-process write is still the only
+				// truth and must keep being served.
+				fs.unlinkSync(gzPath);
+
+				expect(load(cwd)?.seq).toBe(7);
+			}),
+	);
 });
 
 describe("project snapshot worker persist (#958)", () => {


### PR DESCRIPTION
## Summary

- Add the on-disk size to each authoritative project-snapshot stamp and validate it at both public load sites.
- Preserve the load-bearing `diskMtime <= knownMtime` rule for in-flight writes. A different-size body in the same or an older mtime bucket now invalidates the authoritative serve.
- Keep the tier metadata-only. A same-size, same-mtime external rewrite remains invisible by design, matching the issue's requested decision and avoiding #2292's unbounded hot-path hashing cost.
- Stop the unbounded mask on the next read. The full loader deletes the mismatched authoritative entry; the narrow loader serves disk without touching or re-arming the entry's idle timer.

Closes #2285.

## Tests

- Red proof on the pre-fix code: both new parameterized cases failed at `expect(load(cwd)?.seq).toBe(9)` with `expected 7 to be 9`; 2 failed, 53 skipped.
- Mutation proof: replacing both new size comparisons with `true` produced the same two assertion failures.
- `npm run build`
- `npm test -- --run tests/clients/project-snapshot.test.ts` (55 passed)
- `npm run lint`
- `npm run fmt:check`

## Class sweep

Searched `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts` for `mtimeMs`, `.mtime`, `knownMtime`, `lastMtime`, and mtime comparisons.

- `clients/project-snapshot.ts` authoritative cache: defect confirmed at both load sites and fixed here.
- `clients/project-snapshot.ts` parse cache: already compares `mtimeMs` and size.
- `tools/lens-diagnostics.ts`, `clients/advisory-provenance.ts`, `clients/blocker-freshness.ts`, `clients/diagnostic-dispositions.ts`, `clients/diagnostic-line-freshness.ts`, `clients/file-utils.ts`, `clients/opaque-mutation-scan.ts`, `clients/pipeline.ts`, `clients/project-lens-config.ts`, `clients/dispatch/runners/yaml-rule-parser.ts`, and `clients/word-index.ts`: content-bearing metadata gates already include size or a stronger content confirmation.
- `clients/tree-sitter-cache.ts`: production callers provide content, so the content hash is authoritative; its mtime-only fallback is test-only by documented contract.
- `clients/review-graph/workspace-modules.ts`, `clients/workspace-topology.ts`, and project-config directory stamps: directory-membership invalidation, where file-size identity is not a valid axis; not members.
- `clients/freshness.ts`, `clients/read-guard.ts`, `clients/session-state-store.ts`, PID/lock age checks, and diagnostic scanned-at comparisons: event ordering or age gates, not content memos; not members.
- `mcp/build-staleness.ts`, `clients/installer/index.ts`, `clients/lsp/diagnostic-binding.ts`, `clients/lsp/workspace-diagnostics-cache.ts`, and `clients/recent-touches.ts`: mtime-only memo candidates, but separate cache contracts and call paths. This PR does not claim they are safe. The five leads are tracked in #2300 rather than expanding #2285's authoritative-snapshot seam.

No textual twin of the fixed authoritative gate remains.

## Blast radius

Caller grep shows the full loader feeds MCP analysis, reverse-dependency reads, runtime-session warmup/hydration, word-index persistence, and project-snapshot merge writers. The narrow loader feeds runtime-session export/rule hydration. Both now honor a different-size external body immediately.

The hot-path cost stays O(1): no new `stat` or file read was added. Both loaders reuse the existing resolved body `{mtimeMs, size}`. Post-promotion assigns two fields from its existing single stat. Each authoritative hit adds one numeric selection and one equality comparison.

## Test assessment

- `tests/clients/project-snapshot.test.ts`: the two table cases uniquely pin the full and narrow production loaders against a real different-size gzip rewrite in the saved file's same two-second mtime bucket. No existing test is redundant; the older external-writer test covers a strictly newer mtime instead.

## Observability

No production log or ledger record proves this cache decision. The masked-write failure returned a plausible stale snapshot rather than an error, and this fix adds no per-hit logging to the hot path. The regression test is the proof surface; the production observability gap remains explicit.

## AGENTS.md sections consulted

- Issue and PR design contract
- Contributing
- Recurring defect shapes, shape 6
- Test requirements and test-authoring screens
- Standing invariants: caches, durable stores, and path keys

## Fix round (review findings, commit 4aba08cc)

**F1 (blocking, fixed).** Both loaders read `body === null` (nothing on disk)
as a size mismatch, because `diskSize` fell back to `-Infinity` while
`knownSize` was a real stamped number after our own write. An external
deletion of the body — clearing the cache dir mid-session — therefore looked
like a different-size rewrite: both loaders dropped the carry-forward and
returned `null`, contradicting the documented `body === null` contract this
code already stated in its own comment. Rewrote both guards so `body ===
null` short-circuits to "not superseded" and keeps serving the authoritative
object, matching the pre-existing contract.

Kept the comparison in `<=`/`===` form (`body === null || (body.mtimeMs <=
knownMtime && body.size === knownSize)`) rather than the logically
equivalent inverted `>`/`!==` shape, because the inverted form trips
`tests/clients/freshness-sweep.test.ts`'s out-of-kernel mtime-comparison
ratchet, which matches on `>`/`>=`. The freshness kernel's own tolerance
(50ms) is not appropriate here — this gate deliberately uses an exact `<=`
bucket comparison, not a drift-tolerant reference check — so migrating to
`freshnessFromMtime` would change behavior, not just form.

Red proof on the pre-fix commit (fcd358d9), both new parameterized cases:

```
× full loader carries forward the authoritative in-process write when the body disappears from disk (#2296) 60ms
× exports-and-rules loader carries forward the authoritative in-process write when the body disappears from disk (#2296) 33ms
AssertionError: expected undefined to be 7 // Object.is equality
```

Green after the fix: `tests/clients/project-snapshot.test.ts` 57 passed.
Mutation proof: replacing `body === null` with `false` in both sites broke
the build (`'body' is possibly 'null'`) and, forced through, reproduced the
same red failures — the guard is load-bearing.

**F2 (addressed, documented).** The narrow loader still does not delete the
authoritative entry on a size mismatch. Judged the PR body's original
rationale (avoid touching the idle timer) sound rather than thin: the narrow
loader never calls `touchAuthoritativeSnapshot` even on a hit, so a
mismatched entry it leaves in place is not re-armed by it either — eviction
stays bounded by whatever idle window the full loader (or the original
write) last set. Added a comment at the narrow loader recording this instead
of aligning it with the full loader's delete.

**F3 (re-homed).** The five untracked class-sweep leads (`mcp/build-
staleness.ts`, `clients/installer/index.ts`, `clients/lsp/diagnostic-
binding.ts`, `clients/lsp/workspace-diagnostics-cache.ts`,
`clients/recent-touches.ts`) now live in #2300. Updated the class-sweep
section above to reference the issue instead of listing them as loose leads.

**F4 (documented).** Added one sentence to AGENTS.md's caches section:
`touchAuthoritativeSnapshot` re-arms the idle-eviction timer on every full-
loader hit, so a bucket the narrow loader alone keeps hitting rides an
indefinite mask, not one bounded by the 20-minute idle window.

**Verification this round:** `npm run build`; targeted suite
`tests/clients/project-snapshot.test.ts` (57 passed); the five other files
referencing the loaders (`reverse-deps`, `runtime-session-retro-hydrate-
warmup-race`, `word-index-lifecycle`, `word-index`, `symbol-search`, 97
passed, 1 skipped); the ten governance sweeps named in the fix-round brief
(`delivery-surface-ratchet`, `finding-delivery-gate`,
`session-state-conformance`, `bounded-telemetry-sweep`,
`bus-producer-coverage`, `deps-centralization`, `freshness-sweep`,
`managed-tool-seam-coverage`, `profiling-coverage`,
`module-instance-coverage`/`module-instance-binding`,
`sweep-floor-coverage`), all green (313 passed, 1 skipped across those plus
project-snapshot and freshness-sweep); `npm run lint`; `npm run fmt:check`;
`npm run changelog:check` (existing #2285 fragment still valid, no new
fragment needed — same bug, same PR, not yet merged). Full suite deferred to
CI.

`closes #2285` stays: every acceptance criterion from the issue is still
met, and this round only restores a contract this PR itself introduced.

