### PR TITLE
test(rules): guard warmed cache work (closes #2292)

### DIFF
--- a/.changelog/test-2292-rules-cache-work-count.md
+++ b/.changelog/test-2292-rules-cache-work-count.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Guard the warmed YAML rules cache with load-invariant work counts (closes #2292)** — assert that repeated cache hits perform no directory, metadata, or content reads inside the freshness cadence, and that the next cadence performs one metadata sweep without reading rule content.

--- a/tests/clients/dispatch/runners/yaml-rule-parser.test.ts
+++ b/tests/clients/dispatch/runners/yaml-rule-parser.test.ts
@@ -9,7 +9,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // mock for the sibling cadence — makes it spy-able.
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>();
-	return { ...actual, statSync: vi.fn(actual.statSync) };
+	return {
+		...actual,
+		readFileSync: vi.fn(actual.readFileSync),
+		readdirSync: vi.fn(actual.readdirSync),
+		statSync: vi.fn(actual.statSync),
+	};
 });
 
 import {
@@ -100,7 +105,7 @@ describe("yaml-rule-parser cache freshness (#2262)", () => {
 		expect(messages(loadYamlRules(root))).toEqual(["child", "root"]);
 	});
 
-	it("re-stats a rule directory at most once per cadence window, not once per call", () => {
+	it("performs one metadata sweep and no content reads per cadence window", () => {
 		const root = fs.mkdtempSync(
 			path.join(os.tmpdir(), "pilens-rules-cache-bounded-"),
 		);
@@ -110,13 +115,24 @@ describe("yaml-rule-parser cache freshness (#2262)", () => {
 		const start = Date.now();
 		loadYamlRules(root); // primes the cache: one sweep
 
+		const readFileSpy = vi.mocked(fs.readFileSync);
+		const readdirSpy = vi.mocked(fs.readdirSync);
 		const statSpy = vi.mocked(fs.statSync);
-		statSpy.mockClear();
+		for (const spy of [readFileSpy, readdirSpy, statSpy]) spy.mockClear();
 		for (let i = 0; i < 25; i++) loadYamlRules(root);
+		expect(readFileSpy).not.toHaveBeenCalled();
+		expect(readdirSpy).not.toHaveBeenCalled();
 		expect(statSpy).not.toHaveBeenCalled();
 
 		vi.setSystemTime(start + RULES_CACHE_FRESHNESS_CADENCE_MS + 1);
 		loadYamlRules(root);
+		expect(readFileSpy).not.toHaveBeenCalled();
+		expect(readdirSpy).toHaveBeenCalledTimes(1);
+		expect(statSpy).toHaveBeenCalledTimes(1);
+
+		for (let i = 0; i < 25; i++) loadYamlRules(root);
+		expect(readFileSpy).not.toHaveBeenCalled();
+		expect(readdirSpy).toHaveBeenCalledTimes(1);
 		expect(statSpy).toHaveBeenCalledTimes(1);
 	});
 


### PR DESCRIPTION
## Summary

- Add a load-invariant work-count guard for warmed `getCachedRules` calls.
- Assert zero content reads and no metadata work inside the two-second cadence.
- Assert one directory read and one stat at the next cadence boundary, followed by no repeated work in that window.
- Add a Fixed changelog fragment for the CI coverage gap.

Closes #2292.

## Tests

- `performs one metadata sweep and no content reads per cadence window` extends the existing bounded-cost test because the old stat-only assertion could not detect content confirmation or recursive directory work.
- `npx vitest run --project default tests/clients/dispatch/runners/yaml-rule-parser.test.ts` passes 10 tests.
- `npm run lint` passes.
- `npm run fmt:check` passes across 1,417 files.
- Mutation proof: restoring the round-one content-confirm branch from `67e58ffb` fails at `yaml-rule-parser.test.ts:129` because `readFileSync` receives one call for `a.yml`.

## Blast radius

This PR changes one test mock, one existing test case, and one changelog fragment. Production modules, callbacks, dependents, and entry points are unchanged, so the production blast radius is empty. The test exercises the public `loadYamlRules` entry point used by the scanner path.

## Class sweep

- `clients/cache/rule-cache.ts`: covered. `tests/clients/cache/rule-cache.test.ts` mutates a real bundled rule while preserving size and mtime, then proves the bundled tier remains a metadata-only cache hit.
- `clients/file-utils.ts`: covered. `tests/clients/nested-ignore-freshness-clock.test.ts` and `tests/clients/project-ignore-freshness.test.ts` count source stats across the project-ignore cadence.
- No sibling needs a follow-up issue.

## Observability

This test closes the CI observability gap described in #2292 by making warmed-path filesystem work directly countable. Runtime logging remains unchanged because the issue identifies no required production telemetry change.

## Test assessment

Keep the edited test. It guards a P2 hot-path regression with deterministic filesystem work counts and fails when the defective branch is restored. It reuses the existing filesystem mock and bounded-cost fixture, so it adds no parallel harness or timing threshold.

## AGENTS.md sections consulted

- Issue and PR design contract
- Contributing
- Standing invariants
- Test requirements
- Test-authoring screens