### PR TITLE
fix(tests): deflake spawn-timeout-cooldown under load (refs #2235)

### DIFF
--- a/.changelog/2235-spawn-timeout-cooldown.md
+++ b/.changelog/2235-spawn-timeout-cooldown.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Make the spawn-timeout cooldown regression test load-invariant (closes #2235)** — load the real pipeline during test-module setup so the 5000ms test budget measures cooldown behavior instead of contention during a heavy dynamic import.

--- a/tests/clients/spawn-timeout-cooldown.test.ts
+++ b/tests/clients/spawn-timeout-cooldown.test.ts
@@ -46,9 +46,15 @@ vi.mock("../../clients/tool-policy.js", async (importOriginal) => ({
 	getLinterPolicyForCwd: () => null,
 	markdownlintConfigArgs: () => [],
 }));
+
 import { detectFileChangedAfterCommand } from "../../clients/file-utils.js";
 import { makeRunnerCtx } from "../support/runner-ctx.js";
 import { setupTestEnvironment } from "./test-utils.js";
+
+// #2235: load the real pipeline during module setup. Its import graph is
+// substantial, so awaiting it inside a test makes Vitest's 5000ms test budget
+// measure scheduler contention instead of the cooldown behavior.
+const pipeline = await import("../../clients/pipeline.js");
 
 const TIMEOUT_RESULT = {
 	error: null,
@@ -154,45 +160,29 @@ describe("tryMarkdownlintFix consults the seam (review P2)", () => {
 		safeSpawnAsync.mockReset();
 	});
 
-	it(
-		"returns 0 WITHOUT spawning when its resolved command is cooling down",
-		// #2235: this test pairs real filesystem I/O (setupTestEnvironment,
-		// writeFileSync) with a dynamic import of pipeline.js — a genuinely
-		// heavy module graph, measured at ~1.5s to resolve on an idle machine.
-		// The default 5000ms budget has only ~3x margin, which several
-		// concurrent vitest workers or sibling agent worktrees building/testing
-		// at once reliably exhaust: reproduced locally under synthetic 14-worker
-		// CPU load as a hard 5020ms timeout (vs. 1537ms idle), a ~3.3x slowdown
-		// this budget doesn't survive. 20s matches the margin already used
-		// elsewhere in this suite for real-spawn/real-import paths (e.g.
-		// safe-spawn-timeout-teardown.test.ts's 15-20s budgets) and comfortably
-		// covers the measured slowdown with headroom to spare.
-		{ timeout: 20_000 },
-		async () => {
-			const env = setupTestEnvironment("pi-lens-timeout-pipeline-guard-");
-			try {
-				const filePath = path.join(env.tmpDir, "notes.md");
-				fs.writeFileSync(filePath, "# hello\n");
-				const { noteSpawnTimeout } = await seam();
-				// The mocked resolver returns the bare tool id; in production both
-				// lanes resolve the same physical binary, and basename-level
-				// keying is what makes different spellings cross-cool.
-				noteSpawnTimeout({
-					tool: "markdownlint",
-					command: "markdownlint",
-					phase: "availability",
-				});
+	it("returns 0 WITHOUT spawning when its resolved command is cooling down", async () => {
+		const env = setupTestEnvironment("pi-lens-timeout-pipeline-guard-");
+		try {
+			const filePath = path.join(env.tmpDir, "notes.md");
+			fs.writeFileSync(filePath, "# hello\n");
+			const { noteSpawnTimeout } = await seam();
+			// The mocked resolver returns the bare tool id; in production both
+			// lanes resolve the same physical binary, and basename-level
+			// keying is what makes different spellings cross-cool.
+			noteSpawnTimeout({
+				tool: "markdownlint",
+				command: "markdownlint",
+				phase: "availability",
+			});
 
-				const pipeline = await import("../../clients/pipeline.js");
-				const fixed = await pipeline.tryMarkdownlintFix(filePath, env.tmpDir);
+			const fixed = await pipeline.tryMarkdownlintFix(filePath, env.tmpDir);
 
-				expect(fixed).toBe(0);
-				expect(safeSpawnAsync).not.toHaveBeenCalled();
-			} finally {
-				env.cleanup();
-			}
-		},
-	);
+			expect(fixed).toBe(0);
+			expect(safeSpawnAsync).not.toHaveBeenCalled();
+		} finally {
+			env.cleanup();
+		}
+	});
 });
 
 describe("cross-lane key sharing (review P2)", () => {


### PR DESCRIPTION
## Summary

The flaky case in `spawn-timeout-cooldown.test.ts` spent its 5000 ms Vitest budget importing the production pipeline graph after a module reset, not waiting on cooldown time. Under machine load the import alone blew the budget. The test now preloads the real `pipeline.js` during module setup (outside the per-test budget) and drops its 20-second escape-hatch override. The production path stays real; only the heavy import moves.

## Class sweep

The 5000 ms sweep over tests/clients found: nine availability-policy spawn-budget fixtures, one JVM spawn-budget fixture, one oxlint forwarded-option assertion, and several date/deadline constants — all intentional deterministic inputs, not Vitest budgets. Real elapsed waits remain in LSP aggregation, client-retention, and module-report polling; those are follow-up candidates outside this cooldown guard.

## Blast radius

Test-only. The production cooldown guard (`clients/pipeline.ts:665`) is untouched.

## Tests

See the review round below: the reviewer's runs substitute for the author's blocked verification. Locally reproduced: 8/8 on the file, 10x sequential green, 5/5 under forced contention (guard case 6-9 ms), mutation of the shared predicate reds 7 of 8 in under 15 ms.

## Test assessment

Authored by a delegated worker whose verification tooling was blocked by machine-wide dependency-lock contention (`npm ci` failed on a locked rolldown native binary; tsc/vitest/oxfmt unavailable in its worktree). The worker ran NO tests, NO lint, and NO mutation proof — this section is deliberately honest about that. The adversarial review round is the first verification: it must run the file repeatedly under contention, prove the cooldown guard still reds under mutation, and gate the merge on those results plus CI.

## Observability

No runtime record involved; CI plus the review round's contention runs are the evidence.

Refs #2235.

## Review round

First verification (the author ran none): the reviewer measured the mechanism — master's guard test consumed 4779 ms of its 5000 ms budget on an idle machine (import cost inside the test timer); the PR head runs it in 21-30 ms with the import moved to module setup (vitest file summary: import 6.39s / tests 0.21s). 10x sequential and 5x under contention all green. Neutering the shared cooldown predicate reds 7 of 8 tests in 7-15 ms, so a genuine failure stays loud and fast. The class sweep's real axis is `vi.resetModules()` + heavy in-test dynamic import; swept across tests/, this file was the only member. One pre-existing finding filed separately: the `tryMarkdownlintFix consults the seam` case is vacuous at the surface it names (the downstream self-guard at file-utils.ts:961 absorbs the mutation) — true on master too, not introduced here.
