### PR TITLE
fix(tests): feed target-cap state through recordResult (refs #2290)

### DIFF
--- a/.changelog/fix-2290-target-cap-test.md
+++ b/.changelog/fix-2290-target-cap-test.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Make the failed-target cap test load-invariant (closes #2290)** — Seed the real `TestRunnerClient` state with deterministic failed results instead of launching 33 child processes, so the cap assertion is independent of batch contention.

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -11,7 +11,11 @@ import {
 	flushLatencyLog,
 	getLatencyLogPath,
 } from "../../clients/latency-logger.js";
-import { RUNNERS, TestRunnerClient } from "../../clients/test-runner-client.js";
+import {
+	RUNNERS,
+	TestRunnerClient,
+	type TestResult,
+} from "../../clients/test-runner-client.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
 // Only the resolveExec matrix below (#1098) needs this mocked; every other
@@ -1298,6 +1302,36 @@ describe("test-runner-client", () => {
 				path.join(second.tmpDir, `failure-${index}_test.go`),
 			);
 			const client = new TestRunnerClient(false);
+			// The cap is the behavior under test. Feed the real client failed results
+			// at its recording seam instead of paying for 33 process startups.
+			const recordFailedTarget = (root: string, testFile: string): void => {
+				fs.writeFileSync(testFile, "package widget\n");
+				(
+					client as unknown as {
+						recordResult(record: {
+							cwd: string;
+							runner: string;
+							testFile: string;
+							result: TestResult;
+							turnIndex: number;
+						}): void;
+					}
+				).recordResult({
+					cwd: root,
+					runner: "go",
+					testFile,
+					result: {
+						file: testFile,
+						sourceFile: "",
+						runner: "go",
+						passed: 0,
+						failed: 1,
+						skipped: 0,
+						failures: [],
+					},
+					turnIndex: 2045,
+				});
+			};
 			const previousTestMode = process.env.PI_LENS_TEST_MODE;
 			process.env.PI_LENS_TEST_MODE = "0";
 			try {
@@ -1309,13 +1343,7 @@ describe("test-runner-client", () => {
 					...middle.map((testFile) => [second.tmpDir, testFile]),
 					[first.tmpDir, newest],
 				]) {
-					fs.writeFileSync(testFile, "package widget\n");
-					const seeded = await client.runTestFileAsync(testFile, root, {
-						runner: "go",
-						config: failingNodeConfig,
-						turnIndex: 2045,
-					});
-					expect(seeded.failed).toBe(1);
+					recordFailedTarget(root, testFile);
 				}
 
 				expect(


### PR DESCRIPTION
## Summary

The #2044 target-cap test in `tests/clients/test-runner-client.test.ts` timed out under batch contention because it paid 33 real process startups to build its eviction state. It now writes its fixture files and feeds failed results through the real `TestRunnerClient.recordResult` seam — same eviction state, same telemetry path, zero spawned processes. Test body completes in 0.13–0.24 s.

## Tests

- Targeted test: 8 consecutive isolated runs green.
- Full `test-runner-client` file: 160/160.
- Mutation proof: raising the cap to 100 reds at the newest-target assertion (selects `oldest_test.go` instead of `newest_test.go` at line 1345) — the guard still pins the cap.
- npm ci, build, lint, oxfmt all green in the worker's isolated worktree.

## Class sweep

Sibling tests in the same file that spawn real processes for state-building are candidates for the same seam-feeding conversion; this PR scopes to the one contention-flaky member per #2290.

## Blast radius

Test-only; `clients/test-runner-client.ts` untouched.

## Test assessment

Authored by a delegated worker with its own verification (above); the adversarial review round re-verifies independently before merge.

## Observability

Test-layer change; no runtime record involved.

Refs #2290.
