### PR TITLE
fix(tests): convert cross-root eviction to recordResult seam (closes #2305)

### DIFF
--- a/.changelog/fix-2305-cross-root-eviction.md
+++ b/.changelog/fix-2305-cross-root-eviction.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Make cross-root eviction coverage load-invariant (closes #2305)** — Seed failed-target eviction state through `TestRunnerClient.recordResult` instead of spawning child processes, while retaining global ordering, root-map reacquisition, and telemetry assertions.

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -1376,37 +1376,97 @@ describe("test-runner-client", () => {
 			);
 			const newest = path.join(second.tmpDir, "newest_test.go");
 			const client = new TestRunnerClient(false);
-			const recordFailure = async (root: string, testFile: string) => {
+			const recordFailure = (
+				client: TestRunnerClient,
+				root: string,
+				testFile: string,
+			): void => {
 				fs.writeFileSync(testFile, "package widget\n");
-				const result = await client.runTestFileAsync(
+				(
+					client as unknown as {
+						recordResult(record: {
+							cwd: string;
+							runner: string;
+							testFile: string;
+							result: TestResult;
+							turnIndex: number;
+						}): void;
+					}
+				).recordResult({
+					cwd: root,
+					runner: "go",
 					testFile,
-					root,
-					"go",
-					failingNodeConfig,
-				);
-				expect(result.failed).toBe(1);
+					result: {
+						file: testFile,
+						sourceFile: "",
+						runner: "go",
+						passed: 0,
+						failed: 1,
+						skipped: 0,
+						failures: [],
+					},
+					turnIndex: 2045,
+				});
 			};
 
-			await recordFailure(first.tmpDir, hot);
-			for (const testFile of cold) {
-				await recordFailure(second.tmpDir, testFile);
-			}
-			// Refresh A after every original B entry, then force one eviction in B.
-			await recordFailure(first.tmpDir, hot);
-			await recordFailure(second.tmpDir, newest);
+			const previousTestMode = process.env.PI_LENS_TEST_MODE;
+			process.env.PI_LENS_TEST_MODE = "0";
+			try {
+				resetBoundedTelemetry();
+				clearLatencyLog();
+				await flushLatencyLog();
+				recordFailure(client, first.tmpDir, hot);
+				for (const testFile of cold) {
+					recordFailure(client, second.tmpDir, testFile);
+				}
+				// Refresh A after every original B entry, then force one eviction in B.
+				recordFailure(client, first.tmpDir, hot);
+				recordFailure(client, second.tmpDir, newest);
 
-			expect(
-				client.getTestRunTarget(
-					path.join(first.tmpDir, "widget.go"),
+				expect(
+					client.getTestRunTarget(
+						path.join(first.tmpDir, "widget.go"),
+						first.tmpDir,
+					)?.testFile,
+				).toBe(path.resolve(hot));
+				expect(
+					client.getTestRunTarget(
+						path.join(second.tmpDir, "widget.go"),
+						second.tmpDir,
+					)?.testFile,
+				).toBe(path.resolve(cold[1]));
+
+				// Refresh another root, then evict the sole target in this root. The
+				// new target must be inserted into a reacquired root map.
+				const reacquisitionClient = new TestRunnerClient(false);
+				const reacquisitionNewest = path.join(
 					first.tmpDir,
-				)?.testFile,
-			).toBe(path.resolve(hot));
-			expect(
-				client.getTestRunTarget(
-					path.join(second.tmpDir, "widget.go"),
-					second.tmpDir,
-				)?.testFile,
-			).toBe(path.resolve(cold[1]));
+					"reacquired_test.go",
+				);
+				recordFailure(reacquisitionClient, first.tmpDir, hot);
+				for (const testFile of cold) {
+					recordFailure(reacquisitionClient, second.tmpDir, testFile);
+				}
+				recordFailure(reacquisitionClient, second.tmpDir, cold[0]);
+				recordFailure(reacquisitionClient, first.tmpDir, reacquisitionNewest);
+				expect(
+					reacquisitionClient.getTestRunTarget(
+						path.join(first.tmpDir, "widget.go"),
+						first.tmpDir,
+					)?.testFile,
+				).toBe(path.resolve(reacquisitionNewest));
+
+				await flushLatencyLog();
+				const log = fs.readFileSync(getLatencyLogPath(), "utf8");
+				expect(log).toContain('"outcome":"capacity-evicted"');
+				expect(log).toContain('"phase":"test_runner_failed_target_state"');
+			} finally {
+				if (previousTestMode === undefined) {
+					delete process.env.PI_LENS_TEST_MODE;
+				} else {
+					process.env.PI_LENS_TEST_MODE = previousTestMode;
+				}
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary

The cross-root eviction test at tests/clients/test-runner-client.test.ts:1370 spawned 34 real processes and ran at 3301 ms of its 5000 ms budget — one bad run from the #2290 failure. It now builds its eviction state through the real `TestRunnerClient.recordResult` seam (the merged #2303 template), keeping every assertion. Isolated body: 113 ms.

## Tests

- Full targeted file 160/160.
- All four pinned-surface mutations red after conversion: M1 cap 32→100; M2 eviction comparator flip; M3 capacity-evicted telemetry suppressed; M4 post-eviction root-map reacquisition deleted.
- Build, lint, oxfmt green in the worker's isolated worktree.

## Class sweep

With #2303 and this PR, the two contention-critical members are converted; the real spawn→parse→record wiring remains covered — the review proved a wiring cut reds six tests, with `prefers failed-first target when failure cache exists` (:961) as the primary carrier and `retires one runner without clearing another in the same project` (:1080) carrying it across two runners. Neither seam-fed test reds under that cut, which is the correct division of labor.

## Blast radius

Test-only; `clients/test-runner-client.ts` untouched.

## Test assessment

Worker-authored with its own mutation matrix; the adversarial review round re-verifies independently and gates the merge.

## Observability

Test-layer change; the M3 mutation keeps the telemetry assertion load-bearing.

The added reacquisition scenario is belt-and-braces: load-bearing for M4 at test scope, redundant at file scope (the #2303 test pins the same property) — kept deliberately at ~20 ms cost.

Closes #2305.
