### PR TITLE
refactor(pipeline): drop redundant cooldown consult (closes #2301)

### DIFF
--- a/.changelog/2301-remove-redundant-pipeline-cooldown.md
+++ b/.changelog/2301-remove-redundant-pipeline-cooldown.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Remove the redundant markdownlint autofix cooldown guard (closes #2301)** — `detectFileChangedAfterCommand` remains the single source of truth for autofix cooldowns, and its direct test owns that contract.

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -54,7 +54,6 @@ import {
 	getProjectIgnoreMatcher,
 	isExcludedDirName,
 } from "./file-utils.js";
-import { isInSpawnTimeoutCooldown } from "./spawn-timeout-cooldown.js";
 import type { FormatService } from "./format-service.js";
 import { logLatency } from "./latency-logger.js";
 import type { PostAutofixNotice } from "./post-autofix-notice.js";
@@ -651,18 +650,12 @@ async function tryDetektFix(filePath: string, cwd: string): Promise<number> {
 	);
 }
 
-// Exported for #1995 cooldown wiring tests: the guard on this lane is
-// one of three mutation-proof surfaces.
 export async function tryMarkdownlintFix(
 	filePath: string,
 	cwd: string,
 ): Promise<number> {
 	const cmd = await resolveToolCommandWithInstallFallback(cwd, "markdownlint");
 	if (!cmd) return 0;
-	// #1995: skip the spawn entirely when the command is cooling down after a
-	// timeout — detectFileChangedAfterCommand also self-guards, but a wedged
-	// command should not even reach a second budget in the hot loop.
-	if (isInSpawnTimeoutCooldown(cmd)) return 0;
 	// Shared config-args seam (#1247): the lint runner consumes the same
 	// builder, so the bare --fix here can never fall back to markdownlint's
 	// default all-rules-on config again (the whole-file CHANGELOG/AGENTS

--- a/tests/clients/spawn-timeout-cooldown.test.ts
+++ b/tests/clients/spawn-timeout-cooldown.test.ts
@@ -51,11 +51,6 @@ import { detectFileChangedAfterCommand } from "../../clients/file-utils.js";
 import { makeRunnerCtx } from "../support/runner-ctx.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
-// #2235: load the real pipeline during module setup. Its import graph is
-// substantial, so awaiting it inside a test makes Vitest's 5000ms test budget
-// measure scheduler contention instead of the cooldown behavior.
-const pipeline = await import("../../clients/pipeline.js");
-
 const TIMEOUT_RESULT = {
 	error: null,
 	status: null,
@@ -148,37 +143,6 @@ describe("detectFileChangedAfterCommand consults the seam", () => {
 
 			const { isInSpawnTimeoutCooldown } = await seam();
 			expect(isInSpawnTimeoutCooldown(cmd)).toBe(true);
-		} finally {
-			env.cleanup();
-		}
-	});
-});
-
-describe("tryMarkdownlintFix consults the seam (review P2)", () => {
-	beforeEach(() => {
-		vi.resetModules();
-		safeSpawnAsync.mockReset();
-	});
-
-	it("returns 0 WITHOUT spawning when its resolved command is cooling down", async () => {
-		const env = setupTestEnvironment("pi-lens-timeout-pipeline-guard-");
-		try {
-			const filePath = path.join(env.tmpDir, "notes.md");
-			fs.writeFileSync(filePath, "# hello\n");
-			const { noteSpawnTimeout } = await seam();
-			// The mocked resolver returns the bare tool id; in production both
-			// lanes resolve the same physical binary, and basename-level
-			// keying is what makes different spellings cross-cool.
-			noteSpawnTimeout({
-				tool: "markdownlint",
-				command: "markdownlint",
-				phase: "availability",
-			});
-
-			const fixed = await pipeline.tryMarkdownlintFix(filePath, env.tmpDir);
-
-			expect(fixed).toBe(0);
-			expect(safeSpawnAsync).not.toHaveBeenCalled();
 		} finally {
 			env.cleanup();
 		}


### PR DESCRIPTION
## Summary

The cooldown consult at `clients/pipeline.ts:665` was redundant: every spawn path reaches `detectFileChangedAfterCommand`, whose guard at `clients/file-utils.ts:961` absorbs the check, which is why neutering the pipeline copy left 8/8 green (#2301, found in #2299's review). The redundant check is deleted; file-utils stays the single source of truth. The vacuous test and the false "three mutation-proof surfaces" comment go with it — the comment block was deleted outright rather than rewritten (the review confirmed no replacement exists and none is needed; the two real guards carry their own red-proven tests).

## Tests

Neuter verdicts for all three claimed surfaces:
- pipeline.ts:665 — 8/8 green under neuter (vacuous; deleted).
- file-utils.ts:961 — test reds under neuter (independent, retained).
- markdownlint runner guard — test reds under neuter (independent, retained).

Targeted 7/7 after the deletion; build, lint, oxfmt, changelog check green.

## Class sweep

The three surfaces named by the old comment were each neuter-probed; per-member verdicts above. No other cooldown consults found on the pipeline path.

## Blast radius

`tryMarkdownlintFix` has one production caller; caller-grep confirms every spawn path flows through the retained file-utils guard. Behavior unchanged — the deleted check could never fire independently.

## Test assessment

Deleting redundancy was preferred over adding a test for it per the minimalism ladder, justified by the caller sweep plus the surviving guards' red proofs.

## Observability

No runtime record involved.

Refs #2301.
