### PR TITLE
fix(project-diagnostics): derive ast-grep kind per file in scanner (#2217)

### DIFF
--- a/.changelog/2217-scanner-ast-grep-kind.md
+++ b/.changelog/2217-scanner-ast-grep-kind.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Derive the project scan's ast-grep kind per file instead of hard-coding jsts (closes #2217)** — The scanner passed the literal `"jsts"` to `evaluateAstGrepRules` for every napi-evaluated file, including `.css` and `.html`, so `suppressLinterOverlap` (and any future kind-gated ast-grep policy) evaluated non-JS files under a JS/TS linter-overlap decision. It also diverged from the per-edit dispatch path, which derives kind from `detectFileKind` — the same file could see two different kinds depending on which path evaluated it. The scan now calls `detectFileKind` (the shared `KIND_EXTENSIONS` resolver), matching the dispatch path exactly.

--- a/clients/project-diagnostics/scanner.ts
+++ b/clients/project-diagnostics/scanner.ts
@@ -11,6 +11,7 @@ import {
 	loadSg,
 } from "../dispatch/runners/ast-grep-napi.js";
 import type { Diagnostic } from "../dispatch/types.js";
+import { detectFileKind } from "../file-kinds.js";
 import { isTestFile } from "../file-utils.js";
 import { isAtOrAboveHomeDir } from "../path-utils.js";
 import { getProjectDiagnosticsScannerMaxFiles } from "../project-scale.js";
@@ -238,7 +239,7 @@ async function scanFileMajorRules(
 				filePath,
 				rootNode,
 				cwd,
-				"jsts",
+				detectFileKind(filePath),
 				{
 					maxMatchesPerRule: AST_GREP_SCAN_MAX_MATCHES_PER_RULE,
 					maxTotalDiagnostics: AST_GREP_SCAN_MAX_DIAGNOSTICS_PER_FILE,

--- a/tests/clients/project-diagnostics/scanner-ast-grep-kind.test.ts
+++ b/tests/clients/project-diagnostics/scanner-ast-grep-kind.test.ts
@@ -1,0 +1,71 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// #2217: the scanner hard-coded kind "jsts" for every napi-evaluated file,
+// including .css/.html — mislabeling non-JS lanes and diverging from the
+// per-edit dispatch path, which derives kind from detectFileKind (#2296
+// review: css/html now reach the napi runner via dispatch too, so the two
+// paths can disagree on the SAME file). Wrap evaluateAstGrepRules to record
+// the `kind` argument the scanner actually passes.
+const state = vi.hoisted(() => ({
+	kinds: [] as (string | undefined)[],
+}));
+
+vi.mock(
+	"../../../clients/dispatch/runners/ast-grep-napi.js",
+	async (importOriginal) => {
+		const actual =
+			await importOriginal<
+				typeof import("../../../clients/dispatch/runners/ast-grep-napi.js")
+			>();
+		return {
+			...actual,
+			evaluateAstGrepRules: (
+				...args: Parameters<typeof actual.evaluateAstGrepRules>
+			) => {
+				state.kinds.push(args[3]);
+				return actual.evaluateAstGrepRules(...args);
+			},
+		};
+	},
+);
+
+import { scanProjectDiagnostics } from "../../../clients/project-diagnostics/scanner.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+let tmp: string;
+
+beforeEach(() => {
+	tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-scanner-kind-"));
+	state.kinds.length = 0;
+});
+
+afterEach(() => {
+	removeTempDirSync(tmp);
+});
+
+describe("project scan ast-grep kind derivation (#2217)", () => {
+	it("evaluates a .css file under its own kind, not jsts", async () => {
+		const cssFile = path.join(tmp, "style.css");
+		fs.writeFileSync(cssFile, "a { color: red; }\n");
+
+		await scanProjectDiagnostics({ cwd: tmp, tier: "all", files: [cssFile] });
+
+		expect(state.kinds.length).toBeGreaterThan(0);
+		for (const kind of state.kinds) {
+			expect(kind).not.toBe("jsts");
+		}
+		expect(state.kinds).toContain("css");
+	});
+
+	it("still evaluates a .ts file under kind jsts", async () => {
+		const tsFile = path.join(tmp, "index.ts");
+		fs.writeFileSync(tsFile, "export const x = 1;\n");
+
+		await scanProjectDiagnostics({ cwd: tmp, tier: "all", files: [tsFile] });
+
+		expect(state.kinds).toContain("jsts");
+	});
+});


### PR DESCRIPTION
## Summary

The project scanner passed the literal `"jsts"` to `evaluateAstGrepRules` for every
napi-evaluated file, so `.css`/`.html` files were graded under the JS/TS linter-overlap
policy (`suppressLinterOverlap = kind === "jsts" && hasEslintConfig(cwd)`). It now passes
`detectFileKind(filePath)`, the same shared `KIND_EXTENSIONS` resolver the per-edit
dispatch path uses (`clients/dispatch/dispatcher.ts:314` populates `ctx.kind` from it), so
both paths agree on a file's kind.

`clients/project-diagnostics/scanner.ts` is a 2-line change: import `detectFileKind`, call
it in place of the hardcoded literal. No new list, no new seam (the #883
single-source-of-truth pattern). `evaluateAstGrepRules` already types `kind` as
`string | undefined`, so an unrecognized extension resolves to `undefined` and lands on
the same non-jsts branch dispatch would take for it.

Closes #2217

## Tests

- NEW `tests/clients/project-diagnostics/scanner-ast-grep-kind.test.ts` — wraps
  `evaluateAstGrepRules` with `vi.mock` + `importOriginal` to record the `kind` argument
  the scanner actually passes, then drives the real `scanProjectDiagnostics` over a temp
  file.
  - `evaluates a .css file under its own kind, not jsts` — pins the fix. Recorded RED on
    pre-fix code by the authoring run: `AssertionError: expected 'jsts' not to be 'jsts'`.
  - `still evaluates a .ts file under kind jsts` — control; pins that the JS/TS lane is
    unchanged, so the fix cannot pass by making every kind `undefined`.
- No existing test files edited.
- Re-run in this worktree after `npm run build`: 2/2 green. `npm run lint` and
  `npm run fmt:check` clean. Full suite deferred to CI per #1112.
- Authoring screens: the assertion pins the argument at the seam that carries it rather
  than a downstream diagnostic count (wrong-layer pin); the mock delegates to the real
  implementation, so the scan is not an ambient-inspection double; the `.ts` control makes
  an invisible skip visible.

## Test assessment

`scanner-ast-grep-kind.test.ts` is the only place the scanner's `kind` argument is
observed at all. The existing scanner suites assert on returned diagnostics, which cannot
distinguish the two kinds, because `suppressLinterOverlap` is currently the only
kind-gated ast-grep policy and it only subtracts findings when an eslint config is
present. Nothing became redundant; no test was removed or loosened.

## Blast radius

`clients/project-diagnostics/scanner.ts` has two production dependents (`rg` over
non-test, non-compiled sources):

- `tools/lens-diagnostics.ts:73` — `scanProjectDiagnostics`
- `clients/lens-engine.ts:32` — `scanProjectDiagnostics`

The exported signature is unchanged, so both are source-compatible. The behavior change is
confined to the `kind` argument handed to `evaluateAstGrepRules` inside
`scanFileMajorRules`, which feeds only `suppressLinterOverlap`.

Cost delta: one `detectFileKind` call per napi-evaluated file — a bounded
`SPECIAL_FILENAMES` regex sweep plus one `Map` lookup on the extension. This is the
project-scan path, not a per-spawn, per-edit or per-render hot path.

`module_report` with `blastRadius: true` was run and returned `"blastRadius":"none"` with
`provenance.usedBy: "none"` — the review-graph cache is cold in this worktree, so the
transitive walk is unavailable. Recorded here rather than reported as an empty result; the
`rg` sweep above is the substitute.

## Observability

No new log record. The nearest existing one is the `astgrep_napi_unsupported_rules_skipped`
latency phase inside `evaluateAstGrepRules`, which aggregates by rule *language*, not by
the `kind` the caller passed, so it cannot distinguish a pre-fix from a post-fix scan.

Gap named: nothing currently records the `kind` a scan evaluated a file under, so this fix
is provable in production only indirectly — a `.css`/`.html` finding in a project with an
eslint config that would previously have been suppressed. Not worth a new per-file record
on the scan path; if a kind-gated policy beyond `suppressLinterOverlap` lands, the right
place is that policy's own record.

## Class sweep

Defect shape: a hard-coded constant standing in for a value a shared resolver already
derives, producing a per-path divergence for the same input — the single-source-of-truth
shape #883 established.

Whole-tree sweep, `clients/` plus `tools/`, `mcp/`, `scripts/`, `index.ts`:
`rg -n "evaluateAstGrepRules" -g '!tests/**' -g '!*.js'` returns exactly two production
call sites — `clients/project-diagnostics/scanner.ts:238` (this fix) and
`clients/dispatch/runners/ast-grep-napi.ts:996`, which passes `ctx.kind`, populated from
`detectFileKind` at `clients/dispatch/dispatcher.ts:314`. Class of size 1 before the fix,
size 0 after.

Population sweep, family "callers of `evaluateAstGrepRules`", enumerable at two members:

| Member | Verdict |
| --- | --- |
| `clients/dispatch/runners/ast-grep-napi.ts:996` | Already correct — `ctx.kind` from `detectFileKind` |
| `clients/project-diagnostics/scanner.ts:238` | Fixed by this PR |

Consolidation verdict: the family is already folded onto one seam — `detectFileKind` /
`KIND_EXTENSIONS` in `clients/file-kinds.ts`. It stays distributed at the call sites
because the two callers legitimately differ in how they obtain the file list and the
parsed root, not in how they classify a file. There is no third seam to fold onto.
