### PR TITLE
feat(observability): session-end rollup of declined session binds (#2249)

### DIFF
--- a/.changelog/feat-2249-declined-bind-rollup.md
+++ b/.changelog/feat-2249-declined-bind-rollup.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Roll up declined concurrent session starts (refs #2130, closes #2249)** — `logConcurrentSessionBind` (#473) previously wrote one `concurrent_session_bind` record per declined bind with nothing to aggregate them. `index.ts`'s `session_shutdown` handler now also logs one bounded `concurrent_session_bind_rollup` row per primary session, counting declines by classification (`concurrent-secondary` / `secondary-root`), a no-op when none occurred. The counter lives behind `getProcessSingleton` with its own family version, not a module-scope `let` — pi evaluates the pi-lens module graph more than once per process, and a bare `let` would only ever see the binds routed through its own copy. It resets both at the primary's own `session_start` (so a crashed prior primary can't leak a stale tally) and after each emission.

--- a/clients/latency-logger.ts
+++ b/clients/latency-logger.ts
@@ -119,6 +119,11 @@ let recentPhases: Array<{ phase: string; ts: string }> = [];
  * usage records. It reports no new work and therefore cannot own last-phase
  * stall attribution.
  *
+ * #2249: `concurrent_session_bind_rollup` is the same shape as
+ * `session_end_bus_rollup`/`path_attribution_verified_rollup` above — a
+ * zero-duration session-end summary of records already logged individually,
+ * not new work of its own.
+ *
  * #2044: `test_runner_failed_target_state` is a zero-duration decision after a
  * bounded filesystem probe. The surrounding turn-end test-selection phase owns
  * any real work, so this row must not replace it in stall attribution.
@@ -143,6 +148,7 @@ const LAST_PHASE_EXCLUDED = new Set([
 	"lsp_notify_write_late_landed",
 	"degradation_ledger",
 	"path_attribution_verified_rollup",
+	"concurrent_session_bind_rollup",
 ]);
 
 /**

--- a/clients/session-start-observability.ts
+++ b/clients/session-start-observability.ts
@@ -91,9 +91,7 @@ export function getConcurrentSessionBindRollupCounts(): Record<
  * A no-op when nothing was ever declined this session, matching those same
  * rollups' "no noise on an ordinary session" shape.
  */
-export function emitConcurrentSessionBindRollupAtSessionEnd(
-	cwd: string,
-): void {
+export function emitConcurrentSessionBindRollupAtSessionEnd(cwd: string): void {
 	const counts = bindRollupCounts();
 	const total =
 		counts["concurrent-secondary"] +

--- a/clients/session-start-observability.ts
+++ b/clients/session-start-observability.ts
@@ -1,10 +1,52 @@
 import { logLatency } from "./latency-logger.js";
+import { getProcessSingleton } from "./process-singletons.js";
 
 /**
  * The complete observability path for a concurrent secondary. It deliberately
  * emits one bind record only: secondary sessions skip every primary reset and
  * hydration phase.
  */
+
+// #2249: bounded per-session rollup of declined binds, counted at this shared
+// seam so every decline the process's PRIMARY has seen this session —
+// `concurrent-secondary` and `secondary-root` alike — is summarized in one row
+// at session end instead of requiring a reader to hand-count
+// `concurrent_session_bind` lines. Process-singleton backed (AGENTS.md catalog
+// shape 25), NOT a module-scope `let` like the other `*_rollup` counters
+// (bus-events-logger.ts, path-attribution-telemetry.ts): a `let` here exists
+// once per module EVALUATION, not once per process, and #2146 measured one pid
+// evaluating this exact graph nine times — a bare `let` would only ever see
+// the binds routed through its own copy, undercounting every rollup that
+// isn't reached through the first evaluation. `decideSessionStart` never
+// returns a declined classification outside `concurrent-secondary`/
+// `secondary-root` (session-lifecycle.ts), so those two are the whole
+// contract; `unclassified` is a bounded third bucket for the legacy callers
+// this function's `classification?` param still accepts.
+const BIND_ROLLUP_FAMILY = "concurrent-session-bind-rollup";
+const BIND_ROLLUP_VERSION = 1;
+
+type BindRollupClassification =
+	| "concurrent-secondary"
+	| "secondary-root"
+	| "unclassified";
+
+function bindRollupCounts(): Record<BindRollupClassification, number> {
+	return getProcessSingleton(BIND_ROLLUP_FAMILY, BIND_ROLLUP_VERSION, () => ({
+		"concurrent-secondary": 0,
+		"secondary-root": 0,
+		unclassified: 0,
+	}));
+}
+
+function bindRollupKey(
+	classification: string | undefined,
+): BindRollupClassification {
+	return classification === "concurrent-secondary" ||
+		classification === "secondary-root"
+		? classification
+		: "unclassified";
+}
+
 export function logConcurrentSessionBind(args: {
 	secondaryCount: number;
 	sessionReason?: string;
@@ -19,6 +61,7 @@ export function logConcurrentSessionBind(args: {
 	/** #2129: the registered primary's normalized root at decision time. */
 	primaryRoot?: string;
 }): void {
+	bindRollupCounts()[bindRollupKey(args.classification)] += 1;
 	logLatency({
 		type: "phase",
 		filePath: "<pi-lens>",
@@ -26,4 +69,59 @@ export function logConcurrentSessionBind(args: {
 		durationMs: 0,
 		metadata: args,
 	});
+}
+
+/** Snapshot of the current rollup counters, keyed by classification.
+ *  Non-mutating — for tests/observability, mirroring
+ *  `getBusEventRollupCounts`/`getVerifiedPathAttributionGuessCount`. */
+export function getConcurrentSessionBindRollupCounts(): Record<
+	BindRollupClassification,
+	number
+> {
+	return { ...bindRollupCounts() };
+}
+
+/**
+ * Log one `concurrent_session_bind_rollup` row summarizing this session's
+ * declined binds by classification, then clear the counters. Call from
+ * index.ts's `session_shutdown` handler at the same primary-only placement as
+ * `emitBusEventRollupAtSessionEnd`/`emitVerifiedPathAttributionRollup` — a
+ * concurrent secondary's own shutdown returns before reaching that point, and
+ * the counters are process-wide state a still-live secondary would still need.
+ * A no-op when nothing was ever declined this session, matching those same
+ * rollups' "no noise on an ordinary session" shape.
+ */
+export function emitConcurrentSessionBindRollupAtSessionEnd(
+	cwd: string,
+): void {
+	const counts = bindRollupCounts();
+	const total =
+		counts["concurrent-secondary"] +
+		counts["secondary-root"] +
+		counts.unclassified;
+	if (total === 0) return;
+	logLatency({
+		type: "phase",
+		filePath: cwd,
+		phase: "concurrent_session_bind_rollup",
+		durationMs: 0,
+		metadata: { ...counts },
+	});
+	resetConcurrentSessionBindRollupCounts();
+}
+
+/**
+ * Session-boundary reset (AGENTS.md catalog shape 17). Call from index.ts's
+ * `session_start` handler on the PRIMARY continuation path only — never from
+ * a declined bind's own `session_start`, which is exactly what increments
+ * these counters, so resetting there would erase every prior sibling's tally
+ * from the same primary session. Covers the case a primary session never
+ * reaches `session_shutdown` (a crash, a forced kill) and the process's next
+ * primary must still start from zero. Also exported for tests.
+ */
+export function resetConcurrentSessionBindRollupCounts(): void {
+	const counts = bindRollupCounts();
+	counts["concurrent-secondary"] = 0;
+	counts["secondary-root"] = 0;
+	counts.unclassified = 0;
 }

--- a/docs/subagent-compat.md
+++ b/docs/subagent-compat.md
@@ -99,22 +99,32 @@ Assertions:
    `PI_SUBAGENT_PARENT_PID`), no `subagent_light_mode` phase is logged.
    `subagent-mode.ts`'s doc comment requires the PAIR — a lone var set by
    some unrelated tool must not trigger light mode.
-6. **`concurrent_session_bind` (#473) — NOT asserted, documented TODO.**
+6. **`concurrent_session_bind` (#473) and its `concurrent_session_bind_rollup`
+   session-end summary (#2249) — NOT asserted, documented TODO.**
    The guard is fully wired on master (PR #477): `index.ts`'s `session_start`
    handler calls `decideSessionStart()` and logs a `concurrent_session_bind`
    latency phase for a concurrent-secondary bind — so the phase exists to
-   observe. The blocker is DRIVING it keylessly: reproducing tintinweb's
-   in-process model for real (mirroring `agent-runner.ts`'s
-   `createAgentSession()` + `DefaultResourceLoader` + `bindExtensions()`
-   sequence) requires full session construction, which in turn needs
-   model/provider config — not cheaply stubbable without a real model key,
-   and #476 explicitly asks not to ship something flaky here. The unit +
-   behavioral coverage in `tests/clients/session-lifecycle.test.ts` guards
-   the classifier and the no-reset contract in-repo; what Layer B cannot yet
-   add is the end-to-end SDK-driven variant. **Revisit if the pi SDK grows a
-   model-free session constructor or stub provider** — at that point add a
-   Layer B assertion analogous to 1-3 checking the `concurrent_session_bind`
-   phase and the absence of a second LSP fleet teardown.
+   observe. `clients/session-start-observability.ts` also keeps a bounded,
+   process-singleton-backed tally of declined binds by classification
+   (`concurrent-secondary` / `secondary-root`), which `index.ts`'s
+   `session_shutdown` handler logs as one `concurrent_session_bind_rollup`
+   row (primary sessions only) and clears — same primary-only placement as
+   `session_end_bus_rollup`/`path_attribution_verified_rollup`. The blocker is
+   DRIVING either keylessly: reproducing tintinweb's in-process model for real
+   (mirroring `agent-runner.ts`'s `createAgentSession()` +
+   `DefaultResourceLoader` + `bindExtensions()` sequence) requires full
+   session construction, which in turn needs model/provider config — not
+   cheaply stubbable without a real model key, and #476 explicitly asks not
+   to ship something flaky here. The unit + behavioral coverage in
+   `tests/clients/session-lifecycle.test.ts` guards the classifier and the
+   no-reset contract, and `tests/clients/session-start-observability.test.ts`
+   plus `tests/index-integration.test.ts` guard the rollup's counting,
+   process-singleton survival, and primary-only reset/emit wiring, all
+   in-repo; what Layer B cannot yet add is the end-to-end SDK-driven variant.
+   **Revisit if the pi SDK grows a model-free session constructor or stub
+   provider** — at that point add a Layer B assertion analogous to 1-3
+   checking the `concurrent_session_bind`/`concurrent_session_bind_rollup`
+   phases and the absence of a second LSP fleet teardown.
 
 ## What to do when the nightly alerts
 

--- a/index.ts
+++ b/index.ts
@@ -258,7 +258,11 @@ import {
 	getBuildIdentity,
 } from "./clients/build-identity.js";
 import { logSessionStart } from "./clients/sessionstart-logger.js";
-import { logConcurrentSessionBind } from "./clients/session-start-observability.js";
+import {
+	emitConcurrentSessionBindRollupAtSessionEnd,
+	logConcurrentSessionBind,
+	resetConcurrentSessionBindRollupCounts,
+} from "./clients/session-start-observability.js";
 import { normalizeToolDefinition } from "./clients/tool-definition.js";
 import { warmFormatters } from "./clients/formatters-lazy.js";
 
@@ -1867,6 +1871,12 @@ function activateExtension(hostPi: ExtensionAPI) {
 					// accepted cost on the other side (a torn-down secondary's own
 					// bracket goes stale until the next full session start).
 					resetCurrentPhaseForSession();
+					// #2249: same gate — a declined bind's own session_start must never
+					// reach here (it returned above), so this only fires for a genuine
+					// new primary. A crash or forced kill can skip session_shutdown's
+					// own emit+reset below, so the rollup also re-arms here rather than
+					// trusting shutdown alone (AGENTS.md catalog shape 17).
+					resetConcurrentSessionBindRollupCounts();
 
 					// Dynamic tooling (#pi 0.80.x+): put the active tool set back to the
 					// posture this logical conversation had — the always-active baseline
@@ -3101,6 +3111,10 @@ function activateExtension(hostPi: ExtensionAPI) {
 		// process-wide module state a live secondary would still need.
 		emitBusEventRollupAtSessionEnd(runtime.projectRoot);
 		emitVerifiedPathAttributionRollup(runtime.projectRoot);
+		// #2249: same primary-only placement — one concurrent_session_bind_rollup
+		// row summarizing this session's declined binds by classification, a
+		// no-op when none occurred.
+		emitConcurrentSessionBindRollupAtSessionEnd(runtime.projectRoot);
 		// #1123 item 4: dump active handles AFTER teardown — whatever is still
 		// alive at this point is exactly what would keep a --print/--no-session
 		// process from exiting (the #1097 lesson: what survives IS the leak).

--- a/index.ts
+++ b/index.ts
@@ -1876,6 +1876,12 @@ function activateExtension(hostPi: ExtensionAPI) {
 					// new primary. A crash or forced kill can skip session_shutdown's
 					// own emit+reset below, so the rollup also re-arms here rather than
 					// trusting shutdown alone (AGENTS.md catalog shape 17).
+					// #2312 review F1: on the sequential-replacement path (prior primary
+					// never reached session_shutdown), the reset below would otherwise
+					// silently discard an unemitted tally. Emit first — a no-op when
+					// nothing was declined — so the crash/kill case still produces its
+					// one summary row instead of losing it.
+					emitConcurrentSessionBindRollupAtSessionEnd(runtime.projectRoot);
 					resetConcurrentSessionBindRollupCounts();
 
 					// Dynamic tooling (#pi 0.80.x+): put the active tool set back to the

--- a/scripts/compat-smoke-behavioral.mjs
+++ b/scripts/compat-smoke-behavioral.mjs
@@ -41,16 +41,17 @@
  *      `subagent_light_mode` phase logged. `subagent-mode.ts`'s doc comment
  *      requires the PAIR — a lone var set by some unrelated tool must not
  *      trigger light mode (#507/#518).
- *   6. concurrent_session_bind (#473's in-process guard) — NOT asserted.
+ *   6. concurrent_session_bind (#473's in-process guard) and its #2249
+ *      session-end summary concurrent_session_bind_rollup — NOT asserted.
  *      The guard IS fully wired on master (PR #477: `decideSessionStart` is
- *      called from `index.ts`'s `session_start` handler), so the phase
- *      exists — but OBSERVING it requires reproducing tintinweb's in-process
- *      model for real (a second `createAgentSession()` + `bindExtensions()`
- *      in the same process), and session construction needs model/provider
- *      config that can't cheaply be stubbed without a real key. #476
- *      explicitly asks not to ship something flaky here. Documented as a
- *      TODO in docs/subagent-compat.md; revisit if the SDK grows a
- *      model-free session constructor or a stub provider.
+ *      called from `index.ts`'s `session_start` handler), so both phases
+ *      exist — but OBSERVING either requires reproducing tintinweb's
+ *      in-process model for real (a second `createAgentSession()` +
+ *      `bindExtensions()` in the same process), and session construction
+ *      needs model/provider config that can't cheaply be stubbed without a
+ *      real key. #476 explicitly asks not to ship something flaky here.
+ *      Documented as a TODO in docs/subagent-compat.md; revisit if the SDK
+ *      grows a model-free session constructor or a stub provider.
  *
  * Usage: node scripts/compat-smoke-behavioral.mjs [--keep] [--tarball <path>]
  *   --keep            don't delete the scratch project/install dirs
@@ -552,18 +553,20 @@ async function main() {
 		}
 	}
 
-	// --- Assertion 6 (concurrent_session_bind, #473) — documented TODO ---
+	// --- Assertion 6 (concurrent_session_bind + concurrent_session_bind_rollup,
+	// #473 / #2249) — documented TODO ---
 	results.push({
 		id: "concurrent-session-bind-in-process",
 		pass: true,
 		skipped: true,
 		detail:
-			"NOT ASSERTED — decideSessionStart() (clients/session-lifecycle.ts) has no " +
-			"call site in index.ts as of this writing (grep confirms zero matches on " +
-			"master and on the open #473 PR branch); there is no concurrent_session_bind " +
-			"phase to observe yet. Reproducing tintinweb's in-process bindExtensions() " +
-			"model needs a full createAgentSession() + model config that isn't cheaply " +
-			"stubbable without a real model key. See docs/subagent-compat.md.",
+			"NOT ASSERTED — decideSessionStart() (clients/session-lifecycle.ts) IS wired " +
+			"into index.ts's session_start handler, so both the per-bind " +
+			"concurrent_session_bind phase and #2249's session-end " +
+			"concurrent_session_bind_rollup phase exist to observe. Reproducing " +
+			"tintinweb's in-process bindExtensions() model needs a full " +
+			"createAgentSession() + model config that isn't cheaply stubbable without a " +
+			"real model key. See docs/subagent-compat.md.",
 	});
 
 	console.log("\nbehavioral smoke assertions:");

--- a/tests/clients/latency-logger.test.ts
+++ b/tests/clients/latency-logger.test.ts
@@ -226,6 +226,28 @@ describe("getLastLoggedPhase (loop_block attribution, #1122/#1123)", () => {
 		});
 		expect(getLastLoggedPhase()?.phase).toBe("turn_end_tests");
 	});
+
+	// #2249/#2312 review F3: `concurrent_session_bind_rollup` is a zero-duration
+	// session-end summary, the same shape as `session_end_bus_rollup` and
+	// `path_attribution_verified_rollup` above — it must not win lastPhase
+	// attribution for a loop_block that happens to land right after it. Pins
+	// the `LAST_PHASE_EXCLUDED` entry so deleting it reds here instead of
+	// surviving unnoticed.
+	it("does not let the concurrent-session-bind rollup own stall attribution (#2249)", () => {
+		logLatency({
+			type: "phase",
+			phase: "provider_request",
+			filePath: "<pi-lens>",
+			durationMs: 5,
+		});
+		logLatency({
+			type: "phase",
+			phase: "concurrent_session_bind_rollup",
+			filePath: "<pi-lens>",
+			durationMs: 0,
+		});
+		expect(getLastLoggedPhase()?.phase).toBe("provider_request");
+	});
 });
 
 describe("getRecentLoggedPhases (#1723: bounded attribution ring)", () => {

--- a/tests/clients/session-start-observability.test.ts
+++ b/tests/clients/session-start-observability.test.ts
@@ -1,16 +1,23 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LatencyEntry } from "../../clients/latency-logger.js";
+import { _resetProcessSingletonsForTests } from "../../clients/process-singletons.js";
 
 const latencyEntries = vi.hoisted(() => [] as LatencyEntry[]);
 vi.mock("../../clients/latency-logger.js", () => ({
 	logLatency: (entry: LatencyEntry) => latencyEntries.push(entry),
 }));
 
-import { logConcurrentSessionBind } from "../../clients/session-start-observability.js";
+import {
+	emitConcurrentSessionBindRollupAtSessionEnd,
+	getConcurrentSessionBindRollupCounts,
+	logConcurrentSessionBind,
+	resetConcurrentSessionBindRollupCounts,
+} from "../../clients/session-start-observability.js";
 
 describe("session-start observability", () => {
 	beforeEach(() => {
 		latencyEntries.length = 0;
+		_resetProcessSingletonsForTests();
 	});
 
 	it("a concurrent secondary emits only its bind record", () => {
@@ -30,6 +37,185 @@ describe("session-start observability", () => {
 					secondaryCount: 1,
 					sessionReason: "fork",
 					sameCwd: true,
+				},
+			},
+		]);
+	});
+});
+
+// #2249: the rollup is process-singleton backed (AGENTS.md catalog shape 25),
+// not a module-scope `let` like session-lifecycle.ts's sibling rollups. These
+// tests cover the counting/emission contract; the multi-evaluation describe
+// block below covers the specific defect shape 25 exists to prevent.
+describe("session-start observability — #2249 declined-bind rollup", () => {
+	beforeEach(() => {
+		latencyEntries.length = 0;
+		_resetProcessSingletonsForTests();
+	});
+
+	it("accumulates declined binds by classification and emits one bounded row at session end", () => {
+		logConcurrentSessionBind({
+			secondaryCount: 1,
+			sameCwd: true,
+			classification: "concurrent-secondary",
+		});
+		logConcurrentSessionBind({
+			secondaryCount: 2,
+			sameCwd: false,
+			classification: "concurrent-secondary",
+		});
+		logConcurrentSessionBind({
+			secondaryCount: 3,
+			sameCwd: false,
+			classification: "secondary-root",
+		});
+		expect(getConcurrentSessionBindRollupCounts()).toEqual({
+			"concurrent-secondary": 2,
+			"secondary-root": 1,
+			unclassified: 0,
+		});
+
+		latencyEntries.length = 0;
+		emitConcurrentSessionBindRollupAtSessionEnd("/project");
+
+		expect(latencyEntries).toEqual([
+			{
+				type: "phase",
+				filePath: "/project",
+				phase: "concurrent_session_bind_rollup",
+				durationMs: 0,
+				metadata: {
+					"concurrent-secondary": 2,
+					"secondary-root": 1,
+					unclassified: 0,
+				},
+			},
+		]);
+	});
+
+	it("bounds an unrecognized/absent classification into a third fixed bucket", () => {
+		// No `classification` at all — the field is optional for older callers
+		// (see the doc comment on logConcurrentSessionBind's args).
+		logConcurrentSessionBind({ secondaryCount: 1, sameCwd: true });
+		expect(getConcurrentSessionBindRollupCounts()).toEqual({
+			"concurrent-secondary": 0,
+			"secondary-root": 0,
+			unclassified: 1,
+		});
+	});
+
+	it("emits nothing when no bind was declined this session — no noise on an ordinary session", () => {
+		emitConcurrentSessionBindRollupAtSessionEnd("/project");
+		expect(latencyEntries).toEqual([]);
+	});
+
+	it("clears the counters after emitting, so a second session_shutdown call is a no-op", () => {
+		logConcurrentSessionBind({
+			secondaryCount: 1,
+			sameCwd: true,
+			classification: "secondary-root",
+		});
+		latencyEntries.length = 0; // drop the per-bind concurrent_session_bind row
+		emitConcurrentSessionBindRollupAtSessionEnd("/project");
+		expect(latencyEntries).toHaveLength(1);
+
+		latencyEntries.length = 0;
+		emitConcurrentSessionBindRollupAtSessionEnd("/project");
+		expect(latencyEntries).toEqual([]);
+		expect(getConcurrentSessionBindRollupCounts()).toEqual({
+			"concurrent-secondary": 0,
+			"secondary-root": 0,
+			unclassified: 0,
+		});
+	});
+
+	// AGENTS.md catalog shape 17: every once-latch answers "what resets it at
+	// session_start?". index.ts calls this on the PRIMARY continuation path
+	// only, so a crash/kill that skips session_shutdown's own emit-and-reset
+	// still cannot leak a prior primary session's tally into the next one.
+	it("resetConcurrentSessionBindRollupCounts (session-boundary reset) clears without emitting", () => {
+		logConcurrentSessionBind({
+			secondaryCount: 1,
+			sameCwd: true,
+			classification: "concurrent-secondary",
+		});
+		latencyEntries.length = 0; // drop the per-bind concurrent_session_bind row
+		resetConcurrentSessionBindRollupCounts();
+		expect(latencyEntries).toEqual([]);
+		expect(getConcurrentSessionBindRollupCounts()).toEqual({
+			"concurrent-secondary": 0,
+			"secondary-root": 0,
+			unclassified: 0,
+		});
+
+		// Proven a second way: emitting after the reset must also be a no-op —
+		// not just that the getter reports zero.
+		emitConcurrentSessionBindRollupAtSessionEnd("/project");
+		expect(latencyEntries).toEqual([]);
+	});
+});
+
+// AGENTS.md catalog shape 25's own detection method: evaluate the module
+// TWICE (vi.resetModules() + dynamic import) and prove the second evaluation
+// sees the first's state. pi evaluates the pi-lens module graph more than
+// once per process (#2146 measured one pid emitting host_boot nine times), so
+// a module-scope `let` counter here would silently undercount — the second
+// evaluation's `let` starts at zero and never sees binds routed through the
+// first. Every import below uses the `.js` specifier — the artifact the
+// runtime loads (catalog shape 14) — never `.ts`.
+describe("session-start observability — #2249 rollup survives module re-evaluation", () => {
+	beforeEach(() => {
+		latencyEntries.length = 0;
+		_resetProcessSingletonsForTests();
+	});
+
+	afterEach(() => {
+		_resetProcessSingletonsForTests();
+	});
+
+	async function freshEvaluation() {
+		vi.resetModules();
+		return (await import(
+			"../../clients/session-start-observability.js"
+		)) as typeof import("../../clients/session-start-observability.js");
+	}
+
+	it("a second evaluation's bind is counted in the rollup the first evaluation emits", async () => {
+		const first = await freshEvaluation();
+		first.logConcurrentSessionBind({
+			secondaryCount: 1,
+			sameCwd: true,
+			classification: "concurrent-secondary",
+		});
+
+		// pi's SECOND evaluation of the same graph — a fresh module instance,
+		// same process, same globalThis.
+		const second = await freshEvaluation();
+		second.logConcurrentSessionBind({
+			secondaryCount: 2,
+			sameCwd: false,
+			classification: "secondary-root",
+		});
+
+		expect(second.getConcurrentSessionBindRollupCounts()).toEqual({
+			"concurrent-secondary": 1,
+			"secondary-root": 1,
+			unclassified: 0,
+		});
+
+		latencyEntries.length = 0;
+		second.emitConcurrentSessionBindRollupAtSessionEnd("/project");
+
+		expect(latencyEntries).toEqual([
+			{
+				type: "phase",
+				filePath: "/project",
+				phase: "concurrent_session_bind_rollup",
+				durationMs: 0,
+				metadata: {
+					"concurrent-secondary": 1,
+					"secondary-root": 1,
+					unclassified: 0,
 				},
 			},
 		]);

--- a/tests/clients/session-start-observability.test.ts
+++ b/tests/clients/session-start-observability.test.ts
@@ -175,9 +175,7 @@ describe("session-start observability — #2249 rollup survives module re-evalua
 
 	async function freshEvaluation() {
 		vi.resetModules();
-		return (await import(
-			"../../clients/session-start-observability.js"
-		)) as typeof import("../../clients/session-start-observability.js");
+		return (await import("../../clients/session-start-observability.js")) as typeof import("../../clients/session-start-observability.js");
 	}
 
 	it("a second evaluation's bind is counted in the rollup the first evaluation emits", async () => {

--- a/tests/index-integration.test.ts
+++ b/tests/index-integration.test.ts
@@ -449,9 +449,8 @@ describe("index.ts integration", () => {
 	it(
 		"a NEW primary's session_start clears a stale rollup left by a crashed prior primary",
 		async () => {
-			const observability = await import(
-				"../clients/session-start-observability.js"
-			);
+			const observability =
+				await import("../clients/session-start-observability.js");
 			// Simulates a prior primary session that logged a decline and then
 			// never reached session_shutdown (crash/forced kill) — the counters
 			// are process-wide (globalThis-backed) state that outlives it.
@@ -486,9 +485,8 @@ describe("index.ts integration", () => {
 				>()),
 				logLatency,
 			}));
-			const observability = await import(
-				"../clients/session-start-observability.js"
-			);
+			const observability =
+				await import("../clients/session-start-observability.js");
 			const { default: registerExtension } = await import("../index.js");
 			const { pi, handlers } = createMockPi();
 			registerExtension(pi as any);
@@ -538,9 +536,8 @@ describe("index.ts integration", () => {
 				>()),
 				logLatency,
 			}));
-			const observability = await import(
-				"../clients/session-start-observability.js"
-			);
+			const observability =
+				await import("../clients/session-start-observability.js");
 			const { default: registerExtension } = await import("../index.js");
 			const primary = createMockPi();
 			registerExtension(primary.pi as any);

--- a/tests/index-integration.test.ts
+++ b/tests/index-integration.test.ts
@@ -440,6 +440,168 @@ describe("index.ts integration", () => {
 		INTEGRATION_TIMEOUT_MS,
 	);
 
+	// #2249: the declined-bind rollup. Same primary-only reset/emit placement
+	// as the verified-attribution tally above, but process-singleton backed
+	// (AGENTS.md catalog shape 25) rather than a module-scope `let`, and the
+	// counter is driven by the REAL decideSessionStart decline path rather
+	// than a manual record call, so these also exercise the production wiring
+	// end to end.
+	it(
+		"a NEW primary's session_start clears a stale rollup left by a crashed prior primary",
+		async () => {
+			const observability = await import(
+				"../clients/session-start-observability.js"
+			);
+			// Simulates a prior primary session that logged a decline and then
+			// never reached session_shutdown (crash/forced kill) — the counters
+			// are process-wide (globalThis-backed) state that outlives it.
+			observability.logConcurrentSessionBind({
+				secondaryCount: 1,
+				sameCwd: true,
+				classification: "concurrent-secondary",
+			});
+			const { default: registerExtension } = await import("../index.js");
+			const { pi, handlers } = createMockPi();
+			registerExtension(pi as any);
+			await handlers.session_start?.[0]?.(
+				{},
+				makeCtx({ cwd: tmpDir, sessionId: "primary" }),
+			);
+			expect(observability.getConcurrentSessionBindRollupCounts()).toEqual({
+				"concurrent-secondary": 0,
+				"secondary-root": 0,
+				unclassified: 0,
+			});
+		},
+		INTEGRATION_TIMEOUT_MS,
+	);
+
+	it(
+		"primary session_shutdown emits one concurrent-session-bind rollup and clears it, while zero stays silent",
+		async () => {
+			const logLatency = vi.fn();
+			vi.doMock("../clients/latency-logger.js", async (importActual) => ({
+				...(await importActual<
+					typeof import("../clients/latency-logger.js")
+				>()),
+				logLatency,
+			}));
+			const observability = await import(
+				"../clients/session-start-observability.js"
+			);
+			const { default: registerExtension } = await import("../index.js");
+			const { pi, handlers } = createMockPi();
+			registerExtension(pi as any);
+			const shutdown = handlers.session_shutdown?.[0];
+			observability.logConcurrentSessionBind({
+				secondaryCount: 1,
+				sameCwd: true,
+				classification: "concurrent-secondary",
+			});
+			shutdown?.({}, makeCtx({ cwd: tmpDir, sessionId: "primary" }));
+			const rollups = () =>
+				logLatency.mock.calls.filter(
+					([row]) =>
+						(row as { phase?: string }).phase ===
+						"concurrent_session_bind_rollup",
+				);
+			expect(rollups()).toHaveLength(1);
+			expect(rollups()[0][0]).toEqual(
+				expect.objectContaining({
+					phase: "concurrent_session_bind_rollup",
+					metadata: {
+						"concurrent-secondary": 1,
+						"secondary-root": 0,
+						unclassified: 0,
+					},
+				}),
+			);
+			expect(observability.getConcurrentSessionBindRollupCounts()).toEqual({
+				"concurrent-secondary": 0,
+				"secondary-root": 0,
+				unclassified: 0,
+			});
+			logLatency.mockClear();
+			shutdown?.({}, makeCtx({ cwd: tmpDir, sessionId: "primary" }));
+			expect(rollups()).toHaveLength(0);
+		},
+		INTEGRATION_TIMEOUT_MS,
+	);
+
+	it(
+		"secondary session_shutdown does not consume the primary rollup tally",
+		async () => {
+			const logLatency = vi.fn();
+			vi.doMock("../clients/latency-logger.js", async (importActual) => ({
+				...(await importActual<
+					typeof import("../clients/latency-logger.js")
+				>()),
+				logLatency,
+			}));
+			const observability = await import(
+				"../clients/session-start-observability.js"
+			);
+			const { default: registerExtension } = await import("../index.js");
+			const primary = createMockPi();
+			registerExtension(primary.pi as any);
+			await primary.trigger(
+				"session_start",
+				{},
+				makeCtx({ cwd: tmpDir, sessionId: "primary" }),
+			);
+
+			const secondary = createMockPi();
+			registerExtension(secondary.pi as any);
+			// Same cwd, still-live primary ctx, different session id —
+			// decideSessionStart classifies this concurrent-secondary and
+			// index.ts's session_start handler declines the full start, which is
+			// what actually calls logConcurrentSessionBind (real production path,
+			// not a manual record call).
+			await secondary.trigger(
+				"session_start",
+				{},
+				makeCtx({ cwd: tmpDir, sessionId: "secondary" }),
+			);
+			expect(observability.getConcurrentSessionBindRollupCounts()).toEqual({
+				"concurrent-secondary": 1,
+				"secondary-root": 0,
+				unclassified: 0,
+			});
+
+			const rollups = () =>
+				logLatency.mock.calls.filter(
+					([row]) =>
+						(row as { phase?: string }).phase ===
+						"concurrent_session_bind_rollup",
+				);
+
+			await secondary.trigger(
+				"session_shutdown",
+				{},
+				makeCtx({ cwd: tmpDir, sessionId: "secondary" }),
+			);
+			expect(rollups()).toHaveLength(0);
+			expect(observability.getConcurrentSessionBindRollupCounts()).toEqual({
+				"concurrent-secondary": 1,
+				"secondary-root": 0,
+				unclassified: 0,
+			});
+
+			await primary.trigger(
+				"session_shutdown",
+				{},
+				makeCtx({ cwd: tmpDir, sessionId: "primary" }),
+			);
+			expect(rollups()).toHaveLength(1);
+			expect(observability.getConcurrentSessionBindRollupCounts()).toEqual({
+				"concurrent-secondary": 0,
+				"secondary-root": 0,
+				unclassified: 0,
+			});
+		},
+		INTEGRATION_TIMEOUT_MS,
+	);
+
 	// #1910: the tier-3 cascade outstanding-touch registry (clients/lsp/
 	// cascade-tier.ts) is process-shared runtime state, same #473 shape as the
 	// active-tool set and the direct-LSP latch above. A concurrently-live

--- a/tests/index-integration.test.ts
+++ b/tests/index-integration.test.ts
@@ -449,6 +449,13 @@ describe("index.ts integration", () => {
 	it(
 		"a NEW primary's session_start clears a stale rollup left by a crashed prior primary",
 		async () => {
+			const logLatency = vi.fn();
+			vi.doMock("../clients/latency-logger.js", async (importActual) => ({
+				...(await importActual<
+					typeof import("../clients/latency-logger.js")
+				>()),
+				logLatency,
+			}));
 			const observability =
 				await import("../clients/session-start-observability.js");
 			// Simulates a prior primary session that logged a decline and then
@@ -471,6 +478,27 @@ describe("index.ts integration", () => {
 				"secondary-root": 0,
 				unclassified: 0,
 			});
+			// #2312 review F1: the crashed prior primary never reached
+			// session_shutdown, so its tally would otherwise be silently
+			// discarded by the reset above instead of summarized. The fresh
+			// primary's session_start must emit the stale tally before
+			// clearing it — exactly one row, not zero and not more.
+			const rollups = logLatency.mock.calls.filter(
+				([row]) =>
+					(row as { phase?: string }).phase ===
+					"concurrent_session_bind_rollup",
+			);
+			expect(rollups).toHaveLength(1);
+			expect(rollups[0][0]).toEqual(
+				expect.objectContaining({
+					phase: "concurrent_session_bind_rollup",
+					metadata: {
+						"concurrent-secondary": 1,
+						"secondary-root": 0,
+						unclassified: 0,
+					},
+				}),
+			);
 		},
 		INTEGRATION_TIMEOUT_MS,
 	);

--- a/tests/scripts/latency-log-phases.test.ts
+++ b/tests/scripts/latency-log-phases.test.ts
@@ -112,11 +112,8 @@ describe("findPhaseEntries / phaseWasLogged", () => {
 		const previousTestMode = process.env.PI_LENS_TEST_MODE;
 		process.env.PI_LENS_TEST_MODE = "0";
 		try {
-			const {
-				clearLatencyLog,
-				flushLatencyLog,
-				getLatencyLogPath,
-			} = await import("../../clients/latency-logger.js");
+			const { clearLatencyLog, flushLatencyLog, getLatencyLogPath } =
+				await import("../../clients/latency-logger.js");
 			const {
 				logConcurrentSessionBind,
 				emitConcurrentSessionBindRollupAtSessionEnd,

--- a/tests/scripts/latency-log-phases.test.ts
+++ b/tests/scripts/latency-log-phases.test.ts
@@ -110,15 +110,11 @@ describe("findPhaseEntries / phaseWasLogged", () => {
 				ts: "2026-07-10T10:00:01.000Z",
 			},
 		];
-		expect(findPhaseEntries(mixed, "concurrent_session_bind")).toHaveLength(
-			1,
-		);
+		expect(findPhaseEntries(mixed, "concurrent_session_bind")).toHaveLength(1);
 		expect(
 			findPhaseEntries(mixed, "concurrent_session_bind_rollup"),
 		).toHaveLength(1);
-		expect(phaseWasLogged(mixed, "concurrent_session_bind_rollup")).toBe(
-			true,
-		);
+		expect(phaseWasLogged(mixed, "concurrent_session_bind_rollup")).toBe(true);
 	});
 });
 

--- a/tests/scripts/latency-log-phases.test.ts
+++ b/tests/scripts/latency-log-phases.test.ts
@@ -92,6 +92,34 @@ describe("findPhaseEntries / phaseWasLogged", () => {
 			false,
 		);
 	});
+
+	// #2249: `concurrent_session_bind_rollup` (the session-end summary,
+	// index.ts's session_shutdown handler) shares a prefix with
+	// `concurrent_session_bind` (the per-bind record, #473). Exact-match only —
+	// a naive substring/prefix check would conflate the two.
+	it("distinguishes concurrent_session_bind from its concurrent_session_bind_rollup sibling", () => {
+		const mixed = [
+			{
+				type: "phase",
+				phase: "concurrent_session_bind",
+				ts: "2026-07-10T10:00:00.000Z",
+			},
+			{
+				type: "phase",
+				phase: "concurrent_session_bind_rollup",
+				ts: "2026-07-10T10:00:01.000Z",
+			},
+		];
+		expect(findPhaseEntries(mixed, "concurrent_session_bind")).toHaveLength(
+			1,
+		);
+		expect(
+			findPhaseEntries(mixed, "concurrent_session_bind_rollup"),
+		).toHaveLength(1);
+		expect(phaseWasLogged(mixed, "concurrent_session_bind_rollup")).toBe(
+			true,
+		);
+	});
 });
 
 describe("noPhasesLogged", () => {

--- a/tests/scripts/latency-log-phases.test.ts
+++ b/tests/scripts/latency-log-phases.test.ts
@@ -97,24 +97,68 @@ describe("findPhaseEntries / phaseWasLogged", () => {
 	// index.ts's session_shutdown handler) shares a prefix with
 	// `concurrent_session_bind` (the per-bind record, #473). Exact-match only —
 	// a naive substring/prefix check would conflate the two.
-	it("distinguishes concurrent_session_bind from its concurrent_session_bind_rollup sibling", () => {
-		const mixed = [
-			{
-				type: "phase",
-				phase: "concurrent_session_bind",
-				ts: "2026-07-10T10:00:00.000Z",
-			},
-			{
-				type: "phase",
-				phase: "concurrent_session_bind_rollup",
-				ts: "2026-07-10T10:00:01.000Z",
-			},
-		];
-		expect(findPhaseEntries(mixed, "concurrent_session_bind")).toHaveLength(1);
-		expect(
-			findPhaseEntries(mixed, "concurrent_session_bind_rollup"),
-		).toHaveLength(1);
-		expect(phaseWasLogged(mixed, "concurrent_session_bind_rollup")).toBe(true);
+	//
+	// #2312 review F2: hand-built literal objects never touch the feature — the
+	// prior version of this test passed with the whole PR reverted. Drive the
+	// REAL seam instead: the actual `logConcurrentSessionBind`/
+	// `emitConcurrentSessionBindRollupAtSessionEnd` production functions write
+	// through the real `logLatency` sink into a real NDJSON file
+	// (`PI_LENS_HOME` is a per-worker temp dir, set globally by
+	// tests/support/vitest-setup.ts), then `findPhaseEntries` parses that file
+	// back. Deleting `session-start-observability.ts`'s exports, or its call to
+	// `logLatency`, breaks this test structurally (import/behavioral failure),
+	// not just a hand-maintained fixture.
+	it("distinguishes concurrent_session_bind from its concurrent_session_bind_rollup sibling, driven through the real logging seam", async () => {
+		const previousTestMode = process.env.PI_LENS_TEST_MODE;
+		process.env.PI_LENS_TEST_MODE = "0";
+		try {
+			const {
+				clearLatencyLog,
+				flushLatencyLog,
+				getLatencyLogPath,
+			} = await import("../../clients/latency-logger.js");
+			const {
+				logConcurrentSessionBind,
+				emitConcurrentSessionBindRollupAtSessionEnd,
+				resetConcurrentSessionBindRollupCounts,
+			} = await import("../../clients/session-start-observability.js");
+			const fs = await import("node:fs");
+
+			resetConcurrentSessionBindRollupCounts();
+			clearLatencyLog();
+			await flushLatencyLog();
+
+			// One per-bind record (#473's `concurrent_session_bind`)...
+			logConcurrentSessionBind({
+				secondaryCount: 1,
+				sameCwd: true,
+				classification: "concurrent-secondary",
+			});
+			// ...then the real session-end summary
+			// (`concurrent_session_bind_rollup`), sharing the `concurrent_session_bind`
+			// prefix.
+			emitConcurrentSessionBindRollupAtSessionEnd("/tmp/f2-real-seam");
+			await flushLatencyLog();
+
+			const text = fs.readFileSync(getLatencyLogPath(), "utf8");
+			const entries = parseNdjsonEntries(text);
+
+			expect(findPhaseEntries(entries, "concurrent_session_bind")).toHaveLength(
+				1,
+			);
+			expect(
+				findPhaseEntries(entries, "concurrent_session_bind_rollup"),
+			).toHaveLength(1);
+			expect(phaseWasLogged(entries, "concurrent_session_bind_rollup")).toBe(
+				true,
+			);
+		} finally {
+			if (previousTestMode === undefined) {
+				delete process.env.PI_LENS_TEST_MODE;
+			} else {
+				process.env.PI_LENS_TEST_MODE = previousTestMode;
+			}
+		}
 	});
 });
 


### PR DESCRIPTION
## Summary

Declined session starts now get a session-end summary: one `concurrent_session_bind_rollup`
row counting declined binds by classification (`concurrent-secondary` / `secondary-root`,
plus a bounded `unclassified` bucket for the legacy `classification?` path), emitted from
the primary's `session_shutdown` at the same placement as the bus-event and
path-attribution rollups, and reset per session. This is the remainder that kept #2130 open
after PR #2241.

Design points worth calling out:

- Counters live behind `getProcessSingleton` (family `concurrent-session-bind-rollup`, v1),
  not a module-scope `let`. The module graph evaluates more than once per process — #2146
  measured nine evaluations for one pid — so a `let` would only ever count the binds routed
  through its own copy (defect-shape 25).
- Reset fires on the primary-continuation `session_start` path only, after the declined
  bind's own `return` at `index.ts:1855`. It re-arms the counters for a primary that
  crashed or was killed before reaching `session_shutdown` (defect-shape 17), without
  erasing a live sibling's tally.
- Emit is a no-op when nothing was declined, matching the sibling rollups' "no noise on an
  ordinary session" shape.

Closes #2249

### Fix round 1 (review)

`oxfmt` was failing on four of the touched files. Formatting-only commit; no behavior
change.

## Tests

- EDIT `tests/clients/session-start-observability.test.ts` — the unit seam. Covers: each
  classification increments its own bucket; an unknown/absent `classification` lands in
  `unclassified` rather than being dropped; emit is a no-op at zero; emit clears the
  counters; and a `vi.resetModules()` case that re-imports the module and proves the count
  survives, which is the assertion that would red if the counters regressed to a
  module-scope `let`.
- EDIT `tests/index-integration.test.ts` — the wiring seam. Proves the rollup is emitted
  from `session_shutdown` and reset from the primary `session_start`, i.e. that the two
  calls are actually reached, not merely exported.
- EDIT `tests/scripts/latency-log-phases.test.ts` — registers
  `concurrent_session_bind_rollup` in the phase-name sweep, so the new phase cannot be a
  phase no sweep knows about.
- Red-first, recorded by the authoring run: reverse-applying the implementation patch
  failed 6 of 7 unit tests and 3 of 3 new integration tests.
- Re-run in this worktree after `npm run build`: 67/67 green across the three files.
  `npm run lint` and `npm run fmt:check` clean. Full suite deferred to CI per #1112.
- Screens: the `vi.resetModules()` case exists specifically to defeat the parallel-path
  failure (a second module evaluation with its own counters); the integration test pins the
  call site rather than the export (wrong-layer pin); the zero-total case makes an
  invisible skip visible by distinguishing "nothing declined" from "emit never ran".

## Test assessment

Per touched test file:

- `session-start-observability.test.ts` — uniquely pins the counter semantics
  (bucketing, unclassified fallback, no-op at zero, clear-on-emit) and the
  process-singleton backing. Nothing here is covered elsewhere; the singleton conformance
  suite pins `getProcessSingleton` itself, not this family's use of it.
- `index-integration.test.ts` — uniquely pins that emit and reset are wired at the right
  two places in `index.ts`. The unit file cannot prove this; it only proves the functions
  behave when called.
- `latency-log-phases.test.ts` — uniquely pins phase-name registration. One line, and it
  is the file's whole purpose.

Nothing became redundant, and no test was removed or loosened. The overlap between the unit
and integration files is deliberate and narrow: the integration test asserts *reachability*
and the unit test asserts *behavior*, so neither subsumes the other.

## Blast radius

Touched production modules and their dependents (`rg` over non-test, non-compiled sources):

| Module | Production dependents |
| --- | --- |
| `clients/session-start-observability.ts` | `index.ts` only (plus `config/dependency-cruiser-eager-allowlist.json`, which lists it, and `docs/subagent-compat.md`) |
| `clients/latency-logger.ts` | Broad, but the change is one string added to the `LAST_PHASE_EXCLUDED` set — no signature, no export, no control-flow change |
| `index.ts` | Entry point; no dependents |

Entry points touched: the `session_start` handler (one added call on the
primary-continuation path) and the `session_shutdown` handler (one added call, alongside
the two existing rollups).

Hot-path cost: `logConcurrentSessionBind` gains one `getProcessSingleton` lookup plus one
integer increment. That function only runs on a *declined* bind — at most a handful of
times per process — so this is not a per-spawn, per-file or per-render path. The
session-end emit is one `logLatency` row, and only when a decline actually occurred.

`module_report` with `blastRadius: true` was run on
`clients/session-start-observability.ts` and returned `"blastRadius":"none"` with
`provenance.usedBy: "none"` — the review-graph cache is cold in this worktree, so the
transitive walk is unavailable. Recorded rather than reported as empty; the `rg` sweep
above is the substitute.

## Observability

The record that proves this works in production is the new
`concurrent_session_bind_rollup` latency phase (`clients/latency-logger.ts` sink,
`filePath: <projectRoot>`, `durationMs: 0`), whose metadata carries the three per-
classification counts. Its absence on a session where no bind was declined is itself the
designed signal, matching `session_end_bus_rollup` and
`path_attribution_verified_rollup`.

The phase is registered in all three places a new phase has to be registered:
`tests/scripts/latency-log-phases.test.ts`, `scripts/compat-smoke-behavioral.mjs`, and
`docs/subagent-compat.md`. It is added to `LAST_PHASE_EXCLUDED` so a zero-duration
session-end summary can never take the blame for a stall it did not cause.

Gap named honestly: `scripts/compat-smoke-behavioral.mjs` assertion 6 still records this as
NOT ASSERTED. Observing either the per-bind phase or the rollup requires reproducing the
in-process double-`bindExtensions()` model with a real `createAgentSession()`, which needs
model/provider config that cannot be cheaply stubbed. This PR corrects that assertion's
stale claim (it said `decideSessionStart` had no call site; it has had one since PR #477)
but does not close the gap. That is a documented TODO in `docs/subagent-compat.md`, not new
debt from this change.

## Class sweep

Defect shape 25 — session-scoped counters held in module-scope state, which undercounts
whenever the module graph is evaluated more than once per process (#2146: nine evaluations
for one pid).

Whole-tree sweep, `clients/` plus `tools/`, `mcp/`, `scripts/`, `index.ts`, for the
`*_rollup` counter family:

| Member | Backing | Verdict |
| --- | --- | --- |
| `clients/session-start-observability.ts` (`concurrent_session_bind_rollup`) | `getProcessSingleton` | This PR. Correct by construction |
| `clients/bus-events-logger.ts` (`session_end_bus_rollup`) | module-scope `const eventRollupCounts = new Map(…)` (line 110) | Pre-existing exposure to the same shape. NOT fixed here — out of scope for #2249, and correcting it changes counts other tests pin |
| `clients/path-attribution-telemetry.ts` (`path_attribution_verified_rollup`) | module-scope `let verifiedGuessCount = 0` (line 7) | Same verdict |

This is explicitly not a class of size 1: two sibling rollups carry the same latent shape.
This PR deliberately does not convert them — that is a separate change with its own
red-first proof and its own blast radius — and the new code takes the correct form rather
than copying theirs, so the family does not grow.

Consolidation verdict: the family stays distributed for now. Folding all three onto one
"session rollup counter" seam is the right end state and would let a single
`getProcessSingleton` family serve every rollup, but it needs the two siblings converted
first. Filing that as a follow-up rather than smuggling it into a #2249 PR.

## Review round

Maintainer delta 2f755c80/4461a882 on three review findings, contributor commits untouched: the sequential-replacement session_start now emits the pending rollup before resetting (a crashed prior primary's tally was silently discarded; red proof `expected [] to have a length of 1`); the phase-sweep test drives the real production functions through the real log sink instead of literal objects (red proof: TypeError on the pre-feature base); and the new LAST_PHASE_EXCLUDED entry is pinned (deleting it reds `expected 'concurrent_session_bind_rollup' to be 'provider_request'`). 112/112 targeted + 101/101 governance green. The review also surfaced a structural gap filed as #2319: getProcessSingleton-backed session state with closure-inline resets is invisible to the session-state conformance sweep — not this PR's to fix.

