### PR TITLE
fix: add a size axis to the five mtime-only content memos (#2300)

### DIFF
--- a/.changelog/2300-mtime-size-axis-sweep.md
+++ b/.changelog/2300-mtime-size-axis-sweep.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Add a size axis to five mtime-only content memos (closes #2300)** — The MCP warm-build staleness gate, the LSP diagnostic-binding content-hash memo, the workspace-diagnostics per-file freshness cache, the cross-process recent-touches watermark, and the installer's tool-path probe cache now all validate byte size alongside mtime, so an external rewrite landing in the same coarse-granularity mtime bucket with a different length is no longer served as unchanged. Every fix reuses a stat call already being made — no added per-edit I/O.

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -1613,6 +1613,16 @@ export function resetResolvedPathCache(): void {
 interface ProbeCacheEntry {
 	path: string;
 	mtimeMs: number;
+	/**
+	 * #2300: byte size at the same stat call as `mtimeMs`. A binary replaced
+	 * in-place (an upgrade landing in the same coarse-granularity mtime tick)
+	 * would otherwise pass the mtime-only freshness check unnoticed. Optional
+	 * so a pre-#2300 persisted entry doesn't need a version bump to stay
+	 * loadable — `checkProbeCache` fails OPEN (mtime-only) when absent; it
+	 * self-heals on the entry's next `updateProbeCache` write or 24h TTL
+	 * expiry, whichever comes first.
+	 */
+	sizeBytes?: number;
 	cachedAt: number;
 	/**
 	 * True when the `getToolPath` resolution that produced `path` saw a
@@ -1931,9 +1941,16 @@ export async function checkProbeCache(
 	try {
 		await fs.access(entry.path);
 		const stat = await fs.stat(entry.path);
-		if (stat.mtimeMs !== entry.mtimeMs) {
+		// #2300: size alongside mtime, from the same stat — a binary replaced
+		// in-place within the same coarse-granularity mtime tick would otherwise
+		// pass this check unnoticed. `entry.sizeBytes` absent (pre-#2300 entry)
+		// fails open to the mtime-only check (see the field's doc comment).
+		if (
+			stat.mtimeMs !== entry.mtimeMs ||
+			(entry.sizeBytes !== undefined && stat.size !== entry.sizeBytes)
+		) {
 			logSessionStart(
-				`auto-install probe-cache ${toolId}: miss (mtime changed)`,
+				`auto-install probe-cache ${toolId}: miss (mtime/size changed)`,
 			);
 			delete cache[toolId];
 			markProbeCacheChange(toolId, null);
@@ -1970,6 +1987,7 @@ export async function updateProbeCache(
 		const entry: ProbeCacheEntry = {
 			path: resolvedPath,
 			mtimeMs: stat.mtimeMs,
+			sizeBytes: stat.size,
 			cachedAt: Date.now(),
 			...(transient && { transient: true }),
 		};

--- a/clients/lsp/diagnostic-binding.ts
+++ b/clients/lsp/diagnostic-binding.ts
@@ -447,30 +447,39 @@ export function createDiskBindingCache(): DiskBindingCache {
 	// the same path (`SUB\a.ts` vs `sub/a.ts`) can't produce a duplicate memo or a
 	// false miss. Ephemeral (slash-fold + win32-lowercase, no realpath I/O) — the
 	// keys are file paths this process is already stat'ing on the hot read path.
-	const diskHashByPath = new PathKeyedMap<{ mtimeMs: number; hash: string }>(
-		normalizeEphemeralMapKey,
-	);
+	// #2300: the memo guards a CONTENT HASH recompute, so a stale memo serves a
+	// stale hash — `size` is the cheap second axis alongside `mtimeMs`, from the
+	// SAME stat call, so a same-mtime-bucket external rewrite is not masked.
+	const diskHashByPath = new PathKeyedMap<{
+		mtimeMs: number;
+		size: number;
+		hash: string;
+	}>(normalizeEphemeralMapKey);
 	return {
 		boundToCurrentDisk(filePath, stored) {
 			// No fingerprint captured (version-less server) → unknown, never false.
 			if (stored.contentHash === undefined) return "unknown";
-			let mtimeMs: number;
+			let stat: fs.Stats;
 			try {
-				mtimeMs = fs.statSync(filePath).mtimeMs;
+				stat = fs.statSync(filePath);
 			} catch {
 				// Can't stat (deleted/unreadable): can't disprove the binding either,
 				// so stay honest — "unknown", never a manufactured false.
 				return "unknown";
 			}
 			let cached = diskHashByPath.get(filePath);
-			if (!cached || cached.mtimeMs !== mtimeMs) {
+			if (
+				!cached ||
+				cached.mtimeMs !== stat.mtimeMs ||
+				cached.size !== stat.size
+			) {
 				let diskHash: string;
 				try {
 					diskHash = hashDiagnosticContent(fs.readFileSync(filePath, "utf-8"));
 				} catch {
 					return "unknown";
 				}
-				cached = { mtimeMs, hash: diskHash };
+				cached = { mtimeMs: stat.mtimeMs, size: stat.size, hash: diskHash };
 				if (diskHashByPath.size >= DISK_BINDING_MEMO_MAX) {
 					diskHashByPath.clear();
 				}

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -7632,6 +7632,10 @@ export class LSPService {
 		// mtime it was ACTUALLY scanned at (not re-stat'd after the fact, which
 		// could race a concurrent edit).
 		const scannedMtimeByFile = new Map<string, number>();
+		// #2300: size from the SAME stat call as the mtime above — zero extra
+		// syscalls — so the cache write below can give `isEntryFresh` a size
+		// axis alongside the mtime.
+		const scannedSizeByFile = new Map<string, number>();
 
 		// Group files by their primary language server (#387, extracted as
 		// `groupFilesByPrimaryServer` for #631). tsserver — and most servers — is
@@ -7834,7 +7838,9 @@ export class LSPService {
 				// microseconds with no extra event-loop tick, where an awaited
 				// promise would insert one.
 				try {
-					scannedMtimeByFile.set(filePath, nodeFs.statSync(filePath).mtimeMs);
+					const scanStat = nodeFs.statSync(filePath);
+					scannedMtimeByFile.set(filePath, scanStat.mtimeMs);
+					scannedSizeByFile.set(filePath, scanStat.size);
 				} catch {
 					// Best-effort: a failed stat here just means this file won't be
 					// eligible for caching below (no entry gets written for it).
@@ -8102,10 +8108,9 @@ export class LSPService {
 								// too — best-effort stat since the pull already resolved the
 								// diagnostics for this file some time ago.
 								try {
-									scannedMtimeByFile.set(
-										result.filePath,
-										nodeFs.statSync(result.filePath).mtimeMs,
-									);
+									const pullStat = nodeFs.statSync(result.filePath);
+									scannedMtimeByFile.set(result.filePath, pullStat.mtimeMs);
+									scannedSizeByFile.set(result.filePath, pullStat.size);
 								} catch {
 									// Not cache-eligible without a confirmed mtime.
 								}
@@ -8298,6 +8303,7 @@ export class LSPService {
 				result.diagnostics,
 				scannedAt,
 				result.contentHash,
+				scannedSizeByFile.get(result.filePath),
 			);
 		}
 		workspaceDiagnosticsCacheCtx.persist();

--- a/clients/lsp/workspace-diagnostics-cache.ts
+++ b/clients/lsp/workspace-diagnostics-cache.ts
@@ -50,6 +50,21 @@ export interface WorkspaceDiagnosticsCacheEntry {
 	/** The file's own mtime (ms since epoch) at the moment it was scanned. */
 	mtimeMs: number;
 	/**
+	 * #2300: the file's own byte size at the moment it was scanned, from the
+	 * SAME stat call `mtimeMs` came from (zero extra syscalls). `isEntryFresh`'s
+	 * own-file check is an mtime EQUALITY memo — a same-mtime-bucket external
+	 * rewrite (same second/coarse-granularity timestamp, different bytes; the
+	 * NTFS-granularity case #2287 N1 named) is invisible to mtime alone. Size
+	 * is the cheap second axis; a full content hash stays reserved for the
+	 * `contentHash`/binding tier below, not this hot per-file gate.
+	 * Optional so a pre-#2300 persisted entry doesn't need a version bump to
+	 * stay loadable: `isEntryFresh` fails OPEN (mtime-only) when absent,
+	 * mirroring `depIndexAtScan`'s established precedent for this same cache —
+	 * an old entry never asserted a size claim, so there is nothing stronger to
+	 * hold it to, and every entry this cache writes going forward carries it.
+	 */
+	sizeBytes?: number;
+	/**
 	 * Wall-clock time (ms since epoch) this entry was written. The
 	 * dependency-staleness check in `isEntryFresh` compares each import's
 	 * CURRENT mtime against THIS timestamp, not against `mtimeMs` — a file's
@@ -378,7 +393,11 @@ export function classifyWorkspaceDiagnosticsCacheExpiry(
  * Two invalidation layers:
  * 1. The file's OWN mtime must be unchanged since it was scanned (exact
  *    match against `entry.mtimeMs`) — any drift, or a stat failure
- *    (deleted/unreadable), invalidates.
+ *    (deleted/unreadable), invalidates. #2300: when the entry also carries a
+ *    `sizeBytes`, the current size must match too — an external rewrite that
+ *    lands in the same mtime bucket with a different length is otherwise
+ *    invisible to mtime alone. A pre-#2300 entry without `sizeBytes` fails
+ *    OPEN to the mtime-only check (see the field's doc comment).
  * 2. When a reverse-dependency index is available (`getImports` returns an
  *    array rather than `undefined`), every file THIS file imports must not
  *    have changed after `entry.scannedAt` either — this is the fix for the
@@ -427,13 +446,17 @@ export function isEntryFresh(
 	entry: WorkspaceDiagnosticsCacheEntry,
 	getImports: (filePath: string) => string[] | undefined,
 ): boolean {
-	let ownMtime: number;
+	let ownStat: fs.Stats;
 	try {
-		ownMtime = fs.statSync(filePath).mtimeMs;
+		ownStat = fs.statSync(filePath);
 	} catch {
 		return false; // deleted / unreadable
 	}
-	if (ownMtime !== entry.mtimeMs) return false;
+	if (ownStat.mtimeMs !== entry.mtimeMs) return false;
+	// #2300: same axis reused from the stat above — no extra syscall.
+	if (entry.sizeBytes !== undefined && ownStat.size !== entry.sizeBytes) {
+		return false;
+	}
 
 	const imports = getImports(filePath);
 	if (imports === undefined) {
@@ -547,6 +570,11 @@ export interface WorkspaceDiagnosticsCacheContext {
 		 *  against, when the caller had content in hand. Omit when unavailable —
 		 *  the entry's binding then reads "unknown". */
 		contentHash?: string,
+		/** #2300: the file's byte size at the same moment as `mtimeMs`, from the
+		 *  same stat call — see `WorkspaceDiagnosticsCacheEntry.sizeBytes`. Omit
+		 *  when unavailable — `isEntryFresh` then fails open to mtime-only for
+		 *  this entry. */
+		sizeBytes?: number,
 	): void;
 	/** Best-effort disk write of everything recorded so far. Swallows any
 	 * write failure — a failed cache write should never fail the sweep that
@@ -727,7 +755,7 @@ export function createWorkspaceDiagnosticsCacheContext(
 				scannedAt: entry.scannedAt,
 			};
 		},
-		record(filePath, scopeKey, diagnostics, mtimeMs, contentHash) {
+		record(filePath, scopeKey, diagnostics, mtimeMs, contentHash, sizeBytes) {
 			entries[cacheKeyFor(filePath)] = {
 				diagnostics,
 				count: diagnostics.length,
@@ -741,6 +769,7 @@ export function createWorkspaceDiagnosticsCacheContext(
 				// weaker mtime-only path only when that refusal is warranted.
 				depIndexAtScan: hasDepKnowledge(filePath),
 				...(contentHash !== undefined && { contentHash }),
+				...(sizeBytes !== undefined && { sizeBytes }),
 			};
 			dirty = true;
 		},

--- a/clients/recent-touches.ts
+++ b/clients/recent-touches.ts
@@ -79,6 +79,7 @@ export function isRecentTouchesEnabled(): boolean {
 export function _resetRecentTouchesForTests(): void {
 	_enabledCache = undefined;
 	_lastSeenMtimeMs = undefined;
+	_lastSeenSizeBytes = undefined;
 	_lastConsumedCursor.clear();
 }
 
@@ -228,10 +229,12 @@ export async function readCrossProcessTouchesForSessionStart(
 
 // --- Consumer: parent at turn_start (mtime-gated hot path) ---
 
-// Module state: the last mtime we've already consumed, and a per-cwd cursor
-// (max ts already surfaced) so repeated reads of an unchanged-since-last-
-// check file never re-emit the same entries into the accumulator twice.
+// Module state: the last mtime (+ size, #2300) we've already consumed, and a
+// per-cwd cursor (max ts already surfaced) so repeated reads of an
+// unchanged-since-last-check file never re-emit the same entries into the
+// accumulator twice.
 let _lastSeenMtimeMs: number | undefined;
+let _lastSeenSizeBytes: number | undefined;
 const _lastConsumedCursor = new Map<string, number>();
 
 export interface ReadCrossProcessTouchesForTurnStartArgs {
@@ -267,15 +270,25 @@ export async function readCrossProcessTouchesForTurnStart(
 	try {
 		const target = recentTouchesPath(args.cwd);
 		let mtimeMs: number;
+		let sizeBytes: number;
 		try {
-			mtimeMs = (await fs.promises.stat(target)).mtimeMs;
+			const stat = await fs.promises.stat(target);
+			mtimeMs = stat.mtimeMs;
+			sizeBytes = stat.size;
 		} catch {
 			// No record file yet (ENOENT) or inaccessible (EACCES) — nothing to
 			// report; do not disturb the mtime watermark.
 			return [];
 		}
-		if (_lastSeenMtimeMs === mtimeMs) return [];
+		// #2300: size alongside mtime — a same-mtime-bucket rewrite (a sibling
+		// process's write landing in the same coarse-granularity mtime tick)
+		// changes the file's length, so mtime equality alone would wrongly
+		// short-circuit to "nothing new" and drop its entries.
+		if (_lastSeenMtimeMs === mtimeMs && _lastSeenSizeBytes === sizeBytes) {
+			return [];
+		}
 		_lastSeenMtimeMs = mtimeMs;
+		_lastSeenSizeBytes = sizeBytes;
 
 		const selfPid = args.selfPid ?? process.pid;
 		const now = args.now ?? Date.now();

--- a/mcp/build-staleness.ts
+++ b/mcp/build-staleness.ts
@@ -34,7 +34,9 @@
 import * as fs from "node:fs";
 
 /** Injectable so tests never touch the real filesystem. */
-export type StatFn = (targetPath: string) => { mtimeMs: number } | undefined;
+export type StatFn = (
+	targetPath: string,
+) => { mtimeMs: number; size: number } | undefined;
 
 export const realStat: StatFn = (targetPath) => {
 	try {
@@ -48,6 +50,14 @@ export const realStat: StatFn = (targetPath) => {
 export interface BuildStamp {
 	entryPath: string;
 	mtimeMs: number;
+	/**
+	 * #2300: the entry file's byte size at startup, from the same stat call as
+	 * `mtimeMs`. A rebuild that lands in the same mtime bucket as the startup
+	 * stat (coarse filesystem mtime granularity) but changes the bundle's
+	 * length would otherwise be invisible to `checkStaleness`'s mtime-only
+	 * comparison.
+	 */
+	size: number;
 }
 
 /**
@@ -63,11 +73,11 @@ export function computeBuildStamp(
 ): BuildStamp | undefined {
 	const info = stat(entryPath);
 	if (!info) return undefined;
-	return { entryPath, mtimeMs: info.mtimeMs };
+	return { entryPath, mtimeMs: info.mtimeMs, size: info.size };
 }
 
 export interface StalenessCheckResult {
-	/** true when the on-disk entry's mtime no longer matches the startup stamp. */
+	/** true when the on-disk entry's mtime or size no longer matches the startup stamp. */
 	stale: boolean;
 	/** The stamp captured at startup (echoed for logging/tests). */
 	stamp: BuildStamp;
@@ -77,11 +87,12 @@ export interface StalenessCheckResult {
 
 /**
  * One-shot comparison: re-stats `stamp.entryPath` and compares against the
- * startup mtime. A failed re-stat (file briefly missing mid-rebuild-write, or
- * an installed-package layout) is treated as NOT stale — we only ever flag a
- * build change we can positively observe, never assume one from an I/O
- * hiccup (false positives would make every tool call route to fresh, which
- * defeats the warm server's entire purpose).
+ * startup mtime AND size (#2300 — a same-mtime-bucket rebuild that changes
+ * the bundle's length is otherwise invisible). A failed re-stat (file briefly
+ * missing mid-rebuild-write, or an installed-package layout) is treated as
+ * NOT stale — we only ever flag a build change we can positively observe,
+ * never assume one from an I/O hiccup (false positives would make every tool
+ * call route to fresh, which defeats the warm server's entire purpose).
  */
 export function checkStaleness(
 	stamp: BuildStamp,
@@ -90,7 +101,7 @@ export function checkStaleness(
 	const info = stat(stamp.entryPath);
 	if (!info) return { stale: false, stamp, currentMtimeMs: undefined };
 	return {
-		stale: info.mtimeMs !== stamp.mtimeMs,
+		stale: info.mtimeMs !== stamp.mtimeMs || info.size !== stamp.size,
 		stamp,
 		currentMtimeMs: info.mtimeMs,
 	};

--- a/tests/clients/installer/probe-cache.test.ts
+++ b/tests/clients/installer/probe-cache.test.ts
@@ -57,13 +57,20 @@ const TOOL_PATH =
 const MTIME_MS = 1_700_000_000_000;
 
 function makeCacheJson(
-	overrides: Partial<{ cachedAt: number; mtimeMs: number }> = {},
+	overrides: Partial<{
+		cachedAt: number;
+		mtimeMs: number;
+		sizeBytes: number;
+	}> = {},
 ) {
 	return JSON.stringify({
 		[TOOL_ID]: {
 			path: TOOL_PATH,
 			mtimeMs: overrides.mtimeMs ?? MTIME_MS,
 			cachedAt: overrides.cachedAt ?? Date.now(),
+			...(overrides.sizeBytes !== undefined && {
+				sizeBytes: overrides.sizeBytes,
+			}),
 		},
 	});
 }
@@ -137,6 +144,46 @@ describe("checkProbeCache", () => {
 		expect(result).toBe(TOOL_PATH);
 	});
 
+	// #2300: a same-mtime-bucket rewrite (coarse filesystem mtime granularity)
+	// that changes the binary's byte length must not pass the mtime-only
+	// freshness check. Varies SIZE, never same-length content.
+	it("returns undefined and evicts when the binary size has changed even though mtime matches", async () => {
+		mockFsReadFile.mockResolvedValue(
+			makeCacheJson({ mtimeMs: MTIME_MS, sizeBytes: 1000 }),
+		);
+		mockFsAccess.mockResolvedValue(undefined);
+		mockFsStat.mockResolvedValue({ mtimeMs: MTIME_MS, size: 2000 });
+
+		const result = await checkProbeCache(TOOL_ID);
+
+		expect(result).toBeUndefined();
+		expect(mockFsStat).toHaveBeenCalledWith(TOOL_PATH);
+	});
+
+	it("returns the cached path when both mtime and size match", async () => {
+		mockFsReadFile.mockResolvedValue(
+			makeCacheJson({ mtimeMs: MTIME_MS, sizeBytes: 1000 }),
+		);
+		mockFsAccess.mockResolvedValue(undefined);
+		mockFsStat.mockResolvedValue({ mtimeMs: MTIME_MS, size: 1000 });
+
+		const result = await checkProbeCache(TOOL_ID);
+
+		expect(result).toBe(TOOL_PATH);
+	});
+
+	it("keeps serving a legacy entry with no sizeBytes field when mtime matches (fail open)", async () => {
+		mockFsReadFile.mockResolvedValue(makeCacheJson({ mtimeMs: MTIME_MS }));
+		mockFsAccess.mockResolvedValue(undefined);
+		// Real current size differs, but the legacy entry never asserted a size
+		// claim, so this pre-#2300 entry still fails OPEN to mtime-only.
+		mockFsStat.mockResolvedValue({ mtimeMs: MTIME_MS, size: 9999 });
+
+		const result = await checkProbeCache(TOOL_ID);
+
+		expect(result).toBe(TOOL_PATH);
+	});
+
 	it("skips readFile on the second call (uses in-memory cache)", async () => {
 		mockFsReadFile.mockResolvedValue(makeCacheJson({ mtimeMs: MTIME_MS }));
 		mockFsAccess.mockResolvedValue(undefined);
@@ -193,6 +240,28 @@ describe("updateProbeCache", () => {
 		expect(written[TOOL_ID]).toMatchObject({
 			path: TOOL_PATH,
 			mtimeMs: MTIME_MS,
+		});
+	});
+
+	it("persists the resolved binary's size alongside its mtime (#2300)", async () => {
+		vi.useFakeTimers();
+		mockFsReadFile.mockRejectedValue(
+			Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+		);
+		mockFsStat.mockResolvedValue({ mtimeMs: MTIME_MS, size: 4242 });
+
+		await updateProbeCache(TOOL_ID, TOOL_PATH);
+		await vi.advanceTimersByTimeAsync(400);
+
+		const [, content] = mockWriteFileAtomicAsync.mock.calls[0] as [
+			string,
+			string,
+		];
+		const written = JSON.parse(content) as Record<string, unknown>;
+		expect(written[TOOL_ID]).toMatchObject({
+			path: TOOL_PATH,
+			mtimeMs: MTIME_MS,
+			sizeBytes: 4242,
 		});
 	});
 

--- a/tests/clients/lsp/diagnostic-binding.test.ts
+++ b/tests/clients/lsp/diagnostic-binding.test.ts
@@ -116,13 +116,15 @@ describe("#1095 diagnostic-binding — createDiskBindingCache (I5, I6, I8)", () 
 	it("same-mtime-bucket rewrite with a different size is not masked by the mtime-only memo (#2300)", () => {
 		const original = "const x = 1;\n";
 		const file = mkTmpFile("a.ts", original);
-		// Pin the mtime to a clean whole-millisecond value up front — the real
-		// filesystem can report sub-millisecond mtimes that `utimesSync` (Date-
-		// based, whole-ms resolution) can't round-trip exactly, which would
-		// make the forced-same-mtime rewrite below land on a slightly different
-		// mtime instead of proving the same-bucket collision.
+		// Pin the mtime up front so the rewrite below can be forced back to it.
+		// Read the pinned value BACK rather than asserting against the nominal
+		// one: `mtimeMs` is derived from a nanosecond timestamp, so a whole-ms
+		// Date can come back as e.g. 1787865954578.999 on ext4. Only the
+		// round-tripped value is stable across two identical `utimesSync` calls,
+		// and it is what the memo actually caches.
 		const pinnedMtimeMs = Date.now();
 		fs.utimesSync(file, new Date(pinnedMtimeMs), new Date(pinnedMtimeMs));
+		const observedMtimeMs = fs.statSync(file).mtimeMs;
 		const cache = createDiskBindingCache();
 		const stored = { contentHash: hashDiagnosticContent(original) };
 		// Warm the memo: caches {mtimeMs, size} of the original content.
@@ -133,7 +135,7 @@ describe("#1095 diagnostic-binding — createDiskBindingCache (I5, I6, I8)", () 
 		const rewritten = "const x = 22222222222;\n"; // different length than original
 		fs.writeFileSync(file, rewritten);
 		fs.utimesSync(file, new Date(pinnedMtimeMs), new Date(pinnedMtimeMs));
-		expect(fs.statSync(file).mtimeMs).toBe(pinnedMtimeMs);
+		expect(fs.statSync(file).mtimeMs).toBe(observedMtimeMs);
 		// A mtime-only memo would reuse the cached hash of the OLD content and
 		// wrongly report `true`. The size axis forces a re-hash, which correctly
 		// reports `false` against the still-stale `stored` binding.

--- a/tests/clients/lsp/diagnostic-binding.test.ts
+++ b/tests/clients/lsp/diagnostic-binding.test.ts
@@ -113,6 +113,33 @@ describe("#1095 diagnostic-binding — createDiskBindingCache (I5, I6, I8)", () 
 		).toBe(false);
 	});
 
+	it("same-mtime-bucket rewrite with a different size is not masked by the mtime-only memo (#2300)", () => {
+		const original = "const x = 1;\n";
+		const file = mkTmpFile("a.ts", original);
+		// Pin the mtime to a clean whole-millisecond value up front — the real
+		// filesystem can report sub-millisecond mtimes that `utimesSync` (Date-
+		// based, whole-ms resolution) can't round-trip exactly, which would
+		// make the forced-same-mtime rewrite below land on a slightly different
+		// mtime instead of proving the same-bucket collision.
+		const pinnedMtimeMs = Date.now();
+		fs.utimesSync(file, new Date(pinnedMtimeMs), new Date(pinnedMtimeMs));
+		const cache = createDiskBindingCache();
+		const stored = { contentHash: hashDiagnosticContent(original) };
+		// Warm the memo: caches {mtimeMs, size} of the original content.
+		expect(cache.boundToCurrentDisk(file, stored)).toBe(true);
+		// External rewrite with DIFFERENT SIZE content, forced back to the SAME
+		// mtime the memo already cached (the NTFS-granularity collision, #2287
+		// N1 — never same-length content, which is why the size axis matters).
+		const rewritten = "const x = 22222222222;\n"; // different length than original
+		fs.writeFileSync(file, rewritten);
+		fs.utimesSync(file, new Date(pinnedMtimeMs), new Date(pinnedMtimeMs));
+		expect(fs.statSync(file).mtimeMs).toBe(pinnedMtimeMs);
+		// A mtime-only memo would reuse the cached hash of the OLD content and
+		// wrongly report `true`. The size axis forces a re-hash, which correctly
+		// reports `false` against the still-stale `stored` binding.
+		expect(cache.boundToCurrentDisk(file, stored)).toBe(false);
+	});
+
 	it("disk stat/read failure with a contentHash present → unknown, never false (T8, #533)", () => {
 		const cache = createDiskBindingCache();
 		const missing = path.join(os.tmpdir(), "pi-lens-does-not-exist-1095.ts");

--- a/tests/clients/lsp/workspace-diagnostics-cache.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-cache.test.ts
@@ -131,6 +131,36 @@ describe("isEntryFresh (#671)", () => {
 		expect(isEntryFresh(filePath, entry, () => undefined)).toBe(false);
 	});
 
+	// #2300: a same-mtime-bucket external rewrite (coarse mtime granularity;
+	// #2287 N1) that changes the file's byte length must not be masked by the
+	// mtime-only equality check. Varies SIZE, never same-length content.
+	it("is stale when size differs even though mtime is unchanged (entry carries sizeBytes)", () => {
+		const stat = fs.statSync(filePath);
+		const entry = makeEntry({
+			mtimeMs: stat.mtimeMs,
+			sizeBytes: stat.size + 1,
+			scannedAt: Date.now(),
+		});
+		expect(isEntryFresh(filePath, entry, () => undefined)).toBe(false);
+	});
+
+	it("stays fresh when both mtime and size match the entry", () => {
+		const stat = fs.statSync(filePath);
+		const entry = makeEntry({
+			mtimeMs: stat.mtimeMs,
+			sizeBytes: stat.size,
+			scannedAt: Date.now(),
+		});
+		expect(isEntryFresh(filePath, entry, () => undefined)).toBe(true);
+	});
+
+	it("keeps failing OPEN to mtime-only for a legacy entry with no sizeBytes field at all", () => {
+		const mtimeMs = fs.statSync(filePath).mtimeMs;
+		const entry = makeEntry({ mtimeMs, scannedAt: Date.now() });
+		expect(entry.sizeBytes).toBeUndefined();
+		expect(isEntryFresh(filePath, entry, () => undefined)).toBe(true);
+	});
+
 	it("is stale when the file no longer exists", () => {
 		const entry = makeEntry({ mtimeMs: 1 });
 		expect(
@@ -262,6 +292,33 @@ describe("WorkspaceDiagnosticsCacheContext (#671)", () => {
 			count: 0,
 			scannedAt: expect.any(Number),
 		});
+	});
+
+	// #2300: an end-to-end proof that `record`'s sizeBytes reaches
+	// `isEntryFresh` through `lookup` — a same-mtime-bucket external rewrite
+	// that changes the file's length must invalidate a real context's cache.
+	it("a same-mtime-bucket external rewrite with a different size invalidates the recorded entry", () => {
+		const filePath = path.join(tmp, "a.ts");
+		fs.writeFileSync(filePath, "const a = 1;\n");
+		// Pin to a clean whole-millisecond mtime — `utimesSync` (Date-based)
+		// can't round-trip a filesystem's sub-millisecond mtime exactly, which
+		// would make the forced-same-mtime rewrite below land on a slightly
+		// different mtime instead of proving the same-bucket collision.
+		const pinnedMtimeMs = Date.now();
+		fs.utimesSync(filePath, new Date(pinnedMtimeMs), new Date(pinnedMtimeMs));
+		const ctx = createWorkspaceDiagnosticsCacheContext(tmp);
+		const stat = fs.statSync(filePath);
+		ctx.record(filePath, "all|", [], stat.mtimeMs, undefined, stat.size);
+		expect(ctx.lookup(filePath, "all|")).toBeDefined();
+
+		// Rewrite with different-length content, forced back to the SAME mtime
+		// the entry was recorded against.
+		fs.writeFileSync(filePath, "const a = 22222222222;\n");
+		fs.utimesSync(filePath, new Date(pinnedMtimeMs), new Date(pinnedMtimeMs));
+		expect(fs.statSync(filePath).mtimeMs).toBe(pinnedMtimeMs);
+		expect(fs.statSync(filePath).size).not.toBe(stat.size);
+
+		expect(ctx.lookup(filePath, "all|")).toBeUndefined();
 	});
 
 	it("a lookup under a DIFFERENT scopeKey never sees an entry recorded under another scope", () => {

--- a/tests/clients/lsp/workspace-diagnostics-cache.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-cache.test.ts
@@ -300,10 +300,10 @@ describe("WorkspaceDiagnosticsCacheContext (#671)", () => {
 	it("a same-mtime-bucket external rewrite with a different size invalidates the recorded entry", () => {
 		const filePath = path.join(tmp, "a.ts");
 		fs.writeFileSync(filePath, "const a = 1;\n");
-		// Pin to a clean whole-millisecond mtime — `utimesSync` (Date-based)
-		// can't round-trip a filesystem's sub-millisecond mtime exactly, which
-		// would make the forced-same-mtime rewrite below land on a slightly
-		// different mtime instead of proving the same-bucket collision.
+		// Pin the mtime up front so the rewrite below can be forced back to it.
+		// `stat.mtimeMs` below is the round-tripped value, not the nominal one:
+		// `mtimeMs` is derived from a nanosecond timestamp, so a whole-ms Date
+		// can come back as e.g. 1787865854006.999 on ext4.
 		const pinnedMtimeMs = Date.now();
 		fs.utimesSync(filePath, new Date(pinnedMtimeMs), new Date(pinnedMtimeMs));
 		const ctx = createWorkspaceDiagnosticsCacheContext(tmp);
@@ -315,7 +315,7 @@ describe("WorkspaceDiagnosticsCacheContext (#671)", () => {
 		// the entry was recorded against.
 		fs.writeFileSync(filePath, "const a = 22222222222;\n");
 		fs.utimesSync(filePath, new Date(pinnedMtimeMs), new Date(pinnedMtimeMs));
-		expect(fs.statSync(filePath).mtimeMs).toBe(pinnedMtimeMs);
+		expect(fs.statSync(filePath).mtimeMs).toBe(stat.mtimeMs);
 		expect(fs.statSync(filePath).size).not.toBe(stat.size);
 
 		expect(ctx.lookup(filePath, "all|")).toBeUndefined();

--- a/tests/clients/lsp/workspace-diagnostics-warm-attach.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-warm-attach.test.ts
@@ -128,6 +128,33 @@ describe("runWorkspaceDiagnostics warm attach sweeps (#822)", () => {
 		).toBeUndefined();
 	});
 
+	// #2300 C1 (verify round): `runWorkspaceDiagnostics`'s own `record` call
+	// (`clients/lsp/index.ts`) wires `scannedSizeByFile.get(result.filePath)`
+	// as the `sizeBytes` argument. A unit test against the cache primitive
+	// alone (`workspace-diagnostics-cache.test.ts`) cannot see this wiring —
+	// it calls `ctx.record` directly with a hand-supplied size, so neutering
+	// the PRODUCTION argument to `undefined` would leave that test green.
+	// This drives the real sweep end to end and reads the persisted entry
+	// back through the cache's own load API.
+	it("persists the swept file's real byte size into the cache entry (#2300)", async () => {
+		fs.mkdirSync(path.join(tmp, ".pi-lens"));
+		const file = path.join(tmp, "a.ts");
+		fs.writeFileSync(file, "const x = 1;\n");
+		tryWarmAttachedDiagnostics.mockResolvedValue({
+			available: true,
+			response: { diagnostics: [] },
+		});
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		await new LSPService().runWorkspaceDiagnostics(tmp, { files: [file] });
+
+		const { cacheKeyFor, loadWorkspaceDiagnosticsCache } =
+			await import("../../../clients/lsp/workspace-diagnostics-cache.js");
+		const entry =
+			loadWorkspaceDiagnosticsCache(tmp)?.entries[cacheKeyFor(file)];
+		expect(entry?.sizeBytes).toBe(fs.statSync(file).size);
+	});
+
 	it("promotes after an IPC failure and completes that file and the remainder locally", async () => {
 		const files = ["a.ts", "b.ts", "c.ts"].map((name) => path.join(tmp, name));
 		for (const file of files) fs.writeFileSync(file, "const x = 1;\n");

--- a/tests/clients/recent-touches.test.ts
+++ b/tests/clients/recent-touches.test.ts
@@ -331,11 +331,12 @@ describe("recent-touches (#492 cross-process touched-files record)", () => {
 			fs.writeFileSync(firstFile, "// first", "utf-8");
 			fs.writeFileSync(secondFile, "// second", "utf-8");
 
-			// Pin to a clean whole-millisecond mtime up front — `utimesSync`
-			// (Date-based) can't round-trip a filesystem's sub-millisecond mtime
-			// exactly, which would make the forced-same-mtime rewrite below land
-			// on a slightly different mtime instead of proving the same-bucket
-			// collision.
+			// Pin the mtime up front so the rewrite below can be forced back to
+			// it. The pinned value is read BACK before it is asserted on:
+			// `mtimeMs` is derived from a nanosecond timestamp, so a whole-ms
+			// Date can come back as e.g. 1787865854006.999 on ext4. Only the
+			// round-tripped value is stable across two identical `utimesSync`
+			// calls, and it is what the memo actually caches.
 			const pinnedMtimeMs = Date.now();
 			fs.writeFileSync(
 				recordFilePath(),
@@ -351,6 +352,7 @@ describe("recent-touches (#492 cross-process touched-files record)", () => {
 				new Date(pinnedMtimeMs),
 				new Date(pinnedMtimeMs),
 			);
+			const observedMtimeMs = fs.statSync(recordFilePath()).mtimeMs;
 			const first = await readCrossProcessTouchesForTurnStart({
 				cwd: FAKE_CWD,
 				selfPid: process.pid,
@@ -379,7 +381,7 @@ describe("recent-touches (#492 cross-process touched-files record)", () => {
 				new Date(pinnedMtimeMs),
 				new Date(pinnedMtimeMs),
 			);
-			expect(fs.statSync(recordFilePath()).mtimeMs).toBe(pinnedMtimeMs);
+			expect(fs.statSync(recordFilePath()).mtimeMs).toBe(observedMtimeMs);
 
 			const second = await readCrossProcessTouchesForTurnStart({
 				cwd: FAKE_CWD,

--- a/tests/clients/recent-touches.test.ts
+++ b/tests/clients/recent-touches.test.ts
@@ -318,6 +318,76 @@ describe("recent-touches (#492 cross-process touched-files record)", () => {
 			expect(second).toEqual([]);
 		});
 
+		// #2300: a same-mtime-bucket rewrite (coarse filesystem mtime
+		// granularity; #2287 N1) that changes the file's byte length must not
+		// be masked by the mtime-only equality memo. Varies SIZE, never
+		// same-length content, and never a real timing race — the mtime is
+		// forced back with `utimesSync` so the test is deterministic.
+		it("a same-mtime-bucket rewrite with a different size is not dropped by the mtime-only memo", async () => {
+			const { readCrossProcessTouchesForTurnStart } =
+				await import("../../clients/recent-touches.js");
+			const firstFile = path.join(dir, "first.ts");
+			const secondFile = path.join(dir, "second.ts");
+			fs.writeFileSync(firstFile, "// first", "utf-8");
+			fs.writeFileSync(secondFile, "// second", "utf-8");
+
+			// Pin to a clean whole-millisecond mtime up front — `utimesSync`
+			// (Date-based) can't round-trip a filesystem's sub-millisecond mtime
+			// exactly, which would make the forced-same-mtime rewrite below land
+			// on a slightly different mtime instead of proving the same-bucket
+			// collision.
+			const pinnedMtimeMs = Date.now();
+			fs.writeFileSync(
+				recordFilePath(),
+				JSON.stringify({
+					entries: [
+						{ path: firstFile, reason: "autofix", ts: Date.now(), pid: 777 },
+					],
+				}),
+				"utf-8",
+			);
+			fs.utimesSync(
+				recordFilePath(),
+				new Date(pinnedMtimeMs),
+				new Date(pinnedMtimeMs),
+			);
+			const first = await readCrossProcessTouchesForTurnStart({
+				cwd: FAKE_CWD,
+				selfPid: process.pid,
+			});
+			expect(first).toHaveLength(1);
+
+			// Real gap so the second entry's `ts` is strictly newer than the
+			// cursor advanced by the first read (avoids a same-millisecond tie).
+			await new Promise((r) => setTimeout(r, 5));
+
+			// A second, strictly LONGER JSON body (an extra entry) forced back to
+			// the SAME mtime the memo already saw. A mtime-only memo would treat
+			// this as "nothing new" and drop the second entry.
+			fs.writeFileSync(
+				recordFilePath(),
+				JSON.stringify({
+					entries: [
+						{ path: firstFile, reason: "autofix", ts: Date.now(), pid: 777 },
+						{ path: secondFile, reason: "format", ts: Date.now(), pid: 777 },
+					],
+				}),
+				"utf-8",
+			);
+			fs.utimesSync(
+				recordFilePath(),
+				new Date(pinnedMtimeMs),
+				new Date(pinnedMtimeMs),
+			);
+			expect(fs.statSync(recordFilePath()).mtimeMs).toBe(pinnedMtimeMs);
+
+			const second = await readCrossProcessTouchesForTurnStart({
+				cwd: FAKE_CWD,
+				selfPid: process.pid,
+			});
+			expect(second.some((e) => e.path.includes("second.ts"))).toBe(true);
+		});
+
 		it("a new append after a prior consume only surfaces the NEW entry (cursor dedup, not full re-read)", async () => {
 			const { readCrossProcessTouchesForTurnStart } =
 				await import("../../clients/recent-touches.js");

--- a/tests/mcp/build-staleness.test.ts
+++ b/tests/mcp/build-staleness.test.ts
@@ -12,14 +12,18 @@ import {
 	type StatFn,
 } from "../../mcp/build-staleness.js";
 
-function fakeStat(mtimeMs: number | undefined): StatFn {
-	return () => (mtimeMs === undefined ? undefined : { mtimeMs });
+function fakeStat(mtimeMs: number | undefined, size = 100): StatFn {
+	return () => (mtimeMs === undefined ? undefined : { mtimeMs, size });
 }
 
 describe("computeBuildStamp", () => {
-	it("captures the entry path and mtime", () => {
-		const stamp = computeBuildStamp("/repo/mcp/server.js", fakeStat(1000));
-		expect(stamp).toEqual({ entryPath: "/repo/mcp/server.js", mtimeMs: 1000 });
+	it("captures the entry path, mtime, and size", () => {
+		const stamp = computeBuildStamp("/repo/mcp/server.js", fakeStat(1000, 100));
+		expect(stamp).toEqual({
+			entryPath: "/repo/mcp/server.js",
+			mtimeMs: 1000,
+			size: 100,
+		});
 	});
 
 	it("returns undefined when the entry can't be stat'd", () => {
@@ -29,16 +33,16 @@ describe("computeBuildStamp", () => {
 });
 
 describe("checkStaleness", () => {
-	const stamp = { entryPath: "/repo/mcp/server.js", mtimeMs: 1000 };
+	const stamp = { entryPath: "/repo/mcp/server.js", mtimeMs: 1000, size: 100 };
 
-	it("is not stale when the on-disk mtime still matches the startup stamp", () => {
-		const result = checkStaleness(stamp, fakeStat(1000));
+	it("is not stale when the on-disk mtime and size still match the startup stamp", () => {
+		const result = checkStaleness(stamp, fakeStat(1000, 100));
 		expect(result.stale).toBe(false);
 		expect(result.currentMtimeMs).toBe(1000);
 	});
 
 	it("is stale when the on-disk mtime has moved (rebuild/merge landed)", () => {
-		const result = checkStaleness(stamp, fakeStat(2000));
+		const result = checkStaleness(stamp, fakeStat(2000, 100));
 		expect(result.stale).toBe(true);
 		expect(result.currentMtimeMs).toBe(2000);
 	});
@@ -47,6 +51,16 @@ describe("checkStaleness", () => {
 		const result = checkStaleness(stamp, fakeStat(undefined));
 		expect(result.stale).toBe(false);
 		expect(result.currentMtimeMs).toBeUndefined();
+	});
+
+	// #2300: a rebuild landing in the same coarse-granularity mtime bucket as
+	// the startup stamp (NTFS-granularity collision, #2287 N1) changes the
+	// bundle's byte length without moving mtime. Same mtime, different size —
+	// never same-length content — is the regression this class needs.
+	it("is stale when size differs even though mtime is unchanged (same-mtime-bucket rebuild)", () => {
+		const result = checkStaleness(stamp, fakeStat(1000, 250));
+		expect(result.stale).toBe(true);
+		expect(result.currentMtimeMs).toBe(1000);
 	});
 });
 
@@ -68,7 +82,7 @@ describe("StalenessGate", () => {
 		let currentMtime = 1000;
 		const countingStat: StatFn = () => {
 			statCalls++;
-			return { mtimeMs: currentMtime };
+			return { mtimeMs: currentMtime, size: 100 };
 		};
 		let nowMs = 0;
 		const gate = new StalenessGate(stamp, {

--- a/tests/tools/lsp-diagnostics-cache.test.ts
+++ b/tests/tools/lsp-diagnostics-cache.test.ts
@@ -90,7 +90,10 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 	}
 
 	/** The on-disk cache's entry map, or `{}` when nothing was written. */
-	function cacheEntries(): Record<string, { mtimeMs: number }> {
+	function cacheEntries(): Record<
+		string,
+		{ mtimeMs: number; sizeBytes?: number }
+	> {
 		const cacheFile = path.join(
 			tmpDir,
 			".pi-lens",
@@ -101,7 +104,7 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 		return (
 			(
 				JSON.parse(fs.readFileSync(cacheFile, "utf8")) as {
-					entries?: Record<string, { mtimeMs: number }>;
+					entries?: Record<string, { mtimeMs: number; sizeBytes?: number }>;
 				}
 			).entries ?? {}
 		);
@@ -117,6 +120,23 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 			{ cwd: tmpDir },
 		) as Promise<any>;
 	}
+
+	// #2300 C1 (verify round): `collectFileDiagnosticResult`'s own `record`
+	// call (`tools/lsp-diagnostics.ts`) wires `stat.size` as the `sizeBytes`
+	// argument. A unit test against the cache primitive alone
+	// (`workspace-diagnostics-cache.test.ts`) cannot see this wiring — it
+	// calls `ctx.record` directly with a hand-supplied size, so neutering the
+	// PRODUCTION argument to `undefined` would leave that test green. This
+	// drives the real tool end to end and reads the persisted entry back.
+	it("persists the touched file's real byte size into the cache entry (#2300)", async () => {
+		const files = writeFiles(["a.ts"]);
+
+		await runBatch(files);
+
+		const entries = cacheEntries();
+		const entry = Object.values(entries)[0];
+		expect(entry?.sizeBytes).toBe(fs.statSync(files[0]!).size);
+	});
 
 	it("a second identical batch call never touches an unchanged file again", async () => {
 		const files = writeFiles(["a.ts", "b.ts"]);

--- a/tools/lsp-diagnostics.ts
+++ b/tools/lsp-diagnostics.ts
@@ -1358,6 +1358,7 @@ async function collectFileDiagnosticResult(
 			collectedContent !== undefined
 				? hashDiagnosticContent(collectedContent)
 				: undefined,
+			stat.size,
 		);
 	}
 	return {


### PR DESCRIPTION
## Summary

All five sites from #2297's class sweep now carry a size axis (or a recorded exemption), so
a same-mtime-bucket external rewrite with different bytes is no longer invisible. Every fix
reuses a stat call already in flight — zero added syscalls, and no content hashing on any
per-edit path.

Both persisted caches (`workspace-diagnostics-cache`, installer probe cache) add
`sizeBytes` as **optional** and fail OPEN (mtime-only) for pre-existing entries — the
`depIndexAtScan` precedent — self-healing on the entry's next write, and for the probe
cache also within its 24h TTL. No cache-version bump, no forced re-scan on upgrade.

Closes #2300

### Per-site verdicts

| Site | Verdict |
| --- | --- |
| `mcp/build-staleness.ts` | Fixed — `BuildStamp`/`StatFn` carry `size` (in-memory only, so required, no compat shim) |
| `clients/lsp/diagnostic-binding.ts` | Fixed — the `diskHashByPath` memo keys on mtime AND size, because it guards a content-hash recompute and a stale memo therefore serves a stale hash |
| `clients/lsp/workspace-diagnostics-cache.ts` | Fixed (own-file check). Dep-freshness loop exempted — it is a one-sided threshold against `scannedAt`, not an equality memo, and stores no per-dep value to extend |
| `clients/recent-touches.ts` | Fixed — `_lastSeenSizeBytes` alongside the mtime watermark |
| `clients/installer/index.ts` | Was a lead only; the sweep found a real member — probe-cache `ProbeCacheEntry` gains `sizeBytes`. Install-lock age check and PATH-hash memo were reviewed and are not members |

### Fix round 1 (CI)

The three same-mtime-bucket regression tests asserted the forced mtime against the
*nominal* `Date.now()` value they passed to `utimesSync`. `mtimeMs` is derived from a
nanosecond timestamp, so a whole-millisecond `Date` reads back as e.g.
`1787865854006.999` on ext4 — green locally, red on CI:

```
AssertionError: expected 1787865854006.999 to be 1787865854007 // Object.is equality
 ❯ tests/clients/recent-touches.test.ts
AssertionError: expected 1787865954578.999 to be 1787865954579 // Object.is equality
 ❯ tests/clients/lsp/diagnostic-binding.test.ts
```

They now read the pinned value back once and compare the post-rewrite stat against *that*.
Two reads of the same stored value are exact by construction, so the assertion is
platform-independent while still proving the same-bucket collision it exists to prove.
`workspace-diagnostics-cache.test.ts` carried the same latent assertion (it happened to
pass) and was corrected too. Test-only change; no production code touched in this round.

## Tests

New or edited, with what each pins:

- `tests/mcp/build-staleness.test.ts` (EDIT) — a rebuild at the same mtime with a different
  size reads `stale: true`. Regression proof for the in-memory site.
- `tests/clients/lsp/diagnostic-binding.test.ts` (EDIT) — `same-mtime-bucket rewrite with a
  different size is not masked by the mtime-only memo (#2300)`. Pins that the memo forces a
  re-hash, so `boundToCurrentDisk` returns `false` against a stale binding instead of
  reusing the old content's hash.
- `tests/clients/lsp/workspace-diagnostics-cache.test.ts` (EDIT) — end-to-end through a
  real context: `record`'s `sizeBytes` reaches `isEntryFresh` via `lookup`, and a
  same-bucket rewrite invalidates. Also pins the fail-open path for an entry with no
  `sizeBytes`.
- `tests/clients/recent-touches.test.ts` (EDIT) — a same-bucket append with a longer JSON
  body is not dropped by the mtime watermark. Uses a real `setTimeout` gap so the second
  entry's `ts` beats the consumed cursor, and forces the mtime back with `utimesSync` so
  there is no timing race in the test itself.
- `tests/clients/installer/probe-cache.test.ts` (EDIT) — a same-bucket binary replacement
  misses the cache; a pre-#2300 entry without `sizeBytes` still hits (fail-open).

Every regression case varies **size**, never same-length content — same-length is the
#2287 N1 case a size axis provably cannot catch, and pinning it here would be a loose
bound dressed up as coverage.

- Red-first, recorded by the authoring run: source-only `git apply -R`, rebuild, rerun — 8
  new/updated assertions failed pre-fix while 129 pre-existing tests in the same files
  stayed green; 137/137 after re-apply.
- Sibling sweep over files referencing the changed symbols: 33 files, 497 tests, green.
- Re-run in this worktree after the fix-round-1 test correction and `npm run build`:
  117/117 green across the five files. `npm run lint`, `npm run fmt:check` and
  `npm run changelog:check` clean. Full suite deferred to CI per #1112.
- Screens: each new case drives the real cache object rather than asserting on the entry
  shape (wrong-layer pin); the fail-open cases make the pre-#2300-entry path visible
  instead of letting it skip silently; the `utimesSync` pinning removes env-dependent
  timing, and fix round 1 removed the last env-dependent assertion.

## Test assessment

Per touched test file:

- `build-staleness.test.ts` — uniquely pins the in-memory stamp. It is the only site with
  no persistence, so it is also the only one where `size` could be made required.
- `diagnostic-binding.test.ts` — uniquely pins the *memo* layer. The workspace-cache test
  cannot reach it; they are different caches with different lifetimes.
- `workspace-diagnostics-cache.test.ts` — uniquely pins `record` → `lookup` →
  `isEntryFresh` threading, which no unit-level assertion on `isEntryFresh` alone would
  catch (a `record` that never wrote `sizeBytes` would still pass those).
- `recent-touches.test.ts` — uniquely pins the module-scope watermark, including the
  reset in `_resetRecentTouchesForTests`.
- `probe-cache.test.ts` — uniquely pins the fail-open contract for pre-existing persisted
  entries. This is the one assertion that would catch an over-eager fix that made
  `sizeBytes` required and invalidated every cache on upgrade.

Nothing became redundant; nothing was removed or loosened. The five cases look alike but
sit on five different caches with different persistence and lifetime rules, so none
subsumes another. The dep-freshness loop in `workspace-diagnostics-cache.ts` has no new
test because it is a recorded exemption, not a fix — adding a test there would pin
behavior the PR deliberately did not change.

## Blast radius

Touched production modules and their production dependents (`rg` over non-test,
non-compiled sources):

| Module | Dependents |
| --- | --- |
| `mcp/build-staleness.ts` | `mcp/server.ts:84` |
| `clients/lsp/diagnostic-binding.ts` | 9 importers, but the changed symbol is `createDiskBindingCache`, whose only two call sites are `clients/lsp/workspace-diagnostics-cache.ts:624` and `clients/lsp/index.ts:1254`. The other seven import `hashDiagnosticContent` / `touchCoverageGap`, neither of which changed |
| `clients/lsp/workspace-diagnostics-cache.ts` | `clients/lsp/index.ts:132`, `tools/lsp-diagnostics.ts:24`, `clients/lsp/client.ts:69` |
| `clients/recent-touches.ts` | `index.ts:105`, `clients/bus-publish.ts:22` |
| `clients/installer/index.ts` | installer entry points only; `ProbeCacheEntry` is module-private |
| `clients/lsp/index.ts`, `tools/lsp-diagnostics.ts` | Call-site updates (pass `size` through); no exported signature change |

Signature changes, all additive:

- `WorkspaceDiagnosticsCacheContext.record` gains a 6th **optional** parameter. Existing
  callers compile unchanged; both in-tree callers were updated to pass it.
- `StatFn` / `BuildStamp` gain a required `size`. In-memory only, and `realStat` already
  returns a full `fs.Stats`, so the only work was at the test doubles.

Hot paths touched, with the measured cost delta: **zero added syscalls at every site.**
Each one reads `.size` off a `Stats` object the code had already obtained —
`isEntryFresh`'s own-file `statSync`, `boundToCurrentDisk`'s `statSync`, the LSP sweep's
per-file scan stat, `readCrossProcessTouchesForTurnStart`'s per-turn `stat`, and
`checkProbeCache`'s existing `stat`. `clients/lsp/index.ts` previously called
`statSync(...).mtimeMs` inline and now binds the same call's result, which is the same
single syscall. The added work per file is one integer comparison.

`module_report` with `blastRadius: true` returns `"blastRadius":"none"` with
`provenance.usedBy: "none"` in this worktree — the review-graph cache is cold, so the
transitive walk is unavailable. Recorded rather than reported as empty; the `rg` sweep
above is the substitute.

## Observability

No new degradation records, and none warranted: each corrected verdict feeds a mechanism
that is already observed.

- `mcp/build-staleness.ts` — the existing `stale` routing in `mcp/server.ts`. A
  same-bucket rebuild now routes to fresh instead of being served warm.
- `clients/lsp/diagnostic-binding.ts` — the existing #1095 binding demote pipeline. The
  entry now reads `false` instead of a stale `true`.
- `clients/lsp/workspace-diagnostics-cache.ts` — the existing cache-miss path; the file is
  re-scanned rather than replayed.
- `clients/recent-touches.ts` — the existing `agent_nudge` phase, whose
  `originCrossProcess` count now includes entries the mtime watermark used to drop.
- `clients/installer/index.ts` — the existing `logSessionStart` line, whose miss message
  now reads `miss (mtime/size changed)` rather than `miss (mtime changed)`. That wording
  change is the one directly greppable proof in a log.

Gap named: nothing distinguishes a *size*-triggered invalidation from an *mtime*-triggered
one except that installer message. Adding a discriminator to the other four would mean a
new field on hot-path records to observe an event that is rare by construction, so it is
deliberately not done.

## Class sweep

Defect shape: an **equality memo keyed on mtime alone**, where the guarded value depends on
file *content*. Coarse filesystem mtime granularity (the NTFS case named in #2287 N1) lets
a rewrite land in the same bucket, and the memo then serves a value derived from the old
bytes.

This PR *is* the class sweep for #2297's finding — the whole-tree sweep across `clients/`,
`tools/`, `mcp/`, `scripts/` and `index.ts` produced the five-member population in the
Per-site verdicts table above, with a per-member verdict for each. Restated as the two
exemptions, since a verdict of "exempt" needs its reason on the record:

- The **dep-freshness loop** in `workspace-diagnostics-cache.ts` compares each import's
  mtime against `entry.scannedAt` — a one-sided threshold, not an equality memo. There is
  no stored per-dep value to extend with a size, and a size axis would not make a
  threshold comparison more correct.
- The installer's **install-lock age check** and **PATH-hash memo** are time-window and
  string-derived respectively; neither guards a content-derived value.

Explicitly **not** claimed: a size axis does not close the same-length-rewrite case. Two
files with identical length and different bytes in the same mtime bucket still collide.
Closing that needs a content hash, which is the `contentHash` tier this PR deliberately
leaves alone on the per-edit paths for cost reasons. The size axis narrows the window; it
does not eliminate it.

Consolidation verdict: the family stays distributed. The five sites are five different
caches with different lifetimes, persistence models and compat constraints (two persisted
and fail-open, three in-memory), and the shared logic is one integer comparison. Folding
them onto a common "freshness stamp" seam would cost more than it saves, and the real
single-source-of-truth already exists at the layer that matters — every site reads its
axes from one `Stats` object obtained by one stat call.

## Review round

The verify round confirmed all five members with independent mutations (7 of 9 red; the two survivors were the unpinned production wirings), endorsed the exemption arguments, and re-measured the red run (figures above corrected from the authoring run's stale totals). Maintainer delta f7d2d029 closes the C1 gap: both production `record()` call sites now carry end-to-end pins that read the persisted entry back through `loadWorkspaceDiagnosticsCache` — each reds when its wiring argument is neutered to `undefined` (expected undefined to be 13 / to be 2), so a dropped `sizeBytes` can no longer hide behind the legacy fail-open.

