### PR TITLE
fix(ci): read live PR body in close-keyword syntax lint (closes #2086)

### DIFF
--- a/.changelog/fix-2086-close-keyword-lint-live-body.md
+++ b/.changelog/fix-2086-close-keyword-lint-live-body.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Read the live PR body in close-keyword syntax checks (refs #2086)** — Reruns now validate the edited PR body instead of replaying a stale event snapshot.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
           persist-credentials: false
 
       - name: Validate per-issue close keywords
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/check-close-keywords.mjs --lint-pr
 
   # #1844: the changelog-fragment format error hit four PRs in one day, each

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1284,9 +1284,12 @@ label" is not "anyone who can merge".
 CI validates GitHub close-keyword syntax through `scripts/check-close-keywords.mjs`:
 PR bodies may not use a comma-separated close list because GitHub applies only
 the first issue per keyword; use one keyword per issue (`Closes #A. Closes #B.`).
+The syntax check fetches the live PR body with `GITHUB_TOKEN`, so reruns do not
+replay an edited event snapshot. The merged-PR workflow uses the same live-body
+contract and fails closed when the fetch fails.
 The merged-PR workflow rechecks each same-repository close target and comments on
 the PR when a referenced issue is missing or remains open. Keep the parser pure
-and unit-tested; workflow YAML should only pass the event to the script.
+and unit-tested; workflow YAML supplies the token required by the live fetch.
 
 ## Key source layout
 

--- a/scripts/check-close-keywords.d.mts
+++ b/scripts/check-close-keywords.d.mts
@@ -11,6 +11,10 @@ export declare function lintCloseKeywords(body?: string): {
 	offendingLines: string[];
 	valid: boolean;
 };
+export declare function lintPullRequest(
+	fetchImpl?: typeof fetch,
+	event?: { pull_request?: { number: number; body?: string | null } },
+): Promise<void>;
 export declare function verifyMergedPullRequest(
 	fetchImpl?: typeof fetch,
 	event?: { pull_request?: { number: number; body?: string | null } },

--- a/scripts/check-close-keywords.mjs
+++ b/scripts/check-close-keywords.mjs
@@ -76,8 +76,15 @@ function eventPayload() {
 	return JSON.parse(readFileSync(eventPath, "utf8"));
 }
 
-function lintPullRequest() {
-	const result = lintCloseKeywords(eventPayload().pull_request?.body ?? "");
+export async function lintPullRequest(
+	fetchImpl = globalThis.fetch,
+	event = eventPayload(),
+) {
+	const pullRequest = event.pull_request;
+	if (!pullRequest || !process.env.GITHUB_REPOSITORY)
+		throw new Error("Pull request event and GITHUB_REPOSITORY are required");
+	const body = await fetchLivePrBody(pullRequest, fetchImpl);
+	const result = lintCloseKeywords(body);
 	if (!result.valid) {
 		console.error(INVALID_CLOSE_KEYWORD_MESSAGE);
 		for (const line of result.offendingLines) {
@@ -213,7 +220,7 @@ Post-merge close verification found issue(s) that were not closed: ${details}. G
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
 	(async () => {
-		if (process.argv[2] === "--lint-pr") lintPullRequest();
+		if (process.argv[2] === "--lint-pr") await lintPullRequest();
 		else if (process.argv[2] === "--verify-merged")
 			await verifyMergedPullRequest();
 		else

--- a/scripts/check-close-keywords.mjs
+++ b/scripts/check-close-keywords.mjs
@@ -83,7 +83,21 @@ export async function lintPullRequest(
 	const pullRequest = event.pull_request;
 	if (!pullRequest || !process.env.GITHUB_REPOSITORY)
 		throw new Error("Pull request event and GITHUB_REPOSITORY are required");
-	const body = await fetchLivePrBody(pullRequest, fetchImpl);
+	// Same fail-closed reporting contract as verifyMergedPullRequest: a fetch
+	// failure states plainly that the check did not run, instead of surfacing
+	// as a bare thrown message that reads like a broken script (worst for
+	// fork PRs hitting a transient 5xx).
+	let body;
+	try {
+		body = await fetchLivePrBody(pullRequest, fetchImpl);
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		console.error(
+			`::error::Close-keyword syntax check could not fetch the live PR body, so it did not run: ${reason}`,
+		);
+		process.exitCode = 1;
+		return;
+	}
 	const result = lintCloseKeywords(body);
 	if (!result.valid) {
 		console.error(INVALID_CLOSE_KEYWORD_MESSAGE);

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -28,7 +28,7 @@ export const MISSING_ISSUE_REF_MESSAGE =
  * can prove a ref sitting only in the body no longer rescues the title.
  * Pure function so it is unit-testable without a GitHub event payload.
  */
-export function lintPrTitle(title = "", _body = "") {
+export function lintPrTitle(title = "") {
 	const errors = [];
 	if (!CONVENTIONAL_PREFIX.test(title.trim())) {
 		errors.push(MISSING_PREFIX_MESSAGE);
@@ -94,7 +94,7 @@ async function lintPullRequestEvent() {
 	const pullRequest = eventPayload().pull_request;
 	if (!pullRequest) throw new Error("Event payload has no pull_request");
 	const title = await resolveLivePrTitle(pullRequest);
-	const result = lintPrTitle(title, pullRequest.body ?? "");
+	const result = lintPrTitle(title);
 	if (!result.valid) {
 		for (const error of result.errors) console.error(error);
 		process.exitCode = 1;

--- a/tests/scripts/check-close-keywords.test.ts
+++ b/tests/scripts/check-close-keywords.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	INVALID_CLOSE_KEYWORD_MESSAGE,
 	lintCloseKeywords,
+	lintPullRequest,
 	parseCloseKeywords,
 	verifyMergedPullRequest,
 } from "../../scripts/check-close-keywords.mjs";
@@ -111,6 +112,34 @@ describe("close-keyword parser (#1320)", () => {
 		const result = lintCloseKeywords("Intro.\nCloses #12, #13\nOutro.");
 		expect(result.valid).toBe(false);
 		expect(result.offendingLines).toEqual(["Closes #12, #13"]);
+	});
+});
+
+describe("close-keyword syntax lint reads the live body (#2086)", () => {
+	it("uses the live body when a rerun receives a stale event payload", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ body: "Closes #123. Closes #456." }), {
+				status: 200,
+			}),
+		);
+		const event = {
+			pull_request: { number: 2086, body: "Closes #123, #456" },
+		};
+
+		await lintPullRequest(fetchImpl, event);
+
+		expect(fetchImpl).toHaveBeenCalledWith(
+			"https://api.github.test/repos/apmantza/pi-lens/pulls/2086",
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
+		expect(log).toHaveBeenCalledWith(
+			"Close-keyword syntax OK (2 issues referenced).",
+		);
+		log.mockRestore();
 	});
 });
 
@@ -312,6 +341,24 @@ describe("close-keyword-verification.yml carries GITHUB_TOKEN (#2267 F1)", () =>
 		// not GH_TOKEN, so the two are NOT interchangeable here even though
 		// they carry the same secret value.
 		expect(step.env?.GH_TOKEN).toBeTruthy();
+		expect(step.env?.GITHUB_TOKEN).toBeTruthy();
+	});
+
+	it("sets GITHUB_TOKEN on the syntax-lint step", () => {
+		const workflowPath = path.join(REPO_ROOT, ".github/workflows/ci.yml");
+		type WorkflowStep = { run?: string; env?: Record<string, string> };
+		type Workflow = {
+			jobs: { "close-keyword-lint": { steps: WorkflowStep[] } };
+		};
+		const workflow = yaml.load(
+			fs.readFileSync(workflowPath, "utf8"),
+		) as Workflow;
+		const step = workflow.jobs["close-keyword-lint"].steps.find((s) =>
+			(s.run ?? "").includes("check-close-keywords.mjs"),
+		);
+		if (!step) throw new Error("syntax-lint step not found in ci.yml");
+		// Mutation-proof: without this workflow wiring the strict live fetch
+		// fails before it can inspect the current PR body.
 		expect(step.env?.GITHUB_TOKEN).toBeTruthy();
 	});
 });

--- a/tests/scripts/check-close-keywords.test.ts
+++ b/tests/scripts/check-close-keywords.test.ts
@@ -116,6 +116,10 @@ describe("close-keyword parser (#1320)", () => {
 });
 
 describe("close-keyword syntax lint reads the live body (#2086)", () => {
+	afterEach(() => {
+		process.exitCode = undefined;
+	});
+
 	it("uses the live body when a rerun receives a stale event payload", async () => {
 		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
 		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
@@ -139,6 +143,76 @@ describe("close-keyword syntax lint reads the live body (#2086)", () => {
 		expect(log).toHaveBeenCalledWith(
 			"Close-keyword syntax OK (2 issues referenced).",
 		);
+		log.mockRestore();
+	});
+
+	// #2086 criterion 3: the lint path carries the same fail-closed guard set
+	// the verify path got in #2267 -- missing token, non-2xx, malformed
+	// response. Each states that the check did not run instead of surfacing
+	// a bare throw that reads like a broken script.
+	it("fails closed with an ::error record when GITHUB_TOKEN is unset", async () => {
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "");
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchImpl = vi.fn();
+		const event = { pull_request: { number: 2086, body: "Closes #1, #2" } };
+
+		await lintPullRequest(fetchImpl, event);
+
+		expect(process.exitCode).toBe(1);
+		expect(fetchImpl).not.toHaveBeenCalled();
+		// Mutation-proof: letting the fetch error escape to the CLI .catch
+		// prints the bare reason with no ::error:: and no did-not-run
+		// statement; linting the stale payload instead would call log.
+		expect(log).not.toHaveBeenCalled();
+		expect(errorLog).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"::error::Close-keyword syntax check could not fetch the live PR body, so it did not run:",
+			),
+		);
+		errorLog.mockRestore();
+		log.mockRestore();
+	});
+
+	it("fails closed with an ::error record on a non-2xx response", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValue(new Response("service unavailable", { status: 503 }));
+		const event = { pull_request: { number: 2086, body: "Closes #1" } };
+
+		await lintPullRequest(fetchImpl, event);
+
+		expect(process.exitCode).toBe(1);
+		expect(log).not.toHaveBeenCalled();
+		expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("::error::"));
+		expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("503"));
+		errorLog.mockRestore();
+		log.mockRestore();
+	});
+
+	it("fails closed with an ::error record on a malformed response", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+		const event = { pull_request: { number: 2086, body: "Closes #1" } };
+
+		await lintPullRequest(fetchImpl, event);
+
+		expect(process.exitCode).toBe(1);
+		expect(log).not.toHaveBeenCalled();
+		expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("::error::"));
+		errorLog.mockRestore();
 		log.mockRestore();
 	});
 });


### PR DESCRIPTION
## Summary

#2086's remaining gap: the merged #2267/#2284 work fixed the post-merge `--verify-merged` gate to read the live PR body, but the separate `--lint-pr` syntax check still scanned `eventPayload().pull_request.body` — a rerun after a body edit replayed the stale text. `lintPullRequest` now strict-fetches the live body, and the syntax job in ci.yml gains the `GITHUB_TOKEN` it needs (the same wiring shape #2267 added for the verify step, with the YAML assertion pinning it).

## Tests

- New stale-payload/live-body regression test at tests/scripts/check-close-keywords.test.ts:118 — red under a payload-trust mutation, green on the fix; red-first proven (the live-body lint seam did not exist pre-fix).
- YAML wiring assertion for the token, mirroring #2267's precedent.
- 107 targeted tests, lint, fmt all green in the worker's isolated worktree.

## Class sweep

The two consumer paths of close-keyword checking (verify-merged, lint-pr) both now read live; the shape table is in this PR's review record. Payload reads elsewhere in scripts/ were swept in #2267's rounds.

## Blast radius

Script + ci.yml token wiring + tests; AGENTS.md contract line updated.

## Test assessment

Worker-authored with red-first proof; the adversarial review round re-verifies independently and gates the merge.

## Observability

A failed live fetch on the lint path fails closed with an ::error record, matching the verify path's contract.

Closes #2086.
