### PR TITLE
fix(dispatch): bound FactStore content bytes (closes #2247)

### DIFF
--- a/.changelog/2247-fact-store-content-bytes.md
+++ b/.changelog/2247-fact-store-content-bytes.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Bound retained FactStore content bytes (closes #2247)** — file-fact stores now evict least-recently-used records after retaining 64 MiB of UTF-8 `file.content`, as well as after 1,024 records. In-flight dispatch records remain pinned until settlement, and capacity degradation records identify whether count or bytes triggered eviction.

--- a/.changelog/2247-fact-store-content-bytes.md
+++ b/.changelog/2247-fact-store-content-bytes.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Bound retained FactStore content bytes (closes #2247)** — file-fact stores now evict least-recently-used records after retaining 64 MiB of UTF-8 `file.content`, as well as after 1,024 records. In-flight dispatch records remain pinned until settlement, and capacity degradation records identify whether count or bytes triggered eviction.
+- **Bound retained FactStore content bytes (closes #2247)** — file-fact stores now evict least-recently-used records after retaining 64 MiB of UTF-8 `file.content`, as well as after 1,024 records. In-flight dispatch records remain pinned until settlement. A count-axis and a byte-axis eviction on the same store each get their own degradation record instead of sharing one dedupe key, and a pin whose content alone exceeds the byte budget stops evicting unpinned inserts instead of silently discarding every one of them, recording that state through its own degradation kind.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -614,6 +614,14 @@ and only `lsp_server_spawned` answers "how many servers did we start".
 
 ### Dispatch, runners, formatters, and installer
 
+`FactStore` bounds file facts on two axes: 1,024 LRU records and 64 MiB of
+retained UTF-8 `file.content` bytes. It maintains the byte total at each
+mutation; never replace that total with a hot-path map scan. Pinned dispatch
+records count toward the byte budget but remain exempt from eviction until
+`endDispatchFor`, because dispatch reads content after its runners settle.
+Capacity telemetry keeps the per-store subject and names the triggering
+`count` or `bytes` axis in the existing bounded degradation record. (#2247)
+
 Managed verification uses the registry's optional `verificationTimeoutMs` at
 every installer-owned probe seam, including local discovery, npm install, and
 periodic refresh. The refresh candidate projection carries that policy instead

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -466,9 +466,25 @@ export type DegradationKind =
 	 * `file.content` back with `?? ""`, so an evicted content fact turns into
 	 * empty content and inline suppressions stop applying. Recorded once per
 	 * session, stamped with the first evicted path, so the drop is visible in
-	 * the ledger rather than inferred from a downstream symptom.
+	 * the ledger rather than inferred from a downstream symptom. Subject
+	 * carries `<store>:<axis>` (#2247 review F1) so a count-axis and a
+	 * byte-axis eviction on the SAME store each get their own once-per-session
+	 * record instead of one collapsing into the other.
 	 */
-	| "fact-store-capacity-eviction";
+	| "fact-store-capacity-eviction"
+	/**
+	 * The dispatch `FactStore`'s pinned content bytes alone exceed the
+	 * 64 MiB retained-content budget (#2247 review F2). A pin exempts an
+	 * in-flight dispatch's file from eviction, so a leaked pin on a large
+	 * file — or several overlapping ones — can put pinned bytes over budget
+	 * on their own; evicting the remaining unpinned records can never bring
+	 * total bytes back under budget in that state, so `FactStore` stops
+	 * evicting and admits unpinned inserts without eviction until a pin
+	 * releases. Without this kind that admission-without-enforcement state
+	 * is invisible: the store just silently stops honoring its budget.
+	 * Recorded once per session, subject is the store label.
+	 */
+	| "fact-store-pinned-over-budget";
 
 export interface DegradationRecord {
 	kind: unknown;

--- a/clients/dispatch/fact-store.ts
+++ b/clients/dispatch/fact-store.ts
@@ -23,7 +23,7 @@ import { normalizeMapKey } from "../path-utils.js";
 // once-per-session record.
 export type CapacityEvictionReporter = (
 	subject: string,
-	axis: "count" | "bytes",
+	axis: "count" | "bytes" | "pinned-over-budget",
 	reason: string,
 ) => void;
 let capacityEvictionReporter: CapacityEvictionReporter | undefined;
@@ -203,12 +203,27 @@ export class FactStore implements ReadonlyFactStore {
 
 	/** Drop least-recently-used records past either cap, skipping the files whose
 	 *  dispatch pinned them. Pinned content counts toward the byte total, but is
-	 *  never evicted before endDispatchFor. Pins survive until clearAll. */
+	 *  never evicted before endDispatchFor. Pins survive until clearAll.
+	 *
+	 *  #2247 review F2: a leaked (or several overlapping) pin(s) can put pinned
+	 *  bytes over budget ON THEIR OWN. Evicting every unpinned record can never
+	 *  bring the total back under budget in that state — before this guard, the
+	 *  loop below evicted each newly inserted unpinned record on the very next
+	 *  call (it was always the sole remaining unpinned key), so unpinned writes
+	 *  never retained anything: a silent, permanent collapse for the rest of
+	 *  the process. Once byte pressure is unpinned-bytes-driven-only, stop
+	 *  evicting and admit unpinned inserts as-is — best-effort under pin
+	 *  pressure — and record the state distinctly so it is visible instead of
+	 *  inferred from "the store stopped retaining anything". */
 	private evictColdFileFacts(): void {
 		if (!this.overCapacity()) return;
 		for (const key of this.fileFacts.keys()) {
 			if (this.pinnedFiles.has(key)) continue;
 			const axis = this.capacityAxis();
+			if (axis === "bytes" && this.pinnedContentBytes() > MAX_FILE_FACT_CONTENT_BYTES) {
+				this.reportPinnedOverBudget();
+				return;
+			}
 			this.deleteFileFactsRecord(key);
 			this.reportCapacityEviction(key, axis);
 			if (!this.overCapacity()) return;
@@ -228,6 +243,20 @@ export class FactStore implements ReadonlyFactStore {
 
 	private contentBytes(value: unknown): number {
 		return typeof value === "string" ? Buffer.byteLength(value, "utf8") : 0;
+	}
+
+	/** Sum of `file.content` bytes across currently pinned files only. Scans
+	 *  `pinnedFiles`, not the whole map — that set tracks dispatches actually
+	 *  in flight, so it stays small even when `fileFacts` holds up to 1024
+	 *  records (#2247 review F2). Called only while over the byte budget, not
+	 *  on every insert, so it does not reintroduce the whole-map scan the
+	 *  running `retainedContentBytes` total exists to avoid. */
+	private pinnedContentBytes(): number {
+		let total = 0;
+		for (const key of this.pinnedFiles.keys()) {
+			total += this.contentBytes(this.fileFacts.get(key)?.get("file.content"));
+		}
+		return total;
 	}
 
 	private deleteFileFactsRecord(key: string): void {
@@ -257,6 +286,30 @@ export class FactStore implements ReadonlyFactStore {
 				? `file-fact store axis=count exceeded ${MAX_FILE_FACT_RECORDS} records; evicted least-recently-used fact for ${evictedKey}`
 				: `file-fact store axis=bytes exceeded ${MAX_FILE_FACT_CONTENT_BYTES} retained content bytes; evicted least-recently-used fact for ${evictedKey}`,
 		);
+	}
+
+	// #2247 review F2: pinned bytes alone exceeding budget is not an eviction —
+	// nothing is dropped — so it is reported through a distinct axis rather
+	// than reusing `reportCapacityEviction`'s "evicted least-recently-used
+	// fact for X" language, which would misdescribe what happened.
+	private reportPinnedOverBudget(): void {
+		const pinnedBytes = this.pinnedContentBytes();
+		capacityEvictionReporter?.(
+			this.subject,
+			"pinned-over-budget",
+			`file-fact store pinned content bytes (${pinnedBytes}) exceed the ` +
+				`${MAX_FILE_FACT_CONTENT_BYTES}-byte budget; unpinned inserts are ` +
+				`admitted without eviction until a pin releases`,
+		);
+	}
+
+	/** Running UTF-8 byte total for retained `file.content` values. Exposed so
+	 *  tests can crosscheck it against a fresh sum over retained records
+	 *  (#2247 review F3) — the running total is maintained incrementally on
+	 *  every insert/delete path rather than recomputed, so a subtraction
+	 *  dropped from one of those paths would otherwise drift silently. */
+	getRetainedContentBytes(): number {
+		return this.retainedContentBytes;
 	}
 
 	getSessionFact<T>(factId: string): T | undefined {

--- a/clients/dispatch/fact-store.ts
+++ b/clients/dispatch/fact-store.ts
@@ -82,6 +82,14 @@ export class FactStore implements ReadonlyFactStore {
 	// mutation keeps getFileFact/setFileFact O(1) amortized; never scan the map
 	// to decide whether the byte budget is exceeded.
 	private retainedContentBytes = 0;
+	// Subset of retainedContentBytes held by currently pinned files (#2247
+	// review F2). Maintained incrementally the same way — a scan over
+	// `pinnedFiles` looks small in isolation, but `evictColdFileFacts` calls it
+	// on EVERY unpinned insert for as long as pinned bytes stay over budget, so
+	// a scan there would re-walk a large pinned file's full string on every
+	// single write admitted during that window. Keeping a running total avoids
+	// reintroducing exactly the scan `retainedContentBytes` exists to avoid.
+	private pinnedContentBytesTotal = 0;
 
 	/**
 	 * @param subject Discriminates this store's capacity-eviction telemetry
@@ -109,8 +117,10 @@ export class FactStore implements ReadonlyFactStore {
 			this.fileFacts.set(key, facts);
 		}
 		if (factId === "file.content") {
-			this.retainedContentBytes -= this.contentBytes(facts.get(factId));
-			this.retainedContentBytes += this.contentBytes(value);
+			const delta =
+				this.contentBytes(value) - this.contentBytes(facts.get(factId));
+			this.retainedContentBytes += delta;
+			if (this.pinnedFiles.has(key)) this.pinnedContentBytesTotal += delta;
 		}
 		facts.set(factId, value);
 		this.evictColdFileFacts();
@@ -127,7 +137,9 @@ export class FactStore implements ReadonlyFactStore {
 		const facts = this.fileFacts.get(key);
 		if (!facts) return;
 		if (factId === "file.content") {
-			this.retainedContentBytes -= this.contentBytes(facts.get(factId));
+			const dropped = this.contentBytes(facts.get(factId));
+			this.retainedContentBytes -= dropped;
+			if (this.pinnedFiles.has(key)) this.pinnedContentBytesTotal -= dropped;
 		}
 		facts.delete(factId);
 		if (facts.size === 0) this.fileFacts.delete(key);
@@ -191,14 +203,31 @@ export class FactStore implements ReadonlyFactStore {
 	}
 
 	private pinFile(key: string): void {
-		this.pinnedFiles.set(key, (this.pinnedFiles.get(key) ?? 0) + 1);
+		const count = this.pinnedFiles.get(key) ?? 0;
+		// Transition from unpinned to pinned: this file's content joins the
+		// pinned subset. A refcount bump past 1 (an already-pinned file, two
+		// overlapping dispatches) does not — it is already counted.
+		if (count === 0) {
+			this.pinnedContentBytesTotal += this.contentBytes(
+				this.fileFacts.get(key)?.get("file.content"),
+			);
+		}
+		this.pinnedFiles.set(key, count + 1);
 	}
 
 	private unpinFile(key: string): void {
 		const count = this.pinnedFiles.get(key);
 		if (count === undefined) return;
-		if (count <= 1) this.pinnedFiles.delete(key);
-		else this.pinnedFiles.set(key, count - 1);
+		if (count <= 1) {
+			this.pinnedFiles.delete(key);
+			// Transition from pinned to unpinned: this file's content leaves the
+			// pinned subset.
+			this.pinnedContentBytesTotal -= this.contentBytes(
+				this.fileFacts.get(key)?.get("file.content"),
+			);
+		} else {
+			this.pinnedFiles.set(key, count - 1);
+		}
 	}
 
 	/** Drop least-recently-used records past either cap, skipping the files whose
@@ -220,7 +249,10 @@ export class FactStore implements ReadonlyFactStore {
 		for (const key of this.fileFacts.keys()) {
 			if (this.pinnedFiles.has(key)) continue;
 			const axis = this.capacityAxis();
-			if (axis === "bytes" && this.pinnedContentBytes() > MAX_FILE_FACT_CONTENT_BYTES) {
+			if (
+				axis === "bytes" &&
+				this.pinnedContentBytesTotal > MAX_FILE_FACT_CONTENT_BYTES
+			) {
 				this.reportPinnedOverBudget();
 				return;
 			}
@@ -245,24 +277,12 @@ export class FactStore implements ReadonlyFactStore {
 		return typeof value === "string" ? Buffer.byteLength(value, "utf8") : 0;
 	}
 
-	/** Sum of `file.content` bytes across currently pinned files only. Scans
-	 *  `pinnedFiles`, not the whole map — that set tracks dispatches actually
-	 *  in flight, so it stays small even when `fileFacts` holds up to 1024
-	 *  records (#2247 review F2). Called only while over the byte budget, not
-	 *  on every insert, so it does not reintroduce the whole-map scan the
-	 *  running `retainedContentBytes` total exists to avoid. */
-	private pinnedContentBytes(): number {
-		let total = 0;
-		for (const key of this.pinnedFiles.keys()) {
-			total += this.contentBytes(this.fileFacts.get(key)?.get("file.content"));
-		}
-		return total;
-	}
-
 	private deleteFileFactsRecord(key: string): void {
 		const facts = this.fileFacts.get(key);
 		if (!facts) return;
-		this.retainedContentBytes -= this.contentBytes(facts.get("file.content"));
+		const dropped = this.contentBytes(facts.get("file.content"));
+		this.retainedContentBytes -= dropped;
+		if (this.pinnedFiles.has(key)) this.pinnedContentBytesTotal -= dropped;
 		this.fileFacts.delete(key);
 	}
 
@@ -293,7 +313,7 @@ export class FactStore implements ReadonlyFactStore {
 	// than reusing `reportCapacityEviction`'s "evicted least-recently-used
 	// fact for X" language, which would misdescribe what happened.
 	private reportPinnedOverBudget(): void {
-		const pinnedBytes = this.pinnedContentBytes();
+		const pinnedBytes = this.pinnedContentBytesTotal;
 		capacityEvictionReporter?.(
 			this.subject,
 			"pinned-over-budget",
@@ -330,5 +350,6 @@ export class FactStore implements ReadonlyFactStore {
 		this.sessionFacts.clear();
 		this.pinnedFiles.clear();
 		this.retainedContentBytes = 0;
+		this.pinnedContentBytesTotal = 0;
 	}
 }

--- a/clients/dispatch/fact-store.ts
+++ b/clients/dispatch/fact-store.ts
@@ -23,6 +23,7 @@ import { normalizeMapKey } from "../path-utils.js";
 // once-per-session record.
 export type CapacityEvictionReporter = (
 	subject: string,
+	axis: "count" | "bytes",
 	reason: string,
 ) => void;
 let capacityEvictionReporter: CapacityEvictionReporter | undefined;
@@ -46,6 +47,10 @@ export function getFactStoreEvictionReporter():
 // until the heap ran out. Bound the record count the way widget-state.ts bounds
 // its file records.
 const MAX_FILE_FACT_RECORDS = 1024;
+// Keep enough content for 1024 typical source files averaging 64 KiB, while
+// preventing a small number of generated or vendored files from retaining
+// hundreds of MiB for the process lifetime (#2247).
+const MAX_FILE_FACT_CONTENT_BYTES = 64 * 1024 * 1024;
 // Pinned records are exempt from capacity eviction. A dispatch reads its
 // file's facts back after the runner groups settle (`file.content` misses read as
 // empty content, not as "re-derive"), and the fire-and-forget blast-radius
@@ -73,6 +78,10 @@ export class FactStore implements ReadonlyFactStore {
 	// count is > 0. Refcounted, not a Set, so two overlapping dispatches of the
 	// same file both hold the pin until BOTH settle (#2243 item 2).
 	private readonly pinnedFiles = new Map<string, number>();
+	// Running UTF-8 byte total for file.content only. Maintaining it at every
+	// mutation keeps getFileFact/setFileFact O(1) amortized; never scan the map
+	// to decide whether the byte budget is exceeded.
+	private retainedContentBytes = 0;
 
 	/**
 	 * @param subject Discriminates this store's capacity-eviction telemetry
@@ -99,6 +108,10 @@ export class FactStore implements ReadonlyFactStore {
 			facts = new Map();
 			this.fileFacts.set(key, facts);
 		}
+		if (factId === "file.content") {
+			this.retainedContentBytes -= this.contentBytes(facts.get(factId));
+			this.retainedContentBytes += this.contentBytes(value);
+		}
 		facts.set(factId, value);
 		this.evictColdFileFacts();
 	}
@@ -113,6 +126,9 @@ export class FactStore implements ReadonlyFactStore {
 		const key = normalizeMapKey(filePath);
 		const facts = this.fileFacts.get(key);
 		if (!facts) return;
+		if (factId === "file.content") {
+			this.retainedContentBytes -= this.contentBytes(facts.get(factId));
+		}
 		facts.delete(factId);
 		if (facts.size === 0) this.fileFacts.delete(key);
 	}
@@ -126,7 +142,7 @@ export class FactStore implements ReadonlyFactStore {
 	 *  Every `clearFileFactsFor` MUST be paired with an `endDispatchFor`. */
 	clearFileFactsFor(filePath: string): void {
 		const key = normalizeMapKey(filePath);
-		this.fileFacts.delete(key);
+		this.deleteFileFactsRecord(key);
 		this.pinFile(key);
 	}
 
@@ -161,7 +177,7 @@ export class FactStore implements ReadonlyFactStore {
 	 *  pinning there would exempt every scanned file from the capacity cap and
 	 *  defeat it. Normalizes filePath internally. */
 	dropFileFacts(filePath: string): void {
-		this.fileFacts.delete(normalizeMapKey(filePath));
+		this.deleteFileFactsRecord(normalizeMapKey(filePath));
 	}
 
 	/** LRU touch: re-inserting an existing record moves it to the end of the
@@ -185,16 +201,40 @@ export class FactStore implements ReadonlyFactStore {
 		else this.pinnedFiles.set(key, count - 1);
 	}
 
-	/** Drop least-recently-used records past the cap, skipping the files whose
-	 *  dispatch pinned them. Pins survive until endDispatchFor or clearAll. */
+	/** Drop least-recently-used records past either cap, skipping the files whose
+	 *  dispatch pinned them. Pinned content counts toward the byte total, but is
+	 *  never evicted before endDispatchFor. Pins survive until clearAll. */
 	private evictColdFileFacts(): void {
-		if (this.fileFacts.size <= MAX_FILE_FACT_RECORDS) return;
+		if (!this.overCapacity()) return;
 		for (const key of this.fileFacts.keys()) {
 			if (this.pinnedFiles.has(key)) continue;
-			this.fileFacts.delete(key);
-			this.reportCapacityEviction(key);
-			if (this.fileFacts.size <= MAX_FILE_FACT_RECORDS) return;
+			const axis = this.capacityAxis();
+			this.deleteFileFactsRecord(key);
+			this.reportCapacityEviction(key, axis);
+			if (!this.overCapacity()) return;
 		}
+	}
+
+	private overCapacity(): boolean {
+		return (
+			this.fileFacts.size > MAX_FILE_FACT_RECORDS ||
+			this.retainedContentBytes > MAX_FILE_FACT_CONTENT_BYTES
+		);
+	}
+
+	private capacityAxis(): "count" | "bytes" {
+		return this.fileFacts.size > MAX_FILE_FACT_RECORDS ? "count" : "bytes";
+	}
+
+	private contentBytes(value: unknown): number {
+		return typeof value === "string" ? Buffer.byteLength(value, "utf8") : 0;
+	}
+
+	private deleteFileFactsRecord(key: string): void {
+		const facts = this.fileFacts.get(key);
+		if (!facts) return;
+		this.retainedContentBytes -= this.contentBytes(facts.get("file.content"));
+		this.fileFacts.delete(key);
 	}
 
 	// #2243 item 4: the cap silently drops a fact a live dispatch may read back
@@ -206,10 +246,16 @@ export class FactStore implements ReadonlyFactStore {
 	// ONE record per session PER STORE (re-arming at session_start when the
 	// ledger resets) — no latch or generation compare here, so fact-store
 	// keeps no session-scoped state to forget to re-arm.
-	private reportCapacityEviction(evictedKey: string): void {
+	private reportCapacityEviction(
+		evictedKey: string,
+		axis: "count" | "bytes",
+	): void {
 		capacityEvictionReporter?.(
 			this.subject,
-			`file-fact store exceeded ${MAX_FILE_FACT_RECORDS} records; evicted least-recently-used fact for ${evictedKey}`,
+			axis,
+			axis === "count"
+				? `file-fact store axis=count exceeded ${MAX_FILE_FACT_RECORDS} records; evicted least-recently-used fact for ${evictedKey}`
+				: `file-fact store axis=bytes exceeded ${MAX_FILE_FACT_CONTENT_BYTES} retained content bytes; evicted least-recently-used fact for ${evictedKey}`,
 		);
 	}
 
@@ -230,5 +276,6 @@ export class FactStore implements ReadonlyFactStore {
 		this.fileFacts.clear();
 		this.sessionFacts.clear();
 		this.pinnedFiles.clear();
+		this.retainedContentBytes = 0;
 	}
 }

--- a/clients/dispatch/fact-store.ts
+++ b/clients/dispatch/fact-store.ts
@@ -332,6 +332,17 @@ export class FactStore implements ReadonlyFactStore {
 		return this.retainedContentBytes;
 	}
 
+	/** Running UTF-8 byte total for the pinned SUBSET of retained
+	 *  `file.content` values. Exposed so tests can crosscheck it against a
+	 *  fresh sum over `pinnedFiles ∩ fileFacts` (#2247 review F4) — like
+	 *  `retainedContentBytes`, it is maintained incrementally on the pin
+	 *  0→1 transition, the unpin 1→0 transition, content overwrite/delete,
+	 *  and `clearAll`, so a drop from any one of those paths would
+	 *  otherwise drift silently instead of failing loudly. */
+	getPinnedContentBytes(): number {
+		return this.pinnedContentBytesTotal;
+	}
+
 	getSessionFact<T>(factId: string): T | undefined {
 		return this.sessionFacts.get(factId) as T | undefined;
 	}

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -194,7 +194,7 @@ const sessionFacts = new FactStore("dispatch");
 // `setFactStoreEvictionReporter`). The reporter forwards each store's own
 // subject, so the ledger's per-kind+subject dedupe emits exactly ONE record
 // per session PER STORE, re-arming when the ledger resets at session_start.
-setFactStoreEvictionReporter((subject, reason) => {
+setFactStoreEvictionReporter((subject, _axis, reason) => {
 	recordDegradationOnce({
 		kind: "fact-store-capacity-eviction",
 		subject,

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -194,10 +194,30 @@ const sessionFacts = new FactStore("dispatch");
 // `setFactStoreEvictionReporter`). The reporter forwards each store's own
 // subject, so the ledger's per-kind+subject dedupe emits exactly ONE record
 // per session PER STORE, re-arming when the ledger resets at session_start.
-setFactStoreEvictionReporter((subject, _axis, reason) => {
+//
+// #2247 review F1: the axis was previously dropped here, so
+// `recordDegradationOnce`'s `${kind}\0${subject}` dedupe collapsed a store's
+// count-axis and byte-axis evictions onto the SAME key — whichever axis
+// tripped first (always count, since 1024 typical files land far under 64
+// MiB) silently consumed the once-per-session slot and a later byte-axis
+// eviction on that same store recorded nothing. Fold the axis into the
+// subject (`<store>:<axis>`), matching this ledger's own `<store>:<file>`
+// convention (see `demoted-finding-retired`'s doc comment) rather than
+// growing the `kind` union per axis. `pinned-over-budget` (#2247 review F2)
+// is a distinct condition, not an eviction, so it gets its own kind instead
+// of sharing the eviction kind's subject convention.
+setFactStoreEvictionReporter((subject, axis, reason) => {
+	if (axis === "pinned-over-budget") {
+		recordDegradationOnce({
+			kind: "fact-store-pinned-over-budget",
+			subject,
+			reason,
+		});
+		return;
+	}
 	recordDegradationOnce({
 		kind: "fact-store-capacity-eviction",
-		subject,
+		subject: `${subject}:${axis}`,
 		reason,
 	});
 });

--- a/tests/clients/dispatch/fact-store-bound.test.ts
+++ b/tests/clients/dispatch/fact-store-bound.test.ts
@@ -369,7 +369,9 @@ describe("FactStore file-fact bound (#2240)", () => {
 		expect(group).toBeDefined();
 		expect(group?.count).toBe(1);
 		expect(group?.latestReasons.at(-1)?.subject).toBe("dispatch");
-		expect(group?.latestReasons.at(-1)?.reason).toContain("pinned content bytes");
+		expect(group?.latestReasons.at(-1)?.reason).toContain(
+			"pinned content bytes",
+		);
 
 		// A regular byte-axis eviction still applies once pins release and
 		// pressure is unpinned-driven again.

--- a/tests/clients/dispatch/fact-store-bound.test.ts
+++ b/tests/clients/dispatch/fact-store-bound.test.ts
@@ -27,6 +27,11 @@ afterEach(() => setFactStoreEvictionReporter(undefined));
 // eviction. A dispatch pins its file at start and releases it at completion.
 const MAX_RECORDS = 1024;
 const BATCH = 2000;
+const MIB = 1024 * 1024;
+
+function contentOfBytes(bytes: number): string {
+	return "x".repeat(bytes);
+}
 
 function batchPaths(prefix: string, count = BATCH): string[] {
 	return Array.from({ length: count }, (_, i) => `/repo/src/${prefix}-${i}.ts`);
@@ -66,6 +71,55 @@ describe("FactStore file-fact bound (#2240)", () => {
 
 		expect(store.hasFileFact(paths[0], "file.content")).toBe(true);
 		expect(store.hasFileFact(paths[1], "file.content")).toBe(false);
+	});
+
+	it("evicts on retained content bytes before the record cap is reached", () => {
+		const store = new FactStore();
+		const paths = batchPaths("byte-pressure", 3);
+		for (const p of paths) {
+			store.setFileFact(p, "file.content", contentOfBytes(24 * MIB));
+		}
+
+		expect(store.hasFileFact(paths[0], "file.content")).toBe(false);
+		expect(retained(store, paths)).toBe(2);
+	});
+
+	it("weighs retained content as UTF-8 bytes rather than string length", () => {
+		const store = new FactStore();
+		const paths = batchPaths("utf8-byte-pressure", 2);
+		// Two strings total 36 MiB in JavaScript length but 72 MiB in UTF-8.
+		for (const p of paths) {
+			store.setFileFact(p, "file.content", "😀".repeat(9 * MIB));
+		}
+
+		expect(store.hasFileFact(paths[0], "file.content")).toBe(false);
+		expect(store.hasFileFact(paths[1], "file.content")).toBe(true);
+	});
+
+	it("keeps pinned content under byte pressure and evicts it after unpin", () => {
+		const store = new FactStore();
+		const active = "/repo/src/byte-pinned.ts";
+		store.clearFileFactsFor(active);
+		store.setFileFact(active, "file.content", contentOfBytes(40 * MIB));
+		store.setFileFact(
+			"/repo/src/pressure-1.ts",
+			"file.content",
+			contentOfBytes(20 * MIB),
+		);
+		store.setFileFact(
+			"/repo/src/pressure-2.ts",
+			"file.content",
+			contentOfBytes(20 * MIB),
+		);
+
+		expect(store.hasFileFact(active, "file.content")).toBe(true);
+		store.endDispatchFor(active);
+		store.setFileFact(
+			"/repo/src/pressure-3.ts",
+			"file.content",
+			contentOfBytes(20 * MIB),
+		);
+		expect(store.hasFileFact(active, "file.content")).toBe(false);
 	});
 
 	it("never evicts the file whose dispatch is in flight", () => {
@@ -194,6 +248,7 @@ describe("FactStore file-fact bound (#2240)", () => {
 		expect(group?.latestReasons.at(-1)?.reason).toContain(
 			normalizeMapKey(paths[0]),
 		);
+		expect(group?.latestReasons.at(-1)?.reason).toContain("axis=count");
 
 		// Further evictions in the same session do not add a second record.
 		for (const p of batchPaths("evict2"))
@@ -206,6 +261,21 @@ describe("FactStore file-fact bound (#2240)", () => {
 		for (const p of batchPaths("evict3"))
 			store2.setFileFact(p, "file.content", "x");
 		expect(find()?.count).toBe(1);
+	});
+
+	it("records the byte axis when retained content triggers eviction", () => {
+		resetDegradationLedger();
+		setFactStoreEvictionReporter(productionEvictionReporter);
+		const store = new FactStore("dispatch-byte-axis");
+		for (const p of batchPaths("byte-axis", 3)) {
+			store.setFileFact(p, "file.content", contentOfBytes(24 * MIB));
+		}
+
+		const group = getDegradationSummary().find(
+			(g) => g.kind === "fact-store-capacity-eviction",
+		);
+		expect(group?.latestReasons.at(-1)?.subject).toBe("dispatch-byte-axis");
+		expect(group?.latestReasons.at(-1)?.reason).toContain("axis=bytes");
 	});
 
 	// #2243 review round 3 (F1): a DIFFERENT store — a different subject —
@@ -239,7 +309,7 @@ describe("FactStore file-fact bound (#2240)", () => {
 	it("emits capacity eviction through the injected reporter", () => {
 		const reasons: string[] = [];
 		const subjects: string[] = [];
-		setFactStoreEvictionReporter((subject, reason) => {
+		setFactStoreEvictionReporter((subject, _axis, reason) => {
 			subjects.push(subject);
 			reasons.push(reason);
 		});

--- a/tests/clients/dispatch/fact-store-bound.test.ts
+++ b/tests/clients/dispatch/fact-store-bound.test.ts
@@ -227,6 +227,10 @@ describe("FactStore file-fact bound (#2240)", () => {
 	// `sessionFacts` carries — so a mutation to either the reporter's `kind` /
 	// `subject` wiring in integration.ts, or the per-store subject label, reds
 	// this test.
+	//
+	// #2247 review F1: the ledger subject now carries `<store>:<axis>`, so a
+	// count-axis and a byte-axis eviction on the SAME store no longer share
+	// one dedupe key.
 	it("records one capacity-eviction degradation per session, naming the evicted path", () => {
 		expect(productionEvictionReporter).toBeDefined();
 		resetDegradationLedger();
@@ -242,9 +246,9 @@ describe("FactStore file-fact bound (#2240)", () => {
 		const group = find();
 		expect(group).toBeDefined();
 		expect(group?.count).toBe(1);
-		// One record per session per store; the reason names the FIRST evicted
-		// path (oldest inserted).
-		expect(group?.latestReasons.at(-1)?.subject).toBe("dispatch");
+		// One record per session per store per axis; the reason names the FIRST
+		// evicted path (oldest inserted).
+		expect(group?.latestReasons.at(-1)?.subject).toBe("dispatch:count");
 		expect(group?.latestReasons.at(-1)?.reason).toContain(
 			normalizeMapKey(paths[0]),
 		);
@@ -274,8 +278,40 @@ describe("FactStore file-fact bound (#2240)", () => {
 		const group = getDegradationSummary().find(
 			(g) => g.kind === "fact-store-capacity-eviction",
 		);
-		expect(group?.latestReasons.at(-1)?.subject).toBe("dispatch-byte-axis");
+		expect(group?.latestReasons.at(-1)?.subject).toBe(
+			"dispatch-byte-axis:bytes",
+		);
 		expect(group?.latestReasons.at(-1)?.reason).toContain("axis=bytes");
+	});
+
+	// #2247 review F1: the reviewer's missing case — the SAME store trips the
+	// count axis first (its guaranteed order: 1024 typical files land far
+	// under 64 MiB), then a later byte-axis eviction happens on that store
+	// too. Both must produce distinct records; before the fix the count-axis
+	// record consumed the `${kind}\0${subject}` dedupe key and the byte-axis
+	// eviction recorded nothing.
+	it("records both axes for the same store when count then bytes eviction fire in sequence", () => {
+		resetDegradationLedger();
+		setFactStoreEvictionReporter(productionEvictionReporter);
+		const store = new FactStore("dispatch");
+
+		// Count axis fires first: exceed the 1024-record cap with tiny content.
+		for (const p of batchPaths("count-then-bytes", MAX_RECORDS + 1)) {
+			store.setFileFact(p, "file.content", "x");
+		}
+		// Byte axis fires next, on the SAME store: push large content past the
+		// 64 MiB retained-bytes budget.
+		for (const p of batchPaths("count-then-bytes-big", 3)) {
+			store.setFileFact(p, "file.content", contentOfBytes(24 * MIB));
+		}
+
+		const group = getDegradationSummary().find(
+			(g) => g.kind === "fact-store-capacity-eviction",
+		);
+		expect(group?.count).toBe(2);
+		const subjects = group?.latestReasons.map((r) => r.subject) ?? [];
+		expect(subjects).toContain("dispatch:count");
+		expect(subjects).toContain("dispatch:bytes");
 	});
 
 	// #2243 review round 3 (F1): a DIFFERENT store — a different subject —
@@ -299,8 +335,112 @@ describe("FactStore file-fact bound (#2240)", () => {
 		);
 		expect(groups).toHaveLength(1); // one GROUP (kind), two entries within it
 		const subjects = groups[0]?.latestReasons.map((r) => r.subject) ?? [];
-		expect(subjects).toContain("runtime-session-call-graph");
-		expect(subjects).toContain("dispatch");
+		expect(subjects).toContain("runtime-session-call-graph:count");
+		expect(subjects).toContain("dispatch:count");
+	});
+
+	// #2247 review F2: a leaked (or several overlapping) pin(s) whose bytes
+	// alone exceed the 64 MiB budget must not silently wedge the store —
+	// before the fix, every subsequent unpinned insert was evicted on the
+	// same call it was admitted, forever, because it was always the sole
+	// remaining unpinned key.
+	it("does not silently collapse unpinned writes when pinned content alone exceeds the byte budget", () => {
+		resetDegradationLedger();
+		setFactStoreEvictionReporter(productionEvictionReporter);
+		const store = new FactStore("dispatch");
+		const pinnedA = "/repo/src/pinned-a.ts";
+		const pinnedB = "/repo/src/pinned-b.ts";
+		store.clearFileFactsFor(pinnedA);
+		store.setFileFact(pinnedA, "file.content", contentOfBytes(40 * MIB));
+		store.clearFileFactsFor(pinnedB);
+		store.setFileFact(pinnedB, "file.content", contentOfBytes(40 * MIB));
+		// 80 MiB pinned against a 64 MiB budget.
+
+		const normalPaths = batchPaths("normal-under-pin-pressure", 50);
+		for (const p of normalPaths) store.setFileFact(p, "file.content", "small");
+
+		expect(retained(store, normalPaths)).toBe(50);
+		expect(store.hasFileFact(pinnedA, "file.content")).toBe(true);
+		expect(store.hasFileFact(pinnedB, "file.content")).toBe(true);
+
+		const group = getDegradationSummary().find(
+			(g) => g.kind === "fact-store-pinned-over-budget",
+		);
+		expect(group).toBeDefined();
+		expect(group?.count).toBe(1);
+		expect(group?.latestReasons.at(-1)?.subject).toBe("dispatch");
+		expect(group?.latestReasons.at(-1)?.reason).toContain("pinned content bytes");
+
+		// A regular byte-axis eviction still applies once pins release and
+		// pressure is unpinned-driven again.
+		store.endDispatchFor(pinnedA);
+		store.endDispatchFor(pinnedB);
+		store.setFileFact(
+			"/repo/src/after-unpin.ts",
+			"file.content",
+			contentOfBytes(20 * MIB),
+		);
+		expect(store.hasFileFact(pinnedA, "file.content")).toBe(false);
+	});
+
+	// #2247 review F3: three accounting paths (overwrite's subtract-old,
+	// delete's subtraction, clearAll's reset) were mutation-vacuous — nothing
+	// in the suite caught their removal. Recompute a fresh sum over every
+	// path this test ever touched after a mixed operation sequence and
+	// assert it matches the running total exactly, rather than only
+	// asserting individual hasFileFact booleans.
+	it("keeps the running retained-bytes total equal to a fresh sum after a mixed op sequence", () => {
+		const store = new FactStore();
+		const touched = new Set<string>();
+		const freshSum = () => {
+			let total = 0;
+			for (const p of touched) {
+				const content = store.getFileFact<string>(p, "file.content");
+				if (typeof content === "string") {
+					total += Buffer.byteLength(content, "utf8");
+				}
+			}
+			return total;
+		};
+
+		const a = "/repo/src/crosscheck-a.ts";
+		const b = "/repo/src/crosscheck-b.ts";
+		const c = "/repo/src/crosscheck-c.ts";
+		const pinned = "/repo/src/crosscheck-pinned.ts";
+		touched.add(a).add(b).add(c).add(pinned);
+
+		store.setFileFact(a, "file.content", contentOfBytes(1000));
+		expect(store.getRetainedContentBytes()).toBe(freshSum());
+
+		// Overwrite with a DIFFERENT size — exercises subtract-old-on-overwrite.
+		store.setFileFact(a, "file.content", contentOfBytes(300));
+		expect(store.getRetainedContentBytes()).toBe(freshSum());
+
+		// Multibyte content: UTF-8 byte length differs from string length.
+		store.setFileFact(b, "file.content", "😀".repeat(500));
+		expect(store.getRetainedContentBytes()).toBe(freshSum());
+
+		// deleteFileFact subtraction.
+		store.setFileFact(c, "file.content", contentOfBytes(700));
+		store.deleteFileFact(c, "file.content");
+		touched.delete(c);
+		expect(store.getRetainedContentBytes()).toBe(freshSum());
+
+		// clearFileFactsFor / endDispatchFor pin lifecycle, then dropFileFacts.
+		store.clearFileFactsFor(pinned);
+		store.setFileFact(pinned, "file.content", contentOfBytes(2000));
+		expect(store.getRetainedContentBytes()).toBe(freshSum());
+		store.endDispatchFor(pinned);
+		store.dropFileFacts(pinned);
+		touched.delete(pinned);
+		expect(store.getRetainedContentBytes()).toBe(freshSum());
+
+		// clearAll reset.
+		store.setFileFact(a, "file.content", contentOfBytes(50));
+		store.clearAll();
+		touched.clear();
+		expect(store.getRetainedContentBytes()).toBe(0);
+		expect(store.getRetainedContentBytes()).toBe(freshSum());
 	});
 
 	// fact-store must stay an import leaf: it emits eviction telemetry only

--- a/tests/clients/dispatch/fact-store-bound.test.ts
+++ b/tests/clients/dispatch/fact-store-bound.test.ts
@@ -404,6 +404,20 @@ describe("FactStore file-fact bound (#2240)", () => {
 			}
 			return total;
 		};
+		// #2247 review F4: companion sum over pinnedFiles ∩ fileFacts. Tracked
+		// separately from `touched` because a record can be retained without
+		// being pinned.
+		const pinnedTouched = new Set<string>();
+		const freshPinnedSum = () => {
+			let total = 0;
+			for (const p of pinnedTouched) {
+				const content = store.getFileFact<string>(p, "file.content");
+				if (typeof content === "string") {
+					total += Buffer.byteLength(content, "utf8");
+				}
+			}
+			return total;
+		};
 
 		const a = "/repo/src/crosscheck-a.ts";
 		const b = "/repo/src/crosscheck-b.ts";
@@ -430,19 +444,43 @@ describe("FactStore file-fact bound (#2240)", () => {
 
 		// clearFileFactsFor / endDispatchFor pin lifecycle, then dropFileFacts.
 		store.clearFileFactsFor(pinned);
+		pinnedTouched.add(pinned);
 		store.setFileFact(pinned, "file.content", contentOfBytes(2000));
 		expect(store.getRetainedContentBytes()).toBe(freshSum());
+		expect(store.getPinnedContentBytes()).toBe(freshPinnedSum());
 		store.endDispatchFor(pinned);
+		pinnedTouched.delete(pinned);
+		expect(store.getPinnedContentBytes()).toBe(freshPinnedSum());
 		store.dropFileFacts(pinned);
 		touched.delete(pinned);
 		expect(store.getRetainedContentBytes()).toBe(freshSum());
 
-		// clearAll reset.
+		// #2247 review F4 (M10 probe): beginDispatchFor pins a WARM record — one
+		// that already carries content — without clearing it first. The pin's
+		// 0→1 transition is the ONLY place that pre-existing content joins the
+		// pinned subset for this call shape; clearFileFactsFor above always
+		// clears before pinning, so it never exercises that add.
+		const warm = "/repo/src/crosscheck-warm.ts";
+		touched.add(warm);
+		store.setFileFact(warm, "file.content", contentOfBytes(1500));
+		store.beginDispatchFor(warm);
+		pinnedTouched.add(warm);
+		expect(store.getPinnedContentBytes()).toBe(freshPinnedSum());
+
+		// #2247 review F4 (M9 probe): clearAll must reset the pinned total too,
+		// not just the overall total. The pin on `warm` is still held when
+		// clearAll runs — the shape that exposes a stale pinned total
+		// (integration.ts:482 calls clearAll() on session reset; a pin held at
+		// that moment previously left `pinnedContentBytesTotal` nonzero with
+		// `pinnedFiles` emptied, permanently disabling the byte budget).
 		store.setFileFact(a, "file.content", contentOfBytes(50));
 		store.clearAll();
 		touched.clear();
+		pinnedTouched.clear();
 		expect(store.getRetainedContentBytes()).toBe(0);
 		expect(store.getRetainedContentBytes()).toBe(freshSum());
+		expect(store.getPinnedContentBytes()).toBe(0);
+		expect(store.getPinnedContentBytes()).toBe(freshPinnedSum());
 	});
 
 	// fact-store must stay an import leaf: it emits eviction telemetry only


### PR DESCRIPTION
## Summary

FactStore's count axis was bounded (1024-record LRU, #2243) but the byte axis was not — `file.content` retained per record let a few large files hold hundreds of MiB. This adds a 64 MiB retained-content ceiling with a running UTF-8 byte total maintained on every insert and removal path (no full-map scans), evicting LRU-until-under-budget. Pinned records stay exempt during dispatch and become evictable after `endDispatchFor`. The existing per-store eviction telemetry gains `axis=count` / `axis=bytes`.

Budget rationale: 64 MiB accommodates 1024 typical files at ~64 KiB average while stopping a handful of large generated or vendored files from dominating the heap.

## Tests

Red proof on pre-fix code — four assertion failures: byte eviction fires where count alone would not (three 24 MiB records survived), a released pin never became evictable, and neither axis label existed in telemetry. Green after: 8 targeted FactStore/dispatch suites, 77 tests, plus the UTF-8 ceiling case; build, lint, oxfmt, changelog validation clean.

## Class sweep

#2282 (sessionFacts baseline keys) remains open — same family, different store, not touched here. #2255-family review-graph memory has its own independent bound on master.

## Blast radius

`clients/dispatch/fact-store.ts` and its telemetry; the #2243 pin/unpin seam is preserved (dispatcher.ts:1084's post-settle content read cannot lose a pinned record to byte pressure). AGENTS.md invariant updated.

## Test assessment

Worker-authored with red-first proof; the adversarial review round re-verifies independently.

## Observability

The axis label lands in the existing recordDegradationOnce-based per-store record, so a byte-pressure eviction is distinguishable from count pressure in the ledger.

## Fix round (review findings, all probe-proven)

**F1 — the bytes axis could never be recorded in production.** `integration.ts`'s reporter dropped the axis parameter, and `recordDegradationOnce` dedupes on `${kind}\0${subject}`, so a store's count-axis and byte-axis evictions shared one key. Count always tripped first in practice (1024 typical files land far under 64 MiB), consuming the once-per-session slot before any byte-axis eviction could record. Fixed by forwarding the axis and folding it into the ledger subject (`<store>:<axis>`), matching this ledger's existing `<store>:<file>` convention (see `demoted-finding-retired`'s doc comment) rather than growing the `kind` union per axis. Added the missing case: a SAME store trips count first, then bytes, and both now produce distinct records.

**F2 — pinned bytes over budget silently collapsed the store.** With pinned content alone exceeding the 64 MiB budget (a leaked pin, or overlapping pins, on large files), every unpinned insert was the sole remaining evictable entry on every call, so unpinned writes never retained anything — a silent, permanent collapse. Fixed by stopping eviction once pinned bytes alone exceed budget: unpinned inserts are admitted as-is (best-effort under pin pressure), and the state is recorded through a new `fact-store-pinned-over-budget` degradation kind, distinct from an eviction (nothing was actually evicted). Regression test covers the 80 MiB-pinned + 50-normal-write shape, and confirms a normal byte-axis eviction resumes once the pins release. A follow-up perf pass tracks pinned bytes incrementally (like `retainedContentBytes` already does) rather than rescanning pinned content on every write during the over-budget window — the naive scan turned 50 tiny writes against two 40 MiB pinned records into several seconds of `Buffer.byteLength` work.

**F3 — three accounting paths were mutation-vacuous.** `deleteFileFact`'s subtraction, `setFileFact`'s subtract-old-on-overwrite, and `clearAll`'s reset all survived removal across the existing 31 tests. Added a recomputed-sum crosscheck: after a mixed op sequence (overwrite with differing sizes, delete, clear/pin/unpin, dropFileFacts, clearAll, multibyte content), the running `retainedContentBytes` total must equal a fresh sum over retained records. Exposed via a new `getRetainedContentBytes()` getter. Proved red under two source mutations (subtract-old removed; clearAll's reset removed) and reverted both.

**F4 — the NEW pinned-bytes tracking from F2 had two mutation-vacuous maintenance paths.** `clearAll`'s `pinnedContentBytesTotal` reset and `pinFile`'s 0→1 add both survived removal across the full suite (including the F2/F3 additions above). `clearAll`'s gap was live risk, not hypothetical: `integration.ts:482` calls `clearAll()` on session reset, and a pin held at that moment would leave `pinnedContentBytesTotal` stale while `pinnedFiles` emptied — permanently disabling the byte budget for the rest of the process. Extended the F3 crosscheck test with a companion sum over `pinnedFiles ∩ fileFacts`, exercised by a `beginDispatchFor` pin on an already-content-bearing record (the only call shape that depends on `pinFile`'s 0→1 add) followed by a `clearAll` while that pin is still held. Exposed via a new `getPinnedContentBytes()` getter. Proved red under both source mutations (`clearAll`'s reset removed: stale `1500` instead of `0`; `pinFile`'s add removed: `0` instead of `1500`) and reverted both.

Red proof (pre-fix `c9a322ec`): 6 of 6 new/updated assertions fail for the stated reasons — subject strings missing `:count`/`:bytes`, the same-store two-axis test sees `count: 1` instead of `2`, the pin-pressure test retains 0 of 50 writes instead of 50, and the crosscheck test throws `getRetainedContentBytes is not a function`. Green after the fix: 227 tests across the targeted FactStore/dispatch suites plus every registered-or-fail governance sweep (`bounded-telemetry-sweep`, `session-state-conformance`, `bus-producer-coverage`, `deps-centralization`, `finding-delivery-gate`, `freshness-sweep`, `managed-tool-seam-coverage`, `profiling-coverage`, `module-instance-coverage`, `delivery-surface-ratchet`, `sweep-floor-coverage`). Build, lint (`tsc --project tsconfig.json`), oxfmt, and changelog validation all clean.

Closes #2247.
