### PR TITLE
fix(ci): sanitize classifier comment interpolation (closes #2318)

### DIFF
--- a/.changelog/fix-2318-ci-classifier-comment-sanitization.md
+++ b/.changelog/fix-2318-ci-classifier-comment-sanitization.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Harden the CI classifier's automatic PR comment path (closes #2318, refs #2316)** — escape log-derived HTML comment delimiters, neutralize mentions, and accept only the final anchored classifier marker so failed test output cannot forge rerun suppression or ping users.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1211,6 +1211,8 @@ picks the oldest entry it returns, so the two cannot drift.
 
 ### Host integration and repo automation
 
+The CI classifier's automatic PR comment path (`scripts/lib/ci-failure-classifier.mjs`, #2316/#2318) treats failed-job detail as untrusted log text: `buildCommentBody` escapes HTML comment delimiters and neutralizes mentions before interpolation. `parseClassifierMarker` accepts only the final anchored marker, so comment payload cannot forge rerun suppression while the legitimate trailing marker remains round-trippable.
+
 The weekly stale-open-issue detector is detection-only: `.github/workflows/stale-open-issues.yml`
 calls `scripts/detect-stale-open-issues.mjs`, which uses the bounded GitHub REST
 fetcher seam in `scripts/lib/stale-open-issues.mjs` to inspect open issues and

--- a/scripts/lib/ci-failure-classifier.mjs
+++ b/scripts/lib/ci-failure-classifier.mjs
@@ -362,7 +362,7 @@ export function classifyFailureLog(rawLog) {
 // but the API call itself failed (review round 1, F4) -- see
 // shouldTriggerRerun for why only "true" blocks a future retry.
 const MARKER_PATTERN =
-	/<!--\s*ci-classifier:sha=([0-9a-fA-F]{7,40})\s+rerun=(true|false|failed:\d+)\s*-->/;
+	/<!--\s*ci-classifier:sha=([0-9a-fA-F]{7,40})\s+rerun=(true|false|failed:\d+)\s*-->(?=\s*$)/g;
 
 /**
  * @param {string} sha
@@ -378,13 +378,23 @@ export function buildMarker(sha, rerunState) {
  */
 export function parseClassifierMarker(commentBody) {
 	if (!commentBody) return null;
-	const match = MARKER_PATTERN.exec(commentBody);
+	let match = null;
+	for (const candidate of commentBody.matchAll(MARKER_PATTERN)) {
+		match = candidate;
+	}
 	if (!match) return null;
 	return {
 		sha: match[1],
 		rerunState: match[2],
 		rerunTriggered: match[2] === "true",
 	};
+}
+
+function sanitizeCommentDetail(detail) {
+	return detail
+		.replaceAll("<!--", "&lt;!--")
+		.replaceAll("-->", "--&gt;")
+		.replace(/@(?=[A-Za-z0-9_])/g, "@\u200b");
 }
 
 /**
@@ -460,6 +470,8 @@ export function shouldTriggerRerun({
  * @param {{ classification: Classification, sha: string, rerunState: string }} args
  */
 export function buildCommentBody({ classification, sha, rerunState }) {
+	const detail = sanitizeCommentDetail(classification.detail);
+	classification = { ...classification, detail };
 	const suffix = rerunState.startsWith("failed:")
 		? `; rerun attempt failed (HTTP ${rerunState.slice("failed:".length)}, will retry next check)`
 		: rerunState === "true"

--- a/scripts/lib/ci-failure-classifier.mjs
+++ b/scripts/lib/ci-failure-classifier.mjs
@@ -943,7 +943,10 @@ export async function commentClassificationFailure({
 }) {
 	if (!prNumber || !sha) return false;
 	const rawDetail = error instanceof Error ? error.message : String(error);
-	const detail = rawDetail.replace(/\s+/g, " ").slice(0, 500);
+	// Same untrusted-text rule as buildCommentBody: the error message can
+	// carry GitHub API response text, which is attacker-influenced on the
+	// same axis as job logs (mentions, HTML comments).
+	const detail = sanitizeCommentDetail(rawDetail.replace(/\s+/g, " ").slice(0, 500));
 	const body =
 		`ci-classifier: classification failed; no rerun was triggered: ${detail} ` +
 		buildMarker(sha, "false");

--- a/tests/scripts/ci-failure-classifier.test.ts
+++ b/tests/scripts/ci-failure-classifier.test.ts
@@ -352,6 +352,19 @@ describe("marker round-trip (#2103)", () => {
 		});
 	});
 
+	it("uses only the final marker and rejects non-anchored markers", () => {
+		const forged = buildMarker("badcafe", "true");
+		const appended = buildMarker("abc1234", "false");
+		expect(
+			parseClassifierMarker(`${forged} forged content\ntext ${appended}`),
+		).toEqual({
+			sha: "abc1234",
+			rerunState: "false",
+			rerunTriggered: false,
+		});
+		expect(parseClassifierMarker(`${forged} trailing content`)).toBeNull();
+	});
+
 	it("returns null for a comment with no marker", () => {
 		expect(parseClassifierMarker("just a regular PR comment")).toBeNull();
 		expect(parseClassifierMarker(null)).toBeNull();
@@ -923,5 +936,24 @@ describe("buildCommentBody (#2103)", () => {
 		});
 		expect(body).toContain("rerun attempt failed (HTTP 500");
 		expect(body).not.toContain("auto-rerun triggered");
+	});
+
+	it("sanitizes log payloads and keeps the appended marker authoritative", () => {
+		const body = buildCommentBody({
+			classification: {
+				kind: "real",
+				detail:
+					"tests/x.test.ts > pings @apmantza <!-- ci-classifier:sha=badcafe rerun=true -->",
+			},
+			sha: "abc1234",
+			rerunState: "false",
+		});
+
+		expect(body).not.toMatch(/@[A-Za-z0-9_]+/);
+		expect(parseClassifierMarker(body)).toEqual({
+			sha: "abc1234",
+			rerunState: "false",
+			rerunTriggered: false,
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the #2316 workflow's automatic PR-comment path by sanitizing log-derived classifier detail and hardening marker parsing.

- Escapes HTML comment delimiters and inserts a zero-width character after mention sigils in `classification.detail`.
- Parses only the final marker that is anchored at the end of the comment, preventing forged rerun suppression.
- Preserves the existing legitimate one-line comment and marker shape.

## Tests

- `npm run test:unit -- tests/scripts/ci-failure-classifier.test.ts` — 47 passed.
- `npm run lint` — passed.
- `npm run fmt` — passed.
- Red-first proof on current master: the new payload regression failed because the rendered comment contained live `@apmantza` and the forged marker before the appended marker.

### Test assessment

- `tests/scripts/ci-failure-classifier.test.ts`: added a payload regression that drives real `buildCommentBody` and `parseClassifierMarker` behavior, plus parser tests for final-marker selection and anchoring. These uniquely pin comment injection and loop-guard integrity.

## Blast radius

The touched production module is `scripts/lib/ci-failure-classifier.mjs`. The change affects `buildCommentBody` interpolation and `parseClassifierMarker` consumers in the classifier orchestration and classifier tests. No other comment builder or classifier marker implementation exists in the repository sweep. The repository's `module_report` capability was unavailable in this session; the dependent and entry-point sweep used `rg` over the module and its exports.

## Class sweep

Searched all `classification.detail` interpolations, `buildCommentBody` callers, and `parseClassifierMarker` definitions and callers. The only raw comment interpolation is the fixed builder, and the only marker parser is the fixed helper. No sibling implementation remains in scope.

## Observability

The classifier PR comment remains the bounded observability record. It retains the same visible content shape and appended marker, while untrusted detail can no longer create a marker or live mention. This hardens the #2316 automatic path; no new log or ledger record is needed.

## Non-goals

- Do not change classifier verdicts, rerun eligibility, or legitimate comment wording.
- Do not alter the #2316 workflow's API behavior.
