### PR TITLE
test(rules): close #2298's R1/R2 work-count residuals (refs #2292)

### DIFF
--- a/.changelog/test-2298-rules-cache-residuals.md
+++ b/.changelog/test-2298-rules-cache-residuals.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Close #2298's rules-cache work-count residuals (refs #2292)** — count the warmed cache's existence and content-open probes, and verify metadata sweeps across nested rule files.

--- a/tests/clients/dispatch/runners/yaml-rule-parser.test.ts
+++ b/tests/clients/dispatch/runners/yaml-rule-parser.test.ts
@@ -14,6 +14,8 @@ vi.mock("node:fs", async (importOriginal) => {
 		readFileSync: vi.fn(actual.readFileSync),
 		readdirSync: vi.fn(actual.readdirSync),
 		statSync: vi.fn(actual.statSync),
+		existsSync: vi.fn(actual.existsSync),
+		openSync: vi.fn(actual.openSync),
 	};
 });
 
@@ -111,6 +113,11 @@ describe("yaml-rule-parser cache freshness (#2262)", () => {
 		);
 		ruleCacheTempDirs.push(root);
 		writeRule(path.join(root, "a.yml"), "a", "a");
+		writeRule(path.join(root, "nested", "b.yml"), "b", "b");
+		writeRule(path.join(root, "nested", "c.yml"), "c", "c");
+		writeRule(path.join(root, "nested", "deeper", "d.yml"), "d", "d");
+		writeRule(path.join(root, "nested", "deeper", "e.yml"), "e", "e");
+		const ruleFileCount = 5;
 		vi.useFakeTimers();
 		const start = Date.now();
 		loadYamlRules(root); // primes the cache: one sweep
@@ -118,22 +125,31 @@ describe("yaml-rule-parser cache freshness (#2262)", () => {
 		const readFileSpy = vi.mocked(fs.readFileSync);
 		const readdirSpy = vi.mocked(fs.readdirSync);
 		const statSpy = vi.mocked(fs.statSync);
-		for (const spy of [readFileSpy, readdirSpy, statSpy]) spy.mockClear();
+		const existsSpy = vi.mocked(fs.existsSync);
+		const openSpy = vi.mocked(fs.openSync);
+		for (const spy of [readFileSpy, readdirSpy, statSpy, existsSpy, openSpy])
+			spy.mockClear();
 		for (let i = 0; i < 25; i++) loadYamlRules(root);
 		expect(readFileSpy).not.toHaveBeenCalled();
-		expect(readdirSpy).not.toHaveBeenCalled();
 		expect(statSpy).not.toHaveBeenCalled();
+		expect(readdirSpy).not.toHaveBeenCalled();
+		expect(existsSpy).toHaveBeenCalledTimes(25);
+		expect(openSpy).not.toHaveBeenCalled();
 
 		vi.setSystemTime(start + RULES_CACHE_FRESHNESS_CADENCE_MS + 1);
 		loadYamlRules(root);
 		expect(readFileSpy).not.toHaveBeenCalled();
-		expect(readdirSpy).toHaveBeenCalledTimes(1);
-		expect(statSpy).toHaveBeenCalledTimes(1);
+		expect(readdirSpy).toHaveBeenCalledTimes(3);
+		expect(statSpy).toHaveBeenCalledTimes(ruleFileCount);
+		expect(existsSpy).toHaveBeenCalledTimes(26);
+		expect(openSpy).not.toHaveBeenCalled();
 
 		for (let i = 0; i < 25; i++) loadYamlRules(root);
 		expect(readFileSpy).not.toHaveBeenCalled();
-		expect(readdirSpy).toHaveBeenCalledTimes(1);
-		expect(statSpy).toHaveBeenCalledTimes(1);
+		expect(readdirSpy).toHaveBeenCalledTimes(3);
+		expect(statSpy).toHaveBeenCalledTimes(ruleFileCount);
+		expect(existsSpy).toHaveBeenCalledTimes(51);
+		expect(openSpy).not.toHaveBeenCalled();
 	});
 
 	it("orders discovered rule files by code unit, not by locale collation", () => {


### PR DESCRIPTION
### Summary

Closes the two recorded residuals on merged PR #2298 under parent #2292. The bounded-cost test now counts upstream existsSync and openSync calls and uses five nested rule files.

### Tests

- npm ci completed and npm run build passed.
- npx vitest run tests/clients/dispatch/runners/yaml-rule-parser.test.ts passed: 10 tests.
- npm run lint passed.
- npx oxfmt --check tests/clients/dispatch/runners/yaml-rule-parser.test.ts passed.
- R1 mutation proof: temporary second existsSync call failed the assertion: expected vi.fn() to be called 25 times, but got 50 times.
- R2 mutation proof: temporary per-call sweep failed the N-file stat assertion: expected vi.fn() to not be called at all, but actually been called 125 times; 5 files × 25 warmed calls.
- Restored green output: Test Files 1 passed; Tests 10 passed (10).

### Test assessment

- tests/clients/dispatch/runners/yaml-rule-parser.test.ts: extends the existing filesystem mock and bounded-cost case. It uniquely pins one existsSync per invocation, zero openSync calls, zero warm-window stat calls, and exactly five stats per cadence sweep.
- The nested five-file fixture makes the R2 assertion distinguish one sweep from repeated sweeps.

### Blast radius

The change is test-only plus one changelog fragment. It exercises loadYamlRules through the existing getCachedRules entry point. No production module changed, so production callbacks and entry points are unchanged. The repository's module-report tool was unavailable in this session.

### Class sweep

The existing node:fs mock in this test file was the only mock seam needed for this rules-cache work-count contract. The test covers the upstream probe, recursive discovery, metadata sweep, and warm cadence path.

### Observability

No production failure path changes. The test preserves direct call-count evidence for the filesystem work that caused the residuals.

### Non-goals

This PR does not change cache behavior, cadence duration, rule parsing, or production filesystem calls.