### PR TITLE
test(dispatch): pin availability-lane cooldown consult (closes #2309)

### DIFF
--- a/.changelog/fix-2309-availability-cooldown-pin.md
+++ b/.changelog/fix-2309-availability-cooldown-pin.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Pin the availability-probe cooldown consult (closes #2309)** — Preserve the transient timeout decision and skip redundant probes while a command is cooling down.

--- a/.red-proof-2309.txt
+++ b/.red-proof-2309.txt
@@ -1,4 +1,0 @@
-Mutation: clients/dispatch/runners/utils/runner-helpers.ts
-  if (false && isInSpawnTimeoutCooldown(cmd))
-
-Result: the pinning test failed at the early-return assertion because safeSpawnAsync was called once.

--- a/.red-proof-2309.txt
+++ b/.red-proof-2309.txt
@@ -1,0 +1,4 @@
+Mutation: clients/dispatch/runners/utils/runner-helpers.ts
+  if (false && isInSpawnTimeoutCooldown(cmd))
+
+Result: the pinning test failed at the early-return assertion because safeSpawnAsync was called once.

--- a/tests/clients/dispatch/runners/runner-helpers.test.ts
+++ b/tests/clients/dispatch/runners/runner-helpers.test.ts
@@ -117,6 +117,36 @@ describe("runner-helpers availability checker", () => {
 		}
 	});
 
+	it("pins the availability-lane cooldown consult and its transient decision (#2309)", async () => {
+		const safeSpawnMod = await import("../../../../clients/safe-spawn.js");
+		const cooldownMod =
+			await import("../../../../clients/spawn-timeout-cooldown.js");
+		const command = "cooldown-probe-tool";
+
+		cooldownMod.resetSpawnTimeoutCooldowns();
+		cooldownMod.noteSpawnTimeout({
+			tool: command,
+			command,
+			phase: "availability",
+		});
+
+		const checker = createAvailabilityChecker(command);
+		expect(await checker.isAvailableAsync(process.cwd())).toBe(false);
+		expect(safeSpawnMod.safeSpawnAsync).not.toHaveBeenCalled();
+		expect(availabilityDecisions()).toHaveLength(1);
+		expect(availabilityDecisions()[0]?.metadata).toMatchObject({
+			tool: command,
+			verdict: "unavailable",
+			outcome: "transient",
+			cause: "probe-timeout",
+			classifiedBy: "caller",
+			evidence: {
+				command,
+				status: null,
+			},
+		});
+	});
+
 	it("falls back to global command when no local node_modules binary exists", () => {
 		const env = setupTestEnvironment("pi-lens-node-bin-global-");
 		try {

--- a/tests/clients/dispatch/runners/runner-helpers.test.ts
+++ b/tests/clients/dispatch/runners/runner-helpers.test.ts
@@ -123,6 +123,10 @@ describe("runner-helpers availability checker", () => {
 			await import("../../../../clients/spawn-timeout-cooldown.js");
 		const command = "cooldown-probe-tool";
 
+		// The shared beforeEach does not reset logLatencySpy, so the
+		// toHaveLength(1) below is only valid against a locally cleared
+		// history — the same idiom the two later mockReset sites use.
+		logLatencySpy.mockReset();
 		cooldownMod.resetSpawnTimeoutCooldowns();
 		cooldownMod.noteSpawnTimeout({
 			tool: command,


### PR DESCRIPTION
## Summary

Closes #2309. This adds a mutation-proof pin for the availability-probe lane's `isInSpawnTimeoutCooldown()` consult. While the resolved command is cooling down, the checker returns unavailable without spawning and emits the observable transient `probe-timeout` decision classified by the caller. The consult remains because deleting it would remove that decision record.

## Type of change

- [x] Bug fix

## Area

- [x] area:dispatch
- [x] area:tests

## Tests

- `tests/clients/dispatch/runners/runner-helpers.test.ts` — added `pins the availability-lane cooldown consult and its transient decision (#2309)`, which pins both the early return/no-spawn behavior and the `availability_decision` record (`transient`, `probe-timeout`, `caller`, command/status evidence).
- Red-first proof: with the guard changed to `if (false && isInSpawnTimeoutCooldown(cmd))`, the test failed at the early-return assertion because `safeSpawnAsync` was called once. The captured output is in `.red-proof-2309.txt`.
- Targeted green: 8 files, 138 tests passed.
- The test covers the invisible-skip and observability screens: it asserts the returned result, the absence of the side effect, and the emitted record.

## Test assessment

The existing runner-helper tests uniquely cover the availability checker and now also pin the cooldown consult. No existing test became redundant; no tests were removed.

## Blast radius

The touched production module is `clients/dispatch/runners/utils/runner-helpers.ts`; its `createAvailabilityChecker()` callback is used by dispatch runner availability checks, including the availability-probe lane. The change is test-only because the intended production behavior already exists. `module_report` was unavailable in this checkout, so the blast-radius map is recorded from the direct import/call seam and the targeted runner suite. No hot-path cost delta: the added test does not change runtime code.

## Observability

The pinned production record is the `availability_decision` latency event emitted by `noteDecision()` in `runner-helpers.ts`, with `outcome: "transient"`, `cause: "probe-timeout"`, `classifiedBy: "caller"`, and evidence containing the resolved command and null status.

## Class sweep

Defect shape: an unpinned `isInSpawnTimeoutCooldown()` consult that can be neutered without a test proving its branch contract. Whole-tree grep across `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts` found these five members (including the exported predicate declaration):

- `clients/file-utils.ts:961` — autofix lane consult; existing cooldown seam tests pin its zero-result/no-spawn behavior. Keep.
- `tests/support/session-state-registry.ts:679` — test-support registry predicate used to report whether the cooldown latch is armed; not a production dispatch consult. Keep.
- `clients/dispatch/runners/markdownlint.ts:139` — lint lane consult; existing markdownlint timeout tests pin its skip behavior. Keep.
- `clients/dispatch/runners/utils/runner-helpers.ts:1059` — availability-probe lane consult; this PR adds the missing pin for both skip behavior and its transient decision record. Keep.
- `clients/spawn-timeout-cooldown.ts:148` — exported predicate declaration, not a caller/member. Keep.

The production population is three distributed cross-lane callers (`file-utils`, `markdownlint`, and `runner-helpers`) plus one test-support observer; all are accounted for. They stay distributed because each caller owns a different failure-budget lane, while the shared cooldown module remains the single state seam.

## Checklist

- [x] Issue acceptance criteria complete, including red-first proof and whole-tree per-member sweep.
- [x] `npm ci`, `npm run build`, targeted tests, `npm run lint`, and `oxfmt` completed.
- [x] Changelog fragment added with front matter.


## Review round

The verify round proved the pin whole (my exact #2308 neuter reds; each half — early return, noteDecision emission — reds independently; all three discriminating record fields are individually pinned) and independently confirmed the five-member sweep table with zero line drift. Two deltas landed after review: a local `logLatencySpy.mockReset()` (the new test's `toHaveLength(1)` read the whole accumulated spy history and redded under `--sequence.shuffle`; five seeds now pass 54/54 with the neuter still red), and the committed `.red-proof-2309.txt` scratch paraphrase is removed — the red proof, quoted: neutering the consult reds `expected "vi.fn()" to not be called at all, but actually been called 1 times` (spawn half) and `expected [] to have a length of 1 but got +0` (record half).
