### PR TITLE
fix(rules): guard HTML catalog coverage (closes #2325)

### DIFF
--- a/.changelog/fix-2325-html-rule-coverage.md
+++ b/.changelog/fix-2325-html-rule-coverage.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **HTML ast-grep catalog coverage (closes #2325)** — Verify that every NAPI-routed language ships enabled rules and that HTML edits report plaintext HTTP links.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2556,8 +2556,12 @@ NAPI routing and enabled-rule coverage are bidirectional: every enabled catalog
 language has a delivery route, and every NAPI-routed language has at least one
 enabled rule. `ast-grep-napi-language-coverage.test.ts` enforces both directions
 against the shared `getAstGrepRuleSources` census. Normalize catalog `language:`
-values to lowercase before comparing them with the lowercase NAPI bindings;
-the shipped HTML rule declares `language: html`, not `Html`. (#2325)
+values to lowercase before ANY comparison — the corpus mixes case across
+nearly every language (111 `TypeScript` vs 31 `typescript`, 47 `Python` vs
+52 `python`, ...), so a raw-case comparison is wrong somewhere on every
+language, not just HTML. Runtime lowercases (sgconfig.ts, ast-grep-napi.ts);
+tooling that compares raw is the recurring gap — #2331 tracks the two known
+sites. (#2325)
 
 A target repository that supplies its own `sgconfig.yml` / `sgconfig.yaml` at the workspace root takes precedence — pi-lens respects the project config instead of injecting its baseline.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2552,6 +2552,13 @@ The shipped ast-grep baseline that runs on every file dispatch is composed from 
 
 **Rule-ID precedence is shared by raw LSP and NAPI (#497):** `clients/sgconfig.ts` is the discovery seam for both paths, ordered project primary → project secondary/CodeRabbit → bundled native → bundled CodeRabbit. Discovery is recursive and deterministic. The synthesized raw config contains one per-process, per-workspace merged rule directory; lower-layer same-ID definitions are filtered so a project rule overrides its bundled twin without making `sg` reject the config. Same-layer duplicates are deliberately retained for raw ast-grep validation, and NAPI emits an equivalent blocking configuration diagnostic instead of silently choosing. Project-rule caches fingerprint relative paths plus contents, so equal-size/preserved-mtime edits, renames, additions, and removals invalidate correctly. Avoid reintroducing independent rule-dir lists in either path. Even though cross-tier collisions now have defined precedence, a native/CodeRabbit duplicate remains a maintenance hazard; the catalog port still checks CodeRabbit first and skips anything already vendored.
 
+NAPI routing and enabled-rule coverage are bidirectional: every enabled catalog
+language has a delivery route, and every NAPI-routed language has at least one
+enabled rule. `ast-grep-napi-language-coverage.test.ts` enforces both directions
+against the shared `getAstGrepRuleSources` census. Normalize catalog `language:`
+values to lowercase before comparing them with the lowercase NAPI bindings;
+the shipped HTML rule declares `language: html`, not `Html`. (#2325)
+
 A target repository that supplies its own `sgconfig.yml` / `sgconfig.yaml` at the workspace root takes precedence — pi-lens respects the project config instead of injecting its baseline.
 
 ## Tree-sitter rules

--- a/tests/clients/dispatch/runners/ast-grep-napi-language-coverage.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi-language-coverage.test.ts
@@ -312,7 +312,7 @@ describe("html edits run the enabled html catalog (#2325)", () => {
 	});
 	afterAll(() => env.cleanup());
 
-	it("reports a plaintext HTTP link through the dispatch runner", async () => {
+	it("reports a plaintext HTTP link through the napi runner", async () => {
 		const { ctx } = env.addFile(
 			"index.html",
 			'<a href="http://example.com">Example</a>\n',

--- a/tests/clients/dispatch/runners/ast-grep-napi-language-coverage.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi-language-coverage.test.ts
@@ -125,6 +125,14 @@ function servedRuleLanguages(): Set<string> {
 	return served;
 }
 
+function routedLanguagesWithoutRules(
+	ruleCatalog: ReadonlyMap<string, readonly string[]>,
+): string[] {
+	return [...servedRuleLanguages()]
+		.filter((language) => !ruleCatalog.has(language))
+		.sort();
+}
+
 beforeAll(async () => {
 	// Fail loudly rather than let every assertion below pass on an addon that
 	// never loaded — the whole point of this file is that a missing grammar is
@@ -232,6 +240,16 @@ describe("catalog language delivery coverage (#2215)", () => {
 		expect(stale).toEqual([]);
 	});
 
+	it("ships enabled rules for every napi-routed language (#2325)", () => {
+		expect(routedLanguagesWithoutRules(catalog)).toEqual([]);
+
+		// Mutation probe: removing HTML from the enabled catalog must expose the
+		// routed lane instead of letting an empty language report as covered.
+		const withoutHtml = new Map(catalog);
+		withoutHtml.delete("html");
+		expect(routedLanguagesWithoutRules(withoutHtml)).toEqual(["html"]);
+	});
+
 	it("never claims a napi-served language delivers by LSP/CLI only", () => {
 		const served = servedRuleLanguages();
 		const contradictory = (napi.AST_GREP_LSP_ONLY_RULE_LANGUAGES ?? [])
@@ -284,6 +302,23 @@ describe("module-flavored jsts extensions run the catalog (#2215)", () => {
 		expect(napi.canHandle("App.vue")).toBe(false);
 		expect(napi.canHandle("App.svelte")).toBe(false);
 		expect(napi.ruleLanguageForFile("App.vue")).toBeUndefined();
+	});
+});
+
+describe("html edits run the enabled html catalog (#2325)", () => {
+	let env: RealRunnerEnv;
+	beforeAll(() => {
+		env = makeRealRunnerEnv({ hasTool: napiFallbackHasTool });
+	});
+	afterAll(() => env.cleanup());
+
+	it("reports a plaintext HTTP link through the dispatch runner", async () => {
+		const { ctx } = env.addFile(
+			"index.html",
+			'<a href="http://example.com">Example</a>\n',
+		);
+		const result = await napi.default.run(ctx);
+		expect(firedRuleIds(result)).toContain("plaintext-http-link-html");
 	});
 });
 


### PR DESCRIPTION
## Summary

- Close the HTML census discrepancy without changing runtime routing. The shipped rule is `rules/ast-grep-rules/coderabbit/rules/html/security/plaintext-http-link-html.yml:1-2`, where it declares lowercase `language: html`. The shared source census includes bundled CodeRabbit rules through `clients/sgconfig.ts:59-98`.
- Confirm that the zero count came from a case-sensitive `Html` census query. Production lowercases rule languages at `clients/dispatch/runners/ast-grep-napi.ts:775`, matches the lowercase HTML binding at `clients/dispatch/runners/ast-grep-napi.ts:291`, and already serves the rule.
- Add the reverse invariant: every NAPI-routed language must have enabled catalog rules. Keep the scheduling defect out of scope; refs #2323.

## Tests

- `reports a plaintext HTTP link through the napi runner` drives the real NAPI runner with an `.html` file and pins the shipped rule finding.
- `ships enabled rules for every napi-routed language` compares the shared enabled-rule census with the effective NAPI grammar set.
- `npx vitest run tests/clients/dispatch/runners/ast-grep-napi-language-coverage.test.ts` — 18 passed.
- `npm run lint` — passed.
- `npm run fmt:check` — passed.
- `npm run changelog:check` — 147 entries validated.

## Blast radius

Production blast radius is empty: this PR changes tests, durable agent guidance, and one changelog fragment. The `module_report` capability was unavailable in this session. The test exercises `ast-grep-napi` dispatch, `getAstGrepRuleSources`, the YAML loader, and the real NAPI grammar. No production callbacks or entry points change.

## Class sweep

This is the routed-language-with-zero-enabled-rules direction missing from the #2215 matrix. The reverse sweep enumerates every effective NAPI-routed language, not only HTML, and compares it with the same shared source set production evaluates. Existing coverage retains the opposite direction: enabled catalog languages must have a delivery route. Refs #2323 only for the separate scheduling member; this PR does not change scheduling.

## Observability

No production failure path changes, so no new telemetry record is needed. The production proof remains the emitted `plaintext-http-link-html` finding. The coverage test makes a future empty routed lane a required-test failure.

## Test assessment

- Added one regression case to the existing real-runner coverage file. It enters through `napi.default.run`, uses the real YAML catalog and NAPI parser, and asserts the produced rule id.
- Added one contract case to the same file. It derives routed languages from production admission and grammar lookup, then compares them with the shared catalog census.
- Mutation proof 1: excluding lowercase `html` from the census failed with `Received: [html]`.
- Mutation proof 2: removing the HTML binding made the real-runner case fail with `expected [] to include plaintext-http-link-html`.
- No tests were removed or weakened.

Closes #2325.

## Review round

Verify round confirmed the discrepancy trail file-by-file and re-proved both mutation directions (2 red on rule removal, 5 red on binding removal). Two corrections landed as maintainer deltas (ef014869): the .html test's name and this body no longer claim dispatch coverage — it drives `napi.default.run` directly, which is honest for the rule-serving claim; the true dispatch-path test belongs to #2328, whose plan change is what adds ast-grep-napi to the css/html groups (proven by composition: the merged tree runs both PRs' suites 41/41). The class is also NOT size-1: the review censused the whole corpus (111 TypeScript vs 31 typescript, 47 Python vs 52 python, ...) and found two raw-case tooling sites — the rule-pair audit's duplicate key and the catalog overlap warning — re-homed as #2331. AGENTS.md's guidance was broadened accordingly.

