### PR TITLE
fix(lsp): gate ast-grep on first publication (closes #2324)

### DIFF
--- a/.changelog/2324-ast-grep-first-publication.md
+++ b/.changelog/2324-ast-grep-first-publication.md
@@ -1,0 +1,8 @@
+---
+type: fix
+issue: 2324
+---
+
+Keep the ast-grep NAPI fallback active until the auxiliary LSP completes its
+first diagnostic publication for the root, preventing silent findings loss
+during startup and non-publication windows.

--- a/.changelog/2324-ast-grep-first-publication.md
+++ b/.changelog/2324-ast-grep-first-publication.md
@@ -1,8 +1,5 @@
 ---
-type: fix
-issue: 2324
+section: Fixed
 ---
 
-Keep the ast-grep NAPI fallback active until the auxiliary LSP completes its
-first diagnostic publication for the root, preventing silent findings loss
-during startup and non-publication windows.
+- **ast-grep findings survive a silent auxiliary LSP (refs #2324)** — the napi fallback stays active until the ast-grep LSP completes its first diagnostic publication for the root, closing the startup window where Gate B skipped the runner and a never-publishing server silently lost the findings.

--- a/.changelog/2324-ast-grep-first-publication.md
+++ b/.changelog/2324-ast-grep-first-publication.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **ast-grep findings survive a silent auxiliary LSP (refs #2324)** — the napi fallback stays active until the ast-grep LSP completes its first diagnostic publication for the root, closing the startup window where Gate B skipped the runner and a never-publishing server silently lost the findings.
+- **ast-grep findings survive a silent auxiliary LSP (closes #2324)** — the napi fallback stays active until the ast-grep LSP completes its first diagnostic publication for the SPECIFIC FILE (not just anywhere on its client), closing the race where a sibling file's publication wrongly satisfied the gate. The fallback and the late-auxiliary delivery lane no longer both fire for the same file: a napi run consumes that file's pending late-auxiliary pair. The remaining narrow case — a server that published once but goes silent on a later touch of the same file — is now a bounded `aux-runner-findings-lost` degradation record instead of a silent drop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1648,10 +1648,13 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   which makes an array-only edge clone safe. Debounced persistence retains the
   finished graph/maps and materializes serialization arrays only at flush time,
   so callers must likewise replace rather than mutate those snapshots.
-- **Auxiliary LSP liveness is a read-only dispatch seam (#868).**
-  `clients/lsp/index.ts` exposes `isAuxiliaryLspAlive(serverId, filePath)` for
-  Gate-B fallback decisions. It resolves the matching root and inspects only
-  the existing client map; it must never spawn or warm a client. Dispatch-side
+- **Auxiliary LSP publication readiness is a read-only dispatch seam (#868/#2324).**
+  `clients/lsp/index.ts` exposes
+  `hasAuxiliaryLspPublishedForRoot(serverId, filePath)` for Gate-B fallback
+  decisions. It resolves the matching root and requires a live client's first
+  diagnostic publication; process liveness or a resolvable binary is not proof
+  that the server can supersede a fallback runner. It inspects only the existing
+  client map and must never spawn or warm a client. Dispatch-side
   code imports this seam from `lsp/index.ts`, while `dispatch/auxiliary-lsp.ts`
   remains free of the reverse import to avoid the LSP/auxiliary cycle.
 - **Document-symbol enrichment is warm-and-open only (#158).**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1648,12 +1648,17 @@ a *second host adapter* alongside `index.ts`. Design rationale + progress: `mcp.
   which makes an array-only edge clone safe. Debounced persistence retains the
   finished graph/maps and materializes serialization arrays only at flush time,
   so callers must likewise replace rather than mutate those snapshots.
-- **Auxiliary LSP publication readiness is a read-only dispatch seam (#868/#2324).**
-  `clients/lsp/index.ts` exposes
+- **Auxiliary LSP publication readiness is a read-only dispatch seam, per file
+  (#868/#2324).** `clients/lsp/index.ts` exposes
   `hasAuxiliaryLspPublishedForRoot(serverId, filePath)` for Gate-B fallback
-  decisions. It resolves the matching root and requires a live client's first
-  diagnostic publication; process liveness or a resolvable binary is not proof
-  that the server can supersede a fallback runner. It inspects only the existing
+  decisions. It resolves the matching root and requires that live client's
+  FIRST diagnostic publication FOR THAT FILE — `getDiagnosticsVersionForPath`,
+  never the client-global `diagnosticsVersion`. The global counter advances on
+  any path's publication, so it answered "did the server publish?" for a
+  sibling file too, satisfying the gate for a file the server never touched
+  and leaving fallback findings undelivered (the #2324 headline warm-silence
+  case). Process liveness or a resolvable binary is not proof that the server
+  can supersede a fallback runner either. It inspects only the existing
   client map and must never spawn or warm a client. Dispatch-side
   code imports this seam from `lsp/index.ts`, while `dispatch/auxiliary-lsp.ts`
   remains free of the reverse import to avoid the LSP/auxiliary cycle.

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -484,7 +484,22 @@ export type DegradationKind =
 	 * is invisible: the store just silently stops honoring its budget.
 	 * Recorded once per session, subject is the store label.
 	 */
-	| "fact-store-pinned-over-budget";
+	| "fact-store-pinned-over-budget"
+	/**
+	 * Gate B (`clients/dispatch/runners/ast-grep-napi.ts`) skipped the napi
+	 * fallback because the ast-grep LSP client has published for this file
+	 * BEFORE, and a pending late-auxiliary pair for the same (file, "ast-grep")
+	 * still sits in `clients/lsp/pending-aux-coverage.ts` (#2324 F2). Ordering
+	 * makes this pair provably a LEFTOVER from an earlier touch, never this
+	 * one: the aux-grace wait that marks a pair for THIS touch only runs to
+	 * completion, and only decides to mark, after napi's Gate B check has
+	 * already returned (napi's check is a synchronous map lookup; the wait's
+	 * own budget is up to ~1800 ms) — so a pair visible here was marked by a
+	 * PRIOR touch's wait and never got delivered. Subject is the server id, so
+	 * the ledger still answers which server's earlier finding never resurfaced
+	 * after the count-bound stops naming files.
+	 */
+	| "aux-runner-findings-lost";
 
 export interface DegradationRecord {
 	kind: unknown;

--- a/clients/dispatch/runners/ast-grep-napi.ts
+++ b/clients/dispatch/runners/ast-grep-napi.ts
@@ -26,8 +26,7 @@ import { hasEslintConfig } from "../../tool-policy.js";
 import { enabledAuxiliaryLspServerIds } from "../auxiliary-lsp.js";
 import { classifyDefect } from "../diagnostic-taxonomy.js";
 import { recordDegradationOnce } from "../../degradation-ledger.js";
-import { isAuxiliaryLspAlive } from "../../lsp/index.js";
-import { resolveAstGrepNativeExe } from "../../lsp/wait-policy/index.js";
+import { hasAuxiliaryLspPublishedForRoot } from "../../lsp/index.js";
 import { PRIORITY } from "../priorities.js";
 import type {
 	Diagnostic,
@@ -923,20 +922,14 @@ const astGrepNapiRunner: RunnerDefinition = {
 		const astGrepLspEnabled = enabledAuxiliaryLspServerIds((f) =>
 			ctx.pi?.getFlag?.(f),
 		).includes("ast-grep");
-		// Gate B asks whether the LSP will handle this file, not whether a bare
-		// `ast-grep` command happens to be on PATH. The launcher first tries the
-		// platform-native package binary, then PATH; mirror that resolution here.
-		// A live client covers the already-warm case, while a resolvable binary
-		// covers the cold case before the LSP has spawned for this root.
-		const astGrepLspAlive = astGrepLspEnabled
-			? await isAuxiliaryLspAlive("ast-grep", ctx.filePath)
+		// Gate B asks whether the LSP has proved it can handle this root, not
+		// whether an ast-grep process or binary merely exists.
+		// A first publication covers the warm case. Process liveness and binary
+		// resolution do not: both precede proof that this root can publish findings.
+		const astGrepLspPublished = astGrepLspEnabled
+			? await hasAuxiliaryLspPublishedForRoot("ast-grep", ctx.filePath)
 			: false;
-		let astGrepBinaryResolvable = false;
-		if (astGrepLspEnabled && !astGrepLspAlive) {
-			astGrepBinaryResolvable =
-				Boolean(resolveAstGrepNativeExe()) || (await ctx.hasTool("ast-grep"));
-		}
-		if (astGrepLspEnabled && (astGrepLspAlive || astGrepBinaryResolvable)) {
+		if (astGrepLspEnabled && astGrepLspPublished) {
 			return { status: "skipped", diagnostics: [], semantic: "none" };
 		}
 

--- a/clients/dispatch/runners/ast-grep-napi.ts
+++ b/clients/dispatch/runners/ast-grep-napi.ts
@@ -25,8 +25,15 @@ import { logLatency } from "../../latency-logger.js";
 import { hasEslintConfig } from "../../tool-policy.js";
 import { enabledAuxiliaryLspServerIds } from "../auxiliary-lsp.js";
 import { classifyDefect } from "../diagnostic-taxonomy.js";
-import { recordDegradationOnce } from "../../degradation-ledger.js";
+import {
+	incrementDegradationCount,
+	recordDegradationOnce,
+} from "../../degradation-ledger.js";
 import { hasAuxiliaryLspPublishedForRoot } from "../../lsp/index.js";
+import {
+	clearPendingAuxiliaryCoverage,
+	hasPendingAuxiliaryCoverage,
+} from "../../lsp/pending-aux-coverage.js";
 import { PRIORITY } from "../priorities.js";
 import type {
 	Diagnostic,
@@ -930,7 +937,34 @@ const astGrepNapiRunner: RunnerDefinition = {
 			? await hasAuxiliaryLspPublishedForRoot("ast-grep", ctx.filePath)
 			: false;
 		if (astGrepLspEnabled && astGrepLspPublished) {
+			// #2324 F2: "has this server EVER published for this file" can go
+			// stale — a LATER touch's aux-grace wait can find the server silent
+			// for the CURRENT content while an OLDER revision's publication still
+			// satisfies this per-file gate. A pending late-aux entry for this
+			// exact pair is that signal: the aux-grace wait already decided this
+			// touch got no fresh evidence, yet Gate B is about to skip anyway.
+			// Re-running napi here would risk the F3 duplicate this fix just
+			// closed, so the residual loss is made observable instead.
+			if (hasPendingAuxiliaryCoverage(ctx.filePath, "ast-grep")) {
+				incrementDegradationCount({
+					kind: "aux-runner-findings-lost",
+					subject: "ast-grep",
+					reason: `Gate B skipped napi for ${ctx.filePath}: prior publication exists but this touch's aux-grace wait found no fresh evidence`,
+				});
+			}
 			return { status: "skipped", diagnostics: [], semantic: "none" };
+		}
+		if (astGrepLspEnabled && !astGrepLspPublished) {
+			// #2324 F3: napi is about to run BECAUSE the per-file gate found no
+			// publication evidence — the same condition the aux-grace wait just
+			// used (or is about to use) to mark this file pending for late-
+			// auxiliary delivery. Napi's run covers this turn's findings, so
+			// consume that pending pair now. Left unconsumed, the LSP's actual
+			// (delayed) publication would redeliver the identical rule/line at
+			// the next turn_end as `late-auxiliary-findings` — a duplicate
+			// surface, not new coverage. Unknown pairs are a no-op, so this is
+			// safe even when no aux-grace wait ran for this touch.
+			clearPendingAuxiliaryCoverage(ctx.filePath, "ast-grep");
 		}
 
 		const sgModule = await loadSg();

--- a/clients/dispatch/runners/ast-grep-napi.ts
+++ b/clients/dispatch/runners/ast-grep-napi.ts
@@ -33,6 +33,7 @@ import { hasAuxiliaryLspPublishedForRoot } from "../../lsp/index.js";
 import {
 	clearPendingAuxiliaryCoverage,
 	hasPendingAuxiliaryCoverage,
+	recordNapiFallbackCoverage,
 } from "../../lsp/pending-aux-coverage.js";
 import { PRIORITY } from "../priorities.js";
 import type {
@@ -937,34 +938,24 @@ const astGrepNapiRunner: RunnerDefinition = {
 			? await hasAuxiliaryLspPublishedForRoot("ast-grep", ctx.filePath)
 			: false;
 		if (astGrepLspEnabled && astGrepLspPublished) {
-			// #2324 F2: "has this server EVER published for this file" can go
+			// #2324 F2/R2-C: "has this server EVER published for this file" can go
 			// stale — a LATER touch's aux-grace wait can find the server silent
 			// for the CURRENT content while an OLDER revision's publication still
-			// satisfies this per-file gate. A pending late-aux entry for this
-			// exact pair is that signal: the aux-grace wait already decided this
-			// touch got no fresh evidence, yet Gate B is about to skip anyway.
-			// Re-running napi here would risk the F3 duplicate this fix just
-			// closed, so the residual loss is made observable instead.
+			// satisfies this per-file gate. Any pending late-aux entry visible
+			// HERE is necessarily a LEFTOVER from an earlier touch, never this
+			// one: the wait that marks a pair for THIS touch runs to completion
+			// (up to its own grace budget, ~1800ms) strictly AFTER this
+			// synchronous Gate-B check returns, so it cannot have marked
+			// anything yet. Re-running napi here would risk the F3 duplicate
+			// this fix closes, so the loss is made observable instead.
 			if (hasPendingAuxiliaryCoverage(ctx.filePath, "ast-grep")) {
 				incrementDegradationCount({
 					kind: "aux-runner-findings-lost",
 					subject: "ast-grep",
-					reason: `Gate B skipped napi for ${ctx.filePath}: prior publication exists but this touch's aux-grace wait found no fresh evidence`,
+					reason: `Gate B skipped napi for ${ctx.filePath}: a pending late-auxiliary pair from an EARLIER touch is still undelivered while a prior publication satisfies the per-file gate`,
 				});
 			}
 			return { status: "skipped", diagnostics: [], semantic: "none" };
-		}
-		if (astGrepLspEnabled && !astGrepLspPublished) {
-			// #2324 F3: napi is about to run BECAUSE the per-file gate found no
-			// publication evidence — the same condition the aux-grace wait just
-			// used (or is about to use) to mark this file pending for late-
-			// auxiliary delivery. Napi's run covers this turn's findings, so
-			// consume that pending pair now. Left unconsumed, the LSP's actual
-			// (delayed) publication would redeliver the identical rule/line at
-			// the next turn_end as `late-auxiliary-findings` — a duplicate
-			// surface, not new coverage. Unknown pairs are a no-op, so this is
-			// safe even when no aux-grace wait ran for this touch.
-			clearPendingAuxiliaryCoverage(ctx.filePath, "ast-grep");
 		}
 
 		const sgModule = await loadSg();
@@ -1018,6 +1009,32 @@ const astGrepNapiRunner: RunnerDefinition = {
 			rootNode = root.root();
 		} catch {
 			return { status: "skipped", diagnostics: [], semantic: "none" };
+		}
+
+		if (astGrepLspEnabled && !astGrepLspPublished) {
+			// #2324 F3/R2-A/R2-B: napi is about to ACTUALLY EVALUATE RULES —
+			// every early-return skip above (load failure, missing file,
+			// unresolved language, stat/size/read/parse failure) is now behind
+			// us, so this run genuinely covers the file rather than reporting a
+			// zero-finding no-op. Placing this here (not at Gate-B's decision
+			// point) matters twice over:
+			//   - R2-B: a napi run that never reached rule evaluation must NOT
+			//     consume anything — an unparseable .html file, say, would
+			//     otherwise silence the LSP's legitimate late delivery for a
+			//     file napi never actually covered.
+			//   - R2-A: recording coverage HERE, keyed by timestamp, lets the
+			//     aux-grace wait (clients/lsp/index.ts) — which decides whether
+			//     to mark a pending pair for THIS touch strictly AFTER this
+			//     synchronous call returns — see that napi already delivered
+			//     and skip marking, instead of racing a clear against a mark
+			//     that has not been written yet.
+			// The clear below only ever removes a LEFTOVER pair from an
+			// EARLIER touch (this touch's own pair, if the wait decides to
+			// mark one, is marked strictly later) — that pair describes a
+			// PREVIOUS revision this fresh evaluation supersedes, so dropping
+			// it is safe. Unknown pairs are a no-op.
+			recordNapiFallbackCoverage(ctx.filePath);
+			clearPendingAuxiliaryCoverage(ctx.filePath, "ast-grep");
 		}
 
 		const diagnostics = evaluateAstGrepRules(

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -41,7 +41,10 @@ import {
 	fingerprintDocumentContent,
 	type DriftSweepResult,
 } from "./document-drift.js";
-import { markPendingAuxiliaryCoverage } from "./pending-aux-coverage.js";
+import {
+	markPendingAuxiliaryCoverage,
+	napiFallbackCoveredSince,
+} from "./pending-aux-coverage.js";
 import {
 	isAtOrAboveHomeDir,
 	isWindowsPath,
@@ -4807,7 +4810,20 @@ export class LSPService {
 									.filter(
 										(o) =>
 											!o.publishedThisContent &&
-											(o.outcome === "cut_off" || o.outcome === "silent"),
+											(o.outcome === "cut_off" || o.outcome === "silent") &&
+											// #2324 R2-A: ast-grep's napi fallback is a SECOND
+											// producer of coverage for this exact pair. Its
+											// Gate-B check settles synchronously, well before
+											// this wait's own grace budget expires, so by the
+											// time this filter runs, this touch's napi run (if
+											// any) has already recorded its coverage — checked
+											// against THIS wait's own start so a stale record
+											// from an earlier touch can never suppress a mark
+											// this touch's silent server genuinely needs.
+											!(
+												o.serverId === "ast-grep" &&
+												napiFallbackCoveredSince(filePath, waitStartedAt)
+											),
 									)
 									.map((o) => o.serverId);
 								if (collectLaterServerIds.length > 0) {

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -2709,11 +2709,11 @@ export class LSPService {
 	}
 
 	/**
-	 * Read-only liveness check for one server/file pair. Unlike
-	 * `getClientForFile`, this never creates or warms a client; it only resolves
-	 * the server's root and checks the already-connected client map.
+	 * Read-only Gate-B readiness check for one auxiliary server/root. A connected
+	 * process is not yet a diagnostic producer: only its first publication proves
+	 * that this root's client can supersede an in-process fallback runner.
 	 */
-	async isServerAliveForFile(
+	async hasServerPublishedForFileRoot(
 		serverId: string,
 		filePath: string,
 	): Promise<boolean> {
@@ -2723,7 +2723,8 @@ export class LSPService {
 			const root = await this.resolveServerRoot(server, filePath);
 			if (!root) continue;
 			const key = `${server.id}:${normalizeMapKey(root)}`;
-			if (this.state.clients.get(key)?.isAlive()) return true;
+			const client = this.state.clients.get(key);
+			if (client?.isAlive() && client.diagnosticsVersion > 0) return true;
 		}
 		return false;
 	}
@@ -2731,7 +2732,7 @@ export class LSPService {
 	/**
 	 * #2001/#2002 collect-later: read-only cached-diagnostics probe for the
 	 * turn-end late-auxiliary delivery (`clients/runtime-turn.ts`). Like
-	 * `isServerAliveForFile`, this NEVER creates or warms a client — it only
+	 * the Gate-B readiness check, this NEVER creates or warms a client — it only
 	 * resolves each requested server's root and reads the already-connected
 	 * client's cached diagnostics for `filePath`. Servers with no live client
 	 * are simply absent from the returned map. A live client is present only
@@ -6542,7 +6543,7 @@ export class LSPService {
 	 * `executeCommand` above cannot give a render-path probe:
 	 *
 	 * - **Never spawns.** It resolves the already-connected client map the way
-	 *   `isServerAliveForFile` does, instead of routing through
+	 *   other read-only client-map lookups do, instead of routing through
 	 *   `getClientForFile` → `ensureClientForServer`. A probe that spawns a
 	 *   language-server fleet to answer a question about how to RENDER a
 	 *   diagnostic is a cost the caller never asked for — and under warm attach
@@ -8889,15 +8890,14 @@ export function getLSPService(): LSPService {
 }
 
 /**
- * Cross-layer liveness seam for dispatch-side auxiliary gates. This is a
- * liveness read only: it does not spawn, wait for initialization, or probe a
- * binary.
+ * Gate-B readiness seam. It reads only the live client map and never spawns,
+ * waits for initialization, or probes a binary.
  */
-export async function isAuxiliaryLspAlive(
+export async function hasAuxiliaryLspPublishedForRoot(
 	serverId: string,
 	filePath: string,
 ): Promise<boolean> {
-	return getLSPService().isServerAliveForFile(serverId, filePath);
+	return getLSPService().hasServerPublishedForFileRoot(serverId, filePath);
 }
 
 /**

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -4811,18 +4811,24 @@ export class LSPService {
 										(o) =>
 											!o.publishedThisContent &&
 											(o.outcome === "cut_off" || o.outcome === "silent") &&
-											// #2324 R2-A: ast-grep's napi fallback is a SECOND
-											// producer of coverage for this exact pair. Its
-											// Gate-B check settles synchronously, well before
-											// this wait's own grace budget expires, so by the
-											// time this filter runs, this touch's napi run (if
-											// any) has already recorded its coverage — checked
-											// against THIS wait's own start so a stale record
-											// from an earlier touch can never suppress a mark
-											// this touch's silent server genuinely needs.
+											// #2324 R2-A/R3-A: ast-grep's napi fallback is a
+											// SECOND producer of coverage for this exact pair,
+											// dispatched CONCURRENTLY with this whole touch
+											// (dispatcher.ts's Promise.all groups) — not just
+											// concurrently with this wait. On a COLD touch,
+											// getClientsForFile's spawn+handshake (above, before
+											// waitStartedAt is ever captured) can itself take
+											// long enough that napi's near-instant Gate-B check
+											// records coverage BEFORE waitStartedAt — the
+											// issue's own 68ms race shape. Baseline on startedAt
+											// instead: stamped at touchFile's own entry, before
+											// ANY spawn work, so it is the earliest instant this
+											// touch's own napi run could possibly predate. Still
+											// excludes a stale record from an EARLIER touch,
+											// which is all the staleness guard needs.
 											!(
 												o.serverId === "ast-grep" &&
-												napiFallbackCoveredSince(filePath, waitStartedAt)
+												napiFallbackCoveredSince(filePath, startedAt)
 											),
 									)
 									.map((o) => o.serverId);

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -2724,7 +2724,17 @@ export class LSPService {
 			if (!root) continue;
 			const key = `${server.id}:${normalizeMapKey(root)}`;
 			const client = this.state.clients.get(key);
-			if (client?.isAlive() && client.diagnosticsVersion > 0) return true;
+			// #2324 F1: per-file grain. `diagnosticsVersion` is client-global —
+			// any sibling path's publication bumps it, so it cannot answer "did
+			// THIS server publish for THIS file?" (client.ts:339-341). A file
+			// this server never touched would otherwise read as gated-open the
+			// moment any other file on the same client got a publication.
+			if (
+				client?.isAlive() &&
+				client.getDiagnosticsVersionForPath(filePath) > 0
+			) {
+				return true;
+			}
 		}
 		return false;
 	}

--- a/clients/lsp/pending-aux-coverage.ts
+++ b/clients/lsp/pending-aux-coverage.ts
@@ -36,6 +36,21 @@
  * index whose keys are produced by this same process's touch path, so the
  * cheap ephemeral normalizer is the lifetime-appropriate choice per the
  * PathKeyedMap guidance — no realpath walk on the per-edit path.
+ *
+ * #2324 F3/R2-A: this module ALSO hands off in the other direction, for
+ * ast-grep specifically. Gate B's napi runner is a second producer of
+ * coverage for the same (file, "ast-grep") pair — when it runs as the
+ * fallback and actually evaluates rules, it calls
+ * {@link recordNapiFallbackCoverage}. The PRODUCER above reads that record
+ * (via {@link napiFallbackCoveredSince}) before deciding whether to mark a
+ * pair, because napi's Gate-B check settles synchronously while the aux-grace
+ * wait's own decision takes up to its full grace budget — by the time the
+ * wait is ready to mark, THIS touch's napi run (if any) has already finished,
+ * so the wait can reliably see it; a clear issued from napi's side cannot,
+ * because the mark it would be racing has not been written yet.
+ * {@link clearPendingAuxiliaryCoverage} is still used, but only to drop a
+ * LEFTOVER pair from an EARLIER touch once napi has fresh evaluated findings
+ * to supersede it.
  */
 
 import { normalizeEphemeralMapKey } from "../path-utils.js";
@@ -265,10 +280,67 @@ export function drainPendingAuxCapEvictedCount(): number {
 }
 
 /**
+ * #2324 R2-A: (file) -> the timestamp of the LAST time the ast-grep napi
+ * fallback actually evaluated rules for it, as Gate B's runner
+ * (`clients/dispatch/runners/ast-grep-napi.ts`). This is the cross-module
+ * hand-off the aux-grace wait (`clients/lsp/index.ts`) needs to avoid
+ * marking a pending late-auxiliary pair for a file napi ALREADY delivered
+ * for on THIS touch.
+ *
+ * Ordering is why a synchronous clear-on-napi-run cannot do this job: the
+ * wait that decides whether to mark a pair runs for up to ~1800ms (its own
+ * grace budget) AFTER napi's Gate-B check, which is a single map lookup.
+ * Clearing at napi's run start (or end) races the mark and reliably loses —
+ * the mark, if any, has not been written yet. The wait itself is the only
+ * place that knows the outcome, so it is the one that must consult this
+ * store and skip marking, not the runner that must guess at the wait's
+ * future decision.
+ *
+ * Bounded like the pending-pair store itself; oldest evicted first.
+ */
+const napiFallbackCoverage = new Map<string, number>();
+export const MAX_NAPI_COVERAGE_ENTRIES = 50;
+
+/** Record that napi actually evaluated rules for `filePath` at `atMs`. */
+export function recordNapiFallbackCoverage(
+	filePath: string,
+	atMs: number = Date.now(),
+): void {
+	const key = normalizeEphemeralMapKey(filePath);
+	napiFallbackCoverage.delete(key);
+	napiFallbackCoverage.set(key, atMs);
+	while (napiFallbackCoverage.size > MAX_NAPI_COVERAGE_ENTRIES) {
+		const oldest = napiFallbackCoverage.keys().next().value;
+		if (oldest === undefined) break;
+		napiFallbackCoverage.delete(oldest);
+	}
+}
+
+/**
+ * Did napi cover `filePath` at or after `sinceMs`? The aux-grace wait passes
+ * its own `waitStartedAt` baseline so a STALE coverage record from an
+ * earlier touch (napi ran for a PREVIOUS revision) cannot suppress marking a
+ * pair this touch's silent server genuinely needs delivered later.
+ */
+export function napiFallbackCoveredSince(
+	filePath: string,
+	sinceMs: number,
+): boolean {
+	const ts = napiFallbackCoverage.get(normalizeEphemeralMapKey(filePath));
+	return ts !== undefined && ts >= sinceMs;
+}
+
+/** Test-only reset for the napi-coverage hand-off. */
+export function resetNapiFallbackCoverageForTests(): void {
+	napiFallbackCoverage.clear();
+}
+
+/**
  * Session-boundary clear (#1635): pending baselines are unreachable after
  * reset (the generation-stamped keys no longer match any active session).
  */
 export function resetPendingAuxiliaryCoverage(): void {
 	pending.clear();
 	capEvictedCount = 0;
+	napiFallbackCoverage.clear();
 }

--- a/clients/lsp/pending-aux-coverage.ts
+++ b/clients/lsp/pending-aux-coverage.ts
@@ -204,6 +204,22 @@ export function rearmPendingAuxiliaryCoverage(
 }
 
 /**
+ * Read-only check: is this (file, server) pair currently pending late
+ * delivery? #2324 F2: Gate B's "has this server EVER published for this
+ * file" answer goes stale the moment a later touch's aux-grace wait finds
+ * the server silent for the CURRENT content — a pending pair is exactly
+ * that signal, so a caller deciding whether to skip a fallback runner can
+ * tell "published, still current" from "published once, silent now" without
+ * draining or mutating the store.
+ */
+export function hasPendingAuxiliaryCoverage(
+	filePath: string,
+	serverId: string,
+): boolean {
+	return pending.has(pairKey(filePath, serverId));
+}
+
+/**
  * Remove one pair after its findings were delivered, or whenever the caller
  * knows it is resolved. Unknown pairs are a no-op.
  */

--- a/tests/clients/dispatch/runners/ast-grep-napi.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi.test.ts
@@ -59,6 +59,10 @@ function mockWorkingSgLoad(): void {
 				}),
 			}),
 		},
+		// #2324 R2-B: declared but undefined, matching an addon build that
+		// dropped a grammar (#2215) — `getLang` must read this as "no parser
+		// for html", not throw on an undeclared mock export.
+		html: undefined,
 	}));
 }
 
@@ -127,13 +131,22 @@ describe("ast-grep-napi runner — LSP supersede gate (#239 Phase 2)", () => {
 	// @ast-grep/napi mock and collides with the doMock in the skip-path suite.
 });
 
-describe("ast-grep-napi runner — late-auxiliary dedupe (#2324 F3)", () => {
+describe("ast-grep-napi runner — late-auxiliary dedupe (#2324 F3/R2)", () => {
 	beforeEach(() => {
 		vi.resetModules();
 		mockAuxiliaryLspPublished.mockResolvedValue(false);
 	});
 
-	it("consumes the pending late-auxiliary pair when it runs as the fallback, so only one delivery surface arms", async () => {
+	// #2324 R2-A: production can NEVER see a pending pair for THIS touch by
+	// the time napi's clear runs — the wait that marks a pair for this touch
+	// takes up to its own grace budget (~1800ms), strictly LONGER than napi's
+	// Gate-B check plus rule evaluation. Any pair visible here is therefore a
+	// LEFTOVER from an EARLIER touch, describing a PREVIOUS revision this
+	// fresh evaluation supersedes — clearing it is correct. The mark-vs-clear
+	// RACE for THIS touch's own pair is closed on the OTHER side, in
+	// service-aux-grace.test.ts, where the aux-grace wait consults
+	// `napiFallbackCoveredSince` before it ever marks.
+	it("clears a leftover pending pair from an earlier touch once it actually evaluates rules", async () => {
 		const env = setupTestEnvironment("pi-lens-ast-grep-dedupe-");
 		try {
 			const filePath = path.join(env.tmpDir, "file.ts");
@@ -141,8 +154,7 @@ describe("ast-grep-napi runner — late-auxiliary dedupe (#2324 F3)", () => {
 			const pendingAux =
 				await import("../../../../clients/lsp/pending-aux-coverage.js");
 			pendingAux.resetPendingAuxiliaryCoverage();
-			// Lane 1 arms: the aux-grace wait already found ast-grep silent for
-			// this touch and marked it for turn-end late delivery.
+			// A leftover pair from an EARLIER touch, still undelivered.
 			pendingAux.markPendingAuxiliaryCoverage(filePath, ["ast-grep"]);
 			expect(pendingAux.hasPendingAuxiliaryCoverage(filePath, "ast-grep")).toBe(
 				true,
@@ -151,19 +163,57 @@ describe("ast-grep-napi runner — late-auxiliary dedupe (#2324 F3)", () => {
 			mockWorkingSgLoad();
 			const mod =
 				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
-			// Lane 2 arms: Gate B finds no publication yet, so napi runs and
-			// delivers this turn's findings itself.
 			const result = await mod.default.run(
 				createCtx(filePath, { hasTool: async () => false }) as any,
 			);
 			expect(result.status).toBe("succeeded");
 
-			// Exactly one delivery surface should remain armed: napi already
-			// delivered, so the late-auxiliary lane must be consumed — a
-			// pending pair left behind here would redeliver the identical
-			// rule/line at the next turn_end as a duplicate.
+			// This fresh evaluation supersedes the leftover pair.
 			expect(pendingAux.hasPendingAuxiliaryCoverage(filePath, "ast-grep")).toBe(
 				false,
+			);
+			pendingAux.resetPendingAuxiliaryCoverage();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	// #2324 R2-B: the clear/record must sit AFTER every early-return skip —
+	// loadSg failure, missing file, unresolved language, stat/size/read/parse
+	// failure — not at Gate B's decision point. A run that never reaches rule
+	// evaluation did not actually cover the file, so it must not consume a
+	// pending pair a genuine late LSP delivery still needs. Reproduces the
+	// reviewer's probe: an .html file the mocked sg module has no parser for
+	// (`mockWorkingSgLoad` only registers `ts`), so `getLang` returns
+	// undefined and napi skips before ever touching rules.
+	it("preserves a pending late-auxiliary pair when napi never reaches rule evaluation", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-dedupe-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.html");
+			fs.writeFileSync(
+				filePath,
+				"<div>unparsed by the mocked sg module</div>\n",
+			);
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			pendingAux.markPendingAuxiliaryCoverage(filePath, ["ast-grep"]);
+			expect(pendingAux.hasPendingAuxiliaryCoverage(filePath, "ast-grep")).toBe(
+				true,
+			);
+
+			mockWorkingSgLoad();
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+
+			// Napi never evaluated a rule for this file — the pending pair, and
+			// the LSP's legitimate late delivery it represents, must survive.
+			expect(pendingAux.hasPendingAuxiliaryCoverage(filePath, "ast-grep")).toBe(
+				true,
 			);
 			pendingAux.resetPendingAuxiliaryCoverage();
 		} finally {
@@ -320,5 +370,94 @@ describe("ast-grep-napi runner — metadata", () => {
 		expect(runner.id).toBe("ast-grep-napi");
 		expect(runner.appliesTo).toContain("jsts");
 		expect(runner.enabledByDefault).toBe(true);
+	});
+});
+
+// #2324 F2/R2-C: the residual "published once, silent now" loss is a bounded
+// `aux-runner-findings-lost` degradation, not a re-run. Neutering the branch
+// that records it must turn this test red — the finding the review round
+// caught was that no test referenced the record at all, so the branch could
+// be deleted with the suite staying green.
+describe("ast-grep-napi runner — aux-runner-findings-lost degradation (#2324 R2-C)", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockAuxiliaryLspPublished.mockResolvedValue(false);
+	});
+
+	it("records the loss when Gate B skips on a leftover pending pair", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-loss-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			// #2324 R2-C: dynamically imported AFTER vi.resetModules() so this is
+			// the SAME module instance (and the same ledger state) the runner
+			// module below resolves — a static top-of-file import would bind to
+			// a stale pre-reset instance and this test would fail for the wrong
+			// reason.
+			const ledger = await import("../../../../clients/degradation-ledger.js");
+			ledger.resetDegradationLedger();
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			// A leftover pair from an earlier touch — by R2-A's ordering, the
+			// only shape a pair can take by the time this synchronous check
+			// runs (this touch's own mark, if any, is decided strictly later).
+			pendingAux.markPendingAuxiliaryCoverage(filePath, ["ast-grep"]);
+
+			// Gate B: the per-file publication gate reads "published" (a prior
+			// touch's publication), so napi is about to skip.
+			mockAuxiliaryLspPublished.mockResolvedValue(true);
+			mockWorkingSgLoad();
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+
+			const group = ledger
+				.getDegradationSummary()
+				.find((g) => g.kind === "aux-runner-findings-lost");
+			expect(group).toBeDefined();
+			expect(group?.count).toBe(1);
+			expect(group?.latestReasons[0]?.subject).toBe("ast-grep");
+			// The reason must describe an EARLIER-touch leftover, not this
+			// touch's own aux-grace outcome — R2-C's corrected claim.
+			expect(group?.latestReasons[0]?.reason).toContain("EARLIER touch");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			ledger.resetDegradationLedger();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("does not record the loss when no pending pair exists (a clean skip)", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-loss-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			const ledger = await import("../../../../clients/degradation-ledger.js");
+			ledger.resetDegradationLedger();
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+
+			mockAuxiliaryLspPublished.mockResolvedValue(true);
+			mockWorkingSgLoad();
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+			expect(
+				ledger
+					.getDegradationSummary()
+					.find((g) => g.kind === "aux-runner-findings-lost"),
+			).toBeUndefined();
+			ledger.resetDegradationLedger();
+		} finally {
+			env.cleanup();
+		}
 	});
 });

--- a/tests/clients/dispatch/runners/ast-grep-napi.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi.test.ts
@@ -127,6 +127,52 @@ describe("ast-grep-napi runner — LSP supersede gate (#239 Phase 2)", () => {
 	// @ast-grep/napi mock and collides with the doMock in the skip-path suite.
 });
 
+describe("ast-grep-napi runner — late-auxiliary dedupe (#2324 F3)", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockAuxiliaryLspPublished.mockResolvedValue(false);
+	});
+
+	it("consumes the pending late-auxiliary pair when it runs as the fallback, so only one delivery surface arms", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-dedupe-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			const pendingAux = await import(
+				"../../../../clients/lsp/pending-aux-coverage.js"
+			);
+			pendingAux.resetPendingAuxiliaryCoverage();
+			// Lane 1 arms: the aux-grace wait already found ast-grep silent for
+			// this touch and marked it for turn-end late delivery.
+			pendingAux.markPendingAuxiliaryCoverage(filePath, ["ast-grep"]);
+			expect(
+				pendingAux.hasPendingAuxiliaryCoverage(filePath, "ast-grep"),
+			).toBe(true);
+
+			mockWorkingSgLoad();
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			// Lane 2 arms: Gate B finds no publication yet, so napi runs and
+			// delivers this turn's findings itself.
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("succeeded");
+
+			// Exactly one delivery surface should remain armed: napi already
+			// delivered, so the late-auxiliary lane must be consumed — a
+			// pending pair left behind here would redeliver the identical
+			// rule/line at the next turn_end as a duplicate.
+			expect(
+				pendingAux.hasPendingAuxiliaryCoverage(filePath, "ast-grep"),
+			).toBe(false);
+			pendingAux.resetPendingAuxiliaryCoverage();
+		} finally {
+			env.cleanup();
+		}
+	});
+});
+
 describe("ast-grep-napi runner — skip paths", () => {
 	beforeEach(() => {
 		vi.resetModules();

--- a/tests/clients/dispatch/runners/ast-grep-napi.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi.test.ts
@@ -138,16 +138,15 @@ describe("ast-grep-napi runner — late-auxiliary dedupe (#2324 F3)", () => {
 		try {
 			const filePath = path.join(env.tmpDir, "file.ts");
 			fs.writeFileSync(filePath, "const x = 1;\n");
-			const pendingAux = await import(
-				"../../../../clients/lsp/pending-aux-coverage.js"
-			);
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
 			pendingAux.resetPendingAuxiliaryCoverage();
 			// Lane 1 arms: the aux-grace wait already found ast-grep silent for
 			// this touch and marked it for turn-end late delivery.
 			pendingAux.markPendingAuxiliaryCoverage(filePath, ["ast-grep"]);
-			expect(
-				pendingAux.hasPendingAuxiliaryCoverage(filePath, "ast-grep"),
-			).toBe(true);
+			expect(pendingAux.hasPendingAuxiliaryCoverage(filePath, "ast-grep")).toBe(
+				true,
+			);
 
 			mockWorkingSgLoad();
 			const mod =
@@ -163,9 +162,9 @@ describe("ast-grep-napi runner — late-auxiliary dedupe (#2324 F3)", () => {
 			// delivered, so the late-auxiliary lane must be consumed — a
 			// pending pair left behind here would redeliver the identical
 			// rule/line at the next turn_end as a duplicate.
-			expect(
-				pendingAux.hasPendingAuxiliaryCoverage(filePath, "ast-grep"),
-			).toBe(false);
+			expect(pendingAux.hasPendingAuxiliaryCoverage(filePath, "ast-grep")).toBe(
+				false,
+			);
 			pendingAux.resetPendingAuxiliaryCoverage();
 		} finally {
 			env.cleanup();

--- a/tests/clients/dispatch/runners/ast-grep-napi.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi.test.ts
@@ -7,13 +7,39 @@ import {
 } from "../../../support/runner-ctx.js";
 import { setupTestEnvironment } from "../../test-utils.js";
 
-const { mockAuxiliaryLspPublished } = vi.hoisted(() => ({
+const { mockAuxiliaryLspPublished, fsSyncOverrides } = vi.hoisted(() => ({
 	mockAuxiliaryLspPublished: vi.fn().mockResolvedValue(false),
+	// #2324 R3-B: `vi.spyOn` cannot redefine a `node:fs` ESM namespace export
+	// ("Module namespace is not configurable"). Route `statSync`/`readFileSync`
+	// through an overridable indirection instead — real `node:fs` by default
+	// for every OTHER test in this file, throwing only when a test sets its
+	// own override, always reset to undefined afterward.
+	fsSyncOverrides: {
+		statSync: undefined as ((...args: unknown[]) => unknown) | undefined,
+		readFileSync: undefined as ((...args: unknown[]) => unknown) | undefined,
+	},
 }));
 
 vi.mock("../../../../clients/lsp/index.js", () => ({
 	hasAuxiliaryLspPublishedForRoot: mockAuxiliaryLspPublished,
 }));
+
+vi.mock("node:fs", async () => {
+	const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+	return {
+		...actual,
+		statSync: (...args: unknown[]) =>
+			fsSyncOverrides.statSync
+				? fsSyncOverrides.statSync(...args)
+				: // biome-ignore lint/suspicious/noExplicitAny: node:fs overload set
+					(actual.statSync as any)(...args),
+		readFileSync: (...args: unknown[]) =>
+			fsSyncOverrides.readFileSync
+				? fsSyncOverrides.readFileSync(...args)
+				: // biome-ignore lint/suspicious/noExplicitAny: node:fs overload set
+					(actual.readFileSync as any)(...args),
+	};
+});
 
 // Mock heavy dependencies before importing the runner
 vi.mock("../../../../clients/tool-policy.js", () => ({
@@ -456,6 +482,253 @@ describe("ast-grep-napi runner — aux-runner-findings-lost degradation (#2324 R
 					.find((g) => g.kind === "aux-runner-findings-lost"),
 			).toBeUndefined();
 			ledger.resetDegradationLedger();
+		} finally {
+			env.cleanup();
+		}
+	});
+});
+
+// #2324 R3-B: the R2-A ordering fix depends on the PRODUCER write
+// (`recordNapiFallbackCoverage`) actually firing when napi evaluates rules,
+// and NOT firing on any of napi's early-return skips. The prior round's
+// tests only exercised the CONSUMER side (`hasPendingAuxiliaryCoverage`
+// after a manually pre-marked pair), so no-opping the producer write left
+// every existing test green — this pins the write directly.
+describe("ast-grep-napi runner — napiFallbackCoveredSince producer pin (#2324 R3-B)", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockAuxiliaryLspPublished.mockResolvedValue(false);
+	});
+
+	it("ARM A: records coverage after a real rule evaluation", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-r3b-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			const before = Date.now();
+
+			mockWorkingSgLoad();
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).not.toBe("skipped");
+			expect(pendingAux.napiFallbackCoveredSince(filePath, before)).toBe(true);
+			pendingAux.resetPendingAuxiliaryCoverage();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("ARM B1: does not record coverage when loadSg fails", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-r3b-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			const before = Date.now();
+
+			vi.doMock("@ast-grep/napi", () => {
+				throw new Error("native module failed");
+			});
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+			expect(pendingAux.napiFallbackCoveredSince(filePath, before)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("ARM B2: does not record coverage when the file does not exist", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-r3b-");
+		try {
+			const filePath = path.join(env.tmpDir, "missing.ts");
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			const before = Date.now();
+
+			mockWorkingSgLoad();
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+			expect(pendingAux.napiFallbackCoveredSince(filePath, before)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("ARM B3: does not record coverage when the language grammar is unresolved", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-r3b-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.html");
+			fs.writeFileSync(filePath, "<div>no html export in the mock</div>\n");
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			const before = Date.now();
+
+			mockWorkingSgLoad();
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+			expect(pendingAux.napiFallbackCoveredSince(filePath, before)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("ARM B4: does not record coverage when statSync throws", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-r3b-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			const before = Date.now();
+
+			fsSyncOverrides.statSync = () => {
+				throw new Error("stat failed");
+			};
+			mockWorkingSgLoad();
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+			expect(pendingAux.napiFallbackCoveredSince(filePath, before)).toBe(false);
+		} finally {
+			fsSyncOverrides.statSync = undefined;
+			env.cleanup();
+		}
+	});
+
+	it("ARM B5: does not record coverage when the file exceeds the size cap", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-r3b-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(
+				filePath,
+				`const big = "${"x".repeat(1024 * 1024 + 1)}";\n`,
+			);
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			const before = Date.now();
+
+			mockWorkingSgLoad();
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+			expect(pendingAux.napiFallbackCoveredSince(filePath, before)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("ARM B6: does not record coverage when readFileSync throws", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-r3b-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			const before = Date.now();
+
+			fsSyncOverrides.readFileSync = () => {
+				throw new Error("read failed");
+			};
+			mockWorkingSgLoad();
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+			expect(pendingAux.napiFallbackCoveredSince(filePath, before)).toBe(false);
+		} finally {
+			fsSyncOverrides.readFileSync = undefined;
+			env.cleanup();
+		}
+	});
+
+	it("ARM B7: does not record coverage when the grammar fails to parse", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-r3b-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			const before = Date.now();
+
+			vi.doMock("@ast-grep/napi", () => ({
+				ts: {
+					parse: vi.fn(() => {
+						throw new Error("parse failed");
+					}),
+				},
+			}));
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+			expect(pendingAux.napiFallbackCoveredSince(filePath, before)).toBe(false);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("ARM B8: does not record coverage when the parsed root cannot be read", async () => {
+		const env = setupTestEnvironment("pi-lens-ast-grep-r3b-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+			const pendingAux =
+				await import("../../../../clients/lsp/pending-aux-coverage.js");
+			pendingAux.resetPendingAuxiliaryCoverage();
+			const before = Date.now();
+
+			vi.doMock("@ast-grep/napi", () => ({
+				ts: {
+					parse: vi.fn().mockReturnValue({
+						root: () => {
+							throw new Error("root failed");
+						},
+					}),
+				},
+			}));
+			const mod =
+				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
+			const result = await mod.default.run(
+				createCtx(filePath, { hasTool: async () => false }) as any,
+			);
+			expect(result.status).toBe("skipped");
+			expect(pendingAux.napiFallbackCoveredSince(filePath, before)).toBe(false);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/dispatch/runners/ast-grep-napi.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi.test.ts
@@ -7,19 +7,12 @@ import {
 } from "../../../support/runner-ctx.js";
 import { setupTestEnvironment } from "../../test-utils.js";
 
-const { mockAuxiliaryLspAlive, mockResolveAstGrepNativeExe } = vi.hoisted(
-	() => ({
-		mockAuxiliaryLspAlive: vi.fn().mockResolvedValue(false),
-		mockResolveAstGrepNativeExe: vi.fn().mockReturnValue(undefined),
-	}),
-);
-
-vi.mock("../../../../clients/lsp/index.js", () => ({
-	isAuxiliaryLspAlive: mockAuxiliaryLspAlive,
+const { mockAuxiliaryLspPublished } = vi.hoisted(() => ({
+	mockAuxiliaryLspPublished: vi.fn().mockResolvedValue(false),
 }));
 
-vi.mock("../../../../clients/lsp/wait-policy/index.js", () => ({
-	resolveAstGrepNativeExe: mockResolveAstGrepNativeExe,
+vi.mock("../../../../clients/lsp/index.js", () => ({
+	hasAuxiliaryLspPublishedForRoot: mockAuxiliaryLspPublished,
 }));
 
 // Mock heavy dependencies before importing the runner
@@ -72,23 +65,21 @@ function mockWorkingSgLoad(): void {
 describe("ast-grep-napi runner — LSP supersede gate (#239 Phase 2)", () => {
 	beforeEach(() => {
 		vi.resetModules();
-		mockAuxiliaryLspAlive.mockResolvedValue(false);
-		mockResolveAstGrepNativeExe.mockReturnValue(undefined);
+		mockAuxiliaryLspPublished.mockResolvedValue(false);
 	});
 
-	it("skips when PATH fails but the bundled launcher binary resolves", async () => {
+	it("runs until the bundled LSP completes its first root publication", async () => {
 		const env = setupTestEnvironment("pi-lens-ast-grep-gate-");
 		try {
 			const filePath = path.join(env.tmpDir, "file.ts");
 			fs.writeFileSync(filePath, "const r = arr.sort();\n"); // would match no-sort-without-comparator
-			mockResolveAstGrepNativeExe.mockReturnValue("/bundled/ast-grep.exe");
 			mockWorkingSgLoad();
 			const mod =
 				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
 			const result = await mod.default.run(
 				createCtx(filePath, { hasTool: async () => false }) as any,
 			);
-			expect(result.status).toBe("skipped");
+			expect(result.status).toBe("succeeded");
 			expect(result.diagnostics).toHaveLength(0);
 		} finally {
 			env.cleanup();
@@ -112,12 +103,12 @@ describe("ast-grep-napi runner — LSP supersede gate (#239 Phase 2)", () => {
 		}
 	});
 
-	it("skips when a live ast-grep LSP client is handling the file regardless of PATH", async () => {
+	it("skips after the ast-grep LSP completes its first root publication", async () => {
 		const env = setupTestEnvironment("pi-lens-ast-grep-gate-");
 		try {
 			const filePath = path.join(env.tmpDir, "file.ts");
 			fs.writeFileSync(filePath, "const x = 1;\n");
-			mockAuxiliaryLspAlive.mockResolvedValue(true);
+			mockAuxiliaryLspPublished.mockResolvedValue(true);
 			mockWorkingSgLoad();
 			const mod =
 				await import("../../../../clients/dispatch/runners/ast-grep-napi.js");
@@ -244,8 +235,7 @@ describe("ast-grep-napi runner — skip paths", () => {
 describe("ast-grep-napi runner — real shipped rule", () => {
 	it("loads and matches no-sort-without-comparator through the real YAML parser", async () => {
 		vi.resetModules();
-		mockAuxiliaryLspAlive.mockResolvedValue(false);
-		mockResolveAstGrepNativeExe.mockReturnValue(undefined);
+		mockAuxiliaryLspPublished.mockResolvedValue(false);
 		vi.doUnmock("../../../../clients/dispatch/runners/yaml-rule-parser.js");
 		vi.doUnmock("../../../../clients/package-root.js");
 		// Earlier skip-path cases install per-test NAPI mocks. Replace any

--- a/tests/clients/lsp/auxiliary-publication-gate.test.ts
+++ b/tests/clients/lsp/auxiliary-publication-gate.test.ts
@@ -14,6 +14,31 @@ interface PublicationGateHarness {
 	): Promise<boolean>;
 }
 
+/**
+ * Production-faithful double: `diagnosticsVersion` is the client-GLOBAL
+ * counter (bumped by ANY path's publication); `getDiagnosticsVersionForPath`
+ * is the per-path stamp the gate is REQUIRED to read (client.ts:339-352). A
+ * double that only carries the global counter can't catch a gate that
+ * regresses to reading it — see the sibling-file case below.
+ */
+function makeFakeClient() {
+	const perPath = new Map<string, number>();
+	let global = 0;
+	return {
+		isAlive: () => true,
+		get diagnosticsVersion() {
+			return global;
+		},
+		getDiagnosticsVersionForPath(filePath: string) {
+			return perPath.get(normalizeMapKey(filePath)) ?? 0;
+		},
+		publishFor(filePath: string) {
+			global += 1;
+			perPath.set(normalizeMapKey(filePath), global);
+		},
+	};
+}
+
 describe("auxiliary first-publication gate", () => {
 	it("requires a live root client to publish before it supersedes a fallback", async () => {
 		const env = setupTestEnvironment("pi-lens-aux-publication-gate-");
@@ -22,7 +47,7 @@ describe("auxiliary first-publication gate", () => {
 			fs.writeFileSync(filePath, "const value = 1;\n");
 			const service = new LSPService() as unknown as PublicationGateHarness;
 			service.resolveServerRoot = async () => env.tmpDir;
-			const client = { isAlive: () => true, diagnosticsVersion: 0 };
+			const client = makeFakeClient();
 			service.state.clients.set(
 				`ast-grep:${normalizeMapKey(env.tmpDir)}`,
 				client,
@@ -32,10 +57,43 @@ describe("auxiliary first-publication gate", () => {
 				await service.hasServerPublishedForFileRoot("ast-grep", filePath),
 			).toBe(false);
 
-			client.diagnosticsVersion = 1;
+			client.publishFor(filePath);
 			expect(
 				await service.hasServerPublishedForFileRoot("ast-grep", filePath),
 			).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	// #2324 F1: the gate must answer per FILE, not per client. A client is
+	// shared by every file under its root, so a sibling file's publication
+	// bumping the client-global counter must never satisfy the gate for a
+	// file this server has not published for — that gap left findings
+	// silently lost for the second file (the issue's warm-silence headline).
+	it("does not let a sibling file's publication satisfy the gate for an unpublished file", async () => {
+		const env = setupTestEnvironment("pi-lens-aux-publication-gate-sibling-");
+		try {
+			const fileA = path.join(env.tmpDir, "a.ts");
+			const fileB = path.join(env.tmpDir, "b.ts");
+			fs.writeFileSync(fileA, "const a = 1;\n");
+			fs.writeFileSync(fileB, "const b = 2;\n");
+			const service = new LSPService() as unknown as PublicationGateHarness;
+			service.resolveServerRoot = async () => env.tmpDir;
+			const client = makeFakeClient();
+			service.state.clients.set(
+				`ast-grep:${normalizeMapKey(env.tmpDir)}`,
+				client,
+			);
+
+			client.publishFor(fileA);
+
+			expect(
+				await service.hasServerPublishedForFileRoot("ast-grep", fileA),
+			).toBe(true);
+			expect(
+				await service.hasServerPublishedForFileRoot("ast-grep", fileB),
+			).toBe(false);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/lsp/auxiliary-publication-gate.test.ts
+++ b/tests/clients/lsp/auxiliary-publication-gate.test.ts
@@ -1,0 +1,43 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { LSPService } from "../../../clients/lsp/index.js";
+import { normalizeMapKey } from "../../../clients/path-utils.js";
+import { setupTestEnvironment } from "../test-utils.js";
+
+interface PublicationGateHarness {
+	state: { clients: Map<string, unknown> };
+	resolveServerRoot: () => Promise<string>;
+	hasServerPublishedForFileRoot(
+		serverId: string,
+		filePath: string,
+	): Promise<boolean>;
+}
+
+describe("auxiliary first-publication gate", () => {
+	it("requires a live root client to publish before it supersedes a fallback", async () => {
+		const env = setupTestEnvironment("pi-lens-aux-publication-gate-");
+		try {
+			const filePath = path.join(env.tmpDir, "file.ts");
+			fs.writeFileSync(filePath, "const value = 1;\n");
+			const service = new LSPService() as unknown as PublicationGateHarness;
+			service.resolveServerRoot = async () => env.tmpDir;
+			const client = { isAlive: () => true, diagnosticsVersion: 0 };
+			service.state.clients.set(
+				`ast-grep:${normalizeMapKey(env.tmpDir)}`,
+				client,
+			);
+
+			expect(
+				await service.hasServerPublishedForFileRoot("ast-grep", filePath),
+			).toBe(false);
+
+			client.diagnosticsVersion = 1;
+			expect(
+				await service.hasServerPublishedForFileRoot("ast-grep", filePath),
+			).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
+});

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -2080,3 +2080,105 @@ describe('#1533 — silent auxiliary honesty on clientScope "all"', () => {
 		);
 	});
 });
+
+/**
+ * #2324 R2-A — the actual production ordering: the ast-grep napi fallback's
+ * Gate-B check is a synchronous map lookup, while the aux-grace wait that
+ * decides whether to mark a pending late-auxiliary pair runs for up to its
+ * own grace budget (here, up to the aux's own wait). By the time this wait
+ * is ready to decide, THIS touch's napi run (if any) has already recorded
+ * its coverage — the wait consults that record before marking. A clear
+ * issued from napi's side (the F3 fix's first attempt) cannot rely on this
+ * ordering: the mark it would race has not been written yet.
+ */
+describe("R8 — aux grace: ast-grep napi/aux-grace mark ordering (#2324 R2-A)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.resetModules();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+		logLatency.mockReset();
+		delete process.env.PI_LENS_AUX_GRACE_MS;
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		delete process.env.PI_LENS_AUX_GRACE_MS;
+	});
+
+	it("does not mark a pending pair when napi already covered this touch before the wait decides", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		// Dynamically imported AFTER vi.resetModules() so this is the SAME
+		// module instance LSPService resolves internally — a static top-level
+		// import would bind to a stale pre-reset instance.
+		const pendingAux =
+			await import("../../../clients/lsp/pending-aux-coverage.js");
+		pendingAux.resetPendingAuxiliaryCoverage();
+		const service = new LSPService();
+		getServersForFileWithConfig.mockReturnValue([
+			makePrimaryServer("ts-primary"),
+			makeAuxServer("ast-grep"),
+		]);
+		// ast-grep's own wait settles SILENTLY (no publish) well inside its
+		// budget — the shape that, absent this fix, marks a pending pair.
+		createLSPClient
+			.mockResolvedValueOnce(makeClient(800, [], { serverId: "ts-primary" }))
+			.mockResolvedValueOnce(makeClient(900, [], { serverId: "ast-grep" }));
+		await service.getClientsForFile(FILE);
+
+		const touchPromise = service.touchFile(FILE, "content", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["ast-grep"],
+			collectDiagnostics: true,
+			diagnostics: "document",
+		});
+		// Gate B's napi runner is dispatched CONCURRENTLY with this wait
+		// (dispatcher.ts's Promise.all groups) and settles almost immediately
+		// — a synchronous map lookup plus a fast rule evaluation. Reproduced
+		// here by recording napi's coverage right after the touch starts,
+		// well before the aux's own ~900ms wait or the grace ceiling resolve.
+		pendingAux.recordNapiFallbackCoverage(FILE);
+		await vi.advanceTimersByTimeAsync(3000);
+		await touchPromise;
+
+		expect(pendingAux.hasPendingAuxiliaryCoverage(FILE, "ast-grep")).toBe(
+			false,
+		);
+		pendingAux.resetPendingAuxiliaryCoverage();
+	});
+
+	it("still marks the pair when napi's coverage predates this touch (stale record)", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const pendingAux =
+			await import("../../../clients/lsp/pending-aux-coverage.js");
+		pendingAux.resetPendingAuxiliaryCoverage();
+		const service = new LSPService();
+		getServersForFileWithConfig.mockReturnValue([
+			makePrimaryServer("ts-primary"),
+			makeAuxServer("ast-grep"),
+		]);
+		createLSPClient
+			.mockResolvedValueOnce(makeClient(800, [], { serverId: "ts-primary" }))
+			.mockResolvedValueOnce(makeClient(900, [], { serverId: "ast-grep" }));
+		await service.getClientsForFile(FILE);
+
+		// napi covered this file for an EARLIER revision, well before this
+		// touch even starts — a stale record must not suppress a mark this
+		// touch's silent server genuinely needs delivered later.
+		pendingAux.recordNapiFallbackCoverage(FILE);
+		await vi.advanceTimersByTimeAsync(5000);
+
+		const touchPromise = service.touchFile(FILE, "content-2", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["ast-grep"],
+			collectDiagnostics: true,
+			diagnostics: "document",
+		});
+		await vi.advanceTimersByTimeAsync(3000);
+		await touchPromise;
+
+		expect(pendingAux.hasPendingAuxiliaryCoverage(FILE, "ast-grep")).toBe(true);
+		pendingAux.resetPendingAuxiliaryCoverage();
+	});
+});

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -2148,6 +2148,68 @@ describe("R8 — aux grace: ast-grep napi/aux-grace mark ordering (#2324 R2-A)",
 		pendingAux.resetPendingAuxiliaryCoverage();
 	});
 
+	// #2324 R3-A: the issue's own 68ms race, reproduced against the SPECIFIC
+	// baseline the guard uses. Nothing is pre-warmed — `createLSPClient`
+	// itself takes real (fake-timer) time to resolve, modeling the
+	// spawn+handshake `getClientForFile`/`getAuxiliaryClientsForFile` do on a
+	// COLD touch. `waitStartedAt` (clients/lsp/index.ts) is captured only
+	// AFTER that spawn work resolves — well after this touch's own entry —
+	// so a napi record landing in that spawn window predates `waitStartedAt`
+	// even though it postdates `touchFile`'s own start. Baselining on
+	// `startedAt` (stamped at entry, before any spawn) is what lets a
+	// same-touch napi record survive that window.
+	it("does not mark a pending pair when napi's coverage lands during a COLD spawn's handshake window", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const pendingAux =
+			await import("../../../clients/lsp/pending-aux-coverage.js");
+		pendingAux.resetPendingAuxiliaryCoverage();
+		const service = new LSPService();
+		getServersForFileWithConfig.mockReturnValue([
+			makePrimaryServer("ts-primary"),
+			makeAuxServer("ast-grep"),
+		]);
+		const COLD_SPAWN_HANDSHAKE_MS = 400;
+		// No pre-warm call here — this IS the cold spawn. `createLSPClient`
+		// itself is delayed, so `waitStartedAt` (captured only after both
+		// spawns resolve) lands ~400ms after touchFile's own entry.
+		createLSPClient.mockImplementation(
+			(options: { serverId?: string }) =>
+				new Promise((resolve) =>
+					setTimeout(
+						() =>
+							resolve(
+								options?.serverId === "ast-grep"
+									? makeClient(900, [], { serverId: "ast-grep" })
+									: makeClient(100, [], { serverId: "ts-primary" }),
+							),
+						COLD_SPAWN_HANDSHAKE_MS,
+					),
+				),
+		);
+
+		const touchPromise = service.touchFile(FILE, "cold-content", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["ast-grep"],
+			collectDiagnostics: true,
+			diagnostics: "document",
+		});
+		// Gate B's napi runner is dispatched CONCURRENTLY with the WHOLE
+		// touch (dispatcher.ts's Promise.all groups), not just with the LSP
+		// wait — it settles almost immediately regardless of how long THIS
+		// touch's own client spawn takes. Recording at 10ms lands well
+		// inside the 400ms cold-spawn handshake window, before
+		// `waitStartedAt` is ever captured, but after `touchFile`'s entry.
+		await vi.advanceTimersByTimeAsync(10);
+		pendingAux.recordNapiFallbackCoverage(FILE);
+		await vi.advanceTimersByTimeAsync(5000);
+		await touchPromise;
+
+		expect(pendingAux.hasPendingAuxiliaryCoverage(FILE, "ast-grep")).toBe(
+			false,
+		);
+		pendingAux.resetPendingAuxiliaryCoverage();
+	});
+
 	it("still marks the pair when napi's coverage predates this touch (stale record)", async () => {
 		const { LSPService } = await import("../../../clients/lsp/index.js");
 		const pendingAux =

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -244,11 +244,12 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 	{
 		id: "lsp:pending-aux-coverage",
 		module: "lsp/pending-aux-coverage.ts",
-		state: "pending Map (filePath,serverId) pairs",
+		state:
+			"pending Map (filePath,serverId) pairs; napiFallbackCoverage Map (filePath) (#2324 R2-A)",
 		policy: "session_start",
 		resetName: "resetPendingAuxiliaryCoverage",
 		reason:
-			"#2026: pending auxiliary baselines are keyed by cwd and become unreachable when the session generation advances.",
+			"#2026: pending auxiliary baselines are keyed by cwd and become unreachable when the session generation advances. #2324 R2-A: napiFallbackCoverage records WHEN the ast-grep napi fallback last covered a file, so the aux-grace wait can skip marking a duplicate pending pair — a cross-session leftover would wrongly suppress a legitimate mark in the new session.",
 	},
 	// ── The named population from #1635 ──────────────────────────────────────
 	{
@@ -1111,7 +1112,10 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	// #2007 added `gitToplevelMemo`, the worktree-identity cache (3 → 4). It
 	// is registered above and cleared by the same `resetOpaqueMutationState`.
 	"opaque-mutation-scan.ts": 4,
-	"lsp/pending-aux-coverage.ts": 1,
+	// #2324 R2-A added `napiFallbackCoverage`, the napi-run hand-off map
+	// (1 → 2). Registered above and cleared by the same
+	// `resetPendingAuxiliaryCoverage`.
+	"lsp/pending-aux-coverage.ts": 2,
 	"lsp/jvm-runtime.ts": 0,
 	"lsp/session-roots.ts": 1,
 	"lsp/spawn-history.ts": 1,


### PR DESCRIPTION
## Summary

- Keep the ast-grep NAPI fallback active until the live ast-grep client has
  completed its first diagnostic publication for the matching FILE.
- Replace binary/process availability as Gate B evidence with per-file
  publication evidence from the existing root client map.
- Remove the binary-resolution and PATH probes from the dispatch hot path.
- Dedupe the napi fallback against the late-auxiliary delivery lane so the
  same finding cannot arrive twice, with the decision made on the side that
  knows the outcome, not raced against it.

## Phase 1 measurement

The retained 46-hour `latency.log` and `latency.log.1` window contains 196
answered-or-silent ast-grep waits after the issue cutoff. Answered waits have a
1 ms median, 281 ms p75, 789 ms p90, and 985 ms p95. Silent waits have an 833 ms
median, 1,628 ms p75, 2,292 ms p90, and 3,230 ms p95. Only 15/60 silent waits
reach at least 95% of their budget; 32/60 end below half-budget.

As a warm-path proxy, excluding the first three ast-grep waits per process
leaves 121 answered, 46 silent, and one deferred wait. Warm answered waits have
a 1 ms median, 271 ms p75, and 985 ms p95. Warm silent waits have an 819 ms
median, 1,398 ms p75, and 3,004 ms p95. Only 11/46 warm silent waits reach at
least 95% of budget; 25/46 end below half-budget. Most warm silence is therefore
real non-publication after early request settlement, not a 1.8-second budget
miss. Raising the budget would retain silent loss and increase latency.

## Review round 2 (2026-08-28)

The reviewer found five issues after the first pass. All five are fixed here.

**F1 (blocking) — the gate read the wrong grain.** The check at
`clients/lsp/index.ts` used `client.diagnosticsVersion > 0`, the client-GLOBAL
counter. Any sibling file's publication on the same client satisfied the gate
for a file the server never touched, leaving napi skipped and its findings
lost — the issue's headline warm-silence case, unfixed by the first pass.
Fixed by reading `client.getDiagnosticsVersionForPath(filePath)`, the per-path
stamp the `LSPClient` interface already documents as REQUIRED for this exact
reason (`client.ts:339-352`). AGENTS.md's invariant text now says per-file,
not root-grain.

**F3 (high) — napi and the late-auxiliary lane could both deliver the same
finding.** Both arm on the same "no publication evidence yet" condition for
the same file. First attempt: napi clears the pending pair when it runs.
Round 3 found this ordering-broken (see R2-A below); the final fix moves the
decision into the aux-grace wait itself.

**F4 — the test double didn't carry the per-file axis.** Replaced with a
double tracking both the client-global counter and a per-path map.

**F2 — the residual "published once, silent now" gap.** A bounded
`aux-runner-findings-lost` degradation records the loss instead of a silent
drop.

**F5 — deterministic red proofs.** Confirmed `resolveAstGrepNativeExe` is not
referenced anywhere in the gate path — only in `clients/lsp/server.ts`'s real
LSP spawn and in unrelated runner test files.

## Review round 3 (2026-08-28)

Three blocking findings plus two hygiene items on the round-2 fix, all
probe-proven by the reviewer. Fixed here.

**R2-A (blocking) — the F3 clear raced a mark that lands later, and lost.**
`clearPendingAuxiliaryCoverage` at the TOP of napi's run and the pending-pair
MARK at the END of the aux-grace wait (`clients/lsp/index.ts`) run in
DIFFERENT code paths invoked concurrently by `dispatcher.ts`'s
`Promise.all` groups. Napi's Gate-B check is a synchronous map lookup; the
aux-grace wait takes up to its own grace budget (up to ~1800ms for ast-grep).
The clear always executes and returns first; the mark, if the wait decides to
write one, lands after — so the clear can never remove it, and the round-2
test only passed because it marked the pair BEFORE calling the runner, the
reverse of production order.

Fixed by moving the decision to the side that knows the outcome (option (a)
of the three the reviewer offered): napi now records, via a new bounded
hand-off in `pending-aux-coverage.ts`
(`recordNapiFallbackCoverage`/`napiFallbackCoveredSince`), WHEN it last
actually evaluated rules for a file. The aux-grace wait's own mark decision
(`clients/lsp/index.ts`, the `collectLaterServerIds` filter) now consults
that record, keyed against its OWN wait-start timestamp, before it ever
marks a pending pair for ast-grep. Chose this over (b) clear-at-end-of-
dispatch or (c) confirmation-only delivery because the wait already runs
strictly after napi's synchronous check settles — it is the one place that
can see napi's outcome for THIS touch without inventing new synchronization.
`clearPendingAuxiliaryCoverage` stays, but now only removes a LEFTOVER pair
from an EARLIER touch, which is a safe and separate cleanup (see R2-C).

Red proof (mark-after-napi ordering) — new test in
`tests/clients/lsp/service-aux-grace.test.ts` drives a REAL `touchFile` with
a silent ast-grep auxiliary, records napi's coverage right after the touch
starts (reproducing napi's near-instant Gate-B settle vs. the wait's ~900ms
own budget), then asserts no pending pair was marked. Disabling the
`napiFallbackCoveredSince` guard in the wait's filter:

```
FAIL tests/clients/lsp/service-aux-grace.test.ts > R8 — aux grace: ast-grep
napi/aux-grace mark ordering (#2324 R2-A) > does not mark a pending pair
when napi already covered this touch before the wait decides
AssertionError: expected true to be false
- Expected: false
+ Received: true
  at tests/clients/lsp/service-aux-grace.test.ts:2145:68
```

**R2-B (blocking) — the clear sat before napi's seven early skip returns.**
A zero-finding napi run (load failure, missing file, unresolved language,
stat/size/read/parse failure) destroyed the LSP's legitimate late delivery
for a file napi never actually covered — the reviewer's probe: an `.html`
file the napi build has no parser for. Fixed by moving the
record/clear past EVERY early-return skip, right before rule evaluation
starts — a run that never reaches that point did not cover the file, so it
must not consume anything.

Red proof (zero-finding preservation) — mark a pending pair, then run napi
against an `.html` file whose mocked `@ast-grep/napi` module has no `html`
export (`getLang` returns undefined, matching a build that dropped a
grammar, #2215). Moving the record/clear back to Gate B's decision point:

```
FAIL tests/clients/dispatch/runners/ast-grep-napi.test.ts > ast-grep-napi
runner — late-auxiliary dedupe (#2324 F3/R2) > preserves a pending
late-auxiliary pair when napi never reaches rule evaluation
AssertionError: expected false to be true
- Expected: true
+ Received: false
  at tests/clients/dispatch/runners/ast-grep-napi.test.ts:215:73
```

**R2-C (blocking) — the degradation record was vacuous and its reason was
false.** No test referenced `aux-runner-findings-lost`, so the branch could
be deleted with the suite staying green. The reason string also claimed
"this touch's aux-grace wait found no fresh evidence" — but R2-A's corrected
ordering proves a pending pair visible at Gate B's synchronous skip point can
ONLY be a LEFTOVER from an EARLIER touch (this touch's own mark, if any,
lands strictly later). Fixed: the reason now says exactly that, and
`aux-runner-findings-lost` is added to the `DegradationKind` catalog at
`degradation-ledger.ts:23` with a doc comment matching every sibling entry
(it previously bypassed the catalog via the `kind: unknown` field).

Red proof (record branch) — new tests assert the ledger group fires with the
corrected reason (positive) and stays absent on a clean skip (negative
control). Neutering the record branch:

```
FAIL tests/clients/dispatch/runners/ast-grep-napi.test.ts > ast-grep-napi
runner — aux-runner-findings-lost degradation (#2324 R2-C) > records the
loss when Gate B skips on a leftover pending pair
AssertionError: expected undefined to be defined
  at tests/clients/dispatch/runners/ast-grep-napi.test.ts:421:18
```

**R2-D — closes vs. refs.** All three round-3 blockers are fixed and
red-proved. Mapping to #2324's acceptance criteria:

1. "On `outcome:"silent"` the skipped runner re-runs, OR the loss becomes a
   bounded degradation record naming file and server" — satisfied via
   `aux-runner-findings-lost` (subject `"ast-grep"`, reason names the file),
   now correctly scoped to the leftover-pair case R2-A's ordering proves is
   the only shape reachable there.
2. "Gate B does not skip on a server that has not completed its first
   publication for the root" — satisfied by the F1 per-file fix; R2-A/B keep
   the F3 dedupe from reintroducing loss through a duplicate-delivery
   side-channel.
3. "Test reds on pre-fix code" — satisfied; all red proofs above and in
   round 2 are quoted from real runs on mutated/reverted code.
4. "The warm-path 27% silence gets its own measurement before the fix design
   is fixed" — satisfied by the Phase 1 measurement section.

Keeping `Closes #2324`.

**R2-E — restored `## Test assessment`.** Dropped in the round-2 body
rewrite; restored below with the round-3/4 additions folded in.

## Review round 4 (2026-08-28)

No release pressure — landed right, not fast. Two blocking findings, both
probe-proven, both fixed on the same branch.

**R3-A (blocking) — the R2-A ordering fix still raced on a COLD touch.**
`napiFallbackCoveredSince` compared against `waitStartedAt`
(`clients/lsp/index.ts`), captured only AFTER `touchFile` awaits its client
spawn+handshake (`getClientForFile`/`getAuxiliaryClientsForFile`, or
`getClientsForFile` on the `"all"` scope). On a genuinely cold touch — no
warm client pool — that handshake itself can take long enough that napi's
concurrent record (a synchronous Gate-B check plus fast rule evaluation)
lands BEFORE `waitStartedAt` even exists. The guard then reads "not
covered" and marks a pending pair anyway. This is the issue's own 68ms race
trace, reproduced exactly: the round-3 test only passed because it
pre-warmed the client fleet via `service.getClientsForFile(FILE)` before
starting the touch, which a real cold touch never does.

Fixed by baselining on `startedAt` instead of `waitStartedAt` — `startedAt`
is stamped at `touchFile`'s own entry, before ANY spawn work, so it is the
earliest instant this touch's own napi run could possibly predate. It still
excludes a stale record from an EARLIER touch, which is all the staleness
guard needs (proved by the existing "stale record" test, unchanged and
still green).

Red proof (cold-touch, no pre-warm, delayed `createLSPClient`, napi's
record landing before the spawn resolves) — reverting the baseline back to
`waitStartedAt`:

```
FAIL tests/clients/lsp/service-aux-grace.test.ts > R8 — aux grace: ast-grep
napi/aux-grace mark ordering (#2324 R2-A) > does not mark a pending pair
when napi's coverage lands during a COLD spawn's handshake window
AssertionError: expected true to be false
- Expected: false
+ Received: true
  at tests/clients/lsp/service-aux-grace.test.ts:2207:68
```

**R3-B (blocking) — the producer write itself was vacuous.** No test
asserted that `recordNapiFallbackCoverage` (`ast-grep-napi.ts:1036`) ever
fires — the round-2/3 tests all pre-marked the pending pair by hand and
asserted only the CONSUMER side. No-opping the write left all 2347 tests
green. Fixed by pinning the write directly: `napiFallbackCoveredSince`
reads `true` after a real rule evaluation (ARM A), and `false` after EACH
of napi's seven early-return skip paths (ARM B1–B8: `loadSg` failure,
missing file, unresolved language, `statSync` throw, size cap,
`readFileSync` throw, grammar parse failure, parsed-root read failure).

Red proof (write no-opped):

```
FAIL tests/clients/dispatch/runners/ast-grep-napi.test.ts > ast-grep-napi
runner — napiFallbackCoveredSince producer pin (#2324 R3-B) > ARM A:
records coverage after a real rule evaluation
AssertionError: expected false to be true
- Expected: true
+ Received: false
  at tests/clients/dispatch/runners/ast-grep-napi.test.ts:520:66
```

Keeping `Closes #2324` — the reviewer judged the acceptance criteria
substantially met once R3-A lands, and it now has.

## Tests

- `ast-grep-napi.test.ts`: proves the fallback runs before first publication
  and skips after publication (F1); clears a leftover pending pair once it
  actually evaluates rules but preserves one when it never reaches
  evaluation (R2-B); records `aux-runner-findings-lost` on a leftover-pair
  skip and stays silent on a clean skip (R2-C); pins the producer write
  firing after a real evaluation and staying silent across all seven early
  skips (R3-B).
- `auxiliary-publication-gate.test.ts`: proves a live root client at
  diagnostic version zero is not ready, becomes ready at its first
  per-file publication, and that a SIBLING file's publication does not
  satisfy the gate (F1).
- `service-aux-grace.test.ts`: proves the aux-grace wait does not mark a
  pending pair when napi already covered the touch, including on a COLD
  touch whose client spawn delays `waitStartedAt` past napi's own record
  (R3-A), and that a STALE napi-coverage record from an earlier touch does
  not wrongly suppress a genuine mark.

### Test assessment

- `ast-grep-napi.test.ts` uniquely pins dispatch through the real runner
  gate, the leftover-vs-fresh pending-pair distinction (R2-B), the
  degradation record (R2-C), and the producer-write branch coverage
  (R3-B); no existing test becomes redundant.
- `service-aux-grace.test.ts`'s cold-touch case uniquely pins the baseline
  choice (`startedAt` vs. `waitStartedAt`) against a genuinely delayed
  client spawn — no existing test in that file exercises a cold,
  non-pre-warmed spawn combined with `pending-aux-coverage.ts` at all.
- `auxiliary-publication-gate.test.ts` uniquely pins the root client's
  zero-to-one publication transition and the per-file sibling-file case
  (F1); no existing test becomes redundant.

Targeted, this round: `npx vitest run tests/clients/dispatch/runners/ast-grep-napi.test.ts tests/clients/lsp/auxiliary-publication-gate.test.ts tests/clients/lsp/service-aux-grace.test.ts tests/clients/dispatch/plan-exposure.test.ts tests/clients/lsp/late-auxiliary-findings.test.ts tests/clients/lsp/pending-aux-coverage.test.ts tests/clients/session-state-conformance.test.ts` — 195 passed.

Governance sweeps: `delivery-surface-ratchet`, `finding-delivery-gate`,
`bounded-telemetry-sweep`, `bus-producer-coverage`, `deps-centralization`,
`freshness-sweep`, `managed-tool-seam-coverage`, `profiling-coverage`,
`module-instance-coverage`, `sweep-floor-coverage` — 83 passed.

Gate: `npm run lint`. Format: `npx oxfmt` on changed files. Full suite
deferred to CI.

## Blast radius

The changed public seam (`hasServerPublishedForFileRoot` /
`hasAuxiliaryLspPublishedForRoot`) has one production caller:
`ast-grep-napi.run`. The per-file read costs one extra map lookup inside the
same client object already fetched for `isAlive()` — no new allocation, no
new I/O.

Round 3 adds one new bounded map (`napiFallbackCoverage` in
`pending-aux-coverage.ts`, capped at 50 entries, same eviction shape as the
existing `pending` store) and one new read (`napiFallbackCoveredSince`) on
the aux-grace wait's existing per-outcome filter — no new process, timer, or
unbounded state. Registered in `tests/support/session-state-registry.ts` and
cleared by the same `resetPendingAuxiliaryCoverage` session-boundary reset
the existing store already used.

Round 4 changes only which existing, already-in-scope local variable the
read is baselined against (`startedAt` instead of `waitStartedAt`) — no new
state, map, or read added.

## Class sweep

- ast-grep: confirmed Gate-B member, fixed here (grain, dedupe ordering, and
  skip-vacuity).
- opengrep, typos, zizmor: not Gate-B members (no dispatch fallback runner
  whose findings a publication gate can skip) — unchanged from the first
  pass's sweep, re-verified this round.

## Observability

- `late_auxiliary_findings` remains the delayed-LSP delivery record; the
  R2-A ordering fix is what actually keeps it from double-counting napi's
  own delivery (the round-2 fix's dedupe did not, in production).
- `aux-runner-findings-lost` (kind), subject `"ast-grep"`, for the residual
  leftover-pair case (F2/R2-C), now in the `DegradationKind` catalog and
  covered by a direct test.

Closes #2324

