### PR TITLE
style: format ci-failure-classifier (refs #2318)

### DIFF
--- a/scripts/lib/ci-failure-classifier.mjs
+++ b/scripts/lib/ci-failure-classifier.mjs
@@ -946,7 +946,9 @@ export async function commentClassificationFailure({
 	// Same untrusted-text rule as buildCommentBody: the error message can
 	// carry GitHub API response text, which is attacker-influenced on the
 	// same axis as job logs (mentions, HTML comments).
-	const detail = sanitizeCommentDetail(rawDetail.replace(/\s+/g, " ").slice(0, 500));
+	const detail = sanitizeCommentDetail(
+		rawDetail.replace(/\s+/g, " ").slice(0, 500),
+	);
 	const body =
 		`ci-classifier: classification failed; no rerun was triggered: ${detail} ` +
 		buildMarker(sha, "false");


### PR DESCRIPTION
Whitespace-only oxfmt pass on scripts/lib/ci-failure-classifier.mjs. The #2320 maintainer delta ran lint but skipped oxfmt on the touched file, leaving the advisory format check red on master for every subsequent PR. No behavior change; no fragment needed for a format-only fix per repo precedent (style commits).