### PR TITLE
fix(ci): normalize flattened PR bodies in lint (refs #2145)

### DIFF
--- a/.changelog/2145-escaped-newline-body-repair.md
+++ b/.changelog/2145-escaped-newline-body-repair.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Normalize escaped-newline flattened PR bodies for checking (refs #2145)** — a body can arrive with the literal two-character sequence `\\n` (or `\\r\\n`) standing in for a real line break, burying close keywords and section headings. The shared live-body read seam restores high-confidence joins only in memory, warns that the original body was not edited, and preserves genuine `\\n` content inside inline code spans. Strict live-body fetch failures remain fail-closed for close-keyword checks.
+- **Normalize escaped-newline flattened PR bodies for checking (refs #2145)** — a body can arrive with the literal two-character sequence `\\n` (or `\\r\\n`) standing in for a real line break, burying close keywords and section headings. The shared live-body read seam restores high-confidence joins only in memory, warns that the original body was not edited, and preserves genuine `\\n` content inside inline code spans. Strict live-body fetch failures remain fail-closed for close-keyword checks. This change withdraws the auto-repair behavior shipped in v4.1.3; the checks never edit pull request bodies.

--- a/.changelog/2145-escaped-newline-body-repair.md
+++ b/.changelog/2145-escaped-newline-body-repair.md
@@ -1,0 +1,6 @@
+---
+issue: 2145
+type: fix
+---
+
+- **Normalize escaped-newline flattened PR bodies for checking (refs #2145)** — a body can arrive with the literal two-character sequence `\\n` (or `\\r\\n`) standing in for a real line break, burying close keywords and section headings. The shared live-body read seam restores high-confidence joins only in memory, warns that the original body was not edited, and preserves genuine `\\n` content inside inline code spans. Strict live-body fetch failures remain fail-closed for close-keyword checks.

--- a/.changelog/2145-escaped-newline-body-repair.md
+++ b/.changelog/2145-escaped-newline-body-repair.md
@@ -1,6 +1,5 @@
 ---
-issue: 2145
-type: fix
+section: Fixed
 ---
 
 - **Normalize escaped-newline flattened PR bodies for checking (refs #2145)** — a body can arrive with the literal two-character sequence `\\n` (or `\\r\\n`) standing in for a real line break, burying close keywords and section headings. The shared live-body read seam restores high-confidence joins only in memory, warns that the original body was not edited, and preserves genuine `\\n` content inside inline code spans. Strict live-body fetch failures remain fail-closed for close-keyword checks.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
     timeout-minutes: 5
     # Advisory to start: this job is not in required-checks branch protection.
     # A finding stays visible as a red check without blocking a merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -939,17 +939,16 @@ smell warnings count only the current session, or a 24-hour fallback window
 when no session boundary is available; explicit health remains separately
 labeled. (#1432)
 
-The PR body advisory lint may auto-repair only clearly flattened bodies: two or
+The PR body checks normalize only clearly flattened bodies in memory: two or
 more inline template headings, at most two physical newlines, and a minimum
 body length. Detection refuses bodies with escape-loss markers, while the
-post-split structural guard compares repaired heading count with distinct
-template-section count and refuses inconsistent structures. Repair only splits
-inline headings
-whose preceding text ends at body start or sentence-ending punctuation.
-`repairFlattenedBody` is idempotent via its detection short-circuit and must
-pass `lintPrBody` before `patchLivePrBody` writes through the GitHub API; failed,
-stale, or uncheckable repairs report the original errors and never write. The workflow grants
-`pull-requests: write` only to the PR body lint job. (#2145)
+post-split structural guard compares normalized heading count with distinct
+template-section count and refuses inconsistent structures. Normalization only
+splits inline headings whose preceding text ends at body start or
+sentence-ending punctuation. `normalizePrBodyForChecking` returns the body and
+the normalization verdict together, so callers never reclassify a stale event
+payload after checking the live body. The workflow grants the advisory lint
+read-only pull-request access and never edits contributor text. (#2145)
 
 Message-end attribution uses a bounded two-slot session anchor. A primary
 `session_start` rotates `lastStableSessionId` into `previousSessionId` because

--- a/scripts/check-close-keywords.mjs
+++ b/scripts/check-close-keywords.mjs
@@ -89,7 +89,7 @@ export async function lintPullRequest(
 	// fork PRs hitting a transient 5xx).
 	let body;
 	try {
-		body = await fetchLivePrBody(pullRequest, fetchImpl);
+		({ body } = await fetchLivePrBody(pullRequest, fetchImpl));
 	} catch (error) {
 		const reason = error instanceof Error ? error.message : String(error);
 		console.error(
@@ -163,7 +163,7 @@ export async function verifyMergedPullRequest(
 	// failure here fails the check LOUD instead.
 	let liveBody;
 	try {
-		liveBody = await fetchLivePrBody(pullRequest, fetchImpl);
+		({ body: liveBody } = await fetchLivePrBody(pullRequest, fetchImpl));
 	} catch (error) {
 		const reason = error instanceof Error ? error.message : String(error);
 		console.error(

--- a/scripts/check-pr-body.d.mts
+++ b/scripts/check-pr-body.d.mts
@@ -16,11 +16,11 @@ export declare function lintPrBody(
 export declare function fetchLivePrBody(
 	payloadPr: { number: number; body?: string | null },
 	fetchImpl: typeof fetch,
-): Promise<string>;
+): Promise<{ body: string; normalized: boolean }>;
 export declare function resolveLivePrBody(
 	payloadPr: { number: number; body?: string | null },
 	fetchImpl?: typeof fetch,
-): Promise<string>;
+): Promise<{ body: string; normalized: boolean }>;
 export declare function resolveTouchesTests(
 	payloadPr: { number: number },
 	fetchImpl?: typeof fetch,

--- a/scripts/check-pr-body.d.mts
+++ b/scripts/check-pr-body.d.mts
@@ -2,6 +2,10 @@ export declare function detectFlattenedBody(body?: string): boolean;
 export declare function repairFlattenedBody(body?: string): string;
 export declare function detectEscapedNewlineBody(body?: string): boolean;
 export declare function repairEscapedNewlineBody(body?: string): string;
+export declare function normalizePrBodyForChecking(
+	body?: string,
+	pullRequestNumber?: number,
+): { body: string; normalized: boolean };
 export declare function lintPrBody(
 	body?: string,
 	options?: { requireTestAssessment?: boolean },
@@ -17,11 +21,6 @@ export declare function resolveLivePrBody(
 	payloadPr: { number: number; body?: string | null },
 	fetchImpl?: typeof fetch,
 ): Promise<string>;
-export declare function patchLivePrBody(
-	payloadPr: { number: number },
-	body: string,
-	fetchImpl?: typeof fetch,
-): Promise<void>;
 export declare function resolveTouchesTests(
 	payloadPr: { number: number },
 	fetchImpl?: typeof fetch,

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -369,7 +369,7 @@ export function lintPrBody(body = "", options = {}) {
  *
  * @param {{ number: number, body?: string | null }} payloadPr
  * @param {typeof fetch} fetchImpl
- * @returns {Promise<string>}
+ * @returns {Promise<{body: string, normalized: boolean}>}
  */
 export async function fetchLivePrBody(payloadPr, fetchImpl) {
 	const token = process.env.GITHUB_TOKEN;
@@ -393,7 +393,7 @@ export async function fetchLivePrBody(payloadPr, fetchImpl) {
 	const data = await response.json();
 	if (data.body !== null && typeof data.body !== "string")
 		throw new Error("GitHub API returned no body");
-	return normalizePrBodyForChecking(data.body ?? "", payloadPr.number).body;
+	return normalizePrBodyForChecking(data.body ?? "", payloadPr.number);
 }
 
 export async function resolveLivePrBody(
@@ -406,8 +406,7 @@ export async function resolveLivePrBody(
 		console.warn(
 			`::warning::Could not fetch the live PR body; using the event payload instead (${error instanceof Error ? error.message : error}).`,
 		);
-		return normalizePrBodyForChecking(payloadPr.body ?? "", payloadPr.number)
-			.body;
+		return normalizePrBodyForChecking(payloadPr.body ?? "", payloadPr.number);
 	}
 }
 
@@ -483,10 +482,7 @@ export async function lintPullRequestEvent(
 	const pullRequest = event.pull_request;
 	if (!pullRequest || !process.env.GITHUB_REPOSITORY)
 		throw new Error("Pull request event and GITHUB_REPOSITORY are required");
-	const sourceBody = pullRequest.body ?? "";
-	const body = await resolveLivePrBody(pullRequest, fetchImpl);
-	const normalized =
-		detectFlattenedBody(sourceBody) || detectEscapedNewlineBody(sourceBody);
+	const { body, normalized } = await resolveLivePrBody(pullRequest, fetchImpl);
 	const requireTestAssessment =
 		(await resolveTouchesTests(pullRequest, fetchImpl)) === true;
 	const result = lintPrBody(body, { requireTestAssessment });

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -156,6 +156,31 @@ export function detectFlattenedBody(body = "") {
 
 const ESCAPED_NEWLINE = /\\r\\n|\\n/g;
 
+function escapedNewlineRangesOutsideCodeSpans(source) {
+	const protectedRanges = [];
+	for (const match of source.matchAll(/(`+)([\s\S]*?)\1/g)) {
+		protectedRanges.push([match.index, match.index + match[0].length]);
+	}
+	return [...source.matchAll(ESCAPED_NEWLINE)]
+		.filter(
+			({ index }) =>
+				!protectedRanges.some(([start, end]) => index >= start && index < end),
+		)
+		.map(({ index, 0: value }) => ({ index, value }));
+}
+
+function replaceEscapedNewlinesOutsideCodeSpans(source) {
+	const replacements = escapedNewlineRangesOutsideCodeSpans(source);
+	if (!replacements.length) return source;
+	let result = "";
+	let cursor = 0;
+	for (const { index, value } of replacements) {
+		result += source.slice(cursor, index) + "\n";
+		cursor = index + value.length;
+	}
+	return result + source.slice(cursor);
+}
+
 /**
  * Detect the sibling flattening shape from the #2058-era class: a worker
  * emits the literal two-or-four character sequence "\n" or "\r\n" where a
@@ -182,11 +207,14 @@ export function detectEscapedNewlineBody(body = "") {
 		return false;
 	const realNewlines = (source.match(/\r\n|\n/g) ?? []).length;
 	if (realNewlines > FLATTENED_BODY_MAX_NEWLINES) return false;
-	const literalNewlines = source.match(ESCAPED_NEWLINE) ?? [];
+	const literalNewlines = escapedNewlineRangesOutsideCodeSpans(source);
 	if (literalNewlines.length < 2) return false;
-	if (source.replace(ESCAPED_NEWLINE, "").includes("\\")) return false;
-	const candidateHeadingLines = source
-		.replace(ESCAPED_NEWLINE, "\n")
+	const normalized = replaceEscapedNewlinesOutsideCodeSpans(source);
+	const unprotected = source
+		.replace(/(`+)([\s\S]*?)\1/g, (span) => " ".repeat(span.length))
+		.replace(ESCAPED_NEWLINE, "");
+	if (unprotected.includes("\\")) return false;
+	const candidateHeadingLines = normalized
 		.split("\n")
 		.filter((line) =>
 			new RegExp(`^\\s*#{2,4}\\s+(?:${REPAIR_HEADING_PATTERN})\\s*$`, "i").test(
@@ -204,7 +232,29 @@ export function detectEscapedNewlineBody(body = "") {
 export function repairEscapedNewlineBody(body = "") {
 	const source = String(body ?? "");
 	if (!detectEscapedNewlineBody(source)) return source;
-	return source.replace(ESCAPED_NEWLINE, "\n");
+	return replaceEscapedNewlinesOutsideCodeSpans(source);
+}
+
+/**
+ * Normalize only for linting. The body remains unchanged on GitHub: workers
+ * should fix their own PR text, while this read-only path makes a clear
+ * warning when a high-confidence flattened-body repair lets checks proceed.
+ */
+export function normalizePrBodyForChecking(body = "", pullRequestNumber) {
+	const source = String(body ?? "");
+	for (const { detect, repair } of [
+		{ detect: detectFlattenedBody, repair: repairFlattenedBody },
+		{ detect: detectEscapedNewlineBody, repair: repairEscapedNewlineBody },
+	]) {
+		if (!detect(source)) continue;
+		const normalized = repair(source);
+		if (normalized === source) continue;
+		console.warn(
+			`::warning::Normalized flattened PR body for #${pullRequestNumber ?? "?"} for checking only; the original body was not edited.`,
+		);
+		return { body: normalized, normalized: true };
+	}
+	return { body: source, normalized: false };
 }
 
 /** Repair only a body already proven to have the flattened shape. */
@@ -343,7 +393,7 @@ export async function fetchLivePrBody(payloadPr, fetchImpl) {
 	const data = await response.json();
 	if (data.body !== null && typeof data.body !== "string")
 		throw new Error("GitHub API returned no body");
-	return data.body ?? "";
+	return normalizePrBodyForChecking(data.body ?? "", payloadPr.number).body;
 }
 
 export async function resolveLivePrBody(
@@ -356,36 +406,9 @@ export async function resolveLivePrBody(
 		console.warn(
 			`::warning::Could not fetch the live PR body; using the event payload instead (${error instanceof Error ? error.message : error}).`,
 		);
-		return payloadPr.body ?? "";
+		return normalizePrBodyForChecking(payloadPr.body ?? "", payloadPr.number)
+			.body;
 	}
-}
-
-export async function patchLivePrBody(
-	payloadPr,
-	body,
-	fetchImpl = globalThis.fetch,
-) {
-	const token = process.env.GITHUB_TOKEN;
-	if (!token) throw new Error("GITHUB_TOKEN is not set");
-	const apiUrl = process.env.GITHUB_API_URL;
-	const repository = process.env.GITHUB_REPOSITORY;
-	if (!apiUrl || !repository)
-		throw new Error("GITHUB_API_URL or GITHUB_REPOSITORY is missing");
-	const response = await fetchImpl(
-		`${apiUrl}/repos/${repository}/pulls/${payloadPr.number}`,
-		{
-			method: "PATCH",
-			signal: AbortSignal.timeout(10_000),
-			headers: {
-				Accept: "application/vnd.github+json",
-				Authorization: `Bearer ${token}`,
-				"X-GitHub-Api-Version": "2022-11-28",
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({ body }),
-		},
-	);
-	if (!response.ok) throw new Error(`GitHub API returned ${response.status}`);
 }
 
 /**
@@ -460,45 +483,16 @@ export async function lintPullRequestEvent(
 	const pullRequest = event.pull_request;
 	if (!pullRequest || !process.env.GITHUB_REPOSITORY)
 		throw new Error("Pull request event and GITHUB_REPOSITORY are required");
+	const sourceBody = pullRequest.body ?? "";
 	const body = await resolveLivePrBody(pullRequest, fetchImpl);
+	const normalized =
+		detectFlattenedBody(sourceBody) || detectEscapedNewlineBody(sourceBody);
 	const requireTestAssessment =
 		(await resolveTouchesTests(pullRequest, fetchImpl)) === true;
 	const result = lintPrBody(body, { requireTestAssessment });
 	if (result.valid) {
 		console.log(`PR body OK: ${pullRequest.number}`);
-		return { valid: true, repaired: false };
-	}
-	// Each strategy targets a distinct, unambiguous flattening shape (space
-	// joins vs. literal-\n joins). Try both; the first that both detects and
-	// produces a body which re-validates wins.
-	const repairStrategies = [
-		{ detect: detectFlattenedBody, repair: repairFlattenedBody },
-		{ detect: detectEscapedNewlineBody, repair: repairEscapedNewlineBody },
-	];
-	for (const { detect, repair } of repairStrategies) {
-		if (!detect(body)) continue;
-		const repairedBody = repair(body);
-		const repairedResult = lintPrBody(repairedBody, { requireTestAssessment });
-		if (!repairedResult.valid) continue;
-		try {
-			const latestBody = await fetchLivePrBody(pullRequest, fetchImpl);
-			if (latestBody !== body) {
-				console.log(
-					`::notice::Skipped flattened PR body repair for #${pullRequest.number}; the body changed during linting.`,
-				);
-				for (const error of result.errors) console.error(error);
-				return { valid: false, repaired: false };
-			}
-			await patchLivePrBody(pullRequest, repairedBody, fetchImpl);
-			console.log(
-				`::notice::Repaired flattened PR body for #${pullRequest.number} before validation passed.`,
-			);
-			return { valid: true, repaired: true };
-		} catch (error) {
-			console.warn(
-				`::warning::Skipped flattened PR body repair for #${pullRequest.number}; freshness check failed, preserving original lint errors (${error instanceof Error ? error.message : error}).`,
-			);
-		}
+		return { valid: true, repaired: normalized };
 	}
 	for (const error of result.errors) console.error(error);
 	return { valid: false, repaired: false };

--- a/tests/scripts/check-close-keywords.test.ts
+++ b/tests/scripts/check-close-keywords.test.ts
@@ -267,7 +267,7 @@ describe("live PR body resolution (#2086)", () => {
 			}),
 		);
 
-		const body = await fetchLivePrBody(payloadPr, fetchImpl);
+		const { body } = await fetchLivePrBody(payloadPr, fetchImpl);
 		expect(body).toBe("Closes #123. Closes #456.");
 		expect(lintCloseKeywords(body).valid).toBe(true);
 		expect(fetchImpl).toHaveBeenCalledWith(
@@ -289,7 +289,7 @@ describe("live PR body resolution (#2086)", () => {
 			}),
 		);
 
-		const body = await fetchLivePrBody(payloadPr, fetchImpl);
+		const { body } = await fetchLivePrBody(payloadPr, fetchImpl);
 		expect(lintCloseKeywords(payloadPr.body).valid).toBe(false);
 		expect(lintCloseKeywords(body).valid).toBe(true);
 	});
@@ -307,7 +307,7 @@ describe("live PR body resolution (#2086)", () => {
 			}),
 		);
 
-		const body = await fetchLivePrBody(cleanPayloadPr, fetchImpl);
+		const { body } = await fetchLivePrBody(cleanPayloadPr, fetchImpl);
 		expect(lintCloseKeywords(cleanPayloadPr.body).valid).toBe(true);
 		expect(lintCloseKeywords(body).valid).toBe(false);
 	});

--- a/tests/scripts/check-close-keywords.test.ts
+++ b/tests/scripts/check-close-keywords.test.ts
@@ -146,6 +146,34 @@ describe("close-keyword syntax lint reads the live body (#2086)", () => {
 		log.mockRestore();
 	});
 
+	it("sees close keywords in a normalized literal-newline body", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const flattened =
+			"## Summary\\nThis is a complete worker-authored body that says Closes #2145.\\n\\n## Tests\\nThe section heading and issue reference are buried in literal newline soup.\\n\\n## Blast radius\\nChecking only.\\n\\n## Class sweep\\nShared seam.\\n\\n## Observability\\nWarn on normalization.";
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify({ body: flattened }), { status: 200 }),
+			);
+
+		await lintPullRequest(fetchImpl, {
+			pull_request: { number: 2145, body: flattened },
+		});
+
+		expect(log).toHaveBeenCalledWith(
+			"Close-keyword syntax OK (1 issue referenced).",
+		);
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining("checking only"),
+		);
+		warning.mockRestore();
+		log.mockRestore();
+	});
+
 	// #2086 criterion 3: the lint path carries the same fail-closed guard set
 	// the verify path got in #2267 -- missing token, non-2xx, malformed
 	// response. Each states that the check did not run instead of surfacing

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -286,18 +286,16 @@ describe("flattened body CI entrypoint", () => {
 	it("checks the repaired body and reports a warning without writing", async () => {
 		stubApi();
 		const log = vi.spyOn(console, "log").mockImplementation(() => {});
-		const fetchImpl = vi
-			.fn()
-			.mockImplementation(async (url: string, init?: RequestInit) => {
-				if (String(url).includes("/files"))
-					return new Response(
-						JSON.stringify([{ filename: "tests/foo.test.ts" }]),
-						{ status: 200 },
-					);
-				return new Response(JSON.stringify({ body: flattenedBody }), {
-					status: 200,
-				});
+		const fetchImpl = vi.fn().mockImplementation(async (url: string) => {
+			if (String(url).includes("/files"))
+				return new Response(
+					JSON.stringify([{ filename: "tests/foo.test.ts" }]),
+					{ status: 200 },
+				);
+			return new Response(JSON.stringify({ body: flattenedBody }), {
+				status: 200,
 			});
+		});
 		expect(
 			await lintPullRequestEvent(fetchImpl, {
 				pull_request: { number: 2144, body: flattenedBody },
@@ -314,16 +312,14 @@ describe("flattened body CI entrypoint", () => {
 	it("checks an escaped-newline flattened body and reports a warning", async () => {
 		stubApi();
 		const log = vi.spyOn(console, "log").mockImplementation(() => {});
-		const fetchImpl = vi
-			.fn()
-			.mockImplementation(async (url: string, init?: RequestInit) => {
-				if (String(url).includes("/files"))
-					return new Response(JSON.stringify([]), { status: 200 });
-				return new Response(
-					JSON.stringify({ body: escapedNewlineFlattenedBody }),
-					{ status: 200 },
-				);
-			});
+		const fetchImpl = vi.fn().mockImplementation(async (url: string) => {
+			if (String(url).includes("/files"))
+				return new Response(JSON.stringify([]), { status: 200 });
+			return new Response(
+				JSON.stringify({ body: escapedNewlineFlattenedBody }),
+				{ status: 200 },
+			);
+		});
 		expect(
 			await lintPullRequestEvent(fetchImpl, {
 				pull_request: { number: 2145, body: escapedNewlineFlattenedBody },
@@ -335,6 +331,23 @@ describe("flattened body CI entrypoint", () => {
 		);
 		expect(log).toHaveBeenCalledWith("PR body OK: 2145");
 		log.mockRestore();
+	});
+
+	it("reports no repair when the payload is flattened but the live body is clean", async () => {
+		stubApi();
+		const fetchImpl = vi
+			.fn()
+			.mockImplementation(async (url: string) =>
+				String(url).includes("/files")
+					? new Response(JSON.stringify([]), { status: 200 })
+					: new Response(JSON.stringify({ body }), { status: 200 }),
+			);
+
+		expect(
+			await lintPullRequestEvent(fetchImpl, {
+				pull_request: { number: 2145, body: flattenedBody },
+			}),
+		).toEqual({ valid: true, repaired: false });
 	});
 
 	it("refuses a flattened fenced template and preserves lint errors", async () => {
@@ -527,7 +540,10 @@ describe("live PR body resolution (#2085)", () => {
 			.mockResolvedValue(
 				new Response(JSON.stringify({ body: "live" }), { status: 200 }),
 			);
-		expect(await resolveLivePrBody(payloadPr, fetchImpl)).toBe("live");
+		expect(await resolveLivePrBody(payloadPr, fetchImpl)).toEqual({
+			body: "live",
+			normalized: false,
+		});
 		expect(fetchImpl).toHaveBeenCalledWith(
 			"https://api.github.test/repos/apmantza/pi-lens/pulls/2085",
 			expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -550,8 +566,9 @@ describe("live PR body resolution (#2085)", () => {
 			fetchImpl,
 		);
 
-		expect(normalized).toContain("## Tests\n");
-		expect(normalized).toContain("Closes #2145");
+		expect(normalized).toMatchObject({ normalized: true });
+		expect(normalized.body).toContain("## Tests\n");
+		expect(normalized.body).toContain("Closes #2145");
 		expect(warning).toHaveBeenCalledWith(
 			expect.stringContaining("Normalized flattened PR body"),
 		);
@@ -575,9 +592,10 @@ describe("live PR body resolution (#2085)", () => {
 			);
 
 		const normalized = await resolveLivePrBody(payloadPr, fetchImpl);
-		expect(normalized).toContain("## Summary\n");
+		expect(normalized).toMatchObject({ normalized: true });
+		expect(normalized.body).toContain("## Summary\n");
 		expect(codeSpanBody).toContain("`line1\\nline2`");
-		expect(normalized).toContain("`line1\\nline2`");
+		expect(normalized.body).toContain("`line1\\nline2`");
 		warning.mockRestore();
 	});
 
@@ -593,7 +611,10 @@ describe("live PR body resolution (#2085)", () => {
 			);
 
 		try {
-			expect(await resolveLivePrBody(payloadPr, fetchImpl)).toBe("");
+			expect(await resolveLivePrBody(payloadPr, fetchImpl)).toEqual({
+				body: "",
+				normalized: false,
+			});
 			expect(warning).not.toHaveBeenCalled();
 		} finally {
 			warning.mockRestore();
@@ -617,7 +638,10 @@ describe("live PR body resolution (#2085)", () => {
 		vi.stubEnv("GITHUB_TOKEN", "test-token");
 		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const fetchImpl = vi.fn().mockResolvedValue(response);
-		expect(await resolveLivePrBody(payloadPr, fetchImpl)).toBe("fallback");
+		expect(await resolveLivePrBody(payloadPr, fetchImpl)).toEqual({
+			body: "fallback",
+			normalized: false,
+		});
 		expect(warning).toHaveBeenCalledWith(
 			expect.stringContaining("::warning::"),
 		);
@@ -629,7 +653,10 @@ describe("live PR body resolution (#2085)", () => {
 		vi.stubEnv("GITHUB_TOKEN", "");
 		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const fetchImpl = vi.fn();
-		expect(await resolveLivePrBody(payloadPr, fetchImpl)).toBe("fallback");
+		expect(await resolveLivePrBody(payloadPr, fetchImpl)).toEqual({
+			body: "fallback",
+			normalized: false,
+		});
 		expect(fetchImpl).not.toHaveBeenCalled();
 		expect(warning).toHaveBeenCalledWith(
 			expect.stringContaining("GITHUB_TOKEN is not set"),

--- a/tests/scripts/check-pr-body.test.ts
+++ b/tests/scripts/check-pr-body.test.ts
@@ -283,7 +283,7 @@ describe("flattened body CI entrypoint", () => {
 		vi.stubEnv("GITHUB_REPOSITORY", "o/r");
 	}
 
-	it("patches only the repaired body and reports a notice", async () => {
+	it("checks the repaired body and reports a warning without writing", async () => {
 		stubApi();
 		const log = vi.spyOn(console, "log").mockImplementation(() => {});
 		const fetchImpl = vi
@@ -294,8 +294,6 @@ describe("flattened body CI entrypoint", () => {
 						JSON.stringify([{ filename: "tests/foo.test.ts" }]),
 						{ status: 200 },
 					);
-				if (init?.method === "PATCH")
-					return new Response("{}", { status: 200 });
 				return new Response(JSON.stringify({ body: flattenedBody }), {
 					status: 200,
 				});
@@ -305,20 +303,15 @@ describe("flattened body CI entrypoint", () => {
 				pull_request: { number: 2144, body: flattenedBody },
 			}),
 		).toEqual({ valid: true, repaired: true });
-		expect(fetchImpl).toHaveBeenCalledWith(
-			"https://api.example/repos/o/r/pulls/2144",
-			expect.objectContaining({
-				method: "PATCH",
-				body: expect.stringContaining("## Tests\\n"),
-			}),
+		expect(fetchImpl).not.toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ method: "PATCH" }),
 		);
-		expect(log).toHaveBeenCalledWith(
-			expect.stringContaining("::notice::Repaired flattened PR body"),
-		);
+		expect(log).toHaveBeenCalledWith("PR body OK: 2144");
 		log.mockRestore();
 	});
 
-	it("patches an escaped-newline flattened body and reports a notice", async () => {
+	it("checks an escaped-newline flattened body and reports a warning", async () => {
 		stubApi();
 		const log = vi.spyOn(console, "log").mockImplementation(() => {});
 		const fetchImpl = vi
@@ -326,8 +319,6 @@ describe("flattened body CI entrypoint", () => {
 			.mockImplementation(async (url: string, init?: RequestInit) => {
 				if (String(url).includes("/files"))
 					return new Response(JSON.stringify([]), { status: 200 });
-				if (init?.method === "PATCH")
-					return new Response("{}", { status: 200 });
 				return new Response(
 					JSON.stringify({ body: escapedNewlineFlattenedBody }),
 					{ status: 200 },
@@ -338,16 +329,11 @@ describe("flattened body CI entrypoint", () => {
 				pull_request: { number: 2145, body: escapedNewlineFlattenedBody },
 			}),
 		).toEqual({ valid: true, repaired: true });
-		expect(fetchImpl).toHaveBeenCalledWith(
-			"https://api.example/repos/o/r/pulls/2145",
-			expect.objectContaining({
-				method: "PATCH",
-				body: expect.stringContaining("## Tests\\n"),
-			}),
+		expect(fetchImpl).not.toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ method: "PATCH" }),
 		);
-		expect(log).toHaveBeenCalledWith(
-			expect.stringContaining("::notice::Repaired flattened PR body"),
-		);
+		expect(log).toHaveBeenCalledWith("PR body OK: 2145");
 		log.mockRestore();
 	});
 
@@ -374,78 +360,6 @@ describe("flattened body CI entrypoint", () => {
 		);
 		expect(errors).toHaveBeenCalled();
 		errors.mockRestore();
-	});
-
-	it("skips the patch when freshness GET fails", async () => {
-		stubApi();
-		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
-		const errors = vi.spyOn(console, "error").mockImplementation(() => {});
-		let bodyGets = 0;
-		const fetchImpl = vi
-			.fn()
-			.mockImplementation(async (url: string, init?: RequestInit) => {
-				if (String(url).includes("/files"))
-					return new Response(JSON.stringify([]), { status: 200 });
-				if (init?.method === "PATCH")
-					return new Response("{}", { status: 200 });
-				bodyGets += 1;
-				if (bodyGets === 2) throw new Error("transient GET failure");
-				return new Response(JSON.stringify({ body: flattenedBody }), {
-					status: 200,
-				});
-			});
-		expect(
-			await lintPullRequestEvent(fetchImpl, {
-				pull_request: { number: 2144, body: flattenedBody },
-			}),
-		).toEqual({ valid: false, repaired: false });
-		expect(fetchImpl).not.toHaveBeenCalledWith(
-			expect.anything(),
-			expect.objectContaining({ method: "PATCH" }),
-		);
-		expect(warning).toHaveBeenCalledWith(
-			expect.stringContaining("freshness check failed"),
-		);
-		expect(errors).toHaveBeenCalled();
-		warning.mockRestore();
-		errors.mockRestore();
-	});
-
-	it("skips the patch when the live body changes after linting", async () => {
-		stubApi();
-		const log = vi.spyOn(console, "log").mockImplementation(() => {});
-		let bodyGets = 0;
-		const changedBody = `${flattenedBody} changed`;
-		const fetchImpl = vi
-			.fn()
-			.mockImplementation(async (url: string, init?: RequestInit) => {
-				if (String(url).includes("/files"))
-					return new Response(JSON.stringify([]), { status: 200 });
-				if (init?.method === "PATCH")
-					return new Response("{}", { status: 200 });
-				bodyGets += 1;
-				return new Response(
-					JSON.stringify({
-						body: bodyGets === 1 ? flattenedBody : changedBody,
-					}),
-					{
-						status: 200,
-					},
-				);
-			});
-		expect(
-			await lintPullRequestEvent(fetchImpl, {
-				pull_request: { number: 2144, body: flattenedBody },
-			}),
-		).toEqual({ valid: false, repaired: false });
-		expect(fetchImpl).not.toHaveBeenCalledWith(
-			expect.anything(),
-			expect.objectContaining({ method: "PATCH" }),
-		);
-		expect(log).toHaveBeenCalledWith(
-			expect.stringContaining("body changed during linting"),
-		);
-		log.mockRestore();
 	});
 
 	it("reports original errors and does not write when repair remains invalid", async () => {
@@ -599,6 +513,8 @@ describe("PR body lint (#1844)", () => {
 
 describe("live PR body resolution (#2085)", () => {
 	const payloadPr = { number: 2085, body: "fallback" };
+	const flattenedCloseKeywordBody =
+		"## Summary\\nThis worker body references Closes #2145 while preserving the complete report.\\n\\n## Tests\\nThe real flattened fixture reaches the body lint as literal newline soup.\\n\\n## Blast radius\\nOnly checking behavior changes.\\n\\n## Class sweep\\nThe shared live-body seam covers sibling readers.\\n\\n## Observability\\nA warning records that checking used normalized text.";
 
 	afterEach(() => vi.unstubAllEnvs());
 
@@ -616,6 +532,53 @@ describe("live PR body resolution (#2085)", () => {
 			"https://api.github.test/repos/apmantza/pi-lens/pulls/2085",
 			expect.objectContaining({ signal: expect.any(AbortSignal) }),
 		);
+	});
+
+	it("normalizes flattened live bodies for checking and warns without writing", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ body: flattenedCloseKeywordBody }), {
+				status: 200,
+			}),
+		);
+
+		const normalized = await resolveLivePrBody(
+			{ number: 2145, body: flattenedCloseKeywordBody },
+			fetchImpl,
+		);
+
+		expect(normalized).toContain("## Tests\n");
+		expect(normalized).toContain("Closes #2145");
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining("Normalized flattened PR body"),
+		);
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		warning.mockRestore();
+	});
+
+	it("does not mangle a genuine backslash-n inside a code span", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const codeSpanBody = `${escapedNewlineFlattenedBody.replace(
+			"literal backslash-n repair outside fences.",
+			"literal `line1\\nline2` repair outside fences.",
+		)}`;
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify({ body: codeSpanBody }), { status: 200 }),
+			);
+
+		const normalized = await resolveLivePrBody(payloadPr, fetchImpl);
+		expect(normalized).toContain("## Summary\n");
+		expect(codeSpanBody).toContain("`line1\\nline2`");
+		expect(normalized).toContain("`line1\\nline2`");
+		warning.mockRestore();
 	});
 
 	it("treats a null live body as an empty body", async () => {


### PR DESCRIPTION
## Summary
Normalize high-confidence flattened PR bodies only in memory at the shared live-body read seam. The checks remain read-only and warn that GitHub text was not edited.

This withdraws the v4.1.3 auto-repair behavior. Fork pull requests receive a read-only `GITHUB_TOKEN`, so the write path could not serve the majority case.

## Tests
- `tests/scripts/check-pr-body.test.ts`: pins normalization, read-only warnings, live-versus-payload verdicts, code-span preservation, and advisory fallback behavior.
- `tests/scripts/check-close-keywords.test.ts`: pins shared live-body normalization and five fail-closed fetch paths.
- Targeted script tests pass: 112 tests across both files.
- `npx tsc --project tsconfig.json` passes with no diagnostics.
- `npm run build`, `npm run fmt`, and `git diff --check` pass.

### Test assessment
The PR-body suite uniquely pins normalization and the live-body verdict. The close-keyword suite uniquely pins strict consumers of the shared fetch seam. No test became redundant.

## Fix round 2
- Removed the two unused mock parameters that failed TypeScript lint.
- Carried `{ body, normalized }` through `fetchLivePrBody` and `resolveLivePrBody`; the caller no longer re-detects against the stale event payload.
- Added the reviewer case B: a flattened payload plus a clean live body reports `repaired: false`.
- Rewrote the durable contract for read-only checking and reduced the workflow permission to `pull-requests: read`.
- Recorded withdrawal of v4.1.3 auto-repair in the changelog fragment.

## Blast radius
The behavior removal affects the PR-body advisory workflow: it no longer writes pull request bodies and no longer requests write permission. The shared return shape affects `lintPullRequestEvent`, `lintPullRequest`, and `verifyMergedPullRequest`; both close-keyword consumers destructure the body while retaining their fail-closed behavior. Direct import and call-site inspection found no other consumers. Structural `module_report` was unavailable in this session.

## Class sweep
The single-source defect class covered both divergence directions. A flattened live body with a clean payload reports normalization, while a flattened payload with a clean live body does not. Space-flattened and escaped-newline strategies retain their conservative and idempotent guards.

Consulted AGENTS.md sections: Issue and PR design contract, Contributing, Standing invariants, Recurring defect shapes, and Test requirements.

## Observability
A bounded workflow warning identifies the pull request when in-memory normalization occurs and states that the original body was not edited. Strict live-body fetch failures remain fail-closed for close-keyword checks. The removed PATCH path emits nothing because no write is attempted.
## Post-push verification
Required CI on `4c589fda` passed: Lint & type-check and Unit tests both ran on the pushed head. Local `npm run lint` and `npm run astgrep:self-scan` passed. The full local suite completed with 10,729 passing and 37 failing tests; 18 real-Git fixture failures came from the session git guard rejecting temporary `git init`, and the remaining failures were unrelated timeouts or shared-state effects under the loaded run. Issue #2345 records the guard/test-fixture defect and its class sweep. The changed targeted suites remained 112/112 green.