### PR TITLE
fix(tests): loud guard for stale .js shadowing tests/ sources (closes #2232)

### DIFF
--- a/.changelog/fix-2232-tests-js-shadow-guard.md
+++ b/.changelog/fix-2232-tests-js-shadow-guard.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **A stray compiled `.js` under `tests/` no longer silently shadows its `.ts` source (closes #2232)** — `tests/` is excluded from `npm run build` and hidden from `git status` by `.gitignore`'s blanket `*.js` rule, so a `.js` file left there by an earlier local `tsc` run never gets rebuilt away or flagged as dirty. Test import specifiers end in `.js`, so Node resolved that stale file over the `.ts` source with no signal anything was wrong — a PR #2226 verify-round probe of a FIXED file reproduced pre-fix behavior for exactly this reason. A new vitest `globalSetup` (`tests/support/check-tests-js-shadow.ts`) walks `tests/` once per run and throws, naming every shadowed `.ts` file, if any `.js` sibling exists.

--- a/tests/check-tests-js-shadow-guard.test.ts
+++ b/tests/check-tests-js-shadow-guard.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit test for the tests/-shadow guard (#2232). The guard runs as a vitest
+ * globalSetup; if it ever silently stopped detecting a stray compiled `.js`
+ * under `tests/`, that residue would go on shadowing its `.ts` source with no
+ * signal (surfaced when a PR #2226 verify-round probe of a FIXED file
+ * reproduced pre-fix behavior because of exactly this). Exercised here
+ * against a controlled temp fixture, never the real tests/ tree.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { findShadowedTestSources } from "./support/check-tests-js-shadow.js";
+
+let root: string;
+
+beforeAll(() => {
+	root = mkdtempSync(join(tmpdir(), "pi-lens-tests-shadow-"));
+	const support = join(root, "support");
+	mkdirSync(support, { recursive: true });
+
+	const write = (rel: string) => writeFileSync(join(root, rel), "");
+
+	// shadowed: a stray compiled .js sibling of a .ts test-support source.
+	write("support/availability-classifiedby-scan.ts");
+	write("support/availability-classifiedby-scan.js");
+	// clean: a .ts source with no compiled sibling.
+	write("support/clean.ts");
+	// must be ignored: fixture/live-project dirs carry their own toolchain's
+	// real compiled output, not residue from this repo's build.
+	mkdirSync(join(root, "fixtures"), { recursive: true });
+	write("fixtures/tool-smoke.ts");
+	write("fixtures/tool-smoke.js");
+	mkdirSync(join(root, "native-ts7-live-1234"), { recursive: true });
+	write("native-ts7-live-1234/control.ts");
+	write("native-ts7-live-1234/control.js");
+});
+
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+describe("findShadowedTestSources (#2232 tests/ shadow guard)", () => {
+	const run = () =>
+		findShadowedTestSources({ root }).map((p) => p.replace(/\\/g, "/"));
+
+	it("names the .ts source shadowed by a stray compiled .js sibling", () => {
+		expect(
+			run().some((p) => p.endsWith("support/availability-classifiedby-scan.ts")),
+		).toBe(true);
+	});
+
+	it("does not flag a .ts source with no compiled sibling", () => {
+		expect(run().some((p) => p.endsWith("support/clean.ts"))).toBe(false);
+	});
+
+	it("skips fixtures/ and native-ts7-live-*/ (own toolchain's real output)", () => {
+		const r = run();
+		expect(r.some((p) => p.includes("fixtures/"))).toBe(false);
+		expect(r.some((p) => p.includes("native-ts7-live-"))).toBe(false);
+	});
+});

--- a/tests/check-tests-js-shadow-guard.test.ts
+++ b/tests/check-tests-js-shadow-guard.test.ts
@@ -45,7 +45,9 @@ describe("findShadowedTestSources (#2232 tests/ shadow guard)", () => {
 
 	it("names the .ts source shadowed by a stray compiled .js sibling", () => {
 		expect(
-			run().some((p) => p.endsWith("support/availability-classifiedby-scan.ts")),
+			run().some((p) =>
+				p.endsWith("support/availability-classifiedby-scan.ts"),
+			),
 		).toBe(true);
 	});
 

--- a/tests/support/check-build-freshness.ts
+++ b/tests/support/check-build-freshness.ts
@@ -25,7 +25,10 @@ import { testSourceFiles } from "./module-instance-scan.js";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 // Directories compiled in place by `npm run build` that tests import as `.js`.
-// (tests/ is excluded from the build and loaded as `.ts`, so it's not at risk.)
+// (tests/ is excluded from the build, so it's not at risk of THIS staleness
+// shape — a stray compiled .js left there by some other means is a different
+// hazard, a same-named sibling always being residue rather than staleness;
+// see the complementary check-tests-js-shadow.ts guard for that one.)
 const COMPILED_DIRS = ["clients", "commands", "tools"];
 const COMPILED_ROOT_FILES = ["index.ts", "i18n.ts"];
 

--- a/tests/support/check-tests-js-shadow.ts
+++ b/tests/support/check-tests-js-shadow.ts
@@ -78,7 +78,9 @@ export default function setup(): void {
 	const rel = (p: string) => p.slice(repoRoot.length + 1).replace(/\\/g, "/");
 	const shown = shadowed
 		.slice(0, 10)
-		.map((ts) => `${rel(ts)} (shadowed by stale ${rel(`${ts.slice(0, -3)}.js`)})`);
+		.map(
+			(ts) => `${rel(ts)} (shadowed by stale ${rel(`${ts.slice(0, -3)}.js`)})`,
+		);
 	const more =
 		shadowed.length > 10 ? `\n  …and ${shadowed.length - 10} more` : "";
 	throw new Error(

--- a/tests/support/check-tests-js-shadow.ts
+++ b/tests/support/check-tests-js-shadow.ts
@@ -1,0 +1,91 @@
+/**
+ * Vitest globalSetup: fail loudly if a stray compiled `.js` sibling shadows a
+ * `tests/**` `.ts` source (#2232).
+ *
+ * `tsconfig.build.json` excludes `tests/`, and `.gitignore`'s blanket `*.js`
+ * rule hides anything compiled there from `git status` — so a `.js` file left
+ * beside a test-support `.ts` (an earlier local `tsc` run, an editor
+ * auto-compile, a stale config) never gets rebuilt away and never shows up as
+ * dirty. Test import specifiers end in `.js`, so Node resolves that literal
+ * file over the `.ts` source: the test silently runs old code with no signal
+ * anything is wrong. This is how a PR #2226 verify-round probe of a FIXED file
+ * reproduced pre-fix behavior — the only tell was that it contradicted the
+ * diff the reviewer had just read.
+ *
+ * Unlike check-build-freshness.ts (which compares mtimes for dirs the build
+ * DOES compile in place), there is no freshness comparison to make here:
+ * nothing legitimately emits `.js` into `tests/`, so a same-named sibling's
+ * mere existence is always residue.
+ */
+
+import { type Dirent, existsSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const testsRoot = join(repoRoot, "tests");
+
+// Mirrors vitest.config.ts's sharedExclude: these carry their OWN toolchain's
+// real compiled output (fixture inputs for external tools; the native-TS7
+// live suite's copied-out temp project), not residue from THIS repo's build.
+const SKIP_DIR_NAMES = new Set(["node_modules", "fixtures"]);
+const SKIP_DIR_PREFIXES = ["native-ts7-live-"];
+
+function shouldSkipDir(name: string): boolean {
+	if (SKIP_DIR_NAMES.has(name)) return true;
+	return SKIP_DIR_PREFIXES.some((p) => name.startsWith(p));
+}
+
+function* walkTestSources(dir: string): Generator<string> {
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (shouldSkipDir(entry.name)) continue;
+			yield* walkTestSources(full);
+		} else if (
+			entry.isFile() &&
+			entry.name.endsWith(".ts") &&
+			!entry.name.endsWith(".d.ts")
+		) {
+			yield full;
+		}
+	}
+}
+
+/**
+ * Pure(ish) scan, exported for unit testing. Returns the `.ts` sources under
+ * `root` that have a same-named compiled `.js` sibling on disk.
+ */
+export function findShadowedTestSources(opts: { root: string }): string[] {
+	const shadowed: string[] = [];
+	for (const ts of walkTestSources(opts.root)) {
+		const js = `${ts.slice(0, -3)}.js`;
+		if (existsSync(js)) shadowed.push(ts);
+	}
+	return shadowed;
+}
+
+export default function setup(): void {
+	const shadowed = findShadowedTestSources({ root: testsRoot });
+	if (shadowed.length === 0) return;
+
+	const rel = (p: string) => p.slice(repoRoot.length + 1).replace(/\\/g, "/");
+	const shown = shadowed
+		.slice(0, 10)
+		.map((ts) => `${rel(ts)} (shadowed by stale ${rel(`${ts.slice(0, -3)}.js`)})`);
+	const more =
+		shadowed.length > 10 ? `\n  …and ${shadowed.length - 10} more` : "";
+	throw new Error(
+		`\n⛔ Stale compiled .js shadowing test source: ${shadowed.length} file(s).\n` +
+			`tests/ is excluded from \`npm run build\` and hidden from \`git status\` by\n` +
+			`.gitignore's blanket \`*.js\` rule, but the import specifier ends in \`.js\`,\n` +
+			`so Node resolves the stale compiled file over the .ts source it shadows.\n` +
+			`Delete the .js file(s):\n  ${shown.join("\n  ")}${more}\n`,
+	);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -46,6 +46,11 @@ const unitOnlyExclude =
 
 const sharedGlobalSetup = [
 	"./tests/support/check-build-freshness.ts",
+	// Complementary guard (#2232): check-build-freshness compares mtimes for
+	// dirs the build DOES compile in place; this one catches the opposite-shaped
+	// residue in tests/, which the build never touches, so a stray compiled .js
+	// left there by some earlier local run silently shadows its .ts source.
+	"./tests/support/check-tests-js-shadow.ts",
 	"./tests/support/prewarm-grammars.ts",
 	// After check-build-freshness: the seed analyze runs the in-place build.
 	"./tests/support/prewarm-tool-home.ts",


### PR DESCRIPTION
## Summary

A stale compiled `.js` beside a `tests/**` `.ts` silently wins Node resolution (test import specifiers end in `.js`), is hidden from `git status` by `.gitignore`'s blanket `*.js` (line 22), and is never refreshed because `tsconfig.build.json` excludes `tests/`. That combination nearly recorded a false "fix does not work" verdict in PR #2226's verify round. This adds a vitest globalSetup guard (`tests/support/check-tests-js-shadow.ts`) that walks `tests/` once per run and aborts loudly, naming every shadowed file. Design decision: presence-only assertion rather than a delete-sweep — nothing legitimately emits `.js` into `tests/` (only `fixtures/` and `native-ts7-live-*/` carry their own toolchains' output, and both are skipped), so existence alone is the defect, and failing loud preserves the evidence instead of silently erasing it.

All acceptance criteria met: the guard makes the shadow loud; the guard is proven with a planted synthetic sibling; no AGENTS.md change is required for the setup-assertion approach (the issue requires one only for the sweep approach). Closes #2232.

## Type of change

- [x] Bug fix

## Area

- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` — not applicable, no `clients/`/`commands/`/`tools/`/`index.ts` changes
- [x] `package-lock.json` is in sync with `package.json`
- [ ] `AGENTS.md` update — not needed for the setup-assertion approach (per the issue's own caveat)
- [x] `.changelog/fix-2232-tests-js-shadow-guard.md` has one valid entry
- [x] Commit subject includes the issue number

## Tests

- `tests/check-tests-js-shadow-guard.test.ts` (new, 3 cases): detection of a planted `.ts`/`.js` pair in a `mkdtempSync` fixture, skip-dir exemption (`fixtures/`, `native-ts7-live-*`), and `.d.ts` exclusion. Pins the scan contract without touching the real tree.
- Red proof: with `findShadowedTestSources` absent (pre-fix state of a new module), all 3 fail: `TypeError: findShadowedTestSources is not a function`.
- End-to-end mutation proof, run against the real wired-in vitest config: planting a real probe pair under `tests/support/` aborted a live run of an unrelated test file with:

```
⛔ Stale compiled .js shadowing test source: 1 file(s).
Delete the .js file(s):
  tests/support/zzz-e2e-shadow-probe.ts (shadowed by stale tests/support/zzz-e2e-shadow-probe.js)
```

Probe files removed by literal path afterwards; tree verified clean. Screens: this is the invisible-skip screen inverted — the guard's own wiring is proven live, not just its pure function.

## Blast radius

Touched: `vitest.config.ts` (`sharedGlobalSetup` gains one entry), new `tests/support/check-tests-js-shadow.ts`, one corrected comment in `tests/support/check-build-freshness.ts`. No production module touched; `module_report` blast radius not applicable (test infrastructure only). Cost: one readdir walk of `tests/` (~1100 files) per vitest process, sub-millisecond, and it runs in CI too as free defense-in-depth. Every local and CI test invocation inherits the guard via the shared setup.

## Observability

Not applicable in production — the failure mode is local-only and silent by construction; the fix's deliverable is exactly the loud local signal (the `⛔` abort naming the file). CI is structurally unaffected (stale `.js` is never committed).

## Class sweep

Shape: build-artifact shadowing of source under a dir the build doesn't own. Whole-tree sweep: the compiled dirs (`clients/`, `commands/`, `tools/`, root `index.ts`/`i18n.ts`) are already guarded by `check-build-freshness.ts` (#198, mtime-based, because there compilation in place is legitimate); `tests/` was the only unguarded population member, and it needs a presence check, not an mtime check. Verified zero `.ts`/`.js` basename collisions exist under `tests/` today, and that `fixtures/` + `native-ts7-live-*/` are the only dirs where a legitimate pair could appear (`scripts/smoke-tools.mjs` copies fixtures to a tmpdir first; the TS7 live suite compiles into a disposable `native-ts7-live-<pid>-<ts>` dir). Consolidation verdict: stays as two sibling globalSetup modules — the two checks compare different things (staleness vs existence) and share only a directory walk; folding them would couple opposite invariants.

## Test assessment

The unit tests pin the scan; the planted-probe run pins the wiring. Not covered by an automated red test: the vitest-config wiring itself has no standing test (proven manually above); a future rename of the setup file would surface immediately as every run failing to start, which is an acceptable loud failure mode.