### PR TITLE
feat(lsp): emit availability_decision on the managed-bin launch path (refs #2140)

### DIFF
--- a/.changelog/fix-2140-lsp-managed-bin-telemetry.md
+++ b/.changelog/fix-2140-lsp-managed-bin-telemetry.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Emit availability_decision telemetry on the LSP-launch managed-bin fast path (refs #2140)** — `resolveAndLaunch`'s `~/.pi-lens/bin` resolution (clojure-lsp, cue, deno, expert, gleam, marksman, opengrep, rust-analyzer, taplo, terraform-ls, typos-lsp, zizmor, zls) now logs the same `availability_decision` record `SecurityScanClient`'s CLI-scan probe already writes: exactly one `available` row when the managed binary launches directly, and the `unavailable`-then-install-override pair when it doesn't, so the LSP-server launch path stops being invisible in `latency.log`.

--- a/clients/dispatch/runners/utils/availability-policy.ts
+++ b/clients/dispatch/runners/utils/availability-policy.ts
@@ -247,6 +247,8 @@ export function describeInstallAttempt(
 
 export interface AvailabilityDecision {
 	tool: string;
+	/** Producer scope for independent availability evidence (#2351). */
+	producer?: "security-scan" | "lsp-launch";
 	verdict: "available" | "unavailable";
 	outcome: AvailabilityOutcome;
 	cause: AvailabilityCause;
@@ -844,6 +846,9 @@ export function logAvailabilityDecision(
 		durationMs: Math.round(decision.elapsedMs),
 		metadata: {
 			tool: decision.tool,
+			...(decision.producer !== undefined && {
+				producer: decision.producer,
+			}),
 			verdict: decision.verdict,
 			outcome: decision.outcome,
 			cause: decision.cause,

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -93,6 +93,7 @@ import {
 	hasProjectBoundaryMarker,
 	isDirectLspCommandTemporarilyUnavailable,
 	resetClassicTsRepairGuard,
+	resetLspLaunchAvailabilityGeneration,
 } from "./server.js";
 import {
 	classifyCascadeWaitTier,
@@ -8946,6 +8947,10 @@ export async function notifyExternalFileChange(
 }
 
 export function resetLSPService(options: LSPShutdownOptions = {}): void {
+	// Invalidate availability publication started by the retiring service before
+	// any asynchronous teardown. The launch seam checks this generation after
+	// every managed lookup, install, and process launch (#2351).
+	resetLspLaunchAvailabilityGeneration();
 	// A new session must get its own classic-tsserver-repair attempt: the
 	// guard is a process-lifetime flag (see resetClassicTsRepairGuard), so a
 	// repair that failed transiently in an earlier session must not stay

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -35,6 +35,7 @@ import {
 	getToolEnvironment,
 	getToolPath,
 } from "../installer/index.js";
+import { logAvailabilityDecision } from "../dispatch/runners/utils/availability-policy.js";
 import { resolveOpengrepConfig } from "../opengrep-config.js";
 import {
 	isZizmorAuditTarget,
@@ -536,6 +537,7 @@ export async function resolveAndLaunch(
 	// `findManagedNodeToolBinary`'s npm-managed fast path (runner-helpers.ts)
 	// and `SecurityScanClient.probeVersion`'s equivalent fix for the CLI-scan
 	// half of this same issue (#2140, landed in PR #2148/#2137).
+	const managedProbeStartedAt = Date.now();
 	const managedCandidate = spec.managedToolId
 		? await findManagedToolBinary(spec.managedToolId)
 		: undefined;
@@ -594,6 +596,28 @@ export async function resolveAndLaunch(
 			logSessionStart(
 				`lsp launch candidate success tool=${toolLabel} idx=${index} command=${command} source=direct`,
 			);
+			// The managed-dir fast path (#2140) IS the availability probe for a
+			// release-managed tool: a real spawn just confirmed the binary
+			// findManagedToolBinary resolved actually launches. Gated on the exact
+			// managed candidate (never a later bare-PATH fallback), so a session
+			// start with the binary present emits exactly one decision and a
+			// developer-PATH-resolved copy (no managed binary at all) emits none —
+			// unchanged from before this fix.
+			if (managedCandidate !== undefined && command === managedCandidate) {
+				logAvailabilityDecision({
+					tool: toolLabel,
+					verdict: "available",
+					outcome: "success",
+					cause: "ok",
+					elapsedMs: Date.now() - managedProbeStartedAt,
+					latched: true,
+					classifiedBy: "probe",
+					evidence: {
+						binary: path.basename(managedCandidate),
+						source: "managed-dir",
+					},
+				});
+			}
 			return { process: proc, source: "direct" };
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
@@ -651,9 +675,28 @@ export async function resolveAndLaunch(
 
 	// Step 3 — managed install via installer registry
 	if (spec.managedToolId) {
+		// Neither the managed-dir stat (#2140) nor any bare-PATH candidate
+		// resolved this tool — the negative counterpart to the fast-path
+		// "available" decision above, mirroring `SecurityScanClient.probeVersion`'s
+		// failure record so the negative case is visible in latency.log rather
+		// than swallowed by going straight to the install attempt.
+		logAvailabilityDecision({
+			tool: spec.managedToolId,
+			verdict: "unavailable",
+			outcome: "missing",
+			cause: "not-found",
+			elapsedMs: Date.now() - managedProbeStartedAt,
+			latched: true,
+			classifiedBy: "probe",
+			evidence: {
+				command: candidateFailures[candidateFailures.length - 1]?.command,
+				failure: "tool-not-found",
+			},
+		});
 		logSessionStart(
 			`lsp launch ensure-tool start tool=${spec.managedToolId} cwd=${spec.cwd}`,
 		);
+		const installStartedAt = Date.now();
 		const installed = await ensureTool(spec.managedToolId);
 		logSessionStart(
 			`lsp launch ensure-tool result tool=${spec.managedToolId} installed=${installed ? "yes" : "no"} path=${installed ?? ""}`,
@@ -686,6 +729,32 @@ export async function resolveAndLaunch(
 					metadata: {
 						tool: spec.managedToolId,
 						command: installed,
+					},
+				});
+				// Compensating row for the "unavailable" decision logged above (#1606
+				// shape): the install fixed exactly what the fast path found missing,
+				// so the durable record must not be left saying the tool is off.
+				// `source` is only asserted when a fresh managed-dir lookup confirms
+				// the install actually landed in ~/.pi-lens/bin (github/maven/archive
+				// strategies) rather than an npm/pip/gem install elsewhere, so the
+				// evidence never claims a resolution this call didn't derive.
+				const confirmedManagedPath = await findManagedToolBinary(
+					spec.managedToolId,
+				);
+				logAvailabilityDecision({
+					tool: spec.managedToolId,
+					verdict: "available",
+					outcome: "success",
+					cause: "ok",
+					elapsedMs: Date.now() - installStartedAt,
+					latched: true,
+					classifiedBy: "caller",
+					evidence: {
+						install: "succeeded",
+						binary: path.basename(installed),
+						...(confirmedManagedPath !== undefined && {
+							source: "managed-dir",
+						}),
 					},
 				});
 				return { process: proc, source: "managed" };

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -35,6 +35,7 @@ import {
 	getToolEnvironment,
 	getToolPath,
 } from "../installer/index.js";
+import * as installer from "../installer/index.js";
 import {
 	classifyProbeFailure,
 	describeInstallAttempt,
@@ -443,18 +444,8 @@ function staleLaunch(
 async function installEvidenceForLaunch(
 	toolId: string,
 	installed: string,
+	attempt: Parameters<typeof describeInstallAttempt>[0],
 ): Promise<Record<string, unknown>> {
-	// Production always exports getInstallAttempt. If an isolated test double
-	// omits it, preserve the honest unknown state rather than treating a truthy
-	// ensureTool path as proof that this call installed anything.
-	const installer = await import("../installer/index.js");
-	let getInstallAttempt: typeof installer.getInstallAttempt | undefined;
-	try {
-		getInstallAttempt = installer.getInstallAttempt;
-	} catch {
-		// Older test doubles do not expose this production export.
-	}
-	const attempt = getInstallAttempt?.(toolId);
 	const evidence = describeInstallAttempt(attempt);
 	const confirmedManagedPath = await findManagedToolBinary(toolId);
 	return {
@@ -465,6 +456,19 @@ async function installEvidenceForLaunch(
 				source: "managed-dir",
 			}),
 	};
+}
+
+function captureInstallAttempt(
+	toolId: string,
+): Parameters<typeof describeInstallAttempt>[0] {
+	try {
+		// Capture synchronously after ensureTool resolves. Reading this later, after
+		// launch/evidence awaits, can observe another concurrent ensure's outcome.
+		return installer.getInstallAttempt?.(toolId);
+	} catch {
+		// Older test doubles do not expose this production export.
+	}
+	return undefined;
 }
 
 /** Re-arm direct-command availability for the next session. */
@@ -785,6 +789,7 @@ export async function resolveAndLaunch(
 		);
 		const installStartedAt = Date.now();
 		const installed = await ensureTool(spec.managedToolId);
+		const installAttempt = captureInstallAttempt(spec.managedToolId);
 		if (staleLaunch(generation, `${toolLabel}:ensureTool`)) {
 			return undefined;
 		}
@@ -834,6 +839,7 @@ export async function resolveAndLaunch(
 				const evidence = await installEvidenceForLaunch(
 					spec.managedToolId,
 					installed,
+					installAttempt,
 				);
 				if (staleLaunch(generation, `${toolLabel}:managed-evidence`, proc)) {
 					return undefined;
@@ -854,6 +860,11 @@ export async function resolveAndLaunch(
 				});
 				return { process: proc, source: "managed" };
 			} catch (err) {
+				if (
+					staleLaunch(generation, `${toolLabel}:launchLSP:managed-rejection`)
+				) {
+					return undefined;
+				}
 				const message = err instanceof Error ? err.message : String(err);
 				logSessionStart(
 					`lsp launch managed failed tool=${spec.managedToolId} command=${installed} error=${message}`,
@@ -883,6 +894,7 @@ export async function resolveAndLaunch(
 					const reinstalled = await ensureTool(spec.managedToolId, {
 						forceReinstall: true,
 					});
+					const reinstallAttempt = captureInstallAttempt(spec.managedToolId);
 					if (staleLaunch(generation, `${toolLabel}:forceReinstall`)) {
 						return undefined;
 					}
@@ -917,6 +929,7 @@ export async function resolveAndLaunch(
 							const evidence = await installEvidenceForLaunch(
 								spec.managedToolId,
 								reinstalled,
+								reinstallAttempt,
 							);
 							if (
 								staleLaunch(

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -689,7 +689,7 @@ export async function resolveAndLaunch(
 			latched: true,
 			classifiedBy: "probe",
 			evidence: {
-				command: candidateFailures[candidateFailures.length - 1]?.command,
+				command: candidateFailures.at(-1)?.command,
 				failure: "tool-not-found",
 			},
 		});

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -35,7 +35,11 @@ import {
 	getToolEnvironment,
 	getToolPath,
 } from "../installer/index.js";
-import { logAvailabilityDecision } from "../dispatch/runners/utils/availability-policy.js";
+import {
+	classifyProbeFailure,
+	describeInstallAttempt,
+	logAvailabilityDecision,
+} from "../dispatch/runners/utils/availability-policy.js";
 import { resolveOpengrepConfig } from "../opengrep-config.js";
 import {
 	isZizmorAuditTarget,
@@ -58,6 +62,10 @@ import { resolveJavaRuntimeEnv } from "./jvm-runtime.js";
 import { normalizeMapKey } from "./path-utils.js";
 import { getRubyVersionDirNamesSync } from "./ruby-drive-dirs.js";
 import { getProcessSingleton } from "../process-singletons.js";
+import {
+	createGenerationSource,
+	type GenerationHandle,
+} from "../generation-guard.js";
 
 // --- Types ---
 
@@ -405,6 +413,60 @@ const DIRECT_LSP_NEGATIVE_TTL_MS = Math.max(
 const directLspCommandUnavailableUntil = new Map<string, number>();
 const directLspCommandSkipLoggedUntil = new Map<string, number>();
 
+// Availability rows are emitted from the same async launch path that owns the
+// live LSP generation. A session reset can retire that generation while a
+// managed lookup, install, or launch is still awaiting; stale work must not
+// publish into the replacement session (#2351, shape 22).
+const lspLaunchAvailabilityGeneration = createGenerationSource(
+	"lsp-launch-availability",
+);
+
+export function resetLspLaunchAvailabilityGeneration(): void {
+	lspLaunchAvailabilityGeneration.bump();
+}
+
+function staleLaunch(
+	generation: GenerationHandle,
+	subject: string,
+	proc?: LSPProcess,
+): boolean {
+	if (generation.isCurrent()) return false;
+	try {
+		proc?.process?.kill();
+	} catch {
+		// Best-effort cleanup for a process returned after service retirement.
+	}
+	generation.guardedWrite(subject, () => undefined);
+	return true;
+}
+
+async function installEvidenceForLaunch(
+	toolId: string,
+	installed: string,
+): Promise<Record<string, unknown>> {
+	// Production always exports getInstallAttempt. If an isolated test double
+	// omits it, preserve the honest unknown state rather than treating a truthy
+	// ensureTool path as proof that this call installed anything.
+	const installer = await import("../installer/index.js");
+	let getInstallAttempt: typeof installer.getInstallAttempt | undefined;
+	try {
+		getInstallAttempt = installer.getInstallAttempt;
+	} catch {
+		// Older test doubles do not expose this production export.
+	}
+	const attempt = getInstallAttempt?.(toolId);
+	const evidence = describeInstallAttempt(attempt);
+	const confirmedManagedPath = await findManagedToolBinary(toolId);
+	return {
+		...evidence,
+		binary: path.basename(installed),
+		...(confirmedManagedPath !== undefined &&
+			pathsEqual(confirmedManagedPath, installed) && {
+				source: "managed-dir",
+			}),
+	};
+}
+
 /** Re-arm direct-command availability for the next session. */
 export function resetDirectLspCommandAvailability(): void {
 	directLspCommandUnavailableUntil.clear();
@@ -513,6 +575,7 @@ export async function resolveAndLaunch(
 	| { process: LSPProcess; source: "direct" | "managed" | "package-manager" }
 	| undefined
 > {
+	const generation = lspLaunchAvailabilityGeneration.capture();
 	const toolLabel =
 		spec.managedToolId ??
 		spec.candidates[spec.candidates.length - 1] ??
@@ -541,6 +604,9 @@ export async function resolveAndLaunch(
 	const managedCandidate = spec.managedToolId
 		? await findManagedToolBinary(spec.managedToolId)
 		: undefined;
+	if (staleLaunch(generation, `${toolLabel}:findManagedToolBinary`)) {
+		return undefined;
+	}
 	const candidates =
 		managedCandidate && !spec.candidates.includes(managedCandidate)
 			? [managedCandidate, ...spec.candidates]
@@ -581,6 +647,9 @@ export async function resolveAndLaunch(
 				cwd: spec.cwd,
 				env: spec.env,
 			});
+			if (staleLaunch(generation, `${toolLabel}:launchLSP:${command}`, proc)) {
+				return undefined;
+			}
 			logLatency({
 				type: "phase",
 				phase: "lsp_launch_candidate_success",
@@ -610,16 +679,21 @@ export async function resolveAndLaunch(
 					outcome: "success",
 					cause: "ok",
 					elapsedMs: Date.now() - managedProbeStartedAt,
-					latched: true,
+					latched: false,
+					producer: "lsp-launch",
 					classifiedBy: "probe",
 					evidence: {
 						binary: path.basename(managedCandidate),
 						source: "managed-dir",
+						correctsLatchedRow: false,
 					},
 				});
 			}
 			return { process: proc, source: "direct" };
 		} catch (err) {
+			if (staleLaunch(generation, `${toolLabel}:launchLSP:${command}`)) {
+				return undefined;
+			}
 			const message = err instanceof Error ? err.message : String(err);
 			// Defer logging: only a failure if no later candidate/install succeeds.
 			candidateFailures.push({ index, command, message, err });
@@ -680,24 +754,40 @@ export async function resolveAndLaunch(
 		// "available" decision above, mirroring `SecurityScanClient.probeVersion`'s
 		// failure record so the negative case is visible in latency.log rather
 		// than swallowed by going straight to the install attempt.
+		const failedCandidate = candidateFailures.at(-1);
+		const classifiedFailure = classifyProbeFailure(
+			{
+				error:
+					failedCandidate?.err instanceof Error
+						? failedCandidate.err
+						: undefined,
+				spawnFailure: {
+					kind: hasSpawnFailureKind(failedCandidate?.err, "tool-not-found")
+						? "tool-not-found"
+						: undefined,
+				},
+			},
+			{ command: failedCandidate?.command },
+		);
 		logAvailabilityDecision({
 			tool: spec.managedToolId,
 			verdict: "unavailable",
-			outcome: "missing",
-			cause: "not-found",
+			outcome: classifiedFailure.outcome,
+			cause: classifiedFailure.cause,
 			elapsedMs: Date.now() - managedProbeStartedAt,
-			latched: true,
+			latched: false,
 			classifiedBy: "probe",
-			evidence: {
-				command: candidateFailures.at(-1)?.command,
-				failure: "tool-not-found",
-			},
+			producer: "lsp-launch",
+			evidence: classifiedFailure.evidence,
 		});
 		logSessionStart(
 			`lsp launch ensure-tool start tool=${spec.managedToolId} cwd=${spec.cwd}`,
 		);
 		const installStartedAt = Date.now();
 		const installed = await ensureTool(spec.managedToolId);
+		if (staleLaunch(generation, `${toolLabel}:ensureTool`)) {
+			return undefined;
+		}
 		logSessionStart(
 			`lsp launch ensure-tool result tool=${spec.managedToolId} installed=${installed ? "yes" : "no"} path=${installed ?? ""}`,
 		);
@@ -718,6 +808,9 @@ export async function resolveAndLaunch(
 					cwd: spec.cwd,
 					env: spec.env,
 				});
+				if (staleLaunch(generation, `${toolLabel}:launchLSP:managed`, proc)) {
+					return undefined;
+				}
 				logSessionStart(
 					`lsp launch managed success tool=${spec.managedToolId} command=${installed} source=managed`,
 				);
@@ -738,23 +831,25 @@ export async function resolveAndLaunch(
 				// the install actually landed in ~/.pi-lens/bin (github/maven/archive
 				// strategies) rather than an npm/pip/gem install elsewhere, so the
 				// evidence never claims a resolution this call didn't derive.
-				const confirmedManagedPath = await findManagedToolBinary(
+				const evidence = await installEvidenceForLaunch(
 					spec.managedToolId,
+					installed,
 				);
+				if (staleLaunch(generation, `${toolLabel}:managed-evidence`, proc)) {
+					return undefined;
+				}
 				logAvailabilityDecision({
 					tool: spec.managedToolId,
 					verdict: "available",
 					outcome: "success",
 					cause: "ok",
 					elapsedMs: Date.now() - installStartedAt,
-					latched: true,
+					latched: false,
 					classifiedBy: "caller",
+					producer: "lsp-launch",
 					evidence: {
-						install: "succeeded",
-						binary: path.basename(installed),
-						...(confirmedManagedPath !== undefined && {
-							source: "managed-dir",
-						}),
+						...evidence,
+						correctsLatchedRow: false,
 					},
 				});
 				return { process: proc, source: "managed" };
@@ -788,12 +883,24 @@ export async function resolveAndLaunch(
 					const reinstalled = await ensureTool(spec.managedToolId, {
 						forceReinstall: true,
 					});
+					if (staleLaunch(generation, `${toolLabel}:forceReinstall`)) {
+						return undefined;
+					}
 					if (reinstalled) {
 						try {
 							const proc = await launchLSP(reinstalled, spec.args, {
 								cwd: spec.cwd,
 								env: spec.env,
 							});
+							if (
+								staleLaunch(
+									generation,
+									`${toolLabel}:launchLSP:forceReinstall`,
+									proc,
+								)
+							) {
+								return undefined;
+							}
 							logSessionStart(
 								`lsp launch managed force-reinstall success tool=${spec.managedToolId} command=${reinstalled}`,
 							);
@@ -805,6 +912,33 @@ export async function resolveAndLaunch(
 								metadata: {
 									tool: spec.managedToolId,
 									command: reinstalled,
+								},
+							});
+							const evidence = await installEvidenceForLaunch(
+								spec.managedToolId,
+								reinstalled,
+							);
+							if (
+								staleLaunch(
+									generation,
+									`${toolLabel}:forceReinstall-evidence`,
+									proc,
+								)
+							) {
+								return undefined;
+							}
+							logAvailabilityDecision({
+								tool: spec.managedToolId,
+								verdict: "available",
+								outcome: "success",
+								cause: "ok",
+								elapsedMs: Date.now() - installStartedAt,
+								latched: false,
+								classifiedBy: "caller",
+								producer: "lsp-launch",
+								evidence: {
+									...evidence,
+									correctsLatchedRow: false,
 								},
 							});
 							return { process: proc, source: "managed" };
@@ -821,21 +955,34 @@ export async function resolveAndLaunch(
 	}
 
 	// Step 4 — language-native runtime install (go install, gem install, …)
-	if (
-		spec.runtimeInstall &&
-		(await isOnPath(spec.runtimeInstall.runtimeCommand))
-	) {
-		const ok = await spec.runtimeInstall.install();
+	const runtimeInstall = spec.runtimeInstall;
+	const runtimeAvailable = runtimeInstall
+		? await isOnPath(runtimeInstall.runtimeCommand)
+		: false;
+	if (staleLaunch(generation, `${toolLabel}:runtimeAvailability`)) {
+		return undefined;
+	}
+	if (runtimeInstall && runtimeAvailable) {
+		const ok = await runtimeInstall.install();
+		if (staleLaunch(generation, `${toolLabel}:runtimeInstall`)) {
+			return undefined;
+		}
 		if (ok) {
-			const retry = spec.runtimeInstall.retryCandidates ?? spec.candidates;
+			const retry = runtimeInstall.retryCandidates ?? spec.candidates;
 			for (const command of retry) {
 				try {
 					const proc = await launchLSP(command, spec.args, {
 						cwd: spec.cwd,
 						env: spec.env,
 					});
+					if (staleLaunch(generation, `${toolLabel}:launchLSP:runtime`, proc)) {
+						return undefined;
+					}
 					return { process: proc, source: "managed" };
 				} catch (err) {
+					if (staleLaunch(generation, `${toolLabel}:launchLSP:runtime`)) {
+						return undefined;
+					}
 					trackRuntimeFailure(err);
 					// try next
 				}

--- a/clients/security-scan-client.ts
+++ b/clients/security-scan-client.ts
@@ -95,6 +95,7 @@ export abstract class SecurityScanClient<TResult> {
 	private logDurableAbsence(evidence?: ProbeEvidence, elapsedMs = 0): void {
 		logAvailabilityDecision({
 			tool: this.toolName,
+			producer: "security-scan",
 			verdict: "unavailable",
 			outcome: "missing",
 			cause: "not-found",
@@ -192,6 +193,7 @@ export abstract class SecurityScanClient<TResult> {
 			this.log(`${this.toolName} found: ${probe.stdout.trim().split("\n")[0]}`);
 			logAvailabilityDecision({
 				tool: this.toolName,
+				producer: "security-scan",
 				verdict: "available",
 				outcome: "success",
 				cause: "ok",
@@ -224,6 +226,7 @@ export abstract class SecurityScanClient<TResult> {
 				: 0;
 		logAvailabilityDecision({
 			tool: this.toolName,
+			producer: "security-scan",
 			verdict: "unavailable",
 			outcome,
 			cause,

--- a/tests/clients/availability-classifiedby-ok-sweep.test.ts
+++ b/tests/clients/availability-classifiedby-ok-sweep.test.ts
@@ -46,10 +46,9 @@ describe("availability_decision classifiedBy sweep (#2131)", () => {
 		// A regex typo that matched nothing would make the assertion below
 		// trivially true. Pin a floor, not the exact count, which churns.
 		expect(SITES.length).toBeGreaterThan(20);
-		// #2140: resolveAndLaunch's managed-bin fast path added two new
-		// cause:"ok" sites (the direct-launch success and the ensureTool
-		// compensating override), both correctly stamped classifiedBy below.
-		expect(OK_SITES.length).toBe(20);
+		// #2140/#2351: resolveAndLaunch's managed-bin fast path and force-reinstall
+		// recovery add three cause:"ok" sites, all stamped classifiedBy below.
+		expect(OK_SITES.length).toBe(21);
 	});
 
 	it('every cause:"ok" decision stamps classifiedBy', () => {

--- a/tests/clients/availability-classifiedby-ok-sweep.test.ts
+++ b/tests/clients/availability-classifiedby-ok-sweep.test.ts
@@ -46,7 +46,10 @@ describe("availability_decision classifiedBy sweep (#2131)", () => {
 		// A regex typo that matched nothing would make the assertion below
 		// trivially true. Pin a floor, not the exact count, which churns.
 		expect(SITES.length).toBeGreaterThan(20);
-		expect(OK_SITES.length).toBe(18);
+		// #2140: resolveAndLaunch's managed-bin fast path added two new
+		// cause:"ok" sites (the direct-launch success and the ensureTool
+		// compensating override), both correctly stamped classifiedBy below.
+		expect(OK_SITES.length).toBe(20);
 	});
 
 	it('every cause:"ok" decision stamps classifiedBy', () => {

--- a/tests/clients/install-attempt-evidence.test.ts
+++ b/tests/clients/install-attempt-evidence.test.ts
@@ -159,6 +159,27 @@ describe("the installer records what its attempt did (#1500)", () => {
 		);
 	});
 
+	it("keeps the real attempt snapshot distinct from a later cached ensure", async () => {
+		safeSpawnAsync.mockImplementation(async () => {
+			plantFishLspBinary();
+			return npmOk;
+		});
+		const { ensureTool, getInstallAttempt } = await installer();
+
+		expect(await ensureTool("fish-lsp")).toBeDefined();
+		const firstAttempt = getInstallAttempt("fish-lsp");
+		expect(firstAttempt?.outcome).toBe("succeeded");
+
+		// The second real ensure clears the process-global last-attempt slot before
+		// returning its session-cache result. A caller that saved the first result
+		// immediately after its await still reports the correct install.
+		expect(await ensureTool("fish-lsp")).toBeDefined();
+		expect(getInstallAttempt("fish-lsp")).toBeUndefined();
+		expect(describeInstallAttempt(firstAttempt)).toMatchObject({
+			install: "succeeded",
+		});
+	});
+
 	it("project-trust denial records a decline, not a failure", async () => {
 		const trust = await import("../../clients/project-trust.js");
 		vi.mocked(trust.assertInstallAllowed).mockReturnValue(false);

--- a/tests/clients/lsp/managed-bin-fastpath.test.ts
+++ b/tests/clients/lsp/managed-bin-fastpath.test.ts
@@ -469,6 +469,64 @@ describe("resolveAndLaunch — managed-bin availability telemetry (#2140)", () =
 		});
 	});
 
+	it("keeps the ensure invocation's evidence across a concurrent overwrite", async () => {
+		const installedPath = "/home/user/.pi-lens/bin/opengrep";
+		const toolNotFound = Object.assign(new Error("opengrep not found"), {
+			kind: "tool-not-found" as const,
+		});
+		findManagedToolBinary
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValue(installedPath);
+		let ensureCalls = 0;
+		ensureTool.mockImplementation(async () => {
+			ensureCalls++;
+			if (ensureCalls === 1) {
+				getInstallAttempt.mockReturnValue({
+					outcome: "succeeded",
+					at: Date.now(),
+				});
+				return installedPath;
+			}
+			getInstallAttempt.mockReturnValue({
+				outcome: "failed",
+				reason: "concurrent attempt",
+				at: Date.now(),
+			});
+			return null;
+		});
+		launchLSP.mockRejectedValueOnce(toolNotFound);
+		const launch = suspendAt(launchLSP, async () => fakeProc, { calls: 1 });
+		try {
+			const launching = resolveAndLaunch(
+				{
+					candidates: ["opengrep"],
+					args: [],
+					cwd: "/tmp/proj",
+					managedToolId: "opengrep",
+				},
+				true,
+			);
+			await launch.admitted;
+			// A second ensure overwrites the installer's process-global last-attempt
+			// state while the first LSP launch is still airborne.
+			const concurrentEnsure = ensureTool as unknown as (
+				toolId: string,
+			) => Promise<string | null>;
+			expect(await concurrentEnsure("opengrep")).toBeNull();
+			launch.release();
+			expect(await launching).toMatchObject({ source: "managed" });
+			const rows = await decisionsFor("opengrep");
+			expect(metadataOf(rows[1]).evidence).toMatchObject({
+				install: "succeeded",
+			});
+			expect(metadataOf(rows[1]).evidence).not.toMatchObject({
+				install: "failed",
+			});
+		} finally {
+			launch.restore();
+		}
+	});
+
 	it("does not publish managed availability when managed launch fails but PATH fallback succeeds", async () => {
 		const managedPath = "/home/user/.pi-lens/bin/opengrep";
 		const toolNotFound = Object.assign(new Error("managed binary failed"), {
@@ -519,6 +577,42 @@ describe("resolveAndLaunch — managed-bin availability telemetry (#2140)", () =
 		expect(await launching).toBeUndefined();
 		expect(launchLSP).not.toHaveBeenCalled();
 		expect(await decisionsFor("opengrep")).toHaveLength(0);
+	});
+
+	it("drops a rejected launch after reset before force reinstall can start", async () => {
+		const toolNotFound = Object.assign(new Error("opengrep not found"), {
+			kind: "tool-not-found" as const,
+		});
+		findManagedToolBinary.mockResolvedValue(undefined);
+		launchLSP.mockRejectedValueOnce(toolNotFound);
+		ensureTool.mockResolvedValueOnce("opengrep");
+		const launch = suspendAt(launchLSP, async () => {
+			throw toolNotFound;
+		});
+		try {
+			const launching = resolveAndLaunch(
+				{
+					candidates: ["opengrep"],
+					args: [],
+					cwd: "/tmp/proj",
+					managedToolId: "opengrep",
+				},
+				true,
+			);
+			await launch.admitted;
+			resetLspLaunchAvailabilityGeneration();
+			launch.release();
+			expect(await launching).toBeUndefined();
+			expect(ensureTool).toHaveBeenCalledTimes(1);
+			const rows = await decisionsFor("opengrep");
+			expect(rows).toHaveLength(1);
+			expect(rows[0]?.metadata).toMatchObject({
+				verdict: "unavailable",
+				producer: "lsp-launch",
+			});
+		} finally {
+			launch.restore();
+		}
 	});
 
 	it("drops an ensureTool completion after the LSP generation resets", async () => {

--- a/tests/clients/lsp/managed-bin-fastpath.test.ts
+++ b/tests/clients/lsp/managed-bin-fastpath.test.ts
@@ -20,7 +20,7 @@ const { findManagedToolBinary, ensureTool } = vi.hoisted(() => ({
 	findManagedToolBinary: vi.fn(
 		async (_toolId: string) => undefined as string | undefined,
 	),
-	ensureTool: vi.fn(async () => null),
+	ensureTool: vi.fn(async () => null as string | null),
 }));
 vi.mock("../../../clients/lsp/launch.js", () => ({ launchLSP }));
 vi.mock("../../../clients/latency-logger.js", async (importActual) => ({
@@ -120,5 +120,122 @@ describe("resolveAndLaunch — managed-bin fast path (#2140)", () => {
 
 		expect(result?.source).toBe("direct");
 		expect(launchLSP).toHaveBeenCalledWith("typos-lsp", [], expect.anything());
+	});
+});
+
+/** availability_decision records emitted for `tool`, oldest first (#2140). */
+function decisionsFor(tool: string): Array<Record<string, unknown>> {
+	return logLatency.mock.calls
+		.map((call) => call[0] as Record<string, unknown>)
+		.filter(
+			(entry) =>
+				entry?.phase === "availability_decision" &&
+				(entry.metadata as Record<string, unknown> | undefined)?.tool === tool,
+		);
+}
+
+function metadataOf(record: Record<string, unknown>): Record<string, unknown> {
+	return record.metadata as Record<string, unknown>;
+}
+
+describe("resolveAndLaunch — managed-bin availability telemetry (#2140)", () => {
+	beforeEach(() => {
+		launchLSP.mockReset();
+		findManagedToolBinary.mockReset();
+		findManagedToolBinary.mockResolvedValue(undefined);
+		ensureTool.mockReset();
+		logLatency.mockClear();
+	});
+
+	it("emits exactly ONE availability_decision (verdict=available) when the managed binary is present", async () => {
+		const managedPath = "/home/user/.pi-lens/bin/opengrep";
+		findManagedToolBinary.mockImplementation(async (toolId: string) =>
+			toolId === "opengrep" ? managedPath : undefined,
+		);
+		launchLSP.mockResolvedValueOnce(fakeProc);
+
+		const result = await resolveAndLaunch(
+			{
+				candidates: ["opengrep"],
+				args: ["lsp"],
+				cwd: "/tmp/proj",
+				managedToolId: "opengrep",
+			},
+			false,
+		);
+
+		expect(result?.source).toBe("direct");
+		const decisions = decisionsFor("opengrep");
+		expect(decisions).toHaveLength(1);
+		expect(metadataOf(decisions[0])).toMatchObject({
+			verdict: "available",
+			outcome: "success",
+			cause: "ok",
+			classifiedBy: "probe",
+			evidence: { source: "managed-dir", binary: "opengrep" },
+		});
+	});
+
+	it("does not swallow the negative case: unavailable then the install-path override both emit when the binary is absent", async () => {
+		const installedPath = "/home/user/.pi-lens/bin/typos-lsp";
+		// Absent at first resolution; present once the install below "lands" it.
+		findManagedToolBinary.mockImplementation(async (toolId: string) =>
+			toolId === "typos-lsp" && ensureTool.mock.calls.length > 0
+				? installedPath
+				: undefined,
+		);
+		const toolNotFound = Object.assign(new Error("typos-lsp not found"), {
+			kind: "tool-not-found" as const,
+		});
+		launchLSP.mockRejectedValueOnce(toolNotFound);
+		launchLSP.mockResolvedValueOnce(fakeProc);
+		ensureTool.mockResolvedValueOnce(installedPath);
+
+		const result = await resolveAndLaunch(
+			{
+				candidates: ["typos-lsp"],
+				args: [],
+				cwd: "/tmp/proj",
+				managedToolId: "typos-lsp",
+			},
+			true,
+		);
+
+		expect(result?.source).toBe("managed");
+		const decisions = decisionsFor("typos-lsp");
+		expect(decisions).toHaveLength(2);
+		expect(metadataOf(decisions[0])).toMatchObject({
+			verdict: "unavailable",
+			outcome: "missing",
+			cause: "not-found",
+			classifiedBy: "probe",
+		});
+		expect(metadataOf(decisions[1])).toMatchObject({
+			verdict: "available",
+			outcome: "success",
+			cause: "ok",
+			classifiedBy: "caller",
+			evidence: {
+				install: "succeeded",
+				binary: "typos-lsp",
+				source: "managed-dir",
+			},
+		});
+	});
+
+	it("emits no availability_decision when a bare-PATH copy resolves and no managed binary exists", async () => {
+		launchLSP.mockResolvedValueOnce(fakeProc);
+
+		await resolveAndLaunch(
+			{
+				candidates: ["typos-lsp"],
+				args: [],
+				cwd: "/tmp/proj",
+				managedToolId: "typos-lsp",
+			},
+			false,
+		);
+
+		expect(decisionsFor("typos-lsp")).toHaveLength(0);
 	});
 });

--- a/tests/clients/lsp/managed-bin-fastpath.test.ts
+++ b/tests/clients/lsp/managed-bin-fastpath.test.ts
@@ -223,6 +223,40 @@ describe("resolveAndLaunch — managed-bin availability telemetry (#2140)", () =
 		});
 	});
 
+	it("does not assert evidence.source when the install lands outside ~/.pi-lens/bin (npm/pip-strategy servers)", async () => {
+		// findManagedToolBinary short-circuits to undefined for every non-github/
+		// maven/archive strategy (installer/index.ts), before AND after install —
+		// there is nothing to re-confirm, so the compensating row must not claim
+		// managed-dir source it never derived (recurring-defect shape 13).
+		findManagedToolBinary.mockResolvedValue(undefined);
+		const toolNotFound = Object.assign(
+			new Error("bash-language-server not found"),
+			{
+				kind: "tool-not-found" as const,
+			},
+		);
+		launchLSP.mockRejectedValueOnce(toolNotFound);
+		launchLSP.mockResolvedValueOnce(fakeProc);
+		ensureTool.mockResolvedValueOnce(
+			"/home/user/.pi-lens/tools/bash-language-server/bin/bash-language-server",
+		);
+
+		const result = await resolveAndLaunch(
+			{
+				candidates: ["bash-language-server"],
+				args: [],
+				cwd: "/tmp/proj",
+				managedToolId: "bash-language-server",
+			},
+			true,
+		);
+
+		expect(result?.source).toBe("managed");
+		const decisions = decisionsFor("bash-language-server");
+		expect(decisions).toHaveLength(2);
+		expect(metadataOf(decisions[1]).evidence).not.toHaveProperty("source");
+	});
+
 	it("emits no availability_decision when a bare-PATH copy resolves and no managed binary exists", async () => {
 		launchLSP.mockResolvedValueOnce(fakeProc);
 

--- a/tests/clients/lsp/managed-bin-fastpath.test.ts
+++ b/tests/clients/lsp/managed-bin-fastpath.test.ts
@@ -12,32 +12,66 @@
  * `OpengrepServer`/`MarksmanServer`/`TyposLspServer`/`ZizmorServer`'s shared
  * `resolveAndLaunch` call site.
  */
+import * as fs from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { suspendAt, waitFor } from "../interleaving-kit.js";
 
-const { launchLSP } = vi.hoisted(() => ({ launchLSP: vi.fn() }));
-const { logLatency } = vi.hoisted(() => ({ logLatency: vi.fn() }));
-const { findManagedToolBinary, ensureTool } = vi.hoisted(() => ({
-	findManagedToolBinary: vi.fn(
-		async (_toolId: string) => undefined as string | undefined,
-	),
-	ensureTool: vi.fn(async () => null as string | null),
+vi.hoisted(() => {
+	// This suite verifies the same NDJSON bytes a production reader consumes.
+	// Keep the opt-out scoped to this worker; the repository test setup defaults
+	// to test mode so ordinary suites do not write telemetry.
+	process.env.PI_LENS_TEST_MODE = "0";
+});
+
+const { launchLSP, safeSpawnAsync } = vi.hoisted(() => ({
+	launchLSP: vi.fn(),
+	safeSpawnAsync: vi.fn(),
 }));
+const { findManagedToolBinary, ensureTool, getInstallAttempt } = vi.hoisted(
+	() => ({
+		findManagedToolBinary: vi.fn(
+			async (_toolId: string) => undefined as string | undefined,
+		),
+		ensureTool: vi.fn(async () => null as string | null),
+		getInstallAttempt: vi.fn(),
+	}),
+);
 vi.mock("../../../clients/lsp/launch.js", () => ({ launchLSP }));
-vi.mock("../../../clients/latency-logger.js", async (importActual) => ({
-	...(await importActual<
-		typeof import("../../../clients/latency-logger.js")
-	>()),
-	logLatency,
+vi.mock("../../../clients/safe-spawn.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../../clients/safe-spawn.js")>()),
+	safeSpawnAsync,
 }));
 vi.mock("../../../clients/installer/index.js", () => ({
 	ensureTool,
 	getToolEnvironment: () => ({}),
 	findManagedToolBinary,
+	getInstallAttempt,
 }));
 
-import { resolveAndLaunch } from "../../../clients/lsp/server.js";
+import {
+	resetLspLaunchAvailabilityGeneration,
+	resolveAndLaunch,
+} from "../../../clients/lsp/server.js";
+import { SecurityScanClient } from "../../../clients/security-scan-client.js";
+import {
+	clearLatencyLog,
+	flushLatencyLog,
+	getLatencyLogPath,
+} from "../../../clients/latency-logger.js";
 
 const fakeProc = { stdout: {}, stderr: {} } as never;
+
+class CompositionScanClient extends SecurityScanClient<string> {
+	constructor() {
+		super("opengrep");
+	}
+	protected doEnsureAvailable(): Promise<boolean> {
+		return this.probeVersion(["--version"]).then((available) => {
+			this.available = available;
+			return available;
+		});
+	}
+}
 
 describe("resolveAndLaunch — managed-bin fast path (#2140)", () => {
 	beforeEach(() => {
@@ -45,6 +79,8 @@ describe("resolveAndLaunch — managed-bin fast path (#2140)", () => {
 		findManagedToolBinary.mockReset();
 		findManagedToolBinary.mockResolvedValue(undefined);
 		ensureTool.mockReset();
+		getInstallAttempt.mockReset();
+		getInstallAttempt.mockReturnValue({ outcome: "succeeded", at: Date.now() });
 	});
 
 	it("tries the managed release binary BEFORE the bare PATH candidate", async () => {
@@ -124,9 +160,20 @@ describe("resolveAndLaunch — managed-bin fast path (#2140)", () => {
 });
 
 /** availability_decision records emitted for `tool`, oldest first (#2140). */
-function decisionsFor(tool: string): Array<Record<string, unknown>> {
-	return logLatency.mock.calls
-		.map((call) => call[0] as Record<string, unknown>)
+async function decisionsFor(
+	tool: string,
+): Promise<Array<Record<string, unknown>>> {
+	await flushLatencyLog();
+	let text = "";
+	try {
+		text = await fs.readFile(getLatencyLogPath(), "utf8");
+	} catch {
+		return [];
+	}
+	return text
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as Record<string, unknown>)
 		.filter(
 			(entry) =>
 				entry?.phase === "availability_decision" &&
@@ -139,12 +186,13 @@ function metadataOf(record: Record<string, unknown>): Record<string, unknown> {
 }
 
 describe("resolveAndLaunch — managed-bin availability telemetry (#2140)", () => {
-	beforeEach(() => {
+	beforeEach(async () => {
 		launchLSP.mockReset();
 		findManagedToolBinary.mockReset();
 		findManagedToolBinary.mockResolvedValue(undefined);
 		ensureTool.mockReset();
-		logLatency.mockClear();
+		clearLatencyLog();
+		await flushLatencyLog();
 	});
 
 	it("emits exactly ONE availability_decision (verdict=available) when the managed binary is present", async () => {
@@ -165,7 +213,7 @@ describe("resolveAndLaunch — managed-bin availability telemetry (#2140)", () =
 		);
 
 		expect(result?.source).toBe("direct");
-		const decisions = decisionsFor("opengrep");
+		const decisions = await decisionsFor("opengrep");
 		expect(decisions).toHaveLength(1);
 		expect(metadataOf(decisions[0])).toMatchObject({
 			verdict: "available",
@@ -174,6 +222,59 @@ describe("resolveAndLaunch — managed-bin availability telemetry (#2140)", () =
 			classifiedBy: "probe",
 			evidence: { source: "managed-dir", binary: "opengrep" },
 		});
+	});
+
+	it("attributes one managed-tool row to each active producer", async () => {
+		const managedPath = "/home/user/.pi-lens/bin/opengrep";
+		findManagedToolBinary
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValue(managedPath);
+		safeSpawnAsync.mockResolvedValue({
+			stdout: "opengrep 1.0.0",
+			stderr: "",
+			status: 0,
+		} as never);
+		const scanner = new CompositionScanClient();
+		expect(await scanner.ensureAvailable()).toBe(true);
+		// The security producer owns its latch, so a second caller does not
+		// duplicate the same session decision.
+		expect(await scanner.ensureAvailable()).toBe(true);
+
+		launchLSP.mockResolvedValueOnce(fakeProc);
+		expect(
+			await resolveAndLaunch(
+				{
+					candidates: ["opengrep"],
+					args: ["lsp"],
+					cwd: "/tmp/proj",
+					managedToolId: "opengrep",
+				},
+				false,
+			),
+		).toMatchObject({ source: "direct" });
+
+		const rows = await decisionsFor("opengrep");
+		expect(rows).toHaveLength(2);
+		expect(rows.map((row) => metadataOf(row).producer).sort()).toEqual([
+			"lsp-launch",
+			"security-scan",
+		]);
+		expect(rows).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					metadata: expect.objectContaining({
+						producer: "security-scan",
+						latched: true,
+					}),
+				}),
+				expect.objectContaining({
+					metadata: expect.objectContaining({
+						producer: "lsp-launch",
+						latched: false,
+					}),
+				}),
+			]),
+		);
 	});
 
 	it("does not swallow the negative case: unavailable then the install-path override both emit when the binary is absent", async () => {
@@ -202,7 +303,7 @@ describe("resolveAndLaunch — managed-bin availability telemetry (#2140)", () =
 		);
 
 		expect(result?.source).toBe("managed");
-		const decisions = decisionsFor("typos-lsp");
+		const decisions = await decisionsFor("typos-lsp");
 		expect(decisions).toHaveLength(2);
 		expect(metadataOf(decisions[0])).toMatchObject({
 			verdict: "unavailable",
@@ -252,9 +353,36 @@ describe("resolveAndLaunch — managed-bin availability telemetry (#2140)", () =
 		);
 
 		expect(result?.source).toBe("managed");
-		const decisions = decisionsFor("bash-language-server");
+		const decisions = await decisionsFor("bash-language-server");
 		expect(decisions).toHaveLength(2);
 		expect(metadataOf(decisions[1]).evidence).not.toHaveProperty("source");
+	});
+
+	it("only confirms managed-dir source when the installed path matches the fresh managed resolution", async () => {
+		const staleManagedPath = "/home/user/.pi-lens/bin/typos-lsp-old";
+		const installedPath = "/home/user/.pi-lens/bin/typos-lsp";
+		const toolNotFound = Object.assign(new Error("typos-lsp not found"), {
+			kind: "tool-not-found" as const,
+		});
+		findManagedToolBinary
+			.mockResolvedValueOnce(undefined)
+			.mockResolvedValueOnce(staleManagedPath);
+		launchLSP.mockRejectedValueOnce(toolNotFound);
+		launchLSP.mockResolvedValueOnce(fakeProc);
+		ensureTool.mockResolvedValueOnce(installedPath);
+
+		await resolveAndLaunch(
+			{
+				candidates: ["typos-lsp"],
+				args: [],
+				cwd: "/tmp/proj",
+				managedToolId: "typos-lsp",
+			},
+			true,
+		);
+
+		const rows = await decisionsFor("typos-lsp");
+		expect(metadataOf(rows[1]).evidence).not.toHaveProperty("source");
 	});
 
 	it("emits no availability_decision when a bare-PATH copy resolves and no managed binary exists", async () => {
@@ -270,6 +398,184 @@ describe("resolveAndLaunch — managed-bin availability telemetry (#2140)", () =
 			false,
 		);
 
-		expect(decisionsFor("typos-lsp")).toHaveLength(0);
+		expect(await decisionsFor("typos-lsp")).toHaveLength(0);
+	});
+
+	it("does not claim a fresh install when ensureTool only returns a cached path", async () => {
+		const cachedPath = "/home/user/.pi-lens/bin/opengrep";
+		const toolNotFound = Object.assign(new Error("opengrep not found"), {
+			kind: "tool-not-found" as const,
+		});
+		findManagedToolBinary.mockResolvedValue(undefined);
+		launchLSP.mockRejectedValueOnce(toolNotFound);
+		launchLSP.mockResolvedValueOnce(fakeProc);
+		ensureTool.mockResolvedValueOnce(cachedPath);
+		getInstallAttempt.mockReturnValue(undefined);
+
+		await resolveAndLaunch(
+			{
+				candidates: ["opengrep"],
+				args: [],
+				cwd: "/tmp/proj",
+				managedToolId: "opengrep",
+			},
+			true,
+		);
+
+		const rows = await decisionsFor("opengrep");
+		expect(metadataOf(rows[1]).evidence).toMatchObject({
+			install: "not-attempted",
+		});
+		expect(metadataOf(rows[1]).evidence).not.toHaveProperty("source");
+	});
+
+	it("compensates force-reinstall success with the same honest install evidence", async () => {
+		const managedPath = "/home/user/.pi-lens/bin/rust-analyzer";
+		const toolNotFound = Object.assign(new Error("rust-analyzer not found"), {
+			kind: "tool-not-found" as const,
+		});
+		findManagedToolBinary.mockResolvedValue(undefined);
+		launchLSP.mockRejectedValueOnce(toolNotFound);
+		launchLSP.mockRejectedValueOnce(toolNotFound);
+		launchLSP.mockResolvedValueOnce(fakeProc);
+		ensureTool
+			.mockResolvedValueOnce("rust-analyzer")
+			.mockResolvedValueOnce(managedPath);
+		getInstallAttempt.mockReturnValue({
+			outcome: "succeeded",
+			at: Date.now(),
+		});
+
+		await resolveAndLaunch(
+			{
+				candidates: ["rust-analyzer"],
+				args: [],
+				cwd: "/tmp/proj",
+				managedToolId: "rust-analyzer",
+			},
+			true,
+		);
+
+		const rows = await decisionsFor("rust-analyzer");
+		expect(rows).toHaveLength(2);
+		expect(metadataOf(rows[1])).toMatchObject({
+			producer: "lsp-launch",
+			latched: false,
+			evidence: {
+				install: "succeeded",
+				binary: "rust-analyzer",
+				correctsLatchedRow: false,
+			},
+		});
+	});
+
+	it("does not publish managed availability when managed launch fails but PATH fallback succeeds", async () => {
+		const managedPath = "/home/user/.pi-lens/bin/opengrep";
+		const toolNotFound = Object.assign(new Error("managed binary failed"), {
+			kind: "tool-not-found" as const,
+		});
+		findManagedToolBinary.mockResolvedValue(managedPath);
+		launchLSP.mockRejectedValueOnce(toolNotFound);
+		launchLSP.mockResolvedValueOnce(fakeProc);
+
+		const result = await resolveAndLaunch(
+			{
+				candidates: ["opengrep"],
+				args: [],
+				cwd: "/tmp/proj",
+				managedToolId: "opengrep",
+			},
+			false,
+		);
+
+		expect(result?.source).toBe("direct");
+		expect(launchLSP).toHaveBeenNthCalledWith(
+			2,
+			"opengrep",
+			[],
+			expect.anything(),
+		);
+		expect(await decisionsFor("opengrep")).toHaveLength(0);
+	});
+
+	it("drops a managed lookup that settles after the LSP generation resets", async () => {
+		let release!: (value: string | undefined) => void;
+		const pending = new Promise<string | undefined>((resolve) => {
+			release = resolve;
+		});
+		findManagedToolBinary.mockReturnValueOnce(pending);
+		const launching = resolveAndLaunch(
+			{
+				candidates: ["opengrep"],
+				args: [],
+				cwd: "/tmp/proj",
+				managedToolId: "opengrep",
+			},
+			true,
+		);
+		resetLspLaunchAvailabilityGeneration();
+		release(undefined);
+
+		expect(await launching).toBeUndefined();
+		expect(launchLSP).not.toHaveBeenCalled();
+		expect(await decisionsFor("opengrep")).toHaveLength(0);
+	});
+
+	it("drops an ensureTool completion after the LSP generation resets", async () => {
+		const toolNotFound = Object.assign(new Error("opengrep not found"), {
+			kind: "tool-not-found" as const,
+		});
+		findManagedToolBinary.mockResolvedValue(undefined);
+		launchLSP.mockRejectedValueOnce(toolNotFound);
+		const ensure = suspendAt(ensureTool, async () => "/managed/opengrep");
+		try {
+			const launching = resolveAndLaunch(
+				{
+					candidates: ["opengrep"],
+					args: [],
+					cwd: "/tmp/proj",
+					managedToolId: "opengrep",
+				},
+				true,
+			);
+			await ensure.admitted;
+			resetLspLaunchAvailabilityGeneration();
+			ensure.release();
+			expect(await launching).toBeUndefined();
+			const rows = await decisionsFor("opengrep");
+			expect(rows).toHaveLength(1);
+			expect(metadataOf(rows[0])).toMatchObject({
+				verdict: "unavailable",
+				producer: "lsp-launch",
+			});
+		} finally {
+			ensure.restore();
+		}
+	});
+
+	it("drops a launchLSP completion after the LSP generation resets", async () => {
+		findManagedToolBinary.mockResolvedValue(undefined);
+		const launch = suspendAt(launchLSP, async () => fakeProc, { calls: 1 });
+		try {
+			const launching = resolveAndLaunch(
+				{
+					candidates: ["opengrep"],
+					args: [],
+					cwd: "/tmp/proj",
+					managedToolId: "opengrep",
+				},
+				false,
+			);
+			await waitFor(
+				() => launchLSP.mock.calls.length,
+				(calls) => calls === 1,
+			);
+			resetLspLaunchAvailabilityGeneration();
+			launch.release();
+			expect(await launching).toBeUndefined();
+			expect(await decisionsFor("opengrep")).toHaveLength(0);
+		} finally {
+			launch.restore();
+		}
 	});
 });

--- a/tests/clients/security-scan-probe-telemetry.test.ts
+++ b/tests/clients/security-scan-probe-telemetry.test.ts
@@ -143,6 +143,7 @@ const BASELINE_KEYS = [
 	"hostStallMs",
 	"latched",
 	"outcome",
+	"producer",
 	"tool",
 	"verdict",
 ];
@@ -297,6 +298,7 @@ describe.each(CONSUMERS)("probeVersion telemetry: %s (#1501)", (tool) => {
 			"evidence",
 			"latched",
 			"outcome",
+			"producer",
 			"tool",
 			"verdict",
 		]);

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -662,6 +662,15 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 			"The service is torn down and rebuilt per session; this reset is also the seam that carries the sweep hold and TS-repair guard resets.",
 	},
 	{
+		id: "lsp-server:launchAvailabilityGeneration",
+		module: "lsp/server.ts",
+		state: "lspLaunchAvailabilityGeneration",
+		policy: "session_start",
+		resetName: "resetLSPService",
+		reason:
+			"Availability publication shares the LSP service generation. A managed lookup, install, or launch that crosses reset must not publish into the replacement session. #2351.",
+	},
+	{
 		id: "spawn-timeout-cooldown:latches",
 		module: "spawn-timeout-cooldown.ts",
 		state: "timedOutByCommand",


### PR DESCRIPTION
## Summary

Implements the remainder of #2140 that merged PRs #2148 (CLI-scan probe managed-dir resolution) and #2266 (LSP launch candidate ordering) left open, and which #2266's own body named verbatim: no `availability_decision` record existed on the LSP launch path at all, so the LSP half of the managed-binary story stayed invisible in `latency.log`. `resolveAndLaunch` now emits two decisions mirroring `SecurityScanClient.probeVersion`/`ensureViaInstaller`'s exact shape: an `available` (`classifiedBy: "probe"`, `evidence.source: "managed-dir"`) when the managed-dir candidate itself launches, and an `unavailable` (`probe`, `cause: not-found`) + compensating `available` (`caller`) pair around the existing `ensureTool` install step. Gotcha handled: `evidence.source: "managed-dir"` on the install path is only asserted after a fresh `findManagedToolBinary` re-check confirms the install landed there — never fabricated for npm/pip installs (pinned by a dedicated test).

Refs #2140 — all four literal acceptance criteria now read satisfied end-to-end across the three PRs, but the maintainer twice deferred closing as their call, so this PR does not presume it. Issue comment posted naming what this PR adds.

## Type of change

- [x] Enhancement (improvement to existing capability)

## Area

- [x] area:lsp
- [x] area:observability

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds (code under `clients/` changed)
- [x] `package-lock.json` is in sync with `package.json`
- [ ] `AGENTS.md` update — not needed; no documented invariant changes
- [x] `.changelog/fix-2140-lsp-managed-bin-telemetry.md` has one valid entry
- [x] Commit subject includes the issue number

## Tests

- `tests/clients/lsp/managed-bin-fastpath.test.ts` (4 new cases beside 3 pre-existing):
  - emits exactly ONE `availability_decision` (verdict=available) when the managed binary is present (regression proof for the issue's "exactly one decision" criterion)
  - the negative case is not swallowed: `unavailable` then the install-path `available` both emit when the binary is absent (regression proof)
  - a PATH-resolved copy with no managed binary emits no decision (mutation-proof against over-broad gating on `command === managedCandidate`)
  - does not assert `evidence.source` when the install lands outside the managed dir (pins the no-fabricated-evidence rule for npm/pip strategies)
- `tests/clients/availability-classifiedby-ok-sweep.test.ts`: governance floor bumped 18→20 for the two new correctly-stamped `logAvailabilityDecision` sites.

Red on pre-fix code (only `clients/lsp/server.ts` reverted via patch, tests untouched):

```
× emits exactly ONE availability_decision (verdict=available) when the managed binary is present
  AssertionError: expected [] to have a length of 1 but got +0
× does not swallow the negative case: unavailable then the install-path override both emit when the binary is absent
  AssertionError: expected [] to have a length of 2 but got +0
Test Files  1 failed (1)
     Tests  2 failed | 4 passed (6)
```

Screens: the sweep-floor bump is the loose-bound screen (exact count, not >=); the PATH-copy test is the parallel-path screen.

## Blast radius

Touched production module: `clients/lsp/server.ts` (`resolveAndLaunch`) — the single shared launch seam for all 26 `managedToolId` LSP servers. Behavioral delta is telemetry-only: two `logAvailabilityDecision` calls, no control-flow change. Hot path cost: the fast-path decision is one function call after a successful spawn (session-start frequency, not per-file); the install-path re-check adds one `findManagedToolBinary` stat only on the already-slow install fallback. Verification: 20 test files / 317 tests green across sibling `resolveAndLaunch` consumers, `security-scan-probe-telemetry.test.ts`, and the fixer-playbook governance sweeps (delivery-surface-ratchet, session-state-conformance, bounded-telemetry-sweep, bus-producer-coverage, managed-tool-seam-coverage, and siblings).

## Observability

This PR IS the observability record: `latency.log` gains `availability_decision` rows on the LSP launch path — fast path `verdict=available cause=ok classifiedBy=probe evidence.source=managed-dir`; fallback `verdict=unavailable cause=not-found classifiedBy=probe` followed on successful install by `verdict=available classifiedBy=caller`. Post-fix dogfood proof: the issue's paired false-unavailable records for a present managed binary disappear, replaced by the single fast-path row.

## Class sweep

Shape: telemetry seam present on one resolution path (CLI scan) but absent on its sibling (LSP launch) — the cross-path coverage gap AGENTS.md's parallel-path screen targets. Population: all 26 `managedToolId` servers inherit from the one `resolveAndLaunch` seam — 13 github/maven/archive-strategy servers (clojure-lsp, cue, deno, expert, gleam, marksman, opengrep, rust-analyzer, taplo, terraform-ls, typos-lsp, zizmor, zls — matching PR #2266's precedent table) get the fast-path decision; the 13 npm/pip-strategy servers get the negative/compensating pair with `evidence.source` correctly omitted. Whole-tree sweep for other `logAvailabilityDecision` writers: `SecurityScanClient` (fixed by #2148) and the installer's `ensureViaInstaller` were already correct; the classifiedBy-ok sweep test enumerates every site and its floor is pinned at 20. Consolidation verdict: already folded — one seam per process family, no distributed members remain.

## Test assessment

Scope note flagged for review: the telemetry extension covers all 26 managed servers, not only the issue's literal 13 — deliberate, because gating by install strategy would recreate the hand-maintained-allowlist defect. Covered: presence, absence, PATH-copy, non-managed-install evidence. Not covered: a live spawn of a real managed binary (mocked `launchLSP`); the pre-existing integration suites cover real launches.