### PR TITLE
fix(dispatch): remove dead runner default (closes #2354)

### DIFF
--- a/.changelog/2354-remove-dead-runner-default.md
+++ b/.changelog/2354-remove-dead-runner-default.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Remove the unused runner default declaration (closes #2354)** — runner availability remains controlled by dispatch groups and explicit feature gates, so definitions no longer claim an `enabledByDefault` behavior that dispatch never enforced.

--- a/clients/dispatch/runners/actionlint.ts
+++ b/clients/dispatch/runners/actionlint.ts
@@ -87,7 +87,6 @@ const actionlintRunner: RunnerDefinition = {
 	id: "actionlint",
 	appliesTo: ["yaml"],
 	priority: PRIORITY.YAML_LINT + 1,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	when(ctx: DispatchContext): boolean {

--- a/clients/dispatch/runners/ast-grep-napi.ts
+++ b/clients/dispatch/runners/ast-grep-napi.ts
@@ -914,7 +914,6 @@ const astGrepNapiRunner: RunnerDefinition = {
 	id: "ast-grep-napi",
 	appliesTo: ["jsts", "css", "html"],
 	priority: PRIORITY.SPECIALIZED_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: true,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/biome-check.ts
+++ b/clients/dispatch/runners/biome-check.ts
@@ -255,7 +255,6 @@ const biomeCheckJsonRunner: RunnerDefinition = {
 	id: "biome-check-json",
 	appliesTo: ["jsts"],
 	priority: PRIORITY.FORMAT_AND_LINT_PRIMARY,
-	enabledByDefault: true,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {
 		const cwd = ctx.cwd || path.dirname(ctx.filePath);

--- a/clients/dispatch/runners/cpp-check.ts
+++ b/clients/dispatch/runners/cpp-check.ts
@@ -210,7 +210,6 @@ const cppCheckRunner: RunnerDefinition = {
 	id: "cpp-check",
 	appliesTo: ["cxx"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/credo.ts
+++ b/clients/dispatch/runners/credo.ts
@@ -83,7 +83,6 @@ const credoRunner: RunnerDefinition = {
 	id: "credo",
 	appliesTo: ["elixir"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/cue-vet.ts
+++ b/clients/dispatch/runners/cue-vet.ts
@@ -335,7 +335,6 @@ const cueVetRunner: RunnerDefinition = {
 	id: "cue-vet",
 	appliesTo: ["cue"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 	timeoutMs: 30_000,
 

--- a/clients/dispatch/runners/dart-analyze.ts
+++ b/clients/dispatch/runners/dart-analyze.ts
@@ -160,7 +160,6 @@ const dartAnalyzeRunner: RunnerDefinition = {
 	id: "dart-analyze",
 	appliesTo: ["dart"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/detekt.ts
+++ b/clients/dispatch/runners/detekt.ts
@@ -140,7 +140,6 @@ const detektRunner: RunnerDefinition = {
 	id: "detekt",
 	appliesTo: ["kotlin"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	timeoutMs: 90_000,
 	skipTestFiles: false,
 

--- a/clients/dispatch/runners/dotnet-build.ts
+++ b/clients/dispatch/runners/dotnet-build.ts
@@ -139,7 +139,6 @@ const dotnetBuildRunner: RunnerDefinition = {
 	id: "dotnet-build",
 	appliesTo: ["csharp"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	timeoutMs: 90_000,
 	skipTestFiles: false,
 

--- a/clients/dispatch/runners/elixir-check.ts
+++ b/clients/dispatch/runners/elixir-check.ts
@@ -162,7 +162,6 @@ const elixirCheckRunner: RunnerDefinition = {
 	id: "elixir-check",
 	appliesTo: ["elixir"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/eslint.ts
+++ b/clients/dispatch/runners/eslint.ts
@@ -118,7 +118,6 @@ const eslintRunner: RunnerDefinition = {
 	id: "eslint",
 	appliesTo: ["jsts"],
 	priority: PRIORITY.LINT_SECONDARY,
-	enabledByDefault: true,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {
 		const cwd = ctx.cwd || process.cwd();

--- a/clients/dispatch/runners/fact-rules.ts
+++ b/clients/dispatch/runners/fact-rules.ts
@@ -20,7 +20,6 @@ const factRulesRunner: RunnerDefinition = {
 	id: "fact-rules",
 	appliesTo: ["jsts", "python", "go", "rust", "ruby", "shell", "cmake"],
 	priority: PRIORITY.GENERAL_ANALYSIS + 1,
-	enabledByDefault: true,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {
 		const diagnostics = evaluateRules(ctx);

--- a/clients/dispatch/runners/fish-indent.ts
+++ b/clients/dispatch/runners/fish-indent.ts
@@ -15,7 +15,6 @@ const fishIndentRunner: RunnerDefinition = {
 	id: "fish-indent",
 	appliesTo: ["fish"],
 	priority: PRIORITY.FORMAT_AND_LINT_PRIMARY,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/gleam-check.ts
+++ b/clients/dispatch/runners/gleam-check.ts
@@ -50,7 +50,6 @@ const gleamCheckRunner: RunnerDefinition = {
 	id: "gleam-check",
 	appliesTo: ["gleam"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/go-vet.ts
+++ b/clients/dispatch/runners/go-vet.ts
@@ -24,7 +24,6 @@ const goVetRunner: RunnerDefinition = {
 	id: "go-vet",
 	appliesTo: ["go"],
 	priority: PRIORITY.SPECIALIZED_ANALYSIS,
-	enabledByDefault: true,
 	timeoutMs: 40_000,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/golangci-lint.ts
+++ b/clients/dispatch/runners/golangci-lint.ts
@@ -124,7 +124,6 @@ const golangciRunner: RunnerDefinition = {
 	id: "golangci-lint",
 	appliesTo: ["go"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	timeoutMs: 90_000,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/hadolint.ts
+++ b/clients/dispatch/runners/hadolint.ts
@@ -55,7 +55,6 @@ const hadolintRunner: RunnerDefinition = {
 	id: "hadolint",
 	appliesTo: ["docker"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/helm-lint.ts
+++ b/clients/dispatch/runners/helm-lint.ts
@@ -197,7 +197,6 @@ const helmLintRunner: RunnerDefinition = {
 	id: "helm-lint",
 	appliesTo: ["yaml", "helm-template"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 	timeoutMs: 35_000,
 

--- a/clients/dispatch/runners/helm-render.ts
+++ b/clients/dispatch/runners/helm-render.ts
@@ -1107,7 +1107,6 @@ const helmRenderRunner: RunnerDefinition = {
 	id: "helm-render",
 	appliesTo: ["yaml", "helm-template"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 	timeoutMs: RENDER_TIMEOUT_MS + TRIVY_TIMEOUT_MS + 10_000,
 

--- a/clients/dispatch/runners/htmlhint.ts
+++ b/clients/dispatch/runners/htmlhint.ts
@@ -63,7 +63,6 @@ const htmlhintRunner: RunnerDefinition = {
 	id: "htmlhint",
 	appliesTo: ["html"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/javac.ts
+++ b/clients/dispatch/runners/javac.ts
@@ -51,7 +51,6 @@ const javacRunner: RunnerDefinition = {
 	id: "javac",
 	appliesTo: ["java"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/ktlint.ts
+++ b/clients/dispatch/runners/ktlint.ts
@@ -86,7 +86,6 @@ const ktlintRunner: RunnerDefinition = {
 	id: "ktlint",
 	appliesTo: ["kotlin"],
 	priority: PRIORITY.FORMAT_AND_LINT_PRIMARY,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/lsp.ts
+++ b/clients/dispatch/runners/lsp.ts
@@ -124,7 +124,6 @@ const lspRunner: RunnerDefinition = {
 	// is now the only step this seam needs (#1545).
 	appliesTo: getLspCapableKinds(),
 	priority: PRIORITY.LSP_PRIMARY,
-	enabledByDefault: true,
 	timeoutMs: LSP_RUNNER_TIMEOUT_MS,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/markdownlint.ts
+++ b/clients/dispatch/runners/markdownlint.ts
@@ -115,7 +115,6 @@ const markdownlintRunner: RunnerDefinition = {
 	id: "markdownlint",
 	appliesTo: ["markdown"],
 	priority: PRIORITY.DOC_QUALITY,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/mypy.ts
+++ b/clients/dispatch/runners/mypy.ts
@@ -77,7 +77,6 @@ const mypyRunner: RunnerDefinition = {
 	id: "mypy",
 	appliesTo: ["python"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/oxlint.ts
+++ b/clients/dispatch/runners/oxlint.ts
@@ -104,7 +104,6 @@ const oxlintRunner: RunnerDefinition = {
 	id: "oxlint",
 	appliesTo: ["jsts"],
 	priority: PRIORITY.LINT_SECONDARY,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/php-lint.ts
+++ b/clients/dispatch/runners/php-lint.ts
@@ -40,7 +40,6 @@ const phpLintRunner: RunnerDefinition = {
 	id: "php-lint",
 	appliesTo: ["php"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/phpstan.ts
+++ b/clients/dispatch/runners/phpstan.ts
@@ -129,7 +129,6 @@ const phpstanRunner: RunnerDefinition = {
 	id: "phpstan",
 	appliesTo: ["php"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/prisma-validate.ts
+++ b/clients/dispatch/runners/prisma-validate.ts
@@ -49,7 +49,6 @@ const prismaValidateRunner: RunnerDefinition = {
 	id: "prisma-validate",
 	appliesTo: ["prisma"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/psscriptanalyzer.ts
+++ b/clients/dispatch/runners/psscriptanalyzer.ts
@@ -327,7 +327,6 @@ const psScriptAnalyzerRunner: RunnerDefinition = {
 	id: "psscriptanalyzer",
 	appliesTo: ["powershell"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/pyright.ts
+++ b/clients/dispatch/runners/pyright.ts
@@ -29,7 +29,6 @@ const pyrightRunner: RunnerDefinition = {
 	id: "pyright",
 	appliesTo: ["python"],
 	priority: PRIORITY.LSP_FALLBACK,
-	enabledByDefault: true,
 	timeoutMs: 75_000,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/rubocop.ts
+++ b/clients/dispatch/runners/rubocop.ts
@@ -91,7 +91,6 @@ const rubocopRunner: RunnerDefinition = {
 	id: "rubocop",
 	appliesTo: ["ruby"],
 	priority: PRIORITY.FORMAT_AND_LINT_PRIMARY,
-	enabledByDefault: true,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {
 		const cwd = ctx.cwd || process.cwd();

--- a/clients/dispatch/runners/ruff.ts
+++ b/clients/dispatch/runners/ruff.ts
@@ -74,7 +74,6 @@ const ruffRunner: RunnerDefinition = {
 	id: "ruff-lint",
 	appliesTo: ["python"],
 	priority: PRIORITY.FORMAT_AND_LINT_PRIMARY,
-	enabledByDefault: true,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {
 		const cwd = ctx.cwd || process.cwd();

--- a/clients/dispatch/runners/rust-clippy.ts
+++ b/clients/dispatch/runners/rust-clippy.ts
@@ -81,7 +81,6 @@ const rustClippyRunner: RunnerDefinition = {
 	id: "rust-clippy",
 	appliesTo: ["rust"],
 	priority: PRIORITY.SPECIALIZED_ANALYSIS,
-	enabledByDefault: true,
 	timeoutMs: 90_000,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/shellcheck.ts
+++ b/clients/dispatch/runners/shellcheck.ts
@@ -138,7 +138,6 @@ const shellcheckRunner: RunnerDefinition = {
 	id: "shellcheck",
 	appliesTo: ["shell"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false, // Shell scripts in test directories should still be checked
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/shfmt.ts
+++ b/clients/dispatch/runners/shfmt.ts
@@ -39,7 +39,6 @@ const shfmtRunner: RunnerDefinition = {
 	id: "shfmt",
 	appliesTo: ["shell"],
 	priority: PRIORITY.FORMAT_AND_LINT_PRIMARY,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/spellcheck.ts
+++ b/clients/dispatch/runners/spellcheck.ts
@@ -103,7 +103,6 @@ const spellcheckRunner: RunnerDefinition = {
 	id: "spellcheck",
 	appliesTo: ["markdown"],
 	priority: PRIORITY.DOC_QUALITY,
-	enabledByDefault: true,
 	skipTestFiles: false, // Check docs in test files too
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/spotbugs.ts
+++ b/clients/dispatch/runners/spotbugs.ts
@@ -213,7 +213,6 @@ const spotbugsRunner: RunnerDefinition = {
 	id: "spotbugs",
 	appliesTo: ["java", "kotlin"],
 	priority: PRIORITY.DEEP_LANGUAGE_ANALYSIS,
-	enabledByDefault: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {
 		const cwd = ctx.cwd || process.cwd();

--- a/clients/dispatch/runners/sqlfluff.ts
+++ b/clients/dispatch/runners/sqlfluff.ts
@@ -139,7 +139,6 @@ const sqlfluffRunner: RunnerDefinition = {
 	id: "sqlfluff",
 	appliesTo: ["sql"],
 	priority: PRIORITY.SQL_LINT,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/stylelint.ts
+++ b/clients/dispatch/runners/stylelint.ts
@@ -147,7 +147,6 @@ const stylelintRunner: RunnerDefinition = {
 	id: "stylelint",
 	appliesTo: ["css"],
 	priority: PRIORITY.FORMAT_AND_LINT_PRIMARY,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/swiftlint.ts
+++ b/clients/dispatch/runners/swiftlint.ts
@@ -155,7 +155,6 @@ const swiftlintRunner: RunnerDefinition = {
 	id: "swiftlint",
 	appliesTo: ["swift"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/taplo.ts
+++ b/clients/dispatch/runners/taplo.ts
@@ -121,7 +121,6 @@ const taploRunner: RunnerDefinition = {
 	id: "taplo",
 	appliesTo: ["toml"],
 	priority: PRIORITY.FORMAT_AND_LINT_PRIMARY,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/terragrunt.ts
+++ b/clients/dispatch/runners/terragrunt.ts
@@ -154,7 +154,6 @@ const terragruntRunner: RunnerDefinition = {
 	id: "terragrunt",
 	appliesTo: ["terragrunt"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/tflint.ts
+++ b/clients/dispatch/runners/tflint.ts
@@ -77,7 +77,6 @@ const tflintRunner: RunnerDefinition = {
 	id: "tflint",
 	appliesTo: ["terraform"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/tree-sitter.ts
+++ b/clients/dispatch/runners/tree-sitter.ts
@@ -394,7 +394,6 @@ const treeSitterRunner: RunnerDefinition = {
 		"css",
 	],
 	priority: PRIORITY.STRUCTURAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false, // Run on test files too (structural issues matter there)
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/trivy-config.ts
+++ b/clients/dispatch/runners/trivy-config.ts
@@ -163,7 +163,6 @@ const trivyConfigRunner: RunnerDefinition = {
 	id: "trivy-config",
 	appliesTo: ["docker", "yaml", "terraform", "json"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/vale.ts
+++ b/clients/dispatch/runners/vale.ts
@@ -129,7 +129,6 @@ const valeRunner: RunnerDefinition = {
 	id: "vale",
 	appliesTo: ["markdown"],
 	priority: PRIORITY.DOC_QUALITY,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/yamllint.ts
+++ b/clients/dispatch/runners/yamllint.ts
@@ -47,7 +47,6 @@ const yamllintRunner: RunnerDefinition = {
 	id: "yamllint",
 	appliesTo: ["yaml"],
 	priority: PRIORITY.YAML_LINT,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/runners/zig-check.ts
+++ b/clients/dispatch/runners/zig-check.ts
@@ -56,7 +56,6 @@ const zigCheckRunner: RunnerDefinition = {
 	id: "zig-check",
 	appliesTo: ["zig"],
 	priority: PRIORITY.GENERAL_ANALYSIS,
-	enabledByDefault: true,
 	skipTestFiles: false,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {

--- a/clients/dispatch/types.ts
+++ b/clients/dispatch/types.ts
@@ -131,7 +131,6 @@ export interface RunnerDefinition {
 	id: string;
 	appliesTo: readonly FileKind[];
 	priority: number;
-	enabledByDefault: boolean;
 	/** Skip this runner for test files (false positive reduction) */
 	skipTestFiles?: boolean;
 	/** Per-runner wall-clock timeout in ms; overrides dispatch.runnerTimeoutMs when set */

--- a/tests/clients/dispatch/dispatcher-flow.test.ts
+++ b/tests/clients/dispatch/dispatcher-flow.test.ts
@@ -217,7 +217,6 @@ describe("Dispatch Flow", () => {
 				id: "lsp",
 				appliesTo: ["go"],
 				priority: 4,
-				enabledByDefault: true,
 				async run() {
 					return { status: "skipped", diagnostics: [], semantic: "none" };
 				},
@@ -226,7 +225,6 @@ describe("Dispatch Flow", () => {
 				id: "go-vet",
 				appliesTo: ["go"],
 				priority: 12,
-				enabledByDefault: true,
 				async run() {
 					return { status: "skipped", diagnostics: [], semantic: "none" };
 				},
@@ -235,7 +233,6 @@ describe("Dispatch Flow", () => {
 				id: "golangci-lint",
 				appliesTo: ["go"],
 				priority: 14,
-				enabledByDefault: true,
 				async run() {
 					return { status: "skipped", diagnostics: [], semantic: "none" };
 				},
@@ -244,7 +241,6 @@ describe("Dispatch Flow", () => {
 				id: "tree-sitter",
 				appliesTo: ["go"],
 				priority: 20,
-				enabledByDefault: true,
 				async run() {
 					return { status: "succeeded", diagnostics: [], semantic: "none" };
 				},
@@ -274,7 +270,6 @@ describe("Dispatch Flow", () => {
 				id: "lsp",
 				appliesTo: ["go"],
 				priority: 4,
-				enabledByDefault: true,
 				async run() {
 					return { status: "skipped", diagnostics: [], semantic: "none" };
 				},
@@ -283,7 +278,6 @@ describe("Dispatch Flow", () => {
 				id: "go-vet",
 				appliesTo: ["go"],
 				priority: 12,
-				enabledByDefault: true,
 				async run() {
 					return { status: "skipped", diagnostics: [], semantic: "none" };
 				},
@@ -292,7 +286,6 @@ describe("Dispatch Flow", () => {
 				id: "eslint",
 				appliesTo: ["jsts"],
 				priority: 15,
-				enabledByDefault: true,
 				async run() {
 					return { status: "succeeded", diagnostics: [], semantic: "none" };
 				},
@@ -334,7 +327,6 @@ describe("Dispatch Flow", () => {
 				id: "lsp",
 				appliesTo: ["jsts"],
 				priority: 4,
-				enabledByDefault: true,
 				async run() {
 					return {
 						status: "succeeded",
@@ -359,7 +351,6 @@ describe("Dispatch Flow", () => {
 				id: "eslint",
 				appliesTo: ["jsts"],
 				priority: 12,
-				enabledByDefault: true,
 				async run() {
 					return {
 						status: "succeeded",
@@ -410,7 +401,6 @@ describe("Dispatch Flow", () => {
 				id: "code-path",
 				appliesTo: ["jsts"],
 				priority: 10,
-				enabledByDefault: true,
 				async run() {
 					return {
 						status: "succeeded",
@@ -443,7 +433,6 @@ describe("Dispatch Flow", () => {
 				id: "first-fail",
 				appliesTo: ["jsts"],
 				priority: 10,
-				enabledByDefault: true,
 				async run() {
 					calls.push("first-fail");
 					return {
@@ -467,7 +456,6 @@ describe("Dispatch Flow", () => {
 				id: "second-success",
 				appliesTo: ["jsts"],
 				priority: 11,
-				enabledByDefault: true,
 				async run() {
 					calls.push("second-success");
 					return {
@@ -491,7 +479,6 @@ describe("Dispatch Flow", () => {
 				id: "third-skipped",
 				appliesTo: ["jsts"],
 				priority: 12,
-				enabledByDefault: true,
 				async run() {
 					calls.push("third-skipped");
 					return { status: "succeeded", diagnostics: [], semantic: "none" };
@@ -884,7 +871,6 @@ describe("Dispatch Flow", () => {
 				id: "ok",
 				appliesTo: ["jsts"],
 				priority: 10,
-				enabledByDefault: true,
 				async run() {
 					return {
 						status: "succeeded",
@@ -906,7 +892,6 @@ describe("Dispatch Flow", () => {
 				id: "boom",
 				appliesTo: ["jsts"],
 				priority: 11,
-				enabledByDefault: true,
 				async run() {
 					throw new Error("kaboom");
 				},
@@ -943,7 +928,6 @@ describe("Dispatch Flow", () => {
 				id: "skipme",
 				appliesTo: ["jsts"],
 				priority: 10,
-				enabledByDefault: true,
 				when: async () => false,
 				async run() {
 					return { status: "succeeded", diagnostics: [], semantic: "none" };

--- a/tests/clients/dispatch/javac-dispatch-integration.test.ts
+++ b/tests/clients/dispatch/javac-dispatch-integration.test.ts
@@ -178,7 +178,6 @@ function createJavaRegistry(
 		id: "lsp",
 		appliesTo: ["java"],
 		priority: 4,
-		enabledByDefault: true,
 		async run() {
 			return {
 				status: lspReady() ? "succeeded" : "skipped",

--- a/tests/clients/dispatch/rule-policy-dispatcher.test.ts
+++ b/tests/clients/dispatch/rule-policy-dispatcher.test.ts
@@ -41,7 +41,6 @@ function mockRunner(id: string, diagnostics: Diagnostic[]): RunnerDefinition {
 		id,
 		appliesTo: ["jsts"],
 		priority: 10,
-		enabledByDefault: true,
 		async run() {
 			return {
 				status: "succeeded",

--- a/tests/clients/dispatch/runner-collect-later.test.ts
+++ b/tests/clients/dispatch/runner-collect-later.test.ts
@@ -50,7 +50,6 @@ describe("observed runner collect-later tier (#2116)", () => {
 			id: "fixture-runner",
 			appliesTo: ["jsts"],
 			priority: 1,
-			enabledByDefault: true,
 			run: async () => completed,
 		});
 		const ctx = createDispatchContext(
@@ -130,7 +129,6 @@ describe("observed runner collect-later tier (#2116)", () => {
 			id: "failed-runner",
 			appliesTo: ["jsts"],
 			priority: 1,
-			enabledByDefault: true,
 			run: async () => new Promise<RunnerResult>((r) => (resolve = r)),
 		});
 		const ctx = createDispatchContext(
@@ -174,7 +172,6 @@ describe("observed runner collect-later tier (#2116)", () => {
 			id: "direct-runner",
 			appliesTo: ["jsts"],
 			priority: 1,
-			enabledByDefault: true,
 			run: async () => ({
 				status: "succeeded",
 				diagnostics: [

--- a/tests/clients/dispatch/runner-timeout.test.ts
+++ b/tests/clients/dispatch/runner-timeout.test.ts
@@ -56,7 +56,6 @@ describe("runRunner timeout behavior", () => {
 			id: "slow-tool",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			timeoutMs: 30,
 			async run(): Promise<RunnerResult> {
 				return new Promise(() => {});
@@ -78,7 +77,6 @@ describe("runRunner timeout behavior", () => {
 			id: "fast-tool",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			timeoutMs: 5_000,
 			async run(): Promise<RunnerResult> {
 				return {
@@ -112,7 +110,6 @@ describe("runRunner timeout behavior", () => {
 			id: "exploding",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			timeoutMs: 5_000,
 			async run(): Promise<RunnerResult> {
 				throw new Error("runner blew up");
@@ -134,7 +131,6 @@ describe("runRunner timeout behavior", () => {
 			id: "slow-a",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			timeoutMs: 30,
 			async run(): Promise<RunnerResult> {
 				return new Promise(() => {});
@@ -146,7 +142,6 @@ describe("runRunner timeout behavior", () => {
 			id: "fast-b",
 			appliesTo: ["jsts"],
 			priority: 11,
-			enabledByDefault: true,
 			timeoutMs: 5_000,
 			async run(): Promise<RunnerResult> {
 				return {
@@ -213,7 +208,6 @@ describe("runRunner in-flight phase attribution (#1723)", () => {
 			id: "astgrep-scan",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			async run(): Promise<RunnerResult> {
 				// Read the slot mid-flight — this is the synthetic stand-in for a
 				// loop_block sample landing while the runner is still running.
@@ -233,7 +227,6 @@ describe("runRunner in-flight phase attribution (#1723)", () => {
 			id: "fast-tool",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			async run(): Promise<RunnerResult> {
 				return { status: "succeeded", diagnostics: [], semantic: "warning" };
 			},
@@ -253,7 +246,6 @@ describe("runRunner in-flight phase attribution (#1723)", () => {
 			id: "exploding",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			timeoutMs: 5_000,
 			async run(): Promise<RunnerResult> {
 				throw new Error("runner blew up");
@@ -271,7 +263,6 @@ describe("runRunner in-flight phase attribution (#1723)", () => {
 			id: "slow-tool",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			timeoutMs: 30,
 			async run(): Promise<RunnerResult> {
 				return new Promise(() => {});
@@ -339,7 +330,6 @@ describe("runRunner in-flight phase attribution against real parallel groups (#1
 			id: "cpu-hog",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			timeoutMs: 5_000,
 			async run(): Promise<RunnerResult> {
 				return hogPromise;
@@ -349,7 +339,6 @@ describe("runRunner in-flight phase attribution against real parallel groups (#1
 			id: "idle",
 			appliesTo: ["jsts"],
 			priority: 11,
-			enabledByDefault: true,
 			async run(): Promise<RunnerResult> {
 				return { status: "succeeded", diagnostics: [], semantic: "warning" };
 			},
@@ -414,7 +403,6 @@ describe("runRunner in-flight phase attribution against real parallel groups (#1
 			id: "cpu-hog",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			timeoutMs: 5_000,
 			async run(): Promise<RunnerResult> {
 				return hogPromise;
@@ -424,7 +412,6 @@ describe("runRunner in-flight phase attribution against real parallel groups (#1
 			id: "idle",
 			appliesTo: ["jsts"],
 			priority: 11,
-			enabledByDefault: true,
 			async run(): Promise<RunnerResult> {
 				return { status: "succeeded", diagnostics: [], semantic: "warning" };
 			},
@@ -477,7 +464,6 @@ describe("runRunner in-flight phase attribution against real parallel groups (#1
 			id: "innocent-parked-runner",
 			appliesTo: ["jsts"],
 			priority: 10,
-			enabledByDefault: true,
 			timeoutMs: 5_000,
 			async run(): Promise<RunnerResult> {
 				return innocentPromise;
@@ -492,7 +478,6 @@ describe("runRunner in-flight phase attribution against real parallel groups (#1
 			id: "cpu-hog",
 			appliesTo: ["jsts"],
 			priority: 11,
-			enabledByDefault: true,
 			timeoutMs: 5_000,
 			async run(): Promise<RunnerResult> {
 				return hogPromise;
@@ -584,7 +569,6 @@ describe("runRunner in-flight phase attribution against real parallel groups (#1
 				id: "cpu-hog",
 				appliesTo: ["jsts"],
 				priority: 10,
-				enabledByDefault: true,
 				timeoutMs: 60_000, // generous — never meant to fire, resolved manually
 				async run(): Promise<RunnerResult> {
 					return hogPromise;
@@ -594,7 +578,6 @@ describe("runRunner in-flight phase attribution against real parallel groups (#1
 				id: "innocent-co-started-runner",
 				appliesTo: ["jsts"],
 				priority: 11,
-				enabledByDefault: true,
 				timeoutMs: 60_000,
 				async run(): Promise<RunnerResult> {
 					return innocentPromise;

--- a/tests/clients/dispatch/runners/ast-grep-napi.test.ts
+++ b/tests/clients/dispatch/runners/ast-grep-napi.test.ts
@@ -395,7 +395,6 @@ describe("ast-grep-napi runner — metadata", () => {
 		const runner = mod.default;
 		expect(runner.id).toBe("ast-grep-napi");
 		expect(runner.appliesTo).toContain("jsts");
-		expect(runner.enabledByDefault).toBe(true);
 	});
 });
 

--- a/tests/clients/dispatch/runners/eslint.test.ts
+++ b/tests/clients/dispatch/runners/eslint.test.ts
@@ -146,7 +146,6 @@ describe("eslint runner", () => {
 					id,
 					appliesTo: ["jsts"],
 					priority: id === "oxlint" ? 2 : 3,
-					enabledByDefault: true,
 					async run() {
 						downstreamRuns++;
 						return { status: "succeeded", diagnostics: [], semantic: "none" };

--- a/tests/clients/dispatch/runners/oxlint.test.ts
+++ b/tests/clients/dispatch/runners/oxlint.test.ts
@@ -735,7 +735,6 @@ describe("oxlint runner", () => {
 				id: "eslint",
 				appliesTo: ["jsts"],
 				priority: 1,
-				enabledByDefault: true,
 				async run() {
 					return { status: "skipped", diagnostics: [], semantic: "none" };
 				},
@@ -745,7 +744,6 @@ describe("oxlint runner", () => {
 				id: "biome-check-json",
 				appliesTo: ["jsts"],
 				priority: 3,
-				enabledByDefault: true,
 				async run() {
 					biomeCalls.push(Date.now());
 					return { status: "succeeded", diagnostics: [], semantic: "none" };
@@ -1246,7 +1244,6 @@ describe("oxlint runner", () => {
 				id: "malformed-skip",
 				appliesTo: ["jsts"],
 				priority: 1,
-				enabledByDefault: true,
 				async run() {
 					return {
 						status: "skipped",

--- a/tests/clients/dispatch/runners/tree-sitter-runner.test.ts
+++ b/tests/clients/dispatch/runners/tree-sitter-runner.test.ts
@@ -189,7 +189,6 @@ describe("tree-sitter runner — metadata", () => {
 		expect(runner.appliesTo).toContain("rust");
 		expect(runner.appliesTo).toContain("ruby");
 		expect(runner.appliesTo).toContain("cxx");
-		expect(runner.enabledByDefault).toBe(true);
 	});
 });
 

--- a/tests/mocks/runner-factory.ts
+++ b/tests/mocks/runner-factory.ts
@@ -15,7 +15,6 @@ export interface MockRunnerConfig {
 	id: string;
 	appliesTo: string[];
 	priority?: number;
-	enabledByDefault?: boolean;
 	skipTestFiles?: boolean;
 	when?: (ctx: DispatchContext) => boolean | Promise<boolean>;
 	runResult: RunnerResult;
@@ -27,7 +26,6 @@ export function createMockRunner(config: MockRunnerConfig): RunnerDefinition {
 		id: config.id,
 		appliesTo: config.appliesTo as any,
 		priority: config.priority ?? 10,
-		enabledByDefault: config.enabledByDefault ?? true,
 		skipTestFiles: config.skipTestFiles ?? false,
 		when: config.when,
 		async run(_ctx: DispatchContext): Promise<RunnerResult> {


### PR DESCRIPTION
## Summary

Runner definitions no longer claim an `enabledByDefault` policy that dispatch never enforced. The change removes the dead field from `RunnerDefinition`, all 49 runner definitions, and their fixtures. Dispatch groups and explicit feature gates remain the single runner-availability contract.

This follows the minimalism ladder: deleting the unused declaration preserves behavior, while enforcing it would invent a second policy layer and conflict with explicitly gated runners such as SpotBugs.

Consulted AGENTS.md sections: Issue and PR design contract; Contributing; Recurring defect shapes; Standing invariants — Dispatch, runners, formatters, and installer; Test requirements; Testing dispatch runners; Real-runner rule/dispatch tests.

## Tests

- `npm run build` — passed after rebasing onto `origin/master`.
- `npm run lint` — passed.
- `npm run fmt:check` — passed.
- `npm run changelog:check` — passed with 10 entries.
- `npm run astgrep:self-scan` — passed with 0 findings.
- Targeted dispatch batch — 9 files, 144 tests passed.
- Pre-push build — passed.

Edited tests and fixtures:

- `dispatcher-flow.test.ts` — removes the extinct field from inline runner fixtures; existing cases continue to pin group order, skip, failure, and success behavior.
- `javac-dispatch-integration.test.ts` — keeps the Java integration runner fixture aligned with the production type.
- `rule-policy-dispatcher.test.ts` — keeps policy dispatch fixtures aligned without changing assertions.
- `runner-collect-later.test.ts` — keeps collect-later fixtures aligned without changing delivery assertions.
- `runner-timeout.test.ts` — keeps timeout fixtures aligned without changing timeout behavior.
- `ast-grep-napi.test.ts` — removes a value pin for the deleted field; behavior assertions remain.
- `eslint.test.ts` — keeps the runner fixture aligned without changing behavior.
- `oxlint.test.ts` — removes the dead fixture field while preserving runner assertions.
- `tree-sitter-runner.test.ts` — removes a value pin for the deleted field; parser and dispatch assertions remain.
- `tests/mocks/runner-factory.ts` — removes the dead mock option and default.

## Blast radius

`module_report` and symbol-navigation tools were unavailable. A repository-wide `rg` and source read traced `getForKind`, `runGroup`, `dispatchForFile`, `dispatchLint`, `getDispatchGroupsForKind`, and `getAvailableRunners`. None read this field. The blast radius is type declarations and fixtures only; runtime behavior and hot-path cost are unchanged.

## Class sweep

Every `RunnerDefinition` member was checked against runtime readers. `id`, `appliesTo`, `priority`, `skipTestFiles`, `timeoutMs`, `when`, and `run` are consumed. `enabledByDefault` was the only write-only member. The separate `AuxiliaryLspProfile.enabledByDefault` field remains because `auxiliary-lsp.ts` reads it.

A final repository-wide search finds only that separate auxiliary-LSP contract and its contributor documentation.

## Observability

No runtime record changes. The deleted field had no reader and produced no observable state, so new telemetry would describe no behavior.

## Test assessment

No behavior test was removed. Two assertions that pinned the deleted property were removed because their subject no longer exists. The remaining tests continue to pin the runner behavior named above. All other test changes remove excess object-literal properties required by the type cleanup.

## Changelog

Added `.changelog/2354-remove-dead-runner-default.md` under `Fixed`.