### PR TITLE
fix(dispatch): honor grouped runner scope (closes #2353)

### DIFF
--- a/.changelog/2353-group-runner-applies-to.md
+++ b/.changelog/2353-group-runner-applies-to.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Honor runner language scope inside dispatch groups (closes #2353)** — grouped runners now use the same `appliesTo` contract as registry selection, so a runner cannot execute against a mismatched file kind and is recorded as skipped instead of failed.

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -100,7 +100,7 @@ export class RunnerRegistry implements RunnerRegistryContract {
 
 		for (const runner of this.runners.values()) {
 			if (isTest && runner.skipTestFiles) continue;
-			if (runner.appliesTo.includes(kind) || runner.appliesTo.length === 0) {
+			if (runnerAppliesToKind(runner, kind)) {
 				matching.push(runner);
 			}
 		}
@@ -115,6 +115,16 @@ export class RunnerRegistry implements RunnerRegistryContract {
 	clear(): void {
 		this.runners.clear();
 	}
+}
+
+function runnerAppliesToKind(
+	runner: RunnerDefinition,
+	kind: FileKind | undefined,
+): boolean {
+	return (
+		runner.appliesTo.length === 0 ||
+		(kind !== undefined && runner.appliesTo.includes(kind))
+	);
 }
 
 // --- Tool Availability Cache ---
@@ -833,6 +843,35 @@ async function runGroup(
 				status: "test_file_skipped",
 				diagnosticCount: 0,
 				semantic: "none",
+			});
+			continue;
+		}
+
+		// Keep explicit groups aligned with RunnerRegistry.getForKind(): an empty
+		// appliesTo list means every kind, while a populated list must contain the
+		// current kind. A filtered runner remains visible as skipped telemetry so
+		// language mismatches cannot be mistaken for runner failures.
+		const appliesToCurrentKind = runnerAppliesToKind(runner, ctx.kind);
+		if (!appliesToCurrentKind) {
+			const runnerEnd = Date.now();
+			latencies.push({
+				runnerId,
+				startTime: runnerStart,
+				endTime: runnerEnd,
+				durationMs: 0,
+				status: "skipped",
+				diagnosticCount: 0,
+				semantic: "unknown",
+			});
+			logLatency({
+				type: "runner",
+				filePath: ctx.filePath,
+				runnerId,
+				durationMs: 0,
+				status: "skipped",
+				diagnosticCount: 0,
+				semantic: "unknown",
+				metadata: { reason: "applies_to", kind: ctx.kind },
 			});
 			continue;
 		}

--- a/tests/clients/dispatch/dispatcher-flow.test.ts
+++ b/tests/clients/dispatch/dispatcher-flow.test.ts
@@ -329,6 +329,85 @@ describe("Dispatch Flow", () => {
 			expect(result.hasBlockers).toBe(true);
 		});
 
+		it("skips runners that do not apply to the file kind in a group", async () => {
+			const calls: string[] = [];
+			registerRunner(
+				createMockRunner({
+					id: "python-only",
+					appliesTo: ["python"],
+					runResult: {
+						status: "succeeded",
+						diagnostics: [
+							{
+								id: "wrong-kind",
+								message: "must not run",
+								filePath: "test.ts",
+								severity: "error",
+								semantic: "blocking",
+								tool: "python-only",
+							},
+						],
+						semantic: "blocking",
+					},
+				}),
+			);
+			registerRunner(
+				createMockRunner({
+					id: "all-kinds",
+					appliesTo: [],
+					runResult: {
+						status: "succeeded",
+						diagnostics: [],
+						semantic: "none",
+					},
+					when: () => {
+						calls.push("all-kinds");
+						return true;
+					},
+				}),
+			);
+			registerRunner(
+				createMockRunner({
+					id: "jsts-only",
+					appliesTo: ["jsts"],
+					runResult: {
+						status: "succeeded",
+						diagnostics: [],
+						semantic: "none",
+					},
+					when: () => {
+						calls.push("jsts-only");
+						return true;
+					},
+				}),
+			);
+
+			const ctx = createMockContext("test.ts");
+			const result = await dispatchForFile(ctx, [
+				{
+					mode: "all",
+					runnerIds: ["python-only", "all-kinds", "jsts-only"],
+					filterKinds: ["jsts"],
+				},
+			]);
+
+			expect(calls).toEqual(["all-kinds", "jsts-only"]);
+			expect(result.diagnostics).toEqual([]);
+			const report = getLatencyReports().at(-1);
+			expect(report?.runners).toContainEqual(
+				expect.objectContaining({
+					runnerId: "python-only",
+					status: "skipped",
+				}),
+			);
+			expect(report?.runners).not.toContainEqual(
+				expect.objectContaining({
+					runnerId: "python-only",
+					status: "failed",
+				}),
+			);
+		});
+
 		it("suppresses overlapping non-blocking lint warnings when LSP reports same span/class", async () => {
 			registerRunner({
 				id: "lsp",


### PR DESCRIPTION
## Summary

Grouped dispatch now enforces `RunnerDefinition.appliesTo` with the same predicate used by `RunnerRegistry.getForKind`. A mismatched runner is skipped before its `when` or `run` callback and remains visible as skipped latency telemetry rather than a failure.

The current-master rebase also composed the new guard with #2337's grouped `skipTestFiles` guard. The registry order is preserved: test-file exclusion runs before language applicability.

Consulted AGENTS.md sections: Issue and PR design contract; Contributing; Recurring defect shapes; Standing invariants — Dispatch, runners, formatters, and installer; Test requirements; Testing dispatch runners; Real-runner rule/dispatch tests.

## Tests

- `npm run build` — passed on the rebased head.
- `npm run lint` — passed.
- `npm run fmt:check` — passed.
- `npm run changelog:check` — passed with 10 entries.
- `npm run astgrep:self-scan` — passed with 0 findings.
- `dispatcher-flow.test.ts` plus `dispatch-coverage.test.ts` — 31 tests passed.
- Pre-push targeted selection — 24 files, 303 tests passed.
- Guard-deletion mutant — the wrong-kind diagnostic surfaced and the new test failed.
- Wildcard-overmatching mutant — the generic runner was skipped and the new test failed.

The first pre-push attempt had one existing rule-policy test exceed its 5-second timeout under the 24-file parallel batch; 302 tests passed. The exact test passed alone in 314 ms, and the complete pre-push batch passed on retry with 303 tests.

Edited test:

- `tests/clients/dispatch/dispatcher-flow.test.ts` — adds one production-entry regression through `dispatchForFile` that pins mismatched, matching, and wildcard applicability plus skipped-versus-failed latency status.

## Blast radius

`module_report` and symbol-navigation tools were unavailable. Source tracing shows `runGroup` is internal to `dispatchForFile`; callers reach it through dispatch integration and tests. `RunnerRegistry.getForKind` now calls the shared predicate, preserving its prior semantics. The added group check is one array-length test and, for scoped runners, one `includes` call per grouped runner.

## Class sweep

Shape: one `RunnerDefinition` policy enforced on registry selection but bypassed by explicit group lookup. The population sweep covered every `RunnerDefinition` member. Current master already fixed the `skipTestFiles` sibling (#2337); this change fixes `appliesTo`. `id`, `priority`, `timeoutMs`, `when`, and `run` have group-path consumers. The dead `enabledByDefault` sibling is handled separately by PR #2359.

## Composition

A separate worktree merged PR #2359's branch and this branch onto current `origin/master`. Build, lint, and six overlapping dispatch files passed: 6 files and 121 tests. The merge was conflict-free.

## Observability

The existing runner latency surfaces record mismatches as `status: skipped`. The emitted runner row also carries `metadata.reason: applies_to` and the current kind, distinguishing language filtering from failure without a new record family.

## Test assessment

`dispatcher-flow.test.ts` uniquely pins the grouped applicability seam through the production entry point and proves both directions: mismatched runners do not run, while matching and wildcard runners still run. No tests were removed or weakened.

## Changelog

Added `.changelog/2353-group-runner-applies-to.md` under `Fixed`.