### PR TITLE
fix(lsp): rearm late auxiliary coverage (refs #2356)

### DIFF
--- a/.changelog/2356-late-auxiliary-rearm.md
+++ b/.changelog/2356-late-auxiliary-rearm.md
@@ -1,0 +1,8 @@
+---
+section: Fixed
+---
+
+- **Re-arm late auxiliary coverage after notify-stall teardown (refs #2356)** —
+  pending pairs survive temporary client absence, re-raise a bounded scanner
+  coverage gap when replacement does not arrive, and correlate demotion state
+  with each pair generation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,8 +498,9 @@ must reach the AGENT-facing surface too
 (`CascadeNeighborResult.unconfirmedServerIds` and the cascade formatter), not
 only the result wrapper. One aggregate `lsp_scanner_coverage_gap` count per
 touch records every pair; detailed re-raised rows use the bounded telemetry
-cap for the current turn, while the degradation ledger retains each
-server/file identity and the aggregate row reports dropped detail.
+cap for the current turn, while the degradation ledger retains a bounded
+latest server/file identity window and its dropped count. The aggregate row
+reports dropped detail, so identities beyond those bounds are not implied.
 #1493's content-hash exemption outranks a deferral: a scanner whose STORED
 publication is bound to exactly these bytes has reported on this file, so the
 skipped resync withholds nothing — it stays covered, and its stored findings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,6 +444,16 @@ bounded stuck-pair identity in the phase record. Pair-level retirements and
 finding-level counts use separate fields and reconcile each drained pair to
 one retirement or a pending-after count. (#2151)
 
+Notify-stall teardown is a temporary client-generation absence, not proof that
+an auxiliary scanner is gone. `LSPService` carries that reason through the
+read-only late-coverage probe with the demotion timestamp until a replacement
+generation is published; turn-end correlates each pair's mark to that timestamp
+before re-arming under the same TTL and count ceiling. Pairs marked after
+teardown follow ordinary `clientGone` handling. If no replacement appears
+before that bounded window closes, the pre-demotion pair is retired and
+re-raises `lsp_scanner_coverage_gap` with its server/file identity instead of
+being counted as an ordinary `clientGone` absence. (#2356)
+
 Every auxiliary touch emits one bounded `lsp_aux_wait_outcome` latency row, on
 both producers: the `with-auxiliary` grace wait (`waitShape: "aux_grace"`) and,
 since #1533, the `clientScope: "all"` aggregate wait (`waitShape: "aggregate"`),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -496,7 +496,10 @@ silence reads as CLEAN unless the touch names it. A scanner that never attached
 `unconfirmedServerIds`, exactly like a cut-off or silent auxiliary, and the gap
 must reach the AGENT-facing surface too
 (`CascadeNeighborResult.unconfirmedServerIds` and the cascade formatter), not
-only the result wrapper. One `lsp_scanner_coverage_gap` row per touch records it.
+only the result wrapper. One aggregate `lsp_scanner_coverage_gap` count per
+touch records every pair; detailed re-raised rows use the bounded telemetry
+cap for the current turn, while the degradation ledger retains each
+server/file identity and the aggregate row reports dropped detail.
 #1493's content-hash exemption outranks a deferral: a scanner whose STORED
 publication is bound to exactly these bytes has reported on this file, so the
 skipped resync withholds nothing — it stays covered, and its stored findings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
-- **Bound re-raised auxiliary coverage-gap detail (#2356)** — notify-stall pairs still count every uncovered server/file in the degradation ledger and turn-end aggregate, while detailed latency rows are capped at 20 per turn and report dropped detail.
+- **Bound re-raised auxiliary coverage-gap detail (#2356)** — notify-stall pairs still count every uncovered server/file in the degradation ledger and turn-end aggregate, while detailed latency rows are capped at 20 per turn. Bounded latest identity records expose their dropped count.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to pi-lens will be documented in this file.
 
 ### Fixed
 
+- **Bound re-raised auxiliary coverage-gap detail (#2356)** — notify-stall pairs still count every uncovered server/file in the degradation ledger and turn-end aggregate, while detailed latency rows are capped at 20 per turn and report dropped detail.
+
 ### Security
 
 ## [4.1.3] - 2026-08-28

--- a/clients/bounded-telemetry.ts
+++ b/clients/bounded-telemetry.ts
@@ -11,7 +11,8 @@
  * a speculative framework. Three of its four options come straight from those
  * sites. The fourth, `capPerTurn`, expresses #1733's per-turn bound
  * structurally and now caps re-raised auxiliary coverage-gap detail rows
- * (#2356), while the aggregate count and ledger retain every pair.
+ * (#2356), while the aggregate count and ledger retain bounded latest
+ * identities plus the dropped count.
  *
  * Three rules the helper makes structural instead of prose:
  *

--- a/clients/bounded-telemetry.ts
+++ b/clients/bounded-telemetry.ts
@@ -10,9 +10,8 @@
  * get the bounding right. This module is the intersection of those four, not
  * a speculative framework. Three of its four options come straight from those
  * sites. The fourth, `capPerTurn`, expresses #1733's per-turn bound
- * structurally but has no caller yet: that site's bound is its call cadence,
- * and pinning a cap there would red its own wiring tests. It ships tested and
- * mutation-proofed, awaiting its first site.
+ * structurally and now caps re-raised auxiliary coverage-gap detail rows
+ * (#2356), while the aggregate count and ledger retain every pair.
  *
  * Three rules the helper makes structural instead of prose:
  *
@@ -38,7 +37,7 @@
  * stated reason for staying raw.
  *
  * Nothing here ever throws. Telemetry must not perturb the path it observes —
- * every one of the four migrated sites had already decided its outcome before
+ * each caller has already decided its outcome before
  * calling in.
  */
 
@@ -118,6 +117,10 @@ export const BOUNDED_TELEMETRY_PHASES = [
 	 * command was declined on an UNKNOWN rather than assumed clean.
 	 */
 	"shared_checkout_probe_failed",
+	/** #2356: a notify-stall auxiliary remained uncovered after its bounded
+	 * replacement window. Detailed rows are capped per turn; the ledger and
+	 * aggregate turn-end row retain the complete count and identity. */
+	"lsp_scanner_coverage_gap",
 ] as const;
 
 export type BoundedPhase = (typeof BOUNDED_TELEMETRY_PHASES)[number];

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -1338,6 +1338,15 @@ export class LSPService {
 			wedgeTimer: ReturnType<typeof setTimeout>;
 		}
 	>();
+	/**
+	 * #2356: auxiliary clients removed by the notify-stall breaker are a
+	 * temporary absence, not a missing scanner. Keep the demotion identity after
+	 * deleting the client so the turn-end late-coverage probe can re-arm the
+	 * pending pair until a replacement is published (or its existing bounded
+	 * re-arm ceiling is reached). A successful replacement removes the marker.
+	 */
+	private readonly notifyStallDemotions = new Map<string, number>();
+	private static readonly MAX_NOTIFY_STALL_DEMOTIONS = 50;
 	/** LRU clock for capacity eviction, keyed by the canonical server/root key. */
 	private readonly clientLastUsedAt = new Map<string, number>();
 	/**
@@ -1820,6 +1829,14 @@ export class LSPService {
 		// at the ceiling and pay a barrier on its first file.
 		this.auxNotifyInflight.delete(key);
 		this.state.broken.set(key, Date.now() + BROKEN_BASE_COOLDOWN_MS);
+		this.notifyStallDemotions.set(key, Date.now());
+		while (
+			this.notifyStallDemotions.size > LSPService.MAX_NOTIFY_STALL_DEMOTIONS
+		) {
+			const oldest = this.notifyStallDemotions.keys().next().value;
+			if (oldest === undefined) break;
+			this.notifyStallDemotions.delete(oldest);
+		}
 		void entry.client.shutdown().catch(() => {});
 		this.state.clients.delete(key);
 		this.state.clientSpawnedAt.delete(key);
@@ -2748,9 +2765,11 @@ export class LSPService {
 	 * the Gate-B readiness check, this NEVER creates or warms a client — it only
 	 * resolves each requested server's root and reads the already-connected
 	 * client's cached diagnostics for `filePath`. Servers with no live client
-	 * are simply absent from the returned map. A live client is present only
-	 * when its per-file cache entry exists; its timestamp distinguishes a
-	 * published clean result from no publication.
+	 * are absent unless notify-stall teardown marked that generation as
+	 * replaceable; that status carries the demotion timestamp so turn-end late
+	 * coverage can correlate each pair to the removed generation. A live
+	 * client is present even when its per-file cache entry is empty; its
+	 * timestamp distinguishes a published clean result from no publication.
 	 */
 	async readCachedDiagnosticsForServers(
 		filePath: string,
@@ -2758,12 +2777,24 @@ export class LSPService {
 	): Promise<
 		Map<
 			string,
-			{ diags: import("./client.js").LSPDiagnostic[]; publishedAt?: number }
+			{
+				diags: import("./client.js").LSPDiagnostic[];
+				publishedAt?: number;
+				/** The client was removed by notify-stall teardown and may be replaced. */
+				notifyStallDemoted?: boolean;
+				/** When the demoted client generation was removed. */
+				demotedAt?: number;
+			}
 		>
 	> {
 		const out = new Map<
 			string,
-			{ diags: import("./client.js").LSPDiagnostic[]; publishedAt?: number }
+			{
+				diags: import("./client.js").LSPDiagnostic[];
+				publishedAt?: number;
+				notifyStallDemoted?: boolean;
+				demotedAt?: number;
+			}
 		>();
 		if (this.checkDestroyed() || serverIds.size === 0) return out;
 		for (const server of getServersForFileWithConfig(filePath)) {
@@ -2772,7 +2803,20 @@ export class LSPService {
 			if (!root) continue;
 			const key = `${server.id}:${normalizeMapKey(root)}`;
 			const client = this.state.clients.get(key);
-			if (!client?.isAlive()) continue;
+			if (!client?.isAlive()) {
+				const demotedAt = this.notifyStallDemotions.get(key);
+				if (demotedAt !== undefined) {
+					out.set(server.id, {
+						diags: [],
+						notifyStallDemoted: true,
+						demotedAt,
+					});
+				}
+				continue;
+			}
+			// A replacement is live again. The old generation's marker no longer
+			// describes this client and must not make a later absence look transient.
+			this.notifyStallDemotions.delete(key);
 			const entry = client.getAllDiagnostics().get(normalizeMapKey(filePath));
 			out.set(server.id, {
 				diags: entry?.diags ?? [],
@@ -3556,6 +3600,9 @@ export class LSPService {
 						};
 
 			this.state.clients.set(key, client);
+			// #2356: this generation is the replacement the late-coverage probe was
+			// waiting for. Clear the retired-generation marker before any later probe.
+			this.notifyStallDemotions.delete(key);
 			this.unavailableLogged.delete(key);
 			// #1934 review F1: a success retires the previous verdict, so the map
 			// never outlives the attempts it describes.
@@ -8693,6 +8740,7 @@ export class LSPService {
 		// describe a live one. The gate's identity check already neutralises a stale
 		// entry; clearing keeps the map honest rather than relying on that.
 		this.outstandingAuxNotifyWrites.clear();
+		this.notifyStallDemotions.clear();
 		// #1714: same reasoning — a backlog count belongs to a client generation,
 		// and every client is gone. `session_start` reaches this through the service
 		// reset, so the pacing state re-arms with the session rather than living for

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -5670,9 +5670,7 @@ export class LSPService {
 						reason: reasons.join(", ") || "scanner coverage gap",
 					});
 				}
-				logLatency({
-					type: "phase",
-					phase: "lsp_scanner_coverage_gap",
+				emitBounded("lsp_scanner_coverage_gap", `${source}:${normalizedPath}`, {
 					filePath: normalizedPath,
 					durationMs: Date.now() - startedAt,
 					metadata: {
@@ -5681,10 +5679,10 @@ export class LSPService {
 						...(brokenSkippedServerIds.length > 0 && {
 							brokenSkippedServerIds,
 						}),
-						// #1586: the deferrals this touch is actually uncovered for. The raw
+						// #1586: the deferrals this touch is actually uncovered for. The
 						// gate action keeps its own record in `lsp_notify_resync_deferred`;
-						// this row exists to prove a blackout, and a scanner already bound to
-						// these bytes is not one.
+						// this row exists to prove a blackout, and a scanner already bound
+						// to these bytes is not one.
 						...(uncoveredDeferredServerIds.length > 0 && {
 							deferredResyncServerIds: uncoveredDeferredServerIds,
 						}),

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -119,6 +119,7 @@ import {
 // (widget-state.ts) can use the marker without importing this orchestrator —
 // see clients/stale-marker.ts's doc comment.
 import { incrementDegradationCount } from "./degradation-ledger.js";
+import { emitBounded } from "./bounded-telemetry.js";
 import {
 	degradeDemotedFindingBody,
 	formatDeliveryCapNote,
@@ -126,12 +127,16 @@ import {
 } from "./demoted-finding-render.js";
 import { STALE_LINE_MARKER } from "./stale-marker.js";
 import { getActiveSessionId } from "./session-lifecycle.js";
+
 import {
 	getWidgetBlockingFilesForSweep,
 	markWidgetFileBlockersStale,
 	recordRunner,
 } from "./widget-state.js";
 import type { TestRunnerFindingsCache } from "./project-diagnostics/runner-adapters/runner-findings.js";
+
+/** Maximum detailed notify-stall coverage-gap rows emitted in one turn. */
+const LATE_AUX_COVERAGE_GAP_DETAIL_CAP_PER_TURN = 20;
 
 interface TurnEndDeps {
 	ctxCwd?: string;
@@ -2454,6 +2459,8 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 		filePath: string;
 		serverId: string;
 	}> = [];
+	let lateAuxCoverageGapDetailCount = 0;
+	let lateAuxCoverageGapDropCount = 0;
 	const lateAuxStuckPairs: Array<{ filePath: string; serverId: string }> = [];
 	if (drainedPairs.length > 0) {
 		const byFile = new Map<string, typeof drainedPairs>();
@@ -2646,24 +2653,31 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 		// preserving the server/file identity in both the ledger and latency row.
 		for (const pair of lateAuxCoverageGapPairs) {
 			const normalizedPairPath = normalizeMapKey(pair.filePath);
-			incrementDegradationCount({
-				kind: "lsp-scanner-coverage-gap",
-				subject: `${pair.serverId}:${normalizedPairPath}`,
-				reason:
-					"notify-stall replacement was not available before late-coverage ceiling",
-			});
-			logLatency({
-				type: "phase",
-				phase: "lsp_scanner_coverage_gap",
-				filePath: normalizedPairPath,
-				durationMs: 0,
-				metadata: {
-					source: "late-auxiliary",
-					serverIds: [pair.serverId],
-					reason: "notify-stall-replacement-unavailable",
-					reRaised: true,
+			const emitted = emitBounded(
+				"lsp_scanner_coverage_gap",
+				`${pair.serverId}:${normalizedPairPath}`,
+				{
+					filePath: normalizedPairPath,
+					durationMs: 0,
+					metadata: {
+						source: "late-auxiliary",
+						serverIds: [pair.serverId],
+						reason: "notify-stall-replacement-unavailable",
+						reRaised: true,
+					},
 				},
-			});
+				{
+					ledgerKind: "lsp-scanner-coverage-gap",
+					reason:
+						"notify-stall replacement was not available before late-coverage ceiling",
+					capPerTurn: {
+						limit: LATE_AUX_COVERAGE_GAP_DETAIL_CAP_PER_TURN,
+						turnIndex: runtime.turnIndex,
+					},
+				},
+			);
+			if (emitted) lateAuxCoverageGapDetailCount += 1;
+			else lateAuxCoverageGapDropCount += 1;
 		}
 		logLatency({
 			type: "phase",
@@ -2687,6 +2701,8 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 				answered: lateAuxAnswered,
 				notifyStallDemoted: lateAuxNotifyStallDemoted,
 				coverageGapReRaised: lateAuxCoverageGapPairs.length,
+				coverageGapReRaisedDetailed: lateAuxCoverageGapDetailCount,
+				coverageGapReRaisedDropped: lateAuxCoverageGapDropCount,
 				capEvicted: lateAuxCapEvicted,
 				stuckPairs: lateAuxStuckPairs,
 			},

--- a/clients/runtime-turn.ts
+++ b/clients/runtime-turn.ts
@@ -2449,6 +2449,11 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 	let lateAuxExpired = 0;
 	let lateAuxCeilingExhausted = 0;
 	let lateAuxAnswered = 0;
+	let lateAuxNotifyStallDemoted = 0;
+	const lateAuxCoverageGapPairs: Array<{
+		filePath: string;
+		serverId: string;
+	}> = [];
 	const lateAuxStuckPairs: Array<{ filePath: string; serverId: string }> = [];
 	if (drainedPairs.length > 0) {
 		const byFile = new Map<string, typeof drainedPairs>();
@@ -2462,7 +2467,12 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 			for (const [lateAuxPath, pairs] of byFile) {
 				let cached: Map<
 					string,
-					{ diags: LSPDiagnostic[]; publishedAt?: number }
+					{
+						diags: LSPDiagnostic[];
+						publishedAt?: number;
+						notifyStallDemoted?: boolean;
+						demotedAt?: number;
+					}
 				>;
 				try {
 					cached = await service.readCachedDiagnosticsForServers(
@@ -2501,6 +2511,39 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 						// No live client for this server any more — best-effort probe,
 						// drop the pair silently.
 						lateAuxClientGone += 1;
+						continue;
+					}
+					if (cachedEntry.notifyStallDemoted) {
+						if (
+							cachedEntry.demotedAt === undefined ||
+							pair.markedAtMs > cachedEntry.demotedAt
+						) {
+							// A pair marked after teardown belongs to the missing
+							// generation, so it follows ordinary clientGone handling.
+							lateAuxClientGone += 1;
+							continue;
+						}
+						// #2356: notify-stall teardown is a transient absence while the
+						// breaker cools down, but only for a pair marked before teardown.
+						lateAuxNotifyStallDemoted += 1;
+						const pastTtl = isPendingAuxiliaryPastRearmTtl(pair);
+						const atCeiling = (pair.rearmCount ?? 0) >= MAX_LATE_AUX_REARMS;
+						if (!pastTtl && !atCeiling) {
+							rearmPendingAuxiliaryCoverage(pair);
+							lateAuxRearmed += 1;
+							if (lateAuxStuckPairs.length < 20)
+								lateAuxStuckPairs.push({
+									filePath: pair.filePath,
+									serverId: pair.serverId,
+								});
+						} else {
+							if (pastTtl) lateAuxExpired += 1;
+							else lateAuxCeilingExhausted += 1;
+							lateAuxCoverageGapPairs.push({
+								filePath: pair.filePath,
+								serverId: pair.serverId,
+							});
+						}
 						continue;
 					}
 					const rawDiags = cachedEntry.diags;
@@ -2598,6 +2641,30 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 		} catch (err) {
 			dbg(`turn_end: late-auxiliary probe failed: ${err}`);
 		}
+		// #2356: a demoted scanner that never gets replaced remains a coverage
+		// gap. Re-raise it once when the existing bounded late-pair window closes,
+		// preserving the server/file identity in both the ledger and latency row.
+		for (const pair of lateAuxCoverageGapPairs) {
+			const normalizedPairPath = normalizeMapKey(pair.filePath);
+			incrementDegradationCount({
+				kind: "lsp-scanner-coverage-gap",
+				subject: `${pair.serverId}:${normalizedPairPath}`,
+				reason:
+					"notify-stall replacement was not available before late-coverage ceiling",
+			});
+			logLatency({
+				type: "phase",
+				phase: "lsp_scanner_coverage_gap",
+				filePath: normalizedPairPath,
+				durationMs: 0,
+				metadata: {
+					source: "late-auxiliary",
+					serverIds: [pair.serverId],
+					reason: "notify-stall-replacement-unavailable",
+					reRaised: true,
+				},
+			});
+		}
 		logLatency({
 			type: "phase",
 			toolName: "turn_end",
@@ -2618,6 +2685,8 @@ export async function handleTurnEnd(deps: TurnEndDeps): Promise<void> {
 				expired: lateAuxExpired,
 				ceilingExhausted: lateAuxCeilingExhausted,
 				answered: lateAuxAnswered,
+				notifyStallDemoted: lateAuxNotifyStallDemoted,
+				coverageGapReRaised: lateAuxCoverageGapPairs.length,
 				capEvicted: lateAuxCapEvicted,
 				stuckPairs: lateAuxStuckPairs,
 			},

--- a/tests/clients/lsp/late-auxiliary-findings.test.ts
+++ b/tests/clients/lsp/late-auxiliary-findings.test.ts
@@ -34,6 +34,11 @@ vi.mock("../../../clients/latency-logger.js", async (importOriginal) => {
 });
 
 import { CacheManager } from "../../../clients/cache-manager.js";
+import { resetBoundedTelemetry } from "../../../clients/bounded-telemetry.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../../clients/degradation-ledger.js";
 import { RuntimeCoordinator } from "../../../clients/runtime-coordinator.js";
 import { handleTurnEnd } from "../../../clients/runtime-turn.js";
 import {
@@ -46,6 +51,10 @@ import {
 } from "../../../clients/lsp/pending-aux-coverage.js";
 import type { LSPDiagnostic } from "../../../clients/lsp/client.js";
 import { setupTestEnvironment } from "../test-utils.js";
+
+// The fixed behavior admits 20 detailed gap rows per turn. The regression uses
+// 24 pairs, so a half-fixed cap still exceeds this bound and turns the test red.
+const EXPECTED_GAP_DETAIL_CAP_PER_TURN = 20;
 
 function diag(line: number, message: string): LSPDiagnostic {
 	return {
@@ -133,10 +142,14 @@ beforeEach(() => {
 	readCachedDiagnosticsForServers.mockReset();
 	logLatency.mockClear();
 	resetPendingAuxiliaryCoverage();
+	resetBoundedTelemetry();
+	resetDegradationLedger();
 });
 
 afterEach(() => {
 	resetPendingAuxiliaryCoverage();
+	resetBoundedTelemetry();
+	resetDegradationLedger();
 	delete process.env.PI_LENS_LATE_AUX_REARM_TTL_MS;
 });
 
@@ -822,6 +835,80 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 					);
 				});
 			expect(gapRows).toHaveLength(1);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("caps re-raised coverage-gap detail while preserving aggregate visibility (#2356)", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-demoted-gap-cap-");
+		try {
+			process.env.PI_LENS_LATE_AUX_REARM_TTL_MS = "5000";
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-demoted-gap-cap" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const pairCount = EXPECTED_GAP_DETAIL_CAP_PER_TURN + 4;
+			const demotedAt = Date.now();
+			const files = Array.from({ length: pairCount }, (_, index) =>
+				path.join(env.tmpDir, "src", `demoted-gap-${index}.ts`),
+			);
+			for (const file of files) {
+				registerEdit(env, "late-aux-demoted-gap-cap", cacheManager, file);
+				markPendingAuxiliaryCoverage(
+					file,
+					["opengrep"],
+					demotedAt - 1000,
+					demotedAt - 1000,
+					MAX_LATE_AUX_REARMS,
+				);
+			}
+			readCachedDiagnosticsForServers.mockResolvedValue(
+				new Map([
+					["opengrep", { diags: [], notifyStallDemoted: true, demotedAt }],
+				]),
+			);
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+
+			const record = lateAuxRecord();
+			expect(record?.metadata).toMatchObject({
+				coverageGapReRaised: pairCount,
+				coverageGapReRaisedDetailed: EXPECTED_GAP_DETAIL_CAP_PER_TURN,
+				coverageGapReRaisedDropped:
+					pairCount - EXPECTED_GAP_DETAIL_CAP_PER_TURN,
+			});
+			const gapRows = logLatency.mock.calls
+				.map(([entry]) => entry)
+				.filter(
+					(entry: any) =>
+						entry?.phase === "lsp_scanner_coverage_gap" &&
+						entry?.metadata?.reRaised === true,
+				);
+			expect(gapRows).toHaveLength(EXPECTED_GAP_DETAIL_CAP_PER_TURN);
+			expect(
+				gapRows.every((row: any) =>
+					row.metadata.identity.endsWith(row.filePath),
+				),
+			).toBe(true);
+			expect(gapRows[0]).toMatchObject({
+				filePath: expect.stringContaining("demoted-gap-0.ts"),
+				metadata: {
+					identity: expect.stringContaining("opengrep:"),
+					serverIds: ["opengrep"],
+				},
+			});
+			const gapLedger = getDegradationSummary().find(
+				(group) => group.kind === "lsp-scanner-coverage-gap",
+			);
+			expect(gapLedger).toMatchObject({ count: pairCount });
+			expect(
+				gapLedger?.latestReasons.every(
+					(entry) =>
+						entry.subject.startsWith("opengrep:") &&
+						entry.subject.includes("demoted-gap-"),
+				),
+			).toBe(true);
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/lsp/late-auxiliary-findings.test.ts
+++ b/tests/clients/lsp/late-auxiliary-findings.test.ts
@@ -736,4 +736,183 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 			env.cleanup();
 		}
 	});
+
+	it("re-arms a pair while notify-stall teardown awaits a replacement (#2356)", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-demoted-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-demoted" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const file = path.join(env.tmpDir, "src", "demoted.ts");
+			registerEdit(env, "late-aux-demoted", cacheManager, file);
+			markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 1000);
+
+			// This is the LSP service's explicit notify-stall teardown status. It is
+			// distinct from an absent client: the old generation was removed, but the
+			// breaker still permits a replacement attempt after cooldown.
+			readCachedDiagnosticsForServers.mockResolvedValue(
+				new Map([
+					[
+						"opengrep",
+						{ diags: [], notifyStallDemoted: true, demotedAt: Date.now() },
+					],
+				]),
+			);
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+
+			const pending = drainPendingAuxiliaryCoverage();
+			expect(pending).toHaveLength(1);
+			expect(lateAuxRecord()?.metadata).toMatchObject({
+				notifyStallDemoted: 1,
+				rearmed: 1,
+				clientGone: 0,
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("re-raises a coverage gap when a demoted scanner has no replacement (#2356)", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-demoted-gap-");
+		try {
+			process.env.PI_LENS_LATE_AUX_REARM_TTL_MS = "5000";
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({ sessionId: "late-aux-demoted-gap" });
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const file = path.join(env.tmpDir, "src", "demoted-gap.ts");
+			registerEdit(env, "late-aux-demoted-gap", cacheManager, file);
+			markPendingAuxiliaryCoverage(
+				file,
+				["opengrep"],
+				Date.now() - 1000,
+				Date.now() - 1000,
+				MAX_LATE_AUX_REARMS,
+			);
+			readCachedDiagnosticsForServers.mockResolvedValue(
+				new Map([
+					[
+						"opengrep",
+						{ diags: [], notifyStallDemoted: true, demotedAt: Date.now() },
+					],
+				]),
+			);
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+
+			expect(drainPendingAuxiliaryCoverage()).toHaveLength(0);
+			expect(lateAuxRecord()?.metadata).toMatchObject({
+				notifyStallDemoted: 1,
+				coverageGapReRaised: 1,
+				clientGone: 0,
+			});
+			const gapRows = logLatency.mock.calls
+				.map(([entry]) => entry)
+				.filter((entry: unknown) => {
+					if (typeof entry !== "object" || entry === null) return false;
+					const record = entry as {
+						phase?: unknown;
+						metadata?: { reRaised?: unknown };
+					};
+					return (
+						record.phase === "lsp_scanner_coverage_gap" &&
+						record.metadata?.reRaised === true
+					);
+				});
+			expect(gapRows).toHaveLength(1);
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("correlates notify-stall demotions to each pair generation (#2356)", async () => {
+		const env = setupTestEnvironment("pi-lens-late-aux-demoted-generation-");
+		try {
+			process.env.PI_LENS_LATE_AUX_REARM_TTL_MS = "5000";
+			const runtime = new RuntimeCoordinator();
+			runtime.setTelemetryIdentity({
+				sessionId: "late-aux-demoted-generation",
+			});
+			runtime.beginTurn();
+			const cacheManager = new CacheManager(false);
+			const terminalFile = path.join(env.tmpDir, "src", "terminal.ts");
+			const eligibleFile = path.join(env.tmpDir, "src", "eligible.ts");
+			const postDemotionFile = path.join(env.tmpDir, "src", "post-demotion.ts");
+			registerEdit(
+				env,
+				"late-aux-demoted-generation",
+				cacheManager,
+				terminalFile,
+			);
+			registerEdit(
+				env,
+				"late-aux-demoted-generation",
+				cacheManager,
+				eligibleFile,
+			);
+			registerEdit(
+				env,
+				"late-aux-demoted-generation",
+				cacheManager,
+				postDemotionFile,
+			);
+
+			const demotedAt = Date.now();
+			markPendingAuxiliaryCoverage(
+				terminalFile,
+				["opengrep"],
+				demotedAt - 2,
+				demotedAt - 2,
+				MAX_LATE_AUX_REARMS,
+			);
+			markPendingAuxiliaryCoverage(eligibleFile, ["opengrep"], demotedAt - 1);
+			markPendingAuxiliaryCoverage(
+				postDemotionFile,
+				["opengrep"],
+				demotedAt + 1,
+			);
+			readCachedDiagnosticsForServers.mockImplementation(async () => {
+				return new Map([
+					["opengrep", { diags: [], notifyStallDemoted: true, demotedAt }],
+				]);
+			});
+
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+			const firstDrain = drainPendingAuxiliaryCoverage();
+			expect(firstDrain.map((pair) => pair.filePath)).toEqual([eligibleFile]);
+			expect(lateAuxRecord()?.metadata).toMatchObject({
+				pending: 3,
+				notifyStallDemoted: 2,
+				rearmed: 1,
+				clientGone: 1,
+				coverageGapReRaised: 1,
+			});
+
+			// The terminal pair must not clear the shared marker. The pre-demotion
+			// eligible pair remains attributable and re-arms on the next turn.
+			logLatency.mockClear();
+			runtime.beginTurn();
+			markPendingAuxiliaryCoverage(eligibleFile, ["opengrep"], demotedAt - 1);
+			registerEdit(
+				env,
+				"late-aux-demoted-generation",
+				cacheManager,
+				eligibleFile,
+			);
+			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
+			const secondDrain = drainPendingAuxiliaryCoverage();
+			expect(secondDrain.map((pair) => pair.filePath)).toEqual([eligibleFile]);
+			expect(lateAuxRecord()?.metadata).toMatchObject({
+				pending: 1,
+				notifyStallDemoted: 1,
+				rearmed: 1,
+				clientGone: 0,
+				coverageGapReRaised: 0,
+			});
+		} finally {
+			env.cleanup();
+		}
+	});
 });

--- a/tests/clients/lsp/late-auxiliary-findings.test.ts
+++ b/tests/clients/lsp/late-auxiliary-findings.test.ts
@@ -30,7 +30,13 @@ const logLatency = vi.hoisted(() => vi.fn());
 vi.mock("../../../clients/latency-logger.js", async (importOriginal) => {
 	const actual =
 		await importOriginal<typeof import("../../../clients/latency-logger.js")>();
-	return { ...actual, logLatency };
+	return {
+		...actual,
+		logLatency: (entry: Parameters<typeof actual.logLatency>[0]) => {
+			logLatency(entry);
+			actual.logLatency(entry);
+		},
+	};
 });
 
 import { CacheManager } from "../../../clients/cache-manager.js";
@@ -55,6 +61,9 @@ import { setupTestEnvironment } from "../test-utils.js";
 // The fixed behavior admits 20 detailed gap rows per turn. The regression uses
 // 24 pairs, so a half-fixed cap still exceeds this bound and turns the test red.
 const EXPECTED_GAP_DETAIL_CAP_PER_TURN = 20;
+// The degradation ledger keeps 20 latest identity/reason entries per kind;
+// excess identities are represented by droppedCount, not retained implicitly.
+const EXPECTED_LEDGER_IDENTITY_CAP = 20;
 
 function diag(line: number, message: string): LSPDiagnostic {
 	return {
@@ -842,7 +851,14 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 
 	it("caps re-raised coverage-gap detail while preserving aggregate visibility (#2356)", async () => {
 		const env = setupTestEnvironment("pi-lens-late-aux-demoted-gap-cap-");
+		const previousTestMode = process.env.PI_LENS_TEST_MODE;
+		process.env.PI_LENS_TEST_MODE = "0";
+		const realLatencyLogger = await vi.importActual<
+			typeof import("../../../clients/latency-logger.js")
+		>("../../../clients/latency-logger.js");
 		try {
+			realLatencyLogger.clearLatencyLog();
+			await realLatencyLogger.flushLatencyLog();
 			process.env.PI_LENS_LATE_AUX_REARM_TTL_MS = "5000";
 			const runtime = new RuntimeCoordinator();
 			runtime.setTelemetryIdentity({ sessionId: "late-aux-demoted-gap-cap" });
@@ -871,20 +887,29 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 
 			await handleTurnEnd(makeDeps(runtime, cacheManager, env.tmpDir));
 
-			const record = lateAuxRecord();
+			// Read the serialized bytes written by the real logger. The mocked
+			// wrapper above records calls for the surrounding suite, but this proof
+			// verifies the production sink's actual NDJSON surface.
+			await realLatencyLogger.flushLatencyLog();
+			const serializedRows = fs
+				.readFileSync(realLatencyLogger.getLatencyLogPath(), "utf8")
+				.split(/\r?\n/)
+				.filter(Boolean)
+				.map((line) => JSON.parse(line) as any);
+			const record = serializedRows.find(
+				(entry) => entry?.phase === "late_auxiliary_findings",
+			);
 			expect(record?.metadata).toMatchObject({
 				coverageGapReRaised: pairCount,
 				coverageGapReRaisedDetailed: EXPECTED_GAP_DETAIL_CAP_PER_TURN,
 				coverageGapReRaisedDropped:
 					pairCount - EXPECTED_GAP_DETAIL_CAP_PER_TURN,
 			});
-			const gapRows = logLatency.mock.calls
-				.map(([entry]) => entry)
-				.filter(
-					(entry: any) =>
-						entry?.phase === "lsp_scanner_coverage_gap" &&
-						entry?.metadata?.reRaised === true,
-				);
+			const gapRows = serializedRows.filter(
+				(entry) =>
+					entry?.phase === "lsp_scanner_coverage_gap" &&
+					entry?.metadata?.reRaised === true,
+			);
 			expect(gapRows).toHaveLength(EXPECTED_GAP_DETAIL_CAP_PER_TURN);
 			expect(
 				gapRows.every((row: any) =>
@@ -901,7 +926,14 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 			const gapLedger = getDegradationSummary().find(
 				(group) => group.kind === "lsp-scanner-coverage-gap",
 			);
-			expect(gapLedger).toMatchObject({ count: pairCount });
+			expect(gapLedger).toMatchObject({
+				count: pairCount,
+				latestReasons: expect.any(Array),
+				droppedCount: pairCount - EXPECTED_LEDGER_IDENTITY_CAP,
+			});
+			expect(gapLedger?.latestReasons).toHaveLength(
+				EXPECTED_LEDGER_IDENTITY_CAP,
+			);
 			expect(
 				gapLedger?.latestReasons.every(
 					(entry) =>
@@ -910,6 +942,8 @@ describe("turn-end late-auxiliary findings (#2001/#2002)", () => {
 				),
 			).toBe(true);
 		} finally {
+			if (previousTestMode === undefined) delete process.env.PI_LENS_TEST_MODE;
+			else process.env.PI_LENS_TEST_MODE = previousTestMode;
 			env.cleanup();
 		}
 	});

--- a/tests/clients/lsp/service-scanner-coverage-gap.test.ts
+++ b/tests/clients/lsp/service-scanner-coverage-gap.test.ts
@@ -147,6 +147,7 @@ function makeClient(
 			(filePath: string) => stampsByPath.get(filePath) ?? 0,
 		),
 		getDiagnostics: vi.fn(() => diags),
+		getAllDiagnostics: vi.fn(() => new Map()),
 		notify: {
 			open: vi.fn(() => {
 				inFlight += 1;
@@ -551,6 +552,62 @@ describe("#1459 — sweep fan-out must not black out a scanner silently", () => 
 			true,
 		);
 		expect(aux.shutdown).toHaveBeenCalled();
+	});
+
+	it("keeps a pending late pair attributable across notify-stall teardown (#2356)", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const {
+			drainPendingAuxiliaryCoverage,
+			markPendingAuxiliaryCoverage,
+			resetPendingAuxiliaryCoverage,
+		} = await import("../../../clients/lsp/pending-aux-coverage.js");
+		const service = new LSPService();
+		const aux = makeClient("opengrep", undefined, [], "never");
+		const file = `${ROOT}/late.ts`;
+		getServersForFileWithConfig.mockReturnValue([
+			makeServer("opengrep", "auxiliary"),
+		]);
+		(
+			service as unknown as { state: { clients: Map<string, unknown> } }
+		).state.clients.set(AUX_KEY_PREFIX, aux);
+		markPendingAuxiliaryCoverage(file, ["opengrep"], Date.now() - 1000);
+
+		// Call the production teardown seam. It deletes the client, but the
+		// late-pair probe must retain the reason for that temporary absence.
+		(
+			service as unknown as {
+				demoteForNotifyStall: (...args: unknown[]) => void;
+			}
+		).demoteForNotifyStall(
+			AUX_KEY_PREFIX,
+			{ client: aux, info: makeServer("opengrep", "auxiliary") },
+			file,
+			{ outstandingMs: NOTIFY_BUDGET_MS * 5 },
+		);
+
+		const duringCooldown = await service.readCachedDiagnosticsForServers(
+			file,
+			new Set(["opengrep"]),
+		);
+		expect(duringCooldown.get("opengrep")).toMatchObject({
+			notifyStallDemoted: true,
+			demotedAt: expect.any(Number),
+		});
+		expect(aux.shutdown).toHaveBeenCalled();
+		expect(drainPendingAuxiliaryCoverage()).toHaveLength(1);
+
+		// A replacement generation clears the retired-generation marker and is
+		// treated as a normal live cache probe again.
+		const replacement = makeClient("opengrep", 0, [], "never");
+		(
+			service as unknown as { state: { clients: Map<string, unknown> } }
+		).state.clients.set(AUX_KEY_PREFIX, replacement);
+		const afterReplacement = await service.readCachedDiagnosticsForServers(
+			file,
+			new Set(["opengrep"]),
+		);
+		expect(afterReplacement.get("opengrep")).toEqual({ diags: [] });
+		resetPendingAuxiliaryCoverage();
 	});
 
 	it("a queued resync never waits longer than the caller's own budget", async () => {


### PR DESCRIPTION
## Summary

Re-arm late auxiliary coverage pairs after notify-stall client teardown, and re-raise a bounded scanner coverage gap when no replacement arrives. Correlate the demotion timestamp with each pair generation so sibling files cannot clear or inherit one another's state.

The 2026-08-29 review correction makes the telemetry claim truthful and proves the cap through the serialized logger sink.

## Tests

- Edit `tests/clients/lsp/late-auxiliary-findings.test.ts`: the cap-scale case drives real `handleTurnEnd` and real `RuntimeCoordinator` state with 24 demoted pairs. It asserts 20 serialized detail rows, 24 aggregate pairs, 4 dropped detail rows, 20 retained ledger identities, and preserved server/file identity.
- The cap case sets `PI_LENS_TEST_MODE=0`, clears and flushes the real logger, then parses `latency.log` bytes. The LSP service mock remains only at the external child-process boundary.
- Red proof: before forwarding to the real logger, the serialized assertion failed with 0 rows instead of 20.
- Mutation proof: replacing the production cap with `Number.MAX_SAFE_INTEGER` failed with 24 detail rows, `coverageGapReRaisedDetailed: 24`, and `coverageGapReRaisedDropped: 0`.
- Targeted result: 5 files, 87 tests passed. This includes the 40 PR tests plus bounded-telemetry coverage and sibling scanner cases.
- Build, strict lint, format check, changelog check, dependency-cruiser, and ast-grep self-scan passed.

## Blast radius

The fix-round files are `clients/bounded-telemetry.ts`, `tests/clients/lsp/late-auxiliary-findings.test.ts`, `AGENTS.md`, and `CHANGELOG.md`. The existing production cap remains in `clients/runtime-turn.ts`; the existing LSP touch producer remains in `clients/lsp/index.ts`.

Affected runtime paths are the turn-end late-auxiliary probe, bounded telemetry admission, degradation-ledger summary, and serialized latency sink. `module_report` and `read_symbol` were unavailable, so callers and producers were audited with `rg` and source inspection.

## Class sweep

Swept every `lsp_scanner_coverage_gap` producer, every `lsp-scanner-coverage-gap` ledger writer, and every bounded-telemetry registry entry. The two intended producers are the LSP touch aggregate and turn-end re-raise. The LSP touch emits one row per touch; turn-end detail is capped at 20 rows per turn. The ledger count is complete, its latest identity window is bounded at 20, and `droppedCount` reports identities outside that window.

## Observability

The turn-end `late_auxiliary_findings` row reports `coverageGapReRaised`, `coverageGapReRaisedDetailed`, and `coverageGapReRaisedDropped`. Each admitted `lsp_scanner_coverage_gap` row carries the server/file identity. The degradation ledger preserves the complete count, bounded latest identities, and dropped count. No unbounded telemetry is added.

## Test assessment

`tests/clients/lsp/late-auxiliary-findings.test.ts` is the only edited test file. The cap case uniquely pins serialized latency-row admission, aggregate/drop accounting, bounded ledger retention, and identity preservation. No test became redundant.

## Verification

- Fix-round commit: `f7671cb1e71ac09679c4aecf51373910d41f0c6a`.
- `npm run build`.
- `npm run lint`.
- `npm run fmt:check`.
- `npm run changelog:check`.
- `npm run depcruise:check`: no dependency violations; dependency-cruiser reports its known TypeScript 7 parser warning.
- `npm run astgrep:self-scan`: 0 raw findings.
- `npx vitest run tests/clients/lsp/late-auxiliary-findings.test.ts tests/clients/lsp/service-scanner-coverage-gap.test.ts tests/clients/lsp/service-inconclusive-per-server.test.ts tests/clients/bounded-telemetry.test.ts tests/clients/bounded-telemetry-sweep.test.ts`: 87 passed.
