### PR TITLE
fix(lsp): coalesce document notifications (refs #2357)

### DIFF
--- a/.changelog/2357-lsp-notify-coalescing.md
+++ b/.changelog/2357-lsp-notify-coalescing.md
@@ -1,0 +1,8 @@
+---
+section: Fixed
+---
+
+- **Coalesce superseded LSP document notifications (refs #2357)** — same-file
+  `didOpen` and `didChange` bursts now keep only the newest unwritten entry,
+  preserve started writes and different-file ordering, and record the bounded
+  coalesced count in `lsp_document_send` telemetry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,6 +328,12 @@ through `LSPClientState.notifyChangeQueues`; different paths remain parallel.
 `lsp-document-send-order` degradation with the server and normalized path.
 (#2113)
 
+Document `didOpen` and `didChange` notifications share those per-client,
+per-path queues. A same-turn newer entry replaces only an unwritten pending
+entry; a transport write that has started always settles before the newer entry
+runs. Replacements retain the latest content and report their bounded count in
+the succeeding `lsp_document_send` metadata. (#2357)
+
 Auxiliary diagnostic waits preserve a warm-turn fast path: on a cold
 acquisition, the budget is `max(declared wait, observed spawn + 500ms)` clamped
 to an 8s ceiling; on a warm acquisition, it remains `min(declared wait, 2000ms)`. An

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -543,6 +543,31 @@ export interface LSPClientInfo {
 	shutdown(options?: LSPShutdownOptions): Promise<void>;
 }
 
+/**
+ * One document-notification queue entry. A queued entry has not started its
+ * transport write yet, so replacing it cannot leave the server with a partial
+ * protocol message. Once `run` starts, the entry is never replaced; a newer
+ * document state waits behind it and supersedes only the still-pending entry.
+ */
+interface PendingDocumentNotify {
+	run: (coalescedCount: number) => Promise<void>;
+	waiters: Array<{
+		resolve: () => void;
+		reject: (error: unknown) => void;
+	}>;
+	coalescedCount: number;
+}
+
+/**
+ * Per-file queue state. The map itself is per LSP client, so the key pair is
+ * effectively (client, normalized path). Different files retain independent
+ * queues and therefore retain the existing parallel-send behavior.
+ */
+interface DocumentNotifyQueue {
+	pending?: PendingDocumentNotify;
+	running: boolean;
+}
+
 // --- Constants ---
 
 export const INITIALIZE_TIMEOUT_MS = positiveIntFromEnv(
@@ -901,8 +926,8 @@ export interface LSPClientState {
 	 *  above; readers fold their input through `normalizeMapKey`. */
 	readonly diagnosticsVersionsByPath: Map<string, number>;
 	readonly documentVersions: Map<string, number>;
-	/** #2113: tails for same-path didChange sends; different paths stay parallel. */
-	readonly notifyChangeQueues: Map<string, Promise<void>>;
+	/** #2113/#2357: latest-pending same-path document sends; different paths stay parallel. */
+	readonly notifyChangeQueues: Map<string, DocumentNotifyQueue>;
 	/** The LSP document version (`publishDiagnostics.version`) the cached
 	 *  diagnostics for a path were computed against. Only set when the server
 	 *  reports a version; absent entries mean "version unknown" and are treated
@@ -1898,6 +1923,7 @@ function recordSentContent(
 	normalizedPath: string,
 	version: number,
 	content: string,
+	coalescedCount = 0,
 ): void {
 	const scan = scanSentContent(content);
 	const previous = state.documentContentHashes.get(normalizedPath);
@@ -2012,6 +2038,7 @@ function recordSentContent(
 			version,
 			contentLength: content.length,
 			contentLineCount: scan.lfNewlineCount + 1,
+			...(coalescedCount > 0 && { coalescedCount }),
 		},
 	});
 }
@@ -3752,13 +3779,14 @@ export function handleNotifyExternalChange(
 	state.watchQueue.enqueue(uri, type);
 }
 
-export async function handleNotifyOpen(
+async function handleNotifyOpenOnce(
 	state: LSPClientState,
 	filePath: string,
 	content: string,
 	languageId: string,
 	preserveDiagnostics = false,
 	silent = false,
+	coalescedCount = 0,
 ): Promise<void> {
 	if (!isClientAlive(state)) return;
 	const normalizedPath = normalizeMapKey(filePath);
@@ -3813,7 +3841,13 @@ export async function handleNotifyOpen(
 			// #1669 review F7: only mirror the send locally once it actually left
 			// the process — see safeSendNotification's doc comment.
 			if (reopenSent)
-				recordSentContent(state, normalizedPath, version, content);
+				recordSentContent(
+					state,
+					normalizedPath,
+					version,
+					content,
+					coalescedCount,
+				);
 			state.openDocuments.add(normalizedPath);
 			state.openDocumentUris?.set(normalizedPath, uri);
 			return;
@@ -3826,7 +3860,14 @@ export async function handleNotifyOpen(
 				contentChanges: buildContentChanges(state, normalizedPath, content),
 			},
 		);
-		if (changeSent) recordSentContent(state, normalizedPath, version, content);
+		if (changeSent)
+			recordSentContent(
+				state,
+				normalizedPath,
+				version,
+				content,
+				coalescedCount,
+			);
 		return;
 	}
 
@@ -3866,7 +3907,8 @@ export async function handleNotifyOpen(
 		"textDocument/didOpen",
 		{ textDocument: { uri, languageId, version: 0, text: content } },
 	);
-	if (openSent) recordSentContent(state, normalizedPath, 0, content);
+	if (openSent)
+		recordSentContent(state, normalizedPath, 0, content, coalescedCount);
 	state.pendingOpens.delete(normalizedPath);
 	state.openDocuments.add(normalizedPath);
 	state.closedDocuments?.delete(normalizedPath);
@@ -3893,11 +3935,104 @@ export async function handleNotifyOpen(
 	});
 }
 
+/**
+ * Replace only notifications that have not started a transport write. A
+ * microtask starts the first entry so a synchronous burst of callers installs
+ * one latest entry before any bytes are handed to vscode-jsonrpc. Once an
+ * entry starts, it runs to completion; LSP has no cancellation/acknowledgement
+ * for notifications, so dropping a started write could violate didOpen before
+ * didChange ordering or leave a partial message in the pipe.
+ */
+function enqueueDocumentNotify(
+	state: LSPClientState,
+	normalizedPath: string,
+	run: (coalescedCount: number) => Promise<void>,
+): Promise<void> {
+	let queue = state.notifyChangeQueues.get(normalizedPath);
+	if (!queue) {
+		queue = { running: false };
+		state.notifyChangeQueues.set(normalizedPath, queue);
+	}
+	return new Promise<void>((resolve, reject) => {
+		const previous = queue?.pending;
+		// Keep superseded callers attached to the replacement's completion. The
+		// notification is dropped, but callers such as the auxiliary backlog
+		// ledger must not observe completion before the newest content is sent.
+		const waiters = previous?.waiters ?? [];
+		waiters.push({ resolve, reject });
+		queue!.pending = {
+			run,
+			waiters,
+			coalescedCount: (previous?.coalescedCount ?? 0) + (previous ? 1 : 0),
+		};
+		if (queue!.running) return;
+		queue!.running = true;
+		// Let same-turn callers replace the unwritten entry before the runner
+		// invokes the transport. Different path queues still start independently.
+		void Promise.resolve().then(async () => {
+			try {
+				for (;;) {
+					const next = queue!.pending;
+					if (!next) break;
+					queue!.pending = undefined;
+					try {
+						await next.run(next.coalescedCount);
+						for (const waiter of next.waiters) waiter.resolve();
+					} catch (error) {
+						for (const waiter of next.waiters) waiter.reject(error);
+					}
+				}
+			} finally {
+				queue!.running = false;
+				if (
+					!queue!.pending &&
+					state.notifyChangeQueues.get(normalizedPath) === queue
+				) {
+					state.notifyChangeQueues.delete(normalizedPath);
+				}
+			}
+		});
+	});
+}
+
+/** Drop unwritten document notifications when a client is torn down. */
+function cancelDocumentNotifyQueues(state: LSPClientState): void {
+	for (const queue of state.notifyChangeQueues.values()) {
+		for (const waiter of queue.pending?.waiters ?? []) waiter.resolve();
+		queue.pending = undefined;
+	}
+	state.notifyChangeQueues.clear();
+}
+
+export function handleNotifyOpen(
+	state: LSPClientState,
+	filePath: string,
+	content: string,
+	languageId: string,
+	preserveDiagnostics = false,
+	silent = false,
+): Promise<void> {
+	if (!isClientAlive(state)) return Promise.resolve();
+	const normalizedPath = normalizeMapKey(filePath);
+	return enqueueDocumentNotify(state, normalizedPath, (coalescedCount) =>
+		handleNotifyOpenOnce(
+			state,
+			filePath,
+			content,
+			languageId,
+			preserveDiagnostics,
+			silent,
+			coalescedCount,
+		),
+	);
+}
+
 async function handleNotifyChangeOnce(
 	state: LSPClientState,
 	filePath: string,
 	content: string,
 	normalizedPath: string,
+	coalescedCount = 0,
 ): Promise<void> {
 	if (!isClientAlive(state)) return;
 	const uri =
@@ -3921,7 +4056,8 @@ async function handleNotifyChangeOnce(
 		state.documentVersions.set(normalizedPath, 0);
 		state.documentOpenedAt.set(normalizedPath, Date.now());
 		state.diagnosticPublicationCounts.set(normalizedPath, 0);
-		if (fallbackOpenSent) recordSentContent(state, normalizedPath, 0, content);
+		if (fallbackOpenSent)
+			recordSentContent(state, normalizedPath, 0, content, coalescedCount);
 		state.openDocuments.add(normalizedPath);
 		state.openDocumentUris?.set(normalizedPath, uri);
 		return;
@@ -3940,7 +4076,8 @@ async function handleNotifyChangeOnce(
 			contentChanges: buildContentChanges(state, normalizedPath, content),
 		},
 	);
-	if (changeSent) recordSentContent(state, normalizedPath, version, content);
+	if (changeSent)
+		recordSentContent(state, normalizedPath, version, content, coalescedCount);
 }
 
 /**
@@ -3955,20 +4092,15 @@ export function handleNotifyChange(
 ): Promise<void> {
 	if (!isClientAlive(state)) return Promise.resolve();
 	const normalizedPath = normalizeMapKey(filePath);
-	const previous =
-		state.notifyChangeQueues.get(normalizedPath) ?? Promise.resolve();
-	const queued = previous
-		.catch(() => undefined)
-		.then(() =>
-			handleNotifyChangeOnce(state, filePath, content, normalizedPath),
-		);
-	const settled = queued.finally(() => {
-		if (state.notifyChangeQueues.get(normalizedPath) === settled) {
-			state.notifyChangeQueues.delete(normalizedPath);
-		}
-	});
-	state.notifyChangeQueues.set(normalizedPath, settled);
-	return settled;
+	return enqueueDocumentNotify(state, normalizedPath, (coalescedCount) =>
+		handleNotifyChangeOnce(
+			state,
+			filePath,
+			content,
+			normalizedPath,
+			coalescedCount,
+		),
+	);
 }
 
 /** Close a document through the same lifecycle path exposed by the client. */
@@ -4130,6 +4262,9 @@ async function clientShutdownOnce(
 	state.pendingOpens.clear();
 	state.openDocuments.clear();
 	state.openDocumentUris?.clear();
+	// #2357: superseded notifications that have not started writing are moot
+	// once this client is dead; resolve their callers and release the queue.
+	cancelDocumentNotifyQueues(state);
 	// #1412 L1: mirror openDocuments' clear — a shut-down/evicted client's
 	// probe memo is moot along with everything else document-scoped.
 	state.projectIdentityProbedFiles?.clear();

--- a/tests/clients/lsp/client-internals.test.ts
+++ b/tests/clients/lsp/client-internals.test.ts
@@ -63,6 +63,8 @@ import { applyWorkspaceEdit } from "../../../clients/lsp/edits.js";
 // #1667: the LSPClientState fixture moved to a shared module so the
 // multi-identifier pull tests reuse it instead of maintaining a copy.
 import { createMockLspProcess, createMockState } from "./mock-client-state.js";
+import { gatedPromise } from "../../support/fault-injection.js";
+import { waitFor } from "../interleaving-kit.js";
 
 const TEST_FILE = "/project/app.ts";
 const TEST_KEY = normalizeMapKey(TEST_FILE);
@@ -584,6 +586,53 @@ describe("stripDiagnosticNoiseLines", () => {
 });
 
 describe("clientShutdown", () => {
+	it("settles superseded callers and cancels unwritten work without running it (#2357)", async () => {
+		const state = createMockState();
+		state.openDocuments.add(TEST_KEY);
+		state.documentVersions.set(TEST_KEY, 0);
+		const writeGate = gatedPromise<void>();
+		let didChangeCalls = 0;
+		vi.mocked(state.connection.sendNotification).mockImplementation(
+			async (method) => {
+				if (method === "textDocument/didChange") {
+					didChangeCalls++;
+					await writeGate.promise;
+				}
+			},
+		);
+
+		try {
+			const first = handleNotifyChange(state, TEST_FILE, "v1");
+			await waitFor(
+				() => didChangeCalls,
+				(calls) => calls === 1,
+			);
+			let pendingSettled = 0;
+			const second = handleNotifyChange(state, TEST_FILE, "v2").finally(
+				() => pendingSettled++,
+			);
+			const newest = handleNotifyChange(state, TEST_FILE, "v3").finally(
+				() => pendingSettled++,
+			);
+
+			await clientShutdown(state, { fast: true });
+			expect(state.notifyChangeQueues.size).toBe(0);
+			expect(didChangeCalls).toBe(1);
+			await waitFor(
+				() => pendingSettled,
+				(count) => count === 2,
+				{ timeoutMs: 1_000 },
+			);
+			await expect(second).resolves.toBeUndefined();
+			await expect(newest).resolves.toBeUndefined();
+
+			writeGate.resolve();
+			await expect(first).resolves.toBeUndefined();
+		} finally {
+			writeGate.resolve();
+		}
+	});
+
 	it("skips LSP protocol handshake in fast mode", async () => {
 		const process = {
 			killed: false,
@@ -655,6 +704,22 @@ describe("handleNotifyOpen", () => {
 		const didOpenCall = calls.find((c) => c[0] === "textDocument/didOpen");
 		expect(didOpenCall).toBeDefined();
 		expect(state.openDocuments.has(TEST_KEY)).toBe(true);
+	});
+
+	it("coalesces same-file didOpen bursts to the newest content (#2357)", async () => {
+		const state = createMockState();
+		const first = handleNotifyOpen(state, TEST_FILE, "v1", "typescript");
+		const second = handleNotifyOpen(state, TEST_FILE, "v2", "typescript");
+		const newest = handleNotifyOpen(state, TEST_FILE, "v3", "typescript");
+		await Promise.all([first, second, newest]);
+
+		const opens = vi
+			.mocked(state.connection.sendNotification)
+			.mock.calls.filter(([method]) => method === "textDocument/didOpen");
+		expect(opens).toHaveLength(1);
+		expect(
+			(opens[0][1] as { textDocument: { text: string } }).textDocument.text,
+		).toBe("v3");
 	});
 
 	it("#1641 F4: lsp_document_send's contentLineCount matches the gate's LSP-addressable convention (newlines + 1), not wc -l", async () => {
@@ -1124,6 +1189,122 @@ describe("handleNotifyChange", () => {
 		await handleNotifyChange(state, TEST_FILE, "const y = 2;");
 
 		expect(state.connection.sendNotification).not.toHaveBeenCalled();
+	});
+
+	it("coalesces a same-file burst before a non-draining write starts (#2357)", async () => {
+		const state = createMockState();
+		state.openDocuments.add(TEST_KEY);
+		state.documentVersions.set(TEST_KEY, 0);
+		const writeGate = gatedPromise<void>();
+		vi.mocked(state.connection.sendNotification).mockImplementation(
+			async () => writeGate.promise,
+		);
+		logLatencyMock.mockClear();
+
+		try {
+			let settled = 0;
+			const first = handleNotifyChange(state, TEST_FILE, "v1").finally(
+				() => settled++,
+			);
+			const second = handleNotifyChange(state, TEST_FILE, "v2").finally(
+				() => settled++,
+			);
+			const newest = handleNotifyChange(state, TEST_FILE, "v3").finally(
+				() => settled++,
+			);
+			await Promise.resolve();
+
+			const writes = vi
+				.mocked(state.connection.sendNotification)
+				.mock.calls.filter(([method]) => method === "textDocument/didChange");
+			expect(writes).toHaveLength(1);
+			expect(
+				(writes[0][1] as { contentChanges: Array<{ text: string }> })
+					.contentChanges[0].text,
+			).toBe("v3");
+			writeGate.resolve();
+			await waitFor(
+				() => settled,
+				(count) => count === 3,
+				{
+					timeoutMs: 1_000,
+				},
+			);
+			await Promise.all([first, second, newest]);
+
+			const sendRecord = logLatencyMock.mock.calls.find(
+				([entry]) => entry?.phase === "lsp_document_send",
+			);
+			expect(sendRecord?.[0].metadata.coalescedCount).toBe(2);
+		} finally {
+			writeGate.resolve();
+		}
+	});
+
+	it("rejects a started write while continuing with the newer pending entry (#2357)", async () => {
+		const state = createMockState();
+		state.openDocuments.add(TEST_KEY);
+		state.documentVersions.set(TEST_KEY, 0);
+		const firstWrite = gatedPromise<void>();
+		let didChangeCalls = 0;
+		vi.mocked(state.connection.sendNotification).mockImplementation(
+			async (method) => {
+				if (method !== "textDocument/didChange") return;
+				didChangeCalls++;
+				if (didChangeCalls === 1) {
+					await firstWrite.promise;
+					throw new Error("first didChange failed");
+				}
+			},
+		);
+
+		try {
+			const first = handleNotifyChange(state, TEST_FILE, "v1");
+			await waitFor(
+				() => didChangeCalls,
+				(calls) => calls === 1,
+			);
+			const newer = handleNotifyChange(state, TEST_FILE, "v2");
+			firstWrite.resolve();
+
+			await expect(first).rejects.toThrow("first didChange failed");
+			await waitFor(
+				() => didChangeCalls,
+				(calls) => calls === 2,
+				{ timeoutMs: 1_000 },
+			);
+			await expect(newer).resolves.toBeUndefined();
+			expect(state.notifyChangeQueues.size).toBe(0);
+		} finally {
+			firstWrite.resolve();
+		}
+	});
+
+	it("keeps different files independent while coalescing each file (#2357)", async () => {
+		const state = createMockState();
+		const otherFile = "/project/other.ts";
+		state.openDocuments.add(TEST_KEY);
+		state.openDocuments.add(normalizeMapKey(otherFile));
+		state.documentVersions.set(TEST_KEY, 0);
+		state.documentVersions.set(normalizeMapKey(otherFile), 0);
+
+		const a1 = handleNotifyChange(state, TEST_FILE, "a1");
+		const a2 = handleNotifyChange(state, TEST_FILE, "a2");
+		const b1 = handleNotifyChange(state, otherFile, "b1");
+		const b2 = handleNotifyChange(state, otherFile, "b2");
+		await Promise.all([a1, a2, b1, b2]);
+
+		const writes = vi
+			.mocked(state.connection.sendNotification)
+			.mock.calls.filter(([method]) => method === "textDocument/didChange");
+		expect(writes).toHaveLength(2);
+		expect(
+			writes.map(
+				([, params]) =>
+					(params as { contentChanges: Array<{ text: string }> })
+						.contentChanges[0].text,
+			),
+		).toEqual(["a2", "b2"]);
 	});
 });
 

--- a/tests/clients/lsp/document-notify-telemetry.test.ts
+++ b/tests/clients/lsp/document-notify-telemetry.test.ts
@@ -1,0 +1,56 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalPiLensDir } from "../../../clients/file-utils.js";
+import { normalizeMapKey } from "../../../clients/path-utils.js";
+import { createMockState } from "./mock-client-state.js";
+
+const TEST_FILE = "/project/app.ts";
+const TEST_KEY = normalizeMapKey(TEST_FILE);
+
+let previousTestMode: string | undefined;
+let flushLatencyLog: (() => Promise<void>) | undefined;
+
+beforeEach(() => {
+	previousTestMode = process.env.PI_LENS_TEST_MODE;
+	process.env.PI_LENS_TEST_MODE = "0";
+	fs.rmSync(path.join(getGlobalPiLensDir(), "latency.log"), { force: true });
+});
+
+afterEach(async () => {
+	if (flushLatencyLog) await flushLatencyLog();
+	flushLatencyLog = undefined;
+	if (previousTestMode === undefined) delete process.env.PI_LENS_TEST_MODE;
+	else process.env.PI_LENS_TEST_MODE = previousTestMode;
+});
+
+describe("document notification telemetry (#2357)", () => {
+	it("emits the coalesced count through the real latency sink", async () => {
+		vi.resetModules();
+		const [{ handleNotifyChange }, latencyLogger] = await Promise.all([
+			import("../../../clients/lsp/client.js"),
+			import("../../../clients/latency-logger.js"),
+		]);
+		flushLatencyLog = latencyLogger.flushLatencyLog;
+		const state = createMockState();
+		state.openDocuments.add(TEST_KEY);
+		state.documentVersions.set(TEST_KEY, 0);
+
+		await Promise.all([
+			handleNotifyChange(state, TEST_FILE, "v1"),
+			handleNotifyChange(state, TEST_FILE, "v2"),
+			handleNotifyChange(state, TEST_FILE, "v3"),
+		]);
+		await latencyLogger.flushLatencyLog();
+
+		const records = fs
+			.readFileSync(path.join(getGlobalPiLensDir(), "latency.log"), "utf8")
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line) as Record<string, unknown>);
+		const record = records.find(
+			(entry) => entry.phase === "lsp_document_send",
+		) as { metadata?: { coalescedCount?: number } } | undefined;
+		expect(record?.metadata?.coalescedCount).toBe(2);
+	});
+});

--- a/tests/clients/lsp/refresh-and-sync-kind.test.ts
+++ b/tests/clients/lsp/refresh-and-sync-kind.test.ts
@@ -34,6 +34,7 @@ import type { PositionEncoding } from "../../../clients/lsp/position-encoding.js
 // fix (openDocumentUris/projectIdentityProbedFiles) and a `syncKind` default,
 // both folded into the shared file directly by this round's rebase.
 import { createMockState } from "./mock-client-state.js";
+import { suspendAt } from "../interleaving-kit.js";
 
 const TEST_FILE = "/project/app.ts";
 const TEST_KEY = normalizeMapKey(TEST_FILE);
@@ -147,49 +148,48 @@ describe("outgoing didChange honors the negotiated sync kind (#1669)", () => {
 			text: "before",
 		});
 
-		let releaseFirstSend!: () => void;
-		const firstSend = new Promise<void>((resolve) => {
-			releaseFirstSend = resolve;
-		});
-		let didChangeSends = 0;
-		vi.mocked(state.connection.sendNotification).mockImplementation(
-			async (method) => {
-				if (method === "textDocument/didChange" && didChangeSends++ === 0)
-					await firstSend;
-			},
+		const suspension = suspendAt(
+			vi.mocked(state.connection.sendNotification),
+			async () => undefined,
+			{ calls: 1 },
 		);
+		try {
+			const first = handleNotifyChange(state, TEST_FILE, "first");
+			await suspension.admitted;
+			const second = handleNotifyChange(state, TEST_FILE, "second");
+			suspension.release();
+			await Promise.all([first, second]);
 
-		const first = handleNotifyChange(state, TEST_FILE, "first");
-		const second = handleNotifyChange(state, TEST_FILE, "second");
-		releaseFirstSend();
-		await Promise.all([first, second]);
-
-		const changes = vi
-			.mocked(state.connection.sendNotification)
-			.mock.calls.filter((call) => call[0] === "textDocument/didChange")
-			.map(
-				(call) =>
-					(
-						call[1] as {
-							contentChanges: Array<{ range?: unknown; text: string }>;
-						}
-					).contentChanges[0],
-			);
-		expect(changes).toHaveLength(2);
-		expect(changes[0]).toEqual({
-			range: {
-				start: { line: 0, character: 0 },
-				end: { line: 0, character: "before".length },
-			},
-			text: "first",
-		});
-		expect(changes[1]).toEqual({
-			range: {
-				start: { line: 0, character: 0 },
-				end: { line: 0, character: "first".length },
-			},
-			text: "second",
-		});
+			const changes = vi
+				.mocked(state.connection.sendNotification)
+				.mock.calls.filter((call) => call[0] === "textDocument/didChange")
+				.map(
+					(call) =>
+						(
+							call[1] as {
+								contentChanges: Array<{ range?: unknown; text: string }>;
+							}
+						).contentChanges[0],
+				);
+			expect(changes).toHaveLength(2);
+			expect(changes[0]).toEqual({
+				range: {
+					start: { line: 0, character: 0 },
+					end: { line: 0, character: "before".length },
+				},
+				text: "first",
+			});
+			expect(changes[1]).toEqual({
+				range: {
+					start: { line: 0, character: 0 },
+					end: { line: 0, character: "first".length },
+				},
+				text: "second",
+			});
+		} finally {
+			suspension.release();
+			suspension.restore();
+		}
 	});
 
 	it("does not overwrite a newer mirror when a lower version is recorded (#2113)", async () => {

--- a/tests/clients/lsp/shutdown-wedged-connection.test.ts
+++ b/tests/clients/lsp/shutdown-wedged-connection.test.ts
@@ -13,11 +13,11 @@
  * teardown still completes. Pre-fix they hang to their own vitest timeout.
  */
 
-import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MessageConnection } from "vscode-jsonrpc";
 import { removeLspChild } from "../../../clients/instance-registry.js";
 import { logLatency } from "../../../clients/latency-logger.js";
+import { createMockState } from "./mock-client-state.js";
 
 // Keep both budgets short so a wedged double is bounded well inside the
 // per-test timeout. Assigned before any dynamic `client.js` import below, so
@@ -58,23 +58,12 @@ function createWedgedConnection(): MessageConnection {
 }
 
 function createWedgedState(kill: ReturnType<typeof vi.fn>) {
-	const diagnosticEmitter = new EventEmitter();
-	diagnosticEmitter.setMaxListeners(50);
-	// A partial state is enough: clientShutdown only touches lifecycle fields.
-	// Cast once at the boundary rather than restating the full LSPClientState.
-	return {
-		isConnected: true,
-		isDestroyed: false,
-		shutdownRequested: false,
-		connectionDisposed: false,
+	// Build the state through the shared fixture so this test follows the real
+	// LSPClientState contract, including lifecycle maps such as
+	// `notifyChangeQueues`. Only the connection and child process boundaries are
+	// doubled because they provide the wedged-transport and safe-pid probes.
+	return createMockState({
 		connection: createWedgedConnection(),
-		pendingDiagnostics: new Map(),
-		pendingOpens: new Set(),
-		openDocuments: new Set(),
-		openDocumentUris: new Map(),
-		projectIdentityProbedFiles: new Set<string>(),
-		watchQueue: { cancel: vi.fn() },
-		diagnosticEmitter,
 		serverId: "wedged",
 		root: "/project",
 		// pid 0 keeps killProcessTree off both the win32 `taskkill /F /T` branch
@@ -96,8 +85,8 @@ function createWedgedState(kill: ReturnType<typeof vi.fn>) {
 				},
 				off: vi.fn(),
 			},
-		},
-	} as unknown as Parameters<ClientModule["clientShutdown"]>[0];
+		} as any,
+	});
 }
 
 describe("clientShutdown with a fully wedged connection (#1620)", () => {


### PR DESCRIPTION
## Summary

Coalesce superseded same-file LSP `didOpen` and `didChange` notifications before transport writes. Preserve started writes, independent per-file ordering, and caller settlement. Record the bounded coalesced count in the existing `lsp_document_send` telemetry.

## Tests

- `tests/clients/lsp/client-internals.test.ts`: pin newest-content coalescing, shutdown cancellation, started-write rejection with newer continuation, and different-file independence.
- `tests/clients/lsp/refresh-and-sync-kind.test.ts`: preserve the started-write ordering regression using the shared suspension kit, with release and restore in `finally`.
- `tests/clients/lsp/document-notify-telemetry.test.ts`: assert the coalesced count through real latency-log bytes, not a logger mock.
- `tests/clients/lsp/shutdown-wedged-connection.test.ts`: replace the invalid partial client-state double with shared `createMockState`, so all nine shutdown cases exercise the required notification-queue lifecycle state.
- Build, lint, format, changelog, ast-grep, and the composed LSP suites pass.
- Focused fix-round result: 4 files, 178 tests passed.
- Mutation proofs: shutdown cancellation, error continuation, same-file predicate, and coalesced metric guards each turned red when removed or neutered.

## Blast radius

The change affects `LSPClientState.notifyChangeQueues`, `handleNotifyOpen`, `handleNotifyChange`, and client shutdown. Callers remain the existing primary and auxiliary document-notification producers. Different normalized paths retain independent queues. A 10,000-iteration sequential benchmark measured 3,719.77 ms on pre-fix master and 2,035.89 ms after the change.

## Class sweep

Swept all `notifyChangeQueues` consumers and all document notification entry points. `handleNotifyOpen` and `handleNotifyChange` now share one per-client, per-normalized-path queue. Different paths remain independent; shutdown clears pending entries while started writes settle. The existing sync-kind ordering case remains covered.

## Observability

The existing `lsp_document_send` record carries `metadata.coalescedCount` only when a replacement occurred. No new unbounded record or per-occurrence log is added.

## Test assessment

Three existing test files were edited and one new test file was added. The queue cases independently pin queue state, shutdown cleanup, rejection continuation, path independence, and real sink output. The shutdown fix edits the existing nine-case wedged-connection suite to construct real lifecycle state while retaining doubles only at the transport and child-process boundaries.

## Verification

- `npm.cmd run build`
- `npm.cmd run lint`
- `npm.cmd run fmt:check`
- `npm.cmd run changelog:check`
- `npm.cmd run astgrep:self-scan`
- `npx vitest run tests/clients/lsp/client-internals.test.ts tests/clients/lsp/refresh-and-sync-kind.test.ts tests/clients/lsp/document-notify-telemetry.test.ts tests/clients/lsp/shutdown-wedged-connection.test.ts`
- Composed with #2356 on current master: 4 files, 199 tests passed, plus the shared build/lint/format/changelog/ast-grep gates.
- Pre-push build passed. The hook skipped its test subset because 47 files exceeded the 25-file selection cap; CI must run the required suites.
