### PR TITLE
fix(review): normalize session fact keys (refs #2355)

### DIFF
--- a/.changelog/2355-sessionfacts-key.md
+++ b/.changelog/2355-sessionfacts-key.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Run review-graph changed-symbols and entity snapshots under one normalized key per file (refs #2355)** — the session-fact key for a file's changed symbols was written under the agent-supplied spelling, while the review-graph builder read it under `normalizeMapKey`, so a case- or separator-variant path (`src/Target.ts` written, `src/target.ts` read) never hit its own write and the family sat write-only. The entity snapshot used a raw key on both sides, which forked a second empty snapshot when the same file arrived under a re-spelled path and inverted every symbol to `added`, scheduling a blast-radius run for a file nothing changed. Both keys now fold through `normalizeMapKey` at write and read, matching the #210/#1020 raw-path-key discipline.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -944,6 +944,9 @@ cascade baseline (`integration.ts`) and the review-graph
 in this family forks a second empty entity snapshot when one file arrives under
 two case/separator spellings and inverts every symbol to `added` — the #2282 F1
 whole-file-change false positive, re-entered through a re-spelled write (#2355).
+`recordEntitySnapshotDiff` computes that folded path once per call and reuses it
+for both fact keys; do not reintroduce a second realpath probe on this runner
+hot path.
 
 Small process-lifetime memo tables use `clients/bounded-cache.ts` when an
 insertion-ordered LRU cap is sufficient; path-root caches still normalize keys

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -934,6 +934,17 @@ formatter config metadata, and tsconfig-path signatures include recursive
 
 `isFullyQualified` follows host path semantics. Use `isFullyQualifiedWin32` or `isFullyQualifiedPosix` when the consuming path grammar is fixed independently of the host (for example, safe-spawn's Windows resolver).
 
+Every per-file session-fact key in `FactStore`'s bounded map
+(`setBoundedSessionFact`/`getBoundedSessionFact`) writes and reads under one
+normalization per member, applied to both members of the pair. Delta baselines
+(`session.baseline.*`, `dispatcher.ts`) share one per-dispatch constant; the
+cascade baseline (`integration.ts`) and the review-graph
+`changedSymbols`/`entitySnapshot` keys (`clients/review-graph/service.ts` +
+`builder.ts`) fold through `normalizeMapKey` at write and read. A raw-path key
+in this family forks a second empty entity snapshot when one file arrives under
+two case/separator spellings and inverts every symbol to `added` — the #2282 F1
+whole-file-change false positive, re-entered through a re-spelled write (#2355).
+
 Small process-lifetime memo tables use `clients/bounded-cache.ts` when an
 insertion-ordered LRU cap is sufficient; path-root caches still normalize keys
 at the seam. Widget-state's file map remains a plain map because active

--- a/clients/review-graph/service.ts
+++ b/clients/review-graph/service.ts
@@ -55,9 +55,13 @@ export function recordEntitySnapshotDiff(
 	filePath: string,
 	nextSnapshot: Map<string, string>,
 ): { added: string[]; removed: string[]; modified: string[] } {
-	const snapshotKey = `${ENTITY_SNAPSHOT_PREFIX}${filePath}`;
-	// builder.ts reads this one through normalizeMapKey; write it the same way
-	// or the read never hits (#2282 review F3).
+	// Both keys are read through normalizeMapKey elsewhere (builder.ts reads
+	// changedSymbols; the snapshot is only ever re-read by this same function).
+	// Write both under normalizeMapKey or the pair diverges on a case-variant
+	// spelling (#2355): an unnormalized write is a key the reader can never hit,
+	// and an unnormalized snapshot forks a second empty diff. (#2282 review F3,
+	// #210/#1020 class rule.)
+	const snapshotKey = `${ENTITY_SNAPSHOT_PREFIX}${normalizeMapKey(filePath)}`;
 	const changedSymbolsKey = `${CHANGED_SYMBOLS_PREFIX}${normalizeMapKey(filePath)}`;
 	const stored = facts.getBoundedSessionFact<Map<string, string>>(snapshotKey);
 	// An evicted snapshot is unknown, not empty. Diffing against an empty Map

--- a/clients/review-graph/service.ts
+++ b/clients/review-graph/service.ts
@@ -55,14 +55,12 @@ export function recordEntitySnapshotDiff(
 	filePath: string,
 	nextSnapshot: Map<string, string>,
 ): { added: string[]; removed: string[]; modified: string[] } {
-	// Both keys are read through normalizeMapKey elsewhere (builder.ts reads
-	// changedSymbols; the snapshot is only ever re-read by this same function).
-	// Write both under normalizeMapKey or the pair diverges on a case-variant
-	// spelling (#2355): an unnormalized write is a key the reader can never hit,
-	// and an unnormalized snapshot forks a second empty diff. (#2282 review F3,
-	// #210/#1020 class rule.)
-	const snapshotKey = `${ENTITY_SNAPSHOT_PREFIX}${normalizeMapKey(filePath)}`;
-	const changedSymbolsKey = `${CHANGED_SYMBOLS_PREFIX}${normalizeMapKey(filePath)}`;
+	// Normalize once at this boundary, then reuse the folded path for both
+	// per-file facts. An unnormalized write is a key the builder reader can never
+	// hit, and an unnormalized snapshot forks a second empty diff (#2355).
+	const normalizedFilePath = normalizeMapKey(filePath);
+	const snapshotKey = `${ENTITY_SNAPSHOT_PREFIX}${normalizedFilePath}`;
+	const changedSymbolsKey = `${CHANGED_SYMBOLS_PREFIX}${normalizedFilePath}`;
 	const stored = facts.getBoundedSessionFact<Map<string, string>>(snapshotKey);
 	// An evicted snapshot is unknown, not empty. Diffing against an empty Map
 	// puts every entity in `added`, which reads downstream as "the whole file

--- a/tests/clients/dispatch/fact-store-session-bound.test.ts
+++ b/tests/clients/dispatch/fact-store-session-bound.test.ts
@@ -323,5 +323,54 @@ describe("FactStore session-fact bound (#2282)", () => {
 				"Gamma",
 			]);
 		});
+
+		// #2355's own probe shape: `recordEntitySnapshotDiff` is called with the
+		// agent-supplied spelling, while builder.ts reads the key under
+		// normalizeMapKey. A case-variant PAIR (`src/Target.ts` written, the read
+		// arriving as `src/target.ts`) must land on the same normalized key — the
+		// same written stone, one lowercase slot. Red on the pre-#2282 raw-path
+		// writer: the raw `C:/.../Target.ts` key is unreadable from the lowercase
+		// read spelling. Both spellings are win32-shaped and nonexistent, so
+		// normalizeMapKey folds them deterministically on every OS (#1150 shape).
+		it("serves a changedSymbols write to a case-variant read spelling (closes #2355)", () => {
+			const store = new FactStore("dispatch");
+			const writeSpelling = "C:/repo/2355/src/Target.ts";
+			const readSpelling = "c:/repo/2355/src/target.ts";
+			expect(writeSpelling).not.toBe(readSpelling);
+			expect(normalizeMapKey(writeSpelling)).toBe(
+				normalizeMapKey(readSpelling),
+			);
+
+			recordEntitySnapshotDiff(store, writeSpelling, snapshot());
+
+			const readKey = `session.reviewGraph.changedSymbols:${normalizeMapKey(readSpelling)}`;
+			expect(store.getBoundedSessionFact<string[]>(readKey)).toEqual([
+				"alpha",
+				"beta",
+				"Gamma",
+			]);
+		});
+
+		// The entity-snapshot key is the sibling of changedSymbols in the same
+		// function, and it was stored raw on both sides. Within one call the pair
+		// is self-consistent, so the raw key only bites ACROSS spellings: editing
+		// the same file under a second spelling read an empty prior snapshot and
+		// inverted every symbol to `added` — the #2282 F1 whole-file-change
+		// false positive, re-entered through a different door. The snapshot key
+		// must normalize exactly like the changedSymbols key it pairs with.
+		it("diffs a re-spelled file against its own snapshot, not an empty one (refs #2355)", () => {
+			const store = new FactStore("dispatch");
+			const firstSpelling = "C:/repo/2355/src/Target.ts";
+			const reSpelling = "c:/repo/2355/src/target.ts";
+			expect(normalizeMapKey(firstSpelling)).toBe(normalizeMapKey(reSpelling));
+
+			recordEntitySnapshotDiff(store, firstSpelling, snapshot());
+
+			expect(recordEntitySnapshotDiff(store, reSpelling, snapshot())).toEqual({
+				added: [],
+				removed: [],
+				modified: [],
+			});
+		});
 	});
 });

--- a/tests/clients/review-graph/session-facts.test.ts
+++ b/tests/clients/review-graph/session-facts.test.ts
@@ -1,0 +1,57 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import { normalizeMapKey } from "../../../clients/path-utils.js";
+import {
+	buildOrUpdateGraph,
+	clearReviewGraphWorkspaceCache,
+} from "../../../clients/review-graph/builder.js";
+import {
+	computeImpactCascade,
+	recordEntitySnapshotDiff,
+} from "../../../clients/review-graph/service.js";
+import { removeTempDirSync } from "../test-utils.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	clearReviewGraphWorkspaceCache();
+	for (const root of roots.splice(0)) removeTempDirSync(root);
+});
+
+describe("review-graph session facts", () => {
+	it("builder consumes changed symbols written under an alternate path spelling", async () => {
+		const cwd = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-session-facts-"),
+		);
+		roots.push(cwd);
+		const file = path.join(cwd, "target.ts");
+		fs.writeFileSync(
+			file,
+			"export function alpha(): number { return 1; }\nexport function beta(): number { return 2; }\n",
+		);
+
+		const facts = new FactStore("dispatch");
+		const snapshot = new Map([
+			["function:alpha", "alpha-v1"],
+			["function:beta", "beta-v1"],
+		]);
+		// The dispatch runner can hand the service a backslash-spelled path while
+		// the graph walk later supplies the platform's canonical spelling. The
+		// service is the writer; the builder and query are the real readers.
+		const backslashSpelling = file
+			.split(path.sep)
+			.join(String.fromCharCode(92));
+		recordEntitySnapshotDiff(facts, backslashSpelling, snapshot);
+
+		const graph = await buildOrUpdateGraph(cwd, [file], facts);
+		const impact = computeImpactCascade(graph, file, cwd);
+
+		// This value comes from the builder's session-fact lookup and the query's
+		// symbol selection, not from reading the FactStore key in the test.
+		expect(graph.fileNodes.has(normalizeMapKey(file))).toBe(true);
+		expect(impact.changedSymbols).toEqual(["alpha", "beta"]);
+	});
+});


### PR DESCRIPTION
## Summary

- Normalize review-graph `changedSymbols` and `entitySnapshot` session-fact keys at the service boundary.
- Reuse one normalized path for both keys, removing the duplicate `normalizeMapKey` realpath probe per entity-diff call.
- Preserve bounded session-fact eviction semantics and the existing builder/query path-key contract.

## Tests

- `tests/clients/dispatch/fact-store-session-bound.test.ts`: keeps direct changed-symbol and re-spelled entity-snapshot contract cases; these pin key symmetry and snapshot reuse.
- `tests/clients/review-graph/session-facts.test.ts`: drives the real service writer, `FactStore`, `buildOrUpdateGraph`, and `computeImpactCascade`; it proves a backslash-spelled write is consumed by the builder/query reader.
- Mutation proof: changing the service writer to use raw `filePath` makes the real-seam test fail with `impact.changedSymbols = []`; restoring normalized writing returns `['alpha', 'beta']`.
- Hot-path measurement: `recordEntitySnapshotDiff` has one `normalizeMapKey(filePath)` call per invocation, down from two; both fact keys reuse `normalizedFilePath`.
- `npm run build`
- `npm run lint`
- `npm run fmt:check`
- `npm run changelog:check`
- `npm run check:lockfile`
- `npm run depcruise:check`
- `npm run astgrep:self-scan`
- Targeted and governance suites: 10 files, 147/147 tests passed.
- Complete review-graph suite: 27 files passed, 2 skipped; `import-resolvers.test.ts` has one existing 5-second timeout in the suite, while the isolated case passes.

## Blast radius

`recordEntitySnapshotDiff` is called by the tree-sitter dispatch runner. Its bounded session-fact writes feed `builder.ts`'s `upsertChangedSymbols`, `query.ts`'s impact selection, and the tree-sitter blast-radius log. The change is in-memory key construction only; it does not alter durable formats, public APIs, or transport behavior. `module_report` is unavailable in this worker context, so the dependent map uses the repository-wide symbol and call-site sweep above.

## Class sweep

Audited all `changedSymbolsByFile` readers and writers, plus every `setBoundedSessionFact`/`getBoundedSessionFact` family in `clients/`, `mcp/`, and `tools/`.

- Review-graph `changedSymbols`: service write and builder read use `normalizeMapKey`; real builder/query regression passes.
- Review-graph `entitySnapshot`: service read and write use the same normalized key; re-spelled snapshot diff remains empty.
- Dispatch absolute and relative delta baselines: dispatcher derives shared normalized keys for both writes and reads.
- Cascade baselines: integration derives the same normalized key for reads and writes.
- Fixed-vocabulary session facts: not path-keyed, so no normalization applies.

## Observability

No new failure path exists. Existing tree-sitter `entity_diff` and `blast_radius` records show changed entities and consumed symbols. An unchanged re-spelled file produces no entity diff and no spurious blast-radius work.

## Test assessment

- `tests/clients/dispatch/fact-store-session-bound.test.ts`: its edited cases pin direct key symmetry and cross-spelling snapshot reuse; they complement the real builder/query test and are not redundant because they isolate each bounded-store contract.
- `tests/clients/review-graph/session-facts.test.ts`: the new case uniquely pins writer-to-builder-to-query consumption through real in-process state and catches a raw-reader or raw-writer mutation.

Refs #2355.
