### PR TITLE
perf(formatters): read each ancestor dir once in findUp (closes #1603)

### DIFF
--- a/.changelog/1603-formatter-signature-warm-cache.md
+++ b/.changelog/1603-formatter-signature-warm-cache.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Formatter config-signature walk no longer scales with the candidate list (closes #1603)** — `findUp` (used by `formatterConfigSignature` and every `has*Config` check) now reads each ancestor directory once and checks membership in-memory, instead of issuing one `fs.access` per candidate filename per directory. The walk still runs on every `getFormattersForFile` call, so a formatter config created or edited after the first call for a cwd still invalidates the cache exactly as before (#1572/#1596); its cost just no longer grows with how many names `FORMATTER_CONFIG_FILES` holds.
+- **Formatter config-signature lookup is warm-path cached (closes #1603)** — `findUp` reads each ancestor directory once, validates only matched entries, and rejects dangling links. The first lookup for a cwd computes one session-generation signature; warm selections do no configuration polling. The write-result seam invalidates selection for config create, change, and remove events, so formatter detection still re-runs without a per-call filesystem tax.

--- a/.changelog/1603-formatter-signature-warm-cache.md
+++ b/.changelog/1603-formatter-signature-warm-cache.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Formatter config-signature walk no longer scales with the candidate list (closes #1603)** — `findUp` (used by `formatterConfigSignature` and every `has*Config` check) now reads each ancestor directory once and checks membership in-memory, instead of issuing one `fs.access` per candidate filename per directory. The walk still runs on every `getFormattersForFile` call, so a formatter config created or edited after the first call for a cwd still invalidates the cache exactly as before (#1572/#1596); its cost just no longer grows with how many names `FORMATTER_CONFIG_FILES` holds.

--- a/.changelog/1603-formatter-signature-warm-cache.md
+++ b/.changelog/1603-formatter-signature-warm-cache.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Formatter config-signature lookup is warm-path cached (closes #1603)** — `findUp` reads each ancestor directory once, validates only matched entries, and rejects dangling links. The first lookup for a cwd computes one session-generation signature; warm selections do no configuration polling. The write-result seam invalidates selection for config create, change, and remove events, so formatter detection still re-runs without a per-call filesystem tax.
+- **Formatter config-signature lookup is warm-path cached (closes #1603)** — `findUp` reads each ancestor directory once, validates only matched entries, and rejects dangling links. The first lookup for a cwd computes one session-generation signature; concurrent extensions merge into one bounded cache entry, and warm selections do no configuration polling. The write-result seam invalidates selection for config create, change, and remove events, so formatter detection still re-runs without a per-call filesystem tax.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -777,7 +777,13 @@ answers a same-cwd lookup from `detectionCache` before it reaches a probe, so
 dropping the latches without the selection cache leaves the previous session's
 verdict standing in the working directory. Formatter selection emits
 `formatter_selected` with `outcome: "hit" | "miss"` on both cache hits and
-re-detections so hit rate is computable from `latency.log`. (#1895, #1940)
+re-detections so hit rate is computable from `latency.log`. The first lookup for
+a cwd computes one session-generation config signature; warm extension lookups
+do no config polling. The write-result seam calls
+`invalidateFormatterCacheForPath` for config create, change, and remove events,
+which clears the signature and selection state together. External editor
+changes remain outside that seam and are rechecked at session reset. (#1895,
+#1940, #1603)
 
 Helm chart linting uses the shared workspace-topology `Chart.yaml` marker. YAML
 and `.tpl` edits inside a chart dispatch one canonical-root-deduplicated,

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -203,10 +203,24 @@ async function findUp(
 				foldCase ? entries.map((e) => e.toLowerCase()) : entries,
 			);
 			for (const target of targets) {
+				// Nested candidates (for example node_modules/.bin/biome) do
+				// not appear as direct readdir members. They retain the old
+				// bounded candidate probe; direct names use the O(depth + matches)
+				// directory-membership path above.
+				if (target.includes("/") || target.includes("\\")) continue;
 				if (entrySet.has(foldCase ? target.toLowerCase() : target)) {
-					found.push(path.join(currentDir, target));
+					const candidate = path.join(currentDir, target);
+					// Directory membership is only a cheap candidate filter. Keep the
+					// old access check for matched entries so dangling links and entries
+					// that cannot be read do not become config evidence (#1603 R2).
+					if (await fileExists(candidate)) found.push(candidate);
 				}
 			}
+		}
+		for (const target of targets) {
+			if (!target.includes("/") && !target.includes("\\")) continue;
+			const candidate = path.join(currentDir, target);
+			if (await fileExists(candidate)) found.push(candidate);
 		}
 		const parent = path.dirname(currentDir);
 		if (parent === currentDir) break;
@@ -214,6 +228,15 @@ async function findUp(
 	}
 
 	return found;
+}
+
+/** Test-only access to the real filesystem walker and its candidate filter. */
+export function _findUpForTests(
+	targets: string[],
+	startDir: string,
+	stopDir?: string,
+): Promise<string[]> {
+	return findUp(targets, startDir, stopDir);
 }
 
 const WHICH_BUDGET_MS = 5000;
@@ -1567,10 +1590,19 @@ const detectionCache = new BoundedLruCache<
 	string,
 	{ signature: string; entries: Map<string, string[]> }
 >(32);
+// The signature is immutable for a cache generation. This memo is separate
+// from detectionCache because a cwd can have several extension entries, and a
+// warm lookup must not repeat the ancestor walk or stat matched configs.
+const formatterSignatureFlights = new Map<
+	string,
+	{ generation: number; promise: Promise<string> }
+>();
+let formatterCacheGeneration = 0;
 
 // These are the formatter configuration files consulted by the policy helpers
-// above. Their metadata is part of detection cache identity: changing a file
-// must re-run detection even when PATH and installed tools are unchanged. A
+// above. Their metadata is captured by the cold detection signature. The
+// write-result seam invalidates that signature when a config path changes, so
+// detection re-runs even when PATH and installed tools are unchanged. A
 // filename a `has*Config` check reads but this list omits is invisible to the
 // cache: the signature never moves when that file is added, so a project that
 // opts in AFTER the first `getFormattersForFile` call for its cwd keeps
@@ -1674,6 +1706,22 @@ async function formatterConfigSignature(cwd: string): Promise<string> {
 	return parts.join("|");
 }
 
+async function getFormatterConfigSignature(
+	cwd: string,
+	normalizedCwd: string,
+): Promise<string> {
+	const generation = formatterCacheGeneration;
+	const existing = formatterSignatureFlights.get(normalizedCwd);
+	if (existing?.generation === generation) return existing.promise;
+	const promise = formatterConfigSignature(cwd).finally(() => {
+		const current = formatterSignatureFlights.get(normalizedCwd);
+		if (current?.promise === promise)
+			formatterSignatureFlights.delete(normalizedCwd);
+	});
+	formatterSignatureFlights.set(normalizedCwd, { generation, promise });
+	return promise;
+}
+
 // --- Public API ---
 
 export async function getFormattersForFile(
@@ -1692,33 +1740,20 @@ export async function getFormattersForFile(
 		? `${normalizedCwd}:${ext}:${base}`
 		: `${normalizedCwd}:${ext}`;
 
-	const configSignature = await formatterConfigSignature(cwd);
-	// Check cache
+	// A warm entry is authoritative until the write-result seam invalidates its
+	// config path. This is the only way to make the warm path free of config
+	// polling while still reacting immediately to pi-authored create/remove/
+	// change events. External editor changes remain a documented session-boundary
+	// limitation, like other write-result-owned freshness seams.
 	let cached = detectionCache.get(normalizedCwd);
-	if (cached && cached.signature !== configSignature) {
-		// An EXISTING entry whose signature moved is the user telling us the world
-		// changed. Re-probe PATH too, so "install the tool, touch the config" still
-		// works within one session now that a durable absence latches (#1495).
-		// Scoped to a real change on purpose: keying this off "no entry yet" would
-		// drop every PATH verdict on the first save in each new directory, which in
-		// a monorepo means re-probing forever.
-		detectionCache.delete(normalizedCwd);
-		cached = undefined;
-		resetWhichLatches();
-	}
-	if (!cached) {
-		cached = { signature: configSignature, entries: new Map() };
-		detectionCache.set(normalizedCwd, cached);
-	}
-
-	if (cached.entries.has(cacheKey)) {
+	if (cached?.entries.has(cacheKey)) {
 		const enabledNames = cached.entries.get(cacheKey);
 		const selectedFormatterName =
 			enabledNames && enabledNames.length > 0 ? enabledNames[0] : null;
 		logLatency({
 			type: "phase",
 			phase: "formatter_selected",
-			filePath: filePath,
+			filePath,
 			durationMs: 0,
 			metadata: {
 				formatter: selectedFormatterName,
@@ -1729,8 +1764,21 @@ export async function getFormattersForFile(
 			},
 		});
 		if (!enabledNames || enabledNames.length === 0) return [];
-		// Return cached formatters by name (preserves priority order)
 		return ALL_FORMATTERS.filter((f) => enabledNames.includes(f.name));
+	}
+	if (!cached) {
+		const generation = formatterCacheGeneration;
+		const configSignature = await getFormatterConfigSignature(
+			cwd,
+			normalizedCwd,
+		);
+		// An invalidation can happen while the first signature walk is in flight.
+		// Do not publish a pre-invalidation signature into the new generation.
+		if (generation !== formatterCacheGeneration) {
+			return getFormattersForFile(filePath, cwd);
+		}
+		cached = { signature: configSignature, entries: new Map() };
+		detectionCache.set(normalizedCwd, cached);
 	}
 
 	// Detect formatters for this extension (or exact filename, e.g. terragrunt.hcl)
@@ -1904,7 +1952,11 @@ export async function getFormattersForFile(
 
 	// Store the list of enabled formatter names in cache
 	const enabledNames = enabled.map((f) => f.name);
-	cached.entries.set(cacheKey, enabledNames);
+	// An invalidation may have removed or replaced this object while detection
+	// awaited a tool probe. Never repopulate the old generation.
+	if (detectionCache.get(normalizedCwd) === cached) {
+		cached.entries.set(cacheKey, enabledNames);
+	}
 	return enabled;
 }
 
@@ -1919,8 +1971,23 @@ export async function getFormattersForFile(
  * therefore re-arms every directory EXCEPT the one the user is working in.
  */
 export function clearFormatterCache(): void {
+	formatterCacheGeneration += 1;
+	formatterSignatureFlights.clear();
 	detectionCache.clear();
 	resetWhichLatches();
+}
+
+const formatterConfigBasenames = new Set(
+	FORMATTER_CONFIG_FILES.map((fileName) => fileName.toLowerCase()),
+);
+
+/** Invalidate selection when the write-result seam reports a config path. */
+export function invalidateFormatterCacheForPath(filePath: string): void {
+	const basename = filePath.includes("\\")
+		? path.win32.basename(filePath)
+		: path.basename(filePath);
+	if (!formatterConfigBasenames.has(basename.toLowerCase())) return;
+	clearFormatterCache();
 }
 
 /**
@@ -1949,8 +2016,7 @@ export function _getFormatterResetStateForTests(): {
 }
 
 export function clearFormatterRuntimeState(): void {
-	detectionCache.clear();
-	resetWhichLatches();
+	clearFormatterCache();
 	// NO `resetLazyInstallAttempts()` here (#1537 review F1). This function runs
 	// from `resetFormatService()`, which `handleTurnEnd` calls every turn — so
 	// clearing the lazy-install hold here made "held for the session" mean "held

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -14,6 +14,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { BoundedLruCache } from "./bounded-cache.js";
+import { createGenerationSource } from "./generation-guard.js";
 import { normalizeMapKey } from "./path-utils.js";
 import { TERRAGRUNT_FILENAMES } from "./file-kinds.js";
 import {
@@ -1595,9 +1596,9 @@ const detectionCache = new BoundedLruCache<
 // warm lookup must not repeat the ancestor walk or stat matched configs.
 const formatterSignatureFlights = new Map<
 	string,
-	{ generation: number; promise: Promise<string> }
+	{ promise: Promise<string> }
 >();
-let formatterCacheGeneration = 0;
+const formatterCacheGeneration = createGenerationSource("formatter-cache");
 
 // These are the formatter configuration files consulted by the policy helpers
 // above. Their metadata is captured by the cold detection signature. The
@@ -1710,15 +1711,14 @@ async function getFormatterConfigSignature(
 	cwd: string,
 	normalizedCwd: string,
 ): Promise<string> {
-	const generation = formatterCacheGeneration;
 	const existing = formatterSignatureFlights.get(normalizedCwd);
-	if (existing?.generation === generation) return existing.promise;
+	if (existing) return existing.promise;
 	const promise = formatterConfigSignature(cwd).finally(() => {
 		const current = formatterSignatureFlights.get(normalizedCwd);
 		if (current?.promise === promise)
 			formatterSignatureFlights.delete(normalizedCwd);
 	});
-	formatterSignatureFlights.set(normalizedCwd, { generation, promise });
+	formatterSignatureFlights.set(normalizedCwd, { promise });
 	return promise;
 }
 
@@ -1767,18 +1767,25 @@ export async function getFormattersForFile(
 		return ALL_FORMATTERS.filter((f) => enabledNames.includes(f.name));
 	}
 	if (!cached) {
-		const generation = formatterCacheGeneration;
+		const generation = formatterCacheGeneration.capture();
 		const configSignature = await getFormatterConfigSignature(
 			cwd,
 			normalizedCwd,
 		);
 		// An invalidation can happen while the first signature walk is in flight.
 		// Do not publish a pre-invalidation signature into the new generation.
-		if (generation !== formatterCacheGeneration) {
+		if (!generation.isCurrent()) {
 			return getFormattersForFile(filePath, cwd);
 		}
-		cached = { signature: configSignature, entries: new Map() };
-		detectionCache.set(normalizedCwd, cached);
+		// Another cold caller for this cwd can finish the shared signature flight
+		// first. Re-read the LRU before installing an object so the later caller
+		// merges its extension entry into the existing object instead of replacing
+		// the earlier entry.
+		cached = detectionCache.get(normalizedCwd);
+		if (!cached) {
+			cached = { signature: configSignature, entries: new Map() };
+			detectionCache.set(normalizedCwd, cached);
+		}
 	}
 
 	// Detect formatters for this extension (or exact filename, e.g. terragrunt.hcl)
@@ -1971,7 +1978,7 @@ export async function getFormattersForFile(
  * therefore re-arms every directory EXCEPT the one the user is working in.
  */
 export function clearFormatterCache(): void {
-	formatterCacheGeneration += 1;
+	formatterCacheGeneration.bump();
 	formatterSignatureFlights.clear();
 	detectionCache.clear();
 	resetWhichLatches();

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -197,7 +197,8 @@ async function findUp(
 			// On default-case-insensitive platforms the old `fs.access` probe
 			// matched a config file regardless of on-disk casing; fold so the
 			// readdir membership check keeps that behavior.
-			const foldCase = process.platform === "win32" || process.platform === "darwin";
+			const foldCase =
+				process.platform === "win32" || process.platform === "darwin";
 			const entrySet = new Set(
 				foldCase ? entries.map((e) => e.toLowerCase()) : entries,
 			);

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -183,10 +183,28 @@ async function findUp(
 	let currentDir = startDir;
 
 	while (currentDir !== stopDir) {
-		for (const target of targets) {
-			const checkPath = path.join(currentDir, target);
-			if (await fileExists(checkPath)) {
-				found.push(checkPath);
+		// One `readdir` per directory instead of one `access` per target: the
+		// per-target probe made this loop's cost O(targets), so a long target
+		// list (e.g. `FORMATTER_CONFIG_FILES`) paid for every entry at every
+		// ancestor directory even when almost none of them exist (#1603).
+		let entries: string[];
+		try {
+			entries = await fs.readdir(currentDir);
+		} catch {
+			entries = [];
+		}
+		if (entries.length > 0) {
+			// On default-case-insensitive platforms the old `fs.access` probe
+			// matched a config file regardless of on-disk casing; fold so the
+			// readdir membership check keeps that behavior.
+			const foldCase = process.platform === "win32" || process.platform === "darwin";
+			const entrySet = new Set(
+				foldCase ? entries.map((e) => e.toLowerCase()) : entries,
+			);
+			for (const target of targets) {
+				if (entrySet.has(foldCase ? target.toLowerCase() : target)) {
+					found.push(path.join(currentDir, target));
+				}
 			}
 		}
 		const parent = path.dirname(currentDir);

--- a/clients/runtime-tool-result.ts
+++ b/clients/runtime-tool-result.ts
@@ -28,6 +28,7 @@ import {
 	invalidateProjectIgnoreMatcherForPath,
 	isPathIgnoredByProject,
 } from "./file-utils.js";
+import { invalidateFormatterCacheForPath } from "./formatters.js";
 import type { ReadGuard } from "./read-guard.js";
 import { getFormatService } from "./format-service.js";
 import {
@@ -569,7 +570,10 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 			? rawFilePath
 			: path.resolve(resolutionBasis, rawFilePath)
 		: rawFilePath;
-	if (filePath) invalidateProjectIgnoreMatcherForPath(filePath);
+	if (filePath) {
+		invalidateProjectIgnoreMatcherForPath(filePath);
+		invalidateFormatterCacheForPath(filePath);
+	}
 
 	// Purely diagnostic: tool_call's call-time verdict (computed on ITS OWN
 	// resolved path, which may since have been superseded) disagreed with
@@ -1403,6 +1407,7 @@ export async function handleToolResult(deps: ToolResultDeps): Promise<{
 
 	for (const changedFile of result.changedFiles ?? []) {
 		const resolvedChanged = path.resolve(changedFile);
+		invalidateFormatterCacheForPath(resolvedChanged);
 		if (!nodeFs.existsSync(resolvedChanged)) continue;
 		recordProjectChange({
 			runtime,

--- a/tests/clients/formatters-signature-warm-path.test.ts
+++ b/tests/clients/formatters-signature-warm-path.test.ts
@@ -1,0 +1,77 @@
+/**
+ * #1603 — `formatterConfigSignature` ran BEFORE the cache check in
+ * `getFormattersForFile`, and its `findUp` walk probed every one of
+ * `FORMATTER_CONFIG_FILES`' ~60 names with its own `fs.access` call at every
+ * ancestor directory. That cost scaled with the candidate list's length (a
+ * measured 41% growth as #1596 grew it 44→60 entries) and ran unconditionally
+ * on every call, including a fully warm cache hit that never needed it.
+ *
+ * Fixed by having `findUp` read each ancestor directory once (`fs.readdir`)
+ * and check membership in-memory, instead of probing each candidate name with
+ * its own `fs.access`. The walk still runs on every call — so a config file
+ * created after the first call keeps invalidating the cache exactly as
+ * before (#1572/#1596) — but its cost no longer depends on how many names
+ * the candidate list holds.
+ *
+ * This FAILS against pre-fix code: `fs.access` is called once per
+ * (ancestor directory × candidate filename) on every call, so a warm repeat
+ * call for an already-cached extension still fires a large, nonzero number
+ * of `access` probes.
+ */
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...actual,
+		access: vi.fn(actual.access),
+		readdir: vi.fn(actual.readdir),
+	};
+});
+
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	clearFormatterRuntimeState,
+	getFormattersForFile,
+} from "../../clients/formatters.js";
+import { setupTestEnvironment } from "./test-utils.js";
+
+const accessMock = vi.mocked(fsp.access);
+const readdirMock = vi.mocked(fsp.readdir);
+
+let tmpDir: string;
+let cleanup: () => void;
+
+beforeEach(() => {
+	({ tmpDir, cleanup } = setupTestEnvironment("pi-lens-fmt-sig-"));
+	accessMock.mockClear();
+	readdirMock.mockClear();
+});
+
+afterEach(() => {
+	clearFormatterRuntimeState();
+	cleanup();
+});
+
+describe("formatterConfigSignature warm-cache cost (#1603)", () => {
+	it("a repeat call for an already-cached extension makes no per-config-name access probes", async () => {
+		// An extension no formatter claims: `matching` is empty, so the only
+		// filesystem work `getFormattersForFile` does at all is the unconditional
+		// `formatterConfigSignature` walk — isolating exactly the cost this issue
+		// is about.
+		const filePath = path.join(tmpDir, "index.zzznotarealext");
+
+		await getFormattersForFile(filePath, tmpDir);
+		accessMock.mockClear();
+		readdirMock.mockClear();
+
+		await getFormattersForFile(filePath, tmpDir);
+
+		expect(accessMock).not.toHaveBeenCalled();
+		// One readdir per ancestor directory — bounded by directory depth, not
+		// by however many names FORMATTER_CONFIG_FILES holds.
+		expect(readdirMock.mock.calls.length).toBeGreaterThan(0);
+		expect(readdirMock.mock.calls.length).toBeLessThan(20);
+	});
+});

--- a/tests/clients/formatters-signature-warm-path.test.ts
+++ b/tests/clients/formatters-signature-warm-path.test.ts
@@ -14,7 +14,13 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 	};
 });
 
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return { ...actual, existsSync: vi.fn(actual.existsSync) };
+});
+
 import * as fsp from "node:fs/promises";
+import * as nodeFs from "node:fs";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -23,10 +29,13 @@ import {
 	getFormattersForFile,
 	invalidateFormatterCacheForPath,
 } from "../../clients/formatters.js";
+import { gatedPromise } from "../support/fault-injection.js";
+import { assertNonEmptyScan } from "../support/sweep-kit.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
 const accessMock = vi.mocked(fsp.access);
 const readdirMock = vi.mocked(fsp.readdir);
+const existsSyncMock = vi.mocked(nodeFs.existsSync);
 
 let tmpDir: string;
 let cleanup: () => void;
@@ -35,6 +44,7 @@ beforeEach(() => {
 	({ tmpDir, cleanup } = setupTestEnvironment("pi-lens-fmt-sig-"));
 	accessMock.mockClear();
 	readdirMock.mockClear();
+	existsSyncMock.mockClear();
 });
 
 afterEach(() => {
@@ -59,19 +69,108 @@ describe("formatterConfigSignature warm-cache cost (#1603)", () => {
 	});
 
 	it("shares the cold signature walk across concurrent cwd lookups", async () => {
-		const firstFile = path.join(tmpDir, "first.zzznotarealext");
-		await getFormattersForFile(firstFile, tmpDir);
-		const coldReaddirCount = readdirMock.mock.calls.length;
-		expect(coldReaddirCount).toBeGreaterThan(0);
-
-		clearFormatterRuntimeState();
+		const firstFile = path.join(tmpDir, "README.md");
+		const secondFile = path.join(tmpDir, "index.ts");
+		const thirdFile = path.join(tmpDir, "guide.mdx");
+		await fsp.writeFile(path.join(tmpDir, ".prettierrc"), "{}\n");
 		readdirMock.mockClear();
 		await Promise.all([
 			getFormattersForFile(firstFile, tmpDir),
-			getFormattersForFile(path.join(tmpDir, "second.zzzotherext"), tmpDir),
+			getFormattersForFile(secondFile, tmpDir),
+			getFormattersForFile(thirdFile, tmpDir),
 		]);
 
-		expect(readdirMock.mock.calls.length).toBe(coldReaddirCount);
+		expect(readdirMock.mock.calls.length).toBeGreaterThan(0);
+		readdirMock.mockClear();
+		accessMock.mockClear();
+		existsSyncMock.mockClear();
+		await Promise.all([
+			getFormattersForFile(firstFile, tmpDir),
+			getFormattersForFile(secondFile, tmpDir),
+			getFormattersForFile(thirdFile, tmpDir),
+		]);
+		// If either cold caller overwrote the other's cache object, its second
+		// lookup misses and re-runs an explicit-config filesystem check.
+		expect(readdirMock).not.toHaveBeenCalled();
+		expect(accessMock).not.toHaveBeenCalled();
+		expect(existsSyncMock).not.toHaveBeenCalled();
+	});
+
+	it("keeps signature flights independent for different cwd and config state", async () => {
+		const otherCwd = path.join(tmpDir, "nested");
+		await fsp.mkdir(otherCwd);
+		await fsp.writeFile(path.join(otherCwd, ".prettierrc"), "{}\n");
+		readdirMock.mockClear();
+
+		await Promise.all([
+			getFormattersForFile(path.join(tmpDir, "first.zzznotarealext"), tmpDir),
+			getFormattersForFile(
+				path.join(otherCwd, "second.zzznotarealext"),
+				otherCwd,
+			),
+		]);
+
+		const readDirectories = new Set(
+			readdirMock.mock.calls.map(([directory]) => directory),
+		);
+		expect(readDirectories.has(tmpDir)).toBe(true);
+		expect(readDirectories.has(otherCwd)).toBe(true);
+	});
+
+	it("treats a rejected directory read as a negative signature", async () => {
+		const originalReaddir = readdirMock.getMockImplementation()!;
+		readdirMock.mockRejectedValue(new Error("directory unavailable"));
+		await expect(
+			getFormattersForFile(
+				path.join(tmpDir, "unavailable.zzznotarealext"),
+				tmpDir,
+			),
+		).resolves.toEqual([]);
+
+		// Reset clears the negative detection entry and the completed flight, so
+		// a later call can observe the directory after the filesystem recovers.
+		clearFormatterRuntimeState();
+		readdirMock.mockImplementation(originalReaddir);
+		await expect(
+			getFormattersForFile(
+				path.join(tmpDir, "recovered.zzznotarealext"),
+				tmpDir,
+			),
+		).resolves.toEqual([]);
+		expect(readdirMock).toHaveBeenCalled();
+	});
+
+	it("drops a cold result invalidated while its signature is in flight", async () => {
+		const filePath = path.join(tmpDir, "init.lua");
+		const configPath = path.join(tmpDir, "stylua.toml");
+		await fsp.writeFile(configPath, "column_width = 100\n");
+		const gate = gatedPromise<string[]>();
+		const original = readdirMock.getMockImplementation()!;
+		let held = false;
+		readdirMock.mockImplementation(async (...args) => {
+			const entries = await original(...args);
+			if (!held) {
+				held = true;
+				await gate.promise;
+			}
+			return entries;
+		});
+		try {
+			const pending = getFormattersForFile(filePath, tmpDir);
+			while (!held) await new Promise<void>((resolve) => setImmediate(resolve));
+			await fsp.rm(configPath);
+			invalidateFormatterCacheForPath(configPath);
+			gate.resolve([]);
+			expect(await pending).toEqual([]);
+			// The stale caller must retry in the new generation. One walk belongs
+			// to the invalidated flight, and one belongs to its retry.
+			expect(
+				readdirMock.mock.calls.filter(([directory]) => directory === tmpDir),
+			).toHaveLength(2);
+		} finally {
+			gate.resolve([]);
+			readdirMock.mockImplementation(original);
+		}
 	});
 
 	it("scales with matched candidates, not the candidate-list size", async () => {
@@ -85,6 +184,7 @@ describe("formatterConfigSignature warm-cache cost (#1603)", () => {
 		const smallAccesses = accessMock.mock.calls.length;
 		const smallReads = readdirMock.mock.calls.length;
 		expect(small).toEqual([path.join(sourceDir, "real.config")]);
+		assertNonEmptyScan("formatter candidate scaling: small list", small.length);
 
 		accessMock.mockClear();
 		readdirMock.mockClear();
@@ -103,6 +203,7 @@ describe("formatterConfigSignature warm-cache cost (#1603)", () => {
 		// restored per-candidate probe would increase access calls fourfold;
 		// removing entrySet.has would also admit the three missing names.
 		expect(large).toEqual(small);
+		assertNonEmptyScan("formatter candidate scaling: large list", large.length);
 		expect(accessMock.mock.calls.length).toBe(smallAccesses);
 		expect(readdirMock.mock.calls.length).toBe(smallReads);
 	});

--- a/tests/clients/formatters-signature-warm-path.test.ts
+++ b/tests/clients/formatters-signature-warm-path.test.ts
@@ -1,22 +1,8 @@
 /**
- * #1603 — `formatterConfigSignature` ran BEFORE the cache check in
- * `getFormattersForFile`, and its `findUp` walk probed every one of
- * `FORMATTER_CONFIG_FILES`' ~60 names with its own `fs.access` call at every
- * ancestor directory. That cost scaled with the candidate list's length (a
- * measured 41% growth as #1596 grew it 44→60 entries) and ran unconditionally
- * on every call, including a fully warm cache hit that never needed it.
+ * #1603 — warm formatter selection must not poll configuration files.
  *
- * Fixed by having `findUp` read each ancestor directory once (`fs.readdir`)
- * and check membership in-memory, instead of probing each candidate name with
- * its own `fs.access`. The walk still runs on every call — so a config file
- * created after the first call keeps invalidating the cache exactly as
- * before (#1572/#1596) — but its cost no longer depends on how many names
- * the candidate list holds.
- *
- * This FAILS against pre-fix code: `fs.access` is called once per
- * (ancestor directory × candidate filename) on every call, so a warm repeat
- * call for an already-cached extension still fires a large, nonzero number
- * of `access` probes.
+ * Config changes are invalidated by the write-result seam. The cold signature
+ * walk still uses real filesystem state to discover the initial config set.
  */
 
 vi.mock("node:fs/promises", async (importOriginal) => {
@@ -32,8 +18,10 @@ import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	_findUpForTests,
 	clearFormatterRuntimeState,
 	getFormattersForFile,
+	invalidateFormatterCacheForPath,
 } from "../../clients/formatters.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
@@ -55,23 +43,117 @@ afterEach(() => {
 });
 
 describe("formatterConfigSignature warm-cache cost (#1603)", () => {
-	it("a repeat call for an already-cached extension makes no per-config-name access probes", async () => {
-		// An extension no formatter claims: `matching` is empty, so the only
-		// filesystem work `getFormattersForFile` does at all is the unconditional
-		// `formatterConfigSignature` walk — isolating exactly the cost this issue
-		// is about.
+	it("does no filesystem work on a warm selection hit", async () => {
 		const filePath = path.join(tmpDir, "index.zzznotarealext");
 
 		await getFormattersForFile(filePath, tmpDir);
+		const coldReaddirCount = readdirMock.mock.calls.length;
+		expect(coldReaddirCount).toBeGreaterThan(0);
 		accessMock.mockClear();
 		readdirMock.mockClear();
 
 		await getFormattersForFile(filePath, tmpDir);
 
 		expect(accessMock).not.toHaveBeenCalled();
-		// One readdir per ancestor directory — bounded by directory depth, not
-		// by however many names FORMATTER_CONFIG_FILES holds.
+		expect(readdirMock).not.toHaveBeenCalled();
+	});
+
+	it("shares the cold signature walk across concurrent cwd lookups", async () => {
+		const firstFile = path.join(tmpDir, "first.zzznotarealext");
+		await getFormattersForFile(firstFile, tmpDir);
+		const coldReaddirCount = readdirMock.mock.calls.length;
+		expect(coldReaddirCount).toBeGreaterThan(0);
+
+		clearFormatterRuntimeState();
+		readdirMock.mockClear();
+		await Promise.all([
+			getFormattersForFile(firstFile, tmpDir),
+			getFormattersForFile(path.join(tmpDir, "second.zzzotherext"), tmpDir),
+		]);
+
+		expect(readdirMock.mock.calls.length).toBe(coldReaddirCount);
+	});
+
+	it("scales with matched candidates, not the candidate-list size", async () => {
+		const ancestor = path.join(tmpDir, "project");
+		const sourceDir = path.join(ancestor, "src");
+		const nested = path.join(sourceDir, "deep");
+		await fsp.mkdir(nested, { recursive: true });
+		await fsp.writeFile(path.join(sourceDir, "real.config"), "ok\n");
+
+		const small = await _findUpForTests(["real.config"], nested, ancestor);
+		const smallAccesses = accessMock.mock.calls.length;
+		const smallReads = readdirMock.mock.calls.length;
+		expect(small).toEqual([path.join(sourceDir, "real.config")]);
+
+		accessMock.mockClear();
+		readdirMock.mockClear();
+		const large = await _findUpForTests(
+			[
+				"real.config",
+				"missing-a.config",
+				"missing-b.config",
+				"missing-c.config",
+			],
+			nested,
+			ancestor,
+		);
+
+		// The independent setup work is complete before counters are read. A
+		// restored per-candidate probe would increase access calls fourfold;
+		// removing entrySet.has would also admit the three missing names.
+		expect(large).toEqual(small);
+		expect(accessMock.mock.calls.length).toBe(smallAccesses);
+		expect(readdirMock.mock.calls.length).toBe(smallReads);
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"rejects dangling symlinks but keeps accessible matched files",
+		async () => {
+			// Windows ACL denial is not deterministic on the developer and CI
+			// accounts, so the inaccessible-entry axis remains a stated non-goal;
+			// the production access check still preserves the old failure semantics.
+			const ancestor = path.join(tmpDir, "project");
+			const sourceDir = path.join(ancestor, "src");
+			const nested = path.join(sourceDir, "deep");
+			await fsp.mkdir(nested, { recursive: true });
+			await fsp.writeFile(path.join(sourceDir, "real.config"), "ok\n");
+			await fsp.symlink(
+				path.join(sourceDir, "missing-target"),
+				path.join(sourceDir, "dangling.config"),
+			);
+
+			await expect(
+				_findUpForTests(["dangling.config", "real.config"], nested, ancestor),
+			).resolves.toEqual([path.join(sourceDir, "real.config")]);
+		},
+	);
+
+	it("invalidates cold and warm results for config create and remove", async () => {
+		const filePath = path.join(tmpDir, "init.lua");
+		const configPath = path.join(tmpDir, "stylua.toml");
+
+		expect(await getFormattersForFile(filePath, tmpDir)).toEqual([]);
+		await fsp.writeFile(configPath, "column_width = 100\n");
+		// No polling: an external mutation remains invisible until its owner
+		// reports the path through invalidateFormatterCacheForPath.
+		expect(await getFormattersForFile(filePath, tmpDir)).toEqual([]);
+
+		invalidateFormatterCacheForPath(configPath);
+		expect(
+			(await getFormattersForFile(filePath, tmpDir)).map((f) => f.name),
+		).toEqual(["stylua"]);
+
+		await fsp.writeFile(configPath, "column_width = 120\n");
+		invalidateFormatterCacheForPath(configPath);
+		readdirMock.mockClear();
+		expect(
+			(await getFormattersForFile(filePath, tmpDir)).map((f) => f.name),
+		).toEqual(["stylua"]);
 		expect(readdirMock.mock.calls.length).toBeGreaterThan(0);
-		expect(readdirMock.mock.calls.length).toBeLessThan(20);
+
+		await fsp.rm(configPath);
+		invalidateFormatterCacheForPath(configPath);
+		expect(await getFormattersForFile(filePath, tmpDir)).toEqual([]);
 	});
 });

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -22,6 +22,7 @@ import {
 	blackFormatter,
 	clearFormatterRuntimeState,
 	getFormattersForFile,
+	invalidateFormatterCacheForPath,
 	oxfmtFormatter,
 	phpCsFixerFormatter,
 	prettierFormatter,
@@ -491,6 +492,7 @@ describe("getFormattersForFile — policy selection", () => {
 		const filePath = fileIn(tmpDir, "README.md");
 		expect(await getFormattersForFile(filePath, tmpDir)).toEqual([]);
 		createTempFile(tmpDir, ".prettierrc", "{}\n");
+		invalidateFormatterCacheForPath(path.join(tmpDir, ".prettierrc"));
 		expect(
 			(await getFormattersForFile(filePath, tmpDir)).map((f) => f.name),
 		).toEqual(["prettier"]);
@@ -1147,23 +1149,15 @@ describe("getFormattersForFile — policy selection", () => {
 		expect(formatters.map((f) => f.name)).toEqual(["mix"]);
 	});
 
-	// #1572 review F1: `getFormattersForFile` caches its answer per cwd, keyed
-	// by `formatterConfigSignature` — a hash over `FORMATTER_CONFIG_FILES`'
-	// mtimes/sizes. A filename an explicit-config CHECK reads but that list
-	// OMITS is invisible to the signature: adding the file after the first
-	// call for a cwd never invalidates the cache, so the stale (pre-opt-in)
-	// answer sticks for the rest of the session. These tests call
-	// `getFormattersForFile` once with no config (caching `[]`), THEN create
-	// the config, THEN call again in the SAME test/cwd — unlike every test
-	// above, which pre-creates its config in a fresh tmpDir and so can never
-	// observe a signature that fails to move. `stylua` (whose `stylua.toml`
-	// was already listed) is the positive control proving the shape of the
-	// test itself is sound.
-	describe("formatter config signature reacts to config created after the first call", () => {
+	// #1572 review F1: `getFormattersForFile` caches its answer per cwd. Config
+	// create/change/remove events invalidate that cache through the write-result
+	// seam, so these tests report the changed path before the second lookup.
+	describe("formatter config invalidation after the first call", () => {
 		it("control: stylua.toml created after the first call is picked up", async () => {
 			const filePath = fileIn(tmpDir, "init.lua");
 			expect(await getFormattersForFile(filePath, tmpDir)).toEqual([]);
 			createTempFile(tmpDir, "stylua.toml", "column_width = 100\n");
+			invalidateFormatterCacheForPath(path.join(tmpDir, "stylua.toml"));
 			const formatters = await getFormattersForFile(filePath, tmpDir);
 			expect(formatters.map((f) => f.name)).toEqual(["stylua"]);
 		});
@@ -1172,6 +1166,9 @@ describe("getFormattersForFile — policy selection", () => {
 			const filePath = fileIn(tmpDir, "script.ps1");
 			expect(await getFormattersForFile(filePath, tmpDir)).toEqual([]);
 			createTempFile(tmpDir, "PSScriptAnalyzerSettings.psd1", "@{}\n");
+			invalidateFormatterCacheForPath(
+				path.join(tmpDir, "PSScriptAnalyzerSettings.psd1"),
+			);
 			const formatters = await getFormattersForFile(filePath, tmpDir);
 			expect(formatters.map((f) => f.name)).toEqual([
 				"psscriptanalyzer-format",
@@ -1182,6 +1179,7 @@ describe("getFormattersForFile — policy selection", () => {
 			const filePath = fileIn(tmpDir, "Main.java");
 			expect(await getFormattersForFile(filePath, tmpDir)).toEqual([]);
 			createTempFile(tmpDir, ".google-java-format", "{}\n");
+			invalidateFormatterCacheForPath(path.join(tmpDir, ".google-java-format"));
 			await withPathShim("google-java-format", async () => {
 				const formatters = await getFormattersForFile(filePath, tmpDir);
 				expect(formatters.map((f) => f.name)).toEqual(["google-java-format"]);
@@ -1192,6 +1190,7 @@ describe("getFormattersForFile — policy selection", () => {
 			const filePath = fileIn(tmpDir, "CMakeLists.cmake");
 			expect(await getFormattersForFile(filePath, tmpDir)).toEqual([]);
 			createTempFile(tmpDir, ".cmake-format", "# cmake-format config\n");
+			invalidateFormatterCacheForPath(path.join(tmpDir, ".cmake-format"));
 			await withPathShim("cmake-format", async () => {
 				const formatters = await getFormattersForFile(filePath, tmpDir);
 				expect(formatters.map((f) => f.name)).toEqual(["cmake-format"]);
@@ -1202,6 +1201,7 @@ describe("getFormattersForFile — policy selection", () => {
 			const filePath = fileIn(tmpDir, "query.sql");
 			expect(await getFormattersForFile(filePath, tmpDir)).toEqual([]);
 			createTempFile(tmpDir, "setup.cfg", "[sqlfluff]\ndialect = postgres\n");
+			invalidateFormatterCacheForPath(path.join(tmpDir, "setup.cfg"));
 			const formatters = await getFormattersForFile(filePath, tmpDir);
 			expect(formatters.map((f) => f.name)).toEqual(["sqlfluff"]);
 		});
@@ -1218,6 +1218,7 @@ describe("getFormattersForFile — policy selection", () => {
 				(await getFormattersForFile(filePath, tmpDir)).map((f) => f.name),
 			).toEqual(["biome"]);
 			createTempFile(tmpDir, "vite-plus.json", "{}\n");
+			invalidateFormatterCacheForPath(path.join(tmpDir, "vite-plus.json"));
 			const formatters = await getFormattersForFile(filePath, tmpDir);
 			expect(formatters.map((f) => f.name)).toEqual(["oxfmt"]);
 		});
@@ -1230,6 +1231,7 @@ describe("getFormattersForFile — policy selection", () => {
 				"build.gradle.kts",
 				"spotless {\n  kotlin {\n    ktfmt()\n  }\n}\n",
 			);
+			invalidateFormatterCacheForPath(path.join(tmpDir, "build.gradle.kts"));
 			const formatters = await getFormattersForFile(filePath, tmpDir);
 			expect(formatters.map((f) => f.name)).toEqual(["ktfmt"]);
 		});
@@ -1259,6 +1261,7 @@ describe("getFormattersForFile — policy selection", () => {
 				const filePath = fileIn(tmpDir, fileName);
 				expect(await getFormattersForFile(filePath, tmpDir)).toEqual([]);
 				createTempFile(tmpDir, configFile, configContent);
+				invalidateFormatterCacheForPath(path.join(tmpDir, configFile));
 				const formatters = await getFormattersForFile(filePath, tmpDir);
 				expect(formatters.map((f) => f.name)).toEqual([formatterName]);
 			},

--- a/tests/clients/runtime-tool-result.test.ts
+++ b/tests/clients/runtime-tool-result.test.ts
@@ -80,6 +80,96 @@ describe("bash grep searchReads registration", () => {
 		}
 	});
 
+	it("invalidates formatter selection for config removal and changedFiles side effects", async () => {
+		const { runPipeline } = await import("../../clients/pipeline.js");
+		vi.mocked(runPipeline).mockResolvedValue({
+			output: "",
+			hasBlockers: false,
+			isError: false,
+			fileModified: false,
+		});
+		const env = setupTestEnvironment("pi-lens-1603-removal-");
+		try {
+			const filePath = path.join(env.tmpDir, "init.lua");
+			const sourcePath = path.join(env.tmpDir, "source.ts");
+			const configPath = path.join(env.tmpDir, "stylua.toml");
+			fs.writeFileSync(sourcePath, "const value = 1;\n");
+			fs.writeFileSync(configPath, "column_width = 100\n");
+
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			const deps = {
+				getFlag: () => false,
+				dbg: () => {},
+				runtime,
+				cacheManager: { addModifiedRange: () => {}, readTurnState: () => ({}) },
+				biomeClient: {},
+				ruffClient: {},
+				metricsClient: {},
+				resetLSPService: () => {},
+				agentBehaviorRecord: () => [],
+				formatBehaviorWarnings: () => "",
+			} as any;
+
+			await handleToolResult({
+				...deps,
+				event: {
+					toolName: "write",
+					input: { path: configPath },
+					content: [{ type: "text", text: "written" }],
+				},
+			});
+			expect(
+				(await getFormattersForFile(filePath, env.tmpDir)).map((f) => f.name),
+			).toEqual(["stylua"]);
+
+			fs.rmSync(configPath);
+			await handleToolResult({
+				...deps,
+				event: {
+					toolName: "write",
+					input: { path: configPath },
+					content: [{ type: "text", text: "removed" }],
+				},
+			});
+			expect(await getFormattersForFile(filePath, env.tmpDir)).toEqual([]);
+
+			fs.writeFileSync(configPath, "column_width = 120\n");
+			await handleToolResult({
+				...deps,
+				event: {
+					toolName: "write",
+					input: { path: configPath },
+					content: [{ type: "text", text: "written" }],
+				},
+			});
+			expect(
+				(await getFormattersForFile(filePath, env.tmpDir)).map((f) => f.name),
+			).toEqual(["stylua"]);
+
+			fs.rmSync(configPath);
+			vi.mocked(runPipeline).mockResolvedValue({
+				output: "",
+				hasBlockers: false,
+				isError: false,
+				fileModified: false,
+				changedFiles: [configPath],
+			});
+			await handleToolResult({
+				...deps,
+				event: {
+					toolName: "write",
+					input: { path: sourcePath },
+					content: [{ type: "text", text: "source changed" }],
+				},
+			});
+			expect(await getFormattersForFile(filePath, env.tmpDir)).toEqual([]);
+		} finally {
+			clearFormatterRuntimeState();
+			env.cleanup();
+		}
+	});
+
 	it("invalidates the ignore matcher through handleToolResult", async () => {
 		const { runPipeline } = await import("../../clients/pipeline.js");
 		vi.mocked(runPipeline).mockResolvedValue({

--- a/tests/clients/runtime-tool-result.test.ts
+++ b/tests/clients/runtime-tool-result.test.ts
@@ -10,6 +10,10 @@ import {
 } from "../../clients/session-lifecycle.js";
 import { handleToolCall } from "../../clients/runtime-tool-call.js";
 import { handleToolResult } from "../../clients/runtime-tool-result.js";
+import {
+	clearFormatterRuntimeState,
+	getFormattersForFile,
+} from "../../clients/formatters.js";
 import { getProjectIgnoreMatcher } from "../../clients/file-utils.js";
 import {
 	getVerifiedPathAttributionGuessCount,
@@ -31,6 +35,51 @@ const notifyExternalFileChange = vi.hoisted(() => vi.fn(async () => undefined));
 vi.mock("../../clients/lsp/index.js", () => ({ notifyExternalFileChange }));
 
 describe("bash grep searchReads registration", () => {
+	it("invalidates formatter selection through handleToolResult", async () => {
+		const { runPipeline } = await import("../../clients/pipeline.js");
+		vi.mocked(runPipeline).mockResolvedValue({
+			output: "",
+			hasBlockers: false,
+			isError: false,
+			fileModified: false,
+		});
+		const env = setupTestEnvironment("pi-lens-1603-tool-result-");
+		try {
+			const filePath = path.join(env.tmpDir, "init.lua");
+			const configPath = path.join(env.tmpDir, "stylua.toml");
+			expect(await getFormattersForFile(filePath, env.tmpDir)).toEqual([]);
+			fs.writeFileSync(configPath, "column_width = 100\n");
+			expect(await getFormattersForFile(filePath, env.tmpDir)).toEqual([]);
+
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			await handleToolResult({
+				event: {
+					toolName: "write",
+					input: { path: configPath },
+					content: [{ type: "text", text: "written" }],
+				},
+				getFlag: () => false,
+				dbg: () => {},
+				runtime,
+				cacheManager: { addModifiedRange: () => {}, readTurnState: () => ({}) },
+				biomeClient: {},
+				ruffClient: {},
+				metricsClient: {},
+				resetLSPService: () => {},
+				agentBehaviorRecord: () => [],
+				formatBehaviorWarnings: () => "",
+			} as any);
+
+			expect(
+				(await getFormattersForFile(filePath, env.tmpDir)).map((f) => f.name),
+			).toEqual(["stylua"]);
+		} finally {
+			clearFormatterRuntimeState();
+			env.cleanup();
+		}
+	});
+
 	it("invalidates the ignore matcher through handleToolResult", async () => {
 		const { runPipeline } = await import("../../clients/pipeline.js");
 		vi.mocked(runPipeline).mockResolvedValue({

--- a/tests/clients/runtime-tool-result.test.ts
+++ b/tests/clients/runtime-tool-result.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CacheManager } from "../../clients/cache-manager.js";
@@ -22,6 +23,11 @@ import {
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 
 const logLatency = vi.hoisted(() => vi.fn());
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return { ...actual, readdir: vi.fn(actual.readdir) };
+});
+
 vi.mock("../../clients/latency-logger.js", async (importActual) => ({
 	...(await importActual<typeof import("../../clients/latency-logger.js")>()),
 	logLatency,
@@ -33,6 +39,14 @@ vi.mock("../../clients/pipeline.js", () => ({
 
 const notifyExternalFileChange = vi.hoisted(() => vi.fn(async () => undefined));
 vi.mock("../../clients/lsp/index.js", () => ({ notifyExternalFileChange }));
+
+const readdirMock = vi.mocked(fsp.readdir);
+const realReaddir = readdirMock.getMockImplementation()!;
+
+beforeEach(() => {
+	readdirMock.mockImplementation(realReaddir);
+	readdirMock.mockClear();
+});
 
 describe("bash grep searchReads registration", () => {
 	it("invalidates formatter selection through handleToolResult", async () => {
@@ -74,6 +88,67 @@ describe("bash grep searchReads registration", () => {
 			expect(
 				(await getFormattersForFile(filePath, env.tmpDir)).map((f) => f.name),
 			).toEqual(["stylua"]);
+		} finally {
+			clearFormatterRuntimeState();
+			env.cleanup();
+		}
+	});
+
+	it("invalidates a warm formatter selection after an in-place config rewrite", async () => {
+		const { runPipeline } = await import("../../clients/pipeline.js");
+		vi.mocked(runPipeline).mockResolvedValue({
+			output: "",
+			hasBlockers: false,
+			isError: false,
+			fileModified: false,
+		});
+		const env = setupTestEnvironment("pi-lens-1603-rewrite-");
+		try {
+			const filePath = path.join(env.tmpDir, "init.lua");
+			const configPath = path.join(env.tmpDir, "stylua.toml");
+			fs.writeFileSync(configPath, "column_width = 100\n");
+
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			const deps = {
+				getFlag: () => false,
+				dbg: () => {},
+				runtime,
+				cacheManager: { addModifiedRange: () => {}, readTurnState: () => ({}) },
+				biomeClient: {},
+				ruffClient: {},
+				metricsClient: {},
+				resetLSPService: () => {},
+				agentBehaviorRecord: () => [],
+				formatBehaviorWarnings: () => "",
+			} as any;
+
+			expect(
+				(await getFormattersForFile(filePath, env.tmpDir)).map((f) => f.name),
+			).toEqual(["stylua"]);
+			readdirMock.mockClear();
+			expect(
+				(await getFormattersForFile(filePath, env.tmpDir)).map((f) => f.name),
+			).toEqual(["stylua"]);
+			expect(readdirMock).not.toHaveBeenCalled();
+
+			// Keep the same path and file name. Only the contents change in place.
+			fs.writeFileSync(configPath, "column_width = 120\n");
+			await handleToolResult({
+				...deps,
+				event: {
+					toolName: "write",
+					input: { path: configPath },
+					content: [{ type: "text", text: "rewritten" }],
+				},
+			});
+
+			readdirMock.mockClear();
+			expect(
+				(await getFormattersForFile(filePath, env.tmpDir)).map((f) => f.name),
+			).toEqual(["stylua"]);
+			// A warm stale entry would return above without walking ancestors.
+			expect(readdirMock.mock.calls.length).toBeGreaterThan(0);
 		} finally {
 			clearFormatterRuntimeState();
 			env.cleanup();

--- a/tests/config/sweep-floor-coverage.test.ts
+++ b/tests/config/sweep-floor-coverage.test.ts
@@ -59,6 +59,8 @@ const DECLARED_EXCEPTIONS: Readonly<Record<string, string>> = {
 		"contract fixture assertions, not a registered-or-fail source population sweep",
 	"tests/clients/formatter-probe-commands.test.ts":
 		"direct formatter probe behavior tests; the formatter registry sweep is formatter-policy-consistency",
+	"tests/clients/runtime-tool-result.test.ts":
+		"runtime seam behavior cases; filesystem counters verify re-detection, not a population sweep",
 	"tests/clients/language-policy.test.ts":
 		"policy unit cases over synthetic language definitions, not a production walk",
 	"tests/clients/lsp/lsp-primary-reachability.test.ts":

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -1181,7 +1181,7 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	"disposition-publish.ts": 0,
 	"extension-log.ts": 2,
 	"format-events-publish.ts": 0,
-	"formatters.ts": 5,
+	"formatters.ts": 7,
 	"generated-artifacts.ts": 2,
 	// #2007 hoisted git's global-option table to a module-level `new Set`
 	// (1 → 2). It is an import-time frozen lookup with no session lifetime —


### PR DESCRIPTION
## Summary

This correction round preserves concurrent formatter cache entries and routes the generation guard through the shared API.

- `getFormattersForFile` re-reads the bounded cwd cache after the shared signature flight, so concurrent extensions merge instead of overwriting one another.
- `clearFormatterCache` uses `createGenerationSource`; stale signature callers retry after invalidation, and the session registry records seven formatter state symbols.
- `handleToolResult` invalidates formatter state for config create, change, remove, and reported `changedFiles` side effects through the real runtime seam.
- `findUp` reads each ancestor once, then validates only matched candidates with `fs.access`; dangling symlinks and inaccessible matches remain absent.

Refs #1603.

## Tests

- `tests/clients/formatters-signature-warm-path.test.ts` pins zero warm `readdir`/`access`/explicit-config checks, three-worker cold-flight sharing, independent cwd/config signatures, reset recovery after filesystem failure, invalidation during an in-flight signature, candidate-list scaling, accessible-file retention, and POSIX dangling-symlink rejection.
- `tests/clients/runtime-tool-result.test.ts` drives `handleToolResult` with real formatter state through config create, in-place rewrite, removal, recreation, and an autofix `changedFiles` side effect.
- `tests/support/session-state-registry.ts` records the formatter module's seven state symbols; `tests/config/sweep-floor-coverage.test.ts` registers the candidate-scaling sweep through `assertNonEmptyScan`.

The POSIX symlink case is visibly skipped on Windows because deterministic ACL and symlink privileges are unavailable there. Windows ACL denial remains a non-goal.

## Test assessment

The warm-path file uniquely pins the filesystem budget, candidate scaling, cache merge, generation retry, and failure semantics. The runtime-result file uniquely pins production wiring from write events and side effects to formatter invalidation. No test was removed. Existing direct invalidator calls remain unit-level helper tests; production-seam coverage uses `handleToolResult`.

## Blast radius

`findUp` serves `formatterConfigSignature`, `canUseBundleExec`, Rust, Gleam, and related config discovery. `getFormattersForFile` serves `FormatService`, dispatch formatting, and lazy formatter loading. `runtime-tool-result` invalidates formatter state for the written path and reported autofix side-effect paths. The detection LRU remains capped at 32 cwd entries. Signature flights are transient, keyed by normalized cwd, and removed on settlement or reset. Normalized cwd keys preserve monorepo, symlink-alias, and Windows separator/case behavior.

## Class sweep

Swept `findInVenv`, `findInVendorBin`, and `findInNodeModules`. They use nested candidate paths, so replacing their probes with direct `readdir` membership would change their bounded candidate behavior and materially expand this fix. They retain their established probes and `fileExists` failure semantics. A focused follow-up issue could not be filed because GitHub Issues are disabled on `AngriestBird/pi-lens`; the deferred shape is recorded here.

## Observability

Existing `formatter_selected` hit/miss records remain unchanged and now report genuine warm hits. No new failure path was added. Config invalidation is synchronous and bounded by the fixed config-basename set. Stale in-flight detections cannot repopulate an invalidated generation.

## Review dispositions

- HIGH/spec: fixed in `0bb579a9`; shared signature flights are generation-bound, concurrent extension entries merge into one bounded cache object, and warm lookups perform zero configuration filesystem calls.
- MEDIUM/regression: fixed in `de10a7ee`; matched entries undergo `fs.access` validation, with POSIX real-filesystem coverage rejecting dangling links. Windows ACL coverage is explicitly deferred.
- MEDIUM/tests: fixed in `de10a7ee`; candidate-list size varies while `readdir` and `access` are measured independently. The test detects both `entrySet.has` removal and restored per-candidate probes.
- MEDIUM/concurrency: fixed in `0bb579a9`; a three-worker test retains all extension entries, and mutation of the merge reread produced 662 explicit-config filesystem calls instead of zero warm calls.
- MEDIUM/runtime seam: fixed in `0b2d0ae4`; config rewrite, removal, recreation, and `changedFiles` invalidation run through `handleToolResult` with real formatter state.
- Governance: fixed in `0bb579a9`; the generation source uses `clients/generation-guard.ts`, the session count is seven, and the new sweep is registered in sweep-floor coverage.
- Class sweep: nested candidate helpers were inspected and remain unchanged for scope and hot-path stability. GitHub Issues are disabled, so no follow-up link exists.

## Verification

- `npx vitest run tests/config`: 14 files, 68 passed.
- Focused formatter/runtime/generation/session/config run: 20 files, 392 passed, 1 visible Windows skip.
- Broader governance sweep set: 57 files, 668 passed.
- `npm run build`, `npm run lint`, `npm run fmt:check`, `npm run astgrep:self-scan`, `npm run depcruise:check`, `npm run changelog:check`, and `npm run check:lockfile` passed.
- The extension gate completed with `NPM_CONFIG_IGNORE_SCRIPTS=true` because `npm pack --dry-run` entered the package prepare lifecycle and stalled; it checked 435 files and 1,723 imports with no failures.

Pushed head: `0b2d0ae4b75e88832432e0d59b472c9ef371919c`.



