### PR TITLE
perf(review-graph): batch owned-edge removal in multi-file rebuilds (refs #2074)

### DIFF
--- a/.changelog/2074-batch-rebuild-edge-removal.md
+++ b/.changelog/2074-batch-rebuild-edge-removal.md
@@ -2,4 +2,4 @@
 section: Changed
 ---
 
-- **Bound a multi-file review-graph rebuild's edge removal (refs #2074)** — `removeFileOwnedGraphData` now finds a changed file's owned edges through `edgesByFrom`/`edgesByTo` instead of scanning `graph.edges`, and a batch of changed files compacts the edge array once instead of once per file. A multi-file rebuild previously scanned the whole edge array `changedFiles` times; it now scans it once.
+- **Bound a multi-file review-graph rebuild's edge removal (refs #2074)** — `removeFileOwnedGraphData` now finds a changed file's owned edges through `edgesByFrom`/`edgesByTo`, batches adjacency-index removal once per touched bucket, and compacts the edge array once per batch. A multi-file rebuild previously scanned the whole edge array `changedFiles` times and rescanned high-fan-in buckets once per edge; it now keeps both costs proportional to touched buckets.

--- a/.changelog/2074-batch-rebuild-edge-removal.md
+++ b/.changelog/2074-batch-rebuild-edge-removal.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Bound a multi-file review-graph rebuild's edge removal (refs #2074)** — `removeFileOwnedGraphData` now finds a changed file's owned edges through `edgesByFrom`/`edgesByTo` instead of scanning `graph.edges`, and a batch of changed files compacts the edge array once instead of once per file. A multi-file rebuild previously scanned the whole edge array `changedFiles` times; it now scans it once.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1242,7 +1242,9 @@ Incremental review-graph updates resolve deferred symbol edges after restoring
 preserved incoming edges. The live indexes must remain synchronized, and
 `dedupeResolvedEdges` removes only post-resolution duplicates from affected
 target buckets. Do not add a second whole-graph dedupe pass to the hot path;
-the next single-file rebuild must also remain duplicate-free. (#2127)
+the next single-file rebuild must also remain duplicate-free. Multi-file removal
+collects removed edges first, then filters each touched adjacency bucket once;
+per-edge `indexOf`/`splice` in a high-fan-in bucket is quadratic. (#2127, #2074)
 
 ### Git guard
 

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -3312,8 +3312,14 @@ async function tryResumeFromCheckpoint(
 	}
 	const graph = loaded.graph;
 	// Evict every stale (content-changed) processed file so its outdated
-	// contribution is replaced by a fresh walk below.
-	for (const file of stale) removeFileOwnedGraphData(graph, file);
+	// contribution is replaced by a fresh walk below. One shared drop set,
+	// compacted once (#2074) — pruneOrphanNonFileNodes reads graph.edges next,
+	// so the compaction must land before it runs.
+	const removedEdges = new Set<ReviewGraphEdge>();
+	for (const file of stale) removeFileOwnedGraphData(graph, file, removedEdges);
+	if (removedEdges.size > 0) {
+		graph.edges = graph.edges.filter((edge) => !removedEdges.has(edge));
+	}
 	pruneOrphanNonFileNodes(graph);
 	graph.changedSymbolsByFile = new Map();
 	const remaining = filesToBuild.filter((file) => !reusableHashes.has(file));
@@ -4480,44 +4486,55 @@ function addCxxIncludeEdges(
 	}
 }
 
+/**
+ * Drop the nodes/edges a changed file owns, and index-maintain as it goes.
+ * `removedEdges` accumulates edges to drop from `graph.edges` — the CALLER
+ * compacts the array once for the whole batch (#2074): before this, each call
+ * ran its own `graph.edges.filter()`, so a batch of N changed files scanned
+ * the whole edge array N times (changedFiles x graph, not changedFiles x
+ * fan-in/out).
+ *
+ * `removedIds` is exactly `fileNodes`/`symbolNodesByFile`'s entries for this
+ * file — `file` and `symbol` are the only node kinds that ever set `filePath`
+ * (`module`/`external` placeholders never do) — so no `graph.nodes` scan is
+ * needed either, and the owned edges are read straight off `edgesByFrom` /
+ * `edgesByTo` instead of scanning `graph.edges`.
+ */
 function removeFileOwnedGraphData(
 	graph: ReviewGraph,
 	filePath: string,
+	removedEdges: Set<ReviewGraphEdge>,
 ): ReviewGraphEdge[] {
 	const normalized = normalizeMapKey(filePath);
-	const fileNodeId = `file:${normalized}`;
-	const removedIds = new Set<string>();
-	const removedSymbolIds = new Set<string>();
-	for (const [id, node] of graph.nodes) {
-		if (node.filePath !== normalized) continue;
-		removedIds.add(id);
-		if (node.kind === "symbol") removedSymbolIds.add(id);
-	}
+	const fileNodeId = graph.fileNodes.get(normalized) ?? `file:${normalized}`;
+	const removedSymbolIds = new Set(graph.symbolNodesByFile.get(normalized));
+	const removedIds = new Set(removedSymbolIds);
 	if (graph.nodes.has(fileNodeId)) removedIds.add(fileNodeId);
 
+	const candidates = new Set<ReviewGraphEdge>();
+	for (const id of removedIds) {
+		for (const edge of graph.edgesByFrom.get(id) ?? []) {
+			_rebuildCounters.removeOwnedEdgeVisits++;
+			candidates.add(edge);
+		}
+		for (const edge of graph.edgesByTo.get(id) ?? []) {
+			_rebuildCounters.removeOwnedEdgeVisits++;
+			candidates.add(edge);
+		}
+	}
+
 	const preservedIncomingSymbolEdges: ReviewGraphEdge[] = [];
-	const droppedEdges: ReviewGraphEdge[] = [];
-	graph.edges = graph.edges.filter((edge) => {
+	for (const edge of candidates) {
 		const fromRemoved = removedIds.has(edge.from);
-		const toRemoved = removedIds.has(edge.to);
-		if (fromRemoved) {
-			droppedEdges.push(edge);
-			return false;
-		}
-		if (removedSymbolIds.has(edge.to)) {
+		// Preserve importer edges to the stable file node id; the node is
+		// re-added below.
+		if (!fromRemoved && edge.to === fileNodeId) continue;
+		if (!fromRemoved && removedSymbolIds.has(edge.to)) {
 			preservedIncomingSymbolEdges.push({ ...edge });
-			droppedEdges.push(edge);
-			return false;
 		}
-		// Preserve importer edges to the stable file node id; the node is re-added below.
-		if (toRemoved && edge.to === fileNodeId) return true;
-		if (toRemoved) droppedEdges.push(edge);
-		return !toRemoved;
-	});
-	// #2074: keep the adjacency indexes live instead of rebuilding them over the
-	// whole graph afterwards. Only the dropped edges' own buckets are touched.
-	// Unconditional: on an unindexed graph every bucket lookup simply misses.
-	for (const edge of droppedEdges) unindexEdge(graph, edge);
+		removedEdges.add(edge);
+		unindexEdge(graph, edge);
+	}
 	for (const id of removedIds) {
 		const node = graph.nodes.get(id);
 		graph.nodes.delete(id);
@@ -4639,16 +4656,24 @@ async function addFileToGraph(
 /**
  * #2074 acceptance instrumentation. `restoreComparisons` counts edge-metadata
  * stringifications inside `restoreValidIncomingEdges`; `importTargetEdgeScans`
- * counts edges visited by `importTargetsForFile`. Before this change both grew
- * with the whole graph on every one-file rebuild. They are the count-based
- * signal the issue asks for, because wall time on this hardware is IO-noisy
- * (#1920).
+ * counts edges visited by `importTargetsForFile`; `removeOwnedEdgeVisits`
+ * counts edges visited while collecting a changed file's owned edges in
+ * `removeFileOwnedGraphData`. Before this change all three grew with the whole
+ * graph on every one-file rebuild, and `removeOwnedEdgeVisits` grew with
+ * changedFiles x graph on a multi-file batch (one full `graph.edges` scan per
+ * file). They are the count-based signal the issue asks for, because wall time
+ * on this hardware is IO-noisy (#1920).
  */
-const _rebuildCounters = { restoreComparisons: 0, importTargetEdgeScans: 0 };
+const _rebuildCounters = {
+	restoreComparisons: 0,
+	importTargetEdgeScans: 0,
+	removeOwnedEdgeVisits: 0,
+};
 
 export function _getReviewGraphRebuildCountersForTests(): {
 	restoreComparisons: number;
 	importTargetEdgeScans: number;
+	removeOwnedEdgeVisits: number;
 } {
 	return { ..._rebuildCounters };
 }
@@ -4656,6 +4681,7 @@ export function _getReviewGraphRebuildCountersForTests(): {
 export function _resetReviewGraphRebuildCountersForTests(): void {
 	_rebuildCounters.restoreComparisons = 0;
 	_rebuildCounters.importTargetEdgeScans = 0;
+	_rebuildCounters.removeOwnedEdgeVisits = 0;
 }
 
 /**
@@ -4804,9 +4830,18 @@ async function updateGraphFiles(
 		priorTargets: importTargetsForFile(graph, file),
 	}));
 	const preservedIncoming: ReviewGraphEdge[] = [];
+	// #2074: one shared drop set for the whole batch, compacted into graph.edges
+	// exactly once below — not once per file, which made a multi-file rebuild
+	// scan the edge array changedFiles times over.
+	const removedEdges = new Set<ReviewGraphEdge>();
 	for (const file of files) {
-		preservedIncoming.push(...removeFileOwnedGraphData(graph, file));
+		preservedIncoming.push(
+			...removeFileOwnedGraphData(graph, file, removedEdges),
+		);
 		await addFileToGraph(graph, cwd, file, facts, ignoredIds);
+	}
+	if (removedEdges.size > 0) {
+		graph.edges = graph.edges.filter((edge) => !removedEdges.has(edge));
 	}
 	restoreValidIncomingEdges(graph, preservedIncoming);
 	resolveDeferredSymbolEdges(graph, false);

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -1650,22 +1650,64 @@ function indexEdge(graph: ReviewGraph, edge: ReviewGraphEdge): void {
 }
 
 /**
- * Drop `edge` from both adjacency buckets (#2074). Costs one scan of the two
- * buckets the edge belongs to, never a scan of `graph.edges`, so removing a
- * changed file's edges stays proportional to that file's fan-in/fan-out.
+ * Drop `edge` from both adjacency buckets. This is kept for the single-edge
+ * dedupe path; multi-file removal uses `unindexEdges` below so a shared hub
+ * bucket is scanned once rather than once per removed edge (#2074).
  */
 function unindexEdge(graph: ReviewGraph, edge: ReviewGraphEdge): void {
 	const from = graph.edgesByFrom.get(edge.from);
 	if (from) {
+		// Count the full bucket as the linear `indexOf` scan's bounded work.
+		_rebuildCounters.removeOwnedEdgePositions += from.length;
 		const at = from.indexOf(edge);
 		if (at >= 0) from.splice(at, 1);
 		if (from.length === 0) graph.edgesByFrom.delete(edge.from);
 	}
 	const to = graph.edgesByTo.get(edge.to);
 	if (to) {
+		_rebuildCounters.removeOwnedEdgePositions += to.length;
 		const at = to.indexOf(edge);
 		if (at >= 0) to.splice(at, 1);
 		if (to.length === 0) graph.edgesByTo.delete(edge.to);
+	}
+}
+
+/**
+ * Remove a batch of edges from both live adjacency indexes. Each touched
+ * bucket is filtered once, so the work is proportional to the bucket lengths,
+ * not to the product of a hub's fan-in and its removed-edge count (#2074).
+ */
+function unindexEdges(
+	graph: ReviewGraph,
+	removedEdges: ReadonlySet<ReviewGraphEdge>,
+): void {
+	const fromIds = new Set<string>();
+	const toIds = new Set<string>();
+	for (const edge of removedEdges) {
+		fromIds.add(edge.from);
+		toIds.add(edge.to);
+	}
+	for (const fromId of fromIds) {
+		const bucket = graph.edgesByFrom.get(fromId);
+		if (!bucket) continue;
+		const kept: ReviewGraphEdge[] = [];
+		for (const edge of bucket) {
+			_rebuildCounters.removeOwnedEdgePositions++;
+			if (!removedEdges.has(edge)) kept.push(edge);
+		}
+		if (kept.length === 0) graph.edgesByFrom.delete(fromId);
+		else graph.edgesByFrom.set(fromId, kept);
+	}
+	for (const toId of toIds) {
+		const bucket = graph.edgesByTo.get(toId);
+		if (!bucket) continue;
+		const kept: ReviewGraphEdge[] = [];
+		for (const edge of bucket) {
+			_rebuildCounters.removeOwnedEdgePositions++;
+			if (!removedEdges.has(edge)) kept.push(edge);
+		}
+		if (kept.length === 0) graph.edgesByTo.delete(toId);
+		else graph.edgesByTo.set(toId, kept);
 	}
 }
 
@@ -3318,6 +3360,7 @@ async function tryResumeFromCheckpoint(
 	const removedEdges = new Set<ReviewGraphEdge>();
 	for (const file of stale) removeFileOwnedGraphData(graph, file, removedEdges);
 	if (removedEdges.size > 0) {
+		unindexEdges(graph, removedEdges);
 		graph.edges = graph.edges.filter((edge) => !removedEdges.has(edge));
 	}
 	pruneOrphanNonFileNodes(graph);
@@ -4525,6 +4568,10 @@ function removeFileOwnedGraphData(
 
 	const preservedIncomingSymbolEdges: ReviewGraphEdge[] = [];
 	for (const edge of candidates) {
+		// A cross-edge can be discovered from both changed files' adjacency
+		// buckets. Preserve and remove it only once, matching eager unindexing
+		// while the batch indexes remain live until the end.
+		if (removedEdges.has(edge)) continue;
 		const fromRemoved = removedIds.has(edge.from);
 		// Preserve importer edges to the stable file node id; the node is
 		// re-added below.
@@ -4533,7 +4580,6 @@ function removeFileOwnedGraphData(
 			preservedIncomingSymbolEdges.push({ ...edge });
 		}
 		removedEdges.add(edge);
-		unindexEdge(graph, edge);
 	}
 	for (const id of removedIds) {
 		const node = graph.nodes.get(id);
@@ -4661,19 +4707,23 @@ async function addFileToGraph(
  * `removeFileOwnedGraphData`. Before this change all three grew with the whole
  * graph on every one-file rebuild, and `removeOwnedEdgeVisits` grew with
  * changedFiles x graph on a multi-file batch (one full `graph.edges` scan per
- * file). They are the count-based signal the issue asks for, because wall time
- * on this hardware is IO-noisy (#1920).
+ * file). `removeOwnedEdgePositions` counts adjacency positions examined while
+ * removing edges; batching keeps a high-fan-in bucket linear instead of
+ * rescanning its prefix for every edge. They are the count-based signal the
+ * issue asks for, because wall time on this hardware is IO-noisy (#1920).
  */
 const _rebuildCounters = {
 	restoreComparisons: 0,
 	importTargetEdgeScans: 0,
 	removeOwnedEdgeVisits: 0,
+	removeOwnedEdgePositions: 0,
 };
 
 export function _getReviewGraphRebuildCountersForTests(): {
 	restoreComparisons: number;
 	importTargetEdgeScans: number;
 	removeOwnedEdgeVisits: number;
+	removeOwnedEdgePositions: number;
 } {
 	return { ..._rebuildCounters };
 }
@@ -4682,6 +4732,7 @@ export function _resetReviewGraphRebuildCountersForTests(): void {
 	_rebuildCounters.restoreComparisons = 0;
 	_rebuildCounters.importTargetEdgeScans = 0;
 	_rebuildCounters.removeOwnedEdgeVisits = 0;
+	_rebuildCounters.removeOwnedEdgePositions = 0;
 }
 
 /**
@@ -4841,6 +4892,7 @@ async function updateGraphFiles(
 		await addFileToGraph(graph, cwd, file, facts, ignoredIds);
 	}
 	if (removedEdges.size > 0) {
+		unindexEdges(graph, removedEdges);
 		graph.edges = graph.edges.filter((edge) => !removedEdges.has(edge));
 	}
 	restoreValidIncomingEdges(graph, preservedIncoming);

--- a/tests/clients/review-graph/rebuild-cost.test.ts
+++ b/tests/clients/review-graph/rebuild-cost.test.ts
@@ -52,6 +52,37 @@ function makeRing(count: number): string {
 	return root;
 }
 
+/** A real source graph where every caller points at one changed symbol. */
+function makeFanIn(count: number): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-2074-fanin-"));
+	roots.push(root);
+	fs.writeFileSync(path.join(root, ".gitignore"), "node_modules/\n");
+	fs.writeFileSync(path.join(root, ".git"), "");
+	const src = path.join(root, "src");
+	fs.mkdirSync(src, { recursive: true });
+	fs.writeFileSync(
+		path.join(src, "target.ts"),
+		"export function shared(): number {\n\treturn 1;\n}\n",
+	);
+	for (let i = 0; i < count; i++) {
+		fs.writeFileSync(
+			path.join(src, `caller${i}.ts`),
+			`import { shared } from "./target.js";\n` +
+				`export function caller${i}(): number {\n\treturn shared();\n}\n`,
+		);
+	}
+	return root;
+}
+
+function maxCallFanIn(graph: ReviewGraph): number {
+	const byTarget = new Map<string, number>();
+	for (const edge of graph.edges) {
+		if (edge.kind !== "calls") continue;
+		byTarget.set(edge.to, (byTarget.get(edge.to) ?? 0) + 1);
+	}
+	return Math.max(0, ...byTarget.values());
+}
+
 /** A project with exactly the given files, ready for a seq-fast-path rebuild. */
 function makeProject(files: Record<string, string>): string {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-2074-"));
@@ -86,6 +117,7 @@ interface RebuildProbe {
 		restoreComparisons: number;
 		importTargetEdgeScans: number;
 		removeOwnedEdgeVisits: number;
+		removeOwnedEdgePositions: number;
 	};
 	nodes: number;
 	edges: number;
@@ -95,8 +127,11 @@ interface RebuildProbe {
  * Warm the graph, then edit ONE file and rebuild through the #451 seq fast
  * path, counting only the rebuild's work.
  */
-async function warmThenRebuildOneFile(root: string): Promise<RebuildProbe> {
-	const changed = path.join(root, "src", "file0.ts");
+async function warmThenRebuildOneFile(
+	root: string,
+	changedRelative = "file0.ts",
+): Promise<RebuildProbe> {
+	const changed = path.join(root, "src", changedRelative);
 	let seq = 0;
 	const seqHint = {
 		projectSeq: () => seq,
@@ -303,6 +338,25 @@ describe("review-graph one-file rebuild cost (#2074)", () => {
 
 			expect(large.counters.removeOwnedEdgeVisits).toBe(
 				small.counters.removeOwnedEdgeVisits,
+			);
+		},
+	);
+
+	it(
+		"removes a high-fan-in target with one adjacency-bucket pass",
+		{ timeout: 240_000 },
+		async () => {
+			const small = await warmThenRebuildOneFile(makeFanIn(200), "target.ts");
+			const large = await warmThenRebuildOneFile(makeFanIn(400), "target.ts");
+
+			// These are real graph builds. The changed target owns the shared symbol,
+			// so its incoming bucket contains every caller edge. Pin that precondition
+			// independently before comparing the bucket-removal work counter.
+			expect(maxCallFanIn(small.graph)).toBeGreaterThanOrEqual(200);
+			expect(maxCallFanIn(large.graph)).toBeGreaterThanOrEqual(400);
+			expect(large.counters.removeOwnedEdgePositions).toBeGreaterThan(0);
+			expect(large.counters.removeOwnedEdgePositions).toBeLessThan(
+				small.counters.removeOwnedEdgePositions * 3,
 			);
 		},
 	);

--- a/tests/clients/review-graph/rebuild-cost.test.ts
+++ b/tests/clients/review-graph/rebuild-cost.test.ts
@@ -82,7 +82,11 @@ function duplicateEdgeCount(graph: ReviewGraph): number {
 
 interface RebuildProbe {
 	graph: ReviewGraph;
-	counters: { restoreComparisons: number; importTargetEdgeScans: number };
+	counters: {
+		restoreComparisons: number;
+		importTargetEdgeScans: number;
+		removeOwnedEdgeVisits: number;
+	};
 	nodes: number;
 	edges: number;
 }
@@ -106,6 +110,43 @@ async function warmThenRebuildOneFile(root: string): Promise<RebuildProbe> {
 	const graph = await buildOrUpdateGraph(
 		root,
 		[changed],
+		new FactStore(),
+		seqHint,
+	);
+	return {
+		graph,
+		counters: _getReviewGraphRebuildCountersForTests(),
+		nodes: graph.nodes.size,
+		edges: graph.edges.length,
+	};
+}
+
+/**
+ * Warm the graph, then edit EVERY file in `changedRelative` in one batch and
+ * rebuild through the #451 seq fast path, counting only the rebuild's work.
+ */
+async function warmThenRebuildFiles(
+	root: string,
+	changedRelative: string[],
+): Promise<RebuildProbe> {
+	const changed = changedRelative.map((relative) =>
+		path.join(root, "src", relative),
+	);
+	let seq = 0;
+	const seqHint = {
+		projectSeq: () => seq,
+		getFilesChangedSince: () => changed,
+	};
+	await buildOrUpdateGraph(root, changed, new FactStore(), seqHint);
+	seq++;
+	for (const file of changed) {
+		fs.appendFileSync(file, "\nexport const marker = 1;\n");
+	}
+	clearGraphCache();
+	_resetReviewGraphRebuildCountersForTests();
+	const graph = await buildOrUpdateGraph(
+		root,
+		changed,
 		new FactStore(),
 		seqHint,
 	);
@@ -234,6 +275,34 @@ describe("review-graph one-file rebuild cost (#2074)", () => {
 			);
 			expect(large.counters.importTargetEdgeScans).toBeLessThan(
 				small.edges / 2,
+			);
+		},
+	);
+
+	it(
+		"keeps owned-edge removal proportional to the changed files, not batch size times the graph",
+		{ timeout: 240_000 },
+		async () => {
+			// A 2-file batch: before #2074, removeFileOwnedGraphData scanned the
+			// WHOLE graph.edges array once per changed file in the batch, so a
+			// multi-file rebuild cost changedFiles x graph, not changedFiles x
+			// fan-in/out. Two files changed per fixture isolates that multiplier
+			// from the graph-size axis this suite already covers with one file.
+			const small = await warmThenRebuildFiles(makeRing(16), [
+				"file0.ts",
+				"file1.ts",
+			]);
+			const large = await warmThenRebuildFiles(makeRing(64), [
+				"file0.ts",
+				"file1.ts",
+			]);
+
+			// Sanity: the fixture really did scale, so an O(graph) cost would show.
+			expect(large.nodes).toBeGreaterThan(small.nodes * 3);
+			expect(large.edges).toBeGreaterThan(small.edges * 3);
+
+			expect(large.counters.removeOwnedEdgeVisits).toBe(
+				small.counters.removeOwnedEdgeVisits,
 			);
 		},
 	);


### PR DESCRIPTION
## Summary

`removeFileOwnedGraphData` did a full `graph.nodes` scan and a full `graph.edges.filter()` once per changed file, at both call sites — so a multi-file rebuild cost changedFiles x graph, the compounding scan #2121's own class sweep re-homed to #2074 without quantifying. It now reads a file's owned nodes from the authoritative `fileNodes`/`symbolNodesByFile` indexes and its owned edges from `edgesByFrom`/`edgesByTo`, and both callers compact `graph.edges` exactly once per batch.

Non-obvious gotchas handled: compaction lands before `pruneOrphanNonFileNodes`/`restoreValidIncomingEdges` read `graph.edges`; the checkpoint-resume path is safe because the loaded graph is fully indexed (`rebuildIndexes` at load) before eviction; each touched adjacency bucket is filtered once per batch, so high-fan-in hubs avoid repeated linear indexOf/splice removal while within-batch position deduplication preserves correctness.

Refs #2074 — AC1/AC2 already landed via #2092/#2121; AC3 (delta persist) and AC4 (2x growth bound) remain and need a persist-format/edge-store redesign, not another incremental fix. Remainder noted on the issue.

## Tests

- `tests/clients/review-graph/rebuild-cost.test.ts` (edit) — the multi-file ring test holds collection visits flat (`766` pre-fix versus `190`), and the high-fan-in test pins bucket-removal work at `408` positions for 200 callers and `808` for 400 callers. Reverting to per-edge unindexing produces `82,214` positions against the `63,342` bound. Both tests use production counters, not wall-clock time.
- No edits to existing suites: review-graph 145/145 (2 pre-existing skips), seq-fastpath 8/8, checkpoint-resume 5/5, and the randomized `incremental-equivalence.test.ts` (its edit sequence includes a multi-file batch step comparing full vs incremental graph shape) all green unmodified — the correctness contract for the restructure.

## Test assessment

Against the six screens: no parallel path (the counter test drives `updateGraphFiles` on a real graph, and the untouched randomized equivalence suite is the independent correctness oracle); no invisible skip; not a wrong-layer pin (the counter sits inside the production function, exported through the existing `_getReviewGraphRebuildCountersForTests` seam #2074 already uses); no ambient-inspection double; env leakage covered by the existing counter reset helper; the flat-counter assertion is an exact count, and the loose-bound screen is deliberately avoided per the file's #1920 wall-clock rationale.

## Blast radius

Touched: `clients/review-graph/builder.ts` only — `removeFileOwnedGraphData` and its two callers (`updateGraphFiles`, `tryResumeFromCheckpoint`). Hot path (per incremental rebuild): edge-array compaction drops from N scans to 1 per batch; owned-edge collection from O(graph.edges) to O(file fan-in/out); measured by production counters: 766 → 190 visits on the ring fixture, and 15,453/75,953 → 408/808 bucket positions for 200/400-caller fan-in hubs. `module_report` blastRadius: unavailable this session (pi-lens MCP failed to connect).

Investigated, deliberately not touched: `resolveDeferredSymbolEdges`' full edge map (runs once per batch, no compounding; needs a name→placeholder index that doesn't exist), delta persist (existing `semanticFingerprint` skip only helps no-op rebuilds), `cloneGraph` shallow-copy (would alias mutable bucket arrays with the cached graph).

## Class sweep

Class: per-item full-collection scan inside a batch loop (the #1976 re-derive-per-item shape, edge-array variant). Swept `clients/review-graph/` plus `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts` for `graph.edges.filter`/full-scan calls inside per-file loops: after #2092/#2121, `removeFileOwnedGraphData` was the last member on the incremental path; `resolveDeferredSymbolEdges` scans once per batch (not per item) and is named above as the remaining single-scan cost. No other per-item full scans found; consolidation verdict: the family now shares the adjacency indexes as its one seam.

## Observability

The `_rebuildCounters` instrumentation (existing #2074 seam) gains `removeOwnedEdgeVisits`, exported through `_getReviewGraphRebuildCountersForTests` — the count-based production-shaped signal the issue asks for. Rebuild wall time remains visible via the existing review-graph phase logs.
