### PR TITLE
fix(lsp): stop starving auxiliary resync after a slow cold primary spawn (closes #2239)

### DIFF
--- a/.changelog/2239-resync-queue-wait.md
+++ b/.changelog/2239-resync-queue-wait.md
@@ -1,0 +1,11 @@
+---
+section: Fixed
+---
+
+- **Stop starving auxiliary LSP resyncs behind a cold primary spawn (closes #2239)** —
+  the auxiliary resync queue wait now derives from the same effective
+  per-server wait floor `getClientForFile` uses internally, instead of the
+  caller's flat budget alone. A cold primary spawn that legitimately runs
+  past that flat budget (Ruby's 30s override, and the Bash/JSON/Vue/Svelte/
+  Prisma overrides from #2233) no longer zeroes the auxiliary's queue time
+  and reports it uncovered on every such touch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -516,7 +516,11 @@ and only a scanner that cannot accept a write inside the budget makes a waiter
 give up. A write that lands after its deadline but inside the wedge window
 retracts the timeout it was charged for (slow is not broken); one nothing
 accepts for the whole wedge window keeps its strike and demotes the server, so
-the gate cannot defer a dead input path forever. A DEFERRED server is neither
+the gate cannot defer a dead input path forever. Its queue wait uses the
+effective `primaryServerWaitFloorMs`, which includes the caller's
+`maxClientWaitMs` and any primary server `clientWaitTimeoutMs` override, so a
+cold primary's configured wait does not make the remaining queue budget appear
+to be already exhausted. A DEFERRED server is neither
 waited on nor read from — its version cannot advance, so waiting only burns its
 budget and would flip the touch to `inconclusive`, and its diagnostics cache
 still holds the previous content's findings because the resync that would have

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -4107,9 +4107,10 @@ export class LSPService {
 			if (!notifySkipped) {
 				const budget = notifyWriteBudgetMs();
 				// #1459: how long a queued auxiliary may wait for its resync slot. Bounded
-				// by the write budget AND by whatever the caller already declared it is
-				// willing to spend on this touch (`maxClientWaitMs` — cascade's cold
-				// snapshot passes 1000ms), minus what the client wait above already spent.
+				// by the write budget and by the effective primary wait floor, minus what
+				// which includes the caller's `maxClientWaitMs` and any primary
+				// server `clientWaitTimeoutMs` override. The elapsed client wait is
+				// subtracted below.
 				// A flat write-budget wait would tax a caller that asked for less than one
 				// budget in total. Non-positive means "no time left to queue": the server
 				// is reported as uncovered immediately.

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -1026,7 +1026,10 @@ function notifyWriteBudgetMs(): number {
 // cold primary spawn is allowed to run this long, so anything downstream that
 // charges itself against `maxWaitMs` alone — rather than this floor — sees an
 // already-elapsed time it never budgeted for and clamps to zero.
-function primaryServerWaitFloorMs(filePath: string, maxWaitMs?: number): number {
+function primaryServerWaitFloorMs(
+	filePath: string,
+	maxWaitMs?: number,
+): number {
 	const serverWaitOverrideMs = getServersForFileWithConfig(filePath)
 		.filter((s) => s.role !== "auxiliary")
 		.reduce((max, server) => Math.max(max, server.clientWaitTimeoutMs ?? 0), 0);

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -1019,6 +1019,20 @@ function notifyWriteBudgetMs(): number {
 	return Number.isFinite(raw) && raw > 0 ? raw : 2000;
 }
 
+// #2239: the SAME effective per-server wait floor `getClientForFile` uses to
+// size its own acquisition race — the caller's declared budget, raised to
+// whatever the file's primary server(s) configure via `clientWaitTimeoutMs`
+// (Ruby 30s, and the Bash/JSON/Vue/Svelte/Prisma overrides #2233 added). A
+// cold primary spawn is allowed to run this long, so anything downstream that
+// charges itself against `maxWaitMs` alone — rather than this floor — sees an
+// already-elapsed time it never budgeted for and clamps to zero.
+function primaryServerWaitFloorMs(filePath: string, maxWaitMs?: number): number {
+	const serverWaitOverrideMs = getServersForFileWithConfig(filePath)
+		.filter((s) => s.role !== "auxiliary")
+		.reduce((max, server) => Math.max(max, server.clientWaitTimeoutMs ?? 0), 0);
+	return Math.max(maxWaitMs ?? 0, serverWaitOverrideMs);
+}
+
 // #1459: how long ONE auxiliary notify write may stay outstanding before the
 // server counts as wedged rather than merely slow. A scanner whose per-file work
 // exceeds the write budget is normal (opengrep routinely needs >2s on a large
@@ -2376,17 +2390,13 @@ export class LSPService {
 		const servers = getServersForFileWithConfig(filePath).filter(
 			(s) => s.role !== "auxiliary",
 		);
-		const serverWaitOverrideMs = servers.reduce(
-			(max, server) => Math.max(max, server.clientWaitTimeoutMs ?? 0),
-			0,
-		);
 		// hardCapMs is a caller-imposed ceiling (e.g. pipeline budget) that
 		// prevents tool_result from blocking the TUI for the full LSP cold-start
 		// window. When no server config sets a wait (serverWaitOverrideMs = 0),
 		// hardCapMs is used directly — Math.min(0, cap) = 0 would otherwise
 		// take the no-timeout branch and block indefinitely (e.g. pyright, which
 		// has no clientWaitTimeoutMs but can take 30s to initialize on cold start).
-		const serverBaseMs = Math.max(maxWaitMs ?? 0, serverWaitOverrideMs);
+		const serverBaseMs = primaryServerWaitFloorMs(filePath, maxWaitMs);
 		const effectiveMaxWaitMs =
 			hardCapMs !== undefined
 				? serverBaseMs > 0
@@ -4100,11 +4110,25 @@ export class LSPService {
 				// A flat write-budget wait would tax a caller that asked for less than one
 				// budget in total. Non-positive means "no time left to queue": the server
 				// is reported as uncovered immediately.
+				//
+				// #2239: "what the caller already declared" is `primaryServerWaitFloorMs`,
+				// not the raw `options.maxClientWaitMs` — the SAME floor `getClientForFile`
+				// races the primary spawn against. A cold primary configured with its own
+				// `clientWaitTimeoutMs` (Ruby 30s, and the #2233 Bash/JSON/Vue/Svelte/Prisma
+				// overrides) is allowed to run past the caller's flat budget, and did just
+				// that by the time this line runs — charging the subtraction against the
+				// flat value alone always went negative and clamped to zero. The outer
+				// `Math.min(budget, …)` is unchanged, so this raises what "already spent"
+				// is measured against without widening the wait beyond one write budget.
 				const queueWaitMs =
 					options.maxClientWaitMs !== undefined
 						? Math.min(
 								budget,
-								Math.max(0, options.maxClientWaitMs - (Date.now() - startedAt)),
+								Math.max(
+									0,
+									primaryServerWaitFloorMs(filePath, options.maxClientWaitMs) -
+										(Date.now() - startedAt),
+								),
 							)
 						: budget;
 				await Promise.all(

--- a/tests/clients/lsp/service-scanner-coverage-gap.test.ts
+++ b/tests/clients/lsp/service-scanner-coverage-gap.test.ts
@@ -65,7 +65,11 @@ function makeFakeProcess() {
 	};
 }
 
-function makeServer(id: string, role?: "auxiliary") {
+function makeServer(
+	id: string,
+	role?: "auxiliary",
+	extra: Record<string, unknown> = {},
+) {
 	return {
 		id,
 		name: id,
@@ -73,6 +77,7 @@ function makeServer(id: string, role?: "auxiliary") {
 		...(role !== undefined && { role }),
 		root: async () => ROOT,
 		spawn: vi.fn(async () => ({ process: makeFakeProcess(), source: "test" })),
+		...extra,
 	};
 }
 
@@ -649,6 +654,144 @@ describe("#1459 — sweep fan-out must not black out a scanner silently", () => 
 		expect(row.metadata?.queueWaitMs).toBeLessThanOrEqual(callerCapMs);
 		// And the queued touch never pushed a second, overlapping resync.
 		expect(aux.stats.openOffsets).toHaveLength(1);
+	});
+
+	it("an auxiliary resync is not starved when a cold primary spawn exceeds the caller's flat budget (#2239)", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		// #2239: the caller's flat budget (dispatch-lsp-runner's LSP_SPAWN_BUDGET_MS)
+		// is smaller than this primary's own clientWaitTimeoutMs override (Ruby's
+		// 30s in production) — getClientForFile waits out the LARGER floor
+		// internally, so a cold spawn legitimately runs past the flat budget.
+		const FLAT_CALLER_MS = NOTIFY_BUDGET_MS / 2;
+		const PRIMARY_WAIT_FLOOR_MS = NOTIFY_BUDGET_MS * 50;
+		const PRIMARY_SPAWN_DELAY_MS = NOTIFY_BUDGET_MS * 3;
+		// Still outstanding when the cold spawn resolves; short enough that a
+		// queue wait bounded by the write budget can still outlast it.
+		const AUX_WRITE_MS = NOTIFY_BUDGET_MS * 3.5;
+
+		const aux = makeClient("opengrep", AUX_WRITE_MS, [], "never");
+		const primary = makeClient("ruby", 0);
+		getServersForFileWithConfig.mockImplementation((fp: string) =>
+			fp.endsWith("/a.ts")
+				? [makeServer("opengrep", "auxiliary")]
+				: [
+						makeServer("ruby", undefined, {
+							clientWaitTimeoutMs: PRIMARY_WAIT_FLOOR_MS,
+							spawn: vi.fn(
+								() =>
+									new Promise((resolve) => {
+										setTimeout(
+											() =>
+												resolve({ process: makeFakeProcess(), source: "test" }),
+											PRIMARY_SPAWN_DELAY_MS,
+										);
+									}),
+							),
+						}),
+						makeServer("opengrep", "auxiliary"),
+					],
+		);
+		createLSPClient.mockImplementation(
+			async (options: { serverId?: string }) =>
+				options?.serverId === "opengrep" ? aux : primary,
+		);
+
+		void service.touchFile(`${ROOT}/a.ts`, "one", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep"],
+			diagnostics: "document",
+			collectDiagnostics: true,
+			source: "dispatch-lsp-runner",
+			maxClientWaitMs: FLAT_CALLER_MS,
+		});
+		await vi.advanceTimersByTimeAsync(1);
+
+		const second = service.touchFile(`${ROOT}/b.ts`, "two", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep"],
+			diagnostics: "document",
+			collectDiagnostics: true,
+			source: "dispatch-lsp-runner",
+			maxClientWaitMs: FLAT_CALLER_MS,
+		});
+		await vi.advanceTimersByTimeAsync(NOTIFY_BUDGET_MS * 200);
+		await second;
+
+		// The cold ruby spawn alone consumed more than the flat caller budget, but
+		// the auxiliary still got queue time from the SAME per-server floor
+		// getClientForFile used internally — it was not starved to zero.
+		expect(rowsFor("lsp_notify_resync_deferred")).toHaveLength(0);
+		expect(aux.stats.openOffsets).toHaveLength(2);
+	});
+
+	it("does not widen the auxiliary's queue wait past the write budget even when a primary's per-server floor is large (#2239 guard)", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		// The per-server floor (Ruby-sized) is huge, but the write withholding
+		// coverage outlasts the write budget by a wide margin. Deriving queueWaitMs
+		// from the floor must not let it borrow time beyond the write budget —
+		// that would reintroduce the unbounded per-edit latency #1459 closed.
+		const FLAT_CALLER_MS = NOTIFY_BUDGET_MS / 2;
+		const PRIMARY_WAIT_FLOOR_MS = NOTIFY_BUDGET_MS * 50;
+		const PRIMARY_SPAWN_DELAY_MS = NOTIFY_BUDGET_MS / 4;
+		const AUX_WRITE_MS = NOTIFY_BUDGET_MS * 20;
+
+		const aux = makeClient("opengrep", AUX_WRITE_MS, [], "never");
+		const primary = makeClient("ruby", 0);
+		getServersForFileWithConfig.mockImplementation((fp: string) =>
+			fp.endsWith("/a.ts")
+				? [makeServer("opengrep", "auxiliary")]
+				: [
+						makeServer("ruby", undefined, {
+							clientWaitTimeoutMs: PRIMARY_WAIT_FLOOR_MS,
+							spawn: vi.fn(
+								() =>
+									new Promise((resolve) => {
+										setTimeout(
+											() =>
+												resolve({ process: makeFakeProcess(), source: "test" }),
+											PRIMARY_SPAWN_DELAY_MS,
+										);
+									}),
+							),
+						}),
+						makeServer("opengrep", "auxiliary"),
+					],
+		);
+		createLSPClient.mockImplementation(
+			async (options: { serverId?: string }) =>
+				options?.serverId === "opengrep" ? aux : primary,
+		);
+
+		void service.touchFile(`${ROOT}/a.ts`, "one", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep"],
+			diagnostics: "document",
+			collectDiagnostics: true,
+			source: "dispatch-lsp-runner",
+			maxClientWaitMs: FLAT_CALLER_MS,
+		});
+		await vi.advanceTimersByTimeAsync(1);
+
+		const second = service.touchFile(`${ROOT}/b.ts`, "two", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep"],
+			diagnostics: "document",
+			collectDiagnostics: true,
+			source: "dispatch-lsp-runner",
+			maxClientWaitMs: FLAT_CALLER_MS,
+		});
+		await vi.advanceTimersByTimeAsync(NOTIFY_BUDGET_MS * 200);
+		await second;
+
+		const deferrals = rowsFor("lsp_notify_resync_deferred");
+		expect(deferrals).toHaveLength(1);
+		const row = deferrals[0] as { metadata?: Record<string, unknown> };
+		// Bounded by the write budget, nowhere near the 50x-budget server floor.
+		expect(row.metadata?.queueWaitMs).toBeLessThanOrEqual(NOTIFY_BUDGET_MS);
 	});
 
 	it("a queued touch does not write to a client that was evicted while it waited", async () => {


### PR DESCRIPTION
## Summary

`touchFile`'s auxiliary-resync `queueWaitMs` charged elapsed time against the caller's flat `LSP_SPAWN_BUDGET_MS` (5s), while `getClientForFile` races the primary spawn against a larger per-server floor (`clientWaitTimeoutMs`: Ruby 30s, plus the #2233 Bash/JSON/Vue/Svelte/Prisma overrides). A cold primary legitimately running past 5s but under its own floor drove `options.maxClientWaitMs - elapsed` negative, clamped queue time to 0, and reported the auxiliary uncovered via `notifyDeferredServerIds` on every such touch — not only the first cold one.

Fix: extracted `primaryServerWaitFloorMs` (the exact servers-filter-then-reduce `getClientForFile` already did inline) and used it on both sides, so the acquisition race and the queue-wait computation read one source of truth. The outer `Math.min(budget, …)` is untouched — the Scope's anti-widening guard (#1459): the fix raises what "already spent" is measured against without letting any wait exceed one write budget.

Closes #2239 — the Scope's audit directive and anti-widening constraint are both satisfied and tested.

## Tests

- `tests/clients/lsp/service-scanner-coverage-gap.test.ts` — new: "an auxiliary resync is not starved when a cold primary spawn exceeds the caller's flat budget (#2239)". RED pre-fix (with only the no-op refactor in place): `expected [ { type: 'phase', …(4) } ] to have a length of +0 but got 1` on `lsp_notify_resync_deferred`.
- Same file — new guard test pinning that a naively widened fix (server floor as the outer cap) would still defer a wedged 2s write; passes pre- and post-fix by design, reds the wrong implementation (verified by hand-calculation of the deliberately-wrong shape).
- `makeServer` gained an optional `extra` override param (non-breaking, mirrors the sibling test file's pattern).

## Test assessment

Against the six screens: no parallel path (both tests drive `touchFile` through the suite's existing fake-server harness); no invisible skip; not a wrong-layer pin (the starvation is asserted on the emitted `lsp_notify_resync_deferred` record, the production symptom); no ambient-inspection double; env leakage covered by the suite's per-test service teardown; the guard test exists specifically so the fix cannot drift into an unconditionally-widened wait — mutation-proofing the `Math.min(budget, …)` cap.

## Blast radius

Touched: `clients/lsp/index.ts` — one extracted helper, two consumers (`getClientForFile`, the notify-write `queueWaitMs`). The `getClientForFile` side is a pure refactor (same filter+reduce). Behavior change is confined to files whose primary server sets `clientWaitTimeoutMs` above the caller's budget, touched `with-auxiliary`. Per-touch cost: one extra `getServersForFileWithConfig` call on the resync path (config lookup, no spawn). `module_report` blastRadius: unavailable this session (pi-lens MCP failed to connect). Verified: coverage-gap suite 26/26; touch-collect, notify-inflight-throttle (x2), aux-grace (77); every other file referencing `getClientForFile`/`queueWaitMs`/`notifyWriteBudgetMs`/`clientWaitTimeoutMs` (212 tests) green.

## Class sweep

Class: downstream consumer budgeting against a caller-declared constant while the upstream seam races against a derived effective value (split-brain budget). Swept `clients/lsp/` and the dispatch runners for other consumers of `options.maxClientWaitMs`/`LSP_SPAWN_BUDGET_MS` measured against elapsed time: the resync `queueWaitMs` was the only site subtracting elapsed from the flat caller value; `getClientForFile` derives the floor itself and the dispatch lsp-runner passes the constant through without subtracting. Class of size 1; both sides now share `primaryServerWaitFloorMs`, which is the consolidation verdict (one seam).

## Observability

Existing records prove the fix in production: `lsp_notify_resync_deferred` (the starvation signature this removes for slow-cold-spawn servers) and `lsp_scanner_coverage_gap` frequency on Ruby/Bash/JSON/Vue/Svelte/Prisma files touched with-auxiliary. No new record needed — the defect was already visible in these; their post-merge drop is the proof.
