### PR TITLE
fix(tests): bind pytest counts to summary (closes #2408)

### DIFF
--- a/.changelog/fix-2408-pytest-summary-parser.md
+++ b/.changelog/fix-2408-pytest-summary-parser.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Parse pytest counts only from its terminal summary (closes #2408)** — Traceback and service-error numbers such as `port 55432 failed` can no longer become the reported failed-test count, and ANSI formatting no longer corrupts the first count.
+- **Parse pytest counts only from its terminal summary (closes #2408)** — Traceback and service-error numbers such as `port 55432 failed` can no longer become the reported failed-test count, and ANSI formatting or rerun outcomes no longer corrupt the reported counts and duration.

--- a/.changelog/fix-2408-pytest-summary-parser.md
+++ b/.changelog/fix-2408-pytest-summary-parser.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Parse pytest counts only from its final summary (closes #2408)** — Traceback and service-error numbers such as `port 55432 failed` can no longer become the reported failed-test count.
+- **Parse pytest counts only from its terminal summary (closes #2408)** — Traceback and service-error numbers such as `port 55432 failed` can no longer become the reported failed-test count, and ANSI formatting no longer corrupts the first count.

--- a/.changelog/fix-2408-pytest-summary-parser.md
+++ b/.changelog/fix-2408-pytest-summary-parser.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Parse pytest counts only from its final summary (closes #2408)** — Traceback and service-error numbers such as `port 55432 failed` can no longer become the reported failed-test count.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1092,6 +1092,12 @@ immediate `ctx.isIdle()` recheck. The durable `test-runner-findings` cache stays
 available to pull diagnostics and the commit guard; unavailable or failed host
 entry capabilities never fall back to `sendMessage`. (#2366)
 
+Pytest aggregate counts come only from pytest's final outcome summary line
+(#2408), never from a whole-output search. Tracebacks, service errors, assertion
+messages, and captured logs can contain unrelated phrases such as `port 55432
+failed`; summary detection and count extraction must remain bound to the same
+line.
+
 Host-ready delay is a process-lifetime measurement from load-complete to the
 first real `session_start`. The extension consumes that anchor once at the
 entry point; later sessions emit no host-ready phase because no clean

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -1713,15 +1713,26 @@ export class TestRunnerClient {
 		let duration: number | undefined;
 
 		if (summaryLine) {
-			// Extract counts from the summary itself, never arbitrary traceback text.
-			const passedMatch = summaryLine.match(/(\d+)\s+passed/);
-			const failedMatch = summaryLine.match(/(\d+)\s+failed/);
-			const skippedMatch = summaryLine.match(/(\d+)\s+skipped/);
-			const durationMatch = summaryLine.match(/in\s+([\d.]+)s/);
-
-			passed = passedMatch ? parseInt(passedMatch[1], 10) : 0;
-			failed = failedMatch ? parseInt(failedMatch[1], 10) : 0;
-			skipped = skippedMatch ? parseInt(skippedMatch[1], 10) : 0;
+			// Extract counts from comma-delimited summary fields, never arbitrary
+			// traceback text. Token parsing also avoids backtracking over long output.
+			const summaryBody = summaryLine.replace(/^=+\s*/, "");
+			for (const field of summaryBody.split(",")) {
+				const [countText, outcome] = field.trim().split(/\s+/, 2);
+				const count = Number.parseInt(countText, 10);
+				if (!Number.isFinite(count)) continue;
+				switch (outcome) {
+					case "passed":
+						passed = count;
+						break;
+					case "failed":
+						failed = count;
+						break;
+					case "skipped":
+						skipped = count;
+						break;
+				}
+			}
+			const durationMatch = /in\s+([\d.]+)s/.exec(summaryLine);
 			// Rounded, like `jsonRunDurationMs` and PHPUnit's legacy path:
 			// `in 2.01s` is 2009.9999999999998 in binary floating point, and
 			// the turn-end log prints the number as it stands.

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -1693,10 +1693,17 @@ export class TestRunnerClient {
 		const failures: TestFailure[] = [];
 		const output = `${stdout}\n${stderr}`;
 
-		// Parse summary line: "5 passed, 2 failed, 1 skipped in 0.23s"
-		const summaryMatch =
-			output.match(/(\d+)\s+passed?.*?(\d+)\s+failed.*?in\s+([\d.]+)s/i) ||
-			output.match(/(\d+)\s+passed.*?in\s+([\d.]+)s/i);
+		// Parse only pytest's final outcome line. Tracebacks can contain unrelated
+		// phrases such as "port 55432 failed" before the real summary.
+		const summaryLine = output
+			.split(/\r?\n/)
+			.reverse()
+			.find(
+				(line) =>
+					/\b\d+\s+(?:passed|failed|skipped|errors?|warnings?|deselected|xfailed|xpassed)\b/i.test(
+						line,
+					) && /\bin\s+[\d.]+s\b/i.test(line),
+			);
 
 		let passed = 0;
 		let failed = 0;
@@ -1705,12 +1712,12 @@ export class TestRunnerClient {
 		// a real pytest summary, so 0 has to stay available as a measurement.
 		let duration: number | undefined;
 
-		if (summaryMatch) {
-			// Extract numbers from various patterns
-			const passedMatch = output.match(/(\d+)\s+passed/);
-			const failedMatch = output.match(/(\d+)\s+failed/);
-			const skippedMatch = output.match(/(\d+)\s+skipped/);
-			const durationMatch = output.match(/in\s+([\d.]+)s/);
+		if (summaryLine) {
+			// Extract counts from the summary itself, never arbitrary traceback text.
+			const passedMatch = summaryLine.match(/(\d+)\s+passed/);
+			const failedMatch = summaryLine.match(/(\d+)\s+failed/);
+			const skippedMatch = summaryLine.match(/(\d+)\s+skipped/);
+			const durationMatch = summaryLine.match(/in\s+([\d.]+)s/);
 
 			passed = passedMatch ? parseInt(passedMatch[1], 10) : 0;
 			failed = failedMatch ? parseInt(failedMatch[1], 10) : 0;

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -352,6 +352,56 @@ function filesystemErrorCode(error: unknown): string | undefined {
 	return undefined;
 }
 
+interface PytestSummary {
+	passed: number;
+	failed: number;
+	skipped: number;
+	duration?: number;
+}
+
+/** Extract aggregate values from pytest's final outcome line only. */
+function parsePytestSummary(output: string): PytestSummary {
+	const summaryLine = output
+		.split(/\r?\n/)
+		.reverse()
+		.find(
+			(line) =>
+				/\b\d+\s+(?:passed|failed|skipped|errors?|warnings?|deselected|xfailed|xpassed)\b/i.test(
+					line,
+				) && /\bin\s+[\d.]+s\b/i.test(line),
+		);
+	let passed = 0;
+	let failed = 0;
+	let skipped = 0;
+	if (!summaryLine) return { passed, failed, skipped };
+
+	const summaryBody = summaryLine.replace(/^=+\s*/, "");
+	for (const field of summaryBody.split(",")) {
+		const [countText, outcome] = field.trim().split(/\s+/, 2);
+		const count = Number.parseInt(countText, 10);
+		if (!Number.isFinite(count)) continue;
+		switch (outcome) {
+			case "passed":
+				passed = count;
+				break;
+			case "failed":
+				failed = count;
+				break;
+			case "skipped":
+				skipped = count;
+				break;
+		}
+	}
+
+	const durationMatch = /in\s+([\d.]+)s/.exec(summaryLine);
+	// Rounded, like `jsonRunDurationMs` and PHPUnit's legacy path:
+	// `in 2.01s` is 2009.9999999999998 in binary floating point.
+	const duration = durationMatch
+		? Math.round(Number.parseFloat(durationMatch[1]) * 1000)
+		: undefined;
+	return { passed, failed, skipped, duration };
+}
+
 export class TestRunnerClient {
 	private log: (msg: string) => void;
 	// This is an instance-lifetime memo of RESOLVED spellings only, which leaves
@@ -1693,53 +1743,9 @@ export class TestRunnerClient {
 		const failures: TestFailure[] = [];
 		const output = `${stdout}\n${stderr}`;
 
-		// Parse only pytest's final outcome line. Tracebacks can contain unrelated
-		// phrases such as "port 55432 failed" before the real summary.
-		const summaryLine = output
-			.split(/\r?\n/)
-			.reverse()
-			.find(
-				(line) =>
-					/\b\d+\s+(?:passed|failed|skipped|errors?|warnings?|deselected|xfailed|xpassed)\b/i.test(
-						line,
-					) && /\bin\s+[\d.]+s\b/i.test(line),
-			);
-
-		let passed = 0;
-		let failed = 0;
-		let skipped = 0;
-		// #1479: undefined until pytest's own `in N.NNs` is read. `in 0.00s` is
-		// a real pytest summary, so 0 has to stay available as a measurement.
-		let duration: number | undefined;
-
-		if (summaryLine) {
-			// Extract counts from comma-delimited summary fields, never arbitrary
-			// traceback text. Token parsing also avoids backtracking over long output.
-			const summaryBody = summaryLine.replace(/^=+\s*/, "");
-			for (const field of summaryBody.split(",")) {
-				const [countText, outcome] = field.trim().split(/\s+/, 2);
-				const count = Number.parseInt(countText, 10);
-				if (!Number.isFinite(count)) continue;
-				switch (outcome) {
-					case "passed":
-						passed = count;
-						break;
-					case "failed":
-						failed = count;
-						break;
-					case "skipped":
-						skipped = count;
-						break;
-				}
-			}
-			const durationMatch = /in\s+([\d.]+)s/.exec(summaryLine);
-			// Rounded, like `jsonRunDurationMs` and PHPUnit's legacy path:
-			// `in 2.01s` is 2009.9999999999998 in binary floating point, and
-			// the turn-end log prints the number as it stands.
-			// (Routing this through `toMeasuredDurationMs` is #1484, not this.)
-			if (durationMatch)
-				duration = Math.round(parseFloat(durationMatch[1]) * 1000);
-		}
+		// #1479: `duration` stays undefined unless pytest emits its own `in N.NNs`
+		// summary. A measured `in 0.00s` remains a real zero.
+		const { passed, failed, skipped, duration } = parsePytestSummary(output);
 
 		// Parse individual failures: "FAILED tests/test_foo.py::test_something - AssertionError: ..."
 		const failureRegex = /FAILED\s+(\S+::\S+)\s*-\s*(.+?)(?:\n|$)/g;

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -361,7 +361,7 @@ interface PytestSummary {
 }
 
 const PYTEST_SUMMARY_OUTCOME =
-	"(?:passed|failed|skipped|errors?|warnings?|deselected|xfailed|xpassed)";
+	"(?:passed|failed|skipped|reruns?|errors?|warnings?|deselected|xfailed|xpassed)";
 const PYTEST_SUMMARY_LINE = new RegExp(
 	`^\\s*(?:=+\\s*)?\\d+\\s+${PYTEST_SUMMARY_OUTCOME}` +
 		`(?:\\s*,\\s*\\d+\\s+${PYTEST_SUMMARY_OUTCOME})*` +

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -24,6 +24,7 @@ import { PathKeyedMap } from "./path-keyed-map.js";
 import { normalizeEphemeralMapKey, normalizeMapKey } from "./path-utils.js";
 import { isMeasuredDuration, toMeasuredDurationMs } from "./run-duration.js";
 import { safeSpawn, safeSpawnAsync } from "./safe-spawn.js";
+import { stripAnsi } from "./sanitize.js";
 
 // --- Types ---
 
@@ -359,23 +360,30 @@ interface PytestSummary {
 	duration?: number;
 }
 
+const PYTEST_SUMMARY_OUTCOME =
+	"(?:passed|failed|skipped|errors?|warnings?|deselected|xfailed|xpassed)";
+const PYTEST_SUMMARY_LINE = new RegExp(
+	`^\\s*(?:=+\\s*)?\\d+\\s+${PYTEST_SUMMARY_OUTCOME}` +
+		`(?:\\s*,\\s*\\d+\\s+${PYTEST_SUMMARY_OUTCOME})*` +
+		`\\s+in\\s+[\\d.]+s(?:\\s*=+)?\\s*$`,
+	"i",
+);
+
 /** Extract aggregate values from pytest's final outcome line only. */
 function parsePytestSummary(output: string): PytestSummary {
-	const summaryLine = output
+	// Pytest may color the whole summary or individual tokens. Strip ANSI before
+	// selecting and extracting so formatting cannot turn the first count into 0.
+	const normalizedOutput = stripAnsi(output);
+	const summaryLine = normalizedOutput
 		.split(/\r?\n/)
 		.reverse()
-		.find(
-			(line) =>
-				/\b\d+\s+(?:passed|failed|skipped|errors?|warnings?|deselected|xfailed|xpassed)\b/i.test(
-					line,
-				) && /\bin\s+[\d.]+s\b/i.test(line),
-		);
+		.find((line) => PYTEST_SUMMARY_LINE.test(line));
 	let passed = 0;
 	let failed = 0;
 	let skipped = 0;
 	if (!summaryLine) return { passed, failed, skipped };
 
-	const summaryBody = summaryLine.replace(/^=+\s*/, "");
+	const summaryBody = summaryLine.replace(/^=+\s*|\s*=+\s*$/g, "");
 	for (const field of summaryBody.split(",")) {
 		const [countText, outcome] = field.trim().split(/\s+/, 2);
 		const count = Number.parseInt(countText, 10);

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -945,6 +945,89 @@ describe("test-runner-client", () => {
 			expect(result.duration).toBe(2010);
 		});
 
+		it("parses an ANSI-colored pytest summary through the real output parser", () => {
+			const result = (new TestRunnerClient(false) as any).parsePytestOutput(
+				"\u001b[1m2 failed, 1 passed, 3 skipped in 2.19s\u001b[0m",
+				"",
+				1,
+				"/tmp/test_foo.py",
+				"/tmp",
+				"pytest",
+			);
+
+			expect(result.passed).toBe(1);
+			expect(result.failed).toBe(2);
+			expect(result.skipped).toBe(3);
+			expect(result.duration).toBe(2190);
+		});
+
+		it("ignores a count-and-duration lookalike after the genuine summary", () => {
+			const result = (new TestRunnerClient(false) as any).parsePytestOutput(
+				[
+					"===== 2 passed, 1 failed in 1.25s =====",
+					"post-run: 55432 failed in 4s",
+				].join("\n"),
+				"",
+				1,
+				"/tmp/test_foo.py",
+				"/tmp",
+				"pytest",
+			);
+
+			expect(result.passed).toBe(2);
+			expect(result.failed).toBe(1);
+			expect(result.duration).toBe(1250);
+		});
+
+		it("uses the terminal summary when output repeats summary-looking lines", () => {
+			const result = (new TestRunnerClient(false) as any).parsePytestOutput(
+				[
+					"===== 1 passed in 0.10s =====",
+					"===== 2 failed, 3 passed in 0.20s =====",
+				].join("\n"),
+				"",
+				1,
+				"/tmp/test_foo.py",
+				"/tmp",
+				"pytest",
+			);
+
+			expect(result.passed).toBe(3);
+			expect(result.failed).toBe(2);
+			expect(result.duration).toBe(200);
+		});
+
+		it("parses a CRLF-terminated pytest summary", () => {
+			const result = (new TestRunnerClient(false) as any).parsePytestOutput(
+				"===== 2 passed, 1 skipped in 0.50s =====\r\n",
+				"",
+				0,
+				"/tmp/test_foo.py",
+				"/tmp",
+				"pytest",
+			);
+
+			expect(result.passed).toBe(2);
+			expect(result.skipped).toBe(1);
+			expect(result.duration).toBe(500);
+		});
+
+		it("recognizes pytest's outcome token variants in one summary", () => {
+			const result = (new TestRunnerClient(false) as any).parsePytestOutput(
+				"===== 4 passed, 2 failed, 3 skipped, 1 error, 5 warnings, 6 deselected, 7 xfailed, 8 xpassed in 3.21s =====",
+				"",
+				1,
+				"/tmp/test_foo.py",
+				"/tmp",
+				"pytest",
+			);
+
+			expect(result.passed).toBe(4);
+			expect(result.failed).toBe(2);
+			expect(result.skipped).toBe(3);
+			expect(result.duration).toBe(3210);
+		});
+
 		it("rounds the mix test summary duration", () => {
 			const result = (new TestRunnerClient(false) as any).parseMixTestOutput(
 				"Finished in 2.01 seconds (0.00s async, 2.01s sync)\n3 tests, 0 failures",

--- a/tests/clients/test-runner-client.test.ts
+++ b/tests/clients/test-runner-client.test.ts
@@ -1028,6 +1028,25 @@ describe("test-runner-client", () => {
 			expect(result.duration).toBe(3210);
 		});
 
+		it("recognizes rerun outcomes with ANSI, CRLF, and a trailing lookalike", () => {
+			const result = (new TestRunnerClient(false) as any).parsePytestOutput(
+				[
+					"\u001b[1m===== 1 rerun, 2 failed, 3 passed, 4 skipped in 0.50s =====\u001b[0m\r",
+					"post-run: 55432 failed in 4s",
+				].join("\n"),
+				"",
+				1,
+				"/tmp/test_foo.py",
+				"/tmp",
+				"pytest",
+			);
+
+			expect(result.passed).toBe(3);
+			expect(result.failed).toBe(2);
+			expect(result.skipped).toBe(4);
+			expect(result.duration).toBe(500);
+		});
+
 		it("rounds the mix test summary duration", () => {
 			const result = (new TestRunnerClient(false) as any).parseMixTestOutput(
 				"Finished in 2.01 seconds (0.00s async, 2.01s sync)\n3 tests, 0 failures",

--- a/tests/clients/test-runner-pytest-summary.test.ts
+++ b/tests/clients/test-runner-pytest-summary.test.ts
@@ -1,0 +1,68 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+	SafeSpawnOptions,
+	SpawnResult,
+} from "../../clients/safe-spawn.js";
+
+type SafeSpawnAsync = (
+	command: string,
+	args: string[],
+	options?: SafeSpawnOptions,
+) => Promise<SpawnResult>;
+
+const { findGlobalBinary, safeSpawnAsync } = vi.hoisted(() => ({
+	findGlobalBinary: vi.fn(async () => undefined),
+	safeSpawnAsync: vi.fn<SafeSpawnAsync>(async () => ({
+		stdout: [
+			"E connection to server at 127.0.0.1, port 55432 failed",
+			"================ short test summary info ================",
+			"FAILED tests/test_example.py::test_one - RuntimeError",
+			"FAILED tests/test_example.py::test_two - RuntimeError",
+			"2 failed, 1 passed, 50 errors in 2.19s",
+		].join("\n"),
+		stderr: "",
+		status: 1,
+	})),
+}));
+
+vi.mock("../../clients/package-manager.js", () => ({ findGlobalBinary }));
+vi.mock("../../clients/safe-spawn.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../clients/safe-spawn.js")>()),
+	safeSpawnAsync,
+}));
+
+import { RUNNERS, TestRunnerClient } from "../../clients/test-runner-client.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("pytest summary parsing", () => {
+	it("does not read service-error numbers as failed-test counts", async () => {
+		const root = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-pytest-summary-"),
+		);
+		tempDirs.push(root);
+		const testFile = path.join(root, "tests", "test_example.py");
+		fs.mkdirSync(path.dirname(testFile), { recursive: true });
+		fs.writeFileSync(testFile, "def test_example():\n    assert True\n");
+
+		const result = await new TestRunnerClient(false).runTestFileAsync(
+			testFile,
+			root,
+			"pytest",
+			RUNNERS.pytest,
+		);
+
+		expect(result.passed).toBe(1);
+		expect(result.failed).toBe(2);
+		expect(result.duration).toBe(2190);
+	});
+});


### PR DESCRIPTION
## Summary

Bind pytest aggregate extraction to a complete terminal outcome summary.
Normalize ANSI formatting before selection and extraction. Recognize `rerun`
outcomes emitted by pytest-rerunfailures.

Closes #2408. Every acceptance criterion is covered.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] The change has red-first regression tests.
- [x] Targeted test files pass locally after `npm run build`.
- [x] Removing the summary boundary makes a regression test fail.
- [x] Removing ANSI normalization makes a regression test fail.
- [x] Removing rerun support makes a regression test fail.
- [x] The PR title and commits carry the issue reference.
- [x] Lint, formatting, ast-grep self-scan, and build pass.
- [x] `package-lock.json` is unchanged.
- [x] The PR includes a valid changelog entry.

## Tests

Pre-fix and mutation proofs:

```text
Summary boundary mutation: lookalike case expected passed 2, received 0.
ANSI normalization mutation: colored case expected passed 1, received 0.
Rerun-token mutation: rerun case expected passed 3, received 0.
```

Current branch:

```text
Test Files  2 passed (2)
Tests       167 passed (167)
```

The focused parser cases run through `TestRunnerClient.parsePytestOutput`.
The existing spawned-runner test drives `runTestFileAsync` at the process boundary.
Build, lint, formatting, ast-grep self-scan, changelog validation, and
governance suites pass locally.

### Test assessment

- `tests/clients/test-runner-pytest-summary.test.ts` remains unchanged and
  drives the public `runTestFileAsync` path with deterministic pytest output.
- `tests/clients/test-runner-client.test.ts` adds six parser cases covering
  ANSI summaries, trailing lookalikes, repeated summaries, CRLF, outcome-token
  variants, and rerun outcomes. The rerun case composes ANSI, CRLF, failed,
  passed, skipped, and a trailing count-duration lookalike.
- `tests/clients/runtime-turn-session.test.ts` remains unchanged and covers
  downstream test-result delivery.

## Blast radius

`parsePytestOutput` is private to `TestRunnerClient` and is called only for
pytest results from `runTestFileAsync`. Runner detection, command selection,
execution, failure-name extraction, and every other runner parser are unchanged.

The parser scans output lines once and uses the existing `stripAnsi` utility.
No durable data shape or telemetry path changes. No material hot-path cost is
expected.

## Observability

The structured test-runner result and rendered finding expose the corrected
failed, passed, skipped, and duration values. No new failure path or telemetry
record is needed.

## Class sweep

Defect shape: a structured summary parser validates one region but extracts
values from a broader untrusted region.

A whole-tree search found one pytest summary parser. PHPUnit uses labelled
fields; Go, Cargo, .NET, RSpec, Minitest, Gradle, and Mix use anchored or
format-specific summaries. The rerun token was added to the existing pytest
outcome population without broadening the line boundary.

Consolidation verdict: keep the fix local to pytest. A shared parser would
relocate format-specific rules without reducing complexity.
