### PR TITLE
fix(status): stop presenting hints as code warnings (refs #2414)

### DIFF
--- a/.changelog/fix-2414-severity-tier-projection.md
+++ b/.changelog/fix-2414-severity-tier-projection.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Stop presenting hint/info findings as code warnings (refs #2414)** — the TUI footer, `lens_diagnostics` (mode=all/full), and every compact finding-count surface now project severity through one shared classifier: `hint`/`info` tier findings (style opinions such as `no-runtime-typeof`, complexity hints) no longer inflate the `warnings` count or the footer's `!NW` chip. They stay visible everywhere that matters — the detailed diagnostics list, a new `advisories` count so a hint-only file isn't silently dropped from a listing, and a distinct "N hints" line in `lens_diagnostics`' summary — they just never share the warning tally with real, bounded-false-positive-rate warnings.

--- a/clients/widget-state.ts
+++ b/clients/widget-state.ts
@@ -579,7 +579,42 @@ function commitDiagnostics(
 	requestRender();
 }
 
-/** Recompute the {blocking, errors, warnings} tally for a diagnostic set. */
+/**
+ * A diagnostic's compact-count tier (#2414). THE one place every compact
+ * finding-count surface classifies severity into a tally bucket — do not
+ * re-fold tiers per renderer (widget footer, `lens_diagnostics`' `withIssues`
+ * listing/summary, and any future compact surface all import this instead of
+ * hand-rolling the same branch).
+ *
+ * `error`/`warning` are real code defects with a known, bounded
+ * false-positive rate (see "Severity policy" in AGENTS.md, #1777) — they
+ * drive the footer's ●/! chips and block-worthy counts. `advisory` (`hint` +
+ * `info`) is a style opinion: an unaudited authorship rule (complexity,
+ * `no-runtime-typeof`, ...) must never present with the same weight as a
+ * warning. Before #1777 the dispatch path collapsed all three into
+ * `"warning"` at the runner; after #1777 preserved the four LSP/ast-grep
+ * tiers end to end, but this classifier still folded `hint`/`info` into the
+ * `warnings` tally so a file with only style opinions didn't silently vanish
+ * from the footer. #2414 corrects that: advisories no longer inflate
+ * `warnings`, but every consumer must still ask "does this file have ANY
+ * live finding" via `advisories`, not just `warnings`, so a hint-only file
+ * still surfaces in a detailed listing (mode=all's `withIssues`).
+ */
+export type DiagnosticTier = "error" | "warning" | "advisory";
+
+export function classifyDiagnosticTier(
+	d: WidgetDiagnostic,
+): DiagnosticTier | undefined {
+	if (d.severity === "error") return "error";
+	if (d.severity === "warning") return "warning";
+	if (d.severity === "hint" || d.severity === "info") return "advisory";
+	return undefined;
+}
+
+/** Recompute the {blocking, errors, warnings} tally for a diagnostic set.
+ * `hint`/`info` tier findings are tallied separately — see
+ * {@link classifyDiagnosticTier} and {@link countAdvisories} — and never
+ * inflate `warnings` (#2414). */
 function countDiagnostics(diags: WidgetDiagnostic[]): {
 	blocking: number;
 	errors: number;
@@ -601,22 +636,33 @@ function countDiagnostics(diags: WidgetDiagnostic[]): {
 			(diagnostic.staleReason ?? "past-eof") === "past-eof"
 		)
 			continue;
-		if (diagnostic.severity === "error") errors++;
-		// #1777: `hint` and `info` tally alongside `warning`. The dispatch path
-		// now preserves all four ast-grep tiers; before, the runner collapsed
-		// them to "warning" here. An exact `=== "warning"` test would drop those
-		// findings out of the footer entirely, so a file with real findings would
-		// render clean. The footer stays a blocking/error/warning summary on
-		// purpose — the tier distinction is rendered by the code-quality-warnings
-		// advisory, not by these counters.
-		else if (
-			diagnostic.severity === "warning" ||
-			diagnostic.severity === "hint" ||
-			diagnostic.severity === "info"
-		)
-			warnings++;
+		const tier = classifyDiagnosticTier(diagnostic);
+		if (tier === "error") errors++;
+		else if (tier === "warning") warnings++;
+		// tier === "advisory" (hint/info): intentionally excluded from the
+		// footer's warning tally (#2414) — see `countAdvisories` for the
+		// parallel count `getFileDiagnosticSummaries` exposes to
+		// `lens_diagnostics` so a hint-only file still shows up as "has issues".
 	}
 	return { blocking, errors, warnings };
+}
+
+/** Count `hint`/`info` tier findings using the same past-EOF exclusion as
+ * {@link countDiagnostics} (#2414). Kept as a standalone accessor rather than
+ * a new `FileRecord.diagnosticCounts` field — the footer never renders this
+ * number, only `getFileDiagnosticSummaries` (mode=all) needs it, to keep a
+ * hint-only file from being silently dropped from a detailed listing. */
+function countAdvisories(diags: WidgetDiagnostic[]): number {
+	let advisories = 0;
+	for (const diagnostic of diags) {
+		if (
+			diagnostic.stale &&
+			(diagnostic.staleReason ?? "past-eof") === "past-eof"
+		)
+			continue;
+		if (classifyDiagnosticTier(diagnostic) === "advisory") advisories++;
+	}
+	return advisories;
 }
 
 /**
@@ -1140,6 +1186,10 @@ export interface FileDiagnosticSummary {
 	blocking: number;
 	errors: number;
 	warnings: number;
+	/** `hint`/`info` tier findings — style opinions, never folded into
+	 * `warnings` (#2414). A file whose only findings are advisories still has
+	 * `advisories > 0` so it is not silently dropped from a detailed listing. */
+	advisories: number;
 	hasFinalSnapshot: boolean;
 	/**
 	 * The full, uncapped diagnostics for this file (not limited by the TUI's
@@ -1164,6 +1214,7 @@ export function getFileDiagnosticSummaries(): FileDiagnosticSummary[] {
 			blocking: rec.diagnosticCounts.blocking,
 			errors: rec.diagnosticCounts.errors,
 			warnings: rec.diagnosticCounts.warnings,
+			advisories: countAdvisories(rec.allDiagnostics),
 			hasFinalSnapshot: rec.hasFinalDiagnosticsSnapshot,
 			diagnostics: rec.allDiagnostics.map((d) => ({ ...d })),
 		};

--- a/tests/clients/severity-tier-consumers.test.ts
+++ b/tests/clients/severity-tier-consumers.test.ts
@@ -230,20 +230,33 @@ describe("actionable warnings accept a fix from any non-error tier (#1777)", () 
 	});
 });
 
-describe("widget tally keeps hint and info visible (#1777)", () => {
+// #1777 made hint/info survive the dispatch path (previously collapsed to
+// "warning" at the runner) and, at the time, folded them into the widget's
+// `warnings` tally so they weren't dropped from the footer entirely. #2414
+// found that fold itself was the defect: a hint-tier style opinion (e.g.
+// `no-runtime-typeof`, a complexity hint) presented with the same `!NW`
+// warning-icon weight as a real, bounded-false-positive-rate warning. The
+// tally now keeps hint/info VISIBLE (via `advisories`, not dropped) without
+// inflating `warnings`.
+describe("widget tally separates the advisory tier from warnings (#1777 -> #2414)", () => {
 	beforeEach(() => clearWidgetState());
 
-	it("counts hint and info in the non-error tally rather than dropping them", () => {
+	it("counts hint and info as advisories, not warnings", () => {
 		recordDiagnostics(filePath, [
 			{ severity: "hint", semantic: "warning", message: "hint finding" },
 			{ severity: "info", semantic: "warning", message: "info finding" },
 			{ severity: "warning", semantic: "warning", message: "warning finding" },
 		]);
 		const summary = getFileDiagnosticSummaries()[0];
-		expect(summary).toMatchObject({ blocking: 0, errors: 0, warnings: 3 });
+		expect(summary).toMatchObject({
+			blocking: 0,
+			errors: 0,
+			warnings: 1,
+			advisories: 2,
+		});
 	});
 
-	it("still counts errors separately", () => {
+	it("still counts errors separately, and a lone hint stays out of warnings", () => {
 		recordDiagnostics(filePath, [
 			{ severity: "error", semantic: "blocking", message: "boom" },
 			{ severity: "hint", semantic: "warning", message: "hint finding" },
@@ -251,7 +264,8 @@ describe("widget tally keeps hint and info visible (#1777)", () => {
 		expect(getFileDiagnosticSummaries()[0]).toMatchObject({
 			blocking: 1,
 			errors: 1,
-			warnings: 1,
+			warnings: 0,
+			advisories: 1,
 		});
 	});
 });

--- a/tests/clients/widget-state.test.ts
+++ b/tests/clients/widget-state.test.ts
@@ -247,6 +247,64 @@ describe("getFileDiagnosticSummaries", () => {
 			.files.find((f) => f.filePath === filePath);
 		expect(snap?.storedDiagnostics).toBe(12);
 	});
+
+	// #2414: hint/info tier findings are style opinions, not code defects. The
+	// footer's `warnings` tally must not inflate on them, while a genuine
+	// `warning`-tier finding must still count — and the hint/info findings must
+	// still be visible via a separate `advisories` count so a hint-only file
+	// isn't silently dropped from a detailed listing.
+	describe("severity projection (#2414)", () => {
+		it("does not fold hint/info into warnings, but still counts real warnings", () => {
+			const filePath = `${process.cwd()}/severity-projection.ts`;
+			recordDiagnostics(filePath, [
+				{ severity: "hint", line: 1, rule: "long-parameter-list", message: "h" },
+				{ severity: "info", line: 2, rule: "complexity", message: "i" },
+				{ severity: "warning", line: 3, rule: "no-console", message: "w" },
+			]);
+			const entry = getFileDiagnosticSummaries().find(
+				(s) => s.filePath === filePath,
+			);
+			expect(entry?.warnings).toBe(1);
+			expect(entry?.advisories).toBe(2);
+			// All three findings still reach the detailed diagnostics list.
+			expect(entry?.diagnostics).toHaveLength(3);
+		});
+
+		it("a hint/info-only file reports zero warnings but a nonzero advisory count", () => {
+			const filePath = `${process.cwd()}/hints-only.ts`;
+			recordDiagnostics(filePath, [
+				{ severity: "hint", line: 1, rule: "no-runtime-typeof", message: "h1" },
+				{ severity: "info", line: 2, rule: "no-unknown-parameters", message: "h2" },
+			]);
+			const entry = getFileDiagnosticSummaries().find(
+				(s) => s.filePath === filePath,
+			);
+			expect(entry?.blocking).toBe(0);
+			expect(entry?.errors).toBe(0);
+			expect(entry?.warnings).toBe(0);
+			expect(entry?.advisories).toBe(2);
+		});
+
+		it("the TUI footer's warning chip does not fire for a hint/info-only file", () => {
+			const filePath = `${process.cwd()}/hints-only-footer.ts`;
+			recordDiagnostics(filePath, [
+				{ severity: "hint", line: 1, rule: "long-parameter-list", message: "h" },
+				{ severity: "info", line: 2, rule: "complexity", message: "i" },
+			]);
+			const rendered = renderWidget(120, theme).join("\n");
+			expect(rendered).not.toMatch(/\d+W\b/);
+			expect(rendered).toContain("clean");
+		});
+
+		it("the TUI footer's warning chip DOES fire for a real warning", () => {
+			const filePath = `${process.cwd()}/real-warning-footer.ts`;
+			recordDiagnostics(filePath, [
+				{ severity: "warning", line: 1, rule: "no-console", message: "w" },
+			]);
+			const rendered = renderWidget(120, theme).join("\n");
+			expect(rendered).toMatch(/\d+W\b/);
+		});
+	});
 });
 
 describe("widget-state renderWidget", () => {

--- a/tests/clients/widget-state.test.ts
+++ b/tests/clients/widget-state.test.ts
@@ -257,7 +257,12 @@ describe("getFileDiagnosticSummaries", () => {
 		it("does not fold hint/info into warnings, but still counts real warnings", () => {
 			const filePath = `${process.cwd()}/severity-projection.ts`;
 			recordDiagnostics(filePath, [
-				{ severity: "hint", line: 1, rule: "long-parameter-list", message: "h" },
+				{
+					severity: "hint",
+					line: 1,
+					rule: "long-parameter-list",
+					message: "h",
+				},
 				{ severity: "info", line: 2, rule: "complexity", message: "i" },
 				{ severity: "warning", line: 3, rule: "no-console", message: "w" },
 			]);
@@ -274,7 +279,12 @@ describe("getFileDiagnosticSummaries", () => {
 			const filePath = `${process.cwd()}/hints-only.ts`;
 			recordDiagnostics(filePath, [
 				{ severity: "hint", line: 1, rule: "no-runtime-typeof", message: "h1" },
-				{ severity: "info", line: 2, rule: "no-unknown-parameters", message: "h2" },
+				{
+					severity: "info",
+					line: 2,
+					rule: "no-unknown-parameters",
+					message: "h2",
+				},
 			]);
 			const entry = getFileDiagnosticSummaries().find(
 				(s) => s.filePath === filePath,
@@ -288,7 +298,12 @@ describe("getFileDiagnosticSummaries", () => {
 		it("the TUI footer's warning chip does not fire for a hint/info-only file", () => {
 			const filePath = `${process.cwd()}/hints-only-footer.ts`;
 			recordDiagnostics(filePath, [
-				{ severity: "hint", line: 1, rule: "long-parameter-list", message: "h" },
+				{
+					severity: "hint",
+					line: 1,
+					rule: "long-parameter-list",
+					message: "h",
+				},
 				{ severity: "info", line: 2, rule: "complexity", message: "i" },
 			]);
 			const rendered = renderWidget(120, theme).join("\n");

--- a/tests/tools/lens-diagnostics-rule-policy.test.ts
+++ b/tests/tools/lens-diagnostics-rule-policy.test.ts
@@ -387,6 +387,7 @@ describe("lens_diagnostics rule policy — delta mode carried-over tally", () =>
 			blocking: 0,
 			errors: 0,
 			warnings: 2,
+			advisories: 0,
 			hasFinalSnapshot: true,
 			diagnostics: [
 				{
@@ -426,6 +427,7 @@ describe("lens_diagnostics rule policy — mode=all (cache-only)", () => {
 			blocking: 0,
 			errors: 0,
 			warnings: 2,
+			advisories: 0,
 			hasFinalSnapshot: true,
 			diagnostics: [
 				{
@@ -465,6 +467,7 @@ describe("lens_diagnostics rule policy — mode=all (cache-only)", () => {
 			blocking: 0,
 			errors: 0,
 			warnings: 2,
+			advisories: 0,
 			hasFinalSnapshot: true,
 			diagnostics: [
 				{
@@ -497,6 +500,7 @@ describe("lens_diagnostics rule policy — mode=all (cache-only)", () => {
 			blocking: 0,
 			errors: 0,
 			warnings: 1,
+			advisories: 0,
 			hasFinalSnapshot: true,
 			diagnostics: [
 				{

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -295,6 +295,7 @@ describe("lens_diagnostics mode=delta", () => {
 			blocking: 1,
 			errors: 1,
 			warnings: 1,
+			advisories: 0,
 			hasFinalSnapshot: true,
 			diagnostics: [
 				{ severity: "error", message: "boom", line: 5 },
@@ -655,7 +656,12 @@ type Diag = Summary["diagnostics"][number];
 
 function sum(
 	filePath: string,
-	counts: { blocking?: number; errors?: number; warnings?: number },
+	counts: {
+		blocking?: number;
+		errors?: number;
+		warnings?: number;
+		advisories?: number;
+	},
 	opts: { hasFinalSnapshot?: boolean; diagnostics?: Diag[] } = {},
 ): Summary {
 	return {
@@ -663,6 +669,7 @@ function sum(
 		blocking: counts.blocking ?? 0,
 		errors: counts.errors ?? 0,
 		warnings: counts.warnings ?? 0,
+		advisories: counts.advisories ?? 0,
 		hasFinalSnapshot: opts.hasFinalSnapshot ?? true,
 		diagnostics: opts.diagnostics ?? [],
 	};
@@ -2666,6 +2673,59 @@ describe("lens_diagnostics mode=all", () => {
 		});
 	});
 
+	// #2414: hint/info tier findings are style opinions and must not present
+	// as warning defects. `advisories` is a separate tally that keeps a
+	// hint-only file visible without inflating `warnings`.
+	describe("severity projection (#2414)", () => {
+		it("a hint/info-only file is excluded from severity=warning", async () => {
+			mockSummaries.length = 0;
+			mockSummaries.push(sum("/proj/hints.ts", { advisories: 2 }));
+			mockSummaries.push(sum("/proj/real-warning.ts", { warnings: 1 }));
+			const result = await run(makeTool(), {
+				mode: "all",
+				severity: "warning",
+			});
+			const text = String(result.content[0].text);
+			expect(text).toContain("real-warning.ts");
+			expect(text).not.toContain("hints.ts");
+		});
+
+		it("a hint/info-only file still surfaces under severity=all (not dropped)", async () => {
+			mockSummaries.length = 0;
+			mockSummaries.push(sum("/proj/hints.ts", { advisories: 2 }));
+			const result = await run(makeTool(), { mode: "all", severity: "all" });
+			const text = String(result.content[0].text);
+			expect(text).toContain("hints.ts");
+			expect(text).toContain("2 hints");
+			expect(result.details).toMatchObject({ filesWithIssues: 1 });
+		});
+
+		it("summary totals separate advisories from warnings", async () => {
+			mockSummaries.length = 0;
+			mockSummaries.push(sum("/proj/a.ts", { warnings: 3, advisories: 5 }));
+			const result = await run(makeTool(), { mode: "all" });
+			const text = String(result.content[0].text);
+			expect(text).toContain("3 warnings");
+			expect(text).toContain("5 hint/info");
+			expect(result.details).toMatchObject({
+				totalWarnings: 3,
+				totalAdvisories: 5,
+			});
+		});
+
+		it("a hint/info-only session renders as clean, not as N warnings", async () => {
+			mockSummaries.length = 0;
+			mockSummaries.push(sum("/proj/hints.ts", { advisories: 4 }));
+			const result = await run(makeTool(), { mode: "all" });
+			expect(result.details).toMatchObject({
+				totalBlocking: 0,
+				totalErrors: 0,
+				totalWarnings: 0,
+				totalAdvisories: 4,
+			});
+		});
+	});
+
 	// #1799: `semantic === "blocking"` iff `severity === "error"` holds
 	// codebase-wide, so every error-severity finding is ALSO a blocking one —
 	// the rendered summary must not print the same 3 findings once as
@@ -3410,6 +3470,7 @@ describe("lens_diagnostics disposition read-filter (#755)", () => {
 			blocking: 0,
 			errors: 0,
 			warnings: 1,
+			advisories: 0,
 			hasFinalSnapshot: true,
 			diagnostics: [
 				{
@@ -3540,6 +3601,7 @@ describe("lens_diagnostics disposition read-filter (#755)", () => {
 			blocking: 0,
 			errors: 0,
 			warnings: 1,
+			advisories: 0,
 			hasFinalSnapshot: true,
 			diagnostics: [
 				{
@@ -3655,6 +3717,7 @@ describe("lens_diagnostics disposition read-filter (#755)", () => {
 			blocking: 0,
 			errors: 0,
 			warnings: 1,
+			advisories: 0,
 			hasFinalSnapshot: true,
 			diagnostics: [
 				{
@@ -3691,6 +3754,7 @@ describe("lens_diagnostics disposition read-filter (#755)", () => {
 			blocking: 0,
 			errors: 0,
 			warnings: 1,
+			advisories: 0,
 			hasFinalSnapshot: true,
 			diagnostics: [
 				{

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -79,6 +79,7 @@ import type {
 import type { ActionableWarningsReport } from "../clients/actionable-warnings.js";
 import type { CodeQualityWarningsReport } from "../clients/code-quality-warnings.js";
 import {
+	classifyDiagnosticTier,
 	getFileDiagnosticSummaries,
 	type FileDiagnosticSummary,
 	reconcileCorrelatedScanDiagnostics,
@@ -287,6 +288,7 @@ export function createLensDiagnosticsTool(
 			totalBlocking?: number;
 			totalErrors?: number;
 			totalWarnings?: number;
+			totalAdvisories?: number;
 			coldRunners?: string[];
 			failedAnalyzers?: { id: string; summary: string }[];
 		}>(({ details, args, isError, text }) => {
@@ -333,9 +335,16 @@ export function createLensDiagnosticsTool(
 			const b = details?.totalBlocking ?? 0;
 			const e = details?.totalErrors ?? 0;
 			const w = details?.totalWarnings ?? 0;
+			// #2414: hint/info tier never contributes to `b + e + w` — a session
+			// with only style opinions is genuinely "clean" of code defects, but
+			// the one-line summary still names the advisory count so it isn't
+			// indistinguishable from a session with zero findings at all.
+			const adv = details?.totalAdvisories ?? 0;
 			const files = details?.filesWithIssues ?? details?.filesChecked ?? 0;
 			if (b + e + w === 0) {
-				return `lens_diagnostics ${mode} — clean (${files} files)${coldSuffix}${failedSuffix}`;
+				const advisorySuffix =
+					adv > 0 ? `, ${adv} hint${adv === 1 ? "" : "s"}` : "";
+				return `lens_diagnostics ${mode} — clean${advisorySuffix} (${files} files)${coldSuffix}${failedSuffix}`;
 			}
 			const parts = [`${b} blocking`];
 			if (b === 0 && e > 0) parts.push(`${e} errors`);
@@ -1231,30 +1240,31 @@ function summarizeDiagnostics(
 	let blocking = 0;
 	let errors = 0;
 	let warnings = 0;
+	let advisories = 0;
 	for (const diagnostic of diagnostics) {
 		// #1641: a demoted past-EOF entry keeps its severity for display but
 		// drops out of the tallies — same reasoning as widget-state's `isBlocking`.
 		if (diagnostic.stale) continue;
 		if (diagnostic.semantic === "blocking") blocking++;
-		if (diagnostic.severity === "error") errors++;
-		// #1777: `hint` and `info` tally alongside `warning`, matching
-		// `countDiagnostics` in `clients/widget-state.ts` — mode=all reads that
-		// tally and mode=full reads this one, so the two must agree. An exact
-		// `=== "warning"` test scored a hint-only file 0/0/0, the `withIssues`
-		// filter below then dropped it, and mode=full rendered "No issues" for a
-		// file whose own `details` still carried the diagnostic.
-		else if (
-			diagnostic.severity === "warning" ||
-			diagnostic.severity === "hint" ||
-			diagnostic.severity === "info"
-		)
-			warnings++;
+		// #2414: severity → tier classification is shared with
+		// `countDiagnostics`/`countAdvisories` in `clients/widget-state.ts` via
+		// `classifyDiagnosticTier` — mode=all reads that store's tally and
+		// mode=full reads this one, so the two must agree. `hint`/`info` no
+		// longer inflate `warnings` (they used to, matching a pre-#2414
+		// `countDiagnostics`, so a hint-only file scored 0/0/0 there too and the
+		// `withIssues` filter below dropped it — that gap is now closed via
+		// `advisories`, not by re-folding hints into `warnings`).
+		const tier = classifyDiagnosticTier(diagnostic);
+		if (tier === "error") errors++;
+		else if (tier === "warning") warnings++;
+		else if (tier === "advisory") advisories++;
 	}
 	return {
 		filePath,
 		blocking,
 		errors,
 		warnings,
+		advisories,
 		hasFinalSnapshot,
 		diagnostics,
 	};
@@ -2494,11 +2504,18 @@ function formatAllMode(
 	// how those filters already treat any other non-matching severity.
 	const withIssues = visibleSummaries.filter((s) => {
 		if (severity === "error") return s.blocking > 0 || s.errors > 0;
+		// #2414: a "warning" filter must not admit hint/info — that is exactly
+		// the "present hints as warnings" defect this issue exists to close.
 		if (severity === "warning") return s.warnings > 0;
+		// severity: "all" — a hint/info-only file (`advisories > 0`,
+		// warnings === 0) must still surface here, or the #2414 fix that stops
+		// hints inflating `warnings` would silently drop that file from the
+		// detailed listing instead of just from the compact warning tally.
 		return (
 			s.blocking > 0 ||
 			s.errors > 0 ||
 			s.warnings > 0 ||
+			s.advisories > 0 ||
 			(s.diagnostics ?? []).some((d) => d.stale)
 		);
 	});
@@ -2532,6 +2549,7 @@ function formatAllMode(
 	let totalBlocking = 0;
 	let totalErrors = 0;
 	let totalWarnings = 0;
+	let totalAdvisories = 0;
 
 	for (const s of sorted) {
 		const rel = path.relative(cwd, s.filePath);
@@ -2539,6 +2557,11 @@ function formatAllMode(
 		if (s.blocking > 0) parts.push(`🔴 ${s.blocking} blocking`);
 		if (s.errors > 0 && s.blocking === 0) parts.push(`${s.errors}E`);
 		if (s.warnings > 0) parts.push(`${s.warnings}W`);
+		// #2414: hint/info never inflate `warnings`, but a hint-only row still
+		// needs a reason to be listed — otherwise it shows a bare filename with
+		// no count at all.
+		if (s.advisories > 0)
+			parts.push(`${s.advisories} hint${s.advisories === 1 ? "" : "s"}`);
 		if (!s.hasFinalSnapshot) parts.push(`(pending)`);
 		const staleCount = (s.diagnostics ?? []).filter((d) => d.stale).length;
 		if (staleCount > 0) {
@@ -2587,6 +2610,7 @@ function formatAllMode(
 		totalBlocking += s.blocking;
 		totalErrors += s.errors;
 		totalWarnings += s.warnings;
+		totalAdvisories += s.advisories;
 	}
 
 	// #1799: `totalBlocking` and `totalErrors` count the same findings UNLESS a
@@ -2608,6 +2632,11 @@ function formatAllMode(
 		totalWarnings > 0
 			? `  ${totalWarnings} warning${totalWarnings === 1 ? "" : "s"}`
 			: null,
+		// #2414: reported separately from `warnings` — hint/info are style
+		// opinions, not defects, and must not read as unresolved code issues.
+		totalAdvisories > 0
+			? `  ${totalAdvisories} hint/info (style — not counted as warnings)`
+			: null,
 	]
 		.filter(Boolean)
 		.join("\n");
@@ -2622,6 +2651,7 @@ function formatAllMode(
 			totalBlocking,
 			totalErrors,
 			totalWarnings,
+			totalAdvisories,
 			staleDropped,
 		},
 	};


### PR DESCRIPTION
## Summary

`countDiagnostics` (`clients/widget-state.ts`) folded `hint`/`info` tier
findings into the `warnings` tally, so an unaudited style opinion (ast-grep
rules like `no-runtime-typeof`, `long-parameter-list`, a complexity hint)
rendered with the same `!NW` weight as a real, bounded-false-positive-rate
warning in the TUI footer. The identical fold was duplicated in
`tools/lens-diagnostics.ts`'s `summarizeDiagnostics` — mode=all/mode=full
agreed with the footer on the wrong count because both re-implemented the
same branch independently.

**Fix (single shared policy, per the class-sweep ask):**
- `clients/widget-state.ts` exports `classifyDiagnosticTier` — the ONE place
  that maps a diagnostic's severity to `error` / `warning` / `advisory`
  (hint+info). `countDiagnostics` (the footer/header tally) now excludes
  `advisory` from `warnings`. A parallel `countAdvisories` feeds a new
  `advisories` field on `FileDiagnosticSummary` so a hint-only file is never
  silently dropped from a detailed listing.
- `tools/lens-diagnostics.ts`'s `summarizeDiagnostics` imports the same
  `classifyDiagnosticTier` instead of re-folding severity itself. The
  `withIssues` "all"-severity gate now also admits `advisories > 0`, the
  per-file row shows "N hints" when that's the only finding, the session
  summary reports advisories on their own line, and the compact one-line
  tool-call summary renders "clean, N hints" instead of a bare "clean" when
  a session only produced style opinions.

**Left untouched:** `clients/code-quality-warnings.ts` and
`clients/actionable-warnings.ts` already tracked a per-tier `byTier` /
`quiet` breakdown separately from their headline count — they were already
correct and are not the surfaces this issue targets.

**Deliberately out of scope** (per orchestrator instruction): the
knip/marksman/MD047 false-finding investigation named in issue #2414 is a
separate root cause (bad scoping / stale scanner state), not a severity-tier
problem, and is not touched here. Also deliberately out of scope (review
round 1 finding, orchestrator-confirmed): the `pilens_analyze`/MCP surface
folds hint/info via a DIFFERENT axis — `semantic`, not `severity` — a
distinct seam deferred to #2420 (see Class sweep below). This PR uses `Refs
#2414`, not `Closes`, because both of these remain open under separate
investigation.

Refs #2414

## Type of change

- [x] Bug fix

## Area

- [x] area:diagnostics
- [x] area:observability

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted below
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test (proven by the red-first run below)
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` — not run separately; `npm run build` (tsc) passed and this PR does not touch bundling config
- [x] `package-lock.json` is in sync (no dependency changes in this PR)
- [ ] `AGENTS.md` — no update needed; this PR implements the existing "Severity policy" contract already documented there, it does not change it
- [x] `.changelog/fix-2414-severity-tier-projection.md` added in this PR
- [x] Commit subject includes the issue number: `Refs #2414`

## Tests

- **`tests/clients/severity-tier-consumers.test.ts`** (EDIT) — the pre-existing
  #1777 pin ("widget tally keeps hint and info visible") literally asserted
  the old fold (`warnings: 3` for 1 warning + 2 hints, `warnings: 1` for 1
  hint + 1 error). Renamed to "separates the advisory tier from warnings
  (#1777 -> #2414)" and now asserts `warnings: 1, advisories: 2` and
  `warnings: 0, advisories: 1` respectively — a contract-seam pin that would
  have masked this exact regression had it stayed unchanged.
- **`tests/clients/widget-state.test.ts`** (NEW, `severity projection
  (#2414)` block, 4 cases) — hint/info don't inflate `warnings` while a real
  warning still does; a hint/info-only file reports `warnings: 0,
  advisories: 2`; the TUI footer's `NW` chip does not fire for a
  hint/info-only file (renders "clean" instead) but does fire for a real
  warning.
- **`tests/tools/lens-diagnostics.test.ts`** (NEW, `severity projection
  (#2414)` block, 4 cases) — `severity=warning` excludes a hint-only file;
  `severity=all` still surfaces it via `advisories` (not silently dropped
  from the listing — a regression-in-waiting the naive fix would have
  introduced); the summary text separates "N warnings" from "N hint/info";
  an all-hint session reports `totalWarnings: 0` with `totalAdvisories` set
  in the tool's `details`, never folded together.
- **`tests/tools/lens-diagnostics-rule-policy.test.ts`** (EDIT, mechanical) —
  added the new required `advisories: 0` field to 4 hand-built
  `FileDiagnosticSummary` fixtures; no behavior change, TS now enforces the
  field is never silently omitted.

### Red-first proof

Committed the fix+tests, then reverted only `clients/widget-state.ts` and
`tools/lens-diagnostics.ts` to the pre-fix commit (`git checkout HEAD~1 --
clients/widget-state.ts tools/lens-diagnostics.ts`) and re-ran the new/edited
tests:

```
FAIL tests/clients/widget-state.test.ts (73 tests | 3 failed)
  x does not fold hint/info into warnings, but still counts real warnings
  x a hint/info-only file reports zero warnings but a nonzero advisory count
  x the TUI footer's warning chip does not fire for a hint/info-only file
FAIL tests/clients/severity-tier-consumers.test.ts (12 tests | 2 failed)
  x counts hint and info as advisories, not warnings
  x still counts errors separately, and a lone hint stays out of warnings
FAIL tests/tools/lens-diagnostics.test.ts (114 tests | 3 failed)
  x a hint/info-only file still surfaces under severity=all (not dropped)
  x summary totals separate advisories from warnings
  x a hint/info-only session renders as clean, not as N warnings

Test Files  3 failed (3)
     Tests  8 failed | 191 passed (199)
```

Restored the fix (`git checkout HEAD -- clients/widget-state.ts
tools/lens-diagnostics.ts`) — `git status`/`git diff` clean against the
commit, all 8 green again.

### Suites run

- `npm run build` — clean.
- `npm run lint` (`tsc --project tsconfig.json`) — clean.
- Targeted: `tests/clients/widget-state.test.ts`,
  `tests/clients/severity-tier-consumers.test.ts`,
  `tests/tools/lens-diagnostics.test.ts`,
  `tests/tools/lens-diagnostics-rule-policy.test.ts`, plus every other test
  file that imports `clients/widget-state.js`/`tools/lens-diagnostics.js`
  (22 files, 452 tests) — all green.
- Governance sweeps: `delivery-surface-ratchet`, `finding-delivery-gate`,
  `session-state-conformance`, `bounded-telemetry-sweep`,
  `bus-producer-coverage`, `deps-centralization`, `freshness-sweep`,
  `managed-tool-seam-coverage`, `profiling-coverage`,
  `module-instance-coverage` (`config/module-instance-binding.test.ts`),
  `sweep-floor-coverage` — 11 files, 179 tests, all green.
- Full `npm test`: 31 failures (a second run showed 42, in a largely
  *different* set), none in files this PR touches —
  `tests/clients/dispatch/oxfmt-ignored-file-noop.test.ts` (a real oxfmt
  binary probe unrelated to formatting my own files),
  `tests/clients/installer/installer-lifecycle.integration.test.ts` (Windows
  process-tree timing), `tests/clients/dispatch/fact-store-session-bound.test.ts`
  (30s test timeout, unrelated `#2282` FactStore suite), and further
  timing-sensitive/integration suites on the second run (`fact-store-bound`,
  `cascade-graph-occupancy`, MCP spawn smokes, `pi-host-contract`, etc.) —
  none reference `widget-state`, `lens-diagnostics`, `severity`,
  `advisories`, or `hint`. See Review round 1 below: the CI `oxfmt format
  check (advisory)` failure was NOT this — it was my own new test file being
  unformatted, since fixed.

### Test assessment

- `tests/clients/severity-tier-consumers.test.ts` uniquely pins that
  `code-quality-warnings.ts` and `actionable-warnings.ts` correctly preserve
  hint/info as their own tier (byTier breakdown), and now also pins the
  corrected widget-state fold. No test in this file becomes redundant — the
  edited block replaces (does not duplicate) the old assertion.
- `tests/clients/widget-state.test.ts` uniquely pins the TUI footer's render
  output and `getFileDiagnosticSummaries`' per-file counts; the new block is
  additive.
- `tests/tools/lens-diagnostics.test.ts` uniquely pins the `lens_diagnostics`
  tool's text/detail output for mode=all/full; the new block is additive.
- No removal candidates identified.

## Blast radius

`classifyDiagnosticTier` and `countAdvisories` are new, additive exports
from `clients/widget-state.ts` — no existing caller signature changed.
`FileDiagnosticSummary` gained a required `advisories: number` field;
`getFileDiagnosticSummaries()` (the only production factory of this type)
was updated to populate it, and `tools/lens-diagnostics.ts`'s
`summarizeDiagnostics` (the only other constructor) was updated too — `tsc`
confirms these are the only two production call sites (no other object
literal or spread typed as `FileDiagnosticSummary` exists outside tests).

Downstream consumers of `rec.diagnosticCounts.warnings` in
`clients/widget-state.ts` (`renderWidget`, `formatFileRowVertical`,
`formatFileTokenHorizontal`, `classifyFileTier`, `countTotalIn`) all read
through the single `countDiagnostics` function this PR edits — one fix point
covers the TUI footer, the per-file rows (both horizontal and vertical
layout), and file-tier sorting. No per-render cost change: the tally is
still one pass over each file's diagnostics; `countAdvisories` is a second
O(diagnostics) pass but only runs in `getFileDiagnosticSummaries` (mode=all
tool calls), not on the per-edit hot path (`recordDiagnostics` /
`commitDiagnostics`, which still call the unmodified-shape
`countDiagnostics`).

Not touched: `recordFormatter`, any `formatters` field, `FileRecord`'s
formatter bookkeeping — the parallel #2413 fixer's surface. Verified via
`git diff --stat` against this PR's commit: only
`countDiagnostics`/`FileDiagnosticSummary`/`getFileDiagnosticSummaries` in
`clients/widget-state.ts` changed.

## Observability

No new telemetry record needed. `clients/diagnostics-publish.ts`'s
`pilens:diagnostics` bus event already emits each diagnostic entry with its
own `severity` field (not an aggregated count) — a consumer can already
reconstruct the advisory/warning split from the existing payload, satisfying
the issue's "add a breakdown only if existing records cannot already
distinguish tiers." `lens_diagnostics`' `details.totalAdvisories` (new field
on the tool's own `details` output, not a durable log/ledger record) is the
one place this PR adds a count, and it is scoped to that tool call's own
response, not a new persisted or logged record.

## Class sweep

Defect shape: a compact finding-count surface duplicating tier-folding logic
per renderer instead of consulting one shared severity-projection policy
(AGENTS.md "Severity policy", #1777).

Swept every compact finding-count surface reachable from `WidgetDiagnostic`/
`FileDiagnosticSummary`'s `severity` field in `clients/`, `tools/`, `mcp/`,
`scripts/` (`grep -rn "hint\|info" clients tools --include=*.ts` plus manual
review of every `warnings`/`warningCount`/`totalWarnings` accumulator). This
sweep did NOT originally cover the `Diagnostic.semantic` axis
(`pilens_analyze`/MCP) — review round 1 found that gap; it is recorded below
and deferred to #2420, not silently left off the table.

| Surface | Combines or separates tiers? | Verdict |
|---|---|---|
| `clients/widget-state.ts` footer (`renderWidget`, `formatFileRowVertical`, `formatFileTokenHorizontal`, `classifyFileTier`) | Was combining (the bug) | Fixed — all read `rec.diagnosticCounts.warnings`, fed by the single `countDiagnostics`. One fix point. |
| `tools/lens-diagnostics.ts` (`lens_diagnostics` mode=all/full "issues" listing, compact tool-call summary line) | Was combining (the bug, duplicated) | Fixed — `summarizeDiagnostics` now delegates to the shared `classifyDiagnosticTier`; `withIssues`/summary/compact-line widened to track `advisories` separately. |
| `clients/diagnostics-publish.ts` (`pilens:diagnostics` bus event) | Separates already | No change — per-diagnostic `severity` field, no aggregated count to fix. |
| `clients/code-quality-warnings.ts` / `clients/actionable-warnings.ts` | Separates already (#1777 `byTier`) | No change — correct precedent this PR now matches. |
| `clients/turn-summary.ts` (`pi.sendMessage` per-run summary) | Combines, but as a total-findings count, not a "warnings" label | No change — doesn't misrepresent severity; flagged for visibility. |
| `pilens_analyze`/MCP (`clients/dispatch/runners/ast-grep-napi.ts:1284` sets `semantic: severity === "error" ? "blocking" : "warning"` for every hint/info finding → `clients/dispatch/dispatcher.ts:1290` buckets `semantic === "warning" \|\| "none"` into `warnings` → `clients/pipeline.ts:1674` → `clients/mcp/analyze.ts:558` reports `counts.warnings` verbatim; same count surfaces via `clients/mcp/server.ts:1033` and `clients/mcp/analyze-cli.ts:62`) | Combines — a REAL instance of this defect shape, found by review round 1 | **Not fixed here.** This folds on a different axis (`Diagnostic.semantic`, a 3-valued `blocking`/`warning`/`fixed`/`none` field set at the dispatch runner) than the `severity`-axis fold this PR closes (`WidgetDiagnostic.severity`, 4-valued, read downstream of dispatch by widget-state/lens-diagnostics). Reconciling the two axes is a distinct seam — `semantic` also drives the blocking gate and the turn-end advisory tier, so widening its "warning" bucket touches surfaces this PR was explicitly told not to touch (dispatcher/pipeline semantics, #2413's adjacent territory). Deferred to **#2420**. |

Consolidation verdict: the SEVERITY-axis family (widget-state's footer tally
and lens-diagnostics' summary tally) is now folded onto one seam —
`classifyDiagnosticTier` in `clients/widget-state.ts` — rather than left
distributed. Both call sites import it; neither re-implements the
severity-to-tier branch. The SEMANTIC-axis family
(`pilens_analyze`/dispatcher/pipeline/MCP) is a sibling instance of the same
defect shape that this PR does NOT fold in — tracked separately as #2420
rather than silently left unrecorded. The severity-axis sweep above is
complete; the semantic-axis sweep is #2420's to do.

## Review round 1

Reviewer verdict: needs changes (minor) — core fix cleared under attack
(red-run reproduced independently, both call sites mutation-proven, an
inversion probe on the classifier came back clean, #2413 interlock confirmed
disjoint). Two findings, both addressed on this branch:

1. **[spec] Class sweep incomplete.** The `pilens_analyze`/MCP surface
   (`clients/mcp/analyze.ts:558`, `clients/mcp/server.ts:1033`,
   `clients/mcp/analyze-cli.ts:62`) still presents hint/info as warnings, via
   a fold this PR's sweep missed: `clients/dispatch/runners/ast-grep-napi.ts:1284`
   sets `semantic: "warning"` for every non-error severity, and
   `clients/dispatch/dispatcher.ts:1290` buckets `semantic === "warning" ||
   "none"` into its `warnings` count — a DIFFERENT axis (`semantic`) than the
   `severity`-axis fold this PR fixes. Orchestrator decision: do not attempt
   the semantic-axis reconciliation in this PR (it is a distinct seam whose
   blast radius includes the blocking gate and the turn-end advisory tier).
   **No code change** — the Class sweep table above now carries this row
   with an honest verdict, deferred to **#2420**, and the "deliberately out
   of scope" paragraph in the Summary was corrected to name it.
2. **[standards] Self-inflicted CI failure.** The `oxfmt format check
   (advisory)` failure on the prior head was misattributed in this PR body
   to a pre-existing environment gap. That was wrong: this worktree's
   `node_modules/oxfmt` was genuinely absent when I first checked (confirmed
   by `ls node_modules/oxfmt/bin/` failing), which is true, but the actual
   CAUSE of the CI failure was that `tests/clients/widget-state.test.ts` — my
   own new test file — was unformatted (three long object literals around
   the new `severity projection (#2414)` block). CI has oxfmt available and
   correctly flagged it; my local absence of the binary just meant I never
   ran the check that would have caught it before push. Installed oxfmt
   locally (`npm install oxfmt@0.65.0 --no-save`, matching the pinned
   `package.json` devDependency version), ran `npx oxfmt` on the file (only
   reformats the three literals into multi-line form, no semantic change),
   and verified `npx oxfmt --check` is clean across every file this PR
   touches. The "Suites run" section above is corrected to stop attributing
   this to environment.

## Merge order

Per the orchestrator brief, this PR is meant to land before the parallel
#2413 fixer, which also touches `clients/widget-state.ts` (formatter-failure
state). See Blast radius above — this PR does not touch `recordFormatter` or
any `formatters` field, so the two diffs should not textually collide;
#2413's author should rebase onto this once merged.

