### PR TITLE
fix: model-facing analyze counts report advisories separately from warnings (closes #2420)

### DIFF
--- a/.changelog/2420-analyze-advisory-counts.md
+++ b/.changelog/2420-analyze-advisory-counts.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Model-facing analyze counts no longer fold hint/info findings into warnings (closes #2420)** — `pilens_analyze` (and the `pi-lens-analyze` CLI/PostToolUse hook and the MCP server's analyze summary) reported a file whose only findings were `hint`/`info`-tier style opinions (`no-runtime-typeof`, complexity hints) as "N warning(s)". The counts read the dispatch `semantic` axis, which the runner's severity→semantic map folds every non-error tier into (`semantic:"warning"`); the severity-tier projection #2414/#2417 established (`classifyDiagnosticTier` in `widget-state.ts`) never governed this surface. The count-assembly seam now splits an `advisories` count out of the warnings bucket through that same one policy — `hint`/`info` are reported as advisories, real warnings keep their exact count, and advisories stay visible in the diagnostics list and under their own `advisory(ies)` label. The `semantic` axis (which drives blocking) is untouched: this is a display-count split, so nothing that blocked stops blocking.

--- a/clients/mcp/analyze.ts
+++ b/clients/mcp/analyze.ts
@@ -29,7 +29,7 @@ import { PathKeyedMap } from "../path-keyed-map.js";
 import { normalizeMapKey } from "../path-utils.js";
 import { loadProjectSnapshot } from "../project-snapshot.js";
 import { buildOrUpdateGraph } from "../review-graph/service.js";
-import { recordDiagnostics } from "../widget-state.js";
+import { classifyDiagnosticTier, recordDiagnostics } from "../widget-state.js";
 import {
 	deserializeWordIndex,
 	removeWordIndexDocumentAsync,
@@ -226,6 +226,30 @@ const WARMUP_CLIENT_WAIT_MS = 10_000;
 const WARMUP_DIAGNOSTICS_WAIT_MS = 6_000;
 
 /** One diagnostic, flattened to the fields an MCP consumer needs. */
+/**
+ * Split the dispatch `warnings` bucket into real warnings vs advisories using
+ * the ONE severity-projection policy ({@link classifyDiagnosticTier}, #2414/
+ * #2417) so the model-facing counts never present a `hint`/`info`-tier finding
+ * as a warning (#2420, remainder of #2414). The dispatch `semantic` axis (which
+ * also drives blocking) is intentionally NOT consulted or mutated here: this is
+ * a display-count split, not a blocking-decision change. `blockers`
+ * (`semantic:"blocking"`) are computed upstream and never enter this bucket, so
+ * nothing that blocks can stop blocking through this seam. A non-advisory entry
+ * in the bucket (an `error`/`warning`-tier finding routed here as
+ * `semantic:"warning"`/`"none"`) stays counted as a warning exactly as before,
+ * so a mixed file's real warning count is unchanged.
+ */
+export function summarizeWarningTiers(warnings: readonly Diagnostic[]): {
+	warnings: number;
+	advisories: number;
+} {
+	let advisories = 0;
+	for (const w of warnings) {
+		if (classifyDiagnosticTier(w) === "advisory") advisories++;
+	}
+	return { warnings: warnings.length - advisories, advisories };
+}
+
 export interface McpAnalyzeDiagnostic {
 	line?: number;
 	column?: number;
@@ -258,6 +282,18 @@ export interface McpAnalyzeResult {
 		diagnostics: number;
 		blockers: number;
 		warnings: number;
+		/**
+		 * `hint`/`info`-tier findings split OUT of `warnings` (#2420) via the one
+		 * severity-projection policy ({@link classifyDiagnosticTier}). Before
+		 * #2420 the dispatch `semantic` axis folded every non-error tier into the
+		 * warnings bucket, so a file whose only findings were style opinions
+		 * (`no-runtime-typeof`, complexity hints) reported "N warning(s)" on every
+		 * model-facing surface. Advisories are counted here — and still listed in
+		 * `diagnostics` under their own severity — so they stay visible without
+		 * being misrepresented as warnings. The `semantic` axis (which drives
+		 * blocking) is deliberately untouched: this is a display-count split only.
+		 */
+		advisories: number;
 		fixed: number;
 	};
 	diagnostics: McpAnalyzeDiagnostic[];
@@ -555,7 +591,12 @@ export async function analyzeFile(
 		counts: {
 			diagnostics: result.diagnostics.length,
 			blockers: result.blockers.length,
-			warnings: result.warnings.length,
+			// #2420: `result.warnings` is the dispatch warnings bucket
+			// (`semantic:"warning"|"none"`), which still carries `hint`/`info`-tier
+			// findings folded in by the runner's severity→semantic map. Project
+			// them out through the shared tier policy so the model sees real
+			// warnings and advisories separately.
+			...summarizeWarningTiers(result.warnings),
 			fixed: result.fixed.length,
 		},
 		lsp,

--- a/mcp/analyze-cli.ts
+++ b/mcp/analyze-cli.ts
@@ -59,7 +59,9 @@ async function readStdin(): Promise<string> {
 function formatReport(result: McpAnalyzeResult, cwd: string): string {
 	const rel = path.relative(cwd, result.filePath) || result.filePath;
 	const lines = [
-		`🔎 pi-lens: ${rel} — ${result.counts.blockers} blocking, ${result.counts.warnings} warning(s)`,
+		// #2420: advisories (hint/info-tier style opinions) reported under their
+		// own label — no longer folded into the warning count on this surface.
+		`🔎 pi-lens: ${rel} — ${result.counts.blockers} blocking, ${result.counts.warnings} warning(s), ${result.counts.advisories} advisory(ies)`,
 	];
 	for (const d of result.diagnostics.slice(0, 30)) {
 		const marker = d.semantic === "blocking" ? "🔴" : "⚠";

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -1031,6 +1031,9 @@ function formatAnalyze(
 	const summary =
 		`${path.relative(cwd, result.filePath) || result.filePath} [${mode}] — ` +
 		`${result.counts.blockers} blocking, ${result.counts.warnings} warning(s), ` +
+		// #2420: advisories (hint/info-tier style opinions) are reported under
+		// their own label so they are no longer folded into the warning count.
+		`${result.counts.advisories} advisory(ies), ` +
 		`${result.counts.diagnostics} total` +
 		(result.latency ? ` · ${result.latency.totalDurationMs}ms` : "") +
 		lspNote +

--- a/tests/clients/mcp/analyze-advisory-counts.test.ts
+++ b/tests/clients/mcp/analyze-advisory-counts.test.ts
@@ -1,0 +1,76 @@
+/**
+ * #2420 (remainder of #2414): the model-facing analyze counts must not fold
+ * `hint`/`info`-tier findings into `warnings`. The dispatch warnings bucket
+ * (`semantic:"warning"|"none"`) still carries hint/info-severity findings that
+ * the runner's severity→semantic map folded in; `summarizeWarningTiers` splits
+ * them out through the ONE shared severity-projection policy
+ * (`classifyDiagnosticTier`), so the analyze surface reports real warnings and
+ * advisories separately.
+ *
+ * Pre-fix (dispatch semantic axis alone, no tier split) this whole file goes
+ * red: the symbol does not exist, and the counts fold every non-error tier into
+ * warnings.
+ */
+import { describe, expect, it } from "vitest";
+
+import { summarizeWarningTiers } from "../../../clients/mcp/analyze.js";
+import type { Diagnostic } from "../../../clients/dispatch/types.js";
+
+/** A warnings-bucket entry: `semantic` is "warning"/"none" (never "blocking"),
+ * carrying whatever the rule declared as severity — exactly the shape the
+ * dispatcher hands to the count-assembly seam. */
+function bucketEntry(severity: Diagnostic["severity"], id: string): Diagnostic {
+	return {
+		id,
+		message: `finding ${id}`,
+		filePath: "/x/app.ts",
+		line: 1,
+		severity,
+		// The bug is precisely that hint/info land here as `semantic:"warning"`.
+		semantic: "warning",
+		tool: "ast-grep-napi",
+	};
+}
+
+describe("summarizeWarningTiers (#2420)", () => {
+	it("counts a hint-only bucket as 0 warnings + N advisories", () => {
+		const bucket = [
+			bucketEntry("hint", "a"),
+			bucketEntry("hint", "b"),
+			bucketEntry("info", "c"),
+		];
+		expect(summarizeWarningTiers(bucket)).toEqual({
+			warnings: 0,
+			advisories: 3,
+		});
+	});
+
+	it("keeps the exact real-warning count on a mixed bucket", () => {
+		const bucket = [
+			bucketEntry("warning", "w1"),
+			bucketEntry("warning", "w2"),
+			bucketEntry("hint", "h1"),
+			bucketEntry("info", "i1"),
+		];
+		// Real warnings stay put; only the two style opinions move to advisories.
+		expect(summarizeWarningTiers(bucket)).toEqual({
+			warnings: 2,
+			advisories: 2,
+		});
+	});
+
+	it("never reclassifies error-tier entries as advisories (inversion guard)", () => {
+		// An error-severity finding routed into the warnings bucket (rare, but the
+		// bucket accepts `semantic:"none"`) must NOT be demoted to an advisory —
+		// only hint/info are advisory. It stays counted as a non-advisory.
+		const bucket = [bucketEntry("error", "e1"), bucketEntry("hint", "h1")];
+		expect(summarizeWarningTiers(bucket)).toEqual({
+			warnings: 1,
+			advisories: 1,
+		});
+	});
+
+	it("returns zeroes for an empty bucket", () => {
+		expect(summarizeWarningTiers([])).toEqual({ warnings: 0, advisories: 0 });
+	});
+});

--- a/tests/clients/mcp/analyze.test.ts
+++ b/tests/clients/mcp/analyze.test.ts
@@ -153,6 +153,10 @@ describe("analyzeFile", () => {
 			diagnostics: 2,
 			blockers: 1,
 			warnings: 1,
+			// #2420: counts now carry the advisories split. `noUnusedImports`
+			// (severity/semantic "warning") classifies as a real warning, not an
+			// advisory, so the warning count is unchanged and advisories is 0.
+			advisories: 0,
 			fixed: 0,
 		});
 		const warn = result.diagnostics.find((d) => d.rule === "noUnusedImports");

--- a/tests/mcp/analyze-cli.test.ts
+++ b/tests/mcp/analyze-cli.test.ts
@@ -118,16 +118,24 @@ function runBinWithOpenStdin(
 	});
 }
 
+// #2420: a file whose only finding is the hint-tier `no-any-type` rule. Before
+// #2420 this rendered "0 blocking, 1 warning(s)" — a style opinion folded into
+// the model-facing warning count via the dispatch semantic axis.
+const HINT_ONLY = "export const y: any = 1;\n";
+
 let tmpDir: string;
 let smellyFile: string;
 let cleanFile: string;
+let hintFile: string;
 
 beforeAll(() => {
 	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-cli-"));
 	smellyFile = path.join(tmpDir, "smelly.ts");
 	cleanFile = path.join(tmpDir, "clean.ts");
+	hintFile = path.join(tmpDir, "hinty.ts");
 	fs.writeFileSync(smellyFile, SMELLY);
 	fs.writeFileSync(cleanFile, "export const x = 1;\n");
+	fs.writeFileSync(hintFile, HINT_ONLY);
 });
 
 afterAll(() => {
@@ -149,6 +157,21 @@ describe("pi-lens-analyze bin", { retry: 2 }, () => {
 		expect(code).toBe(0);
 		expect(stdout).toContain("pi-lens:");
 		expect(stdout).toMatch(/deep-nesting|console-statement/);
+	}, 45_000);
+
+	// #2420: a hint-only file must report 0 warnings and its findings under the
+	// `advisory(ies)` label, never folded into the warning count.
+	it("reports hint-tier findings as advisories, not warnings, in the CLI header", async () => {
+		const { stdout, code } = await runBin([
+			`--file=${hintFile}`,
+			`--cwd=${tmpDir}`,
+		]);
+		expect(code).toBe(0);
+		const header = stdout.split("\n")[0];
+		// The only findings are hint-tier: zero warnings, at least one advisory.
+		expect(header).toMatch(/0 warning\(s\)/);
+		expect(header).toMatch(/[1-9]\d* advisory\(ies\)/);
+		expect(header).toMatch(/0 blocking/);
 	}, 45_000);
 
 	it("emits a PostToolUse JSON envelope with --hook", async () => {


### PR DESCRIPTION
## Summary

Remainder of #2414 (PR #2417 review finding 1). The model-facing analyze counts
still presented `hint`/`info`-tier findings as **warnings**. A file whose only
findings are style opinions (`no-runtime-typeof`, complexity hints,
`no-any-type`) reported `N warning(s)` on `pilens_analyze`, the
`pi-lens-analyze` CLI/PostToolUse hook, and the MCP server's analyze summary.

**Root cause.** The counts are assembled from the dispatch **`semantic`** axis.
`ast-grep-napi` maps every non-error severity to `semantic:"warning"`
(`severity === "error" ? "blocking" : "warning"`), and the dispatcher's
`warnings` bucket is `semantic === "warning" || "none"`. So the severity-tier
projection #2414/#2417 established (`classifyDiagnosticTier` in
`widget-state.ts`) — the ONE policy separating advisories from warnings for the
footer and `lens_diagnostics` — never governed this model-facing surface.

**Option chosen: (b), the contained one.** I split an `advisories` count out at
the count-assembly seam rather than touching the severity→semantic map or the
dispatcher's warning bucket (option a). Option (a) mutates the `OutputSemantic`
axis, which **also drives blocking** — the issue and AGENTS.md "Severity policy"
both flag this as high-caution for inversions. Option (b) leaves the `semantic`
axis, the `blockers` bucket, and every blocking decision **byte-for-byte
untouched**; it mirrors exactly what #2417 did for `FileDiagnosticSummary`. New
`summarizeWarningTiers` (in `clients/mcp/analyze.ts`) consults
`classifyDiagnosticTier` — no second tier list — and splits the dispatch
`warnings` bucket into `{ warnings, advisories }`. A non-advisory entry
(`error`/`warning` tier routed in as `semantic:"warning"|"none"`) stays counted
as a warning, so a mixed file's real warning count is unchanged. All three
surfaces named in the issue now report warnings and advisories separately; the
advisories stay visible in the `diagnostics` list under their own severity.

Closes #2420 — all acceptance criteria met.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:diagnostics
- [x] area:dispatch
- [x] area:observability

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (no dep changes)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there (no documented invariant changed; this restores conformance to the existing "Severity policy" one-policy rule)
- [x] `.changelog/2420-analyze-advisory-counts.md` has one valid entry in this PR
- [x] Commit subject includes the issue number: `(refs #2420)`

## Tests

- **New `tests/clients/mcp/analyze-advisory-counts.test.ts` (4 cases)** — pins
  `summarizeWarningTiers`, the single count-split policy: hint-only bucket → 0
  warnings + N advisories; mixed bucket keeps the exact real-warning count;
  error-tier entry in the bucket is NOT demoted to advisory (inversion guard);
  empty bucket → zeroes. Regression proof for #2420's count assembly.
- **Edited `tests/mcp/analyze-cli.test.ts` (+1 case, +`hinty.ts` fixture)** —
  spawns the real bin against a hint-only `no-any-type` file and asserts the
  rendered CLI header shows `0 warning(s)` + `≥1 advisory(ies)` + `0 blocking`.
  Pins the render surface end-to-end, not just the count object.

Test-authoring screens satisfied: the CLI case pins the **real rendered output
of a spawned bin** (guards against wrong-layer pin / implementation-mirror — it
asserts the transcript text a model sees, not an internal field); the unit
cases use production-faithful bucket entries (`semantic:"warning"` carrying the
declared severity — the exact shape the dispatcher hands the seam, guarding the
ambient-inspection-double screen).

Red-first, source reverted to pre-fix (tests kept, rebuilt):

```
FAIL tests/clients/mcp/analyze-advisory-counts.test.ts > summarizeWarningTiers (#2420)
TypeError: summarizeWarningTiers is not a function
 Test Files  1 failed (1)
      Tests  4 failed (4)
```

```
FAIL  tests/mcp/analyze-cli.test.ts > pi-lens-analyze bin > reports hint-tier findings as advisories, not warnings, in the CLI header
AssertionError: expected '🔎 pi-lens: hinty.ts — 0 blocking, 1 …' to match /0 warning\(s\)/
+ Received:
"🔎 pi-lens: hinty.ts — 0 blocking, 1 warning(s)"
```

After restoring the fix both go green (hint-only file → `0 blocking, 0
warning(s), 1 advisory(ies)`).

### Test assessment

- `tests/clients/mcp/analyze-advisory-counts.test.ts` — uniquely pins the
  warning/advisory split policy at the count-assembly seam. No existing test
  covers this; makes nothing redundant.
- `tests/mcp/analyze-cli.test.ts` — the added case uniquely pins the CLI header
  render of the advisory count. The pre-existing cases pin bin lifecycle
  (stdin/hook/turn-end) and stay distinct. No removal candidates.

## Blast radius

Touched production modules and their model-facing dependents:

- `clients/mcp/analyze.ts` (`summarizeWarningTiers`, `McpAnalyzeResult.counts`)
  — consumed only by the two renderers below plus type-only imports
  (`clients/lens-engine.ts`, `clients/mcp/ipc.ts`, `clients/mcp/review.ts`,
  `mcp/worker.ts`). `grep counts.warnings` across `clients/`, `mcp/`, `tests/`
  returns ONLY the three surfaces this PR edits — no other consumer folds the
  count.
- `mcp/server.ts` `formatAnalyze` and `mcp/analyze-cli.ts` `formatReport` —
  leaf render functions; no downstream dependents.

Not a hot path (per-analyze-call, once per `pilens_analyze` / hook fire), and
the split is an O(n) pass over an already-materialized warnings array — no
measurable cost delta. Adding a required `advisories` field to
`McpAnalyzeResult.counts`: the two test constructors are untyped/`as unknown`
casts, so no compile break; verified by `npm run lint`.

## Observability

The `advisories` count rides the existing `McpAnalyzeResult` JSON that
`pilens_analyze` returns (and `mcp/worker.ts` writes to stdout), and the
`latency.log` `tool_result` record's `warnings` field is derived from the same
dispatch bucket — so a production analyze call now shows warnings and advisories
distinctly in the tool response the model receives. No new ledger kind needed;
this is a projection correction, not a new degradation path.

## Class sweep

**Defect shape.** Severity/tier misrepresentation on a delivery surface — the
same class #2414 opened and #2417 closed for the footer and `lens_diagnostics`.
AGENTS.md "Severity policy (#1777)": hint/info are advisory, never render with a
warning's weight; the single-source rule is "one severity-projection policy, no
per-renderer folds".

**Population sweep** — every surface that renders a warning-vs-advisory count
from a dispatch bucket, across the WHOLE tree (`grep -rn "warning(s)\|
counts.warnings\|classifyDiagnosticTier\|countAdvisories"` over `clients/`,
`tools/`, `mcp/`, `scripts/`, `index.ts`):

- `clients/widget-state.ts` footer + `getFileDiagnosticSummaries` — **already
  correct** (#2417, `classifyDiagnosticTier` + `countAdvisories`).
- `tools/lens-diagnostics.ts` `withIssues` — consumes `FileDiagnosticSummary`,
  **already correct** (#2417).
- `clients/mcp/analyze.ts` counts → `mcp/server.ts` + `mcp/analyze-cli.ts` —
  **fixed here** (this was the surviving member #2420 identified).
- `clients/ast-grep-client.ts` `"N warning(s)"` render — operates on a
  pre-projection raw diagnostic list for a different (per-runner debug) surface,
  not the model-facing analyze counts; left distinct.

**Consolidation verdict.** The family now folds onto ONE policy —
`classifyDiagnosticTier` in `widget-state.ts` — consumed by both the widget path
(directly / via `countAdvisories`) and the MCP analyze path (via
`summarizeWarningTiers`). No duplicate tier list remains; the class is closed.

## Post-merge semantic screening (after merging #2419, formatter-unavailability)

This branch merged `origin/master` at `cbc3784c` (PR #2419), which added the
`formatUnavailable` routing in `clients/pipeline.ts`. I screened the merged
result for a collision between #2419's formatter-unavailability path and this
PR's advisories split at the analyze count-assembly seam. **No collision — the
two paths are on disjoint pipelines:**

- `clients/mcp/analyze.ts` assembles its `warnings`/`advisories` counts purely
  from `dispatchLintWithResult(...)` (the lint dispatch result), via
  `summarizeWarningTiers(result.warnings)`. `dispatchLintWithResult`
  (`clients/dispatch/integration.ts:2600`) runs providers + runners and returns
  a `DispatchResult`; it never invokes the format phase.
- #2419's `runFormatPhase` / `formatUnavailable` (`clients/pipeline.ts:~1203`)
  is a wholly separate path. An unavailable formatter is explicitly kept OUT of
  `formatFailures` and `formattersUsed`, recorded once via
  `recordDegradationOnce({ kind: "formatter-unavailable", ... })`, and returned
  in its own `formatUnavailable[]`. Its only consumer is
  `clients/runtime-agent-end.ts` (~L633), which surfaces it through
  `summary.unavailable[]` and deliberately does NOT requeue it.

Therefore a formatter being unavailable **cannot inflate either the `warnings`
or `advisories` count** in analyze.ts (it never becomes a `Diagnostic` and never
enters `result.warnings`), and it **does not disappear** — it was never a warning
on the analyze surface to begin with, and it remains visible through the
degradation ledger and the agent-end `unavailable` channel. The PRs are
orthogonal and compose cleanly.

## Review round (post-merge CI catch)

CI Unit tests (job `100055705722`) went red on the merged head with one failure:
`tests/clients/mcp/analyze.test.ts:152` — "maps DispatchResult diagnostics and
counts into the MCP contract". That sibling test asserted the pre-#2420 `counts`
shape with a strict `toEqual` and was missed by the symbol grep because it
asserts the shape without naming `summarizeWarningTiers`/`classifyDiagnosticTier`.
Reproduced red locally (`expected { …, advisories: 0 } to deeply equal { … }`);
the mocked `noUnusedImports` warning classifies as a real warning, so `warnings`
stays 1 and `advisories` is 0. Updated the expected `counts` to the #2420
contract (commit `ba97a55b`). Re-ran analyze + advisory + CLI suites (45 passed)
and the full governance sweep (182 passed); lint/type-check clean.

## AGENTS.md sections consulted

Recurring defect shapes (3, 10, 13, 16, 17, 18); Standing invariants dispatch
group; "Severity policy (#1777)"; "Actionable warnings routing".

Refs #2414, PR #2417 (review finding 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

