### PR TITLE
fix: key build-attempt identity on a monotonic id, not wall-clock ms (closes #2441)

### DIFF
--- a/.changelog/fix-2441-build-latch-ms.md
+++ b/.changelog/fix-2441-build-latch-ms.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Stop asserting build-attempt identity on wall-clock milliseconds (refs #2441)** — `ProjectReport.lastBuildAttempt` now carries the review graph's existing process-wide monotonic `buildId`, and three flaky assertions across `build-latch.test.ts`, `review-graph-seq-fastpath.test.ts`, and `review-graph.service.test.ts` compare `buildId`/`buildGeneration` instead of a `new Date().toISOString()` field that two attempts can legitimately share when they land in the same millisecond (the `build-latch.test.ts:299` CI flake). No production behavior changes — the monotonic identity already existed internally; it's now part of the public `ProjectReport` type and the tests key on it.

--- a/.changelog/fix-2441-build-latch-ms.md
+++ b/.changelog/fix-2441-build-latch-ms.md
@@ -1,5 +1,0 @@
----
-section: Fixed
----
-
-- **Stop asserting build-attempt identity on wall-clock milliseconds (refs #2441)** — `ProjectReport.lastBuildAttempt` now carries the review graph's existing process-wide monotonic `buildId`, and three flaky assertions across `build-latch.test.ts`, `review-graph-seq-fastpath.test.ts`, and `review-graph.service.test.ts` compare `buildId`/`buildGeneration` instead of a `new Date().toISOString()` field that two attempts can legitimately share when they land in the same millisecond (the `build-latch.test.ts:299` CI flake). No production behavior changes — the monotonic identity already existed internally; it's now part of the public `ProjectReport` type and the tests key on it.

--- a/clients/project-report.ts
+++ b/clients/project-report.ts
@@ -174,6 +174,10 @@ export interface ProjectReport {
 		when: string;
 		outcome: "running" | "succeeded" | "skipped" | "failed";
 		reason?: string;
+		/** Process-wide monotonic build identity (#2441). `when` is wall-clock
+		 * ISO and two attempts can land in the same millisecond — this is the
+		 * one field that always distinguishes attempts; compare it, not `when`. */
+		buildId?: number;
 	};
 	view?: "compact";
 	trust?: ProjectReportTrust;

--- a/tests/clients/review-graph-seq-fastpath.test.ts
+++ b/tests/clients/review-graph-seq-fastpath.test.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { FactStore } from "../../clients/dispatch/fact-store.js";
 import { normalizeMapKey } from "../../clients/path-utils.js";
 import {
@@ -86,10 +86,20 @@ describe("review-graph seq fast path (#451)", () => {
 			);
 			hint.bump(aPath);
 
+			// #2441: pin the clock so this rebuild's `builtAt` lands in the SAME
+			// millisecond as `initialGraph.builtAt`, deterministically — wall-clock
+			// ISO strings are allowed to collide between two builds. `buildGeneration`
+			// (`builder.ts`'s process-wide `_graphGenerationCounter`) is bumped only
+			// on a real re-extract (#459) and is the field that must move here.
+			vi.spyOn(Date.prototype, "toISOString").mockReturnValue(
+				initialGraph.builtAt,
+			);
 			clearGraphCache();
 			const graph = await buildOrUpdateGraph(env.tmpDir, [aPath], facts, hint);
+			vi.restoreAllMocks();
 			expect(getLastGraphBuildInfo().mode).toBe("seq-fastpath");
-			expect(graph.builtAt).not.toBe(initialGraph.builtAt);
+			expect(graph.builtAt).toBe(initialGraph.builtAt);
+			expect(graph.buildGeneration).not.toBe(initialGraph.buildGeneration);
 			// The edit is reflected: gamma is now a symbol node.
 			const hasGamma = [...graph.nodes.values()].some(
 				(n) => n.symbolName === "gamma",

--- a/tests/clients/review-graph-seq-fastpath.test.ts
+++ b/tests/clients/review-graph-seq-fastpath.test.ts
@@ -38,6 +38,10 @@ describe("review-graph seq fast path (#451)", () => {
 	afterEach(() => {
 		clearReviewGraphWorkspaceCache();
 		delete process.env.PI_LENS_GRAPH_SEQ_FASTPATH;
+		// Backstop for the Date.prototype.toISOString spy below: if a test's
+		// awaited build rejects before its own try/finally restore runs, this
+		// still clears the pin before the next test in the file (#2446 F1).
+		vi.restoreAllMocks();
 	});
 
 	it("takes the fast path after a hinted build when one file is edited", async () => {
@@ -91,20 +95,33 @@ describe("review-graph seq fast path (#451)", () => {
 			// ISO strings are allowed to collide between two builds. `buildGeneration`
 			// (`builder.ts`'s process-wide `_graphGenerationCounter`) is bumped only
 			// on a real re-extract (#459) and is the field that must move here.
-			vi.spyOn(Date.prototype, "toISOString").mockReturnValue(
-				initialGraph.builtAt,
-			);
+			// #2446 F1: try/finally so a rejecting build still restores the
+			// process-global Date.prototype spy instead of leaking it to later
+			// tests in this file.
+			const isoSpy = vi
+				.spyOn(Date.prototype, "toISOString")
+				.mockReturnValue(initialGraph.builtAt);
 			clearGraphCache();
-			const graph = await buildOrUpdateGraph(env.tmpDir, [aPath], facts, hint);
-			vi.restoreAllMocks();
-			expect(getLastGraphBuildInfo().mode).toBe("seq-fastpath");
-			expect(graph.builtAt).toBe(initialGraph.builtAt);
-			expect(graph.buildGeneration).not.toBe(initialGraph.buildGeneration);
-			// The edit is reflected: gamma is now a symbol node.
-			const hasGamma = [...graph.nodes.values()].some(
-				(n) => n.symbolName === "gamma",
-			);
-			expect(hasGamma).toBe(true);
+			try {
+				const graph = await buildOrUpdateGraph(
+					env.tmpDir,
+					[aPath],
+					facts,
+					hint,
+				);
+				expect(getLastGraphBuildInfo().mode).toBe("seq-fastpath");
+				// #2446 F2: assert the pin fired rather than the mocked artifact
+				// (`graph.builtAt`), so a future clock refactor doesn't red this.
+				expect(isoSpy).toHaveBeenCalled();
+				expect(graph.buildGeneration).not.toBe(initialGraph.buildGeneration);
+				// The edit is reflected: gamma is now a symbol node.
+				const hasGamma = [...graph.nodes.values()].some(
+					(n) => n.symbolName === "gamma",
+				);
+				expect(hasGamma).toBe(true);
+			} finally {
+				vi.restoreAllMocks();
+			}
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/review-graph.service.test.ts
+++ b/tests/clients/review-graph.service.test.ts
@@ -35,6 +35,14 @@ vi.mock("../../clients/latency-logger.js", async (importOriginal) => {
 });
 
 describe("review graph service", () => {
+	afterEach(() => {
+		// Backstop for the Date.prototype.toISOString spy used below: if a
+		// test's awaited build rejects before its own try/finally restore
+		// runs, this still clears the pin before the next test in the file
+		// (#2446 F1).
+		vi.restoreAllMocks();
+	});
+
 	it("builds a TS graph and surfaces importers/callers without duplicate edges", async () => {
 		const env = setupTestEnvironment("pi-lens-review-graph-");
 		try {
@@ -746,17 +754,25 @@ describe("review graph service", () => {
 			// `buildGeneration` (`builder.ts`'s process-wide `_graphGenerationCounter`)
 			// is bumped only on a real re-extract (#459) and is the field that must
 			// move here.
-			vi.spyOn(Date.prototype, "toISOString").mockReturnValue(
-				initialGraph.builtAt,
-			);
-			const graph = await buildOrUpdateGraph(env.tmpDir, [aPath], facts);
-			vi.restoreAllMocks();
-			expect(getLastGraphBuildInfo()).toMatchObject({ mode: "incremental" });
-			expect(graph.builtAt).toBe(initialGraph.builtAt);
-			expect(graph.buildGeneration).not.toBe(initialGraph.buildGeneration);
-			const impact = computeImpactCascade(graph, aPath);
-			expect(impact.directImporters).toContain(normalizeMapKey(bPath));
-			expect(impact.directCallers).toContain(normalizeMapKey(bPath));
+			// #2446 F1: try/finally so a rejecting build still restores the
+			// process-global Date.prototype spy instead of leaking it to later
+			// tests in this file.
+			const isoSpy = vi
+				.spyOn(Date.prototype, "toISOString")
+				.mockReturnValue(initialGraph.builtAt);
+			try {
+				const graph = await buildOrUpdateGraph(env.tmpDir, [aPath], facts);
+				expect(getLastGraphBuildInfo()).toMatchObject({ mode: "incremental" });
+				// #2446 F2: assert the pin fired rather than the mocked artifact
+				// (`graph.builtAt`), so a future clock refactor doesn't red this.
+				expect(isoSpy).toHaveBeenCalled();
+				expect(graph.buildGeneration).not.toBe(initialGraph.buildGeneration);
+				const impact = computeImpactCascade(graph, aPath);
+				expect(impact.directImporters).toContain(normalizeMapKey(bPath));
+				expect(impact.directCallers).toContain(normalizeMapKey(bPath));
+			} finally {
+				vi.restoreAllMocks();
+			}
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/review-graph.service.test.ts
+++ b/tests/clients/review-graph.service.test.ts
@@ -739,9 +739,21 @@ describe("review graph service", () => {
 			);
 			await new Promise((resolve) => setTimeout(resolve, 5));
 
+			// #2441: pin the clock so this rebuild's `builtAt` lands in the SAME
+			// millisecond as `initialGraph.builtAt`, deterministically — wall-clock
+			// ISO strings are allowed to collide between two builds (the `setTimeout`
+			// above only nudges mtime, it never guaranteed a distinct ms).
+			// `buildGeneration` (`builder.ts`'s process-wide `_graphGenerationCounter`)
+			// is bumped only on a real re-extract (#459) and is the field that must
+			// move here.
+			vi.spyOn(Date.prototype, "toISOString").mockReturnValue(
+				initialGraph.builtAt,
+			);
 			const graph = await buildOrUpdateGraph(env.tmpDir, [aPath], facts);
+			vi.restoreAllMocks();
 			expect(getLastGraphBuildInfo()).toMatchObject({ mode: "incremental" });
-			expect(graph.builtAt).not.toBe(initialGraph.builtAt);
+			expect(graph.builtAt).toBe(initialGraph.builtAt);
+			expect(graph.buildGeneration).not.toBe(initialGraph.buildGeneration);
 			const impact = computeImpactCascade(graph, aPath);
 			expect(impact.directImporters).toContain(normalizeMapKey(bPath));
 			expect(impact.directCallers).toContain(normalizeMapKey(bPath));

--- a/tests/clients/review-graph/build-latch.test.ts
+++ b/tests/clients/review-graph/build-latch.test.ts
@@ -290,13 +290,25 @@ describe("project_report retry claim (#1962)", () => {
 		const firstAttempt = getLastReviewGraphBuildAttempt(cwd);
 		_resetReviewGraphSizeSkipVerdictsForTests();
 
+		// #2441: pin the clock so the retry's `recordBuildAttempt` lands in the
+		// SAME millisecond as `firstAttempt` — reproducing "two build attempts
+		// recorded the same ISO timestamp" (CI, ms-resolution flake) on every
+		// run instead of only when two real attempts happen to race into one
+		// ms. `when` is wall-clock and MUST be allowed to collide; `buildId` is
+		// the latch's actual identity (a process-wide monotonic counter,
+		// `builder.ts`'s `_buildIdCounter`) and is the field that must move.
+		vi.spyOn(Date.prototype, "toISOString").mockReturnValue(
+			firstAttempt?.when as string,
+		);
 		const report = await projectReport(cwd);
 		// The hint still names the previous failure, but the reported attempt is
 		// the retry this call started — not the earlier record replayed as if it
 		// were current.
 		expect(report.hint).toContain("A retry was started.");
 		expect(report.lastBuildAttempt?.outcome).toBe("running");
-		expect(report.lastBuildAttempt?.when).not.toBe(firstAttempt?.when);
+		expect(report.lastBuildAttempt?.when).toBe(firstAttempt?.when);
+		expect(report.lastBuildAttempt?.buildId).not.toBe(firstAttempt?.buildId);
+		vi.restoreAllMocks();
 		await settleBackgroundBuild(cwd);
 	});
 


### PR DESCRIPTION
## Summary

`tests/clients/review-graph/build-latch.test.ts:299` flaked in CI (PR #2432,
head 44677cea) when two build attempts landed in the same wall-clock
millisecond: `expected '2026-09-02T11:24:57.508Z' not to be
'2026-09-02T11:24:57.508Z'`. The test compared `ReviewGraphBuildAttempt.when`
(a `new Date().toISOString()` field) for identity between two attempts.

Root cause: production already tracks a real monotonic identity for build
attempts — `buildId`, sourced from `builder.ts`'s process-wide
`_buildIdCounter` — but it was never exposed on the public
`ProjectReport.lastBuildAttempt` TypeScript interface in
`clients/project-report.ts`. The runtime object always carried `buildId`
(structural typing let it flow through silently); the *type* just hid it,
so the test had no collision-proof field to assert on and fell back to
`when`. Fix: widen the interface to declare `buildId?: number`, and pin the
test to it instead of `when`.

Class sweep (see below) found the identical shape twice more in
`review-graph-seq-fastpath.test.ts` and `review-graph.service.test.ts`,
both asserting `graph.builtAt` "changed" to prove a rebuild happened.
`graph.buildGeneration` (`builder.ts`'s `_graphGenerationCounter`, bumped
only on a real re-extract — #459) is the correct, collision-immune field
for that assertion and replaces `builtAt` in both.

All three fixed tests now pin `Date.prototype.toISOString` to force the
same-millisecond collision deterministically (rather than only reproducing
it by landing there by luck), so the regression is proven red-first on
every run, not just occasionally in CI.

No production **behavior** changes — `buildId` already flowed through the
runtime object; this only widens its declared type and repoints three test
assertions at the field that was always the real identity.

Closes #2441 — every acceptance criterion is met: the test now asserts
identity via a monotonic id (not wall-clock ISO equality), and the fix is
proven red-first with a fake clock reproducing the same-ms collision on
pre-fix code.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [x] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts` — N/A: `clients/project-report.ts` changed only a TS interface (type-only, `buildId?: number`), no runtime code path changed; `npm run build` (tsc) and `npm run lint` both pass clean
- [x] `package-lock.json` is in sync with `package.json` (run `npm install` after dep changes) — no dependency changes in this PR
- [ ] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there — N/A: no behavior/convention/invariant change, only a type widening + test-identity fix
- [x] `.changelog/<branch-or-slug>-<short-desc>.md` has one valid entry **in this PR** for any user-facing change (Added/Changed/Deprecated/Removed/Fixed/Security) — see [.changelog/README.md](../.changelog/README.md); internal-only test/refactor PRs may skip it
- [x] Commit subject includes the issue number: `(closes #NNN)` or `(refs #NNN)`

## Tests

**`tests/clients/review-graph/build-latch.test.ts`** — EDIT, "reports the CURRENT attempt, not the frozen prior one" (project_report retry claim, #1962): pins `Date.prototype.toISOString` so the retry's `recordBuildAttempt` lands in the same ms as the first attempt (deterministic reproduction of the CI flake), then asserts `buildId` (not `when`) distinguishes the two attempts. Regression proof for #2441.

**`tests/clients/review-graph-seq-fastpath.test.ts`** — EDIT, "takes the fast path after a hinted build when one file is edited": same clock-pin technique; asserts `graph.buildGeneration` moved across the seq-fastpath rebuild instead of `builtAt`. Same defect shape, found by class sweep.

**`tests/clients/review-graph.service.test.ts`** — EDIT, "updates cached graph incrementally when only the changed file mtime shifts": same clock-pin technique; asserts `graph.buildGeneration` moved across the incremental rebuild instead of `builtAt`. The existing `setTimeout(resolve, 5)` before the second build was a weaker, still-technically-flaky attempt at dodging the same hazard (screen 6, "a bound loose enough to pass a partial regression" — a 5ms sleep is not a guarantee against a coarse or fast clock); left in place since it also matters for the mtime-based change detection this test exercises, but is no longer load-bearing for the `builtAt`/`buildGeneration` assertion.

Test-authoring screens: screen 3 ("pin at the wrong layer") — the fix pins the seam that's actually guaranteed unique (a monotonic counter) instead of the wall-clock output that happened to usually differ; screen 6 ("a bound loose enough to pass a partial regression") — the `service.test.ts` `setTimeout(5)` was exactly this shape for the `builtAt` assertion it used to guard.

### RED proof (pre-fix, quoted verbatim from local runs)

`build-latch.test.ts` (clock pinned, old `.when` assertion still in place):
```
FAIL  |default| tests/clients/review-graph/build-latch.test.ts > project_report retry claim (#1962) > reports the CURRENT attempt, not the frozen prior one
AssertionError: expected '2026-09-02T12:25:01.439Z' not to be '2026-09-02T12:25:01.439Z' // Object.is equality
 ❯ tests/clients/review-graph/build-latch.test.ts:306:45
```

`review-graph-seq-fastpath.test.ts` (clock pinned, old `.builtAt` assertion):
```
FAIL  |default| tests/clients/review-graph-seq-fastpath.test.ts > review-graph seq fast path (#451) > takes the fast path after a hinted build when one file is edited
AssertionError: expected '2026-09-02T12:32:04.814Z' not to be '2026-09-02T12:32:04.814Z' // Object.is equality
 ❯ tests/clients/review-graph-seq-fastpath.test.ts:101:30
```

`review-graph.service.test.ts` (clock pinned, old `.builtAt` assertion):
```
FAIL  |default| tests/clients/review-graph.service.test.ts > review graph service > updates cached graph incrementally when only the changed file mtime shifts
AssertionError: expected '2026-09-02T12:32:39.151Z' not to be '2026-09-02T12:32:39.151Z' // Object.is equality
 ❯ tests/clients/review-graph.service.test.ts:755:30
```

### Mutation proofs (quoted verbatim, source reverted immediately after each)

`buildId` never incrementing (`builder.ts:5947`, `const buildId = _buildIdCounter;`):
```
FAIL  |default| tests/clients/review-graph/build-latch.test.ts > project_report retry claim (#1962) > reports the CURRENT attempt, not the frozen prior one
AssertionError: expected +0 not to be +0 // Object.is equality
 ❯ tests/clients/review-graph/build-latch.test.ts:310:48
```

`buildGeneration` never incrementing on real re-extract, plain incremental path (`builder.ts:5116`):
```
FAIL  |default| tests/clients/review-graph.service.test.ts > review graph service > updates cached graph incrementally when only the changed file mtime shifts
AssertionError: expected 1 not to be 1 // Object.is equality
 ❯ tests/clients/review-graph.service.test.ts:756:38
```

`buildGeneration` never incrementing on real re-extract, seq-fastpath path (`builder.ts:5329`):
```
FAIL  |default| tests/clients/review-graph-seq-fastpath.test.ts > review-graph seq fast path (#451) > takes the fast path after a hinted build when one file is edited
AssertionError: expected 1 not to be 1 // Object.is equality
 ❯ tests/clients/review-graph-seq-fastpath.test.ts:102:38
```

### Test assessment

- `tests/clients/review-graph/build-latch.test.ts` — pins the #1962 process-lifetime-latch dedupe/retry-claim contract; this PR's edit only repoints one assertion's identity field (`buildId` not `when`) and adds a deterministic clock pin. No test made redundant.
- `tests/clients/review-graph-seq-fastpath.test.ts` — pins the #451 seq-fastpath incremental rebuild contract (mode selection + content correctness); this PR's edit only repoints the "did it rebuild" assertion. No test made redundant.
- `tests/clients/review-graph.service.test.ts` — large multi-behavior service-level suite (impact cascade, incremental updates, etc.); this PR's edit touches one test's "did it rebuild" assertion only. No test made redundant.

## Blast radius

Touched: `clients/project-report.ts` (type-only — `ProjectReport.lastBuildAttempt` interface widened by one optional field, no runtime code path changed) and three test files. `module_report` blastRadius for `project-report.ts`: this module is a leaf consumer of `review-graph/builder.js`'s public API (`buildOrUpdateGraph`, `getLastReviewGraphBuildAttempt`, etc.) and exports `projectReport`/`ProjectReport`, consumed by `tools/project-report.ts` and the MCP mirror. No other module reads `ProjectReport.lastBuildAttempt.buildId` today (grepped `lastBuildAttempt` repo-wide: only `clients/project-report.ts`, `tests/clients/project-report.test.ts`, `tests/clients/review-graph/build-latch.test.ts` reference it), so this is additive with zero existing consumers to break. Not a hot path (project_report is a request-driven summarization call, not per-spawn/per-file/per-render).

## Observability

Not applicable — this is a test/type-only fix with no new runtime behavior, log record, or ledger entry. The thing this PR "proves works in production" is CI's own Unit tests job going green on this exact test file where it previously flaked; no new observability surface is introduced.

## Class sweep

Defect shape: a wall-clock ISO timestamp (`new Date().toISOString()`) compared with `.not.toBe`/`.toBe` as if it were a unique identity or ordering key for two events that can legitimately occur in the same millisecond, when a monotonic counter already exists on the same object/record and is the field that should be compared instead. AGENTS.md catalog: this is the same failure family as "a bound loose enough to pass a partial regression" (test-authoring screen 6) generalized to timestamp granularity, and adjacent to catalog shape 6 (a hand-maintained parallel of state a registry already tracks) in spirit — here the "registry" is the existing monotonic counter (`_buildIdCounter` / `_graphGenerationCounter`) and the test was hand-rolling its own weaker proxy (`when`/`builtAt`) instead of using it.

**Search performed:** `grep -rn "toISOString()" clients/ tools/ mcp/ scripts/ index.ts` (over 200 hits — mostly log/report timestamps: `ts`, `generatedAt`, `capturedAt`, `scannedAt`, `savedAt`, `lastSeen`/`lastEdit`/`lastUpdated`, `checkedAt`, `startedAt` — none of these are ever compared for identity/uniqueness anywhere in the tree, they're purely informational/display fields in log records and reports). Narrowed with a second grep for the actual hazard pattern — a test comparing a timestamp-shaped field for identity: `grep -rnE "\.(when|ts|timestamp|scannedAt|capturedAt|generatedAt|savedAt|lastSeen|lastEdit|lastUpdated|builtAt|startedAt|checkedAt)\)\.(not\.)?toBe\(" tests/ --include="*.test.ts"`.

**Findings, with verdict:**
- `tests/clients/review-graph/build-latch.test.ts:299` (`.when`) — same shape, THE reported bug, fixed here.
- `tests/clients/review-graph-seq-fastpath.test.ts:92` (`.builtAt`) — same shape, fixed here (→ `buildGeneration`).
- `tests/clients/review-graph.service.test.ts:744` (`.builtAt`) — same shape, fixed here (→ `buildGeneration`).
- `tests/clients/installer/managed-tool-refresh.test.ts:518` (`stamp.checkedAt`) — asserts EQUALITY to a fixed `NOW`, not "must differ from a sibling" — not a hazard.
- `tests/clients/instance-registry-multi-root.test.ts:161` (`after.startedAt`) — asserts stability (`toBe`, unchanged), not distinctness — a same-ms collision only makes this pass more easily; not a hazard.
- `tests/clients/instance-registry.test.ts:454`, `tests/scripts/latency-log-phases.test.ts:68` — compare against a hardcoded fixed ISO literal (test fixture data), not a second real timestamp — not a hazard.
- `tests/clients/lsp/workspace-diagnostics-cache-expiry.test.ts:169`, `tests/clients/opaque-mutation-scan.test.ts:179`, `tests/clients/recent-touches.test.ts:491` — compare a numeric `Date.now()`/session-clock value that the test itself controls/advances explicitly (test-owned fake clock), not two independently-raced wall-clock reads — not this hazard shape.
- `tests/clients/mutation-seam.test.ts:42`, `tests/clients/debug-handles.test.ts:97`, `tests/clients/debug-heap.test.ts:174`, `tests/clients/extension-log.test.ts:82` — assert only `typeof x === "string"/"number"`, never identity between two records — not a hazard.

**Production-side:** no `Map`/`Set` keyed on a timestamp string, and no sort comparator that orders solely by a wall-clock field without a secondary tiebreaker, was found in `clients/review-graph/builder.ts` or elsewhere in the searched trees — `recordBuildAttempt`'s own dedupe logic (`prior?.buildId !== undefined && buildId < prior.buildId`) already keys off `buildId`, never `when`, so production was never exposed to this hazard; only the public TYPE hid the field, and three tests independently reached for the weaker wall-clock proxy instead.

**Verdict:** class fully addressed — all three live instances fixed, all near-miss patterns checked and ruled out with a stated reason. No consolidation needed (no duplicated production seam to fold — the monotonic counters already existed; this was purely a test/type gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ4a3oS1UDFxs74fLm8U21
