### PR TITLE
fix(word-index): force deterministic yield in #2117 recompaction test (closes #2293)

### DIFF
--- a/.changelog/fix-2293-word-index-recompaction-flake.md
+++ b/.changelog/fix-2293-word-index-recompaction-flake.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **The #2117 arena-recompaction regression test no longer flakes on a scheduling accident (closes #2293)** — `compactPostingsIntoArenaCooperatively` (`clients/word-index-store.ts`) now takes an optional test-only `{ deadline, beforeYield }` seam; production still defaults to the real 8 ms wall-clock `createDeadline(8)`. The old test asserted `grewDuringYield === true`, but that flag was only true when the real cooperative copy happened to cross the 8 ms budget before finishing — a scheduling accident that a busy CI box (or a smaller corpus) could miss, tripping `expected false to be true` on an otherwise-correct fix (3 unrelated PRs paid for this: #2279, #2452, #2456). The rewritten test injects a deadline that expires deterministically on its first check and a `beforeYield` hook that grows the victim list in-line with the real cooperative pause, so the invariant — a list that grows mid-copy is never corrupted — is now proven under a forced yield instead of a hoped-for one.

--- a/clients/word-index-store.ts
+++ b/clients/word-index-store.ts
@@ -1,4 +1,8 @@
-import { createDeadline, yieldIfOverBudget } from "./cooperative-budget.js";
+import {
+	createDeadline,
+	yieldIfOverBudget,
+	type CooperativeDeadline,
+} from "./cooperative-budget.js";
 
 /**
  * Packed backing store for the word index's inverted postings (#2069).
@@ -271,9 +275,25 @@ export function compactPostingsIntoArena(
  *
  * Each `adoptArena` copies and re-homes one list within a single synchronous
  * step, so readers never observe a partially written list.
+ *
+ * `options.deadline` and `options.beforeYield` are a test seam only (#2293):
+ * production always takes the default 8 ms wall-clock deadline. The #2117
+ * regression test used to prove the "grew during a yield" invariant by racing
+ * a real timer against a 40,000-list copy, which made the yield itself a
+ * scheduling accident — the copy sometimes finished inside the 8 ms budget
+ * and never yielded at all, so the test's own precondition went unmet under
+ * load. Injecting a deadline lets a test force a yield deterministically
+ * instead of hoping wall-clock crosses the budget; `beforeYield` runs
+ * in-line, immediately before the real cooperative pause, so a test can
+ * mutate a not-yet-adopted list at that exact point with no reliance on
+ * event-loop scheduling order.
  */
 export async function compactPostingsIntoArenaCooperatively(
 	postings: Map<string, WordPostingList>,
+	options?: {
+		deadline?: CooperativeDeadline;
+		beforeYield?: () => void | Promise<void>;
+	},
 ): Promise<void> {
 	// Snapshot (token, list, width) in one synchronous pass; the arena is sized
 	// from these widths and only unchanged lists are adopted, so the sum of the
@@ -292,7 +312,7 @@ export async function compactPostingsIntoArenaCooperatively(
 	if (lanes === 0) return;
 	const arena = new Int32Array(lanes);
 	let offset = 0;
-	const deadline = createDeadline(8);
+	const deadline = options?.deadline ?? createDeadline(8);
 	for (const plan of planned) {
 		if (
 			postings.get(plan.token) === plan.list &&
@@ -301,7 +321,10 @@ export async function compactPostingsIntoArenaCooperatively(
 		) {
 			offset = plan.list.adoptArena(arena, offset);
 		}
-		if (deadline.expired()) await yieldIfOverBudget(deadline);
+		if (deadline.expired()) {
+			await options?.beforeYield?.();
+			await yieldIfOverBudget(deadline);
+		}
 	}
 }
 

--- a/tests/clients/word-index.test.ts
+++ b/tests/clients/word-index.test.ts
@@ -958,37 +958,49 @@ describe("triggerBackgroundWordIndexBuild (#348 cold-query stampede guard)", () 
 	// dropped the overflow so the tail postings read `undefined`. The fix skips
 	// any list that changed since the snapshot, so no posting is ever corrupted.
 	it("never corrupts postings when an edit grows a list mid-recompaction (#2117)", async () => {
-		// Enough lane data that the copy crosses the 8 ms budget and yields at
-		// least once — the window the concurrent edit needs.
+		// A sizeable corpus so the arena spans many lists, but the yield itself is
+		// no longer sized to cross a wall-clock budget — see the forced deadline
+		// below (#2293).
 		const postings = new Map<string, WordPostingList>();
-		const LISTS = 40_000;
-		const ENTRIES = 60;
+		const LISTS = 2_000;
+		const ENTRIES = 20;
 		for (let t = 0; t < LISTS; t += 1) {
 			const list = new WordPostingList(`token${t}`, ENTRIES);
 			for (let e = 0; e < ENTRIES; e += 1) list.push(t % 7, e);
 			postings.set(`token${t}`, list);
 		}
 		// The victim is inserted last, so the copy adopts it only at the very end;
-		// every yield gap lands before its adoption.
+		// the forced yield below lands well before its adoption.
 		const victim = new WordPostingList("victimToken", 1);
 		victim.push(3, 0);
 		postings.set("victimToken", victim);
 
-		const recompact = compactPostingsIntoArenaCooperatively(postings);
-		let settled = false;
-		void recompact.then(() => {
-			settled = true;
-		});
-		// Grow the victim in each yield gap until the copy finishes. On the
-		// pre-fix code the grown victim overruns its 1-entry arena slot.
+		// #2293: `grewDuringYield` used to be a PRECONDITION riding on the real
+		// 8 ms deadline actually crossing during the copy — true only when the
+		// scheduler let the copy run long enough to yield at least once before
+		// finishing, which a busy CI box or a smaller corpus could miss, failing
+		// the assertion below for a reason unrelated to the #2117 invariant. This
+		// deadline expires on its very first check (deterministically, before the
+		// victim's plan is reached, since the victim is last) and never expires
+		// again once reset — the real `CooperativeDeadline` contract, just driven
+		// by an explicit trigger instead of wall-clock time. `beforeYield` runs
+		// in-line with the production yield, so the growth is guaranteed to land
+		// mid-copy without racing a second concurrently-scheduled loop.
+		let usedOnce = false;
 		let grewDuringYield = false;
-		while (!settled) {
-			await new Promise<void>((resolve) => setImmediate(resolve));
-			if (!settled) {
+		const recompact = compactPostingsIntoArenaCooperatively(postings, {
+			deadline: {
+				expired: () => !usedOnce,
+				reset: () => {
+					usedOnce = true;
+				},
+			},
+			beforeYield: () => {
+				// On the pre-fix code the grown victim overruns its 1-entry arena slot.
 				victim.push(3, victim.length);
 				grewDuringYield = true;
-			}
-		}
+			},
+		});
 		await recompact;
 
 		expect(grewDuringYield).toBe(true);


### PR DESCRIPTION
## Summary

`tests/clients/word-index.test.ts`'s "never corrupts postings when an edit
grows a list mid-recompaction (#2117)" test flaked on Linux CI three times
against unrelated PRs (#2279, #2452, #2456), each time as
`AssertionError: expected false to be true` on `grewDuringYield`. Per the
#2456 round-2 review, `grewDuringYield` was a **precondition**, not the
guard: it is true only when the real 8 ms cooperative copy actually crosses
the wall-clock budget and yields before the 40,000-list copy finishes. On a
run where the copy happens to complete without ever crossing 8 ms (or
completes within a single 8 ms segment, before the test's own racing
`setImmediate` loop gets a turn), the assertion fails for a scheduling
reason that has nothing to do with the #2117 corruption invariant.

The fix makes the yield deterministic instead of hoped-for.
`compactPostingsIntoArenaCooperatively` (`clients/word-index-store.ts`) now
takes an optional test-only `{ deadline, beforeYield }` seam — production
still defaults to the real `createDeadline(8)`, so the production call site
(`clients/word-index.ts:479`) is unchanged. The rewritten test injects a
deadline that expires deterministically on its very first check (well
before the victim's plan, which is last in the snapshot) and a `beforeYield`
hook that grows the victim list in-line with the real cooperative pause —
no second, independently-scheduled `setImmediate` loop racing production's
own. The #2117 invariant itself (a list that grows mid-copy is never
corrupted) is unchanged and still enforced by production; only the test's
means of forcing a yield changed.

Closes #2293 — the flake's root cause is fixed and the invariant is proven
under a forced yield with a passing mutation-proof (see Tests).

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:tests
- [x] area:project-intelligence

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts` — N/A, this PR only adds an optional test-seam parameter to an existing exported function; `npm run build` (the tsconfig.build.json project) passes clean, and `dist/` is not touched by this change's review surface
- [x] `package-lock.json` is in sync with `package.json` (run `npm install` after dep changes) — no dependency changes in this PR
- [ ] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there — no behavior/invariant change (the #2117 invariant text in AGENTS.md's project-intelligence section is still accurate); only a test-authoring seam was added
- [x] `.changelog/fix-2293-word-index-recompaction-flake.md` has one valid entry in this PR
- [x] Commit subject includes the issue number: `fix(word-index): force deterministic yield in #2117 recompaction test` — `Refs #2293` in the body trailer

## Tests

- **`tests/clients/word-index.test.ts`** — rewrote the ONE test in scope,
  "never corrupts postings when an edit grows a list mid-recompaction
  (#2117)" (same `it` name, same invariant). It no longer races two
  independent `setImmediate` loops against each other; it injects a
  deterministic `deadline` (expires on its first check, never again once
  `reset()` fires — the real `CooperativeDeadline` contract, just driven by
  an explicit trigger instead of wall-clock time) and a `beforeYield` hook
  that grows the victim list in-line with the real cooperative pause, called
  by production itself immediately before its real `setImmediate`-based
  yield. Corpus shrunk from 40,000×60 to 2,000×20 postings — no longer
  needed to cross a wall-clock budget, since the yield is now forced;
  kept large enough that the arena still spans many lists ahead of the
  victim (last in the snapshot). This satisfies AGENTS.md's test-authoring
  screen 6 (bound/precondition tied to a real, independently-verified
  contract rather than a round number) and generalizes the existing
  "LSP acquisition-race tests suspend the initialize/create-client seam...
  do not use timing sleeps" rule to this seam.
- No other test file in the whole `tests/` tree carries this defect shape —
  see Class sweep below.

### Red-first proof

**(a) Pre-fix code is timing-dependent.** I could not get the unmodified
`grewDuringYield` assertion to flake at its authored 40,000×60 corpus size
on this dev box across 60 runs total (30 runs at a modest 4-worker CPU-busy
sibling load, 30 more at a heavier 28-worker load pinning most of a 32-core
box) — consistent with the issue's own note that local reproduction had not
been achieved either. Direct timing (`performance.now()` around the real
pre-fix `compactPostingsIntoArenaCooperatively` call, no racing test loop)
showed the 40,000×60 copy always took 26-28 ms on this hardware — comfortably
inside the "yields several times" zone, never near the single-segment
boundary that trips the bug.

I then calibrated the SAME pre-fix racing-loop test structure (byte-for-byte
identical assertions and race logic, only `LISTS`/`ENTRIES` changed) down to
find this box's own timing boundary and reproduced the exact CI failure
mode. At `LISTS=30000, ENTRIES=20` (same production code, same assertions,
same `AssertionError` message), running the pre-fix racing structure showed
genuine non-determinism across separate process invocations — a mixed run
(quoted below) and a fully-red run, matching CI's "occasional flake among
many green runs" pattern:

```
$ REPRO_LISTS=30000 REPRO_ENTRIES=20 node repro-2293.mjs 15
run 1: PASS
run 2: FAIL - expected false to be true (grewDuringYield)

false !== true

run 3: PASS
run 4: FAIL - expected false to be true (grewDuringYield)

false !== true
run 5: PASS
run 6: FAIL - expected false to be true (grewDuringYield)

false !== true
run 7: PASS
run 8: FAIL - expected false to be true (grewDuringYield)

false !== true
run 9: PASS
...
total fails: 4 / 15
```

and, at the same calibration on a fresh process start, a fully-deterministic
red across all 30 runs:

```
$ REPRO_LISTS=30000 REPRO_ENTRIES=20 node repro-2293.mjs 30
run 1: FAIL - expected false to be true (grewDuringYield)

false !== true
...
run 30: FAIL - expected false to be true (grewDuringYield)

false !== true
total fails: 30 / 30
```

`repro-2293.mjs` was a throwaway harness (deleted before push) that ran the
pre-fix test's exact race/assertion logic directly against the compiled
pre-fix `clients/word-index-store.js`, to iterate faster than 30 full
`vitest` boots per calibration point while exercising the identical
production code path and identical `expect(grewDuringYield).toBe(true)`
assertion that failed in CI. This is the same defect class as the CI
failures — a scheduling accident, not the #2117 invariant — reproduced
mechanistically rather than by luck.

**(b) Post-fix, 30× green under the same CPU load.** With the fix
(deterministic `deadline`/`beforeYield` seam) and a 28-worker CPU-busy
sibling running concurrently:

```
$ npm run test:targeted -- tests/clients/word-index.test.ts -t "never corrupts postings"   (×30, looped)
run 1: PASS
run 2: PASS
...
run 30: PASS
total fails: 0 / 30
```

**(c) Mutation proof.** Temporarily reverted `compactPostingsIntoArenaCooperatively`'s copy loop to the exact original #2117 bug shape (adopt every list unconditionally at its CURRENT width, no skip-if-changed check — verbatim from commit `70dd666c`, the pre-#2117-fix version), keeping the new seam. Rebuilt and ran the NEW deterministic test:

```
 FAIL  |default| tests/clients/word-index.test.ts > triggerBackgroundWordIndexBuild (#348 cold-query stampede guard) > never corrupts postings when an edit grows a list mid-recompaction (#2117)
AssertionError: expected 1 to be +0 // Object.is equality

- Expected
+ Received

- 0
+ 1

 ❯ tests/clients/word-index.test.ts:1015:27
   1013|    }
   1014|   }
   1015|   expect(corruptPostings).toBe(0);
      |                           ^
   1016|  }, 30_000);
```

Reverted the mutation (`git checkout HEAD -- clients/word-index-store.ts`),
rebuilt, confirmed green again.

### Test assessment

- `tests/clients/word-index.test.ts` — one test rewritten in place (same
  name, same invariant, same `it` position). No test in this file becomes
  redundant; every other test in the file is unrelated to this seam.

## Blast radius

`compactPostingsIntoArenaCooperatively` has exactly one production call
site, `clients/word-index.ts:479` (`recompactWordIndexPostingsIfNeeded`'s
cooperative arena repack), which calls it with no second argument — the new
`options` parameter is additive and optional, so production behavior and
its call site are byte-for-byte unchanged. Grepped `clients/`, `tools/`,
`mcp/`, `scripts/`, `index.ts` for the symbol; the only other reference is
the test file. No dependents beyond the one already-covered call site.

## Observability

No production behavior changed — the `word-index-arena-recompact`
degradation-ledger entry (AGENTS.md project-intelligence section) that
already covers this seam is untouched. Test-only change; not applicable
beyond the suite itself.

## Class sweep

**Shape:** a test asserts a boolean PRECONDITION (`expect(x).toBe(true)`)
that is only true when a real cooperative `createDeadline`/`yieldIfOverBudget`
wall-clock budget actually crosses during a bulk operation, instead of
forcing the yield deterministically — AGENTS.md's Test-authoring screens
intro ("LSP acquisition-race tests... do not use timing sleeps") and
catalog shape 7 (vacuous/timing-dependent fixture) both cover this class.

Swept the whole tree for the pattern (`while (!settled)` / `grewDuring` /
"at least once" / "crosses the ... budget" combined with
`createDeadline`/`yieldIfOverBudget`/`setImmediate` usage in `tests/`):

- `tests/clients/word-index-superseded-during-rebuild.test.ts` — uses
  `yieldIfOverBudget` as an injected mock function directly (`vi.fn`), not a
  wall-clock race; already deterministic, not this shape.
- `tests/clients/review-graph-superseded-persist.test.ts` — suspends at the
  real cooperative `setImmediate` seam via `vi.spyOn(globalThis, "setImmediate")`,
  a controlled interception, not a wall-clock race against an independent
  `setImmediate` loop; already deterministic, not this shape.
- No other file in `tests/` combines a `createDeadline`-backed cooperative
  budget with a racing `setImmediate` loop and a boolean "did it yield"
  assertion.

**Verdict:** class of size 1 — this was the only instance. No further
consolidation needed; the new `{ deadline, beforeYield }` seam pattern on
`compactPostingsIntoArenaCooperatively` is available if a future
cooperative-copy test needs the same determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ4a3oS1UDFxs74fLm8U21
