### PR TITLE
refactor(observability): one process-table seam for clients/ and scripts/ (closes #2443)

### DIFF
--- a/.changelog/2443-process-table-seam.md
+++ b/.changelog/2443-process-table-seam.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **One process-table seam replaces five hand-rolled snapshotters (closes #2443)** — the Windows `Get-CimInstance Win32_Process` and POSIX `ps` listings used by the orphan reaper, the resource sampler, the worktree-hygiene hook and the compat smoke are now composed and parsed in a single place, `scripts/lib/process-scan.mjs`, with a `fields` projection covering pid, parent pid, age, RSS, kernel/user CPU time, start time and command line, plus platform-side filtering that reports whether it was actually applied. `clients/process-snapshot.ts` is the one crossing point into the extension runtime and keeps its own spawn rails (unref'd child and stdout, an injected tree-kill-and-verify timeout handler, and a status that keeps an empty table distinguishable from a query that never ran). A conformance sweep fails the build if a second file ever spells one of these queries again, so hardening like PR #2438's non-zero-exit check can no longer reach one copy and miss the rest.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1719,6 +1719,31 @@ anywhere else on a command line is a reader, not an occupant; kills are by
 pid, never `taskkill`-by-name. All of that is pure and unit-tested in
 `scripts/lib/worktree-hygiene.mjs`.
 
+**One process-table seam, in scripts/ (#2443).** Every Windows
+`Get-CimInstance Win32_Process` and POSIX `ps` listing in this repo is
+composed and parsed in ONE place, `scripts/lib/process-scan.mjs`:
+`buildProcessQuery(fields, {filter, excludeSelfPid})` builds the command,
+`parseProcessTable` reads it back, and a `fields` projection (`pid`, `ppid`,
+`ageMs`, `rssBytes`, `cpuKernel100ns`, `cpuUser100ns`, `startedAt`,
+`command`) is how a caller asks for the columns it needs. There used to be
+five copies — the instance reaper's three queries, the resource sampler's two,
+and the two scripts — which is how PR #2438's exit-code hardening (a `ps` that
+prints a partial table then dies must not read as complete) reached one and
+not the rest. `tests/config/process-table-seam.test.ts` fails on any second
+file that spells the query.
+
+The seam lives in `scripts/` and NOT in `clients/` on purpose: `clients/*.js`
+is gitignored build output, and `scripts/prune-agent-worktrees.mjs` runs as a
+SessionStart/SubagentStop hook inside freshly created agent worktrees, which
+have neither `node_modules` nor a build. clients/ reaches it through the ONE
+crossing point, `clients/process-snapshot.ts`, which adds the extension's own
+spawn rails (unref'd child + stdout, injected tree-kill-and-verify timeout
+handler, a `SpawnCollectStatus` so an empty table stays distinguishable from
+a query that never ran). Because tsc resolves the `.mjs` through its
+`.d.mts` and would emit nothing, `tsconfig.dist.json` names the file in
+`include` with `allowJs` — without that, `bundle:dist` cannot resolve the
+import (pinned in `tests/packaging.test.ts`).
+
 **Idle is measured from signals the sweep does not write.** A worktree's age
 comes from `WORKTREE_ACTIVITY_SIGNALS` — the checkout directory's mtime, the
 worktree's `<admin>/HEAD` mtime, and the last entry timestamp in

--- a/clients/instance-reaper.ts
+++ b/clients/instance-reaper.ts
@@ -74,10 +74,8 @@ import {
 } from "./atomic-write-staging.js";
 import { acquireQuarantinePidFileLock } from "./bounded-pid-file-lock.js";
 import {
-	type SpawnCollectResult,
 	type SpawnCollectStatus,
 	type SpawnTimeoutKill,
-	spawnCollectStdoutResult,
 	unrefChildAndPipes,
 } from "./child-unref.js";
 import {
@@ -92,6 +90,7 @@ import {
 	readInstanceRegistry,
 } from "./instance-registry.js";
 import { logLatency } from "./latency-logger.js";
+import { queryProcessTable, windowsExe } from "./process-snapshot.js";
 
 const isWindows = process.platform === "win32";
 
@@ -347,36 +346,14 @@ export async function sweepAtomicWriteStages(
 	return sweepOwnStagingFiles(directories, { maxEntries, isPidAlive });
 }
 
-export function windowsExe(name: string): string {
-	return path.join(
-		process.env.SystemRoot ?? String.raw`C:\Windows`,
-		"System32",
-		name,
-	);
-}
-
-/** Resolve an absolute path to `ps` (S4036: never spawn via bare PATH lookup).
- *  Prefers `/bin/ps` (present on virtually every POSIX system), falls back to
- *  `/usr/bin/ps`, and defaults back to `/bin/ps` if neither probe succeeds
- *  (spawn will then fail closed rather than silently resolving via PATH). */
-function posixPsPath(): string {
-	if (fs.existsSync("/bin/ps")) return "/bin/ps";
-	if (fs.existsSync("/usr/bin/ps")) return "/usr/bin/ps";
-	return "/bin/ps";
-}
-
-/** Escape a value for embedding in a WQL LIKE clause: WQL uses `'` as the
- *  string delimiter (doubled to escape) and `%`/`_` as wildcards — the marker
- *  is an opaque path string, so escape all three before interpolating. */
-function escapeWqlLikeValue(value: string): string {
-	return value.replaceAll("'", "''").replaceAll(/[%_]/g, (ch) => `[${ch}]`);
-}
-
-/** Escape a value for a WQL EQUALITY comparison: only the string delimiter
- *  needs escaping — `%`/`_` are literal outside `LIKE`. */
-function escapeWqlStringValue(value: string): string {
-	return value.replaceAll("'", "''");
-}
+/**
+ * Interpreter resolution, WQL escaping and the platform listing itself all
+ * live in the ONE process-table seam (#2443): `scripts/lib/process-scan.mjs`,
+ * reached from clients/ through `clients/process-snapshot.ts`. This file used
+ * to carry its own copy of each, which is how the three queries below drifted
+ * apart from the two in `clients/resource-sampler.ts` and the two in
+ * `scripts/`. `windowsExe` is re-exported by the seam and imported above.
+ */
 
 /** Search running processes whose command line contains `marker` (Windows,
  *  via CIM/WQL). Returns matching pids. Best-effort: any failure ⇒ [], but a
@@ -385,18 +362,14 @@ function escapeWqlStringValue(value: string): string {
  *  tells them apart. */
 async function findPidsByMarkerWindows(marker: string): Promise<number[]> {
 	if (!isWindows || !marker) return [];
-	const escaped = escapeWqlLikeValue(marker);
-	// $PID exclusion: the query's own powershell.exe command line embeds the
-	// marker string, so it would match itself.
-	const psScript =
-		`Get-CimInstance Win32_Process -Filter "CommandLine LIKE '%${escaped}%'" ` +
-		`| Where-Object { $_.ProcessId -ne $PID } ` +
-		`| Select-Object -ExpandProperty ProcessId`;
-	const powershell = windowsExe("WindowsPowerShell\\v1.0\\powershell.exe");
-	const result = await spawnCollectStdoutResult(
-		powershell,
-		["-NoProfile", "-NonInteractive", "-Command", psScript],
-		{ shell: false, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] },
+	const result = await queryProcessTable(
+		{
+			fields: ["pid"],
+			filter: { column: "CommandLine", op: "like", values: [marker] },
+			// The query's own powershell.exe command line embeds the marker, so
+			// without this exclusion the search matches itself.
+			excludeSelfPid: true,
+		},
 		{ timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS },
 	);
 	if (result.status !== "ok") {
@@ -406,10 +379,7 @@ async function findPidsByMarkerWindows(marker: string): Promise<number[]> {
 			reason: `marker command-line search ${result.status}`,
 		});
 	}
-	return result.stdout
-		.split(/\r?\n/)
-		.map((line) => Number(line.trim()))
-		.filter((n) => Number.isFinite(n) && n > 0);
+	return result.rows.map((row) => row.pid);
 }
 
 /** Fetch command lines for a set of pids in one query (Windows: CIM; POSIX:
@@ -426,62 +396,27 @@ async function queryCommandLines(pids: number[]): Promise<Map<number, string>> {
 	const valid = [...new Set(pids.filter((p) => Number.isFinite(p) && p > 0))];
 	const map = new Map<number, string>();
 	if (valid.length === 0) return map;
-	const noteFailure = (status: SpawnCollectStatus) => {
-		if (status === "ok") return;
+	const result = await queryProcessTable(
+		{
+			fields: ["pid", "command"],
+			filter: { column: "ProcessId", op: "eq", values: valid },
+		},
+		{ timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS },
+	);
+	// POSIX `ps -p` exits nonzero when NONE of the requested pids exist, which
+	// is a legitimate clean result for this caller, so that one status is not
+	// recorded on that platform. The shared collector calls it an exit failure;
+	// this caller's command contract makes it the expected empty table. Windows
+	// CIM has no such convention, so an exit failure there is a real failure.
+	const psReportedNoSuchPid = !isWindows && result.status === "exit-error";
+	if (result.status !== "ok" && !psReportedNoSuchPid) {
 		recordDegradationOnce({
 			kind: "orphan-backstop-scan-failed",
 			subject: "identity-query",
-			reason: `command-line identity query ${status}; reap suppressed this sweep`,
+			reason: `command-line identity query ${result.status}; reap suppressed this sweep`,
 		});
-	};
-	if (isWindows) {
-		const filter = valid.map((p) => `ProcessId=${p}`).join(" OR ");
-		const psScript =
-			`Get-CimInstance Win32_Process -Filter "${filter}" ` +
-			`| ForEach-Object { "$($_.ProcessId)\t$($_.CommandLine)" }`;
-		const powershell = windowsExe("WindowsPowerShell\\v1.0\\powershell.exe");
-		const result = await spawnCollectStdoutResult(
-			powershell,
-			["-NoProfile", "-NonInteractive", "-Command", psScript],
-			{ shell: false, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] },
-			{ timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS },
-		);
-		noteFailure(result.status);
-		for (const line of result.stdout.split(/\r?\n/)) {
-			const tab = line.indexOf("\t");
-			if (tab <= 0) continue;
-			const pid = Number(line.slice(0, tab).trim());
-			if (Number.isFinite(pid) && pid > 0) map.set(pid, line.slice(tab + 1));
-		}
-		return map;
 	}
-	const result = await spawnCollectStdoutResult(
-		posixPsPath(),
-		["-p", valid.join(","), "-o", "pid=,args="],
-		{ shell: false, stdio: ["ignore", "pipe", "ignore"] },
-		{ timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS },
-	);
-	// `ps -p` exits nonzero when NONE of the pids exist, which is a legitimate
-	// clean result here, so only spawn/timeout failures are recorded. The
-	// shared collector calls that an exit failure, but this caller's command
-	// contract makes that status the expected empty-table result.
-	if (result.status !== "exit-error") noteFailure(result.status);
-	for (const line of result.stdout.split(/\r?\n/)) {
-		// Linear parse (S8786/S6594: avoid regex backtracking on
-		// attacker-lengthenable ps output) — trim leading whitespace,
-		// then split on the first whitespace run: "  1234 args here".
-		const trimmed = line.trimStart();
-		if (!trimmed) continue;
-		let i = 0;
-		while (i < trimmed.length && trimmed[i] >= "0" && trimmed[i] <= "9") i++;
-		if (i === 0) continue;
-		const pidStr = trimmed.slice(0, i);
-		let j = i;
-		while (j < trimmed.length && (trimmed[j] === " " || trimmed[j] === "\t"))
-			j++;
-		const pid = Number(pidStr);
-		if (Number.isFinite(pid) && pid > 0) map.set(pid, trimmed.slice(j));
-	}
+	for (const row of result.rows) map.set(row.pid, row.command);
 	return map;
 }
 
@@ -805,9 +740,10 @@ export function partitionBackstopCandidates(
 
 /** Enumerate live OS processes whose command line contains one of
  *  `MANAGED_BINARY_NAMES` (#658), independent of the instance registry.
- *  Windows: one batched CIM/WQL query (mirrors `findPidsByMarkerWindows`'s
- *  query pattern). POSIX: `ps -eo pid=,ppid=,args=`, filtered in JS. Returns
- *  `{pid, parentPid, command}` rows. Best-effort: any failure ⇒ []. */
+ *  One projected process-table query through the shared seam, narrowed to
+ *  managed binaries in JS; returns `{pid, parentPid, command, ageMs}` rows.
+ *  Best-effort: any failure ⇒ [], with the scan status carried alongside so
+ *  an empty table is never mistaken for a scan that did not run. */
 async function enumerateManagedProcesses(
 	options: {
 		timeoutMs?: number;
@@ -815,99 +751,37 @@ async function enumerateManagedProcesses(
 		verifyIntervalMs?: number;
 	} = {},
 ): Promise<ManagedProcessScan> {
-	const timeoutMs = options.timeoutMs ?? BACKSTOP_SCAN_TIMEOUT_MS;
-	const collect = {
-		timeoutMs,
-		onTimeout: (child: ChildProcess) => terminateScannerChild(child, options),
-	};
-	if (isWindows) {
-		// #1857: `Name = '…'` equality replaces eight leading-wildcard
-		// `CommandLine LIKE '%…%'` clauses, and the query now also projects
-		// `CreationDate` so the spawn-grace guard has an age to work with. The
-		// image-name set is DERIVED from MANAGED_BINARIES (MANAGED_IMAGE_NAMES),
-		// so adding a managed binary cannot leave a stale parallel list behind.
-		const clauses = MANAGED_IMAGE_NAMES.map(
-			(name) => `Name = '${escapeWqlStringValue(name)}'`,
-		).join(" OR ");
-		// The age column is computed IN PowerShell as a millisecond delta, not
-		// exported as `CreationDate.Ticks`. `Ticks` is the LOCAL-time
-		// representation, so subtracting the Unix epoch in JS produced an age
-		// wrong by the machine's UTC offset — measured on a UTC+3 host as
-		// -8358s for a process started 40 minutes earlier. A delta computed on
-		// one side of the boundary has no timezone to get wrong. The explicit
-		// `[datetime]` test matters: `(Get-Date) - $null` yields a two-thousand
-		// year TimeSpan, which would read as "ancient" and defeat the grace
-		// guard exactly where the data is missing.
-		const psScript =
-			`Get-CimInstance -Query "SELECT ProcessId,ParentProcessId,CreationDate,CommandLine FROM Win32_Process WHERE ${clauses}" ` +
-			`| ForEach-Object { $age = if ($_.CreationDate -is [datetime]) { [int64]((Get-Date) - $_.CreationDate).TotalMilliseconds } else { '' }; ` +
-			`"$($_.ProcessId)\t$($_.ParentProcessId)\t$age\t$($_.CommandLine)" }`;
-		const powershell = windowsExe("WindowsPowerShell\\v1.0\\powershell.exe");
-		const result = await spawnCollectStdoutResult(
-			powershell,
-			["-NoProfile", "-NonInteractive", "-Command", psScript],
-			{ shell: false, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] },
-			collect,
-		);
-		const processes: OsProcessInfo[] = [];
-		for (const line of result.stdout.split(/\r?\n/)) {
-			const firstTab = line.indexOf("\t");
-			if (firstTab <= 0) continue;
-			const secondTab = line.indexOf("\t", firstTab + 1);
-			if (secondTab <= 0) continue;
-			const thirdTab = line.indexOf("\t", secondTab + 1);
-			if (thirdTab <= 0) continue;
-			const pid = Number(line.slice(0, firstTab).trim());
-			const parentPid = Number(line.slice(firstTab + 1, secondTab).trim());
-			const ageMs = parseNonNegativeMs(line.slice(secondTab + 1, thirdTab));
-			const command = line.slice(thirdTab + 1);
-			if (!Number.isFinite(pid) || pid <= 0) continue;
-			processes.push({ pid, parentPid, command, ageMs });
-		}
-		return narrowToManagedBinaries(processes, result);
-	}
-	// POSIX: enumerate everything, filter in JS by managed-name substring —
-	// there is no single-query WQL-style server-side filter available.
-	// `etime` is the POSIX-standard elapsed-time column (Linux and macOS both
-	// support it; `etimes` is Linux-only), and supplies the spawn-grace age.
-	const result = await spawnCollectStdoutResult(
-		posixPsPath(),
-		[...POSIX_PS_ARGS],
-		{ shell: false, stdio: ["ignore", "pipe", "ignore"] },
-		collect,
+	// #1857: `Name = '…'` equality replaces eight leading-wildcard
+	// `CommandLine LIKE '%…%'` clauses, and the projection carries an age so
+	// the spawn-grace guard has something to reason from. The image-name set is
+	// DERIVED from MANAGED_BINARIES (MANAGED_IMAGE_NAMES), so adding a managed
+	// binary cannot leave a stale parallel list behind.
+	//
+	// POSIX `ps` cannot express that filter — the seam reports it as
+	// `serverSideFiltered: false` and hands back the whole table — which is why
+	// `narrowToManagedBinaries` runs on BOTH platforms rather than only on the
+	// POSIX branch. Windows over-collects for its own reason anyway
+	// (`node.exe` is a superset image name covering every node process on the
+	// machine).
+	const result = await queryProcessTable(
+		{
+			fields: ["pid", "ppid", "ageMs", "command"],
+			filter: { column: "Name", op: "eq", values: MANAGED_IMAGE_NAMES },
+		},
+		{
+			timeoutMs: options.timeoutMs ?? BACKSTOP_SCAN_TIMEOUT_MS,
+			onTimeout: (child: ChildProcess) => terminateScannerChild(child, options),
+		},
 	);
-	const processes: OsProcessInfo[] = [];
-	for (const line of result.stdout.split(/\r?\n/)) {
-		// Linear parse (S8786/S6594): "  pid ppid etime args here".
-		const trimmed = line.trimStart();
-		if (!trimmed) continue;
-		let i = 0;
-		while (i < trimmed.length && trimmed[i] >= "0" && trimmed[i] <= "9") i++;
-		if (i === 0) continue;
-		const pid = Number(trimmed.slice(0, i));
-		let rest = trimmed.slice(i);
-		let k = 0;
-		while (k < rest.length && (rest[k] === " " || rest[k] === "\t")) k++;
-		rest = rest.slice(k);
-		let j = 0;
-		while (j < rest.length && rest[j] >= "0" && rest[j] <= "9") j++;
-		if (j === 0) continue;
-		const parentPid = Number(rest.slice(0, j));
-		rest = rest.slice(j);
-		let m = 0;
-		while (m < rest.length && (rest[m] === " " || rest[m] === "\t")) m++;
-		rest = rest.slice(m);
-		// etime token: a non-whitespace run of digits, ':' and '-'.
-		let e = 0;
-		while (e < rest.length && rest[e] !== " " && rest[e] !== "\t") e++;
-		const ageMs = ageMsFromPosixEtime(rest.slice(0, e));
-		let n = e;
-		while (n < rest.length && (rest[n] === " " || rest[n] === "\t")) n++;
-		const args = rest.slice(n);
-		if (!Number.isFinite(pid) || pid <= 0) continue;
-		processes.push({ pid, parentPid, command: args, ageMs });
-	}
-	return narrowToManagedBinaries(processes, result);
+	return narrowToManagedBinaries(
+		result.rows.map((row) => ({
+			pid: row.pid,
+			parentPid: row.ppid,
+			command: row.command,
+			ageMs: row.ageMs,
+		})),
+		result,
+	);
 }
 
 /**
@@ -920,7 +794,7 @@ async function enumerateManagedProcesses(
  */
 function narrowToManagedBinaries(
 	processes: OsProcessInfo[],
-	result: SpawnCollectResult,
+	result: { status: SpawnCollectStatus; timeoutKill?: SpawnTimeoutKill },
 ): ManagedProcessScan {
 	return {
 		processes: processes.filter((proc) => matchesManagedBinary(proc.command)),
@@ -982,52 +856,6 @@ function matchesManagedBinary(command: string): boolean {
 	return MANAGED_BINARY_NAMES.some((name) =>
 		lower.includes(name.toLowerCase()),
 	);
-}
-
-/**
- * Parse the Windows age column: a non-negative integer millisecond count, or
- * anything else. A negative or malformed value is `undefined`, not zero and
- * not a clamp — a nonsensical age means the age is UNKNOWN, and the grace
- * guard must spare an unknown-age process rather than reason from a number it
- * cannot trust. That rule is what surfaced the local-time tick bug during the
- * host probe instead of silently sparing everything.
- */
-function parseNonNegativeMs(raw: string): number | undefined {
-	const token = raw.trim();
-	if (!/^\d+$/.test(token)) return undefined;
-	const value = Number(token);
-	return Number.isFinite(value) ? value : undefined;
-}
-
-/**
- * POSIX enumeration columns. Exported so a real-`ps` test can assert this
- * exact argument vector is accepted by the host's `ps` — a rejected column
- * would make the whole backstop silently return zero rows, and this is the
- * one part of the fix that cannot be checked from a Windows dev machine.
- */
-export const POSIX_PS_ARGS: readonly string[] = [
-	"-eo",
-	"pid=,ppid=,etime=,args=",
-];
-
-/** Parse `ps -o etime` output: `[[dd-]hh:]mm:ss`. Returns undefined for any
- *  shape the column did not produce (a `ps` without the column emits the
- *  command line where the token was expected). */
-export function ageMsFromPosixEtime(raw: string): number | undefined {
-	const token = raw.trim();
-	if (!/^(?:\d+-)?(?:\d+:)?\d+:\d+$/.test(token)) return undefined;
-	let days = 0;
-	let rest = token;
-	const dash = rest.indexOf("-");
-	if (dash >= 0) {
-		days = Number(rest.slice(0, dash));
-		rest = rest.slice(dash + 1);
-	}
-	const parts = rest.split(":").map(Number);
-	if (parts.some((part) => !Number.isFinite(part))) return undefined;
-	const [hours, minutes, seconds] =
-		parts.length === 3 ? parts : [0, parts[0], parts[1]];
-	return ((days * 24 + hours) * 60 * 60 + minutes * 60 + seconds) * 1000;
 }
 
 /**

--- a/clients/process-snapshot.ts
+++ b/clients/process-snapshot.ts
@@ -1,0 +1,129 @@
+/**
+ * The extension runtime's door onto the ONE process-table seam (#2443).
+ *
+ * `scripts/lib/process-scan.mjs` owns what a process listing IS: the field →
+ * platform-column table, the Windows CIM/WQL and POSIX `ps` command
+ * composition, the WQL escaping, and the row parser. This module owns how
+ * clients/ RUNS one, which is genuinely different from how a script runs one
+ * and stays different on purpose:
+ *
+ * - the child and its stdout pipe are `unref`'d (#1155) so a one-shot
+ *   `pi --print` can settle without waiting on a CIM query;
+ * - a child that blows its timeout is terminated through the caller's own
+ *   tree-kill-and-verify machinery (#1864 F3), injected as `onTimeout` — a
+ *   sweep that leaks its own scanner is the defect the sweep exists to fix;
+ * - the outcome carries a `SpawnCollectStatus`, so "the table is empty" and
+ *   "the query never ran" stay distinguishable and the caller can record the
+ *   degradation (#1857).
+ *
+ * WHY THE SEAM IS IMPORTED FROM scripts/ RATHER THAN LIVING HERE: the .mjs
+ * header argues it in full. Short version — `scripts/prune-agent-worktrees.mjs`
+ * is a SessionStart/SubagentStop hook that runs inside freshly created agent
+ * worktrees, where `clients/*.js` (gitignored build output) does not exist
+ * yet, so the shared half has to be the side that needs no build. This file
+ * is the single crossing point; nothing else in clients/ imports scripts/.
+ */
+
+import type { ChildProcess } from "node:child_process";
+import {
+	type SpawnCollectStatus,
+	type SpawnTimeoutKill,
+	spawnCollectStdoutResult,
+} from "./child-unref.js";
+import {
+	buildProcessQuery,
+	parseProcessTable,
+	type ProcessField,
+	type ProcessFilter,
+	type ProcRow,
+} from "../scripts/lib/process-scan.mjs";
+
+export type {
+	ProcessField,
+	ProcessFilter,
+	ProcRow,
+} from "../scripts/lib/process-scan.mjs";
+/**
+ * Re-exported, not redefined. `windowsExe` resolves an absolute System32
+ * interpreter path for a spawn this process is about to make (a bare
+ * `powershell.exe`/`taskkill.exe` is resolvable through a PATH a caller can
+ * shadow, and these spawns decide what gets killed) — one definition of that
+ * rule is the whole point of the seam.
+ */
+export { windowsExe } from "../scripts/lib/process-scan.mjs";
+
+export interface ProcessTableRequest {
+	/** Columns to project. `pid` is always included. */
+	fields: readonly ProcessField[];
+	/** Optional platform-side narrowing; see `serverSideFiltered` below. */
+	filter?: ProcessFilter;
+	/** Windows only: exclude the querying powershell.exe itself. */
+	excludeSelfPid?: boolean;
+}
+
+export interface ProcessTableOptions {
+	/** Hard wall-clock bound on the listing child. */
+	timeoutMs: number;
+	/**
+	 * How to terminate a child that blew `timeoutMs`. Omitted means
+	 * `child-unref.ts`'s default single unverified signal; callers that own a
+	 * tree-kill (the reaper, the sampler) pass theirs.
+	 */
+	onTimeout?: (child: ChildProcess) => Promise<SpawnTimeoutKill>;
+}
+
+export interface ProcessTableResult {
+	rows: ProcRow[];
+	/** `ok` only when the child ran AND exited zero. Anything else means the
+	 *  rows are partial at best, and an absence from them is not evidence. */
+	status: SpawnCollectStatus;
+	exitCode?: number | null;
+	timeoutKill?: SpawnTimeoutKill;
+	/**
+	 * Whether the platform applied `filter` itself. False means the caller
+	 * holds the WHOLE table and must narrow it in JS — the POSIX case for a
+	 * `Name`/`CommandLine` filter, which `ps` cannot express.
+	 */
+	serverSideFiltered: boolean;
+}
+
+/**
+ * Run one process-table query on the extension's spawn rails.
+ *
+ * Never throws and never rejects: an unbuildable query (a Windows-only column
+ * asked for on POSIX, an empty filter) resolves as `spawn-error` with no rows,
+ * the same shape every other failure takes, because every caller here is
+ * best-effort instrumentation or a best-effort sweep.
+ */
+export async function queryProcessTable(
+	request: ProcessTableRequest,
+	options: ProcessTableOptions,
+): Promise<ProcessTableResult> {
+	let query: ReturnType<typeof buildProcessQuery>;
+	try {
+		query = buildProcessQuery(request.fields, {
+			filter: request.filter,
+			excludeSelfPid: request.excludeSelfPid,
+		});
+	} catch {
+		return { rows: [], status: "spawn-error", serverSideFiltered: false };
+	}
+	const result = await spawnCollectStdoutResult(
+		query.command,
+		query.args,
+		{ shell: false, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] },
+		{ timeoutMs: options.timeoutMs, onTimeout: options.onTimeout },
+	);
+	return {
+		// Whatever the collector kept is parsed rather than discarded here: it
+		// drops stdout on a non-zero exit (that output is not evidence of what
+		// is NOT running) but KEEPS the partial table from a timed-out child,
+		// and the caller decides what a partial table is worth by reading
+		// `status`. Re-deciding that here would be a second policy.
+		rows: parseProcessTable(result.stdout, query.tabSeparated, query.fields),
+		status: result.status,
+		exitCode: result.exitCode,
+		timeoutKill: result.timeoutKill,
+		serverSideFiltered: query.serverSideFiltered,
+	};
+}

--- a/clients/resource-sampler.ts
+++ b/clients/resource-sampler.ts
@@ -25,11 +25,11 @@
  * **synchronously in that detached callback**, which no `try { await pidusage }
  * catch {}` at the call site can catch → uncaughtException → the pi host
  * crashes (#620, #533). pidusage 4.0.1 exposes no option to avoid the gwmi
- * path. So on Windows this module runs its OWN fully guarded
- * `Get-CimInstance Win32_Process` query (see `sampleProcessesWindows`),
- * mirroring `findDescendantPidsWindows`'s guard pattern, and computes CPU%
- * from the same KernelModeTime/UserModeTime delta-over-elapsed formula gwmi
- * uses — so a spawn failure can only ever lose a data point, never throw.
+ * path. So on Windows this module asks the shared, fully guarded process-table
+ * seam (`clients/process-snapshot.ts` over `scripts/lib/process-scan.mjs`,
+ * #2443) for the CPU/RSS columns instead, and computes CPU% from the same
+ * KernelModeTime/UserModeTime delta-over-elapsed formula gwmi uses — so a
+ * spawn failure can only ever lose a data point, never throw.
  *
  * Every export here is best-effort: a sampling failure (pid already exited,
  * `pidusage` throwing, permission denied, etc.) must never throw into the
@@ -45,9 +45,9 @@
  */
 
 import pidusage from "pidusage";
-import { spawnCollectStdoutResult } from "./child-unref.js";
 import { recordDegradationOnce } from "./degradation-ledger.js";
-import { terminateScannerChild, windowsExe } from "./instance-reaper.js";
+import { terminateScannerChild } from "./instance-reaper.js";
+import { queryProcessTable } from "./process-snapshot.js";
 
 export const RESOURCE_SAMPLE_QUERY_TIMEOUT_MS = 2_000;
 
@@ -130,25 +130,17 @@ async function findDescendantPidsWindows(
 ): Promise<number[] | null> {
 	if (!runningOnWindows() || !Number.isFinite(rootPid) || rootPid <= 0)
 		return [];
-	// One WQL query pulls every process's (pid, parentPid) pair; walk the BFS
-	// in JS rather than issuing N queries for N tree levels.
-	const psScript =
-		"Get-CimInstance Win32_Process " +
-		"| Select-Object -Property ProcessId,ParentProcessId " +
-		'| ForEach-Object { "$($_.ProcessId),$($_.ParentProcessId)" }';
-	const powershell = windowsExe("WindowsPowerShell\\v1.0\\powershell.exe");
-	// Fire-and-forget, per-poll-tick spawn (#1155): `spawnCollectStdout` unrefs
-	// the child AND its piped stdout so this one-shot CIM query can never keep
-	// a settled `pi --print` process alive past its own close — mirrors the
-	// reaper's identical spawn→collect plumbing (#1153/#1160). Sampling still
-	// works normally in an interactive/long-lived session: unref only means
-	// "don't hold the loop open FOR this alone," the collected stdout is still
-	// delivered whenever `close` fires. The result status keeps a failed query
-	// distinct from a successful empty process table.
-	const result = await spawnCollectStdoutResult(
-		powershell,
-		["-NoProfile", "-NonInteractive", "-Command", psScript],
-		{ shell: false, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] },
+	// One query pulls every process's (pid, parentPid) pair; walk the BFS in
+	// JS rather than issuing N queries for N tree levels. The listing itself is
+	// the shared seam (#2443), which also supplies the fire-and-forget spawn
+	// rails this call has always needed (#1155): the child AND its piped stdout
+	// are unref'd, so this one-shot query can never keep a settled
+	// `pi --print` process alive past its own close, and a scanner child that
+	// blows the timeout is tree-killed and verified rather than abandoned. The
+	// result status keeps a failed query distinct from a successful empty
+	// process table.
+	const result = await queryProcessTable(
+		{ fields: ["pid", "ppid"] },
 		{
 			timeoutMs: RESOURCE_SAMPLE_QUERY_TIMEOUT_MS,
 			onTimeout: (child) => terminateScannerChild(child, {}),
@@ -162,17 +154,11 @@ async function findDescendantPidsWindows(
 		);
 		return null;
 	}
-	const pairs: Array<[number, number]> = [];
-	for (const line of result.stdout.split(/\r?\n/)) {
-		const [pidStr, ppidStr] = line.split(",");
-		const pid = Number(pidStr);
-		const ppid = Number(ppidStr);
-		if (Number.isFinite(pid) && Number.isFinite(ppid)) {
-			pairs.push([pid, ppid]);
-		}
-	}
 
-	return walkDescendantPids(rootPid, pairs);
+	return walkDescendantPids(
+		rootPid,
+		result.rows.map((row) => [row.pid, row.ppid] as [number, number]),
+	);
 }
 
 /**
@@ -214,18 +200,21 @@ export function __windowsCpuHistoryHasForTests(
 }
 
 /**
- * Windows-only CPU%/RSS sampling via a FULLY GUARDED `Get-CimInstance
- * Win32_Process` query (mirrors `findDescendantPidsWindows`): a synchronous
- * throw from `spawn` (the `spawn UNKNOWN` crash vector, #620), a `child`
- * `error` event, or a non-zero/garbage exit all resolve to an errored/absent
- * map — this function can NEVER throw or reject. Deliberately does NOT call
- * `pidusage`, whose unguarded internal `gwmi` spawn is the crash we're fixing.
+ * Windows-only CPU%/RSS sampling through the FULLY GUARDED process-table
+ * seam (mirrors `findDescendantPidsWindows`): a synchronous throw from
+ * `spawn` (the `spawn UNKNOWN` crash vector, #620), a `child` `error` event,
+ * or a non-zero/garbage exit all resolve to an errored/absent map — this
+ * function can NEVER throw or reject. Deliberately does NOT call `pidusage`,
+ * whose unguarded internal `gwmi` spawn is the crash we're fixing.
  *
- * RSS comes from `WorkingSetSize`; CPU% from `KernelModeTime`+`UserModeTime`
- * (both in 100 ns units → ms via `/1e4`) differenced against this pid's prior
- * sample over the elapsed wall time — the same computation pidusage's gwmi
- * path uses. The first time a pid is seen it has no prior sample, so CPU% is
- * reported as 0 for that tick and a real rate lands on the next one.
+ * RSS comes from `WorkingSetSize` (`rssBytes`); CPU% from `KernelModeTime`
+ * plus `UserModeTime` (both in 100 ns units → ms via `/1e4`) differenced
+ * against this pid's prior sample over the elapsed wall time — the same
+ * computation pidusage's gwmi path uses. The first time a pid is seen it has
+ * no prior sample, so CPU% is reported as 0 for that tick and a real rate
+ * lands on the next one. The process creation date (`startedAt`) is the
+ * pid-reuse discriminator: a recycled pid must not inherit the previous
+ * process's CPU baseline.
  */
 async function sampleProcessesWindows(
 	valid: number[],
@@ -233,28 +222,26 @@ async function sampleProcessesWindows(
 	const samples = new Map<number, ProcessUsage>();
 	if (valid.length === 0) return samples;
 
-	// pids are pre-validated finite positive integers, so this WQL filter is
-	// injection-safe. One line per pid: "pid,workingSet,kernel100ns,user100ns,creationDate".
-	const filter = valid.map((p) => `ProcessId=${p}`).join(" or ");
-	const psScript =
-		`Get-CimInstance Win32_Process -Filter "${filter}" ` +
-		"| Select-Object -Property ProcessId,WorkingSetSize,KernelModeTime,UserModeTime,CreationDate " +
-		'| ForEach-Object { "$($_.ProcessId),$($_.WorkingSetSize),$($_.KernelModeTime),$($_.UserModeTime),$($_.CreationDate)" }';
-
-	const powershell = windowsExe("WindowsPowerShell\\v1.0\\powershell.exe");
-	// Fire-and-forget, per-poll-tick spawn (#1155): `spawnCollectStdout` unrefs
-	// the child AND its piped stdout so this one-shot CIM query can never keep
-	// a settled `pi --print` process alive past its own close — mirrors the
-	// reaper's identical spawn→collect plumbing (#1153/#1160). It also absorbs
-	// both failure modes this function used to guard inline — a synchronous
-	// `spawn` throw (the `spawn UNKNOWN` crash vector, #620) and an async
-	// `error` event, or a non-zero exit — the result status keeps failure distinct
-	// map. Sampling still works normally in an interactive/long-lived
-	// session: unref only means "don't hold the loop open FOR this alone."
-	const query = await spawnCollectStdoutResult(
-		powershell,
-		["-NoProfile", "-NonInteractive", "-Command", psScript],
-		{ shell: false, windowsHide: true, stdio: ["ignore", "pipe", "ignore"] },
+	// pids are pre-validated finite positive integers, and the seam validates
+	// them again before they reach the query text, so the filter is
+	// injection-safe. The seam also supplies the fire-and-forget spawn rails
+	// (#1155: the child and its piped stdout are unref'd, so this one-shot
+	// query cannot keep a settled `pi --print` alive past its own close) and
+	// absorbs every failure mode this function used to guard inline — a
+	// synchronous `spawn` throw (the `spawn UNKNOWN` crash vector, #620), an
+	// async `error` event, a timeout, or a non-zero exit — reporting each
+	// through `status` rather than as an indistinguishable empty table.
+	const query = await queryProcessTable(
+		{
+			fields: [
+				"pid",
+				"rssBytes",
+				"cpuKernel100ns",
+				"cpuUser100ns",
+				"startedAt",
+			],
+			filter: { column: "ProcessId", op: "eq", values: valid },
+		},
 		{
 			timeoutMs: RESOURCE_SAMPLE_QUERY_TIMEOUT_MS,
 			onTimeout: (child) => terminateScannerChild(child, {}),
@@ -267,23 +254,19 @@ async function sampleProcessesWindows(
 	try {
 		const now = Date.now();
 		const seen = new Set<number>();
-		for (const line of query.stdout.split(/\r?\n/)) {
-			const parts = line.split(",");
-			if (parts.length < 5) continue;
-			if (parts.slice(0, 5).some((part) => part.trim().length === 0)) continue;
-			const pid = Number(parts[0]);
-			const workingSet = Number(parts[1]);
-			const kernel100ns = Number(parts[2]);
-			const user100ns = Number(parts[3]);
-			const processIdentity = parts.slice(4).join(",").trim();
-			if (!Number.isFinite(pid) || pid <= 0) continue;
+		for (const row of query.rows) {
+			const pid = row.pid;
+			const workingSet = row.rssBytes;
+			const kernel100ns = row.cpuKernel100ns;
+			const user100ns = row.cpuUser100ns;
+			const processIdentity = row.startedAt ?? "";
+			// The seam already rejects a non-integer or negative column as
+			// UNKNOWN (undefined), so an absent value here means the row cannot
+			// be sampled — never that the process used zero.
 			if (
-				!Number.isFinite(workingSet) ||
-				workingSet < 0 ||
-				!Number.isFinite(kernel100ns) ||
-				kernel100ns < 0 ||
-				!Number.isFinite(user100ns) ||
-				user100ns < 0 ||
+				workingSet === undefined ||
+				kernel100ns === undefined ||
+				user100ns === undefined ||
 				processIdentity.length === 0
 			)
 				continue;

--- a/scripts/lib/process-scan.d.mts
+++ b/scripts/lib/process-scan.d.mts
@@ -1,4 +1,8 @@
-// Type declarations for process-scan.mjs (untyped .mjs imported from .ts tests).
+// Type declarations for process-scan.mjs (untyped .mjs imported from .ts).
+//
+// Two consumers: the tests, and `clients/process-snapshot.ts` — the single
+// point where the extension runtime reaches into scripts/ for this seam
+// (#2443; the boundary decision is argued in the .mjs header).
 
 export const LSP_PROCESS_MARKERS: string[];
 
@@ -14,13 +18,52 @@ export function diffSurvivingLspProcesses(
 	after: ProcessRow[],
 ): ProcessRow[];
 
-export type ProcessField = "pid" | "ppid" | "command";
+export type ProcessField =
+	| "pid"
+	| "ppid"
+	| "ageMs"
+	| "rssBytes"
+	| "cpuKernel100ns"
+	| "cpuUser100ns"
+	| "startedAt"
+	| "command";
 
 export interface ProcRow {
 	pid: number;
 	ppid: number;
 	command: string;
+	/** Present only when `ageMs` was projected; undefined when the platform
+	 *  emitted a value that could not be trusted. */
+	ageMs?: number;
+	rssBytes?: number;
+	cpuKernel100ns?: number;
+	cpuUser100ns?: number;
+	startedAt?: string;
 	cwd?: string;
+}
+
+/** A platform-side narrowing of the process table. `ProcessId` is the only
+ *  column POSIX `ps` can filter on; the others apply on Windows only, and
+ *  `serverSideFiltered` on the built query says which happened. */
+export interface ProcessFilter {
+	column: "ProcessId" | "Name" | "CommandLine";
+	op: "eq" | "like";
+	values: ReadonlyArray<string | number>;
+}
+
+export interface ProcessQueryOptions {
+	filter?: ProcessFilter;
+	/** Windows only: drop the query's own powershell.exe row, whose command
+	 *  line embeds whatever marker a `CommandLine` filter searched for. */
+	excludeSelfPid?: boolean;
+}
+
+export interface ProcessQuery {
+	command: string;
+	args: string[];
+	tabSeparated: boolean;
+	fields: ProcessField[];
+	serverSideFiltered: boolean;
 }
 
 export const DEFAULT_SNAPSHOT_TIMEOUT_MS: number;
@@ -30,9 +73,20 @@ export function windowsExe(name: string): string;
 
 export function posixPsPath(): string;
 
+export function escapeWqlLikeValue(value: string | number): string;
+
+export function escapeWqlStringValue(value: string | number): string;
+
+export function ageMsFromPosixEtime(raw: string): number | undefined;
+
 export function normalizeProcessFields(
 	fields: readonly ProcessField[] | null | undefined,
 ): ProcessField[];
+
+export function buildProcessQuery(
+	fields?: readonly ProcessField[],
+	options?: ProcessQueryOptions,
+): ProcessQuery;
 
 export function parseProcessTable(
 	out: string,
@@ -43,6 +97,7 @@ export function parseProcessTable(
 export function snapshotProcesses(
 	fields?: readonly ProcessField[],
 	timeoutMs?: number,
+	options?: ProcessQueryOptions,
 ): Promise<{ rows: ProcRow[]; ok: boolean }>;
 
 export interface ProcessSnapshot {

--- a/scripts/lib/process-scan.mjs
+++ b/scripts/lib/process-scan.mjs
@@ -1,57 +1,109 @@
-// Process-table access for scripts/, in two halves.
+// Process-table access for BOTH trees, in two halves.
 //
 // The PURE half (#476, Layer B assertion 3: zero surviving LSP-server child
 // processes after pi exits — the #472 orphan class) answers "does this
 // command line look like a leaked LSP server, and is it NEW since the
 // baseline snapshot", and is unit-testable with fake process tables.
 //
-// The IMPURE half is the platform listing itself: one `snapshotProcesses`
-// plus its parser. PR #2438 review round 3 (F2) folded the second copy in
-// here. `scripts/prune-agent-worktrees.mjs` and
-// `scripts/compat-smoke-behavioral.mjs` had each grown their own
-// `windowsExe` + `snapshotProcesses` pair with the same Windows CIM / POSIX
-// `ps` split, differing only in which columns they asked for — so a fix to
-// one (the exit-code check that review S5 added: a `ps` that prints a
-// partial table and dies must not read as a complete one) did not reach the
-// other. One function, a `fields` projection, both callers.
+// The IMPURE half is the platform listing itself: `buildProcessQuery` (the
+// one place a Windows CIM/WQL or POSIX `ps` command is composed),
+// `parseProcessTable` (the one place its output is read back), and
+// `snapshotProcesses` (the scripts-side bounded spawn around the pair).
 //
-// NOTE for clients/: `clients/instance-reaper.ts` and
-// `clients/resource-sampler.ts` hold further copies. They are NOT collapsed
-// into this file — scripts/ is untyped .mjs tooling that ships nothing, and
-// clients/ is the extension runtime with its own spawn seam and budget
-// rails. That cross-boundary consolidation is filed separately.
+// #2443 folded the LAST copies in here. Before it there were five: this
+// file's two scripts/ callers plus `clients/instance-reaper.ts` (three
+// queries) and `clients/resource-sampler.ts` (two) — the same projection,
+// the same fail-to-an-empty-table shape, written out five times, which is
+// why PR #2438's exit-code hardening (a `ps` that prints a partial table and
+// then dies must not read as a complete one) reached one copy and not the
+// rest. `tests/config/process-table-seam.test.ts` is the guard that keeps it
+// at one.
+//
+// WHY THE SEAM LIVES IN scripts/ AND NOT IN clients/ (#2443 boundary
+// decision). The obvious alternative — a `clients/process-snapshot.ts`
+// compiled to `.js` and imported by scripts/ — is how ~20 other scripts
+// consume client code, and it was rejected for ONE reason: `clients/*.js` is
+// gitignored build output, and `scripts/prune-agent-worktrees.mjs` is a
+// SessionStart/SubagentStop hook that runs inside freshly created agent
+// worktrees, which have neither `node_modules` nor a build yet. A hygiene
+// hook that throws ERR_MODULE_NOT_FOUND is strictly worse than the
+// duplication it removes. This file therefore stays dependency-free (node:
+// builtins only) and clients/ reaches it through
+// `clients/process-snapshot.ts`, the single crossing point, typed by the
+// sibling `process-scan.d.mts`.
 
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-const isWindows = process.platform === "win32";
+/**
+ * Read the platform LIVE rather than as a module-load constant, so both the
+ * Windows CIM branch and the POSIX `ps` branch of `buildProcessQuery` are
+ * exercisable in unit tests regardless of the host OS (the same reasoning
+ * `clients/resource-sampler.ts` states for its own platform check — the
+ * Windows half of this seam ships to machines no POSIX CI runner can cover,
+ * and vice versa).
+ */
+function runningOnWindows() {
+	return process.platform === "win32";
+}
 
 /** Default ceiling for one process listing. */
 export const DEFAULT_SNAPSHOT_TIMEOUT_MS = 4_000;
 
 /**
- * @typedef {"pid" | "ppid" | "command"} ProcessField
- * @typedef {{ pid: number, ppid: number, command: string, cwd?: string }} ProcRow
+ * @typedef {"pid" | "ppid" | "ageMs" | "rssBytes" | "cpuKernel100ns" | "cpuUser100ns" | "startedAt" | "command"} ProcessField
+ * @typedef {{ pid: number, ppid: number, command: string, ageMs?: number, rssBytes?: number, cpuKernel100ns?: number, cpuUser100ns?: number, startedAt?: string, cwd?: string }} ProcRow
+ * @typedef {{ column: "ProcessId" | "Name" | "CommandLine", op: "eq" | "like", values: ReadonlyArray<string|number> }} ProcessFilter
  */
 
 /**
- * Per-field platform column names. `ps`'s `args` and CIM's `CommandLine` are
- * the same question asked twice; keeping the mapping in one table is what
- * lets a caller say `["pid", "command"]` and get the right query on both.
+ * Per-field platform column names and token shapes. `ps`'s `args` and CIM's
+ * `CommandLine` are the same question asked twice; keeping the mapping in one
+ * table is what lets a caller say `["pid", "command"]` and get the right
+ * query, and the right parse, on both platforms.
+ *
+ * `ps: null` marks a field the POSIX listing cannot answer. Asking for one on
+ * POSIX THROWS rather than yielding a silently absent column — the callers
+ * that need those fields (the resource sampler's CPU/RSS query) are
+ * Windows-only by construction, and a wrong-shaped `ps` invocation would
+ * return zero rows, which reads exactly like "no such process".
  */
 const FIELD_COLUMNS = Object.freeze({
-	pid: { wmi: "ProcessId", ps: "pid" },
-	ppid: { wmi: "ParentProcessId", ps: "ppid" },
-	command: { wmi: "CommandLine", ps: "args" },
+	pid: { wmi: "ProcessId", ps: "pid", token: "int" },
+	ppid: { wmi: "ParentProcessId", ps: "ppid", token: "int" },
+	ageMs: { wmi: "CreationDate", ps: "etime", token: "age" },
+	rssBytes: { wmi: "WorkingSetSize", ps: null, token: "int" },
+	cpuKernel100ns: { wmi: "KernelModeTime", ps: null, token: "int" },
+	cpuUser100ns: { wmi: "UserModeTime", ps: null, token: "int" },
+	startedAt: { wmi: "CreationDate", ps: null, token: "text" },
+	command: { wmi: "CommandLine", ps: "args", token: "tail" },
 });
 
-/** The full projection, and the order every parser assumes. */
+/**
+ * The canonical column ORDER, which every parser assumes. `command` is LAST
+ * because it is the only column that can contain the delimiter — both parsers
+ * take it as the tail of the line. Derived from `FIELD_COLUMNS` rather than
+ * written out again, so a field cannot exist in one list and not the other.
+ */
+const FIELD_ORDER = Object.freeze(Object.keys(FIELD_COLUMNS));
+
+/**
+ * The DEFAULT projection: the three columns every platform can answer, which
+ * is what a caller that names no fields gets. It is deliberately NOT the full
+ * field set — `rssBytes`/`cpuKernel100ns`/`cpuUser100ns`/`startedAt` exist
+ * only on the Windows side, so defaulting to them would make an unprojected
+ * listing throw on POSIX instead of doing the obvious thing.
+ */
 export const ALL_PROCESS_FIELDS = Object.freeze(["pid", "ppid", "command"]);
+
+/** Columns a filter may name. A closed set, so the column half of a WQL
+ *  clause can never carry caller-supplied text. */
+const FILTERABLE_COLUMNS = new Set(["ProcessId", "Name", "CommandLine"]);
 
 /**
  * Absolute path to a System32 executable. Windows resolves a bare
- * `powershell.exe` through PATH, which a caller can shadow; the sweep spawns
+ * `powershell.exe` through PATH, which a caller can shadow; the callers spawn
  * this to decide what to KILL, so the interpreter is named absolutely.
  *
  * @param {string} name
@@ -66,22 +118,24 @@ export function windowsExe(name) {
 }
 
 /**
- * Absolute path to POSIX `ps`, the same reasoning as `windowsExe` applied to
- * the other platform: this listing decides what the sweep KILLS, so the
- * interpreter is named absolutely rather than resolved through a PATH a
- * caller can shadow (master's compat-smoke already spawned `/bin/ps`; this
- * carries that into the shared listing). Falls back to the bare `ps` name
- * only when `/bin/ps` is absent, so a POSIX-like environment that keeps it
- * elsewhere still works.
+ * Absolute path to POSIX `ps` (S4036: never spawn via a bare PATH lookup) —
+ * the same reasoning as `windowsExe` applied to the other platform, since
+ * this listing decides what gets killed. Prefers `/bin/ps`, then
+ * `/usr/bin/ps`, and falls back to `/bin/ps` when neither probe succeeds, so
+ * the spawn fails CLOSED instead of quietly resolving through a PATH a caller
+ * can shadow. (#2443 adopted the reaper's stricter form over this file's
+ * earlier bare-`ps` fallback: one seam, the safer of the two behaviours.)
  *
  * @returns {string}
  */
 export function posixPsPath() {
 	try {
-		return fs.existsSync("/bin/ps") ? "/bin/ps" : "ps";
+		if (fs.existsSync("/bin/ps")) return "/bin/ps";
+		if (fs.existsSync("/usr/bin/ps")) return "/usr/bin/ps";
 	} catch {
-		return "ps";
+		/* unreadable filesystem — fall through to the absolute default */
 	}
+	return "/bin/ps";
 }
 
 /**
@@ -97,7 +151,219 @@ export function normalizeProcessFields(fields) {
 		(fields ?? ALL_PROCESS_FIELDS).filter((field) => field in FIELD_COLUMNS),
 	);
 	requested.add("pid");
-	return ALL_PROCESS_FIELDS.filter((field) => requested.has(field));
+	return FIELD_ORDER.filter((field) => requested.has(field));
+}
+
+/**
+ * Escape a value for embedding in a WQL LIKE clause: WQL uses `'` as the
+ * string delimiter (doubled to escape) and `%`/`_` as wildcards — a marker is
+ * an opaque path string, so escape all three before interpolating.
+ *
+ * @param {string|number} value
+ * @returns {string}
+ */
+export function escapeWqlLikeValue(value) {
+	return String(value)
+		.replaceAll("'", "''")
+		.replaceAll(/[%_]/g, (ch) => `[${ch}]`);
+}
+
+/**
+ * Escape a value for a WQL EQUALITY comparison: only the string delimiter
+ * needs escaping — `%`/`_` are literal outside `LIKE`.
+ *
+ * @param {string|number} value
+ * @returns {string}
+ */
+export function escapeWqlStringValue(value) {
+	return String(value).replaceAll("'", "''");
+}
+
+/**
+ * A pid about to be interpolated into a query, validated as a positive
+ * integer so the numeric branch can never carry query text.
+ *
+ * @param {string|number} value
+ * @returns {number}
+ */
+function assertPid(value) {
+	const pid = Number(value);
+	if (!Number.isInteger(pid) || pid <= 0) {
+		throw new Error(`process filter: invalid pid ${String(value)}`);
+	}
+	return pid;
+}
+
+/**
+ * One WQL boolean expression for a filter. `ProcessId` is compared
+ * numerically (every value validated as a positive integer first, so nothing
+ * caller-supplied reaches the query text); every other column is compared as
+ * an escaped string.
+ *
+ * @param {ProcessFilter} filter
+ * @returns {string}
+ */
+function wqlFilterExpression(filter) {
+	const { column, op, values } = filter;
+	if (!FILTERABLE_COLUMNS.has(column)) {
+		throw new Error(`process filter: unsupported column ${String(column)}`);
+	}
+	const list = [...values];
+	if (list.length === 0) {
+		throw new Error(`process filter: ${column} filter has no values`);
+	}
+	if (column === "ProcessId") {
+		return list.map((value) => `ProcessId=${assertPid(value)}`).join(" OR ");
+	}
+	if (op === "like") {
+		return list
+			.map((value) => `${column} LIKE '%${escapeWqlLikeValue(value)}%'`)
+			.join(" OR ");
+	}
+	return list
+		.map((value) => `${column} = '${escapeWqlStringValue(value)}'`)
+		.join(" OR ");
+}
+
+/**
+ * Compose the platform command that lists processes.
+ *
+ * Windows uses `Get-CimInstance` through `powershell -NoProfile` with an
+ * explicit WQL projection (measured ~316ms for the query vs ~570ms for the
+ * unprojected form on the #2435 box, plus ~208ms powershell startup) —
+ * `tasklist` exposes no parent pid and no command line, and `wmic` is gone
+ * from Windows 11. POSIX uses `ps`, either `-eo <cols>` (every process) or
+ * `-p <pids> -o <cols>` when the filter is a pid set, which is the only
+ * filter `ps` can apply server-side.
+ *
+ * `serverSideFiltered` reports whether the platform actually applied the
+ * filter. A `Name`/`CommandLine` filter has no `ps` equivalent, so on POSIX
+ * the caller gets the whole table and must narrow it itself — said out loud
+ * here rather than left as a per-caller assumption.
+ *
+ * `ageMs` on Windows is computed IN PowerShell as a millisecond delta, never
+ * exported as `CreationDate.Ticks`: `Ticks` is the LOCAL-time representation,
+ * so subtracting the Unix epoch in JS produced an age wrong by the machine's
+ * UTC offset (#1857 — measured on a UTC+3 host as -8358s for a process
+ * started 40 minutes earlier). A delta computed on one side of the boundary
+ * has no timezone to get wrong. The explicit `[datetime]` test matters too:
+ * subtracting `$null` from `(Get-Date)` yields a two-thousand-year TimeSpan,
+ * which would read as "ancient" and defeat a spawn-grace guard exactly where
+ * the data is missing.
+ *
+ * @param {ReadonlyArray<ProcessField>} [fields]
+ * @param {{ filter?: ProcessFilter, excludeSelfPid?: boolean }} [options]
+ * @returns {{ command: string, args: string[], tabSeparated: boolean, fields: ProcessField[], serverSideFiltered: boolean }}
+ */
+export function buildProcessQuery(fields = ALL_PROCESS_FIELDS, options = {}) {
+	const layout = normalizeProcessFields(fields);
+	const filter = options.filter;
+	if (runningOnWindows()) {
+		const columns = [
+			...new Set(layout.map((field) => FIELD_COLUMNS[field].wmi)),
+		];
+		const where = filter ? ` WHERE ${wqlFilterExpression(filter)}` : "";
+		// A CommandLine filter's own marker is embedded in the command line of
+		// the powershell.exe running the query, so the search would match
+		// itself. `$PID` is the only identity that can exclude it, and it is
+		// knowable only inside the child.
+		const excludeSelf = options.excludeSelfPid
+			? " | Where-Object { $_.ProcessId -ne $PID }"
+			: "";
+		const prelude = layout.includes("ageMs")
+			? "$age = if ($_.CreationDate -is [datetime]) { [int64]((Get-Date) - $_.CreationDate).TotalMilliseconds } else { '' }; "
+			: "";
+		const row = layout
+			.map((field) =>
+				field === "ageMs" ? "$age" : `$($_.${FIELD_COLUMNS[field].wmi})`,
+			)
+			.join("`t");
+		return {
+			command: windowsExe("WindowsPowerShell\\v1.0\\powershell.exe"),
+			args: [
+				"-NoProfile",
+				"-NonInteractive",
+				"-Command",
+				`Get-CimInstance -Query "SELECT ${columns.join(",")} FROM Win32_Process${where}"${excludeSelf} | ForEach-Object { ${prelude}"${row}" }`,
+			],
+			tabSeparated: true,
+			fields: layout,
+			serverSideFiltered: Boolean(filter),
+		};
+	}
+	const unsupported = layout.filter((field) => !FIELD_COLUMNS[field].ps);
+	if (unsupported.length > 0) {
+		throw new Error(
+			`process query: ${unsupported.join(", ")} has no POSIX ps column`,
+		);
+	}
+	const columns = layout
+		.map((field) => `${FIELD_COLUMNS[field].ps}=`)
+		.join(",");
+	const pidFilter =
+		filter && filter.column === "ProcessId" && filter.op === "eq"
+			? [...filter.values].map((value) => assertPid(value))
+			: null;
+	return {
+		command: posixPsPath(),
+		args: pidFilter
+			? ["-p", pidFilter.join(","), "-o", columns]
+			: ["-eo", columns],
+		tabSeparated: false,
+		fields: layout,
+		serverSideFiltered: Boolean(pidFilter),
+	};
+}
+
+/**
+ * Parse a non-negative integer token, rejecting anything else. A nonsensical
+ * value means the value is UNKNOWN, not zero — a caller reasoning from a
+ * fabricated 0 is how the #1857 local-time age bug stayed invisible.
+ *
+ * @param {string|undefined} raw
+ * @returns {number|undefined}
+ */
+function parseNonNegativeInt(raw) {
+	const token = String(raw ?? "").trim();
+	if (!/^\d+$/.test(token)) return undefined;
+	const value = Number(token);
+	return Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Parse a `ps -o etime` token: `[[dd-]hh:]mm:ss`. Returns undefined for any
+ * shape the column did not produce (a `ps` without the column emits the
+ * command line where the token was expected).
+ *
+ * @param {string} raw
+ * @returns {number|undefined}
+ */
+export function ageMsFromPosixEtime(raw) {
+	const token = String(raw ?? "").trim();
+	if (!/^(?:\d+-)?(?:\d+:)?\d+:\d+$/.test(token)) return undefined;
+	let days = 0;
+	let rest = token;
+	const dash = rest.indexOf("-");
+	if (dash >= 0) {
+		days = Number(rest.slice(0, dash));
+		rest = rest.slice(dash + 1);
+	}
+	const parts = rest.split(":").map(Number);
+	if (parts.some((part) => !Number.isFinite(part))) return undefined;
+	const [hours, minutes, seconds] =
+		parts.length === 3 ? parts : [0, parts[0], parts[1]];
+	return ((days * 24 + hours) * 60 * 60 + minutes * 60 + seconds) * 1000;
+}
+
+/**
+ * POSIX token pattern per field: every column but the trailing command is a
+ * single whitespace-delimited token, and `etime` is not purely numeric.
+ *
+ * @param {ProcessField} field
+ * @returns {string}
+ */
+function posixTokenPattern(field) {
+	return FIELD_COLUMNS[field].token === "age" ? "(\\S+)" : "(\\d+)";
 }
 
 /**
@@ -107,9 +373,11 @@ export function normalizeProcessFields(fields) {
  * whitespace-aligned columns whose LAST field (`args`) contains spaces, so it
  * is parsed positionally with the tail taken whole.
  *
- * Fields not requested are still present on the row at their zero value
- * (`ppid: 0`, `command: ""`), so consumers see one row shape regardless of
- * the projection.
+ * `pid`, `ppid` and `command` are always present on the row at their zero
+ * value (`ppid: 0`, `command: ""`) so consumers see one row shape regardless
+ * of the projection; every other field appears only when it was requested,
+ * and is `undefined` when the platform emitted a value that could not be
+ * trusted.
  *
  * @param {string} out
  * @param {boolean} tabSeparated
@@ -123,10 +391,18 @@ export function parseProcessTable(
 ) {
 	const layout = normalizeProcessFields(fields);
 	const commandIndex = layout.indexOf("command");
+	const positional = tabSeparated
+		? null
+		: new RegExp(
+				`^\\s*${layout
+					.filter((field) => field !== "command")
+					.map((field) => posixTokenPattern(field))
+					.join("\\s+")}${commandIndex === -1 ? "\\s*$" : "\\s+(.*)$"}`,
+			);
 	const rows = [];
 	for (const line of String(out ?? "").split(/\r?\n/)) {
 		if (!line.trim()) continue;
-		/** @type {string[]|null} */
+		/** @type {string[]} */
 		let parts;
 		if (tabSeparated) {
 			const split = line.split("\t");
@@ -141,15 +417,7 @@ export function parseProcessTable(
 							split.slice(commandIndex).join("\t"),
 						];
 		} else {
-			// Every leading column is numeric; the trailing command, if asked
-			// for, takes the rest of the line verbatim.
-			const numeric = commandIndex === -1 ? layout.length : commandIndex;
-			const pattern = new RegExp(
-				`^\\s*${Array.from({ length: numeric }, () => "(\\d+)").join("\\s+")}${
-					commandIndex === -1 ? "\\s*$" : "\\s+(.*)$"
-				}`,
-			);
-			const match = pattern.exec(line);
+			const match = positional?.exec(line);
 			if (!match) continue;
 			parts = match.slice(1);
 		}
@@ -160,23 +428,39 @@ export function parseProcessTable(
 		const pid = Number(value("pid"));
 		if (!Number.isInteger(pid) || pid <= 0) continue;
 		const ppid = Number(value("ppid"));
-		rows.push({
+		/** @type {ProcRow} */
+		const row = {
 			pid,
 			ppid: Number.isInteger(ppid) && ppid > 0 ? ppid : 0,
 			command: value("command") ?? "",
-		});
+		};
+		for (const field of layout) {
+			if (field === "pid" || field === "ppid" || field === "command") continue;
+			const raw = value(field);
+			if (field === "ageMs") {
+				row.ageMs = tabSeparated
+					? parseNonNegativeInt(raw)
+					: ageMsFromPosixEtime(raw ?? "");
+			} else if (field === "startedAt") {
+				row.startedAt = String(raw ?? "").trim();
+			} else {
+				row[field] = parseNonNegativeInt(raw);
+			}
+		}
+		rows.push(row);
 	}
 	return rows;
 }
 
 /**
- * Snapshot the process table as `{ pid, ppid, command }` rows.
+ * Snapshot the process table, for scripts/ — one bounded spawn around
+ * `buildProcessQuery` plus `parseProcessTable`.
  *
- * Windows uses `Get-CimInstance` through `powershell -NoProfile` with an
- * explicit WQL projection (measured ~316ms for the query vs ~570ms for the
- * unprojected form on the #2435 box, plus ~208ms powershell startup) —
- * `tasklist` exposes no parent pid and no command line, and `wmic` is gone
- * from Windows 11. POSIX uses `ps -eo <cols>`.
+ * clients/ does NOT call this: it needs the extension's own spawn rails (an
+ * unref'd child and piped stdout, a tree-kill-and-verify timeout handler, the
+ * degradation ledger), so `clients/process-snapshot.ts` composes the same two
+ * halves over `spawnCollectStdoutResult` instead. The QUERY and the PARSE are
+ * shared; only the spawn differs, and it differs for a reason.
  *
  * Never rejects. Returns `{ rows, ok }`: `ok` is false when the listing
  * failed, timed out, never spawned, or EXITED NON-ZERO — the last of which
@@ -185,31 +469,29 @@ export function parseProcessTable(
  * caller has that an ABSENCE from the table means anything. Bounded by
  * `timeoutMs` so a hook can never hang a session on a wedged WMI service.
  *
+ * The timed-out child is killed through the HELD HANDLE, never by spawning a
+ * killer (#234: spawning during teardown aborts libuv on Windows).
+ *
  * @param {ReadonlyArray<ProcessField>} [fields]
  * @param {number} [timeoutMs]
+ * @param {{ filter?: ProcessFilter, excludeSelfPid?: boolean }} [options]
  * @returns {Promise<{ rows: ProcRow[], ok: boolean }>}
  */
 export function snapshotProcesses(
 	fields = ALL_PROCESS_FIELDS,
 	timeoutMs = DEFAULT_SNAPSHOT_TIMEOUT_MS,
+	options = {},
 ) {
-	const layout = normalizeProcessFields(fields);
-	const command = isWindows
-		? windowsExe("WindowsPowerShell\\v1.0\\powershell.exe")
-		: posixPsPath();
-	const args = isWindows
-		? [
-				"-NoProfile",
-				"-NonInteractive",
-				"-Command",
-				`Get-CimInstance -Query "SELECT ${layout
-					.map((field) => FIELD_COLUMNS[field].wmi)
-					.join(",")} FROM Win32_Process" | ForEach-Object { "${layout
-					.map((field) => `$($_.${FIELD_COLUMNS[field].wmi})`)
-					.join("`t")}" }`,
-			]
-		: ["-eo", layout.map((field) => `${FIELD_COLUMNS[field].ps}=`).join(",")];
-
+	let query;
+	try {
+		query = buildProcessQuery(fields, options);
+	} catch {
+		// An unbuildable query (a Windows-only column asked for on POSIX, an
+		// empty filter) is a caller bug, not a runtime outage — but this seam's
+		// contract is never to throw at a best-effort caller, so it reports the
+		// same not-ok empty table every other failure reports.
+		return Promise.resolve({ rows: [], ok: false });
+	}
 	return new Promise((resolve) => {
 		let settled = false;
 		const finish = (rows, ok) => {
@@ -228,7 +510,7 @@ export function snapshotProcesses(
 			finish([], false);
 		}, timeoutMs);
 		try {
-			child = spawn(command, args, {
+			child = spawn(query.command, query.args, {
 				shell: false,
 				windowsHide: true,
 				stdio: ["ignore", "pipe", "ignore"],
@@ -246,7 +528,10 @@ export function snapshotProcesses(
 		// Whatever it printed is not evidence of what is NOT running, which is
 		// exactly the question the orphan predicate asks of it.
 		child.once("close", (code, signal) =>
-			finish(parseProcessTable(out, isWindows, layout), code === 0 && !signal),
+			finish(
+				parseProcessTable(out, query.tabSeparated, query.fields),
+				code === 0 && !signal,
+			),
 		);
 	});
 }

--- a/tests/clients/instance-reaper-posix-ps.test.ts
+++ b/tests/clients/instance-reaper-posix-ps.test.ts
@@ -7,6 +7,11 @@
  *
  * That is the one part of the fix a Windows development host cannot check, so
  * it is checked here against the REAL `ps`, on the real CI runner. No mocks.
+ *
+ * #2443 moved the argument vector and the etime parser into the shared
+ * process-table seam. This suite follows them: it now spawns the command the
+ * SEAM composes for the reaper's projection, rather than a copy of it, so a
+ * column the host's `ps` rejects reds here instead of in production.
  */
 
 import { spawn } from "node:child_process";
@@ -14,23 +19,21 @@ import { existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
-	POSIX_PS_ARGS,
 	ageMsFromPosixEtime,
-} from "../../clients/instance-reaper.js";
+	buildProcessQuery,
+} from "../../scripts/lib/process-scan.mjs";
 
-const psPath = existsSync("/bin/ps")
-	? "/bin/ps"
-	: existsSync("/usr/bin/ps")
-		? "/usr/bin/ps"
-		: undefined;
+/** Exactly the projection `enumerateManagedProcesses` asks for. */
+const REAPER_FIELDS = ["pid", "ppid", "ageMs", "command"] as const;
 
 /** Probe the filesystem for `ps`, not `process.platform`: the question is
  *  whether this host HAS the binary the sweep spawns. */
-const hasPs = psPath !== undefined;
+const hasPs = existsSync("/bin/ps") || existsSync("/usr/bin/ps");
 
 function runPs(): Promise<{ stdout: string; code: number | null }> {
+	const query = buildProcessQuery(REAPER_FIELDS);
 	return new Promise((resolve) => {
-		const child = spawn(psPath as string, [...POSIX_PS_ARGS], {
+		const child = spawn(query.command, query.args, {
 			shell: false,
 			stdio: ["ignore", "pipe", "ignore"],
 		});
@@ -46,6 +49,15 @@ function runPs(): Promise<{ stdout: string; code: number | null }> {
 describe.skipIf(!hasPs)(
 	"#1857: the real ps accepts the etime column vector",
 	() => {
+		it("asks for the header-suppressed pid/ppid/etime/args projection", () => {
+			// Pinned so a seam change that silently dropped a column (which would
+			// put the command line where the age token belongs) fails here rather
+			// than by making every process look unknown-aged in production.
+			const query = buildProcessQuery(REAPER_FIELDS);
+			expect(query.args).toEqual(["-eo", "pid=,ppid=,etime=,args="]);
+			expect(query.tabSeparated).toBe(false);
+		});
+
 		it("exits zero and returns rows whose third column parses as an age", async () => {
 			const { stdout, code } = await runPs();
 

--- a/tests/clients/process-snapshot.test.ts
+++ b/tests/clients/process-snapshot.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for clients/process-snapshot.ts (#2443) — the clients-side door onto
+ * the shared process-table seam.
+ *
+ * The seam's query composition and row parsing are pinned in
+ * tests/scripts/process-scan.test.ts. What is pinned HERE is the half this
+ * module owns and the scripts-side `snapshotProcesses` deliberately does not:
+ * the extension's spawn rails. `node:child_process` is mocked, so nothing
+ * spawns; each test drives the fake child to exercise one path.
+ *
+ * The platform is forced per test because both branches ship — the Windows
+ * CIM one to every Windows user, the POSIX `ps` one to everyone else — and
+ * neither CI runner covers both.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type SpawnFn = (...args: unknown[]) => unknown;
+let fakeSpawn: SpawnFn = () => makeFakeChild({ stdout: "" });
+const spawnCalls: Array<{ command: string; args: string[] }> = [];
+
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:child_process")>();
+	return {
+		...actual,
+		spawn: (...args: unknown[]) => {
+			spawnCalls.push({
+				command: args[0] as string,
+				args: (args[1] as string[]) ?? [],
+			});
+			return fakeSpawn(...args);
+		},
+	};
+});
+
+const { queryProcessTable } = await import("../../clients/process-snapshot.js");
+
+interface FakeChild {
+	stdout: {
+		on: (event: string, cb: (chunk: Buffer) => void) => void;
+		unref: ReturnType<typeof vi.fn>;
+	};
+	once: (event: string, cb: (...a: unknown[]) => void) => void;
+	unref: ReturnType<typeof vi.fn>;
+	kill: ReturnType<typeof vi.fn>;
+	pid: number;
+}
+
+function makeFakeChild(opts: {
+	stdout?: string;
+	code?: number;
+	holdOpen?: boolean;
+}): FakeChild {
+	const handlers = new Map<string, (...a: unknown[]) => void>();
+	const dataCbs: Array<(chunk: Buffer) => void> = [];
+	const child: FakeChild = {
+		stdout: {
+			on: (event: string, cb: (chunk: Buffer) => void) => {
+				if (event === "data") dataCbs.push(cb);
+			},
+			unref: vi.fn(),
+		},
+		once: (event: string, cb: (...a: unknown[]) => void) => {
+			handlers.set(event, cb);
+		},
+		unref: vi.fn(),
+		kill: vi.fn(),
+		pid: 4242,
+	};
+	queueMicrotask(() => {
+		if (opts.holdOpen) return;
+		if (opts.stdout) for (const cb of dataCbs) cb(Buffer.from(opts.stdout));
+		handlers.get("close")?.(opts.code ?? 0, null);
+	});
+	return child;
+}
+
+function setPlatform(platform: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", {
+		value: platform,
+		configurable: true,
+	});
+}
+
+const realPlatform = process.platform;
+
+afterEach(() => {
+	setPlatform(realPlatform);
+	fakeSpawn = () => makeFakeChild({ stdout: "" });
+	spawnCalls.length = 0;
+	vi.useRealTimers();
+});
+
+describe("queryProcessTable", () => {
+	it("spawns the composed query and returns its parsed rows", async () => {
+		setPlatform("win32");
+		fakeSpawn = () =>
+			makeFakeChild({ stdout: "111\t7\tnode a.js\r\n222\t7\tnode b.js\r\n" });
+
+		const result = await queryProcessTable(
+			{ fields: ["pid", "ppid", "command"] },
+			{ timeoutMs: 2_000 },
+		);
+
+		expect(result.status).toBe("ok");
+		expect(result.rows).toEqual([
+			{ pid: 111, ppid: 7, command: "node a.js" },
+			{ pid: 222, ppid: 7, command: "node b.js" },
+		]);
+		expect(spawnCalls).toHaveLength(1);
+		expect(spawnCalls[0]?.command.toLowerCase()).toContain("powershell.exe");
+	});
+
+	it("reports whether the platform applied the filter itself", async () => {
+		setPlatform("linux");
+		fakeSpawn = () => makeFakeChild({ stdout: "  111 node a.js\n" });
+
+		const filtered = await queryProcessTable(
+			{
+				fields: ["pid", "command"],
+				filter: { column: "ProcessId", op: "eq", values: [111] },
+			},
+			{ timeoutMs: 2_000 },
+		);
+		expect(filtered.serverSideFiltered).toBe(true);
+		expect(spawnCalls[0]?.args).toEqual(["-p", "111", "-o", "pid=,args="]);
+
+		spawnCalls.length = 0;
+		const unfiltered = await queryProcessTable(
+			{
+				fields: ["pid", "command"],
+				// ps has no server-side name filter: the caller gets the whole
+				// table and must narrow it, which is only safe if it is TOLD.
+				filter: { column: "Name", op: "eq", values: ["node"] },
+			},
+			{ timeoutMs: 2_000 },
+		);
+		expect(unfiltered.serverSideFiltered).toBe(false);
+		expect(spawnCalls[0]?.args).toEqual(["-eo", "pid=,args="]);
+	});
+
+	it("keeps a non-zero exit distinguishable from an empty table", async () => {
+		// The #2438 S5 rule, carried into the clients-side runner: a listing
+		// that printed a table and then died is not evidence of what is NOT
+		// running, so those rows are dropped — and `status` is what tells the
+		// caller that the resulting empty table means nothing.
+		setPlatform("win32");
+		fakeSpawn = () =>
+			makeFakeChild({ stdout: "111\t7\tnode a.js\r\n", code: 1 });
+
+		const result = await queryProcessTable(
+			{ fields: ["pid", "ppid", "command"] },
+			{ timeoutMs: 2_000 },
+		);
+
+		expect(result.status).toBe("exit-error");
+		expect(result.exitCode).toBe(1);
+		expect(result.rows).toEqual([]);
+	});
+
+	it("never spawns for a query the platform cannot answer", async () => {
+		// A Windows-only column on POSIX would become a `ps` invocation with an
+		// unknown column: usage text on stderr, an EMPTY table on stdout, which
+		// reads exactly like "no such process".
+		setPlatform("linux");
+
+		const result = await queryProcessTable(
+			{ fields: ["pid", "rssBytes"] },
+			{ timeoutMs: 2_000 },
+		);
+
+		expect(result.status).toBe("spawn-error");
+		expect(result.rows).toEqual([]);
+		expect(result.serverSideFiltered).toBe(false);
+		expect(spawnCalls).toHaveLength(0);
+	});
+
+	it("unrefs the child and its stdout pipe (#1155)", async () => {
+		// A piped, data-listener-attached child re-references the libuv loop
+		// even after child.unref() unless its stdout pipe is unref'd too, and a
+		// settled `pi --print` must not wait on a best-effort process listing.
+		setPlatform("win32");
+		const spawned: FakeChild[] = [];
+		fakeSpawn = () => {
+			const child = makeFakeChild({ stdout: "" });
+			spawned.push(child);
+			return child;
+		};
+
+		await queryProcessTable({ fields: ["pid"] }, { timeoutMs: 2_000 });
+
+		expect(spawned).toHaveLength(1);
+		expect(spawned[0]?.unref).toHaveBeenCalled();
+		expect(spawned[0]?.stdout.unref).toHaveBeenCalled();
+	});
+
+	it("hands a timed-out child to the caller's own terminator", async () => {
+		// The reaper and the sampler both own tree-kill-and-verify machinery; a
+		// scan that abandons its own scanner child is the defect the scan
+		// exists to fix (#1864 F3), so the handler is INJECTED, not defaulted.
+		setPlatform("win32");
+		vi.useFakeTimers();
+		fakeSpawn = () => makeFakeChild({ holdOpen: true });
+		const onTimeout = vi.fn(async () => "gone" as const);
+
+		const pending = queryProcessTable(
+			{ fields: ["pid"] },
+			{ timeoutMs: 1_000, onTimeout },
+		);
+		await vi.advanceTimersByTimeAsync(1_500);
+		const result = await pending;
+
+		expect(onTimeout).toHaveBeenCalledTimes(1);
+		expect(result.status).toBe("timeout");
+		expect(result.timeoutKill).toBe("gone");
+		// A timed-out listing is bounded, not discarded: whatever it printed
+		// before the deadline is parsed, and `status` carries the warning.
+		expect(result.rows).toEqual([]);
+	});
+});

--- a/tests/clients/resource-sampler.test.ts
+++ b/tests/clients/resource-sampler.test.ts
@@ -5,9 +5,10 @@
  *
  * The sampler is platform-split: on Linux/macOS it uses `pidusage` (mocked
  * here so tests never touch a real process table); on Windows it runs a fully
- * guarded `Get-CimInstance Win32_Process` query (the `node:child_process`
- * `spawn` is mocked so tests never spawn a real process, and each test drives
- * the fake child's stdout / error / exit to exercise a specific path). Both
+ * guarded process-table query through the shared #2443 seam (the
+ * `node:child_process` `spawn` is mocked so tests never spawn a real process,
+ * and each test drives the fake child's stdout / error / exit to exercise a
+ * specific path; the seam emits TAB-joined columns). Both
  * branches are exercised by forcing `process.platform` per describe block, so
  * coverage is identical regardless of the host OS this suite runs on.
  *
@@ -293,7 +294,7 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 	it("never calls pidusage on Windows — the whole point of the fix", async () => {
 		fakeSpawn = () =>
 			makeFakeChild({
-				stdout: "111,1024,0,0,2026-08-30T00:00:00Z\r\n",
+				stdout: "111\t1024\t0\t0\t2026-08-30T00:00:00Z\r\n",
 				code: 0,
 			});
 		await sampleProcesses([111]);
@@ -301,11 +302,11 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 	});
 
 	it("parses RSS (WorkingSetSize) from the CIM output; first tick reports cpu 0", async () => {
-		// One line: pid,workingSet,kernel100ns,user100ns
+		// One row per pid: pid, workingSet, kernel100ns, user100ns, creationDate.
 		fakeSpawn = () =>
 			makeFakeChild({
 				stdout:
-					"111,4096,0,0,2026-08-30T00:00:00Z\r\n222,8192,0,0,2026-08-30T00:00:01Z\r\n",
+					"111\t4096\t0\t0\t2026-08-30T00:00:00Z\r\n222\t8192\t0\t0\t2026-08-30T00:00:01Z\r\n",
 				code: 0,
 			});
 
@@ -321,7 +322,7 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 			// Tick 1: cumulative CPU time = 0 (kernel=0,user=0). Seeds history.
 			fakeSpawn = () =>
 				makeFakeChild({
-					stdout: "111,4096,0,0,2026-08-30T00:00:00Z\r\n",
+					stdout: "111\t4096\t0\t0\t2026-08-30T00:00:00Z\r\n",
 					code: 0,
 				});
 			const first = requireMap(await sampleProcesses([111]));
@@ -332,7 +333,7 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 			vi.setSystemTime(10_000);
 			fakeSpawn = () =>
 				makeFakeChild({
-					stdout: "111,4096,0,50000000,2026-08-30T00:00:00Z\r\n",
+					stdout: "111\t4096\t0\t50000000\t2026-08-30T00:00:00Z\r\n",
 					code: 0,
 				});
 			const second = requireMap(await sampleProcesses([111]));
@@ -349,12 +350,12 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 		try {
 			vi.setSystemTime(0);
 			fakeSpawn = () =>
-				makeFakeChild({ stdout: "111,4096,0,0,2026-08-30T00:00:00Z\r\n" });
+				makeFakeChild({ stdout: "111\t4096\t0\t0\t2026-08-30T00:00:00Z\r\n" });
 			await sampleProcesses([111]);
 			vi.setSystemTime(10_000);
 			fakeSpawn = () =>
 				makeFakeChild({
-					stdout: "111,4096,0,50000000,2026-08-30T00:01:00Z\r\n",
+					stdout: "111\t4096\t0\t50000000\t2026-08-30T00:01:00Z\r\n",
 				});
 			const replacement = requireMap(await sampleProcesses([111]));
 			// The large inherited counter delta belongs to the predecessor. A
@@ -371,27 +372,32 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 			vi.setSystemTime(0);
 			fakeSpawn = () =>
 				makeFakeChild({
-					stdout: "111,4096,10000000,0,2026-08-30T00:00:00Z\r\n",
+					stdout: "111\t4096\t10000000\t0\t2026-08-30T00:00:00Z\r\n",
 				});
 			await sampleProcesses([111]);
 			vi.setSystemTime(10_000);
 			fakeSpawn = () =>
-				makeFakeChild({ stdout: "111,4096,0,0,2026-08-30T00:00:00Z\r\n" });
+				makeFakeChild({ stdout: "111\t4096\t0\t0\t2026-08-30T00:00:00Z\r\n" });
 			expect(requireMap(await sampleProcesses([111])).has(111)).toBe(false);
 		} finally {
 			vi.useRealTimers();
 		}
 	});
 
+	// Every row here is a WELL-FORMED table line (the right column count, tab
+	// separated) carrying ONE unusable value, so the assertion exercises the
+	// per-column rejection rather than passing because the whole line failed to
+	// parse — the CSV spelling these used to carry would have been rejected
+	// wholesale by the tab parser and passed vacuously (#2443).
 	for (const [label, row] of [
-		["empty kernel", "111,4096,,0,2026-08-30T00:00:00Z"],
-		["empty user", "111,4096,0,,2026-08-30T00:00:00Z"],
-		["nonfinite kernel", "111,4096,NaN,0,2026-08-30T00:00:00Z"],
-		["nonfinite user", "111,4096,0,Infinity,2026-08-30T00:00:00Z"],
-		["negative kernel", "111,4096,-1,0,2026-08-30T00:00:00Z"],
-		["negative user", "111,4096,0,-1,2026-08-30T00:00:00Z"],
-		["negative RSS", "111,-1,0,0,2026-08-30T00:00:00Z"],
-		["missing creation identity", "111,4096,0,0,"],
+		["empty kernel", "111\t4096\t\t0\t2026-08-30T00:00:00Z"],
+		["empty user", "111\t4096\t0\t\t2026-08-30T00:00:00Z"],
+		["nonfinite kernel", "111\t4096\tNaN\t0\t2026-08-30T00:00:00Z"],
+		["nonfinite user", "111\t4096\t0\tInfinity\t2026-08-30T00:00:00Z"],
+		["negative kernel", "111\t4096\t-1\t0\t2026-08-30T00:00:00Z"],
+		["negative user", "111\t4096\t0\t-1\t2026-08-30T00:00:00Z"],
+		["negative RSS", "111\t-1\t0\t0\t2026-08-30T00:00:00Z"],
+		["missing creation identity", "111\t4096\t0\t0\t"],
 	] as const) {
 		it(`leaves ${label} Windows usage unmeasured`, async () => {
 			fakeSpawn = () => makeFakeChild({ stdout: `${row}\r\n` });
@@ -402,7 +408,7 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 	it("caps dated PID history and evicts the oldest entry", async () => {
 		const rows = Array.from(
 			{ length: 4_097 },
-			(_, index) => `${index + 1},1,0,0,2026-08-30T00:00:${index}Z`,
+			(_, index) => `${index + 1}\t1\t0\t0\t2026-08-30T00:00:${index}Z`,
 		).join("\r\n");
 		fakeSpawn = () => makeFakeChild({ stdout: rows });
 		await sampleProcesses(Array.from({ length: 4_097 }, (_, i) => i + 1));
@@ -420,10 +426,10 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 		try {
 			vi.setSystemTime(0);
 			const outputs = [
-				"200,0\r\n", // descendant query: one child
-				"111,4096,0,0,2026-08-30T00:00:00Z\r\n", // target only
-				"200,0\r\n",
-				"200,4096,0,50000000,2026-08-30T00:00:00Z\r\n", // target gone
+				"200\t0\r\n", // descendant query: one child
+				"111\t4096\t0\t0\t2026-08-30T00:00:00Z\r\n", // target only
+				"200\t0\r\n",
+				"200\t4096\t0\t50000000\t2026-08-30T00:00:00Z\r\n", // target gone
 			];
 			fakeSpawn = () => makeFakeChild({ stdout: outputs.shift() ?? "" });
 			const resultPromise = sampleProcessTreeCpuPercent(111, 1, 10);
@@ -475,7 +481,7 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 
 	it("reports an errored outcome when the child exits non-zero with garbage stdout", async () => {
 		fakeSpawn = () =>
-			makeFakeChild({ stdout: "not-a-csv-line\r\n<<broken>>\r\n", code: 1 });
+			makeFakeChild({ stdout: "not-a-table-line\r\n<<broken>>\r\n", code: 1 });
 		await expect(sampleProcesses([111])).resolves.toBeNull();
 		expect(
 			getDegradationSummary().find(
@@ -562,7 +568,7 @@ describe("resource-sampler: fire-and-forget CIM spawns are unref'd (#1155)", () 
 		const spawned: ReturnType<typeof makeFakeChild>[] = [];
 		fakeSpawn = () => {
 			const child = makeFakeChild({
-				stdout: "111,4096,0,0,2026-08-30T00:00:00Z\r\n",
+				stdout: "111\t4096\t0\t0\t2026-08-30T00:00:00Z\r\n",
 				code: 0,
 			});
 			spawned.push(child);
@@ -582,7 +588,7 @@ describe("resource-sampler: fire-and-forget CIM spawns are unref'd (#1155)", () 
 		vi.useFakeTimers();
 		const spawned: ReturnType<typeof makeFakeChild>[] = [];
 		fakeSpawn = () => {
-			// Every call here is the descendant-lookup query (pid,parentPid CSV) —
+			// Every call here is the descendant-lookup query (pid/parentPid rows) —
 			// empty output resolves to no descendants, which is fine; the point is
 			// only to observe the spawned child's unref calls.
 			const child = makeFakeChild({ stdout: "", code: 0 });

--- a/tests/config/process-table-seam.test.ts
+++ b/tests/config/process-table-seam.test.ts
@@ -1,0 +1,148 @@
+/**
+ * #2443 — one process-table seam, mechanically.
+ *
+ * Five hand-rolled snapshotters (Windows `Get-CimInstance Win32_Process`
+ * plus POSIX `ps -eo`) had grown across `clients/` and `scripts/`: the
+ * instance reaper, both resource-sampler queries, the compat smoke and the
+ * worktree-prune hook. Same projection, same "fail to an empty table" shape,
+ * five copies — so PR #2438's exit-code hardening reached one of them and
+ * not the others.
+ *
+ * A comment saying "use the seam" is not a guard. This walks the shipped
+ * source trees and the scripts tooling for the query fragments themselves
+ * and requires that exactly one file spells them: the seam,
+ * `scripts/lib/process-scan.mjs`.
+ *
+ * Comments are BLANKED and string contents are KEPT (`strings: "keep"`), so
+ * the sweep matches the query a file actually BUILDS, never prose about it —
+ * a module docstring is still free to explain why the platform listing looks
+ * the way it does.
+ *
+ * The seam itself is `registered`, not exempted, which is what keeps the
+ * sweep alive: it always flags at least one file, so a walk that silently
+ * stopped finding anything reds instead of reading as clean (defect shape
+ * 10).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+	auditRegistry,
+	listSourceFiles,
+	relativePosix,
+	stripSource,
+} from "../support/sweep-kit.js";
+
+const REPO_ROOT = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+
+/** The one file allowed to spell a platform process-table query. */
+const SEAM = "scripts/lib/process-scan.mjs";
+
+/**
+ * The query fragments themselves. Each is a piece of platform syntax that
+ * only a process-table snapshotter has any reason to emit:
+ *
+ * - `Get-CimInstance` / `Win32_Process`: the Windows CIM listing;
+ * - a bare `-eo` argument: `ps`'s "every process, these columns" projection;
+ * - a `pid=,` column list: the `-o pid=,args=` header-suppressed projection
+ *   used by the pid-filtered `ps` form.
+ */
+const QUERY_FRAGMENTS: ReadonlyArray<{ name: string; pattern: RegExp }> = [
+	{ name: "Get-CimInstance", pattern: /Get-CimInstance/ },
+	{ name: "Win32_Process", pattern: /Win32_Process/ },
+	{ name: "ps -eo projection", pattern: /(?<![\w-])-eo(?![\w-])/ },
+	{ name: "ps -o pid= projection", pattern: /(?<![\w-])pid=,/ },
+];
+
+/** The shipped runtime plus the scripts tooling — every tree that could grow
+ *  a sixth copy. `clients/` is scanned as TypeScript only: the sibling
+ *  `clients/*.js` are gitignored build output of those same sources. */
+const SCAN_ROOTS: ReadonlyArray<{ dir: string; extensions: string[] }> = [
+	{ dir: "clients", extensions: [".ts"] },
+	{ dir: "commands", extensions: [".ts"] },
+	{ dir: "mcp", extensions: [".ts"] },
+	{ dir: "tools", extensions: [".ts"] },
+	{ dir: "scripts", extensions: [".mjs", ".js", ".cjs"] },
+];
+
+function scannedFiles(): string[] {
+	const files = SCAN_ROOTS.flatMap(({ dir, extensions }) => {
+		const root = path.join(REPO_ROOT, dir);
+		if (!fs.existsSync(root)) return [];
+		return listSourceFiles(root, { extensions, skipTests: true });
+	}).map((file) => relativePosix(REPO_ROOT, file));
+	const entry = path.join(REPO_ROOT, "index.ts");
+	if (fs.existsSync(entry)) files.push("index.ts");
+	return files.sort();
+}
+
+function fragmentsIn(relativePath: string): string[] {
+	const source = stripSource(
+		fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8"),
+		{ strings: "keep" },
+	);
+	return QUERY_FRAGMENTS.filter(({ pattern }) => pattern.test(source)).map(
+		({ name }) => name,
+	);
+}
+
+describe("process-table seam (#2443)", () => {
+	it("detects each query fragment independently", () => {
+		// The sweep is only as good as its needles: pin each one against the
+		// literal it exists to catch, so a silently-broken pattern reds here
+		// rather than quietly widening the tree.
+		const strippedKeepsStrings = stripSource(
+			'const q = "Get-CimInstance -Query \\"SELECT ProcessId FROM Win32_Process\\"";',
+			{ strings: "keep" },
+		);
+		expect(/Get-CimInstance/.test(strippedKeepsStrings)).toBe(true);
+		expect(/Win32_Process/.test(strippedKeepsStrings)).toBe(true);
+		expect(/(?<![\w-])-eo(?![\w-])/.test('["-eo", "pid=,ppid=,args="]')).toBe(
+			true,
+		);
+		expect(/(?<![\w-])pid=,/.test('"pid=,args="')).toBe(true);
+		// ...and never on prose, which stripSource blanks.
+		expect(
+			/Win32_Process/.test(
+				stripSource("// POSIX ps and Windows Win32_Process listings\n", {
+					strings: "keep",
+				}),
+			),
+		).toBe(false);
+	});
+
+	it("keeps the platform process-table query in exactly one file", () => {
+		const files = scannedFiles();
+		const flagged = files.filter((file) => fragmentsIn(file).length > 0);
+
+		const audit = auditRegistry({
+			sweepName: "process-table seam",
+			flagged,
+			registered: [SEAM],
+			scannedCount: files.length,
+			// Calibration: 900+ source files across clients/, commands/, mcp/,
+			// tools/, scripts/ and index.ts on 2026-09-02. The floor is set well
+			// under that so it survives ordinary churn while still failing loud
+			// if the walk ever resolves to nothing (defect shape 10).
+			minScanned: 300,
+			minFlagged: 1,
+			remediation:
+				`Build the query through ${SEAM} (buildProcessQuery/snapshotProcesses, ` +
+				"or clients/process-snapshot.ts for the clients-side spawn rails) " +
+				"instead of spelling Get-CimInstance/ps -eo again. Five copies of " +
+				"this listing meant PR #2438's exit-code hardening reached one of " +
+				"them and not the rest.",
+		});
+
+		expect(audit.problems).toEqual([]);
+		expect(
+			flagged.filter((file) => file !== SEAM),
+			`files spelling a process-table query outside ${SEAM}`,
+		).toEqual([]);
+	});
+});

--- a/tests/packaging.test.ts
+++ b/tests/packaging.test.ts
@@ -379,8 +379,9 @@ describe("tsconfig.dist.json", () => {
 	const dist = JSON.parse(
 		fs.readFileSync(path.join(root, "tsconfig.dist.json"), "utf8"),
 	) as {
-		compilerOptions?: { outDir?: string; types?: string[] };
+		compilerOptions?: { outDir?: string; types?: string[]; allowJs?: boolean };
 		exclude?: string[];
+		include?: string[];
 	};
 
 	it("emits to ./dist", () => {
@@ -397,5 +398,30 @@ describe("tsconfig.dist.json", () => {
 		// `prepare`. In that environment dev-only @types/node is absent, so the
 		// dist config must not inherit the base config's `types: ["node"]` entry.
 		expect(dist.compilerOptions?.types).toEqual([]);
+	});
+
+	it("compiles the shared process-table seam into dist so esbuild can inline it", () => {
+		// #2443: `clients/process-snapshot.ts` imports
+		// `../scripts/lib/process-scan.mjs` (the seam lives in scripts/ because
+		// the worktree-hygiene hooks run before anything is built — see that
+		// file's header). tsc resolves its TYPES from the sibling `.d.mts` and
+		// would emit no JS at all, leaving `dist/clients/process-snapshot.js`
+		// importing a file that is not there — and `bundle:dist` then dies with
+		// "Could not resolve". Naming the .mjs in `include` (with `allowJs`)
+		// puts it at `dist/scripts/lib/process-scan.mjs`, exactly where that
+		// relative specifier lands.
+		expect(dist.compilerOptions?.allowJs).toBe(true);
+		expect(dist.include ?? []).toContain("scripts/lib/process-scan.mjs");
+	});
+
+	it("keeps tsconfig.dist.json parseable as strict JSON", () => {
+		// This suite reads it with JSON.parse, and so does anything else that
+		// treats a tsconfig as data rather than handing it to tsc: a `//`
+		// comment here fails at read time, not at build time.
+		expect(() =>
+			JSON.parse(
+				fs.readFileSync(path.join(root, "tsconfig.dist.json"), "utf8"),
+			),
+		).not.toThrow();
 	});
 });

--- a/tests/scripts/process-scan.test.ts
+++ b/tests/scripts/process-scan.test.ts
@@ -8,7 +8,11 @@
 
 import { describe, expect, it } from "vitest";
 import {
+	ageMsFromPosixEtime,
+	buildProcessQuery,
 	diffSurvivingLspProcesses,
+	escapeWqlLikeValue,
+	escapeWqlStringValue,
 	evaluateNoSurvivingLspProcesses,
 	isLspServerCommand,
 	normalizeProcessFields,
@@ -19,6 +23,28 @@ import {
 	ALL_PROCESS_FIELDS,
 	LSP_PROCESS_MARKERS,
 } from "../../scripts/lib/process-scan.mjs";
+
+/**
+ * Both branches of `buildProcessQuery` ship — the Windows one to every user
+ * on Windows, the POSIX one to every user on Linux/macOS — and neither CI
+ * runner covers both. The seam reads `process.platform` live for exactly this
+ * reason, so the tests drive it.
+ */
+function withPlatform<T>(platform: NodeJS.Platform, body: () => T): T {
+	const original = process.platform;
+	Object.defineProperty(process, "platform", {
+		value: platform,
+		configurable: true,
+	});
+	try {
+		return body();
+	} finally {
+		Object.defineProperty(process, "platform", {
+			value: original,
+			configurable: true,
+		});
+	}
+}
 
 describe("LSP_PROCESS_MARKERS", () => {
 	it("is a non-empty array of distinctive command fragments", () => {
@@ -197,18 +223,171 @@ describe("windowsExe", () => {
 });
 
 describe("posixPsPath", () => {
-	it("prefers the absolute /bin/ps when present, falling back to the bare name otherwise", async () => {
+	it("always resolves an ABSOLUTE ps, never a bare PATH-resolved name", async () => {
 		// The listing decides what the sweep KILLS, so it must not resolve
 		// through a PATH a caller can shadow — mirrors windowsExe's reasoning
-		// (PR #2438 review round 4, F-D). Whichever branch this box takes, the
-		// two are the only allowed answers.
+		// (PR #2438 review round 4, F-D). #2443 adopted the reaper's stricter
+		// form: /bin/ps, then /usr/bin/ps, and /bin/ps as the fail-closed
+		// default, so a host with neither fails the spawn instead of silently
+		// running whatever `ps` a PATH entry points at.
 		const fs = await import("node:fs");
 		const resolved = posixPsPath();
+		expect(resolved.startsWith("/")).toBe(true);
 		if (fs.existsSync("/bin/ps")) {
 			expect(resolved).toBe("/bin/ps");
 		} else {
-			expect(resolved).toBe("ps");
+			expect(["/bin/ps", "/usr/bin/ps"]).toContain(resolved);
 		}
+	});
+});
+
+describe("buildProcessQuery (#2443: the one composed platform listing)", () => {
+	it("projects only the requested Windows columns, tab-joined", () => {
+		const query = withPlatform("win32", () =>
+			buildProcessQuery(["pid", "command"]),
+		);
+		expect(query.tabSeparated).toBe(true);
+		expect(query.command.toLowerCase()).toContain("powershell.exe");
+		const script = query.args.at(-1) ?? "";
+		expect(script).toContain("SELECT ProcessId,CommandLine FROM");
+		// Never the unprojected form: measured ~570ms vs ~316ms on the #2435 box.
+		expect(script).not.toContain("SELECT * ");
+		expect(script).not.toContain("ParentProcessId");
+	});
+
+	it("asks ps for the same projection with header-suppressed columns", () => {
+		const query = withPlatform("linux", () =>
+			buildProcessQuery(["command", "ppid", "pid"]),
+		);
+		expect(query.tabSeparated).toBe(false);
+		expect(query.args).toEqual(["-eo", "pid=,ppid=,args="]);
+		expect(query.serverSideFiltered).toBe(false);
+	});
+
+	it("computes the Windows age IN PowerShell, never from a local-time tick", () => {
+		// #1857: CreationDate.Ticks is the LOCAL-time representation, so an age
+		// differenced in JS was wrong by the host's UTC offset. The delta has to
+		// be taken on one side of the boundary.
+		const script =
+			withPlatform("win32", () =>
+				buildProcessQuery(["pid", "ageMs", "command"]),
+			).args.at(-1) ?? "";
+		expect(script).toContain("SELECT ProcessId,CreationDate,CommandLine FROM");
+		expect(script).toContain("TotalMilliseconds");
+		expect(script).toContain("-is [datetime]");
+		expect(script).not.toContain("Ticks");
+	});
+
+	it("filters server-side by pid on both platforms", () => {
+		const win = withPlatform("win32", () =>
+			buildProcessQuery(["pid", "command"], {
+				filter: { column: "ProcessId", op: "eq", values: [11, 22] },
+			}),
+		);
+		expect(win.serverSideFiltered).toBe(true);
+		expect(win.args.at(-1)).toContain("WHERE ProcessId=11 OR ProcessId=22");
+
+		const posix = withPlatform("darwin", () =>
+			buildProcessQuery(["pid", "command"], {
+				filter: { column: "ProcessId", op: "eq", values: [11, 22] },
+			}),
+		);
+		expect(posix.serverSideFiltered).toBe(true);
+		expect(posix.args).toEqual(["-p", "11,22", "-o", "pid=,args="]);
+	});
+
+	it("reports an image-name filter as NOT applied on POSIX", () => {
+		// ps has no server-side name filter, so the caller holds the whole table
+		// and must narrow it itself. Saying so is the point: a caller that read
+		// the rows as pre-filtered would kill unrelated processes.
+		const posix = withPlatform("linux", () =>
+			buildProcessQuery(["pid", "command"], {
+				filter: { column: "Name", op: "eq", values: ["node"] },
+			}),
+		);
+		expect(posix.serverSideFiltered).toBe(false);
+		expect(posix.args).toEqual(["-eo", "pid=,args="]);
+	});
+
+	it("escapes WQL string and LIKE values, and rejects a non-pid pid", () => {
+		expect(escapeWqlStringValue("o'brien.exe")).toBe("o''brien.exe");
+		expect(escapeWqlLikeValue("a%b_c'd")).toBe("a[%]b[_]c''d");
+		const script =
+			withPlatform("win32", () =>
+				buildProcessQuery(["pid"], {
+					filter: {
+						column: "CommandLine",
+						op: "like",
+						values: ["C:\\marker'%x"],
+					},
+					excludeSelfPid: true,
+				}),
+			).args.at(-1) ?? "";
+		expect(script).toContain("CommandLine LIKE '%C:\\marker''[%]x%'");
+		expect(script).toContain("$_.ProcessId -ne $PID");
+
+		expect(() =>
+			withPlatform("win32", () =>
+				buildProcessQuery(["pid"], {
+					filter: {
+						column: "ProcessId",
+						op: "eq",
+						values: ["1 OR 1=1" as unknown as number],
+					},
+				}),
+			),
+		).toThrow(/invalid pid/);
+	});
+
+	it("throws rather than silently dropping a Windows-only column on POSIX", () => {
+		// A ps invocation with an unknown column prints usage to stderr and
+		// exits with an EMPTY table, which reads exactly like "no such process".
+		expect(() =>
+			withPlatform("linux", () => buildProcessQuery(["pid", "rssBytes"])),
+		).toThrow(/no POSIX ps column/);
+	});
+});
+
+describe("parseProcessTable: the extended projections (#2443)", () => {
+	it("reads the Windows CPU/RSS row the resource sampler asks for", () => {
+		const rows = parseProcessTable(
+			"111\t4096\t10000000\t50000000\t2026-08-30T00:00:00Z",
+			true,
+			["pid", "rssBytes", "cpuKernel100ns", "cpuUser100ns", "startedAt"],
+		);
+		expect(rows).toEqual([
+			{
+				pid: 111,
+				ppid: 0,
+				command: "",
+				rssBytes: 4096,
+				cpuKernel100ns: 10_000_000,
+				cpuUser100ns: 50_000_000,
+				startedAt: "2026-08-30T00:00:00Z",
+			},
+		]);
+	});
+
+	it("reads an UNKNOWN age as undefined, never as zero", () => {
+		// A zero age reads as "just spawned" and the spawn-grace guard spares
+		// the process forever; undefined routes it to the unknownAge bucket.
+		const windows = parseProcessTable("111\t7\t\tnode x", true, [
+			"pid",
+			"ppid",
+			"ageMs",
+			"command",
+		]);
+		expect(windows).toEqual([
+			{ pid: 111, ppid: 7, ageMs: undefined, command: "node x" },
+		]);
+
+		const posix = parseProcessTable("  111     7 01:02:03 node x", false, [
+			"pid",
+			"ppid",
+			"ageMs",
+			"command",
+		]);
+		expect(posix[0]?.ageMs).toBe(ageMsFromPosixEtime("01:02:03"));
 	});
 });
 

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -5,7 +5,8 @@
 		"outDir": "./dist",
 		"declaration": false,
 		"sourceMap": false,
-		"types": []
+		"types": [],
+		"allowJs": true
 	},
 	"include": [
 		"index.ts",
@@ -13,7 +14,8 @@
 		"clients/**/*.ts",
 		"commands/**/*.ts",
 		"tools/**/*.ts",
-		"mcp/**/*.ts"
+		"mcp/**/*.ts",
+		"scripts/lib/process-scan.mjs"
 	],
 	"exclude": ["node_modules", "tests", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Five hand-rolled process-table snapshotters collapse onto one seam.

The Windows `Get-CimInstance Win32_Process` / POSIX `ps` listing was written
out five times: `clients/instance-reaper.ts` (marker search, identity query,
managed-process enumeration) and `clients/resource-sampler.ts` (descendant-pid
resolution, CPU/RSS sampling), on top of the two `scripts/` callers PR #2438
had already folded together. Same projection, same fail-to-an-empty-table
shape — which is exactly why #2438's exit-code hardening (a `ps` that prints a
partial table and then dies must not read as complete) landed in one copy and
not the rest.

`scripts/lib/process-scan.mjs` is now the ONE place a platform listing is
composed and read back:

- `buildProcessQuery(fields, { filter, excludeSelfPid })` → `{ command, args,
  tabSeparated, fields, serverSideFiltered }`;
- `parseProcessTable(out, tabSeparated, fields)` → rows;
- `snapshotProcesses(fields, timeoutMs, options)` — the scripts-side bounded
  spawn around the pair (unchanged signature; both `scripts/` callers are
  untouched).

The projection is `pid`, `ppid`, `ageMs`, `rssBytes`, `cpuKernel100ns`,
`cpuUser100ns`, `startedAt`, `command`; the default is the portable trio
(`pid`/`ppid`/`command`), because the CPU/RSS columns exist on the Windows
side only. Asking for a Windows-only column on POSIX **throws** rather than
producing a `ps` invocation with an unknown column — that failure mode prints
usage to stderr and an EMPTY table to stdout, which reads exactly like "no
such process". WQL escaping (`escapeWqlLikeValue`/`escapeWqlStringValue`) and
pid validation moved into the seam with the query they protect, and
`serverSideFiltered` tells a caller when `ps` could not apply the filter and
it is therefore still holding the whole table.

### Boundary decision (the issue asked for it to be stated)

The seam stays in `scripts/`, and `clients/` reaches it through ONE crossing
point, the new `clients/process-snapshot.ts`.

The alternative — a `clients/process-snapshot.ts` compiled to `.js` and
imported by `scripts/`, which is how ~20 other scripts already consume client
code — was rejected on one piece of evidence: `clients/*.js` is gitignored
build output, and `scripts/prune-agent-worktrees.mjs` is a
SessionStart/SubagentStop hook that runs **inside freshly created agent
worktrees**. This very worktree had no `node_modules` and zero `clients/*.js`
when the session started. A hygiene hook that dies with
`ERR_MODULE_NOT_FOUND` in the exact environment #2435 built it for is worse
than the duplication being removed. So the shared half is the side that needs
no build, and it stays dependency-free (node: builtins only).

`clients/process-snapshot.ts` keeps what the extension runtime genuinely needs
and a script does not: an unref'd child + stdout pipe (#1155), an injected
tree-kill-and-verify timeout handler (#1864 F3), and a `SpawnCollectStatus` so
"the table is empty" stays distinguishable from "the query never ran" (#1857).
Query and parse are shared; only the spawn differs, and it differs for a
reason.

One build consequence, found by running the packaging build rather than
reasoning about it: `tsc` resolves the `.mjs` through its sibling `.d.mts` and
emits no JS, so `dist/clients/process-snapshot.js` imported a file that was
not there and `bundle:dist` died with `Could not resolve
"../scripts/lib/process-scan.mjs"`. `tsconfig.dist.json` now names the file in
`include` with `allowJs`, which puts it at `dist/scripts/lib/process-scan.mjs`
where that relative specifier lands; esbuild then inlines it into the bundle.
Pinned by a new case in `tests/packaging.test.ts` (plus a case asserting the
file stays strict-JSON parseable, which is how the comment I first wrote there
was caught).

### Per-site verdict table

| Site | Before | After | Notes |
| --- | --- | --- | --- |
| `clients/instance-reaper.ts` `findPidsByMarkerWindows` | own `Get-CimInstance … -Filter "CommandLine LIKE …"` + `$PID` exclusion + own LIKE escaping | `queryProcessTable({fields:["pid"], filter:{column:"CommandLine",op:"like"}, excludeSelfPid:true})` | escaping and the self-exclusion now live with the query |
| `clients/instance-reaper.ts` `queryCommandLines` | Windows CIM branch + POSIX `ps -p … -o pid=,args=` branch, two inline parsers | one `queryProcessTable({fields:["pid","command"], filter:{column:"ProcessId",op:"eq"}})` | the POSIX `-p` form is the seam's pid-filter path; the "`ps -p` exits nonzero when no pid exists" tolerance stays in the caller and is now explicitly POSIX-only |
| `clients/instance-reaper.ts` `enumerateManagedProcesses` | CIM `SELECT …,CreationDate … WHERE Name = …` + POSIX `ps -eo pid=,ppid=,etime=,args=`, two hand-written linear parsers, own `ageMsFromPosixEtime`/`parseNonNegativeMs` | `queryProcessTable({fields:["pid","ppid","ageMs","command"], filter:{column:"Name",op:"eq"}})` | age is still computed IN PowerShell as a ms delta (#1857 local-time `Ticks` bug); `narrowToManagedBinaries` still runs on both platforms because `serverSideFiltered` is false on POSIX |
| `clients/resource-sampler.ts` `findDescendantPidsWindows` | own CIM pid/ppid CSV query + `spawnCollectStdoutResult` plumbing | `queryProcessTable({fields:["pid","ppid"]})` | same unref + `terminateScannerChild` rails, now supplied by the seam |
| `clients/resource-sampler.ts` `sampleProcessesWindows` | own CIM `-Filter "ProcessId=…"` CSV query with a `parts.slice(4).join(",")` hack for a CreationDate that might contain a comma | `queryProcessTable({fields:["pid","rssBytes","cpuKernel100ns","cpuUser100ns","startedAt"], filter:{column:"ProcessId",op:"eq"}})` | tab-joined output removes the comma hack; per-column validation moves into the parser (an untrusted column is `undefined`, never 0) |
| `scripts/prune-agent-worktrees.mjs` | already on `snapshotProcesses` (#2438 F2) | unchanged | signature preserved |
| `scripts/compat-smoke-behavioral.mjs` | already on `snapshotProcesses` (#2438 F2) | unchanged | signature preserved |

Two behaviour changes worth naming explicitly:

- `posixPsPath()` in the seam adopted the reaper's stricter form
  (`/bin/ps` → `/usr/bin/ps` → `/bin/ps` as a fail-closed default) over the
  scripts version's bare-`ps` fallback. One seam, the safer of the two.
- `buildProcessQuery` reads `process.platform` LIVE rather than as a
  module-load constant, so both branches are testable on either host — the
  same reasoning `clients/resource-sampler.ts` already states for its own
  platform check.

Deleted, not deprecated: `instance-reaper`'s `windowsExe` (re-exported from
the seam via `process-snapshot.ts`), `posixPsPath`, `escapeWqlLikeValue`,
`escapeWqlStringValue`, `parseNonNegativeMs`, `ageMsFromPosixEtime`,
`POSIX_PS_ARGS`, and all five inline parsers.

Closes #2443 — the primitive exists, all named sites call it, the grep guard
is a test.

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [x] area:observability
- [x] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (no dependency change)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there
- [x] `.changelog/2443-process-table-seam.md` has one valid entry **in this PR**
- [x] Commit subject includes the issue number: `(closes #2443)`

`npm run lint`: `tsc --project tsconfig.json` exits 0; `oxlint` exits 0 at the
**pinned** 1.80.0 (`npx --yes oxlint@1.80.0 …` → `OXLINT=0`). The junctioned
`node_modules` in this worktree carries oxlint 1.69.0, which reports two
pre-existing `no-control-regex` warnings in `tools/ast-grep-search.ts`, a file
this PR does not touch; the pinned version reports nothing. `oxfmt@0.65.0
--check` is clean on all 11 touched files (it flagged 4 of them before I
formatted).

## Tests

New files:

- **`tests/config/process-table-seam.test.ts`** — the conformance sweep the
  issue asks for, built on `tests/support/sweep-kit.ts` (`listSourceFiles` +
  `stripSource` + `auditRegistry`, not a hand-rolled walk). It walks
  `clients/`, `commands/`, `mcp/`, `tools/`, `scripts/` and `index.ts` with
  comments BLANKED and string contents KEPT (`strings: "keep"`), so it matches
  the query a file actually BUILDS and never prose about it — a module
  docstring stays free to explain the platform. The seam is `registered`
  rather than exempted, which is what keeps the sweep alive: it always flags
  at least one file, so a walk that stopped finding anything reds instead of
  reading as clean (defect shape 10). Floors: `minFlagged: 1`,
  `minScanned: 300`. A second case pins each needle against the literal it
  exists to catch, so a silently-broken pattern reds here.
- **`tests/clients/process-snapshot.test.ts`** — the clients-side runner, with
  `node:child_process` mocked. Pins: rows parsed from the composed query;
  `serverSideFiltered` true for a pid filter and FALSE for a `Name` filter on
  POSIX (with the exact `ps` argv both times); a non-zero exit dropping rows
  while `status` carries the reason; NO spawn at all for a query the platform
  cannot answer; child + stdout `unref` (#1155); and the injected `onTimeout`
  handler being the one that terminates a timed-out child (#1864 F3) with
  `status: "timeout"`.

Edited:

- **`tests/scripts/process-scan.test.ts`** — added `buildProcessQuery` and
  extended-`parseProcessTable` coverage: the Windows projection is exactly the
  columns asked for and never `SELECT *`; the POSIX argv; the age computed in
  PowerShell with the `[datetime]` guard and no `Ticks`; server-side pid
  filtering on both platforms; an image-name filter reported as NOT applied on
  POSIX; WQL escaping and a rejected non-pid pid; the throw for a Windows-only
  column on POSIX; the CPU/RSS row; and an unknown age reading `undefined`,
  never 0. Both platform branches are driven through a `withPlatform` helper.
  The `posixPsPath` case now asserts an ABSOLUTE path in every branch.
- **`tests/clients/instance-reaper-posix-ps.test.ts`** — the real-`ps` suite
  now spawns the command the SEAM composes for the reaper's projection instead
  of a local copy of the argv, and imports `ageMsFromPosixEtime` from the seam.
  A new case pins the argv itself.
- **`tests/clients/resource-sampler.test.ts`** — CIM fixtures migrated from
  comma- to tab-joined. The malformed-row table (empty/NaN/negative
  kernel/user/RSS, missing creation identity) had to be migrated too, and that
  is the interesting part: as CSV those rows are rejected WHOLESALE by the tab
  parser, so the assertions would have passed without ever reaching the
  per-column validation they exist to test — a vacuous pass. They are now
  well-formed table lines carrying one unusable value each.
- **`tests/packaging.test.ts`** — two cases on `tsconfig.dist.json`: that it
  compiles the seam into `dist` (`allowJs` + the `include` entry), and that it
  stays strict-JSON parseable.

Test-authoring screens (AGENTS.md): **implementation mirror** — the sweep
matches the platform query STRINGS, not a symbol name a refactor could rename
past it; **ambient-inspection double** — the fake `spawn` in
`process-snapshot.test.ts` consumes the argv and drives real `close`/`error`
events, and the seam's own POSIX/Windows argv is asserted rather than assumed;
**invisible skip** — the real-`ps` suite's `describe.skipIf` probes the
filesystem for the binary rather than `process.platform`, and the seam's live
platform read means the OTHER platform's branch is still covered on this host;
**all-mocks** — `tests/scripts/process-scan.test.ts` still runs a REAL
`snapshotProcesses()` against the host process table; **loose bound** — the
sweep declares `minFlagged`/`minScanned` floors instead of trusting an empty
result.

### Red proofs

All quoted from my own runs. Working tree = this branch's commit `82b51985`
with only the source under proof reverted to `origin/master`
(`git checkout origin/master -- clients/instance-reaper.ts
clients/resource-sampler.ts tsconfig.dist.json`, rebuilt, then restored — the
tests and the seam stayed committed).

The conformance sweep, run on the pre-fix tree BEFORE any source was written
(this is the first thing I did) and again from the reverted state — identical
both times:

```
 FAIL  |default| tests/config/process-table-seam.test.ts > process-table seam (#2443) > keeps the platform process-table query in exactly one file
AssertionError: expected [ Array(1) ] to deeply equal []

- Expected
+ Received

- []
+ [
+   "process-table seam: 2 flagged item(s) are neither registered nor exempted:
+   clients/instance-reaper.ts
+   clients/resource-sampler.ts
+
+ Build the query through scripts/lib/process-scan.mjs (buildProcessQuery/snapshotProcesses, or clients/process-snapshot.ts for the clients-side spawn rails) instead of spelling Get-CimInstance/ps -eo again. Five copies of this listing meant PR #2438's exit-code hardening reached one of them and not the rest.",
+ ]
```

The packaging guard, with `tsconfig.dist.json` reverted:

```
 FAIL  |default| tests/packaging.test.ts > tsconfig.dist.json > compiles the shared process-table seam into dist so esbuild can inline it
AssertionError: expected undefined to be true // Object.is equality

- Expected:
true

+ Received:
undefined

 ❯ tests/packaging.test.ts:413:41
```

That guard is not theoretical — this is the real `bundle:dist` failure it
exists to prevent, from my own run before the tsconfig change:

```
    dist/clients/process-snapshot.js:27:54:
      27 │ ...uery, parseProcessTable, } from "../scripts/lib/process-scan.mjs";
         ╵                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

1 error
```

The migrated sampler contract, with `clients/resource-sampler.ts` reverted:

```
 ❯ |default| tests/clients/resource-sampler.test.ts (46 tests | 4 failed) 42ms
     × parses RSS (WorkingSetSize) from the CIM output; first tick reports cpu 0 6ms
     × computes CPU% from the kernel+user delta over elapsed wall time on the second tick 5ms
     × invalidates CPU history when Windows reuses a PID 2ms
     × caps dated PID history and evicts the oldest entry 6ms
```

Green after restoring and rebuilding:

```
 Test Files  1 failed | 30 passed (31)
      Tests  491 passed | 3 skipped (494)
```

The one failure is `tests/config/dependency-boundaries.test.ts`, which cannot
run in this worktree: `Error: Cannot find module 'json5'`. `json5` (^2.2.3)
and `dependency-cruiser` (^18.2.0) are devDependencies that are simply not
installed in the `node_modules` this worktree is junctioned to — an
environment gap, unrelated to this change and reproducible on `origin/master`.
That suite (and `npm run depcruise:check`) is CI's. This PR adds no import
cycle: `clients/child-unref.ts` deliberately imports nothing from `clients/`,
so `instance-reaper → process-snapshot → child-unref` is acyclic and the
reviewed static-cycle baseline of 31 should be unchanged.

Suites run green locally after `npm run build`:
`tests/config/` (18 of 19), `tests/packaging.test.ts`,
`tests/typescript-runtime-free.test.ts`, `tests/clients/process-snapshot.test.ts`,
`tests/clients/resource-sampler.test.ts`, all five `instance-reaper*` suites,
`tests/scripts/process-scan.test.ts`,
`tests/scripts/prune-agent-worktrees.test.ts`,
`tests/scripts/worktree-hygiene.test.ts`,
`tests/clients/safe-spawn-timeout-teardown.test.ts`,
`tests/clients/safe-spawn-{cap-race,close-before-error-race,sync-throw,windows-env-plumbing}.test.ts`,
`tests/clients/atomic-write-stage-gc.test.ts`,
`tests/clients/instance-registry.test.ts`, `tests/clients/warm-attach.test.ts`,
`tests/clients/lsp-budget.test.ts`,
`tests/clients/safe-spawn-resource-usage.test.ts`,
`tests/index-loop-block-wiring.test.ts`.
Every `tests/config/*.test.ts` sweep was run regardless of which tree it
walks, per the directory-scanning-governance rule.

### Test assessment

- `tests/config/process-table-seam.test.ts` — uniquely pins "exactly one file
  spells a platform process-table query". Nothing else in the tree asserts
  this. No redundancy introduced.
- `tests/clients/process-snapshot.test.ts` — uniquely pins the clients-side
  spawn rails around the seam. It overlaps `tests/clients/instance-reaper-
  unref.test.ts` and the sampler's "#1155 unref" describe on the unref
  assertion, but those two pin unref for their OWN call paths (the reaper's
  enumeration child; the sampler's two poll-tick children) and would still
  red if this module stopped unref'ing while they were rewired around it — I
  am not proposing to remove them.
- `tests/scripts/process-scan.test.ts` — uniquely pins the seam's query
  composition and parsing, both platforms, plus a real listing of the host
  process table.
- `tests/clients/instance-reaper-posix-ps.test.ts` — uniquely pins that a REAL
  `ps` accepts the reaper's column vector. Still the only real-`ps` acceptance
  test; it now also pins the argv the seam composes.
- `tests/clients/resource-sampler.test.ts` — uniquely pins the CPU%/RSS
  arithmetic, the pid-reuse discriminator and the never-throw crash
  regressions (#533/#620). The fixture migration made 8 previously-vacuous
  malformed-row cases actually exercise per-column validation.
- `tests/packaging.test.ts` — uniquely pins the published-build config.

No test is made redundant by this PR; no removal candidates.

## Blast radius

`module_report` with `blastRadius: true` was NOT available in this worktree
(no `node_modules`/build at session start; the MCP server is not wired into
this session), so the dependents below come from a direct import grep over
`clients/`, `tools/`, `mcp/`, `commands/`, `index.ts`, `scripts/` and
`tests/` — recorded as a gap rather than claimed as tool output.

- **`scripts/lib/process-scan.mjs`** (changed): imported by
  `scripts/prune-agent-worktrees.mjs` (SessionStart/SubagentStop hook),
  `scripts/compat-smoke-behavioral.mjs`, `tests/scripts/process-scan.test.ts`,
  `tests/clients/instance-reaper-posix-ps.test.ts`, and now
  `clients/process-snapshot.ts`. The `snapshotProcesses` signature and the
  default projection are unchanged, so both script callers are byte-identical.
- **`clients/process-snapshot.ts`** (new): imported by
  `clients/instance-reaper.ts` and `clients/resource-sampler.ts`. Imports
  `clients/child-unref.ts` only, which imports nothing from `clients/` — no
  cycle.
- **`clients/instance-reaper.ts`** (changed): the orphan reaper's public
  surface loses `windowsExe`, `POSIX_PS_ARGS` and `ageMsFromPosixEtime`; the
  only in-repo consumers were `clients/resource-sampler.ts` (rewired) and
  `tests/clients/instance-reaper-posix-ps.test.ts` (rewired). `sweepOrphans`,
  `decideOrphanReaping`, `killPidTree` and `terminateScannerChild` are
  untouched.
- **`clients/resource-sampler.ts`** (changed): consumed by
  `clients/safe-spawn.ts` (per-spawn bracketing) and the heartbeat path. The
  exported surface is unchanged.
- **`tsconfig.dist.json`** (changed): affects `npm run build:dist` / `prepare`
  only. Verified by running it — `[bundle] wrote self-contained dist\index.js`,
  with `dist/scripts/lib/process-scan.mjs` emitted and `buildProcessQuery`
  present in the bundled `dist/index.js`.

Hot paths touched: the sampler's per-poll-tick query (`startSpawnUsageSampler`
polls while a spawn is in flight) and the reaper's per-sweep queries. Cost
delta is structurally nil — the same one `powershell.exe`/`ps` child per call,
the same projection, the same timeout — with one direction of improvement: the
descendant query now asks for `ProcessId,ParentProcessId` through the same
projected `SELECT` form the #2435 measurement favours (~316ms vs ~570ms
unprojected) instead of `Get-CimInstance Win32_Process | Select-Object`, which
enumerates every property before projecting. I did not measure that delta on
this box and am not claiming it.

## Observability

Unchanged and preserved, which is the point of routing through a status rather
than an empty array:

- `degradation-ledger` kind `orphan-backstop-scan-failed`, subjects
  `marker-search` and `identity-query` (`clients/instance-reaper.ts`) — still
  recorded on any non-`ok` status, with the POSIX `ps -p`-found-nothing case
  still excluded, now explicitly platform-gated instead of living inside a
  POSIX-only branch.
- `degradation-ledger` kind `resource-sampler-query-failed`, subjects
  `windows-process-table` and `windows-descendant-process-table`
  (`clients/resource-sampler.ts`) — unchanged, and pinned by existing tests.
- `incrementDegradationCount` kind `orphan-backstop-scanner-escalated`
  (`terminateScannerChild`) — unchanged; the seam injects the same handler.
- `[hygiene] process listing failed, timed out or exited non-zero …` on stderr
  from `scripts/prune-agent-worktrees.mjs` — unchanged.

No new record was added: this PR moves where a query is built, not what a
failure means.

## Class sweep

**Class:** duplicated platform-capability access — the single-source-of-truth
rule, and AGENTS.md defect shape 10 (a sweep/probe whose empty result reads as
clean) in the specific form "five copies of a listing, so a hardening fix
reaches one of them".

**Pattern sweep, whole tree** (`clients/`, `commands/`, `mcp/`, `tools/`,
`scripts/`, `index.ts`, `tests/`), needles `Get-CimInstance`, `Win32_Process`,
a bare `-eo` argument, and a `pid=,` column list:

| Site | Verdict |
| --- | --- |
| `scripts/lib/process-scan.mjs` | THE seam — registered |
| `clients/instance-reaper.ts` ×3 | folded (this PR) |
| `clients/resource-sampler.ts` ×2 | folded (this PR) |
| `scripts/prune-agent-worktrees.mjs` | already folded (#2438 F2); its remaining hit is a comment |
| `scripts/compat-smoke-behavioral.mjs` | already folded (#2438 F2) |
| `tests/scripts/worktree-hygiene.test.ts` | synthetic command-line FIXTURE text, not a query — outside the walk (tests are not scanned) |
| `tests/clients/resource-sampler.test.ts`, `tests/scripts/process-scan.test.ts` | fixtures and prose — outside the walk |

**Consolidation verdict: folded onto one seam.** The family is now size 1 and
`tests/config/process-table-seam.test.ts` keeps it there mechanically rather
than by convention. Post-fix `grep -rn "Get-CimInstance\|Win32_Process\|-eo"`
over `clients/` and `scripts/` returns only `scripts/lib/process-scan.mjs`
plus two prose comments (`clients/instance-reaper.ts:595` naming
`Win32_Process.Name` as the concept, `scripts/prune-agent-worktrees.mjs:111`
quoting the measured query cost), both of which the sweep's comment-blanking
correctly ignores.

**Adjacent family checked and deliberately left distributed:** process
KILLING. `clients/instance-reaper.ts` (`taskkill /F /T` via `killPidTree`),
`clients/safe-spawn.ts` (`killPidTreeSync` from exit/signal handlers) and
`scripts/prune-agent-worktrees.mjs` (`process.kill` only, no spawn — #234's
teardown rule) each kill differently ON PURPOSE: the script must never spawn a
killer, and safe-spawn's sync path runs when there is no event loop left. That
is a divergence with a documented reason, not drift, so folding it would be
wrong; it is not in scope for #2443 and I am not filing an issue for it.

**Related open PRs:** #2482, #2480, #2476, #2474, #2470, #2456 — I checked
each one's file list; none touches `clients/instance-reaper.ts`,
`clients/resource-sampler.ts`, `scripts/lib/process-scan.mjs`,
`clients/child-unref.ts`, `tsconfig.dist.json`, `tests/packaging.test.ts` or
`tests/config/process-table-seam.test.ts`. #2474 edits
`tests/config/bounded-eviction-idiom-sweep.test.ts`; this PR does not. No
merge-order constraint either way. Per the orchestrator's constraint I did not
touch `clients/dispatch/runners/utils/toolchain-availability.ts` or
`tests/support/session-state-*` (#2470).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ4a3oS1UDFxs74fLm8U21
