### PR TITLE
fix: attribute resource-sampler scanner escalations to their own kind (closes #2524)

### DIFF
--- a/.changelog/fix-2524-resource-sampler-scanner-kind.md
+++ b/.changelog/fix-2524-resource-sampler-scanner-kind.md
@@ -1,0 +1,38 @@
+---
+section: Fixed
+---
+
+- **Resource-sampler scanner timeouts are recorded under their own kind, not the orphan backstop's (closes #2524)** —
+  `terminateScannerChild` (`clients/instance-reaper.ts`) hardcoded
+  `kind: "orphan-backstop-scanner-escalated"` and a bare `"scan exceeded its
+  timeout"` reason, but has two callers with very different budgets and
+  cadences: the registry-independent orphan backstop (one scan per cooldown
+  window, `BACKSTOP_SCAN_TIMEOUT_MS` 5000ms) and `resource-sampler.ts`'s
+  process-table queries (`RESOURCE_SAMPLE_QUERY_TIMEOUT_MS` 2000ms, fired on
+  every heartbeat/spawn-bracket tick). Every sampler-path escalation was
+  therefore recorded under the backstop's kind — 8 rows observed live in one
+  session while `orphan-backstop.json`'s `lastSweepAt` proved the backstop had
+  not run (defect shape: a record's subject must be its producer). Fix:
+  `terminateScannerChild` now takes its `kind` and `timeoutMs` from an options
+  arg the caller supplies (no duplicated kill/verify machinery); the sampler's
+  two call sites now record the new `resource-sampler-scanner-escalated` kind
+  with its real 2000ms budget in the reason text, while the orphan backstop
+  keeps its own kind and 5000ms budget.
+  New kind `resource-sampler-scanner-escalated` is classified informational
+  (no `⚠` in `/lens-perf`'s degradation summary), not a warning like the
+  backstop's: `terminateScannerChild` fires the instant its caller's timer
+  elapses, strictly before `spawnCollectStdoutResult` (`clients/child-unref.ts`)
+  knows whether "close" or the timeout handler's own settle will win that
+  race — so it can and does fire on a query that goes on to settle
+  `status: "ok"` (matching the issue's observation: no
+  `resource-sampler-query-failed` row alongside any of the 8 escalations). The
+  sampler already treats a lost tick as ordinary best-effort data loss that
+  self-heals on the next heartbeat, so this kind is frequent-by-design noise
+  rather than an actionable fault.
+  Regression test (`tests/clients/resource-sampler-scanner-attribution.test.ts`)
+  drives the REAL production path — `sampleProcesses`'s Windows/guarded-CIM
+  branch through a real `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS` timeout into the
+  real, unmocked `terminateScannerChild` — and asserts the sampler's kind is
+  recorded (with its 2000ms budget) while the backstop's kind is not, plus
+  the informational (no `⚠`) rendering. Only `node:child_process`'s `spawn`
+  and `process.kill` are mocked; no real OS process is touched.

--- a/.changelog/fix-2524-resource-sampler-scanner-kind.md
+++ b/.changelog/fix-2524-resource-sampler-scanner-kind.md
@@ -24,15 +24,39 @@ section: Fixed
   elapses, strictly before `spawnCollectStdoutResult` (`clients/child-unref.ts`)
   knows whether "close" or the timeout handler's own settle will win that
   race — so it can and does fire on a query that goes on to settle
-  `status: "ok"` (matching the issue's observation: no
-  `resource-sampler-query-failed` row alongside any of the 8 escalations). The
-  sampler already treats a lost tick as ordinary best-effort data loss that
-  self-heals on the next heartbeat, so this kind is frequent-by-design noise
-  rather than an actionable fault.
+  `status: "ok"`, matching the issue's observation of 8 escalations with no
+  `resource-sampler-query-failed` row alongside them. That absence is a
+  reliable "settled ok, not raced" signal only up to the FIRST genuine query
+  failure per subject: `recordQueryFailure` records through
+  `recordDegradationOnce`, which is once-per-kind-per-subject for the whole
+  session, so a second-and-later genuine timeout for the same subject adds no
+  further `resource-sampler-query-failed` row either — at that point the
+  discriminator can no longer tell "raced" from "actually failed again" from
+  the summary counts alone; the per-event NDJSON latency log and each
+  escalation's own `latestReasons` entry remain the durable record. The
+  informational rendering itself also drops the reason text (`renderDegradationLines`
+  shows only the kind and count for informational kinds), so a forensic read
+  needing the "which race" detail must go to `getDegradationSummary()`'s
+  `latestReasons` or the NDJSON log, not the rendered summary line.
   Regression test (`tests/clients/resource-sampler-scanner-attribution.test.ts`)
   drives the REAL production path — `sampleProcesses`'s Windows/guarded-CIM
   branch through a real `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS` timeout into the
   real, unmocked `terminateScannerChild` — and asserts the sampler's kind is
   recorded (with its 2000ms budget) while the backstop's kind is not, plus
-  the informational (no `⚠`) rendering. Only `node:child_process`'s `spawn`
-  and `process.kill` are mocked; no real OS process is touched.
+  the informational (no `⚠`) rendering; a third case pins the sampler's OTHER
+  call site (`findDescendantPidsWindows`, reached via
+  `sampleProcessTreeCpuPercent`), which the first two cases left untested
+  (round 2 review). Only `node:child_process`'s `spawn` and `process.kill`
+  are mocked; no real OS process is touched.
+  Round 2 review also found the registry-driven reaper's OWN two scanner
+  queries — `queryCommandLines` and `findPidsByMarkerWindows`
+  (`clients/instance-reaper.ts`, both reached from `sweepOrphans`) — omitted
+  `onTimeout` entirely, so a scanner either spawned that blew
+  `BACKSTOP_SCAN_TIMEOUT_MS` fell through to `child-unref.ts`'s default
+  handler: one bare, unverified `child.kill()`, no tree kill, no
+  identity-carrying record — the exact abandonment `terminateScannerChild`
+  exists to prevent, reachable from inside the orphan backstop path itself.
+  Both now route through `terminateScannerChild` with the backstop's kind and
+  budget, matching `enumerateManagedProcesses`'s existing wiring. New test
+  `tests/clients/instance-reaper-registry-scan-escalation.test.ts` drives
+  `sweepOrphans()` through both real timeouts.

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -428,6 +428,27 @@ export type DegradationKind =
 	 */
 	| "orphan-backstop-scanner-escalated"
 	/**
+	 * #2524: the resource sampler's OWN process-table scanner (heartbeat CPU/RSS
+	 * sampling, `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS` 2000ms — a much tighter and
+	 * far more frequent budget than the orphan backstop's one-per-cooldown
+	 * 5000ms scan) blew its timeout and was tree-killed, the sampler-path
+	 * sibling of `orphan-backstop-scanner-escalated`. Before this kind existed,
+	 * `terminateScannerChild` hardcoded the backstop's kind for BOTH callers, so
+	 * every sampler escalation was misattributed to a backstop sweep that had
+	 * provably not run (defect shape: a record's subject must be its producer).
+	 * Informational, not a `⚠`: `terminateScannerChild` fires the instant its
+	 * caller's timer elapses, strictly before `spawnCollectStdoutResult` knows
+	 * which of "close" or the timeout handler's own settle will win — so this
+	 * kind can and does fire on a query that goes on to settle `status: "ok"`
+	 * (no matching `resource-sampler-query-failed` row), i.e. a kill attempt
+	 * against a scanner that was already about to finish successfully. The
+	 * sampler already treats a lost tick as ordinary best-effort data loss
+	 * (self-healing on the next heartbeat), so this rising/falling noise
+	 * doesn't warrant the same attention as the backstop's rare, single-sweep
+	 * escalation.
+	 */
+	| "resource-sampler-scanner-escalated"
+	/**
 	 * `session_start`'s bounded change-log sequence read (#1162) blew its
 	 * budget and a project snapshot existed on disk, but the freshness gate
 	 * could not tell whether that snapshot was current (#1785). Hydration was
@@ -1086,6 +1107,10 @@ const INFORMATIONAL_DEGRADATION_KINDS: ReadonlySet<string> = new Set([
 	// would.
 	"actionable-warnings-inband-superseded",
 	"actionable-warnings-deferred-superseded",
+	// #2524: can fire on a query that ultimately settles `ok` (see the kind's
+	// doc comment above) and is frequent/self-healing by design — a `⚠` would
+	// cry wolf on the sampler's ordinary best-effort data loss.
+	"resource-sampler-scanner-escalated",
 ]);
 
 export function renderDegradationLines(

--- a/clients/instance-reaper.ts
+++ b/clients/instance-reaper.ts
@@ -371,7 +371,21 @@ async function findPidsByMarkerWindows(marker: string): Promise<number[]> {
 			// without this exclusion the search matches itself.
 			excludeSelfPid: true,
 		},
-		{ timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS },
+		{
+			timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS,
+			// #2527 review F2: omitting `onTimeout` falls through to
+			// child-unref.ts's default — one bare, unverified `child.kill()`, no
+			// tree kill, no identity-carrying record — inside the orphan backstop
+			// path, the exact abandonment `terminateScannerChild`'s own doc
+			// comment says it exists to prevent. This query shares the backstop's
+			// scanner identity and budget (same producer as
+			// `enumerateManagedProcesses`), so it gets the same kind.
+			onTimeout: (child) =>
+				terminateScannerChild(child, {
+					kind: "orphan-backstop-scanner-escalated",
+					timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS,
+				}),
+		},
 	);
 	if (result.status !== "ok") {
 		recordDegradationOnce({
@@ -402,7 +416,18 @@ async function queryCommandLines(pids: number[]): Promise<Map<number, string>> {
 			fields: ["pid", "command"],
 			filter: { column: "ProcessId", op: "eq", values: valid },
 		},
-		{ timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS },
+		{
+			timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS,
+			// #2527 review F2: same rationale as findPidsByMarkerWindows above —
+			// route through the reaper's own tree-kill-and-verify machinery with
+			// the backstop's kind rather than falling through to the unverified
+			// default kill with no ledger record.
+			onTimeout: (child) =>
+				terminateScannerChild(child, {
+					kind: "orphan-backstop-scanner-escalated",
+					timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS,
+				}),
+		},
 	);
 	// POSIX `ps -p` exits nonzero when NONE of the requested pids exist, which
 	// is a legitimate clean result for this caller, so that one status is not
@@ -826,14 +851,22 @@ export interface TerminateScannerChildOptions {
 	verifyIntervalMs?: number;
 	/**
 	 * The degradation kind this escalation is attributed to. #2524: this
-	 * function has two callers with different budgets and cadences — the
-	 * registry-independent orphan backstop (one scan per cooldown window,
+	 * function has callers with two different budgets and cadences — the
+	 * registry-independent orphan backstop's own scanner queries
+	 * (`enumerateManagedProcesses`, `findPidsByMarkerWindows`,
+	 * `queryCommandLines`; one scan per cooldown window,
 	 * `BACKSTOP_SCAN_TIMEOUT_MS`) and the resource sampler's process-table
-	 * queries (every heartbeat/spawn-bracket tick, `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS`).
+	 * queries (`sampleProcessesWindows`, `findDescendantPidsWindows`; every
+	 * heartbeat/spawn-bracket tick, `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS`).
 	 * A hardcoded kind here mis-attributed every sampler escalation to the
 	 * backstop (defect shape: a record's subject must be its producer) — the
 	 * caller now supplies its own kind so the ledger names who actually timed
-	 * out.
+	 * out. #2527 review F2: `findPidsByMarkerWindows` and `queryCommandLines`
+	 * originally omitted `onTimeout` entirely, so a scanner they spawned that
+	 * blew `BACKSTOP_SCAN_TIMEOUT_MS` fell through to `child-unref.ts`'s bare,
+	 * unverified default kill with no identity-carrying record — the exact
+	 * abandonment this function exists to prevent, reachable from inside the
+	 * orphan backstop path itself. Both now route through here too.
 	 */
 	kind: DegradationKind;
 	/** The caller's own timeout budget in ms, folded into the reason text so

--- a/clients/instance-reaper.ts
+++ b/clients/instance-reaper.ts
@@ -79,6 +79,7 @@ import {
 	unrefChildAndPipes,
 } from "./child-unref.js";
 import {
+	type DegradationKind,
 	incrementDegradationCount,
 	recordDegradationOnce,
 } from "./degradation-ledger.js";
@@ -763,14 +764,21 @@ async function enumerateManagedProcesses(
 	// POSIX branch. Windows over-collects for its own reason anyway
 	// (`node.exe` is a superset image name covering every node process on the
 	// machine).
+	const scanTimeoutMs = options.timeoutMs ?? BACKSTOP_SCAN_TIMEOUT_MS;
 	const result = await queryProcessTable(
 		{
 			fields: ["pid", "ppid", "ageMs", "command"],
 			filter: { column: "Name", op: "eq", values: MANAGED_IMAGE_NAMES },
 		},
 		{
-			timeoutMs: options.timeoutMs ?? BACKSTOP_SCAN_TIMEOUT_MS,
-			onTimeout: (child: ChildProcess) => terminateScannerChild(child, options),
+			timeoutMs: scanTimeoutMs,
+			onTimeout: (child: ChildProcess) =>
+				terminateScannerChild(child, {
+					verifyAttempts: options.verifyAttempts,
+					verifyIntervalMs: options.verifyIntervalMs,
+					kind: "orphan-backstop-scanner-escalated",
+					timeoutMs: scanTimeoutMs,
+				}),
 		},
 	);
 	return narrowToManagedBinaries(
@@ -813,6 +821,26 @@ interface ManagedProcessScan {
 	timeoutKill?: SpawnTimeoutKill;
 }
 
+export interface TerminateScannerChildOptions {
+	verifyAttempts?: number;
+	verifyIntervalMs?: number;
+	/**
+	 * The degradation kind this escalation is attributed to. #2524: this
+	 * function has two callers with different budgets and cadences — the
+	 * registry-independent orphan backstop (one scan per cooldown window,
+	 * `BACKSTOP_SCAN_TIMEOUT_MS`) and the resource sampler's process-table
+	 * queries (every heartbeat/spawn-bracket tick, `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS`).
+	 * A hardcoded kind here mis-attributed every sampler escalation to the
+	 * backstop (defect shape: a record's subject must be its producer) — the
+	 * caller now supplies its own kind so the ledger names who actually timed
+	 * out.
+	 */
+	kind: DegradationKind;
+	/** The caller's own timeout budget in ms, folded into the reason text so
+	 *  the ledger names WHICH budget was blown without a second lookup. */
+	timeoutMs: number;
+}
+
 /**
  * Terminate a scanner child that blew the scan timeout, using the reaper's
  * OWN tree-kill-and-verify machinery (#1864 review F3).
@@ -824,10 +852,22 @@ interface ManagedProcessScan {
  * exists to fix, so the scanner now gets exactly what an orphan gets:
  * `taskkill /F /T` or a POSIX group kill, then a verified liveness poll. The
  * escalation is recorded with the scanner's identity, never swallowed.
+ *
+ * The kill attempt itself is real regardless of what happens next: this
+ * handler is invoked the instant the caller's timer elapses, which can race
+ * a query child that is genuinely about to close successfully (its own
+ * "close" event may still win the overall settle — see
+ * `child-unref.ts#spawnCollectStdoutResult`, which resolves on whichever of
+ * "close" or the timeout handler's own settle lands first). This function has
+ * no way to observe that outcome — it runs strictly BEFORE the caller's
+ * promise resolves — so it always records the escalation it actually
+ * attempted; callers whose escalation kind can fire on that race classify it
+ * as informational rather than a warning (see
+ * `degradation-ledger.ts`'s `resource-sampler-scanner-escalated` doc comment).
  */
 export async function terminateScannerChild(
 	child: ChildProcess,
-	options: { verifyAttempts?: number; verifyIntervalMs?: number },
+	options: TerminateScannerChildOptions,
 ): Promise<SpawnTimeoutKill> {
 	const pid = child.pid;
 	const outcome =
@@ -838,9 +878,9 @@ export async function terminateScannerChild(
 				})
 			: "invalid";
 	incrementDegradationCount({
-		kind: "orphan-backstop-scanner-escalated",
+		kind: options.kind,
 		subject: `${isWindows ? "win32-cim" : "posix-ps"}#${pid ?? "no-pid"}`,
-		reason: `scan exceeded its timeout; tree kill reported ${outcome}`,
+		reason: `scan exceeded its ${options.timeoutMs}ms timeout; tree kill reported ${outcome}`,
 	});
 	return outcome;
 }

--- a/clients/resource-sampler.ts
+++ b/clients/resource-sampler.ts
@@ -143,7 +143,11 @@ async function findDescendantPidsWindows(
 		{ fields: ["pid", "ppid"] },
 		{
 			timeoutMs: RESOURCE_SAMPLE_QUERY_TIMEOUT_MS,
-			onTimeout: (child) => terminateScannerChild(child, {}),
+			onTimeout: (child) =>
+				terminateScannerChild(child, {
+					kind: "resource-sampler-scanner-escalated",
+					timeoutMs: RESOURCE_SAMPLE_QUERY_TIMEOUT_MS,
+				}),
 		},
 	);
 	if (result.status !== "ok") {
@@ -244,7 +248,11 @@ async function sampleProcessesWindows(
 		},
 		{
 			timeoutMs: RESOURCE_SAMPLE_QUERY_TIMEOUT_MS,
-			onTimeout: (child) => terminateScannerChild(child, {}),
+			onTimeout: (child) =>
+				terminateScannerChild(child, {
+					kind: "resource-sampler-scanner-escalated",
+					timeoutMs: RESOURCE_SAMPLE_QUERY_TIMEOUT_MS,
+				}),
 		},
 	);
 	if (query.status !== "ok") {

--- a/tests/clients/instance-reaper-registry-scan-escalation.test.ts
+++ b/tests/clients/instance-reaper-registry-scan-escalation.test.ts
@@ -1,0 +1,212 @@
+/**
+ * #2527 review F2: `sweepOrphans` (the REGISTRY-DRIVEN reaper) has two scanner
+ * queries of its own — `queryCommandLines` (identity verification before any
+ * pid kill) and `findPidsByMarkerWindows` (the marker command-line fallback
+ * search) — that omitted `onTimeout` entirely when they were added. A query
+ * that blows `BACKSTOP_SCAN_TIMEOUT_MS` therefore fell through to
+ * `child-unref.ts`'s DEFAULT handler: one bare, unverified `child.kill()`, no
+ * tree kill, no identity-carrying ledger record — the exact scanner
+ * abandonment `terminateScannerChild`'s own doc comment says it exists to
+ * prevent, reachable from INSIDE the orphan backstop's own registry-driven
+ * path. `enumerateManagedProcesses` (the OTHER backstop scanner, exercised by
+ * `sweepUntrackedOrphans` in instance-reaper-backstop.test.ts) already wired
+ * `onTimeout`; these two call sites had not.
+ *
+ * This drives the REAL production path — `sweepOrphans()` (clients/
+ * instance-reaper.js) through a REAL `BACKSTOP_SCAN_TIMEOUT_MS` timeout into
+ * the REAL, unmocked `terminateScannerChild` and its real tree-kill-and-
+ * verify machinery — never a hand-fed call to `terminateScannerChild` or
+ * `queryProcessTable` themselves. Only `node:child_process`'s `spawn` and
+ * `process.kill` are mocked (same technique as
+ * instance-reaper-backstop.test.ts), so no real OS process is ever touched.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface SpawnRecord {
+	command: string;
+	args: string[];
+}
+
+const h = vi.hoisted(() => {
+	const spawns: SpawnRecord[] = [];
+	const state: {
+		registry: unknown[];
+		enabled: boolean;
+		/** pids the fake `process.kill(pid, 0)` probe reports as alive. */
+		alivePids: Set<number>;
+		/** how many non-`taskkill` ("scanner") children have been spawned so far. */
+		scannerSpawnCount: number;
+		/** 1-based scanner-spawn index that should hang forever (exercises the
+		 *  caller's own timeout); 0 disables hanging entirely. */
+		hangOnScannerIndex: number;
+		/** pids of every scanner child spawned, in spawn order. */
+		scannerPids: number[];
+	} = {
+		registry: [],
+		enabled: true,
+		alivePids: new Set<number>(),
+		scannerSpawnCount: 0,
+		hangOnScannerIndex: 0,
+		scannerPids: [],
+	};
+	let nextPid = 80_000;
+	function makeFakeChild(command: string, _args: string[]) {
+		const isKill = command.toLowerCase().includes("taskkill");
+		const pid = nextPid++;
+		let scannerIndex = 0;
+		if (!isKill) {
+			state.scannerSpawnCount++;
+			scannerIndex = state.scannerSpawnCount;
+			state.scannerPids.push(pid);
+		}
+		const hang = !isKill && scannerIndex === state.hangOnScannerIndex;
+		const stdoutHandlers: Array<(chunk: string) => void> = [];
+		const child = {
+			pid,
+			stdout: {
+				on(event: string, cb: (chunk: string) => void) {
+					if (event === "data") stdoutHandlers.push(cb);
+				},
+				unref() {},
+			},
+			stderr: null,
+			stdin: null,
+			unref() {},
+			kill() {},
+			once(event: string, cb: (...a: unknown[]) => void) {
+				if (hang) return child; // never settles — exercises the caller's timeout
+				if (event === "close") {
+					queueMicrotask(() => cb(0, null));
+				}
+				return child;
+			},
+		};
+		return child;
+	}
+	return { spawns, state, makeFakeChild };
+});
+
+vi.mock("node:child_process", () => ({
+	spawn: vi.fn((command: string, args: string[]) => {
+		h.spawns.push({ command, args });
+		return h.makeFakeChild(command, args);
+	}),
+}));
+
+vi.mock("../../clients/instance-registry.js", () => ({
+	isInstanceRegistryEnabled: () => h.state.enabled,
+	readInstanceRegistry: async () => h.state.registry,
+}));
+
+import {
+	BACKSTOP_SCAN_TIMEOUT_MS,
+	sweepOrphans,
+} from "../../clients/instance-reaper.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
+
+function reasonsFor(kind: string): Array<{ subject: string; reason: string }> {
+	return (
+		getDegradationSummary().find((g) => g.kind === kind)?.latestReasons ?? []
+	);
+}
+
+function deadParentInstanceWithChild(child: {
+	pid: number;
+	marker?: string;
+}): unknown {
+	return {
+		pid: 1, // dead parent — never in alivePids below
+		startedAt: new Date().toISOString(),
+		projectRoot: "/proj",
+		lspChildren: [
+			{
+				pid: child.pid,
+				serverId: "ast-grep",
+				command: "ast-grep.exe",
+				spawnedAt: new Date().toISOString(),
+				marker: child.marker,
+			},
+		],
+		lspChildCount: 1,
+		rssBytes: 0,
+		heartbeatAt: new Date().toISOString(),
+	};
+}
+
+beforeEach(() => {
+	h.spawns.length = 0;
+	h.state.registry = [];
+	h.state.enabled = true;
+	h.state.alivePids = new Set<number>();
+	h.state.scannerSpawnCount = 0;
+	h.state.hangOnScannerIndex = 0;
+	h.state.scannerPids.length = 0;
+	resetDegradationLedger();
+	vi.useFakeTimers();
+	vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
+		if (h.state.alivePids.has(Math.abs(pid))) return true;
+		const err = new Error("no such process") as NodeJS.ErrnoException;
+		err.code = "ESRCH";
+		throw err;
+	}) as unknown as typeof process.kill);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe("#2527 review F2: sweepOrphans' own scanner queries escalate through terminateScannerChild", () => {
+	it("queryCommandLines' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified", async () => {
+		// Dead parent, dead child, no marker: queryCommandLines(candidatePids)
+		// still runs (it is unconditional, ahead of the dead/alive decision) and
+		// is this test's only scanner query.
+		h.state.registry = [
+			deadParentInstanceWithChild({ pid: 100 }),
+		];
+		h.state.hangOnScannerIndex = 1; // the queryCommandLines spawn
+
+		const sweep = sweepOrphans();
+		await vi.advanceTimersByTimeAsync(BACKSTOP_SCAN_TIMEOUT_MS + 1_000);
+		await sweep;
+
+		// Pre-fix: `onTimeout` was omitted, so no `terminateScannerChild` call
+		// ever fires, and this record never appears — the scanner is abandoned
+		// with a single bare, unverified `child.kill()` instead.
+		const reasons = reasonsFor("orphan-backstop-scanner-escalated");
+		expect(reasons).toHaveLength(1);
+		expect(reasons[0].reason).toContain(`${BACKSTOP_SCAN_TIMEOUT_MS}ms`);
+		// The escalation's subject is the scanner child that was killed, not the
+		// LSP child pid (100) the query was trying to identify.
+		expect(reasons[0].subject).toContain(String(h.state.scannerPids[0]));
+		expect(reasons[0].subject).not.toContain("#100");
+	});
+
+	it("findPidsByMarkerWindows' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified", async () => {
+		// Dead parent, dead child, WITH a marker: queryCommandLines resolves
+		// cleanly (index 1, not hung), then decideOrphanReaping routes the dead
+		// child into markerSearches, and findPidsByMarkerWindows (scanner index
+		// 2) is the one that hangs.
+		h.state.registry = [
+			deadParentInstanceWithChild({
+				pid: 100,
+				marker: "C:/temp/pi-lens-ast-grep/x.yml",
+			}),
+		];
+		h.state.hangOnScannerIndex = 2; // the findPidsByMarkerWindows spawn
+
+		const sweep = sweepOrphans();
+		await vi.advanceTimersByTimeAsync(BACKSTOP_SCAN_TIMEOUT_MS + 1_000);
+		await sweep;
+
+		expect(h.state.scannerPids).toHaveLength(2);
+		const reasons = reasonsFor("orphan-backstop-scanner-escalated");
+		expect(reasons).toHaveLength(1);
+		expect(reasons[0].reason).toContain(`${BACKSTOP_SCAN_TIMEOUT_MS}ms`);
+		expect(reasons[0].subject).toContain(String(h.state.scannerPids[1]));
+	});
+});

--- a/tests/clients/instance-reaper-registry-scan-escalation.test.ts
+++ b/tests/clients/instance-reaper-registry-scan-escalation.test.ts
@@ -165,9 +165,7 @@ describe("#2527 review F2: sweepOrphans' own scanner queries escalate through te
 		// Dead parent, dead child, no marker: queryCommandLines(candidatePids)
 		// still runs (it is unconditional, ahead of the dead/alive decision) and
 		// is this test's only scanner query.
-		h.state.registry = [
-			deadParentInstanceWithChild({ pid: 100 }),
-		];
+		h.state.registry = [deadParentInstanceWithChild({ pid: 100 })];
 		h.state.hangOnScannerIndex = 1; // the queryCommandLines spawn
 
 		const sweep = sweepOrphans();

--- a/tests/clients/instance-reaper-registry-scan-escalation.test.ts
+++ b/tests/clients/instance-reaper-registry-scan-escalation.test.ts
@@ -19,6 +19,21 @@
  * `queryProcessTable` themselves. Only `node:child_process`'s `spawn` and
  * `process.kill` are mocked (same technique as
  * instance-reaper-backstop.test.ts), so no real OS process is ever touched.
+ *
+ * Round-3 fix (CI red on Linux): `instance-reaper.ts` captures `isWindows` as
+ * a MODULE-LOAD-TIME constant (`const isWindows = process.platform ===
+ * "win32"`), unlike `resource-sampler.ts`'s live per-call platform check. On
+ * Linux CI `sweepOrphans` therefore always takes the posix-`ps` branch and
+ * `findPidsByMarkerWindows` short-circuits to `[]` before spawning anything
+ * (it is `if (!isWindows || !marker) return [];`), so the round-2 version of
+ * this file's second case never produced a second scanner spawn there. Each
+ * case below now forces its OWN platform via `Object.defineProperty` BEFORE
+ * a `vi.resetModules()` + dynamic re-import of `instance-reaper.js` (and its
+ * `degradation-ledger.js`), so the module's `isWindows` constant is
+ * recomputed fresh for that platform on every host, Linux or Windows dev
+ * box alike — the same forcing technique
+ * `resource-sampler-scanner-attribution.test.ts` uses, adapted for a
+ * module-load-time constant rather than a live per-call check.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -99,19 +114,38 @@ vi.mock("../../clients/instance-registry.js", () => ({
 	readInstanceRegistry: async () => h.state.registry,
 }));
 
-import {
-	BACKSTOP_SCAN_TIMEOUT_MS,
-	sweepOrphans,
-} from "../../clients/instance-reaper.js";
-import {
-	getDegradationSummary,
-	resetDegradationLedger,
-} from "../../clients/degradation-ledger.js";
+const realPlatform = process.platform;
+function setPlatform(platform: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", {
+		value: platform,
+		configurable: true,
+	});
+}
 
-function reasonsFor(kind: string): Array<{ subject: string; reason: string }> {
-	return (
-		getDegradationSummary().find((g) => g.kind === kind)?.latestReasons ?? []
-	);
+/**
+ * `instance-reaper.ts` reads `process.platform` into a module-load-time
+ * `const isWindows`, so forcing the platform only takes effect on a FRESH
+ * module instance. `vi.resetModules()` + a dynamic re-import gets one; the
+ * degradation-ledger re-import right after resolves to the SAME fresh
+ * instance `instance-reaper.js` itself imported (no separate resetModules
+ * call between the two), so `getDegradationSummary` observes what
+ * `sweepOrphans` actually recorded.
+ */
+async function loadInstanceReaperFor(platform: NodeJS.Platform) {
+	setPlatform(platform);
+	vi.resetModules();
+	const { BACKSTOP_SCAN_TIMEOUT_MS, sweepOrphans } =
+		await import("../../clients/instance-reaper.js");
+	const { getDegradationSummary } =
+		await import("../../clients/degradation-ledger.js");
+	function reasonsFor(
+		kind: string,
+	): Array<{ subject: string; reason: string }> {
+		return (
+			getDegradationSummary().find((g) => g.kind === kind)?.latestReasons ?? []
+		);
+	}
+	return { BACKSTOP_SCAN_TIMEOUT_MS, sweepOrphans, reasonsFor };
 }
 
 function deadParentInstanceWithChild(child: {
@@ -145,7 +179,6 @@ beforeEach(() => {
 	h.state.scannerSpawnCount = 0;
 	h.state.hangOnScannerIndex = 0;
 	h.state.scannerPids.length = 0;
-	resetDegradationLedger();
 	vi.useFakeTimers();
 	vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
 		if (h.state.alivePids.has(Math.abs(pid))) return true;
@@ -156,12 +189,20 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	setPlatform(realPlatform);
 	vi.restoreAllMocks();
 	vi.useRealTimers();
 });
 
 describe("#2527 review F2: sweepOrphans' own scanner queries escalate through terminateScannerChild", () => {
-	it("queryCommandLines' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified", async () => {
+	it("queryCommandLines' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified (forced posix — genuinely the ps branch on every host)", async () => {
+		// Forced "linux": instance-reaper.ts's module-load-time `isWindows`
+		// resolves false regardless of the host OS, so this genuinely exercises
+		// queryCommandLines' posix `ps` branch even on a Windows dev box, not
+		// just incidentally on Linux CI.
+		const { BACKSTOP_SCAN_TIMEOUT_MS, sweepOrphans, reasonsFor } =
+			await loadInstanceReaperFor("linux");
+
 		// Dead parent, dead child, no marker: queryCommandLines(candidatePids)
 		// still runs (it is unconditional, ahead of the dead/alive decision) and
 		// is this test's only scanner query.
@@ -184,7 +225,14 @@ describe("#2527 review F2: sweepOrphans' own scanner queries escalate through te
 		expect(reasons[0].subject).not.toContain("#100");
 	});
 
-	it("findPidsByMarkerWindows' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified", async () => {
+	it("findPidsByMarkerWindows' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified (forced win32 — the only host where this query runs at all)", async () => {
+		// Forced "win32": findPidsByMarkerWindows is `if (!isWindows || !marker)
+		// return [];` — on the real host platform of CI (Linux) it never spawns
+		// anything, so this branch can only be exercised by forcing the
+		// module's isWindows constant true before import, on every host.
+		const { BACKSTOP_SCAN_TIMEOUT_MS, sweepOrphans, reasonsFor } =
+			await loadInstanceReaperFor("win32");
+
 		// Dead parent, dead child, WITH a marker: queryCommandLines resolves
 		// cleanly (index 1, not hung), then decideOrphanReaping routes the dead
 		// child into markerSearches, and findPidsByMarkerWindows (scanner index

--- a/tests/clients/resource-sampler-scanner-attribution.test.ts
+++ b/tests/clients/resource-sampler-scanner-attribution.test.ts
@@ -186,7 +186,9 @@ describe("#2524: resource-sampler scanner escalation is attributed to its own pr
 		await vi.advanceTimersByTimeAsync(RESOURCE_SAMPLE_QUERY_TIMEOUT_MS + 1_000);
 		// The inter-read window elapses, firing the second read, whose
 		// descendant-pid query also times out.
-		await vi.advanceTimersByTimeAsync(50 + RESOURCE_SAMPLE_QUERY_TIMEOUT_MS + 1_000);
+		await vi.advanceTimersByTimeAsync(
+			50 + RESOURCE_SAMPLE_QUERY_TIMEOUT_MS + 1_000,
+		);
 		const result = await resultPromise;
 
 		// Both queries were unresolvable, so the tree-CPU read itself is unmeasured.

--- a/tests/clients/resource-sampler-scanner-attribution.test.ts
+++ b/tests/clients/resource-sampler-scanner-attribution.test.ts
@@ -84,8 +84,11 @@ const {
 	renderDegradationLines,
 	resetDegradationLedger,
 } = await import("../../clients/degradation-ledger.js");
-const { sampleProcesses, __resetWindowsCpuHistoryForTests } =
-	await import("../../clients/resource-sampler.js");
+const {
+	sampleProcesses,
+	sampleProcessTreeCpuPercent,
+	__resetWindowsCpuHistoryForTests,
+} = await import("../../clients/resource-sampler.js");
 const { RESOURCE_SAMPLE_QUERY_TIMEOUT_MS } =
 	await import("../../clients/resource-sampler.js");
 
@@ -161,5 +164,40 @@ describe("#2524: resource-sampler scanner escalation is attributed to its own pr
 		);
 		expect(samplerLine).toBeDefined();
 		expect(samplerLine).not.toContain("⚠");
+	});
+
+	// #2527 review F1: `sampleProcesses`/`sampleProcessesWindows` above only
+	// exercises ONE of the sampler's two `terminateScannerChild` call sites.
+	// `findDescendantPidsWindows` (the pid/ppid descendant-tree query, used by
+	// `sampleProcessTreeCpuPercent` and `startSpawnUsageSampler` to resolve a
+	// Windows `shell:true` spawn's real worker pids) has its OWN `onTimeout`
+	// wiring a few lines above `sampleProcessesWindows`'s — reverting only that
+	// call site back to the pre-#2524 hardcoded kind must turn a test red, or
+	// the second call site is unguarded coverage.
+	it("also attributes the descendant-pid query's (findDescendantPidsWindows) escalation to the sampler's own kind", async () => {
+		vi.useFakeTimers();
+		h.state.hangQuery = true;
+
+		// windowMs=50 keeps the second (post-window) read's own query timeout
+		// the only slow leg to advance past; floorPercent is irrelevant since
+		// the query never resolves.
+		const resultPromise = sampleProcessTreeCpuPercent(444, 50, 10);
+		// First read's descendant-pid query times out.
+		await vi.advanceTimersByTimeAsync(RESOURCE_SAMPLE_QUERY_TIMEOUT_MS + 1_000);
+		// The inter-read window elapses, firing the second read, whose
+		// descendant-pid query also times out.
+		await vi.advanceTimersByTimeAsync(50 + RESOURCE_SAMPLE_QUERY_TIMEOUT_MS + 1_000);
+		const result = await resultPromise;
+
+		// Both queries were unresolvable, so the tree-CPU read itself is unmeasured.
+		expect(result.measured).toBe(false);
+
+		expect(reasonsFor("orphan-backstop-scanner-escalated")).toHaveLength(0);
+		const reasons = reasonsFor("resource-sampler-scanner-escalated");
+		// Two reads, each triggering one escalation of the descendant-pid query.
+		expect(reasons.length).toBeGreaterThanOrEqual(1);
+		for (const reason of reasons) {
+			expect(reason.reason).toContain(`${RESOURCE_SAMPLE_QUERY_TIMEOUT_MS}ms`);
+		}
 	});
 });

--- a/tests/clients/resource-sampler-scanner-attribution.test.ts
+++ b/tests/clients/resource-sampler-scanner-attribution.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #2524: `terminateScannerChild` (clients/instance-reaper.ts) hardcoded the
+ * kind `orphan-backstop-scanner-escalated` for EVERY caller, but it has two
+ * callers with different budgets and cadences — the registry-independent
+ * orphan backstop (one scan per cooldown window, `BACKSTOP_SCAN_TIMEOUT_MS`
+ * 5000ms) and the resource sampler's process-table queries
+ * (`RESOURCE_SAMPLE_QUERY_TIMEOUT_MS` 2000ms, fired on every
+ * heartbeat/spawn-bracket tick). Every sampler-path escalation was therefore
+ * recorded under the backstop's kind — 8 rows observed live while the
+ * backstop provably had not run (defect shape: a record's subject must be
+ * its producer).
+ *
+ * This drives the REAL production call path: `resource-sampler.ts`'s
+ * `sampleProcesses` (Windows/guarded-CIM branch) through a REAL
+ * `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS` timeout into the REAL, UNMOCKED
+ * `terminateScannerChild` (clients/instance-reaper.js) and its REAL
+ * tree-kill-and-verify machinery — never a hand-fed call to
+ * `terminateScannerChild` itself. Only `node:child_process`'s `spawn` and
+ * `process.kill` are mocked (same technique as
+ * tests/clients/instance-reaper-backstop.test.ts), so no real OS process is
+ * ever touched and no real kill signal is ever sent.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface SpawnRecord {
+	command: string;
+	args: string[];
+}
+
+const h = vi.hoisted(() => {
+	const spawns: SpawnRecord[] = [];
+	const state: {
+		/** The scanner query child never settles — exercises the caller's
+		 *  own RESOURCE_SAMPLE_QUERY_TIMEOUT_MS timeout. */
+		hangQuery: boolean;
+		/** pids the fake `process.kill(pid, 0)` probe reports as alive. */
+		alivePids: Set<number>;
+	} = {
+		hangQuery: false,
+		alivePids: new Set<number>(),
+	};
+	let nextPid = 70_000;
+	function makeFakeChild(command: string, _args: string[]) {
+		const isQuery = command.toLowerCase().includes("powershell");
+		const pid = nextPid++;
+		const stdoutHandlers: Array<(chunk: string) => void> = [];
+		const handlers = new Map<string, (...a: unknown[]) => void>();
+		const child = {
+			pid,
+			stdout: {
+				on(event: string, cb: (chunk: string) => void) {
+					if (event === "data") stdoutHandlers.push(cb);
+				},
+				unref() {},
+			},
+			stderr: null,
+			stdin: null,
+			unref() {},
+			kill() {},
+			once(event: string, cb: (...a: unknown[]) => void) {
+				handlers.set(event, cb);
+				if (isQuery && h.state.hangQuery) return child; // never settles
+				if (event === "close") {
+					queueMicrotask(() => cb(0, null));
+				}
+				return child;
+			},
+		};
+		return child;
+	}
+	return { spawns, state, makeFakeChild };
+});
+
+vi.mock("node:child_process", () => ({
+	spawn: vi.fn((command: string, args: string[]) => {
+		h.spawns.push({ command, args });
+		return h.makeFakeChild(command, args);
+	}),
+}));
+
+const {
+	getDegradationSummary,
+	renderDegradationLines,
+	resetDegradationLedger,
+} = await import("../../clients/degradation-ledger.js");
+const { sampleProcesses, __resetWindowsCpuHistoryForTests } =
+	await import("../../clients/resource-sampler.js");
+const { RESOURCE_SAMPLE_QUERY_TIMEOUT_MS } =
+	await import("../../clients/resource-sampler.js");
+
+const realPlatform = process.platform;
+function setPlatform(platform: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", {
+		value: platform,
+		configurable: true,
+	});
+}
+
+function reasonsFor(kind: string): Array<{ subject: string; reason: string }> {
+	return (
+		getDegradationSummary().find((g) => g.kind === kind)?.latestReasons ?? []
+	);
+}
+
+beforeEach(() => {
+	h.spawns.length = 0;
+	h.state.hangQuery = false;
+	h.state.alivePids = new Set<number>();
+	setPlatform("win32");
+	resetDegradationLedger();
+	__resetWindowsCpuHistoryForTests();
+	vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
+		if (h.state.alivePids.has(Math.abs(pid))) return true;
+		const err = new Error("no such process") as NodeJS.ErrnoException;
+		err.code = "ESRCH";
+		throw err;
+	}) as unknown as typeof process.kill);
+});
+
+afterEach(() => {
+	setPlatform(realPlatform);
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe("#2524: resource-sampler scanner escalation is attributed to its own producer", () => {
+	it("records resource-sampler-scanner-escalated (with its own 2000ms budget) instead of the orphan backstop's kind", async () => {
+		vi.useFakeTimers();
+		h.state.hangQuery = true;
+
+		const query = sampleProcesses([111]);
+		await vi.advanceTimersByTimeAsync(RESOURCE_SAMPLE_QUERY_TIMEOUT_MS + 1_000);
+		await query;
+
+		// The mis-attribution this issue fixes: pre-fix, EVERY escalation —
+		// backstop and sampler alike — landed under this kind.
+		expect(reasonsFor("orphan-backstop-scanner-escalated")).toHaveLength(0);
+
+		const reasons = reasonsFor("resource-sampler-scanner-escalated");
+		expect(reasons).toHaveLength(1);
+		expect(reasons[0].reason).toContain(
+			`${RESOURCE_SAMPLE_QUERY_TIMEOUT_MS}ms`,
+		);
+		// The scanner query child, not pid 111 (the sampling TARGET) — the
+		// escalation's subject is the scanner that was killed.
+		expect(reasons[0].subject).not.toContain("#111");
+	});
+
+	it("renders the sampler's escalation informationally (no ⚠), unlike the backstop's warning tier", async () => {
+		vi.useFakeTimers();
+		h.state.hangQuery = true;
+
+		const query = sampleProcesses([222]);
+		await vi.advanceTimersByTimeAsync(RESOURCE_SAMPLE_QUERY_TIMEOUT_MS + 1_000);
+		await query;
+
+		const lines = renderDegradationLines();
+		const samplerLine = lines.find((line) =>
+			line.includes("resource-sampler-scanner-escalated"),
+		);
+		expect(samplerLine).toBeDefined();
+		expect(samplerLine).not.toContain("⚠");
+	});
+});


### PR DESCRIPTION
## Summary

`terminateScannerChild` (`clients/instance-reaper.ts`) hardcoded
`kind: "orphan-backstop-scanner-escalated"` and a bare `"scan exceeded its
timeout"` reason, but it has two callers with different budgets and cadences:
the registry-independent orphan backstop (one 5000ms scan per cooldown
window — `BACKSTOP_SCAN_TIMEOUT_MS`, correctly attributed) and
`resource-sampler.ts`'s process-table queries (2000ms —
`RESOURCE_SAMPLE_QUERY_TIMEOUT_MS`, fired on every heartbeat/spawn-bracket
tick). Every sampler-path escalation was therefore recorded under the
backstop's kind — 8 rows observed live in one session while
`~/.pi-lens/orphan-backstop.json`'s `lastSweepAt` proved the backstop had not
run. This is the "record's subject must be its producer" shape: a shared
kill/escalation helper attributing every event to whichever producer wrote it
first, regardless of who actually called it.

Fix (all 5 acceptance criteria):
1. `terminateScannerChild` now takes `kind: DegradationKind` and
   `timeoutMs: number` on its options arg instead of hardcoding them — no
   duplicated kill/verify machinery, the caller just supplies its own identity
   and budget.
2. The sampler's two call sites (`findDescendantPidsWindows`,
   `sampleProcessesWindows`) now pass `kind: "resource-sampler-scanner-escalated"`
   and `timeoutMs: RESOURCE_SAMPLE_QUERY_TIMEOUT_MS` (2000). The backstop's one
   call site (`enumerateManagedProcesses`) keeps its own kind and
   `BACKSTOP_SCAN_TIMEOUT_MS`/`options.timeoutMs` budget.
3. Regression test drives the REAL production path — see Tests below — and is
   proven red on pre-fix code.
4. Determined (see doc comments on the new `DegradationKind` entry and on
   `terminateScannerChild` itself): the escalation CAN and does fire on a
   query that goes on to settle `status: "ok"`. `terminateScannerChild` runs
   inside the caller's `onTimeout` hook, which fires the instant the timer
   elapses — strictly BEFORE `spawnCollectStdoutResult`
   (`clients/child-unref.ts`) knows whether the child's own "close" event or
   the timeout handler's own settle wins the race (`settled` flag, first
   caller wins). The issue's own evidence confirms this happens in
   production: 8 escalation rows with ZERO matching
   `resource-sampler-query-failed` rows (that kind is only recorded when
   `query.status !== "ok"`). Rather than suppress (the kill attempt is real
   regardless of the race outcome — a scanner child genuinely got tree-killed)
   the new kind is LABELED via the existing informational tier
   (`INFORMATIONAL_DEGRADATION_KINDS`, no `⚠` in `/lens-perf`'s summary) — the
   same mechanism already used for other frequent, self-healing kinds
   (`log-sink-rotated`, `actionable-warnings-*-superseded`). The backstop's
   kind is UNCHANGED (still a `⚠` warning) since the issue calls its 5000ms
   budget "correct" and it fires at most once per cooldown window.
5. Scope stayed inside this issue's four files (`instance-reaper.ts`,
   `resource-sampler.ts`, `degradation-ledger.ts`, one new test file); #2496
   is a separate, unstarted `windowsExe`/WQL-escaping/`serverSideFiltered`
   sweep on `process-scan.mjs`/`process-snapshot.ts` that touches none of
   these — no overlap to fold.

Closes #2524 — all five acceptance criteria are met.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:observability
- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (regression test for the bug; both call-site budgets exercised via the shared `terminateScannerChild` seam)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted below
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test (see Tests)
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds (touched `clients/`)
- [x] `package-lock.json` is in sync with `package.json` (no dep changes)
- [ ] `AGENTS.md` is updated — not needed: this fixes a mis-attribution inside an existing, documented seam; no new invariant, command, or convention
- [x] `.changelog/fix-2524-resource-sampler-scanner-kind.md` has one valid entry (section: Fixed)
- [x] Commit subject includes `(refs #2524)` — see commits `2d64d20b`, `52f66197`, `ed659faf`, `1f770d71`

## Tests

**New file**: `tests/clients/resource-sampler-scanner-attribution.test.ts` (2 new cases).

Drives the REAL production call path: `resource-sampler.ts`'s `sampleProcesses`
(Windows/guarded-CIM branch) through a REAL `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS`
(2000ms) timeout into the REAL, unmocked `terminateScannerChild`
(`clients/instance-reaper.js`) and its real tree-kill-and-verify machinery —
never a hand-fed call to `terminateScannerChild` itself. Only
`node:child_process`'s `spawn` and `process.kill` are mocked (same technique
as `tests/clients/instance-reaper-backstop.test.ts`), so no real OS process is
ever touched and no real kill signal is ever sent.

1. **"records resource-sampler-scanner-escalated ... instead of the orphan backstop's kind"** — regression proof: asserts `orphan-backstop-scanner-escalated` has zero rows and `resource-sampler-scanner-escalated` has exactly one, with the reason text naming the sampler's own 2000ms budget, and the subject naming the killed SCANNER pid, not the sampling target pid. This is mutation-proof by construction: reverting `clients/instance-reaper.ts`/`clients/resource-sampler.ts` to pre-fix (see red run below) makes it fail exactly on the swapped kind.
2. **"renders the sampler's escalation informationally (no ⚠) ..."** — pins the design decision from acceptance criterion 4 (the informational classification), via `renderDegradationLines()`.

### Red run (pre-fix, `clients/instance-reaper.ts`/`resource-sampler.ts`/`degradation-ledger.ts` reverted to `97c02b17` via `git checkout 97c02b17 -- <files>`, rebuilt, same test file):

```
 FAIL  |default| tests/clients/resource-sampler-scanner-attribution.test.ts > #2524: resource-sampler scanner escalation is attributed to its own producer > records resource-sampler-scanner-escalated (with its own 2000ms budget) instead of the orphan backstop's kind
AssertionError: expected [ Array(1) ] to have a length of +0 but got 1
- Expected: 0
+ Received: 1
 ❯ tests/clients/resource-sampler-scanner-attribution.test.ts:138:59

 FAIL  |default| tests/clients/resource-sampler-scanner-attribution.test.ts > #2524: resource-sampler scanner escalation is attributed to its own producer > renders the sampler's escalation informationally (no ⚠), unlike the backstop's warning tier
AssertionError: expected undefined to be defined
 ❯ tests/clients/resource-sampler-scanner-attribution.test.ts:162:23

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

Restored to the committed fix afterward (`git checkout HEAD -- <files>`, rebuilt); `git status` confirmed a clean tree matching the commit.

### Targeted + governance suites run (all green)

- `tests/clients/resource-sampler-scanner-attribution.test.ts`, `tests/clients/resource-sampler.test.ts`, `tests/clients/instance-reaper-backstop.test.ts`, `tests/clients/instance-reaper.test.ts`, `tests/clients/instance-reaper-posix-ps.test.ts`, `tests/clients/instance-reaper-unref.test.ts`, `tests/clients/instance-reaper-prune-concurrency.test.ts` — **7 files, 123 passed, 3 skipped**.
- Governance sweep (`ls tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts`) — **29 files, 469 passed**.
- Every `tests/config/*.test.ts` — **21 files, 174 passed**.

### Test assessment

`tests/clients/resource-sampler-scanner-attribution.test.ts` is new — it uniquely pins the caller-supplied kind/budget attribution on `terminateScannerChild`'s two REAL call sites, which no existing file covers: `tests/clients/resource-sampler.test.ts` mocks `terminateScannerChild` away entirely (module-level `vi.mock("../../clients/instance-reaper.js", ...)`), so it can never observe which degradation kind the real function records; `tests/clients/instance-reaper-backstop.test.ts` only exercises the backstop's own call site. No existing test becomes redundant.

## Blast radius

- **Corrected in round 2** (see the review section below): `terminateScannerChild`'s importers are `clients/instance-reaper.ts` (its own definition + now THREE call sites: `enumerateManagedProcesses`, `findPidsByMarkerWindows`, `queryCommandLines`) and `clients/resource-sampler.ts` (two call sites) — five total, not the three this section originally claimed. `grep -rl` across `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts` still confirms no OTHER module calls it.
- Signature change is additive-but-required: `kind`/`timeoutMs` became required fields on the options arg. Both call sites in this repo were updated in this PR; no other caller exists to break.
- `DegradationKind` gained one new literal (`resource-sampler-scanner-escalated`); it's a union type, so this is additive and cannot break an existing `switch`/exhaustiveness check elsewhere (none exists over the full union today — verified no `satisfies`/exhaustive switch over `DegradationKind` in `clients/`).
- Hot-path cost: `terminateScannerChild` already ran only on a timeout (a rare, off-nominal path); this PR adds no new work to it beyond two extra fields in an object literal already being constructed at each of the three call sites.

## Observability

`incrementDegradationCount` now writes `resource-sampler-scanner-escalated` rows (visible via `getDegradationSummary()` / `renderDegradationLines()` / `/lens-perf`) instead of the misleading `orphan-backstop-scanner-escalated`. The reason text now names the actual budget blown (`"scan exceeded its 2000ms timeout; tree kill reported <outcome>"`), so a future forensic read no longer needs to cross-reference `orphan-backstop.json`'s `lastSweepAt` to notice the mismatch the issue describes.

## Class sweep

Shape: a shared kill/escalation helper hardcodes a `kind` literal that NAMES A SPECIFIC FEATURE/SUBSYSTEM (not a generic outcome vocabulary), even though it is invoked from call sites belonging to a differently-identified feature with its own budget — the record's subject stops being its true producer. This is the same family as AGENTS.md's side-channel/attribution shapes (catalog shape 5's "read the signal off the ORIGINAL producer" principle, generalized from a dropped property to a hardcoded identity); the issue cites #1550 for this framing.

Swept the whole tree (`clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`, not `clients/` alone) with a script that finds every function body containing `incrementDegradationCount`/`recordDegradationOnce`/`recordDegradation` with a literal `kind: "..."`, then checked which of those functions are referenced from more than one file. 17 candidates surfaced; each reviewed by hand for the specific shape:

- **False positives from the heuristic's crude function-body slicing** (e.g. `clients/lsp/index.ts::walk()` "referenced in 23 files", `clients/tree-sitter-client.ts::escapeRegExp()` "referenced in 6 files"): both are generic, unrelated helpers the regex mis-attributed a later function's degradation call to. Not real.
- **Shared GENERIC outcome kinds, used on purpose** — `runner-empty-result` (`dead-code-client.ts`, `jscpd-client.ts`, `knip-client.ts`, `trivy-config.ts`, `tool-failure.ts`), `trust-refusal` (`project-trust.ts`, called from 7 files), `mode-suppression`, `query-predicates-invalid`: these kinds intentionally describe an OUTCOME shared across many unrelated producers, with `subject` (the tool/rule/command name) carrying producer identity — the accepted pattern elsewhere in this ledger, not the #2524 defect (which hardcoded a kind that itself names ONE feature, "orphan-backstop", and lied about it for a different one).
- **Same-subsystem internal call graphs** — `verifyToolBinary` (3 files, all inside the installer's own verification flow), `createLSPClient`, `deriveCascadeNeighbourBudget`, `recordOutstandingCascadeTouch`, `recordEntitySnapshotDiff`, `sweepOrphans` (registry-driven reaper, called from 3 files but always the SAME reaper): every caller belongs to the kind's own subsystem, so there is no cross-feature mis-attribution to fix.
- Also checked every OTHER call site of `killPidTree` (the tree-kill-and-verify primitive `terminateScannerChild` wraps): `sweepOrphans` and `sweepUntrackedOrphans` each record their OWN dedicated kind (`orphan-reap-kill-unverified`, `orphan-backstop-kill-unverified`) at their own call sites, not inside a shared hardcoded-kind wrapper — no sibling of this defect there.

**Correction (round 2 review, F2 — see below):** the verdict below was WRONG about coverage, though not about the mis-attribution shape itself. The sweep only asked "does a caller of `terminateScannerChild` hardcode the wrong kind"; it never asked the sibling question "does a caller of `queryProcessTable`'s `onTimeout` OMIT it entirely", which is the same underlying defect one level up — `queryCommandLines` and `findPidsByMarkerWindows` (both in `clients/instance-reaper.ts`, both scanning inside the orphan-backstop's own registry-driven path) had no `onTimeout` at all, so a scanner they spawned that blew its timeout fell through to `child-unref.ts`'s bare, unverified default `child.kill()` — no tree kill, no ledger record whatsoever. Fixed in round 2 by wiring both through `terminateScannerChild` with the backstop's kind. The original verdict ("class of size 1") is revised below.

Original verdict (superseded): ~~class of size 1 (`terminateScannerChild`) for the exact shape #2524 describes. No further folding needed.~~

**Revised verdict:** class of size 1 for "a shared kill/escalation helper hardcodes the wrong `kind`" (unchanged — still only `terminateScannerChild`), but a SECOND, related shape existed in the same file and was missed by the first pass: "a `queryProcessTable` call inside the orphan-backstop path omits `onTimeout` entirely, defaulting to an unverified bare kill with no record." `enumerateManagedProcesses` was already correct; `queryCommandLines` and `findPidsByMarkerWindows` were not. All `queryProcessTable` call sites in `clients/instance-reaper.ts` and `clients/resource-sampler.ts` now pass `onTimeout` (grepped and confirmed in round 2 — five call sites total, all wired). No further folding needed after round 2.

## Review round 2

Two findings, both fixed on this branch (commits `52f66197`, `ed659faf`, `1f770d71`; head `1f770d71`):

**F1 (test-coverage gap, MEDIUM):** `resource-sampler.ts` has TWO `terminateScannerChild` call sites — `sampleProcessesWindows` and `findDescendantPidsWindows`. The round-1 test file only drove `sampleProcesses` (which calls `sampleProcessesWindows` directly); `findDescendantPidsWindows` (reached only via `sampleProcessTreeCpuPercent`/`startSpawnUsageSampler`, used to resolve a Windows `shell:true` spawn's real descendant pids) had no dedicated coverage. Reverting only `findDescendantPidsWindows`'s `kind` back to the pre-#2524 hardcoded `"orphan-backstop-scanner-escalated"` left the full 48/48 suite green — the second call site's own fix was unguarded. No source defect (the round-1 fix already covered both call sites correctly); this was purely a coverage gap.
Fix: added a third case to `tests/clients/resource-sampler-scanner-attribution.test.ts` that drives `sampleProcessTreeCpuPercent` (the real production caller of `findDescendantPidsWindows`) through a real `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS` timeout.

**F2 (class sibling, MEDIUM, real source defect):** the round-1 class sweep asked "does a caller of `terminateScannerChild` hardcode the wrong kind" but missed the sibling shape "does a caller of `queryProcessTable` inside the orphan-backstop path omit `onTimeout` entirely." Two of `sweepOrphans`'s own scanner queries — `queryCommandLines` (identity verification before any pid kill) and `findPidsByMarkerWindows` (the marker command-line fallback search), both in `clients/instance-reaper.ts` — had NO `onTimeout` at all. A scanner either spawned that blew `BACKSTOP_SCAN_TIMEOUT_MS` therefore fell through to `child-unref.ts`'s default handler: one bare, unverified `child.kill()`, no tree kill, no identity-carrying ledger record whatsoever — the exact scanner abandonment `terminateScannerChild`'s own doc comment says it exists to prevent, reachable from INSIDE the orphan backstop's own registry-driven path (`enumerateManagedProcesses`, the backstop's OTHER scanner, already had this wired correctly).
Fix: both now pass `onTimeout: (child) => terminateScannerChild(child, { kind: "orphan-backstop-scanner-escalated", timeoutMs: BACKSTOP_SCAN_TIMEOUT_MS })`, matching `enumerateManagedProcesses`'s existing wiring. Updated the "Blast radius" and "Class sweep" sections above with corrections (struck through the superseded verdict rather than silently editing it away).

**Documented, no code change:** `recordQueryFailure` (the "did this query settle `ok` or genuinely fail" signal used to argue the informational classification) records through `recordDegradationOnce`, which is once-per-kind-per-subject for the whole session — so the "no matching `resource-sampler-query-failed` row = the escalation raced a query that settled ok" discriminator only holds up to the FIRST genuine query failure per subject; a second-and-later real timeout for the same subject adds no further row either, and at that point the discriminator can't tell "raced" from "failed again" from the summary alone (the per-event NDJSON log and each escalation's own `latestReasons` entry remain the durable record). Also: `renderDegradationLines()` drops the reason text entirely for informational kinds (`  ${kind}: ${count}`, no `latest.reason`), so a forensic read needing the "which race" detail must go to `getDegradationSummary()` or the NDJSON log, never the rendered `/lens-perf` line. Softened the changelog fragment's phrasing accordingly (`.changelog/fix-2524-resource-sampler-scanner-kind.md`).

### Round 2 red runs

`findDescendantPidsWindows`'s kind reverted to `"orphan-backstop-scanner-escalated"` in `clients/resource-sampler.ts` (only the F1 test's target line), rebuilt, `tests/clients/resource-sampler-scanner-attribution.test.ts`:

```
 FAIL  |default| tests/clients/resource-sampler-scanner-attribution.test.ts > #2524: resource-sampler scanner escalation is attributed to its own producer > also attributes the descendant-pid query's (findDescendantPidsWindows) escalation to the sampler's own kind
AssertionError: expected [ { …(2) }, { …(2) } ] to have a length of +0 but got 2
- Expected
+ Received
- 0
+ 2
 ❯ tests/clients/resource-sampler-scanner-attribution.test.ts:195:59

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

`clients/instance-reaper.ts` reverted to `2d64d20b` (pre-round-2, `onTimeout` absent on both `queryCommandLines`/`findPidsByMarkerWindows`), rebuilt, `tests/clients/instance-reaper-registry-scan-escalation.test.ts`:

```
 ❯ |default| tests/clients/instance-reaper-registry-scan-escalation.test.ts (2 tests | 2 failed) 14ms
     × queryCommandLines' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified 11ms
     × findPidsByMarkerWindows' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified 1ms

AssertionError: expected [] to have a length of 1 but got +0
- Expected
+ Received
- 1
+ 0
 ❯ tests/clients/instance-reaper-registry-scan-escalation.test.ts:181:19
 ❯ tests/clients/instance-reaper-registry-scan-escalation.test.ts:208:19

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

Both files restored to the committed fix afterward (`git checkout HEAD -- <file>`, rebuilt); `git status` confirmed a clean tree matching the commit each time.

### Round 2 targeted + governance suites run (all green)

- The original 7 files + the new `tests/clients/instance-reaper-registry-scan-escalation.test.ts` + the symbol-grep set (`degradation-ledger*`, `safe-spawn-*`, `child-unref`) — **25 files, 277 passed, 3 skipped**.
- Governance sweep (`ls tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts`) — **29 files, 469 passed**.
- Every `tests/config/*.test.ts` — **21 files, 174 passed**.
- `npm run lint` — clean.
- Pinned `oxfmt` 0.65.0 `--check` on every touched file — flagged the two new/edited test files, formatted, re-verified clean, retested green.


## Review round 3

CI run 33733851344 on `1f770d71` (round-2 head) was red on Ubuntu:

```
FAIL tests/clients/instance-reaper-registry-scan-escalation.test.ts > #2527 review F2: sweepOrphans' own scanner queries escalate through terminateScannerChild > findPidsByMarkerWindows' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified
AssertionError: expected [ 80001 ] to have a length of 2 but got 1
```

**Root cause (test-only, no source defect):** `clients/instance-reaper.ts` reads
`process.platform` into a MODULE-LOAD-TIME constant (`const isWindows =
process.platform === "win32"`, line 96) — unlike `resource-sampler.ts`'s
`isWindows()`, which re-reads `process.platform` on every call.
`findPidsByMarkerWindows` is `if (!isWindows || !marker) return [];`: on
Ubuntu CI's real `win32`-false host, that module constant is `false` at
import time, so the round-2 test's second case (which expected a SECOND
scanner spawn for `findPidsByMarkerWindows`) never got one — `sweepOrphans`
only ever spawned the first query (`queryCommandLines`, which has no
platform gate). The round-2 test was written and proven green on a Windows
dev box, where the real host platform happens to make `isWindows` true, so
the CI-only failure was never caught locally.

**Fix (test-only):** each case in
`tests/clients/instance-reaper-registry-scan-escalation.test.ts` now forces
its OWN platform before running, via `Object.defineProperty(process,
"platform", ...)` followed by `vi.resetModules()` and a fresh dynamic
`await import("../../clients/instance-reaper.js")` (+
`degradation-ledger.js`) — the same forcing technique
`resource-sampler-scanner-attribution.test.ts` already uses for a live
per-call platform check, adapted here for a module-load-time constant that
only picks up a forced platform on a freshly-imported module instance. Case
1 (`queryCommandLines`) is forced `"linux"`, so it now genuinely exercises
the posix `ps` branch on every host, not just incidentally on Linux CI;
case 2 (`findPidsByMarkerWindows`) is forced `"win32"`, the only platform
where that query spawns anything at all. Both cases now run — and both
branches get real coverage — on every host, Windows dev box or Linux CI
alike.

### Round 3 proof (forced posix AND forced win32, both green, same run, on a Windows dev host)

```
 ✓ |default| tests/clients/instance-reaper-registry-scan-escalation.test.ts > #2527 review F2: sweepOrphans' own scanner queries escalate through terminateScannerChild > queryCommandLines' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified (forced posix — genuinely the ps branch on every host) 572ms
 ✓ |default| tests/clients/instance-reaper-registry-scan-escalation.test.ts > #2527 review F2: sweepOrphans' own scanner queries escalate through terminateScannerChild > findPidsByMarkerWindows' timed-out scanner is tree-killed and recorded under the backstop kind, not abandoned unverified (forced win32 — the only host where this query runs at all) 11ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

### Round 3 targeted + governance suites run (all green)

- `instance-reaper*.test.ts` (6 files) + `resource-sampler*.test.ts` (2 files)
  + every `tests/config/*.test.ts` (21 files) + the governance sweep
  (`ls tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts`,
  29 files, mechanically selected, includes `generation-guard-sweep` and
  `extension-terminal-silence`) — **58 files, 769 passed, 3 skipped, 0
  failed.**
- `npm run lint` — clean (exit 0).
- Pinned `oxfmt` 0.65.0 (already present in `node_modules/.bin`, matches
  `package.json`'s devDependency pin) `--check` on the touched file —
  flagged it, formatted, re-verified clean, rebuilt, retested green.

Head after this round: `3c542d81`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ4a3oS1UDFxs74fLm8U21
