### PR TITLE
fix: deflake three shared-slot-contention test races (closes #2512, closes #2495)

### DIFF
--- a/.changelog/2512-2495-test-flake-hardening.md
+++ b/.changelog/2512-2495-test-flake-hardening.md
@@ -2,22 +2,31 @@
 section: Fixed
 ---
 
-- **Deflaked three shared-slot-contention test races (closes #2512, closes #2495)** —
+- **Deflaked four shared-slot-contention test races (closes #2512, closes #2495)** —
   `tests/index-vanished-instance-wiring.test.ts` no longer bridges the
   fire-and-forget registerInstance/logVanishedInstances/sweepOrphans registry
   chain with a fixed 50ms sleep; it now wraps `sweepOrphans` (the chain's last
   step) to notify an awaitable settle signal, so the test proves the whole
   chain has landed instead of guessing a wall-clock window.
   `tests/clients/runtime-turn-session.test.ts`'s real-child-spawn test now
-  carries an explicit 20s timeout and is phased into vitest's fully
-  serialized, dead-last `wall-clock-budget` project, removing the contention
-  that made it exceed vitest's 5000ms default under a busy batch.
+  carries an explicit 20s timeout (4x the observed worst case), absorbing
+  the same shared-slot contention directly instead of exceeding vitest's
+  5000ms default under a busy batch; it stays in the default parallel
+  project since it asserts no elapsed-time budget, so it does not qualify
+  for the wall-clock-budget project's dead-last serialized phase.
   `tests/clients/topology-derived-cache-rearm.test.ts` no longer asserts an
   exact null `projectRoot` for a synthetic `homeDir` that only pins the
   ceiling check and cannot confine `findNearestProjectRoot`'s contractually
   unbounded upward walk — a real project marker anywhere above the test's
   temp directory on the host (matching `tests/clients/
   startup-scan-home-ceiling.test.ts`'s established fixture shape) previously
-  produced a found-but-rejected root instead of `null`. The assertion now
-  checks `canWarmCaches`, which is deterministic regardless of the host's
-  real ancestor tree.
+  produced a found-but-rejected root instead of `null`. The assertions now
+  check `projectRoot` identity against the tmp cwd directly, which is
+  deterministic regardless of the host's real ancestor tree (checking
+  `canWarmCaches` instead was itself vacuous, since the synthetic `homeDir`
+  rejects every reachable root before and after a marker is planted).
+  `tests/clients/dispatch/runners/runner-helpers.test.ts`'s locale-key dedup
+  test now asserts the probe call count only after both racing callers have
+  settled, instead of right after a fixed 100ms sleep — the sleep itself
+  stays (it lets the second caller join the in-flight probe before it
+  resolves), but the assertion moved off that timing-dependent instant.

--- a/.changelog/2512-2495-test-flake-hardening.md
+++ b/.changelog/2512-2495-test-flake-hardening.md
@@ -1,0 +1,23 @@
+---
+section: Fixed
+---
+
+- **Deflaked three shared-slot-contention test races (closes #2512, closes #2495)** —
+  `tests/index-vanished-instance-wiring.test.ts` no longer bridges the
+  fire-and-forget registerInstance/logVanishedInstances/sweepOrphans registry
+  chain with a fixed 50ms sleep; it now wraps `sweepOrphans` (the chain's last
+  step) to notify an awaitable settle signal, so the test proves the whole
+  chain has landed instead of guessing a wall-clock window.
+  `tests/clients/runtime-turn-session.test.ts`'s real-child-spawn test now
+  carries an explicit 20s timeout and is phased into vitest's fully
+  serialized, dead-last `wall-clock-budget` project, removing the contention
+  that made it exceed vitest's 5000ms default under a busy batch.
+  `tests/clients/topology-derived-cache-rearm.test.ts` no longer asserts an
+  exact null `projectRoot` for a synthetic `homeDir` that only pins the
+  ceiling check and cannot confine `findNearestProjectRoot`'s contractually
+  unbounded upward walk — a real project marker anywhere above the test's
+  temp directory on the host (matching `tests/clients/
+  startup-scan-home-ceiling.test.ts`'s established fixture shape) previously
+  produced a found-but-rejected root instead of `null`. The assertion now
+  checks `canWarmCaches`, which is deterministic regardless of the host's
+  real ancestor tree.

--- a/tests/clients/dispatch/runners/runner-helpers.test.ts
+++ b/tests/clients/dispatch/runners/runner-helpers.test.ts
@@ -400,14 +400,22 @@ describe("runner-helpers availability checker", () => {
 			};
 			const second = checkerB.isAvailableAsync(process.cwd());
 			// Let the second call's async prefix (findCommand's fs walk) settle
-			// before asserting it did or didn't start a second physical probe.
+			// so it has actually joined the existing flight-registry entry
+			// before that entry resolves and is removed below — releasing too
+			// early makes checkerB find no flight to join and spawn its own
+			// (proven: removing this sleep makes safeSpawnAsync observably
+			// called twice). The call-count assertion itself moves below both
+			// awaits: checking it here, right after the sleep and before
+			// release, only proves "not yet 2" at that instant — a
+			// false-green if the prefix were merely slow rather than actually
+			// deduped. Asserting after both `first`/`second` have fully
+			// settled is deterministic, since nothing can still be pending.
 			await new Promise((resolve) => setTimeout(resolve, 100));
-
-			expect(safeSpawnMod.safeSpawnAsync).toHaveBeenCalledTimes(1);
 
 			releaseProbe({ stdout: "1.0.0", stderr: "", status: 0 });
 			expect(await first).toBe(true);
 			expect(await second).toBe(true);
+			expect(safeSpawnMod.safeSpawnAsync).toHaveBeenCalledTimes(1);
 		} finally {
 			String.prototype.localeCompare = realLocaleCompare;
 		}

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -2594,5 +2594,14 @@ describe("turn_end test runner — cascade neighbors get their own test companio
 			}
 			env.cleanup();
 		}
-	});
+		// #2512: spawns a REAL child process (process.execPath -e ...) through
+		// the real TestRunnerClient — same #1022/#2332 contention class as the
+		// LSP-spawn-heavy lane siblings. Seen timing out at vitest's 5000ms
+		// default under a 47-file parallel batch (5153/5013ms), green solo every
+		// time (7.67s) and on CI alone (405ms) — scheduler contention, not code
+		// speed. An explicit spawn-sized timeout here is belt-and-braces; the
+		// real cure is phasing the whole file into the "wall-clock-budget"
+		// project below (vitest.config.ts), which removes the contention
+		// entirely instead of just outrunning it.
+	}, 20_000);
 });

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -2594,14 +2594,17 @@ describe("turn_end test runner — cascade neighbors get their own test companio
 			}
 			env.cleanup();
 		}
-		// #2512: spawns a REAL child process (process.execPath -e ...) through
-		// the real TestRunnerClient — same #1022/#2332 contention class as the
-		// LSP-spawn-heavy lane siblings. Seen timing out at vitest's 5000ms
-		// default under a 47-file parallel batch (5153/5013ms), green solo every
-		// time (7.67s) and on CI alone (405ms) — scheduler contention, not code
-		// speed. An explicit spawn-sized timeout here is belt-and-braces; the
-		// real cure is phasing the whole file into the "wall-clock-budget"
-		// project below (vitest.config.ts), which removes the contention
-		// entirely instead of just outrunning it.
+		// #2512 round 2: spawns a REAL child process (process.execPath -e ...)
+		// through the real TestRunnerClient — same #1022/#2332 contention class
+		// as the LSP-spawn-heavy lane siblings. Seen timing out at vitest's
+		// 5000ms default under a 47-file parallel batch (5153/5013ms), green
+		// solo every time (7.67s) and on CI alone (405ms) — scheduler
+		// contention, not code speed. This test asserts no elapsed-time budget
+		// (only that the spawn completes and its telemetry lands), so it does
+		// not qualify for the wall-clock-budget project's dead-last serialized
+		// phase (vitest.config.ts's wallClockBudgetInclude — "carry a
+		// wall-clock budget assertion, not just slowness"). An explicit
+		// per-test timeout, 4× the observed worst case, absorbs the contention
+		// directly instead.
 	}, 20_000);
 });

--- a/tests/clients/topology-derived-cache-rearm.test.ts
+++ b/tests/clients/topology-derived-cache-rearm.test.ts
@@ -121,6 +121,23 @@ describe("topology-derived cache re-arm (#2263)", () => {
 			fs.writeFileSync(path.join(env.tmpDir, "index.ts"), "export {}\n");
 			const sourceDir = path.join(env.tmpDir, "src");
 			fs.mkdirSync(sourceDir);
+			// #2495: `homeDir` is a SUBDIRECTORY of `env.tmpDir` (never created on
+			// disk), not a real ancestor — this only pins the ceiling check, it
+			// does not confine the walk. `findNearestProjectRoot` is contractually
+			// unbounded (startup-scan.ts's own docstring: a marker at/above $HOME
+			// must still be *returned*, with rejection applied by the caller — see
+			// tests/clients/startup-scan-home-ceiling.test.ts's "above-home cwd"
+			// cases for the same shape), so on a box with a real marker anywhere
+			// above `env.tmpDir` (here: `C:\Users\R3LiC\package.json`, the
+			// manifest for the user's pi extensions) the walk finds THAT marker
+			// and `projectRoot` comes back as that real path, not null — the
+			// ceiling only forces `canWarmCaches: false`, it never nulls
+			// `projectRoot` for a found-but-rejected root. Asserting the
+			// warm-cache verdict (what quick mode actually branches on, per the
+			// "quick mode active - skipping" dbg check below) instead of the
+			// found root's exact identity is deterministic on every host: since
+			// `homeDir` is nested inside `env.tmpDir`, ANY root the walk can find
+			// starting from `env.tmpDir` is necessarily at-or-above `homeDir`.
 			const homeDir = path.join(env.tmpDir, "home");
 			const firstLanguage = languageProfile.detectProjectLanguageProfile(
 				env.tmpDir,
@@ -129,7 +146,7 @@ describe("topology-derived cache re-arm (#2263)", () => {
 				homeDir,
 			});
 			expect(firstLanguage.configured.jsts).toBeUndefined();
-			expect(firstScan.projectRoot).toBeNull();
+			expect(firstScan.canWarmCaches).toBe(false);
 			const tsconfig = path.join(env.tmpDir, "tsconfig.json");
 			fs.writeFileSync(
 				tsconfig,
@@ -225,9 +242,16 @@ describe("topology-derived cache re-arm (#2263)", () => {
 	it("re-derives startup scan context after topology reset", () => {
 		const env = setupTestEnvironment("pi-lens-topology-startup-");
 		try {
+			// #2495: see the sibling test above — `homeDir` only pins the ceiling
+			// check (nested inside `env.tmpDir`, so any found root is necessarily
+			// at-or-above it); it does not confine the unbounded upward walk, so
+			// `projectRoot` itself can legitimately come back as a real marker
+			// found above `env.tmpDir` on this host. Assert the warm-cache verdict
+			// instead, which is deterministic regardless of what the host's real
+			// ancestor tree contains.
 			const homeDir = path.join(env.tmpDir, "home");
 			const before = resolveStartupScanContext(env.tmpDir, { homeDir });
-			expect(before.projectRoot).toBeNull();
+			expect(before.canWarmCaches).toBe(false);
 
 			fs.mkdirSync(path.join(env.tmpDir, ".git"));
 			resetWorkspaceTopology();

--- a/tests/clients/topology-derived-cache-rearm.test.ts
+++ b/tests/clients/topology-derived-cache-rearm.test.ts
@@ -146,7 +146,15 @@ describe("topology-derived cache re-arm (#2263)", () => {
 				homeDir,
 			});
 			expect(firstLanguage.configured.jsts).toBeUndefined();
-			expect(firstScan.canWarmCaches).toBe(false);
+			// No marker exists in env.tmpDir yet (.git/package.json are only
+			// written below), so the walk cannot resolve projectRoot to tmpDir
+			// itself — it either finds nothing or lands on a real ancestor
+			// marker further up the host's filesystem. Asserting `canWarmCaches`
+			// here is vacuous: homeDir is nested inside env.tmpDir, so
+			// isAtOrAboveHomeDir rejects every reachable root regardless of
+			// whether a marker exists at env.tmpDir, making the assertion true
+			// both before and after a marker is planted there.
+			expect(firstScan.projectRoot).not.toBe(path.resolve(env.tmpDir));
 			const tsconfig = path.join(env.tmpDir, "tsconfig.json");
 			fs.writeFileSync(
 				tsconfig,
@@ -246,12 +254,13 @@ describe("topology-derived cache re-arm (#2263)", () => {
 			// check (nested inside `env.tmpDir`, so any found root is necessarily
 			// at-or-above it); it does not confine the unbounded upward walk, so
 			// `projectRoot` itself can legitimately come back as a real marker
-			// found above `env.tmpDir` on this host. Assert the warm-cache verdict
-			// instead, which is deterministic regardless of what the host's real
-			// ancestor tree contains.
+			// found above `env.tmpDir` on this host. `canWarmCaches` is vacuous
+			// here for the same reason as the sibling test: no marker exists in
+			// env.tmpDir yet (.git is only created below), so the walk cannot
+			// land on env.tmpDir itself — assert that directly instead.
 			const homeDir = path.join(env.tmpDir, "home");
 			const before = resolveStartupScanContext(env.tmpDir, { homeDir });
-			expect(before.canWarmCaches).toBe(false);
+			expect(before.projectRoot).not.toBe(path.resolve(env.tmpDir));
 
 			fs.mkdirSync(path.join(env.tmpDir, ".git"));
 			resetWorkspaceTopology();

--- a/tests/index-vanished-instance-wiring.test.ts
+++ b/tests/index-vanished-instance-wiring.test.ts
@@ -62,6 +62,57 @@ vi.mock("../clients/sessionstart-logger.js", async (importActual) => {
 	};
 });
 
+// #2512: the session_start handler kicks off registerInstance/
+// logVanishedInstances/sweepOrphans fire-and-forget (session_start must not
+// block on registry I/O — see index.ts's own comment at the call site) and
+// this test used to bridge the gap with a fixed 50ms sleep, hoping the real
+// fs read-modify-write chain landed by then. Under shared-slot contention
+// (#2509 round 4's 47-file batch) it sometimes did not, and the assertions
+// below raced ahead of the write. `sweepOrphans` is the LAST step of that
+// chain (index.ts's `.finally(() => { void sweepOrphans(); })`), so wrapping
+// it to notify a listener after it settles gives an exact, awaitable signal
+// for "the whole chain has landed" instead of a wall-clock guess — the same
+// shape as instance-registry.ts's own `_settleRegistryMutationsForTests`,
+// just for the reaper's independent (non-tail-queued) prune write.
+const { onSweepOrphansSettled, notifySweepOrphansSettled } = vi.hoisted(() => {
+	const listeners = new Set<() => void>();
+	return {
+		onSweepOrphansSettled: (cb: () => void): (() => void) => {
+			listeners.add(cb);
+			return () => listeners.delete(cb);
+		},
+		notifySweepOrphansSettled: () => {
+			for (const cb of listeners) cb();
+		},
+	};
+});
+vi.mock("../clients/instance-reaper.js", async (importActual) => {
+	const actual =
+		await importActual<typeof import("../clients/instance-reaper.js")>();
+	return {
+		...actual,
+		sweepOrphans: async (): Promise<void> => {
+			try {
+				await actual.sweepOrphans();
+			} finally {
+				notifySweepOrphansSettled();
+			}
+		},
+	};
+});
+
+/** Resolves the NEXT time the wrapped `sweepOrphans` above completes. Must be
+ * called (to register the listener) BEFORE the action that triggers it, so
+ * the completion can never be missed racing the listener's own registration. */
+function waitForSweepOrphansSettled(): Promise<void> {
+	return new Promise((resolve) => {
+		const unsubscribe = onSweepOrphansSettled(() => {
+			unsubscribe();
+			resolve();
+		});
+	});
+}
+
 function registryFilePath(): string {
 	return path.join(process.env.PI_LENS_HOME as string, "instances.json");
 }
@@ -121,11 +172,15 @@ describe("index session_start vanished-instance wiring (#1123 item 2)", () => {
 
 		const pi = createPiMock();
 		extension(pi.asExtensionAPI());
+		// Registered BEFORE emit so the settle notification can never fire
+		// before this listener exists to catch it.
+		const settled = waitForSweepOrphansSettled();
 		await pi.emit("session_start", {}, makeCtx({ cwd: tmp }));
 		// registerInstance/logVanishedInstances/sweepOrphans are fire-and-forget
-		// (session_start must not block on registry I/O) — give the microtask/IO
-		// chain a tick to land.
-		await new Promise((r) => setTimeout(r, 50));
+		// (session_start must not block on registry I/O); sweepOrphans is the
+		// LAST step of that chain, so awaiting its settle signal proves the
+		// marker log (which runs strictly before it) has already landed too.
+		await settled;
 
 		// logSessionStart (via dbg()) also carries plenty of other session_start
 		// trace lines — isolate the marker line specifically.
@@ -150,8 +205,9 @@ describe("index session_start vanished-instance wiring (#1123 item 2)", () => {
 	it("logs nothing when the registry has no dead entries", async () => {
 		const pi = createPiMock();
 		extension(pi.asExtensionAPI());
+		const settled = waitForSweepOrphansSettled();
 		await pi.emit("session_start", {}, makeCtx({ cwd: tmp }));
-		await new Promise((r) => setTimeout(r, 50));
+		await settled;
 
 		const markerLines = logSessionStartSpy.mock.calls
 			.map((call) => call[0] as string)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -317,16 +317,18 @@ const wallClockBudgetInclude = [
 	// window. Keep child-process CPU sampling and this wall-clock lower bound in
 	// the fully serialized, dead-last phase.
 	"tests/clients/lsp/service-notify-cpu-liveness.test.ts",
-	// #2512: "retires a deleted failed target through the real client and
-	// records real telemetry" spawns a REAL child process through the real
-	// TestRunnerClient and measures the real registry/latency-log write that
-	// follows — same #1022/#2332 contention class as the rest of this list.
-	// Timed out at vitest's 5000ms default under a 47-file parallel batch
-	// (5153/5013ms), green solo every time (7.67s) and on CI alone (405ms).
-	// The file's other 49 tests are synthetic/mocked and pay only the
-	// (small, one-at-a-time) serialization cost of sharing this phase.
-	"tests/clients/runtime-turn-session.test.ts",
 ];
+// #2512 round 2: runtime-turn-session.test.ts's "retires a deleted failed
+// target through the real client and records real telemetry" spawns a REAL
+// child process, and was seen timing out at vitest's 5000ms default under a
+// 47-file parallel batch (5153/5013ms) — but it asserts no elapsed-time
+// budget at all, only that the spawn completes and its telemetry lands. That
+// fails this list's own charter (above: "carry a wall-clock budget assertion,
+// not just slowness"), so it does not belong here. An explicit per-test
+// timeout (20_000ms, 4× the observed 5013ms worst case) absorbs the same
+// contention without pulling 49 unrelated synthetic/mocked tests in the same
+// file into the serialized, dead-last phase — see the timeout at that test's
+// call site in runtime-turn-session.test.ts.
 
 export default defineConfig({
 	test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -317,6 +317,15 @@ const wallClockBudgetInclude = [
 	// window. Keep child-process CPU sampling and this wall-clock lower bound in
 	// the fully serialized, dead-last phase.
 	"tests/clients/lsp/service-notify-cpu-liveness.test.ts",
+	// #2512: "retires a deleted failed target through the real client and
+	// records real telemetry" spawns a REAL child process through the real
+	// TestRunnerClient and measures the real registry/latency-log write that
+	// follows — same #1022/#2332 contention class as the rest of this list.
+	// Timed out at vitest's 5000ms default under a 47-file parallel batch
+	// (5153/5013ms), green solo every time (7.67s) and on CI alone (405ms).
+	// The file's other 49 tests are synthetic/mocked and pay only the
+	// (small, one-at-a-time) serialization cost of sharing this phase.
+	"tests/clients/runtime-turn-session.test.ts",
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Fixes three test-only flakes from the fixed-sleep / unbounded-walk-vs-synthetic-boundary defect classes:

**#2512** — `tests/index-vanished-instance-wiring.test.ts` bridged the fire-and-forget `registerInstance`/`logVanishedInstances`/`sweepOrphans` registry chain (kicked off, never awaited, by `index.ts`'s `session_start` handler) with a fixed `setTimeout(r, 50)`. Under shared-slot contention the real fs read-modify-write chain sometimes had not landed by then. `sweepOrphans` is the chain's last step (`index.ts`'s `.finally(() => { void sweepOrphans(); })`), so the test now wraps it (via `vi.mock` of `clients/instance-reaper.js`, spreading `importActual` for everything else) to notify a `Set`-backed listener registry on completion, and awaits that signal instead of guessing a wall-clock window — the same idea as `instance-registry.ts`'s own `_settleRegistryMutationsForTests`, applied to the reaper's independent (non-tail-queued) prune write.

Also fixes the explicitly named sibling from the issue's own follow-up comment: `tests/clients/runtime-turn-session.test.ts`'s `"retires a deleted failed target through the real client and records real telemetry"` spawns a REAL child process (`process.execPath -e ...`) through the real `TestRunnerClient` and timed out at vitest's 5000ms default under a 47-file parallel batch (5153/5013ms measured), green solo (7.67s) and on CI alone (405ms) — the same #1022/#2332 contention class as the existing `lsp-spawn-heavy`/`wall-clock-budget` lane members. It now carries an explicit `20_000`ms timeout (belt-and-braces) and the whole file is phased into vitest's fully serialized, dead-last `wall-clock-budget` project in `vitest.config.ts`, removing the contention rather than just outrunning it. `tests/config/timing-sensitive-coverage.test.ts`'s existing "wall-clock-budget include entries exist on disk" check covers the new registration.

**#2495** — `tests/clients/topology-derived-cache-rearm.test.ts` passed a synthetic `homeDir = path.join(env.tmpDir, "home")` (a subdirectory of its own cwd, never created on disk) and asserted `resolveStartupScanContext(...).projectRoot === null`. `findNearestProjectRoot` (`clients/startup-scan.ts`) is contractually **unbounded** — its own docstring: a marker at/above `$HOME` must still be *returned*, with rejection applied by the caller (`isAtOrAboveHomeDir`), not swallowed by the walk. Because `homeDir` here is nested *inside* `env.tmpDir`, any root the unbounded walk finds is necessarily at-or-above it, so `canWarmCaches` was always correctly `false` — but on a host with a real project marker anywhere above the test's temp directory (here: `C:\Users\R3LiC\package.json`, the manifest for the user's pi extensions), the walk found and returned THAT marker as `projectRoot` instead of `null`. This is exactly the shape `tests/clients/startup-scan-home-ceiling.test.ts`'s "above-home cwd" tests already document and correctly assert `canWarmCaches`/`reason` for, never `projectRoot`'s exact identity. Both assertions now check `canWarmCaches`, which is deterministic regardless of what the host's real ancestor tree contains — reproduced red-first against the real `C:\Users\R3LiC\package.json` on this dev box, matching the issue's exact repro.

Refs #2463, #2478 (same fixed-sleep-on-async-chain class), #622/#625/#2467 (same HOME-ceiling class), #1022/#2332 (spawn-contention phasing class).

Closes #2512, closes #2495.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs) — test-only PR; existing coverage is hardened, not expanded
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR (via throwaway, uncommitted probe files that forced the races and were deleted before commit — see Tests section)
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test — N/A, no new production guard/branch/filter; the settle-signal test seam itself was proven to catch the exact regression it exists for (see Tests section)
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts` — N/A, no `clients/`/`tools/`/`index.ts` changes, test-files and `vitest.config.ts` only
- [x] `package-lock.json` is in sync with `package.json`
- [ ] `AGENTS.md` is updated — N/A, no new invariant/convention introduced beyond existing documented patterns (`_settleRegistryMutationsForTests` precedent, `wallClockBudgetInclude` precedent)
- [x] `.changelog/2512-2495-test-flake-hardening.md` has one valid entry (Fixed), validated with `node scripts/check-changelog-fragments.mjs`
- [x] Commit subject includes the issue numbers: `(closes #2512, closes #2495)`

## Tests

All three are EDITS of existing test files/config, no new test files.

- `tests/index-vanished-instance-wiring.test.ts` (both `it`s edited): replaced `await new Promise((r) => setTimeout(r, 50))` with an awaitable settle signal wrapping the real `sweepOrphans`. **Red proof** (throwaway probe, deleted before commit): copied the pre-fix test, injected an artificial 200ms delay into `clients/atomic-write.js`'s `writeFileAtomicAsync` (the shared write seam both `registerInstance` and the reaper's prune go through) via `vi.mock`, standing in for shared-slot contention deterministically:
  ```
  AssertionError: expected [ 200836 ] to not include 200836
   ❯ tests/PROBE-old-vanished-wiring.test.ts:143:64
  ```
  Same probe against the FIXED test (settle-signal, same injected 200ms delay): `Test Files 1 passed (1)`, `Tests 2 passed (2)`.

- `tests/clients/runtime-turn-session.test.ts` ("retires a deleted failed target through the real client and records real telemetry"): added an explicit `20_000` timeout. **Red proof** (throwaway probe, deleted before commit): same test body, `vi.mock`'d `clients/safe-spawn.js`'s `safeSpawnAsync` to add a 1300ms delay per call (4 calls observed, ≈5.2s total — matching the issue's reported 5013/5153ms), no explicit timeout (matches pre-fix code):
  ```
  Error: Test timed out in 5000ms.
   ❯ tests/clients/PROBE-runtime-turn-session-timeout.test.ts:72:2
  Duration  8.77s (... tests 5.01s ...)
  ```
  Same probe WITH the `20_000` timeout, same injected delay: `Test Files 1 passed (1)`, `Tests 1 passed (1)`.

- `vitest.config.ts`: added `tests/clients/runtime-turn-session.test.ts` to `wallClockBudgetInclude` (fully serialized, dead-last `wall-clock-budget` project) — removes the contention itself, the timeout bump above is belt-and-braces. Covered by `tests/config/timing-sensitive-coverage.test.ts`'s existing "wall-clock-budget include entries exist on disk" existence check (no new test needed — that guard already walks the live config).

- `tests/clients/topology-derived-cache-rearm.test.ts` (both affected assertions edited): `expect(firstScan.projectRoot).toBeNull()` / `expect(before.projectRoot).toBeNull()` → `expect(...canWarmCaches).toBe(false)`. **Red proof** (this repo's own dev box, real repro, no synthetic delay needed): ran unmodified against pre-fix source —
  ```
  FAIL tests/clients/topology-derived-cache-rearm.test.ts > ... > re-arms all registered topology caches through a live primary→/new start
  AssertionError: expected 'C:\Users\R3LiC' to be null
   ❯ tests/clients/topology-derived-cache-rearm.test.ts:132:34
  FAIL tests/clients/topology-derived-cache-rearm.test.ts > ... > re-derives startup scan context after topology reset
  AssertionError: expected 'C:\Users\R3LiC' to be null
   ❯ tests/clients/topology-derived-cache-rearm.test.ts:230:31
  Test Files  1 failed (1)
       Tests  2 failed | 2 passed (4)
  ```
  After the fix, same file: `Test Files 1 passed (1)`, `Tests 4 passed (4)`.

Test-authoring screen: all three are the **loose bound** screen (a fixed wall-clock wait, or a synthetic boundary that cannot actually confine the thing it is meant to bound) from AGENTS.md's ten screens.

Stability: each of the three fixed files run 10x via `npm run test:targeted` after the fix, all green (`tests/index-vanished-instance-wiring.test.ts` 10/10, `tests/clients/topology-derived-cache-rearm.test.ts` 10/10, `tests/clients/runtime-turn-session.test.ts` 10/10, 50/50 tests each run).

### Test assessment

- `tests/index-vanished-instance-wiring.test.ts` — pins that a REAL `session_start` against a dead-pid registry entry logs the vanished-instance marker BEFORE the reaper prunes that same entry. No test made redundant.
- `tests/clients/runtime-turn-session.test.ts` — pins REAL originating-turn propagation through selection/recording/sink for a retired test target (the #2044 review gap the hand-written doubles elsewhere in the file cannot prove). No test made redundant; only this one `it`'s timeout/phasing changed.
- `tests/clients/topology-derived-cache-rearm.test.ts` — pins that quick-mode session start correctly skips warming when no legitimate project exists, and correctly re-arms all four topology-derived caches (language profile, startup scan, tsconfig paths) after a `/new` sequential-replacement session start. No test made redundant; the assertion shape changed, not the behavior pinned.

## Blast radius

Test-files and `vitest.config.ts` only — no production module touched. `wallClockBudgetInclude` gains one member; the "wall-clock-budget" project's own existing serialization behavior (`maxWorkers: 1`, `groupOrder: 4`, dead-last) is unchanged. `tests/clients/runtime-turn-session.test.ts`'s other 49 tests move from the parallel `default` project into that serialized lane — real but bounded cost (all synthetic/mocked, no real spawns among them), consistent with the existing precedent (`cascade-turn-merge.test.ts`, 18 tests, already in the same lane).

## Observability

Test-only PR — not applicable. The `sweepOrphans` settle-signal wrapper and the timeout/phasing changes exist purely inside `tests/`; nothing they touch is shipped or user-facing.

## Class sweep

**#2512 class** (fixed `setTimeout`/`sleep(N)` bridging a fire-and-forget async chain): grepped `tests/` for `new Promise((r(esolve)?) => setTimeout(r(esolve)?, N))` / `sleep(N)` with N > 0 (29 files), then intersected with files that self-document a "fire-and-forget"/"unawaited" race (10 files) to separate genuine same-class candidates from legitimate real-timer/deadline-behavior tests (`deadline-utils.test.ts`, `fault-injection.test.ts`, `suite-lock*.test.ts`, mtime-tick waits, etc. — out of scope, they test real elapsed-time behavior on purpose, not a race). Of the 10 candidates: `tests/index-vanished-instance-wiring.test.ts` (fixed, this PR) and the explicitly-named `tests/clients/runtime-turn-session.test.ts` (fixed, this PR). Reviewed but left as-is with reasoning:
  - `tests/clients/dispatch/runners/runner-helpers.test.ts:404` (locale-order dedup test) — genuinely same shape (waits for an async `findCommand` fs-walk prefix to settle before asserting no second physical probe fired), but fixing it deterministically needs a NEW test-only settle seam on the shared, widely-used `createAvailabilityChecker`/flight-dedup module (`clients/*-client.ts` availability-policy latch family) — out of scope for a two-issue test-hardening PR; filing as a follow-up rather than expanding this PR's blast radius into shared production code.
  - `tests/clients/instance-registry.test.ts:394` (gated-write ordering test) — the 50ms wait only matters for PRE-#1724 (unserialized) behavior; POST-#1724 both racers are already fully serialized on the same in-process registry-mutation tail regardless of the sleep's length, so it is not currently flake-prone under this repo's shipped code — left as-is.
  - `tests/clients/lsp/integration.test.ts`, `service-notify-cpu-liveness.test.ts` (already in `wallClockBudgetInclude`), `service-document-drift.test.ts`, `shutdown-live-wedged-process.test.ts`, `word-index.test.ts`, `safe-spawn-sync-throw.test.ts`, `scripts/prune-agent-worktrees.test.ts` — real LSP-server/process-death/deliberate-artificial-delay timing budgets, not a fire-and-forget-chain race; out of class.

**#2495 class** (`homeDir:` override paired with an `mkdtemp` root): grepped `tests/` for `homeDir:`/`homeDir =` (18 files), then checked each against `findNearestProjectRoot`'s unbounded-walk contract vs. `clients/config-locations.ts`'s `configSearchDirs` (which correctly `break`s at the ceiling — a genuinely bounded walk, not vulnerable to this class at all). Of the files using the unbounded `startup-scan.ts` walker (`startup-scan-entry-budget.test.ts`, `startup-scan-home-ceiling.test.ts`, `startup-scan-symlink-cycle.test.ts`, `startup-scan-verdict-cache.test.ts`, `monorepo/scale-knob.test.ts`, `monorepo/size-cliff.test.ts`, `monorepo/subdir-scoping.test.ts`), every one except `topology-derived-cache-rearm.test.ts` places a real project marker directly at the scanned `cwd` (found at 0 hops, before any escape past a real or synthetic home boundary can occur) or asserts on `canWarmCaches` rather than `projectRoot`'s exact identity — `startup-scan-home-ceiling.test.ts` is in fact the CANONICAL correct pattern this PR's fix now matches. `topology-derived-cache-rearm.test.ts` was the sole population member with the defect. Consolidation verdict: no shared helper to fold onto — each caller already has its own tmp-fixture setup; the fix is per-fixture (match the established `startup-scan-home-ceiling.test.ts` shape), not a new seam.

## Review round 2

Reviewer probed three findings against the round-1 code (all probe-proven before any fix was written).

**F1 (MEDIUM, fixed)** — `tests/clients/topology-derived-cache-rearm.test.ts:149,254`'s round-1 `canWarmCaches === false` assertions were themselves vacuous: `homeDir` is nested inside `env.tmpDir`, so `isAtOrAboveHomeDir` rejects every reachable root both before AND after the `.git` marker is planted — the assertion is `true` regardless of whether the walk actually landed on `env.tmpDir`. Replaced with `expect(...projectRoot).not.toBe(path.resolve(env.tmpDir))` at both sites (host-independent, same reasoning as round 1: no marker exists in `env.tmpDir` yet at that point in either test). **Red proof**: temporarily moved `fs.mkdirSync(path.join(env.tmpDir, ".git"))` to before each `resolveStartupScanContext`/`firstScan` call (matching the reviewer's exact mutation) and reran:
```
FAIL ... > re-arms all registered topology caches through a live primary→/new start
AssertionError: expected 'C:\Users\R3LiC\AppData\Local\Temp\pi-…' not to be 'C:\Users\R3LiC\AppData\Local\Temp\pi-…'
 ❯ tests/clients/topology-derived-cache-rearm.test.ts:158:38
FAIL ... > re-derives startup scan context after topology reset
AssertionError: expected 'C:\Users\R3LiC\AppData\Local\Temp\pi-…' not to be 'C:\Users\R3LiC\AppData\Local\Temp\pi-…'
 ❯ tests/clients/topology-derived-cache-rearm.test.ts:264:35
Test Files  1 failed (1)
     Tests  2 failed | 2 passed (4)
```
Reverted the mutation (`git checkout --` against the already-committed fix, working tree was clean beforehand) — back to `Test Files 1 passed (1)`, `Tests 4 passed (4)`, 10/10 stable.

**F2 (LOW, fixed in this PR)** — round 1's class-sweep had deferred `tests/clients/dispatch/runners/runner-helpers.test.ts:404` (`await sleep(100)` then `toHaveBeenCalledTimes(1)`, before releasing the shared probe) as needing a new production seam. The reviewer's "move the assertion below `await first`/`await second`" turned out to be a genuine seam-free fix, but round 1's original deferral reasoning undersold a real hazard: first attempt (removing the sleep entirely and releasing immediately) actually **broke** the test — `safeSpawnAsync` called 2 times instead of 1, because releasing the shared probe before checkerB's async prefix reached the flight-join point makes it find no flight to join and spawn independently:
```
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
 ❯ tests/clients/dispatch/runners/runner-helpers.test.ts:416:40
```
This proved the sleep is load-bearing synchronization (letting checkerB join before the flight resolves), not just an assertion-timing crutch. Corrected fix keeps the sleep, moves only the `toHaveBeenCalledTimes(1)` assertion to after both `await first`/`await second` settle — deterministic because nothing can still be pending by then. `Test Files 1 passed (1)`, `Tests 54 passed (54)`, 10/10 stable. No follow-up issue needed; the deferred item is closed.

**F3 (LOW, fixed)** — `wallClockBudgetInclude`'s own charter comment (`vitest.config.ts:308-309`, unchanged this round) requires "a wall-clock budget assertion, not just slowness"; `runtime-turn-session.test.ts`'s spawned-child test asserts none (only that the spawn completes and its telemetry lands — confirmed via grep, no `Date.now()`/elapsed check anywhere in the file's real-spawn test). Admitting it to that list contradicted the list's own stated purpose. Dropped the entry, kept the explicit `20_000`ms per-test timeout (4x headroom over the observed 5013/5153ms worst case) as the direct absorber of the contention, and updated both the `vitest.config.ts` comment and the test's own inline comment to explain why. `Test Files 1 passed (1)`, `Tests 50 passed (50)`, 10/10 stable solo.

**Verification this round**: `npm run build` clean; all three touched files run 10x each (topology-derived-cache-rearm 10/10, runner-helpers 10/10, runtime-turn-session 10/10); the 13 files matching `grep -rl "instance-reaper" tests --include="*.test.ts"` — `198 passed (198)` across `13` files; `tests/config/*.test.ts` (21 files) plus the governance-sweep glob `tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts` (29 files) run together — `643 passed (643)` across `50` files; `npm run lint` clean; `npx oxfmt --check` clean on all four touched files. Changelog fragment (`.changelog/2512-2495-test-flake-hardening.md`) updated to match the round-2 assertion shapes and re-validated with `node scripts/check-changelog-fragments.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ4a3oS1UDFxs74fLm8U21

