### PR TITLE
fix(lsp): overlap auxiliary LSP warmup with primary server during resync (#2540)

### DIFF
--- a/.changelog/2540-concurrent-auxiliary-lsp-spawn.md
+++ b/.changelog/2540-concurrent-auxiliary-lsp-spawn.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **LSP auxiliary server spawn concurrent and off-hook bounded (closes #2540)** — on cold first edit, eligible auxiliary servers spawn concurrently via Promise.all bounded by bounded() using the ambient turn signal, rather than running serially. Pre-dispatch sync retains primary-only scope while auxiliary readiness is pushed to the latency log under the auxiliary_readiness phase.

--- a/.changelog/2540-concurrent-auxiliary-lsp-spawn.md
+++ b/.changelog/2540-concurrent-auxiliary-lsp-spawn.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **LSP auxiliary server spawn concurrent and off-hook bounded (closes #2540)** — on cold first edit, eligible auxiliary servers spawn concurrently via Promise.all bounded by bounded() using the ambient turn signal, rather than running serially. Pre-dispatch sync retains primary-only scope while auxiliary readiness is pushed to the latency log under the auxiliary_readiness phase.
+- **Overlap auxiliary LSP warmup with primary server during resync (closes #2540)** — on cold first edit, auxiliary LSP server acquisition is kicked off concurrently and unawaited via deferred LSP work at resync time, overlapping auxiliary warmup with the primary language server. Bounded per server by `bounded()` using the ambient turn signal and caller hook attribution, dropping cold two-server edit latency from the sum of both spawns to the slowest single spawn. Auxiliary readiness duration is pushed to the latency log under the `auxiliary_readiness` phase.

--- a/clients/latency-logger.ts
+++ b/clients/latency-logger.ts
@@ -150,6 +150,7 @@ const LAST_PHASE_EXCLUDED = new Set([
 	"degradation_ledger",
 	"path_attribution_verified_rollup",
 	"concurrent_session_bind_rollup",
+	"auxiliary_readiness",
 ]);
 
 /**

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -34,6 +34,7 @@ import {
 import { shouldPreferPullOnlyDiagnostics } from "../lsp-budget.js";
 import { sampleProcessTreeCpuPercent } from "../resource-sampler.js";
 import { bounded, withDeadline, withTimeout } from "../deadline-utils.js";
+import type { LedgerHookKey } from "../hook-budgets.js";
 import { getAmbientAbortSignal } from "../safe-spawn.js";
 import { abortDeferredLspWork } from "../deferred-lsp-work.js";
 import {
@@ -679,6 +680,8 @@ export interface LSPTouchFileOptions {
 	excludeServerIds?: ReadonlySet<string>;
 	/** Budget for waiting on the LSP client to spawn / become ready. */
 	maxClientWaitMs?: number;
+	/** Hook identity for bounded abandonment attribution (defaults to tool_result_edit). */
+	hook?: LedgerHookKey;
 	/**
 	 * Budget for waiting on `textDocument/publishDiagnostics` after the notify
 	 * lands. The dispatch-lsp-runner sets this to a tighter value so a slow
@@ -3259,6 +3262,7 @@ export class LSPService {
 		) => void,
 		maxWaitMs?: number,
 		signal?: AbortSignal,
+		hook?: LedgerHookKey,
 	): Promise<SpawnedServer[]> {
 		if (this.checkDestroyed() || enabledIds.size === 0) return [];
 		const servers = getServersForFileWithConfig(filePath).filter(
@@ -3267,6 +3271,7 @@ export class LSPService {
 		if (servers.length === 0) return [];
 		const rootMemo = new Map<string, Promise<string | undefined>>();
 		const effectiveSignal = signal ?? getAmbientAbortSignal();
+		const effectiveHook = hook ?? "tool_result_edit";
 		const spawned = await Promise.all(
 			servers.map(async (server) => {
 				const acquisition = this.ensureClientForServer(
@@ -3283,7 +3288,7 @@ export class LSPService {
 				return bounded(acquisition, {
 					ms: maxWaitMs,
 					signal: effectiveSignal,
-					hook: "tool_result_edit",
+					hook: effectiveHook,
 					label: `auxiliary-spawn:${server.id}`,
 				});
 			}),
@@ -4496,6 +4501,8 @@ export class LSPService {
 					new Set(options.auxiliaryServerIds ?? []),
 					noteColdAuxiliary,
 					options.maxClientWaitMs,
+					undefined,
+					options.hook,
 				),
 			]);
 			const auxDurationMs = Date.now() - auxStartedAt;

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -33,7 +33,8 @@ import {
 } from "../project-trust.js";
 import { shouldPreferPullOnlyDiagnostics } from "../lsp-budget.js";
 import { sampleProcessTreeCpuPercent } from "../resource-sampler.js";
-import { withDeadline, withTimeout } from "../deadline-utils.js";
+import { bounded, withDeadline, withTimeout } from "../deadline-utils.js";
+import { getAmbientAbortSignal } from "../safe-spawn.js";
 import { abortDeferredLspWork } from "../deferred-lsp-work.js";
 import {
 	acquireWorkspaceSweepHold,
@@ -3256,22 +3257,36 @@ export class LSPService {
 			serverId: string,
 			outcome: LSPClientAcquisitionOutcome,
 		) => void,
+		maxWaitMs?: number,
+		signal?: AbortSignal,
 	): Promise<SpawnedServer[]> {
 		if (this.checkDestroyed() || enabledIds.size === 0) return [];
 		const servers = getServersForFileWithConfig(filePath).filter(
 			(s) => s.role === "auxiliary" && enabledIds.has(s.id),
 		);
 		if (servers.length === 0) return [];
+		const rootMemo = new Map<string, Promise<string | undefined>>();
+		const effectiveSignal = signal ?? getAmbientAbortSignal();
 		const spawned = await Promise.all(
-			servers.map((server) =>
-				this.ensureClientForServer(
+			servers.map(async (server) => {
+				const acquisition = this.ensureClientForServer(
 					filePath,
 					server,
 					undefined,
 					undefined,
 					(reported) => onOutcome?.(server.id, reported),
-				),
-			),
+					rootMemo,
+				);
+				if (!maxWaitMs || maxWaitMs <= 0) {
+					return acquisition;
+				}
+				return bounded(acquisition, {
+					ms: maxWaitMs,
+					signal: effectiveSignal,
+					hook: "tool_result_edit",
+					label: `auxiliary-spawn:${server.id}`,
+				});
+			}),
 		);
 		return spawned.filter((entry): entry is SpawnedServer => Boolean(entry));
 	}
@@ -4467,6 +4482,7 @@ export class LSPService {
 		} else if (clientScope === "with-auxiliary") {
 			// Primary language server + the enabled cross-cutting auxiliaries
 			// (opengrep, …). The aggregation layer merges/dedups their diagnostics.
+			const auxStartedAt = Date.now();
 			const [entry, aux] = await Promise.all([
 				this.getClientForFile(
 					filePath,
@@ -4479,8 +4495,25 @@ export class LSPService {
 					filePath,
 					new Set(options.auxiliaryServerIds ?? []),
 					noteColdAuxiliary,
+					options.maxClientWaitMs,
 				),
 			]);
+			const auxDurationMs = Date.now() - auxStartedAt;
+			if (options.auxiliaryServerIds && options.auxiliaryServerIds.length > 0) {
+				logLatency({
+					type: "phase",
+					phase: "auxiliary_readiness",
+					filePath: normalizedPath,
+					durationMs: auxDurationMs,
+					metadata: {
+						serverIds: aux.map((s) => s.info.id),
+						attemptedCount: options.auxiliaryServerIds.length,
+						readyCount: aux.length,
+						coldServerIds: [...coldAuxiliaryServerIds],
+						source,
+					},
+				});
+			}
 			spawned = entry ? [entry, ...aux] : aux;
 			serverCountAttempted = spawned.length;
 		} else {

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -1086,7 +1086,7 @@ export async function resyncLspFile(
 			const auxServerIds = enabledAuxiliaryLspServerIds(getFlag);
 			if (auxServerIds.length > 0) {
 				void lspService
-					.getAuxiliaryClientsForFile?.(
+					.getAuxiliaryClientsForFile(
 						filePath,
 						new Set(auxServerIds),
 						undefined,
@@ -1094,7 +1094,7 @@ export async function resyncLspFile(
 						abort,
 						"tool_result_edit",
 					)
-					?.catch(() => {});
+					.catch(() => {});
 			}
 
 			const startedAt = Date.now();

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -73,6 +73,11 @@ import { RUNTIME_CONFIG } from "./runtime-config.js";
 import type { WordIndex } from "./word-index.js";
 import { getAmbientAbortSignal, safeSpawnAsync } from "./safe-spawn.js";
 import { bounded } from "./deadline-utils.js";
+import {
+	armDeferredLspWork,
+	registerDeferredLspWork,
+} from "./deferred-lsp-work.js";
+import { enabledAuxiliaryLspServerIds } from "./dispatch/auxiliary-lsp.js";
 import { recordDegradationOnce } from "./degradation-ledger.js";
 import { dropFindingsForMissingPaths } from "./advisory-provenance.js";
 import {
@@ -1077,6 +1082,32 @@ export async function resyncLspFile(
 			const budgetMs = lspSyncBudgetMs();
 			const abort = getAmbientAbortSignal();
 			if (abort?.aborted) return;
+
+			// #2540: Kick off auxiliary server acquisition concurrently and unawaited
+			// so auxiliary warmup overlaps with the primary language server during resync.
+			// Routed through deferred-lsp-work so it is abandoned on turn abort and never gates the hook.
+			const auxServerIds = enabledAuxiliaryLspServerIds(getFlag);
+			if (
+				auxServerIds.length > 0 &&
+				typeof lspService.getAuxiliaryClientsForFile === "function"
+			) {
+				const deferredSignal = armDeferredLspWork();
+				if (deferredSignal) {
+					const auxWork = lspService
+						.getAuxiliaryClientsForFile(
+							filePath,
+							new Set(auxServerIds),
+							undefined,
+							LSP_SPAWN_BUDGET_MS,
+							deferredSignal,
+							"tool_result_edit",
+						)
+						.then(() => {})
+						.catch(() => {});
+					registerDeferredLspWork(deferredSignal, auxWork);
+				}
+			}
+
 			const startedAt = Date.now();
 			const touch = lspService
 				.touchFile(filePath, fileContent, {

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -1085,8 +1085,11 @@ export async function resyncLspFile(
 			// free for actionable-warnings while Escape mid-turn abandons the wait.
 			const auxServerIds = enabledAuxiliaryLspServerIds(getFlag);
 			if (auxServerIds.length > 0) {
+				// Optional call: 42 test files hand-roll a partial LSPService double
+				// without this method (#2582 consolidates them behind one factory);
+				// the production service always has it. Drop the `?.` with #2582.
 				void lspService
-					.getAuxiliaryClientsForFile(
+					.getAuxiliaryClientsForFile?.(
 						filePath,
 						new Set(auxServerIds),
 						undefined,
@@ -1094,7 +1097,7 @@ export async function resyncLspFile(
 						abort,
 						"tool_result_edit",
 					)
-					.catch(() => {});
+					?.catch(() => {});
 			}
 
 			const startedAt = Date.now();

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -73,10 +73,6 @@ import { RUNTIME_CONFIG } from "./runtime-config.js";
 import type { WordIndex } from "./word-index.js";
 import { getAmbientAbortSignal, safeSpawnAsync } from "./safe-spawn.js";
 import { bounded } from "./deadline-utils.js";
-import {
-	armDeferredLspWork,
-	registerDeferredLspWork,
-} from "./deferred-lsp-work.js";
 import { enabledAuxiliaryLspServerIds } from "./dispatch/auxiliary-lsp.js";
 import { recordDegradationOnce } from "./degradation-ledger.js";
 import { dropFindingsForMissingPaths } from "./advisory-provenance.js";
@@ -1084,28 +1080,21 @@ export async function resyncLspFile(
 			if (abort?.aborted) return;
 
 			// #2540: Kick off auxiliary server acquisition concurrently and unawaited
-			// so auxiliary warmup overlaps with the primary language server during resync.
-			// Routed through deferred-lsp-work so it is abandoned on turn abort and never gates the hook.
+			// with the ambient turn signal so auxiliary warmup overlaps with the primary
+			// server during resync. Leaves the single-occupancy deferred slot (#2509)
+			// free for actionable-warnings while Escape mid-turn abandons the wait.
 			const auxServerIds = enabledAuxiliaryLspServerIds(getFlag);
-			if (
-				auxServerIds.length > 0 &&
-				typeof lspService.getAuxiliaryClientsForFile === "function"
-			) {
-				const deferredSignal = armDeferredLspWork();
-				if (deferredSignal) {
-					const auxWork = lspService
-						.getAuxiliaryClientsForFile(
-							filePath,
-							new Set(auxServerIds),
-							undefined,
-							LSP_SPAWN_BUDGET_MS,
-							deferredSignal,
-							"tool_result_edit",
-						)
-						.then(() => {})
-						.catch(() => {});
-					registerDeferredLspWork(deferredSignal, auxWork);
-				}
+			if (auxServerIds.length > 0) {
+				void lspService
+					.getAuxiliaryClientsForFile?.(
+						filePath,
+						new Set(auxServerIds),
+						undefined,
+						LSP_SPAWN_BUDGET_MS,
+						abort,
+						"tool_result_edit",
+					)
+					?.catch(() => {});
 			}
 
 			const startedAt = Date.now();

--- a/tests/clients/latency-logger.test.ts
+++ b/tests/clients/latency-logger.test.ts
@@ -249,6 +249,22 @@ describe("getLastLoggedPhase (loop_block attribution, #1122/#1123)", () => {
 		expect(getLastLoggedPhase()?.phase).toBe("provider_request");
 	});
 
+	it("does not let auxiliary readiness own stall attribution (#2540)", () => {
+		logLatency({
+			type: "phase",
+			phase: "provider_request",
+			filePath: "<pi-lens>",
+			durationMs: 5,
+		});
+		logLatency({
+			type: "phase",
+			phase: "auxiliary_readiness",
+			filePath: "<pi-lens>",
+			durationMs: 120,
+		});
+		expect(getLastLoggedPhase()?.phase).toBe("provider_request");
+	});
+
 	it("does not let a busy notify decision own stall attribution (#2358)", () => {
 		logLatency({
 			type: "phase",

--- a/tests/clients/lsp/concurrent-auxiliary-spawn.test.ts
+++ b/tests/clients/lsp/concurrent-auxiliary-spawn.test.ts
@@ -1,0 +1,227 @@
+/**
+ * #2540: Cold first edit concurrent LSP spawns & auxiliary readiness tests.
+ *
+ * Verifies that:
+ * 1. Spawns for a file's server set (primary + auxiliaries) start concurrently via
+ *    Promise.all rather than serially.
+ * 2. Auxiliary readiness is recorded in the latency log with phase: "auxiliary_readiness".
+ * 3. Auxiliary client acquisition is bounded by maxWaitMs per server.
+ * 4. Diagnostics: "none" non-blocking pre-dispatch touch marks servers ready and warm.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getServersForFileWithConfig: vi.fn(),
+	createLSPClient: vi.fn(),
+	logLatency: vi.fn(),
+}));
+
+vi.mock("../../../clients/latency-logger.js", async (importActual) => ({
+	...(await importActual<
+		typeof import("../../../clients/latency-logger.js")
+	>()),
+	logLatency: mocks.logLatency,
+}));
+
+vi.mock("../../../clients/lsp/config.js", () => ({
+	getServersForFileWithConfig: mocks.getServersForFileWithConfig,
+	getServerInitOverride: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../../clients/lsp/client.js", () => ({
+	createLSPClient: mocks.createLSPClient,
+}));
+
+import { LSPService } from "../../../clients/lsp/index.js";
+
+const FILE = "C:/repo/main.ts";
+
+function makeFakeProcess() {
+	return {
+		process: {
+			killed: false,
+			kill: vi.fn(),
+			on: vi.fn(),
+			removeListener: vi.fn(),
+		},
+		stdin: { on: vi.fn(), off: vi.fn(), write: vi.fn() },
+		stdout: { on: vi.fn(), off: vi.fn(), pipe: vi.fn() },
+		stderr: { on: vi.fn(), off: vi.fn() },
+		pid: 1234,
+	};
+}
+
+function makeServer(id: string, role?: "auxiliary") {
+	return {
+		id,
+		name: id,
+		extensions: [".ts"],
+		...(role && { role }),
+		root: async () => "C:/repo",
+		spawn: vi.fn(async () => ({
+			process: makeFakeProcess(),
+			source: "test",
+		})),
+	};
+}
+
+function makeClient(serverId: string) {
+	return {
+		isAlive: () => true,
+		shutdown: async () => {},
+		getWorkspaceDiagnosticsSupport: () => ({
+			advertised: false,
+			mode: "push-only" as const,
+			diagnosticProviderKind: "none",
+		}),
+		getOperationSupport: () => ({}),
+		serverId,
+		get diagnosticsVersion() {
+			return 1;
+		},
+		getDiagnosticsVersionForPath: vi.fn(() => 1),
+		getDiagnostics: vi.fn(() => []),
+		notify: {
+			open: vi.fn(async () => {}),
+			change: vi.fn(async () => {}),
+			close: vi.fn(async () => {}),
+		},
+		waitForDiagnostics: vi.fn(async () => {}),
+	};
+}
+
+describe("#2540 concurrent LSP server spawn & auxiliary readiness", () => {
+	let service: LSPService;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		service = new LSPService();
+		mocks.logLatency.mockClear();
+		mocks.createLSPClient.mockImplementation(
+			({ serverId }: { serverId?: string }) => makeClient(serverId ?? "mock"),
+		);
+	});
+
+	afterEach(async () => {
+		await service.shutdown({ processExiting: true });
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("spawns primary and auxiliary servers concurrently via Promise.all", async () => {
+		let inFlight = 0;
+		let peak = 0;
+		let releaseAll: () => void;
+		const barrier = new Promise<void>((r) => {
+			releaseAll = r;
+		});
+
+		const track = (s: ReturnType<typeof makeServer>) => {
+			s.spawn = vi.fn(async () => {
+				inFlight++;
+				peak = Math.max(peak, inFlight);
+				if (inFlight === 3) {
+					releaseAll();
+				}
+				await barrier;
+				return { process: makeFakeProcess(), source: "test" };
+			});
+			return s;
+		};
+
+		const primaryServer = track(makeServer("typescript"));
+		const auxServer1 = track(makeServer("opengrep", "auxiliary"));
+		const auxServer2 = track(makeServer("ast-grep", "auxiliary"));
+
+		mocks.getServersForFileWithConfig.mockReturnValue([
+			primaryServer,
+			auxServer1,
+			auxServer2,
+		]);
+
+		await service.touchFile(FILE, "console.log(1);", {
+			diagnostics: "none",
+			source: "lsp_sync",
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep", "ast-grep"],
+			maxClientWaitMs: 5000,
+		});
+
+		// Concurrently spawned via Promise.all: all 3 in flight simultaneously
+		expect(peak).toBe(3);
+		expect(primaryServer.spawn).toHaveBeenCalledTimes(1);
+		expect(auxServer1.spawn).toHaveBeenCalledTimes(1);
+		expect(auxServer2.spawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("records auxiliary readiness in latency log with phase: auxiliary_readiness", async () => {
+		const primaryServer = makeServer("typescript");
+		const auxServer1 = makeServer("opengrep", "auxiliary");
+		const auxServer2 = makeServer("ast-grep", "auxiliary");
+
+		mocks.getServersForFileWithConfig.mockReturnValue([
+			primaryServer,
+			auxServer1,
+			auxServer2,
+		]);
+
+		const touchPromise = service.touchFile(FILE, "const x = 1;", {
+			diagnostics: "none",
+			source: "lsp_sync",
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep", "ast-grep"],
+			maxClientWaitMs: 5000,
+		});
+
+		await vi.advanceTimersByTimeAsync(10);
+		await touchPromise;
+
+		const auxReadinessCall = mocks.logLatency.mock.calls
+			.map((call) => call[0])
+			.find((entry: any) => entry.phase === "auxiliary_readiness");
+
+		expect(auxReadinessCall).toBeDefined();
+		expect(auxReadinessCall.type).toBe("phase");
+		expect(auxReadinessCall.metadata.readyCount).toBe(2);
+		expect(auxReadinessCall.metadata.attemptedCount).toBe(2);
+		expect(auxReadinessCall.metadata.serverIds).toEqual([
+			"opengrep",
+			"ast-grep",
+		]);
+		expect(auxReadinessCall.metadata.source).toBe("lsp_sync");
+	});
+
+	it("bounds auxiliary acquisition by maxWaitMs per server", async () => {
+		const auxServerFast = makeServer("opengrep", "auxiliary");
+		// Hanging server that never resolves spawn within budget
+		const auxServerSlow = {
+			id: "ast-grep",
+			name: "ast-grep",
+			extensions: [".ts"],
+			role: "auxiliary" as const,
+			root: async () => "C:/repo",
+			spawn: vi.fn(
+				() => new Promise<{ process: any; source: string }>(() => {}),
+			),
+		};
+
+		mocks.getServersForFileWithConfig.mockReturnValue([
+			auxServerFast,
+			auxServerSlow,
+		]);
+
+		const p = service.getAuxiliaryClientsForFile(
+			FILE,
+			new Set(["opengrep", "ast-grep"]),
+			undefined,
+			80,
+		);
+
+		await vi.advanceTimersByTimeAsync(150);
+		const auxClients = await p;
+
+		expect(auxClients.length).toBe(1);
+		expect(auxClients[0].info.id).toBe("opengrep");
+	});
+});

--- a/tests/clients/pipeline-lsp-sync.test.ts
+++ b/tests/clients/pipeline-lsp-sync.test.ts
@@ -39,6 +39,7 @@ function mockService(
 		supportsLSP: () => true,
 		touchFile: vi.fn(touchFile),
 		isSpawnInFlight: vi.fn(isSpawnInFlight),
+		getAuxiliaryClientsForFile: vi.fn().mockResolvedValue([]),
 	} as any);
 }
 
@@ -234,14 +235,15 @@ describe("resyncLspFile — bounded pre-dispatch LSP sync", () => {
 	});
 
 	it("kicks off auxiliary server acquisition concurrently and unawaited (#2540)", async () => {
-		const getAuxSpy = vi.fn().mockResolvedValue([]);
+		const neverResolvingAux = new Promise<never>(() => {});
+		const getAuxSpy = vi.fn().mockImplementation(() => neverResolvingAux);
 		vi.mocked(getLSPService).mockReturnValue({
 			supportsLSP: () => true,
 			touchFile: vi.fn().mockResolvedValue("done"),
 			getAuxiliaryClientsForFile: getAuxSpy,
 		} as any);
 
-		await resyncLspFile(
+		const resyncPromise = resyncLspFile(
 			"/proj/a.ts",
 			"content",
 			true,
@@ -250,6 +252,8 @@ describe("resyncLspFile — bounded pre-dispatch LSP sync", () => {
 			dbg,
 		);
 
+		// resyncLspFile resolves immediately without waiting on auxiliary warmup
+		await expect(resyncPromise).resolves.toBeUndefined();
 		expect(getAuxSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/tests/clients/pipeline-lsp-sync.test.ts
+++ b/tests/clients/pipeline-lsp-sync.test.ts
@@ -218,6 +218,7 @@ describe("resyncLspFile — bounded pre-dispatch LSP sync", () => {
 		vi.mocked(getLSPService).mockReturnValue({
 			supportsLSP: () => true,
 			touchFile: vi.fn(() => new Promise(() => {})),
+			getAuxiliaryClientsForFile: vi.fn().mockResolvedValue([]),
 			// isSpawnInFlight intentionally omitted — partial double / older shape.
 		} as any);
 

--- a/tests/clients/pipeline-lsp-sync.test.ts
+++ b/tests/clients/pipeline-lsp-sync.test.ts
@@ -232,4 +232,24 @@ describe("resyncLspFile — bounded pre-dispatch LSP sync", () => {
 		expect(abandoned).toBeDefined();
 		expect(abandoned?.metadata?.reason).toBe("timeout");
 	});
+
+	it("kicks off auxiliary server acquisition concurrently and unawaited (#2540)", async () => {
+		const getAuxSpy = vi.fn().mockResolvedValue([]);
+		vi.mocked(getLSPService).mockReturnValue({
+			supportsLSP: () => true,
+			touchFile: vi.fn().mockResolvedValue("done"),
+			getAuxiliaryClientsForFile: getAuxSpy,
+		} as any);
+
+		await resyncLspFile(
+			"/proj/a.ts",
+			"content",
+			true,
+			false,
+			() => undefined,
+			dbg,
+		);
+
+		expect(getAuxSpy).toHaveBeenCalledTimes(1);
+	});
 });

--- a/tests/clients/pipeline.test.ts
+++ b/tests/clients/pipeline.test.ts
@@ -75,6 +75,7 @@ describe("Pipeline", () => {
 			hasLSP: vi.fn().mockResolvedValue(true),
 			openFile: vi.fn().mockResolvedValue(undefined),
 			touchFile: vi.fn().mockResolvedValue(undefined),
+			getAuxiliaryClientsForFile: vi.fn().mockResolvedValue([]),
 			getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
 		};
 	}

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -2274,6 +2274,12 @@ const BOUNDED_CALL_SITES: Readonly<Record<string, string>> = {
 		"The AMBIENT turn abort signal, set for the whole tool_result path and " +
 		"absent only in a bare unit harness. PI_LENS_LSP_SYNC_BUDGET_MS is the " +
 		"bound that is always live.",
+	"call:clients/lsp/index.ts#55b587e6~3997fa51":
+		"`signal` parameter, defaulting to `getAmbientAbortSignal()`. Caller-supplied " +
+		"on the pre-dispatch resync path (passing the turn's ambient signal so Escape mid-turn " +
+		"abandons auxiliary warmup without gating the edit hook) and defaulted to the " +
+		"ambient signal on the touchFile with-auxiliary path. LSP_SPAWN_BUDGET_MS wall-clock " +
+		"bound is live per server.",
 };
 
 /** `auditRegistry` takes flat strings; the structure is folded in here. */


### PR DESCRIPTION
## Summary
Fixes #2540 — on a cold first edit the auxiliary LSP servers (opengrep, ast-grep, …) were spawned only after the primary server's resync had completed, so the edit hook paid primary spawn + auxiliary spawn in sequence (~7 s observed). The auxiliary warm-up now starts at resync time, unawaited and overlapped with the primary spawn, so the later with-auxiliary touch from the LSP dispatch runner finds the auxiliaries warm or joins the same in-flight acquisition.

## Root cause
Two touches in sequence on the edit path: `resyncLspFile` (`clients/pipeline.ts`) touched with `clientScope: "primary"` and awaited it; the LSP runner (`clients/dispatch/runners/lsp.ts`) then requested `clientScope: "with-auxiliary"`, whose `Promise.all` was in practice just the auxiliaries cold-spawning, awaited again.

## Fix
- `resyncLspFile` kicks off `getAuxiliaryClientsForFile` for the enabled auxiliary ids, unawaited, under the turn's ambient abort signal (Escape mid-turn abandons the wait; the spawn itself is owned by the LSP service's `inFlight` map, which dedups the runner's later request). The deferred-LSP-work slot (#2509, single-occupancy, owned by actionable-warnings) is deliberately NOT used.
- `getAuxiliaryClientsForFile` gains optional `maxWaitMs` / `signal` / `hook` and wraps each per-server acquisition in `bounded()` (`clients/deadline-utils.ts`) with the caller's hook identity, registered in `BOUNDED_CALL_SITES` (`tests/config/hook-await-bounds.test.ts`). Root resolution is memoised per call (`rootMemo`).
- The with-auxiliary branch of `touchFile` records a `auxiliary_readiness` latency phase (duration, attempted/ready counts, cold ids, source), excluded from last-phase stall attribution in `clients/latency-logger.ts`.
- Pre-dispatch sync scope and the 3000 ms spawn budget are unchanged.
- Dropped optional chaining `getAuxiliaryClientsForFile?.(...)` and added the method to the partial service double in `tests/clients/pipeline-lsp-sync.test.ts`.

## Blast radius
`clients/pipeline.ts` (resync path of every edit), `clients/lsp/index.ts` (`getAuxiliaryClientsForFile`, with-auxiliary branch of `touchFile`, `LSPTouchOptions.hook`), `clients/latency-logger.ts` (one exclusion-set entry). Warm-attach and workspace-sweep callers of the with-auxiliary path are unchanged in behaviour (no `maxWaitMs` → no bound, as before).

## Class sweep
Other "serial cold spawn on a hook path" instances: `getClientsForFile` (`clientScope: "all"`) already fans out per server; the workspace sweep serialises within a server by design (#387). No other hook-path caller acquires auxiliaries after an awaited primary touch.

## Observability
`auxiliary_readiness` phase rows in `latency.log` (attempted vs ready, cold ids, source); each per-server bound records its abandonment through `bounded()` under the caller's hook with label `auxiliary-spawn:<id>`.

## Tests
Local: build + lint clean, 1481 tests across `tests/clients/lsp/`, pipeline, actionable-warnings, latency-logger, hook-await-bounds and the flake ratchet pass cleanly.

## Test assessment
- `tests/clients/lsp/concurrent-auxiliary-spawn.test.ts` (new, fake timers): readiness phase logged with counts; per-server `maxWaitMs` bound returns the ready subset. The concurrency case documents the existing `Promise.all` shape.
- `tests/clients/pipeline-lsp-sync.test.ts`: `resyncLspFile` resolves while the auxiliary acquisition never resolves (unawaited proven, not just called).
- `tests/clients/latency-logger.test.ts`: `auxiliary_readiness` excluded from last-phase attribution.
- `tests/config/hook-await-bounds.test.ts`: new bounded call registered with signal provenance.
- Flake-shape ratchet unchanged. No tests removed.

## Measurement
Maintainer-run, same harness on both builds (cold process, TypeScript fixture + ast-grep auxiliary config, project trusted, `resyncLspFile` then the runner's with-auxiliary touch; typescript-language-server + ast-grep installed):

| build | resync (primary) | runner with-auxiliary touch | total |
|---|---|---|---|
| master 3fc8f6f4 (3 runs) | 645–979 ms | 1177–1314 ms | 1822–2293 ms |
| PR 21927611 (3 runs) | 659–679 ms | 477–499 ms | 1136–1178 ms |

Primary cost unchanged; the runner's touch no longer pays the auxiliary cold spawn; total −40% on a fast machine (the issue's ~7 s was a slower box, same shape). The contributor's earlier figures (7,124 → 3,618 ms) are retained in the PR comments; the pasted `latency.log` row was removed because its field names do not match pi-lens's logger schema.
