### PR TITLE
test: admit runtime-turn-test-runner-bounds to the flake-shape ratchet after #2528 (refs #2547)

### DIFF
--- a/.changelog/fix-master-red-flake-ratchet-2528.md
+++ b/.changelog/fix-master-red-flake-ratchet-2528.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Tests**: admit `runtime-turn-test-runner-bounds.test.ts` to the flake-shape ratchet after #2528 raised its raw-timer-wait count (the waits are the wall-clock bound under test); master was red on the ratchet since #2528 landed after #2559's baseline.

--- a/tests/clients/runtime-turn-test-runner-bounds.test.ts
+++ b/tests/clients/runtime-turn-test-runner-bounds.test.ts
@@ -1,3 +1,4 @@
+// flake-shape: raw-timer-wait — the subject IS the wall-clock batch bound (budgetMs) racing real settle latency; the 25 ms post-abort resolves model safeSpawnAsync settling on the child's exit event after the kill, and delay(400)/delay(250) prove a run can outlive the batch close — fake timers would collapse the very ordering the assertions discriminate (#2522 R3 F4, #2528 R4 P3c).
 /**
  * #2504 AC2 — the turn-end test-runner fan-out must be bounded.
  *

--- a/tests/support/flake-shape-baseline.json
+++ b/tests/support/flake-shape-baseline.json
@@ -159,7 +159,7 @@
 		"clients/runtime-session-warmup-oneshot.test.ts": 1,
 		"clients/runtime-session-warmup-prewarm.test.ts": 1,
 		"clients/runtime-tool-result-debounce.test.ts": 1,
-		"clients/runtime-turn-test-runner-bounds.test.ts": 1,
+		"clients/runtime-turn-test-runner-bounds.test.ts": 4,
 		"clients/safe-spawn-close-before-error-race.test.ts": 1,
 		"clients/safe-spawn-sync-throw.test.ts": 1,
 		"clients/single-flight.test.ts": 1,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -308,6 +308,8 @@ const lspSpawnHeavyInclude = [
 // host. Sweep coverage for other members lives in this list; new entries must
 // carry a wall-clock budget assertion, not just slowness.
 const wallClockBudgetInclude = [
+	// #2528: the bounded batch helper tests race a real wall-clock budget against settle latency (flake-shape admission).
+	"tests/clients/runtime-turn-test-runner-bounds.test.ts",
 	"tests/clients/startup-overhead.test.ts",
 	"tests/clients/runtime-session-scan-cache.test.ts",
 	"tests/clients/cascade-turn-merge.test.ts",


### PR DESCRIPTION
## Summary
Master is red on `flake-shape-ratchet.test.ts` (run 33751958533): #2528 landed after #2559 minted the baseline and raised `tests/clients/runtime-turn-test-runner-bounds.test.ts` from 1 to 4 `raw-timer-wait` hits. The waits ARE the subject under test — a wall-clock batch bound (`budgetMs`) racing real settle latency (25 ms post-abort resolves model `safeSpawnAsync` settling on the child's exit; `delay(400)`/`delay(250)` prove a run can outlive the batch close). Fake timers would collapse the very ordering the assertions discriminate (#2522 R3 F4, #2528 R4 P3c).

Admission per the ratchet's own instruction: `// flake-shape: raw-timer-wait — …` header on the file, membership in `vitest.config.ts`'s `wallClockBudgetInclude` (serialized lane), baseline count 1 → 4.

## Tests
`npx vitest run tests/clients/flake-shape-ratchet.test.ts tests/clients/runtime-turn-test-runner-bounds.test.ts` → `Test Files 2 passed (2) / Tests 68 passed (68)`. Pre-change the ratchet reds with `raw-timer-wait: clients/runtime-turn-test-runner-bounds.test.ts rose from 1 to 4 hit(s)` (the master failure, reproduced locally).

## Test assessment
- `tests/clients/runtime-turn-test-runner-bounds.test.ts`: header comment only; no assertion changed.
- `tests/support/flake-shape-baseline.json`: one count 1 → 4.
- `vitest.config.ts`: one include entry (moves the file to the serialized wall-clock lane).

## Blast radius
Governance table + test lane assignment only; no runtime code.

## Observability
Not applicable (tests/ only).

## Class sweep
Same shape as #2559 round 2's admissions (#2541's wait-record test, #2550's ci-verdict tests): PRs that land after the baseline mint. The ratchet's job; nothing else to fold.

Maintainer-authored during the subagent freeze (2026-09-03); governance-table catch-up, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ4a3oS1UDFxs74fLm8U21
