### PR TITLE
fix(install): strip devDependencies from the published manifest at pack time (closes #2573)

### DIFF
--- a/.changelog/fix-strip-devdeps-on-pack.md
+++ b/.changelog/fix-strip-devdeps-on-pack.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Install**: the published `package.json` no longer carries `devDependencies` (stripped by `prepack`, restored by `postpack`). npm's resolver walked the dev peer graph when pi supplies host-provided packages into the installed extension, and `@vitejs/devtools@0.7.1` / `vitest@5.0.0` (published 2026-09-03) crash npm 10.9.8 there (`Cannot read properties of null (reading 'edgesOut')`); every install-test lane went red and npm-10 users would hit it at install. The published package never needed them.

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ tests/fixtures/**/bin/
 
 # Live native-TS7 integration temp projects (removed in afterAll; survive hard aborts)
 tests/native-ts7-live-*/
+
+# prepack backup of package.json (scripts/strip-dev-deps-for-pack.mjs)
+.pack-backup/

--- a/package.json
+++ b/package.json
@@ -1,171 +1,171 @@
 {
-  "name": "pi-lens",
-  "version": "4.1.3",
-  "type": "module",
-  "description": "Real-time code feedback for pi — LSP, linters, formatters, type-checking, structural analysis & booboo",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/apmantza/pi-lens.git"
-  },
-  "main": "./dist/index.js",
-  "bin": {
-    "pi-lens": "dist/mcp/cli.js",
-    "pi-lens-mcp": "dist/mcp/server.js",
-    "pi-lens-analyze": "dist/mcp/analyze-cli.js"
-  },
-  "scripts": {
-    "build": "tsc --project tsconfig.build.json",
-    "build:dist": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && npx --yes -p typescript@7.0.2 tsc --project tsconfig.dist.json --noCheck && npm run bundle:dist",
-    "bundle:dist": "node scripts/bundle-dist.mjs",
-    "prepare": "npm run build:dist && node scripts/download-grammars.js --core --dest grammars && node scripts/setup-git-hooks.mjs && node scripts/warm-loader-cache.mjs",
-    "prepack": "node scripts/strip-dev-deps-for-pack.mjs --strip",
-    "postpack": "node scripts/strip-dev-deps-for-pack.mjs --restore",
-    "lint": "tsc --project tsconfig.json && npm run lint:js",
-    "lint:js": "oxlint --deny-warnings --ignore-pattern \"tests/**/*.ts\" --ignore-pattern \"tests/**/*.tsx\" --ignore-pattern \"**/*.d.mts\" --ignore-pattern \"tests/fixtures/autofix-smoke/**\" --ignore-pattern \"tests/fixtures/format-smoke/**\" --ignore-pattern \"tests/fixtures/tool-smoke/**\" --ignore-pattern \"tests/fixtures/call-graph/javascript/**\" --ignore-pattern \"tests/fixtures/function-facts/javascript-parameter.js\" .",
-    "depcruise:check": "depcruise --validate --config .dependency-cruiser.cjs --ignore-known .dependency-cruiser-known-violations.json --output-type err index.ts \"clients/**/*.ts\"",
-    "fmt": "oxfmt",
-    "fmt:check": "oxfmt --check",
-    "watch": "tsc --watch",
-    "test": "node scripts/with-test-lock.mjs -- vitest run",
-    "test:unit": "node scripts/with-test-lock.mjs -- vitest run",
-    "test:integration": "node scripts/with-test-lock.mjs -- vitest run tests/index-integration.test.ts tests/clients/lsp/integration.test.ts",
-    "test:targeted": "node scripts/with-test-lock.mjs --shared -- vitest run",
-    "test:watch": "vitest",
-    "hygiene": "node scripts/prune-agent-worktrees.mjs",
-    "check": "node scripts/check-extensions.mjs",
-    "selftest:install": "node scripts/install-selftest.mjs",
-    "check:lockfile": "node scripts/check-lockfile-sync.mjs",
-    "check:grammars": "node scripts/check-grammar-provenance.mjs",
-    "check:grammar-load": "node scripts/check-grammar-load.mjs",
-    "audit:tree-sitter": "node scripts/audit-tree-sitter-rules.mjs",
-    "audit:rule-catalog": "node scripts/validate-rule-catalog.mjs",
-    "audit:astgrep-rule-pairs": "node scripts/audit-astgrep-rule-pairs.mjs",
-    "astgrep:self-scan": "node scripts/run-astgrep-pi-lens.mjs",
-    "astgrep:self-scan:update-baseline": "node scripts/run-astgrep-pi-lens.mjs --update-baseline",
-    "audit:playground": "node scripts/playground-verify-rule.mjs",
-    "bench:cascade-budget": "node scripts/bench-cascade-budget.mjs",
-    "bench:word-index-replacement": "node scripts/bench-word-index-replacement.mjs",
-    "logs:smells": "node scripts/analyze-pi-lens-logs.mjs",
-    "changelog:check": "node scripts/rollup-changelog.mjs --check",
-    "changelog:release": "node scripts/changelog-release.mjs",
-    "changelog:extract": "node scripts/changelog-extract.mjs",
-    "release:backfill-notes": "node scripts/backfill-github-releases.mjs",
-    "release:backfill-thanks": "node scripts/backfill-release-thanks.mjs",
-    "docs:rule-catalogs": "node scripts/gen-rule-catalogs.mjs",
-    "banner": "npx -y sharp-cli --input banner.svg --output banner.png resize 2200 620",
-    "download-grammars": "node scripts/download-grammars.js",
-    "harness:poc": "node scripts/run-harness.mjs cases/ts/pipeline-dispatch-poc",
-    "harness:python-poc": "node scripts/run-harness.mjs cases/python/pipeline-dispatch-poc",
-    "harness:ts-format-poc": "node scripts/run-harness.mjs cases/ts/format-default-poc",
-    "harness:python-autofix-poc": "node scripts/run-harness.mjs cases/python/autofix-default-poc",
-    "harness:go-poc": "node scripts/run-harness.mjs cases/go/pipeline-dispatch-poc"
-  },
-  "keywords": [
-    "pi",
-    "pi-extension",
-    "pi-package",
-    "linter",
-    "biome",
-    "ast-grep",
-    "ruff",
-    "typescript",
-    "code-quality",
-    "feedback",
-    "type-coverage",
-    "jscpd",
-    "knip"
-  ],
-  "author": "Apostolos Mantzaris",
-  "license": "MIT",
-  "files": [
-    "dist/",
-    "docs/",
-    "grammars/",
-    "vendor/grammars/",
-    "config/",
-    "rules/",
-    "skills/",
-    "scripts/download-grammars.js",
-    "scripts/grammars.lock.json",
-    "scripts/analyze-pi-lens-logs.mjs",
-    "scripts/install-selftest.mjs",
-    "scripts/lib/host-provided-deps.mjs",
-    "scripts/lib/warm-loader-cache.mjs",
-    "scripts/warm-loader-cache.mjs",
-    "scripts/rpc-load-check.mjs",
-    "README.md",
-    "CHANGELOG.md",
-    "banner.svg",
-    "banner.png"
-  ],
-  "dependencies": {
-    "@ast-grep/cli": "^0.45.0",
-    "@ast-grep/napi": "^0.45.0",
-    "js-yaml": "^5.2.2",
-    "minimatch": "^10.2.6",
-    "pidusage": "^4.0.1",
-    "vscode-jsonrpc": "^9.0.0"
-  },
-  "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "^0.84.1",
-    "typebox": "^1.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@earendil-works/pi-coding-agent": {
-      "optional": true
-    },
-    "@earendil-works/pi-tui": {
-      "optional": true
-    },
-    "typebox": {
-      "optional": true
-    }
-  },
-  "optionalDependencies": {
-    "jiti": "^2.7.0",
-    "web-tree-sitter": "0.25.10"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.4.10",
-    "@earendil-works/pi-coding-agent": "^0.84.1",
-    "@earendil-works/pi-tui": "^0.84.1",
-    "@types/node": "^26.0.0",
-    "@types/pidusage": "^2.0.5",
-    "@vitest/coverage-v8": "^4.1.5",
-    "dependency-cruiser": "^18.2.0",
-    "husky": "^9.1.7",
-    "json5": "^2.2.3",
-    "oxfmt": "0.65.0",
-    "oxlint": "1.80.0",
-    "typebox": "^1.0.0",
-    "typescript": "^7.0.2",
-    "typescript-language-server": "^6.0.0",
-    "vitest": "^4.1.1"
-  },
-  "pi": {
-    "extensions": [
-      "./dist/index.js"
-    ],
-    "skills": [
-      "../../skills"
-    ]
-  },
-  "knip": {
-    "entry": [
-      "index.ts"
-    ],
-    "project": [
-      "**/*.ts",
-      "!**/*.test.ts"
-    ],
-    "ignore": [
-      "**/*.test.ts"
-    ]
-  },
-  "allowScripts": {
-    "@ast-grep/cli@0.45.2": true,
-    "@google/genai@1.52.0": true,
-    "protobufjs@7.6.5": true
-  }
+	"name": "pi-lens",
+	"version": "4.1.3",
+	"type": "module",
+	"description": "Real-time code feedback for pi — LSP, linters, formatters, type-checking, structural analysis & booboo",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/apmantza/pi-lens.git"
+	},
+	"main": "./dist/index.js",
+	"bin": {
+		"pi-lens": "dist/mcp/cli.js",
+		"pi-lens-mcp": "dist/mcp/server.js",
+		"pi-lens-analyze": "dist/mcp/analyze-cli.js"
+	},
+	"scripts": {
+		"build": "tsc --project tsconfig.build.json",
+		"build:dist": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && npx --yes -p typescript@7.0.2 tsc --project tsconfig.dist.json --noCheck && npm run bundle:dist",
+		"bundle:dist": "node scripts/bundle-dist.mjs",
+		"prepare": "npm run build:dist && node scripts/download-grammars.js --core --dest grammars && node scripts/setup-git-hooks.mjs && node scripts/warm-loader-cache.mjs",
+		"prepack": "node scripts/strip-dev-deps-for-pack.mjs --strip",
+		"postpack": "node scripts/strip-dev-deps-for-pack.mjs --restore",
+		"lint": "tsc --project tsconfig.json && npm run lint:js",
+		"lint:js": "oxlint --deny-warnings --ignore-pattern \"tests/**/*.ts\" --ignore-pattern \"tests/**/*.tsx\" --ignore-pattern \"**/*.d.mts\" --ignore-pattern \"tests/fixtures/autofix-smoke/**\" --ignore-pattern \"tests/fixtures/format-smoke/**\" --ignore-pattern \"tests/fixtures/tool-smoke/**\" --ignore-pattern \"tests/fixtures/call-graph/javascript/**\" --ignore-pattern \"tests/fixtures/function-facts/javascript-parameter.js\" .",
+		"depcruise:check": "depcruise --validate --config .dependency-cruiser.cjs --ignore-known .dependency-cruiser-known-violations.json --output-type err index.ts \"clients/**/*.ts\"",
+		"fmt": "oxfmt",
+		"fmt:check": "oxfmt --check",
+		"watch": "tsc --watch",
+		"test": "node scripts/with-test-lock.mjs -- vitest run",
+		"test:unit": "node scripts/with-test-lock.mjs -- vitest run",
+		"test:integration": "node scripts/with-test-lock.mjs -- vitest run tests/index-integration.test.ts tests/clients/lsp/integration.test.ts",
+		"test:targeted": "node scripts/with-test-lock.mjs --shared -- vitest run",
+		"test:watch": "vitest",
+		"hygiene": "node scripts/prune-agent-worktrees.mjs",
+		"check": "node scripts/check-extensions.mjs",
+		"selftest:install": "node scripts/install-selftest.mjs",
+		"check:lockfile": "node scripts/check-lockfile-sync.mjs",
+		"check:grammars": "node scripts/check-grammar-provenance.mjs",
+		"check:grammar-load": "node scripts/check-grammar-load.mjs",
+		"audit:tree-sitter": "node scripts/audit-tree-sitter-rules.mjs",
+		"audit:rule-catalog": "node scripts/validate-rule-catalog.mjs",
+		"audit:astgrep-rule-pairs": "node scripts/audit-astgrep-rule-pairs.mjs",
+		"astgrep:self-scan": "node scripts/run-astgrep-pi-lens.mjs",
+		"astgrep:self-scan:update-baseline": "node scripts/run-astgrep-pi-lens.mjs --update-baseline",
+		"audit:playground": "node scripts/playground-verify-rule.mjs",
+		"bench:cascade-budget": "node scripts/bench-cascade-budget.mjs",
+		"bench:word-index-replacement": "node scripts/bench-word-index-replacement.mjs",
+		"logs:smells": "node scripts/analyze-pi-lens-logs.mjs",
+		"changelog:check": "node scripts/rollup-changelog.mjs --check",
+		"changelog:release": "node scripts/changelog-release.mjs",
+		"changelog:extract": "node scripts/changelog-extract.mjs",
+		"release:backfill-notes": "node scripts/backfill-github-releases.mjs",
+		"release:backfill-thanks": "node scripts/backfill-release-thanks.mjs",
+		"docs:rule-catalogs": "node scripts/gen-rule-catalogs.mjs",
+		"banner": "npx -y sharp-cli --input banner.svg --output banner.png resize 2200 620",
+		"download-grammars": "node scripts/download-grammars.js",
+		"harness:poc": "node scripts/run-harness.mjs cases/ts/pipeline-dispatch-poc",
+		"harness:python-poc": "node scripts/run-harness.mjs cases/python/pipeline-dispatch-poc",
+		"harness:ts-format-poc": "node scripts/run-harness.mjs cases/ts/format-default-poc",
+		"harness:python-autofix-poc": "node scripts/run-harness.mjs cases/python/autofix-default-poc",
+		"harness:go-poc": "node scripts/run-harness.mjs cases/go/pipeline-dispatch-poc"
+	},
+	"keywords": [
+		"pi",
+		"pi-extension",
+		"pi-package",
+		"linter",
+		"biome",
+		"ast-grep",
+		"ruff",
+		"typescript",
+		"code-quality",
+		"feedback",
+		"type-coverage",
+		"jscpd",
+		"knip"
+	],
+	"author": "Apostolos Mantzaris",
+	"license": "MIT",
+	"files": [
+		"dist/",
+		"docs/",
+		"grammars/",
+		"vendor/grammars/",
+		"config/",
+		"rules/",
+		"skills/",
+		"scripts/download-grammars.js",
+		"scripts/grammars.lock.json",
+		"scripts/analyze-pi-lens-logs.mjs",
+		"scripts/install-selftest.mjs",
+		"scripts/lib/host-provided-deps.mjs",
+		"scripts/lib/warm-loader-cache.mjs",
+		"scripts/warm-loader-cache.mjs",
+		"scripts/rpc-load-check.mjs",
+		"README.md",
+		"CHANGELOG.md",
+		"banner.svg",
+		"banner.png"
+	],
+	"dependencies": {
+		"@ast-grep/cli": "^0.45.0",
+		"@ast-grep/napi": "^0.45.0",
+		"js-yaml": "^5.2.2",
+		"minimatch": "^10.2.6",
+		"pidusage": "^4.0.1",
+		"vscode-jsonrpc": "^9.0.0"
+	},
+	"peerDependencies": {
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "^0.84.1",
+		"typebox": "^1.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@earendil-works/pi-coding-agent": {
+			"optional": true
+		},
+		"@earendil-works/pi-tui": {
+			"optional": true
+		},
+		"typebox": {
+			"optional": true
+		}
+	},
+	"optionalDependencies": {
+		"jiti": "^2.7.0",
+		"web-tree-sitter": "0.25.10"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.10",
+		"@earendil-works/pi-coding-agent": "^0.84.1",
+		"@earendil-works/pi-tui": "^0.84.1",
+		"@types/node": "^26.0.0",
+		"@types/pidusage": "^2.0.5",
+		"@vitest/coverage-v8": "^4.1.5",
+		"dependency-cruiser": "^18.2.0",
+		"husky": "^9.1.7",
+		"json5": "^2.2.3",
+		"oxfmt": "0.65.0",
+		"oxlint": "1.80.0",
+		"typebox": "^1.0.0",
+		"typescript": "^7.0.2",
+		"typescript-language-server": "^6.0.0",
+		"vitest": "^4.1.1"
+	},
+	"pi": {
+		"extensions": [
+			"./dist/index.js"
+		],
+		"skills": [
+			"../../skills"
+		]
+	},
+	"knip": {
+		"entry": [
+			"index.ts"
+		],
+		"project": [
+			"**/*.ts",
+			"!**/*.test.ts"
+		],
+		"ignore": [
+			"**/*.test.ts"
+		]
+	},
+	"allowScripts": {
+		"@ast-grep/cli@0.45.2": true,
+		"@google/genai@1.52.0": true,
+		"protobufjs@7.6.5": true
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,169 +1,171 @@
 {
-	"name": "pi-lens",
-	"version": "4.1.3",
-	"type": "module",
-	"description": "Real-time code feedback for pi — LSP, linters, formatters, type-checking, structural analysis & booboo",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/apmantza/pi-lens.git"
-	},
-	"main": "./dist/index.js",
-	"bin": {
-		"pi-lens": "dist/mcp/cli.js",
-		"pi-lens-mcp": "dist/mcp/server.js",
-		"pi-lens-analyze": "dist/mcp/analyze-cli.js"
-	},
-	"scripts": {
-		"build": "tsc --project tsconfig.build.json",
-		"build:dist": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && npx --yes -p typescript@7.0.2 tsc --project tsconfig.dist.json --noCheck && npm run bundle:dist",
-		"bundle:dist": "node scripts/bundle-dist.mjs",
-		"prepare": "npm run build:dist && node scripts/download-grammars.js --core --dest grammars && node scripts/setup-git-hooks.mjs && node scripts/warm-loader-cache.mjs",
-		"lint": "tsc --project tsconfig.json && npm run lint:js",
-		"lint:js": "oxlint --deny-warnings --ignore-pattern \"tests/**/*.ts\" --ignore-pattern \"tests/**/*.tsx\" --ignore-pattern \"**/*.d.mts\" --ignore-pattern \"tests/fixtures/autofix-smoke/**\" --ignore-pattern \"tests/fixtures/format-smoke/**\" --ignore-pattern \"tests/fixtures/tool-smoke/**\" --ignore-pattern \"tests/fixtures/call-graph/javascript/**\" --ignore-pattern \"tests/fixtures/function-facts/javascript-parameter.js\" .",
-		"depcruise:check": "depcruise --validate --config .dependency-cruiser.cjs --ignore-known .dependency-cruiser-known-violations.json --output-type err index.ts \"clients/**/*.ts\"",
-		"fmt": "oxfmt",
-		"fmt:check": "oxfmt --check",
-		"watch": "tsc --watch",
-		"test": "node scripts/with-test-lock.mjs -- vitest run",
-		"test:unit": "node scripts/with-test-lock.mjs -- vitest run",
-		"test:integration": "node scripts/with-test-lock.mjs -- vitest run tests/index-integration.test.ts tests/clients/lsp/integration.test.ts",
-		"test:targeted": "node scripts/with-test-lock.mjs --shared -- vitest run",
-		"test:watch": "vitest",
-		"hygiene": "node scripts/prune-agent-worktrees.mjs",
-		"check": "node scripts/check-extensions.mjs",
-		"selftest:install": "node scripts/install-selftest.mjs",
-		"check:lockfile": "node scripts/check-lockfile-sync.mjs",
-		"check:grammars": "node scripts/check-grammar-provenance.mjs",
-		"check:grammar-load": "node scripts/check-grammar-load.mjs",
-		"audit:tree-sitter": "node scripts/audit-tree-sitter-rules.mjs",
-		"audit:rule-catalog": "node scripts/validate-rule-catalog.mjs",
-		"audit:astgrep-rule-pairs": "node scripts/audit-astgrep-rule-pairs.mjs",
-		"astgrep:self-scan": "node scripts/run-astgrep-pi-lens.mjs",
-		"astgrep:self-scan:update-baseline": "node scripts/run-astgrep-pi-lens.mjs --update-baseline",
-		"audit:playground": "node scripts/playground-verify-rule.mjs",
-		"bench:cascade-budget": "node scripts/bench-cascade-budget.mjs",
-		"bench:word-index-replacement": "node scripts/bench-word-index-replacement.mjs",
-		"logs:smells": "node scripts/analyze-pi-lens-logs.mjs",
-		"changelog:check": "node scripts/rollup-changelog.mjs --check",
-		"changelog:release": "node scripts/changelog-release.mjs",
-		"changelog:extract": "node scripts/changelog-extract.mjs",
-		"release:backfill-notes": "node scripts/backfill-github-releases.mjs",
-		"release:backfill-thanks": "node scripts/backfill-release-thanks.mjs",
-		"docs:rule-catalogs": "node scripts/gen-rule-catalogs.mjs",
-		"banner": "npx -y sharp-cli --input banner.svg --output banner.png resize 2200 620",
-		"download-grammars": "node scripts/download-grammars.js",
-		"harness:poc": "node scripts/run-harness.mjs cases/ts/pipeline-dispatch-poc",
-		"harness:python-poc": "node scripts/run-harness.mjs cases/python/pipeline-dispatch-poc",
-		"harness:ts-format-poc": "node scripts/run-harness.mjs cases/ts/format-default-poc",
-		"harness:python-autofix-poc": "node scripts/run-harness.mjs cases/python/autofix-default-poc",
-		"harness:go-poc": "node scripts/run-harness.mjs cases/go/pipeline-dispatch-poc"
-	},
-	"keywords": [
-		"pi",
-		"pi-extension",
-		"pi-package",
-		"linter",
-		"biome",
-		"ast-grep",
-		"ruff",
-		"typescript",
-		"code-quality",
-		"feedback",
-		"type-coverage",
-		"jscpd",
-		"knip"
-	],
-	"author": "Apostolos Mantzaris",
-	"license": "MIT",
-	"files": [
-		"dist/",
-		"docs/",
-		"grammars/",
-		"vendor/grammars/",
-		"config/",
-		"rules/",
-		"skills/",
-		"scripts/download-grammars.js",
-		"scripts/grammars.lock.json",
-		"scripts/analyze-pi-lens-logs.mjs",
-		"scripts/install-selftest.mjs",
-		"scripts/lib/host-provided-deps.mjs",
-		"scripts/lib/warm-loader-cache.mjs",
-		"scripts/warm-loader-cache.mjs",
-		"scripts/rpc-load-check.mjs",
-		"README.md",
-		"CHANGELOG.md",
-		"banner.svg",
-		"banner.png"
-	],
-	"dependencies": {
-		"@ast-grep/cli": "^0.45.0",
-		"@ast-grep/napi": "^0.45.0",
-		"js-yaml": "^5.2.2",
-		"minimatch": "^10.2.6",
-		"pidusage": "^4.0.1",
-		"vscode-jsonrpc": "^9.0.0"
-	},
-	"peerDependencies": {
-		"@earendil-works/pi-coding-agent": "*",
-		"@earendil-works/pi-tui": "^0.84.1",
-		"typebox": "^1.0.0"
-	},
-	"peerDependenciesMeta": {
-		"@earendil-works/pi-coding-agent": {
-			"optional": true
-		},
-		"@earendil-works/pi-tui": {
-			"optional": true
-		},
-		"typebox": {
-			"optional": true
-		}
-	},
-	"optionalDependencies": {
-		"jiti": "^2.7.0",
-		"web-tree-sitter": "0.25.10"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.10",
-		"@earendil-works/pi-coding-agent": "^0.84.1",
-		"@earendil-works/pi-tui": "^0.84.1",
-		"@types/node": "^26.0.0",
-		"@types/pidusage": "^2.0.5",
-		"@vitest/coverage-v8": "^4.1.5",
-		"dependency-cruiser": "^18.2.0",
-		"husky": "^9.1.7",
-		"json5": "^2.2.3",
-		"oxfmt": "0.65.0",
-		"oxlint": "1.80.0",
-		"typebox": "^1.0.0",
-		"typescript": "^7.0.2",
-		"typescript-language-server": "^6.0.0",
-		"vitest": "^4.1.1"
-	},
-	"pi": {
-		"extensions": [
-			"./dist/index.js"
-		],
-		"skills": [
-			"../../skills"
-		]
-	},
-	"knip": {
-		"entry": [
-			"index.ts"
-		],
-		"project": [
-			"**/*.ts",
-			"!**/*.test.ts"
-		],
-		"ignore": [
-			"**/*.test.ts"
-		]
-	},
-	"allowScripts": {
-		"@ast-grep/cli@0.45.2": true,
-		"@google/genai@1.52.0": true,
-		"protobufjs@7.6.5": true
-	}
+  "name": "pi-lens",
+  "version": "4.1.3",
+  "type": "module",
+  "description": "Real-time code feedback for pi — LSP, linters, formatters, type-checking, structural analysis & booboo",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apmantza/pi-lens.git"
+  },
+  "main": "./dist/index.js",
+  "bin": {
+    "pi-lens": "dist/mcp/cli.js",
+    "pi-lens-mcp": "dist/mcp/server.js",
+    "pi-lens-analyze": "dist/mcp/analyze-cli.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "build:dist": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && npx --yes -p typescript@7.0.2 tsc --project tsconfig.dist.json --noCheck && npm run bundle:dist",
+    "bundle:dist": "node scripts/bundle-dist.mjs",
+    "prepare": "npm run build:dist && node scripts/download-grammars.js --core --dest grammars && node scripts/setup-git-hooks.mjs && node scripts/warm-loader-cache.mjs",
+    "prepack": "node scripts/strip-dev-deps-for-pack.mjs --strip",
+    "postpack": "node scripts/strip-dev-deps-for-pack.mjs --restore",
+    "lint": "tsc --project tsconfig.json && npm run lint:js",
+    "lint:js": "oxlint --deny-warnings --ignore-pattern \"tests/**/*.ts\" --ignore-pattern \"tests/**/*.tsx\" --ignore-pattern \"**/*.d.mts\" --ignore-pattern \"tests/fixtures/autofix-smoke/**\" --ignore-pattern \"tests/fixtures/format-smoke/**\" --ignore-pattern \"tests/fixtures/tool-smoke/**\" --ignore-pattern \"tests/fixtures/call-graph/javascript/**\" --ignore-pattern \"tests/fixtures/function-facts/javascript-parameter.js\" .",
+    "depcruise:check": "depcruise --validate --config .dependency-cruiser.cjs --ignore-known .dependency-cruiser-known-violations.json --output-type err index.ts \"clients/**/*.ts\"",
+    "fmt": "oxfmt",
+    "fmt:check": "oxfmt --check",
+    "watch": "tsc --watch",
+    "test": "node scripts/with-test-lock.mjs -- vitest run",
+    "test:unit": "node scripts/with-test-lock.mjs -- vitest run",
+    "test:integration": "node scripts/with-test-lock.mjs -- vitest run tests/index-integration.test.ts tests/clients/lsp/integration.test.ts",
+    "test:targeted": "node scripts/with-test-lock.mjs --shared -- vitest run",
+    "test:watch": "vitest",
+    "hygiene": "node scripts/prune-agent-worktrees.mjs",
+    "check": "node scripts/check-extensions.mjs",
+    "selftest:install": "node scripts/install-selftest.mjs",
+    "check:lockfile": "node scripts/check-lockfile-sync.mjs",
+    "check:grammars": "node scripts/check-grammar-provenance.mjs",
+    "check:grammar-load": "node scripts/check-grammar-load.mjs",
+    "audit:tree-sitter": "node scripts/audit-tree-sitter-rules.mjs",
+    "audit:rule-catalog": "node scripts/validate-rule-catalog.mjs",
+    "audit:astgrep-rule-pairs": "node scripts/audit-astgrep-rule-pairs.mjs",
+    "astgrep:self-scan": "node scripts/run-astgrep-pi-lens.mjs",
+    "astgrep:self-scan:update-baseline": "node scripts/run-astgrep-pi-lens.mjs --update-baseline",
+    "audit:playground": "node scripts/playground-verify-rule.mjs",
+    "bench:cascade-budget": "node scripts/bench-cascade-budget.mjs",
+    "bench:word-index-replacement": "node scripts/bench-word-index-replacement.mjs",
+    "logs:smells": "node scripts/analyze-pi-lens-logs.mjs",
+    "changelog:check": "node scripts/rollup-changelog.mjs --check",
+    "changelog:release": "node scripts/changelog-release.mjs",
+    "changelog:extract": "node scripts/changelog-extract.mjs",
+    "release:backfill-notes": "node scripts/backfill-github-releases.mjs",
+    "release:backfill-thanks": "node scripts/backfill-release-thanks.mjs",
+    "docs:rule-catalogs": "node scripts/gen-rule-catalogs.mjs",
+    "banner": "npx -y sharp-cli --input banner.svg --output banner.png resize 2200 620",
+    "download-grammars": "node scripts/download-grammars.js",
+    "harness:poc": "node scripts/run-harness.mjs cases/ts/pipeline-dispatch-poc",
+    "harness:python-poc": "node scripts/run-harness.mjs cases/python/pipeline-dispatch-poc",
+    "harness:ts-format-poc": "node scripts/run-harness.mjs cases/ts/format-default-poc",
+    "harness:python-autofix-poc": "node scripts/run-harness.mjs cases/python/autofix-default-poc",
+    "harness:go-poc": "node scripts/run-harness.mjs cases/go/pipeline-dispatch-poc"
+  },
+  "keywords": [
+    "pi",
+    "pi-extension",
+    "pi-package",
+    "linter",
+    "biome",
+    "ast-grep",
+    "ruff",
+    "typescript",
+    "code-quality",
+    "feedback",
+    "type-coverage",
+    "jscpd",
+    "knip"
+  ],
+  "author": "Apostolos Mantzaris",
+  "license": "MIT",
+  "files": [
+    "dist/",
+    "docs/",
+    "grammars/",
+    "vendor/grammars/",
+    "config/",
+    "rules/",
+    "skills/",
+    "scripts/download-grammars.js",
+    "scripts/grammars.lock.json",
+    "scripts/analyze-pi-lens-logs.mjs",
+    "scripts/install-selftest.mjs",
+    "scripts/lib/host-provided-deps.mjs",
+    "scripts/lib/warm-loader-cache.mjs",
+    "scripts/warm-loader-cache.mjs",
+    "scripts/rpc-load-check.mjs",
+    "README.md",
+    "CHANGELOG.md",
+    "banner.svg",
+    "banner.png"
+  ],
+  "dependencies": {
+    "@ast-grep/cli": "^0.45.0",
+    "@ast-grep/napi": "^0.45.0",
+    "js-yaml": "^5.2.2",
+    "minimatch": "^10.2.6",
+    "pidusage": "^4.0.1",
+    "vscode-jsonrpc": "^9.0.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "^0.84.1",
+    "typebox": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    },
+    "@earendil-works/pi-tui": {
+      "optional": true
+    },
+    "typebox": {
+      "optional": true
+    }
+  },
+  "optionalDependencies": {
+    "jiti": "^2.7.0",
+    "web-tree-sitter": "0.25.10"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.10",
+    "@earendil-works/pi-coding-agent": "^0.84.1",
+    "@earendil-works/pi-tui": "^0.84.1",
+    "@types/node": "^26.0.0",
+    "@types/pidusage": "^2.0.5",
+    "@vitest/coverage-v8": "^4.1.5",
+    "dependency-cruiser": "^18.2.0",
+    "husky": "^9.1.7",
+    "json5": "^2.2.3",
+    "oxfmt": "0.65.0",
+    "oxlint": "1.80.0",
+    "typebox": "^1.0.0",
+    "typescript": "^7.0.2",
+    "typescript-language-server": "^6.0.0",
+    "vitest": "^4.1.1"
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ],
+    "skills": [
+      "../../skills"
+    ]
+  },
+  "knip": {
+    "entry": [
+      "index.ts"
+    ],
+    "project": [
+      "**/*.ts",
+      "!**/*.test.ts"
+    ],
+    "ignore": [
+      "**/*.test.ts"
+    ]
+  },
+  "allowScripts": {
+    "@ast-grep/cli@0.45.2": true,
+    "@google/genai@1.52.0": true,
+    "protobufjs@7.6.5": true
+  }
 }

--- a/scripts/strip-dev-deps-for-pack.d.mts
+++ b/scripts/strip-dev-deps-for-pack.d.mts
@@ -1,0 +1,1 @@
+export function stripForPack<T extends { devDependencies?: unknown }>(pkg: T): Omit<T, "devDependencies">;

--- a/scripts/strip-dev-deps-for-pack.mjs
+++ b/scripts/strip-dev-deps-for-pack.mjs
@@ -22,7 +22,11 @@ import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const manifest = path.join(root, "package.json");
-const backup = path.join(root, ".pack-backup", "package.json");
+const backupDir = path.join(root, ".pack-backup");
+// npm re-syncs package-lock.json's root entry from the (stripped) manifest
+// during `npm pack` and rewrites the whole file in its own formatting, so the
+// lock is backed up and restored alongside the manifest (#2573 round 2).
+const FILES = ["package.json", "package-lock.json"];
 
 /** Pure: the manifest as it must be published. Exported for the packaging test. */
 export function stripForPack(pkg) {
@@ -39,22 +43,33 @@ function strip() {
 		);
 		return;
 	}
-	fs.mkdirSync(path.dirname(backup), { recursive: true });
-	fs.writeFileSync(backup, raw);
-	fs.writeFileSync(manifest, `${JSON.stringify(stripForPack(pkg), null, 2)}\n`);
+	fs.mkdirSync(backupDir, { recursive: true });
+	for (const f of FILES) {
+		const src = path.join(root, f);
+		if (fs.existsSync(src)) fs.copyFileSync(src, path.join(backupDir, f));
+	}
+	const indent = /^	/m.test(raw) ? "	" : 2;
+	fs.writeFileSync(
+		manifest,
+		`${JSON.stringify(stripForPack(pkg), null, indent)}
+`,
+	);
 	console.error(
-		`[strip-dev-deps] removed ${Object.keys(pkg.devDependencies).length} devDependencies from package.json for packing (backup: .pack-backup/package.json)`,
+		`[strip-dev-deps] removed ${Object.keys(pkg.devDependencies).length} devDependencies from package.json for packing (backup: .pack-backup/)`,
 	);
 }
 
 function restore() {
-	if (!fs.existsSync(backup)) {
+	if (!fs.existsSync(backupDir)) {
 		console.error("[strip-dev-deps] no backup to restore");
 		return;
 	}
-	fs.copyFileSync(backup, manifest);
-	fs.rmSync(path.dirname(backup), { recursive: true, force: true });
-	console.error("[strip-dev-deps] restored package.json");
+	for (const f of FILES) {
+		const b = path.join(backupDir, f);
+		if (fs.existsSync(b)) fs.copyFileSync(b, path.join(root, f));
+	}
+	fs.rmSync(backupDir, { recursive: true, force: true });
+	console.error("[strip-dev-deps] restored package.json and package-lock.json");
 }
 
 const mode = process.argv[2];

--- a/scripts/strip-dev-deps-for-pack.mjs
+++ b/scripts/strip-dev-deps-for-pack.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// prepack/postpack: the published manifest must not carry `devDependencies`.
+//
+// Why: after `pi install npm:pi-lens`, pi supplies the host-provided packages
+// with a plain `npm install --no-save` INTO the installed extension directory
+// (#1926). npm's resolver (arborist) then builds the ideal tree from the
+// installed package.json — devDependencies included — and walks their peer
+// graph. On 2026-09-03 `@vitejs/devtools@0.7.1` / `vitest@5.0.0` published a
+// peer graph that crashes npm 10.9.8 (`Cannot read properties of null
+// (reading 'edgesOut')` in #loadPeerSet); every install-test lane went red and
+// an npm-10 user would hit the same crash at pi's supply step. The published
+// package never needs devDependencies (pi installs with --omit=dev), so they
+// are stripped at pack time and restored after. Proven: same tarball, same
+// npm 10.9.8 — with the block present the supply step crashes; without it,
+// "added 4 packages in 3s".
+//
+//   node scripts/strip-dev-deps-for-pack.mjs --strip     (prepack)
+//   node scripts/strip-dev-deps-for-pack.mjs --restore   (postpack)
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = path.join(root, "package.json");
+const backup = path.join(root, ".pack-backup", "package.json");
+
+/** Pure: the manifest as it must be published. Exported for the packaging test. */
+export function stripForPack(pkg) {
+	const { devDependencies: _dropped, ...rest } = pkg;
+	return rest;
+}
+
+function strip() {
+	const raw = fs.readFileSync(manifest, "utf8");
+	const pkg = JSON.parse(raw);
+	if (!pkg.devDependencies) {
+		console.error("[strip-dev-deps] no devDependencies in package.json; nothing to do");
+		return;
+	}
+	fs.mkdirSync(path.dirname(backup), { recursive: true });
+	fs.writeFileSync(backup, raw);
+	fs.writeFileSync(manifest, `${JSON.stringify(stripForPack(pkg), null, 2)}\n`);
+	console.error(`[strip-dev-deps] removed ${Object.keys(pkg.devDependencies).length} devDependencies from package.json for packing (backup: .pack-backup/package.json)`);
+}
+
+function restore() {
+	if (!fs.existsSync(backup)) {
+		console.error("[strip-dev-deps] no backup to restore");
+		return;
+	}
+	fs.copyFileSync(backup, manifest);
+	fs.rmSync(path.dirname(backup), { recursive: true, force: true });
+	console.error("[strip-dev-deps] restored package.json");
+}
+
+const mode = process.argv[2];
+if (mode === "--strip") strip();
+else if (mode === "--restore") restore();
+else if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("strip-dev-deps-for-pack.mjs")) {
+	console.error("usage: strip-dev-deps-for-pack.mjs --strip | --restore");
+	process.exitCode = 64;
+}

--- a/scripts/strip-dev-deps-for-pack.mjs
+++ b/scripts/strip-dev-deps-for-pack.mjs
@@ -34,13 +34,17 @@ function strip() {
 	const raw = fs.readFileSync(manifest, "utf8");
 	const pkg = JSON.parse(raw);
 	if (!pkg.devDependencies) {
-		console.error("[strip-dev-deps] no devDependencies in package.json; nothing to do");
+		console.error(
+			"[strip-dev-deps] no devDependencies in package.json; nothing to do",
+		);
 		return;
 	}
 	fs.mkdirSync(path.dirname(backup), { recursive: true });
 	fs.writeFileSync(backup, raw);
 	fs.writeFileSync(manifest, `${JSON.stringify(stripForPack(pkg), null, 2)}\n`);
-	console.error(`[strip-dev-deps] removed ${Object.keys(pkg.devDependencies).length} devDependencies from package.json for packing (backup: .pack-backup/package.json)`);
+	console.error(
+		`[strip-dev-deps] removed ${Object.keys(pkg.devDependencies).length} devDependencies from package.json for packing (backup: .pack-backup/package.json)`,
+	);
 }
 
 function restore() {
@@ -56,7 +60,10 @@ function restore() {
 const mode = process.argv[2];
 if (mode === "--strip") strip();
 else if (mode === "--restore") restore();
-else if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("strip-dev-deps-for-pack.mjs")) {
+else if (
+	import.meta.url === `file://${process.argv[1]}` ||
+	process.argv[1]?.endsWith("strip-dev-deps-for-pack.mjs")
+) {
 	console.error("usage: strip-dev-deps-for-pack.mjs --strip | --restore");
 	process.exitCode = 64;
 }

--- a/tests/clients/flake-shape-ratchet.test.ts
+++ b/tests/clients/flake-shape-ratchet.test.ts
@@ -95,7 +95,8 @@ const ADMITTED_AFTER_BASELINE: Readonly<
 	// (prepack/postpack are npm lifecycle hooks); header on the file states why.
 	"real-process-spawn:packaging-pack-manifest.test.ts": {
 		detector: "real-process-spawn",
-		reason: "observes the real npm pack lifecycle (prepack/postpack); no in-process double is faithful",
+		reason:
+			"observes the real npm pack lifecycle (prepack/postpack); no in-process double is faithful",
 	},
 };
 

--- a/tests/clients/flake-shape-ratchet.test.ts
+++ b/tests/clients/flake-shape-ratchet.test.ts
@@ -90,7 +90,14 @@ const FLAKE_SHAPE_BASELINE: Baseline = JSON.parse(
  */
 const ADMITTED_AFTER_BASELINE: Readonly<
 	Record<string, { detector: DetectorName; reason: string }>
-> = {};
+> = {
+	// 2026-09-03: the published-manifest guard must run the real `npm pack`
+	// (prepack/postpack are npm lifecycle hooks); header on the file states why.
+	"real-process-spawn:packaging-pack-manifest.test.ts": {
+		detector: "real-process-spawn",
+		reason: "observes the real npm pack lifecycle (prepack/postpack); no in-process double is faithful",
+	},
+};
 
 /** The `wallClockBudgetInclude` project's `include` list, read from the live config — not a hand-copied mirror of it (single-source-of-truth). */
 function wallClockBudgetInclude(): string[] {

--- a/tests/packaging-pack-manifest.test.ts
+++ b/tests/packaging-pack-manifest.test.ts
@@ -1,0 +1,63 @@
+// flake-shape: real-process-spawn — the published manifest can only be observed by running the real `npm pack` (prepack/postpack are npm lifecycle hooks; nothing in-process reproduces them faithfully).
+/**
+ * The tarball's package.json must not carry devDependencies (2026-09-03):
+ * pi supplies host-provided packages with `npm install --no-save` into the
+ * installed extension, npm's resolver then walks the dev peer graph, and
+ * `@vitejs/devtools@0.7.1` / `vitest@5.0.0` crash npm 10.9.8 in #loadPeerSet.
+ * `scripts/strip-dev-deps-for-pack.mjs` strips them in `prepack` and restores
+ * them in `postpack`; this test observes the REAL `npm pack` output.
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+import { stripForPack } from "../scripts/strip-dev-deps-for-pack.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")) as {
+	name: string;
+	devDependencies?: Record<string, string>;
+	dependencies?: Record<string, string>;
+	scripts: Record<string, string>;
+};
+
+describe("published manifest carries no devDependencies", () => {
+	it("stripForPack drops exactly devDependencies and nothing else", () => {
+		const input = { name: "x", version: "1.0.0", dependencies: { a: "1" }, devDependencies: { vitest: "^4" }, scripts: { prepack: "p" } };
+		const out = stripForPack(input);
+		expect("devDependencies" in out).toBe(false);
+		expect(out).toEqual({ name: "x", version: "1.0.0", dependencies: { a: "1" }, scripts: { prepack: "p" } });
+	});
+
+	it("prepack strips and postpack restores, wired in package.json", () => {
+		expect(pkg.scripts.prepack).toBe("node scripts/strip-dev-deps-for-pack.mjs --strip");
+		expect(pkg.scripts.postpack).toBe("node scripts/strip-dev-deps-for-pack.mjs --restore");
+		expect(pkg.devDependencies && Object.keys(pkg.devDependencies).length).toBeGreaterThan(0);
+	});
+
+	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-pack-"));
+	afterAll(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+	it("the real `npm pack` tarball's package.json has no devDependencies, and the working manifest is restored", { timeout: 180_000 }, () => {
+		const before = fs.readFileSync(path.join(root, "package.json"), "utf8");
+		const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+		const out = execFileSync(npm, ["pack", "--ignore-scripts=false", "--pack-destination", tmp, "--json"], {
+			cwd: root,
+			encoding: "utf8",
+			shell: process.platform === "win32",
+			timeout: 180_000,
+		});
+		const filename = (JSON.parse(out) as Array<{ filename: string }>)[0].filename;
+		// tar with cwd + a relative path: GNU/bsd tar misread `C:...` as a remote host spec.
+		const manifest = execFileSync("tar", ["-xzOf", filename, "package/package.json"], { cwd: tmp, encoding: "utf8" });
+		const packed = JSON.parse(manifest) as { devDependencies?: unknown; dependencies?: unknown; name: string };
+		expect(packed.name).toBe(pkg.name);
+		expect(packed.devDependencies).toBeUndefined();
+		expect(packed.dependencies).toEqual(pkg.dependencies);
+		// postpack put the working manifest back, byte for byte.
+		expect(fs.readFileSync(path.join(root, "package.json"), "utf8")).toBe(before);
+		expect(fs.existsSync(path.join(root, ".pack-backup"))).toBe(false);
+	});
+});

--- a/tests/packaging-pack-manifest.test.ts
+++ b/tests/packaging-pack-manifest.test.ts
@@ -64,6 +64,10 @@ describe("published manifest carries no devDependencies", () => {
 		{ timeout: 180_000 },
 		() => {
 			const before = fs.readFileSync(path.join(root, "package.json"), "utf8");
+			const lockBefore = fs.readFileSync(
+				path.join(root, "package-lock.json"),
+				"utf8",
+			);
 			const npm = process.platform === "win32" ? "npm.cmd" : "npm";
 			const out = execFileSync(
 				npm,
@@ -96,6 +100,10 @@ describe("published manifest carries no devDependencies", () => {
 				before,
 			);
 			expect(fs.existsSync(path.join(root, ".pack-backup"))).toBe(false);
+			// npm re-syncs the lock from the stripped manifest during pack; postpack must put it back too.
+			expect(
+				fs.readFileSync(path.join(root, "package-lock.json"), "utf8"),
+			).toBe(lockBefore);
 		},
 	);
 });

--- a/tests/packaging-pack-manifest.test.ts
+++ b/tests/packaging-pack-manifest.test.ts
@@ -69,18 +69,17 @@ describe("published manifest carries no devDependencies", () => {
 				"utf8",
 			);
 			const npm = process.platform === "win32" ? "npm.cmd" : "npm";
-			const out = execFileSync(
-				npm,
-				["pack", "--ignore-scripts=false", "--pack-destination", tmp, "--json"],
-				{
-					cwd: root,
-					encoding: "utf8",
-					shell: process.platform === "win32",
-					timeout: 180_000,
-				},
-			);
-			const filename = (JSON.parse(out) as Array<{ filename: string }>)[0]
-				.filename;
+			// Not `--json`: `prepare` also runs on pack and its scripts write to stdout
+			// (setup-git-hooks on a fresh CI checkout), which corrupts the JSON payload.
+			execFileSync(npm, ["pack", "--pack-destination", tmp], {
+				cwd: root,
+				encoding: "utf8",
+				shell: process.platform === "win32",
+				timeout: 180_000,
+				stdio: ["ignore", "ignore", "inherit"],
+			});
+			const filename = fs.readdirSync(tmp).find((f) => f.endsWith(".tgz"));
+			if (!filename) throw new Error("npm pack produced no tarball");
 			// tar with cwd + a relative path: GNU/bsd tar misread `C:...` as a remote host spec.
 			const manifest = execFileSync(
 				"tar",

--- a/tests/packaging-pack-manifest.test.ts
+++ b/tests/packaging-pack-manifest.test.ts
@@ -16,7 +16,9 @@ import { afterAll, describe, expect, it } from "vitest";
 import { stripForPack } from "../scripts/strip-dev-deps-for-pack.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")) as {
+const pkg = JSON.parse(
+	fs.readFileSync(path.join(root, "package.json"), "utf8"),
+) as {
 	name: string;
 	devDependencies?: Record<string, string>;
 	dependencies?: Record<string, string>;
@@ -25,39 +27,75 @@ const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"))
 
 describe("published manifest carries no devDependencies", () => {
 	it("stripForPack drops exactly devDependencies and nothing else", () => {
-		const input = { name: "x", version: "1.0.0", dependencies: { a: "1" }, devDependencies: { vitest: "^4" }, scripts: { prepack: "p" } };
+		const input = {
+			name: "x",
+			version: "1.0.0",
+			dependencies: { a: "1" },
+			devDependencies: { vitest: "^4" },
+			scripts: { prepack: "p" },
+		};
 		const out = stripForPack(input);
 		expect("devDependencies" in out).toBe(false);
-		expect(out).toEqual({ name: "x", version: "1.0.0", dependencies: { a: "1" }, scripts: { prepack: "p" } });
+		expect(out).toEqual({
+			name: "x",
+			version: "1.0.0",
+			dependencies: { a: "1" },
+			scripts: { prepack: "p" },
+		});
 	});
 
 	it("prepack strips and postpack restores, wired in package.json", () => {
-		expect(pkg.scripts.prepack).toBe("node scripts/strip-dev-deps-for-pack.mjs --strip");
-		expect(pkg.scripts.postpack).toBe("node scripts/strip-dev-deps-for-pack.mjs --restore");
-		expect(pkg.devDependencies && Object.keys(pkg.devDependencies).length).toBeGreaterThan(0);
+		expect(pkg.scripts.prepack).toBe(
+			"node scripts/strip-dev-deps-for-pack.mjs --strip",
+		);
+		expect(pkg.scripts.postpack).toBe(
+			"node scripts/strip-dev-deps-for-pack.mjs --restore",
+		);
+		expect(
+			pkg.devDependencies && Object.keys(pkg.devDependencies).length,
+		).toBeGreaterThan(0);
 	});
 
 	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-pack-"));
 	afterAll(() => fs.rmSync(tmp, { recursive: true, force: true }));
 
-	it("the real `npm pack` tarball's package.json has no devDependencies, and the working manifest is restored", { timeout: 180_000 }, () => {
-		const before = fs.readFileSync(path.join(root, "package.json"), "utf8");
-		const npm = process.platform === "win32" ? "npm.cmd" : "npm";
-		const out = execFileSync(npm, ["pack", "--ignore-scripts=false", "--pack-destination", tmp, "--json"], {
-			cwd: root,
-			encoding: "utf8",
-			shell: process.platform === "win32",
-			timeout: 180_000,
-		});
-		const filename = (JSON.parse(out) as Array<{ filename: string }>)[0].filename;
-		// tar with cwd + a relative path: GNU/bsd tar misread `C:...` as a remote host spec.
-		const manifest = execFileSync("tar", ["-xzOf", filename, "package/package.json"], { cwd: tmp, encoding: "utf8" });
-		const packed = JSON.parse(manifest) as { devDependencies?: unknown; dependencies?: unknown; name: string };
-		expect(packed.name).toBe(pkg.name);
-		expect(packed.devDependencies).toBeUndefined();
-		expect(packed.dependencies).toEqual(pkg.dependencies);
-		// postpack put the working manifest back, byte for byte.
-		expect(fs.readFileSync(path.join(root, "package.json"), "utf8")).toBe(before);
-		expect(fs.existsSync(path.join(root, ".pack-backup"))).toBe(false);
-	});
+	it(
+		"the real `npm pack` tarball's package.json has no devDependencies, and the working manifest is restored",
+		{ timeout: 180_000 },
+		() => {
+			const before = fs.readFileSync(path.join(root, "package.json"), "utf8");
+			const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+			const out = execFileSync(
+				npm,
+				["pack", "--ignore-scripts=false", "--pack-destination", tmp, "--json"],
+				{
+					cwd: root,
+					encoding: "utf8",
+					shell: process.platform === "win32",
+					timeout: 180_000,
+				},
+			);
+			const filename = (JSON.parse(out) as Array<{ filename: string }>)[0]
+				.filename;
+			// tar with cwd + a relative path: GNU/bsd tar misread `C:...` as a remote host spec.
+			const manifest = execFileSync(
+				"tar",
+				["-xzOf", filename, "package/package.json"],
+				{ cwd: tmp, encoding: "utf8" },
+			);
+			const packed = JSON.parse(manifest) as {
+				devDependencies?: unknown;
+				dependencies?: unknown;
+				name: string;
+			};
+			expect(packed.name).toBe(pkg.name);
+			expect(packed.devDependencies).toBeUndefined();
+			expect(packed.dependencies).toEqual(pkg.dependencies);
+			// postpack put the working manifest back, byte for byte.
+			expect(fs.readFileSync(path.join(root, "package.json"), "utf8")).toBe(
+				before,
+			);
+			expect(fs.existsSync(path.join(root, ".pack-backup"))).toBe(false);
+		},
+	);
 });

--- a/tests/support/flake-shape-baseline.json
+++ b/tests/support/flake-shape-baseline.json
@@ -41,7 +41,8 @@
 		"scripts/rule-catalogs.test.ts": 2,
 		"scripts/rule-language-case.test.ts": 4,
 		"scripts/warm-loader-cache.test.ts": 2,
-		"scripts/with-memory-watch.test.ts": 1
+		"scripts/with-memory-watch.test.ts": 1,
+		"packaging-pack-manifest.test.ts": 3
 	},
 	"elapsed-time-assertion": {
 		"clients/actionable-warnings-bounds.test.ts": 1,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -308,6 +308,8 @@ const lspSpawnHeavyInclude = [
 // host. Sweep coverage for other members lives in this list; new entries must
 // carry a wall-clock budget assertion, not just slowness.
 const wallClockBudgetInclude = [
+	// published-manifest guard runs the real `npm pack` (flake-shape admission).
+	"tests/packaging-pack-manifest.test.ts",
 	// #2528: the bounded batch helper tests race a real wall-clock budget against settle latency (flake-shape admission).
 	"tests/clients/runtime-turn-test-runner-bounds.test.ts",
 	// #2557 review round 3: a real 30s deadline margin is the subject of an abort-vs-deadline precedence assertion (flake-shape admission).


### PR DESCRIPTION
## Summary
All three `Install test` lanes on master have been red since 11:42 UTC 2026-09-03 with `npm error Cannot read properties of null (reading 'edgesOut')` in the step that supplies host-provided packages (`npm install --no-save` into the installed extension, the way pi does — #1926). Root cause: `@vitejs/devtools@0.7.1` (10:28 UTC) and `vitest@5.0.0` (12:24 UTC) published a peer graph that crashes npm 10.9.8's arborist in `#loadPeerSet`; the resolver reaches it because the published `package.json` still carries `devDependencies`. npm 11 is unaffected. Last green install run: e62ebff2 at 10:52 UTC, same npm 10.9.8 — the runner did not change; the registry did.

Proof (local, npm 10.9.8, the last-green tarball): supply step crashes with the block present; with `devDependencies` deleted from the installed manifest, `added 4 packages in 3s`.

Fix: `prepack` strips `devDependencies` (backup under `.pack-backup/`, gitignored, not in `files`), `postpack` restores. The published package never needed them (pi installs with `--omit=dev`); this removes the whole upstream dev peer graph from every consumer's resolver regardless of npm version.

## Tests
- `tests/packaging-pack-manifest.test.ts` (new): pure `stripForPack` drops exactly `devDependencies`; `prepack`/`postpack` wiring; the REAL `npm pack` tarball's `package/package.json` has no `devDependencies`, `dependencies` unchanged, working manifest restored byte-for-byte, no backup dir left. Red before the script existed (`SyntaxError`/`devDependencies` present), green after.
- Ran: `tests/packaging-pack-manifest.test.ts`, `tests/packaging.test.ts`, `tests/clients/flake-shape-ratchet.test.ts`, `tests/config/module-instance-coverage.test.ts` → `Test Files 4 passed / Tests 77 passed`. Lint, oxfmt, depcruise, changelog fragment check clean.

## Test assessment
- New file admitted to the flake-shape ratchet (`real-process-spawn`, 3 hits): header states why a real `npm pack` is the only faithful probe; listed in `wallClockBudgetInclude`; baseline entry added.

## Blast radius
`npm pack` / `npm publish` only (prepack/postpack). `prepare` (git installs) untouched. `.d.mts` sibling for the `.mjs` import (TS7016 rule).

## Observability
Not applicable at runtime; the guard is the packaging test. CI's install lanes are the production signal.

## Class sweep
Any other manifest field that drags dev-only graphs into consumers' resolvers: none — `peerDependencies` are the dep-seam optional peers by design (#1926 tests), `optionalDependencies` none.

Maintainer-authored during the subagent freeze (user-approved fix). Fixes master's red install matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ4a3oS1UDFxs74fLm8U21
