### PR TITLE
fix(ci): compat-smoke reads the latency log from its PI_LENS_HOME pin (closes #2570)

### DIFF
--- a/.changelog/fix-2570-compat-smoke-log-home.md
+++ b/.changelog/fix-2570-compat-smoke-log-home.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Compat-smoke Layer B reads the latency log it actually wrote (fixes #2570)** — the behavioral smoke pins `PI_LENS_HOME` for every child `pi` and reads `latency.log` from that pin; since the tmpdir probe-home redirect (#2534) it had been reading the untouched real `~/.pi-lens`, so the light-mode assertions reported a missing phase and the heavyweight-scan absence checks passed on an empty log. Those checks now require at least one entry from the run.

--- a/docs/subagent-compat.md
+++ b/docs/subagent-compat.md
@@ -71,7 +71,7 @@ first session.
 Assertions:
 
 1. **Subagent light mode engages** — with `PI_SUBAGENT_CHILD=1` set,
-   `subagent_light_mode` is logged to `~/.pi-lens/latency.log` (a `type:
+   `subagent_light_mode` is logged to `$PI_LENS_HOME/latency.log` (a `type:
    "phase"` entry) and none of the seven heavyweight-scan phases
    (`knip`/`jscpd`/`madge`/`dead-code`/`govulncheck`/`gitleaks`/`trivy`) are
    logged for that run.

--- a/scripts/compat-smoke-behavioral.mjs
+++ b/scripts/compat-smoke-behavioral.mjs
@@ -71,6 +71,7 @@ import {
 	noPhasesLogged,
 	parseNdjsonEntries,
 	phaseWasLogged,
+	countEntriesSince,
 } from "./lib/latency-log-phases.mjs";
 import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
 
@@ -141,7 +142,14 @@ function resolvePiBin() {
  * pi-lens's session_shutdown LSP teardown, which would make assertion 3
  * meaningless). Resolves with `{ commandCount, timedOut }`.
  */
-function runPiRpc({ piBin, extensionPath, cwd, env, timeoutMs = 45000 }) {
+function runPiRpc({
+	piBin,
+	extensionPath,
+	cwd,
+	env,
+	logHome,
+	timeoutMs = 45000,
+}) {
 	return new Promise((resolve, reject) => {
 		const child = spawn(
 			piBin,
@@ -159,6 +167,7 @@ function runPiRpc({ piBin, extensionPath, cwd, env, timeoutMs = 45000 }) {
 				stdio: ["pipe", "pipe", "inherit"],
 				env: {
 					...process.env,
+					PI_LENS_HOME: logHome,
 					...env,
 					ANTHROPIC_API_KEY:
 						process.env.ANTHROPIC_API_KEY || "sk-ant-dummy-compat-smoke",
@@ -243,8 +252,14 @@ function snapshotLspCandidates() {
 	return snapshotProcesses(["pid", "command"]);
 }
 
-function readLatencyLogEntries() {
-	const logPath = path.join(os.homedir(), ".pi-lens", "latency.log");
+// The log is read from the PI_LENS_HOME pin every `pi` invocation below
+// runs under — never from the real `~/.pi-lens`. Since #2534 (#2506) the
+// global dir of any process whose cwd is under `os.tmpdir()` is redirected to
+// a per-project probe home, and this smoke's fixture project lives exactly
+// there; reading the real home returned an empty log and the two
+// absence-of-phase assertions passed vacuously (#2570).
+function readLatencyLogEntries(logHome) {
+	const logPath = path.join(logHome, "latency.log");
 	try {
 		return parseNdjsonEntries(fs.readFileSync(logPath, "utf8"));
 	} catch {
@@ -282,6 +297,10 @@ async function main() {
 
 	const projectDir = path.join(scratchRoot, "proj");
 	setUpFixtureProject(projectDir);
+	// Pin the global dir for every child `pi` so the latency log lands where
+	// `readLatencyLogEntries` reads it (same pattern as the other smokes).
+	const logHome = path.join(scratchRoot, "pi-lens-home");
+	fs.mkdirSync(logHome, { recursive: true });
 
 	let extensionPath;
 	try {
@@ -318,9 +337,10 @@ async function main() {
 				piBin,
 				extensionPath,
 				cwd: projectDir,
+				logHome,
 				env: { PI_SUBAGENT_CHILD: "1", PI_LENS_STARTUP_MODE: "full" },
 			});
-			const entries = readLatencyLogEntries();
+			const entries = readLatencyLogEntries(logHome);
 			const lightModeLogged = phaseWasLogged(
 				entries,
 				"subagent_light_mode",
@@ -331,10 +351,11 @@ async function main() {
 				HEAVYWEIGHT_SCAN_PHASES,
 				sinceIso,
 			);
+			const logged = countEntriesSince(entries, sinceIso);
 			results.push({
 				id: "subagent-light-mode-engages",
-				pass: lightModeLogged && heavyweightSkipped,
-				detail: `subagent_light_mode logged=${lightModeLogged}, heavyweight scans absent=${heavyweightSkipped}`,
+				pass: logged > 0 && lightModeLogged && heavyweightSkipped,
+				detail: `entries since run=${logged}, subagent_light_mode logged=${lightModeLogged}, heavyweight scans absent=${heavyweightSkipped}`,
 			});
 		} catch (err) {
 			results.push({
@@ -353,13 +374,14 @@ async function main() {
 				piBin,
 				extensionPath,
 				cwd: projectDir,
+				logHome,
 				env: {
 					PI_SUBAGENT_CHILD: "1",
 					PI_LENS_SUBAGENT_FULL: "1",
 					PI_LENS_STARTUP_MODE: "full",
 				},
 			});
-			const entries = readLatencyLogEntries();
+			const entries = readLatencyLogEntries(logHome);
 			const lightModeAbsent = !phaseWasLogged(
 				entries,
 				"subagent_light_mode",
@@ -387,6 +409,7 @@ async function main() {
 				piBin,
 				extensionPath,
 				cwd: projectDir,
+				logHome,
 				env: { PI_LENS_STARTUP_MODE: "full" },
 			});
 			// Grace period: pi's own teardown (session_shutdown -> LSP fast
@@ -413,13 +436,14 @@ async function main() {
 				piBin,
 				extensionPath,
 				cwd: projectDir,
+				logHome,
 				env: {
 					PI_SUBAGENT_CHILD_AGENT: "compat-smoke-worker",
 					PI_SUBAGENT_PARENT_PID: "4242",
 					PI_LENS_STARTUP_MODE: "full",
 				},
 			});
-			const entries = readLatencyLogEntries();
+			const entries = readLatencyLogEntries(logHome);
 			const lightModeLogged = phaseWasLogged(
 				entries,
 				"subagent_light_mode",
@@ -430,10 +454,11 @@ async function main() {
 				HEAVYWEIGHT_SCAN_PHASES,
 				sinceIso,
 			);
+			const logged = countEntriesSince(entries, sinceIso);
 			results.push({
 				id: "avtc-pair-engages-light-mode",
-				pass: lightModeLogged && heavyweightSkipped,
-				detail: `subagent_light_mode logged=${lightModeLogged}, heavyweight scans absent=${heavyweightSkipped}`,
+				pass: logged > 0 && lightModeLogged && heavyweightSkipped,
+				detail: `entries since run=${logged}, subagent_light_mode logged=${lightModeLogged}, heavyweight scans absent=${heavyweightSkipped}`,
 			});
 		} catch (err) {
 			results.push({
@@ -453,12 +478,13 @@ async function main() {
 				piBin,
 				extensionPath,
 				cwd: projectDir,
+				logHome,
 				env: {
 					PI_SUBAGENT_CHILD_AGENT: "compat-smoke-worker",
 					PI_LENS_STARTUP_MODE: "full",
 				},
 			});
-			const entries = readLatencyLogEntries();
+			const entries = readLatencyLogEntries(logHome);
 			const lightModeAbsent = !phaseWasLogged(
 				entries,
 				"subagent_light_mode",

--- a/scripts/lib/latency-log-phases.d.mts
+++ b/scripts/lib/latency-log-phases.d.mts
@@ -21,3 +21,8 @@ export function noPhasesLogged(
 	phases: string[],
 	sinceIso?: string,
 ): boolean;
+
+export function countEntriesSince(
+	entries: Array<Record<string, unknown>>,
+	sinceIso: string,
+): number;

--- a/scripts/lib/latency-log-phases.mjs
+++ b/scripts/lib/latency-log-phases.mjs
@@ -76,3 +76,20 @@ export function phaseWasLogged(entries, phase, sinceIso) {
 export function noPhasesLogged(entries, phases, sinceIso) {
 	return phases.every((phase) => !phaseWasLogged(entries, phase, sinceIso));
 }
+
+/**
+ * Number of entries (any type) whose `ts` falls at or after `sinceIso`.
+ * Positive control for the absence assertions: "no heavyweight phase logged"
+ * is only evidence when the run wrote SOMETHING to the log the smoke is
+ * reading — an empty or mis-located log made those pass vacuously (#2570).
+ *
+ * @param {Array<Record<string, unknown>>} entries
+ * @param {string} sinceIso ISO timestamp lower bound (inclusive)
+ */
+export function countEntriesSince(entries, sinceIso) {
+	const sinceMs = Date.parse(sinceIso);
+	return entries.filter((e) => {
+		const ts = typeof e.ts === "string" ? Date.parse(e.ts) : Number.NaN;
+		return Number.isFinite(ts) && ts >= sinceMs;
+	}).length;
+}

--- a/scripts/strip-dev-deps-for-pack.d.mts
+++ b/scripts/strip-dev-deps-for-pack.d.mts
@@ -1,1 +1,3 @@
-export function stripForPack<T extends { devDependencies?: unknown }>(pkg: T): Omit<T, "devDependencies">;
+export function stripForPack<T extends { devDependencies?: unknown }>(
+	pkg: T,
+): Omit<T, "devDependencies">;

--- a/tests/scripts/latency-log-phases.test.ts
+++ b/tests/scripts/latency-log-phases.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+	countEntriesSince,
 	findPhaseEntries,
 	noPhasesLogged,
 	parseNdjsonEntries,
@@ -186,5 +187,24 @@ describe("noPhasesLogged", () => {
 				"2099-01-01T00:00:00.000Z",
 			),
 		).toBe(true);
+	});
+});
+
+describe("countEntriesSince (#2570 positive control)", () => {
+	const entries = [
+		{ type: "phase", phase: "slow_fs_probe", ts: "2026-07-10T10:00:00.000Z" },
+		{ type: "runner", phase: "x", ts: "2026-07-10T10:00:05.000Z" },
+		{ type: "phase", phase: "y" }, // no ts — never counted
+		{ type: "phase", phase: "z", ts: "not-a-date" },
+	];
+
+	it("counts entries of any type at or after sinceIso", () => {
+		expect(countEntriesSince(entries, "2026-07-10T10:00:00.000Z")).toBe(2);
+		expect(countEntriesSince(entries, "2026-07-10T10:00:01.000Z")).toBe(1);
+	});
+
+	it("is zero for an empty or mis-located log, so absence assertions cannot pass vacuously", () => {
+		expect(countEntriesSince([], "2026-07-10T10:00:00.000Z")).toBe(0);
+		expect(countEntriesSince(entries, "2099-01-01T00:00:00.000Z")).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary
The nightly compat-smoke Layer B has reported `subagent_light_mode logged=false` since 2026-09-03 with unchanged third-party versions (pi 0.84.4 both days). Not upstream drift: PR #2534 (#2506) redirects the global pi-lens dir of any process whose cwd is under `os.tmpdir()` to a per-project probe home, and the smoke's fixture project lives exactly there. Each child `pi` wrote `latency.log` into `<proj>/.pi-lens-probe-home` while the smoke kept reading `~/.pi-lens/latency.log`, which was empty — so the light-mode phase was "missing" and the two heavyweight-scan absence checks passed vacuously.

## Fix
- Pin `PI_LENS_HOME` to a scratch dir for every `runPiRpc` and read the log from that pin (the pattern `smoke-availability-lifecycle.mjs` and `smoke-psscriptanalyzer-classification.mjs` already use).
- Positive control: the two absence assertions now also require at least one entry from the run (`countEntriesSince`), so a mis-located or empty log can never pass them again (AGENTS.md shape 7, vacuous fixture).
- Doc line in `docs/subagent-compat.md`, changelog fragment.
- Rides along: `oxfmt` of `scripts/strip-dev-deps-for-pack.d.mts` (the advisory format check was already red on master from #2572).

## Blast radius
CI-only: `scripts/compat-smoke-behavioral.mjs` (nightly Layer B), its pure helper `scripts/lib/latency-log-phases.mjs` (+ `.d.mts`), one doc line. No runtime code, no shipped file changes.

## Class sweep
Grepped `scripts/` and `scripts/lib/` for `os.homedir()` + `.pi-lens` readers by name: `analyze-pi-lens-logs`, `warm-loader-cache`, `suite-lock`, `prune-agent-worktrees` read the real home on purpose as host-side tools (no child process under tmpdir whose log they assert). The two other child-spawning smokes already pin `PI_LENS_HOME`. No further instance of the class.

## Observability
The assertion detail line now carries `entries since run=N`, so the nightly run log (and the auto-refreshed #2570 issue body) shows whether the smoke read a live log at all — the record that would have named this defect on day one.

## Test assessment
- New unit test for `countEntriesSince` (2 cases) in `tests/scripts/latency-log-phases.test.ts`; 16/16 pass.
- The regression proof is the nightly run itself: red on 33764761128 (2 assertions failed, unchanged pins); green locally against real pi 0.84.4 with the fix (5/5 pass, `entries since run=43` / `31`).
- No tests deleted; no flake-shape impact (no new spawn/timer shapes in a test file).

## Verification
- `npm run lint` clean; `npx oxfmt --check` clean over the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ4a3oS1UDFxs74fLm8U21
