### PR TITLE
ci: bound and retry the production-dependency audit step (refs #2540)

### DIFF
--- a/.changelog/ci-audit-step-bounded.md
+++ b/.changelog/ci-audit-step-bounded.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **CI production-dependency audit is bounded and retried** — `scripts/audit-prod-deps.mjs` wraps `npm audit --omit=dev --audit-level=high` with a per-attempt timeout and backoff; a real high/critical finding still fails the job, while a registry outage (2026-09-04: five-minute hangs then 400 from npm's retired quick audit endpoint) passes with a visible warning instead of redding every PR on an unchanged lockfile.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,8 +226,13 @@ jobs:
       # `npm install --omit=dev`). Scoped to high/critical to avoid blocking PRs on
       # fix-less moderate advisories; transitive moderate ones are handled by
       # Dependabot security updates. DevDeps are excluded — they never reach users.
+      # Bounded + retried (scripts/audit-prod-deps.mjs): a registry outage
+      # (2026-09-04: ~5 min hang then 400 from the retired quick endpoint) must
+      # not red the job the way a real high/critical finding does. The script
+      # fails only on findings, retries transport errors, and on exhaustion
+      # passes with a visible warning annotation.
       - name: Audit production dependencies
-        run: npm audit --omit=dev --audit-level=high
+        run: node scripts/audit-prod-deps.mjs
 
       # `npm run lint` chains tsc (the TS project) with `lint:js` (oxlint over
       # scripts/**/*.mjs, root *.mjs, tests/**/*.mjs, and other non-TS JS) —

--- a/scripts/audit-prod-deps.d.mts
+++ b/scripts/audit-prod-deps.d.mts
@@ -1,0 +1,12 @@
+export const ATTEMPTS: number;
+export const ATTEMPT_TIMEOUT_MS: number;
+export const BACKOFF_MS: number[];
+export function decideAudit(run: {
+	code: number | null;
+	stdout: string;
+	timedOut: boolean;
+}):
+	| { kind: "clean" }
+	| { kind: "vulnerable"; summary: string }
+	| { kind: "transport"; reason: string };
+export function main(): Promise<number>;

--- a/scripts/audit-prod-deps.mjs
+++ b/scripts/audit-prod-deps.mjs
@@ -1,0 +1,155 @@
+// Bounded, retrying wrapper around `npm audit --omit=dev --audit-level=high`
+// for CI (ci.yml "Audit production dependencies").
+//
+// Why not the bare command: on 2026-09-04 the registry's audit endpoints
+// degraded — each call hung ~5 minutes and then answered 400 ("Invalid
+// package tree") from the retired quick endpoint — so a lockfile master had
+// passed an hour earlier redded every PR's lint job. That is a registry
+// outage, not a vulnerability, and the two must not fail the same way.
+//
+// Contract:
+// - a real high/critical finding in PRODUCTION deps fails the step (exit 1)
+//   exactly as before;
+// - a registry/transport error is retried (bounded per attempt, backoff) and,
+//   if every attempt fails, the step passes with a visible GitHub warning
+//   annotation naming the outage — Dependabot security updates remain the
+//   backstop for the window;
+// - anything unparseable is treated as a transport error, never as clean.
+import { spawn } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export const ATTEMPTS = 3;
+export const ATTEMPT_TIMEOUT_MS = 120_000;
+export const BACKOFF_MS = [0, 15_000, 45_000];
+
+/**
+ * Decide what one `npm audit --json` attempt means.
+ * @param {{ code: number | null, stdout: string, timedOut: boolean }} run
+ * @returns {{ kind: "clean" } | { kind: "vulnerable", summary: string } | { kind: "transport", reason: string }}
+ */
+export function decideAudit(run) {
+	if (run.timedOut) {
+		return {
+			kind: "transport",
+			reason: `timed out after ${ATTEMPT_TIMEOUT_MS}ms`,
+		};
+	}
+	let parsed;
+	try {
+		parsed = JSON.parse(run.stdout);
+	} catch {
+		return { kind: "transport", reason: "audit output was not JSON" };
+	}
+	if (!parsed || typeof parsed !== "object") {
+		return { kind: "transport", reason: "audit output was not an object" };
+	}
+	if (parsed.error) {
+		const e = parsed.error;
+		const detail = [e.code, e.summary ?? e.message].filter(Boolean).join(": ");
+		return {
+			kind: "transport",
+			reason: detail || "audit endpoint returned an error",
+		};
+	}
+	const counts = parsed.metadata?.vulnerabilities;
+	if (!counts || typeof counts !== "object") {
+		return {
+			kind: "transport",
+			reason: "audit output has no metadata.vulnerabilities",
+		};
+	}
+	const high = Number(counts.high ?? 0);
+	const critical = Number(counts.critical ?? 0);
+	if (!Number.isFinite(high) || !Number.isFinite(critical)) {
+		return {
+			kind: "transport",
+			reason: "vulnerability counts were not numbers",
+		};
+	}
+	if (high + critical > 0) {
+		const names = Object.entries(parsed.vulnerabilities ?? {})
+			.filter(
+				([, v]) => v && (v.severity === "high" || v.severity === "critical"),
+			)
+			.map(([name, v]) => `${name} (${v.severity})`);
+		return {
+			kind: "vulnerable",
+			summary: `${high} high, ${critical} critical: ${names.join(", ") || "see npm audit"}`,
+		};
+	}
+	if (run.code !== 0) {
+		// npm exits non-zero for endpoint errors even when it printed a
+		// vulnerability-free object; never read that as clean.
+		return {
+			kind: "transport",
+			reason: `npm audit exited ${run.code} without findings`,
+		};
+	}
+	return { kind: "clean" };
+}
+
+function runAuditOnce() {
+	return new Promise((resolve) => {
+		// Windows needs a shell for npm's .cmd shim; pass the whole command as one
+		// argv entry rather than `shell: true` + args (DEP0190). CI runs on Linux;
+		// the SIGKILL below may leave npm's child alive on Windows, which only
+		// affects a local run.
+		const args = ["audit", "--omit=dev", "--audit-level=high", "--json"];
+		const child =
+			process.platform === "win32"
+				? spawn("cmd.exe", ["/d", "/s", "/c", `npm ${args.join(" ")}`], {
+						stdio: ["ignore", "pipe", "inherit"],
+					})
+				: spawn("npm", args, { stdio: ["ignore", "pipe", "inherit"] });
+		let stdout = "";
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			child.kill("SIGKILL");
+		}, ATTEMPT_TIMEOUT_MS);
+		child.stdout.on("data", (d) => {
+			stdout += d;
+		});
+		child.on("close", (code) => {
+			clearTimeout(timer);
+			resolve({ code, stdout, timedOut });
+		});
+		child.on("error", () => {
+			clearTimeout(timer);
+			resolve({ code: null, stdout, timedOut });
+		});
+	});
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export async function main() {
+	const reasons = [];
+	for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+		if (BACKOFF_MS[attempt]) await sleep(BACKOFF_MS[attempt]);
+		const verdict = decideAudit(await runAuditOnce());
+		if (verdict.kind === "clean") {
+			console.log(
+				`audit: no high/critical vulnerabilities in production deps (attempt ${attempt + 1})`,
+			);
+			return 0;
+		}
+		if (verdict.kind === "vulnerable") {
+			console.error(`audit: ${verdict.summary}`);
+			return 1;
+		}
+		reasons.push(`attempt ${attempt + 1}: ${verdict.reason}`);
+		console.error(`audit: transport failure, ${reasons[reasons.length - 1]}`);
+	}
+	const msg = `npm audit endpoint unavailable after ${ATTEMPTS} attempts (${reasons.join("; ")}) — production-dependency audit SKIPPED this run; Dependabot security updates remain the backstop`;
+	console.log(`::warning title=npm audit skipped::${msg}`);
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		appendFileSync(process.env.GITHUB_STEP_SUMMARY, `> ⚠️ ${msg}\n`);
+	}
+	return 0;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+	process.exitCode = await main();
+}

--- a/tests/scripts/audit-prod-deps.test.ts
+++ b/tests/scripts/audit-prod-deps.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { decideAudit } from "../../scripts/audit-prod-deps.mjs";
+
+const clean = JSON.stringify({
+	metadata: {
+		vulnerabilities: { info: 0, low: 0, moderate: 1, high: 0, critical: 0 },
+	},
+	vulnerabilities: {},
+});
+
+describe("decideAudit (CI audit step verdicts)", () => {
+	it("is clean only when npm exited 0 with zero high/critical", () => {
+		expect(decideAudit({ code: 0, stdout: clean, timedOut: false })).toEqual({
+			kind: "clean",
+		});
+	});
+
+	it("fails on a high or critical finding, naming the package", () => {
+		const out = JSON.stringify({
+			metadata: { vulnerabilities: { high: 1, critical: 0 } },
+			vulnerabilities: {
+				lodash: { severity: "high" },
+				ok: { severity: "low" },
+			},
+		});
+		const v = decideAudit({ code: 1, stdout: out, timedOut: false });
+		expect(v.kind).toBe("vulnerable");
+		expect(v.kind === "vulnerable" && v.summary).toContain("lodash (high)");
+	});
+
+	it("treats the registry's error object as transport, not as clean", () => {
+		const out = JSON.stringify({
+			error: { code: "E400", summary: "Invalid package tree, run npm install" },
+		});
+		const v = decideAudit({ code: 1, stdout: out, timedOut: false });
+		expect(v.kind).toBe("transport");
+		expect(v.kind === "transport" && v.reason).toContain("E400");
+	});
+
+	it("treats a timeout, non-JSON output, and missing metadata as transport", () => {
+		expect(decideAudit({ code: null, stdout: "", timedOut: true }).kind).toBe(
+			"transport",
+		);
+		expect(
+			decideAudit({ code: 0, stdout: "npm warn ...", timedOut: false }).kind,
+		).toBe("transport");
+		expect(decideAudit({ code: 0, stdout: "{}", timedOut: false }).kind).toBe(
+			"transport",
+		);
+	});
+
+	it("never reads a non-zero exit with no findings as clean", () => {
+		expect(decideAudit({ code: 1, stdout: clean, timedOut: false }).kind).toBe(
+			"transport",
+		);
+	});
+});


### PR DESCRIPTION
## Summary
The lint job's `npm audit --omit=dev --audit-level=high` hung ~5 minutes and then failed with 400 from npm's retired quick audit endpoint on 2026-09-04, twice on PR #2568, with a lockfile master had passed an hour earlier. A registry outage and a real high/critical finding must not fail the same way.

## Fix
`scripts/audit-prod-deps.mjs` runs the audit with `--json` under a 120 s per-attempt bound, 3 attempts with backoff. `decideAudit()` fails the step only on high/critical findings; endpoint errors, timeouts and unparseable output are transport (never read as clean) and retried; on exhaustion the step passes with a `::warning` annotation and a step-summary line naming the outage (Dependabot security updates remain the backstop). The workflow step calls the script.

## Blast radius
CI only: one step in the Lint & type-check job. No runtime or shipped files.

## Class sweep
Other registry-dependent CI steps already pass `--no-audit --no-fund` on every install; the audit step was the only one still exposed to the audit endpoints. `scripts/lib` has no existing bounded-spawn helper for standalone CI scripts to fold into (the runtime `safeSpawnAsync` is not importable from a script without a build), so this stays local to the script.

## Observability
Transport failures are printed per attempt; exhaustion emits a GitHub warning annotation and step-summary line, so a skipped audit is visible on the run page, never silent.

## Tests
`tests/scripts/audit-prod-deps.test.ts` covers the verdict function: clean, high finding named, registry error object → transport, timeout/non-JSON/missing metadata → transport, non-zero exit with no findings → transport (never clean).

## Test assessment
Pure verdict tests, no spawns or timers; no flake-shape impact; nothing removed. Live proof during the outage: local run, attempt 1 timed out at 120 s (registry 503 on the bulk endpoint), attempt 2 passed clean, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ4a3oS1UDFxs74fLm8U21
