### PR TITLE
fix(ci): restore priority labels to the label-syncer manifest (refs #2553)

### DIFF
--- a/.changelog/2553-restore-priority-labels-manifest.md
+++ b/.changelog/2553-restore-priority-labels-manifest.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Label syncer no longer deletes the priority labels on every merge-train lane merge (refs #2553)** — `.github/workflows/labels.yml` runs `micnncim/action-label-syncer` with `prune: true` against `.github/labels.yml`, and the manifest never listed `priority:p1`/`p2`/`p3`, so every sync deleted them and stripped the label from every open issue. The three labels are now in the manifest (matching the live colors/descriptions), a comment above them documents the syncer's prune behavior for the next person adding a label by hand, and a new governance test (`tests/config/label-manifest-coverage.test.ts`) fails loud if the manifest ever again drops a label this repo's own rules require. Re-applying the stripped priorities to the 188 already-triaged issues is tracked separately in #2553.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -50,6 +50,22 @@
   color: "0052cc"
   description: Test suite, harnesses, and coverage
 
+# Priority labels
+# NOTE (#2553): .github/workflows/labels.yml runs the label syncer with
+# prune: true on every merge-train post-merge dispatch — it DELETES any live
+# label that is not listed in THIS file. A label added by hand (`gh label
+# create`) or only through the GitHub UI is removed on the next sync. Add a
+# label by editing this file, never by any other means.
+- name: priority:p1
+  color: B60205
+  description: Blocks users or the train
+- name: priority:p2
+  color: D93F0B
+  description: Next release
+- name: priority:p3
+  color: FBCA04
+  description: Backlog
+
 # Triage / workflow labels
 - name: duplicate
   color: cfd3d7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2443,6 +2443,7 @@ All pi packages are `@earendil-works/*` (migrated from `@mariozechner/*` in 0.74
 - **External-contributor issues get priority** — they must not sit unlabeled (a first-time reporter's issue once sat 10 days untouched; see #673).
 - **Label issues you file yourself at creation time**, not in a later sweep.
 - **Every issue carries exactly one `priority:*` label, assigned at triage (#1676).** Priority means dispatch order, honestly: `priority:p1` — the next free worker lane takes it, and a p1 bug blocks the next release (wrong verdicts, silent data loss, crash/hang, host impact). `priority:p2` — the normal queue, batched into themed dispatch waves (hot-path perf with measured numbers, observability gaps with field evidence, contained bugs with workarounds). `priority:p3` — opportunistic: it rides along in a PR already touching the seam, or is `help wanted` material (polish, docs, cold-path costs). Rubric: severity times exposure times evidence — a field-log record upgrades one level; an existing workaround downgrades one. External contributors coordinate on `priority:p2`/`priority:p3` plus `help wanted`; p1 items are usually fleet work.
+- **Labels are created by adding them to `.github/labels.yml`, never by `gh label create` alone** — the Sync labels workflow runs the label syncer with `prune: true` on every merge-train lane merge, which deletes any live label absent from that file (#2553).
 
 ## Commands
 

--- a/tests/config/label-manifest-coverage.test.ts
+++ b/tests/config/label-manifest-coverage.test.ts
@@ -1,0 +1,117 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import yaml from "../../clients/deps/js-yaml.js";
+import { assertNonEmptyScan } from "../support/sweep-kit.js";
+
+/**
+ * `.github/workflows/labels.yml` runs `micnncim/action-label-syncer` with
+ * `prune: true`, dispatched on every merge-train post-merge
+ * (`repository_dispatch: merge-train-post-merge`), against
+ * `.github/labels.yml`. Prune means the manifest is the label set: any live
+ * label absent from it is DELETED on the next sync. #2553's manifest never
+ * listed `priority:p1`/`p2`/`p3`, so every sync silently stripped the
+ * priority label off every open issue (run 34042925533's log, verbatim:
+ * "label: priority:p3 deleted from: apmantza/pi-lens", then p1, p2).
+ *
+ * This sweep is the backstop: it fails loud, before the syncer ever runs,
+ * whenever the manifest drops a label one of this repo's own written rules
+ * requires to exist.
+ */
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..");
+
+interface LabelEntry {
+	name: string;
+	color?: string;
+	description?: string;
+}
+
+function readLabelManifest(): { raw: string; labels: LabelEntry[] } {
+	const raw = readFileSync(resolve(REPO_ROOT, ".github/labels.yml"), "utf8");
+	const labels = yaml.load(raw) as LabelEntry[];
+	return { raw, labels };
+}
+
+/**
+ * The AREA label set AGENTS.md's "Issue triage & labels" section (#1676)
+ * documents, read out of AGENTS.md itself rather than hand-copied here — a
+ * hand-copied list would be exactly the parallel-registry shape the
+ * single-source-of-truth rule forbids, and would silently drift the moment
+ * someone adds an area to AGENTS.md's prose without touching this test.
+ */
+function areaLabelsFromAgentsMd(): string[] {
+	const agentsMd = readFileSync(resolve(REPO_ROOT, "AGENTS.md"), "utf8");
+	const marker = "**AREA (one or more, color `#0052cc`):**";
+	const markerIndex = agentsMd.indexOf(marker);
+	if (markerIndex === -1) {
+		throw new Error(
+			"AGENTS.md's AREA line (#1676, 'Issue triage & labels') was not found " +
+				"at the expected marker — did the doc move or get reworded? Update " +
+				"this sweep's marker to match.",
+		);
+	}
+	const lineEnd = agentsMd.indexOf("\n", markerIndex);
+	const line = agentsMd.slice(
+		markerIndex,
+		lineEnd === -1 ? undefined : lineEnd,
+	);
+	const names = [...line.matchAll(/`(area:[a-z-]+)`/g)].map((m) => m[1]);
+	assertNonEmptyScan(
+		"label-manifest-coverage: AGENTS.md area labels",
+		names.length,
+	);
+	return names;
+}
+
+/**
+ * Every label name this repo's own written rules require to exist, beyond
+ * the AREA set: the three priority labels (#1676's rubric — deleted and
+ * restored once already, #2553), and the merge-train warden's labels
+ * (`.claude/skills/merge-train/SKILL.md`, `AGENTS.md`'s merge-train section).
+ */
+const REQUIRED_NON_AREA_LABELS = [
+	"priority:p1",
+	"priority:p2",
+	"priority:p3",
+	"train:approved",
+	"train:squash",
+	"red-ci",
+	"conflict",
+] as const;
+
+describe("label manifest coverage (#2553)", () => {
+	it("contains every label this repo's rules require to exist", () => {
+		const { labels } = readLabelManifest();
+		assertNonEmptyScan(
+			"label-manifest-coverage: manifest entries",
+			labels.length,
+		);
+		const names = new Set(labels.map((l) => l.name));
+
+		const required = [...REQUIRED_NON_AREA_LABELS, ...areaLabelsFromAgentsMd()];
+		const missing = required.filter((name) => !names.has(name));
+
+		expect(missing).toEqual([]);
+	});
+
+	it("documents the syncer's prune behavior above the priority block", () => {
+		const { raw } = readLabelManifest();
+		const lines = raw.split("\n");
+		const priorityIndex = lines.findIndex((line) =>
+			/^-\s*name:\s*priority:p1\s*$/.test(line.trim()),
+		);
+		expect(priorityIndex).toBeGreaterThan(-1);
+
+		// The documenting comment must sit ABOVE the priority block (so the
+		// next person adding a label by hand sees it before they skip this
+		// file), and must name both "prune" and the issue that found the gap
+		// (#2553) — a comment naming neither is not documentation, just prose.
+		const commentBlockAbove = lines
+			.slice(0, priorityIndex)
+			.filter((line) => /^\s*#/.test(line));
+		const commentText = commentBlockAbove.join("\n");
+		expect(commentText).toMatch(/prune/i);
+		expect(commentText).toMatch(/#2553/);
+	});
+});


### PR DESCRIPTION
## Summary

`.github/workflows/labels.yml` runs `micnncim/action-label-syncer` with
`prune: true` against `.github/labels.yml`, dispatched on every merge-train
post-merge (`repository_dispatch: merge-train-post-merge`). The manifest
never listed `priority:p1`/`p2`/`p3`, so every sync deleted them and stripped
the label off every open issue — reproduced in run 34042925533's log,
verbatim (from issue #2553's latest comment):

```
prune: true
label: priority:p3 deleted from: apmantza/pi-lens
label: priority:p1 deleted from: apmantza/pi-lens
label: priority:p2 deleted from: apmantza/pi-lens
```

This PR stops the recurrence: it adds the three priority labels to the
manifest, documents the syncer's prune behavior in a comment so the next
person adding a label by hand sees the trap, adds a governance test that
fails loud if the manifest ever again drops a label this repo's rules
require, and adds one sentence to AGENTS.md's `#1676` triage rule pointing
at the manifest as the only place to add a label.

**Not in scope** (per the issue): re-applying the stripped `priority:*`
labels to the 188 already-triaged open issues. That is tracked in #2553
itself and is a separate, mechanical restore from each issue's `labeled`
event timeline once this manifest fix is on master — no lane merges until
then per the issue's own note.

Refs #2553 (not `closes` — the re-application of the labels is explicitly
out of scope for this PR and still tracked there).

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [x] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (regression test for the manifest gap)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts` — N/A, no `clients/`/`tools/`/`index.ts` changes
- [x] `package-lock.json` is in sync with `package.json`
- [x] `AGENTS.md` is updated (one sentence added to the `#1676` triage rule)
- [x] `.changelog/2553-restore-priority-labels-manifest.md` has one valid entry (section `Fixed`)
- [x] Commit subject includes the issue number: `Refs #2553` in the trailer

## Tests

**New file:** `tests/config/label-manifest-coverage.test.ts` (2 test cases).

- `contains every label this repo's rules require to exist` — parses
  `.github/labels.yml` and asserts it has every `priority:*` label, the
  merge-train warden labels (`train:approved`, `train:squash`, `red-ci`,
  `conflict`), and every `area:*` label AGENTS.md's `#1676` "Issue triage &
  labels" section documents — the AREA list is read directly out of
  AGENTS.md's own AREA line (regex over the `` `area:xxx` `` backtick spans),
  not hand-copied into the test, so the two can't silently drift apart
  (single-source-of-truth rule).
- `documents the syncer's prune behavior above the priority block` —
  asserts a comment block above the `priority:p1` entry in `labels.yml`
  names both "prune" and "#2553".

**Red-first proof**, run against `origin/master`'s manifest (pre-fix; the
test file and AGENTS.md's `#1676` line came from this branch, only
`.github/labels.yml` and AGENTS.md's AREA-list source were reverted to
`HEAD~1` — this branch's parent, which is `origin/master`):

```
git checkout HEAD~1 -- .github/labels.yml AGENTS.md
npx vitest run tests/config/label-manifest-coverage.test.ts --reporter=verbose

 × |default| tests/config/label-manifest-coverage.test.ts > label manifest coverage (#2553) > contains every label this repo's rules require to exist 9ms
   → expected [ 'priority:p1', 'priority:p2', …(1) ] to deeply equal []
 × |default| tests/config/label-manifest-coverage.test.ts > label manifest coverage (#2553) > documents the syncer's prune behavior above the priority block 1ms
   → expected -1 to be greater than -1

AssertionError: expected [ 'priority:p1', 'priority:p2', …(1) ] to deeply equal []
- Expected
+ Received
- []
+ [
+   "priority:p1",
+   "priority:p2",
+   "priority:p3",
+ ]
 ❯ tests/config/label-manifest-coverage.test.ts:95:19

AssertionError: expected -1 to be greater than -1
 ❯ tests/config/label-manifest-coverage.test.ts:104:25

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

Restored to the fix (`git checkout HEAD -- .github/labels.yml AGENTS.md`),
re-ran: both green.

**Mutation-proof** — neutered each new assertion in the FIXED manifest and
reran the exact same test file, quoting the red:

1. Removed `train:approved` (a non-priority required label) from
   `labels.yml`:
   ```
   AssertionError: expected [ 'train:approved' ] to deeply equal []
    ❯ tests/config/label-manifest-coverage.test.ts:95:19
    Test Files  1 failed (1)
         Tests  1 failed | 1 passed (2)
   ```
2. Removed `area:lsp` (proves the AGENTS.md-derived AREA set is actually
   enforced, not just the hard-coded `REQUIRED_NON_AREA_LABELS`):
   ```
   AssertionError: expected [ 'area:lsp' ] to deeply equal []
    ❯ tests/config/label-manifest-coverage.test.ts:95:19
    Test Files  1 failed (1)
         Tests  1 failed | 1 passed (2)
   ```
3. Removed the prune-documentation comment block above `priority:p1`:
   ```
   AssertionError: expected '# Type labels\n# Area labels\n# Priority labels' to match /prune/i
    ❯ tests/config/label-manifest-coverage.test.ts:114:23
    Test Files  1 failed (1)
         Tests  1 failed | 1 passed (2)
   ```

Each mutation was reverted (`.github/labels.yml` restored byte-for-byte from
a pre-mutation copy) before the next; `git status --short` was clean
against the commit after the last restore, and the full test file reran
green (2 passed) as final confirmation.

### Test assessment

Only one test file is touched in this PR (`tests/config/label-manifest-coverage.test.ts`,
new). No existing test file's assertions became redundant.

## Blast radius

Changed files: `.github/labels.yml` (data only, consumed by the `sync` job
in `.github/workflows/labels.yml`), `AGENTS.md` (prose), `.changelog/*.md`
(new fragment), `tests/config/label-manifest-coverage.test.ts` (new,
governance-only). No `clients/`, `tools/`, `mcp/`, or `index.ts` module is
touched — no production dependency graph, no runtime entry point, no hot
path. The only consumer of `labels.yml` is GitHub's own label-syncer action;
this PR does not change the workflow itself.

## Observability

Not applicable to this PR directly (no telemetry/log changes) — the
observable proof this fix works is negative: the NEXT `Sync labels` run
(triggered by the next merge-train post-merge dispatch) should show zero
`deleted from` lines for `priority:*` in its Action log, where it
previously showed three every time (run 34042925533).

## Class sweep

Defect shape: a hand-maintained manifest (`.github/labels.yml`) that must
mirror every place in the repo's own rules that assumes a label exists, with
`prune: true` turning any gap into an active deletion rather than a passive
staleness. Swept the whole tree for other hand-maintained label-name lists
that could drift from `labels.yml` the same way:

```
grep -rln "priority:p1\|priority:p2\|priority:p3\|labels\.yml" clients/ tools/ mcp/ scripts/ index.ts
  scripts/lib/merge-train-lane.mjs   # POST_MERGE_VALIDATION_WORKFLOWS lists "labels.yml" as a
                                      # workflow FILENAME to validate post-merge dispatch on,
                                      # unrelated to label NAMES — no fold needed
grep -rl "area:lsp" scripts/ tests/support/ mcp/ tools/ clients/ index.ts
  (no matches)
```

No other hand-maintained mirror of the label registry exists. "Class of
size 1" beyond the AREA list itself, which this PR already de-duplicates by
reading it out of AGENTS.md rather than adding a second hand-copied list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y
