### PR TITLE
docs(contracts): blast radius as an optional call-tree diff in the PR body (refs #2585, #2594)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,8 @@ Message-end stale attribution anchors the session id when a live ctx is handled,
 
 **PR body structure is advisory-linted.** Keep `Summary`, `Tests`, `Blast radius`, `Class sweep`, and `Observability` populated — plus `Test assessment` whenever the PR touches `tests/` (see "Test assessment and removal" under Test requirements); `scripts/check-pr-body.mjs` checks structure only, so reviewers still judge the answers.
 
+**Draw the blast radius as a call-tree diff (optional, text only; 2026-09-06).** Prose blast radius keeps missing callers. When a change touches a shared seam, the `Blast radius` section may carry a call-tree diff: the changed symbol, its callers above, its callees below, with `+`/`-` on the lines that moved (`resyncLspFile` / `  touchFile` / `+ getAuxiliaryClientsForFile`). A fix round that changes ordering or control flow shows the before/after as a flow diff of the same shape. The reviewer verifies the tree against grep, which is what the reviewer playbook's neighbourhood rule asks for. Never HTML, Mermaid, or diagrams for their own sake — the smallest text view that makes the reviewer's check mechanical.
+
 ## Contributing
 
 For human contributors and issue/PR authors, see `CONTRIBUTING.md` at the repo root. It covers the development workflow, how to add runners, LSP servers, formatters, and rules, and the issue/PR templates. This `AGENTS.md` is the durable agent context; `CONTRIBUTING.md` is the public contributor guide.


### PR DESCRIPTION
## Summary

One clause added to the PR-body contract in AGENTS.md, right after the structure paragraph: the `Blast radius` section may carry a call-tree diff (changed symbol, callers above, callees below, `+`/`-` on what moved), and a fix round that reorders control flow shows a before/after flow diff. Text only; no HTML or Mermaid. It gives the reviewer's neighbourhood rule (#2601) something mechanical to verify against grep. Motivated by #2585 (the resync reorder) and #2594 (cwd vs `--prefix`), where prose took three paragraphs to say what a six-line diff says.

## Tests

Docs only. No control bytes in the touched file (covered by `tests/config/tracked-control-bytes.test.ts`).

## Blast radius

Contract text; no runtime surface. `scripts/check-pr-body.mjs` is unchanged — the clause is optional.

## Class sweep

No other contract section describes a visual form for PR bodies; the prose contract's "active voice, present tense" still governs the surrounding text.

## Observability

Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y