### PR TITLE
fix(tests): settle hook-await-fold-bounds's abandoned bootstrap loads (closes #2574)

### DIFF
--- a/.changelog/fix-2574-hook-await-fold-abandoned-load.md
+++ b/.changelog/fix-2574-hook-await-fold-abandoned-load.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Deflake `hook-await-fold-bounds` by settling its abandoned bootstrap loads (closes #2574)** — the file's two `clients/bootstrap.ts` cases released their gate and returned while `buildBootstrapClients`'s seventeen-module `Promise.all` was still resolving, so the shared `afterEach`'s `vi.resetModules()` landed on a live import graph. The next case's `await import("../../clients/observed-mutation.js")` then either deadlocked to the 5s suite ceiling (8/20 runs on an idle box) or proceeded with its own `vi.doMock` never applied, which is the `armed: true, scannedCount: 0` in 70ms that CI reported as #2574 and #2596 — a lost mock registration, not a lost timer race. Both cases now await the abandoned load through `loadBootstrapClients()`, which joins the in-flight single-flight rather than starting a second one; no production code or timing changed.

--- a/.changelog/fix-2574-hook-await-fold-fake-timers.md
+++ b/.changelog/fix-2574-hook-await-fold-fake-timers.md
@@ -1,5 +1,0 @@
----
-section: Fixed
----
-
-- **Deflake `hook-await-fold-bounds`'s armed-capture case (closes #2574)** — "records hook-await-exceeded naming the arm when the capture outlives its budget" raced the real `OBSERVED_CAPTURE_BUDGET_MS` (200ms) `setTimeout` inside `bounded()` against the test's never-releasing gate; under load that real race went either way, landing `armed: true` (#2574) or hanging the whole case to the suite's 5s ceiling (#2596). The case now drives `bounded()`'s deadline with `vi.useFakeTimers()` and `vi.advanceTimersByTimeAsync`, so the outcome is decided by a virtual clock the test owns instead of real scheduling.

--- a/.changelog/fix-2574-hook-await-fold-fake-timers.md
+++ b/.changelog/fix-2574-hook-await-fold-fake-timers.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Deflake `hook-await-fold-bounds`'s armed-capture case (closes #2574)** — "records hook-await-exceeded naming the arm when the capture outlives its budget" raced the real `OBSERVED_CAPTURE_BUDGET_MS` (200ms) `setTimeout` inside `bounded()` against the test's never-releasing gate; under load that real race went either way, landing `armed: true` (#2574) or hanging the whole case to the suite's 5s ceiling (#2596). The case now drives `bounded()`'s deadline with `vi.useFakeTimers()` and `vi.advanceTimersByTimeAsync`, so the outcome is decided by a virtual clock the test owns instead of real scheduling.

--- a/tests/clients/hook-await-fold-bounds.test.ts
+++ b/tests/clients/hook-await-fold-bounds.test.ts
@@ -197,6 +197,15 @@ describe("#2523 slice 2 — clients/observed-mutation.ts#withBounds folded onto 
 	}
 
 	it("records hook-await-exceeded naming the arm when the capture outlives its budget", async () => {
+		// #2574/#2596: this case used to race the REAL `OBSERVED_CAPTURE_BUDGET_MS`
+		// (200ms) `setTimeout` inside `bounded()` against this test's
+		// never-releasing gate. Under load that real race went either way — a
+		// fast pass landing `armed: true` before the 200ms fired (#2574), or the
+		// unref'd real timer never getting a scheduling turn at all so the test
+		// hung to the suite's 5s ceiling (#2596, reproduced locally below). A
+		// fake clock this test drives itself removes the dependency on real
+		// scheduling entirely: the deadline fires exactly when this test decides
+		// to advance past it, on every machine under every load.
 		const gate = gateStatsCapture();
 		const ledger = await import("../../clients/degradation-ledger.js");
 		ledger.resetDegradationLedger();
@@ -204,8 +213,16 @@ describe("#2523 slice 2 — clients/observed-mutation.ts#withBounds folded onto 
 		const attribution = await import("../../clients/mutation-attribution.js");
 		observed.resetObservedMutationNet();
 		attribution.resetMutationAttribution();
+		// Enabled only AFTER every dynamic import above has settled: vite-node's
+		// own module resolution leans on a real `setTimeout` internally
+		// (verified empirically — enabling fake timers before these imports
+		// made every run of this case hang to the suite ceiling instead of the
+		// occasional pre-existing flake), and faking it out from under an
+		// in-flight `import()` stalls the import itself rather than the
+		// production code this test means to bound.
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 		try {
-			const armed = await observed.armObservedMutation({
+			const armedPromise = observed.armObservedMutation({
 				toolCallId: "fold-probe-call",
 				toolName: "patch_file",
 				targetPath: "does-not-need-to-exist.ts",
@@ -213,10 +230,19 @@ describe("#2523 slice 2 — clients/observed-mutation.ts#withBounds folded onto 
 				sessionGeneration: 1,
 				turnIndex: 1,
 			});
+			// 10x the production `OBSERVED_CAPTURE_BUDGET_MS` (200ms) — enough
+			// virtual-time margin that the real (unfaked) filesystem work
+			// `collectObservationUniverse` does before reaching the gate cannot
+			// starve the advance, tight enough that a mutation which effectively
+			// removes the timeout (or multiplies the budget past this margin)
+			// still reds the case below (AGENTS.md screen #6).
+			await vi.advanceTimersByTimeAsync(2_000);
+			const armed = await armedPromise;
 			expect(armed).toMatchObject({ armed: false });
 			expect(lastExceededSubject(ledger)).toBe("tool_call:armObservedMutation");
 		} finally {
 			gate.release();
+			vi.useRealTimers();
 		}
 	});
 

--- a/tests/clients/hook-await-fold-bounds.test.ts
+++ b/tests/clients/hook-await-fold-bounds.test.ts
@@ -50,6 +50,13 @@ async function _weakenedWithBoundsWorkDoesNotTypeCheck(): Promise<void> {
 		label: "fold-probe",
 	});
 }
+// `noUnusedLocals` anchor for the probe above, which is never called. This was
+// an `it()` asserting `typeof _weakenedWithBoundsWorkDoesNotTypeCheck ===
+// "function"`; weakening the constraint to plain `T` leaves every runtime case
+// in this file green and reds only `tsc` (TS2578), so the case guarded nothing
+// the probe function did not already guard — deleted in #2574 round 2 under
+// AGENTS.md "Vacuous and trivial tests are deleted in the PR that touches them".
+void _weakenedWithBoundsWorkDoesNotTypeCheck;
 
 /**
  * The subject of the most recent `hook-await-exceeded` row, or `undefined`
@@ -82,6 +89,24 @@ describe("#2523 slice 2 — clients/bootstrap.ts#awaitWithinBounds folded onto b
 	 * the same seam a genuinely slow filesystem stalls it through, and the
 	 * wedge `tests/clients/bootstrap-on-demand.test.ts` already drives this
 	 * module with.
+	 *
+	 * EVERY case that opens this gate must pair `gate.release()` with
+	 * `await bootstrap.loadBootstrapClients()` — the same two lines
+	 * `bootstrap-on-demand.test.ts:266-267` pairs them with, and for the same
+	 * reason read from the other side. `bounded()` abandons the WAIT, not the
+	 * WORK: when these cases return, `buildBootstrapClients`'s seventeen-module
+	 * `Promise.all` is still resolving inside vite-node's module runner, and
+	 * the traced timestamps put the release, the case returning, and the
+	 * `afterEach` above in the SAME millisecond. `doUnmock` + `resetModules`
+	 * then land on a live import graph, and the NEXT case's
+	 * `await import("../../clients/observed-mutation.js")` either deadlocks
+	 * against it (8/20 runs of this file timed out at 5 s) or proceeds with its
+	 * own `doMock` never applied — the `armed: true, scannedCount: 0` in 70 ms
+	 * CI reported as #2574/#2596. Neither is a timer race, which is why a fake
+	 * clock could not fix it. The awaited call joins the flight already
+	 * registered under `BOOTSTRAP_FLIGHT_KEY` (`clients/single-flight.ts`
+	 * shares by key), so it settles the very promise the bound walked away
+	 * from without starting a second load and without touching production.
 	 */
 	function gateOneClientImport(): { release: () => void } {
 		const gate = gatedPromise<void>();
@@ -137,7 +162,9 @@ describe("#2523 slice 2 — clients/bootstrap.ts#awaitWithinBounds folded onto b
 					?.latestReasons.at(-1)?.reason,
 			).toContain("timeout");
 		} finally {
+			// Pair release with settle — see `gateOneClientImport` (#2574).
 			gate.release();
+			await bootstrap.loadBootstrapClients();
 		}
 	});
 
@@ -164,7 +191,9 @@ describe("#2523 slice 2 — clients/bootstrap.ts#awaitWithinBounds folded onto b
 			expect(lastExceededSubject(ledger)).toBeUndefined();
 			expect(ledger.getDegradationSummary()).toEqual([]);
 		} finally {
+			// Pair release with settle — see `gateOneClientImport` (#2574).
 			gate.release();
+			await bootstrap.loadBootstrapClients();
 		}
 	});
 });
@@ -197,15 +226,17 @@ describe("#2523 slice 2 — clients/observed-mutation.ts#withBounds folded onto 
 	}
 
 	it("records hook-await-exceeded naming the arm when the capture outlives its budget", async () => {
-		// #2574/#2596: this case used to race the REAL `OBSERVED_CAPTURE_BUDGET_MS`
-		// (200ms) `setTimeout` inside `bounded()` against this test's
-		// never-releasing gate. Under load that real race went either way — a
-		// fast pass landing `armed: true` before the 200ms fired (#2574), or the
-		// unref'd real timer never getting a scheduling turn at all so the test
-		// hung to the suite's 5s ceiling (#2596, reproduced locally below). A
-		// fake clock this test drives itself removes the dependency on real
-		// scheduling entirely: the deadline fires exactly when this test decides
-		// to advance past it, on every machine under every load.
+		// #2574/#2596 (both the `armed: true, scannedCount: 0` in 70 ms) were
+		// NOT a race between this assertion and the real 200 ms
+		// `OBSERVED_CAPTURE_BUDGET_MS` deadline: the gate below never releases
+		// before the assertion, so with the mock applied `armObservedMutation`
+		// has no path to `armed: true` at all, and the run finished in a third
+		// of the budget. It was the preceding describe's abandoned bootstrap
+		// load colliding with `afterEach`'s `resetModules()` and costing this
+		// case its `doMock` — see `gateOneClientImport` above. The real
+		// deadline is kept deliberately: it is bounded (200 ms) and this case
+		// AWAITS it rather than asserting against a clock, so no scheduling
+		// outcome is left to luck.
 		const gate = gateStatsCapture();
 		const ledger = await import("../../clients/degradation-ledger.js");
 		ledger.resetDegradationLedger();
@@ -213,16 +244,8 @@ describe("#2523 slice 2 — clients/observed-mutation.ts#withBounds folded onto 
 		const attribution = await import("../../clients/mutation-attribution.js");
 		observed.resetObservedMutationNet();
 		attribution.resetMutationAttribution();
-		// Enabled only AFTER every dynamic import above has settled: vite-node's
-		// own module resolution leans on a real `setTimeout` internally
-		// (verified empirically — enabling fake timers before these imports
-		// made every run of this case hang to the suite ceiling instead of the
-		// occasional pre-existing flake), and faking it out from under an
-		// in-flight `import()` stalls the import itself rather than the
-		// production code this test means to bound.
-		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 		try {
-			const armedPromise = observed.armObservedMutation({
+			const armed = await observed.armObservedMutation({
 				toolCallId: "fold-probe-call",
 				toolName: "patch_file",
 				targetPath: "does-not-need-to-exist.ts",
@@ -230,26 +253,11 @@ describe("#2523 slice 2 — clients/observed-mutation.ts#withBounds folded onto 
 				sessionGeneration: 1,
 				turnIndex: 1,
 			});
-			// 10x the production `OBSERVED_CAPTURE_BUDGET_MS` (200ms) — enough
-			// virtual-time margin that the real (unfaked) filesystem work
-			// `collectObservationUniverse` does before reaching the gate cannot
-			// starve the advance, tight enough that a mutation which effectively
-			// removes the timeout (or multiplies the budget past this margin)
-			// still reds the case below (AGENTS.md screen #6).
-			await vi.advanceTimersByTimeAsync(2_000);
-			const armed = await armedPromise;
 			expect(armed).toMatchObject({ armed: false });
 			expect(lastExceededSubject(ledger)).toBe("tool_call:armObservedMutation");
 		} finally {
 			gate.release();
-			vi.useRealTimers();
 		}
-	});
-
-	it("keeps withBounds's T extends object constraint referenced (see _weakenedWithBoundsWorkDoesNotTypeCheck above)", () => {
-		// The compile-time half is the load-bearing assertion; this reference
-		// only keeps `noUnusedLocals` from flagging the probe function above.
-		expect(typeof _weakenedWithBoundsWorkDoesNotTypeCheck).toBe("function");
 	});
 
 	it("reports `aborted`, not `timeout`, when the signal fires mid-capture", async () => {


### PR DESCRIPTION
## Summary

`tests/clients/hook-await-fold-bounds.test.ts` flakes two ways — the
`armed: true, scannedCount: 0` CI failure #2574/#2596 report, and a
`Test timed out in 5000ms` at the same case. Both come from the same writer,
and it is not a clock.

`bounded()` abandons the WAIT, not the WORK. The file's two
`clients/bootstrap.ts` cases call `gate.release()` and return in the SAME
millisecond, while `buildBootstrapClients`'s seventeen-module `Promise.all` is
still resolving inside vite-node's module runner. The shared `afterEach` then
runs `vi.doUnmock` + `vi.resetModules()` over that live import graph, and the
next case's `await import("../../clients/observed-mutation.js")` either
deadlocks against it or proceeds with its own `vi.doMock` never applied.

Both bootstrap cases now pair `gate.release()` with an awaited
`bootstrap.loadBootstrapClients()` — the same two lines
`tests/clients/bootstrap-on-demand.test.ts:266-267` already pairs at every one
of its gated sites. That call joins the flight already registered under
`BOOTSTRAP_FLIGHT_KEY` (`clients/single-flight.ts` shares by key), so it
settles the very promise the bound walked away from without starting a second
load. **No production code and no production timing changed.**

**Round 1's premise was wrong and is reverted here.** It read #2574 as a lost
race against the real 200 ms `OBSERVED_CAPTURE_BUDGET_MS` deadline and
converted the arm case to `vi.useFakeTimers()`. The gate that case installs
never releases before the assertion, so with its `doMock` applied
`armObservedMutation` has no path to `armed: true` at all; CI finished in
**70 ms**, a third of the budget. A fake clock cannot fix a mock that never
registered.

Closes #2574 (see the F3 decision at the bottom). #2596 is already closed as a
duplicate of it and is the same shape, not a hang.

**Merge order**: no interaction with any other open PR. `gh pr list` shows no
other open PR touching `tests/clients/hook-await-fold-bounds.test.ts`,
`tests/clients/bootstrap-on-demand.test.ts`, or `clients/bootstrap.ts`.

## State space — the module registry across this file's tests

Written before any edit in this round (AGENTS.md line 108, "Design the state
space before coding"); it was pushed to this body as its own commit-less update
ahead of the fix.

### Axes

| Axis | Values |
| --- | --- |
| **M-ruff** | `vi.doMock("../../clients/ruff-client.js")` registered in the current registry — yes / no |
| **M-opaque** | `vi.doMock("../../clients/opaque-mutation-scan.js")` registered in the current registry — yes / no |
| **L** | the bootstrap client-module load (`buildBootstrapClients`'s seventeen-module `Promise.all`, gated at `ruff-client`) — not started / in-flight / settled / **abandoned-in-flight** |
| **R** | `vi.resetModules()` run since the mock was registered — yes / no |

### Writers

| # | Writer | What it writes |
| --- | --- | --- |
| W1 | top-level `beforeEach` | `vi.resetModules()` → fresh registry, **R:=yes** |
| W2 | `gateOneClientImport()` | **M-ruff:=yes**, with a factory that blocks on a gate |
| W3 | `gateStatsCapture()` | **M-opaque:=yes**, with a factory returning a gated `captureFileStatsForPaths` |
| W4 | each case's `await import(...)` | materializes the graph in the current registry, running whichever factory is registered |
| W5 | `requestBootstrapClients(...)` → `bounded(loadBootstrapClients(), …)` | starts the load; on deadline/signal `bounded()` **abandons the wait, not the work** → **L:=abandoned-in-flight** |
| W6 | `gate.release()` in each `finally` | unblocks the blocked factory, so the abandoned graph resumes loading — **unsynchronized with the test returning on the next line** |
| W7 | top-level `afterEach` | `doUnmock(ruff)`, `doUnmock(opaque)`, `vi.resetModules()` — **runs over whatever W6 left in flight** |

The defect is entirely in the W5 → W6 → W7 sequence.

### Cells — for the case under repair (`records hook-await-exceeded naming the arm when the capture outlives its budget`)

It is the first case of the second describe, so its inherited state is "what the
two `gateOneClientImport()` cases left behind".

| # | Predecessor state | L at the preceding `afterEach` | Arm case sees its `opaque-mutation-scan` mock? | Arm case's `await import("observed-mutation.js")` settles? | Evidence |
| --- | --- | --- | --- | --- | --- |
| 1 | no bootstrap case ran (arm case alone, `-t`) | n/a | **yes** | **yes** | reviewer: 10/10 green |
| 2 | exactly one bootstrap case ran, its load settled before `afterEach` | settled | **yes** | **yes** | reviewer: 8/8 green with either bootstrap case alone |
| 3 | both ran, both loads settled before `afterEach` | settled | **yes** | **yes** | the green runs of the full file |
| 4 | ≥1 abandoned load still in flight at `afterEach` — **deadlock resolution** | abandoned-in-flight | **no — the factory is never entered** | **NO**: hangs to the 5 s ceiling at `:199` | traced below; **8/20 runs of the PR head** |
| 5 | ≥1 abandoned load still in flight at `afterEach` — **lost-registration resolution** | abandoned-in-flight | **NO** — the arm case imports the REAL `opaque-mutation-scan` | yes, fast | CI run 33809798133 attempt 1, job 100828725390: `armed: true, scannedCount: 0` in **70 ms** |

Cells 4 and 5 are the same collision resolving two ways. **After this PR, cells
4 and 5 are unreachable**: W6 no longer leaves L in `abandoned-in-flight` when
W7 runs, so every cell collapses to cells 1–3.

### Cell-4 trace (PR head `33fbc0cf`, traced copy of the file, run 4 of 10)

```
1788714181336 BOOT1 start
1788714181392 BOOT1 releasing gate
1788714181392 BOOT1 done
1788714181393 afterEach: doUnmock + resetModules
1788714181395 BOOT2 start
1788714181422 BOOT2 releasing gate
1788714181423 BOOT2 done
1788714181423 afterEach: doUnmock + resetModules
1788714181424 ARM start
1788714181424 ARM after gateStatsCapture
1788714181435 ARM after ledger import
1788714186428 afterEach: doUnmock + resetModules      <- +5000ms, the test timed out
1788714186429 afterEach: doUnmock + resetModules
1788714186438 opaque doMock factory ENTERED           <- the import only proceeds AFTER teardown
1788714186443 afterEach: doUnmock + resetModules
1788714186444 mocked captureFileStatsForPaths CALLED
```

`BOOT1`/`BOOT2` each release their gate and return in the SAME millisecond the
`afterEach` fires — the `Promise.all` is unambiguously still resolving when
`resetModules()` lands on it. The arm case's `import()` never completes; the
`doMock` factory is not even entered until after the timeout tears the test
down. (Probe ran under `PI_LENS_HOME=<worktree>/.probe-home`; the traced copy
and the probe home were deleted before commit and are not in the diff.)

### Cell-5 reproduced deterministically

Forcing the mock to be unapplied (retarget `gateStatsCapture`'s `vi.doMock`
specifier to a path that matches nothing) reproduces CI's exact shape from a
clean run, and the case's own assertion is the detector:

```
FAIL  |wall-clock-budget| tests/clients/hook-await-fold-bounds.test.ts > #2523 slice 2 — clients/observed-mutation.ts#withBounds folded onto bounded() > records hook-await-exceeded naming the arm when the capture outlives its budget
AssertionError: expected { armed: true, scannedCount: +0, …(1) } to match object { armed: false }
- Expected
+ Received
  {
-   "armed": false,
+   "armed": true,
  }
 ❯ tests/clients/hook-await-fold-bounds.test.ts:255:18
   Duration  549ms (transform 202ms, setup 17ms, import 269ms, tests 18ms, environment 0ms)
```

`armed: true, scannedCount: 0` in 17 ms of test time, matching CI's 70 ms
wall — and note this is the case's PRE-EXISTING assertion, which is why no new
test is added for cell 5: the detector was never missing, the cause was.

## Before / after — the full file, 20+ runs each

Same clean worktree, idle 32-core box.

**Before** (PR head `33fbc0cf`, 20 runs, `/proc/loadavg` 0.98 → 1.84):

```
PRE-FIX FAILURES: 8/20
```
all eight identical:
```
Error: Test timed out in 5000ms.
 ❯ tests/clients/hook-await-fold-bounds.test.ts:199:2
```

**After** (this head, 25 runs, loadavg 2.40 → 2.31, then a second 25-run series
after the vacuous-case deletion, loadavg → 3.93):

```
POST-FIX FAILURES: 0/25
FINAL POST-FIX FAILURES: 0/25
```

50 consecutive green runs of the full file, 0 failures.

## Fix

`tests/clients/hook-await-fold-bounds.test.ts` only:

1. Both `gateOneClientImport()` cases' `finally` now read
   `gate.release(); await bootstrap.loadBootstrapClients();`.
2. `gateOneClientImport`'s doc comment states the pairing requirement and why,
   naming the sibling site that already does it.
3. The round-1 fake-timer conversion of the arm case is REVERTED
   (`vi.useFakeTimers`, `vi.advanceTimersByTimeAsync(2_000)`,
   `vi.useRealTimers()` all gone). See "Does the fake clock still earn its
   place" below.
4. One vacuous case deleted — see `Test assessment`.

## Type of change

- [x] Bug fix

## Area

- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (this IS the test fix — see Tests below)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted above (this is a deflake: the "red" is the 8/20 pre-fix reproduction plus the deterministic cell-5 reproduction, both quoted)
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test — transcript in `Mutation-proof`, run against the SHIPPED form of the code
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts` — N/A, no production code touched
- [x] `package-lock.json` is in sync with `package.json`
- [ ] `AGENTS.md` is updated — N/A, no new convention introduced (the pairing rule is documented at the seam that needs it)
- [x] `.changelog/fix-2574-hook-await-fold-abandoned-load.md` — validated with `node scripts/check-changelog-fragments.mjs`: `changelog fragments OK (120 entries in .changelog/)`
- [x] Commit subject includes the issue number

## Tests

**Edited**: `tests/clients/hook-await-fold-bounds.test.ts` — no new case; two
existing cases gain one awaited line each, one case loses the round-1 fake
timers, one vacuous case deleted.

- `records hook-await-exceeded naming the demand when the load outlives the wait`
  and `settles on the caller's abort without waiting the budget out, and records
  nothing`: the two writers of the defect. Each now settles the load it
  abandoned before returning. What they pin is unchanged (the `bounded()` fold's
  ledger subject, and the abort bound's elapsed margin).
- `records hook-await-exceeded naming the arm when the capture outlives its
  budget`: back to master's shape plus a comment recording the real cause. It
  pins that `observed-mutation.ts#withBounds` writes `hook-await-exceeded`
  naming `tool_call:armObservedMutation` — the assertion that separates the fold
  from a hand-rolled race.

AGENTS.md test-authoring screens: screen #5 (env/mock mutation must not outlive
the test) is what this PR is ABOUT — the round-1 version satisfied it for fake
timers while the file was already violating it for the module registry, which
is the leak that actually mattered. Screen #6 (loose bound) is why the fake
timers came out: the arm case has no timing assertion, it `await`s a bound the
production code caps at 200 ms, so there is no margin left to be loose about.

### Does the fake clock still earn its place? No — reverted.

The reviewer asked this explicitly. The round-1 conversion was mutation-live at
the timer seam only circularly: with fake timers armed, the deadline cannot fire
unless the test advances it, so of course deleting the advance reds. Under real
timers the same mutations still red — quoted in `Mutation-proof` below, the
`timeoutMs` neuter reds identically without a virtual clock. No stated cell in
the table above needs a virtual clock: the arm case does not assert on elapsed
time, it awaits a 200 ms-bounded call. So the conversion was machinery with no
cell behind it and it is gone (AGENTS.md minimalism ladder, rung 1).

### Test assessment

**`tests/clients/hook-await-fold-bounds.test.ts`** — uniquely pins that
`clients/bootstrap.ts#requestBootstrapClients` and
`clients/observed-mutation.ts#withBounds` are bounded THROUGH
`clients/deadline-utils.ts#bounded` rather than through a hand-rolled copy, by
asserting the `hook-await-exceeded` ledger subject only `bounded()` writes; and
that a caller abort is absent from the ledger on both kinds.

**Deleted (vacuous, no survivor owed):**
`it("keeps withBounds's T extends object constraint referenced …")`, which
asserted `expect(typeof _weakenedWithBoundsWorkDoesNotTypeCheck).toBe("function")`.
Mutation sweep — weaken the constraint at `clients/observed-mutation.ts:490`
(`withBounds<T extends object>` → `withBounds<T>`), rebuild, run the file:

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  1.08s (transform 1.62s, setup 13ms, import 281ms, tests 560ms, environment 0ms)
```

Every runtime case green — the case reds on no mutation of the code it names
and asserts a constant against itself (AGENTS.md: "Vacuous and trivial tests are
deleted in the PR that touches them"). The load-bearing half is the
`@ts-expect-error` in the never-called probe function, and it survives: under
the same mutation, with the `it()` already deleted,

```
tests/clients/hook-await-fold-bounds.test.ts(46,2): error TS2578: Unused '@ts-expect-error' directive.
```

The `noUnusedLocals` anchor the deleted case existed to provide is now one
module-scope `void` reference. No other case in this file reds on no mutation:
the two bootstrap cases and the arm case each red under the `Mutation-proof`
probes below, and the mid-capture-abort case reds on deleting `isAborted()` per
its own comment.

## Mutation-proof

Run against the SHIPPED form of the code (inlined pairing, not the helper an
earlier draft had), rebuilt each time, restored after; `git status --short` is
clean.

**1. Delete the fix — remove BOTH `await bootstrap.loadBootstrapClients();`
lines from the two `finally` blocks** (the guard this PR adds):

```
 FAIL  |wall-clock-budget| tests/clients/hook-await-fold-bounds.test.ts > #2523 slice 2 — clients/observed-mutation.ts#withBounds folded onto bounded() > records hook-await-exceeded naming the arm when the capture outlives its budget
Error: Test timed out in 5000ms.
 ❯ tests/clients/hook-await-fold-bounds.test.ts:226:2
MUTATION 1 FAILURES: 11/20
```

11/20 red vs 0/25 green on the shipped code — the fix is not inert. (The guard is
probabilistic by nature: it removes a race, so its mutation proof is a failure
RATE, not a single deterministic red. The deterministic half is the cell-5
reproduction quoted above.)

**2. Neuter the effective timeout** (`clients/observed-mutation.ts`,
`const timeoutMs = Math.min(remaining, OBSERVED_CAPTURE_BUDGET_MS);` →
`999_000`) — re-run on THIS head to prove it still reds WITHOUT the fake clock,
which is the whole justification for reverting the conversion:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  |wall-clock-budget| tests/clients/hook-await-fold-bounds.test.ts > #2523 slice 2 — clients/observed-mutation.ts#withBounds folded onto bounded() > records hook-await-exceeded naming the arm when the capture outlives its budget
Error: Test timed out in 5000ms.
 ❯ tests/clients/hook-await-fold-bounds.test.ts:228:2
      Tests  1 failed | 3 passed (4)
```

**3. Weaken `withBounds<T extends object>` to `<T>`** — reds `tsc`, not vitest,
which is exactly what justifies deleting the `it()` (transcript in
`Test assessment`).

## Blast radius

Test-only. Zero production modules touched — `git diff origin/master...HEAD
--stat` is `.changelog/` plus one test file. `module_report` blast radius is
not applicable: no production module changed. Verification plan is the 50
consecutive green runs above plus CI.

## Observability

N/A — test-only; no production behavior, logging, or ledger record changed.

## Class sweep

**Shape**: a test that suspends a module's evaluation with a gated `vi.doMock`
factory, releases the gate WITHOUT awaiting the import graph it unblocks, and
lets a shared `beforeEach`/`afterEach` `vi.resetModules()` run over the still-
resolving graph. This is AGENTS.md's shape family for state that outlives the
test that created it (test-authoring screen #5) read at the module-registry
layer rather than the env/mock layer.

Swept the WHOLE tree — `tests/`, `clients/`, `tools/`, `mcp/`, `scripts/`,
`scripts/lib/`, `tests/support/`, `index.ts` — for both the symbol
(`gatedPromise`, `vi.doMock`, `resetModules`, `loadBootstrapClients`) and the
pattern (a `doMock` factory that `await`s a gate). `vi.doMock` exists only under
`tests/`, so the production directories contribute no members.

Population — every `doMock` factory in the repo that awaits a gate:

```
$ grep -rn -A4 "vi\.doMock(" tests/ clients/ tools/ mcp/ scripts/ index.ts | grep -B2 "await gate\."
tests/clients/bootstrap-on-demand.test.ts:52:	vi.doMock("../../clients/ruff-client.js", async (importOriginal) => {
tests/clients/bootstrap-on-demand.test.ts-53-		await gate.promise;
tests/clients/hook-await-fold-bounds.test.ts:88:		vi.doMock("../../clients/ruff-client.js", async (importOriginal) => {
tests/clients/hook-await-fold-bounds.test.ts-89-			await gate.promise;
```

Per-member verdict — **class of size 2, one already correct**:

- `tests/clients/bootstrap-on-demand.test.ts` — **already compliant**. Every one
  of its gated cases pairs `gate.release()` with an awaited load
  (`:149-150`, `:266-267`, `:298-299`, `:334+338`, `:371-372`, `:388-389`,
  `:411-412`). It is the site this PR copies, not a second defect.
- `tests/clients/hook-await-fold-bounds.test.ts` — **the one defective member**,
  fixed here.

Adjacent near-misses, checked and excluded with the reason:

- `tests/clients/lsp/service-runtime-exit-breaker.test.ts` — the only other file
  combining `gatedPromise` with `resetModules`, but its gate wedges a CLIENT
  METHOD (`client.notify.open`), not a `doMock` module factory, so no import
  graph is left in flight. Not the shape.
- The other eleven `gatedPromise` files (`dead-code-client`,
  `dependency-checker-inflight-aba`, `formatters-signature-warm-path`,
  `jscpd-client`, `knip-client`, `lsp/client-internals`, `mcp/session`,
  `package-manager`, `pipeline-lsp-sync`, `security-scan-client-inflight-aba`,
  `tests/support/fault-injection*`) — none calls `vi.resetModules()`, so there
  is no registry swap to collide with. Not the shape.

**Consolidation verdict**: the family stays distributed. Two members, one of
which is already correct; the invariant is one awaited line at the release site,
and folding two call sites onto a shared helper is strictly more code than the
two lines it would replace (an earlier draft of this PR HAD that helper and it
was deleted on the pre-report ladder re-climb). The requirement is documented at
`gateOneClientImport`'s doc comment, where the next author of a gated case in
this file will read it. **No new governance sweep is added**: a detector for
this would have to distinguish "a gated `doMock` released without awaiting its
graph" from ordinary async test code, which needs call-graph semantics rather
than a grep — the same reason #2574's own floated "budget races on a real clock"
detector was declined in round 1, and AGENTS.md's ladder rung 1 ("does it need
to exist") with a population of two.

**Reviewer's named output**: the brief asked for a follow-up issue on the
"abandoned-load / `resetModules` deadlock as its own defect class" *only if this
fix does not already remove it*. It does remove it, at the only site that had
it — cells 4 and 5 are unreachable after this PR, the sweep above shows the
population is 2 with the other member already correct, and 50/50 green runs
confirm it. **No issue filed.** If a future third site wants the invariant
enforced mechanically rather than by the doc comment, that is the moment to file
it, with a population large enough to justify a detector.

## Review round 2 — findings

| Finding | Status | What changed |
| --- | --- | --- |
| **F1** — the real CI failure is `armed: true` at 70 ms, so the mock did not apply; a fake clock cannot fix it | **Fixed** | Reproduced (cell-5 transcript above, deterministic). Round 1's premise is retracted in the Summary, the commit message, the changelog fragment, and the test's own comment. |
| **F2** — 9/12 `Test timed out` on the PR head; the abort/timeout bootstrap cases abandon in-flight loads across `resetModules` | **Fixed** | Reproduced independently: 8/20 on the PR head, with a trace pinpointing the stalled `import()` and the same-millisecond release/`afterEach` collision. Remedy taken: **await the abandoned load in the test** through the existing `loadBootstrapClients()` seam — no production change, no file split. Splitting the describes was not needed and would have hidden the invariant rather than stating it. 0/25 and 0/25 after. |
| **F3** — `closes` only if ≥20/20 green and the CI shape is explained by a cell | **Met → `closes`** | 50 consecutive green runs (two independent 25-run series); the CI shape is cell 5 and is reproduced deterministically. |
| **F4** — the body cited `pipeline-lsp-sync.test.ts` as a fake-timer precedent; that file REJECTS the idiom | **Fixed** | The claim is gone with the whole round-1 body. The fake-timer conversion it was defending is also gone, so no precedent is being claimed at all. |
| **F5** — the test comment and changelog said #2596 was "hanging the whole case"; it is the `armed: true` shape | **Fixed** | Both corrected. The comment at the arm case now states #2574 and #2596 are the same `armed: true, scannedCount: 0` shape; the changelog fragment was rewritten and its filename changed from `…-fake-timers.md` to `…-abandoned-load.md` so it no longer names a fix that is not in the PR. |
| **Reviewer's named output** (file the deadlock defect-class issue only if not already removed) | **Not filed, with reason** | See the Class sweep verdict above. |

### Verification run on this head

- `npm run build` — clean.
- `tests/clients/hook-await-fold-bounds.test.ts` — 25 runs, 0 failures; then 25
  more after the vacuous-case deletion, 0 failures. 4 tests (was 5).
- Governance batch, selected mechanically —
  `ls tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts tests/config/*.test.ts`
  → **56 files**, plus the 5 neighbour files below = **61 files, 840 tests, all
  passing** (`npm run test:targeted`, foreground).
- Neighbours run with them: `tests/clients/bootstrap-on-demand.test.ts`,
  `tests/clients/bounded-hook-await.test.ts`,
  `tests/clients/observed-mutation-net.test.ts`,
  `tests/clients/observed-mutation-integration.test.ts`,
  `tests/config/hook-await-bounds.test.ts`.
- `tests/clients/flake-shape-ratchet.test.ts` — green with the baseline
  UNCHANGED. `tests/support/flake-shape-baseline.json` keeps
  `"clients/hook-await-fold-bounds.test.ts": 1` (the file header's
  `elapsed-time-assertion`); this PR adds no timer/clock shape and removes none,
  so the pin did not need to move. `vitest.config.ts:316` still lists the file
  in `wallClockBudgetInclude`.
- `tests/config/timing-sensitive-coverage.test.ts` — green.
- `npm run lint` — clean. `npx oxfmt --check` (v0.65.0, the pinned
  devDependency) on every touched file — `All matched files use the correct
  format.`
- `node scripts/check-changelog-fragments.mjs` — `changelog fragments OK (120
  entries in .changelog/)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y
