### PR TITLE
test: rename legacy "should" test names to behavior statements (closes #2602)

### DIFF
--- a/.changelog/2602-rename-should-test-names.md
+++ b/.changelog/2602-rename-should-test-names.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Test names state behavior, not hope (closes #2602)** — the ~50 remaining `it("should …")` / `test("should …")` names under `tests/` are renamed to declarative present-tense behavior statements ("does X if Y") per AGENTS.md test-authoring screen 11. String-only rename: no assertion, fixture, or ordering changes.

--- a/.changelog/2602-rename-should-test-names.md
+++ b/.changelog/2602-rename-should-test-names.md
@@ -2,4 +2,4 @@
 section: Changed
 ---
 
-- **Test names state behavior, not hope (closes #2602)** — the ~50 remaining `it("should …")` / `test("should …")` names under `tests/` are renamed to declarative present-tense behavior statements ("does X if Y") per AGENTS.md test-authoring screen 11. String-only rename: no assertion, fixture, or ordering changes.
+- **Test names state behavior, not hope (closes #2602)** — the 58 `it("should …")` / `test("should …")` names under `tests/` (including mid-string, not just leading, `should`) are renamed to declarative present-tense behavior statements ("does X if Y") per AGENTS.md test-authoring screen 11, and one exact duplicate test case is deleted. String-only rename elsewhere: no assertion, fixture, or ordering changes — except seven inert fixture-wrapper strings in `tree-sitter-new-blocker-rules.test.ts`, which are TypeScript source content fed to a tree-sitter query that never inspects them.

--- a/tests/clients/dispatch/dispatcher-flow.test.ts
+++ b/tests/clients/dispatch/dispatcher-flow.test.ts
@@ -56,7 +56,7 @@ describe("Dispatch Flow", () => {
 	});
 
 	describe("Runner Registration", () => {
-		it("should register and retrieve runner", () => {
+		it("registers and retrieves a runner by id", () => {
 			const runner = createCleanRunner("test-runner");
 			registerRunner(runner);
 
@@ -65,12 +65,12 @@ describe("Dispatch Flow", () => {
 			expect(retrieved?.id).toBe("test-runner");
 		});
 
-		it("should return undefined for unknown runner", () => {
+		it("returns undefined for an unregistered runner id", () => {
 			const runner = getRunner("non-existent");
 			expect(runner).toBeUndefined();
 		});
 
-		it("should get runners for specific file kind", () => {
+		it("returns only runners registered for the requested file kind", () => {
 			registerRunner(
 				createMockRunner({
 					id: "ts-runner",
@@ -118,7 +118,7 @@ describe("Dispatch Flow", () => {
 			]);
 		});
 
-		it("should sort runners by priority", () => {
+		it("sorts runners by ascending priority", () => {
 			registerRunner(
 				createMockRunner({
 					id: "low",
@@ -162,7 +162,7 @@ describe("Dispatch Flow", () => {
 	});
 
 	describe("Dispatch Execution", () => {
-		it("should execute single runner and return diagnostics", async () => {
+		it("executes a single runner and returns its diagnostics", async () => {
 			registerRunner(createWarningRunner("mock-linter"));
 
 			const ctx = createMockContext("test.ts");
@@ -305,7 +305,7 @@ describe("Dispatch Flow", () => {
 			expect(result.output).toContain("Pi-lens go analysis unavailable");
 		});
 
-		it("should execute multiple runners in group", async () => {
+		it("executes every runner in a group and aggregates diagnostics", async () => {
 			registerRunner(createWarningRunner("runner-1"));
 			registerRunner(createFailingRunner("runner-2"));
 			registerRunner(createCleanRunner("runner-3"));
@@ -465,7 +465,7 @@ describe("Dispatch Flow", () => {
 			expect(result.diagnostics[0].tool).toBe("lsp");
 		});
 
-		it("should skip unregistered runners gracefully", async () => {
+		it("skips an unregistered runner id without throwing", async () => {
 			registerRunner(createCleanRunner("registered"));
 
 			const ctx = createMockContext("test.ts");
@@ -587,7 +587,7 @@ describe("Dispatch Flow", () => {
 	});
 
 	describe("Delta Mode (Baseline Filtering)", () => {
-		it("should filter pre-existing issues in delta mode", async () => {
+		it("filters out baseline issues in delta mode", async () => {
 			const facts = new FactStore();
 			setBaselineFacts(facts, "/project/test.ts", [
 				{
@@ -640,7 +640,7 @@ describe("Dispatch Flow", () => {
 			expect(result.diagnostics[0].id).toBe("new-issue");
 		});
 
-		it("should report all issues when delta mode disabled", async () => {
+		it("reports baseline issues when delta mode is disabled", async () => {
 			const facts = new FactStore();
 			setBaselineFacts(facts, "/project/test.ts", [
 				{
@@ -808,7 +808,7 @@ describe("Dispatch Flow", () => {
 	});
 
 	describe("Conditional Runners (when)", () => {
-		it("should run conditional runner when condition true", async () => {
+		it("skips the conditional runner because autofix is always disabled", async () => {
 			registerRunner(
 				createConditionalRunner("conditional", (ctx) => ctx.autofix),
 			);
@@ -835,7 +835,7 @@ describe("Dispatch Flow", () => {
 			expect(result.diagnostics).toHaveLength(0);
 		});
 
-		it("should skip conditional runner when condition false", async () => {
+		it("skips the conditional runner when its condition evaluates to false", async () => {
 			registerRunner(
 				createConditionalRunner("conditional", (ctx) => ctx.autofix),
 			);
@@ -857,7 +857,7 @@ describe("Dispatch Flow", () => {
 			expect(result.diagnostics).toHaveLength(0);
 		});
 
-		it("should skip runner when when() throws and continue others", async () => {
+		it("skips a runner whose when() throws and continues with the others", async () => {
 			registerRunner(
 				createMockRunner({
 					id: "throws-when",

--- a/tests/clients/dispatch/dispatcher-flow.test.ts
+++ b/tests/clients/dispatch/dispatcher-flow.test.ts
@@ -510,7 +510,7 @@ describe("Dispatch Flow", () => {
 			expect(result.diagnostics[0].filePath).toContain("src/main.ts");
 		});
 
-		it("fallback mode should continue after failed runner and use next success", async () => {
+		it("fallback mode continues after a failed runner and uses the next success", async () => {
 			const calls: string[] = [];
 			registerRunner({
 				id: "first-fail",
@@ -808,33 +808,6 @@ describe("Dispatch Flow", () => {
 	});
 
 	describe("Conditional Runners (when)", () => {
-		it("skips the conditional runner because autofix is always disabled", async () => {
-			registerRunner(
-				createConditionalRunner("conditional", (ctx) => ctx.autofix),
-			);
-
-			// autofix is now always false (per-tool autofix flags removed)
-			const mockPi = {
-				getFlag: () => false,
-			};
-			const ctx = createDispatchContext(
-				"test.ts",
-				"/project",
-				mockPi,
-				new FactStore(),
-			);
-			const groups: RunnerGroup[] = [
-				{ mode: "all", runnerIds: ["conditional"] },
-			];
-
-			const result = await dispatchForFile(ctx, groups);
-
-			// autofix is always false now (feature removed)
-			expect(ctx.autofix).toBe(false);
-			// Conditional runner skips when autofix is false
-			expect(result.diagnostics).toHaveLength(0);
-		});
-
 		it("skips the conditional runner when its condition evaluates to false", async () => {
 			registerRunner(
 				createConditionalRunner("conditional", (ctx) => ctx.autofix),

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -1873,7 +1873,7 @@ describe('#1533 — silent auxiliary honesty on clientScope "all"', () => {
 		expect(result?.confirmation).toBeUndefined();
 	});
 
-	it("case 2 — a fast silent aux beside a SLOWER primary does newly narrow, and should", async () => {
+	it("case 2 — a fast silent aux beside a slower primary narrows to partial, not confirmed", async () => {
 		// The counter-case to the test above, and the honest half of the blast radius.
 		// rust-analyzer declares 3000 and typos 1500, so under a 2000ms cap:
 		//   timeoutFor(rust-analyzer) = min(2000, 3000) = 2000

--- a/tests/clients/session-start-parallelism.test.ts
+++ b/tests/clients/session-start-parallelism.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
  * After the fix: ensureAvailable() uses async safeSpawnAsync, non-blocking.
  */
 describe("tool availability async patterns", () => {
-	it("ruff-client ensureAvailable should return a Promise", async () => {
+	it("ruff-client ensureAvailable returns a Promise", async () => {
 		const { RuffClient } = await import("../../clients/ruff-client.js");
 		const client = new RuffClient();
 
@@ -19,7 +19,7 @@ describe("tool availability async patterns", () => {
 		expect(typeof result.then).toBe("function");
 	});
 
-	it("biome-client ensureAvailable should return a Promise", async () => {
+	it("biome-client ensureAvailable returns a Promise", async () => {
 		const { BiomeClient } = await import("../../clients/biome-client.js");
 		const client = new BiomeClient();
 
@@ -28,7 +28,7 @@ describe("tool availability async patterns", () => {
 		expect(typeof result.then).toBe("function");
 	});
 
-	it("knip-client ensureAvailable should return a Promise", async () => {
+	it("knip-client ensureAvailable returns a Promise", async () => {
 		const { KnipClient } = await import("../../clients/knip-client.js");
 		const client = new KnipClient();
 
@@ -37,7 +37,7 @@ describe("tool availability async patterns", () => {
 		expect(typeof result.then).toBe("function");
 	});
 
-	it("jscpd-client ensureAvailable should return a Promise", async () => {
+	it("jscpd-client ensureAvailable returns a Promise", async () => {
 		const { JscpdClient } = await import("../../clients/jscpd-client.js");
 		const client = new JscpdClient();
 
@@ -46,7 +46,7 @@ describe("tool availability async patterns", () => {
 		expect(typeof result.then).toBe("function");
 	});
 
-	it("dependency-checker ensureAvailable should return a Promise", async () => {
+	it("dependency-checker ensureAvailable returns a Promise", async () => {
 		const { DependencyChecker } =
 			await import("../../clients/dependency-checker.js");
 		const client = new DependencyChecker();
@@ -56,7 +56,7 @@ describe("tool availability async patterns", () => {
 		expect(typeof result.then).toBe("function");
 	});
 
-	it("sg-runner ensureAvailable should return a Promise", async () => {
+	it("sg-runner ensureAvailable returns a Promise", async () => {
 		const { SgRunner } = await import("../../clients/sg-runner.js");
 		const client = new SgRunner();
 

--- a/tests/clients/tree-sitter-new-blocker-rules.test.ts
+++ b/tests/clients/tree-sitter-new-blocker-rules.test.ts
@@ -78,7 +78,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
-			`it("should work", () => {
+			`it("checks foo", () => {
 				expect(foo);
 			});
 			`,
@@ -92,7 +92,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
-			`it("should work", () => {
+			`it("checks foo", () => {
 				expect(foo).toBe;
 			});
 			`,
@@ -106,7 +106,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
-			`it("should work", () => {
+			`it("checks foo", () => {
 				expect(foo).not.toBe;
 			});
 			`,
@@ -120,7 +120,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
-			`it("should work", () => {
+			`it("checks foo", () => {
 				expect(foo).toBe(true);
 			});
 			`,
@@ -134,7 +134,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
-			`it("should work", () => {
+			`it("checks foo", () => {
 				expect(foo).not.toBe(1);
 			});
 			`,
@@ -148,7 +148,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
-			`it("should work", () => {
+			`it("checks foo", () => {
 				const matcher = expect(foo).toBe;
 			});
 			`,
@@ -162,7 +162,7 @@ describe("S2970 — incomplete assertion (TS)", () => {
 		const query = await getQuery("ts-incomplete-assertion");
 		const filePath = writeTempFile(
 			"ts",
-			`it("should work", () => {
+			`it("checks foo", () => {
 				expect(foo).to.be.true;
 			});
 			`,

--- a/tests/source-filter.test.ts
+++ b/tests/source-filter.test.ts
@@ -61,7 +61,7 @@ function createTempDir(files: Record<string, string>): {
 }
 
 describe("findSourceSibling", () => {
-	it("should find .ts sibling for .js file", () => {
+	it("finds the .ts sibling for a .js file", () => {
 		const { dir, cleanup } = createTempDir({
 			"src/plan.ts": "// source",
 			"src/plan.js": "// compiled",
@@ -75,7 +75,7 @@ describe("findSourceSibling", () => {
 		cleanup();
 	});
 
-	it("should find .tsx sibling for .jsx file", () => {
+	it("finds the .tsx sibling for a .jsx file", () => {
 		const { dir, cleanup } = createTempDir({
 			"component.tsx": "// tsx source",
 			"component.jsx": "// compiled jsx",
@@ -89,7 +89,7 @@ describe("findSourceSibling", () => {
 		cleanup();
 	});
 
-	it("should find .tsx sibling for .js file (fallback chain)", () => {
+	it("finds the .tsx sibling for a .js file via the fallback chain", () => {
 		const { dir, cleanup } = createTempDir({
 			"app.tsx": "// source",
 			"app.js": "// compiled",
@@ -103,7 +103,7 @@ describe("findSourceSibling", () => {
 		cleanup();
 	});
 
-	it("should return null for .js file without sibling", () => {
+	it("returns null for a .js file with no source sibling", () => {
 		const { dir, cleanup } = createTempDir({
 			"legacy.js": "// hand-written",
 		});
@@ -115,7 +115,7 @@ describe("findSourceSibling", () => {
 		cleanup();
 	});
 
-	it("should return null for .ts file (source, not artifact)", () => {
+	it("returns null for a .ts file since it is source, not an artifact", () => {
 		const { dir, cleanup } = createTempDir({
 			"source.ts": "// source",
 		});
@@ -127,7 +127,7 @@ describe("findSourceSibling", () => {
 		cleanup();
 	});
 
-	it("should handle .vue files shadowing .js", () => {
+	it("finds the .vue sibling shadowing a .js file", () => {
 		const { dir, cleanup } = createTempDir({
 			"App.vue": "<!-- vue template -->",
 			"App.js": "// compiled vue",
@@ -141,7 +141,7 @@ describe("findSourceSibling", () => {
 		cleanup();
 	});
 
-	it("should handle .svelte files shadowing .js", () => {
+	it("finds the .svelte sibling shadowing a .js file", () => {
 		const { dir, cleanup } = createTempDir({
 			"Button.svelte": "<!-- svelte component -->",
 			"Button.js": "// compiled svelte",
@@ -155,7 +155,7 @@ describe("findSourceSibling", () => {
 		cleanup();
 	});
 
-	it("should handle .mjs and .cjs variants", () => {
+	it("finds the source sibling for .mjs and .cjs variants", () => {
 		const { dir, cleanup } = createTempDir({
 			"module.ts": "// source",
 			"module.mjs": "// compiled mjs",
@@ -176,7 +176,7 @@ describe("findSourceSibling", () => {
 });
 
 describe("isBuildArtifact", () => {
-	it("should return true for .js with .ts sibling", () => {
+	it("returns true for a .js file with a .ts sibling", () => {
 		const { dir, cleanup } = createTempDir({
 			"plan.ts": "// source",
 			"plan.js": "// compiled",
@@ -187,7 +187,7 @@ describe("isBuildArtifact", () => {
 		cleanup();
 	});
 
-	it("should return false for standalone .js", () => {
+	it("returns false for a standalone .js file", () => {
 		const { dir, cleanup } = createTempDir({
 			"legacy.js": "// hand-written",
 		});
@@ -197,7 +197,7 @@ describe("isBuildArtifact", () => {
 		cleanup();
 	});
 
-	it("should return false for .ts source", () => {
+	it("returns false for a .ts source file", () => {
 		const { dir, cleanup } = createTempDir({
 			"source.ts": "// source",
 		});
@@ -227,7 +227,7 @@ describe("isGeneratedOrArtifact", () => {
 });
 
 describe("filterSourceFiles", () => {
-	it("should filter out .js files that have .ts siblings", () => {
+	it("filters out .js files that have .ts siblings", () => {
 		const { dir, cleanup } = createTempDir({
 			"src/utils.ts": "// source",
 			"src/utils.js": "// compiled",
@@ -254,7 +254,7 @@ describe("filterSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should keep .js files without .ts siblings", () => {
+	it("keeps .js files that have no .ts sibling", () => {
 		const { dir, cleanup } = createTempDir({
 			"lib/legacy.js": "// hand-written",
 			"lib/modern.ts": "// source",
@@ -277,7 +277,7 @@ describe("filterSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should handle mixed file types", () => {
+	it("keeps files across mixed languages that have no artifact equivalent", () => {
 		const { dir, cleanup } = createTempDir({
 			"main.ts": "// ts source",
 			"main.js": "// compiled",
@@ -308,11 +308,11 @@ describe("filterSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should handle empty input", () => {
+	it("returns an empty array for empty input", () => {
 		expect(filterSourceFiles([])).toEqual([]);
 	});
 
-	it("should filter generated artifact paths", () => {
+	it("filters out generated artifact paths", () => {
 		const { dir, cleanup } = createTempDir({
 			"src/main.ts": "// source",
 			"src/generated/client.ts": "// generated",
@@ -337,7 +337,7 @@ describe("filterSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should handle paths with spaces and special characters", () => {
+	it("filters siblings for paths with spaces and special characters", () => {
 		const { dir, cleanup } = createTempDir({
 			"path with spaces/file.ts": "// source",
 			"path with spaces/file.js": "// compiled",
@@ -363,7 +363,7 @@ describe("filterSourceFiles", () => {
 });
 
 describe("collectSourceFiles", () => {
-	it("should collect files excluding build artifacts", () => {
+	it("collects source files while excluding build artifacts", () => {
 		const { dir, cleanup } = createTempDir({
 			"src/plan.ts": "// source",
 			"src/plan.js": "// compiled",
@@ -384,7 +384,7 @@ describe("collectSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should exclude node_modules and other standard dirs", () => {
+	it("excludes node_modules and other standard directories", () => {
 		const { dir, cleanup } = createTempDir({
 			"src/main.ts": "// source",
 			"node_modules/lodash/index.js": "// library",
@@ -404,7 +404,7 @@ describe("collectSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should handle nested directories", () => {
+	it("collects source files from nested directories", () => {
 		const { dir, cleanup } = createTempDir({
 			"deep/nested/dir/file.ts": "// deep",
 			"deep/nested/dir/file.js": "// compiled",
@@ -426,7 +426,7 @@ describe("collectSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should exclude generated paths, declaration stubs, and generated headers", () => {
+	it("excludes generated paths, declaration stubs, and generated headers", () => {
 		const { dir, cleanup } = createTempDir({
 			"src/main.ts": "// source",
 			"src/generated/client.ts": "// codegen",
@@ -481,7 +481,7 @@ describe("collectSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should handle custom extensions", () => {
+	it("collects files matching custom extensions", () => {
 		const { dir, cleanup } = createTempDir({
 			"custom.xyz": "// xyz file",
 			"normal.ts": "// ts file",
@@ -495,7 +495,7 @@ describe("collectSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should handle custom exclude directories", () => {
+	it("excludes custom exclude directories", () => {
 		const { dir, cleanup } = createTempDir({
 			"src/main.ts": "// source",
 			"custom-out/output.ts": "// output",
@@ -511,7 +511,7 @@ describe("collectSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should exclude glob-style directory patterns like *.dSYM", () => {
+	it("excludes glob-style directory patterns like *.dSYM", () => {
 		const { dir, cleanup } = createTempDir({
 			"src/main.ts": "// source",
 			"MyApp.dSYM/Contents/Resources/symbol.ts": "// debug symbol payload",
@@ -527,7 +527,7 @@ describe("collectSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should exclude directories case-insensitively", () => {
+	it("excludes directories case-insensitively", () => {
 		const { dir, cleanup } = createTempDir({
 			"src/main.ts": "// source",
 			"NODE_MODULES/pkg/index.ts": "// should be excluded",
@@ -545,12 +545,12 @@ describe("collectSourceFiles", () => {
 		cleanup();
 	});
 
-	it("should return empty array for non-existent directory", () => {
+	it("returns an empty array for a non-existent directory", () => {
 		const result = collectSourceFiles("/non/existent/path");
 		expect(result).toEqual([]);
 	});
 
-	it("should handle directories with no matching files", () => {
+	it("returns an empty array for a directory with no matching files", () => {
 		const { dir, cleanup } = createTempDir({
 			"image.png": "not really an image",
 			"notes.txt": "plain text",
@@ -565,7 +565,7 @@ describe("collectSourceFiles", () => {
 });
 
 describe("getFilterStats", () => {
-	it("should calculate correct statistics", () => {
+	it("calculates kept/skipped statistics by file type", () => {
 		const allFiles = [
 			"a.ts",
 			"a.js", // artifact
@@ -584,7 +584,7 @@ describe("getFilterStats", () => {
 		expect(stats.byType[".js"]).toBe(2);
 	});
 
-	it("should handle no filtering", () => {
+	it("reports zero skipped when no files are filtered", () => {
 		const files = ["a.ts", "b.ts", "c.py"];
 
 		const stats = getFilterStats(files, files);
@@ -595,7 +595,7 @@ describe("getFilterStats", () => {
 		expect(Object.keys(stats.byType)).toHaveLength(0);
 	});
 
-	it("should handle all files filtered", () => {
+	it("reports zero kept when all files are filtered", () => {
 		const allFiles = ["a.js", "b.js", "c.jsx"];
 		const filtered: string[] = [];
 
@@ -608,7 +608,7 @@ describe("getFilterStats", () => {
 });
 
 describe("SOURCE_PRECEDENCE completeness", () => {
-	it("should have valid precedence chains", () => {
+	it("keeps every SOURCE_PRECEDENCE entry's extensions dot-prefixed and non-self-shadowing", () => {
 		for (const [sourceExt, shadowedExts] of Object.entries(SOURCE_PRECEDENCE)) {
 			// Source extension should start with dot
 			expect(sourceExt).toMatch(/^\./);


### PR DESCRIPTION
## Summary

AGENTS.md test-authoring screen 11 (added 2026-09-06) requires every test
name to be a declarative present-tense statement of behavior and its
condition ("does X if Y"), never `should` — a name that reads as a wish about
the code instead of a line of spec the code must satisfy.

`grep -rnE '\b(it|test)\(("|'"'"')should ' tests/` (leading `should` only)
found 50 matches across 3 files in round 1. Round 2 review correctly pointed
out screen 11 says never `should`, not never LEADING `should` — 8 more
survivors had `should` mid-string. Final count: **58 names across 5 files**,
one of which is a byte-identical duplicate of another and is deleted rather
than renamed (see F1 below). **String-only change everywhere else: no
assertion, fixture, or ordering edits** — except 7 inert fixture-wrapper
strings in `tree-sitter-new-blocker-rules.test.ts` (TypeScript source content
fed to a tree-sitter query that never inspects them; see round 1 detail
below).

Closes #2602 — every acceptance criterion met: all 58 `should` names
addressed (grep now returns 0), no governance sweep added (per criterion 2 —
screen 11 explicitly states no shipped defect names this recurrence yet).

### Fix round 2 (findings from review)

**F1 (medium) — exact duplicate test deleted.**
`dispatcher-flow.test.ts:811` and `:838` were byte-identical after stripping
comments (same runner via `createConditionalRunner("conditional", (ctx) =>
ctx.autofix)`, same `mockPi = { getFlag: () => false }`, same two
assertions). Confirmed with a mutation at the seam that decides whether
`runner.when` runs: `clients/dispatch/dispatcher.js:673`
`if (runner.when) {` → `if (false && runner.when) {` (built artifact from
`clients/dispatch/dispatcher.ts`, mutated directly, then reverted — never
committed). Both tests reds with the identical assertion message:

```
$ npx vitest run tests/clients/dispatch/dispatcher-flow.test.ts -t "skips the conditional runner"
 ❯ |default| tests/clients/dispatch/dispatcher-flow.test.ts (27 tests | 2 failed | 25 skipped)
       × skips the conditional runner because autofix is always disabled
       × skips the conditional runner when its condition evaluates to false

 FAIL  ... > skips the conditional runner because autofix is always disabled
AssertionError: expected [ { …(7) } ] to have a length of +0 but got 1
 ❯ tests/clients/dispatch/dispatcher-flow.test.ts:835:31

 FAIL  ... > skips the conditional runner when its condition evaluates to false
AssertionError: expected [ { …(7) } ] to have a length of +0 but got 1
 ❯ tests/clients/dispatch/dispatcher-flow.test.ts:857:31

 Test Files  1 failed (1)
      Tests  2 failed | 25 skipped (27)
```

Reverted the mutation (confirmed both green again), then deleted the case at
`:811` per AGENTS.md "Test assessment and removal" and kept `:838`
("skips the conditional runner when its condition evaluates to false") as
the named survivor. The `when() → true` direction stays covered elsewhere in
the same file at `:181` (`skips all runners for generated files`, `when`
returns `true` and is counted), `:308`/`:360`/`:375`-area group-execution
cases, and `:201` — reviewer-verified, unchanged by this PR.

**F2 (medium-low) — mid-string `should` survivors renamed.** 8 names carried
`should` NOT in leading position, which round 1's grep anchor missed:
- `dispatcher-flow.test.ts:513` (in a file this PR already touches)
- `session-start-parallelism.test.ts:10,22,31,40,49,59` (6 names, one per
  client: ruff/biome/knip/jscpd/dependency-checker/sg-runner)
- `service-aux-grace.test.ts:1876`

All 8 renamed the same string-only way (assertions unchanged). See the
rename table below for old → new. **Vacuity note for the ledger:** the 6
`session-start-parallelism.test.ts` cases assert only
`toBeInstanceOf(Promise)` and `typeof result.then === "function"` — a type
shape, not a behavior outcome; this is screen 8/"not-throw"-adjacent
(asserting shape, not effect) but pre-dates this PR and is out of scope for
a rename-only change. Flagging for the corpus value ledger, not fixing here.

Two matches in `tests/clients/dispatch/rules/redos-nested-quantifier.test.ts`
(`` `should flag: ${pattern}` `` / `` `should NOT flag: ${pattern}` ``) are
NOT `it`/`test` name strings — they're the custom failure-message argument to
`expect()` — so screen 11 does not apply and they are correctly left alone.

Grep proof restricted to `it`/`test` name strings, run after both F1 and F2:
```
$ grep -rnE '\b(it|test)\(\s*("|'"'"')[^"'"'"']*\bshould\b' tests/ --include=*.test.ts
(no output)
```

**Minor — changelog wording.** Corrected: "no assertion, fixture, or
ordering changes" now reads "inert fixture-wrapper strings only" for the 7
tree-sitter fixture matches, so it doesn't read as a blanket claim about
every one of the 58. `rules/tree-sitter-queries/typescript/incomplete-
assertion.yml` (the query these fixtures feed) and its sibling
`no-console-in-tests.yml` are both untouched.

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [x] Documentation *(test-naming cleanup; no behavior change — closest fit is "internal-only test/refactor")*

## Area

- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [ ] The change has tests (happy path, edge cases, regression test for bugs) — N/A, no new logic; rename-only (plus one duplicate-test deletion)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [ ] Every NEW regression test is proven RED on pre-fix code — N/A, no new tests
- [ ] Every new guard/branch/filter is mutation-proof — N/A, no new guard/branch/filter added; the mutation in F1 above proves a REMOVED duplicate, not a new guard
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts` — N/A, no production code touched (dispatcher.js was mutated locally for F1's proof and reverted; never committed)
- [x] `package-lock.json` is in sync with `package.json`
- [ ] `AGENTS.md` is updated — N/A, no behavior/convention change; screen 11 already documents this recurrence
- [x] `.changelog/2602-rename-should-test-names.md` has one valid entry (section: Changed)
- [x] Commit subject includes the issue number: `Refs #2602` (trailer)

## Tests

No test file gained or lost an assertion, fixture, or execution order,
except the F1 deletion of one byte-identical duplicate case (proven
redundant by mutation, not asserted). Every other edit is a string literal
inside an existing `it(...)`/`test(...)` call.

### Test assessment

- `tests/source-filter.test.ts` — pins `findSourceSibling`/`isBuildArtifact`/
  `filterSourceFiles`/`collectSourceFiles`/`getFilterStats`/
  `SOURCE_PRECEDENCE` behavior across 31 cases; each case is still uniquely
  named and none are made redundant by this PR.
- `tests/clients/tree-sitter-new-blocker-rules.test.ts` — pins the
  `S2970 incomplete-assertion` tree-sitter query across 7 fixture variants;
  unaffected in behavior, only the inert fixture-wrapper string changed.
- `tests/clients/dispatch/dispatcher-flow.test.ts` — pins dispatcher
  registration, execution, delta-mode filtering, and conditional-runner
  behavior. **Removed:** the case at old line 811
  ("skips the conditional runner because autofix is always disabled") —
  proven redundant by the `if (false && runner.when)` mutation at
  `clients/dispatch/dispatcher.js:673`, which reds the SURVIVING case
  `"skips the conditional runner when its condition evaluates to false"`
  (line 838, now the sole case in that block) with the identical assertion
  message quoted in F1 above. The `when() → true` path remains pinned by
  `"skips all runners for generated files"` (line 181) and the group-mode
  cases nearby, none touched by this PR.
- `tests/clients/session-start-parallelism.test.ts` — pins that
  `ensureAvailable()` returns a `Promise` (async, non-blocking) for 6
  clients; string-only rename, assertions (type-shape only, flagged as a
  vacuity candidate above) unchanged.
- `tests/clients/lsp/service-aux-grace.test.ts` — pins the #1533 "case 2"
  partial-confirmation narrowing when a fast silent aux sits beside a
  slower primary; string-only rename, assertions unchanged.

No other removal candidates.

## Blast radius

Zero production modules touched in the committed diff. `clients/dispatch/
dispatcher.js` (a gitignored build artifact compiled from `dispatcher.ts`)
was mutated locally to produce the F1 red proof and immediately reverted —
never committed, never pushed. Blast radius is limited to the 5 test files
touched and their own suites; no other file imports or string-matches any
of the 58 old test-name strings (see "Cross-reference check" below,
unchanged from round 1 plus a re-check for the 8 new names).

## Observability

Not applicable — test-only change, no runtime behavior, no log/ledger record.

## Class sweep

**Defect class:** AGENTS.md test-authoring screen 11 (`should`-named tests,
leading OR mid-string).
**Sweep scope:** whole `tests/` tree (the only place test names live;
`clients/`, `tools/`, `mcp/`, `scripts/` carry no `it`/`test` declarations).

```
grep -rnE '\b(it|test)\(\s*("|'"'"')[^"'"'"']*\bshould\b' tests/ --include=*.test.ts | wc -l
```
Before round 1: 50 (leading-only grep). After round 2's corrected,
non-anchored grep: 0.

**Cross-reference check** (ratchets / `-t` filters / baselines that could pin
the old strings), re-run for all 58 old names including the 8 from round 2:
- `grep -rn "<old name>"` for every old string across the whole repo (not
  just `tests/`) — zero hits outside the 5 files being edited.
- `vitest.config.ts` — no `testNamePattern`/`-t`/`.only` referencing any of
  these names.
- `tests/support/*baseline*.json` (`lsp-double-baseline.json`,
  `flake-shape-baseline.json`, `word-index-rank-baseline.json`) — all keyed
  by file path or symbol name, never by test-name string; none reference the
  renamed or deleted tests.

**Consolidation verdict:** class of size 58, now size 0 in `tests/`. No
governance sweep added — acceptance criterion 2 of #2602 explicitly forbids
one absent a shipped defect naming the recurrence; screen 11's own text
states none exists yet.

## Verification (commands + output)

Build:
```
$ npm run build
> tsc --project tsconfig.build.json
(clean exit)
```

Targeted tests — the 5 touched files, the whole `tests/clients/dispatch/`
tree, `flake-shape-ratchet.test.ts`, and every `tests/config/*.test.ts`
(via the shared `test:targeted` slot, since this batch is well over the
~15-file foreground threshold):
```
$ npm run test:targeted -- tests/source-filter.test.ts tests/clients/tree-sitter-new-blocker-rules.test.ts tests/clients/session-start-parallelism.test.ts tests/clients/lsp/service-aux-grace.test.ts tests/clients/dispatch/ tests/clients/flake-shape-ratchet.test.ts tests/config/*.test.ts
 Test Files  163 passed | 2 skipped (165)
      Tests  2030 passed | 6 skipped (2036)
```

Pre-fix-round mutation red (F1, quoted above in full) and its revert-to-green
re-run are the red-first proof for the deletion.

Grep proof (0 remaining, non-anchored):
```
$ grep -rnE '\b(it|test)\(\s*("|'"'"')[^"'"'"']*\bshould\b' tests/ --include=*.test.ts
(no output)
```

Lint:
```
$ npm run lint
> tsc --project tsconfig.json && npm run lint:js
> oxlint --deny-warnings ... .
(clean exit, no output = no warnings/errors)
```

Format:
```
$ npx oxfmt --check tests/clients/dispatch/dispatcher-flow.test.ts tests/clients/tree-sitter-new-blocker-rules.test.ts tests/source-filter.test.ts tests/clients/session-start-parallelism.test.ts tests/clients/lsp/service-aux-grace.test.ts
Checking formatting...
All matched files use the correct format.
```

Changelog:
```
$ node scripts/check-changelog-fragments.mjs
changelog fragments OK (123 entries in .changelog/)
```

## Rename table (file:line → new name)

| File:Line | Old name | New name |
|---|---|---|
| tests/source-filter.test.ts:64 | should find .ts sibling for .js file | finds the .ts sibling for a .js file |
| tests/source-filter.test.ts:78 | should find .tsx sibling for .jsx file | finds the .tsx sibling for a .jsx file |
| tests/source-filter.test.ts:92 | should find .tsx sibling for .js file (fallback chain) | finds the .tsx sibling for a .js file via the fallback chain |
| tests/source-filter.test.ts:106 | should return null for .js file without sibling | returns null for a .js file with no source sibling |
| tests/source-filter.test.ts:118 | should return null for .ts file (source, not artifact) | returns null for a .ts file since it is source, not an artifact |
| tests/source-filter.test.ts:130 | should handle .vue files shadowing .js | finds the .vue sibling shadowing a .js file |
| tests/source-filter.test.ts:144 | should handle .svelte files shadowing .js | finds the .svelte sibling shadowing a .js file |
| tests/source-filter.test.ts:158 | should handle .mjs and .cjs variants | finds the source sibling for .mjs and .cjs variants |
| tests/source-filter.test.ts:179 | should return true for .js with .ts sibling | returns true for a .js file with a .ts sibling |
| tests/source-filter.test.ts:190 | should return false for standalone .js | returns false for a standalone .js file |
| tests/source-filter.test.ts:200 | should return false for .ts source | returns false for a .ts source file |
| tests/source-filter.test.ts:230 | should filter out .js files that have .ts siblings | filters out .js files that have .ts siblings |
| tests/source-filter.test.ts:257 | should keep .js files without .ts siblings | keeps .js files that have no .ts sibling |
| tests/source-filter.test.ts:280 | should handle mixed file types | keeps files across mixed languages that have no artifact equivalent |
| tests/source-filter.test.ts:311 | should handle empty input | returns an empty array for empty input |
| tests/source-filter.test.ts:315 | should filter generated artifact paths | filters out generated artifact paths |
| tests/source-filter.test.ts:340 | should handle paths with spaces and special characters | filters siblings for paths with spaces and special characters |
| tests/source-filter.test.ts:366 | should collect files excluding build artifacts | collects source files while excluding build artifacts |
| tests/source-filter.test.ts:387 | should exclude node_modules and other standard dirs | excludes node_modules and other standard directories |
| tests/source-filter.test.ts:407 | should handle nested directories | collects source files from nested directories |
| tests/source-filter.test.ts:429 | should exclude generated paths, declaration stubs, and generated headers | excludes generated paths, declaration stubs, and generated headers |
| tests/source-filter.test.ts:484 | should handle custom extensions | collects files matching custom extensions |
| tests/source-filter.test.ts:498 | should handle custom exclude directories | excludes custom exclude directories |
| tests/source-filter.test.ts:514 | should exclude glob-style directory patterns like *.dSYM | excludes glob-style directory patterns like *.dSYM |
| tests/source-filter.test.ts:530 | should exclude directories case-insensitively | excludes directories case-insensitively |
| tests/source-filter.test.ts:548 | should return empty array for non-existent directory | returns an empty array for a non-existent directory |
| tests/source-filter.test.ts:553 | should handle directories with no matching files | returns an empty array for a directory with no matching files |
| tests/source-filter.test.ts:568 | should calculate correct statistics | calculates kept/skipped statistics by file type |
| tests/source-filter.test.ts:587 | should handle no filtering | reports zero skipped when no files are filtered |
| tests/source-filter.test.ts:598 | should handle all files filtered | reports zero kept when all files are filtered |
| tests/source-filter.test.ts:611 | should have valid precedence chains | keeps every SOURCE_PRECEDENCE entry's extensions dot-prefixed and non-self-shadowing |
| tests/clients/tree-sitter-new-blocker-rules.test.ts:81 | should work *(fixture-wrapper string, inert to the query)* | checks foo |
| tests/clients/tree-sitter-new-blocker-rules.test.ts:95 | should work *(fixture-wrapper string, inert to the query)* | checks foo |
| tests/clients/tree-sitter-new-blocker-rules.test.ts:109 | should work *(fixture-wrapper string, inert to the query)* | checks foo |
| tests/clients/tree-sitter-new-blocker-rules.test.ts:123 | should work *(fixture-wrapper string, inert to the query)* | checks foo |
| tests/clients/tree-sitter-new-blocker-rules.test.ts:137 | should work *(fixture-wrapper string, inert to the query)* | checks foo |
| tests/clients/tree-sitter-new-blocker-rules.test.ts:151 | should work *(fixture-wrapper string, inert to the query)* | checks foo |
| tests/clients/tree-sitter-new-blocker-rules.test.ts:165 | should work *(fixture-wrapper string, inert to the query)* | checks foo |
| tests/clients/dispatch/dispatcher-flow.test.ts:59 | should register and retrieve runner | registers and retrieves a runner by id |
| tests/clients/dispatch/dispatcher-flow.test.ts:68 | should return undefined for unknown runner | returns undefined for an unregistered runner id |
| tests/clients/dispatch/dispatcher-flow.test.ts:73 | should get runners for specific file kind | returns only runners registered for the requested file kind |
| tests/clients/dispatch/dispatcher-flow.test.ts:121 | should sort runners by priority | sorts runners by ascending priority |
| tests/clients/dispatch/dispatcher-flow.test.ts:165 | should execute single runner and return diagnostics | executes a single runner and returns its diagnostics |
| tests/clients/dispatch/dispatcher-flow.test.ts:308 | should execute multiple runners in group | executes every runner in a group and aggregates diagnostics |
| tests/clients/dispatch/dispatcher-flow.test.ts:468 | should skip unregistered runners gracefully | skips an unregistered runner id without throwing |
| tests/clients/dispatch/dispatcher-flow.test.ts:513 | fallback mode should continue after failed runner and use next success | fallback mode continues after a failed runner and uses the next success |
| tests/clients/dispatch/dispatcher-flow.test.ts:590 | should filter pre-existing issues in delta mode | filters out baseline issues in delta mode |
| tests/clients/dispatch/dispatcher-flow.test.ts:643 | should report all issues when delta mode disabled | reports baseline issues when delta mode is disabled |
| tests/clients/dispatch/dispatcher-flow.test.ts:811 | should run conditional runner when condition true *(byte-identical duplicate of :838 — DELETED, see F1)* | *(deleted)* |
| tests/clients/dispatch/dispatcher-flow.test.ts:838 | should skip conditional runner when condition false | skips the conditional runner when its condition evaluates to false |
| tests/clients/dispatch/dispatcher-flow.test.ts:860 | should skip runner when when() throws and continue others | skips a runner whose when() throws and continues with the others |
| tests/clients/session-start-parallelism.test.ts:10 | ruff-client ensureAvailable should return a Promise | ruff-client ensureAvailable returns a Promise |
| tests/clients/session-start-parallelism.test.ts:22 | biome-client ensureAvailable should return a Promise | biome-client ensureAvailable returns a Promise |
| tests/clients/session-start-parallelism.test.ts:31 | knip-client ensureAvailable should return a Promise | knip-client ensureAvailable returns a Promise |
| tests/clients/session-start-parallelism.test.ts:40 | jscpd-client ensureAvailable should return a Promise | jscpd-client ensureAvailable returns a Promise |
| tests/clients/session-start-parallelism.test.ts:49 | dependency-checker ensureAvailable should return a Promise | dependency-checker ensureAvailable returns a Promise |
| tests/clients/session-start-parallelism.test.ts:59 | sg-runner ensureAvailable should return a Promise | sg-runner ensureAvailable returns a Promise |
| tests/clients/lsp/service-aux-grace.test.ts:1876 | case 2 — a fast silent aux beside a SLOWER primary does newly narrow, and should | case 2 — a fast silent aux beside a slower primary narrows to partial, not confirmed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y
