### PR TITLE
refactor(lsp): delete touchFile/getAdvertisedCommands presence probes (refs #2598)

### DIFF
--- a/.changelog/fix-2598-delete-presence-probes.md
+++ b/.changelog/fix-2598-delete-presence-probes.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **LSP**: `lsp_diagnostics`, `lsp_navigation` and the tsserver sync escape hatch no longer probe the LSP service for methods it always defines. `collectDiagnosticsForFile` and `openFileBestEffort` touched the file only `if (typeof lspService.touchFile === "function")`, and `attemptTsserverSyncDiagnostics` bailed unless `getAdvertisedCommands` was a function; the real `LSPService` defines both unconditionally, so those hedges (and the `openFile` fallbacks behind them) were reachable only from a partial test double. Production behaviour is unchanged — the touch and the advertisement read now happen on the one path a real service ever took, and the `getDiagnostics` fallback still covers a touch that resolves no clients.

--- a/clients/lsp/tsserver-sync.ts
+++ b/clients/lsp/tsserver-sync.ts
@@ -415,13 +415,22 @@ export async function runTsserverSyncCommand(
  * server had computed but never published (silentOnClean) — these must be
  * surfaced to the caller, not discarded. `confirmed: false` = sync path
  * unavailable, fall through to existing behavior.
+ *
+ * #2598: `getAdvertisedCommands` is REQUIRED here rather than probed for. The
+ * real `LSPService` defines it unconditionally (clients/lsp/index.ts), and both
+ * production callers hand this function that service, so the former
+ * `typeof … !== "function"` bail was reachable only from a partial test double
+ * (AGENTS.md shape 7). It was also unobservable even there: an absent method
+ * throws a `TypeError` that this function's own catch turns into the same
+ * `undefined` the bail returned. `executeCommand` stays optional on
+ * {@link TsserverSyncCapableService} — see {@link runTsserverSyncCommand}.
  */
 export async function attemptTsserverSyncDiagnostics(
 	file: string,
-	svc: TsserverSyncCapableService,
+	svc: TsserverSyncCapableService &
+		Required<Pick<TsserverSyncCapableService, "getAdvertisedCommands">>,
 ): Promise<LSPDiagnostic[] | undefined> {
 	try {
-		if (typeof svc.getAdvertisedCommands !== "function") return undefined;
 		const advertised = await svc.getAdvertisedCommands(file);
 		if (!advertised.includes(TSSERVER_REQUEST_COMMAND)) return undefined;
 

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -2228,8 +2228,12 @@ const HELPER_UNBOUNDED: Readonly<Record<string, number>> = {
 	"tools/effective-config.ts": 1,
 	"tools/lens-diagnostic-mark.ts": 2,
 	"tools/lens-diagnostics.ts": 10,
-	"tools/lsp-diagnostics.ts": 30,
-	"tools/lsp-navigation.ts": 33,
+	// #2598 lowered both by one: `collectDiagnosticsForFile` and
+	// `openFileBestEffort` each dropped their `await lspService.openFile(…)`
+	// arm — the fallback for "a service shape without touchFile", which the
+	// real `LSPService` never was.
+	"tools/lsp-diagnostics.ts": 29,
+	"tools/lsp-navigation.ts": 32,
 	"tools/module-report.ts": 3,
 	"tools/project-report.ts": 1,
 	"tools/symbol-search.ts": 1,

--- a/tests/tools/lsp-diagnostics-inferred-project.test.ts
+++ b/tests/tools/lsp-diagnostics-inferred-project.test.ts
@@ -42,36 +42,33 @@ import { createLspDiagnosticsTool } from "../../tools/lsp-diagnostics.js";
 const INFERRED_BODY = { configFileName: "/dev/null/inferredProject1*" };
 
 function makeService() {
-	return makeLspServiceDouble(
-		{
-			openFile: vi.fn().mockResolvedValue(undefined),
-			getDiagnostics: vi.fn(async () => [
-				{
-					severity: 1,
-					message: "Cannot find name 'describe'.",
-					range: {
-						start: { line: 0, character: 0 },
-						end: { line: 0, character: 8 },
-					},
-					source: "typescript",
-					code: 2582,
+	return makeLspServiceDouble({
+		getDiagnostics: vi.fn(async () => [
+			{
+				severity: 1,
+				message: "Cannot find name 'describe'.",
+				range: {
+					start: { line: 0, character: 0 },
+					end: { line: 0, character: 8 },
 				},
-			]),
-			getDiagnosticsHealth: vi.fn().mockReturnValue(undefined),
-			getCapabilitySnapshots: vi.fn().mockResolvedValue([]),
-			runWorkspaceDiagnostics: vi.fn(),
-			executeReadOnlyCommandOnLiveClient: vi.fn(async () => ({
-				executed: true,
-				result: { success: true, body: INFERRED_BODY },
-			})),
-		},
-		// `touchFile` absence is observed by production at
-		// tools/lsp-diagnostics.ts:789 — this suite asserts the `openFile` arm,
-		// and un-omitting it reds the demotion case. `getAdvertisedCommands` is
-		// left seeded: clients/lsp/tsserver-sync.ts bails the same way on absent
-		// and on "advertises nothing", so omitting it proves nothing (#2592).
-		{ omit: ["touchFile"] },
-	);
+				source: "typescript",
+				code: 2582,
+			},
+		]),
+		getDiagnosticsHealth: vi.fn().mockReturnValue(undefined),
+		getCapabilitySnapshots: vi.fn().mockResolvedValue([]),
+		runWorkspaceDiagnostics: vi.fn(),
+		executeReadOnlyCommandOnLiveClient: vi.fn(async () => ({
+			executed: true,
+			result: { success: true, body: INFERRED_BODY },
+		})),
+		// #2598: the tool touches unconditionally now. `undefined` is the real
+		// `touchFile`'s answer when it resolves no client for the file
+		// (clients/lsp/index.ts, `no_clients`), which is what routes this case
+		// through `getDiagnostics` — the source of the demotable TS error the
+		// demotion under test has to rewrite.
+		touchFile: vi.fn(async () => undefined),
+	});
 }
 
 describe("lsp_diagnostics — inferred-project demotion (#1645 F3)", () => {

--- a/tests/tools/lsp-diagnostics.test.ts
+++ b/tests/tools/lsp-diagnostics.test.ts
@@ -60,42 +60,37 @@ describe("lsp_diagnostics tool", () => {
 		mocked.warmAttached = false;
 		mocked.attachedDiagnostics.mockReset();
 		reconcileScanDiagnosticsMock.mockReset();
-		mocked.service = makeLspServiceDouble(
-			{
-				openFile: vi.fn().mockResolvedValue(undefined),
-				getDiagnostics: vi.fn().mockImplementation(async (filePath: string) => {
-					if (filePath.endsWith("bad.ts")) {
-						return [
-							{
-								severity: 1,
-								message: "Type 'string' is not assignable to type 'number'.",
-								range: {
-									start: { line: 0, character: 16 },
-									end: { line: 0, character: 24 },
-								},
-								source: "ts",
+		mocked.service = makeLspServiceDouble({
+			getDiagnostics: vi.fn().mockImplementation(async (filePath: string) => {
+				if (filePath.endsWith("bad.ts")) {
+					return [
+						{
+							severity: 1,
+							message: "Type 'string' is not assignable to type 'number'.",
+							range: {
+								start: { line: 0, character: 16 },
+								end: { line: 0, character: 24 },
 							},
-						];
-					}
-					return [];
-				}),
-				getDiagnosticsHealth: vi.fn().mockReturnValue(undefined),
-				getCapabilitySnapshots: vi.fn().mockResolvedValue([]),
-				runWorkspaceDiagnostics: vi.fn(),
-			},
-			// `omit` is NOT decoration here: tools/lsp-diagnostics.ts:789 branches
-			// on `typeof serviceWithTouch.touchFile === "function"`, so a factory
-			// default silently moves this suite off the `openFile` arm its cases
-			// assert on. Proven: un-omitting `touchFile` reds 12 of the 59 cases
-			// in this file (#2592). The cases that DO want the touch arm install
-			// `touchFile` on the double themselves.
-			//
-			// `getAdvertisedCommands` is deliberately NOT omitted even though the
-			// pre-#2592 double lacked it: clients/lsp/tsserver-sync.ts bails
-			// identically on "absent" and on "advertises nothing", so an omit
-			// there is unfalsifiable — un-omitting it leaves this file green.
-			{ omit: ["touchFile"] },
-		);
+							source: "ts",
+						},
+					];
+				}
+				return [];
+			}),
+			getDiagnosticsHealth: vi.fn().mockReturnValue(undefined),
+			getCapabilitySnapshots: vi.fn().mockResolvedValue([]),
+			runWorkspaceDiagnostics: vi.fn(),
+			// #2598: `collectDiagnosticsForFile` now touches unconditionally —
+			// the real `LSPService` defines `touchFile` on every shape, so the
+			// probe that used to route this suite down an `openFile` arm is
+			// gone. `undefined` is what the real `touchFile` resolves to when
+			// it resolves NO client for the file (clients/lsp/index.ts, the
+			// `no_clients` return), and it is the state these cases want: the
+			// tool falls through to `getDiagnostics`, where their fixtures
+			// live. Cases that want the touch itself to answer install their
+			// own `touchFile` on the double.
+			touchFile: vi.fn(async () => undefined),
+		});
 	});
 
 	it("uses attached diagnostics for a batch without local warm-up or touches", async () => {
@@ -174,7 +169,7 @@ describe("lsp_diagnostics tool", () => {
 			expect(String(result.content[0]?.text)).toContain("Files checked: 2");
 			expect(String(result.content[0]?.text)).toContain("not assignable");
 			expect(
-				(mocked.service as { openFile: ReturnType<typeof vi.fn> }).openFile,
+				(mocked.service as { touchFile: ReturnType<typeof vi.fn> }).touchFile,
 			).toHaveBeenCalledTimes(2);
 			expect(
 				(
@@ -313,7 +308,7 @@ describe("lsp_diagnostics tool", () => {
 		// No file was opened in the language server — the worker loop saw the
 		// aborted signal and returned before scheduling any file.
 		expect(
-			(mocked.service as { openFile: ReturnType<typeof vi.fn> }).openFile,
+			(mocked.service as { touchFile: ReturnType<typeof vi.fn> }).touchFile,
 		).not.toHaveBeenCalled();
 		// Still returns a (partial) batch result, not a throw.
 		expect(result.isError).toBeUndefined();
@@ -343,7 +338,7 @@ describe("lsp_diagnostics tool", () => {
 			// abort-aware fan-out opened NONE of them in the language server — the
 			// #343 invariant: no in-flight files after the turn is abandoned.
 			expect(
-				(mocked.service as { openFile: ReturnType<typeof vi.fn> }).openFile,
+				(mocked.service as { touchFile: ReturnType<typeof vi.fn> }).touchFile,
 			).not.toHaveBeenCalled();
 			expect(result.isError).toBeUndefined();
 			expect(result.details?.mode).toBe("directory");
@@ -392,12 +387,12 @@ describe("lsp_diagnostics tool", () => {
 			expect(result.details?.totalDiagnostics).toBe(0);
 			expect(String(result.content[0]?.text)).toContain("Files scanned: 1");
 
-			const openFile = (
+			const touchFile = (
 				mocked.service as {
-					openFile: ReturnType<typeof vi.fn>;
+					touchFile: ReturnType<typeof vi.fn>;
 				}
-			).openFile;
-			const opened = openFile.mock.calls.map(([filePath]) =>
+			).touchFile;
+			const opened = touchFile.mock.calls.map(([filePath]) =>
 				path.relative(tmpDir, String(filePath)).replace(/\\/g, "/"),
 			);
 			expect(opened).toEqual(["src/good.ts"]);
@@ -429,10 +424,10 @@ describe("lsp_diagnostics tool", () => {
 			// relative order LANG_EXTENSIONS's ".ts" key had before ".py"), so the
 			// directory scans as typescript and the python file is not opened.
 			expect(result.details?.filesScanned).toBe(1);
-			const openFile = (
-				mocked.service as { openFile: ReturnType<typeof vi.fn> }
-			).openFile;
-			const opened = openFile.mock.calls.map(([filePath]) =>
+			const touchFile = (
+				mocked.service as { touchFile: ReturnType<typeof vi.fn> }
+			).touchFile;
+			const opened = touchFile.mock.calls.map(([filePath]) =>
 				path.relative(tmpDir, String(filePath)).replace(/\\/g, "/"),
 			);
 			expect(opened).toEqual(["a.ts"]);
@@ -460,10 +455,10 @@ describe("lsp_diagnostics tool", () => {
 			expect(result.isError).toBeUndefined();
 			expect(result.details?.mode).toBe("directory");
 			expect(result.details?.filesScanned).toBe(1);
-			const openFile = (
-				mocked.service as { openFile: ReturnType<typeof vi.fn> }
-			).openFile;
-			const opened = openFile.mock.calls.map(([filePath]) =>
+			const touchFile = (
+				mocked.service as { touchFile: ReturnType<typeof vi.fn> }
+			).touchFile;
+			const opened = touchFile.mock.calls.map(([filePath]) =>
 				path.relative(tmpDir, String(filePath)).replace(/\\/g, "/"),
 			);
 			expect(opened).toEqual(["config.ru"]);
@@ -509,10 +504,10 @@ describe("lsp_diagnostics tool", () => {
 			// from `.pi-lens.json` both suppress, not just the canonical dir list.
 			expect(result.isError).toBeUndefined();
 			expect(result.details?.filesScanned).toBe(1);
-			const openFile = (
-				mocked.service as { openFile: ReturnType<typeof vi.fn> }
-			).openFile;
-			const opened = openFile.mock.calls.map(([filePath]) =>
+			const touchFile = (
+				mocked.service as { touchFile: ReturnType<typeof vi.fn> }
+			).touchFile;
+			const opened = touchFile.mock.calls.map(([filePath]) =>
 				path.relative(tmpDir, String(filePath)).replace(/\\/g, "/"),
 			);
 			expect(opened).toEqual(["src/good.ts"]);

--- a/tests/tools/lsp-navigation.test.ts
+++ b/tests/tools/lsp-navigation.test.ts
@@ -39,68 +39,65 @@ const parseToolJson = (result: {
 
 describe("lsp_navigation tool", () => {
 	beforeEach(() => {
-		mocked.service = makeLspServiceDouble(
-			{
-				supportsLSP: vi.fn().mockReturnValue(true),
-				hasLSP: vi.fn().mockResolvedValue(true),
-				openFile: vi.fn().mockResolvedValue(undefined),
-				getDiagnostics: vi.fn().mockResolvedValue([]),
-				getOperationSupport: vi.fn().mockResolvedValue(null),
-				getCapabilitySnapshots: vi.fn().mockResolvedValue([]),
-				codeAction: vi
-					.fn()
-					.mockResolvedValue([
-						{ title: "Move to new file", kind: "refactor.move.newFile" },
-					]),
-				rename: vi.fn().mockResolvedValue(null),
-				renameFile: vi.fn().mockResolvedValue({
-					applied: false,
-					serverIds: [],
-					willRenameFailures: [],
-					didRenameFailures: [],
-					droppedConflicts: 0,
-					inputEditCount: 0,
-					summary: [],
-				}),
-				references: vi.fn().mockResolvedValue([
-					{
-						uri: tmpFileUrl("sample.ts"),
-						range: {
-							start: { line: 1, character: 1 },
-							end: { line: 1, character: 5 },
-						},
-					},
+		// #2598: `openFileBestEffort` no longer branches on `touchFile` being
+		// present — the real `LSPService` always has it — so the double keeps the
+		// factory's `touchFile`, and the scoped-open case below asserts the touch
+		// (with its options), which is the call production actually makes.
+		mocked.service = makeLspServiceDouble({
+			supportsLSP: vi.fn().mockReturnValue(true),
+			hasLSP: vi.fn().mockResolvedValue(true),
+			getDiagnostics: vi.fn().mockResolvedValue([]),
+			getOperationSupport: vi.fn().mockResolvedValue(null),
+			getCapabilitySnapshots: vi.fn().mockResolvedValue([]),
+			codeAction: vi
+				.fn()
+				.mockResolvedValue([
+					{ title: "Move to new file", kind: "refactor.move.newFile" },
 				]),
-				typeDefinition: vi.fn().mockResolvedValue([
-					{
-						uri: tmpFileUrl("types.ts"),
-						range: {
-							start: { line: 9, character: 0 },
-							end: { line: 9, character: 4 },
-						},
+			rename: vi.fn().mockResolvedValue(null),
+			renameFile: vi.fn().mockResolvedValue({
+				applied: false,
+				serverIds: [],
+				willRenameFailures: [],
+				didRenameFailures: [],
+				droppedConflicts: 0,
+				inputEditCount: 0,
+				summary: [],
+			}),
+			references: vi.fn().mockResolvedValue([
+				{
+					uri: tmpFileUrl("sample.ts"),
+					range: {
+						start: { line: 1, character: 1 },
+						end: { line: 1, character: 5 },
 					},
-				]),
-				declaration: vi.fn().mockResolvedValue([]),
-				workspaceSymbol: vi.fn().mockResolvedValue([]),
-				getAdvertisedCommands: vi
-					.fn()
-					.mockResolvedValue(["_typescript.organizeImports"]),
-				executeCommand: vi
-					.fn()
-					.mockResolvedValue({ executed: true, result: null }),
-				documentSymbol: vi.fn().mockResolvedValue([]),
-				incomingCalls: vi.fn().mockResolvedValue([]),
-				outgoingCalls: vi.fn().mockResolvedValue([]),
-				getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
-				getWorkspaceDiagnosticsSupport: vi
-					.fn()
-					.mockResolvedValue({ mode: "push-only" }),
-			},
-			// `openFileBestEffort` (tools/lsp-navigation.ts:709) branches on
-			// `typeof lspService.touchFile === "function"`; this suite has always
-			// taken the `openFile` arm, and a factory default would move it. #2592.
-			{ omit: ["touchFile"] },
-		);
+				},
+			]),
+			typeDefinition: vi.fn().mockResolvedValue([
+				{
+					uri: tmpFileUrl("types.ts"),
+					range: {
+						start: { line: 9, character: 0 },
+						end: { line: 9, character: 4 },
+					},
+				},
+			]),
+			declaration: vi.fn().mockResolvedValue([]),
+			workspaceSymbol: vi.fn().mockResolvedValue([]),
+			getAdvertisedCommands: vi
+				.fn()
+				.mockResolvedValue(["_typescript.organizeImports"]),
+			executeCommand: vi
+				.fn()
+				.mockResolvedValue({ executed: true, result: null }),
+			documentSymbol: vi.fn().mockResolvedValue([]),
+			incomingCalls: vi.fn().mockResolvedValue([]),
+			outgoingCalls: vi.fn().mockResolvedValue([]),
+			getAllDiagnostics: vi.fn().mockResolvedValue(new Map()),
+			getWorkspaceDiagnosticsSupport: vi
+				.fn()
+				.mockResolvedValue({ mode: "push-only" }),
+		});
 	});
 
 	it("reports cached LSP capabilities without requiring path", async () => {
@@ -806,7 +803,7 @@ describe("lsp_navigation tool", () => {
 		},
 	);
 
-	it("opens scoped file before workspaceSymbol query", async () => {
+	it("touches the scoped file, diagnostics off, before a workspaceSymbol query", async () => {
 		const tool = createLspNavigationTool((flag) => flag === "lens-lsp");
 		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-lsp-nav-"));
 		const filePath = path.join(tmpDir, "sample.ts");
@@ -829,11 +826,19 @@ describe("lsp_navigation tool", () => {
 			);
 
 			expect(result.isError).toBeUndefined();
+			// #2598: the scoped pre-open is a `touchFile`, and the OPTIONS are the
+			// point — a `workspaceSymbol` pre-open must not pay for a diagnostics
+			// wait, and must stay on the primary server.
 			expect(
-				(mocked.service as { openFile: ReturnType<typeof vi.fn> }).openFile,
+				(mocked.service as { touchFile: ReturnType<typeof vi.fn> }).touchFile,
 			).toHaveBeenCalledWith(
 				filePath,
 				expect.stringContaining("normalizeMapKey"),
+				{
+					diagnostics: "none",
+					source: "lsp_navigation",
+					clientScope: "primary",
+				},
 			);
 			expect(
 				(mocked.service as { workspaceSymbol: ReturnType<typeof vi.fn> })

--- a/tools/lsp-diagnostics.ts
+++ b/tools/lsp-diagnostics.ts
@@ -696,8 +696,8 @@ type DiagnosticsCollectionResult = {
 	 * were computed against current disk. `boundToCurrentDisk === false` means the
 	 * server's view diverged from disk; the caller demotes such a result to
 	 * "unconfirmed" so a stale-but-fresh-looking result never re-cements the
-	 * widget (#1092). Undefined when the touch path wasn't taken (openFile-only /
-	 * warm-attach / getDiagnostics fallback) → treated as "unknown" (no demotion).
+	 * widget (#1092). Undefined when no touch produced one (warm-attach /
+	 * getDiagnostics fallback) → treated as "unknown" (no demotion).
 	 */
 	binding?: DiagnosticBinding;
 };
@@ -713,13 +713,17 @@ async function collectDiagnosticsForFile(
 	// `touchFile` is the authoritative collection boundary for every scope: it
 	// preserves per-touch timeout, content-binding, and silent-clean confirmation
 	// metadata while returning diagnostics from only the requested clients. The
-	// legacy openFile/getDiagnostics path remains only for an older/mock service
-	// without touchFile, or when touchFile cannot resolve any clients.
+	// getDiagnostics fallback below remains for the two states a REAL service
+	// still reaches: the file read threw (no content to touch with), or the
+	// touch resolved no clients and returned `undefined` (clients/lsp/index.ts
+	// `touchFile`'s `no_clients`/`destroyed` returns). #2598 deleted the third
+	// reason — "an older/mock service without touchFile" — because the real
+	// `LSPService` has always defined the method unconditionally, so that arm
+	// was reachable only from a partial test double (AGENTS.md shape 7).
 	// #1179: the result is an explicit wrapper so side-channel fields survive
 	// array copies; confirmation was added when Marksman's lower-level clean verdict
 	// proved that a successful empty collection also needs explicit provenance.
 	let touched: TouchFileResult | undefined;
-	let usedTouch = false;
 	try {
 		content = fs.readFileSync(absPath, "utf-8");
 		if (isWarmAttached()) {
@@ -771,49 +775,26 @@ async function collectDiagnosticsForFile(
 				};
 			}
 		}
-		const serviceWithTouch = lspService as NonNullable<
-			ReturnType<typeof getLSPService>
-		> & {
-			touchFile?: (
-				filePath: string,
-				content: string,
-				options: {
-					diagnostics: "document";
-					collectDiagnostics: true;
-					maxClientWaitMs?: number;
-					source: string;
-					clientScope: "all" | "primary";
-				},
-			) => Promise<TouchFileResult | undefined>;
-		};
-		if (typeof serviceWithTouch.touchFile === "function") {
-			usedTouch = true;
-			touched = await serviceWithTouch.touchFile(absPath, content, {
-				diagnostics: "document",
-				collectDiagnostics: true,
-				maxClientWaitMs: waitMs,
-				source: "lsp_diagnostics",
-				clientScope: serverScope,
-			});
-			timedOut = touched?.inconclusive === true;
-		} else {
-			await lspService.openFile(absPath, content, {
-				preserveDiagnostics: false,
-			});
-		}
+		touched = await lspService.touchFile(absPath, content, {
+			diagnostics: "document",
+			collectDiagnostics: true,
+			maxClientWaitMs: waitMs,
+			source: "lsp_diagnostics",
+			clientScope: serverScope,
+		});
+		timedOut = touched?.inconclusive === true;
 	} catch {
 		// Non-fatal: getDiagnostics may still have stale/health information.
 	}
 
 	// Only fall through to the unscoped getDiagnostics() read when the touch
-	// branch wasn't taken (openFile-only path, which never collected anything
-	// and genuinely needs the follow-up call) or couldn't resolve any clients
-	// at all (touched stays undefined despite usedTouch). When touched IS
-	// defined it's already the answer — reusing it is what makes
-	// serverScope:"primary" actually skip auxiliary scanners and drops the
-	// common case back to a single LSP round trip instead of two.
+	// produced nothing to read — it threw, the file read threw before it ran, or
+	// it resolved no clients at all. When touched IS defined it's already the
+	// answer — reusing it is what makes serverScope:"primary" actually skip
+	// auxiliary scanners and drops the common case back to a single LSP round
+	// trip instead of two.
 	const diagnostics =
-		usedTouch && touched !== undefined
+		touched !== undefined
 			? touched.diags
 			: await lspService.getDiagnostics(
 					absPath,
@@ -834,26 +815,25 @@ async function collectDiagnosticsForFile(
 					fileRole: detectFileRole(absPath, content),
 				})
 			: diagnostics;
-	// #1095: surface the touch's content binding (only the touch path carries
-	// one; the openFile-only / getDiagnostics fallback leaves it undefined →
+	// #1095: surface the touch's content binding (only a touch that resolved
+	// clients carries one; the getDiagnostics fallback leaves it undefined →
 	// "unknown", no demotion).
-	const binding = usedTouch ? touched?.binding : undefined;
+	const binding = touched?.binding;
 	// #1470: `"partial"` counts here. `confirmedByTouch` feeds
 	// `canTrustTouchConfirmation`, which asks about the PRIMARY's own verdict —
 	// and a partial touch is one whose primary confirmed while an auxiliary was
 	// cut off. Excluding it would render "Primary LSP: unconfirmed" for a primary
 	// that did confirm. The coverage gap is carried separately, below.
-	const confirmedByTouch =
-		usedTouch && touchCompletedConfirmationPolicy(touched);
+	const confirmedByTouch = touchCompletedConfirmationPolicy(touched);
 	return {
 		diagnostics: filtered,
 		timedOut,
 		skipReason: touched?.skipReason,
 		confirmedByTouch,
-		// #1470: only a touch actually contributes a coverage gap; the
-		// openFile+getDiagnostics fallback never reports one, which is honest —
-		// that path claims no confirmation at all.
-		unconfirmedServerIds: usedTouch ? touchCoverageGap(touched) : [],
+		// #1470: only a touch that resolved clients contributes a coverage gap;
+		// the getDiagnostics fallback never reports one, which is honest — that
+		// path claims no confirmation at all.
+		unconfirmedServerIds: touchCoverageGap(touched),
 		content,
 		binding,
 	};

--- a/tools/lsp-navigation.ts
+++ b/tools/lsp-navigation.ts
@@ -706,15 +706,16 @@ async function openFileBestEffort(
 	}
 	if (!fileContent) return;
 	try {
-		if (typeof lspService.touchFile === "function") {
-			await lspService.touchFile(filePath, fileContent, {
-				diagnostics: waitForDiagnostics ? "document" : "none",
-				source: "lsp_navigation",
-				clientScope: waitForDiagnostics ? "all" : "primary",
-			});
-		} else {
-			await lspService.openFile(filePath, fileContent);
-		}
+		// #2598: `touchFile` is defined unconditionally on the real `LSPService`
+		// (clients/lsp/index.ts), so the former `typeof … === "function"` hedge
+		// and its `openFile` arm were reachable only from a partial test double
+		// (AGENTS.md shape 7). Nothing here reads the result — a touch that
+		// resolves no clients is already the no-op this helper wants.
+		await lspService.touchFile(filePath, fileContent, {
+			diagnostics: waitForDiagnostics ? "document" : "none",
+			source: "lsp_navigation",
+			clientScope: waitForDiagnostics ? "all" : "primary",
+		});
 	} catch {
 		/* LSP server may not be ready yet — proceed anyway */
 	}


### PR DESCRIPTION
## Summary

Deletes the three production presence probes #2599 left standing, now that its
`omit` matrix proved which dependents were real:

| site | probe deleted | how the dependents were re-expressed |
| --- | --- | --- |
| `tools/lsp-diagnostics.ts:789` | `typeof serviceWithTouch.touchFile === "function"` | doubles seed `touchFile: async () => undefined` |
| `tools/lsp-navigation.ts:709` | `typeof lspService.touchFile === "function"` | double keeps the factory `touchFile`; the case asserts the touch |
| `clients/lsp/tsserver-sync.ts:424` | `typeof svc.getAdvertisedCommands !== "function"` | no dependent; the method is now REQUIRED in the parameter type |

`LSPService.touchFile` (`clients/lsp/index.ts:4400`) and
`LSPService.getAdvertisedCommands` (`clients/lsp/index.ts:7253`) are
unconditional `async` methods on the class — line numbers confirmed on this
branch — and every production caller of all three sites gets that class from
`getLSPService(): LSPService` (`clients/lsp/index.ts:9682`, a non-optional
return) or from `this`. So each probe's else-arm was reachable only from a
partial test double: AGENTS.md shape 7, the family #2582/#2592 set out to
remove.

Two consequences the deletion forced, both kept in this PR because they are
this diff's own dead weight:

- **`usedTouch` is deleted.** With the probe gone, `touched` is assigned on the
  one path that also sets `usedTouch`, so `usedTouch === false` implies
  `touched === undefined`, and all four of its reads collapse:
  `usedTouch && touched !== undefined` → `touched !== undefined`;
  `usedTouch ? touched?.binding : undefined` → `touched?.binding`;
  `usedTouch && touchCompletedConfirmationPolicy(touched)` → the call alone
  (`result?.confirmation !== undefined`, false for `undefined`);
  `usedTouch ? touchCoverageGap(touched) : []` → the call alone
  (`result?.unconfirmedServerIds ?? []`). A boolean whose value cannot change
  an outcome is plumbing nothing reads.
- **`tests/config/hook-await-bounds.test.ts` pins one fewer unbounded await in
  each tool** (`tools/lsp-diagnostics.ts` 30→29, `tools/lsp-navigation.ts`
  33→32) — each lost its `await lspService.openFile(…)` arm. That governance
  suite caught it; it was not in the symbol grep.

**Refs #2598**, not `closes`: acceptance criteria 2 and 3 are met in full,
criterion 1 is met for the three sites the Ask names but **five same-shape
survivors remain** in `clients/lsp/tsserver-sync.ts`,
`clients/lsp/inferred-project.ts`, `tools/lsp-diagnostics.ts` and
`tools/lens-diagnostics.ts`. They are enumerated with per-site dependents in
**Class sweep** below and named in an issue comment, because none of them can
honestly carry "a comment naming a shape that genuinely lacks it" and each
needs its own dependent sweep (one of them would undo #2599's #611 repair).

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [x] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR — this PR fixes no defect and adds no test FILE, so what stands in its place is the premise red (14 cases), five mutation transcripts, and a before/after equivalence run for every migrated file. All quoted verbatim below.
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test — this PR adds no guard; it deletes three. Each guard the deletion leaves as the SOLE remaining one is mutation-proven red (M1, M3, M4), and the one rewritten assertion is mutation-proven red (M2).
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (run `npm install` after dep changes) — no dep change
- [ ] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there — nothing AGENTS.md states becomes false. Shape 7 and shape 38 both still describe live machinery; the `omit` affordance and the double sweep are untouched.
- [x] `.changelog/fix-2598-delete-presence-probes.md` has one valid entry **in this PR**
- [x] Commit subject includes the issue number

```
$ npm run lint
> tsc --project tsconfig.json && npm run lint:js
> oxlint --deny-warnings --ignore-pattern "tests/**/*.ts" …
(clean, no output)

$ node scripts/check-changelog-fragments.mjs
changelog fragments OK (123 entries in .changelog/)

$ npx oxfmt --check <the 7 touched .ts files>
Checking formatting...
All matched files use the correct format.
Finished in 5ms on 7 files using 32 threads.

$ npm run build:dist
  dist/index.bundled.mjs  4.4mb ⚠️
⚡ Done in 42ms
[bundle] wrote self-contained dist/index.js
```

## Deletion sweep — every dependent, per probe (#2568 lesson)

### `touchFile` — `tools/lsp-diagnostics.ts` + `tools/lsp-navigation.ts`

| question | command | answer |
| --- | --- | --- |
| does the real service always define it? | `grep -nE '^\t(async )?touchFile\(' clients/lsp/index.ts` | `4400: async touchFile(` — unconditional class method |
| what do the production callers hold? | `grep -n 'export function getLSPService' -A 3 clients/lsp/index.ts` | `getLSPService(): LSPService` — the concrete class, non-optional return |
| production readers of the probe | `grep -rn 'typeof .*\.touchFile .*"function"' --include=*.ts clients/ tools/ mcp/ index.ts` | the two sites deleted here, nothing else |
| test doubles depending on the ABSENCE | `grep -rn 'omit: \["touchFile"\]' tests/` | `tests/tools/lsp-diagnostics.test.ts:97`, `tests/tools/lsp-diagnostics-inferred-project.test.ts:73`, `tests/tools/lsp-navigation.test.ts:102` — the three #2599 measured |
| other test files naming `touchFile` | `grep -rln touchFile tests/` | 40 files; every other one either OVERRIDES `touchFile` on a factory-seeded double or drives the real `LSPService`. None reads its absence — all 168 files in the verification run below are green. |
| tests observing `openFile` from these two tools | `grep -rn openFile tests/tools/*.ts` | 12 sites in the three migrated files; all repointed or deleted (see Tests) |

**Premise reproduced first** (the issue's "Live dependents" table, re-measured on
this branch's parent by neutering `omit` in the factory —
`for (const key of options.omit ?? []) delete service[key as string];` →
a comment; `touchFile` is the only key those three files omit, so this is
exactly "un-omit `touchFile` in all three"):

```
 ❯ |default| tests/tools/lsp-navigation.test.ts (38 tests | 1 failed) 197ms
 ❯ |default| tests/tools/lsp-diagnostics-inferred-project.test.ts (1 test | 1 failed) 9ms
 ❯ |default| tests/tools/lsp-diagnostics.test.ts (59 tests | 12 failed) 115ms
⎯⎯⎯⎯⎯⎯ Failed Tests 14 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  |default| tests/tools/lsp-diagnostics-inferred-project.test.ts > lsp_diagnostics — inferred-project demotion (#1645 F3) > writes DEMOTED diagnostics into the shared widget store
AssertionError: expected 0 to be greater than 0
 ❯ tests/tools/lsp-diagnostics-inferred-project.test.ts:105:28
 FAIL  |default| tests/tools/lsp-diagnostics.test.ts > lsp_diagnostics tool > checks explicit filePaths as a batch
AssertionError: expected +0 to be 1 // Object.is equality
 ❯ tests/tools/lsp-diagnostics.test.ts:173:45
 FAIL  |default| tests/tools/lsp-diagnostics.test.ts > lsp_diagnostics tool > returns honest mixed per-file outcomes and aggregate counts (#837)
AssertionError: expected { clean: 2, findings: +0, …(4) } to match object { clean: 1, findings: 1, …(2) }
 ❯ tests/tools/lsp-diagnostics.test.ts:249:42
 FAIL  |default| tests/tools/lsp-diagnostics.test.ts > lsp_diagnostics tool > skips canonical excluded dirs during directory scans
AssertionError: expected [] to deeply equal [ 'src/good.ts' ]
 ❯ tests/tools/lsp-diagnostics.test.ts:403:19
 FAIL  |default| tests/tools/lsp-navigation.test.ts > lsp_navigation tool > opens scoped file before workspaceSymbol query
AssertionError: expected "vi.fn()" to be called with arguments: [ …(2) ]
```

12 + 1 + 1 = 14, matching the issue's table exactly.

**The seam that replaces the absence.** Not a flag on the tool's options — the
tool has no such state to carry, and adding one would be a test-shaped
parameter in production, the same defect wearing a different hat. The seam is
the touch's own RETURN VALUE, which production already branches on:
`clients/lsp/index.ts` `touchFile` returns bare `undefined` when the service is
destroyed (`failureKind: "destroyed"`) and when no client came ready
(`serverCountReady: 0`), and `collectDiagnosticsForFile` has always fallen
through to `getDiagnostics` for exactly that. So the two diagnostics suites seed
`touchFile: vi.fn(async () => undefined)` — the double now mirrors the real
surface AND selects a state the real service genuinely produces — and land on
byte-identical downstream values:

| field | old (`omit`, `usedTouch === false`) | new (`touchFile → undefined`) |
| --- | --- | --- |
| `diagnostics` | `await getDiagnostics(…)` | `await getDiagnostics(…)` |
| `timedOut` | `false` | `touched?.inconclusive === true` → `false` |
| `binding` | `undefined` | `touched?.binding` → `undefined` |
| `confirmedByTouch` | `false` | `touchCompletedConfirmationPolicy(undefined)` → `false` |
| `unconfirmedServerIds` | `[]` | `touchCoverageGap(undefined)` → `[]` |
| `skipReason` | `undefined` | `undefined` |

`tests/tools/lsp-navigation.test.ts` needs no such seed: `openFileBestEffort`
discards the result, so the double keeps the factory's `touchFile` and the one
affected case asserts the touch and **its options** — a strictly stronger
assertion than the `openFile` one it replaces (proof M2).

### `getAdvertisedCommands` — `clients/lsp/tsserver-sync.ts`

| question | command | answer |
| --- | --- | --- |
| does the real service always define it? | `grep -nE '^\t(async )?getAdvertisedCommands\(' clients/lsp/index.ts` | `7253: async getAdvertisedCommands(` |
| production callers of `attemptTsserverSyncDiagnostics` | `grep -rn attemptTsserverSyncDiagnostics --include=*.ts clients/ tools/ mcp/ index.ts` | `clients/lsp/index.ts:5638,6115` (both pass `this`), `tools/lsp-diagnostics.ts:932` (passes the `getLSPService()` service) |
| test doubles depending on the absence | #2599's per-key matrix; re-checked `grep -rn 'omit: \["getAdvertisedCommands"\]' tests/` | none — #2599 deleted all four as unfalsifiable |
| test callers of the function directly | `grep -rn 'attemptTsserverSyncDiagnostics\|runTsserverSyncCommand' tests/` | none |

**Does the removal change any observable behaviour? No, and it could not have.**
The whole body is `try { … } catch { return undefined; }`. For a service without
the method the deleted line returned `undefined`; without the line,
`svc.getAdvertisedCommands(file)` throws a `TypeError` that the function's own
catch turns into the same `undefined`. Same value, same absence of side effects
(the throw happens before any command is issued, exactly as the bail did). The
type now says so: the parameter is
`TsserverSyncCapableService & Required<Pick<…, "getAdvertisedCommands">>`.

`TsserverSyncCapableService` itself keeps `getAdvertisedCommands` optional
deliberately — it is the SHARED structural interface for `runTsserverSyncCommand`
and the `inferred-project.ts` helpers, and `tests/clients/lsp/inferred-project.test.ts:241`
legitimately passes `{}` to `demoteInferredProjectSweepResults`. Narrowing the
one function that calls the method is the precise change; widening the shared
interface would have been a typecheck break in a helper that never touches it.

**`"advertises nothing"` is now the sole guard, so it is pinned** — M1 below.

## Mutation proofs (all quoted verbatim from local runs on this branch)

**M1 — the `!advertised.includes(TSSERVER_REQUEST_COMMAND)` bail, now the only
thing between an advertising read and an `executeCommand`.** Deleted from the
built `clients/lsp/tsserver-sync.js`:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  |default| tests/tools/lsp-diagnostics.test.ts > lsp_diagnostics tool > #611 tsserver sync escape hatch > falls back to unconfirmed when the command isn't advertised
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 2 times
 ❯ tests/tools/lsp-diagnostics.test.ts:927:32
 FAIL  |default| tests/tools/lsp-diagnostics.test.ts > lsp_diagnostics tool > silent-clean confirmation provenance > missing confirmation metadata stays unconfirmed and does not try a TypeScript command
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 2 times
 ❯ tests/tools/lsp-diagnostics.test.ts:1428:32
 Test Files  1 failed (1)
      Tests  2 failed | 57 passed (59)
```

**M2 — the rewritten navigation assertion.** `diagnostics: waitForDiagnostics ? "document" : "none"`
forced to `"document"` in the built `tools/lsp-navigation.js`. The `openFile`
assertion this replaced could not observe the options at all:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  |default| tests/tools/lsp-navigation.test.ts > lsp_navigation tool > touches the scoped file, diagnostics off, before a workspaceSymbol query
AssertionError: expected "vi.fn()" to be called with arguments: [ …(3) ]
-     "diagnostics": "none",
+     "diagnostics": "document",
 Test Files  1 failed (1)
      Tests  1 failed | 37 passed (38)
```

**M3 — the `getDiagnostics` fallback the migrated doubles now select.** If this
branch were decoration, deleting it would leave the suites green:
`touched !== undefined ? touched.diags : await lspService.getDiagnostics(…)`
→ `touched?.diags ?? []`:

```
 FAIL  tests/tools/lsp-diagnostics-inferred-project.test.ts > writes DEMOTED diagnostics into the shared widget store
 FAIL  tests/tools/lsp-diagnostics.test.ts > checks explicit filePaths as a batch
 FAIL  tests/tools/lsp-diagnostics.test.ts > returns honest mixed per-file outcomes and aggregate counts (#837)
 FAIL  tests/tools/lsp-diagnostics.test.ts > #533 honest emptiness > batch: mixed found/clean/unconfirmed never collapses to a bare '0 diagnostics'
 Test Files  2 failed (2)
      Tests  10 failed | 50 passed (60)
```

**M4 — the touch itself, now unconditional.** `touched = await lspService.touchFile(…)`
→ `touched = undefined; false && await lspService.touchFile(…)`:

```
 FAIL  tests/tools/lsp-diagnostics.test.ts > checks explicit filePaths as a batch
AssertionError: expected "vi.fn()" to be called 2 times, but got 0 times
 FAIL  tests/tools/lsp-diagnostics.test.ts > bounds an in-flight file and the whole batch on abort (#837)
AssertionError: expected +0 to be 1 // Object.is equality
 FAIL  tests/tools/lsp-diagnostics.test.ts > skips canonical excluded dirs during directory scans
AssertionError: expected [] to deeply equal [ 'src/good.ts' ]
 Test Files  1 failed (1)
      Tests  24 failed | 35 passed (59)
```

**Proof B — nothing went vacuous.** For each migrated file, one mutation of the
code that file exists to test, run at this branch's HEAD (factory double +
deleted probes) and again with `git checkout origin/master --` on the three
production files and the three test files, rebuilt. Identical verdicts:

| file | mutation (on the built `.js`) | AFTER (branch `77e43b9d`) | BEFORE (`origin/master` `04b4b0a1`) |
| --- | --- | --- | --- |
| `tests/tools/lsp-diagnostics.test.ts` | `applySeverityFilter` returns `[]` | `Tests  14 failed \| 45 passed (59)` | `Tests  14 failed \| 45 passed (59)` |
| `tests/tools/lsp-diagnostics-inferred-project.test.ts` | `applyInferredProjectDemotion` returns its input | `Tests  1 failed (1)` | `Tests  1 failed (1)` |
| `tests/tools/lsp-navigation.test.ts` | `openFileBestEffort` early-returns | `Tests  1 failed \| 37 passed (38)` | `Tests  1 failed \| 37 passed (38)` |

Raw transcript:

```
########## AFTER (branch HEAD 77e43b9d) ##########
--- B1 applySeverityFilter -> [] | tests/tools/lsp-diagnostics.test.ts
 Test Files  1 failed (1)
      Tests  14 failed | 45 passed (59)
--- B2 applyInferredProjectDemotion bypassed | tests/tools/lsp-diagnostics-inferred-project.test.ts
 Test Files  1 failed (1)
      Tests  1 failed (1)
--- B3 openFileBestEffort neutered | tests/tools/lsp-navigation.test.ts
 Test Files  1 failed (1)
      Tests  1 failed | 37 passed (38)
########## BEFORE (origin/master 04b4b0a1) ##########
--- B1 applySeverityFilter -> [] | tests/tools/lsp-diagnostics.test.ts
 Test Files  1 failed (1)
      Tests  14 failed | 45 passed (59)
--- B2 applyInferredProjectDemotion bypassed | tests/tools/lsp-diagnostics-inferred-project.test.ts
 Test Files  1 failed (1)
      Tests  1 failed (1)
--- B3 openFileBestEffort neutered | tests/tools/lsp-navigation.test.ts
 Test Files  1 failed (1)
      Tests  1 failed | 37 passed (38)
```

The proof used `git checkout origin/master -- <7 files>` after committing this
branch's work (`77e43b9d`), then `git checkout HEAD -- <7 files>`; `git status`
came back clean and the edits were re-verified present. No `git stash`.

## Tests

No new test FILES. Every change is an edit; the three suites keep every case
they had (98 → 98).

- **`tests/tools/lsp-diagnostics.test.ts`** — `omit: ["touchFile"]` → a
  `touchFile: vi.fn(async () => undefined)` override with a comment naming the
  real-service state it models. The `openFile: vi.fn()` override is DELETED
  (the tool no longer calls `openFile` at all — `grep -n openFile
  tools/lsp-diagnostics.ts` returns nothing). Seven `openFile` observations
  repointed at `touchFile`: one call-count (`checks explicit filePaths as a
  batch`), **two `not.toHaveBeenCalled()` abort assertions** (`#343`
  short-circuit, batch and directory — these would have gone VACUOUSLY green
  against an `openFile` production no longer calls, which is why they moved
  rather than stayed), and four directory-scan "which files were visited"
  readers. Screens: *ambient-inspection double* (the double mirrors the real
  surface instead of a guessed subset), *all-mocks* (unchanged — the tool's own
  seam is still driven end to end; M1/M3/M4 demonstrate it).
- **`tests/tools/lsp-diagnostics-inferred-project.test.ts`** — same `omit` →
  `touchFile → undefined` swap, dead `openFile` override deleted.
- **`tests/tools/lsp-navigation.test.ts`** — `omit` dropped entirely (factory
  `touchFile` kept), dead `openFile` override deleted, and
  `opens scoped file before workspaceSymbol query` becomes
  `touches the scoped file, diagnostics off, before a workspaceSymbol query`:
  it now asserts the touch **and its options** (`diagnostics: "none"`,
  `clientScope: "primary"`), which is what production actually sends and what
  the old `openFile` assertion structurally could not see. Declarative
  present-tense name per the #2602 convention. Screen: *wrong-layer pin* — the
  case pins the call production makes, not a fallback nothing reaches.
- **`tests/config/hook-await-bounds.test.ts`** — two pins lowered by one each,
  with the reason inline. Governance data, no assertion changed.

Red-first note: this PR fixes no defect, so there is no pre-fix red for a NEW
regression test. What replaces it is the premise red (14 cases, quoted), M1–M4,
and the before/after equivalence table.

### Test assessment

| file | what it uniquely pins | redundancy found |
| --- | --- | --- |
| `tests/tools/lsp-diagnostics.test.ts` | the tool's severity/scope contract, `#533` honest emptiness, `#586` inline suppressions, the `#611` tsserver escape hatch, `#343` abort bounds | none — every case survived the M4 sweep with a distinct failure, and the four `#611` cases still bail at four distinct points (absent `executeCommand`, the not-advertised list, an `executeCommand` rejection, the tier gate) |
| `tests/tools/lsp-diagnostics-inferred-project.test.ts` | one demotion rule reaching the shared widget store | none (single case) |
| `tests/tools/lsp-navigation.test.ts` | the navigation tool's per-operation JSON contract | none |
| `tests/config/hook-await-bounds.test.ts` | the one-hop unbounded-await worklist | none |

**Vacuity sweep on the files touched** (AGENTS.md "Test assessment and
removal"). Three candidates were interrogated, and the verdict was *repair, not
delete*, in each case:

1. `#343` batch abort and 2. `#343` directory abort — both assert
   `not.toHaveBeenCalled()`. After the probe deletion, `openFile` is called by
   NOTHING, so left alone they would have passed on any mutation whatsoever.
   Repointed at `touchFile`; M4 (which stops the touch happening at all) leaves
   them green while redding 24 siblings, and the mutation that *matters* to
   them — dropping the `signal?.aborted` short-circuit — is the pre-existing
   pin, unchanged.
3. The three `openFile: vi.fn().mockResolvedValue(undefined)` overrides — dead
   after the deletion (nothing calls the method). Deleted; the factory default
   remains, so no double loses surface.

No test was removed. `omit` in `tests/support/lsp-service-double.ts` keeps its
own factory unit test (`tests/config/lsp-service-double-sweep.test.ts:445`) as
its only caller, and the ladder says KEEP: it is the affordance the sweep's own
failure message directs authors to (`"seed from makeLspServiceDouble(), using
omit for methods that must be absent"`), and deleting it would leave a future
test that needs a genuinely-absent method with no sanctioned path but a
hand-rolled double — the exact defect #2582 closed. Recorded here rather than
walked past.

## Blast radius

`module_report` was not run: the production delta is three deleted `typeof`
operands, two deleted `else` arms, one deleted local `boolean`, and one
parameter type narrowed — enumerable by grep, and enumerated above. Per module:

- **`tools/lsp-diagnostics.ts`** — `collectDiagnosticsForFile` is called only
  from within this module (per-file collection for `lsp_diagnostics`). Its
  return shape is unchanged field-for-field (table above). The `else` arm it
  loses was `await lspService.openFile(absPath, content, { preserveDiagnostics:
  false })`, which in production never ran.
- **`tools/lsp-navigation.ts`** — `openFileBestEffort` has 7 call sites, all in
  this module (`grep -n openFileBestEffort tools/lsp-navigation.ts`), all
  discarding the result. Behaviour in production is byte-identical: the touch
  arm is the one a real service always took.
- **`clients/lsp/tsserver-sync.ts`** — `attemptTsserverSyncDiagnostics` has
  three production call sites (`clients/lsp/index.ts:5638`, `:6115`,
  `tools/lsp-diagnostics.ts:932`), all handing it the real `LSPService`. The
  narrowed parameter type compiles at all three (`npm run lint` green).
  `TsserverSyncCapableService` is unchanged, so `runTsserverSyncCommand`,
  `fetchTsserverProjectIdentity` and the `inferred-project.ts` helpers are
  untouched.

Not a hot path in the per-render/per-spawn sense — one fewer `typeof` per file
collection. No measured delta claimed.

Verification plan, selected mechanically, not from memory:

```
$ grep -rln "touchFile\|getAdvertisedCommands\|attemptTsserverSyncDiagnostics\|openFileBestEffort\|makeLspServiceDouble\|lsp-navigation\|lsp-diagnostics\|lens-diagnostics\|tsserver-sync" tests/ --include=*.test.ts | wc -l
119
$ ls tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts tests/config/*.test.ts | wc -l
56
$ # union, plus tests/clients/flake-shape-ratchet.test.ts explicitly
$ npm run test:targeted -- <the 168 files>
 Test Files  168 passed (168)
      Tests  2168 passed | 3 skipped (2171)
   Duration  57.31s
```

The governance half of that set is what caught `hook-await-bounds`; the symbol
grep alone would have shipped CI red (the #2107 / #2470 lesson). First run of
the same 168 files, before that pin was lowered:

```
 FAIL  |default| tests/config/hook-await-bounds.test.ts > #2523 AC1 every hook-path await is bounded, and no new hand-rolled race > pins every one-hop helper module's unbounded-await count
AssertionError: hook helper unbounded-await pin (#2523 slice 3 worklist): 2 flagged item(s) are neither registered nor exempted:
  tools/lsp-diagnostics.ts@29
  tools/lsp-navigation.ts@32
 Test Files  1 failed | 167 passed (168)
      Tests  1 failed | 2167 passed | 3 skipped (2171)
```

The full suite is delegated to CI's Unit tests lane: it is serialized
machine-wide and a dozen agent lanes are contending for the lock.

## Observability

Not applicable in the additive sense — nothing is added, and the deleted arms
emitted nothing. What the change does affect is that `latency.log`'s
`lsp_touch_file` phase record (`clients/lsp/index.ts`, via `logLatency`) is now
emitted for EVERY `lsp_diagnostics` and `lsp_navigation` file visit on any
service shape, where previously a service without `touchFile` would have taken
the silent `openFile` arm and recorded nothing. In production that arm never
ran, so this is a widening of the guarantee, not of the volume. `serverScope`
and `clientScope: "primary"` on the navigation pre-open are exactly what M2
pins.

## Class sweep

**Class:** AGENTS.md shape 7 — a test double's shape leaking into the hot path:
a `typeof service.method === "function"` probe in production for a method the
real collaborator defines unconditionally, whose else-arm therefore only a
partial double can reach. The family #2582 opened, #2592/#2599 narrowed
(`isSpawnInFlight`), and this PR narrows further.

**Population sweep — the WHOLE tree.** This PR introduces no new symbol and no
new literal, so the sweep is over the class's own shape, run across `clients/`,
`tools/`, `mcp/`, `commands/`, `scripts/` and `index.ts`, plus the local-const
spelling the regex misses:

```
$ grep -rnE 'typeof [A-Za-z_$][A-Za-z0-9_$.?]*\.[A-Za-z0-9_$]+ (===|!==) "function"' \
    --include=*.ts --include=*.mjs --include=*.js --include=*.cjs \
    clients/ tools/ mcp/ commands/ scripts/ index.ts
… 39 hits, of which the LSP-service-shaped ones are:
clients/lsp/inferred-project.ts:211   executeReadOnlyCommandOnLiveClient
clients/lsp/tsserver-sync.ts:213      options.commandChannel.executeCommand
clients/lsp/tsserver-sync.ts:290      executeReadOnlyCommandOnLiveClient
clients/lsp/tsserver-sync.ts:380      executeCommand
tools/lsp-diagnostics.ts:272          ensureWarmForSweep
$ grep -n 'runWorkspaceDiagnostics !== "function"' tools/lens-diagnostics.ts
1777:	if (typeof runWorkspaceDiagnostics !== "function") {   # local-const spelling
$ grep -rn 'touchFile\|getAdvertisedCommands' --include=*.ts clients/ tools/ mcp/ index.ts | grep 'typeof'
(none)
```

The three sites this PR deletes are gone from the tree; nothing else spells
them. The remaining 33 hits are not this class — `AbortSignal.any`,
`timer.unref`, `spec.command`/`spec.url` (union types that genuinely hold a
function OR a value), the `pi` host object, `ui`, `readGuard`, `cacheManager`,
`scanner`, `ParserClass.init`.

**Per-member verdict for the six LSP-service-shaped survivors, honestly:**

| site | receiver's real shape in production | does a shape genuinely lack it? | dependents on the ABSENCE | verdict |
| --- | --- | --- | --- | --- |
| `tsserver-sync.ts:213` `commandChannel.executeCommand` | `TsserverProjectIdentityCommandChannel` — an **LSPClient**-side channel built in `clients/lsp/client.ts`, not `LSPService` | **yes** — a different object entirely | n/a | **keep**, out of the class |
| `tsserver-sync.ts:380` `svc.executeCommand` | the real `LSPService` (`clients/lsp/index.ts:7278`) | no | **1** — #2599's repaired `#611` case (`falls back to unconfirmed when the sync command IS advertised but the service exposes no executeCommand`) exists *because* the method is outside the factory surface | **defer** — deleting it also deletes that case; that is a judgement this issue's Ask does not authorize |
| `tsserver-sync.ts:290` / `inferred-project.ts:211` `executeReadOnlyCommandOnLiveClient` | the real `LSPService` (`:7320`) | no — and the interface's own comment says "Optional so older test doubles keep working", which is the class stated out loud | **≥1** — `tests/clients/lsp/inferred-project.test.ts:241` passes literal `{}` and asserts the sweep returns its input | **defer** — needs the method added to the factory surface first (which moves `lsp-service-double-sweep.test.ts:523`'s vocabulary pin) |
| `tools/lsp-diagnostics.ts:272` `ensureWarmForSweep` | the real `LSPService` (`:8026`) | no | unmeasured; the call sits inside a per-server group runner with no local catch, so an absent method would reject the whole scan | **defer** — same factory-surface prerequisite |
| `tools/lens-diagnostics.ts:1777` `runWorkspaceDiagnostics` | the real `LSPService` (`:8259`) | no | unmeasured; unlike the others this one has a USER-VISIBLE fallback (`"LSP service does not support project-wide workspace diagnostics."` + `lspUnavailable: true`), so its deletion also deletes a rendered string | **defer** — largest blast radius of the six |

Every deferral is recorded, not walked past: the five are named in a comment on
#2598, which stays open for them. This is why the PR says `refs`, not `closes`.

**Consolidation verdict: the family stays distributed, and shrinks by
deletion.** A shared `hasCapability(service, name)` helper would RELOCATE six
`typeof` expressions into one module without concentrating any logic — each has
a different fallback (return `undefined`, skip a warm-up, render a message,
take an `openFile` arm) — so by AGENTS.md's deletion test it is a shallow
abstraction and does not earn its indirection. The correct fold for this family
is subtraction: the count went 6 → 3 in #2592/#2599 plus this PR
(`isSpawnInFlight`, two `touchFile`, `getAdvertisedCommands`), and the five
survivors above are the remaining worklist.

**Class of size 1 for the `omit` option:**

```
$ grep -rn 'omit: \[' tests/ --include=*.ts
tests/config/lsp-service-double-sweep.test.ts:445:  const omitted = makeLspServiceDouble({}, { omit: ["isSpawnInFlight"] });
```

One caller, the factory's own unit test. Kept — see Test assessment for the
ladder reasoning.

## Merge-order note

No open PR touches these files. #2607 touches
`tests/clients/hook-await-fold-bounds.test.ts`, a different file from this PR's
`tests/config/hook-await-bounds.test.ts`; #2610's rename sweep does not include
any of the three suites (`gh pr diff 2610 --name-only` has no overlap).
Mergeable in any order. This PR adds no sweep, so
`tests/config/sweep-floor-coverage.test.ts` needs no new entry (it is green in
the 168-file run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y
