### PR TITLE
refactor(clients): fold escapeRegExp copies onto one export (closes #2558)

### DIFF
--- a/.changelog/2558-fold-escape-regexp.md
+++ b/.changelog/2558-fold-escape-regexp.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **`escapeRegExp` folded onto one runtime export (refs #2558)** — the regex-escaping helper (and its near-namesakes `escapeRegExpChar`/`escapeRegExpLiteral`/a renamed `escapeRegex`) was hand-copied into eight production modules and four test helpers with a byte-identical body. `clients/string-utils.ts` now owns the one runtime copy and `tests/support/sweep-kit.ts` re-exports it for tests; every former copy imports from one of those instead. A new `tests/config/escape-regexp-fold-sweep.test.ts` guard flags a future re-copy by matching the escaping BODY (not the function's name), so a renamed copy is caught the same way the original `escapeRegex` rename in `scripts/lib/astgrep-self-scan.mjs` was. `clients/file-utils.ts`'s `globToRegExp` keeps its own narrower character class (it omits glob wildcards `*`/`?`, which its caller handles separately) as a documented variant, not a copy.

--- a/clients/dispatch/runners/utils/diagnostic-parsers.ts
+++ b/clients/dispatch/runners/utils/diagnostic-parsers.ts
@@ -6,6 +6,7 @@
  */
 
 import { stripAnsi } from "../../../sanitize.js";
+import { escapeRegExp } from "../../../string-utils.js";
 import { getAutofixCapability } from "../../../tool-policy.js";
 import type { DefectClass, Diagnostic } from "../../types.js";
 
@@ -216,8 +217,4 @@ export function createSimpleParser(
 
 		return diagnostics;
 	};
-}
-
-function escapeRegExp(string: string): string {
-	return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/clients/feature-hints.ts
+++ b/clients/feature-hints.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from "./string-utils.js";
+
 export type FeatureHintKind = "service" | "cli-command" | "library";
 
 export type TrustBoundary =
@@ -15,9 +17,7 @@ function normalizeHintInput(value: string): string {
 }
 
 function hasHintToken(value: string, tokens: readonly string[]): boolean {
-	const escaped = tokens.map((token) =>
-		token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
-	);
+	const escaped = tokens.map((token) => escapeRegExp(token));
 	const alternatives = escaped.join("|");
 	// Path/word boundaries are deliberately explicit: a token must occupy a
 	// segment (or a dot/dash/underscore-separated word), never an arbitrary

--- a/clients/middle-man-analysis.ts
+++ b/clients/middle-man-analysis.ts
@@ -29,6 +29,7 @@
  */
 
 import type { ModuleSymbolEntry } from "./module-report.js";
+import { escapeRegExp } from "./string-utils.js";
 
 /** Self-reference token + member-access separator, per languageId. Both the
  * self→field and field→method hops use the SAME separator in every language
@@ -72,10 +73,6 @@ const MIN_CANDIDATE_METHODS = 2;
  * "mostly" — a class with a couple of forwarding convenience methods among
  * real logic must NOT flag (the exact distinction #325 asks for). */
 const DELEGATION_RATIO_THRESHOLD = 0.9;
-
-function escapeRegExp(s: string): string {
-	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 function buildForwardRegex(token: string, sep: string): RegExp {
 	const t = escapeRegExp(token);

--- a/clients/path-utils.ts
+++ b/clients/path-utils.ts
@@ -17,6 +17,7 @@ import * as path from "node:path";
 import { win32 } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { minimatch } from "./deps/minimatch.js";
+import { escapeRegExp } from "./string-utils.js";
 
 /**
  * Detect a positively Windows-shaped path, regardless of the host OS.
@@ -766,11 +767,6 @@ export const UV_WORKSPACE_EXCLUDE_DIALECT: WorkspaceMemberGlobDialect = {
 	normalizePattern: (pattern) => path.posix.normalize(toPosix(pattern)),
 };
 
-/** Escape one character that carries no glob meaning into a literal. */
-function escapeRegExpChar(ch: string): string {
-	return ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 /**
  * Index of the `]` closing the character class opened at `open`, or `-1` when
  * the run is unterminated (in which case the `[` is a literal). A leading `!`
@@ -815,7 +811,7 @@ function globRunToRegExpSource(
 				continue;
 			}
 		}
-		out += escapeRegExpChar(ch);
+		out += escapeRegExp(ch);
 	}
 	return out;
 }

--- a/clients/review-graph/builder.ts
+++ b/clients/review-graph/builder.ts
@@ -36,7 +36,7 @@ import {
 } from "../path-utils.js";
 import { collectProjectSourceFilesWithBudgetAsync } from "../project-scan-policy.js";
 import { getReviewGraphMaxFilesDerived } from "../project-scale.js";
-import { compareOrdinal } from "../string-utils.js";
+import { compareOrdinal, escapeRegExp } from "../string-utils.js";
 import { BoundedLruCache } from "../bounded-cache.js";
 import {
 	jsTsCandidatePaths,
@@ -1112,10 +1112,6 @@ function makeCtx(
 		hasTool: async () => false,
 		log: () => {},
 	};
-}
-
-function escapeRegExp(string: string): string {
-	return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function createEmptyGraph(): ReviewGraph {

--- a/clients/scratch-tree-policy.ts
+++ b/clients/scratch-tree-policy.ts
@@ -55,6 +55,7 @@
  */
 
 import { EXCLUDED_DIRS, getExcludedDirGlobs } from "./file-utils.js";
+import { escapeRegExp } from "./string-utils.js";
 
 /** Directory-name entries only — drops glob entries (e.g. `*.dSYM`) that a
  * bare directory-name/regex exclude can't express. */
@@ -72,10 +73,6 @@ function literalExcludedDirNames(): string[] {
  */
 export function getScratchTreeGlobPatterns(): string[] {
 	return getExcludedDirGlobs();
-}
-
-function escapeRegExp(literal: string): string {
-	return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /** Bare directory names, for tools (opengrep/semgrep `--exclude`) that treat a

--- a/clients/string-utils.ts
+++ b/clients/string-utils.ts
@@ -18,3 +18,17 @@
 export function compareOrdinal(a: string, b: string): number {
 	return a < b ? -1 : a > b ? 1 : 0;
 }
+
+/**
+ * Escape a string for safe interpolation into a `RegExp` source, so every
+ * regex metacharacter it contains is matched literally instead of taking on
+ * its regex meaning. This is the ONE runtime copy (#2558) — string-utils.ts
+ * is a leaf (no imports of its own), so importing it never creates a cycle.
+ * Before #2558 this same body was hand-copied under this name (and as
+ * `escapeRegExpChar`/`escapeRegExpLiteral`) into ~8 production modules and 3
+ * test helpers; fold new call sites onto this export instead of re-copying
+ * it.
+ */
+export function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/clients/tree-sitter-client.ts
+++ b/clients/tree-sitter-client.ts
@@ -46,6 +46,7 @@ import {
 	assertInstallAllowed,
 	getProjectTrustGeneration,
 } from "./project-trust.js";
+import { escapeRegExp } from "./string-utils.js";
 import { logTreeSitterDiagnostic } from "./tree-sitter-logger.js";
 import { notifyUserDegradation } from "./user-notify.js";
 
@@ -2996,16 +2997,6 @@ export class TreeSitterClient {
 				break; // first __slots__ wins
 			}
 			return slots;
-		}
-
-		/**
-		 * Escape a string for safe interpolation into a `RegExp` source —
-		 * needed anywhere an identifier's raw text is combined with regex
-		 * metacharacters like `\b` word boundaries (see
-		 * "not_closed_or_try_with_resources" below; #1089 P2).
-		 */
-		function escapeRegExp(s: string): string {
-			return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 		}
 
 		switch (postFilter) {

--- a/scripts/lib/astgrep-self-scan.mjs
+++ b/scripts/lib/astgrep-self-scan.mjs
@@ -19,6 +19,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { safeSpawn } from "../../clients/safe-spawn.js";
+import { escapeRegExp } from "../../clients/string-utils.js";
 
 export const SELF_SCAN_CATEGORY = "pi-lens-self-scan";
 
@@ -53,10 +54,6 @@ function readMetadataCategory(text) {
 	if (!m) return undefined;
 	const inner = m[1].match(/^[ \t]*category:\s*(.+)$/m);
 	return inner ? inner[1].trim().replace(/^['"]|['"]$/g, "") : undefined;
-}
-
-function escapeRegex(s) {
-	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /** Every rule ID whose YAML declares `metadata: { category: pi-lens-self-scan }`.
@@ -102,7 +99,7 @@ export function runSelfScan({
 			`[astgrep-self-scan] no rules tagged category: ${SELF_SCAN_CATEGORY} under ${rulesDir(root)} -- nothing to run. If every self-scan rule was intentionally removed, delete this script and its CI wiring instead of letting it report a silent "clean" scan.`,
 		);
 	}
-	const filterRegex = `^(${ids.map(escapeRegex).join("|")})$`;
+	const filterRegex = `^(${ids.map(escapeRegExp).join("|")})$`;
 	const result = safeSpawn(
 		"ast-grep",
 		[

--- a/tests/clients/config-deprecation-registry.test.ts
+++ b/tests/clients/config-deprecation-registry.test.ts
@@ -11,7 +11,7 @@ import {
 	DECLARED_LEGACY_FILE_SURFACES,
 	REGISTERED_LEGACY_FILE_SURFACES,
 } from "../../clients/config-locations.js";
-import { assertNonEmptyScan } from "../support/sweep-kit.js";
+import { assertNonEmptyScan, escapeRegExp } from "../support/sweep-kit.js";
 
 const REPO_ROOT = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -113,7 +113,7 @@ function deprecatedChangelogText(): { released: string; unreleased: string } {
  * one, and a row could ship with nobody ever told about it.
  */
 function isAnnounced(text: string, surface: string): boolean {
-	const escaped = surface.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const escaped = escapeRegExp(surface);
 	return new RegExp("`\\s*" + escaped + "\\s*`").test(text);
 }
 

--- a/tests/clients/deps-centralization.test.ts
+++ b/tests/clients/deps-centralization.test.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { escapeRegExp } from "../support/sweep-kit.js";
 
 const root = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -34,7 +35,7 @@ function* walkTs(dir: string): Generator<string> {
 }
 
 function importRegex(dep: string): RegExp {
-	const esc = dep.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const esc = escapeRegExp(dep);
 	// `from "<dep>"` / `from "<dep>/sub"` (static) or `import("<dep>")` (dynamic)
 	return new RegExp(`(?:from|import\\()\\s*["']${esc}(?:/[^"']*)?["']`);
 }

--- a/tests/clients/mutating-tool-classification.test.ts
+++ b/tests/clients/mutating-tool-classification.test.ts
@@ -19,7 +19,7 @@ import { handleAgentEnd } from "../../clients/runtime-agent-end.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { handleToolResult } from "../../clients/runtime-tool-result.js";
 import { hashlineFixture } from "../support/hashline-anchor-vectors.js";
-import { assertNonEmptyScan } from "../support/sweep-kit.js";
+import { assertNonEmptyScan, escapeRegExp } from "../support/sweep-kit.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
 vi.mock("../../clients/pipeline.js", async (importOriginal) => {
@@ -757,17 +757,6 @@ function collectToolNameAliases(source: string): string[] {
 		if (name) names.add(name);
 	}
 	return [...names];
-}
-
-/**
- * Escape every regex metacharacter, not just the ones an identifier can hold.
- * `$` is legal in a JS identifier and is an anchor in a regex, which is the
- * case that actually matters here — but a partial escape is the
- * `js/incomplete-sanitization` shape CodeQL flags (and is one backslash away
- * from being wrong if this helper is ever reused), so escape the whole class.
- */
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function aliasComparisonPatterns(aliases: string[]): RegExp[] {

--- a/tests/config/diagnostics-bus-conformance.test.ts
+++ b/tests/config/diagnostics-bus-conformance.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { repoRoot } from "../support/module-instance-scan.js";
 import {
 	assertNonEmptyScan,
+	escapeRegExp,
 	listSourceFiles,
 	relativePosix,
 	stripSource,
@@ -91,9 +92,7 @@ function busSubscriberFiles(
 			}
 		}
 		const eventArgument = `(?:["']${EVENT}["']|${
-			[...bindings]
-				.map((binding) => binding.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
-				.join("|") || "(?!)"
+			[...bindings].map(escapeRegExp).join("|") || "(?!)"
 		})`;
 		return new RegExp(`\\.on\\s*\\(\\s*${eventArgument}(?=\\s*[,)])`).test(
 			source,

--- a/tests/config/escape-regexp-fold-sweep.test.ts
+++ b/tests/config/escape-regexp-fold-sweep.test.ts
@@ -1,0 +1,141 @@
+/**
+ * #2558: forbid a NEW copy of the regex-escaping helper outside
+ * `clients/string-utils.ts`.
+ *
+ * Before this issue, `escapeRegExp` (and near-namesakes `escapeRegExpChar`,
+ * `escapeRegExpLiteral`, and a renamed `escapeRegex`) was hand-copied into
+ * eight production modules and four test helpers, all with the byte-identical
+ * body `x.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")` — found by grepping the
+ * NAME (`function escapeRegExp`), which a renamed copy trivially evades
+ * (`scripts/lib/astgrep-self-scan.mjs` shipped exactly that: `escapeRegex`,
+ * same body, different name). `clients/string-utils.ts` now owns the one
+ * runtime copy and `tests/support/sweep-kit.ts` re-exports it for the test
+ * side; every former copy imports from one of those instead.
+ *
+ * This sweep matches the ESCAPING BODY, not the function's name (AGENTS.md
+ * defect shape 38 — "cheapest evasion" screen: a guard that only matches a
+ * name is defeated by a rename that keeps the body). It flags two shapes,
+ * both meaning "a reusable escaping helper duplicates this body":
+ *
+ *   A. `function <name>(<param>) { ... return <param>.replace(<escape>); }`
+ *   B. `(<param>) => <param>.replace(<escape>)` (arrow, parenthesized or
+ *      bare single param) — this is also how `feature-hints.ts`'s inline
+ *      `.map((token) => token.replace(...))` copy read before its fold, so
+ *      an inline arrow callback counts as a "definition" too.
+ *
+ * It deliberately does NOT flag a bare inline `value.replace(<escape>)`
+ * that is not itself a function/arrow body (e.g. `const esc =
+ * dep.replace(...)` in `deps-centralization.test.ts`, or the same shape in
+ * `scripts/lib/merge-train-lane.mjs`, `scripts/rollup-changelog.mjs`,
+ * `scripts/run-all-ts-rules-posthog.mjs`, `scripts/lib/compat-contracts.mjs`,
+ * `tests/clients/config-deprecation-registry.test.ts`, and
+ * `tests/support/public-surface-drift.ts`): each is a single one-off
+ * computation at its own call site, not a copy-pasted HELPER, and
+ * `merge-train-lane.mjs` in particular runs in a workflow with no build step
+ * before it (`.github/workflows/merge-train-lane.yml`), so importing the
+ * compiled `clients/string-utils.js` there would break that job. Folding a
+ * true one-off into an import trades one inline call for a dependency with
+ * no duplication removed; the ladder's step 1 ("does this need to exist")
+ * says no.
+ *
+ * A DIFFERENT character class is a variant, not a copy, and stays out of
+ * this sweep's reach on purpose: `clients/file-utils.ts`'s `globToRegExp`
+ * omits `*` and `?` from the escaped set because its caller handles those
+ * two glob wildcards itself immediately afterward.
+ *
+ * Uses `stripSource(..., { strings: "keep" })` (`tests/support/sweep-kit.ts`)
+ * so comments are blanked (a fake definition written only in a comment must
+ * not count — the #1635/#1692 comment-laundering shape) while regex literals
+ * and string contents are preserved (the default "blank" policy blanks
+ * regex bodies too, which would erase the very escape sequence this sweep
+ * matches on).
+ */
+
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+	assertNonEmptyScan,
+	listSourceFiles,
+	relativePosix,
+	stripSource,
+} from "../support/sweep-kit.js";
+
+const root = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+
+/** The one file allowed to define the escaping body. */
+const CANONICAL_FILE = "clients/string-utils.ts";
+
+// The literal idiom, as it appears in source: `.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")`
+// (quote style may vary; whitespace around the comma may vary).
+const ESCAPE_CALL = String.raw`\.replace\(\s*\/\[\.\*\+\?\^\$\{\}\(\)\|\[\\\]\\\\\]\/g\s*,\s*["'\`]\\\\\$&["'\`]\s*\)`;
+
+/** Shape A: a function declaration/expression whose body returns the escape. */
+const FUNCTION_SHAPE = new RegExp(
+	String.raw`function\s+[A-Za-z_$][\w$]*\s*\([^)]*\)[^{]*\{\s*return\s+[A-Za-z_$][\w$]*` +
+		ESCAPE_CALL +
+		String.raw`\s*;?\s*\}`,
+);
+
+/** Shape B: an arrow function (parenthesized or bare single param) whose
+ * expression body is the escape — including an inline callback such as
+ * `.map((token) => token.replace(...))`. */
+const ARROW_SHAPE = new RegExp(
+	String.raw`(?:\(\s*[A-Za-z_$][\w$]*[^)]*\)|[A-Za-z_$][\w$]*)\s*(?::\s*[\w$]+)?\s*=>\s*[A-Za-z_$][\w$]*` +
+		ESCAPE_CALL,
+);
+
+function listCandidateFiles(): string[] {
+	const files: string[] = [];
+	for (const dir of ["clients", "tools", "mcp", "tests"]) {
+		const abs = path.join(root, dir);
+		try {
+			files.push(
+				...listSourceFiles(abs, {
+					extensions: [".ts"],
+					skipDeclarations: true,
+				}),
+			);
+		} catch {
+			// directory doesn't exist in this checkout; nothing to scan
+		}
+	}
+	return files;
+}
+
+describe("escapeRegExp single-source-of-truth (#2558)", () => {
+	it("has no local escaping-helper definition outside the canonical leaf", () => {
+		const files = listCandidateFiles();
+		assertNonEmptyScan("clients/tools/mcp/tests source files", files.length);
+
+		const offenders: string[] = [];
+		for (const file of files) {
+			const rel = relativePosix(root, file);
+			if (rel === CANONICAL_FILE) continue;
+			const raw = readFileSync(file, "utf8");
+			const stripped = stripSource(raw, { strings: "keep" });
+			if (FUNCTION_SHAPE.test(stripped) || ARROW_SHAPE.test(stripped)) {
+				offenders.push(rel);
+			}
+		}
+
+		expect(
+			offenders,
+			`new escaping-helper definition(s) found outside ${CANONICAL_FILE} — ` +
+				`import { escapeRegExp } from "clients/string-utils.js" ` +
+				`(or its tests/support/sweep-kit.js re-export) instead of re-copying ` +
+				`the body: ${offenders.join(", ")}`,
+		).toEqual([]);
+	});
+
+	it("the canonical leaf still defines escapeRegExp with the expected body", () => {
+		const src = readFileSync(path.join(root, CANONICAL_FILE), "utf8");
+		expect(FUNCTION_SHAPE.test(stripSource(src, { strings: "keep" }))).toBe(
+			true,
+		);
+	});
+});

--- a/tests/config/escape-regexp-fold-sweep.test.ts
+++ b/tests/config/escape-regexp-fold-sweep.test.ts
@@ -23,20 +23,32 @@
  *      `.map((token) => token.replace(...))` copy read before its fold, so
  *      an inline arrow callback counts as a "definition" too.
  *
- * It deliberately does NOT flag a bare inline `value.replace(<escape>)`
- * that is not itself a function/arrow body (e.g. `const esc =
- * dep.replace(...)` in `deps-centralization.test.ts`, or the same shape in
- * `scripts/lib/merge-train-lane.mjs`, `scripts/rollup-changelog.mjs`,
- * `scripts/run-all-ts-rules-posthog.mjs`, `scripts/lib/compat-contracts.mjs`,
- * `tests/clients/config-deprecation-registry.test.ts`, and
- * `tests/support/public-surface-drift.ts`): each is a single one-off
- * computation at its own call site, not a copy-pasted HELPER, and
- * `merge-train-lane.mjs` in particular runs in a workflow with no build step
- * before it (`.github/workflows/merge-train-lane.yml`), so importing the
- * compiled `clients/string-utils.js` there would break that job. Folding a
- * true one-off into an import trades one inline call for a dependency with
- * no duplication removed; the ladder's step 1 ("does this need to exist")
- * says no.
+ * Round 2 (F1): the scan tree used to stop at `clients`/`tools`/`mcp`/`tests`
+ * with only `.ts`, so the very recurrence this file's header names —
+ * `scripts/lib/astgrep-self-scan.mjs`'s renamed `escapeRegex` — was outside
+ * the swept tree and a reintroduction there passed silently. `scripts` is now
+ * scanned too, with `.mjs` added to the extensions (never bare `.js`: a bare
+ * `.js` would also match compiled output sitting next to its `.ts` source —
+ * `clients/string-utils.js` itself — and self-flag the canonical file's own
+ * build artifact as a second "copy" of its own body).
+ *
+ * It deliberately does NOT flag a bare inline `value.replace(<escape>)` that
+ * is not itself a function/arrow body — e.g. `const escapedSha =
+ * mergeSha.replace(...)` in `scripts/lib/merge-train-lane.mjs`, and the same
+ * shape in `scripts/rollup-changelog.mjs`, `scripts/run-all-ts-rules-posthog.mjs`,
+ * and `scripts/lib/compat-contracts.mjs`: each is a single one-off
+ * computation at its own call site, not a copy-pasted HELPER. These four
+ * specifically stay un-folded (not merely un-flagged) because
+ * `merge-train-lane.mjs`'s workflow (`.github/workflows/merge-train-lane.yml`)
+ * runs `node scripts/merge-train-lane.mjs` directly with no `npm install`/
+ * `npm run build` step before it, so importing the compiled
+ * `clients/string-utils.js` there would 404 that job; the other three keep
+ * the same one-off shape for consistency rather than for their own
+ * build-order reason. (Round 2 F3: three PLAIN test-side one-offs that
+ * looked like the same case — `tests/clients/deps-centralization.test.ts`,
+ * `tests/clients/config-deprecation-registry.test.ts`,
+ * `tests/support/public-surface-drift.ts` — turned out to have no such
+ * constraint and are folded onto the `sweep-kit.js` re-export instead.)
  *
  * A DIFFERENT character class is a variant, not a copy, and stays out of
  * this sweep's reach on purpose: `clients/file-utils.ts`'s `globToRegExp`
@@ -89,20 +101,41 @@ const ARROW_SHAPE = new RegExp(
 		ESCAPE_CALL,
 );
 
+// ".mjs", not ".js": scripts/lib/*.mjs are hand-written source, but a bare
+// ".js" would also match compiled output sitting next to its .ts source
+// (clients/string-utils.js itself, and every other clients/*.js this repo's
+// build emits in place) and self-flag the canonical file's own build
+// artifact as a second "copy" of its own body.
+const CANDIDATE_EXTENSIONS = [".ts", ".mjs"];
+
+// A real per-directory floor (not the `assertNonEmptyScan` default of 1) —
+// set well below each directory's actual population (434/17/5/91/1073 at
+// authoring time) so normal file growth/removal never trips it, but a
+// directory silently dropped from the scan (e.g. `scripts` reverted after
+// F1, or a whole tree renamed) reliably does. Mirrors
+// `tests/config/tracked-control-bytes.test.ts`'s per-population floors.
+const CANDIDATE_DIRS: ReadonlyArray<{ dir: string; floor: number }> = [
+	{ dir: "clients", floor: 380 },
+	{ dir: "tools", floor: 10 },
+	{ dir: "mcp", floor: 3 },
+	{ dir: "scripts", floor: 60 },
+	{ dir: "tests", floor: 900 },
+];
+
 function listCandidateFiles(): string[] {
 	const files: string[] = [];
-	for (const dir of ["clients", "tools", "mcp", "tests"]) {
+	for (const { dir, floor } of CANDIDATE_DIRS) {
 		const abs = path.join(root, dir);
-		try {
-			files.push(
-				...listSourceFiles(abs, {
-					extensions: [".ts"],
-					skipDeclarations: true,
-				}),
-			);
-		} catch {
-			// directory doesn't exist in this checkout; nothing to scan
-		}
+		// A configured scan directory that has gone missing (renamed, deleted)
+		// must fail loud, not silently scan fewer files than intended — the
+		// #1718 empty-sweep shape one layer up: `listSourceFiles` itself throws
+		// on a missing `dir`, and this must not swallow that.
+		const found = listSourceFiles(abs, {
+			extensions: CANDIDATE_EXTENSIONS,
+			skipDeclarations: true,
+		});
+		assertNonEmptyScan(`${dir}/ (.ts + .mjs)`, found.length, floor);
+		files.push(...found);
 	}
 	return files;
 }
@@ -110,7 +143,13 @@ function listCandidateFiles(): string[] {
 describe("escapeRegExp single-source-of-truth (#2558)", () => {
 	it("has no local escaping-helper definition outside the canonical leaf", () => {
 		const files = listCandidateFiles();
-		assertNonEmptyScan("clients/tools/mcp/tests source files", files.length);
+		// Belt-and-suspenders total floor on top of each directory's own floor
+		// above (~1620 at authoring time).
+		assertNonEmptyScan(
+			"clients/tools/mcp/scripts/tests source files",
+			files.length,
+			1400,
+		);
 
 		const offenders: string[] = [];
 		for (const file of files) {

--- a/tests/config/files-touched-bus-conformance.test.ts
+++ b/tests/config/files-touched-bus-conformance.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { repoRoot } from "../support/module-instance-scan.js";
 import {
+	escapeRegExp,
 	listSourceFiles,
 	relativePosix,
 	stripSource,
@@ -109,9 +110,7 @@ function busSubscriberFiles(
 			}
 		}
 		const eventArgument = `(?:["']${EVENT}["']|${
-			[...bindings]
-				.map((binding) => binding.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
-				.join("|") || "(?!)"
+			[...bindings].map(escapeRegExp).join("|") || "(?!)"
 		})`;
 		return new RegExp(`\\.on\\s*\\(\\s*${eventArgument}(?=\\s*[,)])`).test(
 			source,

--- a/tests/support/atomic-write-scan.ts
+++ b/tests/support/atomic-write-scan.ts
@@ -29,6 +29,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { toPosix } from "../../clients/path-utils.js";
+import { escapeRegExp } from "./sweep-kit.js";
 
 export const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -89,10 +90,6 @@ function importedFsBindings(source: string): string[] {
 		}
 	}
 	return [...bindings];
-}
-
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**

--- a/tests/support/public-surface-drift.ts
+++ b/tests/support/public-surface-drift.ts
@@ -31,6 +31,7 @@
  */
 
 import * as fs from "node:fs";
+import { escapeRegExp } from "./sweep-kit.js";
 import {
 	assertSchemaStabilityTiers,
 	type JsonSchemaNode,
@@ -97,7 +98,7 @@ export interface PublicSurface {
  * span reading `config.ui.compact` documents `ui`, a longer word does not.
  */
 export function documentedIn(text: string, name: string): boolean {
-	const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const escaped = escapeRegExp(name);
 	const token = `(?<![A-Za-z0-9_$])${escaped}(?![A-Za-z0-9_$])`;
 	return new RegExp(
 		`(\`[^\`\\n]*${token}[^\`\\n]*\`)|("${escaped}"\\s*:)|(^#{1,6}\\s.*${token})|(^\\|[^\\n]*${token})`,

--- a/tests/support/session-state-scan.ts
+++ b/tests/support/session-state-scan.ts
@@ -16,7 +16,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { listSourceFiles, relativePosix, stripSource } from "./sweep-kit.js";
+import {
+	escapeRegExp,
+	listSourceFiles,
+	relativePosix,
+	stripSource,
+} from "./sweep-kit.js";
 
 export const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -552,11 +557,6 @@ export function auditContainerClassExclusions(
 	return problems;
 }
 
-/** Escape a literal identifier for safe use inside a `RegExp` alternation. */
-function escapeRegExpLiteral(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 const containerDeclarationCache = new Map<string, RegExp>();
 
 /**
@@ -581,7 +581,7 @@ function containerDeclarationRegex(dir: string): RegExp {
 	const cached = containerDeclarationCache.get(dir);
 	if (cached) return cached;
 	const names = [...BUILTIN_CONTAINER_CTORS, ...containerClassNames(dir)].map(
-		escapeRegExpLiteral,
+		escapeRegExp,
 	);
 	const regex = new RegExp(
 		`^(?:export\\s+)?(?:const|let)\\s+([A-Za-z_$][\\w$]*)[^=\\n]*=\\s*new\\s+(?:${names.join("|")})\\b`,

--- a/tests/support/sweep-kit.ts
+++ b/tests/support/sweep-kit.ts
@@ -110,6 +110,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { lineContentHash } from "../../clients/read-guard.js";
 import { toPosix } from "../../clients/path-utils.js";
+// Re-exported for test doubles/helpers so the test side has ONE import to
+// reach for instead of hand-copying the escaping body (#2558). This is the
+// ONE test-side re-export; the runtime copy lives in clients/string-utils.ts.
+export { escapeRegExp } from "../../clients/string-utils.js";
 
 // ── 1. Source scanning ──────────────────────────────────────────────────────
 

--- a/tools/lsp-navigation.ts
+++ b/tools/lsp-navigation.ts
@@ -16,6 +16,7 @@ import {
 } from "../clients/lsp-mutation.js";
 import type { LSPCallHierarchyItem } from "../clients/lsp/client.js";
 import { uriToPath } from "../clients/path-utils.js";
+import { escapeRegExp } from "../clients/string-utils.js";
 import { isRecordableProjectPath } from "../clients/file-utils.js";
 import { compactRenderResult } from "./render-compact.js";
 import {
@@ -114,10 +115,6 @@ function emptyReasonForOperation(operation: LspNavigationOperation): string {
 	if (operation === "incomingCalls" || operation === "outgoingCalls")
 		return "no-call-hierarchy-results";
 	return "no-results";
-}
-
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 type SymbolColumnResolution = {


### PR DESCRIPTION
## Summary

Folds the byte-identical `escapeRegExp` copies onto one runtime export. Before
this PR the regex-escaping body `x.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")` was
hand-copied into eight production modules (under `escapeRegExp` and the
near-namesakes `escapeRegExpChar`/a renamed `escapeRegex`) and four test
helpers (under `escapeRegExp`/`escapeRegExpLiteral`). `clients/string-utils.ts`
now owns the ONE runtime copy; `tests/support/sweep-kit.ts` re-exports it for
the test side. Every former copy imports from one of those instead, and a new
governance sweep (`tests/config/escape-regexp-fold-sweep.test.ts`) flags a
future re-copy — matched by BODY, not name, so a rename can't evade it.

`clients/string-utils.ts` was picked over `clients/path-utils.ts` (the issue's
suggested leaf) because it already exists as a pure, zero-import string-utility
leaf (`compareOrdinal`, #2155/#2165) — reusing it beats adding a second leaf or
growing `path-utils.ts` with a non-path-specific helper (AGENTS.md
single-source-of-truth / minimalism-ladder step 2). `path-utils.ts` itself had
its own internal copy (`escapeRegExpChar`) and now imports the shared export
too.

Closes #2558 — every enumerated copy (and three more found by a body-literal
sweep) is folded; the remaining variant and four one-off sites stay
distributed with reasons below.

## Copy table

| Site | Shape | Disposition |
|---|---|---|
| `clients/scratch-tree-policy.ts:77` | `function escapeRegExp` | folded → import from `string-utils.js` |
| `clients/middle-man-analysis.ts:76` | `function escapeRegExp` | folded |
| `clients/tree-sitter-client.ts:3008` (nested) | `function escapeRegExp` | folded |
| `tools/lsp-navigation.ts:119` | `function escapeRegExp` | folded |
| `clients/review-graph/builder.ts:1117` | `function escapeRegExp` | folded (module already imports `../string-utils.js` for `compareOrdinal`) |
| `clients/path-utils.ts:770` | `function escapeRegExpChar` | folded, renamed away, module now imports the shared export |
| `clients/dispatch/runners/utils/diagnostic-parsers.ts:222` | `function escapeRegExp` | folded |
| `clients/feature-hints.ts:19` | inline `.map((token) => token.replace(...))` | folded to `.map((token) => escapeRegExp(token))` |
| `tests/clients/mutating-tool-classification.test.ts:769` | `function escapeRegExp` | folded → `sweep-kit.js` re-export |
| `tests/support/atomic-write-scan.ts:94` | `function escapeRegExp` | folded → `sweep-kit.js` re-export |
| `tests/support/session-state-scan.ts:556` | `function escapeRegExpLiteral` | folded, renamed to `escapeRegExp` at the import |
| `tests/config/diagnostics-bus-conformance.test.ts:95` | inline `.map((binding) => binding.replace(...))` | folded (same arrow-body shape as `feature-hints.ts`) |
| `tests/config/files-touched-bus-conformance.test.ts:113` | inline `.map((binding) => binding.replace(...))` | folded |
| `scripts/lib/astgrep-self-scan.mjs:58` | `function escapeRegex` (renamed copy — **not** in the issue's list, found by grepping the literal VALUE, not the name) | folded → import from `../../clients/string-utils.js` (already build-gated: CI's `Build` step runs before `npm run astgrep:self-scan`) |
| `tests/clients/deps-centralization.test.ts:37` | `const esc = dep.replace(...)` (local var, not a function) | **round 2 (F3):** folded → `sweep-kit.js` re-export |
| `tests/clients/config-deprecation-registry.test.ts:116` | `const escaped = surface.replace(...)` | **round 2 (F3):** folded → `sweep-kit.js` re-export |
| `tests/support/public-surface-drift.ts:100` | `const escaped = name.replace(...)` | **round 2 (F3):** folded → new `./sweep-kit.js` import + re-export |
| `tests/config/bounded-eviction-idiom-sweep.test.ts:125` | none present | stale reference in the issue — this file no longer defines it (drifted since #2546 r2) |

### Variant and one-off sites left distributed (with reasons)

- **`clients/file-utils.ts:989` `globToRegExp`** — narrower character class
  `[.+^${}()|[\]\\]` (omits `*` and `?`): those two are glob wildcards the
  caller substitutes for `.*`/`.` immediately afterward, so folding onto the
  full escape set would double-escape them. Genuine variant, kept.
- **`scripts/rollup-changelog.mjs:178`, `scripts/run-all-ts-rules-posthog.mjs:29`,
  `scripts/lib/compat-contracts.mjs:130`, `scripts/lib/merge-train-lane.mjs:531`**
  — each is a single inline `value.replace(...)` computation embedded
  directly in a larger expression at its own call site, not a reusable
  named/anonymous HELPER. `merge-train-lane.mjs` additionally cannot depend on
  the compiled `clients/string-utils.js`: `.github/workflows/merge-train-lane.yml`'s
  `lane` job runs `node scripts/merge-train-lane.mjs` directly with **no**
  `npm install`/`npm run build` step before it, so that import would 404 in
  that workflow (verified by reading the workflow file). The other three keep
  the same one-off shape for consistency, not for their own build-order
  reason — round 1's "trades an inline call for a dependency with no
  duplication removed" framing was correct for these four but WRONG for the
  three test files above, which round 2 (F3) folds: each already imports
  `tests/support/sweep-kit.js` (or, for `public-surface-drift.ts`, sits in
  the same directory as it), so there was no dependency to trade — just an
  unfolded copy.

**Net-count:** helper definitions found by `grep -rnE 'function escapeRegExp|const escapeRegExp|escapeRegExp(Char)? ?='`
over `clients/ tools/ mcp/ scripts/ tests/ index.ts`: **10 → 1** (the one
export in `clients/string-utils.ts`). Including the `.map(arrow)` sites, the
renamed `escapeRegex`, and round 2's three additional folds, total distinct
duplicate definitions/inline copies removed: **15**.

## Type of change

- [x] Enhancement (improvement to existing capability)

## Area

- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (the new governance sweep; existing tests exercise every touched call site)
- [x] Targeted test files for the touched seams pass locally after `npm run build`
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted below
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds (clients/ and tools/ touched)
- [x] `package-lock.json` is in sync with `package.json` (unchanged by this PR)
- [ ] `AGENTS.md` update — not needed; no new convention or invariant, just a fold of an existing one (single-source-of-truth)
- [x] `.changelog/2558-fold-escape-regexp.md` added (section: Changed); unchanged in round 2 (no user-facing behavior changed, only the governance test's own reach)
- [x] Commit subject includes `Refs #2558`

## Tests

- **`tests/config/escape-regexp-fold-sweep.test.ts` (NEW, widened in round 2)**
  — governance sweep. Two cases: (1) no escaping-HELPER definition (function
  declaration or arrow-with-expression-body, matched by BODY not name) exists
  outside `clients/string-utils.ts`; (2) the canonical leaf still defines it
  with the expected body. Named recurrence: the fold this PR performs, and
  the specific rename-evasion `scripts/lib/astgrep-self-scan.mjs`'s
  `escapeRegex` already demonstrated in this repo (AGENTS.md defect shape 38
  — "cheapest evasion" screen).

  **Round 1 red-first proof 1 (plain reintroduced copy)** — reverted
  `clients/scratch-tree-policy.ts` to reintroduce its original
  `function escapeRegExp` copy, rebuilt, ran the sweep:
  ```
  FAIL  |default| tests/config/escape-regexp-fold-sweep.test.ts > escapeRegExp single-source-of-truth (#2558) > has no local escaping-helper definition outside the canonical leaf
  AssertionError: new escaping-helper definition(s) found outside clients/string-utils.ts — import { escapeRegExp } from "clients/string-utils.js" (or its tests/support/sweep-kit.js re-export) instead of re-copying the body: clients/scratch-tree-policy.ts: expected [ 'clients/scratch-tree-policy.ts' ] to deeply equal []
  ```
  Restored the file, rebuilt, sweep green again.

  **Round 1 red-first proof 2 (shape-38 mutation: renamed copy)** — added a
  differently-named `function escapeRx` with the identical body to
  `clients/middle-man-analysis.ts` (the cheapest evasion of a name-based
  guard), rebuilt, ran the sweep:
  ```
  FAIL  |default| tests/config/escape-regexp-fold-sweep.test.ts > escapeRegExp single-source-of-truth (#2558) > has no local escaping-helper definition outside the canonical leaf
  AssertionError: new escaping-helper definition(s) found outside clients/string-utils.ts — import { escapeRegExp } from "clients/string-utils.js" (or its tests/support/sweep-kit.js re-export) instead of re-copying the body: clients/middle-man-analysis.ts: expected [ 'clients/middle-man-analysis.ts' ] to deeply equal []
  ```
  Restored the file, rebuilt, sweep green again (2/2 passed).

  **Round 2 red-first proof (F1 — the actual reviewer-named recurrence)** —
  reintroduced `scripts/lib/astgrep-self-scan.mjs`'s ORIGINAL renamed copy
  (`function escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g,
  "\\$&"); }`, called as `ids.map(escapeRegex)`) against the round-1 sweep's
  scan tree (`clients`/`tools`/`mcp`/`tests`, `.ts` only) and it passed
  silently — proving F1's claim. After widening `CANDIDATE_DIRS` to include
  `scripts` and `CANDIDATE_EXTENSIONS` to `[".ts", ".mjs"]`, the identical
  reintroduction reds:
  ```
  FAIL  |default| tests/config/escape-regexp-fold-sweep.test.ts > escapeRegExp single-source-of-truth (#2558) > has no local escaping-helper definition outside the canonical leaf
  AssertionError: new escaping-helper definition(s) found outside clients/string-utils.ts — import { escapeRegExp } from "clients/string-utils.js" (or its tests/support/sweep-kit.js re-export) instead of re-copying the body: scripts/lib/astgrep-self-scan.mjs: expected [ 'scripts/lib/astgrep-self-scan.mjs' ] to deeply equal []
  ```
  Restored the file, sweep green again (2/2 passed). Also reran the sweep on
  the shipped (fixed) tree after widening — still green, confirming the four
  legitimate `scripts/*.mjs` inline one-offs are NOT flagged (they're plain
  `value.replace(...)` statements, not function/arrow definitions).

- **Round 2 (F2)** — `assertNonEmptyScan` now takes a real per-directory floor
  (`clients` 380, `tools` 10, `mcp` 3, `scripts` 60, `tests` 900, each well
  below its actual population at authoring time: 434/17/5/91/1073) plus a
  1400 belt-and-suspenders total floor, mirroring
  `tests/config/tracked-control-bytes.test.ts`'s per-population floors. The
  `try/catch` around `listSourceFiles` that swallowed a missing scan
  directory is removed — `listSourceFiles`/`readdirSync` already throws
  `ENOENT` on a missing directory, so removing the swallow is sufficient; not
  separately mutation-proved against a real repo directory (renaming a real
  source tree to prove a throw was judged higher-risk than the property is
  worth — `readdirSync`'s throw-on-missing-path is stdlib-guaranteed
  behavior, not new logic this PR wrote).

- **Round 2 (F3)** — folded three plain test-side `const x = value.replace(...)`
  one-offs (`deps-centralization.test.ts`, `config-deprecation-registry.test.ts`,
  `public-surface-drift.ts`) onto the `sweep-kit.js` re-export; behavior
  unchanged (byte-identical escape), confirmed by each file's own test suite
  (see Verification below).

### Test assessment

No existing test asserts on the identity of the local `escapeRegExp`
function itself (only on its OUTPUT via the modules that call it), so no
existing test became redundant or was removed.

## Blast radius

Every touched production call site keeps the exact same escaping behavior
(same regex, same replacement) — this is a pure extract-and-import refactor,
not a behavior change. Verified per module:

- `clients/path-utils.ts`, `clients/string-utils.ts` → `tests/clients/path-utils.test.ts`, `tests/clients/string-utils.test.ts`
- `clients/scratch-tree-policy.ts` → `tests/clients/scratch-tree-policy-coverage.test.ts`
- `clients/middle-man-analysis.ts` → `tests/clients/middle-man-analysis.test.ts`
- `clients/review-graph/builder.ts` → full `tests/clients/review-graph/` suite (20 files, 150 tests)
- `clients/tree-sitter-client.ts` → full `tests/clients/tree-sitter-*.test.ts` + `tests/clients/dispatch/` (164 files, 2179 tests)
- `clients/dispatch/runners/utils/diagnostic-parsers.ts` → no dedicated test file exists for `createSimpleParser`; covered indirectly by the dispatch suite above and by `npm run build`'s type-check
- `clients/feature-hints.ts` → `tests/clients/feature-hints.test.ts`
- `tools/lsp-navigation.ts` → `tests/tools/lsp-navigation.test.ts`, `tests/tools/lsp-navigation-workspace-attribution.test.ts`
- `scripts/lib/astgrep-self-scan.mjs` → `tests/scripts/astgrep-self-scan.test.ts` (10 tests)
- test-support files (round 1) → `tests/clients/mutating-tool-classification.test.ts`, `tests/clients/atomic-write-sweep.test.ts`, `tests/clients/session-state-conformance.test.ts`, `tests/support/sweep-kit.test.ts`, `tests/config/diagnostics-bus-conformance.test.ts`, `tests/config/files-touched-bus-conformance.test.ts`
- test-support files (round 2, F3) → `tests/clients/deps-centralization.test.ts` (self), `tests/clients/config-deprecation-registry.test.ts` (self), `tests/clients/public-surface-drift.test.ts`, `tests/clients/lsp/lsp-fixture-coverage.test.ts`, `tests/config/sweep-floor-coverage.test.ts` (all consume `public-surface-drift.ts`)

All green (see totals below). No hot-path change (this is a compile-time-cost
regex-escaping helper called on config/scan-path strings, not per-file/
per-spawn data).

## Observability

Not applicable — this is a pure internal-structure refactor (no new
degradation, no new log line; identical string output for identical input).

## Class sweep

Defect class: **helper duplication** (AGENTS.md single-source-of-truth rule,
this issue). Swept the WHOLE tree, not just `clients/`:

- `grep -rnE 'function escapeRegExp|const escapeRegExp|escapeRegExp(Char)? ?='` over `clients/ tools/ mcp/ scripts/ tests/ index.ts` → 10 hits pre-fix, 1 post-fix (the canonical export).
- `grep -rnF '[.*+?^${}()|[\]\\]/g'` (the literal escape-regex VALUE, to catch renamed/anonymous copies the name-grep can't) over the same tree → found the additional `escapeRegex` rename in `scripts/lib/astgrep-self-scan.mjs` (not in the issue's list), the two `.map(arrow)` sites in the bus-conformance tests, and (round 2) the three plain test-side one-offs F3 names. Post-fix this grep returns only: the canonical file (`.ts` + compiled `.js`), the documented `file-utils.ts` variant (different char class), and the 4 single-occurrence inline computations in `scripts/*.mjs` — one of them (`merge-train-lane.mjs`) for a hard environmental reason (no build step in its workflow), the other three left for consistency with it.
- The governance sweep itself now scans `clients/ tools/ mcp/ scripts/ tests/` with both `.ts` and `.mjs` (round 2, F1) — round 1's sweep scanned only `.ts` and skipped `scripts/` entirely, so it could not see the one real pre-existing rename-evasion in this repo (`astgrep-self-scan.mjs`'s `escapeRegex`) and a reintroduction there would have passed silently, which round 2's red-first proof above confirms.

**Consolidation verdict:** folded onto `clients/string-utils.ts` (one runtime
export) + `tests/support/sweep-kit.ts` (one test re-export). 4 single-occurrence
sites in `scripts/*.mjs` stay distributed — each is one inline computation at
its own call site (not a copy-pasted helper), and one of the four cannot
depend on the compiled `clients/` output at all without breaking its workflow.

## Merge-order note

**Correction (round 2):** round 1 stated "no open PR touches these files" —
that was wrong. **#2621** ("decide workspace-member globs without
backtracking", closes #2603) deletes `escapeRegExpChar` in the same
`clients/path-utils.ts` hunk this PR also touches (this PR renames it away
and redirects call sites to the shared `string-utils.js` export; #2621
removes it as part of an unrelated glob-matching rewrite). **Decided merge
order: #2617 (this PR) lands FIRST.** #2621 will need a rebase/merge onto
this PR's `path-utils.ts` state, but that is a textual conflict in a few
lines, not a semantic one — #2621 doesn't call `escapeRegExpChar` (or the
renamed `escapeRegExp`) itself.

## Review round 2

Findings from the coordinator's fix-round-2 message, addressed on the same
branch:

- **F1 (medium)** — sweep only scanned `clients/tools/mcp/tests`, `.ts` only,
  so the recurrence its own docstring names (`astgrep-self-scan.mjs`'s
  `escapeRegex`) was outside its reach; a reintroduction there passed
  silently. Fixed: added `scripts` to `CANDIDATE_DIRS` and `.mjs` to
  `CANDIDATE_EXTENSIONS` (never bare `.js`, which would self-flag compiled
  `clients/string-utils.js`). Proven: sweep green on the widened, shipped
  tree (four `scripts/*.mjs` inline sites correctly unflagged); sweep RED
  when the historical `astgrep-self-scan.mjs` copy is reintroduced (quoted
  above).
- **F2 (low)** — `assertNonEmptyScan` had no explicit floor (default 1) and a
  missing scan directory was silently swallowed. Fixed: real per-directory
  floors + a total floor (see Tests above); removed the `try/catch` so a
  missing directory throws (stdlib `readdirSync` ENOENT behavior, not new
  logic).
- **F3 (low)** — the "trades an inline call for a dependency" reasoning for
  leaving inline copies was false for three test files that already import
  `tests/support/sweep-kit.js` (or sit beside it). Fixed: folded all three
  (`deps-centralization.test.ts`, `config-deprecation-registry.test.ts`,
  `public-surface-drift.ts`) onto the `sweep-kit.js` re-export; corrected the
  sweep's own docstring and this PR body's wording to stop citing them as a
  reason-bearing exception.
- **Merge-order correction** — see above: #2621 conflicts textually on
  `clients/path-utils.ts`; #2617 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y
