### PR TITLE
docs: worktree hygiene — agent trees under .claude/worktrees, prune the lane on merge (refs #2608)

### DIFF
--- a/.claude/agents/pi-lens-fixer.md
+++ b/.claude/agents/pi-lens-fixer.md
@@ -48,7 +48,12 @@ instructions say so.
    (`gh pr list`, `gh pr diff`) and design to compose, not collide; flag
    merge-order implications in your PR body.
    Directory isolation is non-negotiable (#2007): you work in YOUR OWN
-   worktree, never a checkout another session may share. Never switch
+   worktree, never a checkout another session may share. Create it as
+   `.claude/worktrees/agent-<your agent id>` under the main checkout — that
+   is the only path the SubagentStop / SessionStart reaper sweeps. Never
+   under `~/Desktop`, the scratchpad, or any ad-hoc `pi-lens-wt-*` name: on
+   2026-09-06 ten such trees accumulated outside the sweep and had to be
+   removed by hand. Never switch
    branches in a checkout you did not create — a branch switch overwrites
    tracked files other live sessions are editing, and uncommitted WIP is
    unrecoverable. If you find yourself in a shared checkout, stop and cut a

--- a/.claude/skills/merge-train/SKILL.md
+++ b/.claude/skills/merge-train/SKILL.md
@@ -68,6 +68,12 @@ reviewed, zero unreviewed merges). Apply it to each PR in the queue.
 6. **After each merge.** Master moved: check other open PRs for BEHIND/DIRTY,
    check in-flight agents for file overlap with the merged diff and nudge
    affected ones to merge origin/master before their next push.
+   Then prune the lane: `git worktree remove` every tree on the merged
+   branch (fixer AND reviewer trees, wherever they were created) and delete
+   the merged local branch. A lane's tree lives until its PR merges, not
+   after — the orchestrator owns this step; the reaper only sees
+   `.claude/worktrees/agent-*`, and on 2026-09-06 twenty-one merged trees
+   were still standing at the regroup.
 
 ## Queue ordering
 


### PR DESCRIPTION
## Summary

Two workflow fixes after the maintainer found a Desktop full of stale worktrees:

- **Fixer playbook**: create the worktree as `.claude/worktrees/agent-<id>` under the main checkout, the only path the SubagentStop/SessionStart reaper sweeps; never under `~/Desktop`, the scratchpad, or an ad-hoc `pi-lens-wt-*` name. Ten such trees accumulated on 2026-09-06.
- **Merge-train step 6**: after each merge, prune every tree on the merged branch (fixer and reviewer, wherever created) and delete the merged local branch. The orchestrator owns it; twenty-one merged trees were standing at the regroup.

A follow-up issue widens `scripts/prune-agent-worktrees.mjs` to sweep any tree whose branch is merged into `origin/master` regardless of path.

## Tests

Docs only; no control bytes (covered by `tests/config/tracked-control-bytes.test.ts`).

## Blast radius

Agent procedure text. No runtime surface.

## Class sweep

The reviewer and investigator playbooks inherit the same worktree rule via `isolation: worktree` (harness-created under `.claude/worktrees`), so only the fixer text needed the path rule.

## Observability

Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y