### PR TITLE
docs(fixer): unique worktree names (agent-<issue>-<random>), never the session id (refs #2631)

### DIFF
--- a/.claude/agents/pi-lens-fixer.md
+++ b/.claude/agents/pi-lens-fixer.md
@@ -49,8 +49,12 @@ instructions say so.
    merge-order implications in your PR body.
    Directory isolation is non-negotiable (#2007): you work in YOUR OWN
    worktree, never a checkout another session may share. Create it as
-   `.claude/worktrees/agent-<your agent id>` under the main checkout — that
-   is the only path the SubagentStop / SessionStart reaper sweeps. Never
+   `.claude/worktrees/agent-<issue>-<8 random hex>` under the main checkout
+   (e.g. `agent-2345-$(openssl rand -hex 4)` — generate the suffix, never
+   reuse a name you have seen, never use the SESSION id: on 2026-09-06 two
+   fixers both chose `agent-6a12353d` and one destroyed the other's
+   uncommitted edits). That prefix is the only path the SubagentStop /
+   SessionStart reaper sweeps. Never
    under `~/Desktop`, the scratchpad, or any ad-hoc `pi-lens-wt-*` name: on
    2026-09-06 ten such trees accumulated outside the sweep and had to be
    removed by hand. Never switch


### PR DESCRIPTION
## Summary

Two fixers on 2026-09-06 both created `.claude/worktrees/agent-6a12353d` (the SESSION id read as "your agent id"); the second checkout destroyed the first fixer's uncommitted test edit. The playbook now prescribes `agent-<issue>-<8 random hex>` with a generated suffix and forbids reusing a seen name or the session id.

## Tests

Docs only; no control bytes (covered by `tests/config/tracked-control-bytes.test.ts`).

## Blast radius

Fixer procedure text; the reaper's `agent-*` prefix is unchanged.

## Class sweep

Reviewer and investigator trees are harness-created (`isolation: worktree`) with unique ids, so only the fixer text carried the ambiguity.

## Observability

Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y