### PR TITLE
test(lsp): pin the two-auxiliary merge in the per-server touch verdict (refs #1549)

### DIFF
--- a/.changelog/1549-two-auxiliary-merge-guard.md
+++ b/.changelog/1549-two-auxiliary-merge-guard.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- Exercise the per-server touch verdict with two auxiliaries, so a sibling scanner's findings must survive a slow scanner's lapsed wait. (#1549)

--- a/tests/clients/lsp/service-inconclusive-per-server.test.ts
+++ b/tests/clients/lsp/service-inconclusive-per-server.test.ts
@@ -218,7 +218,19 @@ function makeClient(
 	};
 }
 
-/** The cascade neighbour fan-out's own touch shape (integration.ts). */
+/**
+ * The multi-server sweep touch shape: `clientScope: "all"`, which is where a
+ * primary and its auxiliaries are waited on together (`lens_diagnostics`
+ * mode=full, `lsp_diagnostics` `serverScope: "all"`).
+ *
+ * This was the cascade neighbour fan-out's own shape when #1549 landed. #1720
+ * has since narrowed that fan-out to `clientScope: "primary"` (integration.ts),
+ * so the cascade lane no longer attaches auxiliaries at all — the touch-wide
+ * collapse this file guards is unreachable from THAT caller today. The probes
+ * stay on the "all" scope because that is the surface where the merge rule is
+ * still live; naming the wrong caller would make them look like cascade
+ * regression tests they are not.
+ */
 const CASCADE_TOUCH = {
 	clientScope: "all" as const,
 	collectDiagnostics: true as const,
@@ -241,16 +253,19 @@ function latencyRows(phase: string) {
  */
 async function mountService(clients: {
 	primary?: ReturnType<typeof makeClient>;
-	aux: ReturnType<typeof makeClient>;
+	aux: ReturnType<typeof makeClient> | ReturnType<typeof makeClient>[];
 }) {
 	const { LSPService } = await import("../../../clients/lsp/index.js");
 	const service = new LSPService();
+	const auxClients = Array.isArray(clients.aux) ? clients.aux : [clients.aux];
 	getServersForFileWithConfig.mockReturnValue([
 		...(clients.primary ? [makeServer("ts-primary")] : []),
-		makeServer("opengrep", "auxiliary"),
+		...auxClients.map((client) => makeServer(client.serverId, "auxiliary")),
 	]);
-	createLSPClient.mockImplementation(async (options: { serverId?: string }) =>
-		options?.serverId === "opengrep" ? clients.aux : clients.primary,
+	createLSPClient.mockImplementation(
+		async (options: { serverId?: string }) =>
+			auxClients.find((client) => client.serverId === options?.serverId) ??
+			clients.primary,
 	);
 	return service;
 }
@@ -328,6 +343,52 @@ describe("#1549 — per-server touch verdict", () => {
 		// `isConfirmedTouch` still fails closed and no cache is seeded from this.
 		expect(result?.confirmation).toBe("partial");
 		expect(result?.unconfirmedServerIds).toEqual(["opengrep"]);
+	});
+
+	it("the sweep shape with TWO auxiliaries: the healthy scanner's findings survive the slow one's lapse", async () => {
+		// The issue's actual population — a sweep touch attaches ~5 servers, and the
+		// aggregate deadline is the MAX over them, so ONE slow scanner lapses the wait
+		// for everyone. The single-auxiliary probes above pin the primary's answer;
+		// this one pins the SIBLING auxiliary's, which is the other half of "discards
+		// every good answer from the other servers in the same sweep". A merge that
+		// drops on any timeout (rather than per contributor) still passes every
+		// single-aux probe in this file and loses `typos finding` here.
+		const result = await touchOnce(
+			await mountService({
+				primary: makeClient(100, [makeDiagnostic("primary error")], {
+					serverId: "ts-primary",
+				}),
+				aux: [
+					makeClient(150, [makeDiagnostic("typos finding")], {
+						serverId: "typos",
+					}),
+					makeClient(5000, [], { serverId: "opengrep" }),
+				],
+			}),
+		);
+
+		expect((result?.diags ?? []).map((d) => d.message)).toEqual([
+			"primary error",
+			"typos finding",
+		]);
+		expect(result?.inconclusive).toBeUndefined();
+		// Per-SERVER, not per-touch: only the scanner that said nothing is named.
+		expect(result?.confirmation).toBe("partial");
+		expect(result?.unconfirmedServerIds).toEqual(["opengrep"]);
+		// And the record carries the same per-server attribution, so a forensic
+		// sweep can tell a lapsed auxiliary from a lapsed touch.
+		expect(latencyRows("lsp_diagnostics_timeout")[0]?.metadata).toMatchObject({
+			unansweredServerIds: ["opengrep"],
+			attributedToPrimary: false,
+		});
+		expect(latencyRows("degradation_ledger")).toContainEqual(
+			expect.objectContaining({
+				metadata: expect.objectContaining({
+					kind: "lsp-diagnostics-timeout",
+					subject: "opengrep",
+				}),
+			}),
+		);
 	});
 
 	it("the same shape on a CLEAN primary: confirmed-empty findings survive as partial", async () => {
@@ -531,7 +592,7 @@ describe("#1549 — per-server touch verdict", () => {
 	it("a PRIMARY's notify write timing out is a verdict, attributed to notify-write", async () => {
 		process.env.PI_LENS_LSP_NOTIFY_BUDGET_MS = "50";
 		// The primary never received this content; a publication it makes anyway is
-		// about a different revision. Both auxiliaries healthy — a good scanner must
+		// about a different revision. The auxiliary is healthy — a good scanner must
 		// not launder the primary's failure into a confirmation.
 		const result = await runTouch(
 			makeClient(100, [makeDiagnostic("stale finding")], {


### PR DESCRIPTION
## Summary

Refs #1549. **The defect this issue reports does not reproduce on master, and this PR does not fix it — it pins the one slice of the issue's claim that no test covered.** Per AGENTS.md's premise-first rule, the reproduction came before any design work, driven through the real `LSPService.touchFile` merge, and it came back green.

What is already on master (landed by #1571/#1528, verified by the maintainer's 2026-09-02 pass on this issue):

- `resolveTouchVerdict` (`clients/lsp/diagnostic-binding.ts`) is the single rule, and it reads the **PRIMARY population only**: `diagnosticsTimedOut = !hasWaitedPrimary || diagnosticsUnansweredPrimaryServerIds.length > 0` (`clients/lsp/index.ts:5852-5854`). An auxiliary can never make a touch inconclusive.
- A lapsed auxiliary narrows the touch to `confirmation: "partial"` with `unconfirmedServerIds` naming it, and the merge drops **per contributor** (`droppedAuxiliaryServerIds`), not per touch.
- Attribution is on the records: `inconclusiveServerIds` / `inconclusiveReason` on the result, in `lsp_touch_file`, and `unansweredServerIds` / `attributedToPrimary` in `lsp_diagnostics_timeout`.
- The cascade lane cannot even reach the reported shape any more: #1720 narrowed the neighbour fan-out to `clientScope: "primary"` (`clients/dispatch/integration.ts:1983`), so no auxiliary is attached to a neighbour touch at all.

What was **not** pinned: every existing probe uses ONE auxiliary. The issue's claim is "one slow auxiliary discards every good answer from the other servers in the same sweep" — the sibling-auxiliary half was untested, and a merge that discarded every auxiliary contribution whenever the wait lapsed passed all fifteen existing cases in the file (transcript below). This PR adds that case, generalizes the harness to N auxiliaries, and repoints two comments that had drifted from production.

The design the brief asked for (per-server inconclusive, partial marker, touch-wide only when the primary is inconclusive, budgets untouched) is exactly what master already implements, so building it again would have been the #2490 shape — machinery for a collision that cannot occur. **Not `closes`**: acceptance criterion 2 (the dogfood measurement gate) is a measurement, not code; see "Observability" and the issue comment.

### State-space table (per touch, as master behaves — every row traced to code and to a test)

`P` = primary, `A`/`B` = auxiliaries. "Record" names the `latency.log` phase.

| # | P | A | B | Verdict per SERVER | Verdict for the TOUCH | What the agent sees | Record |
|---|---|---|---|---|---|---|---|
| 1 | answered | answered | answered | all covered | `confirmation: "confirmed"`, not inconclusive | all three servers' findings; a clean `[]` may seed the recently-clean cache and reconcile the footer | `lsp_touch_file{inconclusive:false, confirmation:"confirmed"}` |
| 2 | answered | answered | wait lapsed | P,A covered; B unanswered | **`"partial"`**, `unconfirmedServerIds:["B"]`, **not** inconclusive | P's and A's findings, plus "Cascade scanners did not cover N file(s) … (not scanned by B)" (`cascade-format.ts`) / the dispatcher's silent-scanner footer; no cache seed, no reconcile (`isConfirmedTouch` fails closed) | `lsp_diagnostics_timeout{unansweredServerIds:["B"], attributedToPrimary:false}` + bounded `degradation_ledger{kind:"lsp-diagnostics-timeout", subject:"B"}` |
| 3 | answered | notify write never landed | answered | A never received these bytes; its cached findings are about the PREVIOUS revision | `"partial"`, `unconfirmedServerIds:["A"]` | P's and B's findings; A's stale findings are DROPPED (`staleWriteAuxiliaryServerIds`), A named | `lsp_scanner_coverage_gap{auxNoAnswerServerIds:["A"]}`, `lsp_notify_timeout{timedOutServerIds}` |
| 4 | answered | resync deferred by the #1459 fan-out gate | answered | A uncovered unless a stored publication matches these exact bytes (`auxCoveredAtMerge`, #1586) | `"partial"` (or `"confirmed"` when the hash covers it) | same as row 3 | `lsp_scanner_coverage_gap` |
| 5 | answered | skipped: breaker open / never attached | answered | A uncovered | `"partial"` | same as row 3 | `lsp_scanner_coverage_gap` |
| 6 | **wait lapsed, no evidence** | any | any | P unanswered | **`inconclusive: true`**, `inconclusiveServerIds:["P"]`, `inconclusiveReason:"diagnostics-wait"` | "⚠️ Cascade diagnostics inconclusive for N file(s)"; nothing seeded, nothing reconciled | `lsp_touch_file{inconclusive:true, inconclusiveServerIds, inconclusiveReason}` + `lsp_diagnostics_timeout{attributedToPrimary:true}` |
| 7 | **notify write never landed** | any | any | P never received these bytes | `inconclusive: true`, `inconclusiveReason:"notify-write"` | as row 6 | `lsp_notify_timeout` + `lsp_touch_file` |
| 8 | both P deadlines missed | any | any | P unanswered both ways | `inconclusive: true`, `inconclusiveReason:"mixed"` | as row 6 | as rows 6+7 |
| 9 | none configured (aux-only file) | wait lapsed | — | no primary to preserve | `inconclusive: true`, **unattributed** (fail-safe keeps the pre-#1549 touch-wide verdict) | as row 6 | `lsp_diagnostics_timeout` |
| 10 | silent-on-clean, certified (tsserver sync confirm, or the silent-clean gate + liveness ping) | wait lapsed | answered | P answered in the only way its capabilities allow; attribution retracted | `"partial"` naming B, not inconclusive | P's confirmed-clean `[]` plus B's findings, B's gap named | `lsp_tsserver_sync_confirm` / `lsp_silent_clean_confirm` |

Rows 2 and 10's multi-auxiliary column is what this PR's new case pins; rows 6-9 are the "must stay green" side and are pinned by the file's existing fail-safes.

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [x] Documentation (test-only: a regression guard plus two comment corrections; no production code changes)

## Area

- [x] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [x] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [x] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (this PR is the test)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job
- [x] Every NEW regression test is proven RED on pre-fix code — **stated exception**: there is no pre-fix code, because the behaviour is not broken. The new case is proven red by mutation instead, with the transcripts quoted below (M2 is the exact mutation the brief names: "make the merge discard on any timeout")
- [x] Every new guard/branch/filter is mutation-proof — no new guard is added; the seven mutations below prove all 16 cases in the touched file are live
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts` — not applicable, no production files touched
- [x] `package-lock.json` is in sync with `package.json` (pre-commit hook validated it)
- [ ] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there — no behaviour, command, convention or invariant changed
- [x] `.changelog/1549-two-auxiliary-merge-guard.md` has one valid entry (`section: Changed`; `node scripts/check-changelog-fragments.mjs` → `changelog fragments OK (134 entries in .changelog/)`)
- [x] Commit subject includes the issue number (`refs #1549`)

## Tests

One test file touched: `tests/clients/lsp/service-inconclusive-per-server.test.ts`.

**New case** — "the sweep shape with TWO auxiliaries: the healthy scanner's findings survive the slow one's lapse". Primary publishes a finding at 100ms, `typos` publishes one at 150ms, `opengrep` needs 5000ms against the touch's 1000ms cap. Pins: both answers survive in `.diags` in order (`["primary error", "typos finding"]`), the touch is not inconclusive, `confirmation === "partial"` with `unconfirmedServerIds === ["opengrep"]`, `lsp_diagnostics_timeout` carries `unansweredServerIds:["opengrep"], attributedToPrimary:false`, and the bounded degradation ledger has a row for `opengrep`. It exists as a **regression proof for the merge rule's per-contributor drop**, which the single-auxiliary probes structurally cannot see.

**Harness edit** — `mountService` now mounts N auxiliaries, deriving each server id from the client double's own `serverId` instead of the hardcoded `"opengrep"` string (single-source-of-truth: the double already carries its identity). No behavioural change for the existing single-aux callers.

**Comment edits (no assertion changes)** — `CASCADE_TOUCH` was documented as "the cascade neighbour fan-out's own touch shape"; #1720 moved that fan-out to `clientScope: "primary"`, so the fixture now names the surface it actually models (the `clientScope: "all"` sweep) and records that the cascade lane attaches no auxiliaries today. This is fixture-vs-production drift (shape 7 territory): a fixture that names the wrong caller reads as a cascade regression test it is not. A second comment claimed "both auxiliaries healthy" in a single-auxiliary case.

Test-authoring screens: **wrong-layer pin** — the case drives the real `LSPService.touchFile` merge (the production seam), not `resolveTouchVerdict` in isolation, because the sibling-auxiliary drop happens in the merge, not the verdict rule. **Ambient-inspection double** — the client double consumes what production consumes on the axis under test: `notify.open` clears the per-path cache, a publication advances the per-path stamp and records the content binding, and only a landed write produces a publication. **All-mocks** — the assertion reads the service's real output and the real `logLatency` rows, not the doubles. Fake timers throughout (the file's existing `vi.useFakeTimers()`); no wall-clock wait added, so no `flake-shape-ratchet` header is needed (that suite passes, see below).

### Mutation transcripts (verbatim, `npx vitest run tests/clients/lsp/service-inconclusive-per-server.test.ts`)

Each mutation was applied to the BUILT output (`clients/lsp/index.js`, `clients/lsp/diagnostic-binding.js`) and reverted afterwards.

**M1 — restore the pre-#1549 touch-wide verdict** (`diagnosticsUnansweredPrimaryServerIds` → `diagnosticsUnansweredServerIds`):

```
     × tonight's shape: an answered primary beside a slow auxiliary is USABLE, not inconclusive 763ms
     × the sweep shape with TWO auxiliaries: the healthy scanner's findings survive the slow one's lapse 22ms
     × the same shape on a CLEAN primary: confirmed-empty findings survive as partial 20ms
     × the latency row attributes the lapse: unansweredServerIds names the aux, attributedToPrimary is false 25ms
     × a scanner that went unheard is not marked warm, even on a NON-COLLECTING touch 20ms
AssertionError: expected true to be undefined
      Tests  5 failed | 11 passed (16)
```

**M2 — the brief's mutation: make the merge discard on any timeout** (drop every auxiliary contribution when `diagnosticsUnansweredServerIds.length > 0`). This is the one that proves the new case is not redundant — it is the ONLY case in this file that reds:

```
     × the sweep shape with TWO auxiliaries: the healthy scanner's findings survive the slow one's lapse 26ms
AssertionError: expected [ 'primary error' ] to deeply equal [ 'primary error', 'typos finding' ]
      Tests  1 failed | 15 passed (16)
```

Honest scope of M2 elsewhere: run against the four sibling suites, ONE other case also reds — `tests/clients/lsp/service-scanner-coverage-gap.test.ts > "all: no door names a scanner whose findings the merge kept"` (it asserts the naming, not the delivery of a sibling scanner's findings):

```
     × all: no door names a scanner whose findings the merge kept 26ms
 Test Files  1 failed | 3 passed (4)
      Tests  1 failed | 149 passed (150)
```

**M3 — drop the partial marker** (`result.confirmation = "partial"; result.unconfirmedServerIds = …` → `"confirmed"`):

```
     × tonight's shape: an answered primary beside a slow auxiliary is USABLE, not inconclusive 760ms
     × the sweep shape with TWO auxiliaries: the healthy scanner's findings survive the slow one's lapse 23ms
     × the same shape on a CLEAN primary: confirmed-empty findings survive as partial 21ms
     × the latency row attributes the lapse: unansweredServerIds names the aux, attributedToPrimary is false 22ms
     × an AUXILIARY's notify write timing out is a coverage gap, not a verdict 20ms
     × an auxiliary holding the PREVIOUS revision's findings does not get them merged as this touch's answer 19ms
AssertionError: expected 'confirmed' to be 'partial' // Object.is equality
      Tests  6 failed | 10 passed (16)
```

**M4 — delete the no-primary fail-safe** (`!hasWaitedPrimary ||`):

```
     × FAIL-SAFE: a touch with NO primary keeps the pre-#1549 touch-wide verdict 22ms
AssertionError: expected undefined to be true // Object.is equality
      Tests  1 failed | 15 passed (16)
```

**M5 — neuter the #1586/#1493 merge-time coverage exemption** (`auxCoveredAtMerge` emptied):

```
     × #1493 outranks the drop at MERGE time: a late-landing write that publishes for THESE bytes is covered 23ms
AssertionError: expected [ 'primary error' ] to deeply equal [ 'primary error', 'scanner finding' ]
      Tests  1 failed | 15 passed (16)
```

**M6 — the verdict ignores notify-write ids** (`const notifyIds = []`):

```
     × a PRIMARY's notify write timing out is a verdict, attributed to notify-write 22ms
     × names the notify-write cause 2ms
     × reports both deadlines as mixed, deduping the server ids 1ms
      Tests  3 failed | 13 passed (16)
```

**M7 — the verdict rule neutered three ways** (early conclusive return deleted, reason forced to `"notify-write"`, ids always attached):

```
     × tonight's shape: an answered primary beside a slow auxiliary is USABLE, not inconclusive 776ms
     × the sweep shape with TWO auxiliaries: the healthy scanner's findings survive the slow one's lapse 22ms
     × the same shape on a CLEAN primary: confirmed-empty findings survive as partial 20ms
     × the latency row attributes the lapse: unansweredServerIds names the aux, attributedToPrimary is false 22ms
     × FAIL-SAFE: a primary with no evidence keeps the touch inconclusive, and says so 20ms
     × an AUXILIARY's notify write timing out is a coverage gap, not a verdict 20ms
     × an auxiliary holding the PREVIOUS revision's findings does not get them merged as this touch's answer 18ms
     × #1493 outranks the drop at MERGE time: a late-landing write that publishes for THESE bytes is covered 18ms
     × FAIL-SAFE: a touch with NO primary keeps the pre-#1549 touch-wide verdict 18ms
     × is conclusive when no primary missed a deadline 1ms
     × names the diagnostics-wait cause 1ms
     × reports both deadlines as mixed, deduping the server ids 1ms
     × stands on the flag when the attribution is unknowable, rather than blaming nobody 0ms
      Tests  13 failed | 3 passed (16)
```

Unmutated, immediately after restoring both built files: `Tests  16 passed (16)`.

The brief's "must stay green" control (primary times out → touch-wide inconclusive unchanged) is the file's "FAIL-SAFE: a primary with no evidence keeps the touch inconclusive, and says so" case: green unmutated, red under M7, and unaffected by M2 — the merge change cannot touch it.

### Test assessment

`tests/clients/lsp/service-inconclusive-per-server.test.ts` uniquely pins the #1549 verdict rule at BOTH layers: the pure `resolveTouchVerdict` contract and the same rule as observed through the real `touchFile` merge, including the attribution fields on `lsp_touch_file` / `lsp_diagnostics_timeout` and the degradation ledger.

**Vacuous-test sweep of the whole file (required before adding to it): none found, none removed.** Every one of the 16 cases reds under at least one of M1-M7 — M1: 5, M2: 1, M3: 6, M4: 1, M5: 1, M6: 3, M7: 13; union = 16/16. No case asserts a constant, and no case is made redundant by the new one (M2 shows the new case fails alone where all fifteen incumbents pass). Nothing goes to the corpus value ledger from this file.

Closest sibling: `tests/clients/lsp/service-scanner-coverage-gap.test.ts` pins the coverage-gap NAMING doors (breaker, deferral, grace cut-off, hash exemption); it overlaps this PR's new case on M2 by one assertion but does not cover the delivery of a sibling auxiliary's findings.

### Suites run (after `npm run build`)

- Targeted, 17 files (`npx vitest run`, foreground): `service-inconclusive-per-server`, `service-scanner-coverage-gap`, `service-aux-grace`, `service-touch-collect`, `workspace-diagnostics-per-server-verdict`, `workspace-diagnostics-warm-attach`, `cascade-compute`, `cascade-format`, `cascade-turn-merge`, `cascade-budget`, `cascade-logger`, `pipeline-lsp-sync`, `runtime-cascade-defer`, `runtime-session-cascade-tier-reset`, `finding-delivery-gate`, `warm-attach-confirmation`, `dispatch/runners/runner-status-semantics` → `Test Files  17 passed (17)` / `Tests  300 passed (300)`.
- Governance + config, **58 files** selected mechanically (`ls tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts` → 31, plus all 27 `tests/config/*.test.ts`), run through `npm run test:targeted` in the foreground → `Test Files  58 passed (58)` / `Tests  753 passed (753)`. Includes `flake-shape-ratchet`, `generation-guard-sweep`, `extension-terminal-silence`, `pi-lens-home-hermeticity`, `delivery-surface-ratchet`, `finding-delivery-gate`.
  - First attempt showed 9 failures in `pi-host-contract` / `console-capture-window-coverage` / `dependency-boundaries`; cause was a missing worktree-local `node_modules` (`pinned host build missing: …/node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/runner.js`), not this branch. Symlinked `node_modules` to the main checkout as the peer worktrees do, and all 58 pass.
- `npm run lint` (tsc + oxlint): clean. `npx tsc --noEmit -p tsconfig.json`: clean.
- `npx oxfmt --check` on the touched file: `All matched files use the correct format.`
- `node scripts/check-changelog-fragments.mjs`: `changelog fragments OK (134 entries in .changelog/)`.

Total test count run locally for this branch: 1053 (300 targeted + 753 governance/config), plus the 16-case file re-run under each of the 7 mutations. Full suite delegated to CI (serialized machine-wide; twelve lanes contend for it).

## Blast radius

No production module touched — the diff is one test file and one changelog fragment, so `module_report` blast radius is **not applicable** (stated explicitly rather than omitted). The production seams the new case exercises, for the reviewer's benefit: `clients/lsp/index.ts` (`touchFile` verdict + merge), `clients/lsp/diagnostic-binding.ts` (`resolveTouchVerdict`, `touchCoverageGap`), and their consumers `clients/dispatch/dispatcher.ts`, `clients/dispatch/runners/lsp.ts`, `clients/dispatch/integration.ts`, `clients/warm-attach.ts`, `clients/mcp/ipc.ts`, `clients/cascade-format.ts`, `tools/lsp-diagnostics.ts`, `tools/lens-diagnostics.ts`. None of them changes behaviour here.

Merge order: no collision. Checked every open PR's file list (`gh pr diff <n> --name-only` for #2645, #2644, #2643, #2642, #2641, #2575): they touch the fixer playbook, a shared-checkout guard test, runner findings provenance, session root-config eviction, the pack manifest test, and the gitleaks scratch exclusion. None touches `tests/clients/lsp/service-inconclusive-per-server.test.ts`, `clients/lsp/index.ts`, or `clients/lsp/diagnostic-binding.ts`. This PR can land in any order.

## Observability

No new record — the issue's observability criterion was met by #1571 and this PR **extends nothing and duplicates nothing**, exactly as the brief required. The records the new case asserts against, by file and event:

- `~/.pi-lens/latency.log` `lsp_diagnostics_timeout` — `metadata.unansweredServerIds` (which servers produced no evidence) and `metadata.attributedToPrimary` (whether the touch is inconclusive or only coverage-gapped). This is the row that separates "the touch is unknown" from "a scanner is missing".
- `~/.pi-lens/latency.log` `lsp_touch_file` — `inconclusive`, `inconclusiveServerIds`, `inconclusiveReason` (`notify-write` / `diagnostics-wait` / `mixed`), `confirmation`.
- `~/.pi-lens/latency.log` `lsp_scanner_coverage_gap` — `auxNoAnswerServerIds`, for the blackout doors that leave no wait-outcome row.
- The degradation ledger (`incrementDegradationCount`, `kind: "lsp-diagnostics-timeout"`, `subject: <serverId>`) — the bounded, per-server repeated-degradation record; not a per-touch log line (AGENTS.md shapes 10/13).
- `~/.pi-lens/cascade.log` `neighbor_touch` — `metadata.inconclusive` plus `inconclusiveServerIds` / `inconclusiveReason` / `unconfirmedServerIds`.

**Measurement of acceptance criterion 2, read from the maintainer's live logs on this box (read-only; no probe wrote to `~/.pi-lens`):**

- `~/.pi-lens/cascade.log`, window 2026-09-04T23:21Z → 2026-09-06T19:22Z, 107 rows: **zero `neighbor_touch` rows.** The AC's population is structurally absent post-#458/#1720 — TypeScript neighbours classify `tier3-silent` and return before the `neighbor_touch` log site (50 `cascade_tier3_reconcile` rows, aggregate `count: 5`, `resolvedClean: 2`, `resolvedFound: 1`, `unresolved: 2`, all `unresolvedByReason: no-publish`). The gate cannot be read as literally written from this data, which is what the 2026-08-18 issue comment predicted.
- `~/.pi-lens/latency.log` in the same window: 48 `lsp_touch_file` rows, **1 inconclusive (2.1%)**; 1 `lsp_diagnostics_timeout` row, `attributedToPrimary: true`, `unansweredServerIds: ["marksman"]` — a PRIMARY (marksman on markdown) correctly named, not an auxiliary. That is the per-server verdict working end to end on live data, well under the issue's 30% bar, but on the touch population rather than the neighbour population the AC names.

The residual is therefore a measurement/reporting question, not a merge-rule question, which is why this PR says `refs` and not `closes`. An issue comment records exactly what remains.

## Class sweep

**Class:** "a per-server population collapsed into one touch-wide verdict, so one member's missed deadline discards every member's answer" — the #1549 shape, adjacent to AGENTS.md shape 17 (a fail-safe that fails wide) and the #533 honesty doctrine's two directions (overclaim `confirmed` / underclaim `inconclusive`).

Swept the WHOLE tree, not `clients/` alone — `grep -rn "TimedOut" --include=*.ts clients/ tools/ mcp/ index.ts scripts/`, plus symbol greps for `inconclusive`, `unconfirmedServerIds`, `touchCoverageGap`, `resolveTouchVerdict` over the same set.

Population (every site that aggregates a per-server verdict), with a per-member verdict:

| Site | Verdict |
|---|---|
| `clients/lsp/index.ts` `touchFile` (verdict + merge) | Per-server. Owns the rule; delegates to `resolveTouchVerdict`. ✅ |
| `clients/lsp/diagnostic-binding.ts` `resolveTouchVerdict` / `touchCoverageGap` | The single seam. Pure, unit-tested. ✅ |
| `clients/lsp/index.ts` workspace-diagnostics sweep | Per-server (`workspace-diagnostics-per-server-verdict.test.ts`). ✅ |
| `clients/dispatch/integration.ts` cascade neighbour touch | Reads the per-touch flags via `isConfirmedTouch` / `readInconclusive` / `touchCoverageGap`; `clientScope: "primary"` since #1720, so no auxiliary is attached. ✅ |
| `clients/dispatch/dispatcher.ts` | Unions `unconfirmedServerIds` across results for the agent-facing silent-scanner footer; bounded to 4 shown + remainder. ✅ |
| `clients/dispatch/runners/lsp.ts` | Carries `unconfirmedServerIds` through from the incumbent's response. ✅ |
| `clients/cascade-format.ts` | Separate buckets for inconclusive and uncovered; the uncovered line names the servers. ✅ |
| `tools/lsp-diagnostics.ts` | `timedOut = touched?.inconclusive === true` (per-server verdict), and `confirmedByTouch` accepts `"partial"` explicitly (#1470), carrying `unconfirmedServerIds` across the socket. ✅ |
| `tools/lens-diagnostics.ts` | Per-file outcome enum incl. `inconclusive`; reads the same flag. ✅ |
| `clients/lsp/client.ts` shutdown (`shutdownRequestTimedOut` / `exitNotifyTimedOut`) | Same shape, different domain, already split per half by #1620 — not a collapse. ✅ |
| `clients/warm-attach.ts` + `clients/mcp/ipc.ts` | **Known open question, not this PR's:** the incumbent seeds `servedDiagnosticHashes` on `!touched.inconclusive`, so a `partial` touch is servable while its coverage gap crosses the socket in a separate field. Pre-existing since #1470/#1493, documented by the maintainer on this issue (2026-08 comment), and deliberately not bundled. No false clean today — `runners/lsp.ts` carries `unconfirmedServerIds` through. |

**Consolidation verdict:** already folded onto one seam. `resolveTouchVerdict` is the sole producer of the verdict and `touchCoverageGap` the sole reader of the gap; no hand-maintained mirror of either exists anywhere in the tree (the greps above return only the seam and its consumers). Class of remaining sites needing work: **zero**, with the warm-attach seeding question noted above as its own scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y
