### PR TITLE
fix(lsp): CPU-liveness verdict reads its sample window (closes #2358)

### DIFF
--- a/.changelog/2358-cpu-flatness-window.md
+++ b/.changelog/2358-cpu-flatness-window.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **The LSP breaker's CPU-liveness verdict reads its own sample window (closes #2358)** — the notify-stall discriminator took the higher of its two process-CPU reads, but the first read is only a baseline: it reports a rate since whatever observation the last caller left behind (the heartbeat sampler reads every recorded LSP child once per tick, and pidusage keeps 60 s of per-pid history). A scanner that drained its burst and then wedged therefore looked "busy" on CPU it had already stopped burning, survived every re-arm, and died at the hard cap recorded as `cap-exceeded`. The verdict now comes from the window read alone, so such a server is torn down on its adaptive budget and recorded as `budget-exceeded-cpu-flat`; a genuinely busy scanner still defers, because its window read is what proved it busy in the first place.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -625,7 +625,15 @@ earns patience instead of dying by construction. Past the window, the server's
 live process tree is sampled twice across `notifyStallCpuSampleMs()`
 (`notifyStallCpuVerdict` -> `sampleProcessTreeCpuPercent`, `clients/
 resource-sampler.ts`); a BUSY server is left alone and the timer re-arms, and
-only a flat or unmeasured one is torn down. The hard cap still kills a server
+only a flat or unmeasured one is torn down. The verdict is the SECOND read
+alone: both platform samplers report a rate SINCE THE PREVIOUS OBSERVATION of
+that pid — the heartbeat sampler (`clients/quiet-window.ts`) reads every
+recorded LSP child once per tick, and pidusage keeps 60s of per-pid history —
+so the first read only re-anchors the baseline. Folding it into the verdict
+(`Math.max(first, second)`) let CPU the process had already stopped burning
+vote "busy", and the issue's own shape (a scanner that drains its burst and
+THEN wedges) survived every re-arm and died at the cap as `cap-exceeded`
+instead of on its budget as `budget-exceeded-cpu-flat`. The hard cap still kills a server
 whose CPU burns past its deadline: the replacement is the self-heal. The record
 `lsp_notify_backpressure_broken` names which discriminator fired
 (`budget-exceeded-cpu-flat`, `budget-exceeded`, or `cap-exceeded`) and carries

--- a/clients/resource-sampler.ts
+++ b/clients/resource-sampler.ts
@@ -513,9 +513,9 @@ export async function sampleProcessTreeCpuPercent(
 			return null;
 		}
 	};
-	// The FIRST read populates the per-pid CPU history on Windows (a fresh pid
-	// reports 0%; the rate lands on the next read), so the second read is the
-	// one that carries the liveness verdict. Both reads must retain the target;
+	// The FIRST read is a BASELINE, not evidence: it re-anchors this pid's CPU
+	// history (Windows' own map, pidusage's on POSIX) so the second read is a
+	// rate over `windowMs` and nothing else. Both reads must retain the target;
 	// disappearance or query failure is explicitly unmeasured, never flat.
 	const first = await readOnce();
 	const second = await new Promise<{
@@ -538,7 +538,16 @@ export async function sampleProcessTreeCpuPercent(
 	) {
 		return { busy: false, measured: false, cpuPercent: null };
 	}
-	const observed = Math.max(first.cpuPercent, second.cpuPercent);
+	// #2358 (post-#2382): the verdict is the WINDOW read alone. Whatever the
+	// baseline read reports is a rate since the LAST caller's observation —
+	// clients/quiet-window.ts's heartbeat samples every recorded LSP child once
+	// per tick, and pidusage keeps 60 s of per-pid history — so folding it in
+	// (`Math.max(first, second)`) let CPU the process had already stopped
+	// burning vote "busy". A scanner that drained its burst and then wedged (the
+	// issue's own opengrep evidence) was therefore deferred as progressing and
+	// died at the hard cap, misrecorded as `cap-exceeded`, instead of being torn
+	// down on its budget as `budget-exceeded-cpu-flat`.
+	const observed = second.cpuPercent;
 	return {
 		busy: observed > floorPercent,
 		measured: true,

--- a/tests/clients/lsp/service-notify-cpu-liveness.test.ts
+++ b/tests/clients/lsp/service-notify-cpu-liveness.test.ts
@@ -105,7 +105,7 @@ describe("#2358 — CPU-liveness discriminator on a real wedged scanner", () => 
 	let service: ServiceLike | undefined;
 	let childHandles: LSPProcess[] = [];
 
-	async function makeAuxServer(burnCpu: boolean) {
+	async function makeAuxServer(burnCpu: boolean, boundedBurnMs?: number) {
 		return {
 			id: "opengrep",
 			name: "opengrep",
@@ -121,6 +121,9 @@ describe("#2358 — CPU-liveness discriminator on a real wedged scanner", () => 
 						...process.env,
 						FAKE_LSP_WEDGE_STDIN_AFTER_INIT: "1",
 						...(burnCpu ? { FAKE_LSP_BURN_CPU_AFTER_INIT: "1" } : {}),
+						...(boundedBurnMs === undefined
+							? {}
+							: { FAKE_LSP_BURN_CPU_MS: String(boundedBurnMs) }),
 					},
 				});
 				childHandles.push(childHandle);
@@ -129,25 +132,48 @@ describe("#2358 — CPU-liveness discriminator on a real wedged scanner", () => 
 		};
 	}
 
-	async function wedgeTouch(burnCpu: boolean): Promise<void> {
+	/**
+	 * Start the wedging touch and hand back its still-pending promise, so a
+	 * caller can act on the live child while the write is outstanding. The
+	 * promise is wrapped in an object ON PURPOSE: an `async` function that
+	 * RETURNS a promise adopts it, so `await start(...)` would not resolve until
+	 * the whole touch had finished — its diagnostics budget outlives the wedge
+	 * window — and every "while the server is wedged" step would silently run
+	 * after the teardown it meant to observe (measured while writing this: the
+	 * child was already SIGTERMed at the first sample).
+	 */
+	async function startWedgeTouch(
+		burnCpu: boolean,
+		boundedBurnMs?: number,
+	): Promise<{ touch: Promise<unknown> }> {
 		latencyLogger = await import("../../../clients/latency-logger.js");
 		latencyLogger.clearLatencyLog();
 		await latencyLogger.flushLatencyLog();
 		const { LSPService } = await import("../../../clients/lsp/index.js");
 		service = new LSPService() as unknown as ServiceLike;
-		getServersForFileWithConfig.mockReturnValue([await makeAuxServer(burnCpu)]);
+		getServersForFileWithConfig.mockReturnValue([
+			await makeAuxServer(burnCpu, boundedBurnMs),
+		]);
 		// The write to the paused-stdin child never settles, so the touch returns
 		// on its own notify budget; the wedge timer keeps running in the service.
+		return {
+			touch: (
+				service as unknown as {
+					touchFile: (...args: unknown[]) => Promise<unknown>;
+				}
+			).touchFile(`${ROOT}/wedge-file.ts`, BIG_CONTENT, {
+				clientScope: "all",
+				diagnostics: "document",
+				collectDiagnostics: false,
+				source: "lens_diagnostics_full",
+			}),
+		};
+	}
+
+	async function wedgeTouch(burnCpu: boolean): Promise<void> {
 		await (
-			service as unknown as {
-				touchFile: (...args: unknown[]) => Promise<unknown>;
-			}
-		).touchFile(`${ROOT}/wedge-file.ts`, BIG_CONTENT, {
-			clientScope: "all",
-			diagnostics: "document",
-			collectDiagnostics: false,
-			source: "lens_diagnostics_full",
-		});
+			await startWedgeTouch(burnCpu)
+		).touch;
 	}
 
 	const broken = (): boolean => {
@@ -254,6 +280,55 @@ describe("#2358 — CPU-liveness discriminator on a real wedged scanner", () => 
 		// millisecond boundaries, so allow a two-millisecond lower-bound margin.
 		expect(outstandingMs).toBeGreaterThanOrEqual(FIXED_WEDGE_MS - 2);
 	}, 30_000);
+
+	it("tears a BURNED-THEN-FLAT server down at its budget, not at the cap (AC2/AC3)", async () => {
+		// #2358's own evidence shape, which the merged discriminator missed:
+		// opengrep drained a burst (one core busy) and THEN wedged. A liveness
+		// verdict must describe the SAMPLE WINDOW — a process idle for seconds is
+		// flat however much CPU its history carries — so this server is torn down
+		// on its budget, naming `budget-exceeded-cpu-flat`.
+		//
+		// A wider patience window than the sibling cases (600 x 5 = 3000 ms)
+		// leaves the fixture's 1500 ms burn finished well before the first fire,
+		// so both reads of the discriminator straddle a genuinely idle process.
+		process.env.PI_LENS_LSP_NOTIFY_BUDGET_MS = "600";
+		// Sits between a FIRST fire's outstanding window (~3000 ms) and a second
+		// one's (~3000 + sample + re-arm = ~6300 ms): a teardown that needed a
+		// second fire lands past the cap and is recorded as `cap-exceeded`, so
+		// the discriminator assertion below separates the two outcomes.
+		process.env.PI_LENS_LSP_NOTIFY_WEDGED_CAP_MS = "4500";
+		const { touch } = await startWedgeTouch(false, 1500);
+		await waitFor(
+			() => childHandles.length > 0,
+			10_000,
+			"the wedging fixture never spawned",
+		);
+		// Replay ONE production heartbeat tick against the live child: this is
+		// the call clients/quiet-window.ts makes for every recorded LSP child,
+		// once per heartbeat, and it seeds the per-pid CPU history that the
+		// discriminator's own first read then differences against. That history
+		// is what makes "CPU since some earlier observation" diverge from "CPU
+		// during this sample window" on a server that has stopped working.
+		const { sampleProcesses } =
+			await import("../../../clients/resource-sampler.js");
+		await sampleProcesses([process.pid, childHandles[0]?.pid as number]);
+		await touch;
+
+		await waitFor(
+			broken,
+			25_000,
+			"the burned-then-flat server was never torn down",
+		);
+		await latencyLogger?.flushLatencyLog();
+		expect(clientStillRegistered()).toBe(false);
+		const demotions = rowsFor("lsp_notify_backpressure_broken");
+		expect(demotions).toHaveLength(1);
+		expect(demotions[0]?.metadata).toMatchObject({
+			serverId: "opengrep",
+			discriminator: "budget-exceeded-cpu-flat",
+			cpuVerdict: "flat",
+		});
+	}, 40_000);
 
 	it("applies the hard cap even to a burning server, naming cap-exceeded (AC3)", async () => {
 		process.env.PI_LENS_LSP_NOTIFY_WEDGED_CAP_MS = "2500";

--- a/tests/clients/resource-sampler.test.ts
+++ b/tests/clients/resource-sampler.test.ts
@@ -547,6 +547,102 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 	});
 });
 
+/**
+ * #2358: a liveness verdict answers "is this process working RIGHT NOW", so it
+ * may only be read from the window this function itself brackets.
+ *
+ * Both platform samplers report a RATE between two observations, and the FIRST
+ * observation of a pair is whatever the previous caller left behind — the
+ * heartbeat sampler (clients/quiet-window.ts) reads every recorded LSP child
+ * once per tick, and pidusage keeps 60 s of per-pid history. So the first read
+ * can carry a burn the process has already stopped doing. Measured against the
+ * real thing before this suite was written: a child that burned one core for
+ * 1.5 s and then idled was reported `{busy:true, cpuPercent:46.5}` 1.6 s after
+ * it had gone completely idle, because the verdict folded that first read in.
+ */
+describe("#2358 sampleProcessTreeCpuPercent — the verdict is the sample window", () => {
+	beforeEach(() => {
+		pidusageMock.mockReset();
+		__resetWindowsCpuHistoryForTests();
+		resetDegradationLedger();
+	});
+
+	it("POSIX: a process idle across the window is flat, whatever its history carries", async () => {
+		setPlatform("linux");
+		// What real pidusage returns for the "burned, then wedged" child: the
+		// baseline read averages in the burn since the heartbeat's observation,
+		// the window read sees an idle process.
+		pidusageMock
+			.mockResolvedValueOnce({ "111": { cpu: 46.5, memory: 4096 } })
+			.mockResolvedValueOnce({ "111": { cpu: 0, memory: 4096 } });
+		vi.useFakeTimers();
+		try {
+			const verdict = sampleProcessTreeCpuPercent(111, 1_000, 10);
+			await vi.runAllTimersAsync();
+			await expect(verdict).resolves.toEqual({
+				busy: false,
+				measured: true,
+				cpuPercent: 0,
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("POSIX: a process burning across the window is busy on the window read alone", async () => {
+		setPlatform("linux");
+		// The mirror case, and the one that keeps the fix honest: the baseline
+		// read is the 0% a freshly-seeded pid reports, so a BUSY verdict can only
+		// come from the window read.
+		pidusageMock
+			.mockResolvedValueOnce({ "111": { cpu: 0, memory: 4096 } })
+			.mockResolvedValueOnce({ "111": { cpu: 95, memory: 4096 } });
+		vi.useFakeTimers();
+		try {
+			const verdict = sampleProcessTreeCpuPercent(111, 1_000, 10);
+			await vi.runAllTimersAsync();
+			await expect(verdict).resolves.toEqual({
+				busy: true,
+				measured: true,
+				cpuPercent: 95,
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("Windows: the same verdict against a heartbeat-seeded CPU baseline", async () => {
+		setPlatform("win32");
+		vi.useFakeTimers();
+		try {
+			vi.setSystemTime(0);
+			// The heartbeat's own read seeds this pid's baseline at 0 ms of CPU.
+			let outputs = ["111\t4096\t0\t0\t2026-08-30T00:00:00Z\r\n"];
+			fakeSpawn = () => makeFakeChild({ stdout: outputs.shift() ?? "" });
+			await sampleProcesses([111]);
+			// A second later the server has burned 800 ms of CPU and stopped: the
+			// discriminator's baseline read differences 800 ms over 1000 ms of wall
+			// clock (80%), and its window read sees the counter stand still.
+			vi.setSystemTime(1_000);
+			outputs = [
+				"", // descendant query: no children
+				"111\t4096\t0\t8000000\t2026-08-30T00:00:00Z\r\n",
+				"",
+				"111\t4096\t0\t8000000\t2026-08-30T00:00:00Z\r\n",
+			];
+			const verdict = sampleProcessTreeCpuPercent(111, 1_000, 10);
+			await vi.runAllTimersAsync();
+			await expect(verdict).resolves.toEqual({
+				busy: false,
+				measured: true,
+				cpuPercent: 0,
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
 describe("resource-sampler: fire-and-forget CIM spawns are unref'd (#1155)", () => {
 	// Mirrors tests/clients/instance-reaper-unref.test.ts's shape (#1153/#1160):
 	// a piped, `data`-listener-attached child re-references the libuv loop even

--- a/tests/fixtures/fake-lsp-server.mjs
+++ b/tests/fixtures/fake-lsp-server.mjs
@@ -449,11 +449,31 @@ function handle(raw) {
 		// fixture's burns are visible depends on the discriminator sampling
 		// this same process's cumulative CPU, which both Windows and POSIX
 		// do via kernel counters.
+		//
+		// `FAKE_LSP_BURN_CPU_MS=<n>` is the THIRD profile and the one #2358's
+		// production evidence actually had: the scanner burns a core for a
+		// bounded stretch (draining the burst it was handed) and THEN wedges,
+		// flat and silent. Its CPU history therefore carries a burn the process
+		// is no longer doing — which is exactly what a liveness verdict must not
+		// mistake for progress.
 		if (process.env.FAKE_LSP_WEDGE_STDIN_AFTER_INIT === "1") {
 			process.stdin.pause();
+			const boundedBurnMs = Number(process.env.FAKE_LSP_BURN_CPU_MS ?? "");
 			if (process.env.FAKE_LSP_BURN_CPU_AFTER_INIT === "1") {
 				const burnHandle = setInterval(() => burnCpu(100), 100);
 				process.on("exit", () => clearInterval(burnHandle));
+			} else if (Number.isFinite(boundedBurnMs) && boundedBurnMs > 0) {
+				const burnUntil = Date.now() + boundedBurnMs;
+				const burnHandle = setInterval(() => {
+					if (Date.now() >= burnUntil) {
+						clearInterval(burnHandle);
+						return;
+					}
+					burnCpu(90);
+				}, 100);
+				process.on("exit", () => clearInterval(burnHandle));
+				// Outlives the burn, so the process stays alive and flat after it.
+				setInterval(() => {}, 60_000);
 			} else {
 				setInterval(() => {}, 60_000);
 			}


### PR DESCRIPTION
## Summary

#2358's discriminator shipped in #2382 (adaptive budget + CPU-liveness check) and its
clock-boundary test fix in #2410. Driving the ORIGINAL production shape through the real
breaker showed the discriminator still misclassified it: a scanner that drains its burst
and **then** wedges is deferred as "busy" and killed at the hard cap as `cap-exceeded`,
instead of being torn down on its adaptive budget as `budget-exceeded-cpu-flat`.

Root cause is one line in `clients/resource-sampler.ts`:
`const observed = Math.max(first.cpuPercent, second.cpuPercent)`. The first read is a
**baseline**, not evidence. Both platform samplers report a rate *since the previous
observation of that pid* — `clients/quiet-window.ts`'s heartbeat samples every recorded
LSP child once per tick, and pidusage keeps 60 s of per-pid history (verified in
`node_modules/pidusage/lib/history.js`, v4.0.1: `DEFAULT_MAXAGE = 60000`) — so the first
read can carry CPU the process has already stopped burning. Folding it into the verdict
let finished work vote "busy" forever. The verdict is now the window read alone; the
baseline read keeps its other two jobs (re-anchoring the history, proving the target still
exists, so a vanished pid is still `unmeasured`, never `flat`).

Measured against a real child (fixture burns one core for 1.5 s, then idles; sampled
1.6 s into the idle stretch, `PI_LENS_HOME` pinned):

```text
# pre-fix
t= 2001 cpu_ms= 1320
t= 2901 cpu_ms= 1320          <- process completely idle since ~1.6s
t= 3204 DISCRIMINATOR VERDICT: {"busy":true,"measured":true,"cpuPercent":46.468401486988846}

# post-fix, same probe
t= 2001 cpu_ms= 1310
t= 2901 cpu_ms= 1310
t= 3204 DISCRIMINATOR VERDICT: {"busy":false,"measured":true,"cpuPercent":0}
```

### State space (server state x breaker input -> output/record)

The row marked **fixed here** is the one that behaved wrongly; every other row is
unchanged and re-verified green.

| server state | inputs at the fire | output | record |
| --- | --- | --- | --- |
| **responding** | write settles before the wedge timer; `outstandingMs` never reaches the budget | keep; token released, drained barrier folds into the EWMA | `lsp_notify_write_late_landed` when a late landing retracts its strike |
| **busy** (CPU above the 10%-of-a-core floor **across the sample window**), process alive | budget expiry + window read busy | extend once: re-arm `max(fixed floor, k x EWMA x unacked)`, itself capped at `notifyWedgedCapMs()` (60 s default) | `lsp_notify_stall_cpu_busy` (bounded, rising-edge per server/file identity) |
| **busy past the cap** | `outstandingMs >= cap`, checked BEFORE sampling so no busy server waits forever | tear down | `lsp_notify_backpressure_broken` `discriminator: "cap-exceeded"` |
| **wedged** (flat across the window; CPU history may still carry a finished burn) | budget expiry + window read at/below the floor, process alive | tear down at the budget | `..._broken` `discriminator: "budget-exceeded-cpu-flat"`, `cpuVerdict: "flat"` — **fixed here**; before this PR the stale-history read said "busy", the timer re-armed, and the kill arrived at the cap as `cap-exceeded` |
| **exited / unmeasurable** (pid gone, query failed, client with no `getProcessPid`) | budget expiry + no measurement | tear down (pre-#2358 demote-at-budget) | `..._broken` `discriminator: "budget-exceeded"`, `cpuVerdict: "unmeasured"` |
| **any state, retired generation** | client replaced or token released mid-decision | abort: neither teardown nor re-arm | none by design (generation guard, #2382) |
| **any state, #743 streak ladder** | 3 consecutive notify timeouts + busy window read | no demote; ladder resets and the next three timeouts re-try | `lsp_notify_stall_cpu_busy` |

Every teardown and every extension records exactly one bounded row: teardown through
`logLatency` (`lsp_notify_backpressure_broken`, naming `serverId` and the discriminator —
dead / cap-exhausted), extension through `emitBounded` with `ledgerKind:
"lsp-notify-stall-cpu-busy"` (busy-extended), which is rising-edge bounded per
server/file identity and keeps a dropped count in the degradation ledger. No new record
and no new ledger kind was needed — this PR makes the existing ones tell the truth.

Closes #2358 — acceptance criteria: (1) CPU-burning fake server survives past the fixed
window (`AC1` case, #2382, still green); (2) flat-CPU fake server torn down within the
adaptive budget — completed here, including the burned-then-flat shape from the issue's
own evidence; (3) the record names which discriminator fired (#2382, and now the right one
for a wedged server); (4) regression tests for both fakes, red on pre-fix code (#2382 plus
the two new reds below). The issue's sequencing precondition (#2357) is closed; `k` is not
retuned in this PR.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [x] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (no dependency change)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there
- [x] `.changelog/2358-cpu-flatness-window.md` has one valid entry **in this PR**
- [x] Commit subject includes the issue number (`Refs #2358` trailer; the title carries `closes`)

## Tests

**New: `tests/clients/resource-sampler.test.ts` — `#2358 sampleProcessTreeCpuPercent — the
verdict is the sample window` (3 cases).** Pins the fix at its own seam, on BOTH platform
branches through the file's existing `setPlatform()` helper, so neither case is
dev-box-only and both run on the ubuntu Unit-tests lane.

- *POSIX: a process idle across the window is flat, whatever its history carries* — the
  pidusage double returns `cpu: 46.5` for the baseline read and `cpu: 0` for the window
  read, the exact pair the real child produced in the probe quoted above (double is
  production-faithful on the axis under test).
- *POSIX: a process burning across the window is busy on the window read alone* — the
  mirror: baseline `0`, window `95`. Keeps the fix from degenerating into "always flat".
- *Windows: the same verdict against a heartbeat-seeded CPU baseline* — drives the real
  `sampleProcessesWindows` rate math: a heartbeat read seeds the pid at 0 ms of CPU,
  the discriminator's baseline read differences 800 ms of CPU over 1000 ms of wall clock
  (80%), and its window read sees the counter stand still. Fake timers + `setSystemTime`,
  no real child, no raw timer.

Red on pre-fix code (`Math.max` still in `clients/resource-sampler.js`):

```text
 ❯ |default| tests/clients/resource-sampler.test.ts (49 tests | 2 failed) 287ms
     × POSIX: a process idle across the window is flat, whatever its history carries 6ms
     × Windows: the same verdict against a heartbeat-seeded CPU baseline 1ms

 FAIL  |default| tests/clients/resource-sampler.test.ts > #2358 sampleProcessTreeCpuPercent — the verdict is the sample window > POSIX: a process idle across the window is flat, whatever its history carries
AssertionError: expected { busy: true, measured: true, …(1) } to deeply equal { busy: false, measured: true, …(1) }

- Expected
+ Received

  {
-   "busy": false,
-   "cpuPercent": 0,
+   "busy": true,
+   "cpuPercent": 46.5,
    "measured": true,
  }
```

**New: `tests/clients/lsp/service-notify-cpu-liveness.test.ts` — `tears a
BURNED-THEN-FLAT server down at its budget, not at the cap (AC2/AC3)`.** The
production-path proof: a REAL fake LSP child over real stdio, the real
`LSPService.touchFile` -> `claimAuxNotifySlot` -> wedge timer -> `decideNotifyStallTeardown`
path, real process-CPU sampling, and the record read back out of the NDJSON bytes
production writes. The server burns one core for 1500 ms after `initialized` and then
wedges flat with its stdin paused; ONE production heartbeat tick
(`sampleProcesses([process.pid, childPid])`, the call `clients/quiet-window.ts` makes for
every recorded LSP child) seeds the shared per-pid history first. The wedge cap is set
between a first fire's outstanding window (~3000 ms) and a second one's (~6300 ms), so the
discriminator recorded in the teardown row separates "torn down on its budget" from
"survived a bogus busy defer and died at the cap".

Red on pre-fix code:

```text
 ❯ |wall-clock-budget| tests/clients/lsp/service-notify-cpu-liveness.test.ts (4 tests | 1 failed) 32049ms
     × tears a BURNED-THEN-FLAT server down at its budget, not at the cap (AC2/AC3) 7730ms

 FAIL  |wall-clock-budget| tests/clients/lsp/service-notify-cpu-liveness.test.ts > #2358 — CPU-liveness discriminator on a real wedged scanner > tears a BURNED-THEN-FLAT server down at its budget, not at the cap (AC2/AC3)
AssertionError: expected { serverId: 'opengrep', …(4) } to match object { serverId: 'opengrep', …(2) }
(3 matching properties omitted from actual)

- Expected
+ Received

  {
-   "cpuVerdict": "flat",
-   "discriminator": "budget-exceeded-cpu-flat",
+   "discriminator": "cap-exceeded",
    "serverId": "opengrep",
  }
```

**Edited: `tests/fixtures/fake-lsp-server.mjs`** — third wedge profile,
`FAKE_LSP_BURN_CPU_MS=<n>`: burn a core for a bounded stretch after `initialized`, then go
flat forever with stdin still paused. The two incumbent profiles (burn forever / idle from
the start) cannot express "burned, then wedged", which is the shape #2358's evidence
actually had.

**Edited: `tests/clients/lsp/service-notify-cpu-liveness.test.ts` helpers** — `makeAuxServer`
takes the bounded-burn option; `wedgeTouch` is split into `startWedgeTouch` (returns the
still-pending touch **wrapped in an object**) plus the incumbent awaiting wrapper. The
wrapper is not cosmetic: an `async` function that RETURNS a promise adopts it, so
`await start(...)` waited for the whole touch — whose diagnostics budget outlives the wedge
window — and every "while the server is wedged" step silently ran after the teardown it
meant to observe (measured while writing this: the child was already SIGTERMed at the first
sample). The three incumbent cases are unchanged and still pass.

**Timing/flake shape.** No new flake shape: the new service case reuses the file's existing
`waitFor` helper and adds no `setTimeout`/`setInterval`/`vi.waitFor` of its own, so
`tests/support/flake-shape-baseline.json` needs no edit and
`tests/clients/flake-shape-ratchet.test.ts` passes untouched (the file is already pinned at
3 `raw-timer-wait` hits and already listed in `vitest.config.ts`'s
`wallClockBudgetInclude`). The sampler cases run entirely under `vi.useFakeTimers()`; CPU
samples there are injected through the file's existing seams (the `pidusage` mock on the
POSIX branch, the fake CIM `spawn` rows on the Windows branch), never through a wall-clock
wait.

**AGENTS.md test-authoring screens.** Parallel path: both new suites drive the production
functions (`sampleProcessTreeCpuPercent`, `LSPService.touchFile`), never a re-implementation.
Invisible skip: no `skipIf` anywhere; the Windows branch runs on Linux through `setPlatform`.
Ambient-inspection double: the pidusage double returns the values the real thing returned in
the quoted probe. Loose bound: the service case asserts a discriminator VALUE, not an elapsed
time. All-mocks: the service case uses a real child, real stdio and real `/proc` sampling.

### Mutation proofs

Each mutation is applied to the BUILT `clients/resource-sampler.js` (or the fixture), with
the new tests left in place.

1. **Revert the fix** (`const observed = Math.max(first.cpuPercent, second.cpuPercent);`):

```text
--- M1 sampler ---
     × POSIX: a process idle across the window is flat, whatever its history carries 6ms
     × Windows: the same verdict against a heartbeat-seeded CPU baseline 2ms
 Test Files  1 failed (1)
      Tests  2 failed | 47 passed (49)
--- M1 service (built Math.max restored) ---
     × tears a BURNED-THEN-FLAT server down at its budget, not at the cap (AC2/AC3) 7779ms
-   "discriminator": "budget-exceeded-cpu-flat",
+   "discriminator": "cap-exceeded",
 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
```

2. **Take the verdict from the BASELINE read instead** (`const observed = first.cpuPercent;`)
   — proves the busy mirror case is not vacuous either:

```text
--- M2: verdict from the BASELINE read ---
     × POSIX: a process idle across the window is flat, whatever its history carries 10ms
     × POSIX: a process burning across the window is busy on the window read alone 5ms
     × Windows: the same verdict against a heartbeat-seeded CPU baseline 2ms
 Test Files  1 failed (1)
      Tests  3 failed | 46 passed (49)
```

3. **Neuter the new fixture profile** (bounded burn does nothing) on PRE-FIX code — proves
   the new fixture branch is load-bearing for the red, i.e. the new service case reds
   *because of the burn*, not by accident of timing:

```text
--- M3: PRE-FIX sampler + fixture that never burns ---
 Test Files  1 passed (1)
      Tests  1 passed | 3 skipped (4)
```

### Test assessment

- `tests/clients/resource-sampler.test.ts` — uniquely pins the sampler's own contract:
  platform branch selection, per-pid history identity/eviction, malformed-counter
  rejection, target-presence -> `measured`, and now WHICH read carries the verdict. No case
  in it duplicates another: the mutation sweep above reds a different subset for each of the
  three new cases, and M2 shows the busy mirror case is independent of the two flat ones. No
  vacuous case found in the file while probing (every case I mutated against reds on at
  least one mutation), so nothing is removed here.
- `tests/clients/lsp/service-notify-cpu-liveness.test.ts` — uniquely pins the discriminator
  through the REAL breaker on a REAL child: busy survives (AC1), flat dies naming
  `budget-exceeded-cpu-flat` (AC2/AC3), the hard cap still kills a burning server
  (`cap-exceeded`), and now the burned-then-flat shape dies on its budget rather than at the
  cap. The new case is not redundant with the incumbent flat case: that one's child is idle
  from birth, so its baseline read is a freshly-seeded 0% and the defect cannot appear —
  demonstrated by M3, where removing the burn makes the same assertions pass on pre-fix code.
- `tests/fixtures/fake-lsp-server.mjs` — additive third profile behind a new env var; the two
  existing profiles are untouched, and every other suite that spawns this fixture was re-run
  (see totals).

## Blast radius

Production diff is one expression plus comments in `clients/resource-sampler.ts`.
Dependents of that module (grep over `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`):

- `clients/lsp/index.ts` -> `sampleProcessTreeCpuPercent` — the ONLY consumer of the changed
  function, and the behavior under test here.
- `clients/quiet-window.ts` -> `sampleProcesses` (heartbeat telemetry) and
  `clients/safe-spawn.ts` -> `startSpawnUsageSampler` (per-spawn peak/average) — untouched
  code paths; both re-run green.

Not a hot path: the discriminator only runs for a write that has already outlived its
patience window, never per edit or per file. No added work — the change removes a
`Math.max` call. Verification plan: the targeted + governance batches below, then CI's full
Unit-tests lane.

## Observability

No new record; the change corrects the values the existing ones carry, both in latency.log
(read by the log analyzer and the dogfood monitor without asking):

- `lsp_notify_backpressure_broken` (`clients/lsp/index.ts`, `logLatency`) — a wedged server
  now lands with `discriminator: "budget-exceeded-cpu-flat"` and `cpuVerdict: "flat"`
  instead of `cap-exceeded`, so the issue's success metric ("production kills are
  classifiable", "genuinely dead servers still die within the cap") is measurable from the
  log line. Both literals are asserted in the new service test.
- `lsp_notify_stall_cpu_busy` (`emitBounded`, `ledgerKind: "lsp-notify-stall-cpu-busy"`) —
  a bogus busy defer for a flat server no longer emits at all; a real busy defer still does.
  The success path is therefore visible both ways: a busy row when the server progresses, a
  teardown row naming `flat` when it does not.

## Class sweep

Shape: **a verdict computed from an aggregate/stale observation rather than the measurement
window it claims to describe** — the "silencing counted as fixing" family in AGENTS.md's
catalog (shape 10: an ambiguous input must not be read as a definite answer), and the
shared-state screen (the offending input was pidusage's process-global, cross-caller history
map).

Swept the WHOLE tree (`clients/`, `tools/`, `mcp/`, `scripts/`, `scripts/lib/`,
`tests/support/`, `index.ts`) for both the symbol and the pattern:

- `grep -rn "Math.max(" ... | grep -iE "cpu|sample|usage|first|prev|last|rate"` — 19 hits,
  all unrelated (string offsets, ranges, clamped durations). No other place folds a prior
  observation into a current-state verdict.
- `sampleProcessTreeCpuPercent` — exactly one production consumer
  (`clients/lsp/index.ts:1989`), so the fixed verdict has no second reader to keep in sync.
  Class of size 1, proven by the grep.
- Other CPU readers: `clients/quiet-window.ts` and `clients/instance-registry.ts` store
  `cpuPercent` as telemetry (aggregated for display), never as a keep/kill decision;
  `startSpawnUsageSampler`/`UsageAccumulator` report peak/average across a bracketed spawn,
  where a peak over the whole spawn is the intended statistic. `clients/event-loop-monitor.ts:292`
  already computes its CPU over its own window (`cpuTotalMs() - windowStartCpuMs`) — the
  correct shape, and the precedent this fix aligns with. Verdict: no consolidation needed;
  the family stays distributed because only one member is a liveness decision.
- Literal sweep for what this PR introduces: `FAKE_LSP_BURN_CPU_MS` appears only in the
  fixture and its one caller (no third copy, no doc drift).

## Verification

`npm run build` before every run; `npm run build:dist` succeeds; `npm run lint` clean;
`npx oxfmt --check` clean on all four touched files (it flagged the new test file first,
which was then formatted); `node scripts/check-changelog-fragments.mjs` -> `changelog
fragments OK (134 entries in .changelog/)`.

**90 unique test files run locally, all green**, selected mechanically rather than by
memory:

- symbol grep over `tests/` for `sampleProcessTreeCpuPercent|resource-sampler|fake-lsp-server|cpuVerdict|budget-exceeded-cpu-flat|lsp_notify_stall_cpu_busy|notifyStallCpu|FAKE_LSP_BURN_CPU|spawnFakeLspServer`
  -> 29 test files (sampler, memory-sampler, safe-spawn, instance-reaper, latency-logger,
  every `service-notify*` and real-runner LSP suite, `tests/scripts/process-scan`,
  `worktree-hygiene`, `tests/support/fake-lsp-server`): 13 files / 304 tests, 13 files /
  94 tests, 3 files / 47 tests across three batches;
- the whole directory-scanning governance set, selected by
  `ls tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts`
  plus EVERY `tests/config/*.test.ts` -> 58 files / 753 tests (includes
  `flake-shape-ratchet`, `bounded-telemetry-sweep`, `generation-guard-sweep`,
  `lsp-spawn-heavy-coverage`, `process-table-seam`, `dependency-boundaries`);
- after the AGENTS.md edit and again after merging `origin/master`: the two changed
  suites + `packaging` + `host-sdk-type-only` + the 58 governance files -> 62 files /
  844 passed / 5 skipped, and `service-notify-cpu-liveness` + `resource-sampler` +
  `service-inconclusive-per-server` + `service-notify-adaptive-budget` -> 4 files /
  74 tests on the merged tree.

The full suite is delegated to CI's Unit-tests lane (machine-wide serialized locally, and
twelve agent lanes are contending for it).

## Merge order

`origin/master` was merged into this branch after #2646 landed
(`5d04bd28`). That merge is test-only on its side
(`tests/clients/lsp/service-inconclusive-per-server.test.ts` + a changelog fragment) and
touches no seam this PR builds on; the suite it edits was re-run green on the merged tree.
No other open PR touches `clients/resource-sampler.ts`, `clients/lsp/`, or the fixture
(`gh pr list` at branch time: one open PR, `#2575`, secrets/turn-blockers).
