### PR TITLE
docs(contracts): fixer first-five self-check; merge-train prune test, round classification, retarget re-arm (refs #2608, #2664)

### DIFF
--- a/.claude/agents/pi-lens-fixer.md
+++ b/.claude/agents/pi-lens-fixer.md
@@ -63,6 +63,20 @@ instructions say so.
    unrecoverable. If you find yourself in a shared checkout, stop and cut a
    worktree instead. The runtime `--lens-checkout-guard` is a net, not the
    rule; the rule is you never get near it.
+   Set the tree up before the first test run: `ln -s <main checkout>/node_modules
+   node_modules` (worktrees start without one, and every fixer on 2026-09-06
+   then reported `pi-host-contract` and `console-capture-window-coverage` red
+   as "environment"; once that label hid a real regression, #2654's
+   `sweep-floor-coverage` red). A red is environmental ONLY when the same
+   file is red on `origin/master` in the same tree — run it there and quote
+   both results, or treat it as yours.
+   Commit after every proven step, on your branch, before the next probe. Two
+   trees lost uncommitted work the same day: #2358's was removed by a prune
+   that saw a branch with no commits, and #2518 r2's edits died under a
+   `git checkout --` meant for a mutation. `git checkout --` only ever
+   targets committed state (`git checkout HEAD -- <file>`), and never
+   `git reset --soft origin/master` while master moves — it staged a revert
+   of #2646 into #2662's tree.
 3. Reuse the repo's existing machinery — availability-policy latches,
    degradation ledger, established seams — rather than hand-rolling parallel
    state. A hand-maintained list that mirrors a registry is a defect
@@ -314,6 +328,36 @@ Two more checks before the report, both from the same day:
   new mutations. #2583 r3's home-ceiling test went vacuous the moment the new
   gate subsumed its fixture; only the re-run caught it. A guard that was live
   last round is not assumed live this round.
+- **The reviewer's first five.** On the evening of 2026-09-06 every one of
+  five production PRs (#2642 #2643 #2647 #2649 #2654) went back for a round,
+  and each round was made of the same five shapes. Run them on your own diff
+  before opening the PR; each costs minutes here and a fixer round plus a
+  verify there.
+  1. *Observability is a quoted row, not a sentence.* Every record the
+     Observability section names must appear in a test assertion in this
+     diff, quoted in the body. #2642 named a `config_resolved` row a
+     once-per-session claim swallowed; #2649's only record was the failure
+     path; #2654 wrote a per-touched-file row on seven healthy languages;
+     #2647 quoted a `durationMs` that excluded the spawn it added.
+  2. *Mutate the guard both ways.* `if (x)` → `if (true)` AND `if (false)`;
+     the dangerous direction is the one where real failures stop blocking.
+     #2643's git-guard gate, #2647's ladder position and #2644's allow
+     reason were all green under the inverse. The new test must be the ONLY
+     red under at least one mutation, or it has no signature of its own.
+  3. *Sweep by shape, not by symbol.* Grep the expression (`failed === 0 &&
+     error`, the classify/report pair, the path constant), not the function
+     name. #2643 missed a third predicate twenty lines from the new helper;
+     #2654 rebuilt machinery `skills-resolver.ts` already had.
+  4. *Every behavioural sentence maps to a test or a probe.* A docstring
+     invariant (#2643: "`failed` is 0 whenever `error` is set" — the pytest
+     parser sets them independently), a memo that does not exist (#2654), a
+     registry justification your own diff obsoleted (#2642). Delete the
+     sentence or add the proof.
+  5. *Position and lifetime.* Where in the ladder does the new rung sit, and
+     what happens to the new state at `session_start`? #2654's ast-grep row
+     was wiped by `resetDegradationLedger()` and never re-recorded; #2649's
+     failsafe was anchored to the first hold's epoch and released every
+     later healthy call.
 - **The closing keyword lives in the PR BODY.** GitHub ignores `closes #N` in
   a title; four 2026-09-06 PRs needed hand-closing. `closes` only when every
   acceptance box is met, else `refs` plus the remainder comment.

--- a/.claude/skills/merge-train/SKILL.md
+++ b/.claude/skills/merge-train/SKILL.md
@@ -68,7 +68,11 @@ reviewed, zero unreviewed merges). Apply it to each PR in the queue.
 6. **After each merge.** Master moved: check other open PRs for BEHIND/DIRTY,
    check in-flight agents for file overlap with the merged diff and nudge
    affected ones to merge origin/master before their next push.
-   Then prune the lane: `git worktree remove` every tree on the merged
+   Then prune the lane — and ONLY the lane: the merged-ness test is "this
+   tree's branch is the head of the PR just merged" (`gh pr view <n> --json
+   headRefName`), never `merge-base --is-ancestor`: a live fixer's branch
+   with no commits yet passes the ancestor test, and on 2026-09-06 that
+   removed #2358's tree with its uncommitted work. `git worktree remove` every tree on the merged
    branch (fixer AND reviewer trees, wherever they were created) and delete
    the merged local branch. A lane's tree lives until its PR merges, not
    after — the orchestrator owns this step; the reaper only sees
@@ -151,8 +155,21 @@ operator's private notes, so a different orchestrator can run the same train.
 - **Round routing.** Fix rounds that only apply a reviewer-prescribed remedy
   with quoted reds merge on green (CI read on the exact head, both required
   checks, mergeable state). Rounds that add mechanism, touch session or
-  lifecycle semantics, or rewrite a guard get a fresh verify. A verify that
+  lifecycle semantics, or rewrite a guard get a fresh verify. Classify the
+  round by its worst finding, not its count: a round whose findings are all
+  contract (body text, docstrings, a record added WITH its test, a test
+  added for an existing behaviour) merges on green — #2647 r2 is that shape;
+  a round with one behaviour finding (a verdict, a guard direction, a
+  lifecycle hook, a failsafe) gets the same-reviewer verify — #2649 r2 and
+  #2654 r2. Say which in the fixer brief so the reviewer is not re-armed by
+  reflex. A verify that
   reports a NEW defect triggers the round-count rail above.
+- **Retargeting a PR's base does not re-arm CI.** `ci.yml` fires on
+  `opened`/`synchronize`/`reopened`; `gh pr edit --base` is an `edited`
+  event, so the required checks stay ABSENT and `ci-verdict` reports "absent,
+  treating as pending" with exit 0 (#2664). After a retarget, push a commit
+  or close/reopen, and never read exit 0 as green — the merge loop keys on
+  the literal "every gating check concluded success" line.
 - **Maintainer trailing commits** are for intent-free deltas only (a literal
   NUL byte, a false comment, a missing PR-body heading); anything that changes
   what code MEANS goes through a fix round.


### PR DESCRIPTION
## Summary

Contract edits from the 2026-09-06 evening batch, where five of five production PRs (#2642 #2643 #2647 #2649 #2654) went back for a round made of the same five finding shapes.

**Fixer playbook** (`.claude/agents/pi-lens-fixer.md`):
- Worktree setup: link `node_modules` on creation; a red is environmental only when the same file is red on `origin/master` in the same tree (the label hid #2654's real `sweep-floor-coverage` regression).
- Commit after every proven step; `git checkout --` only against committed state; no `git reset --soft origin/master` while master moves (two trees lost uncommitted work today: #2358 prune, #2518 r2 checkout).
- "The reviewer's first five" in *Before you call it done*: observability as a quoted row; mutate guards both ways; sweep by shape not symbol; every behavioural sentence maps to a proof; position and lifetime (ladder rung, `session_start`).

**Merge-train skill** (`.claude/skills/merge-train/SKILL.md`):
- Prune test is "branch is the head of the PR just merged", never `merge-base --is-ancestor` (removed a live tree today).
- Round classification by worst finding: contract-only rounds merge on green (#2647 r2); any behaviour finding gets the same-reviewer verify (#2649 r2, #2654 r2).
- Retargeting a PR base does not re-arm `ci.yml`; `ci-verdict` exits 0 on absent required checks (#2664); push or close/reopen.

## Test assessment

Docs only (tier C). No code, no tests. Orchestrator read plus CI on the head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y