### PR TITLE
fix(tests): deflake instance-reaper-backstop grace-retry metadata race (closes #2669)

### DIFF
--- a/.changelog/fix-2669-backstop-metadata-race.md
+++ b/.changelog/fix-2669-backstop-metadata-race.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Tests**: `instance-reaper-backstop.test.ts`'s grace-retry test no longer reads its metadata off "the last log row" — the retry it arms on a real timer appends its own row asynchronously, so an assertion running late enough for that timer to fire read the retry's metadata instead of the direct sweep's, failing with `expected undefined to be 5` on loaded CI runners (#2669).

--- a/tests/clients/instance-reaper-backstop.test.ts
+++ b/tests/clients/instance-reaper-backstop.test.ts
@@ -132,7 +132,7 @@ import {
 	type OsProcessInfo,
 	partitionBackstopCandidates,
 	scheduleUntrackedOrphanSweep,
-	sweepUntrackedOrphans,
+	sweepUntrackedOrphans as sweepUntrackedOrphansImpl,
 } from "../../clients/instance-reaper.js";
 import {
 	getDegradationSummary,
@@ -174,9 +174,29 @@ function reasonsFor(kind: string): Array<{ subject: string; reason: string }> {
 	);
 }
 
+// #2669: a sweep that spares a candidate on the grace arms a follow-up sweep
+// on a real timer (as little as a few ms — tests pin `graceRetryDelayMs`).
+// That retry appends its OWN `orphan_backstop_reaped` row asynchronously,
+// with no `graceRetryInMs` (it always runs with `allowGraceRetry: false`).
+// Reading "the LAST such row" is therefore reading the wrong sweep's
+// metadata whenever the assertion runs late enough for that timer to have
+// already fired — a real race on loaded CI runners, not a test order
+// dependency. `sweepIndex` is the watermark taken right before the most
+// recently INVOKED sweep, so the lookup always resolves to the row THAT
+// sweep logged (the first `orphan_backstop_reaped` row at or after the
+// watermark), never a later retry's.
+let sweepIndex = 0;
+
+function sweepUntrackedOrphans(
+	...args: Parameters<typeof sweepUntrackedOrphansImpl>
+): ReturnType<typeof sweepUntrackedOrphansImpl> {
+	sweepIndex = h.latency.length;
+	return sweepUntrackedOrphansImpl(...args);
+}
+
 function lastBackstopRecord(): Record<string, unknown> | undefined {
-	return [...h.latency]
-		.reverse()
+	return h.latency
+		.slice(sweepIndex)
 		.find((entry) => entry.phase === "orphan_backstop_reaped");
 }
 
@@ -195,6 +215,7 @@ const FAST = { force: true, verifyAttempts: 1, verifyIntervalMs: 0 } as const;
 beforeEach(() => {
 	h.spawns.length = 0;
 	h.latency.length = 0;
+	sweepIndex = 0;
 	h.state.registry = [];
 	h.state.enabled = true;
 	h.state.stdout = "";
@@ -415,13 +436,19 @@ describe("#1864 review F2: a grace-spared candidate is re-examined", () => {
 		});
 
 		expect(outcome).toBe("clean");
-		expect(backstopMetadata().tooFresh).toBe(1);
-		expect(backstopMetadata().graceRetryInMs).toBe(5);
 
 		// The retry actually runs, and it is NOT blocked by the stamp the first
-		// sweep just wrote.
+		// sweep just wrote. Waiting for it here is also the #2669 regression:
+		// by the time this resolves, the retry's own `orphan_backstop_reaped`
+		// row (it never carries `graceRetryInMs`) is the newest row in the
+		// log, so a metadata lookup keyed on "the last row" instead of "the
+		// row THIS sweep call logged" deterministically reads the retry's
+		// metadata instead of the direct call's.
 		await new Promise((resolve) => setTimeout(resolve, 80));
 		expect(h.state.scannerPids.length).toBeGreaterThanOrEqual(2);
+
+		expect(backstopMetadata().tooFresh).toBe(1);
+		expect(backstopMetadata().graceRetryInMs).toBe(5);
 	});
 
 	it("does not arm a follow-up when nothing was spared", async () => {


### PR DESCRIPTION
## Summary

`tests/clients/instance-reaper-backstop.test.ts > arms one follow-up sweep
when the grace spared a candidate` is order-dependent: `backstopMetadata()` /
`lastBackstopRecord()` picked the LAST `orphan_backstop_reaped` row in the
mocked latency log. The sweep under test arms a grace-retry sweep on a real
5ms timer, and that retry logs its OWN `orphan_backstop_reaped` row
asynchronously — one with no `graceRetryInMs`. An assertion that runs after
that timer has fired therefore reads the retry's metadata instead of the
direct call's, failing with `expected undefined to be 5` (#2669, reproduced
byte-for-byte from CI run 34058495168).

**Root cause decision** (per the issue's fork): this is a TEST defect, not a
product one. No production consumer reads the `orphan_backstop_reaped` phase
— `grep -rn "orphan_backstop_reaped"` across the tree turns up exactly two
hits, the `logLatency` call site in `clients/instance-reaper.ts` and this
test file's own reader. There is no real analyzer that would need a
`retryOf`/`graceRetry` provenance marker to disambiguate the two rows, so
adding one to the product would be machinery for a consumer that doesn't
exist. The fix is entirely in how the test identifies "the row this call
logged."

**Fix**: the test now tracks a watermark (`sweepIndex`) taken immediately
before each invocation of `sweepUntrackedOrphans` (wrapped locally so every
existing call site benefits transparently) and searches FORWARD from that
watermark for the first `orphan_backstop_reaped` row, instead of searching
the whole log backward for the last one. That row is always the one the
just-invoked call logged, regardless of what a later background retry
appends afterward.

The regression test itself moves its metadata assertions to AFTER the
existing 80ms wait for the retry (a wait the test already had, to prove the
retry isn't blocked by the stamp). That turns the CI-load-dependent race into
a **deterministic** repro: by 80ms the 5ms-armed retry has always already
appended its second row, so pre-fix code reads the wrong one on every run,
not just on loaded runners. No new raw timer wait was added (see Tests).

Closes #2669 — the mechanism, reproducer, and suggested fix in the issue are
exactly what's implemented.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (regression test for the bug)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts` — N/A, no product code touched
- [x] `package-lock.json` is in sync with `package.json`
- [ ] `AGENTS.md` is updated — N/A, no new convention/invariant introduced
- [x] `.changelog/fix-2669-backstop-metadata-race.md` added (section: Fixed)
- [x] Commit subject includes the issue number: `(closes #2669)`

## Tests

**Edited**: `tests/clients/instance-reaper-backstop.test.ts`
- `lastBackstopRecord()` / `backstopMetadata()`: now search forward from a
  per-call watermark instead of reverse-searching the whole log. This is the
  fix itself, exercised by every existing assertion in the file (31 tests).
- `sweepUntrackedOrphans` local wrapper: records `h.latency.length` as the
  watermark right before delegating to the real export. Transparent to every
  call site, including the `Promise.all` concurrent-sweep test (which never
  reads `backstopMetadata()` afterward, so the watermark race there is inert).
- `"arms one follow-up sweep when the grace spared a candidate"`: the
  regression test. Moved the `tooFresh`/`graceRetryInMs` assertions to AFTER
  the pre-existing 80ms wait for the retry, making the race deterministic
  instead of load-dependent — this is the #2669 repro, kept as the permanent
  guard rather than an ad-hoc reproducer.

**Red-first proof** (pre-fix code, produced by temporarily reverting only
`lastBackstopRecord`/`sweepUntrackedOrphans` back to the reverse-whole-array
lookup, then running the reordered test):

```
FAIL  |default| tests/clients/instance-reaper-backstop.test.ts > #1864 review F2: a grace-spared candidate is re-examined > arms one follow-up sweep when the grace spared a candidate
AssertionError: expected undefined to be 5 // Object.is equality

- Expected:
5

+ Received:
undefined

 ❯ tests/clients/instance-reaper-backstop.test.ts:436:45
    434|
    435|   expect(backstopMetadata().tooFresh).toBe(1);
    436|   expect(backstopMetadata().graceRetryInMs).toBe(5);
       |                                             ^
    437|  });

 Test Files  1 failed (1)
      Tests  1 failed | 32 skipped (33)
```

This is the mutation-proof for the new watermark guard: reverting it to the
old reverse-search is the only change between this red run and the green run
below — deleting the guard reds the test it exists for.

Also reproduced the ORIGINAL flaky shape verbatim (issue's own repro: unfixed
code, unmoved assertions, `await setTimeout(resolve, 20)` inserted before
them):

```
FAIL  |default| tests/clients/instance-reaper-backstop.test.ts > #1864 review F2: a grace-spared candidate is re-examined > arms one follow-up sweep when the grace spared a candidate
AssertionError: expected undefined to be 5 // Object.is equality
 ❯ tests/clients/instance-reaper-backstop.test.ts:420:45
```
— matches CI's `expected undefined to be 5` byte-for-byte.

**Green, post-fix**, same file, run 10x in a row:

```
 Test Files  1 passed (1)
      Tests  31 passed | 2 skipped (33)
```
(x10, each run's numbers identical — no flake reintroduced)

**No new raw timer wait**: `grep -c "setTimeout(resolve" tests/clients/instance-reaper-backstop.test.ts` is 4 before and after this PR — the fix reuses the wait the test already had rather than adding a fifth, so `flake-shape-ratchet.test.ts`'s pinned baseline (4 for this file) needed no change and stays green as-is.

**Full targeted run** (instance-reaper family + flake-shape ratchet, 7 files):
```
 Test Files  7 passed (7)
      Tests  116 passed | 2 skipped (118)
```

**Governance sweep** — every file matching
`ls tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts`
plus every `tests/config/*.test.ts` (58 files total, via `npm run test:targeted`):
```
 Test Files  58 passed (58)
      Tests  753 passed (753)
```

`npx tsc --project tsconfig.json` (lint's type-check half): clean, no output.
`npx oxfmt --check tests/clients/instance-reaper-backstop.test.ts`: "All matched files use the correct format."

### Test assessment

Only one file is touched: `tests/clients/instance-reaper-backstop.test.ts`.
It uniquely pins the registry-independent orphan-backstop sweep's outcome
classification, kill accounting, cooldown/lock behavior, and the #1864 grace
guard/retry logic. No test in it is made redundant by this change — the fix
only changes HOW two shared helper functions locate a row and where one
test's assertions run; every other test's assertions and coverage are
unchanged. Nothing removed.

## Blast radius

Test-only change. No production module under `clients/`, `tools/`, `mcp/`,
or `index.ts` is touched, so `module_report --blastRadius` is not applicable.
Affected surface is exactly this one test file's own two helper functions
(`lastBackstopRecord`, `backstopMetadata`) and their ~20 call sites within
the same file — all exercised by the full-file run above.

## Observability

Test-only PR — not applicable. No production log or ledger record changes;
`orphan_backstop_reaped` metadata shape is unchanged (still no
`retryOf`/`graceRetry` marker, since no production consumer needs one — see
Summary).

## Class sweep

**Shape**: a test helper that identifies "the row this call produced" by
reading the LAST matching row in a shared log, when a background/async path
under the same call can append another matching row afterward (a
self-re-arming timer, here).

**Sweep**: grepped the whole tree for the mechanical pattern first —
`grep -rn "orphan_backstop_reaped"` across `clients/`, `tools/`, `mcp/`,
`scripts/`, `tests/` — 2 hits total (the one production log-site and this
test's reader), confirming no other consumer of this exact phase exists.

Then swept for the general shape (`.reverse()` used to pick a "last" log
entry) across `tests/clients/*.test.ts`:
- `cache-observability.test.ts` (2 sites), `read-expansion-enrichment.test.ts`
  (1 site): both read the last matching entry immediately after a single
  SYNCHRONOUS call with no background timer that could append a same-phase
  entry afterward — the precondition for this race (an async follow-up that
  logs the same phase) does not hold, so these are not instances of the
  shape.
- `config-resolve.test.ts`, `project-lens-config.test.ts`: comment references
  to `.reverse()` only (a different `PROJECT_CONFIG_LOCATIONS.reverse()`
  mutation note), not log-reading helpers.
- `word-index-stat-concurrency.test.ts`: `[...claims].reverse()` iterates a
  claims list to resolve barriers — unrelated to log-row selection.

**Verdict**: class of size 1 — `instance-reaper-backstop.test.ts` is the only
file in the tree pairing a "last row wins" log reader with a call path that
can asynchronously append a same-phase row after the awaited call returns.
Fixed here; no sibling to fold onto the same seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
