### PR TITLE
docs(merge-train): ci-verdict exits 3 on absent required checks, not 0 (refs #2664)

### DIFF
--- a/.claude/skills/merge-train/SKILL.md
+++ b/.claude/skills/merge-train/SKILL.md
@@ -167,9 +167,11 @@ operator's private notes, so a different orchestrator can run the same train.
 - **Retargeting a PR's base does not re-arm CI.** `ci.yml` fires on
   `opened`/`synchronize`/`reopened`; `gh pr edit --base` is an `edited`
   event, so the required checks stay ABSENT and `ci-verdict` reports "absent,
-  treating as pending" with exit 0 (#2664). After a retarget, push a commit
-  or close/reopen, and never read exit 0 as green — the merge loop keys on
-  the literal "every gating check concluded success" line.
+  treating as pending" — exit 3, not 0; the "exit 0" first recorded on #2664
+  was `$?` read after a `| tail`. After a retarget, push a commit or
+  close/reopen. Read exit codes without a pipe (`node scripts/ci-verdict.mjs
+  <pr>; echo $?`); the merge loop keys on the literal "every gating check
+  concluded success" line.
 - **Maintainer trailing commits** are for intent-free deltas only (a literal
   NUL byte, a false comment, a missing PR-body heading); anything that changes
   what code MEANS goes through a fix round.


### PR DESCRIPTION
## Summary

Corrects one sentence added in #2665: `ci-verdict` on a PR whose required checks are absent exits **3** (pending), not 0. The "exit 0" came from reading `$?` after `| tail`. #2676 pins the fixture and adds the retarget hint. Adds the no-pipe exit-code rule.

## Test assessment

Docs only (tier C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y