### PR TITLE
refactor(scripts): one fixture-workspace bootstrap for the five LSP scripts, home pinned (closes #2670, closes #2658)

### DIFF
--- a/.changelog/2670-lsp-fixture-workspace-bootstrap.md
+++ b/.changelog/2670-lsp-fixture-workspace-bootstrap.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **One fixture-workspace bootstrap for the five LSP dev-harness scripts, home-pinned (closes #2670, closes #2658)** — `scripts/lib/lsp-fixture-workspace.mjs`'s `bootstrapFixtureWorkspace` replaces the hand-copied "copy fixture → register session root → optional disable+reload → optional git init → assert registered" preamble in `smoke-tools.mjs`, `characterize-lsp.mjs`, `probe-clean-signal.mjs`, `server-capabilities.mjs`, and `bench-lsp.mjs` (the last one previously skipped the unconditional register entirely). `withScratchHome()` pins `PI_LENS_HOME`/`PILENS_DATA_DIR` to a scratch temp dir for every one of the five scripts, so their now-unconditional `initLSPConfig` calls no longer write `config_resolved` telemetry into a developer's real `~/.pi-lens`.

--- a/.github/workflows/parser-smoke.yml
+++ b/.github/workflows/parser-smoke.yml
@@ -35,8 +35,20 @@ jobs:
     timeout-minutes: 15
     # The installer resolves GitHub release assets through the REST API.
     # Unauthenticated is 60 requests/hour per IP and shared runners exhaust it.
+    #
+    # PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1, for symmetry with
+    # tool-smoke.yml): this job only runs one `--install` step today, so there
+    # is no per-job cache to preserve here yet, but pinning keeps this
+    # workflow behaving identically to its sibling rather than depending on
+    # `withScratchHome`'s per-invocation default the moment a second
+    # `--install` step is ever added. A bare `/tmp` path, not
+    # `${{ runner.temp }}`: the `runner` context is unavailable at job-level
+    # `env:` (actionlint: "context \"runner\" is not allowed here"), and this
+    # runner's whole VM is destroyed after the job either way.
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PI_LENS_HOME: /tmp/pi-lens-home
+      PILENS_DATA_DIR: /tmp/pi-lens-home
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/tool-smoke.yml
+++ b/.github/workflows/tool-smoke.yml
@@ -33,8 +33,25 @@ jobs:
     # Unauthenticated = 60 req/hr per IP, exhausted on shared-IP runners.
     # The auto-provided token raises this to 5000 req/hr; the installer sends it
     # ONLY to api.github.com, never the asset CDN.
+    #
+    # PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1): job-level, so the SIX
+    # `--install` steps below share one tool tree/bin dir across the job
+    # instead of each `withScratchHome()` pin minting its own empty one per
+    # step — without this, each script re-pulls every managed tool from
+    # scratch (measured against the last full nightly, run 32817692457: the
+    # shared cache made the format step ~9s; per-step scratch homes would add
+    # ~10min across the job and 4-5x the release-asset downloads on this
+    # shared-IP runner). A bare `/tmp` path, not `${{ runner.temp }}`: the
+    # `runner` context is unavailable at job-level `env:` (actionlint: "context
+    # \"runner\" is not allowed here"), and this runner's whole VM — `/tmp`
+    # included — is destroyed after the job either way, so this never becomes
+    # a second `~/.pi-lens` some other step relies on persisting.
+    # `withScratchHome`'s "already pinned" branch is a no-op against an
+    # explicit PI_LENS_HOME, so this is the ONLY change these steps need.
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PI_LENS_HOME: /tmp/pi-lens-home
+      PILENS_DATA_DIR: /tmp/pi-lens-home
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/scripts/bench-lsp.mjs
+++ b/scripts/bench-lsp.mjs
@@ -19,12 +19,14 @@
  * Requires `npm run build:dist`. Without --install, only already-installed
  * servers are measured (others report "unavailable").
  */
-import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+	bootstrapFixtureWorkspace,
+	withScratchHome,
+} from "./lib/lsp-fixture-workspace.mjs";
 
 const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -33,6 +35,11 @@ const repoRoot = path.resolve(
 const argv = process.argv.slice(2);
 const install = argv.includes("--install");
 const langs = argv.filter((a) => !a.startsWith("--"));
+
+// #2670/#2506-shape: pin PI_LENS_HOME/PILENS_DATA_DIR to a scratch temp dir
+// BEFORE the first dist/ import below — dist/clients/latency-logger.js reads
+// its log dir into a top-level const at module load, not lazily per write.
+withScratchHome();
 
 const imp = (rel) => import(pathToFileURL(path.join(repoRoot, rel)).href);
 const { LSP_FIXTURES } = await imp("scripts/smoke-tools.mjs");
@@ -52,13 +59,6 @@ const {
 let ensureTool;
 if (install) {
 	({ ensureTool } = await imp("dist/clients/installer/index.js"));
-}
-
-function copyDirToTemp(srcRel) {
-	const src = path.join(repoRoot, srcRel);
-	const dst = fs.mkdtempSync(path.join(os.tmpdir(), "bench-lsp-"));
-	fs.cpSync(src, dst, { recursive: true });
-	return dst;
 }
 
 const fixtures = langs.length
@@ -85,45 +85,41 @@ for (const fx of fixtures) {
 	if (install && ensureTool) {
 		for (const t of fx.tools ?? []) await ensureTool(t).catch(() => undefined);
 	}
-	const ws = copyDirToTemp(fx.dir);
-	const absFile = path.join(ws, fx.file);
-	if (fx.gitInit) {
-		try {
-			gitExecFileSync(["init", "-q"], { cwd: ws, stdio: "ignore" });
-		} catch {}
-	}
 
 	const auxIds = fx.auxiliaryServerIds ?? [];
-	// Measure ONE server in isolation: disable every other server matching this
-	// file so neither an auxiliary (opengrep/ast-grep) nor an alternate primary
-	// can spawn alongside the server under test.
-	//   - auxiliary fixture → target = the auxiliary(ies); all primaries disabled
-	//   - alternate fixture → target = first primary NOT in fx.disableServers
-	//   - primary fixture   → target = the default (first matching) primary
-	// getServersForFileWithConfig is in registry order — the same order
-	// getClientForFile tries — so primaries[0] is the default it would select.
-	const matching = getServersForFileWithConfig(absFile);
-	let targetIds;
-	if (auxIds.length) {
-		targetIds = new Set(auxIds);
-	} else {
-		const explicitlyDisabled = new Set(fx.disableServers ?? []);
-		const primaries = matching.filter(
-			(s) => s.role !== "auxiliary" && !explicitlyDisabled.has(s.id),
-		);
-		targetIds = new Set(primaries.length ? [primaries[0].id] : []);
-	}
-	const disabledServers = matching
-		.map((s) => s.id)
-		.filter((id) => !targetIds.has(id));
-	if (disabledServers.length) {
-		fs.mkdirSync(path.join(ws, ".pi-lens"), { recursive: true });
-		fs.writeFileSync(
-			path.join(ws, ".pi-lens", "lsp.json"),
-			JSON.stringify({ disabledServers }, null, 2),
-		);
-		await initLSPConfig(ws);
-	}
+	// #2658: every fixture registers its OWN workspace unconditionally (via
+	// bootstrapFixtureWorkspace's early initLSPConfig call), not only when
+	// `disabledServers` below turns out non-empty — the exact #2369/#2655
+	// ordering bug this script shared with its four siblings.
+	const { absFile, cleanup } = await bootstrapFixtureWorkspace(fx, {
+		initLSPConfig,
+		repoRoot,
+		tmpPrefix: "bench-lsp-",
+		// Measure ONE server in isolation: disable every other server matching
+		// this file so neither an auxiliary (opengrep/ast-grep) nor an alternate
+		// primary can spawn alongside the server under test.
+		//   - auxiliary fixture → target = the auxiliary(ies); all primaries disabled
+		//   - alternate fixture → target = first primary NOT in fx.disableServers
+		//   - primary fixture   → target = the default (first matching) primary
+		// getServersForFileWithConfig is in registry order — the same order
+		// getClientForFile tries — so primaries[0] is the default it would select.
+		// Computed here (a function, not a static list) because it needs a real
+		// file path inside the already-copied, already-registered workspace.
+		disableServers: ({ absFile: file }) => {
+			const matching = getServersForFileWithConfig(file);
+			let targetIds;
+			if (auxIds.length) {
+				targetIds = new Set(auxIds);
+			} else {
+				const explicitlyDisabled = new Set(fx.disableServers ?? []);
+				const primaries = matching.filter(
+					(s) => s.role !== "auxiliary" && !explicitlyDisabled.has(s.id),
+				);
+				targetIds = new Set(primaries.length ? [primaries[0].id] : []);
+			}
+			return matching.map((s) => s.id).filter((id) => !targetIds.has(id));
+		},
+	});
 
 	if (!lsp.supportsLSP(absFile)) {
 		results.push({
@@ -132,6 +128,7 @@ for (const fx of fixtures) {
 			role,
 			status: "no-lsp",
 		});
+		cleanup();
 		continue;
 	}
 	let content = fs.readFileSync(absFile, "utf8");
@@ -195,9 +192,7 @@ for (const fx of fixtures) {
 	} finally {
 		// Best-effort: on Windows the warm server still holds handles, so the dir
 		// may not delete until the process exits. Leaking temp dirs is fine.
-		try {
-			fs.rmSync(ws, { recursive: true, force: true });
-		} catch {}
+		cleanup();
 	}
 }
 

--- a/scripts/characterize-lsp.mjs
+++ b/scripts/characterize-lsp.mjs
@@ -11,7 +11,6 @@
  * Requires `npm run build:dist`. Measures only already-installed servers.
  */
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -20,8 +19,10 @@ import {
 	parseTable,
 	replaceTable,
 } from "./lib/md-matrix.mjs";
-import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
-import { assertFixtureWorkspaceRegistered } from "./lib/lsp-fixture-session-guard.mjs";
+import {
+	bootstrapFixtureWorkspace,
+	withScratchHome,
+} from "./lib/lsp-fixture-workspace.mjs";
 
 const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -30,6 +31,12 @@ const repoRoot = path.resolve(
 const argv = process.argv.slice(2);
 const install = argv.includes("--install");
 const langs = argv.filter((a) => !a.startsWith("--"));
+
+// #2670/#2506-shape: pin PI_LENS_HOME/PILENS_DATA_DIR to a scratch temp dir
+// BEFORE the first dist/ import below — dist/clients/latency-logger.js reads
+// its log dir into a top-level const at module load, not lazily per write.
+withScratchHome();
+
 const imp = (rel) => import(pathToFileURL(path.join(repoRoot, rel)).href);
 const { LSP_FIXTURES } = await imp("scripts/smoke-tools.mjs");
 const { getLSPService, resetLSPService } = await imp(
@@ -46,36 +53,21 @@ const lsp = getLSPService();
 const rows = [];
 
 for (const fx of fixtures) {
-	const dst = fs.mkdtempSync(path.join(os.tmpdir(), "char-lsp-"));
-	fs.cpSync(path.join(repoRoot, fx.dir), dst, { recursive: true });
-	// #2369/#2655: every fixture registers its OWN workspace unconditionally —
-	// see lib/lsp-fixture-session-guard.mjs for why this can't be conditional
-	// on `disableServers`.
-	await initLSPConfig(dst);
-	const absFile = path.join(dst, fx.file);
-	if (fx.gitInit) {
-		try {
-			gitExecFileSync(["init", "-q"], { cwd: dst, stdio: "ignore" });
-		} catch {}
-	}
-	if (fx.disableServers) {
-		fs.mkdirSync(path.join(dst, ".pi-lens"), { recursive: true });
-		fs.writeFileSync(
-			path.join(dst, ".pi-lens", "lsp.json"),
-			JSON.stringify({ disabledServers: fx.disableServers }, null, 2),
-		);
-		await initLSPConfig(dst);
-	}
-	if (install && ensureTool) {
-		for (const t of fx.tools ?? []) await ensureTool(t).catch(() => undefined);
-	}
-	await assertFixtureWorkspaceRegistered(fx.lang, dst);
-	if (!lsp.supportsLSP(absFile)) {
-		rows.push({ lang: fx.lang, server: fx.serverHint, mode: "no-lsp" });
-		continue;
-	}
-	const auxIds = fx.auxiliaryServerIds ?? [];
+	const { absFile, cleanup } = await bootstrapFixtureWorkspace(fx, {
+		initLSPConfig,
+		repoRoot,
+		tmpPrefix: "char-lsp-",
+	});
 	try {
+		if (install && ensureTool) {
+			for (const t of fx.tools ?? [])
+				await ensureTool(t).catch(() => undefined);
+		}
+		if (!lsp.supportsLSP(absFile)) {
+			rows.push({ lang: fx.lang, server: fx.serverHint, mode: "no-lsp" });
+			continue;
+		}
+		const auxIds = fx.auxiliaryServerIds ?? [];
 		const content = fs.readFileSync(absFile, "utf8");
 		await lsp.touchFile(absFile, content, {
 			diagnostics: "document",
@@ -100,9 +92,7 @@ for (const fx of fixtures) {
 			mode: `error: ${e?.message ?? e}`,
 		});
 	} finally {
-		try {
-			fs.rmSync(dst, { recursive: true, force: true });
-		} catch {}
+		cleanup();
 	}
 }
 

--- a/scripts/lib/lsp-fixture-session-guard.mjs
+++ b/scripts/lib/lsp-fixture-session-guard.mjs
@@ -2,29 +2,47 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 /**
- * #2369/#2655. Every LSP dev-harness script (`smoke-tools.mjs`,
- * `characterize-lsp.mjs`, `probe-clean-signal.mjs`, `server-capabilities.mjs`)
- * iterates a shared fixture list in ONE process, giving each fixture a
- * fresh, unregistered `os.tmpdir()` workspace. `clients/lsp/session-roots.ts`
- * fails OPEN (declines nothing) only while its registry is empty — the
- * moment any fixture registers its own workspace as a served session root
- * (via `initLSPConfig`, #2052), the registry goes non-empty and every OTHER
- * fixture's still-unregistered workspace is silently declined by
+ * #2369/#2655/#2658. Every LSP dev-harness script (`smoke-tools.mjs`,
+ * `characterize-lsp.mjs`, `probe-clean-signal.mjs`, `server-capabilities.mjs`,
+ * `bench-lsp.mjs`) iterates a shared fixture list in ONE process, giving each
+ * fixture a fresh, unregistered `os.tmpdir()` workspace. `clients/lsp/
+ * session-roots.ts` fails OPEN (declines nothing) only while its registry is
+ * empty — the moment any fixture registers its own workspace as a served
+ * session root (via `initLSPConfig`, #2052), the registry goes non-empty and
+ * every OTHER fixture's still-unregistered workspace is silently declined by
  * `isOutsideAllSessionRoots`. `smoke-tools.mjs`'s `--lsp` lane shipped this
  * exact bug for 12 nightlies (#2369) because `initLSPConfig` was called only
  * for `disableServers` fixtures; `characterize-lsp.mjs` was independently
- * confirmed live-affected the same way for #2655.
+ * confirmed live-affected the same way for #2655, and `bench-lsp.mjs` (not
+ * CI-wired, so lower urgency, but the same defect) for #2658.
  *
  * The actual fix in each script is one line — call `initLSPConfig(workspace)`
  * unconditionally right after copying the fixture into its temp workspace,
- * not only inside a `disableServers` branch. This module is NOT that line
- * (each script still calls its own already-imported `initLSPConfig`, since
- * that import path differs slightly per script); it is ONLY the guard that
- * makes the ordering dependency impossible to silently reintroduce: assert
- * the workspace is actually registered before anything touches it, and
- * throw loudly, naming the issue, if it is not. One implementation, four
- * call sites — a hand-copied guard in each script is exactly the kind of
- * drift a future edit to one copy and not the others would reintroduce.
+ * not only inside a `disableServers` branch. `lsp-fixture-workspace.mjs`'s
+ * `bootstrapFixtureWorkspace` (#2670) is now that line, shared by all five
+ * scripts instead of hand-copied; this module is NOT it (each script's
+ * `initLSPConfig` import path differs slightly, so `bootstrapFixtureWorkspace`
+ * takes it as a parameter rather than importing it here) — it is ONLY the
+ * guard that makes the ordering dependency impossible to silently
+ * reintroduce: assert the workspace is actually registered before anything
+ * touches it, and throw loudly, naming the issue, if it is not. One
+ * implementation, five call sites (all now routed through
+ * `bootstrapFixtureWorkspace`) — a hand-copied guard in each script is
+ * exactly the kind of drift a future edit to one copy and not the others
+ * would reintroduce.
+ *
+ * "Throws loudly" is only end-to-end true for `smoke-tools.mjs --lsp`: it is
+ * the only one of the five wired into `tool-smoke.yml` WITHOUT
+ * `continue-on-error`, so a thrown guard there actually reds the nightly.
+ * `characterize-lsp.mjs`, `probe-clean-signal.mjs`, and
+ * `server-capabilities.mjs`'s workflow steps are each `continue-on-error:
+ * true`; `probe-clean-signal.mjs` additionally catches the throw per-fixture
+ * (`withTimeout`'s wrapping `try/catch`) and always exits 0 regardless.
+ * `bench-lsp.mjs` isn't CI-wired at all (a manual dev tool) — a throw there
+ * surfaces only to whoever ran it locally. The guard is worth having in all
+ * five regardless: a loud local crash (bench-lsp, a direct `node
+ * characterize-lsp.mjs` run) is still far better than the silent zero-
+ * diagnostics regression it replaces, even where CI itself won't turn red.
  */
 
 const repoRoot = path.resolve(

--- a/scripts/lib/lsp-fixture-workspace.d.mts
+++ b/scripts/lib/lsp-fixture-workspace.d.mts
@@ -1,0 +1,66 @@
+/** A fixture from LSP_FIXTURES, as far as this module cares. */
+export interface LspFixtureLike {
+	lang: string;
+	dir: string;
+	file: string;
+	gitInit?: boolean;
+	disableServers?: readonly string[];
+}
+
+export interface DisableServersContext {
+	workspace: string;
+	absFile: string;
+	fx: LspFixtureLike;
+}
+
+export interface BootstrapFixtureWorkspaceOptions {
+	/** The caller's own `initLSPConfig` (each script imports it from a slightly different `dist/` entry point). */
+	initLSPConfig: (cwd: string) => Promise<void>;
+	/** Repo root the fixture's `dir` is resolved against. */
+	repoRoot: string;
+	/** Prefix for the generated `os.tmpdir()` workspace name. Ignored when `workspace` is given. */
+	tmpPrefix?: string;
+	/** Use this directory as-is instead of creating a fresh one (probe-clean-signal.mjs's shape). */
+	workspace?: string;
+	/** Defaults to `fx.gitInit`. */
+	gitInit?: boolean;
+	/**
+	 * Omitted → `fx.disableServers`. An array → an explicit override. A
+	 * function → computed AFTER the workspace is copied and registered
+	 * (bench-lsp.mjs's shape, which needs a real file path to compute it).
+	 */
+	disableServers?:
+		| readonly string[]
+		| ((ctx: DisableServersContext) => readonly string[]);
+}
+
+export interface BootstrapFixtureWorkspaceResult {
+	workspace: string;
+	absFile: string;
+	cleanup: () => void;
+	disabledServers: readonly string[];
+}
+
+export function bootstrapFixtureWorkspace(
+	fx: LspFixtureLike,
+	opts: BootstrapFixtureWorkspaceOptions,
+): Promise<BootstrapFixtureWorkspaceResult>;
+
+export interface WithScratchHomeOptions {
+	/** Skip pinning even when PI_LENS_HOME is unset (no caller in this repo does today). */
+	realHome?: boolean;
+	tmpPrefix?: string;
+}
+
+export interface WithScratchHomeResult {
+	/** The scratch dir now in effect (own or pre-existing), or undefined when `realHome` was passed. */
+	dir: string | undefined;
+	/** True only when this call actually created and pinned a fresh scratch dir. */
+	pinned: boolean;
+	/** Reverses this call's own env mutation (a no-op when `pinned` is false). */
+	restore: () => void;
+}
+
+export function withScratchHome(
+	opts?: WithScratchHomeOptions,
+): WithScratchHomeResult;

--- a/scripts/lib/lsp-fixture-workspace.mjs
+++ b/scripts/lib/lsp-fixture-workspace.mjs
@@ -1,0 +1,173 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gitExecFileSync } from "./git-fixture-env.mjs";
+import { assertFixtureWorkspaceRegistered } from "./lsp-fixture-session-guard.mjs";
+
+/**
+ * #2670 (folds #2658). The one "copy fixture → register session root →
+ * optional `.pi-lens/lsp.json` disable + reload → optional `git init` →
+ * assert registered" bootstrap every LSP dev-harness script needs, shared
+ * instead of hand-copied. Before this module, `characterize-lsp.mjs` and
+ * `server-capabilities.mjs` carried a byte-identical 23-line block,
+ * `probe-clean-signal.mjs` the same shape with two flags read from different
+ * local names, `smoke-tools.mjs` its own (order-shifted, `fx.setup`/
+ * `fx.lombokJar` interleaved) variant, and `bench-lsp.mjs` (#2658) skipped
+ * the unconditional register entirely — the exact #2369/#2655 ordering bug,
+ * a fifth time.
+ *
+ * `initLSPConfig` is caller-supplied rather than imported here: each script
+ * loads it from a slightly different `dist/` entry point (some via a
+ * top-level `await import()`, smoke-tools.mjs from inside a function), and
+ * this module has no opinion on that — see lsp-fixture-session-guard.mjs's
+ * own doc comment for the identical reasoning about not importing
+ * `initLSPConfig` itself.
+ *
+ * `disableServers`:
+ *   - omitted → falls back to `fx.disableServers` (a fixture's own static
+ *     list), matching every caller except bench-lsp.
+ *   - an array → an explicit override.
+ *   - a function `({ workspace, absFile, fx }) => string[]` → computed AFTER
+ *     the workspace exists and is registered but BEFORE anything is
+ *     disabled — bench-lsp's shape: it disables whatever
+ *     `getServersForFileWithConfig(absFile)` returns that isn't this
+ *     fixture's measurement target, which needs a real file path inside a
+ *     real (already-copied) workspace to compute.
+ *
+ * `workspace`, when given, is used as-is instead of a fresh `mkdtempSync` —
+ * probe-clean-signal.mjs pre-creates its temp dir outside this call so its
+ * own `withTimeout` wrapper and `finally` cleanup can own it start to finish
+ * even if bootstrapping itself times out.
+ *
+ * Returns `{ workspace, absFile, cleanup, disabledServers }` — `cleanup()`
+ * removes the workspace (Windows-safe retry, matching smoke-tools.mjs's
+ * existing `safeRm`); a caller that pre-supplied `workspace` and owns its
+ * own cleanup is free to ignore it.
+ */
+export async function bootstrapFixtureWorkspace(fx, opts) {
+	const {
+		initLSPConfig,
+		repoRoot,
+		tmpPrefix = "lsp-fixture-",
+		workspace: preMadeWorkspace,
+		gitInit = fx.gitInit,
+		disableServers,
+	} = opts;
+
+	const workspace =
+		preMadeWorkspace ?? fs.mkdtempSync(path.join(os.tmpdir(), tmpPrefix));
+	fs.cpSync(path.join(repoRoot, fx.dir), workspace, { recursive: true });
+
+	// #2369/#2655/#2658: every fixture registers its OWN workspace
+	// unconditionally — never only inside the `disableServers` branch below.
+	// `clients/lsp/session-roots.ts` fails OPEN (declines nothing) only while
+	// its registry is empty; the moment ANY fixture registers its own
+	// workspace, every OTHER still-unregistered workspace is silently
+	// declined. See lsp-fixture-session-guard.mjs for the full writeup.
+	await initLSPConfig(workspace);
+	const absFile = path.join(workspace, fx.file);
+
+	if (gitInit) {
+		try {
+			gitExecFileSync(["init", "-q"], { cwd: workspace, stdio: "ignore" });
+		} catch {
+			// git unavailable — caller-specific fallback behavior is unaffected
+		}
+	}
+
+	const resolvedDisable =
+		typeof disableServers === "function"
+			? disableServers({ workspace, absFile, fx })
+			: (disableServers ?? fx.disableServers);
+
+	if (resolvedDisable && resolvedDisable.length) {
+		fs.mkdirSync(path.join(workspace, ".pi-lens"), { recursive: true });
+		fs.writeFileSync(
+			path.join(workspace, ".pi-lens", "lsp.json"),
+			JSON.stringify({ disabledServers: resolvedDisable }, null, 2),
+		);
+		// The disabled-server list must land in the CACHED config, so reload
+		// after writing it — the early call above exists only for session-root
+		// registration, which `initLSPConfig` performs before touching disk.
+		await initLSPConfig(workspace);
+	}
+
+	// Harness guard (#2369/#2655/#2658): every fixture must register its own
+	// workspace as a session root before it is touched.
+	await assertFixtureWorkspaceRegistered(fx.lang, workspace);
+
+	const cleanup = () => {
+		try {
+			fs.rmSync(workspace, {
+				recursive: true,
+				force: true,
+				maxRetries: 3,
+				retryDelay: 200,
+			});
+		} catch {
+			// leftover temp dir — harmless, swept by the OS/next run
+		}
+	};
+
+	return {
+		workspace,
+		absFile,
+		cleanup,
+		disabledServers: resolvedDisable ?? [],
+	};
+}
+
+/**
+ * #2670/#2506-shape. The four sibling scripts' now-unconditional
+ * `initLSPConfig` (and smoke-tools.mjs's own) each emit a
+ * `config_resolution_pending` + `config_resolved` pair per fixture — 49 on a
+ * full `--lsp` run, up from 3 pre-#2369 — into whatever `~/.pi-lens/
+ * latency.log`/`sessionstart.log` `getGlobalPiLensLogDir()`/
+ * `getGlobalPiLensDir()` resolve to. Both resolve from `PI_LENS_HOME`
+ * FIRST, before any other fallback (`clients/file-utils.ts`,
+ * `clients/probe-home-state.ts`) — so pinning that one env var (plus its
+ * project-scoped sibling `PILENS_DATA_DIR`) is sufficient, and must happen
+ * before the first `dist/` import: `dist/clients/latency-logger.js` reads
+ * its log directory into a top-level `const` at module load, not lazily
+ * per write.
+ *
+ * Pins only when the caller hasn't already chosen a home (an explicit
+ * `PI_LENS_HOME` — set by an operator, a wrapper script, or a test spawning
+ * one of these harness scripts as a child — always wins, matching
+ * `getGlobalPiLensLogDir()`'s own "PI_LENS_HOME wins over any redirect"
+ * contract instead of silently clobbering it). Pass `{ realHome: true }`
+ * (with a comment explaining why) to skip pinning even when unset — no
+ * caller in this repo does today.
+ *
+ * Deliberately a FRESH directory per call (an actual "per-run" scratch
+ * home, matching what the caller asked for), not a stable one reused across
+ * invocations: a stable global path would let concurrent scripts/agents on
+ * the same machine race on one `instances.json`/tool tree. The cost is that
+ * `--install` runs of these scripts no longer share a tool cache ACROSS
+ * separate script invocations (each of the five nightly steps installs its
+ * own copy) — acceptable for a nightly, manual-dispatch harness whose
+ * runner is itself thrown away every night; see the PR body for the
+ * tradeoff this was weighed against.
+ */
+export function withScratchHome(opts = {}) {
+	const { realHome = false, tmpPrefix = "lsp-fixture-home-" } = opts;
+	if (realHome) {
+		return { dir: undefined, pinned: false, restore: () => {} };
+	}
+	if (process.env.PI_LENS_HOME?.trim()) {
+		// Already pinned by the caller (or a parent process) — respect it.
+		return { dir: process.env.PI_LENS_HOME, pinned: false, restore: () => {} };
+	}
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), tmpPrefix));
+	process.env.PI_LENS_HOME = dir;
+	const dataDirWasUnset = !process.env.PILENS_DATA_DIR?.trim();
+	if (dataDirWasUnset) process.env.PILENS_DATA_DIR = dir;
+	return {
+		dir,
+		pinned: true,
+		restore() {
+			delete process.env.PI_LENS_HOME;
+			if (dataDirWasUnset) delete process.env.PILENS_DATA_DIR;
+		},
+	};
+}

--- a/scripts/lib/lsp-fixture-workspace.mjs
+++ b/scripts/lib/lsp-fixture-workspace.mjs
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { gitExecFileSync } from "./git-fixture-env.mjs";
 import { assertFixtureWorkspaceRegistered } from "./lsp-fixture-session-guard.mjs";
+import { safeRm } from "./safe-rm.mjs";
 
 /**
  * #2670 (folds #2658). The one "copy fixture → register session root →
@@ -96,18 +97,7 @@ export async function bootstrapFixtureWorkspace(fx, opts) {
 	// workspace as a session root before it is touched.
 	await assertFixtureWorkspaceRegistered(fx.lang, workspace);
 
-	const cleanup = () => {
-		try {
-			fs.rmSync(workspace, {
-				recursive: true,
-				force: true,
-				maxRetries: 3,
-				retryDelay: 200,
-			});
-		} catch {
-			// leftover temp dir — harmless, swept by the OS/next run
-		}
-	};
+	const cleanup = () => safeRm(workspace);
 
 	return {
 		workspace,
@@ -149,6 +139,38 @@ export async function bootstrapFixtureWorkspace(fx, opts) {
  * runner is itself thrown away every night; see the PR body for the
  * tradeoff this was weighed against.
  */
+/**
+ * Sweep leftover scratch-home dirs from PRIOR runs (#2670 review F2). Their
+ * processes have long since exited, so nothing still holds a lock inside
+ * them — the same "cleanup belongs at startup, not in the same process that
+ * holds the lock" reasoning `sweepLeftovers` (`smoke-tools.mjs`) already
+ * documents for fixture workspaces. Nothing else ever removes a scratch
+ * home: `withScratchHome`'s `restore()` only unsets the env vars (the dir
+ * itself may still hold installed tools a LATER call in the same process
+ * wants to keep using), and a SIGKILL'd run skips any exit handler entirely
+ * — without this sweep, every `--install` run leaves a full tool tree
+ * behind in `os.tmpdir()` forever.
+ *
+ * Best-effort per entry, same as `sweepLeftovers`: a dir still locked (most
+ * likely a concurrent run's own live scratch home) is left alone rather than
+ * failing the sweep.
+ */
+function sweepScratchHomeLeftovers(tmpPrefix) {
+	const tmp = os.tmpdir();
+	try {
+		for (const entry of fs.readdirSync(tmp)) {
+			if (!entry.startsWith(tmpPrefix)) continue;
+			try {
+				fs.rmSync(path.join(tmp, entry), { recursive: true, force: true });
+			} catch {
+				// still in use — leave it, swept by a later run instead
+			}
+		}
+	} catch {
+		// tmpdir unreadable — ignore
+	}
+}
+
 export function withScratchHome(opts = {}) {
 	const { realHome = false, tmpPrefix = "lsp-fixture-home-" } = opts;
 	if (realHome) {
@@ -158,10 +180,22 @@ export function withScratchHome(opts = {}) {
 		// Already pinned by the caller (or a parent process) — respect it.
 		return { dir: process.env.PI_LENS_HOME, pinned: false, restore: () => {} };
 	}
+	// Startup sweep BEFORE minting this run's own dir, so it never sweeps
+	// itself (#2670 review F2).
+	sweepScratchHomeLeftovers(tmpPrefix);
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), tmpPrefix));
 	process.env.PI_LENS_HOME = dir;
 	const dataDirWasUnset = !process.env.PILENS_DATA_DIR?.trim();
 	if (dataDirWasUnset) process.env.PILENS_DATA_DIR = dir;
+	// #2670 review F3: the redirect otherwise announces itself nowhere — the
+	// pin runs BEFORE `getGlobalPiLensLogDir()`'s own `global-dir-probe-redirect`
+	// degradation row could ever fire (that row only exists for the DIFFERENT,
+	// unpinned probe-redirect path; `PI_LENS_HOME` wins ahead of it and leaves
+	// no trace of its own). One line naming the dir is the only way a human
+	// reading this run's output can find where its telemetry/tool installs went.
+	console.error(
+		`[lsp-fixture-workspace] PI_LENS_HOME pinned to ${dir} (#2506 shape) — this run's tool installs and config_resolved/sessionstart telemetry land there, not the real ~/.pi-lens.`,
+	);
 	return {
 		dir,
 		pinned: true,

--- a/scripts/lib/lsp-fixture-workspace.mjs
+++ b/scripts/lib/lsp-fixture-workspace.mjs
@@ -139,35 +139,89 @@ export async function bootstrapFixtureWorkspace(fx, opts) {
  * runner is itself thrown away every night; see the PR body for the
  * tradeoff this was weighed against.
  */
+const SCRATCH_HOME_OWNER_FILE = "owner.pid";
+// Fallback for a dir with no pid file at all (pre-dates this fix, or its
+// writer crashed between mkdtemp and writing its own pid) — old enough that
+// ANY normal `--install` run (minutes, not hours) is long finished, so this
+// never races a live one.
+const SCRATCH_HOME_ORPHAN_AGE_MS = 60 * 60 * 1000; // 1h
+
 /**
- * Sweep leftover scratch-home dirs from PRIOR runs (#2670 review F2). Their
- * processes have long since exited, so nothing still holds a lock inside
- * them — the same "cleanup belongs at startup, not in the same process that
- * holds the lock" reasoning `sweepLeftovers` (`smoke-tools.mjs`) already
- * documents for fixture workspaces. Nothing else ever removes a scratch
- * home: `withScratchHome`'s `restore()` only unsets the env vars (the dir
- * itself may still hold installed tools a LATER call in the same process
- * wants to keep using), and a SIGKILL'd run skips any exit handler entirely
- * — without this sweep, every `--install` run leaves a full tool tree
- * behind in `os.tmpdir()` forever.
+ * Is the process that minted `entryDir` (its recorded `owner.pid`) still
+ * alive? `undefined` when there's no pid file to check (caller falls back to
+ * an age gate). `process.kill(pid, 0)` sends no signal — it only probes
+ * existence/permission: `ESRCH` means no such process (dead); anything else
+ * (success, or `EPERM` — a live process this one merely lacks permission to
+ * signal) means a real, live process still owns this dir.
+ */
+function scratchHomeOwnerAlive(entryDir) {
+	let pidText;
+	try {
+		pidText = fs.readFileSync(
+			path.join(entryDir, SCRATCH_HOME_OWNER_FILE),
+			"utf8",
+		);
+	} catch {
+		return undefined; // no pid file recorded
+	}
+	const pid = Number.parseInt(pidText.trim(), 10);
+	if (!Number.isInteger(pid) || pid <= 0) return undefined;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return err?.code !== "ESRCH";
+	}
+}
+
+/**
+ * Sweep leftover scratch-home dirs from PRIOR runs (#2670 review F2, hardened
+ * in review round 2 F1). Nothing else ever removes a scratch home:
+ * `withScratchHome`'s `restore()` only unsets the env vars (the dir itself
+ * may still hold installed tools a LATER call in the same process wants to
+ * keep using), and a SIGKILL'd run skips any exit handler entirely — without
+ * this sweep, every `--install` run leaves a full tool tree behind in
+ * `os.tmpdir()` forever.
  *
- * Best-effort per entry, same as `sweepLeftovers`: a dir still locked (most
- * likely a concurrent run's own live scratch home) is left alone rather than
- * failing the sweep.
+ * NOT a blind "try rmSync, catch = still locked" pass (round 1's shape,
+ * reviewer round 2 F1): on POSIX, `rmSync` on a directory another process is
+ * actively using SUCCEEDS regardless — only Windows EPERMs on an open
+ * handle — so that catch block was describing a protection that did not
+ * exist. A live writer whose scratch home got removed out from under it
+ * would keep appending to files by then-unlinked inode: silent, permanent
+ * data loss, not a caught-and-skipped no-op. Liveness is checked for real
+ * instead: each dir's `owner.pid` (written at mint by `withScratchHome`)
+ * against `process.kill(pid, 0)` — alive is skipped unconditionally, dead is
+ * removed. A dir with no pid file at all only goes by age (see
+ * `SCRATCH_HOME_ORPHAN_AGE_MS`), never by whether `rmSync` happens to throw.
  */
 function sweepScratchHomeLeftovers(tmpPrefix) {
+	let entries;
 	const tmp = os.tmpdir();
 	try {
-		for (const entry of fs.readdirSync(tmp)) {
-			if (!entry.startsWith(tmpPrefix)) continue;
-			try {
-				fs.rmSync(path.join(tmp, entry), { recursive: true, force: true });
-			} catch {
-				// still in use — leave it, swept by a later run instead
-			}
-		}
+		entries = fs.readdirSync(tmp);
 	} catch {
-		// tmpdir unreadable — ignore
+		return; // tmpdir unreadable — ignore
+	}
+	for (const entry of entries) {
+		if (!entry.startsWith(tmpPrefix)) continue;
+		const entryDir = path.join(tmp, entry);
+		const ownerAlive = scratchHomeOwnerAlive(entryDir);
+		if (ownerAlive === true) continue; // its writer is still running — never touch a live home
+		if (ownerAlive === undefined) {
+			let mtimeMs;
+			try {
+				mtimeMs = fs.statSync(entryDir).mtimeMs;
+			} catch {
+				continue; // already gone (raced something else) — nothing to do
+			}
+			if (Date.now() - mtimeMs < SCRATCH_HOME_ORPHAN_AGE_MS) continue; // too young to call orphaned yet
+		}
+		try {
+			fs.rmSync(entryDir, { recursive: true, force: true });
+		} catch {
+			// a genuine removal error (e.g. permissions) — leave it, swept by a later run instead
+		}
 	}
 }
 
@@ -184,6 +238,12 @@ export function withScratchHome(opts = {}) {
 	// itself (#2670 review F2).
 	sweepScratchHomeLeftovers(tmpPrefix);
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), tmpPrefix));
+	// Recorded so a LATER run's sweep can tell this one is still alive
+	// (review round 2 F1) rather than guessing from whether rmSync throws.
+	fs.writeFileSync(
+		path.join(dir, SCRATCH_HOME_OWNER_FILE),
+		String(process.pid),
+	);
 	process.env.PI_LENS_HOME = dir;
 	const dataDirWasUnset = !process.env.PILENS_DATA_DIR?.trim();
 	if (dataDirWasUnset) process.env.PILENS_DATA_DIR = dir;

--- a/scripts/lib/safe-rm.d.mts
+++ b/scripts/lib/safe-rm.d.mts
@@ -1,0 +1,1 @@
+export function safeRm(dir: string): void;

--- a/scripts/lib/safe-rm.mjs
+++ b/scripts/lib/safe-rm.mjs
@@ -1,0 +1,29 @@
+import * as fs from "node:fs";
+
+/**
+ * Best-effort recursive directory removal. On Windows a spawned LSP server
+ * (or an installed tool's own child process) can still hold a handle inside
+ * `dir` until ITS process exits, so an in-run `rmSync` can EPERM — never let
+ * that abort the caller. A leftover dir is swept on the next run instead (see
+ * each caller's own startup sweep — `sweepLeftovers` in `smoke-tools.mjs`,
+ * `withScratchHome`'s scratch-home sweep in `lsp-fixture-workspace.mjs`).
+ *
+ * Extracted from `smoke-tools.mjs` (#2670 review F4): `bootstrapFixtureWorkspace`'s
+ * `cleanup()` needs the identical retry-and-swallow shape, and `smoke-tools.mjs`
+ * already imports FROM `lsp-fixture-workspace.mjs` (for `bootstrapFixtureWorkspace`/
+ * `withScratchHome`), so the import direction is forced: this has to live in its
+ * own leaf module rather than in either of theirs, or importing it back would
+ * close a cycle.
+ */
+export function safeRm(dir) {
+	try {
+		fs.rmSync(dir, {
+			recursive: true,
+			force: true,
+			maxRetries: 3,
+			retryDelay: 200,
+		});
+	} catch {
+		// leftover temp dir — swept at the next run's startup sweep
+	}
+}

--- a/scripts/probe-clean-signal.mjs
+++ b/scripts/probe-clean-signal.mjs
@@ -40,8 +40,6 @@
  * Requires `npm run build:dist` (imports from dist/). Measures only
  * already-installed servers unless --install is passed.
  */
-import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
-import { assertFixtureWorkspaceRegistered } from "./lib/lsp-fixture-session-guard.mjs";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -51,6 +49,10 @@ import {
 	classifyCleanBehavior,
 	DRIFT_SUMMARY_PATH,
 } from "./lib/clean-signal.mjs";
+import {
+	bootstrapFixtureWorkspace,
+	withScratchHome,
+} from "./lib/lsp-fixture-workspace.mjs";
 import {
 	mergeRows,
 	mergeSrc,
@@ -66,6 +68,12 @@ const argv = process.argv.slice(2);
 const install = argv.includes("--install");
 const langs = argv.filter((a) => !a.startsWith("--"));
 const ECHO_TRACE = Boolean(process.env.PILENS_PUB_DEBUG);
+
+// #2670/#2506-shape: pin PI_LENS_HOME/PILENS_DATA_DIR to a scratch temp dir
+// BEFORE the first dist/ import below — dist/clients/latency-logger.js reads
+// its log dir into a top-level const at module load, not lazily per write.
+withScratchHome();
+
 const imp = (rel) => import(pathToFileURL(path.join(repoRoot, rel)).href);
 
 // Force the client's publish trace on so we can tally publishes in-process. It
@@ -228,29 +236,17 @@ for (const fx of fixtures) {
 }
 
 async function probeFixture(fx, dst, row) {
-	fs.cpSync(path.join(repoRoot, fx.dir), dst, { recursive: true });
-	// #2369/#2655: every fixture registers its OWN workspace unconditionally —
-	// see lib/lsp-fixture-session-guard.mjs for why this can't be conditional
-	// on `disableServers`.
-	await initLSPConfig(dst);
-	const absFile = path.join(dst, fx.file);
-	if (fx.gitInit) {
-		try {
-			gitExecFileSync(["init", "-q"], { cwd: dst, stdio: "ignore" });
-		} catch {}
-	}
-	if (fx.disableServers) {
-		fs.mkdirSync(path.join(dst, ".pi-lens"), { recursive: true });
-		fs.writeFileSync(
-			path.join(dst, ".pi-lens", "lsp.json"),
-			JSON.stringify({ disabledServers: fx.disableServers }, null, 2),
-		);
-		await initLSPConfig(dst);
-	}
+	// `dst` is pre-created by the caller (mkdtemp'd BEFORE `withTimeout` starts
+	// the race, so its `finally` can always clean it up, even if bootstrapping
+	// itself times out) — pass it straight through as `workspace`.
+	const { absFile } = await bootstrapFixtureWorkspace(fx, {
+		initLSPConfig,
+		repoRoot,
+		workspace: dst,
+	});
 	if (install && ensureTool) {
 		for (const t of fx.tools ?? []) await ensureTool(t).catch(() => undefined);
 	}
-	await assertFixtureWorkspaceRegistered(fx.lang, dst);
 	if (!lsp.supportsLSP(absFile)) {
 		row.mode = "no-lsp";
 		row.detail = "no LSP server registered for this file";

--- a/scripts/server-capabilities.mjs
+++ b/scripts/server-capabilities.mjs
@@ -17,12 +17,13 @@
  * provisioned env (the nightly) to capture those rows.
  */
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { mergeServerCapabilitiesDoc } from "./lib/md-matrix.mjs";
-import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
-import { assertFixtureWorkspaceRegistered } from "./lib/lsp-fixture-session-guard.mjs";
+import {
+	bootstrapFixtureWorkspace,
+	withScratchHome,
+} from "./lib/lsp-fixture-workspace.mjs";
 
 const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -31,6 +32,12 @@ const repoRoot = path.resolve(
 const argv = process.argv.slice(2);
 const install = argv.includes("--install");
 const langs = argv.filter((a) => !a.startsWith("--"));
+
+// #2670/#2506-shape: pin PI_LENS_HOME/PILENS_DATA_DIR to a scratch temp dir
+// BEFORE the first dist/ import below — dist/clients/latency-logger.js reads
+// its log dir into a top-level const at module load, not lazily per write.
+withScratchHome();
+
 const imp = (rel) => import(pathToFileURL(path.join(repoRoot, rel)).href);
 const { LSP_FIXTURES } = await imp("scripts/smoke-tools.mjs");
 const { getLSPService, resetLSPService } = await imp(
@@ -65,36 +72,20 @@ const OPS = [
 ];
 
 for (const fx of fixtures) {
-	const dst = fs.mkdtempSync(path.join(os.tmpdir(), "caps-lsp-"));
-	fs.cpSync(path.join(repoRoot, fx.dir), dst, { recursive: true });
-	// #2369/#2655: every fixture registers its OWN workspace unconditionally —
-	// see lib/lsp-fixture-session-guard.mjs for why this can't be conditional
-	// on `disableServers`.
-	await initLSPConfig(dst);
-	const absFile = path.join(dst, fx.file);
-	if (fx.gitInit) {
-		try {
-			gitExecFileSync(["init", "-q"], { cwd: dst, stdio: "ignore" });
-		} catch {}
-	}
-	if (fx.disableServers) {
-		fs.mkdirSync(path.join(dst, ".pi-lens"), { recursive: true });
-		fs.writeFileSync(
-			path.join(dst, ".pi-lens", "lsp.json"),
-			JSON.stringify({ disabledServers: fx.disableServers }, null, 2),
-		);
-		await initLSPConfig(dst);
-	}
-	if (install && ensureTool) {
-		for (const t of fx.tools ?? []) await ensureTool(t).catch(() => undefined);
-	}
-	await assertFixtureWorkspaceRegistered(fx.lang, dst);
-	if (!lsp.supportsLSP(absFile)) {
-		fs.rmSync(dst, { recursive: true, force: true });
-		continue;
-	}
-	const auxIds = fx.auxiliaryServerIds ?? [];
+	const { absFile, cleanup } = await bootstrapFixtureWorkspace(fx, {
+		initLSPConfig,
+		repoRoot,
+		tmpPrefix: "caps-lsp-",
+	});
 	try {
+		if (install && ensureTool) {
+			for (const t of fx.tools ?? [])
+				await ensureTool(t).catch(() => undefined);
+		}
+		if (!lsp.supportsLSP(absFile)) {
+			continue;
+		}
+		const auxIds = fx.auxiliaryServerIds ?? [];
 		const content = fs.readFileSync(absFile, "utf8");
 		await lsp.touchFile(absFile, content, {
 			diagnostics: "document",
@@ -124,9 +115,7 @@ for (const fx of fixtures) {
 		unavailable.add(fx.serverHint ?? fx.lang);
 		console.error(`[${fx.lang}] error: ${e?.message ?? e}`);
 	} finally {
-		try {
-			fs.rmSync(dst, { recursive: true, force: true });
-		} catch {}
+		cleanup();
 	}
 }
 

--- a/scripts/smoke-tools.d.mts
+++ b/scripts/smoke-tools.d.mts
@@ -109,6 +109,16 @@ export interface ClassifyInstallOutcomeDeps {
 	/** The pip command ladder to probe, in priority order (installer's own). */
 	pipCandidates: readonly string[];
 }
+/**
+ * Everything `classifyInstallOutcome` needs EXCEPT `getInstallAttempt`
+ * (#2670): `resolveUnavailabilityRow` takes the attempt-snapshot `Map` as its
+ * own positional parameter and derives `getInstallAttempt` from it
+ * internally, so a caller has no `getInstallAttempt` key to (mis)assemble.
+ */
+export type ClassifyOutcomeRestDeps = Omit<
+	ClassifyInstallOutcomeDeps,
+	"getInstallAttempt"
+>;
 export interface InstallOutcomeRow {
 	row: "fail" | "skip";
 	detail: string;
@@ -138,11 +148,17 @@ export function pipCandidateUsable(command: string): boolean;
  * install failure among `toolIds` (`classifyInstallOutcome`), or a "skip"
  * carrying `fallbackSkipDetail` when every unavailable tool in the list is
  * legitimately declined/skipped/toolchain-absent/transient.
+ *
+ * `attemptSnapshots` is the actual snapshot `Map` `ensureFixtureTools`
+ * returned — not folded into `restDeps`, so a caller has no
+ * `getInstallAttempt` key of its own to accidentally point at the live
+ * module-global instead (#2670, the #2661 r3 verify's residual).
  */
 export function resolveUnavailabilityRow(
 	toolIds: readonly string[],
 	unavailableTools: ReadonlySet<string>,
-	deps: ClassifyInstallOutcomeDeps,
+	attemptSnapshots: ReadonlyMap<string, SmokeInstallAttempt | undefined>,
+	restDeps: ClassifyOutcomeRestDeps,
 	fallbackSkipDetail: string,
 ): InstallOutcomeRow;
 /**

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -51,6 +51,7 @@ import {
 	bootstrapFixtureWorkspace,
 	withScratchHome,
 } from "./lib/lsp-fixture-workspace.mjs";
+import { safeRm } from "./lib/safe-rm.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
@@ -1257,24 +1258,6 @@ function parseArgs(argv) {
 }
 
 const TMP_PREFIX = "pi-lens-smoke-";
-
-/**
- * Best-effort temp cleanup. On Windows the spawned LSP servers keep a handle on
- * the workspace until THIS process exits, so an in-run rmSync can EPERM; never
- * let that abort the run.
- */
-function safeRm(dir) {
-	try {
-		fs.rmSync(dir, {
-			recursive: true,
-			force: true,
-			maxRetries: 3,
-			retryDelay: 200,
-		});
-	} catch {
-		// leftover temp dir — swept on the next run (see sweepLeftovers)
-	}
-}
 
 /**
  * Sweep leftovers from PRIOR runs. Those runs' LSP servers have long since

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -47,7 +47,10 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { gitExecFileSync } from "./lib/git-fixture-env.mjs";
-import { assertFixtureWorkspaceRegistered } from "./lib/lsp-fixture-session-guard.mjs";
+import {
+	bootstrapFixtureWorkspace,
+	withScratchHome,
+} from "./lib/lsp-fixture-workspace.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
@@ -1564,16 +1567,33 @@ export function classifyInstallOutcome(toolId, deps) {
  * legitimately declined/skipped/toolchain-absent/transient. The single call
  * site all three `runLspHandshake` unavailability branches share (#2661
  * review F3 — three near-identical inline blocks collapsed to one).
+ *
+ * `attemptSnapshots` is the actual `Map` `ensureFixtureTools` returned — not
+ * a `deps`-shaped object carrying its own `getInstallAttempt` closure that a
+ * future edit could reassemble either way. #2670 (from the #2661 r3 verify):
+ * the previous signature took a `deps` object whose caller built
+ * `{ ...classifyDeps, getInstallAttempt: (id) => attemptSnapshots.get(id) }`
+ * at the call site — nothing stopped a later edit from swapping that closure
+ * for the module-global `getInstallAttempt` (mutation E, #2661), which
+ * stayed green because no test exercised the call site's own wiring. Taking
+ * the snapshot Map as its own positional parameter and deriving
+ * `getInstallAttempt` from it INTERNALLY (always overriding anything a
+ * caller's `restDeps` might carry under that key) removes the shape that
+ * mutation needs to exist in.
  */
 export function resolveUnavailabilityRow(
 	toolIds,
 	unavailableTools,
-	deps,
+	attemptSnapshots,
+	restDeps,
 	fallbackSkipDetail,
 ) {
 	for (const id of toolIds) {
 		if (!unavailableTools.has(id)) continue;
-		const outcome = classifyInstallOutcome(id, deps);
+		const outcome = classifyInstallOutcome(id, {
+			...restDeps,
+			getInstallAttempt: (toolId) => attemptSnapshots.get(toolId),
+		});
 		if (outcome.row === "fail") return outcome;
 	}
 	return { row: "skip", detail: fallbackSkipDetail };
@@ -1758,23 +1778,21 @@ async function runLspHandshake({ langs, install, verbose }) {
 				}
 			},
 		);
-		const fixtureClassifyDeps = {
-			...classifyDeps,
-			getInstallAttempt: (toolId) => attemptSnapshots.get(toolId),
-		};
-		const workspace = copyDirToTemp(fx.dir);
-		// #2369: every fixture's temp workspace is a fresh, unregistered session
-		// root. Register it unconditionally (not only for `disableServers`
-		// fixtures) so `isOutsideAllSessionRoots` never declines this workspace's
-		// files just because an EARLIER fixture in the array happened to register
-		// its own (foreign) workspace first and flipped the registry from empty
-		// (fail-open) to non-empty. `disableServers` fixtures still reload below,
-		// after writing `.pi-lens/lsp.json`, so the disabled-server list they set
-		// is the one that lands in the cached config — this early call exists
-		// only for session-root registration, which `initLSPConfig` performs
-		// before anything else regardless of what config is on disk yet.
-		await initLSPConfig(workspace);
-		const absFile = path.join(workspace, fx.file);
+		// #2369/#2655/#2658: every fixture's temp workspace registers itself as a
+		// served session root unconditionally (not only for `disableServers`
+		// fixtures) — see lib/lsp-fixture-workspace.mjs / lib/lsp-fixture-
+		// session-guard.mjs for why this can't be conditional. `fx.setup`/
+		// `fx.lombokJar` (below) don't touch git/LSP-config state, so running
+		// them after registration+gitInit+disable+assert is order-safe.
+		const { workspace, absFile, cleanup } = await bootstrapFixtureWorkspace(
+			fx,
+			{ initLSPConfig, repoRoot, tmpPrefix: "pi-lens-smoke-" },
+		);
+		if (verbose && fx.disableServers) {
+			console.error(
+				`[${fx.lang}] disabled [${fx.disableServers.join(",")}] via .pi-lens/lsp.json → expecting ${fx.expectServerId}`,
+			);
+		}
 		if (fx.setup) {
 			if (verbose) {
 				const desc = Array.isArray(fx.setup) ? fx.setup.join(" ") : fx.setup;
@@ -1789,7 +1807,7 @@ async function runLspHandshake({ langs, install, verbose }) {
 					detail: setupResult.detail,
 					diags: 0,
 				});
-				safeRm(workspace);
+				cleanup();
 				continue;
 			}
 		}
@@ -1805,45 +1823,14 @@ async function runLspHandshake({ langs, install, verbose }) {
 					detail: `lombok.jar unavailable: ${err?.message ?? err}`,
 					diags: 0,
 				});
-				safeRm(workspace);
+				cleanup();
 				continue;
-			}
-		}
-		// Some auxiliary servers (opengrep) root at the nearest .git — give the
-		// temp workspace one so the copied fixture is treated as in-workspace.
-		if (fx.gitInit) {
-			try {
-				gitExecFileSync(["init", "-q"], {
-					cwd: workspace,
-					stdio: "ignore",
-				});
-			} catch {
-				// git unavailable — opengrep falls back to cwd; may not scan the temp file
 			}
 		}
 		const auxIds = fx.auxiliaryServerIds ?? [];
 		const useAux = auxIds.length > 0;
 		const push = (state, detail, diags = 0) =>
 			rows.push({ lang: fx.lang, runner: fx.serverHint, state, detail, diags });
-		// Alternate-primary fixtures: disable the default server for this workspace
-		// so getClientForFile falls through to the alternate.
-		if (fx.disableServers) {
-			fs.mkdirSync(path.join(workspace, ".pi-lens"), { recursive: true });
-			fs.writeFileSync(
-				path.join(workspace, ".pi-lens", "lsp.json"),
-				JSON.stringify({ disabledServers: fx.disableServers }, null, 2),
-			);
-			await initLSPConfig(workspace);
-			if (verbose) {
-				console.error(
-					`[${fx.lang}] disabled [${fx.disableServers.join(",")}] via .pi-lens/lsp.json → expecting ${fx.expectServerId}`,
-				);
-			}
-		}
-		// Harness guard (#2369/#2655): every fixture must register its OWN
-		// workspace as a session root before it is touched — see
-		// lib/lsp-fixture-session-guard.mjs for why.
-		await assertFixtureWorkspaceRegistered(fx.lang, workspace);
 		try {
 			if (!lsp.supportsLSP(absFile)) {
 				push("skip", "no LSP server registered for this file");
@@ -1931,7 +1918,8 @@ async function runLspHandshake({ langs, install, verbose }) {
 					const outcome = resolveUnavailabilityRow(
 						toolList,
 						unavailableTools,
-						fixtureClassifyDeps,
+						attemptSnapshots,
+						classifyDeps,
 						`auxiliary ${auxIds.join(",")} unavailable (tool not installed; pass --install)`,
 					);
 					push(outcome.row, outcome.detail);
@@ -1968,7 +1956,8 @@ async function runLspHandshake({ langs, install, verbose }) {
 					const outcome = resolveUnavailabilityRow(
 						fx.tools ?? [],
 						unavailableTools,
-						fixtureClassifyDeps,
+						attemptSnapshots,
+						classifyDeps,
 						`${fx.expectServerId} unavailable (no client ready; pass --install or install ${(fx.tools ?? []).join(",")})`,
 					);
 					push(outcome.row, outcome.detail);
@@ -2092,7 +2081,8 @@ async function runLspHandshake({ langs, install, verbose }) {
 				const outcome = resolveUnavailabilityRow(
 					fx.tools ?? [],
 					unavailableTools,
-					fixtureClassifyDeps,
+					attemptSnapshots,
+					classifyDeps,
 					`no client ready in ${LSP_CLIENT_WAIT_MS}ms (server missing/slow; try --install)`,
 				);
 				push(outcome.row, outcome.detail);
@@ -2100,7 +2090,7 @@ async function runLspHandshake({ langs, install, verbose }) {
 		} catch (err) {
 			push("fail", `error: ${err?.message ?? err}`);
 		} finally {
-			safeRm(workspace);
+			cleanup();
 		}
 	}
 
@@ -2348,6 +2338,12 @@ async function runAutofixSmoke({ langs, install, verbose }) {
 }
 
 async function main() {
+	// #2670/#2506-shape: pin PI_LENS_HOME/PILENS_DATA_DIR to a scratch temp
+	// dir BEFORE the first dist/ import any lane below performs —
+	// dist/clients/latency-logger.js reads its log dir into a top-level const
+	// at module load, not lazily per write.
+	withScratchHome();
+
 	const {
 		langs,
 		step2,

--- a/tests/config/lsp-fixture-home-workflow-pin.test.ts
+++ b/tests/config/lsp-fixture-home-workflow-pin.test.ts
@@ -1,0 +1,97 @@
+// #2670 review F1: `tool-smoke.yml` runs SIX `--install` invocations
+// (smoke-tools.mjs x3, characterize-lsp.mjs, probe-clean-signal.mjs,
+// server-capabilities.mjs) in ONE job. `PI_LENS_HOME` relocates the
+// installer's tool tree/bin dir/probe cache (module-level consts at
+// `clients/installer/index.ts`), not just logs — with no JOB-level pin, each
+// script's own `withScratchHome()` (scripts/lib/lsp-fixture-workspace.mjs)
+// mints a FRESH, empty scratch home per invocation, so every step re-pulls
+// every managed tool from scratch instead of sharing the one tool tree the
+// job's ephemeral `$HOME` gave them for free pre-#2670. Job-level
+// `PI_LENS_HOME`/`PILENS_DATA_DIR` restores that sharing: `withScratchHome`'s
+// "already pinned" branch is a no-op against an explicit value, so setting it
+// once at the job is the entire fix.
+//
+// Same technique as tests/config/install-smoke-gates.test.ts: load the REAL
+// workflow via yaml.load, assert on the LOADED structure (never a hand-copied
+// restatement of the YAML text).
+//
+// Before this file existed, PI_LENS_HOME/PILENS_DATA_DIR were absent from
+// both workflows entirely (proven below by deleting the env lines from a
+// SOURCE copy and reloading) and no test in the repo checked for them.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import yaml from "../../clients/deps/js-yaml.js";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..");
+
+type Job = { env?: Record<string, unknown>; steps?: unknown };
+type Workflow = { jobs?: Record<string, Job> };
+
+function loadWorkflow(workflowPath: string, source?: string): Workflow {
+	const text = source ?? readFileSync(resolve(REPO_ROOT, workflowPath), "utf8");
+	return yaml.load(text) as Workflow;
+}
+
+// [workflowPath, jobName, installStepCount] — installStepCount is asserted
+// too, so a step added/removed under one of these jobs without updating this
+// table's own understanding of "how many steps share the cache" is visible.
+const WORKFLOWS: Array<[string, string, number]> = [
+	[".github/workflows/tool-smoke.yml", "tool-smoke", 6],
+	[".github/workflows/parser-smoke.yml", "parser-smoke", 1],
+];
+
+describe.each(WORKFLOWS)(
+	"%s jobs.%s.env pins PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1)",
+	(workflowPath, jobName, expectedInstallSteps) => {
+		const workflow = loadWorkflow(workflowPath);
+		const jobEnv = workflow.jobs?.[jobName]?.env;
+
+		it("carries a non-empty PI_LENS_HOME", () => {
+			expect(typeof jobEnv?.PI_LENS_HOME).toBe("string");
+			expect((jobEnv?.PI_LENS_HOME as string).trim().length).toBeGreaterThan(0);
+		});
+
+		it("carries a non-empty PILENS_DATA_DIR", () => {
+			expect(typeof jobEnv?.PILENS_DATA_DIR).toBe("string");
+			expect((jobEnv?.PILENS_DATA_DIR as string).trim().length).toBeGreaterThan(
+				0,
+			);
+		});
+
+		it("PI_LENS_HOME and PILENS_DATA_DIR resolve to the SAME dir (one shared tool tree, not two)", () => {
+			expect(jobEnv?.PI_LENS_HOME).toBe(jobEnv?.PILENS_DATA_DIR);
+		});
+
+		it('never points at ${{ runner.temp }} (unavailable at job-level env — actionlint: "context \\"runner\\" is not allowed here")', () => {
+			expect(String(jobEnv?.PI_LENS_HOME)).not.toContain("runner.temp");
+		});
+
+		it("counts the --install steps this job's cache-sharing claim is actually about", () => {
+			const steps = workflow.jobs?.[jobName]?.steps;
+			const installSteps = (
+				Array.isArray(steps) ? (steps as Array<{ run?: unknown }>) : []
+			).filter((s) => typeof s.run === "string" && s.run.includes("--install"));
+			expect(installSteps.length).toBe(expectedInstallSteps);
+		});
+
+		// Mutation-proof: before this file existed, deleting the pin entirely
+		// left every other check in this repo green.
+		it("mutation-proof: deleting the PI_LENS_HOME env line reds the pin assertion", () => {
+			const source = readFileSync(resolve(REPO_ROOT, workflowPath), "utf8");
+			const lines = source.split("\n");
+			const lineIdx = lines.findIndex((line) =>
+				/^\s*PI_LENS_HOME:\s/.test(line),
+			);
+			expect(lineIdx, "no PI_LENS_HOME: line found").toBeGreaterThanOrEqual(0);
+			const mutatedLines = [...lines];
+			mutatedLines.splice(lineIdx, 1);
+			const mutatedSource = mutatedLines.join("\n");
+			expect(mutatedSource).not.toBe(source);
+			const mutatedWorkflow = loadWorkflow(workflowPath, mutatedSource);
+			expect(
+				mutatedWorkflow.jobs?.[jobName]?.env?.PI_LENS_HOME,
+			).toBeUndefined();
+		});
+	},
+);

--- a/tests/scripts/lsp-fixture-workspace.test.ts
+++ b/tests/scripts/lsp-fixture-workspace.test.ts
@@ -322,37 +322,124 @@ describe("withScratchHome (#2670/#2506-shape)", () => {
 		expect(process.env.PILENS_DATA_DIR).toBeUndefined();
 	});
 
-	// #2670 review F2: nothing else ever removes a scratch home (`restore()`
-	// only unsets the env vars, and a SIGKILL'd run skips any exit handler),
-	// so without a startup sweep every `--install` run leaks a full tool tree.
-	it("sweeps a leftover scratch-home dir from a prior run before minting a new one", () => {
+	// #2670 review F2, hardened in review round 2 F1. `lsp-fixture-workspace-test-home-`,
+	// NOT anything starting with the production default `lsp-fixture-home-`:
+	// the prefix filter is a plain `startsWith`, so a test dir whose name
+	// merely EXTENDS the production prefix (round 1's `lsp-fixture-home-
+	// sweep-test-<pid>-`) is swept by any real script's OWN default-prefixed
+	// sweep running concurrently on the same machine — reviewer round 2 F1's
+	// second direction, reproduced live by the prefix collision alone, no
+	// mutation needed.
+	const SWEEP_TEST_PREFIX = "lsp-fixture-workspace-test-home-";
+
+	function mintScratchHomeDir(): string {
+		return fs.mkdtempSync(path.join(os.tmpdir(), SWEEP_TEST_PREFIX));
+	}
+
+	function writeOwnerPid(dir: string, pid: number): void {
+		fs.writeFileSync(path.join(dir, "owner.pid"), String(pid));
+	}
+
+	/**
+	 * A pid guaranteed to name no process, without spawning one: Linux's own
+	 * `pid_max` (`/proc/sys/kernel/pid_max`, default 4194304, and this repo's
+	 * authoritative Unit tests lane is ubuntu — AGENTS.md platform rule) caps
+	 * every real pid well under this value, and `process.kill(pid, 0)` on an
+	 * out-of-range pid reports the SAME `ESRCH` a genuinely-exited pid would
+	 * (verified directly: `process.kill(999_999_999, 0)` throws
+	 * `{ code: "ESRCH" }`) — the two are indistinguishable to the code under
+	 * test, which only branches on `ESRCH` vs. everything else.
+	 */
+	const IMPOSSIBLE_PID = 999_999_999;
+
+	it("this file's own test prefix does not start with the production default (never cross-swept either direction)", () => {
+		expect(SWEEP_TEST_PREFIX.startsWith("lsp-fixture-home-")).toBe(false);
+	});
+
+	it("does not sweep when a home is already pinned (a no-op call touches nothing under os.tmpdir())", () => {
+		process.env.PI_LENS_HOME = "/some/explicit/home";
+		const leftover = mintScratchHomeDir();
+		try {
+			withScratchHome({ tmpPrefix: SWEEP_TEST_PREFIX });
+			expect(fs.existsSync(leftover)).toBe(true); // untouched — no-op path never sweeps
+		} finally {
+			fs.rmSync(leftover, { recursive: true, force: true });
+		}
+	});
+
+	// #2670 review round 2 F1 (a): the defect this round fixes. Round 1's
+	// sweep did an unconditional `rmSync` and relied on it THROWING to detect
+	// "still in use" — but on POSIX, `rmSync` on a directory another live
+	// process is actively writing into SUCCEEDS regardless (only Windows
+	// EPERMs on an open handle), so that catch block caught nothing. This
+	// test reproduces the hazard directly: a scratch home whose `owner.pid`
+	// names a process that is DEFINITELY still alive (this very test process)
+	// must survive the sweep unconditionally, never merely "usually".
+	it("(a) never removes a scratch home whose owner.pid names a live process", () => {
 		delete process.env.PI_LENS_HOME;
 		delete process.env.PILENS_DATA_DIR;
-		const prefix = `lsp-fixture-home-sweep-test-${process.pid}-`;
-		const leftover = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-		fs.writeFileSync(path.join(leftover, "stale-tool-tree-marker"), "x");
-		expect(fs.existsSync(leftover)).toBe(true);
+		const live = mintScratchHomeDir();
+		writeOwnerPid(live, process.pid); // this test process — guaranteed alive
+		// A populated tool tree, per the reviewer's probe (bin/taplo, tools/,
+		// instances.json) — not load-bearing for the assertion, but makes this
+		// test's failure mode legible as "a live scratch home's tools vanished".
+		fs.mkdirSync(path.join(live, "bin"), { recursive: true });
+		fs.writeFileSync(path.join(live, "bin", "taplo"), "pretend binary");
 
-		const { dir, restore } = withScratchHome({ tmpPrefix: prefix });
+		const { dir, restore } = withScratchHome({ tmpPrefix: SWEEP_TEST_PREFIX });
 		try {
-			expect(fs.existsSync(leftover)).toBe(false); // swept
-			expect(dir).not.toBe(leftover); // this run's OWN dir, minted fresh after the sweep
-			expect(fs.existsSync(dir as string)).toBe(true);
+			expect(fs.existsSync(live)).toBe(true); // survived — the whole point of (a)
+			expect(fs.existsSync(path.join(live, "bin", "taplo"))).toBe(true);
+		} finally {
+			restore();
+			fs.rmSync(dir as string, { recursive: true, force: true });
+			fs.rmSync(live, { recursive: true, force: true });
+		}
+	});
+
+	it("(b) removes a scratch home whose owner.pid names a dead process", () => {
+		delete process.env.PI_LENS_HOME;
+		delete process.env.PILENS_DATA_DIR;
+		const dead = mintScratchHomeDir();
+		writeOwnerPid(dead, IMPOSSIBLE_PID);
+
+		const { dir, restore } = withScratchHome({ tmpPrefix: SWEEP_TEST_PREFIX });
+		try {
+			expect(fs.existsSync(dead)).toBe(false); // swept — its writer is gone
 		} finally {
 			restore();
 			fs.rmSync(dir as string, { recursive: true, force: true });
 		}
 	});
 
-	it("does not sweep when a home is already pinned (a no-op call touches nothing under os.tmpdir())", () => {
-		process.env.PI_LENS_HOME = "/some/explicit/home";
-		const prefix = `lsp-fixture-home-no-sweep-test-${process.pid}-`;
-		const leftover = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	it("(c) skips a dir with no owner.pid that is still young (a mint mid-flight, not yet orphaned)", () => {
+		delete process.env.PI_LENS_HOME;
+		delete process.env.PILENS_DATA_DIR;
+		const young = mintScratchHomeDir(); // fresh mtime, no owner.pid written
+
+		const { dir, restore } = withScratchHome({ tmpPrefix: SWEEP_TEST_PREFIX });
 		try {
-			withScratchHome({ tmpPrefix: prefix });
-			expect(fs.existsSync(leftover)).toBe(true); // untouched — no-op path never sweeps
+			expect(fs.existsSync(young)).toBe(true); // too young to call orphaned
 		} finally {
-			fs.rmSync(leftover, { recursive: true, force: true });
+			restore();
+			fs.rmSync(dir as string, { recursive: true, force: true });
+			fs.rmSync(young, { recursive: true, force: true });
+		}
+	});
+
+	it("(d) removes a dir with no owner.pid once it is old (the crashed-before-writing-its-pid fallback)", () => {
+		delete process.env.PI_LENS_HOME;
+		delete process.env.PILENS_DATA_DIR;
+		const old = mintScratchHomeDir();
+		const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		fs.utimesSync(old, twoHoursAgo, twoHoursAgo);
+
+		const { dir, restore } = withScratchHome({ tmpPrefix: SWEEP_TEST_PREFIX });
+		try {
+			expect(fs.existsSync(old)).toBe(false); // orphaned — swept
+		} finally {
+			restore();
+			fs.rmSync(dir as string, { recursive: true, force: true });
 		}
 	});
 

--- a/tests/scripts/lsp-fixture-workspace.test.ts
+++ b/tests/scripts/lsp-fixture-workspace.test.ts
@@ -1,0 +1,294 @@
+/**
+ * #2670 (folds #2658). `bootstrapFixtureWorkspace`/`withScratchHome`
+ * (scripts/lib/lsp-fixture-workspace.mjs) are the shared "copy fixture →
+ * register session root → optional disable+reload → optional git init →
+ * assert registered" bootstrap for all five LSP dev-harness scripts, plus
+ * the PI_LENS_HOME/PILENS_DATA_DIR scratch-home pin (#2506 shape).
+ *
+ * In-process against the REAL `dist/clients/lsp/config.js` and
+ * `dist/clients/lsp/session-roots.js` — not a mock of either — so a real
+ * signature drift in the helper's own dependencies is what this file would
+ * catch. One in-process pass here covers all five call sites' shared
+ * plumbing; `tests/scripts/smoke-tools-lsp-fixture-registration.test.ts`
+ * keeps the one real-spawn smoke case that needs an actual CLI process
+ * (fixture-ORDER is a whole-process property no in-process call can
+ * reproduce).
+ *
+ * `repoRoot` passed to the helper in these tests is a throwaway temp dir
+ * standing in for the real repo — the helper only ever does
+ * `fs.cpSync(path.join(repoRoot, fx.dir), workspace, ...)`, so a tiny fake
+ * fixture tree is enough and keeps this file independent of the real
+ * LSP_FIXTURES set.
+ *
+ * PI_LENS_HOME/PILENS_DATA_DIR: `tests/support/vitest-setup.ts` already pins
+ * PI_LENS_HOME to a per-worker temp dir for every test in this run (#2506).
+ * The `withScratchHome` describe block below deliberately unsets it for a
+ * few tests to exercise the "nothing pinned yet" branch, and restores it in
+ * `afterEach` — never leaving it unset for a later test in this file or
+ * worker.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+
+const tmpDirs: string[] = [];
+function freshTmpDir(prefix: string): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tmpDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
+	let bootstrapFixtureWorkspace: (
+		fx: Record<string, unknown>,
+		opts: Record<string, unknown>,
+	) => Promise<{
+		workspace: string;
+		absFile: string;
+		cleanup: () => void;
+		disabledServers: string[];
+	}>;
+	let initLSPConfig: (cwd: string) => Promise<void>;
+	let isSessionRootRegistered: (cwd: string) => boolean;
+	let resetLSPConfigStateForTests: () => void;
+	let fakeRepoRoot: string;
+
+	const fx = { lang: "test-lang", dir: "fx-dir", file: "a.txt" };
+
+	beforeEach(async () => {
+		({ bootstrapFixtureWorkspace } = await import(
+			pathToFileURL(
+				path.join(repoRoot, "scripts", "lib", "lsp-fixture-workspace.mjs"),
+			).href
+		));
+		({ initLSPConfig, resetLSPConfigStateForTests } = await import(
+			pathToFileURL(path.join(repoRoot, "dist", "clients", "lsp", "config.js"))
+				.href
+		));
+		({ isSessionRootRegistered } = await import(
+			pathToFileURL(
+				path.join(repoRoot, "dist", "clients", "lsp", "session-roots.js"),
+			).href
+		));
+		resetLSPConfigStateForTests();
+		fakeRepoRoot = freshTmpDir("lsp-fixture-workspace-repo-");
+		fs.mkdirSync(path.join(fakeRepoRoot, "fx-dir"));
+		fs.writeFileSync(path.join(fakeRepoRoot, "fx-dir", "a.txt"), "hello\n");
+	});
+
+	it("copies the fixture, registers the workspace as a session root, and returns workspace/absFile/cleanup", async () => {
+		const { workspace, absFile, cleanup } = await bootstrapFixtureWorkspace(
+			fx,
+			{ initLSPConfig, repoRoot: fakeRepoRoot, tmpPrefix: "test-" },
+		);
+		expect(fs.existsSync(absFile)).toBe(true);
+		expect(fs.readFileSync(absFile, "utf8")).toBe("hello\n");
+		expect(isSessionRootRegistered(workspace)).toBe(true);
+		cleanup();
+		expect(fs.existsSync(workspace)).toBe(false);
+	});
+
+	// The whole point of #2369/#2655/#2658: registration must not depend on
+	// anything else about the fixture. No `disableServers`, no `gitInit` — the
+	// workspace must still be a registered session root.
+	it("registers the workspace unconditionally even when nothing else about the fixture requires it", async () => {
+		const { workspace } = await bootstrapFixtureWorkspace(fx, {
+			initLSPConfig,
+			repoRoot: fakeRepoRoot,
+			tmpPrefix: "test-",
+		});
+		expect(isSessionRootRegistered(workspace)).toBe(true);
+	});
+
+	it("throws (never silently proceeds) when the caller's initLSPConfig doesn't actually register the workspace", async () => {
+		const brokenInitLSPConfig = async () => {
+			// simulates a caller wiring bug: doesn't call the real registrar
+		};
+		await expect(
+			bootstrapFixtureWorkspace(fx, {
+				initLSPConfig: brokenInitLSPConfig,
+				repoRoot: fakeRepoRoot,
+				tmpPrefix: "test-",
+			}),
+		).rejects.toThrow(/#2369\/#2655/);
+	});
+
+	it("git-inits the workspace when gitInit is true", async () => {
+		const { workspace, cleanup } = await bootstrapFixtureWorkspace(fx, {
+			initLSPConfig,
+			repoRoot: fakeRepoRoot,
+			tmpPrefix: "test-",
+			gitInit: true,
+		});
+		expect(fs.existsSync(path.join(workspace, ".git"))).toBe(true);
+		cleanup();
+	});
+
+	it("does not git-init when gitInit is omitted and the fixture doesn't request it", async () => {
+		const { workspace, cleanup } = await bootstrapFixtureWorkspace(fx, {
+			initLSPConfig,
+			repoRoot: fakeRepoRoot,
+			tmpPrefix: "test-",
+		});
+		expect(fs.existsSync(path.join(workspace, ".git"))).toBe(false);
+		cleanup();
+	});
+
+	it("falls back to fx.disableServers when no override is given, writing .pi-lens/lsp.json", async () => {
+		const { workspace, disabledServers, cleanup } =
+			await bootstrapFixtureWorkspace(
+				{ ...fx, disableServers: ["typescript"] },
+				{ initLSPConfig, repoRoot: fakeRepoRoot, tmpPrefix: "test-" },
+			);
+		expect(disabledServers).toEqual(["typescript"]);
+		const written = JSON.parse(
+			fs.readFileSync(path.join(workspace, ".pi-lens", "lsp.json"), "utf8"),
+		);
+		expect(written).toEqual({ disabledServers: ["typescript"] });
+		cleanup();
+	});
+
+	it("writes nothing under .pi-lens when there is nothing to disable", async () => {
+		const { workspace, cleanup } = await bootstrapFixtureWorkspace(fx, {
+			initLSPConfig,
+			repoRoot: fakeRepoRoot,
+			tmpPrefix: "test-",
+		});
+		expect(fs.existsSync(path.join(workspace, ".pi-lens"))).toBe(false);
+		cleanup();
+	});
+
+	// bench-lsp's (#2658) shape: the disable list depends on servers matching
+	// the file INSIDE the just-copied workspace, so it must be computed after
+	// copy+register, not passed in as a static list up front.
+	it("computes disableServers from a function called AFTER the workspace is copied and registered", async () => {
+		const seen: Array<{ workspace: string; absFile: string }> = [];
+		const { workspace, absFile, disabledServers, cleanup } =
+			await bootstrapFixtureWorkspace(fx, {
+				initLSPConfig,
+				repoRoot: fakeRepoRoot,
+				tmpPrefix: "test-",
+				disableServers: (ctx: { workspace: string; absFile: string }) => {
+					// The workspace must already exist and be registered by the time
+					// this runs — assert both, not just record the call.
+					expect(fs.existsSync(ctx.absFile)).toBe(true);
+					expect(isSessionRootRegistered(ctx.workspace)).toBe(true);
+					seen.push(ctx);
+					return ["computed-server"];
+				},
+			});
+		expect(seen).toHaveLength(1);
+		expect(seen[0].workspace).toBe(workspace);
+		expect(seen[0].absFile).toBe(absFile);
+		expect(disabledServers).toEqual(["computed-server"]);
+		cleanup();
+	});
+
+	it("uses a pre-supplied workspace instead of creating a new one (probe-clean-signal's shape)", async () => {
+		const preMade = freshTmpDir("premade-");
+		const { workspace } = await bootstrapFixtureWorkspace(fx, {
+			initLSPConfig,
+			repoRoot: fakeRepoRoot,
+			workspace: preMade,
+		});
+		expect(workspace).toBe(preMade);
+		expect(isSessionRootRegistered(preMade)).toBe(true);
+	});
+});
+
+describe("withScratchHome (#2670/#2506-shape)", () => {
+	let withScratchHome: (opts?: { realHome?: boolean; tmpPrefix?: string }) => {
+		dir: string | undefined;
+		pinned: boolean;
+		restore: () => void;
+	};
+	let savedHome: string | undefined;
+	let savedData: string | undefined;
+
+	beforeEach(async () => {
+		({ withScratchHome } = await import(
+			pathToFileURL(
+				path.join(repoRoot, "scripts", "lib", "lsp-fixture-workspace.mjs"),
+			).href
+		));
+		savedHome = process.env.PI_LENS_HOME;
+		savedData = process.env.PILENS_DATA_DIR;
+	});
+
+	afterEach(() => {
+		// Always restore — `tests/support/vitest-setup.ts` pins PI_LENS_HOME for
+		// every other test in this worker; leaving it unset would send a later
+		// test's writes to the real home (#2506 shape).
+		if (savedHome === undefined) delete process.env.PI_LENS_HOME;
+		else process.env.PI_LENS_HOME = savedHome;
+		if (savedData === undefined) delete process.env.PILENS_DATA_DIR;
+		else process.env.PILENS_DATA_DIR = savedData;
+	});
+
+	it("pins PI_LENS_HOME and PILENS_DATA_DIR to a fresh temp dir when neither is set", () => {
+		delete process.env.PI_LENS_HOME;
+		delete process.env.PILENS_DATA_DIR;
+		const { dir, pinned, restore } = withScratchHome();
+		try {
+			expect(pinned).toBe(true);
+			expect(dir).toBeTruthy();
+			expect(process.env.PI_LENS_HOME).toBe(dir);
+			expect(process.env.PILENS_DATA_DIR).toBe(dir);
+			expect(fs.existsSync(dir as string)).toBe(true);
+		} finally {
+			restore();
+			fs.rmSync(dir as string, { recursive: true, force: true });
+		}
+		expect(process.env.PI_LENS_HOME).toBeUndefined();
+		expect(process.env.PILENS_DATA_DIR).toBeUndefined();
+	});
+
+	it("respects an already-pinned PI_LENS_HOME instead of clobbering the caller's explicit choice", () => {
+		process.env.PI_LENS_HOME = "/some/explicit/home";
+		delete process.env.PILENS_DATA_DIR;
+		const { dir, pinned } = withScratchHome();
+		expect(pinned).toBe(false);
+		expect(dir).toBe("/some/explicit/home");
+		expect(process.env.PI_LENS_HOME).toBe("/some/explicit/home");
+		// PILENS_DATA_DIR is untouched when PI_LENS_HOME was already pinned —
+		// this call is a pure no-op, not a partial pin.
+		expect(process.env.PILENS_DATA_DIR).toBeUndefined();
+	});
+
+	it("leaves PILENS_DATA_DIR untouched when the caller already set it explicitly", () => {
+		delete process.env.PI_LENS_HOME;
+		process.env.PILENS_DATA_DIR = "/some/explicit/data-dir";
+		const { dir, restore } = withScratchHome();
+		try {
+			expect(process.env.PI_LENS_HOME).toBe(dir);
+			expect(process.env.PILENS_DATA_DIR).toBe("/some/explicit/data-dir");
+		} finally {
+			restore();
+			fs.rmSync(dir as string, { recursive: true, force: true });
+		}
+		expect(process.env.PILENS_DATA_DIR).toBe("/some/explicit/data-dir");
+	});
+
+	it("does nothing when { realHome: true } is passed", () => {
+		delete process.env.PI_LENS_HOME;
+		delete process.env.PILENS_DATA_DIR;
+		const { dir, pinned } = withScratchHome({ realHome: true });
+		expect(pinned).toBe(false);
+		expect(dir).toBeUndefined();
+		expect(process.env.PI_LENS_HOME).toBeUndefined();
+		expect(process.env.PILENS_DATA_DIR).toBeUndefined();
+	});
+});

--- a/tests/scripts/lsp-fixture-workspace.test.ts
+++ b/tests/scripts/lsp-fixture-workspace.test.ts
@@ -278,6 +278,16 @@ describe("withScratchHome (#2670/#2506-shape)", () => {
 			expect(process.env.PI_LENS_HOME).toBe(dir);
 			expect(process.env.PILENS_DATA_DIR).toBe(dir);
 			expect(fs.existsSync(dir as string)).toBe(true);
+			// #2670 review round 3 F1: the production `owner.pid` write itself was
+			// untested — deleting it left the round-2 suite fully green, AND (per
+			// the reviewer) silently reopens R2-F1 for any run older than the 1h
+			// age gate: a directory's mtime does not advance on appends to an
+			// EXISTING file inside it, so a long-lived, still-writing home reads as
+			// "idle" to the age gate the moment it crosses that age, with nothing
+			// but this file to say otherwise.
+			expect(
+				fs.readFileSync(path.join(dir as string, "owner.pid"), "utf8"),
+			).toBe(String(process.pid));
 		} finally {
 			restore();
 			fs.rmSync(dir as string, { recursive: true, force: true });
@@ -375,24 +385,45 @@ describe("withScratchHome (#2670/#2506-shape)", () => {
 	// test reproduces the hazard directly: a scratch home whose `owner.pid`
 	// names a process that is DEFINITELY still alive (this very test process)
 	// must survive the sweep unconditionally, never merely "usually".
-	it("(a) never removes a scratch home whose owner.pid names a live process", () => {
+	//
+	// Review round 3 F1: `live` is minted end-to-end by the REAL helper (its
+	// own real `withScratchHome()` call), not a hand-written `owner.pid` —
+	// the production write is what's under test here, not a stand-in for it.
+	// This also re-arms round 2's "M13" (the sweep-must-run-before-its-own-
+	// mkdtemp guard the age gate alone had quietly retired: a dir hand-built
+	// outside any call can't distinguish that ordering, since it already
+	// fully exists — with a valid pid — before the call under test even
+	// starts). The SECOND call below is the one actually exercised: its own
+	// sweep pass must both spare `live` (a genuinely separate, still-alive
+	// prior mint) AND land its own fresh `dir` on disk afterward — explicitly
+	// asserted, not merely assumed because cleanup didn't throw.
+	it("(a) never removes a scratch home whose owner.pid names a live process (helper-minted, end-to-end)", () => {
 		delete process.env.PI_LENS_HOME;
 		delete process.env.PILENS_DATA_DIR;
-		const live = mintScratchHomeDir();
-		writeOwnerPid(live, process.pid); // this test process — guaranteed alive
+		const first = withScratchHome({ tmpPrefix: SWEEP_TEST_PREFIX });
+		const live = first.dir as string;
 		// A populated tool tree, per the reviewer's probe (bin/taplo, tools/,
 		// instances.json) — not load-bearing for the assertion, but makes this
 		// test's failure mode legible as "a live scratch home's tools vanished".
 		fs.mkdirSync(path.join(live, "bin"), { recursive: true });
 		fs.writeFileSync(path.join(live, "bin", "taplo"), "pretend binary");
 
-		const { dir, restore } = withScratchHome({ tmpPrefix: SWEEP_TEST_PREFIX });
+		// Clear the pin `first` just set so this SECOND call's sweep actually
+		// runs (rather than early-returning on "already pinned") — simulating a
+		// second, concurrent run on the same machine while `live` (this very
+		// process) is still alive and using it.
+		delete process.env.PI_LENS_HOME;
+		delete process.env.PILENS_DATA_DIR;
+		const second = withScratchHome({ tmpPrefix: SWEEP_TEST_PREFIX });
 		try {
 			expect(fs.existsSync(live)).toBe(true); // survived — the whole point of (a)
 			expect(fs.existsSync(path.join(live, "bin", "taplo"))).toBe(true);
+			// The SECOND call's own fresh mint must survive its OWN sweep pass.
+			expect(fs.existsSync(second.dir as string)).toBe(true);
+			expect(second.dir).not.toBe(live);
 		} finally {
-			restore();
-			fs.rmSync(dir as string, { recursive: true, force: true });
+			second.restore();
+			fs.rmSync(second.dir as string, { recursive: true, force: true });
 			fs.rmSync(live, { recursive: true, force: true });
 		}
 	});

--- a/tests/scripts/lsp-fixture-workspace.test.ts
+++ b/tests/scripts/lsp-fixture-workspace.test.ts
@@ -31,12 +31,17 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
 	"../..",
 );
+
+// #2670 review F5: was the generic "test-" (collides in spirit with every
+// OTHER file's ad-hoc temp prefix, and gave no hint which suite left a dir
+// behind). Distinctive enough to grep a leaked `/tmp` entry back to this file.
+const WORKSPACE_TEST_PREFIX = "lsp-fixture-workspace-test-";
 
 const tmpDirs: string[] = [];
 function freshTmpDir(prefix: string): string {
@@ -92,8 +97,17 @@ describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
 	it("copies the fixture, registers the workspace as a session root, and returns workspace/absFile/cleanup", async () => {
 		const { workspace, absFile, cleanup } = await bootstrapFixtureWorkspace(
 			fx,
-			{ initLSPConfig, repoRoot: fakeRepoRoot, tmpPrefix: "test-" },
+			{
+				initLSPConfig,
+				repoRoot: fakeRepoRoot,
+				tmpPrefix: WORKSPACE_TEST_PREFIX,
+			},
 		);
+		// Tracked BEFORE any assertion, so an assertion failure below still
+		// leaves this workspace swept by afterEach (#2670 review F5) — this
+		// test in particular then exercises `cleanup()` itself, so the sweep
+		// below is a harmless no-op (`force: true`) on an already-removed dir.
+		tmpDirs.push(workspace);
 		expect(fs.existsSync(absFile)).toBe(true);
 		expect(fs.readFileSync(absFile, "utf8")).toBe("hello\n");
 		expect(isSessionRootRegistered(workspace)).toBe(true);
@@ -108,8 +122,9 @@ describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
 		const { workspace } = await bootstrapFixtureWorkspace(fx, {
 			initLSPConfig,
 			repoRoot: fakeRepoRoot,
-			tmpPrefix: "test-",
+			tmpPrefix: WORKSPACE_TEST_PREFIX,
 		});
+		tmpDirs.push(workspace); // #2670 review F5 — this test never called cleanup()
 		expect(isSessionRootRegistered(workspace)).toBe(true);
 	});
 
@@ -117,11 +132,17 @@ describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
 		const brokenInitLSPConfig = async () => {
 			// simulates a caller wiring bug: doesn't call the real registrar
 		};
+		// A pre-made, TRACKED workspace (#2670 review F5) rather than letting
+		// the helper mint its own via `tmpPrefix`: the promise below REJECTS,
+		// so there is no `{ workspace }` to destructure and track afterward —
+		// the only way to guarantee this dir is swept is to already own its
+		// path before the call.
+		const workspace = freshTmpDir(WORKSPACE_TEST_PREFIX);
 		await expect(
 			bootstrapFixtureWorkspace(fx, {
 				initLSPConfig: brokenInitLSPConfig,
 				repoRoot: fakeRepoRoot,
-				tmpPrefix: "test-",
+				workspace,
 			}),
 		).rejects.toThrow(/#2369\/#2655/);
 	});
@@ -130,9 +151,10 @@ describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
 		const { workspace, cleanup } = await bootstrapFixtureWorkspace(fx, {
 			initLSPConfig,
 			repoRoot: fakeRepoRoot,
-			tmpPrefix: "test-",
+			tmpPrefix: WORKSPACE_TEST_PREFIX,
 			gitInit: true,
 		});
+		tmpDirs.push(workspace);
 		expect(fs.existsSync(path.join(workspace, ".git"))).toBe(true);
 		cleanup();
 	});
@@ -141,8 +163,9 @@ describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
 		const { workspace, cleanup } = await bootstrapFixtureWorkspace(fx, {
 			initLSPConfig,
 			repoRoot: fakeRepoRoot,
-			tmpPrefix: "test-",
+			tmpPrefix: WORKSPACE_TEST_PREFIX,
 		});
+		tmpDirs.push(workspace);
 		expect(fs.existsSync(path.join(workspace, ".git"))).toBe(false);
 		cleanup();
 	});
@@ -151,8 +174,13 @@ describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
 		const { workspace, disabledServers, cleanup } =
 			await bootstrapFixtureWorkspace(
 				{ ...fx, disableServers: ["typescript"] },
-				{ initLSPConfig, repoRoot: fakeRepoRoot, tmpPrefix: "test-" },
+				{
+					initLSPConfig,
+					repoRoot: fakeRepoRoot,
+					tmpPrefix: WORKSPACE_TEST_PREFIX,
+				},
 			);
+		tmpDirs.push(workspace);
 		expect(disabledServers).toEqual(["typescript"]);
 		const written = JSON.parse(
 			fs.readFileSync(path.join(workspace, ".pi-lens", "lsp.json"), "utf8"),
@@ -165,8 +193,9 @@ describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
 		const { workspace, cleanup } = await bootstrapFixtureWorkspace(fx, {
 			initLSPConfig,
 			repoRoot: fakeRepoRoot,
-			tmpPrefix: "test-",
+			tmpPrefix: WORKSPACE_TEST_PREFIX,
 		});
+		tmpDirs.push(workspace);
 		expect(fs.existsSync(path.join(workspace, ".pi-lens"))).toBe(false);
 		cleanup();
 	});
@@ -180,7 +209,7 @@ describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
 			await bootstrapFixtureWorkspace(fx, {
 				initLSPConfig,
 				repoRoot: fakeRepoRoot,
-				tmpPrefix: "test-",
+				tmpPrefix: WORKSPACE_TEST_PREFIX,
 				disableServers: (ctx: { workspace: string; absFile: string }) => {
 					// The workspace must already exist and be registered by the time
 					// this runs — assert both, not just record the call.
@@ -190,6 +219,7 @@ describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
 					return ["computed-server"];
 				},
 			});
+		tmpDirs.push(workspace);
 		expect(seen).toHaveLength(1);
 		expect(seen[0].workspace).toBe(workspace);
 		expect(seen[0].absFile).toBe(absFile);
@@ -198,7 +228,7 @@ describe("bootstrapFixtureWorkspace (#2670/#2658)", () => {
 	});
 
 	it("uses a pre-supplied workspace instead of creating a new one (probe-clean-signal's shape)", async () => {
-		const preMade = freshTmpDir("premade-");
+		const preMade = freshTmpDir(WORKSPACE_TEST_PREFIX);
 		const { workspace } = await bootstrapFixtureWorkspace(fx, {
 			initLSPConfig,
 			repoRoot: fakeRepoRoot,
@@ -290,5 +320,82 @@ describe("withScratchHome (#2670/#2506-shape)", () => {
 		expect(dir).toBeUndefined();
 		expect(process.env.PI_LENS_HOME).toBeUndefined();
 		expect(process.env.PILENS_DATA_DIR).toBeUndefined();
+	});
+
+	// #2670 review F2: nothing else ever removes a scratch home (`restore()`
+	// only unsets the env vars, and a SIGKILL'd run skips any exit handler),
+	// so without a startup sweep every `--install` run leaks a full tool tree.
+	it("sweeps a leftover scratch-home dir from a prior run before minting a new one", () => {
+		delete process.env.PI_LENS_HOME;
+		delete process.env.PILENS_DATA_DIR;
+		const prefix = `lsp-fixture-home-sweep-test-${process.pid}-`;
+		const leftover = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+		fs.writeFileSync(path.join(leftover, "stale-tool-tree-marker"), "x");
+		expect(fs.existsSync(leftover)).toBe(true);
+
+		const { dir, restore } = withScratchHome({ tmpPrefix: prefix });
+		try {
+			expect(fs.existsSync(leftover)).toBe(false); // swept
+			expect(dir).not.toBe(leftover); // this run's OWN dir, minted fresh after the sweep
+			expect(fs.existsSync(dir as string)).toBe(true);
+		} finally {
+			restore();
+			fs.rmSync(dir as string, { recursive: true, force: true });
+		}
+	});
+
+	it("does not sweep when a home is already pinned (a no-op call touches nothing under os.tmpdir())", () => {
+		process.env.PI_LENS_HOME = "/some/explicit/home";
+		const prefix = `lsp-fixture-home-no-sweep-test-${process.pid}-`;
+		const leftover = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+		try {
+			withScratchHome({ tmpPrefix: prefix });
+			expect(fs.existsSync(leftover)).toBe(true); // untouched — no-op path never sweeps
+		} finally {
+			fs.rmSync(leftover, { recursive: true, force: true });
+		}
+	});
+
+	// #2670 review F3: the pin runs before `getGlobalPiLensLogDir()`'s own
+	// `global-dir-probe-redirect` degradation row could ever fire (PI_LENS_HOME
+	// wins ahead of it and leaves no trace of its own), so without this line a
+	// human reading a run's output has no way to find where its telemetry and
+	// tool installs went.
+	it("announces the pinned dir on stderr", () => {
+		delete process.env.PI_LENS_HOME;
+		delete process.env.PILENS_DATA_DIR;
+		const errors: string[] = [];
+		const spy = vi
+			.spyOn(console, "error")
+			.mockImplementation((...args: unknown[]) => {
+				errors.push(args.map(String).join(" "));
+			});
+		const { dir, restore } = withScratchHome();
+		try {
+			expect(errors.some((line) => line.includes("PI_LENS_HOME pinned"))).toBe(
+				true,
+			);
+			expect(errors.some((line) => line.includes(dir as string))).toBe(true);
+		} finally {
+			spy.mockRestore();
+			restore();
+			fs.rmSync(dir as string, { recursive: true, force: true });
+		}
+	});
+
+	it("does not announce anything when a home is already pinned (a true no-op)", () => {
+		process.env.PI_LENS_HOME = "/some/explicit/home";
+		const errors: string[] = [];
+		const spy = vi
+			.spyOn(console, "error")
+			.mockImplementation((...args: unknown[]) => {
+				errors.push(args.map(String).join(" "));
+			});
+		try {
+			withScratchHome();
+			expect(errors).toHaveLength(0);
+		} finally {
+			spy.mockRestore();
+		}
 	});
 });

--- a/tests/scripts/smoke-tools-genuine-install-failure.test.ts
+++ b/tests/scripts/smoke-tools-genuine-install-failure.test.ts
@@ -292,9 +292,23 @@ describe.skipIf(process.platform === "win32")(
 	},
 );
 
-describe("resolveUnavailabilityRow (#2661 F3)", () => {
+// `restDeps` is everything `classifyInstallOutcome` needs EXCEPT
+// `getInstallAttempt` — #2670 moved that out into its own positional
+// `attemptSnapshots` Map parameter (see resolveUnavailabilityRow's own doc
+// comment for why), so a caller here has no `getInstallAttempt` key to set
+// at all under normal use.
+function restDeps(overrides: Record<string, unknown> = {}) {
+	return {
+		toolsById,
+		toolchainPresence: {},
+		pipCandidates: ["pip3", "pip", "python3", "python"],
+		...overrides,
+	};
+}
+
+describe("resolveUnavailabilityRow (#2661 F3 / #2670)", () => {
 	it("returns the first genuine failure among several tool ids", () => {
-		const attempts = new Map<string, SmokeInstallAttempt>([
+		const attemptSnapshots = new Map<string, SmokeInstallAttempt>([
 			["rust-analyzer", { outcome: "declined" }],
 			[
 				"vscode-css-languageserver",
@@ -304,7 +318,8 @@ describe("resolveUnavailabilityRow (#2661 F3)", () => {
 		const result = resolveUnavailabilityRow(
 			["rust-analyzer", "vscode-css-languageserver"],
 			new Set(["rust-analyzer", "vscode-css-languageserver"]),
-			deps((id: string) => attempts.get(id)),
+			attemptSnapshots,
+			restDeps(),
 			"fallback skip detail",
 		);
 		expect(result.row).toBe("fail");
@@ -312,26 +327,74 @@ describe("resolveUnavailabilityRow (#2661 F3)", () => {
 	});
 
 	it("falls back to the given skip detail when nothing is genuine", () => {
-		const attempts = new Map<string, SmokeInstallAttempt>([
+		const attemptSnapshots = new Map<string, SmokeInstallAttempt>([
 			["rust-analyzer", { outcome: "declined" }],
 		]);
 		const result = resolveUnavailabilityRow(
 			["rust-analyzer"],
 			new Set(["rust-analyzer"]),
-			deps((id: string) => attempts.get(id)),
+			attemptSnapshots,
+			restDeps(),
 			"fallback skip detail",
 		);
 		expect(result).toEqual({ row: "skip", detail: "fallback skip detail" });
 	});
 
 	it("skips tool ids that were never unavailable", () => {
+		const attemptSnapshots = new Map<string, SmokeInstallAttempt>([
+			[
+				"vscode-css-languageserver",
+				{ outcome: "failed", reason: "should not be reached" },
+			],
+		]);
 		const result = resolveUnavailabilityRow(
 			["vscode-css-languageserver"],
 			new Set(),
-			deps(() => ({ outcome: "failed", reason: "should not be reached" })),
+			attemptSnapshots,
+			restDeps(),
 			"fallback skip detail",
 		);
 		expect(result).toEqual({ row: "skip", detail: "fallback skip detail" });
+	});
+
+	/**
+	 * #2670 (the #2661 r3 verify's residual): the production call site used to
+	 * assemble a `deps` object at each of `runLspHandshake`'s three
+	 * unavailability sites, with `getInstallAttempt: (id) =>
+	 * attemptSnapshots.get(id)` set INLINE — nothing about that shape stopped
+	 * a future edit from swapping that closure for the live module-global
+	 * `getInstallAttempt` instead (mutation E, #2661 r3), and no test caught
+	 * it because none exercised the assembled object's own precedence.
+	 *
+	 * Reproduces the exact hazard directly against the NEW signature: pass a
+	 * `restDeps` that itself carries a (hostile/mistaken) live
+	 * `getInstallAttempt`, alongside the real snapshot `Map` as its own
+	 * parameter — and assert the snapshot always wins. This is mutation E's
+	 * shape moved onto the new call surface: reverting `resolveUnavailabilityRow`
+	 * to spread `restDeps` AFTER its own derived `getInstallAttempt` (instead
+	 * of before) reintroduces exactly this bug and reds this test.
+	 */
+	it("always classifies from the snapshot Map, never a getInstallAttempt smuggled into restDeps", () => {
+		const attemptSnapshots = new Map<string, SmokeInstallAttempt>([
+			[
+				"vscode-css-languageserver",
+				{ outcome: "failed", reason: "npm ERR! code ENOVERSIONS" },
+			],
+		]);
+		const liveGetInstallAttempt = (): SmokeInstallAttempt => ({
+			outcome: "declined",
+			reason:
+				"should never be read — this is the live global, not the snapshot",
+		});
+		const result = resolveUnavailabilityRow(
+			["vscode-css-languageserver"],
+			new Set(["vscode-css-languageserver"]),
+			attemptSnapshots,
+			restDeps({ getInstallAttempt: liveGetInstallAttempt }),
+			"fallback skip detail",
+		);
+		expect(result.row).toBe("fail");
+		expect(result.detail).toContain("ENOVERSIONS");
 	});
 });
 

--- a/tests/scripts/smoke-tools-lsp-fixture-registration.test.ts
+++ b/tests/scripts/smoke-tools-lsp-fixture-registration.test.ts
@@ -15,8 +15,11 @@
  * `isOutsideAllSessionRoots` — silently, with zero diagnostics, indistinguishable
  * from the tool genuinely finding nothing. The exact same shape independently
  * affected `characterize-lsp.mjs`, `probe-clean-signal.mjs`, and
- * `server-capabilities.mjs` (#2655) — all four scripts' guards now share ONE
- * implementation, `scripts/lib/lsp-fixture-session-guard.mjs`.
+ * `server-capabilities.mjs` (#2655), and `bench-lsp.mjs` (#2658) shared the
+ * identical shape — all five scripts now route through one bootstrap,
+ * `scripts/lib/lsp-fixture-workspace.mjs`'s `bootstrapFixtureWorkspace`
+ * (#2670), which itself calls this guard, `scripts/lib/
+ * lsp-fixture-session-guard.mjs`'s `assertFixtureWorkspaceRegistered`.
  *
  * This file has two layers:
  *
@@ -134,7 +137,7 @@ describe("smoke-tools --lsp: every fixture registers its own session root (#2369
 	});
 });
 
-describe("assertFixtureWorkspaceRegistered: the guard shared by all four LSP harness scripts (#2369/#2655)", () => {
+describe("assertFixtureWorkspaceRegistered: the guard shared by all five LSP harness scripts via bootstrapFixtureWorkspace (#2369/#2655/#2658/#2670)", () => {
 	const guardEntry = path.join(
 		repoRoot,
 		"scripts",
@@ -162,7 +165,7 @@ describe("assertFixtureWorkspaceRegistered: the guard shared by all four LSP har
 		// production module the guard reads from — not a mock standing in for
 		// it. Fresh dynamic import each run (module cache is process-lifetime,
 		// but the registry itself is reset below) matches how every one of the
-		// four calling scripts loads it.
+		// five calling scripts loads it (via bootstrapFixtureWorkspace, #2670).
 		({ assertFixtureWorkspaceRegistered } = await import(
 			pathToFileURL(guardEntry).href
 		));


### PR DESCRIPTION
## Summary

Named output from the #2656 review (#2670), folding #2658 into the same PR.

**One helper for all five LSP dev-harness scripts.** `scripts/lib/lsp-fixture-workspace.mjs`'s `bootstrapFixtureWorkspace(fx, opts)` replaces the hand-copied "copy fixture → `initLSPConfig` (unconditional) → optional git init → optional `.pi-lens/lsp.json` disable + reload → `assertFixtureWorkspaceRegistered`" preamble in `characterize-lsp.mjs`, `server-capabilities.mjs`, `probe-clean-signal.mjs`, `smoke-tools.mjs`, and `bench-lsp.mjs` (#2658's fold). `disableServers` accepts an array (the default four scripts, falling back to `fx.disableServers` when omitted) or a function `({workspace, absFile, fx}) => string[]` invoked AFTER the workspace is copied and registered — bench-lsp's shape, which computes its disable list from `getServersForFileWithConfig(absFile)` and needs a real file path to do it. `probe-clean-signal.mjs` passes a pre-made `workspace` (its own `withTimeout`/`finally` already owns that dir's lifecycle).

Net line count: the five call sites' combined preamble/cleanup code (`git diff --stat` on the five scripts: +199/−215, i.e. **16 fewer lines** across them) collapses into 168 lines in one new file (95 of which are doc comments explaining the five callers' differing needs — `disableServers` array-vs-function, pre-made-vs-fresh workspace, why `initLSPConfig` is caller-supplied). The 23-line byte-identical block in `characterize-lsp.mjs`/`server-capabilities.mjs` is gone; each of the five call sites is now 3–20 lines.

**Home pinning (#2506 shape).** `withScratchHome()` (same module) pins `PI_LENS_HOME`/`PILENS_DATA_DIR` to a fresh `os.tmpdir()` scratch dir before each script's first `dist/` import — `dist/clients/latency-logger.js` reads its log directory into a top-level `const` at module load, not lazily per write, so the pin has to land before that import, not merely before the first fixture. It's a no-op when the caller (a test spawning the script, or an operator) already set `PI_LENS_HOME` explicitly — `getGlobalPiLensLogDir()`'s own "PI_LENS_HOME wins over any redirect" contract, not a second one.

Trade-off, stated for the reviewer to weigh: `PI_LENS_HOME` governs the installer's `tools`/`bin` dirs too, not just logs (there's no separate log-only override in this codebase). A fresh-per-invocation scratch dir means the nightly's five/six `--install` steps no longer share one tool cache across the job the way they implicitly do today (same ephemeral runner `$HOME`) — each step reinstalls its own tools. Considered and rejected: a stable, `repoRoot`-hash-derived scratch dir would preserve that cache, but risks two concurrent agents/CI runs on the same box racing on one `instances.json`/tool tree if the hash ever collided across worktrees, and is machinery beyond what #2670 asked for. Went with the literal ask (a genuinely fresh per-run dir) since the runner itself is thrown away nightly anyway; flagging in case the tool-reinstall cost matters more than it looks from here.

**`resolveUnavailabilityRow` (#2661 r3 residual).** `runLspHandshake` used to build a `fixtureClassifyDeps` object at each of its three unavailability call sites with `getInstallAttempt: (id) => attemptSnapshots.get(id)` set inline — nothing about that shape stopped a future edit from swapping that closure for the live module-global `getInstallAttempt` (mutation E from #2661 r3, which stayed green because no test exercised the call site's own wiring). `resolveUnavailabilityRow` now takes the attempt-snapshot `Map` as its own positional parameter and derives `getInstallAttempt` from it internally, always overriding anything a caller's `restDeps` might carry under that key — there is no longer a `deps` object at the call site with a `getInstallAttempt` key to reassemble either way.

**Docblock drift.** `lsp-fixture-session-guard.mjs`'s comment said the guard "throws loudly" — true end-to-end only for `smoke-tools.mjs --lsp` (the only one of the five NOT `continue-on-error` in `tool-smoke.yml`). The other three CI-wired scripts are `continue-on-error: true`, and `probe-clean-signal.mjs` additionally catches the throw per-fixture in its own `withTimeout`/`try`. `bench-lsp.mjs` isn't CI-wired at all. Corrected to state this precisely.

**#2658's premise, checked live and found not to reproduce.** The issue theorized bench-lsp shares #2369/#2655's cross-fixture poisoning (an earlier fixture's registration flips the session-root registry from fail-open to non-empty, silently declining a later, still-unregistered fixture). Verified live (not by inspection) that this does **not** actually happen in bench-lsp, because — unlike its four siblings, which iterate every fixture in ONE process with no reset between them — bench-lsp calls `resetLSPConfigStateForTests()` (which clears the session-root registry too, since #2518) at the top of **every** iteration, before that iteration's own registration would run. An empty registry fails open (declines nothing), so a fixture that pre-fix never registered was never actually declined either — its `supportsLSP` gate passed regardless of order. Evidence:

```
$ node <probe computing bench-lsp's own disableServers logic over all 49 LSP_FIXTURES>
...
Total fixtures: 49, fixtures with EMPTY disableServers (pre-fix bug window): 12

$ node scripts/bench-lsp.mjs toml            # pre-fix, PI_LENS_HOME=canary
    toml         unavailable  (taplo)
$ node scripts/bench-lsp.mjs expert toml     # pre-fix, expert registers first
    toml         unavailable  (taplo)
    expert       unavailable  (Expert (alternate of ElixirLS))
```

Both orders report the identical `unavailable` status for `toml` (never `no-lsp`, the pre-#2369 defect's actual signature) — order-independent, pre-fix, exactly as post-fix. `bench-lsp.mjs` is still folded into the shared helper (that's #2670's actual ask — one consolidated bootstrap for all five scripts — and it's harmless: one extra, immediately-reset registry entry per iteration), and the acceptance criterion ("registers every fixture's own workspace unconditionally, verified live") is now literally true of the code. But the live verification's honest finding is that the theorized defect window never opened, because bench-lsp's own per-iteration reset already gave it equivalent isolation through a different mechanism. Using `closes #2658` on that basis — the requested code shape is in place and verified live, including verifying the negative.

Closes #2670. Closes #2658.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [x] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (see Tests below)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds — N/A, no `clients/`/`commands/`/`tools/`/`index.ts` changed (scripts-only PR); ran it anyway to keep `dist/` fresh for the tests, and it succeeds
- [x] `package-lock.json` is in sync with `package.json` — unchanged, no dependency edits
- [ ] `AGENTS.md` is updated — N/A, no new convention introduced; this consolidates existing hand-copied logic behind one helper
- [x] `.changelog/2670-lsp-fixture-workspace-bootstrap.md` added (section: Changed)
- [x] Commit subject includes the issue number

## Tests

**New:**

- `tests/scripts/lsp-fixture-workspace.test.ts` (13 tests) — in-process against the REAL `dist/clients/lsp/config.js`/`dist/clients/lsp/session-roots.js` (not mocked), covering `bootstrapFixtureWorkspace` (copy+register+return; unconditional registration with nothing else set; throws when the caller's `initLSPConfig` doesn't actually register — the guard wiring; `gitInit` true/omitted; `disableServers` static-array vs. omitted (falls back to `fx.disableServers`) vs. function (computed after copy+register, bench-lsp's shape, asserting the workspace exists/is registered by the time the callback runs); pre-supplied `workspace`) and `withScratchHome` (pins when unset; respects an already-pinned `PI_LENS_HOME`; leaves an already-set `PILENS_DATA_DIR` alone; `{realHome:true}` no-op). Satisfies AGENTS.md's "parallel path" screen by testing the actual production module, not a stand-in.
- `tests/scripts/smoke-tools-genuine-install-failure.test.ts`: extended `resolveUnavailabilityRow`'s describe block with one new case — "always classifies from the snapshot Map, never a getInstallAttempt smuggled into restDeps" — pinning the #2661 r3 residual (mutation E) against the new signature.

**Edited:** the same file's three existing `resolveUnavailabilityRow` tests updated to the new 5-arg signature (`attemptSnapshots` Map as its own parameter, `restDeps` without `getInstallAttempt`) — no behavioral change to what they pin.

**Red-first:**

```
$ npx vitest run tests/scripts/smoke-tools-genuine-install-failure.test.ts
 (with resolveUnavailabilityRow's internal spread order reverted to
  { getInstallAttempt: (id) => attemptSnapshots.get(id), ...restDeps } —
  i.e. restDeps allowed to win, exactly mutation E's shape)

 ❯ resolveUnavailabilityRow (#2661 F3 / #2670) > always classifies from the
   snapshot Map, never a getInstallAttempt smuggled into restDeps
   AssertionError: expected 'skip' to be 'fail'
 Tests  1 failed | 25 passed (26)
```

```
$ npx vitest run tests/scripts/lsp-fixture-workspace.test.ts
 (with the assertFixtureWorkspaceRegistered call deleted from
  bootstrapFixtureWorkspace)

 ❯ bootstrapFixtureWorkspace (#2670/#2658) > throws (never silently proceeds)
   when the caller's initLSPConfig doesn't actually register the workspace
   AssertionError: promise resolved "{ workspace: ... }" instead of rejecting
 Tests  1 failed | 12 passed (13)
```

Both restored to green after re-verifying (`26/26` and `13/13` respectively). Two further guard mutations proven red the same way (quoted in the session, not reproduced here for length): `if (gitInit)` → `if (false && gitInit)` reds "git-inits the workspace when gitInit is true"; the `disableServers` function-vs-static dispatch forced to always take the static branch reds "computes disableServers from a function…"; `withScratchHome`'s "already pinned" branch forced to `if (false)` reds "respects an already-pinned PI_LENS_HOME…"; its `realHome` branch forced to `if (false && realHome)` reds "does nothing when `{realHome:true}`…"; and the disable-write's `if (resolvedDisable && resolvedDisable.length)` mutated BOTH ways (`if (true)` reds "writes nothing under .pi-lens…", `if (false)` reds "falls back to fx.disableServers…").

### Test assessment

`tests/scripts/smoke-tools-lsp-fixture-registration.test.ts` — unique pin: the real-spawn, whole-process fixture-ORDER defect (`smoke-tools --lsp expert ast-grep`), which an in-process call structurally cannot reproduce (flake-shape header already says so). No test in it is made redundant by this PR; only its docblock/describe text was corrected from "four scripts" to "five, via `bootstrapFixtureWorkspace`" (#2670) to match the new consolidation — no assertions changed. `tests/scripts/smoke-tools-genuine-install-failure.test.ts` — unique pin: `classifyInstallOutcome`'s outcome × toolchain table and the pip-candidate shim tests; nothing removed, three tests updated in place to the new signature plus one new mutation-pin.

## Blast radius

Five dev-harness scripts, all outside the runtime module graph (`clients/`, `commands/`, `tools/`, `index.ts`, `mcp/` untouched) — `blastRadius` from `module_report` is not applicable; nothing in the shipped extension imports these. Callers/entry points: `.github/workflows/tool-smoke.yml`'s nightly steps (`smoke-tools.mjs --lsp/--install`, `characterize-lsp.mjs --install`, `probe-clean-signal.mjs --install`, `server-capabilities.mjs --install`); `bench-lsp.mjs` is manual-only (grepped, no CI reference, confirmed by #2658's own issue body). Verification plan: real local runs of all five scripts against a scratch `PI_LENS_HOME` (below), plus the existing real-spawn regression test. Hot path: N/A — none of these run in the product's per-file/per-spawn/per-render paths.

**Local runs, each of the five scripts, once, with the pin (`PI_LENS_HOME`/`PILENS_DATA_DIR` set to a throwaway dir I created — never the real one):**

```
$ node scripts/smoke-tools.mjs --lsp expert ast-grep --verbose
[ast-grep] aux=ast-grep matched=1/1 sources=["ast-grep"]
✓  ast-grep     ast-grep (auxiliary)         1     auxiliary ast-grep returned 1 diagnostic(s)
1 passed · 1 failed · 0 setup-failed · 0 skipped   (expert fails for the pre-existing, unrelated
                                                     reason its own tool binary isn't installed here)

$ node scripts/characterize-lsp.mjs ast-grep opengrep expert
[ast-grep] mode=push-only
[opengrep] mode=push-only
[expert] mode=unknown   (unrelated: Expert's own tool isn't installed here)

$ node scripts/server-capabilities.mjs ast-grep opengrep expert
[opengrep] file-servers=typescript,opengrep total=2
[ast-grep] file-servers=typescript,ast-grep total=3

$ node scripts/probe-clean-signal.mjs ast-grep opengrep expert
[opengrep] mode=push-only clean-behavior=unknown ...
[ast-grep] mode=push-only clean-behavior=unknown ...

$ node scripts/bench-lsp.mjs expert toml
    toml         unavailable  (taplo)
    expert       unavailable  (Expert (alternate of ElixirLS))
```

None declined (`mode=unknown`/`no-lsp`) for ast-grep/opengrep despite `expert` (a `disableServers` fixture) running first in every multi-fixture invocation — the exact #2369/#2655 reproduction shape from #2656's own issue body, still passing post-refactor.

## Observability

No new telemetry record — this PR redirects existing `config_resolution_pending`/`config_resolved` rows (`clients/lsp/config.ts`), never adds a new kind. Proof the redirect actually works, quoted verbatim from my own runs (canary `HOME`, never the real one — command run with `cwd` set to the main checkout, `HOME`/`PI_LENS_HOME` unset, to hit the exact "normal maintainer checkout" code path `getGlobalPiLensLogDir()`'s own `#2506` agent-worktree/tmpdir redirect does NOT catch):

```
$ wc -l "$CANARY/.pi-lens/latency.log"   # before
wc: .../canary-home/.pi-lens/latency.log: No such file or directory

$ HOME="$CANARY" node <pre-fix characterize-lsp.mjs> ast-grep opengrep
[opengrep] mode=push-only
[ast-grep] mode=push-only

$ wc -l "$CANARY/.pi-lens/latency.log"   # after pre-fix run — GROWS
49 .../canary-home/.pi-lens/latency.log

$ HOME="$CANARY" node <post-fix characterize-lsp.mjs> ast-grep opengrep   # same canary, no PI_LENS_HOME set
[opengrep] mode=push-only
[ast-grep] mode=push-only

$ wc -l "$CANARY/.pi-lens/latency.log"   # after post-fix run — UNCHANGED
49 .../canary-home/.pi-lens/latency.log

$ cat /tmp/lsp-fixture-home-*/latency.log | wc -l   # redirected here instead
49
```

## Class sweep

Shape: a hand-copied "copy fixture → register session root → optional disable → optional git init → assert registered" preamble, duplicated across every LSP dev-harness script (AGENTS.md single-source-of-truth smell). Swept the WHOLE tree, not just `scripts/`:

- `grep -rl "initLSPConfig" --include="*.mjs" --include="*.ts" scripts/ tools/ mcp/ tests/support/` → the five harness scripts (now on the shared helper) plus `mcp/server.ts` and `tests/support/session-state-registry.ts` — both real session-lifecycle callers (`ensureLSPConfigInitialized`/registering a live session's own cwd), not fixture-bootstrap duplicates; left alone.
- `grep -rl "disabledServers"` across the repo (excluding `tests/`, `node_modules`, `dist`) → `clients/config-core/*`, `clients/lsp/config.ts`, `clients/lsp/session-roots.ts`, `clients/degradation-ledger.ts`, etc. are the PRODUCT's config concept, not harness duplication; only `scripts/bench-lsp.mjs` (now via the callback) and the new `scripts/lib/lsp-fixture-workspace.mjs` touch the fixture-harness shape.
- `grep -rl "assertFixtureWorkspaceRegistered"` → now exactly three files: the guard's own implementation, the new helper (its one caller), and the real-spawn test. No hand-copied guard call remains anywhere.

Consolidation verdict: folded onto one seam, `scripts/lib/lsp-fixture-workspace.mjs`, covering all five family members (population of 5, all consolidated — no member left distributed).


## Review round 1

Reviewer verified: every guard mutation-proof, ESM ordering clean in all five scripts, real home untouched, #2658 non-repro finding code-verified. Five findings, all addressed on this branch (head `f52cc83e`):

- **F1 (high) — job-level `--install` cache sharing.** `tool-smoke.yml` runs SIX `--install` steps in one job with no job-level pin; post-PR each `withScratchHome()` call would mint its own empty scratch home, losing the cache the job's shared ephemeral `$HOME` gave them for free pre-PR (measured against run 32817692457: ~+10min/job, 4–5× the release-asset downloads). Fixed: job-level `env: PI_LENS_HOME` / `PILENS_DATA_DIR` on both `tool-smoke.yml` and `parser-smoke.yml` (symmetry). Used a bare `/tmp/pi-lens-home` path, not the reviewer's suggested `${{ runner.temp }}` — **actionlint caught that the `runner` context is unavailable at job-level `env:`** ("context \"runner\" is not allowed here"); `/tmp` is equally ephemeral (the whole VM is destroyed after the job) and needs no context at all. New `tests/config/lsp-fixture-home-workflow-pin.test.ts` (12 tests, `yaml.load`-based, the `install-smoke-gates.test.ts` idiom) pins both workflows' env keys, that they resolve to the same dir, that neither uses `runner.temp`, and counts the `--install` steps each cache claim is about (6 and 1). After this fix: all six `tool-smoke.yml` steps and `parser-smoke.yml`'s one step share `/tmp/pi-lens-home` for the whole job.
- **F2 (medium) — scratch-home leak.** `withScratchHome()` never removed its own dir (`restore()` only unsets env vars; a SIGKILL'd run skips exit handlers) and `sweepLeftovers()` only matches `pi-lens-smoke-`. Fixed: a startup sweep of `lsp-fixture-home-*` inside `withScratchHome()`'s pinning branch, run BEFORE minting this call's own dir (mirrors `sweepLeftovers`'s own "cleanup belongs at startup" reasoning). Verified live: `characterize-lsp.mjs` run twice back-to-back left exactly ONE `/tmp/lsp-fixture-home-*` dir (the second run's), not two.
- **F3 (medium) — unfindable redirect.** Added one `console.error` in the pinned branch naming the dir. Verified live (quoted below).
- **F4 (low) — `safeRm` duplication.** Extracted into `scripts/lib/safe-rm.mjs`; both `smoke-tools.mjs`'s three non-LSP call sites and `bootstrapFixtureWorkspace`'s `cleanup()` now import it. `smoke-tools.mjs` already imports FROM `lsp-fixture-workspace.mjs`, so the shared function had to live in a THIRD, dependency-free leaf module — putting it in either of those two would have closed a cycle.
- **F5 (low) — test-file leak.** `tests/scripts/lsp-fixture-workspace.test.ts`'s helper-created workspaces are now pushed into the existing `tmpDirs` array immediately after creation (before any assertion that could throw first, not just at the end of the test body) and swept in the existing `afterEach`; the "throws" test now uses a pre-made, tracked `workspace:` instead of letting the helper mint one via `tmpPrefix` (the promise rejects, so there is no `{workspace}` to destructure and track afterward). Prefix changed from the generic `test-` to `lsp-fixture-workspace-test-`.

**Red-first, quoted:**

```
$ npx vitest run tests/config/lsp-fixture-home-workflow-pin.test.ts
 (against pre-fix workflow files, no PI_LENS_HOME/PILENS_DATA_DIR job env)

 ❯ .github/workflows/tool-smoke.yml jobs.tool-smoke.env pins PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1) > carries a non-empty PI_LENS_HOME
   AssertionError: expected 'undefined' to be 'string'
 ❯ .github/workflows/parser-smoke.yml jobs.parser-smoke.env pins PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1) > carries a non-empty PI_LENS_HOME
   AssertionError: expected 'undefined' to be 'string'
 Tests  6 failed | 6 passed (12)
```

```
$ npx vitest run tests/scripts/lsp-fixture-workspace.test.ts
 (with sweepScratchHomeLeftovers(tmpPrefix) call deleted from withScratchHome)

 ❯ withScratchHome (#2670/#2506-shape) > sweeps a leftover scratch-home dir from a prior run before minting a new one
 Tests  1 failed | 16 passed (17)

 (with the console.error announcement deleted)

 ❯ withScratchHome (#2670/#2506-shape) > announces the pinned dir on stderr
 Tests  1 failed | 16 passed (17)
```

Both files restored to green after each proof (`12/12` and `17/17`).

**Live verification, F2/F3 together:**

```
$ node scripts/characterize-lsp.mjs ast-grep    # PI_LENS_HOME/PILENS_DATA_DIR unset
[lsp-fixture-workspace] PI_LENS_HOME pinned to /tmp/lsp-fixture-home-HzrmqV (#2506 shape) — this run's tool installs and config_resolved/sessionstart telemetry land there, not the real ~/.pi-lens.
[ast-grep] mode=push-only
$ ls -d /tmp/lsp-fixture-home-*
/tmp/lsp-fixture-home-HzrmqV

$ node scripts/characterize-lsp.mjs ast-grep    # run again, same env
[lsp-fixture-workspace] PI_LENS_HOME pinned to /tmp/lsp-fixture-home-gU2wt8 (#2506 shape) — ...
$ ls -d /tmp/lsp-fixture-home-*
/tmp/lsp-fixture-home-gU2wt8   # the FIRST run's dir was swept, not accumulated
```

**Tests run this round:** `tests/scripts/lsp-fixture-workspace.test.ts` (17), `tests/scripts/smoke-tools-cue-fixture.test.ts` + `smoke-tools-genuine-install-failure.test.ts` + `smoke-tools-lsp-fixture-registration.test.ts` (3 files), the new `tests/config/lsp-fixture-home-workflow-pin.test.ts` (12), all 30 `tests/config/*.test.ts` files (306 tests), `tests/clients/flake-shape-ratchet.test.ts`, and the full `*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*` governance batch (31 files, 516 tests) — all green. `npx <pinned actionlint v1.7.12>` on both `tool-smoke.yml` and `parser-smoke.yml` (and the whole `.github/workflows/` tree) — exit 0. `npm run lint` and `npm run build:dist` both clean. `npx oxfmt --check` clean on every touched file.

No leaked `/tmp/lsp-fixture-workspace-test-*` or `/tmp/lsp-fixture-home-*` dirs after this round's test/probe runs (checked explicitly).


## Review round 2

Verify confirmed F1/F3/F4/F5 fixed and mutation-proof, but found a NEW destructive defect in F2's own remedy (R2-F1, high) — round-count rail applies.

**R2-F1 (high) — the sweep's "still locked → skip" never actually protected anything.** Round 1's `sweepScratchHomeLeftovers()` did `try { rmSync } catch { /* still in use — leave it */ }`. On POSIX, `rmSync` on a directory another process is actively writing into **succeeds regardless** — only Windows EPERMs on an open handle — so that catch block was describing a protection that did not exist. Reproduced directly (not by inspection):

```
$ node -e "... spawn a child holding an open write handle inside a dir, then rmSync that dir from the parent while the child is still writing ..."
rmSync SUCCEEDED while child had the file open
```

A live scratch home mid-`--install` (holding `bin/taplo`, `tools/`, `instances.json` open) could be deleted out from under it by a second concurrent run's sweep; the first keeps appending to files by a now-unlinked inode — silent, permanent loss, not a caught no-op. Second direction: the test suite's own leftover-simulation prefix (`lsp-fixture-home-sweep-test-<pid>-`) **extends** the production default (`lsp-fixture-home-`), so a real script's own sweep running concurrently on the same machine would delete the test's dirs.

**Fix:** `withScratchHome()` writes `owner.pid` (its own `process.pid`) into the dir at mint. The sweep reads it back and checks `process.kill(pid, 0)`: `ESRCH` → the writer is gone → remove; anything else (success, or `EPERM` — a live process this one merely lacks permission to signal) → alive → skip, unconditionally, never by whether `rmSync` happens to throw. A dir with no `owner.pid` at all (pre-dates this fix, or its writer crashed between `mkdtemp` and writing the pid) falls back to a 1-hour age gate. Both false "still locked" comments (the sweep's catch block and its docblock) are deleted. Test suite prefix renamed to `lsp-fixture-workspace-test-home-`, which does not start with `lsp-fixture-home-` — pinned directly by its own test.

### Sweep table (built by reading the sweep, not memory)

| `lsp-fixture-home-*` state | Action | Why (reading `sweepScratchHomeLeftovers`/`scratchHomeOwnerAlive`) | Test |
|---|---|---|---|
| `owner.pid` names a **live** pid | **Skipped**, unconditionally | `scratchHomeOwnerAlive` → `process.kill(pid,0)` doesn't throw (or throws `EPERM`) → returns `true` → the loop's `if (ownerAlive === true) continue` fires before `rmSync` is ever reached | `(a) never removes a scratch home whose owner.pid names a live process` — **proven RED on the round-1 code** (quoted below) |
| `owner.pid` names a **dead** pid | **Removed** | `process.kill(pid,0)` throws `ESRCH` → `scratchHomeOwnerAlive` returns `false` → neither the `=== true` nor `=== undefined` branch fires → falls through to `fs.rmSync` | `(b) removes a scratch home whose owner.pid names a dead process` |
| **No** `owner.pid` file, dir **young** (mtime < 1h) | **Skipped** | `scratchHomeOwnerAlive` returns `undefined` (no pid file) → age check `Date.now() - mtimeMs < SCRATCH_HOME_ORPHAN_AGE_MS` is true → `continue` | `(c) skips a dir with no owner.pid that is still young` |
| **No** `owner.pid` file, dir **old** (mtime ≥ 1h) | **Removed** | `scratchHomeOwnerAlive` returns `undefined`, age check is false → falls through to `fs.rmSync` (the crashed-before-writing-its-pid fallback) | `(d) removes a dir with no owner.pid once it is old` |
| Test-suite-prefixed dir (`lsp-fixture-workspace-test-home-*`) | **Never matched** by a production sweep call | `entry.startsWith(tmpPrefix)` where a real script's `tmpPrefix` defaults to `"lsp-fixture-home-"`; `"lsp-fixture-workspace-test-home-...".startsWith("lsp-fixture-home-")` is `false` — the two prefixes diverge right after `"lsp-fixture-"` | `this file's own test prefix does not start with the production default (never cross-swept either direction)` |
| CI's job-level `PI_LENS_HOME` already pinned | Sweep **never runs at all** | `withScratchHome`'s `if (process.env.PI_LENS_HOME?.trim())` early-returns before `sweepScratchHomeLeftovers` is called — CI is unaffected by this whole finding, exactly as the reviewer noted | `does not sweep when a home is already pinned (a no-op call touches nothing under os.tmpdir())` |

**Red-first, quoted (mutation (a), the destructive defect itself, on the round-1 code):**

```
$ npx vitest run tests/scripts/lsp-fixture-workspace.test.ts   # round-1 sweepScratchHomeLeftovers restored

 ❯ withScratchHome (#2670/#2506-shape) > (a) never removes a scratch home whose owner.pid names a live process
   AssertionError: expected false to be true
 ❯ withScratchHome (#2670/#2506-shape) > (c) skips a dir with no owner.pid that is still young (a mint mid-flight, not yet orphaned)
   AssertionError: expected false to be true
 Tests  2 failed | 18 passed (20)
```

(c) reds too on round-1 code, for the same reason: round-1's blind `rmSync` had no age-awareness either, so a dir mid-`mkdtemp` (no `owner.pid` written yet) was just as exposed. Both restored to green (`20/20`, then `21/21` after the disjointness test was added) on the fixed code. Each of the four directions is independently mutation-proof (quoted in the session): forcing `scratchHomeOwnerAlive` to always return `true` reds (b); setting the age constant absurdly high reds (d); setting it to `0` reds (c).

**No real process spawn needed for the "dead pid" case:** `deadPid()` was replaced with a constant, `IMPOSSIBLE_PID = 999_999_999` — Linux's `pid_max` (default 4194304; this repo's authoritative Unit tests lane is ubuntu) caps every real pid well under that value, and `process.kill(999_999_999, 0)` throws the identical `ESRCH` a genuinely-exited pid would (verified directly). Avoids a real-process-spawn flake-shape admission entirely rather than adding one.

**Class sweep note (per orchestrator instruction — not widened this round):** `sweepLeftovers()` in `smoke-tools.mjs:1286` carries the identical false "still locked" rationale for `pi-lens-smoke-*` fixture-copy temp dirs. Pre-existing (not introduced by this PR), lower severity (a per-fixture temp copy, not a shared HOME holding installed tools/`instances.json`) — left for the orchestrator to file as a follow-up issue, per instruction.

**Tests run this round:** `tests/scripts/lsp-fixture-workspace.test.ts` (21), all three `tests/scripts/smoke-tools*.test.ts` files, the workflow-pin test, all 30 `tests/config/*.test.ts` (306 tests), `flake-shape-ratchet` — all green. `npm run lint` and `npm run build` clean. `npx oxfmt --check` clean. No leaked `/tmp/lsp-fixture-workspace-test-home-*` dirs after this round's runs (checked explicitly).


## Review round 3

Verify confirmed R2-F1 fixed in all four directions (live holder survives; cross-contamination survives; recycled pid → skip; mint window fail-safe). One prescribed remedy, test-only, merges on green without re-verify:

**R3-F1 — the production `owner.pid` write itself was untested.** Deleting `fs.writeFileSync(path.join(dir, SCRATCH_HOME_OWNER_FILE), String(process.pid))` from `withScratchHome` left 21/21 green. Silent consequence: a directory's mtime does not advance on appends to an *existing* file inside it, so a long-running `--install` (installs early, then probes 49 fixtures for an hour) crosses the 1h age gate and reads as idle — R2-F1 reopens for exactly the case it was fixed for.

**Fix:**
- Added, inside the existing `"pins PI_LENS_HOME and PILENS_DATA_DIR..."` case: asserts the freshly minted dir's `owner.pid` holds `String(process.pid)`.
- Restructured (a) to mint its "live" home end-to-end via a real `withScratchHome()` call, then a second `withScratchHome()` call (env cleared between) whose own sweep must both spare that still-alive first mint AND land its own fresh `dir` on disk afterward — now explicitly asserted rather than merely assumed because cleanup didn't throw. Re-arms the sweep-before-mkdtemp ordering guarantee ("M13") that a hand-built fixture directory can't exercise, since it already fully exists — with a valid pid — before the call under test even starts.

**Red, quoted (deleting the write):**

```
$ npx vitest run tests/scripts/lsp-fixture-workspace.test.ts
 (owner.pid write deleted from withScratchHome)

 ❯ withScratchHome (#2670/#2506-shape) > pins PI_LENS_HOME and PILENS_DATA_DIR to a fresh temp dir when neither is set
   Error: ENOENT: no such file or directory, open '/tmp/lsp-fixture-home-bRkA9w/owner.pid'
 Tests  1 failed | 20 passed (21)
```

Test (a) itself does **not** red on this mutation — its own two calls run milliseconds apart, well under the 1h age gate, so the age-gate fallback quietly covers for the missing write. This is not a gap in (a); it is the reviewer's exact point confirmed directly: only a long-running home is exposed, and only a direct content assertion (the one added above) can catch a missing write within a test's own short lifetime. Restored to green (21/21) after the proof.

**Tests run this round:** `tests/scripts/lsp-fixture-workspace.test.ts` (21), all `smoke-tools*.test.ts`, the workflow-pin test, `flake-shape-ratchet` — all green. No leaked `/tmp/lsp-fixture-home-*` or `/tmp/lsp-fixture-workspace-test-home-*` dirs after this round's runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
