### PR TITLE
docs(contracts): surgical-diff check, ledger state vocabulary, regroup debt pass (refs #2694)

### DIFF
--- a/.claude/agents/pi-lens-fixer.md
+++ b/.claude/agents/pi-lens-fixer.md
@@ -347,7 +347,7 @@ two mutation-inert branches under a ticked checklist box; #2595 r1 shipped an
 axis no manifest can reach. #2599 is the positive case — four `omit` entries
 deleted before reporting because the mutation showed they did nothing.
 
-Two more checks before the report, both from the same day:
+More checks before the report (the first two from the same day):
 - **Re-run every prior round's mutation set on the new head**, not only the
   new mutations. #2583 r3's home-ceiling test went vacuous the moment the new
   gate subsumed its fixture; only the re-run caught it. A guard that was live
@@ -382,6 +382,15 @@ Two more checks before the report, both from the same day:
      was wiped by `resetDegradationLedger()` and never re-recorded; #2649's
      failsafe was anchored to the first hold's epoch and released every
      later healthy call.
+- **Every changed line traces to the brief.** Read the diff hunk by hunk and
+  name the finding or acceptance box each hunk serves; a hunk that serves
+  none — adjacent code "improved", a comment reworded, formatting touched,
+  pre-existing dead code removed — comes out. Orphans YOUR change created
+  (an import, a variable, a helper now unused) come out too; dead code you
+  merely noticed goes in the follow-up section, not the diff. A reviewer
+  reads every hunk as a claim, so a hunk with no purpose costs a question
+  and sometimes a round. (Borrowed 2026-09-07 from the "surgical changes"
+  rule in aromanarguello/roman-skills `coding-guidelines`.)
 - **The closing keyword lives in the PR BODY.** GitHub ignores `closes #N` in
   a title; four 2026-09-06 PRs needed hand-closing. `closes` only when every
   acceptance box is met, else `refs` plus the remainder comment.

--- a/.claude/skills/merge-train/SKILL.md
+++ b/.claude/skills/merge-train/SKILL.md
@@ -140,7 +140,14 @@ operator's private notes, so a different orchestrator can run the same train.
   round, state, head SHA, merge-order note, and for bug lanes
   `caught by / should have been caught by`; a header line with the quota
   reading and the merged list. Update it on every dispatch, report and merge.
-  It is what survives a context reset.
+  It is what survives a context reset. `state` is one of exactly:
+  `not started`, `fixing rN`, `waiting on CI`, `waiting on review`,
+  `waiting on verify`, `blocked`, `ready to merge`, `merged`,
+  `needs user decision`, `held` — a fixed vocabulary so a resumed session
+  (or a different orchestrator) can build the status table without reading
+  the transcripts, and so "needs user decision" and "held" are visible as
+  rows rather than buried in prose. (Borrowed 2026-09-07 from the heartbeat
+  classification in aromanarguello/roman-skills `orchestrate-lane`.)
 - **A lane's worktree lives until its PR merges.** Pruning it after a report
   makes the owning worker un-resumable, so every fix round then costs a fresh
   worker. Prune on merge, or when the lane is abandoned.
@@ -210,6 +217,18 @@ operator's private notes, so a different orchestrator can run the same train.
   detector's boundary map). Each entry becomes, before merge, one of: an
   issue, a ledger note with a reason, or a line in the PR body. Silence is not
   a disposition.
+- **Debt pass at the regroup (2026-09-07).** Before prioritising the next
+  cycle, run the repo's own dead-code and duplication tools over the files
+  changed since the last release tag (`git diff --name-only v<last>..origin/master`;
+  `npx knip` uses the config in package.json, Sonar's duplication gate is the
+  CI form): every reviewer's "Named output" that named a re-derived seam
+  (#2694: the call-site scan hand-rolled in three sweeps) is what this pass
+  finds across lanes that no single review can see. Findings become issues
+  with the file list, never release blockers, and test-seam duplication is
+  IN scope — "Test infrastructure — reuse before you write" in AGENTS.md is
+  the standing rule, so the borrowed skill's "test duplication is often
+  intentional" exclusion is not borrowed. (Shape from aromanarguello/roman-skills
+  `techdebt`.)
 - **Session retrospective before the regroup.** One ledger block: what the
   maintainer had to bring in from outside, why the process did not surface it,
   and where the lesson was routed (contract, playbook, skill, issue). The


### PR DESCRIPTION
Second docs-only batch (tier C) from comparing three more external skills (aromanarguello/roman-skills `techdebt`, `coding-guidelines`, `orchestrate-lane`) against the contracts.

- **Fixer playbook, "Before you call it done":** every changed line traces to the brief; orphans your change created come out, dead code you merely noticed goes to follow-ups. The playbook had no surgical-changes rule.
- **Merge-train ledger:** a fixed ten-value `state` vocabulary so a resumed session or another orchestrator can build the status table without reading transcripts.
- **Merge-train regroup:** a debt pass over files changed since the last tag using the repo's own tools (knip config in package.json, Sonar duplication in CI); findings become issues, never release blockers; test-seam duplication is in scope (#2694 is the named recurrence).

Not borrowed: the external `techdebt` exclusion of test duplication (contradicts "reuse before you write"); Codex thread heartbeats (background merge loops and task notifications already cover it); the rest of `coding-guidelines` (minimalism ladder, red-first and the brief contract already state it).

## Tests
None: no code changes. CI on the head is the gate.

## Blast radius
`.claude/agents/pi-lens-fixer.md`, `.claude/skills/merge-train/SKILL.md`.

## Class sweep
All three external skills read in full; each section mapped to an existing contract clause or to one of the three edits above.

## Observability
Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Tq25c3YJbvWzdoQkrn9y