### PR TITLE
fix(merge-train): hold pending gating checks before merge (closes #2679)

### DIFF
--- a/.changelog/fix-2679-merge-train-pending-checks.md
+++ b/.changelog/fix-2679-merge-train-pending-checks.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Hold the merge train for unconcluded gating checks (refs #2679)** — Keep approved PRs pending until every non-advisory check reaches a terminal conclusion.

--- a/.changelog/fix-2679-merge-train-pending-checks.md
+++ b/.changelog/fix-2679-merge-train-pending-checks.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Hold the merge train for unconcluded gating checks (refs #2679)** — Keep approved PRs pending until every non-advisory check reaches a terminal conclusion.
+- **Hold the merge train for unconcluded gating checks (closes #2679)** — Keep approved PRs pending until every non-advisory check reaches a terminal conclusion.

--- a/scripts/lib/merge-train-lane.mjs
+++ b/scripts/lib/merge-train-lane.mjs
@@ -291,7 +291,8 @@ export function evaluateMergeGate(pr, health, { approvedBy } = {}) {
 		);
 
 	// A discovered non-advisory check must reach a terminal conclusion before
-	// UNSTABLE can merge. A discovered CANCELLED row is held because
+	// the PR can merge, whatever the merge state (CLEAN holds too, not only
+	// UNSTABLE). A discovered CANCELLED row is held because
 	// cancel-in-progress can leave it as the latest evidence until a newer
 	// sibling posts; resolveLatestByName already removes it once that happens.
 	const pending = [...byName.values()].filter(

--- a/scripts/lib/merge-train-lane.mjs
+++ b/scripts/lib/merge-train-lane.mjs
@@ -186,7 +186,7 @@ export const MERGE_GATE_REASON = {
 	REQUIRED_CHECK_NOT_SUCCESS: "required-check-not-success",
 	RUN_HEALTH: "run-health",
 	FAILING_CHECK: "failing-check",
-	CHECK_SUPERSEDED: "check-superseded",
+	CHECK_PENDING: "check-pending",
 	MERGE_STATE: "merge-state",
 	BEHIND_BASE: "behind-base",
 	NOT_APPROVED_BY_OWNER: "not-approved-by-owner",
@@ -274,81 +274,37 @@ export function evaluateMergeGate(pr, health, { approvedBy } = {}) {
 			`workflow run health is \`${health.classification}\` on \`${pr.headSha}\``,
 		);
 
-	// #2632 (verify round 1, F1): a discovered check's bare CANCELLED
-	// conclusion is UNCERTAIN evidence, not settled evidence of any kind --
-	// `ci-checks.mjs`'s own doc comment on `isUncertainConclusion` says a
-	// caller gates it "to PEND rather than fail". `cancel-in-progress: true`
-	// (ci.yml:15-16) leaves a stale CANCELLED row as the ONLY entry `byName`
-	// has for a name for several minutes before its replacement posts
-	// (live-probed on PR #2607's "Record post-merge validation": three
-	// check-suites on one commit, the oldest cancelled). Round 1 of this fix
-	// dropped such a row from the `failing` filter below and let it fall
-	// through to a green merge -- wrong, because `MERGEABLE_STATES` admits
-	// UNSTABLE, so THIS filter is the lane's only gate on a non-required
-	// check, and a superseded row whose replacement later posts FAILURE would
-	// already have merged by the time that replacement arrives. This HOLD
-	// (not an exemption folded into `failing`) is the pending-not-green half
-	// of the same contract `ci-verdict.mjs` already applies (`EXIT_PENDING`
-	// via its `pendingGatingRows`) -- `deny()` in this lane IS hold-and-retry:
-	// the label stays on and `runMergeLane` re-evaluates every 10 minutes and
-	// on every `check_suite: completed` webhook (merge-train-lane.yml), so a
-	// superseded check gets re-judged the moment its replacement posts,
-	// exactly like every other not-yet-green reason below.
-	//
-	// This reaches only NAMES NOT IN `REQUIRED_CHECKS`: a required check's
-	// CANCELLED conclusion never even reaches this point, because the
-	// required-check loop above already denied (REQUIRED_CHECK_NOT_SUCCESS)
-	// the moment it saw anything but a literal SUCCESS -- so a required
-	// check's cancellation still hard-fails, matching #2618's "a REQUIRED row
-	// gets NO conclusion exemption" and this issue's own explicit carve-out.
-	//
-	// `!isAdvisoryCheck(c.name)` (verify round 2, V1): an ADVISORY check
-	// (`(advisory)`-suffixed, SonarCloud, CodeQL, `greeting`) is cancelled and
-	// re-triggered by `cancel-in-progress` exactly like any other job -- an
-	// advisory check was NEVER meant to gate anything (that is the whole
-	// point of the advisory allowlist, `failing` below already excludes it
-	// the same way), so holding the merge on an advisory check's transient
-	// cancellation would be WORSE than #2632's original bug: that bug
-	// self-corrected once the replacement posted, but an advisory job that
-	// never posts a replacement (or keeps flapping) would park the train
-	// permanently on a check nothing else in this gate treats as gating.
-	//
-	// Known residual (verify round 2, V2, not fixed in this round -- tracked
-	// as #2679): this hold runs BEFORE `failing`, so a head that is BOTH
-	// genuinely red on one non-required check AND carries an unrelated
-	// superseded-cancelled row on a DIFFERENT name reports `check-superseded`
-	// instead of `failing-check` -- correct verdict (deny), imprecise reason.
-	// #2679 restructures both checks into one hold rung that reports the
-	// right reason regardless of ordering; deliberately out of scope here per
-	// the verify brief, since it is a higher-blast-radius restructuring of
-	// already-shipped #2185 machinery that deserves its own round.
-	const superseded = [...byName.values()].filter(
-		(c) => !isAdvisoryCheck(c.name) && isUncertainConclusion(c.conclusion),
-	);
-	if (superseded.length > 0)
-		return deny(
-			MERGE_GATE_REASON.CHECK_SUPERSEDED,
-			`non-advisory check(s) show a concurrency-superseded \`cancelled\` conclusion with no replacement posted yet, so this is not settled evidence either way: ${superseded.map((c) => `\`${c.name}\``).join(", ")}`,
-		);
-
-	// Judge the RESOLVED run per name, so a superseded duplicate cannot block
-	// a head whose current run passed, and a newer failing duplicate cannot be
-	// hidden by an older passing one. `isBlockingConclusion` (#2618
-	// fix-round-2, F5 net-count fold), not a direct `BLOCKING_CONCLUSIONS.has`
-	// -- this repo's GraphQL rollup already reports UPPERCASE conclusions so
-	// the two were behaviorally identical here, but a second hand-rolled
-	// case-sensitive comparison of the SAME set is exactly the duplication
-	// `isBlockingConclusion` exists to remove (ci-checks.mjs). CANCELLED is
-	// already resolved above (as a hold, not a pass-through), so this filter
-	// never sees one -- every OTHER blocking conclusion (FAILURE, TIMED_OUT,
-	// ACTION_REQUIRED, STARTUP_FAILURE, STALE) still denies unconditionally.
+	// Judge the resolved run per name, so a superseded duplicate cannot block a
+	// head whose current run passed, and a newer failing duplicate cannot be
+	// hidden by an older passing one. Failures win over pending evidence so a
+	// mixed rollup reports the actionable reason first (#2679).
 	const failing = [...byName.values()].filter(
-		(c) => !isAdvisoryCheck(c.name) && isBlockingConclusion(c.conclusion),
+		(c) =>
+			!isAdvisoryCheck(c.name) &&
+			isBlockingConclusion(c.conclusion) &&
+			!isUncertainConclusion(c.conclusion),
 	);
 	if (failing.length > 0)
 		return deny(
 			MERGE_GATE_REASON.FAILING_CHECK,
 			`non-advisory checks are failing: ${failing.map((c) => `\`${c.name}\` (${c.conclusion})`).join(", ")}`,
+		);
+
+	// A discovered non-advisory check must reach a terminal conclusion before
+	// UNSTABLE can merge. A discovered CANCELLED row is held because
+	// cancel-in-progress can leave it as the latest evidence until a newer
+	// sibling posts; resolveLatestByName already removes it once that happens.
+	const pending = [...byName.values()].filter(
+		(c) =>
+			!isAdvisoryCheck(c.name) &&
+			(c.status !== CONCLUDED_STATUS ||
+				c.conclusion == null ||
+				isUncertainConclusion(c.conclusion)),
+	);
+	if (pending.length > 0)
+		return deny(
+			MERGE_GATE_REASON.CHECK_PENDING,
+			`non-advisory check(s) are pending and have not concluded: ${pending.map((c) => `\`${c.name}\``).join(", ")}`,
 		);
 
 	// BEHIND is not a refusal: it is the update lever. Everything above has

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -2492,7 +2492,7 @@ describe("merge-lane gate (#2185)", () => {
 		["IN_PROGRESS", "SUCCESS"],
 		["QUEUED", null],
 		["COMPLETED", null],
-	])("holds a discovered %s check until it concludes", (status, conclusion) => {
+	])("holds a discovered %s check (conclusion %s) until it concludes", (status, conclusion) => {
 		const checkName = `discovered ${status.toLowerCase()} check`;
 		const gate = gateOf(
 			approved({

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -2484,6 +2484,92 @@ describe("merge-lane gate (#2185)", () => {
 		).toMatchObject({ merge: true });
 	});
 
+	// #2679: every discovered non-advisory check must settle before UNSTABLE
+	// can merge. These rows are distinct names so the resolver cannot hide the
+	// pending state behind an unrelated array-order choice.
+	it.each([
+		["IN_PROGRESS", null],
+		["IN_PROGRESS", "SUCCESS"],
+		["QUEUED", null],
+		["COMPLETED", null],
+	])("holds a discovered %s check until it concludes", (status, conclusion) => {
+		const checkName = `discovered ${status.toLowerCase()} check`;
+		const gate = gateOf(
+			approved({
+				mergeStateStatus: "UNSTABLE",
+				checkRuns: [...greenChecks(), { name: checkName, status, conclusion }],
+			}),
+		);
+		expect(gate).toMatchObject({
+			merge: false,
+			reason: MERGE_GATE_REASON.CHECK_PENDING,
+		});
+		expect(gate.detail).toContain(checkName);
+	});
+
+	it("reports every pending discovered check in the hold detail", () => {
+		const names = ["queued discovered check", "running discovered check"];
+		const gate = gateOf(
+			approved({
+				mergeStateStatus: "UNSTABLE",
+				checkRuns: [
+					...greenChecks(),
+					{ name: names[0], status: "QUEUED", conclusion: null },
+					{ name: names[1], status: "IN_PROGRESS", conclusion: null },
+				],
+			}),
+		);
+		expect(gate.reason).toBe(MERGE_GATE_REASON.CHECK_PENDING);
+		for (const name of names) expect(gate.detail).toContain(name);
+	});
+
+	it.each([
+		[
+			"pending first",
+			[
+				{
+					name: "discovered failure",
+					status: "COMPLETED",
+					conclusion: "FAILURE",
+				},
+				{
+					name: "discovered in-flight",
+					status: "IN_PROGRESS",
+					conclusion: null,
+				},
+			],
+		],
+		[
+			"pending first reversed",
+			[
+				{
+					name: "discovered in-flight",
+					status: "IN_PROGRESS",
+					conclusion: null,
+				},
+				{
+					name: "discovered failure",
+					status: "COMPLETED",
+					conclusion: "FAILURE",
+				},
+			],
+		],
+	])(
+		"lets a discovered failure beat pending checks (%s)",
+		(_label, extraChecks) => {
+			const gate = gateOf(
+				approved({
+					mergeStateStatus: "UNSTABLE",
+					checkRuns: [...greenChecks(), ...extraChecks],
+				}),
+			);
+			expect(gate).toMatchObject({
+				merge: false,
+				reason: MERGE_GATE_REASON.FAILING_CHECK,
+			});
+		},
+	);
+
 	// #2632 verify round 1, F1: a discovered (non-required) check-run's
 	// CANCELLED conclusion is a concurrency-superseded artifact -- UNCERTAIN
 	// evidence, not proof of anything -- so it must HOLD (deny, re-evaluated
@@ -2498,7 +2584,7 @@ describe("merge-lane gate (#2185)", () => {
 	// admits UNSTABLE, so the `failing` filter is the lane's ONLY gate on a
 	// non-required check, and a superseded row whose replacement later posts
 	// FAILURE would already have merged. F1's remedy is a dedicated HOLD
-	// (`CHECK_SUPERSEDED`) before `failing` runs.
+	// (`CHECK_PENDING`) after the failure filter runs.
 	it("RED PROOF (#2632 F1): a lone cancelled discovered check (no replacement posted yet) holds, does not merge green", () => {
 		const gate = gateOf(
 			approved({
@@ -2517,7 +2603,7 @@ describe("merge-lane gate (#2185)", () => {
 			merge: false,
 			update: false,
 			silent: false,
-			reason: MERGE_GATE_REASON.CHECK_SUPERSEDED,
+			reason: MERGE_GATE_REASON.CHECK_PENDING,
 		});
 		// F3: the hold names the superseded check, so the PR comment and step
 		// summary show WHY, not just "not green".
@@ -2639,7 +2725,7 @@ describe("merge-lane gate (#2185)", () => {
 	// fail-closed fallback (neither concluded-success, no comparable
 	// timestamp) keeps whichever is the INCUMBENT -- i.e. array order decides
 	// which one `byName` resolves to. Both orders must still deny: the
-	// CANCELLED-wins order denies via the F1 hold (CHECK_SUPERSEDED, not a
+	// CANCELLED-wins order denies via the F1 hold (CHECK_PENDING, not a
 	// pass-through to green), and the FAILURE-wins order denies via
 	// `failing` (FAILING_CHECK) as always -- neither order may merge.
 	it("F2: an unorderable cancelled/FAILURE tie denies in BOTH array orders, never merges", () => {
@@ -2659,7 +2745,7 @@ describe("merge-lane gate (#2185)", () => {
 			approved({ checkRuns: [...greenChecks(), cancelled, failure] }),
 		);
 		expect(cancelledFirst.merge).toBe(false);
-		expect(cancelledFirst.reason).toBe(MERGE_GATE_REASON.CHECK_SUPERSEDED);
+		expect(cancelledFirst.reason).toBe(MERGE_GATE_REASON.CHECK_PENDING);
 		const failureFirst = gateOf(
 			approved({ checkRuns: [...greenChecks(), failure, cancelled] }),
 		);


### PR DESCRIPTION
## Summary

Hold an approved merge-train PR while any discovered non-advisory check remains unconcluded. Report failing checks before pending checks, so mixed evidence gives the actionable failure reason. Preserve the existing advisory-check exemption and cancelled-check hold behavior.

Closes #2679.

## Tests

Targeted command used `node_modules/.bin/vitest run tests/scripts/merge-train-warden.test.ts --configLoader runner`. The linked `node_modules` tree exposed a read-only `.vite-temp`; the runner config loader avoided writes there. The transcript workspace and Vitest working cache were routed under `/tmp` for these runs. This was an invocation-only workaround and is not in the diff. No test source or configuration change reroutes the cache.

### Pre-fix red run

Review-round-1 correction: reproducing this run with the final tests against origin/master `merge-train-lane.mjs` gives **7 failed | 159 passed** — the five cases below plus the two #2632 cancelled-check tests this PR re-points from `CHECK_SUPERSEDED` to `CHECK_PENDING` (`expected 'check-superseded' to be 'check-pending'`). The transcript below was captured before those two expectations were updated.

```text
❯ |default| tests/scripts/merge-train-warden.test.ts (166 tests | 5 failed) 170ms
     × holds a discovered IN_PROGRESS check until it concludes 22ms
     × holds a discovered IN_PROGRESS check until it concludes 2ms
     × holds a discovered QUEUED check until it concludes 2ms
     × holds a discovered COMPLETED check until it concludes 1ms
     × reports every pending discovered check in the hold detail 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  |default| tests/scripts/merge-train-warden.test.ts > merge-lane gate (#2185) > holds a discovered IN_PROGRESS check until it concludes
 FAIL  |default| tests/scripts/merge-train-warden.test.ts > merge-lane gate (#2185) > holds a discovered IN_PROGRESS check until it concludes
 FAIL  |default| tests/scripts/merge-train-warden.test.ts > merge-lane gate (#2185) > holds a discovered QUEUED check until it concludes
 FAIL  |default| tests/scripts/merge-train-warden.test.ts > merge-lane gate (#2185) > holds a discovered COMPLETED check until it concludes
AssertionError: expected { merge: true, update: false, …(4) } to match object { merge: false, reason: undefined }

- Expected
+ Received

  {
-   "merge": false,
-   "reason": undefined,
+   "merge": true,
+   "reason": "green",
  }

 ❯ tests/scripts/merge-train-warden.test.ts:2503:16

 FAIL  |default| tests/scripts/merge-train-warden.test.ts > merge-lane gate (#2185) > reports every pending discovered check in the hold detail
AssertionError: expected 'green' to be undefined // Object.is equality

- Expected:
undefined

+ Received:
"green"

 ❯ tests/scripts/merge-train-warden.test.ts:2522:23

      Tests  5 failed | 161 passed (166)
```

### Final green run

```text
Test Files  1 passed (1)
Tests       166 passed (166)
```

### Mutation probes

Each probe was applied in an external copy of the worktree, then reverted before the next probe. The excerpts below are the exact failing-test summary from each run.

1. Delete the complete `pending` filter and its `if (pending.length > 0) return deny(...)` block.

   ```text
   × holds a discovered IN_PROGRESS check until it concludes
   × holds a discovered IN_PROGRESS check until it concludes
   × holds a discovered QUEUED check until it concludes
   × holds a discovered COMPLETED check until it concludes
   × reports every pending discovered check in the hold detail
   × RED PROOF (#2632 F1): a lone cancelled discovered check (no replacement posted yet) holds, does not merge green
   × F2: an unorderable cancelled/FAILURE tie denies in BOTH array orders, never merges
   Failed Tests 7
   Tests 7 failed | 159 passed (166)
   AssertionError: expected { merge: true, update: false, …(4) } to match object { merge: false, …(1) }
   AssertionError: expected 'green' to be 'check-pending' // Object.is equality
   AssertionError: expected true to be false
   ```

2. Replace `c.status !== CONCLUDED_STATUS ||` with `false ||` in the pending predicate.

   ```text
   × holds a discovered IN_PROGRESS check until it concludes
   Failed Tests 1
   Tests 1 failed | 165 passed (166)
   AssertionError: expected { merge: true, update: false, …(4) } to match object { merge: false, …(1) }
   ```

3. Replace `c.conclusion == null ||` with `false ||` in the pending predicate.

   ```text
   × holds a discovered COMPLETED check until it concludes
   Failed Tests 1
   Tests 1 failed | 165 passed (166)
   AssertionError: expected { merge: true, update: false, …(4) } to match object { merge: false, …(1) }
   ```

4. Change `if (pending.length > 0)` to `if (pending.length > 1)`.

   ```text
   × holds a discovered IN_PROGRESS check until it concludes
   × holds a discovered IN_PROGRESS check until it concludes
   × holds a discovered QUEUED check until it concludes
   × holds a discovered COMPLETED check until it concludes
   × RED PROOF (#2632 F1): a lone cancelled discovered check (no replacement posted yet) holds, does not merge green
   × F2: an unorderable cancelled/FAILURE tie denies in BOTH array orders, never merges
   Failed Tests 6
   Tests 6 failed | 160 passed (166)
   AssertionError: expected { merge: true, update: false, …(4) } to match object { merge: false, …(1) }
   AssertionError: expected true to be false
   ```

5. Remove `&& !isUncertainConclusion(c.conclusion)` from the failing predicate.

   ```text
   × RED PROOF (#2632 F1): a lone cancelled discovered check (no replacement posted yet) holds, does not merge green
   × F2: an unorderable cancelled/FAILURE tie denies in BOTH array orders, never merges
   Failed Tests 2
   Tests 2 failed | 164 passed (166)
   AssertionError: expected { merge: false, update: false, …(4) } to match object { merge: false, update: false, …(2) }
   AssertionError: expected 'failing-check' to be 'check-pending' // Object.is equality
   ```

### Test cases changed

- `tests/scripts/merge-train-warden.test.ts`: add coverage for queued, in-progress, and unconcluded discovered checks; assert that all pending names appear in the detail; and assert that a discovered failure wins over pending evidence in both array orders.
- `tests/scripts/merge-train-warden.test.ts`: update the existing cancelled-check expectations from `CHECK_SUPERSEDED` to the consolidated `CHECK_PENDING` reason.

## Blast radius

The change is local to `evaluateMergeGate`, but it affects the merge-train decision and its direct test helper.

```text
 callers above
   runMergeLane
     evaluateMergeGate(pr, health, { approvedBy })
       + resolveLatestByName(pr.checkRuns)
       + isAdvisoryCheck(check.name)
       + isBlockingConclusion(check.conclusion)
       + isUncertainConclusion(check.conclusion)
       + deny(reason, detail)
       + UPDATEABLE_STATES / MERGEABLE_STATES decision
   gateOf (tests/scripts/merge-train-warden.test.ts)
     evaluateMergeGate(prRecord, health, { approvedBy })

 evaluateMergeGate
   - check-superseded hold before the failing filter
   - failing filter handled every blocking conclusion
   + failing filter excludes uncertain conclusions so failures win over pending evidence
   + pending filter checks non-advisory status, null conclusion, and uncertain conclusion
   + CHECK_PENDING hold after the failing filter, with every pending check named

 callees below
   resolveLatestByName -> latest check per name
   isAdvisoryCheck -> advisory exclusion
   isBlockingConclusion -> settled failure classification
   isUncertainConclusion -> pending/cancelled classification
   deny -> non-merge decision with reason and detail
```

No new caller, public API, process boundary, or filesystem writer is introduced. The hot path adds one bounded pass over the already resolved check-name map, after the existing failure pass.

## Class sweep

The tests cover non-advisory checks in `IN_PROGRESS`, `QUEUED`, and `COMPLETED` with a null conclusion, plus an in-progress check carrying a stale success conclusion. They cover multiple pending names, both check-array orders for failure versus pending, advisory cancellation, required-check cancellation, duplicate resolution, and the existing cancelled-check replacement behavior. Failures remain higher priority than pending evidence. Advisory checks remain outside this gate.

Explicit non-goals are changing required-check handling, changing advisory policy, changing duplicate resolution, changing run-health classification, or changing merge/update state policy.

## Observability

Pending decisions use the existing bounded gate result and now emit `CHECK_PENDING` with a detail naming every pending non-advisory check. Mixed failure and pending evidence reports `FAILING_CHECK` and names the failing checks. No unbounded log or new telemetry path is added.

## Test assessment

The new regression cases run through the real `evaluateMergeGate` implementation and real check-run normalization. They do not replace the gate with a fake. The pre-fix run proves the new cases fail for the missing pending gate, the final run proves the fix, and five independent mutations each produce red output. The existing cancelled-check tests preserve the earlier superseded-check contract under the consolidated pending reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV

