### PR TITLE
fix(guard): heredoc-aware tokenizeShellCommand (closes #2726)

### DIFF
--- a/.changelog/fix-2726-tokenizer-heredoc.md
+++ b/.changelog/fix-2726-tokenizer-heredoc.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Heredoc bodies no longer leak into Bash command analysis (refs #2726)** — `tokenizeShellCommand` now consumes `<<` and `<<-` bodies, drops quoted body text, and retains substitutions from unquoted bodies so git-guard does not classify prose as an executable command.
+- **Heredoc bodies no longer leak into Bash command analysis (refs #2726)** — `tokenizeShellCommand` now consumes `<<` and `<<-` bodies, stops delimiter parsing at shell metacharacters, drops quoted body text, and retains substitutions from unquoted bodies so git-guard does not classify prose as an executable command.

--- a/.changelog/fix-2726-tokenizer-heredoc.md
+++ b/.changelog/fix-2726-tokenizer-heredoc.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Heredoc bodies no longer leak into Bash command analysis (refs #2726)** — `tokenizeShellCommand` now consumes `<<` and `<<-` bodies, drops quoted body text, and retains substitutions from unquoted bodies so git-guard does not classify prose as an executable command.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3706,6 +3706,8 @@ derived eager-import set.
   async sweep/timer callbacks must never dereference `ctx.ui`, which can become
   stale after session replacement.
 - Guard command analysis uses `tokenizeShellCommand` for quoted/separated argv;
+  its heredoc lexer drops quoted bodies, drops unquoted body text, and retains
+  command substitutions because Bash expands them;
   bash read/ownership grants are committed only from successful `tool_result`
   events. Tool-call inspection must not mutate read-guard state, and wrapper,
   launcher, and continuation forms must remain conservative for git commits and

--- a/clients/bash-file-access.ts
+++ b/clients/bash-file-access.ts
@@ -71,7 +71,7 @@ function parseHeredocDelimiter(
 	while (/\s/.test(command[i] ?? "")) i += 1;
 	let delimiter = "";
 	let quoted = false;
-	while (i < command.length && !/\s/.test(command[i] ?? "")) {
+	while (i < command.length && !/[\s;&|<>]/.test(command[i] ?? "")) {
 		const ch = command[i];
 		if (ch === "'" || ch === '"') {
 			quoted = true;

--- a/clients/bash-file-access.ts
+++ b/clients/bash-file-access.ts
@@ -55,8 +55,130 @@ export interface ShellCommandSegment {
 	terminator?: "pipe";
 }
 
+interface PendingHeredoc {
+	delimiter: string;
+	stripTabs: boolean;
+	quoted: boolean;
+}
+
+function parseHeredocDelimiter(
+	command: string,
+	start: number,
+): { heredoc: PendingHeredoc; end: number } | undefined {
+	let i = start;
+	const stripTabs = command[i] === "-";
+	if (stripTabs) i += 1;
+	while (/\s/.test(command[i] ?? "")) i += 1;
+	let delimiter = "";
+	let quoted = false;
+	while (i < command.length && !/\s/.test(command[i] ?? "")) {
+		const ch = command[i];
+		if (ch === "'" || ch === '"') {
+			quoted = true;
+			const quote = ch;
+			i += 1;
+			while (i < command.length && command[i] !== quote) {
+				delimiter += command[i++];
+			}
+			if (command[i] !== quote) return undefined;
+			i += 1;
+			continue;
+		}
+		if (ch === "\\") {
+			quoted = true;
+			i += 1;
+			if (i >= command.length) return undefined;
+			delimiter += command[i++];
+			continue;
+		}
+		delimiter += ch;
+		i += 1;
+	}
+	if (!delimiter) return undefined;
+	return { heredoc: { delimiter, stripTabs, quoted }, end: i - 1 };
+}
+
+function heredocSubstitutionBodies(body: string): string[] {
+	const substitutions: string[] = [];
+	for (let i = 0; i < body.length; i += 1) {
+		if (body.startsWith("$(", i)) {
+			let depth = 1;
+			let quote: "single" | "double" | undefined;
+			for (let end = i + 2; end < body.length; end += 1) {
+				const ch = body[end];
+				if (quote === "single") {
+					if (ch === "'") quote = undefined;
+					continue;
+				}
+				if (quote === "double") {
+					if (ch === '"' && body[end - 1] !== "\\") quote = undefined;
+					continue;
+				}
+				if (ch === "'" || ch === '"') {
+					quote = ch === "'" ? "single" : "double";
+				} else if (body.startsWith("$(", end)) {
+					depth += 1;
+					end += 1;
+				} else if (ch === ")") {
+					depth -= 1;
+					if (depth === 0) {
+						substitutions.push(body.slice(i + 2, end));
+						i = end;
+						break;
+					}
+				}
+			}
+		} else if (body[i] === "`" && body[i - 1] !== "\\") {
+			const end = body.indexOf("`", i + 1);
+			if (end >= 0) {
+				substitutions.push(body.slice(i + 1, end));
+				i = end;
+			}
+		}
+	}
+	return substitutions;
+}
+
+function consumeHeredocBodies(
+	command: string,
+	start: number,
+	heredocs: PendingHeredoc[],
+): { end: number; substitutions: string[] } {
+	let cursor = start;
+	const substitutions: string[] = [];
+	for (const heredoc of heredocs) {
+		const bodyStart = cursor;
+		let found = false;
+		while (cursor < command.length) {
+			const lineEnd = command.indexOf("\n", cursor);
+			const end = lineEnd < 0 ? command.length : lineEnd;
+			let line = command.slice(cursor, end);
+			if (heredoc.stripTabs) line = line.replace(/^\t+/, "");
+			if (line.replace(/\r$/, "") === heredoc.delimiter) {
+				if (!heredoc.quoted)
+					substitutions.push(
+						...heredocSubstitutionBodies(command.slice(bodyStart, cursor)),
+					);
+				cursor = lineEnd < 0 ? end : end + 1;
+				found = true;
+				break;
+			}
+			cursor = lineEnd < 0 ? end : end + 1;
+		}
+		if (!found) {
+			if (!heredoc.quoted)
+				substitutions.push(
+					...heredocSubstitutionBodies(command.slice(bodyStart)),
+				);
+			return { end: command.length - 1, substitutions };
+		}
+	}
+	return { end: cursor - 1, substitutions };
+}
+
 export function tokenizeShellCommand(command: string): ShellCommandSegment[] {
 	const segments: ShellCommandSegment[] = [];
+	const pendingHeredocs: PendingHeredoc[] = [];
 	let tokens: string[] = [];
 	let word = "";
 	let quote: "single" | "double" | undefined;
@@ -130,12 +252,21 @@ export function tokenizeShellCommand(command: string): ShellCommandSegment[] {
 			while (i + 1 < command.length && command[i + 1] !== "\n") i++;
 			continue;
 		}
-		if (/\s/.test(ch)) {
+		if (/\s/.test(ch) && ch !== "\n") {
 			flushWord();
 			continue;
 		}
 		if (ch === ";" || ch === "\n" || ch === "|" || ch === "&") {
 			flushWord();
+			if (ch === "\n" && pendingHeredocs.length > 0) {
+				const heredocs = pendingHeredocs.splice(0);
+				flushSegment();
+				const consumed = consumeHeredocBodies(command, i + 1, heredocs);
+				for (const substitution of consumed.substitutions)
+					segments.push(...tokenizeShellCommand(substitution));
+				i = consumed.end;
+				continue;
+			}
 			let terminator: "pipe" | undefined;
 			if (ch === "|" && next === "|") i++;
 			else if (ch === "&" && next === "&") i++;
@@ -148,6 +279,18 @@ export function tokenizeShellCommand(command: string): ShellCommandSegment[] {
 		}
 		if (ch === "<" || ch === ">") {
 			flushWord();
+			if (
+				ch === "<" &&
+				next === "<" &&
+				command[i - 1] !== "<" &&
+				command[i + 2] !== "<"
+			) {
+				const parsed = parseHeredocDelimiter(command, i + 2);
+				if (parsed) {
+					pendingHeredocs.push(parsed.heredoc);
+					i = parsed.end;
+				}
+			}
 			unsupported = true;
 			continue;
 		}

--- a/clients/git-guard.ts
+++ b/clients/git-guard.ts
@@ -199,6 +199,11 @@ function canonicalizeGuardCommand(command: string): string {
 	let pendingSpace = false;
 	quote = undefined;
 	for (const ch of result) {
+		if (!quote && ch === "\n") {
+			collapsed += ch;
+			pendingSpace = false;
+			continue;
+		}
 		if (!quote && /\s/.test(ch)) {
 			pendingSpace = collapsed.length > 0;
 			continue;

--- a/tests/clients/bash-file-access.test.ts
+++ b/tests/clients/bash-file-access.test.ts
@@ -44,6 +44,55 @@ afterEach(() => {
 });
 
 describe("tokenizeShellCommand — heredocs", () => {
+	it.each([
+		[";", "bare", "EOF"],
+		[";", "single-quoted", "'EOF'"],
+		[";", "double-quoted", '"EOF"'],
+		[";", "escaped", "\\EOF"],
+		["&", "bare", "EOF"],
+		["&", "single-quoted", "'EOF'"],
+		["&", "double-quoted", '"EOF"'],
+		["&", "escaped", "\\EOF"],
+		["|", "bare", "EOF"],
+		["|", "single-quoted", "'EOF'"],
+		["|", "double-quoted", '"EOF"'],
+		["|", "escaped", "\\EOF"],
+		["<", "bare", "EOF"],
+		["<", "single-quoted", "'EOF'"],
+		["<", "double-quoted", '"EOF"'],
+		["<", "escaped", "\\EOF"],
+		[">", "bare", "EOF"],
+		[">", "single-quoted", "'EOF'"],
+		[">", "double-quoted", '"EOF"'],
+		[">", "escaped", "\\EOF"],
+		[" ", "bare", "EOF"],
+		[" ", "single-quoted", "'EOF'"],
+		[" ", "double-quoted", '"EOF"'],
+		[" ", "escaped", "\\EOF"],
+	] as const)(
+		"terminates the delimiter at $0 ($1)",
+		(operator, _form, delimiter) => {
+			const command = `cat <<${delimiter}${operator}echo git push\nbody\nEOF`;
+			const expected =
+				operator === ";" || operator === "&"
+					? [
+							{ tokens: ["cat"], unsupported: true },
+							{ tokens: ["echo", "git", "push"], unsupported: false },
+						]
+					: operator === "|"
+						? [
+								{
+									tokens: ["cat"],
+									unsupported: true,
+									terminator: "pipe" as const,
+								},
+								{ tokens: ["echo", "git", "push"], unsupported: false },
+							]
+						: [{ tokens: ["cat", "echo", "git", "push"], unsupported: true }];
+			expect(tokenizeShellCommand(command)).toEqual(expected);
+		},
+	);
+
 	it("drops heredoc body words while preserving the surrounding command", () => {
 		expect(
 			tokenizeShellCommand("cat <<EOF\nbody git push\nEOF\necho done"),

--- a/tests/clients/bash-file-access.test.ts
+++ b/tests/clients/bash-file-access.test.ts
@@ -8,6 +8,7 @@ import {
 	extractReadPathsFromCommand,
 	extractWrittenPathsFromCommand,
 	parseGrepContextLines,
+	tokenizeShellCommand,
 	type ReadSpan,
 } from "../../clients/bash-file-access.js";
 import { removeTempDirSync } from "./test-utils.js";
@@ -40,6 +41,42 @@ beforeEach(() => {
 
 afterEach(() => {
 	removeTempDirSync(tmp);
+});
+
+describe("tokenizeShellCommand — heredocs", () => {
+	it("drops heredoc body words while preserving the surrounding command", () => {
+		expect(
+			tokenizeShellCommand("cat <<EOF\nbody git push\nEOF\necho done"),
+		).toEqual([
+			{ tokens: ["cat"], unsupported: true },
+			{ tokens: ["echo", "done"], unsupported: false },
+		]);
+	});
+
+	it("drops quoted bodies and keeps substitutions from unquoted bodies", () => {
+		expect(
+			tokenizeShellCommand(
+				"cat <<'EOF'\n$(git push)\nEOF\ncat <<EOF\n$(git commit)\nEOF",
+			),
+		).toEqual([
+			{ tokens: ["cat"], unsupported: true },
+			{ tokens: ["cat"], unsupported: true },
+			{ tokens: ["git", "commit"], unsupported: false },
+		]);
+	});
+
+	it("matches tab-stripped heredoc delimiters", () => {
+		expect(tokenizeShellCommand("cat <<-EOF\n\tbody git push\n\tEOF")).toEqual([
+			{ tokens: ["cat"], unsupported: true },
+		]);
+	});
+
+	it("does not treat a here-string as a heredoc", () => {
+		expect(tokenizeShellCommand("cat <<< git push\necho done")).toEqual([
+			{ tokens: ["cat", "git", "push"], unsupported: true },
+			{ tokens: ["echo", "done"], unsupported: false },
+		]);
+	});
 });
 
 // ── reads: full-file viewers ────────────────────────────────────────────────

--- a/tests/clients/runtime-tool-call.test.ts
+++ b/tests/clients/runtime-tool-call.test.ts
@@ -85,6 +85,32 @@ function baseDeps(
 }
 
 describe("handleToolCall", () => {
+	it("does not let heredoc body words trigger the real git guard", async () => {
+		const env = setupTestEnvironment("pi-lens-2726-heredoc-guard-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			runtime.setTelemetryIdentity({ sessionId: "session-2726" });
+			runtime.updateGitGuardStatus(true, "existing blocker");
+			const result = await handleToolCall(
+				baseDeps({
+					runtime,
+					ctx: { cwd: env.tmpDir },
+					getFlag: (name) => name === "lens-guard",
+					event: {
+						toolName: "bash",
+						input: {
+							command: "cat <<EOF\nbody text: git push\nEOF\n",
+						},
+					},
+				}),
+			);
+			expect(result).toBeUndefined();
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("is a no-op when lensEnabled is false", async () => {
 		const runtime = new RuntimeCoordinator();
 		const recordRead = vi.spyOn(runtime.readGuard, "recordRead");

--- a/tests/clients/runtime-tool-call.test.ts
+++ b/tests/clients/runtime-tool-call.test.ts
@@ -111,6 +111,54 @@ describe("handleToolCall", () => {
 		}
 	});
 
+	it("does not block a command after a heredoc delimiter metacharacter", async () => {
+		const env = setupTestEnvironment("pi-lens-2726-heredoc-operator-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			runtime.setTelemetryIdentity({ sessionId: "session-2726-operator" });
+			runtime.updateGitGuardStatus(true, "existing blocker");
+			const result = await handleToolCall(
+				baseDeps({
+					runtime,
+					ctx: { cwd: env.tmpDir },
+					getFlag: (name) => name === "lens-guard",
+					event: {
+						toolName: "bash",
+						input: { command: "cat <<EOF; echo git push\nbody\nEOF" },
+					},
+				}),
+			);
+			expect(result).toBeUndefined();
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("still blocks a git command after a heredoc body", async () => {
+		const env = setupTestEnvironment("pi-lens-2726-heredoc-git-");
+		try {
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			runtime.setTelemetryIdentity({ sessionId: "session-2726-git" });
+			runtime.updateGitGuardStatus(true, "existing blocker");
+			const result = await handleToolCall(
+				baseDeps({
+					runtime,
+					ctx: { cwd: env.tmpDir },
+					getFlag: (name) => name === "lens-guard",
+					event: {
+						toolName: "bash",
+						input: { command: "cat <<EOF; git push\nbody\nEOF" },
+					},
+				}),
+			);
+			expect(result).toMatchObject({ block: expect.anything() });
+		} finally {
+			env.cleanup();
+		}
+	});
+
 	it("is a no-op when lensEnabled is false", async () => {
 		const runtime = new RuntimeCoordinator();
 		const recordRead = vi.spyOn(runtime.readGuard, "recordRead");


### PR DESCRIPTION
## Summary

Round 2 fixes heredoc delimiter parsing in `tokenizeShellCommand`. Delimiters
now stop at shell metacharacters, including `;`, `&`, `|`, `<`, `>`, and
whitespace. Quoted and escaped delimiter spellings keep the same behavior.

## Tests

Round 1 transcripts carried forward:

- `npm run build` passed before the original heredoc tests.
- The original heredoc tokenizer tests passed after the round 1 body-consumption
  change.
- The original `handleToolCall` heredoc case passed through the real
  `lens-guard` path and did not block prose containing `git push`.

Round 2 red-first and verification:

- Before the source fix, the new `;`, `&`, `|`, `<`, and `>` × quoting cases
  failed: 20 cases total. The built tokenizer merged `echo git push` into the
  heredoc segment. The four whitespace cases were already green because the
  old parser already stopped at whitespace. The new real-path case also
  returned `{ block: true, ... }`.
- After the fix, `npm run build` passed.
- After the fix, `node_modules/.bin/vitest run tests/clients/bash-file-access.test.ts tests/clients/runtime-tool-call.test.ts --configLoader runner` passed: 2 files, 130 tests.
- The matrix covers six delimiter terminators (`;`, `&`, `|`, `<`, `>`, and
  space) across bare, single-quoted, double-quoted, and backslash-escaped
  delimiters: 24 token-stream cases.
- The real `handleToolCall` case with `cat <<EOF; echo git push` returned
  `undefined` and did not block.
- The real `handleToolCall` control with `cat <<EOF; git push` returned a
  blocking result.
- Mutation proof: restoring the old whitespace-only delimiter loop made 21
  targeted tests fail, including all 20 operator cases and the real non-blocking
  `handleToolCall` case.
- The six environment-blocked governance files remain for the orchestrator to
  run outside this sandbox.

## Blast radius

The changed parser is consumed by `commandSegments` in
`clients/bash-file-access.ts`, by `clients/git-guard.ts` for commit and push
classification, and by `clients/runtime-tool-result.ts` for command-result
analysis. The changed tool surface is `handleToolCall` in
`clients/runtime-tool-call.ts`, which invokes the git guard for Bash calls.
No durable storage shape or telemetry record changes.

## Class sweep

The repository sweep found one delimiter parser and one independent sibling
parser. `clients/bash-file-access.ts:64` owns the changed TypeScript parser.
Its consumers are the four `commandSegments` call sites plus direct tokenizer
uses in `clients/git-guard.ts` and `clients/runtime-tool-result.ts`.
`scripts/hooks/guard-bash.mjs:181` owns the sibling `parseHeredocMarker`
implementation. It already uses `WORD_BREAK = /[\\s;&|<>]/` and agrees with
this fix on delimiter termination. That file is intentionally unchanged for
PR #2732.

The population sweep found the four delimiter spellings exercised by the
matrix, the `<<-` behavior covered by the existing tab-stripping test, and all
tokenizer consumers listed above. No second TypeScript heredoc delimiter
parser exists.

## Observability

This is a parser correction, not a new failure path. It emits no new warnings,
logs, or telemetry records. Existing guard decisions remain the observable
result: the false-positive `echo git push` case allows, while a real `git push`
continues to block.

## Test assessment

- `tests/clients/bash-file-access.test.ts` uniquely pins delimiter termination
  for every operator and quoting spelling through exact token streams.
- `tests/clients/runtime-tool-call.test.ts` uniquely pins the production
  `handleToolCall` and `lens-guard` behavior for the false-positive case and
  its real-git control. No existing test became redundant.

## Round 2

Finding: a delimiter immediately followed by `;` was parsed as `EOF;`, which
merged the following command into the heredoc segment and falsely blocked
`cat <<EOF; echo git push`.

Change: stop delimiter parsing at shell metacharacters while preserving quote
and backslash handling. Add a 24-cell tokenizer matrix and two real-path
`handleToolCall` cases.

Evidence: the pre-fix built probe returned `true` for
`isGitCommitOrPushAttempt("bash", { command: "cat <<EOF; echo git push\\nbody\\nEOF" })`.
The post-fix probe returns `false`; the matching real `git push` command returns
`true`. The targeted suites pass 130/130, and reverting the metacharacter guard
produces 21 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV
