### PR TITLE
feat(config): per-analyzer enabled keys and startup scan controls (closes #2721)

### DIFF
--- a/.changelog/2721.md
+++ b/.changelog/2721.md
@@ -1,0 +1,1 @@
+Add project controls for startup analyzers and scan mode.

--- a/.changelog/2721.md
+++ b/.changelog/2721.md
@@ -1,1 +1,0 @@
-Add project controls for startup analyzers and scan mode.

--- a/.changelog/feat-2721-analyzer-disable-keys.md
+++ b/.changelog/feat-2721-analyzer-disable-keys.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Add per-analyzer `knip.enabled`, `jscpd.enabled`, `madge.enabled`, `gitleaks.enabled`, `govulncheck.enabled`, `deadCode.enabled`, and `complexity.enabled` keys plus `startup.mode` and `startup.scans.enabled` controls (refs #2721)** — project and global configuration can disable startup analyzers or heavyweight startup scans while preserving diagnostics and LSP.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1341,6 +1341,12 @@ rows with the project scan time. Projected rows must also use the shared
 Session degradation telemetry owns its dedupe and tally state in
 `clients/degradation-ledger.ts`: use `recordDegradationOnce` for a repeated
 site/subject that represents one user-visible degradation, and
+
+Session-start analyzer controls follow the same rule: a configured analyzer
+skip uses the `startup-analyzer-disabled` kind with the analyzer name as its
+subject, and `startup-scans` identifies the aggregate scan switch. The ledger
+reset in `handleSessionStart` re-arms these rows for each session; do not add a
+second debug-only latch for analyzer configuration.
 `incrementDegradationCount` when every event contributes to the exact group
 count but health should retain only one updated entry per subject. Both reset
 with the ledger at the session boundary; do not add caller-local duplicate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1341,12 +1341,6 @@ rows with the project scan time. Projected rows must also use the shared
 Session degradation telemetry owns its dedupe and tally state in
 `clients/degradation-ledger.ts`: use `recordDegradationOnce` for a repeated
 site/subject that represents one user-visible degradation, and
-
-Session-start analyzer controls follow the same rule: a configured analyzer
-skip uses the `startup-analyzer-disabled` kind with the analyzer name as its
-subject, and `startup-scans` identifies the aggregate scan switch. The ledger
-reset in `handleSessionStart` re-arms these rows for each session; do not add a
-second debug-only latch for analyzer configuration.
 `incrementDegradationCount` when every event contributes to the exact group
 count but health should retain only one updated entry per subject. Both reset
 with the ledger at the session boundary; do not add caller-local duplicate
@@ -1356,6 +1350,13 @@ record and admitted tally milestones also emit a `degradation_ledger` row throug
 the session remains auditable when no health render reaches the transcript.
 Scanner coverage gaps and stalled notify-inflight barriers use the ledger;
 successful notify drains remain latency-only because they are not degradations.
+
+Session-start analyzer controls follow the same rule: a configured analyzer
+skip uses the `startup-analyzer-disabled` kind with the analyzer name as its
+subject, and `startup-scans` identifies the aggregate scan switch. The ledger
+reset in `handleSessionStart` re-arms these rows for each session; do not add a
+second debug-only latch for analyzer configuration.
+
 The `message_end` handler uses `cache-usage-attribution-stale` (subject
 `message_end`) when a confirmed-stale ctx strips the stable id from a
 `cache_usage` row — the row still writes, so the degraded ATTRIBUTION is the

--- a/clients/config-schema.ts
+++ b/clients/config-schema.ts
@@ -187,6 +187,45 @@ function buildConfigSchema(): ConfigSchemaNode {
 		properties[key] ??= opaque("experimental");
 	}
 
+	for (const key of [
+		"knip",
+		"jscpd",
+		"madge",
+		"gitleaks",
+		"govulncheck",
+		"deadCode",
+		"complexity",
+	]) {
+		properties[key] = {
+			type: "object",
+			additionalProperties: true,
+			properties: {
+				enabled: { type: "boolean", [STABILITY_TIER_KEY]: "experimental" },
+			},
+			[STABILITY_TIER_KEY]: "stable",
+		};
+	}
+	properties.startup = {
+		type: "object",
+		additionalProperties: true,
+		properties: {
+			mode: {
+				type: "string",
+				enum: ["quick", "full", "minimal"],
+				[STABILITY_TIER_KEY]: "experimental",
+			},
+			scans: {
+				type: "object",
+				additionalProperties: true,
+				properties: {
+					enabled: { type: "boolean", [STABILITY_TIER_KEY]: "experimental" },
+				},
+				[STABILITY_TIER_KEY]: "experimental",
+			},
+		},
+		[STABILITY_TIER_KEY]: "stable",
+	};
+
 	// The four legacy ROOT LSP keys. Still accepted for their deprecation window
 	// (#2418 registry), and `experimental` because they are scheduled for
 	// removal — a `stable` tier on a key with a `removeNotBefore` would be two

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -36,6 +36,8 @@ import { getProbeHomeRedirectEvent } from "./probe-home-state.js";
 export { LEDGER_FIELD_MAX, truncateForLedger };
 
 export type DegradationKind =
+	/** A configured analyzer was deliberately skipped for this session. */
+	| "startup-analyzer-disabled"
 	/**
 	 * #2430: a tool mutated a tracked file but matched no built-in name and no
 	 * mutation shape adapter, so pi-lens could only find the change by diffing

--- a/clients/lens-config.ts
+++ b/clients/lens-config.ts
@@ -62,6 +62,10 @@ interface PiLensToggleConfig {
 }
 
 export interface PiLensGlobalConfig {
+	startup?: {
+		mode?: "quick" | "full" | "minimal";
+		scans?: { enabled?: boolean };
+	};
 	/**
 	 * Gitignore-style patterns excluded from pi-lens scans across ALL projects.
 	 * Merged at LOWEST precedence: a project `.gitignore` or `.pi-lens.json`
@@ -271,6 +275,25 @@ export function loadPiLensGlobalConfig(
 			? raw.ignore.filter((p): p is string => typeof p === "string")
 			: undefined;
 		if (ignore && ignore.length > 0) config.ignore = ignore;
+
+		const startup = asConfigObject(raw.startup);
+		if (startup) {
+			const startupConfig: PiLensGlobalConfig["startup"] = {};
+			const mode = startup.mode;
+			const scans = asConfigObject(startup.scans);
+			if (mode === "quick" || mode === "full" || mode === "minimal")
+				startupConfig.mode = mode;
+			else if ("mode" in startup)
+				warnInvalid('startup.mode must be "quick", "full", or "minimal"');
+			if (scans) {
+				if (typeof scans.enabled === "boolean") {
+					startupConfig.scans = { enabled: scans.enabled };
+				} else if ("enabled" in scans)
+					warnInvalid("startup.scans.enabled must be a boolean");
+			}
+			if (startupConfig.mode !== undefined || startupConfig.scans !== undefined)
+				config.startup = startupConfig;
+		}
 
 		const dispatch = asConfigObject(raw.dispatch);
 		if (dispatch) {

--- a/clients/lens-flag-registry.ts
+++ b/clients/lens-flag-registry.ts
@@ -242,6 +242,24 @@ export const LENS_FLAGS: readonly LensFlagSpec[] = [
 		default: false,
 		scope: "global",
 	},
+	...(
+		[
+			"knip",
+			"jscpd",
+			"madge",
+			"gitleaks",
+			"govulncheck",
+			"deadCode",
+			"complexity",
+		] as const
+	).map((analyzer) => ({
+		name: `no-${analyzer.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`,
+		description: `Disable the ${analyzer} session-start analyzer. Also via ${analyzer}.enabled=false in config.`,
+		configKey: `${analyzer}.enabled`,
+		negated: true,
+		default: false,
+		scope: "project" as const,
+	})),
 ];
 
 const byName = new Map(LENS_FLAGS.map((spec) => [spec.name, spec]));
@@ -274,6 +292,7 @@ export const GLOBAL_NON_FLAG_CONFIG_SECTIONS: readonly string[] = [
 	"ignore",
 	"dispatch",
 	"widget",
+	"startup",
 	"$schema",
 ];
 
@@ -297,6 +316,7 @@ export const PROJECT_NON_FLAG_CONFIG_SECTIONS: readonly string[] = [
 	"reviewGraph",
 	"trivy",
 	"helm",
+	"startup",
 ];
 
 /**

--- a/clients/project-lens-config.ts
+++ b/clients/project-lens-config.ts
@@ -163,6 +163,10 @@ const REVIEW_GRAPH_MAX_FILES_MIN = 100;
 const REVIEW_GRAPH_MAX_FILES_MAX = 20_000;
 
 export interface PiLensProjectConfig {
+	startup?: {
+		mode?: "quick" | "full" | "minimal";
+		scans?: { enabled?: boolean };
+	};
 	/** gitignore-style glob patterns added to every diagnostic scan. */
 	ignore: string[];
 	/** Per-rule threshold overrides; missing keys mean "use hardcoded default". */
@@ -897,6 +901,48 @@ function parseConfigFile(configPath: string): ParsedConfigFile {
 		}
 	}
 
+	let startup: PiLensProjectConfig["startup"];
+	if (obj.startup !== undefined) {
+		if (
+			!obj.startup ||
+			typeof obj.startup !== "object" ||
+			Array.isArray(obj.startup)
+		) {
+			note("startup must be an object");
+		} else {
+			const section = obj.startup as Record<string, unknown>;
+			if (
+				section.mode === "quick" ||
+				section.mode === "full" ||
+				section.mode === "minimal"
+			) {
+				startup = { mode: section.mode };
+			} else if ("mode" in section) {
+				note('startup.mode must be "quick", "full", or "minimal"');
+			}
+			if (section.scans !== undefined) {
+				if (
+					!section.scans ||
+					typeof section.scans !== "object" ||
+					Array.isArray(section.scans)
+				) {
+					note("startup.scans must be an object");
+				} else if (
+					typeof (section.scans as Record<string, unknown>).enabled ===
+					"boolean"
+				) {
+					startup ??= {};
+					startup.scans = {
+						enabled: (section.scans as Record<string, unknown>)
+							.enabled as boolean,
+					};
+				} else if ("enabled" in (section.scans as Record<string, unknown>)) {
+					note("startup.scans.enabled must be a boolean");
+				}
+			}
+		}
+	}
+
 	// #533 hygiene: mirror the global loader's unknown-key warn so a typo in a
 	// shared `.pi-lens.json` (e.g. `maxProjectFile`, `lps`) produces a signal
 	// instead of silently doing nothing. The recognized set is single-sourced
@@ -974,6 +1020,7 @@ function parseConfigFile(configPath: string): ParsedConfigFile {
 
 	return {
 		config: {
+			...(startup === undefined ? {} : { startup }),
 			ignore,
 			rules,
 			...(mutations as Pick<

--- a/clients/project-lens-config.ts
+++ b/clients/project-lens-config.ts
@@ -354,8 +354,17 @@ export function loadPiLensProjectConfig(
 	// a pi-lens-owned file were then produced by nobody at all. The pi-lens
 	// loader now enumerates those documents itself, for records only: nothing
 	// here is merged, and which file supplies a VALUE is unchanged.
-	reportPiLensConfigRecords(entry.legacyRecords);
 	const configInfo = preloadedInfo ?? freshInfoFor(entry);
+	// The selected legacy document is resolved below and its bounded migration
+	// records are cached with that projection. Reporting the discovery copy as
+	// well would produce two suppression records with different totals, because
+	// the discovery walk and the single-document resolution see different
+	// record populations. Keep discovery-only documents here; the selected file
+	// is reported by `loadCachedConfigFile`.
+	const selectedLegacyPath = configInfo?.path;
+	reportPiLensConfigRecords(
+		entry.legacyRecords.filter((record) => record.file !== selectedLegacyPath),
+	);
 	if (!configInfo) return EMPTY_PROJECT_CONFIG;
 	return loadCachedConfigFile(configInfo);
 }

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -127,6 +127,8 @@ import { resetSpawnTimeoutCooldowns } from "./spawn-timeout-cooldown.js";
 import { resetTestRunnerDelivery } from "./test-runner-delivery.js";
 import { resetLspMutationNoBridgeDbgLatch } from "./lsp-mutation.js";
 import type { SessionStartClassification } from "./session-lifecycle.js";
+import type { PiLensGlobalConfig } from "./lens-config.js";
+import type { PiLensProjectConfig } from "./project-lens-config.js";
 
 /** Durable root-identity value on `session_start_total` records. */
 export type SessionStartRootTelemetry = boolean | "unknown";
@@ -144,6 +146,8 @@ interface SessionStartDeps {
 	sessionReason?: string;
 	handlerEnteredAt?: number;
 	getFlag: (name: string) => boolean | string | undefined;
+	globalConfig?: PiLensGlobalConfig;
+	projectConfig?: PiLensProjectConfig;
 	notify: (msg: string, level: "info" | "warning" | "error") => void;
 	dbg: (msg: string) => void;
 	log: (msg: string) => void;
@@ -449,11 +453,17 @@ function logProjectSnapshotProbe(args: {
 	}
 }
 
-function resolveStartupMode(): StartupMode {
+function resolveStartupMode(
+	projectConfig?: PiLensProjectConfig,
+	globalConfig?: PiLensGlobalConfig,
+): StartupMode {
 	const envMode = (process.env.PI_LENS_STARTUP_MODE ?? "").trim().toLowerCase();
 	if (envMode === "full" || envMode === "minimal" || envMode === "quick") {
 		return envMode;
 	}
+	const configMode =
+		projectConfig?.startup?.mode ?? globalConfig?.startup?.mode;
+	if (configMode) return configMode;
 
 	if (isPrintMode()) {
 		return "quick";
@@ -1201,6 +1211,10 @@ function scheduleStartupScansWithClients(
 		astGrepClient,
 		depChecker,
 	} = deps;
+	const analyzerEnabled = (flag: string): boolean => !deps.getFlag(flag);
+	if (!analyzerEnabled("no-complexity")) {
+		dbg("session_start complexity: skipped (disabled by config)");
+	}
 
 	// Some background scans are CPU-heavy and arrive on the event loop
 	// just as the user is most likely typing (right after /new). Defer
@@ -1311,6 +1325,11 @@ function scheduleStartupScansWithClients(
 		name: string,
 		task: () => Promise<void>,
 	): void => {
+		const flag = `no-${name}`;
+		if (name !== "opengrep" && name !== "trivy" && !analyzerEnabled(flag)) {
+			dbg(`session_start ${name}: skipped (disabled by config)`);
+			return;
+		}
 		if (skipHeavyweightScans) return;
 		void runTask(name, task);
 	};
@@ -1931,7 +1950,7 @@ export async function handleSessionStart(
 	//   entirely — but only when PI_LENS_STARTUP_MODE is unset in the env
 	//   (an explicit env var still takes highest precedence).
 	// Tunable: PI_LENS_WARMUP_DELAY_MS adjusts the warmup delay.
-	let startupMode = resolveStartupMode();
+	let startupMode = resolveStartupMode(deps.projectConfig, deps.globalConfig);
 	// SAFETY: these two flags are process-lifetime state pi-lens stashes on
 	// `globalThis` so a second extension instance in the same process sees the
 	// first one's warmup. There is no ambient declaration for them, and adding
@@ -1945,7 +1964,9 @@ export async function handleSessionStart(
 	if (
 		isFirstSessionOfProcess &&
 		process.env.PI_LENS_COLD_START_QUICK !== "0" &&
-		!process.env.PI_LENS_STARTUP_MODE
+		!process.env.PI_LENS_STARTUP_MODE &&
+		!deps.projectConfig?.startup?.mode &&
+		!deps.globalConfig?.startup?.mode
 	) {
 		// Apply host-provided override (e.g. MCP server forces "full") before
 		// falling back to the TUI quick-mode heuristic.
@@ -2869,7 +2890,12 @@ export async function handleSessionStart(
 		dbg("session_start: no language defaults selected for pre-install");
 	}
 
-	const startupScansWillRun = allowBootstrapTasks && startupScan.canWarmCaches;
+	const startupScansEnabled =
+		deps.projectConfig?.startup?.scans?.enabled ??
+		deps.globalConfig?.startup?.scans?.enabled ??
+		true;
+	const startupScansWillRun =
+		allowBootstrapTasks && startupScan.canWarmCaches && startupScansEnabled;
 	const jstsHeavyScansWillRun =
 		startupScansWillRun && canRunStartupHeavyScans(languageProfile, "jsts");
 	if (allowBootstrapTasks) {
@@ -2940,6 +2966,10 @@ export async function handleSessionStart(
 	// needs it before this point) and is stable across this whole call.
 	if (!allowBootstrapTasks) {
 		dbg("session_start: skipping startup background scans (startup mode)");
+	} else if (!startupScansEnabled) {
+		dbg(
+			"session_start: skipping startup background scans (disabled by config)",
+		);
 	} else if (!startupScan.canWarmCaches) {
 		dbg(
 			`session_start: skipping heavy scans (${startupScan.reason ?? "unknown"})`,

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -10,6 +10,7 @@ import { deadCodeIssueCount } from "./dead-code-client.js";
 import { logDeadCodeScan } from "./dead-code-logger.js";
 import {
 	incrementDegradationCount,
+	recordDegradationOnce,
 	resetDegradationLedger,
 } from "./degradation-ledger.js";
 import { getDiagnosticTracker } from "./diagnostic-tracker.js";
@@ -1214,6 +1215,11 @@ function scheduleStartupScansWithClients(
 	const analyzerEnabled = (flag: string): boolean => !deps.getFlag(flag);
 	if (!analyzerEnabled("no-complexity")) {
 		dbg("session_start complexity: skipped (disabled by config)");
+		recordDegradationOnce({
+			kind: "startup-analyzer-disabled",
+			subject: "complexity",
+			reason: "skipped (disabled by config)",
+		});
 	}
 
 	// Some background scans are CPU-heavy and arrive on the event loop
@@ -1328,6 +1334,11 @@ function scheduleStartupScansWithClients(
 		const flag = `no-${name}`;
 		if (name !== "opengrep" && name !== "trivy" && !analyzerEnabled(flag)) {
 			dbg(`session_start ${name}: skipped (disabled by config)`);
+			recordDegradationOnce({
+				kind: "startup-analyzer-disabled",
+				subject: name,
+				reason: "skipped (disabled by config)",
+			});
 			return;
 		}
 		if (skipHeavyweightScans) return;
@@ -2970,6 +2981,11 @@ export async function handleSessionStart(
 		dbg(
 			"session_start: skipping startup background scans (disabled by config)",
 		);
+		recordDegradationOnce({
+			kind: "startup-analyzer-disabled",
+			subject: "startup-scans",
+			reason: "skipped (disabled by config)",
+		});
 	} else if (!startupScan.canWarmCaches) {
 		dbg(
 			`session_start: skipping heavy scans (${startupScan.reason ?? "unknown"})`,

--- a/clients/runtime-tool-call.ts
+++ b/clients/runtime-tool-call.ts
@@ -1037,6 +1037,7 @@ async function handleToolCallImpl(deps: ToolCallDeps): Promise<ToolCallResult> {
 	// needs nothing but the extension registry; `ComplexityClient.isSupportedFile`
 	// delegates to it, so this is not a second copy.
 	if (
+		!getFlag("no-complexity") &&
 		!isExternalOrVendor &&
 		filePath &&
 		!runtime.complexityBaselines.has(filePath) &&

--- a/clients/runtime-tool-call.ts
+++ b/clients/runtime-tool-call.ts
@@ -1070,6 +1070,12 @@ async function handleToolCallImpl(deps: ToolCallDeps): Promise<ToolCallResult> {
 				entropy: baseline.codeEntropy,
 			});
 		}
+	} else if (getFlag("no-complexity") && filePath && isComplexitySupportedFile(filePath)) {
+		recordDegradationOnce({
+			kind: "startup-analyzer-disabled",
+			subject: "complexity",
+			reason: "skipped (disabled by config)",
+		});
 	}
 
 	// --- Read-Before-Edit Guard: check edits ---

--- a/docs/globalconfig.md
+++ b/docs/globalconfig.md
@@ -35,6 +35,13 @@ Each runtime toggle is settable from the CLI *and* from `config.json`. The two a
 | `--no-dead-code` | `deadCode.enabled` | `true` |
 | `--no-complexity` | `complexity.enabled` | `true` |
 
+## Startup controls
+
+| Configuration key | Default | Accepted values |
+| --- | --- | --- |
+| `startup.mode` | `full` | `quick`, `full`, or `minimal`; `PI_LENS_STARTUP_MODE` wins |
+| `startup.scans.enabled` | `true` | `true` or `false` |
+
 By default pi-lens registers six situational tools (the `ast_grep_*` family,
 `lsp_navigation`, `lens_diagnostic_mark`) inactive and exposes a small loader,
 `pi_lens_activate_tools`, that the model calls to activate the ones it needs.

--- a/docs/globalconfig.md
+++ b/docs/globalconfig.md
@@ -27,6 +27,13 @@ Each runtime toggle is settable from the CLI *and* from `config.json`. The two a
 | `--lens-compact-tool-line` | `ui.compactToolLine` | `false` |
 | `--no-lazy-tools` | `tools.lazy` | `true` |
 | `--lens-turn-end-madge` | `turnEnd.madge.enabled` | `false` |
+| `--no-knip` | `knip.enabled` | `true` |
+| `--no-jscpd` | `jscpd.enabled` | `true` |
+| `--no-madge` | `madge.enabled` | `true` |
+| `--no-gitleaks` | `gitleaks.enabled` | `true` |
+| `--no-govulncheck` | `govulncheck.enabled` | `true` |
+| `--no-dead-code` | `deadCode.enabled` | `true` |
+| `--no-complexity` | `complexity.enabled` | `true` |
 
 By default pi-lens registers six situational tools (the `ast_grep_*` family,
 `lsp_navigation`, `lens_diagnostic_mark`) inactive and exposes a small loader,
@@ -248,6 +255,12 @@ Explicit override for the review graph's own file budget (#775), for monorepos t
 - Why the review graph tapers instead of scaling flatly like the other four budgets: its per-file cost (tree-sitter parse + import-fact extraction) is measurably higher than a directory-entry count or file-existence check, so an unbounded linear budget on a huge `maxProjectFiles` would risk a very slow cold build on the synchronous edit-hook path. See `clients/project-scale.ts`'s `taperedReviewGraphMaxFiles` doc comment for the exact shape and the measured per-file cost it's grounded in.
 
 ### Schema rules
+
+Session-start analyzer keys default to `true` and work in both the global
+config and `.pi-lens.json`. Set one to `false` to skip that analyzer; pi-lens
+records the disabled skip. `startup.mode` accepts `quick`, `full`, or
+`minimal`, and `startup.scans.enabled: false` disables background startup scans
+while leaving diagnostics and LSP active. `PI_LENS_STARTUP_MODE` still wins.
 
 - Unknown rule ids are ignored (forward-compat). Unrecognized **top-level** keys are logged once and then ignored — never fatal to the parse. The LSP namespaces a shared file legitimately carries (`servers`, `serverOverrides`, `disabledServers`, `warmFiles`) and `$schema` are tolerated silently; a user-level-only lens key placed here (e.g. `lsp`, `tests`, `delta`) is logged as "not honored at project scope"; anything else is logged as a likely typo. The raw parsed JSON is still exposed for forward-compat consumers regardless.
 - Every toggle key in the table above must be a boolean, and its containing section must be an object. A wrong type is logged once and the key is treated as absent, so the flag falls through to its default rather than the whole file being rejected.

--- a/index.ts
+++ b/index.ts
@@ -2206,6 +2206,8 @@ function activateExtension(hostPi: ExtensionAPI) {
 						emitHostReadyDelay,
 						sessionReason,
 						handlerEnteredAt,
+						globalConfig,
+						projectConfig: loadPiLensProjectConfig(runtime.projectRoot),
 						// #2129: this call site is only reached for "primary"/
 						// "sequential-replacement" — a declined start returned above.
 						sessionStartClassification: sessionStartDecision.classification,

--- a/tests/clients/lens-config.test.ts
+++ b/tests/clients/lens-config.test.ts
@@ -1042,6 +1042,13 @@ describe("global pi-lens config", () => {
 				"no-autoformat",
 				"no-autofix",
 				"lens-actionable-warning-autofix",
+				"no-knip",
+				"no-jscpd",
+				"no-madge",
+				"no-gitleaks",
+				"no-govulncheck",
+				"no-dead-code",
+				"no-complexity",
 			]);
 
 			// A global-scoped key sitting in a project config decides nothing.

--- a/tests/clients/runtime-session.test.ts
+++ b/tests/clients/runtime-session.test.ts
@@ -8,7 +8,10 @@ import {
 	saveProjectSnapshot,
 } from "../../clients/project-snapshot.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
-import { getDegradationSummary } from "../../clients/degradation-ledger.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
 import {
 	loadPiLensGlobalConfig,
 	resolvePiLensFlag,
@@ -22,6 +25,7 @@ import { handleSessionStart } from "../../clients/runtime-session.js";
 import { _resetSlowFsForTests } from "../../clients/slow-fs.js";
 import { _resetSubagentModeForTests } from "../../clients/subagent-mode.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+import { waitFor as waitForCondition } from "./interleaving-kit.js";
 import { makeLspServiceDouble } from "../support/lsp-service-double.js";
 
 /** A pid guaranteed dead on this machine, for orphan-staging-file tests
@@ -168,100 +172,99 @@ async function runSessionStart(
 	const restoreStartupMode =
 		overrides.startupModeEnv === null
 			? (() => {
-				const previous = process.env.PI_LENS_STARTUP_MODE;
-				delete process.env.PI_LENS_STARTUP_MODE;
-				return () => {
-					if (previous === undefined) delete process.env.PI_LENS_STARTUP_MODE;
-					else process.env.PI_LENS_STARTUP_MODE = previous;
-				};
-			})()
+					const previous = process.env.PI_LENS_STARTUP_MODE;
+					delete process.env.PI_LENS_STARTUP_MODE;
+					return () => {
+						if (previous === undefined) delete process.env.PI_LENS_STARTUP_MODE;
+						else process.env.PI_LENS_STARTUP_MODE = previous;
+					};
+				})()
 			: setStartupMode(overrides.startupModeEnv ?? mode);
 	mockTouchFile.mockClear();
 
 	try {
-		await handleSessionStart(
-			withResidentBootstrap({
-				ctxCwd: env.tmpDir,
-				getFlag: (name: string) => {
-					const override = overrides.getFlag?.(name);
-					if (override !== undefined) return override;
-					if (name === "lens-lsp") return true;
-					if (name === "no-lsp") return false;
-					return false;
+		const sessionDeps = withResidentBootstrap({
+			ctxCwd: env.tmpDir,
+			getFlag: (name: string) => {
+				const override = overrides.getFlag?.(name);
+				if (override !== undefined) return override;
+				if (name === "lens-lsp") return true;
+				if (name === "no-lsp") return false;
+				return false;
+			},
+			projectConfig: overrides.projectConfig,
+			globalConfig: overrides.globalConfig,
+			startupModeOverride: overrides.startupModeOverride,
+			notify,
+			dbg,
+			log: () => {},
+			runtime: {
+				sessionGeneration: 1,
+				isCurrentSession: () => true,
+				markStartupScanInFlight: (name: string) => {
+					inFlightScans.add(name);
 				},
-				projectConfig: overrides.projectConfig,
-				globalConfig: overrides.globalConfig,
-				startupModeOverride: overrides.startupModeOverride,
-				notify,
-				dbg,
-				log: () => {},
-				runtime: {
-					sessionGeneration: 1,
-					isCurrentSession: () => true,
-					markStartupScanInFlight: (name: string) => {
-						inFlightScans.add(name);
-					},
-					clearStartupScanInFlight: (name: string) => {
-						inFlightScans.delete(name);
-					},
-					complexityBaselines: new Map(),
-					resetForSession: () => {},
-					projectRoot: "",
-					projectRulesScan: { hasCustomRules: false, rules: [] },
-					cachedExports: new Map(),
-					errorDebtBaseline: { testsPassed: true, buildPassed: true },
+				clearStartupScanInFlight: (name: string) => {
+					inFlightScans.delete(name);
 				},
-				metricsClient: { reset: () => {} },
-				cacheManager: {
-					writeCache: () => {},
-					readCache: (key: string) => {
-						if (key === "errorDebt") {
-							return {
-								data: { pendingCheck: true, baselineTestsPassed: true },
-							};
-						}
-						return null;
-					},
+				complexityBaselines: new Map(),
+				resetForSession: () => {},
+				projectRoot: "",
+				projectRulesScan: { hasCustomRules: false, rules: [] },
+				cachedExports: new Map(),
+				errorDebtBaseline: { testsPassed: true, buildPassed: true },
+			},
+			metricsClient: { reset: () => {} },
+			cacheManager: {
+				writeCache: () => {},
+				readCache: (key: string) => {
+					if (key === "errorDebt") {
+						return {
+							data: { pendingCheck: true, baselineTestsPassed: true },
+						};
+					}
+					return null;
 				},
-				todoScanner: { scanDirectory, scanFile },
-				astGrepClient: {
-					isAvailable: () => false,
-					ensureAvailable: astGrepEnsure,
-					scanExports,
-				},
-				biomeClient: {
-					isAvailable: () => false,
-					ensureAvailable: biomeEnsure,
-				},
-				ruffClient: {
-					isAvailable: () => false,
-					ensureAvailable: ruffEnsure,
-				},
-				knipClient: {
-					isAvailable: () => false,
-					ensureAvailable: knipEnsure,
-					analyze: knipAnalyze,
-				},
-				jscpdClient: {
-					isAvailable: () => false,
-					ensureAvailable: jscpdEnsure,
-				},
-				depChecker: {
-					isAvailable: () => false,
-					ensureAvailable: depEnsure,
-				},
-				testRunnerClient: {
-					detectRunner: () => ({ runner: "vitest", config: null }),
-					runTestFile: () => ({ failed: 1, error: false }),
-				},
-				goClient: { isGoAvailableAsync: async () => false },
-				rustClient: { isAvailableAsync: async () => false },
-				ensureTool,
-				cleanStaleTsBuildInfo: () => ["tsconfig.tsbuildinfo"],
-				resetDispatchBaselines: () => {},
-				resetLSPService,
-			}) as any,
-		);
+			},
+			todoScanner: { scanDirectory, scanFile },
+			astGrepClient: {
+				isAvailable: () => false,
+				ensureAvailable: astGrepEnsure,
+				scanExports,
+			},
+			biomeClient: {
+				isAvailable: () => false,
+				ensureAvailable: biomeEnsure,
+			},
+			ruffClient: {
+				isAvailable: () => false,
+				ensureAvailable: ruffEnsure,
+			},
+			knipClient: {
+				isAvailable: () => false,
+				ensureAvailable: knipEnsure,
+				analyze: knipAnalyze,
+			},
+			jscpdClient: {
+				isAvailable: () => false,
+				ensureAvailable: jscpdEnsure,
+			},
+			depChecker: {
+				isAvailable: () => false,
+				ensureAvailable: depEnsure,
+			},
+			testRunnerClient: {
+				detectRunner: () => ({ runner: "vitest", config: null }),
+				runTestFile: () => ({ failed: 1, error: false }),
+			},
+			goClient: { isGoAvailableAsync: async () => false },
+			rustClient: { isAvailableAsync: async () => false },
+			ensureTool,
+			cleanStaleTsBuildInfo: () => ["tsconfig.tsbuildinfo"],
+			resetDispatchBaselines: () => {},
+			resetLSPService,
+		}) as any;
+		await handleSessionStart(sessionDeps);
 
 		// The returned `cleanup` waits for the tmpDir-touching background scans
 		// to settle (see the #810 comment above `inFlightScans`) before deleting
@@ -282,6 +285,7 @@ async function runSessionStart(
 
 		return {
 			env: { ...env, cleanup },
+			repeatSessionStart: () => handleSessionStart(sessionDeps),
 			notify,
 			scanDirectory,
 			scanFile,
@@ -347,53 +351,142 @@ it(
 	TEST_BUDGET_MS,
 );
 
-it("skips a disabled startup analyzer through session_start and records it", async () => {
-	const { env, knipEnsure, dbg } = await runSessionStart(
-		"full",
-		(tmpDir) => {
-			createTempFile(tmpDir, "package.json", JSON.stringify({}));
-			createTempFile(tmpDir, "src/index.ts", "export const value = 1;\n");
-		},
-		{ getFlag: (name) => name === "no-knip", startupModeOverride: "full" },
-	);
-	try {
-		await vi.waitFor(() =>
-			expect(dbg).toHaveBeenCalledWith(
-				"session_start knip: skipped (disabled by config)",
-			),
+it(
+	"skips a disabled startup analyzer through session_start and records it",
+	async () => {
+		const { env, knipEnsure, dbg } = await runSessionStart(
+			"full",
+			(tmpDir) => {
+				createTempFile(tmpDir, "package.json", JSON.stringify({}));
+				createTempFile(tmpDir, "src/index.ts", "export const value = 1;\n");
+			},
+			{ getFlag: (name) => name === "no-knip", startupModeOverride: "full" },
 		);
-		expect(knipEnsure).not.toHaveBeenCalled();
-		expect(
-			getDegradationSummary().some(
-				(entry) => entry.kind === "startup-analyzer-disabled",
-			),
-		).toBe(true);
-	} finally {
-		await env.cleanup();
-	}
-}, TEST_BUDGET_MS);
+		try {
+			await waitForCondition(
+				() => dbg.mock.calls,
+				(calls) =>
+					calls.some(
+						([message]) =>
+							message === "session_start knip: skipped (disabled by config)",
+					),
+				{ timeoutMs: HEAVY_IO_TIMEOUT_MS },
+			);
+			expect(dbg).toHaveBeenCalledWith(
+			"session_start knip: skipped (disabled by config)",
+		);
+			expect(knipEnsure).not.toHaveBeenCalled();
+			expect(
+				getDegradationSummary().some(
+					(entry) => entry.kind === "startup-analyzer-disabled",
+				),
+			).toBe(true);
+		} finally {
+			await env.cleanup();
+		}
+	},
+	TEST_BUDGET_MS,
+);
 
 describe("fixture-loaded startup precedence", () => {
-	it("gives PI_LENS_STARTUP_MODE precedence over startup.mode config", async () => {
+	it("gives PI_LENS_STARTUP_MODE precedence through the scan consumer", async () => {
 		const env = setupTestEnvironment("pi-lens-startup-env-precedence-");
 		const globalPath = path.join(env.tmpDir, "global", "config.json");
-		writeConfig(globalPath, { startup: { mode: "quick" } });
+		writeConfig(globalPath, { startup: { mode: "full" } });
 		const globalConfig = loadPiLensGlobalConfig(globalPath);
 		const projectConfig = loadPiLensProjectConfig(env.tmpDir);
 		try {
 			const result = await runSessionStart(
-				"minimal",
-				(tmpDir) => createTempFile(tmpDir, "package.json", "{}"),
+				"full",
+				(tmpDir) => {
+					createTempFile(tmpDir, "package.json", "{}");
+					createTempFile(tmpDir, "src/index.ts", "export const value = 1;\n");
+				},
 				{
 					globalConfig,
 					projectConfig,
+					startupModeEnv: "quick",
 					getFlag: (name) =>
 						resolvePiLensFlag(name, undefined, globalConfig, projectConfig),
 				},
 			);
 			try {
+				expect(result.knipAnalyze).not.toHaveBeenCalled();
 				expect(result.dbg).toHaveBeenCalledWith(
-					"session_start startup mode: minimal",
+					"session_start startup mode: quick",
+				);
+			} finally {
+				await result.env.cleanup();
+			}
+		} finally {
+			env.cleanup();
+		}
+
+		const inverse = setupTestEnvironment("pi-lens-startup-config-precedence-");
+		const inversePath = path.join(inverse.tmpDir, "global", "config.json");
+		writeConfig(inversePath, { startup: { mode: "quick" } });
+		const inverseGlobal = loadPiLensGlobalConfig(inversePath);
+		const inverseProject = loadPiLensProjectConfig(inverse.tmpDir);
+		try {
+			const result = await runSessionStart(
+				"full",
+				(tmpDir) => {
+					createTempFile(tmpDir, "package.json", "{}");
+					createTempFile(tmpDir, "src/index.ts", "export const value = 1;\n");
+				},
+				{
+					globalConfig: inverseGlobal,
+					projectConfig: inverseProject,
+					startupModeEnv: "full",
+					getFlag: (name) =>
+						resolvePiLensFlag(name, undefined, inverseGlobal, inverseProject),
+				},
+			);
+			try {
+				await waitForCondition(
+					() => result.knipAnalyze.mock.calls.length,
+					(count) => count > 0,
+					{ timeoutMs: HEAVY_IO_TIMEOUT_MS },
+				);
+				expect(result.dbg).toHaveBeenCalledWith(
+					"session_start startup mode: full",
+				);
+			} finally {
+				await result.env.cleanup();
+			}
+		} finally {
+			inverse.cleanup();
+		}
+	});
+
+	it("uses startup.mode config at the scan consumer", async () => {
+		const env = setupTestEnvironment("pi-lens-startup-config-mode-");
+		const globalConfig = loadPiLensGlobalConfig(
+			path.join(env.tmpDir, "missing", "config.json"),
+		);
+		writeConfig(path.join(env.tmpDir, ".pi-lens.json"), {
+			startup: { mode: "quick" },
+		});
+		const projectConfig = loadPiLensProjectConfig(env.tmpDir);
+		try {
+			const result = await runSessionStart(
+				"full",
+				(tmpDir) => {
+					createTempFile(tmpDir, "package.json", "{}");
+					createTempFile(tmpDir, "src/index.ts", "export const value = 1;\n");
+				},
+				{
+					globalConfig,
+					projectConfig,
+					startupModeEnv: null,
+					getFlag: (name) =>
+						resolvePiLensFlag(name, undefined, globalConfig, projectConfig),
+				},
+			);
+			try {
+				expect(result.knipAnalyze).not.toHaveBeenCalled();
+				expect(result.dbg).toHaveBeenCalledWith(
+					"session_start startup mode: quick",
 				);
 			} finally {
 				await result.env.cleanup();
@@ -432,10 +525,17 @@ describe("fixture-loaded startup precedence", () => {
 				expect(result.dbg).toHaveBeenCalledWith(
 					"session_start startup mode: full",
 				);
-				await vi.waitFor(() =>
-					expect(result.dbg).toHaveBeenCalledWith(
-						"session_start knip: skipped (disabled by config)",
-					),
+				await waitForCondition(
+					() => result.dbg.mock.calls,
+					(calls) =>
+						calls.some(
+							([message]) =>
+								message === "session_start knip: skipped (disabled by config)",
+						),
+					{ timeoutMs: HEAVY_IO_TIMEOUT_MS },
+				);
+				expect(result.dbg).toHaveBeenCalledWith(
+					"session_start knip: skipped (disabled by config)",
 				);
 				expect(result.knipEnsure).not.toHaveBeenCalled();
 			} finally {
@@ -506,11 +606,49 @@ describe("fixture-loaded startup precedence", () => {
 				expect(result.dbg).not.toHaveBeenCalledWith(
 					"session_start: skipping LSP initialization (disabled by config)",
 				);
+				expect(result.knipAnalyze).not.toHaveBeenCalled();
+				expect(result.depEnsure).not.toHaveBeenCalled();
+				expect(result.astGrepEnsure).not.toHaveBeenCalled();
 			} finally {
 				await result.env.cleanup();
 			}
 		} finally {
 			env.cleanup();
+		}
+	});
+
+	it("records startup analyzer skips once per session and re-arms after reset", async () => {
+		const baseProjectConfig = loadPiLensProjectConfig(process.cwd());
+		const result = await runSessionStart(
+			"full",
+			(tmpDir) => {
+				createTempFile(tmpDir, "package.json", "{}");
+				createTempFile(tmpDir, "src/index.ts", "export const value = 1;\n");
+			},
+			{
+				projectConfig: {
+					...baseProjectConfig,
+					startup: { mode: "full", scans: { enabled: false } },
+				},
+				startupModeEnv: null,
+			},
+		);
+		try {
+			const first = getDegradationSummary().filter(
+				(entry) => entry.kind === "startup-analyzer-disabled",
+			);
+			expect(first).toHaveLength(1);
+			expect(first[0]?.latestReasons[0]?.subject).toBe("startup-scans");
+
+			resetDegradationLedger();
+			await result.repeatSessionStart();
+			const second = getDegradationSummary().filter(
+				(entry) => entry.kind === "startup-analyzer-disabled",
+			);
+			expect(second).toHaveLength(1);
+			expect(second[0]?.latestReasons[0]?.subject).toBe("startup-scans");
+		} finally {
+			await result.env.cleanup();
 		}
 	});
 });

--- a/tests/clients/runtime-session.test.ts
+++ b/tests/clients/runtime-session.test.ts
@@ -8,6 +8,16 @@ import {
 	saveProjectSnapshot,
 } from "../../clients/project-snapshot.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
+import { getDegradationSummary } from "../../clients/degradation-ledger.js";
+import {
+	loadPiLensGlobalConfig,
+	resolvePiLensFlag,
+	type PiLensGlobalConfig,
+} from "../../clients/lens-config.js";
+import {
+	loadPiLensProjectConfig,
+	type PiLensProjectConfig,
+} from "../../clients/project-lens-config.js";
 import { handleSessionStart } from "../../clients/runtime-session.js";
 import { _resetSlowFsForTests } from "../../clients/slow-fs.js";
 import { _resetSubagentModeForTests } from "../../clients/subagent-mode.js";
@@ -89,7 +99,7 @@ const EMPTY_KNIP_RESULT = {
 	summary: "skipped",
 };
 
-function setStartupMode(mode: "full" | "quick"): () => void {
+function setStartupMode(mode: "full" | "quick" | "minimal"): () => void {
 	const prev = process.env.PI_LENS_STARTUP_MODE;
 	process.env.PI_LENS_STARTUP_MODE = mode;
 	return () => {
@@ -98,12 +108,22 @@ function setStartupMode(mode: "full" | "quick"): () => void {
 	};
 }
 
+function writeConfig(filePath: string, config: Record<string, unknown>): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(config));
+}
+
 async function runSessionStart(
-	mode: "full" | "quick",
+	mode: "full" | "quick" | "minimal",
 	setup?: (tmpDir: string) => void,
 	overrides: {
 		astGrepEnsure?: () => Promise<boolean>;
 		scanExports?: () => Promise<Map<string, string>>;
+		getFlag?: (name: string) => boolean | string | undefined;
+		projectConfig?: PiLensProjectConfig;
+		globalConfig?: PiLensGlobalConfig;
+		startupModeOverride?: "full" | "quick" | "minimal";
+		startupModeEnv?: "full" | "quick" | "minimal" | null;
 	} = {},
 ) {
 	const env = setupTestEnvironment("pi-lens-runtime-session-");
@@ -145,7 +165,17 @@ async function runSessionStart(
 	const depEnsure = vi.fn(async () => false);
 	const resetLSPService = vi.fn();
 	const dbg = vi.fn();
-	const restoreStartupMode = setStartupMode(mode);
+	const restoreStartupMode =
+		overrides.startupModeEnv === null
+			? (() => {
+				const previous = process.env.PI_LENS_STARTUP_MODE;
+				delete process.env.PI_LENS_STARTUP_MODE;
+				return () => {
+					if (previous === undefined) delete process.env.PI_LENS_STARTUP_MODE;
+					else process.env.PI_LENS_STARTUP_MODE = previous;
+				};
+			})()
+			: setStartupMode(overrides.startupModeEnv ?? mode);
 	mockTouchFile.mockClear();
 
 	try {
@@ -153,10 +183,15 @@ async function runSessionStart(
 			withResidentBootstrap({
 				ctxCwd: env.tmpDir,
 				getFlag: (name: string) => {
+					const override = overrides.getFlag?.(name);
+					if (override !== undefined) return override;
 					if (name === "lens-lsp") return true;
 					if (name === "no-lsp") return false;
 					return false;
 				},
+				projectConfig: overrides.projectConfig,
+				globalConfig: overrides.globalConfig,
+				startupModeOverride: overrides.startupModeOverride,
 				notify,
 				dbg,
 				log: () => {},
@@ -311,6 +346,174 @@ it(
 	},
 	TEST_BUDGET_MS,
 );
+
+it("skips a disabled startup analyzer through session_start and records it", async () => {
+	const { env, knipEnsure, dbg } = await runSessionStart(
+		"full",
+		(tmpDir) => {
+			createTempFile(tmpDir, "package.json", JSON.stringify({}));
+			createTempFile(tmpDir, "src/index.ts", "export const value = 1;\n");
+		},
+		{ getFlag: (name) => name === "no-knip", startupModeOverride: "full" },
+	);
+	try {
+		await vi.waitFor(() =>
+			expect(dbg).toHaveBeenCalledWith(
+				"session_start knip: skipped (disabled by config)",
+			),
+		);
+		expect(knipEnsure).not.toHaveBeenCalled();
+		expect(
+			getDegradationSummary().some(
+				(entry) => entry.kind === "startup-analyzer-disabled",
+			),
+		).toBe(true);
+	} finally {
+		await env.cleanup();
+	}
+}, TEST_BUDGET_MS);
+
+describe("fixture-loaded startup precedence", () => {
+	it("gives PI_LENS_STARTUP_MODE precedence over startup.mode config", async () => {
+		const env = setupTestEnvironment("pi-lens-startup-env-precedence-");
+		const globalPath = path.join(env.tmpDir, "global", "config.json");
+		writeConfig(globalPath, { startup: { mode: "quick" } });
+		const globalConfig = loadPiLensGlobalConfig(globalPath);
+		const projectConfig = loadPiLensProjectConfig(env.tmpDir);
+		try {
+			const result = await runSessionStart(
+				"minimal",
+				(tmpDir) => createTempFile(tmpDir, "package.json", "{}"),
+				{
+					globalConfig,
+					projectConfig,
+					getFlag: (name) =>
+						resolvePiLensFlag(name, undefined, globalConfig, projectConfig),
+				},
+			);
+			try {
+				expect(result.dbg).toHaveBeenCalledWith(
+					"session_start startup mode: minimal",
+				);
+			} finally {
+				await result.env.cleanup();
+			}
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("gives project fixtures precedence over global config for a flag and mode", async () => {
+		const env = setupTestEnvironment("pi-lens-startup-project-precedence-");
+		const globalPath = path.join(env.tmpDir, "global", "config.json");
+		writeConfig(globalPath, {
+			knip: { enabled: true },
+			startup: { mode: "quick" },
+		});
+		writeConfig(path.join(env.tmpDir, ".pi-lens.json"), {
+			knip: { enabled: false },
+			startup: { mode: "full" },
+		});
+		const globalConfig = loadPiLensGlobalConfig(globalPath);
+		const projectConfig = loadPiLensProjectConfig(env.tmpDir);
+		try {
+			const result = await runSessionStart(
+				"full",
+				(tmpDir) => createTempFile(tmpDir, "package.json", "{}"),
+				{
+					globalConfig,
+					projectConfig,
+					startupModeEnv: null,
+					getFlag: (name) =>
+						resolvePiLensFlag(name, undefined, globalConfig, projectConfig),
+				},
+			);
+			try {
+				expect(result.dbg).toHaveBeenCalledWith(
+					"session_start startup mode: full",
+				);
+				await vi.waitFor(() =>
+					expect(result.dbg).toHaveBeenCalledWith(
+						"session_start knip: skipped (disabled by config)",
+					),
+				);
+				expect(result.knipEnsure).not.toHaveBeenCalled();
+			} finally {
+				await result.env.cleanup();
+			}
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("defaults absent keys to enabled analyzers and full startup", async () => {
+		const env = setupTestEnvironment("pi-lens-startup-defaults-");
+		const globalConfig = loadPiLensGlobalConfig(
+			path.join(env.tmpDir, "missing", "config.json"),
+		);
+		const projectConfig = loadPiLensProjectConfig(env.tmpDir);
+		try {
+			const result = await runSessionStart(
+				"full",
+				(tmpDir) => createTempFile(tmpDir, "package.json", "{}"),
+				{
+					globalConfig,
+					projectConfig,
+					getFlag: (name) =>
+						resolvePiLensFlag(name, undefined, globalConfig, projectConfig),
+				},
+			);
+			try {
+				expect(result.dbg).toHaveBeenCalledWith(
+					"session_start startup mode: full",
+				);
+				expect(result.dbg).not.toHaveBeenCalledWith(
+					"session_start knip: skipped (disabled by config)",
+				);
+			} finally {
+				await result.env.cleanup();
+			}
+		} finally {
+			env.cleanup();
+		}
+	});
+
+	it("keeps lens diagnostics and LSP alive when startup scans are disabled", async () => {
+		const env = setupTestEnvironment("pi-lens-startup-scans-disabled-");
+		writeConfig(path.join(env.tmpDir, ".pi-lens.json"), {
+			startup: { mode: "full", scans: { enabled: false } },
+		});
+		const globalConfig = loadPiLensGlobalConfig(
+			path.join(env.tmpDir, "missing", "config.json"),
+		);
+		const projectConfig = loadPiLensProjectConfig(env.tmpDir);
+		try {
+			const result = await runSessionStart(
+				"full",
+				(tmpDir) => createTempFile(tmpDir, "package.json", "{}"),
+				{
+					globalConfig,
+					projectConfig,
+					getFlag: (name) =>
+						resolvePiLensFlag(name, undefined, globalConfig, projectConfig),
+				},
+			);
+			try {
+				expect(result.resetLSPService).toHaveBeenCalled();
+				expect(result.dbg).toHaveBeenCalledWith(
+					"session_start: skipping startup background scans (disabled by config)",
+				);
+				expect(result.dbg).not.toHaveBeenCalledWith(
+					"session_start: skipping LSP initialization (disabled by config)",
+				);
+			} finally {
+				await result.env.cleanup();
+			}
+		} finally {
+			env.cleanup();
+		}
+	});
+});
 
 describe(
 	"runtime-session notifications",

--- a/tests/clients/runtime-tool-call.test.ts
+++ b/tests/clients/runtime-tool-call.test.ts
@@ -2,6 +2,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { CacheManager } from "../../clients/cache-manager.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../clients/degradation-ledger.js";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
 import { handleToolCall } from "../../clients/runtime-tool-call.js";
 import type { TreeSitterClient } from "../../clients/tree-sitter-client.js";
@@ -85,6 +89,30 @@ function baseDeps(
 }
 
 describe("handleToolCall", () => {
+	it("does not collect a complexity baseline when disabled", async () => {
+		resetDegradationLedger();
+		const env = setupTestEnvironment("pi-lens-runtime-tool-call-complexity-");
+		try {
+			const filePath = createTempFile(env.tmpDir, "src/disabled.ts", "const x = 1;\n");
+			const runtime = new RuntimeCoordinator();
+			runtime.projectRoot = env.tmpDir;
+			await handleToolCall(
+				baseDeps({
+					runtime,
+					getFlag: (name) => name === "no-complexity",
+					event: { toolName: "read", input: { filePath } },
+				}),
+			);
+			expect(runtime.complexityBaselines.has(filePath)).toBe(false);
+		expect(
+			getDegradationSummary().some(
+				(entry) => entry.kind === "startup-analyzer-disabled",
+			),
+		).toBe(true);
+		} finally {
+			env.cleanup();
+		}
+	});
 	it("is a no-op when lensEnabled is false", async () => {
 		const runtime = new RuntimeCoordinator();
 		const recordRead = vi.spyOn(runtime.readGuard, "recordRead");

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -829,7 +829,7 @@ const EXEMPT_SITES: Readonly<Record<string, SweepExemption>> = {
 				"budget many times over.",
 			owner: "#2523 slice 2",
 		},
-	"clients/runtime-session.ts#scheduleStartupScansWithClients:d7c597d6~b67d7877":
+	"clients/runtime-session.ts#d7c597d6~b67d7877":
 		{
 			family: "hook-await",
 			site: "session_start",


### PR DESCRIPTION
## Summary

Round 3 completes the prescribed contract-only verification for #2721. The
startup scan and mode tests now observe analyzer dispatch through
`handleSessionStart`, and the ledger reset is covered across repeated starts.
No production behavior changes are included.

Closes #2721

## Tests

The targeted runtime-session suite passes 20 of 21 tests. The one failure is
the documented pre-existing `quick mode hydrates cached exports and rules from
a fresh project snapshot` case, which also fails on `origin/master`.

Mutation transcripts, each after `npm run build`, with
`--configLoader runner`:

1. Shared seven-analyzer gate neutered: RED. `runtime-session.test.ts >
   fixture-loaded startup precedence > gives project fixtures precedence over
   global config for a flag and mode` reports scheduled analyzer work instead
   of the configured Knip skip.
2. `startupScansWillRun` forced true: RED.
   `runtime-session.test.ts > fixture-loaded startup precedence > keeps lens
   diagnostics and LSP alive when startup scans are disabled` fails at the
   `depEnsure` no-call assertion with one call.
3. Configured `startup.mode` lookup removed: RED. `runtime-session.test.ts >
   fixture-loaded startup precedence > uses startup.mode config at the scan
   consumer` fails because `knipAnalyze` runs in the mutated full path.
4. Tool-call complexity gate forced open: RED. `runtime-tool-call.test.ts >
   handleToolCall > does not collect a complexity baseline when disabled`
   reports an unexpected retained baseline.

The precedence-order mutation, with config evaluated before the environment,
is also RED: `runtime-session.test.ts > fixture-loaded startup precedence >
gives PI_LENS_STARTUP_MODE precedence through the scan consumer` observes
`knipAnalyze` despite `PI_LENS_STARTUP_MODE=quick`.

The repeated-session proof passes. Two `handleSessionStart` runs record exactly
one `startup-analyzer-disabled` row for `startup-scans` each; an explicit
`resetDegradationLedger()` re-arms the row before the second run.

Round-3 governance sweeps, after `npm run build`, with `--configLoader runner`:

1. `hook-await-bounds.test.ts`: RED on the stale named-function exemption and
   unregistered `clients/runtime-session.ts#d7c597d6~b67d7877`; GREEN after
   re-keying that existing exemption to the callback-free occurrence key.
2. `flake-shape-ratchet.test.ts`: RED on four raw timer waits and one risen
   `ungoverned-wait-for` count in `runtime-session.test.ts`; GREEN after removing
   the four fixed sleeps and using the sanctioned interleaving-kit `waitFor`.

## Blast radius

The changed production seam is not modified. Tests exercise `handleSessionStart`,
the deferred analyzer scheduler, the LSP reset, and the degradation ledger.
`AGENTS.md` only moves the startup-analyzer invariant after its complete
ledger sentence.

## Class sweep

The tests use the existing startup analyzer population and the shared scheduler
seams. No new analyzer key, config key, environment flag, spawn, or ledger kind
is introduced.

## Observability

The disabled-scan test asserts that heavyweight analyzer dispatch and deferred
availability probes do not occur while LSP initialization still runs. The
repeated-session test asserts the bounded ledger row and its session reset.

## Round 3

1. Finding 1: replaced log-only scan and mode checks with consumer-side
   scheduler assertions. The `startupScansWillRun` and config-lookup mutations
   are RED.
2. Finding 2: made env/config precedence drive quick-versus-full analyzer
   behavior, and added repeated-session ledger reset coverage. The
   precedence-order mutation is RED.
3. Finding 3: moved the analyzer-control paragraph after the complete ledger
   invariant sentence in `AGENTS.md`.
4. CI follow-up: repaired the stale hook-await exemption and governed the
   round-2 test polling and fixed-delay waits flagged by the two governance
   sweeps.

## Verification

`npm run build` passed. The targeted Vitest run passed 20 relevant tests and
retained only the documented pre-existing snapshot failure. `npm run lint` is
run on the changed files for this round.
