### PR TITLE
fix(hooks): guard-bash here-string and unclosed-substitution residuals (refs #2705, refs #2726)

### DIFF
--- a/.changelog/fix-2705-guard-bash-inert-regions.md
+++ b/.changelog/fix-2705-guard-bash-inert-regions.md
@@ -1,5 +1,4 @@
 ---
 section: Fixed
 ---
-- **Guard-bash preserves here-string boundaries and rejects malformed heredoc substitutions (refs #2705, #2726)** — `<<<` is consumed as a here-string operator instead of being re-read as a phantom heredoc delimiter, and an unclosed `$(` or backtick in an unquoted heredoc body is treated as non-executable by the scanner while later live commands remain classified.
-- **Guard-bash retains valid heredoc substitutions before malformed ones (refs #2705, #2726)** — a valid `$()` or backtick substitution discovered before a later unclosed substitution remains classified, while substitutions nested inside the malformed span remain inert like bash.
+- **Guard-bash preserves here-string boundaries and classifies heredoc substitutions the way bash expands them (refs #2705, #2726)** — `<<<` is consumed as a here-string operator instead of being re-read as a phantom heredoc delimiter; an unclosed `$(` or backtick in an unquoted heredoc body is treated as non-executable while later live commands remain classified; and a valid `$()` or backtick substitution discovered before a later unclosed one stays classified, with substitutions nested inside the malformed span kept inert like bash.

--- a/.changelog/fix-2705-guard-bash-inert-regions.md
+++ b/.changelog/fix-2705-guard-bash-inert-regions.md
@@ -2,3 +2,4 @@
 section: Fixed
 ---
 - **Guard-bash preserves here-string boundaries and rejects malformed heredoc substitutions (refs #2705, #2726)** — `<<<` is consumed as a here-string operator instead of being re-read as a phantom heredoc delimiter, and an unclosed `$(` or backtick in an unquoted heredoc body is treated as non-executable by the scanner while later live commands remain classified.
+- **Guard-bash retains valid heredoc substitutions before malformed ones (refs #2705, #2726)** — a valid `$()` or backtick substitution discovered before a later unclosed substitution remains classified, while substitutions nested inside the malformed span remain inert like bash.

--- a/.changelog/fix-2705-guard-bash-inert-regions.md
+++ b/.changelog/fix-2705-guard-bash-inert-regions.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- **Guard-bash preserves here-string boundaries and rejects malformed heredoc substitutions (refs #2705, #2726)** — `<<<` is consumed as a here-string operator instead of being re-read as a phantom heredoc delimiter, and an unclosed `$(` or backtick in an unquoted heredoc body is treated as non-executable by the scanner while later live commands remain classified.

--- a/scripts/hooks/guard-bash.mjs
+++ b/scripts/hooks/guard-bash.mjs
@@ -224,6 +224,8 @@ function parseHeredocMarker(text, start) {
  * @param {string[]} out flat sink for every substitution body found
  */
 function scanHeredocBodyForSubstitutions(body, out) {
+	/** @type {string[]} */
+	const found = [];
 	let i = 0;
 	while (i < body.length) {
 		const ch = body[i];
@@ -232,19 +234,22 @@ function scanHeredocBodyForSubstitutions(body, out) {
 			continue;
 		}
 		if (ch === "$" && body[i + 1] === "(") {
-			const span = lexRegions(body, i + 2, ")", out);
-			out.push(span.retained);
+			const span = lexRegions(body, i + 2, ")", found);
+			if (!span.closed) return;
+			found.push(span.retained);
 			i = span.end;
 			continue;
 		}
 		if (ch === "`") {
-			const span = lexRegions(body, i + 1, "`", out);
-			out.push(span.retained);
+			const span = lexRegions(body, i + 1, "`", found);
+			if (!span.closed) return;
+			found.push(span.retained);
 			i = span.end;
 			continue;
 		}
 		i++;
 	}
+	out.push(...found);
 }
 
 /**
@@ -308,7 +313,7 @@ function consumeHeredocBody(text, start, heredoc, out) {
  * @param {number} start
  * @param {")"|"`"|null} closer
  * @param {string[]} out
- * @returns {{ end: number; retained: string }}
+ * @returns {{ end: number; retained: string; closed: boolean }}
  */
 function lexRegions(text, start, closer, out) {
 	let retained = "";
@@ -360,7 +365,7 @@ function lexRegions(text, start, closer, out) {
 			continue;
 		}
 		if (closer === ")" && ch === ")") {
-			if (parenDepth === 0) return { end: i + 1, retained };
+			if (parenDepth === 0) return { end: i + 1, retained, closed: true };
 			parenDepth--;
 			retained += ch;
 			atWordStart = true;
@@ -374,7 +379,8 @@ function lexRegions(text, start, closer, out) {
 			i++;
 			continue;
 		}
-		if (closer === "`" && ch === "`") return { end: i + 1, retained };
+		if (closer === "`" && ch === "`")
+			return { end: i + 1, retained, closed: true };
 		if (ch === "\\" && text[i + 1] === "\n") {
 			i += 2;
 			continue;
@@ -391,6 +397,15 @@ function lexRegions(text, start, closer, out) {
 		if (ch === "#" && atWordStart) {
 			const nl = text.indexOf("\n", i);
 			i = nl === -1 ? text.length : nl;
+			continue;
+		}
+		if (ch === "<" && text[i + 1] === "<" && text[i + 2] === "<") {
+			// A here-string is a redirection with one word of input, not a
+			// heredoc marker. Consume all three '<' characters so the third
+			// one cannot be re-read as the start of a phantom delimiter.
+			retained += "<<<";
+			atWordStart = false;
+			i += 3;
 			continue;
 		}
 		if (ch === "<" && text[i + 1] === "<" && text[i + 2] !== "<") {
@@ -447,7 +462,7 @@ function lexRegions(text, start, closer, out) {
 		atWordStart = WORD_BREAK.test(ch);
 		i++;
 	}
-	return { end: i, retained };
+	return { end: i, retained, closed: closer === null };
 }
 
 /**

--- a/scripts/hooks/guard-bash.mjs
+++ b/scripts/hooks/guard-bash.mjs
@@ -234,15 +234,27 @@ function scanHeredocBodyForSubstitutions(body, out) {
 			continue;
 		}
 		if (ch === "$" && body[i + 1] === "(") {
-			const span = lexRegions(body, i + 2, ")", found);
-			if (!span.closed) return;
+			/** @type {string[]} */
+			const spanFound = [];
+			const span = lexRegions(body, i + 2, ")", spanFound);
+			if (!span.closed) {
+				out.push(...found);
+				return;
+			}
+			found.push(...spanFound);
 			found.push(span.retained);
 			i = span.end;
 			continue;
 		}
 		if (ch === "`") {
-			const span = lexRegions(body, i + 1, "`", found);
-			if (!span.closed) return;
+			/** @type {string[]} */
+			const spanFound = [];
+			const span = lexRegions(body, i + 1, "`", spanFound);
+			if (!span.closed) {
+				out.push(...found);
+				return;
+			}
+			found.push(...spanFound);
 			found.push(span.retained);
 			i = span.end;
 			continue;

--- a/tests/scripts/guard-bash-hook.test.ts
+++ b/tests/scripts/guard-bash-hook.test.ts
@@ -125,6 +125,10 @@ const DENY_CASES: Array<[command: string, ruleNeedle: string]> = [
 	// heredoc delimiter does not stop bash expanding $( ) in the body --
 	// verified by running it with a side-effecting stand-in.
 	["cat <<EOF\n$(git stash)\nEOF", "stash"],
+	// review round 2 F1: a valid substitution before an unclosed one must
+	// remain visible to the guard, because bash expands it before reporting
+	// the later malformed substitution.
+	["cat <<EOF\n$(git stash)\n$(echo harmless\nEOF\ngit diff", "stash"],
 	// W1 (#2726): a here-string is not a heredoc marker.  The command after
 	// it remains live and must still be classified.
 	["grep x <<< foo\ngit stash", "stash"],
@@ -199,6 +203,9 @@ const ALLOW_CASES: string[] = [
 	// unquoted heredoc body, but it does continue with a later live command.
 	"cat <<EOF\n$(git stash\nEOF\ngit diff",
 	"cat <<EOF\n`git stash\nEOF\ngit diff",
+	// Real bash reports the malformed outer substitution and does not run a
+	// nested substitution inside it.
+	"cat <<EOF\n$(echo x\n$(git stash)\nEOF",
 ];
 
 // Round-2 survey harness retained as a regression fixture for #2705. The

--- a/tests/scripts/guard-bash-hook.test.ts
+++ b/tests/scripts/guard-bash-hook.test.ts
@@ -129,6 +129,10 @@ const DENY_CASES: Array<[command: string, ruleNeedle: string]> = [
 	// remain visible to the guard, because bash expands it before reporting
 	// the later malformed substitution.
 	["cat <<EOF\n$(git stash)\n$(echo harmless\nEOF\ngit diff", "stash"],
+	// verify round 2: the backtick flush is a separate branch in the hook, so
+	// it needs its own case -- deleting only that branch left the `$( )` case
+	// green while this one allowed.
+	["cat <<EOF\n`git stash`\n`echo harmless\nEOF\ngit diff", "stash"],
 	// W1 (#2726): a here-string is not a heredoc marker.  The command after
 	// it remains live and must still be classified.
 	["grep x <<< foo\ngit stash", "stash"],

--- a/tests/scripts/guard-bash-hook.test.ts
+++ b/tests/scripts/guard-bash-hook.test.ts
@@ -125,6 +125,9 @@ const DENY_CASES: Array<[command: string, ruleNeedle: string]> = [
 	// heredoc delimiter does not stop bash expanding $( ) in the body --
 	// verified by running it with a side-effecting stand-in.
 	["cat <<EOF\n$(git stash)\nEOF", "stash"],
+	// W1 (#2726): a here-string is not a heredoc marker.  The command after
+	// it remains live and must still be classified.
+	["grep x <<< foo\ngit stash", "stash"],
 ];
 
 // Every allow string the issue lists, which must stay green.
@@ -192,6 +195,19 @@ const ALLOW_CASES: string[] = [
 	"gh pr create --body \"$(cat <<'EOF'\nsmiley :) here\nwe never run `git stash`\nEOF\n)\"",
 	// review round 3 (LX-10-1), through the real CLI: a `#` comment.
 	"echo hi # $(git stash)",
+	// W2 (#2726): real bash does not execute an unclosed substitution in an
+	// unquoted heredoc body, but it does continue with a later live command.
+	"cat <<EOF\n$(git stash\nEOF\ngit diff",
+	"cat <<EOF\n`git stash\nEOF\ngit diff",
+];
+
+// Round-2 survey harness retained as a regression fixture for #2705. The
+// 2026-09-07 corpus is the checked-in deny/allow corpus above; the GitHub
+// discussion that originally described the survey is not part of the repo.
+const SURVEY_CORPUS_DATE = "2026-09-07";
+const SURVEY_CORPUS = [
+	...DENY_CASES.map(([command]) => ({ command, expected: "deny" as const })),
+	...ALLOW_CASES.map((command) => ({ command, expected: "allow" as const })),
 ];
 
 describe("scripts/hooks/guard-bash.mjs -- deny list (#2699)", () => {
@@ -218,6 +234,24 @@ describe("scripts/hooks/guard-bash.mjs -- ambient PI_LENS_HOME (#2699)", () => {
 		});
 		expect(result.status).toBe(0);
 	});
+});
+
+describe("scripts/hooks/guard-bash.mjs -- round-2 survey corpus (#2705)", () => {
+	it.each(SURVEY_CORPUS)(
+		`keeps the ${SURVEY_CORPUS_DATE} corpus free of non-rule denies: $command`,
+		({ command, expected }) => {
+			const result = runHook(command);
+			if (expected === "allow") {
+				expect(result.status, command).toBe(0);
+				expect(result.stderr, command).toBe("");
+			} else {
+				expect(result.status, command).toBe(2);
+				expect(result.stderr.toLowerCase(), command).toMatch(
+					/stash|reset|worktree|probe/,
+				);
+			}
+		},
+	);
 });
 
 describe("scripts/hooks/guard-bash.mjs -- never throws (#2699)", () => {


### PR DESCRIPTION
## Summary

Fixes the round-2 heredoc substitution loss in `scripts/hooks/guard-bash.mjs`.
The scanner now retains substitutions found before a later malformed `$()` or
backtick span. It discards substitutions nested inside the malformed span,
matching bash behavior for the mirror case.

This round changes guard behavior and references #2705 and #2726. The PR does
not close either issue. The named remainder of #2705 is the requested
2026-09-07 session-transcript corpus survey. The checked-in 44-deny/32-allow
fixture is synthetic regression coverage, not that session-transcript survey.
The orchestrator must post that remainder on #2705.

The production hook measured 973 lines at `origin/master`, 988 lines at the
PR head before this round, and 1000 lines after this round. The documented
blind-spot list has four entries at both `origin/master` and this head, so no
blind spots were removed by the prior or current change.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:security
- [x] area:tests

## Checklist

- [x] I have read `CONTRIBUTING.md` and `AGENTS.md`
- [x] The change has a regression test for the bug
- [ ] Targeted Vitest passes locally; the offline grammar prefetch hung before results
- [x] The regression case has a pre-fix red proof
- [x] The new flush branches are mutation-proven
- [x] The PR title carries the issue references
- [ ] `npm run lint` was not run in this sandbox
- [x] `npm run build` succeeds
- [x] The changelog fragment is valid
- [x] The commit message references #2705 and #2726

## Tests

The edited `tests/scripts/guard-bash-hook.test.ts` drives the real hook CLI
through its PreToolUse JSON stdin and exit-code/stderr contract. The new case
pins a valid forbidden substitution before an unclosed substitution. It is
also added to the real deny corpus. The mirror case pins that an unclosed
outer substitution before a nested valid substitution remains allowed.

Red-first reproduction on the pre-fix hook:

```text
reviewer-probe-status=0
stderr: <empty>
```

The command was:

```text
cat <<EOF
$(git stash)
$(echo harmless
EOF
git diff
```

Post-fix direct hook probe:

```text
reviewer-probe-status=2
stderr: git stash is forbidden (CLAUDE.md non-negotiable) -- ...
backtick-probe-status=2
stderr: git stash is forbidden (CLAUDE.md non-negotiable) -- ...
mirror-status=0
stderr: <empty>
```

Real bash mirror probe:

```text
bash-mirror-status=0
bash-mirror-stdout=AFTER
bash-mirror-stderr=bash: command substitution: line 4: unexpected EOF while looking for matching `)'
```

The malformed outer substitution runs neither nested substitution. The hook
therefore allows the mirror case.

Mutation proof removed both `out.push(...found)` flushes. The same valid-before-
unclosed probe then produced:

```text
mutation-valid-before-unclosed-status=0
stderr: <empty>
```

This is red against the regression's required exit status 2. The flushes were
restored afterward.

Carried-over W1/W2 probes remain green:

```text
W1 status=2 stderr=git stash is forbidden (CLAUDE.md non-negotiable) -- ...
W2-dollar status=0 stderr=<empty>
W2-backtick status=0 stderr=<empty>
```

`npm run build` passed. `node scripts/check-changelog-fragments.mjs` passed
with `changelog fragments OK (10 entries in .changelog/)`. The instructed
Vitest command was attempted once with `--configLoader runner`; it printed the
offline tree-sitter grammar prefetch failures and hung before test results. It
was stopped after 36 seconds. The orchestrator must rerun it outside this
sandbox.

### Test assessment

- `tests/scripts/guard-bash-hook.test.ts`: uniquely pins the real hook's
  deny/allow CLI contract, including the new valid-before-malformed heredoc
  ordering and the real-bash mirror ordering. No existing test became
  redundant.

## Blast radius

The production module is the standalone `PreToolUse` Bash hook. Its entry
point reads JSON from stdin and writes one bounded rule message to stderr with
exit status 2 on denial; malformed input still exits 0. The changed helper is
called only by `consumeHeredocBody`, which is reached from `lexRegions` for
unquoted heredocs. No callers outside this scanner were found.

Call-tree diff:

```text
run -> classifyPayload -> scannableRegions -> lexRegions
                                      -> consumeHeredocBody
                                         -> scanHeredocBodyForSubstitutions
```

The helper runs once per unquoted heredoc body. The change adds a small
per-substitution array and does not add a process, filesystem, or network
operation. A repository `module_report` was unavailable in this sandbox, so
the caller sweep above is the available evidence.

## Observability

No new failure path or telemetry record exists. Denials continue to use the
existing bounded stderr rule message and exit status 2. Allows remain silent
with exit status 0. The regression observes both the discriminator message
and status through the real CLI.

## Class sweep

For the malformed-substitution class, the whole-tree search covered
`clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`, `tests/support/`, and the
guard test. It found one production scanner, two `!span.closed` branches in
that scanner, and the one real-CLI test family. No duplicate production seam
exists. The population sweep covers both substitution forms: `$()` and
backticks each flush previously found substitutions and each has a direct
post-fix probe. The family stays on one scanner seam.

## Round 2

1. Finding 1: flushed `found` before returning from both malformed `$()` and
   backtick paths; isolated nested discoveries so the mirror case matches
   bash; added the deny regression and the mirror allow case; recorded red,
   post-fix, and mutation probes.
2. Finding 2: stated plainly that the 44/32 checked-in fixture is synthetic
   and that the 2026-09-07 session-transcript survey remains a `refs #2705`
   issue remainder.
3. Finding 3: recomputed measurements from `origin/master` and this head:
   973 lines at origin, 988 before this round, 1000 after this round, and
   four documented blind spots at both endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV
