### PR TITLE
test(sweep-floor): match floor calls over blanked source (#2710)

### DIFF
--- a/.changelog/2710-sweep-floor-comment-blank.md
+++ b/.changelog/2710-sweep-floor-comment-blank.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **The sweep-floor meta-sweep now matches floor calls over comment- and string-blanked source (closes #2710)** — the meta-sweep registered a test file as floor-covered whenever `/assertNonEmptyScan\s*\(/` or the `auditRegistry({…minScanned…})` pattern matched its raw source, so a docblock merely quoting the helper name excused a sweep that made no real floor call (AGENTS.md shape 38; the same raw-vs-blanked mismatch #2693 round 2 F1 fixed in the runner-spawn-cwd sweep). Registration now runs through `stripSource`, and fixture tests pin that a prose-only mention is reported uncovered while a real call still registers.

--- a/tests/config/sweep-floor-coverage.test.ts
+++ b/tests/config/sweep-floor-coverage.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -24,6 +25,9 @@ const SELF = "tests/config/sweep-floor-coverage.test.ts";
  * intent. Exported as a pure function (source in, boolean out) so the
  * emptiness alternation can be unit-tested against literal snippets, not
  * only inferred from a whole-tree census.
+ * Floor-call registration matches over comment/string-blanked source so
+ * a call named only in prose cannot self-register (#2710; AGENTS.md
+ * shape 38, #2693 r2 F1).
  */
 export function looksSweepShaped(source: string): boolean {
 	const enumerates =
@@ -43,6 +47,21 @@ export function looksSweepShaped(source: string): boolean {
 			source,
 		);
 	return enumerates && empties;
+}
+
+/**
+ * Does this sweep-shaped file make a real sweep-kit floor call? #2710:
+ * matched over stripSource-blanked source (AGENTS.md shape 38; the
+ * raw-vs-blanked mismatch #2693 r2 F1 fixed in the runner-spawn-cwd sweep)
+ * so a helper name quoted in a comment or string cannot register a file
+ * that never called it.
+ */
+function isRegisteredFloorSource(source: string): boolean {
+	const stripped = stripSource(source);
+	return (
+		/assertNonEmptyScan\s*\(/.test(stripped) ||
+		/auditRegistry\s*\(\s*\{[\s\S]*?\bminScanned\s*:/.test(stripped)
+	);
 }
 
 function sweepShapeFiles(): string[] {
@@ -173,13 +192,11 @@ describe("registered-or-fail sweep floors", () => {
 		const files = sweepShapeFiles().map((file) =>
 			relativePosix(REPO_ROOT, file),
 		);
-		const registered = files.filter((file) => {
-			const source = fs.readFileSync(path.join(REPO_ROOT, file), "utf8");
-			return (
-				/assertNonEmptyScan\s*\(/.test(source) ||
-				/auditRegistry\s*\(\s*\{[\s\S]*?\bminScanned\s*:/.test(source)
-			);
-		});
+		const registered = files.filter((file) =>
+			isRegisteredFloorSource(
+				fs.readFileSync(path.join(REPO_ROOT, file), "utf8"),
+			),
+		);
 		const scannedCount = listSourceFiles(TESTS_ROOT, {
 			extensions: [".ts"],
 		}).filter((file) => file.endsWith(".test.ts")).length;
@@ -242,5 +259,92 @@ describe("looksSweepShaped emptiness detection (#2088 fix round 3, R1)", () => {
 
 	it("does not flag an emptiness assertion with no enumeration", () => {
 		expect(looksSweepShaped("expect(x.length).toBe(0);")).toBe(false);
+	});
+});
+
+describe("floor-call registration over blanked source (#2710)", () => {
+	// Red-first proof for the #2710 recurrence: a sweep file whose only
+	// floor-call mention lives in a comment or a string must stay
+	// unregistered, and the same file with a real call must register. The
+	// file-level fixture drives the same walk/detect/register/audit
+	// pipeline as the meta-sweep above over real fixture files on disk.
+	const commentOnlyFixture = [
+		`import * as fs from "node:fs";`,
+		`import { assertNonEmptyScan } from "../support/sweep-kit.js";`,
+		`describe("fixture", () => {`,
+		`\tit("scans", () => {`,
+		`\t\t// Registered via assertNonEmptyScan("fixture", files.length);`,
+		`\t\tconst files = fs.readdirSync(dir);`,
+		`\t\texpect(violations).toEqual([]);`,
+		`\t});`,
+		`});`,
+		`const note = "quoted: assertNonEmptyScan(x)";`,
+	].join("\n");
+	const realCallFixture = [
+		`import * as fs from "node:fs";`,
+		`import { assertNonEmptyScan } from "../support/sweep-kit.js";`,
+		`describe("fixture", () => {`,
+		`\tit("scans", () => {`,
+		`\t\tconst files = fs.readdirSync(dir);`,
+		`\t\texpect(violations).toEqual([]);`,
+		`\t\tassertNonEmptyScan("fixture", files.length);`,
+		`\t});`,
+		`});`,
+	].join("\n");
+
+	it("does not register a floor call named only in a comment", () => {
+		expect(
+			isRegisteredFloorSource(`// registered via assertNonEmptyScan("x", 1);`),
+		).toBe(false);
+	});
+
+	it("does not register a floor call quoted inside a string", () => {
+		expect(
+			isRegisteredFloorSource(
+				`const note = "call assertNonEmptyScan(x) here";`,
+			),
+		).toBe(false);
+	});
+
+	it("registers a real assertNonEmptyScan floor call", () => {
+		expect(isRegisteredFloorSource(`assertNonEmptyScan("x", 1);`)).toBe(true);
+	});
+
+	it("registers a real auditRegistry minScanned floor call", () => {
+		expect(
+			isRegisteredFloorSource(
+				`const audit = auditRegistry({ flagged, minScanned: 420 });`,
+			),
+		).toBe(true);
+	});
+
+	it("reports a prose-only fixture sweep file uncovered and passes a real call", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "sweep-floor-2710-"));
+		try {
+			fs.writeFileSync(
+				path.join(root, "comment-only.test.ts"),
+				commentOnlyFixture,
+			);
+			fs.writeFileSync(path.join(root, "real-call.test.ts"), realCallFixture);
+			const flagged = listSourceFiles(root, { extensions: [".ts"] }).filter(
+				(file) => looksSweepShaped(stripSource(fs.readFileSync(file, "utf8"))),
+			);
+			expect(flagged.map((file) => relativePosix(root, file))).toEqual([
+				"comment-only.test.ts",
+				"real-call.test.ts",
+			]);
+			const registered = flagged.filter((file) =>
+				isRegisteredFloorSource(fs.readFileSync(file, "utf8")),
+			);
+			const audit = auditRegistry({
+				sweepName: "#2710 fixture sweep",
+				flagged: flagged.map((file) => relativePosix(root, file)),
+				registered: registered.map((file) => relativePosix(root, file)),
+				exemptions: {},
+			});
+			expect(audit.unaccounted).toEqual(["comment-only.test.ts"]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 });


### PR DESCRIPTION
## Summary

The sweep-floor meta-sweep registered a test file as floor-covered whenever `/assertNonEmptyScan\s*\(/` or the `/auditRegistry\s*\(\s*\{[\s\S]*?\bminScanned\s*:/` pattern matched its RAW source — comments and string contents included. A sweep file whose docblock merely quotes the helper name excused itself without making one real floor call, silently defeating the meta-sweep's own emptiness guard (AGENTS.md defect shape 38; the same raw-vs-blanked mismatch #2693 round 2 F1 fixed in the runner-spawn-cwd sweep).

The registration matcher now runs over `stripSource`-blanked source (default `"blank"` policy: comments and string contents blanked, delimiters kept). The matching logic moved byte-identically into a module-local `isRegisteredFloorSource(source)` helper so the new fixture tests drive the exact seam the meta-sweep drives.

All three acceptance criteria are met: the match runs over comment-and-string-blanked source; a fixture sweep file with the call only in prose is reported uncovered while the same file with a real call passes; the test header carries the one-line recurrence note.

Closes #2710. The three additional raw-source members the class sweep found are filed as 2736 (deliberately not folded into this PR — see Class sweep).

## Type of change

- [x] Bug fix

## Area

- [x] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (regression tests proven red on pre-fix code)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [ ] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts` — N/A: test-only change
- [ ] `package-lock.json` is in sync with `package.json` — N/A: no dependency change
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there — no documented behavior changes; the shape-38 catalog entry already covers this class
- [x] `.changelog/<branch-or-slug>-<short-desc>.md` has one valid entry **in this PR**
- [x] Commit subject includes the issue number: `(closes #2710)`

## Tests

The only changed file is `tests/config/sweep-floor-coverage.test.ts` (plus the changelog fragment).

- **EDIT — meta-sweep registration (`registered` filter):** the two floor-call regexes moved byte-identically into `isRegisteredFloorSource(source)`, which now strips with `stripSource` before matching. Red-first was captured with the helper extracted but still matching RAW source: the extraction-only state reproduces pre-fix behavior exactly (all 7 pre-existing tests stayed green through it, including the meta-sweep over the real tree), and the new tests cannot execute against the unextracted file because the seam they drive did not exist.
- **NEW — `does not register a floor call named only in a comment`:** pins the comment-laundering vector: `// registered via assertNonEmptyScan("x", 1);` must not register.
- **NEW — `does not register a floor call quoted inside a string`:** pins the string-laundering vector: `"call assertNonEmptyScan(x) here"` must not register.
- **NEW — `registers a real assertNonEmptyScan floor call`:** guards the fix's false-negative direction — a real call still registers over blanked source.
- **NEW — `registers a real auditRegistry minScanned floor call`:** same guard for the second registration spelling, whose property keys are code and must survive blanking.
- **NEW — `reports a prose-only fixture sweep file uncovered and passes a real call`:** file-level end-to-end over real fixture files in a temp dir, driving the same walk/detect/register/audit pipeline as the meta-sweep (`listSourceFiles` → `looksSweepShaped(stripSource(…))` → `isRegisteredFloorSource` → `auditRegistry`); asserts `audit.unaccounted` equals exactly `["comment-only.test.ts"]`, which simultaneously proves the prose-only file is flagged, unregistered, and reported, and that the real-call file registered (flagged but absent from `unaccounted`).

Screen mapping (AGENTS.md test-authoring screens): screen 1 (parallel path) — the file-level test enters through the same functions the meta-sweep enters; screen 5 (env leakage) — no env mutation, temp dir removed in `finally`; no mocks and independent expected constants (screens 7/9); behavioral assertions, not throw-checks (screen 8); no skips (screen 2 n/a); no clocks, spawns, or waits (flake-shape ratchet n/a).

### Red-first (matcher extracted, raw source — pre-fix behavior)

```
 FAIL  |default| tests/config/sweep-floor-coverage.test.ts > floor-call registration over blanked source (#2710) > does not register a floor call named only in a comment
AssertionError: expected true to be false // Object.is equality
- Expected + Received
- false + true
 ❯ tests/config/sweep-floor-coverage.test.ts:297:5

 FAIL  |default| tests/config/sweep-floor-coverage.test.ts > floor-call registration over blanked source (#2710) > does not register a floor call quoted inside a string
AssertionError: expected true to be false // Object.is equality
- Expected + Received
- false + true
 ❯ tests/config/sweep-floor-coverage.test.ts:303:5

 FAIL  |default| tests/config/sweep-floor-coverage.test.ts > floor-call registration over blanked source (#2710) > reports a prose-only fixture sweep file uncovered and passes a real call
AssertionError: expected [] to deeply equal [ 'comment-only.test.ts' ]
- Expected + Received
- [ "comment-only.test.ts" ] + []
 ❯ tests/config/sweep-floor-coverage.test.ts:342:30

 Test Files  1 failed (1)
      Tests  3 failed | 7 passed (10)
```

(The 7 passing tests include the meta-sweep "every sweep-shaped test uses sweep-kit or declares a reason" over the real tree — the extraction is behavior-preserving.)

### Green (blanking applied)

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

### Mutation (blanking reverted — the same three tests red again)

```
 ❯ |default| tests/config/sweep-floor-coverage.test.ts (10 tests | 3 failed) 297ms
     × does not register a floor call named only in a comment 4ms
     × does not register a floor call quoted inside a string 0ms
     × reports a prose-only fixture sweep file uncovered and passes a real call 2ms
 Test Files  1 failed (1)
      Tests  3 failed | 7 passed (10)
```

(Full assertion blocks identical to the red-first run, at lines 297/303/342.)

### Population census (raw vs stripped, every test file)

A jiti-run script importing the real `stripSource` from `tests/support/sweep-kit.ts` and applying both registration regexes raw and stripped over every `*.test.ts` under `tests/`:

```
checked 1036 test files, 0 raw-vs-stripped registration diffs
```

No file matches raw-but-not-stripped, so no currently-registered file changes state post-fix and the calibration floors (minScanned 420, minFlagged 29, 13 registered / 45 exemptions) hold unchanged.

Safety batch (content-scanning governance sweeps that walk `tests/` source, run after the fix): `sweep-floor-coverage` + `tracked-control-bytes` + `vacuous-skip-coverage` + `module-instance-coverage` + `escape-regexp-fold-sweep` — `Test Files  5 passed (5)`, `Tests  27 passed (27)`. The full suite is CI's job per the brief.

### Test assessment

`tests/config/sweep-floor-coverage.test.ts` uniquely pins the registered-or-fail meta-sweep's detection stack: sweep-shape flagging (including the #2088 R1 emptiness spellings), floor-call registration (now blanked-source, #2710), and the calibration floors. No test in it was made redundant and no removal candidates surfaced — every case reds on at least one mutation of the matching it pins (the three prose cases red on the blanking revert, shown above; the two real-call cases pin the opposite direction at the unit level and were not separately mutation-run — over-blanking produces a loud false red, not a silent pass).

## Blast radius

Test-only change: no production module is touched, so a production blast-radius map is empty/unavailable by construction (no production symbol changed). The only consumer of the changed seam is the meta-sweep's own `it` in the same file. Calibration surfaces (flagged/scanned counts, the exemption table) are unaffected per the census above. The file-level fixture writes two files under `os.tmpdir()` (mkdtemp) and removes them in `finally`; nothing is written into the repo tree. No hot path is touched.

## Observability

Not applicable in the latency-log/ledger sense — test-infrastructure change, no production failure path. The guard's own record is `auditRegistry`'s composed problem message: the new file-level fixture asserts it (`audit.unaccounted` names the prose-only file), and on the real tree the same "N flagged item(s) are neither registered nor exempted" message is what a future laundered registration would produce.

## Class sweep

Defect shape: AGENTS.md shape 38 (a guard that prose satisfies away), via sweep-kit's documented "comment/string laundering" attack (#1635 R1, #1692 F1); the same raw-vs-blanked mismatch #2693 round 2 F1 fixed.

Pattern and population sweep over the whole test-side detector family (every file under `tests/` that reads other files' source and applies regexes to it, each inspected for raw-vs-stripped/mechanism): 3 additional SELF-EXCUSE-direction members — `git-fixture-governance.test.ts`'s `helperImport` exemption matcher over raw source, `ndjson-writer-conformance.test.ts`'s positive requirements over raw source, `run-outcome-ratchet.test.ts`'s admission needle over raw source — plus 8 false-positive-direction/mitigated members (module-instance-scan, mutating-tool-classification, timing-sensitive-coverage, freshness-sweep, managed-tool-seam-coverage, session-event-guard-sweep's wrapped check, bus-producer-coverage, flake-shape-scan's admission header) and a SAFE census (vacuous-skip-scan, spawn-cwd-scan, host-event-shape-scan, lsp-double-gate, escape-regexp-fold-sweep, bounded-eviction-idiom-sweep, tracked-control-bytes, label-manifest-coverage, gitignore-tracked-shadow, generation-guard-sweep, diagnostics-bus-conformance, workspace-topology-conformance, finding-delivery-gate, public-surface-drift). Full per-member table with quotes: 2736.

Consolidation verdict: fold the text-sweep family onto sweep-kit's `stripSource` (28 files already import it; the kit's two string policies cover both needle directions), lifting `lsp-double-gate.ts`'s comment-vs-literal discriminator (#2585 R4 F3) into the kit as the one marker primitive for `flake-shape-scan.ts`'s admission header. AST-, byte-, and tool-backed matchers stay distributed (prose-proof by construction). The three NEEDS-FIX members and the fold are filed as 2736, deliberately not fixed here per the brief's scope: this PR is the sweep-floor fix, not the sweep-kit refactor.



> Review-round-1 correction (orchestrator): the "13 registered / 45 exemptions" figures above are the 2026-08-27 calibration comment; the reviewer's census of today's tree measures 39 registered / 52 exemptions / 91 shaped with 0 raw-vs-stripped diffs. The floors (minScanned 420, minFlagged 29) are unaffected. Red-run line numbers at HEAD are 298/306/345.
