### PR TITLE
docs(contracts): handoff files for workers without Git authority (refs #2733)

### DIFF
--- a/.changelog/docs-delegated-handoff-files.md
+++ b/.changelog/docs-delegated-handoff-files.md
@@ -1,0 +1,4 @@
+---
+section: Changed
+---
+- **Delegated-worker contract: handoff files for workers without Git authority (refs #2733, #2721)** — `docs/pi-lens-subagent.md` and the AGENTS.md role-contract section now name the `PR_BODY.md` / `COMMIT_MSG.txt` worktree-root handoff the orchestrator commits from, and the sandbox test incantation (`--configLoader runner`, offline grammar prefetch) that plegma codex workers need.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,10 @@ if a daemon copy has drifted.
 
 Name the role, absolute worktree, branch, base, acceptance criteria, non-goals,
 and Git authority in every delegation. A role never grants Git authority by
-itself. Follow "Prove filesystem isolation before coding subagents touch Git":
+itself. When authority is withheld, the worker hands off through `PR_BODY.md`
+and `COMMIT_MSG.txt` at the worktree root (see `docs/pi-lens-subagent.md`) and
+the orchestrator commits with `git push origin HEAD:<branch>` from a detached
+worktree (2026-09-08: seven PRs landed this way through plegma codex workers). Follow "Prove filesystem isolation before coding subagents touch Git":
 if the worker cannot verify a distinct registered worktree, it runs no Git
 commands, and the orchestrator owns commits, pushes, and PR operations.
 

--- a/docs/pi-lens-subagent.md
+++ b/docs/pi-lens-subagent.md
@@ -30,7 +30,18 @@ real store, sink, coordinator, or registry, use it and assert the durable result
 Git authority is separate from the role. Commit, push, or open a PR only when
 the delegation explicitly grants that authority after worktree verification.
 Otherwise, edit and test with the assigned worktree as the command working
-directory, then return the patch and evidence to the orchestrator. Never merge.
+directory, leave every change uncommitted, and write two handoff files at the
+worktree root: `PR_BODY.md` (the full PR body, transcripts pasted) and
+`COMMIT_MSG.txt` (subject, body, issue ref, trailers). Name any path inside the
+worktree that must not be committed. The orchestrator commits from those files;
+they are never committed themselves. Never merge.
+
+A sandboxed worker may find the shared `.git` and the linked `node_modules`
+read-only and the network absent (the codex `workspace-write` sandbox does
+this; see plegma#311). Run Vitest as
+`node_modules/.bin/vitest run <files> --configLoader runner`, and if the
+tree-sitter grammar prefetch hangs offline, verify through direct probes of the
+built code and say so; the orchestrator re-runs the files outside the sandbox.
 
 When Git authority is granted, use one logical commit with an imperative,
 conventional-prefix subject of at most 50 characters, a blank line, and a


### PR DESCRIPTION
## Summary
Folds this session's recurring pattern into the contracts (feedback-evolve-workflow duty): plegma codex workers cannot commit, push, or reach the network (plegma#311), so every fix tonight was handed off through `PR_BODY.md` + `COMMIT_MSG.txt` at the worktree root and committed by the orchestrator with `git push origin HEAD:<branch>`. `docs/pi-lens-subagent.md` now states that convention and the sandbox Vitest incantation; the AGENTS.md role-contract paragraph points at it.

## Tests
Docs only (Tier C). `node scripts/check-changelog-fragments.mjs` OK. No code path changes.

## Blast radius
`docs/pi-lens-subagent.md` (delegated-worker contract, also the daemon-side copy under `~/.plegma/contracts/` is re-synced from it), `AGENTS.md` role-contracts section, one changelog fragment.

## Class sweep
The fixer/reviewer playbooks under `.claude/agents/` already describe worktree isolation and probe hygiene; they do not need the handoff text because the contract they pair with now carries it.

## Observability
n/a (docs).

## Test assessment
n/a (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV