### PR TITLE
fix(glob): collapse adjacent wildcards in read-guard and file-utils (closes #2622)

### DIFF
--- a/.changelog/fix-2622-glob-adjacent-stars.md
+++ b/.changelog/fix-2622-glob-adjacent-stars.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- **Read-guard exemption globs and the file-utils directory glob no longer backtrack on adjacent wildcards (closes #2622)** — runs of adjacent `*` are collapsed to one before compiling, which is semantically identical for the `*`-only dialect and removes the polynomial backtracking (a 12-star pattern against a 40-component path went from tens of seconds to ~2 ms); a differential corpus pins both matchers' answers unchanged.

--- a/.changelog/fix-2622-glob-adjacent-stars.md
+++ b/.changelog/fix-2622-glob-adjacent-stars.md
@@ -1,4 +1,4 @@
 ---
 section: Fixed
 ---
-- **Read-guard exemption globs and the file-utils directory glob no longer backtrack on adjacent wildcards (closes #2622)** — runs of adjacent `*` are collapsed to one before compiling, which is semantically identical for the `*`-only dialect and removes the polynomial backtracking (a 12-star pattern against a 40-component path went from tens of seconds to ~2 ms); a differential corpus pins both matchers' answers unchanged.
+- **Read-guard exemption globs and the file-utils directory glob no longer backtrack on adjacent wildcards (closes #2622)** — runs of adjacent `*` are collapsed to one before compiling, which is semantically identical for the `*`-only dialect and removes the measured backtracking (a 12-star pattern against a 40-component path took >15 s before the fix and ~2 ms after it); a differential corpus pins both matchers' answers unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -865,6 +865,14 @@ or merge restoration, and writes under already-ignored directories remain
 outside the tool-result producer and are tracked by the freshness-probe issue.
 (#2071)
 
+The `*`-only glob compilers in `clients/read-guard.ts` and
+`clients/file-utils.ts` collapse adjacent wildcard runs before constructing a
+regex. `.*.*` has the same language as `.*`, but the former can partition a
+long non-match exponentially. Keep this dialect local; do not introduce
+`**` semantics or fold it into the workspace-member matcher. The regression
+corpus and wall-clock pin live in
+`tests/clients/read-guard-glob-nonbacktracking.test.ts` (#2622).
+
 Consumed nested `.gitignore` sources carry their build-time `mtimeMs` and size
 in the project matcher cache. `getProjectIgnoreMatcher` sweeps those sources
 at most once per root per two-second cadence and routes drift, including

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -988,7 +988,8 @@ function globToRegExp(glob: string): RegExp {
 	// Directory names use the same `*`-only dialect as read-guard exemptions.
 	// Collapse adjacent stars before compiling to avoid nullable-group
 	// backtracking on a non-matching name (#2622).
-	const escaped = glob.replace(/\*+/g, "*")
+	const escaped = glob
+		.replace(/\*+/g, "*")
 		.replace(/[.+^${}()|[\]\\]/g, "\\$&")
 		.replace(/\*/g, ".*")
 		.replace(/\?/g, ".");

--- a/clients/file-utils.ts
+++ b/clients/file-utils.ts
@@ -985,7 +985,10 @@ export function readGitignoreDirs(rootDir: string): string[] {
 }
 
 function globToRegExp(glob: string): RegExp {
-	const escaped = glob
+	// Directory names use the same `*`-only dialect as read-guard exemptions.
+	// Collapse adjacent stars before compiling to avoid nullable-group
+	// backtracking on a non-matching name (#2622).
+	const escaped = glob.replace(/\*+/g, "*")
 		.replace(/[.+^${}()|[\]\\]/g, "\\$&")
 		.replace(/\*/g, ".*")
 		.replace(/\?/g, ".");

--- a/clients/read-guard.ts
+++ b/clients/read-guard.ts
@@ -1890,9 +1890,12 @@ export class ReadGuard {
 			return filePath.endsWith(suffix);
 		}
 		if (pattern.includes("*")) {
-			// Convert glob to regex
+			// Adjacent stars are equivalent to one star in this dialect. Collapse
+			// them before compiling so a non-match cannot backtrack over every
+			// nullable `.*` group (#2622).
+			const collapsedPattern = pattern.replace(/\*+/g, "*");
 			const regex = new RegExp(
-				`^${pattern.replace(/\\/g, "\\\\").replace(/\./g, "\\.").replace(/\*/g, ".*")}$`,
+				`^${collapsedPattern.replace(/\\/g, "\\\\").replace(/\./g, "\\.").replace(/\*/g, ".*")}$`,
 			);
 			return regex.test(filePath);
 		}

--- a/tests/clients/flake-shape-ratchet.test.ts
+++ b/tests/clients/flake-shape-ratchet.test.ts
@@ -134,6 +134,13 @@ const ADMITTED_AFTER_BASELINE: Readonly<
 			reason:
 				"the defect is wall-clock only (2^N globstar backtracking); a fake clock measures nothing",
 		},
+	// 2026-09-08 (#2622): the defect is wall-clock only — 2^N regex
+	// backtracking in both glob compilers; a fake clock measures nothing.
+	"elapsed-time-assertion:clients/read-guard-glob-nonbacktracking.test.ts": {
+		detector: "elapsed-time-assertion",
+		reason:
+			"the defect is wall-clock only (2^N regex backtracking); a fake clock measures nothing",
+	},
 	// 2026-09-06 (#2619 review F1, then N1/N3 in round 3): three real spawns,
 	// each pinning something no in-process double can reach. (1) a `node -e`
 	// child reports what IT resolved for HOME/PI_LENS_INSTALL_LOG — `os.homedir()`

--- a/tests/clients/read-guard-glob-nonbacktracking.test.ts
+++ b/tests/clients/read-guard-glob-nonbacktracking.test.ts
@@ -33,9 +33,7 @@ function readGuardMatch(filePath: string, pattern: string): boolean {
 	return (
 		createReadGuard("read-guard-glob-differential", {
 			exemptions: [{ pattern, mode: "allow" }],
-		})
-			.checkEdit(filePath)
-			.action === "allow"
+		}).checkEdit(filePath).action === "allow"
 	);
 }
 
@@ -126,6 +124,17 @@ describe("adjacent wildcard glob compilers (#2622)", () => {
 		const matched = readGuardMatch(filePath, pattern);
 		const elapsed = performance.now() - started;
 
+		expect(matched).toBe(false);
+		expect(elapsed).toBeLessThan(BUDGET_MS);
+	});
+
+	it(`answers a ${ADJACENT_STARS}-star directory-name miss within ${BUDGET_MS}ms`, () => {
+		const candidate = "cache" + "x".repeat(245);
+		const started = performance.now();
+		const matched = isExcludedDirName(candidate, ["cache************tmp"]);
+		const elapsed = performance.now() - started;
+
+		// Keep deliberate headroom for scheduler contention in the serialized lane.
 		expect(matched).toBe(false);
 		expect(elapsed).toBeLessThan(BUDGET_MS);
 	});

--- a/tests/clients/read-guard-glob-nonbacktracking.test.ts
+++ b/tests/clients/read-guard-glob-nonbacktracking.test.ts
@@ -1,0 +1,132 @@
+// flake-shape: elapsed-time-assertion — the defect under test is regex
+// backtracking. A mocked clock cannot observe the synchronous matcher cost.
+
+/**
+ * #2622 — adjacent wildcard runs in the read-guard and directory-name glob
+ * compilers must not create one nullable regex group per star.
+ *
+ * Both dialects have only `*` wildcards. Collapsing a run of adjacent stars is
+ * therefore language-preserving: `.*.*` and `.*` accept exactly the same
+ * strings, while the latter has no exponential partitioning choices.
+ */
+
+import { describe, expect, it } from "vitest";
+import { isExcludedDirName } from "../../clients/file-utils.js";
+import { createReadGuard } from "../../clients/read-guard.js";
+
+const ADJACENT_STARS = 12;
+const PATH_COMPONENTS = 40;
+const BUDGET_MS = 500;
+
+function oldReadGuardMatch(filePath: string, pattern: string): boolean {
+	if (pattern.startsWith("*")) return filePath.endsWith(pattern.slice(1));
+	if (pattern.includes("*")) {
+		const regex = new RegExp(
+			`^${pattern.replace(/\\/g, "\\\\").replace(/\./g, "\\.").replace(/\*/g, ".*")}$`,
+		);
+		return regex.test(filePath);
+	}
+	return filePath === pattern;
+}
+
+function readGuardMatch(filePath: string, pattern: string): boolean {
+	return (
+		createReadGuard("read-guard-glob-differential", {
+			exemptions: [{ pattern, mode: "allow" }],
+		})
+			.checkEdit(filePath)
+			.action === "allow"
+	);
+}
+
+function oldDirectoryNameMatch(candidate: string, pattern: string): boolean {
+	const escaped = pattern
+		.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+		.replace(/\*/g, ".*")
+		.replace(/\?/g, ".");
+	return new RegExp(`^${escaped}$`, "i").test(candidate);
+}
+
+function directoryNameMatch(candidate: string, pattern: string): boolean {
+	return isExcludedDirName(candidate, [pattern]);
+}
+
+const readGuardCorpus = [
+	"src/*/secret",
+	"src/**/secret",
+	"src************/secret",
+	"src/**/**/secret",
+	"*.md",
+	"/src/api.ts",
+	"literal.with.dots",
+];
+
+const directoryNameCorpus = [
+	"*.dSYM",
+	"cache**tmp",
+	"cache************tmp",
+	"?odule",
+	"literal.with.dots",
+	"excluded-dir-2622",
+];
+
+const subjectCorpus = [
+	"src/secret",
+	"src/a/secret",
+	"src/a/b/secret",
+	"srcXXXXXXXXXXXX/secret",
+	"src/not-secret",
+	"/docs/readme.md",
+	"/src/api.ts",
+	"literal.with.dots",
+	"module",
+	"cache123tmp",
+	"CACHE123TMP",
+	"excluded-dir-subject-2622",
+];
+
+describe("adjacent wildcard glob compilers (#2622)", () => {
+	it("answers the read-guard corpus exactly as the pre-fix compiler did", () => {
+		const differences: string[] = [];
+		for (const pattern of readGuardCorpus) {
+			for (const subject of subjectCorpus) {
+				const expected = oldReadGuardMatch(subject, pattern);
+				const actual = readGuardMatch(subject, pattern);
+				if (actual !== expected) {
+					differences.push(`${pattern} ${subject}: ${actual} !== ${expected}`);
+				}
+			}
+		}
+		expect(differences, differences.join("\n")).toEqual([]);
+	});
+
+	it("answers the directory-name corpus exactly as the pre-fix compiler did", () => {
+		const differences: string[] = [];
+		for (const pattern of directoryNameCorpus) {
+			for (const subject of subjectCorpus) {
+				const expected = oldDirectoryNameMatch(subject, pattern);
+				const actual = directoryNameMatch(subject, pattern);
+				if (actual !== expected) {
+					differences.push(`${pattern} ${subject}: ${actual} !== ${expected}`);
+				}
+			}
+		}
+		expect(differences, differences.join("\n")).toEqual([]);
+	});
+
+	it(`answers a ${ADJACENT_STARS}-star read-guard miss within ${BUDGET_MS}ms`, () => {
+		const filePath = [
+			"src",
+			...Array.from({ length: PATH_COMPONENTS }, (_, i) => `component-${i}`),
+			"not-secret",
+		].join("/");
+		const pattern = `src${"*".repeat(ADJACENT_STARS)}/secret`;
+
+		const started = performance.now();
+		const matched = readGuardMatch(filePath, pattern);
+		const elapsed = performance.now() - started;
+
+		expect(matched).toBe(false);
+		expect(elapsed).toBeLessThan(BUDGET_MS);
+	});
+});

--- a/tests/support/flake-shape-baseline.json
+++ b/tests/support/flake-shape-baseline.json
@@ -18,6 +18,7 @@
 		"clients/pipeline-lsp-sync.test.ts": 5,
 		"clients/project-diagnostics/fresh-fetch.test.ts": 2,
 		"clients/read-expansion-enrichment.test.ts": 1,
+		"clients/read-guard-glob-nonbacktracking.test.ts": 2,
 		"clients/redact/secrets.test.ts": 1,
 		"clients/review-graph.service.test.ts": 1,
 		"clients/runtime-session-retro-hydrate-warmup-race.test.ts": 1,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -326,6 +326,10 @@ const wallClockBudgetInclude = [
 	// the defect it pins is wall-clock (2^N regex backtracking on an interleaved
 	// `**` chain), so a fake clock measures nothing.
 	"tests/clients/workspace-glob-nonbacktracking-budget.test.ts",
+	// #2622: adjacent read-guard stars previously produced exponential regex
+	// backtracking against a long non-matching path; the test measures the real
+	// synchronous matcher cost and belongs in the quiet serialized phase.
+	"tests/clients/read-guard-glob-nonbacktracking.test.ts",
 	// #2619 review F1: the release-QA hermeticity canary spawns a REAL child
 	// under scratchEnv() and reads back what that child resolved. The defect it
 	// pins is a child inheriting the ambient environment, which an in-process


### PR DESCRIPTION
## Summary

Fix PR #2740 round 2 for #2622. Adjacent wildcard runs remain collapsed in
the read-guard and file-utils glob compilers. This round completes the
wall-clock flake-shape admission and adds the matching file-utils regression
budget. All prescribed acceptance criteria are complete.

Round 1 measured the defect through the real synchronous matchers: the
12-star, 40-component read-guard case took >15 s before the fix and ~2 ms
after it. The differential corpus preserved matcher answers.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [x] area:read-guard
- [ ] area:project-intelligence
- [x] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Changed files

- `.changelog/fix-2622-glob-adjacent-stars.md`
- `AGENTS.md`
- `clients/file-utils.ts`
- `clients/read-guard.ts`
- `tests/clients/flake-shape-ratchet.test.ts`
- `tests/clients/read-guard-glob-nonbacktracking.test.ts`
- `tests/support/flake-shape-baseline.json`
- `vitest.config.ts`

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md.
- [x] The change has regression, differential, and timing tests.
- [x] Targeted tests pass after `npm run build`.
- [x] New regression timing assertions are proven red on pre-fix code.
- [x] The adjacent-star guard is covered by the timing regression.
- [x] PR title carries the conventional prefix and issue reference.
- [x] `npm run lint` passes.
- [x] `.changelog/fix-2622-glob-adjacent-stars.md` contains the user-facing entry.
- [x] `AGENTS.md` documents the behavior and verification contract.
- [x] The commit subject uses `(refs #2622)` for this round handoff.

## Tests

Round 1 tests in `tests/clients/read-guard-glob-nonbacktracking.test.ts` pin
language-preserving differential behavior for both glob compilers and the
read-guard wall-clock budget.

Round 2 adds a file-utils timing case. It calls
`isExcludedDirName("cache" + "x".repeat(245), ["cache************tmp"])`,
asserts no match, and applies the same 500 ms budget. The subject passes the
literal prefix, so the test reaches the wildcard matcher. The comment records
the deliberate 500 ms headroom for scheduler contention.

Red-first transcript for the round-2 file-utils guard. After removing only
`clients/file-utils.ts:991`'s `.replace(/\*+/g, "*")`, rebuilding, and running
the bounded probe:

```text
RUN  v4.1.11 /home/akis/.plegma/work/sub-mts929ss-47
exit_code=124
```

The probe timed out after 10 seconds before Vitest completed. Restoring the
line and rebuilding produced the green result below.

```text
Test Files  4 passed (4)
Tests  57 passed (57)
```

Round 1 transcript carried forward: the pre-fix read-guard timing probe
exceeded 15 seconds; the fixed probe measured approximately 2 ms. The round-1
differential corpus passed with no matcher differences.

The ratchet suite reports zero risen or new elapsed-time findings after the
baseline is pinned at two live assertions.

The touched test file satisfies the test-authoring screens for the real
production seam and a bounded assertion. It does not mock the matcher.

## Test assessment

- `tests/clients/read-guard-glob-nonbacktracking.test.ts`: uniquely pins
  language-preserving glob answers and bounded non-matching runtime for both
  production compilers. Round 2 adds the file-utils compiler cell; no test is
  redundant.
- `tests/clients/flake-shape-ratchet.test.ts`: verifies the admission header,
  baseline, lane membership, and two-sided live count. No test is redundant.
- `tests/support/flake-shape-baseline.json`: records the live count of two.
  This is data, not a test case.

## Round 2

1. Finding 1, critical: added the baseline row with live count 2 and the
   `ADMITTED_AFTER_BASELINE` entry. Evidence: flake-shape ratchet passes with
   zero risen or new findings.
2. Finding 2, medium: added the literal-prefix file-utils timing cell.
   Evidence: the guard mutation timed out with exit code 124; restoration
   passed the four-file, 57-test run.
3. Finding 3, high: formatted both touched production/test files and checked
   them with `npx oxfmt --check`. Evidence: both files matched.
4. Finding 4, low: corrected the changed-file list, expanded the blast radius,
   recorded 500 ms headroom, and changed the measured result to `>15 s` before
   and `~2 ms` after the fix.

## Blast radius

`clients/read-guard.ts` changes the shared read-guard exemption glob compiler.
Its callers include read-guard construction and the tool/runtime read-guard
paths. `clients/file-utils.ts` changes `isExcludedDirName`, used by:

- `clients/review-graph/workspace-modules.ts:154/518`
- `tools/lsp-diagnostics.ts:347`
- `clients/git-tracked-ignore.ts:82/183`
- `clients/source-walker.ts:122` through `source-filter.ts:659`
  `extraExcludePatterns`
- `clients/lsp/index.ts:1222`
- `clients/pipeline.ts:150`
- `clients/tree-sitter-client.ts:4570`

The full caller set includes `workspace-modules.ts:154/518`,
`tools/lsp-diagnostics.ts:347`, `git-tracked-ignore.ts:82/183`,
`source-walker.ts:122` through `source-filter.ts:659`
`extraExcludePatterns`, `lsp/index.ts:1222`, `pipeline.ts:150`, and
`tree-sitter-client.ts:4570`. The change adds one normalization pass per glob
compilation and removes exponential backtracking. No durable record changes.

## Observability

This is a synchronous matcher performance fix. It emits no new failure path or
telemetry record. The independent evidence is the bounded real elapsed-time
assertion in `tests/clients/read-guard-glob-nonbacktracking.test.ts`.

## Class sweep

The defect class is adjacent wildcard runs creating nullable regex groups,
covered by AGENTS.md's recurring defect shapes and flake-shape ratchet rules.
The whole-tree sweep covered `clients/`, `tools/`, `mcp/`, `scripts/`, and
`index.ts`. It found the two production glob compilers in
`clients/read-guard.ts` and `clients/file-utils.ts`; no other matching
production compiler was found. The test corpus covers adjacent runs, single
stars, question marks, literals, matching names, and non-matching subjects.

Population verdict: read-guard compiler fixed, file-utils compiler fixed, and
all listed callers consume the shared behavior without API changes. The two
compilers remain distributed because they use different escaping and matcher
entry points; extracting a helper would relocate those rules without reducing
complexity.

## Verification

- `npm run build`: passed.
- `npx oxfmt --check clients/file-utils.ts tests/clients/read-guard-glob-nonbacktracking.test.ts`: passed.
- Four requested Vitest files: passed, 57 tests.
- `npm run lint`: passed.
- `node scripts/check-changelog-fragments.mjs`: passed.

The offline test setup reported unavailable tree-sitter prefetches, but these
four suites completed successfully. The full suite remains CI's responsibility.

