### PR TITLE
fix(installer): dedupe managed npm refresh by package (closes #2666)

### DIFF
--- a/.changelog/fix-2666-managed-refresh-dedupe.md
+++ b/.changelog/fix-2666-managed-refresh-dedupe.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Managed npm refreshes deduplicate shared packages (closes #2666)** — one package update now covers every registered tool id that shares its package, preserving refresh budget slots for other packages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -840,6 +840,12 @@ records count toward the byte budget but remain exempt from eviction until
 Capacity telemetry keeps the per-store subject and names the triggering
 `count` or `bytes` axis in the existing bounded degradation record. (#2247)
 
+Periodic refresh candidates deduplicate npm entries by `packageName`. The first
+registry entry represents a package, and stale ordering uses the oldest covered
+per-tool stamp with `toolId` as the tie-break. One package update stamps every
+installed registry id that shares it, so aliases do not consume another session
+budget slot. The refresh log names the package and covered ids. (#2666)
+
 Managed verification uses the registry's optional `verificationTimeoutMs` at
 every installer-owned probe seam, including local discovery, npm install, and
 periodic refresh. The refresh candidate projection carries that policy instead

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -3716,6 +3716,7 @@ export function getRefreshableManagedNpmTools(): Array<{
 	packageName: string;
 	binaryName: string;
 }> {
+	const seenPackages = new Set<string>();
 	return getRefreshableManagedTools()
 		.filter((candidate) => candidate.strategy === "npm")
 		.map((candidate) => ({
@@ -3724,7 +3725,12 @@ export function getRefreshableManagedNpmTools(): Array<{
 			// have both, so these are total.
 			packageName: candidate.packageName as string,
 			binaryName: candidate.binaryName as string,
-		}));
+		}))
+		.filter((candidate) => {
+			if (seenPackages.has(candidate.packageName)) return false;
+			seenPackages.add(candidate.packageName);
+			return true;
+		});
 }
 
 // --- Periodic refresh seam for the non-npm strategies (#1747) ---

--- a/clients/installer/managed-tool-refresh.ts
+++ b/clients/installer/managed-tool-refresh.ts
@@ -46,6 +46,8 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { HOOK_WALL_BUDGET_MS } from "../hook-budgets.js";
+import { bounded } from "../deadline-utils.js";
 import { recordDegradationOnce } from "../degradation-ledger.js";
 import { commitDurableStoreAsync } from "../durable-store.js";
 import {
@@ -701,6 +703,8 @@ async function performNpmRefresh(
 			0,
 			200,
 		);
+		const coveredIds =
+			candidate.coveredToolIds?.join(",") ?? candidate.toolId;
 		// "Keeping <old version>" would be an unchecked assertion (#1746 review
 		// F2). The spawn budget kills the package manager where it stands, which
 		// can be mid-write: the tree may hold a new version, a half-written one,
@@ -712,10 +716,10 @@ async function performNpmRefresh(
 		recordDegradationOnce({
 			kind: "managed-tool-refresh",
 			subject: candidate.toolId,
-			reason: `${pm} update failed: ${reason || "non-zero exit"}`,
+			reason: `package ${packageName}, covered ids ${coveredIds}; ${pm} update failed: ${reason || "non-zero exit"}`,
 		});
 		logSessionStart(
-			`managed-tool-refresh ${candidate.toolId}: ${pm} update failed after ${elapsedMs}ms — on disk now ${onDisk ?? "unreadable"} (was ${previousVersion ?? "unknown"}); resolution cache cleared for re-probe (${reason || "non-zero exit"})`,
+			`managed-tool-refresh ${candidate.toolId}: ${pm} update failed after ${elapsedMs}ms — package ${packageName}, covered ids ${coveredIds}; on disk now ${onDisk ?? "unreadable"} (was ${previousVersion ?? "unknown"}); resolution cache cleared for re-probe (${reason || "non-zero exit"})`,
 		);
 		await writeRefreshStamp(candidate.toolId, {
 			checkedAt: now,
@@ -767,10 +771,12 @@ async function performNpmRefresh(
 		candidate.packageEntryOf,
 	);
 	if (!verified) {
+		const coveredIds =
+			candidate.coveredToolIds?.join(",") ?? candidate.toolId;
 		recordDegradationOnce({
 			kind: "managed-tool-refresh",
 			subject: candidate.toolId,
-			reason: `binary failed verification after ${pm} update (${previousVersion ?? "unknown"} → ${currentVersion ?? "unknown"})`,
+			reason: `package ${packageName}, covered ids ${coveredIds}; binary failed verification after ${pm} update (${previousVersion ?? "unknown"} → ${currentVersion ?? "unknown"})`,
 		});
 		// Deliberately NOT removed. `installNpmTool` deletes a freshly installed
 		// package that fails verification because nothing was working before it;
@@ -779,7 +785,7 @@ async function performNpmRefresh(
 		// what lets `ensureTool`'s own probe-and-repair path see the breakage and
 		// reinstall. Stamped as failed so the shorter retry cooldown applies.
 		logSessionStart(
-			`managed-tool-refresh ${candidate.toolId}: ${pm} update ran but ${binPath} failed verification — resolution cache cleared for re-probe (${elapsedMs}ms)`,
+			`managed-tool-refresh ${candidate.toolId}: ${pm} update ran but ${binPath} failed verification — package ${packageName}, covered ids ${coveredIds}; resolution cache cleared for re-probe (${elapsedMs}ms)`,
 		);
 		await writeRefreshStamp(candidate.toolId, {
 			checkedAt: now,
@@ -1002,13 +1008,23 @@ async function executeManagedToolRefresh(
 				if (result.attempted && candidate.coveredToolIds) {
 					for (const toolId of candidate.coveredToolIds) {
 						if (toolId === candidate.toolId) continue;
-						await writeRefreshStamp(toolId, {
-							checkedAt: now,
-							...(result.currentVersion !== undefined && {
-								version: result.currentVersion,
+						await bounded(
+							writeRefreshStamp(toolId, {
+								checkedAt: now,
+								...(result.currentVersion !== undefined && {
+									version: result.currentVersion,
+								}),
+								...(result.ok ? {} : { failed: true }),
 							}),
-							...(result.ok ? {} : { failed: true }),
-						});
+							{
+								ms: HOOK_WALL_BUDGET_MS.session_start,
+								// The unref'd timer runs after session_start returns, so no
+								// live turn signal belongs to this background refresh.
+								signal: undefined,
+								hook: "session_start",
+								label: "writeRefreshStamp:covered-tool",
+							},
+						);
 					}
 				}
 				await tap();

--- a/clients/installer/managed-tool-refresh.ts
+++ b/clients/installer/managed-tool-refresh.ts
@@ -360,6 +360,8 @@ export interface RefreshCandidate {
 	 * verifies the binary exactly the way the install did (#2722).
 	 */
 	packageEntryOf?: string;
+	/** npm only — every installed registry id covered by this package update. */
+	coveredToolIds?: string[];
 }
 
 /**
@@ -388,7 +390,23 @@ async function installedRefreshCandidates(): Promise<RefreshCandidate[]> {
 			}),
 		});
 	}
-	return candidates;
+	const byPackage = new Map<string, RefreshCandidate>();
+	const distinct: RefreshCandidate[] = [];
+	for (const candidate of candidates) {
+		if (candidate.strategy !== "npm" || !candidate.packageName) {
+			distinct.push(candidate);
+			continue;
+		}
+		const existing = byPackage.get(candidate.packageName);
+		if (existing) {
+			existing.coveredToolIds?.push(candidate.toolId);
+			continue;
+		}
+		const representative = { ...candidate, coveredToolIds: [candidate.toolId] };
+		byPackage.set(candidate.packageName, representative);
+		distinct.push(representative);
+	}
+	return distinct;
 }
 
 /**
@@ -404,14 +422,24 @@ export function selectStaleTools(
 	const interval = refreshIntervalMs();
 	const retry = retryIntervalMs();
 	const due = candidates.filter((candidate) => {
-		const entry = state.tools[candidate.toolId];
-		if (!entry) return true;
-		const cooldown = entry.failed ? retry : interval;
-		return now - entry.checkedAt >= cooldown;
+		return (candidate.coveredToolIds ?? [candidate.toolId]).some((toolId) => {
+			const entry = state.tools[toolId];
+			if (!entry) return true;
+			const cooldown = entry.failed ? retry : interval;
+			return now - entry.checkedAt >= cooldown;
+		});
 	});
 	return due.sort((a, b) => {
-		const aAt = state.tools[a.toolId]?.checkedAt ?? 0;
-		const bAt = state.tools[b.toolId]?.checkedAt ?? 0;
+		const aAt = Math.min(
+			...(a.coveredToolIds ?? [a.toolId]).map(
+				(toolId) => state.tools[toolId]?.checkedAt ?? 0,
+			),
+		);
+		const bAt = Math.min(
+			...(b.coveredToolIds ?? [b.toolId]).map(
+				(toolId) => state.tools[toolId]?.checkedAt ?? 0,
+			),
+		);
 		return aAt !== bAt ? aAt - bAt : a.toolId.localeCompare(b.toolId);
 	});
 }
@@ -457,6 +485,8 @@ export interface ManagedToolRefreshResult {
 	/** The updated binary answered `--version`. False also covers a failed spawn. */
 	verified: boolean;
 	ok: boolean;
+	/** True when the package-manager or strategy refresh actually ran. */
+	attempted?: boolean;
 }
 
 export interface ManagedToolRefreshOutcome {
@@ -521,6 +551,7 @@ async function refreshNonNpmOne(
 				changed: false,
 				verified: false,
 				ok: false,
+				attempted: false,
 			};
 		}
 		// A real failure may have left a stale cached path or probe entry behind
@@ -560,6 +591,7 @@ async function refreshNonNpmOne(
 			// touched the installed copy, so there is nothing new to check.
 			verified: false,
 			ok: false,
+			attempted: true,
 		};
 	}
 
@@ -592,6 +624,7 @@ async function refreshNonNpmOne(
 		// probe for pip/gem) — `ok: true` here already means "and it runs".
 		verified: true,
 		ok: true,
+		attempted: true,
 	};
 }
 
@@ -624,6 +657,7 @@ async function refreshNpmOne(
 			changed: false,
 			verified: false,
 			ok: false,
+			attempted: false,
 		};
 	}
 	try {
@@ -697,6 +731,7 @@ async function performNpmRefresh(
 			changed: onDisk !== undefined && onDisk !== previousVersion,
 			verified: false,
 			ok: false,
+			attempted: true,
 		};
 	}
 
@@ -760,6 +795,7 @@ async function performNpmRefresh(
 			changed,
 			verified: false,
 			ok: false,
+			attempted: true,
 		};
 	}
 
@@ -771,8 +807,8 @@ async function performNpmRefresh(
 	// can be traced to the version that produced it, and to the moment it moved.
 	logSessionStart(
 		changed
-			? `managed-tool-refresh ${candidate.toolId}: ${previousVersion ?? "unknown"} → ${currentVersion} via ${pm} update, verified (${elapsedMs}ms)`
-			: `managed-tool-refresh ${candidate.toolId}: unchanged at ${currentVersion ?? previousVersion ?? "unknown"} (${elapsedMs}ms)`,
+			? `managed-tool-refresh ${candidate.toolId}: ${previousVersion ?? "unknown"} → ${currentVersion} via ${pm} update, verified; package ${packageName}, covered ids ${candidate.coveredToolIds?.join(",") ?? candidate.toolId} (${elapsedMs}ms)`
+			: `managed-tool-refresh ${candidate.toolId}: unchanged at ${currentVersion ?? previousVersion ?? "unknown"}; package ${packageName}, covered ids ${candidate.coveredToolIds?.join(",") ?? candidate.toolId} (${elapsedMs}ms)`,
 	);
 	return {
 		toolId: candidate.toolId,
@@ -783,6 +819,7 @@ async function performNpmRefresh(
 		changed,
 		verified: true,
 		ok: true,
+		attempted: true,
 	};
 }
 
@@ -934,14 +971,21 @@ async function executeManagedToolRefresh(
 		// `/new` calls walked the entire 22-tool stale list. A local allowance
 		// cannot be re-armed by anyone: a mid-run reset restores the SESSION's
 		// right to start a new run, which is correct, without extending this one.
-		const want = Math.min(maxPerSession(), stale.length);
+		const stalePackages = new Set<string>();
+		const distinctStale = stale.filter((candidate) => {
+			if (candidate.strategy !== "npm" || !candidate.packageName) return true;
+			if (stalePackages.has(candidate.packageName)) return false;
+			stalePackages.add(candidate.packageName);
+			return true;
+		});
+		const want = Math.min(maxPerSession(), distinctStale.length);
 		while (held < want && reserveManagedToolRefreshSlot(maxPerSession())) {
 			held += 1;
 		}
 		let allowance = held;
 
 		const refreshed: ManagedToolRefreshResult[] = [];
-		for (const candidate of stale) {
+		for (const candidate of distinctStale) {
 			// Once a spawn happens the slot is spent for good — a failing tool must
 			// not hand its slot to the next candidate and turn a budget of one into
 			// 22 spawns.
@@ -949,9 +993,24 @@ async function executeManagedToolRefresh(
 			allowance -= 1;
 			held -= 1;
 			try {
-				refreshed.push(
-					await refreshOne(candidate, read.state.tools[candidate.toolId], now),
+				const result = await refreshOne(
+					candidate,
+					read.state.tools[candidate.toolId],
+					now,
 				);
+				refreshed.push(result);
+				if (result.attempted && candidate.coveredToolIds) {
+					for (const toolId of candidate.coveredToolIds) {
+						if (toolId === candidate.toolId) continue;
+						await writeRefreshStamp(toolId, {
+							checkedAt: now,
+							...(result.currentVersion !== undefined && {
+								version: result.currentVersion,
+							}),
+							...(result.ok ? {} : { failed: true }),
+						});
+					}
+				}
 				await tap();
 			} catch (err) {
 				recordDegradationOnce({

--- a/tests/clients/installer/managed-tool-refresh.test.ts
+++ b/tests/clients/installer/managed-tool-refresh.test.ts
@@ -576,6 +576,87 @@ describe("session budget", () => {
 });
 
 describe("failed refresh", () => {
+	it("names every alias when a shared package update fails", async () => {
+		installFixture("vscode-langservers-extracted", "4.0.0", {
+			binaryName: "vscode-json-language-server",
+		});
+		installBinShim("vscode-html-language-server");
+		installBinShim("vscode-css-language-server");
+		writeState({
+			"vscode-css-languageserver": { checkedAt: NOW - 8 * DAY_MS },
+			"vscode-html-languageserver-bin": { checkedAt: NOW - 8 * DAY_MS },
+			"vscode-json-language-server": { checkedAt: NOW - 8 * DAY_MS },
+		});
+		stubSpawn("fail");
+
+		await runManagedToolRefresh(NOW);
+
+		const coveredIds =
+			"vscode-json-language-server,vscode-html-languageserver-bin,vscode-css-languageserver";
+		const failureRow = logRows().find((row) =>
+			row.includes("npm update failed"),
+		);
+		expect(failureRow).toContain("package vscode-langservers-extracted");
+		expect(failureRow).toContain(`covered ids ${coveredIds}`);
+		const group = getDegradationSummary().find(
+			(g) => g.kind === "managed-tool-refresh",
+		);
+		expect(group?.latestReasons[0].reason).toContain(
+			"package vscode-langservers-extracted",
+		);
+		expect(group?.latestReasons[0].reason).toContain(`covered ids ${coveredIds}`);
+		expect(readState()).toMatchObject({
+			"vscode-json-language-server": { failed: true },
+			"vscode-html-languageserver-bin": { failed: true },
+			"vscode-css-languageserver": { failed: true },
+		});
+	});
+
+	it("names every alias when a shared package fails verification", async () => {
+		installFixture("vscode-langservers-extracted", "4.0.0", {
+			binaryName: "vscode-json-language-server",
+		});
+		installBinShim("vscode-html-language-server");
+		installBinShim("vscode-css-language-server");
+		writeState({
+			"vscode-css-languageserver": { checkedAt: NOW - 8 * DAY_MS },
+			"vscode-html-languageserver-bin": { checkedAt: NOW - 8 * DAY_MS },
+			"vscode-json-language-server": { checkedAt: NOW - 8 * DAY_MS },
+		});
+		spawnMock.mockImplementation(async (_command: string, args: string[]) => {
+			if (!args.includes("update")) {
+				return { stdout: "npm", stderr: "", status: 0 };
+			}
+			installFixture("vscode-langservers-extracted", "5.0.0", {
+				binaryName: "vscode-json-language-server",
+				shimExitCode: 1,
+			});
+			return { stdout: "", stderr: "", status: 0 };
+		});
+
+		await runManagedToolRefresh(NOW);
+
+		const coveredIds =
+			"vscode-json-language-server,vscode-html-languageserver-bin,vscode-css-languageserver";
+		const failureRow = logRows().find((row) =>
+			row.includes("failed verification"),
+		);
+		expect(failureRow).toContain("package vscode-langservers-extracted");
+		expect(failureRow).toContain(`covered ids ${coveredIds}`);
+		const group = getDegradationSummary().find(
+			(g) => g.kind === "managed-tool-refresh",
+		);
+		expect(group?.latestReasons[0].reason).toContain(
+			"package vscode-langservers-extracted",
+		);
+		expect(group?.latestReasons[0].reason).toContain(`covered ids ${coveredIds}`);
+		expect(readState()).toMatchObject({
+			"vscode-json-language-server": { failed: true },
+			"vscode-html-languageserver-bin": { failed: true },
+			"vscode-css-languageserver": { failed: true },
+		});
+	});
+
 	it("degrades once, keeps serving, and retries on the shorter cooldown", async () => {
 		installFixture("knip", "6.4.1");
 		writeState({ knip: { checkedAt: NOW - 8 * DAY_MS, version: "6.4.1" } });

--- a/tests/clients/installer/managed-tool-refresh.test.ts
+++ b/tests/clients/installer/managed-tool-refresh.test.ts
@@ -337,6 +337,11 @@ describe("refresh candidate selection", () => {
 		const ids = candidates.map((c) => c.toolId);
 		expect(ids).toContain("knip");
 		expect(ids).toContain("pyright");
+		const shared = candidates.filter(
+			(candidate) => candidate.packageName === "vscode-langservers-extracted",
+		);
+		expect(shared).toHaveLength(1);
+		expect(shared[0].toolId).toBe("vscode-json-language-server");
 		// An explicit `pkg@1.2.3` pin is the intended version; #589 already
 		// reinstalls a managed copy that drifts off one, so it must not be
 		// re-resolved here.
@@ -441,6 +446,52 @@ describe("cadence", () => {
 		await runManagedToolRefresh(NOW);
 
 		expect(updateCalls()[0].args).toContain("pyright");
+	});
+
+	it("refreshes a shared npm package once and advances the next package", async () => {
+		vi.stubEnv("PI_LENS_TOOL_REFRESH_MAX_PER_SESSION", "2");
+		installFixture("vscode-langservers-extracted", "4.0.0", {
+			binaryName: "vscode-css-language-server",
+		});
+		installBinShim("vscode-html-language-server");
+		installBinShim("vscode-json-language-server");
+		installFixture("knip", "6.4.1");
+		writeState({
+			"vscode-css-languageserver": { checkedAt: NOW - 8 * DAY_MS },
+			"vscode-html-languageserver-bin": { checkedAt: NOW - 8 * DAY_MS },
+			"vscode-json-language-server": { checkedAt: NOW - 8 * DAY_MS },
+			knip: { checkedAt: NOW - 7 * DAY_MS },
+		});
+		stubSpawn("ok", {
+			"vscode-langservers-extracted": "5.0.0",
+			knip: "6.32.2",
+		});
+
+		const outcome = await runManagedToolRefresh(NOW);
+
+		expect(updateCalls()).toHaveLength(2);
+		expect(updateCalls().map((call) => call.args)).toEqual(
+			expect.arrayContaining([
+			expect.arrayContaining(["vscode-langservers-extracted"]),
+			expect.arrayContaining(["knip"]),
+		]),
+	);
+		expect(outcome.refreshed.map((refresh) => refresh.packageName)).toEqual(
+			expect.arrayContaining(["vscode-langservers-extracted", "knip"]),
+	);
+		expect(readState()).toMatchObject({
+			"vscode-css-languageserver": { checkedAt: NOW, version: "5.0.0" },
+			"vscode-html-languageserver-bin": { checkedAt: NOW, version: "5.0.0" },
+			"vscode-json-language-server": { checkedAt: NOW, version: "5.0.0" },
+			knip: { checkedAt: NOW, version: "6.32.2" },
+		});
+		expect(
+			logRows().some(
+				(row) =>
+					row.includes("package vscode-langservers-extracted") &&
+					row.includes("covered ids vscode-json-language-server,vscode-html-languageserver-bin,vscode-css-languageserver"),
+			),
+		).toBe(true);
 	});
 
 	it("breaks a stamp tie on tool id so the choice is deterministic", async () => {
@@ -1037,17 +1088,6 @@ describe("post-update verification (review F2)", () => {
 			binaryName: "vscode-json-language-server",
 		});
 		stubSpawn("ok", { "vscode-langservers-extracted": "5.0.0" });
-		// vscode-css-languageserver and vscode-html-languageserver-bin (#2638)
-		// share this same npm package, so the single node_modules install above
-		// makes ALL THREE tool ids "present" and due — mark the other two
-		// already-checked so this run's one-slot-per-session budget
-		// (maxPerSession=1) lands on the json id this test actually verifies,
-		// not on whichever id sorts first alphabetically.
-		writeState({
-			"vscode-css-languageserver": { checkedAt: NOW, version: "4.0.0" },
-			"vscode-html-languageserver-bin": { checkedAt: NOW, version: "4.0.0" },
-		});
-
 		const outcome = await runManagedToolRefresh(NOW);
 
 		expect(outcome.refreshed[0]).toMatchObject({

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -2285,6 +2285,11 @@ const HELPER_UNBOUNDED: Readonly<Record<string, number>> = {
  * rather than silently inherited.
  */
 const BOUNDED_CALL_SITES: Readonly<Record<string, string>> = {
+	"call:clients/installer/managed-tool-refresh.ts#executeManagedToolRefresh:8d9498e9~773eca34":
+		"`undefined` is intentional: the unref'd timer runs after session_start " +
+		"returns, so no live turn signal belongs to this background refresh. The " +
+		"session_start wall budget still bounds the best-effort alias stamp, and " +
+		"the required signal field makes this absence an explicit decision.",
 	"call:clients/actionable-warnings.ts#boundedLspCall:2b57f8b9~9137fb1a":
 		"`LspEnrichmentDeps.signal`. ALWAYS live on the deferred loop (built " +
 		"from the turn signal combined with the deferral controller's). Optional " +


### PR DESCRIPTION
## Summary

Refs #2666. Round 2 fixes the prescribed MEDIUM finding in the managed npm
refresh failure paths. Failed package updates and failed post-update
verification now name the package and every covered tool id in both the session
log row and the bounded degradation reason. The existing shared-package
stamping, ordering, dedupe, and success rows remain unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:installer
- [x] area:observability
- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md.
- [x] The change has regression tests for both failure branches.
- [x] Targeted test files pass locally after `npm run build`.
- [x] The new regression tests are proven RED on pre-fix code.
- [x] The new failure identity is mutation-proof.
- [x] `npm run lint` passes.
- [x] The existing #2666 changelog fragment remains valid.
- [x] The commit subject is at most 50 characters and includes `(refs #2666)`.

## Tests

Round 1, reconstructed from the existing test file and the PR-head baseline:

- `tests/clients/installer/managed-tool-refresh.test.ts` covers candidate
  selection, shared-package dedupe, update command policy, session budget,
  failed refresh cooldown and stamps, concurrent runs, unreadable state,
  version-change observability, post-update verification, package-entry
  verification, cache invalidation, and refresh outcomes.
- The inherited #2666 shared-package test pins one update for the three
  `vscode-langservers-extracted` aliases, stamps all covered ids, preserves
  deterministic ordering, and advances the next package within the budget.

Round 2 tests edited in `tests/clients/installer/managed-tool-refresh.test.ts`:

- `names every alias when a shared package update fails` is a regression proof
  for the missing package and alias identity in npm-update failure rows and
  degradation reasons. It also checks that all three aliases receive
  `failed: true` stamps.
- `names every alias when a shared package fails verification` pins the same
  identity and stamp contract for the post-update verification failure path.

Red-first transcript on 2026-09-08, before the production change:

```text
FAIL ... managed-tool-refresh.test.ts > failed refresh > names every alias when a shared package update fails
AssertionError: expected 'managed-tool-refresh vscode-json-lang…' to contain 'package vscode-langservers-extracted'
Received: "managed-tool-refresh vscode-json-language-server: npm update failed after 0ms — on disk now 4.0.0 (was 4.0.0); resolution cache cleared for re-probe (npm error network ETIMEDOUT registry.npmjs.org)"
Test Files  1 failed (1)
Tests  1 failed | 60 passed (61)
```

Green transcript after the fix:

```text
Test Files  1 passed (1)
Tests  62 passed (62)
```

Mutation transcript after removing `covered ids ${coveredIds}` from the npm
update failure row:

```text
FAIL ... managed-tool-refresh.test.ts > failed refresh > names every alias when a shared package update fails
AssertionError: expected 'managed-tool-refresh vscode-json-lang…' to contain 'covered ids vscode-json-language-serv…'
Received: "managed-tool-refresh vscode-json-language-server: npm update failed after 0ms — package vscode-langservers-extracted; on disk now 4.0.0 (was 4.0.0); resolution cache cleared for re-probe (npm error network ETIMEDOUT registry.npmjs.org)"
Tests  1 failed | 60 passed (61)
```

Additional verification:

- `npm run build` passed before each targeted run.
- `npm run lint` passed.
- Sibling installer suites `managed-tool-refresh-strategies.test.ts`,
  `tool-registry-consistency.test.ts`, and `managed-tool-ids.test.ts` passed:
  4 files and 132 tests, including `managed-tool-refresh.test.ts`.
- The governance sweep was red before the fix: `managed-tool-refresh.ts` had
  30 unbounded awaits against its pinned count of 29 and reported one
  unregistered item at `managed-tool-refresh.ts@30`.
- The governance sweep is green after the fix: 1 file and 12 tests pass, with
  the module back at 29 unbounded awaits. The new `bounded()` call is
  registered with its signal provenance.
- Tree-sitter grammar prefetch reported the expected offline degradation; no
  test in the executed suites depended on the missing downloads.

## Test assessment

The touched test file uniquely pins managed refresh state, package dedupe,
stamping, ledger reasons, and session log rows. The two new cases are not
redundant: one drives npm process failure, and the other drives a broken binary
after npm succeeds. No existing test was removed.

## Blast radius

The production seam is `performNpmRefresh` in
`clients/installer/managed-tool-refresh.ts`, called by
`runManagedToolRefresh`. The change affects only the two npm failure records
and their session log rows. The caller still stamps every `coveredToolIds`
entry, and no success, ordering, dedupe, or refresh-budget path changes.

The module report with `blastRadius: true` was unavailable in this worker
environment. A source sweep found the refresh entry points and all
`recordDegradationOnce` sites; no other caller writes these two npm failure
rows. This is not a hot-path cost change: alias joining runs only on failure
or failed verification, once per package attempt.

## Observability

The proof records are the `managed-tool-refresh` degradation ledger entries and
the `logSessionStart` rows in `clients/installer/managed-tool-refresh.ts`.
The package and covered ids are placed first in ledger reasons so the existing
200-character bound retains the discriminating identity.

## Class sweep

This addresses AGENTS.md's bounded-observability defect shape: a degradation
record must preserve which package, tool, or record is stuck.

Pattern sweep across the repository:

- Searched all `recordDegradationOnce` sites and all managed refresh failure,
  verification, and `covered ids` rows under `clients/`, `tests/`, and the
  repository root. The two npm failure branches are the only rows changed;
  success rows already included package and covered ids.

Population sweep:

- The shared package population is the three registry ids
  `vscode-json-language-server`, `vscode-html-languageserver-bin`, and
  `vscode-css-languageserver`. The new fixtures exercise all three in both
  failure branches, and each receives `failed: true`.

Consolidation verdict: keep the existing candidate-level `coveredToolIds`
population as the single source of truth. No second alias list or helper is
introduced.

## Round 2

Finding: failed npm refresh rows and degradation reasons named only the
representative tool, violating the #2666 package-and-covered-ids invariant.

Change: add bounded `packageName` and `candidate.coveredToolIds` context to
the npm-update-failure and verification-failure rows and records. Put identity
before variable error or version detail so the ledger bound cannot truncate an
alias.

Evidence: red-first failure on the pre-fix code, green 62-test targeted suite,
red mutation after removing covered ids from the failure row, passing build,
passing lint, and passing 70 tests across the three sibling installer suites.

Follow-up: the round-1 alias stamp await increased the hook helper's
unbounded-await count from the pinned 29 to 30. Wrap the per-alias stamp in
`bounded()` with the 5-second `session_start` wall budget and the required
`signal: undefined` field because the unref'd background timer has no live turn
signal. Register the call-site provenance, keep the pin at 29, and verify the
governance sweep red at 30 and green at 29.

## Paths not to commit

- `PR_BODY.md`
- `COMMIT_MSG.txt`
- `.probe-home/`
- The linked `node_modules` tree



Closes #2666.
