### PR TITLE
fix(scripts): npm-retry annotates infra only for network failures (closes #2684)

### DIFF
--- a/.changelog/fix-2684-npm-retry-infra-annotation.md
+++ b/.changelog/fix-2684-npm-retry-infra-annotation.md
@@ -1,4 +1,4 @@
 ---
 section: Fixed
 ---
-- **`scripts/npm-retry.mjs` annotates `infra: registry unreachable` only for network-shaped failures (closes #2684)** — a deterministic npm failure (`ERESOLVE`, `E404`, `EINTEGRITY`, `ETARGET`) now stops after one attempt with a plain "failed after N attempt(s)" line and the exit code preserved, while timeouts, spawn errors and `NET_PATTERN` matches (shared with `scripts/lib/ci-failure-classifier.mjs`) keep the retry backoff and the infra annotation; a test pins that the plain line never matches the auto-rerun classifier.
+- **`scripts/npm-retry.mjs` annotates `infra: registry unreachable` only for network-shaped failures (closes #2684)** — a deterministic npm failure (`ERESOLVE`, `E404`, `EINTEGRITY`, `ETARGET`) now stops after one attempt with a plain "failed after N attempt(s)" line and the exit code preserved, while timeouts, spawn errors, and the widened shared `NET_PATTERN` keep the retry backoff and origin/master's `failed 3 times` infra annotation; network evidence wins over a mixed deterministic code, and unknown non-network failures retain retry behavior.

--- a/.changelog/fix-2684-npm-retry-infra-annotation.md
+++ b/.changelog/fix-2684-npm-retry-infra-annotation.md
@@ -1,4 +1,4 @@
 ---
 section: Fixed
 ---
-- **`scripts/npm-retry.mjs` annotates `infra: registry unreachable` only for network-shaped failures (closes #2684)** — a deterministic npm failure (`ERESOLVE`, `E404`, `EINTEGRITY`, `ETARGET`) now stops after one attempt with a plain "failed after N attempt(s)" line and the exit code preserved, while timeouts, spawn errors, and the widened shared `NET_PATTERN` keep the retry backoff and origin/master's `failed 3 times` infra annotation; network evidence wins over a mixed deterministic code, and unknown non-network failures retain retry behavior.
+- **`scripts/npm-retry.mjs` annotates `infra: registry unreachable` only for network-shaped failures (closes #2684)** — a deterministic npm failure (`ERESOLVE`, `E404`, `EINTEGRITY`, `ETARGET`) now stops after one attempt with a plain "failed after N attempt(s)" line and the exit code preserved, while timeouts, spawn errors, and the restored shared `NET_PATTERN` plus npm-local transient patterns keep the retry backoff and origin/master's `failed 3 times` infra annotation; network evidence wins over a mixed deterministic code, and unknown non-network failures retain retry behavior.

--- a/.changelog/fix-2684-npm-retry-infra-annotation.md
+++ b/.changelog/fix-2684-npm-retry-infra-annotation.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- **`scripts/npm-retry.mjs` annotates `infra: registry unreachable` only for network-shaped failures (closes #2684)** — a deterministic npm failure (`ERESOLVE`, `E404`, `EINTEGRITY`, `ETARGET`) now stops after one attempt with a plain "failed after N attempt(s)" line and the exit code preserved, while timeouts, spawn errors and `NET_PATTERN` matches (shared with `scripts/lib/ci-failure-classifier.mjs`) keep the retry backoff and the infra annotation; a test pins that the plain line never matches the auto-rerun classifier.

--- a/scripts/lib/ci-failure-classifier.d.mts
+++ b/scripts/lib/ci-failure-classifier.d.mts
@@ -30,6 +30,8 @@ export interface ClassifierDecision {
 	commentBody: string;
 }
 
+/** Network-shaped failure needles shared with scripts/npm-retry.mjs (#2684). */
+export declare const NET_PATTERN: RegExp;
 export declare function classifyFailureLog(rawLog: string): Classification;
 export declare function readCgroupOomKillCount(log: string): number | null;
 export declare function describeKernelKillEvidence(log: string): string | null;

--- a/scripts/lib/ci-failure-classifier.mjs
+++ b/scripts/lib/ci-failure-classifier.mjs
@@ -143,13 +143,15 @@ const KILLED_LINE = /(?:^|[\s:])Killed(?:\s|$)/m;
 // `{"outcome":"emit_failed","error":"ECONNRESET"}` (tests/clients/
 // smells-rollup.test.ts:124), so a recovered warning or a test's own
 // console output can contain "ECONNRESET" with no network failure involved.
-// Scoped to lines that also carry an explicit error-shaped prefix (npm's
-// own "npm error" convention, or the runner's own "##[error]" annotation) --
-// a "npm warn" line or arbitrary test output text no longer qualifies.
+// Scoped to npm error/ERR! lines, registry request lines, and this wrapper's
+// own infra annotation. Arbitrary compiler/linter/test output is not evidence.
+// Keep this shared pattern at origin/master's conservative scope. npm-retry
+// composes it with npm-only shapes below because the two consumers have
+// opposite false-positive costs.
 export const NET_PATTERN =
-	/getaddrinfo\s+\w+\s+\S+|\b(?:ENOTFOUND|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ECONNREFUSED|EPIPE|ENETUNREACH|EHOSTUNREACH|FETCH_ERROR|ERR_SOCKET_TIMEOUT)\b|\b(?:502|503|504)(?:\s+Service Unavailable)?\b|\b429\s+Too Many Requests\b|socket hang up|network error|request to\s+\S+\s+failed, reason:|tarball.{0,40}(?:download|fetch).{0,20}fail|net::ERR_NAME_NOT_RESOLVED|registry unreachable/i;
+	/getaddrinfo\s+\w+\s+\S+|\bENOTFOUND\b|\bECONNRESET\b|tarball.{0,40}(?:download|fetch).{0,20}fail|net::ERR_NAME_NOT_RESOLVED/i;
 const ERROR_PREFIXED_LINE =
-	/^(?:.*\bnpm error\b.*|##\[error\].*|::error::.*)$/im;
+	/^(?:.*\bnpm (?:error\b|ERR!)(?:\s|$).*|.*::error::infra:.*|.*\brequest to https?:\/\/\S+ failed, reason:.*)$/gim;
 
 /**
  * @typedef {{ kind: "real" | "infra-kill" | "infra-net", detail: string }} Classification
@@ -338,13 +340,16 @@ export function classifyFailureLog(rawLog) {
 		return { kind: "infra-kill", detail };
 	}
 
-	const errorLine = ERROR_PREFIXED_LINE.exec(log);
-	const netMatch = errorLine ? NET_PATTERN.exec(errorLine[0]) : null;
-	if (netMatch) {
-		return {
-			kind: "infra-net",
-			detail: `no failing assertion; network error: ${netMatch[0].trim()}`,
-		};
+	let inspectedErrorLines = 0;
+	for (const errorLine of log.matchAll(ERROR_PREFIXED_LINE)) {
+		if (++inspectedErrorLines > 1_000) break;
+		const netMatch = NET_PATTERN.exec(errorLine[0]);
+		if (netMatch) {
+			return {
+				kind: "infra-net",
+				detail: `no failing assertion; network error: ${netMatch[0].trim()}`,
+			};
+		}
 	}
 
 	// Spec default (#2103 proposal step 1): "otherwise real". A failing job

--- a/scripts/lib/ci-failure-classifier.mjs
+++ b/scripts/lib/ci-failure-classifier.mjs
@@ -147,8 +147,9 @@ const KILLED_LINE = /(?:^|[\s:])Killed(?:\s|$)/m;
 // own "npm error" convention, or the runner's own "##[error]" annotation) --
 // a "npm warn" line or arbitrary test output text no longer qualifies.
 export const NET_PATTERN =
-	/getaddrinfo\s+\w+\s+\S+|\bENOTFOUND\b|\bECONNRESET\b|tarball.{0,40}(?:download|fetch).{0,20}fail|net::ERR_NAME_NOT_RESOLVED/i;
-const ERROR_PREFIXED_LINE = /^(?:.*\bnpm error\b.*|##\[error\].*)$/im;
+	/getaddrinfo\s+\w+\s+\S+|\b(?:ENOTFOUND|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ECONNREFUSED|EPIPE|ENETUNREACH|EHOSTUNREACH|FETCH_ERROR|ERR_SOCKET_TIMEOUT)\b|\b(?:502|503|504)(?:\s+Service Unavailable)?\b|\b429\s+Too Many Requests\b|socket hang up|network error|request to\s+\S+\s+failed, reason:|tarball.{0,40}(?:download|fetch).{0,20}fail|net::ERR_NAME_NOT_RESOLVED|registry unreachable/i;
+const ERROR_PREFIXED_LINE =
+	/^(?:.*\bnpm error\b.*|##\[error\].*|::error::.*)$/im;
 
 /**
  * @typedef {{ kind: "real" | "infra-kill" | "infra-net", detail: string }} Classification

--- a/scripts/lib/ci-failure-classifier.mjs
+++ b/scripts/lib/ci-failure-classifier.mjs
@@ -146,7 +146,7 @@ const KILLED_LINE = /(?:^|[\s:])Killed(?:\s|$)/m;
 // Scoped to lines that also carry an explicit error-shaped prefix (npm's
 // own "npm error" convention, or the runner's own "##[error]" annotation) --
 // a "npm warn" line or arbitrary test output text no longer qualifies.
-const NET_PATTERN =
+export const NET_PATTERN =
 	/getaddrinfo\s+\w+\s+\S+|\bENOTFOUND\b|\bECONNRESET\b|tarball.{0,40}(?:download|fetch).{0,20}fail|net::ERR_NAME_NOT_RESOLVED/i;
 const ERROR_PREFIXED_LINE = /^(?:.*\bnpm error\b.*|##\[error\].*)$/im;
 

--- a/scripts/lib/retry.d.mts
+++ b/scripts/lib/retry.d.mts
@@ -2,7 +2,7 @@
 
 export type RetryAttemptResult<T> =
 	| { ok: true; value: T }
-	| { ok: false; reason: string };
+	| { ok: false; reason: string; retryable?: boolean };
 
 export type RetryResult<T> =
 	| { ok: true; value: T; attempt: number }

--- a/scripts/lib/retry.mjs
+++ b/scripts/lib/retry.mjs
@@ -14,7 +14,7 @@ const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * @template T
- * @param {(attempt: number) => Promise<{ ok: true, value: T } | { ok: false, reason: string }>} attemptFn
+ * @param {(attempt: number) => Promise<{ ok: true, value: T } | { ok: false, reason: string, retryable?: boolean }>} attemptFn
  * @param {{ attempts?: number, backoffMs?: number[], sleep?: (ms: number) => Promise<void> }} [opts]
  * @returns {Promise<{ ok: true, value: T, attempt: number } | { ok: false, reasons: string[] }>}
  */
@@ -29,6 +29,7 @@ export async function retryWithBackoff(attemptFn, opts = {}) {
 		const result = await attemptFn(attempt);
 		if (result.ok) return { ok: true, value: result.value, attempt };
 		reasons.push(result.reason);
+		if (result.retryable === false) break;
 	}
 	return { ok: false, reasons };
 }

--- a/scripts/npm-retry.d.mts
+++ b/scripts/npm-retry.d.mts
@@ -4,3 +4,8 @@ export function main(
 	args: string[],
 	env: Record<string, string | undefined>,
 ): Promise<number>;
+
+export function classifyNpmFailure(
+	stderr: string,
+	run?: { timedOut?: boolean; error?: Error; code?: number | null },
+): { retryable: boolean; reason: string };

--- a/scripts/npm-retry.mjs
+++ b/scripts/npm-retry.mjs
@@ -36,11 +36,12 @@ const ATTEMPTS = 3;
 const DEFAULT_BACKOFF_MS = [0, 5_000, 15_000];
 const BACKOFF_OVERRIDE_ENV_VAR = "NPM_RETRY_BACKOFF_MS";
 const ATTEMPT_TIMEOUT_MS = 120_000;
-const DETERMINISTIC_ERROR_PATTERN = /\b(?:ERESOLVE|E404|EINTEGRITY|ETARGET)\b/i;
+const DETERMINISTIC_ERROR_PATTERN =
+	/\b(?:ERESOLVE|E404|EINTEGRITY|ETARGET|ENOTEMPTY|EEXIST)\b/i;
 const NPM_EVIDENCE_LINE =
 	/^(?:\s*npm (?:error\b|ERR!)(?:\s|$).*|\s*request to https?:\/\/\S+ failed, reason:.*)$/gim;
 const NPM_SCOPED_PATTERN =
-	/\b(?:502|503|504)(?:\s+Service Unavailable)?\b|\b429\s+Too Many Requests\b|socket hang up|network error|\b(?:ETIMEDOUT|EAI_AGAIN|ECONNREFUSED|EPIPE|ENETUNREACH|EHOSTUNREACH|FETCH_ERROR|ERR_SOCKET_TIMEOUT)\b|registry unreachable/i;
+	/^\s*npm (?:error|ERR!) code (?:E429|E5\d\d)\b|\b(?:502|503|504)(?:\s+Service Unavailable)?\b|\b429\s+Too Many Requests\b|socket hang up|network error|\b(?:ETIMEDOUT|EAI_AGAIN|ECONNREFUSED|EPIPE|ENETUNREACH|EHOSTUNREACH|FETCH_ERROR|ERR_SOCKET_TIMEOUT)\b|registry unreachable/i;
 // Composed from the CI pattern plus npm-only evidence. The line gate keeps
 // shared tokens out of compiler/linter/test text while npm retains the
 // broader retry-oriented network vocabulary.

--- a/scripts/npm-retry.mjs
+++ b/scripts/npm-retry.mjs
@@ -11,12 +11,11 @@
  * and scripts/resolve-newest-in-range-host.mjs (which needs to CAPTURE
  * `npm view`'s stdout, unlike this passthrough wrapper) both build on.
  *
- * Unlike audit-prod-deps.mjs, exhaustion here is NOT a benign pass — an
- * install that never succeeded cannot let the build continue — so this
- * still exits non-zero on exhaustion, but prints a distinct
- * `::error::infra: registry unreachable` line first so a red log is
- * immediately legible as "retried and still couldn't reach the registry"
- * rather than "a real dependency conflict on attempt 1".
+ * Only timeout, spawn-error, or NET_PATTERN-shaped failures are retryable.
+ * Deterministic npm errors (ERESOLVE, E404, EINTEGRITY, and ETARGET) and
+ * other nonzero exits stop after the first attempt. On retryable exhaustion,
+ * this prints `::error::infra: registry unreachable`; deterministic failures
+ * print a plain `failed after N attempt(s)` line instead.
  *
  * Usage: node scripts/npm-retry.mjs <npm subcommand + args...>
  * Test-only backoff override: NPM_RETRY_BACKOFF_MS="0,0,0" (comma-separated
@@ -24,12 +23,14 @@
  */
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { NET_PATTERN } from "./lib/ci-failure-classifier.mjs";
 import { retryWithBackoff } from "./lib/retry.mjs";
 
 const ATTEMPTS = 3;
 const DEFAULT_BACKOFF_MS = [0, 5_000, 15_000];
 const BACKOFF_OVERRIDE_ENV_VAR = "NPM_RETRY_BACKOFF_MS";
 const ATTEMPT_TIMEOUT_MS = 120_000;
+const DETERMINISTIC_ERROR_PATTERN = /\b(?:ERESOLVE|E404|EINTEGRITY|ETARGET)\b/i;
 
 function backoffMsFrom(env) {
 	const override = env?.[BACKOFF_OVERRIDE_ENV_VAR];
@@ -39,7 +40,13 @@ function backoffMsFrom(env) {
 
 function runOnce(args) {
 	return new Promise((resolvePromise) => {
-		const child = spawn("npm", args, { stdio: "inherit" });
+		const child = spawn("npm", args, { stdio: ["inherit", "inherit", "pipe"] });
+		let stderr = "";
+		child.stderr.on("data", (chunk) => {
+			const text = chunk.toString();
+			stderr += text;
+			process.stderr.write(text);
+		});
 		let timedOut = false;
 		const timer = setTimeout(() => {
 			timedOut = true;
@@ -47,11 +54,11 @@ function runOnce(args) {
 		}, ATTEMPT_TIMEOUT_MS);
 		child.on("close", (code) => {
 			clearTimeout(timer);
-			resolvePromise({ code, timedOut });
+			resolvePromise({ code, timedOut, stderr });
 		});
 		child.on("error", (err) => {
 			clearTimeout(timer);
-			resolvePromise({ code: null, timedOut: false, error: err });
+			resolvePromise({ code: null, timedOut: false, error: err, stderr });
 		});
 	});
 }
@@ -68,13 +75,17 @@ export async function main(args, env) {
 			const run = await runOnce(args);
 			lastCode = run.code ?? 1;
 			if (run.code === 0) return { ok: true, value: run };
+			const retryable =
+				run.timedOut || Boolean(run.error) || NET_PATTERN.test(run.stderr);
 			const reason = run.timedOut
 				? `timed out after ${ATTEMPT_TIMEOUT_MS}ms`
 				: run.error
 					? `spawn error: ${run.error.message}`
-					: `exited ${run.code}`;
+					: NET_PATTERN.test(run.stderr)
+						? `network error: ${run.stderr.match(NET_PATTERN)[0]}`
+						: `exited ${run.code}${run.stderr.match(DETERMINISTIC_ERROR_PATTERN) ? ` (${run.stderr.match(DETERMINISTIC_ERROR_PATTERN)[0]})` : ""}`;
 			console.error(`npm-retry: attempt ${attempt + 1} ${reason}`);
-			return { ok: false, reason };
+			return { ok: false, reason, retryable };
 		},
 		{ attempts: ATTEMPTS, backoffMs: backoffMsFrom(env) },
 	);
@@ -92,9 +103,22 @@ export async function main(args, env) {
 		return 0;
 	}
 
-	console.error(
-		`::error::infra: registry unreachable — npm ${args.join(" ")} failed ${ATTEMPTS} times (${result.reasons.join("; ")})`,
-	);
+	const attemptsUsed = result.reasons.length;
+	const summary = `npm ${args.join(" ")} failed after ${attemptsUsed} attempt${attemptsUsed === 1 ? "" : "s"}`;
+	if (
+		result.reasons.some(
+			(reason) =>
+				reason.startsWith("timed out") ||
+				reason.startsWith("spawn error") ||
+				NET_PATTERN.test(reason),
+		)
+	) {
+		console.error(
+			`::error::infra: registry unreachable — ${summary} (${result.reasons.join("; ")})`,
+		);
+	} else {
+		console.error(`${summary} (${result.reasons.join("; ")})`);
+	}
 	return lastCode || 1;
 }
 

--- a/scripts/npm-retry.mjs
+++ b/scripts/npm-retry.mjs
@@ -11,7 +11,7 @@
  * and scripts/resolve-newest-in-range-host.mjs (which needs to CAPTURE
  * `npm view`'s stdout, unlike this passthrough wrapper) both build on.
  *
- * Timeout, spawn-error, or NET_PATTERN-shaped failures are retryable.
+ * Timeout, spawn-error, or npm-evidence-shaped network failures are retryable.
  * Network evidence wins when it appears with a deterministic npm code:
  * losing a legitimate retry is worse than one redundant retry. Deterministic
  * npm errors (ERESOLVE, E404, EINTEGRITY, and ETARGET) stop after one attempt
@@ -37,6 +37,17 @@ const DEFAULT_BACKOFF_MS = [0, 5_000, 15_000];
 const BACKOFF_OVERRIDE_ENV_VAR = "NPM_RETRY_BACKOFF_MS";
 const ATTEMPT_TIMEOUT_MS = 120_000;
 const DETERMINISTIC_ERROR_PATTERN = /\b(?:ERESOLVE|E404|EINTEGRITY|ETARGET)\b/i;
+const NPM_EVIDENCE_LINE =
+	/^(?:\s*npm (?:error\b|ERR!)(?:\s|$).*|\s*request to https?:\/\/\S+ failed, reason:.*)$/gim;
+const NPM_SCOPED_PATTERN =
+	/\b(?:502|503|504)(?:\s+Service Unavailable)?\b|\b429\s+Too Many Requests\b|socket hang up|network error|\b(?:ETIMEDOUT|EAI_AGAIN|ECONNREFUSED|EPIPE|ENETUNREACH|EHOSTUNREACH|FETCH_ERROR|ERR_SOCKET_TIMEOUT)\b|registry unreachable/i;
+// Composed from the CI pattern plus npm-only evidence. The line gate keeps
+// shared tokens out of compiler/linter/test text while npm retains the
+// broader retry-oriented network vocabulary.
+const NPM_NET_PATTERN = new RegExp(
+	`(?:${NET_PATTERN.source}|${NPM_SCOPED_PATTERN.source})`,
+	"i",
+);
 
 /**
  * Classify one npm attempt. Network evidence is checked first so mixed output
@@ -46,7 +57,11 @@ const DETERMINISTIC_ERROR_PATTERN = /\b(?:ERESOLVE|E404|EINTEGRITY|ETARGET)\b/i;
  * @returns {{ retryable: boolean, reason: string }}
  */
 export function classifyNpmFailure(stderr, run = {}) {
-	const networkMatch = NET_PATTERN.exec(stderr);
+	let networkMatch = null;
+	for (const line of String(stderr).matchAll(NPM_EVIDENCE_LINE)) {
+		networkMatch = NPM_NET_PATTERN.exec(line[0]);
+		if (networkMatch) break;
+	}
 	if (run.timedOut) {
 		return {
 			retryable: true,

--- a/scripts/npm-retry.mjs
+++ b/scripts/npm-retry.mjs
@@ -11,11 +11,17 @@
  * and scripts/resolve-newest-in-range-host.mjs (which needs to CAPTURE
  * `npm view`'s stdout, unlike this passthrough wrapper) both build on.
  *
- * Only timeout, spawn-error, or NET_PATTERN-shaped failures are retryable.
- * Deterministic npm errors (ERESOLVE, E404, EINTEGRITY, and ETARGET) and
- * other nonzero exits stop after the first attempt. On retryable exhaustion,
- * this prints `::error::infra: registry unreachable`; deterministic failures
- * print a plain `failed after N attempt(s)` line instead.
+ * Timeout, spawn-error, or NET_PATTERN-shaped failures are retryable.
+ * Network evidence wins when it appears with a deterministic npm code:
+ * losing a legitimate retry is worse than one redundant retry. Deterministic
+ * npm errors (ERESOLVE, E404, EINTEGRITY, and ETARGET) stop after one attempt
+ * when no network evidence appears. Unknown non-network failures retain the
+ * previous retry behavior. On retryable exhaustion, this preserves the
+ * origin/master annotation `::error::infra: registry unreachable — npm ...
+ * failed 3 times`; deterministic failures print a plain `failed after N
+ * attempt(s)` line instead. E404 stays deterministic because npm uses it for
+ * a missing pinned version; transient mirror 404s are rare and the
+ * install-smoke lane would resurface them.
  *
  * Usage: node scripts/npm-retry.mjs <npm subcommand + args...>
  * Test-only backoff override: NPM_RETRY_BACKOFF_MS="0,0,0" (comma-separated
@@ -31,6 +37,34 @@ const DEFAULT_BACKOFF_MS = [0, 5_000, 15_000];
 const BACKOFF_OVERRIDE_ENV_VAR = "NPM_RETRY_BACKOFF_MS";
 const ATTEMPT_TIMEOUT_MS = 120_000;
 const DETERMINISTIC_ERROR_PATTERN = /\b(?:ERESOLVE|E404|EINTEGRITY|ETARGET)\b/i;
+
+/**
+ * Classify one npm attempt. Network evidence is checked first so mixed output
+ * cannot turn a recoverable registry failure into a one-attempt stop.
+ * @param {string} stderr
+ * @param {{ timedOut?: boolean, error?: Error, code?: number | null }} [run]
+ * @returns {{ retryable: boolean, reason: string }}
+ */
+export function classifyNpmFailure(stderr, run = {}) {
+	const networkMatch = NET_PATTERN.exec(stderr);
+	if (run.timedOut) {
+		return {
+			retryable: true,
+			reason: `timed out after ${ATTEMPT_TIMEOUT_MS}ms`,
+		};
+	}
+	if (run.error) {
+		return { retryable: true, reason: `spawn error: ${run.error.message}` };
+	}
+	if (networkMatch) {
+		return { retryable: true, reason: `network error: ${networkMatch[0]}` };
+	}
+	const deterministicMatch = DETERMINISTIC_ERROR_PATTERN.exec(stderr);
+	return {
+		retryable: !deterministicMatch,
+		reason: `exited ${run.code ?? 1}${deterministicMatch ? ` (${deterministicMatch[0]})` : ""}`,
+	};
+}
 
 function backoffMsFrom(env) {
 	const override = env?.[BACKOFF_OVERRIDE_ENV_VAR];
@@ -75,15 +109,7 @@ export async function main(args, env) {
 			const run = await runOnce(args);
 			lastCode = run.code ?? 1;
 			if (run.code === 0) return { ok: true, value: run };
-			const retryable =
-				run.timedOut || Boolean(run.error) || NET_PATTERN.test(run.stderr);
-			const reason = run.timedOut
-				? `timed out after ${ATTEMPT_TIMEOUT_MS}ms`
-				: run.error
-					? `spawn error: ${run.error.message}`
-					: NET_PATTERN.test(run.stderr)
-						? `network error: ${run.stderr.match(NET_PATTERN)[0]}`
-						: `exited ${run.code}${run.stderr.match(DETERMINISTIC_ERROR_PATTERN) ? ` (${run.stderr.match(DETERMINISTIC_ERROR_PATTERN)[0]})` : ""}`;
+			const { retryable, reason } = classifyNpmFailure(run.stderr, run);
 			console.error(`npm-retry: attempt ${attempt + 1} ${reason}`);
 			return { ok: false, reason, retryable };
 		},
@@ -104,15 +130,16 @@ export async function main(args, env) {
 	}
 
 	const attemptsUsed = result.reasons.length;
-	const summary = `npm ${args.join(" ")} failed after ${attemptsUsed} attempt${attemptsUsed === 1 ? "" : "s"}`;
-	if (
-		result.reasons.some(
-			(reason) =>
-				reason.startsWith("timed out") ||
-				reason.startsWith("spawn error") ||
-				NET_PATTERN.test(reason),
-		)
-	) {
+	const networkRetry = result.reasons.some(
+		(reason) =>
+			reason.startsWith("timed out") ||
+			reason.startsWith("spawn error") ||
+			reason.startsWith("network error"),
+	);
+	const summary = networkRetry
+		? `npm ${args.join(" ")} failed ${attemptsUsed} times`
+		: `npm ${args.join(" ")} failed after ${attemptsUsed} attempt${attemptsUsed === 1 ? "" : "s"}`;
+	if (networkRetry) {
 		console.error(
 			`::error::infra: registry unreachable — ${summary} (${result.reasons.join("; ")})`,
 		);

--- a/tests/scripts/ci-failure-classifier.test.ts
+++ b/tests/scripts/ci-failure-classifier.test.ts
@@ -282,6 +282,34 @@ describe("classifyFailureLog (#2103)", () => {
 		expect(result.kind).toBe("infra-net");
 	});
 
+	// Regression proof for the shared NET_PATTERN consumer: a newly recognized
+	// npm network line must reach the real classifier, not only npm-retry.
+	it("recognizes the shared npm and registry network shapes as infra-net", () => {
+		const shapes = [
+			"ETIMEDOUT",
+			"EAI_AGAIN",
+			"503 Service Unavailable",
+			"429 Too Many Requests",
+			"socket hang up",
+			"network error",
+			"ECONNREFUSED",
+			"EPIPE",
+			"ENETUNREACH",
+			"EHOSTUNREACH",
+			"FETCH_ERROR",
+			"ERR_SOCKET_TIMEOUT",
+			"request to https://registry.example failed, reason:",
+			"502",
+			"504",
+			"registry unreachable",
+		];
+		for (const shape of shapes) {
+			expect(classifyFailureLog(`npm error ${shape}`).kind, shape).toBe(
+				"infra-net",
+			);
+		}
+	});
+
 	// F5: empty log is distinguishable from "read something, didn't
 	// recognize it" -- the two are different failure modes (fetch itself
 	// failed / raced the upload, vs. a genuinely new failure shape).

--- a/tests/scripts/ci-failure-classifier.test.ts
+++ b/tests/scripts/ci-failure-classifier.test.ts
@@ -340,9 +340,7 @@ describe("classifyFailureLog (#2103)", () => {
 			"registry unreachable",
 		];
 		for (const shape of shapes) {
-			expect(classifyFailureLog(`npm error ${shape}`).kind, shape).toBe(
-				"real",
-			);
+			expect(classifyFailureLog(`npm error ${shape}`).kind, shape).toBe("real");
 		}
 	});
 
@@ -375,6 +373,16 @@ describe("classifyFailureLog (#2103)", () => {
 		const log = `${oversizedHead}\n##[error]Process completed with exit code 1.\n`;
 		const result = classifyFailureLog(log);
 		expect(result.kind).toBe("real");
+	});
+
+	// Round 4 recurrence: the eligible-line bound must remain active, or a
+	// pathological log can make a late network token change a real verdict.
+	it("round 4: the 1,001st eligible line is outside the scan bound", () => {
+		const log = [
+			...Array.from({ length: 1_000 }, () => "npm error unrelated"),
+			"npm error code ECONNRESET",
+		].join("\n");
+		expect(classifyFailureLog(log).kind).toBe("real");
 	});
 
 	// V4 (BLOCKING, red-proof with the reviewer's fabricated-title shape): a

--- a/tests/scripts/ci-failure-classifier.test.ts
+++ b/tests/scripts/ci-failure-classifier.test.ts
@@ -282,9 +282,46 @@ describe("classifyFailureLog (#2103)", () => {
 		expect(result.kind).toBe("infra-net");
 	});
 
+	// Round 3 HIGH: the shared CI pattern must not treat a token mentioned by
+	// a real compiler/linter/knip error, URL, or test name as network evidence.
+	it("round 3: token mentions in real error contexts remain real", () => {
+		const logs = [
+			'##[error] src/foo.ts(1,7): error TS2322: Type "ETIMEDOUT" is not assignable',
+			"##[error] /src/foo.js:1:1 error socket hang up no-socket-rule",
+			"##[error] knip: https://example.test/502/status unused export",
+			"##[error] test name: retries after ECONNRESET (expected real failure)",
+		];
+		for (const log of logs) {
+			expect(classifyFailureLog(log).kind, log).toBe("real");
+		}
+	});
+
+	// Round 3 MEDIUM: inspect all bounded eligible error lines, not only the
+	// first one, so npm's deterministic preamble cannot hide later network data.
+	it("round 3: a later eligible npm error line still classifies infra-net", () => {
+		const result = classifyFailureLog(
+			"npm error ERESOLVE unable to resolve dependency tree\nnpm error ECONNRESET\n",
+		);
+		expect(result.kind).toBe("infra-net");
+	});
+
 	// Regression proof for the shared NET_PATTERN consumer: a newly recognized
 	// npm network line must reach the real classifier, not only npm-retry.
 	it("recognizes the shared npm and registry network shapes as infra-net", () => {
+		const shapes = [
+			"ENOTFOUND",
+			"ECONNRESET",
+			"tarball package download failed",
+			"net::ERR_NAME_NOT_RESOLVED",
+		];
+		for (const shape of shapes) {
+			expect(classifyFailureLog(`npm error ${shape}`).kind, shape).toBe(
+				"infra-net",
+			);
+		}
+	});
+
+	it("round 3: npm-only network shapes stay real for the CI classifier", () => {
 		const shapes = [
 			"ETIMEDOUT",
 			"EAI_AGAIN",
@@ -298,14 +335,13 @@ describe("classifyFailureLog (#2103)", () => {
 			"EHOSTUNREACH",
 			"FETCH_ERROR",
 			"ERR_SOCKET_TIMEOUT",
-			"request to https://registry.example failed, reason:",
 			"502",
 			"504",
 			"registry unreachable",
 		];
 		for (const shape of shapes) {
 			expect(classifyFailureLog(`npm error ${shape}`).kind, shape).toBe(
-				"infra-net",
+				"real",
 			);
 		}
 	});

--- a/tests/scripts/npm-retry.test.ts
+++ b/tests/scripts/npm-retry.test.ts
@@ -74,25 +74,53 @@ describe("npm-retry.mjs (#2613 review S3a)", () => {
 	// must remain eligible for the backoff path.
 	it("classifies every npm network shape as retryable", () => {
 		const shapes = [
-			"ETIMEDOUT",
-			"EAI_AGAIN",
-			"503 Service Unavailable",
-			"429 Too Many Requests",
-			"socket hang up",
-			"network error",
-			"ECONNREFUSED",
-			"EPIPE",
-			"ENETUNREACH",
-			"EHOSTUNREACH",
-			"FETCH_ERROR",
-			"ERR_SOCKET_TIMEOUT",
-			"npm error request to https://registry.example failed, reason:",
-			"502",
-			"504",
+			"npm error ETIMEDOUT",
+			"npm ERR! EAI_AGAIN",
+			"npm error 503 Service Unavailable",
+			"npm error 429 Too Many Requests",
+			"npm error socket hang up",
+			"npm error network error",
+			"npm error ECONNREFUSED",
+			"npm error EPIPE",
+			"npm error ENETUNREACH",
+			"npm error EHOSTUNREACH",
+			"npm error FETCH_ERROR",
+			"npm error ERR_SOCKET_TIMEOUT",
+			"request to https://registry.example failed, reason: ECONNRESET",
+			"npm error 502",
+			"npm error 504",
+			"npm error tarball package download failed",
+			"npm error registry unreachable",
 		];
 		for (const shape of shapes) {
 			expect(classifyNpmFailure(shape).retryable, shape).toBe(true);
+			expect(classifyNpmFailure(shape).reason, shape).toContain(
+				"network error",
+			);
 		}
+	});
+
+	it("round 3: the npm pattern ignores network tokens in non-npm contexts", () => {
+		const lines = [
+			'error TS2322: Type "ETIMEDOUT" is not assignable',
+			"error socket hang up no-socket-rule",
+			"knip: https://example.test/502/status unused export",
+			"test name retries after ECONNRESET",
+		];
+		for (const line of lines) {
+			// Unknown non-network failures retain npm-retry's compatibility retry
+			// behavior; the guard under test is that they are not called network.
+			expect(classifyNpmFailure(line).reason, line).not.toContain(
+				"network error",
+			);
+		}
+	});
+
+	it("round 3: npm evidence wins over deterministic codes on a later line", () => {
+		const result = classifyNpmFailure(
+			"npm error ERESOLVE unable to resolve dependency tree\nnpm error ECONNRESET",
+		);
+		expect(result.retryable).toBe(true);
 	});
 
 	// Network evidence wins because losing a legitimate retry costs more than

--- a/tests/scripts/npm-retry.test.ts
+++ b/tests/scripts/npm-retry.test.ts
@@ -9,6 +9,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { classifyFailureLog } from "../../scripts/lib/ci-failure-classifier.mjs";
 
 const REPO_ROOT = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -27,7 +28,11 @@ afterEach(() => {
 // registry) while exercising the real spawn path end to end. Fails
 // `failTimes` times (tracked via a counter file, since each attempt is a
 // separate process) before succeeding, or forever for the exhaustion case.
-function stubNpm(root: string, failTimes: number) {
+function stubNpm(
+	root: string,
+	failTimes: number,
+	failure = "stub: simulated registry failure",
+) {
 	const binDir = path.join(root, "bin");
 	fs.mkdirSync(binDir);
 	const npmStub = path.join(binDir, "npm");
@@ -41,7 +46,7 @@ function stubNpm(root: string, failTimes: number) {
 			`const counterFile = ${JSON.stringify(counterFile)};`,
 			`const n = Number(fs.readFileSync(counterFile, "utf8")) + 1;`,
 			`fs.writeFileSync(counterFile, String(n));`,
-			`if (n <= ${failTimes}) { console.error("stub: simulated registry failure"); process.exit(1); }`,
+			`if (n <= ${failTimes}) { console.error(${JSON.stringify(failure)}); process.exit(1); }`,
 			`console.log("stub: ok, args=" + process.argv.slice(2).join(" "));`,
 			"",
 		].join("\n"),
@@ -76,7 +81,7 @@ describe("npm-retry.mjs (#2613 review S3a)", () => {
 	it("retries a failing npm call and succeeds once it recovers", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-npm-retry-"));
 		tempDirs.push(root);
-		const binDir = stubNpm(root, 2);
+		const binDir = stubNpm(root, 2, "npm error code ECONNRESET");
 		const stdout = runCli(binDir, ["install", "--no-save"]);
 		expect(stdout).toContain("stub: ok, args=install --no-save");
 	});
@@ -89,7 +94,7 @@ describe("npm-retry.mjs (#2613 review S3a)", () => {
 	it("prints the 'succeeded on attempt' diagnostic to stderr, never stdout", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-npm-retry-"));
 		tempDirs.push(root);
-		const binDir = stubNpm(root, 1);
+		const binDir = stubNpm(root, 1, "npm error code ECONNRESET");
 		const result = spawnSync(process.execPath, [CLI, "install", "--no-save"], {
 			env: {
 				...process.env,
@@ -107,7 +112,7 @@ describe("npm-retry.mjs (#2613 review S3a)", () => {
 	it("exits non-zero with a distinct infra label when every retry fails", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-npm-retry-"));
 		tempDirs.push(root);
-		const binDir = stubNpm(root, 999);
+		const binDir = stubNpm(root, 999, "npm error code ECONNRESET");
 		try {
 			runCli(binDir, ["ci", "--ignore-scripts"]);
 			expect.unreachable("expected the CLI to exit nonzero");
@@ -115,7 +120,31 @@ describe("npm-retry.mjs (#2613 review S3a)", () => {
 			const e = err as { status?: number; stderr?: string };
 			expect(e.status).not.toBe(0);
 			expect(e.stderr).toMatch(/::error::infra: registry unreachable/);
-			expect(e.stderr).toMatch(/npm ci --ignore-scripts failed 3 times/);
+			expect(e.stderr).toMatch(
+				/npm ci --ignore-scripts failed after 3 attempts/,
+			);
+		}
+	});
+
+	it("does not retry or label a deterministic ERESOLVE failure as infra", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-npm-retry-"));
+		tempDirs.push(root);
+		const binDir = stubNpm(root, 999, "npm error code ERESOLVE");
+		try {
+			runCli(binDir, ["ci", "--ignore-scripts"]);
+			expect.unreachable("expected the CLI to exit nonzero");
+		} catch (err) {
+			const e = err as { status?: number; stderr?: string };
+			expect(e.status).toBe(1);
+			expect(e.stderr).not.toContain("infra: registry unreachable");
+			expect(e.stderr).toContain(
+				"npm ci --ignore-scripts failed after 1 attempt",
+			);
+			expect(e.stderr).not.toMatch(/failed after 1 attempt.*infra/);
+			expect(fs.readFileSync(path.join(root, ".npm-stub-calls"), "utf8")).toBe(
+				"1",
+			);
+			expect(classifyFailureLog(e.stderr ?? "").kind).toBe("real");
 		}
 	});
 });

--- a/tests/scripts/npm-retry.test.ts
+++ b/tests/scripts/npm-retry.test.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { classifyFailureLog } from "../../scripts/lib/ci-failure-classifier.mjs";
+import { classifyNpmFailure } from "../../scripts/npm-retry.mjs";
 
 const REPO_ROOT = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -69,6 +70,50 @@ function runCli(binDir: string, args: string[]) {
 }
 
 describe("npm-retry.mjs (#2613 review S3a)", () => {
+	// Regression proof for npm retry drift: each documented registry failure
+	// must remain eligible for the backoff path.
+	it("classifies every npm network shape as retryable", () => {
+		const shapes = [
+			"ETIMEDOUT",
+			"EAI_AGAIN",
+			"503 Service Unavailable",
+			"429 Too Many Requests",
+			"socket hang up",
+			"network error",
+			"ECONNREFUSED",
+			"EPIPE",
+			"ENETUNREACH",
+			"EHOSTUNREACH",
+			"FETCH_ERROR",
+			"ERR_SOCKET_TIMEOUT",
+			"npm error request to https://registry.example failed, reason:",
+			"502",
+			"504",
+		];
+		for (const shape of shapes) {
+			expect(classifyNpmFailure(shape).retryable, shape).toBe(true);
+		}
+	});
+
+	// Network evidence wins because losing a legitimate retry costs more than
+	// one redundant retry when npm prints both diagnostics.
+	it("gives network signals precedence over deterministic npm errors", () => {
+		const result = classifyNpmFailure(
+			"npm error ERESOLVE unable to resolve dependency tree\nnpm error ECONNRESET",
+		);
+		expect(result.retryable).toBe(true);
+	});
+
+	// Pins the one-attempt guard and its deliberate unknown-error compatibility
+	// behavior; deleting the deterministic set must make this test red.
+	it("stops deterministic errors after one attempt and retries unknown errors", () => {
+		expect(classifyNpmFailure("npm error ERESOLVE").retryable).toBe(false);
+		expect(classifyNpmFailure("npm error E404").retryable).toBe(false);
+		expect(classifyNpmFailure("npm error EINTEGRITY").retryable).toBe(false);
+		expect(classifyNpmFailure("npm error ETARGET").retryable).toBe(false);
+		expect(classifyNpmFailure("npm error something new").retryable).toBe(true);
+	});
+
 	it("passes through a successful npm call with no retry", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-npm-retry-"));
 		tempDirs.push(root);
@@ -120,9 +165,23 @@ describe("npm-retry.mjs (#2613 review S3a)", () => {
 			const e = err as { status?: number; stderr?: string };
 			expect(e.status).not.toBe(0);
 			expect(e.stderr).toMatch(/::error::infra: registry unreachable/);
-			expect(e.stderr).toMatch(
-				/npm ci --ignore-scripts failed after 3 attempts/,
-			);
+			expect(e.stderr).toMatch(/npm ci --ignore-scripts failed 3 times/);
+		}
+	});
+
+	it("pins the origin/master exhaustion annotation and its classifier verdict", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-npm-retry-"));
+		tempDirs.push(root);
+		const binDir = stubNpm(root, 999, "npm error ECONNRESET");
+		try {
+			runCli(binDir, ["ci"]);
+			expect.unreachable("expected the CLI to exit nonzero");
+		} catch (err) {
+			const e = err as { stderr?: string };
+			const annotation =
+				"::error::infra: registry unreachable — npm ci failed 3 times (network error: ECONNRESET; network error: ECONNRESET; network error: ECONNRESET)";
+			expect(e.stderr).toContain(annotation);
+			expect(classifyFailureLog(annotation).kind).toBe("infra-net");
 		}
 	});
 

--- a/tests/scripts/npm-retry.test.ts
+++ b/tests/scripts/npm-retry.test.ts
@@ -70,6 +70,38 @@ function runCli(binDir: string, args: string[]) {
 }
 
 describe("npm-retry.mjs (#2613 review S3a)", () => {
+	const stateSpace = [
+		["ECONNRESET", "npm error code ECONNRESET", true, true, "infra-net"],
+		["ETIMEDOUT", "npm error code ETIMEDOUT", true, true, "real"],
+		["ECONNREFUSED", "npm error code ECONNREFUSED", true, true, "real"],
+		["EAI_AGAIN", "npm error code EAI_AGAIN", true, true, "real"],
+		["ENOTFOUND", "npm error code ENOTFOUND", true, true, "infra-net"],
+		["E429", "npm error code E429", true, true, "real"],
+		["E5xx", "npm error code E503", true, true, "real"],
+		["socket hang up", "npm error socket hang up", true, true, "real"],
+		["E404", "npm error code E404", false, false, "real"],
+		["ERESOLVE", "npm error code ERESOLVE", false, false, "real"],
+		["EINTEGRITY", "npm error code EINTEGRITY", false, false, "real"],
+		["ENOTEMPTY/EEXIST", "npm error code ENOTEMPTY", false, false, "real"],
+		["exit-code-only", "npm error package failed", true, false, "real"],
+	] as const;
+
+	// Round 4 recurrence: npm retry and CI classification must agree on the
+	// evidence model without widening the shared CI pattern with npm-only text.
+	it.each(stateSpace)(
+		"keeps the round-4 state-space row %s aligned across consumers",
+		(_name, stderr, npmRetryable, npmNetwork, ciKind) => {
+			const npmResult = classifyNpmFailure(stderr);
+			expect(npmResult.retryable, stderr).toBe(npmRetryable);
+			expect(classifyFailureLog(stderr).kind, stderr).toBe(ciKind);
+			if (npmNetwork) {
+				expect(npmResult.reason, stderr).toContain("network error");
+			} else {
+				expect(npmResult.reason, stderr).not.toContain("network error");
+			}
+		},
+	);
+
 	// Regression proof for npm retry drift: each documented registry failure
 	// must remain eligible for the backoff path.
 	it("classifies every npm network shape as retryable", () => {


### PR DESCRIPTION
## Summary

Closes #2684. This PR makes npm retry exhaustion annotate infrastructure only
when npm evidence identifies a registry or network-transient failure. It also
keeps the shared CI classifier conservative and bounds its eligible-line scan.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [x] area:dispatch
- [x] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files pass locally after `npm run build` where the environment permits.
- [x] New regression tests are proven RED on pre-fix code below.
- [x] New guards, branches, and filters are mutation-proof below.
- [x] PR title carries the conventional prefix and issue ref.
- [x] `npm run lint` passes.
- [x] Changelog fragment is present and valid.
- [x] Commit subject includes `refs #2684`.

## Tests

Existing commits `6b002855`, `a49e4561`, and `b19ef873` establish the original
retry gate, shared classification, and npm-scoped composition. Round 4 edits
`tests/scripts/npm-retry.test.ts` with table-driven decision tests and
`tests/scripts/ci-failure-classifier.test.ts` with the 1,001-line cap boundary.
The npm child-process cases remain present, but this sandbox cannot execute
real-child npm suites because child spawning returns EPERM.

### Round 4 state-space table, written before the code edit

The table is the decision model. Every row is asserted by a table-driven test
against the exported decision function for that consumer. `network/transient`
means the tool should retry and annotate exhaustion; `deterministic` means it
must stop and stay unannotated; `unknown` preserves npm's compatibility retry
without an infra annotation.

| npm failure signature | class | consumer | retry? | annotation? |
| --- | --- | --- | --- | --- |
| ECONNRESET | network/registry-transient | both: npm scoped / CI `classifyFailureLog` | yes | yes for npm exhaustion / CI infra-net |
| ETIMEDOUT | network/registry-transient | npm scoped | yes | yes for npm exhaustion |
| ECONNREFUSED | network/registry-transient | npm scoped | yes | yes for npm exhaustion |
| EAI_AGAIN | network/registry-transient | npm scoped | yes | yes for npm exhaustion |
| ENOTFOUND | network/registry-transient | both: shared / CI | yes | yes for npm exhaustion / CI infra-net |
| E429 | network/registry-transient | npm scoped | yes | yes for npm exhaustion |
| E5xx / 503 Service Unavailable | network/registry-transient | npm scoped | yes | yes for npm exhaustion |
| socket hang up | network/registry-transient | npm scoped | yes | yes for npm exhaustion |
| E404 | deterministic | both decision functions | no | no |
| ERESOLVE | deterministic | both decision functions | no | no |
| EINTEGRITY | deterministic | both decision functions | no | no |
| ENOTEMPTY/EEXIST | deterministic | both decision functions | no | no |
| exit-code-only | unknown | npm scoped | yes | no |

The single anchored npm-local rule is `npm (error|ERR!) code
(E429|E5\d\d|ECONNRESET|ETIMEDOUT|ECONNREFUSED|EAI_AGAIN|ENOTFOUND)` when
the signature is printed in npm's code form. The implementation retains the
shared `NET_PATTERN` for CI's conservative vocabulary and composes npm-only
signals for forms such as `socket hang up` and `network error`. An explicit
alternation is chosen because it has shorter deterministic exclusions than a
generic `code E\d{3}` rule: only the npm deterministic codes need exclusion,
rather than every non-transient three-digit npm code, while E404 remains
deterministic.

### Red-first and mutation transcripts

- E429 shape removed from the npm-scoped pattern: pre-fix direct decision test
  failed with this exact output:

  `AssertionError: npm error code E429: expected 'exited 1' to contain 'network error'`

  The observed result was `{ retryable: true, reason: "exited 1" }` without
  a `network error` reason.
- The 1,001-line cap boundary was added before the fix. With the cap removed
  from built output, the boundary test failed with:

  `AssertionError: expected 'infra-net' to be 'real' // Object.is equality`

  The restored cap passes and keeps the verdict `real`.
- Anchor mutation: removing the npm evidence line gate makes the three
  non-npm token fixtures classify as network. The compile-valid mutation
  printed these three results:

  `ETIMEDOUT -> { retryable: true, reason: "network error: ETIMEDOUT" }`

  `socket hang up -> { retryable: true, reason: "network error: socket hang up" }`

  `ECONNRESET -> { retryable: true, reason: "network error: ECONNRESET" }`

## Test assessment

- `tests/scripts/npm-retry.test.ts`: uniquely pins npm retry decisions,
  exhaustion annotation, and the real CLI boundary. The new table rows are
  not redundant with the child-process tests.
- `tests/scripts/ci-failure-classifier.test.ts`: uniquely pins CI verdicts,
  including bounded scanning. The new cap boundary complements the existing
  oversized-byte-cap test.
- `tests/config/dmts-export-drift.test.ts`: checks generated declaration drift.
- `tests/config/escape-regexp-fold-sweep.test.ts`: checks regex folding.
- `tests/clients/flake-shape-ratchet.test.ts`: checks test flake-shape limits.
No touched test is a removal candidate.

## Blast radius

Changed production symbols are `classifyNpmFailure` and the npm retry
composition in `scripts/npm-retry.mjs`, plus exported `NET_PATTERN` and
`classifyFailureLog` in `scripts/lib/ci-failure-classifier.mjs`. Callers are
the install-smoke npm wrapper and the CI classifier/rerun decision path.
The shared pattern remains conservative; only npm-local composition widens.
No per-file or per-spawn hot-path cost changes. Callbacks and durable record
shapes are unaffected.

## Observability

The npm wrapper's bounded stderr record is
`::error::infra: registry unreachable — ...` on retryable exhaustion. The CI
classifier emits the existing `infra-net` classification detail. Deterministic
and unknown failures keep their existing plain output or real verdict.

## Class sweep

The defect class is network-signature classification drift at a shared seam,
including shape 16's evidence requirement and the dispatch retry/annotation
policy. The whole-tree sweep covered `clients/`, `tools/`, `mcp/`, `scripts/`,
`scripts/lib/`, `tests/support/`, `index.ts`, and the requested test/config
governance files. It found the two consumers recorded above and no third npm
retry classifier. The population sweep covers every table row above.

Consolidation verdict: stay distributed at the consumer boundary. CI must keep
the conservative shared `NET_PATTERN`; npm requires additional npm-only
transient evidence because its false-negative cost is higher. Both consumers
share the base vocabulary without forcing npm-only tokens into CI.

## Round 4

Applied the prescribed E429 npm annotation fix, the bound-specific 1,001-line
classifier test, and the changelog wording correction. Real-child npm suites
are skipped in this sandbox because child spawning is blocked with EPERM.

The full targeted run reported `Test Files 1 failed | 4 passed (5)` only
because the six child-process cases in `tests/scripts/npm-retry.test.ts`
failed with `Error: spawnSync /usr/bin/node EPERM`; the 116 non-child tests
passed. The decision-focused rerun reported `13 passed`, and the final
governance suites passed.

