### PR TITLE
fix(ci): check close-keyword placement (closes #2640)

### DIFF
--- a/.changelog/fix-2640-close-keyword-placement.md
+++ b/.changelog/fix-2640-close-keyword-placement.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- Require title close keywords to be repeated in the PR body, preventing the four 2026-09-06 incidents including #2610's merge commit from appearing to close issues that GitHub left open.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,46 +86,6 @@ jobs:
       - name: Check client dependency boundaries
         run: npm run depcruise:check
 
-  close-keyword-lint:
-    name: Close-keyword syntax
-    needs: validate-merge-train-dispatch
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.sha || github.ref }}
-          persist-credentials: false
-
-
-      - name: Validate merge-train dispatch payload
-        if: github.event_name == 'repository_dispatch'
-        env:
-          PAYLOAD_REPOSITORY: ${{ github.event.client_payload.repository }}
-          PAYLOAD_SHA: ${{ github.event.client_payload.sha }}
-        run: |
-          set -euo pipefail
-          if [[ "$PAYLOAD_REPOSITORY" != "$GITHUB_REPOSITORY" ]]; then
-            echo "::error::repository_dispatch repository does not match this repository"
-            exit 1
-          fi
-          if [[ ! "$PAYLOAD_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            echo "::error::repository_dispatch SHA must be a 40-hex commit"
-            exit 1
-          fi
-          checked_sha="$(git rev-parse --verify HEAD)"
-          if [[ "${PAYLOAD_SHA,,}" != "$checked_sha" ]]; then
-            echo "::error::checkout does not match the repository_dispatch SHA"
-            exit 1
-          fi
-
-      - name: Validate per-issue close keywords
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/check-close-keywords.mjs --lint-pr
-
   # #1844: the changelog-fragment format error hit four PRs in one day, each
   # costing a full ~4-minute Unit-tests lap to discover. This job runs ONLY
   # the fragment parser (no `npm install`, no `npm run build` -- it is pure

--- a/.github/workflows/close-keywords.yml
+++ b/.github/workflows/close-keywords.yml
@@ -1,0 +1,34 @@
+name: Close-keyword syntax
+
+on:
+  pull_request:
+    branches: [master]
+    # Title edits can add or remove a close keyword after the initial check.
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: close-keywords-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Close-keyword syntax
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22'
+
+      - name: Validate per-issue close keywords
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/check-close-keywords.mjs --lint-pr

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1684,8 +1684,10 @@ replay an edited event snapshot. The merged-PR workflow uses the same live-body
 contract and fails closed when the fetch fails.
 GitHub applies closing keywords from the body only. If a title carries
 `closes`/`fixes`/`resolves #N`, the body must carry a keyword for the same issue;
-otherwise the lint fails with a placement message. Title `refs #N` and bare
-`(#N)` references never trigger this placement check.
+otherwise the lint fails with a placement message. This placement parser covers
+same-repository `#N` forms only: cross-repository `owner/repo#N` and URL forms
+remain outside its boundary. Title `refs #N` and bare `(#N)` references never
+trigger this placement check.
 The merged-PR workflow rechecks each same-repository close target and comments on
 the PR when a referenced issue is missing or remains open. Keep the parser pure
 and unit-tested; workflow YAML supplies the token required by the live fetch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1682,6 +1682,10 @@ the first issue per keyword; use one keyword per issue (`Closes #A. Closes #B.`)
 The syntax check fetches the live PR body with `GITHUB_TOKEN`, so reruns do not
 replay an edited event snapshot. The merged-PR workflow uses the same live-body
 contract and fails closed when the fetch fails.
+GitHub applies closing keywords from the body only. If a title carries
+`closes`/`fixes`/`resolves #N`, the body must carry a keyword for the same issue;
+otherwise the lint fails with a placement message. Title `refs #N` and bare
+`(#N)` references never trigger this placement check.
 The merged-PR workflow rechecks each same-repository close target and comments on
 the PR when a referenced issue is missing or remains open. Keep the parser pure
 and unit-tested; workflow YAML supplies the token required by the live fetch.

--- a/scripts/check-close-keywords.d.mts
+++ b/scripts/check-close-keywords.d.mts
@@ -11,9 +11,20 @@ export declare function lintCloseKeywords(body?: string): {
 	offendingLines: string[];
 	valid: boolean;
 };
+export declare function lintCloseKeywordPlacement(
+	title?: string,
+	body?: string,
+): {
+	valid: boolean;
+	titleIssues: number[];
+	missingBodyIssues: number[];
+};
+export declare function closeKeywordPlacementMessage(missing: number[]): string;
 export declare function lintPullRequest(
 	fetchImpl?: typeof fetch,
-	event?: { pull_request?: { number: number; body?: string | null } },
+	event?: {
+		pull_request?: { number: number; body?: string | null; title?: string };
+	},
 ): Promise<void>;
 export declare function verifyMergedPullRequest(
 	fetchImpl?: typeof fetch,

--- a/scripts/check-close-keywords.d.mts
+++ b/scripts/check-close-keywords.d.mts
@@ -23,7 +23,7 @@ export declare function closeKeywordPlacementMessage(missing: number[]): string;
 export declare function lintPullRequest(
 	fetchImpl?: typeof fetch,
 	event?: {
-		pull_request?: { number: number; body?: string | null; title?: string };
+		pull_request?: { number: number; body?: string | null };
 	},
 ): Promise<void>;
 export declare function verifyMergedPullRequest(

--- a/scripts/check-close-keywords.mjs
+++ b/scripts/check-close-keywords.mjs
@@ -27,14 +27,7 @@ export function stripNonSemanticMarkdown(body = "") {
 		.join("\n");
 }
 
-/**
- * Parse same-repository issues named by GitHub close keywords.
- * Cross-repository references (owner/repo#123) intentionally do not match.
- * The body is scanned AFTER stripNonSemanticMarkdown so quoted examples in
- * code fences/blockquotes are not linted as real syntax.
- */
-export function parseCloseKeywords(body = "") {
-	const scanned = stripNonSemanticMarkdown(body);
+function scanCloseIssues(scanned = "") {
 	const issues = [];
 	const commaLists = [];
 	const offendingLines = [];
@@ -60,6 +53,37 @@ export function parseCloseKeywords(body = "") {
 	}
 
 	return { issues, commaLists, offendingLines };
+}
+
+/**
+ * Parse same-repository issues named by GitHub close keywords.
+ * Cross-repository references (owner/repo#123) intentionally do not match.
+ * The body is scanned AFTER stripNonSemanticMarkdown so quoted examples in
+ * code fences/blockquotes are not linted as real syntax.
+ */
+export function parseCloseKeywords(body = "") {
+	return scanCloseIssues(stripNonSemanticMarkdown(body));
+}
+
+export function lintCloseKeywordPlacement(title = "", body = "") {
+	const titleIssues = scanCloseIssues(String(title)).issues;
+	if (titleIssues.length === 0)
+		return { valid: true, titleIssues, missingBodyIssues: [] };
+	const bodyIssues = parseCloseKeywords(body).issues;
+	const missingBodyIssues = titleIssues.filter(
+		(number) => !bodyIssues.includes(number),
+	);
+	return {
+		valid: missingBodyIssues.length === 0,
+		titleIssues,
+		missingBodyIssues,
+	};
+}
+
+export function closeKeywordPlacementMessage(missing) {
+	const repairs = missing.map((number) => `Closes #${number}.`).join(" ");
+	const alternatives = missing.map((number) => `refs #${number}`).join(", ");
+	return `Invalid close-keyword placement: GitHub only honours closing keywords in the PR body, never in the title. Add the matching body keyword(s): ${repairs} Alternatively, use ${alternatives} in the title.`;
 }
 
 export function lintCloseKeywords(body = "") {
@@ -88,8 +112,9 @@ export async function lintPullRequest(
 	// as a bare thrown message that reads like a broken script (worst for
 	// fork PRs hitting a transient 5xx).
 	let body;
+	let title;
 	try {
-		({ body } = await fetchLivePrBody(pullRequest, fetchImpl));
+		({ body, title } = await fetchLivePrBody(pullRequest, fetchImpl));
 	} catch (error) {
 		const reason = error instanceof Error ? error.message : String(error);
 		console.error(
@@ -104,6 +129,12 @@ export async function lintPullRequest(
 		for (const line of result.offendingLines) {
 			console.error(`  offending line: ${line}`);
 		}
+		process.exitCode = 1;
+		return;
+	}
+	const placement = lintCloseKeywordPlacement(title, body);
+	if (!placement.valid) {
+		console.error(closeKeywordPlacementMessage(placement.missingBodyIssues));
 		process.exitCode = 1;
 		return;
 	}

--- a/scripts/check-close-keywords.mjs
+++ b/scripts/check-close-keywords.mjs
@@ -14,9 +14,8 @@ export const INVALID_CLOSE_KEYWORD_MESSAGE =
  * Remove markdown regions where a close keyword is quotation, not intent
  * (#1355 review): fenced code blocks, inline code spans, and blockquote
  * lines. A PR body QUOTING the bad form as documentation must not fail its
- * own check -- GitHub itself still parses keywords in these regions, so this
- * is deliberately stricter than the platform: quoted forms are exempt from
- * OUR lint while remaining the author's responsibility platform-side.
+ * own check. GitHub does not apply close keywords inside these regions, so the
+ * lint follows the platform's observed model.
  */
 export function stripNonSemanticMarkdown(body = "") {
 	return body
@@ -57,7 +56,10 @@ function scanCloseIssues(scanned = "") {
 
 /**
  * Parse same-repository issues named by GitHub close keywords.
- * Cross-repository references (owner/repo#123) intentionally do not match.
+ * Cross-repository references (owner/repo#123) and URL forms intentionally do
+ * not match. The body keeps GitHub's first-issue-only comma-list semantics;
+ * title placement expands every number so no title-only target escapes the
+ * post-merge backstop.
  * The body is scanned AFTER stripNonSemanticMarkdown so quoted examples in
  * code fences/blockquotes are not linted as real syntax.
  */
@@ -66,7 +68,19 @@ export function parseCloseKeywords(body = "") {
 }
 
 export function lintCloseKeywordPlacement(title = "", body = "") {
-	const titleIssues = scanCloseIssues(String(title)).issues;
+	const scannedTitle = String(title);
+	const titleIssues = [...scanCloseIssues(scannedTitle).issues];
+	for (const match of scannedTitle.matchAll(CLOSE_KEYWORD)) {
+		const rest = scannedTitle.slice(match.index + match[0].length);
+		CLOSE_ISSUE.lastIndex = 0;
+		const issue = CLOSE_ISSUE.exec(rest);
+		if (!issue) continue;
+		const commaTail = rest.slice(issue[0].length).match(/^(?:\s*,\s*#\d+)+/);
+		for (const number of commaTail?.[0].matchAll(/#(\d+)/g) ?? []) {
+			const value = Number(number[1]);
+			if (!titleIssues.includes(value)) titleIssues.push(value);
+		}
+	}
 	if (titleIssues.length === 0)
 		return { valid: true, titleIssues, missingBodyIssues: [] };
 	const bodyIssues = parseCloseKeywords(body).issues;
@@ -193,12 +207,30 @@ export async function verifyMergedPullRequest(
 	// shape #2086 was filed to close, just moved one level up. A fetch
 	// failure here fails the check LOUD instead.
 	let liveBody;
+	let liveTitle;
 	try {
-		({ body: liveBody } = await fetchLivePrBody(pullRequest, fetchImpl));
+		({ body: liveBody, title: liveTitle } = await fetchLivePrBody(
+			pullRequest,
+			fetchImpl,
+		));
 	} catch (error) {
 		const reason = error instanceof Error ? error.message : String(error);
 		console.error(
 			`::error::Post-merge close verification could not fetch the live PR body, so it did not run: ${reason}`,
+		);
+		process.exitCode = 1;
+		return;
+	}
+	const titleIssues = lintCloseKeywordPlacement(liveTitle, "").titleIssues;
+	const unresolvedTitle = titleIssues
+		.map((number) => ({ number, state: getIssueState(repository, number) }))
+		.filter(({ state }) => state !== "closed");
+	if (unresolvedTitle.length > 0) {
+		const details = unresolvedTitle
+			.map(({ number, state }) => `#${number} (${state})`)
+			.join(", ");
+		console.error(
+			`Post-merge close verification found title issue(s) that were not closed: ${details}.`,
 		);
 		process.exitCode = 1;
 		return;

--- a/scripts/check-pr-body.d.mts
+++ b/scripts/check-pr-body.d.mts
@@ -16,7 +16,7 @@ export declare function lintPrBody(
 export declare function fetchLivePrBody(
 	payloadPr: { number: number; body?: string | null },
 	fetchImpl: typeof fetch,
-): Promise<{ body: string; normalized: boolean }>;
+): Promise<{ body: string; normalized: boolean; title: string | undefined }>;
 export declare function resolveLivePrBody(
 	payloadPr: { number: number; body?: string | null },
 	fetchImpl?: typeof fetch,

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -369,7 +369,7 @@ export function lintPrBody(body = "", options = {}) {
  *
  * @param {{ number: number, body?: string | null }} payloadPr
  * @param {typeof fetch} fetchImpl
- * @returns {Promise<{body: string, normalized: boolean}>}
+ * @returns {Promise<{body: string, normalized: boolean, title: string | undefined}>}
  */
 export async function fetchLivePrBody(payloadPr, fetchImpl) {
 	const token = process.env.GITHUB_TOKEN;
@@ -393,7 +393,10 @@ export async function fetchLivePrBody(payloadPr, fetchImpl) {
 	const data = await response.json();
 	if (data.body !== null && typeof data.body !== "string")
 		throw new Error("GitHub API returned no body");
-	return normalizePrBodyForChecking(data.body ?? "", payloadPr.number);
+	return {
+		...normalizePrBodyForChecking(data.body ?? "", payloadPr.number),
+		title: data.title,
+	};
 }
 
 export async function resolveLivePrBody(

--- a/tests/config/close-keyword-workflow.test.ts
+++ b/tests/config/close-keyword-workflow.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import yaml from "../../clients/deps/js-yaml.js";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..");
+const WORKFLOW_PATH = ".github/workflows/close-keywords.yml";
+
+type Workflow = {
+	name?: string;
+	on?: { pull_request?: { branches?: string[]; types?: string[] } };
+	permissions?: Record<string, string>;
+	jobs?: Record<
+		string,
+		{
+			name?: string;
+			permissions?: Record<string, string>;
+			steps?: Array<{ run?: string; env?: Record<string, string> }>;
+		}
+	>;
+};
+
+function loadWorkflow(source?: string): Workflow {
+	return yaml.load(
+		source ?? readFileSync(resolve(REPO_ROOT, WORKFLOW_PATH), "utf8"),
+	) as Workflow;
+}
+
+describe("close-keywords workflow contract (#2640)", () => {
+	it("re-gates title edits and keeps the check-run name stable", () => {
+		const workflow = loadWorkflow();
+		expect(workflow.name).toBe("Close-keyword syntax");
+		expect(workflow.on?.pull_request?.types).toEqual([
+			"opened",
+			"synchronize",
+			"reopened",
+			"edited",
+		]);
+		expect(workflow.jobs?.lint?.name).toBe("Close-keyword syntax");
+	});
+
+	it("requires only pull-request reads and runs the live PR lint", () => {
+		const workflow = loadWorkflow();
+		expect(workflow.permissions).toEqual({ "pull-requests": "read" });
+		const job = workflow.jobs?.lint;
+		expect(job?.permissions).toEqual({ "pull-requests": "read" });
+		const step = job?.steps?.find((candidate) =>
+			(candidate.run ?? "").includes("check-close-keywords.mjs"),
+		);
+		expect(step?.run).toContain("--lint-pr");
+		expect(step?.env?.GITHUB_TOKEN).toContain("secrets.GITHUB_TOKEN");
+	});
+});

--- a/tests/scripts/check-close-keywords.test.ts
+++ b/tests/scripts/check-close-keywords.test.ts
@@ -547,21 +547,58 @@ describe("close-keyword-verification.yml carries GITHUB_TOKEN (#2267 F1)", () =>
 	});
 
 	it("sets GITHUB_TOKEN on the syntax-lint step", () => {
-		const workflowPath = path.join(REPO_ROOT, ".github/workflows/ci.yml");
+		const workflowPath = path.join(
+			REPO_ROOT,
+			".github/workflows/close-keywords.yml",
+		);
 		type WorkflowStep = { run?: string; env?: Record<string, string> };
 		type Workflow = {
-			jobs: { "close-keyword-lint": { steps: WorkflowStep[] } };
+			jobs: { lint: { steps: WorkflowStep[] } };
 		};
 		const workflow = yaml.load(
 			fs.readFileSync(workflowPath, "utf8"),
 		) as Workflow;
-		const step = workflow.jobs["close-keyword-lint"].steps.find((s) =>
+		const step = workflow.jobs.lint.steps.find((s) =>
 			(s.run ?? "").includes("check-close-keywords.mjs"),
 		);
-		if (!step) throw new Error("syntax-lint step not found in ci.yml");
+		if (!step)
+			throw new Error("syntax-lint step not found in close-keywords.yml");
 		// Mutation-proof: without this workflow wiring the strict live fetch
 		// fails before it can inspect the current PR body.
 		expect(step.env?.GITHUB_TOKEN).toBeTruthy();
 		expect(step.run).toContain("--lint-pr");
+	});
+});
+
+describe("verifyMergedPullRequest checks title close keywords (#2640)", () => {
+	it("fails when a title-only close target remains open", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					title: "fix: title-only close (closes #2640)",
+					body: "Summary.",
+				}),
+				{ status: 200 },
+			),
+		);
+		const getIssueState = vi.fn().mockReturnValue("open");
+
+		await verifyMergedPullRequest(
+			fetchImpl,
+			{ pull_request: { number: 2744, body: "Summary." } },
+			getIssueState,
+		);
+
+		expect(process.exitCode).toBe(1);
+		expect(getIssueState).toHaveBeenCalledWith("apmantza/pi-lens", 2640);
+		expect(errorLog).toHaveBeenCalledWith(
+			"Post-merge close verification found title issue(s) that were not closed: #2640 (open).",
+		);
+		errorLog.mockRestore();
+		process.exitCode = undefined;
 	});
 });

--- a/tests/scripts/check-close-keywords.test.ts
+++ b/tests/scripts/check-close-keywords.test.ts
@@ -245,6 +245,106 @@ describe("close-keyword syntax lint reads the live body (#2086)", () => {
 	});
 });
 
+describe("close-keyword placement reads the live title (#2640)", () => {
+	afterEach(() => {
+		process.exitCode = undefined;
+	});
+
+	it("fails the #2610 incident when the title keyword is absent from the body", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					title:
+						'test: rename legacy "should" test names to behavior statements (closes #2602)',
+					body: "Summary: rename legacy should test names to behavior statements.",
+				}),
+				{ status: 200 },
+			),
+		);
+
+		await lintPullRequest(fetchImpl, { pull_request: { number: 2610 } });
+
+		expect(process.exitCode).toBe(1);
+		expect(errorLog).toHaveBeenCalledWith(
+			expect.stringContaining("Invalid close-keyword placement"),
+		);
+		expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("#2602"));
+		expect(errorLog).toHaveBeenCalledWith(
+			expect.stringContaining("Closes #2602."),
+		);
+		expect(log).not.toHaveBeenCalled();
+		errorLog.mockRestore();
+		log.mockRestore();
+	});
+
+	it("accepts the repaired incident", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					title: "fix: repair placement (closes #2602)",
+					body: "Summary.\n\nCloses #2602.",
+				}),
+				{ status: 200 },
+			),
+		);
+
+		await lintPullRequest(fetchImpl, { pull_request: { number: 2610 } });
+
+		expect(process.exitCode).toBeUndefined();
+		expect(log).toHaveBeenCalledWith(
+			"Close-keyword syntax OK (1 issue referenced).",
+		);
+		log.mockRestore();
+	});
+
+	it("reports syntax before placement", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					title: "fixes #1 and closes #3",
+					body: "Closes #1, #2",
+				}),
+				{ status: 200 },
+			),
+		);
+
+		await lintPullRequest(fetchImpl, { pull_request: { number: 2640 } });
+
+		expect(errorLog).toHaveBeenCalledWith(INVALID_CLOSE_KEYWORD_MESSAGE);
+		expect(errorLog).not.toHaveBeenCalledWith(
+			expect.stringContaining("Invalid close-keyword placement"),
+		);
+		errorLog.mockRestore();
+	});
+
+	it("preserves the live title in fetchLivePrBody", async () => {
+		vi.stubEnv("GITHUB_API_URL", "https://api.github.test");
+		vi.stubEnv("GITHUB_REPOSITORY", "apmantza/pi-lens");
+		vi.stubEnv("GITHUB_TOKEN", "test-token");
+		const fetchImpl = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ title: "fix: title", body: "Summary" }), {
+				status: 200,
+			}),
+		);
+		expect(await fetchLivePrBody({ number: 2640 }, fetchImpl)).toMatchObject({
+			title: "fix: title",
+		});
+	});
+});
+
 // #2086: verifyMergedPullRequest read pullRequest.body straight off the
 // closed-event payload, so a rerun after the body was edited post-merge
 // always relinted the STALE body. It now reuses check-pr-body.mjs's
@@ -462,5 +562,6 @@ describe("close-keyword-verification.yml carries GITHUB_TOKEN (#2267 F1)", () =>
 		// Mutation-proof: without this workflow wiring the strict live fetch
 		// fails before it can inspect the current PR body.
 		expect(step.env?.GITHUB_TOKEN).toBeTruthy();
+		expect(step.run).toContain("--lint-pr");
 	});
 });

--- a/tests/scripts/close-keyword-placement.test.ts
+++ b/tests/scripts/close-keyword-placement.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+	closeKeywordPlacementMessage,
+	lintCloseKeywordPlacement,
+} from "../../scripts/check-close-keywords.mjs";
+
+describe("close-keyword placement (#2640)", () => {
+	it("rejects the #2610 incident pair", () => {
+		const result = lintCloseKeywordPlacement(
+			'test: rename legacy "should" test names to behavior statements (closes #2602)',
+			"Summary: rename legacy should test names to behavior statements.",
+		);
+		expect(result).toMatchObject({ valid: false, missingBodyIssues: [2602] });
+	});
+
+	it("accepts the incident after adding the body keyword", () => {
+		expect(
+			lintCloseKeywordPlacement(
+				'test: rename legacy "should" test names to behavior statements (closes #2602)',
+				"Summary: rename legacy should test names to behavior statements.\n\nCloses #2602.",
+			).valid,
+		).toBe(true);
+	});
+
+	it("does not require a body keyword for a title without a close keyword", () => {
+		expect(
+			lintCloseKeywordPlacement(
+				"fix(build): isolate build:dist's tsc npx spawn like esbuild's (#2593)",
+				"Use `closes #2593` only as an example.",
+			),
+		).toMatchObject({ valid: true, titleIssues: [] });
+		expect(
+			lintCloseKeywordPlacement(
+				"refactor: preserve merge-train behavior (refs #2591)",
+				"",
+			),
+		).toMatchObject({ valid: true, titleIssues: [] });
+	});
+
+	it("accepts a body keyword matching a title reference", () => {
+		expect(
+			lintCloseKeywordPlacement(
+				"fix: address build issue (refs #2604)",
+				"Closes #2604.",
+			),
+		).toMatchObject({ valid: true, titleIssues: [] });
+	});
+
+	it("reports each title issue missing from the body", () => {
+		expect(
+			lintCloseKeywordPlacement("fixes #1 and resolves #2", "Closes #1."),
+		).toMatchObject({ valid: false, missingBodyIssues: [2] });
+	});
+
+	it("handles supported syntax and word boundaries", () => {
+		expect(lintCloseKeywordPlacement("FIXES: #7", "").valid).toBe(false);
+		expect(lintCloseKeywordPlacement("resolved #7", "").valid).toBe(false);
+		expect(lintCloseKeywordPlacement("discloses #1", "").valid).toBe(true);
+	});
+
+	it("scans title code formatting as GitHub does", () => {
+		expect(
+			lintCloseKeywordPlacement("docs: how `closes #1` works", ""),
+		).toMatchObject({
+			valid: false,
+			missingBodyIssues: [1],
+		});
+	});
+
+	it("explains the platform rule and every repair", () => {
+		const message = closeKeywordPlacementMessage([2602, 2604]);
+		expect(message).toContain(
+			"GitHub only honours closing keywords in the PR body, never in the title",
+		);
+		expect(message).toContain("#2602");
+		expect(message).toContain("Closes #2602.");
+		expect(message).toContain("refs #2602");
+		expect(message).toContain("#2604");
+	});
+});

--- a/tests/scripts/close-keyword-placement.test.ts
+++ b/tests/scripts/close-keyword-placement.test.ts
@@ -52,6 +52,16 @@ describe("close-keyword placement (#2640)", () => {
 		).toMatchObject({ valid: false, missingBodyIssues: [2] });
 	});
 
+	it("collects every issue in a title comma list", () => {
+		expect(
+			lintCloseKeywordPlacement("closes #1, #2", "Closes #1."),
+		).toMatchObject({
+			valid: false,
+			titleIssues: [1, 2],
+			missingBodyIssues: [2],
+		});
+	});
+
 	it("handles supported syntax and word boundaries", () => {
 		expect(lintCloseKeywordPlacement("FIXES: #7", "").valid).toBe(false);
 		expect(lintCloseKeywordPlacement("resolved #7", "").valid).toBe(false);


### PR DESCRIPTION
## Summary

Move the `Close-keyword syntax` check into its own workflow and trigger it on
`edited` pull-request events. The workflow keeps the check-run name stable, so
`ci-verdict.mjs` and the merge-train lane continue to treat it as a gating
check. Add a post-merge backstop for close keywords found in the PR title.

Closes #2640. All acceptance criteria are complete.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] Read CONTRIBUTING.md and AGENTS.md.
- [x] Added regression and workflow contract tests.
- [x] Proved new regression tests red on the pre-fix code.
- [x] Proved new guards mutation-sensitive.
- [x] Kept the issue reference in the title and body.
- [x] Ran build, lint, and formatting checks.
- [x] Updated AGENTS.md and added the existing changelog fragment.

## Tests

New and edited tests pin these contracts:

- `tests/scripts/close-keyword-placement.test.ts` adds the title comma-list
  regression and proves every title issue is collected.
- `tests/scripts/check-close-keywords.test.ts` adds the title-only merged
  backstop through `verifyMergedPullRequest` with a fake API response, and
  updates workflow wiring to the dedicated workflow.
- `tests/config/close-keyword-workflow.test.ts` loads the real workflow and
  pins its name, `edited` trigger, least permissions, and live lint command.
- Existing `tests/scripts/check-pr-body.test.ts` remains the contract for the
  shared live PR fetch seam.

Red-first transcript for the pre-fix source:

```text
Tests  3 failed | 36 passed (42)
close-keyword-placement.test.ts: titleIssues [1] instead of [1, 2]
check-close-keywords.test.ts: Post-merge close verification OK (0 issues closed).
```

Mutation transcripts:

- Removing title comma-list expansion: `1 failed`, the new placement case
  reported `titleIssues: [1]` and `valid: true`.
- Removing the live-title read: `1 failed`, the backstop logged
  `Post-merge close verification OK (0 issues closed).`.
- Replacing workflow `edited` with `removed`: `1 failed`, the workflow
  contract expected `edited` but received `removed`.

Final targeted run: 15 test files and 260 tests passed. This included all 12
`tests/config/*.test.ts` files that reference workflows, both close-keyword
tests, and `tests/scripts/check-pr-body.test.ts`.

## Test assessment

- `tests/scripts/close-keyword-placement.test.ts` uniquely pins title issue
  expansion and placement semantics; no test is redundant.
- `tests/scripts/check-close-keywords.test.ts` uniquely pins live fetch,
  merged verification, and workflow token wiring; no test is redundant.
- `tests/config/close-keyword-workflow.test.ts` uniquely pins the dedicated
  workflow trigger and gate identity; no test is redundant.
- `tests/scripts/check-pr-body.test.ts` uniquely pins the shared live API
  fetch and remains necessary.

## Blast radius

The changed production seam is `scripts/check-close-keywords.mjs`:

```text
lintPullRequest / verifyMergedPullRequest
  -> fetchLivePrBody
  -> lintCloseKeywordPlacement / parseCloseKeywords
  -> getIssueState
```

The workflow entry points are `.github/workflows/close-keywords.yml` and
`.github/workflows/close-keyword-verification.yml`. The check-run name remains
`Close-keyword syntax`, which preserves merge-train discovery and gating.
No hot path, durable store, callback, or per-file runtime path is touched.

## Observability

Placement failures emit one bounded workflow error naming every missing issue.
The merged-title backstop emits one error naming each unresolved title issue
and exits nonzero. Existing post-merge body failures retain their comment
marker and bounded issue details.

## Class sweep

This fixes stale-event and title-only close-keyword governance, matching
AGENTS.md's dispatch and workflow invariants. A whole-tree sweep covered
`clients/`, `tools/`, `mcp/`, `scripts/`, `tests/support/`, and `index.ts` for
`check-close-keywords`, `lintCloseKeywordPlacement`, `verifyMergedPullRequest`,
and close-keyword workflow invocations. The only production parser seam is
`scripts/check-close-keywords.mjs`; the only close-keyword workflows are the
new open-PR lint workflow and the existing merged-PR verifier.

The parser deliberately leaves cross-repository `owner/repo#N` and URL forms
outside scope. The body retains first-issue-only comma-list semantics, while
title placement enumerates every number. Consolidation verdict: keep both
checks on the existing `check-close-keywords.mjs` seam because the open-PR and
post-merge workflows have different lifecycle triggers and permissions.

## Round 2

Applied Review round 1 findings on 2026-09-08. Moved the syntax check out of
`ci.yml` so `edited` events re-gate it, retained the exact check-run name, and
added per-PR concurrency with `pull-requests: read`. Added the merged-title
backstop, title comma-list coverage, workflow contract coverage, corrected the
GitHub markdown parsing comment, documented parser boundaries in AGENTS.md,
and removed the unused declaration field.

The offline test setup could not pre-fetch tree-sitter grammars. No test was
skipped; the existing per-worker degradation path handled those unavailable
downloads. No child-process suite was blocked by EPERM.

## Changed files

- `.github/workflows/ci.yml`
- `.github/workflows/close-keywords.yml`
- `AGENTS.md`
- `scripts/check-close-keywords.mjs`
- `scripts/check-close-keywords.d.mts`
- `tests/config/close-keyword-workflow.test.ts`
- `tests/scripts/check-close-keywords.test.ts`
- `tests/scripts/close-keyword-placement.test.ts`
