### PR TITLE
chore: format the six files oxfmt flags on master (refs #2731, #2729, #2741)

### DIFF
--- a/clients/installer/managed-tool-refresh.ts
+++ b/clients/installer/managed-tool-refresh.ts
@@ -703,8 +703,7 @@ async function performNpmRefresh(
 			0,
 			200,
 		);
-		const coveredIds =
-			candidate.coveredToolIds?.join(",") ?? candidate.toolId;
+		const coveredIds = candidate.coveredToolIds?.join(",") ?? candidate.toolId;
 		// "Keeping <old version>" would be an unchecked assertion (#1746 review
 		// F2). The spawn budget kills the package manager where it stands, which
 		// can be mid-write: the tree may hold a new version, a half-written one,
@@ -771,8 +770,7 @@ async function performNpmRefresh(
 		candidate.packageEntryOf,
 	);
 	if (!verified) {
-		const coveredIds =
-			candidate.coveredToolIds?.join(",") ?? candidate.toolId;
+		const coveredIds = candidate.coveredToolIds?.join(",") ?? candidate.toolId;
 		recordDegradationOnce({
 			kind: "managed-tool-refresh",
 			subject: candidate.toolId,

--- a/clients/runtime-tool-call.ts
+++ b/clients/runtime-tool-call.ts
@@ -1070,7 +1070,11 @@ async function handleToolCallImpl(deps: ToolCallDeps): Promise<ToolCallResult> {
 				entropy: baseline.codeEntropy,
 			});
 		}
-	} else if (getFlag("no-complexity") && filePath && isComplexitySupportedFile(filePath)) {
+	} else if (
+		getFlag("no-complexity") &&
+		filePath &&
+		isComplexitySupportedFile(filePath)
+	) {
 		recordDegradationOnce({
 			kind: "startup-analyzer-disabled",
 			subject: "complexity",

--- a/tests/clients/installer/managed-tool-refresh.test.ts
+++ b/tests/clients/installer/managed-tool-refresh.test.ts
@@ -472,13 +472,13 @@ describe("cadence", () => {
 		expect(updateCalls()).toHaveLength(2);
 		expect(updateCalls().map((call) => call.args)).toEqual(
 			expect.arrayContaining([
-			expect.arrayContaining(["vscode-langservers-extracted"]),
-			expect.arrayContaining(["knip"]),
-		]),
-	);
+				expect.arrayContaining(["vscode-langservers-extracted"]),
+				expect.arrayContaining(["knip"]),
+			]),
+		);
 		expect(outcome.refreshed.map((refresh) => refresh.packageName)).toEqual(
 			expect.arrayContaining(["vscode-langservers-extracted", "knip"]),
-	);
+		);
 		expect(readState()).toMatchObject({
 			"vscode-css-languageserver": { checkedAt: NOW, version: "5.0.0" },
 			"vscode-html-languageserver-bin": { checkedAt: NOW, version: "5.0.0" },
@@ -489,7 +489,9 @@ describe("cadence", () => {
 			logRows().some(
 				(row) =>
 					row.includes("package vscode-langservers-extracted") &&
-					row.includes("covered ids vscode-json-language-server,vscode-html-languageserver-bin,vscode-css-languageserver"),
+					row.includes(
+						"covered ids vscode-json-language-server,vscode-html-languageserver-bin,vscode-css-languageserver",
+					),
 			),
 		).toBe(true);
 	});
@@ -604,7 +606,9 @@ describe("failed refresh", () => {
 		expect(group?.latestReasons[0].reason).toContain(
 			"package vscode-langservers-extracted",
 		);
-		expect(group?.latestReasons[0].reason).toContain(`covered ids ${coveredIds}`);
+		expect(group?.latestReasons[0].reason).toContain(
+			`covered ids ${coveredIds}`,
+		);
 		expect(readState()).toMatchObject({
 			"vscode-json-language-server": { failed: true },
 			"vscode-html-languageserver-bin": { failed: true },
@@ -649,7 +653,9 @@ describe("failed refresh", () => {
 		expect(group?.latestReasons[0].reason).toContain(
 			"package vscode-langservers-extracted",
 		);
-		expect(group?.latestReasons[0].reason).toContain(`covered ids ${coveredIds}`);
+		expect(group?.latestReasons[0].reason).toContain(
+			`covered ids ${coveredIds}`,
+		);
 		expect(readState()).toMatchObject({
 			"vscode-json-language-server": { failed: true },
 			"vscode-html-languageserver-bin": { failed: true },

--- a/tests/clients/runtime-session.test.ts
+++ b/tests/clients/runtime-session.test.ts
@@ -373,8 +373,8 @@ it(
 				{ timeoutMs: HEAVY_IO_TIMEOUT_MS },
 			);
 			expect(dbg).toHaveBeenCalledWith(
-			"session_start knip: skipped (disabled by config)",
-		);
+				"session_start knip: skipped (disabled by config)",
+			);
 			expect(knipEnsure).not.toHaveBeenCalled();
 			expect(
 				getDegradationSummary().some(

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -829,19 +829,18 @@ const EXEMPT_SITES: Readonly<Record<string, SweepExemption>> = {
 				"budget many times over.",
 			owner: "#2523 slice 2",
 		},
-	"clients/runtime-session.ts#d7c597d6~b67d7877":
-		{
-			family: "hook-await",
-			site: "session_start",
-			reason:
-				"One heavyweight startup analyzer per await (knip, jscpd, " +
-				"govulncheck, gitleaks, opengrep, madge, trivy, ast-grep, " +
-				"review graph, call graph, codebase model, word index). Each " +
-				"has a spawn-level timeout at the leaf and none has a wall " +
-				"bound above it; together they are session_start's 5000ms " +
-				"budget many times over.",
-			owner: "#2523 slice 2",
-		},
+	"clients/runtime-session.ts#d7c597d6~b67d7877": {
+		family: "hook-await",
+		site: "session_start",
+		reason:
+			"One heavyweight startup analyzer per await (knip, jscpd, " +
+			"govulncheck, gitleaks, opengrep, madge, trivy, ast-grep, " +
+			"review graph, call graph, codebase model, word index). Each " +
+			"has a spawn-level timeout at the leaf and none has a wall " +
+			"bound above it; together they are session_start's 5000ms " +
+			"budget many times over.",
+		owner: "#2523 slice 2",
+	},
 	"clients/runtime-session.ts#2c64a178~b262f927": {
 		family: "hook-await",
 		site: "session_start",

--- a/tests/scripts/merge-train-warden.test.ts
+++ b/tests/scripts/merge-train-warden.test.ts
@@ -2492,20 +2492,26 @@ describe("merge-lane gate (#2185)", () => {
 		["IN_PROGRESS", "SUCCESS"],
 		["QUEUED", null],
 		["COMPLETED", null],
-	])("holds a discovered %s check (conclusion %s) until it concludes", (status, conclusion) => {
-		const checkName = `discovered ${status.toLowerCase()} check`;
-		const gate = gateOf(
-			approved({
-				mergeStateStatus: "UNSTABLE",
-				checkRuns: [...greenChecks(), { name: checkName, status, conclusion }],
-			}),
-		);
-		expect(gate).toMatchObject({
-			merge: false,
-			reason: MERGE_GATE_REASON.CHECK_PENDING,
-		});
-		expect(gate.detail).toContain(checkName);
-	});
+	])(
+		"holds a discovered %s check (conclusion %s) until it concludes",
+		(status, conclusion) => {
+			const checkName = `discovered ${status.toLowerCase()} check`;
+			const gate = gateOf(
+				approved({
+					mergeStateStatus: "UNSTABLE",
+					checkRuns: [
+						...greenChecks(),
+						{ name: checkName, status, conclusion },
+					],
+				}),
+			);
+			expect(gate).toMatchObject({
+				merge: false,
+				reason: MERGE_GATE_REASON.CHECK_PENDING,
+			});
+			expect(gate.detail).toContain(checkName);
+		},
+	);
 
 	it("reports every pending discovered check in the hold detail", () => {
 		const names = ["queued discovered check", "running discovered check"];


### PR DESCRIPTION
## Summary
The advisory `oxfmt format check` lane on master has been red since the #2729/#2731 merges: four files reached master without passing the formatter (their workers ran Vitest through `--configLoader runner` and skipped `oxfmt` on those files; one is the orchestrator's own trailing edit on #2729). Pure reformat, no semantic change.

## Tests
`npx oxfmt --check` on the tree: clean. No test change; Tier C (formatting only). CI on the exact head is the gate.

## Blast radius
Whitespace/formatting in `clients/runtime-tool-call.ts`, `tests/clients/runtime-session.test.ts`, `tests/config/hook-await-bounds.test.ts`, `tests/scripts/merge-train-warden.test.ts`.

## Class sweep
The knip advisory lane is a separate, older remainder (54 unused test-support exports + the `publint` devDependency hint) tracked under #2708 and handled in its own lane.

## Observability
n/a.

## Test assessment
n/a (no test semantics changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV