### PR TITLE
chore(knip): clear the test-support export remainder (refs #2708)

### DIFF
--- a/.changelog/chore-2708-knip-test-exports.md
+++ b/.changelog/chore-2708-knip-test-exports.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Cleared 26 unused test exports and 28 unused exported test types (refs #2708)** — test-support APIs are now private where their consumers are local, while the packaging workflow's pinned `publint` dependency remains declared and documented to Knip.

--- a/.changelog/chore-2708-knip-test-exports.md
+++ b/.changelog/chore-2708-knip-test-exports.md
@@ -2,4 +2,4 @@
 section: Changed
 ---
 
-- **Cleared 26 unused test exports and 28 unused exported test types (refs #2708)** — test-support APIs are now private where their consumers are local, while the packaging workflow's pinned `publint` dependency remains declared and documented to Knip.
+- **Cleared 51 of the 54 knip rows (23 of the 26 unused test exports; the 3 flake-shape rows stay for #2742) and 28 unused exported test types (refs #2708)** — test-support APIs are now private where their consumers are local, while the packaging workflow's pinned `publint` dependency remains declared and documented to Knip.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -116,7 +116,10 @@
 		// Spawned as an external LSP server binary (by path/PATH lookup) in
 		// the real-LSP integration and budget tests; no knip plugin models
 		// arbitrary LSP server devDependencies.
-		"typescript-language-server"
+		"typescript-language-server",
+		// The packaging workflow reads this pinned devDependency to install
+		// publint in its production-only job, then invokes its binary directly.
+		"publint"
 	],
 	"ignoreBinaries": [
 		// .github/workflows/lint.yml installs this with `--no-save`

--- a/tests/clients/lsp/mock-client-state.ts
+++ b/tests/clients/lsp/mock-client-state.ts
@@ -16,7 +16,7 @@ import type { LSPClientState } from "../../../clients/lsp/client.js";
 import { TEXT_DOCUMENT_SYNC_KIND_FULL } from "../../../clients/lsp/sync-kind.js";
 import { WatchedFilesQueue } from "../../../clients/lsp/watch-queue.js";
 
-export function createMockConnection(): MessageConnection {
+function createMockConnection(): MessageConnection {
 	return {
 		sendNotification: vi.fn().mockResolvedValue(undefined),
 		sendRequest: vi.fn().mockResolvedValue(undefined),

--- a/tests/helpers/captured-runner-output.ts
+++ b/tests/helpers/captured-runner-output.ts
@@ -25,10 +25,10 @@ export const CAPTURED_OUTPUT_DIR = path.resolve(
 );
 
 /** Placeholder the capture script substitutes for its workspace path. */
-export const WORKSPACE_TOKEN = "__WORKSPACE__";
+const WORKSPACE_TOKEN = "__WORKSPACE__";
 
 /** Fields every provenance header must carry, all non-empty strings. */
-export const REQUIRED_PROVENANCE_FIELDS = [
+const REQUIRED_PROVENANCE_FIELDS = [
 	"runner",
 	"tool",
 	"version",
@@ -38,7 +38,7 @@ export const REQUIRED_PROVENANCE_FIELDS = [
 	"capturedAt",
 ] as const;
 
-export interface CapturedProvenance {
+interface CapturedProvenance {
 	runner: string;
 	tool: string;
 	version: string;
@@ -151,7 +151,7 @@ export function provenanceProblems(fixture: CapturedOutput): string[] {
 }
 
 /** Runner ids that have at least one captured fixture. */
-export function capturedRunnerIds(): string[] {
+function capturedRunnerIds(): string[] {
 	if (!fs.existsSync(CAPTURED_OUTPUT_DIR)) return [];
 	return fs
 		.readdirSync(CAPTURED_OUTPUT_DIR, { withFileTypes: true })
@@ -187,11 +187,6 @@ export function listCapturedOutputs(): CapturedOutput[] {
 		}
 	}
 	return out;
-}
-
-/** Captured fixtures for one runner id. */
-export function capturedOutputsFor(runnerId: string): CapturedOutput[] {
-	return listCapturedOutputs().filter((f) => f.provenance?.runner === runnerId);
 }
 
 /**

--- a/tests/monorepo/fixture.ts
+++ b/tests/monorepo/fixture.ts
@@ -33,7 +33,7 @@ export interface MonorepoPackageSpec {
 	piLensConfig?: Record<string, unknown>;
 }
 
-export interface MonorepoPadFilesSpec {
+interface MonorepoPadFilesSpec {
 	/** Directory (relative to root) to pad with tiny throwaway files. */
 	dir: string;
 	/** How many files to create. */

--- a/tests/support/availability-classifiedby-scan.ts
+++ b/tests/support/availability-classifiedby-scan.ts
@@ -30,7 +30,7 @@ export interface AvailabilityDecisionSite {
 }
 
 /** Directories scanned. Compiled output and tests are not sources of truth. */
-export const SCAN_ROOTS = ["clients"];
+const SCAN_ROOTS = ["clients"];
 
 const CALLEE = "logAvailabilityDecision";
 

--- a/tests/support/bootstrap-mock.ts
+++ b/tests/support/bootstrap-mock.ts
@@ -34,7 +34,7 @@
  */
 
 /** The options `requestBootstrapClients` is called with in production. */
-export interface BootstrapDemandOptions {
+interface BootstrapDemandOptions {
 	reason: string;
 	signal?: AbortSignal;
 	timeoutMs?: number;

--- a/tests/support/hashline-anchor-vectors.ts
+++ b/tests/support/hashline-anchor-vectors.ts
@@ -19,7 +19,7 @@ import * as path from "node:path";
  *    a module-resolution error when the module is absent, which is a much
  *    weaker red-first proof than an assertion failure.
  */
-export interface HashlineAnchorVectors {
+interface HashlineAnchorVectors {
 	upstream: {
 		repo: string;
 		branch: string;
@@ -50,7 +50,7 @@ export interface HashlineStoreCarried {
 
 let cached: HashlineAnchorVectors | undefined;
 
-export function loadHashlineAnchorVectors(): HashlineAnchorVectors {
+function loadHashlineAnchorVectors(): HashlineAnchorVectors {
 	if (cached) return cached;
 	cached = JSON.parse(
 		fs.readFileSync(

--- a/tests/support/hook-await-scan.ts
+++ b/tests/support/hook-await-scan.ts
@@ -105,7 +105,7 @@ function callArguments(
  * it costs nothing today and closes a hole slice 2 would otherwise walk
  * into.
  */
-export function isBoundedAwait(stripped: string, at: number): boolean {
+function isBoundedAwait(stripped: string, at: number): boolean {
 	const head = stripped.slice(at, at + 80);
 	return BOUNDED_CALL.test(head);
 }

--- a/tests/support/host-event-factory.ts
+++ b/tests/support/host-event-factory.ts
@@ -1,18 +1,18 @@
 /**
- * Shared builders for the five event payloads pi-lens's tests fire through
+ * Shared builder for the session-start payload pi-lens's tests fire through
  * `PiMock.emit(eventName, payload, ctx)` — #1681 acceptance criterion 3.
  *
- * Each builder's field set is derived from the pinned host contract (see
+ * The builder's field set is derived from the pinned host contract (see
  * `host-event-shape-scan.ts`'s doc comment for the file:line citations into
  * `packages/coding-agent/src/core/extensions/types.ts`), so a call site that
  * only ever goes through these cannot drift into a host-unfaithful shape.
  * These are optional, not mandatory: existing tests may keep constructing a
  * payload literal by hand (the scan in `host-event-shape-scan.ts` still
- * catches a drift either way), but a NEW suite should prefer these over a
+ * catches a drift either way), but a suite should prefer this over a
  * hand-rolled literal.
  *
  * `sessionId`/`provider`/`model` are deliberately not parameters here — the
- * host never puts them on any of these five events. A test that needs one
+ * host never puts them on this event. A test that needs one
  * passes it to `makeCtx({ sessionId, model })` (`tests/support/pi-mock.ts`)
  * instead, which is where the host actually carries it.
  */
@@ -33,67 +33,4 @@ export function makeSessionStartEvent(
 		event.previousSessionFile = overrides.previousSessionFile;
 	}
 	return event;
-}
-
-export interface ToolCallEventFixture {
-	toolCallId: string;
-	toolName: string;
-	input: Record<string, unknown>;
-}
-
-/** `ToolCallEventBase` plus its per-tool variants — `types.ts:869-872`. */
-export function makeToolCallEvent(
-	overrides: Partial<ToolCallEventFixture> = {},
-): ToolCallEventFixture {
-	return {
-		toolCallId: overrides.toolCallId ?? "call-1",
-		toolName: overrides.toolName ?? "read",
-		input: overrides.input ?? {},
-	};
-}
-
-export interface ToolResultEventFixture {
-	toolCallId: string;
-	toolName: string;
-	input: Record<string, unknown>;
-	content: Array<{ type: string; text?: string }>;
-	details?: unknown;
-	isError: boolean;
-	usage?: unknown;
-}
-
-/**
- * `ToolResultEventBase` — `types.ts:930-939`, pinned against the host's own
- * compiled build by `tests/clients/pi-host-contract.test.ts`'s
- * `HOST_TOOL_RESULT_KEYS`.
- */
-export function makeToolResultEvent(
-	overrides: Partial<ToolResultEventFixture> = {},
-): ToolResultEventFixture {
-	const event: ToolResultEventFixture = {
-		toolCallId: overrides.toolCallId ?? "call-1",
-		toolName: overrides.toolName ?? "read",
-		input: overrides.input ?? {},
-		content: overrides.content ?? [{ type: "text", text: "" }],
-		isError: overrides.isError ?? false,
-	};
-	if (overrides.details !== undefined) event.details = overrides.details;
-	if (overrides.usage !== undefined) event.usage = overrides.usage;
-	return event;
-}
-
-export interface AgentEndEventFixture {
-	messages: unknown[];
-}
-
-/** `AgentEndEvent` — `types.ts:733-736`. */
-export function makeAgentEndEvent(
-	overrides: Partial<AgentEndEventFixture> = {},
-): AgentEndEventFixture {
-	return { messages: overrides.messages ?? [] };
-}
-
-/** `AgentSettledEvent` — `types.ts:739-741`. No fields beyond `type`. */
-export function makeAgentSettledEvent(): Record<string, never> {
-	return {};
 }

--- a/tests/support/host-event-shape-scan.ts
+++ b/tests/support/host-event-shape-scan.ts
@@ -44,7 +44,7 @@ import { fileURLToPath } from "node:url";
 import { toPosix } from "../../clients/path-utils.js";
 import { stripCommentsAndStrings } from "./session-state-scan.ts";
 
-export const repoRoot = path.resolve(
+const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
 	"../..",
 );

--- a/tests/support/lsp-double-gate.ts
+++ b/tests/support/lsp-double-gate.ts
@@ -140,7 +140,7 @@ export function lspServiceMethodNames(): ReadonlySet<string> {
 }
 
 /** Indirection hops the resolver will follow before giving up. */
-export const MAX_RESOLUTION_DEPTH = 8;
+const MAX_RESOLUTION_DEPTH = 8;
 
 const FACTORY = "makeLspServiceDouble";
 const FACTORY_CALL = /\bmakeLspServiceDouble\s*\(/;

--- a/tests/support/module-instance-scan.ts
+++ b/tests/support/module-instance-scan.ts
@@ -48,7 +48,7 @@ export interface DualInstanceImport {
  * rather than restated here: its `exclude` list is the single source of truth
  * for what has no compiled `.js` twin (and therefore no hazard).
  */
-export function uncompiledRoots(): string[] {
+function uncompiledRoots(): string[] {
 	const config = JSON.parse(
 		fs.readFileSync(path.join(repoRoot, "tsconfig.build.json"), "utf8"),
 	) as { exclude?: unknown };
@@ -60,7 +60,7 @@ export function uncompiledRoots(): string[] {
 }
 
 /** True when the build emits a sibling `.js` for this repo-relative path. */
-export function isBuildCompiled(target: string, excluded: string[]): boolean {
+function isBuildCompiled(target: string, excluded: string[]): boolean {
 	if (target.startsWith("../") || path.isAbsolute(target)) return false;
 	if (!/\.(?:ts|mts|cts|tsx)$/.test(target)) return false;
 	if (/\.d\.(?:ts|mts|cts)$/.test(target)) return false;

--- a/tests/support/pi-mock.ts
+++ b/tests/support/pi-mock.ts
@@ -17,13 +17,13 @@ import type {
 	ExtensionCommandContext,
 } from "@earendil-works/pi-coding-agent";
 
-export interface RecordedFlag {
+interface RecordedFlag {
 	description?: string;
 	type: "boolean" | "string";
 	default?: boolean | string;
 }
 
-export interface RecordedCommand {
+interface RecordedCommand {
 	description?: string;
 	handler: (args: string, ctx: ExtensionCommandContext) => Promise<void> | void;
 	getArgumentCompletions?: unknown;
@@ -33,19 +33,19 @@ export interface RecordedCommand {
 type Hook = (event: unknown, ctx: unknown) => unknown;
 
 /** A `ui.notify(...)` call captured for assertions. */
-export interface CapturedNotification {
+interface CapturedNotification {
 	message: string;
 	type: "info" | "warning" | "error";
 }
 
 /** A `ui.setStatus(...)` call captured for assertions. */
-export interface CapturedStatus {
+interface CapturedStatus {
 	key: string;
 	text: string | undefined;
 }
 
 /** A `ui.setWidget(...)` call captured for assertions. */
-export interface CapturedWidget {
+interface CapturedWidget {
 	key: string;
 	content: unknown;
 	options: unknown;
@@ -61,7 +61,7 @@ export interface MockCtx extends ExtensionCommandContext {
 }
 
 /** A `pi.sendMessage(...)` call captured for assertions (#484). */
-export interface CapturedMessage {
+interface CapturedMessage {
 	customType: string;
 	content: unknown;
 	display: boolean;

--- a/tests/support/public-surface-drift.ts
+++ b/tests/support/public-surface-drift.ts
@@ -39,7 +39,7 @@ import {
 } from "./schema-stability.js";
 
 /** One registry whose ids are public API. */
-export interface SurfaceCatalog {
+interface SurfaceCatalog {
 	/** Human name, used in failure messages. */
 	readonly name: string;
 	/** Every id the code accepts today. */

--- a/tests/support/reset-explorer.ts
+++ b/tests/support/reset-explorer.ts
@@ -69,7 +69,7 @@
 /** A yield point the path under test exposes for reset injection. */
 export type Tap = () => void | Promise<void>;
 
-export interface ExploreOutcome<T> {
+interface ExploreOutcome<T> {
 	/** `null` for the baseline pass; the 0-based tap index for a reset pass. */
 	tapIndex: number | null;
 	/** The value `run` resolved to, when it didn't throw. */

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -161,13 +161,10 @@ import {
  * reset" are indistinguishable from the outside, and that ambiguity is the
  * whole defect class.
  */
-export type SessionResetPolicy =
-	| "session_start"
-	| "turn_end"
-	| "process_lifetime";
+type SessionResetPolicy = "session_start" | "turn_end" | "process_lifetime";
 
 /** Arm the state, then check whether it is back in its post-reset shape. */
-export interface SessionStateProbe {
+interface SessionStateProbe {
 	/** Put the state into a dirty, definitely-not-reset condition. */
 	arm(): void;
 	/** True when the state is in its initial, re-armed condition. */

--- a/tests/support/session-state-scan.ts
+++ b/tests/support/session-state-scan.ts
@@ -641,7 +641,7 @@ const PROCESS_SINGLETON_CALL = /getProcessSingleton\s*\(/;
  *    source, so column-zero matching skips it.
  * 5. **Semantics.** The scan cannot tell a session-scoped dedupe set from a
  *    frozen lookup table built once at import. That judgment stays in the
- *    registry and in {@link SessionStateExemption}'s reasons.
+ *    registry and in `SessionStateExemption` (the shape formerly exported here)'s reasons.
  *
  * The #1817 symbol-count pin narrows the FIRST four of these from "invisible"
  * to "a total the pin table tracks", but it inherits one more blind spot of

--- a/tests/support/session-state-scan.ts
+++ b/tests/support/session-state-scan.ts
@@ -720,6 +720,3 @@ export function scanSessionStateCandidates(
 	if (useCache) cachedCandidates = found;
 	return found;
 }
-
-/** A scanned file the registry deliberately does not cover, and why. */
-export type SessionStateExemption = string;

--- a/tests/support/single-flight-scan.ts
+++ b/tests/support/single-flight-scan.ts
@@ -75,12 +75,6 @@ export interface InFlightDeclaration {
  * person then writes or dismisses. A false negative is silent and ships the
  * next copy of the bug; a false positive costs one line and a moment's thought.
  */
-export const SCAN_HEURISTIC_LIMITS = [
-	"closure-scoped state inside factory functions is not seen",
-	"in-flight state not named /[iI]nFlight/ is not seen",
-	"a modifier-less, unannotated class field is not seen (it is shaped exactly like a bare assignment)",
-] as const;
-
 /**
  * Three alternatives, in the order the doc comment lists them: a module-level
  * binding, a modified class field, and a modifier-less class field that is
@@ -128,7 +122,7 @@ export function findInFlightDeclarations(
 }
 
 /** The module that owns the primitive, which is exempt by definition. */
-export const PRIMITIVE_MODULE = "single-flight.ts";
+const PRIMITIVE_MODULE = "single-flight.ts";
 
 /** Scan every `clients/` source for hand-rolled in-flight declarations. */
 export function scanInFlightDeclarations(): InFlightDeclaration[] {

--- a/tests/support/sweep-kit.ts
+++ b/tests/support/sweep-kit.ts
@@ -118,7 +118,7 @@ export { escapeRegExp } from "../../clients/string-utils.js";
 // ── 1. Source scanning ──────────────────────────────────────────────────────
 
 /** What {@link stripSource} does with string and template literal CONTENTS. */
-export type StringPolicy =
+type StringPolicy =
 	/**
 	 * Blank string/template contents along with comments (delimiters kept).
 	 * Use when a bare identifier inside a string must not read as code — the
@@ -532,7 +532,7 @@ export function stableOccurrenceKey(
  * ({@link RegistryAuditInput.requireUniqueFlagged}) can name each colliding
  * occurrence by its own detail rather than repeating the shared key.
  */
-export type FlaggedEntry = string | { key: string; detail: string };
+type FlaggedEntry = string | { key: string; detail: string };
 
 export interface RegistryAuditInput {
 	/** Sweep name, used in every composed message. */
@@ -998,7 +998,7 @@ export function hasNearbyCallSite(
 }
 
 /** Window defaults lifted from #1692's shipped form. */
-export const DEFAULT_EVIDENCE_WINDOW = {
+const DEFAULT_EVIDENCE_WINDOW = {
 	back: 150,
 	forward: 10,
 	calleeProximity: 3,

--- a/tests/support/turn-harness.ts
+++ b/tests/support/turn-harness.ts
@@ -93,7 +93,7 @@ import { setupTestEnvironment } from "../clients/test-utils.js";
  * relative offsets a scenario asks for, which is the only thing any of these
  * assertions depend on.
  */
-export interface ScenarioClock {
+interface ScenarioClock {
 	now(): number;
 	advance(ms: number): void;
 }
@@ -114,7 +114,7 @@ const ACTION_NEEDED_PREFIX = "🔑 ACTION NEEDED";
  * blocker tier" is the exact claim #1622's fix makes, and it is unassertable
  * from a flat string.
  */
-export interface TurnEndView {
+interface TurnEndView {
 	/** The full composed message, exactly as it reaches the agent. */
 	text: string;
 	/**
@@ -163,8 +163,7 @@ function splitTurnEndView(text: string): TurnEndView {
 }
 
 /** A knip run's result, minus the fields no scenario has ever needed to state. */
-export type ScenarioKnipResult = Partial<KnipResult> &
-	Pick<KnipResult, "issues">;
+type ScenarioKnipResult = Partial<KnipResult> & Pick<KnipResult, "issues">;
 
 const EMPTY_KNIP: KnipResult = {
 	success: true,
@@ -176,7 +175,7 @@ const EMPTY_KNIP: KnipResult = {
 	summary: "skipped",
 } as KnipResult;
 
-export interface TurnHarness {
+interface TurnHarness {
 	/** The scenario's project root (a real temp dir). */
 	cwd: string;
 	clock: ScenarioClock;
@@ -259,7 +258,7 @@ export interface TurnHarness {
 	knipClient: unknown;
 }
 
-export interface TurnHarnessOptions {
+interface TurnHarnessOptions {
 	/** Temp-dir prefix, so a failing scenario's leftovers are identifiable. */
 	prefix?: string;
 	/**
@@ -285,7 +284,7 @@ export interface TurnHarnessOptions {
  * Build a harness. Callers must call the returned `cleanup` in a `finally`;
  * {@link runTurnScenario} does that for them.
  */
-export function createTurnHarness(options: TurnHarnessOptions = {}): {
+function createTurnHarness(options: TurnHarnessOptions = {}): {
 	harness: TurnHarness;
 	cleanup: () => void;
 } {

--- a/tests/support/v8-coverage.ts
+++ b/tests/support/v8-coverage.ts
@@ -21,7 +21,7 @@ export interface ScriptCoverageLike {
 	}[];
 }
 
-export interface FileCoverage {
+interface FileCoverage {
 	file: string;
 	functionCount: number;
 	functionsHit: number;

--- a/tests/support/workspace-topology-scan.ts
+++ b/tests/support/workspace-topology-scan.ts
@@ -81,9 +81,7 @@ export const TOPOLOGY_OWNER = "workspace-topology.ts";
  * latter's export set, so a consumer importing it from workspace-topology
  * (a mistake) would not be falsely governed by the wrong module.
  */
-export const GOVERNED_PROBES_BY_MODULE: Readonly<
-	Record<string, readonly string[]>
-> = {
+const GOVERNED_PROBES_BY_MODULE: Readonly<Record<string, readonly string[]>> = {
 	"workspace-topology.js": [
 		"getDirectoryMarkers",
 		"findNearestDirWithMarker",
@@ -105,7 +103,7 @@ export const TOPOLOGY_PROBE_SEAMS: readonly string[] = Object.values(
 const REGISTER_CALL = /\bregisterWorkspaceTopologyReset\(/;
 
 /** Every `.ts` file under `dir` (default `clients/`), minus declarations. */
-export function topologyScanSourceFiles(dir = CLIENTS_ROOT): string[] {
+function topologyScanSourceFiles(dir = CLIENTS_ROOT): string[] {
 	return listSourceFiles(dir, { extensions: [".ts"], skipTests: true });
 }
 
@@ -155,7 +153,7 @@ function canonicalModuleForSpec(
 	return undefined;
 }
 
-export interface TopologyImport {
+interface TopologyImport {
 	/** The governed probe(s) that entered scope through this import. */
 	probes: string[];
 	/** 1-based line of the import statement. */
@@ -164,7 +162,7 @@ export interface TopologyImport {
 	namespace: boolean;
 }
 
-export interface ScanGovernedImportsOptions {
+interface ScanGovernedImportsOptions {
 	/** Absolute path of the source file containing the import declarations. */
 	sourceFilePath: string;
 	/** Directory containing the canonical governed source modules. */
@@ -180,7 +178,7 @@ export interface ScanGovernedImportsOptions {
  * canonical module contribute that module's full probe set, and type-only
  * imports contribute nothing because they cannot feed runtime state.
  */
-export function scanGovernedImports(
+function scanGovernedImports(
 	source: string,
 	options: ScanGovernedImportsOptions,
 ): TopologyImport[] {


### PR DESCRIPTION
## Summary

Clears the current test-side Knip remainder for #2708. Locally consumed test
helpers are private, wholly unused host-event fixtures are removed, and the
CI-pinned `publint` dependency is documented in `knip.jsonc`.

The three `flake-shape-scan.ts` rows remain deferred to #2742 because that
file is in flight there. This change does not flip Knip from advisory to
gating.

## Per-row disposition

The grep sweep used both `.ts` and `.js` spellings, dynamic `import(`
shapes, and source-text references in governance sweeps.

| Symbol | File | Grep result | Disposition |
| --- | --- | --- | --- |
| `createMockConnection` | `tests/clients/lsp/mock-client-state.ts` | Declaration plus local call | Removed export |
| `WORKSPACE_TOKEN` | `tests/helpers/captured-runner-output.ts` | Declaration plus local refs; test imports the helper's other exports | Removed export |
| `REQUIRED_PROVENANCE_FIELDS` | `tests/helpers/captured-runner-output.ts` | Declaration plus local ref | Removed export |
| `capturedRunnerIds` | `tests/helpers/captured-runner-output.ts` | Declaration plus local ref | Removed export |
| `capturedOutputsFor` | `tests/helpers/captured-runner-output.ts` | Declaration only | Deleted |
| `SCAN_ROOTS` | `tests/support/availability-classifiedby-scan.ts` | Declaration plus local ref | Removed export |
| `loadHashlineAnchorVectors` | `tests/support/hashline-anchor-vectors.ts` | Declaration plus local refs | Removed export |
| `isBoundedAwait` | `tests/support/hook-await-scan.ts` | Declaration plus local ref | Removed export |
| `makeToolCallEvent` | `tests/support/host-event-factory.ts` | Declaration only | Deleted |
| `makeToolResultEvent` | `tests/support/host-event-factory.ts` | Declaration only | Deleted |
| `makeAgentEndEvent` | `tests/support/host-event-factory.ts` | Declaration only | Deleted |
| `makeAgentSettledEvent` | `tests/support/host-event-factory.ts` | Declaration only | Deleted |
| `repoRoot` | `tests/support/host-event-shape-scan.ts` | Declaration plus local refs | Removed export |
| `MAX_RESOLUTION_DEPTH` | `tests/support/lsp-double-gate.ts` | Declaration plus local refs | Removed export |
| `uncompiledRoots` | `tests/support/module-instance-scan.ts` | Declaration plus local ref | Removed export |
| `isBuildCompiled` | `tests/support/module-instance-scan.ts` | Declaration plus local ref | Removed export |
| `SCAN_HEURISTIC_LIMITS` | `tests/support/single-flight-scan.ts` | Declaration only | Deleted |
| `PRIMITIVE_MODULE` | `tests/support/single-flight-scan.ts` | Declaration plus local ref | Removed export |
| `DEFAULT_EVIDENCE_WINDOW` | `tests/support/sweep-kit.ts` | Declaration plus local refs | Removed export |
| `createTurnHarness` | `tests/support/turn-harness.ts` | Declaration plus local ref | Removed export |
| `GOVERNED_PROBES_BY_MODULE` | `tests/support/workspace-topology-scan.ts` | Declaration plus local refs | Removed export |
| `topologyScanSourceFiles` | `tests/support/workspace-topology-scan.ts` | Declaration plus local refs | Removed export |
| `scanGovernedImports` | `tests/support/workspace-topology-scan.ts` | Declaration plus local ref | Removed export |
| `testSourceFiles` | `tests/support/flake-shape-scan.ts` | Declaration plus local refs | Deferred to #2742; keep private after merge |
| `testsRelative` | `tests/support/flake-shape-scan.ts` | Declaration plus local refs | Deferred to #2742; keep private after merge |
| `SCAN_INFRASTRUCTURE` | `tests/support/flake-shape-scan.ts` | Declaration plus local ref | Deferred to #2742; keep private after merge |
| `CapturedProvenance` | `tests/helpers/captured-runner-output.ts` | Declaration plus local property type refs | Removed export |
| `MonorepoPadFilesSpec` | `tests/monorepo/fixture.ts` | Declaration plus local property type ref | Removed export |
| `BootstrapDemandOptions` | `tests/support/bootstrap-mock.ts` | Declaration plus local refs | Removed export |
| `HashlineAnchorVectors` | `tests/support/hashline-anchor-vectors.ts` | Declaration plus local refs | Removed export |
| `ToolCallEventFixture` | `tests/support/host-event-factory.ts` | Declaration only after builder sweep | Deleted with builder |
| `ToolResultEventFixture` | `tests/support/host-event-factory.ts` | Declaration only after builder sweep | Deleted with builder |
| `AgentEndEventFixture` | `tests/support/host-event-factory.ts` | Declaration only after builder sweep | Deleted with builder |
| `RecordedFlag` | `tests/support/pi-mock.ts` | Declaration plus local map/method refs | Removed export |
| `RecordedCommand` | `tests/support/pi-mock.ts` | Declaration plus local map/method refs | Removed export |
| `CapturedNotification` | `tests/support/pi-mock.ts` | Declaration plus local property refs | Removed export |
| `CapturedStatus` | `tests/support/pi-mock.ts` | Declaration plus local property refs | Removed export |
| `CapturedWidget` | `tests/support/pi-mock.ts` | Declaration plus local property refs | Removed export |
| `CapturedMessage` | `tests/support/pi-mock.ts` | Declaration plus local property refs | Removed export |
| `SurfaceCatalog` | `tests/support/public-surface-drift.ts` | Declaration plus local property refs | Removed export |
| `ExploreOutcome` | `tests/support/reset-explorer.ts` | Declaration plus local callback refs | Removed export |
| `SessionResetPolicy` | `tests/support/session-state-registry.ts` | Declaration plus local property ref | Removed export |
| `SessionStateProbe` | `tests/support/session-state-registry.ts` | Declaration plus local property ref | Removed export |
| `SessionStateExemption` | `tests/support/session-state-scan.ts` | Declaration only, including documentation text | Deleted |
| `StringPolicy` | `tests/support/sweep-kit.ts` | Declaration plus local type refs | Removed export |
| `FlaggedEntry` | `tests/support/sweep-kit.ts` | Declaration plus local type refs | Removed export |
| `ScenarioClock` | `tests/support/turn-harness.ts` | Declaration plus local property refs | Removed export |
| `TurnEndView` | `tests/support/turn-harness.ts` | Declaration plus local function/property refs | Removed export |
| `ScenarioKnipResult` | `tests/support/turn-harness.ts` | Declaration plus local property refs | Removed export |
| `TurnHarness` | `tests/support/turn-harness.ts` | Declaration plus local refs | Removed export |
| `TurnHarnessOptions` | `tests/support/turn-harness.ts` | Declaration plus local refs | Removed export |
| `FileCoverage` | `tests/support/v8-coverage.ts` | Declaration plus local property refs | Removed export |
| `TopologyImport` | `tests/support/workspace-topology-scan.ts` | Declaration plus local refs | Removed export |
| `ScanGovernedImportsOptions` | `tests/support/workspace-topology-scan.ts` | Declaration plus local parameter ref | Removed export |

## Knip counts

- Before: `54` unused exports and `1` unused devDependency, from the
  master Lint run.
- After source sweep: expected `0` unused exports and `0` unused
  devDependencies, with the three deferred flake-shape rows applying until
  #2742 merges.
- `npm run knip` was attempted before and after. Both attempts stopped in
  `scripts/run-knip.mjs` because its compiled-sibling purge could not spawn
  Git in this read-only shared worktree (`spawnSync git EPERM`).

## Tests

- `npm run build`: passed.
- `npm run lint`: passed.
- `npx oxfmt --check` on all touched source, config, and changelog files:
  passed.
- Consumer sweep: 99 files; 94 passed and 5 failed, with 3 individual tests
  skipped. The 6 failed tests were environmental: Git-backed tests failed with
  `spawnSync git EPERM`,
  three real-LSP tests lacked their offline fixture binaries, and one live
  subprocess test produced no output.
- `tests/config/dmts-export-drift.test.ts` and
  `tests/config/sweep-floor-coverage.test.ts`: 12 tests passed.
- Tree-sitter grammar prefetch was skipped because the environment is offline;
  the suites used their existing degradation path.

## Blast radius

The change affects test-support module boundaries only. Consumers continue to
use the same local bindings. The direct consumer sweep covered captured runner
output, availability, bootstrap, hashline, hook-await, Pi mock, public-surface,
reset, session-state, single-flight, sweep-kit, turn-harness, V8 coverage,
workspace-topology, and configuration governance suites.

## Class sweep

The unused-export population was swept by both source specifiers and symbol
references. The flake-shape file is explicitly excluded from edits and
deferred to #2742. Consolidation verdict: keep the support modules distributed;
the change only narrows their existing local APIs and does not introduce a new
shared seam.

## Observability

N/A. This change removes unused test exports and does not add a failure path or
runtime record.

## Test assessment

Tests are edited only by removing unused fixture builders and export surfaces.
No assertions, fixtures used by consumers, ratchets, or runtime seams change.
The export-drift and sweep-floor suites provide the contract checks.

## Local run note (orchestrator)

Six tests in `tests/clients/lsp/{server-policy,workspace-diagnostics-cache,workspace-diagnostics-pull-binding}.test.ts` are red in the orchestrator sandbox with AND without this diff (identical six on the base tree), so they are environmental here; CI on this head is the arbiter.
