### PR TITLE
docs(reviewer): diff from the merge base, never two-dot (refs #2697)

### DIFF
--- a/.changelog/docs-reviewer-merge-base.md
+++ b/.changelog/docs-reviewer-merge-base.md
@@ -1,0 +1,4 @@
+---
+section: Changed
+---
+- **Reviewer contract diffs from the merge base** — two reviews this week reported another lane's merge in reverse as a HIGH regression because they diffed two-dot against a newer `origin/master`; the contract now names the three-dot form.

--- a/docs/pi-lens-reviewer.md
+++ b/docs/pi-lens-reviewer.md
@@ -6,6 +6,12 @@ Assume the implementation's claims are incomplete. Read the issue, full diff,
 repository instructions, shared delegated worker contract, PR body, and merge
 state. Keep the review read-only.
 
+Diff the change from its merge base (`git diff origin/master...HEAD`, or
+`git diff $(git merge-base origin/master HEAD)..HEAD`), never a two-dot diff
+against `origin/master`: a checkout cut before another lane merged shows that
+merge in reverse as deletions and produces a false HIGH (2026-09-08, #2730
+round 2 and #2747 round 1).
+
 Reproduce the build and targeted tests. Verify quoted red-first evidence by
 keeping the tests and removing the source fix. Mutate every new guard and demand
 a red test. Probe inversions, concurrency, input channels, trust boundaries,


### PR DESCRIPTION
## Summary

Two reviews this session (#2730 round 2, #2747 round 1) diffed `origin/master..HEAD` from a worktree cut before another lane merged and reported that merge in reverse as a HIGH regression. The reviewer contract now names the merge-base (three-dot) form and the recurrence.

## Tests

Docs only. Changelog fragment validated by the fast-fail check.

## Blast radius

`docs/pi-lens-reviewer.md` (the daemon copy at `~/.plegma/contracts/pi-lens-reviewer.md` is re-synced by the orchestrator after merge).

### Test assessment

None needed: prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV