### PR TITLE
chore(knip): clear the last three test-support exports and the dead hooks entry pattern (closes #2708)

### DIFF
--- a/.changelog/chore-2708-knip-remainder.md
+++ b/.changelog/chore-2708-knip-remainder.md
@@ -1,0 +1,4 @@
+---
+section: Changed
+---
+- **knip advisory job green: the last three unused test-support exports are private and the dead `scripts/hooks/**/*.ts` entry pattern is gone (closes #2708)** — `testSourceFiles`, `testsRelative` and `SCAN_INFRASTRUCTURE` in `tests/support/flake-shape-scan.ts` had no importer after #2749; the hooks are `.mjs`, so the `.ts` entry pattern matched nothing.

--- a/.changelog/chore-2708-knip-remainder.md
+++ b/.changelog/chore-2708-knip-remainder.md
@@ -1,4 +1,4 @@
 ---
 section: Changed
 ---
-- **knip advisory job green: the last three unused test-support exports are private and the dead `scripts/hooks/**/*.ts` entry pattern is gone (closes #2708)** — `testSourceFiles`, `testsRelative` and `SCAN_INFRASTRUCTURE` in `tests/support/flake-shape-scan.ts` had no importer after #2749; the hooks are `.mjs`, so the `.ts` entry pattern matched nothing.
+- **knip advisory job green: the last three unused test-support exports are private, the dead `scripts/hooks/**/*.ts` entry pattern is gone, and the path-spawned `jscpd` devDependency is credited (closes #2708)** — `testSourceFiles`, `testsRelative` and `SCAN_INFRASTRUCTURE` in `tests/support/flake-shape-scan.ts` had no importer after #2749; the hooks are `.mjs`, so the `.ts` entry pattern matched nothing.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -95,6 +95,10 @@
 	// of knip's plugins for these tools activates the way this repo uses
 	// them, so knip cannot see the usage on its own:
 	"ignoreDependencies": [
+		// jscpd (#2706, lint.yml "jscpd (advisory)") is a pinned devDependency
+		// spawned by path (`node_modules/.bin/jscpd`) from the workflow step and
+		// never imported, so knip cannot credit it.
+		"jscpd",
 		// knip's husky plugin (packages/knip/src/plugins/husky/index.ts,
 		// pinned tag) only credits the `husky` package itself from the
 		// legacy v8 `package.json#husky.hooks` field; this repo uses v9

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -52,8 +52,7 @@
 		// work: via a scripts/*.mjs entry's own import, or a test's.
 		// Doesn't exist yet (#2697 item 1 adds it); the glob costs nothing
 		// today and needs no follow-up edit once hook scripts land there.
-		"scripts/hooks/**/*.mjs",
-		"scripts/hooks/**/*.ts"
+		"scripts/hooks/**/*.mjs"
 		// tools/*.ts and vitest's setupFiles are NOT listed here: both are
 		// already reached without help — tools/*.ts via index.ts's and
 		// mcp/server.ts's own imports, tests/support/vitest-setup.ts via

--- a/tests/support/flake-shape-scan.ts
+++ b/tests/support/flake-shape-scan.ts
@@ -76,7 +76,7 @@ export const repoRoot = path.resolve(
 const TESTS_ROOT = path.join(repoRoot, "tests");
 
 /** Every `*.test.ts` file under `tests/`, as absolute paths, sorted. */
-export function testSourceFiles(dir = TESTS_ROOT): string[] {
+function testSourceFiles(dir = TESTS_ROOT): string[] {
 	return listSourceFiles(dir, {
 		extensions: [".ts"],
 		skipDeclarations: true,
@@ -84,7 +84,7 @@ export function testSourceFiles(dir = TESTS_ROOT): string[] {
 }
 
 /** `tests/`-relative posix path for an absolute source path. */
-export function testsRelative(absolute: string): string {
+function testsRelative(absolute: string): string {
 	return relativePosix(TESTS_ROOT, absolute);
 }
 
@@ -98,7 +98,7 @@ export function testsRelative(absolute: string): string {
  * `delivery-surface-ratchet.test.ts` makes for `finding-delivery-gate.ts`
  * ("the registry itself").
  */
-export const SCAN_INFRASTRUCTURE: ReadonlySet<string> = new Set([
+const SCAN_INFRASTRUCTURE: ReadonlySet<string> = new Set([
 	"clients/flake-shape-ratchet.test.ts",
 ]);
 


### PR DESCRIPTION
## Summary

The remainder named on #2708 after #2746: three unused exports in `tests/support/flake-shape-scan.ts` (`testSourceFiles`, `testsRelative`, `SCAN_INFRASTRUCTURE`, importer-free after #2749 replaced the text scanner) become module-private, and the `scripts/hooks/**/*.ts` knip entry pattern that matched nothing (the hooks are `.mjs`) is removed.

## Tests

`npm run knip` on this head: no unused exports, no configuration hints (was 3 + 1 on master). Flake-shape ratchet and sweep-kit suites green; lint and format green.

## Blast radius

Test-support visibility only; every remaining consumer of the three symbols is inside the same file. `knip.jsonc` entry list loses a dead pattern.

### Test assessment

No new test: the knip advisory job on master is the check that turns green.

Closes #2708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV