### PR TITLE
test(turn-session): use isRunnerErrorResult in the four formatResult doubles (closes #2673)

### DIFF
--- a/.changelog/2673-runtime-turn-session-double.md
+++ b/.changelog/2673-runtime-turn-session-double.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Turn-end session test doubles use the shared runner-error predicate (closes #2673)** — partial runner errors with `failed === 0` now exercise the same classification as production instead of requiring `passed === 0` in four local `formatResult` doubles.

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -38,7 +38,11 @@ import {
 	checkCrossProcessLspBudget,
 	_resetLspBudgetDecisionForTests,
 } from "../../clients/lsp-budget.js";
-import { RUNNERS, TestRunnerClient } from "../../clients/test-runner-client.js";
+import {
+	isRunnerErrorResult,
+	RUNNERS,
+	TestRunnerClient,
+} from "../../clients/test-runner-client.js";
 import { setupTestEnvironment } from "./test-utils.js";
 
 /**
@@ -2221,7 +2225,7 @@ describe("turn_end test runner — stale results are cached, not discarded", () 
 // test-failure blocker.
 
 describe("turn_end test runner — a runner-error result does not clear a real git-guard blocker (#1524)", () => {
-	it("keeps a pre-existing test-failure blocker after a runner-start failure", async () => {
+	it("keeps a pre-existing test-failure blocker after a runner error with partial passes", async () => {
 		const env = setupTestEnvironment("pi-lens-test-guard-error-");
 		try {
 			const runtime = new RuntimeCoordinator();
@@ -2242,9 +2246,10 @@ describe("turn_end test runner — a runner-error result does not clear a real g
 
 			// Seed a REAL prior test-failure blocker on this exact go test file
 			// — a previous turn genuinely ran it and it failed. The scenario
-			// under test is this same file now failing to even START (a
-			// spawn/config error), which must not read as "it passed" and
-			// clear the blocker it earned last turn.
+			// under test is this same file now reporting a runner error after
+			// partial progress, which must not read as "it passed" and clear
+			// the blocker it earned last turn. This catches divergent doubles
+			// that require passed === 0 in addition to failed === 0 && error.
 			const goTestFile = path.join(env.tmpDir, "src/main_test.go");
 			fs.writeFileSync(goTestFile, "package main\n");
 			mergeGitGuardTestFailure(
@@ -2262,7 +2267,7 @@ describe("turn_end test runner — a runner-error result does not clear a real g
 				file: goTestFile,
 				sourceFile: srcFile,
 				runner: "go",
-				passed: 0,
+				passed: 3,
 				failed: 0,
 				skipped: 0,
 				failures: [],
@@ -2281,18 +2286,22 @@ describe("turn_end test runner — a runner-error result does not clear a real g
 							strategy: "related" as const,
 						}),
 						runTestFileAsync: async () => runnerErrorResult,
-						formatResult: (r: {
-							error?: string;
-							passed: number;
-							failed: number;
-						}) =>
-							r.error && r.passed === 0 && r.failed === 0
+						formatResult: (r: Parameters<typeof isRunnerErrorResult>[0]) =>
+							isRunnerErrorResult(r)
 								? `[Tests] ⚠ Could not run tests: ${r.error}`
 								: "",
 					},
 				}),
 			);
 			await new Promise((resolve) => setImmediate(resolve));
+
+			const persisted = cacheManager.readCache<{ content?: string }>(
+				"test-runner-findings",
+				env.tmpDir,
+			)?.data;
+			expect(persisted?.content).toContain(
+				"[Tests] ⚠ Could not run tests: Runner go exited with 1",
+			);
 
 			// The prior real test-failure blocker must still be in force — a
 			// suite that never started must not read as a pass that clears it.
@@ -2368,12 +2377,8 @@ describe("turn_end test runner — a runner-error-only batch does not itself blo
 							strategy: "related" as const,
 						}),
 						runTestFileAsync: async () => runnerErrorResult,
-						formatResult: (r: {
-							error?: string;
-							passed: number;
-							failed: number;
-						}) =>
-							r.error && r.passed === 0 && r.failed === 0
+						formatResult: (r: Parameters<typeof isRunnerErrorResult>[0]) =>
+							isRunnerErrorResult(r)
 								? `[Tests] ⚠ Could not run tests: ${r.error}`
 								: "",
 					},
@@ -2503,12 +2508,8 @@ describe("turn_end test runner — a runner-error-only batch does not itself blo
 							if (!result) throw new Error(`unexpected test file ${testFile}`);
 							return result;
 						},
-						formatResult: (r: {
-							error?: string;
-							passed: number;
-							failed: number;
-						}) =>
-							r.error && r.passed === 0 && r.failed === 0
+						formatResult: (r: Parameters<typeof isRunnerErrorResult>[0]) =>
+							isRunnerErrorResult(r)
 								? `[Tests] ⚠ Could not run tests: ${r.error}`
 								: `[Tests] ✗ ${r.failed} failed`,
 					},
@@ -2594,12 +2595,8 @@ describe("turn_end test runner — a runner-error-only batch does not itself blo
 							duration: 1,
 							error: "Runner go exited with 1",
 						}),
-						formatResult: (r: {
-							error?: string;
-							passed: number;
-							failed: number;
-						}) =>
-							r.error && r.passed === 0 && r.failed === 0
+						formatResult: (r: Parameters<typeof isRunnerErrorResult>[0]) =>
+							isRunnerErrorResult(r)
 								? `[Tests] ⚠ Could not run tests: ${r.error}`
 								: "",
 					},


### PR DESCRIPTION
## Summary

Replace the four hand-rolled `formatResult` runner-error predicates in
`tests/clients/runtime-turn-session.test.ts` with the exported
`isRunnerErrorResult` predicate from `clients/test-runner-client.ts`.

The regression fixture reports `{ error, passed: 3, failed: 0 }`. Production
classifies it as a runner error, while the old test double treated it as an
empty result. The real `handleTurnEnd` path now proves that the formatted
runner-error content is persisted.

## Tests

- Red-first: before the replacement, the real turn-session test failed at
  `tests/clients/runtime-turn-session.test.ts:2301` with
  `AssertionError: expected '' to contain '[Tests] ⚠ Could not run tests: Runner go exited with 1'`.
- Green regression: the focused case passed after importing and using
  `isRunnerErrorResult`.
- Mutation: replacing the new predicate with `false` made the same assertion
  fail with the same empty-content result.
- `npm run build`: passed.
- `node_modules/.bin/vitest run tests/clients/runtime-turn-session.test.ts --configLoader runner`:
  1 file and 55 tests passed.
- `node_modules/.bin/vitest run tests/config/dependency-boundaries.test.ts --configLoader runner`:
  2 tests passed; 1 governance test was blocked by sandbox `spawnSync /usr/bin/node EPERM`.
- `npx oxfmt --check tests/clients/runtime-turn-session.test.ts`: passed.
- `npm run lint`: passed.

## Blast radius

The only production symbol consumed is the existing pure export
`isRunnerErrorResult` from `clients/test-runner-client.ts`. Its callers above
the changed doubles are the four `handleTurnEnd` test setups. Its callee below
is the existing `failed === 0 && !!error` expression. No production module,
durable record, or runtime behavior changed.

The changed test assertion observes the real `handleTurnEnd` path and the real
`CacheManager` persistence. It does not replace an in-process coordinator or
store.

## Observability

No new production failure path or telemetry record was added. The regression
assertion preserves the discriminating partial-pass runner-error content in
the persisted turn findings.

## Class sweep

The whole-tree sweep searched `clients/`, `tests/`, `tools/`, `mcp/`,
`scripts/`, and `index.ts` for the old boolean shape, `isRunnerErrorResult`,
and all `formatResult` doubles.

- The four issue members in `tests/clients/runtime-turn-session.test.ts` now
  use `isRunnerErrorResult`.
- `tests/clients/test-runner-client.test.ts` contains the production
  `formatResult` contract and already tests the partial-pass divergence.
- `tests/clients/runtime-turn-session.test.ts` has other `formatResult`
  doubles for unrelated failure text, duration, generation, and empty-output
  scenarios. None hand-rolls runner-error classification.
- `tests/clients/runtime-turn-test-runner-bounds.test.ts` has one unconditional
  runner-error formatter and three unrelated formatters. None uses the old
  predicate.
- `tests/support/` has no `formatResult` double, so no shared helper is needed.
- Remaining production `passed === 0 && failed === 0` expressions are parser
  facts tied to nonzero runner exit codes, not `TestResult` classification;
  the production formatter and turn-end summary already use the shared
  predicate. Complementary clean-result filters use `failed === 0 && !error`
  intentionally.

Consolidation verdict: fold the four same-shape doubles onto the existing
production predicate; do not add a support helper because no second test file
contains this classification double.

### Test assessment

- `tests/clients/runtime-turn-session.test.ts`: uniquely pins that a partial
  runner error is formatted and persisted through the real turn-end session
  path, and updates four local doubles to the production classification seam.
- No test was removed. The focused regression and mutation both prove the new
  assertion is load-bearing.

## Files changed

- `tests/clients/runtime-turn-session.test.ts`
- `.changelog/2673-runtime-turn-session-double.md`

`PR_BODY.md`, `COMMIT_MSG.txt`, and `.probe-home/` are handoff/probe artifacts
and must not be committed.


Closes #2673.
