### PR TITLE
fix(scripts): liveness-gated scratch-dir sweeps for smoke-tools and the harness scratch home (closes #2688, closes #2687)

### DIFF
--- a/.changelog/fix-2688-scratch-sweeps.md
+++ b/.changelog/fix-2688-scratch-sweeps.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- **LSP and smoke harness scratch directories use liveness-gated cleanup (closes #2688, closes #2687)** — shared per-run scratch directories record their owner process, preserve live workspaces, remove dead or aged orphaned entries, and announce each scratch home for reliable telemetry discovery.

--- a/.github/workflows/parser-smoke.yml
+++ b/.github/workflows/parser-smoke.yml
@@ -36,19 +36,8 @@ jobs:
     # The installer resolves GitHub release assets through the REST API.
     # Unauthenticated is 60 requests/hour per IP and shared runners exhaust it.
     #
-    # PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1, for symmetry with
-    # tool-smoke.yml): this job only runs one `--install` step today, so there
-    # is no per-job cache to preserve here yet, but pinning keeps this
-    # workflow behaving identically to its sibling rather than depending on
-    # `withScratchHome`'s per-invocation default the moment a second
-    # `--install` step is ever added. A bare `/tmp` path, not
-    # `${{ runner.temp }}`: the `runner` context is unavailable at job-level
-    # `env:` (actionlint: "context \"runner\" is not allowed here"), and this
-    # runner's whole VM is destroyed after the job either way.
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PI_LENS_HOME: /tmp/pi-lens-home
-      PILENS_DATA_DIR: /tmp/pi-lens-home
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/tool-smoke.yml
+++ b/.github/workflows/tool-smoke.yml
@@ -34,24 +34,8 @@ jobs:
     # The auto-provided token raises this to 5000 req/hr; the installer sends it
     # ONLY to api.github.com, never the asset CDN.
     #
-    # PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1): job-level, so the SIX
-    # `--install` steps below share one tool tree/bin dir across the job
-    # instead of each `withScratchHome()` pin minting its own empty one per
-    # step — without this, each script re-pulls every managed tool from
-    # scratch (measured against the last full nightly, run 32817692457: the
-    # shared cache made the format step ~9s; per-step scratch homes would add
-    # ~10min across the job and 4-5x the release-asset downloads on this
-    # shared-IP runner). A bare `/tmp` path, not `${{ runner.temp }}`: the
-    # `runner` context is unavailable at job-level `env:` (actionlint: "context
-    # \"runner\" is not allowed here"), and this runner's whole VM — `/tmp`
-    # included — is destroyed after the job either way, so this never becomes
-    # a second `~/.pi-lens` some other step relies on persisting.
-    # `withScratchHome`'s "already pinned" branch is a no-op against an
-    # explicit PI_LENS_HOME, so this is the ONLY change these steps need.
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PI_LENS_HOME: /tmp/pi-lens-home
-      PILENS_DATA_DIR: /tmp/pi-lens-home
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,6 +385,13 @@ Each routine's output is a PR (or a tracked issue for discovery routines), revie
 
 ## Standing invariants
 
+Harness scratch directories use `scripts/lib/scratch-dir.mjs`: `claimScratchDir`
+records `owner.pid`, and `sweepScratchDirs` removes only dead owners or
+pid-less directories beyond the age fallback. A cleanup catch is not a
+liveness check on POSIX, where removing an open directory can succeed. Fresh
+per-run homes stay isolated, announce their path, and share this seam instead
+of maintaining caller-local sweeps.
+
 Deferred collect-later runners are a three-state delivery contract: edit-time
 pending, turn-end clean, or turn-end failed. The pending state must reach the
 runner latency and widget surfaces, failures must carry their failure kind into

--- a/scripts/lib/lsp-fixture-workspace.mjs
+++ b/scripts/lib/lsp-fixture-workspace.mjs
@@ -1,10 +1,13 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { gitExecFileSync } from "./git-fixture-env.mjs";
 import { assertFixtureWorkspaceRegistered } from "./lsp-fixture-session-guard.mjs";
 import { safeRm } from "./safe-rm.mjs";
-
+import {
+	claimScratchDir,
+	SCRATCH_DIR_ROOT,
+	sweepScratchDirs,
+} from "./scratch-dir.mjs";
 /**
  * #2670 (folds #2658). The one "copy fixture → register session root →
  * optional `.pi-lens/lsp.json` disable + reload → optional `git init` →
@@ -55,8 +58,11 @@ export async function bootstrapFixtureWorkspace(fx, opts) {
 		disableServers,
 	} = opts;
 
-	const workspace =
-		preMadeWorkspace ?? fs.mkdtempSync(path.join(os.tmpdir(), tmpPrefix));
+	let workspace = preMadeWorkspace;
+	if (!workspace) {
+		sweepScratchDirs(SCRATCH_DIR_ROOT, tmpPrefix);
+		workspace = claimScratchDir(SCRATCH_DIR_ROOT, tmpPrefix);
+	}
 	fs.cpSync(path.join(repoRoot, fx.dir), workspace, { recursive: true });
 
 	// #2369/#2655/#2658: every fixture registers its OWN workspace
@@ -139,92 +145,6 @@ export async function bootstrapFixtureWorkspace(fx, opts) {
  * runner is itself thrown away every night; see the PR body for the
  * tradeoff this was weighed against.
  */
-const SCRATCH_HOME_OWNER_FILE = "owner.pid";
-// Fallback for a dir with no pid file at all (pre-dates this fix, or its
-// writer crashed between mkdtemp and writing its own pid) — old enough that
-// ANY normal `--install` run (minutes, not hours) is long finished, so this
-// never races a live one.
-const SCRATCH_HOME_ORPHAN_AGE_MS = 60 * 60 * 1000; // 1h
-
-/**
- * Is the process that minted `entryDir` (its recorded `owner.pid`) still
- * alive? `undefined` when there's no pid file to check (caller falls back to
- * an age gate). `process.kill(pid, 0)` sends no signal — it only probes
- * existence/permission: `ESRCH` means no such process (dead); anything else
- * (success, or `EPERM` — a live process this one merely lacks permission to
- * signal) means a real, live process still owns this dir.
- */
-function scratchHomeOwnerAlive(entryDir) {
-	let pidText;
-	try {
-		pidText = fs.readFileSync(
-			path.join(entryDir, SCRATCH_HOME_OWNER_FILE),
-			"utf8",
-		);
-	} catch {
-		return undefined; // no pid file recorded
-	}
-	const pid = Number.parseInt(pidText.trim(), 10);
-	if (!Number.isInteger(pid) || pid <= 0) return undefined;
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch (err) {
-		return err?.code !== "ESRCH";
-	}
-}
-
-/**
- * Sweep leftover scratch-home dirs from PRIOR runs (#2670 review F2, hardened
- * in review round 2 F1). Nothing else ever removes a scratch home:
- * `withScratchHome`'s `restore()` only unsets the env vars (the dir itself
- * may still hold installed tools a LATER call in the same process wants to
- * keep using), and a SIGKILL'd run skips any exit handler entirely — without
- * this sweep, every `--install` run leaves a full tool tree behind in
- * `os.tmpdir()` forever.
- *
- * NOT a blind "try rmSync, catch = still locked" pass (round 1's shape,
- * reviewer round 2 F1): on POSIX, `rmSync` on a directory another process is
- * actively using SUCCEEDS regardless — only Windows EPERMs on an open
- * handle — so that catch block was describing a protection that did not
- * exist. A live writer whose scratch home got removed out from under it
- * would keep appending to files by then-unlinked inode: silent, permanent
- * data loss, not a caught-and-skipped no-op. Liveness is checked for real
- * instead: each dir's `owner.pid` (written at mint by `withScratchHome`)
- * against `process.kill(pid, 0)` — alive is skipped unconditionally, dead is
- * removed. A dir with no pid file at all only goes by age (see
- * `SCRATCH_HOME_ORPHAN_AGE_MS`), never by whether `rmSync` happens to throw.
- */
-function sweepScratchHomeLeftovers(tmpPrefix) {
-	let entries;
-	const tmp = os.tmpdir();
-	try {
-		entries = fs.readdirSync(tmp);
-	} catch {
-		return; // tmpdir unreadable — ignore
-	}
-	for (const entry of entries) {
-		if (!entry.startsWith(tmpPrefix)) continue;
-		const entryDir = path.join(tmp, entry);
-		const ownerAlive = scratchHomeOwnerAlive(entryDir);
-		if (ownerAlive === true) continue; // its writer is still running — never touch a live home
-		if (ownerAlive === undefined) {
-			let mtimeMs;
-			try {
-				mtimeMs = fs.statSync(entryDir).mtimeMs;
-			} catch {
-				continue; // already gone (raced something else) — nothing to do
-			}
-			if (Date.now() - mtimeMs < SCRATCH_HOME_ORPHAN_AGE_MS) continue; // too young to call orphaned yet
-		}
-		try {
-			fs.rmSync(entryDir, { recursive: true, force: true });
-		} catch {
-			// a genuine removal error (e.g. permissions) — leave it, swept by a later run instead
-		}
-	}
-}
-
 export function withScratchHome(opts = {}) {
 	const { realHome = false, tmpPrefix = "lsp-fixture-home-" } = opts;
 	if (realHome) {
@@ -236,14 +156,8 @@ export function withScratchHome(opts = {}) {
 	}
 	// Startup sweep BEFORE minting this run's own dir, so it never sweeps
 	// itself (#2670 review F2).
-	sweepScratchHomeLeftovers(tmpPrefix);
-	const dir = fs.mkdtempSync(path.join(os.tmpdir(), tmpPrefix));
-	// Recorded so a LATER run's sweep can tell this one is still alive
-	// (review round 2 F1) rather than guessing from whether rmSync throws.
-	fs.writeFileSync(
-		path.join(dir, SCRATCH_HOME_OWNER_FILE),
-		String(process.pid),
-	);
+	sweepScratchDirs(SCRATCH_DIR_ROOT, tmpPrefix);
+	const dir = claimScratchDir(SCRATCH_DIR_ROOT, tmpPrefix);
 	process.env.PI_LENS_HOME = dir;
 	const dataDirWasUnset = !process.env.PILENS_DATA_DIR?.trim();
 	if (dataDirWasUnset) process.env.PILENS_DATA_DIR = dir;
@@ -256,12 +170,21 @@ export function withScratchHome(opts = {}) {
 	console.error(
 		`[lsp-fixture-workspace] PI_LENS_HOME pinned to ${dir} (#2506 shape) — this run's tool installs and config_resolved/sessionstart telemetry land there, not the real ~/.pi-lens.`,
 	);
+	let announcedEnd = false;
+	const announceEnd = () => {
+		if (announcedEnd) return;
+		announcedEnd = true;
+		console.error(`[lsp-fixture-workspace] scratch home complete: ${dir}`);
+	};
+	process.once("exit", announceEnd);
 	return {
 		dir,
 		pinned: true,
 		restore() {
 			delete process.env.PI_LENS_HOME;
 			if (dataDirWasUnset) delete process.env.PILENS_DATA_DIR;
+			process.off("exit", announceEnd);
+			announceEnd();
 		},
 	};
 }

--- a/scripts/lib/scratch-dir.d.mts
+++ b/scripts/lib/scratch-dir.d.mts
@@ -1,0 +1,9 @@
+export const SCRATCH_DIR_ROOT: string;
+export const SCRATCH_OWNER_FILE: string;
+export const DEFAULT_SCRATCH_MAX_AGE_MS: number;
+export function claimScratchDir(root: string, prefix: string): string;
+export function sweepScratchDirs(
+	root: string,
+	prefix: string,
+	options?: { maxAgeMs?: number },
+): number;

--- a/scripts/lib/scratch-dir.mjs
+++ b/scripts/lib/scratch-dir.mjs
@@ -1,0 +1,71 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export const SCRATCH_DIR_ROOT = path.join(os.tmpdir(), "pi-lens-scratch");
+export const SCRATCH_OWNER_FILE = "owner.pid";
+export const DEFAULT_SCRATCH_MAX_AGE_MS = 60 * 60 * 1000;
+
+function ownerAlive(entryDir) {
+	let pidText;
+	try {
+		pidText = fs.readFileSync(path.join(entryDir, SCRATCH_OWNER_FILE), "utf8");
+	} catch {
+		return undefined;
+	}
+	const pid = Number.parseInt(pidText.trim(), 10);
+	if (!Number.isInteger(pid) || pid <= 0) return undefined;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return err?.code !== "ESRCH";
+	}
+}
+
+/** Create a named scratch directory and record the process that owns it. */
+export function claimScratchDir(root, prefix) {
+	fs.mkdirSync(root, { recursive: true });
+	const dir = fs.mkdtempSync(
+		path.join(root, `${prefix}-${process.pid}-${Date.now()}-`),
+	);
+	fs.writeFileSync(path.join(dir, SCRATCH_OWNER_FILE), String(process.pid));
+	return dir;
+}
+
+/** Remove only dead or old orphaned scratch directories for one prefix. */
+export function sweepScratchDirs(
+	root,
+	prefix,
+	{ maxAgeMs = DEFAULT_SCRATCH_MAX_AGE_MS } = {},
+) {
+	let entries;
+	try {
+		entries = fs.readdirSync(root, { withFileTypes: true });
+	} catch {
+		return 0;
+	}
+	let swept = 0;
+	for (const entry of entries) {
+		if (!entry.isDirectory() || !entry.name.startsWith(prefix)) continue;
+		const entryDir = path.join(root, entry.name);
+		const alive = ownerAlive(entryDir);
+		if (alive === true) continue;
+		if (alive === undefined) {
+			let mtimeMs;
+			try {
+				mtimeMs = fs.statSync(entryDir).mtimeMs;
+			} catch {
+				continue;
+			}
+			if (Date.now() - mtimeMs < maxAgeMs) continue;
+		}
+		try {
+			fs.rmSync(entryDir, { recursive: true, force: true });
+			swept++;
+		} catch {
+			// Leave permission- or platform-locked entries for a later sweep.
+		}
+	}
+	return swept;
+}

--- a/scripts/smoke-tools.d.mts
+++ b/scripts/smoke-tools.d.mts
@@ -93,6 +93,8 @@ export function passFloorBreach(
 ): string | null;
 /** Fixtures flagged `tier1` — the scheduled parser lane's selection. */
 export function tier1Fixtures(): SmokeFixture[];
+/** Remove dead or old scratch workspaces from previous smoke runs. */
+export function sweepLeftovers(): number;
 /** One TOOLS registry entry, as far as this classification cares. */
 export interface SmokeToolDefinition {
 	installStrategy?: string;

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -51,6 +51,11 @@ import {
 	bootstrapFixtureWorkspace,
 	withScratchHome,
 } from "./lib/lsp-fixture-workspace.mjs";
+import {
+	claimScratchDir,
+	SCRATCH_DIR_ROOT,
+	sweepScratchDirs,
+} from "./lib/scratch-dir.mjs";
 import { safeRm } from "./lib/safe-rm.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -1259,35 +1264,14 @@ function parseArgs(argv) {
 
 const TMP_PREFIX = "pi-lens-smoke-";
 
-/**
- * Sweep leftovers from PRIOR runs. Those runs' LSP servers have long since
- * exited, so their workspace locks are released and the dirs delete cleanly —
- * this is why cleanup belongs at startup, not in the same process that holds the
- * lock. Keeps %TEMP% from accumulating across nightly runs without a separate
- * unlock step.
- */
-function sweepLeftovers() {
-	const tmp = os.tmpdir();
-	let swept = 0;
-	try {
-		for (const entry of fs.readdirSync(tmp)) {
-			if (!entry.startsWith(TMP_PREFIX)) continue;
-			try {
-				fs.rmSync(path.join(tmp, entry), { recursive: true, force: true });
-				swept++;
-			} catch {
-				// still locked by a live run — leave it
-			}
-		}
-	} catch {
-		// tmpdir unreadable — ignore
-	}
-	return swept;
+/** Sweep prior runs without deleting a workspace owned by a live process. */
+export function sweepLeftovers() {
+	return sweepScratchDirs(SCRATCH_DIR_ROOT, TMP_PREFIX);
 }
 
 function copyDirToTemp(srcRel) {
 	const src = path.join(repoRoot, srcRel);
-	const dest = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-smoke-"));
+	const dest = claimScratchDir(SCRATCH_DIR_ROOT, TMP_PREFIX);
 	fs.cpSync(src, dest, { recursive: true });
 	return dest;
 }

--- a/tests/config/lsp-fixture-home-workflow-pin.test.ts
+++ b/tests/config/lsp-fixture-home-workflow-pin.test.ts
@@ -1,23 +1,13 @@
-// #2670 review F1: `tool-smoke.yml` runs SIX `--install` invocations
-// (smoke-tools.mjs x3, characterize-lsp.mjs, probe-clean-signal.mjs,
-// server-capabilities.mjs) in ONE job. `PI_LENS_HOME` relocates the
-// installer's tool tree/bin dir/probe cache (module-level consts at
-// `clients/installer/index.ts`), not just logs — with no JOB-level pin, each
-// script's own `withScratchHome()` (scripts/lib/lsp-fixture-workspace.mjs)
-// mints a FRESH, empty scratch home per invocation, so every step re-pulls
-// every managed tool from scratch instead of sharing the one tool tree the
-// job's ephemeral `$HOME` gave them for free pre-#2670. Job-level
-// `PI_LENS_HOME`/`PILENS_DATA_DIR` restores that sharing: `withScratchHome`'s
-// "already pinned" branch is a no-op against an explicit value, so setting it
-// once at the job is the entire fix.
+// #2687 option (b): each script keeps a fresh per-run scratch home so concurrent
+// invocations never share a tool tree or instances registry. The home is named,
+// claimed, announced, and swept by scripts/lib/scratch-dir.mjs.
 //
 // Same technique as tests/config/install-smoke-gates.test.ts: load the REAL
 // workflow via yaml.load, assert on the LOADED structure (never a hand-copied
 // restatement of the YAML text).
 //
-// Before this file existed, PI_LENS_HOME/PILENS_DATA_DIR were absent from
-// both workflows entirely (proven below by deleting the env lines from a
-// SOURCE copy and reloading) and no test in the repo checked for them.
+// The workflow-level pins used by the earlier shared-cache design are absent;
+// this test keeps that option (b) decision visible as the workflow changes.
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -42,29 +32,14 @@ const WORKFLOWS: Array<[string, string, number]> = [
 ];
 
 describe.each(WORKFLOWS)(
-	"%s jobs.%s.env pins PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1)",
+	"%s jobs.%s leaves per-run scratch homes to the harness (#2687)",
 	(workflowPath, jobName, expectedInstallSteps) => {
 		const workflow = loadWorkflow(workflowPath);
 		const jobEnv = workflow.jobs?.[jobName]?.env;
 
-		it("carries a non-empty PI_LENS_HOME", () => {
-			expect(typeof jobEnv?.PI_LENS_HOME).toBe("string");
-			expect((jobEnv?.PI_LENS_HOME as string).trim().length).toBeGreaterThan(0);
-		});
-
-		it("carries a non-empty PILENS_DATA_DIR", () => {
-			expect(typeof jobEnv?.PILENS_DATA_DIR).toBe("string");
-			expect((jobEnv?.PILENS_DATA_DIR as string).trim().length).toBeGreaterThan(
-				0,
-			);
-		});
-
-		it("PI_LENS_HOME and PILENS_DATA_DIR resolve to the SAME dir (one shared tool tree, not two)", () => {
-			expect(jobEnv?.PI_LENS_HOME).toBe(jobEnv?.PILENS_DATA_DIR);
-		});
-
-		it('never points at ${{ runner.temp }} (unavailable at job-level env — actionlint: "context \\"runner\\" is not allowed here")', () => {
-			expect(String(jobEnv?.PI_LENS_HOME)).not.toContain("runner.temp");
+		it("does not pin a shared tool tree at job level", () => {
+			expect(jobEnv?.PI_LENS_HOME).toBeUndefined();
+			expect(jobEnv?.PILENS_DATA_DIR).toBeUndefined();
 		});
 
 		it("counts the --install steps this job's cache-sharing claim is actually about", () => {
@@ -73,25 +48,6 @@ describe.each(WORKFLOWS)(
 				Array.isArray(steps) ? (steps as Array<{ run?: unknown }>) : []
 			).filter((s) => typeof s.run === "string" && s.run.includes("--install"));
 			expect(installSteps.length).toBe(expectedInstallSteps);
-		});
-
-		// Mutation-proof: before this file existed, deleting the pin entirely
-		// left every other check in this repo green.
-		it("mutation-proof: deleting the PI_LENS_HOME env line reds the pin assertion", () => {
-			const source = readFileSync(resolve(REPO_ROOT, workflowPath), "utf8");
-			const lines = source.split("\n");
-			const lineIdx = lines.findIndex((line) =>
-				/^\s*PI_LENS_HOME:\s/.test(line),
-			);
-			expect(lineIdx, "no PI_LENS_HOME: line found").toBeGreaterThanOrEqual(0);
-			const mutatedLines = [...lines];
-			mutatedLines.splice(lineIdx, 1);
-			const mutatedSource = mutatedLines.join("\n");
-			expect(mutatedSource).not.toBe(source);
-			const mutatedWorkflow = loadWorkflow(workflowPath, mutatedSource);
-			expect(
-				mutatedWorkflow.jobs?.[jobName]?.env?.PI_LENS_HOME,
-			).toBeUndefined();
 		});
 	},
 );

--- a/tests/scripts/lsp-fixture-workspace.test.ts
+++ b/tests/scripts/lsp-fixture-workspace.test.ts
@@ -32,6 +32,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SCRATCH_DIR_ROOT } from "../../scripts/lib/scratch-dir.mjs";
 
 const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -343,7 +344,8 @@ describe("withScratchHome (#2670/#2506-shape)", () => {
 	const SWEEP_TEST_PREFIX = "lsp-fixture-workspace-test-home-";
 
 	function mintScratchHomeDir(): string {
-		return fs.mkdtempSync(path.join(os.tmpdir(), SWEEP_TEST_PREFIX));
+		fs.mkdirSync(SCRATCH_DIR_ROOT, { recursive: true });
+		return fs.mkdtempSync(path.join(SCRATCH_DIR_ROOT, SWEEP_TEST_PREFIX));
 	}
 
 	function writeOwnerPid(dir: string, pid: number): void {
@@ -495,10 +497,13 @@ describe("withScratchHome (#2670/#2506-shape)", () => {
 			);
 			expect(errors.some((line) => line.includes(dir as string))).toBe(true);
 		} finally {
-			spy.mockRestore();
 			restore();
+			spy.mockRestore();
 			fs.rmSync(dir as string, { recursive: true, force: true });
 		}
+		expect(errors.some((line) => line.includes("scratch home complete"))).toBe(
+			true,
+		);
 	});
 
 	it("does not announce anything when a home is already pinned (a true no-op)", () => {

--- a/tests/scripts/scratch-dir.test.ts
+++ b/tests/scripts/scratch-dir.test.ts
@@ -1,0 +1,61 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	claimScratchDir,
+	SCRATCH_DIR_ROOT,
+	SCRATCH_OWNER_FILE,
+	sweepScratchDirs,
+} from "../../scripts/lib/scratch-dir.mjs";
+import { sweepLeftovers } from "../../scripts/smoke-tools.mjs";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0))
+		fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("scratch directory ownership (#2688/#2687)", () => {
+	it("preserves a live owner and removes a dead owner", () => {
+		const root = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-scratch-test-"),
+		);
+		roots.push(root);
+		const live = claimScratchDir(root, "pi-lens-smoke-");
+		const dead = fs.mkdtempSync(path.join(root, "pi-lens-smoke-dead-"));
+		fs.writeFileSync(path.join(dead, SCRATCH_OWNER_FILE), "999999999");
+
+		expect(sweepScratchDirs(root, "pi-lens-smoke-")).toBe(1);
+		expect(fs.existsSync(live)).toBe(true);
+		expect(fs.existsSync(dead)).toBe(false);
+	});
+
+	it("makes smoke-tools use the same live-owner gate", () => {
+		const live = claimScratchDir(SCRATCH_DIR_ROOT, "pi-lens-smoke-");
+		try {
+			sweepLeftovers();
+			expect(fs.existsSync(live)).toBe(true);
+		} finally {
+			fs.rmSync(live, { recursive: true, force: true });
+		}
+	});
+
+	it("uses the age fallback only for directories without owner.pid", () => {
+		const root = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-scratch-test-"),
+		);
+		roots.push(root);
+		const young = fs.mkdtempSync(path.join(root, "pi-lens-smoke-young-"));
+		const old = fs.mkdtempSync(path.join(root, "pi-lens-smoke-old-"));
+		const oldTime = new Date(Date.now() - 2_000);
+		fs.utimesSync(old, oldTime, oldTime);
+
+		expect(sweepScratchDirs(root, "pi-lens-smoke-", { maxAgeMs: 1_000 })).toBe(
+			1,
+		);
+		expect(fs.existsSync(young)).toBe(true);
+		expect(fs.existsSync(old)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the shared scratch-directory race in #2688 and the unfindable, unswept
LSP harness homes in #2687.

`scripts/lib/scratch-dir.mjs` is now the single ownership seam. It claims
stable-named per-run directories under `/tmp/pi-lens-scratch`, writes
`owner.pid`, preserves live owners, removes dead owners, and age-gates
directories without a pid file. `withScratchHome()` and smoke fixture
workspaces use it. Scratch-home paths are printed at start and completion.

Option (a), extending `PILENS_PROBE=1`, would require moving the installer tool
tree and instances registry into the probe-home contract. That would expand a
log redirection contract into machine-state ownership and could reintroduce
cross-run contamination. Option (b) keeps the fresh-per-run isolation requested
by #2670, gives each directory a stable prefix plus pid and timestamp, and
sweeps siblings through the shared owner gate. This PR implements option (b).

Closes #2688 and closes #2687.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:tests

## Checklist

- [x] I read `CLAUDE.md`, `AGENTS.md`, `docs/pi-lens-subagent.md`, and `docs/pi-lens-fixer.md`.
- [x] The change has regression and edge-case tests.
- [x] The new regression test was red on the pre-fix smoke sweep.
- [x] New liveness and age guards were mutation-tested with compile-valid edits.
- [x] `npm run lint` passes.
- [x] The changelog fragment passes `node scripts/check-changelog-fragments.mjs`.
- [x] No commit, push, or `CHANGELOG.md` edit was made.

## Tests

The red-first and mutation transcripts are below. Vitest also reports the
expected offline grammar prefetch degradation; those grammars are unrelated to
this seam.

- `tests/scripts/scratch-dir.test.ts`: pins live-owner preservation, dead-owner
  removal, smoke-tools consumer wiring, and the young/old pid-less age fallback.
- `tests/scripts/lsp-fixture-workspace.test.ts`: edits the shared-home fixture
  to use the shared root and pins start/completion announcements. Twenty of 21
  tests pass; the git-init test cannot spawn `git` in this sandbox.
- `tests/config/lsp-fixture-home-workflow-pin.test.ts`: pins the honest option
  (b) workflow shape, with no job-level shared home.
- `tests/scripts/smoke-tools-cue-fixture.test.ts`,
  `tests/scripts/smoke-tools-genuine-install-failure.test.ts`, and
  `tests/scripts/smoke-tools-lsp-fixture-registration.test.ts`: sibling smoke
  coverage. The first two pass; the real child-spawn case cannot spawn Node
  (`EPERM`) in this sandbox.

Pre-fix smoke sweep, with the old unconditional `rmSync` body restored:

```text
FAIL tests/scripts/scratch-dir.test.ts > scratch directory ownership (#2688/#2687) > makes smoke-tools use the same live-owner gate
AssertionError: expected 1 to be +0
at tests/scripts/scratch-dir.test.ts:35:29
```

Mutation M1, with `if (alive === true) continue` removed:

```text
FAIL tests/scripts/scratch-dir.test.ts > preserves a live owner and removes a dead owner
AssertionError: expected 2 to be 1
FAIL tests/scripts/scratch-dir.test.ts > makes smoke-tools use the same live-owner gate
AssertionError: expected 1 to be +0
```

Mutation M2, with the age-fallback branch forced false:

```text
FAIL tests/scripts/scratch-dir.test.ts > uses the age fallback only for directories without owner.pid
AssertionError: expected 2 to be 1
```

Passing targeted run:

```text
Test Files  2 passed (2)
Tests  7 passed (7)
```

The full `tests/config/*.test.ts` population ran 35 files. Thirty-one files
passed with 324 tests. Four files had 11 environment failures from blocked
`git`/Node child spawns (`EPERM`); 324 tests still passed.

## Test assessment

- `tests/scripts/scratch-dir.test.ts` is the new contract and regression file;
  no test is redundant.
- `tests/scripts/lsp-fixture-workspace.test.ts` uniquely covers real LSP
  bootstrap state and scratch-home announcements; its existing owner cases
  remain relevant after extraction.
- `tests/config/lsp-fixture-home-workflow-pin.test.ts` uniquely checks the
  workflow does not override per-run ownership; no removal candidate.
- The three smoke-tool files cover existing fixture registration and install
  behavior; no test is removed or made redundant.

## Blast radius

`module_report` was unavailable in this worker, so the call-tree diff below is
the verified grep-based map.

```text
- lsp-fixture-workspace.bootstrapFixtureWorkspace
    - fs.mkdtempSync(os.tmpdir(), tmpPrefix)
    - lsp-fixture-workspace.withScratchHome
        - scratchHomeOwnerAlive
        - sweepScratchHomeLeftovers
        - fs.mkdtempSync(os.tmpdir(), tmpPrefix)
+ lsp-fixture-workspace.bootstrapFixtureWorkspace
    + sweepScratchDirs(SCRATCH_DIR_ROOT, tmpPrefix)
    + claimScratchDir(SCRATCH_DIR_ROOT, tmpPrefix)
+ lsp-fixture-workspace.withScratchHome
    + sweepScratchDirs(SCRATCH_DIR_ROOT, tmpPrefix)
    + claimScratchDir(SCRATCH_DIR_ROOT, tmpPrefix)
    + process exit completion announcement
+ smoke-tools.copyDirToTemp
    + claimScratchDir(SCRATCH_DIR_ROOT, TMP_PREFIX)
+ smoke-tools.sweepLeftovers
    + sweepScratchDirs(SCRATCH_DIR_ROOT, TMP_PREFIX)
```

The five harness entry points remain consumers of `withScratchHome()`:
`probe-clean-signal.mjs`, `server-capabilities.mjs`, `characterize-lsp.mjs`,
`bench-lsp.mjs`, and `smoke-tools.mjs`. The liveness-gate implementation count
falls from two caller-local implementations to one shared helper.

## Observability

Each fresh home emits one stderr line containing its absolute path at claim
time and one completion line at process exit or `restore()`. This is the
production record for locating redirected telemetry and installed tools.

## Class sweep

I screened the temporary-directory cleanup class across `clients/`, `tools/`,
`mcp/`, `scripts/`, `scripts/lib/`, `tests/support/`, and `index.ts`, using
`rg` for `os.tmpdir()`, recursive `rmSync`, and directory scans. The affected
family was the five `withScratchHome()` callers plus `smoke-tools.mjs` and
`bootstrapFixtureWorkspace`; all now use the shared seam.

The remaining `os.tmpdir()` scratch users are deliberately separate families:
availability lifecycle probes, PowerShell classification probes, clean-signal
workspace cleanup, capture/release/compat fixtures, exec isolation, and test
support fixtures. They either remove their own synchronous fixture or have no
cross-process sweep. Folding them into this owner protocol would widen the
contract without a reported concurrent-run defect.

Consolidation verdict: fold the liveness-gated scratch family onto
`scripts/lib/scratch-dir.mjs`; leave unrelated one-shot fixtures distributed.

## Verification

- `npm run build`: passed.
- `npm run lint`: passed.
- `npx oxfmt --check` on all touched JS, TS, declaration, and workflow files:
  passed.
- `node scripts/check-changelog-fragments.mjs`: passed.
- No network was used. Grammar prefetches were skipped by the existing offline
  path, and child-process suites requiring `git` or Node were blocked by
  sandbox `EPERM`.
