### PR TITLE
fix(ci): remove unused scratch export and fix test formatting (refs #2759)

### DIFF
--- a/.changelog/fix-2759-ci-hygiene.md
+++ b/.changelog/fix-2759-ci-hygiene.md
@@ -1,0 +1,12 @@
+---
+category: Fixed
+---
+
+**fix(ci): remove unused scratch export and fix test formatting** (refs #2759)
+
+Remove `export` from `DEFAULT_SCRATCH_MAX_AGE_MS` in `scripts/lib/scratch-dir.mjs`
+and its matching declaration in `scripts/lib/scratch-dir.d.mts`. The constant is
+used internally but has no external consumer — Knip reported it as unused after
+PR #2755 introduced it. Fix oxfmt formatting violations in
+`tests/clients/formatters.test.ts` and `tests/scripts/lint-js-advisory.test.ts`
+introduced by PR #2751.

--- a/.changelog/fix-2759-ci-hygiene.md
+++ b/.changelog/fix-2759-ci-hygiene.md
@@ -1,12 +1,5 @@
 ---
-category: Fixed
+section: Fixed
 ---
 
-**fix(ci): remove unused scratch export and fix test formatting** (refs #2759)
-
-Remove `export` from `DEFAULT_SCRATCH_MAX_AGE_MS` in `scripts/lib/scratch-dir.mjs`
-and its matching declaration in `scripts/lib/scratch-dir.d.mts`. The constant is
-used internally but has no external consumer — Knip reported it as unused after
-PR #2755 introduced it. Fix oxfmt formatting violations in
-`tests/clients/formatters.test.ts` and `tests/scripts/lint-js-advisory.test.ts`
-introduced by PR #2751.
+- **Remove the unused scratch export and declaration, and fix oxfmt violations in two tests (refs #2759).**

--- a/scripts/lib/scratch-dir.d.mts
+++ b/scripts/lib/scratch-dir.d.mts
@@ -1,6 +1,5 @@
 export const SCRATCH_DIR_ROOT: string;
 export const SCRATCH_OWNER_FILE: string;
-export const DEFAULT_SCRATCH_MAX_AGE_MS: number;
 export function claimScratchDir(root: string, prefix: string): string;
 export function sweepScratchDirs(
 	root: string,

--- a/scripts/lib/scratch-dir.mjs
+++ b/scripts/lib/scratch-dir.mjs
@@ -4,7 +4,7 @@ import * as path from "node:path";
 
 export const SCRATCH_DIR_ROOT = path.join(os.tmpdir(), "pi-lens-scratch");
 export const SCRATCH_OWNER_FILE = "owner.pid";
-export const DEFAULT_SCRATCH_MAX_AGE_MS = 60 * 60 * 1000;
+const DEFAULT_SCRATCH_MAX_AGE_MS = 60 * 60 * 1000;
 
 function ownerAlive(entryDir) {
 	let pidText;

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -94,9 +94,7 @@ async function withPathShim(
 	}
 }
 
-async function withIsolatedPath(
-	fn: () => Promise<void> | void,
-): Promise<void> {
+async function withIsolatedPath(fn: () => Promise<void> | void): Promise<void> {
 	const isolatedPath = path.join(tmpDir, "isolated-path");
 	fs.mkdirSync(isolatedPath, { recursive: true });
 	const origPath = process.env.PATH;

--- a/tests/scripts/lint-js-advisory.test.ts
+++ b/tests/scripts/lint-js-advisory.test.ts
@@ -40,7 +40,11 @@ function readPackage(file: string) {
 	];
 }
 
-function writePackage(root: string, name: string, packageJson: Record<string, unknown>) {
+function writePackage(
+	root: string,
+	name: string,
+	packageJson: Record<string, unknown>,
+) {
 	const directory = join(root, "node_modules", name);
 	mkdirSync(directory, { recursive: true });
 	writeFileSync(join(directory, "package.json"), JSON.stringify(packageJson));


### PR DESCRIPTION
## Summary

- Remove `export` from `DEFAULT_SCRATCH_MAX_AGE_MS` in `scripts/lib/scratch-dir.mjs:7` — the constant is used internally at line 40 but has no external consumer. PR #2755 introduced it; Knip reported it unused after merge.
- Remove matching declaration from `scripts/lib/scratch-dir.d.mts:3` so runtime and type contracts stay aligned.
- Fix oxfmt formatting violations in `tests/clients/formatters.test.ts:97-99` and `tests/scripts/lint-js-advisory.test.ts:43` introduced by PR #2751.

## Tests

- `tests/scripts/scratch-dir.test.ts` — scratch behavior suite, 5 tests, all pass.
- `tests/config/dmts-export-drift.test.ts` — declaration-vs-runtime drift guard, pass.
- `tests/clients/formatters.test.ts` — 173 tests (formatting-only change, no behavior change), all pass.
- `tests/scripts/lint-js-advisory.test.ts` — same file, formatting-only, all pass.

## Blast radius

`scripts/lib/scratch-dir.mjs` exports reduced from 5 to 4. No external consumer of `DEFAULT_SCRATCH_MAX_AGE_MS` exists. The constant remains available internally via its default parameter binding. `scripts/lib/scratch-dir.d.mts` is a hand-written type contract, not shipped in the tarball — no published surface affected.

## Class sweep

The unused-export defect is a single-instance: `DEFAULT_SCRATCH_MAX_AGE_MS` was the only export in `scripts/lib/scratch-dir.mjs` without an external consumer. No siblings were found. The declaration file `scripts/lib/scratch-dir.d.mts` is the only hand-written type contract for this module. The oxfmt formatting violations were in two test files; no other files in the same PRs had formatting drift.

## Observability

Knip and oxfmt job outputs prove the result. No runtime telemetry changes.

## Test assessment

- `scratch-dir.test.ts` uniquely pins scratch directory creation, sweep, and owner-alive behavior. Not redundant.
- `dmts-export-drift.test.ts` uniquely pins the declaration-runtime contract. Removing either half of the fix makes it fail — mutation proof confirmed by the investigation.

Closes #2759.