### PR TITLE
fix(format): run formatters from the project root so ignore files and configs resolve as at the CLI (closes #2756)

### DIFF
--- a/.changelog/fix-2756-prettier-ignore-cwd.md
+++ b/.changelog/fix-2756-prettier-ignore-cwd.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Prettier now carries repo-root `.prettierignore` via `--ignore-path` (closes #2756)** — `formatFile` spawns formatters with `cwd` set to the edited file's directory, which meant Prettier's default `.prettierignore` resolution (relative to cwd) never saw a repo-root ignore file. Ignored files were silently rewritten. The fix resolves `.prettierignore` by walking up from the file (same as config discovery) and passes the found path as `--ignore-path`, capped at `$HOME` so a home-level ignore Prettier would never read on its own is not adopted.

--- a/.changelog/fix-2756-prettier-ignore-cwd.md
+++ b/.changelog/fix-2756-prettier-ignore-cwd.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Prettier now carries repo-root `.prettierignore` via `--ignore-path` (closes #2756)** — `formatFile` spawns formatters with `cwd` set to the edited file's directory, which meant Prettier's default `.prettierignore` resolution (relative to cwd) never saw a repo-root ignore file. Ignored files were silently rewritten. The fix resolves `.prettierignore` by walking up from the file (same as config discovery) and passes the found path as `--ignore-path`, capped at `$HOME` so a home-level ignore Prettier would never read on its own is not adopted.
+- **Formatters now run from the project root (closes #2756)** — `formatFile` uses the nearest formatter config or `.gitignore`, with a real `.git` fallback capped at `$HOME`, so `.prettierignore`, `.gitignore`, and cwd-discovered configs resolve as at the CLI. Prettier, Biome, and oxfmt are covered.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -883,6 +883,14 @@ or merge restoration, and writes under already-ignored directories remain
 outside the tool-result producer and are tracked by the freshness-probe issue.
 (#2071)
 
+Formatter children run from `resolveFormatterCwd`'s nearest project marker,
+then the nearest `.git`, with `isAtOrAboveHomeDir` as the ceiling. The absolute
+file path remains the resolver argument, so file-based tools such as Ruff and
+Black keep their file-relative discovery while cwd-sensitive tools such as
+Prettier, Biome, and oxfmt see the project's ignore files. Keep this policy at
+the shared `formatFile` spawn seam; do not add per-formatter ignore argv
+carriage. Files outside a project retain their own directory as cwd. (#2756)
+
 The `*`-only glob compilers in `clients/read-guard.ts` and
 `clients/file-utils.ts` collapse adjacent wildcard runs before constructing a
 regex. `.*.*` has the same language as `.*`, but the former can partition a

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -15,7 +15,11 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { BoundedLruCache } from "./bounded-cache.js";
 import { createGenerationSource } from "./generation-guard.js";
-import { normalizeMapKey } from "./path-utils.js";
+import {
+	findNearestContaining,
+	isAtOrAboveHomeDir,
+	normalizeMapKey,
+} from "./path-utils.js";
 import { resolveCargoPackageEdition } from "./cargo-manifest.js";
 import { resolveKtfmtGradleStyle } from "./gradle-ktfmt-style.js";
 import { resolvePhpCsFixerConfig } from "./php-cs-fixer-config.js";
@@ -936,6 +940,17 @@ export const prettierFormatter: FormatterInfo = {
 		const styleArgs = await indentationArgs(filePath, "prettier", cwd);
 		if (styleArgs === null) return SKIP_FORMATTING;
 		const args = ["--write", ...styleArgs];
+		// #2756: prettier resolves `.prettierignore` from the child cwd, which
+		// `formatFile` sets to the FILE's directory — so a repo-root
+		// `.prettierignore` was never seen and ignored files got rewritten.
+		// Carry the ignore file explicitly via `--ignore-path`, resolved by
+		// walking up from the file's directory (same as config discovery),
+		// capped at $HOME so a home-level ignore prettier would never read on
+		// its own is not adopted.
+		const ignoreDir = findNearestContaining(cwd, [".prettierignore"]);
+		if (ignoreDir && !isAtOrAboveHomeDir(ignoreDir)) {
+			args.push("--ignore-path", path.join(ignoreDir, ".prettierignore"));
+		}
 		const local = await findInNodeModules("prettier", cwd);
 		if (local) return [local, ...args, filePath];
 		// Global bin of any manager (npm/pnpm/yarn/bun) before auto-install (#375).

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -12,14 +12,11 @@
 import { logExtension } from "./extension-log.js";
 import { AsyncLocalStorage } from "node:async_hooks";
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import { BoundedLruCache } from "./bounded-cache.js";
 import { createGenerationSource } from "./generation-guard.js";
-import {
-	findNearestContaining,
-	isAtOrAboveHomeDir,
-	normalizeMapKey,
-} from "./path-utils.js";
+import { findNearestMarkerRoot, normalizeMapKey } from "./path-utils.js";
 import { resolveCargoPackageEdition } from "./cargo-manifest.js";
 import { resolveKtfmtGradleStyle } from "./gradle-ktfmt-style.js";
 import { resolvePhpCsFixerConfig } from "./php-cs-fixer-config.js";
@@ -854,6 +851,115 @@ async function indentationArgs(
 	];
 }
 
+const FORMATTER_MARKERS_BY_NAME: ReadonlyMap<string, readonly string[]> =
+	new Map([
+		["biome", ["biome.json", "biome.jsonc", "package.json"]],
+		[
+			"prettier",
+			[
+				".prettierrc",
+				".prettierrc.json",
+				".prettierrc.yaml",
+				".prettierrc.yml",
+				".prettierrc.js",
+				".prettierrc.cjs",
+				".prettierrc.mjs",
+				"prettier.config.js",
+				"prettier.config.cjs",
+				"prettier.config.mjs",
+				".prettierignore",
+				"package.json",
+			],
+		],
+		[
+			"oxfmt",
+			["oxfmt.toml", ".oxfmtrc.json", "vite-plus.json", "package.json"],
+		],
+		["ruff", ["pyproject.toml", "ruff.toml", ".ruff.toml"]],
+		["black", ["pyproject.toml", "black.toml", ".black"]],
+		["sqlfluff", [".sqlfluff", "pyproject.toml", "setup.cfg"]],
+		["rustfmt", ["rustfmt.toml", ".rustfmt.toml", "Cargo.toml"]],
+		["rubocop", [".rubocop.yml", ".rubocop.yaml"]],
+		["standardrb", [".standard.yml", ".standard.yaml"]],
+		["clang-format", [".clang-format", "_clang-format"]],
+		["php-cs-fixer", [".php-cs-fixer.php", ".php-cs-fixer.dist.php"]],
+		["stylua", ["stylua.toml", ".stylua.toml"]],
+		["ocamlformat", [".ocamlformat"]],
+		["google-java-format", [".google-java-format", ".editorconfig"]],
+		["cljfmt", [".cljfmt.edn", "cljfmt.edn", ".cljfmt"]],
+		[
+			"cmake-format",
+			[
+				".cmake-format",
+				".cmake-format.yaml",
+				".cmake-format.yml",
+				".cmake-format.json",
+				".cmake-format.py",
+				"cmake-format.yaml",
+				"cmake-format.yml",
+				".editorconfig",
+			],
+		],
+		[
+			"psscriptanalyzer-format",
+			["PSScriptAnalyzerSettings.psd1", "ScriptAnalyzerSettings.psd1"],
+		],
+		[
+			"csharpier",
+			[
+				".csharpierrc",
+				".csharpierrc.json",
+				".csharpierrc.yaml",
+				".csharpierrc.yml",
+			],
+		],
+		["ormolu", [".ormolu"]],
+		["taplo", ["taplo.toml", ".taplo.toml"]],
+		["terraform", [".terraform.lock.hcl"]],
+		["swiftformat", [".swiftformat"]],
+		["fantomas", [".fantomasignore", ".editorconfig"]],
+		["mix", [".formatter.exs"]],
+		["shfmt", [".editorconfig"]],
+		["ktlint", [".editorconfig"]],
+		[
+			"ktfmt",
+			[
+				".editorconfig",
+				".ktfmt",
+				".ktfmt.kts",
+				"build.gradle",
+				"build.gradle.kts",
+				"settings.gradle",
+				"settings.gradle.kts",
+			],
+		],
+	]);
+
+/**
+ * Resolve the cwd for the formatter child, capped at the user's home
+ * directory. Files outside a project retain the historical file-directory
+ * cwd. The optional homeDir is only for the ceiling regression test.
+ */
+export function resolveFormatterCwd(
+	absolutePath: string,
+	formatterName?: string,
+	homeDir: string = os.homedir(),
+): string {
+	const fileDir = path.dirname(path.resolve(absolutePath));
+	const effectiveHome = homeDir || undefined;
+	const markers = formatterName
+		? [...(FORMATTER_MARKERS_BY_NAME.get(formatterName) ?? []), ".gitignore"]
+		: [".gitignore"];
+	const root = findNearestMarkerRoot(fileDir, markers, {
+		homeDir: effectiveHome,
+	});
+	if (root) return root;
+	const gitRoot = findNearestMarkerRoot(fileDir, [".git"], {
+		homeDir: effectiveHome,
+	});
+	return gitRoot ?? fileDir;
+}
+
 /**
  * Every biome invocation must carry this. Biome exits 1 with "No files were
  * processed in the specified paths" when the path is ignored by the repo's own
@@ -940,17 +1046,6 @@ export const prettierFormatter: FormatterInfo = {
 		const styleArgs = await indentationArgs(filePath, "prettier", cwd);
 		if (styleArgs === null) return SKIP_FORMATTING;
 		const args = ["--write", ...styleArgs];
-		// #2756: prettier resolves `.prettierignore` from the child cwd, which
-		// `formatFile` sets to the FILE's directory — so a repo-root
-		// `.prettierignore` was never seen and ignored files got rewritten.
-		// Carry the ignore file explicitly via `--ignore-path`, resolved by
-		// walking up from the file's directory (same as config discovery),
-		// capped at $HOME so a home-level ignore prettier would never read on
-		// its own is not adopted.
-		const ignoreDir = findNearestContaining(cwd, [".prettierignore"]);
-		if (ignoreDir && !isAtOrAboveHomeDir(ignoreDir)) {
-			args.push("--ignore-path", path.join(ignoreDir, ".prettierignore"));
-		}
 		const local = await findInNodeModules("prettier", cwd);
 		if (local) return [local, ...args, filePath];
 		// Global bin of any manager (npm/pnpm/yarn/bun) before auto-install (#375).
@@ -2235,6 +2330,7 @@ export async function formatFile(
 	try {
 		const absolutePath = path.resolve(filePath);
 		const cwd = path.dirname(absolutePath);
+		const formatterCwd = resolveFormatterCwd(absolutePath, formatter.name);
 		const contentBefore = await fs.readFile(absolutePath, "utf-8");
 
 		// Resolve command: prefer local (venv/vendor/node_modules) over global.
@@ -2261,7 +2357,7 @@ export async function formatFile(
 		// Run formatter without blocking the event loop.
 		const result = await safeSpawnAsync(cmd[0], cmd.slice(1), {
 			timeout: 15000,
-			cwd,
+			cwd: formatterCwd,
 		});
 
 		// A resolver that could NOT prove absence (it never probed PATH — e.g.

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -16,7 +16,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { BoundedLruCache } from "./bounded-cache.js";
 import { createGenerationSource } from "./generation-guard.js";
-import { findNearestMarkerRoot, normalizeMapKey } from "./path-utils.js";
+import {
+	findNearestMarkerRoot,
+	isRealGitMarker,
+	normalizeMapKey,
+} from "./path-utils.js";
 import { resolveCargoPackageEdition } from "./cargo-manifest.js";
 import { resolveKtfmtGradleStyle } from "./gradle-ktfmt-style.js";
 import { resolvePhpCsFixerConfig } from "./php-cs-fixer-config.js";
@@ -956,6 +960,7 @@ export function resolveFormatterCwd(
 	if (root) return root;
 	const gitRoot = findNearestMarkerRoot(fileDir, [".git"], {
 		homeDir: effectiveHome,
+		markerPredicate: isRealGitMarker,
 	});
 	return gitRoot ?? fileDir;
 }

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -1820,10 +1820,10 @@ const detectionCache = new BoundedLruCache<
 // The signature is immutable for a cache generation. This memo is separate
 // from detectionCache because a cwd can have several extension entries, and a
 // warm lookup must not repeat the ancestor walk or stat matched configs.
-const formatterSignatureFlights = new Map<
+const formatterSignatureFlights = new BoundedLruCache<
 	string,
 	{ promise: Promise<string> }
->();
+>(32);
 const formatterCacheGeneration = createGenerationSource("formatter-cache");
 
 // These are the formatter configuration files consulted by the policy helpers
@@ -2239,12 +2239,17 @@ export function _getFormatterResetStateForTests(): {
 		string,
 		{ signature: string; entries: Map<string, string[]> }
 	>;
+	formatterSignatureFlights: BoundedLruCache<
+		string,
+		{ promise: Promise<string> }
+	>;
 } {
 	return {
 		whichLatchByCommand,
 		whichTransientCommands,
 		cooldownRecordedForRetryAtMs,
 		detectionCache,
+		formatterSignatureFlights,
 	};
 }
 

--- a/clients/path-utils.ts
+++ b/clients/path-utils.ts
@@ -11,7 +11,13 @@
  * - Always convert backslashes to forward slashes for Map key consistency
  */
 
-import { type Dirent, existsSync, realpathSync } from "node:fs";
+import {
+	type Dirent,
+	existsSync,
+	readFileSync,
+	realpathSync,
+	statSync,
+} from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { win32 } from "node:path";
@@ -453,6 +459,25 @@ export interface FindNearestMarkerRootOptions {
 	boundaries?: readonly string[];
 	/** Override for `os.homedir()`, primarily for tests. */
 	homeDir?: string;
+	/** Further validate a marker path before accepting its containing directory. */
+	markerPredicate?: (markerPath: string) => boolean;
+}
+
+/**
+ * Accept only a real Git repository marker: a directory with HEAD, or a
+ * worktree/submodule marker file whose first line starts with `gitdir:`.
+ */
+export function isRealGitMarker(markerPath: string): boolean {
+	try {
+		const marker = statSync(markerPath);
+		if (marker.isDirectory()) return existsSync(path.join(markerPath, "HEAD"));
+		if (!marker.isFile()) return false;
+		return readFileSync(markerPath, "utf8")
+			.split(/\r?\n/, 1)[0]
+			.startsWith("gitdir:");
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -484,10 +509,18 @@ export function findNearestMarkerRoot(
 ): string | null {
 	const boundaries = options.boundaries ?? [];
 	const homeDir = path.resolve(options.homeDir ?? os.homedir());
+	const markerPredicate = options.markerPredicate ?? (() => true);
 	let current = path.resolve(startDir);
 	for (let depth = 0; depth < 64; depth++) {
 		if (isAtOrAboveHomeDir(current, homeDir)) return null;
-		if (markers.some((m) => existsSync(path.join(current, m)))) return current;
+		if (
+			markers.some(
+				(m) =>
+					existsSync(path.join(current, m)) &&
+					markerPredicate(path.join(current, m)),
+			)
+		)
+			return current;
 		if (boundaries.some((m) => existsSync(path.join(current, m)))) return null;
 		const parent = path.dirname(current);
 		if (parent === current) return null;

--- a/tests/clients/dispatch/format-smoke-style-contract.test.ts
+++ b/tests/clients/dispatch/format-smoke-style-contract.test.ts
@@ -15,14 +15,38 @@
  */
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { hasDetectableIndentation } from "../../../clients/dispatch/indent-detect.js";
-import { ALL_FORMATTERS } from "../../../clients/formatters.js";
+import {
+	ALL_FORMATTERS,
+	resolveFormatterCwd,
+} from "../../../clients/formatters.js";
 // Typed via scripts/smoke-tools.d.mts (the harness itself is plain ESM JS).
 import { FORMAT_FIXTURES } from "../../../scripts/smoke-tools.mjs";
 
 const repoRoot = path.resolve(__dirname, "../../..");
+
+describe("formatter-name cwd dispatch", () => {
+	it("keeps Prettier at the gitignore root despite nested Biome config", () => {
+		const root = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-format-dispatch-"),
+		);
+		try {
+			const nested = path.join(root, "sub");
+			fs.mkdirSync(nested, { recursive: true });
+			fs.writeFileSync(path.join(root, ".gitignore"), "ignored.md\n");
+			fs.writeFileSync(path.join(nested, "biome.json"), "{}\n");
+			const filePath = path.join(nested, "app.ts");
+			fs.writeFileSync(filePath, "const value = 1;\n");
+
+			expect(resolveFormatterCwd(filePath, "prettier")).toBe(root);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
 
 /** Formatters whose resolveCommand pins style from the file (indentationArgs). */
 const STYLE_PINNING = new Set(["biome", "prettier", "ruff", "shfmt"]);

--- a/tests/clients/formatters-format-file.test.ts
+++ b/tests/clients/formatters-format-file.test.ts
@@ -14,6 +14,9 @@ async function loadFormatFile() {
 	const mod = await import("../../clients/formatters.js");
 	return {
 		formatFile: mod.formatFile,
+		biome: mod.biomeFormatter,
+		prettier: mod.prettierFormatter,
+		oxfmt: mod.oxfmtFormatter,
 		formatter: mod.terragruntHclFormatter,
 		rubocop: mod.rubocopFormatter,
 	};
@@ -24,6 +27,47 @@ describe("formatFile", () => {
 		vi.resetModules();
 		safeSpawnAsync.mockReset();
 	});
+
+	it.each(["prettier", "biome", "oxfmt"] as const)(
+		"runs %s from the project root so cwd-relative ignores are honored",
+		async (name) => {
+			const env = setupTestEnvironment(`pi-lens-format-${name}-`);
+			try {
+				const nestedDir = path.join(env.tmpDir, "sub", "deep");
+				const filePath = path.join(nestedDir, "app.ts");
+				fs.mkdirSync(nestedDir, { recursive: true });
+				fs.mkdirSync(path.join(env.tmpDir, "node_modules", ".bin"), {
+					recursive: true,
+				});
+				fs.writeFileSync(
+					path.join(env.tmpDir, "node_modules", ".bin", name),
+					"",
+				);
+				fs.writeFileSync(path.join(env.tmpDir, ".gitignore"), "ignored.md\n");
+				fs.writeFileSync(
+					path.join(env.tmpDir, ".prettierignore"),
+					"ignored-by-prettier.md\n",
+				);
+				fs.writeFileSync(filePath, "function f() {\n  return 1;\n}\n");
+				safeSpawnAsync.mockResolvedValue({
+					status: 0,
+					stdout: "",
+					stderr: "",
+				});
+
+				const mod = await loadFormatFile();
+				await mod.formatFile(filePath, mod[name]);
+
+				expect(safeSpawnAsync).toHaveBeenCalledWith(
+					expect.any(String),
+					expect.any(Array),
+					expect.objectContaining({ cwd: env.tmpDir }),
+				);
+			} finally {
+				env.cleanup();
+			}
+		},
+	);
 
 	// A formatter that never ran leaves the file byte-identical, which is
 	// indistinguishable from "already formatted" unless the exit status is part
@@ -244,6 +288,7 @@ describe("formatFile honors SKIP_FORMATTING (#1144)", () => {
 		try {
 			const filePath = path.join(env.tmpDir, "formatted.js");
 			fs.writeFileSync(filePath, "const value = 1;\n");
+			fs.writeFileSync(path.join(env.tmpDir, ".gitignore"), "ignored.md\n");
 			const mod = await import("../../clients/formatters.js");
 			const formatter = {
 				...mod.prettierFormatter,

--- a/tests/clients/formatters-php-cs-fixer-formatfile.test.ts
+++ b/tests/clients/formatters-php-cs-fixer-formatfile.test.ts
@@ -67,10 +67,12 @@ describe("formatFile — php-cs-fixer ancestor config carriage (#2472)", () => {
 			// fix drops "--config" and configPath from `args` and this goes red.
 			expect(cmd).toBe(vendorBin);
 			expect(args).toEqual(["fix", "--config", configPath, filePath]);
-			// The known #2472 mismatch: spawn cwd is the FILE's own directory,
-			// which is NOT the directory the config actually lives in.
-			expect(opts.cwd).toBe(path.dirname(filePath));
-			expect(opts.cwd).not.toBe(path.dirname(configPath));
+			// Formatter children run from the nearest project root. php-cs-fixer's
+			// explicit --config keeps its ancestor config selection independent of
+			// that cwd; its .php-cs-fixer.cache therefore lands at the project root,
+			// matching the CLI invocation.
+			expect(opts.cwd).toBe(env.tmpDir);
+			expect(opts.cwd).not.toBe(path.dirname(filePath));
 		} finally {
 			env.cleanup();
 		}

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -180,6 +180,60 @@ describe("resolveCommand — node_modules/.bin", () => {
 			SKIP_FORMATTING,
 		);
 	});
+
+	it("prettier: passes --ignore-path when repo-root .prettierignore exists", async () => {
+		const binPath = nodeModulesBin(tmpDir, "prettier");
+		makeFakeExe(binPath);
+		// Root .prettierignore that a nested-file cwd would miss (#2756)
+		fs.writeFileSync(path.join(tmpDir, ".prettierignore"), "*.md\n");
+		// File in a nested subdirectory — prettier invoked with cwd=this dir
+		// would not see the root .prettierignore without --ignore-path.
+		const nestedDir = path.join(tmpDir, "src", "deep");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		const filePath = path.join(nestedDir, "app.tsx");
+		// Indentation must be detectable; otherwise resolveCommand returns
+		// SKIP_FORMATTING before reaching the --ignore-path logic.
+		fs.writeFileSync(filePath, "function f() {\n  return 1;\n}\n");
+
+		const cmd = await prettierFormatter.resolveCommand!(filePath, nestedDir);
+
+		expect(cmd).not.toBeNull();
+		expect(cmd).toContain("--ignore-path");
+		expect(cmd).toContain(path.join(tmpDir, ".prettierignore"));
+	});
+
+	it("prettier: does not pass --ignore-path when no .prettierignore exists", async () => {
+		const binPath = nodeModulesBin(tmpDir, "prettier");
+		makeFakeExe(binPath);
+		const filePath = fileIn(tmpDir, "app.tsx");
+		fs.writeFileSync(filePath, "function f() {\n  return 1;\n}\n");
+
+		const cmd = await prettierFormatter.resolveCommand!(filePath, tmpDir);
+
+		expect(cmd).not.toBeNull();
+		expect(cmd).not.toContain("--ignore-path");
+	});
+
+	it("prettier: passes --ignore-path from nearest ancestor, not from file's own dir", async () => {
+		const binPath = nodeModulesBin(tmpDir, "prettier");
+		makeFakeExe(binPath);
+		// Root .prettierignore
+		fs.writeFileSync(path.join(tmpDir, ".prettierignore"), "*.md\n");
+		// INTERMEDIATE .prettierignore closer to the file — the nearest should
+		// win, proving the walk-up stops at the first match.
+		const intermediateDir = path.join(tmpDir, "src");
+		fs.mkdirSync(intermediateDir, { recursive: true });
+		fs.writeFileSync(path.join(intermediateDir, ".prettierignore"), "*.tsx\n");
+		const filePath = path.join(intermediateDir, "app.tsx");
+		fs.writeFileSync(filePath, "function f() {\n  return 1;\n}\n");
+
+		const cmd = await prettierFormatter.resolveCommand!(filePath, intermediateDir);
+
+		expect(cmd).not.toBeNull();
+		expect(cmd).toContain("--ignore-path");
+		// The nearest .prettierignore is the one in src/, not the root.
+		expect(cmd).toContain(path.join(intermediateDir, ".prettierignore"));
+	});
 });
 
 describe("resolveCommand — shfmt style preservation", () => {

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -223,6 +223,36 @@ describe("formatter child cwd", () => {
 
 		expect(resolveFormatterCwd(filePath, "prettier")).toBe(intermediateDir);
 	});
+
+	it.each([
+		["empty .git directory", "directory"],
+		["real .git directory", "real-directory"],
+		["worktree .git file", "file"],
+	] as const)("recognizes %s only as a real repository marker", (_, kind) => {
+		const repoDir = path.join(tmpDir, `git-marker-${kind}`);
+		const nestedDir = path.join(repoDir, "src");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		if (kind === "directory" || kind === "real-directory") {
+			fs.mkdirSync(path.join(repoDir, ".git"));
+			if (kind === "real-directory") {
+				fs.writeFileSync(
+					path.join(repoDir, ".git", "HEAD"),
+					"ref: refs/heads/main\n",
+				);
+			}
+		} else {
+			fs.writeFileSync(
+				path.join(repoDir, ".git"),
+				"gitdir: /shared/main/.git/worktrees/demo\n",
+			);
+		}
+		const filePath = path.join(nestedDir, "app.tsx");
+		fs.writeFileSync(filePath, "function f() {\n  return 1;\n}\n");
+
+		expect(resolveFormatterCwd(filePath, "prettier")).toBe(
+			kind === "directory" ? nestedDir : repoDir,
+		);
+	});
 });
 
 describe("resolveCommand — shfmt style preservation", () => {

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -28,6 +28,7 @@ import {
 	phpCsFixerFormatter,
 	prettierFormatter,
 	psscriptanalyzerFormatFormatter,
+	resolveFormatterCwd,
 	rubocopFormatter,
 	ruffFormatter,
 	standardrbFormatter,
@@ -94,9 +95,7 @@ async function withPathShim(
 	}
 }
 
-async function withIsolatedPath(
-	fn: () => Promise<void> | void,
-): Promise<void> {
+async function withIsolatedPath(fn: () => Promise<void> | void): Promise<void> {
 	const isolatedPath = path.join(tmpDir, "isolated-path");
 	fs.mkdirSync(isolatedPath, { recursive: true });
 	const origPath = process.env.PATH;
@@ -180,59 +179,49 @@ describe("resolveCommand — node_modules/.bin", () => {
 			SKIP_FORMATTING,
 		);
 	});
+});
 
-	it("prettier: passes --ignore-path when repo-root .prettierignore exists", async () => {
-		const binPath = nodeModulesBin(tmpDir, "prettier");
-		makeFakeExe(binPath);
-		// Root .prettierignore that a nested-file cwd would miss (#2756)
-		fs.writeFileSync(path.join(tmpDir, ".prettierignore"), "*.md\n");
-		// File in a nested subdirectory — prettier invoked with cwd=this dir
-		// would not see the root .prettierignore without --ignore-path.
+describe("formatter child cwd", () => {
+	it("uses the nearest project marker, not the file directory", () => {
 		const nestedDir = path.join(tmpDir, "src", "deep");
 		fs.mkdirSync(nestedDir, { recursive: true });
+		fs.writeFileSync(path.join(tmpDir, ".gitignore"), "ignored.md\n");
+		fs.writeFileSync(path.join(tmpDir, ".prettierignore"), "keep.md\n");
 		const filePath = path.join(nestedDir, "app.tsx");
-		// Indentation must be detectable; otherwise resolveCommand returns
-		// SKIP_FORMATTING before reaching the --ignore-path logic.
 		fs.writeFileSync(filePath, "function f() {\n  return 1;\n}\n");
 
-		const cmd = await prettierFormatter.resolveCommand!(filePath, nestedDir);
-
-		expect(cmd).not.toBeNull();
-		expect(cmd).toContain("--ignore-path");
-		expect(cmd).toContain(path.join(tmpDir, ".prettierignore"));
+		expect(resolveFormatterCwd(filePath, "prettier")).toBe(tmpDir);
 	});
 
-	it("prettier: does not pass --ignore-path when no .prettierignore exists", async () => {
-		const binPath = nodeModulesBin(tmpDir, "prettier");
-		makeFakeExe(binPath);
-		const filePath = fileIn(tmpDir, "app.tsx");
+	it("keeps the file directory when no project marker exists", () => {
+		const nestedDir = path.join(tmpDir, "isolated", "src");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		const filePath = path.join(nestedDir, "app.tsx");
 		fs.writeFileSync(filePath, "function f() {\n  return 1;\n}\n");
 
-		const cmd = await prettierFormatter.resolveCommand!(filePath, tmpDir);
-
-		expect(cmd).not.toBeNull();
-		expect(cmd).not.toContain("--ignore-path");
+		expect(resolveFormatterCwd(filePath, undefined, tmpDir)).toBe(nestedDir);
 	});
 
-	it("prettier: passes --ignore-path from nearest ancestor, not from file's own dir", async () => {
-		const binPath = nodeModulesBin(tmpDir, "prettier");
-		makeFakeExe(binPath);
-		// Root .prettierignore
-		fs.writeFileSync(path.join(tmpDir, ".prettierignore"), "*.md\n");
-		// INTERMEDIATE .prettierignore closer to the file — the nearest should
-		// win, proving the walk-up stops at the first match.
+	it("does not adopt an ignore file at the home ceiling", () => {
+		const homeDir = path.join(tmpDir, "home");
+		const nestedDir = path.join(homeDir, "project", "src");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		fs.writeFileSync(path.join(homeDir, ".gitignore"), "ignored.md\n");
+		const filePath = path.join(nestedDir, "app.tsx");
+		fs.writeFileSync(filePath, "function f() {\n  return 1;\n}\n");
+
+		expect(resolveFormatterCwd(filePath, undefined, homeDir)).toBe(nestedDir);
+	});
+
+	it("lets a nearer ignore marker win", () => {
 		const intermediateDir = path.join(tmpDir, "src");
 		fs.mkdirSync(intermediateDir, { recursive: true });
+		fs.writeFileSync(path.join(tmpDir, ".gitignore"), "*.md\n");
 		fs.writeFileSync(path.join(intermediateDir, ".prettierignore"), "*.tsx\n");
 		const filePath = path.join(intermediateDir, "app.tsx");
 		fs.writeFileSync(filePath, "function f() {\n  return 1;\n}\n");
 
-		const cmd = await prettierFormatter.resolveCommand!(filePath, intermediateDir);
-
-		expect(cmd).not.toBeNull();
-		expect(cmd).toContain("--ignore-path");
-		// The nearest .prettierignore is the one in src/, not the root.
-		expect(cmd).toContain(path.join(intermediateDir, ".prettierignore"));
+		expect(resolveFormatterCwd(filePath, "prettier")).toBe(intermediateDir);
 	});
 });
 

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -517,13 +517,13 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 		id: "formatters:whichLatches",
 		module: "formatters.ts",
 		state:
-			"whichLatchByCommand, whichTransientCommands, cooldownRecordedForRetryAtMs (cleared together with detectionCache)",
+			"whichLatchByCommand, whichTransientCommands, cooldownRecordedForRetryAtMs, formatterSignatureFlights (cleared together with detectionCache)",
 		policy: "session_start",
 		resetName: "clearFormatterCache",
 		reason:
 			"#1895: formatter PATH availability is session-scoped, but these module-local latches are not covered by the dispatch availability generation. A formatter installed or removed between sessions must be re-probed. The reset is `clearFormatterCache`, not the latch clear alone: `getFormattersForFile` answers a same-cwd lookup from `detectionCache` before it reaches a `which` probe, so dropping the latches without the selection cache re-arms every directory except the working one (review round on PR #1896).",
 		probe: {
-			// Arms all FOUR pieces of state the reset claims to cover — the three
+			// Arms all FIVE pieces of state the reset claims to cover — the three
 			// latch maps AND the selection cache. A probe that armed only the
 			// latches would stay green if a future cache were added and left out
 			// of `clearFormatterCache`; that omission is precisely the #1895 bug.
@@ -539,6 +539,9 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 					signature: "session-state-registry-probe",
 					entries: new Map(),
 				});
+				ns.formatterSignatureFlights.set("/pi-lens-probe-cwd", {
+					promise: Promise.resolve("session-state-registry-probe"),
+				});
 			},
 			isArmed: () => {
 				const ns = getFormattersInternals();
@@ -546,7 +549,8 @@ export const SESSION_STATE_REGISTRY: SessionStateEntry[] = [
 					ns.whichLatchByCommand.size === 0 &&
 					ns.whichTransientCommands.size === 0 &&
 					ns.cooldownRecordedForRetryAtMs.size === 0 &&
-					ns.detectionCache.size === 0
+					ns.detectionCache.size === 0 &&
+					ns.formatterSignatureFlights.size === 0
 				);
 			},
 			reset: () => clearFormatterCache(),
@@ -1476,7 +1480,7 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	// vocabulary with no session lifetime — SWEEP_HEURISTIC_LIMITS item 5, and
 	// this file's existing registry entries already cover its real caches.
 	// #2756 round 3: the live container scan includes the module-level
-	// formatterSignatureFlights map added with the project-root cwd resolver.
+	// formatterSignatureFlights cache added with the project-root cwd resolver.
 	"formatters.ts": 10,
 	// #2442 review F2: the container regex now recognises BoundedFifoMap /
 	// BoundedLruCache, so this file's module-level bounded cache is counted.

--- a/tests/support/session-state-registry.ts
+++ b/tests/support/session-state-registry.ts
@@ -1475,7 +1475,9 @@ export const SESSION_STATE_SYMBOL_COUNTS: Readonly<Record<string, number>> = {
 	// module-level `new Set`) is counted (8 -> 9). An import-time frozen
 	// vocabulary with no session lifetime — SWEEP_HEURISTIC_LIMITS item 5, and
 	// this file's existing registry entries already cover its real caches.
-	"formatters.ts": 9,
+	// #2756 round 3: the live container scan includes the module-level
+	// formatterSignatureFlights map added with the project-root cwd resolver.
+	"formatters.ts": 10,
 	// #2442 review F2: the container regex now recognises BoundedFifoMap /
 	// BoundedLruCache, so this file's module-level bounded cache is counted.
 	"generated-artifacts.ts": 3,


### PR DESCRIPTION
## Summary

Run every formatter child from the nearest project root. The root is the nearest formatter configuration or ignore marker, then the nearest `.git`, and never `$HOME` or above. Files outside a project keep their file-directory cwd.

This fixes #2756 for Prettier and closes the same cwd-relative ignore/config defect for Biome and oxfmt. The change uses one `formatFile` spawn seam. It removes round 1's Prettier-only `--ignore-path` mechanism, which replaced Prettier's default `.gitignore` source.

## Round 2

This round addresses the review findings by selecting one shared project-root cwd, testing the `$HOME` ceiling, and sweeping every formatter sibling. It keeps the original issue scope and does not add a formatter-specific flag surface.

## A-versus-B comparison

Option A would teach three formatters different ignore-file flags: repeated per-file discovery, tool-specific argv rules, and a permanent risk that a future formatter sibling is missed. Prettier also needs multiple `--ignore-path` values because one path replaces its defaults.

Option B changes only the shared child cwd. Prettier, Biome, oxfmt, and other cwd-sensitive tools then observe the same project files they observe when run by a user from the project root. Ruff and Black resolve configuration from the file path, so their behavior remains file-based. PHP-CS-Fixer retains its explicit `--config` carriage from #2472, so moving cwd does not make that fix redundant or conflict with it. A file with no project marker falls back to its own directory. A formatter that writes a cache relative to cwd may move that cache to the project root, which is the same project-root execution contract and is preferable to per-file cache placement. No formatter in this tree relies on the old file-directory cwd for a documented behavior.

Option B is implemented.

## Tests

Red-first before the fix, using the real `formatFile` seam and fake process-boundary spawn capture:

- With `formatFile` changed to pass the file directory, all three sibling cases failed: `runs prettier from the project root...`, `runs biome from the project root...`, and `runs oxfmt from the project root...`. Each received `cwd = <tmp>/sub/deep` instead of `cwd = <tmp>`.
- With the project-root walk removed from `resolveFormatterCwd`, the nearest-marker test failed by selecting the file directory.

Mutation transcripts:

- Mutation: replace `resolveFormatterCwd(absolutePath)` with `cwd` at the spawn. Result: 3 failed, 10 passed in `tests/clients/formatters-format-file.test.ts`.
- Mutation: remove `{ homeDir: effectiveHome }` from the project-root search. Result: the `$HOME` ceiling test failed; it selected the home directory instead of the file directory.
- Mutation: remove sibling use of the shared spawn cwd. Result: the Biome and oxfmt cases fail with the same cwd mismatch. The three cases are parameterized over the real formatter definitions, so deleting the shared wiring cannot leave the sibling tests green.

The new and edited tests are:

- `tests/clients/formatters-format-file.test.ts`: parameterized Prettier, Biome, and oxfmt spawn-cwd contract through `formatFile`.
- `tests/clients/formatters.test.ts`: nearest project marker, no project marker, `$HOME` ceiling, and nearest ignore marker.
- Existing formatter resolution cases: round 1's three Prettier argv tests were removed because the implementation no longer carries ignore paths in argv.

Real-binary probes with Prettier 3.9.6, Biome 2.5.11, and oxfmt 0.66.0:

| Probe | Result |
| --- | --- |
| Prettier from repo root, default ignore sources | Only `sub/plain.ts` was reported; `.gitignore` and `.prettierignore` were honored. |
| Prettier from `sub/`, default ignore sources | `ignored.ts`, `keep.ts`, and `plain.ts` were all reported. |
| Prettier from `sub/`, both explicit ignore paths | Only `plain.ts` was reported. |
| Biome from root with VCS integration and `useIgnoreFile` enabled | `Formatted 0 files`; the `.gitignore`d file was not processed. |
| oxfmt from root with `ignorePatterns` in root `.oxfmtrc.json` | `Expected at least one target file`; the ignored file was excluded. |

`npm run build` passes. `npm run lint` passes. The targeted formatter and dispatch Vitest run passes 4 files and 207 tests. The required `tests/config/dependency-boundaries.test.ts` child Node probe is blocked by sandbox `spawnSync /usr/bin/node EPERM`. The tree-sitter grammar prefetch is also offline; the tests use their existing degraded path.

## Blast radius

The shared spawn seam changes cwd for every formatter listed in the class sweep below.

```text
- formatFile(filePath, formatter)
  - resolveFormatterCommand(formatter, absolutePath, fileDir)
  + resolveFormatterCwd(absolutePath)
  - safeSpawnAsync(command, args, { timeout, cwd: fileDir })
  + safeSpawnAsync(command, args, { timeout, cwd: formatterCwd })
    - formatter.resolveCommand(filePath, fileDir)  # unchanged resolver input
    - safeSpawnAsync process boundary                         # unchanged
```

Strict consumers are unchanged: `format-service.ts`, pipeline formatting, formatter outcome accounting, and all formatter command resolvers still receive the file directory for file-based command resolution. PHP-CS-Fixer still passes its explicit config path. No durable record or failure path changes.

## Class sweep

| Formatter | Config/ignore discovery basis | Verdict |
| --- | --- | --- |
| Biome | cwd-relative VCS ignore and `biome.json` | Root cwd fixes sibling ignore discovery. |
| Prettier | cwd-relative `.gitignore` and `.prettierignore`; config resolver gets file directory | Root cwd fixes #2756; no argv flags. |
| oxfmt | cwd-relative config and ignore files | Root cwd fixes sibling discovery. |
| Ruff, Black | File-path/project config discovery | Cwd move does not alter file-based resolution. |
| SQLFluff, RuboCop, StandardRB | Ancestor project config, with cwd-sensitive tool execution | Root cwd preserves the selected project config. |
| GoFmt, RustFmt, Zig, Dart, Nixfmt, Gleam, Cue | No cwd-relative ignore source in the formatter seam | Root cwd is harmless; file argument remains absolute. |
| Shfmt, Ktlint, Google Java Format | `.editorconfig` or tool defaults | Root cwd selects the project editor configuration. |
| Mix, Ocamlformat, Clang-Format, Ktfmt, Terraform | Ancestor formatter/project configuration | Root cwd agrees with project discovery; file arguments remain absolute. |
| PHP-CS-Fixer | Explicit `--config` from `resolvePhpCsFixerConfig` | Explicit carriage remains authoritative; cwd move is compatible. |
| CSharpier, Fantomas, SwiftFormat, Stylua, Ormolu, Taplo | Ancestor tool configuration | Root cwd preserves project-level discovery. |
| Terragrunt HCL | Binary-driven formatter with absolute `--file` | Root cwd is harmless. |
| KtLint, PSScriptAnalyzer format | Editor/settings discovery or explicit settings | Root cwd preserves project settings; explicit settings remain in argv. |
| CMake Format, Cljfmt | Ancestor config | Root cwd preserves project config. |

The sweep covered all 35 entries in `ALL_FORMATTERS`: Biome, Prettier, oxfmt, Ruff, Black, SQLFluff, Gofmt, Rustfmt, Zig, Dart, Shfmt, Nixfmt, Mix, Ocamlformat, Clang-Format, Ktlint, Ktfmt, Terraform, Terragrunt HCL, PHP-CS-Fixer, CSharpier, Fantomas, SwiftFormat, Stylua, Ormolu, Rubocop, StandardRB, Gleam, Taplo, Google Java Format, Cljfmt, CMake Format, Cue, PSScriptAnalyzer Format, and the filename-keyed Terragrunt path. The consolidation verdict is to keep one shared spawn cwd seam; deleting it would relocate the same cwd logic into every formatter caller.

## Observability

This fix changes only the child process cwd. It adds no failure path, retry, ledger record, or unbounded data. Existing formatter spawn errors and outcome records remain unchanged.

### Test assessment

The edited tests are regression proofs for a real process-boundary seam, not in-process doubles. The fake spawn is limited to the external binary boundary and independently observes the cwd supplied to `safeSpawnAsync`. The real formatter definitions resolve their commands before the capture. The real-binary probes independently validate the tool behavior behind the three sibling cases.

No test was removed for convenience. The three round-1 tests asserted the deleted Prettier-only argv mechanism and were replaced by shared-seam cwd assertions. The dependency-boundary test remains required for the maintainer environment because this sandbox cannot spawn its child Node process.


## Round 3

### Round 3 CI fixes

- `tests/clients/formatters-php-cs-fixer-formatfile.test.ts`: updated the
  real-seam assertion to pin the project-root cwd selected by
  `resolveFormatterCwd`, while retaining the load-bearing `--config` path
  assertion. php-cs-fixer's explicit config argument carries the ancestor
  config, and its `.php-cs-fixer.cache` therefore lands at the project root,
  matching the CLI invocation.
- `tests/support/session-state-registry.ts`: registered the live formatter
  state under the existing `clearFormatterCache` reset contract and updated
  `formatters.ts`'s pinned stateful-symbol count from 9 to 10. The
  `formatterSignatureFlights` map is bounded by in-flight work and is cleared
  at the formatter cache reset seam.

### Summary

Use the shared `findNearestMarkerRoot` walker with a marker predicate. A Git
fallback is valid only for a directory containing `.git/HEAD` or a `.git` file
whose first line starts with `gitdir:`. Update the changelog to describe
project-root formatter cwd behavior and add the formatter-name dispatch pin.

### Red-first evidence

- Before the fix, the empty `.git` fixture failed because cwd resolved to the
  stray repository directory instead of the file directory.
- The pre-fix test run reported 1 failed and 186 passed tests across the two
  new-test files.

### Mutation evidence

- Removing `markerPredicate: isRealGitMarker` made
  `recognizes empty .git directory only as a real repository marker` fail with
  the cwd resolving to the empty `.git` parent.
- Replacing the formatter-name lookup with the Biome marker set made
  `keeps Prettier at the gitignore root despite nested Biome config` fail with
  cwd resolving to `sub/` instead of the `.gitignore` root.

### Tests

- `tests/clients/formatters.test.ts`: pins empty, real-directory, and worktree
  file Git markers and the file-directory fallback.
- `tests/clients/formatters-format-file.test.ts`: pins Prettier, Biome, and
  oxfmt formatter child cwd through `formatFile`.
- `tests/clients/dispatch/format-smoke-style-contract.test.ts`: pins
  formatter-name-specific marker lookup.
- `tests/config/dependency-boundaries.test.ts`: blocked by sandbox
  `spawnSync /usr/bin/node EPERM`; the other two tests in that file passed.

### Blast radius

`formatFile` calls `resolveFormatterCwd`, which calls the shared
`findNearestMarkerRoot` walker. Existing callers keep the default marker
predicate, so only formatter Git fallback validation changes. The helper reads
one marker path synchronously per upward candidate; it adds no durable state,
new failure path, or telemetry surface.

### Class sweep

Searched `clients/`, `scripts/lib/`, and worktree-hygiene fixtures for
`gitdir:` and Git-marker helpers. No existing real-marker helper was present;
the shared path walker is the consolidation seam. Formatter cwd discovery has
one production caller. The sweep stays on one seam because deleting the shared
walker would move the same upward-walk logic back into formatter callers.

### Observability

This guard only selects a child cwd and emits no new failure path. Formatter
spawn results remain unchanged and continue through the existing `formatFile`
result handling.

### Verification

- `npm run build`: passed.
- `npm run lint`: passed.
- `npx oxfmt --check` on touched TypeScript files: passed.
- Targeted formatter and dispatch suites: 202 passed.
- Grammar prefetch was unavailable offline; Vitest used its existing per-worker
  degradation path.


## Round 4

### Summary

This round preserves the project-root formatter cwd and registers the
formatter signature-flight cache with the existing session reset.

### Decisions

1. Keep the project-root cwd for php-cs-fixer. The test at
   `tests/clients/formatters-php-cs-fixer-formatfile.test.ts:74` asserts the
   root cwd. Its `--config` carriage remains at line 69. The explicit config
   keeps ancestor selection independent of cwd, and the cache lands at the
   project root, matching the CLI.
2. Treat `formatterSignatureFlights` as session-scoped directory-keyed state.
   `clients/formatters.ts:1823` uses a 32-entry `BoundedLruCache`. The reset
   hook exposes it at lines 2242-2252. The registry records it at
   `tests/support/session-state-registry.ts:520`, arms it at lines 542-544,
   and verifies it clears at lines 549-553. The symbol-count pin remains 10
   at line 1484.

### Tests

The historical php-cs-fixer red was reproduced by mutating the cwd assertion:

```text
AssertionError: expected '/tmp/pi-lens-phpcsfixer-formatfile-Uje5L9' to be '/tmp/pi-lens-phpcsfixer-formatfile-Uje5L9/src/App'
Expected: "/tmp/pi-lens-phpcsfixer-formatfile-Uje5L9/src/App"
Received: "/tmp/pi-lens-phpcsfixer-formatfile-Uje5L9"
```

The historical session-state red was reproduced by mutating the pin from 10
to 9:

```text
AssertionError: session-state symbol-count pin: 1 flagged item(s) are neither registered nor exempted:
  formatters.ts@10
```

After restoring the intended pins and applying the cache fix, this command
passed:

```text
Test Files  5 passed (5)
Tests  329 passed (329)
```

The five files were `formatters-php-cs-fixer-formatfile.test.ts`,
`session-state-conformance.test.ts`, `formatters.test.ts`,
`formatters-format-file.test.ts`, and
`dispatch/format-smoke-style-contract.test.ts`.

### Blast radius

```text
formatFile
  -> resolveFormatterCwd
  -> safeSpawnAsync(cwd: formatterCwd)

getFormattersForFile
  -> getFormatterConfigSignature
  -> formatterSignatureFlights (bounded, reset by clearFormatterCache)
```

The production callers are the shared formatter spawn seam and formatter
detection. The registry probe is the only test consumer of the reset hook.
No durable record or external tool surface changes.

### Class sweep

`rg` across the repository found no sibling `formatterSignatureFlights`
implementation. Existing formatter caches use `BoundedLruCache`; this change
folds the new directory-keyed cache onto that seam.

### Observability

No new failure path exists. The existing formatter cache reset and session
state conformance records remain the verification surface. The reset probe
now fails if this cache is omitted.

### Verification

- `npm run build` passed.
- `npm run lint` passed.
- `npx oxfmt --check` passed for the three formatter and registry test/source files.
- The full test suite was not run.
- Tree-sitter grammar prefetch was skipped because this worktree has no network.

Changed production and registry files: `clients/formatters.ts` and
`tests/support/session-state-registry.ts`. The existing php-cs-fixer test pin
was already present on the supplied head and remains unchanged. `CHANGELOG.md`
was not edited.
