### PR TITLE
fix(ci): restore the job-level shared tool tree in the smoke workflows (refs #2762, refs #2687)

### DIFF
--- a/.changelog/fix-2762-smoke-shared-home.md
+++ b/.changelog/fix-2762-smoke-shared-home.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- **Nightly tool smoke: the six `--install` steps share one tool tree again (refs #2762, refs #2687)** — #2755 dropped the job-level `PI_LENS_HOME`/`PILENS_DATA_DIR` pin from `tool-smoke.yml` and `parser-smoke.yml`, so the Format layer started from an empty scratch home and seven managed formatters ran against nothing; the pin and its workflow test are restored, per-run scratch isolation stays the local default.

--- a/.github/workflows/parser-smoke.yml
+++ b/.github/workflows/parser-smoke.yml
@@ -36,8 +36,19 @@ jobs:
     # The installer resolves GitHub release assets through the REST API.
     # Unauthenticated is 60 requests/hour per IP and shared runners exhaust it.
     #
+    # PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1, for symmetry with
+    # tool-smoke.yml): this job only runs one `--install` step today, so there
+    # is no per-job cache to preserve here yet, but pinning keeps this
+    # workflow behaving identically to its sibling rather than depending on
+    # `withScratchHome`'s per-invocation default the moment a second
+    # `--install` step is ever added. A bare `/tmp` path, not
+    # `${{ runner.temp }}`: the `runner` context is unavailable at job-level
+    # `env:` (actionlint: "context \"runner\" is not allowed here"), and this
+    # runner's whole VM is destroyed after the job either way.
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PI_LENS_HOME: /tmp/pi-lens-home
+      PILENS_DATA_DIR: /tmp/pi-lens-home
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/tool-smoke.yml
+++ b/.github/workflows/tool-smoke.yml
@@ -34,8 +34,24 @@ jobs:
     # The auto-provided token raises this to 5000 req/hr; the installer sends it
     # ONLY to api.github.com, never the asset CDN.
     #
+    # PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1): job-level, so the SIX
+    # `--install` steps below share one tool tree/bin dir across the job
+    # instead of each `withScratchHome()` pin minting its own empty one per
+    # step — without this, each script re-pulls every managed tool from
+    # scratch (measured against the last full nightly, run 32817692457: the
+    # shared cache made the format step ~9s; per-step scratch homes would add
+    # ~10min across the job and 4-5x the release-asset downloads on this
+    # shared-IP runner). A bare `/tmp` path, not `${{ runner.temp }}`: the
+    # `runner` context is unavailable at job-level `env:` (actionlint: "context
+    # \"runner\" is not allowed here"), and this runner's whole VM — `/tmp`
+    # included — is destroyed after the job either way, so this never becomes
+    # a second `~/.pi-lens` some other step relies on persisting.
+    # `withScratchHome`'s "already pinned" branch is a no-op against an
+    # explicit PI_LENS_HOME, so this is the ONLY change these steps need.
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PI_LENS_HOME: /tmp/pi-lens-home
+      PILENS_DATA_DIR: /tmp/pi-lens-home
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/tests/config/lsp-fixture-home-workflow-pin.test.ts
+++ b/tests/config/lsp-fixture-home-workflow-pin.test.ts
@@ -1,13 +1,29 @@
-// #2687 option (b): each script keeps a fresh per-run scratch home so concurrent
-// invocations never share a tool tree or instances registry. The home is named,
-// claimed, announced, and swept by scripts/lib/scratch-dir.mjs.
+// #2762 recurrence (2026-09-08): #2755 removed these job-level pins in favour
+// of per-invocation scratch homes; the first nightly after it lost the shared
+// tool tree between the --install steps and the Format layer reported seven
+// managed formatters as "ran clean but left the file unchanged". Per-run
+// isolation stays the LOCAL default (scripts/lib/scratch-dir.mjs); in CI the
+// job-level pin wins because withScratchHome() respects an explicit value.
+// #2670 review F1: `tool-smoke.yml` runs SIX `--install` invocations
+// (smoke-tools.mjs x3, characterize-lsp.mjs, probe-clean-signal.mjs,
+// server-capabilities.mjs) in ONE job. `PI_LENS_HOME` relocates the
+// installer's tool tree/bin dir/probe cache (module-level consts at
+// `clients/installer/index.ts`), not just logs — with no JOB-level pin, each
+// script's own `withScratchHome()` (scripts/lib/lsp-fixture-workspace.mjs)
+// mints a FRESH, empty scratch home per invocation, so every step re-pulls
+// every managed tool from scratch instead of sharing the one tool tree the
+// job's ephemeral `$HOME` gave them for free pre-#2670. Job-level
+// `PI_LENS_HOME`/`PILENS_DATA_DIR` restores that sharing: `withScratchHome`'s
+// "already pinned" branch is a no-op against an explicit value, so setting it
+// once at the job is the entire fix.
 //
 // Same technique as tests/config/install-smoke-gates.test.ts: load the REAL
 // workflow via yaml.load, assert on the LOADED structure (never a hand-copied
 // restatement of the YAML text).
 //
-// The workflow-level pins used by the earlier shared-cache design are absent;
-// this test keeps that option (b) decision visible as the workflow changes.
+// Before this file existed, PI_LENS_HOME/PILENS_DATA_DIR were absent from
+// both workflows entirely (proven below by deleting the env lines from a
+// SOURCE copy and reloading) and no test in the repo checked for them.
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -32,14 +48,29 @@ const WORKFLOWS: Array<[string, string, number]> = [
 ];
 
 describe.each(WORKFLOWS)(
-	"%s jobs.%s leaves per-run scratch homes to the harness (#2687)",
+	"%s jobs.%s.env pins PI_LENS_HOME/PILENS_DATA_DIR (#2670 review F1)",
 	(workflowPath, jobName, expectedInstallSteps) => {
 		const workflow = loadWorkflow(workflowPath);
 		const jobEnv = workflow.jobs?.[jobName]?.env;
 
-		it("does not pin a shared tool tree at job level", () => {
-			expect(jobEnv?.PI_LENS_HOME).toBeUndefined();
-			expect(jobEnv?.PILENS_DATA_DIR).toBeUndefined();
+		it("carries a non-empty PI_LENS_HOME", () => {
+			expect(typeof jobEnv?.PI_LENS_HOME).toBe("string");
+			expect((jobEnv?.PI_LENS_HOME as string).trim().length).toBeGreaterThan(0);
+		});
+
+		it("carries a non-empty PILENS_DATA_DIR", () => {
+			expect(typeof jobEnv?.PILENS_DATA_DIR).toBe("string");
+			expect((jobEnv?.PILENS_DATA_DIR as string).trim().length).toBeGreaterThan(
+				0,
+			);
+		});
+
+		it("PI_LENS_HOME and PILENS_DATA_DIR resolve to the SAME dir (one shared tool tree, not two)", () => {
+			expect(jobEnv?.PI_LENS_HOME).toBe(jobEnv?.PILENS_DATA_DIR);
+		});
+
+		it('never points at ${{ runner.temp }} (unavailable at job-level env — actionlint: "context \\"runner\\" is not allowed here")', () => {
+			expect(String(jobEnv?.PI_LENS_HOME)).not.toContain("runner.temp");
 		});
 
 		it("counts the --install steps this job's cache-sharing claim is actually about", () => {
@@ -48,6 +79,25 @@ describe.each(WORKFLOWS)(
 				Array.isArray(steps) ? (steps as Array<{ run?: unknown }>) : []
 			).filter((s) => typeof s.run === "string" && s.run.includes("--install"));
 			expect(installSteps.length).toBe(expectedInstallSteps);
+		});
+
+		// Mutation-proof: before this file existed, deleting the pin entirely
+		// left every other check in this repo green.
+		it("mutation-proof: deleting the PI_LENS_HOME env line reds the pin assertion", () => {
+			const source = readFileSync(resolve(REPO_ROOT, workflowPath), "utf8");
+			const lines = source.split("\n");
+			const lineIdx = lines.findIndex((line) =>
+				/^\s*PI_LENS_HOME:\s/.test(line),
+			);
+			expect(lineIdx, "no PI_LENS_HOME: line found").toBeGreaterThanOrEqual(0);
+			const mutatedLines = [...lines];
+			mutatedLines.splice(lineIdx, 1);
+			const mutatedSource = mutatedLines.join("\n");
+			expect(mutatedSource).not.toBe(source);
+			const mutatedWorkflow = loadWorkflow(workflowPath, mutatedSource);
+			expect(
+				mutatedWorkflow.jobs?.[jobName]?.env?.PI_LENS_HOME,
+			).toBeUndefined();
 		});
 	},
 );


### PR DESCRIPTION
## Summary

#2755 removed the job-level `PI_LENS_HOME`/`PILENS_DATA_DIR` pin from `tool-smoke.yml` and `parser-smoke.yml` (the #2670 review F1 measure that lets the six `--install` steps share one tool tree) and rewrote the pin test to assert its absence. The first nightly after it (run 34215458928) started the Format layer from an empty scratch home; seven managed formatters were selected but "ran clean and left the file unchanged" (#2762). This restores the two workflow hunks with their rationale and the pin test, and records the recurrence in the test header.

`withScratchHome()` still returns early on an explicit `PI_LENS_HOME` (`scripts/lib/lsp-fixture-workspace.mjs:153-156`), so the per-run scratch isolation #2687 introduced remains the local default; CI is the one place a job-level shared tree is intended.

## Tests

`tests/config/lsp-fixture-home-workflow-pin.test.ts` restored: it asserts both workflows carry the job-level env, that the two values are equal, and that neither uses `${{ runner.temp }}`. Red-first is the current master (the test as restored fails against master's workflows); green on this branch. lsp-fixture-workspace and scratch-dir suites unchanged and green.

## Blast radius

Two workflow files (job-level `env:` only) and one test. No runtime code.

## Class sweep

No other workflow runs more than one `--install` step; `parser-smoke.yml` is pinned for symmetry as before.

## Observability

Nightly `Tool smoke` Format layer; the drift tracker #2762 closes itself on the next green run.

### Test assessment

Restored workflow-contract test; the nightly run is the only executable check for the shared-tree behaviour.

Open question for the reviewer: why the seven rows reported `success` + unchanged instead of the harness's `tool not installed → skip` — the formatter's binary resolution in an empty home deserves its own row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV