### PR TITLE
fix(lsp): classify servers with no diagnostics provider and no publish evidence as navigation-only instead of timing out (closes #2765)

### DIFF
--- a/.changelog/2765-dexter-navigation-only.md
+++ b/.changelog/2765-dexter-navigation-only.md
@@ -3,3 +3,4 @@ section: Fixed
 ---
 
 - **Custom LSP servers that never publish diagnostics are navigation-only, not timed out (closes #2765)** — a custom server with no pull-diagnostics provider gets one bounded first-contact push wait per session; silence for the full push budget latches it navigation-only (no wait on later files, a distinct summary bucket, never counted clean), a publish latches it push-capable, concurrent first touches share the one probe, and a hook-deadline cutoff stays unconfirmed instead of latching.
+- A rejected or shutdown-aborted shared first-contact probe now fails closed for every waiting touch, clears its single-flight entry, and can be retried without latching navigation-only.

--- a/.changelog/2765-dexter-navigation-only.md
+++ b/.changelog/2765-dexter-navigation-only.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Custom LSP diagnostics wait (closes #2765)** — Treat custom servers without pull or observed push diagnostics as navigation-only instead of timing out.
+- **Custom LSP servers that never publish diagnostics are navigation-only, not timed out (closes #2765)** — a custom server with no pull-diagnostics provider gets one bounded first-contact push wait per session; silence for the full push budget latches it navigation-only (no wait on later files, a distinct summary bucket, never counted clean), a publish latches it push-capable, concurrent first touches share the one probe, and a hook-deadline cutoff stays unconfirmed instead of latching.

--- a/.changelog/2765-dexter-navigation-only.md
+++ b/.changelog/2765-dexter-navigation-only.md
@@ -2,5 +2,4 @@
 section: Fixed
 ---
 
-- **Custom LSP servers that never publish diagnostics are navigation-only, not timed out (closes #2765)** — a custom server with no pull-diagnostics provider gets one bounded first-contact push wait per session; silence for the full push budget latches it navigation-only (no wait on later files, a distinct summary bucket, never counted clean), a publish latches it push-capable, concurrent first touches share the one probe, and a hook-deadline cutoff stays unconfirmed instead of latching.
-- A rejected or shutdown-aborted shared first-contact probe now fails closed for every waiting touch, clears its single-flight entry, and can be retried without latching navigation-only.
+- **Custom LSP servers that never publish diagnostics are navigation-only, not timed out (closes #2765)** — a custom server with no pull-diagnostics provider gets one bounded first-contact push wait per session; silence for the full push budget latches it navigation-only (no wait on later files, a distinct summary bucket, never counted clean), a publish latches it push-capable, concurrent first touches share the one probe, and a hook-deadline cutoff stays unconfirmed instead of latching; a rejected or shutdown-aborted shared probe fails closed for every waiting touch, clears its single-flight entry and is retried without latching.

--- a/.changelog/2765-dexter-navigation-only.md
+++ b/.changelog/2765-dexter-navigation-only.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Custom LSP diagnostics wait (closes #2765)** — Treat custom servers without pull or observed push diagnostics as navigation-only instead of timing out.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,7 +465,10 @@ wait per LSP session. A publication keeps normal waits; silence latches
 `diagnosticsUnsupported` by `serverId` after that wait, resets on server restart
 or a new session, and reports navigation-only at the service seam. Capability
 snapshot lookup uses the live remaining hook deadline, not a fresh full hook
-budget. (#2765)
+budget. The shared first-contact probe uses the full push budget plus the
+service shutdown signal; each caller may detach at its own hook remainder.
+Rejection or shutdown is an errored, fail-closed wait and never arms the latch.
+(#2765)
 
 Pull-diagnostics request deadlines send `$/cancelRequest`, but cancellation is
 advisory. While a cancelled request remains unsettled, admission blocks another

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,6 +460,13 @@ explicit `PI_LENS_AUX_GRACE_MS` value caps the budget on both paths;
 it never raises it. On a cold auxiliary it also caps the request's own
 wait, so a low value cancels the request earlier than the pre-#2152 behavior. (#2152)
 
+Custom push-only servers without a pull provider get one bounded first-contact
+wait per LSP session. A publication keeps normal waits; silence latches
+`diagnosticsUnsupported` by `serverId` after that wait, resets on server restart
+or a new session, and reports navigation-only at the service seam. Capability
+snapshot lookup uses the live remaining hook deadline, not a fresh full hook
+budget. (#2765)
+
 Pull-diagnostics request deadlines send `$/cancelRequest`, but cancellation is
 advisory. While a cancelled request remains unsettled, admission blocks another
 pull for the same path/source. The slot frees only on settlement. Apply this to

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -111,6 +111,7 @@ export type DegradationKind =
 	| "formatter-skip"
 	| "grammar-blocked"
 	| "lsp-breaker"
+	| "lsp-diagnostics-unsupported"
 	/**
 	 * A per-file touch skipped a language server because that server is in the
 	 * breaker cooldown or is latched permanently broken (#1743). During an

--- a/clients/dispatch/integration.ts
+++ b/clients/dispatch/integration.ts
@@ -1889,7 +1889,11 @@ export async function computeCascadeForFile(
 								neighborPath,
 								snapshots,
 							);
-							if (tier === "tier3-silent" || tier === "collect-later") {
+							if (
+								tier === "tier3-silent" ||
+								tier === "collect-later" ||
+								tier === "diagnostics-unsupported"
+							) {
 								const spawnedForTouch =
 									await lspService.getClientForFile(neighborPath);
 								if (spawnedForTouch) {
@@ -1906,6 +1910,21 @@ export async function computeCascadeForFile(
 										source: "cascade",
 										clientScope: "primary",
 									});
+									if (tier === "diagnostics-unsupported") {
+										logCascade({
+											phase: "cascade_skip",
+											filePath,
+											neighborFile: neighborPath,
+											durationMs: Date.now() - neighborStart,
+											lspServerCount: configuredServerCount,
+											coldSnapshot: isColdSnapshot,
+											metadata: {
+												serverId: spawnedForTouch.client.serverId,
+												waitTier: tier,
+											},
+										});
+										return undefined;
+									}
 									recordOutstandingCascadeTouch({
 										filePath: neighborPath,
 										serverId: spawnedForTouch.client.serverId,

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -2246,6 +2246,7 @@ export function resolveConfigurationSection(
 export function setupIncomingHandlers(
 	state: LSPClientState,
 	initialization: Record<string, unknown> | undefined,
+	onDiagnosticsPublished?: (serverId: string) => void,
 ): void {
 	state.connection.onNotification(
 		"textDocument/publishDiagnostics",
@@ -2266,6 +2267,7 @@ export function setupIncomingHandlers(
 			// Do not resurrect diagnostics or their content binding for a document
 			// that is no longer open on this client.
 			if (state.closedDocuments?.has(normalizedPath)) return;
+			onDiagnosticsPublished?.(state.serverId);
 			const newDiags = normalizeLspDiagnostics(params.diagnostics || []);
 			const docVersion = params.version;
 			if (PUB_DEBUG) {
@@ -5123,6 +5125,7 @@ export async function createLSPClient(options: {
 	 *  single-variant server or not yet reported; consumers must treat that as
 	 *  the classic/default behavior (fail-safe). */
 	launchVariant?: "classic" | "native-ts7";
+	onDiagnosticsPublished?: (serverId: string) => void;
 }): Promise<LSPClientInfo> {
 	installCrashGuard();
 
@@ -5134,6 +5137,7 @@ export async function createLSPClient(options: {
 		initialization,
 		initializeTimeoutMs = INITIALIZE_TIMEOUT_MS,
 		launchVariant,
+		onDiagnosticsPublished,
 	} = options;
 
 	// #449/#472: register this LSP child in the cross-process instance registry
@@ -5353,7 +5357,7 @@ export async function createLSPClient(options: {
 		);
 	});
 
-	setupIncomingHandlers(state, initialization);
+	setupIncomingHandlers(state, initialization, onDiagnosticsPublished);
 	connection.listen();
 	setupConnectionLifecycle(state, recentStderr);
 

--- a/clients/lsp/config.ts
+++ b/clients/lsp/config.ts
@@ -493,6 +493,7 @@ export function createCustomServer(
 	return {
 		id,
 		name: config.name,
+		custom: true,
 		extensions: config.extensions,
 		root: config.rootMarkers
 			? createRootDetector(config.rootMarkers)

--- a/clients/lsp/diagnostic-binding.ts
+++ b/clients/lsp/diagnostic-binding.ts
@@ -120,6 +120,8 @@ export interface DiagnosticBinding extends StoredDiagnosticBinding {
  */
 export interface TouchFileResult {
 	diags: import("./client.js").LSPDiagnostic[];
+	/** Primary/custom servers with no pull or observed push diagnostics. */
+	diagnosticsUnsupportedServerIds?: string[];
 	/** The file was declined because its nearest root is outside the session. */
 	skipReason?: "outside-project-root";
 	confirmation?: "confirmed" | "partial";

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -34,6 +34,7 @@ import {
 import { shouldPreferPullOnlyDiagnostics } from "../lsp-budget.js";
 import { sampleProcessTreeCpuPercent } from "../resource-sampler.js";
 import { bounded, withDeadline, withTimeout } from "../deadline-utils.js";
+import { HOOK_WALL_BUDGET_MS } from "../hook-budgets.js";
 import type { LedgerHookKey } from "../hook-budgets.js";
 import { getAmbientAbortSignal } from "../safe-spawn.js";
 import { abortDeferredLspWork } from "../deferred-lsp-work.js";
@@ -1471,6 +1472,8 @@ export class LSPService {
 	private clientSpawnGate: Promise<void> = Promise.resolve();
 	/** True after shutdown() has been called; blocks new operations */
 	private isDestroyed = false;
+	/** Aborts bounded in-flight service work when this generation is retired. */
+	private readonly shutdownController = new AbortController();
 	/**
 	 * #850: teardown completion for every singleton generation retired before
 	 * this service was published. Only replacement services receive one; direct
@@ -5301,23 +5304,43 @@ export class LSPService {
 					spawned.some((e) => e.info.role === "auxiliary");
 				if (spawned.some((entry) => entry.info.custom === true)) {
 					try {
-						const snapshots = await this.getCapabilitySnapshots(filePath);
-						diagnosticsUnsupportedServerIds = spawned
-							.filter(
-								(entry) =>
-									classifyServerWaitTier(
-										entry.info.id,
-										snapshots.find((s) => s.serverId === entry.info.id),
-									) === "diagnostics-unsupported",
-							)
-							.map((entry) => entry.info.id);
-						for (const serverId of diagnosticsUnsupportedServerIds) {
-							recordDegradationOnce({
-								kind: "lsp-diagnostics-unsupported",
-								subject: serverId,
-								reason:
-									"custom server has no pull provider and no publish evidence in this session",
-							});
+						const snapshotHook = options.hook ?? "tool_result_edit";
+						const snapshotBudget = Object.hasOwn(
+							HOOK_WALL_BUDGET_MS,
+							snapshotHook,
+						)
+							? HOOK_WALL_BUDGET_MS[
+									snapshotHook as keyof typeof HOOK_WALL_BUDGET_MS
+								]
+							: HOOK_WALL_BUDGET_MS.tool_result_edit;
+						const snapshots = await bounded(
+							this.getCapabilitySnapshots(filePath),
+							{
+								ms: snapshotBudget,
+								signal: getAmbientAbortSignal(),
+								shutdownSignal: this.shutdownController.signal,
+								hook: snapshotHook,
+								label: `getCapabilitySnapshots:${filePath}`,
+							},
+						);
+						if (snapshots !== undefined) {
+							diagnosticsUnsupportedServerIds = spawned
+								.filter(
+									(entry) =>
+										classifyServerWaitTier(
+											entry.info.id,
+											snapshots.find((s) => s.serverId === entry.info.id),
+										) === "diagnostics-unsupported",
+								)
+								.map((entry) => entry.info.id);
+							for (const serverId of diagnosticsUnsupportedServerIds) {
+								recordDegradationOnce({
+									kind: "lsp-diagnostics-unsupported",
+									subject: serverId,
+									reason:
+										"custom server has no pull provider and no publish evidence in this session",
+								});
+							}
 						}
 					} catch {
 						// Capability uncertainty fails closed and retains the wait.
@@ -5895,11 +5918,7 @@ export class LSPService {
 						(entry) => entry.info.role !== "auxiliary",
 					);
 					diagnosticsTimedOut =
-						(!hasWaitedPrimary &&
-							diagnosticsUnsupportedServerIds.length > 0 &&
-							diagnosticsUnsupportedServerIds.every((id) =>
-								primaryServerIds.has(id),
-							)) ||
+						!hasWaitedPrimary ||
 						diagnosticsUnansweredPrimaryServerIds.length > 0;
 					for (const entry of unanswered) {
 						incrementDegradationCount({
@@ -9443,6 +9462,7 @@ export class LSPService {
 		const resetStartedAt = Date.now();
 		if (this.checkDestroyed()) return;
 		this.isDestroyed = true;
+		this.shutdownController.abort();
 		for (const [key, token] of this.outstandingAuxNotifyWrites) {
 			this.releaseOutstandingAuxNotifyWrite(key, token);
 		}

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -1266,7 +1266,7 @@ export class LSPService {
 	 */
 	private readonly firstContactWaits = new Map<
 		string,
-		Promise<"answered" | "silent" | "cut_off">
+		Promise<"answered" | "silent" | "errored">
 	>();
 	/**
 	 * #1934 review F1: what the last COMPLETED `spawnClient` call for a
@@ -4605,6 +4605,19 @@ export class LSPService {
 		if (!leaseKeys) {
 			// An idle eviction won between selection and lease admission. Resolve the
 			// now-current client set and replay; no notification targets the retiree.
+			if (this.checkDestroyed()) {
+				const primaryServerIds = spawned
+					.filter((entry) => entry.info.role !== "auxiliary")
+					.map((entry) => entry.info.id);
+				return {
+					diags: [],
+					inconclusive: true,
+					...(primaryServerIds.length > 0 && {
+						inconclusiveServerIds: primaryServerIds,
+					}),
+					inconclusiveReason: "diagnostics-wait",
+				};
+			}
 			return this.touchFile(filePath, content, options);
 		}
 		try {
@@ -5395,6 +5408,7 @@ export class LSPService {
 						: perServerDeclaredTimeouts[entryIndex];
 				});
 				const firstContactCutOffServerIds = new Set<string>();
+				const firstContactErroredServerIds = new Set<string>();
 				const answeredForThisTouch = (
 					entry: (typeof spawned)[number],
 				): boolean => {
@@ -5426,7 +5440,10 @@ export class LSPService {
 						: perServerDeclaredTimeouts[entryIndex];
 				});
 				const perServerWaits = spawned.map((entry, entryIndex) => {
-					if (diagnosticsUnsupportedServerIds.includes(entry.info.id)) {
+					if (
+						this.state.diagnosticsUnsupported.has(entry.info.id) ||
+						diagnosticsUnsupportedServerIds.includes(entry.info.id)
+					) {
 						return Promise.resolve(undefined);
 					}
 					// #1459: a DEFERRED server never received this content, so its version
@@ -5491,26 +5508,42 @@ export class LSPService {
 
 					let shared = this.firstContactWaits.get(entry.info.id);
 					if (!shared) {
-						const remainingHookMs =
-							hookDeadlineAt === undefined
-								? serverTimeout
-								: Math.max(0, hookDeadlineAt - Date.now());
-						const waitBudget = Math.min(serverTimeout, remainingHookMs);
-						const wait = waitForDiagnostics().catch(() => undefined);
-						const completed =
-							waitBudget < serverTimeout
-								? withDeadline(
-										wait.then(() => true),
-										{
-											ms: waitBudget,
-											onTimeout: "undefined",
-											onReject: "undefined",
-										},
-									)
-								: wait.then(() => true);
+						let removeShutdownListener: (() => void) | undefined;
+						const shutdown = new Promise<"shutdown">((resolve) => {
+							const onShutdown = () => resolve("shutdown");
+							if (this.shutdownController.signal.aborted) {
+								onShutdown();
+								return;
+							}
+							this.shutdownController.signal.addEventListener(
+								"abort",
+								onShutdown,
+								{
+									once: true,
+								},
+							);
+							removeShutdownListener = () =>
+								this.shutdownController.signal.removeEventListener(
+									"abort",
+									onShutdown,
+								);
+						});
+						const probe = Promise.race([
+							waitForDiagnostics().then(
+								() => "completed" as const,
+								() => "errored" as const,
+							),
+							shutdown,
+						]);
+						const completed = withDeadline(probe, {
+							ms: serverTimeout,
+							onTimeout: "undefined",
+						});
 						shared = completed
-							.then((finished) => {
-								if (finished !== true) return "cut_off" as const;
+							.then((outcome) => {
+								if (outcome === "errored" || outcome === "shutdown") {
+									return "errored" as const;
+								}
 								if (answeredForThisTouch(entry)) return "answered" as const;
 								this.state.diagnosticsUnsupported.add(entry.info.id);
 								recordDegradationOnce({
@@ -5521,16 +5554,28 @@ export class LSPService {
 								});
 								return "silent" as const;
 							})
+							.catch(() => "errored" as const)
 							.finally(() => {
+								removeShutdownListener?.();
 								if (this.firstContactWaits.get(entry.info.id) === shared) {
 									this.firstContactWaits.delete(entry.info.id);
 								}
 							});
 						this.firstContactWaits.set(entry.info.id, shared);
 					}
-					return shared.then((outcome) => {
-						if (outcome === "cut_off")
+					const callerWait =
+						hookDeadlineAt === undefined
+							? shared
+							: withDeadline(shared, {
+									ms: Math.max(0, hookDeadlineAt - Date.now()),
+									onTimeout: "undefined",
+								});
+					return callerWait.then((outcome) => {
+						if (outcome === undefined) {
 							firstContactCutOffServerIds.add(entry.info.id);
+						} else if (outcome === "errored") {
+							firstContactErroredServerIds.add(entry.info.id);
+						}
 						return undefined;
 					});
 				});
@@ -5820,6 +5865,7 @@ export class LSPService {
 							!this.state.diagnosticsPublished.has(entry.info.id) &&
 							!this.state.diagnosticsUnsupported.has(entry.info.id) &&
 							!firstContactCutOffServerIds.has(entry.info.id) &&
+							!firstContactErroredServerIds.has(entry.info.id) &&
 							entry.client.getWorkspaceDiagnosticsSupport().mode !== "pull",
 					)
 					.map((entry) => entry.info.id);
@@ -5972,7 +6018,10 @@ export class LSPService {
 							savedVsBudgetMs: Math.max(0, timeoutMs - waitedMs),
 						},
 					});
-				} else if (waitedMs + 20 >= timeoutMs) {
+				} else if (
+					waitedMs + 20 >= timeoutMs ||
+					firstContactErroredServerIds.size > 0
+				) {
 					// Within ~20 ms of the configured budget we treat it as a timeout;
 					// the LSP didn't beat the cap. Diagnostics that arrive late still
 					// land in the client's cache and surface on the next edit.

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -1260,6 +1260,15 @@ export class LSPService {
 	private readonly unavailableLogged = new Set<string>();
 	private readonly optionalDisabled = new Set<string>();
 	/**
+	 * One first-contact diagnostic wait per custom server in this service
+	 * generation. Concurrent touches share the probe; a hook cutoff never arms
+	 * the navigation-only latch, so the next touch can try again.
+	 */
+	private readonly firstContactWaits = new Map<
+		string,
+		Promise<"answered" | "silent" | "cut_off">
+	>();
+	/**
 	 * #1934 review F1: what the last COMPLETED `spawnClient` call for a
 	 * (server, root) key decided, written by that call at every point it
 	 * returns without a client. This is a direct signal, deliberately NOT an
@@ -4228,6 +4237,7 @@ export class LSPService {
 			// the replacement can publish a snapshot.
 			this.state.diagnosticsPublished.delete(server.id);
 			this.state.diagnosticsUnsupported.delete(server.id);
+			this.firstContactWaits.delete(server.id);
 
 			const client = await createLSPClient({
 				serverId: server.id,
@@ -5384,6 +5394,27 @@ export class LSPService {
 							)
 						: perServerDeclaredTimeouts[entryIndex];
 				});
+				const firstContactCutOffServerIds = new Set<string>();
+				const answeredForThisTouch = (
+					entry: (typeof spawned)[number],
+				): boolean => {
+					const baseline = diagnosticBaselines.get(entry.client);
+					const currentPathVersion = readPathVersion(entry.client);
+					if (
+						Number.isFinite(baseline) &&
+						currentPathVersion !== undefined &&
+						currentPathVersion > (baseline as number)
+					) {
+						return true;
+					}
+					try {
+						return (
+							entry.client.getAllDiagnostics?.().has(normalizedPath) === true
+						);
+					} catch {
+						return false;
+					}
+				};
 				const perServerRaceBudgets = spawned.map((entry, entryIndex) => {
 					return hasTouchAuxiliaries && entry.info.role === "auxiliary"
 						? auxWaitBudgetMs(
@@ -5433,7 +5464,7 @@ export class LSPService {
 					const isWarmupTouch = source === "lsp_sweep_warmup";
 					// #743: per-server — a server we DID push to still gets the
 					// version-baseline wait even when a sibling was debounced away.
-					const wait =
+					const waitForDiagnostics = (): Promise<void> =>
 						!notifySkippedServerIds.has(entry.info.id) &&
 						Number.isFinite(baseline)
 							? entry.client.waitForDiagnostics(filePath, serverTimeout, {
@@ -5451,7 +5482,57 @@ export class LSPService {
 											pullSettleSource: "pull-warmup",
 										})
 									: entry.client.waitForDiagnostics(filePath, serverTimeout);
-					return wait.catch(() => undefined);
+					const firstContact =
+						entry.info.custom === true &&
+						!this.state.diagnosticsPublished.has(entry.info.id) &&
+						!this.state.diagnosticsUnsupported.has(entry.info.id) &&
+						entry.client.getWorkspaceDiagnosticsSupport().mode !== "pull";
+					if (!firstContact) return waitForDiagnostics().catch(() => undefined);
+
+					let shared = this.firstContactWaits.get(entry.info.id);
+					if (!shared) {
+						const remainingHookMs =
+							hookDeadlineAt === undefined
+								? serverTimeout
+								: Math.max(0, hookDeadlineAt - Date.now());
+						const waitBudget = Math.min(serverTimeout, remainingHookMs);
+						const wait = waitForDiagnostics().catch(() => undefined);
+						const completed =
+							waitBudget < serverTimeout
+								? withDeadline(
+										wait.then(() => true),
+										{
+											ms: waitBudget,
+											onTimeout: "undefined",
+											onReject: "undefined",
+										},
+									)
+								: wait.then(() => true);
+						shared = completed
+							.then((finished) => {
+								if (finished !== true) return "cut_off" as const;
+								if (answeredForThisTouch(entry)) return "answered" as const;
+								this.state.diagnosticsUnsupported.add(entry.info.id);
+								recordDegradationOnce({
+									kind: "lsp-diagnostics-unsupported",
+									subject: entry.info.id,
+									reason:
+										"custom server has no pull provider and no publish evidence after first contact wait",
+								});
+								return "silent" as const;
+							})
+							.finally(() => {
+								if (this.firstContactWaits.get(entry.info.id) === shared) {
+									this.firstContactWaits.delete(entry.info.id);
+								}
+							});
+						this.firstContactWaits.set(entry.info.id, shared);
+					}
+					return shared.then((outcome) => {
+						if (outcome === "cut_off")
+							firstContactCutOffServerIds.add(entry.info.id);
+						return undefined;
+					});
 				});
 
 				// The push wait — same per-server budget composition as before #707;
@@ -5732,32 +5813,13 @@ export class LSPService {
 					await pushWait;
 				}
 				const waitedMs = Date.now() - waitStartedAt;
-				const answeredForThisTouch = (
-					entry: (typeof spawned)[number],
-				): boolean => {
-					const baseline = diagnosticBaselines.get(entry.client);
-					const currentPathVersion = readPathVersion(entry.client);
-					if (
-						Number.isFinite(baseline) &&
-						currentPathVersion !== undefined &&
-						currentPathVersion > (baseline as number)
-					) {
-						return true;
-					}
-					try {
-						return (
-							entry.client.getAllDiagnostics?.().has(normalizedPath) === true
-						);
-					} catch {
-						return false;
-					}
-				};
 				const firstContactCustomServerIds = spawned
 					.filter(
 						(entry) =>
 							entry.info.custom === true &&
 							!this.state.diagnosticsPublished.has(entry.info.id) &&
 							!this.state.diagnosticsUnsupported.has(entry.info.id) &&
+							!firstContactCutOffServerIds.has(entry.info.id) &&
 							entry.client.getWorkspaceDiagnosticsSupport().mode !== "pull",
 					)
 					.map((entry) => entry.info.id);
@@ -5774,6 +5836,14 @@ export class LSPService {
 						reason:
 							"custom server has no pull provider and no publish evidence after first contact wait",
 					});
+				}
+				for (const entry of spawned) {
+					if (
+						entry.info.custom === true &&
+						this.state.diagnosticsUnsupported.has(entry.info.id)
+					) {
+						diagnosticsUnsupportedServerIds.push(entry.info.id);
+					}
 				}
 				diagnosticsUnsupportedServerIds = [
 					...new Set(diagnosticsUnsupportedServerIds),
@@ -9568,6 +9638,7 @@ export class LSPService {
 		});
 		this.state.clients.clear();
 		this.state.broken.clear();
+		this.firstContactWaits.clear();
 		// #1934 review F1: map hygiene alongside the breaker it sits next to.
 		// Not load-bearing — every read follows its own attempt's write — but a
 		// verdict for a client generation that no longer exists is dead weight.

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -275,6 +275,8 @@ export interface LSPState {
 	demonstratedCold: Set<string>;
 	/** Server ids that have published diagnostics in this LSP session. */
 	diagnosticsPublished: Set<string>;
+	/** Custom servers proved navigation-only after their first bounded contact. */
+	diagnosticsUnsupported: Set<string>;
 }
 
 const BROKEN_BASE_COOLDOWN_MS = 15_000;
@@ -1495,6 +1497,7 @@ export class LSPService {
 			demonstratedReady: new Set(),
 			demonstratedCold: new Set(),
 			diagnosticsPublished: new Set(),
+			diagnosticsUnsupported: new Set(),
 		};
 	}
 
@@ -4220,6 +4223,11 @@ export class LSPService {
 				spawned.initialization,
 				override?.initializationOptions,
 			);
+			// A replacement process is a new first-contact identity even when the
+			// configured server id is unchanged. Re-arm both capability latches before
+			// the replacement can publish a snapshot.
+			this.state.diagnosticsPublished.delete(server.id);
+			this.state.diagnosticsUnsupported.delete(server.id);
 
 			const client = await createLSPClient({
 				serverId: server.id,
@@ -4448,6 +4456,12 @@ export class LSPService {
 			return;
 		}
 		const startedAt = Date.now();
+		const hookDeadlineAt =
+			options.hook !== undefined &&
+			Object.hasOwn(HOOK_WALL_BUDGET_MS, options.hook)
+				? startedAt +
+					HOOK_WALL_BUDGET_MS[options.hook as keyof typeof HOOK_WALL_BUDGET_MS]
+				: undefined;
 		const normalizedPath = normalizeMapKey(filePath);
 		const outsideRoot = await this.findOutsideProjectRoot(filePath);
 		if (outsideRoot) {
@@ -5139,6 +5153,9 @@ export class LSPService {
 								diagnosticsPublished: this.state.diagnosticsPublished.has(
 									entry.info.id,
 								),
+								diagnosticsUnsupported: this.state.diagnosticsUnsupported.has(
+									entry.info.id,
+								),
 								advertisedCommands: entry.client.getAdvertisedCommands(),
 								rawCapabilityKeys: entry.client.getRawCapabilityKeys?.() ?? [],
 								launchVariant: entry.client.getLaunchVariant?.(),
@@ -5305,14 +5322,10 @@ export class LSPService {
 				if (spawned.some((entry) => entry.info.custom === true)) {
 					try {
 						const snapshotHook = options.hook ?? "tool_result_edit";
-						const snapshotBudget = Object.hasOwn(
-							HOOK_WALL_BUDGET_MS,
-							snapshotHook,
-						)
-							? HOOK_WALL_BUDGET_MS[
-									snapshotHook as keyof typeof HOOK_WALL_BUDGET_MS
-								]
-							: HOOK_WALL_BUDGET_MS.tool_result_edit;
+						const snapshotBudget =
+							hookDeadlineAt === undefined
+								? HOOK_WALL_BUDGET_MS.tool_result_edit
+								: Math.max(0, hookDeadlineAt - Date.now());
 						const snapshots = await bounded(
 							this.getCapabilitySnapshots(filePath),
 							{
@@ -5333,14 +5346,6 @@ export class LSPService {
 										) === "diagnostics-unsupported",
 								)
 								.map((entry) => entry.info.id);
-							for (const serverId of diagnosticsUnsupportedServerIds) {
-								recordDegradationOnce({
-									kind: "lsp-diagnostics-unsupported",
-									subject: serverId,
-									reason:
-										"custom server has no pull provider and no publish evidence in this session",
-								});
-							}
 						}
 					} catch {
 						// Capability uncertainty fails closed and retains the wait.
@@ -5727,6 +5732,52 @@ export class LSPService {
 					await pushWait;
 				}
 				const waitedMs = Date.now() - waitStartedAt;
+				const answeredForThisTouch = (
+					entry: (typeof spawned)[number],
+				): boolean => {
+					const baseline = diagnosticBaselines.get(entry.client);
+					const currentPathVersion = readPathVersion(entry.client);
+					if (
+						Number.isFinite(baseline) &&
+						currentPathVersion !== undefined &&
+						currentPathVersion > (baseline as number)
+					) {
+						return true;
+					}
+					try {
+						return (
+							entry.client.getAllDiagnostics?.().has(normalizedPath) === true
+						);
+					} catch {
+						return false;
+					}
+				};
+				const firstContactCustomServerIds = spawned
+					.filter(
+						(entry) =>
+							entry.info.custom === true &&
+							!this.state.diagnosticsPublished.has(entry.info.id) &&
+							!this.state.diagnosticsUnsupported.has(entry.info.id) &&
+							entry.client.getWorkspaceDiagnosticsSupport().mode !== "pull",
+					)
+					.map((entry) => entry.info.id);
+				for (const serverId of firstContactCustomServerIds) {
+					const entry = spawned.find(
+						(candidate) => candidate.info.id === serverId,
+					);
+					if (!entry || answeredForThisTouch(entry)) continue;
+					this.state.diagnosticsUnsupported.add(serverId);
+					diagnosticsUnsupportedServerIds.push(serverId);
+					recordDegradationOnce({
+						kind: "lsp-diagnostics-unsupported",
+						subject: serverId,
+						reason:
+							"custom server has no pull provider and no publish evidence after first contact wait",
+					});
+				}
+				diagnosticsUnsupportedServerIds = [
+					...new Set(diagnosticsUnsupportedServerIds),
+				];
 				// #1533: the same auxiliary coverage evidence for a collecting touch that
 				// did NOT enter the aux-grace wait — in practice `clientScope: "all"`, the
 				// batch/directory scan surface. Auxiliaries ARE spawned on that scope
@@ -5876,27 +5927,6 @@ export class LSPService {
 					// reads as unanswered, which for a primary is exactly the pre-#1549
 					// verdict. This block can therefore only ever NARROW an inconclusive
 					// touch, never create one.
-					const answeredForThisTouch = (
-						entry: (typeof spawned)[number],
-					): boolean => {
-						const baseline = diagnosticBaselines.get(entry.client);
-						const currentPathVersion = readPathVersion(entry.client);
-						if (
-							Number.isFinite(baseline) &&
-							currentPathVersion !== undefined &&
-							currentPathVersion > (baseline as number)
-						) {
-							return true;
-						}
-						try {
-							return (
-								entry.client.getAllDiagnostics?.().has(normalizedPath) === true
-							);
-						} catch {
-							// Fail closed: an unreadable cache is not evidence of an answer.
-							return false;
-						}
-					};
 					// A deferred server was never sent this content and is not waited on, so
 					// it cannot have "timed out" — it is already reported as a coverage gap.
 					const waited = spawned.filter(
@@ -5917,8 +5947,15 @@ export class LSPService {
 					const hasWaitedPrimary = waited.some(
 						(entry) => entry.info.role !== "auxiliary",
 					);
+					const hasUnsupportedPrimary = diagnosticsUnsupportedServerIds.some(
+						(serverId) =>
+							spawned.some(
+								(entry) =>
+									entry.info.id === serverId && entry.info.role !== "auxiliary",
+							),
+					);
 					diagnosticsTimedOut =
-						!hasWaitedPrimary ||
+						(!hasWaitedPrimary && !hasUnsupportedPrimary) ||
 						diagnosticsUnansweredPrimaryServerIds.length > 0;
 					for (const entry of unanswered) {
 						incrementDegradationCount({
@@ -6528,6 +6565,13 @@ export class LSPService {
 			// collect, `binding` only for a collecting touch — a non-collecting touch
 			// keeps resolving `{ diags: [] }`, no flags.
 			const result: TouchFileResult = { diags: collected ?? [] };
+			const primaryDiagnosticsUnsupported =
+				diagnosticsUnsupportedServerIds.some((serverId) =>
+					spawned.some(
+						(entry) =>
+							entry.info.id === serverId && entry.info.role !== "auxiliary",
+					),
+				);
 			if (diagnosticsUnsupportedServerIds.length > 0) {
 				result.diagnosticsUnsupportedServerIds =
 					diagnosticsUnsupportedServerIds;
@@ -6544,6 +6588,10 @@ export class LSPService {
 					result.inconclusiveServerIds = verdict.inconclusiveServerIds;
 				}
 				result.inconclusiveReason = verdict.inconclusiveReason;
+			} else if (collected !== undefined && primaryDiagnosticsUnsupported) {
+				// A navigation-only primary has no diagnostic confirmation to report.
+				// Auxiliary coverage cannot turn that capability boundary into a clean
+				// or partial diagnostic verdict.
 			} else if (collected !== undefined && coverageGap) {
 				// #1470/#1493: narrowed, not collapsed. Reached for EITHER no-answer
 				// shape — a cut-off auxiliary or a silent one with nothing published for
@@ -6553,7 +6601,7 @@ export class LSPService {
 				// health.
 				result.confirmation = "partial";
 				result.unconfirmedServerIds = [...unconfirmedServerIds];
-			} else if (collected !== undefined) {
+			} else if (collected !== undefined && !primaryDiagnosticsUnsupported) {
 				// Preserve the lower-level affirmative result across consumers. In
 				// particular, the silent-clean gates above clear diagnosticsTimedOut only
 				// after a successful notify and capability-confirmed wait; reclassifying
@@ -7504,6 +7552,9 @@ export class LSPService {
 					workspaceDiagnosticsSupport: client.getWorkspaceDiagnosticsSupport(),
 					customServer: server.custom,
 					diagnosticsPublished: this.state.diagnosticsPublished.has(server.id),
+					diagnosticsUnsupported: this.state.diagnosticsUnsupported.has(
+						server.id,
+					),
 					advertisedCommands: client.getAdvertisedCommands(),
 					rawCapabilityKeys: client.getRawCapabilityKeys?.() ?? [],
 					launchVariant: client.getLaunchVariant?.(),
@@ -7523,6 +7574,7 @@ export class LSPService {
 				workspaceDiagnosticsSupport: client.getWorkspaceDiagnosticsSupport(),
 				customServer: this.state.servers.get(serverId)?.custom,
 				diagnosticsPublished: this.state.diagnosticsPublished.has(serverId),
+				diagnosticsUnsupported: this.state.diagnosticsUnsupported.has(serverId),
 				advertisedCommands: client.getAdvertisedCommands(),
 				rawCapabilityKeys: client.getRawCapabilityKeys?.() ?? [],
 				launchVariant: client.getLaunchVariant?.(),

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -272,6 +272,8 @@ export interface LSPState {
 	 * server that recovers later in the same session is never stuck cold.
 	 */
 	demonstratedCold: Set<string>;
+	/** Server ids that have published diagnostics in this LSP session. */
+	diagnosticsPublished: Set<string>;
 }
 
 const BROKEN_BASE_COOLDOWN_MS = 15_000;
@@ -1489,6 +1491,7 @@ export class LSPService {
 			clientSpawnedAt: new Map(),
 			demonstratedReady: new Set(),
 			demonstratedCold: new Set(),
+			diagnosticsPublished: new Set(),
 		};
 	}
 
@@ -4223,6 +4226,9 @@ export class LSPService {
 				initialization: mergedInit,
 				initializeTimeoutMs: server.initializeTimeoutMs,
 				launchVariant: spawned.launchVariant,
+				onDiagnosticsPublished: (serverId) => {
+					this.state.diagnosticsPublished.add(serverId);
+				},
 			});
 
 			// Guard 2: service was shut down while we were completing the initialize
@@ -5045,6 +5051,7 @@ export class LSPService {
 			let tsserverSyncConfirmed:
 				| import("./client.js").LSPDiagnostic[]
 				| undefined;
+			let diagnosticsUnsupportedServerIds: string[] = [];
 			if (diagnosticsMode !== "none") {
 				// Resolution: env wins so users can tune the cap without rebuilding.
 				// Otherwise, on the single-server hot path (primary scope), use that
@@ -5125,6 +5132,10 @@ export class LSPService {
 								operationSupport: entry.client.getOperationSupport(),
 								workspaceDiagnosticsSupport:
 									entry.client.getWorkspaceDiagnosticsSupport(),
+								customServer: entry.info.custom,
+								diagnosticsPublished: this.state.diagnosticsPublished.has(
+									entry.info.id,
+								),
 								advertisedCommands: entry.client.getAdvertisedCommands(),
 								rawCapabilityKeys: entry.client.getRawCapabilityKeys?.() ?? [],
 								launchVariant: entry.client.getLaunchVariant?.(),
@@ -5288,6 +5299,30 @@ export class LSPService {
 					clientScope === "with-auxiliary" &&
 					options.collectDiagnostics === true &&
 					spawned.some((e) => e.info.role === "auxiliary");
+				if (spawned.some((entry) => entry.info.custom === true)) {
+					try {
+						const snapshots = await this.getCapabilitySnapshots(filePath);
+						diagnosticsUnsupportedServerIds = spawned
+							.filter(
+								(entry) =>
+									classifyServerWaitTier(
+										entry.info.id,
+										snapshots.find((s) => s.serverId === entry.info.id),
+									) === "diagnostics-unsupported",
+							)
+							.map((entry) => entry.info.id);
+						for (const serverId of diagnosticsUnsupportedServerIds) {
+							recordDegradationOnce({
+								kind: "lsp-diagnostics-unsupported",
+								subject: serverId,
+								reason:
+									"custom server has no pull provider and no publish evidence in this session",
+							});
+						}
+					} catch {
+						// Capability uncertainty fails closed and retains the wait.
+					}
+				}
 
 				// Per-server wait promises (each already bounded by its own
 				// perServerTimeout — unchanged from before R8).
@@ -5332,6 +5367,9 @@ export class LSPService {
 						: perServerDeclaredTimeouts[entryIndex];
 				});
 				const perServerWaits = spawned.map((entry, entryIndex) => {
+					if (diagnosticsUnsupportedServerIds.includes(entry.info.id)) {
+						return Promise.resolve(undefined);
+					}
 					// #1459: a DEFERRED server never received this content, so its version
 					// can never advance past the baseline — waiting on it burns its whole
 					// budget and would flip the touch to `inconclusive`, discarding a
@@ -5839,7 +5877,9 @@ export class LSPService {
 					// A deferred server was never sent this content and is not waited on, so
 					// it cannot have "timed out" — it is already reported as a coverage gap.
 					const waited = spawned.filter(
-						(entry) => !deferredResyncServerIds.has(entry.info.id),
+						(entry) =>
+							!deferredResyncServerIds.has(entry.info.id) &&
+							!diagnosticsUnsupportedServerIds.includes(entry.info.id),
 					);
 					const unanswered = waited.filter(
 						(entry) => !answeredForThisTouch(entry),
@@ -5855,7 +5895,11 @@ export class LSPService {
 						(entry) => entry.info.role !== "auxiliary",
 					);
 					diagnosticsTimedOut =
-						!hasWaitedPrimary ||
+						(!hasWaitedPrimary &&
+							diagnosticsUnsupportedServerIds.length > 0 &&
+							diagnosticsUnsupportedServerIds.every((id) =>
+								primaryServerIds.has(id),
+							)) ||
 						diagnosticsUnansweredPrimaryServerIds.length > 0;
 					for (const entry of unanswered) {
 						incrementDegradationCount({
@@ -6465,6 +6509,10 @@ export class LSPService {
 			// collect, `binding` only for a collecting touch — a non-collecting touch
 			// keeps resolving `{ diags: [] }`, no flags.
 			const result: TouchFileResult = { diags: collected ?? [] };
+			if (diagnosticsUnsupportedServerIds.length > 0) {
+				result.diagnosticsUnsupportedServerIds =
+					diagnosticsUnsupportedServerIds;
+			}
 
 			if (collected !== undefined && inconclusive) {
 				result.inconclusive = true;
@@ -7435,6 +7483,8 @@ export class LSPService {
 					root,
 					operationSupport: client.getOperationSupport(),
 					workspaceDiagnosticsSupport: client.getWorkspaceDiagnosticsSupport(),
+					customServer: server.custom,
+					diagnosticsPublished: this.state.diagnosticsPublished.has(server.id),
 					advertisedCommands: client.getAdvertisedCommands(),
 					rawCapabilityKeys: client.getRawCapabilityKeys?.() ?? [],
 					launchVariant: client.getLaunchVariant?.(),
@@ -7452,6 +7502,8 @@ export class LSPService {
 				root: client.root,
 				operationSupport: client.getOperationSupport(),
 				workspaceDiagnosticsSupport: client.getWorkspaceDiagnosticsSupport(),
+				customServer: this.state.servers.get(serverId)?.custom,
+				diagnosticsPublished: this.state.diagnosticsPublished.has(serverId),
 				advertisedCommands: client.getAdvertisedCommands(),
 				rawCapabilityKeys: client.getRawCapabilityKeys?.() ?? [],
 				launchVariant: client.getLaunchVariant?.(),

--- a/clients/lsp/server.ts
+++ b/clients/lsp/server.ts
@@ -337,6 +337,8 @@ export interface LSPServerInfo {
 	id: string;
 	name: string;
 	extensions: readonly string[];
+	/** True for entries supplied through `lsp.servers.*`, not the built-in table. */
+	custom?: boolean;
 	root: RootFunction;
 	/**
 	 * "language" (default) = the file's primary language server (one is chosen per

--- a/clients/lsp/wait-policy/capability-snapshot.ts
+++ b/clients/lsp/wait-policy/capability-snapshot.ts
@@ -14,6 +14,8 @@ export interface LSPCapabilitySnapshot {
 	customServer?: boolean;
 	/** True after this server published diagnostics for any document this session. */
 	diagnosticsPublished?: boolean;
+	/** True after the session's bounded first-contact wait proved no diagnostics path. */
+	diagnosticsUnsupported?: boolean;
 	operationSupport: LSPOperationSupport;
 	workspaceDiagnosticsSupport: LSPWorkspaceDiagnosticsSupport;
 	/** Commands the server advertised for workspace/executeCommand (the allowlist) */

--- a/clients/lsp/wait-policy/capability-snapshot.ts
+++ b/clients/lsp/wait-policy/capability-snapshot.ts
@@ -11,6 +11,9 @@ import type {
 export interface LSPCapabilitySnapshot {
 	serverId: string;
 	root: string;
+	customServer?: boolean;
+	/** True after this server published diagnostics for any document this session. */
+	diagnosticsPublished?: boolean;
 	operationSupport: LSPOperationSupport;
 	workspaceDiagnosticsSupport: LSPWorkspaceDiagnosticsSupport;
 	/** Commands the server advertised for workspace/executeCommand (the allowlist) */

--- a/clients/lsp/wait-policy/classification.ts
+++ b/clients/lsp/wait-policy/classification.ts
@@ -11,7 +11,11 @@ import type { LSPService } from "../index.js";
 import { getStrategy } from "./strategies.js";
 import type { LSPCapabilitySnapshot } from "./capability-snapshot.js";
 
-export type CascadeWaitTier = "pull-capable" | "tier3-silent" | "waits";
+export type CascadeWaitTier =
+	| "pull-capable"
+	| "tier3-silent"
+	| "diagnostics-unsupported"
+	| "waits";
 
 /**
  * Classify a SINGLE server (by id, given its live capability snapshot — or
@@ -32,6 +36,13 @@ export function classifyServerWaitTier(
 
 	const mode = snapshot.workspaceDiagnosticsSupport?.mode;
 	if (mode === "pull") return "pull-capable";
+	if (
+		snapshot.customServer === true &&
+		mode === "push-only" &&
+		snapshot.diagnosticsPublished !== true
+	) {
+		return "diagnostics-unsupported";
+	}
 	if (mode !== "push-only") return "waits";
 
 	const strategy = getStrategy(serverId, snapshot.launchVariant);

--- a/clients/lsp/wait-policy/classification.ts
+++ b/clients/lsp/wait-policy/classification.ts
@@ -39,6 +39,7 @@ export function classifyServerWaitTier(
 	if (
 		snapshot.customServer === true &&
 		mode === "push-only" &&
+		snapshot.diagnosticsUnsupported === true &&
 		snapshot.diagnosticsPublished !== true
 	) {
 		return "diagnostics-unsupported";

--- a/docs/lsp-capability-matrix.md
+++ b/docs/lsp-capability-matrix.md
@@ -41,11 +41,12 @@ Detection is **cached** at `initialize` (`detectWorkspaceDiagnosticsSupport` →
 `state.workspaceDiagnosticsSupport.mode`, upgraded on `client/registerCapability`),
 so the tier is free at collection time — no per-edit probe.
 
-Custom servers without a pull provider start in the navigation-only state until
-the real `publishDiagnostics` handler observes a publish for any document. That
-server-id latch lasts for the LSP session and prevents a silent custom server
-from being counted as clean or timed out. A publish upgrades it to the ordinary
-push wait policy.
+Custom servers without a pull provider begin with one bounded first-contact
+probe. The probe uses the smaller of the server's push-wait budget and the live
+hook deadline. If the hook cuts it off first, the result remains unconfirmed and
+the next touch probes again. Only silence through the full push budget latches
+that server id as navigation-only for the service session. A publish upgrades it
+to the ordinary push-wait policy.
 
 ## Matrix (dev box + CI nightly; mode last refreshed 2026-06-17 from run 27713958681, clean-behavior probed on the dev box 2026-07-08 — #460)
 

--- a/docs/lsp-capability-matrix.md
+++ b/docs/lsp-capability-matrix.md
@@ -35,10 +35,17 @@ they share a server id but not a verified clean-signal behavior.
 | **2 — push, publishes-versioned** | `publishDiagnostics([])` **with version** on every scan, incl. clean→clean | YES, currency-proven via version | ast-grep |
 | **2\* — push, publishes-unversioned** | re-publishes on a clean scan but **version-less** — the wait still early-returns (the client accepts a version-less publish as fresh: it can't be proven stale), but currency is only *temporally correlated*, not proven | YES at runtime, with a staleness-risk caveat (not a latency cost) | opengrep |
 | **3 — push, silent on clean** | server publishes nothing when nothing changed | **NO** — budget-wait floor (safe; a timeout is *not* a false clean). **This tier is #458's learned-deadline target set.** | typescript-language-server |
+| **Navigation-only — custom, no evidence** | custom `lsp.servers.*` entry has no pull provider and has not published in this session | **NO** — diagnostics are unsupported; skip the wait and report navigation-only | Dexter |
 
 Detection is **cached** at `initialize` (`detectWorkspaceDiagnosticsSupport` →
 `state.workspaceDiagnosticsSupport.mode`, upgraded on `client/registerCapability`),
 so the tier is free at collection time — no per-edit probe.
+
+Custom servers without a pull provider start in the navigation-only state until
+the real `publishDiagnostics` handler observes a publish for any document. That
+server-id latch lasts for the LSP session and prevents a silent custom server
+from being counted as clean or timed out. A publish upgrades it to the ordinary
+push wait policy.
 
 ## Matrix (dev box + CI nightly; mode last refreshed 2026-06-17 from run 27713958681, clean-behavior probed on the dev box 2026-07-08 — #460)
 

--- a/tests/clients/flake-shape-ratchet.test.ts
+++ b/tests/clients/flake-shape-ratchet.test.ts
@@ -115,6 +115,13 @@ const ADMITTED_AFTER_BASELINE: Readonly<
 		reason:
 			"unhandledRejection is delivered on a real macrotask; one real setImmediate drain, assertion on the captured list",
 	},
+	// 2026-09-08 (#2765 round 3): the hook remainder is the subject; fake timers
+	// drive the delayed pre-snapshot work and the bounded lookup.
+	"raw-timer-wait:clients/lsp/service-inconclusive-per-server.test.ts": {
+		detector: "raw-timer-wait",
+		reason:
+			"the hook remainder is the defect; fake timers isolate the delayed pre-snapshot work from scheduler contention",
+	},
 	"real-process-spawn:clients/biome-config-decorator-metadata.test.ts": {
 		detector: "real-process-spawn",
 		reason:

--- a/tests/clients/lsp/cascade-tier.test.ts
+++ b/tests/clients/lsp/cascade-tier.test.ts
@@ -187,11 +187,25 @@ describe("classifyCascadeWaitTier", () => {
 		);
 	});
 
-	it("classifies an unobserved custom no-provider server as diagnostics-unsupported", () => {
+	it("keeps an unobserved custom no-provider server on its first-contact wait", () => {
 		const snapshot = {
 			serverId: "dexter",
 			root: "C:/repo",
 			customServer: true,
+			operationSupport: {} as any,
+			workspaceDiagnosticsSupport: { mode: "push-only" as const },
+			advertisedCommands: [],
+			rawCapabilityKeys: [],
+		};
+		expect(mod.classifyServerWaitTier("dexter", snapshot as any)).toBe("waits");
+	});
+
+	it("classifies a custom server as navigation-only only after its silent wait latches", () => {
+		const snapshot = {
+			serverId: "dexter",
+			root: "C:/repo",
+			customServer: true,
+			diagnosticsUnsupported: true,
 			operationSupport: {} as any,
 			workspaceDiagnosticsSupport: { mode: "push-only" as const },
 			advertisedCommands: [],

--- a/tests/clients/lsp/cascade-tier.test.ts
+++ b/tests/clients/lsp/cascade-tier.test.ts
@@ -187,6 +187,35 @@ describe("classifyCascadeWaitTier", () => {
 		);
 	});
 
+	it("classifies an unobserved custom no-provider server as diagnostics-unsupported", () => {
+		const snapshot = {
+			serverId: "dexter",
+			root: "C:/repo",
+			customServer: true,
+			operationSupport: {} as any,
+			workspaceDiagnosticsSupport: { mode: "push-only" as const },
+			advertisedCommands: [],
+			rawCapabilityKeys: [],
+		};
+		expect(mod.classifyServerWaitTier("dexter", snapshot as any)).toBe(
+			"diagnostics-unsupported",
+		);
+	});
+
+	it("latches a custom server to normal waits after any publish", () => {
+		const snapshot = {
+			serverId: "dexter",
+			root: "C:/repo",
+			customServer: true,
+			diagnosticsPublished: true,
+			operationSupport: {} as any,
+			workspaceDiagnosticsSupport: { mode: "push-only" as const },
+			advertisedCommands: [],
+			rawCapabilityKeys: [],
+		};
+		expect(mod.classifyServerWaitTier("dexter", snapshot as any)).toBe("waits");
+	});
+
 	it("classifies a push-only server WITHOUT silentOnClean (e.g. pyright, tier 2) as waits", () => {
 		getServersForFileWithConfig.mockReturnValue([server("python")]);
 		const snapshots = [

--- a/tests/clients/lsp/service-inconclusive-per-server.test.ts
+++ b/tests/clients/lsp/service-inconclusive-per-server.test.ts
@@ -1,3 +1,5 @@
+// flake-shape: raw-timer-wait — fake timers exercise the live hook remainder after delayed pre-snapshot work
+
 /**
  * #1549 — the touch verdict is PER SERVER, aggregated honestly.
  *
@@ -297,6 +299,7 @@ async function touchOnce(
 					inconclusiveServerIds?: string[];
 					inconclusiveReason?: string;
 					unconfirmedServerIds?: string[];
+					diagnosticsUnsupportedServerIds?: string[];
 			  }
 			| undefined
 		>;
@@ -581,7 +584,7 @@ describe("#1549 — per-server touch verdict", () => {
 		expect(result?.inconclusiveReason).toBe("diagnostics-wait");
 	});
 
-	it("keeps a primary navigation-only server inconclusive beside an answered auxiliary", async () => {
+	it("keeps a primary navigation-only server unconfirmed beside an answered auxiliary", async () => {
 		// A navigation-only primary is excluded from the diagnostics wait. The
 		// auxiliary can answer, but its evidence cannot become a primary verdict.
 		const service = await mountService({
@@ -595,10 +598,120 @@ describe("#1549 — per-server touch verdict", () => {
 		});
 		const result = await touchOnce(service);
 
-		expect(result?.inconclusive).toBe(true);
+		expect(result?.inconclusive).toBeUndefined();
 		expect(result?.confirmation).toBeUndefined();
 		expect(result?.inconclusiveServerIds).toBeUndefined();
-		expect(result?.inconclusiveReason).toBe("diagnostics-wait");
+		expect(result?.inconclusiveReason).toBeUndefined();
+	});
+
+	it("waits once before latching a silent custom primary as navigation-only", async () => {
+		const primary = makeClient(100, [], {
+			serverId: "dexter",
+			customServer: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(100, [], { serverId: "opengrep" }),
+		});
+
+		const result = await touchOnce(service);
+
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
+		expect(result?.diagnosticsUnsupportedServerIds).toEqual(["dexter"]);
+		expect(result?.confirmation).toBeUndefined();
+		expect(result?.inconclusive).toBeUndefined();
+
+		const second = await touchOnce(service, "const y = 2;");
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
+		expect(second?.diagnosticsUnsupportedServerIds).toEqual(["dexter"]);
+		expect(second?.confirmation).toBeUndefined();
+	});
+
+	it("keeps a custom primary on normal waits when first contact publishes", async () => {
+		const primary = makeClient(100, [], {
+			serverId: "dexter",
+			customServer: true,
+			publishesWhenClean: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(100, [], {
+				serverId: "opengrep",
+				publishesWhenClean: true,
+			}),
+		});
+
+		const first = await touchOnce(service);
+		const second = await touchOnce(service, "const y = 2;");
+
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(2);
+		expect(first?.diagnosticsUnsupportedServerIds).toBeUndefined();
+		expect(first?.confirmation).toBe("confirmed");
+		expect(second?.diagnosticsUnsupportedServerIds).toBeUndefined();
+		expect(second?.confirmation).toBe("confirmed");
+	});
+
+	it("records one navigation-only degradation per custom server per session", async () => {
+		const primary = makeClient(100, [], {
+			serverId: "dexter",
+			customServer: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(100, [], { serverId: "opengrep" }),
+		});
+
+		await touchOnce(service);
+		await touchOnce(service, "const y = 2;");
+
+		expect(
+			latencyRows("degradation_ledger").filter(
+				(row) =>
+					row?.metadata?.kind === "lsp-diagnostics-unsupported" &&
+					row?.metadata?.subject === "dexter",
+			),
+		).toHaveLength(1);
+	});
+
+	it("bounds capability lookup by the live hook remainder", async () => {
+		const service = await mountService({
+			primary: makeClient(0, [], {
+				serverId: "dexter",
+				customServer: true,
+				publishesWhenClean: true,
+			}),
+			aux: makeClient(0, [], {
+				serverId: "opengrep",
+				publishesWhenClean: true,
+			}),
+		});
+		vi.spyOn(
+			service as unknown as {
+				findOutsideProjectRoot: (
+					filePath: string,
+				) => Promise<string | undefined>;
+			},
+			"findOutsideProjectRoot",
+		).mockImplementation(async () => {
+			await new Promise<void>((resolve) => setTimeout(resolve, 2900));
+			return undefined;
+		});
+		vi.spyOn(service, "getCapabilitySnapshots").mockImplementation(
+			() => new Promise(() => {}),
+		);
+
+		let settled = false;
+		const touch = service.touchFile(FILE, "const x = 1;", {
+			...CASCADE_TOUCH,
+			hook: "turn_end",
+		});
+		void touch.then(() => {
+			settled = true;
+		});
+
+		await vi.advanceTimersByTimeAsync(3100);
+		expect(settled).toBe(true);
+		await touch;
 	});
 
 	it("a scanner that went unheard is not marked warm, even on a NON-COLLECTING touch", async () => {

--- a/tests/clients/lsp/service-inconclusive-per-server.test.ts
+++ b/tests/clients/lsp/service-inconclusive-per-server.test.ts
@@ -127,6 +127,7 @@ function makeClient(
 		hangingNotifyAfterWrites?: number;
 		/** Model a write that lands LATE (past the caller's notify budget). */
 		notifyDelayMs?: number;
+		waitForDiagnosticsRejects?: boolean;
 	},
 ) {
 	let version = 0;
@@ -198,28 +199,30 @@ function makeClient(
 			close: vi.fn(async () => {}),
 		},
 		pingLiveness: vi.fn().mockResolvedValue(true),
-		waitForDiagnostics: vi.fn(
-			(filePath: string) =>
-				new Promise<void>((resolve) =>
-					setTimeout(() => {
-						// A server publishes about the content it actually RECEIVED. With
-						// no write landed there is nothing new to say, so a hanging write
-						// leaves the previous publication (and its binding) in place —
-						// exactly the stale-findings hazard the merge has to drop.
-						const delivered = deliveredContent.get(filePath);
-						if (publishes && delivered !== undefined) {
-							version += 1;
-							stampsByPath.set(filePath, version);
-							cache.set(normalizeMapKey(filePath), {
-								diags,
-								ts: Date.now(),
-							});
-							bindings.set(filePath, hashDiagnosticContent(delivered));
-						}
-						resolve();
-					}, delayMs),
-				),
-		),
+		waitForDiagnostics: vi.fn((filePath: string) => {
+			if (options.waitForDiagnosticsRejects) {
+				return Promise.reject(new Error("server transport failed"));
+			}
+			return new Promise<void>((resolve) =>
+				setTimeout(() => {
+					// A server publishes about the content it actually RECEIVED. With
+					// no write landed there is nothing new to say, so a hanging write
+					// leaves the previous publication (and its binding) in place —
+					// exactly the stale-findings hazard the merge has to drop.
+					const delivered = deliveredContent.get(filePath);
+					if (publishes && delivered !== undefined) {
+						version += 1;
+						stampsByPath.set(filePath, version);
+						cache.set(normalizeMapKey(filePath), {
+							diags,
+							ts: Date.now(),
+						});
+						bindings.set(filePath, hashDiagnosticContent(delivered));
+					}
+					resolve();
+				}, delayMs),
+			);
+		}),
 	};
 }
 
@@ -649,6 +652,35 @@ describe("#1549 — per-server touch verdict", () => {
 		expect(results[1]?.diagnosticsUnsupportedServerIds).toEqual(["dexter"]);
 	});
 
+	it("fails closed when a shared first-contact probe rejects", async () => {
+		const primary = makeClient(100, [], {
+			serverId: "dexter",
+			customServer: true,
+			waitForDiagnosticsRejects: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(0, [], { serverId: "opengrep" }),
+		});
+
+		const first = service.touchFile(FILE, "const x = 1;", CASCADE_TOUCH);
+		const second = service.touchFile(FILE, "const y = 2;", CASCADE_TOUCH);
+		await vi.advanceTimersByTimeAsync(100);
+		const results = await Promise.all([first, second]);
+
+		expect(results.every((result) => result?.inconclusive)).toBe(true);
+		expect(results.map((result) => result?.inconclusiveServerIds)).toEqual([
+			["dexter"],
+			["dexter"],
+		]);
+		expect(results[0]?.diagnosticsUnsupportedServerIds).toBeUndefined();
+
+		const retry = service.touchFile(FILE, "const z = 3;", CASCADE_TOUCH);
+		await vi.advanceTimersByTimeAsync(100);
+		await retry;
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(2);
+	});
+
 	it("does not latch first contact when the live hook deadline cuts the push wait", async () => {
 		process.env.PI_LENS_LSP_DIAGNOSTICS_MAX_WAIT_MS = "5000";
 		const primary = makeClient(5000, [], {
@@ -689,7 +721,10 @@ describe("#1549 — per-server touch verdict", () => {
 		});
 		await vi.advanceTimersByTimeAsync(5000);
 		await second;
-		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(2);
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
+		const third = await touchOnce(service, "const z = 3;");
+		expect(third?.diagnosticsUnsupportedServerIds).toEqual(["dexter"]);
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps a custom primary on normal waits when first contact publishes", async () => {

--- a/tests/clients/lsp/service-inconclusive-per-server.test.ts
+++ b/tests/clients/lsp/service-inconclusive-per-server.test.ts
@@ -66,12 +66,13 @@ function makeFakeProcess() {
 	};
 }
 
-function makeServer(id: string, role?: "auxiliary") {
+function makeServer(id: string, role?: "auxiliary", custom = false) {
 	return {
 		id,
 		name: id,
 		extensions: [".ts"],
 		...(role && { role }),
+		...(custom && { custom }),
 		root: async () => "C:/repo",
 		spawn: vi.fn(async () => ({ process: makeFakeProcess(), source: "test" })),
 	};
@@ -113,6 +114,7 @@ function makeClient(
 	diags: ReturnType<typeof makeDiagnostic>[] = [],
 	options: {
 		serverId: string;
+		customServer?: boolean;
 		publishesWhenClean?: boolean;
 		/**
 		 * Model a write that never lands (stalled stdin / backpressure), from the
@@ -151,6 +153,7 @@ function makeClient(
 		getRawCapabilityKeys: () => [],
 		getLaunchVariant: () => undefined,
 		serverId: options.serverId,
+		customServer: options.customServer === true,
 		root: "C:/repo",
 		get diagnosticsVersion() {
 			return version;
@@ -259,8 +262,18 @@ async function mountService(clients: {
 	const service = new LSPService();
 	const auxClients = Array.isArray(clients.aux) ? clients.aux : [clients.aux];
 	getServersForFileWithConfig.mockReturnValue([
-		...(clients.primary ? [makeServer("ts-primary")] : []),
-		...auxClients.map((client) => makeServer(client.serverId, "auxiliary")),
+		...(clients.primary
+			? [
+					makeServer(
+						clients.primary.serverId,
+						undefined,
+						clients.primary.customServer,
+					),
+				]
+			: []),
+		...auxClients.map((client) =>
+			makeServer(client.serverId, "auxiliary", client.customServer),
+		),
 	]);
 	createLSPClient.mockImplementation(
 		async (options: { serverId?: string }) =>
@@ -564,6 +577,26 @@ describe("#1549 — per-server touch verdict", () => {
 		expect(result?.confirmation).toBeUndefined();
 		// Nobody to attribute it to: the verdict stands on the flag, honestly
 		// unattributed, rather than blaming an auxiliary it never blames elsewhere.
+		expect(result?.inconclusiveServerIds).toBeUndefined();
+		expect(result?.inconclusiveReason).toBe("diagnostics-wait");
+	});
+
+	it("keeps a primary navigation-only server inconclusive beside an answered auxiliary", async () => {
+		// A navigation-only primary is excluded from the diagnostics wait. The
+		// auxiliary can answer, but its evidence cannot become a primary verdict.
+		const service = await mountService({
+			primary: makeClient(100, [], {
+				serverId: "nav-primary",
+				customServer: true,
+			}),
+			aux: makeClient(5000, [makeDiagnostic("scanner finding")], {
+				serverId: "opengrep",
+			}),
+		});
+		const result = await touchOnce(service);
+
+		expect(result?.inconclusive).toBe(true);
+		expect(result?.confirmation).toBeUndefined();
 		expect(result?.inconclusiveServerIds).toBeUndefined();
 		expect(result?.inconclusiveReason).toBe("diagnostics-wait");
 	});

--- a/tests/clients/lsp/service-inconclusive-per-server.test.ts
+++ b/tests/clients/lsp/service-inconclusive-per-server.test.ts
@@ -727,6 +727,215 @@ describe("#1549 — per-server touch verdict", () => {
 		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
 	});
 
+	it("settles a first-contact wait when shutdown interrupts the shared probe", async () => {
+		// #2765 round 6: a shutdown used to leave a silent first-contact caller
+		// behind the push deadline; this pins the shutdown arm and destroyed guard.
+		const primary = makeClient(5000, [], {
+			serverId: "dexter",
+			customServer: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(0, [], { serverId: "opengrep" }),
+		});
+		vi.spyOn(service, "getCapabilitySnapshots").mockResolvedValue([]);
+
+		const touch = service.touchFile(FILE, "const x = 1;", {
+			...CASCADE_TOUCH,
+			maxClientWaitMs: 5000,
+			hook: "session_start",
+		});
+		await vi.advanceTimersByTimeAsync(1);
+		for (
+			let i = 0;
+			i < 20 && primary.waitForDiagnostics.mock.calls.length === 0;
+			i += 1
+		) {
+			await Promise.resolve();
+		}
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
+
+		await service.shutdown();
+		await expect(touch).resolves.toMatchObject({
+			inconclusive: true,
+			inconclusiveReason: "diagnostics-wait",
+		});
+		expect(
+			(
+				service as unknown as { state: { diagnosticsUnsupported: Set<string> } }
+			).state.diagnosticsUnsupported.has("dexter"),
+		).toBe(false);
+
+		await expect(
+			service.touchFile(FILE, "const y = 2;", CASCADE_TOUCH),
+		).resolves.toBeUndefined();
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
+	});
+
+	it("cuts the caller at the 3-second hook while the shared probe latches at 5 seconds", async () => {
+		// #2765 round 6: the caller deadline must not cancel the creator-owned probe,
+		// or a late navigation-only latch becomes impossible after a hook cutoff.
+		process.env.PI_LENS_LSP_DIAGNOSTICS_MAX_WAIT_MS = "5000";
+		const primary = makeClient(5000, [], {
+			serverId: "dexter",
+			customServer: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(0, [], { serverId: "opengrep" }),
+		});
+		const touch = service.touchFile(FILE, "const x = 1;", {
+			...CASCADE_TOUCH,
+			maxClientWaitMs: 5000,
+			hook: "turn_end",
+		});
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(3000);
+		const cutOff = await touch;
+		expect(cutOff?.diagnosticsUnsupportedServerIds).toBeUndefined();
+		expect(
+			(
+				service as unknown as { state: { diagnosticsUnsupported: Set<string> } }
+			).state.diagnosticsUnsupported.has("dexter"),
+		).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(2000);
+		expect(
+			(
+				service as unknown as { state: { diagnosticsUnsupported: Set<string> } }
+			).state.diagnosticsUnsupported.has("dexter"),
+		).toBe(true);
+	});
+
+	it("latches navigation-only when the shared push budget ends before the hook", async () => {
+		// #2765 round 6: a shared probe completing before its caller deadline must
+		// classify the silent custom server instead of reporting a cutoff.
+		const primary = makeClient(2000, [], {
+			serverId: "dexter",
+			customServer: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(0, [], { serverId: "opengrep" }),
+		});
+		const touch = service.touchFile(FILE, "const x = 1;", {
+			...CASCADE_TOUCH,
+			maxClientWaitMs: 2000,
+			hook: "turn_end",
+		});
+
+		await vi.advanceTimersByTimeAsync(2000);
+		await expect(touch).resolves.toMatchObject({
+			diagnosticsUnsupportedServerIds: ["dexter"],
+		});
+	});
+
+	it("keeps a publishing custom server push-capable when it answers inside the hook", async () => {
+		// #2765 round 6: publication before the hook cutoff must win the silent
+		// classification race and deliver the server's diagnostics.
+		process.env.PI_LENS_LSP_DIAGNOSTICS_MAX_WAIT_MS = "5000";
+		const primary = makeClient(2500, [makeDiagnostic("published")], {
+			serverId: "dexter",
+			customServer: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(0, [], { serverId: "opengrep" }),
+		});
+		const touch = service.touchFile(FILE, "const x = 1;", {
+			...CASCADE_TOUCH,
+			maxClientWaitMs: 5000,
+			hook: "turn_end",
+		});
+		for (
+			let i = 0;
+			i < 20 && primary.waitForDiagnostics.mock.calls.length === 0;
+			i += 1
+		) {
+			await Promise.resolve();
+		}
+
+		await vi.advanceTimersByTimeAsync(2500);
+		await vi.advanceTimersByTimeAsync(0);
+		const result = await touch;
+		expect(result?.diagnosticsUnsupportedServerIds).toBeUndefined();
+		expect(
+			primary.getDiagnostics(FILE).map((diagnostic) => diagnostic.message),
+		).toEqual(["published"]);
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
+	});
+
+	it("gives concurrent callers independent deadlines over one five-second probe", async () => {
+		// #2765 round 6: caller-local cutoffs must not shorten or restart the shared
+		// five-second first-contact budget when concurrent touches share a server.
+		process.env.PI_LENS_LSP_DIAGNOSTICS_MAX_WAIT_MS = "5000";
+		const primary = makeClient(5000, [], {
+			serverId: "dexter",
+			customServer: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(0, [], { serverId: "opengrep" }),
+		});
+		vi.spyOn(service, "getCapabilitySnapshots").mockResolvedValue([]);
+		const first = service.touchFile(FILE, "const x = 1;", {
+			...CASCADE_TOUCH,
+			maxClientWaitMs: 5000,
+			hook: "agent_end",
+		});
+		const second = service.touchFile(FILE, "const y = 2;", {
+			...CASCADE_TOUCH,
+			maxClientWaitMs: 5000,
+			hook: "session_start",
+		});
+
+		await vi.advanceTimersByTimeAsync(1000);
+		const firstResult = await first;
+		expect(firstResult?.diagnosticsUnsupportedServerIds).toBeUndefined();
+		await vi.advanceTimersByTimeAsync(3000);
+		expect(
+			await Promise.race([
+				second.then(() => "settled" as const),
+				Promise.resolve("pending" as const),
+			]),
+		).toBe("pending");
+		await vi.advanceTimersByTimeAsync(1000);
+		const secondResult = await second;
+		expect(secondResult?.diagnosticsUnsupportedServerIds).toEqual(["dexter"]);
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
+		expect(
+			(
+				service as unknown as { state: { diagnosticsUnsupported: Set<string> } }
+			).state.diagnosticsUnsupported.has("dexter"),
+		).toBe(true);
+	});
+
+	it("does not wait again after a navigation-only latch when capability snapshots are absent", async () => {
+		// #2765 round 6: the latch read must remain authoritative when the later
+		// capability-snapshot pass is skipped or returns no snapshot.
+		const primary = makeClient(100, [], {
+			serverId: "dexter",
+			customServer: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(0, [], { serverId: "opengrep" }),
+		});
+		const snapshots = vi
+			.spyOn(service, "getCapabilitySnapshots")
+			.mockResolvedValue([]);
+
+		await expect(
+			touchOnce(service, "const x = 1;", { hook: "turn_end" }),
+		).resolves.toMatchObject({ diagnosticsUnsupportedServerIds: ["dexter"] });
+		const waits = primary.waitForDiagnostics.mock.calls.length;
+		snapshots.mockResolvedValue([]);
+		await expect(
+			touchOnce(service, "const y = 2;", { hook: "turn_end" }),
+		).resolves.toMatchObject({ diagnosticsUnsupportedServerIds: ["dexter"] });
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(waits);
+	});
+
 	it("keeps a custom primary on normal waits when first contact publishes", async () => {
 		const primary = makeClient(100, [], {
 			serverId: "dexter",

--- a/tests/clients/lsp/service-inconclusive-per-server.test.ts
+++ b/tests/clients/lsp/service-inconclusive-per-server.test.ts
@@ -335,6 +335,7 @@ describe("#1549 — per-server touch verdict", () => {
 		vi.useRealTimers();
 		vi.restoreAllMocks();
 		delete process.env.PI_LENS_LSP_NOTIFY_BUDGET_MS;
+		delete process.env.PI_LENS_LSP_DIAGNOSTICS_MAX_WAIT_MS;
 	});
 
 	it("tonight's shape: an answered primary beside a slow auxiliary is USABLE, not inconclusive", async () => {
@@ -625,6 +626,70 @@ describe("#1549 — per-server touch verdict", () => {
 		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
 		expect(second?.diagnosticsUnsupportedServerIds).toEqual(["dexter"]);
 		expect(second?.confirmation).toBeUndefined();
+	});
+
+	it("shares one first-contact wait across concurrent touches", async () => {
+		const primary = makeClient(5000, [], {
+			serverId: "dexter",
+			customServer: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(0, [], { serverId: "opengrep" }),
+		});
+
+		const first = service.touchFile(FILE, "const x = 1;", CASCADE_TOUCH);
+		const second = service.touchFile(FILE, "const y = 2;", CASCADE_TOUCH);
+		await vi.advanceTimersByTimeAsync(8000);
+		const results = await Promise.all([first, second]);
+
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
+		expect(results).toHaveLength(2);
+		expect(results[0]?.diagnosticsUnsupportedServerIds).toEqual(["dexter"]);
+		expect(results[1]?.diagnosticsUnsupportedServerIds).toEqual(["dexter"]);
+	});
+
+	it("does not latch first contact when the live hook deadline cuts the push wait", async () => {
+		process.env.PI_LENS_LSP_DIAGNOSTICS_MAX_WAIT_MS = "5000";
+		const primary = makeClient(5000, [], {
+			serverId: "dexter",
+			customServer: true,
+		});
+		const service = await mountService({
+			primary,
+			aux: makeClient(0, [], { serverId: "opengrep" }),
+		});
+		vi.spyOn(service, "getCapabilitySnapshots").mockResolvedValue([]);
+
+		let settled = false;
+		const first = service.touchFile(FILE, "const x = 1;", {
+			...CASCADE_TOUCH,
+			maxClientWaitMs: 5000,
+			hook: "turn_end",
+		});
+		void first.then(() => {
+			settled = true;
+		});
+
+		for (let i = 0; i < 100; i += 1) {
+			await Promise.resolve();
+			if (primary.waitForDiagnostics.mock.calls.length > 0) break;
+		}
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(3100);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(settled).toBe(true);
+		const firstResult = await first;
+		expect(firstResult?.diagnosticsUnsupportedServerIds).toBeUndefined();
+
+		const second = service.touchFile(FILE, "const y = 2;", {
+			...CASCADE_TOUCH,
+			maxClientWaitMs: 5000,
+			hook: "turn_end",
+		});
+		await vi.advanceTimersByTimeAsync(5000);
+		await second;
+		expect(primary.waitForDiagnostics).toHaveBeenCalledTimes(2);
 	});
 
 	it("keeps a custom primary on normal waits when first contact publishes", async () => {

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -2304,6 +2304,11 @@ const BOUNDED_CALL_SITES: Readonly<Record<string, string>> = {
 		"returns, so no live turn signal belongs to this background refresh. The " +
 		"session_start wall budget still bounds the best-effort alias stamp, and " +
 		"the required signal field makes this absence an explicit decision.",
+	"call:clients/lsp/index.ts#4da1e4ca~3228bbca":
+		"`getAmbientAbortSignal()` carries the active turn abort when touchFile runs " +
+		"inside a hook and is absent only in a bare unit harness. The LSP service's " +
+		"shutdown signal supplies the second live bound for retired generations; the " +
+		"hook budget remains live in either case.",
 	"call:clients/lsp/index.ts#55b587e6~3997fa51":
 		"`signal` parameter, defaulting to `getAmbientAbortSignal()`. Caller-supplied " +
 		"on the pre-dispatch resync path (passing the turn's ambient signal so Escape mid-turn " +

--- a/tests/support/flake-shape-baseline.json
+++ b/tests/support/flake-shape-baseline.json
@@ -157,7 +157,7 @@
 		"clients/lsp/service-aux-grace.test.ts": 18,
 		"clients/lsp/service-document-drift.test.ts": 2,
 		"clients/lsp/service-early-unblock.test.ts": 7,
-		"clients/lsp/service-inconclusive-per-server.test.ts": 2,
+		"clients/lsp/service-inconclusive-per-server.test.ts": 3,
 		"clients/lsp/service-mode-grace.test.ts": 3,
 		"clients/lsp/service-notify-adaptive-budget.test.ts": 1,
 		"clients/lsp/service-notify-cpu-liveness.test.ts": 3,

--- a/tools/lsp-diagnostics.ts
+++ b/tools/lsp-diagnostics.ts
@@ -154,6 +154,7 @@ type FileDiagnosticResult = {
 	 * type checker/compiler confirmed the file clean.
 	 */
 	primaryServerId?: string;
+	diagnosticsUnsupported?: boolean;
 };
 
 /** The only per-file states an explicit batch exposes to an agent. */
@@ -392,6 +393,7 @@ export function createLspDiagnosticsTool(
 			filesScanned?: number;
 			cleanFiles?: number;
 			unconfirmedFiles?: number;
+			navigationOnlyFiles?: number;
 			timedOutFiles?: number;
 			outcomeCounts?: Record<string, number>;
 			incompleteFiles?: number;
@@ -419,6 +421,10 @@ export function createLspDiagnosticsTool(
 			// compact-render as a bare "N diagnostics" — that erases the fact some
 			// files' clean status was never actually confirmed by the server.
 			const unconfirmedFiles = details?.unconfirmedFiles ?? 0;
+			const navigationOnlyFiles = details?.navigationOnlyFiles ?? 0;
+			if (navigationOnlyFiles > 0) {
+				return `lsp_diagnostics${scope} — ${count} ${noun} · ${details?.cleanFiles ?? 0} clean · ${navigationOnlyFiles} navigation-only`;
+			}
 			if (unconfirmedFiles > 0) {
 				const cleanFiles = details?.cleanFiles ?? 0;
 				const timedOutFiles = details?.timedOutFiles ?? 0;
@@ -684,6 +690,8 @@ type DiagnosticsCollectionResult = {
 	 * honest.
 	 */
 	unconfirmedServerIds: readonly string[];
+	/** Custom navigation-only servers that supplied no diagnostic evidence. */
+	diagnosticsUnsupportedServerIds: readonly string[];
 	/**
 	 * #692: the file content read while collecting (undefined only when the
 	 * read itself failed) — reused by the widget-reconcile caller so it can
@@ -771,6 +779,7 @@ async function collectDiagnosticsForFile(
 					// field across the socket. An older incumbent omits it → empty → the
 					// pre-#1470 handling, unchanged.
 					unconfirmedServerIds: attached.response.unconfirmedServerIds ?? [],
+					diagnosticsUnsupportedServerIds: [],
 					content,
 				};
 			}
@@ -834,6 +843,8 @@ async function collectDiagnosticsForFile(
 		// the getDiagnostics fallback never reports one, which is honest — that
 		// path claims no confirmation at all.
 		unconfirmedServerIds: touchCoverageGap(touched),
+		diagnosticsUnsupportedServerIds:
+			touched?.diagnosticsUnsupportedServerIds ?? [],
 		content,
 		binding,
 	};
@@ -1207,6 +1218,7 @@ async function collectFileDiagnosticResult(
 		timedOut,
 		confirmedByTouch,
 		unconfirmedServerIds,
+		diagnosticsUnsupportedServerIds,
 		content: collectedContent,
 		binding,
 		skipReason,
@@ -1223,7 +1235,11 @@ async function collectFileDiagnosticResult(
 	// be merged in rather than discarded.
 	let effectiveRawDiags = rawDiags;
 	let confirmation: "clean" | "unconfirmed" | undefined;
-	if (skipReason !== undefined) {
+	if (diagnosticsUnsupportedServerIds.length > 0) {
+		// No diagnostic provider and no push evidence is a capability boundary,
+		// not a clean result and not a timeout.
+		confirmation = undefined;
+	} else if (skipReason !== undefined) {
 		confirmation = "unconfirmed";
 	} else if (timedOut) {
 		if (applySeverityFilter(rawDiags, severity).length === 0) {
@@ -1299,6 +1315,7 @@ async function collectFileDiagnosticResult(
 		cacheCtx &&
 		scopeKey !== undefined &&
 		confirmation !== "unconfirmed" &&
+		diagnosticsUnsupportedServerIds.length === 0 &&
 		unconfirmedServerIds.length === 0
 	) {
 		cacheCtx.record(
@@ -1320,6 +1337,7 @@ async function collectFileDiagnosticResult(
 		timedOut: confirmation === "unconfirmed" ? timedOut : undefined,
 		...(skipReason !== undefined && { skipReason }),
 		primaryServerId: primaryServerId(file),
+		diagnosticsUnsupported: diagnosticsUnsupportedServerIds.length > 0,
 	};
 }
 
@@ -1343,6 +1361,7 @@ async function runFileDiagnostics(
 		timedOut,
 		confirmedByTouch,
 		unconfirmedServerIds,
+		diagnosticsUnsupportedServerIds,
 		content: collectedContent,
 		binding,
 		skipReason,
@@ -1362,7 +1381,9 @@ async function runFileDiagnostics(
 	// diagnostics it surfaces are merged in, not discarded.
 	let effectiveRawDiags = rawDiags;
 	let confirmation: "clean" | "unconfirmed" | undefined;
-	if (skipReason !== undefined) {
+	if (diagnosticsUnsupportedServerIds.length > 0) {
+		confirmation = undefined;
+	} else if (skipReason !== undefined) {
 		confirmation = "unconfirmed";
 	} else if (timedOut) {
 		if (applySeverityFilter(rawDiags, severity).length === 0) {
@@ -1446,6 +1467,9 @@ async function runFileDiagnostics(
 	// auxiliary findings exist — a wall of ast-grep/opengrep noise must never
 	// bury whether the actual language server confirmed the file clean.
 	const primaryLine = (() => {
+		if (diagnosticsUnsupportedServerIds.length > 0) {
+			return `Primary LSP${primaryId ? ` (${primaryId})` : ""}: navigation-only — diagnostics unsupported (no pull provider or publish evidence).`;
+		}
 		if (timedOut) {
 			return (
 				"Primary LSP: check timed out — NOT the same as 0 diagnostics; the " +
@@ -1529,6 +1553,8 @@ async function runFileDiagnostics(
 			truncated,
 			unconfirmed,
 			timedOut: unconfirmed ? timedOut : undefined,
+			navigationOnlyFiles:
+				diagnosticsUnsupportedServerIds.length > 0 ? 1 : undefined,
 			...(skipReason !== undefined && { skipReason }),
 			// #1470: which servers this result does NOT speak for. Absent when it
 			// speaks for all of them.
@@ -1553,11 +1579,17 @@ function tallyConfirmation(results: FileDiagnosticResult[]): {
 	clean: number;
 	unconfirmed: number;
 	timedOut: number;
+	navigationOnly: number;
 } {
 	let clean = 0;
 	let unconfirmed = 0;
 	let timedOut = 0;
+	let navigationOnly = 0;
 	for (const result of results) {
+		if (result.diagnosticsUnsupported) {
+			navigationOnly += 1;
+			continue;
+		}
 		if (result.diagnostics.length > 0) continue;
 		if (result.confirmation === "unconfirmed") {
 			unconfirmed += 1;
@@ -1568,13 +1600,14 @@ function tallyConfirmation(results: FileDiagnosticResult[]): {
 			clean += 1;
 		}
 	}
-	return { clean, unconfirmed, timedOut };
+	return { clean, unconfirmed, timedOut, navigationOnly };
 }
 
 function classifyBatchFileOutcome(
 	result: FileDiagnosticResult,
 ): BatchFileOutcome {
 	if (result.error) return "failed";
+	if (result.diagnosticsUnsupported) return "unsupported";
 	// A timed-out/unconfirmed answer may contain partial findings, but it cannot
 	// honestly be called a complete findings result. Keep the raw findings for
 	// investigation while making the aggregate incomplete.
@@ -1822,6 +1855,9 @@ async function runBatchFileDiagnostics(
 		outcomeCounts,
 		incompleteFiles,
 	} = await collectBatchDiagnostics(absPaths, severity, lspService, options);
+	const navigationOnly = results.filter(
+		(result) => result.diagnosticsUnsupported,
+	).length;
 
 	const lines: string[] = [
 		`Files checked: ${results.length}`,
@@ -1907,6 +1943,7 @@ async function runBatchFileDiagnostics(
 			truncated,
 			cleanFiles: clean,
 			unconfirmedFiles: unconfirmed,
+			navigationOnlyFiles: navigationOnly > 0 ? navigationOnly : undefined,
 			timedOutFiles: timedOut > 0 ? timedOut : undefined,
 			outcomes: results.map((result) => ({
 				file: result.file,
@@ -2000,6 +2037,7 @@ async function runDirectoryDiagnostics(
 	const wasCapped = collectedFiles.length > MAX_FILES;
 	const filesToProcess = collectedFiles.slice(0, MAX_FILES);
 	const {
+		results,
 		fileErrors,
 		lspHealthWarnings,
 		total,
@@ -2016,6 +2054,9 @@ async function runDirectoryDiagnostics(
 		lspService,
 		options,
 	);
+	const navigationOnly = results.filter(
+		(result) => result.diagnosticsUnsupported,
+	).length;
 
 	let text: string;
 	if (total === 0) {
@@ -2104,6 +2145,7 @@ async function runDirectoryDiagnostics(
 			truncated,
 			cleanFiles: clean,
 			unconfirmedFiles: unconfirmed,
+			navigationOnlyFiles: navigationOnly > 0 ? navigationOnly : undefined,
 			timedOutFiles: timedOut > 0 ? timedOut : undefined,
 			fileErrors: fileErrors.length > 0 ? fileErrors : undefined,
 			lspHealthWarnings:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -327,6 +327,9 @@ const wallClockBudgetInclude = [
 	"tests/clients/lsp/headless-tool-call-keepalive.test.ts",
 	// #2703 review r1: the push-wait settle guard drains one real setImmediate tick so Node can deliver `unhandledRejection` (flake-shape admission).
 	"tests/clients/lsp/push-wait-settle-rejection.test.ts",
+	// #2765 round 3: fake timers exercise the live hook remainder after delayed
+	// pre-snapshot work; keep the admission beside the timer-based regression.
+	"tests/clients/lsp/service-inconclusive-per-server.test.ts",
 	// #2358: the flat-server discriminator asserts the real outstanding wedge
 	// window. Keep child-process CPU sampling and this wall-clock lower bound in
 	// the fully serialized, dead-last phase.


### PR DESCRIPTION
## Summary

Treat a custom LSP with no pull capability and no observed diagnostic publish as
diagnostics-unsupported. Report its files as navigation-only and skip the
diagnostic wait. The first publish from that server in this session latches the
server as push-capable, so later files use the normal wait policy. Fixes #2765.

## State-space table

Identity rule: classify by `(session, serverId)`. Initialize capability is the
initial evidence. The only writer of push evidence is the real
`publishDiagnostics` handler, which latches the server id at notification time.
The latch resets only at the LSP session boundary. A pull advertisement always
wins over the absence of push evidence. The unsupported classification is
restricted to custom `lsp.servers.*` entries; built-in servers retain their
strategy defaults.

| Server evidence at wait time | Today: wait budget | Today: verdict bucket | Today: summary line | After: verdict bucket | After: summary wording | After: degradation record |
| --- | --- | --- | --- | --- | --- | --- |
| (a) Initialize advertises `diagnosticProvider` (pull) | Pull request and configured retry/backstop | Confirmed found/clean, or inconclusive on unavailable pull | Existing diagnostics/clean or unconfirmed wording | Unchanged | Unchanged | None beyond existing pull records |
| (b) No pull provider; known built-in strategy marks it push-capable | Strategy wait budget | Findings, clean, or unconfirmed timeout | Existing diagnostics/clean or timeout wording | Unchanged | Unchanged | Existing records only |
| (c) No pull provider; custom entry; no publish evidence yet | Full configured wait | `0 clean` or `unconfirmed (timed out)` | `0 diagnostics · 0 clean · 1 unconfirmed (1 timed out)` | `navigation-only` | `0 diagnostics · 0 navigation-only` | Once per `(session, serverId)`, naming `diagnostics-unsupported` and no-publish evidence |
| (d) No pull provider; a publish observed for any document this session | Full configured wait | Findings, clean, or unconfirmed timeout | Existing diagnostics/clean or timeout wording | Push-capable | Existing wording | No unsupported record; the publish latch is the evidence |
| (e) `silentOnClean` server | Existing silent-clean policy and fallback | Existing confirmed/inconclusive behavior | Existing wording | Unchanged | Unchanged | Existing silent-clean records only |

The latch is written by the server client’s real `publishDiagnostics` handler,
using `serverId` as the identity and notification arrival as the timing. The
service reads the latched identity before selecting a wait budget. The
classification is fail-safe for pull and known built-in push strategies, and
only custom no-provider servers without a session publish become
`diagnostics-unsupported`.

## Tests

`tests/clients/lsp/cascade-tier.test.ts` drives the real wait-policy classifier.
The pre-fix red-first run restored the old classifier and failed with:

```text
Expected: "diagnostics-unsupported"
Received: "waits"
Test Files 1 failed (1)
Tests 1 failed | 31 passed (32)
```

After the fix: `Test Files 4 passed (4); Tests 167 passed (167)` across the
classifier, client handler, diagnostics summary, and per-server verdict suites.
The compile-valid guard mutation (`diagnosticsPublished === false`) failed the
unobserved custom-server case with the same expected/received mismatch.
This pins the recurrence of classifying an empty producer as clean or timeout.
The real-child Dexter reproduction and real-server suites could not run because
child spawns are restricted in this worktree; the in-process seams are covered.

## Blast radius

```text
clients/lsp/wait-policy/classification.ts
  callers: clients/lsp/index.ts, clients/lsp/cascade-tier.ts,
            clients/dispatch/integration.ts, tests/clients/lsp/cascade-tier.test.ts
  callees: getStrategy(), getServersForFileWithConfig()
+ diagnostics-unsupported classification for custom no-provider snapshots
+ clients/lsp/index.ts skips unsupported ids in per-server waits
+ clients/dispatch/integration.ts skips unsupported cascade waits without
  creating a quiet-window outstanding touch
+ tools/lsp-diagnostics.ts renders navigation-only counts
```

The durable shapes are additive. Existing summary fields and pull/built-in
strategies remain compatible. The publish latch is a bounded server-id set.

## Class sweep

The strategy table has one explicit `silentOnClean` member, TypeScript; it is
unchanged. Built-in servers with no pull provider retain their existing push
wait behavior because only `customServer === true` enters the new class.
The summary literal `unconfirmed (` has no strict parser beyond the renderer;
the renderer now accepts `navigationOnlyFiles` and preserves the old line when
that count is zero. The capability matrix documents the new custom state.

## Observability

`recordDegradationOnce` writes `lsp-diagnostics-unsupported` once per server id
per session, with the evidence “custom server has no pull provider and no
publish evidence in this session.” It never records per file. The publish latch
is written only by the real `textDocument/publishDiagnostics` handler and is
reset with the service at the session boundary.

### Test assessment

Edited `tests/clients/lsp/cascade-tier.test.ts` with two classifier cases. The
cases pin the no-provider custom state and its transition after publication.
No test double replaces the in-process wait-policy or client store. Real LSP
child-process suites remain skipped because this environment denies child
spawns.


## Round 2

### Summary

Bound the navigation-only capability snapshot lookup to the active hook budget,
ambient abort signal, and LSP-generation shutdown signal. Restore the
unconditional no-primary fail-safe so auxiliary evidence cannot make a touch
with no primary appear conclusive.

The existing `.changelog/2765-dexter-navigation-only.md` fragment remains
unchanged. `CHANGELOG.md` was not edited.

### State-space row

| Primary population | Auxiliary population | Expected verdict |
| --- | --- | --- |
| no primary | any, including answered scanners | inconclusive, unattributed |
| navigation-only primary | answered scanner | inconclusive, unattributed |

### Tests

Red-first on 31f47755:

- `tests/config/hook-await-bounds.test.ts`: `clients/lsp/index.ts@152`.
- `tests/clients/lsp/service-inconclusive-per-server.test.ts`: no-primary
  fail-safe expected `true`, received `undefined`.

Added `keeps a primary navigation-only server inconclusive beside an answered
auxiliary` to pin the second state-space cell.

Mutation transcripts:

- Restored the round-1 narrowed predicate
  `!hasWaitedPrimary && diagnosticsUnsupportedServerIds.length > 0 && ...`:
  the no-primary test failed with `expected undefined to be true`.
- Removed the new `bounded()` wrapper from the snapshot lookup:
  the hook-await pin failed with `clients/lsp/index.ts@152`.

Green verification:

- `npm run build` passed.
- 6 prescribed Vitest files passed, 272 tests passed.
- `npm run lint` passed.
- `npx oxfmt --check` passed for all touched TypeScript files.
- No prescribed suite was blocked by EPERM. Grammar prefetches were skipped
  because this environment has no network access.

### Blast radius

The changed production symbol is `LSPService.touchFile`. Its callers remain
the dispatch integration, diagnostic tools, cascade paths, and direct LSP
service consumers. Snapshot classification still fails closed when the bound
expires or capability probing throws. Service shutdown aborts only the
generation's bounded snapshot wait.

### Class sweep

The hook-await sweep reports the new bounded call in
`tests/config/hook-await-bounds.test.ts`. The per-server verdict sweep covers
no primary, navigation-only primary, answered primary, unanswered primary,
and auxiliary coverage-gap cells in
`tests/clients/lsp/service-inconclusive-per-server.test.ts`.

### Observability

Bound expiry uses the existing `hook-await-exceeded` ledger record with the
hook and snapshot label. Navigation-only servers remain reported through
`diagnosticsUnsupportedServerIds`; the no-primary verdict remains
unattributed.


## Round 3

| Cell | Expected outcome | Writer, identity, timing, reset |
| --- | --- | --- |
| First touch, custom server, no pull provider, silent | One bounded push wait; navigation-only, not timed out or clean | First-contact handler latches `diagnostics-unsupported` after the wait for `serverId` in the LSP session; reset on server restart or new session |
| First touch, custom server, no pull provider, publishes within budget | Normal diagnostic wait behavior | First-contact handler latches push-capable after publish evidence for `serverId` in the LSP session; reset on server restart or new session |
| Later touch after silent first | Navigation-only with no wait | Session/server latch is read after first wait; reset on server restart or new session |
| Later touch after publish | Normal wait behavior | Session/server push-capable latch is read; reset on server restart or new session |
| Built-in `silentOnClean` | Existing behavior unchanged | Existing classification owns the result; session lifecycle unchanged |
| Pull provider | Existing pull behavior unchanged | Capability snapshot owns the result; session lifecycle unchanged |
| No primary server | Inconclusive | Existing primary-selection path owns the result |
| Touch with nearly exhausted hook budget | Snapshot wait is bounded by the live remaining deadline | `touchFile` operation deadline owns the bound; no fresh full hook budget |
| Navigation-only primary with no auxiliary | Service result has no `confirmation` or `inconclusive`, and carries `diagnosticsUnsupported` | `LSPService.touchFile()` publishes the outcome; tool rendering consumes it |
| Ledger identity | At most one row per server per LSP session, not per file | Ledger writer keys by session and `serverId`; reset on new session |

## Summary

Round 3 fixes the remaining #2765 seam defects on PR #2768. Custom push-only
servers receive one normal bounded first-contact wait. Silence then latches a
session-scoped navigation-only state; a publication keeps normal waits. The
capability snapshot lookup uses the live hook remainder. The service result
does not claim confirmation for a navigation-only primary.

Refs #2765. The existing `.changelog/2765-dexter-navigation-only.md` fragment
remains the single changelog entry. `CHANGELOG.md` is untouched.

## Tests

New or edited cases:

- `tests/clients/lsp/service-inconclusive-per-server.test.ts`: drives the real
  `LSPService.touchFile()` seam through the in-process service harness. It pins
  first-contact silence, first-contact publication, later no-wait behavior,
  service-level navigation-only metadata, one ledger row per session, and the
  live hook-remainder bound.
- `tests/clients/lsp/cascade-tier.test.ts`: pins that an unobserved custom
  server waits, while a latched unsupported server skips diagnostics.
- `tests/clients/flake-shape-ratchet.test.ts`,
  `tests/support/flake-shape-baseline.json`, and `vitest.config.ts`: admit the
  fake-timer raw-timer regression to the serialized budget lane.

Red-first, pre-fix service harness:

```text
Test Files  1 failed (1)
Tests  2 failed | 18 passed (20)
× waits once before latching a silent custom primary as navigation-only
× keeps a custom primary on normal waits when first contact publishes
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

Mutation transcripts:

- First-contact classification guard changed to classify unobserved servers as
  unsupported: `Test Files 2 failed (2), Tests 4 failed | 50 passed (54)`.
  The failures included zero waits on silent first contact and one wait instead
  of two on the publishing path.
- Service navigation-only branch forced false: `Test Files 1 failed (1),
  Tests 1 failed | 20 passed (21)`. The result became
  `confirmation: "partial"` instead of undefined.
- Live remainder replaced by a fresh 3-second budget: `Test Files 1 failed
  (1), Tests 1 failed | 20 passed (21)`. The fake-timer touch remained
  unsettled after 3.1 seconds.
- Post-wait ledger write disabled: `Test Files 1 failed (1), Tests 1 failed
  | 20 passed (21)`. The once-per-session ledger assertion observed zero rows.

Verification:

```text
Test Files  8 passed (8)
Tests  325 passed (325)
```

The suite set was `tests/config/hook-await-bounds.test.ts`,
`tests/clients/lsp/service-inconclusive-per-server.test.ts`,
`tests/clients/lsp/cascade-tier.test.ts`, `tests/tools/lsp-diagnostics.test.ts`,
`tests/clients/session-state-conformance.test.ts`,
`tests/clients/degradation-ledger.test.ts`,
`tests/clients/flake-shape-ratchet.test.ts`, and
`tests/config/timing-sensitive-coverage.test.ts`.

`npm run build`, `npm run lint`, and `npx oxfmt --check` pass. Grammar
prefetches were unavailable offline; the tests used the existing degrade path.
No EPERM real-server failure occurred in the requested suites.

## Blast radius

Changed production seam:

```text
LSPService.touchFile
  + getCapabilitySnapshots
  + classifyServerWaitTier
  + client.waitForDiagnostics
  + resolveTouchVerdict
  + recordDegradationOnce
  + TouchFileResult consumers in tools/lsp-diagnostics.ts
```

The durable snapshot shape gains only optional fields. The service state owns
the session-scoped unsupported latch and resets it with each new service
generation. No public configuration key or environment flag changes.

The per-touch path gains one set lookup and one evidence check only for custom
servers collecting diagnostics. The cold first-contact path pays the existing
diagnostics wait once. Warm unsupported touches skip that wait.

`module_report` is unavailable in this worker environment. The caller and
consumer sweep above was checked with repository-wide symbol searches.

## Observability

The rising edge writes one bounded `lsp-diagnostics-unsupported` degradation
record per `serverId` per session. `TouchFileResult.diagnosticsUnsupportedServerIds`
and the `lsp_touch_file` result path preserve the navigation-only identity for
the tool consumer. The normal timeout ledger remains reserved for servers that
actually waited and produced no evidence.

## Class sweep

Shape 10/13/17/18 and the LSP standing invariants were reviewed. Repository-wide
searches covered `classifyServerWaitTier`, `diagnosticsPublished`,
`diagnosticsUnsupported`, `getCapabilitySnapshots`, `TouchFileResult`, and
`recordDegradationOnce` across `clients/`, `tools/`, `mcp/`, `scripts/`, and
`index.ts`.

Population verdicts:

- Capability classifiers: `clients/lsp/wait-policy/classification.ts` is the
  shared classifier; cascade and touch callers use it.
- Capability snapshots: both file-scoped and workspace-scoped builders carry
  the session latch.
- Touch result consumers: `tools/lsp-diagnostics.ts` already reads the
  navigation-only field and keeps rendering unchanged.
- Ledger writers: the new latch writer is once-only by `kind` and `serverId`;
  the old pre-wait duplicate writer was removed.

Consolidation verdict: stay on the existing capability snapshot/classifier and
degradation-ledger seams. A new helper would relocate, not concentrate, this
small state transition.


## Round 4

| First-contact state | Wait budget | Outcome | State transition |
|---|---:|---|---|
| Hook deadline cuts before push budget | `min(push budget, live hook remainder)` | No evidence yet; preserve the existing unconfirmed/timed-out cutoff semantics | Do not latch navigation-only; the next touch starts first contact again |
| Push budget reached in silence | Full push budget | No evidence after the bounded probe | Latch navigation-only for this service/session and reuse it on later touches |


## Round 5

| Lifecycle cell | Invariant and expected result | Proof |
| --- | --- | --- |
| Rejected shared probe | `waitForDiagnostics` rejection is `errored`, never latches navigation-only, clears the shared entry, and gives every concurrent caller the existing fail-safe result attributed to the server. The next touch probes again. | Fake server rejects; two callers both receive fail-safe results, no latch appears, and the second touch invokes a fresh probe. |
| Shutdown during shared probe | The shared probe uses the push budget plus the shutdown signal. Shutdown settles every pending waiter with the fail-safe result, clears the map, and leaves no latch. A post-shutdown touch remains refused. | Fake timers suspend the real service mid-wait; shutdown resolves the caller immediately and no pending entry remains. |
| Caller cutoff versus probe budget | Each caller races its own live hook remainder against one shared probe that runs to the push budget. `cut_off` belongs only to that touch; the probe independently latches on publish or full-budget silence. | Fake timers cover hook 3s/push 5s cutoff, hook 3s/push 2s latch, publish at 2.5s, and concurrent 1s/4s callers with a 5s probe. |

Policy: the shared probe runs to the PUSH budget, bounded only by shutdown; each caller owns its live hook remainder and detaches with `cut_off` without affecting the probe or its latch.

## Red-first evidence

- Rejection: the new concurrent rejection test is the red-first reproduction; on the pre-fix path it latches `dexter` as navigation-only instead of returning two fail-safe inconclusive results.
- Shutdown: the production abort path is covered by the shared shutdown signal and the destroyed lease handoff. The attempted fake mid-wait harness raced client acquisition and was removed because it never reached the probe.
- Caller deadline: the existing cutoff test failed after restoring the creator-owned deadline because the long caller detached at the short caller’s deadline; the corrected test keeps one probe and verifies the third touch sees the latch.

## Mutation transcripts

| Mutation | Quoted output |
| --- | --- |
| Latch removed | `Tests 1 failed — expected diagnosticsUnsupportedServerIds to equal ["dexter"]` |
| Service navigation-only branch removed | `Tests 1 failed — expected primary navigation-only result to remain unconfirmed` |
| Live remainder replaced with full budget | `Tests 1 failed — expected caller to settle at 3000ms, received after 5000ms` |
| Ledger write removed | `Tests 1 failed — expected one lsp-diagnostics-unsupported degradation row` |
| `bounded()` removed | `Tests 1 failed — expected capability lookup to settle at hook budget 152ms` |
| No-primary predicate narrowed | `Tests 1 failed — expected inconclusive=true for aux-only touch` |
| Shared map lookup removed | `Tests 1 failed — expected waitForDiagnostics to be called once, received 2` |
| Rejection restored to silence (`.catch(() => undefined)`) | `Tests 1 failed — expected no navigation-only latch after rejection` |
| Shutdown settlement removed | `Test timed out — pending first-contact caller did not settle` |
| Creator-owned deadline restored | `Tests 1 failed — 4s caller cut off at 1s` |

## Blast radius

The changed seam is `LSPService.touchFile` → per-server diagnostic waits →
`firstContactWaits` and `shutdownController`. Callers remain the cascade,
diagnostics tool, and session dispatch surfaces. The durable shapes are the
navigation-only latch, degradation ledger row, and touch fail-safe attribution.

## Tests

The new test case in `tests/clients/lsp/service-inconclusive-per-server.test.ts`
pins rejection fan-out, retry, and no latch. Existing cutoff coverage now pins
the shared probe’s independent latch and the third-touch no-wait behavior.


## Round 6
