### PR TITLE
fix(smoke): classify formatFile's typed unavailable outcome as a skip in the Format layer (refs #2767, refs #2762)

### DIFF
--- a/.changelog/fix-2767-typed-unavailable-format-smoke.md
+++ b/.changelog/fix-2767-typed-unavailable-format-smoke.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Format smoke rows classify typed unavailable outcomes as skips (refs #2767)** — The format smoke harness no longer reports missing formatter executables as formatting failures.

--- a/scripts/smoke-tools.d.mts
+++ b/scripts/smoke-tools.d.mts
@@ -57,6 +57,21 @@ export interface FormatFixture {
 	 */
 	expect?: "reformat" | "preserve";
 }
+export interface FormatResult {
+	success: boolean;
+	changed: boolean;
+	error?: string;
+	outcome: "formatted" | "unchanged" | "skipped" | "unavailable" | "failed";
+}
+export interface FormatRowVerdict {
+	status: "pass" | "skip" | "fail";
+	detail: string;
+}
+/** Classify one formatter result without running tools or touching files. */
+export function classifyFormatRow(
+	target: FormatResult,
+	fx: FormatFixture,
+): FormatRowVerdict;
 export interface AutofixFixture {
 	lang: string;
 	dir: string;

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -92,6 +92,50 @@ export function tier1Fixtures() {
 }
 
 /**
+ * Classify one format smoke row from the formatter's typed result (#2767).
+ * `formatFile` intentionally reports an unavailable executable with
+ * `success: true`; the typed outcome must win over the success flag so the
+ * smoke lane reports an honest skip instead of a false formatting failure.
+ */
+export function classifyFormatRow(target, fx) {
+	if (target.outcome === "unavailable") {
+		const err = target.error ?? "unknown error";
+		return { status: "skip", detail: `tool not installed (${err})` };
+	}
+	if (!target.success) {
+		const err = target.error ?? "unknown error";
+		// A missing binary is "unavailable", not a failure (matches the rest
+		// of the harness — the runner is selected via config, but the tool
+		// isn't installed on this machine/runner).
+		if (/ENOENT|not found|not recognized|No such file/i.test(err)) {
+			return { status: "skip", detail: `tool not installed (${err})` };
+		}
+		return { status: "fail", detail: `formatter failed to run: ${err}` };
+	}
+	if (fx.expect === "preserve") {
+		// #1144: unconfigured workspace + no indentation evidence ⇒ the
+		// formatter must refuse rather than impose its stock style.
+		if (target.changed) {
+			return {
+				status: "fail",
+				detail: `${fx.formatter} rewrote an unconfigured file with no detectable style (style-preserving refusal expected)`,
+			};
+		}
+		return {
+			status: "pass",
+			detail: `${fx.formatter} preserved the unconfigured file`,
+		};
+	}
+	if (target.changed) {
+		return { status: "pass", detail: `${fx.formatter} reformatted the file` };
+	}
+	return {
+		status: "fail",
+		detail: "ran clean but left the mis-formatted file unchanged",
+	};
+}
+
+/**
  * One minimal real project per language. `targets` are the runner ids whose
  * tool we are smoke-testing; `expectDiagnostic` is the fixture's known defect
  * (used by --step2).
@@ -2154,32 +2198,8 @@ async function runFormatSmoke({ langs, install, verbose }) {
 				);
 				continue;
 			}
-			if (!target.success) {
-				const err = target.error ?? "unknown error";
-				// A missing binary is "unavailable", not a failure (matches the rest
-				// of the harness — the runner is selected via config, but the tool
-				// isn't installed on this machine/runner).
-				if (/ENOENT|not found|not recognized|No such file/i.test(err)) {
-					push("skip", `tool not installed (${err})`);
-				} else {
-					push("fail", `formatter failed to run: ${err}`);
-				}
-			} else if (fx.expect === "preserve") {
-				// #1144: unconfigured workspace + no indentation evidence ⇒ the
-				// formatter must refuse rather than impose its stock style.
-				if (target.changed) {
-					push(
-						"fail",
-						`${fx.formatter} rewrote an unconfigured file with no detectable style (style-preserving refusal expected)`,
-					);
-				} else {
-					push("pass", `${fx.formatter} preserved the unconfigured file`);
-				}
-			} else if (target.changed) {
-				push("pass", `${fx.formatter} reformatted the file`);
-			} else {
-				push("fail", "ran clean but left the mis-formatted file unchanged");
-			}
+			const verdict = classifyFormatRow(target, fx);
+			push(verdict.status, verdict.detail);
 		} catch (err) {
 			push("fail", `error: ${err?.message ?? err}`);
 		} finally {

--- a/tests/scripts/smoke-tools-format-verdict.test.ts
+++ b/tests/scripts/smoke-tools-format-verdict.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { classifyFormatRow } from "../../scripts/smoke-tools.mjs";
+
+const fixture = {
+	lang: "python",
+	dir: "tests/fixtures/tool-smoke/python",
+	file: "bad.py",
+	formatter: "black",
+};
+
+describe("classifyFormatRow (#2767)", () => {
+	it("skips a typed unavailable result even when success is true", () => {
+		// Regression: formatFile's typed unavailable outcome must not become a
+		// false formatting failure when the executable is absent on nightly.
+		expect(
+			classifyFormatRow(
+				{
+					success: true,
+					changed: false,
+					outcome: "unavailable",
+					error: "Cannot spawn black: tool not found (spawn black ENOENT)",
+				},
+				fixture,
+			),
+		).toEqual({
+			status: "skip",
+			detail:
+				"tool not installed (Cannot spawn black: tool not found (spawn black ENOENT))",
+		});
+	});
+
+	it("passes a successful changed result", () => {
+		expect(
+			classifyFormatRow(
+				{ success: true, changed: true, outcome: "formatted" },
+				fixture,
+			),
+		).toEqual({ status: "pass", detail: "black reformatted the file" });
+	});
+
+	it("fails a successful unchanged reformat result", () => {
+		expect(
+			classifyFormatRow(
+				{ success: true, changed: false, outcome: "unchanged" },
+				fixture,
+			),
+		).toEqual({
+			status: "fail",
+			detail: "ran clean but left the mis-formatted file unchanged",
+		});
+	});
+
+	it.each([
+		[
+			"ENOENT",
+			"spawn black ENOENT",
+			"skip",
+			"tool not installed (spawn black ENOENT)",
+		],
+		[
+			"other failure",
+			"black exited with status 2",
+			"fail",
+			"formatter failed to run: black exited with status 2",
+		],
+	])(
+		"classifies an unsuccessful result: %s",
+		(_name, error, status, detail) => {
+			expect(
+				classifyFormatRow(
+					{ success: false, changed: false, outcome: "failed", error },
+					fixture,
+				),
+			).toEqual({ status, detail });
+		},
+	);
+
+	it("passes preserve with no change", () => {
+		expect(
+			classifyFormatRow(
+				{ success: true, changed: false, outcome: "skipped" },
+				{ ...fixture, expect: "preserve" },
+			),
+		).toEqual({
+			status: "pass",
+			detail: "black preserved the unconfigured file",
+		});
+	});
+
+	it("fails preserve when the formatter changes the file", () => {
+		expect(
+			classifyFormatRow(
+				{ success: true, changed: true, outcome: "formatted" },
+				{ ...fixture, expect: "preserve" },
+			),
+		).toEqual({
+			status: "fail",
+			detail:
+				"black rewrote an unconfigured file with no detectable style (style-preserving refusal expected)",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the format smoke harness for #2767 items 1 and 3. The exported
`classifyFormatRow(target, fx)` helper checks the typed `outcome` first, so
`success: true, changed: false, outcome: "unavailable"` reports `skip` with
the existing `tool not installed (...)` detail. The existing failure, preserve,
and changed branches remain unchanged.

This PR references #2767. Item 2 remains open: install the seven managed
formatters on the nightly runner. This fix reports those missing tools as
honest skips with zero coverage.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [x] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] Read CLAUDE.md, AGENTS.md, and the pi-lens fixer contracts.
- [x] Added regression coverage for the typed unavailable result and all existing branches.
- [x] Proved the regression test red before the guard was restored.
- [x] Proved the new guard mutation-sensitive.
- [x] Ran the targeted suites after `npm run build`.
- [x] Ran `npm run lint`.
- [x] Added one changelog fragment.
- [x] Left changes uncommitted as requested.

## Tests

New test file: `tests/scripts/smoke-tools-format-verdict.test.ts`. It drives the
pure exported verdict seam with the real `FormatterResult` shapes and pins:

- typed `unavailable` with `success: true` → skip;
- successful changed and unchanged reformat results → pass and fail;
- unsuccessful ENOENT and other failures → skip and fail;
- preserve unchanged and changed results → pass and fail.

Red-first and mutation transcript, before restoring the typed guard:

```
FAIL tests/scripts/smoke-tools-format-verdict.test.ts
1 failed | 6 passed (7)
Expected status: skip; received status: fail
Received detail: ran clean but left the mis-formatted file unchanged
```

Restored guard result:

```
Test Files  1 passed (1)
Tests  7 passed (7)
```

The same red proves mutation sensitivity: deleting the `outcome ===
"unavailable"` branch reproduces the failure above. Adjacent smoke and fixture
coverage suites pass 37/37 tests. The config governance sweep ran 37 config
files plus `tests/scripts/smoke-tools-genuine-install-failure.test.ts`; 34 files
passed, while 11 tests were blocked by this sandbox's EPERM child-process and
git-spawn restrictions.

## Test assessment

- `tests/scripts/smoke-tools-format-verdict.test.ts`: uniquely pins the
  extracted pure format-row verdict, including the shipped typed-outcome
  regression. No redundant tests identified.
- `tests/clients/dispatch/format-smoke-style-contract.test.ts`: existing
  fixture style contract; unchanged and passed.
- `tests/clients/dispatch/smoke-fixture-coverage.test.ts`: existing fixture
  population and pass-floor contract; unchanged and passed.
- `tests/scripts/smoke-tools-genuine-install-failure.test.ts`: existing
  installer outcome contract; unchanged and passed.

## Blast radius

The production blast radius is limited to the format smoke harness:

```
runFormatSmoke
  -> formatService.formatFile
  -> classifyFormatRow  [new pure seam]
       -> typed FormatterResult.outcome
       -> existing success/error/changed branches
```

The helper is called only from `scripts/smoke-tools.mjs:2201`. Its declaration
is mirrored in `scripts/smoke-tools.d.mts:60-74`. No client runtime module,
formatter result producer, or dispatch consumer changed. The helper adds no
filesystem, process, timer, or telemetry work.

## Class sweep

Item 3 sweep searched:
`grep -rn ".success" clients/format-service.ts clients/dispatch tools/ scripts/ |
grep -i format`.

| Consumer | Verdict |
| --- | --- |
| `clients/format-service.ts:128` | Records `success` with the typed `outcome`; no user-visible miscount. |
| `clients/format-service.ts:135` | Builds `allSucceeded`; unavailable remains success by design and is handled by typed consumers. |
| `clients/format-service.ts:141` | Carries `success` and `outcome` into the summary; no misclassification. |
| `clients/pipeline.ts:1258-1269` | Explicitly excludes `unavailable` from format usage and records a bounded unavailable degradation. Clean; no change. |
| `clients/pipeline.ts:1282` | Counts only `!success` as formatter failure; unavailable has `success: true` and is excluded. Clean; no change. |
| `clients/widget-state.ts:1688-1695` | Failed marker excludes typed unavailable; clean. |
| `clients/widget-state.ts:1846-1855` | Changed/failed summaries preserve the unavailable exclusion; clean. |
| `tools/`, `scripts/` other than smoke harness | No FormatterResult.success consumer found by the requested sweep. |

Consolidation verdict: keep the product consumers distributed because each owns
a different summary or lifecycle surface and already reads the typed outcome.
The smoke harness is the only remaining misclassified consumer and now folds
onto one local pure seam.

## Observability

No new failure path is added. Unavailable formatters retain the existing
bounded `formatter-unavailable` degradation in `clients/pipeline.ts:1261`.
The smoke row now exposes `skip` and the tool error, preserving the
missing-tool identity for nightly diagnosis.
