### PR TITLE
test(lint): drop the no-op replacement CodeQL flagged in the tsgolint preflight test (refs #2709)

### DIFF
--- a/.changelog/test-codeql-49-identity-replace.md
+++ b/.changelog/test-codeql-49-identity-replace.md
@@ -1,0 +1,4 @@
+---
+section: Changed
+---
+- **Dropped a no-op string replacement in the tsgolint preflight test (refs #2709)** — CodeQL alert 49 (`js/identity-replacement`): the helper replaced `/package.json` with itself; the key lookup now only strips the `/tmp/` prefix.

--- a/tests/scripts/lint-js-advisory.test.ts
+++ b/tests/scripts/lint-js-advisory.test.ts
@@ -34,9 +34,7 @@ function resolver(name: string) {
 
 function readPackage(file: string) {
 	return packageFiles[
-		file
-			.replace(/^\/tmp\//, "")
-			.replace(/\/package\.json$/, "/package.json") as keyof typeof packageFiles
+		file.replace(/^\/tmp\//, "") as keyof typeof packageFiles
 	];
 }
 


### PR DESCRIPTION
## Summary

CodeQL alert 49 (`js/identity-replacement`, medium): `readPackage()` in `tests/scripts/lint-js-advisory.test.ts` replaced `/package.json` with itself. The lookup only needs the `/tmp/` prefix stripped; the dead replacement is removed. Behaviour unchanged (7/7 tests).

## Tests

`tests/scripts/lint-js-advisory.test.ts` green before and after; no new test (dead code removal).

## Blast radius

One test helper.

## Class sweep

`grep -rn 'replace(' tests scripts clients | grep -E 'replace\((.+), *\1\)'` style identity replacements: CodeQL reports this one alert on master.

## Observability

The alert closes on the next master CodeQL scan.

### Test assessment

Test-only cleanup; orchestrator read plus CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV