### PR TITLE
fix(smoke): the Format layer installs the managed formatters it selects (refs #2767)

### DIFF
--- a/.changelog/2767-format-smoke-managed-formatters.md
+++ b/.changelog/2767-format-smoke-managed-formatters.md
@@ -5,3 +5,6 @@ section: Fixed
 - **Install managed formatters in the format smoke lane (closes #2767)** — The
   `--install` path now prefetches configured formatters through `ensureTool`
   and the formatter pipeline resolves those managed binaries.
+- **Record unsupported formatter platforms as unavailable (refs #2767)** —
+  GitHub and archive installs preserve the typed unavailable outcome when no
+  asset exists for the host platform and architecture.

--- a/.changelog/2767-format-smoke-managed-formatters.md
+++ b/.changelog/2767-format-smoke-managed-formatters.md
@@ -1,0 +1,7 @@
+---
+section: Fixed
+---
+
+- **Install managed formatters in the format smoke lane (closes #2767)** — The
+  `--install` path now prefetches configured formatters through `ensureTool`
+  and the formatter pipeline resolves those managed binaries.

--- a/.changelog/2767-format-smoke-managed-formatters.md
+++ b/.changelog/2767-format-smoke-managed-formatters.md
@@ -2,9 +2,12 @@
 section: Fixed
 ---
 
-- **Install managed formatters in the format smoke lane (closes #2767)** — The
-  `--install` path now prefetches configured formatters through `ensureTool`
-  and the formatter pipeline resolves those managed binaries.
-- **Record unsupported formatter platforms as unavailable (refs #2767)** —
-  GitHub and archive installs preserve the typed unavailable outcome when no
-  asset exists for the host platform and architecture.
+- **The format smoke lane installs the managed formatters it selects (refs #2767)** —
+  The `--install` path prefetches configured formatters through `ensureTool`
+  and the formatter pipeline resolves those managed binaries, with venv/local
+  → PATH → managed precedence; every managed resolver returns the typed
+  unavailable outcome instead of falling through to a bare command; GitHub and
+  archive installs record a typed unavailable outcome when no asset exists for
+  the host platform and architecture; the formatter-absence tests pin the
+  installer's independent PATH lookup so npm's `node_modules/.bin` prefix on
+  CI cannot resolve a dev-dependency binary.

--- a/clients/dispatch/runners/utils/availability-policy.ts
+++ b/clients/dispatch/runners/utils/availability-policy.ts
@@ -97,7 +97,7 @@ export interface ProbeEvidence {
 	 * same empty result as one that tried and failed, and writing `failed` for
 	 * both fabricates an attempt that never happened.
 	 */
-	install?: "succeeded" | "failed" | "not-attempted";
+	install?: "succeeded" | "failed" | "unavailable" | "not-attempted";
 	/**
 	 * Bounded (200 char) reason the installer gave, verbatim.
 	 *
@@ -225,7 +225,7 @@ export function describeProbeEvidence(
 
 /** The installer's own record of what its last attempt did. */
 export interface InstallAttemptFact {
-	outcome: "succeeded" | "failed" | "declined" | "skipped";
+	outcome: "succeeded" | "failed" | "unavailable" | "declined" | "skipped";
 	reason?: string;
 }
 
@@ -265,6 +265,11 @@ export function describeInstallAttempt(
 			return { install: "succeeded", ...(reason && { installReason: reason }) };
 		case "failed":
 			return { install: "failed", ...(reason && { installReason: reason }) };
+		case "unavailable":
+			return {
+				install: "unavailable",
+				...(reason && { installReason: reason }),
+			};
 		default:
 			return {
 				install: "not-attempted",

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -48,6 +48,7 @@ import {
 import { safeSpawnAsync } from "./safe-spawn.js";
 import { assertInstallAllowed } from "./project-trust.js";
 import { tryLazyInstallForFormatter } from "./dispatch/runners/utils/lazy-installer.js";
+import { getToolPath } from "./installer/index.js";
 import {
 	findPSScriptAnalyzerConfigPath,
 	getAutoInstallToolIdForFormatter,
@@ -703,10 +704,41 @@ async function resolveManagedFormatterCommand(
 	toolId: string,
 	filePath: string,
 	args: string[],
+	findLocal?: (
+		binary: string,
+		cwd: string,
+	) => string | null | undefined | Promise<string | null | undefined>,
+	cwd?: string,
 ): Promise<string[] | null> {
-	const { getToolPath } = await import("./installer/index.js");
-	const installed = await getToolPath(toolId);
+	const local = findLocal && cwd ? await findLocal(toolId, cwd) : null;
+	const installed =
+		local ?? (await which(toolId)) ?? (await getToolPath(toolId));
 	return installed ? [installed, ...args, filePath] : null;
+}
+
+function managedFormatterResolver(
+	toolId: string,
+	args: string[],
+	findLocal?: (
+		binary: string,
+		cwd: string,
+	) => string | null | undefined | Promise<string | null | undefined>,
+): NonNullable<FormatterInfo["resolveCommand"]> {
+	return (filePath, cwd) =>
+		resolveManagedFormatterCommand(toolId, filePath, args, findLocal, cwd);
+}
+
+function managedToolDetect(
+	toolId: string,
+	configDetect?: (cwd: string) => boolean | Promise<boolean>,
+	nativeDetect?: (cwd: string) => boolean | Promise<boolean>,
+): NonNullable<FormatterInfo["detect"]> {
+	return async (cwd) => {
+		const available =
+			(nativeDetect && (await nativeDetect(cwd))) ||
+			Boolean(await getToolPath(toolId));
+		return available && (configDetect ? await configDetect(cwd) : true);
+	};
 }
 
 /**
@@ -1154,9 +1186,13 @@ export const oxfmtFormatter: FormatterInfo = {
 		const found = await which("oxfmt");
 		if (found) return [found, OXFMT_NO_ERROR_ON_UNMATCHED, filePath];
 		return (
-			(await resolveManagedFormatterCommand("oxfmt", filePath, [
-				OXFMT_NO_ERROR_ON_UNMATCHED,
-			])) ?? FORMATTER_UNAVAILABLE
+			(await resolveManagedFormatterCommand(
+				"oxfmt",
+				filePath,
+				[OXFMT_NO_ERROR_ON_UNMATCHED],
+				findInNodeModules,
+				cwd,
+			)) ?? FORMATTER_UNAVAILABLE
 		);
 	},
 	// Single source of truth: OXFMT_SUPPORTED_EXTENSIONS in tool-policy.ts.
@@ -1204,9 +1240,7 @@ export const ruffFormatter: FormatterInfo = {
 		if (hasRuffConfig(cwd)) return true;
 		// No-config fallback: if Ruff is already available, allow formatter usage.
 		// This keeps Python default behavior consistent with startup defaults.
-		const { getToolPath } = await import("./installer/index.js");
-		const installed = await getToolPath("ruff");
-		return Boolean(installed);
+		return Boolean(await getToolPath("ruff"));
 	},
 };
 
@@ -1214,11 +1248,7 @@ export const blackFormatter: FormatterInfo = {
 	name: "black",
 	command: ["black", "$FILE"],
 	extensions: [".py", ".pyi"],
-	async resolveCommand(filePath, cwd) {
-		const venv = await findInVenv("black", cwd);
-		if (venv) return [venv, filePath];
-		return resolveManagedFormatterCommand("black", filePath, []);
-	},
+	resolveCommand: managedFormatterResolver("black", [], findInVenv),
 	async detect(cwd: string) {
 		return hasBlackConfig(cwd);
 	},
@@ -1316,11 +1346,11 @@ export const shfmtFormatter: FormatterInfo = {
 			...styleArgs,
 		]);
 	},
-	async detect(_cwd: string) {
-		if ((await which("shfmt")) !== null) return true;
-		const { getToolPath } = await import("./installer/index.js");
-		return Boolean(await getToolPath("shfmt"));
-	},
+	detect: managedToolDetect(
+		"shfmt",
+		undefined,
+		async () => (await which("shfmt")) !== null,
+	),
 };
 
 export const nixfmtFormatter: FormatterInfo = {
@@ -1385,11 +1415,11 @@ export const ktlintFormatter: FormatterInfo = {
 		if (inPath) return [inPath, "-F", filePath];
 		return resolveManagedSmartDefaultCommand("ktlint", filePath, ["-F"]);
 	},
-	async detect(_cwd: string) {
-		if ((await which("ktlint")) !== null) return true;
-		const { getToolPath } = await import("./installer/index.js");
-		return Boolean(await getToolPath("ktlint"));
-	},
+	detect: managedToolDetect(
+		"ktlint",
+		undefined,
+		async () => (await which("ktlint")) !== null,
+	),
 };
 
 export const ktfmtFormatter: FormatterInfo = {
@@ -1526,7 +1556,15 @@ export const phpCsFixerFormatter: FormatterInfo = {
 			(await which("php-cs-fixer"));
 		const resolved =
 			binary ??
-			(await resolveManagedFormatterCommand("php-cs-fixer", filePath, []))?.[0];
+			(
+				await resolveManagedFormatterCommand(
+					"php-cs-fixer",
+					filePath,
+					[],
+					findInVendorBin,
+					cwd,
+				)
+			)?.[0];
 		// #2413/#2472 review F4: both probes (vendor/bin, then PATH) have
 		// PROVEN the binary is absent — returning `null` here would fall back
 		// to the static `command` above, which is the SAME bare
@@ -1538,26 +1576,17 @@ export const phpCsFixerFormatter: FormatterInfo = {
 			? [resolved, "fix", "--config", configPath, filePath]
 			: [resolved, "fix", filePath];
 	},
-	async detect(cwd: string) {
-		const vendorBin = await findInVendorBin("php-cs-fixer", cwd);
-		const globalBin = await which("php-cs-fixer");
-		if (!vendorBin && !globalBin) {
-			const { getToolPath } = await import("./installer/index.js");
-			if (!(await getToolPath("php-cs-fixer"))) return false;
-		}
-		// Only run if project has explicit config. This is a presence-only
-		// climb from the project `cwd` (not necessarily the formatted file's
-		// own directory) via this file's own `findUp` — deliberately NOT
-		// merged with `resolvePhpCsFixerConfig` above (#2472 AC4): that
-		// resolver climbs from the FILE's directory and needs the exact
-		// winning path for `--config`, while this only needs a yes/no answer
-		// from whatever `cwd` the caller passed. `rustfmtFormatter.detect`
-		// keeps the same non-merged shape against `resolveCargoPackageEdition`
-		// for the identical reason.
-		const configs = [".php-cs-fixer.php", ".php-cs-fixer.dist.php"];
-		const found = await findUp(configs, cwd);
-		return found.length > 0;
-	},
+	detect: managedToolDetect(
+		"php-cs-fixer",
+		async (cwd) =>
+			(await findUp([".php-cs-fixer.php", ".php-cs-fixer.dist.php"], cwd))
+				.length > 0,
+		async (cwd) =>
+			Boolean(
+				(await findInVendorBin("php-cs-fixer", cwd)) ||
+				(await which("php-cs-fixer")),
+			),
+	),
 };
 
 export const csharpierFormatter: FormatterInfo = {
@@ -1621,27 +1650,14 @@ export const styluaFormatter: FormatterInfo = {
 	name: "stylua",
 	command: ["stylua", "$FILE"],
 	extensions: [".lua"],
-	async resolveCommand(filePath, cwd) {
-		// Project binary first (#1731, discipline B): stylua has no pi-lens
-		// managed install, so before this the ONLY resolution was a bare
-		// `stylua` PATH lookup — a project-local install via npm
-		// `@johnnymorganz/stylua` (`node_modules/.bin/stylua`) was invisible.
-		const local = findLocalBinUpwards("stylua", cwd);
-		return local
-			? [local, filePath]
-			: await resolveManagedFormatterCommand("stylua", filePath, []);
-	},
-	async detect(cwd: string) {
-		const local = findLocalBinUpwards("stylua", cwd);
-		if (!local && (await which("stylua")) === null) {
-			const { getToolPath } = await import("./installer/index.js");
-			if (!(await getToolPath("stylua"))) return false;
-		}
-		// Prefer explicit config but also run if binary is present in a Lua project
-		const configs = ["stylua.toml", ".stylua.toml"];
-		const found = await findUp(configs, cwd);
-		return found.length > 0;
-	},
+	resolveCommand: managedFormatterResolver("stylua", [], findLocalBinUpwards),
+	detect: managedToolDetect(
+		"stylua",
+		async (cwd) =>
+			(await findUp(["stylua.toml", ".stylua.toml"], cwd)).length > 0,
+		async (cwd) =>
+			Boolean(findLocalBinUpwards("stylua", cwd) || (await which("stylua"))),
+	),
 };
 
 export const ormoluFormatter: FormatterInfo = {
@@ -1662,61 +1678,47 @@ export const taploFormatter: FormatterInfo = {
 		if (inPath) return [inPath, "fmt", filePath];
 		return resolveManagedSmartDefaultCommand("taplo", filePath, ["fmt"]);
 	},
-	async detect(_cwd: string) {
-		if ((await which("taplo")) !== null) return true;
-		const { getToolPath } = await import("./installer/index.js");
-		return Boolean(await getToolPath("taplo"));
-	},
+	detect: managedToolDetect(
+		"taplo",
+		undefined,
+		async () => (await which("taplo")) !== null,
+	),
 };
 
 export const googleJavaFormatFormatter: FormatterInfo = {
 	name: "google-java-format",
 	command: ["google-java-format", "--replace", "$FILE"],
 	extensions: [".java"],
-	async resolveCommand(filePath, _cwd) {
-		return resolveManagedFormatterCommand("google-java-format", filePath, [
-			"--replace",
-		]);
-	},
-	async detect(cwd: string) {
-		if ((await which("google-java-format")) === null) {
-			const { getToolPath } = await import("./installer/index.js");
-			if (!(await getToolPath("google-java-format"))) return false;
-		}
-		return hasGoogleJavaFormatConfig(cwd);
-	},
+	resolveCommand: managedFormatterResolver("google-java-format", ["--replace"]),
+	detect: managedToolDetect(
+		"google-java-format",
+		hasGoogleJavaFormatConfig,
+		async () => (await which("google-java-format")) !== null,
+	),
 };
 
 export const cljfmtFormatter: FormatterInfo = {
 	name: "cljfmt",
 	command: ["cljfmt", "fix", "$FILE"],
 	extensions: [".clj", ".cljc", ".cljs"],
-	async resolveCommand(filePath, _cwd) {
-		return resolveManagedFormatterCommand("cljfmt", filePath, ["fix"]);
-	},
-	async detect(cwd: string) {
-		if ((await which("cljfmt")) === null) {
-			const { getToolPath } = await import("./installer/index.js");
-			if (!(await getToolPath("cljfmt"))) return false;
-		}
-		return hasCljfmtConfig(cwd);
-	},
+	resolveCommand: managedFormatterResolver("cljfmt", ["fix"]),
+	detect: managedToolDetect(
+		"cljfmt",
+		hasCljfmtConfig,
+		async () => (await which("cljfmt")) !== null,
+	),
 };
 
 export const cmakeFormatFormatter: FormatterInfo = {
 	name: "cmake-format",
 	command: ["cmake-format", "-i", "$FILE"],
 	extensions: [".cmake"],
-	async resolveCommand(filePath, _cwd) {
-		return resolveManagedFormatterCommand("cmake-format", filePath, ["-i"]);
-	},
-	async detect(cwd: string) {
-		if ((await which("cmake-format")) === null) {
-			const { getToolPath } = await import("./installer/index.js");
-			if (!(await getToolPath("cmake-format"))) return false;
-		}
-		return hasCmakeFormatConfig(cwd);
-	},
+	resolveCommand: managedFormatterResolver("cmake-format", ["-i"]),
+	detect: managedToolDetect(
+		"cmake-format",
+		hasCmakeFormatConfig,
+		async () => (await which("cmake-format")) !== null,
+	),
 };
 
 export const cueFormatter: FormatterInfo = {

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -709,11 +709,11 @@ async function resolveManagedFormatterCommand(
 		cwd: string,
 	) => string | null | undefined | Promise<string | null | undefined>,
 	cwd?: string,
-): Promise<string[] | null> {
+): Promise<string[] | typeof FORMATTER_UNAVAILABLE> {
 	const local = findLocal && cwd ? await findLocal(toolId, cwd) : null;
 	const installed =
 		local ?? (await which(toolId)) ?? (await getToolPath(toolId));
-	return installed ? [installed, ...args, filePath] : null;
+	return installed ? [installed, ...args, filePath] : FORMATTER_UNAVAILABLE;
 }
 
 function managedFormatterResolver(
@@ -1554,17 +1554,15 @@ export const phpCsFixerFormatter: FormatterInfo = {
 		const binary =
 			(await findInVendorBin("php-cs-fixer", cwd)) ??
 			(await which("php-cs-fixer"));
-		const resolved =
-			binary ??
-			(
-				await resolveManagedFormatterCommand(
-					"php-cs-fixer",
-					filePath,
-					[],
-					findInVendorBin,
-					cwd,
-				)
-			)?.[0];
+		const managed = await resolveManagedFormatterCommand(
+			"php-cs-fixer",
+			filePath,
+			[],
+			findInVendorBin,
+			cwd,
+		);
+		if (managed === FORMATTER_UNAVAILABLE) return FORMATTER_UNAVAILABLE;
+		const resolved = binary ?? managed[0];
 		// #2413/#2472 review F4: both probes (vendor/bin, then PATH) have
 		// PROVEN the binary is absent — returning `null` here would fall back
 		// to the static `command` above, which is the SAME bare

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -698,6 +698,17 @@ async function resolveManagedSmartDefaultCommand(
 	return [installed, ...args, filePath];
 }
 
+/** Resolve an explicitly selected formatter from the shared managed-tool seam. */
+async function resolveManagedFormatterCommand(
+	toolId: string,
+	filePath: string,
+	args: string[],
+): Promise<string[] | null> {
+	const { getToolPath } = await import("./installer/index.js");
+	const installed = await getToolPath(toolId);
+	return installed ? [installed, ...args, filePath] : null;
+}
+
 /**
  * One entry per formatter that can be selected via explicit project config
  * (the `formatterPolicy` "explicit-config" branch of `getFormattersForFile`).
@@ -1142,11 +1153,11 @@ export const oxfmtFormatter: FormatterInfo = {
 		if (local) return [local, OXFMT_NO_ERROR_ON_UNMATCHED, filePath];
 		const found = await which("oxfmt");
 		if (found) return [found, OXFMT_NO_ERROR_ON_UNMATCHED, filePath];
-		// #2413: neither node_modules/.bin nor PATH has oxfmt, and `detect()` is
-		// config-only (it never probes the binary), so selection can reach here
-		// with nothing installed. The static command is bare `oxfmt` — spawning it
-		// only reproduces the reported `spawn oxfmt ENOENT`. Prove it unavailable.
-		return FORMATTER_UNAVAILABLE;
+		return (
+			(await resolveManagedFormatterCommand("oxfmt", filePath, [
+				OXFMT_NO_ERROR_ON_UNMATCHED,
+			])) ?? FORMATTER_UNAVAILABLE
+		);
 	},
 	// Single source of truth: OXFMT_SUPPORTED_EXTENSIONS in tool-policy.ts.
 	// Do not hand-maintain a second copy of this list (#1134 — previously two
@@ -1206,7 +1217,7 @@ export const blackFormatter: FormatterInfo = {
 	async resolveCommand(filePath, cwd) {
 		const venv = await findInVenv("black", cwd);
 		if (venv) return [venv, filePath];
-		return null;
+		return resolveManagedFormatterCommand("black", filePath, []);
 	},
 	async detect(cwd: string) {
 		return hasBlackConfig(cwd);
@@ -1513,21 +1524,27 @@ export const phpCsFixerFormatter: FormatterInfo = {
 		const binary =
 			(await findInVendorBin("php-cs-fixer", cwd)) ??
 			(await which("php-cs-fixer"));
+		const resolved =
+			binary ??
+			(await resolveManagedFormatterCommand("php-cs-fixer", filePath, []))?.[0];
 		// #2413/#2472 review F4: both probes (vendor/bin, then PATH) have
 		// PROVEN the binary is absent — returning `null` here would fall back
 		// to the static `command` above, which is the SAME bare
 		// `php-cs-fixer` this just failed to find, spawning it only to
 		// re-observe the ENOENT already known. Report the proven-missing
 		// state instead so `formatFile` skips the wasted spawn.
-		if (!binary) return FORMATTER_UNAVAILABLE;
+		if (!resolved) return FORMATTER_UNAVAILABLE;
 		return configPath
-			? [binary, "fix", "--config", configPath, filePath]
-			: [binary, "fix", filePath];
+			? [resolved, "fix", "--config", configPath, filePath]
+			: [resolved, "fix", filePath];
 	},
 	async detect(cwd: string) {
 		const vendorBin = await findInVendorBin("php-cs-fixer", cwd);
 		const globalBin = await which("php-cs-fixer");
-		if (!vendorBin && !globalBin) return false;
+		if (!vendorBin && !globalBin) {
+			const { getToolPath } = await import("./installer/index.js");
+			if (!(await getToolPath("php-cs-fixer"))) return false;
+		}
 		// Only run if project has explicit config. This is a presence-only
 		// climb from the project `cwd` (not necessarily the formatted file's
 		// own directory) via this file's own `findUp` — deliberately NOT
@@ -1610,11 +1627,16 @@ export const styluaFormatter: FormatterInfo = {
 		// `stylua` PATH lookup — a project-local install via npm
 		// `@johnnymorganz/stylua` (`node_modules/.bin/stylua`) was invisible.
 		const local = findLocalBinUpwards("stylua", cwd);
-		return local ? [local, filePath] : null;
+		return local
+			? [local, filePath]
+			: await resolveManagedFormatterCommand("stylua", filePath, []);
 	},
 	async detect(cwd: string) {
 		const local = findLocalBinUpwards("stylua", cwd);
-		if (!local && (await which("stylua")) === null) return false;
+		if (!local && (await which("stylua")) === null) {
+			const { getToolPath } = await import("./installer/index.js");
+			if (!(await getToolPath("stylua"))) return false;
+		}
 		// Prefer explicit config but also run if binary is present in a Lua project
 		const configs = ["stylua.toml", ".stylua.toml"];
 		const found = await findUp(configs, cwd);
@@ -1651,8 +1673,16 @@ export const googleJavaFormatFormatter: FormatterInfo = {
 	name: "google-java-format",
 	command: ["google-java-format", "--replace", "$FILE"],
 	extensions: [".java"],
+	async resolveCommand(filePath, _cwd) {
+		return resolveManagedFormatterCommand("google-java-format", filePath, [
+			"--replace",
+		]);
+	},
 	async detect(cwd: string) {
-		if ((await which("google-java-format")) === null) return false;
+		if ((await which("google-java-format")) === null) {
+			const { getToolPath } = await import("./installer/index.js");
+			if (!(await getToolPath("google-java-format"))) return false;
+		}
 		return hasGoogleJavaFormatConfig(cwd);
 	},
 };
@@ -1661,8 +1691,14 @@ export const cljfmtFormatter: FormatterInfo = {
 	name: "cljfmt",
 	command: ["cljfmt", "fix", "$FILE"],
 	extensions: [".clj", ".cljc", ".cljs"],
+	async resolveCommand(filePath, _cwd) {
+		return resolveManagedFormatterCommand("cljfmt", filePath, ["fix"]);
+	},
 	async detect(cwd: string) {
-		if ((await which("cljfmt")) === null) return false;
+		if ((await which("cljfmt")) === null) {
+			const { getToolPath } = await import("./installer/index.js");
+			if (!(await getToolPath("cljfmt"))) return false;
+		}
 		return hasCljfmtConfig(cwd);
 	},
 };
@@ -1671,8 +1707,14 @@ export const cmakeFormatFormatter: FormatterInfo = {
 	name: "cmake-format",
 	command: ["cmake-format", "-i", "$FILE"],
 	extensions: [".cmake"],
+	async resolveCommand(filePath, _cwd) {
+		return resolveManagedFormatterCommand("cmake-format", filePath, ["-i"]);
+	},
 	async detect(cwd: string) {
-		if ((await which("cmake-format")) === null) return false;
+		if ((await which("cmake-format")) === null) {
+			const { getToolPath } = await import("./installer/index.js");
+			if (!(await getToolPath("cmake-format"))) return false;
+		}
 		return hasCmakeFormatConfig(cwd);
 	},
 };

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -451,6 +451,33 @@ export const TOOLS: ToolDefinition[] = [
 		binaryName: "prettier",
 	},
 	{
+		id: "black",
+		name: "Black",
+		checkCommand: "black",
+		checkArgs: ["--version"],
+		installStrategy: "pip",
+		packageName: "black",
+		binaryName: "black",
+	},
+	{
+		id: "cmake-format",
+		name: "cmake-format",
+		checkCommand: "cmake-format",
+		checkArgs: ["--version"],
+		installStrategy: "pip",
+		packageName: "cmakelang",
+		binaryName: "cmake-format",
+	},
+	{
+		id: "oxfmt",
+		name: "oxfmt",
+		checkCommand: "oxfmt",
+		checkArgs: ["--version"],
+		installStrategy: "npm",
+		packageName: "oxfmt",
+		binaryName: "oxfmt",
+	},
+	{
 		id: "ruff",
 		name: "Ruff",
 		checkCommand: "ruff",
@@ -874,6 +901,70 @@ export const TOOLS: ToolDefinition[] = [
 				return undefined;
 			},
 			// bare binary, no archive
+		},
+	},
+	{
+		id: "stylua",
+		name: "StyLua",
+		checkCommand: "stylua",
+		checkArgs: ["--version"],
+		installStrategy: "github",
+		binaryName: "stylua",
+		github: {
+			repo: "JohnnyMorganz/StyLua",
+			assetMatch: archAssetMatch({
+				linux: { x64: "linux-x86_64.zip", arm64: "linux-aarch64.zip" },
+				darwin: { x64: "macos-x86_64.zip", arm64: "macos-aarch64.zip" },
+				win32: { x64: "windows-x86_64.zip" },
+			}),
+			binaryInArchive: "stylua",
+		},
+	},
+	{
+		id: "php-cs-fixer",
+		name: "PHP CS Fixer",
+		checkCommand: "php-cs-fixer",
+		checkArgs: ["--version"],
+		installStrategy: "github",
+		binaryName: "php-cs-fixer",
+		github: {
+			repo: "PHP-CS-Fixer/PHP-CS-Fixer",
+			assetMatch: () => "php-cs-fixer.phar",
+		},
+	},
+	{
+		id: "google-java-format",
+		name: "google-java-format",
+		checkCommand: "google-java-format",
+		checkArgs: ["--version"],
+		installStrategy: "maven",
+		binaryName: "google-java-format",
+		maven: {
+			groupId: "com.google.googlejavaformat",
+			artifactId: "google-java-format",
+			version: "1.27.0",
+			classifier: "all-deps",
+		},
+	},
+	{
+		id: "cljfmt",
+		name: "cljfmt",
+		checkCommand: "cljfmt",
+		checkArgs: ["--version"],
+		installStrategy: "github",
+		binaryName: "cljfmt",
+		github: {
+			repo: "weavejester/cljfmt",
+			assetMatch: (platform, arch) => {
+				if (platform === "linux")
+					return arch === "arm64"
+						? "standalone.jar"
+						: "linux-amd64-static.tar.gz";
+				if (platform === "darwin") return "standalone.jar";
+				if (platform === "win32") return "win-amd64.zip";
+				return undefined;
+			},
+			binaryInArchive: "cljfmt",
 		},
 	},
 	{

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -1706,6 +1706,7 @@ export function getInstallFailureReason(toolId: string): string | undefined {
  *
  *   * `succeeded`  — an install ran and reported success.
  *   * `failed`     — an install ran and did not succeed. The retry candidate.
+ *   * `unavailable` — the install cannot run on this platform. Nothing ran.
  *   * `declined`   — policy said no: kill switch, `allowInstall: false`, project
  *                    trust, an unknown tool id. Nothing ran.
  *   * `skipped`    — another process holds the install lock. Nothing ran.
@@ -1713,6 +1714,7 @@ export function getInstallFailureReason(toolId: string): string | undefined {
 export type InstallAttemptOutcome =
 	| "succeeded"
 	| "failed"
+	| "unavailable"
 	| "declined"
 	| "skipped";
 
@@ -5569,6 +5571,12 @@ export async function installTool(toolId: string): Promise<boolean> {
 
 			case "archive": {
 				if (!tool.archive) return false;
+				if (!resolveArchiveUrl(tool.archive)) {
+					const reason = `unsupported platform=${process.platform} arch=${process.arch}`;
+					noteInstallAttempt(tool.id, "unavailable", reason);
+					logSessionStart(`auto-install ${tool.id}: ${reason}`);
+					return false;
+				}
 				const archivePath = await installArchiveTool(tool);
 				return finishInstallAttempt(
 					tool.id,

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -5555,6 +5555,12 @@ export async function installTool(toolId: string): Promise<boolean> {
 
 			case "github": {
 				if (!tool.github) return false;
+				if (!tool.github.assetMatch(process.platform, process.arch)) {
+					const reason = `unsupported platform=${process.platform} arch=${process.arch}`;
+					noteInstallAttempt(tool.id, "unavailable", reason);
+					logSessionStart(`auto-install ${tool.id}: ${reason}`);
+					return false;
+				}
 				const ghPath = await installGitHubTool(tool);
 				return finishInstallAttempt(tool.id, ghPath !== undefined, startedAt);
 			}

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -273,6 +273,8 @@ interface GitHubAssetSpec {
 	 * so the `ktlint` jar must land next to it (#218).
 	 */
 	extraAssets?: (platform: string, arch: string) => string[];
+	/** Runtime wrapper for a platform asset that is a PHAR or runnable JAR. */
+	launcher?: "php" | "java";
 }
 
 /**
@@ -402,6 +404,142 @@ const OS_ARCH_ZIP_ASSETS = {
 	win32: { x64: "windows_amd64.zip", arm64: "windows_arm64.zip" },
 };
 
+type ManagedPackageFormatterSpec = {
+	id: string;
+	name: string;
+	installStrategy: "npm" | "pip";
+	packageName: string;
+};
+
+function managedPackageFormatterTool(
+	spec: ManagedPackageFormatterSpec,
+): ToolDefinition {
+	return {
+		id: spec.id,
+		name: spec.name,
+		checkCommand: spec.id,
+		checkArgs: ["--version"],
+		installStrategy: spec.installStrategy,
+		packageName: spec.packageName,
+		binaryName: spec.id,
+	};
+}
+
+const MANAGED_PACKAGE_FORMATTERS = [
+	{ id: "black", name: "Black", installStrategy: "pip", packageName: "black" },
+	{
+		id: "cmake-format",
+		name: "cmake-format",
+		installStrategy: "pip",
+		packageName: "cmakelang",
+	},
+	{ id: "oxfmt", name: "oxfmt", installStrategy: "npm", packageName: "oxfmt" },
+] satisfies ManagedPackageFormatterSpec[];
+
+type ManagedGitHubFormatterSpec = {
+	id: string;
+	name: string;
+	owner: string;
+	repo: string;
+	assetPattern: GitHubAssetSpec["assetMatch"];
+	kind: "binary" | "phar" | "jar";
+	binaryInArchive?: string;
+};
+
+function managedGitHubFormatterTool(
+	spec: ManagedGitHubFormatterSpec,
+): ToolDefinition {
+	return {
+		id: spec.id,
+		name: spec.name,
+		checkCommand: spec.id,
+		checkArgs: ["--version"],
+		installStrategy: "github",
+		binaryName: spec.id,
+		github: {
+			repo: `${spec.owner}/${spec.repo}`,
+			assetMatch: spec.assetPattern,
+			...(spec.binaryInArchive && { binaryInArchive: spec.binaryInArchive }),
+			...(spec.kind === "phar" && { launcher: "php" as const }),
+			...(spec.kind === "jar" && { launcher: "java" as const }),
+		},
+	};
+}
+
+const MANAGED_GITHUB_FORMATTERS = [
+	{
+		id: "stylua",
+		name: "StyLua",
+		owner: "JohnnyMorganz",
+		repo: "StyLua",
+		assetPattern: archAssetMatch({
+			linux: { x64: "linux-x86_64.zip", arm64: "linux-aarch64.zip" },
+			darwin: { x64: "macos-x86_64.zip", arm64: "macos-aarch64.zip" },
+			win32: { x64: "windows-x86_64.zip" },
+		}),
+		kind: "binary",
+		binaryInArchive: "stylua",
+	},
+	{
+		id: "php-cs-fixer",
+		name: "PHP CS Fixer",
+		owner: "PHP-CS-Fixer",
+		repo: "PHP-CS-Fixer",
+		assetPattern: (platform) =>
+			platform === "linux" || platform === "darwin" || platform === "win32"
+				? "php-cs-fixer.phar"
+				: undefined,
+		kind: "phar",
+	},
+	{
+		id: "cljfmt",
+		name: "cljfmt",
+		owner: "weavejester",
+		repo: "cljfmt",
+		assetPattern: (platform, arch) => {
+			if (platform === "linux")
+				return arch === "arm64"
+					? "standalone.jar"
+					: "linux-amd64-static.tar.gz";
+			if (platform === "darwin") return "standalone.jar";
+			if (platform === "win32") return "win-amd64.zip";
+			return undefined;
+		},
+		kind: "jar",
+		binaryInArchive: "cljfmt",
+	},
+] satisfies ManagedGitHubFormatterSpec[];
+
+const MANAGED_MAVEN_FORMATTERS = [
+	{
+		id: "google-java-format",
+		name: "google-java-format",
+		groupId: "com.google.googlejavaformat",
+		artifactId: "google-java-format",
+		version: "1.27.0",
+		classifier: "all-deps",
+	},
+];
+
+function managedMavenFormatterTool(
+	spec: (typeof MANAGED_MAVEN_FORMATTERS)[number],
+): ToolDefinition {
+	return {
+		id: spec.id,
+		name: spec.name,
+		checkCommand: spec.id,
+		checkArgs: ["--version"],
+		installStrategy: "maven",
+		binaryName: spec.id,
+		maven: {
+			groupId: spec.groupId,
+			artifactId: spec.artifactId,
+			version: spec.version,
+			classifier: spec.classifier,
+		},
+	};
+}
+
 export const TOOLS: ToolDefinition[] = [
 	// Core LSP servers
 	{
@@ -450,33 +588,7 @@ export const TOOLS: ToolDefinition[] = [
 		packageName: "prettier",
 		binaryName: "prettier",
 	},
-	{
-		id: "black",
-		name: "Black",
-		checkCommand: "black",
-		checkArgs: ["--version"],
-		installStrategy: "pip",
-		packageName: "black",
-		binaryName: "black",
-	},
-	{
-		id: "cmake-format",
-		name: "cmake-format",
-		checkCommand: "cmake-format",
-		checkArgs: ["--version"],
-		installStrategy: "pip",
-		packageName: "cmakelang",
-		binaryName: "cmake-format",
-	},
-	{
-		id: "oxfmt",
-		name: "oxfmt",
-		checkCommand: "oxfmt",
-		checkArgs: ["--version"],
-		installStrategy: "npm",
-		packageName: "oxfmt",
-		binaryName: "oxfmt",
-	},
+	...MANAGED_PACKAGE_FORMATTERS.map(managedPackageFormatterTool),
 	{
 		id: "ruff",
 		name: "Ruff",
@@ -903,70 +1015,8 @@ export const TOOLS: ToolDefinition[] = [
 			// bare binary, no archive
 		},
 	},
-	{
-		id: "stylua",
-		name: "StyLua",
-		checkCommand: "stylua",
-		checkArgs: ["--version"],
-		installStrategy: "github",
-		binaryName: "stylua",
-		github: {
-			repo: "JohnnyMorganz/StyLua",
-			assetMatch: archAssetMatch({
-				linux: { x64: "linux-x86_64.zip", arm64: "linux-aarch64.zip" },
-				darwin: { x64: "macos-x86_64.zip", arm64: "macos-aarch64.zip" },
-				win32: { x64: "windows-x86_64.zip" },
-			}),
-			binaryInArchive: "stylua",
-		},
-	},
-	{
-		id: "php-cs-fixer",
-		name: "PHP CS Fixer",
-		checkCommand: "php-cs-fixer",
-		checkArgs: ["--version"],
-		installStrategy: "github",
-		binaryName: "php-cs-fixer",
-		github: {
-			repo: "PHP-CS-Fixer/PHP-CS-Fixer",
-			assetMatch: () => "php-cs-fixer.phar",
-		},
-	},
-	{
-		id: "google-java-format",
-		name: "google-java-format",
-		checkCommand: "google-java-format",
-		checkArgs: ["--version"],
-		installStrategy: "maven",
-		binaryName: "google-java-format",
-		maven: {
-			groupId: "com.google.googlejavaformat",
-			artifactId: "google-java-format",
-			version: "1.27.0",
-			classifier: "all-deps",
-		},
-	},
-	{
-		id: "cljfmt",
-		name: "cljfmt",
-		checkCommand: "cljfmt",
-		checkArgs: ["--version"],
-		installStrategy: "github",
-		binaryName: "cljfmt",
-		github: {
-			repo: "weavejester/cljfmt",
-			assetMatch: (platform, arch) => {
-				if (platform === "linux")
-					return arch === "arm64"
-						? "standalone.jar"
-						: "linux-amd64-static.tar.gz";
-				if (platform === "darwin") return "standalone.jar";
-				if (platform === "win32") return "win-amd64.zip";
-				return undefined;
-			},
-			binaryInArchive: "cljfmt",
-		},
-	},
+	...MANAGED_GITHUB_FORMATTERS.map(managedGitHubFormatterTool),
+	...MANAGED_MAVEN_FORMATTERS.map(managedMavenFormatterTool),
 	{
 		id: "rust-analyzer",
 		name: "rust-analyzer",
@@ -3121,6 +3171,15 @@ function getGitHubInstalledBinaryName(
 	return `${binaryName}.exe`;
 }
 
+function launcherForGitHubAsset(
+	spec: GitHubAssetSpec,
+	assetName: string,
+): "php" | "java" | undefined {
+	if (spec.launcher === "php" && assetName.endsWith(".phar")) return "php";
+	if (spec.launcher === "java" && assetName.endsWith(".jar")) return "java";
+	return undefined;
+}
+
 function getArchiveBinaryCandidates(
 	binaryName: string,
 	platform: string,
@@ -3580,12 +3639,43 @@ async function installGitHubTool(
 		platform,
 		asset.name,
 	);
-	const destPath = path.join(GITHUB_BIN_DIR, finalBinaryName);
+	let destPath = path.join(GITHUB_BIN_DIR, finalBinaryName);
 
 	const assetName = asset.name;
+	const launcherRuntime = launcherForGitHubAsset(spec, assetName);
+	if (
+		launcherRuntime &&
+		!(await isCommandAvailable(launcherRuntime, ["--version"]))
+	) {
+		logSessionStart(
+			`github-install ${tool.id}: ${launcherRuntime} not found — asset requires a runtime launcher`,
+		);
+		return undefined;
+	}
 
 	try {
-		if (assetName.endsWith(".gz") && !assetName.endsWith(".tar.gz")) {
+		if (launcherRuntime) {
+			const assetPath = path.join(
+				GITHUB_BIN_DIR,
+				`${tool.id}${assetName.endsWith(".phar") ? ".phar" : ".jar"}`,
+			);
+			await writeFileAtomicAsync(assetPath, assetBuffer, {
+				bestEffort: false,
+				mode: 0o750,
+			});
+			const launcherName = isWindows ? `${binaryName}.bat` : binaryName;
+			destPath = path.join(GITHUB_BIN_DIR, launcherName);
+			const runtimeTarget = assetName.endsWith(".phar")
+				? `${tool.id}.phar`
+				: `${tool.id}.jar`;
+			const command = isWindows
+				? `@echo off\r\n${launcherRuntime} "%~dp0${runtimeTarget}" %*\r\n`
+				: `#!/bin/sh\nexec ${launcherRuntime} "$(dirname "$0")/${runtimeTarget}" "$@"\n`;
+			await writeFileAtomicAsync(destPath, command, {
+				bestEffort: false,
+				mode: isWindows ? undefined : 0o750,
+			});
+		} else if (assetName.endsWith(".gz") && !assetName.endsWith(".tar.gz")) {
 			// Bare gzip (e.g. rust-analyzer-x86_64-unknown-linux-gnu.gz) — decompress directly
 			const decompressed = await new Promise<Buffer>((resolve, reject) => {
 				const gunzip = createGunzip();
@@ -5900,6 +5990,8 @@ export function getToolInstallStrategy(
  * "at least one platform" guard instead.
  */
 export const GITHUB_TOOLS = [
+	"cljfmt",
+	"php-cs-fixer",
 	"shellcheck",
 	"shfmt",
 	"rust-analyzer",
@@ -5939,6 +6031,17 @@ export function resolveGitHubAsset(
 ): string | undefined {
 	const tool = TOOLS.find((t) => t.id === toolId);
 	return tool?.github?.assetMatch(platform, arch);
+}
+
+export function resolveGitHubAssetLauncher(
+	toolId: string,
+	_platform: string,
+	assetName: string,
+): "php" | "java" | undefined {
+	const tool = TOOLS.find((t) => t.id === toolId);
+	return tool?.github
+		? launcherForGitHubAsset(tool.github, assetName)
+		: undefined;
 }
 
 export function resolveGitHubInstalledBinaryName(

--- a/scripts/smoke-tools.d.mts
+++ b/scripts/smoke-tools.d.mts
@@ -63,6 +63,13 @@ export interface FormatResult {
 	error?: string;
 	outcome: "formatted" | "unchanged" | "skipped" | "unavailable" | "failed";
 }
+/** Run the production Format smoke layer, optionally with injected seams. */
+export function runFormatSmoke(options: {
+	langs: string[];
+	install: boolean;
+	verbose: boolean;
+	deps?: unknown;
+}): Promise<number>;
 export interface FormatRowVerdict {
 	status: "pass" | "skip" | "fail";
 	detail: string;

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -264,7 +264,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/go",
 		file: "bad.go",
 		targets: ["go-vet"],
-		tools: [],
+		tools: ["black"],
 		expectDiagnostic: true,
 	},
 	{
@@ -272,7 +272,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/powershell",
 		file: "bad.ps1",
 		targets: ["psscriptanalyzer"],
-		tools: [],
+		tools: ["cmake-format"],
 		expectDiagnostic: true,
 	},
 	{
@@ -280,7 +280,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/rust",
 		file: "src/main.rs",
 		targets: ["rust-clippy"],
-		tools: [],
+		tools: ["oxfmt"],
 		expectDiagnostic: true,
 	},
 	{
@@ -288,7 +288,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/csharp",
 		file: "Program.cs",
 		targets: ["dotnet-build"],
-		tools: [],
+		tools: ["stylua"],
 		expectDiagnostic: true,
 	},
 	{
@@ -296,7 +296,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/zig",
 		file: "bad.zig",
 		targets: ["zig-check"],
-		tools: [],
+		tools: ["cljfmt"],
 		expectDiagnostic: true,
 	},
 	{
@@ -304,7 +304,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/java",
 		file: "Bad.java",
 		targets: ["javac"],
-		tools: [],
+		tools: ["php-cs-fixer"],
 		expectDiagnostic: true,
 	},
 	{
@@ -312,7 +312,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/dart",
 		file: "bad.dart",
 		targets: ["dart-analyze"],
-		tools: [],
+		tools: ["google-java-format"],
 		expectDiagnostic: true,
 	},
 	{
@@ -1032,7 +1032,7 @@ const FORMAT_FIXTURES = [
 		dir: "tests/fixtures/format-smoke/python-black",
 		file: "messy.py",
 		formatter: "black",
-		tools: [],
+		tools: ["black"],
 	},
 	{
 		lang: "ruby-standard",
@@ -1046,7 +1046,7 @@ const FORMAT_FIXTURES = [
 		dir: "tests/fixtures/format-smoke/cmake",
 		file: "messy.cmake",
 		formatter: "cmake-format",
-		tools: [],
+		tools: ["cmake-format"],
 	},
 	{
 		// oxfmt (the JS Oxidation Compiler formatter) is selected over biome via a
@@ -1056,7 +1056,7 @@ const FORMAT_FIXTURES = [
 		dir: "tests/fixtures/format-smoke/js-oxfmt",
 		file: "messy.js",
 		formatter: "oxfmt",
-		tools: [],
+		tools: ["oxfmt"],
 	},
 	// Standalone-binary formatters (no language runtime needed) — each fixture
 	// ships the config its detect() requires (stylua.toml / .cljfmt.edn /
@@ -1066,7 +1066,7 @@ const FORMAT_FIXTURES = [
 		dir: "tests/fixtures/format-smoke/lua",
 		file: "messy.lua",
 		formatter: "stylua",
-		tools: [],
+		tools: ["stylua"],
 	},
 	{
 		lang: "haskell",
@@ -1080,21 +1080,21 @@ const FORMAT_FIXTURES = [
 		dir: "tests/fixtures/format-smoke/clojure",
 		file: "messy.clj",
 		formatter: "cljfmt",
-		tools: [],
+		tools: ["cljfmt"],
 	},
 	{
 		lang: "php",
 		dir: "tests/fixtures/format-smoke/php",
 		file: "messy.php",
 		formatter: "php-cs-fixer",
-		tools: [],
+		tools: ["php-cs-fixer"],
 	},
 	{
 		lang: "java-gjf",
 		dir: "tests/fixtures/format-smoke/java-gjf",
 		file: "Messy.java",
 		formatter: "google-java-format",
-		tools: [],
+		tools: ["google-java-format"],
 	},
 	{
 		lang: "cpp",
@@ -2136,6 +2136,7 @@ async function runFormatSmoke({ langs, install, verbose }) {
 	const formatService = getFormatService();
 
 	let ensureTool;
+	let getInstallAttempt;
 	if (install) {
 		const installerEntry = path.join(
 			repoRoot,
@@ -2144,7 +2145,9 @@ async function runFormatSmoke({ langs, install, verbose }) {
 			"installer",
 			"index.js",
 		);
-		({ ensureTool } = await import(pathToFileURL(installerEntry).href));
+		({ ensureTool, getInstallAttempt } = await import(
+			pathToFileURL(installerEntry).href
+		));
 	}
 
 	const selected = langs.length
@@ -2157,16 +2160,18 @@ async function runFormatSmoke({ langs, install, verbose }) {
 
 	const rows = [];
 	for (const fx of selected) {
-		if (install && ensureTool) {
-			for (const toolId of fx.tools ?? []) {
-				const resolved = await ensureTool(toolId);
+		await ensureFixtureTools(
+			install ? (fx.tools ?? []) : [],
+			ensureTool,
+			getInstallAttempt,
+			(toolId, resolved) => {
 				if (verbose) {
 					console.error(
 						`[${fx.lang}] ensureTool(${toolId}) → ${resolved ?? "UNAVAILABLE"}`,
 					);
 				}
-			}
-		}
+			},
+		);
 		const workspace = copyDirToTemp(fx.dir);
 		const absFile = path.join(workspace, fx.file);
 		const push = (state, detail) =>

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -264,7 +264,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/go",
 		file: "bad.go",
 		targets: ["go-vet"],
-		tools: ["black"],
+		tools: [],
 		expectDiagnostic: true,
 	},
 	{
@@ -272,7 +272,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/powershell",
 		file: "bad.ps1",
 		targets: ["psscriptanalyzer"],
-		tools: ["cmake-format"],
+		tools: [],
 		expectDiagnostic: true,
 	},
 	{
@@ -280,7 +280,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/rust",
 		file: "src/main.rs",
 		targets: ["rust-clippy"],
-		tools: ["oxfmt"],
+		tools: [],
 		expectDiagnostic: true,
 	},
 	{
@@ -288,7 +288,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/csharp",
 		file: "Program.cs",
 		targets: ["dotnet-build"],
-		tools: ["stylua"],
+		tools: [],
 		expectDiagnostic: true,
 	},
 	{
@@ -296,7 +296,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/zig",
 		file: "bad.zig",
 		targets: ["zig-check"],
-		tools: ["cljfmt"],
+		tools: [],
 		expectDiagnostic: true,
 	},
 	{
@@ -304,7 +304,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/java",
 		file: "Bad.java",
 		targets: ["javac"],
-		tools: ["php-cs-fixer"],
+		tools: [],
 		expectDiagnostic: true,
 	},
 	{
@@ -312,7 +312,7 @@ const FIXTURES = [
 		dir: "tests/fixtures/tool-smoke/dart",
 		file: "bad.dart",
 		targets: ["dart-analyze"],
-		tools: ["google-java-format"],
+		tools: [],
 		expectDiagnostic: true,
 	},
 	{
@@ -2124,16 +2124,17 @@ async function runLspHandshake({ langs, install, verbose }) {
  * sqlfluff fix, biome, dart …), so this also covers the safe-autofix path.
  * Returns the failure count.
  */
-async function runFormatSmoke({ langs, install, verbose }) {
+export async function runFormatSmoke({ langs, install, verbose, deps }) {
 	const fmtEntry = path.join(repoRoot, "dist", "clients", "format-service.js");
-	if (!fs.existsSync(fmtEntry)) {
+	if (!deps && !fs.existsSync(fmtEntry)) {
 		console.error(
 			`dist build missing: ${fmtEntry}\nRun \`npm run build:dist\` first.`,
 		);
 		process.exit(2);
 	}
-	const { getFormatService } = await import(pathToFileURL(fmtEntry).href);
-	const formatService = getFormatService();
+	const formatService = deps?.getFormatService
+		? deps.getFormatService()
+		: (await import(pathToFileURL(fmtEntry).href)).getFormatService();
 
 	let ensureTool;
 	let getInstallAttempt;
@@ -2145,9 +2146,13 @@ async function runFormatSmoke({ langs, install, verbose }) {
 			"installer",
 			"index.js",
 		);
-		({ ensureTool, getInstallAttempt } = await import(
-			pathToFileURL(installerEntry).href
-		));
+		if (deps) {
+			({ ensureTool, getInstallAttempt } = deps);
+		} else {
+			({ ensureTool, getInstallAttempt } = await import(
+				pathToFileURL(installerEntry).href
+			));
+		}
 	}
 
 	const selected = langs.length
@@ -2165,6 +2170,7 @@ async function runFormatSmoke({ langs, install, verbose }) {
 			ensureTool,
 			getInstallAttempt,
 			(toolId, resolved) => {
+				deps?.onEnsure?.(toolId, resolved);
 				if (verbose) {
 					console.error(
 						`[${fx.lang}] ensureTool(${toolId}) → ${resolved ?? "UNAVAILABLE"}`,

--- a/tests/clients/formatter-unavailable-outcome.test.ts
+++ b/tests/clients/formatter-unavailable-outcome.test.ts
@@ -69,7 +69,12 @@ describe("formatFile classifies an unavailable tool distinctly from a failure (#
 
 	it("real oxfmt with no executable resolves to unavailable, never spawning oxfmt", async () => {
 		const env = setupTestEnvironment("pi-lens-unavail-oxfmt-");
+		const originalPath = process.env.PATH;
 		try {
+			// getToolPath also checks PATH without using the mocked which seam.
+			// Pin that independent input so npm's script-local node_modules/.bin
+			// prefix cannot turn this absence case into a formatter spawn on CI.
+			process.env.PATH = path.join(env.tmpDir, "empty-bin");
 			const filePath = path.join(env.tmpDir, "a.ts");
 			fs.writeFileSync(filePath, "const x=1\n");
 
@@ -84,6 +89,8 @@ describe("formatFile classifies an unavailable tool distinctly from a failure (#
 			// A which-probe is allowed; a FORMAT spawn of oxfmt is not.
 			expect(formatSpawns()).toEqual([]);
 		} finally {
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
 			env.cleanup();
 		}
 	});
@@ -114,8 +121,12 @@ describe("formatFile classifies an unavailable tool distinctly from a failure (#
 
 		const originalHome = process.env.HOME;
 		const originalUserProfile = process.env.USERPROFILE;
+		const originalPath = process.env.PATH;
 		process.env.HOME = fakeHome;
 		process.env.USERPROFILE = fakeHome;
+		// Pin the installer's independent PATH leg as well as HOME. The test
+		// mocks which(), but npm test prepends the repository bin to PATH.
+		process.env.PATH = path.join(fakeHome, "empty-bin");
 		try {
 			const { formatFile, oxfmtFormatter } = await loadFormatters();
 			const result = await formatFile(filePath, oxfmtFormatter);
@@ -129,6 +140,8 @@ describe("formatFile classifies an unavailable tool distinctly from a failure (#
 			else process.env.HOME = originalHome;
 			if (originalUserProfile === undefined) delete process.env.USERPROFILE;
 			else process.env.USERPROFILE = originalUserProfile;
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
 			env.cleanup();
 		}
 	});

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -21,8 +21,11 @@ import {
 	SKIP_FORMATTING,
 	biomeFormatter,
 	blackFormatter,
+	cmakeFormatFormatter,
+	cljfmtFormatter,
 	clearFormatterRuntimeState,
 	getFormattersForFile,
+	googleJavaFormatFormatter,
 	invalidateFormatterCacheForPath,
 	oxfmtFormatter,
 	phpCsFixerFormatter,
@@ -33,6 +36,7 @@ import {
 	ruffFormatter,
 	standardrbFormatter,
 	shfmtFormatter,
+	styluaFormatter,
 } from "../../clients/formatters.js";
 import { createTempFile, setupTestEnvironment } from "./test-utils.js";
 import { _getSpotlessGradleReadCountForTests } from "../../clients/tool-policy.js";
@@ -179,6 +183,48 @@ describe("resolveCommand — node_modules/.bin", () => {
 			SKIP_FORMATTING,
 		);
 	});
+});
+
+describe("resolveCommand — PATH precedes managed formatter (#2767)", () => {
+	it.each([
+		["black", blackFormatter, "main.py"],
+		["cmake-format", cmakeFormatFormatter, "CMakeLists.cmake"],
+		["stylua", styluaFormatter, "main.lua"],
+		["google-java-format", googleJavaFormatFormatter, "Main.java"],
+		["cljfmt", cljfmtFormatter, "main.clj"],
+		["oxfmt", oxfmtFormatter, "main.ts"],
+		["php-cs-fixer", phpCsFixerFormatter, "main.php"],
+	] as const)(
+		"uses PATH %s before a managed copy",
+		async (toolId, formatter, fileName) => {
+			const pathDir = path.join(tmpDir, "path-bin");
+			const pathBinary = path.join(pathDir, isWin ? `${toolId}.cmd` : toolId);
+			const managedBinary = path.join(
+				tmpDir,
+				"managed-bin",
+				isWin ? `${toolId}.exe` : toolId,
+			);
+			makeFakeExe(pathBinary);
+			makeFakeExe(managedBinary);
+			const originalPath = process.env.PATH;
+			process.env.PATH = `${pathDir}${path.delimiter}${originalPath ?? ""}`;
+			const installer = await import("../../clients/installer/index.js");
+			const managedSpy = vi
+				.spyOn(installer, "getToolPath")
+				.mockResolvedValue(managedBinary);
+			try {
+				const command = await formatter.resolveCommand!(
+					fileIn(tmpDir, fileName),
+					tmpDir,
+				);
+				expect(command?.[0]).toBe(pathBinary);
+				expect(managedSpy).not.toHaveBeenCalledWith(toolId);
+			} finally {
+				managedSpy.mockRestore();
+				process.env.PATH = originalPath;
+			}
+		},
+	);
 });
 
 describe("formatter child cwd", () => {

--- a/tests/clients/formatters.test.ts
+++ b/tests/clients/formatters.test.ts
@@ -227,6 +227,31 @@ describe("resolveCommand — PATH precedes managed formatter (#2767)", () => {
 	);
 });
 
+describe("managed formatter absence is typed (#2767)", () => {
+	it.each([
+		["black", blackFormatter, "main.py"],
+		["cmake-format", cmakeFormatFormatter, "CMakeLists.cmake"],
+		["stylua", styluaFormatter, "main.lua"],
+		["cljfmt", cljfmtFormatter, "main.clj"],
+		["php-cs-fixer", phpCsFixerFormatter, "main.php"],
+		["google-java-format", googleJavaFormatFormatter, "Main.java"],
+		["oxfmt", oxfmtFormatter, "main.ts"],
+	] as const)(
+		"returns formatter-unavailable for %s when every candidate is absent",
+		async (_toolId, formatter, fileName) => {
+			// #2767: a resolver that proved every candidate absent must not return
+			// null, because the generic fallback would spawn the missing bare command.
+			await withIsolatedPath(async () => {
+				const command = await formatter.resolveCommand!(
+					fileIn(tmpDir, fileName),
+					tmpDir,
+				);
+				expect(command).toBe("formatter-unavailable");
+			});
+		},
+	);
+});
+
 describe("formatter child cwd", () => {
 	it("uses the nearest project marker, not the file directory", () => {
 		const nestedDir = path.join(tmpDir, "src", "deep");
@@ -415,12 +440,12 @@ describe("resolveCommand — .venv", () => {
 		expect(cmd![1]).toBe(filePath);
 	});
 
-	it("black: returns null when no venv", async () => {
+	it("black: returns formatter-unavailable when no candidate resolves", async () => {
 		const cmd = await blackFormatter.resolveCommand!(
 			fileIn(tmpDir, "main.py"),
 			tmpDir,
 		);
-		expect(cmd).toBeNull();
+		expect(cmd).toBe("formatter-unavailable");
 	});
 });
 

--- a/tests/clients/installer/github-release.test.ts
+++ b/tests/clients/installer/github-release.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	GITHUB_TOOLS,
 	GitHubToolId,
+	resolveGitHubAssetLauncher,
 } from "../../../clients/installer/index.js";
 
 // Ensure the real installer module is used, not any mock registered by other test files
@@ -12,6 +13,20 @@ const SUPPORTED_PLATFORMS = ["linux", "darwin", "win32"] as const;
 const COMMON_ARCHES = ["x64", "arm64"] as const;
 
 describe("GitHub release asset selection", () => {
+	it.each([
+		["php-cs-fixer", "linux", "x64", "php-cs-fixer.phar", "php"],
+		["php-cs-fixer", "win32", "x64", "php-cs-fixer.phar", "php"],
+		["cljfmt", "darwin", "arm64", "standalone.jar", "java"],
+		["cljfmt", "linux", "arm64", "standalone.jar", "java"],
+		["cljfmt", "linux", "x64", "linux-amd64-static.tar.gz", undefined],
+	] as const)(
+		"maps %s %s/%s asset %s to launcher %s",
+		(toolId, platform, asset, launcher) => {
+			expect(resolveGitHubAssetLauncher(toolId, platform, asset)).toBe(
+				launcher,
+			);
+		},
+	);
 	it("every github tool has an asset for all supported platform/arch combos", async () => {
 		const { resolveGitHubAsset } =
 			await import("../../../clients/installer/index.js");

--- a/tests/clients/installer/github-release.test.ts
+++ b/tests/clients/installer/github-release.test.ts
@@ -21,7 +21,7 @@ describe("GitHub release asset selection", () => {
 		["cljfmt", "linux", "x64", "linux-amd64-static.tar.gz", undefined],
 	] as const)(
 		"maps %s %s/%s asset %s to launcher %s",
-		(toolId, platform, asset, launcher) => {
+		(toolId, platform, _arch, asset, launcher) => {
 			expect(resolveGitHubAssetLauncher(toolId, platform, asset)).toBe(
 				launcher,
 			);

--- a/tests/clients/installer/managed-tool-refresh.test.ts
+++ b/tests/clients/installer/managed-tool-refresh.test.ts
@@ -105,6 +105,7 @@ import type { ToolDefinition } from "../../../clients/installer/index.js";
 import {
 	checkProbeCache,
 	getRefreshableManagedNpmTools,
+	getInstallAttempt,
 	getToolPath,
 	installTool,
 	resetProbeCacheStateForTesting,
@@ -947,6 +948,45 @@ describe("the session counter records attempts (review F3)", () => {
 		await runManagedToolRefresh(NOW);
 
 		expect(managedToolRefreshesThisSession()).toBe(0);
+	});
+});
+
+describe("unsupported platform install outcomes", () => {
+	function withUnsupportedPlatform<T>(fn: () => Promise<T>): Promise<T> {
+		const originalPlatform = process.platform;
+		const originalArch = process.arch;
+		Object.defineProperty(process, "platform", { value: "freebsd" });
+		Object.defineProperty(process, "arch", { value: "x64" });
+		return fn().finally(() => {
+			Object.defineProperty(process, "platform", { value: originalPlatform });
+			Object.defineProperty(process, "arch", { value: originalArch });
+		});
+	}
+
+	it("records GitHub tools without a matching asset as unavailable", async () => {
+		// Regression: an unsupported GitHub platform must not become a retryable
+		// failed download after installGitHubTool returns undefined.
+		await withUnsupportedPlatform(async () => {
+			await expect(installTool("stylua")).resolves.toBe(false);
+		});
+
+		expect(getInstallAttempt("stylua")).toMatchObject({
+			outcome: "unavailable",
+			reason: "unsupported platform=freebsd arch=x64",
+		});
+	});
+
+	it("records archive tools without a matching URL as unavailable", async () => {
+		// Mutation proof: this catches a disabled unsupported-reason branch even
+		// though installArchiveTool itself also returns undefined.
+		await withUnsupportedPlatform(async () => {
+			await expect(installTool("clangd")).resolves.toBe(false);
+		});
+
+		expect(getInstallAttempt("clangd")).toMatchObject({
+			outcome: "unavailable",
+			reason: "unsupported platform=freebsd arch=x64",
+		});
 	});
 });
 

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -2190,7 +2190,10 @@ const HELPER_UNBOUNDED: Readonly<Record<string, number>> = {
 	"clients/file-time.ts": 1,
 	"clients/file-utils.ts": 1,
 	"clients/format-service.ts": 5,
-	"clients/formatters.ts": 115,
+	// #2767: managed formatter resolution adds 15 installer-path awaits. These
+	// use the installer's bounded probes and cannot receive hook signals until
+	// the existing formatter dependency seam is signal-aware.
+	"clients/formatters.ts": 130,
 	"clients/gitleaks-client.ts": 4,
 	"clients/govulncheck-client.ts": 6,
 	// 192 → 194 (#2722), in two steps, both registered rather than absorbed:

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -2190,10 +2190,9 @@ const HELPER_UNBOUNDED: Readonly<Record<string, number>> = {
 	"clients/file-time.ts": 1,
 	"clients/file-utils.ts": 1,
 	"clients/format-service.ts": 5,
-	// #2767: managed formatter resolution adds 15 installer-path awaits. These
-	// use the installer's bounded probes and cannot receive hook signals until
-	// the existing formatter dependency seam is signal-aware.
-	"clients/formatters.ts": 130,
+	// #2767: managed formatter resolution uses the installer's bounded probes;
+	// keep the measured count pinned until the formatter seam carries signals.
+	"clients/formatters.ts": 114,
 	"clients/gitleaks-client.ts": 4,
 	"clients/govulncheck-client.ts": 6,
 	// 192 → 194 (#2722), in two steps, both registered rather than absorbed:
@@ -2210,7 +2209,7 @@ const HELPER_UNBOUNDED: Readonly<Record<string, number>> = {
 	// budget and up to three attempts, so the hook path got shorter, not longer.
 	// Like every other entry here neither can take a hook's signal until #2523
 	// AC4 threads it through the deps types.
-	"clients/installer/index.ts": 194,
+	"clients/installer/index.ts": 197,
 	"clients/installer/managed-tool-refresh.ts": 29,
 	"clients/instance-reaper.ts": 26,
 	"clients/instance-registry.ts": 23,

--- a/tests/scripts/smoke-tools-format-install.test.ts
+++ b/tests/scripts/smoke-tools-format-install.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-	ensureFixtureTools,
 	FORMAT_FIXTURES,
+	FIXTURES,
+	runFormatSmoke,
 } from "../../scripts/smoke-tools.mjs";
 
 const MANAGED_FORMATTERS = [
@@ -20,20 +21,57 @@ describe("format smoke installer wiring", () => {
 		const getInstallAttempt = vi.fn();
 		const requests: string[] = [];
 
-		for (const formatter of MANAGED_FORMATTERS) {
-			const fixture = FORMAT_FIXTURES.find((fx) => fx.formatter === formatter);
-			expect(fixture, `${formatter} must have a format fixture`).toBeDefined();
-			await ensureFixtureTools(
-				fixture?.tools ?? [],
+		const result = await runFormatSmoke({
+			langs: [
+				"python-black",
+				"cmake",
+				"js-oxfmt",
+				"lua",
+				"clojure",
+				"php",
+				"java-gjf",
+			],
+			install: true,
+			verbose: false,
+			deps: {
 				ensureTool,
 				getInstallAttempt,
-				(toolId) => requests.push(toolId),
-			);
-		}
+				getFormatService: () => ({
+					recordRead: vi.fn(),
+					formatFile: vi.fn(async (filePath: string) => ({
+						formatters: [
+							{
+								name: FORMAT_FIXTURES.find((fx) => filePath.endsWith(fx.file))
+									?.formatter,
+								success: true,
+								changed: true,
+								outcome: "formatted",
+							},
+						],
+						anyChanged: true,
+						allSucceeded: true,
+					})),
+				}),
+				onEnsure: (toolId: string) => requests.push(toolId),
+			},
+		});
 
-		expect(requests).toEqual(MANAGED_FORMATTERS);
-		expect(ensureTool.mock.calls.map(([toolId]) => toolId)).toEqual(
-			MANAGED_FORMATTERS,
+		expect([...new Set(requests)].sort()).toEqual(
+			[...MANAGED_FORMATTERS].sort(),
 		);
+		expect(
+			[...new Set(ensureTool.mock.calls.map(([toolId]) => toolId))].sort(),
+		).toEqual([...MANAGED_FORMATTERS].sort());
+		expect(result).toBe(0);
+		const formatterTools = new Set(MANAGED_FORMATTERS);
+		const misplaced = FIXTURES.flatMap((fixture) =>
+			(fixture.tools ?? [])
+				.filter((toolId) => formatterTools.has(toolId))
+				.map((toolId) => `${fixture.lang}:${toolId}`),
+		);
+		expect(
+			misplaced,
+			"formatter installs belong only to FORMAT_FIXTURES",
+		).toEqual([]);
 	});
 });

--- a/tests/scripts/smoke-tools-format-install.test.ts
+++ b/tests/scripts/smoke-tools-format-install.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	ensureFixtureTools,
+	FORMAT_FIXTURES,
+} from "../../scripts/smoke-tools.mjs";
+
+const MANAGED_FORMATTERS = [
+	"black",
+	"cmake-format",
+	"stylua",
+	"cljfmt",
+	"php-cs-fixer",
+	"google-java-format",
+	"oxfmt",
+];
+
+describe("format smoke installer wiring", () => {
+	it("requests the managed tool for every selected managed formatter", async () => {
+		const ensureTool = vi.fn(async (toolId: string) => `/managed/${toolId}`);
+		const getInstallAttempt = vi.fn();
+		const requests: string[] = [];
+
+		for (const formatter of MANAGED_FORMATTERS) {
+			const fixture = FORMAT_FIXTURES.find((fx) => fx.formatter === formatter);
+			expect(fixture, `${formatter} must have a format fixture`).toBeDefined();
+			await ensureFixtureTools(
+				fixture?.tools ?? [],
+				ensureTool,
+				getInstallAttempt,
+				(toolId) => requests.push(toolId),
+			);
+		}
+
+		expect(requests).toEqual(MANAGED_FORMATTERS);
+		expect(ensureTool.mock.calls.map(([toolId]) => toolId)).toEqual(
+			MANAGED_FORMATTERS,
+		);
+	});
+});


### PR DESCRIPTION
## Round 5 — CI-only red

### Root cause and fix

The Unit tests job has no `PI_LENS_HOME`, `XDG_*`, or global install step. It
runs `npm install`, then `npm test`; npm prepends the repository's
`node_modules/.bin` to the child PATH. `package.json` declares `oxfmt`, so that
PATH contains a real `oxfmt` shim even though each test's mocked `which()`
returns `null`.

The temporary `getToolPath("oxfmt")` trace identified the returning leg:

```text
[getToolPath oxfmt] PATH candidate oxfmt: true
[getToolPath oxfmt] returning PATH candidate oxfmt
```

The PATH leg is legitimate production discovery and is independent of the
formatter module's mocked `which` seam. The fix pins that independent input in
both absence tests to an empty test-owned PATH directory and restores PATH in
`finally`. It does not change production PATH discovery or the deliberate
POSIX HOME-level local-bin case.

### Red and mutation evidence

With the temporary trace enabled in built output, a CI-shaped run used a fresh
HOME, `USERPROFILE`, `XDG_CONFIG_HOME`, and `XDG_CACHE_HOME`, and ran through
`npm test` so npm supplied its script-local PATH. Before the test pin, both
cases failed:

```text
Tests  2 failed | 9 passed (11)
AssertionError: expected 'failed' to be 'unavailable'
```

The trace above proves the PATH leg was re-enabled and returned the bare
command. This is the mutation red for the surviving CI path.

### Verification

- `PI_LENS_HOME=$PWD/.probe-home node_modules/.bin/vitest run tests/clients/formatter-unavailable-outcome.test.ts --configLoader runner`
  — 11 passed.
- `PI_LENS_HOME=$PWD/.probe-home node_modules/.bin/vitest run tests/clients/formatters.test.ts tests/clients/installer/ --configLoader runner`
  — 540 passed, 56 skipped.
- `PI_LENS_HOME=$PWD/.probe-home npm run lint` — passed.
- `PI_LENS_HOME=$PWD/.probe-home npm run build` — passed.

The pattern sweep found the shared installer PATH leg and no other formatter
absence test that mocks `which` while leaving npm's PATH prefix unpinned. The
population sweep covered all oxfmt absence cases in
`formatter-unavailable-outcome.test.ts`; the HOME drive-case test retains its
intentional POSIX PATH-independent local-bin assertion. The blast radius is
limited to those two test inputs; production callers of `getToolPath` are
unchanged.

The single changelog fragment is `.changelog/2767-format-smoke-managed-formatters.md`.
`CHANGELOG.md` is untouched. Changes remain uncommitted.

### Orchestrator note (round 5)

Root cause of the CI-only red: `npm test` prefixes PATH with `node_modules/.bin`, where the repo's dev-dependency `oxfmt` lives, so the installer's legitimate PATH leg returned it past the formatter module's mocked `which`. Fix is test-side pinning of PATH; production discovery is unchanged. The changelog fragment was folded to a single top-level entry (the fragment gate failed on ea52d38f with three bullets).
