### PR TITLE
ci(complexity): advisory complexity report over clients/, tools/ and mcp/ from pi-lens's own client (refs #2697)

### DIFF
--- a/.changelog/ci-2697-complexity-advisory.md
+++ b/.changelog/ci-2697-complexity-advisory.md
@@ -1,0 +1,4 @@
+---
+section: Added
+---
+- **`complexity (advisory)` CI job dogfoods pi-lens's own complexity client over `clients/`, `tools/` and `mcp/` (refs #2697)** — `npm run complexity` writes a Markdown report (top functions by cyclomatic/cognitive complexity, files over 1,000 lines, split candidates at the dispatch threshold of 15) to the step summary and an artifact; `ComplexityClient` now exposes the per-function metrics it already computed.

--- a/.changelog/ci-2697-complexity-advisory.md
+++ b/.changelog/ci-2697-complexity-advisory.md
@@ -1,4 +1,4 @@
 ---
 section: Added
 ---
-- **`complexity (advisory)` CI job dogfoods pi-lens's own complexity client over `clients/`, `tools/` and `mcp/` (refs #2697)** — `npm run complexity` writes a Markdown report (top functions by cyclomatic/cognitive complexity, files over 1,000 lines, split candidates at the dispatch threshold of 15) to the step summary and an artifact; `ComplexityClient` now exposes the per-function metrics it already computed.
+- **`complexity (advisory)` CI job dogfoods pi-lens's own complexity client over `clients/`, `tools/` and `mcp/` (refs #2697)** — `npm run complexity` writes a Markdown report (top functions by cyclomatic/cognitive complexity, files over 1,000 lines, split candidates at the dispatch threshold of 15) to the step summary and an artifact; `ComplexityClient` exposes the per-function metrics it already computes, uses the dispatch cyclomatic metric for JS/TS, and fails when analysis produces no files or throws.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -609,6 +609,37 @@ jobs:
       - name: Detect duplicated code
         run: node_modules/.bin/jscpd --config .jscpd.json clients scripts tools mcp index.ts
 
+  complexity:
+    name: complexity (advisory)
+    needs: validate-merge-train-dispatch
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.sha || github.ref }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - run: npm run build
+      - name: Generate complexity report
+        run: node scripts/complexity-report.mjs | tee complexity-report.txt
+      - name: Publish complexity report
+        if: always()
+        run: cat complexity-report.txt >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: complexity-report
+          path: reports/complexity/complexity.md
+          if-no-files-found: ignore
+
   yamllint:
     name: yamllint (advisory)
     needs: validate-merge-train-dispatch

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -627,6 +627,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts
+      - name: Download core tree-sitter grammars
+        run: node scripts/download-grammars.js --core --dest grammars
       - run: npm run build
       - name: Generate complexity report
         run: node scripts/complexity-report.mjs | tee complexity-report.txt

--- a/clients/complexity-client.ts
+++ b/clients/complexity-client.ts
@@ -45,6 +45,8 @@ export interface FileComplexity {
 	aiCommentPatterns: number;
 	singleUseFunctions: number;
 	tryCatchCount: number;
+	/** Per-function metrics used by advisory reports and model diagnostics. */
+	functions: FunctionMetrics[];
 }
 
 export interface FunctionMetrics {
@@ -568,6 +570,7 @@ export class ComplexityClient {
 			aiCommentPatterns: countAICommentPatterns(content),
 			singleUseFunctions: countSingleUseFunctions(functions),
 			tryCatchCount: countTryCatch(root, nodes),
+			functions,
 		};
 	}
 

--- a/clients/complexity-client.ts
+++ b/clients/complexity-client.ts
@@ -265,7 +265,8 @@ function isLogicalOp(node: TsNode, nodes: LangNodes): boolean {
 
 /** Cyclomatic contribution of a subtree: decision points + logical operators. */
 function subtreeCyclomatic(root: TsNode, nodes: LangNodes): number {
-	if (nodes === JSTS) return calcCyclomaticComplexity(root);
+	// Dispatch uses 1-based McCabe; this client exposes 0-based contributions (#2697).
+	if (nodes === JSTS) return calcCyclomaticComplexity(root) - 1;
 	let cc = 0;
 	walk(root, (n) => {
 		if (nodes.decision.has(n.type)) cc++;

--- a/clients/complexity-client.ts
+++ b/clients/complexity-client.ts
@@ -14,6 +14,7 @@
 import { createSubsystemLogger } from "./extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { calcCyclomaticComplexity } from "./dispatch/facts/function-facts.js";
 import {
 	firstChildOfType,
 	withTreeSitterRoot,
@@ -264,6 +265,7 @@ function isLogicalOp(node: TsNode, nodes: LangNodes): boolean {
 
 /** Cyclomatic contribution of a subtree: decision points + logical operators. */
 function subtreeCyclomatic(root: TsNode, nodes: LangNodes): number {
+	if (nodes === JSTS) return calcCyclomaticComplexity(root);
 	let cc = 0;
 	walk(root, (n) => {
 		if (nodes.decision.has(n.type)) cc++;

--- a/clients/dispatch/facts/function-facts.ts
+++ b/clients/dispatch/facts/function-facts.ts
@@ -221,7 +221,7 @@ function isCallPassThrough(
 	return { pass: true, target: (expr.children ?? [])[0]?.text };
 }
 
-function calcCyclomaticComplexity(body: TsNode): number {
+export function calcCyclomaticComplexity(body: TsNode): number {
 	let cc = 1;
 	walk(body, (node) => {
 		if (COMPLEXITY_TYPES.has(node.type)) {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"bench:cascade-budget": "node scripts/bench-cascade-budget.mjs",
 		"bench:word-index-replacement": "node scripts/bench-word-index-replacement.mjs",
 		"logs:smells": "node scripts/analyze-pi-lens-logs.mjs",
+		"complexity": "node scripts/complexity-report.mjs",
 		"changelog:check": "node scripts/rollup-changelog.mjs --check",
 		"changelog:release": "node scripts/changelog-release.mjs",
 		"changelog:extract": "node scripts/changelog-extract.mjs",

--- a/scripts/complexity-report.d.mts
+++ b/scripts/complexity-report.d.mts
@@ -20,6 +20,7 @@ export interface ComplexityFileResult {
 
 export declare const COMPLEXITY_FUNCTION_THRESHOLD: number;
 export declare const COMPLEXITY_FILE_SIZE_THRESHOLD: number;
+export declare function requireAnalyzedFiles(results: unknown[]): void;
 export declare function shapeComplexityReport(
 	results: ComplexityFileResult[],
 	options?: {

--- a/scripts/complexity-report.d.mts
+++ b/scripts/complexity-report.d.mts
@@ -1,0 +1,30 @@
+export interface ComplexityFunctionResult {
+	name: string;
+	line: number;
+	length: number;
+	cyclomatic: number;
+	cognitive: number;
+	nestingDepth: number;
+	filePath?: string;
+}
+
+export interface ComplexityFileResult {
+	filePath: string;
+	linesOfCode: number;
+	maxCyclomaticComplexity: number;
+	cognitiveComplexity: number;
+	functionCount: number;
+	lineCount?: number;
+	functions?: ComplexityFunctionResult[];
+}
+
+export declare const COMPLEXITY_FUNCTION_THRESHOLD: number;
+export declare const COMPLEXITY_FILE_SIZE_THRESHOLD: number;
+export declare function shapeComplexityReport(
+	results: ComplexityFileResult[],
+	options?: {
+		topN?: number;
+		fileSizeThreshold?: number;
+		functionThreshold?: number;
+	},
+): string;

--- a/scripts/complexity-report.mjs
+++ b/scripts/complexity-report.mjs
@@ -4,6 +4,11 @@ import { resolve } from "node:path";
 export const COMPLEXITY_FUNCTION_THRESHOLD = 15;
 export const COMPLEXITY_FILE_SIZE_THRESHOLD = 1000;
 
+export function requireAnalyzedFiles(results) {
+	if (results.length === 0)
+		throw new Error("complexity analysis produced zero analyzed files");
+}
+
 export function shapeComplexityReport(results, options = {}) {
 	const topN = options.topN ?? 20;
 	const files = results
@@ -109,6 +114,7 @@ async function main() {
 				lineCount: (await readFile(file, "utf8")).split(/\r?\n/).length - 1,
 			});
 	}
+	requireAnalyzedFiles(results);
 	const report = shapeComplexityReport(results, {
 		topN: Number(process.env.COMPLEXITY_TOP_N) || 20,
 	});
@@ -135,6 +141,6 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 				),
 			)
 			.catch(() => {});
-		process.exitCode = 0;
+		process.exitCode = 1;
 	});
 }

--- a/scripts/complexity-report.mjs
+++ b/scripts/complexity-report.mjs
@@ -1,0 +1,140 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+export const COMPLEXITY_FUNCTION_THRESHOLD = 15;
+export const COMPLEXITY_FILE_SIZE_THRESHOLD = 1000;
+
+export function shapeComplexityReport(results, options = {}) {
+	const topN = options.topN ?? 20;
+	const files = results
+		.filter(Boolean)
+		.toSorted(
+			(a, b) =>
+				b.maxCyclomaticComplexity - a.maxCyclomaticComplexity ||
+				(b.lineCount ?? b.linesOfCode) - (a.lineCount ?? a.linesOfCode) ||
+				a.filePath.localeCompare(b.filePath),
+		);
+	const functions = results
+		.flatMap((file) =>
+			(file.functions ?? []).map((fn) => ({ ...fn, filePath: file.filePath })),
+		)
+		.toSorted(
+			(a, b) =>
+				b.cyclomatic - a.cyclomatic ||
+				b.cognitive - a.cognitive ||
+				b.length - a.length ||
+				a.filePath.localeCompare(b.filePath) ||
+				a.line - b.line,
+		);
+	const splitFiles = files.filter(
+		(file) =>
+			(file.lineCount ?? file.linesOfCode) >
+			(options.fileSizeThreshold ?? COMPLEXITY_FILE_SIZE_THRESHOLD),
+	);
+	const splitFunctions = functions.filter(
+		(fn) =>
+			fn.cyclomatic >=
+			(options.functionThreshold ?? COMPLEXITY_FUNCTION_THRESHOLD),
+	);
+	const lines = [
+		"# Complexity report",
+		"",
+		`Advisory thresholds: files over ${options.fileSizeThreshold ?? COMPLEXITY_FILE_SIZE_THRESHOLD} lines; functions at or above cyclomatic complexity ${options.functionThreshold ?? COMPLEXITY_FUNCTION_THRESHOLD}. Metrics come from pi-lens's ComplexityClient.`,
+		"",
+		"## Top functions",
+		"",
+		"| Function | File:line | Cyclomatic | Cognitive | Length | Nesting |",
+		"|---|---:|---:|---:|---:|---:|",
+		...functions
+			.slice(0, topN)
+			.map(
+				(fn) =>
+					`| ${fn.name} | ${fn.filePath}:${fn.line} | ${fn.cyclomatic} | ${fn.cognitive} | ${fn.length} | ${fn.nestingDepth} |`,
+			),
+		"",
+		"## Top files",
+		"",
+		"| File | Lines | Max cyclomatic | Cognitive | Functions |",
+		"|---|---:|---:|---:|---:|",
+		...files
+			.slice(0, topN)
+			.map(
+				(file) =>
+					`| ${file.filePath} | ${file.lineCount ?? file.linesOfCode} | ${file.maxCyclomaticComplexity} | ${file.cognitiveComplexity} | ${file.functionCount} |`,
+			),
+		"",
+		"## Split candidates",
+		"",
+		...splitFiles.map(
+			(file) =>
+				`- **File:** \`${file.filePath}\` (${file.lineCount ?? file.linesOfCode} lines)`,
+		),
+		...splitFunctions.map(
+			(fn) =>
+				`- **Function:** \`${fn.name}\` at \`${fn.filePath}:${fn.line}\` (cyclomatic ${fn.cyclomatic})`,
+		),
+		...(splitFiles.length === 0 && splitFunctions.length === 0
+			? ["- None identified."]
+			: []),
+		"",
+	];
+	return lines.join("\n");
+}
+
+async function sourceFiles(root) {
+	const found = [];
+	async function visit(dir) {
+		for (const entry of await readdir(dir, { withFileTypes: true })) {
+			const path = resolve(dir, entry.name);
+			if (entry.isDirectory()) await visit(path);
+			else if (/\.(ts|tsx)$/.test(entry.name) && !entry.name.endsWith(".d.ts"))
+				found.push(path);
+		}
+	}
+	for (const dir of ["clients", "tools", "mcp"])
+		await visit(resolve(root, dir));
+	return found;
+}
+
+async function main() {
+	const root = resolve(import.meta.dirname, "..");
+	const { ComplexityClient } = await import("../clients/complexity-client.js");
+	const client = new ComplexityClient();
+	const results = [];
+	for (const file of await sourceFiles(root)) {
+		const result = await client.analyzeFile(file);
+		if (result)
+			results.push({
+				...result,
+				lineCount: (await readFile(file, "utf8")).split(/\r?\n/).length - 1,
+			});
+	}
+	const report = shapeComplexityReport(results, {
+		topN: Number(process.env.COMPLEXITY_TOP_N) || 20,
+	});
+	const output = resolve(root, "reports/complexity/complexity.md");
+	await mkdir(resolve(root, "reports/complexity"), { recursive: true });
+	await writeFile(output, report);
+	process.stdout.write(report);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((error) => {
+		console.error(`complexity advisory unavailable: ${error.message}`);
+		const output = resolve(
+			import.meta.dirname,
+			"../reports/complexity/complexity.md",
+		);
+		mkdir(resolve(import.meta.dirname, "../reports/complexity"), {
+			recursive: true,
+		})
+			.then(() =>
+				writeFile(
+					output,
+					"# Complexity report\n\nAnalysis unavailable in this run.\n",
+				),
+			)
+			.catch(() => {});
+		process.exitCode = 0;
+	});
+}

--- a/scripts/lib/ci-checks.mjs
+++ b/scripts/lib/ci-checks.mjs
@@ -46,6 +46,7 @@ export const ADVISORY_CHECKS = new Set([
 	"typos (advisory)",
 	"taplo (advisory)",
 	"mutation (advisory)",
+	"complexity (advisory)",
 	// .github/workflows/greetings.yml's `greeting` job (the job KEY -- no
 	// `name:` override), posted by `actions/first-interaction` on
 	// `pull_request_target: types: [opened]` only. A cosmetic

--- a/tests/clients/complexity-client.test.ts
+++ b/tests/clients/complexity-client.test.ts
@@ -28,6 +28,17 @@ describe("ComplexityClient.isSupportedFile", () => {
 });
 
 describe("ComplexityClient.analyzeFile — JS/TS", () => {
+	it("keeps JS/TS cyclomatic contributions zero-based", async () => {
+		const noDecision = await analyze("no-decision.ts", "function f() { return 1; }\n");
+		const oneDecision = await analyze(
+			"one-decision.ts",
+			"function f(n: number) { if (n) return 1; return 0; }\n",
+		);
+
+		expect(noDecision!.functions[0]?.cyclomatic).toBe(0);
+		expect(oneDecision!.functions[0]?.cyclomatic).toBe(1);
+	});
+
 	it("computes cyclomatic / cognitive / nesting / MI for a TS function", async () => {
 		const m = await analyze(
 			"a.ts",

--- a/tests/config/advisory-tool-workflow.test.ts
+++ b/tests/config/advisory-tool-workflow.test.ts
@@ -24,6 +24,7 @@ const mutationWorkflow = yaml.load(
 ) as { jobs: Record<string, { name?: string; "continue-on-error"?: boolean }> };
 
 const tools = [
+	["complexity", "complexity (advisory)"],
 	["jscpd", "jscpd (advisory)"],
 	["yamllint", "yamllint (advisory)"],
 	["typos", "typos (advisory)"],
@@ -55,6 +56,23 @@ describe("#2706 advisory tooling workflow contracts", () => {
 		const job = workflow.jobs[key];
 		expect(job?.name).toBe(name);
 		expect(job?.["continue-on-error"]).toBe(true);
+	});
+
+	it("keeps complexity wired to the report, summary, and pinned upload", () => {
+		const raw = readFileSync(
+			resolve(ROOT, ".github/workflows/lint.yml"),
+			"utf8",
+		);
+		const start = raw.indexOf("  complexity:");
+		const next = raw.slice(start + 1).search(/^  [A-Za-z0-9_-]+:/m);
+		const block = raw.slice(start, next === -1 ? undefined : start + 1 + next);
+		expect(block).toContain("npm run build");
+		expect(block).toContain("node scripts/complexity-report.mjs");
+		expect(block).toContain('>> \"$GITHUB_STEP_SUMMARY\"');
+		expect(block).toContain("path: reports/complexity/complexity.md");
+		expect(block).toMatch(
+			/actions\/upload-artifact@[0-9a-f]{40} # v\d+\.\d+\.\d+/,
+		);
 	});
 
 	it("pins every action in the four jobs to a full SHA with a release comment", () => {

--- a/tests/scripts/ci-verdict.test.ts
+++ b/tests/scripts/ci-verdict.test.ts
@@ -993,6 +993,7 @@ describe("isAdvisoryCheck — every job name from a PR-triggered workflow is cla
 		"typos (advisory)",
 		"taplo (advisory)",
 		"mutation (advisory)",
+		"complexity (advisory)",
 		"greeting",
 		// #2700 review round 3: named "oxlint (advisory)" (the `(advisory)`
 		// suffix, not a hand-maintained ci-checks.mjs entry like `greeting`
@@ -1093,6 +1094,7 @@ describe("isAdvisoryCheck — every job name from a PR-triggered workflow is cla
 				"typos (advisory)",
 				"taplo (advisory)",
 				"mutation (advisory)",
+				"complexity (advisory)",
 			]),
 		);
 	});

--- a/tests/scripts/complexity-report.test.ts
+++ b/tests/scripts/complexity-report.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { shapeComplexityReport } from "../../scripts/complexity-report.mjs";
+
+describe("complexity report shaper", () => {
+	it("orders metrics and identifies file/function split candidates", () => {
+		const report = shapeComplexityReport([
+			{
+				filePath: "clients/small.ts",
+				linesOfCode: 20,
+				maxCyclomaticComplexity: 16,
+				cognitiveComplexity: 9,
+				functionCount: 1,
+				functions: [
+					{
+						name: "hard",
+						line: 4,
+						length: 8,
+						cyclomatic: 16,
+						cognitive: 9,
+						nestingDepth: 2,
+					},
+				],
+			},
+			{
+				filePath: "clients/tree-sitter-client.ts",
+				linesOfCode: 1200,
+				maxCyclomaticComplexity: 8,
+				cognitiveComplexity: 30,
+				functionCount: 1,
+				functions: [
+					{
+						name: "wide",
+						line: 40,
+						length: 100,
+						cyclomatic: 8,
+						cognitive: 20,
+						nestingDepth: 4,
+					},
+				],
+			},
+			{
+				filePath: "clients/quiet.ts",
+				linesOfCode: 10,
+				maxCyclomaticComplexity: 2,
+				cognitiveComplexity: 1,
+				functionCount: 1,
+				functions: [
+					{
+						name: "quiet",
+						line: 1,
+						length: 2,
+						cyclomatic: 2,
+						cognitive: 1,
+						nestingDepth: 1,
+					},
+				],
+			},
+		]);
+		expect(report.indexOf("hard")).toBeLessThan(report.indexOf("wide"));
+		expect(report).toContain("clients/tree-sitter-client.ts:40");
+		expect(report).toContain(
+			"- **File:** `clients/tree-sitter-client.ts` (1200 lines)",
+		);
+		expect(report).toContain("- **Function:** `hard` at `clients/small.ts:4`");
+		expect(report).not.toContain("Function: `wide`");
+	});
+});

--- a/tests/scripts/complexity-report.test.ts
+++ b/tests/scripts/complexity-report.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { shapeComplexityReport } from "../../scripts/complexity-report.mjs";
+import {
+	requireAnalyzedFiles,
+	shapeComplexityReport,
+} from "../../scripts/complexity-report.mjs";
 
 describe("complexity report shaper", () => {
 	it("orders metrics and identifies file/function split candidates", () => {
@@ -63,5 +66,36 @@ describe("complexity report shaper", () => {
 		);
 		expect(report).toContain("- **Function:** `hard` at `clients/small.ts:4`");
 		expect(report).not.toContain("Function: `wide`");
+	});
+
+	it("treats a function at the dispatch threshold as a split candidate", () => {
+		const report = shapeComplexityReport([
+			{
+				filePath: "clients/boundary.ts",
+				linesOfCode: 20,
+				maxCyclomaticComplexity: 15,
+				cognitiveComplexity: 1,
+				functionCount: 1,
+				functions: [
+					{
+						name: "boundary",
+						line: 1,
+						length: 4,
+						cyclomatic: 15,
+						cognitive: 1,
+						nestingDepth: 1,
+					},
+				],
+			},
+		]);
+		expect(report).toContain(
+			"- **Function:** `boundary` at `clients/boundary.ts:1` (cyclomatic 15)",
+		);
+	});
+
+	it("rejects a report with zero analyzed files", () => {
+		expect(() => requireAnalyzedFiles([])).toThrow(
+			"complexity analysis produced zero analyzed files",
+		);
 	});
 });


### PR DESCRIPTION
## Round 3

### Summary

Keep the JS/TS complexity client’s cyclomatic contribution zero-based while
the shared dispatch helper remains 1-based McCabe complexity (refs #2697).

### Tests

- Added `tests/clients/complexity-client.test.ts` coverage for no-decision and
  one-`if` JS/TS functions through the real `ComplexityClient` seam.
- Pre-fix red with core grammars available: `expected 1 to be +0`; the existing
  complexity case also reported `expected 6 to be 5`.
- Mutation red after removing `- 1` from built output: `expected 1 to be +0`.
- Green: `npm run build`; targeted complexity suites, 24 tests passed.

### Blast radius

`collectFunctionMetrics` → `subtreeCyclomatic` → `calcCyclomaticComplexity`.
Only JS/TS per-function complexity changes; Python, Go, Rust, dispatch facts,
and aggregate baseline behavior remain unchanged.

### Observability

The existing per-function metrics and complexity report expose the corrected
value. No new failure path or telemetry record is introduced.

Grammar download was attempted with `node scripts/download-grammars.js --core
--dest grammars` but the sandbox had no network access. The test was completed
with the pinned core grammar cache already present in a sibling checkout.
