### PR TITLE
fix(lsp): reclassify pull-declaring servers that only push (refs #2776)

### DIFF
--- a/.changelog/2776-lsp-push-observation.md
+++ b/.changelog/2776-lsp-push-observation.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Reclassify pull-declaring servers that only push (refs #2776)** — Keep `publishDiagnostics` results when a server declares pull diagnostics but delivers diagnostics through push notifications.

--- a/.changelog/2776-lsp-push-observation.md
+++ b/.changelog/2776-lsp-push-observation.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Reclassify pull-declaring servers that only push (refs #2776)** — Keep `publishDiagnostics` results when a server declares pull diagnostics but delivers diagnostics through push notifications.
+- **Keep pull capability until unavailable and reconcile late pushes (refs #2776)** — Treat `publishDiagnostics` as observed-channel telemetry, keep pull capability for both-channel servers, demote only after a pull is proven unavailable, and let a diagnostic push supersede a provisional empty pull.

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -1065,6 +1065,8 @@ export interface LSPClientState {
 	projectIdentityProbedFiles?: Set<string>;
 	/** Mutable: updated by applyDynamicCapabilities after registerCapability events */
 	workspaceDiagnosticsSupport: LSPWorkspaceDiagnosticsSupport;
+	/** Effective diagnostics channel observed during this client session. */
+	observedDiagnosticsChannel?: "push";
 	/** Mutable: upgraded by applyDynamicCapabilities after registerCapability events */
 	operationSupport: LSPOperationSupport;
 	/** #1971: parsed `FileOperationRegistrationOptions` filters from initialize —
@@ -2174,7 +2176,7 @@ export function applyDynamicCapabilities(state: LSPClientState): void {
 	if (hasDynamicPull) {
 		state.workspaceDiagnosticsSupport = {
 			advertised: true,
-			mode: "pull",
+			mode: state.observedDiagnosticsChannel === "push" ? "push-only" : "pull",
 			// #1667: workspace-pull support is what the REGISTRATION declares. The
 			// spec registers workspace pull as `registerOptions.workspaceDiagnostics`
 			// on a `textDocument/diagnostic` registration - `workspace/diagnostic` is
@@ -2268,6 +2270,23 @@ export function setupIncomingHandlers(
 			// that is no longer open on this client.
 			if (state.closedDocuments?.has(normalizedPath)) return;
 			onDiagnosticsPublished?.(state.serverId);
+			if (state.workspaceDiagnosticsSupport.mode === "pull") {
+				// A declaration is only a promise of pull support. If this live
+				// session publishes first, its effective channel is push; keeping the
+				// declared pull mode would wait for an answer that never arrives and
+				// could turn an empty pull timeout into a clean result (#2776).
+				recordDegradationOnce({
+					kind: "lsp-capability-skip",
+					subject: `${state.serverId}:diagnostics-channel`,
+					reason:
+						"declared=pull observed=push; using published diagnostics for this session",
+				});
+				state.observedDiagnosticsChannel = "push";
+				state.workspaceDiagnosticsSupport = {
+					...state.workspaceDiagnosticsSupport,
+					mode: "push-only",
+				};
+			}
 			const newDiags = normalizeLspDiagnostics(params.diagnostics || []);
 			const docVersion = params.version;
 			if (PUB_DEBUG) {

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -398,6 +398,8 @@ export interface LSPClientInfo {
 	getTrackedDiagnosticPaths(): string[];
 	/** Capability snapshot for workspace diagnostics support */
 	getWorkspaceDiagnosticsSupport(): LSPWorkspaceDiagnosticsSupport;
+	/** Effective diagnostics channel observed during this client session. */
+	getObservedDiagnosticsChannel(): "push" | undefined;
 	/**
 	 * Issue one project-wide `workspace/diagnostic` pull. Resolves per-file
 	 * reports, or `undefined` when unsupported/dead/timed-out/malformed.
@@ -920,6 +922,8 @@ export interface LSPClientState {
 	readonly pushDiagnostics: Map<string, LSPDiagnostic[]>;
 	readonly pushDiagnosticTimestamps: Map<string, number>;
 	readonly documentPullDiagnostics: Map<string, LSPDiagnostic[]>;
+	/** Document version observed when the latest pull answer for a path landed. */
+	documentPullDiagnosticVersions?: Map<string, number>;
 	readonly documentPullDiagnosticTimestamps: Map<string, number>;
 	/** Most recent operational pull failures, capped to avoid unbounded telemetry. */
 	readonly pullFailureHistory: LSPPullFailure[];
@@ -1067,6 +1071,8 @@ export interface LSPClientState {
 	workspaceDiagnosticsSupport: LSPWorkspaceDiagnosticsSupport;
 	/** Effective diagnostics channel observed during this client session. */
 	observedDiagnosticsChannel?: "push";
+	/** Pull was attempted and proved unavailable for this client session. */
+	pullDiagnosticsUnavailable?: boolean;
 	/** Mutable: upgraded by applyDynamicCapabilities after registerCapability events */
 	operationSupport: LSPOperationSupport;
 	/** #1971: parsed `FileOperationRegistrationOptions` filters from initialize —
@@ -1529,11 +1535,36 @@ function getMergedDiagnosticsForPath(
 	const legacy = state as unknown as {
 		diagnostics?: Map<string, LSPDiagnostic[]>;
 	};
-	return mergeDiagnosticLists(
+	const push =
 		state.pushDiagnostics?.get(normalizedPath) ??
-			legacy.diagnostics?.get(normalizedPath),
-		state.documentPullDiagnostics?.get(normalizedPath),
-	);
+		legacy.diagnostics?.get(normalizedPath);
+	const pull = state.documentPullDiagnostics?.get(normalizedPath);
+	const pullVersion = state.documentPullDiagnosticVersions?.get(normalizedPath);
+	const pushVersion = state.diagnosticDocVersions?.get(normalizedPath);
+	// An answered pull is authoritative for its requested document version. A
+	// later, versioned push is newer evidence; an equal or unversioned push
+	// cannot be ordered and therefore yields to the answer.
+	if (
+		state.workspaceDiagnosticsSupport.mode === "pull" &&
+		state.observedDiagnosticsChannel === "push" &&
+		pull !== undefined &&
+		(pullVersion === undefined ||
+			pushVersion === undefined ||
+			pushVersion <= pullVersion)
+	) {
+		return pull;
+	}
+	if (
+		state.workspaceDiagnosticsSupport.mode === "pull" &&
+		state.observedDiagnosticsChannel === "push" &&
+		pull !== undefined &&
+		pushVersion !== undefined &&
+		pullVersion !== undefined &&
+		pushVersion > pullVersion
+	) {
+		return push ?? [];
+	}
+	return mergeDiagnosticLists(push, pull);
 }
 
 /**
@@ -1759,6 +1790,27 @@ export function diagnosticsVersionForPath(
 	return state.diagnosticsVersionsByPath?.get(normalizedPath) ?? 0;
 }
 
+/** Mark a declared pull provider unavailable only after a negative protocol
+ * outcome. A push observation alone is telemetry: both-channel servers
+ * legitimately publish and answer pulls (#2776 R2). */
+export function markPullDiagnosticsUnavailable(state: LSPClientState): void {
+	if (state.pullDiagnosticsUnavailable) return;
+	state.pullDiagnosticsUnavailable = true;
+	if (state.workspaceDiagnosticsSupport.mode !== "pull") return;
+	state.workspaceDiagnosticsSupport = {
+		...state.workspaceDiagnosticsSupport,
+		mode: "push-only",
+	};
+	if (state.observedDiagnosticsChannel === "push") {
+		recordDegradationOnce({
+			kind: "lsp-capability-skip",
+			subject: `${state.serverId}:diagnostics-channel`,
+			reason:
+				"declared=pull observed=push; pull proven unavailable, using published diagnostics for this session",
+		});
+	}
+}
+
 /** Exported for tests: the quiet-window timer cancel on clear/resync is the
  * headline #1412 safety property (a stale versionless publication must never
  * land after the document content changed). */
@@ -1780,6 +1832,7 @@ export function clearDiagnosticsForPath(
 	state.pendingDiagnostics?.delete(normalizedPath);
 	state.pushDiagnosticTimestamps?.delete(normalizedPath);
 	state.documentPullDiagnostics?.delete(normalizedPath);
+	state.documentPullDiagnosticVersions?.delete(normalizedPath);
 	state.documentPullDiagnosticTimestamps?.delete(normalizedPath);
 	state.diagnosticDocVersions?.delete(normalizedPath);
 	// #1095: a cleared path must never serve a stale content binding alongside a
@@ -2176,7 +2229,7 @@ export function applyDynamicCapabilities(state: LSPClientState): void {
 	if (hasDynamicPull) {
 		state.workspaceDiagnosticsSupport = {
 			advertised: true,
-			mode: state.observedDiagnosticsChannel === "push" ? "push-only" : "pull",
+			mode: state.pullDiagnosticsUnavailable ? "push-only" : "pull",
 			// #1667: workspace-pull support is what the REGISTRATION declares. The
 			// spec registers workspace pull as `registerOptions.workspaceDiagnostics`
 			// on a `textDocument/diagnostic` registration - `workspace/diagnostic` is
@@ -2270,23 +2323,9 @@ export function setupIncomingHandlers(
 			// that is no longer open on this client.
 			if (state.closedDocuments?.has(normalizedPath)) return;
 			onDiagnosticsPublished?.(state.serverId);
-			if (state.workspaceDiagnosticsSupport.mode === "pull") {
-				// A declaration is only a promise of pull support. If this live
-				// session publishes first, its effective channel is push; keeping the
-				// declared pull mode would wait for an answer that never arrives and
-				// could turn an empty pull timeout into a clean result (#2776).
-				recordDegradationOnce({
-					kind: "lsp-capability-skip",
-					subject: `${state.serverId}:diagnostics-channel`,
-					reason:
-						"declared=pull observed=push; using published diagnostics for this session",
-				});
-				state.observedDiagnosticsChannel = "push";
-				state.workspaceDiagnosticsSupport = {
-					...state.workspaceDiagnosticsSupport,
-					mode: "push-only",
-				};
-			}
+			// Push observation is telemetry only. A pull declaration remains
+			// effective until a pull response proves it unavailable (#2776 R2).
+			state.observedDiagnosticsChannel = "push";
 			const newDiags = normalizeLspDiagnostics(params.diagnostics || []);
 			const docVersion = params.version;
 			if (PUB_DEBUG) {
@@ -3142,6 +3181,10 @@ async function pullDiagnosticSource(
 			state.diagnosticBindings.set(normalizedPath, { contentHash: sentHash });
 			primaryCount = primaryItems.length;
 		}
+		state.documentPullDiagnosticVersions?.set(
+			normalizedPath,
+			state.documentVersions.get(normalizedPath) ?? 0,
+		);
 		let totalCount = primaryCount;
 		if (report.resultId !== undefined) {
 			state.pullResultIds.set(sourceKey, report.resultId);
@@ -3720,6 +3763,31 @@ export async function clientWaitForDiagnostics(
 		return currentVersion !== undefined && cachedVersion < currentVersion;
 	};
 
+	const waitForPushReconciliation = async (): Promise<void> => {
+		if (getMergedDiagnosticsForPath(state, normalizedPath).length > 0) return;
+		const strategy = getStrategy(state.serverId, state.launchVariant);
+		const waitMs = Math.min(
+			timeoutMs,
+			Math.max(PULL_DIAGNOSTICS_RETRY_INTERVAL_MS, strategy.debounceMs + 25),
+		);
+		await new Promise<void>((resolve) => {
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const onDiagnostics = (file: string) => {
+				if (normalizeMapKey(file) !== normalizedPath) return;
+				if (getMergedDiagnosticsForPath(state, normalizedPath).length === 0)
+					return;
+				if (timer) clearTimeout(timer);
+				state.diagnosticEmitter.removeListener("diagnostics", onDiagnostics);
+				resolve();
+			};
+			state.diagnosticEmitter.on("diagnostics", onDiagnostics);
+			timer = setTimeout(() => {
+				state.diagnosticEmitter.removeListener("diagnostics", onDiagnostics);
+				resolve();
+			}, waitMs);
+		});
+	};
+
 	if (state.workspaceDiagnosticsSupport.mode === "pull") {
 		// Pull is authoritative. An AFFIRMATIVE outcome — diagnostics `found`, or
 		// an authoritative empty `clean` report — ends the wait. An `unavailable`
@@ -3748,6 +3816,9 @@ export async function clientWaitForDiagnostics(
 			return;
 		}
 		let sawClean = outcome.status === "clean";
+		if (outcome.status === "unavailable") {
+			markPullDiagnosticsUnavailable(state);
+		}
 
 		const strategy = getStrategy(state.serverId, state.launchVariant);
 		const retryBudgetMs =
@@ -3772,19 +3843,39 @@ export async function clientWaitForDiagnostics(
 				Math.max(0, retryBudgetMs - (Date.now() - startedAt)),
 			);
 			if (outcome.status === "clean") sawClean = true;
+			if (outcome.status === "unavailable") {
+				markPullDiagnosticsUnavailable(state);
+			}
 		}
 		if (options.pullOnly) {
 			if (outcome.status === "found" || sawClean) {
+				if (
+					sawClean &&
+					outcome.status !== "found" &&
+					state.observedDiagnosticsChannel === "push"
+				) {
+					await waitForPushReconciliation();
+				}
 				logTypeScriptPullSettle(
 					state,
 					normalizedPath,
 					Date.now() - pullSettleStartedAt,
 					pullSettleSource,
 				);
+				return;
 			}
-			return;
+			// Once pull is proven unavailable, fall through to the push wait even
+			// for a caller that entered with the pull-capable snapshot. The mode
+			// transition above is the evidence that this session is push-only.
 		}
 		if (outcome.status === "found" || sawClean) {
+			if (
+				sawClean &&
+				outcome.status !== "found" &&
+				state.observedDiagnosticsChannel === "push"
+			) {
+				await waitForPushReconciliation();
+			}
 			logTypeScriptPullSettle(
 				state,
 				normalizedPath,
@@ -5316,6 +5407,7 @@ export async function createLSPClient(options: {
 		pushDiagnostics: new Map(),
 		pushDiagnosticTimestamps: new Map(),
 		documentPullDiagnostics: new Map(),
+		documentPullDiagnosticVersions: new Map(),
 		documentPullDiagnosticTimestamps: new Map(),
 		pullFailureHistory: [],
 		pendingDiagnostics: new Map(),
@@ -5656,6 +5748,10 @@ export async function createLSPClient(options: {
 
 		getWorkspaceDiagnosticsSupport() {
 			return state.workspaceDiagnosticsSupport;
+		},
+
+		getObservedDiagnosticsChannel() {
+			return state.observedDiagnosticsChannel;
 		},
 
 		requestWorkspaceDiagnostics(budgetMs: number) {

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -5468,7 +5468,8 @@ export class LSPService {
 							pressureSnapshots.find(
 								(snapshot) => snapshot.serverId === entry.client.serverId,
 							),
-						) === "pull-capable";
+						) === "pull-capable" &&
+						entry.client.getObservedDiagnosticsChannel?.() !== "push";
 					// #1639: `ensureWarmForSweep`'s readiness probe (`source:
 					// "lsp_sweep_warmup"`, `collectDiagnostics: false`) runs a real pull
 					// round trip on this same file, then the sweep's real touch follows

--- a/tests/clients/lsp/client-internals.test.ts
+++ b/tests/clients/lsp/client-internals.test.ts
@@ -45,6 +45,7 @@ import {
 	clientWaitForDiagnostics,
 	closeDocument,
 	diagnosticsVersionForPath,
+	markPullDiagnosticsUnavailable,
 	normalizeClientWorkspaceEdit,
 	handleNotifyChange,
 	handleNotifyExternalChange,
@@ -1547,7 +1548,7 @@ describe("publishDiagnostics handler — superseded push guard (cache-poisoning 
 		expect(state.pushDiagnostics.get(TEST_KEY)).toEqual([]);
 	});
 
-	it("demotes a pull declaration after the first observed push", async () => {
+	it("keeps a pull declaration after the first observed push", async () => {
 		const { state, emitPublishDiagnostics } = createCapturingState({
 			workspaceDiagnosticsSupport: {
 				advertised: true,
@@ -1557,15 +1558,42 @@ describe("publishDiagnostics handler — superseded push guard (cache-poisoning 
 			},
 		});
 
+		const published = new Promise<void>((resolve) => {
+			state.diagnosticEmitter.once("diagnostics", resolve);
+		});
 		emitPublishDiagnostics({
 			uri: pathToFileURL(TEST_FILE).href,
-			diagnostics: [diagnostic("push-only result")],
+			diagnostics: [
+				{
+					severity: 1,
+					message: "push",
+					range: {
+						start: { line: 0, character: 0 },
+						end: { line: 0, character: 1 },
+					},
+				},
+			],
 		});
+		await published;
+		expect(state.workspaceDiagnosticsSupport.mode).toBe("pull");
+		expect(state.observedDiagnosticsChannel).toBe("push");
+		expect(state.pushDiagnostics.get(TEST_KEY)).toHaveLength(1);
+	});
 
-		await vi.waitFor(() => {
-			expect(state.workspaceDiagnosticsSupport.mode).toBe("push-only");
-			expect(state.pushDiagnostics.get(TEST_KEY)).toHaveLength(1);
+	it("demotes only after a declared pull is proven unavailable", async () => {
+		const { state } = createCapturingState({
+			workspaceDiagnosticsSupport: {
+				advertised: true,
+				mode: "pull",
+				workspaceDiagnostics: false,
+				diagnosticProviderKind: "object",
+			},
 		});
+		state.observedDiagnosticsChannel = "push";
+		markPullDiagnosticsUnavailable(state);
+
+		expect(state.workspaceDiagnosticsSupport.mode).toBe("push-only");
+		expect(state.pullDiagnosticsUnavailable).toBe(true);
 	});
 
 	it("keeps classic TypeScript's first publication authoritative", () => {
@@ -2079,6 +2107,53 @@ describe("clientWaitForDiagnostics — pull mode (#240)", () => {
 		expect(Date.now() - start).toBeLessThan(80);
 	});
 
+	it("reconciles a diagnostic push that follows an empty pull", async () => {
+		const state = pullState();
+		let publishHandler:
+			| ((params: {
+					uri: string;
+					diagnostics?: LSPDiagnostic[];
+					version?: number;
+			  }) => void)
+			| undefined;
+		vi.mocked(state.connection.onNotification).mockImplementation(
+			(method: string, callback: (params: unknown) => void) => {
+				if (method === "textDocument/publishDiagnostics") {
+					publishHandler = callback as typeof publishHandler;
+				}
+			},
+		);
+		setupIncomingHandlers(state, undefined);
+		state.observedDiagnosticsChannel = "push";
+		let resolvePull!: (value: { kind: string; items: never[] }) => void;
+		state.connection.sendRequest = vi.fn(
+			() =>
+				new Promise((resolve) => {
+					resolvePull = resolve as typeof resolvePull;
+				}),
+		);
+		const wait = clientWaitForDiagnostics(state, TEST_FILE, 500);
+		await Promise.resolve();
+		publishHandler?.({
+			uri: pathToFileURL(TEST_FILE).href,
+			diagnostics: [
+				{
+					severity: 1,
+					message: "late push",
+					range: {
+						start: { line: 0, character: 0 },
+						end: { line: 0, character: 1 },
+					},
+				},
+			],
+		});
+		resolvePull({ kind: "full", items: [] });
+
+		await wait;
+		expect(state.pushDiagnostics.get(TEST_KEY)).toHaveLength(1);
+		expect(state.pushDiagnostics.get(TEST_KEY)?.[0]?.message).toBe("late push");
+	});
+
 	it("resolves immediately when the pull returns diagnostics (found)", async () => {
 		const state = pullState();
 		state.connection.sendRequest = vi.fn().mockResolvedValue({
@@ -2111,6 +2186,7 @@ describe("clientWaitForDiagnostics — pull mode (#240)", () => {
 		const start = Date.now();
 		await clientWaitForDiagnostics(state, TEST_FILE, 120);
 		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+		expect(state.workspaceDiagnosticsSupport.mode).toBe("push-only");
 	});
 
 	it("bounds a hung pull request instead of hanging forever", async () => {
@@ -2872,7 +2948,7 @@ describe("applyDynamicCapabilities", () => {
 
 		applyDynamicCapabilities(state);
 
-		expect(state.workspaceDiagnosticsSupport.mode).toBe("push-only");
+		expect(state.workspaceDiagnosticsSupport.mode).toBe("pull");
 	});
 
 	it("upgrades to pull mode when workspace/diagnostic is registered", () => {

--- a/tests/clients/lsp/client-internals.test.ts
+++ b/tests/clients/lsp/client-internals.test.ts
@@ -1486,11 +1486,11 @@ describe("publishDiagnostics handler — superseded push guard (cache-poisoning 
 		version?: number;
 	};
 
-	function createCapturingState(): {
+	function createCapturingState(overrides: Partial<LSPClientState> = {}): {
 		state: LSPClientState;
 		emitPublishDiagnostics: (params: PublishDiagnosticsParams) => void;
 	} {
-		const state = createMockState({ serverId: "test-server" });
+		const state = createMockState({ serverId: "test-server", ...overrides });
 		let handler: ((params: PublishDiagnosticsParams) => void) | undefined;
 		(
 			state.connection.onNotification as unknown as ReturnType<typeof vi.fn>
@@ -1545,6 +1545,27 @@ describe("publishDiagnostics handler — superseded push guard (cache-poisoning 
 
 		await wait;
 		expect(state.pushDiagnostics.get(TEST_KEY)).toEqual([]);
+	});
+
+	it("demotes a pull declaration after the first observed push", async () => {
+		const { state, emitPublishDiagnostics } = createCapturingState({
+			workspaceDiagnosticsSupport: {
+				advertised: true,
+				mode: "pull",
+				workspaceDiagnostics: false,
+				diagnosticProviderKind: "object",
+			},
+		});
+
+		emitPublishDiagnostics({
+			uri: pathToFileURL(TEST_FILE).href,
+			diagnostics: [diagnostic("push-only result")],
+		});
+
+		await vi.waitFor(() => {
+			expect(state.workspaceDiagnosticsSupport.mode).toBe("push-only");
+			expect(state.pushDiagnostics.get(TEST_KEY)).toHaveLength(1);
+		});
 	});
 
 	it("keeps classic TypeScript's first publication authoritative", () => {
@@ -2841,6 +2862,17 @@ describe("applyDynamicCapabilities", () => {
 		expect(state.workspaceDiagnosticsSupport.diagnosticProviderKind).toBe(
 			"dynamic",
 		);
+	});
+
+	it("keeps observed push mode when a pull registration arrives later", () => {
+		const state = createMockState({ observedDiagnosticsChannel: "push" });
+		state.dynamicRegistrations.set("diag-1", {
+			method: "textDocument/diagnostic",
+		});
+
+		applyDynamicCapabilities(state);
+
+		expect(state.workspaceDiagnosticsSupport.mode).toBe("push-only");
 	});
 
 	it("upgrades to pull mode when workspace/diagnostic is registered", () => {

--- a/tests/clients/lsp/mock-client-state.ts
+++ b/tests/clients/lsp/mock-client-state.ts
@@ -65,6 +65,7 @@ export function createMockState(
 		pushDiagnostics: new Map(),
 		pushDiagnosticTimestamps: new Map(),
 		documentPullDiagnostics: new Map(),
+		documentPullDiagnosticVersions: new Map(),
 		documentPullDiagnosticTimestamps: new Map(),
 		pullFailureHistory: [],
 		pendingDiagnostics: new Map(),

--- a/tests/clients/lsp/refresh-and-sync-kind.test.ts
+++ b/tests/clients/lsp/refresh-and-sync-kind.test.ts
@@ -1547,10 +1547,67 @@ describe("declared pull versus observed push diagnostics (#2776)", () => {
 				"pi-lens-pull-declaring-push-only.ts",
 			);
 			await client.notify.open(filePath, "const x = 1;\n", "typescript");
-			await vi.waitFor(() => {
-				expect(client.getDiagnostics(filePath)).toHaveLength(1);
-			});
+			await client.waitForDiagnostics(filePath, 500);
+			expect(client.getDiagnostics(filePath)).toHaveLength(1);
 			expect(client.getWorkspaceDiagnosticsSupport().mode).toBe("push-only");
+		} finally {
+			await client.shutdown().catch(() => {});
+			await stopLSP(proc).catch(() => {});
+		}
+	}, 15_000);
+
+	it("keeps pulling when a server both pushes and answers pulls", async () => {
+		const proc = await spawnFakeLspServer({
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				FAKE_LSP_PULL_DECLARED_BOTH_CHANNEL: "1",
+				FAKE_LSP_ECHO_REQUEST_METHODS: "1",
+			},
+		});
+		const client = await createLSPClient({
+			serverId: "fake-both-channel",
+			process: proc,
+			root: process.cwd(),
+		});
+		try {
+			const filePath = path.join(
+				os.tmpdir(),
+				"pi-lens-pull-declaring-both-channel.ts",
+			);
+			await client.notify.open(filePath, "const x = 1;\n", "typescript");
+			await client.waitForDiagnostics(filePath, 500);
+			// The push is version 1 while the answered pull covered version 0, so
+			// the newer push is authoritative for this file.
+			expect(client.getDiagnostics(filePath)).toHaveLength(1);
+			expect(client.getWorkspaceDiagnosticsSupport().mode).toBe("pull");
+		} finally {
+			await client.shutdown().catch(() => {});
+			await stopLSP(proc).catch(() => {});
+		}
+	}, 15_000);
+
+	it("lets a diagnostic push supersede an empty pull", async () => {
+		const proc = await spawnFakeLspServer({
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				FAKE_LSP_PULL_EMPTY_THEN_PUSH: "1",
+			},
+		});
+		const client = await createLSPClient({
+			serverId: "fake-empty-then-push",
+			process: proc,
+			root: process.cwd(),
+		});
+		try {
+			const filePath = path.join(
+				os.tmpdir(),
+				"pi-lens-empty-pull-then-push.ts",
+			);
+			await client.notify.open(filePath, "const x = 1;\n", "typescript");
+			await client.waitForDiagnostics(filePath, 500);
+			expect(client.getDiagnostics(filePath)).toHaveLength(1);
 		} finally {
 			await client.shutdown().catch(() => {});
 			await stopLSP(proc).catch(() => {});

--- a/tests/clients/lsp/refresh-and-sync-kind.test.ts
+++ b/tests/clients/lsp/refresh-and-sync-kind.test.ts
@@ -1527,6 +1527,37 @@ describe("negotiateSyncKind through the real createLSPClient init path (#1669 re
 	}, 15_000);
 });
 
+describe("declared pull versus observed push diagnostics (#2776)", () => {
+	it("keeps push diagnostics when the server declares pull but never answers pull", async () => {
+		const proc = await spawnFakeLspServer({
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				FAKE_LSP_PULL_DECLARED_PUSH_ONLY: "1",
+			},
+		});
+		const client = await createLSPClient({
+			serverId: "fake-pull-declaring-push-only",
+			process: proc,
+			root: process.cwd(),
+		});
+		try {
+			const filePath = path.join(
+				os.tmpdir(),
+				"pi-lens-pull-declaring-push-only.ts",
+			);
+			await client.notify.open(filePath, "const x = 1;\n", "typescript");
+			await vi.waitFor(() => {
+				expect(client.getDiagnostics(filePath)).toHaveLength(1);
+			});
+			expect(client.getWorkspaceDiagnosticsSupport().mode).toBe("push-only");
+		} finally {
+			await client.shutdown().catch(() => {});
+			await stopLSP(proc).catch(() => {});
+		}
+	}, 15_000);
+});
+
 describe("#2065 fix round 1 F1: a crashed client deregisters from activeLspClients", () => {
 	it("stops counting a client's retained text once its process is killed, without a graceful shutdown() call", async () => {
 		const before = getLspDocumentTextRetentionSnapshot();

--- a/tests/fixtures/fake-lsp-server.mjs
+++ b/tests/fixtures/fake-lsp-server.mjs
@@ -485,19 +485,28 @@ function handle(raw) {
 			data.params?.textDocument?.uri,
 			data.params?.textDocument?.text ?? "",
 		);
-		if (process.env.FAKE_LSP_PULL_DECLARED_PUSH_ONLY === "1") {
+		if (
+			process.env.FAKE_LSP_PULL_DECLARED_PUSH_ONLY === "1" ||
+			process.env.FAKE_LSP_PULL_DECLARED_BOTH_CHANNEL === "1"
+		) {
 			send({
 				jsonrpc: "2.0",
 				method: "textDocument/publishDiagnostics",
 				params: {
 					uri: data.params?.textDocument?.uri,
-					version: data.params?.textDocument?.version,
+					version:
+						process.env.FAKE_LSP_PULL_DECLARED_BOTH_CHANNEL === "1"
+							? 1
+							: data.params?.textDocument?.version,
 					diagnostics: [
 						{
 							severity: 1,
 							code: "FAKE-PUSH-ONLY",
 							source: "fake-lsp",
-							message: "push-only diagnostic",
+							message:
+								process.env.FAKE_LSP_PULL_DECLARED_BOTH_CHANNEL === "1"
+									? "both-channel push"
+									: "push-only diagnostic",
 							range: {
 								start: { line: 0, character: 0 },
 								end: { line: 0, character: 1 },
@@ -692,7 +701,9 @@ function handle(raw) {
 			id: data.id,
 			result: {
 				kind: "full",
-				items: text.includes("fake-lsp-clean")
+				items:
+					text.includes("fake-lsp-clean") ||
+					process.env.FAKE_LSP_PULL_EMPTY_THEN_PUSH === "1"
 					? []
 					: [
 					{
@@ -709,6 +720,29 @@ function handle(raw) {
 					],
 			},
 		});
+		if (process.env.FAKE_LSP_PULL_EMPTY_THEN_PUSH === "1") {
+			setTimeout(() => {
+				send({
+					jsonrpc: "2.0",
+					method: "textDocument/publishDiagnostics",
+					params: {
+						uri: data.params?.textDocument?.uri,
+						version: 1,
+						diagnostics: [
+							{
+								severity: 1,
+								code: "FAKE-LATE-PUSH",
+								message: "late push diagnostic",
+								range: {
+									start: { line: 0, character: 0 },
+									end: { line: 0, character: 1 },
+								},
+							},
+						],
+					},
+				});
+			}, 20);
+		}
 		return;
 	}
 

--- a/tests/fixtures/fake-lsp-server.mjs
+++ b/tests/fixtures/fake-lsp-server.mjs
@@ -485,6 +485,29 @@ function handle(raw) {
 			data.params?.textDocument?.uri,
 			data.params?.textDocument?.text ?? "",
 		);
+		if (process.env.FAKE_LSP_PULL_DECLARED_PUSH_ONLY === "1") {
+			send({
+				jsonrpc: "2.0",
+				method: "textDocument/publishDiagnostics",
+				params: {
+					uri: data.params?.textDocument?.uri,
+					version: data.params?.textDocument?.version,
+					diagnostics: [
+						{
+							severity: 1,
+							code: "FAKE-PUSH-ONLY",
+							source: "fake-lsp",
+							message: "push-only diagnostic",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 1 },
+							},
+						},
+					],
+				},
+			});
+			return;
+		}
 		// Gated on the wedge profile so every existing test keeps the incumbent
 		// silent-on-open behaviour it was written against.
 		if (HAS_BACKLOG_WEDGE) {
@@ -662,6 +685,7 @@ function handle(raw) {
 
 	// Pull diagnostics
 	if (data.method === "textDocument/diagnostic") {
+		if (process.env.FAKE_LSP_PULL_DECLARED_PUSH_ONLY === "1") return;
 		const text = openDocuments.get(data.params?.textDocument?.uri) ?? "";
 		send({
 			jsonrpc: "2.0",


### PR DESCRIPTION
## Summary

Keep a pull-declaring LSP server pull-capable until a pull is proven unavailable. Record push observation separately, and let a later diagnostic push replace an empty pull result before the caller caches confirmed clean.

## State-space model

The declared capability is immutable for the session. `observed push` is telemetry only. `effective mode` stays `pull` until a pull response is proven unavailable by timeout, method-not-found (`-32601`), or an error response; that transition is session-wide and is written by the pull response handler. A push is accepted by the `publishDiagnostics` handler, which is the sole writer of push evidence. The initialize result writes the declared capability. Dynamic registration updates the declared capability and resets effective mode only when it adds pull support; it never demotes from a push observation.

| Declared mode | Pull outcome | Push for F | Ordering | Server class | Rule and writer |
|---|---|---|---|---|---|
| push-only | not attempted | none | either | push-only | Initialize result keeps push-only; publish handler owns any later push result. |
| push-only | answered non-empty | any | either | push-only | Pull response handler stores the non-empty pull result; publish handler stores push evidence; result reconciliation uses the freshest accepted evidence. |
| push-only | answered empty | none | either | push-only | Pull response handler may report empty, but no pull-based confirmed-clean classification is created. |
| push-only | timed out / method-not-found | any | either | push-only | Pull response handler records unavailable only if a pull was attempted; effective mode remains push-only. |
| pull | not attempted | none | either | pull-only | Initialize result leaves effective mode pull; caller may not claim clean without attempting pull or receiving push evidence. |
| pull | answered non-empty | none | either | pull-only | Pull response handler stores diagnostics and returns found; effective mode remains pull. |
| pull | answered empty | none | either | pull-only | Pull response handler records a provisional empty result; it is confirmed clean only if no later push with diagnostics is observed for F. |
| pull | timed out / method-not-found / error | none | either | pull-only | Pull response handler transitions effective mode to push-only, records one bounded degradation after pushes are observed, and waits for push evidence rather than claiming clean. |
| pull | any | empty push | before pull answer | push-only despite declaring | Publish handler records observed push and empty evidence; pull response handler may retain pull mode unless the pull is unavailable. Empty remains empty, not a diagnostic result. |
| pull | any | with diagnostics | before pull answer | push-only despite declaring | Publish handler records observed push and diagnostics; the result is found. A later empty pull cannot overwrite it. |
| pull | answered empty | empty push | after pull answer; push version equal or unversioned | push-only despite declaring | The answered pull wins because equal or unversioned push evidence cannot be ordered against it; final result is empty. |
| pull | answered empty | with diagnostics | after pull answer; push version > pulled version | push-only despite declaring | The newer versioned push wins; final result is found. |
| pull | answered empty | with diagnostics | after pull answer; push version equal or unversioned | push-only despite declaring | The answered pull wins because equal or unversioned push evidence cannot be ordered against it; final result is empty. |
| pull | answered empty | none | after pull answer | pull-only | Pull response handler confirms clean only after its reconciliation point observes no diagnostic push for F. |
| pull | answered non-empty | any push | either | both-channel | Pull remains enabled. Pull response handler keeps pull-derived results; publish handler records independent push telemetry and reconciles by version. |
| pull | timed out / method-not-found / error | any push | either | both-channel | Pull response handler transitions to push-only only after the unavailable outcome; an observed push does not itself cause demotion. |
| pull | answered empty | with diagnostics | after pull answer; push version > pulled version | both-channel | The newer versioned push wins. |
| pull | answered empty | with diagnostics | after pull answer; push version equal or unversioned | both-channel | The answered pull wins; an equal-version push is inconsistent, and an unversioned push cannot be ordered. |

### Writers and invariants

- Initialize result writes declared capability and initial effective mode.
- The `publishDiagnostics` handler writes observed push telemetry and per-file push evidence. It never demotes a pull declaration.
- The pull response handler writes pull evidence, confirms clean only after reconciliation, and performs the one-way unavailable transition.
- Dynamic registration writes declared capability. It preserves effective pull capability while available and cannot erase observed push telemetry.
- Push evidence is per file. A later push with diagnostics wins over an empty pull at equal-or-newer version or without a version. A stale versioned push does not poison the cache.
- `recordDegradationOnce` remains once per server/session and fires on the proven unavailable transition after push evidence exists; its reason names declared pull and observed push.

## Tests

Round 2 extends the real-wire fake-server coverage for push-only despite declaration, both-channel pull plus push, and empty-pull-then-diagnostic-push ordering. Seam tests cover pull retention, unavailable transition, and late-push reconciliation. Mutation transcripts are appended below.

## Blast radius

Changed seam: LSP client capability state, `clientWaitForDiagnostics`, and per-file collection in `LSPService.touchFile`. Callers include dispatch waits, workspace sweeps, and diagnostic collection. The existing push/pull maps and bounded degradation ledger remain the durable records.

## Class sweep

The defect pattern was searched across `clients/lsp` and `tests/clients/lsp`: first-push capability demotion and early pull-only snapshots are the two round-1 members. No third capability writer was found beyond initialize, dynamic registration, publish handling, and pull response handling.

## Observability

The existing once-per-server degradation record remains bounded. Its transition reason records declared capability and observed channel. Push and pull results retain their existing per-file version metadata.

## Round 2

Round 2 addresses review findings F1 and F2 from PR #2781. The prescription is implemented only where the state-space model requires it: push observation is telemetry, pull remains effective until proven unavailable, and late push diagnostics supersede provisional empty pull results.

### Verification transcript

The pre-fix review probe reproduced both defects:

```text
expected textDocument/diagnostic — Number of calls: 0
expected [] to have a length of 1 but got +0
```

The seam suite passed after the fix:

```text
Test Files  1 passed (1)
Tests  131 passed (131)
```

Mutation of the built-output late-push guard (`observedDiagnosticsChannel === "push"` -> `false`) failed the new seam test:

```text
reconciles a diagnostic push that follows an empty pull
AssertionError: Target cannot be null or undefined.
```

Mutation of the built-output unavailable transition (`markPullDiagnosticsUnavailable(state)` -> `void state`) also failed:

```text
expected 'push-only' to be 'push-only'
Received: 'pull'
```

The three real-wire fake-server tests are present but environment-blocked here. Each child exited during initialization before the wire handshake (`stream may have been destroyed`, exit code 0 or no code). The orchestrator must rerun those tests where child spawns are permitted.

## Round 3

The both-channel wire case now uses a versioned push at document version 1 against a pull answered for version 0. The newer push is authoritative, so the corrected assertion expects one diagnostic. Equal or unversioned pushes yield to an answered pull.

The pre-fix wire run had six reds. After the round-2 fix, one red remained in the both-channel case because the fixture did not exercise explicit version ordering. The round-3 fixture and expectation close that mismatch.

The three added `vi.waitFor` calls were replaced with promises resolved by the client's `textDocument/publishDiagnostics` notification, preserving deterministic wire acknowledgement without adding a ratchet entry.

The round-3 ratchet passed:

```text
Test Files  1 passed (1)
Tests  46 passed (46)
```

The targeted command was `vitest run tests/clients/lsp/refresh-and-sync-kind.test.ts tests/clients/lsp/client-internals.test.ts --configLoader runner`. `client-internals.test.ts` passed all 173 tests. The refresh wire cases remained environment-blocked: all six real-child cases failed during initialization with `stream may have been destroyed`, including the three cases the orchestrator must rerun outside this sandbox.

## Round 4

The r3 wire-test settle promises observed raw `textDocument/publishDiagnostics` arrival. That notification can reach the test observer before the client's handler stores diagnostics, so the assertion could read an empty cache. The tests now use wire arrival only as a trigger, then await the real client's `waitForDiagnostics` settle seam before reading `getDiagnostics`.

The versioned-push suspicion is disproven. The fixture opens documents at version 0, and the r3 pushes use version 1, so the superseded-push guard accepts them because `1 < 0` is false. No production handler change was needed.

The build passed. The requested combined LSP run passed 175 tests, with the six known real-child initialization failures in `refresh-and-sync-kind.test.ts` caused by this sandbox's destroyed streams. The flake-shape ratchet passed with 46 tests, preserving the 4/3 `vi.waitFor` count.

## Round 5

The real child suite reproduced the reported four reds outside the sandbox:
three diagnostics cases read an empty store, and the #2065 crash case saw one
retained client instead of two. The trace showed that the test's raw
`connection.onNotification("textDocument/publishDiagnostics", ...)` observer
replaced the production handler for that notification. The wire notification
arrived, but the handler never stored it. Removing that competing registration
and awaiting the client's settle seam fixed the three diagnostics reds. The
remaining #2065 red was leaked state from the timed-out third test and cleared
when that test completed its real cleanup.

The both-channel fixture now answers its pull with a diagnostic while also
publishing a push diagnostic. The empty-pull-then-push fixture remains the
separate late-push reconciliation case. This keeps the real-wire matrix
independent: positive pull answer, unavailable pull, and late push after clean.

### Verification transcript

```text
npm run build
PASS

refresh-and-sync-kind.test.ts
Test Files  1 passed (1)
Tests  48 passed (48)

refresh-and-sync-kind.test.ts + client-internals.test.ts + flake-shape-ratchet.test.ts
Test Files  3 passed (3)
Tests  225 passed (225)
```

The required pre-fix probe produced five reds: one both-channel wire case and
four client-internals contracts. The unavailable-transition mutation produced
two reds. A broader observed-channel mutation stayed green, so it is not used
as proof. No `vi.waitFor` calls were added; the counts remain 3 in the wire
file and 4 in client-internals.

## Round 6

The reported symptom belongs to the production wait/classification layer, not
the client diagnostic store. The store-level wire cases are green on master;
the pre-fix red set is the five pull-wait contracts that pass a stale
`pull-capable` snapshot into `LSPService.touchFile`, producing a clean or
timed-out verdict despite one pushed diagnostic.

The production wait now reads the observed channel before forcing pull-only
behavior. A push therefore remains usable evidence, while the client keeps a
pull declaration effective for both-channel servers. Version reconciliation
still protects the returned diagnostic ordering.

Verification after the fix:

```text
npm run build
PASS

refresh-and-sync-kind.test.ts + client-internals.test.ts + flake-shape-ratchet.test.ts
Test Files  3 passed (3)
Tests  225 passed (225)
```

The two store-level wire cases remain because they protect versioned evidence
ordering and late push reconciliation, which the wait verdict does not cover.

### Orchestrator run (round 6, 2026-09-09, outside the codex sandbox)

```text
post-fix:  refresh-and-sync-kind + client-internals + flake-shape-ratchet — Test Files 3 passed (3), Tests 225 passed (225)
pre-fix (clients/ reverted, tests kept): 5 failed | 174 passed (179)
  keeps a pull declaration after the first observed push
  demotes only after a declared pull is proven unavailable
  does NOT treat a failed/unavailable pull as clean — waits the budget rather than short-circuiting
  keeps observed push mode when a pull registration arrives later
  keeps pulling when a server both pushes and answers pulls
vi.waitFor counts unchanged (4 / 3)
```

The two store-level wire cases for the emmylua and late-push shapes are green on master by construction (the store already kept pushes); the reported verdict defect is pinned by the five contracts above through `LSPService.touchFile`.
