### PR TITLE
fix(lsp-diagnostics): partition primary vs auxiliary by server provenance, not diagnostic.source (refs #2776)

### DIFF
--- a/.changelog/fix-lsp-diagnostics-2776.md
+++ b/.changelog/fix-lsp-diagnostics-2776.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Partition LSP diagnostics by server provenance (refs #2776)** — custom language servers now render their diagnostics as primary findings even when their server-authored `source` value differs from the registered server id.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,6 +498,11 @@ result carries that lane in `unconfirmedServerIds` and stays ineligible for the
 fully-covered workspace cache and footer replacement. Never reconstruct the gap
 from a touch-wide timeout: consume `touchFile`'s frozen coverage set. (#1549)
 
+Collected LSP diagnostics carry the registered delivering `serverId` alongside
+the server-authored protocol `source`. Primary-versus-auxiliary verdicts and
+counts partition by `serverId`; `source` remains display and auxiliary-profile
+metadata only. (#2776)
+
 MCP `ensureReady` treats its cwd memo as a fast path, not authoritative root
 state. It must consult `shouldInitializeSessionRoot` so the session-root cap can
 evict and later re-register a root used by a real MCP tool call. The shared

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -303,6 +303,8 @@ export type DegradationKind =
 	 * (older host, unexpected shape) never reaches this kind.
 	 */
 	| "cache-usage-attribution-stale"
+	/** A workspace diagnostics cache was rejected during the v3 provenance migration (#2776). */
+	| "lsp-workspace-cache-migration"
 	/**
 	 * A tool-event path did not resolve to an existing file, and pi's own
 	 * unicode/spacing variant ladder did not find it either (#1655 item 5).

--- a/clients/lsp/client.ts
+++ b/clients/lsp/client.ts
@@ -114,6 +114,8 @@ export interface LSPDiagnostic {
 	};
 	code?: string | number;
 	source?: string;
+	/** Registered server that delivered this diagnostic. Not LSP protocol data. */
+	serverId?: string;
 }
 
 export interface LSPPullFailure {

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -660,6 +660,13 @@ function mergeLspDiagnostics(
 	return merged;
 }
 
+function attributeDiagnostics(
+	serverId: string,
+	diagnostics: import("./client.js").LSPDiagnostic[],
+): import("./client.js").LSPDiagnostic[] {
+	return diagnostics.map((diagnostic) => ({ ...diagnostic, serverId }));
+}
+
 export type LSPDiagnosticsMode = "none" | "document" | "full";
 export type LSPTouchClientScope = "primary" | "all" | "with-auxiliary";
 
@@ -4717,7 +4724,9 @@ export class LSPService {
 						const binding = entry.client.getDiagnosticBinding?.(filePath);
 						if (!bindingMatchesTouchContent(binding)) return [];
 						const diags = entry.client.getDiagnostics(filePath);
-						return diags.length > 0 ? [{ diags, binding }] : [];
+						return diags.length > 0
+							? [{ serverId: entry.info.id, diags, binding }]
+							: [];
 					})
 				: [];
 			// #1493: auxiliaries whose STORED publication already covers exactly the
@@ -6286,7 +6295,12 @@ export class LSPService {
 			// diagnostics from the client cache as always.
 			let collected = options.collectDiagnostics
 				? tsserverSyncConfirmed !== undefined
-					? mergeLspDiagnostics(tsserverSyncConfirmed)
+					? mergeLspDiagnostics(
+							attributeDiagnostics(
+								spawned[0]?.info.id ?? "unknown",
+								tsserverSyncConfirmed,
+							),
+						)
 					: mergeLspDiagnostics([
 							// #1459: a DEFERRED server's cache still holds the PREVIOUS
 							// content's findings — the resync that would have cleared it never
@@ -6299,9 +6313,14 @@ export class LSPService {
 							...spawned.flatMap((entry) =>
 								droppedAuxiliaryServerIds.has(entry.info.id)
 									? []
-									: entry.client.getDiagnostics(filePath),
+									: attributeDiagnostics(
+											entry.info.id,
+											entry.client.getDiagnostics(filePath),
+										),
 							),
-							...carriedAuxiliary.flatMap((entry) => entry.diags),
+							...carriedAuxiliary.flatMap((entry) =>
+								attributeDiagnostics(entry.serverId, entry.diags),
+							),
 						])
 				: undefined;
 			// #1095 (P3-b): whether `collected` came from a tsserver sync confirm
@@ -6347,7 +6366,14 @@ export class LSPService {
 						retractPrimaryTimeoutAttribution(); // #1549
 						syncConfirmed = true;
 						collected =
-							syncResult.length > 0 ? mergeLspDiagnostics(syncResult) : [];
+							syncResult.length > 0
+								? mergeLspDiagnostics(
+										attributeDiagnostics(
+											spawned[0]?.info.id ?? "unknown",
+											syncResult,
+										),
+									)
+								: [];
 						logLatency({
 							type: "phase",
 							phase: "lsp_tsserver_sync_confirm",
@@ -7156,7 +7182,7 @@ export class LSPService {
 				].join(":");
 				if (seen.has(key)) continue;
 				seen.add(key);
-				merged.push(diagnostic);
+				merged.push({ ...diagnostic, serverId: entry.serverId });
 			}
 		}
 
@@ -9525,15 +9551,16 @@ export class LSPService {
 			);
 			const clientDiags = client.getAllDiagnostics();
 			for (const [filePath, entry] of clientDiags) {
+				const attributed = attributeDiagnostics(client.serverId, entry.diags);
 				const existing = all.get(filePath);
 				if (existing) {
 					existing.diags = mergeLspDiagnostics([
 						...existing.diags,
-						...entry.diags,
+						...attributed,
 					]);
 					existing.ts = Math.max(existing.ts, entry.ts);
 				} else {
-					all.set(filePath, { diags: [...entry.diags], ts: entry.ts });
+					all.set(filePath, { diags: attributed, ts: entry.ts });
 				}
 				const list = bindingsByPath.get(filePath) ?? [];
 				list.push(entry.binding);

--- a/clients/lsp/workspace-diagnostics-cache.ts
+++ b/clients/lsp/workspace-diagnostics-cache.ts
@@ -36,12 +36,17 @@ import {
  * `LSPWorkspaceDiagnosticResult.timedOut` in `./index.ts`) into
  * `WorkspaceDiagnosticsCacheEntry`.
  */
+// v3 (#2776): cached diagnostics must carry per-diagnostic `serverId`
+// provenance before replay, because primary/auxiliary partitioning is
+// server-owned rather than source-owned. v2 entries predate that contract and
+// are rejected so the owning server can re-collect them instead of silently
+// demoting old primary findings to auxiliary.
 // v2 (#1095): entries may carry an optional `contentHash` fingerprint of the
 // file bytes the cached diagnostics were computed against, so a `lookup` can
 // surface a content `binding` (boundToCurrentDisk) beyond the mtime proxy.
 // Legacy v1 entries are rejected by the version guard and re-scanned — a
 // deliberately clean break so no entry lacking the field is ever served.
-export const WORKSPACE_DIAGNOSTICS_CACHE_VERSION = 2;
+export const WORKSPACE_DIAGNOSTICS_CACHE_VERSION = 3;
 const CACHE_FILE = "lsp-workspace-diagnostics.json";
 
 export interface WorkspaceDiagnosticsCacheEntry {

--- a/clients/lsp/workspace-diagnostics-cache.ts
+++ b/clients/lsp/workspace-diagnostics-cache.ts
@@ -8,6 +8,7 @@ import { normalizeMapKey } from "../path-utils.js";
 import { loadReverseDependencyIndexFromSnapshot } from "../reverse-deps.js";
 import { freshnessFromMtime } from "../freshness.js";
 import { logLatency } from "../latency-logger.js";
+import { recordDegradationOnce } from "../degradation-ledger.js";
 import { compareOrdinal } from "../string-utils.js";
 import { workspaceDiagnosticsCacheSessionStart } from "./workspace-diagnostics-session.js";
 import type { LSPDiagnostic } from "./client.js";
@@ -266,9 +267,39 @@ export function loadWorkspaceDiagnosticsCache(
 	return readJsonCache<WorkspaceDiagnosticsCache>(cachePath(cwd), (parsed) => {
 		if (!parsed || typeof parsed !== "object") return undefined;
 		const cache = parsed as WorkspaceDiagnosticsCache;
-		if (cache.version !== WORKSPACE_DIAGNOSTICS_CACHE_VERSION) return undefined;
+		if (cache.version !== WORKSPACE_DIAGNOSTICS_CACHE_VERSION) {
+			if (cache.version === 1 || cache.version === 2) {
+				recordDegradationOnce({
+					kind: "lsp-workspace-cache-migration",
+					subject: path.resolve(cwd),
+					reason: `rejected v${cache.version} cache with ${
+						cache.entries && typeof cache.entries === "object"
+							? Object.keys(cache.entries).length
+							: 0
+					} entries during provenance migration`,
+				});
+			}
+			return undefined;
+		}
 		if (!cache.entries || typeof cache.entries !== "object") return undefined;
-		return cache;
+		const validEntries: Record<string, WorkspaceDiagnosticsCacheEntry> = {};
+		for (const [key, entry] of Object.entries(cache.entries)) {
+			if (!entry || typeof entry !== "object") continue;
+			if (
+				!Array.isArray(entry.diagnostics) ||
+				entry.diagnostics.some(
+					(diagnostic) =>
+						!diagnostic ||
+						typeof diagnostic !== "object" ||
+						typeof diagnostic.serverId !== "string" ||
+						diagnostic.serverId.length === 0,
+				)
+			) {
+				continue;
+			}
+			validEntries[key] = entry;
+		}
+		return { ...cache, entries: validEntries };
 	});
 }
 

--- a/tests/clients/lsp/refresh-and-sync-kind.test.ts
+++ b/tests/clients/lsp/refresh-and-sync-kind.test.ts
@@ -1297,7 +1297,7 @@ describe("workspace/diagnostic/refresh reaches an unregistered cwd's on-disk cac
 				version: WORKSPACE_DIAGNOSTICS_CACHE_VERSION,
 				entries: {
 					[normalizeMapKey(filePath)]: {
-						diagnostics: [{ message: "stale" } as any],
+						diagnostics: [{ message: "stale", serverId: "typescript" } as any],
 						count: 1,
 						mtimeMs: 1,
 						scannedAt: Date.now(),

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -15,6 +15,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { hashDiagnosticContent } from "../../../clients/lsp/diagnostic-binding.js";
 
 const getServersForFileWithConfig = vi.fn();
@@ -30,6 +33,7 @@ vi.mock("../../../clients/latency-logger.js", async (importActual) => ({
 
 vi.mock("../../../clients/lsp/config.js", () => ({
 	getServersForFileWithConfig,
+	primaryServerId: vi.fn(() => "ts-primary"),
 	getServerInitOverride: vi.fn().mockReturnValue(undefined),
 }));
 
@@ -84,7 +88,9 @@ function makeAuxServer(id: string, ext = ".ts") {
 	};
 }
 
-function makeDiagnostic(message: string) {
+function makeDiagnostic(
+	message: string,
+): import("../../../clients/lsp/client.js").LSPDiagnostic {
 	return {
 		severity: 1 as const,
 		message,
@@ -310,6 +316,55 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 		vi.useRealTimers();
 		vi.restoreAllMocks();
 		delete process.env.PI_LENS_AUX_GRACE_MS;
+	});
+
+	it("partitions real lens_diagnostics results by delivering server id (#2776)", async () => {
+		vi.useRealTimers();
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "lsp-provenance-"));
+		const file = path.join(root, "main.ts");
+		fs.writeFileSync(file, "const value = 1;\n");
+		try {
+			const { createLensDiagnosticsTool } =
+				await import("../../../tools/lens-diagnostics.js");
+			const primary = makePrimaryServer("ts-primary");
+			const auxiliary = makeAuxServer("auxiliary-profile");
+			getServersForFileWithConfig.mockReturnValue([primary, auxiliary]);
+			const primaryClient = makeClient(
+				0,
+				[{ ...makeDiagnostic("eslint primary"), source: "eslint" }],
+				{ serverId: "ts-primary" },
+			);
+			const auxiliaryClient = makeClient(
+				0,
+				[{ ...makeDiagnostic("auxiliary finding"), source: "auxiliary" }],
+				{ serverId: "auxiliary-profile" },
+			);
+			createLSPClient
+				.mockResolvedValueOnce(primaryClient)
+				.mockResolvedValueOnce(auxiliaryClient);
+
+			const { LSPService } = await import("../../../clients/lsp/index.js");
+			const service = new LSPService();
+			const result = await createLensDiagnosticsTool(
+				{ readCache: vi.fn() } as never,
+				() => root,
+				() => service,
+			).execute(
+				"provenance-2776",
+				{ mode: "full", paths: [file], refreshRunners: "none" },
+				new AbortController().signal,
+				null,
+				{ cwd: root },
+			);
+			const details = result.details as {
+				lspPrimaryDiagnosticsCount?: number;
+				lspAuxiliaryDiagnosticsCount?: number;
+			};
+			expect(details.lspPrimaryDiagnosticsCount).toBe(1);
+			expect(details.lspAuxiliaryDiagnosticsCount).toBe(1);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("completes at primary+auxGrace, not at the aux deadline", async () => {

--- a/tests/clients/lsp/service-touch-collect.test.ts
+++ b/tests/clients/lsp/service-touch-collect.test.ts
@@ -175,6 +175,7 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 		const { LSPService } = await import("../../../clients/lsp/index.js");
 		const service = new LSPService();
 		const diagnostic = makeDiagnostic("collected error");
+		const attributedDiagnostic = { ...diagnostic, serverId: "python" };
 		const client = {
 			isAlive: () => true,
 			shutdown: async () => {},
@@ -211,13 +212,14 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 			true,
 		);
 		expect(client.waitForDiagnostics).toHaveBeenCalledWith(FILE, 25);
-		expect(result?.diags).toEqual([diagnostic]);
+		expect(result?.diags).toEqual([attributedDiagnostic]);
 	});
 
 	it("skips notify.open on the second touch with identical content but still waits for diagnostics (#116)", async () => {
 		const { LSPService } = await import("../../../clients/lsp/index.js");
 		const service = new LSPService();
 		const diagnostic = makeDiagnostic("collected error");
+		const attributedDiagnostic = { ...diagnostic, serverId: "python" };
 		const client = {
 			isAlive: () => true,
 			shutdown: async () => {},
@@ -266,7 +268,7 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 
 		expect(client.notify.open).toHaveBeenCalledTimes(1);
 		expect(client.waitForDiagnostics).toHaveBeenCalledWith(FILE, 25);
-		expect(result?.diags).toEqual([diagnostic]);
+		expect(result?.diags).toEqual([attributedDiagnostic]);
 	});
 
 	it("sends notify.open again when the second touch has different content", async () => {
@@ -752,6 +754,7 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 			const { LSPService } = await import("../../../clients/lsp/index.js");
 			const service = new LSPService();
 			const diagnostic = makeDiagnostic("real error");
+			const attributedDiagnostic = { ...diagnostic, serverId: "python" };
 			// First client call: confirms one real diagnostic (fast, no timeout).
 			let diagnosticsToReturn = [diagnostic];
 			const client = {
@@ -778,9 +781,9 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 				maxDiagnosticsWaitMs: 8000,
 				source: "dispatch-lsp-runner",
 			});
-			expect(firstResult?.diags).toEqual([diagnostic]);
+			expect(firstResult?.diags).toEqual([attributedDiagnostic]);
 			expect((firstResult as any).inconclusive).not.toBe(true);
-			expect(service.getLastKnownDiagnostics(FILE)).toEqual([diagnostic]);
+			expect(service.getLastKnownDiagnostics(FILE)).toEqual([attributedDiagnostic]);
 
 			// Second touch: content changed (so notify isn't skipped) and the
 			// diagnostics wait is forced to time out via maxDiagnosticsWaitMs: 0
@@ -812,13 +815,14 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 			).toBe(true);
 			expect({ ...secondResult }.inconclusive).toBe(true);
 			// The prior confirmed non-empty record must survive untouched.
-			expect(service.getLastKnownDiagnostics(FILE)).toEqual([diagnostic]);
+			expect(service.getLastKnownDiagnostics(FILE)).toEqual([attributedDiagnostic]);
 		});
 
 		it("a confirmed (non-timeout) empty result still clears lastKnownDiagnostics as before", async () => {
 			const { LSPService } = await import("../../../clients/lsp/index.js");
 			const service = new LSPService();
 			const diagnostic = makeDiagnostic("real error");
+			const attributedDiagnostic = { ...diagnostic, serverId: "python" };
 			let diagnosticsToReturn = [diagnostic];
 			const client = {
 				isAlive: () => true,
@@ -844,7 +848,7 @@ describe("LSPService.touchFile collectDiagnostics", () => {
 				maxDiagnosticsWaitMs: 8000,
 				source: "dispatch-lsp-runner",
 			});
-			expect(service.getLastKnownDiagnostics(FILE)).toEqual([diagnostic]);
+			expect(service.getLastKnownDiagnostics(FILE)).toEqual([attributedDiagnostic]);
 
 			// Second touch: content changed, generous budget (no timeout), and the
 			// server genuinely reports zero diagnostics this time — the existing

--- a/tests/clients/lsp/silent-clean-confirm.test.ts
+++ b/tests/clients/lsp/silent-clean-confirm.test.ts
@@ -288,6 +288,7 @@ describe("touchFile capability-aware AGGREGATE wait (#814)", () => {
 			},
 			source: "typos",
 		};
+		const attributedFinding = { ...finding, serverId: "typos" };
 		createLSPClient.mockImplementation(async (opts: { serverId: string }) => {
 			if (opts.serverId === "typos") {
 				return makePublishingClient("typos", tmp, filePath, [finding]);
@@ -307,7 +308,7 @@ describe("touchFile capability-aware AGGREGATE wait (#814)", () => {
 
 		expect((result as { inconclusive?: boolean }).inconclusive).toBeUndefined();
 		expect(result?.confirmation).toBe("confirmed");
-		expect(result?.diags).toEqual([finding]);
+		expect(result?.diags).toEqual([attributedFinding]);
 	});
 
 	it("#1277: scope-all — the still-outstanding silent server is WEDGED (fails the liveness ping), so the touch stays INCONCLUSIVE even though the publishing sibling answered", async () => {

--- a/tests/clients/lsp/workspace-diagnostics-cache-expiry.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-cache-expiry.test.ts
@@ -50,6 +50,7 @@ function blockingDiagnostic(): LSPDiagnostic {
 		severity: 1,
 		code: 2339,
 		source: "typescript",
+		serverId: "typescript",
 		message: "Property 'foo' does not exist on type 'Bar'.",
 	};
 }

--- a/tests/clients/lsp/workspace-diagnostics-cache.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-cache.test.ts
@@ -34,10 +34,15 @@ import {
 	saveProjectSnapshot,
 } from "../../../clients/project-snapshot.js";
 import { removeTempDirSync } from "../test-utils.js";
+import {
+	getDegradationSummary,
+	resetDegradationLedger,
+} from "../../../clients/degradation-ledger.js";
 
 let tmp: string;
 
 beforeEach(() => {
+	resetDegradationLedger();
 	tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-lsp-cache-"));
 	// Legacy per-project data dir marker so the cache file writes INSIDE tmp
 	// (cleaned up by afterEach) instead of the real global ~/.pi-lens dir.
@@ -119,6 +124,59 @@ describe("loadWorkspaceDiagnosticsCache / saveWorkspaceDiagnosticsCache (#671)",
 			JSON.stringify({ version: WORKSPACE_DIAGNOSTICS_CACHE_VERSION }),
 		);
 		expect(loadWorkspaceDiagnosticsCache(tmp)).toBeUndefined();
+	});
+
+	it("rejects only a v3 entry whose diagnostic lacks serverId (#2776)", () => {
+		saveWorkspaceDiagnosticsCache(tmp, {
+			version: WORKSPACE_DIAGNOSTICS_CACHE_VERSION,
+			entries: {
+				bad: makeEntry({
+					diagnostics: [
+						{
+							severity: 1,
+							message: "missing provenance",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 1 },
+							},
+						},
+					],
+				}),
+				good: makeEntry({
+					diagnostics: [
+						{
+							severity: 1,
+							message: "kept",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 1 },
+							},
+							serverId: "typescript",
+						},
+					],
+				}),
+			},
+		});
+
+		expect(loadWorkspaceDiagnosticsCache(tmp)?.entries).toEqual(
+			expect.objectContaining({ good: expect.anything() }),
+		);
+		expect(loadWorkspaceDiagnosticsCache(tmp)?.entries.bad).toBeUndefined();
+	});
+
+	it("records one bounded migration degradation with the old version and entry count (#2776)", () => {
+		saveWorkspaceDiagnosticsCache(tmp, {
+			version: 2,
+			entries: { a: makeEntry(), b: makeEntry() },
+		});
+		expect(loadWorkspaceDiagnosticsCache(tmp)).toBeUndefined();
+		expect(loadWorkspaceDiagnosticsCache(tmp)).toBeUndefined();
+		const group = getDegradationSummary().find(
+			(entry) => entry.kind === "lsp-workspace-cache-migration",
+		);
+		expect(group?.count).toBe(1);
+		expect(group?.latestReasons[0]?.reason).toContain("v2");
+		expect(group?.latestReasons[0]?.reason).toContain("2 entries");
 	});
 });
 
@@ -355,6 +413,7 @@ describe("WorkspaceDiagnosticsCacheContext (#671)", () => {
 					start: { line: 0, character: 0 },
 					end: { line: 0, character: 1 },
 				},
+				serverId: "typescript",
 			},
 		];
 
@@ -1094,9 +1153,16 @@ describe("runWorkspaceDiagnostics cache integration (#671)", () => {
 		const { client, waitCalls } = makeFakeClient(tmpSweep);
 		createLSPClient.mockResolvedValue(client);
 		const { LSPService } = await import("../../../clients/lsp/index.js");
-		await new LSPService().runWorkspaceDiagnostics(tmpSweep);
+		const service = new LSPService();
+		await service.runWorkspaceDiagnostics(tmpSweep);
 
 		expect(waitCalls.length).toBeGreaterThan(0);
+		const callsAfterMigration = waitCalls.length;
+		expect(loadWorkspaceDiagnosticsCache(tmpSweep)?.version).toBe(
+			WORKSPACE_DIAGNOSTICS_CACHE_VERSION,
+		);
+		await service.runWorkspaceDiagnostics(tmpSweep);
+		expect(waitCalls.length).toBe(callsAfterMigration);
 	});
 });
 

--- a/tests/clients/lsp/workspace-diagnostics-cache.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-cache.test.ts
@@ -96,6 +96,16 @@ describe("loadWorkspaceDiagnosticsCache / saveWorkspaceDiagnosticsCache (#671)",
 		expect(loadWorkspaceDiagnosticsCache(tmp)).toBeUndefined();
 	});
 
+	it("fails open on a v2 cache so provenance-less diagnostics are re-collected (#2776)", () => {
+		saveWorkspaceDiagnosticsCache(tmp, {
+			version: WORKSPACE_DIAGNOSTICS_CACHE_VERSION - 1,
+			entries: { "/a.ts": makeEntry() },
+		});
+		// Old records still parse safely, but the strict cache consumer refuses
+		// to serve them because their diagnostics have no serverId provenance.
+		expect(loadWorkspaceDiagnosticsCache(tmp)).toBeUndefined();
+	});
+
 	it("fails open when entries is missing/malformed", () => {
 		const cacheFile = path.join(
 			tmp,
@@ -1048,6 +1058,44 @@ describe("runWorkspaceDiagnostics cache integration (#671)", () => {
 		await service.runWorkspaceDiagnostics(tmpSweep);
 		// The mismatched entry was NOT served — a.ts (the only file) fell through to
 		// a fresh touch. A served cache hit would have produced zero wait calls.
+		expect(waitCalls.length).toBeGreaterThan(0);
+	});
+
+	it("re-collects a provenance-less v2 entry instead of replaying it (#2776)", async () => {
+		const file = path.join(tmpSweep, "a.ts");
+		fs.writeFileSync(file, "const z = 1;\n");
+		const stat = fs.statSync(file);
+		saveWorkspaceDiagnosticsCache(tmpSweep, {
+			version: WORKSPACE_DIAGNOSTICS_CACHE_VERSION - 1,
+			entries: {
+				[cacheKeyFor(file)]: {
+					diagnostics: [
+						{
+							severity: 1,
+							message: "old primary finding",
+							range: {
+								start: { line: 0, character: 0 },
+								end: { line: 0, character: 1 },
+							},
+						},
+					],
+					count: 1,
+					mtimeMs: stat.mtimeMs,
+					scannedAt: Date.now(),
+					scopeKey: buildScopeKey("all", ["opengrep"]),
+				},
+			},
+		});
+
+		const tsServer = makeTsServer(tmpSweep);
+		getServersForFileWithConfig.mockImplementation((fp: string) =>
+			fp.endsWith(".ts") ? [tsServer] : [],
+		);
+		const { client, waitCalls } = makeFakeClient(tmpSweep);
+		createLSPClient.mockResolvedValue(client);
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		await new LSPService().runWorkspaceDiagnostics(tmpSweep);
+
 		expect(waitCalls.length).toBeGreaterThan(0);
 	});
 });

--- a/tests/clients/lsp/workspace-diagnostics-clean-reanswer.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-clean-reanswer.test.ts
@@ -57,6 +57,7 @@ function ghostDiagnostic() {
 		severity: 1 as const,
 		code: 2339,
 		source: "typescript",
+		serverId: "typescript",
 		message: "Property 'foo' does not exist on type 'Bar'.",
 	};
 }

--- a/tests/clients/lsp/workspace-diagnostics-pull-binding.test.ts
+++ b/tests/clients/lsp/workspace-diagnostics-pull-binding.test.ts
@@ -89,7 +89,11 @@ describe("runWorkspaceDiagnostics pull-sweep content binding (#1104)", () => {
 			getOperationSupport: () => ({}),
 			notify: { open: vi.fn(async () => {}) },
 			requestWorkspaceDiagnostics: vi.fn(async () => [
-				{ filePath: file, diagnostics: [{ message: "boom" }], contentHash },
+				{
+					filePath: file,
+					diagnostics: [{ message: "boom", serverId: "python" }],
+					contentHash,
+				},
 			]),
 			waitForDiagnostics: vi.fn().mockResolvedValue(undefined),
 			getDiagnostics: vi.fn(() => []),
@@ -118,7 +122,7 @@ describe("runWorkspaceDiagnostics pull-sweep content binding (#1104)", () => {
 		const requestWorkspaceDiagnostics = vi.fn(async () => [
 			{
 				filePath: file,
-				diagnostics: [{ message: "boom" }],
+				diagnostics: [{ message: "boom", serverId: "python" }],
 				contentHash: hashDiagnosticContent(originalContent),
 			},
 		]);

--- a/tests/config/lsp-spawn-heavy-coverage.test.ts
+++ b/tests/config/lsp-spawn-heavy-coverage.test.ts
@@ -211,7 +211,7 @@ describe("lsp-spawn-heavy Vitest project coverage", () => {
 			// excluded); half rounded up is 429, documented floor 430.
 			scannedCount: files.length,
 			minScanned: 430,
-			// Calibration: 19 spawning-test candidates on 2026-08-30 (4 phased,
+			// Calibration: 20 spawning-test candidates on 2026-09-09 (5 phased,
 			// 15 exempted); half rounded up is 10.
 			minFlagged: 10,
 			remediation:

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -1236,12 +1236,14 @@ describe("lens_diagnostics mode=full", () => {
 								start: { line: 1, character: 0 },
 								end: { line: 1, character: 5 },
 							},
-							source: "typescript",
+							serverId: "typescript",
+							source: "eslint",
 							code: 2322,
 						},
 						{
 							severity: 2,
 							message: "ast-grep rule hit",
+							serverId: "ast-grep",
 							range: {
 								start: { line: 2, character: 0 },
 								end: { line: 2, character: 5 },

--- a/tests/tools/lsp-diagnostics-2776.test.ts
+++ b/tests/tools/lsp-diagnostics-2776.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression coverage for #2776: a custom primary LSP's server-authored
+ * diagnostic source must not make its finding render as auxiliary.
+ *
+ * This drives the real custom-server loader, LSPService, and tool handler.
+ * The fake server declares pull diagnostics, ignores the pull, and pushes the
+ * diagnostic so the collection path must preserve the delivering server id.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const fixture = fileURLToPath(
+	new URL("../fixtures/fake-lsp-server.mjs", import.meta.url),
+);
+const root = fs.mkdtempSync(path.join(process.cwd(), ".probe-2776-"));
+const probeFixture = path.join(root, "fake-lsp-server.mjs");
+const fixtureSource = fs.readFileSync(fixture, "utf8");
+fs.writeFileSync(
+	probeFixture,
+	fixtureSource
+		.replace(
+			'if (data.method === "textDocument/diagnostic") {',
+			'if (data.method === "textDocument/diagnostic") {\n\t\tif (process.env.PROBE_IGNORE_PULL === "1") return;',
+		)
+		.replace(
+			"diagnostics: [],",
+			'diagnostics: [{ severity: 1, source: "probe-2776", code: "P2776", message: "syntax error from push", range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } } }],',
+		),
+);
+
+process.env.PI_LENS_HOME = path.join(root, ".pi-lens-home");
+process.env.FAKE_LSP_NOTIFY_BACKLOG_WEDGE = "1";
+process.env.PROBE_IGNORE_PULL = "1";
+
+describe("#2776 custom primary diagnostic provenance", () => {
+	const workspace = path.join(root, "workspace");
+	const file = path.join(workspace, "broken.lua");
+	let service: { shutdown: () => Promise<void> } | undefined;
+
+	beforeAll(async () => {
+		fs.mkdirSync(path.join(workspace, ".pi-lens"), { recursive: true });
+		fs.writeFileSync(file, "syntax error\n");
+		fs.writeFileSync(
+			path.join(workspace, ".pi-lens", "lsp.json"),
+			JSON.stringify({
+				servers: {
+					emmylua: {
+						name: "probe custom emmylua",
+						extensions: [".lua"],
+						command: process.execPath,
+						args: [probeFixture],
+						rootMarkers: [".luarc.json", ".git"],
+					},
+				},
+				disabledServers: ["lua"],
+			}),
+		);
+		const config = await import("../../clients/lsp/config.js");
+		await config.initLSPConfig(workspace);
+		const lsp = await import("../../clients/lsp/index.js");
+		service = lsp.getLSPService();
+	});
+
+	afterAll(async () => {
+		await service?.shutdown();
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it("reports a pushed primary diagnostic even when source is server-authored", async () => {
+		const { createLspDiagnosticsTool } =
+			await import("../../tools/lsp-diagnostics.js");
+		const result = (await createLspDiagnosticsTool().execute(
+			"probe-2776",
+			{ path: file, waitMs: 2000, serverScope: "primary" },
+			undefined,
+			null,
+			{ cwd: workspace },
+		)) as any;
+		const text = String(result.content[0]?.text);
+
+		expect(text).toContain("Primary LSP (emmylua): 1 diagnostic.");
+		expect(text).not.toContain("Primary LSP (emmylua): confirmed clean.");
+		expect(result.details?.primaryDiagnosticsCount).toBe(1);
+		expect(result.details?.auxiliaryDiagnosticsCount).toBe(0);
+	});
+});

--- a/tests/tools/lsp-diagnostics-2776.test.ts
+++ b/tests/tools/lsp-diagnostics-2776.test.ts
@@ -1,3 +1,9 @@
+// #2776: this regression must run against the real fake-server wire. The
+// handler verdict depends on a custom primary server pushing a diagnostic
+// after the pull request is ignored, so mocked clients cannot reproduce the
+// server-id provenance path. Admit this file to the serialized
+// lsp-spawn-heavy lane to keep its real initialize/diagnostics exchange out
+// of the default project's fork storm.
 /**
  * Regression coverage for #2776: a custom primary LSP's server-authored
  * diagnostic source must not make its finding render as auxiliary.

--- a/tests/tools/lsp-diagnostics-cache.test.ts
+++ b/tests/tools/lsp-diagnostics-cache.test.ts
@@ -213,6 +213,7 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 				end: { line: 0, character: 1 },
 			},
 			source: "typescript",
+			serverId: "typescript",
 		};
 		touchFile.mockResolvedValueOnce({ diags: [diag] });
 
@@ -245,6 +246,7 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 				end: { line: 0, character: 1 },
 			},
 			source: "typescript",
+			serverId: "typescript",
 		};
 		touchFile.mockResolvedValueOnce({
 			diags: [diag],
@@ -285,6 +287,7 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 						end: { line: 0, character: 1 },
 					},
 					source: "typescript",
+					serverId: "typescript",
 				},
 			],
 			confirmation: "partial",
@@ -330,6 +333,7 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 						end: { line: 0, character: 1 },
 					},
 					source: "typescript",
+					serverId: "typescript",
 				},
 			],
 			confirmation: "partial",
@@ -362,6 +366,7 @@ describe("lsp_diagnostics batch — workspace-diagnostics cache (#671)", () => {
 				end: { line: 0, character: 1 },
 			},
 			source: "typescript",
+			serverId: "typescript",
 		};
 		touchFile.mockResolvedValueOnce({ diags: [diag] });
 

--- a/tests/tools/lsp-diagnostics.test.ts
+++ b/tests/tools/lsp-diagnostics.test.ts
@@ -2049,6 +2049,7 @@ describe("lsp_diagnostics tool", () => {
 									end: { line: 0, character: 1 },
 								},
 								source: "typescript",
+								serverId: "typescript",
 							},
 							{
 								severity: 2,
@@ -2058,6 +2059,7 @@ describe("lsp_diagnostics tool", () => {
 									end: { line: 1, character: 1 },
 								},
 								source: "ast-grep",
+								serverId: "ast-grep",
 							},
 						];
 					}
@@ -2303,6 +2305,7 @@ describe("lsp_diagnostics tool", () => {
 									end: { line: 0, character: 1 },
 								},
 								source: "typescript",
+								serverId: "typescript",
 							},
 						];
 					}
@@ -2316,6 +2319,7 @@ describe("lsp_diagnostics tool", () => {
 									end: { line: 0, character: 1 },
 								},
 								source: "ast-grep",
+								serverId: "ast-grep",
 							},
 						];
 					}

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -92,6 +92,7 @@ import {
 	widgetDiagnosticUri,
 } from "../clients/widget-state.js";
 import { logLatency } from "../clients/latency-logger.js";
+import { logExtension } from "../clients/extension-log.js";
 import { convertLspDiagnostics } from "../clients/dispatch/utils/lsp-diagnostics.js";
 import { retagAuxiliaryDiagnostics } from "../clients/dispatch/auxiliary-lsp.js";
 import { detectFileRole } from "../clients/file-role.js";
@@ -1505,7 +1506,7 @@ function tallyLspPrimaryVsAuxiliary(results: WorkspaceLspDiagnosticResult[]): {
 	for (const result of results) {
 		const primaryId = primaryServerId(result.filePath);
 		for (const diagnostic of result.diagnostics ?? []) {
-			if (diagnostic.source === primaryId) primary += 1;
+			if (diagnostic.serverId === primaryId) primary += 1;
 			else auxiliary += 1;
 		}
 	}
@@ -2140,6 +2141,31 @@ async function formatFullMode(
 	// so a page of ast-grep/opengrep/marksman noise never buries whether the
 	// real language server itself found anything in this sweep.
 	const lspPrimaryVsAuxiliary = tallyLspPrimaryVsAuxiliary(confirmedLspResults);
+	logExtension({
+		subsystem: "lsp-diagnostics",
+		message: "lens_diagnostics verdict",
+		metadata: {
+			server: [
+				...new Set(
+					confirmedLspResults.map(
+						(result) => primaryServerId(result.filePath) ?? "unknown",
+					),
+				),
+			].join(","),
+			primary: lspPrimaryVsAuxiliary.primary,
+			auxiliary: lspPrimaryVsAuxiliary.auxiliary,
+			total: lspPrimaryVsAuxiliary.primary + lspPrimaryVsAuxiliary.auxiliary,
+			sources: [
+				...new Set(
+					confirmedLspResults.flatMap((result) =>
+						(result.diagnostics ?? []).map(
+							(diagnostic) => diagnostic.source ?? "unknown",
+						),
+					),
+				),
+			].slice(0, 5),
+		},
+	});
 	const lspPrimaryVsAuxiliaryNote =
 		lspPrimaryVsAuxiliary.primary + lspPrimaryVsAuxiliary.auxiliary > 0
 			? `\n\nLSP sweep findings: ${lspPrimaryVsAuxiliary.primary} primary (language server), ` +

--- a/tools/lsp-diagnostics.ts
+++ b/tools/lsp-diagnostics.ts
@@ -117,6 +117,7 @@ type FileDiag = {
 	severity: number;
 	message: string;
 	source?: string;
+	serverId?: string;
 	code?: string | number;
 };
 
@@ -749,7 +750,7 @@ async function collectDiagnosticsForFile(
 				const scopedDiagnostics =
 					serverScope === "primary"
 						? attached.response.diagnostics.filter(
-								(item) => item.source === primaryServerId(absPath),
+								(item) => item.serverId === primaryServerId(absPath),
 							)
 						: attached.response.diagnostics;
 				const filtered = applyAuxiliarySuppressions(
@@ -861,6 +862,7 @@ function diagnosticsToFileDiags(
 		severity: d.severity,
 		message: d.message,
 		source: d.source,
+		serverId: d.serverId,
 		code: d.code,
 	}));
 }
@@ -1460,8 +1462,8 @@ async function runFileDiagnostics(
 	}
 
 	const primaryId = primaryServerId(absPath);
-	const primaryDiags = limited.filter((d) => d.source === primaryId);
-	const auxiliaryDiags = limited.filter((d) => d.source !== primaryId);
+	const primaryDiags = limited.filter((d) => d.serverId === primaryId);
+	const auxiliaryDiags = limited.filter((d) => d.serverId !== primaryId);
 
 	// Primary confirmation is always its own line, independent of how many
 	// auxiliary findings exist — a wall of ast-grep/opengrep noise must never
@@ -1804,10 +1806,10 @@ async function collectBatchDiagnostics(
 		results.map((r) => [r.file, r.primaryServerId] as const),
 	);
 	const primaryDisplay = display.filter(
-		(d) => d.source === primaryIdByFile.get(d.file),
+		(d) => d.serverId === primaryIdByFile.get(d.file),
 	);
 	const auxiliaryDisplay = display.filter(
-		(d) => d.source !== primaryIdByFile.get(d.file),
+		(d) => d.serverId !== primaryIdByFile.get(d.file),
 	);
 	return {
 		results,
@@ -1950,10 +1952,10 @@ async function runBatchFileDiagnostics(
 				outcome: result.outcome,
 				reason: result.inconclusiveReason ?? result.error ?? result.unavailable,
 				primaryDiagnosticsCount: result.diagnostics.filter(
-					(diagnostic) => diagnostic.source === result.primaryServerId,
+					(diagnostic) => diagnostic.serverId === result.primaryServerId,
 				).length,
 				auxiliaryDiagnosticsCount: result.diagnostics.filter(
-					(diagnostic) => diagnostic.source !== result.primaryServerId,
+					(diagnostic) => diagnostic.serverId !== result.primaryServerId,
 				).length,
 			})),
 			outcomeCounts,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -275,6 +275,10 @@ const timingSensitiveInclude = [
 // silently goes stale.
 const lspSpawnHeavyInclude = [
 	"tests/clients/ast-grep-rule-precedence-followups.test.ts",
+	// #2776: the real fake-server wire is the only way to reproduce the
+	// custom-primary handler verdict after pull diagnostics are ignored and a
+	// server-authored diagnostic is pushed; keep that handshake in this lane.
+	"tests/tools/lsp-diagnostics-2776.test.ts",
 	// #2344: npm test leaves this real-child integration suite in the default
 	// project unless it is explicitly phased here. `test:integration` still
 	// selects the same file positionally, while `test:unit` excludes it below.
@@ -542,7 +546,7 @@ export default defineConfig({
 					globalSetup: sharedGlobalSetup,
 					setupFiles: sharedSetupFiles,
 					execArgv: sharedExecArgv,
-					// Full serialization, not just a cap: four files, but the point
+					// Full serialization, not just a cap: five files, but the point
 					// is to guarantee zero overlap with the "default" project's
 					// fork storm (the actual contention source, see #1022/#2332
 					// above), not to bound intra-project concurrency.


### PR DESCRIPTION
## Round 4

### Summary

Strictly validate every cached diagnostic's `serverId` at the shared cache loader. Reject only the invalid entry so the next sweep re-collects it. Record v1/v2 cache rejection once per session with the old version and entry count. The v2 migration test proves one re-collection, a v3 rewrite, and zero additional diagnostic waits on the unchanged second invocation.

The real `lens_diagnostics` handler test uses one primary and one auxiliary server on one file. It proves a primary diagnostic with `source: "eslint"` remains primary, while the auxiliary diagnostic remains auxiliary because partitioning uses `serverId`.

The reporter's second symptom, mode=full `1 unconfirmed (timed out)`, is deferred to wait-hardening scope in #2781.

### Tests

- `tests/clients/lsp/workspace-diagnostics-cache.test.ts`: added v3 per-entry provenance rejection, bounded migration-record coverage, and the v2-to-v3 re-collection sequence.
- `tests/clients/lsp/service-aux-grace.test.ts`: added one real `lens_diagnostics` handler test with primary and auxiliary server-role clients on one file.
- Updated persisted-diagnostic fixtures in `tests/tools/lsp-diagnostics-cache.test.ts`, `tests/clients/lsp/workspace-diagnostics-cache-expiry.test.ts`, `tests/clients/lsp/workspace-diagnostics-clean-reanswer.test.ts`, `tests/clients/lsp/workspace-diagnostics-pull-binding.test.ts`, and `tests/clients/lsp/refresh-and-sync-kind.test.ts` to include the required provenance field.

Red-first and mutation evidence:

- Before the strict loader fix, `rejects only a v3 entry whose diagnostic lacks serverId` served the invalid entry: `Received: { diagnostics: [{ message: "missing provenance", ... }] }`.
- With the strict predicate mutated in built `clients/lsp/workspace-diagnostics-cache.js` to `false`, the same test failed: `expected ... to be undefined`, and the missing-provenance entry was received.
- With the migration `recordDegradationOnce` mutated in built output to a no-op, `records one bounded migration degradation` failed: `expected undefined to be 1`.

### Blast radius

The changed loader is called by `createWorkspaceDiagnosticsCacheContext`, which is consumed by `LSPService.runWorkspaceDiagnostics` and `tools/lsp-diagnostics.ts`. Invalid persisted entries now take their existing cache-miss path. Valid entries and empty diagnostic entries retain the existing behavior.

### Class sweep

Searched all `loadWorkspaceDiagnosticsCache`, `createWorkspaceDiagnosticsCacheContext`, and `serverId` diagnostic attribution call sites. Both cache consumers use the shared strict loader. Runtime attribution already stamps live results through `attributeDiagnostics`; no sibling loader or parallel partition predicate was found.

### Observability

`lsp-workspace-cache-migration` uses `recordDegradationOnce`, keyed by the resolved workspace cache root. Its reason carries the rejected old version and entry count, so upgrade cost is visible once per session without per-file noise.

### Verification

`PI_LENS_HOME=$PWD/.probe-home` is used for probe and test runs. `CHANGELOG.md` remains untouched. The required directory suites, lint, and build are run in this worktree; four `server-policy` “falls back to file directory” failures are environmental here and are reported separately.

## Round 5 — lane admission

Admit `tests/tools/lsp-diagnostics-2776.test.ts` to the serialized `lsp-spawn-heavy` Vitest project. The regression must use the real fake-server wire because only that exchange reproduces the custom-primary handler verdict after pull diagnostics are ignored and a server-authored diagnostic is pushed. `tests/clients/lsp/service-aux-grace.test.ts` uses mocked clients and fake process objects, so it is not a real-child candidate and remains outside the lane.

### Tests

- `tests/config/lsp-spawn-heavy-coverage.test.ts`: update the registered-or-fail baseline from four to five phased candidates.
- `tests/tools/lsp-diagnostics-2776.test.ts`: add the real-wire admission header and run it under the serialized lane.

### Orchestrator run (rounds 4+5, 2026-09-09, outside the codex sandbox)

```text
build ok, lint ok
tests/tools/ + tests/clients/lsp/ — 1731 passed (4 environmental server-policy reds, identical on master here)
tests/config/ (lane membership, baselines, spawn-heavy coverage) — 37 files, 355 passed
```
