### PR TITLE
ci(strictness): spike — scratch configs, per-directory report, two-sided ratchet, advisory lane (refs #2697)

### DIFF
--- a/.changelog/2697-strictness-spike.md
+++ b/.changelog/2697-strictness-spike.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Add a TypeScript strictness spike with scratch configs, per-directory counts, a two-sided ratchet, and an advisory report lane (refs #2697)** — the migration remains staged by directory instead of enabling either flag globally.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -642,6 +642,30 @@ jobs:
           path: reports/complexity/complexity.md
           if-no-files-found: ignore
 
+  strictness:
+    name: strictness (advisory)
+    needs: validate-merge-train-dispatch
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.sha || github.ref }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Generate strictness report
+        run: node scripts/strictness-report.mjs | tee strictness-report.txt
+      - name: Publish strictness report
+        if: always()
+        run: cat strictness-report.txt >> "$GITHUB_STEP_SUMMARY"
+
   yamllint:
     name: yamllint (advisory)
     needs: validate-merge-train-dispatch

--- a/scripts/strictness-report.d.mts
+++ b/scripts/strictness-report.d.mts
@@ -1,0 +1,15 @@
+export interface StrictnessResult {
+	config: string;
+	exitCode: number;
+	total: number;
+	counts: Record<string, number>;
+}
+
+export declare const REPORT_ROOTS: readonly string[];
+export declare function parseDiagnostics(
+	output: string,
+	repoRoot: string,
+): Record<string, number>;
+export declare function runCheck(config: string, repoRoot?: string): StrictnessResult;
+export declare function formatReport(summary: StrictnessResult[]): string;
+export declare function main(argv?: string[]): void;

--- a/scripts/strictness-report.mjs
+++ b/scripts/strictness-report.mjs
@@ -1,0 +1,93 @@
+import { spawnSync } from "node:child_process";
+import { resolve, relative, sep } from "node:path";
+
+export const REPORT_ROOTS = ["clients", "tools", "mcp", "scripts", "tests"];
+
+function reportDirectory(file) {
+	const normalized = file.split(sep).join("/");
+	const root = REPORT_ROOTS.find(
+		(candidate) => normalized === candidate || normalized.startsWith(`${candidate}/`),
+	);
+	if (!root) return "other";
+	const parts = normalized.split("/");
+	const rootIndex = parts.indexOf(root);
+	const directoryParts = parts.slice(0, -1);
+	// Keep two directory levels below each configured root. This preserves
+	// useful runner/LSP buckets such as tests/clients/dispatch/runners.
+	return directoryParts.slice(rootIndex, rootIndex + 4).join("/") || root;
+}
+
+export function parseDiagnostics(output, repoRoot) {
+	const counts = new Map();
+	const diagnosticPattern = /^(.*)\((\d+),(\d+)\): error TS\d+/;
+	for (const line of String(output).split(/\r?\n/)) {
+		const match = diagnosticPattern.exec(line);
+		if (!match) continue;
+		const file = relative(repoRoot, resolve(repoRoot, match[1]));
+		const directory = reportDirectory(file);
+		counts.set(directory, (counts.get(directory) ?? 0) + 1);
+	}
+	return Object.fromEntries([...counts].sort(([a], [b]) => a.localeCompare(b)));
+}
+
+export function runCheck(config, repoRoot = resolve(import.meta.dirname, "..")) {
+	const tsc = resolve(repoRoot, "node_modules/typescript/bin/tsc");
+	const result = spawnSync(process.execPath, [tsc, "-p", config, "--noEmit", "--pretty", "false"], {
+		cwd: repoRoot,
+		encoding: "utf8",
+	});
+	const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+	return {
+		config,
+		exitCode: result.status ?? 1,
+		total: (output.match(/^.*\(\d+,\d+\): error TS\d+/gm) ?? []).length,
+		counts: parseDiagnostics(output, repoRoot),
+	};
+}
+
+function table(summary) {
+	const directories = new Set(summary.flatMap(({ counts }) => Object.keys(counts)));
+	const rows = [...directories].sort().map((directory) =>
+		`| ${directory} | ${summary[0].counts[directory] ?? 0} | ${summary[1].counts[directory] ?? 0} |`,
+	);
+	return [
+		"| Directory | noUncheckedIndexedAccess | exactOptionalPropertyTypes |",
+		"|---|---:|---:|",
+		...rows,
+	].join("\n");
+}
+
+export function formatReport(summary) {
+	return [
+		"# TypeScript strictness spike",
+		"",
+		table(summary),
+		"",
+		"## JSON summary",
+		"",
+		"```json",
+		JSON.stringify(summary, null, 2),
+		"```",
+		"",
+	].join("\n");
+}
+
+export function main(argv = process.argv.slice(2)) {
+	const repoRoot = resolve(import.meta.dirname, "..");
+	const configs = argv.length > 0 ? argv : [
+		"tsconfig.strict-indexed.json",
+		"tsconfig.strict-optional.json",
+	];
+	const summary = configs.map((config) => runCheck(config, repoRoot));
+	process.stdout.write(formatReport(summary));
+	process.stdout.write(`\n${JSON.stringify(summary)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	try {
+		main();
+	} catch (error) {
+		console.error(`strictness report unavailable: ${error.message}`);
+	}
+	process.exitCode = 0;
+}

--- a/tests/config/advisory-tool-workflow.test.ts
+++ b/tests/config/advisory-tool-workflow.test.ts
@@ -25,6 +25,7 @@ const mutationWorkflow = yaml.load(
 
 const tools = [
 	["complexity", "complexity (advisory)"],
+	["strictness", "strictness (advisory)"],
 	["jscpd", "jscpd (advisory)"],
 	["yamllint", "yamllint (advisory)"],
 	["typos", "typos (advisory)"],

--- a/tests/config/strictness-baseline.json
+++ b/tests/config/strictness-baseline.json
@@ -1,0 +1,37 @@
+{
+	"tsconfig.strict-indexed.json": {
+		"clients": 468,
+		"clients/config-core": 18,
+		"clients/dispatch": 29,
+		"clients/dispatch/rules": 12,
+		"clients/dispatch/runners": 95,
+		"clients/dispatch/runners/utils": 3,
+		"clients/lsp": 42,
+		"clients/lsp/wait-policy": 1,
+		"clients/project-diagnostics/runner-adapters": 1,
+		"clients/redact": 16,
+		"clients/review-graph": 18,
+		"mcp": 1,
+		"scripts": 1,
+		"tools": 4
+	},
+	"tsconfig.strict-optional.json": {
+		"clients": 359,
+		"clients/config-core": 1,
+		"clients/dispatch": 18,
+		"clients/dispatch/facts": 1,
+		"clients/dispatch/runners": 32,
+		"clients/dispatch/runners/utils": 9,
+		"clients/dispatch/utils": 2,
+		"clients/installer": 25,
+		"clients/lsp": 57,
+		"clients/mcp": 6,
+		"clients/project-diagnostics": 3,
+		"clients/project-diagnostics/runner-adapters": 3,
+		"clients/redact": 2,
+		"clients/review-graph": 42,
+		"mcp": 10,
+		"scripts": 1,
+		"tools": 48
+	}
+}

--- a/tests/config/strictness-ratchet.test.ts
+++ b/tests/config/strictness-ratchet.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	runCheck,
+	type StrictnessResult,
+} from "../../scripts/strictness-report.mjs";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+const baseline = JSON.parse(
+	readFileSync(resolve(import.meta.dirname, "strictness-baseline.json"), "utf8"),
+) as Record<string, Record<string, number>>;
+const productionRoots = ["clients", "tools", "mcp", "scripts"];
+
+function productionCounts(result: StrictnessResult) {
+	return Object.fromEntries(
+		Object.entries(result.counts).filter(([directory]) =>
+			productionRoots.some(
+				(root) => directory === root || directory.startsWith(`${root}/`),
+			),
+		),
+	);
+}
+
+function compare(result: StrictnessResult, expected: Record<string, number>) {
+	const actual = productionCounts(result);
+	const problems: string[] = [];
+	for (const directory of new Set([...Object.keys(actual), ...Object.keys(expected)])) {
+		const before = expected[directory] ?? 0;
+		const after = actual[directory] ?? 0;
+		if (after > before)
+			problems.push(`${directory}: regression (${before} -> ${after})`);
+		if (after < before)
+			problems.push(
+				`${directory}: ratchet down — lower the baseline (${before} -> ${after})`,
+			);
+	}
+	return problems;
+}
+
+describe("TypeScript strictness spike ratchets", () => {
+	it(
+		"pins both scratch configurations without permitting drift",
+		() => {
+			const results = [
+				runCheck("tsconfig.strict-indexed.json", ROOT),
+				runCheck("tsconfig.strict-optional.json", ROOT),
+			];
+			for (const result of results) {
+				expect(result.exitCode).toBe(1);
+				expect(result.total).toBeGreaterThan(0);
+				expect(compare(result, baseline[result.config])).toEqual([]);
+			}
+		},
+		120_000,
+	);
+});

--- a/tests/scripts/ci-verdict.test.ts
+++ b/tests/scripts/ci-verdict.test.ts
@@ -994,6 +994,8 @@ describe("isAdvisoryCheck — every job name from a PR-triggered workflow is cla
 		"taplo (advisory)",
 		"mutation (advisory)",
 		"complexity (advisory)",
+		// #2697 item 9: the strictness census lane (two scratch tsconfigs) is advisory.
+		"strictness (advisory)",
 		"greeting",
 		// #2700 review round 3: named "oxlint (advisory)" (the `(advisory)`
 		// suffix, not a hand-maintained ci-checks.mjs entry like `greeting`

--- a/tsconfig.strict-indexed.json
+++ b/tsconfig.strict-indexed.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUncheckedIndexedAccess": true,
+		"noEmit": true
+	}
+}

--- a/tsconfig.strict-optional.json
+++ b/tsconfig.strict-optional.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"exactOptionalPropertyTypes": true,
+		"noEmit": true
+	}
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -315,6 +315,9 @@ const lspSpawnHeavyInclude = [
 // host. Sweep coverage for other members lives in this list; new entries must
 // carry a wall-clock budget assertion, not just slowness.
 const wallClockBudgetInclude = [
+	// #2697: the strictness ratchet spawns two real tsc processes and waits for
+	// their wall-clock completion; keep its 120s budget in the quiet phase.
+	"tests/config/strictness-ratchet.test.ts",
 	"tests/clients/biome-config-decorator-metadata.test.ts",
 	"tests/clients/build-identity.test.ts",
 	"tests/clients/cascade-turn-merge.test.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -315,9 +315,6 @@ const lspSpawnHeavyInclude = [
 // host. Sweep coverage for other members lives in this list; new entries must
 // carry a wall-clock budget assertion, not just slowness.
 const wallClockBudgetInclude = [
-	// #2697: the strictness ratchet spawns two real tsc processes and waits for
-	// their wall-clock completion; keep its 120s budget in the quiet phase.
-	"tests/config/strictness-ratchet.test.ts",
 	"tests/clients/biome-config-decorator-metadata.test.ts",
 	"tests/clients/build-identity.test.ts",
 	"tests/clients/cascade-turn-merge.test.ts",
@@ -368,6 +365,9 @@ const wallClockBudgetInclude = [
 	// `**` chain), so a fake clock measures nothing.
 	"tests/clients/workspace-glob-nonbacktracking-budget.test.ts",
 	"tests/config/gitignore-tracked-shadow.test.ts",
+	// #2697: the strictness ratchet spawns two real tsc processes and waits for
+	// their wall-clock completion; keep its 120s budget in the quiet phase.
+	"tests/config/strictness-ratchet.test.ts",
 	"tests/config/tracked-control-bytes.test.ts",
 	// published-manifest guard runs the real `npm pack` (flake-shape admission).
 	"tests/packaging-pack-manifest.test.ts",


### PR DESCRIPTION
## Summary

Refs #2697. This spike adds two scratch TypeScript configurations, a report-only
per-directory diagnostic census, a two-sided production ratchet, and an
advisory CI lane. It does not enable either flag in `tsconfig.json` and makes
no production-code changes. Every requested spike criterion is complete.

The measured totals are 2,660 for `noUncheckedIndexedAccess` and 742 for
`exactOptionalPropertyTypes`. The report keeps test directories visible but
does not ratchet them because fixture indexing creates noise; a later migration
wave can add tests deliberately.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [x] area:tests

## Checklist

- [x] Read `CONTRIBUTING.md`, `AGENTS.md`, and the fixer contracts.
- [x] Added the report, baseline, workflow lane, and ratchet test.
- [x] Proved both ratchet directions with compile-valid mutations; transcripts are below.
- [x] Pinned the 120,000 ms real-process test in the wall-clock-budget project with its reason.
- [x] Added one `.changelog/` fragment; `CHANGELOG.md` is untouched.
- [x] `npm run build` and `npm run lint` pass.
- [x] The `tests/config/` suite passes.
- [x] No Git commands changed repository state; this worktree remains uncommitted.

## Tests

- `tests/config/strictness-ratchet.test.ts`: runs both real `tsc` scratch checks and compares every production directory against both baseline maps. Counts above the pin report regression; counts below it require tightening the pin.
- `tests/config/advisory-tool-workflow.test.ts`: extends the real YAML contract census to require the named strictness advisory job and its tolerance.
- `tests/config/strictness-baseline.json`: records the measured production counts for each flag.

Mutation transcripts:

```text
compile-valid clients/strictness-spike-mutation.ts:
const match: string[] = ["x"];
const value: string = match[2];

Expected []
Received ["clients: regression (468 -> 469)"]
```

The inverse baseline mutation raises `clients` from 468 to 469 and proves the
ratchet-down side:

```text
Expected []
Received ["clients: ratchet down — lower the baseline (469 -> 468)"]
```

Lowering a baseline number is the opposite direction mathematically and red as
`regression (467 -> 468)`; that transcript confirms the upper guard too. The
temporary mutation file was removed before the final build and tests.

Report table from master:

| Directory | noUncheckedIndexedAccess | exactOptionalPropertyTypes |
|---|---:|---:|
| clients | 468 | 359 |
| clients/config-core | 18 | 1 |
| clients/dispatch | 29 | 18 |
| clients/dispatch/facts | 0 | 1 |
| clients/dispatch/rules | 12 | 0 |
| clients/dispatch/runners | 95 | 32 |
| clients/dispatch/runners/utils | 3 | 9 |
| clients/dispatch/utils | 0 | 2 |
| clients/installer | 0 | 25 |
| clients/lsp | 42 | 57 |
| clients/lsp/wait-policy | 1 | 0 |
| clients/mcp | 0 | 6 |
| clients/project-diagnostics | 0 | 3 |
| clients/project-diagnostics/runner-adapters | 1 | 3 |
| clients/redact | 16 | 2 |
| clients/review-graph | 18 | 42 |
| mcp | 1 | 10 |
| scripts | 1 | 1 |
| tools | 4 | 48 |
| tests | 56 | 3 |
| tests/clients | 866 | 65 |
| tests/clients/cache | 10 | 0 |
| tests/clients/config-core | 20 | 0 |
| tests/clients/dispatch | 123 | 4 |
| tests/clients/dispatch/rules | 10 | 0 |
| tests/clients/dispatch/runners | 223 | 7 |
| tests/clients/dispatch/utils | 14 | 1 |
| tests/clients/installer | 32 | 2 |
| tests/clients/lsp | 180 | 11 |
| tests/clients/mcp | 14 | 0 |
| tests/clients/project-diagnostics | 4 | 0 |
| tests/clients/review-graph | 15 | 0 |
| tests/config | 62 | 3 |
| tests/mcp | 33 | 0 |
| tests/mocks | 0 | 1 |
| tests/monorepo | 0 | 1 |
| tests/scripts | 136 | 4 |
| tests/skills | 12 | 0 |
| tests/support | 58 | 5 |
| tests/tools | 80 | 1 |

## Migration plan

Migrate one report bucket per lane, ordered by remaining count. Start with
`clients/dispatch/runners` (95 indexed, 32 optional), `clients/lsp` (42, 57),
`clients/config-core` (18, 1), `clients/review-graph` (18, 42), and then the
remaining `clients/` buckets in descending count. Migrate `tools`, `mcp`, and
`scripts` after the client lanes. Each lane updates its baseline only after
the directory is clean, then adds a two-sided ratchet pin.

The dominant indexed shape is an unchecked regex or split read, for example
`const value: string = match[2]`; narrow the match or prove the index exists.
The dominant optional-property shape is an object spread that drops an
optional property, for example `{ ...options, value }`; preserve omission
semantics or explicitly include `undefined` under the chosen type contract.

Estimated lanes: 6 client lanes for dispatch runners, LSP, config-core,
review-graph, installer/redaction, and the remaining clients; 3 follow-up
lanes for tools, mcp, and scripts. The lane count is an estimate, not a new
configuration knob.

## Test assessment

- `tests/config/strictness-ratchet.test.ts` uniquely pins the two strictness
  counts and both directions; it makes no existing test redundant.
- `tests/config/advisory-tool-workflow.test.ts` already pins advisory workflow
  contracts; this edit adds the strictness job to its existing population.

## Blast radius

No production module changed, so the production call-graph blast radius is
empty. The report is a standalone Node process invoked by CI and the ratchet;
the Vitest config is the only test-runner entry point changed. Verification
covers the build, lint, config suite, report execution, and real `tsc` child
processes.

## Observability

The report is the observability surface. It prints the table and JSON summary,
and CI appends the table and summary to `$GITHUB_STEP_SUMMARY`. The report is
advisory and always exits 0, while the local ratchet remains the bounded drift
detector for production directories.

## Class sweep

The swept class is strictness diagnostic counting and baseline drift. The
report scans `clients/`, `tools/`, `mcp/`, `scripts/`, and `tests/`, while the
ratchet population deliberately includes only the four production roots.
The workflow sweep covers the existing advisory jobs and adds strictness to
the real YAML contract census. Consolidation verdict: keep one report seam
(`scripts/strictness-report.mjs`) and one baseline seam; migration remains
distributed by directory so each wave has a reviewable error budget.

### Orchestrator run (2026-09-09, outside the codex sandbox)

```text
build ok, lint ok, fragment valid
tests/config/ (incl. strictness-ratchet + advisory-tool-workflow pin) — 38 files, 357 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV

