### PR TITLE
fix(diagnostics): guidance names mode=all as cache-only and mode=full+paths as the active check (refs #2792)

### DIFF
--- a/.changelog/fix-diagnostics-2792.md
+++ b/.changelog/fix-diagnostics-2792.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Clarify diagnostic verification guidance (refs #2792)** — `lens_diagnostics mode=all` reports cached diagnostics only, while `mode=full` with `paths` performs an active targeted check.

--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -1880,7 +1880,7 @@ function scheduleDeferredToolProbesWithClients(
 export const SESSION_START_GUIDANCE: string[] = [
 	"📌 pi-lens active — automated checks run on every edit/write; blocking errors (including pre-existing) show inline and must be fixed.\n" +
 		"Key tools (see each tool's own description for args):\n" +
-		"• lens_diagnostics — session-wide diagnostic state; mode=all resurfaces stale blocking errors that dropped from turn context.\n" +
+		"• lens_diagnostics — mode=all reports cached diagnostics only; for changed files with absent or stale cache, use mode=full with paths for an active check.\n" +
 		"• symbol_search → module_report → read_symbol/read_enclosing — ranked identifier search, then navigable outline/callback handles + exact body reads; cheaper than reading a whole file before editing.\n" +
 		"• lsp_diagnostics — probe LSP for errors in a file/folder/workspace.\n" +
 		"• Situational (activate via pi_lens_activate_tools): lsp_navigation, ast_grep_search, ast_grep_replace, ast_grep_dump.",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,8 +50,9 @@ for the consumer-facing version of this routing.
 
 pi-lens exposes these high-value tools to agents:
 
-- `lens_diagnostics` — cached diagnostic state; use `mode=all` before declaring
-  work complete, and `mode=full` for an expensive project-wide LSP scan.
+- `lens_diagnostics` — `mode=all` reports cached diagnostics only; it does not
+  verify current files. For changed files with absent or stale cache, use
+  `mode=full` with `paths` for an active targeted check.
 - `lsp_navigation` / `lsp_diagnostics` — IDE-style navigation and diagnostics.
 - `ast_grep_search` / `ast_grep_replace` — AST-aware structural search/replace.
 - `module_report` / `read_symbol` — navigable outline and targeted symbol-body
@@ -182,8 +183,8 @@ turn-end is skipped, not faked: one line on stderr and nothing on stdout.
 
 - Run `npm run build` before tests after editing TypeScript; tests import
   generated `.js` artifacts.
-- Use `lens_diagnostics mode=all` to surface stale blockers from the current
-  session.
+- Use `lens_diagnostics mode=all` to report cached blockers from the current
+  session. For an active check, use `mode=full` with `paths`.
 - Check `~/.pi-lens/sessionstart.log`, `~/.pi-lens/latency.log`, and
   `~/.pi-lens/cascade.log` for lifecycle/performance/debug traces.
 - For live tool validation, use `node scripts/smoke-tools.mjs` with the relevant

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -640,10 +640,7 @@ const ALL_TOOLS = [
 	},
 	{
 		name: "pilens_diagnostics",
-		description:
-			"Query pi-lens's diagnostic state across ALL runners (not just LSP). " +
-			"mode=delta (current turn, instant), mode=all (every dispatched file this " +
-			"session), mode=full (expensive project-wide active scan).",
+		description: lensDiagnosticsTool.description,
 		inputSchema: schemaWithCwd(lensDiagnosticsTool.parameters),
 	},
 	{

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -1337,6 +1337,13 @@ describe("context injection framing", () => {
 		// Stay lean: the orientation is a nudge, not re-documentation of every arg.
 		expect(text.length).toBeLessThan(750);
 	});
+
+	it("SESSION_START_GUIDANCE distinguishes cached reporting from active verification (#2792)", () => {
+		const text = SESSION_START_GUIDANCE.join("\n");
+		expect(text).toContain("mode=all reports cached diagnostics only");
+		expect(text).toContain("mode=full with paths for an active check");
+		expect(text).not.toContain("use mode=all to verify");
+	});
 });
 
 // ── Unresolved inline blocker re-surfacing ────────────────────────────────────

--- a/tests/mcp/server.smoke.test.ts
+++ b/tests/mcp/server.smoke.test.ts
@@ -75,7 +75,19 @@ describe("pi-lens MCP server (stdio smoke)", { retry: 2 }, () => {
 		// between the two if the mirror ever stopped being a direct passthrough.
 		const diagnosticsTool = tools.find(
 			(t) => t.name === "pilens_diagnostics",
-		) as { inputSchema: { properties?: Record<string, unknown> } } | undefined;
+		) as
+			| {
+					description?: string;
+					inputSchema: { properties?: Record<string, unknown> };
+			  }
+			| undefined;
+		expect(diagnosticsTool?.description).toContain(
+			"mode=delta/all are cache-only",
+		);
+		expect(diagnosticsTool?.description).toContain("mode=full with paths");
+		expect(diagnosticsTool?.description).not.toContain(
+			"use mode=all to verify",
+		);
 		expect(diagnosticsTool?.inputSchema.properties).toHaveProperty("paths");
 		const astSearchTool = tools.find(
 			(t) => t.name === "pilens_ast_grep_search",

--- a/tests/tools/lens-diagnostics.test.ts
+++ b/tests/tools/lens-diagnostics.test.ts
@@ -242,6 +242,22 @@ describe("lens_diagnostics compact render header", () => {
 // ── schema ────────────────────────────────────────────────────────────────────
 
 describe("lens_diagnostics schema", () => {
+	it("describes all as cache-only reporting and full with paths as active verification", () => {
+		const tool = makeTool();
+		const modeDescription = String(
+			(tool.parameters.properties.mode as { description?: unknown })
+				.description,
+		);
+		expect(tool.promptSnippet).toContain(
+			"mode=all reports cached diagnostics only",
+		);
+		expect(tool.promptSnippet).toContain("mode=full with paths");
+		expect(tool.promptSnippet).not.toContain(
+			"use lens_diagnostics mode=all to verify",
+		);
+		expect(modeDescription).toContain("all = cache-only diagnostics");
+		expect(modeDescription).toContain("add paths for a targeted active check");
+	});
 	it("exposes mode and severity parameters", () => {
 		const tool = makeTool();
 		const props = (tool.parameters as { properties: Record<string, unknown> })

--- a/tools/lens-diagnostics.ts
+++ b/tools/lens-diagnostics.ts
@@ -254,7 +254,8 @@ export function createLensDiagnosticsTool(
 		label: "Project Diagnostics",
 		description:
 			"Query pi-lens's diagnostic state. mode=delta/all are cache-only and instant; " +
-			"mode=full is an expensive active project-wide LSP scan merged with cached runner state.\n\n" +
+			"mode=full is an active LSP scan merged with cached runner state. Use mode=full " +
+			"with paths for a targeted active check; it need not scan the whole project.\n\n" +
 			"IMPORTANT: unlike lsp_diagnostics (LSP only), this tool covers ALL dispatch " +
 			"runners: LSP errors, tree-sitter structural rules, ast-grep security rules, " +
 			"biome/ruff/eslint lint findings, complexity violations, and more.\n\n" +
@@ -264,11 +265,14 @@ export function createLensDiagnosticsTool(
 			"mode=all: blocking errors and warnings — with the actual messages (line, rule, " +
 			"text), not just counts — for every file the agent has " +
 			"EDITED this session (files that went through the dispatch pipeline). " +
-			"NOTE: unedited files with pre-existing errors do NOT appear here — this is " +
-			"not a full project scan. Use before declaring work done; stale blocking " +
-			"errors from earlier turns are visible even if they dropped from turn-end context.\n\n" +
-			"mode=full: EXPENSIVE active scan. Runs project-wide LSP diagnostics for " +
-			"all supported files (including unedited files), then merges/deduplicates " +
+			"NOTE: this is cache-only reporting, not verification of the files' current state. " +
+			"Unedited files with pre-existing errors do NOT appear here, and an empty cache " +
+			"is not proof of clean. Stale blocking errors from earlier turns are visible even " +
+			"if they dropped from turn-end context. For changed files with absent or stale " +
+			"cache, use mode=full with paths to actively check those files.\n\n" +
+			"mode=full: active scan. Without paths, runs project-wide LSP diagnostics for " +
+			"all supported files (including unedited files); with paths, actively scans " +
+			"exactly those files. Then merges/deduplicates " +
 			"that with mode=all cached runner state. Optional refreshRunners=cheap/all/cached " +
 			"folds in project-wide runner findings: the in-process scanners (tree-sitter + " +
 			"fact-rules + ast-grep) plus a FRESH run of the heavyweight analyzers — knip, " +
@@ -277,7 +281,9 @@ export function createLensDiagnosticsTool(
 			"analyzer de-dupes against a concurrent background run of itself, so this can't " +
 			"double-spawn. Bounded by the slowest analyzer (trivy's own ~180s ceiling).",
 		promptSnippet:
-			"Use lens_diagnostics mode=all to verify no blocking errors remain; use mode=full for expensive project-wide checks",
+			"mode=all reports cached diagnostics only; it does not verify current files. " +
+			"For changed files with absent or stale cache, use mode=full with paths for " +
+			"an active targeted check.",
 		renderResult: compactRenderResult<{
 			mode?: string;
 			phase?: string;
@@ -360,8 +366,9 @@ export function createLensDiagnosticsTool(
 					enum: ["delta", "all", "full"],
 					description:
 						"delta = current turn's fixable warnings (default). " +
-						"all = session diagnostics for edited/dispatched files. " +
-						"full = expensive active project-wide LSP scan plus cached runner diagnostics.",
+						"all = cache-only diagnostics for edited/dispatched files; it does not " +
+						"verify current files. full = active LSP scan plus cached runner " +
+						"diagnostics; add paths for a targeted active check.",
 				}),
 			),
 			refreshRunners: Type.Optional(


### PR DESCRIPTION
## Summary

Clarify diagnostic guidance for issue #2792. `mode=all` reports cached diagnostics only. `mode=full` with `paths` performs an active targeted check. MCP now reuses the registered Pi tool description.

The runtime behavior is unchanged.

### Six-surface contract

| Surface | Before | After |
| --- | --- | --- |
| Pi tool description | “Use before declaring work done”; `mode=full` was an “EXPENSIVE active scan” that implied only project-wide use. | States that `mode=all` is cache-only, an empty cache is not proof of clean, and `mode=full` with `paths` actively checks those files. |
| Pi prompt snippet | “Use lens_diagnostics mode=all to verify no blocking errors remain; use mode=full for expensive project-wide checks” | “mode=all reports cached diagnostics only; it does not verify current files. For changed files with absent or stale cache, use mode=full with paths for an active targeted check.” |
| Pi `mode` parameter | `all = session diagnostics`; `full = expensive active project-wide LSP scan` | `all = cache-only diagnostics`; `full = active LSP scan`; `paths` gives a targeted active check. |
| Session-start orientation | “mode=all resurfaces stale blocking errors that dropped from turn context.” | “mode=all reports cached diagnostics only; for changed files with absent or stale cache, use mode=full with paths for an active check.” |
| MCP `tools/list` | “mode=all (every dispatched file this session), mode=full (expensive project-wide active scan).” | Reuses the Pi tool description, including the cache-only and targeted-active contract. |
| `docs/usage.md` | “use `mode=all` before declaring work complete, and `mode=full` for an expensive project-wide LSP scan.” | Says `mode=all` does not verify current files and recommends `mode=full` with `paths` for changed files with absent or stale cache. |

All six surfaces were checked through their production seams. The `paths` parameter already had correct wording and was retained.

## Tests

New or edited regression coverage:

- `tests/tools/lens-diagnostics.test.ts`: pins the registered Pi tool prompt snippet and `mode` parameter contract. It rejects the old “use mode=all to verify” wording.
- `tests/clients/runtime-turn-session.test.ts`: pins the emitted session-start orientation and rejects the old cache-verification implication.
- `tests/mcp/server.smoke.test.ts`: calls the real MCP subprocess and `tools/list`; it pins the corrected description and rejects the old claim.
- `tests/tools/lens-diagnostics.test.ts`: existing real-seam cases confirm `mode=all` with an uncached `paths` entry emits the cached-only note and `mode=full` with paths forwards the exact files to the active scan seams.

Red-first transcript on the pre-fix wording:

```text
Test Files  3 failed (3) | Tests  3 failed, 179 passed (182)
FAIL tests/mcp/server.smoke.test.ts > lists the pi-lens tools
FAIL tests/clients/runtime-turn-session.test.ts > SESSION_START_GUIDANCE distinguishes cached reporting from active verification
FAIL tests/tools/lens-diagnostics.test.ts > describes all as cache-only reporting and full with paths as active verification
```

Green transcript after the fix:

```text
Test Files  3 passed (3) | Tests 182 passed (182)
```

Targeted runtime contrast:

```text
mode=all with paths hitting no cached files includes the cached-only/use-mode=full note ✓
mode=full: LSP sweep and cheap scanner receive exactly the listed (existing) files ✓
Test Files 1 passed | Tests 2 passed, 114 skipped
```

## Blast radius

Changed symbols and dependents:

```text
createLensDiagnosticsTool().description / promptSnippet / parameters
  callers: pi registration in index.ts; MCP ALL_TOOLS via lensDiagnosticsTool
  callees: none; metadata only
  + corrected cache-only and targeted-active guidance

SESSION_START_GUIDANCE
  caller: session-start context injection in runtime-session.ts
  callees: none; static orientation text
  + corrected cache-only and targeted-active guidance

MCP ALL_TOOLS[pilens_diagnostics].description
  caller: tools/list consumers
  + reuses createLensDiagnosticsTool().description

docs/usage.md and .changelog/fix-diagnostics-2792.md
  no runtime dependents
```

No runtime decision, cache, durable record, or telemetry shape changed.

## Class sweep

Searched all Markdown, TypeScript, JavaScript, and MJS files, excluding generated release history and AGENTS.md, for completion or verification claims tied to `mode=all`, plus project-wide-only `mode=full` guidance.

- `tools/lens-diagnostics.ts`: fixed the reported tool metadata and retained the existing cache-only execution note.
- `clients/runtime-session.ts`: fixed the reported session orientation.
- `mcp/server.ts`: folded the duplicate description onto the Pi tool seam.
- `docs/usage.md`: fixed the reported usage and troubleshooting guidance.
- `docs/agent-tools.md`: describes active `mode=full` project review only; no `mode=all` verification claim.
- `docs/agent-guide.md`: recommends `mode=full` for a clean verdict; no cache-only `mode=all` verification claim.
- Remaining `mode=all` matches are implementation comments, cache behavior, blocker-detail advice, or tests. None claims that cache-only `mode=all` verifies current files.

Consolidation verdict: fold the MCP capability description onto `createLensDiagnosticsTool().description`. The Pi registration is the single metadata seam; the short session orientation and usage guide remain distributed in their required homes.

## Observability

The registered Pi metadata, emitted session-start text, and real MCP `tools/list` response prove the guidance contract. Existing runtime behavior remains the evidence for cached-only reporting and targeted active scanning. No new failure path exists, so no bounded telemetry is needed.

## Test assessment

The new tests observe independent production outputs: registered metadata, emitted orientation, and MCP protocol metadata. They do not replace the real in-process diagnostic store or MCP registry. The existing `paths` execution tests retain their real tool seam and verify cache-only versus active-scan dispatch behavior.

## Verification

- `npm run build` — passed.
- `npm run lint` — passed.
- `npm run changelog:check` — passed.
- `npm run check:lockfile` — passed.
- `npx oxfmt` on all touched files — passed.
- `npm run fmt:check` — reports three unrelated pre-existing files: `scripts/strictness-report.d.mts`, `scripts/strictness-report.mjs`, and `tests/config/strictness-ratchet.test.ts`.
- Targeted Vitest files — passed, 182 tests.

The remaining mechanical governance suites and PR-script checks are run below before handoff.

### Orchestrator run (2026-09-09, outside the codex sandbox)

```text
build ok, lint ok, oxfmt clean, fragment valid
new pins + tests/tools/lens-diagnostics + tests/mcp/ — all green except tests/mcp/analyze-cli.test.ts "hint-tier findings as advisories", which fails identically on master in this environment (environmental, unrelated)
```

Refs #2792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gEp548mWcf8nWL9xivZWV
