### PR TITLE
chore(worktrees): prune merged clean trees with a per-run cap; never a tree with untracked files (refs #2631, #2538, #2784)

### DIFF
--- a/.changelog/2631-merged-worktree-sweep.md
+++ b/.changelog/2631-merged-worktree-sweep.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Prune merged clean worktrees with a per-run cap; never a tree with untracked files (refs #2631, #2538, #2784)** — the agent-worktree hygiene sweep now also removes any registered worktree whose branch tip is an ancestor of `origin/master` and whose checkout is clean, clears `.claude/worktrees/agent-*` leftovers that hold nothing but git's own `.git` gitlink, and caps removals per run with `--max` (default 10). An untracked file counts as a deliverable: only an empty `git status --porcelain` is clean, and the keep record names the first entry it protected.

--- a/scripts/lib/worktree-hygiene.d.mts
+++ b/scripts/lib/worktree-hygiene.d.mts
@@ -86,6 +86,47 @@ export function planWorktreePrune(options: {
 	isPidAlive?: (pid: number) => boolean;
 }): PrunePlan;
 
+export interface MergedWorktreeCandidate {
+	path: string;
+	branch?: string | null;
+	bare?: boolean;
+	/** `git status --porcelain` answered and was EMPTY (no changes, no untracked files). */
+	clean?: boolean;
+	statusUnreadable?: boolean;
+	/** HEAD is an ancestor of `origin/master` (strict; side branches do not count). */
+	mergedIntoMaster?: boolean;
+	/** First porcelain entry, bounded — names the change a keep protects. */
+	statusDetail?: string | null;
+	mtimeMs: number;
+	locked?: boolean;
+	lockPid?: number | null;
+	unevaluated?: boolean;
+}
+
+/**
+ * Merged-branch sweep (#2631): which NON-PRIMARY trees (excluding the main
+ * checkout is the caller's job) may be removed — any path whose branch is an
+ * ancestor of `origin/master` and whose checkout is clean, untracked files
+ * included in "clean" via porcelain.
+ */
+export function planMergedWorktreeRemovals(options: {
+	candidates: MergedWorktreeCandidate[];
+	nowMs: number;
+	selfPath?: string | string[] | null;
+	isPidAlive?: (pid: number) => boolean;
+	selectedKeys?: Set<string> | null;
+}): PrunePlan;
+
+/**
+ * Verdict for an unregistered `.claude/worktrees/agent-*` directory (#2538):
+ * removable only when it holds nothing but git's own `.git` gitlink — every
+ * other entry is treated as an untracked deliverable. Null input means the
+ * directory could not be read.
+ */
+export function unregisteredAgentDirVerdict(
+	entryNames: string[] | null | undefined,
+): { removable: boolean; reason: string };
+
 export function orderBySelection<T extends { path: string }>(
 	rows: T[],
 	only: string[] | null,
@@ -185,6 +226,16 @@ export function formatWorktreeRecord(input: {
 	ageMs: number;
 	dryRun?: boolean;
 	removed?: boolean;
+	/** #2631: the merged-branch sweep selected this tree. */
+	merged?: boolean;
+	error?: string | null;
+	nowIso?: string;
+}): string;
+
+export function formatUnregisteredDirRecord(input: {
+	path: string;
+	dryRun?: boolean;
+	removed?: boolean;
 	error?: string | null;
 	nowIso?: string;
 }): string;
@@ -220,6 +271,8 @@ export function formatRunRecord(input: {
 	/** Why the run's single scoped tree is still on disk; null if removed. */
 	keptReason?: string | null;
 	removed?: number;
+	/** #2538: unregistered agent-* directories this run removed. */
+	unregisteredDirs?: number;
 	orphans?: number;
 	rows?: number;
 	dryRun?: boolean;

--- a/scripts/lib/worktree-hygiene.mjs
+++ b/scripts/lib/worktree-hygiene.mjs
@@ -481,6 +481,171 @@ export function planWorktreePrune({
 }
 
 /**
+ * @typedef {object} MergedWorktreeCandidate
+ * @property {string} path                Absolute worktree path.
+ * @property {string|null} [branch]       Full ref (`refs/heads/...`), null for
+ *   a detached worktree.
+ * @property {boolean} [bare]
+ * @property {boolean} [clean]            `git status --porcelain` answered and
+ *   was EMPTY: no tracked changes AND no untracked files. Porcelain reports
+ *   untracked files, so this one flag already covers both halves of "clean".
+ * @property {boolean} [statusUnreadable] The `git status` call itself failed
+ *   or timed out — an unanswered safety question, so the tree is kept.
+ * @property {boolean} [mergedIntoMaster] HEAD is an ancestor of
+ *   `origin/master` (strict: merged only into a side branch does not count).
+ * @property {string|null} [statusDetail] First porcelain entry, bounded —
+ *   names the change (typically the untracked file) a keep protects.
+ * @property {number} mtimeMs             Newest observed activity timestamp.
+ * @property {boolean} [locked]
+ * @property {number|null} [lockPid]
+ * @property {boolean} [unevaluated]      The caller ran out of time budget
+ *   before it could read this tree's status. Never removable.
+ */
+
+/**
+ * Decide which non-primary worktrees the MERGED-BRANCH sweep (#2631) may
+ * remove: any path whose branch tip is an ancestor of `origin/master` and
+ * whose checkout is clean. The 2026-09-06 recurrence stood at 21 merged,
+ * clean, pushed trees because the sweep only ever considered
+ * `.claude/worktrees/agent-*`.
+ *
+ * Deliberately NO age rail: a clean tree at a merged HEAD is byte-identical
+ * to a commit that is already on `origin/master`, so there is nothing in it
+ * to lose at any age. The protection a live session gets is the rails below —
+ * uncommitted or untracked files (a working tree is rarely clean), and the
+ * git lock naming a live pid.
+ *
+ * THE UNTRACKED-FILE RAIL IS THE WHOLE POINT. An untracked file is a
+ * deliverable, never disposable: on 2026-09-09 a 22 KB report left untracked
+ * in a worktree was destroyed by a sweep that treated its checkout content as
+ * removable. `git status --porcelain` reports untracked files, so an empty
+ * porcelain output is the ONLY clean that may be removed, and the keep record
+ * names the first porcelain entry so the operator sees what was protected.
+ *
+ * Rails are evaluated in a fixed order and the FIRST one that fires wins,
+ * mirroring `planWorktreePrune`: hard rails (work destruction) before soft
+ * ones (liveness, selection).
+ *
+ * @param {object} options
+ * @param {MergedWorktreeCandidate[]} options.candidates  Non-primary trees
+ *   only — excluding the main checkout is the CALLER's job.
+ * @param {number} options.nowMs
+ * @param {string|string[]|null} [options.selfPath] Worktree(s) this process
+ *   lives in; never removed.
+ * @param {(pid: number) => boolean} [options.isPidAlive]
+ * @param {Set<string>|null} [options.selectedKeys] `--only` narrowing; the
+ *   merged sweep runs over the same set the age sweep was narrowed to.
+ * @returns {PrunePlan}
+ */
+export function planMergedWorktreeRemovals({
+	candidates,
+	nowMs,
+	selfPath = null,
+	isPidAlive = () => false,
+	selectedKeys = null,
+}) {
+	const selfKeys = new Set(
+		(Array.isArray(selfPath) ? selfPath : selfPath ? [selfPath] : [])
+			.map((entry) => enclosingAgentWorktree(entry) ?? toComparablePath(entry))
+			.filter(Boolean),
+	);
+	const remove = [];
+	const keep = [];
+
+	for (const row of candidates ?? []) {
+		const key = toComparablePath(row.path);
+		const selected = selectedKeys ? selectedKeys.has(key) : false;
+		const ageMs = Math.max(0, nowMs - (Number(row.mtimeMs) || 0));
+		const push = (reason, detail = null) =>
+			keep.push({ path: row.path, reason, detail });
+
+		if (selfKeys.has(key)) {
+			push("self", "this sweep is running inside it");
+			continue;
+		}
+		if (selectedKeys && !selected) {
+			push("not-selected", "--only named other trees");
+			continue;
+		}
+		if (row.unevaluated) {
+			push("not-evaluated", "time budget exhausted before this tree was read");
+			continue;
+		}
+		if (!row.branch) {
+			push("detached", "no branch to verify as merged");
+			continue;
+		}
+		if (row.statusUnreadable) {
+			push(
+				"status-unreadable",
+				"git status could not be read before the removal decision",
+			);
+			continue;
+		}
+		if (!row.clean) {
+			push(
+				"dirty",
+				row.statusDetail ??
+					"uncommitted or untracked changes would be destroyed",
+			);
+			continue;
+		}
+		const lockPid = row.lockPid ?? null;
+		if (!selected && row.locked && lockPid !== null && isPidAlive(lockPid)) {
+			push("locked-live", `git lock names live pid ${lockPid}`);
+			continue;
+		}
+		if (!row.mergedIntoMaster) {
+			push("unmerged", "HEAD is not an ancestor of origin/master");
+			continue;
+		}
+		remove.push({
+			path: row.path,
+			branch: row.branch ?? null,
+			ageMs,
+			locked: Boolean(row.locked),
+			selected,
+		});
+	}
+
+	return { remove, keep };
+}
+
+/**
+ * Top-level entries of a worktree checkout that are git's own bookkeeping
+ * rather than content. Only the top-level `.git` gitlink matches: a deeper
+ * `.git` belongs to a vendored nested repository, which is content.
+ */
+const GIT_METADATA_ENTRY_NAMES = new Set([".git"]);
+
+/**
+ * Verdict for an UNREGISTERED `.claude/worktrees/agent-*` directory (#2538):
+ * present on disk, absent from `git worktree list`.
+ *
+ * An unregistered directory has no index and no known branch, so "is this
+ * file tracked (recoverable from git)?" is UNANSWERABLE — and an unanswered
+ * safety question is a NO. Every surviving entry is therefore treated as an
+ * untracked deliverable and the directory is kept, named: on 2026-09-09 a
+ * 22 KB report left untracked in a worktree was destroyed by a sweep that
+ * treated its checkout content as removable. A directory is removable only
+ * when it holds nothing but git's own `.git` gitlink.
+ *
+ * @param {string[]|null|undefined} entryNames Top-level readdir names, or
+ *   null when the directory could not be read.
+ * @returns {{ removable: boolean, reason: string }}
+ */
+export function unregisteredAgentDirVerdict(entryNames) {
+	if (!Array.isArray(entryNames)) {
+		return { removable: false, reason: "unreadable" };
+	}
+	const content = entryNames.filter(
+		(name) => !GIT_METADATA_ENTRY_NAMES.has(name),
+	);
+	if (content.length === 0) return { removable: true, reason: "empty" };
+	return { removable: false, reason: `untracked content: ${content[0]}` };
+}
+
+/**
  * Order candidates so anything `only` names is inspected FIRST. The caller
  * enriches trees under a wall-clock budget (a hook has ~2s), and a
  * SubagentStop sweep has exactly one tree it cares about — it must never
@@ -1010,7 +1175,7 @@ export function formatKillRecord(input) {
  * `--quiet` hook run leaves behind, so it has to carry the verdict, not just
  * the path.
  *
- * @param {{ path: string, branch?: string|null, ageMs: number, dryRun?: boolean, removed?: boolean, error?: string|null, nowIso?: string }} input
+ * @param {{ path: string, branch?: string|null, ageMs: number, dryRun?: boolean, removed?: boolean, merged?: boolean, error?: string|null, nowIso?: string }} input
  * @returns {string}
  */
 export function formatWorktreeRecord(input) {
@@ -1020,6 +1185,30 @@ export function formatWorktreeRecord(input) {
 		worktree: String(input.path ?? "").slice(0, MAX_RECORDED_COMMAND_CHARS),
 		branch: input.branch ?? null,
 		ageMs: Math.round(Number(input.ageMs) || 0),
+		dryRun: Boolean(input.dryRun),
+		removed: Boolean(input.removed),
+		// #2631: true when the merged-branch sweep selected the tree, so a
+		// reader can tell the two removal passes apart in one log file.
+		merged: Boolean(input.merged),
+	};
+	if (input.error) record.error = String(input.error).slice(0, 200);
+	return JSON.stringify(record);
+}
+
+/**
+ * Bounded ledger record for one UNREGISTERED agent-worktree directory
+ * removal (#2538). Same bounded-field discipline as formatWorktreeRecord;
+ * a distinct event name because the path was NOT a registered worktree —
+ * a reader must be able to tell the two removal kinds apart.
+ *
+ * @param {{ path: string, dryRun?: boolean, removed?: boolean, error?: string|null, nowIso?: string }} input
+ * @returns {string}
+ */
+export function formatUnregisteredDirRecord(input) {
+	const record = {
+		ts: input.nowIso ?? new Date().toISOString(),
+		event: "hygiene.unregistered-dir",
+		path: String(input.path ?? "").slice(0, MAX_RECORDED_COMMAND_CHARS),
 		dryRun: Boolean(input.dryRun),
 		removed: Boolean(input.removed),
 	};
@@ -1106,7 +1295,7 @@ export const RUN_SKIP_REASONS = Object.freeze({
  * scoped to, and is null for a run that removed that tree or was scoped to no
  * single tree at all.
  *
- * @param {{ hook?: string|null, outcome: "fired"|"skipped", reason?: string|null, worktree?: string|null, keptReason?: string|null, removed?: number, orphans?: number, rows?: number, dryRun?: boolean, budgetMs?: number, durationMs?: number, nowIso?: string }} input
+ * @param {{ hook?: string|null, outcome: "fired"|"skipped", reason?: string|null, worktree?: string|null, keptReason?: string|null, removed?: number, unregisteredDirs?: number, orphans?: number, rows?: number, dryRun?: boolean, budgetMs?: number, durationMs?: number, nowIso?: string }} input
  * @returns {string}
  */
 export function formatRunRecord(input) {
@@ -1122,6 +1311,7 @@ export function formatRunRecord(input) {
 			: null,
 		keptReason: input.keptReason ?? null,
 		removed: count(input.removed),
+		unregisteredDirs: count(input.unregisteredDirs),
 		orphans: count(input.orphans),
 		rows: count(input.rows),
 		dryRun: Boolean(input.dryRun),

--- a/scripts/prune-agent-worktrees.d.mts
+++ b/scripts/prune-agent-worktrees.d.mts
@@ -2,6 +2,7 @@
 // from .ts tests). Only the pure, exported seams are declared — the CLI body
 // is not importable surface.
 
+export const DEFAULT_MAX_REMOVALS: number;
 export const DEFAULT_HOOK_BUDGET_MS: number;
 export const DEFAULT_MANUAL_BUDGET_MS: number;
 export const HOOK_TIMEOUT_MS: Readonly<Record<string, number>>;

--- a/scripts/prune-agent-worktrees.mjs
+++ b/scripts/prune-agent-worktrees.mjs
@@ -2,24 +2,38 @@
 /**
  * scripts/prune-agent-worktrees.mjs (#2435)
  *
- * Agent worktree + orphan-process hygiene. Two independent sweeps:
+ * Agent worktree + orphan-process hygiene. Three independent sweeps:
  *
- *  1. WORKTREES. Every `.claude/worktrees/agent-*` git worktree that is
+ *  1. AGENT WORKTREES. Every `.claude/worktrees/agent-*` git worktree that is
  *     clean, whose HEAD is contained in an `origin/*` ref, and that is old
  *     enough (or explicitly named by `--only`) is removed, together with the
  *     agent-session branch it left behind. 15 such trees accumulated on one
  *     box in a single day (#2435), each with its own build output.
- *  2. ORPHAN FIXTURES. Any `tests/fixtures/*` / `tests/support/*` helper
+ *  2. MERGED-BRANCH TREES (#2631). Any OTHER registered worktree — any path,
+ *     the 2026-09-06 recurrence stood under `~/Desktop/pi-lens-wt-*` — whose
+ *     branch tip is an ancestor of `origin/master` AND whose checkout is
+ *     clean (no tracked changes, no untracked files) is removed and its
+ *     merged local branch deleted. An untracked file is a deliverable, never
+ *     disposable: on 2026-09-09 a 22 KB report left untracked in a worktree
+ *     was destroyed by a sweep that treated its checkout as removable, so an
+ *     empty `git status --porcelain` is the only clean that qualifies, and
+ *     the keep record names the first porcelain entry it protected.
+ *  3. UNREGISTERED DIRECTORIES (#2538). `.claude/worktrees/agent-*` entries
+ *     present on disk but absent from `git worktree list` are removed only
+ *     when they hold nothing but git's own `.git` gitlink — with no index and
+ *     no known branch, every other file is treated as an untracked deliverable.
+ *  4. ORPHAN FIXTURES. Any `tests/fixtures/*` / `tests/support/*` helper
  *     process whose parent has exited is killed — the class that left
  *     `fake-lsp-server.mjs` running for an hour after its fixer finished and
  *     made one worktree unremovable. The fixture's own missing teardown is
  *     #2436; this is the machine-level net under it, not the fix.
  *
- * ALL the decision logic lives in scripts/lib/worktree-hygiene.mjs and is
- * pure (tables in, verdicts out). This file owns only the I/O: `git`
- * invocations, the platform process listing, `process.kill`, and the ledger
- * write. Anything that could destroy work is therefore unit-testable
- * WITHOUT this file running.
+ *  2 and 3 are capped per run with `--max` (default 10); what the cap skips
+ *  is printed. All the decision logic lives in scripts/lib/worktree-hygiene.mjs
+ *  and is pure (tables in, verdicts out). This file owns only the I/O: `git`
+ *  invocations, the platform process listing, `process.kill`, and the ledger
+ *  write. Anything that could destroy work is therefore unit-testable
+ *  WITHOUT this file running.
  *
  * Safety rails (see the library header for the full contract):
  *   - never a dirty tree; never an unpushed tree — no flag overrides either;
@@ -116,9 +130,11 @@ import {
 	RUN_SKIP_REASONS,
 	capRemovals,
 	collectAncestorPids,
+	enclosingAgentWorktree,
 	formatKillRecord,
 	formatRunRecord,
 	formatScanRecord,
+	formatUnregisteredDirRecord,
 	formatWorktreeRecord,
 	isAgentBranchCandidate,
 	isAgentWorktreePath,
@@ -128,11 +144,13 @@ import {
 	parseReflogLastEntryMs,
 	parseWorktreeList,
 	planBranchDeletions,
+	planMergedWorktreeRemovals,
 	planOrphanSweep,
 	planWorktreePrune,
 	pruneLogLines,
 	selectProcessesUnderPath,
 	toComparablePath,
+	unregisteredAgentDirVerdict,
 	worktreeActivityFromSignals,
 } from "./lib/worktree-hygiene.mjs";
 import { snapshotProcesses } from "./lib/process-scan.mjs";
@@ -149,6 +167,15 @@ const isWindows = process.platform === "win32";
 export const DEFAULT_HOOK_BUDGET_MS = 2_000;
 /** Wall-clock budget for a manual (non-hook) invocation. */
 export const DEFAULT_MANUAL_BUDGET_MS = 60_000;
+/**
+ * Per-run removal cap for the merged-branch sweep (#2631) and the
+ * unregistered-directory pass (#2538), overridable with `--max`. What the cap
+ * skips is printed as deferred, so a bigger backlog drains one run at a time
+ * instead of a single sweep destroying an unbounded number of trees. In hook
+ * modes the effective cap is the smaller of this and the policy's own
+ * `maxRemovals` — the hook-timeout arithmetic is sized for one removal.
+ */
+export const DEFAULT_MAX_REMOVALS = 10;
 /**
  * The hook timeouts registered in `.claude/settings.json`, in ms. Mirrored
  * rather than read at runtime (one small file read on every sweep, plus a
@@ -244,6 +271,11 @@ const USAGE = `Usage: node scripts/prune-agent-worktrees.mjs [options]
   --dry-run             Print the plan and exit without removing or killing.
   --min-age <duration>  Minimum worktree age to be eligible (default 30m).
                         Accepts 500, 500ms, 90s, 30m, 2h.
+  --max <n>             Per-run removal cap for the merged-branch sweep
+                        (#2631) and the unregistered-directory pass (#2538),
+                        default 10. What the cap skips is printed as deferred.
+                        In hook modes the effective cap is the smaller of
+                        this and the policy's own cap (SessionStart: 1).
   --budget-ms <dur>     Wall-clock budget for the whole sweep (default: sized
                         to the hook timeout in --hook mode, 60s otherwise).
                         Trees not reached are reported "not-evaluated" and
@@ -286,12 +318,13 @@ Always exits 0.`;
 
 /**
  * @param {string[]} argv
- * @returns {{ dryRun: boolean, minAgeMs: number, only: string[]|null, hook: string|null, orphanSweep: boolean, json: boolean, quiet: boolean, help: boolean, errors: string[] }}
+ * @returns {{ dryRun: boolean, minAgeMs: number, max: number, only: string[]|null, hook: string|null, orphanSweep: boolean, json: boolean, quiet: boolean, help: boolean, errors: string[] }}
  */
 export function parseArgs(argv) {
 	const options = {
 		dryRun: false,
 		minAgeMs: DEFAULT_MIN_AGE_MS,
+		max: DEFAULT_MAX_REMOVALS,
 		budgetMs: null,
 		scanTimeoutMs: null,
 		only: null,
@@ -319,6 +352,18 @@ export function parseArgs(argv) {
 					options.errors.push(`invalid --min-age value: ${String(raw)}`);
 				} else {
 					options.minAgeMs = parsed;
+				}
+				break;
+			}
+			case "--max": {
+				const raw = argv[++i];
+				// Digits only: `--max 0` means ZERO removals (a plan-only run),
+				// and an unreadable value is an error rather than a silent
+				// fallback that would disable the cap on a destructive step.
+				if (raw === undefined || !/^\d+$/.test(String(raw))) {
+					options.errors.push(`invalid --max value: ${String(raw)}`);
+				} else {
+					options.max = Number(raw);
 				}
 				break;
 			}
@@ -907,6 +952,58 @@ function isContainedInOrigin(
 }
 
 /**
+ * True iff `sha` is an ancestor of `origin/master` — the STRICT merged
+ * criterion of the merged-branch sweep (#2631). A tree merged only into a
+ * side branch is NOT merged for this purpose: the sweep deletes the local
+ * branch after removal, and only `origin/master` containment makes that
+ * unconditional. Unreadable git output or a missing `origin/master` => false
+ * => "unmerged" => kept. Fails safe.
+ *
+ * @param {string|null} sha
+ * @param {string} repoRoot
+ * @param {number} [timeoutMs]
+ * @returns {boolean}
+ */
+function isAncestorOfOriginMaster(
+	sha,
+	repoRoot,
+	timeoutMs = DEFAULT_GIT_TIMEOUT_MS,
+) {
+	if (!sha) return false;
+	// `--is-ancestor` communicates through its exit code; git() returns "" on
+	// exit 0 and null on any non-zero exit.
+	return (
+		git(
+			["merge-base", "--is-ancestor", sha, "origin/master"],
+			repoRoot,
+			timeoutMs,
+		) !== null
+	);
+}
+
+/**
+ * `git status --porcelain`, tri-state, plus the FIRST porcelain entry so a
+ * keep record can NAME what it protected (#2631). Porcelain reports untracked
+ * files too, so "clean" already excludes untracked deliverables — an empty
+ * porcelain output is the only clean any removal in this script may act on
+ * (on 2026-09-09 a 22 KB untracked report was destroyed by a sweep that read
+ * its checkout as removable).
+ *
+ * @param {string} worktreePath
+ * @param {number} [timeoutMs]
+ * @returns {{ state: "clean"|"dirty"|"unreadable", firstEntry: string|null }}
+ */
+function statusSnapshot(worktreePath, timeoutMs = DEFAULT_GIT_TIMEOUT_MS) {
+	const out = git(["status", "--porcelain"], worktreePath, timeoutMs);
+	if (out === null) return { state: "unreadable", firstEntry: null };
+	const firstLine = out.split(/\r?\n/).find((line) => line.trim() !== "");
+	return {
+		state: out.trim() !== "" ? "dirty" : "clean",
+		firstEntry: firstLine ? firstLine.trim().slice(0, 120) : null,
+	};
+}
+
+/**
  * `git status --porcelain`, tri-state. `"unreadable"` (the call timed out,
  * the process never spawned, or the worktree could not answer at all) is
  * kept APART from a genuine `"dirty"` porcelain output — both still refuse
@@ -920,9 +1017,7 @@ function isContainedInOrigin(
  * @returns {"clean"|"dirty"|"unreadable"}
  */
 export function isDirty(worktreePath, timeoutMs = DEFAULT_GIT_TIMEOUT_MS) {
-	const out = git(["status", "--porcelain"], worktreePath, timeoutMs);
-	if (out === null) return "unreadable";
-	return out.trim() !== "" ? "dirty" : "clean";
+	return statusSnapshot(worktreePath, timeoutMs).state;
 }
 
 // ---------------------------------------------------------------------------
@@ -1137,6 +1232,63 @@ function unlinkTopLevelLinks(worktreePath) {
 	return unlinked;
 }
 
+/**
+ * Enumerate `.claude/worktrees/agent-*` directories that are present on disk
+ * but absent from `git worktree list` (#2538) — the leftovers whose metadata
+ * `git worktree prune` already dropped, which the registration-based sweeps
+ * never see. A directory becomes a removal candidate only when
+ * `unregisteredAgentDirVerdict` proves it holds nothing but git's own `.git`
+ * gitlink; any other entry is treated as an untracked deliverable (see the
+ * 2026-09-09 22 KB report note on that verdict) and the directory is KEPT,
+ * named. Unreadable is keep, never remove.
+ *
+ * @param {{ base: string, registeredKeys: Set<string>, selfKeys: Set<string> }} input
+ * @returns {{ remove: string[], keep: { path: string, reason: string, detail: string|null }[] }}
+ */
+function collectUnregisteredAgentDirs({ base, registeredKeys, selfKeys }) {
+	const plan = { remove: [], keep: [] };
+	let entries;
+	try {
+		entries = fs.readdirSync(base, { withFileTypes: true });
+	} catch {
+		return plan;
+	}
+	for (const entry of entries) {
+		// Directories only, and never a symlink: a symlink named `agent-*`
+		// pointing out of the tree must not be followed or removed.
+		if (!entry.isDirectory()) continue;
+		// The naming convention `worktreePathFromHookPayload` documents:
+		// Claude Code names a managed agent worktree `agent-<agentId>`.
+		if (!/^agent-/.test(entry.name)) continue;
+		const full = path.join(base, entry.name);
+		const key = toComparablePath(full);
+		if (registeredKeys.has(key)) continue;
+		if (selfKeys.has(key)) {
+			plan.keep.push({
+				path: full,
+				reason: "self",
+				detail: "this sweep is running inside it",
+			});
+			continue;
+		}
+		let names = null;
+		try {
+			names = fs.readdirSync(full);
+		} catch {
+			names = null;
+		}
+		const verdict = unregisteredAgentDirVerdict(names);
+		if (verdict.removable) plan.remove.push(full);
+		else
+			plan.keep.push({
+				path: full,
+				reason: "has-untracked-content",
+				detail: verdict.reason,
+			});
+	}
+	return plan;
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -1288,14 +1440,18 @@ async function main(argv) {
 	 */
 	let agentTree = null;
 
+	// Where `.claude/worktrees/` actually lives: the MAIN checkout's root. The
+	// SubagentStop payload derivation needs it, and so does the unregistered-
+	// directory pass (#2538), which every non-scoped mode runs.
+	const worktreesBase =
+		mainCheckoutRoot(
+			Math.min(
+				DEFAULT_GIT_TIMEOUT_MS,
+				Math.max(MIN_GIT_TIMEOUT_MS, budgetLeft()),
+			),
+		) ?? REPO_ROOT;
+
 	if (policy.scopedToAgentTree) {
-		const worktreesBase =
-			mainCheckoutRoot(
-				Math.min(
-					DEFAULT_GIT_TIMEOUT_MS,
-					Math.max(MIN_GIT_TIMEOUT_MS, budgetLeft()),
-				),
-			) ?? REPO_ROOT;
 		const derived = worktreePathFromHookPayload(payload, worktreesBase);
 		// Deliberately does NOT fall back to the ordinary sweep: this hook has
 		// a mandate over exactly one agent's tree, and with no usable agent_id
@@ -1387,6 +1543,16 @@ async function main(argv) {
 	const listed = parseWorktreeList(porcelain);
 	const nowMs = Date.now();
 
+	// The MAIN checkout (always `git worktree list`'s first row) is never a
+	// candidate of either sweep; neither is the checkout this script runs from.
+	const primaryKeys = new Set(
+		[listed[0]?.path, REPO_ROOT].filter(Boolean).map(toComparablePath),
+	);
+	// #2631: the merged-branch sweep runs wherever removals run, EXCEPT the
+	// SubagentStop hooks, whose mandate is exactly the one tree their payload
+	// derived — touching sibling trees there would break the scoping contract.
+	const mergedPassRuns = policy.removeWorktrees && !policy.scopedToAgentTree;
+
 	// Trees named by --only are inspected FIRST, so a narrowed manual run never
 	// loses its budget to unrelated siblings (orderBySelection, tested).
 	const ordered = orderBySelection(listed, only);
@@ -1404,7 +1570,12 @@ async function main(argv) {
 	let evaluated = 0;
 	let skippedForBudget = 0;
 	const candidates = ordered.map((row) => {
-		if (!isAgentWorktreePath(row.path)) {
+		const isPrimary = primaryKeys.has(toComparablePath(row.path));
+		const isAgentTree = isAgentWorktreePath(row.path);
+		// The age rail evaluates agent trees; the merged pass (#2631) evaluates
+		// every OTHER non-primary tree. An unevaluated tree is never removable
+		// by either sweep, so skipping one for budget is safe for both.
+		if (isPrimary || (!isAgentTree && !mergedPassRuns)) {
 			return { ...row, dirty: false, pushed: false, mtimeMs: nowMs };
 		}
 		// `evaluated === 0` guarantees at least one tree is always inspected,
@@ -1437,7 +1608,17 @@ async function main(argv) {
 		// that removes nothing shipped. Reading first means no future signal
 		// added to the gatherer can quietly re-open the hole.
 		const mtimeMs = worktreeActivityMs(row.path, nowMs);
-		const dirtyState = isDirty(row.path, enrichBudget());
+		const status = statusSnapshot(row.path, enrichBudget());
+		// #2631: STRICT origin/master ancestry for the merged pass — a tree
+		// merged only into a side branch is not merged for a sweep that
+		// deletes the local branch after removal.
+		const mergedIntoMaster = mergedPassRuns
+			? isAncestorOfOriginMaster(row.head, REPO_ROOT, enrichBudget())
+			: false;
+		let pushed = mergedIntoMaster;
+		if (isAgentTree && !pushed) {
+			pushed = isContainedInOrigin(row.head, REPO_ROOT, enrichBudget());
+		}
 		return {
 			path: row.path,
 			head: row.head,
@@ -1445,13 +1626,20 @@ async function main(argv) {
 			locked: row.locked,
 			lockPid: parseLockPid(row.lockedReason),
 			mtimeMs,
-			dirty: dirtyState !== "clean",
+			dirty: status.state !== "clean",
 			// Threaded through to `planWorktreePrune`'s dirty rail so the
 			// ledger's `keptReason` can say `status-unreadable` instead of
 			// `dirty` when the real story is a budget too tight to ask
 			// (review round 3, F2) -- both still refuse removal.
-			dirtyUnreadable: dirtyState === "unreadable",
-			pushed: isContainedInOrigin(row.head, REPO_ROOT, enrichBudget()),
+			dirtyUnreadable: status.state === "unreadable",
+			pushed,
+			// Merged-pass facts (#2631). Porcelain reports untracked files, so
+			// `clean` covers BOTH halves of "no tracked changes, no untracked
+			// files", and `statusDetail` names what a keep protects.
+			clean: status.state === "clean",
+			statusUnreadable: status.state === "unreadable",
+			mergedIntoMaster,
+			statusDetail: status.firstEntry,
 		};
 	});
 
@@ -1468,17 +1656,86 @@ async function main(argv) {
 		isPidAlive,
 	});
 
+	// #2631: the merged-branch sweep plans over every non-primary tree the
+	// enrichment evaluated — agent-shaped and not. The age rail below and the
+	// merged rail overlap on agent trees; the combined removal list is deduped
+	// by path right after the capping.
+	const mergedPlan = mergedPassRuns
+		? planMergedWorktreeRemovals({
+				candidates: candidates.filter(
+					(candidate) =>
+						!primaryKeys.has(toComparablePath(candidate.path)) &&
+						!candidate.bare,
+				),
+				nowMs,
+				selfPath: [SCRIPT_DIR, process.cwd()],
+				isPidAlive,
+				selectedKeys,
+			})
+		: { remove: [], keep: [] };
+
 	// At most one removal per SessionStart run: `git worktree remove` is
 	// bounded at REMOVE_TIMEOUT_MS and a SIGKILLed removal leaves a
 	// half-removed tree, so the hook's timeout has to cover the removal it
-	// starts (review S8). A manual run is uncapped.
-	const removals = policy.removeWorktrees
-		? capRemovals(plan.remove, policy.maxRemovals)
-		: [];
-	const removalKeys = new Set(removals.map((removal) => removal.path));
-	const deferred = plan.remove.filter(
-		(removal) => !removalKeys.has(removal.path),
+	// starts (review S8). A manual run takes the `--max` cap instead.
+	//
+	// The RAW age-plan removals are the `deferred` source AND the merged
+	// pass's dedupe base. Capping happens ONCE, on `removals` below: deriving
+	// `deferred` from an already-capped list would drop everything past the
+	// cap, and for a non-removing policy (--keep-agent-tree) drop plan.remove
+	// entirely, which reads keptReason as null ("removed") instead of
+	// "removal-not-permitted".
+	const ageRemovals = plan.remove;
+	const ageRemovalKeys = new Set(
+		ageRemovals.map((removal) => toComparablePath(removal.path)),
 	);
+	// #2631: the merged pass's own removals, deduped against the age rail's —
+	// a tree both plans selected is removed once.
+	const mergedRemovals =
+		mergedPassRuns && policy.removeWorktrees
+			? mergedPlan.remove
+					.filter(
+						(removal) => !ageRemovalKeys.has(toComparablePath(removal.path)),
+					)
+					.map((removal) => ({ ...removal, fromMerged: true }))
+			: [];
+	// #2538/#2631: `--max` (default 10) bounds every removal ONE run performs,
+	// age rail and merged pass combined, and what it skips is printed. Hook
+	// modes keep their policy cap — the hook-timeout arithmetic (budget +
+	// recheck + removal + margin <= timeout) is sized for ONE removal — so the
+	// effective cap is the smaller of the two.
+	const runCap = Math.min(policy.maxRemovals, options.max);
+	const removals = policy.removeWorktrees
+		? capRemovals([...ageRemovals, ...mergedRemovals], runCap)
+		: [];
+	const removalKeys = new Set(
+		removals.map((removal) => toComparablePath(removal.path)),
+	);
+	const deferred = [...ageRemovals, ...mergedRemovals].filter(
+		(removal) => !removalKeys.has(toComparablePath(removal.path)),
+	);
+
+	// --- unregistered `.claude/worktrees/agent-*` directories (#2538) ---
+	// Every non-scoped mode runs this pass: the SubagentStop hooks have a
+	// mandate over exactly one agent's tree, never over its siblings' leftovers.
+	const unregisteredPlan = policy.scopedToAgentTree
+		? { remove: [], keep: [] }
+		: collectUnregisteredAgentDirs({
+				base: path.join(worktreesBase, ".claude", "worktrees"),
+				registeredKeys: new Set(
+					listed.map((row) => toComparablePath(row.path)),
+				),
+				selfKeys: new Set(
+					[SCRIPT_DIR, process.cwd()]
+						.map(
+							(entry) =>
+								enclosingAgentWorktree(entry) ?? toComparablePath(entry),
+						)
+						.filter(Boolean),
+				),
+			});
+	const unregisteredRemovals = unregisteredPlan.remove.slice(0, options.max);
+	const unregisteredDeferred = unregisteredPlan.remove.slice(options.max);
 
 	const wantProcessScan =
 		removals.length > 0 || (options.orphanSweep && policy.orphanSweep);
@@ -1553,6 +1810,12 @@ async function main(argv) {
 					})),
 					deferred: deferred.map((removal) => removal.path),
 					keep: plan.keep,
+					mergedKeep: mergedPlan.keep,
+					unregistered: {
+						remove: unregisteredRemovals,
+						deferred: unregisteredDeferred,
+						keep: unregisteredPlan.keep,
+					},
 					orphans: orphans.map(({ row, reason }) => ({
 						pid: row.pid,
 						ppid: row.ppid,

--- a/scripts/prune-agent-worktrees.mjs
+++ b/scripts/prune-agent-worktrees.mjs
@@ -1259,7 +1259,7 @@ function collectUnregisteredAgentDirs({ base, registeredKeys, selfKeys }) {
 		if (!entry.isDirectory()) continue;
 		// The naming convention `worktreePathFromHookPayload` documents:
 		// Claude Code names a managed agent worktree `agent-<agentId>`.
-		if (!/^agent-/.test(entry.name)) continue;
+		if (!entry.name.startsWith("agent-")) continue;
 		const full = path.join(base, entry.name);
 		const key = toComparablePath(full);
 		if (registeredKeys.has(key)) continue;

--- a/scripts/prune-agent-worktrees.mjs
+++ b/scripts/prune-agent-worktrees.mjs
@@ -1705,16 +1705,6 @@ async function main(argv) {
 	// recheck + removal + margin <= timeout) is sized for ONE removal — so the
 	// effective cap is the smaller of the two.
 	const runCap = Math.min(policy.maxRemovals, options.max);
-	const removals = policy.removeWorktrees
-		? capRemovals([...ageRemovals, ...mergedRemovals], runCap)
-		: [];
-	const removalKeys = new Set(
-		removals.map((removal) => toComparablePath(removal.path)),
-	);
-	const deferred = [...ageRemovals, ...mergedRemovals].filter(
-		(removal) => !removalKeys.has(toComparablePath(removal.path)),
-	);
-
 	// --- unregistered `.claude/worktrees/agent-*` directories (#2538) ---
 	// Every non-scoped mode runs this pass: the SubagentStop hooks have a
 	// mandate over exactly one agent's tree, never over its siblings' leftovers.
@@ -1734,8 +1724,42 @@ async function main(argv) {
 						.filter(Boolean),
 				),
 			});
-	const unregisteredRemovals = unregisteredPlan.remove.slice(0, options.max);
-	const unregisteredDeferred = unregisteredPlan.remove.slice(options.max);
+	// #2631/#2538: one raw plan owns the operator's deletion budget. Keep the
+	// kind marker only while capping; partitioning afterward gives each
+	// execution path its own shape without creating a second budget.
+	const rawRegisteredRemovals = [...ageRemovals, ...mergedRemovals];
+	const rawCombinedRemovals = [
+		...rawRegisteredRemovals.map((removal) => ({
+			...removal,
+			kind: "registered",
+		})),
+		...unregisteredPlan.remove.map((entry) => ({
+			path: entry,
+			ageMs: 0,
+			kind: "unregistered",
+		})),
+	];
+	const cappedCombinedRemovals = policy.removeWorktrees
+		? capRemovals(rawCombinedRemovals, runCap)
+		: [];
+	const selectedRemovalKeys = new Set(
+		cappedCombinedRemovals.map((removal) => toComparablePath(removal.path)),
+	);
+	const deferredCombinedRemovals = rawCombinedRemovals.filter(
+		(removal) => !selectedRemovalKeys.has(toComparablePath(removal.path)),
+	);
+	const removals = cappedCombinedRemovals
+		.filter((removal) => removal.kind === "registered")
+		.map(({ kind: _kind, ...removal }) => removal);
+	const unregisteredRemovals = cappedCombinedRemovals
+		.filter((removal) => removal.kind === "unregistered")
+		.map((removal) => removal.path);
+	const deferred = deferredCombinedRemovals
+		.filter((removal) => removal.kind === "registered")
+		.map(({ kind: _kind, ...removal }) => removal);
+	const unregisteredDeferred = deferredCombinedRemovals
+		.filter((removal) => removal.kind === "unregistered")
+		.map((removal) => removal.path);
 
 	const wantProcessScan =
 		removals.length > 0 || (options.orphanSweep && policy.orphanSweep);
@@ -1843,6 +1867,14 @@ async function main(argv) {
 					: `keep    ${removal.path}  (removal is not permitted in this mode)`,
 			);
 		}
+		for (const unregisteredPath of unregisteredDeferred) {
+			say(
+				policy.removeWorktrees
+					? `defer   ${unregisteredPath}  (removal cap ${policy.maxRemovals} per ` +
+							`run; the next sweep takes it)`
+					: `keep    ${unregisteredPath}  (removal is not permitted in this mode)`,
+			);
+		}
 		for (const removal of removals) {
 			const procs = perTreeProcesses.get(removal.path) ?? [];
 			say(
@@ -1864,6 +1896,7 @@ async function main(argv) {
 	const removedBranchRefs = [];
 	/** Trees actually removed — 0 on a dry run, which the record also says. */
 	let removedCount = 0;
+	let unregisteredRemovedCount = 0;
 	/**
 	 * Paths the enrichment pass certified clean but that turned up dirty (or
 	 * unreadable) on the immediate pre-remove recheck (review round 3, F1) --
@@ -2005,6 +2038,27 @@ async function main(argv) {
 			);
 		}
 		if (removals.length > 0) git(["worktree", "prune"], REPO_ROOT, removeBound);
+		for (const unregisteredPath of unregisteredRemovals) {
+			let removed = false;
+			try {
+				fs.rmSync(unregisteredPath, { recursive: true, force: true });
+				removed = !fs.existsSync(unregisteredPath);
+			} catch {
+				/* the bounded candidate remains for the next sweep */
+			}
+			if (removed) {
+				removedCount++;
+				unregisteredRemovedCount++;
+			}
+			records.push(
+				formatUnregisteredDirRecord({
+					path: unregisteredPath,
+					removed,
+					error: removed ? null : "directory removal failed",
+					nowIso,
+				}),
+			);
+		}
 
 		for (const { row, reason } of orphans) {
 			const { killed, error } = await terminatePid(row.pid);
@@ -2047,6 +2101,15 @@ async function main(argv) {
 					path: removal.path,
 					branch: removal.branch,
 					ageMs: removal.ageMs,
+					dryRun: true,
+					nowIso,
+				}),
+			);
+		}
+		for (const unregisteredPath of unregisteredRemovals) {
+			records.push(
+				formatUnregisteredDirRecord({
+					path: unregisteredPath,
 					dryRun: true,
 					nowIso,
 				}),
@@ -2100,6 +2163,7 @@ async function main(argv) {
 			worktree: targetPath,
 			keptReason,
 			removed: removedCount,
+			unregisteredDirs: unregisteredRemovedCount,
 			orphans: orphans.length,
 			rows: table.length,
 			dryRun: options.dryRun,

--- a/tests/scripts/prune-agent-worktrees.test.ts
+++ b/tests/scripts/prune-agent-worktrees.test.ts
@@ -565,12 +565,19 @@ describe("candidate enrichment order (review round 3, F1b)", () => {
 
 	it("reads worktree activity before anything that runs git in the tree", () => {
 		const activityAt = source.indexOf("worktreeActivityMs(row.path, nowMs)");
-		const dirtyAt = source.indexOf("isDirty(row.path,");
+		// #2631 renamed the enrichment-time status read: `isDirty(row.path, …)`
+		// became `statusSnapshot(row.path, …)` so the keep record can name the
+		// first porcelain entry it protected. `statusSnapshot` IS the call that
+		// runs `git status` inside the tree, so the invariant this pins is
+		// unchanged: activity is read BEFORE it.
+		const dirtyAt = source.indexOf("statusSnapshot(row.path,");
 		expect(
 			activityAt,
 			"worktreeActivityMs(row.path, …) call site",
 		).toBeGreaterThan(-1);
-		expect(dirtyAt, "isDirty(row.path, …) call site").toBeGreaterThan(-1);
+		expect(dirtyAt, "statusSnapshot(row.path, …) call site").toBeGreaterThan(
+			-1,
+		);
 		expect(activityAt).toBeLessThan(dirtyAt);
 	});
 });

--- a/tests/scripts/prune-agent-worktrees.test.ts
+++ b/tests/scripts/prune-agent-worktrees.test.ts
@@ -414,11 +414,15 @@ describe("worktreeActivityMs across a real `git status` (review round 3, F1)", (
 	const BACKDATE_MS = 3 * 60 * 60_000;
 
 	const git = (args: string[], cwd: string) =>
-		gitExecFileSync("git", args, {
-			cwd,
-			encoding: "utf8",
-			stdio: "pipe",
-		}) as string;
+		gitExecFileSync(
+			process.platform === "win32" ? "git.exe" : "/usr/bin/git",
+			args,
+			{
+				cwd,
+				encoding: "utf8",
+				stdio: "pipe",
+			},
+		) as string;
 
 	function adminDirOf(worktreePath: string): string {
 		const dotGit = path.join(worktreePath, ".git");
@@ -431,7 +435,10 @@ describe("worktreeActivityMs across a real `git status` (review round 3, F1)", (
 	}
 
 	beforeEach(() => {
-		fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-f1-"));
+		fs.mkdirSync(path.join(process.cwd(), ".probe-home"), { recursive: true });
+		fixtureRoot = fs.mkdtempSync(
+			path.join(process.cwd(), ".probe-home", "pi-lens-f1-"),
+		);
 		repo = path.join(fixtureRoot, "repo");
 		fs.mkdirSync(repo);
 		git(["init", "-q", "-b", "master"], repo);
@@ -591,14 +598,21 @@ describe("isDirty (review round 3, F2)", () => {
 	let repo = "";
 
 	const git = (args: string[], cwd: string) =>
-		gitExecFileSync("git", args, {
-			cwd,
-			encoding: "utf8",
-			stdio: "pipe",
-		}) as string;
+		gitExecFileSync(
+			process.platform === "win32" ? "git.exe" : "/usr/bin/git",
+			args,
+			{
+				cwd,
+				encoding: "utf8",
+				stdio: "pipe",
+			},
+		) as string;
 
 	beforeEach(() => {
-		root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-f2-"));
+		fs.mkdirSync(path.join(process.cwd(), ".probe-home"), { recursive: true });
+		root = fs.mkdtempSync(
+			path.join(process.cwd(), ".probe-home", "pi-lens-f2-"),
+		);
 		repo = path.join(root, "repo");
 		fs.mkdirSync(repo);
 		git(["init", "-q", "-b", "master"], repo);
@@ -640,6 +654,7 @@ describe("isDirty (review round 3, F2)", () => {
 		// way), covered here for the outcome that matters: never "clean".
 		const notARepo = path.join(root, "not-a-repo");
 		fs.mkdirSync(notARepo);
+		fs.writeFileSync(path.join(notARepo, ".git"), "gitdir: missing\n");
 		expect(isDirty(notARepo)).toBe("unreadable");
 	});
 });
@@ -923,13 +938,20 @@ describe("keptReasonFor (#2486 / PR #2493 review round 2, S2)", () => {
  */
 function createSubagentStopFixture(agentId: string) {
 	const git = (args: string[], cwd: string) =>
-		gitExecFileSync("git", args, {
-			cwd,
-			encoding: "utf8",
-			stdio: "pipe",
-		}) as string;
+		gitExecFileSync(
+			process.platform === "win32" ? "git.exe" : "/usr/bin/git",
+			args,
+			{
+				cwd,
+				encoding: "utf8",
+				stdio: "pipe",
+			},
+		) as string;
 
-	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-2486-"));
+	fs.mkdirSync(path.join(process.cwd(), ".probe-home"), { recursive: true });
+	const root = fs.mkdtempSync(
+		path.join(process.cwd(), ".probe-home", "pi-lens-2486-"),
+	);
 	const repo = path.join(root, "main");
 	const ledgerDir = path.join(root, "ledger");
 	fs.mkdirSync(repo, { recursive: true });
@@ -1098,6 +1120,38 @@ function createSubagentStopFixture(agentId: string) {
 		return siblingPath;
 	}
 
+	function addCapCandidates(count: number) {
+		git(["worktree", "remove", "--force", "--force", worktree], repo);
+		const registered: string[] = [];
+		const unregistered: string[] = [];
+		for (let index = 0; index < count; index++) {
+			const registeredPath = path.join(
+				repo,
+				"merged-candidates",
+				`registered-${index}`,
+			);
+			fs.mkdirSync(path.dirname(registeredPath), { recursive: true });
+			git(
+				["worktree", "add", "-q", "-b", `pr-${9100 + index}`, registeredPath],
+				repo,
+			);
+			registered.push(registeredPath);
+			const unregisteredPath = path.join(
+				repo,
+				".claude",
+				"worktrees",
+				`agent-unregistered-${index}`,
+			);
+			fs.mkdirSync(unregisteredPath, { recursive: true });
+			fs.writeFileSync(
+				path.join(unregisteredPath, ".git"),
+				"gitdir: missing\n",
+			);
+			unregistered.push(unregisteredPath);
+		}
+		return { registered, unregistered };
+	}
+
 	/**
 	 * #2519 round 2, F1: a THIRD module-substitution hook alongside
 	 * `patchProcessScan`/`patchRecheck` -- this one appends synthetic rows to
@@ -1161,6 +1215,7 @@ function createSubagentStopFixture(agentId: string) {
 		patchProcessScanAppendRows,
 		addNodeModulesJunction,
 		addSiblingWorktree,
+		addCapCandidates,
 		cleanup,
 	};
 }
@@ -1260,6 +1315,102 @@ describe("SubagentStop hook, end to end (#2486)", () => {
 
 	const eventsOf = (records: Record<string, unknown>[]) =>
 		records.map((record) => record.event);
+
+	it("leaves both candidate kinds untouched in dry-run and at --max 0", () => {
+		const candidates = fixture.addCapCandidates(5);
+		const before = [candidates.registered[0], candidates.unregistered[0]].map(
+			(entry) => ({ entry, stat: fs.statSync(entry) }),
+		);
+		const dryRun = JSON.parse(
+			runCli(["--max", "2", "--dry-run", "--no-orphan-sweep", "--json"], ""),
+		) as { remove: unknown[]; unregistered: { remove: unknown[] } };
+		expect(dryRun.remove).toHaveLength(2);
+		expect(dryRun.unregistered.remove).toHaveLength(0);
+		for (const { entry, stat } of before) {
+			const after = fs.statSync(entry);
+			expect(after.ino).toBe(stat.ino);
+			expect(after.mtimeMs).toBe(stat.mtimeMs);
+		}
+
+		const zero = JSON.parse(
+			runCli(["--max", "0", "--no-orphan-sweep", "--json"], ""),
+		) as {
+			remove: unknown[];
+			deferred: string[];
+			unregistered: { remove: unknown[]; deferred: string[] };
+		};
+		expect(zero.remove).toHaveLength(0);
+		expect(zero.deferred).toHaveLength(5);
+		expect(zero.unregistered.remove).toHaveLength(0);
+		expect(zero.unregistered.deferred).toHaveLength(5);
+		expect(candidates.registered.every((entry) => fs.existsSync(entry))).toBe(
+			true,
+		);
+		expect(candidates.unregistered.every((entry) => fs.existsSync(entry))).toBe(
+			true,
+		);
+	});
+
+	it(
+		"applies --max once across registered and unregistered removals",
+		{ timeout: 90_000 },
+		() => {
+			// #2631/#2538 recurrence: two destructive passes must not each spend
+			// the operator's one explicit deletion budget. Five candidates in each
+			// population with --max 2 must remove exactly two total, then defer the
+			// other eight from the same raw combined plan.
+			const candidates = fixture.addCapCandidates(5);
+			const out = runCli(["--max", "2", "--no-orphan-sweep", "--json"], "");
+			const plan = JSON.parse(out) as {
+				remove: { path: string }[];
+				deferred: string[];
+				unregistered: { remove: string[]; deferred: string[] };
+			};
+			expect(plan.remove).toHaveLength(2);
+			expect(plan.unregistered.remove).toHaveLength(0);
+			expect(plan.deferred).toHaveLength(3);
+			expect(plan.unregistered.deferred).toHaveLength(5);
+			expect(
+				candidates.registered.filter((entry) => fs.existsSync(entry)),
+			).toHaveLength(3);
+			expect(
+				candidates.unregistered.filter((entry) => fs.existsSync(entry)),
+			).toHaveLength(5);
+			const firstRecords = ledgerRecords();
+			expect(
+				firstRecords.filter(
+					(record) => record.event === "hygiene.worktree-removed",
+				),
+			).toHaveLength(2);
+			expect(
+				firstRecords.filter(
+					(record) => record.event === "hygiene.unregistered-dir",
+				),
+			).toHaveLength(0);
+			expect(
+				firstRecords.find((record) => record.event === "hygiene.run"),
+			).toMatchObject({
+				removed: 2,
+				unregisteredDirs: 0,
+			});
+
+			// The deferred candidates use the same raw plan on the next run. This
+			// also drives both execution paths and their distinct ledger records.
+			runCli(["--max", "10", "--no-orphan-sweep"], "");
+			const records = ledgerRecords();
+			expect(
+				records.filter((record) => record.event === "hygiene.worktree-removed"),
+			).toHaveLength(5);
+			expect(
+				records.filter((record) => record.event === "hygiene.unregistered-dir"),
+			).toHaveLength(5);
+			expect(records.at(-1)).toMatchObject({
+				event: "hygiene.run",
+				removed: 8,
+				unregisteredDirs: 5,
+			});
+		},
+	);
 
 	it(
 		"still removes the trees --only names, on the manual policy",
@@ -1551,7 +1702,7 @@ describe("SubagentStop hook, end to end (#2486)", () => {
 							clearInterval(timer);
 							resolve();
 						});
-					}, 150);
+					}, 500);
 				});
 				await Promise.all([cliRun, hammer]);
 


### PR DESCRIPTION
Operating rule: `--max` is one deletion budget for every removal pass in a run.

Kept: The existing registered and unregistered execution paths remain separate
after planning; only their cap and deferred-plan source are shared.

## Summary

- Build one tagged raw removal plan for registered and unregistered candidates.
- Apply `capRemovals` once using the smaller of `--max` and the hook policy cap.
- Partition the capped plan and its deferred complement back into both paths.
- Remove eligible unregistered directories and record them as `hygiene.unregistered-dir`.
- Move all real Git repositories in this test file under `$PWD/.probe-home` and use the existing `git-fixture-env` seam.

## Round 2

### F1 disposition

Fixed. The shared tagged plan is capped once, and both deferred lists come from
the same uncapped combined plan. The effective cap still includes the hook
policy cap. The run record counts registered worktrees and unregistered
directories separately while `removed` reports the total.

### Red-first and mutation evidence

- Review r1 reproduction: five registered plus five unregistered candidates
  with `--max 2` removed 4 today, because each pass spent 2.
- Compile-valid mutation: restoring an independent
  `unregisteredPlan.remove.slice(0, options.max)` produced
  `AssertionError: expected [ …(2) ] to have a length of +0 but got 2`.
  The regression expected zero unregistered removals in the first capped run.
- Environment repair: the previous 21 Git-guard failures are gone after
  moving the repositories under `.probe-home`; the full file has 0 blocked tests.

### Executed verification list

- `--dry-run`: passed. Candidate directory inode and mtime stayed unchanged.
- `--max 0`: passed. Both removal lists were empty, with five registered and
  five unregistered candidates deferred; all ten directories remained.
- Five-candidate end-to-end cap: passed. Five registered plus five
  unregistered candidates produced 2 total removals on the first run, then 8
  on the uncapped follow-up.
- Branch deletion refuses a branch checked out elsewhere: passed in
  `planBranchDeletions` coverage.
- Ledger records: passed. The merged pass emitted five
  `hygiene.worktree-removed` records, the unregistered pass emitted five
  `hygiene.unregistered-dir` records, and the final run record had
  `removed: 8, unregisteredDirs: 5`.

## Tests

- `tests/scripts/prune-agent-worktrees.test.ts`: edited fixture roots and added
  dry-run, zero-cap, combined-cap, deferred-plan, and ledger assertions.
- `tests/scripts/worktree-hygiene.test.ts`: existing branch-deletion and cap
  contract coverage ran unchanged.
- Build: `npm run build` passed.
- Lint: `npm run lint` passed. The linter reported only existing warnings in
  generated fixture copies under `.probe-home`.
- Targeted tests: `178 passed, 2 skipped` across both files.
- Final prune CLI file: `58 passed, 2 skipped`.

## Blast radius

The changed production seam is `main()` in
`scripts/prune-agent-worktrees.mjs`. Its callers are the manual CLI,
SessionStart, and SubagentStop hook entry points. Its callees are the existing
registered planner, unregistered collector, cap helper, filesystem removal,
and ledger formatters. Registered process scanning and branch deletion remain
on their existing paths.

## Class sweep

The cap split was searched across `scripts/prune-agent-worktrees.mjs`,
`scripts/lib/worktree-hygiene.mjs`, and the script tests. The only independent
unregistered slice was replaced. Existing pure `capRemovals` callers remain
valid. The consolidation verdict is to fold both destructive populations onto
the one combined-plan seam because a second slice recreates the defect.

## Observability

Registered removals retain `hygiene.worktree-removed`; unregistered removals
use the bounded `hygiene.unregistered-dir` record. `hygiene.run.removed` is the
total, and `unregisteredDirs` identifies the unregistered subset.

## Test assessment

The new tests drive the real CLI, real Git repositories, real filesystem
removals, and the real ledger. Git process setup uses the existing fixture
environment seam; no in-process production store or sink is mocked.

## Preflight

`npm run preflight` is unavailable in this checkout: npm reports
`Missing script: "preflight"`.

| Gate | Result |
| --- | --- |
| `npm run build` | passed |
| `npm run lint` | passed |
| `tests/scripts/prune-agent-worktrees.test.ts` | 58 passed, 2 skipped |
| Both targeted script suites | 178 passed, 2 skipped |
| `npm run fmt:check` | passed |
| `npm run changelog:check` | passed |
| `git diff --check` | passed |
| `npm run preflight` | unavailable, missing npm script |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
