### PR TITLE
ci(policy): skip PR title, body and close-keyword checks for dependabot (refs #2714)

### DIFF
--- a/.changelog/2714-dependabot-pr-policy-skip.md
+++ b/.changelog/2714-dependabot-pr-policy-skip.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Skip the PR title, body and close-keyword checks for dependabot PRs (refs #2714)** — the `pr-title-lint` and `pr-body-lint` jobs in lint.yml and the lint job in close-keywords.yml now carry a `dependabot[bot]` skip condition. A bump can never carry an issue ref or the PR-body template, so these checks no longer go red on every bump and no merge-train pass has to ignore them by hand. Lint, Unit tests, the install tests and the advisory lanes still run on bumps.

--- a/.claude/skills/merge-train/SKILL.md
+++ b/.claude/skills/merge-train/SKILL.md
@@ -229,9 +229,11 @@ operator's private notes, so a different orchestrator can run the same train.
   2026-09-07).** The PR-title issue-ref gate is a policy check this train
   applies to human PRs; a bump title can never carry a ref. Merge order: one
   at a time (each merge dirties the rest; dependabot rebases them itself);
-  gate on Lint, Unit tests and every non-advisory check on the exact head,
-  ignoring only "PR title"/"PR body"; hold anything red on a real check with a
-  comment naming the check (2026-09-07: tsls 6 needs a Node-floor bump, biome
+  gate on Lint, Unit tests and every non-advisory check on the exact head;
+  lint.yml and close-keywords.yml themselves skip "PR title", "PR body
+  (advisory)" and "Close-keyword syntax" for dependabot (2026-09-09, refs
+  #2714), so nothing needs hand-ignoring; hold anything red on a real check
+  with a comment naming the check (2026-09-07: tsls 6 needs a Node-floor bump, biome
   fails the install test, vitest 5 fails four gates; a bump whose install
   script is pinned by `allowScripts` needs the pin moved in a maintainer
   commit on the bump branch). A major bump with peers (vitest + coverage-v8)

--- a/.github/workflows/close-keywords.yml
+++ b/.github/workflows/close-keywords.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   lint:
     name: Close-keyword syntax
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,7 +105,7 @@ jobs:
   pr-title-lint:
     name: PR title
     needs: validate-merge-train-dispatch
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -151,7 +151,7 @@ jobs:
   pr-body-lint:
     name: PR body (advisory)
     needs: validate-merge-train-dispatch
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/tests/config/advisory-tool-workflow.test.ts
+++ b/tests/config/advisory-tool-workflow.test.ts
@@ -14,6 +14,7 @@ const workflow = yaml.load(
 		string,
 		{
 			name?: string;
+			if?: string;
 			"continue-on-error"?: boolean;
 			steps?: Array<Record<string, unknown>>;
 		}
@@ -99,5 +100,47 @@ describe("#2706 advisory tooling workflow contracts", () => {
 				);
 			}
 		}
+	});
+});
+
+describe("#2714 dependabot skips the human PR-policy checks", () => {
+	// Recurrence: Dependabot PRs can never carry an issue ref in the title or
+	// the PR-body template, so `PR title` and `PR body (advisory)` went red on
+	// every bump and the merge train ignored them by hand. The skip must stay
+	// on exactly the three policy jobs (pr-title-lint, pr-body-lint in
+	// lint.yml plus the close-keyword job in close-keywords.yml); no other job
+	// may inherit it, or a bump would skip a check that still applies to it.
+	const dependabotSkip =
+		"github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'";
+
+	it("skips pr-title-lint and pr-body-lint for dependabot and no other lint.yml job", () => {
+		const policyJobs = ["pr-title-lint", "pr-body-lint"];
+		for (const key of policyJobs) {
+			expect(workflow.jobs[key]?.if, `${key} must skip dependabot`).toBe(
+				dependabotSkip,
+			);
+		}
+		const others = Object.keys(workflow.jobs).filter(
+			(key) => !policyJobs.includes(key),
+		);
+		for (const key of others) {
+			expect(
+				workflow.jobs[key]?.if ?? "",
+				`${key} must not skip dependabot`,
+			).not.toContain("dependabot");
+		}
+	});
+
+	it("skips the close-keyword job for dependabot", () => {
+		const closeKeywords = yaml.load(
+			readFileSync(
+				resolve(ROOT, ".github/workflows/close-keywords.yml"),
+				"utf8",
+			),
+		) as { jobs: Record<string, { if?: string }> };
+		expect(
+			closeKeywords.jobs.lint?.if,
+			"close-keyword must skip dependabot",
+		).toBe(dependabotSkip);
 	});
 });


### PR DESCRIPTION
# PR body: skip PR title, body and close-keyword checks for dependabot

Operating rule: a dependabot PR can never carry an issue ref or the PR-body template, so the workflow itself skips `PR title`, `PR body (advisory)` and `Close-keyword syntax` for `dependabot[bot]` and no merge-train pass ignores those reds by hand.

Kept: ci.yml untouched per brief. The changelog-fragment fast-fail job has no dependabot exemption, but `scripts/check-changelog-fragments.mjs` only validates the format of fragments that exist, so a bump with no fragment passes it. Lint, Unit tests, install tests and all advisory lanes still run on bumps.

## Summary

- Dependabot PRs show `PR title` red, `PR body (advisory)` red and `Close-keyword syntax` red on every bump. The merge-train rule told the orchestrator to ignore them by hand. This change makes the exception mechanical.
- `lint.yml` jobs `pr-title-lint` and `pr-body-lint` now carry `if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'`.
- `close-keywords.yml`'s `lint` job gets the same condition.
- `ci-checks.mjs` already classifies a `skipped` conclusion as a valid completed state ("skipped" is not hypothetical, it is the observed shape), so a skipped check is neutral to the merge train, not red.

## Tests

Red first, quoted against the unmodified workflows (`tests/config/advisory-tool-workflow.test.ts`, the shape test that loads lint.yml):

```
AssertionError: pr-title-lint must skip dependabot: expected 'github.event_name == \'pull_request\'' to be 'github.event_name == \'pull_request\'…'
AssertionError: close-keyword must skip dependabot: expected undefined to be 'github.event_name == \'pull_request\'…'
```

Mutation 1, neutered guard (dependabot clause dropped from `pr-body-lint` only): red names the exact job.

```
AssertionError: pr-body-lint must skip dependabot: expected 'github.event_name == \'pull_request\'' to be 'github.event_name == \'pull_request\'…'
      Tests  1 failed | 11 passed (12)
```

Mutation 2, over-applied guard (condition added to `oxfmt`, which bumps must still run): the negative assertion reds.

```
AssertionError: oxfmt must not skip dependabot: expected 'github.event_name == \'pull_request\'…' not to contain 'dependabot'
      Tests  1 failed | 11 passed (12)
```

Both mutations reverted; final state green.

- `PI_LENS_HOME=$PWD/.probe-home node_modules/.bin/vitest run tests/config/advisory-tool-workflow.test.ts --configLoader runner`: 12 passed.
- `PI_LENS_HOME=$PWD/.probe-home node_modules/.bin/vitest run tests/config/ --configLoader runner`: 41 files, 370 tests, all passed.
- `npm run lint`: pass. `npm run fmt:check`: pass.
- `npx --no-install actionlint .github/workflows/lint.yml`: environment-blocked. actionlint is a standalone Go binary that the CI job downloads; there is no local binary and the sandbox has no network (`npm ERR! could not determine executable to run`). YAML validity is proven by the js-yaml load inside the shape test, which asserts the exact parsed `if:` value on all three jobs.

### Test assessment

- `tests/config/advisory-tool-workflow.test.ts` (edited): extended the lint.yml-loading shape test with one describe and two tests. One pins the exact dependabot skip on `pr-title-lint` and `pr-body-lint` and fails if any other lint.yml job inherits it; the other pins the skip on close-keywords.yml's lint job. The recurrence comment names the shipped defect: bumps red on title/body/close-keyword checks and the merge train ignores them by hand. No test removed.

## Blast radius

- Manifest-only behavior change. The three jobs evaluate their `if:` only on `pull_request` events; pushes, `repository_dispatch` post-merge validation and the `record-post-merge-validation` job (which does not `needs:` either lint.yml policy job) are untouched.
- Human PRs: all three checks still run, unchanged.
- Dependabot PRs: the three jobs report `skipped`. Lint, Unit tests, install tests, changelog fast-fail and every advisory lane still run, so real regressions on a bump stay visible.
- `.claude/skills/merge-train/SKILL.md`: the "Dependabot PRs merge on real checks" rule now states the workflow-level skip instead of the hand-ignoring instruction (one sentence, refs #2714).

## Class sweep

- Grepped all of `.github/workflows/` for `user.login` and `dependabot`: the three added conditions are the only author-keyed conditions in the tree.
- `close-keyword-verification.yml` was considered and excluded: it verifies close keywords on already-merged PRs, so it is not a PR gate a bump can fail.
- `changelog-fragment-fastfail` (ci.yml) was considered and left as-is per brief: it is PR-gated but validates only the format of existing fragments, so a bump without one is not red.

## Observability

No new failure path; no record added. The behavior is observable in CI state itself: on a dependabot PR the three check-runs report conclusion `skipped` (neutral per `scripts/lib/ci-checks.mjs`), and on a human PR nothing changes. `node scripts/ci-verdict.mjs` and the merge lane already read skipped as a completed, non-failing state.

## Preflight

```
| gate                      | mirrored CI job                | pass/fail | first red line |
| ------------------------- | ------------------------------ | --------- | -------------- |
| build                     | Lint & type-check              | pass      |                |
| lint                      | Lint & type-check              | pass      |                |
| fmt:check                 | oxfmt format check (advisory)  | pass      |                |
| changelog:check           | Unit tests                     | pass      |                |
| check-changelog-fragments | Changelog fragment (fast-fail) | pass      |                |
| check:lockfile            | Lint & type-check              | pass      |                |
| tests/config              | Unit tests                     | pass      |                |
| generation-guard          | Unit tests                     | pass      |                |
| flake-shape-ratchet       | Unit tests                     | pass      |                |
| lsp-spawn-heavy-coverage  | Unit tests                     | pass      |                |
| ci-verdict                | Unit tests                     | pass      |                |
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
