### PR TITLE
ci(release-qa): tool-smoke install lane in the baseline; red install = do-not-ship, unreachable = inconclusive (refs #2663, #2784)

### DIFF
--- a/.changelog/2663-tool-smoke-install-baseline.md
+++ b/.changelog/2663-tool-smoke-install-baseline.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- **Add the tool-smoke install lane to the release-QA baseline (refs #2663, #2784)** — a `tool-smoke-install` row installs every npm/pip installer-registry entry through the real smoke harness, so a dead registry entry is a red do-not-ship row, a registry-unreachable lane is INCONCLUSIVE, and neither reads as green.

--- a/docs/release-qa-baseline.md
+++ b/docs/release-qa-baseline.md
@@ -84,6 +84,7 @@ PR's packed tarball (#2700, the check #2587 was missing). `attw`
 | config-provenance | a project config is LOADED and its provenance is reportable | mcp-stdio | `tools/call` `pilens_effective_config` with the fixture file | result names the fixture's `.pi-lens.json` as a contributing document | tool result text | new — `tests/config/pi-lens-config-schema.test.ts` covers the schema, not the packaged load | — |
 | degradation-visible | a silently-ignored input is RECORDED as a degradation instead of vanishing | mcp-stdio | `tools/call` `pilens_health` with the fixture's project-tier `lsp.enabled` (a global-only setting) loaded | health text carries a `config-ignored` degradation line naming the fixture's `.pi-lens.json` | health tool result text | `clients/degradation-ledger.ts` is the reused machinery; no smoke asserts it end to end | #1605 lane 2 (availability-lifecycle): the degradation-recorded half; #1605 additionally asserts RECOVERY, which this row does not |
 | git-install-loads | a `git:` install of a pushed ref builds and loads in a real pi | git-install | `pi install git:github.com/apmantza/pi-lens@<ref>` then `get_commands` | at least 1 `lens-*` command and at least 4 skills | get_commands response JSON | `scripts/rpc-load-check.mjs` assertion, re-run against the git layout | — |
+| tool-smoke-install | every npm/pip entry in the installer registry resolves on a real install | npm-install | `node <installed>/scripts/smoke-tools.mjs --install --install-registry` (about 1m 29s cold on this box for 33 entries) | the report shows every npm/pip entry resolved or a named legitimate skip (toolchain absent, declined), and no genuine install failure; a registry-unreachable classification leaves the lane UNMEASURED; requires network access to the npm and pip registries | install-registry JSON report | `classifyInstallOutcome` from the #2661 fixture lanes — this lane sweeps the whole npm/pip registry, where fixture lanes exercise only the entries their fixtures name | — |
 
 ## Why `skills-registered` pins the registrar
 
@@ -150,6 +151,7 @@ Ship line, from the outcomes:
 | pi did not boot with NO candidate installed | BLOCKED — no verdict | 3 | 0 |
 | pi booted, the candidate would not install or activate | do not ship, cause named on the verdict | 1 | 0 |
 | any row FAILED | do not ship | 1 | N |
+| any row classified registry-unreachable (its lane UNMEASURED) | INCONCLUSIVE — no verdict, the skips are not green | 3 | N |
 | pi booted but zero rows PASSED | INCONCLUSIVE — no verdict | 3 | N |
 | any UNTESTED or SKIPPED, at least one PASS | ship with caveats, each named | 2 | N |
 | all PASS | ship | 0 | N |

--- a/scripts/release-qa.d.mts
+++ b/scripts/release-qa.d.mts
@@ -66,6 +66,7 @@ export interface RunnerOptions {
 
 export const BASELINE_TABLE_MARKER: string;
 export const BASELINE_COLUMNS: readonly string[];
+export const TOOL_SMOKE_INSTALL_ROW_ID: string;
 export const OUTCOME: {
 	readonly PASS: "PASS";
 	readonly FAIL: "FAIL";
@@ -77,6 +78,16 @@ export function parseBaselineRows(text: string): ParsedBaseline;
 export function classifyRowOutcome(probe: ProbeReport | null | undefined): {
 	outcome: string;
 	detail: string;
+};
+export function classifyToolSmokeInstallReport(
+	report: Record<string, unknown> | null,
+	context?: Record<string, unknown>,
+): {
+	status: string;
+	detail: string;
+	shows: string;
+	networkBlocked: boolean;
+	witnessContent: string;
 };
 export function formatOutcome(result: {
 	outcome: string;
@@ -93,8 +104,19 @@ export function shipVerdict(
 		blocked?: boolean;
 		blockedReason?: string;
 		candidateFailure?: string;
+		inconclusiveReason?: string;
 	},
 ): Verdict;
+export function runToolSmokeInstallProbe(ctx: {
+	installedPkgDir: string;
+	projectDir: string;
+	env: NodeJS.ProcessEnv;
+}): {
+	status: string;
+	detail: string;
+	shows?: string;
+	witness?: { ext: string; content: string };
+};
 /**
  * The refusal message for a dirty checkout, or null when it is clean. A
  * `--from tree` run packs `git archive HEAD`, so an uncommitted edit would be

--- a/scripts/release-qa.mjs
+++ b/scripts/release-qa.mjs
@@ -94,6 +94,14 @@ const EXPECTED_SKILL_REGISTRAR = "extension:index";
 const MIN_SHIPPED_SKILLS = 4;
 
 /**
+ * The baseline row that witnesses the installer registry (#2663): every
+ * npm/pip entry installs for real through the tool smoke's registry install
+ * lane, a genuine install failure is do-not-ship, and a registry-unreachable
+ * classification refuses the ship verdict instead of reading as green.
+ */
+export const TOOL_SMOKE_INSTALL_ROW_ID = "tool-smoke-install";
+
+/**
  * Short, schema-stable marker for the baseline's matrix table. Deliberately the
  * first two columns only: a marker naming a column that a later revision adds
  * or renames would stop finding the table and the runner would silently report
@@ -330,6 +338,19 @@ export function shipVerdict(results, options = {}) {
 			caveats: failed.map((r) => `${r.id}: ${r.detail}`),
 		};
 	}
+	// #2663: the tool-smoke install row is the release gate's ground truth for
+	// the installer registry. A registry-unreachable classification (the
+	// smoke's own transient-network branch) means that lane is UNMEASURED —
+	// its skips are not green — so the run refuses a ship verdict even where
+	// other rows passed. A genuine install failure outranks it (above): a real
+	// defect is a verdict, not an unmeasurable run.
+	if (options.inconclusiveReason) {
+		return {
+			verdict: "INCONCLUSIVE",
+			reason: options.inconclusiveReason,
+			caveats: [],
+		};
+	}
 	const caveats = list.filter(
 		(r) => r.outcome === OUTCOME.UNTESTED || r.outcome === OUTCOME.SKIPPED,
 	);
@@ -522,6 +543,157 @@ export function classifySelftestOutput(code, stdout) {
 		status: code === 0 && failLines.length === 0 ? "pass" : "fail",
 		detail: shows,
 		shows,
+	};
+}
+
+/**
+ * The tool-smoke install lane's report → the row's probe verdict (#2663).
+ *
+ *   - any genuine install failure (the smoke's red row, #2661) → `"fail"`:
+ *     the row FAILs and the run is do-not-ship (exit 1);
+ *   - no genuine failure but at least one registry-unreachable tool →
+ *     `"unreachable"` with `networkBlocked: true`: the lane is UNMEASURED, so
+ *     the run refuses a ship verdict (INCONCLUSIVE, exit 3) instead of
+ *     reading the skips as green;
+ *   - otherwise → `"pass"`: every entry resolved, with the legitimately
+ *     unavailable ones (toolchain absent, declined) named in the detail.
+ *
+ * The classification itself is never re-derived here — the row/skip verdict
+ * per tool is the smoke's `classifyInstallOutcome` (#2661), consumed through
+ * the lane's JSON; this function only maps that verdict onto the release
+ * gate's outcomes.
+ *
+ * A lane that produced no parseable report — crashed, missing dist build,
+ * timed out — is `"error"`: the check did not run, and a release gate whose
+ * check did not run is not a pass. `toolCount === 0` is the same refusal: a
+ * lane that enumerated no npm/pip entries witnessed nothing.
+ *
+ * @param {{ lane?: string, toolCount?: number, installed?: number, ok?: boolean, results?: Array<{ toolId: string, state: string, detail?: string, networkUnreachable?: boolean }> } | null} report
+ * @param {{ exitCode?: number, stderrTail?: string, timedOut?: boolean, stdout?: string }} [context]
+ */
+export function classifyToolSmokeInstallReport(report, context = {}) {
+	const stderrTail = String(context.stderrTail ?? "")
+		.trim()
+		.split(/\r?\n/)
+		.filter((l) => l.trim().length > 0)
+		.slice(-1)[0];
+	const witnessContent = report
+		? JSON.stringify(report)
+		: String(context.stdout ?? "");
+	if (!report) {
+		const why = context.timedOut
+			? "the install lane timed out"
+			: `the install lane produced no parseable result${
+					context.exitCode ? ` (exit ${context.exitCode})` : ""
+				}`;
+		return {
+			status: "error",
+			detail: `${why}${stderrTail ? `: ${stderrTail}` : ""}`,
+			shows: why,
+			networkBlocked: false,
+			witnessContent,
+		};
+	}
+	if (!Number.isInteger(report.toolCount) || report.toolCount <= 0) {
+		return {
+			status: "error",
+			detail: "the install lane enumerated no npm/pip registry entries",
+			shows: "install lane enumerated no npm/pip registry entries",
+			networkBlocked: false,
+			witnessContent,
+		};
+	}
+	const results = report.results ?? [];
+	const failures = results.filter((r) => r?.state === "fail");
+	if (failures.length > 0) {
+		const shows = `${failures.length} genuine install failure(s): ${failures
+			.map((f) => f.detail || f.toolId)
+			.join("; ")}`;
+		return {
+			status: "fail",
+			detail: shows,
+			shows,
+			networkBlocked: false,
+			witnessContent,
+		};
+	}
+	const network = results.filter((r) => r?.networkUnreachable);
+	if (network.length > 0) {
+		const shows =
+			`registry unreachable for ${network.length} npm/pip ` +
+			`${network.length === 1 ? "entry" : "entries"} ` +
+			`(${network.map((r) => r.toolId).join(", ")}); install ground truth unmeasured`;
+		return {
+			status: "unreachable",
+			detail: shows,
+			shows,
+			networkBlocked: true,
+			witnessContent,
+		};
+	}
+	const skips = results.filter((r) => r?.state === "skip");
+	const shows =
+		`${report.installed}/${report.toolCount} npm/pip registry entries resolved` +
+		(skips.length > 0
+			? `; ${skips.length} legitimately unavailable (${skips
+					.map((s) => s.toolId)
+					.join(", ")})`
+			: "");
+	return {
+		status: "pass",
+		detail: shows,
+		shows,
+		networkBlocked: false,
+		witnessContent,
+	};
+}
+
+/**
+ * Run the installed smoke boundary for the registry baseline row.
+ * @param {{ installedPkgDir: string, projectDir: string, env: NodeJS.ProcessEnv }} ctx
+ * @returns {{ status: string, detail: string, shows?: string, witness?: { ext: string, content: string } }}
+ */
+export function runToolSmokeInstallProbe(ctx) {
+	const script = path.join(ctx.installedPkgDir, "scripts", "smoke-tools.mjs");
+	if (!fs.existsSync(script)) {
+		return {
+			status: "fail",
+			detail: `smoke-tools.mjs is not in the installed package (${script})`,
+		};
+	}
+	let report = null;
+	let context = {};
+	try {
+		const stdout = execFileSync(
+			process.execPath,
+			[script, "--install", "--install-registry"],
+			{
+				cwd: ctx.projectDir,
+				encoding: "utf8",
+				env: ctx.env,
+				timeout: 900_000,
+				maxBuffer: 10 * 1024 * 1024,
+			},
+		);
+		try {
+			report = JSON.parse(stdout.trim());
+		} catch {
+			context = { stdout };
+		}
+	} catch (err) {
+		context = {
+			exitCode: err?.status,
+			stderrTail: err?.stderr,
+			timedOut: Boolean(err?.killed),
+			stdout: err?.stdout,
+		};
+	}
+	const classified = classifyToolSmokeInstallReport(report, context);
+	return {
+		status: classified.status,
+		detail: classified.detail,
+		shows: classified.shows,
+		witness: { ext: "json", content: classified.witnessContent },
 	};
 }
 
@@ -1492,6 +1664,19 @@ const ROW_PROBES = {
 			},
 		};
 	},
+
+	// The installer registry's ground truth (#2663): the smoke's install lane
+	// runs against the INSTALLED package's own dist (the script resolves its
+	// dist relative to its own location), so a registry entry that is dead in
+	// the shipped artifact is one red row here — the same red row shape the
+	// fixture lanes produce (#2661) — instead of a ⚠ skip folded into
+	// "toolchain absent". The classification is the lane's own
+	// `classifyToolSmokeInstallReport` mapping; a registry-unreachable verdict
+	// surfaces as status "unreachable" and `main()` turns it into the run's
+	// INCONCLUSIVE reason rather than letting the skips read as green.
+	[TOOL_SMOKE_INSTALL_ROW_ID]: async (ctx) => {
+		return runToolSmokeInstallProbe(ctx);
+	},
 };
 
 /** Row ids this runner can execute. Exported for the drift guard. */
@@ -1743,6 +1928,11 @@ async function main() {
 	};
 
 	const results = [];
+	// #2663: a registry-unreachable classification means the lane's skips are
+	// UNMEASURED, not green, so the run refuses a ship verdict. Carried beside
+	// `blocked`/`candidateFailure` for the same reason they are: the verdict is
+	// about the run, not any one row's outcome cell.
+	const unreachableRows = [];
 	for (const row of rows) {
 		const probe = ROW_PROBES[row.id];
 		let raw;
@@ -1764,6 +1954,7 @@ async function main() {
 			}
 		}
 		const probeOutcome = classifyRowOutcome(raw);
+		if (raw.status === "unreachable") unreachableRows.push(row.id);
 		let witnessPath = "";
 		if (raw.witness) {
 			const file = path.join(evidenceDir, `${row.id}.${raw.witness.ext}`);
@@ -1796,6 +1987,9 @@ async function main() {
 		blocked,
 		blockedReason,
 		candidateFailure,
+		inconclusiveReason: unreachableRows.length
+			? `registry-unreachable row(s) left UNMEASURED: ${unreachableRows.join(", ")}`
+			: "",
 	});
 	const report = renderReport({
 		rows,

--- a/scripts/smoke-tools.d.mts
+++ b/scripts/smoke-tools.d.mts
@@ -180,6 +180,7 @@ export type ClassifyOutcomeRestDeps = Omit<
 export interface InstallOutcomeRow {
 	row: "fail" | "skip";
 	detail: string;
+	networkUnreachable: boolean;
 }
 /**
  * Classify why `toolId` never resolved via `ensureTool`, using the
@@ -235,6 +236,27 @@ export function ensureFixtureTools(
 ): Promise<{
 	unavailableTools: Set<string>;
 	attemptSnapshots: Map<string, SmokeInstallAttempt | undefined>;
+}>;
+export function runInstallRegistrySmoke(options?: {
+	verbose?: boolean;
+	deps?: {
+		TOOLS: Array<{ id: string; installStrategy: string }>;
+		ensureTool: (toolId: string) => Promise<string | undefined>;
+		getInstallAttempt: (toolId: string) => SmokeInstallAttempt | undefined;
+		pipCommandCandidates?: () => string[];
+	};
+}): Promise<{
+	lane: string;
+	toolCount: number;
+	installed: number;
+	ok: boolean;
+	results: Array<{
+		toolId: string;
+		installStrategy: string;
+		state: string;
+		detail: string;
+		networkUnreachable: boolean;
+	}>;
 }>;
 export const FIXTURES: SmokeFixture[];
 export const LSP_FIXTURES: LspFixture[];

--- a/scripts/smoke-tools.mjs
+++ b/scripts/smoke-tools.mjs
@@ -1387,6 +1387,7 @@ function parseArgs(argv) {
 	let autofix = false;
 	let tier1 = false;
 	let minPass = null;
+	let installRegistry = false;
 	for (const arg of argv) {
 		if (arg === "--step2") step2 = true;
 		else if (arg === "--verbose" || arg === "-v") verbose = true;
@@ -1395,6 +1396,7 @@ function parseArgs(argv) {
 		else if (arg === "--lsp-gate") lspGate = true;
 		else if (arg === "--format") format = true;
 		else if (arg === "--tier1") tier1 = true;
+		else if (arg === "--install-registry") installRegistry = true;
 		else if (arg.startsWith("--min-pass="))
 			minPass = Number.parseInt(arg.slice("--min-pass=".length), 10);
 		else if (arg === "--autofix") autofix = true;
@@ -1411,6 +1413,7 @@ function parseArgs(argv) {
 		autofix,
 		tier1,
 		minPass,
+		installRegistry,
 	};
 }
 
@@ -1650,6 +1653,7 @@ export function classifyInstallOutcome(toolId, deps) {
 	if (attempt?.outcome !== "failed") {
 		return {
 			row: "skip",
+			networkUnreachable: false,
 			detail: `${toolId} unavailable (${attempt?.outcome ?? "no install attempt"}${attempt?.reason ? `: ${firstLine(attempt.reason)}` : ""})`,
 		};
 	}
@@ -1657,6 +1661,7 @@ export function classifyInstallOutcome(toolId, deps) {
 	if (TRANSIENT_NETWORK_PATTERN.test(reason)) {
 		return {
 			row: "skip",
+			networkUnreachable: true,
 			detail: `${toolId} unavailable (transient registry/network condition: ${firstLine(reason)})`,
 		};
 	}
@@ -1670,11 +1675,13 @@ export function classifyInstallOutcome(toolId, deps) {
 	if (!genuine) {
 		return {
 			row: "skip",
+			networkUnreachable: false,
 			detail: `${toolId} unavailable (no ${strategy ?? "known"} toolchain on this runner)`,
 		};
 	}
 	return {
 		row: "fail",
+		networkUnreachable: false,
 		detail: `ensureTool(${toolId}) failed (${strategy} toolchain present): ${firstLine(reason)}`,
 	};
 }
@@ -1756,6 +1763,123 @@ export async function ensureFixtureTools(
 		}
 	}
 	return { unavailableTools, attemptSnapshots };
+}
+
+/**
+ * Registry install lane (--install-registry, #2663): install every TOOLS
+ * entry whose installStrategy is npm or pip — the two strategies whose
+ * toolchain this harness itself guarantees (#2661: npm runs under Node, so it
+ * is always "present"; pip is probed through the installer's own
+ * `pipCommandCandidates` ladder) — and classify each unavailability with the
+ * SAME `classifyInstallOutcome` the fixture lanes use, so a dead registry
+ * entry (the #2638 `vscode-css-languageserver` shape) is one red row here
+ * instead of a ⚠ skip folded into "toolchain absent".
+ *
+ * The fixture lanes only exercise the registry entries their fixtures name;
+ * this lane sweeps the whole npm/pip registry, which is what the release gate
+ * (`scripts/release-qa.mjs`'s `tool-smoke-install` row) consumes.
+ *
+ * Output contract: ONE JSON document on stdout, human progress on stderr.
+ * Exit code (decided by the caller in main()): 0 when no genuine install
+ * failure, 1 otherwise. A network-unreachable classification is a SKIP here —
+ * the smoke's own semantics (#2661 F2: a runner with no network is a runner
+ * condition, not an installer defect) — and carries `networkUnreachable: true`
+ * so the release-qa consumer can refuse a ship verdict on an unmeasured lane
+ * instead of reading the skips as green.
+ *
+ * `deps` injects the installer surface for tests (the seam `runFormatSmoke`
+ * uses); production resolves it from dist/clients/installer. `toolchainPresence`
+ * is injectable for the same reason — the production value starts empty and
+ * caches probe results per strategy.
+ */
+export async function runInstallRegistrySmoke({ verbose, deps } = {}) {
+	let ensureTool;
+	let TOOLS = [];
+	let getInstallAttempt;
+	let pipCommandCandidatesFn;
+	let toolchainPresence = {};
+	if (deps) {
+		({
+			ensureTool,
+			TOOLS,
+			getInstallAttempt,
+			pipCommandCandidates: pipCommandCandidatesFn,
+			toolchainPresence,
+		} = deps);
+	} else {
+		const installerEntry = path.join(
+			repoRoot,
+			"dist",
+			"clients",
+			"installer",
+			"index.js",
+		);
+		if (!fs.existsSync(installerEntry)) {
+			console.error(
+				`dist build missing: ${installerEntry}\nRun \`npm run build:dist\` first.`,
+			);
+			process.exit(2);
+		}
+		({
+			ensureTool,
+			TOOLS,
+			getInstallAttempt,
+			pipCommandCandidates: pipCommandCandidatesFn,
+		} = await import(pathToFileURL(installerEntry).href));
+	}
+	const toolsById = new Map(TOOLS.map((t) => [t.id, t]));
+	const pipCandidates = pipCommandCandidatesFn?.() ?? [];
+	const targets = TOOLS.filter(
+		(t) => t.installStrategy === "npm" || t.installStrategy === "pip",
+	);
+	const { unavailableTools, attemptSnapshots } = await ensureFixtureTools(
+		targets.map((t) => t.id),
+		ensureTool,
+		getInstallAttempt,
+		(toolId, resolved) => {
+			if (verbose) {
+				console.error(`ensureTool(${toolId}) → ${resolved ?? "UNAVAILABLE"}`);
+			}
+		},
+	);
+	const results = [];
+	for (const tool of targets) {
+		if (!unavailableTools.has(tool.id)) {
+			results.push({
+				toolId: tool.id,
+				installStrategy: tool.installStrategy,
+				state: "pass",
+				detail: "resolved",
+				networkUnreachable: false,
+			});
+			continue;
+		}
+		const outcome = classifyInstallOutcome(tool.id, {
+			toolsById,
+			toolchainPresence,
+			pipCandidates,
+			getInstallAttempt: (toolId) => attemptSnapshots.get(toolId),
+		});
+		results.push({
+			toolId: tool.id,
+			installStrategy: tool.installStrategy,
+			state: outcome.row,
+			detail: outcome.detail,
+			networkUnreachable: outcome.networkUnreachable,
+		});
+	}
+	const genuineFailures = results.filter((r) => r.state === "fail");
+	return {
+		lane: "install-registry",
+		toolCount: results.length,
+		installed: results.filter((r) => r.state === "pass").length,
+		genuineFailures: genuineFailures.map((r) => r.toolId),
+		networkUnreachable: results
+			.filter((r) => r.networkUnreachable)
+			.map((r) => r.toolId),
+		ok: genuineFailures.length === 0,
+		results,
+	};
 }
 
 /** Classify one target runner's outcome against the Step-1 bar. */
@@ -2615,12 +2739,19 @@ async function main() {
 		autofix,
 		tier1,
 		minPass,
+		installRegistry,
 	} = parseArgs(process.argv.slice(2));
 
 	// Clean leftovers from prior runs (their file locks are released now).
 	const swept = sweepLeftovers();
 	if (verbose && swept > 0)
 		console.error(`swept ${swept} leftover temp workspace(s)`);
+
+	if (installRegistry) {
+		const result = await runInstallRegistrySmoke({ verbose });
+		console.log(JSON.stringify(result));
+		process.exit(result.ok ? 0 : 1);
+	}
 
 	if (lsp) {
 		process.exit(

--- a/tests/scripts/release-qa.test.ts
+++ b/tests/scripts/release-qa.test.ts
@@ -56,6 +56,7 @@ import {
 	pollToTerminal,
 	rowReportShows,
 	rowProbeRequest,
+	runToolSmokeInstallProbe,
 	scratchEnv,
 	renderCoverageLine,
 	renderReport,
@@ -174,6 +175,87 @@ describe("release-QA matrix and probe map are one list (#2606)", () => {
 		const { rows } = parseBaselineRows(baselineText());
 		const documented = rows.map((r) => r.id).sort();
 		expect(implementedRowIds()).toEqual(documented);
+	});
+});
+
+describe("release-QA tool-smoke install lane (#2663)", () => {
+	// The doc↔probe tie for #2663's row, pinned by name: the tool-smoke
+	// install lane (#2661's red-on-genuine-install-failure classification)
+	// joins the release gate, and a row present in only one of the two lists
+	// is either an undocumented probe or a documented row the runner silently
+	// skips. The generic tie above holds the whole list; this one names the
+	// new row so its removal reads as a named failure, not a count drift.
+	it("documents the tool-smoke-install row and implements its probe", () => {
+		const { rows } = parseBaselineRows(baselineText());
+		const documented = rows.find((r) => r.id === "tool-smoke-install");
+		expect(
+			documented,
+			"row tool-smoke-install is missing from the matrix",
+		).toBeDefined();
+		expect(implementedRowIds()).toContain("tool-smoke-install");
+	});
+
+	function stubSmoke(report: object, exitCode = 0) {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "release-qa-smoke-"));
+		const scripts = path.join(root, "scripts");
+		fs.mkdirSync(scripts);
+		fs.writeFileSync(
+			path.join(scripts, "smoke-tools.mjs"),
+			`process.stdout.write(${JSON.stringify(JSON.stringify(report))}); process.exit(${exitCode});\n`,
+		);
+		return root;
+	}
+
+	it("maps a red install row to exit 1 through the real smoke process boundary", () => {
+		const root = stubSmoke({
+			lane: "install-registry",
+			toolCount: 1,
+			installed: 0,
+			results: [{ toolId: "dead-tool", state: "fail", detail: "E404" }],
+		});
+		try {
+			const raw = runToolSmokeInstallProbe({
+				installedPkgDir: root,
+				projectDir: root,
+				env: { ...process.env, PI_LENS_HOME: path.join(root, ".probe-home") },
+			});
+			const result = { id: "tool-smoke-install", ...classifyRowOutcome(raw) };
+			const verdict = shipVerdict([result]);
+			expect(verdictExitCode(verdict.verdict)).toBe(1);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("maps a network-unreachable install row to exit 3 through the real smoke process boundary", () => {
+		const root = stubSmoke({
+			lane: "install-registry",
+			toolCount: 1,
+			installed: 0,
+			results: [
+				{
+					toolId: "offline-tool",
+					state: "skip",
+					detail: "transient registry/network condition",
+					networkUnreachable: true,
+				},
+			],
+		});
+		try {
+			const raw = runToolSmokeInstallProbe({
+				installedPkgDir: root,
+				projectDir: root,
+				env: { ...process.env, PI_LENS_HOME: path.join(root, ".probe-home") },
+			});
+			expect(raw.status).toBe("unreachable");
+			const result = { id: "tool-smoke-install", ...classifyRowOutcome(raw) };
+			const verdict = shipVerdict([result], {
+				inconclusiveReason: "registry-unreachable row(s) left UNMEASURED",
+			});
+			expect(verdictExitCode(verdict.verdict)).toBe(3);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/tests/scripts/release-qa.test.ts
+++ b/tests/scripts/release-qa.test.ts
@@ -195,7 +195,7 @@ describe("release-QA tool-smoke install lane (#2663)", () => {
 		expect(implementedRowIds()).toContain("tool-smoke-install");
 	});
 
-	function stubSmoke(report: object, exitCode = 0) {
+	function stubSmoke(report: Record<string, unknown>, exitCode = 0) {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "release-qa-smoke-"));
 		const scripts = path.join(root, "scripts");
 		fs.mkdirSync(scripts);

--- a/tests/scripts/smoke-tools-genuine-install-failure.test.ts
+++ b/tests/scripts/smoke-tools-genuine-install-failure.test.ts
@@ -35,6 +35,7 @@ import {
 	classifyInstallOutcome,
 	ensureFixtureTools,
 	pipCandidateUsable,
+	runInstallRegistrySmoke,
 	resolveUnavailabilityRow,
 } from "../../scripts/smoke-tools.mjs";
 
@@ -217,6 +218,32 @@ describe("classifyInstallOutcome (#2638/#2661) — outcome × toolchain table", 
 		expect(result.row).toBe("fail");
 		expect(result.detail).not.toContain("second line never shown");
 		expect(result.detail.length).toBeLessThan(300);
+	});
+
+	it("preserves the network-unreachable classification for release consumers", () => {
+		const result = classifyInstallOutcome(
+			"vscode-css-languageserver",
+			deps(() => ({
+				outcome: "failed",
+				reason: "npm error ENOTFOUND registry.npmjs.org",
+			})),
+		);
+		expect(result.networkUnreachable).toBe(true);
+	});
+
+	it("carries the classifier tag into the registry report", async () => {
+		const report = await runInstallRegistrySmoke({
+			deps: {
+				TOOLS: [{ id: "vscode-css-languageserver", installStrategy: "npm" }],
+				ensureTool: async () => undefined,
+				getInstallAttempt: () => ({
+					outcome: "failed",
+					reason: "npm error ENOTFOUND registry.npmjs.org",
+				}),
+				pipCommandCandidates: () => [],
+			},
+		});
+		expect(report.results[0].networkUnreachable).toBe(true);
 	});
 });
 


### PR DESCRIPTION
Operating rule: The release-QA baseline runs the smoke installer over every npm/pip registry entry; genuine install failures block shipping, and network-unreachable results stay inconclusive.

Kept: Existing fixture, LSP, formatter, and autofix smoke modes keep their current `--install` behavior; the registry sweep uses the explicit `--install-registry` mode alongside that flag.

## Summary

- Add the `tool-smoke-install` baseline row and invoke the installed smoke script across the full npm/pip registry population.
- Reuse `classifyInstallOutcome` and carry its network-unreachable tag into the JSON boundary.
- Map genuine failures to DO-NOT-SHIP exit 1 and network-unreachable lanes to INCONCLUSIVE exit 3.

## Tests

- `tests/scripts/release-qa.test.ts`: added the baseline tie assertion and real child-process stub tests for exit 1 and exit 3 mapping.
- `tests/scripts/smoke-tools-genuine-install-failure.test.ts`: added classifier-tag propagation coverage and retained the existing install outcome matrix.
- Red-first tie: removing the documentation row produced `expected ... to deeply equal ...` and `row tool-smoke-install is missing from the matrix`.
- Mutation: replacing `networkUnreachable: outcome.networkUnreachable` with `false` produced `expected false to be true`.
- Targeted result: 103 passed; the unrelated dirty-checkout test is blocked by the environment Git guard.

## Blast radius

The changed call tree is:

```text
release-qa main
  ROW_PROBES[tool-smoke-install]
    + runToolSmokeInstallProbe
      child node scripts/smoke-tools.mjs --install --install-registry
        runInstallRegistrySmoke
          ensureFixtureTools
          classifyInstallOutcome
```

The release-QA row map, smoke CLI, installer registry, and their TypeScript declaration sidecars are affected. Existing fixture callers retain their behavior.

## Class sweep

The install-outcome sweep covers npm, pip, gem, GitHub, Maven, and archive strategies through the existing classifier. Only npm and pip entries enter the new registry lane. The classifier remains the single decision seam.

## Observability

The JSON witness records the bounded tool id, state, detail, and network-unreachable tag. Release-QA records the row id and bounded failure or inconclusive reason in its report.

## Test assessment

The new process tests mock only the installed smoke executable boundary. They use the real release-QA probe, parser, row classifier, and verdict code. The smoke classifier propagation test uses the real in-process smoke seam and does not replace the installer registry.

## Verification

```text
| gate                      | mirrored CI job                | pass/fail | first red line |
| ------------------------- | ------------------------------ | --------- | -------------- |
| build                     | Lint & type-check              | pass      |                |
| lint                      | Lint & type-check              | pass      |                |
| fmt:check                 | oxfmt format check (advisory)  | pass      |                |
| changelog:check           | Unit tests                     | pass      |                |
| check-changelog-fragments | Changelog fragment (fast-fail) | pass      |                |
| check:lockfile            | Lint & type-check              | pass      |                |
| tests/config              | Unit tests                     | pass      |                |
| generation-guard          | Unit tests                     | pass      |                |
| flake-shape-ratchet       | Unit tests                     | pass      |                |
| lsp-spawn-heavy-coverage  | Unit tests                     | pass      |                |
| ci-verdict                | Unit tests                     | pass      |                |
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
