### PR TITLE
docs(skills): aggregate-host call forms for lens_diagnostics and the situational tools (refs #2967)

### DIFF
--- a/clients/runtime-session.ts
+++ b/clients/runtime-session.ts
@@ -1883,7 +1883,7 @@ function scheduleDeferredToolProbesWithClients(
 export const SESSION_START_GUIDANCE: string[] = [
 	"📌 pi-lens active — automated checks run on every edit/write; blocking errors (including pre-existing) show inline and must be fixed.\n" +
 		"Key tools (see each tool's own description for args):\n" +
-		"• lens_diagnostics — source=session reads cache; empty cache ≠ clean; use source=lsp scope=paths for changed files with absent or stale findings.\n" +
+		"• lens_diagnostics — source=session reads cache; empty cache ≠ clean; use source=lsp scope=paths for changed files with absent or stale findings (aggregate hosts: lens(action=diagnostics)).\n" +
 		"• symbol_search → module_report → read_symbol/read_enclosing — ranked identifier search, then navigable outline/callback handles + exact body reads; cheaper than reading a whole file before editing.\n" +
 		"• Situational (activate via pi_lens_activate_tools): lsp_navigation, ast_grep_search, ast_grep_replace. Use ast_grep_search with dump=true to inspect AST nodes.",
 ];

--- a/skills/pi-lens-ast-grep/SKILL.md
+++ b/skills/pi-lens-ast-grep/SKILL.md
@@ -9,6 +9,21 @@ Use `ast_grep_search` and `ast_grep_replace` for semantic code search/replace. a
 
 These tools (plus `ast_grep_outline`, `lsp_navigation`) are registered but inactive by default on hosts that support pi's dynamic tooling. If a call to one of them isn't recognized, activate it first: `pi_lens_activate_tools tools=["ast_grep_search", "ast_grep_replace"]`.
 
+On hosts that aggregate pi-lens behind a single `lens` tool, the `ast_grep_*` tools and `pi_lens_activate_tools` may not be registered at all. There, fall back to the `ast-grep` CLI (alias `sg`) — patterns, metavariables, and YAML rules are identical:
+
+```bash
+# search (≈ ast_grep_search)
+ast-grep run -p 'fetchMetrics($$$ARGS)' -l ts src/
+
+# rewrite (≈ ast_grep_replace; -U applies all)
+ast-grep run -p 'var $X' -r 'let $X' -l js src/ -U
+
+# full YAML rule (≈ the rule: parameter)
+ast-grep scan --rule my-rule.yml src/
+```
+
+Structural-intent parameters map to YAML constraints: `insideKind` → `inside: { kind: ..., stopBy: end }`, `hasKind`/`hasDescendantKind` → `has: { kind: ... }`, `follows` → `follows: { pattern: ... }`, `precedes` → `precedes: { pattern: ... }`.
+
 ## When to Use
 
 - Function calls, imports, class methods (structured code)

--- a/skills/pi-lens-lsp-navigation/SKILL.md
+++ b/skills/pi-lens-lsp-navigation/SKILL.md
@@ -7,6 +7,13 @@ description: Navigate code with IDE features and run proactive LSP diagnostics o
 
 Use `lsp_navigation` as **PRIMARY** for code intelligence. Use `lens_diagnostics` with `source=lsp` as **PRIMARY** for proactive type/error checks. Do NOT use grep/glob/ast-grep first for code intelligence.
 
+## Aggregate-tool hosts
+
+Some hosts expose pi-lens through a single aggregate tool — `lens(action=...)` — instead of registering the standalone names below. On those hosts:
+
+- Proactive checks: `lens({ action: "lsp_diagnostics", ... })` — same parameters as the table below; the cached-report entry point maps to `lens({ action: "diagnostics", ... })`.
+- If `lsp_navigation` is not among the aggregate's actions, do not call the standalone name: use the host's structural search funnel (`symbol_search` → `module_report` → `read_symbol`) or the `ast-grep` CLI for navigation instead.
+
 ## Diagnostics
 
 Use `lens_diagnostics` with `source=lsp` before builds/tests or after touching several files:

--- a/tests/clients/runtime-turn-session.test.ts
+++ b/tests/clients/runtime-turn-session.test.ts
@@ -1337,6 +1337,9 @@ describe("context injection framing", () => {
 			expect(text).toContain(tool);
 		}
 
+		// Aggregate hosts reach the same entry point as lens(action=diagnostics).
+		expect(text).toMatch(/aggregate hosts: lens\(action=diagnostics\)/);
+
 		// Stay lean: the orientation is a nudge, not re-documentation of every arg.
 		expect(text.length).toBeLessThan(750);
 	});


### PR DESCRIPTION
Refs #2967.

## Summary

Some agent harnesses consolidate many single-purpose tools into one aggregate tool with an `action` parameter — `lens(action="lsp_diagnostics", …)` instead of standalone `lsp_diagnostics`, `lens_diagnostics` and the rest — because per-turn tool-schema overhead grows linearly with the number of registered tools, since every request re-sends every JSON schema. This matters most for CJK users: injected docs and schemas are frequently truncated by maxChars-style limits, so both the schema budget and the doc budget are tight.

On such hosts pi-lens's skill docs and its session-start orientation are actively misleading. They tell the model to call the standalone tool names, the model complies, and the call fails because the name is not registered. The failure mode is quiet drift — the model falls back to grep — rather than a loud error, which makes it hard to notice.

This PR keeps the standalone names as the default copy and adds the aggregate call form where the model meets it. The host that motivated it is the DeepSeek Harness, whose adapter aggregates in-process on the host-adapter side; the aggregate's schema and the fact that the situational tools are not registered on that surface are recorded on #2967.

## Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)

## Area

- [x] area:session

## Changes

**`clients/runtime-session.ts` (`SESSION_START_GUIDANCE`)** — the standalone `lens_diagnostics` bullet is unchanged as the default wording. The aggregate form is a conditional note inside the same bullet: `(aggregate hosts: lens(action=diagnostics))`. A standalone host therefore still advertises only names it registers. The discovery-funnel and situational bullets are untouched.

**`skills/pi-lens-lsp-navigation/SKILL.md`** — a new "Aggregate-tool hosts" section: proactive checks as `lens({ action: "lsp_diagnostics", … })` with the same parameters, the cached entry point as `lens({ action: "diagnostics", … })`, and the instruction not to call the standalone `lsp_navigation` name when it is not among the aggregate's actions — use the host's structural search funnel or the `ast-grep` CLI instead.

**`skills/pi-lens-ast-grep/SKILL.md`** — after the existing dynamic-tooling activation note: on aggregate hosts the `ast_grep_*` tools and `pi_lens_activate_tools` may not be registered at all, so fall back to the `ast-grep` CLI, with the structural-intent parameters mapped to their YAML-rule equivalents.

**`tests/clients/runtime-turn-session.test.ts`** — one added assertion that the note reaches the rendered guidance, driven through the real session-start path rather than the string alone. Every existing assertion is kept, including the lean-length bound.

## Tests

| File or case | Coverage |
| --- | --- |
| `tests/clients/runtime-turn-session.test.ts` | The rendered session-start guidance contains the aggregate note, and the existing advertised-tools loop and lean bound still hold. |

Contributor's local run: `vitest run tests/clients/runtime-turn-session.test.ts` green; `tsc --project tsconfig.json` clean; `oxfmt --check` clean on the edited files; `markdownlint-cli2` reports zero issues on both skill documents. A full local `npm test` on macOS showed 45 failures that reproduce identically on pristine upstream HEAD on that machine (ast-grep binary probing, installer and LSP environment-dependent suites) and touch none of the files changed here. CI on this head is the authority and is green.

### Test assessment

The added assertion pins the one behaviour this PR introduces: that the note is present in the guidance the host actually renders. It asserts through the real session-start path, not against the literal string, so a refactor that changes how the guidance is assembled still exercises it. No redundant test was removed.

## Blast radius

`SESSION_START_GUIDANCE` is a single exported constant consumed by the session-start orientation. The change is additive text inside an existing bullet, so every host continues to see the standalone names it registers, and aggregate hosts gain a parenthetical. The lean-length bound is the guard that keeps the orientation from growing into re-documentation, and it still passes.

The two skill documents are agent-facing prose with no runtime consumer.

## Class sweep

The shape is "agent-facing text that names a tool the host may not register". `#2535` is the same class on the MCP path, where an advisory names `lens_diagnostics` while the tool is registered as `pilens_diagnostics`, and it is being fixed with an adapter-aware resolver plus a guard that bans hard-coded tool names in agent-facing strings. The durable fix for both is #2967: render the orientation and the skill call forms from the surface the host actually registers. This PR is the conservative interim that does not require that boundary to exist yet.

## Observability

No new failure path; no record added.

---

## 中文附注（动机说明）

部分 agent 宿主会把多个单用途工具聚合为一个带 `action` 参数的聚合工具（如 `lens(action="lsp_diagnostics")`），原因是每轮请求都要重发全部工具的 JSON schema，工具数量越多每轮开销越大；对中文用户影响更明显——注入文档与 schema 常受 maxChars 类截断限制，预算更紧。聚合形态下，pi-lens 的技能文档与会话启动指引仍指引调用独立工具名，模型照做即调用未注册的名字而失败，且失败是静默回退（改用 grep）而非显式报错，不易察觉。本 PR 保留独立工具文档为主体，在模型触达处补充聚合调用形态与 CLI 备选。

---

*Maintainer note: the title and this body were updated by the maintainer to add the required issue reference and the template sections, and to describe the reworked diff — the earlier text still described the first revision, which changed the default wording for every host. The contribution itself is unchanged.*
