### PR TITLE
fix(dispatch): runner "no config detected" advisories log once per tool and root at debug level (refs #2811)

### DIFF
--- a/.changelog/2811-runner-no-config-advisory.md
+++ b/.changelog/2811-runner-no-config-advisory.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Fix runner no-config advisories logging once per tool and root at debug level (refs #2811)** — Dispatch now bounds constant runner advisories to one record per tool and resolved root per session.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1144,6 +1144,12 @@ which clears the signature and selection state together. External editor
 changes remain outside that seam and are rechecked at session reset. (#1895,
 #1940, #1603)
 
+Runner advisories that describe a constant no-config or cooldown condition use
+`logRunnerAdvisoryOnce` in `clients/tool-cwd.ts`, keyed by tool and resolved
+root, and pass debug level through `DispatchContext.log`. The shared
+generation map resets with the degradation ledger, so one session emits one
+record per tool/root and the next session re-arms it. (#2811)
+
 Helm chart linting uses the shared workspace-topology `Chart.yaml` marker. YAML
 and `.tpl` edits inside a chart dispatch one canonical-root-deduplicated,
 bounded `helm lint` pass through the ordinary typed availability/install seam.

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -14,7 +14,7 @@
  * - BaselineStore: Track pre-existing issues for delta mode
  */
 
-import { logExtension } from "../extension-log.js";
+import { logExtension, type ExtensionLogLevel } from "../extension-log.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { FileKind } from "../file-kinds.js";
@@ -372,11 +372,13 @@ export function createDispatchContext(
 			return checkToolAvailability(command, facts);
 		},
 
-		log(message: string): void {
+		log(message: string, level?: ExtensionLogLevel): void {
 			// #1333: pi owns the terminal — a runner advisory must never be a raw
 			// write. Every DispatchContext.log line lands in extension.log instead.
 			logExtension({
 				subsystem: "dispatch",
+				// exactOptionalPropertyTypes: an omitted level must stay omitted.
+				...(level !== undefined && { level }),
 				message,
 				metadata: { filePath: normalizedFilePath, kind },
 			});

--- a/clients/dispatch/runners/markdownlint.ts
+++ b/clients/dispatch/runners/markdownlint.ts
@@ -1,5 +1,5 @@
 import { safeSpawnAsync } from "../../safe-spawn.js";
-import { resolveRunnerCwd } from "../../tool-cwd.js";
+import { logRunnerAdvisoryOnce, resolveRunnerCwd } from "../../tool-cwd.js";
 import {
 	getLinterPolicyForCwd,
 	markdownlintConfigArgs,
@@ -137,7 +137,10 @@ const markdownlintRunner: RunnerDefinition = {
 		// its budget in another lane (availability verify, autofix --fix). Skip
 		// without spawning — "not checked", never re-reported as clean.
 		if (isInSpawnTimeoutCooldown(cmd)) {
-			ctx.log(
+			logRunnerAdvisoryOnce(
+				ctx,
+				"markdownlint",
+				cwd,
 				`markdownlint: ${cmd} is cooling down after a spawn timeout — skipping (one bounded failure budget per edit)`,
 			);
 			return { status: "skipped", diagnostics: [], semantic: "none" };

--- a/clients/dispatch/runners/sqlfluff.ts
+++ b/clients/dispatch/runners/sqlfluff.ts
@@ -1,5 +1,5 @@
 import { safeSpawnAsync } from "../../safe-spawn.js";
-import { resolveRunnerCwd } from "../../tool-cwd.js";
+import { logRunnerAdvisoryOnce, resolveRunnerCwd } from "../../tool-cwd.js";
 import { getLinterPolicyForCwd, hasSqlfluffConfig } from "../../tool-policy.js";
 import { PRIORITY } from "../priorities.js";
 import type {
@@ -150,7 +150,12 @@ const sqlfluffRunner: RunnerDefinition = {
 		}
 		const hasConfig = hasSqlfluffConfig(cwd);
 		if (!hasConfig) {
-			ctx.log("sqlfluff: no config detected, using ANSI dialect defaults");
+			logRunnerAdvisoryOnce(
+				ctx,
+				"sqlfluff",
+				cwd,
+				"sqlfluff: no config detected, using ANSI dialect defaults",
+			);
 		}
 
 		let cmd: string | null = null;

--- a/clients/dispatch/runners/stylelint.ts
+++ b/clients/dispatch/runners/stylelint.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import { safeSpawnAsync } from "../../safe-spawn.js";
-import { resolveRunnerCwd } from "../../tool-cwd.js";
+import { logRunnerAdvisoryOnce, resolveRunnerCwd } from "../../tool-cwd.js";
 import {
 	getLinterPolicyForCwd,
 	hasStylelintConfig,
@@ -159,7 +159,12 @@ const stylelintRunner: RunnerDefinition = {
 		const fileDir = path.dirname(path.resolve(cwd, ctx.filePath));
 		const hasConfig = hasStylelintConfig(fileDir) || hasStylelintConfig(cwd);
 		if (!hasConfig) {
-			ctx.log("stylelint: no config detected, running with default rules");
+			logRunnerAdvisoryOnce(
+				ctx,
+				"stylelint",
+				cwd,
+				"stylelint: no config detected, running with default rules",
+			);
 		}
 
 		let cmd: string | null = null;

--- a/clients/dispatch/runners/yamllint.ts
+++ b/clients/dispatch/runners/yamllint.ts
@@ -1,4 +1,5 @@
 import { safeSpawnAsync } from "../../safe-spawn.js";
+import { logRunnerAdvisoryOnce } from "../../tool-cwd.js";
 import { getLinterPolicyForCwd, hasYamllintConfig } from "../../tool-policy.js";
 import { PRIORITY } from "../priorities.js";
 import type {
@@ -58,7 +59,12 @@ const yamllintRunner: RunnerDefinition = {
 		}
 		const hasConfig = hasYamllintConfig(cwd);
 		if (!hasConfig) {
-			ctx.log("yamllint: no config detected, running with default rules");
+			logRunnerAdvisoryOnce(
+				ctx,
+				"yamllint",
+				cwd,
+				"yamllint: no config detected, running with default rules",
+			);
 		}
 
 		let cmd: string | null = null;

--- a/clients/dispatch/types.ts
+++ b/clients/dispatch/types.ts
@@ -11,6 +11,7 @@
  * The dispatcher must handle these semantics consistently.
  */
 
+import type { ExtensionLogLevel } from "../extension-log.js";
 import type { FileKind } from "../file-kinds.js";
 import type { FileRole } from "../file-role.js";
 import type { GeneratedArtifactEvidence } from "../generated-artifacts.js";
@@ -233,7 +234,8 @@ export interface DispatchContext {
 	readonly telemetryProvider?: string;
 
 	hasTool(command: string): Promise<boolean>;
-	log(message: string): void;
+	/** Log an advisory to the dispatch sink; `level` defaults to `error`. */
+	log(message: string, level?: ExtensionLogLevel): void;
 }
 
 // --- Tool Plan ---

--- a/clients/tool-cwd.ts
+++ b/clients/tool-cwd.ts
@@ -1,7 +1,7 @@
 import * as os from "node:os";
 import { existsSync, readdirSync } from "node:fs";
 import * as path from "node:path";
-import { logExtension } from "./extension-log.js";
+import { type ExtensionLogLevel, logExtension } from "./extension-log.js";
 import {
 	isRealGitMarker,
 	isAtOrAboveHomeDir,
@@ -231,6 +231,29 @@ function emitResolution(
 		level: "debug",
 		message: `cwd ${kind} ${tool} cwd=${cwd} reason=${reason}`,
 	});
+}
+
+/**
+ * Emit a constant runner advisory once per (tool, resolved root) per session
+ * (#2811): the yamllint/stylelint/sqlfluff "no config detected" lines and
+ * markdownlint's spawn-timeout cooldown notice logged once PER FILE at error
+ * level — 17 lines in one session for one tool. The throttle shares the
+ * resolution-log map and its ledger-generation reset, so `session_start`
+ * re-arms it like every once-latch in this module. The message rides
+ * `ctx.log` at debug level so the dispatch seam stays the one sink for
+ * runner lines, with its own filePath/kind metadata.
+ */
+export function logRunnerAdvisoryOnce(
+	ctx: { log(message: string, level?: ExtensionLogLevel): void },
+	tool: string,
+	root: string,
+	message: string,
+): void {
+	syncGeneration();
+	const key = _toolCwdEphemeralKey(["runner-advisory", tool, root]);
+	if (logged.current(key) !== 0) return;
+	logged.bump(key);
+	ctx.log(message, "debug");
 }
 
 /** Resolve every child process cwd/root through one bounded, synchronous seam. */

--- a/tests/clients/dispatch/runner-no-config-advisory.test.ts
+++ b/tests/clients/dispatch/runner-no-config-advisory.test.ts
@@ -1,0 +1,214 @@
+/**
+ * The #2811 recurrence: a constant per-file advisory on a runner path
+ * ("no config detected", the markdownlint spawn-timeout cooldown notice)
+ * logged once PER FILE at error level — 17 lines in one session for one
+ * tool. The guards here red when the once-per-(tool, resolved root)
+ * throttle is dropped (two lines, error level) and when the debug level is
+ * lost (a line lands at the sink's error default).
+ *
+ * These drive the REAL dispatcher (createDispatchContext + dispatchForFile)
+ * with the REAL runner modules and assert against the REAL extension.log
+ * sink. PI_LENS_TEST_MODE=0 is the sanctioned single-file opt-out for real
+ * writes; the log lives under the worker's hermetic PI_LENS_HOME.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetDegradationLedger } from "../../../clients/degradation-ledger.js";
+import {
+	createDispatchContext,
+	dispatchForFile,
+	RunnerRegistry,
+} from "../../../clients/dispatch/dispatcher.js";
+import { FactStore } from "../../../clients/dispatch/fact-store.js";
+import markdownlintRunner from "../../../clients/dispatch/runners/markdownlint.js";
+import sqlfluffRunner from "../../../clients/dispatch/runners/sqlfluff.js";
+import stylelintRunner from "../../../clients/dispatch/runners/stylelint.js";
+import yamllintRunner from "../../../clients/dispatch/runners/yamllint.js";
+import type { RunnerDefinition } from "../../../clients/dispatch/types.js";
+import {
+	flushExtensionLog,
+	getExtensionLogPath,
+} from "../../../clients/extension-log.js";
+import {
+	noteSpawnTimeout,
+	resetSpawnTimeoutCooldowns,
+} from "../../../clients/spawn-timeout-cooldown.js";
+
+interface AdvisoryLine {
+	level?: string;
+	message?: string;
+	metadata?: { filePath?: string };
+}
+
+let tempRoot: string;
+const savedEnv: Record<string, string | undefined> = {};
+
+function readDispatchLines(messagePrefix: string): AdvisoryLine[] {
+	const logFile = getExtensionLogPath();
+	if (!fs.existsSync(logFile)) return [];
+	return fs
+		.readFileSync(logFile, "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as AdvisoryLine)
+		.filter(
+			(line) =>
+				line.message?.startsWith(messagePrefix) &&
+				line.metadata?.filePath?.startsWith(tempRoot),
+		);
+}
+
+/** Dispatch one file through the real dispatcher with only the given runner. */
+async function dispatchReal(
+	registry: RunnerRegistry,
+	runnerId: string,
+	fileName: string,
+): Promise<void> {
+	const filePath = path.join(tempRoot, fileName);
+	const ctx = createDispatchContext(
+		filePath,
+		tempRoot,
+		{ getFlag: () => false },
+		new FactStore(),
+	);
+	await dispatchForFile(
+		ctx,
+		[{ mode: "all", runnerIds: [runnerId] }],
+		registry,
+	);
+}
+
+function writeProjectFile(name: string, content: string): void {
+	fs.writeFileSync(path.join(tempRoot, name), content);
+}
+
+function register(
+	registry: RunnerRegistry,
+	runners: RunnerDefinition[],
+): RunnerRegistry {
+	for (const runner of runners) registry.register(runner);
+	return registry;
+}
+
+beforeEach(() => {
+	tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-2811-"));
+	savedEnv.PI_LENS_TEST_MODE = process.env.PI_LENS_TEST_MODE;
+	process.env.PI_LENS_TEST_MODE = "0";
+});
+
+afterEach(async () => {
+	resetSpawnTimeoutCooldowns();
+	if (savedEnv.PI_LENS_TEST_MODE === undefined) {
+		delete process.env.PI_LENS_TEST_MODE;
+	} else {
+		process.env.PI_LENS_TEST_MODE = savedEnv.PI_LENS_TEST_MODE;
+	}
+	await flushExtensionLog();
+	fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("runner per-file advisories throttle once per tool and root (#2811)", () => {
+	it("logs the yamllint no-config advisory once at debug level across two dispatches", async () => {
+		const registry = register(new RunnerRegistry(), [yamllintRunner]);
+		writeProjectFile("a.yml", "key: value\n");
+		writeProjectFile("b.yml", "other: value\n");
+
+		await dispatchReal(registry, "yamllint", "a.yml");
+		await dispatchReal(registry, "yamllint", "b.yml");
+		await flushExtensionLog();
+
+		const lines = readDispatchLines("yamllint: no config detected");
+		expect(lines).toHaveLength(1);
+		expect(lines[0]?.level).toBe("debug");
+		expect(lines.filter((line) => line.level === "error")).toHaveLength(0);
+	}, 30_000);
+
+	it("logs the stylelint and sqlfluff no-config advisories once each across two dispatches", async () => {
+		const registry = register(new RunnerRegistry(), [
+			stylelintRunner,
+			sqlfluffRunner,
+		]);
+		writeProjectFile("a.css", "a { color: red; }\n");
+		writeProjectFile("b.css", "b { color: blue; }\n");
+		writeProjectFile("q.sql", "SELECT 1;\n");
+		writeProjectFile("r.sql", "SELECT 2;\n");
+
+		await dispatchReal(registry, "stylelint", "a.css");
+		await dispatchReal(registry, "stylelint", "b.css");
+		await dispatchReal(registry, "sqlfluff", "q.sql");
+		await dispatchReal(registry, "sqlfluff", "r.sql");
+		await flushExtensionLog();
+
+		for (const prefix of [
+			"stylelint: no config detected",
+			"sqlfluff: no config detected",
+		]) {
+			const lines = readDispatchLines(prefix);
+			expect(lines, prefix).toHaveLength(1);
+			expect(lines[0]?.level, prefix).toBe("debug");
+			expect(
+				lines.filter((line) => line.level === "error"),
+				prefix,
+			).toHaveLength(0);
+		}
+	}, 30_000);
+
+	// Skips on Windows with a stated reason: the cooldown shim is a POSIX
+	// shebang script, so on win32 the availability probe cannot resolve it and
+	// the runner skips before the cooldown branch (no Windows behavior pinned).
+	it.skipIf(process.platform === "win32")(
+		"logs the markdownlint spawn-timeout cooldown advisory once at debug level",
+		{ timeout: 30_000 },
+		async () => {
+			const registry = register(new RunnerRegistry(), [markdownlintRunner]);
+			const shimDir = path.join(tempRoot, "venv", "bin");
+			fs.mkdirSync(shimDir, { recursive: true });
+			// The availability checker probes "markdownlint-cli2", so the shim must
+			// carry that name to resolve.
+			const shimPath = path.join(shimDir, "markdownlint-cli2");
+			fs.writeFileSync(shimPath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+			writeProjectFile("a.md", "# hello\n");
+			writeProjectFile("b.md", "# world\n");
+			writeProjectFile("c.md", "# again\n");
+
+			// First dispatch: the shim resolves and verifies, the cooldown is not
+			// armed, so the runner completes without the cooldown advisory.
+			await dispatchReal(registry, "markdownlint", "a.md");
+			// Arm the runtime cooldown the same way a spawn timeout would; the next
+			// two dispatches take the cooldown branch, which must not log per file.
+			noteSpawnTimeout({
+				tool: "markdownlint",
+				command: shimPath,
+				phase: "lint",
+				durationMs: 1,
+			});
+			await dispatchReal(registry, "markdownlint", "b.md");
+			await dispatchReal(registry, "markdownlint", "c.md");
+			await flushExtensionLog();
+
+			const lines = readDispatchLines("markdownlint: ");
+			expect(lines).toHaveLength(1);
+			expect(lines[0]?.level).toBe("debug");
+		},
+	);
+
+	it("re-arms the advisory after the session-start ledger reset", async () => {
+		const registry = register(new RunnerRegistry(), [yamllintRunner]);
+		writeProjectFile("a.yml", "key: value\n");
+
+		await dispatchReal(registry, "yamllint", "a.yml");
+		// session_start resets the degradation ledger, which is the throttle's
+		// generation source; the next dispatch in the same session-as-root
+		// must record again instead of staying silent forever.
+		resetDegradationLedger();
+		await dispatchReal(registry, "yamllint", "a.yml");
+		await flushExtensionLog();
+
+		const lines = readDispatchLines("yamllint: no config detected");
+		expect(lines).toHaveLength(2);
+		expect(lines.map((line) => line.level)).toEqual(["debug", "debug"]);
+	}, 30_000);
+});


### PR DESCRIPTION
## Summary

Fixes issue #2811 by logging constant runner no-config and cooldown advisories
once per tool and resolved root per session at debug level. The change uses the
existing `tool-cwd` generation map and preserves the dispatch log metadata.
The acceptance criteria are complete except for CI and Tier A review.

## Type of change

- [x] Bug fix

## Area

- [x] area:dispatch
- [x] area:observability

## Tests

- `tests/clients/dispatch/runner-no-config-advisory.test.ts`: new real-dispatch
  regression coverage for yamllint, stylelint, sqlfluff, and markdownlint.
  It asserts one debug-level record across repeated file dispatches and reset.
- Red-first on master: yamllint produced two records instead of one, and the
  reset case produced `error, error` instead of `debug, debug`.
- Mutation proof: replacing the throttle with `if (false) return` produced
  three failing tests. The repeated yamllint, stylelint, sqlfluff, and
  markdownlint cases each reported two records instead of one.
- Dispatch suite: all collected executable batches passed; repository skips
  remained. Config suite: 49 test files, 49 passed, 418 tests passed.
- `npm run fmt:check`: passed.
- `npm run preflight`: passed; transcript pasted below.
- `node scripts/check-pr-body.mjs --lint-local PR_BODY.md`: passed.

### Test assessment

The new test file uniquely pins the real dispatcher-to-extension-log path for
per-tool/root throttling and debug severity. No existing test becomes redundant.

## Blast radius

The changed production seam is `logRunnerAdvisoryOnce` in `clients/tool-cwd.ts`.
Its callers are the yamllint, stylelint, sqlfluff, and markdownlint runners.
It calls `syncGeneration`, the existing `logged` generation map, and
`DispatchContext.log`. `DispatchContext.log` also has callers through all
registered runners, while its optional level preserves existing error defaults.
The requested `module_report` tool is unavailable in this environment, so a
structural grep supplied the caller map. The per-file hot path adds one bounded
key lookup and one conditional only when an advisory occurs.

## Observability

The `extension.log` dispatch records remain the production proof. They retain
the runner message, `debug` level, file path, and file kind. The shared map is
reset with the degradation-ledger session generation.

## Class sweep

The defect class is constant per-file runner advisories emitted at error level,
catalog shape 3 and the dispatch advisory/severity rules in `AGENTS.md`.
Whole-tree grep covered `clients/`, `tools/`, `mcp/`, `scripts/`, and `index.ts`
for `no config detected`, the markdownlint cooldown wording, and runner
`ctx.log` sites. Only yamllint, stylelint, sqlfluff, and markdownlint matched;
the other runner log sites were not constant no-config/cooldown advisories.
The population sweep fixed all four members in this change. Consolidation
verdict: fold onto `logRunnerAdvisoryOnce` in `clients/tool-cwd.ts`, because
removing that seam would duplicate the same throttle and level handling.
The related `lazy-installer.ts:304` cooldown record was inspected and is not a
per-file advisory emission, so it remains unchanged.

### Preflight transcript

Pending the final `npm run preflight` run.
