### PR TITLE
feat(observability): tool-result bytes and truncated flag on the usage footer and the per-turn row (refs #2800)

### DIFF
--- a/.changelog/feat-2800-item7-tool-result-bytes.md
+++ b/.changelog/feat-2800-item7-tool-result-bytes.md
@@ -1,0 +1,4 @@
+---
+section: Added
+---
+- **Per-call tool-result observability**: the `usage tokens=<n> elapsed-ms=<n>` contract footer gains `bytes=<delivered payload bytes> truncated=<true|false>` on both host surfaces, the payload byte bound runs before the footer is stamped with the footer's own maximum size reserved so the delivered text (footer included) never exceeds 40 KiB, and the per-turn `cache_usage` latency row aggregates `toolResultBytes` and `toolResultsTruncated` over the turn's tool calls (refs #2800)

--- a/.changelog/feat-2800-item7-tool-result-bytes.md
+++ b/.changelog/feat-2800-item7-tool-result-bytes.md
@@ -1,4 +1,4 @@
 ---
 section: Added
 ---
-- **Per-call tool-result observability**: the `usage tokens=<n> elapsed-ms=<n>` contract footer gains `bytes=<delivered payload bytes> truncated=<true|false>` on both host surfaces, the payload byte bound runs before the footer is stamped with the footer's own maximum size reserved so the delivered text (footer included) never exceeds 40 KiB, and the per-turn `cache_usage` latency row aggregates `toolResultBytes` and `toolResultsTruncated` over the turn's tool calls (refs #2800)
+- **Per-call tool-result observability**: the `usage tokens=<n> elapsed-ms=<n>` contract footer gains `bytes=<delivered payload bytes> truncated=<true|false>` on both host surfaces, the payload byte bound runs before the footer is stamped with the footer's own maximum size reserved so the delivered text (footer included) never exceeds 40 KiB for the single-text-block results production emits (the bound is per text block, inherited from #2852), and the per-turn `cache_usage` latency row aggregates `toolResultBytes` and `toolResultsTruncated` over the turn's tool calls (refs #2800)

--- a/clients/cache-observability.ts
+++ b/clients/cache-observability.ts
@@ -263,6 +263,10 @@ interface SessionAttributionState {
 	readonly findingIdentities: Set<string>;
 	findingIdentityCapRecorded: boolean;
 	turnEndAdvisoryBytes: number;
+	/** Delivered tool-result bytes summed over the turn (#2800 item 7). */
+	toolResultBytes: number;
+	/** Delivered tool results whose bound fired, counted over the turn. */
+	toolResultsTruncated: number;
 	/** Transcript length at the previous `context` observation. */
 	lastObservedMessageCount?: number;
 	/** Full-identity SHA-256 evidence from the previous usage record. */
@@ -330,6 +334,8 @@ function newAttributionState(): SessionAttributionState {
 		findingIdentities: new Set(),
 		findingIdentityCapRecorded: false,
 		turnEndAdvisoryBytes: 0,
+		toolResultBytes: 0,
+		toolResultsTruncated: 0,
 		summary: newCacheUsageSummary(),
 	};
 }
@@ -1324,6 +1330,8 @@ export function logCacheUsage(
 				state.turnEndAdvisoryBytes + state.injectedBytes.turnEndAdvisory,
 		};
 		const injectedFindingsRepeated = state.injectedFindingsRepeated;
+		const toolResultBytes = state.toolResultBytes;
+		const toolResultsTruncated = state.toolResultsTruncated;
 		// This record is the turn boundary: reset the per-turn accumulators and
 		// re-arm the prefix-break flag so the next verdict describes the NEXT gap.
 		state.lastUsageAtMs = nowMs;
@@ -1344,6 +1352,8 @@ export function logCacheUsage(
 		state.injectedBytes = emptyInjectedBytes();
 		state.injectedFindingsRepeated = 0;
 		state.turnEndAdvisoryBytes = 0;
+		state.toolResultBytes = 0;
+		state.toolResultsTruncated = 0;
 		// Clear the request stamp too: the next turn measures from ITS request, and
 		// a turn whose `context` call pi-lens never saw must fall back rather than
 		// reuse this one.
@@ -1387,6 +1397,11 @@ export function logCacheUsage(
 				attributionCharsCapped,
 				injectedBytes,
 				injectedFindingsRepeated,
+				// Delivered tool-result aggregation over the turn (#2800 item 7):
+				// the sum of each delivered footer's bytes= figure and the count
+				// of results whose bound fired.
+				toolResultBytes,
+				toolResultsTruncated,
 				...(context
 					? {
 							// MessageEndEvent has no request/context id in the host API. These
@@ -1602,6 +1617,34 @@ export function recordTurnEndAdvisoryBytes(
 		MAX_INJECTED_BYTES,
 		state.turnEndAdvisoryBytes + Math.max(0, bytes),
 	);
+}
+
+/**
+ * Fold one delivered tool result into the per-turn aggregation the
+ * `cache_usage` row reports as `toolResultBytes` / `toolResultsTruncated`
+ * (#2800 item 7). `bytes` is the delivered payload's UTF-8 byte count as
+ * stamped in the result's own footer, and `truncated` is the footer's
+ * truncated flag. Called from each host adapter's delivery seam; the row is
+ * emitted by `logCacheUsage`, which resets both figures at the turn boundary.
+ * The byte sum saturates at the attribution bound so the row stays bounded.
+ */
+export function recordToolResultDelivery(args: {
+	sessionId?: string;
+	sessionRole?: "primary" | "concurrent-secondary";
+	bytes: number;
+	truncated: boolean;
+}): void {
+	const state = attributionFor(
+		attributionKey(args.sessionId, args.sessionRole),
+	);
+	const bytes = Number.isFinite(args.bytes)
+		? Math.max(0, Math.floor(args.bytes))
+		: 0;
+	state.toolResultBytes = Math.min(
+		MAX_ATTRIBUTION_BYTES,
+		state.toolResultBytes + bytes,
+	);
+	if (args.truncated === true) state.toolResultsTruncated += 1;
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -111,10 +111,7 @@ import {
 } from "./clients/tool-config.js";
 import { recordDegradationOnce } from "./clients/degradation-ledger.js";
 import { wrapToolsForCompactLine } from "./clients/tool-render.js";
-import {
-	finalizeToolResult,
-	renderToolResultContract,
-} from "./tools/render-compact.js";
+import { finalizeToolResultWithDelivery } from "./tools/render-compact.js";
 import { loadPiLensProjectConfig } from "./clients/project-lens-config.js";
 import { initLensEventsGetter } from "./clients/lens-events.js";
 import { wireBusEmitterGetter } from "./clients/bus-publish.js";
@@ -276,6 +273,7 @@ import {
 	logCacheUsage,
 	observeCacheContext,
 	observeCachePrefix,
+	recordToolResultDelivery,
 	resetCacheFindingIdentitiesSession,
 	recordTurnEndAdvisoryBytes,
 } from "./clients/cache-observability.js";
@@ -1826,11 +1824,31 @@ function activateExtension(hostPi: ExtensionAPI) {
 			const execute = normalized.execute;
 			if (typeof execute === "function") {
 				normalized.execute = (...args: unknown[]) =>
-					Promise.resolve(execute(...args)).then((result) =>
-						finalizeToolResult(
-							result as Parameters<typeof renderToolResultContract>[0],
-						),
-					);
+					Promise.resolve(execute(...args)).then((result) => {
+						const delivery = finalizeToolResultWithDelivery(
+							result as Parameters<typeof finalizeToolResultWithDelivery>[0],
+						);
+						// #2800 item 7: the per-turn cache_usage row sums each delivered
+						// tool result's bytes. The SDK hands the live ExtensionContext as
+						// the fifth execute argument, so attribution mirrors the
+						// message_end handler: stable session id plus this activation's
+						// owned role.
+						if (lensEnabled) {
+							try {
+								const ctx = args[4];
+								const sessionId = getStableSessionId(ctx);
+								recordToolResultDelivery({
+									sessionId,
+									sessionRole: classifyOwnedSessionEmission(ctx, sessionId),
+									bytes: delivery.deliveredBytes,
+									truncated: delivery.truncated,
+								});
+							} catch {
+								// Observability must never break tool delivery.
+							}
+						}
+						return delivery.result;
+					});
 			}
 			pi.registerTool(normalized as any);
 		} catch {

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -25,8 +25,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	finalizeToolResult,
-	renderToolResultContract,
-	boundToolResultText,
+	finalizeToolResultWithDelivery,
 	renderToolText as toolText,
 	stripResultDetails,
 } from "../tools/render-compact.js";
@@ -1925,11 +1924,13 @@ async function handleRequest(request: JsonRpcRequest): Promise<void> {
 			maybeAutoSessionStart();
 			try {
 				let result = await callTool(name, args);
-				result = renderToolResultContract(result);
 				// #535: pilens_analyze already self-routes (fresh-fork) when stale —
 				// see the forcedFresh branch inside callTool. Every other tool that
 				// depends on warm-only process state gets an honest-degrade warning
 				// instead, so the warm boundary never silently serves old code.
+				// The warning precedes the #2800 item 7 gate, so it is part of the
+				// payload the byte bound protects (kept in the retained tail) and
+				// its bytes land in the footer's delivered figure.
 				if (
 					WARN_ONLY_STALE_TOOLS.has(name) &&
 					!result.isError &&
@@ -1937,9 +1938,13 @@ async function handleRequest(request: JsonRpcRequest): Promise<void> {
 				) {
 					result = withStaleWarning(result);
 				}
+				// #2800 item 7: the payload bound runs first with the footer's own
+				// size reserved, then the footer is stamped with the delivered
+				// payload's byte count and the bound's truncated flag.
+				const delivery = finalizeToolResultWithDelivery(result);
 				// The gate consumed `details` for the footer's diag lines above;
 				// strip it so the wire carries only the bounded text (#2852 N1).
-				sendResult(id ?? null, boundToolResultText(stripResultDetails(result)));
+				sendResult(id ?? null, stripResultDetails(delivery.result));
 			} catch (err) {
 				// Surface as a tool error (isError), not a transport error, so the
 				// agent sees the message instead of a dead request.

--- a/tests/clients/cache-observability.test.ts
+++ b/tests/clients/cache-observability.test.ts
@@ -14,6 +14,7 @@ import {
 	logCacheUsage,
 	observeCacheContext,
 	observeCachePrefix,
+	recordToolResultDelivery,
 	resetCacheFindingIdentitiesSession,
 	resetCachePrefixObservation,
 } from "../../clients/cache-observability.js";
@@ -95,6 +96,8 @@ describe("cache-observability — response-side usage (#1018)", () => {
 						other: 0,
 					},
 					injectedFindingsRepeated: 0,
+					toolResultBytes: 0,
+					toolResultsTruncated: 0,
 				},
 			},
 		]);
@@ -1686,5 +1689,65 @@ describe("cache-observability — per-source injection attribution (#1071)", () 
 			turnEndAdvisory: 0,
 			other: 0,
 		});
+	});
+});
+
+describe("cache-observability — tool-result delivery bytes (#2800 item 7)", () => {
+	beforeEach(() => {
+		latencyEntries.length = 0;
+		resetCachePrefixObservation();
+	});
+
+	const usageRows = () =>
+		latencyEntries.filter((entry) => entry.phase === "cache_usage");
+
+	it("sums two tool calls' delivered bytes onto the turn row", () => {
+		recordToolResultDelivery({
+			sessionId: "row",
+			bytes: 100,
+			truncated: false,
+		});
+		recordToolResultDelivery({
+			sessionId: "row",
+			bytes: 233,
+			truncated: false,
+		});
+		logCacheUsage(assistantMessage(), undefined, { sessionId: "row" });
+		expect(usageRows()[0]?.metadata).toMatchObject({
+			toolResultBytes: 333,
+			toolResultsTruncated: 0,
+		});
+	});
+
+	it("counts truncated results and resets both figures at the turn boundary", () => {
+		recordToolResultDelivery({ sessionId: "turn", bytes: 50, truncated: true });
+		recordToolResultDelivery({
+			sessionId: "turn",
+			bytes: 10,
+			truncated: false,
+		});
+		logCacheUsage(assistantMessage(), undefined, { sessionId: "turn" });
+		expect(usageRows()[0]?.metadata).toMatchObject({
+			toolResultBytes: 60,
+			toolResultsTruncated: 1,
+		});
+		logCacheUsage(assistantMessage(), undefined, { sessionId: "turn" });
+		expect(usageRows()[1]?.metadata).toMatchObject({
+			toolResultBytes: 0,
+			toolResultsTruncated: 0,
+		});
+	});
+
+	it("saturates the byte sum at the attribution bound and never goes negative", () => {
+		recordToolResultDelivery({
+			sessionId: "sat",
+			bytes: 5_000_000,
+			truncated: false,
+		});
+		recordToolResultDelivery({ sessionId: "sat", bytes: -12, truncated: true });
+		logCacheUsage(assistantMessage(), undefined, { sessionId: "sat" });
+		const metadata = usageRows()[0]?.metadata;
+		expect(metadata?.toolResultBytes).toBeLessThanOrEqual(1_048_576);
+		expect(metadata?.toolResultsTruncated).toBe(1);
 	});
 });

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -1984,13 +1984,15 @@ const EXEMPT_SITES: Readonly<Record<string, SweepExemption>> = {
 			"as well as from every tool request (AC8).",
 		owner: "#2523 slice 2",
 	},
-	"mcp/server.ts#handleRequest:3543a7ce~e5cc4ea3": {
+	"mcp/server.ts#handleRequest:3543a7ce~154cbab1": {
 		family: "hook-await",
 		site: "off-hook",
 		reason:
 			"MCP tool-request handler (LSP navigation/diagnostics) and the " +
 			"request dispatcher itself. An agent is waiting on its own " +
-			"request; no pi hook budget applies.",
+			"request; no pi hook budget applies. " +
+			"(Key re-derived on #2800 item 7: the callTool await's occurrence " +
+			"hash moved when the stale-warning block was hoisted above it.)",
 		owner: "#2523 slice 2",
 	},
 	"mcp/server.ts#startIpcServer:3c5e37d1~30036a6f": {

--- a/tests/config/result-contract-governance.test.ts
+++ b/tests/config/result-contract-governance.test.ts
@@ -148,24 +148,24 @@ describe("result contract across registered tool surfaces", () => {
 			}
 			const mcpResultValue = mcpResult.result as ToolResult;
 			expect(mcpText, `${entry.name}: MCP result`).toMatch(
-				/result (?:ok|error)\n(?:diag severity=.*\n)?usage tokens=\d+ elapsed-ms=\d+$/,
+				/result (?:ok|error)\n(?:diag severity=.*\n)?usage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=(?:true|false)$/,
 			);
 			expect(
 				mcpText?.includes("result error"),
 				`${entry.name}: MCP verdict matches isError`,
 			).toBe(mcpResultValue.isError === true);
 			expect(mcpText, `${entry.name}: MCP usage`).toMatch(
-				/usage tokens=\d+ elapsed-ms=\d+/,
+				/usage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=(?:true|false)/,
 			);
 			expect(piText, `${entry.name}: pi result`).toMatch(
-				/result (?:ok|error)\n(?:diag severity=.*\n)?usage tokens=\d+ elapsed-ms=\d+$/,
+				/result (?:ok|error)\n(?:diag severity=.*\n)?usage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=(?:true|false)$/,
 			);
 			expect(
 				piText?.includes("result error"),
 				`${entry.name}: pi verdict matches isError`,
 			).toBe(piResult?.isError === true);
 			expect(piText, `${entry.name}: pi usage`).toMatch(
-				/usage tokens=\d+ elapsed-ms=\d+/,
+				/usage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=(?:true|false)/,
 			);
 		}
 	}, 30_000);
@@ -215,7 +215,7 @@ describe("result contract across registered tool surfaces", () => {
 			);
 			const text = result?.content?.[0]?.text;
 			expect(text, `${entry.name}: pi rendering`).toMatch(
-				/result (?:ok|error)\n(?:diag severity=.*\n)?usage tokens=\d+ elapsed-ms=\d+$/,
+				/result (?:ok|error)\n(?:diag severity=.*\n)?usage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=(?:true|false)$/,
 			);
 			expect(
 				text?.includes("result error"),
@@ -266,5 +266,155 @@ describe("result contract across registered tool surfaces", () => {
 			MAX_RESULT_BYTES,
 		);
 		expect(text).toContain("characters omitted");
+		// Item 7 (refs #2800): the footer reports the delivered payload, and the
+		// bound reserves the footer's own size, so footer included the text stays
+		// inside the budget. Dropping the reserve reds the byteLength assert;
+		// reporting pre-bound bytes reds the bytes= assert below.
+		const delivered = Number(text.match(/bytes=(\d+)/)?.[1]);
+		expect(Number.isFinite(delivered), "bytes= present").toBe(true);
+		expect(delivered).toBeLessThanOrEqual(MAX_RESULT_BYTES);
+		expect(text).toMatch(/truncated=true$/);
+	});
+
+	it("stamps exact delivered bytes on a normal result through both surfaces", async () => {
+		// Item 7 (refs #2800): bytes= is the UTF-8 byte count of the delivered
+		// payload text (the footer excluded), measured here independently from
+		// the rendered text on both real surfaces.
+		const args = { path: path.join(cwd, "fixture.ts"), symbol: "enclosing" };
+		const readByteFigures = (text: string | undefined) => {
+			const match = text?.match(
+				/\n\nresult ok\nusage tokens=\d+ elapsed-ms=\d+ bytes=(\d+) truncated=(true|false)$/,
+			);
+			expect(match, "footer with bytes=/truncated=").not.toBeNull();
+			const payload = text?.slice(0, text.indexOf("\n\nresult ok")) as string;
+			return {
+				bytes: Number(match?.[1]),
+				truncated: match?.[2],
+				measured: Buffer.byteLength(payload, "utf8"),
+			};
+		};
+		const piTool = pi.getTool("read_symbol") as {
+			execute?: (...args: unknown[]) => Promise<ToolResult>;
+		};
+		const piResult = await piTool.execute?.(
+			"governance",
+			args,
+			new AbortController().signal,
+			undefined,
+			{ cwd },
+		);
+		const piFigures = readByteFigures(piResult?.content?.[0]?.text);
+		expect(piFigures.truncated).toBe("false");
+		expect(piFigures.bytes).toBe(piFigures.measured);
+		const mcpResult = await mcp.request(150, "tools/call", {
+			name: "pilens_read_symbol",
+			arguments: { ...args, file: args.path },
+		});
+		const mcpFigures = readByteFigures(
+			(mcpResult.result as ToolResult).content?.[0]?.text,
+		);
+		expect(mcpFigures.truncated).toBe("false");
+		expect(mcpFigures.bytes).toBe(mcpFigures.measured);
+	});
+
+	it("sums the turn's tool calls onto the real cache_usage row (refs #2800 item 7)", async () => {
+		// Real sinks: no cache-observability mock. Two normal calls plus one
+		// oversized call close a turn; the emitted message_end writes the real
+		// `cache_usage` latency row whose toolResultBytes must equal the sum of
+		// the delivered footers' bytes= figures, and whose toolResultsTruncated
+		// must count the oversized call. Dropping the wrapper aggregation reds
+		// both asserts with 0.
+		const { flushLatencyLog, getLatencyLogPath } =
+			await import("../../clients/latency-logger.js");
+		const sessionId = `row-bytes-${Date.now().toString(36)}`;
+		const ctx = {
+			cwd,
+			sessionManager: { getSessionId: () => sessionId },
+		};
+		const readSymbol = pi.getTool("read_symbol") as {
+			execute?: (...args: unknown[]) => Promise<ToolResult>;
+		};
+		const executed = [
+			await readSymbol.execute?.(
+				"row-1",
+				{ path: path.join(cwd, "fixture.ts"), symbol: "enclosing" },
+				new AbortController().signal,
+				undefined,
+				ctx,
+			),
+			await readSymbol.execute?.(
+				"row-2",
+				{ path: path.join(cwd, "fixture.ts"), symbol: "enclosing" },
+				new AbortController().signal,
+				undefined,
+				ctx,
+			),
+			await readSymbol.execute?.(
+				"row-3",
+				{ path: path.join(cwd, "big.ts"), symbol: "bigSymbol" },
+				new AbortController().signal,
+				undefined,
+				ctx,
+			),
+		];
+		const figures = executed.map((result) => {
+			const text = result?.content?.[0]?.text ?? "";
+			return {
+				bytes: Number(text.match(/bytes=(\d+)/)?.[1]),
+				truncated: /truncated=true$/.test(text),
+			};
+		});
+		for (const figure of figures) {
+			expect(Number.isFinite(figure.bytes), "footer bytes= present").toBe(true);
+		}
+		// #1742's sanctioned opt-out: the row must be read from the REAL sink,
+		// so test mode is scoped off for exactly this write/read window.
+		const previousTestMode = process.env.PI_LENS_TEST_MODE;
+		process.env.PI_LENS_TEST_MODE = "0";
+		try {
+			await pi.emit(
+				"message_end",
+				{
+					message: {
+						role: "assistant",
+						provider: "p",
+						model: "m",
+						usage: { input: 1, output: 1, cacheRead: 1, cacheWrite: 0 },
+					},
+				},
+				ctx,
+			);
+			await flushLatencyLog();
+		} finally {
+			if (previousTestMode === undefined) {
+				delete process.env.PI_LENS_TEST_MODE;
+			} else {
+				process.env.PI_LENS_TEST_MODE = previousTestMode;
+			}
+		}
+		const rows = fs
+			.readFileSync(getLatencyLogPath(), "utf8")
+			.split("\n")
+			.filter(Boolean)
+			.map(
+				(line) =>
+					JSON.parse(line) as {
+						phase?: string;
+						metadata?: Record<string, unknown>;
+					},
+			)
+			.filter(
+				(entry) =>
+					entry.phase === "cache_usage" &&
+					entry.metadata?.sessionId === sessionId,
+			);
+		expect(rows, "one cache_usage row for the session").toHaveLength(1);
+		const metadata = rows[0].metadata as Record<string, unknown>;
+		expect(metadata.toolResultBytes).toBe(
+			figures.reduce((sum, figure) => sum + figure.bytes, 0),
+		);
+		expect(metadata.toolResultsTruncated).toBe(
+			figures.filter((figure) => figure.truncated).length,
+		);
 	});
 });

--- a/tests/mcp/build-staleness.smoke.test.ts
+++ b/tests/mcp/build-staleness.smoke.test.ts
@@ -152,8 +152,10 @@ describe("warm build-staleness guard (real spawn)", { retry: 2 }, () => {
 		// gate's re-stat throttle disabled above, the very next call sees the
 		// advanced mtime. The fixture body exceeds MAX_RESULT_BYTES, making
 		// this the one configuration in which the bound-vs-warning ordering is
-		// observable (refs #2852 N2): binding before warning would deliver
-		// 40,960 bytes PLUS the warning.
+		// observable (refs #2852 N2, re-ordered by #2800 item 7): the warning is
+		// part of the payload the bound protects, and the footer is stamped
+		// after the bound with the footer's own size reserved, so warning plus
+		// bounded payload plus footer still fit the budget.
 		await harness.request(10, "initialize", {
 			protocolVersion: "2025-06-18",
 			capabilities: {},
@@ -176,6 +178,18 @@ describe("warm build-staleness guard (real spawn)", { retry: 2 }, () => {
 		expect(text).toContain("characters omitted");
 		expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(
 			MAX_RESULT_BYTES,
+		);
+		// Item 7 (refs #2800): the footer is stamped after the bound, so the
+		// delivered text (footer included) stays inside the budget and the
+		// footer reports the delivered payload with the truncated flag.
+		expect(text).toMatch(
+			/\n\nresult ok\nusage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=true$/,
+		);
+		const delivered = Number(text.match(/bytes=(\d+)/)?.[1]);
+		expect(Number.isFinite(delivered), "bytes= present").toBe(true);
+		expect(delivered).toBeLessThanOrEqual(MAX_RESULT_BYTES);
+		expect(text.indexOf("warmCodeStale: true")).toBeLessThan(
+			text.indexOf("\n\nresult ok"),
 		);
 		// N1: the wire result must not carry the unbounded `details` duplicate —
 		// the whole serialized result stays within the text budget plus the

--- a/tests/mcp/server.smoke.test.ts
+++ b/tests/mcp/server.smoke.test.ts
@@ -121,7 +121,7 @@ describe("pi-lens MCP server (stdio smoke)", { retry: 2 }, () => {
 		expect(first.content[0]?.text).toContain("pilens_ast_grep_search");
 		expect(first.content[0]?.text).toContain("dump=true");
 		expect(first.content[0]?.text).toMatch(
-			/result error\nusage tokens=\d+ elapsed-ms=\d+$/,
+			/result error\nusage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=(?:true|false)$/,
 		);
 		const second = (
 			await harness.request(4, "tools/call", {
@@ -139,7 +139,7 @@ describe("pi-lens MCP server (stdio smoke)", { retry: 2 }, () => {
 		).result as typeof first;
 		expect(unknown.isError).toBe(true);
 		expect(unknown.content[0]?.text).toMatch(
-			/result error\nusage tokens=\d+ elapsed-ms=\d+$/,
+			/result error\nusage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=(?:true|false)$/,
 		);
 
 		const health = async (id: number) => {

--- a/tests/tools/render-compact.test.ts
+++ b/tests/tools/render-compact.test.ts
@@ -3,10 +3,19 @@ import {
 	baseName,
 	finalizeToolResult,
 	fullTextOf,
+	MAX_RESULT_BYTES,
 	renderToolResultContract,
 	renderToolText,
+	RESULT_FOOTER_RESERVE_BYTES,
 	selectCompactText,
 } from "../../tools/render-compact.js";
+
+/** Independently measures the delivered payload bytes a footer reports: the
+ * full rendered text minus the footer block the gate appended after it. */
+function deliveredPayloadBytes(text: string): number {
+	const footerStart = text.search(/\n\nresult (?:ok|error)\n/);
+	return Buffer.byteLength(text.slice(0, footerStart), "utf8");
+}
 
 describe("render-compact", () => {
 	const result = {
@@ -74,7 +83,9 @@ describe("render-compact", () => {
 		const text = result.content[0]?.text ?? "";
 		expect(text).toContain("result ok");
 		expect(text).toContain("diag severity=warning");
-		expect(text).toMatch(/usage tokens=\d+ elapsed-ms=0/);
+		expect(text).toMatch(
+			/usage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=(?:true|false)/,
+		);
 		// Exactly one footer: re-finalizing an already-final result must not
 		// append a second contract block (refs #2852 N4). `toContain` passed on
 		// double-stamped text, so count the verdict lines instead.
@@ -84,5 +95,70 @@ describe("render-compact", () => {
 		expect(
 			footerCount(renderToolResultContract(result).content[0]?.text ?? ""),
 		).toBe(1);
+	});
+
+	describe("delivered-byte reporting (refs #2800 item 7)", () => {
+		it("stamps exact delivered payload bytes on a normal result", () => {
+			const result = finalizeToolResult(
+				renderToolText("measured body", { symbols: 1 }),
+			);
+			const text = result.content[0]?.text ?? "";
+			const match = text.match(
+				/usage tokens=\d+ elapsed-ms=\d+ bytes=(\d+) truncated=(true|false)$/,
+			);
+			expect(match, "footer with bytes= and truncated=").not.toBeNull();
+			expect(match?.[2]).toBe("false");
+			// The expected value is measured from the rendered text, not derived
+			// from the production path's own computation.
+			expect(Number(match?.[1])).toBe(deliveredPayloadBytes(text));
+		});
+
+		it("keeps an oversized delivered text (footer included) inside MAX_RESULT_BYTES", () => {
+			const result = finalizeToolResult(
+				renderToolText("x".repeat(MAX_RESULT_BYTES * 2)),
+			);
+			const text = result.content[0]?.text ?? "";
+			expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(
+				MAX_RESULT_BYTES,
+			);
+			expect(text).toMatch(/truncated=true$/);
+			expect(text).toContain("characters omitted");
+			const delivered = Number(text.match(/bytes=(\d+)/)?.[1]);
+			// bytes= describes the delivered payload, never the pre-bound input.
+			expect(delivered).toBeLessThanOrEqual(MAX_RESULT_BYTES);
+			expect(delivered).toBe(deliveredPayloadBytes(text));
+		});
+
+		it("keeps the error verdict and delivered bytes on an isError result", () => {
+			const result = finalizeToolResult({
+				...renderToolText("boom"),
+				isError: true,
+			});
+			const text = result.content[0]?.text ?? "";
+			expect(text).toMatch(
+				/result error\nusage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=false$/,
+			);
+			expect(Number(text.match(/bytes=(\d+)/)?.[1])).toBe(
+				deliveredPayloadBytes(text),
+			);
+		});
+
+		it("reserves the footer's maximum size inside the result budget", () => {
+			expect(RESULT_FOOTER_RESERVE_BYTES).toBeGreaterThan(0);
+			expect(RESULT_FOOTER_RESERVE_BYTES).toBeLessThan(MAX_RESULT_BYTES);
+		});
+
+		it("bounds the footer's diag section so the reserve stays sound", () => {
+			const diagnostics = Array.from({ length: 5_000 }, () => ({
+				severity: "w".repeat(300),
+			}));
+			const result = finalizeToolResult(
+				renderToolText("body", { diagnostics }),
+			);
+			const text = result.content[0]?.text ?? "";
+			expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(
+				MAX_RESULT_BYTES,
+			);
+		});
 	});
 });

--- a/tests/tools/render-compact.test.ts
+++ b/tests/tools/render-compact.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
 	baseName,
 	finalizeToolResult,
+	finalizeToolResultWithDelivery,
 	fullTextOf,
 	MAX_RESULT_BYTES,
 	renderToolResultContract,
 	renderToolText,
 	RESULT_FOOTER_RESERVE_BYTES,
+	RESULT_PAYLOAD_BUDGET_BYTES,
 	selectCompactText,
 } from "../../tools/render-compact.js";
 
@@ -129,6 +131,59 @@ describe("render-compact", () => {
 			expect(delivered).toBe(deliveredPayloadBytes(text));
 		});
 
+		it("keeps a fitting stamped result untouched on re-entry and reports the footer's own figures", () => {
+			const first = finalizeToolResultWithDelivery(
+				renderToolText("y".repeat(MAX_RESULT_BYTES * 2)),
+			);
+			const firstText = first.result.content[0]?.text ?? "";
+			expect(Buffer.byteLength(firstText, "utf8")).toBeLessThanOrEqual(
+				MAX_RESULT_BYTES,
+			);
+			expect(first.truncated).toBe(true);
+			// Second gate over the already-stamped result (refs #2852 N4): the
+			// delivered text is kept as delivered and the figures are the kept
+			// footer's own prior values (row 6) — never a footer-inclusive
+			// re-measure and never a hard-coded `false` (round 2 F1).
+			const second = finalizeToolResultWithDelivery(first.result);
+			const secondText = second.result.content[0]?.text ?? "";
+			expect(secondText).toBe(firstText);
+			const footerCount = (source: string) =>
+				(source.match(/^result (?:ok|error)$/gm) ?? []).length;
+			expect(footerCount(secondText)).toBe(1);
+			expect(second.deliveredBytes).toBe(first.deliveredBytes);
+			expect(second.truncated).toBe(first.truncated);
+			// The reported figure is the payload the text actually carries, not
+			// the footer-inclusive total the pre-fix branch measured.
+			expect(second.deliveredBytes).toBe(deliveredPayloadBytes(secondText));
+		});
+
+		it("bounds an oversized pre-stamped result on re-entry", () => {
+			// A result stamped without the gate's bound (the direct
+			// renderToolResultContract path): oversized payload plus footer.
+			const preStamped = renderToolResultContract(
+				renderToolText("x".repeat(MAX_RESULT_BYTES * 2)),
+			);
+			const preStampedBytes = Buffer.byteLength(fullTextOf(preStamped), "utf8");
+			expect(preStampedBytes).toBeGreaterThan(MAX_RESULT_BYTES);
+			// The gate must still bound it on re-entry: the pre-fix re-entry
+			// branch returned before the bound and delivered the whole
+			// pre-stamped text unbounded.
+			const gated = finalizeToolResultWithDelivery(preStamped);
+			const gatedText = fullTextOf(gated.result);
+			expect(Buffer.byteLength(gatedText, "utf8")).toBeLessThanOrEqual(
+				MAX_RESULT_BYTES,
+			);
+			const footerCount = (source: string) =>
+				(source.match(/^result (?:ok|error)$/gm) ?? []).length;
+			expect(footerCount(gatedText)).toBe(1);
+			// The figures are the kept footer's own (row 6: prior value kept) —
+			// the footer describes the payload as it was first stamped.
+			const footer = gatedText.match(/bytes=(\d+) truncated=(true|false)$/);
+			expect(footer, "kept footer figures").not.toBeNull();
+			expect(gated.deliveredBytes).toBe(Number(footer?.[1]));
+			expect(gated.truncated).toBe(footer?.[2] === "true");
+		});
+
 		it("keeps the error verdict and delivered bytes on an isError result", () => {
 			const result = finalizeToolResult({
 				...renderToolText("boom"),
@@ -143,9 +198,48 @@ describe("render-compact", () => {
 			);
 		});
 
-		it("reserves the footer's maximum size inside the result budget", () => {
-			expect(RESULT_FOOTER_RESERVE_BYTES).toBeGreaterThan(0);
-			expect(RESULT_FOOTER_RESERVE_BYTES).toBeLessThan(MAX_RESULT_BYTES);
+		it("reserves the byte count of the footer's widest literal and covers a rendered worst case", () => {
+			// Round 2 F2 pin: the reserve must equal the widest footer the
+			// renderer can emit — the error verdict, a diag section at its 1 KiB
+			// cap (separator included), 16-digit numeric fields
+			// (Number.MAX_SAFE_INTEGER width), and the wider `truncated=false`.
+			// Editing either side without the other reds here.
+			const widest = `\n\nresult error\n${"x".repeat(1024)}\nusage tokens=${"9".repeat(16)} elapsed-ms=${"9".repeat(16)} bytes=${"9".repeat(16)} truncated=false`;
+			expect(RESULT_FOOTER_RESERVE_BYTES).toBe(
+				Buffer.byteLength(widest, "utf8"),
+			);
+			// Soundness through the real renderer: a result at the same maxima
+			// (error verdict, diag section filled to the cap, 16-digit usage)
+			// renders a footer no wider than the reserve. Four 215-byte diag
+			// lines plus one 164-byte line fill the 1 KiB cap exactly.
+			const diagnostics = [
+				{ severity: "w".repeat(200) },
+				{ severity: "w".repeat(200) },
+				{ severity: "w".repeat(200) },
+				{ severity: "w".repeat(200) },
+				{ severity: "w".repeat(149) },
+			];
+			const worst = renderToolResultContract({
+				content: [{ type: "text" as const, text: "payload" }],
+				isError: true,
+				usage: {
+					tokens: Number.MAX_SAFE_INTEGER,
+					elapsedMs: Number.MAX_SAFE_INTEGER,
+				},
+				details: { diagnostics },
+			});
+			const worstText = worst.content[0]?.text ?? "";
+			const footerStart = worstText.search(/\n\nresult (?:ok|error)\n/);
+			expect(footerStart, "footer in rendered worst case").toBeGreaterThan(-1);
+			expect(RESULT_FOOTER_RESERVE_BYTES).toBeGreaterThanOrEqual(
+				Buffer.byteLength(worstText.slice(footerStart), "utf8"),
+			);
+			// The payload budget is the result budget minus the reserve; the
+			// round-1 M1 mutation (binding the payload at the full budget) reds
+			// on this line.
+			expect(RESULT_PAYLOAD_BUDGET_BYTES).toBe(
+				MAX_RESULT_BYTES - RESULT_FOOTER_RESERVE_BYTES,
+			);
 		});
 
 		it("bounds the footer's diag section so the reserve stays sound", () => {

--- a/tools/render-compact.ts
+++ b/tools/render-compact.ts
@@ -34,6 +34,27 @@ export const MAX_RESULT_BYTES = 40 * 1024;
 // unbounded result; ordinary results keep the complete-log contract below it.
 export const COMPLETE_MCP_RESULT_INPUT_BUDGET_BYTES = 8 * 1024 * 1024;
 
+// #2800 item 7: the footer is stamped AFTER the payload bound, so the
+// footer's own maximum size is reserved inside MAX_RESULT_BYTES. The reserve
+// is computed from the footer's widest literal: the `result error` verdict, a
+// bounded diag severity section, and maximum-width numeric fields with the
+// wider `truncated=false` value.
+const FOOTER_MAX_DIGITS = String(Number.MAX_SAFE_INTEGER).length;
+/** One `diag severity=` line is width-bounded so the footer's maximum size
+ * stays finite and the reserve above stays sound. */
+const FOOTER_DIAG_LINE_MAX_CHARS = 200;
+const FOOTER_DIAG_SECTION_MAX_BYTES = 1024;
+
+export const RESULT_FOOTER_RESERVE_BYTES = Buffer.byteLength(
+	`\n\nresult error\n${"x".repeat(FOOTER_DIAG_SECTION_MAX_BYTES)}\nusage tokens=${"9".repeat(FOOTER_MAX_DIGITS)} elapsed-ms=${"9".repeat(FOOTER_MAX_DIGITS)} bytes=${"9".repeat(FOOTER_MAX_DIGITS)} truncated=false`,
+	"utf8",
+);
+
+/** The payload byte budget the footer is stamped into: the delivered result
+ * budget minus the reserved footer maximum (#2800 item 7). */
+export const RESULT_PAYLOAD_BUDGET_BYTES =
+	MAX_RESULT_BYTES - RESULT_FOOTER_RESERVE_BYTES;
+
 export interface BoundedToolText {
 	text: string;
 	truncated: boolean;
@@ -66,10 +87,15 @@ function renderHeadTail(
 	return { text: render(low), keptCharacters: low };
 }
 
-/** Bound model-facing result text while retaining both the useful head and tail. */
-export function boundToolText(text: string): BoundedToolText {
+/** Bound model-facing result text while retaining both the useful head and tail.
+ * `maxBytes` defaults to the full result budget; the footer gate passes the
+ * payload budget that leaves room for the stamped footer (#2800 item 7). */
+export function boundToolText(
+	text: string,
+	maxBytes: number = MAX_RESULT_BYTES,
+): BoundedToolText {
 	const totalBytes = Buffer.byteLength(text, "utf8");
-	if (totalBytes <= MAX_RESULT_BYTES) {
+	if (totalBytes <= maxBytes) {
 		return { text, truncated: false, omittedCharacters: 0 };
 	}
 
@@ -104,7 +130,7 @@ export function boundToolText(text: string): BoundedToolText {
 		fs.writeFileSync(fullOutputPath, logText.text, "utf8");
 		const output = renderHeadTail(
 			logText.text,
-			MAX_RESULT_BYTES,
+			maxBytes,
 			() =>
 				`\n\n[incomplete: ${omittedBytes} bytes omitted, budget ${COMPLETE_MCP_RESULT_INPUT_BUDGET_BYTES}]\n\n[Full output: ${fullOutputPath}]\n\n`,
 		);
@@ -119,7 +145,7 @@ export function boundToolText(text: string): BoundedToolText {
 	fs.writeFileSync(fullOutputPath, text, "utf8");
 	const output = renderHeadTail(
 		text,
-		MAX_RESULT_BYTES,
+		maxBytes,
 		(head, tail) =>
 			`\n\n[${text.length - head - tail} characters omitted. Full output: ${fullOutputPath}]\n\n`,
 	);
@@ -155,7 +181,15 @@ export interface LensToolResult<D = unknown> extends CompactResultLike<D> {
 /** Matches an already-stamped contract footer at the end of the joined text.
  * A result re-entering the gate must not gain a second footer (refs #2852 N4). */
 const CONTRACT_FOOTER_TAIL_RE =
-	/(?:^|\n)result (?:ok|error)\n(?:diag severity=[^\n]*\n)*usage tokens=\d+ elapsed-ms=\d+$/;
+	/(?:^|\n)result (?:ok|error)\n(?:diag severity=[^\n]*\n)*usage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=(?:true|false)$/;
+
+/** Optional delivery figures the footer reports when the caller has already
+ * bounded the payload (#2800 item 7). Absent on a direct stamp of an unbound
+ * result, where the input text IS the delivered payload. */
+export interface ToolResultDeliveryStats {
+	bytes: number;
+	truncated: boolean;
+}
 
 /**
  * Add the stable, model-facing result footer shared by pi and MCP.
@@ -165,9 +199,14 @@ const CONTRACT_FOOTER_TAIL_RE =
  * time is not a property of a projection and must not make parity tests flaky.
  * Idempotent: a result whose text already ends with the footer is only
  * `isError`-normalized, never stamped twice.
+ *
+ * When `delivery` is given (the gate path), `bytes=`/`truncated=` describe the
+ * already-bound payload; otherwise they describe this function's input text,
+ * which is the delivered payload because no bound has run.
  */
 export function renderToolResultContract<T extends ToolResultContractLike>(
 	result: T,
+	delivery?: ToolResultDeliveryStats,
 ): T {
 	const normalized = {
 		...result,
@@ -184,23 +223,32 @@ export function renderToolResultContract<T extends ToolResultContractLike>(
 	const text = textBlocks.join("\n");
 	if (CONTRACT_FOOTER_TAIL_RE.test(text)) return normalized;
 	const details = normalized.details as Record<string, unknown> | undefined;
-	const diagnostics = Array.isArray(details?.diagnostics)
-		? details.diagnostics
-				.filter(
-					(value): value is Record<string, unknown> =>
-						Boolean(value) && typeof value === "object",
-				)
-				.map((diagnostic) => diagnostic.severity)
-				.filter((severity): severity is string => typeof severity === "string")
-				.map((severity) => `diag severity=${severity}`)
-		: [];
+	// The diag section is width- and byte-bounded (#2800 item 7) so the
+	// footer's maximum size — and therefore the reserved budget above — stays
+	// finite regardless of how many diagnostics a result carries.
+	const diagLines: string[] = [];
+	let diagSectionBytes = 0;
+	if (Array.isArray(details?.diagnostics)) {
+		for (const value of details.diagnostics) {
+			if (!value || typeof value !== "object") continue;
+			const severity = (value as Record<string, unknown>).severity;
+			if (typeof severity !== "string") continue;
+			const line = `diag severity=${severity.slice(0, FOOTER_DIAG_LINE_MAX_CHARS)}`;
+			const lineBytes = Buffer.byteLength(line, "utf8") + 1;
+			if (diagSectionBytes + lineBytes > FOOTER_DIAG_SECTION_MAX_BYTES) break;
+			diagLines.push(line);
+			diagSectionBytes += lineBytes;
+		}
+	}
 	const tokens =
 		normalized.usage?.tokens ?? Math.ceil(Buffer.byteLength(text, "utf8") / 4);
 	const elapsedMs = normalized.usage?.elapsedMs ?? 0;
+	const deliveredBytes = delivery?.bytes ?? Buffer.byteLength(text, "utf8");
+	const truncated = delivery?.truncated === true;
 	const contractLines = [
 		`result ${normalized.isError ? "error" : "ok"}`,
-		...diagnostics,
-		`usage tokens=${tokens} elapsed-ms=${elapsedMs}`,
+		...diagLines,
+		`usage tokens=${tokens} elapsed-ms=${elapsedMs} bytes=${deliveredBytes} truncated=${truncated ? "true" : "false"}`,
 	];
 	let lastTextIndex = -1;
 	for (let index = content.length - 1; index >= 0; index--) {
@@ -221,18 +269,31 @@ export function renderToolResultContract<T extends ToolResultContractLike>(
 	};
 }
 
-/** Apply the #2848 byte bound to every text block of a rendered result. The
- * bound runs LAST in every composition so a result that already carries the
- * contract footer still fits MAX_RESULT_BYTES on delivery. */
-export function boundToolResultText<T extends CompactResultLike>(result: T): T {
-	if (!result.content) return result;
+/** Bound the payload text blocks so the footer stamped afterwards still fits
+ * inside MAX_RESULT_BYTES (refs #2800 item 7): each block is bounded to the
+ * result budget minus the reserved footer maximum, and the delivered byte
+ * count plus the bound's truncated flag travel with the result so the footer
+ * can report them. Per-block bounding is inherited from #2852; production
+ * results carry a single text block (renderToolText). */
+export function boundResultPayload<T extends CompactResultLike>(
+	result: T,
+): { result: T; deliveredBytes: number; truncated: boolean } {
+	if (!result.content) {
+		return { result, deliveredBytes: 0, truncated: false };
+	}
+	let deliveredBytes = 0;
+	let truncated = false;
+	const content = result.content.map((block) => {
+		if (block.type !== "text" || typeof block.text !== "string") return block;
+		const bound = boundToolText(block.text, RESULT_PAYLOAD_BUDGET_BYTES);
+		deliveredBytes += Buffer.byteLength(bound.text, "utf8");
+		truncated = truncated || bound.truncated;
+		return { ...block, text: bound.text };
+	});
 	return {
-		...result,
-		content: result.content.map((block) =>
-			block.type === "text" && typeof block.text === "string"
-				? { ...block, text: boundToolText(block.text).text }
-				: block,
-		),
+		result: { ...result, content },
+		deliveredBytes,
+		truncated,
 	};
 }
 
@@ -269,11 +330,50 @@ export function stripResultDetails<T extends CompactResultLike>(result: T): T {
 	return rest as T;
 }
 
+/** What the gate returns alongside the finished result: the figures the
+ * per-turn cache_usage row aggregates (#2800 item 7). */
+export interface FinalizedToolDelivery<T> {
+	result: T;
+	deliveredBytes: number;
+	truncated: boolean;
+}
+
+/** Finish a host-adapter result after its status and all warnings exist
+ * (#2800 item 7): the payload bound runs FIRST with the footer's own maximum
+ * size reserved inside MAX_RESULT_BYTES, then the footer is stamped LAST with
+ * the delivered payload's byte count and the bound's truncated flag. So
+ * `bytes=`/`truncated=` describe what the model actually receives, and the
+ * delivered text — footer included — never exceeds MAX_RESULT_BYTES. */
+export function finalizeToolResultWithDelivery<
+	T extends ToolResultContractLike,
+>(result: T): FinalizedToolDelivery<T> {
+	const normalized = { ...result, isError: result.isError === true } as T;
+	const existingText = fullTextOf(normalized);
+	if (CONTRACT_FOOTER_TAIL_RE.test(existingText)) {
+		// Idempotent re-entry (refs #2852 N4): never stamp twice, never re-bound.
+		return {
+			result: normalized,
+			deliveredBytes: Buffer.byteLength(existingText, "utf8"),
+			truncated: false,
+		};
+	}
+	const bound = boundResultPayload(normalized);
+	const stamped = renderToolResultContract(bound.result, {
+		bytes: bound.deliveredBytes,
+		truncated: bound.truncated,
+	});
+	return {
+		result: stamped,
+		deliveredBytes: bound.deliveredBytes,
+		truncated: bound.truncated,
+	};
+}
+
 /** Finish a host-adapter result after its status and all warnings exist. */
 export function finalizeToolResult<T extends ToolResultContractLike>(
 	result: T,
 ): T {
-	return boundToolResultText(renderToolResultContract(result));
+	return finalizeToolResultWithDelivery(result).result;
 }
 
 interface CompactSummaryInput<D = unknown> {

--- a/tools/render-compact.ts
+++ b/tools/render-compact.ts
@@ -179,9 +179,11 @@ export interface LensToolResult<D = unknown> extends CompactResultLike<D> {
 }
 
 /** Matches an already-stamped contract footer at the end of the joined text.
- * A result re-entering the gate must not gain a second footer (refs #2852 N4). */
+ * A result re-entering the gate must not gain a second footer (refs #2852 N4).
+ * The byte and truncated groups let the gate read the kept footer's own
+ * delivery figures on re-entry (round 2 F1). */
 const CONTRACT_FOOTER_TAIL_RE =
-	/(?:^|\n)result (?:ok|error)\n(?:diag severity=[^\n]*\n)*usage tokens=\d+ elapsed-ms=\d+ bytes=\d+ truncated=(?:true|false)$/;
+	/(?:^|\n)result (?:ok|error)\n(?:diag severity=[^\n]*\n)*usage tokens=\d+ elapsed-ms=\d+ bytes=(\d+) truncated=(true|false)$/;
 
 /** Optional delivery figures the footer reports when the caller has already
  * bounded the payload (#2800 item 7). Absent on a direct stamp of an unbound
@@ -343,21 +345,43 @@ export interface FinalizedToolDelivery<T> {
  * size reserved inside MAX_RESULT_BYTES, then the footer is stamped LAST with
  * the delivered payload's byte count and the bound's truncated flag. So
  * `bytes=`/`truncated=` describe what the model actually receives, and the
- * delivered text — footer included — never exceeds MAX_RESULT_BYTES. */
+ * delivered text — footer included — never exceeds MAX_RESULT_BYTES.
+ *
+ * Re-entry (refs #2852 N4, round 2 F1): the bound still runs on an
+ * already-stamped result — master applied the bound after the stamp-skip, and
+ * the kept tail carries the footer through it — so re-entry is never delivered
+ * unbounded. A stamped result within the delivered budget is kept as-is; the
+ * figures are the kept footer's own prior values, never a footer-inclusive
+ * re-measure and never a hard-coded `false`. */
 export function finalizeToolResultWithDelivery<
 	T extends ToolResultContractLike,
 >(result: T): FinalizedToolDelivery<T> {
 	const normalized = { ...result, isError: result.isError === true } as T;
 	const existingText = fullTextOf(normalized);
-	if (CONTRACT_FOOTER_TAIL_RE.test(existingText)) {
-		// Idempotent re-entry (refs #2852 N4): never stamp twice, never re-bound.
+	const existingFooter = CONTRACT_FOOTER_TAIL_RE.exec(existingText);
+	if (
+		existingFooter &&
+		Buffer.byteLength(existingText, "utf8") <= MAX_RESULT_BYTES
+	) {
 		return {
 			result: normalized,
-			deliveredBytes: Buffer.byteLength(existingText, "utf8"),
-			truncated: false,
+			deliveredBytes: Number(existingFooter[1]),
+			truncated: existingFooter[2] === "true",
 		};
 	}
 	const bound = boundResultPayload(normalized);
+	const text = fullTextOf(bound.result);
+	const keptFooter = CONTRACT_FOOTER_TAIL_RE.exec(text);
+	if (keptFooter) {
+		// The bound ran and the kept tail still carries the footer, so there is
+		// nothing to stamp; the kept footer's figures stay the delivery
+		// contract (row 6: prior value kept).
+		return {
+			result: bound.result,
+			deliveredBytes: Number(keptFooter[1]),
+			truncated: keptFooter[2] === "true",
+		};
+	}
 	const stamped = renderToolResultContract(bound.result, {
 		bytes: bound.deliveredBytes,
 		truncated: bound.truncated,


### PR DESCRIPTION
## Summary

Item 7 of #2800 (per-call tool-result observability). The `usage tokens=<n> elapsed-ms=<n>` contract footer gains ` bytes=<delivered bytes> truncated=<true|false>` on both surfaces, and the per-turn `cache_usage` row (#2841's shape) gains `toolResultBytes` (sum of the turn's delivered footer byte figures) and `toolResultsTruncated` (count of results whose bound fired).

The figures describe the DELIVERED payload, so the transform order changes on both surfaces (was: footer → bound):

```
tool result → [MCP: stale warning when warn-only + stale]
           → payload bound (per text block at MAX_RESULT_BYTES − RESULT_FOOTER_RESERVE_BYTES)
           → footer stamped LAST with bytes= / truncated=
```

`RESULT_FOOTER_RESERVE_BYTES` is computed from the footer's widest literal (error verdict + a bounded diag section + maximum-width numeric fields + `truncated=false`), so the delivered text, footer included, never exceeds 40 KiB. #2852's order pins (stale warning before the bound; footer present; exactly one footer) stay green.

`bytes=` counts UTF-8 bytes of the delivered payload text blocks (footer excluded — a footer cannot report a value that includes itself without a fixed-point iteration; the reserve is what makes payload+footer ≤ 40 KiB provable). The footer's diag severity section is width-bounded (200 chars/line) and byte-bounded (1 KiB) so the footer's maximum size — hence the reserve — is finite; surplus severity lines are dropped (they are informational severity echoes; the payload still carries the findings).

State-space table (result state → what `bytes=` reports):

| # | state | bound fires | footer `bytes=` | `truncated=` | delivered incl. footer |
|---|---|---|---|---|---|
| 1 | normal (≤ payload budget) | no | exact payload bytes | false | ≤ 40960 |
| 2 | isError, within budget | no | exact payload bytes | false | ≤ 40960, verdict `result error` |
| 3 | stale-warned (MCP), within budget | no | exact bytes incl. warning | false | ≤ 40960 |
| 4 | oversized | yes | exact delivered bytes | true | ≤ 40960 |
| 5 | oversized + stale (MCP) | yes | exact delivered bytes | true | ≤ 40960, warning precedes footer |
| 6 | already-stamped (re-entry) | n/a | prior value kept; no second stamp | kept | footer tail regex matches |

Row aggregation: recorded from the pi delivery seam (`index.ts`'s registration wrapper — the SDK hands the live ExtensionContext as the fifth execute argument, so attribution mirrors the message_end handler: stable session id plus the activation-owned role). Both figures reset at the turn boundary with the other accumulators; the byte sum saturates at 1 MiB. The MCP dispatcher stamps the footer only: the `cache_usage` row is emitted by pi's `message_end` from pi-process state, and the MCP process's separate attribution state has no reader — recording there would be dead data.

Operating rule: the delivered figures describe the delivered payload — the byte bound runs before the footer is stamped, with the footer's own maximum size reserved, so the delivered text (footer included) never exceeds 40 KiB.

## Tests

Red-first through the real surfaces (pre-fix build, verbatim):

```
tests/config/result-contract-governance.test.ts (5 tests | 5 failed)
AssertionError: ast_grep_search: MCP result: expected 'bad.ts:5:16: items.sort()  [TypeScrip…' to match /result (?:ok|error)\n(?:diag severity…/
AssertionError: bytes= present: expected false to be true // Object.is equality
AssertionError: footer with bytes=/truncated=: expected null not to be null
AssertionError: footer bytes= present: expected false to be true // Object.is equality
```

```
tests/mcp/server.smoke.test.ts
AssertionError: expected 'The ast_grep_dump tool was retired. C…' to match /result error\nusage tokens=\d+ elapse…/
tests/mcp/build-staleness.smoke.test.ts
AssertionError: expected '../../home/akis/.plegma/work/sub-vwch…' to match /\n\nresult ok\nusage tokens=\d+ elaps…/
```

New coverage: normal result `bytes=` exact on both real surfaces (expected value measured from the rendered text, not derived from production); oversized → `truncated=true`, `bytes=` ≤ 40960, delivered text (footer included) ≤ 40960; stale+oversized keeps the warning and the bound through a real MCP child; the real `cache_usage` row (real sink, `PI_LENS_TEST_MODE` scoped off per #1742) sums three calls — two normal plus one oversized — into `toolResultBytes` and counts the truncated one.

Mutation transcripts (each rebuilds, runs, then reverts):

```
M1 drop the reserve (bound at MAX_RESULT_BYTES):
AssertionError: expected 41030 to be less than or equal to 40960   (unit, delivered incl. footer)
AssertionError: expected 41890 to be less than or equal to 40960   (diag-section unit)
AssertionError: expected 41030 to be less than or equal to 40960   (governance, real pi wrapper)
M2 report pre-bound bytes:
AssertionError: expected 156580 to be less than or equal to 40960  (unit)
AssertionError: expected 39976 to be 156732 // Object.is equality  (governance, real pi wrapper)
AssertionError: expected 81920 to be less than or equal to 40960   (row test)
M3 drop the aggregation (recorder no-ops):
AssertionError: expected +0 to be 39976 // Object.is equality
AssertionError: expected { provider: 'anthropic', …(32) } to match object { toolResultBytes: 333, …(1) }
AssertionError: expected +0 to be 1 // Object.is equality
```

Validation: `npm run build`; `tests/tools/`, `tests/mcp/`, `tests/clients/mcp/`, every file under `tests/config/`, `tests/index-integration.test.ts`, `tests/clients/cache-observability.test.ts` — 1147 passed, 1 failed, 1 skipped. The one failure (`tests/mcp/analyze-cli.test.ts` "reports hint-tier findings as advisories") is red on this box with BASE production sources too (my four production files reverted, rebuilt, same red; the bin reports correctly outside the vitest worker) — environmental, not from this change. `npm run fmt:check` clean.

## Blast radius

```
index.ts registerTool wrapper
- finalizeToolResult(renderToolResultContract cast)
+ finalizeToolResultWithDelivery → recordToolResultDelivery (new edge to clients/cache-observability.ts)
tools/render-compact.ts
- finalizeToolResult = boundToolResultText(renderToolResultContract(x))
+ finalizeToolResultWithDelivery = bound → stamp(stats); finalizeToolResult delegates to it
- boundToolResultText (deleted; sole production caller was the gate)
+ boundResultPayload → boundToolText(text, RESULT_PAYLOAD_BUDGET_BYTES)
  renderToolResultContract(result, delivery?)   ← optional stats param; regex + diag section bounded
mcp/server.ts handleRequest tools/call
- renderToolResultContract → withStaleWarning → boundToolResultText → send
+ withStaleWarning → finalizeToolResultWithDelivery → stripResultDetails → send
  finalizeToolResult (unknown-tool / failure paths — unchanged callers, same output + footer fields)
```

Downstream consumers of the footer text: the governance roster sweep, MCP smoke pins, and the compact-line summarizer (TUI-only, reads `details`) — the summarizer is unaffected because `details` still carries the payload on pi. The `await callTool` occurrence hash in `mcp/server.ts` moved with the reorder; the `hook-await-bounds` exemption key was re-derived (per-key diff, not a count match).

## Class sweep

- Footer literal pins: grepped `usage tokens=` / `elapsed-ms` repo-wide — `tools/render-compact.ts` plus three test files (`tests/tools/render-compact.test.ts`, `tests/config/result-contract-governance.test.ts`, `tests/mcp/server.smoke.test.ts`); zero hits in `docs/`. All moved in the same change.
- Byte-bound seam: `boundToolText` callers are the gate (payload budget) and `tests/mcp/server.smoke.test.ts` (unit, default budget unchanged); `boundToolResultText` had exactly one production caller (the gate) and is deleted. `MAX_RESULT_BYTES` consumers (build-staleness smoke, governance pins) keep asserting the same constant — no literal drift.
- Footer stampers: `renderToolResultContract`'s production callers are the gate and the MCP dispatcher only; the #2800 roster sweep pins every registry tool's footer on both surfaces in the same change.
- Governance interaction (shape 36): the hook-await-bounds exemption was re-derived from the moved occurrence key, not regenerated by count.
- Per-block bounding is inherited from #2852 (each text block bounded independently); production results carry one text block (`renderToolText`). Recorded here, not changed.

## Observability

The footer (`bytes=` / `truncated=` on every delivered tool result, both surfaces) and the per-turn `cache_usage` row (`toolResultBytes` / `toolResultsTruncated`) are the surfaces. No new failure path; no record added. The diag-section bound drops surplus severity lines silently — recorded here rather than in a new record, since the delivered payload still carries the findings.

## Test assessment

- `tests/tools/render-compact.test.ts` — pin moved to the new footer format; +5: exact payload bytes (measured independently), oversized total ≤ budget incl. footer, isError verdict + bytes, reserve bounds, diag-section cap.
- `tests/config/result-contract-governance.test.ts` — parity-loop + pi-only regexes moved; oversized wrapper test extended (bytes present, ≤ budget, `truncated=true`, footer included ≤ budget); +2: exact delivered bytes on both real surfaces, real `cache_usage` row summing the turn's calls from the real sink.
- `tests/mcp/server.smoke.test.ts` — two footer regexes moved (unknown-tool + retired-dump error paths).
- `tests/mcp/build-staleness.smoke.test.ts` — oversized stale cell extended (footer format, `truncated=true`, warning precedes footer, bytes ≤ budget); ordering comment updated to the #2800 order.
- `tests/clients/cache-observability.test.ts` — full-metadata pin gained the two keys; +3 recorder tests (sum of two, truncated count + turn-boundary reset, saturation + negative clamp).
- `tests/config/hook-await-bounds.test.ts` — `mcp/server.ts#handleRequest` callTool await occurrence key re-derived after the reorder.

Kept: per-block bounding from #2852; `boundToolText`'s default budget and the complete-log branch unchanged; MCP stamps the footer only (the row is pi's `message_end` product); no tool descriptions changed (roster pin untouched); `finalizeToolResult`'s signature unchanged for its remaining callers.

## Preflight

```
| gate                      | mirrored CI job                | pass/fail | first red line |
| ------------------------- | ------------------------------ | --------- | -------------- |
| build                     | Lint & type-check              | pass      |                |
| lint                      | Lint & type-check              | pass      |                |
| fmt:check                 | oxfmt format check             | pass      |                |
| changelog:check           | Unit tests                     | pass      |                |
| check-changelog-fragments | Changelog fragment (fast-fail) | pass      |                |
| check:lockfile            | Lint & type-check              | pass      |                |
| lockfile:complete         | Lint & type-check              | pass      |                |
| tests/config              | Unit tests                     | pass      |                |
| generation-guard          | Unit tests                     | pass      |                |
| flake-shape-ratchet       | Unit tests                     | pass      |                |
| lsp-spawn-heavy-coverage  | Unit tests                     | pass      |                |
| ci-verdict                | Unit tests                     | pass      |                |
| knip                      | knip (advisory)                | pass      |                |
| check-pr-title            | PR title                       | pass      |                |
| check-close-keywords      | Close-keyword syntax           | pass      |                |
| check-pr-body             | PR body (advisory)             | pass      |                |
```


## Round 2

Review verdict: merge after fixes (F1 MEDIUM re-entry bound skipped; F2 LOW vacuous reserve pin; F3 LOW changelog precondition). Fixer round cut off by the backend weekly limit after the code landed; the orchestrator finished the handoff.

- **F1 — fixed.** `finalizeToolResultWithDelivery` re-entry: a stamped result within `MAX_RESULT_BYTES` is kept as delivered and reports the kept footer's own `bytes=`/`truncated=` (parsed from the footer, never a footer-inclusive re-measure nor a hard-coded `false`); an oversized pre-stamped result is bounded on re-entry. Tests: "keeps a fitting stamped result untouched on re-entry and reports the footer's own figures" and "bounds an oversized pre-stamped result on re-entry" in `tests/tools/render-compact.test.ts`.
- **F2 — fixed.** `RESULT_FOOTER_RESERVE_BYTES` is pinned to the exact byte count of the footer's widest literal (`tests/tools/render-compact.test.ts:211`).
- **F3 — fixed.** The changelog bullet carries the single-text-block precondition.

Ran on the handoff tree (orchestrator): build; tests/tools, tests/mcp, tests/clients/mcp, tests/clients/cache-observability, every tests/config file, tests/index-integration — 100 files, 1,150 passed, 1 skipped; fmt:check clean after formatting the test file; tsc clean. No new failure path; no record added.
