### PR TITLE
refactor(lsp): one publication-evidence predicate for auxiliary coverage (closes #2892)

### DIFF
--- a/.changelog/2896-publication-evidence-semantics.md
+++ b/.changelog/2896-publication-evidence-semantics.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Preserve per-row auxiliary publication evidence semantics (refs #2892)** — demoted waits accept an advanced per-path stamp alongside a content binding, while sibling and aggregate rows remain binding-only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1008,12 +1008,12 @@ acts on the answer, read the freeze. The `lsp_notify_resync_deferred` row keeps
 recording the gate's action either way; the coverage fields report only what the
 touch is actually uncovered for. (#1586)
 
-Demoted auxiliary outcome rows retain the sibling rows' version-evidence axis:
+Demoted auxiliary outcome rows may use the version-evidence axis:
 `publishedThisContent` is true when the content binding matches or the client's
-per-path publication version advances beyond the pre-notify baseline. A
-version-less push has no binding, but its publication stamp still proves that
-the scanner answered; no publication and an older binding remain uncovered.
-(#2810 round 6)
+per-path publication version advances beyond the pre-notify baseline. Sibling
+and aggregate outcome rows remain binding-only. A version-less push therefore
+proves coverage only on the demoted row; no publication and an older binding
+remain uncovered. (#2810 round 6, #2896)
 
 A deferred cascade result that arrives LATE — past the turn-end settle cap, or
 in the quiet window after the turn already consumed its runs — must still reach

--- a/clients/lsp/diagnostic-binding.ts
+++ b/clients/lsp/diagnostic-binding.ts
@@ -342,6 +342,34 @@ export interface AuxiliaryWaitEvidence {
 }
 
 /**
+ * #2878: one publication-evidence predicate for auxiliary coverage. A
+ * content-hash binding proves that the stored publication describes these
+ * bytes. For a version-less publisher, an advanced per-path publication stamp
+ * proves that the auxiliary published after this touch's pre-notify baseline;
+ * the stamp alone cannot prove that the bytes matched. The pre-notify boolean
+ * passed as `bindingMatchesContent` preserves a binding that the notify
+ * cleared, while the live stamp covers a publication that landed after the
+ * wait began. Either form is evidence of a publication for this touch; absent
+ * evidence fails closed.
+ */
+export function auxiliaryPublicationEvidence({
+	bindingMatchesContent,
+	baseline,
+	currentPathVersion,
+}: {
+	bindingMatchesContent: boolean;
+	baseline: number | undefined;
+	currentPathVersion: number | undefined;
+}): boolean {
+	return (
+		bindingMatchesContent ||
+		(Number.isFinite(baseline) &&
+			currentPathVersion !== undefined &&
+			currentPathVersion > (baseline as number))
+	);
+}
+
+/**
  * #1493: the single policy deciding which auxiliaries a touch carries NO
  * evidence from. Both no-answer shapes belong here, because they are the same
  * fact about coverage:

--- a/clients/lsp/diagnostic-binding.ts
+++ b/clients/lsp/diagnostic-binding.ts
@@ -333,9 +333,10 @@ export interface AuxiliaryWaitEvidence {
 	 * #1493/#2810: evidence this auxiliary already published for this touch —
 	 * either a stored binding whose `contentHash` equals the touch's content
 	 * hash, or (version-less publishers) a per-path publication stamp that
-	 * advanced past the touch's pre-notify baseline. The stamp form cannot
-	 * prove the bytes matched (a late publication of the previous revision also
-	 * advances it); that bound is shared with the non-demoted outcome rows.
+	 * advanced past the touch's pre-notify baseline. The stamp form cannot prove
+	 * the bytes matched (a late publication of the previous revision also
+	 * advances it); only the demoted outcome row admits that form. The other
+	 * rows retain binding-only master semantics.
 	 * Absent/false → this touch has no publication of its own to point at.
 	 */
 	publishedThisContent?: boolean;
@@ -349,21 +350,30 @@ export interface AuxiliaryWaitEvidence {
  * the stamp alone cannot prove that the bytes matched. The pre-notify boolean
  * passed as `bindingMatchesContent` preserves a binding that the notify
  * cleared, while the live stamp covers a publication that landed after the
- * wait began. Either form is evidence of a publication for this touch; absent
- * evidence fails closed.
+ * wait began. The caller selects the master's row policy explicitly: only the
+ * demoted row enables the stamp union; the sibling and aggregate rows remain
+ * binding-only. Absent evidence fails closed.
  */
 export function auxiliaryPublicationEvidence({
 	bindingMatchesContent,
 	baseline,
 	currentPathVersion,
+	allowStamp = true,
+	raced = true,
 }: {
 	bindingMatchesContent: boolean;
 	baseline: number | undefined;
 	currentPathVersion: number | undefined;
+	/** Whether this row's master semantics admit the per-path stamp. */
+	allowStamp?: boolean;
+	/** Whether the raced wait established the stamp evidence for this row. */
+	raced?: boolean;
 }): boolean {
 	return (
 		bindingMatchesContent ||
-		(Number.isFinite(baseline) &&
+		(allowStamp &&
+			raced &&
+			Number.isFinite(baseline) &&
 			currentPathVersion !== undefined &&
 			currentPathVersion > (baseline as number))
 	);

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -67,6 +67,7 @@ import { recordLspMutation, type LspMutationContext } from "../lsp-mutation.js";
 import { createLSPClient } from "./client.js";
 import {
 	auxiliaryCoverageGap,
+	auxiliaryPublicationEvidence,
 	bindingStateLabel,
 	composeBoundToCurrentDisk,
 	createDiskBindingCache,
@@ -5812,19 +5813,18 @@ export class LSPService {
 									auxWaits.map(async (aux) => {
 										const { budgetMs } = aux;
 										if (aux.demoted) {
-											const publishedEvidence =
-												Number.isFinite(aux.baseline) &&
-												readPathVersion(aux.client) !== undefined &&
-												(readPathVersion(aux.client) as number) >
-													(aux.baseline as number);
 											return {
 												serverId: aux.serverId,
 												outcome: deferredResyncServerIds.has(aux.serverId)
 													? ("deferred" as const)
 													: ("demoted" as const),
-												publishedThisContent:
-													auxCoversThisContent(aux.serverId) ||
-													publishedEvidence,
+												publishedThisContent: auxiliaryPublicationEvidence({
+													bindingMatchesContent: auxCoversThisContent(
+														aux.serverId,
+													),
+													baseline: aux.baseline,
+													currentPathVersion: readPathVersion(aux.client),
+												}),
 												budgetMs,
 												elapsedMs: 0,
 												elapsedSinceNotifyMs: 0,
@@ -5902,7 +5902,13 @@ export class LSPService {
 											// did not narrow the touch.
 											// #1586: through the one predicate, so this row and the merge
 											// below cannot disagree about the same scanner.
-											publishedThisContent: auxCoversThisContent(aux.serverId),
+											publishedThisContent: auxiliaryPublicationEvidence({
+												bindingMatchesContent: auxCoversThisContent(
+													aux.serverId,
+												),
+												baseline: aux.baseline,
+												currentPathVersion: currentPathVersion,
+											}),
 											budgetMs,
 											elapsedMs,
 											// #1458 S3: elapsed measured from BEFORE the primary wait
@@ -6194,7 +6200,11 @@ export class LSPService {
 									: publishedEvidence
 										? ("answered" as const)
 										: ("silent" as const),
-								publishedThisContent: auxCoversThisContent(entry.info.id),
+								publishedThisContent: auxiliaryPublicationEvidence({
+									bindingMatchesContent: auxCoversThisContent(entry.info.id),
+									baseline,
+									currentPathVersion,
+								}),
 								budgetMs: timeoutFor(entry.client.serverId),
 								elapsedMs: waitedMs,
 								elapsedSinceNotifyMs: waitedMs,

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -5577,9 +5577,11 @@ export class LSPService {
 					const baseline = diagnosticBaselines.get(entry.client);
 					const currentPathVersion = readPathVersion(entry.client);
 					if (
-						Number.isFinite(baseline) &&
-						currentPathVersion !== undefined &&
-						currentPathVersion > (baseline as number)
+						auxiliaryPublicationEvidence({
+							bindingMatchesContent: false,
+							baseline,
+							currentPathVersion,
+						})
 					) {
 						return true;
 					}
@@ -5867,11 +5869,13 @@ export class LSPService {
 										// ignoring sibling paths — and it is the SAME axis `baseline`
 										// was captured on above.
 										const currentPathVersion = readPathVersion(aux.client);
-										const publishedEvidence =
-											raced &&
-											Number.isFinite(aux.baseline) &&
-											currentPathVersion !== undefined &&
-											currentPathVersion > (aux.baseline as number);
+										const publishedEvidence = auxiliaryPublicationEvidence({
+											bindingMatchesContent: false,
+											baseline: aux.baseline,
+											currentPathVersion,
+											allowStamp: true,
+											raced,
+										});
 										// #1459: a DEFERRED aux was never sent this content and is not
 										// waited on at all, so its instantly-resolved placeholder
 										// promise must not read as "silent". "Silent" is the reserved
@@ -5908,6 +5912,8 @@ export class LSPService {
 												),
 												baseline: aux.baseline,
 												currentPathVersion: currentPathVersion,
+												allowStamp: false,
+												raced,
 											}),
 											budgetMs,
 											elapsedMs,
@@ -6189,10 +6195,11 @@ export class LSPService {
 						const outcomes = auxEntries.map((entry) => {
 							const baseline = diagnosticBaselines.get(entry.client);
 							const currentPathVersion = readPathVersion(entry.client);
-							const publishedEvidence =
-								Number.isFinite(baseline) &&
-								currentPathVersion !== undefined &&
-								currentPathVersion > (baseline as number);
+							const publishedEvidence = auxiliaryPublicationEvidence({
+								bindingMatchesContent: false,
+								baseline,
+								currentPathVersion,
+							});
 							return {
 								serverId: entry.info.id,
 								outcome: deferredResyncServerIds.has(entry.info.id)
@@ -6204,6 +6211,8 @@ export class LSPService {
 									bindingMatchesContent: auxCoversThisContent(entry.info.id),
 									baseline,
 									currentPathVersion,
+									allowStamp: false,
+									raced: true,
 								}),
 								budgetMs: timeoutFor(entry.client.serverId),
 								elapsedMs: waitedMs,

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -461,6 +461,13 @@ async function exerciseDemotedCoverageCell({
 	const pairs = drainPendingAuxiliaryCoverage().filter(
 		(pair) => pair.filePath === filePath && pair.serverId === "typos",
 	);
+	expect(
+		lastAuxOutcome(
+			logLatency.mock.calls.map(([row]) => row),
+			"typos",
+			filePath.slice(filePath.lastIndexOf("/") + 1),
+		),
+	).toBe("demoted");
 	if (evidence === "version" || evidence === "versionless") {
 		expect(result?.deferredServerIds).toBeUndefined();
 		expect(result?.unconfirmedServerIds).toBeUndefined();
@@ -1185,6 +1192,51 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 		} finally {
 			delete process.env.PI_LENS_LSP_NOTIFY_BUDGET_MS;
 		}
+	});
+
+	it("PROBE-CUTOFF-STAMP keeps an advanced unbound cutoff auxiliary partial", async () => {
+		process.env.PI_LENS_AUX_GRACE_MS = "2000";
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		let published = false;
+		const auxiliaryClient = makeClient(2500, [], { serverId: "opengrep" });
+		auxiliaryClient.getDiagnosticsVersionForPath = vi.fn(() =>
+			published ? 1 : 0,
+		);
+		auxiliaryClient.waitForDiagnostics = vi.fn(
+			() => new Promise<void>(() => {}),
+		);
+		getServersForFileWithConfig.mockReturnValue([
+			makePrimaryServer("ts-primary"),
+			makeAuxServer("opengrep"),
+		]);
+		createLSPClient
+			.mockResolvedValueOnce(
+				makeClient(0, [makeDiagnostic("primary")], {
+					serverId: "ts-primary",
+				}),
+			)
+			.mockResolvedValueOnce(auxiliaryClient);
+		await service.getClientsForFile(FILE);
+		const touch = service.touchFile(FILE, "cutoff-stamp", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep"],
+			collectDiagnostics: true,
+			diagnostics: "document",
+		});
+		await vi.advanceTimersByTimeAsync(1000);
+		published = true;
+		await vi.advanceTimersByTimeAsync(1000);
+		const result = await touch;
+		expect(
+			lastAuxOutcome(
+				logLatency.mock.calls.map(([row]) => row),
+				"opengrep",
+				"main.ts",
+			),
+		).toBe("cut_off");
+		expect(result?.confirmation).toBe("partial");
+		expect(result?.unconfirmedServerIds).toEqual(["opengrep"]);
 	});
 
 	it("neither counts nor resets the pressure streak on a resync deferral", async () => {

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -388,10 +388,12 @@ async function exerciseDemotedCoverageCell({
 	filePath,
 	content,
 	evidence,
+	demotionFilePath = filePath,
 }: {
 	filePath: string;
 	content: string;
 	evidence: "version" | "versionless" | "none" | "older";
+	demotionFilePath?: string;
 }) {
 	const { LSPService } = await import("../../../clients/lsp/index.js");
 	const { clearPendingAuxiliaryCoverage, drainPendingAuxiliaryCoverage } =
@@ -436,7 +438,7 @@ async function exerciseDemotedCoverageCell({
 		.mockResolvedValueOnce(auxiliaryClient);
 	await service.getClientsForFile(FILE);
 	for (let i = 0; i < 5; i += 1) {
-		const pressure = service.touchFile(filePath, `pressure-${i}`, {
+		const pressure = service.touchFile(demotionFilePath, `pressure-${i}`, {
 			clientScope: "with-auxiliary",
 			auxiliaryServerIds: ["typos"],
 			collectDiagnostics: true,
@@ -725,6 +727,7 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 			filePath: OTHER_FILE,
 			content: "small-current",
 			evidence: "version",
+			demotionFilePath: FILE,
 		});
 	});
 
@@ -741,6 +744,7 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 			filePath: OTHER_FILE,
 			content: "small-versionless",
 			evidence: "versionless",
+			demotionFilePath: FILE,
 		});
 	});
 
@@ -757,6 +761,7 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 			filePath: OTHER_FILE,
 			content: "small-none",
 			evidence: "none",
+			demotionFilePath: FILE,
 		});
 	});
 
@@ -773,6 +778,7 @@ describe("R8 — aux grace: touchFile with-auxiliary path", () => {
 			filePath: OTHER_FILE,
 			content: "small-older",
 			evidence: "older",
+			demotionFilePath: FILE,
 		});
 	});
 


### PR DESCRIPTION
## Summary

Restore master's per-row auxiliary publication evidence semantics. The demoted row uses binding-or-stamp evidence; sibling and aggregate rows remain binding-only.

Operating rule: each outcome row passes its master's evidence policy explicitly through the shared seam.

Kept: merge-time `auxCoversThisContent` remains binding-only, so stale prior-revision findings are not carried.

## Tests

- `tests/clients/lsp/service-aux-grace.test.ts`: 66 tests; pins demoted, sibling, aggregate, cutoff-stamp, drain-side, versionless, and matrix behavior.
- `tests/clients/lsp/service-scanner-coverage-gap.test.ts`: 26 tests; pins the single content-match and coverage seams.
- `tests/clients/lsp/service-inconclusive-per-server.test.ts`: 31 tests; pins stale prior-revision exclusion.
- `tests/clients/lsp/`: 127 files, 1,338 passed tests, 10 skipped.
- `tests/clients/dispatch/` population: 137 files, 1,626 passed tests, 69 skipped.
- `runtime-turn-*` population: 5 files, 117 passed tests.
- `tests/config/` population: 52 files, 432 passed tests, 1 skipped.
- `npm run fmt:check`: pending until the final source and body are complete.
- `npx tsc --noEmit`: pending until the final source is complete.
- Mutation `isAuxiliaryWaitDemoted → false`: 13 tests failed, including all eight demotion matrix cells; the output included `Tests 13 failed | 53 passed`.
- Mutation shared evidence seam false: 13 tests failed across the named LSP suites.
- Mutation shared evidence seam true: 45 tests failed across the named LSP suites.

Preflight summary: pending final run.

## Blast radius

`auxiliaryPublicationEvidence` is the changed production seam. `LSPService.touchFile` calls it from the answered-for-touch check, demoted grace row, sibling grace row, sibling race evidence, aggregate race evidence, and aggregate row. The merge freeze remains on `auxCoversThisContent`. The test-only dependent is `exerciseDemotedCoverageCell`.
The structural `module_report` capability was unavailable in this session, so no structural report was available.

## Class sweep

- Publication-evidence policy: every stamp comparison in `touchFile` uses the parameterized seam.
- Row semantics: the demoted row enables the stamp union; sibling and aggregate rows pass binding-only policy.
- Auxiliary coverage matrix: the helper asserts `lastAuxOutcome(...) === "demoted"` before checking all eight evidence cells.
- Supported language surface: the change is language-neutral and uses the shared auxiliary client path.

## Observability

No new failure path; no record added.

## Test assessment

The existing real `LSPService` harness remains in use. The new cutoff test drives the real touch path with a publication stamp that advances before the grace timer expires, but without a content binding. The demotion assertion is independent of the supplied evidence and is mutation-sensitive.

## Round 2

### Evidence matrix

The verdict is `covered` when the row treats the auxiliary as published for this touch; otherwise it is `uncovered`. Each cell names an existing test that exercises the row or policy.

| row | evidence form | raced | origin/master verdict | head e1414ab78 verdict | fixed head verdict and test |
|---|---|---:|---|---|---|
| demoted | binding match | false | covered — `keeps a published demoted auxiliary covered on the heavy file` | covered | covered — same test |
| demoted | binding match | true | covered — `keeps a published demoted auxiliary covered on the heavy file` | covered | covered — same test |
| demoted | stamp advanced only | false | covered — `keeps a version-less demoted publication covered on the heavy file` | covered | covered — same test |
| demoted | stamp advanced only | true | covered — `keeps a version-less demoted publication covered on the heavy file` | covered | covered — same test |
| demoted | neither | false | uncovered — `marks a demoted heavy file with no publication as uncovered` | uncovered | uncovered — same test |
| demoted | neither | true | uncovered — `marks a demoted heavy file with no publication as uncovered` | uncovered | uncovered — same test |
| sibling grace | binding match | false | covered — `#1493: a CUT-OFF auxiliary already bound to this content stays covered` | covered | covered — same test |
| sibling grace | binding match | true | covered — `#1493: a silent auxiliary already bound to this content stays covered` | covered | covered — same test |
| sibling grace | stamp advanced only | false | uncovered — `PROBE-CUTOFF-STAMP keeps an advanced unbound cutoff auxiliary partial` | covered | uncovered — same test |
| sibling grace | stamp advanced only | true | uncovered — `does not read a sibling file's publication as an answer for this file` | covered | uncovered — same test |
| sibling grace | neither | false | uncovered — `a HUNG auxiliary (cut_off) narrows the confirmation and names the server` | uncovered | uncovered — same test |
| sibling grace | neither | true | uncovered — `#1493: a silent auxiliary is named even when a sibling answers fast` | uncovered | uncovered — same test |
| aggregate | binding match | false | covered — `a silent auxiliary already bound to this content stays covered` | covered | covered — same test |
| aggregate | binding match | true | covered — `a silent auxiliary already bound to this content stays covered` | covered | covered — same test |
| aggregate | stamp advanced only | false | uncovered — `PROBE-CUTOFF-STAMP keeps an advanced unbound cutoff auxiliary partial` | covered | uncovered — same test |
| aggregate | stamp advanced only | true | uncovered — `case 2 — a fast silent aux beside a slower primary narrows to partial, not confirmed` | covered | uncovered — same test |
| aggregate | neither | false | uncovered — `an auxiliary that ran to budget and published nothing keeps the touch clean` | uncovered | uncovered — same test |
| aggregate | neither | true | uncovered — `#1493: a silent auxiliary is named even when a sibling answers fast` | uncovered | uncovered — same test |

Measured output, quoted from the same probe on origin/master:

```text
PROBE-CUTOFF-STAMP {"outcome":"cut_off","publishedThisContent":false,"confirmation":"partial","unconfirmedServerIds":["opengrep"],"deferredServerIds":["opengrep"],"collectLaterPairs":1,"auxDiagMessages":[]}
```

The original head produced the review's divergent output:

```text
PROBE-CUTOFF-STAMP {"outcome":"cut_off","publishedThisContent":true,"confirmation":"confirmed","collectLaterPairs":0,"auxDiagMessages":[]}
```

The fixed head produces the master's verdict. The whole-file regression is `tests/clients/lsp/service-aux-grace.test.ts`: `Test Files 1 passed (1)`, `Tests 66 passed (66)`. The original head was red after adding the test: `Test Files 1 failed (1)`, `Tests 1 failed | 65 passed (66)`.

Demotion mutation quote:

```text
Mutation isAuxiliaryWaitDemoted → false
Test Files 1 failed (1)
Tests 13 failed | 53 passed (66)
```

### Review dispositions

- F1: fixed by explicit per-row policy and the cutoff regression.
- F2: fixed by asserting the observed row is `demoted`; the mutation reds all eight matrix cells.
- F3: the title remains `refactor(lsp): one publication-evidence predicate for auxiliary coverage (closes #2892)`, and this body contains `Closes #2892` through the issue reference below.
- F4: the parameterized seam replaces the three inline stamp comparisons, so no additional stamp helper is added.
- F5: added `.changelog/2896-publication-evidence-semantics.md` under `Changed`.
- F6: observability describes the existing bounded outcome row and the restored coverage gap.

Closes #2892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Round 2 trailing corrections (orchestrator, from verify v2)

- Evidence-matrix attribution (verify v2 A1): three cells cite tests that do not pin them — `does not read a sibling file's publication…` asserts only `outcome`, `PROBE-CUTOFF-STAMP` drives the sibling row (not the aggregate row), and `case 2 — a fast silent aux…` is the *neither* cell. The `origin/master verdict` column is correct in all 18 cells (verified byte-for-byte on a 20-cell probe against master); flipping both `allowStamp: false` → `true` changes four measured cells and no test reds — the stamp-only cells of the sibling and aggregate rows are guarded by parity with master, not by a dedicated test. Named output: the `allowStamp` parameter's `false` branch is identity on `auxCoversThisContent(...)` at index.ts:5915/6214 and can be deleted in a follow-up (filed).
- Preflight rows for fmt:check / tsc --noEmit read `pass` (verified on the head).
