### PR TITLE
chore(hooks): pre-commit refuses handoff files (refs #2807)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,11 @@ if [ -n "$PI_LENS_SKIP_HOOKS" ]; then
   exit 0
 fi
 
+# Handoff files never enter history (pi-lens #2807; 2026-09-10: four lanes
+# committed PR_BODY.md and redded gitignore-tracked-shadow in CI).
+if git diff --cached --name-only | grep -qE '(^|/)(PR_BODY\.md|COMMIT_MSG\.txt|REVIEW\.md|INVESTIGATION\.md|MONITOR\.md)$'; then
+  echo "[pre-commit] refusing to commit a handoff file (PR_BODY.md / COMMIT_MSG.txt / REVIEW.md / INVESTIGATION.md / MONITOR.md); git rm --cached it." >&2
+  exit 1
+fi
+
 npm run check:lockfile && npm run changelog:check && npm run lint


### PR DESCRIPTION
## Summary

`.husky/pre-commit` refuses a commit whose index holds a handoff file (`PR_BODY.md`, `COMMIT_MSG.txt`, `REVIEW.md`, `INVESTIGATION.md`, `MONITOR.md`). Four lanes on 2026-09-10 (#2860, #2876, #2877, #2895) committed `PR_BODY.md` despite the fixer contract and redded `gitignore-tracked-shadow` in CI; the orchestrator's index check (a user-level hook) does not run for plegma/Claude workers, so the repo hook is the only mechanism every worker shares. Refs #2807.

## Tests

Red-first on this branch: `git add -f PR_BODY.md && git commit` → `[pre-commit] refusing to commit a handoff file …`, exit 1 (the message counted once). Green: the real commit of this change passed the hook (check:lockfile, changelog:check, lint). No vitest suite covers husky hooks; CI on this head is the remaining gate.

## Blast radius

`.husky/pre-commit` only; every local commit path. `PI_LENS_SKIP_HOOKS` still bypasses it as before.

## Class sweep

The five handoff names match `~/.claude/hooks/commit-index-check.mjs`'s `FORBIDDEN` list and the `gitignore-tracked-shadow` sweep's targets; no other handoff file name exists in AGENTS.md.

## Observability

No new failure path; no record added.

## Test assessment

No test files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
