### PR TITLE
fix(dispatch): helm-lint resolves its cwd through resolveRunnerCwd (closes #2882)

### DIFF
--- a/.changelog/fix-2882-helm-lint-runner-cwd.md
+++ b/.changelog/fix-2882-helm-lint-runner-cwd.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Route helm-lint through the runner cwd resolver (closes #2882)** — Helm lint now runs with the cwd selected by the shared dispatch runner seam.

--- a/clients/dispatch/runners/helm-lint.ts
+++ b/clients/dispatch/runners/helm-lint.ts
@@ -3,6 +3,7 @@ import { PathKeyedMap } from "../../path-keyed-map.js";
 import { normalizeMapKey } from "../../path-utils.js";
 import { safeSpawnAsync } from "../../safe-spawn.js";
 import { truncatedByOutputCap } from "../../spawn-output-cap.js";
+import { resolveRunnerCwd } from "../../tool-cwd.js";
 import { findNearestDirWithMarker } from "../../workspace-topology.js";
 import { PRIORITY } from "../priorities.js";
 import type {
@@ -201,6 +202,7 @@ const helmLintRunner: RunnerDefinition = {
 	timeoutMs: 35_000,
 
 	async run(ctx: DispatchContext): Promise<RunnerResult> {
+		const cwd = resolveRunnerCwd(ctx, "helm");
 		const workspaceRoot = path.resolve(ctx.projectRoot ?? ctx.cwd);
 		const startDir = path.dirname(path.resolve(ctx.filePath));
 		const discovered = findNearestDirWithMarker(startDir, "chartYamlPath");
@@ -209,7 +211,7 @@ const helmLintRunner: RunnerDefinition = {
 		if (!isWithin(workspaceRoot, chartRoot)) return SKIPPED;
 		const existing = inFlightByChartRoot.get(chartRoot);
 		if (existing) return existing;
-		const promise = lintChart(chartRoot, ctx.cwd).finally(() => {
+		const promise = lintChart(chartRoot, cwd).finally(() => {
 			if (inFlightByChartRoot.get(chartRoot) === promise)
 				inFlightByChartRoot.delete(chartRoot);
 		});

--- a/tests/clients/dispatch/runners/helm-lint.test.ts
+++ b/tests/clients/dispatch/runners/helm-lint.test.ts
@@ -4,6 +4,12 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DispatchContext } from "../../../../clients/dispatch/types.js";
 import {
+	createDispatchContext,
+	dispatchForFile,
+	RunnerRegistry,
+} from "../../../../clients/dispatch/dispatcher.js";
+import { FactStore } from "../../../../clients/dispatch/fact-store.js";
+import {
 	capFastExitSpawnResult,
 	capKilledSpawnResult,
 	capThenAbortedSpawnResult,
@@ -122,6 +128,44 @@ describe("helm-lint runner", () => {
 				resourceLabel: "helm-lint",
 			}),
 		);
+	});
+
+	it("passes the resolved cwd through the real dispatcher for a nested chart", async () => {
+		const projectRoot = fs.mkdtempSync(
+			path.join(os.homedir(), "pi-lens-helm-dispatch-"),
+		);
+		try {
+			const callerCwd = path.join(projectRoot, "caller");
+			const chartRoot = path.join(projectRoot, "project", "charts", "child");
+			const filePath = createChart(chartRoot, "templates/deployment.yaml");
+			fs.mkdirSync(callerCwd, { recursive: true });
+
+			const registry = new RunnerRegistry();
+			registry.register(helmLintRunner);
+			const ctx = createDispatchContext(
+				filePath,
+				callerCwd,
+				{ getFlag: () => false },
+				new FactStore(),
+				undefined,
+				undefined,
+				projectRoot,
+			);
+
+			await dispatchForFile(
+				ctx,
+				[{ mode: "all", runnerIds: ["helm-lint"] }],
+				registry,
+			);
+
+			expect(safeSpawnAsync).toHaveBeenCalledWith(
+				"helm",
+				["lint", path.resolve(chartRoot)],
+				expect.objectContaining({ cwd: path.dirname(filePath) }),
+			);
+		} finally {
+			fs.rmSync(projectRoot, { recursive: true, force: true });
+		}
 	});
 
 	it("deduplicates concurrent edits by canonical chart root", async () => {

--- a/tests/clients/dispatch/runners/helm-lint.test.ts
+++ b/tests/clients/dispatch/runners/helm-lint.test.ts
@@ -132,13 +132,20 @@ describe("helm-lint runner", () => {
 
 	it("passes the resolved cwd through the real dispatcher for a nested chart", async () => {
 		const projectRoot = fs.mkdtempSync(
-			path.join(os.homedir(), "pi-lens-helm-dispatch-"),
+			path.join(os.tmpdir(), "pi-lens-helm-dispatch-"),
 		);
 		try {
 			const callerCwd = path.join(projectRoot, "caller");
 			const chartRoot = path.join(projectRoot, "project", "charts", "child");
 			const filePath = createChart(chartRoot, "templates/deployment.yaml");
 			fs.mkdirSync(callerCwd, { recursive: true });
+			fs.mkdirSync(path.join(projectRoot, "project", ".git"), {
+				recursive: true,
+			});
+			fs.writeFileSync(
+				path.join(projectRoot, "project", ".git", "HEAD"),
+				"ref: refs/heads/main\n",
+			);
 
 			const registry = new RunnerRegistry();
 			registry.register(helmLintRunner);
@@ -161,7 +168,7 @@ describe("helm-lint runner", () => {
 			expect(safeSpawnAsync).toHaveBeenCalledWith(
 				"helm",
 				["lint", path.resolve(chartRoot)],
-				expect.objectContaining({ cwd: path.dirname(filePath) }),
+				expect.objectContaining({ cwd: path.join(projectRoot, "project") }),
 			);
 		} finally {
 			fs.rmSync(projectRoot, { recursive: true, force: true });

--- a/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
+++ b/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
@@ -713,18 +713,13 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 		"cwd is runScan's own `cwd` parameter, the directory `trivy fs` is pointed at",
 	],
 ];
-const MIGRATION_WORKLIST_ROWS: ReadonlyArray<readonly [string, string]> = [
-	[
-		"clients/dispatch/runners/helm-lint.ts#run:833aee95~833aee95",
-		'#2882: helm-lint\'s run() reads `ctx.cwd` directly instead of resolveRunnerCwd(ctx, "helm") — the one runner still bypassing the #2777 seam, and this row retires when that lands',
-	],
-];
+const MIGRATION_WORKLIST_ROWS: ReadonlyArray<readonly [string, string]> = [];
 /**
  * The worklist can only shrink. Lower this when a row lands; never raise it —
  * a new non-conforming site belongs in one of the two reasoned tables above,
  * or gets fixed.
  */
-const WORKLIST_CEILING = 1;
+const WORKLIST_CEILING = 0;
 /** See the comment on the `beforeAll` below for where this number comes from. */
 const SCAN_HOOK_TIMEOUT_MS = 30_000;
 


### PR DESCRIPTION
## Summary

Closes #2882. Helm lint now resolves its child-process cwd through `resolveRunnerCwd(ctx, "helm")`, matching every sibling dispatch runner. The migration worklist row is retired, and its ceiling decreases from one to zero.

The real dispatcher regression uses a chart below a project root and a caller cwd outside that tree. Before the fix, Helm received the caller directory. After the fix, Helm receives the nested chart file directory.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [x] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [x] I have read CONTRIBUTING.md and AGENTS.md
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files pass locally after `npm run build`
- [x] The regression test is proven RED on pre-fix code
- [x] The cwd guard is mutation-proof
- [x] PR title carries the conventional prefix and issue reference
- [x] `npm run fmt:check` and `npx tsc --noEmit` pass
- [x] The changelog fragment has one Fixed entry

## Tests

- `tests/clients/dispatch/runners/helm-lint.test.ts`: added `passes the resolved cwd through the real dispatcher for a nested chart`; it drives the real dispatcher and pins the independent spawn options cwd [test file](tests/clients/dispatch/runners/helm-lint.test.ts). Pre-fix result: `1 failed | 15 passed`; received `cwd: .../caller`, expected `cwd: .../project`. Fixed result: `16 passed` [review evidence](REVIEW.md).
- `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts`: edited the migration population and ceiling; the stale-row proof failed with `1 exemption(s) name an item the scan no longer flags` for `clients/dispatch/runners/helm-lint.ts#run`, and the fixed sweep passed `8 tests`.

The regression test uses the real in-process dispatcher and runner. Safe spawn and availability remain process-boundary mocks. It covers the wrong-layer pin and independent observable screens.

### Test assessment

- `helm-lint.test.ts` uniquely covers Helm output parsing and runner outcomes; the new dispatcher test adds the cwd regression proof and makes no existing test redundant.
- `runner-spawn-cwd-sweep.test.ts` uniquely covers whole-tree cwd population and worklist liveness; the row and ceiling edits retire one completed migration item.

## Blast radius

The touched production module is `clients/dispatch/runners/helm-lint.ts`. Its entry point is the registered `helm-lint` runner, reached by the dispatch plans for YAML and Helm template files. The callback is the `lintChart(...).finally(...)` in-flight cleanup. The change only alters the cwd passed to availability resolution and `safeSpawnAsync`; chart discovery, deduplication, timeout, parsing, and result classification remain unchanged.

The repository's `module_report` tool is unavailable in this environment, so the structural blast-radius report is unavailable. The population sweep covers all recognized dispatch runner spawn sites. The cwd resolver adds one synchronous marker-resolution path per Helm runner invocation, matching sibling runners.

## Observability

covered by existing record `tool-cwd-resolution` at `clients/tool-cwd.ts:318` [runtime seam](clients/tool-cwd.ts). The seam also emits the bounded `cwd runner helm cwd=… reason=…` resolution record with subject `helm` [runtime seam](clients/tool-cwd.ts).

## Class sweep

This fixes the dispatch runner cwd-origin defect class, catalog shape 40, and the #2777 shared-seam migration [AGENTS.md](AGENTS.md). The whole-tree pattern sweep is `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts`; it scans the complete recognized runner population and passed `8 tests` after the fix [sweep test](tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts). The support detector sweep is `tests/support/spawn-cwd-scan.test.ts`, included in the required suite and passing [support sweep](tests/support/spawn-cwd-scan.test.ts).

The population sweep found the Helm `run` site as the final migration row. Removing the row made its stale-exemption check pass, and lowering `WORKLIST_CEILING` to zero ratchets the completed population. Consolidation verdict: dispatch runner cwd selection stays centralized in `resolveRunnerCwd`; no alias-resolution scanner changes are included because that is #2888.

Preflight result:

| gate | mirrored CI job | pass/fail | first red line |
| --- | --- | --- | --- |
| build | Lint & type-check | pass | |
| lint | Lint & type-check | pass | |
| fmt:check | oxfmt format check | pass | |
| changelog:check | Unit tests | pass | |
| check-changelog-fragments | Changelog fragment (fast-fail) | pass | |
| check:lockfile | Lint & type-check | pass | |
| lockfile:complete | Lint & type-check | pass | |
| tests/config | Unit tests | pass | |
| generation-guard | Unit tests | pass | |
| flake-shape-ratchet | Unit tests | pass | |
| lsp-spawn-heavy-coverage | Unit tests | pass | |
| ci-verdict | Unit tests | pass | |
| knip | knip (advisory) | pass | |

Operating rule: every dispatch runner passes a cwd selected by the shared runner cwd seam to its child process.

Kept: scanner alias resolution remains unchanged for #2888.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round 2

F1 is fixed by placing the dispatcher fixture under `os.tmpdir()`, creating a real `.git/HEAD` at `<projectRoot>/project`, and asserting the `git-root` cwd arm [test file](tests/clients/dispatch/runners/helm-lint.test.ts). The reviewer’s proven whole-file mutation result is `1 failed | 15 passed (16)` before the runtime fix and `16 passed (16)` with it [review evidence](REVIEW.md).

F2 is fixed by citing the existing bounded `tool-cwd-resolution` record at `clients/tool-cwd.ts:318` and correcting the class citation to catalog shape 40 [runtime seam](clients/tool-cwd.ts) [AGENTS.md](AGENTS.md).

Round 2 preflight result:

| gate | mirrored CI job | pass/fail | first red line |
| --- | --- | --- | --- |
| build | Lint & type-check | pass | |
| lint | Lint & type-check | pass | |
| fmt:check | oxfmt format check | pass | |
| changelog:check | Unit tests | pass | |
| check-changelog-fragments | Changelog fragment (fast-fail) | pass | |
| check:lockfile | Lint & type-check | pass | |
| lockfile:complete | Lint & type-check | pass | |
| tests/config | Unit tests | pass | |
| generation-guard | Unit tests | pass | |
| flake-shape-ratchet | Unit tests | pass | |
| lsp-spawn-heavy-coverage | Unit tests | pass | |
| ci-verdict | Unit tests | pass | |
| knip | knip (advisory) | pass | |

The standalone `tests/config` run passed `432 tests` with one skipped, and the final preflight passed all gates [test command result](tests/config).
