### PR TITLE
fix(rules): demote the TypeScript sql-injection rule from blocking error to warning (refs #2909)

### DIFF
--- a/.changelog/ts-sql-injection-demote.md
+++ b/.changelog/ts-sql-injection-demote.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **`sql-injection` (TypeScript tree-sitter rule) is a warning, not a blocking error.** The query keys on the callee name only (`query|execute|exec|run`), so any template literal passed to a same-named non-SQL function fired a blocking finding; it stays as a warning until the rule gains a receiver/type signal.

--- a/docs/tree-sitter_rules_catalog.md
+++ b/docs/tree-sitter_rules_catalog.md
@@ -218,7 +218,7 @@ Rule source: `rules/tree-sitter-queries/<language>/`.
 | `no-eval` | error | security | eval() detected — security risk, never use eval |
 | `no-jump-in-finally` | warning | bug | return/break/continue/throw in finally overrides the try/catch result and silently swallows exceptions |
 | `self-assignment` | error | reliability | '{{VAR}}' is assigned to itself |
-| `sql-injection` | error | security | SQL injection risk — use parameterized queries, never interpolate into SQL |
+| `sql-injection` | warning | security | SQL injection risk — use parameterized queries, never interpolate into SQL |
 | `switch-case-termination` | error | reliability | Switch case should end with break, return, throw, or continue |
 | `switch-non-case-labels-ts` | error | reliability | switch statements should not contain non-case labels |
 | `ts-command-injection` | error | security | Potential command injection sink — avoid child_process command execution with untrusted input |

--- a/rules/tree-sitter-queries/typescript/sql-injection.yml
+++ b/rules/tree-sitter-queries/typescript/sql-injection.yml
@@ -1,11 +1,15 @@
 # SQL Injection Detection
-# Detects unsafe interpolation in SQL-like template literals
+# Detects unsafe interpolation in SQL-like template literals.
+# Demoted from error/blocking to warning on 2026-09-10 (maintainer): the
+# query keys on the callee NAME only (query|execute|exec|run), so any
+# `run(`…${x}…`)` / `exec(`…`)` in non-SQL code fires — too many false
+# positives to block on. A real SQL sink needs a receiver/type signal.
 id: sql-injection
 name: SQL Injection Risk
-severity: error
+severity: warning
 category: security
 defect_class: injection
-inline_tier: blocking
+inline_tier: warning
 language: typescript
 
 message: "SQL injection risk — use parameterized queries, never interpolate into SQL"


### PR DESCRIPTION
## Summary

`rules/tree-sitter-queries/typescript/sql-injection.yml` drops from `severity: error` / `inline_tier: blocking` to `warning` / `warning`. Maintainer request (2026-09-10): the rule has fired as a false positive too many times. Root cause is the query itself — it matches any `call_expression` whose callee NAME is `query`, `execute`, `exec` or `run` with a template substitution in the arguments, so `run(`…${x}…`)` / `exec(`…`)` in non-SQL code (child processes, task runners) blocks. The rule keeps detecting the real shape; a receiver/type signal is the follow-up that would let it return to blocking.

## Tests

- `tests/clients/tree-sitter-slop-rules.test.ts`, `tests/clients/circular-deps-regression.test.ts`, `tests/clients/tree-sitter-security-gap-rules.test.ts` and every `tests/config` file: 55 files / 551 passed / 1 skipped on this head (none pins this rule's severity; the go/python sql-injection rules are untouched).
- Severity-only change to a data file: no red-first test applies; CI on the exact head is the gate.

## Blast radius

Rule data only. Consumers: the tree-sitter rule loader (severity → inline tier mapping) and the analyze/diagnostics counts, where this rule's findings move from blocking to warning.

## Class sweep

Other callee-name-only security rules in `rules/tree-sitter-queries/typescript/`: not audited here; the maintainer named this rule only.

## Observability

No new failure path; no record added.

## Test assessment

No test files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
