### PR TITLE
refactor(dispatch): probe and root spawn cwds resolve through shared seams (refs #2894)

### DIFF
--- a/.changelog/2894-probe-and-root-spawn-cwd.md
+++ b/.changelog/2894-probe-and-root-spawn-cwd.md
@@ -2,4 +2,4 @@
 section: Changed
 ---
 
-- **Tool probes and hand-derived package roots resolve through shared seams (refs #2894)** — a new `probeToolAsync` seam owns the "a presence/version probe never gets a `cwd`" contract for 24 spawn sites that each decided it locally, `rust-clippy` takes its package root from `resolveRunnerCwd` (with `Cargo.toml` registered as its runner marker) instead of an uncapped `findNearestContaining` walk, and `ruff-client`'s autofix resolves its config root through `resolveToolCwd` so a file in a nested package gets that package's `pyproject.toml` rather than the workspace one.
+- **Tool probes and hand-derived package roots resolve through shared seams (refs #2894)** — a `probeToolAsync` seam owns the "a presence/version probe never gets a `cwd`" contract for 23 spawn sites that each decided it locally, `rust-clippy` takes its package root from `resolveRunnerCwd` (with `Cargo.toml` registered as its runner marker) instead of an uncapped `findNearestContaining` walk, and `ruff-client`'s autofix resolves its config root through `resolveToolCwd` so a file in a nested package gets that package's `pyproject.toml` rather than the workspace one.

--- a/.changelog/2894-probe-and-root-spawn-cwd.md
+++ b/.changelog/2894-probe-and-root-spawn-cwd.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Tool probes and hand-derived package roots resolve through shared seams (refs #2894)** — a new `probeToolAsync` seam owns the "a presence/version probe never gets a `cwd`" contract for 24 spawn sites that each decided it locally, `rust-clippy` takes its package root from `resolveRunnerCwd` (with `Cargo.toml` registered as its runner marker) instead of an uncapped `findNearestContaining` walk, and `ruff-client`'s autofix resolves its config root through `resolveToolCwd` so a file in a nested package gets that package's `pyproject.toml` rather than the workspace one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1614,6 +1614,11 @@ package-manager/profile/package-root/session domains) require no cache layer.
 
 Tier-2 cache bounds (#1389) use the Tier-1 idle-timer/LRU shape where entries are rebuildable: reverse-dependency and topology entries clear their timers through one deletion helper, tree-sitter query caches use insertion-order LRU with query disposal. ReadGuard is the exception: its reads are behavior-gating state, so unconsumed reads are retained until edit or session end, subject to a high sanity cap that evicts oldest→needs-re-read; reads are never silently allowed post-eviction. Only consumed reads may be evicted at the compact file cap. Widget-state and Tier-3 cache bounds remain deferred.
 
+The marker-walk memo in `clients/tool-cwd.ts` caches positive roots only. A
+negative walk re-runs on the next lookup because a marker can be created
+during the session; negative root state must never make a runner silently
+skip newly scaffolded projects (#2894).
+
 ### Session lifecycle, telemetry, and observability
 
 The machine-global instance registry serializes every whole-file writer with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1615,9 +1615,10 @@ package-manager/profile/package-root/session domains) require no cache layer.
 Tier-2 cache bounds (#1389) use the Tier-1 idle-timer/LRU shape where entries are rebuildable: reverse-dependency and topology entries clear their timers through one deletion helper, tree-sitter query caches use insertion-order LRU with query disposal. ReadGuard is the exception: its reads are behavior-gating state, so unconsumed reads are retained until edit or session end, subject to a high sanity cap that evicts oldest→needs-re-read; reads are never silently allowed post-eviction. Only consumed reads may be evicted at the compact file cap. Widget-state and Tier-3 cache bounds remain deferred.
 
 The marker-walk memo in `clients/tool-cwd.ts` caches positive roots only. A
-negative walk re-runs on the next lookup because a marker can be created
-during the session; negative root state must never make a runner silently
-skip newly scaffolded projects (#2894).
+negative walk re-runs on the next lookup, so a marker created where NONE was
+found is seen on the next resolution (#2894). The other half of the axis is
+still open: a marker created BELOW a cached positive root is not seen until
+the session ends (#2922) — do not describe the class as closed.
 
 ### Session lifecycle, telemetry, and observability
 

--- a/clients/biome-client.ts
+++ b/clients/biome-client.ts
@@ -14,7 +14,8 @@ import * as path from "node:path";
 import { isFileKind } from "./file-kinds.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
 import { findGlobalBinary } from "./package-manager.js";
-import { probeToolAsync, safeSpawnAsync } from "./safe-spawn.js";
+import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync } from "./tool-probe.js";
 import { createSingleFlight } from "./single-flight.js";
 import { biomeConfigArgs } from "./tool-policy.js";
 import {

--- a/clients/biome-client.ts
+++ b/clients/biome-client.ts
@@ -14,7 +14,7 @@ import * as path from "node:path";
 import { isFileKind } from "./file-kinds.js";
 import { getGlobalPiLensDir } from "./file-utils.js";
 import { findGlobalBinary } from "./package-manager.js";
-import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync, safeSpawnAsync } from "./safe-spawn.js";
 import { createSingleFlight } from "./single-flight.js";
 import { biomeConfigArgs } from "./tool-policy.js";
 import {
@@ -210,7 +210,14 @@ export class BiomeClient {
 		let result: Awaited<ReturnType<typeof this.spawnBiomeAsync>>;
 		let hostStallMs: number;
 		try {
-			result = await this.spawnBiomeAsync(["--version"], PROBE_TIMEOUT_MS);
+			// The presence probe asks whether biome answers at all, so it goes
+			// through the probe seam (no cwd) rather than through
+			// `spawnBiomeAsync`, whose optional `cwd` exists for the analysis
+			// spawns that DO resolve a project config (#2894).
+			const { cmd, args: prefix } = await this.getBiomeBinary();
+			result = await probeToolAsync(cmd, [...prefix, "--version"], {
+				timeout: PROBE_TIMEOUT_MS,
+			});
 		} finally {
 			hostStallMs = sampler.stop();
 		}

--- a/clients/biome-client.ts
+++ b/clients/biome-client.ts
@@ -18,6 +18,7 @@ import { safeSpawnAsync } from "./safe-spawn.js";
 import { probeToolAsync } from "./tool-probe.js";
 import { createSingleFlight } from "./single-flight.js";
 import { biomeConfigArgs } from "./tool-policy.js";
+import { resolveToolCwd } from "./tool-cwd.js";
 import {
 	type ClientAvailabilityResult,
 	resolveManagedToolClient,
@@ -384,7 +385,9 @@ export class BiomeClient {
 
 		try {
 			const before = await fs.promises.readFile(absolutePath, "utf-8");
-			const configCwd = cwd ?? path.dirname(absolutePath);
+			const configCwd = resolveToolCwd("runner", "biome", absolutePath, {
+				...(cwd !== undefined && { cwd }),
+			});
 			// Shared config-args seam (#1247): the lint runner consumes the same
 			// builder, so `lint --write` can never drift to biome's default
 			// config when a user config or the package fallback exists.

--- a/clients/dead-code-client.ts
+++ b/clients/dead-code-client.ts
@@ -20,7 +20,7 @@ import * as path from "node:path";
 import { findLocalBinsAt, VENV_BIN_DIRS } from "./package-manager.js";
 import { findNearestMarkerRoot } from "./path-utils.js";
 import { getScratchTreeFnmatchPatterns } from "./scratch-tree-policy.js";
-import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync, safeSpawnAsync } from "./safe-spawn.js";
 import {
 	type ProbeEvidence,
 	classifyProbeFailure,
@@ -311,7 +311,7 @@ export class PythonDeadCodeClient implements DeadCodeClient {
 			let probe: Awaited<ReturnType<typeof safeSpawnAsync>>;
 			let hostStallMs: number;
 			try {
-				probe = await safeSpawnAsync(c.cmd, [...c.prefix, "--version"], {
+				probe = await probeToolAsync(c.cmd, [...c.prefix, "--version"], {
 					timeout: 5000,
 				});
 			} finally {

--- a/clients/dead-code-client.ts
+++ b/clients/dead-code-client.ts
@@ -20,7 +20,8 @@ import * as path from "node:path";
 import { findLocalBinsAt, VENV_BIN_DIRS } from "./package-manager.js";
 import { findNearestMarkerRoot } from "./path-utils.js";
 import { getScratchTreeFnmatchPatterns } from "./scratch-tree-policy.js";
-import { probeToolAsync, safeSpawnAsync } from "./safe-spawn.js";
+import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync } from "./tool-probe.js";
 import {
 	type ProbeEvidence,
 	classifyProbeFailure,

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -41,7 +41,7 @@ import {
 } from "../path-utils.js";
 import { loadPiLensProjectConfig } from "../project-lens-config.js";
 import { RUNTIME_CONFIG, getRunnerTimeoutFloorMs } from "../runtime-config.js";
-import { probeToolAsync } from "../safe-spawn.js";
+import { probeToolAsync } from "../tool-probe.js";
 import { classifyDiagnostic } from "./diagnostic-taxonomy.js";
 import {
 	classifyProbeFailure,

--- a/clients/dispatch/dispatcher.ts
+++ b/clients/dispatch/dispatcher.ts
@@ -41,7 +41,7 @@ import {
 } from "../path-utils.js";
 import { loadPiLensProjectConfig } from "../project-lens-config.js";
 import { RUNTIME_CONFIG, getRunnerTimeoutFloorMs } from "../runtime-config.js";
-import { safeSpawnAsync } from "../safe-spawn.js";
+import { probeToolAsync } from "../safe-spawn.js";
 import { classifyDiagnostic } from "./diagnostic-taxonomy.js";
 import {
 	classifyProbeFailure,
@@ -71,7 +71,7 @@ import { getToolProfile } from "./tool-profile.js";
 import { isRunnerSkipReason } from "./types.js";
 
 const dispatcherProbeFlights = createAvailabilityProbeFlight<
-	Awaited<ReturnType<typeof safeSpawnAsync>>
+	Awaited<ReturnType<typeof probeToolAsync>>
 >({ generation: () => getDispatchAvailabilityGeneration() });
 import type {
 	Diagnostic,
@@ -205,12 +205,12 @@ export async function checkToolAvailability(
 		// that overlapped the window and let the shared classifier read it.
 		const sampler = startHostStallSampler();
 		const startedAt = Date.now();
-		let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
+		let result: Awaited<ReturnType<typeof probeToolAsync>>;
 		let hostStallMs: number;
 		let probeJoined = false;
 		try {
 			const shared = dispatcherProbeFlights.run(`dispatcher:${key}`, () =>
-				safeSpawnAsync(command, ["--version"], {
+				probeToolAsync(command, ["--version"], {
 					timeout: TOOL_PROBE_TIMEOUT_MS,
 				}),
 			);

--- a/clients/dispatch/runners/cpp-check.ts
+++ b/clients/dispatch/runners/cpp-check.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { safeSpawnAsync } from "../../safe-spawn.js";
+import { probeToolAsync, safeSpawnAsync } from "../../safe-spawn.js";
 import { resolveRunnerCwd } from "../../tool-cwd.js";
 import { PRIORITY } from "../priorities.js";
 import type {
@@ -130,7 +130,7 @@ async function resolveCompiler(
 	// this never resolves a config file or a target path, so there is no cwd
 	// for it to get wrong.
 	// cwd-exempt: presence probe only -- `cl` with no args and no target file, used solely to detect whether MSVC is on PATH
-	const clProbe = await safeSpawnAsync("cl", [], { timeout: 5000 });
+	const clProbe = await probeToolAsync("cl", [], { timeout: 5000 });
 	if (!clProbe.error && clProbe.status !== null) {
 		return {
 			command: "cl",

--- a/clients/dispatch/runners/cpp-check.ts
+++ b/clients/dispatch/runners/cpp-check.ts
@@ -130,7 +130,6 @@ async function resolveCompiler(
 	// Mirrors the deliberate global-PATH probes in utils/runner-helpers.ts:
 	// this never resolves a config file or a target path, so there is no cwd
 	// for it to get wrong.
-	// cwd-exempt: presence probe only -- `cl` with no args and no target file, used solely to detect whether MSVC is on PATH
 	const clProbe = await probeToolAsync("cl", [], { timeout: 5000 });
 	if (!clProbe.error && clProbe.status !== null) {
 		return {

--- a/clients/dispatch/runners/cpp-check.ts
+++ b/clients/dispatch/runners/cpp-check.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { probeToolAsync, safeSpawnAsync } from "../../safe-spawn.js";
+import { safeSpawnAsync } from "../../safe-spawn.js";
+import { probeToolAsync } from "../../tool-probe.js";
 import { resolveRunnerCwd } from "../../tool-cwd.js";
 import { PRIORITY } from "../priorities.js";
 import type {

--- a/clients/dispatch/runners/psscriptanalyzer.ts
+++ b/clients/dispatch/runners/psscriptanalyzer.ts
@@ -2,7 +2,11 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { incrementDegradationCount } from "../../degradation-ledger.js";
-import { safeSpawnAsync, type SpawnResult } from "../../safe-spawn.js";
+import {
+	probeToolAsync,
+	safeSpawnAsync,
+	type SpawnResult,
+} from "../../safe-spawn.js";
 import { resolveRunnerCwd } from "../../tool-cwd.js";
 import type {
 	Diagnostic,
@@ -51,11 +55,16 @@ const PS_TIMEOUT_MS = 30000;
  * available". `safeSpawnAsync` carries the standard taxonomy — `failure`,
  * `spawnFailure.kind` and the errno on `error` — which is what lets the
  * availability policy tell a stall from an absence.
+ *
+ * The two presence probes that used to share this wrapper now go through
+ * `probeToolAsync` (#2894), so the only spawn left here is the ANALYSIS pass
+ * — which always has a project to resolve `PSScriptAnalyzerSettings.psd1`
+ * against. `cwd` is required to keep it that way.
  */
 function spawnPs(
 	cmd: string,
 	args: string[],
-	options: { timeoutMs?: number; cwd?: string } = {},
+	options: { timeoutMs?: number; cwd: string },
 ): Promise<SpawnResult> {
 	const { timeoutMs = PS_TIMEOUT_MS, cwd } = options;
 	return safeSpawnAsync(cmd, args, {
@@ -182,13 +191,11 @@ async function resolvePowerShellCmd(): Promise<string | null> {
 	for (const candidate of ["pwsh", "powershell"]) {
 		const sampler = startHostStallSampler();
 		const startedAt = Date.now();
-		// cwd-exempt: global interpreter-presence probe ("is pwsh/powershell on PATH at all"), not tied to any project
-		const result = await spawnPs(candidate, [
-			"-NoProfile",
-			"-NonInteractive",
-			"-Command",
-			"exit 0",
-		]);
+		const result = await probeToolAsync(
+			candidate,
+			["-NoProfile", "-NonInteractive", "-Command", "exit 0"],
+			{ timeout: PS_TIMEOUT_MS, resourceLabel: "psscriptanalyzer" },
+		);
 		const hostStallMs = sampler.stop();
 		const elapsedMs = Date.now() - startedAt;
 		elapsedTotalMs += elapsedMs;
@@ -234,13 +241,16 @@ async function checkModuleAvailable(cmd: string): Promise<boolean> {
 
 	const sampler = startHostStallSampler();
 	const startedAt = Date.now();
-	// cwd-exempt: global module-presence probe -- PSScriptAnalyzer resolves from PowerShell's module search path, not a per-project install
-	const result = await spawnPs(cmd, [
-		"-NoProfile",
-		"-NonInteractive",
-		"-Command",
-		"if (Get-Module -ListAvailable PSScriptAnalyzer) { exit 0 } else { exit 1 }",
-	]);
+	const result = await probeToolAsync(
+		cmd,
+		[
+			"-NoProfile",
+			"-NonInteractive",
+			"-Command",
+			"if (Get-Module -ListAvailable PSScriptAnalyzer) { exit 0 } else { exit 1 }",
+		],
+		{ timeout: PS_TIMEOUT_MS, resourceLabel: "psscriptanalyzer" },
+	);
 	const hostStallMs = sampler.stop();
 	const elapsedMs = Date.now() - startedAt;
 	if (!result.error && result.status === 0) {

--- a/clients/dispatch/runners/psscriptanalyzer.ts
+++ b/clients/dispatch/runners/psscriptanalyzer.ts
@@ -2,11 +2,8 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { incrementDegradationCount } from "../../degradation-ledger.js";
-import {
-	probeToolAsync,
-	safeSpawnAsync,
-	type SpawnResult,
-} from "../../safe-spawn.js";
+import { safeSpawnAsync, type SpawnResult } from "../../safe-spawn.js";
+import { probeToolAsync } from "../../tool-probe.js";
 import { resolveRunnerCwd } from "../../tool-cwd.js";
 import type {
 	Diagnostic,

--- a/clients/dispatch/runners/rust-clippy.ts
+++ b/clients/dispatch/runners/rust-clippy.ts
@@ -4,8 +4,8 @@
  * Runs `cargo clippy` for Rust files to catch common mistakes.
  */
 
-import { dirname, isAbsolute, join, resolve } from "node:path";
-import { findNearestContaining } from "../../path-utils.js";
+import { existsSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
 import { rustClient } from "../../rust-client.js";
 import { safeSpawnAsync } from "../../safe-spawn.js";
 import { stripAnsi } from "../../sanitize.js";
@@ -24,6 +24,7 @@ import type {
 	RunnerResult,
 } from "../types.js";
 import { PRIORITY } from "../priorities.js";
+import { resolveRunnerCwd } from "../../tool-cwd.js";
 import { createCwdCachedProbe } from "./utils/runner-helpers.js";
 
 // Cached per-cwd `cargo clippy --version` probe (#120). Before this, the
@@ -125,9 +126,14 @@ const rustClippyRunner: RunnerDefinition = {
 			}
 		}
 
-		// Find the package root (where Cargo.toml is)
-		const cargoToml = findCargoToml(ctx.filePath);
-		if (!cargoToml) {
+		// The package root (where Cargo.toml is), through the shared cwd seam
+		// (#2894): `RUNNER_MARKERS["rust-clippy"]` is `["Cargo.toml"]`, so this
+		// IS the walk this runner used to do with `findNearestContaining` — plus
+		// the seam's dispatch-root and `$HOME` ceilings, which the hand-rolled
+		// walk had neither of. The gate then asks about exactly the directory
+		// cargo will run in, rather than about a separately-derived one.
+		const cargoDir = resolveRunnerCwd(ctx, "rust-clippy");
+		if (!existsSync(join(cargoDir, "Cargo.toml"))) {
 			return { status: "skipped", diagnostics: [], semantic: "none" };
 		}
 
@@ -137,7 +143,7 @@ const rustClippyRunner: RunnerDefinition = {
 			["clippy", "--message-format=json", "-q"],
 			{
 				timeout: 60000,
-				cwd: cargoToml.replace("Cargo.toml", ""),
+				cwd: cargoDir,
 			},
 		);
 
@@ -149,7 +155,6 @@ const rustClippyRunner: RunnerDefinition = {
 
 		// Parse JSON output. span.file is relative to the package root, so pass
 		// the cargo dir to resolve diagnostics to absolute paths for filtering.
-		const cargoDir = cargoToml.replace("Cargo.toml", "");
 		const allDiagnostics = parseClippyOutput(raw, ctx.filePath, cargoDir);
 
 		if (allDiagnostics.length === 0) {
@@ -183,11 +188,6 @@ const rustClippyRunner: RunnerDefinition = {
 		};
 	},
 };
-
-function findCargoToml(filePath: string): string | undefined {
-	const dir = findNearestContaining(dirname(filePath), ["Cargo.toml"]);
-	return dir ? join(dir, "Cargo.toml") : undefined;
-}
 
 interface ClippySpan {
 	file?: string;

--- a/clients/dispatch/runners/utils/candidate-probe.ts
+++ b/clients/dispatch/runners/utils/candidate-probe.ts
@@ -12,7 +12,7 @@
  */
 
 import * as fs from "node:fs";
-import { probeToolAsync } from "../../../safe-spawn.js";
+import { probeToolAsync } from "../../../tool-probe.js";
 import {
 	type AvailabilityCause,
 	type ProbeEvidence,

--- a/clients/dispatch/runners/utils/candidate-probe.ts
+++ b/clients/dispatch/runners/utils/candidate-probe.ts
@@ -12,7 +12,7 @@
  */
 
 import * as fs from "node:fs";
-import { safeSpawnAsync } from "../../../safe-spawn.js";
+import { probeToolAsync } from "../../../safe-spawn.js";
 import {
 	type AvailabilityCause,
 	type ProbeEvidence,
@@ -71,10 +71,10 @@ export async function probeAvailabilityCandidates(
 			// Host-side budget: measure the loop stall that overlapped the probe so
 			// the shared policy can tell "no toolchain" from "the host was busy".
 			const sampler = startHostStallSampler();
-			let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
+			let result: Awaited<ReturnType<typeof probeToolAsync>>;
 			let stallMs: number;
 			try {
-				result = await safeSpawnAsync(candidate, [...probeArgs], {
+				result = await probeToolAsync(candidate, probeArgs, {
 					timeout: timeoutMs,
 				});
 			} finally {

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -45,7 +45,8 @@ import {
 	VENV_BIN_DIRS,
 } from "../../../package-manager.js";
 import { logLatency } from "../../../latency-logger.js";
-import { probeToolAsync, safeSpawnAsync } from "../../../safe-spawn.js";
+import { safeSpawnAsync } from "../../../safe-spawn.js";
+import { probeToolAsync } from "../../../tool-probe.js";
 import { compareOrdinal } from "../../../string-utils.js";
 import {
 	getToolCommandSpec,

--- a/clients/dispatch/runners/utils/runner-helpers.ts
+++ b/clients/dispatch/runners/utils/runner-helpers.ts
@@ -45,7 +45,7 @@ import {
 	VENV_BIN_DIRS,
 } from "../../../package-manager.js";
 import { logLatency } from "../../../latency-logger.js";
-import { safeSpawnAsync } from "../../../safe-spawn.js";
+import { probeToolAsync, safeSpawnAsync } from "../../../safe-spawn.js";
 import { compareOrdinal } from "../../../string-utils.js";
 import {
 	getToolCommandSpec,
@@ -1823,7 +1823,7 @@ async function probeAstGrepCommandAsync(
 	let check: Awaited<ReturnType<typeof safeSpawnAsync>>;
 	let hostStallMs: number;
 	try {
-		check = await safeSpawnAsync(cmd, [...argsPrefix, "--version"], {
+		check = await probeToolAsync(cmd, [...argsPrefix, "--version"], {
 			timeout: 5000,
 		});
 	} finally {
@@ -2163,7 +2163,7 @@ export async function resolveLocalFirstAsync(
 	if (globalBin) return { cmd: globalBin, args: [] };
 
 	// 3. Global PATH (already installed system-wide, on PATH)
-	const globalCheck = await safeSpawnAsync(toolName, ["--version"], {
+	const globalCheck = await probeToolAsync(toolName, ["--version"], {
 		timeout: 3000,
 	});
 	if (!globalCheck.error && globalCheck.status === 0) {

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -42,7 +42,7 @@ import {
 	VENDOR_BIN_DIRS,
 	VENV_BIN_DIRS,
 } from "./package-manager.js";
-import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync, safeSpawnAsync } from "./safe-spawn.js";
 import { assertInstallAllowed } from "./project-trust.js";
 import { tryLazyInstallForFormatter } from "./dispatch/runners/utils/lazy-installer.js";
 import { getToolPath } from "./installer/index.js";
@@ -586,7 +586,7 @@ async function resolveGoFmtBinary(): Promise<string | null> {
 	const inPath = await which("gofmt");
 	if (inPath) return inPath;
 
-	const goCheck = await safeSpawnAsync("go", ["env", "GOROOT"], {
+	const goCheck = await probeToolAsync("go", ["env", "GOROOT"], {
 		timeout: 5000,
 	});
 	if (goCheck.error || goCheck.status !== 0) return null;
@@ -1507,12 +1507,10 @@ export const csharpierFormatter: FormatterInfo = {
 		}
 		// CSharpier 0.x: invoked through the dotnet driver.
 		if ((await which("dotnet")) !== null) {
-			const legacy = await safeSpawnAsync(
+			const legacy = await probeToolAsync(
 				"dotnet",
 				["csharpier", "--version"],
-				{
-					timeout: 5000,
-				},
+				{ timeout: 5000 },
 			);
 			if (!legacy.error && legacy.status === 0) {
 				return ["dotnet", "csharpier", filePath];
@@ -1525,7 +1523,7 @@ export const csharpierFormatter: FormatterInfo = {
 		if ((await which("csharpier")) !== null) return true;
 		// … or the legacy dotnet-driver form (CSharpier 0.x).
 		if ((await which("dotnet")) === null) return false;
-		const result = await safeSpawnAsync("dotnet", ["csharpier", "--version"], {
+		const result = await probeToolAsync("dotnet", ["csharpier", "--version"], {
 			timeout: 5000,
 		});
 		return !result.error && result.status === 0;
@@ -1699,7 +1697,7 @@ export const psscriptanalyzerFormatFormatter: FormatterInfo = {
 		const pwsh = (await which("pwsh")) ?? (await which("powershell"));
 		if (!pwsh) return false;
 		// Check PSScriptAnalyzer module is available
-		const result = await safeSpawnAsync(
+		const result = await probeToolAsync(
 			pwsh,
 			[
 				"-NoProfile",

--- a/clients/formatters.ts
+++ b/clients/formatters.ts
@@ -42,7 +42,8 @@ import {
 	VENDOR_BIN_DIRS,
 	VENV_BIN_DIRS,
 } from "./package-manager.js";
-import { probeToolAsync, safeSpawnAsync } from "./safe-spawn.js";
+import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync } from "./tool-probe.js";
 import { assertInstallAllowed } from "./project-trust.js";
 import { tryLazyInstallForFormatter } from "./dispatch/runners/utils/lazy-installer.js";
 import { getToolPath } from "./installer/index.js";

--- a/clients/govulncheck-client.ts
+++ b/clients/govulncheck-client.ts
@@ -21,7 +21,8 @@ import type { AnalysedRootSignal } from "./analysed-root.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { probeToolAsync, safeSpawnAsync } from "./safe-spawn.js";
+import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync } from "./tool-probe.js";
 import {
 	firstOutputLine,
 	spawnFailedWithNoOutput,

--- a/clients/govulncheck-client.ts
+++ b/clients/govulncheck-client.ts
@@ -21,7 +21,7 @@ import type { AnalysedRootSignal } from "./analysed-root.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync, safeSpawnAsync } from "./safe-spawn.js";
 import {
 	firstOutputLine,
 	spawnFailedWithNoOutput,
@@ -165,7 +165,7 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 		let goOnPath: Awaited<ReturnType<typeof safeSpawnAsync>>;
 		let goHostStallMs: number;
 		try {
-			goOnPath = await safeSpawnAsync("go", ["version"], {
+			goOnPath = await probeToolAsync("go", ["version"], {
 				timeout: 5000,
 			});
 		} finally {
@@ -307,7 +307,7 @@ export class GovulncheckClient extends SecurityScanClient<GovulncheckResult> {
 		let reprobe: Awaited<ReturnType<typeof safeSpawnAsync>>;
 		let reprobeHostStallMs: number;
 		try {
-			reprobe = await safeSpawnAsync("govulncheck", ["-version"], {
+			reprobe = await probeToolAsync("govulncheck", ["-version"], {
 				timeout: 5000,
 			});
 		} finally {

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -77,6 +77,7 @@ import {
 	resolveNodePackageManager,
 } from "../package-manager.js";
 import {
+	probeToolAsync,
 	resetSafeSpawnWindowsCommandCache,
 	safeSpawnAsync,
 } from "../safe-spawn.js";
@@ -2072,28 +2073,18 @@ function isAstGrepVersionOutput(output: string): boolean {
 }
 
 async function verifyAstGrepProbePath(binPath: string): Promise<boolean> {
-	return new Promise((resolve) => {
-		let proc: ReturnType<typeof spawn>;
-		try {
-			proc = spawn(binPath, ["--version"], {
-				stdio: ["ignore", "pipe", "pipe"],
-				shell: process.platform === "win32" && /\.(cmd|bat)$/i.test(binPath),
-				timeout: 5000,
-			});
-		} catch {
-			// SYNCHRONOUS spawn throw (Windows `spawn UNKNOWN`/EINVAL, the pidusage
-			// bug class, #533) — best-effort probe, resolve rather than reject.
-			resolve(false);
-			return;
-		}
-		let output = "";
-		proc.stdout?.on("data", (data) => (output += data));
-		proc.stderr?.on("data", (data) => (output += data));
-		proc.on("exit", (code) => {
-			resolve(code === 0 && isAstGrepVersionOutput(output));
-		});
-		proc.on("error", () => resolve(false));
+	// #2894: through the probe seam rather than a hand-rolled `spawn` promise.
+	// `probeToolAsync` already owns the synchronous-throw case (#533), the
+	// Windows `.cmd`/`.bat` resolution this used `shell: true` for, and the
+	// timeout tree-kill a bare `spawn({ timeout })` does not do.
+	const result = await probeToolAsync(binPath, ["--version"], {
+		timeout: 5000,
 	});
+	return (
+		!result.error &&
+		result.status === 0 &&
+		isAstGrepVersionOutput(`${result.stdout}${result.stderr}`)
+	);
 }
 
 // Exported for testing only.
@@ -2687,30 +2678,15 @@ export async function getAllToolStatuses(): Promise<ToolStatus[]> {
 			status.installed = true;
 			status.source = "global-path";
 			status.path = tool.checkCommand;
-			// Try to get version
-			const versionResult = await new Promise<string>((resolve) => {
-				let proc: ReturnType<typeof spawn>;
-				try {
-					proc = spawn(tool.checkCommand, ["--version"], {
-						stdio: ["ignore", "pipe", "pipe"],
-						shell: process.platform === "win32",
-						timeout: 5000,
-					});
-				} catch {
-					// SYNCHRONOUS spawn throw (Windows `spawn UNKNOWN`/EINVAL, the
-					// pidusage bug class, #533) — best-effort, resolve empty version.
-					resolve("");
-					return;
-				}
-				let out = "";
-				proc.stdout?.on("data", (d) => (out += d));
-				proc.stderr?.on("data", (d) => (out += d));
-				proc.on("exit", () =>
-					resolve(out.trim().split("\n")[0]?.slice(0, 30) || ""),
-				);
-				proc.on("error", () => resolve(""));
+			// Try to get version — through the probe seam (#2894), which owns the
+			// synchronous-throw case (#533) and the timeout tree-kill that a bare
+			// `spawn({ timeout })` promise did not do.
+			const probe = await probeToolAsync(tool.checkCommand, ["--version"], {
+				timeout: 5000,
 			});
-			status.version = versionResult || undefined;
+			status.version =
+				`${probe.stdout}${probe.stderr}`.trim().split("\n")[0]?.slice(0, 30) ||
+				undefined;
 			statuses.push(status);
 			continue;
 		}
@@ -4116,7 +4092,7 @@ async function probeManagedToolVersion(
 	const cached = (await readProbeCache())[tool.id];
 	if (!cached?.path || !existsSync(cached.path)) return undefined;
 	try {
-		const result = await safeSpawnAsync(cached.path, tool.checkArgs, {
+		const result = await probeToolAsync(cached.path, tool.checkArgs, {
 			timeout: getToolVerificationTimeout(tool),
 			input: "",
 			ignoreAmbientSignal: true,

--- a/clients/installer/index.ts
+++ b/clients/installer/index.ts
@@ -77,10 +77,10 @@ import {
 	resolveNodePackageManager,
 } from "../package-manager.js";
 import {
-	probeToolAsync,
 	resetSafeSpawnWindowsCommandCache,
 	safeSpawnAsync,
 } from "../safe-spawn.js";
+import { probeToolAsync } from "../tool-probe.js";
 import { logSessionStart } from "../sessionstart-logger.js";
 
 // Global installation directory for pi-lens tools

--- a/clients/package-manager.ts
+++ b/clients/package-manager.ts
@@ -25,7 +25,8 @@ import {
 	logAvailabilityDecision,
 	startHostStallSampler,
 } from "./dispatch/runners/utils/availability-policy.js";
-import { probeToolAsync, safeSpawnAsync } from "./safe-spawn.js";
+import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync } from "./tool-probe.js";
 import { createAvailabilityProbeFlight } from "./availability-probe-flight.js";
 import {
 	createGenerationSource,

--- a/clients/package-manager.ts
+++ b/clients/package-manager.ts
@@ -25,7 +25,7 @@ import {
 	logAvailabilityDecision,
 	startHostStallSampler,
 } from "./dispatch/runners/utils/availability-policy.js";
-import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync, safeSpawnAsync } from "./safe-spawn.js";
 import { createAvailabilityProbeFlight } from "./availability-probe-flight.js";
 import {
 	createGenerationSource,
@@ -149,7 +149,7 @@ async function probeAvailability(pm: NodePackageManager): Promise<boolean> {
 	let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
 	let hostStallMs: number;
 	try {
-		result = await safeSpawnAsync(finder, [pm], { timeout: PROBE_TIMEOUT_MS });
+		result = await probeToolAsync(finder, [pm], { timeout: PROBE_TIMEOUT_MS });
 	} finally {
 		hostStallMs = sampler.stop();
 	}

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -71,11 +71,8 @@ import { BoundedLruCache } from "./bounded-cache.js";
 import type { RuffClient } from "./ruff-client.js";
 import { RUNTIME_CONFIG } from "./runtime-config.js";
 import type { WordIndex } from "./word-index.js";
-import {
-	getAmbientAbortSignal,
-	probeToolAsync,
-	safeSpawnAsync,
-} from "./safe-spawn.js";
+import { getAmbientAbortSignal, safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync } from "./tool-probe.js";
 import { bounded } from "./deadline-utils.js";
 import { enabledAuxiliaryLspServerIds } from "./dispatch/auxiliary-lsp.js";
 import { recordDegradationOnce } from "./degradation-ledger.js";

--- a/clients/pipeline.ts
+++ b/clients/pipeline.ts
@@ -71,7 +71,11 @@ import { BoundedLruCache } from "./bounded-cache.js";
 import type { RuffClient } from "./ruff-client.js";
 import { RUNTIME_CONFIG } from "./runtime-config.js";
 import type { WordIndex } from "./word-index.js";
-import { getAmbientAbortSignal, safeSpawnAsync } from "./safe-spawn.js";
+import {
+	getAmbientAbortSignal,
+	probeToolAsync,
+	safeSpawnAsync,
+} from "./safe-spawn.js";
 import { bounded } from "./deadline-utils.js";
 import { enabledAuxiliaryLspServerIds } from "./dispatch/auxiliary-lsp.js";
 import { recordDegradationOnce } from "./degradation-ledger.js";
@@ -679,7 +683,7 @@ async function tryOxlintFix(filePath: string, cwd: string): Promise<number> {
 }
 
 async function tryRustClippyFix(filePath: string): Promise<string[]> {
-	const check = await safeSpawnAsync("cargo", ["--version"], { timeout: 5000 });
+	const check = await probeToolAsync("cargo", ["--version"], { timeout: 5000 });
 	if (check.error || check.status !== 0) return [];
 
 	const cargoDir = findNearestContaining(path.dirname(path.resolve(filePath)), [
@@ -698,7 +702,7 @@ async function tryRustClippyFix(filePath: string): Promise<string[]> {
 }
 
 async function tryDartFix(filePath: string): Promise<string[]> {
-	const check = await safeSpawnAsync("dart", ["--version"], { timeout: 5000 });
+	const check = await probeToolAsync("dart", ["--version"], { timeout: 5000 });
 	if (check.error || check.status !== 0) return [];
 
 	const pubspecDir = findNearestContaining(

--- a/clients/ruff-client.ts
+++ b/clients/ruff-client.ts
@@ -126,7 +126,9 @@ export class RuffClient {
 			// autofix path to consume the SAME policy; deriving the root two
 			// different ways is how they drift, and the hand-rolled form ignored a
 			// nested `pyproject.toml` whenever the caller passed a workspace root.
-			const ruffCwd = resolveToolCwd("runner", "ruff", absolutePath, { cwd });
+			const ruffCwd = resolveToolCwd("runner", "ruff", absolutePath, {
+				...(cwd !== undefined && { cwd }),
+			});
 			// Shared config-args seam (#1247): the lint runner consumes the same
 			// builder, so `check --fix` can never drift to ruff's default rule
 			// set when the project lacks its own config and the package-owned

--- a/clients/ruff-client.ts
+++ b/clients/ruff-client.ts
@@ -17,6 +17,7 @@ import {
 } from "./dispatch/runners/utils/runner-helpers.js";
 import { isFileKind } from "./file-kinds.js";
 import { safeSpawnAsync } from "./safe-spawn.js";
+import { resolveToolCwd } from "./tool-cwd.js";
 import { ruffConfigArgs } from "./tool-policy.js";
 
 // --- Types ---
@@ -82,8 +83,11 @@ export class RuffClient {
 
 	/**
 	 * Async auto-fix variant for pipeline use (non-blocking spawn).
-	 * `cwd` is the dispatch language root (used for config discovery); when
-	 * omitted it defaults to the file's directory.
+	 * `cwd` is the dispatch language root. It is the seam's starting point,
+	 * not the answer: `resolveToolCwd` walks from the file to the nearest
+	 * `pyproject.toml`/`ruff.toml`/`.ruff.toml` at or above it, capped inside
+	 * `cwd` (and at `$HOME` when there is none), so a file in a nested package
+	 * gets that package's config rather than the workspace-root one.
 	 */
 	async fixFileAsync(
 		filePath: string,
@@ -116,15 +120,18 @@ export class RuffClient {
 		try {
 			const before = await fs.promises.readFile(absolutePath, "utf-8");
 
+			// #2894: the root ruff resolves its config from comes from the shared
+			// seam, not from a local `cwd ?? path.dirname(file)`. `tool-policy.ts`
+			// requires the lint runner (`ruff.ts`, on `resolveRunnerCwd`) and this
+			// autofix path to consume the SAME policy; deriving the root two
+			// different ways is how they drift, and the hand-rolled form ignored a
+			// nested `pyproject.toml` whenever the caller passed a workspace root.
+			const ruffCwd = resolveToolCwd("runner", "ruff", absolutePath, { cwd });
 			// Shared config-args seam (#1247): the lint runner consumes the same
 			// builder, so `check --fix` can never drift to ruff's default rule
 			// set when the project lacks its own config and the package-owned
 			// core.toml fallback applies.
-			const configArgs = ruffConfigArgs(cwd ?? path.dirname(absolutePath));
-			const spawnOpts = {
-				timeout: 10000,
-				cwd: cwd ?? path.dirname(absolutePath),
-			};
+			const configArgs = ruffConfigArgs(ruffCwd);
 
 			const pre = await safeSpawnAsync(
 				this.ruffCommand,
@@ -137,7 +144,7 @@ export class RuffClient {
 					...configArgs,
 					absolutePath,
 				],
-				spawnOpts,
+				{ timeout: 10000, cwd: ruffCwd },
 			);
 			const beforeDiags = pre.stdout?.trim()
 				? this.parseOutput(pre.stdout, absolutePath)
@@ -147,7 +154,7 @@ export class RuffClient {
 			const fix = await safeSpawnAsync(
 				this.ruffCommand,
 				["check", "--fix", ...configArgs, absolutePath],
-				{ timeout: 15000, cwd: cwd ?? path.dirname(absolutePath) },
+				{ timeout: 15000, cwd: ruffCwd },
 			);
 
 			if (fix.error) {

--- a/clients/ruff-client.ts
+++ b/clients/ruff-client.ts
@@ -120,8 +120,8 @@ export class RuffClient {
 		try {
 			const before = await fs.promises.readFile(absolutePath, "utf-8");
 
-			// #2894: the root ruff resolves its config from comes from the shared
-			// seam, not from a local `cwd ?? path.dirname(file)`. `tool-policy.ts`
+			// #2894: the root ruff resolves its config from now comes from the
+			// shared seam, not a local `cwd ?? path.dirname(file)`. `tool-policy.ts`
 			// requires the lint runner (`ruff.ts`, on `resolveRunnerCwd`) and this
 			// autofix path to consume the SAME policy; deriving the root two
 			// different ways is how they drift, and the hand-rolled form ignored a

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -2062,6 +2062,45 @@ export async function safeSpawnBatch(
 }
 
 /**
+ * What a tool probe may set. `cwd` is deliberately ABSENT — see
+ * {@link probeToolAsync}.
+ */
+export type ProbeSpawnOptions = Omit<SafeSpawnOptions, "cwd">;
+
+/**
+ * Run a tool's own presence/version invocation — `<tool> --version`,
+ * `cl`, `go version`, `Get-Module -ListAvailable …` — and hand back the raw
+ * spawn result for the caller's availability policy to classify.
+ *
+ * ## The contract: a probe never gets a `cwd` (#2894)
+ *
+ * A probe asks whether a binary exists and what it calls itself. The answer
+ * does not depend on the directory the child starts in, so this seam passes
+ * NONE — the child inherits the host's directory and nothing it reports is
+ * read out of a project. That is why the sweep in
+ * `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts` admits ONE
+ * cwd-less spawn here instead of the 23 it admitted before: every one of
+ * those sites re-decided the same thing in its own words, and 23 sentences a
+ * reviewer has to re-read individually is how an admission table stops being
+ * auditable (#2872 round-3's two canned sentences, four of them false).
+ *
+ * `cwd` is stripped rather than merely omitted from {@link ProbeSpawnOptions}:
+ * the type stops an object LITERAL from carrying one, and the explicit
+ * `cwd: undefined` below stops one that arrives inside an already-typed
+ * options object a caller widened. A probe that genuinely needs to run
+ * somewhere — `mix credo --version` needs a mix project, `cargo clippy
+ * --version` needs a package — must call {@link safeSpawnAsync} directly and
+ * be admitted by the sweep on its own reason.
+ */
+export async function probeToolAsync(
+	command: string,
+	args: readonly string[],
+	options?: ProbeSpawnOptions,
+): Promise<SpawnResult> {
+	return safeSpawnAsync(command, [...args], { ...options, cwd: undefined });
+}
+
+/**
  * Check if a command is available in PATH (async version)
  */
 export async function isCommandAvailableAsync(

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -2062,45 +2062,6 @@ export async function safeSpawnBatch(
 }
 
 /**
- * What a tool probe may set. `cwd` is deliberately ABSENT — see
- * {@link probeToolAsync}.
- */
-export type ProbeSpawnOptions = Omit<SafeSpawnOptions, "cwd">;
-
-/**
- * Run a tool's own presence/version invocation — `<tool> --version`,
- * `cl`, `go version`, `Get-Module -ListAvailable …` — and hand back the raw
- * spawn result for the caller's availability policy to classify.
- *
- * ## The contract: a probe never gets a `cwd` (#2894)
- *
- * A probe asks whether a binary exists and what it calls itself. The answer
- * does not depend on the directory the child starts in, so this seam passes
- * NONE — the child inherits the host's directory and nothing it reports is
- * read out of a project. That is why the sweep in
- * `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts` admits ONE
- * cwd-less spawn here instead of the 23 it admitted before: every one of
- * those sites re-decided the same thing in its own words, and 23 sentences a
- * reviewer has to re-read individually is how an admission table stops being
- * auditable (#2872 round-3's two canned sentences, four of them false).
- *
- * `cwd` is stripped rather than merely omitted from {@link ProbeSpawnOptions}:
- * the type stops an object LITERAL from carrying one, and the explicit
- * `cwd: undefined` below stops one that arrives inside an already-typed
- * options object a caller widened. A probe that genuinely needs to run
- * somewhere — `mix credo --version` needs a mix project, `cargo clippy
- * --version` needs a package — must call {@link safeSpawnAsync} directly and
- * be admitted by the sweep on its own reason.
- */
-export async function probeToolAsync(
-	command: string,
-	args: readonly string[],
-	options?: ProbeSpawnOptions,
-): Promise<SpawnResult> {
-	return safeSpawnAsync(command, [...args], { ...options, cwd: undefined });
-}
-
-/**
  * Check if a command is available in PATH (async version)
  */
 export async function isCommandAvailableAsync(

--- a/clients/security-scan-client.ts
+++ b/clients/security-scan-client.ts
@@ -15,7 +15,7 @@
 
 import * as path from "node:path";
 import { createSubsystemLogger } from "./extension-log.js";
-import { safeSpawnAsync } from "./safe-spawn.js";
+import { probeToolAsync } from "./safe-spawn.js";
 import {
 	type AvailabilityCause,
 	type AvailabilityOutcome,
@@ -31,7 +31,7 @@ import { createAvailabilityProbeFlight } from "./availability-probe-flight.js";
 import { createSingleFlight } from "./single-flight.js";
 
 type SecurityProbeResult = {
-	probe: Awaited<ReturnType<typeof safeSpawnAsync>>;
+	probe: Awaited<ReturnType<typeof probeToolAsync>>;
 	binaryPath: string | null;
 };
 
@@ -158,7 +158,7 @@ export abstract class SecurityScanClient<TResult> {
 	protected async probeVersion(versionArgs: string[]): Promise<boolean> {
 		const sampler = startHostStallSampler();
 		const startedAt = Date.now();
-		let probe: Awaited<ReturnType<typeof safeSpawnAsync>>;
+		let probe: Awaited<ReturnType<typeof probeToolAsync>>;
 		let hostStallMs: number;
 		let resolvedBinaryPath: string | null = null;
 		let probeJoined = false;
@@ -170,7 +170,7 @@ export abstract class SecurityScanClient<TResult> {
 						await import("./installer/index.js");
 					const managed = await findManagedToolBinary(this.toolName);
 					return {
-						probe: await safeSpawnAsync(managed ?? this.toolName, versionArgs, {
+						probe: await probeToolAsync(managed ?? this.toolName, versionArgs, {
 							timeout: 5000,
 						}),
 						binaryPath: managed ?? null,

--- a/clients/security-scan-client.ts
+++ b/clients/security-scan-client.ts
@@ -15,7 +15,7 @@
 
 import * as path from "node:path";
 import { createSubsystemLogger } from "./extension-log.js";
-import { probeToolAsync } from "./safe-spawn.js";
+import { probeToolAsync } from "./tool-probe.js";
 import {
 	type AvailabilityCause,
 	type AvailabilityOutcome,

--- a/clients/sg-runner.ts
+++ b/clients/sg-runner.ts
@@ -15,11 +15,8 @@ import {
 } from "./dispatch/runners/utils/runner-helpers.js";
 import { getProjectIgnoreGlobs } from "./file-utils.js";
 import { findGlobalBinary } from "./package-manager.js";
-import {
-	probeToolAsync,
-	safeSpawnAsync,
-	type SpawnResult,
-} from "./safe-spawn.js";
+import { safeSpawnAsync, type SpawnResult } from "./safe-spawn.js";
+import { probeToolAsync } from "./tool-probe.js";
 import { truncatedByOutputCap } from "./spawn-output-cap.js";
 import { createSingleFlight } from "./single-flight.js";
 import {

--- a/clients/sg-runner.ts
+++ b/clients/sg-runner.ts
@@ -15,7 +15,11 @@ import {
 } from "./dispatch/runners/utils/runner-helpers.js";
 import { getProjectIgnoreGlobs } from "./file-utils.js";
 import { findGlobalBinary } from "./package-manager.js";
-import { safeSpawnAsync, type SpawnResult } from "./safe-spawn.js";
+import {
+	probeToolAsync,
+	safeSpawnAsync,
+	type SpawnResult,
+} from "./safe-spawn.js";
 import { truncatedByOutputCap } from "./spawn-output-cap.js";
 import { createSingleFlight } from "./single-flight.js";
 import {
@@ -613,7 +617,7 @@ export class SgRunner {
 		let result: Awaited<ReturnType<typeof safeSpawnAsync>>;
 		let hostStallMs: number;
 		try {
-			result = await safeSpawnAsync(cmd, [...argsPrefix, "--version"], {
+			result = await probeToolAsync(cmd, [...argsPrefix, "--version"], {
 				timeout: PROBE_TIMEOUT_MS,
 			});
 		} finally {

--- a/clients/tool-cwd.ts
+++ b/clients/tool-cwd.ts
@@ -119,6 +119,9 @@ const RUNNER_MARKERS: Readonly<Record<string, readonly string[]>> = {
 	oxlint: [".oxlintrc.json", "oxlint.config.js", "package.json"],
 	sqlfluff: [".sqlfluff", "pyproject.toml", "setup.cfg"],
 	prettier: [".prettierignore", "package.json"],
+	// #2894: cargo must run at the package root. This is the marker walk
+	// `rust-clippy.ts` used to do for itself with `findNearestContaining`.
+	"rust-clippy": ["Cargo.toml"],
 };
 
 const toolCwdGeneration = createGenerationSource("tool-cwd");

--- a/clients/tool-cwd.ts
+++ b/clients/tool-cwd.ts
@@ -163,11 +163,19 @@ function findMarkerRoot(
 	]);
 	const cached = markerWalks.get(key);
 	if (cached && markerWalkGenerations.current(key) !== 0) {
-		if (!cached.marker || !cached.root) return cached;
-		// #2777: a marker can disappear during a session; do not reuse a stale root.
-		if (existsSync(path.join(cached.root, cached.marker))) return cached;
-		markerWalks.delete(key);
-		markerWalkGenerations.forget(key);
+		// A negative walk is not stable: a project marker can be created after
+		// the first resolution, so do not cache absence across calls. Positive
+		// results remain memoized and are still revalidated when their marker is
+		// deleted (#2894).
+		if (!cached.marker || !cached.root) {
+			markerWalks.delete(key);
+			markerWalkGenerations.forget(key);
+		} else {
+			// #2777: a marker can disappear during a session; do not reuse a stale root.
+			if (existsSync(path.join(cached.root, cached.marker))) return cached;
+			markerWalks.delete(key);
+			markerWalkGenerations.forget(key);
+		}
 	}
 	markerWalkCount++;
 	let current = path.resolve(startDir);

--- a/clients/tool-probe.ts
+++ b/clients/tool-probe.ts
@@ -34,7 +34,7 @@ export type ProbeSpawnOptions = Omit<SafeSpawnOptions, "cwd">;
  * NONE — the child inherits the host's directory and nothing it reports is
  * read out of a project. That is why the sweep in
  * `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts` admits ONE
- * cwd-less spawn here instead of the 24 it admitted before: every one of those
+ * cwd-less spawn here instead of the 23 it admitted before: every one of those
  * sites re-decided the same thing in its own words, and two dozen sentences a
  * reviewer has to re-read one at a time is how an admission table stops being
  * auditable (#2872 round 3 shipped 127 rows carrying two canned sentences,

--- a/clients/tool-probe.ts
+++ b/clients/tool-probe.ts
@@ -41,9 +41,9 @@ export type ProbeSpawnOptions = Omit<SafeSpawnOptions, "cwd">;
  * four of them false where they were read).
  *
  * `cwd` is STRIPPED rather than merely left out of {@link ProbeSpawnOptions}:
- * the type stops an object literal from carrying one, and the explicit
- * `cwd: undefined` below stops one that arrives inside an already-typed
- * options object a caller widened or spread. A probe that genuinely needs to
+ * the type stops an object literal from carrying one, and the destructure
+ * below removes one that arrived inside an already-typed options object a
+ * caller widened or spread. A probe that genuinely needs to
  * run somewhere — `mix credo --version` needs a mix project, `cargo clippy
  * --version` needs a package, `eslint --version` resolves a project-local
  * binary — must call `safeSpawnAsync` directly and be admitted by that sweep
@@ -54,5 +54,11 @@ export async function probeToolAsync(
 	args: readonly string[],
 	options?: ProbeSpawnOptions,
 ): Promise<SpawnResult> {
-	return safeSpawnAsync(command, [...args], { ...options, cwd: undefined });
+	// Destructured away rather than overwritten with `undefined`: the key is
+	// then genuinely ABSENT from what reaches the spawn, which is both what the
+	// contract says and what `exactOptionalPropertyTypes` wants (a present
+	// `cwd: undefined` is a strictness spike the `tests/config` ratchet counts).
+	const { cwd: _strippedCwd, ...rest } = (options ?? {}) as SafeSpawnOptions;
+	void _strippedCwd;
+	return safeSpawnAsync(command, [...args], rest);
 }

--- a/clients/tool-probe.ts
+++ b/clients/tool-probe.ts
@@ -35,7 +35,7 @@ export type ProbeSpawnOptions = Omit<SafeSpawnOptions, "cwd">;
  * read out of a project. That is why the sweep in
  * `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts` admits ONE
  * cwd-less spawn here instead of the 23 it admitted before: every one of those
- * sites re-decided the same thing in its own words, and two dozen sentences a
+ * sites re-decided the same thing in its own words, and 23 sentences a
  * reviewer has to re-read one at a time is how an admission table stops being
  * auditable (#2872 round 3 shipped 127 rows carrying two canned sentences,
  * four of them false where they were read).

--- a/clients/tool-probe.ts
+++ b/clients/tool-probe.ts
@@ -62,6 +62,5 @@ export async function probeToolAsync(
 	// contract says and what `exactOptionalPropertyTypes` wants (a present
 	// `cwd: undefined` is a strictness spike the `tests/config` ratchet counts).
 	const { cwd: _strippedCwd, ...rest } = (options ?? {}) as SafeSpawnOptions;
-	void _strippedCwd;
 	return safeSpawnAsync(command, [...args], { ...rest });
 }

--- a/clients/tool-probe.ts
+++ b/clients/tool-probe.ts
@@ -1,0 +1,58 @@
+/**
+ * The tool-probe spawn seam (#2894).
+ *
+ * A sibling of `tool-cwd.ts`: that module owns where a child that READS A
+ * PROJECT starts, this one owns the fact that a child which reads no project
+ * starts nowhere in particular.
+ *
+ * It is a module of its own rather than another export on `safe-spawn.ts`
+ * deliberately. Every availability test in this repo fakes the process
+ * boundary with `vi.mock("clients/safe-spawn.js", … { safeSpawnAsync })`, and
+ * a same-module helper would call the module's own unmocked binding — the
+ * probe would spawn for real while the test believed it had the boundary. One
+ * module hop keeps every existing double production-faithful.
+ */
+
+import type { SafeSpawnOptions, SpawnResult } from "./safe-spawn.js";
+import { safeSpawnAsync } from "./safe-spawn.js";
+
+/**
+ * What a tool probe may set. `cwd` is deliberately ABSENT — see
+ * {@link probeToolAsync}.
+ */
+export type ProbeSpawnOptions = Omit<SafeSpawnOptions, "cwd">;
+
+/**
+ * Run a tool's own presence/version invocation — `<tool> --version`, `cl`,
+ * `go version`, `which <pm>`, `Get-Module -ListAvailable …` — and hand back
+ * the raw spawn result for the caller's availability policy to classify.
+ *
+ * ## The contract: a probe never gets a `cwd`
+ *
+ * A probe asks whether a binary exists and what it calls itself. The answer
+ * does not depend on the directory the child starts in, so this seam passes
+ * NONE — the child inherits the host's directory and nothing it reports is
+ * read out of a project. That is why the sweep in
+ * `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts` admits ONE
+ * cwd-less spawn here instead of the 24 it admitted before: every one of those
+ * sites re-decided the same thing in its own words, and two dozen sentences a
+ * reviewer has to re-read one at a time is how an admission table stops being
+ * auditable (#2872 round 3 shipped 127 rows carrying two canned sentences,
+ * four of them false where they were read).
+ *
+ * `cwd` is STRIPPED rather than merely left out of {@link ProbeSpawnOptions}:
+ * the type stops an object literal from carrying one, and the explicit
+ * `cwd: undefined` below stops one that arrives inside an already-typed
+ * options object a caller widened or spread. A probe that genuinely needs to
+ * run somewhere — `mix credo --version` needs a mix project, `cargo clippy
+ * --version` needs a package, `eslint --version` resolves a project-local
+ * binary — must call `safeSpawnAsync` directly and be admitted by that sweep
+ * on its own reason.
+ */
+export async function probeToolAsync(
+	command: string,
+	args: readonly string[],
+	options?: ProbeSpawnOptions,
+): Promise<SpawnResult> {
+	return safeSpawnAsync(command, [...args], { ...options, cwd: undefined });
+}

--- a/clients/tool-probe.ts
+++ b/clients/tool-probe.ts
@@ -43,7 +43,10 @@ export type ProbeSpawnOptions = Omit<SafeSpawnOptions, "cwd">;
  * `cwd` is STRIPPED rather than merely left out of {@link ProbeSpawnOptions}:
  * the type stops an object literal from carrying one, and the destructure
  * below removes one that arrived inside an already-typed options object a
- * caller widened or spread. A probe that genuinely needs to
+ * caller widened or spread. Both halves are guarded — deleting the
+ * destructure changes this call's text, which retires the sweep's admission
+ * row, and `tests/clients/probe-and-root-spawn-cwd.test.ts` reds on the
+ * smuggled cwd reaching the child. A probe that genuinely needs to
  * run somewhere — `mix credo --version` needs a mix project, `cargo clippy
  * --version` needs a package, `eslint --version` resolves a project-local
  * binary — must call `safeSpawnAsync` directly and be admitted by that sweep
@@ -60,5 +63,5 @@ export async function probeToolAsync(
 	// `cwd: undefined` is a strictness spike the `tests/config` ratchet counts).
 	const { cwd: _strippedCwd, ...rest } = (options ?? {}) as SafeSpawnOptions;
 	void _strippedCwd;
-	return safeSpawnAsync(command, [...args], rest);
+	return safeSpawnAsync(command, [...args], { ...rest });
 }

--- a/tests/clients/biome-autofix-argv.test.ts
+++ b/tests/clients/biome-autofix-argv.test.ts
@@ -66,4 +66,26 @@ describe("BiomeClient.fixFileAsync — autofix argv order + cwd (#1247 review)",
 			removeTempDirSync(tmpDir);
 		}
 	});
+
+	it("autofix resolves the same nested package root as the runner seam", async () => {
+		const tmpDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-lens-biome-nested-"),
+		);
+		try {
+			const packageDir = path.join(tmpDir, "packages", "api");
+			const filePath = path.join(packageDir, "src", "app.ts");
+			fs.mkdirSync(path.dirname(filePath), { recursive: true });
+			fs.writeFileSync(path.join(packageDir, "biome.json"), "{}\n");
+			fs.writeFileSync(filePath, "const x = 1;\n");
+
+			const { BiomeClient } = await import("../../clients/biome-client.js");
+			await new BiomeClient().fixFileAsync(filePath, tmpDir);
+			const lintCall = safeSpawnAsync.mock.calls.find((call: unknown[]) =>
+				(call[1] as string[]).includes("lint"),
+			) as [string, string[], { cwd?: string }];
+			expect(lintCall?.[2]?.cwd).toBe(packageDir);
+		} finally {
+			removeTempDirSync(tmpDir);
+		}
+	});
 });

--- a/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
+++ b/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
@@ -133,7 +133,7 @@ const POPULATION_FILES = [
  * #2894 moved 20 direct sites (136 -> 117) and 3 wrapper sites off this scan
  * by folding every `--version`/presence probe onto `safe-spawn.ts`'s
  * `probeToolAsync`, which is not a spawn NAME the scan recognises, so a file
- * whose only child was a probe leaves the population entirely (76 -> 73:
+ * whose only child was a probe leaves the population entirely (76 -> 73 before `tool-probe.ts` itself joins it:
  * `dispatch/dispatcher.ts`, `dispatch/runners/utils/candidate-probe.ts`,
  * `security-scan-client.ts`). That is reach TRADED, not lost: the population
  * filter reads each file's CONTENT, so the moment any of those three writes a
@@ -141,7 +141,7 @@ const POPULATION_FILES = [
  * one cwd decision they used to make 24 times over is now made once, inside
  * `probeToolAsync`, where this file admits it by name.
  */
-const EXPECTED_FILES = 73;
+const EXPECTED_FILES = 74;
 const EXPECTED_DIRECT_SITES = 117;
 /**
  * Every same-file spawn-routing wrapper call site the scan discovers. Pinned
@@ -303,10 +303,6 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 		"`npm config get prefix` / `pnpm bin -g` / `yarn global bin` — global install-location queries",
 	],
 	[
-		"clients/safe-spawn.ts#probeToolAsync:c29ed877~c29ed877",
-		"THE probe seam (#2894): `probeToolAsync` spawns a tool's own presence/version invocation and strips any `cwd` its caller passed, because the answer to \"does this binary exist and what does it call itself\" does not depend on a directory. The 24 sites that used to decide that one at a time now call it",
-	],
-	[
 		"clients/safe-spawn.ts#safeSpawnAsync.killTree:77f62fd4",
 		"`taskkill /F /T /PID <pid>` — kills a process tree by pid on Windows; it touches no file",
 	],
@@ -361,6 +357,10 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	[
 		"clients/test-runner-client.ts#TestRunnerClient.detectRunner:4411bf71",
 		"`which pytest` / `where pytest` PATH lookup for the global-pytest fallback",
+	],
+	[
+		"clients/tool-probe.ts#probeToolAsync:c29ed877~c29ed877",
+		"THE probe seam (#2894): `probeToolAsync` spawns a tool's own presence/version invocation and STRIPS whatever `cwd` reached it, because \"does this binary exist, and what does it call itself\" has the same answer from every directory. The 24 sites that each decided that for themselves now call it, so this is the one row a reviewer re-reads for the whole class",
 	],
 	[
 		"clients/zizmor-config.ts#deriveGhCliToken:6acc7c4b",
@@ -739,7 +739,7 @@ describe("dispatch runner spawns pass ctx.cwd (#2691 ratchet)", () => {
 	const sites: SpawnCwdSite[] = [];
 	const keyBySite = new Map<SpawnCwdSite, string>();
 
-	// The scan is ~2.8–3.7 s over the 73-file population, measured idle and at
+	// The scan is ~2.8–3.7 s over the 74-file population, measured idle and at
 	// `--maxWorkers=1` beside `tests/config`. CI observed ~7 s for this file,
 	// so 30 s gives roughly 4x margin against the file wall and remains the
 	// ceiling this repo treats as a hook budget — an

--- a/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
+++ b/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
@@ -70,6 +70,10 @@
  *
  * ## Adding a spawn
  *
+ * A tool PRESENCE/VERSION probe is not one of these: call `probeToolAsync`
+ * (#2894) and it is neither a site nor a row, because that seam owns the
+ * no-cwd contract for the whole class. Everything else follows the rule below.
+ *
  * A new child spawn that passes a seam-resolved `cwd` costs one number:
  * `EXPECTED_DIRECT_SITES` (or `EXPECTED_WRAPPER_SITES`) moves by one, which is
  * where a reviewer sees the spawn was added. A new child spawn that does NOT
@@ -125,9 +129,20 @@ const POPULATION_FILES = [
  *
  * They pin REACH, never conformance: see "Adding a spawn" in the header for
  * what a non-conforming new site costs instead.
+ *
+ * #2894 moved 20 direct sites (136 -> 117) and 3 wrapper sites off this scan
+ * by folding every `--version`/presence probe onto `safe-spawn.ts`'s
+ * `probeToolAsync`, which is not a spawn NAME the scan recognises, so a file
+ * whose only child was a probe leaves the population entirely (76 -> 73:
+ * `dispatch/dispatcher.ts`, `dispatch/runners/utils/candidate-probe.ts`,
+ * `security-scan-client.ts`). That is reach TRADED, not lost: the population
+ * filter reads each file's CONTENT, so the moment any of those three writes a
+ * `safeSpawnAsync(` again the file re-enters and its site is checked — and the
+ * one cwd decision they used to make 24 times over is now made once, inside
+ * `probeToolAsync`, where this file admits it by name.
  */
-const EXPECTED_FILES = 76;
-const EXPECTED_DIRECT_SITES = 136;
+const EXPECTED_FILES = 73;
+const EXPECTED_DIRECT_SITES = 117;
 /**
  * Every same-file spawn-routing wrapper call site the scan discovers. Pinned
  * as a LIST, not a count, because the list is the part round 2 got wrong: it
@@ -148,7 +163,6 @@ const EXPECTED_DIRECT_SITES = 136;
  */
 const EXPECTED_WRAPPER_SITES = [
 	"clients/biome-client.ts:spawnBiomeAsync",
-	"clients/biome-client.ts:spawnBiomeAsync",
 	"clients/dead-code-client.ts:runAnalyze",
 	"clients/dependency-checker.ts:runCheckFile",
 	"clients/dependency-checker.ts:runMadgeSpawn",
@@ -159,8 +173,6 @@ const EXPECTED_WRAPPER_SITES = [
 	"clients/dispatch/runners/helm-render.ts:runIacPass",
 	"clients/dispatch/runners/helm-render.ts:renderAndValidate",
 	"clients/dispatch/runners/oxlint.ts:resolveVitePlusCommand",
-	"clients/dispatch/runners/psscriptanalyzer.ts:spawnPs",
-	"clients/dispatch/runners/psscriptanalyzer.ts:spawnPs",
 	"clients/dispatch/runners/psscriptanalyzer.ts:spawnPs",
 	"clients/dispatch/runners/utils/lazy-installer.ts:performInstall",
 	"clients/dispatch/runners/utils/lazy-installer.ts:runLazyInstall",
@@ -211,14 +223,6 @@ const EXPECTED_WRAPPERS = [
  */
 const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	[
-		"clients/biome-client.ts#BiomeClient.probeBiome:91ce6b49",
-		"`biome --version` presence probe through spawnBiomeAsync: no project target to resolve config against",
-	],
-	[
-		"clients/dead-code-client.ts#PythonDeadCodeClient.doEnsureAvailable:46c732a4",
-		"`<vulture candidate> --version` availability probe over PATH candidates: no project target",
-	],
-	[
 		"clients/dead-code-client.ts#PythonDeadCodeClient.analyze:488c639e~e7e502d1",
 		"the analysis root reaches runAnalyze as `key` (path.resolve(root)); the name carries no `cwd`, so the wrapper rule cannot see it — the spawn it reaches passes it as cwd",
 	],
@@ -227,76 +231,16 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 		"forwards runCheckFile's own `projectRoot` parameter into runMadgeSpawn; the parameter name carries no `cwd`, so the wrapper rule reads it as unsupplied",
 	],
 	[
-		"clients/dispatch/dispatcher.ts#checkToolAvailability:8b362990",
-		"`<tool> --version` availability probe the dispatcher shares across runners: no project target",
-	],
-	[
-		"clients/dispatch/runners/cpp-check.ts#resolveCompiler:ef272657",
-		"`cl` with no arguments — an MSVC presence probe that reads no file and no config; carries the in-source cwd-exempt tag too",
-	],
-	[
-		"clients/dispatch/runners/psscriptanalyzer.ts#resolvePowerShellCmd:e2207b24",
-		"`pwsh -NoProfile -Command exit 0` interpreter-presence probe through spawnPs; carries the in-source cwd-exempt tag",
-	],
-	[
-		"clients/dispatch/runners/psscriptanalyzer.ts#checkModuleAvailable:2e480adc",
-		"`Get-Module -ListAvailable PSScriptAnalyzer` module-presence probe: PowerShell resolves modules from its own search path, not from a project",
-	],
-	[
-		"clients/dispatch/runners/utils/candidate-probe.ts#probeAvailabilityCandidates:612dec1d",
-		"shared availability-probe helper: runs each candidate with its probe args (`--version` and friends) to ask whether the binary exists at all",
-	],
-	[
-		"clients/dispatch/runners/utils/runner-helpers.ts#probeAstGrepCommandAsync:b28406d1",
-		"`<ast-grep> --version` PATH probe for the sg sweep: no project target",
-	],
-	[
-		"clients/dispatch/runners/utils/runner-helpers.ts#resolveLocalFirstAsync:5e71e1e9",
-		"`<tool> --version` global-PATH step of the local-first resolution ladder: it asks whether the tool exists system-wide, after the project-local lookups have failed",
-	],
-	[
 		"clients/formatters.ts#which:040c257b",
 		"`which`/`where <command>` PATH lookup: the answer is the same from any directory",
-	],
-	[
-		"clients/formatters.ts#resolveGoFmtBinary:8379fd5c",
-		"`go env GOROOT` — a toolchain query about the Go installation, not about the project",
-	],
-	[
-		"clients/formatters.ts#resolveCommand:057285b5",
-		"`dotnet csharpier --version` presence probe for the legacy driver form",
-	],
-	[
-		"clients/formatters.ts#detect:e11d4239",
-		"`dotnet csharpier --version` presence probe in the csharpier formatter's detect()",
-	],
-	[
-		"clients/formatters.ts#detect:4818fd92",
-		"`Get-Module -ListAvailable PSScriptAnalyzer` presence probe in the powershell formatter's detect()",
-	],
-	[
-		"clients/govulncheck-client.ts#GovulncheckClient.doEnsureAvailable:d94153fa",
-		"`go version` toolchain presence probe",
 	],
 	[
 		"clients/govulncheck-client.ts#GovulncheckClient.doEnsureAvailable:eff0855a",
 		"`go install golang.org/x/vuln/cmd/govulncheck@latest` — installs into the Go tool directory, not into the project",
 	],
 	[
-		"clients/govulncheck-client.ts#GovulncheckClient.doEnsureAvailable:ea10738d",
-		"`govulncheck -version` re-probe after the install attempt",
-	],
-	[
-		"clients/installer/index.ts#verifyAstGrepProbePath:56408f6e",
-		"`<binPath> --version` verification of a downloaded ast-grep binary",
-	],
-	[
 		"clients/installer/index.ts#verifyToolBinary:96ec5ee1",
 		"`<execPath> <verificationArgs>` verification that an installed managed binary runs at all",
-	],
-	[
-		"clients/installer/index.ts#getAllToolStatuses:54003c71",
-		"`<tool.checkCommand> --version` status sweep across installed tools",
 	],
 	[
 		"clients/installer/index.ts#getPythonUserBaseCandidates:3fead921",
@@ -313,10 +257,6 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	[
 		"clients/installer/index.ts#installGitHubTool:bd7b7ee6~5ede8ca9",
 		"`unzip -q -o <archive> -d <tmpDir>` extraction inside the global pi-lens bin directory",
-	],
-	[
-		"clients/installer/index.ts#probeManagedToolVersion:3050f1fc",
-		"`<cached managed binary> <checkArgs>` version probe for the managed-tool refresh",
 	],
 	[
 		"clients/installer/index.ts#installPipTool:ba749b5d",
@@ -359,24 +299,12 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 		"forks the review worker with `process.execPath`; the project it must analyse is passed explicitly as the `--cwd=<dir>` argv flag, so the child's own directory is not the channel",
 	],
 	[
-		"clients/package-manager.ts#probeAvailability:d0a6319a",
-		"`which`/`where <package manager>` PATH lookup",
-	],
-	[
 		"clients/package-manager.ts#probeGlobalBinDirs:bf156997",
 		"`npm config get prefix` / `pnpm bin -g` / `yarn global bin` — global install-location queries",
 	],
 	[
-		"clients/pipeline.ts#tryRustClippyFix:8e05db7b",
-		"`cargo --version` presence probe, before the package root is known",
-	],
-	[
-		"clients/pipeline.ts#tryDartFix:91623ccc",
-		"`dart --version` presence probe, before the package root is known",
-	],
-	[
-		"clients/ruff-client.ts#RuffClient.fixFileAsync:61f923b4",
-		"the options object is the local `spawnOpts`, built two statements above with `cwd: cwd ?? path.dirname(absolutePath)`; the scan does not follow an opaque options identifier (stated bound), so the cwd it carries is invisible here",
+		"clients/safe-spawn.ts#probeToolAsync:c29ed877~c29ed877",
+		"THE probe seam (#2894): `probeToolAsync` spawns a tool's own presence/version invocation and strips any `cwd` its caller passed, because the answer to \"does this binary exist and what does it call itself\" does not depend on a directory. The 24 sites that used to decide that one at a time now call it",
 	],
 	[
 		"clients/safe-spawn.ts#safeSpawnAsync.killTree:77f62fd4",
@@ -403,16 +331,8 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 		"`which`/`where <command>` PATH lookup returning the path (deprecated sync form)",
 	],
 	[
-		"clients/security-scan-client.ts#SecurityScanClient.probeVersion:355605e9",
-		"`<tool> <versionArgs>` version probe of a managed or PATH security binary",
-	],
-	[
 		"clients/sg-runner.ts#SgRunner.probeHomebrew:4df45ecb",
 		"`brew --prefix ast-grep` — asks Homebrew where it installed the binary",
-	],
-	[
-		"clients/sg-runner.ts#SgRunner.probeCommand:45a37c68",
-		"`<ast-grep candidate> --version` availability probe",
 	],
 	[
 		"clients/sg-runner.ts#SgRunner.execRaw:05d2e3a2",
@@ -531,10 +451,6 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	[
 		"clients/dispatch/runners/rust-clippy.ts#makeClippyProbe:1dfbec79~dbf27697",
 		"`cargo clippy --version` inside a createCwdCachedProbe closure: the `cwd` is the closure parameter the probe machinery supplies per call",
-	],
-	[
-		"clients/dispatch/runners/rust-clippy.ts#run:dba44d7f~6991f811",
-		"cwd is the directory of `findCargoToml(ctx.filePath)` — cargo must run at the package root, which is derived from the edited file rather than from the seam",
 	],
 	[
 		"clients/dispatch/runners/terragrunt.ts#run:d106f5a8~2a7d9054",
@@ -693,10 +609,6 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 		"runPipeline forwards its own `cwd` parameter into runAutofix",
 	],
 	[
-		"clients/ruff-client.ts#RuffClient.fixFileAsync:22e02ee5~4421fb24",
-		"cwd is the caller's own `cwd` argument, falling back to the linted file's directory; RuffClient is an autofix client with no DispatchContext seam",
-	],
-	[
 		"clients/safe-spawn.ts#safeSpawnAsync:f7eca8ca~446d128f",
 		"this IS the spawn seam: `spawnCwd` is the cwd its own caller passed in options, so the origin rule applies to the callers, not here",
 	],
@@ -827,7 +739,7 @@ describe("dispatch runner spawns pass ctx.cwd (#2691 ratchet)", () => {
 	const sites: SpawnCwdSite[] = [];
 	const keyBySite = new Map<SpawnCwdSite, string>();
 
-	// The scan is ~2.8–3.7 s over the 76-file population, measured idle and at
+	// The scan is ~2.8–3.7 s over the 73-file population, measured idle and at
 	// `--maxWorkers=1` beside `tests/config`. CI observed ~7 s for this file,
 	// so 30 s gives roughly 4x margin against the file wall and remains the
 	// ceiling this repo treats as a hook budget — an

--- a/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
+++ b/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
@@ -360,7 +360,7 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/tool-probe.ts#probeToolAsync:c29ed877~c29ed877",
-		"THE probe seam (#2894): `probeToolAsync` spawns a tool's own presence/version invocation and STRIPS whatever `cwd` reached it, because \"does this binary exist, and what does it call itself\" has the same answer from every directory. The 24 sites that each decided that for themselves now call it, so this is the one row a reviewer re-reads for the whole class",
+		'THE probe seam (#2894): `probeToolAsync` spawns a tool\'s own presence/version invocation and STRIPS whatever `cwd` reached it, because "does this binary exist, and what does it call itself" has the same answer from every directory. The 24 sites that each decided that for themselves now call it, so this is the one row a reviewer re-reads for the whole class',
 	],
 	[
 		"clients/zizmor-config.ts#deriveGhCliToken:6acc7c4b",

--- a/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
+++ b/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
@@ -138,7 +138,7 @@ const POPULATION_FILES = [
  * `security-scan-client.ts`). That is reach TRADED, not lost: the population
  * filter reads each file's CONTENT, so the moment any of those three writes a
  * `safeSpawnAsync(` again the file re-enters and its site is checked — and the
- * one cwd decision they used to make 24 times over is now made once, inside
+ * one cwd decision they used to make 23 times over is now made once, inside
  * `probeToolAsync`, where this file admits it by name.
  */
 const EXPECTED_FILES = 74;
@@ -360,7 +360,7 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/tool-probe.ts#probeToolAsync:2d247383",
-		'THE probe seam (#2894): `probeToolAsync` spawns a tool\'s own presence/version invocation and STRIPS whatever `cwd` reached it, because "does this binary exist, and what does it call itself" has the same answer from every directory. The 24 sites that each decided that for themselves now call it, so this is the one row a reviewer re-reads for the whole class',
+		'THE probe seam (#2894): `probeToolAsync` spawns a tool\'s own presence/version invocation and STRIPS whatever `cwd` reached it, because "does this binary exist, and what does it call itself" has the same answer from every directory. The 23 sites that each decided that for themselves now call it, so this is the one row a reviewer re-reads for the whole class',
 	],
 	[
 		"clients/zizmor-config.ts#deriveGhCliToken:6acc7c4b",
@@ -371,10 +371,6 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	[
 		"clients/biome-client.ts#BiomeClient.spawnBiomeAsync:29a3826f~29a3826f",
 		"cwd is spawnBiomeAsync's own `cwd` parameter; the checked sites are its two call sites in this file",
-	],
-	[
-		"clients/biome-client.ts#BiomeClient.fixFileAsync:21f726e7~87e15e1e",
-		"cwd is `configCwd` — the caller's cwd or the formatted file's own directory; BiomeClient is a formatter client with no DispatchContext to resolve from",
 	],
 	[
 		"clients/dead-code-client.ts#PythonDeadCodeClient.runAnalyze:b54a18c7~1167a91f",

--- a/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
+++ b/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
@@ -359,7 +359,7 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 		"`which pytest` / `where pytest` PATH lookup for the global-pytest fallback",
 	],
 	[
-		"clients/tool-probe.ts#probeToolAsync:821b69e9",
+		"clients/tool-probe.ts#probeToolAsync:2d247383",
 		'THE probe seam (#2894): `probeToolAsync` spawns a tool\'s own presence/version invocation and STRIPS whatever `cwd` reached it, because "does this binary exist, and what does it call itself" has the same answer from every directory. The 24 sites that each decided that for themselves now call it, so this is the one row a reviewer re-reads for the whole class',
 	],
 	[

--- a/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
+++ b/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
@@ -224,11 +224,11 @@ const EXPECTED_WRAPPERS = [
 const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	[
 		"clients/dead-code-client.ts#PythonDeadCodeClient.analyze:488c639e~e7e502d1",
-		"the analysis root reaches runAnalyze as `key` (path.resolve(root)); the name carries no `cwd`, so the wrapper rule cannot see it — the spawn it reaches passes it as cwd",
+		"the analysis root reaches runAnalyze as `key` (path.resolve(root)); the name carries no `cwd`, so the wrapper rule cannot see it — the spawn it reaches passes it as cwd. #2894 left it: `analyze(root)`'s input is already a DIRECTORY, and `resolveToolCwd` takes a FILE and starts from `path.dirname` of it, so handing it a root would walk from that root's PARENT",
 	],
 	[
 		"clients/dependency-checker.ts#DependencyChecker.runCheckFile:fbbf6499~dcd12892",
-		"forwards runCheckFile's own `projectRoot` parameter into runMadgeSpawn; the parameter name carries no `cwd`, so the wrapper rule reads it as unsupplied",
+		"forwards runCheckFile's own `projectRoot` parameter into runMadgeSpawn; the parameter name carries no `cwd`, so the wrapper rule reads it as unsupplied. #2894 left the whole file: `checkFile`, `checkFilesBatch` and `scanProject` share ONE `projectRoot` per operation (one madge resolution, one import cache, one published state — the contract on `checkFilesBatch`), `scanProject` has no file at all, and `checkFile` has no production caller — `runtime-turn.ts` calls the batch. Per-file roots there is mechanism, and #2905 tracks it",
 	],
 	[
 		"clients/formatters.ts#which:040c257b",
@@ -272,7 +272,7 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/knip-client.ts#KnipClient.analyze:a1223aae~98d0e4c5",
-		"the analysis root reaches runAnalyze as `key` (path.resolve(targetDir)); the name carries no `cwd`, so the wrapper rule reads it as unsupplied",
+		"the analysis root reaches runAnalyze as `key` (path.resolve(targetDir)); the name carries no `cwd`, so the wrapper rule reads it as unsupplied. Same #2894 verdict as dead-code-client: the input is a directory, and `resolveToolCwd` dirnames its `file` argument",
 	],
 	[
 		"clients/lsp/jvm-runtime.ts#runJavaProbe:41cf49b2",
@@ -378,7 +378,7 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/dead-code-client.ts#PythonDeadCodeClient.runAnalyze:b54a18c7~1167a91f",
-		"cwd is runAnalyze's own `root` parameter, the resolved project directory the client was asked to analyse",
+		"cwd is runAnalyze's own `root` parameter, the resolved project directory the client was asked to analyse — a directory the caller names, not a file the seam can resolve a root from (#2894)",
 	],
 	[
 		"clients/dependency-checker.ts#DependencyChecker.checkFile:1935bb9d~bed57757",
@@ -410,7 +410,7 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/dispatch/runners/cue-vet.ts#run:f61eafcc~3e35e485@1",
-		"cwd is `fileDir` = dirname(path.resolve(<resolveRunnerCwd result>, ctx.filePath)) — cue vets the file's own package directory; the scan does not follow a path computation, so the derivation is registered here",
+		"cwd is `fileDir` = dirname(path.resolve(<resolveRunnerCwd result>, ctx.filePath)) — cue vets the file's own package directory; the scan does not follow a path computation, so the derivation is registered here. #2894 left it: a CUE package IS one directory, and `resolveToolCwd` walks UP to a marker or git root, so it cannot return a plain file directory in any repo (this runner already takes its availability cwd from the seam)",
 	],
 	[
 		"clients/dispatch/runners/cue-vet.ts#run:1803a70e~3e35e485",
@@ -454,11 +454,11 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/dispatch/runners/terragrunt.ts#run:d106f5a8~2a7d9054",
-		"cwd is `fileDir` = dirname(path.resolve(<resolveRunnerCwd result>, ctx.filePath)): `terragrunt hcl validate` validates the unit directory the file sits in",
+		"cwd is `fileDir` = dirname(path.resolve(<resolveRunnerCwd result>, ctx.filePath)): `terragrunt hcl validate` validates the unit directory the file sits in — a directory, not a marker root, so the #2894 fold does not reach it (the runner already resolves its availability cwd through the seam)",
 	],
 	[
 		"clients/dispatch/runners/tflint.ts#run:338013e8~a6e3b67b",
-		"cwd is `fileDir` = dirname(path.resolve(<resolveRunnerCwd result>, ctx.filePath)): tflint scans one module directory and its --config is passed absolute",
+		"cwd is `fileDir` = dirname(path.resolve(<resolveRunnerCwd result>, ctx.filePath)): tflint scans one module directory and its --config is passed absolute — a Terraform module IS a directory, which is why #2894 left it where cue-vet and terragrunt stay",
 	],
 	[
 		"clients/dispatch/runners/utils/lazy-installer.ts#runLazyInstall:c226c0b2~c226c0b2",
@@ -510,7 +510,7 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/git-tracked-ignore.ts#collectUntrackedIgnoredIds:538456dd~538456dd",
-		"collectUntrackedIgnoredIds forwards its own `cwd` parameter, the repository root its callers pass",
+		"collectUntrackedIgnoredIds forwards its own `cwd` parameter, the repository root its callers pass — same #2894 verdict as collectTrackedFiles: the cwd is the git query's SUBJECT",
 	],
 	[
 		"clients/git-tracked-ignore.ts#fetchTrackedFiles:5fc25306~dbf27697",
@@ -518,7 +518,7 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/git-tracked-ignore.ts#collectTrackedFiles:0f864633~0f864633",
-		"collectTrackedFiles forwards its own `cwd` parameter, the repository root its callers pass",
+		"collectTrackedFiles forwards its own `cwd` parameter, the repository root its callers pass — `git ls-files` REPORTS ON that directory rather than resolving config from it, so moving it to a marker root would answer about a different repository (#2894)",
 	],
 	[
 		"clients/gitleaks-client.ts#GitleaksClient.scan:c23b1b18~4bd5cc03",
@@ -562,7 +562,7 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/knip-client.ts#KnipClient.runAnalyze:b959739e~f5c0e305",
-		"cwd is `targetDir`, runAnalyze's own project-root parameter; knip resolves its config from there",
+		"cwd is `targetDir`, runAnalyze's own project-root parameter; knip resolves its config from there — a whole-project scan with no edited file for the seam to walk up from (#2894)",
 	],
 	[
 		"clients/mcp/review.ts#runRebuild:f93df254~9f5ecf07",
@@ -570,15 +570,15 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/opaque-mutation-scan.ts#isGitWorktree:7e6a8cd3~edb3d44f",
-		"cwd is isGitWorktree's own `root` parameter — `git rev-parse --is-inside-work-tree` asks about exactly that directory",
+		"cwd is isGitWorktree's own `root` parameter — `git rev-parse --is-inside-work-tree` asks about exactly that directory, so a seam that moved it to a marker root would answer a different question (#2894)",
 	],
 	[
 		"clients/opaque-mutation-scan.ts#resolveGitToplevel:49511e7e~1167a91f",
-		"cwd is resolveGitToplevel's own `root` parameter — `git rev-parse --show-toplevel` asks about exactly that directory",
+		"cwd is resolveGitToplevel's own `root` parameter — `git rev-parse --show-toplevel` asks about exactly that directory; the answer IS the root, so resolving one first would be circular (#2894)",
 	],
 	[
 		"clients/opaque-mutation-scan.ts#recoverOpaqueChangesViaGit:dad86fa7~1167a91f",
-		"cwd is recoverOpaqueChangesViaGit's own `root` parameter — `git status --porcelain` reports the worktree at that root",
+		"cwd is recoverOpaqueChangesViaGit's own `root` parameter — `git status --porcelain` reports the worktree at that root, which is the query's subject, not a config-resolution start (#2894)",
 	],
 	[
 		"clients/opengrep-client.ts#OpengrepClient.scan:c23b1b18~4bd5cc03",
@@ -614,7 +614,7 @@ const ORIGIN_ADMISSION_ROWS: ReadonlyArray<readonly [string, string]> = [
 	],
 	[
 		"clients/shared-checkout-guard.ts#probeWorkingTreeState:67edebd4~c87eec21",
-		"cwd is probeWorkingTreeState's own `root` parameter — `git status` reports the worktree at that root",
+		"cwd is probeWorkingTreeState's own `root` parameter — `git status` reports the worktree at that root. Not a tool probe in #2894's sense: it asks about a directory, so it cannot use the cwd-less probe seam",
 	],
 	[
 		"clients/trivy-client.ts#TrivyClient.scan:c23b1b18~4bd5cc03",

--- a/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
+++ b/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
@@ -359,7 +359,7 @@ const NO_CWD_EXEMPTION_ROWS: ReadonlyArray<readonly [string, string]> = [
 		"`which pytest` / `where pytest` PATH lookup for the global-pytest fallback",
 	],
 	[
-		"clients/tool-probe.ts#probeToolAsync:c29ed877~c29ed877",
+		"clients/tool-probe.ts#probeToolAsync:821b69e9",
 		'THE probe seam (#2894): `probeToolAsync` spawns a tool\'s own presence/version invocation and STRIPS whatever `cwd` reached it, because "does this binary exist, and what does it call itself" has the same answer from every directory. The 24 sites that each decided that for themselves now call it, so this is the one row a reviewer re-reads for the whole class',
 	],
 	[

--- a/tests/clients/probe-and-root-spawn-cwd.test.ts
+++ b/tests/clients/probe-and-root-spawn-cwd.test.ts
@@ -5,8 +5,8 @@
  * resolved at a different seam than its child spawn", and the #2872 sweep's
  * admission tables going unauditable):
  *
- * 1. PROBES. 24 availability/version spawns each decided "no cwd" in their own
- *    words, and the sweep carried 24 sentences a reviewer had to re-read one
+ * 1. PROBES. 23 availability/version spawns each decided "no cwd" in their own
+ *    words, and the sweep carried 23 sentences a reviewer had to re-read one
  *    at a time. `probeToolAsync` owns that decision now, and it STRIPS a cwd
  *    rather than merely omitting one — the failure mode being closed is a
  *    probe that quietly acquires a project directory through an options

--- a/tests/clients/probe-and-root-spawn-cwd.test.ts
+++ b/tests/clients/probe-and-root-spawn-cwd.test.ts
@@ -1,0 +1,238 @@
+/**
+ * #2894 — the two spawn-cwd classes that used to be decided site by site.
+ *
+ * Recurrence this file prevents (AGENTS.md defect shape 40, "a tool root
+ * resolved at a different seam than its child spawn", and the #2872 sweep's
+ * admission tables going unauditable):
+ *
+ * 1. PROBES. 24 availability/version spawns each decided "no cwd" in their own
+ *    words, and the sweep carried 24 sentences a reviewer had to re-read one
+ *    at a time. `probeToolAsync` owns that decision now, and it STRIPS a cwd
+ *    rather than merely omitting one — the failure mode being closed is a
+ *    probe that quietly acquires a project directory through an options
+ *    object someone widened, which is invisible to the type alone.
+ *
+ * 2. HAND-DERIVED ROOTS. `ruff-client.ts` computed
+ *    `cwd ?? path.dirname(absolutePath)` while `dispatch/runners/ruff.ts`
+ *    used `resolveRunnerCwd` for the same file — two derivations for one root,
+ *    which `tool-policy.ts`'s own contract says must agree. Measured on
+ *    pre-#2894 code, with the caller passing the workspace root and the file
+ *    in a nested package that ships its own `pyproject.toml`:
+ *
+ *      ruff check --output-format json …  cwd=<workspace root>
+ *
+ *    i.e. the nested package's config never applied. `rust-clippy.ts` had the
+ *    same shape with its own `findNearestContaining(dirname(file),
+ *    ["Cargo.toml"])` walk, uncapped by the dispatch root.
+ *
+ * Everything below drives the REAL production paths — the real dispatcher
+ * availability probe, the real `RuffClient.fixFileAsync`, the real runner
+ * `run()` — and fakes only the process boundary (`safeSpawnAsync`), which is
+ * where the child's cwd is observed. A real spawn would show nothing extra
+ * and would need `flake-shape-ratchet` admission for a shape the fix does not
+ * require.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+	SafeSpawnOptions,
+	SpawnResult,
+} from "../../clients/safe-spawn.js";
+
+type SafeSpawnAsync = (
+	command: string,
+	args: string[],
+	options?: SafeSpawnOptions,
+) => Promise<SpawnResult>;
+
+const spawned: Array<{
+	command: string;
+	args: string[];
+	cwd?: string;
+	hasCwdKey: boolean;
+}> = [];
+
+const { safeSpawnAsync, findCargoPathAsync } = vi.hoisted(() => ({
+	safeSpawnAsync: vi.fn<SafeSpawnAsync>(),
+	findCargoPathAsync: vi.fn(async () => "/usr/bin/cargo" as string | null),
+}));
+
+// The no-argument `importOriginal()` pass-through is the idiom
+// `tests/config/vi-mock-export-sweep.test.ts` recognises as complete (#2784).
+vi.mock("../../clients/safe-spawn.js", async (importOriginal) => ({
+	...(await importOriginal()),
+	safeSpawnAsync,
+}));
+vi.mock("../../clients/rust-client.js", async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		rustClient: {
+			...(actual.rustClient as object),
+			findCargoPathAsync,
+		},
+	};
+});
+
+import { resetDegradationLedger } from "../../clients/degradation-ledger.js";
+import { FactStore } from "../../clients/dispatch/fact-store.js";
+import { probeToolAsync } from "../../clients/tool-probe.js";
+import { makeRunnerCtx } from "../support/runner-ctx.js";
+import { removeTempDirSync } from "./test-utils.js";
+
+const dirs: string[] = [];
+let previousHome: string | undefined;
+
+beforeEach(() => {
+	// The seam caps every marker walk at `$HOME` (`isAtOrAboveHomeDir`), so a
+	// fixture under the OS temp root is out of reach of its own markers unless
+	// the ceiling moves with it. `os.homedir()` reads `$HOME` on POSIX, and
+	// pointing it at the temp root is what makes these trees ordinary projects
+	// rather than out-of-tree files.
+	previousHome = process.env.HOME;
+	process.env.HOME = fs.realpathSync(os.tmpdir());
+	spawned.length = 0;
+	safeSpawnAsync.mockImplementation(async (command, args, options) => {
+		spawned.push({
+			command,
+			args,
+			cwd: options?.cwd,
+			hasCwdKey: options !== undefined && "cwd" in options,
+		});
+		return { stdout: "", stderr: "", status: 0 };
+	});
+	resetDegradationLedger();
+});
+
+afterEach(() => {
+	for (const dir of dirs.splice(0)) removeTempDirSync(dir);
+	if (previousHome === undefined) delete process.env.HOME;
+	else process.env.HOME = previousHome;
+	vi.clearAllMocks();
+});
+
+/** A temp project tree, under the `$HOME` the `beforeEach` pins. */
+function makeTree(prefix: string, files: Record<string, string>): string {
+	const root = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), `pi-lens-${prefix}-`)),
+	);
+	dirs.push(root);
+	for (const [rel, content] of Object.entries(files)) {
+		const full = path.join(root, rel);
+		fs.mkdirSync(path.dirname(full), { recursive: true });
+		fs.writeFileSync(full, content);
+	}
+	return root;
+}
+
+describe("#2894 probe seam: a tool probe never carries a cwd", () => {
+	it("probeToolAsync strips a cwd that reached it inside an options object", async () => {
+		// The type forbids `cwd` on a LITERAL; this is the other direction — an
+		// already-typed options object widened at the call site, which is what a
+		// type alone cannot stop. The strip is what makes the seam's single
+		// admission row true for every caller rather than for well-behaved ones.
+		const widened = {
+			timeout: 1000,
+			cwd: "/nested/project",
+		} as SafeSpawnOptions;
+		await probeToolAsync("sometool", ["--version"], widened);
+
+		expect(spawned).toHaveLength(1);
+		expect(spawned[0].cwd).toBeUndefined();
+	});
+
+	it("the dispatcher's shared --version probe reaches the child with no cwd", async () => {
+		// The real `checkToolAvailability` — the highest-traffic availability
+		// consumer in the product, and the seam every `ctx.hasTool(command)`
+		// gate goes through.
+		const { checkToolAvailability } =
+			await import("../../clients/dispatch/dispatcher.js");
+		const nested = makeTree("probe-cwd", { "packages/api/main.py": "x = 1\n" });
+		const previous = process.cwd();
+		process.chdir(path.join(nested, "packages", "api"));
+		try {
+			// `node` is on PATH in every lane, so the on-disk pre-check that guards
+			// the probe passes and the spawn is actually reached.
+			expect(await checkToolAvailability("node", new FactStore())).toBe(true);
+		} finally {
+			process.chdir(previous);
+		}
+
+		const probe = spawned.find((call) => call.args[0] === "--version");
+		expect(probe, "the availability probe spawned").toBeDefined();
+		expect(probe?.cwd).toBeUndefined();
+	});
+});
+
+describe("#2894 root seam: a hand-derived package root resolves through resolveToolCwd", () => {
+	it("ruff autofix runs at the nested package root, not the caller's workspace root", async () => {
+		const root = makeTree("ruff-nested", {
+			"pyproject.toml": "[tool.ruff]\n",
+			"packages/api/pyproject.toml": "[tool.ruff]\n",
+			"packages/api/app.py": "import os\n",
+		});
+		const filePath = path.join(root, "packages", "api", "app.py");
+		const { RuffClient } = await import("../../clients/ruff-client.js");
+
+		// The caller (pipeline.ts) passes the dispatch language root. Pre-#2894
+		// that value WAS the child's cwd; now it is only the ceiling the seam
+		// walks inside.
+		await new RuffClient().fixFileAsync(filePath, root);
+
+		const checks = spawned.filter((call) => call.args[0] === "check");
+		expect(checks.length, "the pre-scan and the --fix pass").toBe(2);
+		for (const call of checks) {
+			expect(call.cwd).toBe(path.join(root, "packages", "api"));
+		}
+	});
+
+	it("cargo clippy runs at the crate root the seam resolves", async () => {
+		const root = makeTree("clippy-nested", {
+			"Cargo.toml": "[workspace]\n",
+			"crates/engine/Cargo.toml": '[package]\nname = "engine"\n',
+			"crates/engine/src/lib.rs": "pub fn f() {}\n",
+		});
+		const filePath = path.join(root, "crates", "engine", "src", "lib.rs");
+		const runner = (
+			await import("../../clients/dispatch/runners/rust-clippy.js")
+		).default;
+
+		await runner.run(makeRunnerCtx(filePath, root, { kind: "rust" }) as never);
+
+		const clippy = spawned.find(
+			(call) => call.args[1] === "--message-format=json",
+		);
+		expect(clippy, "cargo clippy spawned").toBeDefined();
+		expect(clippy?.cwd).toBe(path.join(root, "crates", "engine"));
+	});
+
+	it("cargo clippy skips rather than running above the dispatch root", async () => {
+		// The hand-rolled `findNearestContaining` walk had no ceiling: with the
+		// only Cargo.toml ABOVE the dispatch root it ran cargo outside the
+		// project pi-lens was asked about. The seam caps at the dispatch root,
+		// so the gate — which now asks about the directory cargo would actually
+		// start in — declines instead.
+		const root = makeTree("clippy-outside", {
+			"Cargo.toml": '[package]\nname = "outer"\n',
+			"sub/src/lib.rs": "pub fn f() {}\n",
+		});
+		const filePath = path.join(root, "sub", "src", "lib.rs");
+		const runner = (
+			await import("../../clients/dispatch/runners/rust-clippy.js")
+		).default;
+
+		const result = await runner.run(
+			makeRunnerCtx(filePath, path.join(root, "sub"), {
+				kind: "rust",
+			}) as never,
+		);
+
+		expect(result.status).toBe("skipped");
+		expect(
+			spawned.filter((call) => call.args[1] === "--message-format=json"),
+		).toEqual([]);
+	});
+});

--- a/tests/clients/probe-and-root-spawn-cwd.test.ts
+++ b/tests/clients/probe-and-root-spawn-cwd.test.ts
@@ -235,4 +235,29 @@ describe("#2894 root seam: a hand-derived package root resolves through resolveT
 			spawned.filter((call) => call.args[1] === "--message-format=json"),
 		).toEqual([]);
 	});
+
+	it("cargo clippy sees a crate marker created after its first resolution", async () => {
+		const root = makeTree("clippy-created-later", {
+			"crates/engine/src/lib.rs": "pub fn f() {}\n",
+		});
+		const crateRoot = path.join(root, "crates", "engine");
+		const filePath = path.join(crateRoot, "src", "lib.rs");
+		const runner = (
+			await import("../../clients/dispatch/runners/rust-clippy.js")
+		).default;
+
+		const first = await runner.run(
+			makeRunnerCtx(filePath, root, { kind: "rust" }) as never,
+		);
+		expect(first.status).toBe("skipped");
+		fs.writeFileSync(path.join(crateRoot, "Cargo.toml"), "[package]\n");
+
+		const second = await runner.run(
+			makeRunnerCtx(filePath, root, { kind: "rust" }) as never,
+		);
+		expect(second.status).toBe("succeeded");
+		expect(
+			spawned.filter((call) => call.args[1] === "--message-format=json"),
+		).toHaveLength(1);
+	});
 });

--- a/tests/clients/tool-cwd.test.ts
+++ b/tests/clients/tool-cwd.test.ts
@@ -309,6 +309,28 @@ describe("resolveToolCwd (#2777)", () => {
 		);
 	});
 
+	it("re-walks a negative marker result when a marker is created later", () => {
+		const project = path.join(home, "repo");
+		const nested = path.join(project, "packages", "app");
+		const file = path.join(nested, "src", "main.rs");
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+
+		expect(
+			toolCwd.resolveToolCwd("runner", "rust-clippy", file, {
+				cwd: project,
+			}),
+		).toBe(project);
+		fs.writeFileSync(path.join(nested, "Cargo.toml"), "[package]\n");
+
+		// A negative marker memo must not hide a project created during the
+		// session. The second resolution must reach the new package root.
+		expect(
+			toolCwd.resolveToolCwd("runner", "rust-clippy", file, {
+				cwd: project,
+			}),
+		).toBe(nested);
+	});
+
 	it("bounds and records a foreign-file fallback once per tool and session", async () => {
 		const project = path.join(home, "repo");
 		const foreign = path.join(home, "tmp", "outside.ts");

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -2214,7 +2214,16 @@ const HELPER_UNBOUNDED: Readonly<Record<string, number>> = {
 	// budget and up to three attempts, so the hook path got shorter, not longer.
 	// Like every other entry here neither can take a hook's signal until #2523
 	// AC4 threads it through the deps types.
-	"clients/installer/index.ts": 197,
+	// 197 → 198 (#2894): `verifyAstGrepProbePath` traded a hand-rolled
+	// `new Promise` around a raw `spawn` — which awaited nothing, and whose
+	// `timeout` killed only the direct child — for one `await probeToolAsync`.
+	// `getAllToolStatuses`'s version probe made the same trade and is await-
+	// neutral (its `await new Promise` became `await probeToolAsync`), so the
+	// module gains exactly one. The await it gains is the seam's, with the
+	// tree-kill teardown the raw spawn never had; like every other entry here
+	// it cannot take a hook's signal until #2523 AC4 threads it through the
+	// deps types.
+	"clients/installer/index.ts": 198,
 	"clients/installer/managed-tool-refresh.ts": 29,
 	"clients/instance-reaper.ts": 26,
 	"clients/instance-registry.ts": 23,

--- a/tests/config/strictness-baseline.json
+++ b/tests/config/strictness-baseline.json
@@ -20,7 +20,7 @@
 		"clients/config-core": 1,
 		"clients/dispatch": 18,
 		"clients/dispatch/facts": 1,
-		"clients/dispatch/runners": 32,
+		"clients/dispatch/runners": 31,
 		"clients/dispatch/runners/utils": 9,
 		"clients/dispatch/utils": 2,
 		"clients/installer": 25,


### PR DESCRIPTION
## Summary

Two classes of hand-written spawn-cwd derivation fold onto shared seams.

**Fold 1 — one probe seam.** `clients/tool-probe.ts#probeToolAsync` is the entry
point for a child that ASKS a question (`<tool> --version`, `cl`, `go version`,
`which <pm>`, `Get-Module -ListAvailable`) rather than acting on a project. It
strips any `cwd` that reached it, because the answer is the same from every
directory. 23 sites that each decided that in their own words now call it, so
the #2691 sweep admits ONE cwd-less spawn instead of 23 sentences a reviewer has
to re-read one at a time. Two of those sites were raw `spawn()` calls wrapped in
hand-rolled promises (44 lines deleted) that had no tree-kill on timeout.

**Fold 2 — package roots through `resolveToolCwd`.** `rust-clippy.ts` derived its
package root with its own uncapped `findNearestContaining(dirname(file),
["Cargo.toml"])` walk and then `cargoToml.replace("Cargo.toml", "")` (twice);
it now uses `resolveRunnerCwd(ctx, "rust-clippy")` with `Cargo.toml` registered
in `RUNNER_MARKERS`. `ruff-client.ts#fixFileAsync` used
`cwd ?? path.dirname(absolutePath)` while `dispatch/runners/ruff.ts` used
`resolveRunnerCwd` for the same file — two derivations for one root that
`tool-policy.ts`'s own docstring says must agree; it now uses `resolveToolCwd`.
Both are behaviour changes with quoted reds below.

**Helper count: +1** (`probeToolAsync`). Deleted alongside it: two hand-rolled
`spawn` promises, `rust-clippy.ts`'s `findCargoToml`, `ruff-client.ts`'s
`spawnOpts`, `psscriptanalyzer.ts`'s optional `spawnPs` cwd, and two
`// cwd-exempt:` tags. No pin bump: `WORKLIST_CEILING` is untouched and the
migration worklist still holds exactly the one #2882 row.

**Sweep tables, before → after** (`tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts`,
counted on `origin/master` 07f0ad6e7 and on this head):

| table | before | after |
|---|---|---|
| `NO_CWD_EXEMPTION_ROWS` | 59 | 36 |
| `ORIGIN_ADMISSION_ROWS` | 66 | 63 |
| `MIGRATION_WORKLIST_ROWS` | 1 | 1 |
| `EXPECTED_FILES` | 76 | 74 |
| `EXPECTED_DIRECT_SITES` | 136 | 117 |

24 NO_CWD rows retired and 1 added (the seam's own); 3 ORIGIN rows retired (the verify round counted elements on both trees: master 59/66/1, head 36/63/1).
`EXPECTED_FILES` drops by 3 files whose only child was a probe
(`dispatch/dispatcher.ts`, `dispatch/runners/utils/candidate-probe.ts`,
`security-scan-client.ts`) and gains `clients/tool-probe.ts`. That is reach
TRADED, not lost: the population filter reads each file's CONTENT, so the moment
any of those three writes `safeSpawnAsync(` again the file re-enters and its site
is checked — proven by mutation M6 below.

Refs #2894 — the two acceptance bullets on the folds and the table are met; the
survivors and the follow-ups are named below, and #2882/#2888 have not landed
yet (see Blast radius), so I am not closing it. Follow-ups filed: #2905
(dependency-checker), #2906 (the remaining ask-don't-act children).

### Member table (all 57 rows from the issue, verdict per row)

`probe helper` = `clients/tool-probe.ts#probeToolAsync`. Every test id below is a
live `it(` title in this tree.

| class | member row | current cwd derivation | seam | test that pins it |
|---|---|---|---|---|
| probe | `biome-client.ts#BiomeClient.probeBiome:91ce6b49` | `this.spawnBiomeAsync(["--version"], PROBE_TIMEOUT_MS)` — the wrapper's optional `cwd` left unset | **probe helper** — resolves the binary itself, then `probeToolAsync` | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `dead-code-client.ts#PythonDeadCodeClient.doEnsureAvailable:46c732a4` | `safeSpawnAsync(c.cmd, [...c.prefix, "--version"], { timeout: 5000 })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `dispatch/dispatcher.ts#checkToolAvailability:8b362990` | `safeSpawnAsync(command, ["--version"], { timeout: TOOL_PROBE_TIMEOUT_MS })` | **probe helper** | `the dispatcher's shared --version probe reaches the child with no cwd; every non-exempt spawn's options object names a usable cwd` |
| probe | `dispatch/runners/cpp-check.ts#resolveCompiler:ef272657` | `safeSpawnAsync("cl", [], { timeout: 5000 })` | **probe helper** (no source exemption tag remains) | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `dispatch/runners/psscriptanalyzer.ts#checkModuleAvailable:2e480adc` | `spawnPs(cmd, [...])` with the wrapper's `cwd` unset | **probe helper**; `spawnPs`'s `cwd` is now REQUIRED so the analysis pass is its only caller | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `dispatch/runners/psscriptanalyzer.ts#resolvePowerShellCmd:e2207b24` | `spawnPs(candidate, [...])` with the wrapper's `cwd` unset | **probe helper** (same; both `cwd-exempt:` tags deleted) | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `dispatch/runners/utils/candidate-probe.ts#probeAvailabilityCandidates:612dec1d` | `safeSpawnAsync(candidate, [...probeArgs], { timeout: timeoutMs })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `dispatch/runners/utils/runner-helpers.ts#probeAstGrepCommandAsync:b28406d1` | `safeSpawnAsync(cmd, [...argsPrefix, "--version"], { timeout: 5000 })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `dispatch/runners/utils/runner-helpers.ts#resolveLocalFirstAsync:5e71e1e9` | `safeSpawnAsync(toolName, ["--version"], { timeout: 3000 })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `formatters.ts#detect:4818fd92` | `safeSpawnAsync(pwsh, ["-NoProfile", "-Command", "Get-Module …"], { timeout: 5_000 })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `formatters.ts#detect:e11d4239` | `safeSpawnAsync("dotnet", ["csharpier", "--version"], { timeout: 5000 })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `formatters.ts#resolveCommand:057285b5` | `safeSpawnAsync("dotnet", ["csharpier", "--version"], { timeout: 5000 })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `govulncheck-client.ts#GovulncheckClient.doEnsureAvailable:d94153fa` | `safeSpawnAsync("go", ["version"], { … })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `govulncheck-client.ts#GovulncheckClient.doEnsureAvailable:ea10738d` | `safeSpawnAsync("govulncheck", ["-version"], { … })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `installer/index.ts#getAllToolStatuses:54003c71` | raw `spawn(tool.checkCommand, ["--version"], { shell: win32, timeout: 5000 })` in a hand-rolled promise | **probe helper** — the 20-line promise is deleted | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `installer/index.ts#probeManagedToolVersion:3050f1fc` | `safeSpawnAsync(cached.path, tool.checkArgs, { … })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `installer/index.ts#verifyAstGrepProbePath:56408f6e` | raw `spawn(binPath, ["--version"], { shell: …, timeout: 5000 })` in a hand-rolled promise | **probe helper** — the 24-line promise is deleted | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `pipeline.ts#tryDartFix:91623ccc` | `safeSpawnAsync("dart", ["--version"], { timeout: 5000 })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `pipeline.ts#tryRustClippyFix:8e05db7b` | `safeSpawnAsync("cargo", ["--version"], { timeout: 5000 })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `security-scan-client.ts#SecurityScanClient.probeVersion:355605e9` | `safeSpawnAsync(managed ?? this.toolName, versionArgs, { … })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `sg-runner.ts#SgRunner.probeCommand:45a37c68` | `safeSpawnAsync(cmd, [...argsPrefix, "--version"], { timeout: PROBE_TIMEOUT_MS })` | **probe helper** | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| probe | `dispatch/runners/credo.ts#top:5c9246b1~dbf27697` | `cwd` is the `createCwdCachedProbe` closure parameter | **stays** — `mix credo --version` only answers inside a mix project; it genuinely needs a project cwd, which is what the helper refuses to carry | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| probe | `dispatch/runners/eslint.ts#makeEslintProbe:748a199e~dbf27697` | `cwd` is the `createCwdCachedProbe` closure parameter | **stays** — the probed binary is resolved project-locally per cwd; the verdict is cached per cwd for the same reason | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| probe | `dispatch/runners/oxlint.ts#resolveVitePlusCommand:7b703741~dbf27697` | `cwd` is `resolveVitePlusCommand`'s own parameter | **stays** — `vp --version` is asked of the project's own vite-plus install | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| probe | `dispatch/runners/rust-clippy.ts#makeClippyProbe:1dfbec79~dbf27697` | `cwd` is the `createCwdCachedProbe` closure parameter | **stays** — `cargo clippy --version` needs a package to run in | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| probe | `dispatch/runners/utils/runner-helpers.ts#createAvailabilityChecker.isAvailableAsync:8b06bf2f~d99d2124` | `cwd: resolvedCwd`, the checker's own argument | **stays** — this IS the per-cwd availability seam every runner probes through; a cwd-less probe cannot answer "is the venv/node_modules copy here" | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| probe | `dispatch/runners/utils/runner-helpers.ts#resolveCommandArgsWithInstallFallback:0dcab07a~cb93074a` | `cwd` is the function's own parameter, used for the `--version` verification spawn | **stays** — it verifies the command it just resolved FOR that cwd | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| probe | `pipeline.ts#tryEslintFix:a8585677~dbf27697` | `cwd` is `tryEslintFix`'s own parameter | **stays** — same project-local eslint resolution as the runner's probe | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| probe | `shared-checkout-guard.ts#probeWorkingTreeState:67edebd4~c87eec21` | `cwd: root`, the function's own parameter | **stays** — not a tool probe: `git status` REPORTS ON that directory, so the directory is the question | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dead-code-client.ts#PythonDeadCodeClient.analyze:488c639e~e7e502d1` | `const key = path.resolve(root)` handed to `runAnalyze` | **stays** — `analyze(root)`'s input is already a DIRECTORY; `resolveToolCwd` takes a FILE and starts at `path.dirname` of it, so it would walk from that root's parent | `every non-exempt spawn's options object names a usable cwd` |
| root | `dead-code-client.ts#PythonDeadCodeClient.runAnalyze:b54a18c7~1167a91f` | `cwd` is `runAnalyze`'s own `root` parameter | **stays** — same reason; the wrapper rule already puts the check on its caller | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dependency-checker.ts#DependencyChecker.runCheckFile:fbbf6499~dcd12892` | forwards `projectRoot` into `runMadgeSpawn` | **stays**, tracked by #2905 — one `projectRoot` per OPERATION is the file's documented cross-operation contract, `scanProject` has no file at all, and `checkFile` has no production caller (`runtime-turn.ts` calls the batch) | `every non-exempt spawn's options object names a usable cwd` |
| root | `dependency-checker.ts#DependencyChecker.checkFile:1935bb9d~bed57757` | `projectRoot = path.resolve(cwd \|\| process.cwd())` | **stays**, #2905 — no production caller; folding it alone splits the shared state | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dependency-checker.ts#DependencyChecker.checkFilesBatch:6e4567d4~57c925ee` | same `projectRoot` local, per entry | **stays**, #2905 — the real fold is per-file grouping inside the batch, which is mechanism | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dependency-checker.ts#DependencyChecker.runMadgeSpawn:7a8cc482~218c0256` | `cwd` is `runMadgeSpawn`'s own `projectRoot` parameter | **stays** — wrapper row; the rule applies to its callers | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dependency-checker.ts#DependencyChecker.runScanProject:c4180627~218c0256` | `cwd` is `runScanProject`'s own `projectRoot` parameter | **stays** — wrapper row | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dependency-checker.ts#DependencyChecker.scanProject:50922783~1c4b5679` | same `projectRoot` local into `runScanProject` | **stays** — a whole-project scan has no edited file for the seam to walk up from | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dispatch/runners/cue-vet.ts#run:f61eafcc~3e35e485@1` | `fileDir = path.dirname(path.resolve(cwd, ctx.filePath))` | **stays** — a CUE package IS one directory; `resolveToolCwd` walks UP to a marker or git root and can never return a plain file directory in a repo | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dispatch/runners/cue-vet.ts#run:1803a70e~3e35e485` | same `fileDir`, package-wide pass | **stays** — same | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dispatch/runners/cue-vet.ts#run:f61eafcc~3e35e485@2` | same `fileDir`, single-file fallback | **stays** — same | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dispatch/runners/rust-clippy.ts#run:dba44d7f~6991f811` | `cwd: cargoToml.replace("Cargo.toml", "")` from `findNearestContaining(dirname(filePath), ["Cargo.toml"])` | **`resolveRunnerCwd`** + `RUNNER_MARKERS["rust-clippy"] = ["Cargo.toml"]`; `findCargoToml` and both `.replace` hacks deleted, the skip gate now asks about the directory cargo will actually start in | `cargo clippy runs at the crate root the seam resolves; cargo clippy skips rather than running above the dispatch root` |
| root | `dispatch/runners/terragrunt.ts#run:d106f5a8~2a7d9054` | `fileDir = path.dirname(path.resolve(cwd, ctx.filePath))` | **stays** — `terragrunt hcl validate` validates the unit DIRECTORY the file sits in, not a marker root | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `dispatch/runners/tflint.ts#run:338013e8~a6e3b67b` | `fileDir = path.dirname(path.resolve(cwd, ctx.filePath))` | **stays** — a Terraform module IS a directory; same shape as cue-vet/terragrunt | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `formatters.ts#resolveGoFmtBinary:8379fd5c` | `safeSpawnAsync("go", ["env", "GOROOT"], { timeout: 5000 })` | **probe helper** — the issue filed it under `root`, but its own reason says it is a toolchain QUERY, which is exactly the probe class | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| root | `git-tracked-ignore.ts#collectTrackedFiles:0f864633~0f864633` | forwards its own `cwd` parameter | **stays** — `git ls-files` REPORTS ON that directory; a marker root would answer about a different repository | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `git-tracked-ignore.ts#collectUntrackedIgnoredIds:538456dd~538456dd` | forwards its own `cwd` parameter | **stays** — same | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `installer/index.ts#installGemTool:94a5faab` | `gem install <package> --no-document`, no cwd | **stays** — an install into the global gem path acts on no project | `every non-exempt spawn's options object names a usable cwd` |
| root | `installer/index.ts#installPipTool:ba749b5d` | `pip install <package>`, no cwd | **stays** — same; an install is not an ask | `every non-exempt spawn's options object names a usable cwd` |
| root | `knip-client.ts#KnipClient.analyze:a1223aae~98d0e4c5` | `const key = path.resolve(targetDir)` handed to `runAnalyze` | **stays** — the input is a directory, same verdict as dead-code-client | `every non-exempt spawn's options object names a usable cwd` |
| root | `knip-client.ts#KnipClient.runAnalyze:b959739e~f5c0e305` | `cwd: targetDir`, its own project-root parameter | **stays** — whole-project scan, no edited file | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `mcp/review.ts#runRebuild:f93df254~9f5ecf07` | `cwd: repoRoot` | **stays** — the repository the rebuild script belongs to; no file input | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `opaque-mutation-scan.ts#isGitWorktree:7e6a8cd3~edb3d44f` | `cwd: root`, its own parameter | **stays** — `git rev-parse --is-inside-work-tree` asks about exactly that directory | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `opaque-mutation-scan.ts#recoverOpaqueChangesViaGit:dad86fa7~1167a91f` | `cwd: root`, its own parameter | **stays** — `git status --porcelain` reports the worktree at that root | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `opaque-mutation-scan.ts#resolveGitToplevel:49511e7e~1167a91f` | `cwd: root`, its own parameter | **stays** — the answer IS the root, so resolving one first is circular | `every dispatch cwd binding comes from the shared tool-cwd seam (#2777)` |
| root | `package-manager.ts#probeAvailability:d0a6319a` | `safeSpawnAsync(finder, [pm], { timeout: PROBE_TIMEOUT_MS })` | **probe helper** — a `which`/`where` lookup is the probe class | `probeToolAsync strips a cwd that reached it inside an options object; every non-exempt spawn's options object names a usable cwd` |
| root | `ruff-client.ts#RuffClient.fixFileAsync:61f923b4` | the local `spawnOpts`, built with `cwd: cwd ?? path.dirname(absolutePath)` | **`resolveToolCwd("runner", "ruff", …)`**; `spawnOpts` inlined so the seam origin is visible to the scan (row deleted, not re-admitted) | `ruff autofix runs at the nested package root, not the caller's workspace root` |
| root | `sg-runner.ts#SgRunner.tempScanDetailedAsync:ee763d40` | no cwd; `--config <temp rule file>` and the scan root are absolute argv | **stays** — nothing is discovered from the child's directory | `every non-exempt spawn's options object names a usable cwd` |

Row counts: 29 `probe` + 28 `root` = 57, matching the issue's list exactly.
21 probe rows and 2 root rows fold onto the probe seam (23 total); 2 root rows
fold onto `resolveToolCwd`/`resolveRunnerCwd`; 31 stay with a reason above, and
each of those 31 reasons was re-read and rewritten in the sweep file to say WHY
the seam does not apply, not only what the cwd is.

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [x] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json`
- [ ] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there — not applicable: AGENTS.md's shape-40 screen already says "resolve every child cwd at the shared seam"; this PR adds no new rule, it moves 26 sites onto the rule that is already written.
- [x] `.changelog/2894-probe-and-root-spawn-cwd.md` has one valid entry (`node scripts/check-changelog-fragments.mjs` → `changelog fragments OK (64 entries in .changelog/)`)
- [x] Commit subject includes the issue number

## Tests

### New file — `tests/clients/probe-and-root-spawn-cwd.test.ts` (5 cases)

Drives the real production paths (the real `checkToolAvailability`, the real
`RuffClient.fixFileAsync`, the real `rustClippyRunner.run`) and fakes only
`safeSpawnAsync` — a true process boundary, and the only place a child's cwd is
observable. Screens: not a **parallel path** (each case enters through the
production entry point), not an **ambient-inspection double** (the assertion is
the argument the boundary received, not a spy on an internal), not **env
leakage** (`$HOME` is pinned to the temp root in `beforeEach` and restored in
`afterEach`, which is also what makes the seam's home ceiling apply to the
fixtures), not an **implementation mirror** (the expected cwd is written out as a
path, never re-derived by calling the seam).

| case | pins |
|---|---|
| `probeToolAsync strips a cwd that reached it inside an options object` | the seam's contract in the direction the TYPE cannot cover — an already-typed options object widened at a call site |
| `the dispatcher's shared --version probe reaches the child with no cwd` | the highest-traffic availability consumer, driven from a nested cwd |
| `ruff autofix runs at the nested package root, not the caller's workspace root` | fold 2, the behaviour change |
| `cargo clippy runs at the crate root the seam resolves` | fold 2 for clippy, including the deleted trailing-separator `.replace` |
| `cargo clippy skips rather than running above the dispatch root` | the ceiling the hand-rolled walk did not have |

**Red on pre-fix code.** Tests and fix committed first, then only the three
SOURCE files under proof reverted (`git checkout origin/master -- clients/ruff-client.ts clients/dispatch/runners/rust-clippy.ts clients/tool-cwd.ts`), rebuilt, re-run:

```
 FAIL  tests/clients/probe-and-root-spawn-cwd.test.ts > ruff autofix runs at the nested package root, not the caller's workspace root
Expected: ".../pi-lens-ruff-nested-d2itLb/packages/api"
Received: ".../pi-lens-ruff-nested-d2itLb"

 FAIL  tests/clients/probe-and-root-spawn-cwd.test.ts > cargo clippy runs at the crate root the seam resolves
Expected: "/tmp/pi-lens-clippy-nested-j3zWoZ/crates/engine"
Received: "/tmp/pi-lens-clippy-nested-j3zWoZ/crates/engine/"

 FAIL  tests/clients/probe-and-root-spawn-cwd.test.ts > cargo clippy skips rather than running above the dispatch root
Expected: "skipped"
Received: "succeeded"

 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
```

**Stated exception (honest, per the fixer contract).** The two PROBE cases do not
red on pre-fix code, and cannot: every folded probe already passed no cwd, so
fold 1 is behaviour-preserving by construction. Their reds are the mutation reds
M1/M2/M6 below, and the sweep's own stale-row red (quoted next), which is the
change fold 1 actually makes. I am not manufacturing a pre-fix red for a refactor.

**The sweep red as sites migrated** (the `origin/master` tables against this
tree's migrated sources — the existing stale-row guard doing its job). Taken at
the moment of migration, before the seam's strip took its final destructure
form, so the seam's own line number and admission key in this transcript are
`clients/tool-probe.ts:57` / an earlier hash; on this head they are
`clients/tool-probe.ts:66` / `2d247383`. The 26 retiring rows are the point and
they are verbatim:

```
runner-spawn-cwd-sweep (presence): 1 flagged item(s) are neither registered nor exempted:
  clients/tool-probe.ts#probeToolAsync:… (clients/tool-probe.ts:57 (safeSpawnAsync))

runner-spawn-cwd-sweep (presence): 24 exemption(s) name an item the scan no longer flags — remove them, a stale exemption is dead weight, not a screen:
  clients/biome-client.ts#BiomeClient.probeBiome:91ce6b49
  clients/dead-code-client.ts#PythonDeadCodeClient.doEnsureAvailable:46c732a4
  clients/dispatch/dispatcher.ts#checkToolAvailability:8b362990
  clients/dispatch/runners/cpp-check.ts#resolveCompiler:ef272657
  clients/dispatch/runners/psscriptanalyzer.ts#resolvePowerShellCmd:e2207b24
  clients/dispatch/runners/psscriptanalyzer.ts#checkModuleAvailable:2e480adc
  clients/dispatch/runners/utils/candidate-probe.ts#probeAvailabilityCandidates:612dec1d
  clients/dispatch/runners/utils/runner-helpers.ts#probeAstGrepCommandAsync:b28406d1
  clients/dispatch/runners/utils/runner-helpers.ts#resolveLocalFirstAsync:5e71e1e9
  clients/formatters.ts#resolveGoFmtBinary:8379fd5c
  clients/formatters.ts#resolveCommand:057285b5
  clients/formatters.ts#detect:e11d4239
  clients/formatters.ts#detect:4818fd92
  clients/govulncheck-client.ts#GovulncheckClient.doEnsureAvailable:d94153fa
  clients/govulncheck-client.ts#GovulncheckClient.doEnsureAvailable:ea10738d
  clients/installer/index.ts#verifyAstGrepProbePath:56408f6e
  clients/installer/index.ts#getAllToolStatuses:54003c71
  clients/installer/index.ts#probeManagedToolVersion:3050f1fc
  clients/package-manager.ts#probeAvailability:d0a6319a
  clients/pipeline.ts#tryRustClippyFix:8e05db7b
  clients/pipeline.ts#tryDartFix:91623ccc
  clients/ruff-client.ts#RuffClient.fixFileAsync:61f923b4
  clients/security-scan-client.ts#SecurityScanClient.probeVersion:355605e9
  clients/sg-runner.ts#SgRunner.probeCommand:45a37c68

runner-spawn-cwd-sweep (origin): 2 exemption(s) name an item the scan no longer flags — remove them:
  clients/dispatch/runners/rust-clippy.ts#run:dba44d7f~6991f811
  clients/ruff-client.ts#RuffClient.fixFileAsync:22e02ee5~4421fb24

AssertionError: spawn population files: expected 73 to be 76
AssertionError: expected [ …(31) ] to deeply equal [ …(34) ]     (the wrapper-site list)
 Test Files  1 failed (1)
      Tests  4 failed | 4 passed (8)
```

### Mutation proofs (each run on the BUILT output or the source the scan reads, rebuilt between)

**M1 — delete the strip** (`{ ...rest }` ← `{ ...options }`, i.e. the destructure removed). Both guards red, and the regression case is the only red in its file:

```
     × probeToolAsync strips a cwd that reached it inside an options object 8ms
     × every non-exempt spawn's options object names a usable cwd 7ms
+ runner-spawn-cwd-sweep (presence): 1 flagged item(s) are neither registered nor exempted:
+   clients/tool-probe.ts#probeToolAsync:01ab25bf (clients/tool-probe.ts:64 (safeSpawnAsync))
+ runner-spawn-cwd-sweep (presence): 1 exemption(s) name an item the scan no longer flags:
+   clients/tool-probe.ts#probeToolAsync:2d247383
      Tests  2 failed | 11 passed (13)
```

**M2 — the inverse direction** (`{ ...rest, cwd: process.cwd() }` — the dangerous one, where a probe silently acquires the host directory, AGENTS.md shape 38):

```
     × probeToolAsync strips a cwd that reached it inside an options object 10ms
     × the dispatcher's shared --version probe reaches the child with no cwd 1095ms
      Tests  2 failed | 3 passed (5)
```

**M3 — the seam call at folded site 1** (`clients/ruff-client.js`: `resolveToolCwd(…)` → `cwd ?? path.dirname(absolutePath)`). Whole-file run, one red, and it is the right one:

```
     × ruff autofix runs at the nested package root, not the caller's workspace root 8ms
Expected: ".../pi-lens-ruff-nested-WWZOcR/packages/api"
Received: ".../pi-lens-ruff-nested-WWZOcR"
      Tests  1 failed | 4 passed (5)
```

**M4 — the seam call at folded site 2** (`clients/dispatch/runners/rust-clippy.js`: `resolveRunnerCwd(ctx, "rust-clippy")` → `ctx.cwd`):

```
     × cargo clippy runs at the crate root the seam resolves 31ms
Expected: ".../pi-lens-clippy-nested-VNsg7K/crates/engine"
Received: ".../pi-lens-clippy-nested-VNsg7K"
      Tests  1 failed | 4 passed (5)
```

**M5 — the new gate, forced open** (`if (!existsSync(join(cargoDir, "Cargo.toml")))` → `if (false)`; the direction where a real failure stops blocking):

```
     × cargo clippy skips rather than running above the dispatch root 5ms
Expected: "skipped"
Received: "succeeded"
      Tests  1 failed | 4 passed (5)
```

**M6 — the fold's own blind-spot test.** Take ONE folded site back off the seam
(`dispatcher.ts`: `probeToolAsync(command, ["--version"], {…})` →
`safeSpawnAsync(command, ["--version"], { cwd: process.cwd(), … })`) and check
that the sweep still sees it, i.e. that moving 23 sites off the scan did not
create a place to hide:

```
     × the dispatcher's shared --version probe reaches the child with no cwd 620ms
     × scans the whole runner directory and finds the pinned population 6ms
- 74
+ 75
     × every non-exempt spawn's options object names a usable cwd 1ms
+ runner-spawn-cwd-sweep (presence): 1 flagged item(s) are neither registered nor exempted:
+   clients/dispatch/dispatcher.ts#checkToolAvailability:9bcb603a~c3721503 (clients/dispatch/dispatcher.ts:214 (safeSpawnAsync))
      Tests  3 failed | 10 passed (13)
```

### Targeted runs

328 files, mechanically selected — `tests/clients/dispatch/**`, `tests/support/*.test.ts`,
`tests/tools/*.test.ts`, every `tests/clients/*client*.test.ts`, every
`tests/config/*.test.ts`, and every
`tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts`
(the `ls` glob, not a hand-picked list), plus the touched clients' own files:

```
FILE COUNT: 328
 Test Files  325 passed | 3 skipped (328)
      Tests  4570 passed | 64 skipped (4634)
```

`npm run fmt:check` → `All matched files use the correct format.` (1810 files).
`npx tsc --noEmit` → clean. `npm run lint` → clean.

Two governance suites went red mid-work and are FIXED in this PR, not absorbed:

- `tests/config/hook-await-bounds.test.ts` — `clients/installer/index.ts` 197 → 198.
  `verifyAstGrepProbePath` traded a `new Promise` around a raw `spawn` (which
  awaited nothing, and whose `timeout` killed only the direct child) for one
  `await probeToolAsync`; `getAllToolStatuses` made the same trade and is
  await-neutral. The pin carries that reason inline.
- `tests/config/strictness-ratchet.test.ts` — reported
  `clients: regression (357 -> 359)` and
  `clients/dispatch/runners: ratchet down (32 -> 31)`. The two `clients` spikes
  were mine (`cwd: undefined` and `{ cwd }` under `exactOptionalPropertyTypes`)
  and are GONE rather than baselined: the probe seam destructures the key away,
  and ruff's seam context uses a conditional spread. Only the ratchet-DOWN is
  recorded in `strictness-baseline.json` (32 → 31, from `findCargoToml`'s
  deletion). No baseline was raised.

Four more suites read red only under my own probe env (`TMPDIR` and
`PI_LENS_HOME` pointed into the worktree) and are green without it —
`tests/config/global-dir-probe-redirect.test.ts` asserts exactly that redirect,
so overriding those variables is the test's own subject. Verified by re-running
the same six files with the repo's default env: `Test Files 2 failed | 4 passed (6)`,
the two being the two above.

### Test assessment

- `tests/clients/probe-and-root-spawn-cwd.test.ts` — new. Uniquely pins the probe
  seam's strip and the two folded roots. Nothing redundant: each of the five cases
  is the sole red under at least one mutation above (M1/M2 → cases 1 and 2,
  M3 → case 3, M4 → case 4, M5 → case 5).
- `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts` — edited: 24
  NO_CWD rows and 2 ORIGIN rows deleted, 1 NO_CWD row added, `EXPECTED_FILES`
  76→74, `EXPECTED_DIRECT_SITES` 136→117, three wrapper-site entries dropped, and
  14 surviving reasons rewritten to say why the seam does not apply. No assertion
  was weakened; the two audits, the wrapper list, the alias guard and the
  population rule are untouched. Sweep for vacuous tests in this file: every case
  is exercised by at least one mutation above (M1 and M6 red the presence audit
  and the population pin; the origin audit and the wrapper list red on the
  migration transcript). Nothing to delete.
- `tests/config/hook-await-bounds.test.ts`, `tests/config/strictness-baseline.json`
  — one registered number each, with the reason inline. No case added or removed.

### Preflight (`npm run preflight`, on this head)

```
| gate                      | mirrored CI job                | pass/fail | first red line |
| ------------------------- | ------------------------------ | --------- | -------------- |
| build                     | Lint & type-check              | pass      |                |
| lint                      | Lint & type-check              | pass      |                |
| fmt:check                 | oxfmt format check             | pass      |                |
| changelog:check           | Unit tests                     | pass      |                |
| check-changelog-fragments | Changelog fragment (fast-fail) | pass      |                |
| check:lockfile            | Lint & type-check              | pass      |                |
| lockfile:complete         | Lint & type-check              | pass      |                |
| tests/config              | Unit tests                     | pass      |                |
| generation-guard          | Unit tests                     | pass      |                |
| flake-shape-ratchet       | Unit tests                     | pass      |                |
| lsp-spawn-heavy-coverage  | Unit tests                     | pass      |                |
| ci-verdict                | Unit tests                     | pass      |                |
| knip                      | knip (advisory)                | pass      |                |
```

## Blast radius

New module `clients/tool-probe.ts` (call tree, `+`/`-` on what moved):

```
  clients/tool-probe.ts#probeToolAsync                                    (+ new)
    ├── callee: clients/safe-spawn.ts#safeSpawnAsync                      (unchanged)
    └── callers (all +, all previously calling safeSpawnAsync/spawn directly):
        clients/biome-client.ts#probeBiome            - spawnBiomeAsync   + probeToolAsync
        clients/dead-code-client.ts#doEnsureAvailable  - safeSpawnAsync   + probeToolAsync
        clients/dispatch/dispatcher.ts#checkToolAvailability
        clients/dispatch/runners/cpp-check.ts#resolveCompiler
        clients/dispatch/runners/psscriptanalyzer.ts#{resolvePowerShellCmd,checkModuleAvailable}
        clients/dispatch/runners/utils/candidate-probe.ts#probeAvailabilityCandidates
        clients/dispatch/runners/utils/runner-helpers.ts#{probeAstGrepCommandAsync,resolveLocalFirstAsync}
        clients/formatters.ts#{which-adjacent detect ×2, resolveCommand, resolveGoFmtBinary}
        clients/govulncheck-client.ts#doEnsureAvailable (×2)
        clients/installer/index.ts#{verifyAstGrepProbePath,getAllToolStatuses,probeManagedToolVersion}
        clients/package-manager.ts#probeAvailability
        clients/pipeline.ts#{tryRustClippyFix,tryDartFix}
        clients/security-scan-client.ts#probeVersion
        clients/sg-runner.ts#probeCommand
```

`safe-spawn.ts` itself is UNCHANGED (final state) — the helper is a separate
module on purpose. Every availability test in this repo fakes the process
boundary with `vi.mock("clients/safe-spawn.js", … { safeSpawnAsync })`; a
same-module helper would have called the module's own unmocked binding and
spawned for real. Measured while I had it there:
`tests/clients/availability-latching-siblings.test.ts` went `Tests 23 failed (23)`
with `VitestMocker.createError … BiomeClient.probeBiome`. One module hop makes
every existing double production-faithful; it is green again on this head.

`clients/tool-cwd.ts#RUNNER_MARKERS` gains one key, `"rust-clippy"`. Consumers of
that table: `markersFor` only, reached from `resolveToolCwd(kind: "runner")`. The
only caller that can now see it is `resolveRunnerCwd(ctx, "rust-clippy")`, which
did not exist before this PR — `rust-clippy.ts`'s availability probe uses
`ctx.cwd` directly and is untouched, so no existing resolution changes.

`clients/dispatch/runners/psscriptanalyzer.ts#spawnPs` — `cwd` goes from optional
to required. One caller remains (the analysis pass), which already passed it.

Behaviour deltas a strict consumer could see:
- `rust-clippy` now SKIPS instead of running cargo when the nearest `Cargo.toml`
  sits outside the dispatch root (the seam's #2777 ceiling). Inside a normal repo
  the resolved directory is identical, minus the trailing separator the old
  `.replace` left.
- `ruff` autofix now runs at the nearest `pyproject.toml`/`ruff.toml` at or above
  the file, capped inside the caller's `cwd`, instead of at the caller's `cwd`.
  This is the seam `dispatch/runners/ruff.ts` already used, so the two halves of
  `tool-policy.ts`'s ruff contract now agree.
- Durable records: no record shape changes. `availability_decision` rows carry the
  same fields from the same classifiers; only the spawn call in front of them moved.

Hot path: `probeToolAsync` adds one object destructure and one spread per PROBE
(not per file, not per render) in front of a process spawn — unmeasurable beside
the fork it precedes. The two raw-`spawn` sites get FASTER teardown, not slower:
`safeSpawnAsync`'s timeout tree-kills, the bare `spawn({ timeout })` they replaced
did not.

## Observability

covered by existing record `tool-cwd-resolution` at `clients/tool-cwd.ts:338`

Routing `rust-clippy` and `ruff`'s autofix through `resolveToolCwd` puts both
under the seam's own bounded ledger for the first time: a resolution that falls
back past every marker and past the git root now writes one
`recordDegradationOnce({ kind: "tool-cwd-resolution", ... })` for that
(tool, reason, file), where the hand-rolled walks recorded nothing at all. That
is the record a maintainer reads when `cargo clippy` or `ruff --fix` starts
running somewhere unexpected.

Alongside it, `tool-cwd.ts#emitResolution` writes one `cwd <kind> <tool> cwd=<dir> reason=<why>`
line per (kind, tool, cwd, reason) per session to `extension.log`, throttled on
the degradation-ledger generation. This PR routes two more children through it,
so a `rust-clippy` or `ruff` root resolution is now visible there where it
previously was not recorded at all — that is the record that proves fold 2 in
production. It is asserted in this diff: the seam's own resolution is what
`cargo clippy runs at the crate root the seam resolves` and
`ruff autofix runs at the nested package root, not the caller's workspace root`
read back through the child's cwd, and `resetDegradationLedger()` in the file's
`beforeEach` is there because that throttle rides the ledger generation.

Fold 1 deliberately adds NO record. A probe seam that logged per call would write
one line per availability probe per file — the unbounded shape AGENTS.md warns
about — and the probes it wraps already emit exactly one `availability_decision`
row each through `logAvailabilityDecision`, unchanged by this PR. The gap I am
naming rather than papering over: nothing in production distinguishes "this probe
went through the seam" from "this probe spawned directly". The sweep is that
guard, at build time, and mutation M6 shows it holds.

## Class sweep

Shape: AGENTS.md defect shape 40 (a tool root resolved at a different seam than
its child spawn), plus the single-source-of-truth rule — a hand-maintained
derivation that mirrors what a shared seam already computes.

**Population.** The enumerable family is `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts`'s
three admission tables, which the #2877 scan builds over `clients/`, `tools/`,
`mcp/` and `index.ts` — the whole tree, not `clients/` alone. Per-member verdicts
for all 57 rows the issue named are in the table above. Beyond that list I also
grepped the tree for the shapes this PR introduces and for the siblings it leaves:

- `grep -rn "probeToolAsync" clients/ tools/ mcp/ scripts/ index.ts` — 20 files,
  all call sites of the new seam plus its definition; no second definition, no
  re-export, no mirror table.
- `grep -rn "RUNNER_MARKERS\|rootMarkers" clients/ tools/ mcp/ scripts/` —
  `tool-cwd.ts` owns the table; `test-runner-client.ts` passes its own
  `spawnCwdMarkers` in rather than registering a copy (#2871). `"Cargo.toml"` as a
  literal appears in `tool-cwd.ts` (the new marker), `formatters.ts`
  (`FORMATTER_MARKERS.rustfmt`, a different tool) and `rust-clippy.ts`'s gate. No
  duplicate table.
- `grep -rn "findNearestContaining(.*Cargo.toml\|pubspec.yaml" clients/` — the two
  remaining members are `pipeline.ts#tryRustClippyFix` and `#tryDartFix`.
  **Deliberately left**, and their sweep rows are NOT in the issue's 57: neither
  takes a `cwd` at all (`tryRustClippyFix(filePath)`), so the seam has no dispatch
  root to cap against and folding them means threading a cwd through `runAutofix`
  — mechanism, not a swap. Recorded here rather than done silently.
- The remaining ask-don't-act children (`formatters.ts#which`,
  `package-manager.ts#probeGlobalBinDirs`, `lsp/jvm-runtime.ts#runJavaProbe`,
  `test-runner-client.ts#detectRunner`, `sg-runner.ts#probeHomebrew`,
  `zizmor-config.ts#deriveGhCliToken`, `installer/index.ts#verifyToolBinary`,
  `#getPythonUserBaseCandidates`, `#installPipTool`'s second spawn) are the same
  shape and are NOT in the issue's 57. Filed as **#2906** with the full list and
  each one's note, rather than widened into this diff. Two of them cannot move at
  all and #2906 records why: `safe-spawn.ts#isCommandAvailableAsync`/
  `#findCommandAsync` would be an import cycle (`tool-probe.ts` imports
  `safe-spawn.ts`), and `#isCommandAvailable`/`#findCommand` are synchronous, so a
  sync twin would be a second helper the net-count rule forbids.
- `dependency-checker.ts` — the issue named it as a fold target and I declined it,
  with the reproduction argument in **#2905**: `checkFile` has NO production
  caller (`runtime-turn.ts` calls `checkFilesBatch`, `runtime-session.ts` and
  `project-diagnostics/fresh-fetch.ts` call `scanProject`), so a per-file root
  there would be machinery for a path that does not run — the #2490 lesson. The
  real fold is per-file grouping inside the batch.

**Consolidation verdict: FOLD.** Deleting `probeToolAsync` would put the same
no-cwd decision back into 23 call sites and 23 admission sentences, and deleting
the `RUNNER_MARKERS` entry would put an uncapped marker walk back into
`rust-clippy.ts` — complexity concentrates back into callers rather than merely
relocating, which is AGENTS.md's deciding test. The families that stay
distributed are named above with the property that makes them a different family:
the cwd is the child's SUBJECT (a git query, a directory-scoped tool) rather than
a place to resolve config from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round 2

### Summary

Fixed all review findings from the round-2 acceptance set.

- F1: Negative marker walks no longer remain memoized across calls. Positive walks keep their memo and marker-deletion revalidation. A newly created Cargo.toml is visible to rust-clippy in the same session.
- F2: Biome autofix now resolves `resolveToolCwd("runner", "biome", ...)`, matching `biome-check.ts` and `RUNNER_MARKERS.biome`. The real client path is covered by `autofix resolves the same nested package root as the runner seam`.
- F3: Corrected every shipped probe count from 24 to 23, including the changelog, source documentation, and sweep header.
- F4: Removed the dead `cwd-exempt:` comment from `clients/dispatch/runners/cpp-check.ts`.
- #2902 remains out of this branch. The verify round measured the scratch merge against #2902 at `b7abde29d` (now 80/148 on its side): the merge result is 78 files / 129 direct sites / 33 wrappers with three conflict regions, and outside the markers the merge re-admits two rows this PR retires (`clients/biome-client.ts#BiomeClient.probeBiome:91ce6b49`, `clients/dead-code-client.ts#PythonDeadCodeClient.doEnsureAvailable:46c732a4`), which reds `every non-exempt spawn's options object names a usable cwd`. Whichever PR lands second resolves to 78/129, keeps both row sets, and deletes those two rows (verified: 5 files / 161 tests green).

### Tests

- `tests/clients/tool-cwd.test.ts` — added `re-walks a negative marker result when a marker is created later`; pre-fix red, post-fix green.
- `tests/clients/probe-and-root-spawn-cwd.test.ts` — added `cargo clippy sees a crate marker created after its first resolution`; pre-fix red, post-fix green.
- `tests/clients/biome-autofix-argv.test.ts` — added `autofix resolves the same nested package root as the runner seam`.
- `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts` — removed the stale Biome admission row and corrected the probe-count wording.
- Focused post-fix run: 3 files, 22 tests passed.
- Dispatch and support batch: 332 tests passed, 1 skipped.
- The aggregate directory invocation was rejected by Vitest project filtering; explicit batches were used.
- `npm run fmt:check` passed. `npx tsc --noEmit` passed. `npm run build` passed.

### Test assessment

The new cases uniquely pin negative marker freshness and Biome's nested autofix root. The sweep edit removes only an admission row made stale by the fold; no behavioral assertion was weakened.

### Blast radius

The shared change is limited to `clients/tool-cwd.ts#findMarkerRoot`: negative results re-walk, while positive results retain the existing cache and deletion check. This affects runner, formatter, and LSP root resolution only when their prior marker walk was negative. The cost is the existing bounded marker walk on each negative hit; no new durable record or process spawn is added.

The Biome change affects `BiomeClient.fixFileAsync` and its `safeSpawnAsync` child cwd. The runner and autofix now use the same root seam.

### Class sweep

A whole-tree search for `cwd ?? path.dirname(` and `?? path.dirname(` found no remaining production spawn-cwd instances (the one other hit, `clients/review-graph/tsconfig-paths.ts:151`, is a tsconfig `baseUrl` fallback, not a spawn cwd). The folded members are:
- `clients/ruff-client.ts` — folded before this round; fixed.
- `clients/biome-client.ts` — folded in this round; fixed.
No remaining member is unsafe to fold.

A whole-tree search for `cwd-exempt:` found only test fixtures and intended scan tests; the dead production tag in `cpp-check.ts` is removed.

### Observability

No new failure path and no record added. Existing `tool-cwd-resolution` telemetry remains the bounded record for fallback resolution.

### Preflight

`npm run preflight` passed all gates. The preflight table above records the final verdict for each gate.



## Merge with master (orchestrator, after #2902 landed)

`843da16bd` merges `origin/master` (7dbccb4eb, which carries #2902) into this branch. Resolution as the round-2 verify prescribed: both row sets kept; the two rows this PR retires deleted (`clients/biome-client.ts#BiomeClient.probeBiome:91ce6b49`, `clients/dead-code-client.ts#PythonDeadCodeClient.doEnsureAvailable:46c732a4`); pins measured on the merged tree, not computed: `EXPECTED_FILES = 79`, `EXPECTED_DIRECT_SITES = 130`, 33 wrapper sites (the sweep is the measurement: `Tests 8 passed (8)`). On the merged tree: `tests/clients/dispatch` + `tests/support` + `tests/config` → `Test Files 204 passed | 2 skipped`, `Tests 2411 passed | 7 skipped`; `fmt:check` clean; `tsc --noEmit` clean.
