### PR TITLE
fix(dispatch): detectFileRole recognises Go _test.go and the other table conventions (closes #2880)

### DIFF
--- a/.changelog/fix-2880-go-test-file-role.md
+++ b/.changelog/fix-2880-go-test-file-role.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **`detectFileRole` recognises Go `_test.go` and the other table conventions (closes #2880)** — Editing `pkg/foo_test.go` produced no test target because the shared role classifier only knew `.test.`/`.spec.`/prefix/dir patterns. It now also matches the `_test.`/`_spec.` suffix infixes and the case-sensitive `*Test(s).<ext>` CamelCase suffix for Java/Kotlin/C#/F#/PHP, derived from the test-runner client's own `SOURCE_TO_TEST_PATTERNS` + `RUNNERS` table, so an edited Go test file runs its own package tests.
+- **`detectFileRole` recognises Go `_test.go` and the other table conventions (closes #2880)** — Editing `pkg/foo_test.go` produced no test target because the shared role classifier only knew `.test.`/`.spec.`/prefix/dir patterns. It now also matches the `_test.`/`_spec.` suffix infixes and the case-sensitive `*Test(s).<ext>` CamelCase suffix for Java/Kotlin/C#/F#/PHP, informed by the test-runner client's `SOURCE_TO_TEST_PATTERNS` + `RUNNERS` table; hand-written, see #2928 for the single-classifier fold, so an edited Go test file runs its own package tests.

--- a/.changelog/fix-2880-go-test-file-role.md
+++ b/.changelog/fix-2880-go-test-file-role.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **`detectFileRole` recognises Go `_test.go` and the other table conventions (closes #2880)** — Editing `pkg/foo_test.go` produced no test target because the shared role classifier only knew `.test.`/`.spec.`/prefix/dir patterns. It now also matches the `_test.`/`_spec.` suffix infixes and the case-sensitive `*Test(s).<ext>` CamelCase suffix for Java/Kotlin/C#/F#/PHP, derived from the test-runner client's own `SOURCE_TO_TEST_PATTERNS` + `RUNNERS` table, so an edited Go test file runs its own package tests.

--- a/clients/file-role.ts
+++ b/clients/file-role.ts
@@ -80,19 +80,33 @@ function isTypeStub(content: string): boolean {
  */
 export function detectFileRole(filePath: string, content?: string): FileRole {
 	const windowsShaped = isWindowsPath(filePath);
-	const base = (
-		windowsShaped ? win32.basename(filePath) : basename(filePath)
-	).toLowerCase();
+	const rawBase = windowsShaped ? win32.basename(filePath) : basename(filePath);
+	const base = rawBase.toLowerCase();
 	const dir = (windowsShaped ? win32.dirname(filePath) : dirname(filePath))
 		.replace(/\\/g, "/")
 		.toLowerCase();
 
 	// --- Test ---
+	// Suffix conventions are derived from the test-runner client's own
+	// knowledge (SOURCE_TO_TEST_PATTERNS + RUNNERS kinds in
+	// clients/test-runner-client.ts), never a hand-written list:
+	// - `_test.` infix: Go (`*_test.go`), pytest (`*_test.py`), ExUnit
+	//   (`*_test.exs`), Dart (`*_test.dart`). The underscore anchor keeps
+	//   this precise: `contest.py` and `latest.ts` do not match.
+	// - `_spec.` infix: RSpec (`*_spec.rb`).
+	// - CamelCase `*Test(s).<ext>` suffix, matched case-SENSITIVELY on the
+	//   raw basename: JUnit/Surefire (`*Test.java`, `*TestCase.java`),
+	//   Kotlin (`*Test.kt`), dotnet (`*Test.cs`/`*Tests.cs`), PHPUnit
+	//   (`*Test.php`). Case matters: Surefire's `*Test.java` does not match
+	//   `contest.java`, so neither do we.
 	if (
 		base.includes(".test.") ||
 		base.includes(".spec.") ||
+		base.includes("_test.") ||
+		base.includes("_spec.") ||
 		base.startsWith("test_") ||
 		base.startsWith("spec_") ||
+		/(Test|Tests|TestCase)\.(java|kt|kts|cs|fs|php)$/.test(rawBase) ||
 		dir.includes("/__tests__/") ||
 		dir.includes("/test/") ||
 		dir.includes("/tests/") ||

--- a/clients/file-role.ts
+++ b/clients/file-role.ts
@@ -87,9 +87,10 @@ export function detectFileRole(filePath: string, content?: string): FileRole {
 		.toLowerCase();
 
 	// --- Test ---
-	// Suffix conventions are derived from the test-runner client's own
-	// knowledge (SOURCE_TO_TEST_PATTERNS + RUNNERS kinds in
-	// clients/test-runner-client.ts), never a hand-written list:
+	// Suffix conventions informed by the test-runner table
+	// (SOURCE_TO_TEST_PATTERNS + RUNNERS kinds in
+	// clients/test-runner-client.ts); hand-written, not iterated from it —
+	// see #2928 for the single-classifier fold:
 	// - `_test.` infix: Go (`*_test.go`), pytest (`*_test.py`), ExUnit
 	//   (`*_test.exs`), Dart (`*_test.dart`). The underscore anchor keeps
 	//   this precise: `contest.py` and `latest.ts` do not match.

--- a/clients/test-runner-client.ts
+++ b/clients/test-runner-client.ts
@@ -1190,7 +1190,8 @@ export class TestRunnerClient {
 	 * file whose *related* test file needs to be discovered).
 	 *
 	 * Primary signal: `detectFileRole` (naming convention: `.test.`/`.spec.`
-	 * basenames, `test_`/`spec_` prefixes, `__tests__/`/`tests/`/`spec/`
+	 * basenames, `_test.`/`_spec.` suffix infixes, `*Test(s).<ext>` CamelCase
+	 * suffixes, `test_`/`spec_` prefixes, `__tests__/`/`tests/`/`spec/`
 	 * directories — shared with the rest of the codebase, not a second
 	 * parallel detector).
 	 *

--- a/tests/clients/file-role.test.ts
+++ b/tests/clients/file-role.test.ts
@@ -62,11 +62,12 @@ describe("detectFileRole", () => {
 		expect(detectFileRole("/home/dev/project/src/foo.ts")).toBe("source");
 	});
 
-	// Refs #2880: every test-file convention the test-runner client already
-	// dispatches on (SOURCE_TO_TEST_PATTERNS + RUNNERS kinds in
-	// clients/test-runner-client.ts) must classify as "test" here, or an
-	// edited test file takes the related-discovery path and runs the wrong
-	// tests or none. Each row pairs the convention with a co-located
+	// Refs #2880: hand-written pins for the test-file conventions the
+	// test-runner client dispatches on (informed by SOURCE_TO_TEST_PATTERNS
+	// + RUNNERS kinds in clients/test-runner-client.ts, not iterated from
+	// them — see #2928 for the single-classifier fold). A convention
+	// missing here lets an edited test file take the related-discovery
+	// path and run the wrong tests or none. Each row pairs the convention with a co-located
 	// source file the same convention must NOT claim, so a row proves its
 	// own name rule rather than a test-directory rule. The `_test.go` row
 	// is the reported defect: pre-fix it classified as "source" and

--- a/tests/clients/file-role.test.ts
+++ b/tests/clients/file-role.test.ts
@@ -62,6 +62,59 @@ describe("detectFileRole", () => {
 		expect(detectFileRole("/home/dev/project/src/foo.ts")).toBe("source");
 	});
 
+	// Refs #2880: every test-file convention the test-runner client already
+	// dispatches on (SOURCE_TO_TEST_PATTERNS + RUNNERS kinds in
+	// clients/test-runner-client.ts) must classify as "test" here, or an
+	// edited test file takes the related-discovery path and runs the wrong
+	// tests or none. Each row pairs the convention with a co-located
+	// source file the same convention must NOT claim, so a row proves its
+	// own name rule rather than a test-directory rule. The `_test.go` row
+	// is the reported defect: pre-fix it classified as "source" and
+	// `getTestRunTarget` for the edited file returned null.
+	it("recognises every test-file convention the test-runner client dispatches on", () => {
+		const cases: Array<[string, "test" | "source"]> = [
+			// Go `*_test.go` suffix (the #2880 row).
+			["/repo/pkg/foo_test.go", "test"],
+			["/repo/pkg/foo.go", "source"],
+			// pytest knows BOTH `test_*.py` and `*_test.py`.
+			["/repo/pkg/test_foo.py", "test"],
+			["/repo/pkg/foo_test.py", "test"],
+			["/repo/pkg/foo.py", "source"],
+			// RSpec `*_spec.rb` suffix, outside any spec/ directory.
+			["/repo/pkg/thing_spec.rb", "test"],
+			["/repo/pkg/thing.rb", "source"],
+			// ExUnit `*_test.exs` suffix, outside the test/ tree.
+			["/repo/lib/accounts/user_test.exs", "test"],
+			["/repo/lib/accounts/user.ex", "source"],
+			// JUnit/Surefire/Gradle `*Test.java` suffix, outside src/test/.
+			["/repo/src/main/java/com/x/FooTest.java", "test"],
+			["/repo/src/main/java/com/x/Foo.java", "source"],
+			// Kotlin `*Test.kt` suffix.
+			["/repo/src/FooTest.kt", "test"],
+			["/repo/src/Foo.kt", "source"],
+			// dotnet `*Tests.cs` suffix.
+			["/repo/src/FooTests.cs", "test"],
+			["/repo/src/Foo.cs", "source"],
+			// PHPUnit `*Test.php` suffix.
+			["/repo/src/ThingTest.php", "test"],
+			["/repo/src/Thing.php", "source"],
+			// JS/TS `.test.`/`.spec.` infixes (pre-existing behavior, pinned).
+			["/repo/src/foo.test.ts", "test"],
+			["/repo/src/foo.spec.js", "test"],
+			// minitest `test_*.rb` prefix (pre-existing behavior, pinned).
+			["/repo/test/test_foo.rb", "test"],
+			// Anchor precision: the `_test.`/`_spec.` infixes need the
+			// underscore, and the CamelCase suffix needs the capital T, so
+			// ordinary words containing "test"/"spec" stay source.
+			["/repo/pkg/contest.py", "source"],
+			["/repo/src/latest.ts", "source"],
+			["/repo/src/main/java/com/x/contest.java", "source"],
+		];
+		for (const [file, expected] of cases) {
+			expect(detectFileRole(file), file).toBe(expected);
+		}
+	});
+
 	// #2346 negative proof: the longest-line real file in `clients/` that
 	// still classifies as plain SOURCE under the content-shape test. Measured
 	// on 2026-08-28 with the shipped probe algorithm: the overall maximum mean

--- a/tests/clients/test-runner-selection.test.ts
+++ b/tests/clients/test-runner-selection.test.ts
@@ -177,6 +177,25 @@ describe("#2870 runner selection is per file kind", () => {
 		expect(target?.strategy).toBe("self");
 	});
 
+	it("treats an edited Go test file as its own target (refs #2880)", () => {
+		// `detectFileRole` missed the `_test.go` suffix, so editing
+		// `pkg/foo_test.go` took the related-discovery path: `findTestFile`
+		// looked for `foo_test_test.go`, found nothing, and the edit ran no
+		// tests. Measured pre-fix through this same seam:
+		// `getTestRunTarget(pkg/foo_test.go) === null`.
+		const root = makeRoot("pi-lens-2880-go-self-");
+		write(root, "go.mod", "module example.com/x\n");
+		write(root, "pkg/foo.go", "package foo\n");
+		const editedTest = write(root, "pkg/foo_test.go", "package foo\n");
+		const target = new TestRunnerClient(false).getTestRunTarget(
+			editedTest,
+			root,
+		);
+		expect(target?.runner).toBe("go");
+		expect(target?.strategy).toBe("self");
+		expect(target?.testFile).toBe(editedTest);
+	});
+
 	it("anchors a nested Go module's source file at its own module", () => {
 		const repo = makePolyglotRepo();
 		const target = new TestRunnerClient(false).getTestRunTarget(


### PR DESCRIPTION
## Summary

`detectFileRole` (`clients/file-role.ts`) classified test files only by `.test.`/`.spec.` infixes, `test_`/`spec_` prefixes, and test-directory segments. Go's `_test.go` suffix matches none of those, so editing `pkg/foo_test.go` classified as `source`, `findTestFile` searched for `foo_test_test.go`, and `getTestRunTarget` returned null. The fix widens the shared classifier with hand-written suffix arms informed by the conventions the test-runner client dispatches on (`SOURCE_TO_TEST_PATTERNS` + `RUNNERS` in `clients/test-runner-client.ts`): the `_test.` infix (Go, pytest `*_test.py`, ExUnit `*_test.exs`, Dart `*_test.dart`), the `_spec.` infix (RSpec), and the case-sensitive `*Test(s).<ext>` CamelCase suffix for `java|kt|kts|cs|fs|php` (JUnit, Kotlin, dotnet, PHPUnit). The arms are hand-written, not iterated from the table — neither the classifier nor the test imports either table (review probe: gutting the `.go`/`.php` rows leaves both new tests green); see #2928 for the single-classifier fold. Case-sensitivity is load-bearing: `*Test.java` does not match `contest.java`, so neither does the new arm. No new helper was added; the `isTestFile` comment in `clients/test-runner-client.ts` is updated so it names the widened set.

Closes #2880. Every acceptance criterion is met: `*_test.go` classifies as test, `getTestRunTarget` for the edited file returns a `go`/`self` target, the regression test is red on pre-fix code through the real seam, and the sibling sweep is recorded below.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [x] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (regenerate with the exact npm pin in `package.json`'s `packageManager` field)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there
- [x] `.changelog/<branch-or-slug>-<short-desc>.md` has one valid entry **in this PR** for any user-facing change (Added/Changed/Deprecated/Removed/Fixed/Security) — see [.changelog/README.md](../.changelog/README.md); internal-only test/refactor PRs may skip it
- [x] Commit subject includes the issue number: `(closes #NNN)` or `(refs #NNN)`

## Tests

| Test | What it pins and why |
| ---- | -------------------- |
| `recognises every test-file convention the test-runner client dispatches on` (`tests/clients/file-role.test.ts`) | Hand-written 24-row `cases` array pinning the conventions the runner dispatches on, informed by `SOURCE_TO_TEST_PATTERNS` + `RUNNERS` (not iterated from them): Go `_test.go`, pytest both spellings, RSpec `_spec.rb`, ExUnit `_test.exs`, `*Test.java`/`*Test.kt`/`*Tests.cs`/`*Test.php`, plus the pre-existing `.test.`/`.spec.`/`test_` pins and `contest.*`/`latest.ts` anchor-precision negatives. Red-first proof for the reported defect. |
| `treats an edited Go test file as its own target (refs #2880)` (`tests/clients/test-runner-selection.test.ts`) | Drives the real `getTestRunTarget` over a real `go.mod` fixture for an edited `pkg/foo_test.go`; expects `runner=go`, `strategy=self`. Red-first proof through the dispatch seam, not a hand-shaped input. |

Red on pre-fix code (fix reverted, rebuilt, same command):

```text
FAIL tests/clients/file-role.test.ts > recognises every test-file convention ...
AssertionError: /repo/pkg/foo_test.go: expected 'source' to be 'test'
FAIL tests/clients/test-runner-selection.test.ts > treats an edited Go test file ...
AssertionError: expected undefined to be 'go'
Test Files  2 failed (2); Tests  2 failed | 23 passed (25)
```

Green after the fix: `tests/clients/test-runner-client.test.ts`, `test-runner-selection.test.ts`, `file-role.test.ts`, `collateral-test-role.test.ts`, `review-graph/missing-node-cause.test.ts`, `lens-map.test.ts`, `scan-exclusion-stack.test.ts` — 7 files, 253 tests, all pass. `tests/clients/dispatch` whole dir: 138 passed, 2 skipped. Every `tests/config` file: 52 passed. `npm run fmt:check`, `npx tsc --noEmit`, `npm run build:dist`, `npm run preflight` all green.

Screens satisfied: parallel path (both tests enter at the production seam, `detectFileRole`/`getTestRunTarget`, never a helper); wrong-layer pin (the table test would still pass if a call site hard-coded one value only when every row agrees, and each row pairs a convention with a co-located source file the same convention must not claim); implementation mirror (expected roles are hand-derived from the runner table and tool defaults, not copied from the predicate).

Mutation proof (neutering in the built output, one guard at a time): `_test.` neutered reds the Go row; the CamelCase regex replaced with `false` reds with `/repo/src/main/java/com/x/FooTest.java: expected 'source' to be 'test'`; `_spec.` neutered reds with `/repo/pkg/thing_spec.rb: expected 'source' to be 'test'`.

### Test assessment

| File touched | Unique behavior pinned | Redundancy |
| ------------ | ---------------------- | ---------- |
| `tests/clients/file-role.test.ts` | The only file pinning `detectFileRole`'s name rules per convention, including the new suffix arms and the `contest.*` precision negatives. | None removed; the new `it` block complements the existing Windows-shape and generated-file cases. |
| `tests/clients/test-runner-selection.test.ts` | The only file pinning kind-gated runner selection through the real `getTestRunTarget`; the new case is its first edited-test-file `self` case for Go. | None removed. No removal candidates. |

## Blast radius

`clients/file-role.ts` `detectFileRole` gains two substring arms and one anchored regex arm on the miss path, plus a case-preserving `rawBase`. Dependents (all read-only consumers, none changed): `TestRunnerClient.isTestFile` (the fixed path), `clients/collateral-test-role.ts`, `clients/review-graph/builder.ts` + `query.ts` (test files stay out of the graph — newly recognised test files are now correctly excluded), `clients/lens-map.ts`, `clients/dispatch/dispatcher.ts`, `clients/lsp/index.ts`, `tools/lens-diagnostics.ts`, `tools/lsp-diagnostics.ts`, `clients/codebase-model.ts`. `clients/test-runner-client.ts` has a comment-only change. Per-call cost measured at ~535 ns over 160,000 mixed-path calls; the delta is at most two `String.includes` scans plus one anchored regex test with no I/O and no allocation, short-circuited after the existing arms. Verification: the suites named under Tests, plus `npm run preflight` green on the head.

## Observability

No new failure path; no record added.

## Class sweep

Shape: a filename-convention classifier missing a suffix its own consumer table already knows (AGENTS.md shapes 2/42 family: rule keyed on one language's spelling). Pattern grep over `clients/`, `tools/`, `mcp/`, `index.ts` for `.test.`/`_test.`/`_spec.`/`Test.java` matchers finds test-name knowledge in four places: `clients/file-role.ts` (fixed here), `clients/test-runner-client.ts` `SOURCE_TO_TEST_PATTERNS` (the discovery table, already complete), `clients/file-utils.ts` `isTestFile` (skip-gate over test/fixture/mock files, a different contract — widening it is a separate consolidation decision, tracked in #2928), and `clients/word-index.ts:224` `TEST_VENDOR_RE` (language-agnostic filename matcher written as an alternation, found by probing the alternation spelling rather than the literal-substring grep that missed it). `TEST_VENDOR_RE` misses `_test.go`, `*Test.php`, and `_spec.rb`, so this PR creates a new disagreement with it: a co-located Go test file is now `test` to the classifier but full-weight source to the word index. Both halves are tracked in #2928. `clients/todo-scanner.ts:176` (`/\.(test|spec)\.[jt]sx?$/`) is not a member: it is explicitly jsts-scoped by its extension class.

Population verdicts, one per convention in the runner table:

| Convention | Verdict |
| ---------- | ------- |
| Go `*_test.go` | Added (`_test.` infix); the reported defect. |
| Python `test_*.py` | Already covered (`test_` prefix). |
| Python `*_test.py` | Added (`_test.` infix). |
| RSpec `*_spec.rb` | Added (`_spec.` infix); minitest `test_*.rb` already covered. |
| ExUnit `*_test.exs` | Added (`_test.` infix). |
| Java/Kotlin `*Test.java`/`*Test.kt` | Added (case-sensitive CamelCase arm; three of Surefire's four default includes — omits `Test*.java`, which stays `source`). |
| dotnet `*Test.cs`/`*Tests.cs` | Added (same arm). |
| PHPUnit `*Test.php` | Added (same arm). |
| Rust `#[cfg(test)]` in-file | Out of scope: a filename classifier cannot see it without content, and no call site passes content for this purpose; `tests/`-dir files remain covered. |
| Dart `*_test.dart` | Covered as a side effect of the `_test.` infix; no dispatch change (no `RUNNERS` entry claims kind `dart`). |
| JS/TS `.test.`/`.spec.`, `__tests__`/dirs | Already covered; pinned by the same table test. |

Consolidation verdict: stay distributed. The discovery table (`SOURCE_TO_TEST_PATTERNS`) answers where the related test lives; the classifier answers whether a file is a test; `file-utils.ts:isTestFile` answers whether a skip-gate applies (fixture/mock arms included). Removing the shared classifier would relocate, not concentrate, complexity — the fix instead routes through the existing seam (`isTestFile` already delegates to `detectFileRole`).

Known limitation (no code change this round): the `_test.`/`_spec.` infixes are extension-blind and the test arm sits ahead of the migration/config arms, so `openapi_spec.yaml` and `0002_add_test.sql` classify as `test` (losing `migration`), as does `vitest_test.config.ts` (losing `config`). Bound measured by the reviewer on this head: 0 of 3458 tracked files change role pre-to-post fix. Of the four auxiliary-LSP profiles only ast-grep sets `skipTestFiles`, so a misclassified workflow or config file does not lose security findings from the other three.

## Round 2

Contract-only round per the review on head `2cfeab601` (verdict: merge after fixes, no behaviour change). The code is untouched except for comments; no guard, branch, or outcome value changed.

| Finding | Fix |
| ------- | --- |
| F1 (High): "derived from SOURCE_TO_TEST_PATTERNS + RUNNERS, never a hand-written list" is false — neither the classifier nor the test imports either table (reviewer gutted the `.go`/`.php` rows, both new tests stayed green; seven arm literals appear in neither table) | `clients/file-role.ts` comment, this body's Summary and Tests table, and `.changelog/fix-2880-go-test-file-role.md` now say "informed by the test-runner table; hand-written; see #2928 for the single-classifier fold". A real derivation is #2928's job, not this round's. |
| F2 (Medium): class sweep said "exactly three places"; there are four | Sweep now names `clients/word-index.ts:224` `TEST_VENDOR_RE` (alternation spelling the literal grep missed), states this PR creates a disagreement with it, links #2928 for it and for `file-utils.ts:isTestFile`, and records `clients/todo-scanner.ts:176` as not a member (jsts-scoped). |
| F3 (Low): infixes extension-blind, ahead of migration/config arms | "Known limitation" note above: `openapi_spec.yaml`, `0002_add_test.sql` classify as `test`; reviewer bound 0 of 3458 tracked files change role; only ast-grep sets `skipTestFiles`. Body note only, no code change. |
| F4 (Low): "Surefire semantics" overclaims (`Test*.java` omitted) | Table row now says "three of Surefire's four default includes — omits `Test*.java`, which stays `source`". |

