### PR TITLE
test(sweep): spawn-cwd scanner derives one vocabulary from the seam and freezes (closes #2927)

### DIFF
--- a/.changelog/test-2927-spawn-cwd-scanner-one-vocabulary.md
+++ b/.changelog/test-2927-spawn-cwd-scanner-one-vocabulary.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Spawn-cwd scanner derives one vocabulary from the seam and freezes (closes #2927)** — the scan's site rule and the sweep's population predicate both derive from the `SPAWN_NAMES` / `NODE_SPAWN_NAMES` tuples, with per-name parity tests; the `// cwd-exempt:` channel stays as the documented escape hatch; the scanner header states the simplify-not-extend freeze policy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1151,7 +1151,14 @@ reason is "this should move onto the seam" live in a ratcheted
 `MIGRATION_WORKLIST_ROWS` whose reason OPENS with the issue that retires it.
 Both rules run through `auditRegistry` (`tests/support/sweep-kit.ts`). Adding a
 conforming spawn moves the population pins; adding a non-conforming one costs a
-reasoned row, never a pin bump. Stated bounds: an ALIASED
+reasoned row, never a pin bump. `SPAWN_NAMES` and `NODE_SPAWN_NAMES` in
+`tests/support/spawn-cwd-scan.ts` are the one vocabulary the scan's site rule
+and the sweep's population predicate both derive from, with per-name parity in
+`tests/support/spawn-cwd-scan-vocabulary.test.ts` (#2927). A new scanner
+finding is a reason to simplify the scanner, not extend it; the fallback is an
+ast-grep rule matching unseamed `child_process` calls. The `// cwd-exempt:`
+tag stays as the documented escape hatch for genuine non-project children.
+Stated bounds: an ALIASED
 `node:child_process` import is not a site (#2888), and the scan does not follow
 a path computation into the seam. The `beforeAll` carries an explicit 30 s
 timeout because the scan is ~2.8 s idle / ~3.7 s under `--maxWorkers=1`

--- a/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
+++ b/tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts
@@ -87,6 +87,7 @@ import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
 import { lineContentHash } from "../../../../clients/read-guard.js";
 import {
+	holdsAScannableSpawn,
 	type SpawnCwdSite,
 	scanSpawnCwd,
 } from "../../../support/spawn-cwd-scan.js";
@@ -724,33 +725,16 @@ const WORKLIST_CEILING = 0;
 const SCAN_HOOK_TIMEOUT_MS = 30_000;
 
 /**
- * Whether a file can hold a site the scan recognises: one of the seam wrappers
- * by name, or a named `spawn`/`execFile` import from `child_process` or
- * `node:child_process`. It mirrors
- * `spawn-cwd-scan.ts`'s own site rule deliberately — round 4's population
- * filter listed only the five seam names while the scanner also counted
- * `spawn`/`execFile`, so a file whose only child spawn was a bare `spawn(`
- * could never move a pin (round-5 v4-N3). An ALIASED import is a stated bound
- * of both, tracked by #2888.
+ * The population predicate lives in `tests/support/spawn-cwd-scan.ts` beside
+ * the two name tuples it derives from (one vocabulary, #2927): one of the
+ * seam wrappers by name, or a named `spawn`/`execFile` import from
+ * `child_process` or `node:child_process`. It mirrors the scan's own site
+ * rule deliberately — round 4's population filter listed only the five seam
+ * names while the scanner also counted `spawn`/`execFile`, so a file whose
+ * only child spawn was a bare `spawn(` could never move a pin (round-5
+ * v4-N3). An ALIASED child_process import is a stated bound of both, tracked
+ * by #2888.
  */
-function holdsAScannableSpawn(source: string): boolean {
-	const hasUnaliasedChildProcessImport = [
-		...source.matchAll(
-			/import(?:\s+[\w*$]+\s*,)?\s*\{([^}]*)\}\s*from\s*["'](?:node:)?child_process["']/g,
-		),
-	].some((match) =>
-		match[1]
-			.split(",")
-			.some((specifier) =>
-				/^(?:\s*)(?:spawn|execFile)(?:\s*)$/.test(specifier),
-			),
-	);
-	return (
-		/\b(?:safeSpawnAsync|safeSpawnSync|safeSpawn|spawnSupervised|execa)\s*\(/.test(
-			source,
-		) || hasUnaliasedChildProcessImport
-	);
-}
 const NO_CWD_EXEMPTIONS = Object.fromEntries(NO_CWD_EXEMPTION_ROWS);
 const ORIGIN_ADMISSIONS = Object.fromEntries([
 	...ORIGIN_ADMISSION_ROWS,

--- a/tests/support/spawn-cwd-scan-vocabulary.test.ts
+++ b/tests/support/spawn-cwd-scan-vocabulary.test.ts
@@ -1,0 +1,79 @@
+/**
+ * One-vocabulary parity for `spawn-cwd-scan.ts` (#2927, folding #2926).
+ *
+ * `SPAWN_NAMES` and `NODE_SPAWN_NAMES` are the single source of truth for
+ * "what counts as a spawn". The scan's own site rule and the sweep's
+ * population predicate (`holdsAScannableSpawn`, same module) both derive from
+ * them. Each test below loops over the tuple it pins, so adding a name to a
+ * tuple automatically extends the coverage: a name the scanner does not scan,
+ * or a predicate that does not admit it, reds here instead of riding in
+ * uncounted (the #2902 round-3 probe: one name added, 140 tests green).
+ *
+ * These assert behaviour through the real seams (`scanSpawnCwd`,
+ * `holdsAScannableSpawn`), never the derivation expression itself — a test
+ * that rebuilt the alternation would pass alongside a drifted copy instead of
+ * catching it.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	NODE_SPAWN_NAMES,
+	SPAWN_NAMES,
+	holdsAScannableSpawn,
+	scanSpawnCwd,
+} from "./spawn-cwd-scan.js";
+
+describe("spawn-cwd scanner vocabulary (#2927)", () => {
+	it("scans every seam-wrapper name the vocabulary holds", async () => {
+		// A drifted literal in the scan's site rule — one name off — drops the
+		// name's sites while the tuple still claims them.
+		for (const name of SPAWN_NAMES) {
+			const scan = await scanSpawnCwd("fixture.ts", `${name}("tool", [], {});`);
+			expect(
+				scan.sites.map((site) => `${site.callee}:${site.kind}`),
+				`seam wrapper ${name} is a direct site`,
+			).toEqual([`${name}:direct`]);
+		}
+	});
+
+	it("admits every seam-wrapper name in the population predicate", async () => {
+		// The reviewer's exact probe (#2926): a name added to the tuple that
+		// the predicate does not admit leaves the sweep green and blind.
+		for (const name of SPAWN_NAMES) {
+			expect(
+				holdsAScannableSpawn(`const r = await ${name}("t", [], {});`),
+				`seam wrapper ${name} is a population file`,
+			).toBe(true);
+		}
+	});
+
+	it("scans and admits every node spawn name the vocabulary holds", async () => {
+		for (const name of NODE_SPAWN_NAMES) {
+			const source = `import { ${name} } from "node:child_process";\n${name}("tool", []);`;
+			const scan = await scanSpawnCwd("fixture.ts", source);
+			expect(
+				scan.sites.map((site) => `${site.callee}:${site.kind}`),
+				`node spawn ${name} is a direct site`,
+			).toEqual([`${name}:direct`]);
+			expect(
+				holdsAScannableSpawn(source),
+				`node spawn ${name} is a population file`,
+			).toBe(true);
+		}
+	});
+
+	it("keeps the bounds: object methods and aliased imports stay out", () => {
+		// `server.spawn(` is an LSP server definition's own method (round-5
+		// v4-N3); an aliased import is the stated #2888 bound, on both sides.
+		expect(
+			holdsAScannableSpawn("await server.spawn(root, { allowInstall });"),
+			"a method named spawn on some object",
+		).toBe(false);
+		expect(
+			holdsAScannableSpawn(
+				'import { spawn as nodeSpawn } from "node:child_process";\nnodeSpawn("t", []);',
+			),
+			"an aliased import is the stated bound, not a population file",
+		).toBe(false);
+	});
+});

--- a/tests/support/spawn-cwd-scan-vocabulary.test.ts
+++ b/tests/support/spawn-cwd-scan-vocabulary.test.ts
@@ -76,18 +76,4 @@ describe("spawn-cwd scanner vocabulary (#2927)", () => {
 		).toBe(true);
 	});
 
-	it("keeps the bounds: object methods and unbound spellings stay out", () => {
-		// `server.spawn(` is an LSP server definition's own method (round-5
-		// v4-N3); `promisify(exec)` never binds a vocabulary name (#2888).
-		expect(
-			holdsAScannableSpawn("await server.spawn(root, { allowInstall });"),
-			"a method named spawn on some object",
-		).toBe(false);
-		expect(
-			holdsAScannableSpawn(
-				'import { execFileAsync } from "node:child_process";\nexecFileAsync("tool");',
-			),
-			"an unrecognised child_process spelling stays outside the population",
-		).toBe(false);
-	});
 });

--- a/tests/support/spawn-cwd-scan-vocabulary.test.ts
+++ b/tests/support/spawn-cwd-scan-vocabulary.test.ts
@@ -75,5 +75,4 @@ describe("spawn-cwd scanner vocabulary (#2927)", () => {
 			"an aliased node spawn is a population file",
 		).toBe(true);
 	});
-
 });

--- a/tests/support/spawn-cwd-scan.ts
+++ b/tests/support/spawn-cwd-scan.ts
@@ -161,8 +161,10 @@ export interface SpawnCwdScan {
  * Three of the five names (`safeSpawnSync`, `spawnSupervised`, `execa`) have
  * no definition in `clients/` today: they are admitted spellings, not live
  * call sites. This list therefore cannot be derived from the seam modules'
- * own exports without moving the population, so it stays curated — and every
- * name in it is pinned by `spawn-cwd-scan-vocabulary.test.ts`.
+ * own exports without moving the population, so it stays curated. The
+ * vocabulary test pins that each name is both scanned and admitted; a name with
+ * no production site (the three above) can be deleted without any red, so the
+ * curated list is a documented bound, not a guarded one.
  */
 export const SPAWN_NAMES = [
 	"safeSpawnAsync",

--- a/tests/support/spawn-cwd-scan.ts
+++ b/tests/support/spawn-cwd-scan.ts
@@ -61,6 +61,26 @@
  * the expected verdict per cell — is the "Detector state space (round 3)"
  * table on PR #2693, and every cell has a named fixture in
  * `spawn-cwd-scan.test.ts`.
+ *
+ * ## Freeze policy (#2927)
+ *
+ * A new scanner finding is a reason to SIMPLIFY this scanner, not to extend
+ * it. Every extension so far (rounds 1 through 5, #2888, #2902) closed the
+ * shown hole and left the next spelling open — AGENTS.md defect shape 34, "a
+ * guard that enumerates surface spellings". If a finding does not converge in
+ * one verify round, the fallback is an ast-grep rule matching any
+ * `child_process` call not routed through the seam, run by the existing rule
+ * engine, with this scanner deleted.
+ *
+ * ## The `// cwd-exempt:` escape hatch (#2923, kept)
+ *
+ * The tag stays as the documented escape hatch for a genuine non-project
+ * child: a presence probe that reads no file and no config. Live users are
+ * `cpp-check.ts`'s `cl` probe and `psscriptanalyzer.ts`'s two PowerShell
+ * presence probes; #2911 removes those tags, after which the channel has zero
+ * users and remains covered by the K10 self-tests alone. Deleting the parser
+ * instead would flag those sites and move the sweep pins, so deletion stays
+ * out until a lane carries the production tags with it.
  */
 
 import { loadAstGrepNapi } from "../../clients/deps/ast-grep-napi.js";
@@ -137,14 +157,32 @@ export interface SpawnCwdScan {
 }
 
 /** The seam's own wrappers: recognised by the callee's simple name, because
- * every one of them is a pi-lens export nothing else in the tree is called. */
-const SPAWN_NAMES = new Set([
+ * every one of them is a pi-lens export nothing else in the tree is called.
+ *
+ * ## One vocabulary (#2926, closed by #2927)
+ *
+ * This tuple is the SINGLE source of truth for the seam side of "what counts
+ * as a spawn". The scan's own site rule ({@link scanSpawnCwd}'s `siteNames`)
+ * and the sweep's population predicate ({@link holdsAScannableSpawn}, consumed
+ * by `runner-spawn-cwd-sweep.test.ts`) both derive from it — a second
+ * hand-written copy of this list is a defect, not a convenience. The #2902
+ * round-3 probe added one name here and all 140 sweep tests stayed green,
+ * because the population predicate carried its own copy and never saw it.
+ *
+ * Three of the five names (`safeSpawnSync`, `spawnSupervised`, `execa`) have
+ * no definition in `clients/` today: they are admitted spellings, not live
+ * call sites. This list therefore cannot be derived from the seam modules'
+ * own exports without moving the population, so it stays curated — and every
+ * name in it is pinned by `spawn-cwd-scan-vocabulary.test.ts`.
+ */
+export const SPAWN_NAMES = [
 	"safeSpawnAsync",
 	"safeSpawnSync",
 	"safeSpawn",
 	"spawnSupervised",
 	"execa",
-]);
+] as const;
+const SPAWN_NAME_SET = new Set<string>(SPAWN_NAMES);
 /**
  * `node:child_process` itself, recognised only when the file IMPORTS the name
  * unaliased. A simple-name match would read `server.spawn(root, …)` — an LSP
@@ -152,12 +190,47 @@ const SPAWN_NAMES = new Set([
  * `clients/lsp/index.ts` entered the population as a phantom site when the
  * population filter and this list were reconciled (round-5 v4-N3).
  *
+ * Same one-vocabulary rule as {@link SPAWN_NAMES}: the scan's import matcher
+ * below and the sweep's population predicate both derive from this tuple.
+ *
  * Stated bound: an ALIASED import (`import { spawn as nodeSpawn }`) is not a
  * site here — `clients/lsp/client.ts`, `clients/instance-reaper.ts` and
  * `clients/child-unref.ts` each spawn that way and are outside this sweep's
  * reach. Tracked by #2888.
  */
-const NODE_SPAWN_NAMES = new Set(["spawn", "execFile"]);
+export const NODE_SPAWN_NAMES = ["spawn", "execFile"] as const;
+const NODE_SPAWN_NAME_SET = new Set<string>(NODE_SPAWN_NAMES);
+/** The child_process import specifier the population predicate admits. */
+const NODE_SPAWN_SPECIFIER_PATTERN = new RegExp(
+	`^(?:\\s*)(?:${NODE_SPAWN_NAMES.join("|")})(?:\\s*)$`,
+);
+/** A seam-wrapper call the population predicate admits. */
+const SEAM_CALL_PATTERN = new RegExp(`\\b(?:${SPAWN_NAMES.join("|")})\\s*\\(`);
+
+/**
+ * Whether a file can hold a site the scan recognises: one of the seam
+ * wrappers by name, or an unaliased import of a {@link NODE_SPAWN_NAMES} name
+ * from `child_process` or `node:child_process`. This lives here, beside the
+ * two tuples, so the sweep's population filter and the scan's own site rule
+ * derive from one vocabulary instead of hand-copying it: round 4's filter
+ * listed only the five seam names while the scanner also counted
+ * `spawn`/`execFile`, so a file whose only child spawn was a bare `spawn(`
+ * could never move a pin (round-5 v4-N3), and the #2902 round-3 probe showed
+ * the surviving copy drifting the same way (#2926). An ALIASED
+ * child_process import stays out on both sides, tracked by #2888.
+ */
+export function holdsAScannableSpawn(source: string): boolean {
+	const hasUnaliasedChildProcessImport = [
+		...source.matchAll(
+			/import(?:\s+[\w*$]+\s*,)?\s*\{([^}]*)\}\s*from\s*["'](?:node:)?child_process["']/g,
+		),
+	].some((match) =>
+		match[1]
+			.split(",")
+			.some((specifier) => NODE_SPAWN_SPECIFIER_PATTERN.test(specifier)),
+	);
+	return SEAM_CALL_PATTERN.test(source) || hasUnaliasedChildProcessImport;
+}
 /** `safeSpawn*(command, args, options?)` — the options object is argument 2. */
 const SPAWN_OPTIONS_INDEX = 2;
 const EXEMPT_TAG = /^\s*\/\/\s*cwd-exempt:\s*(.+)/;
@@ -277,7 +350,10 @@ function importedNodeSpawnNames(root: SgNode): Set<string> {
 							const text = named.text();
 							// `spawn as nodeSpawn` is an import_specifier with an alias;
 							// only the unaliased form is matched by simple name below.
-							if (NODE_SPAWN_NAMES.has(text) && !/\bas\b/.test(named.text())) {
+							if (
+								NODE_SPAWN_NAME_SET.has(text) &&
+								!/\bas\b/.test(named.text())
+							) {
 								names.add(text);
 							}
 						}
@@ -1250,7 +1326,10 @@ export async function scanSpawnCwd(
 	// One list decides what a site is, for the shared census below and for the
 	// loop that reads the sites: two copies of the rule meant a mutation of
 	// either one left the other enforcing it.
-	const siteNames = new Set([...SPAWN_NAMES, ...importedNodeSpawnNames(root)]);
+	const siteNames = new Set([
+		...SPAWN_NAME_SET,
+		...importedNodeSpawnNames(root),
+	]);
 	// A same-file function that RETURNS the seam's result is itself a seam
 	// resolver — `test-runner-client.ts`'s `resolveSpawnCwd` (#2879),
 	// `tool-cwd.ts`'s `resolveRunnerCwd`, `formatters.ts`'s


### PR DESCRIPTION
## Summary

The spawn-cwd detector stops drifting: one vocabulary, one predicate home, then frozen.

`tests/support/spawn-cwd-scan.ts` now exports the two name tuples every clause derives from. `SPAWN_NAMES` (the five seam wrappers) and `NODE_SPAWN_NAMES` (seven `child_process` names since #2902) were each spelled twice: once as a private set in the scanner and once as a hand-written literal in the sweep's `holdsAScannableSpawn`. The #2902 round-3 probe proved the drift: adding `spawnGuarded` to the scanner's set left all 140 sweep tests green. This PR moves `holdsAScannableSpawn` beside the tuples and derives both its clauses from them, so a name the scanner scans is a name the population admits, by construction.

Scope, per #2927 (folds #2926 and #2923):

1. One vocabulary: done, with one named deviation from #2927 item 1 — the seam-wrapper names are NOT read from the seam modules' own exports: three of the five (`safeSpawnSync`, `spawnSupervised`, `execa`) have no definition in `clients/` today (verified by the reviewer), so deriving from exports would move the population; the list stays curated and the scanner header says so. Both tuples are exported; the scan's site rule, binding table, and population predicate all derive from them. Per-name parity tests red on either side drifting.
2. `// cwd-exempt:` channel: deleted with its self-tests. Round 1 kept it with three live users (`cpp-check.ts` `cl` probe, `psscriptanalyzer.ts` two PowerShell probes); #2911 then removed those tags, and the merged-tree grep (`grep -rn "cwd-exempt:" clients tools mcp index.ts`) returns zero production users, so round 2 deletes the parser, the `exemptReason` field, and the K10 self-tests as #2927 item 2 asks.
3. Freeze: the scanner header states the policy (a new finding simplifies the scanner; fallback is an ast-grep rule for unseamed `child_process` calls with this scanner deleted), and AGENTS.md carries the one-vocabulary, freeze, and channel-deleted sentences.

Merge note: #2902 and #2911 are merged (master `abc4ac39c`). #2902 rewrote `holdsAScannableSpawn` in the sweep file with namespace/default/dynamic/require coverage and widened `NODE_SPAWN_NAMES` to seven names; this round keeps that broader pattern, moves it into the scanner beside the tuples, and derives its remaining hand-written seam clause from `SPAWN_NAMES` (the sweep's copy is deleted). #2911 removed the exempt tags, so the channel deletion above applies. See `## Round 2 (merge)` for the per-region resolutions.

Closes #2927. Scope items 2 and 3 are met as asked; item 1 is met with the curated-list deviation named above.

## Type of change

- [ ] Bug fix
- [x] Enhancement (improvement to existing capability)
- [ ] New feature (net-new capability)
- [ ] Documentation

## Area

- [x] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts` (not changed)
- [x] `package-lock.json` is in sync with `package.json` (untouched)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there
- [x] `.changelog/<branch-or-slug>-<short-desc>.md` has one valid entry **in this PR** for any user-facing change (Added/Changed/Deprecated/Removed/Fixed/Security) — see [.changelog/README.md](../.changelog/README.md); internal-only test/refactor PRs may skip it
- [x] Commit subject includes the issue number: `(closes #NNN)` or `(refs #NNN)`

## Tests

New file `tests/support/spawn-cwd-scan-vocabulary.test.ts` (4 cases, each loops the tuple it pins, so a tuple addition extends coverage by itself):

- `scans every seam-wrapper name the vocabulary holds`: each `SPAWN_NAMES` entry yields one direct site from `scanSpawnCwd`. Pins the scan side of the derivation.
- `admits every seam-wrapper name in the population predicate`: each entry is admitted by `holdsAScannableSpawn`. Pins the population side; red-first proof of #2926 below.
- `scans and admits every node spawn name the vocabulary holds`: each `NODE_SPAWN_NAMES` entry (seven since #2902) yields a direct site and a population hit, plus an aliased-binding parity pair (`nodeSpawn:direct` site and predicate admit).
- `keeps the bounds: object methods and unbound spellings stay out`: `server.spawn(` and `execFileAsync` stay negative on the predicate.

Screens (AGENTS.md test-authoring): screen 1 (production entry points `scanSpawnCwd` / `holdsAScannableSpawn`, same functions production uses), screen 3 (expectations observe scan output from tuple data; no rebuilt alternation), screen 7 (no mocks; real scanner), screen 9 (tuples are input data, not a re-implementation of the rule).

Red-first (pre-fix shape: tuple gains `spawnGuarded`, predicate reverts to a hand-written literal — the reviewer's exact probe):

- `admits every seam-wrapper name in the population predicate`
- `AssertionError: seam wrapper spawnGuarded is a population file: expected false to be true`
- `Tests 1 failed | 3 passed (4)`

Mutations, whole-file runs, quoted (re-run on the merged tree in round 2 with identical shape):

- Site rule replaced by a one-name-off literal (drops `execa`): `scans every seam-wrapper name the vocabulary holds` reds with `seam wrapper execa is a direct site: expected [] to deeply equal [ 'execa:direct' ]`.
- `safeSpawnAsync` dropped from the tuple: sweep reds 5 ways, including `spawn population files: expected 9 to be 79` and `a seam wrapper by name: expected false to be true`. Tuple contents are pinned by the population pins.

Suites (round 2, merged tree): `tests/support/` 15 files 286 passed; `tests/config/` 52 files 432 passed 1 skipped; sweep 8 passed with pins MEASURED on the merged tree (79 files, 130 direct sites, 33 wrapper sites — identical to master's, no pin edit); `probe-and-root-spawn-cwd` 6 passed; flake-shape ratchet green with no new admission; `npm run lint` exit 0; `npx tsc --noEmit` exit 0; `npm run fmt:check` clean; `npm run preflight` 13/13 pass.

### Test assessment

- `tests/support/spawn-cwd-scan-vocabulary.test.ts` (new): uniquely pins that each tuple entry is both scanned and admitted. Round 2 re-targets its bounds case to the merged semantics (aliased bindings admitted both sides; `execFileAsync` stays out). The vocabulary test file's "keeps the bounds" case duplicated two sweep assertions character for character and is deleted in the trailing commit; the node-side admit loop mirrors the sweep's but its scan half is new.
- `tests/clients/dispatch/runners/runner-spawn-cwd-sweep.test.ts` (edited: predicate moved out, `NODE_SPAWN_NAMES` + predicate imported): still the integration assertion over the live tree; pins measured on the merged tree (79/130/33, unchanged from master). The moved function keeps its sweep-level coverage (`the population rule admits exactly what the scan can see`); the deleted local copy is the helper-count decrease.
- `tests/support/spawn-cwd-scan.test.ts` (edited): K10 exemption-tag block (5 tests) plus the `redundantExemptions` harness deleted with the channel; all other state-space cells untouched.
- Deletions in this round: the five K10 tests above (vacuity-proven: their seam `exemptReason` no longer exists, so they red on no mutation of shipped code). Named survivor: none needed — vacuous, not redundant.

## Blast radius

Tests-only change; no production module touched, so `module_report` has nothing to map (empty, recorded explicitly). Affected dependents of `tests/support/spawn-cwd-scan.ts`: the sweep test (imports `holdsAScannableSpawn` and `NODE_SPAWN_NAMES`), the self-tests, and the parity file. The moved predicate keeps master's broad binding coverage (named, aliased, namespace, default, dynamic-import, require) and derives its remaining hand-written seam clause from `SPAWN_NAMES`; internal scan uses switch from the private set to the derived `SPAWN_NAME_SET` with no behavior change. No hot path touched; no cost delta to measure. Verification: the four files plus `probe-and-root-spawn-cwd`, ratchet, config, and preflight, all green above.

## Class sweep

Defect class: a detector vocabulary hand-copied across two files (AGENTS.md shape 34 family: the copies agree today and nothing asserts they must). Population sweep over `clients/`, `tools/`, `mcp/`, `scripts/`, `index.ts`, `tests/` for `SPAWN_NAMES`, `NODE_SPAWN_NAMES`, `holdsAScannableSpawn`:

- Scanner private `SPAWN_NAMES` set: converted to the exported tuple; internal uses (`SPAWN_NAME_SET`, census alternation) derived. Fixed.
- Sweep hand-written five-name regex: deleted; sweep imports the predicate. Fixed (round 2: the surviving copy was master's broader function; the seam clause is now derived too).
- Scanner private `NODE_SPAWN_NAMES` set and sweep inline specifier regexes: both derive from the exported seven-name tuple now (round 2 takes master's seven names and its namespace/default/dynamic/require coverage). Fixed.
- Class sweep by identifier found no third member, but an identifier grep cannot find a hand-copied LIST: `tests/support/flake-shape-scan.ts:~269` holds the same seven `child_process` names as a literal alternation (and `availability-gate.ts:~105` another). Recorded, not folded here — the freeze policy applies to the scanner, and those two live outside it.

Consolidation verdict: stay distributed against the two lookalikes. `tests/support/availability-gate.ts` `SPAWN_CALLS` answers a different question (did a module probe at all, including `exec`/`spawnAsync`/`spawnSync` the cwd sweep must not scan); folding the vocabularies would couple unrelated sweeps, and the deletion test relocates lines without concentrating logic. The sweep's fail-safe alias/call/apply patterns detect invisible spellings, not vocabulary membership. Neither is a member.

## Observability

No new failure path; no record added.

## Round 2 (merge)

Master is `abc4ac39c` (merge of #2911). This round merges `origin/master` and resolves by design, not by text.

Conflict regions and resolutions:

- `tests/support/spawn-cwd-scan.ts`, tuples: kept the exported `SPAWN_NAMES` tuple and took master's seven-name `NODE_SPAWN_NAMES`. Both clauses of `holdsAScannableSpawn` now derive from the tuples in one home (the node's alternation as master wrote it; the seam's `SEAM_CALL_PATTERN` from `SPAWN_NAMES`). Internal scan uses derive from `SPAWN_NAME_SET`.
- Same file, import bindings: took master's `addClause` (named, aliased, namespace, default bindings plus dynamic-import and require). The round-1 unaliased-only matcher is gone.
- Same file, site census: took master's `nodeSpawnBindings`. The round-1 `siteNames` set is gone.
- `runner-spawn-cwd-sweep.test.ts`: imports both `holdsAScannableSpawn` and `NODE_SPAWN_NAMES` from the scanner. The sweep's local copy of the predicate is deleted, so the helper count is flat (47 → 47 module-level functions, measured by the reviewer): the sweep's copy of the predicate was deleted and one derived helper added.
- `AGENTS.md`: keeps the one-vocabulary, freeze, and seven-name bound sentences. The escape-hatch sentence now records the channel deletion (#2927 item 2, #2923).

Channel decision: `grep -rn "cwd-exempt:" clients tools mcp index.ts` returns zero production users (exit 1) on the merged tree. Per #2927 item 2, round 2 deletes the channel: `EXEMPT_TAG`, `MIN_EXEMPT_REASON_LENGTH`, `exemptAbove`, the `exemptReason` field (two write sites), the K10 block (5 tests: `f-exempt-absent`, `f-exempt-comment`, `f-exempt-redundant`, `f-exempt-thin-reason`, the wrapper-call exemption), and the `redundantExemptions` harness. A repo-wide grep for the channel identifiers afterwards returns zero hits. Deleting the parser moves no pin because no production tag exists.

Pins are measured, not computed. The sweep runs green on the merged tree with `EXPECTED_FILES` 79, `EXPECTED_DIRECT_SITES` 130, and 33 wrapper sites. No pin was edited.

Probes re-run on the merged tree, quoted:

- Parity (`spawnGuarded` added to the tuple, predicate seam clause reverted to a hand-written literal): `admits every seam-wrapper name in the population predicate` reds with `AssertionError: seam wrapper spawnGuarded is a population file: expected false to be true`, `Tests 1 failed | 3 passed (4)`.
- Drifted census literal (drops `execa`): `scans every seam-wrapper name the vocabulary holds` reds with `AssertionError: seam wrapper execa is a direct site: expected [] to deeply equal [ 'execa:direct' ]`.
- `safeSpawnAsync` dropped from the tuple: sweep reds 5 ways, including `spawn population files: expected 9 to be 79` and `a seam wrapper by name: expected false to be true`.

Every `it(` title named above exists in the tree. `PI_LENS_HOME=$PWD/.probe-home` for all runs. No agents were used. No CI was read.

Environment note: `npm run preflight` (via its `knip` gate, `scripts/run-knip.mjs`) deletes gitignored in-place `.js` by design and never rebuilds. Two runs in this round hit the stale-build guard right after preflight. The fix is `npm run build` before any later test run. The suites above all ran on a fresh build.



## Review follow-through (orchestrator)

Review verdict merge after fixes, all contract-only: the header sentence "every name in it is pinned" was false (deleting the three site-less names leaves 294 tests green) and is reworded; the duplicated "keeps the bounds" test is deleted; the body now names the item-1 deviation, the two literal copies of the child_process names outside the scanner, and the flat helper count.
