### PR TITLE
refactor(lsp): fold allowStamp's identity branch out of auxiliary coverage (closes #2914)

### DIFF
--- a/.changelog/refactor-2914-aux-coverage-allow-stamp-fold.md
+++ b/.changelog/refactor-2914-aux-coverage-allow-stamp-fold.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- **Fold `allowStamp` out of auxiliary coverage (closes #2914)** — The stamp-union predicate keeps one behaviour; the sibling and aggregate rows call the binding predicate directly.

--- a/clients/lsp/diagnostic-binding.ts
+++ b/clients/lsp/diagnostic-binding.ts
@@ -350,29 +350,25 @@ export interface AuxiliaryWaitEvidence {
  * the stamp alone cannot prove that the bytes matched. The pre-notify boolean
  * passed as `bindingMatchesContent` preserves a binding that the notify
  * cleared, while the live stamp covers a publication that landed after the
- * wait began. The caller selects the master's row policy explicitly: only the
- * demoted row enables the stamp union; the sibling and aggregate rows remain
- * binding-only. Absent evidence fails closed.
+ * wait began. This predicate is the union; only the demoted row calls it.
+ * The sibling and aggregate rows stay binding-only by calling
+ * `auxCoversThisContent` directly (#2914). Absent evidence fails closed.
  */
 export function auxiliaryPublicationEvidence({
 	bindingMatchesContent,
 	baseline,
 	currentPathVersion,
-	allowStamp = true,
 	raced = true,
 }: {
 	bindingMatchesContent: boolean;
 	baseline: number | undefined;
 	currentPathVersion: number | undefined;
-	/** Whether this row's master semantics admit the per-path stamp. */
-	allowStamp?: boolean;
 	/** Whether the raced wait established the stamp evidence for this row. */
 	raced?: boolean;
 }): boolean {
 	return (
 		bindingMatchesContent ||
-		(allowStamp &&
-			raced &&
+		(raced &&
 			Number.isFinite(baseline) &&
 			currentPathVersion !== undefined &&
 			currentPathVersion > (baseline as number))

--- a/clients/lsp/diagnostic-binding.ts
+++ b/clients/lsp/diagnostic-binding.ts
@@ -350,9 +350,11 @@ export interface AuxiliaryWaitEvidence {
  * the stamp alone cannot prove that the bytes matched. The pre-notify boolean
  * passed as `bindingMatchesContent` preserves a binding that the notify
  * cleared, while the live stamp covers a publication that landed after the
- * wait began. This predicate is the union; only the demoted row calls it.
- * The sibling and aggregate rows stay binding-only by calling
- * `auxCoversThisContent` directly (#2914). Absent evidence fails closed.
+ * wait began. This predicate is the union. Four callers use it; only the
+ * demoted row's `publishedThisContent` takes the union — the sibling and
+ * aggregate rows compute that field from `auxCoversThisContent` directly
+ * (#2914), while their `outcome` field still reads the stamp through this
+ * predicate. Absent evidence fails closed.
  */
 export function auxiliaryPublicationEvidence({
 	bindingMatchesContent,

--- a/clients/lsp/index.ts
+++ b/clients/lsp/index.ts
@@ -5873,7 +5873,6 @@ export class LSPService {
 											bindingMatchesContent: false,
 											baseline: aux.baseline,
 											currentPathVersion,
-											allowStamp: true,
 											raced,
 										});
 										// #1459: a DEFERRED aux was never sent this content and is not
@@ -5906,15 +5905,10 @@ export class LSPService {
 											// did not narrow the touch.
 											// #1586: through the one predicate, so this row and the merge
 											// below cannot disagree about the same scanner.
-											publishedThisContent: auxiliaryPublicationEvidence({
-												bindingMatchesContent: auxCoversThisContent(
-													aux.serverId,
-												),
-												baseline: aux.baseline,
-												currentPathVersion: currentPathVersion,
-												allowStamp: false,
-												raced,
-											}),
+											// #2914: binding-only by construction — the direct call
+											// below is master's line; the stamp axis already decided
+											// the outcome above and must not re-admit the row here.
+											publishedThisContent: auxCoversThisContent(aux.serverId),
 											budgetMs,
 											elapsedMs,
 											// #1458 S3: elapsed measured from BEFORE the primary wait
@@ -6207,13 +6201,10 @@ export class LSPService {
 									: publishedEvidence
 										? ("answered" as const)
 										: ("silent" as const),
-								publishedThisContent: auxiliaryPublicationEvidence({
-									bindingMatchesContent: auxCoversThisContent(entry.info.id),
-									baseline,
-									currentPathVersion,
-									allowStamp: false,
-									raced: true,
-								}),
+								// #2914: binding-only by construction — the direct call
+								// below is master's line; the stamp axis already decided
+								// the outcome above and must not re-admit the row here.
+								publishedThisContent: auxCoversThisContent(entry.info.id),
 								budgetMs: timeoutFor(entry.client.serverId),
 								elapsedMs: waitedMs,
 								elapsedSinceNotifyMs: waitedMs,

--- a/tests/clients/lsp/service-aux-grace.test.ts
+++ b/tests/clients/lsp/service-aux-grace.test.ts
@@ -3165,3 +3165,131 @@ describe("R8 — aux grace: ast-grep napi/aux-grace mark ordering (#2324 R2-A)",
 		pendingAux.resetPendingAuxiliaryCoverage();
 	});
 });
+
+/**
+ * #2914 — the sibling and aggregate `publishedThisContent` rows are
+ * binding-only by construction (master's direct `auxCoversThisContent` call).
+ * Each test below drives the stamp-only cell through the real touchFile: the
+ * auxiliary publishes during the wait (its per-path stamp advances past the
+ * pre-notify baseline, so the outcome reads "answered") while carrying no
+ * content binding for these bytes (the double exposes no
+ * `getDiagnosticBinding`, and the pre-notify snapshot is empty). The row must
+ * still report `publishedThisContent: false` — the stamp axis already decided
+ * the outcome, and re-admitting it here would let a late publication of the
+ * previous revision pose as coverage of this one. Rewriting either row as the
+ * stamp union flips its `publishedThisContent` to true and reds its test.
+ */
+describe("#2914 — non-demoted aux rows stay binding-only", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.resetModules();
+		getServersForFileWithConfig.mockReset();
+		createLSPClient.mockReset();
+		logLatency.mockReset();
+		delete process.env.PI_LENS_AUX_GRACE_MS;
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		delete process.env.PI_LENS_AUX_GRACE_MS;
+	});
+
+	function graceOutcomes() {
+		const row = logLatency.mock.calls.find(
+			([entry]) =>
+				entry.phase === "lsp_aux_wait_outcome" &&
+				entry.metadata?.waitShape === "aux_grace",
+		)?.[0];
+		return row?.metadata?.outcomes as
+			| Array<{
+					serverId: string;
+					outcome: string;
+					publishedThisContent?: boolean;
+			  }>
+			| undefined;
+	}
+
+	it("the with-auxiliary grace row reports binding-only on stamp-only evidence", async () => {
+		process.env.PI_LENS_AUX_GRACE_MS = String(AUX_GRACE_MS);
+
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+
+		// Aux publishes a finding at 400ms, inside the 500ms grace: its stamp
+		// advances, but the double carries no content binding for these bytes.
+		const primaryClient = makeClient(100, [makeDiagnostic("primary error")], {
+			serverId: "ts-primary",
+		});
+		const auxClient = makeClient(400, [makeDiagnostic("aux finding")], {
+			serverId: "opengrep-aux",
+		});
+		getServersForFileWithConfig.mockReturnValue([
+			makePrimaryServer("ts-primary"),
+			makeAuxServer("opengrep-aux"),
+		]);
+		createLSPClient
+			.mockResolvedValueOnce(primaryClient)
+			.mockResolvedValueOnce(auxClient);
+		await service.getClientsForFile(FILE);
+
+		const touchPromise = service.touchFile(FILE, "stamp-only-grace", {
+			clientScope: "with-auxiliary",
+			auxiliaryServerIds: ["opengrep-aux"],
+			collectDiagnostics: true,
+			diagnostics: "document",
+		});
+		await vi.advanceTimersByTimeAsync(500);
+		const result = await touchPromise;
+
+		// Sanity that this is the stamp-only cell: the stamp decided the outcome.
+		const outcomes = graceOutcomes();
+		expect(outcomes?.[0]?.outcome).toBe("answered");
+		expect(result?.confirmation).toBe("confirmed");
+		// The pin: the row itself stays binding-only.
+		expect(outcomes?.[0]?.publishedThisContent).toBe(false);
+	});
+
+	it("the aggregate row reports binding-only on stamp-only evidence", async () => {
+		const { LSPService } = await import("../../../clients/lsp/index.js");
+		const service = new LSPService();
+		getServersForFileWithConfig.mockReturnValue([
+			makePrimaryServer("ts-primary"),
+			makeAuxServer("opengrep"),
+		]);
+		createLSPClient.mockImplementation(
+			async (options: { serverId?: string }) =>
+				options?.serverId === "opengrep"
+					? makeClient(900, [makeDiagnostic("aux finding")], {
+							serverId: "opengrep",
+						})
+					: makeClient(100, [makeDiagnostic("primary error")], {
+							serverId: "ts-primary",
+						}),
+		);
+
+		const touch = service.touchFile(FILE, "stamp-only-aggregate", {
+			clientScope: "all",
+			collectDiagnostics: true,
+			diagnostics: "document",
+		});
+		await vi.advanceTimersByTimeAsync(5000);
+		const result = await touch;
+		const outcomes = logLatency.mock.calls.find(
+			([entry]) => entry.phase === "lsp_aux_wait_outcome",
+		)?.[0]?.metadata?.outcomes as
+			| Array<{
+					serverId: string;
+					outcome: string;
+					publishedThisContent?: boolean;
+			  }>
+			| undefined;
+
+		// Sanity that this is the stamp-only cell: the stamp decided the outcome.
+		expect(outcomes?.[0]?.outcome).toBe("answered");
+		expect(result?.confirmation).toBe("confirmed");
+		expect(result?.unconfirmedServerIds).toBeUndefined();
+		// The pin: the row itself stays binding-only.
+		expect(outcomes?.[0]?.publishedThisContent).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Folds the `allowStamp` parameter out of `auxiliaryPublicationEvidence`
(`clients/lsp/diagnostic-binding.ts`). Its `false` branch is the identity
function on `bindingMatchesContent` (proven by a 24-cell probe through the
real function: 0 mismatches), so the two non-demoted rows that passed
`allowStamp: false` now call master's direct `auxCoversThisContent` line, the
demoted row keeps the union, and the parameter is deleted.

Closes #2914 — every acceptance criterion holds: the two rows are back on the
direct call, the parameter is gone, the demoted row stays on the union,
helper count is -0/+0, one pinning test per non-demoted row reds under the
union mutant, and the function count goes down or stays (no new function).

## Type of change

- [ ] Bug fix
- [ ] New feature (net-new capability)
- [x] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [x] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [ ] area:perf
- [ ] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (regenerate with the exact npm pin in `package.json`'s `packageManager` field)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there
- [x] `.changelog/<branch-or-slug>-<short-desc>.md` has one valid entry **in this PR** for any user-facing change (Added/Changed/Deprecated/Removed/Fixed/Security) — see [.changelog/README.md](../.changelog/README.md); internal-only test/refactor PRs may skip it
- [x] Commit subject includes the issue number: `(closes #NNN)` or `(refs #NNN)`

## Tests

| Test file / case | What it pins and why |
| --- | --- |
| `tests/clients/lsp/service-aux-grace.test.ts` — `the with-auxiliary grace row reports binding-only on stamp-only evidence` (NEW) | Regression proof for the grace-path row: stamp-only cell (aux publishes in-grace, no content binding) must report `publishedThisContent: false`. Reds when the row is rewritten as the union. |
| `tests/clients/lsp/service-aux-grace.test.ts` — `the aggregate row reports binding-only on stamp-only evidence` (NEW) | Regression proof for the `clientScope: "all"` row: same stamp-only cell, same pin. Reds when the row is rewritten as the union. |
| `tests/clients/lsp` whole dir (137 files, 1391 passed) | Behaviour unchanged across the auxiliary-coverage population. |
| `tests/config` whole dir (52 files, 432 passed) | Governance sweeps unaffected. |

Premise probe (pre-fix, through the real built function, 24 cells over
binding x baseline x current x raced): `allowStamp: false` returns exactly
`bindingMatchesContent` in every cell, and the default union admits the
stamp-only cell. Output: `cells=24 mismatches=0`.

New tests are red-first by mutation (whole-file runs, all other tests green):

MUT-A (grace row rewritten as the union):

```text
Test Files  1 failed (1)
Tests  1 failed | 67 passed (68)
× the with-auxiliary grace row reports binding-only on stamp-only evidence
```

MUT-B (aggregate row rewritten as the union):

```text
Test Files  1 failed (1)
Tests  1 failed | 67 passed (68)
× the aggregate row reports binding-only on stamp-only evidence
```

Screens: both tests enter at the production entry point (`LSPService.touchFile`,
the same function production enters — screen 1), assert the `logLatency` mock
row only as the read-out of bytes the real service wrote (screen 7: the
outcome and confirmation come from the real touch, not the mock), and name the
mutation each reds on (screen 3).

`npm run preflight` (last, on this head):

| gate | mirrored CI job | pass/fail | first red line |
| --- | --- | --- | --- |
| build | Lint & type-check | pass |  |
| lint | Lint & type-check | pass |  |
| fmt:check | oxfmt format check | pass |  |
| changelog:check | Unit tests | pass |  |
| check-changelog-fragments | Changelog fragment (fast-fail) | pass |  |
| check:lockfile | Lint & type-check | pass |  |
| lockfile:complete | Lint & type-check | pass |  |
| tests/config | Unit tests | pass |  |
| generation-guard | Unit tests | pass |  |
| flake-shape-ratchet | Unit tests | pass |  |
| lsp-spawn-heavy-coverage | Unit tests | pass |  |
| ci-verdict | Unit tests | pass |  |
| knip | knip (advisory) | pass |  |

### Test assessment

`tests/clients/lsp/service-aux-grace.test.ts` uniquely pins the per-edit and
aggregate auxiliary wait producers (grace budgets, outcome evidence, coverage
naming) through the real `LSPService`. This PR makes no test redundant: the two
new cases pin cells no existing case visits (stamp advanced, binding absent —
existing answered-cases all carry bindings or clean publishes, existing
silent-cases carry no stamp). No removal candidates.

## Blast radius

Changed symbol: `auxiliaryPublicationEvidence`
(`clients/lsp/diagnostic-binding.ts` — `allowStamp?: boolean` removed; body is
now the unconditional union). Callers above, callees below:

```text
touchFile (clients/lsp/index.ts)
  answeredForThisTouch (~5580, union, unchanged)
  demoted-row publishedThisContent (~5823, union kept, unchanged)
  grace outcome publishedEvidence (~5872, `allowStamp: true` line dropped, unchanged)
  aggregate outcome publishedEvidence (~6192, unchanged)
+ grace publishedThisContent (~5909): union{allowStamp:false} → auxCoversThisContent(aux.serverId)
+ aggregate publishedThisContent (~6210): union{allowStamp:false} → auxCoversThisContent(entry.info.id)
auxiliaryPublicationEvidence
  bindingMatchesContent (caller-supplied boolean, unchanged)
  Number.isFinite / comparisons (unchanged)
```

No hot path touched (per-touch outcome assembly, not per-spawn/per-file/per-render);
no cost delta to measure. `module_report` unavailable in this lane; the tree
above is verified by grep. Verification: `tests/clients/lsp` (1391 passed),
`tests/config` (432 passed), `tsc --noEmit` clean, `build:dist` succeeds.

## Observability

No new failure path; no record added.

## Class sweep

Shape: dead-parameter fold (minimalism ladder step 1 — the `false` branch need
not exist; net-count rule — function count unchanged, parameter count -1).
Pattern sweep — every caller of the seam in the tree (grep pasted, post-fix):

```text
clients/lsp/index.ts:70:      auxiliaryPublicationEvidence,   (import)
clients/lsp/index.ts:5580:    auxiliaryPublicationEvidence({  (answered check, union)
clients/lsp/index.ts:5823:    auxiliaryPublicationEvidence({  (demoted row, union kept)
clients/lsp/index.ts:5872:    auxiliaryPublicationEvidence({  (grace outcome, union)
clients/lsp/index.ts:6192:    auxiliaryPublicationEvidence({  (aggregate outcome, union)
clients/lsp/diagnostic-binding.ts:357: export function auxiliaryPublicationEvidence({
```

Population sweep — `allowStamp` literal over `clients/`, `tools/`, `mcp/`,
`scripts/`, `index.ts`, `tests/`: zero hits in tracked source after this
change (only stale compiled `.js`, regenerated by `npm run build`).
Deletion sweep (dependents first): no test doubles of the parameter exist
(the literal never appears in `tests/`), and no other production module
imports it — the grep above is the complete member list.

Consolidation verdict: fold (done here) — the union lives in the one
predicate; binding-only rows call the one binding predicate. No new seam.


## Review follow-through (orchestrator)

Review verdict merge-ready; the docstring at `clients/lsp/diagnostic-binding.ts` overclaimed "only the demoted row calls it" (four call sites use the predicate; only the demoted row's `publishedThisContent` takes the union) and is reworded in the trailing commit; the pasted grep line number is corrected to 6192. The mirror-image dead argument (`bindingMatchesContent: false` at three call sites) is filed as #2934.
