### PR TITLE
ci(release): publish through the pinned npm; republish input to recover v4.1.6 (refs #2800)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [master]
   workflow_dispatch:
+    inputs:
+      republish:
+        description: >-
+          Publish package.json's version to npm from its EXISTING tag
+          (recovers a release whose tag and GitHub release were created but
+          whose publish-npm job failed, e.g. v4.1.6 on 2026-09-10). The tag
+          and the GitHub release are not recreated.
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -18,6 +27,8 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       tag: ${{ steps.meta.outputs.tag }}
       should_release: ${{ steps.meta.outputs.should_release }}
+      should_publish: ${{ steps.meta.outputs.should_publish }}
+      publish_ref: ${{ steps.meta.outputs.publish_ref }}
     steps:
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -28,6 +39,8 @@ jobs:
       - name: Compute release metadata
         id: meta
         shell: bash
+        env:
+          REPUBLISH: ${{ inputs.republish || 'false' }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TAG="v$VERSION"
@@ -41,10 +54,22 @@ jobs:
             SHOULD_RELEASE=true
           fi
 
+          # A manual `republish` run publishes the ALREADY-TAGGED tree to npm
+          # (the tag and the GitHub release stay as they are); a normal run
+          # publishes the commit it releases. Anything else never publishes.
+          SHOULD_PUBLISH="$SHOULD_RELEASE"
+          PUBLISH_REF="$GITHUB_SHA"
+          if [ "$SHOULD_RELEASE" = false ] && [ "$REPUBLISH" = true ]; then
+            SHOULD_PUBLISH=true
+            PUBLISH_REF="$TAG"
+          fi
+
           {
             echo "version=$VERSION"
             echo "tag=$TAG"
             echo "should_release=$SHOULD_RELEASE"
+            echo "should_publish=$SHOULD_PUBLISH"
+            echo "publish_ref=$PUBLISH_REF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Verify bump PR rolled up changelog entries
@@ -151,7 +176,12 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: [prepare, release]
-    if: needs.prepare.outputs.should_release == 'true'
+    # Runs after a real release (release job succeeded) or on a manual
+    # `republish` (release job skipped because the tag already exists).
+    if: >-
+      ${{ !cancelled()
+          && needs.prepare.outputs.should_publish == 'true'
+          && (needs.release.result == 'success' || needs.release.result == 'skipped') }}
     permissions:
       contents: read
       # Required for OIDC trusted publishing: npm exchanges this job's GitHub
@@ -163,6 +193,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: ${{ needs.prepare.outputs.publish_ref }}
           persist-credentials: false
 
       # yamllint disable-line rule:line-length
@@ -196,5 +227,13 @@ jobs:
           npm_pin="$(node -p "require('./package.json').packageManager.replace(/^npm@/, '')")"
           npx -y "npm@${npm_pin}" install --no-audit --no-fund
 
+      # Publish through the PINNED npm, not the runner's bundled one: since
+      # 9183f39c6 the pin step only caches npm@<pin> via npx (it no longer
+      # installs it globally), so a bare `npm publish` ran Node 22's bundled
+      # npm, which has no OIDC trusted-publishing support — the PUT went out
+      # unauthenticated and the registry answered E404 (v4.1.6, 2026-09-10:
+      # tag and GitHub release created, npm publish failed).
       - name: Publish to npm
-        run: npm publish
+        run: |
+          npm_pin="$(node -p "require('./package.json').packageManager.replace(/^npm@/, '')")"
+          npx -y "npm@${npm_pin}" publish


### PR DESCRIPTION
## Summary

The v4.1.6 release run (34530690014) created the tag and the GitHub release, then `publish-npm` failed: `npm error 404 Not Found - PUT https://registry.npmjs.org/pi-lens`. Cause: 9183f39c6 (2026-09-09, lockfile gate) changed the "Pin npm" step from `npm install -g npm@11.18.0` to `npx -y npm@<pin> --version`, which caches the pinned npm but leaves the runner's bundled npm in place; `npm publish` therefore ran Node 22's bundled npm, which has no OIDC trusted-publishing support, so the PUT went out unauthenticated. v4.1.5 (2026-09-08) published through the global install that commit removed.

Fix: publish through `npx -y npm@<pin>` like the install step. Recovery: a `workflow_dispatch` input `republish` — when the version's tag already exists, `publish-npm` runs against the TAGGED tree (`publish_ref`) and the tag / GitHub release are left untouched.

## Tests

Workflow-only. `actionlint` runs in CI (Lint workflow). No test id table.

## Blast radius

`.github/workflows/release.yml` only: `prepare` gains `should_publish` / `publish_ref` outputs and a `REPUBLISH` env; `publish-npm`'s `if` allows the `release` job to be skipped on a republish; its checkout takes `ref: publish_ref`. Normal pushes to master behave as before (`should_publish == should_release`, `publish_ref == GITHUB_SHA`).

## Class sweep

`grep -n "npm publish\|npm install -g" .github/workflows/*.yml`: the only bare `npm publish` is this one; ci.yml's production-install job already uses the pinned npm.

## Observability

No new failure path; no record added.

## Checklist

- [x] Root cause quoted from the failed job log
- [x] Recovery path for the half-published v4.1.6 (republish input)
- [x] Changelog: none (CI-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
