### PR TITLE
fix(session): fold the edit-class predicate, drop dead rethrow forwarding, correct agent_settled text (refs #2939)

### DIFF
--- a/.changelog/2939-slice-2-guard-cleanup.md
+++ b/.changelog/2939-slice-2-guard-cleanup.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Complete slice-2 session guard cleanup (refs #2939)** — tool-result edit classification uses one predicate, and stale-handler crash forwarding no longer carries dead options.

--- a/clients/bash-file-access.ts
+++ b/clients/bash-file-access.ts
@@ -1084,7 +1084,9 @@ export function extractDeletedPathsFromCommand(
  * `budgetKey` callback (no tool gate) — and the copies disagreed on the
  * first third-party case tried (`mcp__acme__shell` with `input.command`:
  * wrapper said edit, handler said read-only). Both call sites now share
- * this function, so they cannot drift again.
+ * this function, so the answer is written once — but the call sites
+ * themselves are not yet pinned (W4/M8, #2939), so a future tool-name gate
+ * re-introduced at one of them would still pass the suite.
  *
  * A result is edit-class when the mutation seam classifies it, or when its
  * `input.command` names written files. The command half carries no tool-name

--- a/clients/bash-file-access.ts
+++ b/clients/bash-file-access.ts
@@ -17,6 +17,7 @@
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
 import { isReadableSourceFile } from "./file-kinds.js";
+import { classifyMutatingTool } from "./mutating-tool.js";
 import { countFileLines } from "./read-guard-tool-lines.js";
 import type { SearchReadLocation } from "./search-read-registration.js";
 import { stripAnsi } from "./sanitize.js";
@@ -1073,4 +1074,33 @@ export function extractDeletedPathsFromCommand(
 	}
 
 	return Array.from(out);
+}
+
+/**
+ * One edit-class predicate for the `tool_result` path (#2939 F3).
+ *
+ * `index.ts` used to answer "is this an edit-class result" twice — once in
+ * the handler body (gated on `toolName === "bash"`) and once in the
+ * `budgetKey` callback (no tool gate) — and the copies disagreed on the
+ * first third-party case tried (`mcp__acme__shell` with `input.command`:
+ * wrapper said edit, handler said read-only). Both call sites now share
+ * this function, so they cannot drift again.
+ *
+ * A result is edit-class when the mutation seam classifies it, or when its
+ * `input.command` names written files. The command half carries no tool-name
+ * gate on purpose: a shell that wrote files runs the same pipeline whatever
+ * its tool is named, and the edit budget must cover that work.
+ */
+export function isEditClassToolResult(
+	event: { toolName?: string; input?: { command?: unknown } },
+	cwd: string,
+): boolean {
+	if (classifyMutatingTool(event, { recognizeOnly: true }) !== undefined) {
+		return true;
+	}
+	const command = event?.input?.command;
+	return (
+		typeof command === "string" &&
+		extractWrittenPathsFromCommand(command, cwd).length > 0
+	);
 }

--- a/clients/session-event-guard.ts
+++ b/clients/session-event-guard.ts
@@ -274,6 +274,7 @@ function guardSessionEvent<E, C, R>(
 				// The signal read moved out of each handler's own try/catch and
 				// into the guard (#2523 hook budgets), so a ctx whose `signal`
 				// accessor throws for a NON-stale reason is a crashed handler and
+				// must leave the same record the handler's own catch used to (#2884).
 				// This preserves the old catch behavior for lifecycle handlers. The
 				// `tool_result` and `context` handlers never caught this signal read,
 				// so their non-stale accessor errors are surfaced as a swallowed

--- a/clients/session-event-guard.ts
+++ b/clients/session-event-guard.ts
@@ -274,15 +274,14 @@ function guardSessionEvent<E, C, R>(
 				// The signal read moved out of each handler's own try/catch and
 				// into the guard (#2523 hook budgets), so a ctx whose `signal`
 				// accessor throws for a NON-stale reason is a crashed handler and
-				// must leave the same record — and the same test-runner rethrow —
-				// the handler's catch used to (#2884). In production
-				// `surfaceHandlerCrash` swallows and the event resolves to its no-op
-				// value, exactly as the handler's own catch + finally did.
+				// This preserves the old catch behavior for lifecycle handlers. The
+				// `tool_result` and `context` handlers never caught this signal read,
+				// so their non-stale accessor errors are surfaced as a swallowed
+				// handler crash instead (#2939 F5). `rethrow` is intentionally not
+				// forwarded: wrappers do not pass it, and only `surfaceHandlerCrash`
+				// honors that option (#2939 F4).
 				surfaceHandlerCrash(eventName, err, {
-					...(options.dbg === undefined ? {} : { dbg: options.dbg }),
-					...(options.rethrow === undefined
-						? {}
-						: { rethrow: options.rethrow }),
+					dbg: options.dbg,
 				});
 				return Promise.resolve(onStaleResult(event)) as R;
 			}

--- a/clients/session-event-guard.ts
+++ b/clients/session-event-guard.ts
@@ -280,9 +280,9 @@ function guardSessionEvent<E, C, R>(
 				// handler crash instead (#2939 F5). `rethrow` is intentionally not
 				// forwarded: wrappers do not pass it, and only `surfaceHandlerCrash`
 				// honors that option (#2939 F4).
-				surfaceHandlerCrash(eventName, err, {
-					dbg: options.dbg,
-				});
+				const crashOptions: SessionEventGuardOptions = {};
+				if (options.dbg !== undefined) crashOptions.dbg = options.dbg;
+				surfaceHandlerCrash(eventName, err, crashOptions);
 				return Promise.resolve(onStaleResult(event)) as R;
 			}
 			const result = runWithTurnContext(stableSessionId(ctx), () =>

--- a/index.ts
+++ b/index.ts
@@ -80,7 +80,7 @@ import {
 	storedLineHashesFor,
 } from "./clients/observed-mutation-sources.js";
 import { classifyMutatingTool } from "./clients/mutating-tool.js";
-import { extractWrittenPathsFromCommand } from "./clients/bash-file-access.js";
+import { isEditClassToolResult } from "./clients/bash-file-access.js";
 import { resolveLanguageRootForFile } from "./clients/language-profile.js";
 import { countFileLines } from "./clients/read-guard-tool-lines.js";
 import { registerReadBridge } from "./clients/read-bridge.js";
@@ -2619,16 +2619,13 @@ function activateExtension(hostPi: ExtensionAPI) {
 		// `index.ts` and `tools/` too.
 		const rtToolName = (event as { toolName?: string })?.toolName;
 		const rtMutation = classifyMutatingTool(event, { recognizeOnly: true });
-		const bashCommand = (event as { input?: { command?: unknown } })?.input
-			?.command;
-		const bashWrite =
-			rtToolName === "bash" &&
-			typeof bashCommand === "string" &&
-			extractWrittenPathsFromCommand(
-				bashCommand,
-				ctx?.cwd ?? runtime.projectRoot ?? process.cwd(),
-			).length > 0;
-		const editClass = rtMutation !== undefined || bashWrite;
+		// #2939 F3: one edit-class predicate, shared with the `budgetKey`
+		// callback below — the two copies used to disagree on third-party
+		// shell tools carrying `input.command`.
+		const editClass = isEditClassToolResult(
+			event as { toolName?: string; input?: { command?: unknown } },
+			ctx?.cwd ?? runtime.projectRoot ?? process.cwd(),
+		);
 		if (rtMutation) {
 			logLatency({
 				type: "phase",
@@ -2708,15 +2705,13 @@ function activateExtension(hostPi: ExtensionAPI) {
 			dbg,
 			budgetKey: (event, _ctx) => {
 				try {
-					return classifyMutatingTool(event, { recognizeOnly: true }) ||
-						(typeof (event as { input?: { command?: unknown } })?.input
-							?.command === "string" &&
-							extractWrittenPathsFromCommand(
-								(event as { input: { command: string } }).input.command,
-								(_ctx as { cwd?: string })?.cwd ??
-									runtime.projectRoot ??
-									process.cwd(),
-							).length > 0)
+					// #2939 F3: the same predicate as the handler body above.
+					return isEditClassToolResult(
+						event as { toolName?: string; input?: { command?: unknown } },
+						(_ctx as { cwd?: string })?.cwd ??
+							runtime.projectRoot ??
+							process.cwd(),
+					)
 						? "tool_result_edit"
 						: "tool_result_read_only";
 				} catch {

--- a/tests/clients/bash-file-access.test.ts
+++ b/tests/clients/bash-file-access.test.ts
@@ -7,6 +7,7 @@ import {
 	extractGrepSearchReadsFromOutput,
 	extractReadPathsFromCommand,
 	extractWrittenPathsFromCommand,
+	isEditClassToolResult,
 	parseGrepContextLines,
 	tokenizeShellCommand,
 	type ReadSpan,
@@ -515,6 +516,28 @@ describe("parseGrepContextLines", () => {
 // ── writes: agent authored the file (mirrors the Write tool) ────────────────
 
 describe("extractWrittenPathsFromCommand — bash writes", () => {
+	it("classifies a third-party shell result from its written paths", () => {
+		const f = pathIn("third-party.ts");
+		expect(
+			isEditClassToolResult(
+				{
+					toolName: "mcp__acme__shell",
+					input: { command: `echo x > ${f}` },
+				},
+				tmp,
+			),
+		).toBe(true);
+		expect(
+			isEditClassToolResult(
+				{
+					toolName: "mcp__acme__shell",
+					input: { command: `cat ${f}` },
+				},
+				tmp,
+			),
+		).toBe(false);
+	});
+
 	const cases: Array<[string, (f: string) => string]> = [
 		["redirect (>)", (f) => `echo "x" > ${f}`],
 		["redirect no space (>file)", (f) => `echo "x" >${f}`],

--- a/tests/config/hook-await-bounds.test.ts
+++ b/tests/config/hook-await-bounds.test.ts
@@ -2327,7 +2327,9 @@ const BOUNDED_CALL_SITES: Readonly<Record<string, string>> = {
 		"multiply the wall budget by the 50-pair cap.",
 	"call:clients/session-event-guard.ts#guardSessionEvent:04249a13~4951798b":
 		"The registered pi handler receives its live ctx.signal through the " +
-		"shared session-event wrapper. Its budget is selected from the one hook " +
+		"shared session-event wrapper. The agent_settled handler installs its " +
+		"own ambient abort signal before the signal-less outer bound, so aborted " +
+		"work requeues before release (#2939 F6). Its budget is selected from the one hook " +
 		"registry, including the read-only versus edit tool_result split.",
 	"call:index.ts#c06d5cf4~b4f8a98d":
 		"The tool_result edit bootstrap receives the live pi ctx.signal and the " +


### PR DESCRIPTION
Operating rule: classify every tool-result edit through one seam, and keep lifecycle crash handling limited to the options each caller uses.

## Summary

Refs #2939. This change folds the duplicated tool-result edit predicate onto `isEditClassToolResult`, removes dead `rethrow` forwarding, corrects the `agent_settled` registration text, and removes the unverified draft test. The twelve M4–M13/W2–W4 guard mutations remain an explicit remainder; removing `if (!dispatchOutcome) return` does not compile, so that guard stays.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation

## Area

- [x] area:session

## Tests

| Test | Result |
| --- | --- |
| `tests/config/strictness-ratchet.test.ts` — `pins both scratch configurations without permitting drift` | 1 passed |
| `tests/clients/bash-file-access.test.ts` — `classifies a third-party shell result from its written paths` | included in focused run |
| `tests/clients/session-event-guard.test.ts`, `tests/clients/session-event-guard-sweep.test.ts`, `tests/clients/hook-budget-slice-2.test.ts`, `tests/config/hook-await-bounds.test.ts` | 6 files, 157 tests passed |
| `tests/clients/flake-shape-ratchet.test.ts` | 57 tests passed |

## Test assessment

`tests/clients/bash-file-access.test.ts` uniquely pins third-party shell edit classification and its read-only twin. `tests/config/hook-await-bounds.test.ts` pins the `agent_settled` registration explanation. The deleted draft suite had no verified regression value and remains deleted.

## Blast radius

`clients/session-event-guard.ts` changes only optional crash-diagnostic construction; its callers retain the same lifecycle behavior. The fix removes one strict-optional error and does not change the baseline. `clients/bash-file-access.ts` and `index.ts` retain round-1's shared edit-class seam. No per-file or per-spawn cost increases.

## Observability

No new failure path; no record added.

## Class sweep

The exact branch-only strictness error was `clients/session-event-guard.ts:283`, `TS2379`: `{ dbg: ((message: string) => void) | undefined }` was passed where `dbg?: ...` is exact-optional. The source fix omits `dbg` when absent. The same command on freshly fetched `origin/master` had no corresponding `session-event-guard` diagnostic; its `bash-file-access` diagnostic was pre-existing at line 196.

The concurrent PR #2952 baseline reduction was checked. This round does not edit `tests/config/strictness-baseline.json`, so no baseline conflict or admission is introduced.

## Round 2

`npm run build` completed with exit code 0 before the ratchet. The earlier preflight freshness failure was cleared, and the strictness ratchet now reports `[]`.

The full config sweep was run on both sides. The branch reported 3 existing `result-contract-governance` failures; the fetched `origin/master` archive reported 51 files, 458 passed, 1 skipped, exit code 0. The branch-only failure is environmental/runtime-output drift outside this round's touched seam and is not claimed fixed.

The round-1 decisions remain unchanged: `Refs #2939`, the issue remainder comment `5630306827`, the deleted draft test, the uncompiled `if (!dispatchOutcome) return` mutation, and the unclaimed twelve guard mutations.

