### PR TITLE
fix(sampler): bound spawn usage sampling concurrency, rate and lifetime (refs #2968)

### DIFF
--- a/.changelog/fix-2968-spawn-usage-sampler-backpressure.md
+++ b/.changelog/fix-2968-spawn-usage-sampler-backpressure.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Bound the spawn usage sampler's concurrency, rate and lifetime (refs #2968)** — a poll tick no longer starts while the previous one is still querying the process table, the interval backs off once a child outlives the short-lived window, and polling stops at a cap derived from the spawn's own deadline; on Windows this ends the `powershell.exe`/`taskkill.exe` pile-up behind a child that never exits, and skipped ticks and capped samplers are counted on the degradation ledger.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4319,6 +4319,24 @@ those failures, so consumers leave usage unknown rather than fabricating zero
 samples, and records one bounded `resource-sampler-query-failed` degradation
 per query subject. (#1863)
 
+The spawn sampler is bounded on all three axes, and a new poller owes the same
+three. `startSpawnUsageSampler` polls a child through the process-table seam,
+and ONE Windows tick is two `powershell.exe` CIM queries plus a `taskkill.exe`
+whenever a query blows `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS` — so an unguarded
+interval is a process multiplier, not a timer. #2968 (external report) measured
+234 live `powershell.exe`/`taskkill.exe` (~10GB) behind four children that hung
+for 5-6h. The bounds: no tick starts while the previous one is in flight
+(CONCURRENCY); past `SPAWN_SAMPLE_FULL_RATE_TICKS` the delay doubles to
+`SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER` x the base (RATE — the 750ms interval
+exists to catch SHORT-LIVED children); polling ends at a hard cap that
+`safe-spawn.ts` derives from this spawn's own deadline plus its teardown grace
+(LIFETIME), because every stop path a spawn has — `exit`, `close`, `error` —
+requires the child to settle, and a hung child settles nothing. A capped
+sampler still returns what it gathered. Skipped ticks and the cap are counted
+on the ledger (`resource-sampler-tick-overlapped`,
+`resource-sampler-lifetime-capped`): a sampler that has silently stopped
+sampling is #1863's shape one level up. (#2968)
+
 File-operation rename filters match only the decoded URI path, never a basename
 fallback. Unsupported wire URI schemes fail closed; entity-kind probes are
 conditional on a filter declaring `matches` and use `lstat` so symlinks are

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -590,6 +590,17 @@ export type DegradationKind =
 	 * pi's `agent_settled` window and dogfood logs show gaps up to 52 minutes;
 	 * this kind means a session out-touched that cadence.
 	 */
+	/**
+	 * #2968: a `startSpawnUsageSampler` poll stopped at its LIFETIME cap
+	 * (`SPAWN_SAMPLE_LIFETIME_CAP_MS`, or the spawn's own deadline plus
+	 * teardown grace) while the child it brackets was still running — the
+	 * child outlived every teardown `safeSpawnAsync` owns. The summary
+	 * gathered before the cap is still returned; this is the row that says the
+	 * reading is truncated, and that something spawned is not dying. One
+	 * subject for all samplers, counted, so a session that hangs four children
+	 * for six hours writes a tally rather than a row per spawn.
+	 */
+	| "resource-sampler-lifetime-capped"
 	| "resource-sampler-query-failed"
 	/**
 	 * `read-guard.ts`'s per-file record cap (`READ_GUARD_MAX_RECORDS_PER_FILE`)
@@ -600,6 +611,18 @@ export type DegradationKind =
 	 * hand-rolled per-file Set (#1913 review F1).
 	 */
 	| "resource-sampler-scanner-escalated"
+	/**
+	 * #2968: a `startSpawnUsageSampler` poll tick was SKIPPED because the
+	 * previous tick's process-table queries had not settled yet. Before the
+	 * in-flight guard the tick fired anyway, so on Windows — where one tick is
+	 * two `powershell.exe` CIM queries plus, past the query timeout, a
+	 * `taskkill.exe` — every slow query stacked another set of children on the
+	 * host (the external report measured 234 of them). A skip means sampling
+	 * resolution was lost, which #1863's "a failed query must not read as an
+	 * empty table" rule says has to be visible; it is counted, not once-only,
+	 * because the count is the backpressure signal.
+	 */
+	| "resource-sampler-tick-overlapped"
 	/**
 	 * `read-guard.ts`'s whole-file evictor (`evictFile`) dropped a file's
 	 * tracked read/edit state (#1918, the #1913 class sibling). Fires from

--- a/clients/degradation-ledger.ts
+++ b/clients/degradation-ledger.ts
@@ -591,9 +591,10 @@ export type DegradationKind =
 	 * this kind means a session out-touched that cadence.
 	 */
 	/**
-	 * #2968: a `startSpawnUsageSampler` poll stopped at its LIFETIME cap
-	 * (`SPAWN_SAMPLE_LIFETIME_CAP_MS`, or the spawn's own deadline plus
-	 * teardown grace) while the child it brackets was still running — the
+	 * #2968: a `startSpawnUsageSampler` poll stopped at its LIFETIME cap — the
+	 * caller-supplied bound, which `safeSpawnAsync` derives as the spawn's
+	 * effective timeout plus `SPAWN_SAMPLER_TEARDOWN_GRACE_MS` — while the
+	 * child it brackets was still running; the
 	 * child outlived every teardown `safeSpawnAsync` owns. The summary
 	 * gathered before the cap is still returned; this is the row that says the
 	 * reading is truncated, and that something spawned is not dying. One

--- a/clients/resource-sampler.ts
+++ b/clients/resource-sampler.ts
@@ -45,11 +45,25 @@
  */
 
 import pidusage from "pidusage";
-import { recordDegradationOnce } from "./degradation-ledger.js";
+import {
+	incrementDegradationCount,
+	recordDegradationOnce,
+} from "./degradation-ledger.js";
 import { terminateScannerChild } from "./instance-reaper.js";
 import { queryProcessTable } from "./process-snapshot.js";
 
 export const RESOURCE_SAMPLE_QUERY_TIMEOUT_MS = 2_000;
+
+/**
+ * ONE ledger subject for every spawn sampler in the session (#2968). The
+ * per-spawn identity (pid, command) is NOT the subject: a subject is a
+ * `tallies` key, and one key per spawn would make the ledger grow with the
+ * session's spawn count — catalog shape 9, the same leak this fix exists to
+ * close. The command that was sampled is already on the `spawn_resource_usage`
+ * latency row; what the ledger answers is "did sampling hit its bounds, and
+ * how often", which is a per-session tally.
+ */
+const SPAWN_SAMPLER_LEDGER_SUBJECT = "spawn-usage-sampler";
 
 function recordQueryFailure(
 	subject: string,
@@ -432,29 +446,6 @@ export interface SpawnUsageSummary {
 	peakRssBytes: number;
 }
 
-/**
- * Brackets one transient spawn with a short-interval poll. Usage:
- *
- *   const sampler = startSpawnUsageSampler(child.pid);
- *   child.on("close", () => {
- *     const usage = sampler.stop(); // null if never got a single sample
- *   });
- *
- * `intervalMs` defaults to 750ms — inside the issue's suggested 500ms-1s
- * band, cheap enough not to become a new source of measurable overhead for
- * the (usually sub-few-second) analyzer children this brackets. Best-effort:
- * a poll tick that throws (pid already gone, sampling error) is silently
- * skipped — it never stops the timer or the spawn early, and `stop()` is
- * always safe to call even if zero samples ever landed.
- *
- * Windows note: `clients/safe-spawn.ts` spawns with `shell: true` on Windows,
- * so `pid` here is `cmd.exe`'s pid, not the real tool's — sampling it alone
- * would report near-zero usage for the whole invocation. Each Windows tick
- * resolves `pid`'s live descendant tree (`findDescendantPidsWindows`) and
- * sums usage across `pid` + every descendant, so a `node`/`npx`-wrapped tool
- * (or one that re-execs itself) is actually captured. POSIX spawns are
- * unwrapped (`shell: false`), so `pid` there is already the real tool.
- */
 export interface ProcessTreeCpuSample {
 	/** True when the process tree burned CPU above the liveness floor. */
 	busy: boolean;
@@ -555,16 +546,97 @@ export async function sampleProcessTreeCpuPercent(
 	};
 }
 
+/**
+ * Base poll cadence — inside #620's suggested 500ms-1s band, cheap enough not
+ * to become measurable overhead for the (usually sub-few-second) analyzer
+ * children this brackets.
+ */
+export const SPAWN_SAMPLE_INTERVAL_MS = 750;
+
+/**
+ * #2968: how many ticks keep the full `intervalMs` cadence before the backoff
+ * starts. 8 × 750ms = the first 6 seconds, which covers the short-lived
+ * analyzer children the short interval exists for; a child still running past
+ * that is not short-lived and does not need sub-second resolution.
+ */
+export const SPAWN_SAMPLE_FULL_RATE_TICKS = 8;
+
+/**
+ * #2968: backoff ceiling, as a multiple of `intervalMs` (16 × 750ms = 12s).
+ * Past the full-rate window the delay doubles each tick up to this, so a
+ * long-lived child costs a bounded ~5 polls/minute instead of 80.
+ */
+export const SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER = 16;
+
+/**
+ * #2968: default hard bound on a sampler's polling lifetime — safe-spawn's own
+ * default 30s spawn timeout plus its teardown grace. The one production caller
+ * (`clients/safe-spawn.ts`) passes the deadline it actually computed; this
+ * default only ever applies to a caller that forgot, and it is deliberately
+ * the SAFE direction (bounded) rather than "poll forever".
+ */
+export const SPAWN_SAMPLE_LIFETIME_CAP_MS = 35_000;
+
+/**
+ * Brackets one transient spawn with a short-interval poll. Usage:
+ *
+ *   const sampler = startSpawnUsageSampler(child.pid, interval, capMs);
+ *   child.on("close", () => {
+ *     const usage = sampler.stop(); // null if never got a single sample
+ *   });
+ *
+ * Best-effort: a poll tick that throws (pid already gone, sampling error) is
+ * silently skipped — it never stops the polling or the spawn early, and
+ * `stop()` is always safe to call even if zero samples ever landed.
+ *
+ * Windows note: `clients/safe-spawn.ts` spawns with `shell: true` on Windows,
+ * so `pid` here is `cmd.exe`'s pid, not the real tool's — sampling it alone
+ * would report near-zero usage for the whole invocation. Each Windows tick
+ * resolves `pid`'s live descendant tree (`findDescendantPidsWindows`) and
+ * sums usage across `pid` + every descendant, so a `node`/`npx`-wrapped tool
+ * (or one that re-execs itself) is actually captured. POSIX spawns are
+ * unwrapped (`shell: false`), so `pid` there is already the real tool.
+ *
+ * ## Backpressure: three bounds, three axes (#2968, external report)
+ *
+ * A Windows tick is not free — it is TWO `powershell.exe` CIM queries (the
+ * descendant walk plus the usage read), and a query that blows
+ * `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS` adds a `taskkill.exe`. With a `setInterval`
+ * that neither waited for its own tick nor ever expired, four children that
+ * hung for 5-6 hours left 234 live `powershell.exe`/`taskkill.exe` processes
+ * (~10GB) parented by the host. Each bound below closes one axis; catalog
+ * shape 9 is exactly the shape where closing only one of them is not a fix:
+ *
+ * 1. CONCURRENCY — a tick never starts while the previous one is unsettled
+ *    (`inFlight`). The old `setInterval` fired regardless, so a query slower
+ *    than the interval stacked one more pair of children every tick.
+ * 2. RATE — past `SPAWN_SAMPLE_FULL_RATE_TICKS` the delay doubles per tick up
+ *    to `SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER × intervalMs`. The short
+ *    interval exists to catch short-lived children; a 180s runner (the
+ *    longest spawn timeout in the tree) costs ~26 polls instead of 240.
+ * 3. LIFETIME — polling stops for good at `lifetimeCapMs`, measured from
+ *    start. `stop()` still returns everything gathered up to that point; a
+ *    capped sampler loses resolution, never the reading it already had.
+ *
+ * Ticks skipped for (1) and the cap in (3) are both recorded, bounded, on the
+ * degradation ledger — a sampler that quietly stops sampling is the #1863 /
+ * #2132 shape one level up.
+ */
 export function startSpawnUsageSampler(
 	pid: number | undefined,
-	intervalMs = 750,
+	intervalMs = SPAWN_SAMPLE_INTERVAL_MS,
+	lifetimeCapMs = SPAWN_SAMPLE_LIFETIME_CAP_MS,
 ): { stop: () => SpawnUsageSummary | null } {
 	if (!Number.isFinite(pid) || (pid as number) <= 0) {
 		return { stop: () => null };
 	}
 	const targetPid = pid as number;
 	const accumulator = new UsageAccumulator();
+	const startedAt = Date.now();
 	let stopped = false;
+	let inFlight = false;
+	let tickCount = 0;
+	let timer: ReturnType<typeof setTimeout> | undefined;
 
 	const tick = async () => {
 		if (stopped) return;
@@ -591,20 +663,72 @@ export function startSpawnUsageSampler(
 		}
 	};
 
+	const releaseInFlight = (): void => {
+		inFlight = false;
+	};
+
+	/**
+	 * Delay before the NEXT tick, given how many have already run. Full rate
+	 * through the short-lived window, then doubling to the ceiling (#2968).
+	 */
+	const nextDelayMs = (): number => {
+		if (tickCount <= SPAWN_SAMPLE_FULL_RATE_TICKS) return intervalMs;
+		const grown = intervalMs * 2 ** (tickCount - SPAWN_SAMPLE_FULL_RATE_TICKS);
+		return Math.min(grown, intervalMs * SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER);
+	};
+
+	const arm = (delayMs: number): void => {
+		timer = setTimeout(runTick, delayMs);
+		// Never let this timer keep the process alive on its own.
+		timer.unref?.();
+	};
+
+	function runTick(): void {
+		timer = undefined;
+		if (stopped) return;
+		if (Date.now() - startedAt >= lifetimeCapMs) {
+			// LIFETIME bound: deliberately NOT re-armed. The accumulator is kept,
+			// so `stop()` still answers with everything gathered before the cap.
+			incrementDegradationCount({
+				kind: "resource-sampler-lifetime-capped",
+				subject: SPAWN_SAMPLER_LEDGER_SUBJECT,
+				reason: `spawn sampler stopped polling at its ${lifetimeCapMs}ms lifetime cap; the child was still running`,
+			});
+			return;
+		}
+		tickCount++;
+		if (inFlight) {
+			// CONCURRENCY bound: the previous tick's process-table queries have
+			// not settled, so starting another would stack a second set of
+			// children on top of them (#2968's Windows pile-up).
+			incrementDegradationCount({
+				kind: "resource-sampler-tick-overlapped",
+				subject: SPAWN_SAMPLER_LEDGER_SUBJECT,
+				reason: `spawn sampler skipped a poll tick: the previous sample was still in flight after ${intervalMs}ms`,
+			});
+		} else {
+			inFlight = true;
+			// `tick` never rejects (it is fully guarded), but settle BOTH ways
+			// anyway: a rejection that escaped would otherwise latch `inFlight`
+			// true and silently end all sampling.
+			void tick().then(releaseInFlight, releaseInFlight);
+		}
+		arm(nextDelayMs());
+	}
+
 	// Fire one tick immediately (short-lived children can exit before the
 	// first interval elapses) plus a recurring poll.
-	void tick();
-	const timer = setInterval(() => {
-		void tick();
-	}, intervalMs);
-	// Never let this timer keep the process alive on its own.
-	timer.unref?.();
+	tickCount = 1;
+	inFlight = true;
+	void tick().then(releaseInFlight, releaseInFlight);
+	arm(nextDelayMs());
 
 	return {
 		stop(): SpawnUsageSummary | null {
 			if (stopped) return accumulator.summarize();
 			stopped = true;
-			clearInterval(timer);
+			if (timer !== undefined) clearTimeout(timer);
+			timer = undefined;
 			return accumulator.summarize();
 		},
 	};

--- a/clients/resource-sampler.ts
+++ b/clients/resource-sampler.ts
@@ -551,7 +551,7 @@ export async function sampleProcessTreeCpuPercent(
  * to become measurable overhead for the (usually sub-few-second) analyzer
  * children this brackets.
  */
-export const SPAWN_SAMPLE_INTERVAL_MS = 750;
+const SPAWN_SAMPLE_INTERVAL_MS = 750;
 
 /**
  * #2968: how many ticks keep the full `intervalMs` cadence before the backoff
@@ -559,23 +559,14 @@ export const SPAWN_SAMPLE_INTERVAL_MS = 750;
  * analyzer children the short interval exists for; a child still running past
  * that is not short-lived and does not need sub-second resolution.
  */
-export const SPAWN_SAMPLE_FULL_RATE_TICKS = 8;
+const SPAWN_SAMPLE_FULL_RATE_TICKS = 8;
 
 /**
  * #2968: backoff ceiling, as a multiple of `intervalMs` (16 × 750ms = 12s).
  * Past the full-rate window the delay doubles each tick up to this, so a
  * long-lived child costs a bounded ~5 polls/minute instead of 80.
  */
-export const SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER = 16;
-
-/**
- * #2968: default hard bound on a sampler's polling lifetime — safe-spawn's own
- * default 30s spawn timeout plus its teardown grace. The one production caller
- * (`clients/safe-spawn.ts`) passes the deadline it actually computed; this
- * default only ever applies to a caller that forgot, and it is deliberately
- * the SAFE direction (bounded) rather than "poll forever".
- */
-export const SPAWN_SAMPLE_LIFETIME_CAP_MS = 35_000;
+const SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER = 16;
 
 /**
  * Brackets one transient spawn with a short-interval poll. Usage:
@@ -624,11 +615,16 @@ export const SPAWN_SAMPLE_LIFETIME_CAP_MS = 35_000;
  * Ticks skipped for (1) and the cap in (3) are both recorded, bounded, on the
  * degradation ledger — a sampler that quietly stops sampling is the #1863 /
  * #2132 shape one level up.
+ *
+ * `lifetimeCapMs` has no default ON PURPOSE: an unbounded sampler is the whole
+ * defect, so the bound is the caller's to state rather than something a future
+ * call site can forget. The cadence keeps its default, which is policy this
+ * module owns.
  */
 export function startSpawnUsageSampler(
 	pid: number | undefined,
 	intervalMs = SPAWN_SAMPLE_INTERVAL_MS,
-	lifetimeCapMs = SPAWN_SAMPLE_LIFETIME_CAP_MS,
+	lifetimeCapMs: number,
 ): { stop: () => SpawnUsageSummary | null } {
 	if (!Number.isFinite(pid) || (pid as number) <= 0) {
 		return { stop: () => null };

--- a/clients/resource-sampler.ts
+++ b/clients/resource-sampler.ts
@@ -616,7 +616,10 @@ export const SPAWN_SAMPLE_LIFETIME_CAP_MS = 35_000;
  *    longest spawn timeout in the tree) costs ~26 polls instead of 240.
  * 3. LIFETIME — polling stops for good at `lifetimeCapMs`, measured from
  *    start. `stop()` still returns everything gathered up to that point; a
- *    capped sampler loses resolution, never the reading it already had.
+ *    capped sampler loses resolution, never the reading it already had. The
+ *    cap is read at TICK granularity, so the last poll can land up to one
+ *    backed-off interval (≤ 12s by default) before polling ends — the tick
+ *    that discovers the cap does no sampling and arms nothing.
  *
  * Ticks skipped for (1) and the cap in (3) are both recorded, bounded, on the
  * degradation ledger — a sampler that quietly stops sampling is the #1863 /

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -27,10 +27,7 @@ import { logLatency } from "./latency-logger.js";
 import { recordDegradation } from "./degradation-ledger.js";
 import { logExtension } from "./extension-log.js";
 import { isFullyQualifiedWin32 } from "./path-utils.js";
-import {
-	SPAWN_SAMPLE_INTERVAL_MS,
-	startSpawnUsageSampler,
-} from "./resource-sampler.js";
+import { startSpawnUsageSampler } from "./resource-sampler.js";
 import { compareOrdinal } from "./string-utils.js";
 
 export interface SpawnResourceUsage {
@@ -1569,8 +1566,13 @@ export async function safeSpawnAsync(
 		let usageSampler: { stop: () => SpawnResourceUsage | null };
 		try {
 			usageSampler = startSpawnUsageSampler(
+				// The poll CADENCE is the sampler's own policy (it owns the backoff
+				// too); the DEADLINE is this function's. Passing `undefined` rather
+				// than importing the cadence constant keeps this module's view of
+				// the sampler at one export, which is also what every existing
+				// `vi.mock` of it provides.
 				child.pid,
-				SPAWN_SAMPLE_INTERVAL_MS,
+				undefined,
 				timeout + SPAWN_SAMPLER_TEARDOWN_GRACE_MS,
 			);
 		} catch {

--- a/clients/safe-spawn.ts
+++ b/clients/safe-spawn.ts
@@ -27,7 +27,10 @@ import { logLatency } from "./latency-logger.js";
 import { recordDegradation } from "./degradation-ledger.js";
 import { logExtension } from "./extension-log.js";
 import { isFullyQualifiedWin32 } from "./path-utils.js";
-import { startSpawnUsageSampler } from "./resource-sampler.js";
+import {
+	SPAWN_SAMPLE_INTERVAL_MS,
+	startSpawnUsageSampler,
+} from "./resource-sampler.js";
 import { compareOrdinal } from "./string-utils.js";
 
 export interface SpawnResourceUsage {
@@ -1111,6 +1114,18 @@ export function resetUtf8ConsoleCodePageStateForTests(): void {
 const EXIT_PIPE_IDLE_GRACE_MS = 100;
 const EXIT_PIPE_IDLE_MAX_WAIT_MS = 2000;
 
+/**
+ * #2968: how long past its own deadline this spawn's CPU/RSS sampler may keep
+ * polling. Everything this function does to end a child after the deadline
+ * fits inside it: `killTree`'s SIGTERM plus its 1000ms SIGKILL escalation (or
+ * Windows' `taskkill /F /T`), then at most EXIT_PIPE_IDLE_MAX_WAIT_MS of
+ * pipe-idle wait. A child still alive past deadline + this grace has outlived
+ * every teardown available here, so polling it further only buys the Windows
+ * process pile-up the report measured — and `stop()` still returns whatever
+ * the sampler gathered before the cap.
+ */
+const SPAWN_SAMPLER_TEARDOWN_GRACE_MS = 5_000;
+
 // ============================================================================
 // ASYNC VERSION (Recommended - Non-blocking)
 // ============================================================================
@@ -1544,9 +1559,20 @@ export async function safeSpawnAsync(
 		// best-effort/never-throws by design, but this call site wraps it anyway
 		// (belt and suspenders: the sampling seam must never be the reason a real
 		// spawn fails) with a no-op fallback sampler.
+		//
+		// #2968: the sampler's polling lifetime is bounded by THIS spawn's own
+		// deadline plus the teardown grace, not by the child's willingness to
+		// exit. `finalize`/the `error` handler still stop it on every settle
+		// path, but none of those paths exist for a child that never settles —
+		// a hung `.cmd` shim whose tree survives `taskkill /F /T` kept polling
+		// for 5-6 hours in the report.
 		let usageSampler: { stop: () => SpawnResourceUsage | null };
 		try {
-			usageSampler = startSpawnUsageSampler(child.pid);
+			usageSampler = startSpawnUsageSampler(
+				child.pid,
+				SPAWN_SAMPLE_INTERVAL_MS,
+				timeout + SPAWN_SAMPLER_TEARDOWN_GRACE_MS,
+			);
 		} catch {
 			usageSampler = { stop: () => null };
 		}

--- a/tests/clients/resource-sampler.test.ts
+++ b/tests/clients/resource-sampler.test.ts
@@ -64,8 +64,6 @@ vi.mock("../../clients/instance-reaper.js", async (importOriginal) => {
 
 const {
 	sampleProcesses,
-	SPAWN_SAMPLE_FULL_RATE_TICKS,
-	SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER,
 	UsageAccumulator,
 	walkDescendantPids,
 	startSpawnUsageSampler,
@@ -873,11 +871,12 @@ describe("#2968 startSpawnUsageSampler backpressure", () => {
 		await vi.advanceTimersByTimeAsync(10_000);
 		sampler.stop();
 
+		// Literal expectations, not the module's own constants: a test that
+		// recomputes the interval from the values it is pinning would follow any
+		// edit to them instead of catching it.
 		const gaps = sampledAt.slice(1).map((at, i) => at - sampledAt[i]);
-		expect(gaps.slice(0, SPAWN_SAMPLE_FULL_RATE_TICKS - 1)).toEqual(
-			Array(SPAWN_SAMPLE_FULL_RATE_TICKS - 1).fill(100),
-		);
-		expect(Math.max(...gaps)).toBe(100 * SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER);
+		expect(gaps.slice(0, 7)).toEqual([100, 100, 100, 100, 100, 100, 100]);
+		expect(Math.max(...gaps)).toBe(1_600); // 16 x the 100ms base interval
 		// 10s at a flat 100ms interval is 101 ticks; the backoff makes it ~14.
 		expect(sampledAt.length).toBeLessThan(20);
 	});

--- a/tests/clients/resource-sampler.test.ts
+++ b/tests/clients/resource-sampler.test.ts
@@ -522,7 +522,7 @@ describe("sampleProcesses (Windows / guarded CIM path)", () => {
 		fakeSpawn = () => makeFakeChild({ emitError: true });
 		vi.useFakeTimers();
 		try {
-			const sampler = startSpawnUsageSampler(999, 100);
+			const sampler = startSpawnUsageSampler(999, 100, 60_000);
 			await vi.advanceTimersByTimeAsync(0);
 			expect(sampler.stop()).toBeNull();
 			expect(
@@ -692,7 +692,7 @@ describe("resource-sampler: fire-and-forget CIM spawns are unref'd (#1155)", () 
 			return child;
 		};
 
-		const sampler = startSpawnUsageSampler(999, 100);
+		const sampler = startSpawnUsageSampler(999, 100, 60_000);
 		await vi.advanceTimersByTimeAsync(0); // flush the immediate tick
 		sampler.stop();
 
@@ -719,15 +719,15 @@ describe("startSpawnUsageSampler", () => {
 	});
 
 	it("returns a no-op sampler (stop() => null) for an undefined/invalid pid", () => {
-		expect(startSpawnUsageSampler(undefined).stop()).toBeNull();
-		expect(startSpawnUsageSampler(0).stop()).toBeNull();
-		expect(startSpawnUsageSampler(-5).stop()).toBeNull();
+		expect(startSpawnUsageSampler(undefined, 100, 60_000).stop()).toBeNull();
+		expect(startSpawnUsageSampler(0, 100, 60_000).stop()).toBeNull();
+		expect(startSpawnUsageSampler(-5, 100, 60_000).stop()).toBeNull();
 	});
 
 	it("samples immediately on start and again on each poll tick, aggregating into a summary", async () => {
 		pidusageMock.mockResolvedValue({ "555": { cpu: 10, memory: 1000 } });
 
-		const sampler = startSpawnUsageSampler(555, 100);
+		const sampler = startSpawnUsageSampler(555, 100, 60_000);
 		await vi.advanceTimersByTimeAsync(0); // flush the immediate tick
 		await vi.advanceTimersByTimeAsync(250); // ~2-3 more ticks at 100ms
 
@@ -740,14 +740,14 @@ describe("startSpawnUsageSampler", () => {
 
 	it("stop() before any tick lands returns null (never a fabricated zero reading)", () => {
 		pidusageMock.mockImplementation(() => new Promise(() => {})); // never resolves
-		const sampler = startSpawnUsageSampler(555, 100);
+		const sampler = startSpawnUsageSampler(555, 100, 60_000);
 		expect(sampler.stop()).toBeNull();
 	});
 
 	it("a poll tick that rejects is silently skipped, not fatal to the sampler", async () => {
 		pidusageMock.mockRejectedValue(new Error("pid gone"));
 
-		const sampler = startSpawnUsageSampler(555, 100);
+		const sampler = startSpawnUsageSampler(555, 100, 60_000);
 		await vi.advanceTimersByTimeAsync(0);
 		await vi.advanceTimersByTimeAsync(300);
 
@@ -756,7 +756,7 @@ describe("startSpawnUsageSampler", () => {
 
 	it("stop() is idempotent — calling it twice returns the same summary and doesn't throw", async () => {
 		pidusageMock.mockResolvedValue({ "555": { cpu: 5, memory: 500 } });
-		const sampler = startSpawnUsageSampler(555, 100);
+		const sampler = startSpawnUsageSampler(555, 100, 60_000);
 		await vi.advanceTimersByTimeAsync(0);
 
 		const first = sampler.stop();

--- a/tests/clients/resource-sampler.test.ts
+++ b/tests/clients/resource-sampler.test.ts
@@ -64,6 +64,8 @@ vi.mock("../../clients/instance-reaper.js", async (importOriginal) => {
 
 const {
 	sampleProcesses,
+	SPAWN_SAMPLE_FULL_RATE_TICKS,
+	SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER,
 	UsageAccumulator,
 	walkDescendantPids,
 	startSpawnUsageSampler,
@@ -762,5 +764,121 @@ describe("startSpawnUsageSampler", () => {
 		const first = sampler.stop();
 		const second = sampler.stop();
 		expect(second).toEqual(first);
+	});
+});
+
+/**
+ * #2968 (external report, Windows 11 24H2): the sampler had no backpressure of
+ * any kind. `setInterval(() => void tick(), 750)` started a tick whether or not
+ * the previous one had settled, and nothing ever expired the timer — only the
+ * bracketed child's own settle (`exit`/`close`/`error` in safe-spawn) stopped
+ * it. Three `opengrep.exe` and one `typos-lsp.exe` that hung for 5-6.4 hours
+ * therefore kept polling, and because ONE Windows tick is two `powershell.exe`
+ * CIM queries (descendant walk + usage read) plus a `taskkill.exe` whenever a
+ * query blows `RESOURCE_SAMPLE_QUERY_TIMEOUT_MS`, the host ended up parenting
+ * 234 live processes (~10GB). The reporter's own rate check: one child, 3.3s,
+ * powershell/taskkill 1 -> 13 unpatched, 1 -> 1 with the sampler short-circuited.
+ *
+ * Each test below pins one of the three bounds. They run on the POSIX
+ * (`pidusage`) path except where the assertion is about the spawned query
+ * children, which only exist on the Windows path; the bounds themselves live
+ * in platform-independent code, so a Linux CI lane genuinely exercises them.
+ */
+describe("#2968 startSpawnUsageSampler backpressure", () => {
+	beforeEach(() => {
+		pidusageMock.mockReset();
+		setPlatform("linux");
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("skips a poll tick while the previous one is still in flight", async () => {
+		// Recurrence: a tick that starts while the previous one is still querying
+		// the process table stacks a second set of children on the first — the
+		// concurrency axis of #2968's pile-up.
+		pidusageMock.mockImplementation(() => new Promise(() => {})); // never settles
+		const sampler = startSpawnUsageSampler(555, 100, 60_000);
+
+		await vi.advanceTimersByTimeAsync(0); // the immediate tick
+		await vi.advanceTimersByTimeAsync(5_000);
+
+		expect(pidusageMock).toHaveBeenCalledTimes(1);
+		expect(
+			getDegradationSummary().find(
+				(group) => group.kind === "resource-sampler-tick-overlapped",
+			)?.count,
+		).toBeGreaterThanOrEqual(5);
+		expect(sampler.stop()).toBeNull();
+	});
+
+	it("starts no second process-table query while the first is unsettled (Windows path)", async () => {
+		// Recurrence: the same guard counted where the report counted it — in
+		// spawned children. Every unguarded tick was one more `powershell.exe`
+		// (two, once the first query returns) against a box already too slow to
+		// answer the previous one.
+		setPlatform("win32");
+		const spawned: ReturnType<typeof makeFakeChild>[] = [];
+		fakeSpawn = () => {
+			const child = makeFakeChild({ holdOpen: true }); // query never answers
+			spawned.push(child);
+			return child;
+		};
+		const sampler = startSpawnUsageSampler(999, 100, 60_000);
+
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(1_500); // 15 unguarded ticks' worth
+
+		expect(spawned.length).toBe(1);
+		sampler.stop();
+	});
+
+	it("stops polling at its lifetime cap and still returns what it gathered", async () => {
+		// Recurrence: the lifetime axis. The sampler's only stop was the child's
+		// own settle, so a child that never exits polled forever (5-6.4 hours in
+		// the report). Capping must not silently drop the reading already taken.
+		pidusageMock.mockResolvedValue({ "555": { cpu: 4, memory: 2048 } });
+		const sampler = startSpawnUsageSampler(555, 100, 1_000);
+
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(1_000);
+		const callsAtCap = pidusageMock.mock.calls.length;
+		await vi.advanceTimersByTimeAsync(60_000); // a minute past the cap
+
+		expect(pidusageMock.mock.calls.length).toBe(callsAtCap);
+		expect(
+			getDegradationSummary().find(
+				(group) => group.kind === "resource-sampler-lifetime-capped",
+			)?.count,
+		).toBe(1);
+		const summary = sampler.stop();
+		expect(summary?.sampleCount).toBe(callsAtCap);
+		expect(summary?.peakRssBytes).toBe(2048);
+	});
+
+	it("backs the interval off to the ceiling once the child outlives the short-lived window", async () => {
+		// Recurrence: the rate axis. The 750ms interval exists to catch
+		// short-lived children (the module's own comment says so); a child still
+		// running minutes later was paying the same two queries every 750ms.
+		const sampledAt: number[] = [];
+		pidusageMock.mockImplementation(async () => {
+			sampledAt.push(Date.now());
+			return { "555": { cpu: 1, memory: 10 } };
+		});
+		const sampler = startSpawnUsageSampler(555, 100, 60_000);
+
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(10_000);
+		sampler.stop();
+
+		const gaps = sampledAt.slice(1).map((at, i) => at - sampledAt[i]);
+		expect(gaps.slice(0, SPAWN_SAMPLE_FULL_RATE_TICKS - 1)).toEqual(
+			Array(SPAWN_SAMPLE_FULL_RATE_TICKS - 1).fill(100),
+		);
+		expect(Math.max(...gaps)).toBe(100 * SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER);
+		// 10s at a flat 100ms interval is 101 ticks; the backoff makes it ~14.
+		expect(sampledAt.length).toBeLessThan(20);
 	});
 });

--- a/tests/clients/safe-spawn-resource-usage.test.ts
+++ b/tests/clients/safe-spawn-resource-usage.test.ts
@@ -18,25 +18,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const stopMock = vi.fn();
 const startSpawnUsageSamplerMock = vi.fn(
-	(_pid: number | undefined, _intervalMs?: number, _lifetimeCapMs?: number) => ({
+	(
+		_pid: number | undefined,
+		_intervalMs?: number,
+		_lifetimeCapMs?: number,
+	) => ({
 		stop: stopMock,
 	}),
 );
-// Spread the real module so its constants (SPAWN_SAMPLE_INTERVAL_MS, which
-// safe-spawn passes through) stay real and a future export addition passes
-// through instead of arriving undefined.
-vi.mock("../../clients/resource-sampler.js", async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import("../../clients/resource-sampler.js")>();
-	return {
-		...actual,
-		startSpawnUsageSampler: (
-			pid: number | undefined,
-			intervalMs?: number,
-			lifetimeCapMs?: number,
-		) => startSpawnUsageSamplerMock(pid, intervalMs, lifetimeCapMs),
-	};
-});
+vi.mock("../../clients/resource-sampler.js", () => ({
+	startSpawnUsageSampler: (
+		pid: number | undefined,
+		intervalMs?: number,
+		lifetimeCapMs?: number,
+	) => startSpawnUsageSamplerMock(pid, intervalMs, lifetimeCapMs),
+}));
 
 const logLatencyMock = vi.fn();
 vi.mock("../../clients/latency-logger.js", () => ({
@@ -59,31 +55,32 @@ describe("safeSpawnAsync resource-usage bracketing (#620)", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("starts the sampler right after spawn, with the child's pid", async () => {
+	it("starts the sampler right after spawn, with the child's pid and a cap from THIS spawn's deadline (#2968)", async () => {
+		// #2968 recurrence: the sampler's only stop was the child's own settle,
+		// so a child that never exits (a hung `.cmd` shim that survives
+		// `taskkill /F /T`) polled for hours — 234 live powershell/taskkill
+		// processes in the report. The polling bound has to come from the
+		// deadline safe-spawn actually computed for THIS spawn, not from a
+		// constant that knows nothing about the caller's timeout.
+		//
+		// The cap assertion rides on this spawn rather than its own: every real
+		// child in this file is one more `real-process-spawn` hit against
+		// tests/support/flake-shape-baseline.json, and a fix does not widen that
+		// baseline for a test it wrote.
 		stopMock.mockReturnValue(null);
-		const result = await safeSpawnAsync(NODE, EXIT_OK);
+		const result = await safeSpawnAsync(NODE, EXIT_OK, { timeout: 12_000 });
 
 		expect(startSpawnUsageSamplerMock).toHaveBeenCalledTimes(1);
-		const [pidArg] = startSpawnUsageSamplerMock.mock.calls[0];
-		expect(typeof pidArg).toBe("number");
-		expect(result.status).toBe(0);
-	});
-
-	it("bounds the sampler's polling lifetime by THIS spawn's own deadline (#2968)", async () => {
-		// Recurrence: #2968 — the sampler's only stop was the child's settle, so
-		// a child that never exits (a hung `.cmd` shim surviving `taskkill /F /T`)
-		// polled for hours. The bound has to come from the deadline safe-spawn
-		// actually computed for this spawn, not from a constant that knows
-		// nothing about the caller's timeout.
-		stopMock.mockReturnValue(null);
-		await safeSpawnAsync(NODE, EXIT_OK, { timeout: 12_000 });
-
-		const [, intervalMsArg, lifetimeCapMsArg] =
+		const [pidArg, intervalMsArg, lifetimeCapMsArg] =
 			startSpawnUsageSamplerMock.mock.calls[0];
-		expect(intervalMsArg).toBe(750);
-		// 12s timeout + the 5s teardown grace (SIGTERM, 1s SIGKILL escalation,
-		// then at most 2s of pipe-idle wait).
+		expect(typeof pidArg).toBe("number");
+		// The cadence stays the sampler's own default; only the deadline is
+		// safe-spawn's to supply.
+		expect(intervalMsArg).toBeUndefined();
+		// 12s timeout + the 5s teardown grace (SIGTERM, its 1s SIGKILL
+		// escalation, then at most 2s of pipe-idle wait).
 		expect(lifetimeCapMsArg).toBe(17_000);
+		expect(result.status).toBe(0);
 	});
 
 	it("stops the sampler exactly once and attaches resourceUsage when a summary landed", async () => {

--- a/tests/clients/safe-spawn-resource-usage.test.ts
+++ b/tests/clients/safe-spawn-resource-usage.test.ts
@@ -18,12 +18,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const stopMock = vi.fn();
 const startSpawnUsageSamplerMock = vi.fn(
-	(_pid: number | undefined, _intervalMs?: number) => ({ stop: stopMock }),
+	(_pid: number | undefined, _intervalMs?: number, _lifetimeCapMs?: number) => ({
+		stop: stopMock,
+	}),
 );
-vi.mock("../../clients/resource-sampler.js", () => ({
-	startSpawnUsageSampler: (pid: number | undefined, intervalMs?: number) =>
-		startSpawnUsageSamplerMock(pid, intervalMs),
-}));
+// Spread the real module so its constants (SPAWN_SAMPLE_INTERVAL_MS, which
+// safe-spawn passes through) stay real and a future export addition passes
+// through instead of arriving undefined.
+vi.mock("../../clients/resource-sampler.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../clients/resource-sampler.js")>();
+	return {
+		...actual,
+		startSpawnUsageSampler: (
+			pid: number | undefined,
+			intervalMs?: number,
+			lifetimeCapMs?: number,
+		) => startSpawnUsageSamplerMock(pid, intervalMs, lifetimeCapMs),
+	};
+});
 
 const logLatencyMock = vi.fn();
 vi.mock("../../clients/latency-logger.js", () => ({
@@ -54,6 +67,23 @@ describe("safeSpawnAsync resource-usage bracketing (#620)", () => {
 		const [pidArg] = startSpawnUsageSamplerMock.mock.calls[0];
 		expect(typeof pidArg).toBe("number");
 		expect(result.status).toBe(0);
+	});
+
+	it("bounds the sampler's polling lifetime by THIS spawn's own deadline (#2968)", async () => {
+		// Recurrence: #2968 — the sampler's only stop was the child's settle, so
+		// a child that never exits (a hung `.cmd` shim surviving `taskkill /F /T`)
+		// polled for hours. The bound has to come from the deadline safe-spawn
+		// actually computed for this spawn, not from a constant that knows
+		// nothing about the caller's timeout.
+		stopMock.mockReturnValue(null);
+		await safeSpawnAsync(NODE, EXIT_OK, { timeout: 12_000 });
+
+		const [, intervalMsArg, lifetimeCapMsArg] =
+			startSpawnUsageSamplerMock.mock.calls[0];
+		expect(intervalMsArg).toBe(750);
+		// 12s timeout + the 5s teardown grace (SIGTERM, 1s SIGKILL escalation,
+		// then at most 2s of pipe-idle wait).
+		expect(lifetimeCapMsArg).toBe(17_000);
 	});
 
 	it("stops the sampler exactly once and attaches resourceUsage when a summary landed", async () => {


### PR DESCRIPTION
## Summary

Operating rule: a sampler that polls a child process is bounded on every axis it can grow on — concurrency, rate, and lifetime — and each bound is observable when it fires.

Kept: the Windows two-query-per-tick shape, the 750ms base cadence, and `spawn_resource_usage` as the sampler's only consumer. Folding the descendant walk and the usage read into one CIM query, and sharing one query across live samplers, are deliberately NOT in this PR (see Class sweep).

`startSpawnUsageSampler` polled through `setInterval(() => { void tick(); }, 750)` that neither waited for its own tick nor ever expired. The only thing that stopped it was the bracketed child's own settle. On Windows one tick is TWO `powershell.exe` CIM queries plus a `taskkill.exe` whenever a query blows the 2s query timeout, so four children that hung for 5-6.4 hours left 234 live processes (~10GB) parented by the pi host (external report, Windows 11 24H2, no `wmic.exe`).

Three bounds, one per growth axis (AGENTS.md defect shape 9 — "a resource bounded on one axis while it grows on another"):

1. **Concurrency** — a tick never starts while the previous one is unsettled.
2. **Rate** — past 8 ticks (6s at the base cadence) the delay doubles per tick to a 16x ceiling (12s). The short interval exists to catch SHORT-LIVED children, which the module's own comment already said.
3. **Lifetime** — polling stops for good at a cap that `safe-spawn.ts` derives from THIS spawn's effective deadline plus a 5s teardown grace (`SIGTERM` + its 1s `SIGKILL` escalation, or `taskkill /F /T`, then at most `EXIT_PIPE_IDLE_MAX_WAIT_MS` of pipe-idle wait). `stop()` still returns everything gathered before the cap. `lifetimeCapMs` has no default: an unbounded sampler is the defect, so the bound is the caller's to state and cannot be forgotten by a future call site.

Refs #2968 — `Refs`, not `Closes`: the reporter's fix 3 (one shared process-table query per interval across live samplers) is not delivered, and the Windows code path itself cannot be executed here. Remainder commented on the issue.

### Assessment of the report (step 1) — every claim checked against the tree

Line numbers below are `origin/master` (713c993b1) unless marked "post-fix" — the claims are about the code as reported.

| # | Claim | Verdict | Evidence |
|---|---|---|---|
| 1 | `setInterval(() => { void tick(); }, 750)` with no in-flight guard | **Holds** | `clients/resource-sampler.ts:597` — `void tick()` inside the interval callback, `tick` is `async`, nothing gates re-entry |
| 2 | "The timer is cleared only on `child.on("close")`" | **Refuted as written, holds in substance** | The sampler is stopped from `finalize` (`clients/safe-spawn.ts:1870`, reached from `onChildSettle` on **`exit` OR `close`**) and from the `error` handler (`:1996`). So three settle paths, not one. But every one of them requires the CHILD to settle: the timeout (`:1702`), abort (`:1631`), and output-cap (`:1645`) paths only *kill*; they never stop the sampler, and there is no host-disposal path at all. A child whose tree survives `taskkill /F /T` settles nothing, so the sampler's lifetime was genuinely unbounded — the reporter's conclusion is right, the mechanism is one step wider |
| 3 | Two CIM queries per tick on Windows | **Holds** | `findDescendantPidsWindows` → `queryProcessTable` (`resource-sampler.ts:142`) and `sampleProcessesWindows` → `queryProcessTable` (`:238`); `buildProcessQuery` spawns `windowsExe("WindowsPowerShell\\v1.0\\powershell.exe")` per call (`scripts/lib/process-scan.mjs:282`). One tick = 2 spawns; N live samplers = 2N per interval |
| 4 | A query past 2000ms is tree-killed by `taskkill /F /T`, a third process in the same window | **Holds** | `onTimeout: terminateScannerChild` at both query sites → `killPidTree` → `nodeSpawn(windowsExe("taskkill.exe"), ["/F","/T","/PID",...])` (`clients/instance-reaper.ts:529`). It records `resource-sampler-scanner-escalated`, which is exactly the row the reporter pasted (11 of them, three distinct `win32-cim` pids) |
| 5 | The code's own comment says the short interval is for SHORT-LIVED children | **Holds** | pre-fix docstring: "the (usually sub-few-second) analyzer children this brackets" |
| 6 | The only consumer is one `spawn_resource_usage` latency row | **Holds** | `logLatency({phase: "spawn_resource_usage"})` at `clients/safe-spawn.ts:1720`; `SpawnResult.resourceUsage` is written at five return sites and read NOWHERE outside `safe-spawn.ts` (`grep -rn "resourceUsage" clients tools mcp index.ts` returns only `safe-spawn.ts` plus unrelated `process.resourceUsage()` hits in `memory-sampler.ts`) |
| 7 | Do `sampleProcesses` and `findDescendantPids` share work today? | **No, and the overlap is total** | The descendant query already pulls the WHOLE table (`fields: ["pid","ppid"]`, no filter); the usage query then re-queries the same table filtered to pid+descendants. One query asking for both column sets would serve both — see Class sweep for why that is not in this PR |
| 8 | Rate: unmodified 1 → 13 powershell/taskkill over ~3.3s | **Consistent with the tree, not reproducible here** | Linux has no per-tick spawn at all (POSIX path is `pidusage`/procfs — the probe below measured `maxLiveDescendantProcesses: 1`). What I could measure is the TICK rate, which is the multiplier: 54 ticks in 40s pre-fix, and each tick is 2 spawns on Windows |

Other samplers checked while assessing: the heartbeat path (`clients/quiet-window.ts:277` → `sampleProcesses([host, ...lspChildren])`) batches every pid into ONE query and is awaited by its quiet-window task, so it cannot overlap itself; `sampleProcessTreeCpuPercent` is bounded at two reads per call. Neither is a member of this defect class.

### What is proven here vs. reasoned from the Windows code path

Proven on this Linux box: the in-flight guard (both platform branches), the backoff, the lifetime cap, the two ledger records, and the per-spawn cap wiring — through the real sampler, with the real `queryProcessTable`/`child-unref` seam and only `spawn`/`pidusage` (true process boundaries) faked, plus a real-child real-timer probe.

NOT verified, reasoned from the code path: that a saved tick saves exactly two `powershell.exe` (and, past the 2s query timeout, one `taskkill.exe`) on Windows; and the absolute process counts in the report. There is no Windows machine in this environment and no Windows transcript is claimed anywhere in this PR. A Windows confirmation is wanted — the issue comment says exactly what to measure.

## Type of change

- [x] Bug fix
- [ ] New feature (net-new capability)
- [ ] Enhancement (improvement to existing capability)
- [ ] Documentation

## Area

- [ ] area:lsp
- [ ] area:dispatch
- [ ] area:installer
- [ ] area:diagnostics
- [ ] area:read-guard
- [ ] area:project-intelligence
- [x] area:perf
- [x] area:observability
- [ ] area:session
- [ ] area:config
- [ ] area:security
- [ ] area:tests

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [AGENTS.md](../AGENTS.md)
- [x] The change has tests (happy path, edge cases, regression test for bugs)
- [x] Targeted test files for the touched seams pass locally after `npm run build`; the full suite is CI's job.
- [x] Every NEW regression test is proven RED on pre-fix code; the red output is quoted in this PR
- [x] Every new guard/branch/filter is mutation-proof: deleting or neutering it reds at least one test
- [x] PR title carries the conventional prefix and the issue ref
- [x] `npm run lint` passes
- [x] `npm run build:dist` succeeds if I changed code under `clients/`, `commands/`, `tools/`, or `index.ts`
- [x] `package-lock.json` is in sync with `package.json` (untouched; `check:lockfile` and `lockfile:complete` pass in preflight)
- [x] `AGENTS.md` is updated if this PR changes behavior, commands, conventions, or invariants documented there
- [x] `.changelog/<branch-or-slug>-<short-desc>.md` has one valid entry **in this PR** (`node scripts/check-changelog-fragments.mjs` → `changelog fragments OK (15 entries in .changelog/)`)
- [x] Commit subject includes the issue number: `(closes #NNN)` or `(refs #NNN)` — `Refs #2968` in each commit body

## Tests

New, all in `tests/clients/resource-sampler.test.ts` under `describe("#2968 startSpawnUsageSampler backpressure")` — each drives the real sampler (only `spawn` / `pidusage`, true process boundaries, are faked) and each names its recurrence in a comment:

- `skips a poll tick while the previous one is still in flight` — concurrency bound on the POSIX branch, counted in `pidusage` calls with a never-settling query. Also asserts the `resource-sampler-tick-overlapped` ledger count. Screens: wrong-layer pin (the guard is read through the sampler, not by re-stating the predicate), all-mocks (the accumulator, ledger and timers are real).
- `starts no second process-table query while the first is unsettled (Windows path)` — the same bound counted where the report counted it: spawned query children, with `setPlatform("win32")` and a `holdOpen` child. Screens: parallel path (the Windows branch is the one that pays 2 spawns/tick).
- `stops polling at its lifetime cap and still returns what it gathered` — lifetime bound, plus "a capped sampler emits what it had" and the `resource-sampler-lifetime-capped` ledger count.
- `backs the interval off to the ceiling once the child outlives the short-lived window` — rate bound, asserted on the real gaps between real `Date.now()` reads inside the sampled calls. Expectations are LITERALS (`100`, `1_600`), never the module's own constants: a test that recomputes what it pins follows an edit instead of catching it (implementation-mirror screen).

Edited: `tests/clients/safe-spawn-resource-usage.test.ts` — the existing "starts the sampler right after spawn" case now also asserts the constructor args (`intervalMs` undefined, `lifetimeCapMs` 17_000 for a 12_000 timeout). Deliberately folded into that existing spawn rather than added as a new `it`: every real child in that file is one more `real-process-spawn` hit against `tests/support/flake-shape-baseline.json`, and a fix does not widen a flake baseline for a test it wrote. Also: its `vi.mock` factory now forwards the third argument (a double that drops an argument production honors can turn an inert fix green).

Existing call sites in `resource-sampler.test.ts` gained an explicit `lifetimeCapMs` because the parameter is required now — 9 mechanical edits, no behavior asserted differently.

### Red-first (tests kept, `clients/resource-sampler.ts` + `safe-spawn.ts` + `degradation-ledger.ts` reverted to `origin/master`, rebuilt)

```
FAIL tests/clients/resource-sampler.test.ts > #2968 … > skips a poll tick while the previous one is still in flight
AssertionError: expected "vi.fn()" to be called 1 times, but got 51 times
FAIL tests/clients/resource-sampler.test.ts > #2968 … > starts no second process-table query while the first is unsettled (Windows path)
AssertionError: expected 16 to be 1 // Object.is equality
FAIL tests/clients/resource-sampler.test.ts > #2968 … > stops polling at its lifetime cap and still returns what it gathered
AssertionError: expected 611 to be 11 // Object.is equality
FAIL tests/clients/resource-sampler.test.ts > #2968 … > backs the interval off to the ceiling once the child outlives the short-lived window
AssertionError: expected 100 to be 1600 // Object.is equality
FAIL tests/clients/safe-spawn-resource-usage.test.ts > … > starts the sampler right after spawn, with the child's pid and a cap from THIS spawn's deadline (#2968)
AssertionError: expected undefined to be 17000 // Object.is equality
 Tests  5 failed | 56 passed (61)
```

### Mutation proofs (neutered in the BUILT `clients/*.js`, rebuilt between mutations, re-run at the final head)

| id | mutation (built output) | red |
|---|---|---|
| M1 | `if (inFlight) {` → `if (false) {` | `expected "vi.fn()" to be called 1 times, but got 13 times` + `expected 11 to be 1` (both overlap tests) |
| M2 | `if (inFlight) {` → `if (true) {` (dangerous direction: every tick skipped) | `expected 1 to be greater than or equal to 2` + `expected [] to deeply equal [ 100, 100, … ]` |
| M3 | `if (Date.now() - startedAt >= lifetimeCapMs) {` → `if (false) {` | `expected 48 to be 10` |
| M4 | same → `if (true) {` (cap fires immediately) | `expected 1 to be greater than or equal to 2`, 3 tests red |
| M5 | `if (tickCount <= SPAWN_SAMPLE_FULL_RATE_TICKS)` → `if (true)` (no backoff) | `expected 100 to be 1600` |
| M6 | same → `if (false)` (backoff from tick 1) | `expected [ +0, 1, 3, 6, 12, 25, 50 ] to deeply equal [ 100, 100, … ]` |
| M7 | overlap `incrementDegradationCount({` → `((x) => x)({` | `skips a poll tick while the previous one is still in flight` red |
| M8 | cap `incrementDegradationCount({` → `((x) => x)({` | `expected undefined to be 1` |
| M9 | `safe-spawn.js`: drop `, timeout + SPAWN_SAMPLER_TEARDOWN_GRACE_MS` | `expected undefined to be 17000` |

### Real-child probe (real spawn, real timers, real `pidusage`, production sampler; `PI_LENS_HOME` pinned to the worktree)

```
pre-fix  (startSpawnUsageSampler(pid, 750)):
 {"elapsedS":"40.0","cap":"none (pre-fix: unbounded)","sampleCount":54,
  "peakRssBytes":7585792,"maxLiveDescendantProcesses":1,"childStillAlive":true}
post-fix (startSpawnUsageSampler(pid, 750, 35000)):
 {"elapsedS":"42.0","cap":"35000ms","sampleCount":13,
  "peakRssBytes":7155712,"maxLiveDescendantProcesses":1,"childStillAlive":true}
```

54 polls and still going, vs 13 polls and polling finished at the cap, against a child that is still alive in both runs. `maxLiveDescendantProcesses: 1` is the honest Linux caveat: the only child is the `sleep` under test, because the POSIX branch reads procfs instead of spawning. The 4.2x tick reduction is what turns into a 4.2x spawn reduction on Windows, plus everything after 35s going to zero.

### Test assessment

- `tests/clients/resource-sampler.test.ts` — uniquely pins the sampling seam itself: the pure accumulator, the pure descendant BFS, both platform sampling branches including every #620 spawn-failure shape, the #2358 window verdict, and now the three backpressure bounds. Nothing in it is made redundant by this PR: the four new cases are the only red under M1/M3/M5 respectively, and I re-ran the pre-existing cases under every mutation above — `samples immediately on start and again on each poll tick` is the only red under M2/M4, so it is now load-bearing rather than redundant. No vacuous case found while mutating: every pre-existing case in the file reds under at least one of the nine mutations or asserts a distinct pure-function output. No removals.
- `tests/clients/safe-spawn-resource-usage.test.ts` — uniquely pins the WIRING (sampler started once per spawn, stopped exactly once, `resourceUsage` surfaced and logged, never fabricated, spawn survives a throwing sampler) and now the per-spawn cap. `starts the sampler right after spawn …` is the only red under M9. No removals; nothing became redundant.

## Blast radius

`clients/resource-sampler.ts#startSpawnUsageSampler` — signature gained a required third parameter.

- Callers above: `clients/safe-spawn.ts:1568` post-fix (`safeSpawnAsync`, the ONLY production caller — `grep -rn "startSpawnUsageSampler" clients tools mcp scripts index.ts` returns that site plus the module itself) and 13 call sites in `tests/clients/resource-sampler.test.ts`. `tsc --noEmit` is the enforcement: a caller that omits the bound does not compile.
- Callees below: `+ incrementDegradationCount` (new edge to `clients/degradation-ledger.ts`), unchanged `sampleProcesses` / `findDescendantPidsWindows` / `queryProcessTable` / `terminateScannerChild`.
- `clients/safe-spawn.ts#safeSpawnAsync` — every dispatch runner, formatter, installer probe and analyzer in the tree calls it; its own signature, return shape and settle paths are untouched. The only behavioral delta for a caller is that a spawn whose child outlives `timeout + 5s` reports a `resourceUsage` summary covering the first part of that window instead of the whole of it. `SpawnResult.resourceUsage` has no consumer outside `safe-spawn.ts` (grep in the assessment table), so no strict consumer of a durable record changes shape.
- `clients/degradation-ledger.ts` — two members added to `DegradationKind`, alphabetically placed (`tests/config/degradation-kind-order.test.ts` passes). Neither is informational, so both render with `⚠` in `pilens_health`; existing rows parse unchanged.
- Hot path: yes, per-spawn. Cost delta is NEGATIVE on every platform (strictly fewer polls per spawn; unchanged for a child that finishes inside the 6s full-rate window, which is the common analyzer case). The added per-tick work is one `Date.now()` comparison and one boolean test.
- `vi.mock` dependents of the touched modules: `tests/clients/safe-spawn-{cap-race,close-before-error-race,sync-throw}.test.ts` mock `resource-sampler.js` with a factory returning only `startSpawnUsageSampler`. `tests/config/vi-mock-export-sweep.test.ts` redded when an intermediate revision had `safe-spawn` import a second export from the module; the shipped revision passes only the deadline and keeps that import surface at one export, so all three doubles stay faithful. Quoted red from that intermediate run: `tests/clients/safe-spawn-cap-race.test.ts:../../clients/resource-sampler.js:["startSpawnUsageSampler"]: regression; missing SPAWN_SAMPLE_INTERVAL_MS`.

## Observability

Two records, both through the existing ledger seam, both counted (not per-occurrence) with ONE session-wide subject `spawn-usage-sampler` — a per-spawn subject would make the ledger's `tallies` grow with the session's spawn count, which is the same shape-9 leak this PR closes:

- `kind: "resource-sampler-tick-overlapped"` — `incrementDegradationCount` in `clients/resource-sampler.ts`, asserted by `skips a poll tick while the previous one is still in flight` (`expect(...count).toBeGreaterThanOrEqual(5)`), mutation-proven by M7.
- `kind: "resource-sampler-lifetime-capped"` — same seam, asserted by `stops polling at its lifetime cap and still returns what it gathered` (`expect(...count).toBe(1)`), mutation-proven by M8. Real durable row from the post-fix probe (`.probe-home/latency.log`, one row for one capped sampler):

```
{"type":"phase","phase":"degradation_ledger","filePath":"spawn-usage-sampler","durationMs":0,"metadata":{"kind":"resource-sampler-lifetime-capped","subject":"spawn-usage-sampler","count":1,"ledgerGeneration":0},"ts":"2026-09-11T17:05:17.012Z","pid":109398,"turnId":"turn:0"}
```

Lifetime: both are session-scoped tallies cleared by `resetDegradationLedger()` at a session boundary, and re-recorded by the next sampler that hits a bound — nothing latches past the session that observed it (catalog shape 17). Durable writes are first-occurrence plus power-of-two milestones, so a session that skips 4,000 ticks writes ~13 rows, not 4,000. The backoff is by design, not a degradation, and records nothing.

## Class sweep

Shape: **AGENTS.md defect shape 9** ("a resource bounded on one axis while it grows on another"), with shape 4's "a timer that outlives its one-shot settle" as the lifetime half.

Pattern sweep, whole tree (`clients/`, `clients/**`, `tools/`, `mcp/`, `scripts/`, `scripts/lib/`, `index.ts`, `i18n.ts`), for a recurring timer whose tick does async work — and specifically spawns:

- `grep -rn "setInterval(" clients/ tools/ mcp/ scripts/ index.ts i18n.ts` → exactly 2 other hits. `clients/dispatch/runners/utils/availability-policy.ts:542` (`startHostStallSampler`) has the same "stopped only by the operation's settle" lifetime shape but its tick is pure arithmetic — no I/O, no child — so it is not a member. `scripts/with-memory-watch.mjs:91` reads `/proc/meminfo` synchronously in a dev-only watcher. Verdict for both: not members, not changed.
- `grep -rn "queryProcessTable(" clients/ scripts/ tools/ mcp/ index.ts` → 5 call sites: the 2 in the sampler (fixed here) and 3 in `clients/instance-reaper.ts` (`findPidsByMarkerWindows`, `queryCommandLines`, `enumerateManagedProcesses`). All three are one-shot per sweep, and the sweep is `scheduleUntrackedOrphanSweep()` at session start under a machine-wide timestamp cooldown (`index.ts:2320`) — no recurring timer, no overlap. Verdict: not members.
- `grep -rln "spawnCollectStdoutResult" clients/ scripts/` → `process-snapshot.ts`, `instance-reaper.ts`, `degradation-ledger.ts`, `child-unref.ts`, `scripts/lib/process-scan.mjs`; all covered by the two greps above.
- The heartbeat consumer (`clients/quiet-window.ts:277`) batches all pids into one query per quiet-window run and is awaited by its task — bounded by `HEARTBEAT_SAMPLE_TIMEOUT_MS`. Not a member.

**Class of size 1**, proven by the greps above: `startSpawnUsageSampler` was the only recurring per-tick process spawner in the tree.

Literal/symbol sweep for what this PR introduces (`grep -rn` over `*.ts`, `*.mjs`, `*.md`, `*.json`, excluding build output): `resource-sampler-tick-overlapped`, `resource-sampler-lifetime-capped`, `SPAWN_SAMPLE_INTERVAL_MS`, `SPAWN_SAMPLE_FULL_RATE_TICKS`, `SPAWN_SAMPLE_MAX_INTERVAL_MULTIPLIER`, `SPAWN_SAMPLER_TEARDOWN_GRACE_MS`, `spawn-usage-sampler` — each defined exactly once, no hand-maintained mirror, no duplicate literal. The three cadence constants are module-private (nothing outside reads them, so nothing exports them), and the removed `SPAWN_SAMPLE_LIFETIME_CAP_MS` default is gone rather than left unreachable.

Consolidation verdict, and what is deliberately NOT done (the reporter's fix 3):

- **Fold the two Windows queries into one** — the descendant query already pulls the whole table unfiltered, so one query projecting `pid, ppid, rssBytes, cpuKernel100ns, cpuUser100ns, startedAt` would serve both halves and halve the per-tick spawns. Not in this PR: it restructures the one code path that cannot be executed in this environment, and its only local proof would be the same mocked `spawn` the rest of the Windows suite uses — i.e. a fidelity the query TEXT does not get. With the three bounds landed, it buys a 2x on a cost that is now rate- and lifetime-capped.
- **One shared process-table query per interval across live samplers** — shared mutable state with multiple readers, per-sampler tick phases to reconcile, and a cache-freshness axis; the single-query fold above achieves most of the same reduction with no shared state, so the shared cache should be measured against that alternative rather than built first.

Both are filed as a follow-up with this member list (see the issue comment on #2968); neither is half-built here.

## Local runs (this worktree, `PI_LENS_HOME` pinned; CI is authoritative)

- `npm run build` → exit 0 (rebuilt before every test run and between every mutation)
- `npx tsc --noEmit` → exit 0
- `npm run fmt:check` → `All matched files use the correct format.` (one file needed `npx oxfmt`; re-ran the suites after)
- Targeted + dependents (9 files): `Test Files 9 passed (9) / Tests 137 passed (137)` — `resource-sampler`, `resource-sampler-scanner-attribution`, `instance-reaper-registry-scan-escalation`, `lsp/service-notify-cpu-liveness`, `safe-spawn-resource-usage`, `safe-spawn-cap-race`, `safe-spawn-close-before-error-race`, `safe-spawn-sync-throw`, `flake-shape-ratchet`
- Every `tests/config/*.test.ts` (53 files): `Test Files 53 passed (53) / Tests 470 passed | 1 skipped (471)`
- Directory-scanning governance suites, selected mechanically with `ls tests/clients/*{sweep,ratchet,conformance,coverage,gate,governance,silence,hermeticity,invariant,contract}*.test.ts` (31 files, run in two batches): `16 passed (16) / 163 passed` and `14 passed (14) / 321 passed`, plus `flake-shape-ratchet` in the dependents batch
- `npm run preflight` → 13/13 gates pass (build, lint, fmt:check, changelog:check, check-changelog-fragments, check:lockfile, lockfile:complete, tests/config, generation-guard, flake-shape-ratchet, lsp-spawn-heavy-coverage, ci-verdict, knip)
- Merged `origin/master` (713c993b1) into the branch before handoff and re-ran build, preflight, dependents, `tests/config` and both governance batches on the merged head. Master's new commits touch `session-event-guard.ts`, `bash-file-access.ts`, `index.ts` and `tests/config/hook-await-bounds.test.ts` — no overlap with the sampler or spawn seams, so there is no seam the merge recombined.
- One pre-existing advisory row in `tests/config`, not from this diff: `vi-mock-export-sweep` WARNING `module-instance-binding.test.ts:…/clients/installer/index.js … missing count rose from 45 to 46`. This diff touches no file under `clients/installer/`; the suite passes.
