### PR TITLE
test(hygiene): sweep the warmup-oneshot fixture family (refs #2912)

### DIFF
--- a/tests/clients/runtime-session-warmup-oneshot.test.ts
+++ b/tests/clients/runtime-session-warmup-oneshot.test.ts
@@ -23,10 +23,23 @@
 import { withResidentBootstrap } from "../support/bootstrap-access.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { RuntimeCoordinator } from "../../clients/runtime-coordinator.js";
+import { waitForProjectSnapshotPersistsForTests } from "../../clients/project-snapshot.js";
 import { _resetSubagentModeForTests } from "../../clients/subagent-mode.js";
-import { createTempFile, setupTestEnvironment } from "./test-utils.js";
+import {
+	cleanupTestEnvironments,
+	createTempFile,
+	setupTestEnvironment,
+} from "./test-utils.js";
 
 const touchFileSpy = vi.hoisted(() => vi.fn());
 const logLatencySpy = vi.hoisted(() => vi.fn());
@@ -154,6 +167,21 @@ describe("quick-mode warmup one-shot retention (#1154)", () => {
 		vi.restoreAllMocks();
 		_resetSubagentModeForTests();
 	});
+
+	const cleanupWarmupOneshotTemps = async () => {
+		// Warmup persists the runtime snapshot after its latency record; drain
+		// that worker before the final macrotask sweep removes this family's roots.
+		await waitForProjectSnapshotPersistsForTests();
+		for (let tick = 0; tick < 3; tick++) {
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			cleanupTestEnvironments("pi-lens-warmup-oneshot-", {
+				untrack: tick === 2,
+			});
+		}
+	};
+
+	afterEach(cleanupWarmupOneshotTemps);
+	afterAll(cleanupWarmupOneshotTemps);
 
 	it("does NOT schedule/run the warmup in print mode (`-p`/`--print`) — the one-shot retention fix", async () => {
 		const env = setupTestEnvironment("pi-lens-warmup-oneshot-print-");


### PR DESCRIPTION
Refs #2912

## Summary

Add a per-family asynchronous cleanup sweep for the warmup one-shot fixtures.

## Premise

The combined pre-fix run reproduced the CI leak on the first attempt:


FAIL tests/config/tmp-fixture-hygiene.test.ts > tmp-fixture-hygiene
AssertionError: leaked 1 top-level entries:
pi-lens-warmup-oneshot-interactive-Wv1yqT


No [test cleanup] could not remove temp dir warning appeared. env.cleanup() removed the root, then deferred warmup snapshot work recreated it.

## The fix

Mirror cleanupReverseDepsTemps: await waitForProjectSnapshotPersistsForTests(), drain three macrotasks, sweep pi-lens-warmup-oneshot-, and pass untrack: tick === 2. The basename startsWith match covers interactive, print, and unref prefixes.

## Class sweep

I grepped every setupTestEnvironment("pi-lens-...") in tests/, every cleanupTestEnvironments call, and tests/config/tmp-fixture-hygiene-baseline.json. The audit found 1,021 producer prefixes, 5 sweep stems, and 36 admitted prefixes. The following complete list has neither a family sweep nor an admission:

- tests/clients/actionable-warnings-deferred-bounds.test.ts: pi-lens-2504-deferred-
- tests/clients/advisory-provenance-finding-freshness.test.ts: pi-lens-freshness-1708-, pi-lens-freshness-1708-outside-, pi-lens-freshness-boundary-, pi-lens-freshness-boundary-part-
- tests/clients/advisory-provenance-finding-paths.test.ts: pi-lens-finding-paths-, pi-lens-finding-paths-ancestor-
- tests/clients/blocker-freshness-delivery-cap.test.ts: pi-lens-1950-cap-, pi-lens-1950-suppressed-
- tests/clients/blocker-freshness-turn-end.test.ts: pi-lens-fresh-turnend-, pi-lens-fresh-turnend-keep-, pi-lens-runner-fresh-turnend-, pi-lens-runner-idle-reset-, pi-lens-runner-no-write-turn-
- tests/clients/blocker-past-eof-turn-end.test.ts: pi-lens-past-eof-compose-, pi-lens-past-eof-turnend-, pi-lens-past-eof-turnend-keep-, pi-lens-past-eof-turnend-rearm-
- tests/clients/cascade-turn-merge.test.ts: pi-lens-cascade-f1-pending-
- tests/clients/coderabbit-ast-grep-rules.test.ts: pi-lens-coderabbit-smoke-
- tests/clients/complexity-client.test.ts: pi-lens-cx-
- tests/clients/dead-code-client-exit-code.test.ts: pi-lens-vulture-genuine-clean-, pi-lens-vulture-silent-crash-
- tests/clients/dead-code-client.test.ts: pi-lens-deadcode-, pi-lens-deadcode-boundary-
- tests/clients/dead-code-vulture-project-config.test.ts: pi-lens-vulture-config-, pi-lens-vulture-noconfig-, pi-lens-vulture-venv-, pi-lens-vulture-venv-ancestor-, pi-lens-vulture-venv-home-
- tests/clients/demoted-blocker-render-retirement.test.ts: pi-lens-1944-body-, pi-lens-1944-drift-, pi-lens-1944-guard-drift-, pi-lens-1944-guard-lines-, pi-lens-1944-guard-live-, pi-lens-1944-guard-ok-, pi-lens-1944-ledger-, pi-lens-1944-retire-
- tests/clients/dependency-checker-inflight-aba.test.ts: pi-lens-dep-check-aba-, pi-lens-dep-check-clean-, pi-lens-dep-scan-aba-, pi-lens-dep-scan-clean-
- tests/clients/dependency-checker-madge-memo-reset.test.ts: pi-lens-madge-memo-reset-
- tests/clients/diagnostic-line-freshness.test.ts: pi-lens-past-eof-cache-fresh-, pi-lens-past-eof-cache-hit-, pi-lens-past-eof-cache-miss-, pi-lens-past-eof-shared-, pi-lens-past-eof-shared-rearm-, pi-lens-past-eof-v1-
- tests/clients/dispatch-context-normalized.test.ts: pi-lens-2016-ctx-
- tests/clients/dispatch/formatter-exit-code-posture.test.ts: pi-lens-biome-unmatched-, pi-lens-exit-msg-, pi-lens-exit-msg-stdout-, pi-lens-exit-posture-, pi-lens-exit-posture-all-, pi-lens-exit-posture-ok-
- tests/clients/dispatch/javac-dispatch-integration.test.ts: pi-lens-javac-cache-recovery-, pi-lens-javac-dispatch-ceiling-, pi-lens-javac-dispatch-notice-
- tests/clients/dispatch/oxfmt-ignored-file-noop.test.ts: pi-lens-oxfmt-cmd-shape-, pi-lens-oxfmt-ignored-contract-, pi-lens-oxfmt-ignored-seam-, pi-lens-oxfmt-still-formats-, pi-lens-oxfmt-strict-, pi-lens-oxfmt-which-
- tests/clients/dispatch/runners/ast-grep-napi.test.ts: pi-lens-ast-grep-, pi-lens-ast-grep-dedupe-, pi-lens-ast-grep-gate-, pi-lens-ast-grep-loss-, pi-lens-ast-grep-r3b-, pi-lens-ast-grep-real-rule-
- tests/clients/dispatch/runners/ast-grep-rule-ignores.test.ts: pi-lens-java-ignores-
- tests/clients/dispatch/runners/biome-check-runner.test.ts: pi-lens-biome-check-
- tests/clients/dispatch/runners/eslint.test.ts: pi-lens-eslint-clean-, pi-lens-eslint-error-exit-one-, pi-lens-eslint-fallback-stop-, pi-lens-eslint-fatal-, pi-lens-eslint-stderr-gating-, pi-lens-eslint-warning-exit-zero-
- tests/clients/dispatch/runners/exit-blind-runners.test.ts: pi-lens-go-vet-, pi-lens-mypy-syntax-, pi-lens-spellcheck-, pi-lens-yamllint-bound-
- tests/clients/dispatch/runners/fish-indent.test.ts: pi-lens-fish-indent-
- tests/clients/dispatch/runners/htmlhint.test.ts: pi-lens-htmlhint-findings-, pi-lens-htmlhint-rules-argv-
- tests/clients/dispatch/runners/java-csharp-runners.test.ts: pi-lens-c-runner-, pi-lens-cpp-runner-, pi-lens-dotnet-build-runner-, pi-lens-javac-runner-
- tests/clients/dispatch/runners/javac-build-descriptor-gate.test.ts: pi-lens-javac-gate-gradle-, pi-lens-javac-gate-maven-, pi-lens-javac-gate-standalone-
- tests/clients/dispatch/runners/markdownlint-fixable.test.ts: pi-lens-markdownlint-cli2fmt-, pi-lens-markdownlint-default-config-, pi-lens-markdownlint-fixable-
- tests/clients/dispatch/runners/nonzero-exit-no-output.test.ts: pi-lens-detekt-, pi-lens-hadolint-, pi-lens-htmlhint-
- tests/clients/dispatch/runners/oxlint.test.ts: pi-lens-oxlint-clean-match-, pi-lens-oxlint-cwd-, pi-lens-oxlint-error-promotion-, pi-lens-oxlint-eslint-config-, pi-lens-oxlint-excluded-, pi-lens-oxlint-fallback-, pi-lens-oxlint-fallback-stop-, pi-lens-oxlint-garbage-failure-, pi-lens-oxlint-runner-, pi-lens-oxlint-skip-telemetry-, pi-lens-oxlint-timeout-partial-, pi-lens-oxlint-vite-plus-fallback-, pi-lens-oxlint-vp-home-ceiling-, pi-lens-oxlint-warning-exit-zero-, pi-lens-oxlint-zero-files-error-, pi-lens-oxlint-zero-files-stderr-, pi-lens-runner-skip-reason-boundary-
- tests/clients/dispatch/runners/parsed-nothing.test.ts: pi-lens-1948-detekt-, pi-lens-1948-taplo-, pi-lens-1948-tflint-, pi-lens-1948-tflint-clean-, pi-lens-1948-vale-, pi-lens-1948-vale-bound-, pi-lens-1948-vale-clean-, pi-lens-1948-vale-empty-, pi-lens-1948-vale-findings-, pi-lens-1948-vale-silent-
- tests/clients/dispatch/runners/pyright-environment.test.ts: pi-lens-pyright-venv-
- tests/clients/dispatch/runners/ruff.test.ts: pi-lens-ruff-cwd-, pi-lens-ruff-runner-
- tests/clients/dispatch/runners/runner-helpers-generation-ledger.test.ts: pi-lens-genguard-managed-, pi-lens-genguard-quiet-, pi-lens-genguard-resolve-
- tests/clients/dispatch/runners/runner-helpers.test.ts: pi-lens-a-, pi-lens-b-, pi-lens-global-bin-, pi-lens-local-first-, pi-lens-managed-broken-, pi-lens-managed-broken-cwd-, pi-lens-managed-check-args-, pi-lens-managed-cooldown-, pi-lens-managed-cooldown-cwd-, pi-lens-managed-dir-finder-, pi-lens-managed-dir-spawn-count-, pi-lens-managed-inflight-, pi-lens-managed-memo-, pi-lens-managed-memo-cwd-, pi-lens-managed-straddle-, pi-lens-managed-transient-, pi-lens-managed-transient-cwd-, pi-lens-managed-transient-memo-, pi-lens-managed-transient-memo-cwd-, pi-lens-no-venv-, pi-lens-no-venv-no-managed-, pi-lens-node-bin-, pi-lens-node-bin-global-, pi-lens-path-probe-, pi-lens-sg-home-ceiling-, pi-lens-sg-own-install-cwd-, pi-lens-sg-own-install-home-, pi-lens-sg-project-bin-, pi-lens-vendor-bin-, pi-lens-vendor-bin-home-, pi-lens-venv-ancestor-, pi-lens-venv-home-ceiling-, pi-lens-venv-over-managed-, pi-lens-venv-quote-
- tests/clients/dispatch/runners/runner-status-semantics.test.ts: pi-lens-go-, pi-lens-lsp-agent-coverage-, pi-lens-lsp-agent-coverage-primary-, pi-lens-lsp-astgrep-source-, pi-lens-lsp-astgrep-test-skip-, pi-lens-lsp-bounded-, pi-lens-lsp-cold-, pi-lens-lsp-cutoff-, pi-lens-lsp-cutoff-findings-, pi-lens-lsp-fix-, pi-lens-lsp-inconclusive-, pi-lens-lsp-late-status-, pi-lens-lsp-mixed-coverage-, pi-lens-lsp-notice-partition-, pi-lens-lsp-parallel-, pi-lens-lsp-refactor-, pi-lens-lsp-warm-cutoff-, pi-lens-lsp-warm-fix-, pi-lens-lsp-warm-fix-fail-, pi-lens-rb-, pi-lens-rs-
- tests/clients/dispatch/runners/secondary-language-runners.test.ts: pi-lens-dart-flutter-runner-, pi-lens-dart-runner-, pi-lens-elixir-runner-, pi-lens-elixirc-contextless-, pi-lens-gleam-runner-, pi-lens-zig-contextless-, pi-lens-zig-runner-
- tests/clients/dispatch/runners/shellcheck.test.ts: pi-lens-shellcheck-, pi-lens-shellcheck-cwd-
- tests/clients/dispatch/runners/shfmt.test.ts: pi-lens-shfmt-
- tests/clients/dispatch/runners/spellcheck.test.ts: pi-lens-spellcheck-cwd-
- tests/clients/dispatch/runners/stylelint-fixable.test.ts: pi-lens-stylelint-fixable-
- tests/clients/dispatch/runners/taplo.test.ts: pi-lens-taplo-, pi-lens-taplo-local-
- tests/clients/dispatch/runners/terraform-kotlin-runners.test.ts: pi-lens-ktlint-runner-, pi-lens-tflint-runner-
- tests/clients/dispatch/runners/terragrunt.test.ts: pi-lens-terragrunt-runner-
- tests/clients/dispatch/runners/tflint-policy.test.ts: pi-lens-tflint-policy-
- tests/clients/dispatch/runners/yaml-sql-config-gating.test.ts: pi-lens-sqlfluff-gate-, pi-lens-yaml-sql-gate-, pi-lens-yamllint-gate-
- tests/clients/dispatch/runners/yaml-sql-runners.test.ts: pi-lens-sqlfluff-cwd-, pi-lens-sqlfluff-runner-, pi-lens-yamllint-cwd-, pi-lens-yamllint-runner-
- tests/clients/ext-gate-before-ignore.test.ts: pi-lens-1974-filter-, pi-lens-1974-identity-, pi-lens-1974-jscpd-, pi-lens-1974-lsp-diag-, pi-lens-1974-modules-, pi-lens-1974-scale-, pi-lens-1974-startup-, pi-lens-1974-warmup-
- tests/clients/formatter-template-preserve.test.ts: pi-lens-2384-hazard-, pi-lens-2384-html-, pi-lens-2384-optin-, pi-lens-2384-yaml-
- tests/clients/formatter-unavailable-outcome.test.ts: pi-lens-unavail-belt-, pi-lens-unavail-ok-, pi-lens-unavail-oxfmt-, pi-lens-unavail-oxfmt-drivecase-, pi-lens-unavail-oxfmt-home-, pi-lens-unavail-phpcsfixer-, pi-lens-unavail-realfail-, pi-lens-unavail-seam-
- tests/clients/formatters-bin-walker-home-ceiling.test.ts: pi-lens-bin-walker-all-, pi-lens-bin-walker-home-, pi-lens-bin-walker-order-
- tests/clients/formatters-format-file.test.ts: pi-lens-format-file-, pi-lens-format-npx-available-, pi-lens-format-npx-gated-, pi-lens-format-skip-
- tests/clients/formatters-php-cs-fixer-formatfile.test.ts: pi-lens-phpcsfixer-formatfile-
- tests/clients/formatters-signature-warm-path.test.ts: pi-lens-fmt-sig-
- tests/clients/formatters-stylua-project-binary.test.ts: pi-lens-stylua-local-, pi-lens-stylua-resolve-
- tests/clients/formatters.test.ts: pi-lens-fmt-test-
- tests/clients/git-guard.test.ts: pi-lens-git-guard-advisory-, pi-lens-git-guard-aggregate-, pi-lens-git-guard-content-, pi-lens-git-guard-deleted-, pi-lens-git-guard-empty-, pi-lens-git-guard-forged-provenance-, pi-lens-git-guard-incomplete-provenance-, pi-lens-git-guard-retire-, pi-lens-git-guard-retire-sibling-, pi-lens-git-guard-retire-source-, pi-lens-git-guard-runtime-, pi-lens-git-guard-stale-inline-, pi-lens-git-guard-stale-sibling-, pi-lens-git-guard-test-clear-, pi-lens-git-guard-tests-, pi-lens-git-guard-unknown-
- tests/clients/git-tracked-ignore.test.ts: pi-lens-git-tracked-ignore-, pi-lens-git-tracked-ignore-nogit-, pi-lens-git-tracked-ignore-ttl-
- tests/clients/gitleaks-client.test.ts: pi-lens-gitleaks-bad-pkg-, pi-lens-gitleaks-config-, pi-lens-gitleaks-dedupe-, pi-lens-gitleaks-empty-, pi-lens-gitleaks-git-hook-, pi-lens-gitleaks-gitdir-, pi-lens-gitleaks-gitfile-, pi-lens-gitleaks-husky-, pi-lens-gitleaks-loose-gate-, pi-lens-gitleaks-nogit-, pi-lens-gitleaks-other-hook-, pi-lens-gitleaks-pkg-, pi-lens-gitleaks-pkg-wrap-, pi-lens-gitleaks-smartdefault-, pi-lens-gitleaks-strict-default-
- tests/clients/gitleaks-scratch-exclusion.test.ts: pi-lens-gitleaks-cfg-local-, pi-lens-gitleaks-cfg-nolocal-, pi-lens-gitleaks-cfg-nowalker-, pi-lens-gitleaks-cfg-paths-, pi-lens-gitleaks-cfg-regex-, pi-lens-gitleaks-cfg-winsep-, pi-lens-gitleaks-env-, pi-lens-gitleaks-env-ignored-, pi-lens-gitleaks-nested-repo-, pi-lens-gitleaks-nogit-, pi-lens-gitleaks-scratch-, pi-lens-gitleaks-scratch2-, pi-lens-gitleaks-tracked-, pi-lens-gitleaks-walkeronly-
- tests/clients/govulncheck-client.test.ts: pi-lens-govulncheck-dedupe-
- tests/clients/grammar-ensure-retry.test.ts: pi-lens-grammar-retry-
- tests/clients/grammar-load-failure.test.ts: pi-lens-grammar-load-fail-, pi-lens-grammar-load-fail-abort-, pi-lens-grammar-load-fail-memo-
- tests/clients/grammar-poisoned-wasm.test.ts: pi-lens-grammar-poison-
- tests/clients/grammar-stale-version.test.ts: pi-lens-grammar-stale-version-
- tests/clients/grammar-truncation-real-lock.test.ts: pi-lens-grammar-real-lock-
- tests/clients/grammar-truncation.test.ts: pi-lens-grammar-truncation-
- tests/clients/graph-cache.test.ts: pi-lens-graph-drift-
- tests/clients/ignore-compile-memo.test.ts: pi-lens-1976-compile-, pi-lens-1976-inst-a-, pi-lens-1976-inst-b-, pi-lens-1976-inval-, pi-lens-1976-leak-, pi-lens-1976-repeat-, pi-lens-1976-shared-, pi-lens-1976-walk-, pi-lens-2071-allow-, pi-lens-2071-ignore-, pi-lens-2071-lifecycle-, pi-lens-2071-nested-git-, pi-lens-2071-no-git-
- tests/clients/jscpd-client.test.ts: pi-lens-jscpd-, pi-lens-jscpd-aba-, pi-lens-jscpd-clean-, pi-lens-jscpd-config-, pi-lens-jscpd-crash-, pi-lens-jscpd-managed-
- tests/clients/knip-cache-consumer-staleness.test.ts: pi-lens-knip-1630-
- tests/clients/knip-client.test.ts: pi-lens-knip-, pi-lens-knip-boundary-, pi-lens-knip-boundary-skip-, pi-lens-knip-broken-shim-, pi-lens-knip-cache-, pi-lens-knip-dedupe-, pi-lens-knip-genuine-clean-, pi-lens-knip-genuine-findings-, pi-lens-knip-globcache-, pi-lens-knip-memo-, pi-lens-knip-memo-change-, pi-lens-knip-memo-external-, pi-lens-knip-overrides-, pi-lens-knip-overrides-e2e-
- tests/clients/knip-project-toolchain.test.ts: pi-lens-knip-bin-, pi-lens-knip-bin2-, pi-lens-knip-bound-, pi-lens-knip-cap-, pi-lens-knip-cfg-, pi-lens-knip-cfgbare-, pi-lens-knip-cfgpkg-, pi-lens-knip-gate-, pi-lens-knip-gate2-, pi-lens-knip-local-, pi-lens-knip-nolocal-, pi-lens-knip-record-, pi-lens-knip-record2-, pi-lens-knip-rerecord-
- tests/clients/language-profile-warmup.test.ts: pi-lens-warmup-cap-, pi-lens-warmup-dart-, pi-lens-warmup-ignore-, pi-lens-warmup-priority-, pi-lens-warmup-root-
- tests/clients/lsp-mutation-autofix-dedupe-cap.test.ts: pi-lens-2460-autofix-cap-
- tests/clients/lsp-mutation-bridge-equivalence.test.ts: pi-lens-2450-equiv-
- tests/clients/lsp-mutation-normalize-once.test.ts: pi-lens-2016-lsp-mutation-
- tests/clients/lsp-mutation-settled-sweep-composition.test.ts: pi-lens-2465-bridge-, pi-lens-2465-direct-
- tests/clients/lsp/auxiliary-publication-gate.test.ts: pi-lens-aux-publication-gate-, pi-lens-aux-publication-gate-sibling-
- tests/clients/lsp/clangd-lazy-indexing.test.ts: pi-lens-clangd-
- tests/clients/lsp/late-auxiliary-findings.test.ts: pi-lens-late-aux-ceiling-, pi-lens-late-aux-clean-, pi-lens-late-aux-deleted-, pi-lens-late-aux-deliver-, pi-lens-late-aux-demoted-, pi-lens-late-aux-demoted-gap-, pi-lens-late-aux-demoted-gap-cap-, pi-lens-late-aux-demoted-generation-, pi-lens-late-aux-expire-, pi-lens-late-aux-extend-, pi-lens-late-aux-gone-, pi-lens-late-aux-pair-reconcile-, pi-lens-late-aux-probe-throw-, pi-lens-late-aux-rearm-, pi-lens-late-aux-reconcile-, pi-lens-late-aux-repromote-, pi-lens-late-aux-stale-, pi-lens-late-aux-stale-ceiling-
- tests/clients/lsp/workspace-sweep-hold.test.ts: pi-lens-sweep-hold-cancel-, pi-lens-sweep-hold-defer-, pi-lens-sweep-hold-second-turn-
- tests/clients/module-report-call-graph-identity-missing.test.ts: pi-lens-modreport-identity-
- tests/clients/module-report-callbacks-kotlin-csharp.test.ts: pi-lens-modreport-kc-
- tests/clients/module-report-native-callbacks.test.ts: pi-lens-modreport-native-
- tests/clients/mutating-tool-classification.test.ts: pi-lens-2423-carry-, pi-lens-2423-drain-, pi-lens-2423-insert-, pi-lens-2423-negative-, pi-lens-2423-noblock-, pi-lens-2423-nopreflight-, pi-lens-2423-registry-pro-, pi-lens-2423-registry-stale-, pi-lens-2423-replace-, pi-lens-2423-telemetry-
- tests/clients/mutation-attribution.test.ts: pi-lens-2430-badfile-, pi-lens-2430-persist-, pi-lens-2449-durable-
- tests/clients/mutation-bridge.test.ts: pi-lens-2423-bridge-, pi-lens-2423-bridge-register-, pi-lens-2423-bridge-scope-, pi-lens-2423-bridge-throw-, pi-lens-2423-bridge-write-, pi-lens-2465-no-read-guard-
- tests/clients/nested-ignore-freshness-clock.test.ts: pi-lens-2071-bounded-cost-, pi-lens-2071-divergence-, pi-lens-2071-drift-drop-, pi-lens-2071-mtime-axis-, pi-lens-2071-publish-order-, pi-lens-2071-rearm-, pi-lens-2071-single-stat-
- tests/clients/observed-mutation-integration.test.ts: pi-lens-2430-first-, pi-lens-2430-hotpath-, pi-lens-2430-persist-path-, pi-lens-2430-second-, pi-lens-2449-double-record-, pi-lens-2449-narrow-skip-, pi-lens-2449-settle-order-, pi-lens-2464-context-, pi-lens-2464-crash-, pi-lens-2464-dispatch-, pi-lens-2464-f1-concurrent-, pi-lens-2464-f1-eviction-, pi-lens-2464-f1-latch-, pi-lens-2464-f2-dir-, pi-lens-2464-postconditions-
- tests/clients/observed-mutation-net.test.ts: pi-lens-2430-abort-, pi-lens-2430-arm-, pi-lens-2430-attrib-, pi-lens-2430-budget-, pi-lens-2430-cap-, pi-lens-2430-charge-, pi-lens-2430-clean-, pi-lens-2430-gen-, pi-lens-2430-handled-, pi-lens-2430-hot-, pi-lens-2430-nowalk-, pi-lens-2430-ranges-, pi-lens-2430-refresh-, pi-lens-2430-reset-, pi-lens-2430-sweep-, pi-lens-2449-charge-, pi-lens-2449-deattrib-, pi-lens-2449-deattrib-gap-, pi-lens-2449-dir-, pi-lens-2449-dircap-, pi-lens-2449-handled-cap-, pi-lens-2449-incremental-, pi-lens-2449-linecount-, pi-lens-2449-linehash-abort-, pi-lens-2449-rangebudget-, pi-lens-2449-refresh-abort-, pi-lens-2449-refresh-scale-, pi-lens-2449-sametick-, pi-lens-2449-seed-, pi-lens-2449-settle-budget-, pi-lens-2449-sibling-, pi-lens-2449-touch-, pi-lens-2449-unverifiable-, pi-lens-2449-window-
- tests/clients/path-utils.test.ts: pi-lens-find-multi-, pi-lens-find-nearest-, pi-lens-find-none-, pi-lens-find-tool-config-, pi-lens-find-tool-config-homeceiling-, pi-lens-find-tool-config-mockedhome-, pi-lens-find-tool-config-nearest-, pi-lens-find-tool-config-none-, pi-lens-find-tool-config-order-, pi-lens-marker-root-, pi-lens-marker-root-boundary-, pi-lens-marker-root-boundary-same-, pi-lens-marker-root-home-, pi-lens-marker-root-none-, pi-lens-path-, pi-lens-walkup-
- tests/clients/pi-host-contract.test.ts: pi-lens-1655-f1-, pi-lens-1655-f1-silent-, pi-lens-1655-f2-, pi-lens-1655-f2-ok-, pi-lens-1655-item3-, pi-lens-1655-item5-, pi-lens-1655-item5-miss-, pi-lens-1655-item5-write-
- tests/clients/pipeline-eslint-autofix.test.ts: pi-lens-eslint-autofix-
- tests/clients/project-conventions.test.ts: pi-lens-conv-agentdocs-, pi-lens-conv-next-, pi-lens-conv-next-low-, pi-lens-conv-nopkg-, pi-lens-conv-plain-, pi-lens-conv-react-only-, pi-lens-conv-vite-react-
- tests/clients/project-ignore-freshness.test.ts: pi-lens-2159-cadence-, pi-lens-2159-delete-, pi-lens-2159-delete-ordering-, pi-lens-2159-external-, pi-lens-2159-ordering-, pi-lens-2159-settled-
- tests/clients/project-trust-install-bypasses.test.ts: pi-lens-trust-npx-
- tests/clients/read-expansion-enrichment.test.ts: pi-lens-enrich-flat-, pi-lens-enrich-hier-, pi-lens-enrich-timeout-
- tests/clients/read-expansion.test.ts: pi-lens-read-expansion-, pi-lens-read-expansion-ancestry-, pi-lens-read-expansion-limit-, pi-lens-read-expansion-md-, pi-lens-read-expansion-noancestry-, pi-lens-read-expansion-over-, pi-lens-read-expansion-overlap-
- tests/clients/read-guard-symbol-read.test.ts: pi-lens-guard-symbolread-, pi-lens-guard-symbolread-doc-
- tests/clients/read-guard-tool-lines.test.ts: pi-lens-2423-guard-, pi-lens-2423-pro-carried-, pi-lens-2423-pro-decimal-, pi-lens-2423-pro-insert-, pi-lens-2423-pro-replace-, pi-lens-2423-pro-reversed-, pi-lens-2423-pro-source-, pi-lens-2423-pro-stale-, pi-lens-blank-ambig-, pi-lens-blank-exact-, pi-lens-blank-extra-, pi-lens-blank-indent-, pi-lens-blank-missing-, pi-lens-blank-single-, pi-lens-didyoumean-, pi-lens-didyoumean-cjk-, pi-lens-didyoumean-cr-, pi-lens-didyoumean-none-, pi-lens-indent-2to-tab-, pi-lens-indent-4to-tab-, pi-lens-indent-match-, pi-lens-indent-mixed-to-tab-, pi-lens-indent-no-fix-, pi-lens-indent-resolve-, pi-lens-indent-tab-to-2-, pi-lens-indent-tab-to-4-, pi-lens-unicode-, pi-lens-unicode-ambig-, pi-lens-ws-ambig-, pi-lens-ws-operators-, pi-lens-ws-resolve-, pi-lens-ws-single-
- tests/clients/review-graph-persist.test.ts: pi-lens-graph-persist-
- tests/clients/review-graph-seq-fastpath.test.ts: pi-lens-seqfp-, pi-lens-seqfp-del-, pi-lens-seqfp-gen-, pi-lens-seqfp-kill-, pi-lens-seqfp-new-, pi-lens-seqfp-nohint-, pi-lens-seqfp-same-content-, pi-lens-seqfp-verify-
- tests/clients/review-graph-workspace-modules.test.ts: pi-lens-module-src-memo-clear-, pi-lens-module-src-memo-hit-, pi-lens-module-src-memo-ignore-, pi-lens-module-src-memo-same-tick-, pi-lens-module-src-memo-stale-, pi-lens-workspace-modules-files-, pi-lens-workspace-modules-pnpm-
- tests/clients/review-graph.service.test.ts: pi-lens-review-graph-, pi-lens-review-graph-cache-, pi-lens-review-graph-cap-, pi-lens-review-graph-cap-bound-, pi-lens-review-graph-cap-log-, pi-lens-review-graph-cap-under-, pi-lens-review-graph-cycle-, pi-lens-review-graph-ignore-gate-, pi-lens-review-graph-ignore-gate-nogit-, pi-lens-review-graph-incremental-, pi-lens-review-graph-javascript-, pi-lens-review-graph-langs-, pi-lens-review-graph-migrate-, pi-lens-review-graph-near-miss-, pi-lens-review-graph-notests-, pi-lens-review-graph-refs-, pi-lens-review-graph-resolution-, pi-lens-review-graph-resolve-, pi-lens-review-graph-scope-, pi-lens-review-graph-shared-, pi-lens-review-graph-source-memo-, pi-lens-review-graph-source-memo-clear-, pi-lens-review-graph-source-memo-eviction-, pi-lens-review-graph-source-memo-ghost-, pi-lens-review-graph-source-memo-scale-, pi-lens-review-graph-source-set-, pi-lens-review-graph-under-home-, pi-lens-review-graph-v3-migrate-, pi-lens-review-graph-v4-migrate-, pi-lens-review-graph-workspace-, pi-lens-review-graph-workspace-external-, pi-lens-review-graph-workspace-subpath-
- tests/clients/review-graph/import-resolvers.test.ts: pi-lens-import-resolve-
- tests/clients/review-graph/lsp-symbol-fallback.test.ts: pi-lens-graph-lsp-, pi-lens-graph-lsp-cold-, pi-lens-graph-lsp-flat-, pi-lens-graph-lsp-ir-empty-, pi-lens-graph-lsp-productive-
- tests/clients/review-graph/stage-sweep.test.ts: pi-lens-stage-sweep-
- tests/clients/review-graph/symbol-id.test.ts: pi-lens-symbol-collision-
- tests/clients/review-graph/tsconfig-paths.test.ts: pi-lens-tsconfig-paths-
- tests/clients/runner-availability-negative-convergence.test.ts: pi-lens-2252-globs-, pi-lens-2252-globs-cache-, pi-lens-2252-globs-unparse-, pi-lens-2252-runner-
- tests/clients/runtime-context-provenance.test.ts: pi-lens-advisory-
- tests/clients/runtime-coordinator-dependency-drift-cap.test.ts: pi-lens-1950-missing-, pi-lens-1950-notstale-, pi-lens-1950-peek-, pi-lens-1950-retire-, pi-lens-1950-wrongreason-
- tests/clients/runtime-event-flow.test.ts: pi-lens-event-flow-
- tests/clients/runtime-session-cascade-tier-reset.test.ts: pi-lens-cascade-tier-reset-
- tests/clients/runtime-session-quick-mode-observability.test.ts: pi-lens-quick-mode-obs-
- tests/clients/runtime-session-scan-cache.test.ts: pi-lens-scan-cache-, pi-lens-scan-cache-corrupt-, pi-lens-scan-cache-expired-, pi-lens-scan-cache-neg-, pi-lens-scan-cache-quick-, pi-lens-scan-cache-quick-warmup-
- tests/clients/runtime-session-sequence-read-budget.test.ts: pi-lens-seq-budget-advance-, pi-lens-seq-budget-fast-, pi-lens-seq-budget-print-, pi-lens-seq-budget-retro-stale-, pi-lens-seq-budget-seq0-, pi-lens-seq-budget-slow-
- tests/clients/runtime-session-snapshot-gate.test.ts: pi-lens-meta-gate-fresh-, pi-lens-meta-gate-full-, pi-lens-meta-gate-legacy-, pi-lens-meta-gate-stale-, pi-lens-meta-gate-version-
- tests/clients/runtime-session.test.ts: pi-lens-env-override-startup-mode-, pi-lens-mcp-startup-mode-, pi-lens-runtime-session-, pi-lens-startup-config-mode-, pi-lens-startup-config-precedence-, pi-lens-startup-defaults-, pi-lens-startup-env-precedence-, pi-lens-startup-project-precedence-, pi-lens-startup-scans-disabled-, pi-lens-tui-startup-mode-
- tests/clients/runtime-tool-call.test.ts: pi-lens-2402-bookkeeping-, pi-lens-2402-committed-, pi-lens-2402-first-, pi-lens-2402-full-retry-, pi-lens-2402-normalized-, pi-lens-2402-retry-, pi-lens-2423-f5-anchor-memo-, pi-lens-2726-heredoc-git-, pi-lens-2726-heredoc-guard-, pi-lens-2726-heredoc-operator-, pi-lens-runtime-tool-call-complexity-, pi-lens-runtime-tool-call-dupe-, pi-lens-runtime-tool-call-edit-, pi-lens-runtime-tool-call-expansion-, pi-lens-runtime-tool-call-poisoned-, pi-lens-runtime-tool-call-read-, pi-lens-runtime-tool-call-write-
- tests/clients/runtime-tool-result-debounce.test.ts: pi-lens-debounce-bogus-env-, pi-lens-debounce-coalesce-, pi-lens-debounce-disabled-, pi-lens-debounce-flush-, pi-lens-debounce-spaced-, pi-lens-flush-spelling-, pi-lens-inflight-hash-axis-, pi-lens-inflight-spelling-
- tests/clients/runtime-tool-result.test.ts: pi-lens-1603-removal-, pi-lens-1603-rewrite-, pi-lens-1603-tool-result-, pi-lens-2071-tool-result-, pi-lens-2802-bash-cap-, pi-lens-2802-multi-span-clip-, pi-lens-2802-native-read-eof-, pi-lens-2802-native-supersession-, pi-lens-2802-opaque-noop-, pi-lens-2802-pipe-fallback-, pi-lens-2802-unknown-authorship-, pi-lens-attribution-block-clear-, pi-lens-attribution-divergence-, pi-lens-attribution-miss-, pi-lens-attribution-verified-, pi-lens-bash-failed-grep-, pi-lens-bash-read-result-, pi-lens-bash-rm-burst-, pi-lens-bash-rm-failed-, pi-lens-bash-rm-known-, pi-lens-bash-rm-no-lsp-, pi-lens-bash-rm-noop-, pi-lens-bash-rm-unknown-, pi-lens-correlation-callid-, pi-lens-grep-context-credit-, pi-lens-grep-search-reads-, pi-lens-monorepo-cwd-, pi-lens-monorepo-dispatch-, pi-lens-native-edit-failed-, pi-lens-native-edit-hash-, pi-lens-new-file-pipeline-, pi-lens-out-of-order-, pi-lens-runtime-tool-, pi-lens-runtime-tool-bash-budget-, pi-lens-runtime-tool-bash-edit-, pi-lens-runtime-tool-bash-write-, pi-lens-runtime-tool-change-log-, pi-lens-runtime-tool-crash-reset-, pi-lens-runtime-tool-dedupe-, pi-lens-runtime-tool-deferred-format-, pi-lens-runtime-tool-fixed-alias-, pi-lens-runtime-tool-format-queued-, pi-lens-runtime-tool-immediate-format-, pi-lens-runtime-tool-large-content-, pi-lens-runtime-tool-path-, pi-lens-runtime-tool-post-mutation-, pi-lens-runtime-tool-primary-crash-, pi-lens-runtime-tool-secondary-crash-, pi-lens-runtime-tool-side-effect-, pi-lens-turn-summary-off-, pi-lens-turn-summary-on-, pi-lens-worktree-attribution-
- tests/clients/runtime-turn-dead-code.test.ts: pi-lens-dead-code-malformed-, pi-lens-dead-code-turn-
- tests/clients/runtime-turn-secrets-disposition.test.ts: pi-lens-turnend-govulncheck-, pi-lens-turnend-secrets-, pi-lens-turnend-secrets-stale-gitleaks-, pi-lens-turnend-secrets-stale-trivy-, pi-lens-turnend-trivy-cve-, pi-lens-turnend-trivy-secrets-
- tests/clients/runtime-turn-session.test.ts: pi-lens-beginturn-blockers-, pi-lens-callgraph-mixed-, pi-lens-callgraph-only-, pi-lens-callgraph-partial-, pi-lens-callgraph-same-file-, pi-lens-callgraph-testrole-mixed-, pi-lens-callgraph-testrole-only-, pi-lens-consume-blockers-, pi-lens-ctx-frame-, pi-lens-ctx-guidance-, pi-lens-ctx-test-, pi-lens-dedup-cross-, pi-lens-dedup-same-, pi-lens-foreign-live-, pi-lens-idle-budget-, pi-lens-idle-error-, pi-lens-idle-error-reporter-, pi-lens-idle-generation-, pi-lens-idle-primary-, pi-lens-idle-secondary-, pi-lens-knip-availability-, pi-lens-knip-backoff-, pi-lens-knip-cache-keep-, pi-lens-knip-delta-, pi-lens-knip-shift-, pi-lens-license-, pi-lens-no-stamp-, pi-lens-resolved-blocker-, pi-lens-same-session-, pi-lens-secret-collapse-, pi-lens-secret-legacy-nested-, pi-lens-stale-evict-, pi-lens-stamp-, pi-lens-trivy-age-, pi-lens-trivy-age-unknown-, pi-lens-turn-seq-report-, pi-lens-unresolved-blocker-
- tests/clients/runtime-turn-test-runner-bounds.test.ts: pi-lens-2504-runner-
- tests/clients/session-lifecycle.test.ts: pi-lens-concurrent-secondary-, pi-lens-guard-disabled-
- tests/clients/session-start-total-classification.test.ts: pi-lens-session-start-total-omit-, pi-lens-session-start-total-quick-
- tests/clients/spawn-timeout-cooldown.test.ts: pi-lens-timeout-autofix-guard-, pi-lens-timeout-autofix-note-, pi-lens-timeout-lint-guard-, pi-lens-timeout-lint-note-
- tests/clients/startup-overhead.test.ts: pi-lens-overhead-boundary-, pi-lens-overhead-full-, pi-lens-overhead-once-, pi-lens-overhead-quick-, pi-lens-overhead-records-
- tests/clients/startup-scan-symlink-cycle.test.ts: pi-lens-symlink-async-, pi-lens-symlink-async-home-, pi-lens-symlink-mutual-, pi-lens-symlink-mutual-home-, pi-lens-symlink-outside-, pi-lens-symlink-self-, pi-lens-symlink-self-home-, pi-lens-symlink-subtree-, pi-lens-symlink-subtree-home-
- tests/clients/startup-scan-verdict-cache.test.ts: pi-lens-early-exit-, pi-lens-exact-count-, pi-lens-scan-stamp-, pi-lens-scan-stamp-async-
- tests/clients/terragrunt-filenames.test.ts: pi-lens-terragrunt-sst-
- tests/clients/test-runner-client.test.ts: pi-lens-2522-, pi-lens-2522-p3c-, pi-lens-2522-r2-, pi-lens-resolve-exec-, pi-lens-tests-, pi-lens-tests-2044-, pi-lens-tests-2044-cold-, pi-lens-tests-2044-first-, pi-lens-tests-2044-hot-, pi-lens-tests-2044-second-
- tests/clients/test-utils-ownership.test.ts: pi-lens-ownership-setup-
- tests/clients/tool-policy-conventions.test.ts: pi-lens-tool-policy-conventions-
- tests/clients/tool-policy.test.ts: pi-lens-java-classes-, pi-lens-java-descriptor-, pi-lens-java-none-, pi-lens-tflint-policy-none-, pi-lens-tflint-policy-root-, pi-lens-tool-policy-, pi-lens-tool-policy-biome-walkup-, pi-lens-tool-policy-black-walkup-, pi-lens-tool-policy-detekt-walkup-, pi-lens-tool-policy-eslint-pkg-walkup-, pi-lens-tool-policy-eslint-walkup-, pi-lens-tool-policy-fmt-config-walkup-, pi-lens-tool-policy-ktfmt-absent-, pi-lens-tool-policy-ktfmt-gradle-, pi-lens-tool-policy-ktfmt-marker-, pi-lens-tool-policy-more-config-, pi-lens-tool-policy-mypy-walkup-, pi-lens-tool-policy-nearest-pkg-, pi-lens-tool-policy-oxfmt-svelte-false-, pi-lens-tool-policy-oxfmt-svelte-generic-toml-, pi-lens-tool-policy-oxfmt-svelte-json-, pi-lens-tool-policy-oxfmt-svelte-noflag-, pi-lens-tool-policy-oxfmt-svelte-nopackage-, pi-lens-tool-policy-oxfmt-svelte-toml-, pi-lens-tool-policy-oxfmt-svelte-toml-comment-, pi-lens-tool-policy-oxlint-config-mts-walkup-, pi-lens-tool-policy-oxlint-config-ts-walkup-, pi-lens-tool-policy-oxlint-jsonc-walkup-, pi-lens-tool-policy-oxlint-walkup-, pi-lens-tool-policy-prettier-false-, pi-lens-tool-policy-prettier-null-, pi-lens-tool-policy-prettier-walkup-, pi-lens-tool-policy-ruff-walkup-pyproject-, pi-lens-tool-policy-ruff-walkup-toml-, pi-lens-tool-policy-spotless-disabled-, pi-lens-tool-policy-spotless-ktfmt-, pi-lens-tool-policy-spotless-ktlint-, pi-lens-tool-policy-spotless-lexical-, pi-lens-tool-policy-spotless-memo-, pi-lens-tool-policy-spotless-settings-, pi-lens-tool-policy-stylelint-walkup-, pi-lens-tool-policy-vite-plus-
- tests/clients/topology-derived-cache-rearm.test.ts: pi-lens-topology-language-, pi-lens-topology-live-session-, pi-lens-topology-startup-, pi-lens-topology-tsconfig-
- tests/clients/tracked-aware-ignore-matcher.test.ts: pi-lens-tracked-ignore-, pi-lens-tracked-ignore-case-, pi-lens-tracked-ignore-negation-, pi-lens-tracked-ignore-nogit-, pi-lens-tracked-ignore-pilens-, pi-lens-tracked-ignore-sep-, pi-lens-tracked-ignore-unprimed-, pi-lens-tracked-ignore-untracked-, pi-lens-tracked-ignore-walk-
- tests/clients/tree-sitter-abort-degrade.test.ts: pi-lens-tsabort-mr-, pi-lens-tsabort-rg-
- tests/clients/tree-sitter-cache.test.ts: pi-lens-tccache-del-, pi-lens-tccache-grow-, pi-lens-tccache-lru-, pi-lens-tccache-mtime-, pi-lens-tccache-nospan-, pi-lens-tccache-refresh-, pi-lens-tccache-save-, pi-lens-tccache-scanreuse-, pi-lens-tccache-shrink-, pi-lens-tccache-stats-, pi-lens-tccache-zerofloor-
- tests/clients/tree-sitter-client-init.test.ts: pi-lens-tree-sitter-2112-asset-, pi-lens-tree-sitter-2112-cwd-, pi-lens-tree-sitter-2112-package-
- tests/clients/tree-sitter-lua-shared-module.test.ts: pi-lens-lua255-, pi-lens-yaml427-
- tests/clients/tree-sitter-python-rules.test.ts: pi-lens-python-rules-
- tests/clients/tree-sitter-query-batch.test.ts: pi-lens-884-rules-, pi-lens-batch-bad-, pi-lens-batch-bound-, pi-lens-batch-cap-, pi-lens-batch-eq-, pi-lens-batch-eviction-, pi-lens-batch-filter-, pi-lens-batch-perm-, pi-lens-batch-retry-
- tests/clients/tree-sitter-ruby-rules.test.ts: pi-lens-ruby-rules-
- tests/clients/tree-sitter-shared.test.ts: pi-lens-tscache-, pi-lens-tscache-x-, pi-lens-tsevict-
- tests/clients/tree-sitter-sonar-rules.test.ts: pi-lens-sonar-ts-rules-
- tests/clients/tree-sitter-symbols.test.ts: pi-lens-export-scope-, pi-lens-visibility-, pi-lens-visibility-py-
- tests/clients/turn-state-stale-gate.test.ts: pi-lens-2504-gate-
- tests/clients/widget-dependency-drift-delivery-cap.test.ts: pi-lens-2275-cap-, pi-lens-2275-headless-, pi-lens-2275-quiet-, pi-lens-2275-three-
- tests/clients/word-index-cap-bound-refresh.test.ts: pi-lens-word-cap-bound-
- tests/clients/word-index-cooperative-occupancy.test.ts: pi-lens-word-preflight-occupancy-
- tests/clients/word-index-lifecycle.test.ts: pi-lens-wordindex-fallback-, pi-lens-wordindex-full-absent-, pi-lens-wordindex-full-fresh-, pi-lens-wordindex-full-stale-, pi-lens-wordindex-warmup-
- tests/clients/word-index-mtime-preserved-freshness.test.ts: pi-lens-word-legacy-badsize-, pi-lens-word-legacy-nosize-, pi-lens-word-mtime-preserved-, pi-lens-word-mtime-preserved-rt-
- tests/clients/word-index-observability.test.ts: pi-lens-word-cold-, pi-lens-word-persist-fail-, pi-lens-word-persist-ok-, pi-lens-word-recompact-async-, pi-lens-word-recompact-log-, pi-lens-word-refused-, pi-lens-word-replacement-reset-, pi-lens-word-skip-
- tests/clients/word-index-path-divergence.test.ts: pi-lens-wi-refresh-divergence-
- tests/clients/word-index-persist.test.ts: pi-lens-word-index-persist-
- tests/clients/word-index-refresh-performance.test.ts: pi-lens-word-refresh-perf-
- tests/clients/word-index-session-refresh.test.ts: pi-lens-word-refresh-budget-, pi-lens-word-refresh-cap-, pi-lens-word-refresh-delete-, pi-lens-word-refresh-dense-, pi-lens-word-refresh-epoch-, pi-lens-word-refresh-reuse-preflight-, pi-lens-word-refresh-scaled-dense-, pi-lens-word-refresh-stale-, pi-lens-word-refresh-stale-window-, pi-lens-word-refresh-superseded-, pi-lens-word-refresh-threshold-, pi-lens-word-refresh-threshold-over-, pi-lens-word-refresh-unreadable-
- tests/clients/word-index-stat-concurrency.test.ts: pi-lens-word-stat-concurrency-, pi-lens-word-stat-order-, pi-lens-word-stat-reject-, pi-lens-word-stat-supersession-
- tests/clients/word-index-vanish-before-read.test.ts: pi-lens-word-vanish-read-
- tests/clients/word-index.test.ts: pi-lens-wordindex-cold-, pi-lens-wordindex-failed-, pi-lens-wordindex-preserve-, pi-lens-wordindex-recompact-, pi-lens-wordindex-stampede-, pi-lens-wordindex-under-home-, pi-lens-wordindex-unsafe-root-
- tests/clients/workspace-topology.test.ts: pi-lens-workspace-topology-
- tests/clients/write-autofix-attachment-message.test.ts: pi-lens-1590-aggregate-, pi-lens-1590-attached-, pi-lens-1590-none-, pi-lens-1590-size-capped-
- tests/clients/write-autofix-nudge-suppression.test.ts: pi-lens-1464-aggregate-, pi-lens-1464-attached-, pi-lens-1464-deferred-, pi-lens-1464-size-capped-
- tests/monorepo/pnpm-symlink.test.ts: pi-lens-pnpm-symlink-outside-
- tests/scripts/lint-js.test.ts: pi-lens-lint-js-2439-, pi-lens-lint-js-2454-mutation-
- tests/support/real-runner-ctx.ts: pi-lens-real-
- tests/tools/module-report.test.ts: pi-lens-modreport-tool-, pi-lens-readenc-tool-, pi-lens-readsym-tool-
- tests/tools/project-report.test.ts: pi-lens-projreport-entry-budget-, pi-lens-projreport-tool-
- tests/tools/symbol-search.test.ts: pi-lens-symbolsearch-capped-, pi-lens-symbolsearch-cold-, pi-lens-symbolsearch-failed-, pi-lens-symbolsearch-graphcold-, pi-lens-symbolsearch-graphwarm-, pi-lens-symbolsearch-lang-, pi-lens-symbolsearch-nofilter-, pi-lens-symbolsearch-nomatch-, pi-lens-symbolsearch-paths-, pi-lens-symbolsearch-queryfile-, pi-lens-symbolsearch-querylang-, pi-lens-symbolsearch-querynofilter-, pi-lens-symbolsearch-queryunknown-, pi-lens-symbolsearch-suggestednext-, pi-lens-symbolsearch-warm-
The remaining producers are covered by one of the five sweep stems or one of the 36 baseline admissions. Consolidation verdict: keep cleanup distributed by owning family; a process-wide hook is an explicit non-goal because separate Vitest module instances share /tmp.

## Tests

Pre-fix combined red: the hygiene suite reported one leaked pi-lens-warmup-oneshot-interactive-Wv1yqT entry while the pair had 10 passing tests.

Post-fix combined repetitions:
- Run 1: 2 files passed, 10 tests passed, exit 0.
- Run 2: 2 files passed, 10 tests passed, exit 0.
- Run 3: 2 files passed, 10 tests passed, exit 0.

Mutation: changed the compile-valid intermediate cleanup behavior to untrack: true, rebuilt successfully, and ran five combined repetitions. All five stayed green, so this pair cannot observe that mutation because the project-snapshot drain settles the persistence before the first sweep. No mutation red exists to quote; this is an observed limitation, not a claimed guard proof.

## Blast radius

Only tests/clients/runtime-session-warmup-oneshot.test.ts changes. The added imports call the existing project-snapshot test drain and test-utils family cleanup helper. Production runtime, shared cleanup semantics, and the hygiene baseline remain unchanged.

## Observability

No new failure path; no record added.

## Test assessment

The existing warmup characterization test remains real-path coverage through handleSessionStart, saveRuntimeProjectSnapshot, and the actual tracked-environment cleanup helper. The edit adds lifecycle cleanup coverage for the three warmup one-shot producer prefixes.

## Verification

- git rev-parse HEAD matched origin/master: exit 0.
- npm run build: exit 0 before the first test run.
- tests/config/ Vitest population: 54 files, 477 passed, 1 skipped; exit 0.
- npx tsc --noEmit: exit 0.
- npm run fmt:check: exit 0.
- Final npm run build: exit 0.
- Final combined run 1: exit 0.
- Final combined run 2: exit 0.
- Final combined run 3: exit 0.
- Mutation build: exit 0.
- Mutation combined repetitions 1–5: exit 0 each.
- npm run preflight: all 13 gates passed in the final table; exit 0.

## Skipped

No full 1,095-file population, CI read, or sub-agent run was performed.
