### PR TITLE
test(hygiene): the #2992 probe home lives in the worktree, not /tmp (refs #2912)

### DIFF
--- a/.changelog/test-3003-2992-probe-home-out-of-tmp.md
+++ b/.changelog/test-3003-2992-probe-home-out-of-tmp.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Keep the #2992 regression probe out of system temp (refs #2912)** — the read-bridge lifecycle test stores its ledger home under the ignored worktree-local `.probe-home` directory, so asynchronous bookkeeping cannot recreate a leaked top-level `/tmp` fixture.

--- a/tests/index-2992-integration.test.ts
+++ b/tests/index-2992-integration.test.ts
@@ -1,10 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	cleanupTestEnvironments,
-	setupTestEnvironment,
-} from "./clients/test-utils.js";
+import { removeTempDirSync } from "./clients/test-utils.js";
 import { createPiMock, makeCtx } from "./support/pi-mock.js";
 
 describe("#2992 read bridge lifecycle", () => {
@@ -12,7 +9,11 @@ describe("#2992 read bridge lifecycle", () => {
 	let filePath: string;
 
 	beforeEach(() => {
-		probeHome = setupTestEnvironment("pi-lens-2992-home-").tmpDir;
+		const probeRoot = path.join(process.cwd(), ".probe-home");
+		fs.mkdirSync(probeRoot, { recursive: true });
+		probeHome = path.join(probeRoot, "pi-lens-2992-home");
+		removeTempDirSync(probeHome);
+		fs.mkdirSync(probeHome, { recursive: true });
 		process.env.PI_LENS_HOME = probeHome;
 		filePath = path.join(process.cwd(), "index-2992-probe.ts");
 		fs.writeFileSync(filePath, "export const guarded = true;\n");
@@ -22,9 +23,7 @@ describe("#2992 read bridge lifecycle", () => {
 		fs.rmSync(filePath, { force: true });
 		for (let tick = 0; tick < 3; tick++) {
 			await new Promise<void>((resolve) => setImmediate(resolve));
-			cleanupTestEnvironments("pi-lens-2992-home-", {
-				untrack: tick === 2,
-			});
+			removeTempDirSync(probeHome);
 		}
 		vi.restoreAllMocks();
 	});


### PR DESCRIPTION
Refs #2912

## Summary

Move the #2992 integration test home from `/tmp` to ignored worktree-local `.probe-home`. Keep the real extension, read guard, ledger, and host-boundary staleness injection unchanged.

## Premise

Verified `tests/config/tmp-fixture-hygiene.test.ts`: `tmpHygieneLeakReport()` compares top-level entries from the run-wide `os.tmpdir()` baseline, and the scanner does not recurse into worktree-local paths. The pre-fix paired reproduction was clean locally, so the schedule-dependent CI leak was not reproduced here.

```text
Test Files  2 passed (2)
Tests       10 passed (10)
exit code: 0
```

## The fix

Use `.probe-home/pi-lens-2992-home` as the per-test `PI_LENS_HOME`, create it before each test, and remove it through `removeTempDirSync` during the existing three-tick cleanup. This removes the `/tmp` exposure. Another drain tick would only move the asynchronous recreation race, and an admission would hide a leak that the test can avoid.

The cwd probe files are not covered by `.gitignore`, but `afterEach` already removes both `index-2992-probe.ts` and `index-2992-recovered.ts`. No second persistent hygiene or Git-ignore issue remains.

## The proof still holds

Mutated built `index.js` `getBridgeFlag` stale fallback from `undefined` to `true`. The authorization test remained red:

```text
AssertionError: expected { block: true, …(1) } to be undefined
Edit without read: you have not read `/home/akis/.plegma/work/sub-mtyfitru-202/index-2992-probe.ts`
mutation exit code: 1
```

## Tests

The combined pair was run eight times after the fix. Every repetition passed:

```text
1: 2 files, 10 tests, exit code 0
2: 2 files, 10 tests, exit code 0
3: 2 files, 10 tests, exit code 0
4: 2 files, 10 tests, exit code 0
5: 2 files, 10 tests, exit code 0
6: 2 files, 10 tests, exit code 0
7: 2 files, 10 tests, exit code 0
8: 2 files, 10 tests, exit code 0
```

Edited `tests/index-2992-integration.test.ts` to pin the home locally and retain cleanup. The repetitions pin the recurrence: asynchronous ledger recreation must not create a top-level `/tmp` entry.

## Blast radius

This is test-only. The changed call tree is:

```text
tests/index-2992-integration.test.ts
  beforeEach -> removeTempDirSync -> fs.rmSync
  afterEach  -> removeTempDirSync -> fs.rmSync
```

No production modules, runtime entry points, or shared behavior change. The population sweep found no other use of the `pi-lens-2992-home-` prefix.

## Class sweep

The sweep covered `setupTestEnvironment`, `cleanupTestEnvironments`, `PI_LENS_HOME`, and `pi-lens-2992-home-` references in the test tree. Only this regression file used the affected prefix; the shared scanner and five admitted families remain unchanged.

## Observability

No new failure path; no record added.

## Test assessment

The edited test continues to use the real extension factory, real `ReadGuard`, real ledger, and real bridge. Only the host `getFlag` boundary injects staleness. The test does not replace an in-process runtime or store with a fake.

## Verification

Commands ran with `PI_LENS_HOME=$PWD/.probe-home`; no `PILENS_DATA_DIR` was set:

```text
npm run build: exit code 0
paired reproduction: exit code 0 (clean; not reproduced locally)
npm run build after fix: exit code 0
targeted sibling suites: 4 files, 128 tests passed, exit code 0
tests/config: 54 files, 477 passed, 1 skipped, exit code 0
acceptance mutation: exit code 1, expected red
npx tsc --noEmit: exit code 0
npm run fmt:check: exit code 0
npm run preflight: exit code 0
```

## Skipped

The full 1,095-file population was not run. CI status was not read.
