### PR TITLE
test(hygiene): the #2992 probe restores PI_LENS_HOME instead of leaking it into the worker (refs #2912)

### DIFF
--- a/.changelog/2912-home-env-restore.md
+++ b/.changelog/2912-home-env-restore.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- **Restore the probe home environment after the #2992 integration tests (refs #2912)** — prevent later tests from inheriting the stable probe registry path.
+- **Isolate registry consumers and restore probe-home state (refs #2912)** — prevent later tests from inheriting the #2992 probe registry and keep PID-scoped root assertions independent of worker history.

--- a/.changelog/2912-home-env-restore.md
+++ b/.changelog/2912-home-env-restore.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Restore the probe home environment after the #2992 integration tests (refs #2912)** — prevent later tests from inheriting the stable probe registry path.

--- a/tests/index-2992-integration.test.ts
+++ b/tests/index-2992-integration.test.ts
@@ -3,6 +3,10 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { removeTempDirSync } from "./clients/test-utils.js";
 import { createPiMock, makeCtx } from "./support/pi-mock.js";
+import {
+	_settleRegistryMutationsForTests,
+	deregisterInstance,
+} from "../clients/instance-registry.js";
 
 const workerHome = process.env.PI_LENS_HOME;
 
@@ -33,6 +37,12 @@ describe("#2992 read bridge lifecycle", () => {
 			await new Promise<void>((resolve) => setImmediate(resolve));
 			removeTempDirSync(probeHome);
 		}
+		// #2912 recurrence: session_start queues registerInstance without
+		// awaiting it. Drain and remove that test-owned PID entry before the
+		// home restore, or a reused Vitest worker leaks this root to the next
+		// file's PID-scoped registry assertion.
+		await _settleRegistryMutationsForTests();
+		deregisterInstance();
 		if (previousHome === undefined) delete process.env.PI_LENS_HOME;
 		else process.env.PI_LENS_HOME = previousHome;
 		vi.restoreAllMocks();

--- a/tests/index-2992-integration.test.ts
+++ b/tests/index-2992-integration.test.ts
@@ -4,11 +4,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { removeTempDirSync } from "./clients/test-utils.js";
 import { createPiMock, makeCtx } from "./support/pi-mock.js";
 
+const workerHome = process.env.PI_LENS_HOME;
+
 describe("#2992 read bridge lifecycle", () => {
 	let probeHome: string;
 	let filePath: string;
+	let previousHome: string | undefined;
+	let homeAtSetup: string | undefined;
+	let setupCount = 0;
 
 	beforeEach(() => {
+		homeAtSetup = process.env.PI_LENS_HOME;
+		previousHome = process.env.PI_LENS_HOME;
+		setupCount++;
 		const probeRoot = path.join(process.cwd(), ".probe-home");
 		fs.mkdirSync(probeRoot, { recursive: true });
 		probeHome = path.join(probeRoot, "pi-lens-2992-home");
@@ -25,6 +33,8 @@ describe("#2992 read bridge lifecycle", () => {
 			await new Promise<void>((resolve) => setImmediate(resolve));
 			removeTempDirSync(probeHome);
 		}
+		if (previousHome === undefined) delete process.env.PI_LENS_HOME;
+		else process.env.PI_LENS_HOME = previousHome;
 		vi.restoreAllMocks();
 	});
 
@@ -219,5 +229,12 @@ describe("#2992 read bridge lifecycle", () => {
 				deferAutofix: false,
 			}),
 		).toBe(false);
+	});
+
+	it("keeps the next test from inheriting PI_LENS_HOME (#2912)", () => {
+		// #2912 recurrence: a cross-test PI_LENS_HOME leak redirects the real
+		// instance registry and makes an unrelated worker observe an extra root.
+		expect(setupCount).toBeGreaterThan(1);
+		expect(homeAtSetup).toBe(workerHome);
 	});
 });

--- a/tests/index-multi-root-session-start.test.ts
+++ b/tests/index-multi-root-session-start.test.ts
@@ -63,29 +63,43 @@ async function rootsForThisPid(): Promise<string[]> {
 	return entry ? getInstanceRoots(entry) : [];
 }
 
+const testRegistryHome = path.join(
+	process.cwd(),
+	".probe-home",
+	"index-multi-root-session-start",
+);
+const workerHome = process.env.PI_LENS_HOME;
+
 describe("session_start keys on the project root (#2129 wiring)", () => {
 	let hostRoot: string;
 	let tempWorktree: string;
+	let previousHome: string | undefined;
 
 	beforeEach(async () => {
+		previousHome = process.env.PI_LENS_HOME;
+		fs.mkdirSync(path.dirname(testRegistryHome), { recursive: true });
+		removeTempDirSync(testRegistryHome);
+		fs.mkdirSync(testRegistryHome, { recursive: true });
+		process.env.PI_LENS_HOME = testRegistryHome;
 		_resetSessionLifecycleForTests();
-		// The registry entry is keyed by pid, so it survives between tests in
-		// this file and roots would accumulate across them. Drain first: a
-		// previous test's fire-and-forget writes would otherwise land AFTER this
-		// deregistration and resurrect its roots inside this test.
+		// The registry entry is keyed by pid. Drain first: a previous test's
+		// fire-and-forget writes would otherwise land AFTER this deregistration
+		// and resurrect its roots inside this test.
 		await new Promise<void>((resolve) => setImmediate(resolve));
 		await settleRegistryWrites();
 		deregisterInstance();
-		// The deregistration itself is queued. Drain it before creating the
-		// next roots, or a prior worker write can re-add an old root after the
-		// new session has started (#2130).
 		await settleRegistryWrites();
 		hostRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-host-root-"));
 		tempWorktree = fs.mkdtempSync(path.join(os.tmpdir(), "pi-agent-worktree-"));
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		_resetSessionLifecycleForTests();
+		await settleRegistryWrites();
+		deregisterInstance();
+		await settleRegistryWrites();
+		if (previousHome === undefined) delete process.env.PI_LENS_HOME;
+		else process.env.PI_LENS_HOME = previousHome;
 		removeTempDirSync(hostRoot);
 		removeTempDirSync(tempWorktree);
 	});
@@ -173,6 +187,26 @@ describe("session_start keys on the project root (#2129 wiring)", () => {
 		);
 
 		expect(await rootsForThisPid()).toHaveLength(2);
+	}, 30_000);
+
+	it("does not count a root from the worker registry (#2130)", async () => {
+		if (!workerHome) throw new Error("Vitest did not provide PI_LENS_HOME");
+		const previousHome = process.env.PI_LENS_HOME;
+		process.env.PI_LENS_HOME = workerHome;
+		try {
+			await registerInstance("/foreign-worker-root");
+			await settleRegistryWrites();
+			if (previousHome === undefined) delete process.env.PI_LENS_HOME;
+			else process.env.PI_LENS_HOME = previousHome;
+			expect(await rootsForThisPid()).toEqual([]);
+		} finally {
+			process.env.PI_LENS_HOME = workerHome;
+			await settleRegistryWrites();
+			deregisterInstance();
+			await settleRegistryWrites();
+			if (previousHome === undefined) delete process.env.PI_LENS_HOME;
+			else process.env.PI_LENS_HOME = previousHome;
+		}
 	}, 30_000);
 
 	it("a declined temp root still registers itself in instances.json (#2130)", async () => {


### PR DESCRIPTION
Refs #2912

## Summary

Round 3 isolates `tests/index-multi-root-session-start.test.ts` from the reused Vitest worker's PID-scoped instance registry. The test now uses a worktree-local `PI_LENS_HOME`, drains and deregisters its own entry, and restores the worker home after teardown.

The decision follows the test's intended contract: a secondary sharing the host root must not remove the host root. The assertion concerns the roots created by this test, not a global claim that no other file registered a root. Isolation preserves the two-root and same-root behavior while removing an unbounded dependency on every producer that shares the worker.

The round-1 structural-fix claim was disproven. Round 1's `PI_LENS_HOME` restore and round 2's drain plus `deregisterInstance()` remain correct hygiene, but neither establishes that the next consumer observes only its own roots. The hypothesis is not described as confirmed until the final probe passed; the final probe passed 30/30 after this consumer-side change.

## Tests

- `tests/index-multi-root-session-start.test.ts`: 8 passed standalone, including `does not count a root from the worker registry (#2130)`.
- `tests/index-2992-integration.test.ts`: 4 passed standalone.
- Ordered pair `tests/index-2992-integration.test.ts tests/index-multi-root-session-start.test.ts`: 30 consecutive runs, every run passed with exit code 0. Runs 1–30: PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS, PASS.
- Registry and configuration population: 69 files, 684 tests; 671 passed, 1 skipped, and 12 failed in environment-dependent tests. The failures were `git init` exit 128 in real-git fixtures and missing built `dist/clients/lsp/config.js` in `lsp-fixture-workspace`; no product assertion failed.
- `npx tsc --noEmit`: passed.
- `npm run fmt:check`: passed.
- `npm run preflight`: passed locally. The table reported pass for build, lint, fmt:check, changelog:check, tests/config, lsp-spawn-heavy-coverage, ci-verdict, and advisory knip.
- Full 1,095-file population: skipped as instructed.

Mutation proofs:

- Removing the consumer's `process.env.PI_LENS_HOME = testRegistryHome` assignment reds `does not count a root from the worker registry (#2130)` with `expected [ '/foreign-worker-root' ] to deeply equal []`.
- Mutating `getBridgeFlag`'s stale fallback from `return undefined` to `return true` reds `tests/index-2992-integration.test.ts` on `index-2992-probe.ts`: `expected { block: true, ... } to be undefined`.

## Blast radius

The production activation and instance-registry implementations are unchanged. The test-only blast radius is the registry home used by the multi-root session-start harness.

Call-tree diff:

```text
index-multi-root-session-start.test.ts
- beforeEach -> shared worker PI_LENS_HOME -> PID-scoped instances.json
+ beforeEach -> worktree-local testRegistryHome -> PID-scoped instances.json
+ afterEach -> settle -> deregister -> restore previous PI_LENS_HOME
  rootsForThisPid -> readInstanceRegistry -> getInstanceRoots
```

No production failure path or new telemetry record was added.

## Class sweep

The requested `rg -l 'rootsForThisPid|registerInstance|deregisterInstance|instances.json' tests/` sweep found 22 paths: 18 runnable test files, 2 fixture modules, 1 fixture corpus, and `tests/support/vitest-setup.ts`. The runnable population and every file under `tests/config/` were executed together. Existing per-test `PI_LENS_HOME` save/restore patterns were reused; no shared helper was introduced.

The prior round's arithmetic claim that 242 files assign `process.env` and 234 restore it is removed rather than repeated: it was not a sufficient classification of the registry-consumer seam. This round reports the directly relevant 22-path sweep and its 69-file runnable execution instead of an unsupported eight-file remainder.

## Observability

No new failure path was added; no record added. The existing bounded `extension-ctx-stale` record remains covered by the real #2992 bridge test and its stale-fallback mutation.

## Test assessment

The new isolation case uses the real instance registry and real file-backed `instances.json`. It temporarily registers `/foreign-worker-root` in the worker home, restores the test home for the assertion, and removes the foreign entry in `finally`. It does not replace the registry with a fake or assert a setup-owned counter.

## Round 1

Round 1 restored `PI_LENS_HOME` after the #2992 integration tests. That fix was valid and `undefined`-aware, but its structural-fix claim was disproven: verification found the ordered-pair failure 8 times in 10 observations. Restoring the producer's environment did not give the multi-root consumer ownership of its PID-scoped registry.

## Round 2

Round 2 retained the restore and added a registry drain plus `deregisterInstance()`. Those changes fixed a genuine unawaited `registerInstance` and are retained. Verification still found the ordered-pair failure 9 times in 20 observations, including a reused worker observing a third root. The drain repaired producer hygiene but did not establish the consumer's claimed invariant.

## Round 3

The framing was evaluated against #2130 and the test itself. The two-root count is local evidence for the host root plus the secondary root. The same-root case separately proves that shutdown must not delete the shared host root. Nothing in the test asserts that unrelated files must never register, so a worker-global count adds accidental coverage obligations without strengthening #2130. Consumer isolation therefore preserves the intended behavior and removes the race surface.

The test now pins `PI_LENS_HOME` to `.probe-home/index-multi-root-session-start`, cleans that registry before each case, drains and deregisters on both sides of each test, and restores the prior environment. The added foreign-worker-root case reds when the isolation assignment is removed, proving the guard is mutation-sensitive.

Preflight result: pass. The first preflight invocation did not emit a usable exit receipt; a second invocation completed with exit code 0 and all listed gates passed.
