### PR TITLE
test(hygiene): register and drain the lens-map fixtures a raw mkdtemp hid from every sweep (refs #2912)

### DIFF
--- a/.changelog/2912-raw-mkdtemp-drain.md
+++ b/.changelog/2912-raw-mkdtemp-drain.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- **Drain and track lens-map fixtures (refs #2912)** — route lens-map temporary roots through the shared environment registry so deferred graph writes cannot recreate an untracked `/tmp` root after teardown.

--- a/tests/clients/lens-map.test.ts
+++ b/tests/clients/lens-map.test.ts
@@ -1,5 +1,4 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -18,7 +17,10 @@ import type {
 	ReviewGraphEdge,
 	ReviewGraphNode,
 } from "../../clients/review-graph/types.js";
-import { removeTempDirSync } from "./test-utils.js";
+import {
+	cleanupTestEnvironmentsDrained,
+	setupTestEnvironment,
+} from "./test-utils.js";
 
 // aggregateGraphToFiles keys files via normalizeMapKey (same as the rest of the
 // review-graph stack) — on Windows that resolves a relative path like "a.ts"
@@ -254,7 +256,8 @@ describe("aggregateGraphToFiles", () => {
 	});
 
 	it("dedupes absolute multi-twin sets after native path normalization", () => {
-		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-map-twins-"));
+		const env = setupTestEnvironment("pi-lens-map-twins-");
+		const root = env.tmpDir;
 		try {
 			const source = path.join(root, "src.ts");
 			const sourceTwins = [
@@ -317,7 +320,7 @@ describe("aggregateGraphToFiles", () => {
 				{ from: idFor(source), to: idFor(dep), weight: 1 },
 			]);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			env.cleanup();
 		}
 	});
 
@@ -805,21 +808,23 @@ describe("parseUntrackedIgnoredOutput", () => {
 
 describe("generateLensMap", () => {
 	let tmpDir: string;
+	let cleanup: () => Promise<void>;
 	let previousDataDir: string | undefined;
 
 	beforeEach(() => {
-		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-lens-map-"));
+		const env = setupTestEnvironment("pi-lens-map-");
+		tmpDir = env.tmpDir;
+		cleanup = () => cleanupTestEnvironmentsDrained("pi-lens-map-");
 		previousDataDir = process.env.PILENS_DATA_DIR;
 		process.env.PILENS_DATA_DIR = path.join(tmpDir, "data");
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		if (previousDataDir === undefined) delete process.env.PILENS_DATA_DIR;
 		else process.env.PILENS_DATA_DIR = previousDataDir;
-		// generateLensMap can still be flushing writes into the data dir when
-		// afterEach runs, which surfaces as ENOTEMPTY on Linux — the shared
-		// helper's retry+warn (#810) covers this instead of a local retry.
-		removeTempDirSync(tmpDir);
+		// generateLensMap has no separate persistence barrier. Keep this root
+		// tracked while the shared bounded macrotask drain catches deferred writes.
+		await cleanup();
 	});
 
 	it("writes a self-contained HTML file under the project data dir's reports/ folder", async () => {


### PR DESCRIPTION
Refs #2912

## Summary

Register both lens-map temporary-root families and drain deferred work before final cleanup. This closes the untracked `/tmp` recreation path reported by CI.

## Premise

The base was `146a94053`. Four pre-fix combined runs passed locally, so the CI leak did not reproduce in this environment. The supplied CI red was `[tmp-hygiene] leaked 1 top-level entries: pi-lens-map-5jd2...`, and the test comment identifies deferred `generateLensMap` writes as the cause.

## The fix

Use `setupTestEnvironment` for `pi-lens-map-twins-` and `pi-lens-map-`. Use `cleanupTestEnvironmentsDrained` for the asynchronous `generateLensMap` family. No separate `generateLensMap` completion barrier exists, so this is bounded retry through macrotask draining, not a guaranteed barrier. Preserve the existing `undefined`-aware `PILENS_DATA_DIR` restoration. Add the changelog fragment.

## The raw-mkdtemp sweep

Round-1 review found this section was not independently auditable: it presented ten focused files as a member table without saying what separated a member from a non-member, and it missed at least one raw `pi-lens-*` producer (`tests/clients/lsp/server-policy.test.ts:59`, `pi-lens-ts-${label}-`). It is rewritten here around the membership criterion rather than around a hand-picked list.

**Correction to the premise this section was originally written against.** The header comment on `tests/config/tmp-fixture-hygiene.test.ts` states that the setup hook contains every temp dir by pointing `TMPDIR`/`TMP`/`TEMP` at a per-file private root. That is not what the code does — `tests/support/vitest-setup.ts` never assigns any of those variables, and its line 50 says the opposite outright (`keep the real TMPDIR so the final governance ...`). The gate snapshots the **real** `/tmp`, filters the `pi-lens-` prefix, diffs before and after each test file, and admits known prefixes from a baseline. Filed as #3010; no change to that comment is made here, so this PR's test-only scope is unchanged.

The correction matters for scoping this sweep. Under the described mechanism every `os.tmpdir()`-derived root is contained by construction and raw `mkdtempSync` is irrelevant. Under the real mechanism a raw root is contained only by its own file's teardown — so raw-mkdtemp is the **search space**, and membership needs a second condition.

**Membership criterion.** A file is a member when it owns a `pi-lens-*` root that something can write to **after that file's teardown has run**. A deferred producer with no awaitable completion signal is the shape; a synchronous fixture that `rmSync`s its own root is not a member however it was created, because nothing can recreate it.

**Search space, reproducible:**

```
$ git grep -l 'mkdtempSync' -- tests/ | wc -l
362
$ # files with a raw pi-lens- prefix and no setupTestEnvironment call
308
$ # distinct pi-lens-* prefixes created by raw mkdtempSync under tests/
368
```

**Proven members** are the prefixes already carrying a row in `tests/config/tmp-fixture-hygiene-baseline.json` (37 rows at this head), plus the two families fixed here. Those rows are the members the gate has actually observed leaking; anything else in the 308 is an unproven suspect, and a new member announces itself as a new baseline row rather than being found by reading.

| File | Prefix or family | Deferred producer | Verdict |
| --- | --- | --- | --- |
| `tests/clients/lens-map.test.ts` | `pi-lens-map-` | Yes — `generateLensMap` | **Fixed here**: registered, drained |
| `tests/clients/lens-map.test.ts` | `pi-lens-map-twins-` | No — twin aggregation is synchronous | **Fixed here**: registered, synchronous `env.cleanup()` |
| `tests/clients/reverse-deps.test.ts` | `pi-lens-reverse-deps-snapshot-` | Yes | Admitted, shrink-only ratchet |
| `tests/clients/runtime-agent-end.test.ts` | `pi-lens-agent-end-` | Yes (owner stem, 5 producers) | Admitted, shrink-only ratchet |
| `tests/clients/runtime-session-warm-skip-notify.test.ts` | `pi-lens-warm-skip-notify-` | Yes (owner stem) | Admitted, shrink-only ratchet |
| `tests/clients/runtime-session-warmup-oneshot.test.ts` | `pi-lens-warmup-oneshot-interactive-` | Yes | Admitted, shrink-only ratchet |
| `tests/clients/review-graph/build-latch.test.ts` | `pi-lens-build-latch-` | Yes | Admitted |
| `tests/clients/lsp/server-policy.test.ts` | `pi-lens-ts-*-` | Not demonstrated | Unproven suspect; named because round 1 found it missing from this table |

The remaining 30 baseline rows are unchanged by this PR and keep their existing reasons. No prefix is added to or removed from `tests/config/tmp-fixture-hygiene-baseline.json`.

**What this PR does and does not close.** Registration is structural: `setupTestEnvironment` records the root, so the family sweep can always reach it — that is a genuine change of kind, not a narrowed window, and it is what makes the fixed root reachable at all. The drain is not structural in the same sense: it is a bounded three-tick macrotask retry, because `generateLensMap` exposes no completion barrier. A producer that defers past the last tick still recreates the directory after untracking. So `pi-lens-map-` exits the *unreachable-root* class outright and joins the *bounded-drain* families on the timing axis, alongside the four rows above whose baseline reasons already say the drain "reduces but does not eliminate residual recreation".

Consolidation verdict: fold onto `setupTestEnvironment` plus the existing family drain; do not add another cleanup seam. The genuine remaining gap is the absence of a completion barrier on the deferred producers, which is one issue across all five families rather than anything specific to lens-map.

## Tests

The combined pair ran 15 consecutive post-fix times. Every run had 2 files and 29 tests, with exit code 0. Runs 1–5, 6, 8–15 were silent-clean. Run 7 passed but emitted one transient `[tmp-hygiene] observed 1 unadmitted entry(s) from /tmp` observation from concurrent hygiene ownership; later runs were clean.

The compile-valid mutation changed the drain prefix to `pi-lens-map-wrong-`. The combined pair then failed with exit code 1: `tests/config/tmp-fixture-hygiene.test.ts` reported `leaked 1 top-level entries: pi-lens-map-YHCjRq`. The mutation was restored.

New or edited test coverage: `tests/clients/lens-map.test.ts` keeps the existing twin aggregation case on a tracked root and routes the `generateLensMap` teardown through the shared bounded drain. These tests pin registration visibility and deferred-root cleanup.

## Blast radius

Changed test-only callers: `aggregateGraphToFiles` setup and `generateLensMap` teardown in `tests/clients/lens-map.test.ts`. The callees are `setupTestEnvironment`, `env.cleanup`, and `cleanupTestEnvironmentsDrained` in `tests/clients/test-utils.ts`; production code is unchanged. The `PILENS_DATA_DIR` restore remains on the same path.

## Class sweep

The defect class is an unregistered raw temporary root that a deferred producer can recreate after local teardown. The sweep found the broad population described above, fixed the directly affected lens-map members, and deferred the remaining synchronous or already-admitted families with their member list recorded here. No AGENTS.md catalog entry was added.

## Observability

No new failure path; no record added.

## Test assessment

The edited tests use the real `setupTestEnvironment` registry and real cleanup helper. No in-process runtime or persistence seam was mocked or replaced.

## Verification

Commands and exit codes:

- `git rev-parse HEAD` on entry: `146a940531c2ce4356810bb7307f64a85bd539a7`; exit 0.
- `git fetch origin master`: exit 0; `origin/master` was `146a94053`.
- `npm run build` before tests: exit 0.
- Combined pair, 15 repetitions: exit 0 for runs 1–15.
- Mutation combined pair: exit 1 as quoted above; mutation then restored.
- Sibling `rg -l 'lens-map|generateLensMap' tests/` test files: 4 files, 106 tests, exit 0.
- `tests/config/`: 55 files, 485 passed, 1 skipped, exit 0.

## Skipped

Final `npx tsc --noEmit`, `npm run fmt:check`, and `npm run preflight` are run after this body is written. No full 1,095-file population was run. No CI read or push was performed.

